### PR TITLE
fix: Correctly set mutex

### DIFF
--- a/lib/datadog/core/workers/async.rb
+++ b/lib/datadog/core/workers/async.rb
@@ -11,6 +11,10 @@ module Datadog
           FORK_POLICY_RESTART = :restart
           SHUTDOWN_TIMEOUT = 1
 
+          # This single shared mutex is used to avoid concurrency issues during the
+          # initialization of per-instance lazy-initialized mutexes.
+          MUTEX_INIT = Mutex.new
+
           def self.included(base)
             base.prepend(PrependedMethods)
           end
@@ -86,7 +90,7 @@ module Datadog
             :result
 
           def mutex
-            @mutex ||= Mutex.new
+            @mutex || MUTEX_INIT.synchronize { @mutex ||= Mutex.new }
           end
 
           def after_fork
@@ -99,7 +103,7 @@ module Datadog
             :pid
 
           def mutex_after_fork
-            @mutex_after_fork ||= Mutex.new
+            @mutex_after_fork || MUTEX_INIT.synchronize { @mutex_after_fork ||= Mutex.new }
           end
 
           def worker

--- a/lib/datadog/core/workers/interval_loop.rb
+++ b/lib/datadog/core/workers/interval_loop.rb
@@ -10,6 +10,10 @@ module Datadog
         BACK_OFF_MAX = 5
         BASE_INTERVAL = 1
 
+        # This single shared mutex is used to avoid concurrency issues during the
+        # initialization of per-instance lazy-initialized mutexes.
+        MUTEX_INIT = Mutex.new
+
         def self.included(base)
           base.prepend(PrependedMethods)
         end
@@ -82,7 +86,7 @@ module Datadog
           :loop_base_interval
 
         def mutex
-          @mutex ||= Mutex.new
+          @mutex || MUTEX_INIT.synchronize { @mutex ||= Mutex.new }
         end
 
         private


### PR DESCRIPTION
**What does this PR do?**

Fixes Mutex assignment to be thread-safe.

**Motivation**

Tried to find what might be causing https://github.com/DataDog/dd-trace-rb/issues/2045 and found (unfortunately unrelated) but somewhat problematic code. We've tried this patch in production, unfortunately as I said, it's not fixing #2045, but still worth fixing.

**Additional Notes**

This is a simple demo, why `@mutex ||= Mutex.new` is a bad idea. Save the below ruby script as `demo.rb`:

``` ruby
    module BeforePatch
      def mutex
        @mutex ||= Mutex.new
      end
    end

    module AfterPatch
      def self.included(base)
        base.prepend(PrependMethods)
      end

      module PrependMethods
        def initialize(...)
          @mutex = Mutex.new
          super(...)
        end

        attr_reader :mutex
      end
    end

    class Demo
      include(ENV["FIXED"] ? AfterPatch : BeforePatch)
    end

    demo    = Demo.new
    results = []
    workers = Array.new(32) do
      Thread.new do
        results << demo.mutex.object_id
      end
    end

    workers.each(&:join)
    puts results.tally
```

Run:

``` bash
    while true; do ruby demo.rb; done
```

At some point you will see that there are more than one mutex. Now, run:

``` bash
    while true; do FIXED=1 ruby demo.rb; done
```

There should be no such issue.

**How to test the change?**

It's not very feasible to automatically test this. But the change is small enough.