### PR TITLE
Fix Rails < 3 conditional check in Utils#railtie_supported?

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -134,6 +134,3 @@ end
 gem 'docile', '~> 1.3.5' if RUBY_VERSION < '2.5'
 gem 'ffi', '~> 1.12.2' if RUBY_VERSION < '2.3'
 gem 'msgpack', '~> 1.3.3' if RUBY_VERSION < '2.4'
-
-# gem 'rails', '< 3'
-gem 'rails'

--- a/Gemfile
+++ b/Gemfile
@@ -134,3 +134,6 @@ end
 gem 'docile', '~> 1.3.5' if RUBY_VERSION < '2.5'
 gem 'ffi', '~> 1.12.2' if RUBY_VERSION < '2.3'
 gem 'msgpack', '~> 1.3.3' if RUBY_VERSION < '2.4'
+
+# gem 'rails', '< 3'
+gem 'rails'

--- a/lib/datadog/tracing/contrib/rails/utils.rb
+++ b/lib/datadog/tracing/contrib/rails/utils.rb
@@ -17,7 +17,7 @@ module Datadog
           end
 
           def self.railtie_supported?
-            !(defined?(::Rails::VERSION::MAJOR) && ::Rails::VERSION::MAJOR >= 3 && defined?(::Rails::Railtie)).nil?
+            !!(defined?(::Rails::VERSION::MAJOR) && ::Rails::VERSION::MAJOR >= 3 && defined?(::Rails::Railtie))
           end
         end
       end

--- a/spec/datadog/tracing/contrib/rails/utils_spec.rb
+++ b/spec/datadog/tracing/contrib/rails/utils_spec.rb
@@ -5,10 +5,6 @@ RSpec.describe Datadog::Tracing::Contrib::Rails::Utils do
   describe 'railtie_supported?' do
     subject(:railtie_supported?) { described_class.railtie_supported? }
 
-    before do
-      stub_const('::Rails::Railtie', instance_double('::Rails::Railtie'))
-    end
-
     context 'on rails 2 and below' do
       before { stub_const('::Rails::VERSION::MAJOR', 2) }
 
@@ -18,6 +14,7 @@ RSpec.describe Datadog::Tracing::Contrib::Rails::Utils do
     context 'on rails 3 and above' do
       before do
         stub_const('::Rails::VERSION::MAJOR', 3)
+        stub_const('::Rails::Railtie', instance_double('::Rails::Railtie'))
       end
 
       it { is_expected.to be true }

--- a/spec/datadog/tracing/contrib/rails/utils_spec.rb
+++ b/spec/datadog/tracing/contrib/rails/utils_spec.rb
@@ -1,0 +1,26 @@
+require 'lib/datadog/tracing/contrib/rails/utils'
+require 'rails/version'
+
+RSpec.describe Datadog::Tracing::Contrib::Rails::Utils do
+  describe 'railtie_supported?' do
+    subject(:railtie_supported?) { described_class.railtie_supported? }
+
+    before do
+      stub_const('::Rails::Railtie', instance_double('::Rails::Railtie'))
+    end
+
+    context 'on rails 2 and below' do
+      before { stub_const('::Rails::VERSION::MAJOR', 2) }
+
+      it { is_expected.to be false }
+    end
+
+    context 'on rails 3 and above' do
+      before do
+        stub_const('::Rails::VERSION::MAJOR', 3)
+      end
+
+      it { is_expected.to be true }
+    end
+  end
+end


### PR DESCRIPTION
**What does this PR do?**
The `Rails::VERSION::MAJOR >= 3` condition evalutes to `false`, but `false` is not `nil?`, so railtie_supported? was returning true, causing the code to attempt to load the railties on Rails version prior to 3. To fix this, I've removed the explicit `.nil?` check and replaced it with a boolean coercion (which will return false for both `nil` and `false`, rather then returning false for `nil` and true for `false`.

**Motivation**
We're integrating ddtrace into an application that uses Rails 2 in production while also supporting Rails 3 in development. 

**Additional Notes**
This change lets the gem at least boot fully enough to instrument some of our ancillary gems (postgres, redis) and run the continuous profiler, which was our biggest goal. There may be more PRs in the future if desired as we enable more Rails 2 functionality, but given the level of customization involved in our Rails 2 setup, I can't necessarily guarantee it.

**How to test the change?**

My server boots ^.^ 

Probably the easiest way to test this is to just mock out the Rails 2 constants in the console to confirm to yourself that the old logic doesn't work and the new logic does work.