### PR TITLE
[PROF-7307] Avoid triggering allocation sampling during sampling

### DIFF
--- a/ext/ddtrace_profiling_native_extension/collectors_cpu_and_wall_time_worker.c
+++ b/ext/ddtrace_profiling_native_extension/collectors_cpu_and_wall_time_worker.c
@@ -98,6 +98,12 @@ struct cpu_and_wall_time_worker_state {
   // Used by `_native_stop` to flag the worker thread to start (see comment on `_native_sampling_loop`)
   VALUE stop_thread;
 
+  // Others
+
+  // Used to detect/avoid nested sampling, e.g. when the object_allocation_tracepoint gets triggered by a memory allocation
+  // that happens during another sample.
+  bool during_sample;
+
   struct stats {
     // How many times we tried to trigger a sample
     unsigned int trigger_sample_attempts;
@@ -115,6 +121,8 @@ struct cpu_and_wall_time_worker_state {
     uint64_t sampling_time_ns_min;
     uint64_t sampling_time_ns_max;
     uint64_t sampling_time_ns_total;
+    // How many times we saw allocations being done inside a sample
+    unsigned int allocations_during_sample;
   } stats;
 };
 
@@ -242,6 +250,8 @@ static VALUE _native_new(VALUE klass) {
   atomic_init(&state->should_run, false);
   state->failure_exception = Qnil;
   state->stop_thread = Qnil;
+
+  state->during_sample = false;
 
   reset_stats(state);
 
@@ -487,8 +497,12 @@ static void sample_from_postponed_job(DDTRACE_UNUSED void *_unused) {
     return; // We're not on the main Ractor; we currently don't support profiling non-main Ractors
   }
 
+  state->during_sample = true;
+
   // Rescue against any exceptions that happen during sampling
   safely_call(rescued_sample_from_postponed_job, state->self_instance, state->self_instance);
+
+  state->during_sample = false;
 }
 
 static VALUE rescued_sample_from_postponed_job(VALUE self_instance) {
@@ -674,8 +688,12 @@ static void after_gc_from_postponed_job(DDTRACE_UNUSED void *_unused) {
     return; // We're not on the main Ractor; we currently don't support profiling non-main Ractors
   }
 
+  state->during_sample = true;
+
   // Trigger sampling using the Collectors::ThreadState; rescue against any exceptions that happen during sampling
   safely_call(thread_context_collector_sample_after_gc, state->thread_context_collector_instance, state->self_instance);
+
+  state->during_sample = false;
 }
 
 // Equivalent to Ruby begin/rescue call, where we call a C function and jump to the exception handler if an
@@ -755,6 +773,7 @@ static VALUE _native_stats(DDTRACE_UNUSED VALUE self, VALUE instance) {
     ID2SYM(rb_intern("sampling_time_ns_max")),                       /* => */ pretty_sampling_time_ns_max,
     ID2SYM(rb_intern("sampling_time_ns_total")),                     /* => */ pretty_sampling_time_ns_total,
     ID2SYM(rb_intern("sampling_time_ns_avg")),                       /* => */ pretty_sampling_time_ns_avg,
+    ID2SYM(rb_intern("allocations_during_sample")),                  /* => */ UINT2NUM(state->stats.allocations_during_sample),
   };
   for (long unsigned int i = 0; i < VALUE_COUNT(arguments); i += 2) rb_hash_aset(stats_as_hash, arguments[i], arguments[i+1]);
   return stats_as_hash;
@@ -815,6 +834,29 @@ static void on_newobj_event(DDTRACE_UNUSED VALUE tracepoint_data, DDTRACE_UNUSED
   } else {
     allocation_count++;
   }
+
+  struct cpu_and_wall_time_worker_state *state = active_sampler_instance_state; // Read from global variable, see "sampler global state safety" note above
+
+  // This should not happen in a normal situation because the tracepoint is always enabled after the instance is set
+  // and disabled before it is cleared, but just in case...
+  if (state == NULL) return;
+
+  // In a few cases, we may actually be allocating an object as part of profiler sampling. We don't want to recursively
+  // sample, so we just return early
+  if (state->during_sample) {
+    state->stats.allocations_during_sample++;
+    return;
+  }
+
+  // @ivoanjo: Strictly speaking, this is not needed because Ruby should not call the same tracepoint while a previous
+  // invocation is still pending, (e.g. it wouldn't call `on_newobj_event` while it's already running), but I decided
+  // to keep this here for consistency -- every call to the thread context (other than the special gc calls which are
+  // defined as not being able to allocate) sets this.
+  state->during_sample = true;
+
+  // TODO: Sampling goes here (calling into `thread_context_collector_sample_allocation`)
+
+  state->during_sample = false;
 }
 
 static void disable_tracepoints(struct cpu_and_wall_time_worker_state *state) {

--- a/spec/datadog/profiling/collectors/cpu_and_wall_time_worker_spec.rb
+++ b/spec/datadog/profiling/collectors/cpu_and_wall_time_worker_spec.rb
@@ -526,6 +526,7 @@ RSpec.describe Datadog::Profiling::Collectors::CpuAndWallTimeWorker do
         sampling_time_ns_max: nil,
         sampling_time_ns_total: nil,
         sampling_time_ns_avg: nil,
+        allocations_during_sample: 0,
       )
     end
   end


### PR DESCRIPTION
**What does this PR do?**:

In rare cases (such as when throwing exceptions), the profiler may need to allocate Ruby objects during sampling.

This object allocation will trigger the `object_allocation_tracepoint` but we don't want to try to sample in the middle of sampling.

To avoid any issues altogether, I've introduced a `during_sample` flag that can be used to detect this and avoid trying to do sampling during sampling.

Note that the functions modified all run while holding on to the global VM lock, which is why this flag does not need any special concerns re: concurrency.

I've also chosen to keep a counter for how often this happens that may come in handy when debugging any issues around this (and should be cheap enough to keep).

**Motivation**:

This PR is one more piece on the path to providing allocation profiling. The key missing part is the "// TODO: Sampling goes here", which is what will actually trigger recording of stack traces when objects get allocated.

In the spirit of small, incremental changes, I'm opening a PR with just this, and will later follow up with the rest of the implementation.

**Additional Notes**:

I also slightly moved around the declarations of fields inside `struct cpu_and_wall_time_worker_state` and in the constructor. **I've made this change in a separate commit, so I recommend reviewing this PR commit-by-commit as that makes a lot more sense.**

**How to test the change?**:

This change is a bit hard to test, since it affects only the C-level internal state of the profiler. I can't think of a great way of testing this that doesn't involve adding a lot of complexity to the profiler C code just for the purpose of enabling testing.

Instead, I plan to test this using integration testing, e.g. when making sure that the allocation profiling can be run at the same time as other kinds of profiling.