### PR TITLE
Fix cached_target_files.

### DIFF
--- a/lib/datadog/core/remote/client.rb
+++ b/lib/datadog/core/remote/client.rb
@@ -137,14 +137,7 @@ module Datadog
               # base64 is needed otherwise the Go agent fails with an unmarshal error
               capabilities: @capabilities.base64_capabilities
             },
-            cached_target_files: [
-              # TODO: to be implemented once we cache configuration content
-              # {
-              #   path: '',
-              #   length: 0,
-              #   hashes: '';
-              # }
-            ],
+            cached_target_files: state.cached_target_files,
           }
         end
       end

--- a/lib/datadog/core/remote/configuration/repository.rb
+++ b/lib/datadog/core/remote/configuration/repository.rb
@@ -71,21 +71,23 @@ module Datadog
               :config_states,
               :has_error,
               :error,
-              :opaque_backend_state
+              :opaque_backend_state,
+              :cached_target_files
 
             def initialize(repository)
               @repository = repository
               @root_version = repository.root_version
               @targets_version = repository.targets_version
-              @config_states = contents_to_config_states(repository.contents)
+              @config_states = []
               @has_error = false
               @error = ''
               @opaque_backend_state = repository.opaque_backend_state
+              @cached_target_files = contents_to_cached_target_files(repository.contents)
             end
 
             private
 
-            def contents_to_config_states(contents)
+            def contents_to_cached_target_files(contents)
               return [] if contents.empty?
 
               contents.map do |content|

--- a/sig/datadog/core/remote/configuration/repository.rbs
+++ b/sig/datadog/core/remote/configuration/repository.rbs
@@ -34,7 +34,9 @@ module Datadog
 
             attr_reader repository: Repository
 
-            attr_reader config_states: Array[Hash[Symbol, untyped]]
+            attr_reader config_states: Array[untyped]
+
+            attr_reader cached_target_files: Array[Hash[Symbol, untyped]]
 
             attr_reader has_error: bool
 
@@ -46,7 +48,7 @@ module Datadog
 
             private
 
-            def contents_to_config_states: (ContentList contents) -> Array[Hash[Symbol, untyped]]
+            def contents_to_cached_target_files: (ContentList contents) -> Array[Hash[Symbol, untyped]]
           end
 
           class Transaction

--- a/spec/datadog/core/remote/configuration/respository_spec.rb
+++ b/spec/datadog/core/remote/configuration/respository_spec.rb
@@ -265,10 +265,10 @@ RSpec.describe Datadog::Core::Remote::Configuration::Repository do
   describe Datadog::Core::Remote::Configuration::Repository::State do
     let(:repository) { Datadog::Core::Remote::Configuration::Repository.new }
 
-    describe '#config_states' do
+    describe '#cached_target_files' do
       context 'without changes' do
         it 'return empty array' do
-          expect(repository.state.config_states).to eq([])
+          expect(repository.state.cached_target_files).to eq([])
         end
       end
 
@@ -278,7 +278,7 @@ RSpec.describe Datadog::Core::Remote::Configuration::Repository do
           new_content.hexdigest(:sha256)
         end
 
-        let(:expected_config_states) do
+        let(:expected_cached_target_files) do
           [
             {
               :hashes => [
@@ -294,28 +294,28 @@ RSpec.describe Datadog::Core::Remote::Configuration::Repository do
         end
 
         context 'insert' do
-          it 'return config_states' do
+          it 'return cached_target_files' do
             repository.transaction do |_repository, transaction|
               transaction.insert(path, target, content)
             end
 
-            expect(repository.state.config_states).to eq(expected_config_states)
+            expect(repository.state.cached_target_files).to eq(expected_cached_target_files)
           end
         end
 
         context 'update' do
-          it 'return config_states' do
+          it 'return cached_target_files' do
             repository.transaction do |_repository, transaction|
               transaction.insert(path, target, content)
             end
 
-            expect(repository.state.config_states).to eq(expected_config_states)
+            expect(repository.state.cached_target_files).to eq(expected_cached_target_files)
 
             repository.transaction do |_repository, transaction|
               transaction.update(path, target, new_content)
             end
 
-            expected_updated_config_states = [
+            expected_updated_cached_target_files = [
               {
                 :hashes => [
                   {
@@ -328,24 +328,24 @@ RSpec.describe Datadog::Core::Remote::Configuration::Repository do
               }
             ]
 
-            expect(repository.state.config_states).to_not eq(expected_config_states)
-            expect(repository.state.config_states).to eq(expected_updated_config_states)
+            expect(repository.state.cached_target_files).to_not eq(expected_cached_target_files)
+            expect(repository.state.cached_target_files).to eq(expected_updated_cached_target_files)
           end
         end
 
         context 'delete' do
-          it 'return config_states' do
+          it 'return cached_target_files' do
             repository.transaction do |_repository, transaction|
               transaction.insert(path, target, content)
             end
 
-            expect(repository.state.config_states).to eq(expected_config_states)
+            expect(repository.state.cached_target_files).to eq(expected_cached_target_files)
 
             repository.transaction do |_repository, transaction|
               transaction.delete(path)
             end
 
-            expect(repository.state.config_states).to eq([])
+            expect(repository.state.cached_target_files).to eq([])
           end
         end
       end


### PR DESCRIPTION
On the previous PR https://github.com/DataDog/dd-trace-rb/pull/2771 we populate `config_states` but we wanted to populate `cached_target_files`.

I validated this changes works against our system-tests


