### PR TITLE
Glue remote config together

### DIFF
--- a/ddtrace.gemspec
+++ b/ddtrace.gemspec
@@ -65,7 +65,7 @@ Gem::Specification.new do |spec|
   spec.add_dependency 'debase-ruby_core_source', '>= 0.10.16', '<= 3.2.0'
 
   # Used by appsec
-  spec.add_dependency 'libddwaf', '~> 1.6.2.0.0'
+  spec.add_dependency 'libddwaf', '~> 1.8.2.0.0'
 
   # Used by profiling (and possibly others in the future)
   # When updating the version here, please also update the version in `native_extension_helpers.rb` (and yes we have a test for it)

--- a/lib/datadog/appsec.rb
+++ b/lib/datadog/appsec.rb
@@ -17,6 +17,22 @@ module Datadog
         appsec_component.processor if appsec_component
       end
 
+      def reconfigure(ruleset:)
+        appsec_component = components.appsec
+
+        return unless appsec_component
+
+        appsec_component.reconfigure(ruleset: ruleset)
+      end
+
+      def reconfigure_lock(&block)
+        appsec_component = components.appsec
+
+        return unless appsec_component
+
+        appsec_component.reconfigure_lock(&block)
+      end
+
       private
 
       def components

--- a/lib/datadog/appsec.rb
+++ b/lib/datadog/appsec.rb
@@ -40,10 +40,6 @@ module Datadog
       end
     end
 
-    def self.writer
-      @writer ||= Writer.new
-    end
-
     # Expose AppSec to global shared objects
     Extensions.activate!
   end

--- a/lib/datadog/appsec/component.rb
+++ b/lib/datadog/appsec/component.rb
@@ -28,12 +28,28 @@ module Datadog
 
       def initialize(processor:)
         @processor = processor
+        @mutex = Mutex.new
+      end
+
+      def reconfigure(ruleset:)
+        @mutex.synchronize do
+          old = @processor
+          @processor = Processor.new(ruleset: ruleset)
+
+          old.finalize if processor && processor.ready?
+        end
+      end
+
+      def reconfigure_lock(&block)
+        @mutex.synchronize(&block)
       end
 
       def shutdown!
-        if processor && processor.ready?
-          processor.finalize
-          @processor = nil
+        @mutex.synchronize do
+          if processor && processor.ready?
+            processor.finalize
+            @processor = nil
+          end
         end
       end
     end

--- a/lib/datadog/appsec/component.rb
+++ b/lib/datadog/appsec/component.rb
@@ -33,10 +33,13 @@ module Datadog
 
       def reconfigure(ruleset:)
         @mutex.synchronize do
-          old = @processor
-          @processor = Processor.new(ruleset: ruleset)
+          new = Processor.new(ruleset: ruleset)
 
-          old.finalize if processor && processor.ready?
+          if new && new.ready?
+            old = @processor
+            @processor = new
+            old.finalize
+          end
         end
       end
 

--- a/lib/datadog/appsec/contrib/rack/gateway/request.rb
+++ b/lib/datadog/appsec/contrib/rack/gateway/request.rb
@@ -14,7 +14,7 @@ module Datadog
             attr_reader :env
 
             def initialize(env)
-              super
+              super()
               @env = env
             end
 

--- a/lib/datadog/appsec/contrib/rack/gateway/response.rb
+++ b/lib/datadog/appsec/contrib/rack/gateway/response.rb
@@ -12,7 +12,7 @@ module Datadog
             attr_reader :body, :status, :headers, :active_context
 
             def initialize(body, status, headers, active_context:)
-              super
+              super()
               @body = body
               @status = status
               @headers = headers.each_with_object({}) { |(k, v), h| h[k.downcase] = v }

--- a/lib/datadog/appsec/contrib/rack/request_middleware.rb
+++ b/lib/datadog/appsec/contrib/rack/request_middleware.rb
@@ -23,6 +23,7 @@ module Datadog
             @oneshot_tags_sent = false
           end
 
+          # rubocop:disable Metrics/AbcSize,Metrics/PerceivedComplexity,Metrics/CyclomaticComplexity,Metrics/MethodLength
           def call(env)
             return @app.call(env) unless Datadog::AppSec.enabled?
 
@@ -88,6 +89,7 @@ module Datadog
               processor.deactivate_context
             end
           end
+          # rubocop:enable Metrics/AbcSize,Metrics/PerceivedComplexity,Metrics/CyclomaticComplexity,Metrics/MethodLength
 
           private
 

--- a/lib/datadog/appsec/contrib/rack/request_middleware.rb
+++ b/lib/datadog/appsec/contrib/rack/request_middleware.rb
@@ -26,6 +26,7 @@ module Datadog
           def call(env)
             return @app.call(env) unless Datadog::AppSec.enabled?
 
+            Datadog::Core::Remote.active_remote.barrier(:once) unless Datadog::Core::Remote.active_remote.nil?
             processor = Datadog::AppSec.processor
 
             return @app.call(env) if processor.nil? || !processor.ready?

--- a/lib/datadog/appsec/contrib/rails/gateway/request.rb
+++ b/lib/datadog/appsec/contrib/rails/gateway/request.rb
@@ -12,7 +12,7 @@ module Datadog
             attr_reader :request
 
             def initialize(request)
-              super
+              super()
               @request = request
             end
 

--- a/lib/datadog/appsec/contrib/sinatra/gateway/route_params.rb
+++ b/lib/datadog/appsec/contrib/sinatra/gateway/route_params.rb
@@ -12,7 +12,7 @@ module Datadog
             attr_reader :params
 
             def initialize(params)
-              super
+              super()
               @params = params
             end
           end

--- a/lib/datadog/appsec/instrumentation/gateway/argument.rb
+++ b/lib/datadog/appsec/instrumentation/gateway/argument.rb
@@ -12,7 +12,7 @@ module Datadog
           attr_reader :id
 
           def initialize(id)
-            super
+            super()
             @id = id
           end
         end

--- a/lib/datadog/appsec/instrumentation/gateway/argument.rb
+++ b/lib/datadog/appsec/instrumentation/gateway/argument.rb
@@ -5,9 +5,7 @@ module Datadog
     module Instrumentation
       class Gateway
         # Base class for Gateway Arguments
-        class Argument
-          def initialize(*); end
-        end
+        class Argument; end
 
         # Gateway User argument
         class User < Argument

--- a/lib/datadog/appsec/instrumentation/gateway/argument.rb
+++ b/lib/datadog/appsec/instrumentation/gateway/argument.rb
@@ -5,7 +5,7 @@ module Datadog
     module Instrumentation
       class Gateway
         # Base class for Gateway Arguments
-        class Argument; end
+        class Argument; end # rubocop:disable Lint/EmptyClass
 
         # Gateway User argument
         class User < Argument

--- a/lib/datadog/appsec/processor.rb
+++ b/lib/datadog/appsec/processor.rb
@@ -71,8 +71,6 @@ module Datadog
 
         unless load_libddwaf && load_ruleset(settings, ruleset: ruleset) && create_waf_handle(settings)
           Datadog.logger.warn { 'AppSec is disabled, see logged errors above' }
-
-          return
         end
       end
 

--- a/lib/datadog/appsec/processor.rb
+++ b/lib/datadog/appsec/processor.rb
@@ -64,12 +64,12 @@ module Datadog
 
       attr_reader :ruleset_info, :addresses
 
-      def initialize
+      def initialize(ruleset: nil)
         @ruleset_info = nil
         @addresses = []
         settings = Datadog::AppSec.settings
 
-        unless load_libddwaf && load_ruleset(settings) && create_waf_handle(settings)
+        unless load_libddwaf && load_ruleset(settings, ruleset: ruleset) && create_waf_handle(settings)
           Datadog.logger.warn { 'AppSec is disabled, see logged errors above' }
 
           return
@@ -129,8 +129,8 @@ module Datadog
         Processor.require_libddwaf && Processor.libddwaf_provides_waf?
       end
 
-      def load_ruleset(settings)
-        ruleset_setting = settings.ruleset
+      def load_ruleset(settings, ruleset: nil)
+        ruleset_setting = ruleset || settings.ruleset
 
         ruleset = begin
           case ruleset_setting

--- a/lib/datadog/appsec/processor.rb
+++ b/lib/datadog/appsec/processor.rb
@@ -137,12 +137,12 @@ module Datadog
           when :recommended, :strict
             JSON.parse(Datadog::AppSec::Assets.waf_rules(ruleset_setting))
           when :risky
-            JSON.parse(Datadog::AppSec::Assets.waf_rules(:recommended))
             Datadog.logger.warn(
               'The :risky Application Security Management ruleset has been deprecated and no longer available.'\
               'The `:recommended` ruleset will be used instead.'\
               'Please remove the `appsec.ruleset = :risky` setting from your Datadog.configure block.'
             )
+            JSON.parse(Datadog::AppSec::Assets.waf_rules(:recommended))
           when String
             JSON.parse(File.read(ruleset_setting))
           when File, StringIO

--- a/lib/datadog/core/configuration/settings.rb
+++ b/lib/datadog/core/configuration/settings.rb
@@ -5,6 +5,7 @@ require_relative 'ext'
 require_relative '../environment/ext'
 require_relative '../runtime/ext'
 require_relative '../telemetry/ext'
+require_relative '../remote/ext'
 require_relative '../../profiling/ext'
 
 require_relative '../../tracing/configuration/settings'
@@ -462,6 +463,29 @@ module Datadog
           # @return [Boolean]
           option :enabled do |o|
             o.default { env_to_bool(Core::Telemetry::Ext::ENV_ENABLED, false) }
+            o.lazy
+          end
+        end
+
+        # Remote configuration
+        # @public_api
+        settings :remote do
+          # Enable remote configuration. This allows fetching of remote configuration for live updates.
+          #
+          # @default `DD_REMOTE_CONFIGURATION_ENABLED` environment variable, otherwise `false`. In a future release,
+          #   this value will be changed to `true` by default.
+          # @return [Boolean]
+          option :enabled do |o|
+            o.default { env_to_bool(Core::Remote::Ext::ENV_ENABLED, false) }
+            o.lazy
+          end
+
+          # Tune remote configuration polling interval.
+          #
+          # @default `DD_REMOTE_CONFIGURATION_POLL_INTERVAL_SECONDS` environment variable, otherwise `60.0` seconds.
+          # @return [Float]
+          option :poll_interval_seconds do |o|
+            o.default { env_to_float(Core::Remote::Ext::ENV_POLL_INTERVAL_SECONDS, 60.0) }
             o.lazy
           end
         end

--- a/lib/datadog/core/configuration/settings.rb
+++ b/lib/datadog/core/configuration/settings.rb
@@ -482,10 +482,10 @@ module Datadog
 
           # Tune remote configuration polling interval.
           #
-          # @default `DD_REMOTE_CONFIGURATION_POLL_INTERVAL_SECONDS` environment variable, otherwise `60.0` seconds.
+          # @default `DD_REMOTE_CONFIGURATION_POLL_INTERVAL_SECONDS` environment variable, otherwise `5.0` seconds.
           # @return [Float]
           option :poll_interval_seconds do |o|
-            o.default { env_to_float(Core::Remote::Ext::ENV_POLL_INTERVAL_SECONDS, 60.0) }
+            o.default { env_to_float(Core::Remote::Ext::ENV_POLL_INTERVAL_SECONDS, 5.0) }
             o.lazy
           end
         end

--- a/lib/datadog/core/remote/client.rb
+++ b/lib/datadog/core/remote/client.rb
@@ -97,8 +97,6 @@ module Datadog
           else
             raise SyncError, "unexpected transport response: #{response.inspect}"
           end
-
-          # TODO: dispatch config updates to listeners
         end
         # rubocop:enable Metrics/AbcSize,Metrics/PerceivedComplexity
 

--- a/lib/datadog/core/remote/client.rb
+++ b/lib/datadog/core/remote/client.rb
@@ -27,7 +27,11 @@ module Datadog
 
           if response.ok?
             # when response is completely empty, do nothing as in: leave as is
-            return if response.empty?
+            if response.empty?
+              Datadog.logger.debug { 'remote: empty response => NOOP' }
+
+              return
+            end
 
             paths = response.client_configs.map do |path|
               Configuration::Path.parse(path)
@@ -84,7 +88,11 @@ module Datadog
               # TODO: also remove stale config (matching removed) from cache (client configs is exhaustive list of paths)
             end
 
-            dispatcher.dispatch(changes, repository)
+            if changes.empty?
+              Datadog.logger.debug { 'remote: no changes' }
+            else
+              dispatcher.dispatch(changes, repository)
+            end
           else
             raise SyncError, "unexpected transport response: #{response.inspect}"
           end

--- a/lib/datadog/core/remote/client.rb
+++ b/lib/datadog/core/remote/client.rb
@@ -229,7 +229,6 @@ module Datadog
             exclusions_contents = select_content(repository, 'ASM', ['exclusion_filters'])
             exclusions = exclusions_contents.map { |content| parse_content(content) }
 
-            binding.pry
             ruleset = AppSec::Processor::RuleMerger.merge(
               rules: rules,
               data: data,

--- a/lib/datadog/core/remote/client.rb
+++ b/lib/datadog/core/remote/client.rb
@@ -22,7 +22,7 @@ module Datadog
           register_receivers
         end
 
-        # rubocop:disable Metrics/AbcSize
+        # rubocop:disable Metrics/AbcSize,Metrics/PerceivedComplexity
         def sync
           response = transport.send_config(payload)
 
@@ -100,7 +100,7 @@ module Datadog
 
           # TODO: dispatch config updates to listeners
         end
-        # rubocop:enable Metrics/AbcSize
+        # rubocop:enable Metrics/AbcSize,Metrics/PerceivedComplexity
 
         class SyncError < StandardError; end
 

--- a/lib/datadog/core/remote/client.rb
+++ b/lib/datadog/core/remote/client.rb
@@ -193,7 +193,7 @@ module Datadog
 
         def select_content(repository, product, config_ids = [])
           repository.contents.select do |content|
-            content.path.product == 'ASM_DATA' && (config_ids.empty? || config_ids.include?(content.path.config_id))
+            content.path.product == product && (config_ids.empty? || config_ids.include?(content.path.config_id))
           end
         end
 
@@ -229,6 +229,7 @@ module Datadog
             exclusions_contents = select_content(repository, 'ASM', ['exclusion_filters'])
             exclusions = exclusions_contents.map { |content| parse_content(content) }
 
+            binding.pry
             ruleset = AppSec::Processor::RuleMerger.merge(
               rules: rules,
               data: data,

--- a/lib/datadog/core/remote/component.rb
+++ b/lib/datadog/core/remote/component.rb
@@ -23,9 +23,18 @@ module Datadog
           @worker = Worker.new(interval: settings.remote.poll_interval_seconds) { @client.sync }
         end
 
-        def sync
-          # TODO: start elsewere, block smartly. this way makes it start on demand for now
+        def barrier(kind)
+          return if @worker.nil?
+
+          # Make it start on demand (for now)
           @worker.start
+
+          case kind
+          when :once
+            # TODO: block until first update has been received
+          when :next
+            # TODO: block until next update has been received
+          end
         end
 
         def shutdown!

--- a/lib/datadog/core/remote/component.rb
+++ b/lib/datadog/core/remote/component.rb
@@ -20,7 +20,7 @@ module Datadog
           transport_v7 = Datadog::Core::Transport::HTTP.v7(**transport_options.dup)
 
           @client = Client.new(transport_v7)
-          @worker = Worker.new(interval: 10) { @client.sync }
+          @worker = Worker.new(interval: settings.remote.poll_interval_seconds) { @client.sync }
         end
 
         def sync
@@ -29,11 +29,13 @@ module Datadog
         end
 
         def shutdown!
-          @worker.stop
+          @worker.stop unless @worker.nil?
         end
 
         class << self
           def build(settings, agent_settings)
+            return unless settings.remote.enabled
+
             # TODO: condition with configuration
             new(settings, agent_settings)
           end

--- a/lib/datadog/core/remote/ext.rb
+++ b/lib/datadog/core/remote/ext.rb
@@ -1,0 +1,12 @@
+# frozen_string_literal: true
+
+module Datadog
+  module Core
+    module Remote
+      module Ext
+        ENV_ENABLED = 'DD_REMOTE_CONFIGURATION_ENABLED'
+        ENV_POLL_INTERVAL_SECONDS = 'DD_REMOTE_CONFIGURATION_POLL_INTERVAL_SECONDS'
+      end
+    end
+  end
+end

--- a/sig/datadog/appsec.rbs
+++ b/sig/datadog/appsec.rbs
@@ -6,10 +6,12 @@ module Datadog
 
     def self.processor: () -> Datadog::AppSec::Processor?
 
+    def self.reconfigure: (ruleset: ::Hash[untyped, untyped]) -> void
+
+    def self.reconfigure_lock: () { () -> void } -> void
+
     private
 
     def self.components: () -> Datadog::Core::Configuration::Components
   end
 end
-
-

--- a/sig/datadog/appsec/component.rbs
+++ b/sig/datadog/appsec/component.rbs
@@ -1,13 +1,14 @@
 module Datadog
   module AppSec
     class Component
-      def self.build_appsec_component: (Datadog::AppSec::Configuration::Settings settings) -> Datadog::AppSec::Component?
+      def self.build_appsec_component: (Datadog::Core::Configuration::Settings settings) -> Datadog::AppSec::Component?
 
       private
 
       def self.create_processor: () -> Datadog::AppSec::Processor?
 
       attr_reader processor: Datadog::AppSec::Processor?
+      attr_reader mutex: Thread::Mutex
 
       def initialize: (processor: Datadog::AppSec::Processor?) -> void
 

--- a/sig/datadog/appsec/component.rbs
+++ b/sig/datadog/appsec/component.rbs
@@ -11,6 +11,10 @@ module Datadog
 
       def initialize: (processor: Datadog::AppSec::Processor?) -> void
 
+      def self.reconfigure: (ruleset: ::Hash[untyped, untyped]) -> void
+
+      def self.reconfigure_lock: () { () -> void } -> void
+
       def shutdown!: () -> untyped
     end
   end

--- a/sig/datadog/appsec/processor.rbs
+++ b/sig/datadog/appsec/processor.rbs
@@ -42,8 +42,6 @@ module Datadog
       def new_context: () -> Context
       def activate_context: () -> Context
       def deactivate_context: () -> void
-      def update_rule_data: (untyped data) -> untyped
-      def toggle_rules: (untyped map) -> untyped
       def finalize: () -> void
 
       attr_reader handle: untyped

--- a/sig/datadog/appsec/processor.rbs
+++ b/sig/datadog/appsec/processor.rbs
@@ -37,7 +37,7 @@ module Datadog
       @ruleset: ::Hash[::String, untyped]
       @addresses: ::Array[::String]
 
-      def initialize: () -> void
+      def initialize: (?ruleset: ::Hash[untyped, untyped]?) -> void
       def ready?: () -> bool
       def new_context: () -> Context
       def activate_context: () -> Context
@@ -51,9 +51,10 @@ module Datadog
       private
 
       def apply_denylist_data: (Configuration::Settings settings) -> untyped
+      def combine_denylist_data: (Configuration::Settings settings) -> ::Array[::Hash[::String, untyped]]
       def denylist_data: (String id, ::Array[untyped] denylist) -> ::Hash[::String, untyped | "data_with_expiration"]
       def load_libddwaf: () -> bool
-      def load_ruleset: (Configuration::Settings settings) -> bool
+      def load_ruleset: (Configuration::Settings settings, ?ruleset: ::Hash[untyped, untyped]?) -> bool
       def create_waf_handle: (Configuration::Settings settings) -> bool
 
       def self.libddwaf_provides_waf?: () -> bool

--- a/sig/datadog/core/configuration/settings.rbs
+++ b/sig/datadog/core/configuration/settings.rbs
@@ -4,6 +4,16 @@ module Datadog
       class Settings
         include Base
 
+        interface _Remote
+          def enabled: () -> bool
+
+          def enabled=: (bool) -> void
+
+          def poll_interval_seconds: () -> ::Float
+
+          def poll_interval_seconds=: (::Float) -> void
+        end
+
         def initialize: (*untyped _) -> untyped
 
         def env: -> String
@@ -15,6 +25,8 @@ module Datadog
         def runtime_metrics: (?untyped? options) -> untyped
 
         def appsec: (?untyped? options) -> Datadog::AppSec::Configuration::Settings
+
+        def remote: (?untyped? options) -> Datadog::Core::Configuration::Settings::_Remote
       end
     end
   end

--- a/sig/datadog/core/remote/client.rbs
+++ b/sig/datadog/core/remote/client.rbs
@@ -47,7 +47,14 @@ module Datadog
 
         def capabilities_binary: () -> String
 
+        def select_content: (Configuration::Repository, ::String, ?::Array[::String]) -> ::Array[Configuration::Content]
+
+        def parse_content: (Configuration::Content) -> untyped
+
         def register_receivers: () -> void
+
+        class ReadError < StandardError
+        end
       end
     end
   end

--- a/sig/datadog/core/remote/component.rbs
+++ b/sig/datadog/core/remote/component.rbs
@@ -5,13 +5,13 @@ module Datadog
         attr_reader client: Datadog::Core::Remote::Client
         attr_reader worker: Datadog::Core::Remote::Worker
 
-        def initialize: (Datadog::AppSec::Configuration::Settings settings, Datadog::Core::Configuration::AgentSettingsResolver::AgentSettings agent_settings) -> void
+        def initialize: (Datadog::Core::Configuration::Settings settings, Datadog::Core::Configuration::AgentSettingsResolver::AgentSettings agent_settings) -> void
 
         def sync: () -> void
 
         def shutdown!: () -> void
 
-        def self.build: (Datadog::AppSec::Configuration::Settings settings, Datadog::Core::Configuration::AgentSettingsResolver::AgentSettings agent_settings) -> Datadog::Core::Remote::Component
+        def self.build: (Datadog::Core::Configuration::Settings settings, Datadog::Core::Configuration::AgentSettingsResolver::AgentSettings agent_settings) -> Datadog::Core::Remote::Component?
       end
     end
   end

--- a/sig/datadog/core/remote/configuration.rbs
+++ b/sig/datadog/core/remote/configuration.rbs
@@ -1,0 +1,8 @@
+module Datadog
+  module Core
+    module Remote
+      class Configuration
+      end
+    end
+  end
+end

--- a/sig/datadog/core/remote/ext.rbs
+++ b/sig/datadog/core/remote/ext.rbs
@@ -1,0 +1,11 @@
+module Datadog
+  module Core
+    module Remote
+      module Ext
+        ENV_ENABLED: ::String
+
+        ENV_POLL_INTERVAL_SECONDS: ::String
+      end
+    end
+  end
+end

--- a/sig/datadog/core/remote/worker.rbs
+++ b/sig/datadog/core/remote/worker.rbs
@@ -6,11 +6,11 @@ module Datadog
         attr_reader stopping: bool
         attr_reader started: bool
         attr_reader thr: Thread?
-        attr_reader interval: Integer
+        attr_reader interval: ::Float
         attr_reader mutex: ::Thread::Mutex
         attr_reader block: (^() -> void)
 
-        def initialize: (interval: Integer) { () -> void } -> void
+        def initialize: (interval: ::Float) { () -> void } -> void
 
         def start: () -> void
 
@@ -24,7 +24,7 @@ module Datadog
 
         def release_lock: () -> void
 
-        def poll: (Integer interval) -> void
+        def poll: (::Float interval) -> void
 
         def call: () -> void
       end

--- a/spec/datadog/core/configuration/settings_spec.rb
+++ b/spec/datadog/core/configuration/settings_spec.rb
@@ -1109,4 +1109,72 @@ RSpec.describe Datadog::Core::Configuration::Settings do
       end
     end
   end
+
+  describe '#remote' do
+    describe '#enabled' do
+      subject(:enabled) { settings.remote.enabled }
+
+      context "when #{Datadog::Core::Remote::Ext::ENV_ENABLED}" do
+        around do |example|
+          ClimateControl.modify(Datadog::Core::Remote::Ext::ENV_ENABLED => environment) do
+            example.run
+          end
+        end
+
+        context 'is not defined' do
+          let(:environment) { nil }
+
+          it { is_expected.to be false }
+        end
+
+        context 'is defined' do
+          let(:environment) { 'true' }
+
+          it { is_expected.to be true }
+        end
+      end
+    end
+
+    describe '#enabled=' do
+      it 'updates the #enabled setting' do
+        expect { settings.remote.enabled = true }
+          .to change { settings.remote.enabled }
+          .from(false)
+          .to(true)
+      end
+    end
+
+    describe '#poll_interval_seconds' do
+      subject(:enabled) { settings.remote.poll_interval_seconds }
+
+      context "when #{Datadog::Core::Remote::Ext::ENV_POLL_INTERVAL_SECONDS}" do
+        around do |example|
+          ClimateControl.modify(Datadog::Core::Remote::Ext::ENV_POLL_INTERVAL_SECONDS => environment) do
+            example.run
+          end
+        end
+
+        context 'is not defined' do
+          let(:environment) { nil }
+
+          it { is_expected.to eq 5.0 }
+        end
+
+        context 'is defined' do
+          let(:environment) { '1' }
+
+          it { is_expected.to eq 1.0 }
+        end
+      end
+    end
+
+    describe '#poll_interval_seconds=' do
+      it 'updates the #poll_interval_seconds setting' do
+        expect { settings.remote.poll_interval_seconds = 1 }
+          .to change { settings.remote.poll_interval_seconds }
+          .from(5.0)
+          .to(1.0)
+      end
+    end
+  end
 end

--- a/spec/datadog/core/remote/client_spec.rb
+++ b/spec/datadog/core/remote/client_spec.rb
@@ -120,10 +120,10 @@ RSpec.describe Datadog::Core::Remote::Client do
     }
   end
   let(:exclusion_content) do
-    '{"exclusions":[{"conditions":[{"operator":"ip_match","parameters":{"inputs":[{"address":"http.client_ip"}]}}]]'
+    '{"exclusions":[{"conditions":[{"operator":"ip_match","parameters":{"inputs":[{"address":"http.client_ip"}]}}]}]}'
   end
   let(:blocked_ips_content) do
-    '{"rules_data":[{"data":[{"expiration":1678972458,"value":"42.42.42.1"}]}'
+    '{"rules_data":[{"data":[{"expiration":1678972458,"value":"42.42.42.1"}]}]}'
   end
   let(:response_body) do
     {
@@ -181,7 +181,7 @@ RSpec.describe Datadog::Core::Remote::Client do
 
           # We have to modify the response to trick the client into think on the second sync
           # the content for datadog/603646/ASM_DATA/blocked_ips/config have change
-          new_blocked_ips = '{"rules_data":[{"data":["fake new data"]'
+          new_blocked_ips = '{"rules_data":[{"data":["fake new data"]}]}'
           expect_any_instance_of(Datadog::Core::Transport::HTTP::Config::Response).to receive(:target_files).and_return(
             [
               {

--- a/spec/datadog/core/remote/client_spec.rb
+++ b/spec/datadog/core/remote/client_spec.rb
@@ -95,7 +95,18 @@ RSpec.describe Datadog::Core::Remote::Client do
         },
         'hashes' => { 'sha256' => Digest::SHA256.hexdigest(blocked_ips_content) },
         'length' => 1834
-      }
+      },
+      'datadog/603646/ASM_DD/latest/config' => {
+        'custom' => {
+          'c' => ['client_id'],
+          'tracer-predicates' => {
+            'tracer_predicates_v1' => [{ 'clientID' => 'client_id' }]
+          },
+          'v' => 21
+        },
+        'hashes' => { 'sha256' => Digest::SHA256.hexdigest(rules_data) },
+        'length' => 645
+      },
     }
   end
   let(:targets) do
@@ -125,11 +136,51 @@ RSpec.describe Datadog::Core::Remote::Client do
   let(:blocked_ips_content) do
     '{"rules_data":[{"data":[{"expiration":1678972458,"value":"42.42.42.1"}]}]}'
   end
+  let(:rules_data) do
+    {
+      version: '2.2',
+      metadata: {
+        rules_version: '1.5.2'
+      },
+      rules: [
+        {
+          id: 'blk-001-001',
+          name: 'Block IP Addresses',
+          tags: {
+            type: 'block_ip',
+            category: 'security_response'
+          },
+          conditions: [
+            {
+              parameters: {
+                inputs: [
+                  {
+                    address: 'http.client_ip'
+                  }
+                ],
+                data: 'blocked_ips'
+              },
+              operator: 'ip_match'
+            }
+          ],
+          transformers: [],
+          on_match: [
+            'block'
+          ]
+        }
+      ]
+    }.to_json
+  end
+
   let(:response_body) do
     {
       'roots' => roots.map { |r| Base64.strict_encode64(r.to_json).chomp },
       'targets' => Base64.strict_encode64(targets.to_json).chomp,
       'target_files' => [
+        {
+          'path' => 'datadog/603646/ASM_DD/latest/config',
+          'raw' => Base64.strict_encode64(rules_data).chomp
+        },
         {
           'path' => 'datadog/603646/ASM_DATA/blocked_ips/config',
           'raw' => Base64.strict_encode64(blocked_ips_content).chomp
@@ -141,6 +192,7 @@ RSpec.describe Datadog::Core::Remote::Client do
       ],
       'client_configs' => [
         'datadog/603646/ASM_DATA/blocked_ips/config',
+        'datadog/603646/ASM_DD/latest/config',
         'datadog/603646/ASM/exclusion_filters/config'
       ]
     }.to_json
@@ -166,10 +218,56 @@ RSpec.describe Datadog::Core::Remote::Client do
         expect(repository.contents.size).to_not eq(0)
       end
 
+      it 'propagates changes to AppSec' do
+        expected_ruleset = {
+          'exclusions' => [{
+            'conditions' => [{
+              'operator' => 'ip_match',
+              'parameters' => {
+                'inputs' => [{
+                  'address' => 'http.client_ip'
+                }]
+              }
+            }]
+          }],
+          'metadata' => {
+            'rules_version' => '1.5.2'
+          },
+          'rules' => [{
+            'conditions' => [{
+              'operator' => 'ip_match',
+              'parameters' => {
+                'data' => 'blocked_ips',
+                'inputs' => [{
+                  'address' => 'http.client_ip'
+                }]
+              }
+            }],
+            'id' => 'blk-001-001',
+            'name' => 'Block IP Addresses',
+            'on_match' => ['block'],
+            'tags' => {
+              'category' => 'security_response', 'type' => 'block_ip'
+            },
+            'transformers' => []
+          }],
+          'rules_data' => [{
+            'data' => [{
+              'expiration' => 1678972458,
+              'value' => '42.42.42.1'
+            }]
+          }],
+          'version' => '2.2'
+        }
+
+        expect(Datadog::AppSec).to receive(:reconfigure).with(ruleset: expected_ruleset)
+        client.sync
+      end
+
       context 'when the data is the same' do
         it 'does not commit the information to the transaction' do
           expect_any_instance_of(Datadog::Core::Remote::Configuration::Repository::Transaction).to receive(:insert)
-            .exactly(2).and_call_original
+            .exactly(3).and_call_original
           client.sync
           client.sync
         end
@@ -191,6 +289,10 @@ RSpec.describe Datadog::Core::Remote::Client do
               {
                 :path => 'datadog/603646/ASM/exclusion_filters/config',
                 :content => StringIO.new(exclusion_content)
+              },
+              {
+                :path => 'datadog/603646/ASM_DD/latest/config',
+                :content => StringIO.new(rules_data)
               }
             ]
           )
@@ -221,6 +323,15 @@ RSpec.describe Datadog::Core::Remote::Client do
                     'v' => 51
                   },
                   'hashes' => { 'sha256' => Digest::SHA256.hexdigest(new_blocked_ips) },
+                  'length' => 1834
+                },
+                'datadog/603646/ASM_DD/latest/config' => {
+                  'custom' => {
+                    'c' => ['client_id'],
+                    'tracer-predicates' => { 'tracer_predicates_v1' => [{ 'clientID' => 'client_id' }] },
+                    'v' => 51
+                  },
+                  'hashes' => { 'sha256' => Digest::SHA256.hexdigest(rules_data) },
                   'length' => 1834
                 }
               },

--- a/spec/datadog/tracing/integration_spec.rb
+++ b/spec/datadog/tracing/integration_spec.rb
@@ -897,21 +897,47 @@ RSpec.describe 'Tracer integration tests' do
     let(:port) { 34567 }
 
     context 'when :transport_options' do
+      let(:remote_enabled) { false }
+      let(:transport_options) { proc { |t| on_build.call(t) } }
+
       before do
         Datadog.configure do |c|
           c.tracing.transport_options = transport_options
+          c.remote.enabled = remote_enabled
         end
       end
 
       context 'is provided' do
-        let(:transport_options) { proc { |t| on_build.call(t) } }
+        let(:on_build) do
+          double('on_build').tap do |double|
+            expect(double).to receive(:call)
+              .with(kind_of(Datadog::Transport::HTTP::Builder))
+              .at_least(1).time
+            expect(double).to receive(:call)
+              .with(kind_of(Datadog::Core::Configuration::AgentSettingsResolver::TransportOptionsResolver))
+              .at_least(1).time
+          end
+        end
+
+        it do
+          configure
+
+          tracer.writer.transport.tap do |transport|
+            expect(transport).to be_a_kind_of(Datadog::Transport::Traces::Transport)
+            expect(transport.current_api.adapter.hostname).to be hostname
+            expect(transport.current_api.adapter.port).to be port
+          end
+        end
+      end
+
+      context 'is provided and remote configuration enabled' do
+        let(:remote_enabled) { true }
         let(:on_build) do
           double('on_build').tap do |double|
             expect(double).to receive(:call)
               .with(kind_of(Datadog::Transport::HTTP::Builder))
               .at_least(1).time
             # For the remote component.
-            # TODO: make sure is only call when is enabled in the configuration
             expect(double).to receive(:call)
               .with(kind_of(Datadog::Core::Transport::HTTP::Builder))
               .at_least(1).time


### PR DESCRIPTION
<!--
Check out the
https://github.com/DataDog/dd-trace-rb/blob/master/docs/DevelopmentGuide.md
for guidance on how to set up your development environment,
run the test suite, write new integrations, and more.
-->

**What does this PR do?**

Ties all the things together to Make It Work.

See commit messages for the details.

**Motivation**

Remote configuration

**Additional Notes**

- This mostly handles only the happy path of things (e.g agent with endpoint, no agent disappearing, etc...)
- There is AppSec stuff in Core still. This will be moved away shortly.

**How to test the change?**

Interactively:

```
docker run --rm -it -e DD_APM_ENABLED=true -e DD_ENV=${your_env} -e DD_HOSTNAME=lloeki.cassini -e DD_BIND_HOST=0.0.0.0 -e DD_APM_NON_LOCAL_TRAFFIC=true -e DD_API_KEY=${your_api_key} -e DD_REMOTE_CONFIGURATION_ENABLED=true -p 8126:8126 datadog/agent:7.42.0
```

Then:

```
env DD_AGENT_HOST=${agent_ip} DD_APPSEC_ENABLED=true DD_REMOTE_CONFIGURATION_ENABLED=true DD_REMOTE_CONFIGURATION_POLL_INTERVAL_SECONDS=10 DD_DIAGNOSTICS=true bundle exec puma -w 0 -p 9292
```

And:

```
# Note that the first request is the one that kicks off the worker, so it is not covered by the RC update.

# should block: rules override
curl -vvv -H 'User-Agent: Arachni/v2' 'http://user:pass@127.0.0.1:9292/?q=1%20OR%201;'
# should not block: exclusion filter
curl -vvv -H 'User-Agent: Nessus SOAP' 'http://user:pass@127.0.0.1:9292/?q=1%20OR%201;'

# these could block or not block depending on exclusion filters and denylist item expiration
curl -vvv -H 'X-Cluster-Client-IP: 80.80.80.80' 'http://user:pass@127.0.0.1:9292/'
curl -vvv -H 'X-Cluster-Client-IP: 1.0.0.1' 'http://user:pass@127.0.0.1:9292/'
curl -vvv -H 'X-Cluster-Client-IP: 1.2.3.4' 'http://user:pass@127.0.0.1:9292/'
```

Toggle stuff in the UI and see things being updated live in debug logs.