### PR TITLE
Rename conflicting `send_payload` method

### DIFF
--- a/lib/ddtrace/transport/http/traces.rb
+++ b/lib/ddtrace/transport/http/traces.rb
@@ -25,7 +25,7 @@ module Datadog
 
         # Extensions for HTTP client
         module Client
-          def send_payload(request)
+          def send_traces_payload(request)
             send_request(request) do |api, env|
               api.send_traces(env)
             end

--- a/lib/ddtrace/transport/traces.rb
+++ b/lib/ddtrace/transport/traces.rb
@@ -128,7 +128,7 @@ module Datadog
           responses = chunker.encode_in_chunks(traces.lazy).map do |encoded_traces, trace_count|
             request = Request.new(EncodedParcel.new(encoded_traces, trace_count))
 
-            client.send_payload(request).tap do |response|
+            client.send_traces_payload(request).tap do |response|
               if downgrade?(response)
                 downgrade!
                 return send_traces(traces)

--- a/spec/ddtrace/transport/http/traces_spec.rb
+++ b/spec/ddtrace/transport/http/traces_spec.rb
@@ -28,8 +28,8 @@ RSpec.describe Datadog::Transport::HTTP::Client do
 
   let(:api) { instance_double(Datadog::Transport::HTTP::API::Instance) }
 
-  describe '#send_payload' do
-    subject(:send_payload) { client.send_payload(request) }
+  describe '#send_traces_payload' do
+    subject(:send_traces_payload) { client.send_traces_payload(request) }
 
     let(:request) { instance_double(Datadog::Transport::Traces::Request) }
     let(:response) { instance_double(Datadog::Transport::HTTP::Traces::Response) }

--- a/spec/ddtrace/transport/traces_spec.rb
+++ b/spec/ddtrace/transport/traces_spec.rb
@@ -179,8 +179,8 @@ RSpec.describe Datadog::Transport::Traces::Transport do
 
       allow(Datadog::Transport::HTTP::Client).to receive(:new).with(api_v1).and_return(client_v1)
       allow(Datadog::Transport::HTTP::Client).to receive(:new).with(api_v2).and_return(client_v2)
-      allow(client_v1).to receive(:send_payload).with(request).and_return(response)
-      allow(client_v2).to receive(:send_payload).with(request).and_return(response)
+      allow(client_v1).to receive(:send_traces_payload).with(request).and_return(response)
+      allow(client_v2).to receive(:send_traces_payload).with(request).and_return(response)
 
       allow(Datadog::Transport::Traces::Request).to receive(:new).and_return(request)
     end
@@ -190,7 +190,7 @@ RSpec.describe Datadog::Transport::Traces::Transport do
 
       it 'sends to only the current API once' do
         is_expected.to eq(responses)
-        expect(client_v2).to have_received(:send_payload).with(request).once
+        expect(client_v2).to have_received(:send_traces_payload).with(request).once
 
         expect(health_metrics).to have_received(:transport_chunked).with(1)
       end
@@ -206,7 +206,7 @@ RSpec.describe Datadog::Transport::Traces::Transport do
 
         it 'successfully sends a single request' do
           is_expected.to eq(responses)
-          expect(client_v2).to have_received(:send_payload).with(request).once
+          expect(client_v2).to have_received(:send_traces_payload).with(request).once
 
           expect(health_metrics).to have_received(:transport_chunked).with(1)
         end
@@ -232,8 +232,8 @@ RSpec.describe Datadog::Transport::Traces::Transport do
       it 'attempts each API once as it falls back after each failure' do
         is_expected.to eq(responses)
 
-        expect(client_v2).to have_received(:send_payload).with(request).once
-        expect(client_v1).to have_received(:send_payload).with(request).once
+        expect(client_v2).to have_received(:send_traces_payload).with(request).once
+        expect(client_v1).to have_received(:send_traces_payload).with(request).once
 
         expect(health_metrics).to have_received(:transport_chunked).with(1)
       end
@@ -248,8 +248,8 @@ RSpec.describe Datadog::Transport::Traces::Transport do
       it 'attempts each API once as it falls back after each failure' do
         is_expected.to eq(responses)
 
-        expect(client_v2).to have_received(:send_payload).with(request).once
-        expect(client_v1).to have_received(:send_payload).with(request).once
+        expect(client_v2).to have_received(:send_traces_payload).with(request).once
+        expect(client_v1).to have_received(:send_traces_payload).with(request).once
 
         expect(health_metrics).to have_received(:transport_chunked).with(1)
       end


### PR DESCRIPTION


<!--
Check out the
https://github.com/DataDog/dd-trace-rb/blob/master/docs/DevelopmentGuide.md
for guidance on how to set up your development environment,
run the test suite, write new integrations, and more.
-->

**What does this PR do?**

Move a generically named method out of the way.

**Motivation**

The transport infrastructure is mostly generic, except for a few choke points. This addresses one of them.

The `send_payload` method, while defined in a trace-specific module, is included at the class level.

When attempting to reuse transport for other use cases, the method conflicts with other modules extending the generic client class.

Luckily its use is very limited and self-contained to a trace transport specific scope. By renaming it additional modules are able to be included and can follow a consistent pattern without conflict.

**Additional Notes**

This has been discovered while implementing additional transport facilities for remote configuration, from an AppSec impetus.

The whole transport code is fairly involved and due for a rewrite, nonetheless it handles many corner cases. which would make a drop-in rewrite carry much risk to tracing.

Therefore a more segregated approach is being taken to implement the required additional transports, aiming:
- to be a second use case, highlighting the limitations and hopefully providing insights for improvements.
- to be of little invasiveness to the current transport code; still, some are required.

This is one of those changes.

**How to test the change?**

CI should be green.
