### PR TITLE
[APPSEC-8957] Populate remote client cached_target_files payload field

### DIFF
--- a/lib/datadog/core/remote/configuration/content.rb
+++ b/lib/datadog/core/remote/configuration/content.rb
@@ -44,6 +44,8 @@ module Datadog
             d = case type
                 when :sha256
                   ::Digest::SHA256.new
+                when :sha512
+                  ::Digest::SHA512.new
                 else
                   raise InvalidHashTypeError, type
                 end

--- a/lib/datadog/core/remote/configuration/content.rb
+++ b/lib/datadog/core/remote/configuration/content.rb
@@ -26,22 +26,18 @@ module Datadog
             @hashes = {}
           end
 
-          def hash(type)
+          def hexdigest(type)
             @hashes[type] || compute_and_store_hash(type)
           end
 
           def length
-            @data.size
+            @length ||= @data.size
           end
 
           private
 
           def compute_and_store_hash(type)
-            result = Digest.hexdigest(type, @data)
-            @hashes[type] = result
-            result
-          ensure
-            @data.rewind
+            @hashes[type] = Digest.hexdigest(type, @data)
           end
 
           private_class_method :new

--- a/lib/datadog/core/remote/configuration/digest.rb
+++ b/lib/datadog/core/remote/configuration/digest.rb
@@ -40,6 +40,8 @@ module Datadog
               end
 
               d.hexdigest
+            ensure
+              data.rewind
             end
           end
 
@@ -49,7 +51,7 @@ module Datadog
           end
 
           def check(content)
-            content.hash(@type) == hexdigest
+            content.hexdigest(@type) == hexdigest
           end
         end
       end

--- a/lib/datadog/core/remote/configuration/digest.rb
+++ b/lib/datadog/core/remote/configuration/digest.rb
@@ -1,0 +1,58 @@
+# frozen_string_literal: true
+
+module Datadog
+  module Core
+    module Remote
+      class Configuration
+        # Represent a list of Configuration::Digest
+        class DigestList < Array
+          class << self
+            def parse(hash)
+              new.concat(hash.map { |type, hexdigest| Digest.new(type, hexdigest) })
+            end
+          end
+
+          def check(content)
+            map { |digest| digest.check(content) }.reduce(:&)
+          end
+        end
+
+        # Stores and validates different cryptographic hash functions
+        class Digest
+          class InvalidHashTypeError < StandardError; end
+          attr_reader :type, :hexdigest
+
+          DIGEST_CHUNK = 1024
+
+          class << self
+            def hexdigest(type, data)
+              d = case type
+                  when :sha256
+                    ::Digest::SHA256.new
+                  when :sha512
+                    ::Digest::SHA512.new
+                  else
+                    raise InvalidHashTypeError, type
+                  end
+
+              while (buf = data.read(DIGEST_CHUNK))
+                d.update(buf)
+              end
+
+              d.hexdigest
+            end
+          end
+
+          def initialize(type, hexdigest)
+            @type = type.to_sym
+            @hexdigest = hexdigest
+          end
+
+          def check(content)
+            content.hash(@type) == hexdigest
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/datadog/core/remote/configuration/repository.rb
+++ b/lib/datadog/core/remote/configuration/repository.rb
@@ -68,37 +68,37 @@ module Datadog
             attr_reader \
               :root_version,
               :targets_version,
+              :config_states,
               :has_error,
               :error,
-              :opaque_backend_state,
-              :repository
+              :opaque_backend_state
 
             def initialize(repository)
               @repository = repository
               @root_version = repository.root_version
               @targets_version = repository.targets_version
-              @config_states = []
+              @config_states = contents_to_config_states(repository.contents)
               @has_error = false
               @error = ''
               @opaque_backend_state = repository.opaque_backend_state
             end
 
-            def config_states
-              return [] if @repository.contents.empty?
+            private
 
-              @repository.contents.each_with_object([]) do |content, acc|
-                config_state = {
+            def contents_to_config_states(contents)
+              return [] if contents.empty?
+
+              contents.map do |content|
+                {
                   path: content.path.to_s,
                   length: content.length,
-                  hashes: content.hashes.each_with_object([]) do |(key, value), hashes_acc|
-                    hashes_acc << {
-                      algorithm: key,
-                      hash: value
+                  hashes: content.hashes.map do |algorithm, hexdigest|
+                    {
+                      algorithm: algorithm,
+                      hash: hexdigest
                     }
-                    hashes_acc
                   end
                 }
-                acc << config_state
               end
             end
           end

--- a/lib/datadog/core/remote/configuration/repository.rb
+++ b/lib/datadog/core/remote/configuration/repository.rb
@@ -15,6 +15,7 @@ module Datadog
             :targets_version
 
           UNVERIFIED_ROOT_VERSION = 1
+
           INITIAL_TARGETS_VERSION = 0
 
           def initialize
@@ -67,18 +68,38 @@ module Datadog
             attr_reader \
               :root_version,
               :targets_version,
-              :config_states,
               :has_error,
               :error,
-              :opaque_backend_state
+              :opaque_backend_state,
+              :repository
 
             def initialize(repository)
+              @repository = repository
               @root_version = repository.root_version
               @targets_version = repository.targets_version
               @config_states = []
               @has_error = false
               @error = ''
               @opaque_backend_state = repository.opaque_backend_state
+            end
+
+            def config_states
+              return [] if @repository.contents.empty?
+
+              @repository.contents.each_with_object([]) do |content, acc|
+                config_state = {
+                  path: content.path.to_s,
+                  length: content.length,
+                  hashes: content.hashes.each_with_object([]) do |(key, value), hashes_acc|
+                    hashes_acc << {
+                      algorithm: key,
+                      hash: value
+                    }
+                    hashes_acc
+                  end
+                }
+                acc << config_state
+              end
             end
           end
 

--- a/lib/datadog/core/remote/configuration/target.rb
+++ b/lib/datadog/core/remote/configuration/target.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 require_relative 'path'
+require_relative 'digest'
 
 module Datadog
   module Core
@@ -46,7 +47,7 @@ module Datadog
           class << self
             def parse(hash)
               length = Integer(hash['length'])
-              digests = DigestList.parse(hash['hashes'])
+              digests = Configuration::DigestList.parse(hash['hashes'])
 
               new(digests: digests, length: length)
             end
@@ -64,37 +65,6 @@ module Datadog
           def check(content)
             digests.check(content)
           end
-
-          # Represent a list of Configuration::Target::Digest
-          class DigestList < Array
-            class << self
-              def parse(hash)
-                new.concat(hash.map { |type, hexdigest| Digest.new(type, hexdigest) })
-              end
-            end
-
-            def check(content)
-              map { |digest| digest.check(content) }.reduce(:&)
-            end
-          end
-
-          private_constant :DigestList
-
-          # Stores and validates different cryptographic hash functions
-          class Digest
-            attr_reader :type, :hexdigest
-
-            def initialize(type, hexdigest)
-              @type = type.to_sym
-              @hexdigest = hexdigest
-            end
-
-            def check(content)
-              content.hash(@type) == hexdigest
-            end
-          end
-
-          private_constant :DigestList
         end
       end
     end

--- a/sig/datadog/core/remote/configuration/content.rbs
+++ b/sig/datadog/core/remote/configuration/content.rbs
@@ -11,9 +11,11 @@ module Datadog
 
           attr_reader hashes: Hash[Symbol, String]
 
+          @length: Integer
+
           def initialize: (path: Configuration::Path, data: StringIO) -> void
 
-          def hash: (Symbol type) -> String
+          def hexdigest: (Symbol type) -> String
 
           def length: () -> Integer
 

--- a/sig/datadog/core/remote/configuration/content.rbs
+++ b/sig/datadog/core/remote/configuration/content.rbs
@@ -3,11 +3,6 @@ module Datadog
     module Remote
       class Configuration
         class Content
-          class InvalidHashTypeError < StandardError
-          end
-
-          DIGEST_CHUNK: 1024
-
           def self.parse: (::Hash[Symbol, untyped] hash) -> Content
 
           attr_reader path: Configuration::Path

--- a/sig/datadog/core/remote/configuration/content.rbs
+++ b/sig/datadog/core/remote/configuration/content.rbs
@@ -3,13 +3,28 @@ module Datadog
     module Remote
       class Configuration
         class Content
+          class InvalidHashTypeError < StandardError
+          end
+
+          DIGEST_CHUNK: 1024
+
           def self.parse: (::Hash[Symbol, untyped] hash) -> Content
 
           attr_reader path: Configuration::Path
 
           attr_reader data: StringIO
 
+          attr_reader hashes: Hash[Symbol, String]
+
           def initialize: (path: Configuration::Path, data: StringIO) -> void
+
+          def hash: (Symbol type) -> String
+
+          def length: () -> Integer
+
+          private
+
+          def compute_and_store_hash: (Symbol type) -> String
         end
 
         class ContentList < Array[Content]

--- a/sig/datadog/core/remote/configuration/digest.rbs
+++ b/sig/datadog/core/remote/configuration/digest.rbs
@@ -1,0 +1,30 @@
+module Datadog
+  module Core
+    module Remote
+      class Configuration
+        class DigestList < Array[Digest]
+          def self.parse: (::Hash[::String, untyped] hash) -> DigestList
+
+          def check: (Datadog::Core::Remote::Configuration::Content content) -> bool
+        end
+
+        class Digest
+          class InvalidHashTypeError < StandardError
+          end
+
+          DIGEST_CHUNK: 1024
+
+          attr_reader type: ::Symbol
+
+          attr_reader hexdigest: ::String
+
+          def self.hexdigest: (Symbol type, StringIO data) -> String
+
+          def initialize: (::String type, ::String hexdigest) -> void
+
+          def check: (Datadog::Core::Remote::Configuration::Content content) -> bool
+        end
+      end
+    end
+  end
+end

--- a/sig/datadog/core/remote/configuration/repository.rbs
+++ b/sig/datadog/core/remote/configuration/repository.rbs
@@ -34,7 +34,7 @@ module Datadog
 
             attr_reader repository: Repository
 
-            @config_states: Array[Hash[Symbol, untyped]]
+            attr_reader config_states: Array[Hash[Symbol, untyped]]
 
             attr_reader has_error: bool
 
@@ -44,7 +44,9 @@ module Datadog
 
             def initialize: (Repository repository) -> void
 
-            def config_states: () -> Array[Hash[Symbol, untyped]]
+            private
+
+            def contents_to_config_states: (ContentList contents) -> Array[Hash[Symbol, untyped]]
           end
 
           class Transaction

--- a/sig/datadog/core/remote/configuration/repository.rbs
+++ b/sig/datadog/core/remote/configuration/repository.rbs
@@ -32,7 +32,9 @@ module Datadog
 
             attr_reader targets_version: Integer
 
-            attr_reader config_states: Array[untyped]
+            attr_reader repository: Repository
+
+            @config_states: Array[Hash[Symbol, untyped]]
 
             attr_reader has_error: bool
 
@@ -41,6 +43,8 @@ module Datadog
             attr_reader opaque_backend_state: String?
 
             def initialize: (Repository repository) -> void
+
+            def config_states: () -> Array[Hash[Symbol, untyped]]
           end
 
           class Transaction

--- a/sig/datadog/core/remote/configuration/target.rbs
+++ b/sig/datadog/core/remote/configuration/target.rbs
@@ -27,7 +27,7 @@ module Datadog
           class DigestList < Array[Digest]
             def self.parse: (::Hash[::String, untyped] hash) -> DigestList
 
-            def check: (StringIO data) -> bool
+            def check: (Datadog::Core::Remote::Configuration::Content content) -> bool
           end
 
           class Digest
@@ -37,13 +37,7 @@ module Datadog
 
             def initialize: (::String type, ::String hexdigest) -> void
 
-            def check: (StringIO data) -> bool
-
-            private
-
-            DIGEST_CHUNK: 1024
-
-            def chunked_hexdigest: (StringIO io) -> ::String
+            def check: (Datadog::Core::Remote::Configuration::Content content) -> bool
           end
         end
       end

--- a/sig/datadog/core/remote/configuration/target.rbs
+++ b/sig/datadog/core/remote/configuration/target.rbs
@@ -23,22 +23,6 @@ module Datadog
           def initialize: (digests: DigestList, length: ::Integer) -> void
 
           def check: (untyped content) -> bool
-
-          class DigestList < Array[Digest]
-            def self.parse: (::Hash[::String, untyped] hash) -> DigestList
-
-            def check: (Datadog::Core::Remote::Configuration::Content content) -> bool
-          end
-
-          class Digest
-            attr_reader type: ::Symbol
-
-            attr_reader hexdigest: ::String
-
-            def initialize: (::String type, ::String hexdigest) -> void
-
-            def check: (Datadog::Core::Remote::Configuration::Content content) -> bool
-          end
         end
       end
     end

--- a/spec/datadog/core/remote/configuration/content_spec.rb
+++ b/spec/datadog/core/remote/configuration/content_spec.rb
@@ -242,15 +242,15 @@ RSpec.describe Datadog::Core::Remote::Configuration::ContentList do
       end
     end
 
-    describe '#hash' do
+    describe '#hexdigest' do
       before do
-        content.hash(:sha256)
-        content.hash(:sha512)
+        content.hexdigest(:sha256)
+        content.hexdigest(:sha512)
       end
 
       context 'compute hash of content' do
         it 'returns hash value' do
-          expect(content.hash(:sha256)).to eq('c8358ce9038693fb74ad8625e4c6c563bd2afb16b4412b2c8f7dba062e9e88de')
+          expect(content.hexdigest(:sha256)).to eq('c8358ce9038693fb74ad8625e4c6c563bd2afb16b4412b2c8f7dba062e9e88de')
         end
 
         it 'stores the value in hashes' do

--- a/spec/datadog/core/remote/configuration/content_spec.rb
+++ b/spec/datadog/core/remote/configuration/content_spec.rb
@@ -262,12 +262,6 @@ RSpec.describe Datadog::Core::Remote::Configuration::ContentList do
             }
           )
         end
-
-        context 'when hash type is not supported' do
-          it 'raises InvalidHashTypeError' do
-            expect { content.hash(:invalid) }.to raise_error(described_class::InvalidHashTypeError)
-          end
-        end
       end
     end
   end

--- a/spec/datadog/core/remote/configuration/content_spec.rb
+++ b/spec/datadog/core/remote/configuration/content_spec.rb
@@ -245,6 +245,7 @@ RSpec.describe Datadog::Core::Remote::Configuration::ContentList do
     describe '#hash' do
       before do
         content.hash(:sha256)
+        content.hash(:sha512)
       end
 
       context 'compute hash of content' do
@@ -256,6 +257,8 @@ RSpec.describe Datadog::Core::Remote::Configuration::ContentList do
           expect(content.hashes).to eq(
             {
               :sha256 => 'c8358ce9038693fb74ad8625e4c6c563bd2afb16b4412b2c8f7dba062e9e88de',
+              :sha512 => '546b5325ec8559dda0b34f3e628e99c7b9d18eb59b23ec87f672b1ed8c4ac9ac'\
+                '11ac6ffb15e6b4d71f5f343ec243d142db61aaf60f4a0410e39dc916c623cc82'
             }
           )
         end

--- a/spec/datadog/core/remote/configuration/content_spec.rb
+++ b/spec/datadog/core/remote/configuration/content_spec.rb
@@ -223,4 +223,49 @@ RSpec.describe Datadog::Core::Remote::Configuration::ContentList do
       expect(paths[0].to_s).to eq('datadog/603646/ASM/exclusion_filters/config')
     end
   end
+
+  describe Datadog::Core::Remote::Configuration::Content do
+    subject(:content) do
+      described_class.parse(
+        {
+          :path => path.to_s,
+          :content => string_io_content
+        }
+      )
+    end
+
+    describe '#hashes' do
+      context 'when no hash has been computed' do
+        it 'return {}' do
+          expect(content.hashes).to eq({})
+        end
+      end
+    end
+
+    describe '#hash' do
+      before do
+        content.hash(:sha256)
+      end
+
+      context 'compute hash of content' do
+        it 'returns hash value' do
+          expect(content.hash(:sha256)).to eq('c8358ce9038693fb74ad8625e4c6c563bd2afb16b4412b2c8f7dba062e9e88de')
+        end
+
+        it 'stores the value in hashes' do
+          expect(content.hashes).to eq(
+            {
+              :sha256 => 'c8358ce9038693fb74ad8625e4c6c563bd2afb16b4412b2c8f7dba062e9e88de',
+            }
+          )
+        end
+
+        context 'when hash type is not supported' do
+          it 'raises InvalidHashTypeError' do
+            expect { content.hash(:invalid) }.to raise_error(described_class::InvalidHashTypeError)
+          end
+        end
+      end
+    end
+  end
 end

--- a/spec/datadog/core/remote/configuration/digest_spec.rb
+++ b/spec/datadog/core/remote/configuration/digest_spec.rb
@@ -1,0 +1,73 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+require 'datadog/core/remote/configuration/digest'
+require 'datadog/core/remote/configuration/content'
+
+RSpec.describe Datadog::Core::Remote::Configuration::Digest do
+  let(:data) { StringIO.new('Hello World') }
+  let(:content) do
+    Datadog::Core::Remote::Configuration::Content.parse(
+      {
+        :path => 'datadog/603646/ASM/exclusion_filters/config',
+        :content => data
+      }
+    )
+  end
+
+  describe '.hexdigest' do
+    context 'valid type' do
+      it 'returns hexdigest' do
+        hexdigest = 'a591a6d40bf420404a011733cfb7b190d62c65bf0bcda32b57b277d9ad9f146e'
+        expect(described_class.hexdigest(:sha256, data)).to eq(hexdigest)
+      end
+    end
+
+    context 'invalid type is not supported' do
+      it 'raises InvalidHashTypeError' do
+        expect { described_class.hexdigest(:invalid, data) }.to raise_error(
+          described_class::InvalidHashTypeError
+        )
+      end
+    end
+  end
+
+  describe '#check' do
+    let(:digest) { described_class.new(:sha256, Digest::SHA256.hexdigest(value)) }
+
+    context 'valid content' do
+      let(:value) { 'Hello World' }
+      it 'returns true' do
+        expect(digest.check(content)).to eq(true)
+      end
+    end
+
+    context 'invalid content' do
+      let(:value) { 'wrong value' }
+      it 'returns false' do
+        expect(digest.check(content)).to eq(false)
+      end
+    end
+  end
+
+  describe Datadog::Core::Remote::Configuration::DigestList do
+    let(:digests) { { sha256: Digest::SHA256.hexdigest(value) } }
+    subject(:digest_list) { described_class.parse(digests) }
+
+    describe '#check' do
+      context 'valid content' do
+        let(:value) { 'Hello World' }
+        it 'returns true' do
+          expect(digest_list.check(content)).to eq(true)
+        end
+      end
+
+      context 'invalid content' do
+        let(:value) { 'wrong value' }
+        it 'returns false' do
+          expect(digest_list.check(content)).to eq(false)
+        end
+      end
+    end
+  end
+end

--- a/spec/datadog/core/remote/configuration/digest_spec.rb
+++ b/spec/datadog/core/remote/configuration/digest_spec.rb
@@ -21,6 +21,12 @@ RSpec.describe Datadog::Core::Remote::Configuration::Digest do
         hexdigest = 'a591a6d40bf420404a011733cfb7b190d62c65bf0bcda32b57b277d9ad9f146e'
         expect(described_class.hexdigest(:sha256, data)).to eq(hexdigest)
       end
+
+      it 'ensures data is rewinded' do
+        expect(data.eof?).to eq(false)
+        described_class.hexdigest(:sha256, data)
+        expect(data.eof?).to eq(false)
+      end
     end
 
     context 'invalid type is not supported' do

--- a/spec/datadog/core/remote/configuration/respository_spec.rb
+++ b/spec/datadog/core/remote/configuration/respository_spec.rb
@@ -8,10 +8,6 @@ RSpec.describe Datadog::Core::Remote::Configuration::Repository do
   subject(:repository) { described_class.new }
   let(:raw_target) do
     {
-      'custom' =>
-        { 'c' => ['854b784e-64ae-4c82-ac9b-fc2aea723260'],
-          'tracer-predicates' => { 'tracer_predicates_v1' => [{ 'clientID' => '854b784e-64ae-4c82-ac9b-fc2aea723260' }] },
-          'v' => 21 },
       'hashes' => { 'sha256' => Digest::SHA256.hexdigest(raw.to_json) },
       'length' => 645
     }
@@ -94,6 +90,17 @@ RSpec.describe Datadog::Core::Remote::Configuration::Repository do
 
   let(:content) do
     Datadog::Core::Remote::Configuration::Content.parse({ :path => path.to_s, :content => string_io_content })
+  end
+
+  let(:new_content_string_io_content) { StringIO.new('hello world') }
+
+  let(:new_content) do
+    Datadog::Core::Remote::Configuration::Content.parse(
+      {
+        :path => path.to_s,
+        :content => new_content_string_io_content
+      }
+    )
   end
 
   describe '#transaction' do
@@ -252,6 +259,97 @@ RSpec.describe Datadog::Core::Remote::Configuration::Repository do
   describe '#state' do
     it 'returns a state instance' do
       expect(repository.state).to be_a(described_class::State)
+    end
+  end
+
+  describe Datadog::Core::Remote::Configuration::Repository::State do
+    let(:repository) { Datadog::Core::Remote::Configuration::Repository.new }
+    subject(:state) { repository.state }
+
+    describe '#config_states' do
+      context 'without changes' do
+        it 'return empty array' do
+          expect(state.config_states).to eq([])
+        end
+      end
+
+      context 'with changes' do
+        before do
+          content.hash(:sha256)
+          new_content.hash(:sha256)
+        end
+
+        let(:expected_config_states) do
+          [
+            {
+              :hashes => [
+                {
+                  algorithm: :sha256,
+                  hash: content.hash(:sha256)
+                }
+              ],
+              :length => 645,
+              :path => 'datadog/603646/ASM/exclusion_filters/config'
+            }
+          ]
+        end
+
+        context 'insert' do
+          it 'return config_states' do
+            repository.transaction do |_repository, transaction|
+              transaction.insert(path, target, content)
+            end
+
+            expect(state.config_states).to eq(expected_config_states)
+          end
+        end
+
+        context 'update' do
+          it 'return config_states' do
+            repository.transaction do |_repository, transaction|
+              transaction.insert(path, target, content)
+            end
+
+            expect(state.config_states).to eq(expected_config_states)
+
+            repository.transaction do |_repository, transaction|
+              transaction.update(path, target, new_content)
+            end
+
+            expected_updated_config_states = [
+              {
+                :hashes => [
+                  {
+                    algorithm: :sha256,
+                    hash: new_content.hash(:sha256)
+                  }
+                ],
+                :length => new_content_string_io_content.length,
+                :path => 'datadog/603646/ASM/exclusion_filters/config'
+              }
+            ]
+
+            expect(state.config_states).to_not eq(expected_config_states)
+            expect(state.config_states).to eq(expected_updated_config_states)
+          end
+        end
+
+        context 'delete' do
+          it 'return config_states' do
+            repository.transaction do |_repository, transaction|
+              transaction.insert(path, target, content)
+            end
+
+            expect(state.config_states).to eq(expected_config_states)
+
+            repository.transaction do |_repository, transaction|
+              transaction.delete(path)
+            end
+
+            expect(state.config_states).to eq([])
+          end
+        end
+      end
     end
   end
 end

--- a/spec/datadog/core/remote/configuration/respository_spec.rb
+++ b/spec/datadog/core/remote/configuration/respository_spec.rb
@@ -264,19 +264,18 @@ RSpec.describe Datadog::Core::Remote::Configuration::Repository do
 
   describe Datadog::Core::Remote::Configuration::Repository::State do
     let(:repository) { Datadog::Core::Remote::Configuration::Repository.new }
-    subject(:state) { repository.state }
 
     describe '#config_states' do
       context 'without changes' do
         it 'return empty array' do
-          expect(state.config_states).to eq([])
+          expect(repository.state.config_states).to eq([])
         end
       end
 
       context 'with changes' do
         before do
-          content.hash(:sha256)
-          new_content.hash(:sha256)
+          content.hexdigest(:sha256)
+          new_content.hexdigest(:sha256)
         end
 
         let(:expected_config_states) do
@@ -285,7 +284,7 @@ RSpec.describe Datadog::Core::Remote::Configuration::Repository do
               :hashes => [
                 {
                   algorithm: :sha256,
-                  hash: content.hash(:sha256)
+                  hash: content.hexdigest(:sha256)
                 }
               ],
               :length => 645,
@@ -300,7 +299,7 @@ RSpec.describe Datadog::Core::Remote::Configuration::Repository do
               transaction.insert(path, target, content)
             end
 
-            expect(state.config_states).to eq(expected_config_states)
+            expect(repository.state.config_states).to eq(expected_config_states)
           end
         end
 
@@ -310,7 +309,7 @@ RSpec.describe Datadog::Core::Remote::Configuration::Repository do
               transaction.insert(path, target, content)
             end
 
-            expect(state.config_states).to eq(expected_config_states)
+            expect(repository.state.config_states).to eq(expected_config_states)
 
             repository.transaction do |_repository, transaction|
               transaction.update(path, target, new_content)
@@ -321,7 +320,7 @@ RSpec.describe Datadog::Core::Remote::Configuration::Repository do
                 :hashes => [
                   {
                     algorithm: :sha256,
-                    hash: new_content.hash(:sha256)
+                    hash: new_content.hexdigest(:sha256)
                   }
                 ],
                 :length => new_content_string_io_content.length,
@@ -329,8 +328,8 @@ RSpec.describe Datadog::Core::Remote::Configuration::Repository do
               }
             ]
 
-            expect(state.config_states).to_not eq(expected_config_states)
-            expect(state.config_states).to eq(expected_updated_config_states)
+            expect(repository.state.config_states).to_not eq(expected_config_states)
+            expect(repository.state.config_states).to eq(expected_updated_config_states)
           end
         end
 
@@ -340,13 +339,13 @@ RSpec.describe Datadog::Core::Remote::Configuration::Repository do
               transaction.insert(path, target, content)
             end
 
-            expect(state.config_states).to eq(expected_config_states)
+            expect(repository.state.config_states).to eq(expected_config_states)
 
             repository.transaction do |_repository, transaction|
               transaction.delete(path)
             end
 
-            expect(state.config_states).to eq([])
+            expect(repository.state.config_states).to eq([])
           end
         end
       end

--- a/spec/datadog/core/remote/configuration/target_spec.rb
+++ b/spec/datadog/core/remote/configuration/target_spec.rb
@@ -170,10 +170,6 @@ RSpec.describe Datadog::Core::Remote::Configuration::TargetMap do
   describe Datadog::Core::Remote::Configuration::Target do
     let(:raw_target) do
       {
-        'custom' =>
-          { 'c' => ['854b784e-64ae-4c82-ac9b-fc2aea723260'],
-            'tracer-predicates' => { 'tracer_predicates_v1' => [{ 'clientID' => '854b784e-64ae-4c82-ac9b-fc2aea723260' }] },
-            'v' => 21 },
         'hashes' => { 'sha256' => Digest::SHA256.hexdigest(raw.to_json) },
         'length' => 645
       }


### PR DESCRIPTION
The `cached_target_files` field intends to signal to the agent what files the tracer has seen and subsequent requests. We do not have to pull that information from the agent.

We can retrieve that information from the `repository.contents`

To do that, we have to tweak a little the different remote configuration components. The `Digest` and `DigestList` are no longer private classes under `Target`. 
We will use the `Digest` class to compute the hash value of the content on demand and store that information on the `Content` instances. That way, we do not have to calculate the hash of the content over an over. 

Another quick addition is adding support for `:sha512`. The remote configuration backend supports hashing the content using that algorithm. 


