### PR TITLE
[APPSEC-8492] Appsec update ruleset to 1.5.2

### DIFF
--- a/lib/datadog/appsec/assets/waf_rules/recommended.json
+++ b/lib/datadog/appsec/assets/waf_rules/recommended.json
@@ -1,7 +1,7 @@
 {
   "version": "2.2",
   "metadata": {
-    "rules_version": "1.5.1"
+    "rules_version": "1.5.2"
   },
   "rules": [
     {
@@ -1351,16 +1351,11 @@
               "etc/timezone",
               "etc/modules",
               "etc/passwd",
-              "etc/passwd~",
-              "etc/passwd-",
               "etc/shadow",
-              "etc/shadow~",
-              "etc/shadow-",
               "etc/fstab",
               "etc/motd",
               "etc/hosts",
               "etc/group",
-              "etc/group-",
               "etc/alias",
               "etc/crontab",
               "etc/crypttab",
@@ -1871,11 +1866,8 @@
               "dev/tcp/",
               "dev/udp/",
               "dev/zero",
-              "etc/group",
               "etc/master.passwd",
-              "etc/passwd",
               "etc/pwd.db",
-              "etc/shadow",
               "etc/shells",
               "etc/spwd.db",
               "proc/self/",
@@ -4090,9 +4082,7 @@
               "java.lang.number",
               "java.lang.object",
               "java.lang.process",
-              "java.lang.processbuilder",
               "java.lang.reflect",
-              "java.lang.runtime",
               "java.lang.string",
               "java.lang.stringbuilder",
               "java.lang.system",
@@ -4448,6 +4438,44 @@
             "options": {
               "case_sensitive": false,
               "min_length": 24
+            }
+          },
+          "operator": "match_regex"
+        }
+      ],
+      "transformers": []
+    },
+    {
+      "id": "dog-942-001",
+      "name": "Blind XSS callback domains",
+      "tags": {
+        "type": "xss",
+        "category": "attack_attempt",
+        "confidence": "1"
+      },
+      "conditions": [
+        {
+          "parameters": {
+            "inputs": [
+              {
+                "address": "server.request.query"
+              },
+              {
+                "address": "server.request.body"
+              },
+              {
+                "address": "server.request.path_params"
+              },
+              {
+                "address": "server.request.headers.no_cookies"
+              },
+              {
+                "address": "grpc.server.request.message"
+              }
+            ],
+            "regex": "https?:\\/\\/(?:.*\\.)?(?:bxss\\.in|xss\\.ht|js\\.rip)",
+            "options": {
+              "case_sensitive": false
             }
           },
           "operator": "match_regex"
@@ -5084,36 +5112,6 @@
       ]
     },
     {
-      "id": "sqr-000-007",
-      "name": "NoSQL: Detect common exploitation strategy",
-      "tags": {
-        "type": "nosql_injection",
-        "category": "attack_attempt"
-      },
-      "conditions": [
-        {
-          "parameters": {
-            "inputs": [
-              {
-                "address": "server.request.query"
-              },
-              {
-                "address": "server.request.body"
-              },
-              {
-                "address": "server.request.path_params"
-              }
-            ],
-            "regex": "^\\$(eq|ne|(l|g)te?|n?in|not|(n|x|)or|and|regex|where|expr|exists)$"
-          },
-          "operator": "match_regex"
-        }
-      ],
-      "transformers": [
-        "keys_only"
-      ]
-    },
-    {
       "id": "sqr-000-008",
       "name": "Windows: Detect attempts to exfiltrate .ini files",
       "tags": {
@@ -5312,7 +5310,7 @@
                 "address": "grpc.server.request.message"
               }
             ],
-            "regex": "^(jar:)?(http|https):\\/\\/((\\[)?[:0-9a-f\\.x]{2,}(\\])?)(:[0-9]{1,5})?(\\/.*)?$"
+            "regex": "^(jar:)?(http|https):\\/\\/((\\[)?[:0-9a-f\\.x]{2,}(\\])?)(:[0-9]{1,5})?(\\/[^:@]*)?$"
           },
           "operator": "match_regex"
         }
@@ -5349,7 +5347,7 @@
                 "address": "grpc.server.request.message"
               }
             ],
-            "regex": "(http|https):\\/\\/(?:.*\\.)?(?:burpcollaborator\\.net|localtest\\.me|mail\\.ebc\\.apple\\.com|bugbounty\\.dod\\.network|.*\\.[nx]ip\\.io|oastify\\.com|oast\\.(?:pro|live|site|online|fun|me)|sslip\\.io|requestbin\\.com|requestbin\\.net|hookbin\\.com|webhook\\.site|canarytokens\\.com|interact\\.sh|ngrok\\.io|bugbounty\\.click)"
+            "regex": "(http|https):\\/\\/(?:.*\\.)?(?:burpcollaborator\\.net|localtest\\.me|mail\\.ebc\\.apple\\.com|bugbounty\\.dod\\.network|.*\\.[nx]ip\\.io|oastify\\.com|oast\\.(?:pro|live|site|online|fun|me)|sslip\\.io|requestbin\\.com|requestbin\\.net|hookbin\\.com|webhook\\.site|canarytokens\\.com|interact\\.sh|ngrok\\.io|bugbounty\\.click|prbly\\.win|qualysperiscope\\.com)"
           },
           "operator": "match_regex"
         }

--- a/lib/datadog/appsec/assets/waf_rules/strict.json
+++ b/lib/datadog/appsec/assets/waf_rules/strict.json
@@ -1,7 +1,7 @@
 {
   "version": "2.2",
   "metadata": {
-    "rules_version": "1.5.1"
+    "rules_version": "1.5.2"
   },
   "rules": [
     {
@@ -1523,6 +1523,36 @@
       ],
       "transformers": [
         "removeNulls"
+      ]
+    },
+    {
+      "id": "sqr-000-007",
+      "name": "NoSQL: Detect common exploitation strategy",
+      "tags": {
+        "type": "nosql_injection",
+        "category": "attack_attempt"
+      },
+      "conditions": [
+        {
+          "parameters": {
+            "inputs": [
+              {
+                "address": "server.request.query"
+              },
+              {
+                "address": "server.request.body"
+              },
+              {
+                "address": "server.request.path_params"
+              }
+            ],
+            "regex": "^\\$(eq|ne|(l|g)te?|n?in|not|(n|x|)or|and|regex|where|expr|exists)$"
+          },
+          "operator": "match_regex"
+        }
+      ],
+      "transformers": [
+        "keys_only"
       ]
     },
     {


### PR DESCRIPTION
Update appsec ruleset to 1.5.2.

Here are the rules from the [appsec-event-rules repo](https://github.com/DataDog/appsec-event-rules/tree/1.5.2/build) for version 1.5.2