### PR TITLE
Update lib injection github action commit hash

### DIFF
--- a/.github/workflows/lib-injection.yml
+++ b/.github/workflows/lib-injection.yml
@@ -51,7 +51,7 @@ jobs:
     steps:
       - name: lib-injection test runner
         id: lib-injection-test-runner
-        uses: DataDog/system-tests/lib-injection/runner@4eb1ec01b61c1c7e84f219127a91d07f03b0f85e
+        uses: DataDog/system-tests/lib-injection/runner@584bf76f7a5c6f6e466346ba8a68a6b7a6293d9b
         with:
           docker-registry: ghcr.io
           docker-registry-username: ${{ github.repository_owner }}
@@ -73,6 +73,7 @@ jobs:
         with:
           repository: DataDog/system-tests
           path: system-tests
+          ref: tonycthsu/fix-ruby-images-for-lib-injection-tests
       - name: Overwrite auto inject script with commit SHA
         run: |
           sed -i "s~<DD_TRACE_SHA_TO_BE_REPLACED>~${{github.sha}}~g" lib-injection/auto_inject.rb

--- a/.github/workflows/lib-injection.yml
+++ b/.github/workflows/lib-injection.yml
@@ -51,7 +51,7 @@ jobs:
     steps:
       - name: lib-injection test runner
         id: lib-injection-test-runner
-        uses: DataDog/system-tests/lib-injection/runner@584bf76f7a5c6f6e466346ba8a68a6b7a6293d9b
+        uses: DataDog/system-tests/lib-injection/runner@495d99b7a5d62ae8e2b7de39ec16334cbeb16523
         with:
           docker-registry: ghcr.io
           docker-registry-username: ${{ github.repository_owner }}

--- a/.github/workflows/lib-injection.yml
+++ b/.github/workflows/lib-injection.yml
@@ -73,7 +73,6 @@ jobs:
         with:
           repository: DataDog/system-tests
           path: system-tests
-          ref: tonycthsu/fix-ruby-images-for-lib-injection-tests
       - name: Overwrite auto inject script with commit SHA
         run: |
           sed -i "s~<DD_TRACE_SHA_TO_BE_REPLACED>~${{github.sha}}~g" lib-injection/auto_inject.rb

--- a/.github/workflows/test-macos.yaml
+++ b/.github/workflows/test-macos.yaml
@@ -8,7 +8,6 @@ jobs:
         os:
           - macos-latest
         ruby:
-          - '2.1'
           - '2.2'
           - '2.3'
           - '2.4'


### PR DESCRIPTION
**What does this PR do?**

https://github.com/DataDog/system-tests/pull/1034

Update the github action commit hash to pin ruby image

In addition to fixing the `lib-injection` GH action, we added the code from this [PR](https://github.com/DataDog/dd-trace-rb/pull/2736). The PR removes the ruby 2.1 from the `test-macos` matrix