### PR TITLE
Add remote configuration PORO objects

### DIFF
--- a/Steepfile
+++ b/Steepfile
@@ -658,6 +658,7 @@ target :ddtrace do
   library 'net-http'
   library 'securerandom'
   library 'base64'
+  library 'digest'
 
   # TODO: gem 'libddwaf'
 

--- a/lib/datadog/core/remote/configuration/content.rb
+++ b/lib/datadog/core/remote/configuration/content.rb
@@ -6,6 +6,7 @@ module Datadog
   module Core
     module Remote
       class Configuration
+        # Content stores the information associated with a specific Configuration::Path
         class Content
           class << self
             def parse(hash)
@@ -26,6 +27,8 @@ module Datadog
           private_class_method :new
         end
 
+        # ContentList stores a list of Conetnt instances
+        # It provides convinient methods for finding content base on Configuration::Path and Configuration::Target
         class ContentList < Array
           class << self
             def parse(array)

--- a/lib/datadog/core/remote/configuration/content.rb
+++ b/lib/datadog/core/remote/configuration/content.rb
@@ -1,0 +1,47 @@
+# frozen_string_literal: true
+
+module Datadog
+  module Core
+    module Remote
+      class Configuration
+        class Content
+          attr_reader :path, :data
+
+          def initialize(path:, data:)
+            @path = path
+            @data = data
+          end
+
+          class << self
+            def parse(hash)
+              path = Path.parse(hash[:path])
+              data = hash[:content]
+
+              new(path: path, data: data)
+            end
+          end
+        end
+
+        class ContentList < Array
+          def find(path, target)
+            select { |c| c.path.eql?(path) && target.check(c) }.first
+          end
+
+          def [](path)
+            select { |c| c.path.eql?(path) }.first
+          end
+
+          def paths
+            map(&:path).uniq
+          end
+
+          class << self
+            def parse(array)
+              new.concat(array.map { |c| Content.parse(c) })
+            end
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/datadog/core/remote/configuration/content.rb
+++ b/lib/datadog/core/remote/configuration/content.rb
@@ -1,17 +1,12 @@
 # frozen_string_literal: true
 
+require_relative 'path'
+
 module Datadog
   module Core
     module Remote
       class Configuration
         class Content
-          attr_reader :path, :data
-
-          def initialize(path:, data:)
-            @path = path
-            @data = data
-          end
-
           class << self
             def parse(hash)
               path = Path.parse(hash[:path])
@@ -20,25 +15,34 @@ module Datadog
               new(path: path, data: data)
             end
           end
+
+          attr_reader :path, :data
+
+          def initialize(path:, data:)
+            @path = path
+            @data = data
+          end
+
+          private_class_method :new
         end
 
         class ContentList < Array
-          def find(path, target)
-            select { |c| c.path.eql?(path) && target.check(c) }.first
-          end
-
-          def [](path)
-            select { |c| c.path.eql?(path) }.first
-          end
-
-          def paths
-            map(&:path).uniq
-          end
-
           class << self
             def parse(array)
               new.concat(array.map { |c| Content.parse(c) })
             end
+          end
+
+          def find_content(path, target)
+            find { |c| c.path.eql?(path) && target.check(c) }
+          end
+
+          def [](path)
+            find { |c| c.path.eql?(path) }
+          end
+
+          def paths
+            map(&:path).uniq
           end
         end
       end

--- a/lib/datadog/core/remote/configuration/path.rb
+++ b/lib/datadog/core/remote/configuration/path.rb
@@ -35,9 +35,7 @@ module Datadog
               # @type var source: ::String
               source = _ = m['source']
 
-              if org_id
-                source = _ = source.delete("/#{org_id}")
-              end
+              source = _ = source.delete("/#{org_id}") if org_id
 
               # @type var product: ::String
               product = _ = m['product']

--- a/lib/datadog/core/remote/configuration/path.rb
+++ b/lib/datadog/core/remote/configuration/path.rb
@@ -30,19 +30,21 @@ module Datadog
 
               raise ParseError, "could not parse: #{path.inspect}" if m.nil?
 
-              # @type var org_id: ::Integer?
-              org_id = _ = m['org_id'] ? m['org_id'].to_i : nil
-              # @type var source: ::String
-              source = _ = m['source']
+              org_id = m['org_id'] ? m['org_id'].to_i : nil
 
-              source = _ = source.delete("/#{org_id}") if org_id
+              source = m['source']
+              raise ParseError, 'missing source value' unless source
 
-              # @type var product: ::String
-              product = _ = m['product']
-              # @type var config_id: ::String
-              config_id = _ = m['config_id']
-              # @type var name: ::String
-              name = _ = m['name']
+              source = source.delete("/#{org_id}") if org_id
+
+              product = m['product']
+              raise ParseError, 'missing product value' unless product
+
+              config_id = m['config_id']
+              raise ParseError, 'missing config_id value' unless config_id
+
+              name = m['name']
+              raise ParseError, 'missing name value' unless name
 
               new(source: source, org_id: org_id, product: product, config_id: config_id, name: name)
             end

--- a/lib/datadog/core/remote/configuration/path.rb
+++ b/lib/datadog/core/remote/configuration/path.rb
@@ -4,6 +4,7 @@ module Datadog
   module Core
     module Remote
       class Configuration
+        # Path stores path information
         class Path
           class ParseError < StandardError; end
 
@@ -29,18 +30,21 @@ module Datadog
 
               raise ParseError, "could not parse: #{path.inspect}" if m.nil?
 
-              org_id = m['org_id']
+              # @type var org_id: ::Integer?
+              org_id = _ = m['org_id'] ? m['org_id'].to_i : nil
+              # @type var source: ::String
+              source = _ = m['source']
 
               if org_id
-                source = m['source'].delete("/#{org_id}")
-                org_id = Integer(org_id)
-              else
-                source = m['source']
+                source = _ = source.delete("/#{org_id}")
               end
 
-              product = m['product']
-              config_id = m['config_id']
-              name = m['name']
+              # @type var product: ::String
+              product = _ = m['product']
+              # @type var config_id: ::String
+              config_id = _ = m['config_id']
+              # @type var name: ::String
+              name = _ = m['name']
 
               new(source: source, org_id: org_id, product: product, config_id: config_id, name: name)
             end

--- a/lib/datadog/core/remote/configuration/path.rb
+++ b/lib/datadog/core/remote/configuration/path.rb
@@ -1,0 +1,73 @@
+# frozen_string_literal: true
+
+module Datadog
+  module Core
+    module Remote
+      class Configuration
+        class Path
+          attr_reader :source, :org_id, :product, :config_id, :name
+
+          def initialize(source:, product:, config_id:, name:, org_id: nil)
+            @source = source
+            @org_id = org_id
+            @product = product
+            @config_id = config_id
+            @name = name
+          end
+
+          def to_s
+            "#{source}/#{product}/#{config_id}/#{name}"
+          end
+
+          def ==(other)
+            return false unless other.is_a?(Path)
+
+            to_s == other.to_s
+          end
+
+          def hash
+            to_s.hash
+          end
+
+          def eql?(other)
+            hash == other.hash
+          end
+
+          class << self
+            RE = %r{
+              ^
+              (?<source>
+                datadog/(?<org_id>\d+)
+                |
+                employee
+              )
+              /
+              (?<product>[^/]+)
+              /
+              (?<config_id>[^/]+)
+              /
+              (?<name>config)
+              $
+            }mx.freeze
+
+            def parse(path)
+              m = RE.match(path)
+
+              raise ParseError, "could not parse: #{path.inspect}" if m.nil?
+
+              source = m['source']
+              org_id = Integer(m['org_id']) unless m['org_id'].nil?
+              product = m['product']
+              config_id = m['config_id']
+              name = m['name']
+
+              new(source: source, org_id: org_id, product: product, config_id: config_id, name: name)
+            end
+          end
+
+          class ParseError < StandardError; end
+        end
+      end
+    end
+  end
+end

--- a/lib/datadog/core/remote/configuration/target.rb
+++ b/lib/datadog/core/remote/configuration/target.rb
@@ -1,0 +1,109 @@
+# frozen_string_literal: true
+
+require 'digest/sha2'
+
+module Datadog
+  module Core
+    module Remote
+      class Configuration
+        class Target
+          def initialize(digests:, length:)
+            @digests = digests
+            @length = length
+          end
+
+          def check(content)
+            @digests.check(content.data)
+          end
+
+          class << self
+            def parse(hash)
+              length = Integer(hash['length'])
+              digests = DigestList.parse(hash['hashes'])
+
+              new(digests: digests, length: length)
+            end
+          end
+
+          class Digest
+            attr_reader :type, :hexdigest
+
+            def initialize(type, hexdigest)
+              @type = type.to_sym
+              @hexdigest = hexdigest
+            end
+
+            def check(data)
+              case @type
+              when :sha256
+                chunked_hexdigest(data) == hexdigest
+              else
+                fail
+              end
+            ensure
+              data.rewind
+            end
+
+            private
+
+            DIGEST_CHUNK = 1024
+
+            def chunked_hexdigest(io)
+              d = ::Digest::SHA256.new
+
+              while (buf = io.read(DIGEST_CHUNK))
+                d.update(buf)
+              end
+
+              d.hexdigest
+            end
+          end
+
+          class DigestList < Array
+            def check(data)
+              map { |digest| digest.check(data) }.reduce(:&)
+            end
+
+            class << self
+              def parse(hash)
+                new.concat(hash.map { |type, hexdigest| Digest.new(type, hexdigest) })
+              end
+            end
+          end
+        end
+
+        class TargetMap < Hash
+          attr_reader :opaque_backend_state, :version
+
+          def initialize
+            super
+
+            @opaque_backend_state = nil
+            @version = nil
+          end
+
+          class << self
+            def parse(hash)
+              opaque_backend_state = hash['signed']['custom']['opaque_backend_state']
+              version = hash['signed']['version']
+
+              map = new
+
+              map.instance_eval do
+                @opaque_backend_state = opaque_backend_state
+                @version = version
+              end
+
+              hash['signed']['targets'].each_with_object(map) do |(p, t), m|
+                path = Configuration::Path.parse(p)
+                target = Configuration::Target.parse(t)
+
+                m[path] = target
+              end
+            end
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/datadog/core/remote/configuration/target.rb
+++ b/lib/datadog/core/remote/configuration/target.rb
@@ -1,87 +1,13 @@
 # frozen_string_literal: true
 
 require 'digest/sha2'
+require_relative 'path'
 
 module Datadog
   module Core
     module Remote
       class Configuration
-        class Target
-          def initialize(digests:, length:)
-            @digests = digests
-            @length = length
-          end
-
-          def check(content)
-            @digests.check(content.data)
-          end
-
-          class << self
-            def parse(hash)
-              length = Integer(hash['length'])
-              digests = DigestList.parse(hash['hashes'])
-
-              new(digests: digests, length: length)
-            end
-          end
-
-          class Digest
-            attr_reader :type, :hexdigest
-
-            def initialize(type, hexdigest)
-              @type = type.to_sym
-              @hexdigest = hexdigest
-            end
-
-            def check(data)
-              case @type
-              when :sha256
-                chunked_hexdigest(data) == hexdigest
-              else
-                fail
-              end
-            ensure
-              data.rewind
-            end
-
-            private
-
-            DIGEST_CHUNK = 1024
-
-            def chunked_hexdigest(io)
-              d = ::Digest::SHA256.new
-
-              while (buf = io.read(DIGEST_CHUNK))
-                d.update(buf)
-              end
-
-              d.hexdigest
-            end
-          end
-
-          class DigestList < Array
-            def check(data)
-              map { |digest| digest.check(data) }.reduce(:&)
-            end
-
-            class << self
-              def parse(hash)
-                new.concat(hash.map { |type, hexdigest| Digest.new(type, hexdigest) })
-              end
-            end
-          end
-        end
-
         class TargetMap < Hash
-          attr_reader :opaque_backend_state, :version
-
-          def initialize
-            super
-
-            @opaque_backend_state = nil
-            @version = nil
-          end
-
           class << self
             def parse(hash)
               opaque_backend_state = hash['signed']['custom']['opaque_backend_state']
@@ -102,6 +28,89 @@ module Datadog
               end
             end
           end
+
+          attr_reader :opaque_backend_state, :version
+
+          def initialize
+            super
+
+            @opaque_backend_state = nil
+            @version = nil
+          end
+
+          private_class_method :new
+        end
+
+        class Target
+          class << self
+            def parse(hash)
+              length = Integer(hash['length'])
+              digests = DigestList.parse(hash['hashes'])
+
+              new(digests: digests, length: length)
+            end
+          end
+
+          def initialize(digests:, length:)
+            @digests = digests
+            @length = length
+          end
+
+          private_class_method :new
+
+          def check(content)
+            @digests.check(content.data)
+          end
+
+          class DigestList < Array
+            class << self
+              def parse(hash)
+                new.concat(hash.map { |type, hexdigest| Digest.new(type, hexdigest) })
+              end
+            end
+
+            def check(data)
+              map { |digest| digest.check(data) }.reduce(:&)
+            end
+          end
+
+          private_constant :DigestList
+
+          class Digest
+            attr_reader :type, :hexdigest
+
+            def initialize(type, hexdigest)
+              @type = type.to_sym
+              @hexdigest = hexdigest
+            end
+
+            def check(data)
+              case @type
+              when :sha256
+                chunked_hexdigest(data) == hexdigest
+              else
+                raise
+              end
+            ensure
+              data.rewind
+            end
+
+            private
+
+            DIGEST_CHUNK = 1024
+
+            def chunked_hexdigest(io)
+              d = ::Digest::SHA256.new
+
+              while (buf = io.read(DIGEST_CHUNK))
+                d.update(buf)
+              end
+
+              d.hexdigest
+            end
+          end
+
+          private_constant :DigestList
         end
       end
     end

--- a/lib/datadog/core/remote/configuration/target.rb
+++ b/lib/datadog/core/remote/configuration/target.rb
@@ -7,6 +7,7 @@ module Datadog
   module Core
     module Remote
       class Configuration
+        # TargetMap stores information regarding Configuration::Path and Configuration::Target
         class TargetMap < Hash
           class << self
             def parse(hash)
@@ -41,6 +42,7 @@ module Datadog
           private_class_method :new
         end
 
+        # Target stores digest information
         class Target
           class << self
             def parse(hash)
@@ -51,6 +53,8 @@ module Datadog
             end
           end
 
+          attr_reader :length, :digests
+
           def initialize(digests:, length:)
             @digests = digests
             @length = length
@@ -59,9 +63,10 @@ module Datadog
           private_class_method :new
 
           def check(content)
-            @digests.check(content.data)
+            digests.check(content.data)
           end
 
+          # Represent a list of Configuration::Target::Digest
           class DigestList < Array
             class << self
               def parse(hash)
@@ -76,6 +81,7 @@ module Datadog
 
           private_constant :DigestList
 
+          # Stores and validates different cryptographic hash functions
           class Digest
             attr_reader :type, :hexdigest
 

--- a/sig/datadog/core/remote/configuration/content.rbs
+++ b/sig/datadog/core/remote/configuration/content.rbs
@@ -1,0 +1,27 @@
+module Datadog
+  module Core
+    module Remote
+      class Configuration
+        class Content
+          def self.parse: (::Hash[Symbol, untyped] hash) -> Content
+
+          attr_reader path: Configuration::Path
+
+          attr_reader data: StringIO
+
+          def initialize: (path: Configuration::Path, data: StringIO) -> void
+        end
+
+        class ContentList < Array[Content]
+          def self.parse: (::Array[::Hash[Symbol, untyped]] array) -> ContentList
+
+          def find_content: (Configuration::Path path, Configuration::Target target) -> Content?
+
+          def []: (Configuration::Path path) ->  Content?
+
+          def paths: () -> ::Array[Path]?
+        end
+      end
+    end
+  end
+end

--- a/sig/datadog/core/remote/configuration/path.rbs
+++ b/sig/datadog/core/remote/configuration/path.rbs
@@ -1,0 +1,37 @@
+module Datadog
+  module Core
+    module Remote
+      class Configuration
+        # Path stores path information
+        class Path
+          class ParseError < StandardError
+          end
+
+          RE: ::Regexp
+
+          def self.parse: (::String path) -> Path
+
+          attr_reader source: ::String
+
+          attr_reader org_id: ::Integer?
+
+          attr_reader product: ::String
+
+          attr_reader config_id: ::String
+
+          attr_reader name: ::String
+
+          def initialize: (source: ::String, product: ::String, config_id: ::String, name: ::String, ?org_id: ::Integer?) -> void
+
+          def to_s: () -> ::String
+
+          def ==: (Path other) -> bool
+
+          def hash: () -> ::Integer
+
+          def eql?: (Path other) -> bool
+        end
+      end
+    end
+  end
+end

--- a/sig/datadog/core/remote/configuration/target.rbs
+++ b/sig/datadog/core/remote/configuration/target.rbs
@@ -1,0 +1,52 @@
+module Datadog
+  module Core
+    module Remote
+      class Configuration
+        class TargetMap < Hash[Configuration::Path, Configuration::Target]
+          def self.parse: (::Hash[::String, untyped] hash) -> TargetMap
+
+          attr_reader opaque_backend_state: ::String?
+
+          attr_reader version: ::Integer?
+
+          def initialize: () -> void
+        end
+
+
+        class Target
+          attr_reader length: ::Integer
+
+          attr_reader digests: DigestList
+
+          def self.parse: (::Hash[::String, untyped] hash) -> Target
+
+          def initialize: (digests: DigestList, length: ::Integer) -> void
+
+          def check: (untyped content) -> bool
+
+          class DigestList < Array[Digest]
+            def self.parse: (::Hash[::String, untyped] hash) -> DigestList
+
+            def check: (StringIO data) -> bool
+          end
+
+          class Digest
+            attr_reader type: ::Symbol
+
+            attr_reader hexdigest: ::String
+
+            def initialize: (::String type, ::String hexdigest) -> void
+
+            def check: (StringIO data) -> bool
+
+            private
+
+            DIGEST_CHUNK: 1024
+
+            def chunked_hexdigest: (StringIO io) -> ::String
+          end
+        end
+      end
+    end
+  end
+end

--- a/spec/datadog/core/remote/configuration/content_spec.rb
+++ b/spec/datadog/core/remote/configuration/content_spec.rb
@@ -1,0 +1,115 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+require 'datadog/core/remote/configuration/content'
+require 'datadog/core/remote/configuration/target'
+
+RSpec.describe Datadog::Core::Remote::Configuration::ContentList do
+  let(:raw_target) do
+    {
+      'custom' =>
+        { 'c' => ['854b784e-64ae-4c82-ac9b-fc2aea723260'],
+          'tracer-predicates' => { 'tracer_predicates_v1' => [{ 'clientID' => '854b784e-64ae-4c82-ac9b-fc2aea723260' }] },
+          'v' => 21 },
+      'hashes' => { 'sha256' => 'c8358ce9038693fb74ad8625e4c6c563bd2afb16b4412b2c8f7dba062e9e88de' },
+      'length' => 645
+    }
+  end
+
+  let(:target) { Datadog::Core::Remote::Configuration::Target.parse(raw_target) }
+  let(:path)  { Datadog::Core::Remote::Configuration::Path.parse('datadog/603646/ASM/exclusion_filters/config') }
+
+  # rubocop:disable Layout/LineLength
+  let(:raw) { 'eyJleGNsdXNpb25zIjpbeyJjb25kaXRpb25zIjpbeyJvcGVyYXRvciI6ImlwX21hdGNoIiwicGFyYW1ldGVycyI6eyJpbnB1dHMiOlt7ImFkZHJlc3MiOiJodHRwLmNsaWVudF9pcCJ9XSwibGlzdCI6WyI0LjQuNC40Il19fV0sImlkIjoiODc0NDU5YWUtMTM3Zi00Yzk5LTljNTQtMTA5YjFhMTE3Yjg2In0seyJjb25kaXRpb25zIjpbeyJvcGVyYXRvciI6Im1hdGNoX3JlZ2V4IiwicGFyYW1ldGVycyI6eyJpbnB1dHMiOlt7ImFkZHJlc3MiOiJzZXJ2ZXIucmVxdWVzdC51cmkucmF3In1dLCJvcHRpb25zIjp7ImNhc2Vfc2Vuc2l0aXZlIjpmYWxzZX0sInJlZ2V4IjoiXi93YWYifX1dLCJpZCI6ImQxMzkwOTQ5LWNmMWEtNDA4ZC1iYzNmLTA0M2QwNjg5ZDg5ZSJ9LHsiaWQiOiI1ZmU4ZTUzMC1kM2VjLTRlNmQtYmMwNi0wYTY2MzdjNmU3NjMiLCJydWxlc190YXJnZXQiOlt7InJ1bGVfaWQiOiJ1YTAtNjAwLTU1eCJ9XX0seyJjb25kaXRpb25zIjpbeyJvcGVyYXRvciI6ImlwX21hdGNoIiwicGFyYW1ldGVycyI6eyJpbnB1dHMiOlt7ImFkZHJlc3MiOiJodHRwLmNsaWVudF9pcCJ9XSwibGlzdCI6WyI4LjguOC44Il19fV0sImlkIjoiMDgxZTFmYmUtYzczYi00YWQyLWJiODMtNDc1MjM1NDI3MWJjIn1dLCJydWxlc19vdmVycmlkZSI6W119' }
+  # rubocop:enable Layout/LineLength
+
+  let(:string_io_content) { StringIO.new(Base64.strict_decode64(raw).freeze) }
+  subject(:content_list) do
+    described_class.parse(
+      [{
+        :path => path.to_s,
+        :content => string_io_content
+      }]
+    )
+  end
+
+  describe '.parse' do
+    context 'valid data' do
+      it 'returns a ContentList instance' do
+        expect(content_list).to be_a(described_class)
+      end
+    end
+
+    context 'invalid data' do
+      it 'raises Path::ParseError' do
+        expect do
+          described_class.parse(
+            [{
+              :path => 'invalid path',
+              :content => string_io_content
+            }]
+          )
+        end.to raise_error(Datadog::Core::Remote::Configuration::Path::ParseError)
+      end
+    end
+  end
+
+  describe '#find_content' do
+    it 'returns a content instance if path and target matches' do
+      content = content_list.find_content(path, target)
+      expect(content).to be_a(Datadog::Core::Remote::Configuration::Content)
+    end
+
+    it 'returns nil if does not find a valid path' do
+      non_existing_path = Datadog::Core::Remote::Configuration::Path.parse('employee/ASM/exclusion_filters/config')
+
+      content = content_list.find_content(non_existing_path, target)
+      expect(content).to be_nil
+    end
+
+    it 'returns nil if target does not check' do
+      wrong_target = Datadog::Core::Remote::Configuration::Target.parse(
+        {
+          'custom' => {
+            'c' => ['5bb79ec4-0f50-464c-8400-b88521e1b96e'],
+            'tracer-predicates' => {
+              'tracer_predicates_v1' => [
+                {
+                  'clientID' => '5bb79ec4-0f50-464c-8400-b88521e1b96e'
+                }
+              ]
+            },
+            'v' => 245
+          },
+          'hashes' => { 'sha256' => 'e39c699e5e626da1a43369ab3e7f17cce6a21c0ce1d2261280c7f2ac61c5db1b' },
+          'length' => 4605
+        }
+      )
+
+      content = content_list.find_content(path, wrong_target)
+      expect(content).to be_nil
+    end
+  end
+
+  describe '#[]' do
+    it 'returns a content instance if path matches' do
+      content = content_list[path]
+      expect(content).to be_a(Datadog::Core::Remote::Configuration::Content)
+    end
+
+    it 'returns nil if doesn not find a match' do
+      non_existing_path = Datadog::Core::Remote::Configuration::Path.parse('employee/ASM/exclusion_filters/config')
+
+      content = content_list[non_existing_path]
+      expect(content).to be_nil
+    end
+  end
+
+  describe '#paths' do
+    it 'returns an array of paths instance' do
+      paths = content_list.paths
+      expect(paths.size).to eq(1)
+      expect(paths[0].to_s).to eq('datadog/603646/ASM/exclusion_filters/config')
+    end
+  end
+end

--- a/spec/datadog/core/remote/configuration/path_spec.rb
+++ b/spec/datadog/core/remote/configuration/path_spec.rb
@@ -1,0 +1,57 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+require 'datadog/core/remote/configuration/path'
+
+RSpec.describe Datadog::Core::Remote::Configuration::Path do
+  describe '.parse' do
+    context 'invalid path' do
+      it 'raises ParseError' do
+        expect { described_class.parse('invalid_path') }.to raise_error(described_class::ParseError)
+      end
+    end
+
+    context 'valid path' do
+      it 'returns a Path instance' do
+        path = described_class.parse('datadog/123/ASM/blocked_ips/config')
+        expect(path).to be_a(described_class)
+        expect(path.source).to eq('datadog')
+        expect(path.org_id).to eq(123)
+        expect(path.product).to eq('ASM')
+        expect(path.config_id).to eq('blocked_ips')
+        expect(path.name).to eq('config')
+      end
+
+      it 'returns an emplyee Path instance without org_id' do
+        path = described_class.parse('employee/ASM/blocked_ips/config')
+        expect(path).to be_a(described_class)
+        expect(path.source).to eq('employee')
+        expect(path.org_id).to be_nil
+        expect(path.product).to eq('ASM')
+        expect(path.config_id).to eq('blocked_ips')
+        expect(path.name).to eq('config')
+      end
+    end
+  end
+
+  describe '#==' do
+    it 'returns if two path are the same' do
+      path1 = described_class.parse('datadog/123/ASM/blocked_ips/config')
+      path1dup = path1.dup
+      path2 = described_class.parse('employee/ASM/blocked_ips/config')
+
+      expect(path1 == path1dup).to be_truthy
+      expect(path1 == path2).to be_falsy
+    end
+  end
+
+  describe '#eql?' do
+    it 'returns if two path are the same' do
+      path1 = described_class.parse('datadog/123/ASM/blocked_ips/config')
+      path2 = described_class.parse('employee/ASM/blocked_ips/config')
+
+      expect(path1).to be_eql(path1)
+      expect(path1).not_to be_eql(path2)
+    end
+  end
+end

--- a/spec/datadog/core/remote/configuration/target_spec.rb
+++ b/spec/datadog/core/remote/configuration/target_spec.rb
@@ -1,0 +1,171 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+require 'datadog/core/remote/configuration/target'
+
+RSpec.describe Datadog::Core::Remote::Configuration::TargetMap do
+  let(:version) { 46761194 }
+  let(:opaque_backend_state) { 'eyJ2ZXJzaW9uIjoyLCJzdGF0ZSI6eyJmaWxlX2hhc2hlcyI6eyJkYXRhZG3FOMU44PSJdfX19' }
+
+  # rubocop:disable Layout/LineLength
+  let(:raw_target) do
+    {
+      'signatures' => [
+        {
+          'keyid' => '44de082b06652b24c3ccfecba7dcbdb82f1cc58e3813f824665a6085a6d6b6a3',
+          'sig' => '0a66cbda8de50af143708a8811892786727260b707144b910c07d00e7950d01804835dbd56e789fe8f89f1d0355bb653b8f2a8e41ab90f24d88f2c458438cd00'
+        }
+      ],
+      'signed' =>
+        {
+          '_type' => 'targets',
+          'custom' => {
+            'agent_refresh_interval' => 50,
+            'opaque_backend_state' => opaque_backend_state
+          },
+          'expires' => '2023-06-15T15:25:56Z',
+          'spec_version' => '1.0.0',
+          'targets' => {
+            'datadog/603646/ASM/blocking/config' => {
+              'custom' => {
+                'c' => ['5bb79ec4-0f50-464c-8400-b88521e1b96e'],
+                'tracer-predicates' => {
+                  'tracer_predicates_v1' => [
+                    {
+                      'clientID' => '5bb79ec4-0f50-464c-8400-b88521e1b96e'
+                    }
+                  ]
+                },
+                'v' => 245
+              },
+              'hashes' => { 'sha256' => 'e39c699e5e626da1a43369ab3e7f17cce6a21c0ce1d2261280c7f2ac61c5db1b' },
+              'length' => 4605
+            },
+            'datadog/603646/ASM/exclusion_filters/config' => {
+              'custom' => {
+                'c' => ['5bb79ec4-0f50-464c-8400-b88521e1b96e'],
+                'tracer-predicates' => {
+                  'tracer_predicates_v1' => [
+                    {
+                      'clientID' => '5bb79ec4-0f50-464c-8400-b88521e1b96e'
+                    }
+                  ]
+                }, 'v' => 21
+              },
+              'hashes' => { 'sha256' => 'c8358ce9038693fb74ad8625e4c6c563bd2afb16b4412b2c8f7dba062e9e88de' },
+              'length' => 645
+            },
+          },
+          'version' => version,
+        }
+    }
+  end
+  # rubocop:enable Layout/LineLength
+
+  describe '.parse' do
+    context 'with valid target hash' do
+      it 'returns a TargetMap instance' do
+        target_map = described_class.parse(raw_target)
+        expect(target_map).to be_a(described_class)
+
+        expect(target_map.opaque_backend_state).to eq(opaque_backend_state)
+        expect(target_map.version).to eq(version)
+      end
+
+      it 'uses path instances as key and target instance as value' do
+        target_map = described_class.parse(raw_target)
+
+        path = Datadog::Core::Remote::Configuration::Path.parse('datadog/603646/ASM/exclusion_filters/config')
+        expect(target_map[path]).to be_a(Datadog::Core::Remote::Configuration::Target)
+
+        not_present_path = Datadog::Core::Remote::Configuration::Path.parse('employee/ASM_DD/17.recommended.json/config')
+        expect(target_map[not_present_path]).to be_nil
+      end
+    end
+
+    context 'with valid target path' do
+      it 'raises Path::ParseError' do
+        invalid_data = {
+          'signatures' => [
+            {
+              'keyid' => '44de082b06652b24c3ccfecba7dcbdb82f1cc58e3813f824665a6085a6d6b6a3',
+              'sig' => '0a66cbda8de50af143708a881189278672'
+            }
+          ],
+          'signed' =>
+            {
+              '_type' => 'targets',
+              'custom' => {
+                'agent_refresh_interval' => 50,
+                'opaque_backend_state' => opaque_backend_state
+              },
+              'expires' => '2023-06-15T15:25:56Z',
+              'spec_version' => '1.0.0',
+              'targets' => {
+                'invalid_path' => {}
+              },
+              'version' => version,
+            }
+        }
+
+        expect { described_class.parse(invalid_data) }.to raise_error(
+          Datadog::Core::Remote::Configuration::Path::ParseError
+        )
+      end
+    end
+  end
+end
+
+RSpec.describe Datadog::Core::Remote::Configuration::Target do
+  let(:raw_target) do
+    {
+      'custom' =>
+        { 'c' => ['854b784e-64ae-4c82-ac9b-fc2aea723260'],
+          'tracer-predicates' => { 'tracer_predicates_v1' => [{ 'clientID' => '854b784e-64ae-4c82-ac9b-fc2aea723260' }] },
+          'v' => 21 },
+      'hashes' => { 'sha256' => 'c8358ce9038693fb74ad8625e4c6c563bd2afb16b4412b2c8f7dba062e9e88de' },
+      'length' => 645
+    }
+  end
+
+  subject(:target) { described_class.parse(raw_target) }
+
+  describe '.parse' do
+    context 'with valid target' do
+      it 'returns a Target instance' do
+        expect(target).to be_a(described_class)
+      end
+    end
+  end
+
+  describe '#check' do
+    context 'valid content' do
+      it 'returns true' do
+        # rubocop:disable Layout/LineLength
+        raw = 'eyJleGNsdXNpb25zIjpbeyJjb25kaXRpb25zIjpbeyJvcGVyYXRvciI6ImlwX21hdGNoIiwicGFyYW1ldGVycyI6eyJpbnB1dHMiOlt7ImFkZHJlc3MiOiJodHRwLmNsaWVudF9pcCJ9XSwibGlzdCI6WyI0LjQuNC40Il19fV0sImlkIjoiODc0NDU5YWUtMTM3Zi00Yzk5LTljNTQtMTA5YjFhMTE3Yjg2In0seyJjb25kaXRpb25zIjpbeyJvcGVyYXRvciI6Im1hdGNoX3JlZ2V4IiwicGFyYW1ldGVycyI6eyJpbnB1dHMiOlt7ImFkZHJlc3MiOiJzZXJ2ZXIucmVxdWVzdC51cmkucmF3In1dLCJvcHRpb25zIjp7ImNhc2Vfc2Vuc2l0aXZlIjpmYWxzZX0sInJlZ2V4IjoiXi93YWYifX1dLCJpZCI6ImQxMzkwOTQ5LWNmMWEtNDA4ZC1iYzNmLTA0M2QwNjg5ZDg5ZSJ9LHsiaWQiOiI1ZmU4ZTUzMC1kM2VjLTRlNmQtYmMwNi0wYTY2MzdjNmU3NjMiLCJydWxlc190YXJnZXQiOlt7InJ1bGVfaWQiOiJ1YTAtNjAwLTU1eCJ9XX0seyJjb25kaXRpb25zIjpbeyJvcGVyYXRvciI6ImlwX21hdGNoIiwicGFyYW1ldGVycyI6eyJpbnB1dHMiOlt7ImFkZHJlc3MiOiJodHRwLmNsaWVudF9pcCJ9XSwibGlzdCI6WyI4LjguOC44Il19fV0sImlkIjoiMDgxZTFmYmUtYzczYi00YWQyLWJiODMtNDc1MjM1NDI3MWJjIn1dLCJydWxlc19vdmVycmlkZSI6W119'
+        # rubocop:enable Layout/LineLength
+        string_io_content = StringIO.new(Base64.strict_decode64(raw).freeze)
+
+        content_hash = {
+          :path => 'datadog/603646/ASM/exclusion_filters/config',
+          :content => string_io_content
+        }
+        content = Datadog::Core::Remote::Configuration::Content.parse(content_hash)
+
+        expect(target.check(content)).to be_truthy
+      end
+    end
+
+    context 'invalid content' do
+      it 'returns false' do
+        content_hash = {
+          :path => 'datadog/603646/ASM/exclusion_filters/config',
+          :content => StringIO.new('Hello World')
+        }
+        content = Datadog::Core::Remote::Configuration::Content.parse(content_hash)
+
+        expect(target.check(content)).to be_falsy
+      end
+    end
+  end
+end


### PR DESCRIPTION

<!--
Check out the
https://github.com/DataDog/dd-trace-rb/blob/master/docs/DevelopmentGuide.md
for guidance on how to set up your development environment,
run the test suite, write new integrations, and more.
-->

**What does this PR do?**

Add PORO objects for remote configuration response data coming from #2678

**Motivation**

Remote configuration

**Additional Notes**

These objects correspond to the data being received by the `/v0.7/config` endpoint.

The parse class methods whould probably move out to be part of transport, but:

- having them here makes the implementation simpler
- transport is due for a redesign, and the responsibility of it is a bit unclear currently

**How to test the change?**
<!--
Describe here how the change can be validated.
You are strongly encouraged to provide automated tests for this PR (unit or integration).
If this change cannot be feasibly tested, please explain why,
unless the change does not modify code (e.g. only modifies docs, comments).
-->

Directly:

```
require 'datadog/core/remote/configuration/path'
require 'datadog/core/remote/configuration/target'
require 'datadog/core/remote/configuration/content'

path = Datadog::Core::Remote::Configuration::Path.parse('datadog/42/PRODUCT/foo/config')
path.config_id
path.name
path.org_id
path.product
path.source
content = Datadog::Core::Remote::Configuration::Content.parse({path: 'datadog/42/PRODUCT/foo/config', content: StringIO.new('Lorem ipsum')})
content.path
content.data.read
content.data.rewind
digest = Datadog::Core::Remote::Configuration::Target::Digest.new(:sha256, 'a9a66978f378456c818fb8a3e7c6ad3d2c83e62724ccbdea7b36253fb8df5edd')
digest.type
digest.hexdigest
digest.check(content.data)
digest_list = Datadog::Core::Remote::Configuration::Target::DigestList.parse({'sha256' => 'a9a66978f378456c818fb8a3e7c6ad3d2c83e62724ccbdea7b36253fb8df5edd'})
digest_list.check(content.data)
target = Datadog::Core::Remote::Configuration::Target.parse({'length' => 11, 'hashes' => {'sha256' => 'a9a66978f378456c818fb8a3e7c6ad3d2c83e62724ccbdea7b36253fb8df5edd'}})
target.check(content)
content_list = Datadog::Core::Remote::Configuration::ContentList.parse([{path: 'datadog/42/PRODUCT/foo/config', content: StringIO.new('Lorem ipsum')}])
content_list.paths
content_list.find(path, target)
target_map = Datadog::Core::Remote::Configuration::TargetMap.parse(
  {
    'signed' => {
      'custom' => {
        'opaque_backend_state' => 'OPAQUE_DATA'
      },
      'targets' => {
        'datadog/42/PRODUCT/foo/config' => {'length' => 11, 'hashes' => {'sha256' => 'a9a66978f378456c818fb8a3e7c6ad3d2c83e62724ccbdea7b36253fb8df5edd'}}
      },
      'version' => 42,
    }
  }
)
target_map.version
target_map.opaque_backend_state
target_map[path]
target_map.map { |p, t| content_list.find(p, t) }
```

With the `/v0.7/config` endpoint:

```
require 'ddtrace'

Datadog.configure do |c|
    c.agent.host = '192.168.135.133'
    # c.diagnostics.debug = true
end

transport_options = {
  agent_settings: Datadog::Core::Configuration::AgentSettingsResolver.call(Datadog.configuration)
}

require 'datadog/core/transport/http'

transport_v7 = Datadog::Core::Transport::HTTP.v7(**transport_options.dup)

CAP_ASM_ACTIVATION                = 1 << 1 # Remote activation via ASM_FEATURES product
CAP_ASM_IP_BLOCKING               = 1 << 2 # accept IP blocking data from ASM_DATA product
CAP_ASM_DD_RULES                  = 1 << 3 # read ASM rules from ASM_DD product
CAP_ASM_EXCLUSIONS                = 1 << 4 # exclusion filters (passlist) via ASM product
CAP_ASM_REQUEST_BLOCKING          = 1 << 5 # can block on request info
CAP_ASM_RESPONSE_BLOCKING         = 1 << 6 # can block on response info
CAP_ASM_USER_BLOCKING             = 1 << 7 # accept user blocking data from ASM_DATA product
CAP_ASM_CUSTOM_RULES              = 1 << 8 # accept custom rules
CAP_ASM_CUSTOM_BLOCKING_RESPONSE  = 1 << 9 # supports custom http code or redirect sa blocking response

capabilities = [
  CAP_ASM_IP_BLOCKING,
  CAP_ASM_USER_BLOCKING,
  CAP_ASM_CUSTOM_RULES,
  CAP_ASM_EXCLUSIONS,
  CAP_ASM_REQUEST_BLOCKING,
  CAP_ASM_RESPONSE_BLOCKING,
  CAP_ASM_DD_RULES,
].reduce(&:|)

capabilities_binary = capabilities
  .to_s(16)
  .tap { |s| s.size.odd? && s.prepend('0') }
  .scan(/\h\h/)
  .map { |e| e.to_i(16) }
  .pack('C*')

products = [
  'ASM_DD',       # Datadog employee issued configuration
  'ASM',          # customer issued configuration (rulesets, passlist...)
  'ASM_FEATURES', # capabilities
  'ASM_DATA',     # config files (IP addresses or users for blocking)
]

state = OpenStruct.new(
  {
    root_version: 1,              # unverified mode, so 1
    targets_version: 0,           # from scratch, so zero
    config_states: [],            # from scratch, so empty
    has_error: false,             # from scratch, so false
    error: '',                    # from scratch, so blank
    opaque_backend_state: '',     # from scratch, so blank
  }
)

id = SecureRandom.uuid # client id

payload = {
  client: {
    state: {
      root_version:         state.root_version,
      targets_version:      state.targets_version,
      config_states:        state.config_states,
      has_error:            state.has_error,
      error:                state.error,
      backend_client_state: state.opaque_backend_state,
    },
    id: id,
    products: products,
    is_tracer: true,
    is_agent: false,
    client_tracer: {
      runtime_id:      Datadog::Core::Environment::Identity.id,
      language:        Datadog::Core::Environment::Identity.lang,
      tracer_version:  Datadog::Core::Environment::Identity.tracer_version,
      service:         Datadog.configuration.service,
      env:             Datadog.configuration.env,
    # app_version:     app_version,   # TODO: I don't know where this is in the tracer
      tags:            [],            # TODO: add nice tags!
    },
    # base64 is needed otherwise the Go agent fails with an unmarshal error
    capabilities: Base64.encode64(capabilities_binary).chomp,
  },
  cached_target_files: [
  # {
  #   path: '',
  #   length: 0,
  #   hashes: '';
  # }
  ],
}

res = transport_v7.send_config(payload)

require 'datadog/core/remote/configuration/path'
require 'datadog/core/remote/configuration/target'
require 'datadog/core/remote/configuration/content'


res.client_configs.map { |p| Datadog::Core::Remote::Configuration::Path.parse(p) }
Datadog::Core::Remote::Configuration::ContentList.parse(res.target_files)
Datadog::Core::Remote::Configuration::TargetMap.parse(res.targets)
```