### PR TITLE
Add a basic `shell.nix` file

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,7 +1,6 @@
 *.gem
 *.rbc
 *.swp
-*.nix
 *.vim
 /.config
 /coverage/

--- a/shell.nix
+++ b/shell.nix
@@ -1,0 +1,44 @@
+{
+  # use the environment channel
+  pkgs ? import <nixpkgs> {},
+
+  # use a pinned package state
+  pinned ? import(fetchTarball("https://github.com/NixOS/nixpkgs/archive/14d9b465c71.tar.gz")) {},
+}:
+let
+  # specify ruby version to use
+  ruby = pinned.ruby_3_1;
+
+  # control llvm/clang version (e.g for packages built from source)
+  llvm = pinned.llvmPackages_12;
+
+  # control gcc version (e.g for packages built from source)
+  gcc = pinned.gcc12;
+in llvm.stdenv.mkDerivation {
+  # unique project name for this environment derivation
+  name = "dd-trace-rb.devshell";
+
+  buildInputs = [
+    ruby
+
+    # TODO: some gems insist on using `gcc` on Linux, satisfy them for now:
+    # - json
+    # - protobuf
+    # - ruby-prof
+    gcc
+  ];
+
+  shellHook = ''
+    # get major.minor.0 ruby version
+    export RUBY_VERSION="$(ruby -e 'puts RUBY_VERSION.gsub(/\d+$/, "0")')"
+
+    # make gem install work in-project, compatibly with bundler
+    export GEM_HOME="$(pwd)/vendor/bundle/ruby/$RUBY_VERSION"
+
+    # make bundle work in-project
+    export BUNDLE_PATH="$(pwd)/vendor/bundle"
+
+    # enable calling gem scripts without bundle exec
+    export PATH="$GEM_HOME/bin:$PATH"
+  '';
+}

--- a/spec/ddtrace/release_gem_spec.rb
+++ b/spec/ddtrace/release_gem_spec.rb
@@ -30,6 +30,7 @@ RSpec.describe 'gem release process' do
            |Steepfile
            |ddtrace\.gemspec
            |docker-compose\.yml
+           |shell\.nix
           )
           $
         /x


### PR DESCRIPTION
**What does this PR do?**

This is entirely optional to use but for nixpkgs users this is a really easy way to get things up and running. With just:

```
nix-shell
```

All needed dependencies get automatically pulled in, dropping the user in a ready-to-use shell. It gets extra-nice with `direnv`.

Then as usual:

```
bundle install
```

Puts everything in a `vendor/bundle` directory, which behaves as usual regarding `gem install` and `bundle` in general. Should it need to be cleaned up, e.g to start form scratch, a simple `rm -rf vendor/bundle` is sufficient.

Also, gem commands can typically be run with or without `bundle exec`.

It also pins to a specific commit for the channel, so that tool versions are always consistent across platforms (incl. CPU arches and OSes).

**Motivation**

- It gets tiresome to keep this file in sync across repo clones
- It can benefit some of our users that happen to be nix users

**Additional Notes**

Why I do it that way: for non-nix folks the nix part is small and understandable, and `gem`/`bundle` things behave as folks are used to, so works OOTB and is very approachable compared to the more "sanctioned" approaches below.

There is such a thing as [`bundix`](https://github.com/nix-community/bundix), [`bundlerEnv`](https://fzakaria.com/2020/07/19/what-is-bundlerenv-doing.html), and [`ruby-nix`](https://github.com/sagittaros/ruby-nix) which integrate nix with bundler. I have yet to try these.

There is such a thing as [Nix flakes](https://zero-to-nix.com/concepts/flakes), which are crazy powerful but not as approachable to non-nixers, and it's a bit new so I'm not quite mastering it yet.

**How to test the change?**

1. install [nixpkgs](https://nixos.org/manual/nix/stable/installation/installing-binary.html) (which can be done on macOS or any Linux distribution, does not conflict with Homebrew, and is [easily removed](https://nixos.org/manual/nix/stable/installation/installing-binary.html#uninstalling)) or drop in a Nix-based container with `docker run --rm -it -v "${PWD}":"${PWD}" -w "${PWD}" nixos/nix`
2. `cd dd-trace-rb`
3. `nix-shell` (wait a bit, it takes a bit of time for it to sync the package channel)
4. `ruby --version`
5. `bundle install`
