### PR TITLE
Add more scenarios to system tests

### DIFF
--- a/.github/workflows/system-tests.yml
+++ b/.github/workflows/system-tests.yml
@@ -297,7 +297,7 @@ jobs:
           echo ${{ secrets.GITHUB_TOKEN }} | docker login ${{ env.REGISTRY }} -u ${{ github.actor }} --password-stdin
       - uses: actions/delete-package-versions@v4
         with:
-          package-version-ids: gha${{ github.run_id }}-g${{ github.sha }}
-          package-name: system-tests/${{ matrix.image }}
+          package-version-ids: 'gha${{ github.run_id }}-g${{ github.sha }}'
+          package-name: 'system-tests/${{ matrix.image }}'
           package-type: 'container'
         continue-on-error: true

--- a/.github/workflows/system-tests.yml
+++ b/.github/workflows/system-tests.yml
@@ -211,13 +211,13 @@ jobs:
         uses: actions/upload-artifact@v3
         if: ${{ always() }}
         with:
-          name: system-tests-${{ matrix.library }}-${{ matrix.app }}-${{ matrix.scenario }}-logs-${{ github.run_id }}-${{ github.sha }}
+          name: system-tests-${{ matrix.library }}-${{ matrix.app }}-${{ matrix.scenario }}-logs-gha${{ github.run_id }}-g${{ github.sha }}
           path: logs*
       - name: Archive logs (aggregated)
         uses: actions/upload-artifact@v3
         if: ${{ always() }}
         with:
-          name: system-tests-${{ matrix.library }}-${{ matrix.app }}-logs-${{ github.run_id }}-${{ github.sha }}
+          name: system-tests-${{ matrix.library }}-${{ matrix.app }}-logs-gha${{ github.run_id }}-g${{ github.sha }}
           path: logs*
 
   aggregate:
@@ -258,7 +258,7 @@ jobs:
       - name: Retrieve logs
         uses: actions/download-artifact@v3
         with:
-          name: system-tests-${{ matrix.library }}-${{ matrix.app }}-logs-${{ github.run_id }}-${{ github.sha }}
+          name: system-tests-${{ matrix.library }}-${{ matrix.app }}-logs-gha${{ github.run_id }}-g${{ github.sha }}
           path: .
       - name: Print fancy log report
         run: |

--- a/.github/workflows/system-tests.yml
+++ b/.github/workflows/system-tests.yml
@@ -33,8 +33,25 @@ jobs:
           - rails60
           - rails61
           - rails70
+        scenario:
+          - DEFAULT
+          - APPSEC_CUSTOM_RULES
+          - REMOTE_CONFIG_MOCKED_BACKEND_ASM_DD
+          - REMOTE_CONFIG_MOCKED_BACKEND_ASM_FEATURES
+          - REMOTE_CONFIG_MOCKED_BACKEND_ASM_FEATURES_NOCACHE
+          - REMOTE_CONFIG_MOCKED_BACKEND_ASM_DD_NOCACHE
+          - APPSEC_MISSING_RULES
+          - APPSEC_CORRUPTED_RULES
+          - APPSEC_DISABLED
+          - APPSEC_LOW_WAF_TIMEOUT
+          - APPSEC_CUSTOM_OBFUSCATION
+          - APPSEC_RATE_LIMITER
+          - APPSEC_IP_BLOCKING
+          - APPSEC_REQUEST_BLOCKING
+          - SAMPLING
+          - PROFILING
     runs-on: ubuntu-latest
-    name: System Tests (${{ matrix.weblog-variant }})
+    name: System Tests (${{ matrix.scenario }}, ${{ matrix.weblog-variant }})
     steps:
       - name: Setup python 3.9
         uses: actions/setup-python@v4
@@ -59,72 +76,7 @@ jobs:
         run: ./build.sh --library ${{ matrix.library }} --weblog-variant ${{ matrix.weblog-variant }}
 
       - name: Run default scenario
-        run: ./run.sh
-        env:
-          DD_API_KEY: ${{ secrets.DD_APPSEC_SYSTEM_TESTS_API_KEY }}
-      - name: Run APPSEC_CUSTOM_RULES scenario
-        run: ./run.sh APPSEC_CUSTOM_RULES
-        env:
-          DD_API_KEY: ${{ secrets.DD_APPSEC_SYSTEM_TESTS_API_KEY }}
-      - name: Run APPSEC_CUSTOM_RULES scenario
-        run: ./run.sh APPSEC_CUSTOM_RULES
-        env:
-          DD_API_KEY: ${{ secrets.DD_APPSEC_SYSTEM_TESTS_API_KEY }}
-      - name: Run REMOTE_CONFIG_MOCKED_BACKEND_ASM_DD scenario
-        run: ./run.sh REMOTE_CONFIG_MOCKED_BACKEND_ASM_DD
-        env:
-          DD_API_KEY: ${{ secrets.DD_APPSEC_SYSTEM_TESTS_API_KEY }}
-      - name: Run REMOTE_CONFIG_MOCKED_BACKEND_ASM_FEATURES_NOCACHE scenario
-        run: ./run.sh REMOTE_CONFIG_MOCKED_BACKEND_ASM_FEATURES_NOCACHE
-        env:
-          DD_API_KEY: ${{ secrets.DD_APPSEC_SYSTEM_TESTS_API_KEY }}
-      - name: Run REMOTE_CONFIG_MOCKED_BACKEND_LIVE_DEBUGGING_NOCACHE scenario
-        run: ./run.sh REMOTE_CONFIG_MOCKED_BACKEND_LIVE_DEBUGGING_NOCACHE
-        env:
-          DD_API_KEY: ${{ secrets.DD_APPSEC_SYSTEM_TESTS_API_KEY }}
-      - name: Run REMOTE_CONFIG_MOCKED_BACKEND_ASM_DD_NOCACHE scenario
-        run: ./run.sh REMOTE_CONFIG_MOCKED_BACKEND_ASM_DD_NOCACHE
-        env:
-          DD_API_KEY: ${{ secrets.DD_APPSEC_SYSTEM_TESTS_API_KEY }}
-      - name: Run APPSEC_MISSING_RULES scenario
-        run: ./run.sh APPSEC_MISSING_RULES
-        env:
-          DD_API_KEY: ${{ secrets.DD_APPSEC_SYSTEM_TESTS_API_KEY }}
-      - name: Run APPSEC_CORRUPTED_RULES scenario
-        if: steps.build.outcome == 'success' && github.event.action != 'opened' && !contains(github.event.pull_request.labels.*.name, 'run-default-scenario')
-        run: ./run.sh APPSEC_CORRUPTED_RULES
-        env:
-          DD_API_KEY: ${{ secrets.DD_APPSEC_SYSTEM_TESTS_API_KEY }}
-      - name: Run APPSEC_DISABLED scenario
-        run: ./run.sh APPSEC_DISABLED
-        env:
-          DD_API_KEY: ${{ secrets.DD_APPSEC_SYSTEM_TESTS_API_KEY }}
-      - name: Run APPSEC_LOW_WAF_TIMEOUT scenario
-        run: ./run.sh APPSEC_LOW_WAF_TIMEOUT
-        env:
-          DD_API_KEY: ${{ secrets.DD_APPSEC_SYSTEM_TESTS_API_KEY }}
-      - name: Run APPSEC_CUSTOM_OBFUSCATION scenario
-        run: ./run.sh APPSEC_CUSTOM_OBFUSCATION
-        env:
-          DD_API_KEY: ${{ secrets.DD_APPSEC_SYSTEM_TESTS_API_KEY }}
-      - name: Run APPSEC_RATE_LIMITER scenario
-        run: ./run.sh APPSEC_RATE_LIMITER
-        env:
-          DD_API_KEY: ${{ secrets.DD_APPSEC_SYSTEM_TESTS_API_KEY }}
-      - name: Run APPSEC_IP_BLOCKING scenario
-        run: ./run.sh APPSEC_IP_BLOCKING
-        env:
-          DD_API_KEY: ${{ secrets.DD_APPSEC_SYSTEM_TESTS_API_KEY }}
-      - name: Run APPSEC_REQUEST_BLOCKING scenario
-        run: ./run.sh APPSEC_REQUEST_BLOCKING
-        env:
-          DD_API_KEY: ${{ secrets.DD_APPSEC_SYSTEM_TESTS_API_KEY }}
-      - name: Run SAMPLING scenario
-        run: ./run.sh SAMPLING
-        env:
-          DD_API_KEY: ${{ secrets.DD_APPSEC_SYSTEM_TESTS_API_KEY }}
-      - name: Run PROFILING scenario
-        run: ./run.sh PROFILING
+        run: ./run.sh ${{ matrix.scenario }}
         env:
           DD_API_KEY: ${{ secrets.DD_APPSEC_SYSTEM_TESTS_API_KEY }}
 
@@ -132,7 +84,7 @@ jobs:
         uses: actions/upload-artifact@v3
         if: ${{ always() }}
         with:
-          name: system-tests-${{ matrix.library }}-${{ matrix.weblog-variant }}-logs-${{ github.run_id }}-${{ github.sha }}
+          name: system-tests-${{ matrix.library }}-${{ matrix.scenario }}-${{ matrix.weblog-variant }}-logs-${{ github.run_id }}-${{ github.sha }}
           path: logs*
 
       - name: Print fancy log report

--- a/.github/workflows/system-tests.yml
+++ b/.github/workflows/system-tests.yml
@@ -249,54 +249,63 @@ jobs:
           name: system-tests-${{ matrix.library }}-REMOTE_CONFIG_MOCKED_BACKEND_ASM_DD-${{ matrix.app }}-logs-${{ github.run_id }}-${{ github.sha }}
           path: .
         continue-on-error: true
+        if: ${{ matrix.app == 'rack' }}
       - name: Retrieve logs
         uses: actions/download-artifact@v3
         with:
           name: system-tests-${{ matrix.library }}-REMOTE_CONFIG_MOCKED_BACKEND_ASM_FEATURES-${{ matrix.app }}-logs-${{ github.run_id }}-${{ github.sha }}
           path: .
         continue-on-error: true
+        if: ${{ matrix.app == 'rack' }}
       - name: Retrieve logs
         uses: actions/download-artifact@v3
         with:
           name: system-tests-${{ matrix.library }}-REMOTE_CONFIG_MOCKED_BACKEND_ASM_FEATURES_NOCACHE-${{ matrix.app }}-logs-${{ github.run_id }}-${{ github.sha }}
           path: .
         continue-on-error: true
+        if: ${{ matrix.app == 'rack' }}
       - name: Retrieve logs
         uses: actions/download-artifact@v3
         with:
           name: system-tests-${{ matrix.library }}-REMOTE_CONFIG_MOCKED_BACKEND_ASM_DD_NOCACHE-${{ matrix.app }}-logs-${{ github.run_id }}-${{ github.sha }}
           path: .
         continue-on-error: true
+        if: ${{ matrix.app == 'rack' }}
       - name: Retrieve logs
         uses: actions/download-artifact@v3
         with:
           name: system-tests-${{ matrix.library }}-APPSEC_MISSING_RULES-${{ matrix.app }}-logs-${{ github.run_id }}-${{ github.sha }}
           path: .
         continue-on-error: true
+        if: ${{ matrix.app == 'rack' }}
       - name: Retrieve logs
         uses: actions/download-artifact@v3
         with:
           name: system-tests-${{ matrix.library }}-APPSEC_CORRUPTED_RULES-${{ matrix.app }}-logs-${{ github.run_id }}-${{ github.sha }}
           path: .
         continue-on-error: true
+        if: ${{ matrix.app == 'rack' }}
       - name: Retrieve logs
         uses: actions/download-artifact@v3
         with:
           name: system-tests-${{ matrix.library }}-APPSEC_LOW_WAF_TIMEOUT-${{ matrix.app }}-logs-${{ github.run_id }}-${{ github.sha }}
           path: .
         continue-on-error: true
+        if: ${{ matrix.app == 'rack' }}
       - name: Retrieve logs
         uses: actions/download-artifact@v3
         with:
           name: system-tests-${{ matrix.library }}-APPSEC_CUSTOM_OBFUSCATION-${{ matrix.app }}-logs-${{ github.run_id }}-${{ github.sha }}
           path: .
         continue-on-error: true
+        if: ${{ matrix.app == 'rack' }}
       - name: Retrieve logs
         uses: actions/download-artifact@v3
         with:
           name: system-tests-${{ matrix.library }}-APPSEC_RATE_LIMITER-${{ matrix.app }}-logs-${{ github.run_id }}-${{ github.sha }}
           path: .
         continue-on-error: true
+        if: ${{ matrix.app == 'rack' }}
       - name: Retrieve logs
         uses: actions/download-artifact@v3
         with:
@@ -315,12 +324,14 @@ jobs:
           name: system-tests-${{ matrix.library }}-SAMPLING-${{ matrix.app }}-logs-${{ github.run_id }}-${{ github.sha }}
           path: .
         continue-on-error: true
+        if: ${{ matrix.app == 'rack' }}
       - name: Retrieve logs
         uses: actions/download-artifact@v3
         with:
           name: system-tests-${{ matrix.library }}-PROFILING-${{ matrix.app }}-logs-${{ github.run_id }}-${{ github.sha }}
           path: .
         continue-on-error: true
+        if: ${{ matrix.app == 'rack' }}
       - name: Print fancy log report
         run: |
           find logs*

--- a/.github/workflows/system-tests.yml
+++ b/.github/workflows/system-tests.yml
@@ -36,7 +36,7 @@ jobs:
       - name: Save image
         uses: actions/upload-artifact@v3
         with:
-          name: docker-image-${{ matrix.image }}
+          name: docker-image-${{ matrix.image }}-${{ github.run_id }}-${{ github.sha }}
           path: images/*
           retention-days: 1
 
@@ -87,7 +87,7 @@ jobs:
       - name: Save image
         uses: actions/upload-artifact@v3
         with:
-          name: docker-image-${{ matrix.image }}-${{ matrix.app }}
+          name: docker-image-${{ matrix.image }}-${{ matrix.app }}-${{ github.run_id }}-${{ github.sha }}
           path: images/*
           retention-days: 1
 
@@ -146,17 +146,17 @@ jobs:
       - name: Retrieve agent image
         uses: actions/download-artifact@v3
         with:
-          name: docker-image-agent
+          name: docker-image-agent-${{ github.run_id }}-${{ github.sha }}
           path: images
       - name: Retrieve runner image
         uses: actions/download-artifact@v3
         with:
-          name: docker-image-runner
+          name: docker-image-runner-${{ github.run_id }}-${{ github.sha }}
           path: images
       - name: Retrieve app image
         uses: actions/download-artifact@v3
         with:
-          name: docker-image-weblog-${{ matrix.app }}
+          name: docker-image-weblog-${{ matrix.app }}-${{ github.run_id }}-${{ github.sha }}
           path: images
       - name: Load images
         run: |

--- a/.github/workflows/system-tests.yml
+++ b/.github/workflows/system-tests.yml
@@ -74,9 +74,69 @@ jobs:
         run: ./run.sh
         env:
           DD_API_KEY: ${{ secrets.DD_APPSEC_SYSTEM_TESTS_API_KEY }}
-
       - name: Run APPSEC_CUSTOM_RULES scenario
         run: ./run.sh APPSEC_CUSTOM_RULES
+        env:
+          DD_API_KEY: ${{ secrets.DD_APPSEC_SYSTEM_TESTS_API_KEY }}
+      - name: Run APPSEC_CUSTOM_RULES scenario
+        run: ./run.sh APPSEC_CUSTOM_RULES
+        env:
+          DD_API_KEY: ${{ secrets.DD_APPSEC_SYSTEM_TESTS_API_KEY }}
+      - name: Run REMOTE_CONFIG_MOCKED_BACKEND_ASM_DD scenario
+        run: ./run.sh REMOTE_CONFIG_MOCKED_BACKEND_ASM_DD
+        env:
+          DD_API_KEY: ${{ secrets.DD_APPSEC_SYSTEM_TESTS_API_KEY }}
+      - name: Run REMOTE_CONFIG_MOCKED_BACKEND_ASM_FEATURES_NOCACHE scenario
+        run: ./run.sh REMOTE_CONFIG_MOCKED_BACKEND_ASM_FEATURES_NOCACHE
+        env:
+          DD_API_KEY: ${{ secrets.DD_APPSEC_SYSTEM_TESTS_API_KEY }}
+      - name: Run REMOTE_CONFIG_MOCKED_BACKEND_LIVE_DEBUGGING_NOCACHE scenario
+        run: ./run.sh REMOTE_CONFIG_MOCKED_BACKEND_LIVE_DEBUGGING_NOCACHE
+        env:
+          DD_API_KEY: ${{ secrets.DD_APPSEC_SYSTEM_TESTS_API_KEY }}
+      - name: Run REMOTE_CONFIG_MOCKED_BACKEND_ASM_DD_NOCACHE scenario
+        run: ./run.sh REMOTE_CONFIG_MOCKED_BACKEND_ASM_DD_NOCACHE
+        env:
+          DD_API_KEY: ${{ secrets.DD_APPSEC_SYSTEM_TESTS_API_KEY }}
+      - name: Run APPSEC_MISSING_RULES scenario
+        run: ./run.sh APPSEC_MISSING_RULES
+        env:
+          DD_API_KEY: ${{ secrets.DD_APPSEC_SYSTEM_TESTS_API_KEY }}
+      - name: Run APPSEC_CORRUPTED_RULES scenario
+        if: steps.build.outcome == 'success' && github.event.action != 'opened' && !contains(github.event.pull_request.labels.*.name, 'run-default-scenario')
+        run: ./run.sh APPSEC_CORRUPTED_RULES
+        env:
+          DD_API_KEY: ${{ secrets.DD_APPSEC_SYSTEM_TESTS_API_KEY }}
+      - name: Run APPSEC_DISABLED scenario
+        run: ./run.sh APPSEC_DISABLED
+        env:
+          DD_API_KEY: ${{ secrets.DD_APPSEC_SYSTEM_TESTS_API_KEY }}
+      - name: Run APPSEC_LOW_WAF_TIMEOUT scenario
+        run: ./run.sh APPSEC_LOW_WAF_TIMEOUT
+        env:
+          DD_API_KEY: ${{ secrets.DD_APPSEC_SYSTEM_TESTS_API_KEY }}
+      - name: Run APPSEC_CUSTOM_OBFUSCATION scenario
+        run: ./run.sh APPSEC_CUSTOM_OBFUSCATION
+        env:
+          DD_API_KEY: ${{ secrets.DD_APPSEC_SYSTEM_TESTS_API_KEY }}
+      - name: Run APPSEC_RATE_LIMITER scenario
+        run: ./run.sh APPSEC_RATE_LIMITER
+        env:
+          DD_API_KEY: ${{ secrets.DD_APPSEC_SYSTEM_TESTS_API_KEY }}
+      - name: Run APPSEC_IP_BLOCKING scenario
+        run: ./run.sh APPSEC_IP_BLOCKING
+        env:
+          DD_API_KEY: ${{ secrets.DD_APPSEC_SYSTEM_TESTS_API_KEY }}
+      - name: Run APPSEC_REQUEST_BLOCKING scenario
+        run: ./run.sh APPSEC_REQUEST_BLOCKING
+        env:
+          DD_API_KEY: ${{ secrets.DD_APPSEC_SYSTEM_TESTS_API_KEY }}
+      - name: Run SAMPLING scenario
+        run: ./run.sh SAMPLING
+        env:
+          DD_API_KEY: ${{ secrets.DD_APPSEC_SYSTEM_TESTS_API_KEY }}
+      - name: Run PROFILING scenario
+        run: ./run.sh PROFILING
         env:
           DD_API_KEY: ${{ secrets.DD_APPSEC_SYSTEM_TESTS_API_KEY }}
 

--- a/.github/workflows/system-tests.yml
+++ b/.github/workflows/system-tests.yml
@@ -31,7 +31,7 @@ jobs:
           docker pull ghcr.io/datadog/dd-trace-rb/system-tests/${{ matrix.image }}:latest
           docker tag ghcr.io/datadog/dd-trace-rb/system-tests/${{ matrix.image }}:latest system_tests/${{ matrix.image }}:latest
       - name: Build image
-        run: ./build.sh --images ${{ matrix.image }}
+        run: ./build.sh --images ${{ matrix.image }} --extra-docker-args --cache-from=ghcr.io/datadog/dd-trace-rb/system-tests/${{ matrix.image }}:latest
       - name: Export image
         run: |
           docker image list
@@ -95,7 +95,7 @@ jobs:
         run: |
           echo ${{ secrets.GITHUB_TOKEN }} | docker login ${{ env.REGISTRY }} -u ${{ github.actor }} --password-stdin
       - name: Build
-        run: ./build.sh --library ${{ matrix.library }} --weblog-variant ${{ matrix.app }} --images ${{ matrix.image }}
+        run: ./build.sh --library ${{ matrix.library }} --weblog-variant ${{ matrix.app }} --images ${{ matrix.image }} --extra-docker-args --cache-from=ghcr.io/datadog/dd-trace-rb/system-tests/${{ matrix.image }}:${{ matrix.app }}
       - name: Export image
         run: |
           docker image list

--- a/.github/workflows/system-tests.yml
+++ b/.github/workflows/system-tests.yml
@@ -31,7 +31,7 @@ jobs:
           docker pull ghcr.io/datadog/dd-trace-rb/system-tests/${{ matrix.image }}:latest
           docker tag ghcr.io/datadog/dd-trace-rb/system-tests/${{ matrix.image }}:latest system_tests/${{ matrix.image }}:latest
       - name: Build image
-        run: ./build.sh --images ${{ matrix.image }} --extra-docker-args --cache-from=ghcr.io/datadog/dd-trace-rb/system-tests/${{ matrix.image }}:latest
+        run: ./build.sh --images ${{ matrix.image }}
       - name: Export image
         run: |
           docker image list
@@ -95,7 +95,7 @@ jobs:
         run: |
           echo ${{ secrets.GITHUB_TOKEN }} | docker login ${{ env.REGISTRY }} -u ${{ github.actor }} --password-stdin
       - name: Build
-        run: ./build.sh --library ${{ matrix.library }} --weblog-variant ${{ matrix.app }} --images ${{ matrix.image }} --extra-docker-args --cache-from=ghcr.io/datadog/dd-trace-rb/system-tests/${{ matrix.image }}:${{ matrix.app }}
+        run: ./build.sh --library ${{ matrix.library }} --weblog-variant ${{ matrix.app }} --images ${{ matrix.image }}
       - name: Export image
         run: |
           docker image list

--- a/.github/workflows/system-tests.yml
+++ b/.github/workflows/system-tests.yml
@@ -26,31 +26,31 @@ jobs:
         uses: actions/checkout@v3
         with:
           repository: 'DataDog/system-tests'
-      - name: Pull image
+      - name: Pull released image
         run: |
           docker pull ghcr.io/datadog/dd-trace-rb/system-tests/${{ matrix.image }}:latest
           docker tag ghcr.io/datadog/dd-trace-rb/system-tests/${{ matrix.image }}:latest system_tests/${{ matrix.image }}:latest
       - name: Build image
         run: ./build.sh --images ${{ matrix.image }}
-      - name: Export image
+      - name: List images
         run: |
           docker image list
-          mkdir -p images
-          docker save system_tests/${{ matrix.image }} > images/${{ matrix.image }}.tar
-      - name: Save image
-        uses: actions/upload-artifact@v3
-        with:
-          name: docker-image-${{ matrix.image }}-${{ github.run_id }}-${{ github.sha }}
-          path: images/*
-          retention-days: 1
       - name: Log in to the Container registry
-        if: ${{ github.ref == 'refs/heads/master' }}
         run: |
           echo ${{ secrets.GITHUB_TOKEN }} | docker login ${{ env.REGISTRY }} -u ${{ github.actor }} --password-stdin
-      - name: Push image
+      - name: Tag image for CI run
+        run:
+          docker tag system_tests/${{ matrix.image }}:latest ghcr.io/datadog/dd-trace-rb/system-tests/${{ matrix.image }}:gha${{ github.run_id }}-g${{ github.sha }}
+      - name: Push image for CI run
+        run: |
+          docker push ghcr.io/datadog/dd-trace-rb/system-tests/${{ matrix.image }}:gha${{ github.run_id }}-g${{ github.sha }}
+      - name: Tag image for release
+        if: ${{ github.ref == 'refs/heads/master' }}
+        run:
+          docker tag system_tests/${{ matrix.image }}:latest ghcr.io/datadog/dd-trace-rb/system-tests/${{ matrix.image }}:latest
+      - name: Push image for release
         if: ${{ github.ref == 'refs/heads/master' }}
         run: |
-          docker tag system_tests/${{ matrix.image }}:latest ghcr.io/datadog/dd-trace-rb/system-tests/${{ matrix.image }}:latest
           docker push ghcr.io/datadog/dd-trace-rb/system-tests/${{ matrix.image }}:latest
 
   build-apps:
@@ -87,31 +87,29 @@ jobs:
         uses: actions/checkout@v3
         with:
           path: 'binaries/dd-trace-rb'
-      - name: Pull image
+      - name: Pull released image
         run: |
-          docker pull ghcr.io/datadog/dd-trace-rb/system-tests/${{ matrix.image }}:${{ matrix.app }}
-          docker tag ghcr.io/datadog/dd-trace-rb/system-tests/${{ matrix.image }}:${{ matrix.app }} system_tests/${{ matrix.image }}
+          docker pull ghcr.io/datadog/dd-trace-rb/system-tests/${{ matrix.image }}-${{ matrix.app }}:latest
+          docker tag ghcr.io/datadog/dd-trace-rb/system-tests/${{ matrix.image }}-${{ matrix.app }}:latest system_tests/${{ matrix.image }}:latest
       - name: Log in to the Container registry
         run: |
           echo ${{ secrets.GITHUB_TOKEN }} | docker login ${{ env.REGISTRY }} -u ${{ github.actor }} --password-stdin
       - name: Build
         run: ./build.sh --library ${{ matrix.library }} --weblog-variant ${{ matrix.app }} --images ${{ matrix.image }}
-      - name: Export image
+      - name: Tag image for CI run
+        run:
+          docker tag system_tests/${{ matrix.image }}:latest ghcr.io/datadog/dd-trace-rb/system-tests/${{ matrix.image }}-${{ matrix.app }}:gha${{ github.run_id }}-g${{ github.sha }}
+      - name: Push image for CI run
         run: |
-          docker image list
-          mkdir -p images
-          docker save system_tests/${{ matrix.image }} > images/${{ matrix.image }}-${{ matrix.app }}.tar
-      - name: Save image
-        uses: actions/upload-artifact@v3
-        with:
-          name: docker-image-${{ matrix.image }}-${{ matrix.app }}-${{ github.run_id }}-${{ github.sha }}
-          path: images/*
-          retention-days: 1
-      - name: Push image
+          docker push ghcr.io/datadog/dd-trace-rb/system-tests/${{ matrix.image }}-${{ matrix.app }}:gha${{ github.run_id }}-g${{ github.sha }}
+      - name: Tag image for release
+        if: ${{ github.ref == 'refs/heads/master' }}
+        run:
+          docker tag system_tests/${{ matrix.image }}:latest ghcr.io/datadog/dd-trace-rb/system-tests/${{ matrix.image }}-${{ matrix.app }}:latest
+      - name: Push image for release
         if: ${{ github.ref == 'refs/heads/master' }}
         run: |
-          docker tag system_tests/${{ matrix.image }} ghcr.io/datadog/dd-trace-rb/system-tests/${{ matrix.image }}:${{ matrix.app }}
-          docker push ghcr.io/datadog/dd-trace-rb/system-tests/${{ matrix.image }}:${{ matrix.app }}
+          docker push ghcr.io/datadog/dd-trace-rb/system-tests/${{ matrix.image }}-${{ matrix.app }}:latest
 
   test:
     strategy:
@@ -190,28 +188,20 @@ jobs:
         uses: actions/checkout@v3
         with:
           repository: 'DataDog/system-tests'
-      - name: Retrieve agent image
-        uses: actions/download-artifact@v3
-        with:
-          name: docker-image-agent-${{ github.run_id }}-${{ github.sha }}
-          path: images
-      - name: Retrieve runner image
-        uses: actions/download-artifact@v3
-        with:
-          name: docker-image-runner-${{ github.run_id }}-${{ github.sha }}
-          path: images
-      - name: Retrieve app image
-        uses: actions/download-artifact@v3
-        with:
-          name: docker-image-weblog-${{ matrix.app }}-${{ github.run_id }}-${{ github.sha }}
-          path: images
-      - name: Load images
+      - name: Pull agent image
         run: |
-          find images
-          cd images
-          docker load < agent.tar
-          docker load < runner.tar
-          docker load < weblog-${{ matrix.app }}.tar
+          docker pull ghcr.io/datadog/dd-trace-rb/system-tests/agent:gha${{ github.run_id }}-g${{ github.sha }}
+          docker tag ghcr.io/datadog/dd-trace-rb/system-tests/agent:gha${{ github.run_id }}-g${{ github.sha }} system_tests/agent:latest
+      - name: Pull runner image
+        run: |
+          docker pull ghcr.io/datadog/dd-trace-rb/system-tests/runner:gha${{ github.run_id }}-g${{ github.sha }}
+          docker tag ghcr.io/datadog/dd-trace-rb/system-tests/runner:gha${{ github.run_id }}-g${{ github.sha }} system_tests/runner:latest
+      - name: Pull app image
+        run: |
+          docker pull ghcr.io/datadog/dd-trace-rb/system-tests/weblog-${{ matrix.app }}:gha${{ github.run_id }}-g${{ github.sha }}
+          docker tag ghcr.io/datadog/dd-trace-rb/system-tests/weblog-${{ matrix.app }}:gha${{ github.run_id }}-g${{ github.sha }} system_tests/weblog:latest
+      - name: List images
+        run: |
           docker image list
       - name: Run scenario
         run: ./run.sh ${{ matrix.scenario }}

--- a/.github/workflows/system-tests.yml
+++ b/.github/workflows/system-tests.yml
@@ -264,3 +264,40 @@ jobs:
         run: |
           find logs*
           python utils/scripts/markdown_logs.py >> $GITHUB_STEP_SUMMARY
+
+  cleanup:
+    strategy:
+      fail-fast: false
+      matrix:
+        image:
+          - runner
+          - agent
+          - weblog-rack
+          - weblog-sinatra14
+          - weblog-sinatra20
+          - weblog-sinatra21
+          - weblog-rails32
+          - weblog-rails40
+          - weblog-rails41
+          - weblog-rails42
+          - weblog-rails50
+          - weblog-rails51
+          - weblog-rails52
+          - weblog-rails60
+          - weblog-rails61
+          - weblog-rails70
+    runs-on: ubuntu-latest
+    needs:
+      - test
+    if: ${{ always() }}
+    name: Cleanup (${{ matrix.image }})
+    steps:
+      - name: Log in to the Container registry
+        run: |
+          echo ${{ secrets.GITHUB_TOKEN }} | docker login ${{ env.REGISTRY }} -u ${{ github.actor }} --password-stdin
+      - uses: actions/delete-package-versions@v4
+        with:
+          package-version-ids: gha${{ github.run_id }}-g${{ github.sha }}
+          package-name: system-tests/${{ matrix.image }}
+          package-type: 'container'
+        continue-on-error: true

--- a/.github/workflows/system-tests.yml
+++ b/.github/workflows/system-tests.yml
@@ -166,7 +166,7 @@ jobs:
           docker load < runner.tar
           docker load < weblog-${{ matrix.app }}.tar
           docker image list
-      - name: Run default scenario
+      - name: Run scenario
         run: ./run.sh ${{ matrix.scenario }}
         env:
           DD_API_KEY: ${{ secrets.DD_APPSEC_SYSTEM_TESTS_API_KEY }}
@@ -176,6 +176,127 @@ jobs:
         with:
           name: system-tests-${{ matrix.library }}-${{ matrix.scenario }}-${{ matrix.app }}-logs-${{ github.run_id }}-${{ github.sha }}
           path: logs*
+
+  aggregate:
+    strategy:
+      fail-fast: false
+      matrix:
+        library:
+          - ruby
+        app:
+          - rack
+          - sinatra14
+          - sinatra20
+          - sinatra21
+          - rails32
+          - rails40
+          - rails41
+          - rails42
+          - rails50
+          - rails51
+          - rails52
+          - rails60
+          - rails61
+          - rails70
+    runs-on: ubuntu-latest
+    needs:
+      - test
+    if: ${{ always() }}
+    name: Aggregate (${{ matrix.app }})
+    steps:
+      - name: Setup python 3.9
+        uses: actions/setup-python@v4
+        with:
+          python-version: '3.9'
+      - name: Checkout
+        uses: actions/checkout@v3
+        with:
+          repository: 'DataDog/system-tests'
+      - name: Retrieve logs
+        uses: actions/download-artifact@v3
+        with:
+          name: system-tests-${{ matrix.library }}-DEFAULT-${{ matrix.app }}-logs-${{ github.run_id }}-${{ github.sha }}
+          path: .
+        continue-on-error: true
+      - name: Retrieve logs
+        uses: actions/download-artifact@v3
+        with:
+          name: system-tests-${{ matrix.library }}-REMOTE_CONFIG_MOCKED_BACKEND_ASM_DD-${{ matrix.app }}-logs-${{ github.run_id }}-${{ github.sha }}
+          path: .
+        continue-on-error: true
+      - name: Retrieve logs
+        uses: actions/download-artifact@v3
+        with:
+          name: system-tests-${{ matrix.library }}-REMOTE_CONFIG_MOCKED_BACKEND_ASM_FEATURES-${{ matrix.app }}-logs-${{ github.run_id }}-${{ github.sha }}
+          path: .
+        continue-on-error: true
+      - name: Retrieve logs
+        uses: actions/download-artifact@v3
+        with:
+          name: system-tests-${{ matrix.library }}-REMOTE_CONFIG_MOCKED_BACKEND_ASM_FEATURES_NOCACHE-${{ matrix.app }}-logs-${{ github.run_id }}-${{ github.sha }}
+          path: .
+        continue-on-error: true
+      - name: Retrieve logs
+        uses: actions/download-artifact@v3
+        with:
+          name: system-tests-${{ matrix.library }}-REMOTE_CONFIG_MOCKED_BACKEND_ASM_DD_NOCACHE-${{ matrix.app }}-logs-${{ github.run_id }}-${{ github.sha }}
+          path: .
+        continue-on-error: true
+      - name: Retrieve logs
+        uses: actions/download-artifact@v3
+        with:
+          name: system-tests-${{ matrix.library }}-APPSEC_MISSING_RULES-${{ matrix.app }}-logs-${{ github.run_id }}-${{ github.sha }}
+          path: .
+        continue-on-error: true
+      - name: Retrieve logs
+        uses: actions/download-artifact@v3
+        with:
+          name: system-tests-${{ matrix.library }}-APPSEC_CORRUPTED_RULES-${{ matrix.app }}-logs-${{ github.run_id }}-${{ github.sha }}
+          path: .
+        continue-on-error: true
+      - name: Retrieve logs
+        uses: actions/download-artifact@v3
+        with:
+          name: system-tests-${{ matrix.library }}-APPSEC_LOW_WAF_TIMEOUT-${{ matrix.app }}-logs-${{ github.run_id }}-${{ github.sha }}
+          path: .
+        continue-on-error: true
+      - name: Retrieve logs
+        uses: actions/download-artifact@v3
+        with:
+          name: system-tests-${{ matrix.library }}-APPSEC_CUSTOM_OBFUSCATION-${{ matrix.app }}-logs-${{ github.run_id }}-${{ github.sha }}
+          path: .
+        continue-on-error: true
+      - name: Retrieve logs
+        uses: actions/download-artifact@v3
+        with:
+          name: system-tests-${{ matrix.library }}-APPSEC_RATE_LIMITER-${{ matrix.app }}-logs-${{ github.run_id }}-${{ github.sha }}
+          path: .
+        continue-on-error: true
+      - name: Retrieve logs
+        uses: actions/download-artifact@v3
+        with:
+          name: system-tests-${{ matrix.library }}-APPSEC_IP_BLOCKING-${{ matrix.app }}-logs-${{ github.run_id }}-${{ github.sha }}
+          path: .
+        continue-on-error: true
+      - name: Retrieve logs
+        uses: actions/download-artifact@v3
+        with:
+          name: system-tests-${{ matrix.library }}-APPSEC_REQUEST_BLOCKING-${{ matrix.app }}-logs-${{ github.run_id }}-${{ github.sha }}
+          path: .
+        continue-on-error: true
+      - name: Retrieve logs
+        uses: actions/download-artifact@v3
+        with:
+          name: system-tests-${{ matrix.library }}-SAMPLING-${{ matrix.app }}-logs-${{ github.run_id }}-${{ github.sha }}
+          path: .
+        continue-on-error: true
+      - name: Retrieve logs
+        uses: actions/download-artifact@v3
+        with:
+          name: system-tests-${{ matrix.library }}-PROFILING-${{ matrix.app }}-logs-${{ github.run_id }}-${{ github.sha }}
+          path: .
+        continue-on-error: true
       - name: Print fancy log report
-        if: ${{ always() }}
-        run: python utils/scripts/markdown_logs.py >> $GITHUB_STEP_SUMMARY
+        run: |
+          ls -l logs
+          python utils/scripts/markdown_logs.py >> $GITHUB_STEP_SUMMARY

--- a/.github/workflows/system-tests.yml
+++ b/.github/workflows/system-tests.yml
@@ -16,35 +16,23 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        include:
-          - library: ruby
-            weblog-variant: rack
-          - library: ruby
-            weblog-variant: sinatra14
-          - library: ruby
-            weblog-variant: sinatra20
-          - library: ruby
-            weblog-variant: sinatra21
-          - library: ruby
-            weblog-variant: rails32
-          - library: ruby
-            weblog-variant: rails40
-          - library: ruby
-            weblog-variant: rails41
-          - library: ruby
-            weblog-variant: rails42
-          - library: ruby
-            weblog-variant: rails50
-          - library: ruby
-            weblog-variant: rails51
-          - library: ruby
-            weblog-variant: rails52
-          - library: ruby
-            weblog-variant: rails60
-          - library: ruby
-            weblog-variant: rails61
-          - library: ruby
-            weblog-variant: rails70
+        library:
+          - ruby
+        weblog-variant:
+          - rack
+          - sinatra14
+          - sinatra20
+          - sinatra21
+          - rails32
+          - rails40
+          - rails41
+          - rails42
+          - rails50
+          - rails51
+          - rails52
+          - rails60
+          - rails61
+          - rails70
     runs-on: ubuntu-latest
     name: System Tests (${{ matrix.weblog-variant }})
     steps:

--- a/.github/workflows/system-tests.yml
+++ b/.github/workflows/system-tests.yml
@@ -160,8 +160,8 @@ jobs:
           path: images
       - name: Load images
         run: |
+          find images
           cd images
-          ls -l
           docker load < agent.tar
           docker load < runner.tar
           docker load < weblog-${{ matrix.app }}.tar
@@ -298,5 +298,5 @@ jobs:
         continue-on-error: true
       - name: Print fancy log report
         run: |
-          ls -l logs
+          find logs*
           python utils/scripts/markdown_logs.py >> $GITHUB_STEP_SUMMARY

--- a/.github/workflows/system-tests.yml
+++ b/.github/workflows/system-tests.yml
@@ -195,11 +195,17 @@ jobs:
         run: ./run.sh ${{ matrix.scenario }}
         env:
           DD_API_KEY: ${{ secrets.DD_APPSEC_SYSTEM_TESTS_API_KEY }}
-      - name: Archive logs
+      - name: Archive logs (per scenario)
         uses: actions/upload-artifact@v3
         if: ${{ always() }}
         with:
-          name: system-tests-${{ matrix.library }}-${{ matrix.scenario }}-${{ matrix.app }}-logs-${{ github.run_id }}-${{ github.sha }}
+          name: system-tests-${{ matrix.library }}-${{ matrix.app }}-${{ matrix.scenario }}-logs-${{ github.run_id }}-${{ github.sha }}
+          path: logs*
+      - name: Archive logs (aggregated)
+        uses: actions/upload-artifact@v3
+        if: ${{ always() }}
+        with:
+          name: system-tests-${{ matrix.library }}-${{ matrix.app }}-logs-${{ github.run_id }}-${{ github.sha }}
           path: logs*
 
   aggregate:
@@ -240,98 +246,9 @@ jobs:
       - name: Retrieve logs
         uses: actions/download-artifact@v3
         with:
-          name: system-tests-${{ matrix.library }}-DEFAULT-${{ matrix.app }}-logs-${{ github.run_id }}-${{ github.sha }}
+          name: system-tests-${{ matrix.library }}-${{ matrix.app }}-logs-${{ github.run_id }}-${{ github.sha }}
           path: .
         continue-on-error: true
-      - name: Retrieve logs
-        uses: actions/download-artifact@v3
-        with:
-          name: system-tests-${{ matrix.library }}-REMOTE_CONFIG_MOCKED_BACKEND_ASM_DD-${{ matrix.app }}-logs-${{ github.run_id }}-${{ github.sha }}
-          path: .
-        continue-on-error: true
-        if: ${{ matrix.app == 'rack' }}
-      - name: Retrieve logs
-        uses: actions/download-artifact@v3
-        with:
-          name: system-tests-${{ matrix.library }}-REMOTE_CONFIG_MOCKED_BACKEND_ASM_FEATURES-${{ matrix.app }}-logs-${{ github.run_id }}-${{ github.sha }}
-          path: .
-        continue-on-error: true
-        if: ${{ matrix.app == 'rack' }}
-      - name: Retrieve logs
-        uses: actions/download-artifact@v3
-        with:
-          name: system-tests-${{ matrix.library }}-REMOTE_CONFIG_MOCKED_BACKEND_ASM_FEATURES_NOCACHE-${{ matrix.app }}-logs-${{ github.run_id }}-${{ github.sha }}
-          path: .
-        continue-on-error: true
-        if: ${{ matrix.app == 'rack' }}
-      - name: Retrieve logs
-        uses: actions/download-artifact@v3
-        with:
-          name: system-tests-${{ matrix.library }}-REMOTE_CONFIG_MOCKED_BACKEND_ASM_DD_NOCACHE-${{ matrix.app }}-logs-${{ github.run_id }}-${{ github.sha }}
-          path: .
-        continue-on-error: true
-        if: ${{ matrix.app == 'rack' }}
-      - name: Retrieve logs
-        uses: actions/download-artifact@v3
-        with:
-          name: system-tests-${{ matrix.library }}-APPSEC_MISSING_RULES-${{ matrix.app }}-logs-${{ github.run_id }}-${{ github.sha }}
-          path: .
-        continue-on-error: true
-        if: ${{ matrix.app == 'rack' }}
-      - name: Retrieve logs
-        uses: actions/download-artifact@v3
-        with:
-          name: system-tests-${{ matrix.library }}-APPSEC_CORRUPTED_RULES-${{ matrix.app }}-logs-${{ github.run_id }}-${{ github.sha }}
-          path: .
-        continue-on-error: true
-        if: ${{ matrix.app == 'rack' }}
-      - name: Retrieve logs
-        uses: actions/download-artifact@v3
-        with:
-          name: system-tests-${{ matrix.library }}-APPSEC_LOW_WAF_TIMEOUT-${{ matrix.app }}-logs-${{ github.run_id }}-${{ github.sha }}
-          path: .
-        continue-on-error: true
-        if: ${{ matrix.app == 'rack' }}
-      - name: Retrieve logs
-        uses: actions/download-artifact@v3
-        with:
-          name: system-tests-${{ matrix.library }}-APPSEC_CUSTOM_OBFUSCATION-${{ matrix.app }}-logs-${{ github.run_id }}-${{ github.sha }}
-          path: .
-        continue-on-error: true
-        if: ${{ matrix.app == 'rack' }}
-      - name: Retrieve logs
-        uses: actions/download-artifact@v3
-        with:
-          name: system-tests-${{ matrix.library }}-APPSEC_RATE_LIMITER-${{ matrix.app }}-logs-${{ github.run_id }}-${{ github.sha }}
-          path: .
-        continue-on-error: true
-        if: ${{ matrix.app == 'rack' }}
-      - name: Retrieve logs
-        uses: actions/download-artifact@v3
-        with:
-          name: system-tests-${{ matrix.library }}-APPSEC_IP_BLOCKING-${{ matrix.app }}-logs-${{ github.run_id }}-${{ github.sha }}
-          path: .
-        continue-on-error: true
-      - name: Retrieve logs
-        uses: actions/download-artifact@v3
-        with:
-          name: system-tests-${{ matrix.library }}-APPSEC_REQUEST_BLOCKING-${{ matrix.app }}-logs-${{ github.run_id }}-${{ github.sha }}
-          path: .
-        continue-on-error: true
-      - name: Retrieve logs
-        uses: actions/download-artifact@v3
-        with:
-          name: system-tests-${{ matrix.library }}-SAMPLING-${{ matrix.app }}-logs-${{ github.run_id }}-${{ github.sha }}
-          path: .
-        continue-on-error: true
-        if: ${{ matrix.app == 'rack' }}
-      - name: Retrieve logs
-        uses: actions/download-artifact@v3
-        with:
-          name: system-tests-${{ matrix.library }}-PROFILING-${{ matrix.app }}-logs-${{ github.run_id }}-${{ github.sha }}
-          path: .
-        continue-on-error: true
-        if: ${{ matrix.app == 'rack' }}
       - name: Print fancy log report
         run: |
           find logs*

--- a/.github/workflows/system-tests.yml
+++ b/.github/workflows/system-tests.yml
@@ -12,13 +12,92 @@ env:
   REGISTRY: ghcr.io
 
 jobs:
-  system-tests:
+  build-harness:
+    strategy:
+      fail-fast: false
+      matrix:
+        image:
+          - runner
+          - agent
+    runs-on: ubuntu-latest
+    name: Build (${{ matrix.image }})
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+        with:
+          repository: 'DataDog/system-tests'
+      - name: Build image
+        run: ./build.sh --images ${{ matrix.image }}
+      - name: Export image
+        run: |
+          docker image list
+          mkdir -p images
+          docker save system_tests/${{ matrix.image }} > images/${{ matrix.image }}.tar
+      - name: Save image
+        uses: actions/upload-artifact@v3
+        with:
+          name: docker-image-${{ matrix.image }}
+          path: images/*
+          retention-days: 1
+
+  build-apps:
+    strategy:
+      fail-fast: false
+      matrix:
+        image:
+          - weblog
+        library:
+          - ruby
+        app:
+          - rack
+          - sinatra14
+          - sinatra20
+          - sinatra21
+          - rails32
+          - rails40
+          - rails41
+          - rails42
+          - rails50
+          - rails51
+          - rails52
+          - rails60
+          - rails61
+          - rails70
+    runs-on: ubuntu-latest
+    name: Build (${{ matrix.app }})
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+        with:
+          repository: 'DataDog/system-tests'
+      - name: Checkout dd-trace-rb
+        uses: actions/checkout@v3
+        with:
+          path: 'binaries/dd-trace-rb'
+      - name: Log in to the Container registry
+        run: |
+          echo ${{ secrets.GITHUB_TOKEN }} | docker login ${{ env.REGISTRY }} -u ${{ github.actor }} --password-stdin
+      - name: Build
+        run: ./build.sh --library ${{ matrix.library }} --weblog-variant ${{ matrix.app }} --images ${{ matrix.image }}
+      - name: Export image
+        run: |
+          docker image list
+          mkdir -p images
+          docker save system_tests/${{ matrix.image }} > images/${{ matrix.image }}-${{ matrix.app }}.tar
+      - name: Save image
+        uses: actions/upload-artifact@v3
+        with:
+          name: docker-image-${{ matrix.image }}-${{ matrix.app }}
+          path: images/*
+          retention-days: 1
+
+  test:
     strategy:
       fail-fast: false
       matrix:
         library:
           - ruby
-        weblog-variant:
+        app:
           - rack
           - sinatra14
           - sinatra20
@@ -35,11 +114,11 @@ jobs:
           - rails70
         scenario:
           - DEFAULT
-          - APPSEC_CUSTOM_RULES
           - REMOTE_CONFIG_MOCKED_BACKEND_ASM_DD
           - REMOTE_CONFIG_MOCKED_BACKEND_ASM_FEATURES
           - REMOTE_CONFIG_MOCKED_BACKEND_ASM_FEATURES_NOCACHE
           - REMOTE_CONFIG_MOCKED_BACKEND_ASM_DD_NOCACHE
+          - APPSEC_CUSTOM_RULES
           - APPSEC_MISSING_RULES
           - APPSEC_CORRUPTED_RULES
           - APPSEC_DISABLED
@@ -51,42 +130,52 @@ jobs:
           - SAMPLING
           - PROFILING
     runs-on: ubuntu-latest
-    name: System Tests (${{ matrix.scenario }}, ${{ matrix.weblog-variant }})
+    needs:
+      - build-harness
+      - build-apps
+    name: Test (${{ matrix.app }}, ${{ matrix.scenario }})
     steps:
       - name: Setup python 3.9
         uses: actions/setup-python@v4
         with:
           python-version: '3.9'
-
       - name: Checkout
         uses: actions/checkout@v3
         with:
           repository: 'DataDog/system-tests'
-
-      - name: Checkout dd-trace-rb
-        uses: actions/checkout@v3
+      - name: Retrieve agent image
+        uses: actions/download-artifact@v3
         with:
-          path: 'binaries/dd-trace-rb'
-
-      - name: Log in to the Container registry
+          name: docker-image-agent
+          path: images
+      - name: Retrieve runner image
+        uses: actions/download-artifact@v3
+        with:
+          name: docker-image-runner
+          path: images
+      - name: Retrieve app image
+        uses: actions/download-artifact@v3
+        with:
+          name: docker-image-weblog-${{ matrix.app }}
+          path: images
+      - name: Load images
         run: |
-          echo ${{ secrets.GITHUB_TOKEN }} | docker login ${{ env.REGISTRY }} -u ${{ github.actor }} --password-stdin
-
-      - name: Build
-        run: ./build.sh --library ${{ matrix.library }} --weblog-variant ${{ matrix.weblog-variant }}
-
+          cd images
+          ls -l
+          docker load < agent.tar
+          docker load < runner.tar
+          docker load < weblog-${{ matrix.app }}.tar
+          docker image list
       - name: Run default scenario
         run: ./run.sh ${{ matrix.scenario }}
         env:
           DD_API_KEY: ${{ secrets.DD_APPSEC_SYSTEM_TESTS_API_KEY }}
-
       - name: Archive logs
         uses: actions/upload-artifact@v3
         if: ${{ always() }}
         with:
-          name: system-tests-${{ matrix.library }}-${{ matrix.scenario }}-${{ matrix.weblog-variant }}-logs-${{ github.run_id }}-${{ github.sha }}
+          name: system-tests-${{ matrix.library }}-${{ matrix.scenario }}-${{ matrix.app }}-logs-${{ github.run_id }}-${{ github.sha }}
           path: logs*
-
       - name: Print fancy log report
         if: ${{ always() }}
         run: python utils/scripts/markdown_logs.py >> $GITHUB_STEP_SUMMARY

--- a/.github/workflows/system-tests.yml
+++ b/.github/workflows/system-tests.yml
@@ -114,21 +114,46 @@ jobs:
           - rails70
         scenario:
           - DEFAULT
-          - REMOTE_CONFIG_MOCKED_BACKEND_ASM_DD
-          - REMOTE_CONFIG_MOCKED_BACKEND_ASM_FEATURES
-          - REMOTE_CONFIG_MOCKED_BACKEND_ASM_FEATURES_NOCACHE
-          - REMOTE_CONFIG_MOCKED_BACKEND_ASM_DD_NOCACHE
-          - APPSEC_CUSTOM_RULES
-          - APPSEC_MISSING_RULES
-          - APPSEC_CORRUPTED_RULES
           - APPSEC_DISABLED
-          - APPSEC_LOW_WAF_TIMEOUT
-          - APPSEC_CUSTOM_OBFUSCATION
-          - APPSEC_RATE_LIMITER
           - APPSEC_IP_BLOCKING
           - APPSEC_REQUEST_BLOCKING
-          - SAMPLING
-          - PROFILING
+        include:
+          - library: ruby
+            app: rack
+            scenario: REMOTE_CONFIG_MOCKED_BACKEND_ASM_DD
+          - library: ruby
+            app: rack
+            scenario: REMOTE_CONFIG_MOCKED_BACKEND_ASM_FEATURES
+          - library: ruby
+            app: rack
+            scenario: REMOTE_CONFIG_MOCKED_BACKEND_ASM_FEATURES_NOCACHE
+          - library: ruby
+            app: rack
+            scenario: REMOTE_CONFIG_MOCKED_BACKEND_ASM_DD_NOCACHE
+          - library: ruby
+            app: rack
+            scenario: APPSEC_CUSTOM_RULES
+          - library: ruby
+            app: rack
+            scenario: APPSEC_MISSING_RULES
+          - library: ruby
+            app: rack
+            scenario: APPSEC_CORRUPTED_RULES
+          - library: ruby
+            app: rack
+            scenario: APPSEC_LOW_WAF_TIMEOUT
+          - library: ruby
+            app: rack
+            scenario: APPSEC_CUSTOM_OBFUSCATION
+          - library: ruby
+            app: rack
+            scenario: APPSEC_RATE_LIMITER
+          - library: ruby
+            app: rack
+            scenario: SAMPLING
+          - library: ruby
+            app: rack
+            scenario: PROFILING
     runs-on: ubuntu-latest
     needs:
       - build-harness

--- a/.github/workflows/system-tests.yml
+++ b/.github/workflows/system-tests.yml
@@ -270,7 +270,6 @@ jobs:
         with:
           name: system-tests-${{ matrix.library }}-${{ matrix.app }}-logs-${{ github.run_id }}-${{ github.sha }}
           path: .
-        continue-on-error: true
       - name: Print fancy log report
         run: |
           find logs*

--- a/.github/workflows/system-tests.yml
+++ b/.github/workflows/system-tests.yml
@@ -26,6 +26,10 @@ jobs:
         uses: actions/checkout@v3
         with:
           repository: 'DataDog/system-tests'
+      - name: Pull image
+        run: |
+          docker pull ghcr.io/datadog/dd-trace-rb/system-tests/${{ matrix.image }}:latest
+          docker tag ghcr.io/datadog/dd-trace-rb/system-tests/${{ matrix.image }}:latest system_tests/${{ matrix.image }}:latest
       - name: Build image
         run: ./build.sh --images ${{ matrix.image }}
       - name: Export image
@@ -39,6 +43,15 @@ jobs:
           name: docker-image-${{ matrix.image }}-${{ github.run_id }}-${{ github.sha }}
           path: images/*
           retention-days: 1
+      - name: Log in to the Container registry
+        if: ${{ github.ref == 'refs/heads/master' }}
+        run: |
+          echo ${{ secrets.GITHUB_TOKEN }} | docker login ${{ env.REGISTRY }} -u ${{ github.actor }} --password-stdin
+      - name: Push image
+        if: ${{ github.ref == 'refs/heads/master' }}
+        run: |
+          docker tag system_tests/${{ matrix.image }}:latest ghcr.io/datadog/dd-trace-rb/system-tests/${{ matrix.image }}:latest
+          docker push ghcr.io/datadog/dd-trace-rb/system-tests/${{ matrix.image }}:latest
 
   build-apps:
     strategy:
@@ -74,6 +87,10 @@ jobs:
         uses: actions/checkout@v3
         with:
           path: 'binaries/dd-trace-rb'
+      - name: Pull image
+        run: |
+          docker pull ghcr.io/datadog/dd-trace-rb/system-tests/${{ matrix.image }}:${{ matrix.app }}
+          docker tag ghcr.io/datadog/dd-trace-rb/system-tests/${{ matrix.image }}:${{ matrix.app }} system_tests/${{ matrix.image }}
       - name: Log in to the Container registry
         run: |
           echo ${{ secrets.GITHUB_TOKEN }} | docker login ${{ env.REGISTRY }} -u ${{ github.actor }} --password-stdin
@@ -90,6 +107,11 @@ jobs:
           name: docker-image-${{ matrix.image }}-${{ matrix.app }}-${{ github.run_id }}-${{ github.sha }}
           path: images/*
           retention-days: 1
+      - name: Push image
+        if: ${{ github.ref == 'refs/heads/master' }}
+        run: |
+          docker tag system_tests/${{ matrix.image }} ghcr.io/datadog/dd-trace-rb/system-tests/${{ matrix.image }}:${{ matrix.app }}
+          docker push ghcr.io/datadog/dd-trace-rb/system-tests/${{ matrix.image }}:${{ matrix.app }}
 
   test:
     strategy:


### PR DESCRIPTION
<!--
Check out the
https://github.com/DataDog/dd-trace-rb/blob/master/docs/DevelopmentGuide.md
for guidance on how to set up your development environment,
run the test suite, write new integrations, and more.
-->

**What does this PR do?**

Enable more system test scenarios to be run in CI

**Motivation**

The default scenario covers only a limited number of tests

- Validate new developments
- Guarantee no regression

**Additional Notes**

Probably the system tests repo should provide an cross-repo reusable GitHub workflow so that we don't have to update this one manually.

**How to test the change?**

CI