### PR TITLE
fix debian sources for old ruby images

### DIFF
--- a/integration/images/ruby/2.1/Dockerfile
+++ b/integration/images/ruby/2.1/Dockerfile
@@ -1,8 +1,8 @@
 FROM ruby:2.1
 
 # Add Jessie repos
-# Fixes https://superuser.com/questions/1423486/issue-with-fetching-http-deb-debian-org-debian-dists-jessie-updates-inrelease
-RUN printf "deb http://archive.debian.org/debian/ jessie main\ndeb-src http://archive.debian.org/debian/ jessie main\ndeb http://security.debian.org jessie/updates main\ndeb-src http://security.debian.org jessie/updates main" > /etc/apt/sources.list
+# Fixes https://www.lucas-nussbaum.net/blog/?p=947
+RUN printf "deb http://archive.debian.org/debian/ jessie main\ndeb-src http://archive.debian.org/debian/ jessie main" > /etc/apt/sources.list
 
 ENV DEBIAN_FRONTEND=noninteractive
 

--- a/integration/images/ruby/2.2/Dockerfile
+++ b/integration/images/ruby/2.2/Dockerfile
@@ -1,8 +1,8 @@
 FROM ruby:2.2
 
 # Add Jessie repos
-# Fixes https://superuser.com/questions/1423486/issue-with-fetching-http-deb-debian-org-debian-dists-jessie-updates-inrelease
-RUN printf "deb http://archive.debian.org/debian/ jessie main\ndeb-src http://archive.debian.org/debian/ jessie main\ndeb http://security.debian.org jessie/updates main\ndeb-src http://security.debian.org jessie/updates main" > /etc/apt/sources.list
+# Fixes https://www.lucas-nussbaum.net/blog/?p=947
+RUN printf "deb http://archive.debian.org/debian/ jessie main\ndeb-src http://archive.debian.org/debian/ jessie main" > /etc/apt/sources.list
 
 ENV DEBIAN_FRONTEND=noninteractive
 


### PR DESCRIPTION
Try solving:

```
== Building base images... ==
Sending build context to Docker daemon  3.072kB
Step 1/2 : FROM datadog/agent
 ---> 0a6ebf8b0c00
Step 2/2 : COPY agent.yaml /etc/datadog-agent/datadog.yaml
 ---> Using cache
 ---> ecdcbe083e51
Successfully built ecdcbe083e51
Successfully tagged datadog/dd-apm-demo:agent
Sending build context to Docker daemon  53.76kB
Step 1/14 : FROM ruby:2.1
 ---> 223d1eaa9523
Step 2/14 : RUN printf "deb http://archive.debian.org/debian/ jessie main\ndeb-src http://archive.debian.org/debian/ jessie main\ndeb http://security.debian.org jessie/updates main\ndeb-src http://security.debian.org jessie/updates main" > /etc/apt/sources.list
 ---> Using cache
 ---> edc10e20ecba
Step 3/14 : ENV DEBIAN_FRONTEND=noninteractive
 ---> Using cache
 ---> 7bbfb5633f35
Step 4/14 : RUN set -ex &&         echo "===> Installing dependencies" &&         apt-get -y update &&         apt-get install -y --force-yes --no-install-recommends             curl wget tar gzip gnupg apt-transport-https ca-certificates tzdata locales &&                 echo "===> Installing NodeJS" &&         apt-get install -y --force-yes --no-install-recommends nodejs &&                 echo "===> Installing Yarn" &&         curl -sS https://dl.yarnpkg.com/debian/pubkey.gpg | apt-key add - &&         echo "deb https://dl.yarnpkg.com/debian/ stable main" | tee /etc/apt/sources.list.d/yarn.list &&         apt-get update &&         apt-get install -y --force-yes --no-install-recommends yarn &&                 echo "===> Installing database libraries" &&         apt-get install -y --force-yes --no-install-recommends             postgresql-client sqlite3 &&                 echo "===> Installing dev tools" &&         mkdir -p /usr/share/man/man1 &&         apt-get install -y --force-yes --no-install-recommends             sudo git openssh-client rsync vim             net-tools netcat parallel unzip zip bzip2 &&                 echo "===> Cleaning up" &&         rm -rf /var/lib/apt/lists/*;
 ---> Running in d4f461b5797f
===> Installing dependencies
+ echo ===> Installing dependencies
+ apt-get -y update
Ign http://security.debian.org jessie/updates InRelease
Ign http://security.debian.org jessie/updates Release.gpg
Ign http://security.debian.org jessie/updates Release
Err http://security.debian.org jessie/updates/main Sources
  404  Not Found [IP: 151.101.66.132 80]
Err http://security.debian.org jessie/updates/main amd64 Packages
  404  Not Found [IP: 151.101.66.132 80]
Ign http://archive.debian.org jessie InRelease
Get:1 http://archive.debian.org jessie Release.gpg [2420 B]
Get:2 http://archive.debian.org jessie Release [148 kB]
Ign http://archive.debian.org jessie Release
Get:3 http://archive.debian.org jessie/main Sources [9169 kB]
Get:4 http://archive.debian.org jessie/main amd64 Packages [9098 kB]
W: GPG error: http://archive.debian.org jessie Release: The following signatures were invalid: KEYEXPIRED 1587841717
W: Failed to fetch http://security.debian.org/dists/jessie/updates/main/source/Sources  404  Not Found [IP: 151.101.66.132 80]

WFetched 18.4 MB in 7s (2411 kB/s)
: Failed to fetch http://security.debian.org/dists/jessie/updates/main/binary-amd64/Packages  404  Not Found [IP: 151.101.66.132 80]

E: Some index files failed to download. They have been ignored, or old ones used instead.
The command '/bin/sh -c set -ex &&         echo "===> Installing dependencies" &&         apt-get -y update &&         apt-get install -y --force-yes --no-install-recommends             curl wget tar gzip gnupg apt-transport-https ca-certificates tzdata locales &&                 echo "===> Installing NodeJS" &&         apt-get install -y --force-yes --no-install-recommends nodejs &&                 echo "===> Installing Yarn" &&         curl -sS https://dl.yarnpkg.com/debian/pubkey.gpg | apt-key add - &&         echo "deb https://dl.yarnpkg.com/debian/ stable main" | tee /etc/apt/sources.list.d/yarn.list &&         apt-get update &&         apt-get install -y --force-yes --no-install-recommends yarn &&                 echo "===> Installing database libraries" &&         apt-get install -y --force-yes --no-install-recommends             postgresql-client sqlite3 &&                 echo "===> Installing dev tools" &&         mkdir -p /usr/share/man/man1 &&         apt-get install -y --force-yes --no-install-recommends             sudo git openssh-client rsync vim             net-tools netcat parallel unzip zip bzip2 &&                 echo "===> Cleaning up" &&         rm -rf /var/lib/apt/lists/*;' returned a non-zero code: 100

Exited with code exit status 100

```

From CircleCI, when building old ruby images for `build_and_test_integration` for ruby 2.1 and 2.2