### PR TITLE
Reuse array for listing threads instead of creating one every time

### DIFF
--- a/ext/ddtrace_profiling_native_extension/private_vm_api_access.c
+++ b/ext/ddtrace_profiling_native_extension/private_vm_api_access.c
@@ -204,8 +204,7 @@ ptrdiff_t stack_depth_for(VALUE thread) {
 #endif
 
 // Tries to match rb_thread_list() but that method isn't accessible to extensions
-VALUE ddtrace_thread_list(void) {
-  VALUE result = rb_ary_new();
+void ddtrace_thread_list(VALUE result_array) {
   rb_thread_t *thread = NULL;
 
   // Ruby 3 Safety: Our implementation is inspired by `rb_ractor_thread_list` BUT that method wraps the operations below
@@ -234,13 +233,11 @@ VALUE ddtrace_thread_list(void) {
         case THREAD_RUNNABLE:
         case THREAD_STOPPED:
         case THREAD_STOPPED_FOREVER:
-          rb_ary_push(result, thread->self);
+          rb_ary_push(result_array, thread->self);
         default:
           break;
       }
     }
-
-  return result;
 }
 
 bool is_thread_alive(VALUE thread) {

--- a/ext/ddtrace_profiling_native_extension/private_vm_api_access.h
+++ b/ext/ddtrace_profiling_native_extension/private_vm_api_access.h
@@ -23,7 +23,7 @@ bool is_current_thread_holding_the_gvl(void);
 current_gvl_owner gvl_owner(void);
 uint64_t native_thread_id_for(VALUE thread);
 ptrdiff_t stack_depth_for(VALUE thread);
-VALUE ddtrace_thread_list(void);
+void ddtrace_thread_list(VALUE result_array);
 bool is_thread_alive(VALUE thread);
 VALUE thread_name_for(VALUE thread);
 

--- a/spec/datadog/profiling/collectors/cpu_and_wall_time_worker_spec.rb
+++ b/spec/datadog/profiling/collectors/cpu_and_wall_time_worker_spec.rb
@@ -546,9 +546,7 @@ RSpec.describe Datadog::Profiling::Collectors::CpuAndWallTimeWorker do
         100.times { Object.new }
         after_allocations = described_class._native_allocation_count
 
-        # The profiler can (currently) cause extra allocations, which is why this is not exactly 100
-        expect(after_allocations - before_allocations).to be >= 100
-        expect(after_allocations - before_allocations).to be < 110
+        expect(after_allocations - before_allocations).to be 100
       end
 
       it 'returns different numbers of allocations for different threads' do
@@ -573,10 +571,10 @@ RSpec.describe Datadog::Profiling::Collectors::CpuAndWallTimeWorker do
 
         background_t1.join
 
-        # This test checks that even though we observed >= 100 allocations in a background thread t1, the counters for
-        # the current thread were not affected by this change (even though they may be slightly affected by the profiler)
+        # This test checks that even though we observed 100 allocations in a background thread t1, the counters for
+        # the current thread were not affected by this change
 
-        expect(after_t1 - before_t1).to be >= 100
+        expect(after_t1 - before_t1).to be 100
         expect(after_allocations - before_allocations).to be < 10
       end
     end

--- a/spec/datadog/profiling/collectors/cpu_and_wall_time_worker_spec.rb
+++ b/spec/datadog/profiling/collectors/cpu_and_wall_time_worker_spec.rb
@@ -542,14 +542,24 @@ RSpec.describe Datadog::Profiling::Collectors::CpuAndWallTimeWorker do
       end
 
       it 'returns the number of allocations between two calls of the method' do
+        # To get the exact expected number of allocations, we run this once before so that Ruby can create and cache all
+        # it needs to
+        new_object = proc { Object.new }
+        1.times(&new_object)
+
         before_allocations = described_class._native_allocation_count
-        100.times { Object.new }
+        100.times(&new_object)
         after_allocations = described_class._native_allocation_count
 
         expect(after_allocations - before_allocations).to be 100
       end
 
       it 'returns different numbers of allocations for different threads' do
+        # To get the exact expected number of allocations, we run this once before so that Ruby can create and cache all
+        # it needs to
+        new_object = proc { Object.new }
+        1.times(&new_object)
+
         t1_can_run = Queue.new
         t1_has_run = Queue.new
         before_t1 = nil
@@ -559,7 +569,7 @@ RSpec.describe Datadog::Profiling::Collectors::CpuAndWallTimeWorker do
           before_t1 = described_class._native_allocation_count
           t1_can_run.pop
 
-          100.times { Object.new }
+          100.times(&new_object)
           after_t1 = described_class._native_allocation_count
           t1_has_run << true
         end


### PR DESCRIPTION
**What does this PR do?**:

This PR changes the `ddtrace_thread_list` method to, instead of creating a new Ruby array to contain its result, receive a pre-existing array for it to use.

Then, it changes the `CpuAndWallTime` collector to always reuse the same array for this list.

**Motivation**:

The thread list array was the one single Ruby object allocation that the profiler always did on every sample. Now that we're exposing object counts and experimenting with allocation profiling, this regular allocation was really annoying to deal with when looking at data and writing tests.

By reusing the same object, this problem goes away, and even some specs can be simplified.

**Additional Notes**:

N/A

**How to test the change?**:

This change is covered by the existing unit tests.
