### PR TITLE
Fix 'uninitialized constant GRPC::Interceptor' when with the 'gapic-common' gem

### DIFF
--- a/lib/datadog/tracing/contrib/grpc/integration.rb
+++ b/lib/datadog/tracing/contrib/grpc/integration.rb
@@ -20,7 +20,14 @@ module Datadog
           end
 
           def self.loaded?
-            !defined?(::GRPC).nil?
+            !defined?(::GRPC).nil? &&
+              # When using the Google "Calendar User Availability API"
+              # (https://developers.google.com/calendar/api/user-availability/reference/rest), though the gem
+              # `google-cloud-calendar-useravailability-v1alpha` (currently in private preview),
+              # it's possible to load `GRPC` without loading the rest of the `grpc` gem. See:
+              # https://github.com/googleapis/gapic-generator-ruby/blob/f1c2e73219453e497b6ec2dc807a907e939e1342/gapic-common/lib/gapic/common.rb#L15-L16
+              # When this happens, there are no gRPC components of interest to instrument.
+              !defined?(::GRPC::Interceptor).nil? && !defined?(::GRPC::InterceptionContext).nil?
           end
 
           def self.compatible?

--- a/spec/datadog/tracing/contrib/grpc/integration_spec.rb
+++ b/spec/datadog/tracing/contrib/grpc/integration_spec.rb
@@ -28,7 +28,26 @@ RSpec.describe Datadog::Tracing::Contrib::GRPC::Integration do
     context 'when GRPC is defined' do
       before { stub_const('GRPC', Class.new) }
 
-      it { is_expected.to be true }
+      context 'when GRPC::Interceptor is defined' do
+        before { stub_const('GRPC::Interceptor', Class.new) }
+
+        context 'when GRPC::InterceptionContext is defined' do
+          before { stub_const('GRPC::InterceptionContext', Class.new) }
+          it { is_expected.to be true }
+        end
+
+        context 'when GRPC::InterceptionContext is not defined' do
+          before { hide_const('GRPC::InterceptionContext') }
+
+          it { is_expected.to be false }
+        end
+      end
+
+      context 'when GRPC::Interceptor is not defined' do
+        before { hide_const('GRPC::Interceptor') }
+
+        it { is_expected.to be false }
+      end
     end
 
     context 'when GRPC is not defined' do


### PR DESCRIPTION
This PR fixes the error 
```
Failed to apply Datadog::Tracing::Contrib::GRPC::Patcher patch. Cause: uninitialized constant GRPC::Interceptor
```
when gRPC was partially loaded.

This has been reported to us by users of the Google [Calendar User Availability API](https://developers.google.com/calendar/api/user-availability/reference/rest) gem. That gem is not publicly available yet, but its dependency on the public [`gapic-common` gem](https://rubygems.org/gems/gapic-common) is where the issue lies, allowing us to address this issue.

`gapic-common` only loads [a couple file from gPRC](https://github.com/googleapis/gapic-generator-ruby/blob/f1c2e73219453e497b6ec2dc807a907e939e1342/gapic-common/lib/gapic/common.rb#L15-L16), which only contain constants and error classes.

There's nothing of value to instrument if only such subset of gPRC is loaded.

This PR ensures we check for the presence of the relevant gPRC client and server files that we actually have an instrumentation point.