### PR TITLE
[APPSEC-8867] Appsec reuse rules when ASM_DD is empty

### DIFF
--- a/lib/datadog/appsec/component.rb
+++ b/lib/datadog/appsec/component.rb
@@ -1,6 +1,8 @@
 # frozen_string_literal: true
 
 require_relative 'processor'
+require_relative 'processor/rule_merger'
+require_relative 'processor/rule_loader'
 
 module Datadog
   module AppSec
@@ -10,14 +12,23 @@ module Datadog
         def build_appsec_component(settings)
           return unless settings.respond_to?(:appsec) && settings.appsec.enabled
 
-          processor = create_processor
+          processor = create_processor(settings)
           new(processor: processor)
         end
 
         private
 
-        def create_processor
-          processor = Processor.new
+        def create_processor(settings)
+          rules = AppSec::Processor::RuleLoader.load_rules(settings)
+          return nil unless rules
+          data = AppSec::Processor::RuleLoader.load_data(settings)
+
+          ruleset = AppSec::Processor::RuleMerger.merge(
+            rules: [rules],
+            data: data,
+          )
+
+          processor = Processor.new(ruleset: ruleset)
           return nil unless processor.ready?
 
           processor

--- a/lib/datadog/appsec/component.rb
+++ b/lib/datadog/appsec/component.rb
@@ -19,9 +19,13 @@ module Datadog
         private
 
         def create_processor(settings)
-          rules = AppSec::Processor::RuleLoader.load_rules(settings)
+          rules = AppSec::Processor::RuleLoader.load_rules(ruleset: settings.appsec.ruleset)
           return nil unless rules
-          data = AppSec::Processor::RuleLoader.load_data(settings)
+
+          data = AppSec::Processor::RuleLoader.load_data(
+            ip_denylist: settings.appsec.ip_denylist,
+            user_id_denylist: settings.appsec.user_id_denylist
+          )
 
           ruleset = AppSec::Processor::RuleMerger.merge(
             rules: [rules],

--- a/lib/datadog/appsec/processor/rule_loader.rb
+++ b/lib/datadog/appsec/processor/rule_loader.rb
@@ -1,0 +1,67 @@
+# frozen_string_literal: true
+
+require_relative '../assets'
+
+module Datadog
+  module AppSec
+    class Processor
+      # RuleLoader utility modules
+      # that load appsec rules and data from  settings
+      module RuleLoader
+        class << self
+          def load_rules(settings)
+            ruleset_setting = settings.appsec.ruleset
+
+            begin
+              case ruleset_setting
+              when :recommended, :strict
+                JSON.parse(Datadog::AppSec::Assets.waf_rules(ruleset_setting))
+              when :risky
+                Datadog.logger.warn(
+                  'The :risky Application Security Management ruleset has been deprecated and no longer available.'\
+                  'The `:recommended` ruleset will be used instead.'\
+                  'Please remove the `appsec.ruleset = :risky` setting from your Datadog.configure block.'
+                )
+                JSON.parse(Datadog::AppSec::Assets.waf_rules(:recommended))
+              when String
+                JSON.parse(File.read(ruleset_setting))
+              when File, StringIO
+                JSON.parse(ruleset_setting.read || '').tap { ruleset_setting.rewind }
+              when Hash
+                ruleset_setting
+              else
+                raise ArgumentError, "unsupported value for ruleset setting: #{ruleset_setting.inspect}"
+              end
+            rescue StandardError => e
+              Datadog.logger.error do
+                "libddwaf ruleset failed to load, ruleset: #{ruleset_setting.inspect} error: #{e.inspect}"
+              end
+
+              nil
+            end
+          end
+
+          def load_data(settings)
+            appsec_settings = settings.appsec
+
+            data = []
+            data << { 'rules_data' => [denylist_data('blocked_ips', appsec_settings.ip_denylist)] } if appsec_settings.ip_denylist.any?
+            data << { 'rules_data' => [denylist_data('blocked_users', appsec_settings.user_id_denylist)] } if appsec_settings.user_id_denylist.any?
+
+            data.any? ? data : nil
+          end
+
+          private
+
+          def denylist_data(id, denylist)
+            {
+              'id' => id,
+              'type' => 'data_with_expiration',
+              'data' => denylist.map { |v| { 'value' => v.to_s, 'expiration' => 2**63 } }
+            }
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/datadog/core/remote/client.rb
+++ b/lib/datadog/core/remote/client.rb
@@ -204,14 +204,17 @@ module Datadog
             overrides = []
             exclusions = []
 
-            repository.contents.each  do |content|
+            asm_data_config_types = ['blocked_ips', 'blocked_users']
+            asm_overrides_config_types = ['blocking', 'disabled_rules']
+
+            repository.contents.each do |content|
               case content.path.product
               when 'ASM_DD'
                 rules << parse_content(content)
               when 'ASM_DATA'
-                data << parse_content(content) if ['blocked_ips', 'blocked_users' ].include?(content.path.config_id)
+                data << parse_content(content) if asm_data_config_types.include?(content.path.config_id)
               when 'ASM'
-                overrides << parse_content(content) if ['blocking', 'disabled_rules'].include?(content.path.config_id)
+                overrides << parse_content(content) if asm_overrides_config_types.include?(content.path.config_id)
                 exclusions << parse_content(content) if content.path.config_id == 'exclusion_filters'
               end
             end
@@ -233,16 +236,16 @@ module Datadog
 
             Datadog::AppSec.reconfigure(ruleset: ruleset)
           end
+        end
 
-          def parse_content(content)
-            data = content.data.read
+        def parse_content(content)
+          data = content.data.read
 
-            content.data.rewind
+          content.data.rewind
 
-            raise ReadError, 'EOF reached' if data.nil?
+          raise ReadError, 'EOF reached' if data.nil?
 
-            JSON.parse(data)
-          end
+          JSON.parse(data)
         end
       end
     end

--- a/sig/datadog/appsec/processor.rbs
+++ b/sig/datadog/appsec/processor.rbs
@@ -37,7 +37,7 @@ module Datadog
       @ruleset: ::Hash[::String, untyped]
       @addresses: ::Array[::String]
 
-      def initialize: (?ruleset: ::Hash[untyped, untyped]?) -> void
+      def initialize: (ruleset: ::Hash[untyped, untyped]) -> void
       def ready?: () -> bool
       def new_context: () -> Context
       def activate_context: () -> Context
@@ -48,12 +48,8 @@ module Datadog
 
       private
 
-      def apply_denylist_data: (Configuration::Settings settings) -> untyped
-      def combine_denylist_data: (Configuration::Settings settings) -> ::Array[::Hash[::String, untyped]]
-      def denylist_data: (String id, ::Array[untyped] denylist) -> ::Hash[::String, untyped | "data_with_expiration"]
       def load_libddwaf: () -> bool
-      def load_ruleset: (Configuration::Settings settings, ?ruleset: ::Hash[untyped, untyped]?) -> bool
-      def create_waf_handle: (Configuration::Settings settings) -> bool
+      def create_waf_handle: (Configuration::Settings settings, ::Hash[String, untyped] ruleset) -> bool
 
       def self.libddwaf_provides_waf?: () -> bool
       def self.require_libddwaf: () -> bool

--- a/sig/datadog/appsec/processor/rule_loader.rbs
+++ b/sig/datadog/appsec/processor/rule_loader.rbs
@@ -1,0 +1,17 @@
+module Datadog
+  module AppSec
+    class Processor
+      module RuleLoader
+        type ruleset = Symbol | String | File | StringIO | Hash[String, untyped]
+        def self.load_rules: (ruleset: ruleset) -> ::Hash[untyped, untyped]?
+
+        def self.load_data: (?ip_denylist: Array[String], ?user_id_denylist: Array[String]) -> Array[Hash[String, untyped]]?
+
+        private
+
+        def self.denylist_data: (String id, Array[String] denylist) -> ::Hash[::String, untyped]
+      end
+    end
+  end
+end
+

--- a/spec/datadog/appsec/component_spec.rb
+++ b/spec/datadog/appsec/component_spec.rb
@@ -40,6 +40,16 @@ RSpec.describe Datadog::AppSec::Component do
           expect(component.processor).to be_nil
         end
       end
+
+      context 'when loading ruleset from settings fails' do
+        it 'returns a Datadog::AppSec::Component with a nil processor' do
+          expect(Datadog::AppSec::Processor::RuleLoader).to receive(:load_rules).and_return(nil)
+
+          component = described_class.build_appsec_component(settings_with_appsec)
+
+          expect(component.processor).to be_nil
+        end
+      end
     end
 
     context 'when appsec is not enabled' do

--- a/spec/datadog/appsec/processor/rule_loader_spec.rb
+++ b/spec/datadog/appsec/processor/rule_loader_spec.rb
@@ -1,0 +1,158 @@
+require 'datadog/appsec/spec_helper'
+require 'datadog/appsec/processor/rule_loader'
+
+RSpec.describe Datadog::AppSec::Processor::RuleLoader do
+  describe '#load_ruleset' do
+    let(:basic_ruleset) do
+      {
+        'version' => '1.0',
+        'events' => [
+          {
+            'id' => 1,
+            'name' => 'Rule 1',
+            'tags' => { 'type' => 'flow1' },
+            'conditions' => [
+              { 'operation' => 'match_regex', 'parameters' => { 'inputs' => ['value2'], 'regex' => 'rule1' } },
+            ],
+            'action' => 'record',
+          }
+        ]
+      }
+    end
+    let(:recommended) { JSON.parse(Datadog::AppSec::Assets.waf_rules(:recommended)) }
+    let(:strict) { JSON.parse(Datadog::AppSec::Assets.waf_rules(:strict)) }
+
+    subject(:rules) { described_class.load_rules(ruleset: ruleset) }
+
+    context 'when ruleset is :recommended' do
+      let(:ruleset) { :recommended }
+
+      it do
+        expect(rules).to_not be_nil
+        expect(rules).to eq(recommended)
+      end
+    end
+
+    context 'when ruleset is :strict' do
+      let(:ruleset) { :strict }
+
+      it do
+        expect(rules).to_not be_nil
+        expect(rules).to eq(strict)
+      end
+    end
+
+    context 'when ruleset is :risky, defaults to recommended' do
+      let(:ruleset) { :risky }
+
+      it do
+        expect(rules).to_not be_nil
+        expect(rules).to eq(recommended)
+      end
+    end
+
+    context 'when ruleset is an existing path' do
+      let(:ruleset) { "#{__dir__}../../../../../lib/datadog/appsec/assets/waf_rules/recommended.json" }
+
+      it { expect(rules).to_not be_nil }
+    end
+
+    context 'when ruleset is a non existing path' do
+      let(:ruleset) { '/does/not/exist' }
+
+      it { expect(rules).to be_nil }
+    end
+
+    context 'when ruleset is IO-like' do
+      let(:ruleset) { StringIO.new(JSON.dump(basic_ruleset)) }
+
+      it do
+        expect(rules).to_not be_nil
+        expect(rules).to eq(basic_ruleset)
+      end
+    end
+
+    context 'when ruleset is Ruby' do
+      let(:ruleset) { basic_ruleset }
+
+      it do
+        expect(rules).to_not be_nil
+        expect(rules).to eq(basic_ruleset)
+      end
+    end
+
+    context 'when ruleset is not parseable' do
+      let(:ruleset) { StringIO.new('this is not json') }
+
+      it { expect(rules).to be_nil }
+    end
+  end
+
+  describe '#load_data' do
+    let(:ip_denylist) { [] }
+    let(:user_id_denylist) { [] }
+    subject(:data) { described_class.load_data(ip_denylist: ip_denylist, user_id_denylist: user_id_denylist) }
+
+    context 'empty data' do
+      it 'returns nil' do
+        expect(data).to be_nil
+      end
+    end
+
+    context 'non empty data' do
+      context 'with ip_denylist' do
+        let(:ip_denylist) { ['1.1.1.1', '1.1.1.2'] }
+
+        it 'returns data information' do
+          expect(data).to_not be_nil
+          expect(data.size).to eq 1
+          rules_data = data[0]['rules_data'][0]
+
+          expect(rules_data).to_not be_nil
+          expect(rules_data['id']).to eq 'blocked_ips'
+          expect(rules_data['type']).to eq 'data_with_expiration'
+
+          ip_values_data = rules_data['data']
+          ip_values = ip_values_data.each.with_object([]) do |ip, acc|
+            acc << ip['value']
+          end
+
+          expect(ip_values_data.size).to eq 2
+          expect(ip_values).to eq(ip_denylist)
+        end
+      end
+
+      context 'with user_id_denylist' do
+        let(:user_id_denylist) { ['1', '2'] }
+
+        it 'returns data information' do
+          expect(data).to_not be_nil
+          expect(data.size).to eq 1
+          rules_data = data[0]['rules_data'][0]
+
+          expect(rules_data).to_not be_nil
+          expect(rules_data['id']).to eq 'blocked_users'
+          expect(rules_data['type']).to eq 'data_with_expiration'
+
+          user_id_values_data = rules_data['data']
+          user_id_values = user_id_values_data.each.with_object([]) do |user, acc|
+            acc << user['value']
+          end
+
+          expect(user_id_values_data.size).to eq 2
+          expect(user_id_values).to eq(user_id_denylist)
+        end
+      end
+
+      context 'with ip_denylist and user_id_denylist' do
+        let(:ip_denylist) { ['1.1.1.1', '1.1.1.2'] }
+        let(:user_id_denylist) { ['1', '2'] }
+
+        it 'returns data information' do
+          expect(data).to_not be_nil
+          expect(data.size).to eq 2
+        end
+      end
+    end
+  end
+end

--- a/spec/datadog/appsec/processor_spec.rb
+++ b/spec/datadog/appsec/processor_spec.rb
@@ -1,5 +1,7 @@
 require 'datadog/appsec/spec_helper'
 require 'datadog/appsec/processor'
+require 'datadog/appsec/processor/rule_loader'
+require 'datadog/appsec/processor/rule_merger'
 
 RSpec.describe Datadog::AppSec::Processor do
   before do
@@ -17,6 +19,8 @@ RSpec.describe Datadog::AppSec::Processor do
 
     allow(Datadog).to receive(:logger).and_return(logger)
   end
+
+  let(:ruleset) { Datadog::AppSec::Processor::RuleLoader.load_rules(ruleset: :recommended) }
 
   after do
     described_class.send(:reset_active_context)
@@ -59,7 +63,7 @@ RSpec.describe Datadog::AppSec::Processor do
       end
 
       it 'return the previously set current context' do
-        processor = described_class.new
+        processor = described_class.new(ruleset: ruleset)
         context = processor.new_context
 
         described_class.send(:active_context=, context)
@@ -81,7 +85,7 @@ RSpec.describe Datadog::AppSec::Processor do
 
       describe '.reset_active_context' do
         it 'sets active_context to nil' do
-          processor = described_class.new
+          processor = described_class.new(ruleset: ruleset)
           context = processor.new_context
 
           described_class.send(:active_context=, context)
@@ -104,7 +108,7 @@ RSpec.describe Datadog::AppSec::Processor do
         allow(Object).to receive(:require).with('libddwaf').and_raise(LoadError)
       end
 
-      it { expect(described_class.new.send(:load_libddwaf)).to be false }
+      it { expect(described_class.new(ruleset: ruleset).send(:load_libddwaf)).to be false }
     end
 
     context 'when loaded but missing mandatory const' do
@@ -113,7 +117,7 @@ RSpec.describe Datadog::AppSec::Processor do
         hide_const('Datadog::AppSec::WAF')
       end
 
-      it { expect(described_class.new.send(:load_libddwaf)).to be false }
+      it { expect(described_class.new(ruleset: ruleset).send(:load_libddwaf)).to be false }
     end
 
     context 'when loaded successfully' do
@@ -124,126 +128,15 @@ RSpec.describe Datadog::AppSec::Processor do
         stub_const('Datadog::AppSec::WAF::LibDDWAF::Error', Class.new(StandardError))
       end
 
-      it { expect(described_class.new.send(:load_libddwaf)).to be true }
-    end
-  end
-
-  describe '#load_ruleset' do
-    let(:settings) { Datadog::AppSec.settings }
-    let(:basic_ruleset) do
-      {
-        'version' => '1.0',
-        'events' => [
-          {
-            'id' => 1,
-            'name' => 'Rule 1',
-            'tags' => { 'type' => 'flow1' },
-            'conditions' => [
-              { 'operation' => 'match_regex', 'parameters' => { 'inputs' => ['value2'], 'regex' => 'rule1' } },
-            ],
-            'action' => 'record',
-          }
-        ]
-      }
-    end
-
-    before do
-      allow(settings).to receive(:ruleset).and_return(ruleset)
-    end
-
-    context 'when ruleset is :recommended' do
-      let(:ruleset) { :recommended }
-
-      before do
-        expect(Datadog::AppSec::Assets).to receive(:waf_rules).with(:recommended).and_call_original.twice
-      end
-
-      it { expect(described_class.new.send(:load_ruleset, settings)).to be true }
-    end
-
-    context 'when ruleset is :strict' do
-      let(:ruleset) { :strict }
-
-      before do
-        expect(Datadog::AppSec::Assets).to receive(:waf_rules).with(:strict).and_call_original.twice
-      end
-
-      it { expect(described_class.new.send(:load_ruleset, settings)).to be true }
-    end
-
-    context 'when ruleset is :risky' do
-      let(:ruleset) { :risky }
-
-      before do
-        expect(Datadog::AppSec::Assets).to receive(:waf_rules).with(:recommended).and_call_original.twice
-      end
-
-      it { expect(described_class.new.send(:load_ruleset, settings)).to be true }
-    end
-
-    context 'when ruleset is an existing path' do
-      let(:ruleset) { "#{__dir__}/../../../lib/datadog/appsec/assets/waf_rules/recommended.json" }
-
-      it { expect(described_class.new.send(:load_ruleset, settings)).to be true }
-    end
-
-    context 'when ruleset is a non existing path' do
-      let(:ruleset) { '/does/not/exist' }
-
-      it { expect(described_class.new.send(:load_ruleset, settings)).to be false }
-    end
-
-    context 'when ruleset is IO-like' do
-      let(:ruleset) { StringIO.new(JSON.dump(basic_ruleset)) }
-
-      it { expect(described_class.new.send(:load_ruleset, settings)).to be true }
-    end
-
-    context 'when ruleset is Ruby' do
-      let(:ruleset) { basic_ruleset }
-
-      it { expect(described_class.new.send(:load_ruleset, settings)).to be true }
-    end
-
-    context 'when ruleset is not parseable' do
-      let(:ruleset) { StringIO.new('this is not json') }
-
-      it { expect(described_class.new.send(:load_ruleset, settings)).to be false }
-    end
-  end
-
-  describe '#create_waf_handle' do
-    let(:ruleset) { :recommended }
-    let(:settings) { Datadog::AppSec.settings }
-
-    before do
-      allow(settings).to receive(:ruleset).and_return(ruleset)
-    end
-
-    context 'when ruleset is default' do
-      let(:ruleset) { :recommended }
-
-      before do
-        expect(Datadog::AppSec::Assets).to receive(:waf_rules).with(:recommended).and_call_original
-      end
-
-      it { expect(described_class.new.send(:create_waf_handle, settings)).to be true }
-    end
-
-    context 'when ruleset is invalid' do
-      let(:ruleset) { { 'not' => 'valid' } }
-
-      it { expect(described_class.new.send(:create_waf_handle, settings)).to be false }
+      it { expect(described_class.new(ruleset: ruleset).send(:load_libddwaf)).to be true }
     end
   end
 
   describe '#initialize' do
-    let(:ruleset) { :recommended }
+    subject(:processor) { described_class.new(ruleset: ruleset) }
 
-    subject(:processor) { described_class.new }
-
-    before do
-      allow(Datadog::AppSec.settings).to receive(:ruleset).and_return(ruleset)
+    context 'when valid ruleset' do
+      it { is_expected.to be_ready }
     end
 
     context 'when libddwaf fails to load' do
@@ -267,26 +160,6 @@ RSpec.describe Datadog::AppSec::Processor do
       it { is_expected.to_not be_ready }
     end
 
-    context 'when ruleset is a non existing path' do
-      let(:ruleset) { '/does/not/exist' }
-
-      before do
-        expect(Datadog.logger).to receive(:warn)
-      end
-
-      it { is_expected.to_not be_ready }
-    end
-
-    context 'when ruleset is not parseable' do
-      let(:ruleset) { StringIO.new('this is not json') }
-
-      before do
-        expect(Datadog.logger).to receive(:warn)
-      end
-
-      it { is_expected.to_not be_ready }
-    end
-
     context 'when ruleset is invalid' do
       let(:ruleset) { { 'not' => 'valid' } }
 
@@ -296,47 +169,9 @@ RSpec.describe Datadog::AppSec::Processor do
 
       it { is_expected.to_not be_ready }
     end
-
-    context 'when loading static data rule configuration' do
-      before do
-        allow(Datadog::AppSec.settings).to receive(:ip_denylist).and_return(['192.192.1.1'])
-        allow(Datadog::AppSec.settings).to receive(:user_id_denylist).and_return(['user3'])
-      end
-
-      it 'stores the data as part of the @ruleset' do
-        processor = described_class.new
-        ruleset = processor.instance_variable_get(:@ruleset)
-
-        blocked_ips = ruleset['rules_data'].find { |hash| hash['id'] == 'blocked_ips' }
-        blocked_users = ruleset['rules_data'].find { |hash| hash['id'] == 'blocked_users' }
-
-        expect(blocked_ips).to_not be_nil
-        expect(blocked_users).to_not be_nil
-        expect(blocked_ips['type']).to eq('data_with_expiration')
-        expect(blocked_users['type']).to eq('data_with_expiration')
-
-        blocked_ips_data = blocked_ips['data']
-        blocked_user_data = blocked_users['data']
-        expect(blocked_ips_data.size).to eq(1)
-        expect(blocked_user_data.size).to eq(1)
-        expect(blocked_ips_data[0]['value']).to eq('192.192.1.1')
-        expect(blocked_user_data[0]['value']).to eq('user3')
-      end
-    end
-
-    context 'when things are OK' do
-      before do
-        expect(Datadog::AppSec::Assets).to receive(:waf_rules).with(:recommended).and_call_original
-        expect(Datadog.logger).to_not receive(:warn)
-      end
-
-      it { is_expected.to be_ready }
-    end
   end
 
   describe '#new_context' do
-    let(:ruleset) { :recommended }
-
     let(:input_safe) { { 'server.request.headers.no_cookies' => { 'user-agent' => 'Ruby' } } }
     let(:input_sqli) { { 'server.request.query' => { 'q' => '1 OR 1;' } } }
     let(:input_scanner) { { 'server.request.headers.no_cookies' => { 'user-agent' => 'Nessus SOAP' } } }
@@ -346,7 +181,7 @@ RSpec.describe Datadog::AppSec::Processor do
 
     let(:input) { input_scanner }
 
-    let(:processor) { described_class.new }
+    let(:processor) { described_class.new(ruleset: ruleset) }
     subject(:context) { processor.new_context }
 
     after do
@@ -376,10 +211,7 @@ RSpec.describe Datadog::AppSec::Processor do
         results.first
       end
 
-      let(:set_ip_denylist) { nil }
-
       before do
-        set_ip_denylist
         runs
       end
 
@@ -489,8 +321,14 @@ RSpec.describe Datadog::AppSec::Processor do
         context 'one blockable attack' do
           let(:input) { input_client_ip }
 
-          let(:set_ip_denylist) do
-            allow(Datadog::AppSec.settings).to receive(:ip_denylist).and_return([client_ip])
+          let(:ruleset) do
+            rules = Datadog::AppSec::Processor::RuleLoader.load_rules(ruleset: :recommended)
+            data = Datadog::AppSec::Processor::RuleLoader.load_data(ip_denylist: [client_ip])
+
+            Datadog::AppSec::Processor::RuleMerger.merge(
+              rules: [rules],
+              data: data,
+            )
           end
 
           it { expect(matches).to have_attributes(count: 1) }
@@ -503,21 +341,23 @@ RSpec.describe Datadog::AppSec::Processor do
 
   describe '#active_context' do
     it 'creates a new context and store in the class .active_context variable' do
-      context = described_class.new.activate_context
+      context = described_class.new(ruleset: ruleset).activate_context
       expect(context).to eq(described_class.active_context)
     end
 
     context 'when an active context already exists' do
       it 'raises AlreadyActiveContextError' do
-        described_class.new.activate_context
-        expect { described_class.new.activate_context }.to raise_error(described_class::AlreadyActiveContextError)
+        described_class.new(ruleset: ruleset).activate_context
+        expect do
+          described_class.new(ruleset: ruleset).activate_context
+        end.to raise_error(described_class::AlreadyActiveContextError)
       end
     end
   end
 
   describe '#deactivate_context' do
     it 'finalize the active context and reset the class .active_context variable' do
-      handler = described_class.new
+      handler = described_class.new(ruleset: ruleset)
       context = handler.activate_context
 
       expect(context).to receive(:finalize)
@@ -527,7 +367,9 @@ RSpec.describe Datadog::AppSec::Processor do
 
     context 'without an active_context' do
       it 'raises NoActiveContextError' do
-        expect { described_class.new.deactivate_context }.to raise_error(described_class::NoActiveContextError)
+        expect do
+          described_class.new(ruleset: ruleset).deactivate_context
+        end.to raise_error(described_class::NoActiveContextError)
       end
     end
   end

--- a/spec/datadog/core/remote/client_spec.rb
+++ b/spec/datadog/core/remote/client_spec.rb
@@ -326,7 +326,8 @@ RSpec.describe Datadog::Core::Remote::Client do
         it 'uses the rules from the appsec settings' do
           expect(Datadog::AppSec::Processor::RuleLoader).to receive(:load_rules).with(
             ruleset: Datadog.configuration.appsec.ruleset
-          ).and_call_original
+          ).at_least(:once).and_call_original
+
           client.sync
         end
 

--- a/spec/datadog/core/remote/client_spec.rb
+++ b/spec/datadog/core/remote/client_spec.rb
@@ -74,7 +74,8 @@ RSpec.describe Datadog::Core::Remote::Client do
       },
     ]
   end
-  let(:target_content) do
+
+  let(:exclusions_filter_content) do
     {
       'datadog/603646/ASM/exclusion_filters/config' => {
         'custom' => {
@@ -84,18 +85,28 @@ RSpec.describe Datadog::Core::Remote::Client do
           },
           'v' => 21
         },
-        'hashes' => { 'sha256' => Digest::SHA256.hexdigest(exclusion_content) },
+        'hashes' => { 'sha256' => Digest::SHA256.hexdigest(exclusions) },
         'length' => 645
-      },
+      }
+    }
+  end
+
+  let(:blocked_ips_content) do
+    {
       'datadog/603646/ASM_DATA/blocked_ips/config' => {
         'custom' => {
           'c' => ['client_id'],
           'tracer-predicates' => { 'tracer_predicates_v1' => [{ 'clientID' => 'client_id' }] },
           'v' => 51
         },
-        'hashes' => { 'sha256' => Digest::SHA256.hexdigest(blocked_ips_content) },
+        'hashes' => { 'sha256' => Digest::SHA256.hexdigest(blocked_ips) },
         'length' => 1834
       },
+    }
+  end
+
+  let(:rules_content) do
+    {
       'datadog/603646/ASM_DD/latest/config' => {
         'custom' => {
           'c' => ['client_id'],
@@ -109,6 +120,9 @@ RSpec.describe Datadog::Core::Remote::Client do
       },
     }
   end
+
+  let(:target_content) { {} }
+
   let(:targets) do
     {
       'signatures' => [
@@ -130,12 +144,15 @@ RSpec.describe Datadog::Core::Remote::Client do
       }
     }
   end
-  let(:exclusion_content) do
+
+  let(:exclusions) do
     '{"exclusions":[{"conditions":[{"operator":"ip_match","parameters":{"inputs":[{"address":"http.client_ip"}]}}]}]}'
   end
-  let(:blocked_ips_content) do
+
+  let(:blocked_ips) do
     '{"rules_data":[{"data":[{"expiration":1678972458,"value":"42.42.42.1"}]}]}'
   end
+
   let(:rules_data) do
     {
       version: '2.2',
@@ -172,36 +189,62 @@ RSpec.describe Datadog::Core::Remote::Client do
     }.to_json
   end
 
+  let(:rules_data_response) do
+    {
+      'path' => 'datadog/603646/ASM_DD/latest/config',
+      'raw' => Base64.strict_encode64(rules_data).chomp
+    }
+  end
+
+  let(:blocked_ips_data_response) do
+    {
+      'path' => 'datadog/603646/ASM_DATA/blocked_ips/config',
+      'raw' => Base64.strict_encode64(blocked_ips).chomp
+    }
+  end
+
+  let(:exclusion_data_response) do
+    {
+      'path' => 'datadog/603646/ASM/exclusion_filters/config',
+      'raw' => Base64.strict_encode64(exclusions).chomp
+    }
+  end
+
+  let(:target_files) { [] }
+
+  let(:client_configs) { [] }
+
   let(:response_body) do
     {
       'roots' => roots.map { |r| Base64.strict_encode64(r.to_json).chomp },
       'targets' => Base64.strict_encode64(targets.to_json).chomp,
-      'target_files' => [
-        {
-          'path' => 'datadog/603646/ASM_DD/latest/config',
-          'raw' => Base64.strict_encode64(rules_data).chomp
-        },
-        {
-          'path' => 'datadog/603646/ASM_DATA/blocked_ips/config',
-          'raw' => Base64.strict_encode64(blocked_ips_content).chomp
-        },
-        {
-          'path' => 'datadog/603646/ASM/exclusion_filters/config',
-          'raw' => Base64.strict_encode64(exclusion_content).chomp
-        }
-      ],
-      'client_configs' => [
-        'datadog/603646/ASM_DATA/blocked_ips/config',
-        'datadog/603646/ASM_DD/latest/config',
-        'datadog/603646/ASM/exclusion_filters/config'
-      ]
+      'target_files' => target_files,
+      'client_configs' => client_configs,
     }.to_json
   end
+
   let(:repository) { Datadog::Core::Remote::Configuration::Repository.new }
+
   subject(:client) { described_class.new(transport, repository: repository) }
 
   describe '#sync' do
     include_context 'HTTP connection stub'
+
+    let(:client_configs) do
+      [
+        'datadog/603646/ASM_DATA/blocked_ips/config',
+        'datadog/603646/ASM_DD/latest/config',
+        'datadog/603646/ASM/exclusion_filters/config'
+      ]
+    end
+
+    let(:target_files) do
+      [rules_data_response, blocked_ips_data_response, exclusion_data_response]
+    end
+
+    let(:target_content) do
+      {}.merge(exclusions_filter_content).merge(blocked_ips_content).merge(rules_content)
+    end
 
     context 'valid response' do
       let(:response_code) { 200 }
@@ -260,8 +303,40 @@ RSpec.describe Datadog::Core::Remote::Client do
           'version' => '2.2'
         }
 
-        expect(Datadog::AppSec).to receive(:reconfigure).with(ruleset: expected_ruleset)
+        expect(Datadog::AppSec).to receive(:reconfigure).with(ruleset: expected_ruleset).and_call_original
         client.sync
+      end
+
+      context 'when there is no ASM_DD information' do
+        let(:client_configs) do
+          [
+            'datadog/603646/ASM_DATA/blocked_ips/config',
+            'datadog/603646/ASM/exclusion_filters/config'
+          ]
+        end
+
+        let(:target_files) do
+          [blocked_ips_data_response, exclusion_data_response]
+        end
+
+        let(:target_content) do
+          {}.merge(exclusions_filter_content).merge(blocked_ips_content)
+        end
+
+        it 'uses the rules from the appsec settings' do
+          expect(Datadog::AppSec::Processor::RuleLoader).to receive(:load_rules).with(
+            ruleset: Datadog.configuration.appsec.ruleset
+          ).and_call_original
+          client.sync
+        end
+
+        it 'raises SyncError if no default rules available' do
+          expect(Datadog::AppSec::Processor::RuleLoader).to receive(:load_rules).with(
+            ruleset: Datadog.configuration.appsec.ruleset
+          ).and_return(nil)
+
+          expect { client.sync }.to raise_error(described_class::SyncError)
+        end
       end
 
       context 'when the data is the same' do
@@ -288,7 +363,7 @@ RSpec.describe Datadog::Core::Remote::Client do
               },
               {
                 :path => 'datadog/603646/ASM/exclusion_filters/config',
-                :content => StringIO.new(exclusion_content)
+                :content => StringIO.new(exclusions)
               },
               {
                 :path => 'datadog/603646/ASM_DD/latest/config',
@@ -313,7 +388,7 @@ RSpec.describe Datadog::Core::Remote::Client do
                     'tracer-predicates' => { 'tracer_predicates_v1' => [{ 'clientID' => 'client_id' }] },
                     'v' => 21
                   },
-                  'hashes' => { 'sha256' => Digest::SHA256.hexdigest(exclusion_content) },
+                  'hashes' => { 'sha256' => Digest::SHA256.hexdigest(exclusions) },
                   'length' => 645
                 },
                 'datadog/603646/ASM_DATA/blocked_ips/config' => {
@@ -367,7 +442,7 @@ RSpec.describe Datadog::Core::Remote::Client do
             'target_files' => [
               {
                 'path' => 'datadog/603646/ASM/exclusion_filters/config',
-                'raw' => Base64.strict_encode64(exclusion_content).chomp
+                'raw' => Base64.strict_encode64(exclusions).chomp
               }
             ],
             'client_configs' => [
@@ -403,7 +478,7 @@ RSpec.describe Datadog::Core::Remote::Client do
                   },
                   'v' => 21
                 },
-                'hashes' => { 'sha256' => Digest::SHA256.hexdigest(exclusion_content) },
+                'hashes' => { 'sha256' => Digest::SHA256.hexdigest(exclusions) },
                 'length' => 645
               },
             }


### PR DESCRIPTION
<!--
Check out the
https://github.com/DataDog/dd-trace-rb/blob/master/docs/DevelopmentGuide.md
for guidance on how to set up your development environment,
run the test suite, write new integrations, and more.
-->

**What does this PR do?**
<!-- A brief description of the change being made with this pull request. -->

During Remote Client sync, there could be occasions when the rules information from `ASM_DD` product is not present or not available. 

In those situations, we should default to the ones defined on the appsec settings. By default is `:recommended`


**Additional Notes**
<!-- Anything else we should know when reviewing? -->

I had to extract away the parsing of the ruleset from the `AppSec::Processor`, so I could reuse it in other places in the code base. I like it because it removes that functionality from `Processor`, which is only responsible for ensuring a valid processor and context are created, with the `ruleset` provided.

**How to test the change?**
<!--
Describe here how the change can be validated.
You are strongly encouraged to provide automated tests for this PR (unit or integration).
If this change cannot be feasibly tested, please explain why,
unless the change does not modify code (e.g. only modifies docs, comments).
-->

CI
