### PR TITLE
Fix remote configuration path parsing

### DIFF
--- a/lib/datadog/core/remote/configuration/path.rb
+++ b/lib/datadog/core/remote/configuration/path.rb
@@ -21,7 +21,7 @@ module Datadog
               /
               (?<config_id>[^/]+)
               /
-              (?<name>config)
+              (?<name>[^/]+)
               $
             }mx.freeze
 

--- a/spec/datadog/core/remote/configuration/path_spec.rb
+++ b/spec/datadog/core/remote/configuration/path_spec.rb
@@ -5,53 +5,160 @@ require 'datadog/core/remote/configuration/path'
 
 RSpec.describe Datadog::Core::Remote::Configuration::Path do
   describe '.parse' do
-    context 'invalid path' do
-      it 'raises ParseError' do
-        expect { described_class.parse('invalid_path') }.to raise_error(described_class::ParseError)
+    let(:product) { SecureRandom.hex }
+    let(:config_id) { SecureRandom.hex }
+    let(:name) { SecureRandom.hex }
+
+    let(:components) do
+      [source, org_id, product, config_id, name]
+    end
+
+    let(:input) { components.compact.join('/') }
+
+    shared_examples 'a parsed path' do
+      subject(:path) { described_class.parse(input) }
+
+      let(:expected_attrs) do
+        {
+          source: source,
+          org_id: org_id.nil? ? org_id : Integer(org_id),
+          product: product,
+          config_id: config_id,
+          name: name,
+        }
+      end
+
+      it 'returns a Path instance' do
+        expect(path).to be_a(described_class)
+      end
+
+      it 'has attributes parsed' do
+        expect(path).to have_attributes(expected_attrs)
       end
     end
 
-    context 'valid path' do
-      it 'returns a Path instance' do
-        path = described_class.parse('datadog/123/ASM/blocked_ips/config')
-        expect(path).to be_a(described_class)
-        expect(path.source).to eq('datadog')
-        expect(path.org_id).to eq(123)
-        expect(path.product).to eq('ASM')
-        expect(path.config_id).to eq('blocked_ips')
-        expect(path.name).to eq('config')
+    shared_examples 'parsing failed' do
+      it 'raises ParseError' do
+        expect { described_class.parse(input) }.to raise_error(described_class::ParseError)
+      end
+    end
+
+    shared_examples 'invalid rest parsing failed' do
+      context 'with missing product' do
+        let(:product) { nil }
+
+        it_behaves_like 'parsing failed'
       end
 
-      it 'returns an emplyee Path instance without org_id' do
-        path = described_class.parse('employee/ASM/blocked_ips/config')
-        expect(path).to be_a(described_class)
-        expect(path.source).to eq('employee')
-        expect(path.org_id).to be_nil
-        expect(path.product).to eq('ASM')
-        expect(path.config_id).to eq('blocked_ips')
-        expect(path.name).to eq('config')
+      context 'with missing config_id' do
+        let(:config_id) { nil }
+
+        it_behaves_like 'parsing failed'
       end
+
+      context 'with missing name' do
+        let(:name) { nil }
+
+        it_behaves_like 'parsing failed'
+      end
+
+      context 'with too many components' do
+        let(:input) { (components << 'extra').compact.join('/') }
+
+        it_behaves_like 'parsing failed'
+      end
+    end
+
+    context 'without a source' do
+      let(:source) { nil }
+
+      context 'with an org id' do
+        let(:org_id) { '42' }
+
+        it_behaves_like 'parsing failed'
+      end
+
+      context 'without an org id' do
+        let(:org_id) { nil }
+
+        it_behaves_like 'parsing failed'
+      end
+    end
+
+    context 'with a datadog source' do
+      let(:source) { 'datadog' }
+
+      context 'and an org id' do
+        let(:org_id) { '42' }
+
+        it_behaves_like 'a parsed path'
+        it_behaves_like 'invalid rest parsing failed'
+      end
+
+      context 'with a non-integer org id' do
+        let(:org_id) { 'abc' }
+
+        it_behaves_like 'parsing failed'
+      end
+
+      context 'without an org id' do
+        let(:org_id) { nil }
+
+        it_behaves_like 'parsing failed'
+      end
+    end
+
+    context 'with an employee source' do
+      let(:source) { 'employee' }
+
+      context 'without an org id' do
+        let(:org_id) { nil }
+
+        it_behaves_like 'a parsed path'
+        it_behaves_like 'invalid rest parsing failed'
+      end
+
+      context 'and an org id' do
+        let(:org_id) { '42' }
+
+        it_behaves_like 'parsing failed'
+      end
+    end
+  end
+
+  describe '#to_s' do
+    subject(:path) { described_class.parse(input).to_s }
+
+    context 'with a datadog source' do
+      let(:input) { 'datadog/123/ASM/blocked_ips/config' }
+
+      it { is_expected.to eq(input) }
+    end
+
+    context 'with an employee source' do
+      let(:input) { 'employee/ASM/blocked_ips/config' }
+
+      it { is_expected.to eq(input) }
     end
   end
 
   describe '#==' do
-    it 'returns if two path are the same' do
-      path1 = described_class.parse('datadog/123/ASM/blocked_ips/config')
-      path1dup = path1.dup
-      path2 = described_class.parse('employee/ASM/blocked_ips/config')
+    subject(:path) { described_class.parse('datadog/42/BAR/baz/quz') }
 
-      expect(path1 == path1dup).to be_truthy
-      expect(path1 == path2).to be_falsy
-    end
+    let(:other_path) { described_class.parse('datadog/43/BAR/baz/quz') }
+
+    it { is_expected.to eq(path) }
+    it { is_expected.to eq(path.dup) }
+    it { is_expected.to_not eq(other_path) }
   end
 
   describe '#eql?' do
-    it 'returns if two path are the same' do
-      path1 = described_class.parse('datadog/123/ASM/blocked_ips/config')
-      path2 = described_class.parse('employee/ASM/blocked_ips/config')
+    subject(:path) { described_class.parse('datadog/42/BAR/baz/quz') }
 
-      expect(path1).to be_eql(path1)
-      expect(path1).not_to be_eql(path2)
-    end
+    let(:other_path) { described_class.parse('datadog/43/BAR/baz/quz') }
+
+    it { is_expected.to be_eql(path) }
+    it { is_expected.to be_eql(path.dup) }
+    it { is_expected.to_not be_eql(other_path) }
   end
 end


### PR DESCRIPTION
<!--
Check out the
https://github.com/DataDog/dd-trace-rb/blob/master/docs/DevelopmentGuide.md
for guidance on how to set up your development environment,
run the test suite, write new integrations, and more.
-->

**What does this PR do?**

Fix remote configuration path parsing

**Motivation**

Turns out `config` hardcodedness was kind of ambiguous in the spec and I misunderstood it as being general. This now fails as `blocked_ips` has the config name be some kind of hash.

**Additional Notes**

RFC has been clarified.

**How to test the change?**

RC should now work with `blocked_ips` from `ASM_DATA` as sent from the backend.
