### PR TITLE
Fix using SemanticLogger#log(severity, message, progname)

### DIFF
--- a/lib/datadog/tracing/contrib/semantic_logger/instrumentation.rb
+++ b/lib/datadog/tracing/contrib/semantic_logger/instrumentation.rb
@@ -14,6 +14,7 @@ module Datadog
           module InstanceMethods
             def log(log, message = nil, progname = nil, &block)
               return super unless Datadog.configuration.tracing[:semantic_logger].enabled
+              return super unless log.is_a?(::SemanticLogger::Log)
 
               original_named_tags = log.named_tags || {}
 

--- a/spec/datadog/tracing/contrib/semantic_logger/instrumentation_spec.rb
+++ b/spec/datadog/tracing/contrib/semantic_logger/instrumentation_spec.rb
@@ -66,5 +66,38 @@ RSpec.describe Datadog::Tracing::Contrib::SemanticLogger::Instrumentation do
 
       log
     end
+
+    context 'when log in Logger compatible mode' do
+      subject(:log) do
+        ThreadHelpers.with_leaky_thread_creation('semantic_logger log_compatible') do
+          instrumented.log(::Logger::INFO, 'test')
+        end
+      end
+
+      it 'merges correlation data with original options' do
+        assertion = proc do |event|
+          expect(event.named_tags).to eq(
+            { dd: {
+                env: 'env',
+                service: 'service',
+                span_id: span_id.to_s,
+                trace_id: trace_id.to_s,
+                version: 'version'
+              },
+              ddsource: 'ruby' }
+          )
+        end
+
+        if SemanticLogger::Logger.respond_to?(:call_subscribers)
+          expect(SemanticLogger::Logger).to receive(:call_subscribers, &assertion) # semantic_logger >= 4.4.0
+        else
+          ThreadHelpers.with_leaky_thread_creation('semantic_logger processor') do
+            expect(SemanticLogger::Processor).to receive(:<<, &assertion) # semantic_logger < 4.4.0
+          end
+        end
+
+        log
+      end
+    end
   end
 end


### PR DESCRIPTION
`SemanticLogger` provides interface which is fully compatible with `Logger` interface
It is possible to use `SemanticLogger#add` and `SemanticLogger#log` instance methods on `SemanticLogger` as it would be just plain `Logger`
Datadog instrumentation doesn't expect that first argument in method `#log` might be not `SemanticLogger::Log` but severity level like `Logger::WARN` as result fails with error `NoMethodError: undefined method 'named_tags' for 2:Integer`.

Originally met issue in Rails project, here is specs:
- rails 6.1.7.3
- rails_semantic_logger 4.12.0 
- semantic_logger 4.13.0
- ddtrace 1.4.2

When have configuration for datadog:
```ruby
Datadog.configure do |conf|
  conf.env = Rails.env
  conf.service = 'my_service'
  conf.tracing.instrument :rails
  conf.tracing.sampling.default_rate = 1.0
end
```

When have enabled `:rails' instrumentation, ':semantic_logger` added right away as there is `SemanticLogger` on project.
Real case scenario is that on project there might be some external gems that may allow to provide logger as part of it's configuration, but may work with logger as it's plain ruby's `Logger` and use `#add` or `#log` methods. 
In case of using `#log` it causes failure because instrumentation prepended and there is no safeguard on first argument `log`

Example to reproduce having rails with setup `datadog` to instrument `rails` and `semantic_logger` installed:
```ruby
SemanticLogger['MyService'].log(Logger::WARN, 'some warn')
```
