### PR TITLE
make sure ThreadHelpers.with_leaky_thread_creation is available when called

### DIFF
--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -254,10 +254,9 @@ end
 
 Thread.prepend(DatadogThreadDebugger)
 
+require 'spec/support/thread_helpers'
 # Enforce test time limit, to allow us to debug why some test runs get stuck in CI
 if ENV.key?('CI')
-  require 'spec/support/thread_helpers'
-
   ThreadHelpers.with_leaky_thread_creation('Deadline thread') do
     Thread.new do
       Thread.current.name = 'spec_helper.rb CI debugging Deadline thread' unless RUBY_VERSION.start_with?('2.1.', '2.2.')


### PR DESCRIPTION
Following the work of @marcotc on https://github.com/DataDog/dd-trace-rb/pull/2742

After pulling the latest master, I noticed that when executing the tests with `ENV['CI']` we would get an error:
![image](https://user-images.githubusercontent.com/4672858/229857450-0daca8d6-3524-4533-a812-dc9a1f8962b7.png)

I fixed the `require` issue. The leak thread detection still reports the thread created within `Timeout.ensure_timeout_thread_created`. I would like to investigate more on that, but for now I think fixing running specs locally is more important 