### PR TITLE
Make `racecar` traces use the default service name

### DIFF
--- a/lib/datadog/tracing/contrib/racecar/configuration/settings.rb
+++ b/lib/datadog/tracing/contrib/racecar/configuration/settings.rb
@@ -25,8 +25,6 @@ module Datadog
               o.default { env_to_float(Ext::ENV_ANALYTICS_SAMPLE_RATE, 1.0) }
               o.lazy
             end
-
-            option :service_name, default: Ext::DEFAULT_PEER_SERVICE_NAME
           end
         end
       end


### PR DESCRIPTION
Right now, if no `service_name` is specified for a `racecar` trace, the default will not come from the `DD_SERVICE` env var, but will rather be the static string `"racecar"`. This seems like a poor default, assuming an organization runs more than one consumer.

**What does this PR do?**
It removes the override for the `service_name` option, allowing the default behavior to take place.

**Motivation**
We want to configure our Datadog service names with Kubernetes annotations, but some integrations do not respect those, and we have to force the use of the env var on a case by case basis.

**How to test the change?**
Test that it uses the env var `DD_SERVICE` rather than just `"racecar"`.