### PR TITLE
Add remote configuration repository

### DIFF
--- a/lib/datadog/core/remote/configuration/repository.rb
+++ b/lib/datadog/core/remote/configuration/repository.rb
@@ -1,5 +1,7 @@
 # frozen_string_literal: true
 
+require_relative 'content'
+
 module Datadog
   module Core
     module Remote
@@ -130,22 +132,22 @@ module Datadog
             end
 
             class Set
+              attr_reader :opaque_backend_state, :targets_version
+
               def initialize(**options)
                 @opaque_backend_state = options[:opaque_backend_state]
                 @targets_version = options[:targets_version]
               end
 
               def apply(repository)
-                if @opaque_backend_state
-                  repository.instance_variable_set(:@opaque_backend_state, @opaque_backend_state)
-                end
+                repository.instance_variable_set(:@opaque_backend_state, @opaque_backend_state) if @opaque_backend_state
 
-                if @targets_version
-                  repository.instance_variable_set(:@targets_version, @targets_version)
-                end
+                repository.instance_variable_set(:@targets_version, @targets_version) if @targets_version
               end
             end
           end
+
+          private_constant :Operation
         end
       end
     end

--- a/lib/datadog/core/remote/configuration/repository.rb
+++ b/lib/datadog/core/remote/configuration/repository.rb
@@ -95,15 +95,8 @@ module Datadog
 
           # Operation
           module Operation
-            # Base
-            class Base
-              def apply(repository)
-                raise NoMethodError
-              end
-            end
-
             # Delete contents base on path
-            class Delete < Base
+            class Delete
               attr_reader :path
 
               def initialize(path)
@@ -117,7 +110,7 @@ module Datadog
             end
 
             # Insert content into the reporistory contents
-            class Insert < Base
+            class Insert
               attr_reader :path, :target, :content
 
               def initialize(path, target, content)
@@ -133,7 +126,7 @@ module Datadog
             end
 
             # Update existimng repository's contents
-            class Update < Base
+            class Update
               attr_reader :path, :target, :content
 
               def initialize(path, target, content)
@@ -149,7 +142,7 @@ module Datadog
             end
 
             # Set repository metadata
-            class Set < Base
+            class Set
               attr_reader :opaque_backend_state, :targets_version
 
               def initialize(**options)

--- a/lib/datadog/core/remote/configuration/repository.rb
+++ b/lib/datadog/core/remote/configuration/repository.rb
@@ -1,0 +1,153 @@
+# frozen_string_literal: true
+
+module Datadog
+  module Core
+    module Remote
+      class Configuration
+        class Repository
+          attr_reader \
+            :contents,
+            :opaque_backend_state,
+            :root_version,
+            :targets_version
+
+          UNVERIFIED_ROOT_VERSION = 1
+          INITIAL_TARGETS_VERSION = 0
+
+          def initialize
+            @contents = ContentList.new
+            @opaque_backend_state = nil
+            @root_version = UNVERIFIED_ROOT_VERSION
+            @targets_version = INITIAL_TARGETS_VERSION
+          end
+
+          def paths
+            @contents.paths
+          end
+
+          def [](path)
+            @contents[path]
+          end
+
+          def transaction
+            transaction = Transaction.new
+
+            yield(self, transaction)
+
+            commit(transaction)
+          end
+
+          def commit(transaction)
+            transaction.operations.each { |op| op.apply(self) }
+          end
+
+          def state
+            State.new(self)
+          end
+
+          class State
+            attr_reader \
+              :root_version,
+              :targets_version,
+              :config_states,
+              :has_error,
+              :error,
+              :opaque_backend_state
+
+            def initialize(repository)
+              @root_version = repository.root_version
+              @targets_version = repository.targets_version
+              @config_states = []
+              @has_error = false
+              @error = ''
+              @opaque_backend_state = repository.opaque_backend_state
+            end
+          end
+
+          class Transaction
+            attr_reader :operations
+
+            def initialize
+              @operations = []
+            end
+
+            def delete(path)
+              @operations << Operation::Delete.new(path)
+            end
+
+            def insert(path, target, content)
+              @operations << Operation::Insert.new(path, target, content)
+            end
+
+            def update(path, target, content)
+              @operations << Operation::Update.new(path, target, content)
+            end
+
+            def set(**options)
+              @operations << Operation::Set.new(**options)
+            end
+          end
+
+          module Operation
+            class Delete
+              attr_reader :path
+
+              def initialize(path)
+                @path = path
+              end
+
+              def apply(repository)
+                repository.contents.reject! { |c| c.path.eql?(@path) }
+              end
+            end
+
+            class Insert
+              attr_reader :path, :target, :content
+
+              def initialize(path, target, content)
+                @path = path
+                @target = target
+                @content = content
+              end
+
+              def apply(repository)
+                repository.contents << @content if repository[path].nil?
+              end
+            end
+
+            class Update
+              attr_reader :path, :target, :content
+
+              def initialize(path, target, content)
+                @path = path
+                @target = target
+                @content = content
+              end
+
+              def apply(repository)
+                repository.contents.map! { |c| c.path.eql?(@path) ? @content : c }
+              end
+            end
+
+            class Set
+              def initialize(**options)
+                @opaque_backend_state = options[:opaque_backend_state]
+                @targets_version = options[:targets_version]
+              end
+
+              def apply(repository)
+                if @opaque_backend_state
+                  repository.instance_variable_set(:@opaque_backend_state, @opaque_backend_state)
+                end
+
+                if @targets_version
+                  repository.instance_variable_set(:@targets_version, @targets_version)
+                end
+              end
+            end
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/datadog/core/remote/configuration/repository.rb
+++ b/lib/datadog/core/remote/configuration/repository.rb
@@ -6,6 +6,7 @@ module Datadog
   module Core
     module Remote
       class Configuration
+        # Repository
         class Repository
           attr_reader \
             :contents,
@@ -47,6 +48,7 @@ module Datadog
             State.new(self)
           end
 
+          # State store the repository state
           class State
             attr_reader \
               :root_version,
@@ -66,6 +68,7 @@ module Datadog
             end
           end
 
+          # Encapsulates transaction operations
           class Transaction
             attr_reader :operations
 
@@ -90,13 +93,16 @@ module Datadog
             end
           end
 
+          # Operation
           module Operation
+            # Base
             class Base
               def apply(repository)
                 raise NoMethodError
               end
             end
 
+            # Delete contents base on path
             class Delete < Base
               attr_reader :path
 
@@ -110,6 +116,7 @@ module Datadog
               end
             end
 
+            # Insert content into the reporistory contents
             class Insert < Base
               attr_reader :path, :target, :content
 
@@ -125,6 +132,7 @@ module Datadog
               end
             end
 
+            # Update existimng repository's contents
             class Update < Base
               attr_reader :path, :target, :content
 
@@ -140,6 +148,7 @@ module Datadog
               end
             end
 
+            # Set repository metadata
             class Set < Base
               attr_reader :opaque_backend_state, :targets_version
 

--- a/lib/datadog/core/remote/configuration/repository.rb
+++ b/lib/datadog/core/remote/configuration/repository.rb
@@ -91,10 +91,17 @@ module Datadog
           end
 
           module Operation
-            class Delete
+            class Base
+              def apply(repository)
+                raise NoMethodError
+              end
+            end
+
+            class Delete < Base
               attr_reader :path
 
               def initialize(path)
+                super()
                 @path = path
               end
 
@@ -103,10 +110,11 @@ module Datadog
               end
             end
 
-            class Insert
+            class Insert < Base
               attr_reader :path, :target, :content
 
               def initialize(path, target, content)
+                super()
                 @path = path
                 @target = target
                 @content = content
@@ -117,10 +125,11 @@ module Datadog
               end
             end
 
-            class Update
+            class Update < Base
               attr_reader :path, :target, :content
 
               def initialize(path, target, content)
+                super()
                 @path = path
                 @target = target
                 @content = content
@@ -131,10 +140,11 @@ module Datadog
               end
             end
 
-            class Set
+            class Set < Base
               attr_reader :opaque_backend_state, :targets_version
 
               def initialize(**options)
+                super()
                 @opaque_backend_state = options[:opaque_backend_state]
                 @targets_version = options[:targets_version]
               end

--- a/sig/datadog/core/remote/configuration/repository.rbs
+++ b/sig/datadog/core/remote/configuration/repository.rbs
@@ -44,7 +44,7 @@ module Datadog
           end
 
           class Transaction
-            attr_reader operations: Array[Operation::Base]
+            attr_reader operations: Array[operation]
 
             def initialize: () -> void
 
@@ -57,12 +57,10 @@ module Datadog
             def set: (**untyped options) -> void
           end
 
-          module Operation
-            class Base
-              def apply: (Repository repository) -> void
-            end
+          type operation = Operation::Insert | Operation::Update | Operation::Delete | Operation::Set
 
-            class Delete < Base
+          module Operation
+            class Delete
               attr_reader path: Configuration::Path
 
               def initialize: (Configuration::Path path) -> void
@@ -70,7 +68,7 @@ module Datadog
               def apply: (Repository repository) -> void
             end
 
-            class Insert < Base
+            class Insert
               attr_reader path: Configuration::Path
 
               attr_reader target: Configuration::Target
@@ -82,7 +80,7 @@ module Datadog
               def apply: (Repository repository) -> void
             end
 
-            class Update < Base
+            class Update
               attr_reader path: Configuration::Path
 
               attr_reader target: Configuration::Target
@@ -94,7 +92,7 @@ module Datadog
               def apply: (Repository repository) -> void
             end
 
-            class Set < Base
+            class Set
               attr_reader opaque_backend_state: String?
 
               attr_reader targets_version: String?

--- a/sig/datadog/core/remote/configuration/repository.rbs
+++ b/sig/datadog/core/remote/configuration/repository.rbs
@@ -1,0 +1,111 @@
+module Datadog
+  module Core
+    module Remote
+      class Configuration
+        class Repository
+          attr_reader contents: ContentList
+
+          attr_reader opaque_backend_state: String?
+
+          attr_reader root_version: Integer
+
+          attr_reader targets_version: Integer
+
+          UNVERIFIED_ROOT_VERSION: 1
+
+          INITIAL_TARGETS_VERSION: 0
+
+          def initialize: () -> void
+
+          def paths: () -> ::Array[Path]?
+
+          def []: (Configuration::Path path) -> Content?
+
+          def transaction: () { (Repository, Transaction) -> void } -> void
+
+          def commit: (Transaction transaction) -> void
+
+          def state: () -> State
+
+          class State
+            attr_reader root_version: Integer
+
+            attr_reader targets_version: Integer
+
+            attr_reader config_states: Array[untyped]
+
+            attr_reader has_error: bool
+
+            attr_reader error: String
+
+            attr_reader opaque_backend_state: String?
+
+            def initialize: (Repository repository) -> void
+          end
+
+          class Transaction
+            attr_reader operations: Array[Operation::Base]
+
+            def initialize: () -> void
+
+            def delete: (Configuration::Path path) -> void
+
+            def insert: (Configuration::Path path, Configuration::Target target, Configuration::Content content) -> void
+
+            def update: (Configuration::Path path, Configuration::Target target, Configuration::Content content) -> void
+
+            def set: (**untyped options) -> void
+          end
+
+          module Operation
+            class Base
+              def apply: (Repository repository) -> void
+            end
+
+            class Delete < Base
+              attr_reader path: Configuration::Path
+
+              def initialize: (Configuration::Path path) -> void
+
+              def apply: (Repository repository) -> void
+            end
+
+            class Insert < Base
+              attr_reader path: Configuration::Path
+
+              attr_reader target: Configuration::Target
+
+              attr_reader content: Configuration::Content
+
+              def initialize: (Configuration::Path path, Configuration::Target target, Configuration::Content content) -> void
+
+              def apply: (Repository repository) -> void
+            end
+
+            class Update < Base
+              attr_reader path: Configuration::Path
+
+              attr_reader target: Configuration::Target
+
+              attr_reader content: Configuration::Content
+
+              def initialize: (Configuration::Path path, Configuration::Target target, Configuration::Content content) -> void
+
+              def apply: (Repository repository) -> void
+            end
+
+            class Set < Base
+              attr_reader opaque_backend_state: String?
+
+              attr_reader targets_version: String?
+
+              def initialize: (**untyped options) -> void
+
+              def apply: (Repository repository) -> void
+            end
+          end
+        end
+      end
+    end
+  end
+end

--- a/spec/datadog/core/remote/configuration/respository_spec.rb
+++ b/spec/datadog/core/remote/configuration/respository_spec.rb
@@ -41,7 +41,9 @@ RSpec.describe Datadog::Core::Remote::Configuration::Repository do
     end
 
     it 'commits transaction' do
-      expect(repository).to receive(:commit).with(instance_of(Datadog::Core::Remote::Configuration::Repository::Transaction))
+      expect(repository).to receive(:commit).with(
+        instance_of(Datadog::Core::Remote::Configuration::Repository::Transaction)
+      )
       repository.transaction(&proc {})
     end
 

--- a/spec/datadog/core/remote/configuration/respository_spec.rb
+++ b/spec/datadog/core/remote/configuration/respository_spec.rb
@@ -1,0 +1,172 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+require 'datadog/core/remote/configuration/repository'
+require 'datadog/core/remote/configuration/target'
+
+RSpec.describe Datadog::Core::Remote::Configuration::Repository do
+  subject(:repository) { described_class.new }
+  let(:raw_target) do
+    {
+      'custom' =>
+        { 'c' => ['854b784e-64ae-4c82-ac9b-fc2aea723260'],
+          'tracer-predicates' => { 'tracer_predicates_v1' => [{ 'clientID' => '854b784e-64ae-4c82-ac9b-fc2aea723260' }] },
+          'v' => 21 },
+      'hashes' => { 'sha256' => 'c8358ce9038693fb74ad8625e4c6c563bd2afb16b4412b2c8f7dba062e9e88de' },
+      'length' => 645
+    }
+  end
+
+  let(:target) { Datadog::Core::Remote::Configuration::Target.parse(raw_target) }
+  let(:path)  { Datadog::Core::Remote::Configuration::Path.parse('datadog/603646/ASM/exclusion_filters/config') }
+
+  # rubocop:disable Layout/LineLength
+  let(:raw) { 'eyJleGNsdXNpb25zIjpbeyJjb25kaXRpb25zIjpbeyJvcGVyYXRvciI6ImlwX21hdGNoIiwicGFyYW1ldGVycyI6eyJpbnB1dHMiOlt7ImFkZHJlc3MiOiJodHRwLmNsaWVudF9pcCJ9XSwibGlzdCI6WyI0LjQuNC40Il19fV0sImlkIjoiODc0NDU5YWUtMTM3Zi00Yzk5LTljNTQtMTA5YjFhMTE3Yjg2In0seyJjb25kaXRpb25zIjpbeyJvcGVyYXRvciI6Im1hdGNoX3JlZ2V4IiwicGFyYW1ldGVycyI6eyJpbnB1dHMiOlt7ImFkZHJlc3MiOiJzZXJ2ZXIucmVxdWVzdC51cmkucmF3In1dLCJvcHRpb25zIjp7ImNhc2Vfc2Vuc2l0aXZlIjpmYWxzZX0sInJlZ2V4IjoiXi93YWYifX1dLCJpZCI6ImQxMzkwOTQ5LWNmMWEtNDA4ZC1iYzNmLTA0M2QwNjg5ZDg5ZSJ9LHsiaWQiOiI1ZmU4ZTUzMC1kM2VjLTRlNmQtYmMwNi0wYTY2MzdjNmU3NjMiLCJydWxlc190YXJnZXQiOlt7InJ1bGVfaWQiOiJ1YTAtNjAwLTU1eCJ9XX0seyJjb25kaXRpb25zIjpbeyJvcGVyYXRvciI6ImlwX21hdGNoIiwicGFyYW1ldGVycyI6eyJpbnB1dHMiOlt7ImFkZHJlc3MiOiJodHRwLmNsaWVudF9pcCJ9XSwibGlzdCI6WyI4LjguOC44Il19fV0sImlkIjoiMDgxZTFmYmUtYzczYi00YWQyLWJiODMtNDc1MjM1NDI3MWJjIn1dLCJydWxlc19vdmVycmlkZSI6W119' }
+  # rubocop:enable Layout/LineLength
+
+  let(:string_io_content) { StringIO.new(Base64.strict_decode64(raw).freeze) }
+
+  let(:content) do
+    Datadog::Core::Remote::Configuration::Content.parse({ :path => path.to_s, :content => string_io_content })
+  end
+
+  describe '#transaction' do
+    it 'yields self and a new Repository::Transaction instance' do
+      expect do |b|
+        repository.transaction(&b)
+      end.to yield_with_args(
+        repository,
+        instance_of(Datadog::Core::Remote::Configuration::Repository::Transaction)
+      )
+    end
+
+    it 'commits transaction' do
+      expect(repository).to receive(:commit).with(instance_of(Datadog::Core::Remote::Configuration::Repository::Transaction))
+      repository.transaction(&proc {})
+    end
+
+    describe 'set operation' do
+      it 'set values' do
+        expect(repository.opaque_backend_state).to be_nil
+        expect(repository.targets_version).to eq(0)
+
+        repository.transaction do |_repository, transaction|
+          transaction.set(opaque_backend_state: '1', targets_version: 3)
+        end
+
+        expect(repository.opaque_backend_state).to eq('1')
+        expect(repository.targets_version).to eq(3)
+      end
+    end
+
+    describe 'insert operation' do
+      it 'store content' do
+        expect(repository.contents.size).to eq(0)
+
+        repository.transaction do |_repository, transaction|
+          transaction.insert(path, target, content)
+        end
+
+        expect(repository.contents.size).to eq(1)
+      end
+
+      it 'does not store same path twice' do
+        expect(repository.contents.size).to eq(0)
+
+        repository.transaction do |_repository, transaction|
+          transaction.insert(path, target, content)
+          transaction.insert(path, target, content)
+        end
+
+        expect(repository.contents.size).to eq(1)
+      end
+    end
+
+    describe 'update operation' do
+      it 'change the path\'s content' do
+        expect(repository.contents.size).to eq(0)
+
+        repository.transaction do |_repository, transaction|
+          transaction.insert(path, target, content)
+        end
+
+        expect(repository.contents[path]).to eq(content)
+
+        new_content = Datadog::Core::Remote::Configuration::Content.parse(
+          { :path => path.to_s,
+            :content => StringIO.new('hello world') }
+        )
+
+        repository.transaction do |_repository, transaction|
+          transaction.update(path, target, new_content)
+        end
+
+        expect(repository.contents[path]).to eq(new_content)
+      end
+
+      it 'does not change the path\'s content if path doesn not exists' do
+        expect(repository.contents.size).to eq(0)
+
+        repository.transaction do |_repository, transaction|
+          transaction.insert(path, target, content)
+        end
+
+        expect(repository.contents[path]).to eq(content)
+        new_path = Datadog::Core::Remote::Configuration::Path.parse('employee/ASM/exclusion_filters/config')
+        new_content = Datadog::Core::Remote::Configuration::Content.parse(
+          { :path => new_path.to_s,
+            :content => StringIO.new('hello world') }
+        )
+
+        repository.transaction do |_repository, transaction|
+          transaction.update(new_path, target, new_content)
+        end
+
+        expect(repository.contents.size).to eq(1)
+        expect(repository.contents[path]).to eq(content)
+      end
+    end
+
+    describe 'delete operation' do
+      it 'delete existing content base on path' do
+        expect(repository.contents.size).to eq(0)
+
+        repository.transaction do |_repository, transaction|
+          transaction.insert(path, target, content)
+        end
+
+        expect(repository.contents[path]).to eq(content)
+
+        repository.transaction do |_repository, transaction|
+          transaction.delete(path)
+        end
+
+        expect(repository.contents[path]).to be_nil
+      end
+
+      it 'does not delete content if path does not match' do
+        expect(repository.contents.size).to eq(0)
+
+        repository.transaction do |_repository, transaction|
+          transaction.insert(path, target, content)
+        end
+
+        expect(repository.contents[path]).to eq(content)
+
+        new_path = Datadog::Core::Remote::Configuration::Path.parse('employee/ASM/exclusion_filters/config')
+
+        repository.transaction do |_repository, transaction|
+          transaction.delete(new_path)
+        end
+
+        expect(repository.contents[path]).to eq(content)
+      end
+    end
+  end
+
+  describe '#state' do
+    it 'returns a state instance' do
+      expect(repository.state).to be_a(described_class::State)
+    end
+  end
+end


### PR DESCRIPTION

<!--
Check out the
https://github.com/DataDog/dd-trace-rb/blob/master/docs/DevelopmentGuide.md
for guidance on how to set up your development environment,
run the test suite, write new integrations, and more.
-->

**What does this PR do?**

Add configuration repository, using PORO from #2687

**Motivation**
<!-- What inspired you to submit this pull request? -->

**Additional Notes**

This is an initial basic implementation. It is notably missing:

- storing digests for each bit of content
- reporting a summary of which paths have been updated and their corresponding data for taking action on the newly received configuration
- error tracking and reporting
- a content caching mechanism and cache state reporting

These will be added progressively.

**How to test the change?**
<!--
Describe here how the change can be validated.
You are strongly encouraged to provide automated tests for this PR (unit or integration).
If this change cannot be feasibly tested, please explain why,
unless the change does not modify code (e.g. only modifies docs, comments).
-->

```
  require 'datadog/core/remote/configuration/path'
  require 'datadog/core/remote/configuration/target'
  require 'datadog/core/remote/configuration/content'

  path = Datadog::Core::Remote::Configuration::Path.parse('datadog/42/PRODUCT/foo/config')
  content = Datadog::Core::Remote::Configuration::Content.parse({path: 'datadog/42/PRODUCT/foo/config', content: StringIO.new('Lorem ipsum')})
  target = Datadog::Core::Remote::Configuration::Target.parse({'length' => 11, 'hashes' => {'sha256' => 'a9a66978f378456c818fb8a3e7c6ad3d2c83e62724ccbdea7b36253fb8df5edd'}})

  path2 = Datadog::Core::Remote::Configuration::Path.parse('datadog/42/PRODUCT/bar/config')
  content2 = Datadog::Core::Remote::Configuration::Content.parse({path: 'datadog/42/PRODUCT/bar/config', content: StringIO.new('Lorem ipsum')})
  target2 = Datadog::Core::Remote::Configuration::Target.parse({'length' => 11, 'hashes' => {'sha256' => 'a9a66978f378456c818fb8a3e7c6ad3d2c83e62724ccbdea7b36253fb8df5edd'}})

  content3 = Datadog::Core::Remote::Configuration::Content.parse({path: 'datadog/42/PRODUCT/foo/config', content: StringIO.new('dolor sit amet')})
  target3 = Datadog::Core::Remote::Configuration::Target.parse({'length' => 11, 'hashes' => {'sha256' => 'aa8311d08b68a5fdda55ad0947fff3c5a4b2397f5f766e9c9a79f4a5486c633c'}})

  require 'datadog/core/remote/configuration/repository'

  txn = Datadog::Core::Remote::Configuration::Repository::Transaction.new
  txn.delete(path)
  txn.operations

  txn = Datadog::Core::Remote::Configuration::Repository::Transaction.new
  txn.insert(path, target, content)
  txn.operations

  txn = Datadog::Core::Remote::Configuration::Repository::Transaction.new
  txn.update(path, target, content)
  txn.operations

  txn = Datadog::Core::Remote::Configuration::Repository::Transaction.new
  txn.set(opaque_backend_state: 'OPAQUE_DATA')
  txn.operations

  txn = Datadog::Core::Remote::Configuration::Repository::Transaction.new
  txn.set(targets_version: 42)
  txn.operations

  repository = Datadog::Core::Remote::Configuration::Repository.new
  repository.contents
  repository.root_version
  repository.targets_version

  repository.transaction do |repo, txn|
    txn.insert(path, target, content)
    txn.set(opaque_backend_state: 'OPAQUE_DATA', targets_version: target_map.version)
  end

  repository.contents
  repository.root_version
  repository.targets_version
  repository[path]

  repository.transaction do |repo, txn|
    txn.insert(path2, target2, content2)
  end

  repository[path2]
  repository.contents

  repository.transaction do |repo, txn|
    txn.insert(path, target, content)
  end

  repository.contents

  repository.transaction do |repo, txn|
    txn.update(path, target3, content3)
  end

  repository[path]

  repository.transaction do |repo, txn|
    txn.delete(path)
  end

  repository.contents
  repository[path]

  repository.transaction do |repo, txn|
    txn.update(path, target, content)
  end

  repository[path]
```