### PR TITLE
[APPSEC-8458] introduce AppSec::Utils::ReadWriteLock

### DIFF
--- a/lib/datadog/appsec/utils/read_write_lock.rb
+++ b/lib/datadog/appsec/utils/read_write_lock.rb
@@ -1,0 +1,78 @@
+# frozen_string_literal: true
+
+module Datadog
+  module AppSec
+    module Utils
+      # Simple implentation for a fair read write lock
+      # It allows for as many concurrent readers but only one concurrent writer.
+      # To avoid the writer thread being exhausted, once a writer thread has signaled that it wants to acquire the lock,
+      # no more reader threads can acquire the lock.
+      # The new reader threads will wait for the writer thread to finish.
+      class ReadWriteLock
+        def initialize
+          @reader_mutex    = Mutex.new
+          @reader_q        = ConditionVariable.new
+          @reader_count    = 0
+          @reader_releases = 0
+
+          @writer_mutex    = Mutex.new
+          @writer_q        = ConditionVariable.new
+          @writter         = false
+        end
+
+        def with_rlock
+          rlock
+          yield
+        ensure
+          runlock
+        end
+
+        def with_lock
+          lock
+          yield
+        ensure
+          unlock
+        end
+
+        def rlock
+          @reader_mutex.synchronize do
+            @reader_count += 1
+
+            writter = false
+
+            @writer_mutex.synchronize do
+              writter = @writter
+            end
+
+            @reader_q.wait(@reader_mutex) if writter
+          end
+        end
+
+        def runlock
+          @reader_mutex.synchronize do
+            @reader_releases += 1
+
+            @writer_mutex.synchronize { @writer_q.signal } if @reader_releases == @reader_count
+          end
+        end
+
+        def lock
+          @writer_mutex.synchronize do
+            @writer_q.wait(@writer_mutex) while (@reader_releases != @reader_count) || @writter
+
+            @writter = true
+          end
+        end
+
+        def unlock
+          @writer_mutex.synchronize do
+            @writter = false
+            @writer_q.signal
+          end
+
+          @reader_mutex.synchronize { @reader_q.broadcast }
+        end
+      end
+    end
+  end
+end

--- a/sig/datadog/appsec/utils/read_write_lock.rbs
+++ b/sig/datadog/appsec/utils/read_write_lock.rbs
@@ -1,0 +1,29 @@
+module Datadog
+  module AppSec
+    module Utils
+      class ReadWriteLock
+        attr_reader reader_mutex: Thread::Mutex
+        attr_reader writer_mutex: Thread::Mutex
+        attr_reader writer_q: Thread::ConditionVariable
+        attr_reader reader_q: Thread::ConditionVariable
+        attr_reader reader_count: Integer
+        attr_reader reader_releases: Integer
+        attr_reader writter: bool
+
+        def initialize: () -> void
+
+        def with_rlock: () { () -> untyped } -> void
+
+        def with_lock: () { () -> untyped } -> void
+
+        def rlock: () -> void
+
+        def runlock: () -> void
+
+        def lock: () -> void
+
+        def unlock: () -> void
+      end
+    end
+  end
+end

--- a/spec/datadog/appsec/utils/read_write_lock_spec.rb
+++ b/spec/datadog/appsec/utils/read_write_lock_spec.rb
@@ -1,0 +1,129 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+require 'datadog/appsec/utils/read_write_lock'
+
+RSpec.describe Datadog::AppSec::Utils::ReadWriteLock do
+  subject(:read_write_lock) { described_class.new }
+
+  context 'read locks' do
+    it 'allows for many readers' do
+      rw_lock = read_write_lock
+      state = 0
+      read_threads = Array.new(3) do
+        Thread.new do
+          rw_lock.with_rlock do
+            expect(state).to eq(0)
+          end
+        end
+      end
+
+      read_threads.each(&:join)
+    end
+
+    it 'release the read lock when an exception occurs' do
+      rw_lock = read_write_lock
+      expect(rw_lock).to receive(:runlock)
+      begin
+        rw_lock.with_rlock do
+          raise StandardError
+        end
+      rescue
+        # do nothing
+      end
+    end
+
+    it 'writter waits while readers holds the lock' do
+      rw_lock = read_write_lock
+      state = 0
+      queue = Queue.new
+      queue2 = Queue.new
+      queue3 = Queue.new
+
+      read_thread = Thread.new do
+        rw_lock.with_rlock do
+          queue << 1
+          queue3 << 1
+          queue2.pop
+        end
+      end
+
+      write_thread = Thread.new do
+        queue3.pop
+        rw_lock.with_lock do
+          state = 1
+        end
+      end
+
+      # The read thead holds the lock and the writter tries to acquire the lock
+      queue.pop
+      expect(state).to eq(0)
+
+      # we relase the reader lock ans the write locks acquires it and modify state
+      queue2 << 1
+      read_thread.join
+      write_thread.join
+      expect(state).to eq(1)
+    end
+  end
+
+  context 'writer locks' do
+    it 'release the write lock when an exception occurs' do
+      rw_lock = read_write_lock
+      expect(rw_lock).to receive(:unlock)
+      begin
+        rw_lock.with_lock do
+          raise StandardError
+        end
+      rescue
+        # do nothing
+      end
+    end
+
+    it 'read threads wait for writter lock to be released' do
+      rw_lock = read_write_lock
+      state = 0
+      queue = Queue.new
+      queue2 = Queue.new
+      queue3 = Queue.new
+      queue4 = Queue.new
+
+      read_thread = Thread.new do
+        queue2.pop
+        expect(state).to eq(0)
+        queue3 << 1
+
+        # Wait for writer thread to release the lock. That happens at line 119
+        rw_lock.with_rlock do
+          expect(state).to eq(1)
+        end
+      end
+
+      write_thread = Thread.new do
+        rw_lock.with_lock do
+          queue.pop
+          # Allow the reader thread to start running. Check the vale of state before the writer changes it
+          queue2 << 1
+
+          # The reader thread has signal that state is 0 and procced to acquire the reader lock.
+          # It has to wait because the writer thread holds the lock
+          queue3.pop
+
+          # Modify state
+          state = 1
+
+          queue4.pop
+        end
+      end
+
+      # The writter thread holds the lock and modify state
+      queue << 1
+
+      # We release the writter lock and assert that state has change inside the reader thread
+      queue4 << 1
+      read_thread.join
+      write_thread.join
+    end
+  end
+end


### PR DESCRIPTION
<!--
Check out the
https://github.com/DataDog/dd-trace-rb/blob/master/docs/DevelopmentGuide.md
for guidance on how to set up your development environment,
run the test suite, write new integrations, and more.
-->

**What does this PR do?**
<!-- A brief description of the change being made with this pull request. -->

Introduce a native ruby ReadWrite Lock implementation. This RWLock would be used in subsequent work for the Remote Client Configuration.  

You can check this [PR](https://github.com/DataDog/dd-trace-rb/pull/2714) to understand where we will use the read-write lock.

The implementation provides a fair reader write lock. 

It allows for as many concurrent readers but only one concurrent writer. To avoid the writer thread being exhausted, once a writer thread has signalled that it wants to acquire the lock, no more reader threads can acquire the read lock. The new reader threads will wait for the writer thread to finish the writing. 

**Motivation**

The motivation is to reduce the contention when reading or writing the `AppSec.processor` singleton variable.

There will be a background thread that might modify the processor instance. During that process, we want any request to wait until the background thread has finished updating the processor instance. 

In this case, we do not have any background thread modifying the processor instance. We want as many concurrent read operations as possible.

**Additional Notes**

I provided a simple unit test for the implementation, and I also tested against this script: 

```ruby
require 'benchmark'

TOTAL_THREADS = 100 # set as high as practicable, for a better test

def test(lock)
  puts "READ INTENSIVE (80% read, 20% write):"
  single_test(lock, (TOTAL_THREADS * 0.8).floor, (TOTAL_THREADS * 0.2).floor)
  puts "WRITE INTENSIVE (80% write, 20% read):"
  single_test(lock, (TOTAL_THREADS * 0.2).floor, (TOTAL_THREADS * 0.8).floor)
  puts "BALANCED (50% read, 50% write):"
  single_test(lock, (TOTAL_THREADS * 0.5).floor, (TOTAL_THREADS * 0.5).floor)
end

def single_test(lock, n_readers, n_writers, reader_iterations=50, writer_iterations=50, reader_sleep=0.001, writer_sleep=0.001)
  puts "Testing #{lock.class} with #{n_readers} readers and #{n_writers} writers. Readers iterate #{reader_iterations} times, sleeping #{reader_sleep}s each time, writers iterate #{writer_iterations} times, sleeping #{writer_sleep}s each time"
  mutex = Mutex.new
  bad   = false
  data  = 0

  result = Benchmark.measure do
    readers = n_readers.times.collect do |i|
                Thread.new do
                  reader_iterations.times do
                    lock.with_read_lock do
                      mutex.synchronize { bad = true } if (data % 2) != 0
                      sleep(reader_sleep)
                      mutex.synchronize { bad = true } if (data % 2) != 0
                    end
                  end
                end
              end
    writers = n_writers.times.collect do |i|
                Thread.new do
                  writer_iterations.times do
                    lock.with_write_lock do
                      value = (data += 1)
                      sleep(writer_sleep)
                      data  = value+1
                    end
                  end
                end
              end

    readers.each { |t| t.join }
    writers.each { |t| t.join }
    puts "BAD!!! Readers+writers overlapped!" if mutex.synchronize { bad }
    puts "BAD!!! Writers overlapped! Expected data #{(n_writers * writer_iterations * 2)} got #{data}" if data != (n_writers * writer_iterations * 2)
    puts "Expected data #{(n_writers * writer_iterations * 2)} got #{data}"
  end
  puts result
end

test(Datadog::AppSec::Utils::ReadWriteLock.new)
```


This is the results from running it:
```
READ INTENSIVE (80% read, 20% write):
Testing Locks::ReadWriteMutex with 80 readers and 20 writers. Readers iterate 50 times, sleeping 0.001s each time, writers iterate 50 times, sleeping 0.001s each time
Expected data 2000 got 2000
  0.028927   0.095037   0.123964 (  1.388397)

WRITE INTENSIVE (80% write, 20% read):
Testing Locks::ReadWriteMutex with 20 readers and 80 writers. Readers iterate 50 times, sleeping 0.001s each time, writers iterate 50 times, sleeping 0.001s each time
Expected data 8000 got 8000
  0.089277   0.143242   0.232519 (  5.363435)

BALANCED (50% read, 50% write):
Testing Locks::ReadWriteMutex with 50 readers and 50 writers. Readers iterate 50 times, sleeping 0.001s each time, writers iterate 50 times, sleeping 0.001s each time
Expected data 5000 got 5000
  0.066041   0.151607   0.217648 (  3.345871)
```

**How to test the change?**
<!--
Describe here how the change can be validated.
You are strongly encouraged to provide automated tests for this PR (unit or integration).
If this change cannot be feasibly tested, please explain why,
unless the change does not modify code (e.g. only modifies docs, comments).
-->

CI 
