### PR TITLE
Fix small inconsistencies in ddtrace logging

### DIFF
--- a/ext/ddtrace_profiling_native_extension/collectors_idle_sampling_helper.c
+++ b/ext/ddtrace_profiling_native_extension/collectors_idle_sampling_helper.c
@@ -170,15 +170,15 @@ static void interrupt_idle_sampling_loop(void *state_ptr) {
   // ask the thread to stop, instead of exiting early.
 
   error = pthread_mutex_lock(&state->wakeup_mutex);
-  if (error) { fprintf(stderr, "[DDTRACE] Error during pthread_mutex_lock in interrupt_idle_sampling_loop (%s)\n", strerror(error)); }
+  if (error) { fprintf(stderr, "[ddtrace] Error during pthread_mutex_lock in interrupt_idle_sampling_loop (%s)\n", strerror(error)); }
 
   state->requested_action = ACTION_STOP;
 
   error = pthread_mutex_unlock(&state->wakeup_mutex);
-  if (error) { fprintf(stderr, "[DDTRACE] Error during pthread_mutex_unlock in interrupt_idle_sampling_loop (%s)\n", strerror(error)); }
+  if (error) { fprintf(stderr, "[ddtrace] Error during pthread_mutex_unlock in interrupt_idle_sampling_loop (%s)\n", strerror(error)); }
 
   error = pthread_cond_broadcast(&state->wakeup);
-  if (error) { fprintf(stderr, "[DDTRACE] Error during pthread_cond_broadcast in interrupt_idle_sampling_loop (%s)\n", strerror(error)); }
+  if (error) { fprintf(stderr, "[ddtrace] Error during pthread_cond_broadcast in interrupt_idle_sampling_loop (%s)\n", strerror(error)); }
 }
 
 static VALUE _native_stop(DDTRACE_UNUSED VALUE self, VALUE self_instance) {

--- a/ext/ddtrace_profiling_native_extension/extconf.rb
+++ b/ext/ddtrace_profiling_native_extension/extconf.rb
@@ -26,7 +26,7 @@ def skip_building_extension!(reason)
   if fail_install_if_missing_extension
     require 'mkmf'
     Logging.message(
-      ' [ddtrace] Failure cause: ' \
+      '[ddtrace] Failure cause: ' \
       "#{Datadog::Profiling::NativeExtensionHelpers::Supported.render_skipped_reason_file(**reason)}\n"
     )
   else
@@ -65,9 +65,9 @@ $stderr.puts(
 # that may fail on an environment not properly setup for building Ruby extensions.
 require 'mkmf'
 
-Logging.message(" [ddtrace] Using compiler:\n")
+Logging.message("[ddtrace] Using compiler:\n")
 xsystem("#{CONFIG['CC']} -v")
-Logging.message(" [ddtrace] End of compiler information\n")
+Logging.message("[ddtrace] End of compiler information\n")
 
 # mkmf on modern Rubies actually has an append_cflags that does something similar
 # (see https://github.com/ruby/ruby/pull/5760), but as usual we need a bit more boilerplate to deal with legacy Rubies
@@ -162,7 +162,7 @@ end
 
 # If we got here, libdatadog is available and loaded
 ENV['PKG_CONFIG_PATH'] = "#{ENV['PKG_CONFIG_PATH']}:#{Libdatadog.pkgconfig_folder}"
-Logging.message(" [ddtrace] PKG_CONFIG_PATH set to #{ENV['PKG_CONFIG_PATH'].inspect}\n")
+Logging.message("[ddtrace] PKG_CONFIG_PATH set to #{ENV['PKG_CONFIG_PATH'].inspect}\n")
 $stderr.puts("Using libdatadog #{Libdatadog::VERSION} from #{Libdatadog.pkgconfig_folder}")
 
 unless pkg_config('datadog_profiling_with_rpath')
@@ -186,7 +186,7 @@ end
 $LDFLAGS += \
   ' -Wl,-rpath,$$$\\\\{ORIGIN\\}/' \
   "#{Datadog::Profiling::NativeExtensionHelpers.libdatadog_folder_relative_to_native_lib_folder}"
-Logging.message(" [ddtrace] After pkg-config $LDFLAGS were set to: #{$LDFLAGS.inspect}\n")
+Logging.message("[ddtrace] After pkg-config $LDFLAGS were set to: #{$LDFLAGS.inspect}\n")
 
 # Tag the native extension library with the Ruby version and Ruby platform.
 # This makes it easier for development (avoids "oops I forgot to rebuild when I switched my Ruby") and ensures that

--- a/ext/ddtrace_profiling_native_extension/ruby_helpers.c
+++ b/ext/ddtrace_profiling_native_extension/ruby_helpers.c
@@ -58,7 +58,7 @@ void grab_gvl_and_raise(VALUE exception_class, const char *format_string, ...) {
 
   rb_thread_call_with_gvl(trigger_raise, &args);
 
-  rb_bug("[DDTRACE] Unexpected: Reached the end of grab_gvl_and_raise while raising '%s'\n", args.exception_message);
+  rb_bug("[ddtrace] Unexpected: Reached the end of grab_gvl_and_raise while raising '%s'\n", args.exception_message);
 }
 
 struct syserr_raise_arguments {
@@ -91,7 +91,7 @@ void grab_gvl_and_raise_syserr(int syserr_errno, const char *format_string, ...)
 
   rb_thread_call_with_gvl(trigger_syserr_raise, &args);
 
-  rb_bug("[DDTRACE] Unexpected: Reached the end of grab_gvl_and_raise_syserr while raising '%s'\n", args.exception_message);
+  rb_bug("[ddtrace] Unexpected: Reached the end of grab_gvl_and_raise_syserr while raising '%s'\n", args.exception_message);
 }
 
 void raise_syserr(

--- a/lib/datadog/appsec/autoload.rb
+++ b/lib/datadog/appsec/autoload.rb
@@ -4,7 +4,7 @@ if %w[1 true].include?((ENV['DD_APPSEC_ENABLED'] || '').downcase)
     Datadog::AppSec::Contrib::AutoInstrument.patch_all
   rescue StandardError => e
     Kernel.warn(
-      '[DDTRACE] AppSec failed to instrument. No security check will be performed. error: ' \
+      '[ddtrace] AppSec failed to instrument. No security check will be performed. error: ' \
       " #{e.class.name} #{e.message}"
     )
   end

--- a/lib/datadog/kit/enable_core_dumps.rb
+++ b/lib/datadog/kit/enable_core_dumps.rb
@@ -17,10 +17,10 @@ module Datadog
           end
 
         if maximum_size <= 0
-          Kernel.warn("[DDTRACE] Could not enable core dumps on crash, maximum size is #{maximum_size} (disabled).")
+          Kernel.warn("[ddtrace] Could not enable core dumps on crash, maximum size is #{maximum_size} (disabled).")
           return
         elsif maximum_size == current_size
-          Kernel.warn('[DDTRACE] Core dumps already enabled, nothing to do!')
+          Kernel.warn('[ddtrace] Core dumps already enabled, nothing to do!')
           return
         end
 
@@ -28,17 +28,17 @@ module Datadog
           Process.setrlimit(:CORE, maximum_size)
         rescue => e
           Kernel.warn(
-            "[DDTRACE] Failed to enable core dumps. Cause: #{e.class.name} #{e.message} " \
+            "[ddtrace] Failed to enable core dumps. Cause: #{e.class.name} #{e.message} " \
             "Location: #{Array(e.backtrace).first}"
           )
           return
         end
 
         if current_size == 0
-          Kernel.warn("[DDTRACE] Enabled core dumps. Maximum size: #{maximum_size} Output pattern: '#{core_pattern}'")
+          Kernel.warn("[ddtrace] Enabled core dumps. Maximum size: #{maximum_size} Output pattern: '#{core_pattern}'")
         else
           Kernel.warn(
-            "[DDTRACE] Raised core dump limit. Old size: #{current_size} " \
+            "[ddtrace] Raised core dump limit. Old size: #{current_size} " \
             "Maximum size: #{maximum_size} Output pattern: '#{core_pattern}'"
           )
         end

--- a/lib/datadog/profiling.rb
+++ b/lib/datadog/profiling.rb
@@ -140,7 +140,7 @@ module Datadog
         # NOTE: We use Kernel#warn here because this code gets run BEFORE Datadog.logger is actually set up.
         # In the future it'd be nice to shuffle the logger startup to happen first to avoid this special case.
         Kernel.warn(
-          '[DDTRACE] Error while loading google-protobuf gem. ' \
+          '[ddtrace] Error while loading google-protobuf gem. ' \
           "Cause: '#{e.class.name} #{e.message}' Location: '#{Array(e.backtrace).first}'. " \
           'This can happen when google-protobuf is missing its native components. ' \
           'To fix this, try removing and reinstalling the gem, forcing it to recompile the components: ' \


### PR DESCRIPTION
**What does this PR do?**

While reviewing another PR, I noticed that we're somewhat inconsistent when we prefix logging messages:

* In a few cases we used `[DDTRACE]` instead of `[ddtrace]`
* In a few cases we prefixed the `[ddtrace]` with a space, others we didn't

This PR tweaks all messages to use the same `[ddtrace]` prefix and to not use a space before it.

**Motivation**:

Improve consistency of user-visible messages.

**Additional Notes**:

N/A

**How to test the change?**:

Some of the messages do have test coverage; for others, we'll need to rely on the PR review to make sure the change is correct.