### PR TITLE
Fix missing digest require

### DIFF
--- a/lib/datadog/core/remote/configuration/digest.rb
+++ b/lib/datadog/core/remote/configuration/digest.rb
@@ -1,5 +1,7 @@
 # frozen_string_literal: true
 
+require 'digest'
+
 module Datadog
   module Core
     module Remote


### PR DESCRIPTION
<!--
Check out the
https://github.com/DataDog/dd-trace-rb/blob/master/docs/DevelopmentGuide.md
for guidance on how to set up your development environment,
run the test suite, write new integrations, and more.
-->

**What does this PR do?**
<!-- A brief description of the change being made with this pull request. -->

**Motivation**

Saw a bunch of these locally:

```
D, [2023-04-13T23:08:57.783586 #4664] DEBUG -- ddtrace: [ddtrace] (/Users/lloeki/Source/github.com/DataDog/dd-trace-rb/lib/datadog/core/remote/worker.rb:89:in `call') remote worker perform
E, [2023-04-13T23:08:57.842171 #4664] ERROR -- ddtrace: [ddtrace] (/Users/lloeki/Source/github.com/DataDog/dd-trace-rb/lib/datadog/core/remote/component.rb:32:in `rescue in block in initialize') remote worker error: NameError uninitialized constant Digest

                    ::Digest::SHA256.new
                    ^^^^^^^^ location: /Users/lloeki/Source/github.com/DataDog/dd-trace-rb/lib/datadog/core/remote/configuration/digest.rb:31:in `hexdigest'
```

Dunno exactly when I started my Puma process so I can't say for sure which branch triggered it. I think it's https://github.com/DataDog/dd-trace-rb/pull/2771.

**Additional Notes**

Nope

**How to test the change?**

Run an app with `DD_REMOTE_CONFIGURATION_ENABLED=true` and hit it with a request to trigger a RC start.