### PR TITLE
require appsec instrumentation files only when instrumentation has been activated.

### DIFF
--- a/lib/datadog/appsec/contrib/rack/integration.rb
+++ b/lib/datadog/appsec/contrib/rack/integration.rb
@@ -4,8 +4,6 @@ require_relative '../integration'
 
 require_relative 'configuration/settings'
 require_relative 'patcher'
-require_relative 'request_middleware'
-require_relative 'request_body_middleware'
 
 module Datadog
   module AppSec
@@ -24,7 +22,7 @@ module Datadog
           end
 
           def self.loaded?
-            !defined?(::Rack).nil?
+            !defined?(::Rack::Request).nil?
           end
 
           def self.compatible?

--- a/lib/datadog/appsec/contrib/rack/patcher.rb
+++ b/lib/datadog/appsec/contrib/rack/patcher.rb
@@ -1,8 +1,6 @@
 # frozen_string_literal: true
 
 require_relative '../patcher'
-require_relative '../../monitor'
-require_relative 'gateway/watcher'
 
 module Datadog
   module AppSec
@@ -23,6 +21,11 @@ module Datadog
           end
 
           def patch
+            require_relative 'gateway/watcher'
+            require_relative '../../monitor'
+            require_relative 'request_middleware'
+            require_relative 'request_body_middleware'
+
             Monitor::Gateway::Watcher.watch
             Gateway::Watcher.watch
             Patcher.instance_variable_set(:@patched, true)

--- a/lib/datadog/appsec/contrib/rails/patcher.rb
+++ b/lib/datadog/appsec/contrib/rails/patcher.rb
@@ -3,14 +3,6 @@
 require_relative '../../../core/utils/only_once'
 
 require_relative '../patcher'
-require_relative 'framework'
-require_relative '../../response'
-require_relative '../rack/request_middleware'
-require_relative '../rack/request_body_middleware'
-require_relative 'gateway/watcher'
-require_relative 'gateway/request'
-
-require_relative '../../../tracing/contrib/rack/middlewares'
 
 module Datadog
   module AppSec
@@ -34,6 +26,14 @@ module Datadog
           end
 
           def patch
+            require_relative 'framework'
+            require_relative '../../response'
+            require_relative '../rack/request_middleware'
+            require_relative '../rack/request_body_middleware'
+            require_relative 'gateway/watcher'
+            require_relative 'gateway/request'
+            require_relative '../../../tracing/contrib/rack/middlewares'
+
             Gateway::Watcher.watch
             patch_before_intialize
             patch_after_intialize

--- a/lib/datadog/appsec/contrib/sinatra/patcher.rb
+++ b/lib/datadog/appsec/contrib/sinatra/patcher.rb
@@ -1,15 +1,6 @@
 # frozen_string_literal: true
 
-require_relative '../../../tracing/contrib/rack/middlewares'
-
 require_relative '../patcher'
-require_relative '../../response'
-require_relative '../rack/request_middleware'
-require_relative 'framework'
-require_relative 'gateway/watcher'
-require_relative 'gateway/route_params'
-require_relative 'gateway/request'
-require_relative '../../../tracing/contrib/sinatra/framework'
 
 module Datadog
   module AppSec
@@ -131,6 +122,14 @@ module Datadog
           end
 
           def patch
+            require_relative '../../response'
+            require_relative '../rack/request_middleware'
+            require_relative 'framework'
+            require_relative 'gateway/watcher'
+            require_relative 'gateway/route_params'
+            require_relative 'gateway/request'
+            require_relative '../../../tracing/contrib/sinatra/framework'
+
             Gateway::Watcher.watch
             patch_default_middlewares
             patch_dispatch

--- a/spec/datadog/appsec/contrib/rack/gateway/response_spec.rb
+++ b/spec/datadog/appsec/contrib/rack/gateway/response_spec.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 require 'datadog/appsec/spec_helper'
-require 'datadog/appsec/contrib/rack/gateway/request'
+require 'datadog/appsec/contrib/rack/gateway/response'
 require 'datadog/appsec/processor'
 require 'rack'
 


### PR DESCRIPTION
The main reason to do this is to make sure we are not loading files that depend on customer dependencies
unless we are certain the customer wants to instrument such a library.

The customer complained that when trying to load `dd-trace-rb` for non-rack projects, some required files that depend on `Rack::Request` being loaded. 

The test script to validate that things are working as expected is:

```ruby
#!/usr/bin/env ruby

require 'bundler/inline'

gemfile do
  source 'https://rubygems.org'
  gem 'rack', require: 'rack/utils'
  gem 'ddtrace', '1.10.1', require: 'ddtrace/auto_instrument'
end
```

As we can see, the `rack` is loaded, but only a subset of the rack gem.

The changes on this PR fix it with two changes:
- Make sure only to require dedicated files for the instrumentation of rack, sinatra and rails when they get activated
- Making sure the rack integration condition `loaded?` does not simply check for the existence of `Rack` class, but `Rack::Request`, which signals that certain rack components have been loaded. 
