### PR TITLE
Improve controller instrumentation and deprecate option `exception_controller`

### DIFF
--- a/docs/GettingStarted.md
+++ b/docs/GettingStarted.md
@@ -1644,7 +1644,6 @@ end
 | --- | ----------- | ------- |
 | `distributed_tracing` | Enables [distributed tracing](#distributed-tracing) so that this service trace is connected with a trace of another service if tracing headers are received | `true` |
 | `request_queuing` | Track HTTP request time spent in the queue of the frontend server. See [HTTP request queuing](#http-request-queuing) for setup details. | `false` |
-| `exception_controller` | Class/Module or String which identifies a custom exception controller class. Tracer provides improved error behavior when it can identify custom exception controllers. By default, without this option, it 'guesses' what a custom exception controller looks like. Providing this option aids this identification. | `nil` |
 | `middleware` | Add the trace middleware to the Rails application. Set to `false` if you don't want the middleware to load. | `true` |
 | `middleware_names` | Enables any short-circuited middleware requests to display the middleware name as a resource for the trace. | `false` |
 | `service_name` | Service name used when tracing application requests (on the `rack` level) | `'<app_name>'` (inferred from your Rails application namespace) |

--- a/docs/GettingStarted.md
+++ b/docs/GettingStarted.md
@@ -1644,7 +1644,7 @@ end
 | --- | ----------- | ------- |
 | `distributed_tracing` | Enables [distributed tracing](#distributed-tracing) so that this service trace is connected with a trace of another service if tracing headers are received | `true` |
 | `request_queuing` | Track HTTP request time spent in the queue of the frontend server. See [HTTP request queuing](#http-request-queuing) for setup details. | `false` |
-| `exception_controller` | Class or Module which identifies a custom exception controller class. Tracer provides improved error behavior when it can identify custom exception controllers. By default, without this option, it 'guesses' what a custom exception controller looks like. Providing this option aids this identification. | `nil` |
+| `exception_controller` | Class/Module or String which identifies a custom exception controller class. Tracer provides improved error behavior when it can identify custom exception controllers. By default, without this option, it 'guesses' what a custom exception controller looks like. Providing this option aids this identification. | `nil` |
 | `middleware` | Add the trace middleware to the Rails application. Set to `false` if you don't want the middleware to load. | `true` |
 | `middleware_names` | Enables any short-circuited middleware requests to display the middleware name as a resource for the trace. | `false` |
 | `service_name` | Service name used when tracing application requests (on the `rack` level) | `'<app_name>'` (inferred from your Rails application namespace) |

--- a/integration/apps/rails-seven/app/controllers/basic_controller.rb
+++ b/integration/apps/rails-seven/app/controllers/basic_controller.rb
@@ -28,6 +28,12 @@ class BasicController < ApplicationController
     head :ok
   end
 
+  def boom
+    # Make the span visible from graph
+    sleep 0.1
+    raise StandardError, 'bala boom!'
+  end
+
   private
 
   def fib(n)

--- a/integration/apps/rails-seven/app/controllers/errors_controller.rb
+++ b/integration/apps/rails-seven/app/controllers/errors_controller.rb
@@ -1,0 +1,8 @@
+
+class ErrorsController < ApplicationController
+  def server_error
+    # Make the span visible from graph
+    sleep 0.1
+    render plain: "OK"
+  end
+end

--- a/integration/apps/rails-seven/config/application.rb
+++ b/integration/apps/rails-seven/config/application.rb
@@ -82,5 +82,7 @@ module Acme
 
     config.cache_store = :redis_cache_store, { url: ENV['REDIS_URL'] }
     config.action_controller.perform_caching = true
+
+    config.exceptions_app = self.routes
   end
 end

--- a/integration/apps/rails-seven/config/routes.rb
+++ b/integration/apps/rails-seven/config/routes.rb
@@ -1,4 +1,6 @@
 Rails.application.routes.draw do
+  match '/500', via: :all, to: 'errors#server_error'
+
   get '/', to: 'basic#default'
   get 'health', to: 'health#check'
   get 'health/detailed', to: 'health#detailed_check'
@@ -6,6 +8,7 @@ Rails.application.routes.draw do
   # Basic test scenarios
   get 'basic/default', to: 'basic#default'
   get 'basic/fibonacci', to: 'basic#fibonacci'
+  get 'basic/boom', to: 'basic#boom'
 
   # Job test scenarios
   post 'jobs', to: 'jobs#create'

--- a/integration/apps/rails-six/app/controllers/basic_controller.rb
+++ b/integration/apps/rails-six/app/controllers/basic_controller.rb
@@ -28,6 +28,12 @@ class BasicController < ApplicationController
     head :ok
   end
 
+  def boom
+    # Make the span visible from graph
+    sleep 0.1
+    raise StandardError, 'bala boom!'
+  end
+
   private
 
   def fib(n)

--- a/integration/apps/rails-six/app/controllers/errors_controller.rb
+++ b/integration/apps/rails-six/app/controllers/errors_controller.rb
@@ -1,0 +1,8 @@
+
+class ErrorsController < ApplicationController
+  def server_error
+    # Make the span visible from graph
+    sleep 0.1
+    render plain: "OK"
+  end
+end

--- a/integration/apps/rails-six/config/application.rb
+++ b/integration/apps/rails-six/config/application.rb
@@ -94,5 +94,7 @@ module Acme
 
     config.cache_store = :redis_cache_store, { url: ENV['REDIS_URL'] }
     config.action_controller.perform_caching = true
+
+    config.exceptions_app = self.routes
   end
 end

--- a/integration/apps/rails-six/config/routes.rb
+++ b/integration/apps/rails-six/config/routes.rb
@@ -1,4 +1,6 @@
 Rails.application.routes.draw do
+  match '/500', via: :all, to: 'errors#server_error'
+
   get '/', to: 'basic#default'
   get 'health', to: 'health#check'
   get 'health/detailed', to: 'health#detailed_check'
@@ -6,6 +8,7 @@ Rails.application.routes.draw do
   # Basic test scenarios
   get 'basic/default', to: 'basic#default'
   get 'basic/fibonacci', to: 'basic#fibonacci'
+  get 'basic/boom', to: 'basic#boom'
 
   # Job test scenarios
   post 'jobs', to: 'jobs#create'

--- a/lib/datadog/tracing/contrib/action_pack/action_controller/instrumentation.rb
+++ b/lib/datadog/tracing/contrib/action_pack/action_controller/instrumentation.rb
@@ -117,7 +117,8 @@ module Datadog
               rescue NameError => e
                 ONLY_ONCE.run do
                   Datadog.logger.error do
-                    "Unable to constantize #{exception_controller_class} from `exception_controller` option, please make sure to provide string can be constantized"
+                    "Unable to resolve #{e.name} from `exception_controller` option ends up with "\
+                    "`#{e.class}`. Please make sure to provide a string can be constantized."
                   end
                 end
                 !headers[:request_exception].nil?

--- a/lib/datadog/tracing/contrib/action_pack/action_controller/instrumentation.rb
+++ b/lib/datadog/tracing/contrib/action_pack/action_controller/instrumentation.rb
@@ -6,6 +6,8 @@ require_relative '../utils'
 require_relative '../../rack/middlewares'
 require_relative '../../analytics'
 
+require_relative '../../../../core/utils/only_once'
+
 module Datadog
   module Tracing
     module Contrib
@@ -13,6 +15,8 @@ module Datadog
         module ActionController
           # Instrumentation for ActionController components
           module Instrumentation
+            ONLY_ONCE = Datadog::Core::Utils::OnlyOnce.new
+
             module_function
 
             def start_processing(payload)
@@ -35,7 +39,7 @@ module Datadog
               tracing_context[:dd_request_span] = span
 
               # We want the route to show up as the trace's resource
-              trace.resource = span.resource
+              trace.resource = span.resource unless payload.fetch(:exception_controller?)
 
               span.set_tag(Tracing::Metadata::Ext::TAG_COMPONENT, Ext::TAG_COMPONENT)
               span.set_tag(Tracing::Metadata::Ext::TAG_OPERATION, Ext::TAG_OPERATION_CONTROLLER)
@@ -54,7 +58,7 @@ module Datadog
 
               begin
                 # We repeat this in both start and at finish because the resource may have changed during the request
-                trace.resource = span.resource
+                trace.resource = span.resource unless payload.fetch(:exception_controller?)
 
                 # Set analytics sample rate
                 Utils.set_analytics_sample_rate(span)
@@ -82,22 +86,41 @@ module Datadog
             end
 
             def exception_controller?(payload)
-              exception_controller_class = Datadog.configuration.tracing[:action_pack][:exception_controller]
-              controller = payload.fetch(:controller)
-              headers = payload.fetch(:headers)
+              begin
+                exception_controller_class = Datadog.configuration.tracing[:action_pack][:exception_controller]
 
-              # If no exception controller class has been set,
+                controller = payload.fetch(:controller)
+                headers = payload.fetch(:headers)
+
+                # If no exception controller class has been set,
+                # guess whether this is an exception controller from the headers.
+                return !headers[:request_exception].nil? if exception_controller_class.nil?
+
+                # If an exception controller class has been provided as a string,
+                # try to find the constant defined from string
+                if exception_controller_class.is_a?(String)
+                  exception_controller_class = Object.const_get(exception_controller_class)
+                end
+
+                # If an exception controller class has been specified,
+                # check if the controller is a kind of the exception controller class.
+                if exception_controller_class.is_a?(Module)
+                  controller <= exception_controller_class
+                # Otherwise if the exception controller class is some other value (like false)
+                # assume that this controller doesn't handle exceptions.
+                else
+                  false
+                end
+
+              # If an string cannot be constantized
               # guess whether this is an exception controller from the headers.
-              if exception_controller_class.nil?
+              rescue NameError => e
+                ONLY_ONCE.run do
+                  Datadog.logger.error do
+                    "Unable to constantize #{exception_controller_class} from `exception_controller` option, please make sure to provide string can be constantized"
+                  end
+                end
                 !headers[:request_exception].nil?
-              # If an exception controller class has been specified,
-              # check if the controller is a kind of the exception controller class.
-              elsif exception_controller_class.is_a?(Class) || exception_controller_class.is_a?(Module)
-                controller <= exception_controller_class
-              # Otherwise if the exception controller class is some other value (like false)
-              # assume that this controller doesn't handle exceptions.
-              else
-                false
               end
             end
 

--- a/lib/datadog/tracing/contrib/action_pack/configuration/settings.rb
+++ b/lib/datadog/tracing/contrib/action_pack/configuration/settings.rb
@@ -1,6 +1,8 @@
 require_relative '../../configuration/settings'
 require_relative '../ext'
 
+require_relative '../../../../core'
+
 module Datadog
   module Tracing
     module Contrib
@@ -24,7 +26,18 @@ module Datadog
               o.lazy
             end
 
-            option :exception_controller
+            # DEV-2.0: Breaking changes for removal.
+            option :exception_controller do |o|
+              o.on_set do |value|
+                if value
+                  Datadog::Core.log_deprecation do
+                    "Option `#{o.instance_variable_get(:@name)}` has been deprecated and will be removed, "\
+                    'the value provided is no longer effective.'
+                  end
+                end
+              end
+            end
+
             option :service_name
           end
         end

--- a/lib/datadog/tracing/contrib/action_pack/configuration/settings.rb
+++ b/lib/datadog/tracing/contrib/action_pack/configuration/settings.rb
@@ -31,8 +31,8 @@ module Datadog
               o.on_set do |value|
                 if value
                   Datadog::Core.log_deprecation do
-                    "Option `#{o.instance_variable_get(:@name)}` has been deprecated and will be removed, "\
-                    'the value provided is no longer effective.'
+                    'The error controller is now automatically detected. '\
+                    "Option `#{o.instance_variable_get(:@name)}` is no longer required and will be removed."
                   end
                 end
               end

--- a/lib/datadog/tracing/contrib/rails/configuration/settings.rb
+++ b/lib/datadog/tracing/contrib/rails/configuration/settings.rb
@@ -1,5 +1,7 @@
 require_relative '../../configuration/settings'
 
+require_relative '../../../../core'
+
 module Datadog
   module Tracing
     module Contrib
@@ -48,10 +50,15 @@ module Datadog
 
             option :request_queuing, default: false
 
+            # DEV-2.0: Breaking changes for removal.
             option :exception_controller do |o|
               o.on_set do |value|
-                # Update ActionPack exception controller too
-                Datadog.configuration.tracing[:action_pack][:exception_controller] = value
+                if value
+                  Datadog::Core.log_deprecation do
+                    "Option `#{o.instance_variable_get(:@name)}` has been deprecated and will be removed, "\
+                    'the value provided is no longer effective.'
+                  end
+                end
               end
             end
 

--- a/lib/datadog/tracing/contrib/rails/configuration/settings.rb
+++ b/lib/datadog/tracing/contrib/rails/configuration/settings.rb
@@ -55,8 +55,8 @@ module Datadog
               o.on_set do |value|
                 if value
                   Datadog::Core.log_deprecation do
-                    "Option `#{o.instance_variable_get(:@name)}` has been deprecated and will be removed, "\
-                    'the value provided is no longer effective.'
+                    'The error controller is now automatically detected. '\
+                    "Option `#{o.instance_variable_get(:@name)}` is no longer required and will be removed."
                   end
                 end
               end

--- a/spec/datadog/tracing/contrib/action_pack/action_controller/metal_spec.rb
+++ b/spec/datadog/tracing/contrib/action_pack/action_controller/metal_spec.rb
@@ -65,6 +65,10 @@ RSpec.describe 'Datadog::Tracing::Contrib::ActionPack::ActionController::Metal' 
           map '/boom' do
             run error_action
           end
+
+          map '/error_handler' do
+            run error_handler
+          end
         end
       end
 
@@ -131,6 +135,28 @@ RSpec.describe 'Datadog::Tracing::Contrib::ActionPack::ActionController::Metal' 
               expect(controller_span).to have_error
             end
           end
+
+          context 'when given a request to error handling endpoint' do
+            it 'renders within ErrorController' do
+              get '/error_handler'
+
+              expect(spans).to have(2).items
+
+              rack_span, handle_err_span = spans
+
+              expect(rack_span).to be_root_span
+              expect(rack_span.name).to eq('rack.request')
+              expect(rack_span.resource).to eq('ErrorController#handle_error')
+
+              expect(handle_err_span.parent_id).to eq(rack_span.id)
+              expect(handle_err_span.name).to eq('rails.action_controller')
+              expect(handle_err_span.resource).to eq('ErrorController#handle_error')
+              expect(handle_err_span.get_tag('component')).to eq('action_pack')
+              expect(handle_err_span.get_tag('operation')).to eq('controller')
+              expect(handle_err_span.get_tag('rails.route.controller')).to eq('ErrorController')
+              expect(handle_err_span.get_tag('rails.route.action')).to eq('handle_error')
+            end
+          end
         end
 
         context 'when configure exception_controller with a constant' do
@@ -193,6 +219,28 @@ RSpec.describe 'Datadog::Tracing::Contrib::ActionPack::ActionController::Metal' 
               expect(controller_span.get_tag('rails.route.controller')).to eq('TestController')
               expect(controller_span.get_tag('rails.route.action')).to eq('raise_exception')
               expect(controller_span).to have_error
+            end
+          end
+
+          context 'when given a request to error handling endpoint' do
+            it 'renders within ErrorController' do
+              get '/error_handler'
+
+              expect(spans).to have(2).items
+
+              rack_span, handle_err_span = spans
+
+              expect(rack_span).to be_root_span
+              expect(rack_span.name).to eq('rack.request')
+              expect(rack_span.resource).to eq('ErrorController#handle_error')
+
+              expect(handle_err_span.parent_id).to eq(rack_span.id)
+              expect(handle_err_span.name).to eq('rails.action_controller')
+              expect(handle_err_span.resource).to eq('ErrorController#handle_error')
+              expect(handle_err_span.get_tag('component')).to eq('action_pack')
+              expect(handle_err_span.get_tag('operation')).to eq('controller')
+              expect(handle_err_span.get_tag('rails.route.controller')).to eq('ErrorController')
+              expect(handle_err_span.get_tag('rails.route.action')).to eq('handle_error')
             end
           end
         end
@@ -259,6 +307,28 @@ RSpec.describe 'Datadog::Tracing::Contrib::ActionPack::ActionController::Metal' 
               expect(controller_span).to have_error
             end
           end
+
+          context 'when given a request to error handling endpoint' do
+            it 'renders within ErrorController' do
+              get '/error_handler'
+
+              expect(spans).to have(2).items
+
+              rack_span, handle_err_span = spans
+
+              expect(rack_span).to be_root_span
+              expect(rack_span.name).to eq('rack.request')
+              expect(rack_span.resource).to eq('ErrorController#handle_error')
+
+              expect(handle_err_span.parent_id).to eq(rack_span.id)
+              expect(handle_err_span.name).to eq('rails.action_controller')
+              expect(handle_err_span.resource).to eq('ErrorController#handle_error')
+              expect(handle_err_span.get_tag('component')).to eq('action_pack')
+              expect(handle_err_span.get_tag('operation')).to eq('controller')
+              expect(handle_err_span.get_tag('rails.route.controller')).to eq('ErrorController')
+              expect(handle_err_span.get_tag('rails.route.action')).to eq('handle_error')
+            end
+          end
         end
 
         context 'when configure exception_controller with a wrong string' do
@@ -321,6 +391,28 @@ RSpec.describe 'Datadog::Tracing::Contrib::ActionPack::ActionController::Metal' 
               expect(controller_span.get_tag('rails.route.controller')).to eq('TestController')
               expect(controller_span.get_tag('rails.route.action')).to eq('raise_exception')
               expect(controller_span).to have_error
+            end
+          end
+
+          context 'when given a request to error handling endpoint' do
+            it 'renders within ErrorController' do
+              get '/error_handler'
+
+              expect(spans).to have(2).items
+
+              rack_span, handle_err_span = spans
+
+              expect(rack_span).to be_root_span
+              expect(rack_span.name).to eq('rack.request')
+              expect(rack_span.resource).to eq('ErrorController#handle_error')
+
+              expect(handle_err_span.parent_id).to eq(rack_span.id)
+              expect(handle_err_span.name).to eq('rails.action_controller')
+              expect(handle_err_span.resource).to eq('ErrorController#handle_error')
+              expect(handle_err_span.get_tag('component')).to eq('action_pack')
+              expect(handle_err_span.get_tag('operation')).to eq('controller')
+              expect(handle_err_span.get_tag('rails.route.controller')).to eq('ErrorController')
+              expect(handle_err_span.get_tag('rails.route.action')).to eq('handle_error')
             end
           end
         end

--- a/spec/datadog/tracing/contrib/action_pack/action_controller/metal_spec.rb
+++ b/spec/datadog/tracing/contrib/action_pack/action_controller/metal_spec.rb
@@ -157,6 +157,28 @@ RSpec.describe 'Datadog::Tracing::Contrib::ActionPack::ActionController::Metal' 
               expect(handle_err_span.get_tag('rails.route.action')).to eq('handle_error')
             end
           end
+
+          context 'when given a request to error handling endpoint with ActionDispatch exception' do
+            it 'renders within ErrorController and does not change trace resource' do
+              get '/error_handler', {}, 'action_dispatch.exception' => ArgumentError.new
+
+              expect(spans).to have(2).items
+
+              rack_span, handle_err_span = spans
+
+              expect(rack_span).to be_root_span
+              expect(rack_span.name).to eq('rack.request')
+              expect(rack_span.resource).to eq('GET 200')
+
+              expect(handle_err_span.parent_id).to eq(rack_span.id)
+              expect(handle_err_span.name).to eq('rails.action_controller')
+              expect(handle_err_span.resource).to eq('ErrorController#handle_error')
+              expect(handle_err_span.get_tag('component')).to eq('action_pack')
+              expect(handle_err_span.get_tag('operation')).to eq('controller')
+              expect(handle_err_span.get_tag('rails.route.controller')).to eq('ErrorController')
+              expect(handle_err_span.get_tag('rails.route.action')).to eq('handle_error')
+            end
+          end
         end
 
         context 'when configure exception_controller with a constant' do
@@ -233,6 +255,28 @@ RSpec.describe 'Datadog::Tracing::Contrib::ActionPack::ActionController::Metal' 
               expect(rack_span).to be_root_span
               expect(rack_span.name).to eq('rack.request')
               expect(rack_span.resource).to eq('ErrorController#handle_error')
+
+              expect(handle_err_span.parent_id).to eq(rack_span.id)
+              expect(handle_err_span.name).to eq('rails.action_controller')
+              expect(handle_err_span.resource).to eq('ErrorController#handle_error')
+              expect(handle_err_span.get_tag('component')).to eq('action_pack')
+              expect(handle_err_span.get_tag('operation')).to eq('controller')
+              expect(handle_err_span.get_tag('rails.route.controller')).to eq('ErrorController')
+              expect(handle_err_span.get_tag('rails.route.action')).to eq('handle_error')
+            end
+          end
+
+          context 'when given a request to error handling endpoint with ActionDispatch exception' do
+            it 'renders within ErrorController and does not change trace resource' do
+              get '/error_handler', {}, 'action_dispatch.exception' => ArgumentError.new
+
+              expect(spans).to have(2).items
+
+              rack_span, handle_err_span = spans
+
+              expect(rack_span).to be_root_span
+              expect(rack_span.name).to eq('rack.request')
+              expect(rack_span.resource).to eq('GET 200')
 
               expect(handle_err_span.parent_id).to eq(rack_span.id)
               expect(handle_err_span.name).to eq('rails.action_controller')
@@ -329,6 +373,28 @@ RSpec.describe 'Datadog::Tracing::Contrib::ActionPack::ActionController::Metal' 
               expect(handle_err_span.get_tag('rails.route.action')).to eq('handle_error')
             end
           end
+
+          context 'when given a request to error handling endpoint with ActionDispatch exception' do
+            it 'renders within ErrorController and does not change trace resource' do
+              get '/error_handler', {}, 'action_dispatch.exception' => ArgumentError.new
+
+              expect(spans).to have(2).items
+
+              rack_span, handle_err_span = spans
+
+              expect(rack_span).to be_root_span
+              expect(rack_span.name).to eq('rack.request')
+              expect(rack_span.resource).to eq('GET 200')
+
+              expect(handle_err_span.parent_id).to eq(rack_span.id)
+              expect(handle_err_span.name).to eq('rails.action_controller')
+              expect(handle_err_span.resource).to eq('ErrorController#handle_error')
+              expect(handle_err_span.get_tag('component')).to eq('action_pack')
+              expect(handle_err_span.get_tag('operation')).to eq('controller')
+              expect(handle_err_span.get_tag('rails.route.controller')).to eq('ErrorController')
+              expect(handle_err_span.get_tag('rails.route.action')).to eq('handle_error')
+            end
+          end
         end
 
         context 'when configure exception_controller with a wrong string' do
@@ -405,6 +471,28 @@ RSpec.describe 'Datadog::Tracing::Contrib::ActionPack::ActionController::Metal' 
               expect(rack_span).to be_root_span
               expect(rack_span.name).to eq('rack.request')
               expect(rack_span.resource).to eq('ErrorController#handle_error')
+
+              expect(handle_err_span.parent_id).to eq(rack_span.id)
+              expect(handle_err_span.name).to eq('rails.action_controller')
+              expect(handle_err_span.resource).to eq('ErrorController#handle_error')
+              expect(handle_err_span.get_tag('component')).to eq('action_pack')
+              expect(handle_err_span.get_tag('operation')).to eq('controller')
+              expect(handle_err_span.get_tag('rails.route.controller')).to eq('ErrorController')
+              expect(handle_err_span.get_tag('rails.route.action')).to eq('handle_error')
+            end
+          end
+
+          context 'when given a request to error handling endpoint with ActionDispatch exception' do
+            it 'renders within ErrorController and does not change trace resource' do
+              get '/error_handler', {}, 'action_dispatch.exception' => ArgumentError.new
+
+              expect(spans).to have(2).items
+
+              rack_span, handle_err_span = spans
+
+              expect(rack_span).to be_root_span
+              expect(rack_span.name).to eq('rack.request')
+              expect(rack_span.resource).to eq('GET 200')
 
               expect(handle_err_span.parent_id).to eq(rack_span.id)
               expect(handle_err_span.name).to eq('rails.action_controller')

--- a/spec/datadog/tracing/contrib/action_pack/action_controller/metal_spec.rb
+++ b/spec/datadog/tracing/contrib/action_pack/action_controller/metal_spec.rb
@@ -1,0 +1,330 @@
+require 'datadog/tracing/contrib/support/spec_helper'
+
+require 'action_controller'
+
+require 'ddtrace'
+require 'datadog/tracing/contrib/action_pack/action_controller/instrumentation'
+
+RSpec.describe 'Datadog::Tracing::Contrib::ActionPack::ActionController::Metal' do
+  include Rack::Test::Methods
+
+  describe '#process_action' do
+    context 'with ErrorController' do
+      after do
+        Datadog.configuration.tracing[:action_pack].reset!
+        Datadog.registry[:rack].reset_configuration!
+      end
+
+      let(:exception_controller_class) do
+        stub_const(
+          'ErrorController',
+          Class.new(ActionController::Base) do
+            def handle_error
+              head :ok
+            end
+          end
+        )
+      end
+
+      let(:controller_class) do
+        stub_const(
+          'TestController',
+          Class.new(ActionController::Base) do
+            def test
+              head :ok
+            end
+
+            def raise_exception
+              raise StandardError, 'bala boom!'
+            end
+          end
+        )
+      end
+
+      let(:app) do
+        test_action = controller_class.action(:test)
+        error_action = controller_class.action(:raise_exception)
+        error_handler = exception_controller_class.action(:handle_error)
+
+        # This app mimic the middleware stack of Rails on Rack,
+        # use ActionDispatch::ShowExceptions to render exception with error handler
+        #
+        # The trace with `/boom` looks like:
+        # ================================ rack.request =================================
+        #       === rails.action_controller ===       === rails.action_controller ===
+        #       (TestController#raise_exception)       (ErrorController#handle_error)
+
+        Rack::Builder.app do
+          use Datadog::Tracing::Contrib::Rack::TraceMiddleware
+          use ActionDispatch::ShowExceptions, error_handler
+
+          map '/test' do
+            run test_action
+          end
+
+          map '/boom' do
+            run error_action
+          end
+        end
+      end
+
+      context 'ErrorController' do
+        context 'when default configuration' do
+          before do
+            Datadog.configure do |c|
+              c.tracing.instrument :rack
+              c.tracing.instrument :action_pack
+            end
+          end
+
+          context 'when given a request to test endpoint' do
+            it 'renders within TestController' do
+              get '/test'
+
+              expect(spans).to have(2).items
+
+              rack_span, controller_span = spans
+
+              expect(rack_span).to be_root_span
+              expect(rack_span.name).to eq('rack.request')
+              expect(rack_span.resource).to eq('TestController#test')
+
+              expect(controller_span.parent_id).to eq(rack_span.id)
+              expect(controller_span.name).to eq('rails.action_controller')
+              expect(controller_span.resource).to eq('TestController#test')
+              expect(controller_span.get_tag('component')).to eq('action_pack')
+              expect(controller_span.get_tag('operation')).to eq('controller')
+              expect(controller_span.get_tag('rails.route.controller')).to eq('TestController')
+              expect(controller_span.get_tag('rails.route.action')).to eq('test')
+            end
+          end
+
+          context 'when given a request that raise exception' do
+            it 'renders the exception with error handler' do
+              get '/boom'
+
+              expect(spans).to have(3).items
+
+              rack_span, handle_err_span, controller_span = spans
+
+              expect(rack_span).to be_root_span
+              expect(rack_span.name).to eq('rack.request')
+              expect(rack_span.resource).to eq('TestController#raise_exception')
+              expect(rack_span).to_not have_error
+
+              expect(handle_err_span.parent_id).to eq(rack_span.id)
+              expect(handle_err_span.name).to eq('rails.action_controller')
+              expect(handle_err_span.resource).to eq('ErrorController#handle_error')
+              expect(handle_err_span.get_tag('component')).to eq('action_pack')
+              expect(handle_err_span.get_tag('operation')).to eq('controller')
+              expect(handle_err_span.get_tag('rails.route.controller')).to eq('ErrorController')
+              expect(handle_err_span.get_tag('rails.route.action')).to eq('handle_error')
+              expect(handle_err_span).to_not have_error
+
+              expect(controller_span.parent_id).to eq(rack_span.id)
+              expect(controller_span.name).to eq('rails.action_controller')
+              expect(controller_span.resource).to eq('TestController#raise_exception')
+              expect(controller_span.get_tag('component')).to eq('action_pack')
+              expect(controller_span.get_tag('operation')).to eq('controller')
+              expect(controller_span.get_tag('rails.route.controller')).to eq('TestController')
+              expect(controller_span.get_tag('rails.route.action')).to eq('raise_exception')
+              expect(controller_span).to have_error
+            end
+          end
+        end
+
+        context 'when configure exception_controller with a constant' do
+          before do
+            Datadog.configure do |c|
+              c.tracing.instrument :rack
+              c.tracing.instrument :action_pack, exception_controller: exception_controller_class
+            end
+          end
+
+          context 'when given a request to test endpoint' do
+            it 'renders within TestController' do
+              get '/test'
+
+              expect(spans).to have(2).items
+
+              rack_span, controller_span = spans
+
+              expect(rack_span).to be_root_span
+              expect(rack_span.name).to eq('rack.request')
+              expect(rack_span.resource).to eq('TestController#test')
+
+              expect(controller_span.parent_id).to eq(rack_span.id)
+              expect(controller_span.name).to eq('rails.action_controller')
+              expect(controller_span.resource).to eq('TestController#test')
+              expect(controller_span.get_tag('component')).to eq('action_pack')
+              expect(controller_span.get_tag('operation')).to eq('controller')
+              expect(controller_span.get_tag('rails.route.controller')).to eq('TestController')
+              expect(controller_span.get_tag('rails.route.action')).to eq('test')
+            end
+          end
+
+          context 'when given a request that raise exception' do
+            it 'renders the exception with error handler' do
+              get '/boom'
+
+              expect(spans).to have(3).items
+
+              rack_span, handle_err_span, controller_span = spans
+
+              expect(rack_span).to be_root_span
+              expect(rack_span.name).to eq('rack.request')
+              expect(rack_span.resource).to eq('TestController#raise_exception')
+              expect(rack_span).to_not have_error
+
+              expect(handle_err_span.parent_id).to eq(rack_span.id)
+              expect(handle_err_span.name).to eq('rails.action_controller')
+              expect(handle_err_span.resource).to eq('ErrorController#handle_error')
+              expect(handle_err_span.get_tag('component')).to eq('action_pack')
+              expect(handle_err_span.get_tag('operation')).to eq('controller')
+              expect(handle_err_span.get_tag('rails.route.controller')).to eq('ErrorController')
+              expect(handle_err_span.get_tag('rails.route.action')).to eq('handle_error')
+              expect(handle_err_span).to_not have_error
+
+              expect(controller_span.parent_id).to eq(rack_span.id)
+              expect(controller_span.name).to eq('rails.action_controller')
+              expect(controller_span.resource).to eq('TestController#raise_exception')
+              expect(controller_span.get_tag('component')).to eq('action_pack')
+              expect(controller_span.get_tag('operation')).to eq('controller')
+              expect(controller_span.get_tag('rails.route.controller')).to eq('TestController')
+              expect(controller_span.get_tag('rails.route.action')).to eq('raise_exception')
+              expect(controller_span).to have_error
+            end
+          end
+        end
+
+        context 'when configure exception_controller with a string' do
+          before do
+            Datadog.configure do |c|
+              c.tracing.instrument :rack
+              c.tracing.instrument :action_pack, exception_controller: exception_controller_class.to_s
+            end
+          end
+
+          context 'when given a request to test endpoint' do
+            it 'renders within TestController' do
+              get '/test'
+
+              expect(spans).to have(2).items
+
+              rack_span, controller_span = spans
+
+              expect(rack_span).to be_root_span
+              expect(rack_span.name).to eq('rack.request')
+              expect(rack_span.resource).to eq('TestController#test')
+
+              expect(controller_span.parent_id).to eq(rack_span.id)
+              expect(controller_span.name).to eq('rails.action_controller')
+              expect(controller_span.resource).to eq('TestController#test')
+              expect(controller_span.get_tag('component')).to eq('action_pack')
+              expect(controller_span.get_tag('operation')).to eq('controller')
+              expect(controller_span.get_tag('rails.route.controller')).to eq('TestController')
+              expect(controller_span.get_tag('rails.route.action')).to eq('test')
+            end
+          end
+
+          context 'when given a request that raise exception' do
+            it 'renders the exception with error handler' do
+              get '/boom'
+
+              expect(spans).to have(3).items
+
+              rack_span, handle_err_span, controller_span = spans
+
+              expect(rack_span).to be_root_span
+              expect(rack_span.name).to eq('rack.request')
+              expect(rack_span.resource).to eq('TestController#raise_exception')
+              expect(rack_span).to_not have_error
+
+              expect(handle_err_span.parent_id).to eq(rack_span.id)
+              expect(handle_err_span.name).to eq('rails.action_controller')
+              expect(handle_err_span.resource).to eq('ErrorController#handle_error')
+              expect(handle_err_span.get_tag('component')).to eq('action_pack')
+              expect(handle_err_span.get_tag('operation')).to eq('controller')
+              expect(handle_err_span.get_tag('rails.route.controller')).to eq('ErrorController')
+              expect(handle_err_span.get_tag('rails.route.action')).to eq('handle_error')
+              expect(handle_err_span).to_not have_error
+
+              expect(controller_span.parent_id).to eq(rack_span.id)
+              expect(controller_span.name).to eq('rails.action_controller')
+              expect(controller_span.resource).to eq('TestController#raise_exception')
+              expect(controller_span.get_tag('component')).to eq('action_pack')
+              expect(controller_span.get_tag('operation')).to eq('controller')
+              expect(controller_span.get_tag('rails.route.controller')).to eq('TestController')
+              expect(controller_span.get_tag('rails.route.action')).to eq('raise_exception')
+              expect(controller_span).to have_error
+            end
+          end
+        end
+
+        context 'when configure exception_controller with a wrong string' do
+          before do
+            Datadog.configure do |c|
+              c.tracing.instrument :rack
+              c.tracing.instrument :action_pack, exception_controller: 'CannotFindThisConstant'
+            end
+          end
+
+          context 'when given a request to test endpoint' do
+            it 'renders within TestController' do
+              get '/test'
+
+              expect(spans).to have(2).items
+
+              rack_span, controller_span = spans
+
+              expect(rack_span).to be_root_span
+              expect(rack_span.name).to eq('rack.request')
+              expect(rack_span.resource).to eq('TestController#test')
+
+              expect(controller_span.parent_id).to eq(rack_span.id)
+              expect(controller_span.name).to eq('rails.action_controller')
+              expect(controller_span.resource).to eq('TestController#test')
+              expect(controller_span.get_tag('component')).to eq('action_pack')
+              expect(controller_span.get_tag('operation')).to eq('controller')
+              expect(controller_span.get_tag('rails.route.controller')).to eq('TestController')
+              expect(controller_span.get_tag('rails.route.action')).to eq('test')
+            end
+          end
+
+          context 'when given a request that raise exception' do
+            it 'renders the exception with error handler' do
+              get '/boom'
+
+              expect(spans).to have(3).items
+
+              rack_span, handle_err_span, controller_span = spans
+
+              expect(rack_span).to be_root_span
+              expect(rack_span.name).to eq('rack.request')
+              expect(rack_span.resource).to eq('TestController#raise_exception')
+              expect(rack_span).to_not have_error
+
+              expect(handle_err_span.parent_id).to eq(rack_span.id)
+              expect(handle_err_span.name).to eq('rails.action_controller')
+              expect(handle_err_span.resource).to eq('ErrorController#handle_error')
+              expect(handle_err_span.get_tag('component')).to eq('action_pack')
+              expect(handle_err_span.get_tag('operation')).to eq('controller')
+              expect(handle_err_span.get_tag('rails.route.controller')).to eq('ErrorController')
+              expect(handle_err_span.get_tag('rails.route.action')).to eq('handle_error')
+              expect(handle_err_span).to_not have_error
+
+              expect(controller_span.parent_id).to eq(rack_span.id)
+              expect(controller_span.name).to eq('rails.action_controller')
+              expect(controller_span.resource).to eq('TestController#raise_exception')
+              expect(controller_span.get_tag('component')).to eq('action_pack')
+              expect(controller_span.get_tag('operation')).to eq('controller')
+              expect(controller_span.get_tag('rails.route.controller')).to eq('TestController')
+              expect(controller_span.get_tag('rails.route.action')).to eq('raise_exception')
+              expect(controller_span).to have_error
+            end
+          end
+        end
+      end
+    end
+  end
+end

--- a/spec/datadog/tracing/contrib/action_pack/configuration/settings_spec.rb
+++ b/spec/datadog/tracing/contrib/action_pack/configuration/settings_spec.rb
@@ -1,0 +1,21 @@
+require 'datadog/tracing/contrib/action_pack/configuration/settings'
+
+RSpec.describe Datadog::Tracing::Contrib::ActionPack::Configuration::Settings do
+  describe 'Option `exception_controller`' do
+    context 'when without defining option' do
+      it { expect { described_class.new }.not_to log_deprecation }
+    end
+
+    context 'when given a non `nil` value' do
+      it do
+        expect { described_class.new(exception_controller: '123') }
+          .to log_deprecation(include('Option `exception_controller` has been deprecated'))
+      end
+
+      it do
+        expect { described_class.new.tap { |s| s.exception_controller = '123' } }
+          .to log_deprecation(include('Option `exception_controller` has been deprecated'))
+      end
+    end
+  end
+end

--- a/spec/datadog/tracing/contrib/action_pack/configuration/settings_spec.rb
+++ b/spec/datadog/tracing/contrib/action_pack/configuration/settings_spec.rb
@@ -9,12 +9,12 @@ RSpec.describe Datadog::Tracing::Contrib::ActionPack::Configuration::Settings do
     context 'when given a non `nil` value' do
       it do
         expect { described_class.new(exception_controller: '123') }
-          .to log_deprecation(include('Option `exception_controller` has been deprecated'))
+          .to log_deprecation(include('Option `exception_controller` is no longer required'))
       end
 
       it do
         expect { described_class.new.tap { |s| s.exception_controller = '123' } }
-          .to log_deprecation(include('Option `exception_controller` has been deprecated'))
+          .to log_deprecation(include('Option `exception_controller` is no longer required'))
       end
     end
   end

--- a/spec/datadog/tracing/contrib/rails/configuration/settings_spec.rb
+++ b/spec/datadog/tracing/contrib/rails/configuration/settings_spec.rb
@@ -1,0 +1,21 @@
+require 'datadog/tracing/contrib/rails/configuration/settings'
+
+RSpec.describe Datadog::Tracing::Contrib::Rails::Configuration::Settings do
+  describe 'Option `exception_controller`' do
+    context 'when without defining option' do
+      it { expect { described_class.new }.not_to log_deprecation }
+    end
+
+    context 'when given a non `nil` value' do
+      it do
+        expect { described_class.new(exception_controller: '123') }
+          .to log_deprecation(include('Option `exception_controller` has been deprecated'))
+      end
+
+      it do
+        expect { described_class.new.tap { |s| s.exception_controller = '123' } }
+          .to log_deprecation(include('Option `exception_controller` has been deprecated'))
+      end
+    end
+  end
+end

--- a/spec/datadog/tracing/contrib/rails/configuration/settings_spec.rb
+++ b/spec/datadog/tracing/contrib/rails/configuration/settings_spec.rb
@@ -9,12 +9,12 @@ RSpec.describe Datadog::Tracing::Contrib::Rails::Configuration::Settings do
     context 'when given a non `nil` value' do
       it do
         expect { described_class.new(exception_controller: '123') }
-          .to log_deprecation(include('Option `exception_controller` has been deprecated'))
+          .to log_deprecation(include('Option `exception_controller` is no longer required'))
       end
 
       it do
         expect { described_class.new.tap { |s| s.exception_controller = '123' } }
-          .to log_deprecation(include('Option `exception_controller` has been deprecated'))
+          .to log_deprecation(include('Option `exception_controller` is no longer required'))
       end
     end
   end


### PR DESCRIPTION
### Why?

This PR addresses issues (https://github.com/DataDog/dd-trace-rb/issues/2709 , https://github.com/DataDog/dd-trace-rb/issues/2611 , https://github.com/DataDog/dd-trace-rb/issues/2567) we've had for instrumenting an exception handling controller.

1. The trace resource being overwritten by the exception handling controller, make it hard understand the origin of error.
2. Configuration for `exception_controller` with constant does not work properly with zeitwerk autoloading.

----

### What? 

After careful examination of the problem, I have concluded that the current behaviour of option `exception_controller` is bringing more harm than benefit, because of the fundamental problem to answer the question about what is the strategy to decide whether to overwrite trace resource?

🚫  It should not be made by based on whether the current controller is handling the request being defined as an exceptional controller, since a request could be sent to the path directly (such case: overwrite trace resource).
✅ **The decision should be made by whether an exception being redirected by `ActionDispatch::ShowException`.** 

The changes are made to depend on the default behaviour for `ActionDispatch::ShowException` and make the option `exception_controller` obsolete. We decided to deprecate the option and no longer required to solve the problem with zeitwerk autoloading.

**We recommend our users to remove `exception_controller`  option from the configuration.**

----

### Snapshot of changes

![Screenshot 2023-03-28 at 11 42 21](https://user-images.githubusercontent.com/16049123/228201305-e5c5b30a-e7cf-40f2-9e25-61699d009dcf.png)
