### PR TITLE
Add remote configuration component

### DIFF
--- a/lib/datadog/core/remote.rb
+++ b/lib/datadog/core/remote.rb
@@ -1,0 +1,23 @@
+# frozen_string_literal: true
+
+module Datadog
+  module Core
+    module Remote
+      class << self
+        def active_remote
+          remote
+        end
+
+        private
+
+        def components
+          Datadog.send(:components)
+        end
+
+        def remote
+          components.remote
+        end
+      end
+    end
+  end
+end

--- a/lib/datadog/core/remote/component.rb
+++ b/lib/datadog/core/remote/component.rb
@@ -1,0 +1,42 @@
+# frozen_string_literal: true
+
+require_relative 'worker'
+require_relative 'client'
+require_relative '../transport/http'
+require_relative '../remote'
+
+module Datadog
+  module Core
+    module Remote
+      class Component
+        attr_reader :client
+
+        def initialize(settings, agent_settings)
+          transport_options = {}
+          transport_options[:agent_settings] = agent_settings if agent_settings
+
+          @transport_v7 = Datadog::Core::Transport::HTTP.v7(**transport_options.dup)
+
+          @client = Client.new(@transport_v7)
+          @worker = Worker.new(interval: 1) { @client.sync }
+        end
+
+        def sync
+          # TODO: start elsewere, block smartly. this way makes it start on demand for now
+          @worker.start
+        end
+
+        def shutdown!
+          @worker.stop
+        end
+
+        class << self
+          def build(settings, agent_settings)
+            # TODO: condition with configuration
+            new(settings, agent_settings)
+          end
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
<!--
Check out the
https://github.com/DataDog/dd-trace-rb/blob/master/docs/DevelopmentGuide.md
for guidance on how to set up your development environment,
run the test suite, write new integrations, and more.
-->

**What does this PR do?**

- Add a new component class for remote configuration
- Set up and tear down the component via `Datadog::Core::Configuration::Components`

**Motivation**

Remote configuration

**Additional Notes**

- The component is instantiated but not started until its `sync` method is called, which should be done on demand.
- Its creation is not yet controlled by configuration
- Its settings such as polling rate is not yet controlled by configuration

**How to test the change?**

```
  require 'ddtrace'

  Datadog.configure do |c|
    c.agent.host = '192.168.135.133'
    #c.tracing.enabled = true
    #c.diagnostics.debug = true
  end

  Datadog::Core::Remote.active_remote.sync
  repository = Datadog::Core::Remote.active_remote.client.instance_eval { @repository }

  loop do
    pp repository
    sleep 1
  end
```
