### PR TITLE
Fix CircleCI badge image

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # Datadog Trace Client
 
 [![Gem](https://img.shields.io/gem/v/ddtrace)](https://rubygems.org/gems/ddtrace/)
-[![CircleCI](https://circleci.com/gh/DataDog/dd-trace-rb/tree/master.svg?style=svg&circle-token=b0bd5ef866ec7f7b018f48731bb495f2d1372cc1)](https://circleci.com/gh/DataDog/dd-trace-rb/tree/master)
+[![CircleCI](https://circleci.com/gh/DataDog/dd-trace-rb/tree/master.svg?style=svg)](https://circleci.com/gh/DataDog/dd-trace-rb/tree/master)
 [![codecov](https://codecov.io/gh/DataDog/dd-trace-rb/branch/master/graph/badge.svg)](https://app.codecov.io/gh/DataDog/dd-trace-rb/branch/master)
 [![YARD documentation](https://img.shields.io/badge/YARD-documentation-blue)][api docs]
 


### PR DESCRIPTION
The previous link to our badge image had a `circle-token` parameter that is no longer valid.

This PR removes the `circle-token` altogether, given it's not required for public repositories.

The diff looks funny, ![Screenshot 2023-04-13 at 1 46 05 PM](https://user-images.githubusercontent.com/583503/231879026-00208a25-7817-49fe-9bd0-389b54a6fa88.png), but clicking "View file" will show you the actual result.

