### PR TITLE
Fix "NameError: uninitialized constant Datadog::Core::Vendor::IPAddr::AddressFamilyError"

### DIFF
--- a/lib/datadog/core/vendor/ipaddr.rb
+++ b/lib/datadog/core/vendor/ipaddr.rb
@@ -42,7 +42,7 @@ module Datadog
             when Socket::AF_INET6
               addr & 0xfe00_0000_0000_0000_0000_0000_0000_0000 == 0xfc00_0000_0000_0000_0000_0000_0000_0000
             else
-              raise IPAddr::AddressFamilyError, 'unsupported address family'
+              raise ::IPAddr::AddressFamilyError, 'unsupported address family'
             end
           end
 
@@ -55,7 +55,7 @@ module Datadog
             when Socket::AF_INET6
               addr & 0xffc0_0000_0000_0000_0000_0000_0000_0000 == 0xfe80_0000_0000_0000_0000_0000_0000_0000
             else
-              raise IPAddr::AddressFamilyError, 'unsupported address family'
+              raise ::IPAddr::AddressFamilyError, 'unsupported address family'
             end
           end
 
@@ -68,7 +68,7 @@ module Datadog
             when Socket::AF_INET6
               addr == 1
             else
-              raise IPAddr::AddressFamilyError, 'unsupported address family'
+              raise ::IPAddr::AddressFamilyError, 'unsupported address family'
             end
           end
         end

--- a/spec/datadog/core/vendor/ipaddr_spec.rb
+++ b/spec/datadog/core/vendor/ipaddr_spec.rb
@@ -1,0 +1,25 @@
+require 'datadog/core/vendor/ipaddr'
+require 'ipaddr'
+require 'ostruct'
+
+RSpec.describe Datadog::Core::Vendor::IPAddr do
+  let(:invalid_object) { OpenStruct.new.tap { |o| o.instance_variable_set(:@addr, nil) } }
+
+  describe '.private?' do
+    it 'correctly raises when object is invalid' do
+      expect { described_class.private?(invalid_object) }.to raise_error(::IPAddr::AddressFamilyError)
+    end
+  end
+
+  describe '.link_local?' do
+    it 'correctly raises when object is invalid' do
+      expect { described_class.link_local?(invalid_object) }.to raise_error(::IPAddr::AddressFamilyError)
+    end
+  end
+
+  describe '.loopback?' do
+    it 'correctly raises when object is invalid' do
+      expect { described_class.loopback?(invalid_object) }.to raise_error(::IPAddr::AddressFamilyError)
+    end
+  end
+end


### PR DESCRIPTION
**What does this PR do?**:

This PR fixes a bug in the recently-introduced `IPAddr` module.

During review of #2665 the `IPAddr` module was introduced, and while experimenting with the steep type checker, I noticed there was a collision between our `IPAddr` module and the `IPAddr` module where we were looking for execptions.

I'm not sure if this would happen in production, since we always created an `IPAddr` instance with an IP, never a specific `family`, but let's fix this anyway.

**Motivation**:

Less bugs!

**Additional Notes**:

(N/A)

**How to test the change?**:

This module is a backport of `IPAddr` to older Rubies. Previously, we only tested it indirectly.

I added a minimal test to validate this change.