### PR TITLE
Set libddwaf timeout to a high value for AppSec specs

### DIFF
--- a/spec/datadog/appsec/contrib/rack/integration_test_spec.rb
+++ b/spec/datadog/appsec/contrib/rack/integration_test_spec.rb
@@ -130,6 +130,7 @@ RSpec.describe 'Rack integration tests' do
       c.tracing.instrument :rack
 
       c.appsec.enabled = appsec_enabled
+      c.appsec.waf_timeout = 10_000_000 # in us
       c.appsec.instrument :rack
       c.appsec.ip_denylist = appsec_ip_denylist
       c.appsec.user_id_denylist = appsec_user_id_denylist

--- a/spec/datadog/appsec/contrib/rails/integration_test_spec.rb
+++ b/spec/datadog/appsec/contrib/rails/integration_test_spec.rb
@@ -86,6 +86,7 @@ RSpec.describe 'Rails integration tests' do
       c.tracing.instrument :rails
 
       c.appsec.enabled = appsec_enabled
+      c.appsec.waf_timeout = 10_000_000 # in us
       c.appsec.instrument :rails
       c.appsec.ip_denylist = appsec_ip_denylist
       c.appsec.user_id_denylist = appsec_user_id_denylist

--- a/spec/datadog/appsec/contrib/sinatra/integration_test_spec.rb
+++ b/spec/datadog/appsec/contrib/sinatra/integration_test_spec.rb
@@ -98,6 +98,7 @@ RSpec.describe 'Sinatra integration tests' do
       c.tracing.instrument :sinatra
 
       c.appsec.enabled = appsec_enabled
+      c.appsec.waf_timeout = 10_000_000 # in us
       c.appsec.instrument :sinatra
       c.appsec.ip_denylist = appsec_ip_denylist
       c.appsec.user_id_denylist = appsec_user_id_denylist


### PR DESCRIPTION


<!--
Check out the
https://github.com/DataDog/dd-trace-rb/blob/master/docs/DevelopmentGuide.md
for guidance on how to set up your development environment,
run the test suite, write new integrations, and more.
-->

**What does this PR do?**

Set libddwaf timeout to a high value for AppSec specs

**Motivation**

This removes a frequent cause of flakiness

**Additional Notes**

For these test cases we want libddwaf to always run to completion. 10s per request should be enough!

**How to test the change?**

CI should be green. Hopefully it removes most of the flakiness, which can only be observed over time.
