### PR TITLE
Telemetry:Remove nil values from payload

### DIFF
--- a/Steepfile
+++ b/Steepfile
@@ -118,6 +118,7 @@ target :ddtrace do
   ignore 'lib/datadog/core/utils.rb'
   ignore 'lib/datadog/core/utils/compression.rb'
   ignore 'lib/datadog/core/utils/forking.rb'
+  ignore 'lib/datadog/core/utils/hash.rb' # Refinement module
   ignore 'lib/datadog/core/utils/network.rb'
   ignore 'lib/datadog/core/utils/object_set.rb'
   ignore 'lib/datadog/core/utils/only_once.rb'

--- a/lib/datadog/core/telemetry/v1/application.rb
+++ b/lib/datadog/core/telemetry/v1/application.rb
@@ -1,9 +1,13 @@
+require_relative '../../utils/hash'
+
 module Datadog
   module Core
     module Telemetry
       module V1
         # Describes attributes for application environment object
         class Application
+          using Core::Utils::Hash::Refinement
+
           ERROR_NIL_LANGUAGE_NAME_MESSAGE = ':language_name must not be nil'.freeze
           ERROR_NIL_LANGUAGE_VERSION_MESSAGE = ':language_version must not be nil'.freeze
           ERROR_NIL_SERVICE_NAME_MESSAGE = ':service_name must not be nil'.freeze
@@ -54,7 +58,7 @@ module Datadog
           end
 
           def to_h
-            {
+            hash = {
               env: @env,
               language_name: @language_name,
               language_version: @language_version,
@@ -66,6 +70,8 @@ module Datadog
               service_version: @service_version,
               tracer_version: @tracer_version
             }
+            hash.compact!
+            hash
           end
 
           private

--- a/lib/datadog/core/telemetry/v1/dependency.rb
+++ b/lib/datadog/core/telemetry/v1/dependency.rb
@@ -1,9 +1,13 @@
+require_relative '../../utils/hash'
+
 module Datadog
   module Core
     module Telemetry
       module V1
         # Describes attributes for dependency object
         class Dependency
+          using Core::Utils::Hash::Refinement
+
           ERROR_NIL_NAME_MESSAGE = ':name must not be nil'.freeze
 
           attr_reader \
@@ -23,11 +27,13 @@ module Datadog
           end
 
           def to_h
-            {
+            hash = {
               hash: @hash,
               name: @name,
               version: @version
             }
+            hash.compact!
+            hash
           end
         end
       end

--- a/lib/datadog/core/telemetry/v1/host.rb
+++ b/lib/datadog/core/telemetry/v1/host.rb
@@ -1,9 +1,13 @@
+require_relative '../../utils/hash'
+
 module Datadog
   module Core
     module Telemetry
       module V1
         # Describes attributes for host object
         class Host
+          using Core::Utils::Hash::Refinement
+
           attr_reader \
             :container_id,
             :hostname,
@@ -34,7 +38,7 @@ module Datadog
           end
 
           def to_h
-            {
+            hash = {
               container_id: @container_id,
               hostname: @hostname,
               kernel_name: @kernel_name,
@@ -43,6 +47,8 @@ module Datadog
               os: @os,
               os_version: @os_version,
             }
+            hash.compact!
+            hash
           end
         end
       end

--- a/lib/datadog/core/telemetry/v1/integration.rb
+++ b/lib/datadog/core/telemetry/v1/integration.rb
@@ -1,9 +1,13 @@
+require_relative '../../utils/hash'
+
 module Datadog
   module Core
     module Telemetry
       module V1
         # Describes attributes for integration object
         class Integration
+          using Core::Utils::Hash::Refinement
+
           ERROR_NIL_ENABLED_MESSAGE = ':enabled must not be nil'.freeze
           ERROR_NIL_NAME_MESSAGE = ':name must not be nil'.freeze
 
@@ -32,7 +36,7 @@ module Datadog
           end
 
           def to_h
-            {
+            hash = {
               auto_enabled: @auto_enabled,
               compatible: @compatible,
               enabled: @enabled,
@@ -40,6 +44,8 @@ module Datadog
               name: @name,
               version: @version
             }
+            hash.compact!
+            hash
           end
 
           private

--- a/lib/datadog/core/telemetry/v1/product.rb
+++ b/lib/datadog/core/telemetry/v1/product.rb
@@ -1,9 +1,13 @@
+require_relative '../../utils/hash'
+
 module Datadog
   module Core
     module Telemetry
       module V1
         # Describes attributes for products object
         class Product
+          using Core::Utils::Hash::Refinement
+
           attr_reader \
             :appsec,
             :profiler
@@ -16,10 +20,12 @@ module Datadog
           end
 
           def to_h
-            {
+            hash = {
               appsec: @appsec,
               profiler: @profiler
             }
+            hash.compact!
+            hash
           end
         end
       end

--- a/lib/datadog/core/telemetry/v1/telemetry_request.rb
+++ b/lib/datadog/core/telemetry/v1/telemetry_request.rb
@@ -1,9 +1,13 @@
+require_relative '../../utils/hash'
+
 module Datadog
   module Core
     module Telemetry
       module V1
         # Describes attributes for telemetry API request
         class TelemetryRequest
+          using Core::Utils::Hash::Refinement
+
           ERROR_NIL_API_VERSION_MESSAGE = ':api_version must not be nil'.freeze
           ERROR_NIL_APPLICATION_MESSAGE = ':application must not be nil'.freeze
           ERROR_NIL_HOST_MESSAGE = ':host must not be nil'.freeze
@@ -64,7 +68,7 @@ module Datadog
           end
 
           def to_h
-            {
+            hash = {
               api_version: @api_version,
               application: @application.to_h,
               debug: @debug,
@@ -76,6 +80,8 @@ module Datadog
               session_id: @session_id,
               tracer_time: @tracer_time
             }
+            hash.compact!
+            hash
           end
 
           private

--- a/lib/datadog/core/utils/hash.rb
+++ b/lib/datadog/core/utils/hash.rb
@@ -1,0 +1,32 @@
+# frozen_string_literal: true
+
+module Datadog
+  module Core
+    module Utils
+      # Refinements for {Hash}.
+      module Hash
+        # This refinement ensures modern rubies are allowed to use newer,
+        # simpler, and more performant APIs.
+        module Refinement
+          # Introduced in Ruby 2.4
+          unless ::Hash.method_defined?(:compact)
+            refine ::Hash do
+              def compact
+                reject { |_k, v| v.nil? }
+              end
+            end
+          end
+
+          # Introduced in Ruby 2.4
+          unless ::Hash.method_defined?(:compact!)
+            refine ::Hash do
+              def compact!
+                reject! { |_k, v| v.nil? }
+              end
+            end
+          end
+        end
+      end
+    end
+  end
+end

--- a/spec/datadog/core/telemetry/collector_spec.rb
+++ b/spec/datadog/core/telemetry/collector_spec.rb
@@ -295,7 +295,7 @@ RSpec.describe Datadog::Core::Telemetry::Collector do
 
       it 'sets integration as enabled' do
         expect(integrations).to include(
-          an_object_having_attributes(name: 'rake', enabled: true, compatible: true, error: nil)
+          an_object_having_attributes(name: 'rake', enabled: true, compatible: true)
         )
       end
 
@@ -333,7 +333,7 @@ RSpec.describe Datadog::Core::Telemetry::Collector do
               name: 'redis',
               enabled: false,
               compatible: false,
-              error: { type: 'StandardError', message: nil, line: nil }.to_s
+              error: { type: 'StandardError' }.to_s
             )
           )
       end

--- a/spec/datadog/core/telemetry/v1/app_event_spec.rb
+++ b/spec/datadog/core/telemetry/v1/app_event_spec.rb
@@ -144,7 +144,7 @@ RSpec.describe Datadog::Core::Telemetry::V1::AppEvent do
 
       it do
         is_expected.to eq(
-          integrations: [{ auto_enabled: nil, compatible: nil, enabled: true, error: nil, name: 'pg', version: nil }]
+          integrations: [{ enabled: true, name: 'pg' }]
         )
       end
     end
@@ -161,8 +161,8 @@ RSpec.describe Datadog::Core::Telemetry::V1::AppEvent do
                                { name: 'profiling.enabled', value: false }],
           configuration: [{ name: 'DD_AGENT_HOST', value: 'localhost' },
                           { name: 'DD_TRACE_SAMPLE_RATE', value: '1' }],
-          dependencies: [{ hash: nil, name: 'pg', version: nil }],
-          integrations: [{ auto_enabled: nil, compatible: nil, enabled: true, error: nil, name: 'pg', version: nil }]
+          dependencies: [{ name: 'pg' }],
+          integrations: [{ enabled: true, name: 'pg' }]
         )
       end
     end

--- a/spec/datadog/core/telemetry/v1/telemetry_request_spec.rb
+++ b/spec/datadog/core/telemetry/v1/telemetry_request_spec.rb
@@ -204,29 +204,18 @@ RSpec.describe Datadog::Core::Telemetry::V1::TelemetryRequest do
       is_expected.to eq(
         api_version: api_version,
         application: {
-          env: nil,
           language_name: 'ruby',
           language_version: '3.0',
           products: {},
-          runtime_name: nil,
-          runtime_patches: nil,
-          runtime_version: nil,
           service_name: 'myapp',
-          service_version: nil,
           tracer_version: '1.0'
         },
         debug: debug,
         host: {
           container_id: 'd39b145254d1f9c337fdd2be132f6',
-          hostname: nil,
-          kernel_name: nil,
-          kernel_release: nil,
-          kernel_version: nil,
-          os: nil,
-          os_version: nil
         },
         payload: {
-          integrations: [{ auto_enabled: nil, compatible: nil, enabled: true, error: nil, name: 'pg', version: nil }]
+          integrations: [{ enabled: true, name: 'pg' }]
         },
         request_type: request_type,
         runtime_id: dummy_runtime_id,


### PR DESCRIPTION
Our V1 telemetry implementation returns `nil` values in key/value mappings, when telemetry dictates that `nil` values should be omitted from the flushed payload.

This behaviour is enforced by system-tests, which started failing recently:
```
tests/test_schemas.py::Test_Library::test_full - Exception: Schema is invalid in logs/interfaces/library/000__...
tests/test_schemas.py::Test_Library::test_non_regression - Exception: Schema is invalid in logs/interfaces/lib...
tests/test_schemas.py::Test_Agent::test_full - Exception: Schema is invalid in logs/interfaces/agent/003__api_...
tests/test_schemas.py::Test_Agent::test_non_regression - Exception: Schema is invalid in logs/interfaces/agent...
```

This PR addresses these system-tests failures by removing empty values from the returned payload.

Testing compliance for the full Telemetry schema is the responsibility of the system-tests repository: there's a strict JSON Schema validator in that repository. The tests present in this PR are simple unit tests.