### PR TITLE
Capture user-relevant implementation details for the Processing Pipeline

### DIFF
--- a/docs/GettingStarted.md
+++ b/docs/GettingStarted.md
@@ -2549,8 +2549,9 @@ In both cases, the processor method *must* return the `trace` object; this retur
 
 #### Caveats
 
-1. The [debug mode logs](#enabling-debug-mode) reports the state of spans *before* the Processing Pipeline is executed.
-2. Removing a span in the Processing Pipeline also removes all children spans from the removed span. This prevents orphan spans in the trace graph.
+1. Removed spans will not generate trace metrics, affecting monitors and dashboards.
+2. Removing a span also removes all children spans from the removed span. This prevents orphan spans in the trace graph.
+3. The [debug mode logs](#enabling-debug-mode) reports the state of spans *before* the Processing Pipeline is executed: modified or removed spans will display their original state in debug mode logs.
 
 ### Trace correlation
 

--- a/docs/GettingStarted.md
+++ b/docs/GettingStarted.md
@@ -2547,6 +2547,11 @@ Datadog::Tracing.before_flush(MyCustomProcessor.new)
 
 In both cases, the processor method *must* return the `trace` object; this return value will be passed to the next processor in the pipeline.
 
+#### Caveats
+
+1. The [debug mode logs](#enabling-debug-mode) reports the state of spans *before* the Processing Pipeline is executed.
+2. Removing a span in the Processing Pipeline also removes all children spans from the removed span. This prevents orphan spans in the trace graph.
+
 ### Trace correlation
 
 In many cases, such as logging, it may be useful to correlate trace IDs to other events or data streams, for easier cross-referencing.


### PR DESCRIPTION
This PR adds a few important details about how the Processing Pipeline behaves when activate by the user.

These concerns have been brought up in the past and can cause confusion when not known by the application maintainer.