### PR TITLE
Simplify macOS testing matrix

### DIFF
--- a/.github/workflows/test-macos.yaml
+++ b/.github/workflows/test-macos.yaml
@@ -6,8 +6,7 @@ jobs:
       fail-fast: false
       matrix:
         os:
-          - macos-11
-          - macos-12
+          - macos-latest
         ruby:
           - '2.1'
           - '2.2'


### PR DESCRIPTION
**What does this PR do?**:

This PR changes the `Test macOS` github action to only use the latest macOS for testing, rather than testing with multiple versions of macOS.

**Motivation**:

We don't currently support macOS on production environments, as documented in
<https://github.com/DataDog/dd-trace-rb/blob/master/docs/GettingStarted.md#apple-macos-support>

It's still valuable to "keep an eye on" macOS, since we do want to be able to use it in development.

BUT our test matrix is rather complex, so I think not testing older macOS versions * 10 Ruby versions we support is a worthy simplification.

Additionally, once github adds support for macOS 13, we'll automatically start testing on that one as well, which should match what most macOS-based developers are using.

**Additional Notes**:

N/A

**How to test the change?**:

Validate that the `Test macOS` github action still runs, but only on macos-latest (macOS 12), and does not run on macOS 11.
