### PR TITLE
[PROF-7360] Enable CPU Profiling 2.0 by default

### DIFF
--- a/benchmarks/profiler_sample_loop.rb
+++ b/benchmarks/profiler_sample_loop.rb
@@ -21,6 +21,7 @@ class ProfilerSampleLoopBenchmark
       c.profiling.enabled = true
       c.profiling.exporter.transport = MockProfilerTransport.new
       c.tracing.transport_options = proc { |t| t.adapter :test }
+      c.profiling.advanced.force_enable_legacy_profiler = true
     end
 
     # Stop background threads

--- a/ext/ddtrace_profiling_native_extension/private_vm_api_access.c
+++ b/ext/ddtrace_profiling_native_extension/private_vm_api_access.c
@@ -652,6 +652,7 @@ check_method_entry(VALUE obj, int can_be_svar)
         if (can_be_svar) {
             return check_method_entry(((struct vm_svar *)obj)->cref_or_me, FALSE);
         }
+        // fallthrough
       default:
 #if VM_CHECK_MODE > 0
         rb_bug("check_method_entry: svar should not be there:");

--- a/ext/ddtrace_profiling_native_extension/private_vm_api_access.c
+++ b/ext/ddtrace_profiling_native_extension/private_vm_api_access.c
@@ -19,6 +19,7 @@
   #pragma GCC diagnostic push
   #pragma GCC diagnostic ignored "-Wunused-parameter"
   #pragma GCC diagnostic ignored "-Wattributes"
+  #pragma GCC diagnostic ignored "-Wpragmas"
   #pragma GCC diagnostic ignored "-Wexpansion-to-defined"
     #include <vm_core.h>
   #pragma GCC diagnostic pop

--- a/ext/ddtrace_profiling_native_extension/private_vm_api_access.c
+++ b/ext/ddtrace_profiling_native_extension/private_vm_api_access.c
@@ -19,6 +19,7 @@
   #pragma GCC diagnostic push
   #pragma GCC diagnostic ignored "-Wunused-parameter"
   #pragma GCC diagnostic ignored "-Wattributes"
+  #pragma GCC diagnostic ignored "-Wexpansion-to-defined"
     #include <vm_core.h>
   #pragma GCC diagnostic pop
   #include <iseq.h>

--- a/integration/apps/rack/spec/integration/basic_spec.rb
+++ b/integration/apps/rack/spec/integration/basic_spec.rb
@@ -14,7 +14,18 @@ RSpec.describe 'Basic scenarios' do
   let(:expected_profiler_available) { RUBY_VERSION >= '2.3' }
 
   let(:expected_profiler_threads) do
-    contain_exactly('Datadog::Profiling::Collectors::OldStack', 'Datadog::Profiling::Scheduler') unless RUBY_VERSION < '2.3'
+    if RUBY_VERSION >= '2.6.'
+      contain_exactly(
+        'Datadog::Profiling::Collectors::IdleSamplingHelper',
+        'Datadog::Profiling::Collectors::CpuAndWallTimeWorker',
+        'Datadog::Profiling::Scheduler',
+      )
+    elsif RUBY_VERSION >= '2.3'
+      contain_exactly(
+        'Datadog::Profiling::Collectors::OldStack',
+        'Datadog::Profiling::Scheduler',
+      )
+    end
   end
 
   context 'component checks' do

--- a/integration/apps/sinatra2-classic/spec/integration/basic_spec.rb
+++ b/integration/apps/sinatra2-classic/spec/integration/basic_spec.rb
@@ -14,7 +14,18 @@ RSpec.describe 'Basic scenarios' do
   let(:expected_profiler_available) { RUBY_VERSION >= '2.3' }
 
   let(:expected_profiler_threads) do
-    contain_exactly('Datadog::Profiling::Collectors::OldStack', 'Datadog::Profiling::Scheduler') unless RUBY_VERSION < '2.3'
+    if RUBY_VERSION >= '2.6.'
+      contain_exactly(
+        'Datadog::Profiling::Collectors::IdleSamplingHelper',
+        'Datadog::Profiling::Collectors::CpuAndWallTimeWorker',
+        'Datadog::Profiling::Scheduler',
+      )
+    elsif RUBY_VERSION >= '2.3'
+      contain_exactly(
+        'Datadog::Profiling::Collectors::OldStack',
+        'Datadog::Profiling::Scheduler',
+      )
+    end
   end
 
   context 'component checks' do

--- a/integration/apps/sinatra2-modular/spec/integration/basic_spec.rb
+++ b/integration/apps/sinatra2-modular/spec/integration/basic_spec.rb
@@ -14,7 +14,18 @@ RSpec.describe 'Basic scenarios' do
   let(:expected_profiler_available) { RUBY_VERSION >= '2.3' }
 
   let(:expected_profiler_threads) do
-    contain_exactly('Datadog::Profiling::Collectors::OldStack', 'Datadog::Profiling::Scheduler') unless RUBY_VERSION < '2.3'
+    if RUBY_VERSION >= '2.6.'
+      contain_exactly(
+        'Datadog::Profiling::Collectors::IdleSamplingHelper',
+        'Datadog::Profiling::Collectors::CpuAndWallTimeWorker',
+        'Datadog::Profiling::Scheduler',
+      )
+    elsif RUBY_VERSION >= '2.3'
+      contain_exactly(
+        'Datadog::Profiling::Collectors::OldStack',
+        'Datadog::Profiling::Scheduler',
+      )
+    end
   end
 
   context 'component checks' do

--- a/lib/datadog/core/configuration/settings.rb
+++ b/lib/datadog/core/configuration/settings.rb
@@ -261,6 +261,18 @@ module Datadog
               o.lazy
             end
 
+            # Forces enabling the *legacy* (non-CPU Profiling 2.0 profiler) even when it would otherwise NOT be enabled.
+            #
+            # Temporarily added to ease migration to the new CPU Profiling 2.0 profiler, and will be removed soon.
+            # Do not use unless instructed to by support.
+            # This option will be deprecated for removal once the legacy profiler is removed.
+            #
+            # @default `DD_PROFILING_FORCE_ENABLE_LEGACY` environment variable, otherwise `false`
+            option :force_enable_legacy_profiler do |o|
+              o.default { env_to_bool('DD_PROFILING_FORCE_ENABLE_LEGACY', false) }
+              o.lazy
+            end
+
             # Forces enabling of profiling of time/resources spent in Garbage Collection.
             #
             # Note that setting this to "false" (or not setting it) will not prevent the feature from being

--- a/lib/datadog/core/configuration/settings.rb
+++ b/lib/datadog/core/configuration/settings.rb
@@ -205,7 +205,7 @@ module Datadog
             # The default should be enough for most services, allowing 16 threads to be sampled around 30 times
             # per second for a 60 second period.
             #
-            # This setting is ignored when CPU Profiling 2.0 is in use.
+            # Deprecated for removal: This setting is ignored when CPU Profiling 2.0 is in use.
             option :max_events, default: 32768
 
             # Controls the maximum number of frames for each thread sampled. Can be tuned to avoid omitted frames in the

--- a/lib/datadog/core/configuration/settings.rb
+++ b/lib/datadog/core/configuration/settings.rb
@@ -202,7 +202,7 @@ module Datadog
           # @public_api
           settings :advanced do
             # This should never be reduced, as it can cause the resulting profiles to become biased.
-            # The current default should be enough for most services, allowing 16 threads to be sampled around 30 times
+            # The default should be enough for most services, allowing 16 threads to be sampled around 30 times
             # per second for a 60 second period.
             #
             # This setting is ignored when CPU Profiling 2.0 is in use.
@@ -252,8 +252,8 @@ module Datadog
             # Forces enabling the new CPU Profiling 2.0 profiler (see ddtrace release notes for more details).
             #
             # Note that setting this to "false" (or not setting it) will not prevent the new profiler from
-            # being automatically used in the future.
-            # This option will be deprecated for removal once the new profiler gets enabled by default for all customers.
+            # being automatically used.
+            # This option will be deprecated for removal once the legacy profiler is removed.
             #
             # @default `DD_PROFILING_FORCE_ENABLE_NEW` environment variable, otherwise `false`
             option :force_enable_new_profiler do |o|
@@ -266,14 +266,13 @@ module Datadog
             # Note that setting this to "false" (or not setting it) will not prevent the feature from being
             # being automatically enabled in the future.
             #
-            # This toggle was added because, although this feature is safe and enabled by default on Ruby 2.x,
-            # on Ruby 3.x it can break in applications that make use of Ractors due to two Ruby VM bugs:
-            # https://bugs.ruby-lang.org/issues/19112 AND https://bugs.ruby-lang.org/issues/18464.
-            #
-            # If you use Ruby 3.x and your application does not use Ractors (or if your Ruby has been patched), the
-            # feature is fully safe to enable and this toggle can be used to do so.
-            #
-            # Furthermore, currently this feature can add a lot of overhead for GC-heavy workloads.
+            # This feature defaults to off for two reasons:
+            # 1. Currently this feature can add a lot of overhead for GC-heavy workloads.
+            # 2. Although this feature is safe on Ruby 2.x, on Ruby 3.x it can break in applications that make use of
+            #    Ractors due to two Ruby VM bugs:
+            #    https://bugs.ruby-lang.org/issues/19112 AND https://bugs.ruby-lang.org/issues/18464.
+            #    If you use Ruby 3.x and your application does not use Ractors (or if your Ruby has been patched), the
+            #    feature is fully safe to enable and this toggle can be used to do so.
             #
             # We expect the once the above issues are overcome, we'll automatically enable the feature on fixed Ruby
             # versions.
@@ -292,6 +291,8 @@ module Datadog
             #
             # If you use Ruby 3.x and your application does not use Ractors (or if your Ruby has been patched), the
             # feature is fully safe to enable and this toggle can be used to do so.
+            #
+            # @default `true` on Ruby 2.x, `false` on Ruby 3.x
             option :allocation_counting_enabled, default: RUBY_VERSION.start_with?('2.')
           end
 

--- a/lib/datadog/core/configuration/settings.rb
+++ b/lib/datadog/core/configuration/settings.rb
@@ -205,7 +205,7 @@ module Datadog
             # The default should be enough for most services, allowing 16 threads to be sampled around 30 times
             # per second for a 60 second period.
             #
-            # Deprecated for removal: This setting is ignored when CPU Profiling 2.0 is in use.
+            # @deprecated This setting is ignored when CPU Profiling 2.0 is in use.
             option :max_events, default: 32768
 
             # Controls the maximum number of frames for each thread sampled. Can be tuned to avoid omitted frames in the
@@ -236,7 +236,7 @@ module Datadog
             # grouping and categorization of stack traces.
             option :code_provenance_enabled, default: true
 
-            # No longer does anything, and will be removed on dd-trace-rb 2.0.
+            # @deprecated No longer does anything, and will be removed on dd-trace-rb 2.0.
             #
             # This was added as a temporary support option in case of issues with the new `Profiling::HttpTransport` class
             # but we're now confident it's working nicely so we've removed the old code path.

--- a/lib/datadog/profiling/component.rb
+++ b/lib/datadog/profiling/component.rb
@@ -142,21 +142,16 @@ module Datadog
       end
 
       private_class_method def self.print_new_profiler_warnings
-        if Gem::Version.new(RUBY_VERSION) >= Gem::Version.new('2.6')
-          Datadog.logger.warn(
-            'New Ruby profiler has been force-enabled. This is a beta feature. Please report any issues ' \
-            'you run into to Datadog support or via <https://github.com/datadog/dd-trace-rb/issues/new>!'
-          )
-        else
-          # For more details on the issue, see the "BIG Issue" comment on `gvl_owner` function in
-          # `private_vm_api_access.c`.
-          Datadog.logger.warn(
-            'New Ruby profiler has been force-enabled on a legacy Ruby version (< 2.6). This is not recommended in ' \
-            'production environments, as due to limitations in Ruby APIs, we suspect it may lead to crashes in very ' \
-            'rare situations. Please report any issues you run into to Datadog support or ' \
-            'via <https://github.com/datadog/dd-trace-rb/issues/new>!'
-          )
-        end
+        return if Gem::Version.new(RUBY_VERSION) >= Gem::Version.new('2.6')
+
+        # For more details on the issue, see the "BIG Issue" comment on `gvl_owner` function in
+        # `private_vm_api_access.c`.
+        Datadog.logger.warn(
+          'The new CPU Profiling 2.0 profiler has been force-enabled on a legacy Ruby version (< 2.6). This is not ' \
+          'recommended in production environments, as due to limitations in Ruby APIs, we suspect it may lead to crashes ' \
+          'in very rare situations. Please report any issues you run into to Datadog support or ' \
+          'via <https://github.com/datadog/dd-trace-rb/issues/new>!'
+        )
       end
 
       private_class_method def self.enable_new_profiler?(settings)

--- a/lib/datadog/profiling/component.rb
+++ b/lib/datadog/profiling/component.rb
@@ -64,7 +64,7 @@ module Datadog
 
         # NOTE: Please update the Initialization section of ProfilingDevelopment.md with any changes to this method
 
-        if settings.profiling.advanced.force_enable_new_profiler
+        if enable_new_profiler?(settings)
           print_new_profiler_warnings
 
           recorder = Datadog::Profiling::StackRecorder.new(

--- a/sig/datadog/profiling/component.rbs
+++ b/sig/datadog/profiling/component.rbs
@@ -28,6 +28,8 @@ module Datadog
       def self.enable_gc_profiling?: (untyped settings) -> bool
 
       def self.print_new_profiler_warnings: () -> void
+
+      def self.enable_new_profiler?: (untyped settings) -> bool
     end
   end
 end

--- a/spec/datadog/core/configuration/settings_spec.rb
+++ b/spec/datadog/core/configuration/settings_spec.rb
@@ -460,6 +460,41 @@ RSpec.describe Datadog::Core::Configuration::Settings do
         end
       end
 
+      describe '#force_enable_legacy_profiler' do
+        subject(:force_enable_legacy_profiler) { settings.profiling.advanced.force_enable_legacy_profiler }
+
+        context 'when DD_PROFILING_FORCE_ENABLE_LEGACY' do
+          around do |example|
+            ClimateControl.modify('DD_PROFILING_FORCE_ENABLE_LEGACY' => environment) do
+              example.run
+            end
+          end
+
+          context 'is not defined' do
+            let(:environment) { nil }
+
+            it { is_expected.to be false }
+          end
+
+          { 'true' => true, 'false' => false }.each do |string, value|
+            context "is defined as #{string}" do
+              let(:environment) { string }
+
+              it { is_expected.to be value }
+            end
+          end
+        end
+      end
+
+      describe '#force_enable_legacy_profiler=' do
+        it 'updates the #force_enable_legacy_profiler setting' do
+          expect { settings.profiling.advanced.force_enable_legacy_profiler = true }
+            .to change { settings.profiling.advanced.force_enable_legacy_profiler }
+            .from(false)
+            .to(true)
+        end
+      end
+
       describe '#force_enable_gc_profiling' do
         subject(:force_enable_gc_profiling) { settings.profiling.advanced.force_enable_gc_profiling }
 

--- a/spec/datadog/profiling/component_spec.rb
+++ b/spec/datadog/profiling/component_spec.rb
@@ -137,7 +137,7 @@ RSpec.describe Datadog::Profiling::Component do
 
           it 'logs a warning message mentioning that profiler has been force-enabled AND that it may cause issues' do
             expect(Datadog.logger).to receive(:warn).with(
-              /New Ruby profiler has been force-enabled on a legacy Ruby version \(< 2.6\). This is not recommended/
+              /The new CPU Profiling 2.0 profiler has been force-enabled on a legacy Ruby version/
             )
 
             build_profiler_component

--- a/spec/datadog/profiling/component_spec.rb
+++ b/spec/datadog/profiling/component_spec.rb
@@ -342,6 +342,8 @@ RSpec.describe Datadog::Profiling::Component do
   describe '.enable_new_profiler?' do
     subject(:enable_new_profiler?) { described_class.send(:enable_new_profiler?, settings) }
 
+    before { skip_if_profiling_not_supported(self) }
+
     context 'when force_enable_legacy_profiler is enabled' do
       before do
         settings.profiling.advanced.force_enable_legacy_profiler = true

--- a/spec/datadog/profiling/component_spec.rb
+++ b/spec/datadog/profiling/component_spec.rb
@@ -114,18 +114,6 @@ RSpec.describe Datadog::Profiling::Component do
           build_profiler_component
         end
 
-        context 'on Ruby 2.6 and above' do
-          before { skip 'Behavior does not apply to current Ruby version' if RUBY_VERSION < '2.6.' }
-
-          it 'logs a warning message mentioning that profiler has been force-enabled' do
-            expect(Datadog.logger).to receive(:warn).with(
-              /New Ruby profiler has been force-enabled. This is a beta feature/
-            )
-
-            build_profiler_component
-          end
-        end
-
         context 'on Ruby 2.5 and below' do
           before { skip 'Behavior does not apply to current Ruby version' if RUBY_VERSION >= '2.6.' }
 

--- a/spec/datadog/profiling/component_spec.rb
+++ b/spec/datadog/profiling/component_spec.rb
@@ -101,7 +101,11 @@ RSpec.describe Datadog::Profiling::Component do
       end
 
       context 'when using the new CPU Profiling 2.0 profiler' do
-        before { expect(described_class).to receive(:enable_new_profiler?).with(settings).and_return(true) }
+        before do
+          expect(described_class).to receive(:enable_new_profiler?).with(settings).and_return(true)
+          # Silence warning spam about using the new profiler on legacy Rubies
+          allow(Datadog.logger).to receive(:warn) if RUBY_VERSION < '2.6.'
+        end
 
         it 'does not initialize the OldStack collector' do
           expect(Datadog::Profiling::Collectors::OldStack).to_not receive(:new)

--- a/spec/datadog/profiling/tasks/setup_spec.rb
+++ b/spec/datadog/profiling/tasks/setup_spec.rb
@@ -13,19 +13,11 @@ RSpec.describe Datadog::Profiling::Tasks::Setup do
 
     before do
       described_class::ACTIVATE_EXTENSIONS_ONLY_ONCE.send(:reset_ran_once_state_for_tests)
-
-      allow(task).to receive(:check_if_cpu_time_profiling_is_supported)
     end
 
     it 'actives the forking extension before setting up the at_fork hooks' do
       expect(task).to receive(:activate_forking_extensions).ordered
       expect(task).to receive(:setup_at_fork_hooks).ordered
-
-      run
-    end
-
-    it 'checks if CPU time profiling is available' do
-      expect(task).to receive(:check_if_cpu_time_profiling_is_supported)
 
       run
     end
@@ -116,36 +108,6 @@ RSpec.describe Datadog::Profiling::Tasks::Setup do
     end
   end
 
-  describe '#check_if_cpu_time_profiling_is_supported' do
-    subject(:check_if_cpu_time_profiling_is_supported) { task.send(:check_if_cpu_time_profiling_is_supported) }
-
-    before do
-      expect(task).to receive(:cpu_time_profiling_unsupported_reason).and_return(unsupported_reason)
-    end
-
-    context 'when CPU time profiling is supported' do
-      let(:unsupported_reason) { nil }
-
-      it 'does not log a message' do
-        expect(Datadog.logger).to_not receive(:info)
-
-        check_if_cpu_time_profiling_is_supported
-      end
-    end
-
-    context 'when CPU time profiling is not supported' do
-      let(:unsupported_reason) { 'Simulated failure' }
-
-      it 'logs info message' do
-        expect(Datadog.logger).to receive(:info) do |&message|
-          expect(message.call).to include('CPU time profiling skipped')
-        end
-
-        check_if_cpu_time_profiling_is_supported
-      end
-    end
-  end
-
   describe '#setup_at_fork_hooks' do
     subject(:setup_at_fork_hooks) { task.send(:setup_at_fork_hooks) }
 
@@ -210,44 +172,6 @@ RSpec.describe Datadog::Profiling::Tasks::Setup do
 
           setup_at_fork_hooks
         end
-      end
-    end
-  end
-
-  describe '#cpu_time_profiling_unsupported_reason' do
-    subject(:cpu_time_profiling_unsupported_reason) { task.send(:cpu_time_profiling_unsupported_reason) }
-
-    context 'when JRuby is used' do
-      before { stub_const('RUBY_ENGINE', 'jruby') }
-
-      it { is_expected.to include 'JRuby' }
-    end
-
-    context 'when using MRI Ruby' do
-      before { stub_const('RUBY_ENGINE', 'ruby') }
-
-      context 'when running on macOS' do
-        before { stub_const('RUBY_PLATFORM', 'x86_64-darwin19') }
-
-        it { is_expected.to include 'macOS' }
-      end
-
-      context 'when running on Windows' do
-        before { stub_const('RUBY_PLATFORM', 'mswin') }
-
-        it { is_expected.to include 'Windows' }
-      end
-
-      context 'when running on a non-Linux platform' do
-        before { stub_const('RUBY_PLATFORM', 'my-homegrown-os') }
-
-        it { is_expected.to include 'my-homegrown-os' }
-      end
-
-      context 'when running on Linux' do
-        before { stub_const('RUBY_PLATFORM', 'x86_64-linux-gnu') }
-
-        it { is_expected.to be nil }
       end
     end
   end


### PR DESCRIPTION
**What does this PR do?**:

This PR graduates the new CPU Profiling 2.0 profiler from being in beta to being GA (general availability).

For reference on the advantages brought by the new profiler, check the [dd-trace-rb 1.10.0 release notes](https://github.com/DataDog/dd-trace-rb/releases/tag/v1.10.0).

Whenever profiling is enabled, the CPU Profiling 2.0 profiler will now be used by default unless:

1. The `mysql2` gem is installed. Older versions of libmysqlclient (the C library used by the mysql2 gem) have a bug in their signal handling code that the profiler can trigger. This bug (https://bugs.mysql.com/bug.php?id=83109) is fixed in libmysqlclient versions 8.0.0 and above.

   Because currently we don't (yet?) have a way to detect which version of libmysqlclient is in use by the `mysql2` gem, we opt for disabling CPU Profiling 2.0 in these situations, and emit a warning message telling why this has happened.

2. The profiler is running on Ruby 2.5 or below. These Ruby versions are missing an API that allows the profiler to detect the currently-active Ruby thread. We have deployed a workaround, but suspect that it may lead to crashes in extremely rare situations. (We've never seen the crashes in practice, but we can't be sure given how the VM behaves on those versions.)

This PR also adds a (temporary, expected to be deprecated) setting that can be used to force the legacy profiler to be used instead of the new CPU Profiling 2.0 profiler.

We do not recommend the use of this setting unless instructed by support. This setting can be set via code (`c.profiling.advanced.force_enable_legacy_profiler`) or via an environment variable (`DD_PROFILING_FORCE_ENABLE_LEGACY`).

**Motivation**:

Release CPU Profiling 2.0 to all customers.

**Additional Notes**:

I plan to explore an idea to optionally make CPU Profiling 2.0 sample without signals (by instead behaving like the legacy profiler). This should allow us to fully replace the legacy profiler with CPU Profiling 2.0 even for the customers affected by the caveats above (with some trade-offs, to be explored).

This PR has been opened on top of #2700 to avoid merge conflicts, but is otherwise completely independent from it.

**How to test the change?**:

Validate that when running the profiler, the new CPU Profiling 2.0 profiler gets used. The easiest way to do so is by looking at the profiler UX, and seeing if selecting "CPU Time by Thread Name" in the right sidebar shows thread names. (Alternatively -- inspect the profile and check if `_native_sampling_loop` is shown).
