### PR TITLE
Test:Enable Telemetry system-test

### DIFF
--- a/.github/workflows/system-tests.yml
+++ b/.github/workflows/system-tests.yml
@@ -174,6 +174,18 @@ jobs:
           - library: ruby
             app: rack
             scenario: PROFILING
+          - library: ruby
+            app: rack
+            scenario: TELEMETRY_APP_STARTED_PRODUCTS_DISABLED
+          - library: ruby
+            app: rack
+            scenario: TELEMETRY_DEPENDENCY_LOADED_TEST_FOR_DEPENDENCY_COLLECTION_DISABLED
+          - library: ruby
+            app: rack
+            scenario: TELEMETRY_LOG_GENERATION_DISABLED
+          - library: ruby
+            app: rack
+            scenario: TELEMETRY_METRIC_GENERATION_DISABLED
     runs-on: ubuntu-latest
     needs:
       - build-harness


### PR DESCRIPTION
This PR enables Telemetry test scenarios from `system-tests` to run on `dd-trace-rb` commits.

The scenarios are all currently passing with an XPASS status: they can't be fully enabled because telemetry changes to make them pass are not yet released in a public version of `ddtrace`.