### PR TITLE
Change default `service_name` values Part 2

### DIFF
--- a/lib/datadog/tracing/contrib/active_record/configuration/settings.rb
+++ b/lib/datadog/tracing/contrib/active_record/configuration/settings.rb
@@ -26,7 +26,12 @@ module Datadog
             end
 
             option :service_name do |o|
-              o.default { Utils.adapter_name }
+              o.default do
+                Contrib::SpanAttributeSchema.fetch_service_name(
+                  Ext::ENV_SERVICE_NAME,
+                  Utils.adapter_name
+                )
+              end
               o.lazy
             end
           end

--- a/lib/datadog/tracing/contrib/active_record/configuration/settings.rb
+++ b/lib/datadog/tracing/contrib/active_record/configuration/settings.rb
@@ -28,7 +28,7 @@ module Datadog
             option :service_name do |o|
               o.default do
                 Contrib::SpanAttributeSchema.fetch_service_name(
-                  Ext::ENV_SERVICE_NAME,
+                  "",
                   Utils.adapter_name
                 )
               end

--- a/lib/datadog/tracing/contrib/active_record/configuration/settings.rb
+++ b/lib/datadog/tracing/contrib/active_record/configuration/settings.rb
@@ -28,7 +28,7 @@ module Datadog
             option :service_name do |o|
               o.default do
                 Contrib::SpanAttributeSchema.fetch_service_name(
-                  "",
+                  '',
                   Utils.adapter_name
                 )
               end

--- a/lib/datadog/tracing/contrib/active_record/events/sql.rb
+++ b/lib/datadog/tracing/contrib/active_record/events/sql.rb
@@ -46,9 +46,11 @@ module Datadog
               span.set_tag(Tracing::Metadata::Ext::TAG_OPERATION, Ext::TAG_OPERATION_SQL)
 
               # Tag as an external peer service
-              span.set_tag(Tracing::Metadata::Ext::TAG_PEER_SERVICE, span.service)
-              # TODO: Populate hostname for JDBC connections
-              span.set_tag(Tracing::Metadata::Ext::TAG_PEER_HOSTNAME, config[:host]) if config[:host]
+              if Contrib::SpanAttributeSchema.default_span_attribute_schema?
+                span.set_tag(Tracing::Metadata::Ext::TAG_PEER_SERVICE, span.service)
+                # TODO: Populate hostname for JDBC connections
+                span.set_tag(Tracing::Metadata::Ext::TAG_PEER_HOSTNAME, config[:host]) if config[:host]
+              end
 
               # Set analytics sample rate
               if Contrib::Analytics.enabled?(configuration[:analytics_enabled])

--- a/lib/datadog/tracing/contrib/active_support/cache/instrumentation.rb
+++ b/lib/datadog/tracing/contrib/active_support/cache/instrumentation.rb
@@ -40,8 +40,10 @@ module Datadog
               span.set_tag(Tracing::Metadata::Ext::TAG_COMPONENT, Ext::TAG_COMPONENT)
               span.set_tag(Tracing::Metadata::Ext::TAG_OPERATION, Ext::TAG_OPERATION_CACHE)
 
-              # Tag as an external peer service
-              span.set_tag(Tracing::Metadata::Ext::TAG_PEER_SERVICE, service)
+              if Contrib::SpanAttributeSchema.default_span_attribute_schema?
+                # Tag as an external peer service
+                span.set_tag(Tracing::Metadata::Ext::TAG_PEER_SERVICE, service)
+              end
 
               tracing_context[:dd_cache_span] = span
             rescue StandardError => e

--- a/lib/datadog/tracing/contrib/dalli/configuration/settings.rb
+++ b/lib/datadog/tracing/contrib/dalli/configuration/settings.rb
@@ -25,7 +25,12 @@ module Datadog
             end
 
             option :service_name do |o|
-              o.default { ENV.fetch(Ext::ENV_SERVICE_NAME, Ext::DEFAULT_PEER_SERVICE_NAME) }
+              o.default do
+                Contrib::SpanAttributeSchema.fetch_service_name(
+                  Ext::ENV_SERVICE_NAME,
+                  Ext::DEFAULT_PEER_SERVICE_NAME
+                )
+              end
               o.lazy
             end
           end

--- a/lib/datadog/tracing/contrib/dalli/instrumentation.rb
+++ b/lib/datadog/tracing/contrib/dalli/instrumentation.rb
@@ -28,8 +28,10 @@ module Datadog
                 span.set_tag(Tracing::Metadata::Ext::TAG_OPERATION, Ext::TAG_OPERATION_COMMAND)
 
                 # Tag as an external peer service
-                span.set_tag(Tracing::Metadata::Ext::TAG_PEER_SERVICE, span.service)
-                span.set_tag(Tracing::Metadata::Ext::TAG_PEER_HOSTNAME, hostname)
+                if Contrib::SpanAttributeSchema.default_span_attribute_schema?
+                  span.set_tag(Tracing::Metadata::Ext::TAG_PEER_SERVICE, span.service)
+                  span.set_tag(Tracing::Metadata::Ext::TAG_PEER_HOSTNAME, hostname)
+                end
 
                 # Set analytics sample rate
                 if Contrib::Analytics.enabled?(datadog_configuration[:analytics_enabled])

--- a/lib/datadog/tracing/contrib/elasticsearch/configuration/settings.rb
+++ b/lib/datadog/tracing/contrib/elasticsearch/configuration/settings.rb
@@ -27,7 +27,12 @@ module Datadog
             option :quantize, default: {}
 
             option :service_name do |o|
-              o.default { ENV.fetch(Ext::ENV_SERVICE_NAME, Ext::DEFAULT_PEER_SERVICE_NAME) }
+              o.default do
+                Contrib::SpanAttributeSchema.fetch_service_name(
+                  Ext::ENV_SERVICE_NAME,
+                  Ext::DEFAULT_PEER_SERVICE_NAME
+                )
+              end
               o.lazy
             end
           end

--- a/lib/datadog/tracing/contrib/elasticsearch/patcher.rb
+++ b/lib/datadog/tracing/contrib/elasticsearch/patcher.rb
@@ -90,8 +90,10 @@ module Datadog
                     body = JSON.generate(body) if body && !body.is_a?(String)
 
                     # Tag as an external peer service
-                    span.set_tag(Tracing::Metadata::Ext::TAG_PEER_SERVICE, span.service)
-                    span.set_tag(Tracing::Metadata::Ext::TAG_PEER_HOSTNAME, host) if host
+                    if Contrib::SpanAttributeSchema.default_span_attribute_schema?
+                      span.set_tag(Tracing::Metadata::Ext::TAG_PEER_SERVICE, span.service)
+                      span.set_tag(Tracing::Metadata::Ext::TAG_PEER_HOSTNAME, host) if host
+                    end
 
                     # Set analytics sample rate
                     if Contrib::Analytics.enabled?(datadog_configuration[:analytics_enabled])

--- a/lib/datadog/tracing/contrib/ethon/configuration/settings.rb
+++ b/lib/datadog/tracing/contrib/ethon/configuration/settings.rb
@@ -29,7 +29,12 @@ module Datadog
             option :split_by_domain, default: false
 
             option :service_name do |o|
-              o.default { ENV.fetch(Ext::ENV_SERVICE_NAME, Ext::DEFAULT_PEER_SERVICE_NAME) }
+              o.default do
+                Contrib::SpanAttributeSchema.fetch_service_name(
+                  Ext::ENV_SERVICE_NAME,
+                  Ext::DEFAULT_PEER_SERVICE_NAME
+                )
+              end
               o.lazy
             end
           end

--- a/lib/datadog/tracing/contrib/ethon/easy_patch.rb
+++ b/lib/datadog/tracing/contrib/ethon/easy_patch.rb
@@ -121,8 +121,11 @@ module Datadog
               method = Ext::NOT_APPLICABLE_METHOD
               method = @datadog_method.to_s if instance_variable_defined?(:@datadog_method) && !@datadog_method.nil?
               span.resource = method
-              # Tag as an external peer service
-              span.set_tag(Tracing::Metadata::Ext::TAG_PEER_SERVICE, span.service)
+
+              if Contrib::SpanAttributeSchema.default_span_attribute_schema?
+                # Tag as an external peer service
+                span.set_tag(Tracing::Metadata::Ext::TAG_PEER_SERVICE, span.service)
+              end
               # Set analytics sample rate
               Contrib::Analytics.set_sample_rate(span, analytics_sample_rate) if analytics_enabled?
 
@@ -139,7 +142,9 @@ module Datadog
               span.set_tag(Tracing::Metadata::Ext::NET::TAG_TARGET_HOST, uri.host)
               span.set_tag(Tracing::Metadata::Ext::NET::TAG_TARGET_PORT, uri.port)
 
-              span.set_tag(Tracing::Metadata::Ext::TAG_PEER_HOSTNAME, uri.host)
+              if Contrib::SpanAttributeSchema.default_span_attribute_schema?
+                span.set_tag(Tracing::Metadata::Ext::TAG_PEER_HOSTNAME, uri.host)
+              end
             end
 
             def set_span_error_message(message)

--- a/lib/datadog/tracing/contrib/ethon/multi_patch.rb
+++ b/lib/datadog/tracing/contrib/ethon/multi_patch.rb
@@ -67,8 +67,10 @@ module Datadog
 
               @datadog_multi_span.set_tag(Tracing::Metadata::Ext::TAG_KIND, Tracing::Metadata::Ext::SpanKind::TAG_CLIENT)
 
-              # Tag as an external peer service
-              @datadog_multi_span.set_tag(Tracing::Metadata::Ext::TAG_PEER_SERVICE, @datadog_multi_span.service)
+              if Contrib::SpanAttributeSchema.default_span_attribute_schema?
+                # Tag as an external peer service
+                @datadog_multi_span.set_tag(Tracing::Metadata::Ext::TAG_PEER_SERVICE, @datadog_multi_span.service)
+              end
 
               # Set analytics sample rate
               Contrib::Analytics.set_sample_rate(@datadog_multi_span, analytics_sample_rate) if analytics_enabled?

--- a/lib/datadog/tracing/contrib/excon/configuration/settings.rb
+++ b/lib/datadog/tracing/contrib/excon/configuration/settings.rb
@@ -29,7 +29,12 @@ module Datadog
             option :split_by_domain, default: false
 
             option :service_name do |o|
-              o.default { ENV.fetch(Ext::ENV_SERVICE_NAME, Ext::DEFAULT_PEER_SERVICE_NAME) }
+              o.default do
+                Contrib::SpanAttributeSchema.fetch_service_name(
+                  Ext::ENV_SERVICE_NAME,
+                  Ext::DEFAULT_PEER_SERVICE_NAME
+                )
+              end
               o.lazy
             end
           end

--- a/lib/datadog/tracing/contrib/excon/middleware.rb
+++ b/lib/datadog/tracing/contrib/excon/middleware.rb
@@ -119,9 +119,11 @@ module Datadog
             span.set_tag(Tracing::Metadata::Ext::TAG_COMPONENT, Ext::TAG_COMPONENT)
             span.set_tag(Tracing::Metadata::Ext::TAG_OPERATION, Ext::TAG_OPERATION_REQUEST)
 
-            # Tag as an external peer service
-            span.set_tag(Tracing::Metadata::Ext::TAG_PEER_SERVICE, span.service)
-            span.set_tag(Tracing::Metadata::Ext::TAG_PEER_HOSTNAME, datum[:host])
+            if Contrib::SpanAttributeSchema.default_span_attribute_schema?
+              # Tag as an external peer service
+              span.set_tag(Tracing::Metadata::Ext::TAG_PEER_SERVICE, span.service)
+              span.set_tag(Tracing::Metadata::Ext::TAG_PEER_HOSTNAME, datum[:host])
+            end
 
             # Set analytics sample rate
             Contrib::Analytics.set_sample_rate(span, analytics_sample_rate) if analytics_enabled?

--- a/lib/datadog/tracing/contrib/faraday/configuration/settings.rb
+++ b/lib/datadog/tracing/contrib/faraday/configuration/settings.rb
@@ -33,7 +33,12 @@ module Datadog
             option :split_by_domain, default: false
 
             option :service_name do |o|
-              o.default { ENV.fetch(Ext::ENV_SERVICE_NAME, Ext::DEFAULT_PEER_SERVICE_NAME) }
+              o.default do
+                Contrib::SpanAttributeSchema.fetch_service_name(
+                  Ext::ENV_SERVICE_NAME,
+                  Ext::DEFAULT_PEER_SERVICE_NAME
+                )
+              end
               o.lazy
             end
           end

--- a/lib/datadog/tracing/contrib/faraday/middleware.rb
+++ b/lib/datadog/tracing/contrib/faraday/middleware.rb
@@ -45,9 +45,11 @@ module Datadog
             span.set_tag(Tracing::Metadata::Ext::TAG_COMPONENT, Ext::TAG_COMPONENT)
             span.set_tag(Tracing::Metadata::Ext::TAG_OPERATION, Ext::TAG_OPERATION_REQUEST)
 
-            # Tag as an external peer service
-            span.set_tag(Tracing::Metadata::Ext::TAG_PEER_SERVICE, span.service)
-            span.set_tag(Tracing::Metadata::Ext::TAG_PEER_HOSTNAME, env[:url].host)
+            if Contrib::SpanAttributeSchema.default_span_attribute_schema?
+              # Tag as an external peer service
+              span.set_tag(Tracing::Metadata::Ext::TAG_PEER_SERVICE, span.service)
+              span.set_tag(Tracing::Metadata::Ext::TAG_PEER_HOSTNAME, env[:url].host)
+            end
 
             # Set analytics sample rate
             if Contrib::Analytics.enabled?(options[:analytics_enabled])

--- a/spec/datadog/tracing/contrib/active_record/configuration/configuration_spec.rb
+++ b/spec/datadog/tracing/contrib/active_record/configuration/configuration_spec.rb
@@ -11,7 +11,7 @@ RSpec.describe Datadog::Tracing::Contrib::ActiveRecord::Configuration::Settings 
     context 'when without service_name v0' do # default to include base
       it do
         with_modified_env DD_TRACE_SPAN_ATTRIBUTE_SCHEMA: 'v0' do
-          expect(described_class.new.service_name).to eq('aws')
+          expect(described_class.new.service_name).to eq('defaultdb')
         end
       end
     end

--- a/spec/datadog/tracing/contrib/active_record/configuration/configuration_spec.rb
+++ b/spec/datadog/tracing/contrib/active_record/configuration/configuration_spec.rb
@@ -1,0 +1,31 @@
+require 'datadog/tracing/contrib/active_record/configuration/settings'
+
+RSpec.describe Datadog::Tracing::Contrib::ActiveRecord::Configuration::Settings do
+  describe 'Option `service_name`' do
+    context 'when with service_name' do # default to include base
+      it do
+        expect(described_class.new(service_name: 'test-service').service_name).to eq('test-service')
+      end
+    end
+
+    context 'when without service_name v0' do # default to include base
+      it do
+        with_modified_env DD_TRACE_SPAN_ATTRIBUTE_SCHEMA: 'v0' do
+          expect(described_class.new.service_name).to eq('aws')
+        end
+      end
+    end
+
+    context 'when without service_name v1' do # default to include base
+      it do
+        with_modified_env DD_TRACE_SPAN_ATTRIBUTE_SCHEMA: 'v1' do
+          expect(described_class.new.service_name).to eq('rspec')
+        end
+      end
+    end
+  end
+
+  def with_modified_env(options = {}, &block)
+    ClimateControl.modify(options, &block)
+  end
+end

--- a/spec/datadog/tracing/contrib/active_record/tracer_spec.rb
+++ b/spec/datadog/tracing/contrib/active_record/tracer_spec.rb
@@ -1,6 +1,7 @@
 require 'datadog/tracing/contrib/support/spec_helper'
 require 'datadog/tracing/contrib/analytics_examples'
 require 'datadog/tracing/contrib/integration_examples'
+require 'datadog/tracing/contrib/span_attribute_schema_examples'
 require 'ddtrace'
 
 require 'spec/datadog/tracing/contrib/rails/support/deprecation'

--- a/spec/datadog/tracing/contrib/active_record/tracer_spec.rb
+++ b/spec/datadog/tracing/contrib/active_record/tracer_spec.rb
@@ -64,6 +64,8 @@ RSpec.describe 'ActiveRecord instrumentation' do
     end
 
     context 'and service_name' do
+      it_behaves_like 'schema version span', 'mysql2'
+
       context 'is not set' do
         it { expect(span.service).to eq('mysql2') }
       end

--- a/spec/datadog/tracing/contrib/aws/configuration/configuration_spec.rb
+++ b/spec/datadog/tracing/contrib/aws/configuration/configuration_spec.rb
@@ -1,0 +1,31 @@
+require 'datadog/tracing/contrib/aws/configuration/settings'
+
+RSpec.describe Datadog::Tracing::Contrib::Aws::Configuration::Settings do
+  describe 'Option `service_name`' do
+    context 'when with service_name' do # default to include base
+      it do
+        expect(described_class.new(service_name: 'test-service').service_name).to eq('test-service')
+      end
+    end
+
+    context 'when without service_name v0' do # default to include base
+      it do
+        with_modified_env DD_TRACE_SPAN_ATTRIBUTE_SCHEMA: 'v0' do
+          expect(described_class.new.service_name).to eq('aws')
+        end
+      end
+    end
+
+    context 'when without service_name v1' do # default to include base
+      it do
+        with_modified_env DD_TRACE_SPAN_ATTRIBUTE_SCHEMA: 'v1' do
+          expect(described_class.new.service_name).to eq('rspec')
+        end
+      end
+    end
+  end
+
+  def with_modified_env(options = {}, &block)
+    ClimateControl.modify(options, &block)
+  end
+end

--- a/spec/datadog/tracing/contrib/aws/instrumentation_spec.rb
+++ b/spec/datadog/tracing/contrib/aws/instrumentation_spec.rb
@@ -95,7 +95,7 @@ RSpec.describe 'AWS instrumentation' do
 
       it_behaves_like 'measured span for integration'
       it_behaves_like 'environment service name', 'DD_TRACE_AWS_SERVICE_NAME'
-      it_behaves_like 'span attributes schema'
+      it_behaves_like 'schema version span', 'rspec'
 
       it 'generates a span' do
         expect(span.name).to eq('aws.command')

--- a/spec/datadog/tracing/contrib/aws/instrumentation_spec.rb
+++ b/spec/datadog/tracing/contrib/aws/instrumentation_spec.rb
@@ -44,7 +44,7 @@ RSpec.describe 'AWS instrumentation' do
       it_behaves_like 'measured span for integration'
       it_behaves_like 'a peer service span'
       it_behaves_like 'environment service name', 'DD_TRACE_AWS_SERVICE_NAME'
-      it_behaves_like 'span attributes schema'
+      it_behaves_like 'schema version span'
 
       it 'generates a span' do
         expect(span.name).to eq('aws.command')

--- a/spec/datadog/tracing/contrib/dalli/configuration/configuration_spec.rb
+++ b/spec/datadog/tracing/contrib/dalli/configuration/configuration_spec.rb
@@ -1,6 +1,6 @@
-require 'datadog/tracing/contrib/aws/configuration/settings'
+require 'datadog/tracing/contrib/dalli/configuration/settings'
 
-RSpec.describe Datadog::Tracing::Contrib::Aws::Configuration::Settings do
+RSpec.describe Datadog::Tracing::Contrib::Dalli::Configuration::Settings do
   describe 'Option `service_name`' do
     context 'when with service_name' do # default to include base
       it do
@@ -11,7 +11,7 @@ RSpec.describe Datadog::Tracing::Contrib::Aws::Configuration::Settings do
     context 'when without service_name v0' do # default to include base
       it do
         with_modified_env DD_TRACE_SPAN_ATTRIBUTE_SCHEMA: 'v0' do
-          expect(described_class.new.service_name).to eq('aws')
+          expect(described_class.new.service_name).to eq('memcached')
         end
       end
     end

--- a/spec/datadog/tracing/contrib/dalli/instrumentation_spec.rb
+++ b/spec/datadog/tracing/contrib/dalli/instrumentation_spec.rb
@@ -2,6 +2,7 @@ require 'datadog/tracing/contrib/support/spec_helper'
 require 'datadog/tracing/contrib/analytics_examples'
 require 'datadog/tracing/contrib/integration_examples'
 require 'datadog/tracing/contrib/environment_service_name_examples'
+require 'datadog/tracing/contrib/span_attribute_schema_examples'
 
 require 'dalli'
 require 'ddtrace'
@@ -29,6 +30,13 @@ RSpec.describe 'Dalli instrumentation' do
   end
 
   it_behaves_like 'environment service name', 'DD_TRACE_DALLI_SERVICE_NAME' do
+    subject do
+      client.set('abc', 123)
+      try_wait_until { fetch_spans.any? }
+    end
+  end
+
+  it_behaves_like 'schema version span' do
     subject do
       client.set('abc', 123)
       try_wait_until { fetch_spans.any? }

--- a/spec/datadog/tracing/contrib/elasticsearch/configuration/configuration_spec.rb
+++ b/spec/datadog/tracing/contrib/elasticsearch/configuration/configuration_spec.rb
@@ -1,0 +1,31 @@
+require 'datadog/tracing/contrib/elasticsearch/configuration/settings'
+
+RSpec.describe Datadog::Tracing::Contrib::Elasticsearch::Configuration::Settings do
+  describe 'Option `service_name`' do
+    context 'when with service_name' do # default to include base
+      it do
+        expect(described_class.new(service_name: 'test-service').service_name).to eq('test-service')
+      end
+    end
+
+    context 'when without service_name v0' do # default to include base
+      it do
+        with_modified_env DD_TRACE_SPAN_ATTRIBUTE_SCHEMA: 'v0' do
+          expect(described_class.new.service_name).to eq('elasticsearch')
+        end
+      end
+    end
+
+    context 'when without service_name v1' do # default to include base
+      it do
+        with_modified_env DD_TRACE_SPAN_ATTRIBUTE_SCHEMA: 'v1' do
+          expect(described_class.new.service_name).to eq('rspec')
+        end
+      end
+    end
+  end
+
+  def with_modified_env(options = {}, &block)
+    ClimateControl.modify(options, &block)
+  end
+end

--- a/spec/datadog/tracing/contrib/elasticsearch/patcher_spec.rb
+++ b/spec/datadog/tracing/contrib/elasticsearch/patcher_spec.rb
@@ -2,6 +2,7 @@ require 'datadog/tracing/contrib/support/spec_helper'
 require 'datadog/tracing/contrib/analytics_examples'
 require 'datadog/tracing/contrib/integration_examples'
 require 'datadog/tracing/contrib/environment_service_name_examples'
+require 'datadog/tracing/contrib/span_attribute_schema_examples'
 
 require 'ddtrace'
 
@@ -62,6 +63,7 @@ RSpec.describe Datadog::Tracing::Contrib::Elasticsearch::Patcher do
       before { request }
 
       it_behaves_like 'environment service name', 'DD_TRACE_ELASTICSEARCH_SERVICE_NAME'
+      it_behaves_like 'schema version span'
 
       it { expect(span.name).to eq('elasticsearch.query') }
       it { expect(span.service).to eq('elasticsearch') }
@@ -127,6 +129,7 @@ RSpec.describe Datadog::Tracing::Contrib::Elasticsearch::Patcher do
       it_behaves_like 'measured span for integration', false
 
       it_behaves_like 'environment service name', 'DD_TRACE_ELASTICSEARCH_SERVICE_NAME'
+      it_behaves_like 'schema version span'
 
       it { expect(span.name).to eq('elasticsearch.query') }
       it { expect(span.service).to eq('elasticsearch') }

--- a/spec/datadog/tracing/contrib/ethon/configuration/configuration_spec.rb
+++ b/spec/datadog/tracing/contrib/ethon/configuration/configuration_spec.rb
@@ -1,0 +1,31 @@
+require 'datadog/tracing/contrib/ethon/configuration/settings'
+
+RSpec.describe Datadog::Tracing::Contrib::Ethon::Configuration::Settings do
+  describe 'Option `service_name`' do
+    context 'when with service_name' do # default to include base
+      it do
+        expect(described_class.new(service_name: 'test-service').service_name).to eq('test-service')
+      end
+    end
+
+    context 'when without service_name v0' do # default to include base
+      it do
+        with_modified_env DD_TRACE_SPAN_ATTRIBUTE_SCHEMA: 'v0' do
+          expect(described_class.new.service_name).to eq('ethon')
+        end
+      end
+    end
+
+    context 'when without service_name v1' do # default to include base
+      it do
+        with_modified_env DD_TRACE_SPAN_ATTRIBUTE_SCHEMA: 'v1' do
+          expect(described_class.new.service_name).to eq('rspec')
+        end
+      end
+    end
+  end
+
+  def with_modified_env(options = {}, &block)
+    ClimateControl.modify(options, &block)
+  end
+end

--- a/spec/datadog/tracing/contrib/ethon/easy_patch_spec.rb
+++ b/spec/datadog/tracing/contrib/ethon/easy_patch_spec.rb
@@ -1,5 +1,6 @@
 require 'datadog/tracing/contrib/support/spec_helper'
 require 'datadog/tracing/contrib/environment_service_name_examples'
+require 'datadog/tracing/contrib/span_attribute_schema_examples'
 
 require 'ethon'
 require 'datadog/tracing/contrib/ethon/easy_patch'
@@ -113,6 +114,10 @@ RSpec.describe Datadog::Tracing::Contrib::Ethon::EasyPatch do
     end
 
     it_behaves_like 'environment service name', 'DD_TRACE_ETHON_SERVICE_NAME' do
+      let(:span) { span_op }
+    end
+
+    it_behaves_like 'schema version span' do
       let(:span) { span_op }
     end
   end

--- a/spec/datadog/tracing/contrib/ethon/multi_patch_spec.rb
+++ b/spec/datadog/tracing/contrib/ethon/multi_patch_spec.rb
@@ -5,6 +5,7 @@ require 'datadog/tracing/contrib/ethon/multi_patch'
 require 'datadog/tracing/contrib/ethon/shared_examples'
 require 'datadog/tracing/contrib/analytics_examples'
 require 'datadog/tracing/contrib/environment_service_name_examples'
+require 'datadog/tracing/contrib/span_attribute_schema_examples'
 
 require 'spec/datadog/tracing/contrib/ethon/support/thread_helpers'
 
@@ -115,6 +116,10 @@ RSpec.describe Datadog::Tracing::Contrib::Ethon::MultiPatch do
         end
 
         it_behaves_like 'environment service name', 'DD_TRACE_ETHON_SERVICE_NAME' do
+          let(:span) { multi_span }
+        end
+
+        it_behaves_like 'schema version span' do
           let(:span) { multi_span }
         end
       end

--- a/spec/datadog/tracing/contrib/excon/configuration/configuration_spec.rb
+++ b/spec/datadog/tracing/contrib/excon/configuration/configuration_spec.rb
@@ -1,0 +1,31 @@
+require 'datadog/tracing/contrib/excon/configuration/settings'
+
+RSpec.describe Datadog::Tracing::Contrib::Excon::Configuration::Settings do
+  describe 'Option `service_name`' do
+    context 'when with service_name' do # default to include base
+      it do
+        expect(described_class.new(service_name: 'test-service').service_name).to eq('test-service')
+      end
+    end
+
+    context 'when without service_name v0' do # default to include base
+      it do
+        with_modified_env DD_TRACE_SPAN_ATTRIBUTE_SCHEMA: 'v0' do
+          expect(described_class.new.service_name).to eq('excon')
+        end
+      end
+    end
+
+    context 'when without service_name v1' do # default to include base
+      it do
+        with_modified_env DD_TRACE_SPAN_ATTRIBUTE_SCHEMA: 'v1' do
+          expect(described_class.new.service_name).to eq('rspec')
+        end
+      end
+    end
+  end
+
+  def with_modified_env(options = {}, &block)
+    ClimateControl.modify(options, &block)
+  end
+end

--- a/spec/datadog/tracing/contrib/excon/instrumentation_spec.rb
+++ b/spec/datadog/tracing/contrib/excon/instrumentation_spec.rb
@@ -2,6 +2,7 @@ require 'datadog/tracing/contrib/integration_examples'
 require 'datadog/tracing/contrib/support/spec_helper'
 require 'datadog/tracing/contrib/analytics_examples'
 require 'datadog/tracing/contrib/environment_service_name_examples'
+require 'datadog/tracing/contrib/span_attribute_schema_examples'
 
 require 'excon'
 require 'ddtrace'
@@ -75,12 +76,14 @@ RSpec.describe Datadog::Tracing::Contrib::Excon::Middleware do
     end
 
     it_behaves_like 'environment service name', 'DD_TRACE_EXCON_SERVICE_NAME'
+    it_behaves_like 'schema version span'
   end
 
   context 'when there is successful request' do
     subject!(:response) { connection.get(path: '/success') }
 
     it_behaves_like 'environment service name', 'DD_TRACE_EXCON_SERVICE_NAME'
+    it_behaves_like 'schema version span'
 
     it_behaves_like 'analytics for integration' do
       let(:analytics_enabled_var) { Datadog::Tracing::Contrib::Excon::Ext::ENV_ANALYTICS_ENABLED }
@@ -117,6 +120,7 @@ RSpec.describe Datadog::Tracing::Contrib::Excon::Middleware do
     subject!(:response) { connection.post(path: '/failure') }
 
     it_behaves_like 'environment service name', 'DD_TRACE_EXCON_SERVICE_NAME'
+    it_behaves_like 'schema version span'
 
     it do
       expect(request_span.service).to eq(Datadog::Tracing::Contrib::Excon::Ext::DEFAULT_PEER_SERVICE_NAME)
@@ -146,6 +150,7 @@ RSpec.describe Datadog::Tracing::Contrib::Excon::Middleware do
     subject!(:response) { connection.get(path: '/not_found') }
 
     it_behaves_like 'environment service name', 'DD_TRACE_EXCON_SERVICE_NAME'
+    it_behaves_like 'schema version span'
 
     it { expect(request_span).to_not have_error }
   end

--- a/spec/datadog/tracing/contrib/faraday/configuration/configuration_spec.rb
+++ b/spec/datadog/tracing/contrib/faraday/configuration/configuration_spec.rb
@@ -1,0 +1,31 @@
+require 'datadog/tracing/contrib/faraday/configuration/settings'
+
+RSpec.describe Datadog::Tracing::Contrib::Faraday::Configuration::Settings do
+  describe 'Option `service_name`' do
+    context 'when with service_name' do # default to include base
+      it do
+        expect(described_class.new(service_name: 'test-service').service_name).to eq('test-service')
+      end
+    end
+
+    context 'when without service_name v0' do # default to include base
+      it do
+        with_modified_env DD_TRACE_SPAN_ATTRIBUTE_SCHEMA: 'v0' do
+          expect(described_class.new.service_name).to eq('faraday')
+        end
+      end
+    end
+
+    context 'when without service_name v1' do # default to include base
+      it do
+        with_modified_env DD_TRACE_SPAN_ATTRIBUTE_SCHEMA: 'v1' do
+          expect(described_class.new.service_name).to eq('rspec')
+        end
+      end
+    end
+  end
+
+  def with_modified_env(options = {}, &block)
+    ClimateControl.modify(options, &block)
+  end
+end

--- a/spec/datadog/tracing/contrib/faraday/middleware_spec.rb
+++ b/spec/datadog/tracing/contrib/faraday/middleware_spec.rb
@@ -2,6 +2,7 @@ require 'datadog/tracing/contrib/integration_examples'
 require 'datadog/tracing/contrib/support/spec_helper'
 require 'datadog/tracing/contrib/analytics_examples'
 require 'datadog/tracing/contrib/environment_service_name_examples'
+require 'datadog/tracing/contrib/span_attribute_schema_examples'
 
 require 'faraday'
 
@@ -44,6 +45,7 @@ RSpec.describe 'Faraday middleware' do
     let(:use_middleware) { false }
 
     it_behaves_like 'environment service name', 'DD_TRACE_FARADAY_SERVICE_NAME'
+    it_behaves_like 'schema version span'
 
     it 'uses default configuration' do
       expect(response.status).to eq(200)
@@ -88,6 +90,7 @@ RSpec.describe 'Faraday middleware' do
       after { WebMock.disable! }
 
       it_behaves_like 'environment service name', 'DD_TRACE_FARADAY_SERVICE_NAME'
+      it_behaves_like 'schema version span'
 
       it 'uses default configuration' do
         expect(response.status).to eq(200)
@@ -132,6 +135,7 @@ RSpec.describe 'Faraday middleware' do
     subject!(:response) { client.get('/success') }
 
     it_behaves_like 'environment service name', 'DD_TRACE_FARADAY_SERVICE_NAME'
+    it_behaves_like 'schema version span'
 
     it do
       expect(response).to be_a_kind_of(::Faraday::Response)
@@ -144,6 +148,7 @@ RSpec.describe 'Faraday middleware' do
     subject!(:response) { client.get('/success') }
 
     it_behaves_like 'environment service name', 'DD_TRACE_FARADAY_SERVICE_NAME'
+    it_behaves_like 'schema version span'
 
     it_behaves_like 'analytics for integration' do
       let(:analytics_enabled_var) { Datadog::Tracing::Contrib::Faraday::Ext::ENV_ANALYTICS_ENABLED }
@@ -179,6 +184,7 @@ RSpec.describe 'Faraday middleware' do
     subject!(:response) { client.post('/failure') }
 
     it_behaves_like 'environment service name', 'DD_TRACE_FARADAY_SERVICE_NAME'
+    it_behaves_like 'schema version span'
 
     it do
       expect(span.service).to eq(Datadog::Tracing::Contrib::Faraday::Ext::DEFAULT_PEER_SERVICE_NAME)
@@ -248,6 +254,7 @@ RSpec.describe 'Faraday middleware' do
     it { expect(span).to_not have_error }
 
     it_behaves_like 'environment service name', 'DD_TRACE_FARADAY_SERVICE_NAME'
+    it_behaves_like 'schema version span'
   end
 
   context 'when there is custom error handling' do
@@ -259,6 +266,7 @@ RSpec.describe 'Faraday middleware' do
     it { expect(span).to have_error }
 
     it_behaves_like 'environment service name', 'DD_TRACE_FARADAY_SERVICE_NAME'
+    it_behaves_like 'schema version span'
   end
 
   context 'when split by domain' do

--- a/spec/datadog/tracing/contrib/span_attribute_schema_examples.rb
+++ b/spec/datadog/tracing/contrib/span_attribute_schema_examples.rb
@@ -1,4 +1,4 @@
-RSpec.shared_examples 'span attributes schema' do
+RSpec.shared_examples 'schema version span' do |_default_service_name|
   before do
     subject
   end


### PR DESCRIPTION
Part 2 of process to change all default values for `service_names` per integration to `DD_SERVICE`

- Change default `service_name` values based on span attribute schema version. If version is v0, the default stays as is, otherwise if it is version v1, the default changes to `DD_SERVICE`
- Adds and updates all tests for impacted integrations. This includes a new `configuration_spec.rb` per integration that tests the switching of defaults between v0 and v1.
- Encapsulates old `peer.service` and `peer.hostname` values behind `v0` schema version only as there will be changes to the value based on version in the future.

Affected integrations: `faraday`, ...