### PR TITLE
[APPSEC-7791] Handle exceptions when fetching remote config:

### DIFF
--- a/Steepfile
+++ b/Steepfile
@@ -643,6 +643,7 @@ target :ddtrace do
   library 'tsort'
   library 'json'
   library 'ipaddr'
+  library 'socket'
   library 'net-http'
   library 'securerandom'
   library 'base64'

--- a/sig/datadog/core/remote/client.rbs
+++ b/sig/datadog/core/remote/client.rbs
@@ -21,6 +21,8 @@ module Datadog
 
         private
 
+        def fetch_remote_configuration: () -> Datadog::Core::Transport::Config::Response?
+
         def payload: () ->  ::Hash[Symbol, untyped]
       end
     end

--- a/sig/datadog/core/transport/http/config.rbs
+++ b/sig/datadog/core/transport/http/config.rbs
@@ -35,7 +35,7 @@ module Datadog
 
           # Extensions for HTTP client
           module Client : HTTP::Client
-            def send_config_payload: (untyped request) -> untyped
+            def send_config_payload: (untyped request) -> Datadog::Core::Transport::HTTP::Config::Response?
           end
 
           module API
@@ -43,9 +43,9 @@ module Datadog
             module Spec
               attr_reader config: untyped
 
-              def config=: (untyped endpoint) -> untyped
+              def config=: (Datadog::Core::Transport::HTTP::Config::API::Endpoint endpoint) -> void
 
-              def send_config: (untyped env) ?{ () -> untyped } -> untyped
+              def send_config: (Datadog::Transport::HTTP::Env env) ?{ () -> untyped } -> Datadog::Core::Transport::HTTP::Config::Response?
 
               # Raised when traces sent but no traces endpoint is defined
               class NoConfigEndpointDefinedError < StandardError
@@ -59,7 +59,7 @@ module Datadog
 
             # Extensions for HTTP API Instance
             module Instance : HTTP::API::Instance
-              def send_config: (untyped env) -> untyped
+              def send_config: (Datadog::Transport::HTTP::Env env) -> Datadog::Core::Transport::HTTP::Config::Response?
 
               # Raised when traces sent to API that does not support traces
               class ConfigNotSupportedError < StandardError
@@ -77,9 +77,9 @@ module Datadog
 
               attr_reader encoder: untyped
 
-              def initialize: (untyped path, untyped encoder) -> void
+              def initialize: (String path, untyped encoder) -> void
 
-              def call: (untyped env) { (untyped) -> untyped } -> untyped
+              def call: (Datadog::Transport::HTTP::Env env) { (untyped) -> untyped } -> Datadog::Core::Transport::HTTP::Config::Response?
             end
           end
         end

--- a/spec/datadog/core/remote/client_spec.rb
+++ b/spec/datadog/core/remote/client_spec.rb
@@ -364,8 +364,9 @@ RSpec.describe Datadog::Core::Remote::Client do
       context 'not a 200 response' do
         let(:response_code) { 401 }
 
-        it 'raises SyncError' do
-          expect { client.sync }.to raise_error(described_class::SyncError)
+        it 'does nothing' do
+          expect(client.repository).to_not receive(:transaction)
+          client.sync
         end
       end
 


### PR DESCRIPTION
When fetching remote configuration, we could face errors. 

- The connection fails to open to communicate with the agent 
- The agent is up and running, but the `/v0.7/config` endpoint is not present
- The agent and the config endpoint are up and running, but the response from the config endpoint is invalid

We want to guard ourselves against those cases.

The code on this PR handles those cases. 

In the case of the agent, the endpoint being down or an invalid response payload, we return `nil` rather than `Datadog::Core::Transport::Config::Response`

In the case that the agent returns a 200 with an empty response, we are going to return an empty                                       `Datadog::Core::Transport::Config::Response` 

