### PR TITLE
Test:Fix start_with typo

### DIFF
--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -260,7 +260,7 @@ if ENV.key?('CI')
 
   ThreadHelpers.with_leaky_thread_creation('Deadline thread') do
     Thread.new do
-      Thread.current.name = 'spec_helper.rb CI debugging Deadline thread' unless RUBY_VERSION.start_with('2.1.', '2.2.')
+      Thread.current.name = 'spec_helper.rb CI debugging Deadline thread' unless RUBY_VERSION.start_with?('2.1.', '2.2.')
 
       sleep_time = 30 * 60 # 30 minutes
       sleep(sleep_time)


### PR DESCRIPTION
Minor typo on `String#start_with?` method. Does not affect test correctness, but breaks deadline thread.