### PR TITLE
[APPSEC-8287] Add AppSec::Processor::RuleMerger

### DIFF
--- a/lib/datadog/appsec/processor/rule_merger.rb
+++ b/lib/datadog/appsec/processor/rule_merger.rb
@@ -17,21 +17,24 @@ module Datadog
         end
 
         class << self
-          def merge(rules:, data: nil, overrides: nil)
+          def merge(rules:, data: nil, overrides: nil, exclusions: nil)
             combined_rules = combine_rules(rules)
 
             rules_data = combine_data(data) if data
-            rules_overrides_and_exclusions = combine_overrides(overrides) if overrides
+            rules_overrides = combine_overrides(overrides) if overrides
+            rules_exclusions = combine_exclusions(exclusions) if exclusions
 
-            combined_rules.merge!(rules_data) if rules_data
-            combined_rules.merge!(rules_overrides_and_exclusions) if rules_overrides_and_exclusions
+            combined_rules['rules_data'] = rules_data if rules_data
+            combined_rules['rules_override'] = rules_overrides if rules_overrides
+            combined_rules['exclusions'] = rules_exclusions if rules_exclusions
+
             combined_rules
           end
 
           private
 
           def combine_rules(rules)
-            return rules[0] if rules.size == 1
+            return rules[0].dup if rules.size == 1
 
             final_rules = []
             # @type var final_version: ::String
@@ -60,22 +63,15 @@ module Datadog
 
             data.each do |data_entry|
               data_entry['rules_data'].each do |value|
-                data_exists = result.select { |x| x['id'] == value['id'] }
+                existing_data = result.find { |x| x['id'] == value['id'] }
 
-                if data_exists.any?
-                  existing_data = data_exists.first
-
-                  if existing_data['type'] == value['type']
-                    # Duplicate entry base on type and id
-                    # We need to merge the existing data with the new one
-                    # and make sure to remove duplicates
-                    merged_data = merge_data_base_on_expiration(existing_data['data'], value['data'])
-                    existing_data['data'] = merged_data
-                  else
-                    result << value
-                  end
+                if existing_data && existing_data['type'] == value['type']
+                  # Duplicate entry base on type and id
+                  # We need to merge the existing data with the new one
+                  # and make sure to remove duplicates
+                  merged_data = merge_data_base_on_expiration(existing_data['data'], value['data'])
+                  existing_data['data'] = merged_data
                 else
-                  # First entry for that id
                   result << value
                 end
               end
@@ -83,7 +79,7 @@ module Datadog
 
             return unless result.any?
 
-            { 'rules_data' => result }
+            result
           end
 
           def merge_data_base_on_expiration(data1, data2)
@@ -97,43 +93,51 @@ module Datadog
                 # the one with the highest expiration value
                 # We replace it if the expiration is higher than the current one
                 # or if no experiration
-                expiration = result[data['value']]
-                result[data['value']] = data['expiration'] if data['expiration'].nil? || data['expiration'] > expiration
+                current_expiration = result[data['value']]
+                new_expiration = data['expiration']
+
+                if new_expiration.nil? || current_expiration && new_expiration > current_expiration
+                  result[data['value']] = new_expiration
+                end
               else
                 result[data['value']] = data['expiration']
               end
             end
 
             result.each_with_object([]) do |entry, acc|
-              # There could be cases that there is no experitaion value.
-              # To singal that there is no expiration we use the default value 0.
-              acc << { 'value' => entry[0], 'expiration' => entry[1] || 0 }
+              value = { 'value' => entry[0] }
+              value['expiration'] = entry[1] if entry[1]
+
+              acc << value
             end
           end
 
           def combine_overrides(overrides)
-            result = {}
-            exclusions = []
             rules_override = []
 
             overrides.each do |override|
-              if override['rules_override']
-                override['rules_override'].each do |rule_override|
-                  rules_override << rule_override
-                end
-              elsif override['exclusions']
-                override['exclusions'].each do |exclusion|
-                  exclusions << exclusion
-                end
+              override['rules_override'].each do |rule_override|
+                rules_override << rule_override
               end
             end
 
-            result['exclusions'] = exclusions if exclusions.any?
-            result['rules_override'] = rules_override if rules_override.any?
+            return if rules_override.empty?
 
-            return if result.empty?
+            rules_override
+          end
 
-            result
+          def combine_exclusions(exclusions)
+            rules_exclusions = []
+
+            exclusions.each do |exclusion|
+              exclusion['exclusions'].each do |rule_exclusion|
+                rules_exclusions << rule_exclusion
+              end
+            end
+
+            return if rules_exclusions.empty?
+
+            rules_exclusions
           end
         end
       end

--- a/lib/datadog/appsec/processor/rule_merger.rb
+++ b/lib/datadog/appsec/processor/rule_merger.rb
@@ -1,0 +1,107 @@
+# frozen_string_literal: true
+
+module Datadog
+  module AppSec
+    class Processor
+      # RuleMerger merge different sources of information
+      # into the rules payload
+      module RuleMerger
+        class << self
+          def merge(rules:, data: nil, overrides: nil)
+            rules_dup = rules.dup
+
+            rules_data = combine_data(data) if data
+            rules_overrides_and_exclusions = combine_overrides(overrides) if overrides
+
+            rules_dup.merge!(rules_data) if rules_data
+            rules_dup.merge!(rules_overrides_and_exclusions) if rules_overrides_and_exclusions
+            rules_dup
+          end
+
+          private
+
+          def combine_data(data)
+            result = []
+
+            data.each do |data_entry|
+              data_entry['rules_data'].each do |value|
+                data_exists = result.select { |x| x['id'] == value['id'] }
+
+                if data_exists.any?
+                  existing_data = data_exists.first
+
+                  if existing_data['type'] == value['type']
+                    # Duplicate entry base on type and id
+                    # We need to merge the existing data with the new one
+                    # and make sure to remove duplicates
+                    merged_data = merge_data_base_on_expiration(existing_data['data'], value['data'])
+                    existing_data['data'] = merged_data
+                  else
+                    result << value
+                  end
+                else
+                  # First entry for that id
+                  result << value
+                end
+              end
+            end
+
+            return unless result.any?
+
+            { 'rules_data' => result }
+          end
+
+          def merge_data_base_on_expiration(data1, data2)
+            result = data1.each_with_object({}) do |value, acc|
+              acc[value['value']] = value['expiration']
+            end
+
+            data2.each do |data|
+              if result.key?(data['value'])
+                # The value is duplicated so we need to keep
+                # the one with the highest expiration value
+                # We replace it if the expiration is higher than the current one
+                # or if no experiration
+                expiration = result[data['value']]
+                result[data['value']] = data['expiration'] if data['expiration'].nil? || data['expiration'] > expiration
+              else
+                result[data['value']] = data['expiration']
+              end
+            end
+
+            result.each_with_object([]) do |entry, acc|
+              # There could be cases that there is no experitaion value.
+              # To singal that there is no expiration we use the default value 0.
+              acc << { 'value' => entry[0], 'expiration' => entry[1] || 0 }
+            end
+          end
+
+          def combine_overrides(overrides)
+            result = {}
+            exclusions = []
+            rules_override = []
+
+            overrides.each do |override|
+              if override['rules_override']
+                override['rules_override'].each do |rule_override|
+                  rules_override << rule_override
+                end
+              elsif override['exclusions']
+                override['exclusions'].each do |exclusion|
+                  exclusions << exclusion
+                end
+              end
+            end
+
+            result['exclusions'] = exclusions if exclusions.any?
+            result['rules_override'] = rules_override if rules_override.any?
+
+            return if result.empty?
+
+            result
+          end
+        end
+      end
+    end
+  end
+end

--- a/sig/datadog/appsec/processor/rule_merger.rbs
+++ b/sig/datadog/appsec/processor/rule_merger.rbs
@@ -2,13 +2,19 @@ module Datadog
   module AppSec
     class Processor
       module RuleMerger
+        class RuleVersionMismatchError < StandardError
+          def initialize: (::String version1, ::String version2) -> void
+        end
+
         type rules = ::Hash[::String, untyped]
         type data = ::Hash[::String, untyped]
         type overrides = ::Hash[::String, untyped]
 
-        def self.merge: (rules: untyped, ?data: ::Array[data]?, ?overrides: ::Array[overrides]?) -> rules
+        def self.merge: (rules: ::Array[rules], ?data: ::Array[data]?, ?overrides: ::Array[overrides]?) -> rules
 
         private
+
+        def self.combine_rules: (::Array[rules] rules) -> untyped
 
         def self.combine_data: (::Array[data] data) -> (nil | { rules_data: untyped })
 

--- a/sig/datadog/appsec/processor/rule_merger.rbs
+++ b/sig/datadog/appsec/processor/rule_merger.rbs
@@ -1,0 +1,21 @@
+module Datadog
+  module AppSec
+    class Processor
+      module RuleMerger
+        type rules = ::Hash[::String, untyped]
+        type data = ::Hash[::String, untyped]
+        type overrides = ::Hash[::String, untyped]
+
+        def self.merge: (rules: untyped, ?data: ::Array[data]?, ?overrides: ::Array[overrides]?) -> rules
+
+        private
+
+        def self.combine_data: (::Array[data] data) -> (nil | { rules_data: untyped })
+
+        def self.merge_data_base_on_expiration: (::Array[data] data1, ::Array[data] data2) -> ::Array[data]
+
+        def self.combine_overrides: (::Array[overrides] overrides) -> overrides?
+      end
+    end
+  end
+end

--- a/sig/datadog/appsec/processor/rule_merger.rbs
+++ b/sig/datadog/appsec/processor/rule_merger.rbs
@@ -9,18 +9,21 @@ module Datadog
         type rules = ::Hash[::String, untyped]
         type data = ::Hash[::String, untyped]
         type overrides = ::Hash[::String, untyped]
+        type exclusions = ::Hash[::String, untyped]
 
-        def self.merge: (rules: ::Array[rules], ?data: ::Array[data]?, ?overrides: ::Array[overrides]?) -> rules
+        def self.merge: (rules: ::Array[rules], ?data: ::Array[data]?, ?overrides: ::Array[overrides]?, ?exclusions: ::Array[exclusions]?) -> rules
 
         private
 
         def self.combine_rules: (::Array[rules] rules) -> untyped
 
-        def self.combine_data: (::Array[data] data) -> (nil | { rules_data: untyped })
+        def self.combine_data: (::Array[data] data) -> ::Array[data]?
 
         def self.merge_data_base_on_expiration: (::Array[data] data1, ::Array[data] data2) -> ::Array[data]
 
-        def self.combine_overrides: (::Array[overrides] overrides) -> overrides?
+        def self.combine_overrides: (::Array[overrides] overrides) -> ::Array[overrides]?
+
+        def self.combine_exclusions: (::Array[exclusions] exclusions) -> ::Array[exclusions]?
       end
     end
   end

--- a/spec/datadog/appsec/processor/rule_merger_spec.rb
+++ b/spec/datadog/appsec/processor/rule_merger_spec.rb
@@ -1,0 +1,473 @@
+require 'datadog/appsec/spec_helper'
+require 'datadog/appsec/processor/rule_merger'
+
+RSpec.describe Datadog::AppSec::Processor::RuleMerger do
+  let(:rules) do
+    {
+      'version' => '2.2',
+      'metadata' => {
+        'rules_version' => '1.4.3'
+      },
+      'rules' => [
+        {
+          'id' => 'usr-001-001',
+          'name' => 'Super rule',
+          'tags' => {
+            'type' => 'security_scanner',
+            'category' => 'scanners'
+          },
+          'conditions' => [
+            {
+              'parameters' => {
+                'inputs' => [
+                  {
+                    'address' => 'server.request.headers',
+                    'key_path' => ['user-agent']
+                  }
+                ],
+                'regex' => '^SuperScanner$'
+              },
+              'operator' => 'regex_match'
+            }
+          ],
+          'transformers' => []
+        }
+      ]
+    }
+  end
+
+  context 'overrides' do
+    context 'without overrides' do
+      it 'does not merge rules_overrides or exclusions' do
+        expected_result = rules
+
+        result = described_class.merge(rules: rules)
+        expect(result).to eq(expected_result)
+      end
+    end
+
+    context 'with overrides' do
+      it 'merge rules_overrides' do
+        rules_overrides = [
+          {
+            'rules_override' => [
+              {
+                'id' => 'usr-001-001',
+                'on_match' => ['block']
+              }
+            ]
+          },
+          {
+            'rules_override' => [
+              {
+                'id' => 'usr-001-001',
+                'enabled' => false,
+              }
+            ]
+          },
+        ]
+
+        expected_result = rules.merge(
+          {
+            'rules_override' => [
+              {
+                'id' => 'usr-001-001',
+                'on_match' => ['block']
+              },
+              {
+                'id' => 'usr-001-001',
+                'enabled' => false
+              }
+            ]
+          }
+        )
+
+        result = described_class.merge(rules: rules, overrides: rules_overrides)
+        expect(result).to eq(expected_result)
+      end
+
+      it 'merges exclusions' do
+        rules_overrides = [
+          {
+            'exclusions' => [
+              {
+                'conditions' => [
+                  {
+                    'operator' => 'match_regex',
+                    'parameters' => {
+                      'inputs' => [
+                        {
+                          'address' => 'server.request.uri.raw'
+                        }
+                      ],
+                      'options' => {
+                        'case_sensitive' => false
+                      },
+                      'regex' => '^/api/v2/ci/pipeline/.*'
+                    }
+                  }
+                ],
+                'id' => '1931d0f4-c521-4500-af34-6c4d8b8b3494'
+              }
+            ]
+          }
+        ]
+
+        expected_result = rules.merge(
+          {
+            'exclusions' => [
+              {
+                'conditions' => [
+                  {
+                    'operator' => 'match_regex',
+                    'parameters' => {
+                      'inputs' => [
+                        { 'address' => 'server.request.uri.raw' }
+                      ],
+                      'options' => { 'case_sensitive' => false },
+                      'regex' => '^/api/v2/ci/pipeline/.*'
+                    }
+                  }
+                ],
+                'id' => '1931d0f4-c521-4500-af34-6c4d8b8b3494'
+              }
+            ]
+          }
+        )
+
+        result = described_class.merge(rules: rules, overrides: rules_overrides)
+        expect(result).to eq(expected_result)
+      end
+
+      it 'merges rules_overrides and exclusions' do
+        rules_overrides = [
+          {
+            'rules_override' => [
+              {
+                'id' => 'usr-001-001',
+                'on_match' => ['block']
+              }
+            ]
+          },
+          {
+            'rules_override' => [
+              {
+                'id' => 'usr-001-001',
+                'enabled' => false,
+              }
+            ]
+          },
+          {
+            'exclusions' => [
+              {
+                'conditions' => [
+                  {
+                    'operator' => 'match_regex',
+                    'parameters' => {
+                      'inputs' => [
+                        {
+                          'address' => 'server.request.uri.raw'
+                        }
+                      ],
+                      'options' => {
+                        'case_sensitive' => false
+                      },
+                      'regex' => '^/api/v2/ci/pipeline/.*'
+                    }
+                  }
+                ],
+                'id' => '1931d0f4-c521-4500-af34-6c4d8b8b3494'
+              }
+            ]
+          }
+        ]
+
+        expected_result = rules.merge(
+          {
+            'exclusions' => [
+              {
+                'conditions' => [
+                  {
+                    'operator' => 'match_regex',
+                    'parameters' => {
+                      'inputs' => [
+                        { 'address' => 'server.request.uri.raw' }
+                      ],
+                      'options' => { 'case_sensitive' => false },
+                      'regex' => '^/api/v2/ci/pipeline/.*'
+                    }
+                  }
+                ],
+                'id' => '1931d0f4-c521-4500-af34-6c4d8b8b3494'
+              }
+            ],
+            'rules_override' => [
+              {
+                'id' => 'usr-001-001',
+                'on_match' => ['block']
+              },
+              {
+                'id' => 'usr-001-001',
+                'enabled' => false
+              }
+            ]
+          }
+        )
+
+        result = described_class.merge(rules: rules, overrides: rules_overrides)
+        expect(result).to eq(expected_result)
+      end
+    end
+  end
+
+  context 'data' do
+    it 'merges rules_data' do
+      rules_data = [
+        {
+          'rules_data' => [
+            {
+              'data' => [
+                {
+                  'expiration' => 1677171437,
+                  'value' => 'this is a test'
+                }
+              ],
+              'id' => 'blocked_users',
+              'type' => 'data_with_expiration'
+            }
+          ]
+        },
+        {
+          'rules_data' => [
+            {
+              'data' => [
+                {
+                  'expiration' => 1678279317,
+                  'value' => '9.9.9.9'
+                }
+              ],
+              'id' => 'blocked_ips',
+              'type' => 'ip_with_expiration'
+            }
+          ]
+        },
+        {
+          'rules_data' => [
+            {
+              'data' => [
+                {
+                  'expiration' => 1678279317,
+                  'value' => 'this is a second test'
+                }
+              ],
+              'id' => 'blocked_users',
+              'type' => 'data_with_expiration'
+            }
+          ]
+        }
+      ]
+
+      expected_result = rules.merge(
+        {
+          'rules_data' => [
+            {
+              'id' => 'blocked_users',
+              'type' => 'data_with_expiration',
+              'data' => [
+                {
+                  'expiration' => 1677171437,
+                  'value' => 'this is a test'
+                },
+                {
+                  'expiration' => 1678279317,
+                  'value' => 'this is a second test'
+                }
+              ]
+            },
+            {
+              'id' => 'blocked_ips',
+              'type' => 'ip_with_expiration',
+              'data' => [
+                {
+                  'expiration' => 1678279317,
+                  'value' => '9.9.9.9'
+                }
+              ]
+            },
+          ]
+        }
+      )
+
+      result = described_class.merge(rules: rules, data: rules_data)
+      expect(result).to eq(expected_result)
+    end
+
+    it 'merges data of different types' do
+      rules_data = [
+        {
+          'rules_data' => [
+            {
+              'data' => [
+                {
+                  'expiration' => 1677171437,
+                  'value' => 'this is a test'
+                }
+              ],
+              'id' => 'blocked_users',
+              'type' => 'data_with_expiration'
+            }
+          ]
+        },
+        {
+          'rules_data' => [
+            {
+              'data' => [
+                {
+                  'value' => 'this is a test'
+                }
+              ],
+              'id' => 'blocked_users',
+              'type' => 'test_data'
+            }
+          ]
+        }
+      ]
+
+      expected_result = rules.merge(
+        {
+          'rules_data' => [
+            {
+              'id' => 'blocked_users',
+              'type' => 'data_with_expiration',
+              'data' => [
+                {
+                  'expiration' => 1677171437,
+                  'value' => 'this is a test'
+                }
+              ]
+            },
+            {
+              'data' => [
+                {
+                  'value' => 'this is a test'
+                }
+              ],
+              'id' => 'blocked_users',
+              'type' => 'test_data'
+            }
+          ]
+        }
+      )
+
+      result = described_class.merge(rules: rules, data: rules_data)
+      expect(result).to eq(expected_result)
+    end
+
+    context 'with duplicates entries' do
+      it 'removes duplicate entry and leave the one with the longest expiration ' do
+        rules_data = [
+          {
+            'rules_data' => [
+              {
+                'data' => [
+                  {
+                    'expiration' => 1677171437,
+                    'value' => 'this is a test'
+                  }
+                ],
+                'id' => 'blocked_users',
+                'type' => 'data_with_expiration'
+              }
+            ]
+          },
+          {
+            'rules_data' => [
+              {
+                'data' => [
+                  {
+                    'expiration' => 167710000,
+                    'value' => 'this is a test'
+                  }
+                ],
+                'id' => 'blocked_users',
+                'type' => 'data_with_expiration'
+              }
+            ]
+          }
+        ]
+
+        expected_result = rules.merge(
+          {
+            'rules_data' => [
+              {
+                'id' => 'blocked_users',
+                'type' => 'data_with_expiration',
+                'data' => [
+                  {
+                    'expiration' => 1677171437,
+                    'value' => 'this is a test'
+                  }
+                ]
+              }
+            ]
+          }
+        )
+
+        result = described_class.merge(rules: rules, data: rules_data)
+        expect(result).to eq(expected_result)
+      end
+
+      it 'keeps the entry without expiration' do
+        rules_data = [
+          {
+            'rules_data' => [
+              {
+                'data' => [
+                  {
+                    'expiration' => 1677171437,
+                    'value' => 'this is a test'
+                  }
+                ],
+                'id' => 'blocked_users',
+                'type' => 'data_with_expiration'
+              }
+            ]
+          },
+          {
+            'rules_data' => [
+              {
+                'data' => [
+                  {
+                    'value' => 'this is a test'
+                  }
+                ],
+                'id' => 'blocked_users',
+                'type' => 'data_with_expiration'
+              }
+            ]
+          }
+        ]
+
+        expected_result = rules.merge(
+          {
+            'rules_data' => [
+              {
+                'id' => 'blocked_users',
+                'type' => 'data_with_expiration',
+                'data' => [
+                  {
+                    'expiration' => 0,
+                    'value' => 'this is a test'
+                  }
+                ]
+              }
+            ]
+          }
+        )
+
+        result = described_class.merge(rules: rules, data: rules_data)
+        expect(result).to eq(expected_result)
+      end
+    end
+  end
+end

--- a/spec/datadog/appsec/processor/rule_merger_spec.rb
+++ b/spec/datadog/appsec/processor/rule_merger_spec.rb
@@ -34,8 +34,8 @@ RSpec.describe Datadog::AppSec::Processor::RuleMerger do
             'transformers' => []
           }
         ]
-      }
-    ]
+      }.freeze
+    ].freeze
   end
 
   context 'rules' do
@@ -86,7 +86,7 @@ RSpec.describe Datadog::AppSec::Processor::RuleMerger do
                 ]
               },
             ]
-          }
+          }.freeze
 
           expected_result = {
             'version' => '2.2',
@@ -153,7 +153,7 @@ RSpec.describe Datadog::AppSec::Processor::RuleMerger do
             ]
           }
 
-          result = described_class.merge(rules: rules_dup)
+          result = described_class.merge(rules: rules_dup.freeze)
           expect(result).to eq(expected_result)
         end
 
@@ -202,9 +202,11 @@ RSpec.describe Datadog::AppSec::Processor::RuleMerger do
                 ]
               },
             ]
-          }
+          }.freeze
 
-          expect { described_class.merge(rules: rules_dup) }.to raise_error(described_class::RuleVersionMismatchError)
+          expect do
+            described_class.merge(rules: rules_dup.freeze)
+          end.to raise_error(described_class::RuleVersionMismatchError)
         end
       end
     end
@@ -259,138 +261,143 @@ RSpec.describe Datadog::AppSec::Processor::RuleMerger do
         result = described_class.merge(rules: rules, overrides: rules_overrides)
         expect(result).to eq(expected_result)
       end
+    end
+  end
 
-      it 'merges exclusions' do
-        rules_overrides = [
-          {
-            'exclusions' => [
-              {
-                'conditions' => [
-                  {
-                    'operator' => 'match_regex',
-                    'parameters' => {
-                      'inputs' => [
-                        {
-                          'address' => 'server.request.uri.raw'
-                        }
-                      ],
-                      'options' => {
-                        'case_sensitive' => false
-                      },
-                      'regex' => '^/api/v2/ci/pipeline/.*'
-                    }
+  context 'exclusions' do
+    it 'merges exclusions' do
+      exclusions = [
+        {
+          'exclusions' => [
+            {
+              'conditions' => [
+                {
+                  'operator' => 'match_regex',
+                  'parameters' => {
+                    'inputs' => [
+                      {
+                        'address' => 'server.request.uri.raw'
+                      }
+                    ],
+                    'options' => {
+                      'case_sensitive' => false
+                    },
+                    'regex' => '^/api/v2/ci/pipeline/.*'
                   }
-                ],
-                'id' => '1931d0f4-c521-4500-af34-6c4d8b8b3494'
-              }
-            ]
-          }
-        ]
-
-        expected_result = rules[0].merge(
-          {
-            'exclusions' => [
-              {
-                'conditions' => [
-                  {
-                    'operator' => 'match_regex',
-                    'parameters' => {
-                      'inputs' => [
-                        { 'address' => 'server.request.uri.raw' }
-                      ],
-                      'options' => { 'case_sensitive' => false },
-                      'regex' => '^/api/v2/ci/pipeline/.*'
-                    }
+                }
+              ],
+              'id' => '1931d0f4-c521-4500-af34-6c4d8b8b3494'
+            }
+          ]
+        },
+        {
+          'exclusions' => [
+            {
+              'conditions' => [
+                {
+                  'operator' => 'match_regex',
+                  'parameters' => {
+                    'inputs' => [
+                      {
+                        'address' => 'server.request.uri.raw'
+                      }
+                    ],
+                    'options' => {
+                      'case_sensitive' => false
+                    },
+                    'regex' => '^/api/v2/source-code-integration/enrich-stack-trace'
                   }
-                ],
-                'id' => '1931d0f4-c521-4500-af34-6c4d8b8b3494'
-              }
-            ]
-          }
-        )
+                }
+              ],
+              'id' => 'f40fbf52-baec-42bd-9868-cf002b6cdbed',
+              'inputs' => [
+                {
+                  'address' => 'server.request.query',
+                  'key_path' => [
+                    'stack'
+                  ]
+                },
+                {
+                  'address' => 'server.request.body',
+                  'key_path' => [
+                    'stack'
+                  ]
+                },
+                {
+                  'address' => 'server.request.path_params',
+                  'key_path' => [
+                    'stack'
+                  ]
+                }
+              ]
+            }
+          ],
+        }
+      ]
 
-        result = described_class.merge(rules: rules, overrides: rules_overrides)
-        expect(result).to eq(expected_result)
-      end
-
-      it 'merges rules_overrides and exclusions' do
-        rules_overrides = [
-          {
-            'rules_override' => [
-              {
-                'id' => 'usr-001-001',
-                'on_match' => ['block']
-              }
-            ]
-          },
-          {
-            'rules_override' => [
-              {
-                'id' => 'usr-001-001',
-                'enabled' => false,
-              }
-            ]
-          },
-          {
-            'exclusions' => [
-              {
-                'conditions' => [
-                  {
-                    'operator' => 'match_regex',
-                    'parameters' => {
-                      'inputs' => [
-                        {
-                          'address' => 'server.request.uri.raw'
-                        }
-                      ],
-                      'options' => {
-                        'case_sensitive' => false
-                      },
-                      'regex' => '^/api/v2/ci/pipeline/.*'
-                    }
+      expected_result = rules[0].merge(
+        {
+          'exclusions' => [
+            {
+              'conditions' => [
+                {
+                  'operator' => 'match_regex',
+                  'parameters' => {
+                    'inputs' => [
+                      { 'address' => 'server.request.uri.raw' }
+                    ],
+                    'options' => { 'case_sensitive' => false },
+                    'regex' => '^/api/v2/ci/pipeline/.*'
                   }
-                ],
-                'id' => '1931d0f4-c521-4500-af34-6c4d8b8b3494'
-              }
-            ]
-          }
-        ]
-
-        expected_result = rules[0].merge(
-          {
-            'exclusions' => [
-              {
-                'conditions' => [
-                  {
-                    'operator' => 'match_regex',
-                    'parameters' => {
-                      'inputs' => [
-                        { 'address' => 'server.request.uri.raw' }
-                      ],
-                      'options' => { 'case_sensitive' => false },
-                      'regex' => '^/api/v2/ci/pipeline/.*'
-                    }
+                }
+              ],
+              'id' => '1931d0f4-c521-4500-af34-6c4d8b8b3494'
+            },
+            {
+              'conditions' => [
+                {
+                  'operator' => 'match_regex',
+                  'parameters' => {
+                    'inputs' => [
+                      {
+                        'address' => 'server.request.uri.raw'
+                      }
+                    ],
+                    'options' => {
+                      'case_sensitive' => false
+                    },
+                    'regex' => '^/api/v2/source-code-integration/enrich-stack-trace'
                   }
-                ],
-                'id' => '1931d0f4-c521-4500-af34-6c4d8b8b3494'
-              }
-            ],
-            'rules_override' => [
-              {
-                'id' => 'usr-001-001',
-                'on_match' => ['block']
-              },
-              {
-                'id' => 'usr-001-001',
-                'enabled' => false
-              }
-            ]
-          }
-        )
+                }
+              ],
+              'id' => 'f40fbf52-baec-42bd-9868-cf002b6cdbed',
+              'inputs' => [
+                {
+                  'address' => 'server.request.query',
+                  'key_path' => [
+                    'stack'
+                  ]
+                },
+                {
+                  'address' => 'server.request.body',
+                  'key_path' => [
+                    'stack'
+                  ]
+                },
+                {
+                  'address' => 'server.request.path_params',
+                  'key_path' => [
+                    'stack'
+                  ]
+                }
+              ]
+            }
+          ]
+        }
+      )
 
-        result = described_class.merge(rules: rules, overrides: rules_overrides)
-        expect(result).to eq(expected_result)
-      end
+      result = described_class.merge(rules: rules, exclusions: exclusions)
+      expect(result).to eq(expected_result)
     end
   end
 
@@ -591,7 +598,7 @@ RSpec.describe Datadog::AppSec::Processor::RuleMerger do
         expect(result).to eq(expected_result)
       end
 
-      it 'keeps the entry without expiration' do
+      it 'removes expiration key if no experation is provided' do
         rules_data = [
           {
             'rules_data' => [
@@ -630,7 +637,6 @@ RSpec.describe Datadog::AppSec::Processor::RuleMerger do
                 'type' => 'data_with_expiration',
                 'data' => [
                   {
-                    'expiration' => 0,
                     'value' => 'this is a test'
                   }
                 ]
@@ -640,6 +646,135 @@ RSpec.describe Datadog::AppSec::Processor::RuleMerger do
         )
 
         result = described_class.merge(rules: rules, data: rules_data)
+        expect(result).to eq(expected_result)
+      end
+    end
+
+    context 'data, overrides, and exclusions' do
+      it 'merges all information' do
+        rules_data = [
+          {
+            'rules_data' => [
+              {
+                'data' => [
+                  {
+                    'expiration' => 1677171437,
+                    'value' => 'this is a test'
+                  }
+                ],
+                'id' => 'blocked_users',
+                'type' => 'data_with_expiration'
+              }
+            ]
+          },
+          {
+            'rules_data' => [
+              {
+                'data' => [
+                  {
+                    'value' => 'this is a test'
+                  }
+                ],
+                'id' => 'blocked_users',
+                'type' => 'data_with_expiration'
+              }
+            ]
+          }
+        ]
+
+        exclusions = [
+          {
+            'exclusions' => [
+              {
+                'conditions' => [
+                  {
+                    'operator' => 'match_regex',
+                    'parameters' => {
+                      'inputs' => [
+                        {
+                          'address' => 'server.request.uri.raw'
+                        }
+                      ],
+                      'options' => {
+                        'case_sensitive' => false
+                      },
+                      'regex' => '^/api/v2/ci/pipeline/.*'
+                    }
+                  }
+                ],
+                'id' => '1931d0f4-c521-4500-af34-6c4d8b8b3494'
+              }
+            ]
+          },
+        ]
+
+        rules_overrides = [
+          {
+            'rules_override' => [
+              {
+                'id' => 'usr-001-001',
+                'on_match' => ['block']
+              }
+            ]
+          },
+          {
+            'rules_override' => [
+              {
+                'id' => 'usr-001-001',
+                'enabled' => false,
+              }
+            ]
+          },
+        ]
+
+        expected_result = rules[0].merge(
+          {
+            'rules_data' => [
+              {
+                'id' => 'blocked_users',
+                'type' => 'data_with_expiration',
+                'data' => [
+                  {
+                    'value' => 'this is a test'
+                  }
+                ]
+              }
+            ],
+            'rules_override' => [
+              {
+                'id' => 'usr-001-001',
+                'on_match' => ['block']
+              },
+              {
+                'enabled' => false,
+                'id' => 'usr-001-001'
+              }
+            ],
+            'exclusions' => [
+              {
+                'conditions' => [
+                  {
+                    'operator' => 'match_regex',
+                    'parameters' => {
+                      'inputs' => [
+                        {
+                          'address' => 'server.request.uri.raw'
+                        }
+                      ],
+                      'options' => {
+                        'case_sensitive' => false
+                      },
+                      'regex' => '^/api/v2/ci/pipeline/.*'
+                    }
+                  }
+                ],
+                'id' => '1931d0f4-c521-4500-af34-6c4d8b8b3494'
+              }
+            ]
+          }
+        )
+
+        result = described_class.merge(rules: rules, data: rules_data, overrides: rules_overrides, exclusions: exclusions)
         expect(result).to eq(expected_result)
       end
     end


### PR DESCRIPTION
In Appsec, there has to be some transformation when the remote configuration client is going to merge existing information with the provided by the agent. 

The agent can provide multiple pieces of information regarding new rules data, rules override, or entirely new rules set. 

Before being able to instantiate a new `AppSec::Processor` we need to make sure the rules payload has the correct format. 

The correct format is:

```
{
    version: ...,
    metadata: ...,
    rules: [...],
    exclusions: [...],
    rules_override: [...],
    rules_data: [...]
}
```

There is also some merging logic we need to account for when merging `rules_data`

When combining rules data with the same id, type and value, we need to keep the one with the highest expiration or if no expiration is provided.


