### PR TITLE
Check info endpoint for remote configuration availability in the agent

### DIFF
--- a/lib/datadog/core/remote/component.rb
+++ b/lib/datadog/core/remote/component.rb
@@ -20,28 +20,6 @@ module Datadog
           transport_options = {}
           transport_options[:agent_settings] = agent_settings if agent_settings
 
-          transport_root = Datadog::Core::Transport::HTTP.root(**transport_options.dup)
-
-          res = transport_root.send_info
-          if res.ok?
-            if res.endpoints.include?('/v0.7/config')
-              Datadog.logger.debug { 'agent reachable and reports remote configuration endpoint' }
-            else
-              Datadog.logger.error do
-                'agent reachable but does not report remote configuration endpoint: ' \
-                  'disabling remote configuration for this process.'
-              end
-
-              return
-            end
-          else
-            Datadog.logger.error do
-              'agent unreachable: disabling remote configuration for this process.'
-            end
-
-            return
-          end
-
           transport_v7 = Datadog::Core::Transport::HTTP.v7(**transport_options.dup)
 
           capabilities = Client::Capabilities.new(settings)
@@ -137,6 +115,31 @@ module Datadog
         class << self
           def build(settings, agent_settings)
             return unless settings.remote.enabled
+
+            transport_options = {}
+            transport_options[:agent_settings] = agent_settings if agent_settings
+
+            transport_root = Datadog::Core::Transport::HTTP.root(**transport_options.dup)
+
+            res = transport_root.send_info
+            if res.ok?
+              if res.endpoints.include?('/v0.7/config')
+                Datadog.logger.debug { 'agent reachable and reports remote configuration endpoint' }
+              else
+                Datadog.logger.error do
+                  'agent reachable but does not report remote configuration endpoint: ' \
+                    'disabling remote configuration for this process.'
+                end
+
+                return
+              end
+            else
+              Datadog.logger.error do
+                'agent unreachable: disabling remote configuration for this process.'
+              end
+
+              return
+            end
 
             new(settings, agent_settings)
           end


### PR DESCRIPTION
<!--
Check out the
https://github.com/DataDog/dd-trace-rb/blob/master/docs/DevelopmentGuide.md
for guidance on how to set up your development environment,
run the test suite, write new integrations, and more.
-->

**What does this PR do?**

Check info endpoint for remote configuration availability in the agent

**Motivation**

RC should not even start if the agent is unreachable or not configured properly.

**Additional Notes**

This should also warn the user so that corrective action can be taken self-served.

**How to test the change?**

Either one of:

- Do not start agent
- Start agent without `DD_REMOTE_CONFIGURATION_ENABLED=false` env var

And then start an app with `DD_REMOTE_CONFIGURATION_ENABLED=true`