### PR TITLE
Fix duplicated typechecking signature

### DIFF
--- a/sig/datadog/core/configuration.rbs
+++ b/sig/datadog/core/configuration.rbs
@@ -1,8 +1,6 @@
 module Datadog
   module Core
     module Configuration
-      def configuration: () -> Settings
-
       def tracer: () -> Datadog::Tracing::Tracer
 
       def logger: () -> Datadog::Core::Logger


### PR DESCRIPTION
**What does this PR do?**:

This PR removes a duplicated typechecking signature. Two different PRs added this independently, and the merge to master did not conflict diff-wise, but it conflicted semantically (e.g. master got two copies of the signature).

Oops!

**Motivation**:

Fix typechecking error in master.

**Additional Notes**:

I wonder if the "deploy train" feature from GitHub might've caught this one. Maybe something to explore?

**How to test the change?**:

Validate that typechecking is back to green.