### PR TITLE
Defect fix: check Rack::Request is defined

### DIFF
--- a/lib/datadog/appsec/contrib/rack/gateway/request.rb
+++ b/lib/datadog/appsec/contrib/rack/gateway/request.rb
@@ -36,7 +36,7 @@ module Datadog
             # Rack < 2.0 does not have :each_header
             # TODO: We need access to Rack here. We must make sure we are able to load AppSec without Rack,
             # TODO: while still ensure correctness in ths code path.
-            if defined?(::Rack) && ::Rack::Request.instance_methods.include?(:each_header)
+            if defined?(::Rack::Request) && ::Rack::Request.instance_methods.include?(:each_header)
               def headers
                 request.each_header.each_with_object({}) do |(k, v), h|
                   h[k.gsub(/^HTTP_/, '').downcase.tr('_', '-')] = v if k =~ /^HTTP_/


### PR DESCRIPTION
In some scenarios, `Rack` is defined, but `Rack::Request` is not. Avoid raising an error in these circumstances.

Resolves #2724 