### PR TITLE
Fix w3c propagation special character handling

### DIFF
--- a/lib/datadog/tracing/distributed/trace_context.rb
+++ b/lib/datadog/tracing/distributed/trace_context.rb
@@ -194,13 +194,13 @@ module Datadog
         # Serialize `_dd.p.{key}` by first removing the `_dd.p.` prefix.
         # Then replacing invalid characters with `_`.
         #
-        # Returns a new object if modified given `name` is a Hash key, thus always frozen.
+        # Returns a new object, given `name` is a Hash key thus always frozen.
         def serialize_tag_key(name)
           key = name.delete_prefix(Tracing::Metadata::Ext::Distributed::TAGS_PREFIX)
 
           # DEV: It's unlikely that characters will be out of range, as they mostly
           # DEV: come from Datadog-controlled sources.
-          # DEV: Trying to `match?` is measurably faster than a `gsub` that does not match.
+          # DEV: Trying to `match?` is measurably faster than a `gsub!` that does not match.
           key.gsub!(INVALID_TAG_KEY_CHARS, '_') if INVALID_TAG_KEY_CHARS.match?(key)
 
           key

--- a/lib/datadog/tracing/distributed/trace_context.rb
+++ b/lib/datadog/tracing/distributed/trace_context.rb
@@ -193,20 +193,22 @@ module Datadog
 
         # Serialize `_dd.p.{key}` by first removing the `_dd.p.` prefix.
         # Then replacing invalid characters with `_`.
+        #
+        # Returns a new object if modified given `name` is a Hash key, thus always frozen.
         def serialize_tag_key(name)
           key = name.delete_prefix(Tracing::Metadata::Ext::Distributed::TAGS_PREFIX)
 
           # DEV: It's unlikely that characters will be out of range, as they mostly
           # DEV: come from Datadog-controlled sources.
           # DEV: Trying to `match?` is measurably faster than a `gsub` that does not match.
-          if INVALID_TAG_KEY_CHARS.match?(key)
-            key.gsub(INVALID_TAG_KEY_CHARS, '_')
-          else
-            key
-          end
+          key.gsub!(INVALID_TAG_KEY_CHARS, '_') if INVALID_TAG_KEY_CHARS.match?(key)
+
+          key
         end
 
-        # Replaces invalid characters with `_`, then replaces `=` with `:`.
+        # Replaces invalid characters with `_`, then replaces `=` with `~`.
+        #
+        # Returns a new object if modified given `value` belongs to the {TraceDigest} being serialized.
         def serialize_tag_value(value)
           # DEV: It's unlikely that characters will be out of range, as they mostly
           # DEV: come from Datadog-controlled sources.
@@ -217,9 +219,12 @@ module Datadog
                   value
                 end
 
-          # DEV: Checking for an unlikely '=' is faster than a no-op `tr!`.
-          ret.tr!('=', ':') if ret.include?('=')
-          ret
+          # DEV: Checking for an unlikely '=' is faster than a no-op `tr`.
+          if ret.include?('=')
+            ret.tr('=', '~')
+          else
+            ret
+          end
         end
 
         def extract_traceparent(traceparent)
@@ -309,9 +314,9 @@ module Datadog
           [origin, sampling_priority, tags, unknown_fields]
         end
 
-        # Restore `:` back to `=`.
+        # Restore `~` back to `=`.
         def deserialize_tag_value(value)
-          value.tr!(':', '=')
+          value.tr!('~', '=')
           value
         end
 
@@ -363,9 +368,9 @@ module Datadog
         INVALID_TAG_KEY_CHARS = /[\u0000-\u0020,=\u007F-\u{10FFFF}]/.freeze
         private_constant :INVALID_TAG_KEY_CHARS
 
-        # Replace all characters with `_`, except ASCII characters 0x20-0x7E.
-        # Additionally, `,`, ':' and `;` must also be replaced by `_`.
-        INVALID_TAG_VALUE_CHARS = /[\u0000-\u001F,:;\u007F-\u{10FFFF}]/.freeze
+        # Replace all characters with `_`, except ASCII characters 0x20-0x7D.
+        # Additionally, `,` and `;` must also be replaced by `_`.
+        INVALID_TAG_VALUE_CHARS = /[\u0000-\u001F,;\u007E-\u{10FFFF}]/.freeze
         private_constant :INVALID_TAG_VALUE_CHARS
       end
     end

--- a/lib/datadog/tracing/distributed/trace_context.rb
+++ b/lib/datadog/tracing/distributed/trace_context.rb
@@ -194,7 +194,8 @@ module Datadog
         # Serialize `_dd.p.{key}` by first removing the `_dd.p.` prefix.
         # Then replacing invalid characters with `_`.
         #
-        # Returns a new object, given `name` is a Hash key thus always frozen.
+        # The argument `name` is always frozen.
+        # Returns a new String object for the serialized key.
         def serialize_tag_key(name)
           key = name.delete_prefix(Tracing::Metadata::Ext::Distributed::TAGS_PREFIX)
 
@@ -208,7 +209,8 @@ module Datadog
 
         # Replaces invalid characters with `_`, then replaces `=` with `~`.
         #
-        # Returns a new object if modified given `value` belongs to the {TraceDigest} being serialized.
+        # The argument `value` belongs to {TraceDigest}, thus should not be directly modified.
+        # Returns a new String object for the serialized value.
         def serialize_tag_value(value)
           # DEV: It's unlikely that characters will be out of range, as they mostly
           # DEV: come from Datadog-controlled sources.

--- a/spec/datadog/tracing/distributed/trace_context_spec.rb
+++ b/spec/datadog/tracing/distributed/trace_context_spec.rb
@@ -214,7 +214,7 @@ RSpec.shared_examples 'Trace Context distributed format' do
             "\u001F", # Last lower invalid character
             ',',
             ';',
-            '~', # First upper invalid character
+            '~', # First upper invalid character (\u007E)
             "\u{10FFFF}" # Last unicode character
           ].each do |character|
             context character.inspect do

--- a/spec/datadog/tracing/distributed/trace_context_spec.rb
+++ b/spec/datadog/tracing/distributed/trace_context_spec.rb
@@ -434,9 +434,9 @@ RSpec.shared_examples 'Trace Context distributed format' do
           it { is_expected.to eq('_dd.p.dm' => '-1') }
         end
 
-        context "{ 'key' => 'value=with=equals' }" do
-          let(:tags) { 't.key:value:with:equals' }
-          it { is_expected.to eq('_dd.p.key' => 'value:with:equals') }
+        context "{ 'key' => 'value~with~tilde' }" do
+          let(:tags) { 't.key:value~with~tilde' }
+          it { is_expected.to eq('_dd.p.key' => 'value=with=tilde') }
         end
       end
 


### PR DESCRIPTION
This PR fixes three w3c `tracecontext` propagation issues:
1. If the provided `TraceDigest#trace_distributed_tags` contained Hash values that needed to be escaped during distributed trace injection, those value were being modified leaving the original `TraceDigest#trace_distributed_tags` changed. The provided `TraceDigest#trace_distributed_tags` does not change anymore on injection. This never affected distributed header extraction.
2. `:` is not considered an invalid `trace_distributed_tags` value anymore, thus it is not going to be escaped.
3. `=` is now serialized as `~`, instead of `:`.

These issues were caught by our tracestate headers system tests: https://github.com/DataDog/system-tests/blob/92064c6af29562f2962176767c417fc2b0eda867/parametric/test_headers_tracestate_dd.py