### PR TITLE
Fix profiler flaky test due to incomplete dynamic sampling rate disable mechanism

### DIFF
--- a/spec/datadog/profiling/collectors/cpu_and_wall_time_worker_spec.rb
+++ b/spec/datadog/profiling/collectors/cpu_and_wall_time_worker_spec.rb
@@ -329,7 +329,9 @@ RSpec.describe Datadog::Profiling::Collectors::CpuAndWallTimeWorker do
         # Sanity checking
 
         # We're currently targeting 100 samples per second, so 5 in 100ms is a conservative approximation that hopefully
-        # will not cause flakiness
+        # will not cause flakiness.
+        # If this turns out to be flaky due to the dynamic sampling rate mechanism, it can be disabled like we do for
+        # the test below.
         expect(sample_count).to be >= 5, "sample_count: #{sample_count}, stats: #{stats}"
         expect(trigger_sample_attempts).to be >= sample_count
       end
@@ -341,8 +343,6 @@ RSpec.describe Datadog::Profiling::Collectors::CpuAndWallTimeWorker do
       before { expect(Datadog.logger).to receive(:warn).with(/dynamic sampling rate disabled/) }
 
       it 'is able to sample even when all threads are sleeping' do
-        skip('Test is flaky -- @ivoanjo is investigating')
-
         start
         wait_until_running
 
@@ -559,6 +559,11 @@ RSpec.describe Datadog::Profiling::Collectors::CpuAndWallTimeWorker do
         signal_handler_enqueued_sample: 0,
         signal_handler_wrong_thread: 0,
         sampled: 0,
+        skipped_sample_because_of_dynamic_sampling_rate: 0,
+        postponed_job_skipped_already_existed: 0,
+        postponed_job_success: 0,
+        postponed_job_full: 0,
+        postponed_job_unknown_result: 0,
         sampling_time_ns_min: nil,
         sampling_time_ns_max: nil,
         sampling_time_ns_total: nil,


### PR DESCRIPTION
**What does this PR do?**:

This PR is a follow-up of the saga of the "sampling while VM is idle" flaky spec.

In #2708 after analyzing previous failed specs, I determined that the profiler dynamic sampling rate mechanism was kicking in on this spec and making if flaky -- if e.g. CI was busy that day and some of the samples took longer than expected.

To combat this, #2708 introduced a way to disable the dynamic sampling rate mechanism, so we could still assert on the correctness of the profiler in this test.

But unfortunately I did not properly disable the mechanism, and this meant that the flaky test came back to haunt us, leading us to disable it in #2759.

This PR fixes the missing disable step in
`rescued_sample_from_postponed_job`, and re-enables the flaky spec.

This check was missing from the earlier #2708 change because the dynamic sampling rate mechanism kicks in two places:
* Inside `run_sampling_trigger_loop`, it's used to decide for how long to sleep for (this was what #2708 changed)
* Inside `rescued_sample_from_postponed_job`, it's used to actually decide if a sample should happen or not. This was what was missing

Thus the problem was that background thread was ignoring the sleep part of the dynamic sampling rate mechanism and sending more signals, but the signals did not translate into samples since the latter filter skipped them.

This was what we saw in the logs of flaky executions ([Example](https://app.circleci.com/pipelines/github/DataDog/dd-trace-rb/9486/workflows/2fa85a35-19c0-4bdf-ac66-4a872080f7ab/jobs/352689/tests)):

> `Failure/Error: expect(sample_count).to be >= 8, "sample_count: #{sample_count}, stats: #{stats}, debug_failures: #{debug_failures}"`
> `  sample_count: 2, stats: {:trigger_sample_attempts=>20, :trigger_simulated_signal_delivery_attempts=>20, :simulated_signal_delivery=>20, :signal_handler_enqueued_sample=>20, :signal_handler_wrong_thread=>0, :sampled=>2, :sampling_time_ns_min=>115046, :sampling_time_ns_max=>3709725, :sampling_time_ns_total=>3824771, :sampling_time_ns_avg=>1912385.5, :allocations_during_sample=>0},`

In this case, there were 20 signals delivered, but only 2 samples taken.

As part of this fix, I added extra counters that I've been meaning to add that would've helped to diagnose issues like these.

**Motivation**:

These specs have been useful in the past to catch issues, so it's important to have them running in CI.

**Additional Notes**:

N/A

**How to test the change?**:

Validate that CI is green, and hopefully this is the last PR for a long time dealing with flakiness coming from this test.