### PR TITLE
Allow `1` as true value in environment variables

### DIFF
--- a/lib/datadog/core/environment/variable_helpers.rb
+++ b/lib/datadog/core/environment/variable_helpers.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Datadog
   module Core
     # Namespace for handling application environment
@@ -14,11 +16,17 @@ module Datadog
         # @param [Boolean] default the default value if the keys in `var` are not present in the environment
         # @param [Boolean] deprecation_warning when `var` is a list, record a deprecation log when
         #   the first key in `var` is not used.
-        # @return [Boolean] if the environment value is the string `true`
+        # @return [Boolean] if the environment value is the string `true` or `1`
         # @return [default] if the environment value is not found
         def env_to_bool(var, default = nil, deprecation_warning: true)
           var = decode_array(var, deprecation_warning)
-          var && ENV.key?(var) ? ENV[var].to_s.strip.downcase == 'true' : default
+          if var && ENV.key?(var)
+            value = ENV[var].to_s.strip
+            value.downcase!
+            value == 'true' || value == '1' # rubocop:disable Style/MultipleComparison
+          else
+            default
+          end
         end
 
         # Reads an environment variable as an Integer.

--- a/spec/datadog/core/environment/variable_helpers_spec.rb
+++ b/spec/datadog/core/environment/variable_helpers_spec.rb
@@ -72,9 +72,10 @@ RSpec.describe Datadog::Core::Environment::VariableHelpers do
       %w[
         true
         TRUE
+        1
       ].each do |value|
         context value.to_s do
-          let(:env_value) { value.to_s }
+          let(:env_value) { value }
 
           it { is_expected.to be true }
         end
@@ -85,11 +86,11 @@ RSpec.describe Datadog::Core::Environment::VariableHelpers do
         '',
         'false',
         'FALSE',
-        0,
-        1
+        '0',
+        'arbitrary string',
       ].each do |value|
         context value.to_s do
-          let(:env_value) { value.to_s }
+          let(:env_value) { value }
 
           it { is_expected.to be false }
         end

--- a/spec/datadog/core/environment/variable_helpers_spec.rb
+++ b/spec/datadog/core/environment/variable_helpers_spec.rb
@@ -69,12 +69,13 @@ RSpec.describe Datadog::Core::Environment::VariableHelpers do
       include_context 'env var'
 
       # True values
-      %w[
-        true
-        TRUE
-        1
+      [
+        'true',
+        'TRUE',
+        '1',
+        ' 1 ',
       ].each do |value|
-        context value.to_s do
+        context "'#{value}'" do
           let(:env_value) { value }
 
           it { is_expected.to be true }
@@ -89,7 +90,7 @@ RSpec.describe Datadog::Core::Environment::VariableHelpers do
         '0',
         'arbitrary string',
       ].each do |value|
-        context value.to_s do
+        context "'#{value}'" do
           let(:env_value) { value }
 
           it { is_expected.to be false }


### PR DESCRIPTION
We currently only support the string `true` as a truthy boolean configuration value (case insensitive).

Our standard for APM Tracing configuration is actually to allow either `true` or `1`.

This PR changes the logic to accept `1` as a valid true value for environment variable configuration.

There are no other functional changes to configuration parsing.