### PR TITLE
Omit `_dd.span_sampling.max_per_second` when not configured

### DIFF
--- a/spec/datadog/tracing/integration_spec.rb
+++ b/spec/datadog/tracing/integration_spec.rb
@@ -406,7 +406,7 @@ RSpec.describe 'Tracer integration tests' do
       it do
         expect(single_sampled_span.get_metric('_dd.span_sampling.mechanism')).to eq(8)
         expect(single_sampled_span.get_metric('_dd.span_sampling.rule_rate')).to eq(1.0)
-        expect(single_sampled_span.get_metric('_dd.span_sampling.max_per_second')).to eq(-1)
+        expect(single_sampled_span.get_metric('_dd.span_sampling.max_per_second')).to be_nil
         expect(local_root_span.get_tag('_dd.p.dm')).to eq('-8')
       end
     end

--- a/spec/datadog/tracing/sampling/span/rule_spec.rb
+++ b/spec/datadog/tracing/sampling/span/rule_spec.rb
@@ -19,7 +19,8 @@ RSpec.describe Datadog::Tracing::Sampling::Span::Rule do
       end
 
       it 'sets rate limit unlimited' do
-        expect(rule.rate_limit).to eq(-1)
+        expect(Datadog::Tracing::Sampling::TokenBucket).to receive(:new).with(-1)
+        expect(rule.rate_limit).to be_nil
       end
     end
   end


### PR DESCRIPTION
For Single Span Sampling, when no rate limit is provided, we should not include the `_dd.span_sampling.max_per_second`.

Before this PR, `_dd.span_sampling.max_per_second` was included with a default value of `-1`, meaning unlimited.

After this PR, `_dd.span_sampling.max_per_second` will be omitted when not configured. The backend will assume an unlimited rate for such cases.

This fixes an inconsistency we had with the Single Span Sampling specification. 