### PR TITLE
Cherry-pick PR2703 "[DOCS-5086] Update link text in Ruby tracing setup" to master

### DIFF
--- a/docs/GettingStarted.md
+++ b/docs/GettingStarted.md
@@ -9,7 +9,7 @@ databases and microservices so that developers have high visibility into bottlen
 
 For the general APM documentation, see our [setup documentation][setup docs].
 
-For more information about what APM looks like once your application is sending information to Datadog, take a look at [Visualizing your APM data][visualization docs].
+For more information about what APM looks like once your application is sending information to Datadog, take a look at [Terms and Concepts][visualization docs].
 
 For the library API documentation, see our [YARD documentation][yard docs].
 
@@ -17,7 +17,7 @@ To contribute, check out the [contribution guidelines][contribution docs] and [d
 
 [setup docs]: https://docs.datadoghq.com/tracing/
 [development docs]: https://github.com/DataDog/dd-trace-rb/blob/master/README.md#development
-[visualization docs]: https://docs.datadoghq.com/tracing/visualization/
+[visualization docs]: https://docs.datadoghq.com/tracing/glossary/
 [contribution docs]: https://github.com/DataDog/dd-trace-rb/blob/master/CONTRIBUTING.md
 [development docs]: https://github.com/DataDog/dd-trace-rb/blob/master/docs/DevelopmentGuide.md
 [yard docs]: https://www.rubydoc.info/gems/ddtrace/


### PR DESCRIPTION
**What does this PR do?**:

Cherry-pick https://github.com/DataDog/dd-trace-rb/pull/2703 back to master. This is a docs-only update.

**Motivation**:

Make sure the change in #2703 doesn't get lost on the next release.

**Additional Notes**:

N/A

**How to test the change?**:

Use eyes to look at diff. Click link to see if it works ;)
