### PR TITLE
Patch the ❤ method for Sidekiq 7 compatibility

### DIFF
--- a/lib/datadog/tracing/contrib/sidekiq/server_internal_tracer/heartbeat.rb
+++ b/lib/datadog/tracing/contrib/sidekiq/server_internal_tracer/heartbeat.rb
@@ -27,7 +27,7 @@ module Datadog
 
             private
 
-            def heartbeat
+            def ❤ # rubocop:disable Naming/AsciiIdentifiers, Naming/MethodName
               configuration = Datadog.configuration.tracing[:sidekiq]
 
               Datadog::Tracing.trace(Ext::SPAN_HEARTBEAT, service: configuration[:service_name]) do |span|


### PR DESCRIPTION
<!--
Check out the
https://github.com/DataDog/dd-trace-rb/blob/master/docs/DevelopmentGuide.md
for guidance on how to set up your development environment,
run the test suite, write new integrations, and more.
-->

**What does this PR do?**

Fixes `sidekiq.heartbeat` traces in Sidekiq 7.

In Sidekiq 6.5.8, the [heartbeat code](https://github.com/sidekiq/sidekiq/blob/v6.5.8/lib/sidekiq/launcher.rb#L73-L79) looks like this:
```ruby
    def start_heartbeat
      loop do
        heartbeat
        sleep BEAT_PAUSE
      end
      logger.info("Heartbeat stopping...")
    end
```

While in Sidekiq 7.0.7 [it is this](https://github.com/sidekiq/sidekiq/blob/v6.5.8/lib/sidekiq/launcher.rb#L73-L79):
```ruby
    def start_heartbeat
      loop do
        beat
        sleep BEAT_PAUSE
      end
      logger.info("Heartbeat stopping...")
    end
```

So the change is that it now calls `beat` rather than `heartbeat`, and `heartbeat` is only called at sidekiq startup.

Both these methods internally call `Sidekiq::Launcher::❤` (isn't unicode great) which does the actual beating logic.

Previously, ddtrace was wrapping the `❤` method so it would work on Sidekiq 6 or 7, in PR #2170 this was changed to wrap the `heartbeat`.

Here you can see the `sidekiq.heartbeat` traces stop after upgrading to Sidekiq 7:
![image](https://user-images.githubusercontent.com/1756799/228421849-8c740816-5e85-44d1-8454-7bcf1f1845ed.png)

**Motivation**
We have monitors that watch for `sidekiq.heartbeat` and now they are failing due to the missing traces.

**Additional Notes**
<!-- Anything else we should know when reviewing? -->

**How to test the change?**
<!--
Describe here how the change can be validated.
You are strongly encouraged to provide automated tests for this PR (unit or integration).
If this change cannot be feasibly tested, please explain why,
unless the change does not modify code (e.g. only modifies docs, comments).
-->

When running on Sidekiq 7, the heartbeat event gets sent through.