### PR TITLE
Add workaround for pending gitlab benchmark jobs

### DIFF
--- a/.gitlab/benchmarks.yml
+++ b/.gitlab/benchmarks.yml
@@ -14,10 +14,8 @@ variables:
     - if: $CI_PIPELINE_SOURCE == "schedule"
       when: always
     - when: manual
-
   # If you have a problem with Gitlab cache, see Troubleshooting section in Benchmarking Platform docs
   image: $GITLAB_BENCHMARKS_CI_IMAGE
-
   script:
     - export ARTIFACTS_DIR="$(pwd)/reports" && (mkdir "${ARTIFACTS_DIR}" || :)
     - export DD_API_KEY=$(aws ssm get-parameter --region us-east-1 --name ci.dd-trace-rb.dd_api_key --with-decryption --query "Parameter.Value" --out text)
@@ -34,6 +32,10 @@ variables:
     FF_USE_LEGACY_KUBERNETES_EXECUTION_STRATEGY: "true"
     DD_RELENV_DDTRACE_COMMIT_ID: $CI_COMMIT_SHORT_SHA
     K6_RUN_ID_PREFIX: ci_rb
+  # Workaround: Currently we're not running the benchmarks on every PR, but GitHub still shows them as pending.
+  # By marking the benchmarks as allow_failure, this should go away. (This workaround should be removed once the
+  # benchmarks get changed to run on every PR)
+  allow_failure: true
 
 baseline-benchmarks:
   extends: .benchmarks


### PR DESCRIPTION
**What does this PR do?**:

This PR adds a workaround for the GitLab benchmark jobs configuration that was causing them to show up on GitHub as "Pending" and never completing for every PR.

| Screenshot without fix |
| ---------- |
| ![image (6)](https://user-images.githubusercontent.com/2785847/231196868-c949c801-68da-47e6-9d6d-98dccc769da9.png) |

**Motivation**:

Currently the jobs don't run on every PR so this fixes the "Pending" issue.

Hopefully soon we'll start running the benchmarks on every PR and so we'll be able to remove this workaround.

**Additional Notes**:

Thanks @ddyurchenko for the help setting this so far.

**How to test the change?**:

Verify that you no longer see "Pending" jobs on the GitHub CI status.
