### PR TITLE
Update TeamCity env var extraction

### DIFF
--- a/lib/datadog/ci/ext/environment.rb
+++ b/lib/datadog/ci/ext/environment.rb
@@ -174,9 +174,6 @@ module Datadog
             TAG_PIPELINE_URL => url,
             TAG_PROVIDER_NAME => 'bitbucket',
             TAG_WORKSPACE_PATH => env['BITBUCKET_CLONE_DIR'],
-            Core::Git::Ext::TAG_COMMIT_AUTHOR_NAME => env['BUILD_REQUESTEDFORID'],
-            Core::Git::Ext::TAG_COMMIT_AUTHOR_EMAIL => env['BUILD_REQUESTEDFOREMAIL'],
-            Core::Git::Ext::TAG_COMMIT_MESSAGE => env['BUILD_SOURCEVERSIONMESSAGE']
           }
         end
 
@@ -265,9 +262,6 @@ module Datadog
             TAG_PIPELINE_URL => pipeline_url,
             TAG_PROVIDER_NAME => 'github',
             TAG_WORKSPACE_PATH => env['GITHUB_WORKSPACE'],
-            Core::Git::Ext::TAG_COMMIT_AUTHOR_NAME => env['BUILD_REQUESTEDFORID'],
-            Core::Git::Ext::TAG_COMMIT_AUTHOR_EMAIL => env['BUILD_REQUESTEDFOREMAIL'],
-            Core::Git::Ext::TAG_COMMIT_MESSAGE => env['BUILD_SOURCEVERSIONMESSAGE'],
             TAG_CI_ENV_VARS => {
               'GITHUB_SERVER_URL' => env['GITHUB_SERVER_URL'],
               'GITHUB_REPOSITORY' => env['GITHUB_REPOSITORY'],
@@ -325,9 +319,6 @@ module Datadog
             TAG_PIPELINE_URL => env['BUILD_URL'],
             TAG_PROVIDER_NAME => 'jenkins',
             TAG_WORKSPACE_PATH => env['WORKSPACE'],
-            Core::Git::Ext::TAG_COMMIT_AUTHOR_NAME => env['BUILD_REQUESTEDFORID'],
-            Core::Git::Ext::TAG_COMMIT_AUTHOR_EMAIL => env['BUILD_REQUESTEDFOREMAIL'],
-            Core::Git::Ext::TAG_COMMIT_MESSAGE => env['BUILD_SOURCEVERSIONMESSAGE'],
             TAG_CI_ENV_VARS => {
               'DD_CUSTOM_TRACE_ID' => env['DD_CUSTOM_TRACE_ID']
             }.to_json

--- a/lib/datadog/ci/ext/environment.rb
+++ b/lib/datadog/ci/ext/environment.rb
@@ -337,17 +337,8 @@ module Datadog
         def extract_teamcity(env)
           {
             TAG_PROVIDER_NAME => 'teamcity',
-            Core::Git::Ext::TAG_REPOSITORY_URL => env['BUILD_VCS_URL'],
-            Core::Git::Ext::TAG_COMMIT_SHA => env['BUILD_VCS_NUMBER'],
-            TAG_WORKSPACE_PATH => env['BUILD_CHECKOUTDIR'],
-            TAG_PIPELINE_ID => env['BUILD_ID'],
-            TAG_PIPELINE_NUMBER => env['BUILD_NUMBER'],
-            TAG_PIPELINE_URL => (
-              env['SERVER_URL'] && env['BUILD_ID'] ? "#{env['SERVER_URL']}/viewLog.html?buildId=#{env['BUILD_ID']}" : nil
-            ),
-            Core::Git::Ext::TAG_COMMIT_AUTHOR_NAME => env['BUILD_REQUESTEDFORID'],
-            Core::Git::Ext::TAG_COMMIT_AUTHOR_EMAIL => env['BUILD_REQUESTEDFOREMAIL'],
-            Core::Git::Ext::TAG_COMMIT_MESSAGE => env['BUILD_SOURCEVERSIONMESSAGE']
+            TAG_JOB_NAME => env['TEAMCITY_BUILDCONF_NAME'],
+            TAG_JOB_URL => env['BUILD_URL'],
           }
         end
 

--- a/spec/datadog/ci/ext/fixtures/ci/teamcity.json
+++ b/spec/datadog/ci/ext/fixtures/ci/teamcity.json
@@ -1,0 +1,78 @@
+[
+  [
+    {
+      "BUILD_URL": "the-build-url",
+      "TEAMCITY_BUILDCONF_NAME": "Test 1",
+      "TEAMCITY_VERSION": "2022.10 (build 116751)"
+    },
+    {
+      "ci.job.name": "Test 1",
+      "ci.job.url": "the-build-url",
+      "ci.provider.name": "teamcity"
+    }
+  ],
+  [
+    {
+      "BUILD_URL": "the-build-url",
+      "DD_GIT_BRANCH": "user-supplied-branch",
+      "DD_GIT_COMMIT_AUTHOR_DATE": "usersupplied-authordate",
+      "DD_GIT_COMMIT_AUTHOR_EMAIL": "usersupplied-authoremail",
+      "DD_GIT_COMMIT_AUTHOR_NAME": "usersupplied-authorname",
+      "DD_GIT_COMMIT_COMMITTER_DATE": "usersupplied-comitterdate",
+      "DD_GIT_COMMIT_COMMITTER_EMAIL": "usersupplied-comitteremail",
+      "DD_GIT_COMMIT_COMMITTER_NAME": "usersupplied-comittername",
+      "DD_GIT_COMMIT_MESSAGE": "usersupplied-message",
+      "DD_GIT_COMMIT_SHA": "b9f0fb3fdbb94c9d24b2c75b49663122a529e123",
+      "DD_GIT_REPOSITORY_URL": "git@github.com:DataDog/userrepo.git",
+      "TEAMCITY_BUILDCONF_NAME": "Test 1",
+      "TEAMCITY_VERSION": "2022.10 (build 116751)"
+    },
+    {
+      "ci.job.name": "Test 1",
+      "ci.job.url": "the-build-url",
+      "ci.provider.name": "teamcity",
+      "git.branch": "user-supplied-branch",
+      "git.commit.author.date": "usersupplied-authordate",
+      "git.commit.author.email": "usersupplied-authoremail",
+      "git.commit.author.name": "usersupplied-authorname",
+      "git.commit.committer.date": "usersupplied-comitterdate",
+      "git.commit.committer.email": "usersupplied-comitteremail",
+      "git.commit.committer.name": "usersupplied-comittername",
+      "git.commit.message": "usersupplied-message",
+      "git.commit.sha": "b9f0fb3fdbb94c9d24b2c75b49663122a529e123",
+      "git.repository_url": "git@github.com:DataDog/userrepo.git"
+    }
+  ],
+  [
+    {
+      "BUILD_URL": "the-build-url",
+      "DD_GIT_COMMIT_AUTHOR_DATE": "usersupplied-authordate",
+      "DD_GIT_COMMIT_AUTHOR_EMAIL": "usersupplied-authoremail",
+      "DD_GIT_COMMIT_AUTHOR_NAME": "usersupplied-authorname",
+      "DD_GIT_COMMIT_COMMITTER_DATE": "usersupplied-comitterdate",
+      "DD_GIT_COMMIT_COMMITTER_EMAIL": "usersupplied-comitteremail",
+      "DD_GIT_COMMIT_COMMITTER_NAME": "usersupplied-comittername",
+      "DD_GIT_COMMIT_MESSAGE": "usersupplied-message",
+      "DD_GIT_COMMIT_SHA": "b9f0fb3fdbb94c9d24b2c75b49663122a529e123",
+      "DD_GIT_REPOSITORY_URL": "git@github.com:DataDog/userrepo.git",
+      "DD_GIT_TAG": "0.0.2",
+      "TEAMCITY_BUILDCONF_NAME": "Test 1",
+      "TEAMCITY_VERSION": "2022.10 (build 116751)"
+    },
+    {
+      "ci.job.name": "Test 1",
+      "ci.job.url": "the-build-url",
+      "ci.provider.name": "teamcity",
+      "git.commit.author.date": "usersupplied-authordate",
+      "git.commit.author.email": "usersupplied-authoremail",
+      "git.commit.author.name": "usersupplied-authorname",
+      "git.commit.committer.date": "usersupplied-comitterdate",
+      "git.commit.committer.email": "usersupplied-comitteremail",
+      "git.commit.committer.name": "usersupplied-comittername",
+      "git.commit.message": "usersupplied-message",
+      "git.commit.sha": "b9f0fb3fdbb94c9d24b2c75b49663122a529e123",
+      "git.repository_url": "git@github.com:DataDog/userrepo.git",
+      "git.tag": "0.0.2"
+    }
+  ]
+]


### PR DESCRIPTION
**What does this PR do?**

Adds a test for TeamCity and updates the env var extraction to match the spec.

Also fixes a small and harmless copy-paste error that caused to try to read Azure Pipelines env vars in other providers.

**Motivation**
Improve support for TeamCity.

**How to test the change?**
Updated the fixtures generated from the ciapp spec.
