### PR TITLE
Disable typechecking contrib folders by default

### DIFF
--- a/Steepfile
+++ b/Steepfile
@@ -3,6 +3,10 @@ target :ddtrace do
 
   check 'lib/'
 
+  ignore 'lib/datadog/appsec/contrib/'
+  ignore 'lib/datadog/ci/contrib/'
+  ignore 'lib/datadog/tracing/contrib/'
+
   ignore 'lib/datadog/appsec.rb'
   ignore 'lib/datadog/appsec/component.rb'
   ignore 'lib/datadog/appsec/contrib/auto_instrument.rb'


### PR DESCRIPTION
**What does this PR do?**:

In #2672 we changed our type checking configuration to be on by default for new files.

While not a bad idea for regular contributors to the core and products, it's an awful experience for people contributing new integrations, since getting type checking going for contrib is quite hard at this moment.

Thus, this PR tweaks the type checking configuration to disable the dd-trace-rb contrib folders by default. In the future, we can always make these ignore rules more finer-grained, when we're feeling brave enough to start adding types to those classes.

**Motivation**:

Make sure that contributors have a good experience and balance that with gently pushing people to add type signatures to more classes.

**Additional Notes**:

N/A

**How to test the change?**:

Add an empty class inside any of those folders, and verify that `bundle exec rake typecheck` does not complain.