### PR TITLE
Minor: Tweak profiling error guidance when pkg-config is missing

### DIFF
--- a/ext/ddtrace_profiling_native_extension/native_extension_helpers.rb
+++ b/ext/ddtrace_profiling_native_extension/native_extension_helpers.rb
@@ -174,6 +174,8 @@ module Datadog
           'the `pkg-config` package on Homebrew and Debian/Ubuntu-based Linux;',
           'the `pkgconf` package on Arch and Alpine-based Linux;',
           'the `pkgconf-pkg-config` package on Fedora/Red Hat-based Linux.',
+          '(Tip: When fixing this, ensure `pkg-config` is installed **before**',
+          'running `bundle install`, and remember to clear any installed gems cache).',
           suggested: CONTACT_SUPPORT,
         )
 


### PR DESCRIPTION
**What does this PR do?**:

This PR adds the following tip to the error message that customers see when trying to enable profiling but the `pkg-config` system tool is missing:

> (Tip: When fixing this, ensure `pkg-config` is installed **before** running `bundle install`, and remember to clear any installed gems cache).

We've had a couple of customers so far run into this issue -- they install `pkg-config`, and can see it running on their container, but they still see the error, because when `bundle install` runs, the tool is not there yet.

Hopefully this tip will avoid other customers running into this issue.

**Motivation**:

Improve customer UX when enabling the profiler.

**Additional Notes**:

I've been considering reimplementing what we need out of `pkg-config` so that we stop requiring this tool but for now hopefully this reduces the number of frustrated customers due to this problem.

**How to test the change?**:

The easiest way to test this is to use one of our development Ruby images, and just delete `pkg-config` from it using ``rm `which pkg-config` ``.

If then you run `bundle exec rake clean compile` and then try to run the profiler, you should see the error popping up as a log:

```
$ DD_PROFILING_ENABLED=true bundle exec ddtracerb exec ruby -e "sleep"
W, [2023-02-24T10:33:59.671680 #772]  WARN -- ddtrace: [ddtrace] Profiling was requested but is not
supported, profiling disabled: Your ddtrace installation is missing support for the Continuous
Profiler because the `pkg-config` system tool is missing. This issue can usually be fixed by installing
one of the following: the `pkg-config` package on Homebrew and Debian/Ubuntu-based Linux; the `pkgconf`
package on Arch and Alpine-based Linux; the `pkgconf-pkg-config` package on Fedora/Red Hat-based
Linux. (Tip: When fixing this, ensure `pkg-config` is installed **before** running `bundle install`,
and remember to clear any installed gem caches). For help solving this issue, please contact Datadog
support at <https://docs.datadoghq.com/help/>. You can also check out the Continuous Profiler
troubleshooting page at <https://dtdg.co/ruby-profiler-troubleshooting>.
```
