### PR TITLE
[PROF-6555] Support disabling endpoint names collection in new profiler

### DIFF
--- a/benchmarks/profiler_sample_loop_v2.rb
+++ b/benchmarks/profiler_sample_loop_v2.rb
@@ -17,7 +17,8 @@ class ProfilerSampleLoopBenchmark
 
   def create_profiler
     @recorder = Datadog::Profiling::StackRecorder.new(cpu_time_enabled: true, alloc_samples_enabled: true)
-    @collector = Datadog::Profiling::Collectors::ThreadContext.new(recorder: @recorder, max_frames: 400, tracer: nil)
+    @collector =
+      Datadog::Profiling::Collectors::ThreadContext.new(recorder: @recorder, max_frames: 400, tracer: nil, endpoint_collection_enabled: false)
   end
 
   def thread_with_very_deep_stack(depth: 500)

--- a/lib/datadog/profiling/collectors/cpu_and_wall_time_worker.rb
+++ b/lib/datadog/profiling/collectors/cpu_and_wall_time_worker.rb
@@ -17,9 +17,15 @@ module Datadog
           recorder:,
           max_frames:,
           tracer:,
+          endpoint_collection_enabled:,
           gc_profiling_enabled:,
           allocation_counting_enabled:,
-          thread_context_collector: ThreadContext.new(recorder: recorder, max_frames: max_frames, tracer: tracer),
+          thread_context_collector: ThreadContext.new(
+            recorder: recorder,
+            max_frames: max_frames,
+            tracer: tracer,
+            endpoint_collection_enabled: endpoint_collection_enabled,
+          ),
           idle_sampling_helper: IdleSamplingHelper.new
         )
           self.class._native_initialize(

--- a/lib/datadog/profiling/collectors/thread_context.rb
+++ b/lib/datadog/profiling/collectors/thread_context.rb
@@ -14,9 +14,9 @@ module Datadog
       #
       # Methods prefixed with _native_ are implemented in `collectors_thread_context.c`
       class ThreadContext
-        def initialize(recorder:, max_frames:, tracer:)
+        def initialize(recorder:, max_frames:, tracer:, endpoint_collection_enabled:)
           tracer_context_key = safely_extract_context_key_from(tracer)
-          self.class._native_initialize(self, recorder, max_frames, tracer_context_key)
+          self.class._native_initialize(self, recorder, max_frames, tracer_context_key, endpoint_collection_enabled)
         end
 
         def inspect

--- a/lib/datadog/profiling/component.rb
+++ b/lib/datadog/profiling/component.rb
@@ -75,7 +75,7 @@ module Datadog
             recorder: recorder,
             max_frames: settings.profiling.advanced.max_frames,
             tracer: optional_tracer,
-            endpoint_collection_enabled: true, # settings.profiling.advanced.endpoint.collection.enabled,
+            endpoint_collection_enabled: settings.profiling.advanced.endpoint.collection.enabled,
             gc_profiling_enabled: enable_gc_profiling?(settings),
             allocation_counting_enabled: settings.profiling.advanced.allocation_counting_enabled,
           )

--- a/lib/datadog/profiling/component.rb
+++ b/lib/datadog/profiling/component.rb
@@ -75,6 +75,7 @@ module Datadog
             recorder: recorder,
             max_frames: settings.profiling.advanced.max_frames,
             tracer: optional_tracer,
+            endpoint_collection_enabled: true, # settings.profiling.advanced.endpoint.collection.enabled,
             gc_profiling_enabled: enable_gc_profiling?(settings),
             allocation_counting_enabled: settings.profiling.advanced.allocation_counting_enabled,
           )

--- a/spec/datadog/profiling/component_spec.rb
+++ b/spec/datadog/profiling/component_spec.rb
@@ -106,6 +106,7 @@ RSpec.describe Datadog::Profiling::Component do
             recorder: instance_of(Datadog::Profiling::StackRecorder),
             max_frames: settings.profiling.advanced.max_frames,
             tracer: tracer,
+            endpoint_collection_enabled: anything,
             gc_profiling_enabled: anything,
             allocation_counting_enabled: anything,
           )
@@ -193,6 +194,28 @@ RSpec.describe Datadog::Profiling::Component do
           it 'initializes a CpuAndWallTimeWorker collector with allocation_counting_enabled set to false' do
             expect(Datadog::Profiling::Collectors::CpuAndWallTimeWorker).to receive(:new).with hash_including(
               allocation_counting_enabled: false,
+            )
+
+            build_profiler_component
+          end
+        end
+
+        it 'initializes a CpuAndWallTimeWorker collector with endpoint_collection_enabled set to true' do
+          expect(Datadog::Profiling::Collectors::CpuAndWallTimeWorker).to receive(:new).with hash_including(
+            endpoint_collection_enabled: true,
+          )
+
+          build_profiler_component
+        end
+
+        context 'when endpoint_collection_enabled is disabled' do
+          before do
+            settings.profiling.advanced.endpoint.collection.enabled = false
+          end
+
+          it 'initializes a CpuAndWallTimeWorker collector with endpoint_collection_enabled set to false' do
+            expect(Datadog::Profiling::Collectors::CpuAndWallTimeWorker).to receive(:new).with hash_including(
+              endpoint_collection_enabled: true,
             )
 
             build_profiler_component

--- a/spec/datadog/profiling/component_spec.rb
+++ b/spec/datadog/profiling/component_spec.rb
@@ -215,7 +215,7 @@ RSpec.describe Datadog::Profiling::Component do
 
           it 'initializes a CpuAndWallTimeWorker collector with endpoint_collection_enabled set to false' do
             expect(Datadog::Profiling::Collectors::CpuAndWallTimeWorker).to receive(:new).with hash_including(
-              endpoint_collection_enabled: true,
+              endpoint_collection_enabled: false,
             )
 
             build_profiler_component


### PR DESCRIPTION
**What does this PR do?**:

This PR updates the new CPU Profiling 2.0 profiler to honor the existing `profiling.advanced.endpoint.collection.enabled` setting.

This setting defaults to enabled. When disabled, the profiler will omit endpoint names in the collected data.

**Motivation**:

Not supporting this was an oversight; the new profiler (still in beta) should honor this setting.

**Additional Notes**:

I'm opening this PR on top of #2697 to avoid conflicts, but both PRs are conceptually independent.

**How to test the change?**:

Change includes test coverage.
