### PR TITLE
Remove unused remote configuration payload from specs

### DIFF
--- a/spec/datadog/core/remote/client_spec.rb
+++ b/spec/datadog/core/remote/client_spec.rb
@@ -26,65 +26,12 @@ RSpec.describe Datadog::Core::Remote::Client do
   end
 
   let(:transport) { Datadog::Core::Transport::HTTP.v7(&proc { |_client| }) }
-  let(:roots) do
-    [
-      {
-        'signatures' => [
-          {
-            'keyid' => 'bla1',
-            'sig' => 'fake sig'
-          },
-        ],
-        'signed' => {
-          '_type' => 'root',
-          'consistent_snapshot' => true,
-          'expires' => '2022-02-01T00:00:00Z',
-          'keys' => {
-            'foo' => {
-              'keyid_hash_algorithms' => ['sha256', 'sha512'],
-              'keytype' => 'ed25519',
-              'keyval' => {
-                'public' => 'blabla'
-              },
-              'scheme' => 'ed25519'
-            }
-          },
-          'roles' => {
-            'root' => {
-              'keyids' => ['bla1',
-                           'bla2'],
-              'threshold' => 2
-            },
-            'snapshot' => {
-              'keyids' => ['foo'],
-              'threshold' => 1 \
-            },
-            'targets' => { \
-              'keyids' => ['foo'],
-              'threshold' => 1 \
-            },
-            'timestamp' => {
-              'keyids' => ['foo'],
-              'threshold' => 1
-            }
-          },
-          'spec_version' => '1.0',
-          'version' => 2
-        }
-      },
-    ]
-  end
-
+  # In the current version of remote configuration roots need to be an array
+  # but the content is not used
+  let(:roots) { [] }
   let(:exclusions_filter_content) do
     {
       'datadog/603646/ASM/exclusion_filters/config' => {
-        'custom' => {
-          'c' => ['client_id'],
-          'tracer-predicates' => {
-            'tracer_predicates_v1' => [{ 'clientID' => 'client_id' }]
-          },
-          'v' => 21
-        },
         'hashes' => { 'sha256' => Digest::SHA256.hexdigest(exclusions) },
         'length' => 645
       }
@@ -94,11 +41,6 @@ RSpec.describe Datadog::Core::Remote::Client do
   let(:blocked_ips_content) do
     {
       'datadog/603646/ASM_DATA/blocked_ips/config' => {
-        'custom' => {
-          'c' => ['client_id'],
-          'tracer-predicates' => { 'tracer_predicates_v1' => [{ 'clientID' => 'client_id' }] },
-          'v' => 51
-        },
         'hashes' => { 'sha256' => Digest::SHA256.hexdigest(blocked_ips) },
         'length' => 1834
       },
@@ -108,13 +50,6 @@ RSpec.describe Datadog::Core::Remote::Client do
   let(:rules_content) do
     {
       'datadog/603646/ASM_DD/latest/config' => {
-        'custom' => {
-          'c' => ['client_id'],
-          'tracer-predicates' => {
-            'tracer_predicates_v1' => [{ 'clientID' => 'client_id' }]
-          },
-          'v' => 21
-        },
         'hashes' => { 'sha256' => Digest::SHA256.hexdigest(rules_data) },
         'length' => 645
       },
@@ -125,20 +60,11 @@ RSpec.describe Datadog::Core::Remote::Client do
 
   let(:targets) do
     {
-      'signatures' => [
-        {
-          'keyid' => 'hello',
-          'sig' => 'sig'
-        }
-      ],
       'signed' => {
-        '_type' => 'targets',
         'custom' => {
           'agent_refresh_interval' => 50,
           'opaque_backend_state' => 'iuycygweiuegciwbiecwbicw'
         },
-        'expires' => '2023-06-17T10:16:42Z',
-        'spec_version' => '1.0.0',
         'targets' => target_content,
         'version' => 46915439
       }
@@ -310,38 +236,20 @@ RSpec.describe Datadog::Core::Remote::Client do
 
           updated_targets = {
             'signed' => {
-              '_type' => 'targets',
               'custom' => {
                 'agent_refresh_interval' => 50,
                 'opaque_backend_state' => 'iucwgi'
               },
-              'expires' => '2023-06-17T10:16:42Z',
-              'spec_version' => '1.0.0',
               'targets' => {
                 'datadog/603646/ASM/exclusion_filters/config' => {
-                  'custom' => {
-                    'c' => ['client_id'],
-                    'tracer-predicates' => { 'tracer_predicates_v1' => [{ 'clientID' => 'client_id' }] },
-                    'v' => 21
-                  },
                   'hashes' => { 'sha256' => Digest::SHA256.hexdigest(exclusions) },
                   'length' => 645
                 },
                 'datadog/603646/ASM_DATA/blocked_ips/config' => {
-                  'custom' => {
-                    'c' => ['client_id'],
-                    'tracer-predicates' => { 'tracer_predicates_v1' => [{ 'clientID' => 'client_id' }] },
-                    'v' => 51
-                  },
                   'hashes' => { 'sha256' => Digest::SHA256.hexdigest(new_blocked_ips) },
                   'length' => 1834
                 },
                 'datadog/603646/ASM_DD/latest/config' => {
-                  'custom' => {
-                    'c' => ['client_id'],
-                    'tracer-predicates' => { 'tracer_predicates_v1' => [{ 'clientID' => 'client_id' }] },
-                    'v' => 51
-                  },
                   'hashes' => { 'sha256' => Digest::SHA256.hexdigest(rules_data) },
                   'length' => 1834
                 }
@@ -400,25 +308,7 @@ RSpec.describe Datadog::Core::Remote::Client do
 
         context 'missing target for path from the response' do
           let(:response_code) { 200 }
-          let(:target_content) do
-            {
-              'datadog/603646/ASM/exclusion_filters/config' => {
-                'custom' => {
-                  'c' => ['client_id'],
-                  'tracer-predicates' => {
-                    'tracer_predicates_v1' => [
-                      {
-                        'clientID' => 'client_id'
-                      }
-                    ]
-                  },
-                  'v' => 21
-                },
-                'hashes' => { 'sha256' => Digest::SHA256.hexdigest(exclusions) },
-                'length' => 645
-              },
-            }
-          end
+          let(:target_content) { {}.merge(exclusions_filter_content) }
 
           it 'raises SyncError' do
             expect do
@@ -434,15 +324,6 @@ RSpec.describe Datadog::Core::Remote::Client do
           let(:target_content) do
             {
               'invalid path' => {
-                'custom' => {
-                  'c' => ['client_id'],
-                  'tracer-predicates' => {
-                    'tracer_predicates_v1' => [
-                      { 'clientID' => 'client_id' }
-                    ]
-                  },
-                  'v' => 21
-                },
                 'hashes' => { 'sha256' => 'fake sha' },
                 'length' => 645
               },

--- a/spec/datadog/core/remote/configuration/content_spec.rb
+++ b/spec/datadog/core/remote/configuration/content_spec.rb
@@ -7,10 +7,6 @@ require 'datadog/core/remote/configuration/target'
 RSpec.describe Datadog::Core::Remote::Configuration::ContentList do
   let(:raw_target) do
     {
-      'custom' =>
-        { 'c' => ['854b784e-64ae-4c82-ac9b-fc2aea723260'],
-          'tracer-predicates' => { 'tracer_predicates_v1' => [{ 'clientID' => '854b784e-64ae-4c82-ac9b-fc2aea723260' }] },
-          'v' => 21 },
       'hashes' => { 'sha256' => Digest::SHA256.hexdigest(raw.to_json) },
       'length' => 645
     }
@@ -136,17 +132,6 @@ RSpec.describe Datadog::Core::Remote::Configuration::ContentList do
     it 'returns nil if target does not check' do
       wrong_target = Datadog::Core::Remote::Configuration::Target.parse(
         {
-          'custom' => {
-            'c' => ['5bb79ec4-0f50-464c-8400-b88521e1b96e'],
-            'tracer-predicates' => {
-              'tracer_predicates_v1' => [
-                {
-                  'clientID' => '5bb79ec4-0f50-464c-8400-b88521e1b96e'
-                }
-              ]
-            },
-            'v' => 245
-          },
           'hashes' => { 'sha256' => 'e39c699e5e626da1a43369ab3e7f17cce6a21c0ce1d2261280c7f2ac61c5db1b' },
           'length' => 4605
         }

--- a/spec/datadog/core/remote/configuration/respository_spec.rb
+++ b/spec/datadog/core/remote/configuration/respository_spec.rb
@@ -199,8 +199,10 @@ RSpec.describe Datadog::Core::Remote::Configuration::Repository do
         expect(repository.contents[path]).to eq(content)
         new_path = Datadog::Core::Remote::Configuration::Path.parse('employee/ASM/exclusion_filters/config')
         new_content = Datadog::Core::Remote::Configuration::Content.parse(
-          { :path => new_path.to_s,
-            :content => StringIO.new('hello world') }
+          {
+            :path => new_path.to_s,
+            :content => StringIO.new('hello world')
+          }
         )
 
         changes = repository.transaction do |_repository, transaction|

--- a/spec/datadog/core/remote/configuration/target_spec.rb
+++ b/spec/datadog/core/remote/configuration/target_spec.rb
@@ -6,6 +6,7 @@ require 'datadog/core/remote/configuration/target'
 RSpec.describe Datadog::Core::Remote::Configuration::TargetMap do
   let(:version) { 46761194 }
   let(:opaque_backend_state) { 'eyJ2ZXJzaW9uIjoyLCJzdGF0ZSI6eyJmaWxlX2hhc2hlcyI6eyJkYXRhZG3FOMU44PSJdfX19' }
+  let(:target_path) { 'datadog/603646/ASM/exclusion_filters/config' }
   let(:raw) do
     {
       exclusions: [
@@ -79,12 +80,6 @@ RSpec.describe Datadog::Core::Remote::Configuration::TargetMap do
 
   let(:raw_target_map) do
     {
-      'signatures' => [
-        {
-          'keyid' => '44de082b06652b24c3ccfecba7dcbdb82f1cc58e3813f824665a6085a6d6b6a3',
-          'sig' => '0a66cbda8de50af143708a8811892786727260b707144b910c07d00e7950d'
-        }
-      ],
       'signed' =>
         {
           '_type' => 'targets',
@@ -94,26 +89,21 @@ RSpec.describe Datadog::Core::Remote::Configuration::TargetMap do
           },
           'expires' => '2023-06-15T15:25:56Z',
           'spec_version' => '1.0.0',
-          'targets' => {
-            'datadog/603646/ASM/exclusion_filters/config' => {
-              'custom' => {
-                'c' => ['5bb79ec4-0f50-464c-8400-b88521e1b96e'],
-                'tracer-predicates' => {
-                  'tracer_predicates_v1' => [
-                    {
-                      'clientID' => '5bb79ec4-0f50-464c-8400-b88521e1b96e'
-                    }
-                  ]
-                }, 'v' => 21
-              },
-              'hashes' => { 'sha256' => Digest::SHA256.hexdigest(raw.to_json) },
-              'length' => 645
-            },
-          },
+          'targets' => targets,
           'version' => version,
         }
     }
   end
+
+  let(:targets) do
+    {
+      target_path => {
+        'hashes' => { 'sha256' => Digest::SHA256.hexdigest(raw.to_json) },
+        'length' => 645
+      },
+    }
+  end
+
   describe '.parse' do
     context 'with valid target hash' do
       it 'returns a TargetMap instance' do
@@ -127,7 +117,7 @@ RSpec.describe Datadog::Core::Remote::Configuration::TargetMap do
       it 'uses path instances as key and target instance as value' do
         target_map = described_class.parse(raw_target_map)
 
-        path = Datadog::Core::Remote::Configuration::Path.parse('datadog/603646/ASM/exclusion_filters/config')
+        path = Datadog::Core::Remote::Configuration::Path.parse(target_path)
         expect(target_map[path]).to be_a(Datadog::Core::Remote::Configuration::Target)
 
         not_present_path = Datadog::Core::Remote::Configuration::Path.parse('employee/ASM_DD/17.recommended.json/config')
@@ -136,31 +126,10 @@ RSpec.describe Datadog::Core::Remote::Configuration::TargetMap do
     end
 
     context 'with valid target path' do
-      it 'raises Path::ParseError' do
-        invalid_data = {
-          'signatures' => [
-            {
-              'keyid' => '44de082b06652b24c3ccfecba7dcbdb82f1cc58e3813f824665a6085a6d6b6a3',
-              'sig' => '0a66cbda8de50af143708a881189278672'
-            }
-          ],
-          'signed' =>
-            {
-              '_type' => 'targets',
-              'custom' => {
-                'agent_refresh_interval' => 50,
-                'opaque_backend_state' => opaque_backend_state
-              },
-              'expires' => '2023-06-15T15:25:56Z',
-              'spec_version' => '1.0.0',
-              'targets' => {
-                'invalid_path' => {}
-              },
-              'version' => version,
-            }
-        }
+      let(:targets) { { 'invalid_path' => {} } }
 
-        expect { described_class.parse(invalid_data) }.to raise_error(
+      it 'raises Path::ParseError' do
+        expect { described_class.parse(raw_target_map) }.to raise_error(
           Datadog::Core::Remote::Configuration::Path::ParseError
         )
       end
@@ -191,7 +160,7 @@ RSpec.describe Datadog::Core::Remote::Configuration::TargetMap do
           string_io_content = StringIO.new(raw.to_json)
 
           content_hash = {
-            :path => 'datadog/603646/ASM/exclusion_filters/config',
+            :path => target_path,
             :content => string_io_content
           }
           content = Datadog::Core::Remote::Configuration::Content.parse(content_hash)
@@ -203,7 +172,7 @@ RSpec.describe Datadog::Core::Remote::Configuration::TargetMap do
       context 'invalid content' do
         it 'returns false' do
           content_hash = {
-            :path => 'datadog/603646/ASM/exclusion_filters/config',
+            :path => target_path,
             :content => StringIO.new('Hello World')
           }
           content = Datadog::Core::Remote::Configuration::Content.parse(content_hash)

--- a/spec/datadog/core/remote/dispatcher_spec.rb
+++ b/spec/datadog/core/remote/dispatcher_spec.rb
@@ -12,10 +12,6 @@ RSpec.describe Datadog::Core::Remote::Dispatcher do
   end
   let(:raw_target) do
     {
-      'custom' =>
-        { 'c' => ['854b784e-64ae-4c82-ac9b-fc2aea723260'],
-          'tracer-predicates' => { 'tracer_predicates_v1' => [{ 'clientID' => '854b784e-64ae-4c82-ac9b-fc2aea723260' }] },
-          'v' => 21 },
       'hashes' => { 'sha256' => Digest::SHA256.hexdigest(raw.to_json) },
       'length' => 645
     }


### PR DESCRIPTION
Reduce the amount of unnecessary information from the remote specs 