### PR TITLE
Removing ruby 2.1 from the test macos GH action.

### DIFF
--- a/.github/workflows/test-macos.yaml
+++ b/.github/workflows/test-macos.yaml
@@ -8,7 +8,6 @@ jobs:
         os:
           - macos-latest
         ruby:
-          - '2.1'
           - '2.2'
           - '2.3'
           - '2.4'


### PR DESCRIPTION
Ruby 2.1 uses an old version of RubyGems, which uses a deprecated endpoint `/api/v1/dependencies`.
The setup step tries to download all dependencies of the bundler at install time but fails.

https://blog.rubygems.org/2023/02/22/dependency-api-deprecation.html

At this point is easier to remove version 2.1 from the matrix that trying to fix.

Specs for ruby 2.1 are run on Circle-CI in a linux environment.

Here is a [PR](https://github.com/DataDog/dd-trace-rb/actions/runs/4595543500/jobs/8120498975?pr=2733) that the `test-macos` action, just fails for ruby 2.1 
