### PR TITLE
Do not try accessing the appsec settings if the appsec module is not loaded

### DIFF
--- a/lib/datadog/appsec/component.rb
+++ b/lib/datadog/appsec/component.rb
@@ -8,7 +8,7 @@ module Datadog
     class Component
       class << self
         def build_appsec_component(settings)
-          return unless settings.enabled
+          return unless defined?(Datadog::AppSec::Configuration) && settings.appsec.enabled
 
           processor = create_processor
           new(processor: processor)

--- a/lib/datadog/appsec/component.rb
+++ b/lib/datadog/appsec/component.rb
@@ -8,7 +8,7 @@ module Datadog
     class Component
       class << self
         def build_appsec_component(settings)
-          return unless defined?(Datadog::AppSec::Configuration) && settings.appsec.enabled
+          return unless settings.respond_to?(:appsec) && settings.appsec.enabled
 
           processor = create_processor
           new(processor: processor)

--- a/lib/datadog/core/configuration/components.rb
+++ b/lib/datadog/core/configuration/components.rb
@@ -88,7 +88,7 @@ module Datadog
           @telemetry = self.class.build_telemetry(settings)
 
           # AppSec
-          @appsec = Datadog::AppSec::Component.build_appsec_component(settings.appsec)
+          @appsec = Datadog::AppSec::Component.build_appsec_component(settings)
         end
 
         # Starts up components

--- a/spec/datadog/appsec/component_spec.rb
+++ b/spec/datadog/appsec/component_spec.rb
@@ -4,12 +4,15 @@ require 'datadog/appsec/component'
 RSpec.describe Datadog::AppSec::Component do
   describe '.build_appsec_component' do
     let(:settings) do
-      Datadog::AppSec::Configuration::Settings.new.merge(
-        Datadog::AppSec::Configuration::DSL.new.tap do |appsec|
-          appsec.enabled = appsec_enabled
-        end
+      double(
+        appsec: Datadog::AppSec::Configuration::Settings.new.merge(
+          Datadog::AppSec::Configuration::DSL.new.tap do |appsec|
+            appsec.enabled = appsec_enabled
+          end
+        )
       )
     end
+
     context 'when appsec is enabled' do
       let(:appsec_enabled) { true }
       it 'returns a Datadog::AppSec::Component instance' do

--- a/spec/datadog/appsec/component_spec.rb
+++ b/spec/datadog/appsec/component_spec.rb
@@ -3,8 +3,11 @@ require 'datadog/appsec/component'
 
 RSpec.describe Datadog::AppSec::Component do
   describe '.build_appsec_component' do
-    let(:settings) do
+    let(:seetings_without_appsec) { double(Datadog::Core::Configuration) }
+
+    let(:settings_with_appsec) do
       double(
+        Datadog::Core::Configuration,
         appsec: Datadog::AppSec::Configuration::Settings.new.merge(
           Datadog::AppSec::Configuration::DSL.new.tap do |appsec|
             appsec.enabled = appsec_enabled
@@ -16,14 +19,14 @@ RSpec.describe Datadog::AppSec::Component do
     context 'when appsec is enabled' do
       let(:appsec_enabled) { true }
       it 'returns a Datadog::AppSec::Component instance' do
-        component = described_class.build_appsec_component(settings)
+        component = described_class.build_appsec_component(settings_with_appsec)
         expect(component).to be_a(described_class)
       end
 
       context 'when processor is ready' do
         it 'returns a Datadog::AppSec::Component with a processor instance' do
           expect_any_instance_of(Datadog::AppSec::Processor).to receive(:ready?).and_return(true)
-          component = described_class.build_appsec_component(settings)
+          component = described_class.build_appsec_component(settings_with_appsec)
 
           expect(component.processor).to be_a(Datadog::AppSec::Processor)
         end
@@ -32,7 +35,7 @@ RSpec.describe Datadog::AppSec::Component do
       context 'when processor fail to instanciate' do
         it 'returns a Datadog::AppSec::Component with a nil processor' do
           expect_any_instance_of(Datadog::AppSec::Processor).to receive(:ready?).and_return(false)
-          component = described_class.build_appsec_component(settings)
+          component = described_class.build_appsec_component(settings_with_appsec)
 
           expect(component.processor).to be_nil
         end
@@ -43,7 +46,14 @@ RSpec.describe Datadog::AppSec::Component do
       let(:appsec_enabled) { false }
 
       it 'returns nil' do
-        component = described_class.build_appsec_component(settings)
+        component = described_class.build_appsec_component(settings_with_appsec)
+        expect(component).to be_nil
+      end
+    end
+
+    context 'when appsec is not active' do
+      it 'returns nil' do
+        component = described_class.build_appsec_component(seetings_without_appsec)
         expect(component).to be_nil
       end
     end


### PR DESCRIPTION
fix https://github.com/DataDog/dd-trace-rb/issues/2677

The issue is that trying to access `settings.appsec` when configuring `Datadog` is that if the `appsec` hasn't being required or if the customer did not require `ddtrace` the error we would get is `undefined method `appsec' for #<Datadog::Core::Configuration::Settings>`

The appsec setting is loaded here:

https://github.com/DataDog/dd-trace-rb/blob/28c3c3e1b19a625efe7ba3e107cadea3da0a75c5/lib/ddtrace.rb#L7

https://github.com/DataDog/dd-trace-rb/blob/28c3c3e1b19a625efe7ba3e107cadea3da0a75c5/lib/datadog/appsec.rb#L32

The fix makes sure to double check before if the appsec configuration module has been loaded, and if it hasn't, we will no-op. 

I tested this change loading just `datadog/ci` in an `irb` session and calling `Datadog.configure {}`

```
irb -I lib -r datadog/ci
irb(main):001:0> Datadog.configure { |c| c.ci.enabled = true ; c.ci.instrument :rspec }
W, [2023-03-09T18:43:49.071225 #26424]  WARN -- ddtrace: [ddtrace] Unable to patch Datadog::CI::Contrib::RSpec::Integration (Available?: false, Loaded? false, Compatible? false, Patchable? false)
=>
#<#<Class:0x0000000107909428>:0x0000000107de8160
 @instrumented_integrations=
  {:rspec=>
    #<Datadog::CI::Contrib::RSpec::Integration:0x0000000107d41158
     @default_configuration=
      #<Datadog::CI::Contrib::RSpec::Configuration::Settings:0x0000000107de7e18
       @options=
        {:enabled=>
          #<Datadog::Core::Configuration::Option:0x0000000107fc7080
           @context=#<Datadog::CI::Contrib::RSpec::Configuration::Settings:0x0000000107de7e18 ...>,
           @definition=
            #<Datadog::Core::Configuration::OptionDefinition:0x0000000107e0a6e8
             @default=#<Proc:0x0000000107d47170 /Users/gustavo.caso/src/github.com/DataDog/dd-trace-rb/lib/datadog/ci/contrib/rspec/configuration/settings.rb:13>,
             @delegate_to=nil,
             @depends_on=[],
             @lazy=true,
             @name=:enabled,
             @on_set=nil,
             @resetter=nil,
             @setter=#<Proc:0x0000000107969918 /Users/gustavo.caso/src/github.com/DataDog/dd-trace-rb/lib/datadog/core/configuration/option_definition.rb:8 (lambda)>,
             @type=nil>,
           @is_set=true,
           @value=true>}>,
     @name=:rspec>},
 @integrations_pending_activation=#<Set: {}>,
 @options=
  {:test_mode=>
    #<Datadog::Core::Configuration::Option:0x0000000107fc6fe0
     @context=#<#<Class:0x0000000107909428>:0x0000000107de8160 ...>,
     @definition=
      #<Datadog::Core::Configuration::OptionDefinition:0x00000001079029e8
       @default=#<Proc:0x00000001078c8518 /Users/gustavo.caso/src/github.com/DataDog/dd-trace-rb/lib/datadog/core/configuration/base.rb:31>,
       @delegate_to=nil,
       @depends_on=[],
       @lazy=true,
       @name=:test_mode,
       @on_set=nil,
       @resetter=#<Proc:0x00000001078c84f0 /Users/gustavo.caso/src/github.com/DataDog/dd-trace-rb/lib/datadog/core/configuration/base.rb:34>,
       @setter=#<Proc:0x0000000107969918 /Users/gustavo.caso/src/github.com/DataDog/dd-trace-rb/lib/datadog/core/configuration/option_definition.rb:8 (lambda)>,
       @type=#<Class:0x0000000107904428>>,
     @is_set=true,
     @value=
      #<#<Class:0x0000000107904428>:0x0000000107de5690
       @options=
        {:enabled=>
          #<Datadog::Core::Configuration::Option:0x0000000107fc6f90
           @context=#<#<Class:0x0000000107904428>:0x0000000107de5690 ...>,
           @definition=
            #<Datadog::Core::Configuration::OptionDefinition:0x0000000107902da8
             @default=#<Proc:0x00000001078caa70 /Users/gustavo.caso/src/github.com/DataDog/dd-trace-rb/lib/datadog/tracing/configuration/settings.rb:347>,
             @delegate_to=nil,
             @depends_on=[],
             @lazy=true,
             @name=:enabled,
             @on_set=nil,
             @resetter=nil,
             @setter=#<Proc:0x0000000107969918 /Users/gustavo.caso/src/github.com/DataDog/dd-trace-rb/lib/datadog/core/configuration/option_definition.rb:8 (lambda)>,
             @type=nil>,
           @is_set=true,
           @value=true>,
         :trace_flush=>
          #<Datadog::Core::Configuration::Option:0x0000000107fc6ef0
           @context=#<#<Class:0x0000000107904428>:0x0000000107de5690 ...>,
           @definition=
            #<Datadog::Core::Configuration::OptionDefinition:0x0000000107902c68
             @default=#<Proc:0x00000001078c9d78 /Users/gustavo.caso/src/github.com/DataDog/dd-trace-rb/lib/datadog/tracing/configuration/settings.rb:352>,
             @delegate_to=nil,
             @depends_on=[],
             @lazy=true,
             @name=:trace_flush,
             @on_set=nil,
             @resetter=nil,
             @setter=#<Proc:0x0000000107969918 /Users/gustavo.caso/src/github.com/DataDog/dd-trace-rb/lib/datadog/core/configuration/option_definition.rb:8 (lambda)>,
             @type=nil>,
           @is_set=true,
           @value=#<Datadog::CI::Flush::Finished:0x0000000107de4308>>,
         :writer_options=>
          #<Datadog::Core::Configuration::Option:0x0000000107fc6e50
           @context=#<#<Class:0x0000000107904428>:0x0000000107de5690 ...>,
           @definition=
            #<Datadog::Core::Configuration::OptionDefinition:0x0000000107902b28
             @default=#<Proc:0x00000001078c93a0 /Users/gustavo.caso/src/github.com/DataDog/dd-trace-rb/lib/datadog/tracing/configuration/settings.rb:357>,
             @delegate_to=nil,
             @depends_on=[],
             @lazy=true,
             @name=:writer_options,
             @on_set=nil,
             @resetter=nil,
             @setter=#<Proc:0x0000000107969918 /Users/gustavo.caso/src/github.com/DataDog/dd-trace-rb/lib/datadog/core/configuration/option_definition.rb:8 (lambda)>,
             @type=nil>,
           @is_set=true,
           @value={}>}>>,
   :transport_options=>
    #<Datadog::Core::Configuration::Option:0x0000000107fc6b80
     @context=#<#<Class:0x0000000107909428>:0x0000000107de8160 ...>,
     @definition=
      #<Datadog::Core::Configuration::OptionDefinition:0x0000000107902768
       @default=nil,
       @delegate_to=nil,
       @depends_on=[],
       @lazy=false,
       @name=:transport_options,
       @on_set=nil,
       @resetter=nil,
       @setter=#<Proc:0x0000000107969918 /Users/gustavo.caso/src/github.com/DataDog/dd-trace-rb/lib/datadog/core/configuration/option_definition.rb:8 (lambda)>,
       @type=nil>,
     @is_set=true,
     @value=nil>,
   :instance=>
    #<Datadog::Core::Configuration::Option:0x0000000107fc6400
     @context=#<#<Class:0x0000000107909428>:0x0000000107de8160 ...>,
     @definition=
      #<Datadog::Core::Configuration::OptionDefinition:0x0000000107906c28
       @default=nil,
       @delegate_to=nil,
       @depends_on=[],
       @lazy=false,
       @name=:instance,
       @on_set=nil,
       @resetter=nil,
       @setter=#<Proc:0x0000000107969918 /Users/gustavo.caso/src/github.com/DataDog/dd-trace-rb/lib/datadog/core/configuration/option_definition.rb:8 (lambda)>,
       @type=nil>,
     @is_set=true,
     @value=nil>,
   :enabled=>
    #<Datadog::Core::Configuration::Option:0x0000000107fc6180
     @context=#<#<Class:0x0000000107909428>:0x0000000107de8160 ...>,
     @definition=
      #<Datadog::Core::Configuration::OptionDefinition:0x0000000107906fe8
       @default=#<Proc:0x00000001048268d8 /Users/gustavo.caso/src/github.com/DataDog/dd-trace-rb/lib/datadog/tracing/configuration/settings.rb:172>,
       @delegate_to=nil,
       @depends_on=[],
       @lazy=true,
       @name=:enabled,
       @on_set=nil,
       @resetter=nil,
       @setter=#<Proc:0x0000000107969918 /Users/gustavo.caso/src/github.com/DataDog/dd-trace-rb/lib/datadog/core/configuration/option_definition.rb:8 (lambda)>,
       @type=nil>,
     @is_set=true,
     @value=true>,
   :sampling=>
    #<Datadog::Core::Configuration::Option:0x0000000107fc6130
     @context=#<#<Class:0x0000000107909428>:0x0000000107de8160 ...>,
     @definition=
      #<Datadog::Core::Configuration::OptionDefinition:0x00000001079044c8
       @default=#<Proc:0x00000001078cb5b0 /Users/gustavo.caso/src/github.com/DataDog/dd-trace-rb/lib/datadog/core/configuration/base.rb:31>,
       @delegate_to=nil,
       @depends_on=[],
       @lazy=true,
       @name=:sampling,
       @on_set=nil,
       @resetter=#<Proc:0x00000001078cb588 /Users/gustavo.caso/src/github.com/DataDog/dd-trace-rb/lib/datadog/core/configuration/base.rb:34>,
       @setter=#<Proc:0x0000000107969918 /Users/gustavo.caso/src/github.com/DataDog/dd-trace-rb/lib/datadog/core/configuration/option_definition.rb:8 (lambda)>,
       @type=#<Class:0x00000001079051e8>>,
     @is_set=true,
     @value=
      #<#<Class:0x00000001079051e8>:0x0000000107ccaad0
       @options=
        {:span_rules=>
          #<Datadog::Core::Configuration::Option:0x0000000107fc60e0
           @context=#<#<Class:0x00000001079051e8>:0x0000000107ccaad0 ...>,
           @definition=
            #<Datadog::Core::Configuration::OptionDefinition:0x00000001079046a8
             @default=#<Proc:0x00000001078cb920 /Users/gustavo.caso/src/github.com/DataDog/dd-trace-rb/lib/datadog/tracing/configuration/settings.rb:306>,
             @delegate_to=nil,
             @depends_on=[],
             @lazy=true,
             @name=:span_rules,
             @on_set=nil,
             @resetter=nil,
             @setter=#<Proc:0x0000000107969918 /Users/gustavo.caso/src/github.com/DataDog/dd-trace-rb/lib/datadog/core/configuration/option_definition.rb:8 (lambda)>,
             @type=nil>,
           @is_set=true,
           @value=nil>}>>}>
irb(main):002:0>
```
