### PR TITLE
Add support for GET in transport

### DIFF
--- a/lib/ddtrace/transport/http/adapters/net.rb
+++ b/lib/ddtrace/transport/http/adapters/net.rb
@@ -53,6 +53,18 @@ module Datadog
             end
           end
 
+          def get(env)
+            get = ::Net::HTTP::Get.new(env.path, env.headers)
+
+            # Connect and send the request
+            http_response = open do |http|
+              http.request(get)
+            end
+
+            # Build and return response
+            Response.new(http_response)
+          end
+
           def post(env)
             post = nil
 

--- a/lib/ddtrace/transport/request.rb
+++ b/lib/ddtrace/transport/request.rb
@@ -5,7 +5,7 @@ module Datadog
       attr_reader \
         :parcel
 
-      def initialize(parcel)
+      def initialize(parcel = nil)
         @parcel = parcel
       end
     end

--- a/spec/ddtrace/transport/http/adapters/net_spec.rb
+++ b/spec/ddtrace/transport/http/adapters/net_spec.rb
@@ -102,9 +102,28 @@ RSpec.describe Datadog::Transport::HTTP::Adapters::Net do
       before { allow(env).to receive(:verb).and_return(verb) }
 
       context ':get' do
+        include_context 'HTTP connection stub'
         let(:verb) { :get }
+        let(:http_response) { double('http_response') }
 
-        it { expect { call }.to raise_error(described_class::UnknownHTTPMethod) }
+        context 'and a simple get request' do
+          let(:get) { instance_double(Net::HTTP::Get) }
+
+          it 'makes a GET and produces a response' do
+            expect(Net::HTTP::Get)
+              .to receive(:new)
+              .with(env.path, env.headers)
+              .and_return(get)
+
+            expect(http_connection)
+              .to receive(:request)
+              .with(get)
+              .and_return(http_response)
+
+            is_expected.to be_a_kind_of(described_class::Response)
+            expect(call.http_response).to be(http_response)
+          end
+        end
       end
 
       context ':post' do
@@ -155,6 +174,30 @@ RSpec.describe Datadog::Transport::HTTP::Adapters::Net do
             expect(call.http_response).to be(http_response)
           end
         end
+      end
+
+      context ':head' do
+        let(:verb) { :head }
+
+        it { expect { call }.to raise_error(described_class::UnknownHTTPMethod) }
+      end
+
+      context ':put' do
+        let(:verb) { :put }
+
+        it { expect { call }.to raise_error(described_class::UnknownHTTPMethod) }
+      end
+
+      context ':delete' do
+        let(:verb) { :delete }
+
+        it { expect { call }.to raise_error(described_class::UnknownHTTPMethod) }
+      end
+
+      context ':patch' do
+        let(:verb) { :patch }
+
+        it { expect { call }.to raise_error(described_class::UnknownHTTPMethod) }
       end
     end
   end

--- a/spec/ddtrace/transport/request_spec.rb
+++ b/spec/ddtrace/transport/request_spec.rb
@@ -9,5 +9,11 @@ RSpec.describe Datadog::Transport::Request do
 
   describe '#initialize' do
     it { is_expected.to have_attributes(parcel: parcel) }
+
+    context 'with no argument' do
+      subject(:request) { described_class.new }
+
+      it { is_expected.to have_attributes(parcel: nil) }
+    end
   end
 end


### PR DESCRIPTION

<!--
Check out the
https://github.com/DataDog/dd-trace-rb/blob/master/docs/DevelopmentGuide.md
for guidance on how to set up your development environment,
run the test suite, write new integrations, and more.
-->

**What does this PR do?**

Implement GET support for HTTP transport.

**Motivation**

Some endpoints respond to GET, which was not implemented.

**Additional Notes**

In addition, since GET can't have a body, a `Request` parcel can be omitted. It is therefore made optional.

**How to test the change?**

CI should be green.