### PR TITLE
Remove check for `::Rack::Request.instance_methods.include?(:each_header)` at load time

### DIFF
--- a/lib/datadog/appsec/contrib/rack/gateway/request.rb
+++ b/lib/datadog/appsec/contrib/rack/gateway/request.rb
@@ -33,20 +33,9 @@ module Datadog
               end
             end
 
-            # Rack < 2.0 does not have :each_header
-            # TODO: We need access to Rack here. We must make sure we are able to load AppSec without Rack,
-            # TODO: while still ensure correctness in ths code path.
-            if defined?(::Rack) && ::Rack::Request.instance_methods.include?(:each_header)
-              def headers
-                request.each_header.each_with_object({}) do |(k, v), h|
-                  h[k.gsub(/^HTTP_/, '').downcase.tr('_', '-')] = v if k =~ /^HTTP_/
-                end
-              end
-            else
-              def headers
-                request.env.each_with_object({}) do |(k, v), h|
-                  h[k.gsub(/^HTTP_/, '').downcase.tr('_', '-')] = v if k =~ /^HTTP_/
-                end
+            def headers
+              request.env.each_with_object({}) do |(k, v), h|
+                h[k.gsub(/^HTTP_/, '').downcase.tr('_', '-')] = v if k =~ /^HTTP_/
               end
             end
 

--- a/spec/datadog/appsec/contrib/rack/gateway/response_spec.rb
+++ b/spec/datadog/appsec/contrib/rack/gateway/response_spec.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 require 'datadog/appsec/spec_helper'
-require 'datadog/appsec/contrib/rack/gateway/request'
+require 'datadog/appsec/contrib/rack/gateway/response'
 require 'datadog/appsec/processor'
 require 'rack'
 


### PR DESCRIPTION
Fixes https://github.com/DataDog/dd-trace-rb/issues/2724

The easiest solution rather than checking for the existence of `each_header` method for a rack request is to simply use `request.env.each_with_object`.

Removing that code fixes the load time issue when using `dd-trace-rb` on a non rack base application