### PR TITLE
Doc:Publish YARD docs to GitHub pages

### DIFF
--- a/.github/workflows/yard.yml
+++ b/.github/workflows/yard.yml
@@ -1,0 +1,46 @@
+name: Deploy Yard documentation to Pages
+
+on:
+  push:
+    branches: ["release"]
+
+  # Allows you to run this workflow manually from the Actions tab
+  workflow_dispatch:
+
+# Sets permissions of the GITHUB_TOKEN to allow deployment to GitHub Pages
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+# Allow only one concurrent deployment, skipping runs queued between the run in-progress and latest queued.
+# However, do NOT cancel in-progress runs as we want to allow these production deployments to complete.
+concurrency:
+  group: "pages"
+  cancel-in-progress: false
+
+jobs:
+  deploy:
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+      - uses: ruby/setup-ruby@v1
+        with:
+          ruby-version: '3.2'
+          bundler-cache: true
+      - name: Generate YARD documentation
+        run: bundle exec rake docs
+      - name: Setup Pages
+        uses: actions/configure-pages@v3
+      - name: Upload artifact
+        uses: actions/upload-pages-artifact@v1
+        with:
+          # Upload generated YARD directory
+          path: 'doc/'
+      - name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@v2

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 [![Gem](https://img.shields.io/gem/v/ddtrace)](https://rubygems.org/gems/ddtrace/)
 [![CircleCI](https://circleci.com/gh/DataDog/dd-trace-rb/tree/master.svg?style=svg&circle-token=b0bd5ef866ec7f7b018f48731bb495f2d1372cc1)](https://circleci.com/gh/DataDog/dd-trace-rb/tree/master)
 [![codecov](https://codecov.io/gh/DataDog/dd-trace-rb/branch/master/graph/badge.svg)](https://app.codecov.io/gh/DataDog/dd-trace-rb/branch/master)
-[![YARD documentation](https://img.shields.io/badge/YARD-documentation-blue)](https://s3.amazonaws.com/gems.datadoghq.com/trace/docs/index.html)
+[![YARD documentation](https://img.shields.io/badge/YARD-documentation-blue)][api docs]
 
 ``ddtrace`` is Datadog’s tracing client for Ruby. It is used to trace requests as they flow across web servers,
 databases and microservices so that developers have great visiblity into bottlenecks and troublesome requests.
@@ -22,7 +22,7 @@ For contributing, checkout the [contribution guidelines][contribution docs] and 
 
 [setup docs]: https://docs.datadoghq.com/tracing/setup/ruby/
 [api docs]: https://github.com/DataDog/dd-trace-rb/blob/master/docs/GettingStarted.md
-[gem docs]: https://s3.amazonaws.com/gems.datadoghq.com/trace/docs/index.html
+[gem docs]: https://datadog.github.io/dd-trace-rb/
 [visualization docs]: https://docs.datadoghq.com/tracing/visualization/
 [contribution docs]: https://github.com/DataDog/dd-trace-rb/blob/master/CONTRIBUTING.md
 [development docs]: https://github.com/DataDog/dd-trace-rb/blob/master/docs/DevelopmentGuide.md


### PR DESCRIPTION
This PR publishes `ddtrace` YARD docs to this repository's GitHub page: https://datadog.github.io/dd-trace-rb/ (currently not published).

This is done by a  GitHub Action that runs on pushes to the `release` branch, which is the branch we use to publish documentation to our official website.

Here's the published page from my personal repository, using the same `yard.yml` GitHub Action from this PR: https://marcotc.github.io/dd-trace-rb/