### PR TITLE
Add info transport endpoint

### DIFF
--- a/Steepfile
+++ b/Steepfile
@@ -653,6 +653,7 @@ target :ddtrace do
   library 'tsort'
   library 'json'
   library 'ipaddr'
+  library 'net-http'
 
   # TODO: gem 'libddwaf'
 

--- a/lib/datadog/core/configuration/agent_settings_resolver.rb
+++ b/lib/datadog/core/configuration/agent_settings_resolver.rb
@@ -66,9 +66,9 @@ module Datadog
 
         def call
           # A transport_options proc configured for unix domain socket overrides most of the logic on this file
-          if transport_options.adapter == Transport::Ext::UnixSocket::ADAPTER
+          if transport_options.adapter == Datadog::Transport::Ext::UnixSocket::ADAPTER
             return AgentSettings.new(
-              adapter: Transport::Ext::UnixSocket::ADAPTER,
+              adapter: Datadog::Transport::Ext::UnixSocket::ADAPTER,
               ssl: false,
               hostname: nil,
               port: nil,
@@ -98,9 +98,9 @@ module Datadog
           # If no agent settings have been provided, we try to connect using a local unix socket.
           # We only do so if the socket is present when `ddtrace` runs.
           if should_use_uds_fallback?
-            Transport::Ext::UnixSocket::ADAPTER
+            Datadog::Transport::Ext::UnixSocket::ADAPTER
           else
-            Transport::Ext::HTTP::ADAPTER
+            Datadog::Transport::Ext::HTTP::ADAPTER
           end
         end
 
@@ -204,9 +204,9 @@ module Datadog
             if configured_hostname.nil? &&
                 configured_port.nil? &&
                 deprecated_for_removal_transport_configuration_proc.nil? &&
-                File.exist?(Transport::Ext::UnixSocket::DEFAULT_PATH)
+                File.exist?(Datadog::Transport::Ext::UnixSocket::DEFAULT_PATH)
 
-              Transport::Ext::UnixSocket::DEFAULT_PATH
+              Datadog::Transport::Ext::UnixSocket::DEFAULT_PATH
             end
         end
 

--- a/lib/datadog/core/transport/http.rb
+++ b/lib/datadog/core/transport/http.rb
@@ -1,0 +1,139 @@
+# frozen_string_literal: true
+
+require 'uri'
+
+require_relative '../environment/container'
+require_relative '../environment/ext'
+require_relative '../../../ddtrace/transport/ext'
+require_relative '../../../ddtrace/transport/http/adapters/net'
+require_relative '../../../ddtrace/transport/http/adapters/test'
+require_relative '../../../ddtrace/transport/http/adapters/unix_socket'
+
+# TODO: Improve negotiation to allow per endpoint selection
+#
+# Since endpoint negotiation happens at the `API::Spec` level there can not be
+# a mix of enpoints at various versions or versionless without describing all
+# the possible combinations as specs. See http/api.
+#
+# Below should be:
+# require_relative '../../../ddtrace/transport/http/api'
+require_relative 'http/api'
+
+# TODO: Decouple transport/http/builder
+#
+# See http/builder
+#
+# Below should be:
+# require_relative '../../../ddtrace/transport/http/builder'
+require_relative 'http/builder'
+
+# TODO: Decouple transport/http
+#
+# Because a new transport is required for every (API, Client, Transport)
+# triplet and endpoints cannot be negotiated independently, there can not be a
+# single `default` transport, but only endpoint-specific ones.
+
+module Datadog
+  module Core
+    module Transport
+      # Namespace for HTTP transport components
+      module HTTP
+        # NOTE: Due to... legacy reasons... This class likes having a default `AgentSettings` instance to fall back to.
+        # Because we generate this instance with an empty instance of `Settings`, the resulting `AgentSettings` below
+        # represents only settings specified via environment variables + the usual defaults.
+        #
+        # DO NOT USE THIS IN NEW CODE, as it ignores any settings specified by users via `Datadog.configure`.
+        DO_NOT_USE_ENVIRONMENT_AGENT_SETTINGS = Datadog::Core::Configuration::AgentSettingsResolver.call(
+          Datadog::Core::Configuration::Settings.new,
+          logger: nil,
+        )
+
+        module_function
+
+        # Builds a new Transport::HTTP::Client
+        def new(klass, &block)
+          Builder.new(&block).to_transport(klass)
+        end
+
+        # Builds a new Transport::HTTP::Client with default settings
+        # Pass a block to override any settings.
+        def root(
+          agent_settings: DO_NOT_USE_ENVIRONMENT_AGENT_SETTINGS,
+          **options
+        )
+          new(Transport::Negotiation::Transport) do |transport|
+            transport.adapter(agent_settings)
+            transport.headers default_headers
+
+            apis = API.defaults
+
+            transport.api API::ROOT, apis[API::ROOT]
+
+            # Apply any settings given by options
+            unless options.empty?
+              transport.default_api = options[:api_version] if options.key?(:api_version)
+              transport.headers options[:headers] if options.key?(:headers)
+            end
+
+            if agent_settings.deprecated_for_removal_transport_configuration_proc
+              agent_settings.deprecated_for_removal_transport_configuration_proc.call(transport)
+            end
+
+            # Call block to apply any customization, if provided
+            yield(transport) if block_given?
+          end
+        end
+
+        def default_headers
+          {
+            Datadog::Transport::Ext::HTTP::HEADER_CLIENT_COMPUTED_TOP_LEVEL => '1',
+            Datadog::Transport::Ext::HTTP::HEADER_META_LANG => Datadog::Core::Environment::Ext::LANG,
+            Datadog::Transport::Ext::HTTP::HEADER_META_LANG_VERSION => Datadog::Core::Environment::Ext::LANG_VERSION,
+            Datadog::Transport::Ext::HTTP::HEADER_META_LANG_INTERPRETER => Datadog::Core::Environment::Ext::LANG_INTERPRETER,
+            Datadog::Transport::Ext::HTTP::HEADER_META_TRACER_VERSION => Datadog::Core::Environment::Ext::TRACER_VERSION
+          }.tap do |headers|
+            # Add container ID, if present.
+            container_id = Datadog::Core::Environment::Container.container_id
+            headers[Datadog::Transport::Ext::HTTP::HEADER_CONTAINER_ID] = container_id unless container_id.nil?
+          end
+        end
+
+        def default_adapter
+          Transport::Ext::HTTP::ADAPTER
+        end
+
+        def default_hostname(logger: Datadog.logger)
+          logger.warn(
+            'Deprecated for removal: Using #default_hostname for configuration is deprecated and will ' \
+            'be removed on a future ddtrace release.'
+          )
+
+          DO_NOT_USE_ENVIRONMENT_AGENT_SETTINGS.hostname
+        end
+
+        def default_port(logger: Datadog.logger)
+          logger.warn(
+            'Deprecated for removal: Using #default_hostname for configuration is deprecated and will ' \
+            'be removed on a future ddtrace release.'
+          )
+
+          DO_NOT_USE_ENVIRONMENT_AGENT_SETTINGS.port
+        end
+
+        def default_url(logger: Datadog.logger)
+          logger.warn(
+            'Deprecated for removal: Using #default_url for configuration is deprecated and will ' \
+            'be removed on a future ddtrace release.'
+          )
+
+          nil
+        end
+
+        # Add adapters to registry
+        Builder::REGISTRY.set(Datadog::Transport::HTTP::Adapters::Net, Datadog::Transport::Ext::HTTP::ADAPTER)
+        Builder::REGISTRY.set(Datadog::Transport::HTTP::Adapters::Test, Datadog::Transport::Ext::Test::ADAPTER)
+        Builder::REGISTRY.set(Datadog::Transport::HTTP::Adapters::UnixSocket, Datadog::Transport::Ext::UnixSocket::ADAPTER)
+      end
+    end
+  end
+end

--- a/lib/datadog/core/transport/http.rb
+++ b/lib/datadog/core/transport/http.rb
@@ -63,7 +63,7 @@ module Datadog
         )
           new(Transport::Negotiation::Transport) do |transport|
             transport.adapter(agent_settings)
-            transport.headers default_headers
+            transport.headers(default_headers)
 
             apis = API.defaults
 

--- a/lib/datadog/core/transport/http.rb
+++ b/lib/datadog/core/transport/http.rb
@@ -99,7 +99,7 @@ module Datadog
         end
 
         def default_adapter
-          Transport::Ext::HTTP::ADAPTER
+          Datadog::Transport::Ext::HTTP::ADAPTER
         end
 
         def default_hostname(logger: Datadog.logger)

--- a/lib/datadog/core/transport/http.rb
+++ b/lib/datadog/core/transport/http.rb
@@ -89,7 +89,8 @@ module Datadog
             Datadog::Transport::Ext::HTTP::HEADER_CLIENT_COMPUTED_TOP_LEVEL => '1',
             Datadog::Transport::Ext::HTTP::HEADER_META_LANG => Datadog::Core::Environment::Ext::LANG,
             Datadog::Transport::Ext::HTTP::HEADER_META_LANG_VERSION => Datadog::Core::Environment::Ext::LANG_VERSION,
-            Datadog::Transport::Ext::HTTP::HEADER_META_LANG_INTERPRETER => Datadog::Core::Environment::Ext::LANG_INTERPRETER,
+            Datadog::Transport::Ext::HTTP::HEADER_META_LANG_INTERPRETER =>
+              Datadog::Core::Environment::Ext::LANG_INTERPRETER,
             Datadog::Transport::Ext::HTTP::HEADER_META_TRACER_VERSION => Datadog::Core::Environment::Ext::TRACER_VERSION
           }.tap do |headers|
             # Add container ID, if present.

--- a/lib/datadog/core/transport/http/api.rb
+++ b/lib/datadog/core/transport/http/api.rb
@@ -1,0 +1,47 @@
+# frozen_string_literal: true
+
+require_relative '../../encoding'
+
+require_relative '../../../../ddtrace/transport/http/api/map'
+
+# TODO: Decouple standard transport/http/api/instance
+#
+# Separate classes are needed because transport/http/trace includes
+# Trace::API::Instance which closes over and uses a single spec, which is
+# negotiated as either /v3 or /v4 for the whole API at the spec level, but we
+# need an independent toplevel path at the endpoint level.
+#
+# Separate classes are needed because of `include Trace::API::Instance`.
+#
+# Below should be:
+# require_relative '../../../../ddtrace/transport/http/api/spec'
+require_relative 'api/spec'
+
+# TODO: only needed for Negotiation::API::Endpoint
+require_relative 'negotiation'
+
+module Datadog
+  module Core
+    module Transport
+      module HTTP
+        # Namespace for API components
+        module API
+          # Default API versions
+          ROOT = 'root'
+
+          module_function
+
+          def defaults
+            Datadog::Transport::HTTP::API::Map[
+              ROOT => Spec.new do |s|
+                s.info = Negotiation::API::Endpoint.new(
+                  '/info',
+                )
+              end,
+            ]
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/datadog/core/transport/http/api.rb
+++ b/lib/datadog/core/transport/http/api.rb
@@ -6,7 +6,7 @@ require_relative '../../../../ddtrace/transport/http/api/map'
 
 # TODO: Decouple standard transport/http/api/instance
 #
-# Separate classes are needed because transport/http/trace includes
+# Separate classes are needed because transport/http/traces includes
 # Trace::API::Instance which closes over and uses a single spec, which is
 # negotiated as either /v3 or /v4 for the whole API at the spec level, but we
 # need an independent toplevel path at the endpoint level.

--- a/lib/datadog/core/transport/http/api/instance.rb
+++ b/lib/datadog/core/transport/http/api/instance.rb
@@ -1,0 +1,37 @@
+# frozen_string_literal: true
+
+module Datadog
+  module Core
+    module Transport
+      module HTTP
+        module API
+          # An API configured with adapter and routes
+          class Instance
+            attr_reader \
+              :adapter,
+              :headers,
+              :spec
+
+            def initialize(spec, adapter, options = {})
+              @spec = spec
+              @adapter = adapter
+              @headers = options.fetch(:headers, {})
+            end
+
+            def encoder
+              spec.encoder
+            end
+
+            def call(env)
+              # Add headers to request env, unless empty.
+              env.headers.merge!(headers) unless headers.empty?
+
+              # Send request env to the adapter.
+              adapter.call(env)
+            end
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/datadog/core/transport/http/api/spec.rb
+++ b/lib/datadog/core/transport/http/api/spec.rb
@@ -1,0 +1,19 @@
+# frozen_string_literal: true
+
+module Datadog
+  module Core
+    module Transport
+      module HTTP
+        module API
+          # Specification for an HTTP API
+          # Defines behaviors without specific configuration details.
+          class Spec
+            def initialize
+              yield(self) if block_given?
+            end
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/datadog/core/transport/http/builder.rb
+++ b/lib/datadog/core/transport/http/builder.rb
@@ -157,6 +157,8 @@ module Datadog
             attr_reader :key
 
             def initialize(key)
+              super()
+
               @key = key
             end
 
@@ -170,6 +172,8 @@ module Datadog
             attr_reader :type
 
             def initialize(type)
+              super()
+
               @type = type
             end
 
@@ -183,6 +187,8 @@ module Datadog
             attr_reader :key
 
             def initialize(key)
+              super()
+
               @key = key
             end
 

--- a/lib/datadog/core/transport/http/builder.rb
+++ b/lib/datadog/core/transport/http/builder.rb
@@ -1,0 +1,211 @@
+# frozen_string_literal: true
+
+require_relative '../../configuration/agent_settings_resolver'
+require_relative '../../../../ddtrace/transport/http/adapters/registry'
+require_relative '../../../../ddtrace/transport/http/api/map'
+
+# TODO: Decouple standard transport/http/api/instance
+#
+# Separate classes are needed because transport/http/trace includes
+# Trace::API::Instance which closes over and uses a single spec, which is
+# negotiated as either /v3 or /v4 for the whole API at the spec level, but we
+# need an independent toplevel path at the endpoint level.
+#
+# Separate classes are needed because of `include Trace::API::Instance`.
+#
+# Below should be:
+# require_relative '../../../../ddtrace/transport/http/api/instance'
+require_relative 'api/instance'
+
+# TODO: Decouple transport/http/client
+#
+# The standard one does `include Transport::HTTP::Statistics` and performs
+# stats updates, which may or may not be desirable in general.
+#
+# Below should be:
+# require_relative '../../../../ddtrace/transport/http/client'
+require_relative 'client'
+
+# TODO: Decouple transport/http/builder
+#
+# This class is duplicated even though it is tantalisingly close to the
+# one in ddtrace/transport mostly because it refers to a different
+# `API::Instance` in `#api_instance_class` but also because it operates on a
+# different `HTTP::Client`, as well as de-hardcoding the transport class
+# `Transport::Traces::Transport` in `#to_transport`
+#
+# Additionally, its design makes it so there can be only one (API, Client,
+# Transport) triplet, requiring a new transport instance for any varying
+# element of the triplet.
+
+module Datadog
+  module Core
+    module Transport
+      module HTTP
+        # Builds new instances of Transport::HTTP::Client
+        class Builder
+          REGISTRY = Datadog::Transport::HTTP::Adapters::Registry.new
+
+          attr_reader \
+            :apis,
+            :api_options,
+            :default_adapter,
+            :default_api,
+            :default_headers
+
+          def initialize
+            # Global settings
+            @default_adapter = nil
+            @default_headers = {}
+
+            # Client settings
+            @apis = Datadog::Transport::HTTP::API::Map.new
+            @default_api = nil
+
+            # API settings
+            @api_options = {}
+
+            yield(self) if block_given?
+          end
+
+          def adapter(config, *args, **kwargs)
+            @default_adapter = case config
+                               when Core::Configuration::AgentSettingsResolver::AgentSettings
+                                 registry_klass = REGISTRY.get(config.adapter)
+                                 raise UnknownAdapterError, config.adapter if registry_klass.nil?
+
+                                 registry_klass.build(config)
+                               when Symbol
+                                 registry_klass = REGISTRY.get(config)
+                                 raise UnknownAdapterError, config if registry_klass.nil?
+
+                                 registry_klass.new(*args, **kwargs)
+                               else
+                                 config
+                               end
+          end
+
+          def headers(values = {})
+            @default_headers.merge!(values)
+          end
+
+          # Adds a new API to the client
+          # Valid options:
+          #  - :adapter
+          #  - :default
+          #  - :fallback
+          #  - :headers
+          def api(key, spec, options = {})
+            options = options.dup
+
+            # Copy spec into API map
+            @apis[key] = spec
+
+            # Apply as default API, if specified to do so.
+            @default_api = key if options.delete(:default) || @default_api.nil?
+
+            # Save all other settings for initialization
+            (@api_options[key] ||= {}).merge!(options)
+          end
+
+          def default_api=(key)
+            raise UnknownApiError, key unless @apis.key?(key)
+
+            @default_api = key
+          end
+
+          def to_transport(klass)
+            raise NoDefaultApiError if @default_api.nil?
+
+            klass.new(to_api_instances, @default_api)
+          end
+
+          def to_api_instances
+            raise NoApisError if @apis.empty?
+
+            @apis.inject(Datadog::Transport::HTTP::API::Map.new) do |instances, (key, spec)|
+              instances.tap do
+                api_options = @api_options[key].dup
+
+                # Resolve the adapter to use for this API
+                adapter = api_options.delete(:adapter) || @default_adapter
+                raise NoAdapterForApiError, key if adapter.nil?
+
+                # Resolve fallback and merge headers
+                fallback = api_options.delete(:fallback)
+                api_options[:headers] = @default_headers.merge((api_options[:headers] || {}))
+
+                # Add API::Instance with all settings
+                instances[key] = api_instance_class.new(
+                  spec,
+                  adapter,
+                  api_options
+                )
+
+                # Configure fallback, if provided.
+                instances.with_fallbacks(key => fallback) unless fallback.nil?
+              end
+            end
+          end
+
+          def api_instance_class
+            API::Instance
+          end
+
+          # Raised when the API key does not match known APIs.
+          class UnknownApiError < StandardError
+            attr_reader :key
+
+            def initialize(key)
+              @key = key
+            end
+
+            def message
+              "Unknown transport API '#{key}'!"
+            end
+          end
+
+          # Raised when the identifier cannot be matched to an adapter.
+          class UnknownAdapterError < StandardError
+            attr_reader :type
+
+            def initialize(type)
+              @type = type
+            end
+
+            def message
+              "Unknown transport adapter '#{type}'!"
+            end
+          end
+
+          # Raised when an adapter cannot be resolved for an API instance.
+          class NoAdapterForApiError < StandardError
+            attr_reader :key
+
+            def initialize(key)
+              @key = key
+            end
+
+            def message
+              "No adapter resolved for transport API '#{key}'!"
+            end
+          end
+
+          # Raised when built without defining APIs.
+          class NoApisError < StandardError
+            def message
+              'No APIs configured for transport!'
+            end
+          end
+
+          # Raised when client built without defining a default API.
+          class NoDefaultApiError < StandardError
+            def message
+              'No default API configured for transport!'
+            end
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/datadog/core/transport/http/client.rb
+++ b/lib/datadog/core/transport/http/client.rb
@@ -1,0 +1,45 @@
+# frozen_string_literal: true
+
+require_relative '../../../../ddtrace/transport/http/env'
+
+# TODO: Decouple transport/http/client
+#
+# The standard one does `include Transport::HTTP::Statistics` and performs
+# stats updates, which may or may not be desirable in general.
+
+module Datadog
+  module Core
+    module Transport
+      module HTTP
+        # Routes, encodes, and sends tracer data to the trace agent via HTTP.
+        class Client
+          attr_reader :api
+
+          def initialize(api)
+            @api = api
+          end
+
+          def send_request(request, &block)
+            # Build request into env
+            env = build_env(request)
+
+            # Get responses from API
+            response = yield(api, env)
+
+            response
+          rescue StandardError => e
+            message =
+              "Internal error during #{self.class.name} request. Cause: #{e.class.name} #{e.message} " \
+              "Location: #{Array(e.backtrace).first}"
+
+            Datadog::Transport::InternalErrorResponse.new(e)
+          end
+
+          def build_env(request)
+            Datadog::Transport::HTTP::Env.new(request)
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/datadog/core/transport/http/client.rb
+++ b/lib/datadog/core/transport/http/client.rb
@@ -24,13 +24,13 @@ module Datadog
             env = build_env(request)
 
             # Get responses from API
-            response = yield(api, env)
-
-            response
+            yield(api, env)
           rescue StandardError => e
             message =
               "Internal error during #{self.class.name} request. Cause: #{e.class.name} #{e.message} " \
               "Location: #{Array(e.backtrace).first}"
+
+            Datadog.logger.error(message)
 
             Datadog::Transport::InternalErrorResponse.new(e)
           end

--- a/lib/datadog/core/transport/http/negotiation.rb
+++ b/lib/datadog/core/transport/http/negotiation.rb
@@ -1,0 +1,144 @@
+# frozen_string_literal: true
+
+require 'json'
+
+require_relative '../negotiation'
+require_relative 'client'
+require_relative '../../../../ddtrace/transport/http/response'
+require_relative '../../../../ddtrace/transport/http/api/endpoint'
+
+# TODO: Decouple standard transport/http/api/instance
+#
+# Separate classes are needed because transport/http/trace includes
+# Trace::API::Instance which closes over and uses a single spec, which is
+# negotiated as either /v3 or /v4 for the whole API at the spec level, but we
+# need an independent toplevel path at the endpoint level.
+#
+# Separate classes are needed because of `include Trace::API::Instance`.
+#
+# Below should be:
+# require_relative '../../../../ddtrace/transport/http/api/instance'
+require_relative 'api/instance'
+# Below should be:
+# require_relative '../../../../ddtrace/transport/http/api/spec'
+require_relative 'api/spec'
+
+module Datadog
+  module Core
+    module Transport
+      module HTTP
+        # HTTP transport behavior for agent feature negotiation
+        module Negotiation
+          # Response from HTTP transport for agent feature negotiation
+          class Response
+            include Datadog::Transport::HTTP::Response
+            include Core::Transport::Negotiation::Response
+
+            def initialize(http_response, options = {})
+              super(http_response)
+
+              # TODO: transform endpoint hash in a better object for negotiation
+              # TODO: transform config in a better object, notably config has max_request_bytes
+              @version = options[:version]
+              @endpoints = options[:endpoints]
+              @config = options[:config]
+            end
+          end
+
+          # Extensions for HTTP client
+          module Client
+            def send_info_payload(request)
+              send_request(request) do |api, env|
+                api.send_info(env)
+              end
+            end
+          end
+
+          module API
+            # Extensions for HTTP API Spec
+            module Spec
+              attr_reader :info
+
+              def info=(endpoint)
+                @info = endpoint
+              end
+
+              def send_info(env, &block)
+                raise NoNegotiationEndpointDefinedError, self if info.nil?
+
+                info.call(env, &block)
+              end
+
+              # Raised when traces sent but no traces endpoint is defined
+              class NoNegotiationEndpointDefinedError < StandardError
+                attr_reader :spec
+
+                def initialize(spec)
+                  super()
+
+                  @spec = spec
+                end
+
+                def message
+                  'No info endpoint is defined for API specification!'
+                end
+              end
+            end
+
+            # Extensions for HTTP API Instance
+            module Instance
+              def send_info(env)
+                raise NegotiationNotSupportedError, spec unless spec.is_a?(Negotiation::API::Spec)
+
+                spec.send_info(env) do |request_env|
+                  call(request_env)
+                end
+              end
+
+              # Raised when traces sent to API that does not support traces
+              class NegotiationNotSupportedError < StandardError
+                attr_reader :spec
+
+                def initialize(spec)
+                  super()
+
+                  @spec = spec
+                end
+
+                def message
+                  'Info not supported for this API!'
+                end
+              end
+            end
+
+            # Endpoint for negotiation
+            class Endpoint < Datadog::Transport::HTTP::API::Endpoint
+              def initialize(path)
+                super(:get, path)
+              end
+
+              def call(env, &block)
+                # Query for response
+                http_response = super(env, &block)
+
+                # Process the response
+                body = JSON.parse(http_response.payload, symbolize_names: true)
+
+                # TODO: there should be more processing here to ensure a proper response_options
+                response_options = body.is_a?(Hash) ? body : {}
+
+                # Build and return a trace response
+                Negotiation::Response.new(http_response, response_options)
+              end
+            end
+          end
+
+          # Add negotiation behavior to transport components
+          HTTP::Client.include(Negotiation::Client)
+          HTTP::API::Spec.include(Negotiation::API::Spec)
+          HTTP::API::Instance.include(Negotiation::API::Instance)
+        end
+      end
+    end
+  end
+end

--- a/lib/datadog/core/transport/negotiation.rb
+++ b/lib/datadog/core/transport/negotiation.rb
@@ -47,12 +47,7 @@ module Datadog
           def send_info
             request = Request.new
 
-            response = @client.send_info_payload(request)
-
-            # TODO: not sure if we're supposed to do that as we don't chunk like traces
-            # Datadog.health_metrics.transport_chunked(responses.size)
-
-            response
+            @client.send_info_payload(request)
           end
 
           def current_api

--- a/lib/datadog/core/transport/negotiation.rb
+++ b/lib/datadog/core/transport/negotiation.rb
@@ -1,0 +1,65 @@
+# frozen_string_literal: true
+
+require_relative '../../../ddtrace/transport/request'
+
+# TODO: Resolve conceptual conundrum
+#
+# It seems that through naming of `Transport::Traces::Transport` the transport
+# is specific to traces, which kind of matches the almost-generic-but-not-quite
+# implementation.
+#
+# This may be why `Transport::Traces::Transport` negotiates only considering
+# the `/vX/traces` path, but here we don't negotiate since we are at the root.
+#
+# In turn this means that API::Spec cannot describe multiple roots, or even
+# endpoints that happen to differ in version.
+#
+# Concepts such as Spec, API, Endpoint, and Transport should be clarified
+# before attempting further refactoring here, to attempt to resolve whether a
+# Transport - via its negotiated Spec - describes a function (implemented as
+# one or more endpoints) or whether the Spec describes the API towards the
+# agent as a whole, morphing through negotiation into the best available
+# version for each endpoint.
+
+module Datadog
+  module Core
+    module Transport
+      module Negotiation
+        # Negotiation request
+        class Request < Datadog::Transport::Request
+        end
+
+        # Negotiation response
+        module Response
+          attr_reader :version, :endpoints, :config
+        end
+
+        # Negotiation transport
+        class Transport
+          attr_reader :client, :apis, :default_api, :current_api_id
+
+          def initialize(apis, default_api)
+            @apis = apis
+
+            @client = HTTP::Client.new(current_api)
+          end
+
+          def send_info
+            request = Request.new
+
+            response = @client.send_info_payload(request)
+
+            # TODO: not sure if we're supposed to do that as we don't chunk like traces
+            # Datadog.health_metrics.transport_chunked(responses.size)
+
+            response
+          end
+
+          def current_api
+            @apis[HTTP::API::ROOT]
+          end
+        end
+      end
+    end
+  end
+end

--- a/sig/datadog/core/configuration/agent_settings_resolver.rbs
+++ b/sig/datadog/core/configuration/agent_settings_resolver.rbs
@@ -5,6 +5,14 @@ module Datadog
         class AgentSettings < ::Struct[untyped]
           def initialize: (adapter: untyped, ssl: untyped, hostname: untyped, port: untyped, uds_path: untyped, timeout_seconds: untyped, deprecated_for_removal_transport_configuration_proc: untyped) -> void
           def merge: (**::Hash[untyped, untyped] member_values) -> AgentSettingsResolver
+
+          attr_reader adapter: untyped
+          attr_reader ssl: untyped
+          attr_reader hostname: untyped
+          attr_reader port: untyped
+          attr_reader uds_path: untyped
+          attr_reader timeout_seconds: untyped
+          attr_reader deprecated_for_removal_transport_configuration_proc: untyped
         end
 
         def self.call: (untyped settings, ?logger: untyped) -> untyped

--- a/sig/datadog/core/transport/http.rbs
+++ b/sig/datadog/core/transport/http.rbs
@@ -11,7 +11,7 @@ module Datadog
         DO_NOT_USE_ENVIRONMENT_AGENT_SETTINGS: untyped
 
         # Builds a new Transport::HTTP::Client
-        def self?.new: (untyped klass) ?{ () -> untyped } -> untyped
+        def self?.new: (untyped klass) ?{ (untyped) -> untyped } -> untyped
 
         # Builds a new Transport::HTTP::Client with default settings
         # Pass a block to override any settings.

--- a/sig/datadog/core/transport/http.rbs
+++ b/sig/datadog/core/transport/http.rbs
@@ -1,20 +1,11 @@
 module Datadog
   module Core
     module Transport
-      # Namespace for HTTP transport components
       module HTTP
-        # NOTE: Due to... legacy reasons... This class likes having a default `AgentSettings` instance to fall back to.
-        # Because we generate this instance with an empty instance of `Settings`, the resulting `AgentSettings` below
-        # represents only settings specified via environment variables + the usual defaults.
-        #
-        # DO NOT USE THIS IN NEW CODE, as it ignores any settings specified by users via `Datadog.configure`.
         DO_NOT_USE_ENVIRONMENT_AGENT_SETTINGS: untyped
 
-        # Builds a new Transport::HTTP::Client
         def self?.new: (untyped klass) ?{ (untyped) -> untyped } -> untyped
 
-        # Builds a new Transport::HTTP::Client with default settings
-        # Pass a block to override any settings.
         def self?.root: (?agent_settings: untyped, **untyped options) { (untyped) -> untyped } -> untyped
 
         def self?.default_headers: () -> untyped

--- a/sig/datadog/core/transport/http.rbs
+++ b/sig/datadog/core/transport/http.rbs
@@ -1,0 +1,32 @@
+module Datadog
+  module Core
+    module Transport
+      # Namespace for HTTP transport components
+      module HTTP
+        # NOTE: Due to... legacy reasons... This class likes having a default `AgentSettings` instance to fall back to.
+        # Because we generate this instance with an empty instance of `Settings`, the resulting `AgentSettings` below
+        # represents only settings specified via environment variables + the usual defaults.
+        #
+        # DO NOT USE THIS IN NEW CODE, as it ignores any settings specified by users via `Datadog.configure`.
+        DO_NOT_USE_ENVIRONMENT_AGENT_SETTINGS: untyped
+
+        # Builds a new Transport::HTTP::Client
+        def self?.new: (untyped klass) ?{ () -> untyped } -> untyped
+
+        # Builds a new Transport::HTTP::Client with default settings
+        # Pass a block to override any settings.
+        def self?.root: (?agent_settings: untyped, **untyped options) { (untyped) -> untyped } -> untyped
+
+        def self?.default_headers: () -> untyped
+
+        def self?.default_adapter: () -> untyped
+
+        def self?.default_hostname: (?logger: untyped) -> untyped
+
+        def self?.default_port: (?logger: untyped) -> untyped
+
+        def self?.default_url: (?logger: untyped) -> nil
+      end
+    end
+  end
+end

--- a/sig/datadog/core/transport/http/api.rbs
+++ b/sig/datadog/core/transport/http/api.rbs
@@ -2,9 +2,7 @@ module Datadog
   module Core
     module Transport
       module HTTP
-        # Namespace for API components
         module API
-          # Default API versions
           ROOT: "root"
 
           def self?.defaults: () -> untyped

--- a/sig/datadog/core/transport/http/api.rbs
+++ b/sig/datadog/core/transport/http/api.rbs
@@ -1,0 +1,15 @@
+module Datadog
+  module Core
+    module Transport
+      module HTTP
+        # Namespace for API components
+        module API
+          # Default API versions
+          ROOT: "root"
+
+          def self?.defaults: () -> untyped
+        end
+      end
+    end
+  end
+end

--- a/sig/datadog/core/transport/http/api/instance.rbs
+++ b/sig/datadog/core/transport/http/api/instance.rbs
@@ -3,7 +3,6 @@ module Datadog
     module Transport
       module HTTP
         module API
-          # An API configured with adapter and routes
           class Instance
             attr_reader adapter: untyped
 

--- a/sig/datadog/core/transport/http/api/instance.rbs
+++ b/sig/datadog/core/transport/http/api/instance.rbs
@@ -1,0 +1,24 @@
+module Datadog
+  module Core
+    module Transport
+      module HTTP
+        module API
+          # An API configured with adapter and routes
+          class Instance
+            attr_reader adapter: untyped
+
+            attr_reader headers: untyped
+
+            attr_reader spec: untyped
+
+            def initialize: (untyped spec, untyped adapter, ?::Hash[untyped, untyped] options) -> void
+
+            def encoder: () -> untyped
+
+            def call: (untyped env) -> untyped
+          end
+        end
+      end
+    end
+  end
+end

--- a/sig/datadog/core/transport/http/api/spec.rbs
+++ b/sig/datadog/core/transport/http/api/spec.rbs
@@ -3,8 +3,6 @@ module Datadog
     module Transport
       module HTTP
         module API
-          # Specification for an HTTP API
-          # Defines behaviors without specific configuration details.
           class Spec
             def initialize: () { (untyped) -> untyped } -> void
           end

--- a/sig/datadog/core/transport/http/api/spec.rbs
+++ b/sig/datadog/core/transport/http/api/spec.rbs
@@ -1,0 +1,15 @@
+module Datadog
+  module Core
+    module Transport
+      module HTTP
+        module API
+          # Specification for an HTTP API
+          # Defines behaviors without specific configuration details.
+          class Spec
+            def initialize: () { (untyped) -> untyped } -> void
+          end
+        end
+      end
+    end
+  end
+end

--- a/sig/datadog/core/transport/http/builder.rbs
+++ b/sig/datadog/core/transport/http/builder.rbs
@@ -4,7 +4,7 @@ module Datadog
       module HTTP
         # Builds new instances of Transport::HTTP::Client
         class Builder
-          REGISTRY: untyped
+          REGISTRY: Datadog::Transport::HTTP::Adapters::Registry
 
           attr_reader apis: untyped
 
@@ -16,7 +16,7 @@ module Datadog
 
           attr_reader default_headers: untyped
 
-          def initialize: () { (untyped) -> untyped } -> void
+          def initialize: () ?{ (untyped) -> untyped } -> void
 
           def adapter: (untyped config, *untyped args, **untyped kwargs) -> untyped
 

--- a/sig/datadog/core/transport/http/builder.rbs
+++ b/sig/datadog/core/transport/http/builder.rbs
@@ -1,0 +1,81 @@
+module Datadog
+  module Core
+    module Transport
+      module HTTP
+        # Builds new instances of Transport::HTTP::Client
+        class Builder
+          REGISTRY: untyped
+
+          attr_reader apis: untyped
+
+          attr_reader api_options: untyped
+
+          attr_reader default_adapter: untyped
+
+          attr_reader default_api: untyped
+
+          attr_reader default_headers: untyped
+
+          def initialize: () { (untyped) -> untyped } -> void
+
+          def adapter: (untyped config, *untyped args, **untyped kwargs) -> untyped
+
+          def headers: (?::Hash[untyped, untyped] values) -> untyped
+
+          # Adds a new API to the client
+          # Valid options:
+          #  - :adapter
+          #  - :default
+          #  - :fallback
+          #  - :headers
+          def api: (untyped key, untyped spec, ?::Hash[untyped, untyped] options) -> untyped
+
+          def default_api=: (untyped key) -> untyped
+
+          def to_transport: (untyped klass) -> untyped
+
+          def to_api_instances: () -> untyped
+
+          def api_instance_class: () -> untyped
+
+          # Raised when the API key does not match known APIs.
+          class UnknownApiError < StandardError
+            attr_reader key: untyped
+
+            def initialize: (untyped key) -> void
+
+            def message: () -> ::String
+          end
+
+          # Raised when the identifier cannot be matched to an adapter.
+          class UnknownAdapterError < StandardError
+            attr_reader type: untyped
+
+            def initialize: (untyped `type`) -> void
+
+            def message: () -> ::String
+          end
+
+          # Raised when an adapter cannot be resolved for an API instance.
+          class NoAdapterForApiError < StandardError
+            attr_reader key: untyped
+
+            def initialize: (untyped key) -> void
+
+            def message: () -> ::String
+          end
+
+          # Raised when built without defining APIs.
+          class NoApisError < StandardError
+            def message: () -> "No APIs configured for transport!"
+          end
+
+          # Raised when client built without defining a default API.
+          class NoDefaultApiError < StandardError
+            def message: () -> "No default API configured for transport!"
+          end
+        end
+      end
+    end
+  end
+end

--- a/sig/datadog/core/transport/http/builder.rbs
+++ b/sig/datadog/core/transport/http/builder.rbs
@@ -2,7 +2,6 @@ module Datadog
   module Core
     module Transport
       module HTTP
-        # Builds new instances of Transport::HTTP::Client
         class Builder
           REGISTRY: Datadog::Transport::HTTP::Adapters::Registry
 
@@ -22,12 +21,6 @@ module Datadog
 
           def headers: (?::Hash[untyped, untyped] values) -> untyped
 
-          # Adds a new API to the client
-          # Valid options:
-          #  - :adapter
-          #  - :default
-          #  - :fallback
-          #  - :headers
           def api: (untyped key, untyped spec, ?::Hash[untyped, untyped] options) -> untyped
 
           def default_api=: (untyped key) -> untyped
@@ -38,7 +31,6 @@ module Datadog
 
           def api_instance_class: () -> untyped
 
-          # Raised when the API key does not match known APIs.
           class UnknownApiError < StandardError
             attr_reader key: untyped
 
@@ -47,7 +39,6 @@ module Datadog
             def message: () -> ::String
           end
 
-          # Raised when the identifier cannot be matched to an adapter.
           class UnknownAdapterError < StandardError
             attr_reader type: untyped
 
@@ -56,7 +47,6 @@ module Datadog
             def message: () -> ::String
           end
 
-          # Raised when an adapter cannot be resolved for an API instance.
           class NoAdapterForApiError < StandardError
             attr_reader key: untyped
 
@@ -65,12 +55,10 @@ module Datadog
             def message: () -> ::String
           end
 
-          # Raised when built without defining APIs.
           class NoApisError < StandardError
             def message: () -> "No APIs configured for transport!"
           end
 
-          # Raised when client built without defining a default API.
           class NoDefaultApiError < StandardError
             def message: () -> "No default API configured for transport!"
           end

--- a/sig/datadog/core/transport/http/client.rbs
+++ b/sig/datadog/core/transport/http/client.rbs
@@ -1,0 +1,18 @@
+module Datadog
+  module Core
+    module Transport
+      module HTTP
+        # Routes, encodes, and sends tracer data to the trace agent via HTTP.
+        class Client
+          attr_reader api: untyped
+
+          def initialize: (untyped api) -> void
+
+          def send_request: (untyped request) { (untyped, untyped) -> untyped } -> untyped
+
+          def build_env: (untyped request) -> untyped
+        end
+      end
+    end
+  end
+end

--- a/sig/datadog/core/transport/http/client.rbs
+++ b/sig/datadog/core/transport/http/client.rbs
@@ -2,7 +2,6 @@ module Datadog
   module Core
     module Transport
       module HTTP
-        # Routes, encodes, and sends tracer data to the trace agent via HTTP.
         class Client
           attr_reader api: untyped
 

--- a/sig/datadog/core/transport/http/negotiation.rbs
+++ b/sig/datadog/core/transport/http/negotiation.rbs
@@ -1,0 +1,65 @@
+module Datadog
+  module Core
+    module Transport
+      module HTTP
+        # HTTP transport behavior for agent feature negotiation
+        module Negotiation
+          # Response from HTTP transport for agent feature negotiation
+          class Response
+            include Datadog::Transport::HTTP::Response
+
+            include Core::Transport::Negotiation::Response
+
+            def initialize: (untyped http_response, ?::Hash[untyped, untyped] options) -> void
+          end
+
+          # Extensions for HTTP client
+          module Client
+            def send_info_payload: (untyped request) -> untyped
+          end
+
+          module API
+            # Extensions for HTTP API Spec
+            module Spec
+              attr_reader info: untyped
+
+              def info=: (untyped endpoint) -> untyped
+
+              def send_info: (untyped env) ?{ () -> untyped } -> untyped
+
+              # Raised when traces sent but no traces endpoint is defined
+              class NoNegotiationEndpointDefinedError < StandardError
+                attr_reader spec: untyped
+
+                def initialize: (untyped spec) -> void
+
+                def message: () -> "No info endpoint is defined for API specification!"
+              end
+            end
+
+            # Extensions for HTTP API Instance
+            module Instance
+              def send_info: (untyped env) -> untyped
+
+              # Raised when traces sent to API that does not support traces
+              class NegotiationNotSupportedError < StandardError
+                attr_reader spec: untyped
+
+                def initialize: (untyped spec) -> void
+
+                def message: () -> "Info not supported for this API!"
+              end
+            end
+
+            # Endpoint for negotiation
+            class Endpoint < Datadog::Transport::HTTP::API::Endpoint
+              def initialize: (untyped path) -> void
+
+              def call: (untyped env) ?{ () -> untyped } -> untyped
+            end
+          end
+        end
+      end
+    end
+  end
+end

--- a/sig/datadog/core/transport/http/negotiation.rbs
+++ b/sig/datadog/core/transport/http/negotiation.rbs
@@ -14,7 +14,7 @@ module Datadog
           end
 
           # Extensions for HTTP client
-          module Client
+          module Client : HTTP::Client
             def send_info_payload: (untyped request) -> untyped
           end
 
@@ -38,7 +38,7 @@ module Datadog
             end
 
             # Extensions for HTTP API Instance
-            module Instance
+            module Instance : HTTP::API::Instance
               def send_info: (untyped env) -> untyped
 
               # Raised when traces sent to API that does not support traces
@@ -55,7 +55,7 @@ module Datadog
             class Endpoint < Datadog::Transport::HTTP::API::Endpoint
               def initialize: (untyped path) -> void
 
-              def call: (untyped env) ?{ () -> untyped } -> untyped
+              def call: (untyped env) { (untyped) -> untyped } -> untyped
             end
           end
         end

--- a/sig/datadog/core/transport/http/negotiation.rbs
+++ b/sig/datadog/core/transport/http/negotiation.rbs
@@ -2,9 +2,7 @@ module Datadog
   module Core
     module Transport
       module HTTP
-        # HTTP transport behavior for agent feature negotiation
         module Negotiation
-          # Response from HTTP transport for agent feature negotiation
           class Response
             include Datadog::Transport::HTTP::Response
 
@@ -13,13 +11,11 @@ module Datadog
             def initialize: (untyped http_response, ?::Hash[untyped, untyped] options) -> void
           end
 
-          # Extensions for HTTP client
           module Client : HTTP::Client
             def send_info_payload: (untyped request) -> untyped
           end
 
           module API
-            # Extensions for HTTP API Spec
             module Spec
               attr_reader info: untyped
 
@@ -27,7 +23,6 @@ module Datadog
 
               def send_info: (untyped env) ?{ () -> untyped } -> untyped
 
-              # Raised when traces sent but no traces endpoint is defined
               class NoNegotiationEndpointDefinedError < StandardError
                 attr_reader spec: untyped
 
@@ -37,11 +32,9 @@ module Datadog
               end
             end
 
-            # Extensions for HTTP API Instance
             module Instance : HTTP::API::Instance
               def send_info: (untyped env) -> untyped
 
-              # Raised when traces sent to API that does not support traces
               class NegotiationNotSupportedError < StandardError
                 attr_reader spec: untyped
 
@@ -51,7 +44,6 @@ module Datadog
               end
             end
 
-            # Endpoint for negotiation
             class Endpoint < Datadog::Transport::HTTP::API::Endpoint
               def initialize: (untyped path) -> void
 

--- a/sig/datadog/core/transport/negotiation.rbs
+++ b/sig/datadog/core/transport/negotiation.rbs
@@ -2,11 +2,9 @@ module Datadog
   module Core
     module Transport
       module Negotiation
-        # Negotiation request
         class Request < Datadog::Transport::Request
         end
 
-        # Negotiation response
         module Response
           attr_reader version: untyped
 
@@ -15,7 +13,6 @@ module Datadog
           attr_reader config: untyped
         end
 
-        # Negotiation transport
         class Transport
           attr_reader client: untyped
 

--- a/sig/datadog/core/transport/negotiation.rbs
+++ b/sig/datadog/core/transport/negotiation.rbs
@@ -1,0 +1,37 @@
+module Datadog
+  module Core
+    module Transport
+      module Negotiation
+        # Negotiation request
+        class Request < Datadog::Transport::Request
+        end
+
+        # Negotiation response
+        module Response
+          attr_reader version: untyped
+
+          attr_reader endpoints: untyped
+
+          attr_reader config: untyped
+        end
+
+        # Negotiation transport
+        class Transport
+          attr_reader client: untyped
+
+          attr_reader apis: untyped
+
+          attr_reader default_api: untyped
+
+          attr_reader current_api_id: untyped
+
+          def initialize: (untyped apis, untyped default_api) -> void
+
+          def send_info: () -> untyped
+
+          def current_api: () -> untyped
+        end
+      end
+    end
+  end
+end

--- a/sig/ddtrace/transport/ext.rbs
+++ b/sig/ddtrace/transport/ext.rbs
@@ -1,0 +1,49 @@
+module Datadog
+  module Transport
+    # @public_api
+    module Ext
+      # @public_api
+      module HTTP
+        ADAPTER: :net_http
+
+        DEFAULT_HOST: "127.0.0.1"
+
+        DEFAULT_PORT: 8126
+
+        HEADER_CONTAINER_ID: "Datadog-Container-ID"
+
+        HEADER_DD_API_KEY: "DD-API-KEY"
+
+        # Tells agent that `_dd.top_level` metrics have been set by the tracer.
+        # The agent will not calculate top-level spans but instead trust the tracer tagging.
+        #
+        # This prevents partially flushed traces being mistakenly marked as top-level.
+        #
+        # Setting this header to any non-empty value enables this feature.
+        HEADER_CLIENT_COMPUTED_TOP_LEVEL: "Datadog-Client-Computed-Top-Level"
+
+        HEADER_META_LANG: "Datadog-Meta-Lang"
+
+        HEADER_META_LANG_VERSION: "Datadog-Meta-Lang-Version"
+
+        HEADER_META_LANG_INTERPRETER: "Datadog-Meta-Lang-Interpreter"
+
+        HEADER_META_TRACER_VERSION: "Datadog-Meta-Tracer-Version"
+      end
+
+      # @public_api
+      module Test
+        ADAPTER: :test
+      end
+
+      # @public_api
+      module UnixSocket
+        ADAPTER: :unix
+
+        DEFAULT_PATH: "/var/run/datadog/apm.socket"
+
+        DEFAULT_TIMEOUT_SECONDS: 1
+      end
+    end
+  end
+end

--- a/sig/ddtrace/transport/ext.rbs
+++ b/sig/ddtrace/transport/ext.rbs
@@ -10,9 +10,9 @@ module Datadog
 
         DEFAULT_PORT: 8126
 
-        HEADER_CONTAINER_ID: "Datadog-Container-ID"
+        HEADER_CONTAINER_ID: ::String
 
-        HEADER_DD_API_KEY: "DD-API-KEY"
+        HEADER_DD_API_KEY: ::String
 
         # Tells agent that `_dd.top_level` metrics have been set by the tracer.
         # The agent will not calculate top-level spans but instead trust the tracer tagging.
@@ -20,15 +20,15 @@ module Datadog
         # This prevents partially flushed traces being mistakenly marked as top-level.
         #
         # Setting this header to any non-empty value enables this feature.
-        HEADER_CLIENT_COMPUTED_TOP_LEVEL: "Datadog-Client-Computed-Top-Level"
+        HEADER_CLIENT_COMPUTED_TOP_LEVEL: ::String
 
-        HEADER_META_LANG: "Datadog-Meta-Lang"
+        HEADER_META_LANG: ::String
 
-        HEADER_META_LANG_VERSION: "Datadog-Meta-Lang-Version"
+        HEADER_META_LANG_VERSION: ::String
 
-        HEADER_META_LANG_INTERPRETER: "Datadog-Meta-Lang-Interpreter"
+        HEADER_META_LANG_INTERPRETER: ::String
 
-        HEADER_META_TRACER_VERSION: "Datadog-Meta-Tracer-Version"
+        HEADER_META_TRACER_VERSION: ::String
       end
 
       # @public_api

--- a/sig/ddtrace/transport/ext.rbs
+++ b/sig/ddtrace/transport/ext.rbs
@@ -1,8 +1,6 @@
 module Datadog
   module Transport
-    # @public_api
     module Ext
-      # @public_api
       module HTTP
         ADAPTER: :net_http
 
@@ -14,12 +12,6 @@ module Datadog
 
         HEADER_DD_API_KEY: ::String
 
-        # Tells agent that `_dd.top_level` metrics have been set by the tracer.
-        # The agent will not calculate top-level spans but instead trust the tracer tagging.
-        #
-        # This prevents partially flushed traces being mistakenly marked as top-level.
-        #
-        # Setting this header to any non-empty value enables this feature.
         HEADER_CLIENT_COMPUTED_TOP_LEVEL: ::String
 
         HEADER_META_LANG: ::String
@@ -31,12 +23,10 @@ module Datadog
         HEADER_META_TRACER_VERSION: ::String
       end
 
-      # @public_api
       module Test
         ADAPTER: :test
       end
 
-      # @public_api
       module UnixSocket
         ADAPTER: :unix
 

--- a/sig/ddtrace/transport/http.rbs
+++ b/sig/ddtrace/transport/http.rbs
@@ -1,0 +1,30 @@
+module Datadog
+  module Transport
+    # Namespace for HTTP transport components
+    module HTTP
+      # NOTE: Due to... legacy reasons... This class likes having a default `AgentSettings` instance to fall back to.
+      # Because we generate this instance with an empty instance of `Settings`, the resulting `AgentSettings` below
+      # represents only settings specified via environment variables + the usual defaults.
+      #
+      # DO NOT USE THIS IN NEW CODE, as it ignores any settings specified by users via `Datadog.configure`.
+      DO_NOT_USE_ENVIRONMENT_AGENT_SETTINGS: untyped
+
+      # Builds a new Transport::HTTP::Client
+      def self?.new: () ?{ () -> untyped } -> untyped
+
+      # Builds a new Transport::HTTP::Client with default settings
+      # Pass a block to override any settings.
+      def self?.default: (?agent_settings: untyped, **untyped options) { (untyped) -> untyped } -> untyped
+
+      def self?.default_headers: () -> untyped
+
+      def self?.default_adapter: () -> untyped
+
+      def self?.default_hostname: (?logger: untyped) -> untyped
+
+      def self?.default_port: (?logger: untyped) -> untyped
+
+      def self?.default_url: (?logger: untyped) -> nil
+    end
+  end
+end

--- a/sig/ddtrace/transport/http.rbs
+++ b/sig/ddtrace/transport/http.rbs
@@ -1,19 +1,10 @@
 module Datadog
   module Transport
-    # Namespace for HTTP transport components
     module HTTP
-      # NOTE: Due to... legacy reasons... This class likes having a default `AgentSettings` instance to fall back to.
-      # Because we generate this instance with an empty instance of `Settings`, the resulting `AgentSettings` below
-      # represents only settings specified via environment variables + the usual defaults.
-      #
-      # DO NOT USE THIS IN NEW CODE, as it ignores any settings specified by users via `Datadog.configure`.
       DO_NOT_USE_ENVIRONMENT_AGENT_SETTINGS: untyped
 
-      # Builds a new Transport::HTTP::Client
       def self?.new: () ?{ () -> untyped } -> untyped
 
-      # Builds a new Transport::HTTP::Client with default settings
-      # Pass a block to override any settings.
       def self?.default: (?agent_settings: untyped, **untyped options) { (untyped) -> untyped } -> untyped
 
       def self?.default_headers: () -> untyped

--- a/sig/ddtrace/transport/http/adapters/net.rbs
+++ b/sig/ddtrace/transport/http/adapters/net.rbs
@@ -2,7 +2,6 @@ module Datadog
   module Transport
     module HTTP
       module Adapters
-        # Adapter for Net::HTTP
         class Net
           attr_reader hostname: untyped
 
@@ -12,10 +11,8 @@ module Datadog
 
           attr_reader ssl: untyped
 
-          # in seconds
           DEFAULT_TIMEOUT: 30
 
-          # @deprecated Positional parameters are deprecated. Use named parameters instead.
           def initialize: (?untyped? hostname, ?untyped? port, **untyped options) -> void
 
           def self.build: (untyped agent_settings) -> untyped
@@ -30,7 +27,6 @@ module Datadog
 
           def url: () -> ::String
 
-          # Raised when called with an unknown HTTP method
           class UnknownHTTPMethod < StandardError
             attr_reader verb: untyped
 
@@ -39,7 +35,6 @@ module Datadog
             def message: () -> ::String
           end
 
-          # A wrapped Net::HTTP response that implements the Transport::Response interface
           class Response
             include Datadog::Transport::Response
 

--- a/sig/ddtrace/transport/http/adapters/net.rbs
+++ b/sig/ddtrace/transport/http/adapters/net.rbs
@@ -1,0 +1,70 @@
+module Datadog
+  module Transport
+    module HTTP
+      module Adapters
+        # Adapter for Net::HTTP
+        class Net
+          attr_reader hostname: untyped
+
+          attr_reader port: untyped
+
+          attr_reader timeout: untyped
+
+          attr_reader ssl: untyped
+
+          # in seconds
+          DEFAULT_TIMEOUT: 30
+
+          # @deprecated Positional parameters are deprecated. Use named parameters instead.
+          def initialize: (?untyped? hostname, ?untyped? port, **untyped options) -> void
+
+          def self.build: (untyped agent_settings) -> untyped
+
+          def open: () ?{ () -> untyped } -> untyped
+
+          def call: (untyped env) -> untyped
+
+          def get: (untyped env) -> untyped
+
+          def post: (untyped env) -> untyped
+
+          def url: () -> ::String
+
+          # Raised when called with an unknown HTTP method
+          class UnknownHTTPMethod < StandardError
+            attr_reader verb: untyped
+
+            def initialize: (untyped verb) -> void
+
+            def message: () -> ::String
+          end
+
+          # A wrapped Net::HTTP response that implements the Transport::Response interface
+          class Response
+            include Datadog::Transport::Response
+
+            attr_reader http_response: untyped
+
+            def initialize: (untyped http_response) -> void
+
+            def payload: () -> untyped
+
+            def code: () -> untyped
+
+            def ok?: () -> untyped
+
+            def unsupported?: () -> untyped
+
+            def not_found?: () -> untyped
+
+            def client_error?: () -> untyped
+
+            def server_error?: () -> untyped
+
+            def inspect: () -> ::String
+          end
+        end
+      end
+    end
+  end
+end

--- a/sig/ddtrace/transport/http/adapters/registry.rbs
+++ b/sig/ddtrace/transport/http/adapters/registry.rbs
@@ -8,7 +8,6 @@ module Datadog
           def build: (untyped) -> untyped
         end
 
-        # List of available adapters
         class Registry
           def initialize: () -> void
 

--- a/sig/ddtrace/transport/http/adapters/registry.rbs
+++ b/sig/ddtrace/transport/http/adapters/registry.rbs
@@ -2,11 +2,17 @@ module Datadog
   module Transport
     module HTTP
       module Adapters
+        interface _Class
+          def new: (*untyped, **untyped) -> untyped
+          def nil?: () -> bool
+          def build: (untyped) -> untyped
+        end
+
         # List of available adapters
         class Registry
           def initialize: () -> void
 
-          def get: (untyped name) -> untyped
+          def get: (untyped name) -> _Class
 
           def set: (untyped klass, ?untyped? name) -> (nil | untyped)
         end

--- a/sig/ddtrace/transport/http/adapters/registry.rbs
+++ b/sig/ddtrace/transport/http/adapters/registry.rbs
@@ -1,0 +1,16 @@
+module Datadog
+  module Transport
+    module HTTP
+      module Adapters
+        # List of available adapters
+        class Registry
+          def initialize: () -> void
+
+          def get: (untyped name) -> untyped
+
+          def set: (untyped klass, ?untyped? name) -> (nil | untyped)
+        end
+      end
+    end
+  end
+end

--- a/sig/ddtrace/transport/http/adapters/test.rbs
+++ b/sig/ddtrace/transport/http/adapters/test.rbs
@@ -1,0 +1,53 @@
+module Datadog
+  module Transport
+    module HTTP
+      module Adapters
+        # Adapter for testing
+        class Test
+          attr_reader buffer: untyped
+
+          attr_reader status: untyped
+
+          # @param buffer [Array] an optional array that will capture all spans sent to this adapter, defaults to +nil+
+          # @deprecated Positional parameters are deprecated. Use named parameters instead.
+          def initialize: (?untyped? buffer, **untyped options) -> void
+
+          def call: (untyped env) -> untyped
+
+          def buffer?: () -> untyped
+
+          def add_request: (untyped env) -> (untyped | nil)
+
+          def set_status!: (untyped status) -> untyped
+
+          def url: () -> nil
+
+          # Response for test adapter
+          class Response
+            include Datadog::Transport::Response
+
+            attr_reader body: untyped
+
+            attr_reader code: untyped
+
+            def initialize: (untyped code, ?untyped? body) -> void
+
+            def payload: () -> untyped
+
+            def ok?: () -> untyped
+
+            def unsupported?: () -> untyped
+
+            def not_found?: () -> untyped
+
+            def client_error?: () -> untyped
+
+            def server_error?: () -> untyped
+
+            def inspect: () -> ::String
+          end
+        end
+      end
+    end
+  end
+end

--- a/sig/ddtrace/transport/http/adapters/test.rbs
+++ b/sig/ddtrace/transport/http/adapters/test.rbs
@@ -2,14 +2,11 @@ module Datadog
   module Transport
     module HTTP
       module Adapters
-        # Adapter for testing
         class Test
           attr_reader buffer: untyped
 
           attr_reader status: untyped
 
-          # @param buffer [Array] an optional array that will capture all spans sent to this adapter, defaults to +nil+
-          # @deprecated Positional parameters are deprecated. Use named parameters instead.
           def initialize: (?untyped? buffer, **untyped options) -> void
 
           def call: (untyped env) -> untyped
@@ -22,7 +19,6 @@ module Datadog
 
           def url: () -> nil
 
-          # Response for test adapter
           class Response
             include Datadog::Transport::Response
 

--- a/sig/ddtrace/transport/http/adapters/unix_socket.rbs
+++ b/sig/ddtrace/transport/http/adapters/unix_socket.rbs
@@ -1,0 +1,40 @@
+module Datadog
+  module Transport
+    module HTTP
+      module Adapters
+        # Adapter for Unix sockets
+        class UnixSocket < Adapters::Net
+          attr_reader filepath: untyped
+
+          attr_reader timeout: untyped
+
+          alias uds_path filepath
+
+          # @deprecated Positional parameters are deprecated. Use named parameters instead.
+          def initialize: (?untyped? uds_path, **untyped options) -> void
+
+          def self.build: (untyped agent_settings) -> untyped
+
+          def open: () ?{ () -> untyped } -> untyped
+
+          def url: () -> ::String
+
+          # Re-implements Net:HTTP with underlying Unix socket
+          class HTTP < ::Net::HTTP
+            DEFAULT_TIMEOUT: 1
+
+            attr_reader filepath: untyped
+
+            attr_reader unix_socket: untyped
+
+            alias uds_path filepath
+
+            def initialize: (untyped uds_path, ?::Hash[untyped, untyped] options) -> void
+
+            def connect: () -> untyped
+          end
+        end
+      end
+    end
+  end
+end

--- a/sig/ddtrace/transport/http/adapters/unix_socket.rbs
+++ b/sig/ddtrace/transport/http/adapters/unix_socket.rbs
@@ -2,7 +2,6 @@ module Datadog
   module Transport
     module HTTP
       module Adapters
-        # Adapter for Unix sockets
         class UnixSocket < Adapters::Net
           attr_reader filepath: untyped
 
@@ -10,7 +9,6 @@ module Datadog
 
           alias uds_path filepath
 
-          # @deprecated Positional parameters are deprecated. Use named parameters instead.
           def initialize: (?untyped? uds_path, **untyped options) -> void
 
           def self.build: (untyped agent_settings) -> untyped
@@ -19,7 +17,6 @@ module Datadog
 
           def url: () -> ::String
 
-          # Re-implements Net:HTTP with underlying Unix socket
           class HTTP < ::Net::HTTP
             DEFAULT_TIMEOUT: 1
 

--- a/sig/ddtrace/transport/http/api.rbs
+++ b/sig/ddtrace/transport/http/api.rbs
@@ -1,0 +1,15 @@
+module Datadog
+  module Transport
+    module HTTP
+      # Namespace for API components
+      module API
+        # Default API versions
+        V4: "v0.4"
+
+        V3: "v0.3"
+
+        def self?.defaults: () -> untyped
+      end
+    end
+  end
+end

--- a/sig/ddtrace/transport/http/api.rbs
+++ b/sig/ddtrace/transport/http/api.rbs
@@ -1,9 +1,7 @@
 module Datadog
   module Transport
     module HTTP
-      # Namespace for API components
       module API
-        # Default API versions
         V4: "v0.4"
 
         V3: "v0.3"

--- a/sig/ddtrace/transport/http/api/endpoint.rbs
+++ b/sig/ddtrace/transport/http/api/endpoint.rbs
@@ -1,0 +1,18 @@
+module Datadog
+  module Transport
+    module HTTP
+      module API
+        # Endpoint
+        class Endpoint
+          attr_reader verb: untyped
+
+          attr_reader path: untyped
+
+          def initialize: (untyped verb, untyped path) -> void
+
+          def call: (untyped env) { (untyped) -> untyped } -> untyped
+        end
+      end
+    end
+  end
+end

--- a/sig/ddtrace/transport/http/api/endpoint.rbs
+++ b/sig/ddtrace/transport/http/api/endpoint.rbs
@@ -2,7 +2,6 @@ module Datadog
   module Transport
     module HTTP
       module API
-        # Endpoint
         class Endpoint
           attr_reader verb: untyped
 

--- a/sig/ddtrace/transport/http/api/fallbacks.rbs
+++ b/sig/ddtrace/transport/http/api/fallbacks.rbs
@@ -2,7 +2,6 @@ module Datadog
   module Transport
     module HTTP
       module API
-        # Extension for Map with adds fallback versions.
         module Fallbacks
           def fallbacks: () -> untyped
 

--- a/sig/ddtrace/transport/http/api/fallbacks.rbs
+++ b/sig/ddtrace/transport/http/api/fallbacks.rbs
@@ -1,0 +1,16 @@
+module Datadog
+  module Transport
+    module HTTP
+      module API
+        # Extension for Map with adds fallback versions.
+        module Fallbacks
+          def fallbacks: () -> untyped
+
+          def with_fallbacks: (untyped fallbacks) -> untyped
+
+          def add_fallbacks!: (untyped fallbacks) -> untyped
+        end
+      end
+    end
+  end
+end

--- a/sig/ddtrace/transport/http/api/instance.rbs
+++ b/sig/ddtrace/transport/http/api/instance.rbs
@@ -2,7 +2,6 @@ module Datadog
   module Transport
     module HTTP
       module API
-        # An API configured with adapter and routes
         class Instance
           attr_reader adapter: untyped
 

--- a/sig/ddtrace/transport/http/api/instance.rbs
+++ b/sig/ddtrace/transport/http/api/instance.rbs
@@ -1,0 +1,22 @@
+module Datadog
+  module Transport
+    module HTTP
+      module API
+        # An API configured with adapter and routes
+        class Instance
+          attr_reader adapter: untyped
+
+          attr_reader headers: untyped
+
+          attr_reader spec: untyped
+
+          def initialize: (untyped spec, untyped adapter, ?::Hash[untyped, untyped] options) -> void
+
+          def encoder: () -> untyped
+
+          def call: (untyped env) -> untyped
+        end
+      end
+    end
+  end
+end

--- a/sig/ddtrace/transport/http/api/map.rbs
+++ b/sig/ddtrace/transport/http/api/map.rbs
@@ -3,7 +3,7 @@ module Datadog
     module HTTP
       module API
         # A mapping of API version => API Routes/Instance
-        class Map < Hash
+        class Map < Hash[untyped, untyped]
           include Fallbacks
         end
       end

--- a/sig/ddtrace/transport/http/api/map.rbs
+++ b/sig/ddtrace/transport/http/api/map.rbs
@@ -1,0 +1,12 @@
+module Datadog
+  module Transport
+    module HTTP
+      module API
+        # A mapping of API version => API Routes/Instance
+        class Map < Hash
+          include Fallbacks
+        end
+      end
+    end
+  end
+end

--- a/sig/ddtrace/transport/http/api/map.rbs
+++ b/sig/ddtrace/transport/http/api/map.rbs
@@ -2,7 +2,6 @@ module Datadog
   module Transport
     module HTTP
       module API
-        # A mapping of API version => API Routes/Instance
         class Map < Hash[untyped, untyped]
           include Fallbacks
         end

--- a/sig/ddtrace/transport/http/api/spec.rbs
+++ b/sig/ddtrace/transport/http/api/spec.rbs
@@ -2,8 +2,6 @@ module Datadog
   module Transport
     module HTTP
       module API
-        # Specification for an HTTP API
-        # Defines behaviors without specific configuration details.
         class Spec
           def initialize: () { (untyped) -> untyped } -> void
         end

--- a/sig/ddtrace/transport/http/api/spec.rbs
+++ b/sig/ddtrace/transport/http/api/spec.rbs
@@ -1,0 +1,13 @@
+module Datadog
+  module Transport
+    module HTTP
+      module API
+        # Specification for an HTTP API
+        # Defines behaviors without specific configuration details.
+        class Spec
+          def initialize: () { (untyped) -> untyped } -> void
+        end
+      end
+    end
+  end
+end

--- a/sig/ddtrace/transport/http/builder.rbs
+++ b/sig/ddtrace/transport/http/builder.rbs
@@ -1,0 +1,79 @@
+module Datadog
+  module Transport
+    module HTTP
+      # Builds new instances of Transport::HTTP::Client
+      class Builder
+        REGISTRY: untyped
+
+        attr_reader apis: untyped
+
+        attr_reader api_options: untyped
+
+        attr_reader default_adapter: untyped
+
+        attr_reader default_api: untyped
+
+        attr_reader default_headers: untyped
+
+        def initialize: () { (untyped) -> untyped } -> void
+
+        def adapter: (untyped config, *untyped args, **untyped kwargs) -> untyped
+
+        def headers: (?::Hash[untyped, untyped] values) -> untyped
+
+        # Adds a new API to the client
+        # Valid options:
+        #  - :adapter
+        #  - :default
+        #  - :fallback
+        #  - :headers
+        def api: (untyped key, untyped spec, ?::Hash[untyped, untyped] options) -> untyped
+
+        def default_api=: (untyped key) -> untyped
+
+        def to_transport: () -> untyped
+
+        def to_api_instances: () -> untyped
+
+        def api_instance_class: () -> untyped
+
+        # Raised when the API key does not match known APIs.
+        class UnknownApiError < StandardError
+          attr_reader key: untyped
+
+          def initialize: (untyped key) -> void
+
+          def message: () -> ::String
+        end
+
+        # Raised when the identifier cannot be matched to an adapter.
+        class UnknownAdapterError < StandardError
+          attr_reader type: untyped
+
+          def initialize: (untyped `type`) -> void
+
+          def message: () -> ::String
+        end
+
+        # Raised when an adapter cannot be resolved for an API instance.
+        class NoAdapterForApiError < StandardError
+          attr_reader key: untyped
+
+          def initialize: (untyped key) -> void
+
+          def message: () -> ::String
+        end
+
+        # Raised when built without defining APIs.
+        class NoApisError < StandardError
+          def message: () -> "No APIs configured for transport!"
+        end
+
+        # Raised when client built without defining a default API.
+        class NoDefaultApiError < StandardError
+          def message: () -> "No default API configured for transport!"
+        end
+      end
+    end
+  end
+end

--- a/sig/ddtrace/transport/http/builder.rbs
+++ b/sig/ddtrace/transport/http/builder.rbs
@@ -1,7 +1,6 @@
 module Datadog
   module Transport
     module HTTP
-      # Builds new instances of Transport::HTTP::Client
       class Builder
         REGISTRY: untyped
 
@@ -21,12 +20,6 @@ module Datadog
 
         def headers: (?::Hash[untyped, untyped] values) -> untyped
 
-        # Adds a new API to the client
-        # Valid options:
-        #  - :adapter
-        #  - :default
-        #  - :fallback
-        #  - :headers
         def api: (untyped key, untyped spec, ?::Hash[untyped, untyped] options) -> untyped
 
         def default_api=: (untyped key) -> untyped
@@ -37,7 +30,6 @@ module Datadog
 
         def api_instance_class: () -> untyped
 
-        # Raised when the API key does not match known APIs.
         class UnknownApiError < StandardError
           attr_reader key: untyped
 
@@ -46,7 +38,6 @@ module Datadog
           def message: () -> ::String
         end
 
-        # Raised when the identifier cannot be matched to an adapter.
         class UnknownAdapterError < StandardError
           attr_reader type: untyped
 
@@ -55,7 +46,6 @@ module Datadog
           def message: () -> ::String
         end
 
-        # Raised when an adapter cannot be resolved for an API instance.
         class NoAdapterForApiError < StandardError
           attr_reader key: untyped
 
@@ -64,12 +54,10 @@ module Datadog
           def message: () -> ::String
         end
 
-        # Raised when built without defining APIs.
         class NoApisError < StandardError
           def message: () -> "No APIs configured for transport!"
         end
 
-        # Raised when client built without defining a default API.
         class NoDefaultApiError < StandardError
           def message: () -> "No default API configured for transport!"
         end

--- a/sig/ddtrace/transport/http/client.rbs
+++ b/sig/ddtrace/transport/http/client.rbs
@@ -1,0 +1,18 @@
+module Datadog
+  module Transport
+    module HTTP
+      # Routes, encodes, and sends tracer data to the trace agent via HTTP.
+      class Client
+        include Transport::HTTP::Statistics
+
+        attr_reader api: untyped
+
+        def initialize: (untyped api) -> void
+
+        def send_request: (untyped request) { (untyped, untyped) -> untyped } -> untyped
+
+        def build_env: (untyped request) -> untyped
+      end
+    end
+  end
+end

--- a/sig/ddtrace/transport/http/client.rbs
+++ b/sig/ddtrace/transport/http/client.rbs
@@ -1,7 +1,6 @@
 module Datadog
   module Transport
     module HTTP
-      # Routes, encodes, and sends tracer data to the trace agent via HTTP.
       class Client
         include Transport::HTTP::Statistics
 

--- a/sig/ddtrace/transport/http/env.rbs
+++ b/sig/ddtrace/transport/http/env.rbs
@@ -1,7 +1,6 @@
 module Datadog
   module Transport
     module HTTP
-      # Data structure for an HTTP request
       class Env < Hash[untyped, untyped]
         attr_reader request: untyped
 

--- a/sig/ddtrace/transport/http/env.rbs
+++ b/sig/ddtrace/transport/http/env.rbs
@@ -2,7 +2,7 @@ module Datadog
   module Transport
     module HTTP
       # Data structure for an HTTP request
-      class Env < Hash
+      class Env < Hash[untyped, untyped]
         attr_reader request: untyped
 
         def initialize: (untyped request, ?untyped? options) -> void

--- a/sig/ddtrace/transport/http/env.rbs
+++ b/sig/ddtrace/transport/http/env.rbs
@@ -1,0 +1,32 @@
+module Datadog
+  module Transport
+    module HTTP
+      # Data structure for an HTTP request
+      class Env < Hash
+        attr_reader request: untyped
+
+        def initialize: (untyped request, ?untyped? options) -> void
+
+        def verb: () -> untyped
+
+        def verb=: (untyped value) -> untyped
+
+        def path: () -> untyped
+
+        def path=: (untyped value) -> untyped
+
+        def body: () -> untyped
+
+        def body=: (untyped value) -> untyped
+
+        def headers: () -> untyped
+
+        def headers=: (untyped value) -> untyped
+
+        def form: () -> untyped
+
+        def form=: (untyped value) -> untyped
+      end
+    end
+  end
+end

--- a/sig/ddtrace/transport/http/response.rbs
+++ b/sig/ddtrace/transport/http/response.rbs
@@ -1,0 +1,36 @@
+module Datadog
+  module Transport
+    module HTTP
+      # Wraps an HTTP response from an adapter.
+      #
+      # Used by endpoints to wrap responses from adapters with
+      # fields or behavior that's specific to that endpoint.
+      module Response
+        def initialize: (untyped http_response) -> void
+
+        # (see Datadog::Transport::Response#payload)
+        def payload: () -> untyped
+
+        # (see Datadog::Transport::Response#internal_error?)
+        def internal_error?: () -> untyped
+
+        # (see Datadog::Transport::Response#unsupported?)
+        def unsupported?: () -> untyped
+
+        # (see Datadog::Transport::Response#ok?)
+        def ok?: () -> untyped
+
+        # (see Datadog::Transport::Response#not_found?)
+        def not_found?: () -> untyped
+
+        # (see Datadog::Transport::Response#client_error?)
+        def client_error?: () -> untyped
+
+        # (see Datadog::Transport::Response#server_error?)
+        def server_error?: () -> untyped
+
+        def code: () -> (untyped | nil)
+      end
+    end
+  end
+end

--- a/sig/ddtrace/transport/http/response.rbs
+++ b/sig/ddtrace/transport/http/response.rbs
@@ -1,32 +1,21 @@
 module Datadog
   module Transport
     module HTTP
-      # Wraps an HTTP response from an adapter.
-      #
-      # Used by endpoints to wrap responses from adapters with
-      # fields or behavior that's specific to that endpoint.
       module Response
         def initialize: (untyped http_response) -> void
 
-        # (see Datadog::Transport::Response#payload)
         def payload: () -> untyped
 
-        # (see Datadog::Transport::Response#internal_error?)
         def internal_error?: () -> untyped
 
-        # (see Datadog::Transport::Response#unsupported?)
         def unsupported?: () -> untyped
 
-        # (see Datadog::Transport::Response#ok?)
         def ok?: () -> untyped
 
-        # (see Datadog::Transport::Response#not_found?)
         def not_found?: () -> untyped
 
-        # (see Datadog::Transport::Response#client_error?)
         def client_error?: () -> untyped
 
-        # (see Datadog::Transport::Response#server_error?)
         def server_error?: () -> untyped
 
         def code: () -> (untyped | nil)

--- a/sig/ddtrace/transport/http/statistics.rbs
+++ b/sig/ddtrace/transport/http/statistics.rbs
@@ -1,18 +1,14 @@
 module Datadog
   module Transport
     module HTTP
-      # Tracks statistics for HTTP transports
       module Statistics
         def self.included: (untyped base) -> untyped
 
-        # Instance methods for HTTP statistics
         module InstanceMethods
-          # Decorate metrics for HTTP responses
           def metrics_for_response: (untyped response) -> untyped
 
           private
 
-          # The most common status code on a healthy tracer
           STATUS_CODE_200: "status_code:200"
 
           def metrics_tag_value: (untyped status_code) -> (untyped | ::String)

--- a/sig/ddtrace/transport/http/statistics.rbs
+++ b/sig/ddtrace/transport/http/statistics.rbs
@@ -1,0 +1,23 @@
+module Datadog
+  module Transport
+    module HTTP
+      # Tracks statistics for HTTP transports
+      module Statistics
+        def self.included: (untyped base) -> untyped
+
+        # Instance methods for HTTP statistics
+        module InstanceMethods
+          # Decorate metrics for HTTP responses
+          def metrics_for_response: (untyped response) -> untyped
+
+          private
+
+          # The most common status code on a healthy tracer
+          STATUS_CODE_200: "status_code:200"
+
+          def metrics_tag_value: (untyped status_code) -> (untyped | ::String)
+        end
+      end
+    end
+  end
+end

--- a/sig/ddtrace/transport/http/traces.rbs
+++ b/sig/ddtrace/transport/http/traces.rbs
@@ -1,0 +1,75 @@
+module Datadog
+  module Transport
+    module HTTP
+      # HTTP transport behavior for traces
+      module Traces
+        # Response from HTTP transport for traces
+        class Response
+          include HTTP::Response
+
+          include Datadog::Transport::Traces::Response
+
+          def initialize: (untyped http_response, ?::Hash[untyped, untyped] options) -> void
+        end
+
+        # Extensions for HTTP client
+        module Client
+          def send_traces_payload: (untyped request) -> untyped
+        end
+
+        module API
+          # Extensions for HTTP API Spec
+          module Spec
+            attr_reader traces: untyped
+
+            def traces=: (untyped endpoint) -> untyped
+
+            def send_traces: (untyped env) ?{ () -> untyped } -> untyped
+
+            def encoder: () -> untyped
+
+            # Raised when traces sent but no traces endpoint is defined
+            class NoTraceEndpointDefinedError < StandardError
+              attr_reader spec: untyped
+
+              def initialize: (untyped spec) -> void
+
+              def message: () -> "No trace endpoint is defined for API specification!"
+            end
+          end
+
+          # Extensions for HTTP API Instance
+          module Instance
+            def send_traces: (untyped env) -> untyped
+
+            # Raised when traces sent to API that does not support traces
+            class TracesNotSupportedError < StandardError
+              attr_reader spec: untyped
+
+              def initialize: (untyped spec) -> void
+
+              def message: () -> "Traces not supported for this API!"
+            end
+          end
+
+          # Endpoint for submitting trace data
+          class Endpoint < HTTP::API::Endpoint
+            HEADER_CONTENT_TYPE: "Content-Type"
+
+            HEADER_TRACE_COUNT: "X-Datadog-Trace-Count"
+
+            SERVICE_RATE_KEY: "rate_by_service"
+
+            attr_reader encoder: untyped
+
+            def initialize: (untyped path, untyped encoder, ?::Hash[untyped, untyped] options) -> void
+
+            def service_rates?: () -> untyped
+
+            def call: (untyped env) ?{ () -> untyped } -> untyped
+          end
+        end
+      end
+    end
+  end
+end

--- a/sig/ddtrace/transport/http/traces.rbs
+++ b/sig/ddtrace/transport/http/traces.rbs
@@ -1,9 +1,7 @@
 module Datadog
   module Transport
     module HTTP
-      # HTTP transport behavior for traces
       module Traces
-        # Response from HTTP transport for traces
         class Response
           include HTTP::Response
 
@@ -12,13 +10,11 @@ module Datadog
           def initialize: (untyped http_response, ?::Hash[untyped, untyped] options) -> void
         end
 
-        # Extensions for HTTP client
         module Client
           def send_traces_payload: (untyped request) -> untyped
         end
 
         module API
-          # Extensions for HTTP API Spec
           module Spec
             attr_reader traces: untyped
 
@@ -28,7 +24,6 @@ module Datadog
 
             def encoder: () -> untyped
 
-            # Raised when traces sent but no traces endpoint is defined
             class NoTraceEndpointDefinedError < StandardError
               attr_reader spec: untyped
 
@@ -38,11 +33,9 @@ module Datadog
             end
           end
 
-          # Extensions for HTTP API Instance
           module Instance
             def send_traces: (untyped env) -> untyped
 
-            # Raised when traces sent to API that does not support traces
             class TracesNotSupportedError < StandardError
               attr_reader spec: untyped
 
@@ -52,7 +45,6 @@ module Datadog
             end
           end
 
-          # Endpoint for submitting trace data
           class Endpoint < HTTP::API::Endpoint
             HEADER_CONTENT_TYPE: "Content-Type"
 

--- a/sig/ddtrace/transport/io.rbs
+++ b/sig/ddtrace/transport/io.rbs
@@ -1,12 +1,8 @@
 module Datadog
   module Transport
-    # Namespace for IO transport components
     module IO
-      # Builds a new Transport::IO::Client
       def self?.new: (untyped `out`, untyped encoder) -> untyped
 
-      # Builds a new Transport::IO::Client with default settings
-      # Pass options to override any settings.
       def self?.default: (?::Hash[untyped, untyped] options) -> untyped
     end
   end

--- a/sig/ddtrace/transport/io.rbs
+++ b/sig/ddtrace/transport/io.rbs
@@ -1,0 +1,13 @@
+module Datadog
+  module Transport
+    # Namespace for IO transport components
+    module IO
+      # Builds a new Transport::IO::Client
+      def self?.new: (untyped `out`, untyped encoder) -> untyped
+
+      # Builds a new Transport::IO::Client with default settings
+      # Pass options to override any settings.
+      def self?.default: (?::Hash[untyped, untyped] options) -> untyped
+    end
+  end
+end

--- a/sig/ddtrace/transport/io/client.rbs
+++ b/sig/ddtrace/transport/io/client.rbs
@@ -1,7 +1,6 @@
 module Datadog
   module Transport
     module IO
-      # Encodes and writes tracer data to IO
       class Client
         include Transport::Statistics
 

--- a/sig/ddtrace/transport/io/client.rbs
+++ b/sig/ddtrace/transport/io/client.rbs
@@ -1,0 +1,28 @@
+module Datadog
+  module Transport
+    module IO
+      # Encodes and writes tracer data to IO
+      class Client
+        include Transport::Statistics
+
+        attr_reader encoder: untyped
+
+        attr_reader out: untyped
+
+        def initialize: (untyped `out`, untyped encoder, ?::Hash[untyped, untyped] options) -> void
+
+        def send_request: (untyped request) { (untyped, untyped) -> untyped } -> untyped
+
+        def encode_data: (untyped encoder, untyped request) -> untyped
+
+        def write_data: (untyped `out`, untyped data) -> untyped
+
+        def build_response: (untyped _request, untyped _data, untyped result) -> untyped
+
+        private
+
+        def send_default_request: (untyped `out`, untyped request) -> untyped
+      end
+    end
+  end
+end

--- a/sig/ddtrace/transport/io/response.rbs
+++ b/sig/ddtrace/transport/io/response.rbs
@@ -1,0 +1,16 @@
+module Datadog
+  module Transport
+    module IO
+      # Response from HTTP transport for traces
+      class Response
+        include Transport::Response
+
+        attr_reader result: untyped
+
+        def initialize: (untyped result) -> void
+
+        def ok?: () -> true
+      end
+    end
+  end
+end

--- a/sig/ddtrace/transport/io/response.rbs
+++ b/sig/ddtrace/transport/io/response.rbs
@@ -1,7 +1,6 @@
 module Datadog
   module Transport
     module IO
-      # Response from HTTP transport for traces
       class Response
         include Transport::Response
 

--- a/sig/ddtrace/transport/io/traces.rbs
+++ b/sig/ddtrace/transport/io/traces.rbs
@@ -1,0 +1,44 @@
+module Datadog
+  module Transport
+    module IO
+      # IO transport behavior for traces
+      module Traces
+        # Response from HTTP transport for traces
+        class Response < IO::Response
+          include Transport::Traces::Response
+
+          def initialize: (untyped result, ?::Integer trace_count) -> void
+        end
+
+        # Extensions for HTTP client
+        module Client
+          def send_traces: (untyped traces) { (untyped, untyped) -> untyped } -> ::Array[untyped]
+        end
+
+        # Encoder for IO-specific trace encoding
+        # API compliant when used with {JSONEncoder}.
+        module Encoder
+          ENCODED_IDS: ::Array[:trace_id | :span_id | :parent_id]
+
+          # Encodes a list of traces
+          def encode_traces: (untyped encoder, untyped traces) -> untyped
+
+          private
+
+          def encode_trace: (untyped trace) -> untyped
+        end
+
+        # Transfer object for list of traces
+        class Parcel
+          include Transport::Parcel
+
+          include Encoder
+
+          def count: () -> untyped
+
+          def encode_with: (untyped encoder) -> untyped
+        end
+      end
+    end
+  end
+end

--- a/sig/ddtrace/transport/io/traces.rbs
+++ b/sig/ddtrace/transport/io/traces.rbs
@@ -1,26 +1,20 @@
 module Datadog
   module Transport
     module IO
-      # IO transport behavior for traces
       module Traces
-        # Response from HTTP transport for traces
         class Response < IO::Response
           include Transport::Traces::Response
 
           def initialize: (untyped result, ?::Integer trace_count) -> void
         end
 
-        # Extensions for HTTP client
         module Client
           def send_traces: (untyped traces) { (untyped, untyped) -> untyped } -> ::Array[untyped]
         end
 
-        # Encoder for IO-specific trace encoding
-        # API compliant when used with {JSONEncoder}.
         module Encoder
           ENCODED_IDS: ::Array[:trace_id | :span_id | :parent_id]
 
-          # Encodes a list of traces
           def encode_traces: (untyped encoder, untyped traces) -> untyped
 
           private
@@ -28,7 +22,6 @@ module Datadog
           def encode_trace: (untyped trace) -> untyped
         end
 
-        # Transfer object for list of traces
         class Parcel
           include Transport::Parcel
 

--- a/sig/ddtrace/transport/parcel.rbs
+++ b/sig/ddtrace/transport/parcel.rbs
@@ -1,0 +1,13 @@
+module Datadog
+  module Transport
+    # Data transfer object for generic data
+    # @abstract
+    module Parcel
+      attr_reader data: untyped
+
+      def initialize: (untyped data) -> void
+
+      def encode_with: (untyped encoder) -> untyped
+    end
+  end
+end

--- a/sig/ddtrace/transport/parcel.rbs
+++ b/sig/ddtrace/transport/parcel.rbs
@@ -1,7 +1,5 @@
 module Datadog
   module Transport
-    # Data transfer object for generic data
-    # @abstract
     module Parcel
       attr_reader data: untyped
 

--- a/sig/ddtrace/transport/request.rbs
+++ b/sig/ddtrace/transport/request.rbs
@@ -1,0 +1,10 @@
+module Datadog
+  module Transport
+    # Defines request for transport operations
+    class Request
+      attr_reader parcel: untyped
+
+      def initialize: (?untyped? parcel) -> void
+    end
+  end
+end

--- a/sig/ddtrace/transport/request.rbs
+++ b/sig/ddtrace/transport/request.rbs
@@ -1,6 +1,5 @@
 module Datadog
   module Transport
-    # Defines request for transport operations
     class Request
       attr_reader parcel: untyped
 

--- a/sig/ddtrace/transport/response.rbs
+++ b/sig/ddtrace/transport/response.rbs
@@ -1,6 +1,5 @@
 module Datadog
   module Transport
-    # Defines abstract response for transport operations
     module Response
       def payload: () -> nil
 
@@ -19,7 +18,6 @@ module Datadog
       def inspect: () -> ::String
     end
 
-    # A generic error response for internal errors
     class InternalErrorResponse
       include Response
 

--- a/sig/ddtrace/transport/response.rbs
+++ b/sig/ddtrace/transport/response.rbs
@@ -1,0 +1,35 @@
+module Datadog
+  module Transport
+    # Defines abstract response for transport operations
+    module Response
+      def payload: () -> nil
+
+      def ok?: () -> nil
+
+      def unsupported?: () -> nil
+
+      def not_found?: () -> nil
+
+      def client_error?: () -> nil
+
+      def server_error?: () -> nil
+
+      def internal_error?: () -> nil
+
+      def inspect: () -> ::String
+    end
+
+    # A generic error response for internal errors
+    class InternalErrorResponse
+      include Response
+
+      attr_reader error: untyped
+
+      def initialize: (untyped error) -> void
+
+      def internal_error?: () -> true
+
+      def inspect: () -> ::String
+    end
+  end
+end

--- a/sig/ddtrace/transport/serializable_trace.rbs
+++ b/sig/ddtrace/transport/serializable_trace.rbs
@@ -1,0 +1,56 @@
+module Datadog
+  module Transport
+    # Adds serialization functions to a {Datadog::TraceSegment}
+    class SerializableTrace
+      attr_reader trace: untyped
+
+      def initialize: (untyped trace) -> void
+
+      # MessagePack serializer interface. Making this object
+      # respond to `#to_msgpack` allows it to be automatically
+      # serialized by MessagePack.
+      #
+      # This is more efficient than doing +MessagePack.pack(span.to_hash)+
+      # as we don't have to create an intermediate Hash.
+      #
+      # @param packer [MessagePack::Packer] serialization buffer, can be +nil+ with JRuby
+      def to_msgpack: (?untyped? packer) -> untyped
+
+      # JSON serializer interface.
+      # Used by older version of the transport.
+      def to_json: (*untyped args) -> untyped
+    end
+
+    # Adds serialization functions to a {Datadog::Span}
+    class SerializableSpan
+      attr_reader span: untyped
+
+      def initialize: (untyped span) -> void
+
+      # MessagePack serializer interface. Making this object
+      # respond to `#to_msgpack` allows it to be automatically
+      # serialized by MessagePack.
+      #
+      # This is more efficient than doing +MessagePack.pack(span.to_hash)+
+      # as we don't have to create an intermediate Hash.
+      #
+      # @param packer [MessagePack::Packer] serialization buffer, can be +nil+ with JRuby
+      # rubocop:disable Metrics/AbcSize
+      def to_msgpack: (?untyped? packer) -> untyped
+
+      # JSON serializer interface.
+      # Used by older version of the transport.
+      def to_json: (*untyped args) -> untyped
+
+      # Used for serialization
+      # @return [Integer] in nanoseconds since Epoch
+      def time_nano: (untyped time) -> untyped
+
+      def to_hash: () -> untyped
+
+      # Used for serialization
+      # @return [Integer] in nanoseconds since Epoch
+      def duration_nano: (untyped duration) -> untyped
+    end
+  end
+end

--- a/sig/ddtrace/transport/serializable_trace.rbs
+++ b/sig/ddtrace/transport/serializable_trace.rbs
@@ -1,55 +1,28 @@
 module Datadog
   module Transport
-    # Adds serialization functions to a {Datadog::TraceSegment}
     class SerializableTrace
       attr_reader trace: untyped
 
       def initialize: (untyped trace) -> void
 
-      # MessagePack serializer interface. Making this object
-      # respond to `#to_msgpack` allows it to be automatically
-      # serialized by MessagePack.
-      #
-      # This is more efficient than doing +MessagePack.pack(span.to_hash)+
-      # as we don't have to create an intermediate Hash.
-      #
-      # @param packer [MessagePack::Packer] serialization buffer, can be +nil+ with JRuby
       def to_msgpack: (?untyped? packer) -> untyped
 
-      # JSON serializer interface.
-      # Used by older version of the transport.
       def to_json: (*untyped args) -> untyped
     end
 
-    # Adds serialization functions to a {Datadog::Span}
     class SerializableSpan
       attr_reader span: untyped
 
       def initialize: (untyped span) -> void
 
-      # MessagePack serializer interface. Making this object
-      # respond to `#to_msgpack` allows it to be automatically
-      # serialized by MessagePack.
-      #
-      # This is more efficient than doing +MessagePack.pack(span.to_hash)+
-      # as we don't have to create an intermediate Hash.
-      #
-      # @param packer [MessagePack::Packer] serialization buffer, can be +nil+ with JRuby
-      # rubocop:disable Metrics/AbcSize
       def to_msgpack: (?untyped? packer) -> untyped
 
-      # JSON serializer interface.
-      # Used by older version of the transport.
       def to_json: (*untyped args) -> untyped
 
-      # Used for serialization
-      # @return [Integer] in nanoseconds since Epoch
       def time_nano: (untyped time) -> untyped
 
       def to_hash: () -> untyped
 
-      # Used for serialization
-      # @return [Integer] in nanoseconds since Epoch
       def duration_nano: (untyped duration) -> untyped
     end
   end

--- a/sig/ddtrace/transport/statistics.rbs
+++ b/sig/ddtrace/transport/statistics.rbs
@@ -1,0 +1,33 @@
+module Datadog
+  module Transport
+    # Tracks statistics for transports
+    module Statistics
+      def stats: () -> untyped
+
+      def update_stats_from_response!: (untyped response) -> untyped
+
+      def metrics_for_response: (untyped response) -> untyped
+
+      def update_stats_from_exception!: (untyped exception) -> untyped
+
+      def metrics_for_exception: (untyped _exception) -> { api_errors: untyped }
+
+      # Stat counts
+      class Counts
+        attr_accessor success: untyped
+
+        attr_accessor client_error: untyped
+
+        attr_accessor server_error: untyped
+
+        attr_accessor internal_error: untyped
+
+        attr_accessor consecutive_errors: untyped
+
+        def initialize: () -> void
+
+        def reset!: () -> untyped
+      end
+    end
+  end
+end

--- a/sig/ddtrace/transport/statistics.rbs
+++ b/sig/ddtrace/transport/statistics.rbs
@@ -1,6 +1,5 @@
 module Datadog
   module Transport
-    # Tracks statistics for transports
     module Statistics
       def stats: () -> untyped
 
@@ -12,7 +11,6 @@ module Datadog
 
       def metrics_for_exception: (untyped _exception) -> { api_errors: untyped }
 
-      # Stat counts
       class Counts
         attr_accessor success: untyped
 

--- a/sig/ddtrace/transport/trace_formatter.rbs
+++ b/sig/ddtrace/transport/trace_formatter.rbs
@@ -1,0 +1,51 @@
+module Datadog
+  module Transport
+    # Prepares traces for transport
+    class TraceFormatter
+      attr_reader root_span: untyped
+
+      attr_reader trace: untyped
+
+      def self.format!: (untyped trace) -> untyped
+
+      def initialize: (untyped trace) -> void
+
+      # Modifies a trace so suitable for transport
+      def format!: () -> (nil | untyped)
+
+      def set_resource!: () -> (nil | untyped)
+
+      def set_trace_tags!: () -> (nil | untyped)
+
+      def tag_agent_sample_rate!: () -> (nil | untyped)
+
+      def tag_hostname!: () -> (nil | untyped)
+
+      def tag_lang!: () -> (nil | untyped)
+
+      def tag_origin!: () -> (nil | untyped)
+
+      def tag_process_id!: () -> (nil | untyped)
+
+      def tag_rate_limiter_rate!: () -> (nil | untyped)
+
+      def tag_rule_sample_rate!: () -> (nil | untyped)
+
+      def tag_runtime_id!: () -> (nil | untyped)
+
+      def tag_sample_rate!: () -> (nil | untyped)
+
+      def tag_sampling_decision_maker!: () -> (nil | untyped)
+
+      def tag_sampling_priority!: () -> (nil | untyped)
+
+      def tag_high_order_trace_id!: () -> (nil | untyped)
+
+      private
+
+      def partial?: () -> untyped
+
+      def find_root_span: (untyped trace) -> untyped
+    end
+  end
+end

--- a/sig/ddtrace/transport/trace_formatter.rbs
+++ b/sig/ddtrace/transport/trace_formatter.rbs
@@ -1,6 +1,5 @@
 module Datadog
   module Transport
-    # Prepares traces for transport
     class TraceFormatter
       attr_reader root_span: untyped
 
@@ -10,7 +9,6 @@ module Datadog
 
       def initialize: (untyped trace) -> void
 
-      # Modifies a trace so suitable for transport
       def format!: () -> (nil | untyped)
 
       def set_resource!: () -> (nil | untyped)

--- a/sig/ddtrace/transport/traces.rbs
+++ b/sig/ddtrace/transport/traces.rbs
@@ -1,7 +1,6 @@
 module Datadog
   module Transport
     module Traces
-      # Data transfer object for encoded traces
       class EncodedParcel
         include Datadog::Transport::Parcel
 
@@ -12,42 +11,24 @@ module Datadog
         def count: () -> untyped
       end
 
-      # Traces request
       class Request < Datadog::Transport::Request
       end
 
-      # Traces response
       module Response
         attr_reader service_rates: untyped
 
         attr_reader trace_count: untyped
       end
 
-      # Traces chunker
       class Chunker
-        # Trace agent limit payload size of 10 MiB (since agent v5.11.0):
-        # https://github.com/DataDog/datadog-agent/blob/6.14.1/pkg/trace/api/api.go#L46
-        #
-        # We set the value to a conservative 5 MiB, in case network speed is slow.
         DEFAULT_MAX_PAYLOAD_SIZE: untyped
 
         attr_reader encoder: untyped
 
         attr_reader max_size: untyped
 
-        #
-        # Single traces larger than +max_size+ will be discarded.
-        #
-        # @param encoder [Datadog::Core::Encoding::Encoder]
-        # @param max_size [String] maximum acceptable payload size
         def initialize: (untyped encoder, ?max_size: untyped) -> void
 
-        # Encodes a list of traces in chunks.
-        # Before serializing, all traces are normalized. Trace nesting is not changed.
-        #
-        # @param traces [Enumerable<Trace>] list of traces
-        # @return [Enumerable[Array[Bytes,Integer]]] list of encoded chunks: each containing a byte array and
-        #   number of traces
         def encode_in_chunks: (untyped traces) -> untyped
 
         private
@@ -55,16 +36,10 @@ module Datadog
         def encode_one: (untyped trace) -> (nil | untyped)
       end
 
-      # Encodes traces using {Datadog::Core::Encoding::Encoder} instances.
       module Encoder
         def self?.encode_trace: (untyped encoder, untyped trace) -> untyped
       end
 
-      # Sends traces based on transport API configuration.
-      #
-      # This class initializes the HTTP client, breaks down large
-      # batches of traces into smaller chunks and handles
-      # API version downgrade handshake.
       class Transport
         attr_reader client: untyped
 
@@ -90,7 +65,6 @@ module Datadog
 
         def change_api!: (untyped api_id) -> untyped
 
-        # Raised when configured with an unknown API version
         class UnknownApiVersionError < StandardError
           attr_reader version: untyped
 
@@ -99,7 +73,6 @@ module Datadog
           def message: () -> ::String
         end
 
-        # Raised when configured with an unknown API version
         class NoDowngradeAvailableError < StandardError
           attr_reader version: untyped
 

--- a/sig/ddtrace/transport/traces.rbs
+++ b/sig/ddtrace/transport/traces.rbs
@@ -1,0 +1,113 @@
+module Datadog
+  module Transport
+    module Traces
+      # Data transfer object for encoded traces
+      class EncodedParcel
+        include Datadog::Transport::Parcel
+
+        attr_reader trace_count: untyped
+
+        def initialize: (untyped data, untyped trace_count) -> void
+
+        def count: () -> untyped
+      end
+
+      # Traces request
+      class Request < Datadog::Transport::Request
+      end
+
+      # Traces response
+      module Response
+        attr_reader service_rates: untyped
+
+        attr_reader trace_count: untyped
+      end
+
+      # Traces chunker
+      class Chunker
+        # Trace agent limit payload size of 10 MiB (since agent v5.11.0):
+        # https://github.com/DataDog/datadog-agent/blob/6.14.1/pkg/trace/api/api.go#L46
+        #
+        # We set the value to a conservative 5 MiB, in case network speed is slow.
+        DEFAULT_MAX_PAYLOAD_SIZE: untyped
+
+        attr_reader encoder: untyped
+
+        attr_reader max_size: untyped
+
+        #
+        # Single traces larger than +max_size+ will be discarded.
+        #
+        # @param encoder [Datadog::Core::Encoding::Encoder]
+        # @param max_size [String] maximum acceptable payload size
+        def initialize: (untyped encoder, ?max_size: untyped) -> void
+
+        # Encodes a list of traces in chunks.
+        # Before serializing, all traces are normalized. Trace nesting is not changed.
+        #
+        # @param traces [Enumerable<Trace>] list of traces
+        # @return [Enumerable[Array[Bytes,Integer]]] list of encoded chunks: each containing a byte array and
+        #   number of traces
+        def encode_in_chunks: (untyped traces) -> untyped
+
+        private
+
+        def encode_one: (untyped trace) -> (nil | untyped)
+      end
+
+      # Encodes traces using {Datadog::Core::Encoding::Encoder} instances.
+      module Encoder
+        def self?.encode_trace: (untyped encoder, untyped trace) -> untyped
+      end
+
+      # Sends traces based on transport API configuration.
+      #
+      # This class initializes the HTTP client, breaks down large
+      # batches of traces into smaller chunks and handles
+      # API version downgrade handshake.
+      class Transport
+        attr_reader client: untyped
+
+        attr_reader apis: untyped
+
+        attr_reader default_api: untyped
+
+        attr_reader current_api_id: untyped
+
+        def initialize: (untyped apis, untyped default_api) -> void
+
+        def send_traces: (untyped traces) -> untyped
+
+        def stats: () -> untyped
+
+        def current_api: () -> untyped
+
+        private
+
+        def downgrade?: (untyped response) -> (false | untyped)
+
+        def downgrade!: () -> untyped
+
+        def change_api!: (untyped api_id) -> untyped
+
+        # Raised when configured with an unknown API version
+        class UnknownApiVersionError < StandardError
+          attr_reader version: untyped
+
+          def initialize: (untyped version) -> void
+
+          def message: () -> ::String
+        end
+
+        # Raised when configured with an unknown API version
+        class NoDowngradeAvailableError < StandardError
+          attr_reader version: untyped
+
+          def initialize: (untyped version) -> void
+
+          def message: () -> ::String
+        end
+      end
+    end
+  end
+end

--- a/spec/datadog/core/transport/http_spec.rb
+++ b/spec/datadog/core/transport/http_spec.rb
@@ -1,0 +1,67 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+require 'datadog/core/transport/http'
+require 'datadog/core/transport/http/negotiation'
+require 'datadog/core/transport/negotiation'
+
+RSpec.describe Datadog::Core::Transport::HTTP do
+  describe '.root' do
+    subject(:transport) { described_class.root(&client_options) }
+
+    let(:client_options) { proc { |_client| } }
+
+    it { is_expected.to be_a(Datadog::Core::Transport::Negotiation::Transport) }
+
+    describe '#send_info' do
+      subject(:response) { transport.send_info }
+
+      let(:request_verb) { :get }
+
+      let(:response_code) { 200 }
+      let(:response_body) do
+        JSON.dump(
+          {
+            version: '42',
+            endpoints: [
+              '/info',
+              '/v0/path',
+            ],
+            config: {
+              max_request_bytes: '1234',
+            }
+          }
+        )
+      end
+
+      before do
+        request_class = case request_verb
+                        when :get then ::Net::HTTP::Get
+                        else raise "bad verb: #{request_verb.inspect}"
+                        end
+        http_request = instance_double(request_class)
+        allow(request_class).to receive(:new).and_return(http_request)
+
+        http_connection = instance_double(::Net::HTTP)
+        allow(::Net::HTTP).to receive(:new).and_return(http_connection)
+
+        allow(http_connection).to receive(:open_timeout=)
+        allow(http_connection).to receive(:read_timeout=)
+        allow(http_connection).to receive(:use_ssl=)
+
+        allow(http_connection).to receive(:start).and_yield(http_connection)
+
+        http_response = instance_double(::Net::HTTPResponse, body: response_body, code: response_code)
+        allow(http_connection).to receive(:request).with(http_request).and_return(http_response)
+      end
+
+      it { is_expected.to be_a(Datadog::Core::Transport::HTTP::Negotiation::Response) }
+
+      it { is_expected.to be_ok }
+      it { is_expected.to have_attributes(:version => '42') }
+      it { is_expected.to have_attributes(:endpoints => ['/info', '/v0/path']) }
+      it { is_expected.to have_attributes(:config => { max_request_bytes: '1234' }) }
+    end
+  end
+end

--- a/spec/datadog/core/transport/integration_spec.rb
+++ b/spec/datadog/core/transport/integration_spec.rb
@@ -1,0 +1,30 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+require 'datadog/core/transport/http'
+require 'datadog/core/transport/http/negotiation'
+require 'datadog/core/transport/negotiation'
+
+RSpec.describe Datadog::Core::Transport::HTTP do
+  before { skip unless ENV['TEST_DATADOG_INTEGRATION'] }
+
+  describe '.root' do
+    subject(:transport) { described_class.root(&client_options) }
+
+    let(:client_options) { proc { |_client| } }
+
+    it { is_expected.to be_a(Datadog::Core::Transport::Negotiation::Transport) }
+
+    describe '#send_info' do
+      subject(:response) { transport.send_info }
+
+      it { is_expected.to be_a(Datadog::Core::Transport::HTTP::Negotiation::Response) }
+
+      it { is_expected.to be_ok }
+      it { is_expected.to_not have_attributes(:version => be_nil) }
+      it { is_expected.to_not have_attributes(:endpoints => be_nil) }
+      it { is_expected.to_not have_attributes(:config => be_nil) }
+    end
+  end
+end


### PR DESCRIPTION
<!--
Check out the
https://github.com/DataDog/dd-trace-rb/blob/master/docs/DevelopmentGuide.md
for guidance on how to set up your development environment,
run the test suite, write new integrations, and more.
-->

**What does this PR do?**

Implement the `/info` endpoint without impacting the current trace endpoint.

**Motivation**

The goal of this commit is twofold:

- prepare for endpoint and configuration negotiation with the agent
- lay ground for reaching to other endpoints than the trace API

To that end, it:

- duplicates and alters a few files, noting the issues encountered towards full reusability of the current transport implementation.
- implements requesting to the `GET /info` endpoint
- does not implement processing the response nor any form of actual negotiation using that response

**Additional Notes**

This may be easier to review by comparing between `lib/ddtrace` and `lib/datadog/core`, e.g:

```
diff --color -w -u lib/{ddtrace,datadog/core}/transport/http/builder.rb
```

The short-term goal is to enable implementing additional endpoints, such as `/v0.7/config` for remote configuration.

Many comments have been dropped in the code itself to act as persistent analysis towards a possible later longer-term refactoring.

**How to test the change?**

The code is isolated and uncalled, so CI should stay green.

Manual testing:

- Step 1: start the agent
```
docker run --rm -it -e DD_APM_ENABLED=true -e DD_ENV=${YOUR_ENV} -e DD_HOSTNAME=${YOUR_HOSTNAME} -e DD_BIND_HOST=0.0.0.0 -e DD_APM_NON_LOCAL_TRAFFIC=true -e DD_API_KEY=${YOUR_API_KEY}-e DD_REMOTE_CONFIGURATION_ENABLED=true -p 8126:8126 datadog/agent:7.42.0
```
- Step 2: hit it with the following code

```
require 'ddtrace'

Datadog.configure do |c|
    c.agent.host = "#{YOUR_AGENT_HOST}"
    # c.diagnostics.debug = true
end

transport_options = {
  agent_settings: Datadog::Core::Configuration::AgentSettingsResolver.call(Datadog.configuration)
}

require 'datadog/core/transport/http'

transport_root = Datadog::Core::Transport::HTTP.root(**transport_options.dup)

puts transport_root.send_info.inspect
```
