### PR TITLE
Temporarily disable flaky profiler spec

### DIFF
--- a/spec/datadog/profiling/collectors/cpu_and_wall_time_worker_spec.rb
+++ b/spec/datadog/profiling/collectors/cpu_and_wall_time_worker_spec.rb
@@ -341,6 +341,8 @@ RSpec.describe Datadog::Profiling::Collectors::CpuAndWallTimeWorker do
       before { expect(Datadog.logger).to receive(:warn).with(/dynamic sampling rate disabled/) }
 
       it 'is able to sample even when all threads are sleeping' do
+        skip('Test is flaky -- @ivoanjo is investigating')
+
         start
         wait_until_running
 


### PR DESCRIPTION
**What does this PR do?**:

This PR disables a profiler spec that is flaky, as seen in these recent test runs:

* <https://app.circleci.com/pipelines/github/DataDog/dd-trace-rb/9486/workflows/2fa85a35-19c0-4bdf-ac66-4a872080f7ab/jobs/352689>
* <https://app.circleci.com/pipelines/github/DataDog/dd-trace-rb/9471/workflows/cb7224c5-2896-415c-a1fd-b0c64eacb953/jobs/352129>
* <https://app.circleci.com/pipelines/github/DataDog/dd-trace-rb/9677/workflows/9ddbbdfc-3a2f-40b9-8076-6b6a47a34d1f/jobs/359559>

**Motivation**:

Make sure there are no flaky tests in our test suite.

**Additional Notes**:

I still plan to gather additional information on what is causing this flakiness; it's not clear to me what's happening with the current output. But until I do so, let's stop annoying everyone else.

In particular, this test is very similar to the
"when main thread is sleeping but a background thread is working" "it is able to sample even when the main thread is sleeping" and yet that other test has not been causing the same flakiness.

I wonder if VM is taking an opportunity to GC while the Ruby app is idle, thus not allowing us to sample as much as we intended.

To be investigated.

**How to test the change?**:

Verify that RSpec skips the test.
