### PR TITLE
[PROF-7307] Add support for allocation samples to `ThreadContext`

### DIFF
--- a/ext/ddtrace_profiling_native_extension/collectors_thread_context.h
+++ b/ext/ddtrace_profiling_native_extension/collectors_thread_context.h
@@ -7,6 +7,7 @@ void thread_context_collector_sample(
   long current_monotonic_wall_time_ns,
   VALUE profiler_overhead_stack_thread
 );
+void thread_context_collector_sample_allocation(VALUE self_instance, unsigned int sample_weight);
 VALUE thread_context_collector_sample_after_gc(VALUE self_instance);
 void thread_context_collector_on_gc_start(VALUE self_instance);
 void thread_context_collector_on_gc_finish(VALUE self_instance);

--- a/spec/datadog/profiling/collectors/thread_context_spec.rb
+++ b/spec/datadog/profiling/collectors/thread_context_spec.rb
@@ -63,6 +63,10 @@ RSpec.describe Datadog::Profiling::Collectors::ThreadContext do
     described_class::Testing._native_sample_after_gc(cpu_and_wall_time_collector)
   end
 
+  def sample_allocation(weight:)
+    described_class::Testing._native_sample_allocation(cpu_and_wall_time_collector, weight)
+  end
+
   def thread_list
     described_class::Testing._native_thread_list
   end
@@ -810,6 +814,75 @@ RSpec.describe Datadog::Profiling::Collectors::ThreadContext do
               cpu_time_at_previous_sample_ns: cpu_time_at_previous_sample_ns_before + cpu_time_spent_in_gc
             )
           end
+        end
+      end
+    end
+  end
+
+  describe '#sample_allocation' do
+    let(:single_sample) do
+      expect(samples.size).to be 1
+      samples.first
+    end
+
+    it 'samples the caller thread' do
+      sample_allocation(weight: 123)
+
+      expect(object_id_from(single_sample.labels.fetch(:'thread id'))).to be Thread.current.object_id
+    end
+
+    it 'tags the sample with the provided weight' do
+      sample_allocation(weight: 123)
+
+      expect(single_sample.values).to include(:'alloc-samples' => 123)
+    end
+
+    it 'includes the thread names, if available' do
+      thread_with_name = Thread.new do
+        Thread.current.name = 'thread_with_name'
+        sample_allocation(weight: 123)
+      end.join
+      thread_without_name = Thread.new { sample_allocation(weight: 123) }.join
+
+      sample_with_name = samples_for_thread(samples, thread_with_name).first
+      sample_without_name = samples_for_thread(samples, thread_without_name).first
+
+      expect(sample_with_name.labels).to include(:'thread name' => 'thread_with_name')
+      expect(sample_without_name.labels).to_not include(:'thread name')
+    end
+
+    describe 'code hotspots' do
+      # NOTE: To avoid duplicating all of the similar-but-slightly different tests from `#sample` (due to how
+      # `#sample` includes every thread, but `#sample_allocation` includes only the caller thread), here is a simpler
+      # test to make sure this works in the common case
+      context 'when there is an active trace on the sampled thread' do
+        let(:tracer) { Datadog::Tracing.send(:tracer) }
+        let(:t1) do
+          Thread.new(ready_queue) do |ready_queue|
+            inside_t1 do
+              Datadog::Tracing.trace('profiler.test', type: 'web') do |_span, trace|
+                trace.resource = 'trace_resource'
+
+                Datadog::Tracing.trace('profiler.test.inner') do |inner_span|
+                  @t1_span_id = inner_span.id
+                  @t1_local_root_span_id = trace.send(:root_span).id
+                  sample_allocation(weight: 456)
+                  ready_queue << true
+                  sleep
+                end
+              end
+            end
+          end
+        end
+
+        after { Datadog::Tracing.shutdown! }
+
+        it 'gathers the "local root span id", "span id" and "trace endpoint"' do
+          expect(single_sample.labels).to include(
+            :'local root span id' => @t1_local_root_span_id.to_i,
+            :'span id' => @t1_span_id.to_i,
+            :'trace endpoint' => 'trace_resource',
+          )
         end
       end
     end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,5 +1,8 @@
 $LOAD_PATH.unshift File.expand_path('..', __dir__)
 $LOAD_PATH.unshift File.expand_path('../lib', __dir__)
+
+Thread.main.name = 'Thread.main' unless Gem::Version.new(RUBY_VERSION) < Gem::Version.new('2.3')
+
 require 'pry'
 require 'rspec/collection_matchers'
 require 'rspec/wait'


### PR DESCRIPTION
**What does this PR do?**:

This PR adds the `thread_context_collector_sample_allocation` API to the `ThreadContext` collector.

This will be used to support allocation profiling (but right now it's not being called automatically when allocations happen, yet).

**Motivation**:

This is an incremental step towards supporting allocation profiling.

I'm still working on the scaling/weighting strategy, and may end up adding that logic directly on the `ThreadContext`, haven't decided yet.

**Additional Notes**:

I'm opening this PR is on top of #2654 to avoid merge conflicts, but this PR is otherwise completely independent from it.

**How to test the change?**:

Change includes test coverage. End-to-end testing will come later once this is wired up in the `CpuAndWallTimeWorker`.
