### PR TITLE
Scope the benchmarking service account to benchmarking jobs only

### DIFF
--- a/.gitlab/benchmarks.yml
+++ b/.gitlab/benchmarks.yml
@@ -3,7 +3,6 @@
 # -----------------------------------------------------
 
 variables:
-  KUBERNETES_SERVICE_ACCOUNT_OVERWRITE: dd-trace-rb
   GITLAB_BENCHMARKS_CI_IMAGE: 486234852809.dkr.ecr.us-east-1.amazonaws.com/ci/benchmarking-platform:ruby-gitlab
 
 .benchmarks:
@@ -32,6 +31,7 @@ variables:
     FF_USE_LEGACY_KUBERNETES_EXECUTION_STRATEGY: "true"
     DD_RELENV_DDTRACE_COMMIT_ID: $CI_COMMIT_SHORT_SHA
     K6_RUN_ID_PREFIX: ci_rb
+    KUBERNETES_SERVICE_ACCOUNT_OVERWRITE: dd-trace-rb
   # Workaround: Currently we're not running the benchmarks on every PR, but GitHub still shows them as pending.
   # By marking the benchmarks as allow_failure, this should go away. (This workaround should be removed once the
   # benchmarks get changed to run on every PR)


### PR DESCRIPTION
<!--
Check out the
https://github.com/DataDog/dd-trace-rb/blob/master/docs/DevelopmentGuide.md
for guidance on how to set up your development environment,
run the test suite, write new integrations, and more.
-->

**What does this PR do?**
Scope the benchmarking service account to benchmarking jobs only
<!-- A brief description of the change being made with this pull request. -->

**Motivation**
Ruby deployments to the reliability environment have been broken for a week. The cause was traced to https://github.com/DataDog/dd-trace-rb/commit/65459510a66ef8ce11550b3df0e720dc4ad42065
<!-- What inspired you to submit this pull request? -->

**How to test the change?**
* Validate deploys to the reliability env are fixed
* Validate running benchmarks still works