### PR TITLE
Protect Processor::Context#run with a mutex

### DIFF
--- a/lib/datadog/appsec/processor.rb
+++ b/lib/datadog/appsec/processor.rb
@@ -22,11 +22,13 @@ module Datadog
 
           start_ns = Core::Utils::Time.get_time(:nanosecond)
 
+          # this WAF::Context#run call is not thread safe as it mutates the context
           # TODO: remove multiple assignment
           _code, res = @context.run(input, timeout)
 
           stop_ns = Core::Utils::Time.get_time(:nanosecond)
 
+          # these updates are not thread safe and should be protected
           @time_ns += res.total_runtime
           @time_ext_ns += (stop_ns - start_ns)
           @timeouts += 1 if res.timeout

--- a/lib/datadog/appsec/processor.rb
+++ b/lib/datadog/appsec/processor.rb
@@ -14,9 +14,12 @@ module Datadog
           @time_ext_ns = 0.0
           @timeouts = 0
           @events = []
+          @run_mutex = Mutex.new
         end
 
         def run(input, timeout = WAF::LibDDWAF::DDWAF_RUN_TIMEOUT)
+          @run_mutex.lock
+
           start_ns = Core::Utils::Time.get_time(:nanosecond)
 
           # TODO: remove multiple assignment
@@ -30,6 +33,8 @@ module Datadog
           @timeouts += 1 if res.timeout
 
           res
+        ensure
+          @run_mutex.unlock
         end
 
         def finalize

--- a/lib/datadog/appsec/processor.rb
+++ b/lib/datadog/appsec/processor.rb
@@ -23,8 +23,7 @@ module Datadog
           start_ns = Core::Utils::Time.get_time(:nanosecond)
 
           # TODO: remove multiple assignment
-          _code, res = _ = @context.run(input, timeout)
-          # @type var res: WAF::Result
+          _code, res = @context.run(input, timeout)
 
           stop_ns = Core::Utils::Time.get_time(:nanosecond)
 

--- a/sig/datadog/appsec/processor.rbs
+++ b/sig/datadog/appsec/processor.rbs
@@ -12,6 +12,8 @@ module Datadog
 
         @context: WAF::Context
 
+        @run_mutex: ::Thread::Mutex
+
         def initialize: (Processor processor) -> void
         def run: (data input, ?::Integer timeout) -> WAF::Result
         def finalize: () -> void

--- a/vendor/rbs/libddwaf/0/datadog/appsec/waf.rbs
+++ b/vendor/rbs/libddwaf/0/datadog/appsec/waf.rbs
@@ -202,7 +202,7 @@ module Datadog
         def initialize: (Handle handle) -> void
         def finalize: () -> void
 
-        def run: (data input, ?::Integer timeout) -> ::Array[top]
+        def run: (data input, ?::Integer timeout) -> [::Symbol, Result]
 
         private
 


### PR DESCRIPTION
<!--
Check out the
https://github.com/DataDog/dd-trace-rb/blob/master/docs/DevelopmentGuide.md
for guidance on how to set up your development environment,
run the test suite, write new integrations, and more.
-->

**What does this PR do?**

Protect Processor::Context#run with a mutex

**Motivation**

`ddwaf_run` mutates `ddwaf_context` in a non-thread-safe way.

**Additional Notes**

Sicne there is a 1:1:1 context - request - web worker thread mapping it should very rarely happen in typical apps so the lock will just fly through.

This aims to protect from code that spawns threads within a request and that would theoretically trigger a context run (e.g [ActionController::Live](https://github.com/rails/rails/blob/2675c906b1cc4cc877ddee4d62dc33f544adc748/actionpack/lib/action_controller/metal/live.rb)). There is currently none but there could be in the future.

**How to test the change?**

Difficult since there's no such real case currently. Even synthetically (e.g in a spec) it would be hard as it would require producing a reliably failing case of libddwaf stepping onto itself.