### PR TITLE
Tag known leaky Timeout internal thread

### DIFF
--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -288,10 +288,12 @@ end
 # Helper matchers
 RSpec::Matchers.define_negated_matcher :not_be, :be
 
-# The Ruby Timeout class uses a long-lived class-level thread that is never terminated.
-# Creating it early here ensures tests that tests that check for leaking threads are not
-# triggered by the creation of this thread.
-#
-# This has to be one once for the lifetime of this process, and was introduced in Ruby 3.1.
-# Before 3.1, a thread was created and destroyed on every Timeout#timeout call.
-Timeout.ensure_timeout_thread_created if Timeout.respond_to?(:ensure_timeout_thread_created)
+ThreadHelpers.with_leaky_thread_creation("Timeout's internal thread") do
+  # The Ruby Timeout class uses a long-lived class-level thread that is never terminated.
+  # Creating it early here ensures tests that tests that check for leaking threads are not
+  # triggered by the creation of this thread.
+  #
+  # This has to be one once for the lifetime of this process, and was introduced in Ruby 3.1.
+  # Before 3.1, a thread was created and destroyed on every Timeout#timeout call.
+  Timeout.ensure_timeout_thread_created if Timeout.respond_to?(:ensure_timeout_thread_created)
+end


### PR DESCRIPTION
This PR tags `Timeout.ensure_timeout_thread_created` as a known leaky thread: this one is created internally by the `Timeout` class.

This ensures this `Timeout` thread is not reported as a leaky thread from `ddtrace`.