### PR TITLE
Fix (hopefully for good) flaky profiling "sampling while VM is idle" spec

### DIFF
--- a/lib/datadog/profiling/collectors/cpu_and_wall_time_worker.rb
+++ b/lib/datadog/profiling/collectors/cpu_and_wall_time_worker.rb
@@ -26,14 +26,24 @@ module Datadog
             tracer: tracer,
             endpoint_collection_enabled: endpoint_collection_enabled,
           ),
-          idle_sampling_helper: IdleSamplingHelper.new
+          idle_sampling_helper: IdleSamplingHelper.new,
+          # **NOTE**: This should only be used for testing; disabling the dynamic sampling rate will increase the
+          # profiler overhead!
+          dynamic_sampling_rate_enabled: true
         )
+          unless dynamic_sampling_rate_enabled
+            Datadog.logger.warn(
+              'Profiling dynamic sampling rate disabled. This should only be used for testing, and will increase overhead!'
+            )
+          end
+
           self.class._native_initialize(
             self,
             thread_context_collector,
             gc_profiling_enabled,
             idle_sampling_helper,
-            allocation_counting_enabled
+            allocation_counting_enabled,
+            dynamic_sampling_rate_enabled,
           )
           @worker_thread = nil
           @failure_exception = nil

--- a/sig/datadog/profiling/collectors/cpu_and_wall_time_worker.rbs
+++ b/sig/datadog/profiling/collectors/cpu_and_wall_time_worker.rbs
@@ -13,6 +13,7 @@ module Datadog
           allocation_counting_enabled: bool,
           ?thread_context_collector: Datadog::Profiling::Collectors::ThreadContext,
           ?idle_sampling_helper: Datadog::Profiling::Collectors::IdleSamplingHelper,
+          ?dynamic_sampling_rate_enabled: bool,
         ) -> void
       end
     end

--- a/spec/datadog/profiling/collectors/cpu_and_wall_time_worker_spec.rb
+++ b/spec/datadog/profiling/collectors/cpu_and_wall_time_worker_spec.rb
@@ -336,6 +336,10 @@ RSpec.describe Datadog::Profiling::Collectors::CpuAndWallTimeWorker do
     end
 
     context 'when all threads are sleeping (no thread holds the Global VM Lock)' do
+      let(:options) { { dynamic_sampling_rate_enabled: false } }
+
+      before { expect(Datadog.logger).to receive(:warn).with(/dynamic sampling rate disabled/) }
+
       it 'is able to sample even when all threads are sleeping' do
         start
         wait_until_running
@@ -359,16 +363,11 @@ RSpec.describe Datadog::Profiling::Collectors::CpuAndWallTimeWorker do
 
         # Sanity checking
 
-        # We're currently targeting 100 samples per second (aka 20 in the 0.2 period above), so expecting 5 samples is a
-        # conservative choice that hopefully will not cause flakiness.
+        # We're currently targeting 100 samples per second (aka ~20 in the 0.2 period above), so expecting 8 samples
+        # will hopefully not cause flakiness. But this test has been flaky in the past so... Ping @ivoanjo if it happens
+        # again.
         #
-        # @ivoanjo: One source of flakiness here in the past has been the dynamic sampling rate component -- if for some
-        # reason the profiler takes longer to sample (maybe the CI machine is busy today...), it will by design slow down
-        # and take less samples. For now, I tried to tune down this value, and am hesitating on adding a way to disable
-        # the dynamic sampling rate while we're running this test (because this is something we'd never do in production).
-        # But if spec proves to be flaky again, then I think we'll need to go with that solution (as I think this test
-        # is still quite valuable).
-        expect(sample_count).to be >= 5, "sample_count: #{sample_count}, stats: #{stats}, debug_failures: #{debug_failures}"
+        expect(sample_count).to be >= 8, "sample_count: #{sample_count}, stats: #{stats}, debug_failures: #{debug_failures}"
         expect(trigger_sample_attempts).to be >= sample_count
       end
     end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -257,6 +257,8 @@ if ENV.key?('CI')
 
   ThreadHelpers.with_leaky_thread_creation('Deadline thread') do
     Thread.new do
+      Thread.current.name = 'spec_helper.rb CI debugging Deadline thread' unless RUBY_VERSION.start_with('2.1.', '2.2.')
+
       sleep_time = 30 * 60 # 30 minutes
       sleep(sleep_time)
 


### PR DESCRIPTION
**What does this PR do?**:

This PR attempts to fix a flaky profiling spec that was last seen in <https://app.circleci.com/pipelines/github/DataDog/dd-trace-rb/9405/workflows/89cdfecc-0767-4fc9-85ab-1caa0abda773/jobs/349752>

This spec has some inherent flakiness, as it runs the profiler for a short while and then asserts on some of the counters. Since all this is asynchronous, values could be off.

In fact, this is not the first time this spec was changed to try to resolve flakiness:
* e194ec68dc5841d7dae68cc53c1d81e34ac9cea3
* #2539
* 7d22e545c2a1adc4856faf1956c1b5bab1338396

The last time this caused flakiness, the source was the dynamic sampling rate component. If for some reason the CI machine is having a slow day, sampling takes longer, and then the dynamic sampling rate component kicks in and delays samples (this is by design!).

This has happened again today; so, as I promised on 7d22e545c2a1adc4856faf1956c1b5bab1338396, I went in an added a way to disable the dynamic sampling rate component so it does not impact this spec.

**Motivation**:

Get us to zero flaky specs.

**Additional Notes**:

N/A

**How to test the change?**:

Change includes test coverage.