### PR TITLE
fix: prevent unintentional modification of arguments

### DIFF
--- a/lib/datadog/kit/appsec/events.rb
+++ b/lib/datadog/kit/appsec/events.rb
@@ -23,7 +23,7 @@ module Datadog
           track(LOGIN_SUCCESS_EVENT, trace, **others)
 
           user_options = user.dup
-          user_id = user.delete(:id)
+          user_id = user_options.delete(:id)
 
           raise ArgumentError, 'missing required key: :user => { :id }' if user_id.nil?
 

--- a/spec/datadog/kit/appsec/events_spec.rb
+++ b/spec/datadog/kit/appsec/events_spec.rb
@@ -32,6 +32,15 @@ RSpec.describe Datadog::Kit::AppSec::Events do
       end
       expect(meta).to include('usr.id' => '42', 'appsec.events.users.login.success.foo' => 'bar')
     end
+
+    it 'maintains integrity of user argument' do
+      user_argument = { id: '42' }
+      user_argument_dup = user_argument.dup
+      trace_op.measure('root') do
+        described_class.track_login_success(trace_op, user: user_argument, foo: 'bar')
+      end
+      expect(user_argument).to eql(user_argument_dup)
+    end
   end
 
   describe '#track_login_failure' do


### PR DESCRIPTION
**What does this PR do?**
Fixes what appears to be a bug

**Motivation**
1. The original code looks as though this was the intention[1]
2. It's bad practice to unintentionally modify the parameters of a function

*1: In the original code:
```ruby
          user_options = user.dup
          user_id = user.delete(:id)

          raise ArgumentError, 'missing required key: :user => { :id }' if user_id.nil?

          Kit::Identity.set_user(trace, id: user_id, **user_options)
```

`Kit::Identity.set_user(trace, id: user_id, **user_options)` would be redundant as `:id` exists in `user_options` and would replace the previously specified argument

Additionally, if this was intended, then the following is equivalent and better:
```ruby
          user_id = user.delete(:id)

          raise ArgumentError, 'missing required key: :user => { :id }' if user_id.nil?

          Kit::Identity.set_user(trace, id: user_id, **user)
```

or, not equivalent, but better still:

```ruby
          raise ArgumentError, 'missing required key: :user => { :id }' if user[:id].nil?

          Kit::Identity.set_user(trace, **user)
```

in all cases you still get a non-descriptive error if `user` is `nil`

Also checking for `user.id` here is redundant, and somewhat irrelevant as this is done again by:
https://github.com/DataDog/dd-trace-rb/blob/1d20aa8bd58ccd60265fd0d3c7e0de58456242cc/lib/datadog/kit/identity.rb#L33

So probably just go with:

```ruby
          Kit::Identity.set_user(trace, **user)
```