### PR TITLE
Add remote configuration worker

### DIFF
--- a/lib/datadog/core/remote/worker.rb
+++ b/lib/datadog/core/remote/worker.rb
@@ -1,0 +1,79 @@
+# frozen_string_literal: true
+
+module Datadog
+  module Core
+    module Remote
+      class Worker
+        def initialize(interval:, &block)
+          @mutex = Mutex.new
+          @thr = nil
+
+          @starting = false
+          @stopping = false
+          @started = false
+
+          @interval = interval
+          @block = block
+        end
+
+        def start
+          Datadog.logger.debug { 'remote worker starting' }
+
+          @mutex.lock
+
+          return if @starting || @started
+
+          @starting = true
+
+          @thr = Thread.new { poll(@interval) }
+
+          @started = true
+          @starting = false
+
+          Datadog.logger.debug { 'remote worker started' }
+        ensure
+          @mutex.unlock
+        end
+
+        def stop
+          Datadog.logger.debug { 'remote worker stopping' }
+
+          @mutex.lock
+
+          @stopping = true
+
+          @thr.kill unless @thr.nil?
+
+          @started = false
+          @stopping = false
+
+          Datadog.logger.debug { 'remote worker stopped' }
+        ensure
+          @mutex.unlock
+        end
+
+        def started?
+          @started
+        end
+
+        private
+
+        def poll(interval)
+          loop do
+            break unless @mutex.synchronize { @starting || @started }
+
+            call
+
+            sleep(interval)
+          end
+        end
+
+        def call
+          Datadog.logger.debug { 'remote worker perform' }
+
+          @block.call
+        end
+      end
+    end
+  end
+end

--- a/lib/datadog/core/remote/worker.rb
+++ b/lib/datadog/core/remote/worker.rb
@@ -47,7 +47,10 @@ module Datadog
 
           thread = @thr
 
-          thread.kill if thread
+          if thread
+            thread.kill
+            thread.join
+          end
 
           @started = false
           @stopping = false

--- a/lib/datadog/core/remote/worker.rb
+++ b/lib/datadog/core/remote/worker.rb
@@ -3,6 +3,7 @@
 module Datadog
   module Core
     module Remote
+      # Worker executes a block every interval on a separate Thread
       class Worker
         def initialize(interval:, &block)
           @mutex = Mutex.new

--- a/lib/datadog/core/remote/worker.rb
+++ b/lib/datadog/core/remote/worker.rb
@@ -39,13 +39,15 @@ module Datadog
           Datadog.logger.debug { 'remote worker stopping' }
 
           @mutex.lock
-
           @stopping = true
 
-          @thr.kill unless @thr.nil?
+          thread = @thr
+
+          thread.kill if thread
 
           @started = false
           @stopping = false
+          @thr = nil
 
           Datadog.logger.debug { 'remote worker stopped' }
         ensure

--- a/sig/datadog/core/remote/worker.rbs
+++ b/sig/datadog/core/remote/worker.rbs
@@ -20,6 +20,10 @@ module Datadog
 
         private
 
+        def acquire_lock: () -> void
+
+        def release_lock: () -> void
+
         def poll: (Integer interval) -> void
 
         def call: () -> void

--- a/sig/datadog/core/remote/worker.rbs
+++ b/sig/datadog/core/remote/worker.rbs
@@ -8,9 +8,9 @@ module Datadog
         attr_reader thr: Thread?
         attr_reader interval: Integer
         attr_reader mutex: ::Thread::Mutex
-        attr_reader block: (^() -> untyped)
+        attr_reader block: (^() -> void)
 
-        def initialize: (interval: Integer) { () -> untyped } -> void
+        def initialize: (interval: Integer) { () -> void } -> void
 
         def start: () -> void
 

--- a/sig/datadog/core/remote/worker.rbs
+++ b/sig/datadog/core/remote/worker.rbs
@@ -1,0 +1,29 @@
+module Datadog
+  module Core
+    module Remote
+      class Worker
+        attr_reader starting: bool
+        attr_reader stopping: bool
+        attr_reader started: bool
+        attr_reader thr: Thread?
+        attr_reader interval: Integer
+        attr_reader mutex: ::Thread::Mutex
+        attr_reader block: (^() -> untyped)
+
+        def initialize: (interval: Integer) { () -> untyped } -> void
+
+        def start: () -> void
+
+        def stop: () -> void
+
+        def started?: () -> bool
+
+        private
+
+        def poll: (Integer interval) -> void
+
+        def call: () -> void
+      end
+    end
+  end
+end

--- a/spec/datadog/core/remote/worker_spec.rb
+++ b/spec/datadog/core/remote/worker_spec.rb
@@ -4,6 +4,9 @@ require 'spec_helper'
 require 'datadog/core/remote/worker'
 
 RSpec.describe Datadog::Core::Remote::Worker do
+  let(:task) { proc { 1 + 1 } }
+  subject(:worker) { described_class.new(interval: 1, &task) }
+
   describe '#initialize' do
     it 'raises ArgumentError when no block is provided' do
       expect do
@@ -12,37 +15,38 @@ RSpec.describe Datadog::Core::Remote::Worker do
     end
   end
 
-  subject(:worker) do
-    described_class.new(interval: 1) do
-      1 + 1
-    end
-  end
-
   describe '#start' do
+    after { worker.stop }
+
     it 'mark worker as started' do
       expect(worker).not_to be_started
       worker.start
       expect(worker).to be_started
-      worker.stop
     end
 
     it 'acquire and release lock' do
-      expect(worker).to receive(:acquire_lock)
-      expect(worker).to receive(:release_lock)
+      expect(worker).to receive(:acquire_lock).at_least(:once)
+      expect(worker).to receive(:release_lock).at_least(:once)
       worker.start
     end
 
-    it 'execute block when started' do
-      result = []
-      queue = Queue.new
-      queue_worker = described_class.new(interval: 1) do
-        result << queue.pop
+    context 'execute block when started' do
+      let(:result) { [] }
+      let(:queue) { Queue.new }
+      let(:task) do
+        proc do
+          value = 1
+          result << value
+          queue << value
+        end
       end
-      queue_worker.start
-      # Unblock worker thread
-      queue << 1
-      expect(result).to eq([1])
-      queue_worker.stop
+
+      it 'runs block' do
+        worker.start
+        # Wait for the work task to execute once
+        queue.pop
+        expect(result).to eq([1])
+      end
     end
   end
 

--- a/spec/datadog/core/remote/worker_spec.rb
+++ b/spec/datadog/core/remote/worker_spec.rb
@@ -1,0 +1,64 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+require 'datadog/core/remote/worker'
+
+RSpec.describe Datadog::Core::Remote::Worker do
+  describe '#initialize' do
+    it 'raises ArgumentError when no block is provided' do
+      expect do
+        described_class.new(interval: 1)
+      end.to raise_error(ArgumentError)
+    end
+  end
+
+  subject(:worker) do
+    described_class.new(interval: 1) do
+      1 + 1
+    end
+  end
+
+  describe '#start' do
+    it 'mark worker as started' do
+      expect(worker).not_to be_started
+      worker.start
+      expect(worker).to be_started
+      worker.stop
+    end
+
+    it 'acquire and release lock' do
+      expect(worker).to receive(:acquire_lock)
+      expect(worker).to receive(:release_lock)
+      worker.start
+    end
+
+    it 'execute block when started' do
+      result = []
+      queue = Queue.new
+      queue_worker = described_class.new(interval: 1) do
+        result << queue.pop
+      end
+      queue_worker.start
+      # Unblock worker thread
+      queue << 1
+      expect(result).to eq([1])
+      queue_worker.stop
+    end
+  end
+
+  describe '#stop' do
+    it 'mark worker as stopped' do
+      expect(worker).not_to be_started
+      worker.start
+      expect(worker).to be_started
+      worker.stop
+      expect(worker).not_to be_started
+    end
+
+    it 'acquire and release lock' do
+      expect(worker).to receive(:acquire_lock)
+      expect(worker).to receive(:release_lock)
+      worker.stop
+    end
+  end
+end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -166,7 +166,11 @@ RSpec.configure do |config|
         # teardown in those tests.
         # They currently flood the output, making our test
         # suite output unreadable.
-        if example.file_path.start_with?('./spec/datadog/core/workers/', './spec/ddtrace/workers/')
+        if example.file_path.start_with?(
+          './spec/datadog/core/workers/',
+          './spec/ddtrace/workers/',
+          './spec/datadog/core/remote/worker_spec.rb'
+        )
           puts # Add newline so we get better output when the progress formatter is being used
           RSpec.warning("FIXME: #{example.file_path}:#{example.metadata[:line_number]} is leaking threads")
           next

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -168,8 +168,7 @@ RSpec.configure do |config|
         # suite output unreadable.
         if example.file_path.start_with?(
           './spec/datadog/core/workers/',
-          './spec/ddtrace/workers/',
-          './spec/datadog/core/remote/worker_spec.rb'
+          './spec/ddtrace/workers/'
         )
           puts # Add newline so we get better output when the progress formatter is being used
           RSpec.warning("FIXME: #{example.file_path}:#{example.metadata[:line_number]} is leaking threads")


### PR DESCRIPTION
<!--
Check out the
https://github.com/DataDog/dd-trace-rb/blob/master/docs/DevelopmentGuide.md
for guidance on how to set up your development environment,
run the test suite, write new integrations, and more.
-->

**What does this PR do?**

Implement a polling worker for remote configuration.

**Motivation**

Remote configuration

**Additional Notes**

This is a simple generic polling worker:

- pass it a block via `new` and it'll call it every `interval`
- it can be stopped and started in a thread safe way

There is no fork protection: it is supposed to start on demand when the first request comes in.

**How to test the change?**

Example to use it in conjunction with the remote configuration client is below.

Note that the agent may not reply immediately with a full configuration, but it happens eventually.

```
  require 'ddtrace'

  Datadog.configure do |c|
    c.agent.host = '192.168.135.133'
    #c.tracing.enabled = true
    #c.diagnostics.debug = true
  end

  transport_options = {
    agent_settings: Datadog::Core::Configuration::AgentSettingsResolver.call(
      Datadog.configuration
    )
  }

  require 'datadog/core/transport/http'

  transport_v7 = Datadog::Core::Transport::HTTP.v7(**transport_options.dup)

  require 'datadog/core/remote/client'

  client = Datadog::Core::Remote::Client.new(transport_v7)
  repository = client.instance_eval { @repository }
  
  require 'datadog/core/remote/worker'
  
  worker = Datadog::Core::Remote::Worker.new(interval: 10) do
    client.sync

    puts '========='
    pp repository
    puts '========='
  end

  worker.start
  sleep 100
  worker.stop
  
  repository.contents
  ```