### PR TITLE
Migrate ddprof microbenchmarks from RelEnv

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -1,6 +1,7 @@
 stages:
   - deploy
-  - benchmarks
+  - macrobenchmarks
+  - microbenchmarks
 
 include: ".gitlab/benchmarks.yml"
 

--- a/.gitlab/benchmarks.yml
+++ b/.gitlab/benchmarks.yml
@@ -80,7 +80,7 @@ ddprof-benchmark:
   script:
     - export ARTIFACTS_DIR="$(pwd)/reports" && (mkdir "${ARTIFACTS_DIR}" || :)
     - export DD_API_KEY=$(aws ssm get-parameter --region us-east-1 --name ci.dd-trace-rb.dd_api_key --with-decryption --query "Parameter.Value" --out text)
-    - git clone --branch ruby/gitlab https://gitlab-ci-token:${CI_JOB_TOKEN}@gitlab.ddbuild.io/DataDog/benchmarking-platform /platform && cd /platform
+    - git clone --branch ruby/ddprof-benchmark https://gitlab-ci-token:${CI_JOB_TOKEN}@gitlab.ddbuild.io/DataDog/benchmarking-platform /platform && cd /platform
     - ./steps/capture-hardware-software-info.sh
     - ./steps/run-benchmarks.sh
     - "./steps/upload-results-to-s3.sh || :"

--- a/.gitlab/benchmarks.yml
+++ b/.gitlab/benchmarks.yml
@@ -4,6 +4,7 @@
 
 variables:
   GITLAB_BENCHMARKS_CI_IMAGE: 486234852809.dkr.ecr.us-east-1.amazonaws.com/ci/benchmarking-platform:ruby-gitlab
+  GITLAB_DDPROF_BENCHMARK_CI_IMAGE: 486234852809.dkr.ecr.us-east-1.amazonaws.com/ci/benchmarking-platform:ruby-ddprof-benchmark
 
 .benchmarks:
   stage: benchmarks
@@ -28,7 +29,7 @@ variables:
       - reports/
     expire_in: 3 months
   variables:
-    FF_USE_LEGACY_KUBERNETES_EXECUTION_STRATEGY: "true"
+    FF_USE_LEGACY_KUBERNETES_EXECUTION_STRATEGY: "true" # Important tweak for stability of benchmarks
     DD_RELENV_DDTRACE_COMMIT_ID: $CI_COMMIT_SHORT_SHA
     K6_RUN_ID_PREFIX: ci_rb
     KUBERNETES_SERVICE_ACCOUNT_OVERWRITE: dd-trace-rb
@@ -66,3 +67,29 @@ profiling-and-tracing-and-appsec-benchmarks:
   extends: .benchmarks
   variables:
     DD_RELENV_CONFIGURATION: profiling-and-tracing-and-appsec
+
+# -----------------------------------------------------
+# Microbenchmarks that report to statsd
+# -----------------------------------------------------
+ddprof-benchmark:
+  stage: benchmarks
+  tags: ["runner:apm-k8s-same-cpu"]
+  timeout: 1h
+  when: manual
+  image: $GITLAB_DDPROF_BENCHMARK_CI_IMAGE
+  script:
+    - export ARTIFACTS_DIR="$(pwd)/reports" && (mkdir "${ARTIFACTS_DIR}" || :)
+    - export DD_API_KEY=$(aws ssm get-parameter --region us-east-1 --name ci.dd-trace-rb.dd_api_key --with-decryption --query "Parameter.Value" --out text)
+    - git clone --branch ruby/gitlab https://gitlab-ci-token:${CI_JOB_TOKEN}@gitlab.ddbuild.io/DataDog/benchmarking-platform /platform && cd /platform
+    - ./steps/capture-hardware-software-info.sh
+    - ./steps/run-benchmarks.sh
+    - "./steps/upload-results-to-s3.sh || :"
+  artifacts:
+    name: "reports"
+    paths:
+      - reports/
+    expire_in: 3 months
+  variables:
+    FF_USE_LEGACY_KUBERNETES_EXECUTION_STRATEGY: "true" # Important tweak for stability of benchmarks
+    LATEST_COMMIT_ID: $CI_COMMIT_SHA
+    KUBERNETES_SERVICE_ACCOUNT_OVERWRITE: dd-trace-rb

--- a/.gitlab/benchmarks.yml
+++ b/.gitlab/benchmarks.yml
@@ -7,7 +7,7 @@ variables:
   GITLAB_DDPROF_BENCHMARK_CI_IMAGE: 486234852809.dkr.ecr.us-east-1.amazonaws.com/ci/benchmarking-platform:ruby-ddprof-benchmark
 
 .benchmarks:
-  stage: benchmarks
+  stage: macrobenchmarks
   tags: ["runner:apm-k8s-same-cpu"]
   timeout: 1h
   rules:
@@ -72,7 +72,7 @@ profiling-and-tracing-and-appsec-benchmarks:
 # Microbenchmarks that report to statsd
 # -----------------------------------------------------
 ddprof-benchmark:
-  stage: benchmarks
+  stage: microbenchmarks
   tags: ["runner:apm-k8s-same-cpu"]
   timeout: 1h
   when: manual


### PR DESCRIPTION
**What does this PR do?**

Migrate ddprof microbenchmarks from RelEnv into Benchmarking Platform.

**Motivation**

These microbenchmarks are broken in RelEnv, hopefully they will have some more love here.