### PR TITLE
Add remote configuration client

### DIFF
--- a/lib/datadog/core/remote/client.rb
+++ b/lib/datadog/core/remote/client.rb
@@ -22,6 +22,9 @@ module Datadog
           response = @transport.send_config(payload)
 
           if response.ok?
+            # when response is completely empty, do nothing as in: leave as is
+            return if response.empty?
+
             paths = response.client_configs.map do |path|
               Configuration::Path.parse(path)
             end

--- a/lib/datadog/core/remote/client.rb
+++ b/lib/datadog/core/remote/client.rb
@@ -2,10 +2,7 @@
 
 require 'securerandom'
 
-require_relative 'configuration/repository'
-require_relative 'configuration/path'
-require_relative 'configuration/target'
-require_relative 'configuration/content'
+require_relative 'configuration'
 
 module Datadog
   module Core

--- a/lib/datadog/core/remote/client.rb
+++ b/lib/datadog/core/remote/client.rb
@@ -1,0 +1,173 @@
+# frozen_string_literal: true
+
+require 'securerandom'
+
+require_relative 'configuration/repository'
+require_relative 'configuration/path'
+require_relative 'configuration/target'
+require_relative 'configuration/content'
+
+module Datadog
+  module Core
+    module Remote
+      class Client
+        def initialize(transport)
+          @transport = transport
+
+          @repository = Configuration::Repository.new
+          @id = SecureRandom.uuid
+        end
+
+        def sync
+          response = @transport.send_config(payload)
+
+          if response.ok?
+            paths = response.client_configs.map do |path|
+              Configuration::Path.parse(path)
+            end
+
+            targets = Configuration::TargetMap.parse(response.targets)
+
+            contents = Configuration::ContentList.parse(response.target_files)
+
+            # TODO: sometimes it can strangely be so that paths.empty?
+            # TODO: sometimes it can strangely be so that targets.empty?
+
+            @repository.transaction do |current, transaction|
+              # paths to be removed: previously applied paths minus ingress paths
+              (current.paths - paths).each { |p| transaction.delete(p) }
+
+              # go through each ingress path
+              paths.each do |path|
+                # match target with path
+                target = targets[path]
+
+                # abort entirely if matching target not found
+                raise SyncError, "no target for path '#{path}'" if target.nil?
+
+                # new paths are not in previously applied paths
+                new = !current.paths.include?(path)
+
+                # updated paths are in previously applied paths
+                # but the content hash changed
+                changed = current.paths.include?(path) && !current.contents.find(path, target)
+
+                # skip if unchanged
+                same = !new && !changed
+                next if same
+
+                # match content with path and target
+                content = contents.find_content(path, target)
+
+                # abort entirely if matching content not found
+                raise SyncError, "no valid content for target at path '#{path}'" if content.nil?
+
+                # to be added or updated << config
+                # TODO: metadata (hash, version, etc...)
+                transaction.insert(path, target, content) if new
+                transaction.update(path, target, content) if changed
+              end
+
+              # save backend opaque backend state
+              transaction.set(opaque_backend_state: targets.opaque_backend_state)
+              transaction.set(targets_version: targets.version)
+
+              # upon transaction end, new list of applied config + metadata (add, change, remove) will be saved
+              # TODO: also remove stale config (matching removed) from cache (client configs is exhaustive list of paths)
+            end
+          else
+            raise SyncError, "unexpected transport response: #{response.inspect}"
+          end
+
+          # TODO: dispatch config updates to listeners
+        end
+
+        class SyncError < StandardError; end
+
+        private
+
+        def payload
+          state = @repository.state
+
+          {
+            client: {
+              state: {
+                root_version: state.root_version,
+                targets_version: state.targets_version,
+                config_states: state.config_states,
+                has_error: state.has_error,
+                error: state.error,
+                backend_client_state: state.opaque_backend_state,
+              },
+              id: @id,
+              products: products,
+              is_tracer: true,
+              is_agent: false,
+              client_tracer: {
+                runtime_id: Core::Environment::Identity.id,
+                language: Core::Environment::Identity.lang,
+                tracer_version: Core::Environment::Identity.tracer_version,
+                service: Datadog.configuration.service,
+                env: Datadog.configuration.env,
+                # app_version: app_version, # TODO: I don't know what this is
+                tags: [], # TODO: add nice tags!
+              },
+              # base64 is needed otherwise the Go agent fails with an unmarshal error
+              capabilities: Base64.encode64(capabilities_binary).chomp,
+            },
+            cached_target_files: [
+              # TODO: to be implemented once we cache configuration content
+              # {
+              #   path: '',
+              #   length: 0,
+              #   hashes: '';
+              # }
+            ],
+          }
+        end
+
+        # TODO: this is serialization of capabilities, it should go in the request serializer/encoder
+        CAP_ASM_ACTIVATION                = 1 << 1 # Remote activation via ASM_FEATURES product
+        CAP_ASM_IP_BLOCKING               = 1 << 2 # accept IP blocking data from ASM_DATA product
+        CAP_ASM_DD_RULES                  = 1 << 3 # read ASM rules from ASM_DD product
+        CAP_ASM_EXCLUSIONS                = 1 << 4 # exclusion filters (passlist) via ASM product
+        CAP_ASM_REQUEST_BLOCKING          = 1 << 5 # can block on request info
+        CAP_ASM_RESPONSE_BLOCKING         = 1 << 6 # can block on response info
+        CAP_ASM_USER_BLOCKING             = 1 << 7 # accept user blocking data from ASM_DATA product
+        CAP_ASM_CUSTOM_RULES              = 1 << 8 # accept custom rules
+        CAP_ASM_CUSTOM_BLOCKING_RESPONSE  = 1 << 9 # supports custom http code or redirect sa blocking response
+
+        # TODO: this should go in the AppSec namespace
+        # TODO: condition by active configuration
+        def products
+          [
+            'ASM_DD',       # Datadog employee issued configuration
+            'ASM',          # customer issued configuration (rulesets, passlist...)
+            'ASM_FEATURES', # capabilities
+            'ASM_DATA',     # config files (IP addresses or users for blocking)
+          ]
+        end
+
+        # TODO: as a declaration, this should go in the AppSec namepsace
+        # TODO: as serialization, this should go in the request serializer/encoder
+        # TODO: condition by active configuration
+        def capabilities
+          [
+            CAP_ASM_IP_BLOCKING,
+            CAP_ASM_USER_BLOCKING,
+            CAP_ASM_CUSTOM_RULES,
+            CAP_ASM_EXCLUSIONS,
+            CAP_ASM_REQUEST_BLOCKING,
+            CAP_ASM_RESPONSE_BLOCKING,
+            CAP_ASM_DD_RULES,
+          ].reduce(&:|)
+        end
+
+        # TODO: this is serialization of capabilities, it should go in the request serializer/encoder
+        def capabilities_binary
+          capabilities.to_s(16).tap { |s| s.size.odd? && s.prepend('0') }.scan(/\h\h/).map { |e| e.to_i(16) }.pack('C*')
+        end
+      end
+    end
+  end
+end

--- a/lib/datadog/core/remote/client.rb
+++ b/lib/datadog/core/remote/client.rb
@@ -52,7 +52,7 @@ module Datadog
 
                 # updated paths are in previously applied paths
                 # but the content hash changed
-                changed = current.paths.include?(path) && !current.contents.find(path, target)
+                changed = current.paths.include?(path) && !current.contents.find_content(path, target)
 
                 # skip if unchanged
                 same = !new && !changed

--- a/lib/datadog/core/remote/client.rb
+++ b/lib/datadog/core/remote/client.rb
@@ -7,6 +7,7 @@ require_relative 'configuration'
 module Datadog
   module Core
     module Remote
+      # Client communicates with the agent and sync remote configuration
       class Client
         attr_reader :transport, :repository, :id
 

--- a/lib/datadog/core/remote/configuration.rb
+++ b/lib/datadog/core/remote/configuration.rb
@@ -1,0 +1,15 @@
+# frozen_string_literal: true
+
+require_relative 'configuration/path'
+require_relative 'configuration/content'
+require_relative 'configuration/target'
+require_relative 'configuration/repository'
+
+module Datadog
+  module Core
+    module Remote
+      class Configuration
+      end
+    end
+  end
+end

--- a/lib/datadog/core/remote/configuration.rb
+++ b/lib/datadog/core/remote/configuration.rb
@@ -8,8 +8,11 @@ require_relative 'configuration/repository'
 module Datadog
   module Core
     module Remote
+      # Configuration
+      # rubocop:disable Lint/EmptyClass
       class Configuration
       end
+      # rubocop:enable Lint/EmptyClass
     end
   end
 end

--- a/lib/datadog/core/transport/config.rb
+++ b/lib/datadog/core/transport/config.rb
@@ -23,6 +23,10 @@ module Datadog
         # Config response
         module Response
           attr_reader :roots, :targets, :target_files, :client_configs
+
+          def empty?
+            @empty
+          end
         end
 
         # Config transport

--- a/lib/datadog/core/transport/http/config.rb
+++ b/lib/datadog/core/transport/http/config.rb
@@ -40,7 +40,7 @@ module Datadog
 
               begin
                 payload = JSON.parse(http_response.payload, symbolize_names: true)
-              rescue JSON::ParseError => e
+              rescue JSON::ParserError => e
                 raise ParseError.new(:roots, e)
               end
 

--- a/lib/datadog/core/transport/http/config.rb
+++ b/lib/datadog/core/transport/http/config.rb
@@ -38,11 +38,21 @@ module Datadog
             def initialize(http_response, options = {}) # rubocop:disable Metrics/AbcSize,Metrics/CyclomaticComplexity,Metrics/MethodLength,Metrics/PerceivedComplexity
               super(http_response)
 
+              begin
+                payload = JSON.parse(http_response.payload, symbolize_names: true)
+              rescue JSON::ParseError => e
+                raise ParseError.new(:roots, e)
+              end
+
+              raise TypeError.new(Hash, payload) unless payload.is_a?(Hash)
+
+              @empty = true if payload.empty?
+
               # TODO: these fallbacks should be improved
-              roots = options[:roots] || []
-              targets = options[:targets] || ''
-              target_files = options[:target_files] || []
-              client_configs = options[:client_configs] || []
+              roots = payload[:roots] || []
+              targets = payload[:targets] || Base64.encode64('{}').chomp
+              target_files = payload[:target_files] || []
+              client_configs = payload[:client_configs] || []
 
               raise TypeError.new(Array, roots) unless roots.is_a?(Array)
 
@@ -238,13 +248,9 @@ module Datadog
                 # Query for response
                 http_response = super(env, &block)
 
-                # Process the response
-                body = JSON.parse(http_response.payload, symbolize_names: true)
+                response_options = {}
 
-                # TODO: there should be more processing here to ensure a proper response_options
-                response_options = body.is_a?(Hash) ? body : {}
-
-                # Build and return a trace response
+                # Build and return a response
                 Config::Response.new(http_response, response_options)
               end
             end

--- a/sig/datadog/core/configuration.rbs
+++ b/sig/datadog/core/configuration.rbs
@@ -1,6 +1,8 @@
 module Datadog
   module Core
     module Configuration
+      def configuration: () -> Settings
+
       def tracer: () -> Datadog::Tracing::Tracer
 
       def logger: () -> Datadog::Core::Logger

--- a/sig/datadog/core/configuration/settings.rbs
+++ b/sig/datadog/core/configuration/settings.rbs
@@ -6,6 +6,10 @@ module Datadog
 
         def initialize: (*untyped _) -> untyped
 
+        def env: -> String
+
+        def service: -> String
+
         def logger=: (untyped logger) -> untyped
 
         def runtime_metrics: (?untyped? options) -> untyped

--- a/sig/datadog/core/remote/client.rbs
+++ b/sig/datadog/core/remote/client.rbs
@@ -8,7 +8,7 @@ module Datadog
 
         attr_reader id: ::String
 
-        def initialize: (Datadog::Core::Transport::Config::Transport transport) -> void
+        def initialize: (Datadog::Core::Transport::Config::Transport transport, ?repository: Configuration::Repository) -> void
 
         def sync: () -> void
 

--- a/sig/datadog/core/remote/client.rbs
+++ b/sig/datadog/core/remote/client.rbs
@@ -1,0 +1,50 @@
+module Datadog
+  module Core
+    module Remote
+      class Client
+        attr_reader transport: Datadog::Core::Transport::Config::Transport
+
+        attr_reader repository: Configuration::Repository
+
+        attr_reader id: ::String
+
+        def initialize: (Datadog::Core::Transport::Config::Transport transport) -> void
+
+        def sync: () -> void
+
+        class SyncError < StandardError
+        end
+
+        private
+
+        def payload: () ->  ::Hash[Symbol, untyped]
+
+        CAP_ASM_ACTIVATION: Integer
+
+        CAP_ASM_IP_BLOCKING: Integer
+
+        CAP_ASM_DD_RULES: Integer
+
+        CAP_ASM_EXCLUSIONS: Integer
+
+        CAP_ASM_REQUEST_BLOCKING: Integer
+
+        CAP_ASM_RESPONSE_BLOCKING: Integer
+
+        CAP_ASM_USER_BLOCKING: Integer
+
+        CAP_ASM_CUSTOM_RULES: Integer
+
+        CAP_ASM_CUSTOM_BLOCKING_RESPONSE: Integer
+
+        CAPABILITIES: Array[Integer]
+
+        def products: () -> ::Array[::String]
+
+        def capabilities: () -> Integer
+
+        def capabilities_binary: () -> String
+      end
+    end
+  end
+end

--- a/sig/datadog/core/remote/configuration/content.rbs
+++ b/sig/datadog/core/remote/configuration/content.rbs
@@ -19,7 +19,7 @@ module Datadog
 
           def []: (Configuration::Path path) ->  Content?
 
-          def paths: () -> ::Array[Path]?
+          def paths: () -> ::Array[Path]
         end
       end
     end

--- a/sig/datadog/core/remote/configuration/repository.rbs
+++ b/sig/datadog/core/remote/configuration/repository.rbs
@@ -17,7 +17,7 @@ module Datadog
 
           def initialize: () -> void
 
-          def paths: () -> ::Array[Path]?
+          def paths: () -> ::Array[Path]
 
           def []: (Configuration::Path path) -> Content?
 

--- a/sig/datadog/core/transport/config.rbs
+++ b/sig/datadog/core/transport/config.rbs
@@ -22,6 +22,10 @@ module Datadog
           attr_reader target_files: untyped
 
           attr_reader client_configs: untyped
+
+          attr_reader empty: bool
+
+          def empty?: () -> bool
         end
 
         # Config transport

--- a/spec/datadog/core/remote/client_spec.rb
+++ b/spec/datadog/core/remote/client_spec.rb
@@ -1,0 +1,337 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+require 'datadog/core/transport/http'
+require 'datadog/core/remote/client'
+
+RSpec.describe Datadog::Core::Remote::Client do
+  shared_context 'HTTP connection stub' do
+    before do
+      request_class = ::Net::HTTP::Post
+      http_request = instance_double(request_class)
+      allow(http_request).to receive(:body=)
+      allow(request_class).to receive(:new).and_return(http_request)
+
+      http_connection = instance_double(::Net::HTTP)
+      allow(::Net::HTTP).to receive(:new).and_return(http_connection)
+
+      allow(http_connection).to receive(:open_timeout=)
+      allow(http_connection).to receive(:read_timeout=)
+      allow(http_connection).to receive(:use_ssl=)
+
+      allow(http_connection).to receive(:start).and_yield(http_connection)
+      http_response = instance_double(::Net::HTTPResponse, body: response_body, code: response_code)
+      allow(http_connection).to receive(:request).with(http_request).and_return(http_response)
+    end
+  end
+
+  let(:transport) { Datadog::Core::Transport::HTTP.v7(&proc { |_client| }) }
+  let(:roots) do
+    [
+      {
+        'signatures' => [
+          {
+            'keyid' => 'bla1',
+            'sig' => 'fake sig'
+          },
+        ],
+        'signed' => {
+          '_type' => 'root',
+          'consistent_snapshot' => true,
+          'expires' => '2022-02-01T00:00:00Z',
+          'keys' => {
+            'foo' => {
+              'keyid_hash_algorithms' => ['sha256', 'sha512'],
+              'keytype' => 'ed25519',
+              'keyval' => {
+                'public' => 'blabla'
+              },
+              'scheme' => 'ed25519'
+            }
+          },
+          'roles' => {
+            'root' => {
+              'keyids' => ['bla1',
+                           'bla2'],
+              'threshold' => 2
+            },
+            'snapshot' => {
+              'keyids' => ['foo'],
+              'threshold' => 1 \
+            },
+            'targets' => { \
+              'keyids' => ['foo'],
+              'threshold' => 1 \
+            },
+            'timestamp' => {
+              'keyids' => ['foo'],
+              'threshold' => 1
+            }
+          },
+          'spec_version' => '1.0',
+          'version' => 2
+        }
+      },
+    ]
+  end
+  let(:target_content) do
+    {
+      'datadog/603646/ASM/exclusion_filters/config' => {
+        'custom' => {
+          'c' => ['client_id'],
+          'tracer-predicates' => {
+            'tracer_predicates_v1' => [{ 'clientID' => 'client_id' }]
+          },
+          'v' => 21
+        },
+        'hashes' => { 'sha256' => Digest::SHA256.hexdigest(exclusion_content) },
+        'length' => 645
+      },
+      'datadog/603646/ASM_DATA/blocked_ips/config' => {
+        'custom' => {
+          'c' => ['client_id'],
+          'tracer-predicates' => { 'tracer_predicates_v1' => [{ 'clientID' => 'client_id' }] },
+          'v' => 51
+        },
+        'hashes' => { 'sha256' => Digest::SHA256.hexdigest(blocked_ips_content) },
+        'length' => 1834
+      }
+    }
+  end
+  let(:targets) do
+    {
+      'signatures' => [
+        {
+          'keyid' => 'hello',
+          'sig' => 'sig'
+        }
+      ],
+      'signed' => {
+        '_type' => 'targets',
+        'custom' => {
+          'agent_refresh_interval' => 50,
+          'opaque_backend_state' => 'iuycygweiuegciwbiecwbicw'
+        },
+        'expires' => '2023-06-17T10:16:42Z',
+        'spec_version' => '1.0.0',
+        'targets' => target_content,
+        'version' => 46915439
+      }
+    }
+  end
+  let(:exclusion_content) do
+    '{"exclusions":[{"conditions":[{"operator":"ip_match","parameters":{"inputs":[{"address":"http.client_ip"}]}}]]'
+  end
+  let(:blocked_ips_content) do
+    '{"rules_data":[{"data":[{"expiration":1678972458,"value":"42.42.42.1"}]}'
+  end
+  let(:response_body) do
+    {
+      'roots' => roots.map { |r| Base64.strict_encode64(r.to_json).chomp },
+      'targets' => Base64.strict_encode64(targets.to_json).chomp,
+      'target_files' => [
+        {
+          'path' => 'datadog/603646/ASM_DATA/blocked_ips/config',
+          'raw' => Base64.strict_encode64(blocked_ips_content).chomp
+        },
+        {
+          'path' => 'datadog/603646/ASM/exclusion_filters/config',
+          'raw' => Base64.strict_encode64(exclusion_content).chomp
+        }
+      ],
+      'client_configs' => [
+        'datadog/603646/ASM_DATA/blocked_ips/config',
+        'datadog/603646/ASM/exclusion_filters/config'
+      ]
+    }.to_json
+  end
+  let(:repository) { Datadog::Core::Remote::Configuration::Repository.new }
+  subject(:client) { described_class.new(transport, repository: repository) }
+
+  describe '#sync' do
+    include_context 'HTTP connection stub'
+
+    context 'valid response' do
+      let(:response_code) { 200 }
+
+      it 'store all changes into the repository' do
+        expect(repository.opaque_backend_state).to be_nil
+        expect(repository.targets_version).to eq(0)
+        expect(repository.contents.size).to eq(0)
+
+        client.sync
+
+        expect(repository.opaque_backend_state).to_not be_nil
+        expect(repository.targets_version).to_not eq(0)
+        expect(repository.contents.size).to_not eq(0)
+      end
+
+      context 'when the data is the same' do
+        it 'does not commit the information to the transaction' do
+          expect_any_instance_of(Datadog::Core::Remote::Configuration::Repository::Transaction).to receive(:insert)
+            .exactly(2).and_call_original
+          client.sync
+          client.sync
+        end
+      end
+
+      context 'when the data has change' do
+        it 'updates the contents' do
+          client.sync
+
+          # We have to modify the response to trick the client into think on the second sync
+          # the content for datadog/603646/ASM_DATA/blocked_ips/config have change
+          new_blocked_ips = '{"rules_data":[{"data":["fake new data"]'
+          expect_any_instance_of(Datadog::Core::Transport::HTTP::Config::Response).to receive(:target_files).and_return(
+            [
+              {
+                :path => 'datadog/603646/ASM_DATA/blocked_ips/config',
+                :content => StringIO.new(new_blocked_ips)
+              },
+              {
+                :path => 'datadog/603646/ASM/exclusion_filters/config',
+                :content => StringIO.new(exclusion_content)
+              }
+            ]
+          )
+
+          updated_targets = {
+            'signed' => {
+              '_type' => 'targets',
+              'custom' => {
+                'agent_refresh_interval' => 50,
+                'opaque_backend_state' => 'iucwgi'
+              },
+              'expires' => '2023-06-17T10:16:42Z',
+              'spec_version' => '1.0.0',
+              'targets' => {
+                'datadog/603646/ASM/exclusion_filters/config' => {
+                  'custom' => {
+                    'c' => ['client_id'],
+                    'tracer-predicates' => { 'tracer_predicates_v1' => [{ 'clientID' => 'client_id' }] },
+                    'v' => 21
+                  },
+                  'hashes' => { 'sha256' => Digest::SHA256.hexdigest(exclusion_content) },
+                  'length' => 645
+                },
+                'datadog/603646/ASM_DATA/blocked_ips/config' => {
+                  'custom' => {
+                    'c' => ['client_id'],
+                    'tracer-predicates' => { 'tracer_predicates_v1' => [{ 'clientID' => 'client_id' }] },
+                    'v' => 51
+                  },
+                  'hashes' => { 'sha256' => Digest::SHA256.hexdigest(new_blocked_ips) },
+                  'length' => 1834
+                }
+              },
+              'version' => 469154399387498379
+            }
+          }
+          expect_any_instance_of(Datadog::Core::Transport::HTTP::Config::Response).to receive(:targets).and_return(
+            updated_targets
+          )
+
+          expect_any_instance_of(Datadog::Core::Remote::Configuration::Repository::Transaction).to receive(:update)
+            .exactly(1).and_call_original
+          client.sync
+        end
+      end
+    end
+
+    context 'invalid response' do
+      context 'not a 200 response' do
+        let(:response_code) { 401 }
+
+        it 'raises SyncError' do
+          expect { client.sync }.to raise_error(described_class::SyncError)
+        end
+      end
+
+      context 'invalid response body' do
+        let(:response_code) { 200 }
+        let(:response_body) do
+          {
+            'roots' => roots.map { |r| Base64.strict_encode64(r.to_json).chomp },
+            'targets' => Base64.strict_encode64(targets.to_json).chomp,
+            'target_files' => [
+              {
+                'path' => 'datadog/603646/ASM/exclusion_filters/config',
+                'raw' => Base64.strict_encode64(exclusion_content).chomp
+              }
+            ],
+            'client_configs' => [
+              'datadog/603646/ASM_DATA/blocked_ips/config',
+            ]
+          }.to_json
+        end
+
+        context 'missing content for path from the response' do
+          it 'raises SyncError' do
+            expect do
+              client.sync
+            end.to raise_error(
+              described_class::SyncError,
+              %r{no valid content for target at path 'datadog/603646/ASM_DATA/blocked_ips/config'}
+            )
+          end
+        end
+
+        context 'missing target for path from the response' do
+          let(:response_code) { 200 }
+          let(:target_content) do
+            {
+              'datadog/603646/ASM/exclusion_filters/config' => {
+                'custom' => {
+                  'c' => ['client_id'],
+                  'tracer-predicates' => {
+                    'tracer_predicates_v1' => [
+                      {
+                        'clientID' => 'client_id'
+                      }
+                    ]
+                  },
+                  'v' => 21
+                },
+                'hashes' => { 'sha256' => Digest::SHA256.hexdigest(exclusion_content) },
+                'length' => 645
+              },
+            }
+          end
+
+          it 'raises SyncError' do
+            expect do
+              client.sync
+            end.to raise_error(
+              described_class::SyncError,
+              %r{no target for path 'datadog/603646/ASM_DATA/blocked_ips/config'}
+            )
+          end
+        end
+
+        context 'invalid path' do
+          let(:target_content) do
+            {
+              'invalid path' => {
+                'custom' => {
+                  'c' => ['client_id'],
+                  'tracer-predicates' => {
+                    'tracer_predicates_v1' => [
+                      { 'clientID' => 'client_id' }
+                    ]
+                  },
+                  'v' => 21
+                },
+                'hashes' => { 'sha256' => 'fake sha' },
+                'length' => 645
+              },
+            }
+          end
+
+          it 'raises Path::ParseError' do
+            expect { client.sync }.to raise_error(Datadog::Core::Remote::Configuration::Path::ParseError)
+          end
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION


<!--
Check out the
https://github.com/DataDog/dd-trace-rb/blob/master/docs/DevelopmentGuide.md
for guidance on how to set up your development environment,
run the test suite, write new integrations, and more.
-->

**What does this PR do?**

Implement the remote configuration client class.

**Motivation**

Remote configuration

**Additional Notes**

Barebones implementation, some questions remain to be solved:

- there is AppSec-specific code in there (products and capabilities declaration)
- the callback system is missing because the repository does not yet report changes
- caching is not handled

There is an issue where the backend appears not to report any `client_configs` nor `target_files`, and `targets` may have targets but they may not correspond and/or include to the active client id.

In such gases, calling `client.sync` multiple times ends up getting the configuration. At this stage it is unknown whether this is expected API endpoint behaviour (e.g a delay in creating entries for a new client id, a "data lag" inside the agent...)

**How to test the change?**

```
  require 'ddtrace'

  Datadog.configure do |c|
    c.agent.host = '192.168.135.133'
    #c.tracing.enabled = true
    #c.diagnostics.debug = true
  end

  transport_options = {
    agent_settings: Datadog::Core::Configuration::AgentSettingsResolver.call(
      Datadog.configuration
    )
  }

  require 'datadog/core/transport/http'

  transport_v7 = Datadog::Core::Transport::HTTP.v7(**transport_options.dup)

  require 'datadog/core/remote/client'

  client = Datadog::Core::Remote::Client.new(transport_v7)
  repository = client.instance_eval { @repository }

  client.sync
  
  repository.contents
```