### PR TITLE
Update Gem version requirements for some older libraries

### DIFF
--- a/lib/datadog/tracing/contrib/dalli/integration.rb
+++ b/lib/datadog/tracing/contrib/dalli/integration.rb
@@ -10,7 +10,7 @@ module Datadog
         class Integration
           include Contrib::Integration
 
-          MINIMUM_VERSION = Gem::Version.new('2.0.0')
+          MINIMUM_VERSION = Gem::Version.new('1.0.0')
           DALLI_PROTOCOL_BINARY_VERSION = Gem::Version.new('3.0.0')
 
           # @public_api Changing the integration name or integration options can cause breaking changes

--- a/lib/datadog/tracing/contrib/ethon/integration.rb
+++ b/lib/datadog/tracing/contrib/ethon/integration.rb
@@ -11,7 +11,7 @@ module Datadog
         class Integration
           include Contrib::Integration
 
-          MINIMUM_VERSION = Gem::Version.new('0.11.0')
+          MINIMUM_VERSION = Gem::Version.new('0.9.0')
 
           # @public_api Changing the integration name or integration options can cause breaking changes
           register_as :ethon

--- a/lib/datadog/tracing/contrib/faraday/integration.rb
+++ b/lib/datadog/tracing/contrib/faraday/integration.rb
@@ -11,7 +11,7 @@ module Datadog
         class Integration
           include Contrib::Integration
 
-          MINIMUM_VERSION = Gem::Version.new('0.14.0')
+          MINIMUM_VERSION = Gem::Version.new('0.9.0')
 
           # @public_api Changing the integration name or integration options can cause breaking changes
           register_as :faraday, auto_patch: true

--- a/lib/datadog/tracing/contrib/rake/integration.rb
+++ b/lib/datadog/tracing/contrib/rake/integration.rb
@@ -10,7 +10,7 @@ module Datadog
         class Integration
           include Contrib::Integration
 
-          MINIMUM_VERSION = Gem::Version.new('12.0')
+          MINIMUM_VERSION = Gem::Version.new('10.0')
 
           # @public_api Changing the integration name or integration options can cause breaking changes
           register_as :rake


### PR DESCRIPTION
**What does this PR do?**
<!-- A brief description of the change being made with this pull request. -->

This PR updates the Gem version requirements for a few different libraries we currently use in production. I've tested these integrations locally and they all seem to work, and I've reviewed the changes between the versions currently required and the older versions, and found no major changes.

**Motivation**
<!-- What inspired you to submit this pull request? -->

As part of our Datadog integration for Genius, we went through the list of incompatible Gems detected byauto-instrumentation. I identified these gems as having very minor changes between the currently-incompatible versions we use and the versions requried by Datadog, enabling use them via autoinstrumentation.

**Additional Notes**

I have not tested these changes in production but I have tested them locally and on our staging environment.

I understand if Datadog feels these changes are too risky or represent too much of a breaking change to accept. Open to suggestions on how we can enable these integrations without maintaining our own fork of the ddtracerb gem. 

**How to test the change?**
<!--
Describe here how the change can be validated.
You are strongly encouraged to provide automated tests for this PR (unit or integration).
If this change cannot be feasibly tested, please explain why,
unless the change does not modify code (e.g. only modifies docs, comments).
-->

In theory, the best way to test these changes is to update whatever integration tests already exist for these libraries with the older versions. I haven't looked into that.
