### PR TITLE
[APPSEC-8868] Store if a specific appsec configuration option has been configured by customer using `Datadog.configure` block or an ENV variable

### DIFF
--- a/lib/datadog/appsec/configuration.rb
+++ b/lib/datadog/appsec/configuration.rb
@@ -79,12 +79,14 @@ module Datadog
           settings
         end
 
-        def default_setting?(setting)
-          settings.default?(setting)
-        end
-
         def settings
           @settings ||= Settings.new
+        end
+
+        private
+
+        def default_setting?(setting)
+          settings.send(:default?, setting)
         end
       end
     end

--- a/lib/datadog/appsec/configuration.rb
+++ b/lib/datadog/appsec/configuration.rb
@@ -79,6 +79,10 @@ module Datadog
           settings
         end
 
+        def default_setting?(setting)
+          settings.default?(setting)
+        end
+
         def settings
           @settings ||= Settings.new
         end

--- a/lib/datadog/appsec/configuration/settings.rb
+++ b/lib/datadog/appsec/configuration/settings.rb
@@ -1,3 +1,7 @@
+# frozen_string_literal: true
+
+require 'set'
+
 module Datadog
   module AppSec
     module Configuration
@@ -87,8 +91,8 @@ module Datadog
         end
 
         # rubocop:disable Layout/LineLength
-        DEFAULT_OBFUSCATOR_KEY_REGEX = '(?i)(?:p(?:ass)?w(?:or)?d|pass(?:_?phrase)?|secret|(?:api_?|private_?|public_?)key)|token|consumer_?(?:id|key|secret)|sign(?:ed|ature)|bearer|authorization'.freeze
-        DEFAULT_OBFUSCATOR_VALUE_REGEX = '(?i)(?:p(?:ass)?w(?:or)?d|pass(?:_?phrase)?|secret|(?:api_?|private_?|public_?|access_?|secret_?)key(?:_?id)?|token|consumer_?(?:id|key|secret)|sign(?:ed|ature)?|auth(?:entication|orization)?)(?:\s*=[^;]|"\s*:\s*"[^"]+")|bearer\s+[a-z0-9\._\-]+|token:[a-z0-9]{13}|gh[opsu]_[0-9a-zA-Z]{36}|ey[I-L][\w=-]+\.ey[I-L][\w=-]+(?:\.[\w.+\/=-]+)?|[\-]{5}BEGIN[a-z\s]+PRIVATE\sKEY[\-]{5}[^\-]+[\-]{5}END[a-z\s]+PRIVATE\sKEY|ssh-rsa\s*[a-z0-9\/\.+]{100,}'.freeze
+        DEFAULT_OBFUSCATOR_KEY_REGEX = '(?i)(?:p(?:ass)?w(?:or)?d|pass(?:_?phrase)?|secret|(?:api_?|private_?|public_?)key)|token|consumer_?(?:id|key|secret)|sign(?:ed|ature)|bearer|authorization'
+        DEFAULT_OBFUSCATOR_VALUE_REGEX = '(?i)(?:p(?:ass)?w(?:or)?d|pass(?:_?phrase)?|secret|(?:api_?|private_?|public_?|access_?|secret_?)key(?:_?id)?|token|consumer_?(?:id|key|secret)|sign(?:ed|ature)?|auth(?:entication|orization)?)(?:\s*=[^;]|"\s*:\s*"[^"]+")|bearer\s+[a-z0-9\._\-]+|token:[a-z0-9]{13}|gh[opsu]_[0-9a-zA-Z]{36}|ey[I-L][\w=-]+\.ey[I-L][\w=-]+(?:\.[\w.+\/=-]+)?|[\-]{5}BEGIN[a-z\s]+PRIVATE\sKEY[\-]{5}[^\-]+[\-]{5}END[a-z\s]+PRIVATE\sKEY|ssh-rsa\s*[a-z0-9\/\.+]{100,}'
         # rubocop:enable Layout/LineLength
 
         DEFAULTS = {
@@ -116,9 +120,14 @@ module Datadog
 
         def initialize
           @integrations = []
+          # Stores which options have been configured using Datadog.configure block or ENV variables
+          @configured = Set.new
           @options = DEFAULTS.dup.tap do |options|
             ENVS.each do |env, (key, conv)|
-              options[key] = conv.call(ENV[env]) if ENV[env]
+              if ENV[env]
+                options[key] = conv.call(ENV[env])
+                @configured << key
+              end
             end
           end
         end
@@ -180,9 +189,16 @@ module Datadog
           integration.options
         end
 
+        def default?(option)
+          !@configured.include?(option)
+        end
+
         def merge(dsl)
           dsl.options.each do |k, v|
-            @options[k] = v unless v.nil?
+            unless v.nil?
+              @options[k] = v
+              @configured << k
+            end
           end
 
           return self unless @options[:enabled]

--- a/lib/datadog/appsec/configuration/settings.rb
+++ b/lib/datadog/appsec/configuration/settings.rb
@@ -189,10 +189,6 @@ module Datadog
           integration.options
         end
 
-        def default?(option)
-          !@configured.include?(option)
-        end
-
         def merge(dsl)
           dsl.options.each do |k, v|
             unless v.nil?
@@ -221,6 +217,10 @@ module Datadog
         end
 
         private
+
+        def default?(option)
+          !@configured.include?(option)
+        end
 
         # Restore to original state, for testing only.
         def reset!

--- a/sig/datadog/appsec/configuration.rbs
+++ b/sig/datadog/appsec/configuration.rbs
@@ -41,6 +41,10 @@ module Datadog
         def configure: () { (DSL) -> void } -> void
 
         def settings: () -> Settings
+
+        private
+
+        def default_setting?: (Symbol setting) -> bool
       end
     end
   end

--- a/sig/datadog/appsec/configuration/settings.rbs
+++ b/sig/datadog/appsec/configuration/settings.rbs
@@ -25,6 +25,7 @@ module Datadog
 
         @options: options
         @integrations: ::Array[Integration]
+        @configured: Set[Symbol]
 
         def enabled: () -> bool
         def ruleset: () -> (::Symbol | ::String | ::Hash[::String, untyped] | ::File | ::StringIO)
@@ -35,6 +36,7 @@ module Datadog
         def trace_rate_limit: () -> ::Integer
         def obfuscator_key_regex: () -> ::String
         def obfuscator_value_regex: () -> ::String
+        def default?: (Symbol option) -> bool
 
         def []: (::Symbol integration_name) -> options
 

--- a/sig/datadog/appsec/configuration/settings.rbs
+++ b/sig/datadog/appsec/configuration/settings.rbs
@@ -36,13 +36,14 @@ module Datadog
         def trace_rate_limit: () -> ::Integer
         def obfuscator_key_regex: () -> ::String
         def obfuscator_value_regex: () -> ::String
-        def default?: (Symbol option) -> bool
 
         def []: (::Symbol integration_name) -> options
 
         def merge: (DSL) -> Settings
 
         private
+
+        def default?: (Symbol option) -> bool
 
         def reset!: () -> void
       end

--- a/spec/datadog/appsec/configuration/settings_spec.rb
+++ b/spec/datadog/appsec/configuration/settings_spec.rb
@@ -143,14 +143,11 @@ RSpec.describe Datadog::AppSec::Configuration::Settings do
     end
 
     context 'with env vars' do
-      before do
-        stub_const('ENV', {})
-        allow(ENV).to receive(:[]).and_call_original
-      end
-
       describe 'DD_APPSEC_ENABLED' do
-        before do
-          allow(ENV).to receive(:[]).with('DD_APPSEC_ENABLED').and_return('1')
+        around do |example|
+          ClimateControl.modify('DD_APPSEC_ENABLED' => '1') do
+            example.run
+          end
         end
 
         describe '#enabled' do
@@ -165,8 +162,10 @@ RSpec.describe Datadog::AppSec::Configuration::Settings do
       end
 
       describe 'DD_APPSEC_RULES' do
-        before do
-          allow(ENV).to receive(:[]).with('DD_APPSEC_RULES').and_return('/some/path')
+        around do |example|
+          ClimateControl.modify('DD_APPSEC_RULES' => '/some/path') do
+            example.run
+          end
         end
 
         describe '#ruleset' do
@@ -181,8 +180,10 @@ RSpec.describe Datadog::AppSec::Configuration::Settings do
       end
 
       describe 'DD_APPSEC_WAF_TIMEOUT' do
-        before do
-          allow(ENV).to receive(:[]).with('DD_APPSEC_WAF_TIMEOUT').and_return('42')
+        around do |example|
+          ClimateControl.modify('DD_APPSEC_WAF_TIMEOUT' => '42') do
+            example.run
+          end
         end
 
         describe '#waf_timeout' do
@@ -197,8 +198,10 @@ RSpec.describe Datadog::AppSec::Configuration::Settings do
       end
 
       describe 'DD_APPSEC_WAF_DEBUG' do
-        before do
-          allow(ENV).to receive(:[]).with('DD_APPSEC_WAF_DEBUG').and_return('1')
+        around do |example|
+          ClimateControl.modify('DD_APPSEC_WAF_DEBUG' => '1') do
+            example.run
+          end
         end
 
         describe '#waf_debug' do
@@ -213,8 +216,10 @@ RSpec.describe Datadog::AppSec::Configuration::Settings do
       end
 
       describe 'DD_APPSEC_TRACE_RATE_LIMIT' do
-        before do
-          allow(ENV).to receive(:[]).with('DD_APPSEC_TRACE_RATE_LIMIT').and_return('1024')
+        around do |example|
+          ClimateControl.modify('DD_APPSEC_TRACE_RATE_LIMIT' => '1024') do
+            example.run
+          end
         end
 
         describe '#trace_rate_limit' do
@@ -229,8 +234,10 @@ RSpec.describe Datadog::AppSec::Configuration::Settings do
       end
 
       describe 'DD_APPSEC_OBFUSCATION_PARAMETER_KEY_REGEXP' do
-        before do
-          allow(ENV).to receive(:[]).with('DD_APPSEC_OBFUSCATION_PARAMETER_KEY_REGEXP').and_return('bar')
+        around do |example|
+          ClimateControl.modify('DD_APPSEC_OBFUSCATION_PARAMETER_KEY_REGEXP' => 'bar') do
+            example.run
+          end
         end
 
         describe '#obfuscator_key_regex' do
@@ -245,8 +252,10 @@ RSpec.describe Datadog::AppSec::Configuration::Settings do
       end
 
       describe 'DD_APPSEC_OBFUSCATION_PARAMETER_VALUE_REGEXP' do
-        before do
-          allow(ENV).to receive(:[]).with('DD_APPSEC_OBFUSCATION_PARAMETER_VALUE_REGEXP').and_return('bar')
+        around do |example|
+          ClimateControl.modify('DD_APPSEC_OBFUSCATION_PARAMETER_VALUE_REGEXP' => 'bar') do
+            example.run
+          end
         end
 
         describe '#obfuscator_value_regex' do
@@ -262,8 +271,10 @@ RSpec.describe Datadog::AppSec::Configuration::Settings do
 
       describe '#default?' do
         context 'when the configuration option is configured via ENV var' do
-          before do
-            allow(ENV).to receive(:[]).with('DD_APPSEC_ENABLED').and_return('1')
+          around do |example|
+            ClimateControl.modify('DD_APPSEC_ENABLED' => '1') do
+              example.run
+            end
           end
 
           it 'return false' do

--- a/spec/datadog/appsec/configuration/settings_spec.rb
+++ b/spec/datadog/appsec/configuration/settings_spec.rb
@@ -259,6 +259,34 @@ RSpec.describe Datadog::AppSec::Configuration::Settings do
           it { expect { obfuscator_value_regex_ }.to change { settings.obfuscator_value_regex }.from('bar').to('baz') }
         end
       end
+
+      describe '#default?' do
+        context 'when the configuration option is configured via ENV var' do
+          before do
+            allow(ENV).to receive(:[]).with('DD_APPSEC_ENABLED').and_return('1')
+          end
+
+          it 'return false' do
+            expect(settings.default?(:enabled)).to eq(false)
+          end
+        end
+
+        context 'when the configuration option is configured via merge' do
+          before do
+            settings.merge(dsl.tap { |c| c.enabled = true })
+          end
+
+          it 'returns false' do
+            expect(settings.default?(:enabled)).to eq(false)
+          end
+        end
+
+        context 'when the configuration option is not configured' do
+          it 'returns true' do
+            expect(settings.default?(:enabled)).to eq(true)
+          end
+        end
+      end
     end
   end
 end

--- a/spec/datadog/appsec/configuration/settings_spec.rb
+++ b/spec/datadog/appsec/configuration/settings_spec.rb
@@ -277,8 +277,8 @@ RSpec.describe Datadog::AppSec::Configuration::Settings do
             end
           end
 
-          it 'return false' do
-            expect(settings.default?(:enabled)).to eq(false)
+          it 'returns false' do
+            expect(settings.send(:default?, :enabled)).to eq(false)
           end
         end
 
@@ -288,13 +288,13 @@ RSpec.describe Datadog::AppSec::Configuration::Settings do
           end
 
           it 'returns false' do
-            expect(settings.default?(:enabled)).to eq(false)
+            expect(settings.send(:default?, :enabled)).to eq(false)
           end
         end
 
         context 'when the configuration option is not configured' do
           it 'returns true' do
-            expect(settings.default?(:enabled)).to eq(true)
+            expect(settings.send(:default?, :enabled)).to eq(true)
           end
         end
       end

--- a/spec/datadog/appsec/configuration/settings_spec.rb
+++ b/spec/datadog/appsec/configuration/settings_spec.rb
@@ -32,12 +32,12 @@ RSpec.describe Datadog::AppSec::Configuration::Settings do
 
     describe '#enabled' do
       subject(:enabled) { settings.enabled }
-      it { is_expected.to eq(true) }
+      it { is_expected.to eq(false) }
     end
 
     describe '#enabled=' do
-      subject(:enabled_) { settings.merge(dsl.tap { |c| c.enabled = false }) }
-      it { expect { enabled_ }.to change { settings.enabled }.from(true).to(false) }
+      subject(:enabled_) { settings.merge(dsl.tap { |c| c.enabled = true }) }
+      it { expect { enabled_ }.to change { settings.enabled }.from(false).to(true) }
     end
 
     describe '#ruleset' do

--- a/spec/datadog/appsec/extensions_spec.rb
+++ b/spec/datadog/appsec/extensions_spec.rb
@@ -1,4 +1,6 @@
-require 'datadog/appsec/spec_helper'
+# frozen_string_literal: true
+
+require 'spec_helper'
 
 RSpec.describe Datadog::AppSec::Extensions do
   shared_context 'registry with integration' do
@@ -31,19 +33,18 @@ RSpec.describe Datadog::AppSec::Extensions do
           subject(:configure) { described_class.configure(&block) }
 
           context 'that calls #instrument for an integration' do
-            let(:block) { proc { |c| c.appsec.instrument integration_name } }
+            let(:block) do
+              proc do |c|
+                c.appsec.enabled = true
+                c.appsec.instrument integration_name
+              end
+            end
 
             it 'configures the integration' do
               # If integration_class.loaded? is invoked, it means the correct integration is being activated.
-              begin
-                old_appsec_enabled = ENV['DD_APPSEC_ENABLED']
-                ENV['DD_APPSEC_ENABLED'] = 'true'
-                expect(integration_class).to receive(:loaded?).and_return(false)
+              expect(integration_class).to receive(:loaded?).and_return(false)
 
-                configure
-              ensure
-                ENV['DD_APPSEC_ENABLED'] = old_appsec_enabled
-              end
+              configure
             end
           end
         end
@@ -59,12 +60,12 @@ RSpec.describe Datadog::AppSec::Extensions do
 
       describe '#enabled' do
         subject(:enabled) { settings.enabled }
-        it { is_expected.to eq(true) }
+        it { is_expected.to eq(false) }
       end
 
       describe '#enabled=' do
-        subject(:enabled_) { settings.enabled = false }
-        it { expect { enabled_ }.to change { settings.enabled }.from(true).to(false) }
+        subject(:enabled_) { settings.enabled = true }
+        it { expect { enabled_ }.to change { settings.enabled }.from(false).to(true) }
       end
 
       describe '#ruleset' do

--- a/spec/datadog/appsec/extensions_spec.rb
+++ b/spec/datadog/appsec/extensions_spec.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-require 'spec_helper'
+require 'datadog/appsec/spec_helper'
 
 RSpec.describe Datadog::AppSec::Extensions do
   shared_context 'registry with integration' do

--- a/spec/datadog/appsec/spec_helper.rb
+++ b/spec/datadog/appsec/spec_helper.rb
@@ -1,11 +1,3 @@
 require 'ddtrace'
 require 'datadog/appsec'
 require 'spec_helper'
-
-RSpec.configure do |config|
-  # As AppSec is disabled by default, activate it using the environment variable DD_APPSEC_ENABLED.
-  config.before do
-    allow(ENV).to receive(:[]).and_call_original
-    allow(ENV).to receive(:[]).with('DD_APPSEC_ENABLED').and_return('true')
-  end
-end

--- a/spec/datadog/appsec_spec.rb
+++ b/spec/datadog/appsec_spec.rb
@@ -9,7 +9,7 @@ RSpec.describe Datadog::AppSec do
 
     context 'when the configuration option is not configured' do
       it 'returns true' do
-        expect(described_class.default_setting?(:enabled)).to eq(true)
+        expect(described_class.send(:default_setting?, :enabled)).to eq(true)
       end
     end
 
@@ -18,7 +18,7 @@ RSpec.describe Datadog::AppSec do
         described_class.configure do |c|
           c.enabled = true
         end
-        expect(described_class.default_setting?(:enabled)).to eq(false)
+        expect(described_class.send(:default_setting?, :enabled)).to eq(false)
       end
     end
   end

--- a/spec/datadog/appsec_spec.rb
+++ b/spec/datadog/appsec_spec.rb
@@ -1,6 +1,6 @@
-require 'spec_helper'
+# frozen_string_literal: true
 
-require 'datadog/appsec'
+require 'datadog/appsec/spec_helper'
 
 RSpec.describe Datadog::AppSec do
   describe '#default_setting?' do

--- a/spec/datadog/appsec_spec.rb
+++ b/spec/datadog/appsec_spec.rb
@@ -1,0 +1,25 @@
+require 'spec_helper'
+
+require 'datadog/appsec'
+
+RSpec.describe Datadog::AppSec do
+  describe '#default_setting?' do
+    before { described_class.settings.send(:reset!) }
+    after { described_class.settings.send(:reset!) }
+
+    context 'when the configuration option is not configured' do
+      it 'returns true' do
+        expect(described_class.default_setting?(:enabled)).to eq(true)
+      end
+    end
+
+    context 'when the configuration option is configured ' do
+      it 'returns false' do
+        described_class.configure do |c|
+          c.enabled = true
+        end
+        expect(described_class.default_setting?(:enabled)).to eq(false)
+      end
+    end
+  end
+end


### PR DESCRIPTION
<!--
Check out the
https://github.com/DataDog/dd-trace-rb/blob/master/docs/DevelopmentGuide.md
for guidance on how to set up your development environment,
run the test suite, write new integrations, and more.
-->

**What does this PR do?**
<!-- A brief description of the change being made with this pull request. -->

This PR creates an internal API for `Datadog::AppSec` to query if the customer has configured a setting via the `Datadog.configure` block or via a ENV variable. 

Internally the AppSec module would be able to query that information using `Datadog::AppSec.default_setting?`

**Motivation**
<!-- What inspired you to submit this pull request? -->

For enabling remote configuration, we need to make sure the customer hasn't set a ruleset option manually. Currently, we can only check for the existence of the ENV variable `DD_APPSEC_RULES`, but that is not enough. We also need to know if the `appsec.ruleset` has been set manually vi the customer. 

This new internal API would be use [here](https://github.com/DataDog/dd-trace-rb/pull/2733/files#diff-af9353ccefa8c307f715dae7907301f1b04a6a2d05b2a20b841a0af6dc5199a7R105-R112) 

**Additional Notes**
<!-- Anything else we should know when reviewing? -->

Example:

```
Datadog.configure do |c|
  c.appsec.enabled = true
  c.appsec.ruleset = :strict
end

Datadog::AppSec.default_setting?(:ruleset) #=> false
Datadog::AppSec.default_setting?(:enabled) #=> false
Datadog::AppSec.default_setting?(:obfuscator_value_regex) #=> true
```

**How to test the change?**
<!--
Describe here how the change can be validated.
You are strongly encouraged to provide automated tests for this PR (unit or integration).
If this change cannot be feasibly tested, please explain why,
unless the change does not modify code (e.g. only modifies docs, comments).
-->

CI 
