### PR TITLE
Add remote configuration changeset

### DIFF
--- a/lib/datadog/core/remote/client.rb
+++ b/lib/datadog/core/remote/client.rb
@@ -36,7 +36,7 @@ module Datadog
             # TODO: sometimes it can strangely be so that paths.empty?
             # TODO: sometimes it can strangely be so that targets.empty?
 
-            changes = repository.transaction do |current, transaction|
+            repository.transaction do |current, transaction|
               # paths to be removed: previously applied paths minus ingress paths
               (current.paths - paths).each { |p| transaction.delete(p) }
 

--- a/lib/datadog/core/remote/client.rb
+++ b/lib/datadog/core/remote/client.rb
@@ -36,7 +36,7 @@ module Datadog
             # TODO: sometimes it can strangely be so that paths.empty?
             # TODO: sometimes it can strangely be so that targets.empty?
 
-            repository.transaction do |current, transaction|
+            changes = repository.transaction do |current, transaction|
               # paths to be removed: previously applied paths minus ingress paths
               (current.paths - paths).each { |p| transaction.delete(p) }
 

--- a/lib/datadog/core/remote/configuration/content.rb
+++ b/lib/datadog/core/remote/configuration/content.rb
@@ -44,6 +44,20 @@ module Datadog
             find { |c| c.path.eql?(path) }
           end
 
+          def []=(path, content)
+            map! { |c| c.path.eql?(path) ? content : c }
+
+            content
+          end
+
+          def delete(path)
+            idx = index { |e| e.path.eql?(path) }
+
+            return if idx.nil?
+
+            delete_at(idx)
+          end
+
           def paths
             map(&:path).uniq
           end

--- a/lib/datadog/core/remote/configuration/content.rb
+++ b/lib/datadog/core/remote/configuration/content.rb
@@ -46,8 +46,6 @@ module Datadog
 
           def []=(path, content)
             map! { |c| c.path.eql?(path) ? content : c }
-
-            content
           end
 
           def delete(path)

--- a/lib/datadog/core/remote/configuration/repository.rb
+++ b/lib/datadog/core/remote/configuration/repository.rb
@@ -187,31 +187,7 @@ module Datadog
             end
           end
 
-          class ChangeSet < Array
-            def paths
-              map { |c| c.path }
-            end
-
-            def add(path, previous, content)
-              return if previous.nil? && content.nil?
-
-              return deleted(path, previous) if content.nil?
-              return inserted(path, content) if previous.nil?
-              return updated(path, content, previous)
-            end
-
-            def deleted(path, previous)
-              self << Change::Deleted.new(path, previous).freeze
-            end
-
-            def inserted(path, content)
-              self << Change::Inserted.new(path, content).freeze
-            end
-
-            def updated(path, content, previous)
-              self << Change::Updated.new(path, content, previous).freeze
-            end
-          end
+          private_constant :Operation
 
           module Change
             class Deleted
@@ -243,7 +219,31 @@ module Datadog
             end
           end
 
-          private_constant :Operation
+          class ChangeSet < Array
+            def paths
+              map { |c| c.path }
+            end
+
+            def add(path, previous, content)
+              return if previous.nil? && content.nil?
+
+              return deleted(path, previous) if previous && content.nil?
+              return inserted(path, content) if content && previous.nil?
+              return updated(path, content, previous) if content && previous
+            end
+
+            def deleted(path, previous)
+              self << Change::Deleted.new(path, previous).freeze
+            end
+
+            def inserted(path, content)
+              self << Change::Inserted.new(path, content).freeze
+            end
+
+            def updated(path, content, previous)
+              self << Change::Updated.new(path, content, previous).freeze
+            end
+          end
         end
       end
     end

--- a/lib/datadog/core/remote/configuration/repository.rb
+++ b/lib/datadog/core/remote/configuration/repository.rb
@@ -43,8 +43,8 @@ module Datadog
           def commit(transaction)
             previous = contents.dup
 
-            touched = transaction.operations.each_with_object([]) do |op, touched|
-              touched << op.apply(self)
+            touched = transaction.operations.each_with_object([]) do |op, acc|
+              acc << op.apply(self)
             end
 
             changes = ChangeSet.new
@@ -190,6 +190,7 @@ module Datadog
           private_constant :Operation
 
           module Change
+            # Delete change
             class Deleted
               attr_reader :path, :previous
 
@@ -199,6 +200,7 @@ module Datadog
               end
             end
 
+            # Insert change
             class Inserted
               attr_reader :path, :content
 
@@ -208,6 +210,7 @@ module Datadog
               end
             end
 
+            # Update change
             class Updated
               attr_reader :path, :content, :previous
 
@@ -219,9 +222,10 @@ module Datadog
             end
           end
 
+          # Store list of Changes
           class ChangeSet < Array
             def paths
-              map { |c| c.path }
+              map(&:path)
             end
 
             def add(path, previous, content)

--- a/sig/datadog/core/remote/configuration/content.rbs
+++ b/sig/datadog/core/remote/configuration/content.rbs
@@ -19,6 +19,10 @@ module Datadog
 
           def []: (Configuration::Path path) ->  Content?
 
+          def []=: (Configuration::Path path, Content content) -> Content
+
+          def delete: (Configuration::Path path) -> Content?
+
           def paths: () -> ::Array[Path]
         end
       end

--- a/sig/datadog/core/remote/configuration/content.rbs
+++ b/sig/datadog/core/remote/configuration/content.rbs
@@ -19,7 +19,7 @@ module Datadog
 
           def []: (Configuration::Path path) ->  Content?
 
-          def []=: (Configuration::Path path, Content content) -> Content
+          def []=: (Configuration::Path path, Content content) -> ContentList
 
           def delete: (Configuration::Path path) -> Content?
 

--- a/sig/datadog/core/remote/configuration/repository.rbs
+++ b/sig/datadog/core/remote/configuration/repository.rbs
@@ -23,7 +23,7 @@ module Datadog
 
           def transaction: () { (Repository, Transaction) -> void } -> void
 
-          def commit: (Transaction transaction) -> void
+          def commit: (Transaction transaction) -> ChangeSet
 
           def state: () -> State
 
@@ -100,6 +100,48 @@ module Datadog
               def initialize: (**untyped options) -> void
 
               def apply: (Repository repository) -> void
+            end
+          end
+
+          type change = Change::Deleted | Change::Inserted | Change::Updated
+
+          class ChangeSet < Array[change]
+            def paths: () -> Array[Configuration::Path]?
+
+            def add: (Configuration::Path path, Configuration::Content? previous, Configuration::Content? content) -> ChangeSet?
+
+            def deleted: (Configuration::Path path, Configuration::Content previous) -> ChangeSet
+
+            def inserted: (Configuration::Path path, Configuration::Content content) -> ChangeSet
+
+            def updated: (Configuration::Path path, Configuration::Content content, Configuration::Content previous) -> ChangeSet
+          end
+
+          module Change
+            class Deleted
+              attr_reader path: Configuration::Path
+
+              attr_reader previous: Configuration::Content
+
+              def initialize: (untyped path, Configuration::Content previous) -> void
+            end
+
+            class Inserted
+              attr_reader path: Configuration::Path
+
+              attr_reader content: Configuration::Content
+
+              def initialize: (Configuration::Path path, Configuration::Content content) -> void
+            end
+
+            class Updated
+              attr_reader path: Configuration::Path
+
+              attr_reader content: Configuration::Content
+
+              attr_reader previous: Configuration::Content
+
+              def initialize: (Configuration::Path path, Configuration::Content content, Configuration::Content previous) -> void
             end
           end
         end

--- a/spec/datadog/core/remote/configuration/content_spec.rb
+++ b/spec/datadog/core/remote/configuration/content_spec.rb
@@ -105,6 +105,51 @@ RSpec.describe Datadog::Core::Remote::Configuration::ContentList do
     end
   end
 
+  describe '#[]=' do
+    let(:updated_string_io) { StringIO.new('Hello World') }
+    let(:updated_content) do
+      Datadog::Core::Remote::Configuration::Content.parse(
+        {
+          :path => path.to_s,
+          :content => updated_string_io
+        }
+      )
+    end
+
+    it 'replaces content for an existing path' do
+      content = content_list[path]
+      expect(content.data).to eq(string_io_content)
+      content_list[path] = updated_content
+
+      content = content_list[path]
+      expect(content.data).to eq(updated_string_io)
+    end
+
+    it 'if path does not match does not updates it' do
+      non_existing_path = Datadog::Core::Remote::Configuration::Path.parse('employee/ASM/exclusion_filters/config')
+
+      content_list[non_existing_path] = updated_content
+      expect(content_list[non_existing_path]).to be_nil
+    end
+  end
+
+  describe '#delete' do
+    it 'removes content from list' do
+      content = content_list[path]
+      expect(content.data).to eq(string_io_content)
+
+      expect(content_list.delete(path)).to eq(content)
+
+      expect(content_list[path]).to be_nil
+    end
+
+    it 'if path does not exists returns nil' do
+      non_existing_path = Datadog::Core::Remote::Configuration::Path.parse('employee/ASM/exclusion_filters/config')
+
+      expect(content_list.delete(non_existing_path)).to be_nil
+    end
+  end
+
   describe '#paths' do
     it 'returns an array of paths instance' do
       paths = content_list.paths


### PR DESCRIPTION
<!--
Check out the
https://github.com/DataDog/dd-trace-rb/blob/master/docs/DevelopmentGuide.md
for guidance on how to set up your development environment,
run the test suite, write new integrations, and more.
-->

**What does this PR do?**

Add a reporting of which paths were touched, what the content was before and what it is after the transaction.

**Motivation**

Remote configuration.

Contrary to transactions which are a sequential list of operations to apply in order, for mutative usage internal to the repository, a changeset is a report of state change, for a consumer external to the repository (more precisely the upcoming dispatcher).

**Additional Notes**

Using an `Array`-based `ContentList` may not be the most optimal data structure. I am considering changing it to a `Hash`-based `ContentMap` instead in the future. Nonetheless, `ContentList` does the job for this PR.

**How to test the change?**

```
  require 'datadog/core/remote/configuration/path'
  require 'datadog/core/remote/configuration/target'
  require 'datadog/core/remote/configuration/content'

  path2 = Datadog::Core::Remote::Configuration::Path.parse('datadog/42/PRODUCT/bar/config')
  content2 = Datadog::Core::Remote::Configuration::Content.parse({path: 'datadog/42/PRODUCT/bar/config', content: StringIO.new('Lorem ipsum')})
  target2 = Datadog::Core::Remote::Configuration::Target.parse({'length' => 11, 'hashes' => {'sha256' => 'a9a66978f378456c818fb8a3e7c6ad3d2c83e62724ccbdea7b36253fb8df5edd'}})
  content3 = Datadog::Core::Remote::Configuration::Content.parse({path: 'datadog/42/PRODUCT/foo/config', content: StringIO.new('dolor sit amet')})
  target3 = Datadog::Core::Remote::Configuration::Target.parse({'length' => 11, 'hashes' => {'sha256' => 'aa8311d08b68a5fdda55ad0947fff3c5a4b2397f5f766e9c9a79f4a5486c633c'}})

  require 'datadog/core/remote/configuration/repository'

  repository = Datadog::Core::Remote::Configuration::Repository.new

  changes = repository.transaction do |repo, txn|
    txn.insert(path, target, content) # new => change
    txn.insert(path2, target2, content2) # new => change
    txn.set(targets_version: 42) # no path touched  => no change
    txn.update(path, target3, content3) # different => change
  end

  changes # should have 2 inserts, with content2 and content3

  changes = repository.transaction do |repo, txn|
    txn.update(path, target, content) # new => change
    txn.insert(path2, target2, content2) # already there => no change
  end

  changes # should have 1 update

  changes = repository.transaction do |repo, txn|
    txn.delete(path) # exists => change
  end

  changes # should have 1 delete

  changes = repository.transaction do |repo, txn|
    txn.delete(path) # absent => no change
  end
 
  changes # should have no delete
```