### PR TITLE
Use workaround for steep issue only in GitHub Actions

### DIFF
--- a/.github/workflows/test-macos.yaml
+++ b/.github/workflows/test-macos.yaml
@@ -31,7 +31,7 @@ jobs:
       # head rubies
       - if: ${{ matrix.ruby == 'head' }}
         run: sed -i~ -e '/spec\.required_ruby_version/d' ddtrace.gemspec
-      - uses: ruby/setup-ruby@31a7f6d628878b80bc63375a93ae079ec50a1601 # v1.143.0
+      - uses: ruby/setup-ruby@9669f3ee51dc3f4eda8447ab696b3ab19a90d14b # v1.144.0
         with:
           ruby-version: ${{ matrix.ruby }}
           bundler-cache: true # runs 'bundle install' and caches installed gems automatically

--- a/Gemfile
+++ b/Gemfile
@@ -122,11 +122,10 @@ group :check do
   # bundler that supports pathname as a default gem. (Gem::LoadError)
   #
   # @ivoanjo: For the life of me, I tried updating to the latest bundler, different ways of invoking rake (binstubs, ...)
-  # and could not fix this issue. As a final workaround, I decided to opt for not installing steep on the offending setups.
-  # Hopefully, if you want to run steep on macos, you can either manually remove this, or use a different Ruby (like 3.2)
-  # instead.
-  skip_versions_of_macos_that_fail_in_ci = RUBY_PLATFORM.include?('darwin') && RUBY_VERSION.start_with?('3.0.', '3.1.')
-  if RUBY_VERSION >= '2.7.0' && RUBY_PLATFORM != 'java' && !skip_versions_of_macos_that_fail_in_ci
+  # and could not fix this issue. As a final workaround, I decided to not install steep on the affected Ruby versions on
+  # GitHub Actions.
+  steep_ci_workaround = ENV['GITHUB_ACTIONS'] == 'true' && RUBY_VERSION.start_with?('3.0.', '3.1.')
+  if RUBY_VERSION >= '2.7.0' && RUBY_PLATFORM != 'java' && !steep_ci_workaround
     gem 'rbs', '~> 2.8.1', require: false
     gem 'steep', '~> 1.3.1', require: false
   end


### PR DESCRIPTION
**What does this PR do?**:

This PR tweaks the workaround added in #2675 for the failing combination of steep 1.3.1 with Ruby 3.0 and 3.1 on GitHub Actions (GHA).

In the prior PR, I just excluded `steep` from all macOS configurations running Ruby 3.0 and 3.1, which was a lot more than was needed. In this PR I tweak this to only exclude `steep` when running on GHA, since we have not seen this issue elsewhere.

**Motivation**:

The previous workaround broke the local development setup for one of our colleagues :(

**Additional Notes**:

I also tried bumping to the latest version of the `ruby/setup-ruby` prebuilt action, but that didn't help (but it doesn't hurt either, so I left it in).

**How to test the change?**:

Validate that the "test macOS" GitHub Action, along with all others, are green. Furthermore, validate that `steep` is installed by default for development on macOS.
