### PR TITLE
[APPSEC-8112] Appsec block request when user ID matches rules data 

### DIFF
--- a/lib/datadog/appsec/ext.rb
+++ b/lib/datadog/appsec/ext.rb
@@ -1,0 +1,10 @@
+# typed: false
+# frozen_string_literal: true
+
+module Datadog
+  module AppSec
+    module Ext
+      INTERRUPT = :datadog_appsec_interrupt
+    end
+  end
+end

--- a/lib/datadog/appsec/monitor/gateway/watcher.rb
+++ b/lib/datadog/appsec/monitor/gateway/watcher.rb
@@ -1,6 +1,7 @@
 # typed: false
 # frozen_string_literal: true
 
+require_relative '../../ext'
 require_relative '../../instrumentation/gateway'
 require_relative '../../reactive/operation'
 require_relative '../reactive/set_user'
@@ -48,7 +49,7 @@ module Datadog
                   _result, block = Monitor::Reactive::SetUser.publish(op, user)
                 end
 
-                next [nil, [[:block, event]]] if block
+                throw(Datadog::AppSec::Ext::INTERRUPT, [nil, [:block, event]]) if block
 
                 ret, res = stack.call(user)
 

--- a/lib/datadog/kit/identity.rb
+++ b/lib/datadog/kit/identity.rb
@@ -56,6 +56,11 @@ module Datadog
         others.each do |k, v|
           trace.set_tag("usr.#{k}", v) unless v.nil?
         end
+
+        if Datadog.configuration.appsec.enabled
+          user = OpenStruct.new(id: id)
+          ::Datadog::AppSec::Instrumentation.gateway.push('identity.set_user', user)
+        end
       end
       # rubocop:enable Metrics/PerceivedComplexity
       # rubocop:enable Metrics/CyclomaticComplexity

--- a/sig/datadog/appsec/ext.rbs
+++ b/sig/datadog/appsec/ext.rbs
@@ -1,0 +1,7 @@
+module Datadog
+  module AppSec
+    module Ext
+      INTERRUPT: Symbol
+    end
+  end
+end

--- a/spec/datadog/appsec/contrib/rack/integration_test_spec.rb
+++ b/spec/datadog/appsec/contrib/rack/integration_test_spec.rb
@@ -139,7 +139,10 @@ RSpec.describe 'Rack integration tests' do
     end
   end
 
-  after { Datadog.registry[:rack].reset_configuration! }
+  after do
+    Datadog::AppSec.settings.send(:reset!)
+    Datadog.registry[:rack].reset_configuration!
+  end
 
   context 'for an application' do
     # TODO: also test without Tracing: it should run without trace transport

--- a/spec/datadog/appsec/contrib/rails/integration_test_spec.rb
+++ b/spec/datadog/appsec/contrib/rails/integration_test_spec.rb
@@ -97,6 +97,11 @@ RSpec.describe 'Rails integration tests' do
     end
   end
 
+  after do
+    Datadog::AppSec.settings.send(:reset!)
+    Datadog.registry[:rails].reset_configuration!
+  end
+
   context 'for an application' do
     include_context 'Rails test application'
 

--- a/spec/datadog/appsec/contrib/sinatra/integration_test_spec.rb
+++ b/spec/datadog/appsec/contrib/sinatra/integration_test_spec.rb
@@ -44,6 +44,7 @@ RSpec.describe 'Sinatra integration tests' do
   let(:appsec_enabled) { true }
   let(:tracing_enabled) { true }
   let(:appsec_ip_denylist) { nil }
+  let(:appsec_user_id_denylist) { nil }
   let(:appsec_ruleset) { :recommended }
 
   let(:crs_942_100) do
@@ -101,6 +102,7 @@ RSpec.describe 'Sinatra integration tests' do
       c.appsec.enabled = appsec_enabled
       c.appsec.instrument :sinatra
       c.appsec.ip_denylist = appsec_ip_denylist
+      c.appsec.user_id_denylist = appsec_user_id_denylist
       c.appsec.ruleset = appsec_ruleset
 
       # TODO: test with c.appsec.instrument :rack
@@ -254,6 +256,11 @@ RSpec.describe 'Sinatra integration tests' do
           post '/success' do
             'ok'
           end
+
+          get '/set_user' do
+            Datadog::Kit::Identity.set_user(Datadog::Tracing.active_trace, id: 'blocked-user-id')
+            'ok'
+          end
         end
       end
 
@@ -358,6 +365,26 @@ RSpec.describe 'Sinatra integration tests' do
           it_behaves_like 'a GET 404 span'
           it_behaves_like 'a trace with AppSec tags'
           it_behaves_like 'a trace with AppSec events'
+        end
+
+        context 'with user blocking ID' do
+          let(:url) { '/set_user' }
+
+          it { is_expected.to be_ok }
+
+          it_behaves_like 'a GET 200 span'
+          it_behaves_like 'a trace with AppSec tags'
+          it_behaves_like 'a trace without AppSec events'
+
+          context 'with an event-triggering user ID' do
+            let(:appsec_user_id_denylist) { ['blocked-user-id'] }
+
+            it { is_expected.to be_forbidden }
+
+            it_behaves_like 'a GET 403 span'
+            it_behaves_like 'a trace with AppSec tags'
+            it_behaves_like 'a trace with AppSec events'
+          end
         end
       end
 

--- a/spec/datadog/appsec/contrib/sinatra/integration_test_spec.rb
+++ b/spec/datadog/appsec/contrib/sinatra/integration_test_spec.rb
@@ -110,6 +110,7 @@ RSpec.describe 'Sinatra integration tests' do
   end
 
   after do
+    Datadog::AppSec.settings.send(:reset!)
     Datadog.registry[:rack].reset_configuration!
     Datadog.registry[:sinatra].reset_configuration!
   end

--- a/spec/datadog/kit/identity_spec.rb
+++ b/spec/datadog/kit/identity_spec.rb
@@ -230,5 +230,29 @@ RSpec.describe Datadog::Kit::Identity do
         expect { described_class.set_user(trace_op, id: 42, foo: 42) }.to raise_error(TypeError)
       end
     end
+
+    context 'appsec' do
+      after { Datadog.configuration.appsec.send(:reset!) }
+
+      context 'when is enabled' do
+        it 'instruments the user information to appsec' do
+          Datadog.configuration.appsec.enabled = true
+          user = OpenStruct.new(id: '42')
+          expect_any_instance_of(Datadog::AppSec::Instrumentation::Gateway).to receive(:push).with(
+            'identity.set_user',
+            user
+          )
+          described_class.set_user(trace_op, id: '42')
+        end
+      end
+
+      context 'when is disabled' do
+        it 'does not instrument the user information to appsec' do
+          Datadog.configuration.appsec.enabled = false
+          expect_any_instance_of(Datadog::AppSec::Instrumentation::Gateway).to_not receive(:push).with('identity.set_user')
+          described_class.set_user(trace_op, id: '42')
+        end
+      end
+    end
   end
 end


### PR DESCRIPTION
<!--
Check out the
https://github.com/DataDog/dd-trace-rb/blob/master/docs/DevelopmentGuide.md
for guidance on how to set up your development environment,
run the test suite, write new integrations, and more.
-->

**What does this PR do?**
<!-- A brief description of the change being made with this pull request. -->

This PR works on top of the previous work done to introduce the [`AppSec::Component`](https://github.com/DataDog/dd-trace-rb/pull/2632) and the [`Appsec::Monitor`](https://github.com/DataDog/dd-trace-rb/pull/2617)

The new code added does the following:

- When calling `Kit::Identity.set_user` if appsec is enabled, we would propagate the user information to the appsec reactive engine
- If the reactive engine considers that we should react based on the information provided, we are going to `throw`
- The appsec rack middleware listens for the throw from the reactive engine if it encounters it. We would interrupt the request and return a 403

I had to add `Datadog::AppSec.settings.send(:reset!)` after all the integration contrib tests to avoid having leaky tests. 

**Motivation**
<!-- What inspired you to submit this pull request? -->

**Additional Notes**
<!-- Anything else we should know when reviewing? -->

**How to test the change?**
<!--
Describe here how the change can be validated.
You are strongly encouraged to provide automated tests for this PR (unit or integration).
If this change cannot be feasibly tested, please explain why,
unless the change does not modify code (e.g. only modifies docs, comments).
-->

CI should be 🟢 
