### PR TITLE
[PROF-7409] Do not auto-enable new profiler when rugged gem is detected

### DIFF
--- a/lib/datadog/profiling/component.rb
+++ b/lib/datadog/profiling/component.rb
@@ -172,8 +172,19 @@ module Datadog
             'library used by the mysql2 gem) have a bug in their signal handling code that the new profiler can trigger. ' \
             'This bug (https://bugs.mysql.com/bug.php?id=83109) is fixed in libmysqlclient versions 8.0.0 and above. ' \
             'If your Linux distribution provides a modern libmysqlclient, you can force-enable the new CPU Profiling 2.0 ' \
-            'profiler by using the `DD_PROFILING_FORCE_ENABLE_NEW` or `c.profiling.advanced.force_enable_new_profiler` ' \
-            'settings.'
+            'profiler by using the `DD_PROFILING_FORCE_ENABLE_NEW` environment variable or the ' \
+            '`c.profiling.advanced.force_enable_new_profiler` setting.' \
+          )
+          return false
+        end
+
+        if Gem.loaded_specs['rugged']
+          Datadog.logger.warn(
+            'Falling back to legacy profiler because rugged gem is installed. Some operations on this gem are ' \
+            'currently incompatible with the new CPU Profiling 2.0 profiler, as detailed in ' \
+            '<https://github.com/datadog/dd-trace-rb/issues/2721>. If you still want to try out the new profiler, you ' \
+            'can force-enable it by using the `DD_PROFILING_FORCE_ENABLE_NEW` environment variable or the ' \
+            '`c.profiling.advanced.force_enable_new_profiler` setting.'
           )
           return false
         end

--- a/spec/datadog/profiling/component_spec.rb
+++ b/spec/datadog/profiling/component_spec.rb
@@ -402,8 +402,28 @@ RSpec.describe Datadog::Profiling::Component do
           end
         end
 
-        context 'when mysql2 gem is not available' do
-          include_context 'loaded gems', :mysql2 => nil
+        context 'when rugged gem is available' do
+          include_context 'loaded gems', :rugged => Gem::Version.new('1.6.3')
+
+          before { allow(Datadog.logger).to receive(:warn) }
+
+          it { is_expected.to be false }
+
+          it 'logs a warning message mentioning that the legacy profiler is going to be used' do
+            expect(Datadog.logger).to receive(:warn).with(/Falling back to legacy profiler/)
+
+            enable_new_profiler?
+          end
+
+          context 'when force_enable_new_profiler is enabled' do
+            before { settings.profiling.advanced.force_enable_new_profiler = true }
+
+            it { is_expected.to be true }
+          end
+        end
+
+        context 'when mysql2 / rugged gem are not available' do
+          include_context('loaded gems', mysql2: nil, rugged: nil)
 
           it { is_expected.to be true }
         end


### PR DESCRIPTION
**What does this PR do?**:

This PR adds the `rugged` gem to the list of gems that prevent the new CPU Profiling 2.0 profiler from being auto-enabled.

This is needed because the `rugged` gem (more specifically, its C-level dependencies) do not correctly handle the unix signals that the new profiler uses.

We plan to do more than just add this workaround, but until we do so, this change will prevent customers from being bitten by the issue.

**Motivation**:

Make sure that customers being moved to the new CPU Profiling 2.0 profiler have a smooth experience.

**Additional Notes**:

N/A

**How to test the change?**:

The snippet shared by the customer in <https://github.com/DataDog/dd-trace-rb/issues/2721> reproduces the issue for me every time.

With this change, as expected, the issue no longer appears.
