### PR TITLE
Bump to version 1.11.0.beta1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,39 @@
 
 ## [Unreleased]
 
+## [1.11.0.beta1] - 2023-04-14
+
+As of ddtrace 1.11.0.beta1, CPU Profiling 2.0 is now GA and enabled by default. For more details, check the release notes.
+
+As of ddtrace 1.11.0.beta1, Remote Configuration is now public beta and disabled by default. For more details, check the release notes.
+
+### Added
+
+* Add remote configuration beta, disabled by default ([#2674][], [#2678][], [#2686][], [#2687][], [#2688][], [#2689][], [#2696][], [#2705][], [#2731][], [#2732][], [#2733][], [#2739][], [#2756][], [#2769][], [#2771][], [#2773][], [#2789][])
+* AppSec: Add response headers passing to WAF ([#2701][])
+* Tracing: Distributed tracing for Sidekiq ([#2513][])
+* Tracing: Add Roda integration ([#2368][])
+* Profiling: [PROF-6555] Support disabling endpoint names collection in new profiler ([#2698][])
+
+### Changed
+
+* Core: Allow `1` as true value in environment variables ([#2710][])
+* Profiling: [PROF-7360] Enable CPU Profiling 2.0 by default ([#2702][])
+* Tracing: Improve controller instrumentation and deprecate option `exception_controller` ([#2726][])
+* Tracing: Implement Span Attribute Schema Environment Variable ([#2727][])
+
+### Fixed
+
+* Bug: Tracing: Fix w3c propagation special character handling ([#2720][])
+* Performance: Tracing: Use `+@` instead of `dup` for duplicating strings ([#2704][])
+* Profiling: [PROF-7307] Avoid triggering allocation sampling during sampling ([#2690][])
+* Integrations: Tracing: Fix Rails < 3 conditional check in Utils#railtie_supported? ([#2695][])
+* Profiling: [PROF-7409] Do not auto-enable new profiler when rugged gem is detected ([#2741][])
+* Tracing: Fix using SemanticLogger#log(severity, message, progname) ([#2748][]) ([@rqz13][])
+* Profiling: [PROF-6447] Improve detection of mysql2 gem incompatibilities with profiler ([#2770][])
+* AppSec: Remove check for `::Rack::Request.instance_methods.include?(:each_header)` at load time ([#2778][])
+* Tracing: Fix quadratic backtracking on invalid URI ([#2788][])
+
 ## [1.10.1] - 2023-03-10
 
 ### Fixed
@@ -2323,7 +2356,8 @@ Release notes: https://github.com/DataDog/dd-trace-rb/releases/tag/v0.3.1
 
 Git diff: https://github.com/DataDog/dd-trace-rb/compare/v0.3.0...v0.3.1
 
-[Unreleased]: https://github.com/DataDog/dd-trace-rb/compare/v1.10.1...master
+[Unreleased]: https://github.com/DataDog/dd-trace-rb/compare/v1.11.0.beta1...master
+[1.11.0.beta1]: https://github.com/DataDog/dd-trace-rb/compare/v1.10.1...v1.11.0.beta1
 [1.10.1]: https://github.com/DataDog/dd-trace-rb/compare/v1.10.0...v1.10.1
 [1.10.0]: https://github.com/DataDog/dd-trace-rb/compare/v1.9.0...v1.10.0
 [1.9.0]: https://github.com/DataDog/dd-trace-rb/compare/v1.8.0...v1.9.0
@@ -3261,6 +3295,7 @@ Git diff: https://github.com/DataDog/dd-trace-rb/compare/v0.3.0...v0.3.1
 [#2363]: https://github.com/DataDog/dd-trace-rb/issues/2363
 [#2365]: https://github.com/DataDog/dd-trace-rb/issues/2365
 [#2367]: https://github.com/DataDog/dd-trace-rb/issues/2367
+[#2368]: https://github.com/DataDog/dd-trace-rb/issues/2368
 [#2378]: https://github.com/DataDog/dd-trace-rb/issues/2378
 [#2382]: https://github.com/DataDog/dd-trace-rb/issues/2382
 [#2390]: https://github.com/DataDog/dd-trace-rb/issues/2390
@@ -3293,6 +3328,7 @@ Git diff: https://github.com/DataDog/dd-trace-rb/compare/v0.3.0...v0.3.1
 [#2501]: https://github.com/DataDog/dd-trace-rb/issues/2501
 [#2504]: https://github.com/DataDog/dd-trace-rb/issues/2504
 [#2512]: https://github.com/DataDog/dd-trace-rb/issues/2512
+[#2513]: https://github.com/DataDog/dd-trace-rb/issues/2513
 [#2522]: https://github.com/DataDog/dd-trace-rb/issues/2522
 [#2526]: https://github.com/DataDog/dd-trace-rb/issues/2526
 [#2530]: https://github.com/DataDog/dd-trace-rb/issues/2530
@@ -3334,7 +3370,39 @@ Git diff: https://github.com/DataDog/dd-trace-rb/compare/v0.3.0...v0.3.1
 [#2663]: https://github.com/DataDog/dd-trace-rb/issues/2663
 [#2665]: https://github.com/DataDog/dd-trace-rb/issues/2665
 [#2668]: https://github.com/DataDog/dd-trace-rb/issues/2668
+[#2674]: https://github.com/DataDog/dd-trace-rb/issues/2674
+[#2678]: https://github.com/DataDog/dd-trace-rb/issues/2678
 [#2679]: https://github.com/DataDog/dd-trace-rb/issues/2679
+[#2686]: https://github.com/DataDog/dd-trace-rb/issues/2686
+[#2687]: https://github.com/DataDog/dd-trace-rb/issues/2687
+[#2688]: https://github.com/DataDog/dd-trace-rb/issues/2688
+[#2689]: https://github.com/DataDog/dd-trace-rb/issues/2689
+[#2690]: https://github.com/DataDog/dd-trace-rb/issues/2690
+[#2695]: https://github.com/DataDog/dd-trace-rb/issues/2695
+[#2696]: https://github.com/DataDog/dd-trace-rb/issues/2696
+[#2698]: https://github.com/DataDog/dd-trace-rb/issues/2698
+[#2701]: https://github.com/DataDog/dd-trace-rb/issues/2701
+[#2702]: https://github.com/DataDog/dd-trace-rb/issues/2702
+[#2704]: https://github.com/DataDog/dd-trace-rb/issues/2704
+[#2705]: https://github.com/DataDog/dd-trace-rb/issues/2705
+[#2710]: https://github.com/DataDog/dd-trace-rb/issues/2710
+[#2720]: https://github.com/DataDog/dd-trace-rb/issues/2720
+[#2726]: https://github.com/DataDog/dd-trace-rb/issues/2726
+[#2727]: https://github.com/DataDog/dd-trace-rb/issues/2727
+[#2731]: https://github.com/DataDog/dd-trace-rb/issues/2731
+[#2732]: https://github.com/DataDog/dd-trace-rb/issues/2732
+[#2733]: https://github.com/DataDog/dd-trace-rb/issues/2733
+[#2739]: https://github.com/DataDog/dd-trace-rb/issues/2739
+[#2741]: https://github.com/DataDog/dd-trace-rb/issues/2741
+[#2748]: https://github.com/DataDog/dd-trace-rb/issues/2748
+[#2756]: https://github.com/DataDog/dd-trace-rb/issues/2756
+[#2769]: https://github.com/DataDog/dd-trace-rb/issues/2769
+[#2770]: https://github.com/DataDog/dd-trace-rb/issues/2770
+[#2771]: https://github.com/DataDog/dd-trace-rb/issues/2771
+[#2773]: https://github.com/DataDog/dd-trace-rb/issues/2773
+[#2778]: https://github.com/DataDog/dd-trace-rb/issues/2778
+[#2788]: https://github.com/DataDog/dd-trace-rb/issues/2788
+[#2789]: https://github.com/DataDog/dd-trace-rb/issues/2789
 [@AdrianLC]: https://github.com/AdrianLC
 [@Azure7111]: https://github.com/Azure7111
 [@BabyGroot]: https://github.com/BabyGroot
@@ -3456,6 +3524,7 @@ Git diff: https://github.com/DataDog/dd-trace-rb/compare/v0.3.0...v0.3.1
 [@renchap]: https://github.com/renchap
 [@ricbartm]: https://github.com/ricbartm
 [@roccoblues]: https://github.com/roccoblues
+[@rqz13]: https://github.com/rqz13
 [@saturnflyer]: https://github.com/saturnflyer
 [@sco11morgan]: https://github.com/sco11morgan
 [@senny]: https://github.com/senny

--- a/gemfiles/jruby_9.2.21.0_contrib.gemfile.lock
+++ b/gemfiles/jruby_9.2.21.0_contrib.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    ddtrace (1.10.1)
+    ddtrace (1.11.0.beta1)
       debase-ruby_core_source (>= 0.10.16, <= 3.2.0)
       libdatadog (~> 2.0.0.1.0)
       libddwaf (~> 1.8.2.0.0)

--- a/gemfiles/jruby_9.2.21.0_contrib_old.gemfile.lock
+++ b/gemfiles/jruby_9.2.21.0_contrib_old.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    ddtrace (1.10.1)
+    ddtrace (1.11.0.beta1)
       debase-ruby_core_source (>= 0.10.16, <= 3.2.0)
       libdatadog (~> 2.0.0.1.0)
       libddwaf (~> 1.8.2.0.0)

--- a/gemfiles/jruby_9.2.21.0_core_old.gemfile.lock
+++ b/gemfiles/jruby_9.2.21.0_core_old.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    ddtrace (1.10.1)
+    ddtrace (1.11.0.beta1)
       debase-ruby_core_source (>= 0.10.16, <= 3.2.0)
       libdatadog (~> 2.0.0.1.0)
       libddwaf (~> 1.8.2.0.0)

--- a/gemfiles/jruby_9.2.21.0_cucumber3.gemfile.lock
+++ b/gemfiles/jruby_9.2.21.0_cucumber3.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    ddtrace (1.10.1)
+    ddtrace (1.11.0.beta1)
       debase-ruby_core_source (>= 0.10.16, <= 3.2.0)
       libdatadog (~> 2.0.0.1.0)
       libddwaf (~> 1.8.2.0.0)

--- a/gemfiles/jruby_9.2.21.0_cucumber4.gemfile.lock
+++ b/gemfiles/jruby_9.2.21.0_cucumber4.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    ddtrace (1.10.1)
+    ddtrace (1.11.0.beta1)
       debase-ruby_core_source (>= 0.10.16, <= 3.2.0)
       libdatadog (~> 2.0.0.1.0)
       libddwaf (~> 1.8.2.0.0)

--- a/gemfiles/jruby_9.2.21.0_cucumber5.gemfile.lock
+++ b/gemfiles/jruby_9.2.21.0_cucumber5.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    ddtrace (1.10.1)
+    ddtrace (1.11.0.beta1)
       debase-ruby_core_source (>= 0.10.16, <= 3.2.0)
       libdatadog (~> 2.0.0.1.0)
       libddwaf (~> 1.8.2.0.0)

--- a/gemfiles/jruby_9.2.21.0_hanami_1.gemfile.lock
+++ b/gemfiles/jruby_9.2.21.0_hanami_1.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    ddtrace (1.10.1)
+    ddtrace (1.11.0.beta1)
       debase-ruby_core_source (>= 0.10.16, <= 3.2.0)
       libdatadog (~> 2.0.0.1.0)
       libddwaf (~> 1.8.2.0.0)

--- a/gemfiles/jruby_9.2.21.0_opentelemetry.gemfile.lock
+++ b/gemfiles/jruby_9.2.21.0_opentelemetry.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    ddtrace (1.10.1)
+    ddtrace (1.11.0.beta1)
       debase-ruby_core_source (>= 0.10.16, <= 3.2.0)
       libdatadog (~> 1.0.1.1.0)
       libddwaf (~> 1.5.1.0.0)

--- a/gemfiles/jruby_9.2.21.0_rails5_mysql2.gemfile.lock
+++ b/gemfiles/jruby_9.2.21.0_rails5_mysql2.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    ddtrace (1.10.1)
+    ddtrace (1.11.0.beta1)
       debase-ruby_core_source (>= 0.10.16, <= 3.2.0)
       libdatadog (~> 2.0.0.1.0)
       libddwaf (~> 1.8.2.0.0)

--- a/gemfiles/jruby_9.2.21.0_rails5_postgres.gemfile.lock
+++ b/gemfiles/jruby_9.2.21.0_rails5_postgres.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    ddtrace (1.10.1)
+    ddtrace (1.11.0.beta1)
       debase-ruby_core_source (>= 0.10.16, <= 3.2.0)
       libdatadog (~> 2.0.0.1.0)
       libddwaf (~> 1.8.2.0.0)

--- a/gemfiles/jruby_9.2.21.0_rails5_postgres_redis.gemfile.lock
+++ b/gemfiles/jruby_9.2.21.0_rails5_postgres_redis.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    ddtrace (1.10.1)
+    ddtrace (1.11.0.beta1)
       debase-ruby_core_source (>= 0.10.16, <= 3.2.0)
       libdatadog (~> 2.0.0.1.0)
       libddwaf (~> 1.8.2.0.0)

--- a/gemfiles/jruby_9.2.21.0_rails5_postgres_redis_activesupport.gemfile.lock
+++ b/gemfiles/jruby_9.2.21.0_rails5_postgres_redis_activesupport.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    ddtrace (1.10.1)
+    ddtrace (1.11.0.beta1)
       debase-ruby_core_source (>= 0.10.16, <= 3.2.0)
       libdatadog (~> 2.0.0.1.0)
       libddwaf (~> 1.8.2.0.0)

--- a/gemfiles/jruby_9.2.21.0_rails5_postgres_sidekiq.gemfile.lock
+++ b/gemfiles/jruby_9.2.21.0_rails5_postgres_sidekiq.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    ddtrace (1.10.1)
+    ddtrace (1.11.0.beta1)
       debase-ruby_core_source (>= 0.10.16, <= 3.2.0)
       libdatadog (~> 2.0.0.1.0)
       libddwaf (~> 1.8.2.0.0)

--- a/gemfiles/jruby_9.2.21.0_rails5_semantic_logger.gemfile.lock
+++ b/gemfiles/jruby_9.2.21.0_rails5_semantic_logger.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    ddtrace (1.10.1)
+    ddtrace (1.11.0.beta1)
       debase-ruby_core_source (>= 0.10.16, <= 3.2.0)
       libdatadog (~> 2.0.0.1.0)
       libddwaf (~> 1.8.2.0.0)

--- a/gemfiles/jruby_9.2.21.0_rails61_mysql2.gemfile.lock
+++ b/gemfiles/jruby_9.2.21.0_rails61_mysql2.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    ddtrace (1.10.1)
+    ddtrace (1.11.0.beta1)
       debase-ruby_core_source (>= 0.10.16, <= 3.2.0)
       libdatadog (~> 2.0.0.1.0)
       libddwaf (~> 1.8.2.0.0)

--- a/gemfiles/jruby_9.2.21.0_rails61_postgres.gemfile.lock
+++ b/gemfiles/jruby_9.2.21.0_rails61_postgres.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    ddtrace (1.10.1)
+    ddtrace (1.11.0.beta1)
       debase-ruby_core_source (>= 0.10.16, <= 3.2.0)
       libdatadog (~> 2.0.0.1.0)
       libddwaf (~> 1.8.2.0.0)

--- a/gemfiles/jruby_9.2.21.0_rails61_postgres_redis.gemfile.lock
+++ b/gemfiles/jruby_9.2.21.0_rails61_postgres_redis.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    ddtrace (1.10.1)
+    ddtrace (1.11.0.beta1)
       debase-ruby_core_source (>= 0.10.16, <= 3.2.0)
       libdatadog (~> 2.0.0.1.0)
       libddwaf (~> 1.8.2.0.0)

--- a/gemfiles/jruby_9.2.21.0_rails61_postgres_sidekiq.gemfile.lock
+++ b/gemfiles/jruby_9.2.21.0_rails61_postgres_sidekiq.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    ddtrace (1.10.1)
+    ddtrace (1.11.0.beta1)
       debase-ruby_core_source (>= 0.10.16, <= 3.2.0)
       libdatadog (~> 2.0.0.1.0)
       libddwaf (~> 1.8.2.0.0)

--- a/gemfiles/jruby_9.2.21.0_rails61_semantic_logger.gemfile.lock
+++ b/gemfiles/jruby_9.2.21.0_rails61_semantic_logger.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    ddtrace (1.10.1)
+    ddtrace (1.11.0.beta1)
       debase-ruby_core_source (>= 0.10.16, <= 3.2.0)
       libdatadog (~> 2.0.0.1.0)
       libddwaf (~> 1.8.2.0.0)

--- a/gemfiles/jruby_9.2.21.0_rails6_mysql2.gemfile.lock
+++ b/gemfiles/jruby_9.2.21.0_rails6_mysql2.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    ddtrace (1.10.1)
+    ddtrace (1.11.0.beta1)
       debase-ruby_core_source (>= 0.10.16, <= 3.2.0)
       libdatadog (~> 2.0.0.1.0)
       libddwaf (~> 1.8.2.0.0)

--- a/gemfiles/jruby_9.2.21.0_rails6_postgres.gemfile.lock
+++ b/gemfiles/jruby_9.2.21.0_rails6_postgres.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    ddtrace (1.10.1)
+    ddtrace (1.11.0.beta1)
       debase-ruby_core_source (>= 0.10.16, <= 3.2.0)
       libdatadog (~> 2.0.0.1.0)
       libddwaf (~> 1.8.2.0.0)

--- a/gemfiles/jruby_9.2.21.0_rails6_postgres_redis.gemfile.lock
+++ b/gemfiles/jruby_9.2.21.0_rails6_postgres_redis.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    ddtrace (1.10.1)
+    ddtrace (1.11.0.beta1)
       debase-ruby_core_source (>= 0.10.16, <= 3.2.0)
       libdatadog (~> 2.0.0.1.0)
       libddwaf (~> 1.8.2.0.0)

--- a/gemfiles/jruby_9.2.21.0_rails6_postgres_redis_activesupport.gemfile.lock
+++ b/gemfiles/jruby_9.2.21.0_rails6_postgres_redis_activesupport.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    ddtrace (1.10.1)
+    ddtrace (1.11.0.beta1)
       debase-ruby_core_source (>= 0.10.16, <= 3.2.0)
       libdatadog (~> 2.0.0.1.0)
       libddwaf (~> 1.8.2.0.0)

--- a/gemfiles/jruby_9.2.21.0_rails6_postgres_sidekiq.gemfile.lock
+++ b/gemfiles/jruby_9.2.21.0_rails6_postgres_sidekiq.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    ddtrace (1.10.1)
+    ddtrace (1.11.0.beta1)
       debase-ruby_core_source (>= 0.10.16, <= 3.2.0)
       libdatadog (~> 2.0.0.1.0)
       libddwaf (~> 1.8.2.0.0)

--- a/gemfiles/jruby_9.2.21.0_rails6_semantic_logger.gemfile.lock
+++ b/gemfiles/jruby_9.2.21.0_rails6_semantic_logger.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    ddtrace (1.10.1)
+    ddtrace (1.11.0.beta1)
       debase-ruby_core_source (>= 0.10.16, <= 3.2.0)
       libdatadog (~> 2.0.0.1.0)
       libddwaf (~> 1.8.2.0.0)

--- a/gemfiles/jruby_9.2.21.0_redis_3.gemfile.lock
+++ b/gemfiles/jruby_9.2.21.0_redis_3.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    ddtrace (1.10.1)
+    ddtrace (1.11.0.beta1)
       debase-ruby_core_source (>= 0.10.16, <= 3.2.0)
       libdatadog (~> 2.0.0.1.0)
       libddwaf (~> 1.8.2.0.0)

--- a/gemfiles/jruby_9.2.21.0_redis_4.gemfile.lock
+++ b/gemfiles/jruby_9.2.21.0_redis_4.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    ddtrace (1.10.1)
+    ddtrace (1.11.0.beta1)
       debase-ruby_core_source (>= 0.10.16, <= 3.2.0)
       libdatadog (~> 2.0.0.1.0)
       libddwaf (~> 1.8.2.0.0)

--- a/gemfiles/jruby_9.2.21.0_redis_5.gemfile.lock
+++ b/gemfiles/jruby_9.2.21.0_redis_5.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    ddtrace (1.10.1)
+    ddtrace (1.11.0.beta1)
       debase-ruby_core_source (>= 0.10.16, <= 3.2.0)
       libdatadog (~> 2.0.0.1.0)
       libddwaf (~> 1.8.2.0.0)

--- a/gemfiles/jruby_9.2.21.0_resque2_redis3.gemfile.lock
+++ b/gemfiles/jruby_9.2.21.0_resque2_redis3.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    ddtrace (1.10.1)
+    ddtrace (1.11.0.beta1)
       debase-ruby_core_source (>= 0.10.16, <= 3.2.0)
       libdatadog (~> 2.0.0.1.0)
       libddwaf (~> 1.8.2.0.0)

--- a/gemfiles/jruby_9.2.21.0_resque2_redis4.gemfile.lock
+++ b/gemfiles/jruby_9.2.21.0_resque2_redis4.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    ddtrace (1.10.1)
+    ddtrace (1.11.0.beta1)
       debase-ruby_core_source (>= 0.10.16, <= 3.2.0)
       libdatadog (~> 2.0.0.1.0)
       libddwaf (~> 1.8.2.0.0)

--- a/gemfiles/jruby_9.2.21.0_sinatra.gemfile.lock
+++ b/gemfiles/jruby_9.2.21.0_sinatra.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    ddtrace (1.10.1)
+    ddtrace (1.11.0.beta1)
       debase-ruby_core_source (>= 0.10.16, <= 3.2.0)
       libdatadog (~> 2.0.0.1.0)
       libddwaf (~> 1.8.2.0.0)

--- a/gemfiles/jruby_9.2.8.0_opentelemetry.gemfile.lock
+++ b/gemfiles/jruby_9.2.8.0_opentelemetry.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    ddtrace (1.10.1)
+    ddtrace (1.11.0.beta1)
       debase-ruby_core_source (>= 0.10.16, <= 3.2.0)
       libdatadog (~> 1.0.1.1.0)
       libddwaf (~> 1.5.1.0.0)

--- a/gemfiles/jruby_9.3.9.0_contrib.gemfile.lock
+++ b/gemfiles/jruby_9.3.9.0_contrib.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    ddtrace (1.10.1)
+    ddtrace (1.11.0.beta1)
       debase-ruby_core_source (>= 0.10.16, <= 3.2.0)
       libdatadog (~> 2.0.0.1.0)
       libddwaf (~> 1.8.2.0.0)

--- a/gemfiles/jruby_9.3.9.0_contrib_old.gemfile.lock
+++ b/gemfiles/jruby_9.3.9.0_contrib_old.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    ddtrace (1.10.1)
+    ddtrace (1.11.0.beta1)
       debase-ruby_core_source (>= 0.10.16, <= 3.2.0)
       libdatadog (~> 2.0.0.1.0)
       libddwaf (~> 1.8.2.0.0)

--- a/gemfiles/jruby_9.3.9.0_core_old.gemfile.lock
+++ b/gemfiles/jruby_9.3.9.0_core_old.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    ddtrace (1.10.1)
+    ddtrace (1.11.0.beta1)
       debase-ruby_core_source (>= 0.10.16, <= 3.2.0)
       libdatadog (~> 2.0.0.1.0)
       libddwaf (~> 1.8.2.0.0)

--- a/gemfiles/jruby_9.3.9.0_cucumber3.gemfile.lock
+++ b/gemfiles/jruby_9.3.9.0_cucumber3.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    ddtrace (1.10.1)
+    ddtrace (1.11.0.beta1)
       debase-ruby_core_source (>= 0.10.16, <= 3.2.0)
       libdatadog (~> 2.0.0.1.0)
       libddwaf (~> 1.8.2.0.0)

--- a/gemfiles/jruby_9.3.9.0_cucumber4.gemfile.lock
+++ b/gemfiles/jruby_9.3.9.0_cucumber4.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    ddtrace (1.10.1)
+    ddtrace (1.11.0.beta1)
       debase-ruby_core_source (>= 0.10.16, <= 3.2.0)
       libdatadog (~> 2.0.0.1.0)
       libddwaf (~> 1.8.2.0.0)

--- a/gemfiles/jruby_9.3.9.0_cucumber5.gemfile.lock
+++ b/gemfiles/jruby_9.3.9.0_cucumber5.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    ddtrace (1.10.1)
+    ddtrace (1.11.0.beta1)
       debase-ruby_core_source (>= 0.10.16, <= 3.2.0)
       libdatadog (~> 2.0.0.1.0)
       libddwaf (~> 1.8.2.0.0)

--- a/gemfiles/jruby_9.3.9.0_hanami_1.gemfile.lock
+++ b/gemfiles/jruby_9.3.9.0_hanami_1.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    ddtrace (1.10.1)
+    ddtrace (1.11.0.beta1)
       debase-ruby_core_source (>= 0.10.16, <= 3.2.0)
       libdatadog (~> 2.0.0.1.0)
       libddwaf (~> 1.8.2.0.0)

--- a/gemfiles/jruby_9.3.9.0_opentelemetry.gemfile.lock
+++ b/gemfiles/jruby_9.3.9.0_opentelemetry.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    ddtrace (1.10.1)
+    ddtrace (1.11.0.beta1)
       debase-ruby_core_source (>= 0.10.16, <= 3.2.0)
       libdatadog (~> 2.0.0.1.0)
       libddwaf (~> 1.8.2.0.0)

--- a/gemfiles/jruby_9.3.9.0_rails5_mysql2.gemfile.lock
+++ b/gemfiles/jruby_9.3.9.0_rails5_mysql2.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    ddtrace (1.10.1)
+    ddtrace (1.11.0.beta1)
       debase-ruby_core_source (>= 0.10.16, <= 3.2.0)
       libdatadog (~> 2.0.0.1.0)
       libddwaf (~> 1.8.2.0.0)

--- a/gemfiles/jruby_9.3.9.0_rails5_postgres.gemfile.lock
+++ b/gemfiles/jruby_9.3.9.0_rails5_postgres.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    ddtrace (1.10.1)
+    ddtrace (1.11.0.beta1)
       debase-ruby_core_source (>= 0.10.16, <= 3.2.0)
       libdatadog (~> 2.0.0.1.0)
       libddwaf (~> 1.8.2.0.0)

--- a/gemfiles/jruby_9.3.9.0_rails5_postgres_redis.gemfile.lock
+++ b/gemfiles/jruby_9.3.9.0_rails5_postgres_redis.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    ddtrace (1.10.1)
+    ddtrace (1.11.0.beta1)
       debase-ruby_core_source (>= 0.10.16, <= 3.2.0)
       libdatadog (~> 2.0.0.1.0)
       libddwaf (~> 1.8.2.0.0)

--- a/gemfiles/jruby_9.3.9.0_rails5_postgres_redis_activesupport.gemfile.lock
+++ b/gemfiles/jruby_9.3.9.0_rails5_postgres_redis_activesupport.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    ddtrace (1.10.1)
+    ddtrace (1.11.0.beta1)
       debase-ruby_core_source (>= 0.10.16, <= 3.2.0)
       libdatadog (~> 2.0.0.1.0)
       libddwaf (~> 1.8.2.0.0)

--- a/gemfiles/jruby_9.3.9.0_rails5_postgres_sidekiq.gemfile.lock
+++ b/gemfiles/jruby_9.3.9.0_rails5_postgres_sidekiq.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    ddtrace (1.10.1)
+    ddtrace (1.11.0.beta1)
       debase-ruby_core_source (>= 0.10.16, <= 3.2.0)
       libdatadog (~> 2.0.0.1.0)
       libddwaf (~> 1.8.2.0.0)

--- a/gemfiles/jruby_9.3.9.0_rails5_semantic_logger.gemfile.lock
+++ b/gemfiles/jruby_9.3.9.0_rails5_semantic_logger.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    ddtrace (1.10.1)
+    ddtrace (1.11.0.beta1)
       debase-ruby_core_source (>= 0.10.16, <= 3.2.0)
       libdatadog (~> 2.0.0.1.0)
       libddwaf (~> 1.8.2.0.0)

--- a/gemfiles/jruby_9.3.9.0_rails61_mysql2.gemfile.lock
+++ b/gemfiles/jruby_9.3.9.0_rails61_mysql2.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    ddtrace (1.10.1)
+    ddtrace (1.11.0.beta1)
       debase-ruby_core_source (>= 0.10.16, <= 3.2.0)
       libdatadog (~> 2.0.0.1.0)
       libddwaf (~> 1.8.2.0.0)

--- a/gemfiles/jruby_9.3.9.0_rails61_postgres.gemfile.lock
+++ b/gemfiles/jruby_9.3.9.0_rails61_postgres.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    ddtrace (1.10.1)
+    ddtrace (1.11.0.beta1)
       debase-ruby_core_source (>= 0.10.16, <= 3.2.0)
       libdatadog (~> 2.0.0.1.0)
       libddwaf (~> 1.8.2.0.0)

--- a/gemfiles/jruby_9.3.9.0_rails61_postgres_redis.gemfile.lock
+++ b/gemfiles/jruby_9.3.9.0_rails61_postgres_redis.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    ddtrace (1.10.1)
+    ddtrace (1.11.0.beta1)
       debase-ruby_core_source (>= 0.10.16, <= 3.2.0)
       libdatadog (~> 2.0.0.1.0)
       libddwaf (~> 1.8.2.0.0)

--- a/gemfiles/jruby_9.3.9.0_rails61_postgres_sidekiq.gemfile.lock
+++ b/gemfiles/jruby_9.3.9.0_rails61_postgres_sidekiq.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    ddtrace (1.10.1)
+    ddtrace (1.11.0.beta1)
       debase-ruby_core_source (>= 0.10.16, <= 3.2.0)
       libdatadog (~> 2.0.0.1.0)
       libddwaf (~> 1.8.2.0.0)

--- a/gemfiles/jruby_9.3.9.0_rails61_semantic_logger.gemfile.lock
+++ b/gemfiles/jruby_9.3.9.0_rails61_semantic_logger.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    ddtrace (1.10.1)
+    ddtrace (1.11.0.beta1)
       debase-ruby_core_source (>= 0.10.16, <= 3.2.0)
       libdatadog (~> 2.0.0.1.0)
       libddwaf (~> 1.8.2.0.0)

--- a/gemfiles/jruby_9.3.9.0_rails6_mysql2.gemfile.lock
+++ b/gemfiles/jruby_9.3.9.0_rails6_mysql2.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    ddtrace (1.10.1)
+    ddtrace (1.11.0.beta1)
       debase-ruby_core_source (>= 0.10.16, <= 3.2.0)
       libdatadog (~> 2.0.0.1.0)
       libddwaf (~> 1.8.2.0.0)

--- a/gemfiles/jruby_9.3.9.0_rails6_postgres.gemfile.lock
+++ b/gemfiles/jruby_9.3.9.0_rails6_postgres.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    ddtrace (1.10.1)
+    ddtrace (1.11.0.beta1)
       debase-ruby_core_source (>= 0.10.16, <= 3.2.0)
       libdatadog (~> 2.0.0.1.0)
       libddwaf (~> 1.8.2.0.0)

--- a/gemfiles/jruby_9.3.9.0_rails6_postgres_redis.gemfile.lock
+++ b/gemfiles/jruby_9.3.9.0_rails6_postgres_redis.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    ddtrace (1.10.1)
+    ddtrace (1.11.0.beta1)
       debase-ruby_core_source (>= 0.10.16, <= 3.2.0)
       libdatadog (~> 2.0.0.1.0)
       libddwaf (~> 1.8.2.0.0)

--- a/gemfiles/jruby_9.3.9.0_rails6_postgres_redis_activesupport.gemfile.lock
+++ b/gemfiles/jruby_9.3.9.0_rails6_postgres_redis_activesupport.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    ddtrace (1.10.1)
+    ddtrace (1.11.0.beta1)
       debase-ruby_core_source (>= 0.10.16, <= 3.2.0)
       libdatadog (~> 2.0.0.1.0)
       libddwaf (~> 1.8.2.0.0)

--- a/gemfiles/jruby_9.3.9.0_rails6_postgres_sidekiq.gemfile.lock
+++ b/gemfiles/jruby_9.3.9.0_rails6_postgres_sidekiq.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    ddtrace (1.10.1)
+    ddtrace (1.11.0.beta1)
       debase-ruby_core_source (>= 0.10.16, <= 3.2.0)
       libdatadog (~> 2.0.0.1.0)
       libddwaf (~> 1.8.2.0.0)

--- a/gemfiles/jruby_9.3.9.0_rails6_semantic_logger.gemfile.lock
+++ b/gemfiles/jruby_9.3.9.0_rails6_semantic_logger.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    ddtrace (1.10.1)
+    ddtrace (1.11.0.beta1)
       debase-ruby_core_source (>= 0.10.16, <= 3.2.0)
       libdatadog (~> 2.0.0.1.0)
       libddwaf (~> 1.8.2.0.0)

--- a/gemfiles/jruby_9.3.9.0_redis_3.gemfile.lock
+++ b/gemfiles/jruby_9.3.9.0_redis_3.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    ddtrace (1.10.1)
+    ddtrace (1.11.0.beta1)
       debase-ruby_core_source (>= 0.10.16, <= 3.2.0)
       libdatadog (~> 2.0.0.1.0)
       libddwaf (~> 1.8.2.0.0)

--- a/gemfiles/jruby_9.3.9.0_redis_4.gemfile.lock
+++ b/gemfiles/jruby_9.3.9.0_redis_4.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    ddtrace (1.10.1)
+    ddtrace (1.11.0.beta1)
       debase-ruby_core_source (>= 0.10.16, <= 3.2.0)
       libdatadog (~> 2.0.0.1.0)
       libddwaf (~> 1.8.2.0.0)

--- a/gemfiles/jruby_9.3.9.0_redis_5.gemfile.lock
+++ b/gemfiles/jruby_9.3.9.0_redis_5.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    ddtrace (1.10.1)
+    ddtrace (1.11.0.beta1)
       debase-ruby_core_source (>= 0.10.16, <= 3.2.0)
       libdatadog (~> 2.0.0.1.0)
       libddwaf (~> 1.8.2.0.0)

--- a/gemfiles/jruby_9.3.9.0_resque2_redis3.gemfile.lock
+++ b/gemfiles/jruby_9.3.9.0_resque2_redis3.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    ddtrace (1.10.1)
+    ddtrace (1.11.0.beta1)
       debase-ruby_core_source (>= 0.10.16, <= 3.2.0)
       libdatadog (~> 2.0.0.1.0)
       libddwaf (~> 1.8.2.0.0)

--- a/gemfiles/jruby_9.3.9.0_resque2_redis4.gemfile.lock
+++ b/gemfiles/jruby_9.3.9.0_resque2_redis4.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    ddtrace (1.10.1)
+    ddtrace (1.11.0.beta1)
       debase-ruby_core_source (>= 0.10.16, <= 3.2.0)
       libdatadog (~> 2.0.0.1.0)
       libddwaf (~> 1.8.2.0.0)

--- a/gemfiles/jruby_9.3.9.0_sinatra.gemfile.lock
+++ b/gemfiles/jruby_9.3.9.0_sinatra.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    ddtrace (1.10.1)
+    ddtrace (1.11.0.beta1)
       debase-ruby_core_source (>= 0.10.16, <= 3.2.0)
       libdatadog (~> 2.0.0.1.0)
       libddwaf (~> 1.8.2.0.0)

--- a/gemfiles/jruby_9.4.0.0_contrib.gemfile.lock
+++ b/gemfiles/jruby_9.4.0.0_contrib.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    ddtrace (1.10.1)
+    ddtrace (1.11.0.beta1)
       debase-ruby_core_source (>= 0.10.16, <= 3.2.0)
       libdatadog (~> 2.0.0.1.0)
       libddwaf (~> 1.8.2.0.0)

--- a/gemfiles/jruby_9.4.0.0_contrib_old.gemfile.lock
+++ b/gemfiles/jruby_9.4.0.0_contrib_old.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    ddtrace (1.10.1)
+    ddtrace (1.11.0.beta1)
       debase-ruby_core_source (>= 0.10.16, <= 3.2.0)
       libdatadog (~> 2.0.0.1.0)
       libddwaf (~> 1.8.2.0.0)

--- a/gemfiles/jruby_9.4.0.0_core_old.gemfile.lock
+++ b/gemfiles/jruby_9.4.0.0_core_old.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    ddtrace (1.10.1)
+    ddtrace (1.11.0.beta1)
       debase-ruby_core_source (>= 0.10.16, <= 3.2.0)
       libdatadog (~> 2.0.0.1.0)
       libddwaf (~> 1.8.2.0.0)

--- a/gemfiles/jruby_9.4.0.0_cucumber3.gemfile.lock
+++ b/gemfiles/jruby_9.4.0.0_cucumber3.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    ddtrace (1.10.1)
+    ddtrace (1.11.0.beta1)
       debase-ruby_core_source (>= 0.10.16, <= 3.2.0)
       libdatadog (~> 2.0.0.1.0)
       libddwaf (~> 1.8.2.0.0)

--- a/gemfiles/jruby_9.4.0.0_cucumber4.gemfile.lock
+++ b/gemfiles/jruby_9.4.0.0_cucumber4.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    ddtrace (1.10.1)
+    ddtrace (1.11.0.beta1)
       debase-ruby_core_source (>= 0.10.16, <= 3.2.0)
       libdatadog (~> 2.0.0.1.0)
       libddwaf (~> 1.8.2.0.0)

--- a/gemfiles/jruby_9.4.0.0_cucumber5.gemfile.lock
+++ b/gemfiles/jruby_9.4.0.0_cucumber5.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    ddtrace (1.10.1)
+    ddtrace (1.11.0.beta1)
       debase-ruby_core_source (>= 0.10.16, <= 3.2.0)
       libdatadog (~> 2.0.0.1.0)
       libddwaf (~> 1.8.2.0.0)

--- a/gemfiles/jruby_9.4.0.0_opentelemetry.gemfile.lock
+++ b/gemfiles/jruby_9.4.0.0_opentelemetry.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    ddtrace (1.10.1)
+    ddtrace (1.11.0.beta1)
       debase-ruby_core_source (>= 0.10.16, <= 3.2.0)
       libdatadog (~> 2.0.0.1.0)
       libddwaf (~> 1.8.2.0.0)

--- a/gemfiles/jruby_9.4.0.0_rails61_mysql2.gemfile.lock
+++ b/gemfiles/jruby_9.4.0.0_rails61_mysql2.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    ddtrace (1.10.1)
+    ddtrace (1.11.0.beta1)
       debase-ruby_core_source (>= 0.10.16, <= 3.2.0)
       libdatadog (~> 2.0.0.1.0)
       libddwaf (~> 1.8.2.0.0)

--- a/gemfiles/jruby_9.4.0.0_rails61_postgres.gemfile.lock
+++ b/gemfiles/jruby_9.4.0.0_rails61_postgres.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    ddtrace (1.10.1)
+    ddtrace (1.11.0.beta1)
       debase-ruby_core_source (>= 0.10.16, <= 3.2.0)
       libdatadog (~> 2.0.0.1.0)
       libddwaf (~> 1.8.2.0.0)

--- a/gemfiles/jruby_9.4.0.0_rails61_postgres_redis.gemfile.lock
+++ b/gemfiles/jruby_9.4.0.0_rails61_postgres_redis.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    ddtrace (1.10.1)
+    ddtrace (1.11.0.beta1)
       debase-ruby_core_source (>= 0.10.16, <= 3.2.0)
       libdatadog (~> 2.0.0.1.0)
       libddwaf (~> 1.8.2.0.0)

--- a/gemfiles/jruby_9.4.0.0_rails61_postgres_sidekiq.gemfile.lock
+++ b/gemfiles/jruby_9.4.0.0_rails61_postgres_sidekiq.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    ddtrace (1.10.1)
+    ddtrace (1.11.0.beta1)
       debase-ruby_core_source (>= 0.10.16, <= 3.2.0)
       libdatadog (~> 2.0.0.1.0)
       libddwaf (~> 1.8.2.0.0)

--- a/gemfiles/jruby_9.4.0.0_rails61_semantic_logger.gemfile.lock
+++ b/gemfiles/jruby_9.4.0.0_rails61_semantic_logger.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    ddtrace (1.10.1)
+    ddtrace (1.11.0.beta1)
       debase-ruby_core_source (>= 0.10.16, <= 3.2.0)
       libdatadog (~> 2.0.0.1.0)
       libddwaf (~> 1.8.2.0.0)

--- a/gemfiles/jruby_9.4.0.0_redis_3.gemfile.lock
+++ b/gemfiles/jruby_9.4.0.0_redis_3.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    ddtrace (1.10.1)
+    ddtrace (1.11.0.beta1)
       debase-ruby_core_source (>= 0.10.16, <= 3.2.0)
       libdatadog (~> 2.0.0.1.0)
       libddwaf (~> 1.8.2.0.0)

--- a/gemfiles/jruby_9.4.0.0_redis_4.gemfile.lock
+++ b/gemfiles/jruby_9.4.0.0_redis_4.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    ddtrace (1.10.1)
+    ddtrace (1.11.0.beta1)
       debase-ruby_core_source (>= 0.10.16, <= 3.2.0)
       libdatadog (~> 2.0.0.1.0)
       libddwaf (~> 1.8.2.0.0)

--- a/gemfiles/jruby_9.4.0.0_redis_5.gemfile.lock
+++ b/gemfiles/jruby_9.4.0.0_redis_5.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    ddtrace (1.10.1)
+    ddtrace (1.11.0.beta1)
       debase-ruby_core_source (>= 0.10.16, <= 3.2.0)
       libdatadog (~> 2.0.0.1.0)
       libddwaf (~> 1.8.2.0.0)

--- a/gemfiles/jruby_9.4.0.0_resque2_redis3.gemfile.lock
+++ b/gemfiles/jruby_9.4.0.0_resque2_redis3.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    ddtrace (1.10.1)
+    ddtrace (1.11.0.beta1)
       debase-ruby_core_source (>= 0.10.16, <= 3.2.0)
       libdatadog (~> 2.0.0.1.0)
       libddwaf (~> 1.8.2.0.0)

--- a/gemfiles/jruby_9.4.0.0_resque2_redis4.gemfile.lock
+++ b/gemfiles/jruby_9.4.0.0_resque2_redis4.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    ddtrace (1.10.1)
+    ddtrace (1.11.0.beta1)
       debase-ruby_core_source (>= 0.10.16, <= 3.2.0)
       libdatadog (~> 2.0.0.1.0)
       libddwaf (~> 1.8.2.0.0)

--- a/gemfiles/jruby_9.4.0.0_sinatra.gemfile.lock
+++ b/gemfiles/jruby_9.4.0.0_sinatra.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    ddtrace (1.10.1)
+    ddtrace (1.11.0.beta1)
       debase-ruby_core_source (>= 0.10.16, <= 3.2.0)
       libdatadog (~> 2.0.0.1.0)
       libddwaf (~> 1.8.2.0.0)

--- a/gemfiles/ruby_2.1.10_contrib.gemfile.lock
+++ b/gemfiles/ruby_2.1.10_contrib.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    ddtrace (1.10.1)
+    ddtrace (1.11.0.beta1)
       debase-ruby_core_source (>= 0.10.16, <= 3.2.0)
       libdatadog (~> 2.0.0.1.0)
       libddwaf (~> 1.8.2.0.0)

--- a/gemfiles/ruby_2.1.10_core_old.gemfile.lock
+++ b/gemfiles/ruby_2.1.10_core_old.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    ddtrace (1.10.1)
+    ddtrace (1.11.0.beta1)
       debase-ruby_core_source (>= 0.10.16, <= 3.2.0)
       libdatadog (~> 2.0.0.1.0)
       libddwaf (~> 1.8.2.0.0)

--- a/gemfiles/ruby_2.1.10_rails32_mysql2.gemfile.lock
+++ b/gemfiles/ruby_2.1.10_rails32_mysql2.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    ddtrace (1.10.1)
+    ddtrace (1.11.0.beta1)
       debase-ruby_core_source (>= 0.10.16, <= 3.2.0)
       libdatadog (~> 2.0.0.1.0)
       libddwaf (~> 1.8.2.0.0)

--- a/gemfiles/ruby_2.1.10_rails32_postgres.gemfile.lock
+++ b/gemfiles/ruby_2.1.10_rails32_postgres.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    ddtrace (1.10.1)
+    ddtrace (1.11.0.beta1)
       debase-ruby_core_source (>= 0.10.16, <= 3.2.0)
       libdatadog (~> 2.0.0.1.0)
       libddwaf (~> 1.8.2.0.0)

--- a/gemfiles/ruby_2.1.10_rails32_postgres_redis.gemfile.lock
+++ b/gemfiles/ruby_2.1.10_rails32_postgres_redis.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    ddtrace (1.10.1)
+    ddtrace (1.11.0.beta1)
       debase-ruby_core_source (>= 0.10.16, <= 3.2.0)
       libdatadog (~> 2.0.0.1.0)
       libddwaf (~> 1.8.2.0.0)

--- a/gemfiles/ruby_2.1.10_rails32_postgres_sidekiq.gemfile.lock
+++ b/gemfiles/ruby_2.1.10_rails32_postgres_sidekiq.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    ddtrace (1.10.1)
+    ddtrace (1.11.0.beta1)
       debase-ruby_core_source (>= 0.10.16, <= 3.2.0)
       libdatadog (~> 2.0.0.1.0)
       libddwaf (~> 1.8.2.0.0)

--- a/gemfiles/ruby_2.1.10_rails4_mysql2.gemfile.lock
+++ b/gemfiles/ruby_2.1.10_rails4_mysql2.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    ddtrace (1.10.1)
+    ddtrace (1.11.0.beta1)
       debase-ruby_core_source (>= 0.10.16, <= 3.2.0)
       libdatadog (~> 2.0.0.1.0)
       libddwaf (~> 1.8.2.0.0)

--- a/gemfiles/ruby_2.1.10_rails4_postgres.gemfile.lock
+++ b/gemfiles/ruby_2.1.10_rails4_postgres.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    ddtrace (1.10.1)
+    ddtrace (1.11.0.beta1)
       debase-ruby_core_source (>= 0.10.16, <= 3.2.0)
       libdatadog (~> 2.0.0.1.0)
       libddwaf (~> 1.8.2.0.0)

--- a/gemfiles/ruby_2.1.10_rails4_postgres_redis.gemfile.lock
+++ b/gemfiles/ruby_2.1.10_rails4_postgres_redis.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    ddtrace (1.10.1)
+    ddtrace (1.11.0.beta1)
       debase-ruby_core_source (>= 0.10.16, <= 3.2.0)
       libdatadog (~> 2.0.0.1.0)
       libddwaf (~> 1.8.2.0.0)

--- a/gemfiles/ruby_2.1.10_rails4_semantic_logger.gemfile.lock
+++ b/gemfiles/ruby_2.1.10_rails4_semantic_logger.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    ddtrace (1.10.1)
+    ddtrace (1.11.0.beta1)
       debase-ruby_core_source (>= 0.10.16, <= 3.2.0)
       libdatadog (~> 2.0.0.1.0)
       libddwaf (~> 1.8.2.0.0)

--- a/gemfiles/ruby_2.1.10_redis_3.gemfile.lock
+++ b/gemfiles/ruby_2.1.10_redis_3.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    ddtrace (1.10.1)
+    ddtrace (1.11.0.beta1)
       debase-ruby_core_source (>= 0.10.16, <= 3.2.0)
       libdatadog (~> 2.0.0.1.0)
       libddwaf (~> 1.8.2.0.0)

--- a/gemfiles/ruby_2.1.10_sinatra.gemfile.lock
+++ b/gemfiles/ruby_2.1.10_sinatra.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    ddtrace (1.10.1)
+    ddtrace (1.11.0.beta1)
       debase-ruby_core_source (>= 0.10.16, <= 3.2.0)
       libdatadog (~> 2.0.0.1.0)
       libddwaf (~> 1.8.2.0.0)

--- a/gemfiles/ruby_2.2.10_contrib.gemfile.lock
+++ b/gemfiles/ruby_2.2.10_contrib.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    ddtrace (1.10.1)
+    ddtrace (1.11.0.beta1)
       debase-ruby_core_source (>= 0.10.16, <= 3.2.0)
       libdatadog (~> 2.0.0.1.0)
       libddwaf (~> 1.8.2.0.0)

--- a/gemfiles/ruby_2.2.10_core_old.gemfile.lock
+++ b/gemfiles/ruby_2.2.10_core_old.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    ddtrace (1.10.1)
+    ddtrace (1.11.0.beta1)
       debase-ruby_core_source (>= 0.10.16, <= 3.2.0)
       libdatadog (~> 2.0.0.1.0)
       libddwaf (~> 1.8.2.0.0)

--- a/gemfiles/ruby_2.2.10_rails32_mysql2.gemfile.lock
+++ b/gemfiles/ruby_2.2.10_rails32_mysql2.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    ddtrace (1.10.1)
+    ddtrace (1.11.0.beta1)
       debase-ruby_core_source (>= 0.10.16, <= 3.2.0)
       libdatadog (~> 2.0.0.1.0)
       libddwaf (~> 1.8.2.0.0)

--- a/gemfiles/ruby_2.2.10_rails32_postgres.gemfile.lock
+++ b/gemfiles/ruby_2.2.10_rails32_postgres.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    ddtrace (1.10.1)
+    ddtrace (1.11.0.beta1)
       debase-ruby_core_source (>= 0.10.16, <= 3.2.0)
       libdatadog (~> 2.0.0.1.0)
       libddwaf (~> 1.8.2.0.0)

--- a/gemfiles/ruby_2.2.10_rails32_postgres_redis.gemfile.lock
+++ b/gemfiles/ruby_2.2.10_rails32_postgres_redis.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    ddtrace (1.10.1)
+    ddtrace (1.11.0.beta1)
       debase-ruby_core_source (>= 0.10.16, <= 3.2.0)
       libdatadog (~> 2.0.0.1.0)
       libddwaf (~> 1.8.2.0.0)

--- a/gemfiles/ruby_2.2.10_rails32_postgres_sidekiq.gemfile.lock
+++ b/gemfiles/ruby_2.2.10_rails32_postgres_sidekiq.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    ddtrace (1.10.1)
+    ddtrace (1.11.0.beta1)
       debase-ruby_core_source (>= 0.10.16, <= 3.2.0)
       libdatadog (~> 2.0.0.1.0)
       libddwaf (~> 1.8.2.0.0)

--- a/gemfiles/ruby_2.2.10_rails4_mysql2.gemfile.lock
+++ b/gemfiles/ruby_2.2.10_rails4_mysql2.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    ddtrace (1.10.1)
+    ddtrace (1.11.0.beta1)
       debase-ruby_core_source (>= 0.10.16, <= 3.2.0)
       libdatadog (~> 2.0.0.1.0)
       libddwaf (~> 1.8.2.0.0)

--- a/gemfiles/ruby_2.2.10_rails4_postgres.gemfile.lock
+++ b/gemfiles/ruby_2.2.10_rails4_postgres.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    ddtrace (1.10.1)
+    ddtrace (1.11.0.beta1)
       debase-ruby_core_source (>= 0.10.16, <= 3.2.0)
       libdatadog (~> 2.0.0.1.0)
       libddwaf (~> 1.8.2.0.0)

--- a/gemfiles/ruby_2.2.10_rails4_postgres_redis.gemfile.lock
+++ b/gemfiles/ruby_2.2.10_rails4_postgres_redis.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    ddtrace (1.10.1)
+    ddtrace (1.11.0.beta1)
       debase-ruby_core_source (>= 0.10.16, <= 3.2.0)
       libdatadog (~> 2.0.0.1.0)
       libddwaf (~> 1.8.2.0.0)

--- a/gemfiles/ruby_2.2.10_rails4_postgres_sidekiq.gemfile.lock
+++ b/gemfiles/ruby_2.2.10_rails4_postgres_sidekiq.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    ddtrace (1.10.1)
+    ddtrace (1.11.0.beta1)
       debase-ruby_core_source (>= 0.10.16, <= 3.2.0)
       libdatadog (~> 2.0.0.1.0)
       libddwaf (~> 1.8.2.0.0)

--- a/gemfiles/ruby_2.2.10_rails4_semantic_logger.gemfile.lock
+++ b/gemfiles/ruby_2.2.10_rails4_semantic_logger.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    ddtrace (1.10.1)
+    ddtrace (1.11.0.beta1)
       debase-ruby_core_source (>= 0.10.16, <= 3.2.0)
       libdatadog (~> 2.0.0.1.0)
       libddwaf (~> 1.8.2.0.0)

--- a/gemfiles/ruby_2.2.10_rails5_mysql2.gemfile.lock
+++ b/gemfiles/ruby_2.2.10_rails5_mysql2.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    ddtrace (1.10.1)
+    ddtrace (1.11.0.beta1)
       debase-ruby_core_source (>= 0.10.16, <= 3.2.0)
       libdatadog (~> 2.0.0.1.0)
       libddwaf (~> 1.8.2.0.0)

--- a/gemfiles/ruby_2.2.10_rails5_postgres.gemfile.lock
+++ b/gemfiles/ruby_2.2.10_rails5_postgres.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    ddtrace (1.10.1)
+    ddtrace (1.11.0.beta1)
       debase-ruby_core_source (>= 0.10.16, <= 3.2.0)
       libdatadog (~> 2.0.0.1.0)
       libddwaf (~> 1.8.2.0.0)

--- a/gemfiles/ruby_2.2.10_rails5_postgres_redis.gemfile.lock
+++ b/gemfiles/ruby_2.2.10_rails5_postgres_redis.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    ddtrace (1.10.1)
+    ddtrace (1.11.0.beta1)
       debase-ruby_core_source (>= 0.10.16, <= 3.2.0)
       libdatadog (~> 2.0.0.1.0)
       libddwaf (~> 1.8.2.0.0)

--- a/gemfiles/ruby_2.2.10_rails5_postgres_redis_activesupport.gemfile.lock
+++ b/gemfiles/ruby_2.2.10_rails5_postgres_redis_activesupport.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    ddtrace (1.10.1)
+    ddtrace (1.11.0.beta1)
       debase-ruby_core_source (>= 0.10.16, <= 3.2.0)
       libdatadog (~> 2.0.0.1.0)
       libddwaf (~> 1.8.2.0.0)

--- a/gemfiles/ruby_2.2.10_rails5_postgres_sidekiq.gemfile.lock
+++ b/gemfiles/ruby_2.2.10_rails5_postgres_sidekiq.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    ddtrace (1.10.1)
+    ddtrace (1.11.0.beta1)
       debase-ruby_core_source (>= 0.10.16, <= 3.2.0)
       libdatadog (~> 2.0.0.1.0)
       libddwaf (~> 1.8.2.0.0)

--- a/gemfiles/ruby_2.2.10_rails5_semantic_logger.gemfile.lock
+++ b/gemfiles/ruby_2.2.10_rails5_semantic_logger.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    ddtrace (1.10.1)
+    ddtrace (1.11.0.beta1)
       debase-ruby_core_source (>= 0.10.16, <= 3.2.0)
       libdatadog (~> 2.0.0.1.0)
       libddwaf (~> 1.8.2.0.0)

--- a/gemfiles/ruby_2.2.10_redis_3.gemfile.lock
+++ b/gemfiles/ruby_2.2.10_redis_3.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    ddtrace (1.10.1)
+    ddtrace (1.11.0.beta1)
       debase-ruby_core_source (>= 0.10.16, <= 3.2.0)
       libdatadog (~> 2.0.0.1.0)
       libddwaf (~> 1.8.2.0.0)

--- a/gemfiles/ruby_2.2.10_sinatra.gemfile.lock
+++ b/gemfiles/ruby_2.2.10_sinatra.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    ddtrace (1.10.1)
+    ddtrace (1.11.0.beta1)
       debase-ruby_core_source (>= 0.10.16, <= 3.2.0)
       libdatadog (~> 2.0.0.1.0)
       libddwaf (~> 1.8.2.0.0)

--- a/gemfiles/ruby_2.3.8_contrib.gemfile.lock
+++ b/gemfiles/ruby_2.3.8_contrib.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    ddtrace (1.10.1)
+    ddtrace (1.11.0.beta1)
       debase-ruby_core_source (>= 0.10.16, <= 3.2.0)
       libdatadog (~> 2.0.0.1.0)
       libddwaf (~> 1.8.2.0.0)

--- a/gemfiles/ruby_2.3.8_contrib_old.gemfile.lock
+++ b/gemfiles/ruby_2.3.8_contrib_old.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    ddtrace (1.10.1)
+    ddtrace (1.11.0.beta1)
       debase-ruby_core_source (>= 0.10.16, <= 3.2.0)
       libdatadog (~> 2.0.0.1.0)
       libddwaf (~> 1.8.2.0.0)

--- a/gemfiles/ruby_2.3.8_core_old.gemfile.lock
+++ b/gemfiles/ruby_2.3.8_core_old.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    ddtrace (1.10.1)
+    ddtrace (1.11.0.beta1)
       debase-ruby_core_source (>= 0.10.16, <= 3.2.0)
       libdatadog (~> 2.0.0.1.0)
       libddwaf (~> 1.8.2.0.0)

--- a/gemfiles/ruby_2.3.8_cucumber3.gemfile.lock
+++ b/gemfiles/ruby_2.3.8_cucumber3.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    ddtrace (1.10.1)
+    ddtrace (1.11.0.beta1)
       debase-ruby_core_source (>= 0.10.16, <= 3.2.0)
       libdatadog (~> 2.0.0.1.0)
       libddwaf (~> 1.8.2.0.0)

--- a/gemfiles/ruby_2.3.8_cucumber4.gemfile.lock
+++ b/gemfiles/ruby_2.3.8_cucumber4.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    ddtrace (1.10.1)
+    ddtrace (1.11.0.beta1)
       debase-ruby_core_source (>= 0.10.16, <= 3.2.0)
       libdatadog (~> 2.0.0.1.0)
       libddwaf (~> 1.8.2.0.0)

--- a/gemfiles/ruby_2.3.8_hanami_1.gemfile.lock
+++ b/gemfiles/ruby_2.3.8_hanami_1.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    ddtrace (1.10.1)
+    ddtrace (1.11.0.beta1)
       debase-ruby_core_source (>= 0.10.16, <= 3.2.0)
       libdatadog (~> 2.0.0.1.0)
       libddwaf (~> 1.8.2.0.0)

--- a/gemfiles/ruby_2.3.8_rails32_mysql2.gemfile.lock
+++ b/gemfiles/ruby_2.3.8_rails32_mysql2.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    ddtrace (1.10.1)
+    ddtrace (1.11.0.beta1)
       debase-ruby_core_source (>= 0.10.16, <= 3.2.0)
       libdatadog (~> 2.0.0.1.0)
       libddwaf (~> 1.8.2.0.0)

--- a/gemfiles/ruby_2.3.8_rails32_postgres.gemfile.lock
+++ b/gemfiles/ruby_2.3.8_rails32_postgres.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    ddtrace (1.10.1)
+    ddtrace (1.11.0.beta1)
       debase-ruby_core_source (>= 0.10.16, <= 3.2.0)
       libdatadog (~> 2.0.0.1.0)
       libddwaf (~> 1.8.2.0.0)

--- a/gemfiles/ruby_2.3.8_rails32_postgres_redis.gemfile.lock
+++ b/gemfiles/ruby_2.3.8_rails32_postgres_redis.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    ddtrace (1.10.1)
+    ddtrace (1.11.0.beta1)
       debase-ruby_core_source (>= 0.10.16, <= 3.2.0)
       libdatadog (~> 2.0.0.1.0)
       libddwaf (~> 1.8.2.0.0)

--- a/gemfiles/ruby_2.3.8_rails32_postgres_sidekiq.gemfile.lock
+++ b/gemfiles/ruby_2.3.8_rails32_postgres_sidekiq.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    ddtrace (1.10.1)
+    ddtrace (1.11.0.beta1)
       debase-ruby_core_source (>= 0.10.16, <= 3.2.0)
       libdatadog (~> 2.0.0.1.0)
       libddwaf (~> 1.8.2.0.0)

--- a/gemfiles/ruby_2.3.8_rails4_mysql2.gemfile.lock
+++ b/gemfiles/ruby_2.3.8_rails4_mysql2.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    ddtrace (1.10.1)
+    ddtrace (1.11.0.beta1)
       debase-ruby_core_source (>= 0.10.16, <= 3.2.0)
       libdatadog (~> 2.0.0.1.0)
       libddwaf (~> 1.8.2.0.0)

--- a/gemfiles/ruby_2.3.8_rails4_postgres.gemfile.lock
+++ b/gemfiles/ruby_2.3.8_rails4_postgres.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    ddtrace (1.10.1)
+    ddtrace (1.11.0.beta1)
       debase-ruby_core_source (>= 0.10.16, <= 3.2.0)
       libdatadog (~> 2.0.0.1.0)
       libddwaf (~> 1.8.2.0.0)

--- a/gemfiles/ruby_2.3.8_rails4_postgres_redis.gemfile.lock
+++ b/gemfiles/ruby_2.3.8_rails4_postgres_redis.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    ddtrace (1.10.1)
+    ddtrace (1.11.0.beta1)
       debase-ruby_core_source (>= 0.10.16, <= 3.2.0)
       libdatadog (~> 2.0.0.1.0)
       libddwaf (~> 1.8.2.0.0)

--- a/gemfiles/ruby_2.3.8_rails4_postgres_sidekiq.gemfile.lock
+++ b/gemfiles/ruby_2.3.8_rails4_postgres_sidekiq.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    ddtrace (1.10.1)
+    ddtrace (1.11.0.beta1)
       debase-ruby_core_source (>= 0.10.16, <= 3.2.0)
       libdatadog (~> 2.0.0.1.0)
       libddwaf (~> 1.8.2.0.0)

--- a/gemfiles/ruby_2.3.8_rails4_semantic_logger.gemfile.lock
+++ b/gemfiles/ruby_2.3.8_rails4_semantic_logger.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    ddtrace (1.10.1)
+    ddtrace (1.11.0.beta1)
       debase-ruby_core_source (>= 0.10.16, <= 3.2.0)
       libdatadog (~> 2.0.0.1.0)
       libddwaf (~> 1.8.2.0.0)

--- a/gemfiles/ruby_2.3.8_rails5_mysql2.gemfile.lock
+++ b/gemfiles/ruby_2.3.8_rails5_mysql2.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    ddtrace (1.10.1)
+    ddtrace (1.11.0.beta1)
       debase-ruby_core_source (>= 0.10.16, <= 3.2.0)
       libdatadog (~> 2.0.0.1.0)
       libddwaf (~> 1.8.2.0.0)

--- a/gemfiles/ruby_2.3.8_rails5_postgres.gemfile.lock
+++ b/gemfiles/ruby_2.3.8_rails5_postgres.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    ddtrace (1.10.1)
+    ddtrace (1.11.0.beta1)
       debase-ruby_core_source (>= 0.10.16, <= 3.2.0)
       libdatadog (~> 2.0.0.1.0)
       libddwaf (~> 1.8.2.0.0)

--- a/gemfiles/ruby_2.3.8_rails5_postgres_redis.gemfile.lock
+++ b/gemfiles/ruby_2.3.8_rails5_postgres_redis.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    ddtrace (1.10.1)
+    ddtrace (1.11.0.beta1)
       debase-ruby_core_source (>= 0.10.16, <= 3.2.0)
       libdatadog (~> 2.0.0.1.0)
       libddwaf (~> 1.8.2.0.0)

--- a/gemfiles/ruby_2.3.8_rails5_postgres_redis_activesupport.gemfile.lock
+++ b/gemfiles/ruby_2.3.8_rails5_postgres_redis_activesupport.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    ddtrace (1.10.1)
+    ddtrace (1.11.0.beta1)
       debase-ruby_core_source (>= 0.10.16, <= 3.2.0)
       libdatadog (~> 2.0.0.1.0)
       libddwaf (~> 1.8.2.0.0)

--- a/gemfiles/ruby_2.3.8_rails5_postgres_sidekiq.gemfile.lock
+++ b/gemfiles/ruby_2.3.8_rails5_postgres_sidekiq.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    ddtrace (1.10.1)
+    ddtrace (1.11.0.beta1)
       debase-ruby_core_source (>= 0.10.16, <= 3.2.0)
       libdatadog (~> 2.0.0.1.0)
       libddwaf (~> 1.8.2.0.0)

--- a/gemfiles/ruby_2.3.8_rails5_semantic_logger.gemfile.lock
+++ b/gemfiles/ruby_2.3.8_rails5_semantic_logger.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    ddtrace (1.10.1)
+    ddtrace (1.11.0.beta1)
       debase-ruby_core_source (>= 0.10.16, <= 3.2.0)
       libdatadog (~> 2.0.0.1.0)
       libddwaf (~> 1.8.2.0.0)

--- a/gemfiles/ruby_2.3.8_redis_3.gemfile.lock
+++ b/gemfiles/ruby_2.3.8_redis_3.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    ddtrace (1.10.1)
+    ddtrace (1.11.0.beta1)
       debase-ruby_core_source (>= 0.10.16, <= 3.2.0)
       libdatadog (~> 2.0.0.1.0)
       libddwaf (~> 1.8.2.0.0)

--- a/gemfiles/ruby_2.3.8_resque2_redis3.gemfile.lock
+++ b/gemfiles/ruby_2.3.8_resque2_redis3.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    ddtrace (1.10.1)
+    ddtrace (1.11.0.beta1)
       debase-ruby_core_source (>= 0.10.16, <= 3.2.0)
       libdatadog (~> 2.0.0.1.0)
       libddwaf (~> 1.8.2.0.0)

--- a/gemfiles/ruby_2.3.8_resque2_redis4.gemfile.lock
+++ b/gemfiles/ruby_2.3.8_resque2_redis4.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    ddtrace (1.10.1)
+    ddtrace (1.11.0.beta1)
       debase-ruby_core_source (>= 0.10.16, <= 3.2.0)
       libdatadog (~> 2.0.0.1.0)
       libddwaf (~> 1.8.2.0.0)

--- a/gemfiles/ruby_2.3.8_sinatra.gemfile.lock
+++ b/gemfiles/ruby_2.3.8_sinatra.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    ddtrace (1.10.1)
+    ddtrace (1.11.0.beta1)
       debase-ruby_core_source (>= 0.10.16, <= 3.2.0)
       libdatadog (~> 2.0.0.1.0)
       libddwaf (~> 1.8.2.0.0)

--- a/gemfiles/ruby_2.4.10_contrib.gemfile.lock
+++ b/gemfiles/ruby_2.4.10_contrib.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    ddtrace (1.10.1)
+    ddtrace (1.11.0.beta1)
       debase-ruby_core_source (>= 0.10.16, <= 3.2.0)
       libdatadog (~> 2.0.0.1.0)
       libddwaf (~> 1.8.2.0.0)

--- a/gemfiles/ruby_2.4.10_contrib_old.gemfile.lock
+++ b/gemfiles/ruby_2.4.10_contrib_old.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    ddtrace (1.10.1)
+    ddtrace (1.11.0.beta1)
       debase-ruby_core_source (>= 0.10.16, <= 3.2.0)
       libdatadog (~> 2.0.0.1.0)
       libddwaf (~> 1.8.2.0.0)

--- a/gemfiles/ruby_2.4.10_core_old.gemfile.lock
+++ b/gemfiles/ruby_2.4.10_core_old.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    ddtrace (1.10.1)
+    ddtrace (1.11.0.beta1)
       debase-ruby_core_source (>= 0.10.16, <= 3.2.0)
       libdatadog (~> 2.0.0.1.0)
       libddwaf (~> 1.8.2.0.0)

--- a/gemfiles/ruby_2.4.10_cucumber3.gemfile.lock
+++ b/gemfiles/ruby_2.4.10_cucumber3.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    ddtrace (1.10.1)
+    ddtrace (1.11.0.beta1)
       debase-ruby_core_source (>= 0.10.16, <= 3.2.0)
       libdatadog (~> 2.0.0.1.0)
       libddwaf (~> 1.8.2.0.0)

--- a/gemfiles/ruby_2.4.10_cucumber4.gemfile.lock
+++ b/gemfiles/ruby_2.4.10_cucumber4.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    ddtrace (1.10.1)
+    ddtrace (1.11.0.beta1)
       debase-ruby_core_source (>= 0.10.16, <= 3.2.0)
       libdatadog (~> 2.0.0.1.0)
       libddwaf (~> 1.8.2.0.0)

--- a/gemfiles/ruby_2.4.10_hanami_1.gemfile.lock
+++ b/gemfiles/ruby_2.4.10_hanami_1.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    ddtrace (1.10.1)
+    ddtrace (1.11.0.beta1)
       debase-ruby_core_source (>= 0.10.16, <= 3.2.0)
       libdatadog (~> 2.0.0.1.0)
       libddwaf (~> 1.8.2.0.0)

--- a/gemfiles/ruby_2.4.10_rails5_mysql2.gemfile.lock
+++ b/gemfiles/ruby_2.4.10_rails5_mysql2.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    ddtrace (1.10.1)
+    ddtrace (1.11.0.beta1)
       debase-ruby_core_source (>= 0.10.16, <= 3.2.0)
       libdatadog (~> 2.0.0.1.0)
       libddwaf (~> 1.8.2.0.0)

--- a/gemfiles/ruby_2.4.10_rails5_postgres.gemfile.lock
+++ b/gemfiles/ruby_2.4.10_rails5_postgres.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    ddtrace (1.10.1)
+    ddtrace (1.11.0.beta1)
       debase-ruby_core_source (>= 0.10.16, <= 3.2.0)
       libdatadog (~> 2.0.0.1.0)
       libddwaf (~> 1.8.2.0.0)

--- a/gemfiles/ruby_2.4.10_rails5_postgres_redis.gemfile.lock
+++ b/gemfiles/ruby_2.4.10_rails5_postgres_redis.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    ddtrace (1.10.1)
+    ddtrace (1.11.0.beta1)
       debase-ruby_core_source (>= 0.10.16, <= 3.2.0)
       libdatadog (~> 2.0.0.1.0)
       libddwaf (~> 1.8.2.0.0)

--- a/gemfiles/ruby_2.4.10_rails5_postgres_redis_activesupport.gemfile.lock
+++ b/gemfiles/ruby_2.4.10_rails5_postgres_redis_activesupport.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    ddtrace (1.10.1)
+    ddtrace (1.11.0.beta1)
       debase-ruby_core_source (>= 0.10.16, <= 3.2.0)
       libdatadog (~> 2.0.0.1.0)
       libddwaf (~> 1.8.2.0.0)

--- a/gemfiles/ruby_2.4.10_rails5_postgres_sidekiq.gemfile.lock
+++ b/gemfiles/ruby_2.4.10_rails5_postgres_sidekiq.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    ddtrace (1.10.1)
+    ddtrace (1.11.0.beta1)
       debase-ruby_core_source (>= 0.10.16, <= 3.2.0)
       libdatadog (~> 2.0.0.1.0)
       libddwaf (~> 1.8.2.0.0)

--- a/gemfiles/ruby_2.4.10_rails5_semantic_logger.gemfile.lock
+++ b/gemfiles/ruby_2.4.10_rails5_semantic_logger.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    ddtrace (1.10.1)
+    ddtrace (1.11.0.beta1)
       debase-ruby_core_source (>= 0.10.16, <= 3.2.0)
       libdatadog (~> 2.0.0.1.0)
       libddwaf (~> 1.8.2.0.0)

--- a/gemfiles/ruby_2.4.10_redis_3.gemfile.lock
+++ b/gemfiles/ruby_2.4.10_redis_3.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    ddtrace (1.10.1)
+    ddtrace (1.11.0.beta1)
       debase-ruby_core_source (>= 0.10.16, <= 3.2.0)
       libdatadog (~> 2.0.0.1.0)
       libddwaf (~> 1.8.2.0.0)

--- a/gemfiles/ruby_2.4.10_redis_4.gemfile.lock
+++ b/gemfiles/ruby_2.4.10_redis_4.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    ddtrace (1.10.1)
+    ddtrace (1.11.0.beta1)
       debase-ruby_core_source (>= 0.10.16, <= 3.2.0)
       libdatadog (~> 2.0.0.1.0)
       libddwaf (~> 1.8.2.0.0)

--- a/gemfiles/ruby_2.4.10_resque2_redis3.gemfile.lock
+++ b/gemfiles/ruby_2.4.10_resque2_redis3.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    ddtrace (1.10.1)
+    ddtrace (1.11.0.beta1)
       debase-ruby_core_source (>= 0.10.16, <= 3.2.0)
       libdatadog (~> 2.0.0.1.0)
       libddwaf (~> 1.8.2.0.0)

--- a/gemfiles/ruby_2.4.10_resque2_redis4.gemfile.lock
+++ b/gemfiles/ruby_2.4.10_resque2_redis4.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    ddtrace (1.10.1)
+    ddtrace (1.11.0.beta1)
       debase-ruby_core_source (>= 0.10.16, <= 3.2.0)
       libdatadog (~> 2.0.0.1.0)
       libddwaf (~> 1.8.2.0.0)

--- a/gemfiles/ruby_2.4.10_sinatra.gemfile.lock
+++ b/gemfiles/ruby_2.4.10_sinatra.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    ddtrace (1.10.1)
+    ddtrace (1.11.0.beta1)
       debase-ruby_core_source (>= 0.10.16, <= 3.2.0)
       libdatadog (~> 2.0.0.1.0)
       libddwaf (~> 1.8.2.0.0)

--- a/gemfiles/ruby_2.5.9_contrib.gemfile.lock
+++ b/gemfiles/ruby_2.5.9_contrib.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    ddtrace (1.10.1)
+    ddtrace (1.11.0.beta1)
       debase-ruby_core_source (>= 0.10.16, <= 3.2.0)
       libdatadog (~> 2.0.0.1.0)
       libddwaf (~> 1.8.2.0.0)

--- a/gemfiles/ruby_2.5.9_contrib_old.gemfile.lock
+++ b/gemfiles/ruby_2.5.9_contrib_old.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    ddtrace (1.10.1)
+    ddtrace (1.11.0.beta1)
       debase-ruby_core_source (>= 0.10.16, <= 3.2.0)
       libdatadog (~> 2.0.0.1.0)
       libddwaf (~> 1.8.2.0.0)

--- a/gemfiles/ruby_2.5.9_core_old.gemfile.lock
+++ b/gemfiles/ruby_2.5.9_core_old.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    ddtrace (1.10.1)
+    ddtrace (1.11.0.beta1)
       debase-ruby_core_source (>= 0.10.16, <= 3.2.0)
       libdatadog (~> 2.0.0.1.0)
       libddwaf (~> 1.8.2.0.0)

--- a/gemfiles/ruby_2.5.9_cucumber3.gemfile.lock
+++ b/gemfiles/ruby_2.5.9_cucumber3.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    ddtrace (1.10.1)
+    ddtrace (1.11.0.beta1)
       debase-ruby_core_source (>= 0.10.16, <= 3.2.0)
       libdatadog (~> 2.0.0.1.0)
       libddwaf (~> 1.8.2.0.0)

--- a/gemfiles/ruby_2.5.9_cucumber4.gemfile.lock
+++ b/gemfiles/ruby_2.5.9_cucumber4.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    ddtrace (1.10.1)
+    ddtrace (1.11.0.beta1)
       debase-ruby_core_source (>= 0.10.16, <= 3.2.0)
       libdatadog (~> 2.0.0.1.0)
       libddwaf (~> 1.8.2.0.0)

--- a/gemfiles/ruby_2.5.9_cucumber5.gemfile.lock
+++ b/gemfiles/ruby_2.5.9_cucumber5.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    ddtrace (1.10.1)
+    ddtrace (1.11.0.beta1)
       debase-ruby_core_source (>= 0.10.16, <= 3.2.0)
       libdatadog (~> 2.0.0.1.0)
       libddwaf (~> 1.8.2.0.0)

--- a/gemfiles/ruby_2.5.9_hanami_1.gemfile.lock
+++ b/gemfiles/ruby_2.5.9_hanami_1.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    ddtrace (1.10.1)
+    ddtrace (1.11.0.beta1)
       debase-ruby_core_source (>= 0.10.16, <= 3.2.0)
       libdatadog (~> 2.0.0.1.0)
       libddwaf (~> 1.8.2.0.0)

--- a/gemfiles/ruby_2.5.9_opentelemetry.gemfile.lock
+++ b/gemfiles/ruby_2.5.9_opentelemetry.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    ddtrace (1.10.1)
+    ddtrace (1.11.0.beta1)
       debase-ruby_core_source (>= 0.10.16, <= 3.2.0)
       libdatadog (~> 1.0.1.1.0)
       libddwaf (~> 1.5.1.0.0)

--- a/gemfiles/ruby_2.5.9_rails5_mysql2.gemfile.lock
+++ b/gemfiles/ruby_2.5.9_rails5_mysql2.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    ddtrace (1.10.1)
+    ddtrace (1.11.0.beta1)
       debase-ruby_core_source (>= 0.10.16, <= 3.2.0)
       libdatadog (~> 2.0.0.1.0)
       libddwaf (~> 1.8.2.0.0)

--- a/gemfiles/ruby_2.5.9_rails5_postgres.gemfile.lock
+++ b/gemfiles/ruby_2.5.9_rails5_postgres.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    ddtrace (1.10.1)
+    ddtrace (1.11.0.beta1)
       debase-ruby_core_source (>= 0.10.16, <= 3.2.0)
       libdatadog (~> 2.0.0.1.0)
       libddwaf (~> 1.8.2.0.0)

--- a/gemfiles/ruby_2.5.9_rails5_postgres_redis.gemfile.lock
+++ b/gemfiles/ruby_2.5.9_rails5_postgres_redis.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    ddtrace (1.10.1)
+    ddtrace (1.11.0.beta1)
       debase-ruby_core_source (>= 0.10.16, <= 3.2.0)
       libdatadog (~> 2.0.0.1.0)
       libddwaf (~> 1.8.2.0.0)

--- a/gemfiles/ruby_2.5.9_rails5_postgres_redis_activesupport.gemfile.lock
+++ b/gemfiles/ruby_2.5.9_rails5_postgres_redis_activesupport.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    ddtrace (1.10.1)
+    ddtrace (1.11.0.beta1)
       debase-ruby_core_source (>= 0.10.16, <= 3.2.0)
       libdatadog (~> 2.0.0.1.0)
       libddwaf (~> 1.8.2.0.0)

--- a/gemfiles/ruby_2.5.9_rails5_postgres_sidekiq.gemfile.lock
+++ b/gemfiles/ruby_2.5.9_rails5_postgres_sidekiq.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    ddtrace (1.10.1)
+    ddtrace (1.11.0.beta1)
       debase-ruby_core_source (>= 0.10.16, <= 3.2.0)
       libdatadog (~> 2.0.0.1.0)
       libddwaf (~> 1.8.2.0.0)

--- a/gemfiles/ruby_2.5.9_rails5_semantic_logger.gemfile.lock
+++ b/gemfiles/ruby_2.5.9_rails5_semantic_logger.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    ddtrace (1.10.1)
+    ddtrace (1.11.0.beta1)
       debase-ruby_core_source (>= 0.10.16, <= 3.2.0)
       libdatadog (~> 2.0.0.1.0)
       libddwaf (~> 1.8.2.0.0)

--- a/gemfiles/ruby_2.5.9_rails61_mysql2.gemfile.lock
+++ b/gemfiles/ruby_2.5.9_rails61_mysql2.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    ddtrace (1.10.1)
+    ddtrace (1.11.0.beta1)
       debase-ruby_core_source (>= 0.10.16, <= 3.2.0)
       libdatadog (~> 2.0.0.1.0)
       libddwaf (~> 1.8.2.0.0)

--- a/gemfiles/ruby_2.5.9_rails61_postgres.gemfile.lock
+++ b/gemfiles/ruby_2.5.9_rails61_postgres.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    ddtrace (1.10.1)
+    ddtrace (1.11.0.beta1)
       debase-ruby_core_source (>= 0.10.16, <= 3.2.0)
       libdatadog (~> 2.0.0.1.0)
       libddwaf (~> 1.8.2.0.0)

--- a/gemfiles/ruby_2.5.9_rails61_postgres_redis.gemfile.lock
+++ b/gemfiles/ruby_2.5.9_rails61_postgres_redis.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    ddtrace (1.10.1)
+    ddtrace (1.11.0.beta1)
       debase-ruby_core_source (>= 0.10.16, <= 3.2.0)
       libdatadog (~> 2.0.0.1.0)
       libddwaf (~> 1.8.2.0.0)

--- a/gemfiles/ruby_2.5.9_rails61_postgres_sidekiq.gemfile.lock
+++ b/gemfiles/ruby_2.5.9_rails61_postgres_sidekiq.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    ddtrace (1.10.1)
+    ddtrace (1.11.0.beta1)
       debase-ruby_core_source (>= 0.10.16, <= 3.2.0)
       libdatadog (~> 2.0.0.1.0)
       libddwaf (~> 1.8.2.0.0)

--- a/gemfiles/ruby_2.5.9_rails61_semantic_logger.gemfile.lock
+++ b/gemfiles/ruby_2.5.9_rails61_semantic_logger.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    ddtrace (1.10.1)
+    ddtrace (1.11.0.beta1)
       debase-ruby_core_source (>= 0.10.16, <= 3.2.0)
       libdatadog (~> 2.0.0.1.0)
       libddwaf (~> 1.8.2.0.0)

--- a/gemfiles/ruby_2.5.9_rails6_mysql2.gemfile.lock
+++ b/gemfiles/ruby_2.5.9_rails6_mysql2.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    ddtrace (1.10.1)
+    ddtrace (1.11.0.beta1)
       debase-ruby_core_source (>= 0.10.16, <= 3.2.0)
       libdatadog (~> 2.0.0.1.0)
       libddwaf (~> 1.8.2.0.0)

--- a/gemfiles/ruby_2.5.9_rails6_postgres.gemfile.lock
+++ b/gemfiles/ruby_2.5.9_rails6_postgres.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    ddtrace (1.10.1)
+    ddtrace (1.11.0.beta1)
       debase-ruby_core_source (>= 0.10.16, <= 3.2.0)
       libdatadog (~> 2.0.0.1.0)
       libddwaf (~> 1.8.2.0.0)

--- a/gemfiles/ruby_2.5.9_rails6_postgres_redis.gemfile.lock
+++ b/gemfiles/ruby_2.5.9_rails6_postgres_redis.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    ddtrace (1.10.1)
+    ddtrace (1.11.0.beta1)
       debase-ruby_core_source (>= 0.10.16, <= 3.2.0)
       libdatadog (~> 2.0.0.1.0)
       libddwaf (~> 1.8.2.0.0)

--- a/gemfiles/ruby_2.5.9_rails6_postgres_redis_activesupport.gemfile.lock
+++ b/gemfiles/ruby_2.5.9_rails6_postgres_redis_activesupport.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    ddtrace (1.10.1)
+    ddtrace (1.11.0.beta1)
       debase-ruby_core_source (>= 0.10.16, <= 3.2.0)
       libdatadog (~> 2.0.0.1.0)
       libddwaf (~> 1.8.2.0.0)

--- a/gemfiles/ruby_2.5.9_rails6_postgres_sidekiq.gemfile.lock
+++ b/gemfiles/ruby_2.5.9_rails6_postgres_sidekiq.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    ddtrace (1.10.1)
+    ddtrace (1.11.0.beta1)
       debase-ruby_core_source (>= 0.10.16, <= 3.2.0)
       libdatadog (~> 2.0.0.1.0)
       libddwaf (~> 1.8.2.0.0)

--- a/gemfiles/ruby_2.5.9_rails6_semantic_logger.gemfile.lock
+++ b/gemfiles/ruby_2.5.9_rails6_semantic_logger.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    ddtrace (1.10.1)
+    ddtrace (1.11.0.beta1)
       debase-ruby_core_source (>= 0.10.16, <= 3.2.0)
       libdatadog (~> 2.0.0.1.0)
       libddwaf (~> 1.8.2.0.0)

--- a/gemfiles/ruby_2.5.9_redis_3.gemfile.lock
+++ b/gemfiles/ruby_2.5.9_redis_3.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    ddtrace (1.10.1)
+    ddtrace (1.11.0.beta1)
       debase-ruby_core_source (>= 0.10.16, <= 3.2.0)
       libdatadog (~> 2.0.0.1.0)
       libddwaf (~> 1.8.2.0.0)

--- a/gemfiles/ruby_2.5.9_redis_4.gemfile.lock
+++ b/gemfiles/ruby_2.5.9_redis_4.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    ddtrace (1.10.1)
+    ddtrace (1.11.0.beta1)
       debase-ruby_core_source (>= 0.10.16, <= 3.2.0)
       libdatadog (~> 2.0.0.1.0)
       libddwaf (~> 1.8.2.0.0)

--- a/gemfiles/ruby_2.5.9_redis_5.gemfile.lock
+++ b/gemfiles/ruby_2.5.9_redis_5.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    ddtrace (1.10.1)
+    ddtrace (1.11.0.beta1)
       debase-ruby_core_source (>= 0.10.16, <= 3.2.0)
       libdatadog (~> 2.0.0.1.0)
       libddwaf (~> 1.8.2.0.0)

--- a/gemfiles/ruby_2.5.9_resque2_redis3.gemfile.lock
+++ b/gemfiles/ruby_2.5.9_resque2_redis3.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    ddtrace (1.10.1)
+    ddtrace (1.11.0.beta1)
       debase-ruby_core_source (>= 0.10.16, <= 3.2.0)
       libdatadog (~> 2.0.0.1.0)
       libddwaf (~> 1.8.2.0.0)

--- a/gemfiles/ruby_2.5.9_resque2_redis4.gemfile.lock
+++ b/gemfiles/ruby_2.5.9_resque2_redis4.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    ddtrace (1.10.1)
+    ddtrace (1.11.0.beta1)
       debase-ruby_core_source (>= 0.10.16, <= 3.2.0)
       libdatadog (~> 2.0.0.1.0)
       libddwaf (~> 1.8.2.0.0)

--- a/gemfiles/ruby_2.5.9_sinatra.gemfile.lock
+++ b/gemfiles/ruby_2.5.9_sinatra.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    ddtrace (1.10.1)
+    ddtrace (1.11.0.beta1)
       debase-ruby_core_source (>= 0.10.16, <= 3.2.0)
       libdatadog (~> 2.0.0.1.0)
       libddwaf (~> 1.8.2.0.0)

--- a/gemfiles/ruby_2.6.10_contrib.gemfile.lock
+++ b/gemfiles/ruby_2.6.10_contrib.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    ddtrace (1.10.1)
+    ddtrace (1.11.0.beta1)
       debase-ruby_core_source (>= 0.10.16, <= 3.2.0)
       libdatadog (~> 2.0.0.1.0)
       libddwaf (~> 1.8.2.0.0)

--- a/gemfiles/ruby_2.6.10_contrib_old.gemfile.lock
+++ b/gemfiles/ruby_2.6.10_contrib_old.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    ddtrace (1.10.1)
+    ddtrace (1.11.0.beta1)
       debase-ruby_core_source (>= 0.10.16, <= 3.2.0)
       libdatadog (~> 2.0.0.1.0)
       libddwaf (~> 1.8.2.0.0)

--- a/gemfiles/ruby_2.6.10_core_old.gemfile.lock
+++ b/gemfiles/ruby_2.6.10_core_old.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    ddtrace (1.10.1)
+    ddtrace (1.11.0.beta1)
       debase-ruby_core_source (>= 0.10.16, <= 3.2.0)
       libdatadog (~> 2.0.0.1.0)
       libddwaf (~> 1.8.2.0.0)

--- a/gemfiles/ruby_2.6.10_cucumber3.gemfile.lock
+++ b/gemfiles/ruby_2.6.10_cucumber3.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    ddtrace (1.10.1)
+    ddtrace (1.11.0.beta1)
       debase-ruby_core_source (>= 0.10.16, <= 3.2.0)
       libdatadog (~> 2.0.0.1.0)
       libddwaf (~> 1.8.2.0.0)

--- a/gemfiles/ruby_2.6.10_cucumber4.gemfile.lock
+++ b/gemfiles/ruby_2.6.10_cucumber4.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    ddtrace (1.10.1)
+    ddtrace (1.11.0.beta1)
       debase-ruby_core_source (>= 0.10.16, <= 3.2.0)
       libdatadog (~> 2.0.0.1.0)
       libddwaf (~> 1.8.2.0.0)

--- a/gemfiles/ruby_2.6.10_cucumber5.gemfile.lock
+++ b/gemfiles/ruby_2.6.10_cucumber5.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    ddtrace (1.10.1)
+    ddtrace (1.11.0.beta1)
       debase-ruby_core_source (>= 0.10.16, <= 3.2.0)
       libdatadog (~> 2.0.0.1.0)
       libddwaf (~> 1.8.2.0.0)

--- a/gemfiles/ruby_2.6.10_hanami_1.gemfile.lock
+++ b/gemfiles/ruby_2.6.10_hanami_1.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    ddtrace (1.10.1)
+    ddtrace (1.11.0.beta1)
       debase-ruby_core_source (>= 0.10.16, <= 3.2.0)
       libdatadog (~> 2.0.0.1.0)
       libddwaf (~> 1.8.2.0.0)

--- a/gemfiles/ruby_2.6.10_opentelemetry.gemfile.lock
+++ b/gemfiles/ruby_2.6.10_opentelemetry.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    ddtrace (1.10.1)
+    ddtrace (1.11.0.beta1)
       debase-ruby_core_source (>= 0.10.16, <= 3.2.0)
       libdatadog (~> 2.0.0.1.0)
       libddwaf (~> 1.8.2.0.0)

--- a/gemfiles/ruby_2.6.10_rails5_mysql2.gemfile.lock
+++ b/gemfiles/ruby_2.6.10_rails5_mysql2.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    ddtrace (1.10.1)
+    ddtrace (1.11.0.beta1)
       debase-ruby_core_source (>= 0.10.16, <= 3.2.0)
       libdatadog (~> 2.0.0.1.0)
       libddwaf (~> 1.8.2.0.0)

--- a/gemfiles/ruby_2.6.10_rails5_postgres.gemfile.lock
+++ b/gemfiles/ruby_2.6.10_rails5_postgres.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    ddtrace (1.10.1)
+    ddtrace (1.11.0.beta1)
       debase-ruby_core_source (>= 0.10.16, <= 3.2.0)
       libdatadog (~> 2.0.0.1.0)
       libddwaf (~> 1.8.2.0.0)

--- a/gemfiles/ruby_2.6.10_rails5_postgres_redis.gemfile.lock
+++ b/gemfiles/ruby_2.6.10_rails5_postgres_redis.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    ddtrace (1.10.1)
+    ddtrace (1.11.0.beta1)
       debase-ruby_core_source (>= 0.10.16, <= 3.2.0)
       libdatadog (~> 2.0.0.1.0)
       libddwaf (~> 1.8.2.0.0)

--- a/gemfiles/ruby_2.6.10_rails5_postgres_redis_activesupport.gemfile.lock
+++ b/gemfiles/ruby_2.6.10_rails5_postgres_redis_activesupport.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    ddtrace (1.10.1)
+    ddtrace (1.11.0.beta1)
       debase-ruby_core_source (>= 0.10.16, <= 3.2.0)
       libdatadog (~> 2.0.0.1.0)
       libddwaf (~> 1.8.2.0.0)

--- a/gemfiles/ruby_2.6.10_rails5_postgres_sidekiq.gemfile.lock
+++ b/gemfiles/ruby_2.6.10_rails5_postgres_sidekiq.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    ddtrace (1.10.1)
+    ddtrace (1.11.0.beta1)
       debase-ruby_core_source (>= 0.10.16, <= 3.2.0)
       libdatadog (~> 2.0.0.1.0)
       libddwaf (~> 1.8.2.0.0)

--- a/gemfiles/ruby_2.6.10_rails5_semantic_logger.gemfile.lock
+++ b/gemfiles/ruby_2.6.10_rails5_semantic_logger.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    ddtrace (1.10.1)
+    ddtrace (1.11.0.beta1)
       debase-ruby_core_source (>= 0.10.16, <= 3.2.0)
       libdatadog (~> 2.0.0.1.0)
       libddwaf (~> 1.8.2.0.0)

--- a/gemfiles/ruby_2.6.10_rails61_mysql2.gemfile.lock
+++ b/gemfiles/ruby_2.6.10_rails61_mysql2.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    ddtrace (1.10.1)
+    ddtrace (1.11.0.beta1)
       debase-ruby_core_source (>= 0.10.16, <= 3.2.0)
       libdatadog (~> 2.0.0.1.0)
       libddwaf (~> 1.8.2.0.0)

--- a/gemfiles/ruby_2.6.10_rails61_postgres.gemfile.lock
+++ b/gemfiles/ruby_2.6.10_rails61_postgres.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    ddtrace (1.10.1)
+    ddtrace (1.11.0.beta1)
       debase-ruby_core_source (>= 0.10.16, <= 3.2.0)
       libdatadog (~> 2.0.0.1.0)
       libddwaf (~> 1.8.2.0.0)

--- a/gemfiles/ruby_2.6.10_rails61_postgres_redis.gemfile.lock
+++ b/gemfiles/ruby_2.6.10_rails61_postgres_redis.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    ddtrace (1.10.1)
+    ddtrace (1.11.0.beta1)
       debase-ruby_core_source (>= 0.10.16, <= 3.2.0)
       libdatadog (~> 2.0.0.1.0)
       libddwaf (~> 1.8.2.0.0)

--- a/gemfiles/ruby_2.6.10_rails61_postgres_sidekiq.gemfile.lock
+++ b/gemfiles/ruby_2.6.10_rails61_postgres_sidekiq.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    ddtrace (1.10.1)
+    ddtrace (1.11.0.beta1)
       debase-ruby_core_source (>= 0.10.16, <= 3.2.0)
       libdatadog (~> 2.0.0.1.0)
       libddwaf (~> 1.8.2.0.0)

--- a/gemfiles/ruby_2.6.10_rails61_semantic_logger.gemfile.lock
+++ b/gemfiles/ruby_2.6.10_rails61_semantic_logger.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    ddtrace (1.10.1)
+    ddtrace (1.11.0.beta1)
       debase-ruby_core_source (>= 0.10.16, <= 3.2.0)
       libdatadog (~> 2.0.0.1.0)
       libddwaf (~> 1.8.2.0.0)

--- a/gemfiles/ruby_2.6.10_rails6_mysql2.gemfile.lock
+++ b/gemfiles/ruby_2.6.10_rails6_mysql2.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    ddtrace (1.10.1)
+    ddtrace (1.11.0.beta1)
       debase-ruby_core_source (>= 0.10.16, <= 3.2.0)
       libdatadog (~> 2.0.0.1.0)
       libddwaf (~> 1.8.2.0.0)

--- a/gemfiles/ruby_2.6.10_rails6_postgres.gemfile.lock
+++ b/gemfiles/ruby_2.6.10_rails6_postgres.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    ddtrace (1.10.1)
+    ddtrace (1.11.0.beta1)
       debase-ruby_core_source (>= 0.10.16, <= 3.2.0)
       libdatadog (~> 2.0.0.1.0)
       libddwaf (~> 1.8.2.0.0)

--- a/gemfiles/ruby_2.6.10_rails6_postgres_redis.gemfile.lock
+++ b/gemfiles/ruby_2.6.10_rails6_postgres_redis.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    ddtrace (1.10.1)
+    ddtrace (1.11.0.beta1)
       debase-ruby_core_source (>= 0.10.16, <= 3.2.0)
       libdatadog (~> 2.0.0.1.0)
       libddwaf (~> 1.8.2.0.0)

--- a/gemfiles/ruby_2.6.10_rails6_postgres_redis_activesupport.gemfile.lock
+++ b/gemfiles/ruby_2.6.10_rails6_postgres_redis_activesupport.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    ddtrace (1.10.1)
+    ddtrace (1.11.0.beta1)
       debase-ruby_core_source (>= 0.10.16, <= 3.2.0)
       libdatadog (~> 2.0.0.1.0)
       libddwaf (~> 1.8.2.0.0)

--- a/gemfiles/ruby_2.6.10_rails6_postgres_sidekiq.gemfile.lock
+++ b/gemfiles/ruby_2.6.10_rails6_postgres_sidekiq.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    ddtrace (1.10.1)
+    ddtrace (1.11.0.beta1)
       debase-ruby_core_source (>= 0.10.16, <= 3.2.0)
       libdatadog (~> 2.0.0.1.0)
       libddwaf (~> 1.8.2.0.0)

--- a/gemfiles/ruby_2.6.10_rails6_semantic_logger.gemfile.lock
+++ b/gemfiles/ruby_2.6.10_rails6_semantic_logger.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    ddtrace (1.10.1)
+    ddtrace (1.11.0.beta1)
       debase-ruby_core_source (>= 0.10.16, <= 3.2.0)
       libdatadog (~> 2.0.0.1.0)
       libddwaf (~> 1.8.2.0.0)

--- a/gemfiles/ruby_2.6.10_redis_3.gemfile.lock
+++ b/gemfiles/ruby_2.6.10_redis_3.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    ddtrace (1.10.1)
+    ddtrace (1.11.0.beta1)
       debase-ruby_core_source (>= 0.10.16, <= 3.2.0)
       libdatadog (~> 2.0.0.1.0)
       libddwaf (~> 1.8.2.0.0)

--- a/gemfiles/ruby_2.6.10_redis_4.gemfile.lock
+++ b/gemfiles/ruby_2.6.10_redis_4.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    ddtrace (1.10.1)
+    ddtrace (1.11.0.beta1)
       debase-ruby_core_source (>= 0.10.16, <= 3.2.0)
       libdatadog (~> 2.0.0.1.0)
       libddwaf (~> 1.8.2.0.0)

--- a/gemfiles/ruby_2.6.10_redis_5.gemfile.lock
+++ b/gemfiles/ruby_2.6.10_redis_5.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    ddtrace (1.10.1)
+    ddtrace (1.11.0.beta1)
       debase-ruby_core_source (>= 0.10.16, <= 3.2.0)
       libdatadog (~> 2.0.0.1.0)
       libddwaf (~> 1.8.2.0.0)

--- a/gemfiles/ruby_2.6.10_resque2_redis3.gemfile.lock
+++ b/gemfiles/ruby_2.6.10_resque2_redis3.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    ddtrace (1.10.1)
+    ddtrace (1.11.0.beta1)
       debase-ruby_core_source (>= 0.10.16, <= 3.2.0)
       libdatadog (~> 2.0.0.1.0)
       libddwaf (~> 1.8.2.0.0)

--- a/gemfiles/ruby_2.6.10_resque2_redis4.gemfile.lock
+++ b/gemfiles/ruby_2.6.10_resque2_redis4.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    ddtrace (1.10.1)
+    ddtrace (1.11.0.beta1)
       debase-ruby_core_source (>= 0.10.16, <= 3.2.0)
       libdatadog (~> 2.0.0.1.0)
       libddwaf (~> 1.8.2.0.0)

--- a/gemfiles/ruby_2.6.10_sinatra.gemfile.lock
+++ b/gemfiles/ruby_2.6.10_sinatra.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    ddtrace (1.10.1)
+    ddtrace (1.11.0.beta1)
       debase-ruby_core_source (>= 0.10.16, <= 3.2.0)
       libdatadog (~> 2.0.0.1.0)
       libddwaf (~> 1.8.2.0.0)

--- a/gemfiles/ruby_2.7.6_contrib.gemfile.lock
+++ b/gemfiles/ruby_2.7.6_contrib.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    ddtrace (1.10.1)
+    ddtrace (1.11.0.beta1)
       debase-ruby_core_source (>= 0.10.16, <= 3.2.0)
       libdatadog (~> 2.0.0.1.0)
       libddwaf (~> 1.8.2.0.0)

--- a/gemfiles/ruby_2.7.6_contrib_old.gemfile.lock
+++ b/gemfiles/ruby_2.7.6_contrib_old.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    ddtrace (1.10.1)
+    ddtrace (1.11.0.beta1)
       debase-ruby_core_source (>= 0.10.16, <= 3.2.0)
       libdatadog (~> 2.0.0.1.0)
       libddwaf (~> 1.8.2.0.0)

--- a/gemfiles/ruby_2.7.6_core_old.gemfile.lock
+++ b/gemfiles/ruby_2.7.6_core_old.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    ddtrace (1.10.1)
+    ddtrace (1.11.0.beta1)
       debase-ruby_core_source (>= 0.10.16, <= 3.2.0)
       libdatadog (~> 2.0.0.1.0)
       libddwaf (~> 1.8.2.0.0)

--- a/gemfiles/ruby_2.7.6_cucumber3.gemfile.lock
+++ b/gemfiles/ruby_2.7.6_cucumber3.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    ddtrace (1.10.1)
+    ddtrace (1.11.0.beta1)
       debase-ruby_core_source (>= 0.10.16, <= 3.2.0)
       libdatadog (~> 2.0.0.1.0)
       libddwaf (~> 1.8.2.0.0)

--- a/gemfiles/ruby_2.7.6_cucumber4.gemfile.lock
+++ b/gemfiles/ruby_2.7.6_cucumber4.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    ddtrace (1.10.1)
+    ddtrace (1.11.0.beta1)
       debase-ruby_core_source (>= 0.10.16, <= 3.2.0)
       libdatadog (~> 2.0.0.1.0)
       libddwaf (~> 1.8.2.0.0)

--- a/gemfiles/ruby_2.7.6_cucumber5.gemfile.lock
+++ b/gemfiles/ruby_2.7.6_cucumber5.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    ddtrace (1.10.1)
+    ddtrace (1.11.0.beta1)
       debase-ruby_core_source (>= 0.10.16, <= 3.2.0)
       libdatadog (~> 2.0.0.1.0)
       libddwaf (~> 1.8.2.0.0)

--- a/gemfiles/ruby_2.7.6_hanami_1.gemfile.lock
+++ b/gemfiles/ruby_2.7.6_hanami_1.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    ddtrace (1.10.1)
+    ddtrace (1.11.0.beta1)
       debase-ruby_core_source (>= 0.10.16, <= 3.2.0)
       libdatadog (~> 2.0.0.1.0)
       libddwaf (~> 1.8.2.0.0)

--- a/gemfiles/ruby_2.7.6_opentelemetry.gemfile.lock
+++ b/gemfiles/ruby_2.7.6_opentelemetry.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    ddtrace (1.10.1)
+    ddtrace (1.11.0.beta1)
       debase-ruby_core_source (>= 0.10.16, <= 3.2.0)
       libdatadog (~> 2.0.0.1.0)
       libddwaf (~> 1.8.2.0.0)

--- a/gemfiles/ruby_2.7.6_rails5_mysql2.gemfile.lock
+++ b/gemfiles/ruby_2.7.6_rails5_mysql2.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    ddtrace (1.10.1)
+    ddtrace (1.11.0.beta1)
       debase-ruby_core_source (>= 0.10.16, <= 3.2.0)
       libdatadog (~> 2.0.0.1.0)
       libddwaf (~> 1.8.2.0.0)

--- a/gemfiles/ruby_2.7.6_rails5_postgres.gemfile.lock
+++ b/gemfiles/ruby_2.7.6_rails5_postgres.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    ddtrace (1.10.1)
+    ddtrace (1.11.0.beta1)
       debase-ruby_core_source (>= 0.10.16, <= 3.2.0)
       libdatadog (~> 2.0.0.1.0)
       libddwaf (~> 1.8.2.0.0)

--- a/gemfiles/ruby_2.7.6_rails5_postgres_redis.gemfile.lock
+++ b/gemfiles/ruby_2.7.6_rails5_postgres_redis.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    ddtrace (1.10.1)
+    ddtrace (1.11.0.beta1)
       debase-ruby_core_source (>= 0.10.16, <= 3.2.0)
       libdatadog (~> 2.0.0.1.0)
       libddwaf (~> 1.8.2.0.0)

--- a/gemfiles/ruby_2.7.6_rails5_postgres_redis_activesupport.gemfile.lock
+++ b/gemfiles/ruby_2.7.6_rails5_postgres_redis_activesupport.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    ddtrace (1.10.1)
+    ddtrace (1.11.0.beta1)
       debase-ruby_core_source (>= 0.10.16, <= 3.2.0)
       libdatadog (~> 2.0.0.1.0)
       libddwaf (~> 1.8.2.0.0)

--- a/gemfiles/ruby_2.7.6_rails5_postgres_sidekiq.gemfile.lock
+++ b/gemfiles/ruby_2.7.6_rails5_postgres_sidekiq.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    ddtrace (1.10.1)
+    ddtrace (1.11.0.beta1)
       debase-ruby_core_source (>= 0.10.16, <= 3.2.0)
       libdatadog (~> 2.0.0.1.0)
       libddwaf (~> 1.8.2.0.0)

--- a/gemfiles/ruby_2.7.6_rails5_semantic_logger.gemfile.lock
+++ b/gemfiles/ruby_2.7.6_rails5_semantic_logger.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    ddtrace (1.10.1)
+    ddtrace (1.11.0.beta1)
       debase-ruby_core_source (>= 0.10.16, <= 3.2.0)
       libdatadog (~> 2.0.0.1.0)
       libddwaf (~> 1.8.2.0.0)

--- a/gemfiles/ruby_2.7.6_rails61_mysql2.gemfile.lock
+++ b/gemfiles/ruby_2.7.6_rails61_mysql2.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    ddtrace (1.10.1)
+    ddtrace (1.11.0.beta1)
       debase-ruby_core_source (>= 0.10.16, <= 3.2.0)
       libdatadog (~> 2.0.0.1.0)
       libddwaf (~> 1.8.2.0.0)

--- a/gemfiles/ruby_2.7.6_rails61_postgres.gemfile.lock
+++ b/gemfiles/ruby_2.7.6_rails61_postgres.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    ddtrace (1.10.1)
+    ddtrace (1.11.0.beta1)
       debase-ruby_core_source (>= 0.10.16, <= 3.2.0)
       libdatadog (~> 2.0.0.1.0)
       libddwaf (~> 1.8.2.0.0)

--- a/gemfiles/ruby_2.7.6_rails61_postgres_redis.gemfile.lock
+++ b/gemfiles/ruby_2.7.6_rails61_postgres_redis.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    ddtrace (1.10.1)
+    ddtrace (1.11.0.beta1)
       debase-ruby_core_source (>= 0.10.16, <= 3.2.0)
       libdatadog (~> 2.0.0.1.0)
       libddwaf (~> 1.8.2.0.0)

--- a/gemfiles/ruby_2.7.6_rails61_postgres_sidekiq.gemfile.lock
+++ b/gemfiles/ruby_2.7.6_rails61_postgres_sidekiq.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    ddtrace (1.10.1)
+    ddtrace (1.11.0.beta1)
       debase-ruby_core_source (>= 0.10.16, <= 3.2.0)
       libdatadog (~> 2.0.0.1.0)
       libddwaf (~> 1.8.2.0.0)

--- a/gemfiles/ruby_2.7.6_rails61_semantic_logger.gemfile.lock
+++ b/gemfiles/ruby_2.7.6_rails61_semantic_logger.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    ddtrace (1.10.1)
+    ddtrace (1.11.0.beta1)
       debase-ruby_core_source (>= 0.10.16, <= 3.2.0)
       libdatadog (~> 2.0.0.1.0)
       libddwaf (~> 1.8.2.0.0)

--- a/gemfiles/ruby_2.7.6_rails6_mysql2.gemfile.lock
+++ b/gemfiles/ruby_2.7.6_rails6_mysql2.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    ddtrace (1.10.1)
+    ddtrace (1.11.0.beta1)
       debase-ruby_core_source (>= 0.10.16, <= 3.2.0)
       libdatadog (~> 2.0.0.1.0)
       libddwaf (~> 1.8.2.0.0)

--- a/gemfiles/ruby_2.7.6_rails6_postgres.gemfile.lock
+++ b/gemfiles/ruby_2.7.6_rails6_postgres.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    ddtrace (1.10.1)
+    ddtrace (1.11.0.beta1)
       debase-ruby_core_source (>= 0.10.16, <= 3.2.0)
       libdatadog (~> 2.0.0.1.0)
       libddwaf (~> 1.8.2.0.0)

--- a/gemfiles/ruby_2.7.6_rails6_postgres_redis.gemfile.lock
+++ b/gemfiles/ruby_2.7.6_rails6_postgres_redis.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    ddtrace (1.10.1)
+    ddtrace (1.11.0.beta1)
       debase-ruby_core_source (>= 0.10.16, <= 3.2.0)
       libdatadog (~> 2.0.0.1.0)
       libddwaf (~> 1.8.2.0.0)

--- a/gemfiles/ruby_2.7.6_rails6_postgres_redis_activesupport.gemfile.lock
+++ b/gemfiles/ruby_2.7.6_rails6_postgres_redis_activesupport.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    ddtrace (1.10.1)
+    ddtrace (1.11.0.beta1)
       debase-ruby_core_source (>= 0.10.16, <= 3.2.0)
       libdatadog (~> 2.0.0.1.0)
       libddwaf (~> 1.8.2.0.0)

--- a/gemfiles/ruby_2.7.6_rails6_postgres_sidekiq.gemfile.lock
+++ b/gemfiles/ruby_2.7.6_rails6_postgres_sidekiq.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    ddtrace (1.10.1)
+    ddtrace (1.11.0.beta1)
       debase-ruby_core_source (>= 0.10.16, <= 3.2.0)
       libdatadog (~> 2.0.0.1.0)
       libddwaf (~> 1.8.2.0.0)

--- a/gemfiles/ruby_2.7.6_rails6_semantic_logger.gemfile.lock
+++ b/gemfiles/ruby_2.7.6_rails6_semantic_logger.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    ddtrace (1.10.1)
+    ddtrace (1.11.0.beta1)
       debase-ruby_core_source (>= 0.10.16, <= 3.2.0)
       libdatadog (~> 2.0.0.1.0)
       libddwaf (~> 1.8.2.0.0)

--- a/gemfiles/ruby_2.7.6_redis_3.gemfile.lock
+++ b/gemfiles/ruby_2.7.6_redis_3.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    ddtrace (1.10.1)
+    ddtrace (1.11.0.beta1)
       debase-ruby_core_source (>= 0.10.16, <= 3.2.0)
       libdatadog (~> 2.0.0.1.0)
       libddwaf (~> 1.8.2.0.0)

--- a/gemfiles/ruby_2.7.6_redis_4.gemfile.lock
+++ b/gemfiles/ruby_2.7.6_redis_4.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    ddtrace (1.10.1)
+    ddtrace (1.11.0.beta1)
       debase-ruby_core_source (>= 0.10.16, <= 3.2.0)
       libdatadog (~> 2.0.0.1.0)
       libddwaf (~> 1.8.2.0.0)

--- a/gemfiles/ruby_2.7.6_redis_5.gemfile.lock
+++ b/gemfiles/ruby_2.7.6_redis_5.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    ddtrace (1.10.1)
+    ddtrace (1.11.0.beta1)
       debase-ruby_core_source (>= 0.10.16, <= 3.2.0)
       libdatadog (~> 2.0.0.1.0)
       libddwaf (~> 1.8.2.0.0)

--- a/gemfiles/ruby_2.7.6_resque2_redis3.gemfile.lock
+++ b/gemfiles/ruby_2.7.6_resque2_redis3.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    ddtrace (1.10.1)
+    ddtrace (1.11.0.beta1)
       debase-ruby_core_source (>= 0.10.16, <= 3.2.0)
       libdatadog (~> 2.0.0.1.0)
       libddwaf (~> 1.8.2.0.0)

--- a/gemfiles/ruby_2.7.6_resque2_redis4.gemfile.lock
+++ b/gemfiles/ruby_2.7.6_resque2_redis4.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    ddtrace (1.10.1)
+    ddtrace (1.11.0.beta1)
       debase-ruby_core_source (>= 0.10.16, <= 3.2.0)
       libdatadog (~> 2.0.0.1.0)
       libddwaf (~> 1.8.2.0.0)

--- a/gemfiles/ruby_2.7.6_sinatra.gemfile.lock
+++ b/gemfiles/ruby_2.7.6_sinatra.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    ddtrace (1.10.1)
+    ddtrace (1.11.0.beta1)
       debase-ruby_core_source (>= 0.10.16, <= 3.2.0)
       libdatadog (~> 2.0.0.1.0)
       libddwaf (~> 1.8.2.0.0)

--- a/gemfiles/ruby_3.0.4_contrib.gemfile.lock
+++ b/gemfiles/ruby_3.0.4_contrib.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    ddtrace (1.10.1)
+    ddtrace (1.11.0.beta1)
       debase-ruby_core_source (>= 0.10.16, <= 3.2.0)
       libdatadog (~> 2.0.0.1.0)
       libddwaf (~> 1.8.2.0.0)

--- a/gemfiles/ruby_3.0.4_contrib_old.gemfile.lock
+++ b/gemfiles/ruby_3.0.4_contrib_old.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    ddtrace (1.10.1)
+    ddtrace (1.11.0.beta1)
       debase-ruby_core_source (>= 0.10.16, <= 3.2.0)
       libdatadog (~> 2.0.0.1.0)
       libddwaf (~> 1.8.2.0.0)

--- a/gemfiles/ruby_3.0.4_core_old.gemfile.lock
+++ b/gemfiles/ruby_3.0.4_core_old.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    ddtrace (1.10.1)
+    ddtrace (1.11.0.beta1)
       debase-ruby_core_source (>= 0.10.16, <= 3.2.0)
       libdatadog (~> 2.0.0.1.0)
       libddwaf (~> 1.8.2.0.0)

--- a/gemfiles/ruby_3.0.4_cucumber3.gemfile.lock
+++ b/gemfiles/ruby_3.0.4_cucumber3.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    ddtrace (1.10.1)
+    ddtrace (1.11.0.beta1)
       debase-ruby_core_source (>= 0.10.16, <= 3.2.0)
       libdatadog (~> 2.0.0.1.0)
       libddwaf (~> 1.8.2.0.0)

--- a/gemfiles/ruby_3.0.4_cucumber4.gemfile.lock
+++ b/gemfiles/ruby_3.0.4_cucumber4.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    ddtrace (1.10.1)
+    ddtrace (1.11.0.beta1)
       debase-ruby_core_source (>= 0.10.16, <= 3.2.0)
       libdatadog (~> 2.0.0.1.0)
       libddwaf (~> 1.8.2.0.0)

--- a/gemfiles/ruby_3.0.4_cucumber5.gemfile.lock
+++ b/gemfiles/ruby_3.0.4_cucumber5.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    ddtrace (1.10.1)
+    ddtrace (1.11.0.beta1)
       debase-ruby_core_source (>= 0.10.16, <= 3.2.0)
       libdatadog (~> 2.0.0.1.0)
       libddwaf (~> 1.8.2.0.0)

--- a/gemfiles/ruby_3.0.4_opentelemetry.gemfile.lock
+++ b/gemfiles/ruby_3.0.4_opentelemetry.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    ddtrace (1.10.1)
+    ddtrace (1.11.0.beta1)
       debase-ruby_core_source (>= 0.10.16, <= 3.2.0)
       libdatadog (~> 2.0.0.1.0)
       libddwaf (~> 1.8.2.0.0)

--- a/gemfiles/ruby_3.0.4_rails61_mysql2.gemfile.lock
+++ b/gemfiles/ruby_3.0.4_rails61_mysql2.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    ddtrace (1.10.1)
+    ddtrace (1.11.0.beta1)
       debase-ruby_core_source (>= 0.10.16, <= 3.2.0)
       libdatadog (~> 2.0.0.1.0)
       libddwaf (~> 1.8.2.0.0)

--- a/gemfiles/ruby_3.0.4_rails61_postgres.gemfile.lock
+++ b/gemfiles/ruby_3.0.4_rails61_postgres.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    ddtrace (1.10.1)
+    ddtrace (1.11.0.beta1)
       debase-ruby_core_source (>= 0.10.16, <= 3.2.0)
       libdatadog (~> 2.0.0.1.0)
       libddwaf (~> 1.8.2.0.0)

--- a/gemfiles/ruby_3.0.4_rails61_postgres_redis.gemfile.lock
+++ b/gemfiles/ruby_3.0.4_rails61_postgres_redis.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    ddtrace (1.10.1)
+    ddtrace (1.11.0.beta1)
       debase-ruby_core_source (>= 0.10.16, <= 3.2.0)
       libdatadog (~> 2.0.0.1.0)
       libddwaf (~> 1.8.2.0.0)

--- a/gemfiles/ruby_3.0.4_rails61_postgres_sidekiq.gemfile.lock
+++ b/gemfiles/ruby_3.0.4_rails61_postgres_sidekiq.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    ddtrace (1.10.1)
+    ddtrace (1.11.0.beta1)
       debase-ruby_core_source (>= 0.10.16, <= 3.2.0)
       libdatadog (~> 2.0.0.1.0)
       libddwaf (~> 1.8.2.0.0)

--- a/gemfiles/ruby_3.0.4_rails61_semantic_logger.gemfile.lock
+++ b/gemfiles/ruby_3.0.4_rails61_semantic_logger.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    ddtrace (1.10.1)
+    ddtrace (1.11.0.beta1)
       debase-ruby_core_source (>= 0.10.16, <= 3.2.0)
       libdatadog (~> 2.0.0.1.0)
       libddwaf (~> 1.8.2.0.0)

--- a/gemfiles/ruby_3.0.4_redis_3.gemfile.lock
+++ b/gemfiles/ruby_3.0.4_redis_3.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    ddtrace (1.10.1)
+    ddtrace (1.11.0.beta1)
       debase-ruby_core_source (>= 0.10.16, <= 3.2.0)
       libdatadog (~> 2.0.0.1.0)
       libddwaf (~> 1.8.2.0.0)

--- a/gemfiles/ruby_3.0.4_redis_4.gemfile.lock
+++ b/gemfiles/ruby_3.0.4_redis_4.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    ddtrace (1.10.1)
+    ddtrace (1.11.0.beta1)
       debase-ruby_core_source (>= 0.10.16, <= 3.2.0)
       libdatadog (~> 2.0.0.1.0)
       libddwaf (~> 1.8.2.0.0)

--- a/gemfiles/ruby_3.0.4_redis_5.gemfile.lock
+++ b/gemfiles/ruby_3.0.4_redis_5.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    ddtrace (1.10.1)
+    ddtrace (1.11.0.beta1)
       debase-ruby_core_source (>= 0.10.16, <= 3.2.0)
       libdatadog (~> 2.0.0.1.0)
       libddwaf (~> 1.8.2.0.0)

--- a/gemfiles/ruby_3.0.4_resque2_redis3.gemfile.lock
+++ b/gemfiles/ruby_3.0.4_resque2_redis3.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    ddtrace (1.10.1)
+    ddtrace (1.11.0.beta1)
       debase-ruby_core_source (>= 0.10.16, <= 3.2.0)
       libdatadog (~> 2.0.0.1.0)
       libddwaf (~> 1.8.2.0.0)

--- a/gemfiles/ruby_3.0.4_resque2_redis4.gemfile.lock
+++ b/gemfiles/ruby_3.0.4_resque2_redis4.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    ddtrace (1.10.1)
+    ddtrace (1.11.0.beta1)
       debase-ruby_core_source (>= 0.10.16, <= 3.2.0)
       libdatadog (~> 2.0.0.1.0)
       libddwaf (~> 1.8.2.0.0)

--- a/gemfiles/ruby_3.0.4_sinatra.gemfile.lock
+++ b/gemfiles/ruby_3.0.4_sinatra.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    ddtrace (1.10.1)
+    ddtrace (1.11.0.beta1)
       debase-ruby_core_source (>= 0.10.16, <= 3.2.0)
       libdatadog (~> 2.0.0.1.0)
       libddwaf (~> 1.8.2.0.0)

--- a/gemfiles/ruby_3.1.2_contrib.gemfile.lock
+++ b/gemfiles/ruby_3.1.2_contrib.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    ddtrace (1.10.1)
+    ddtrace (1.11.0.beta1)
       debase-ruby_core_source (>= 0.10.16, <= 3.2.0)
       libdatadog (~> 2.0.0.1.0)
       libddwaf (~> 1.8.2.0.0)

--- a/gemfiles/ruby_3.1.2_contrib_old.gemfile.lock
+++ b/gemfiles/ruby_3.1.2_contrib_old.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    ddtrace (1.10.1)
+    ddtrace (1.11.0.beta1)
       debase-ruby_core_source (>= 0.10.16, <= 3.2.0)
       libdatadog (~> 2.0.0.1.0)
       libddwaf (~> 1.8.2.0.0)

--- a/gemfiles/ruby_3.1.2_core_old.gemfile.lock
+++ b/gemfiles/ruby_3.1.2_core_old.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    ddtrace (1.10.1)
+    ddtrace (1.11.0.beta1)
       debase-ruby_core_source (>= 0.10.16, <= 3.2.0)
       libdatadog (~> 2.0.0.1.0)
       libddwaf (~> 1.8.2.0.0)

--- a/gemfiles/ruby_3.1.2_cucumber3.gemfile.lock
+++ b/gemfiles/ruby_3.1.2_cucumber3.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    ddtrace (1.10.1)
+    ddtrace (1.11.0.beta1)
       debase-ruby_core_source (>= 0.10.16, <= 3.2.0)
       libdatadog (~> 2.0.0.1.0)
       libddwaf (~> 1.8.2.0.0)

--- a/gemfiles/ruby_3.1.2_cucumber4.gemfile.lock
+++ b/gemfiles/ruby_3.1.2_cucumber4.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    ddtrace (1.10.1)
+    ddtrace (1.11.0.beta1)
       debase-ruby_core_source (>= 0.10.16, <= 3.2.0)
       libdatadog (~> 2.0.0.1.0)
       libddwaf (~> 1.8.2.0.0)

--- a/gemfiles/ruby_3.1.2_cucumber5.gemfile.lock
+++ b/gemfiles/ruby_3.1.2_cucumber5.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    ddtrace (1.10.1)
+    ddtrace (1.11.0.beta1)
       debase-ruby_core_source (>= 0.10.16, <= 3.2.0)
       libdatadog (~> 2.0.0.1.0)
       libddwaf (~> 1.8.2.0.0)

--- a/gemfiles/ruby_3.1.2_opentelemetry.gemfile.lock
+++ b/gemfiles/ruby_3.1.2_opentelemetry.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    ddtrace (1.10.1)
+    ddtrace (1.11.0.beta1)
       debase-ruby_core_source (>= 0.10.16, <= 3.2.0)
       libdatadog (~> 2.0.0.1.0)
       libddwaf (~> 1.8.2.0.0)

--- a/gemfiles/ruby_3.1.2_rails61_mysql2.gemfile.lock
+++ b/gemfiles/ruby_3.1.2_rails61_mysql2.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    ddtrace (1.10.1)
+    ddtrace (1.11.0.beta1)
       debase-ruby_core_source (>= 0.10.16, <= 3.2.0)
       libdatadog (~> 2.0.0.1.0)
       libddwaf (~> 1.8.2.0.0)

--- a/gemfiles/ruby_3.1.2_rails61_postgres.gemfile.lock
+++ b/gemfiles/ruby_3.1.2_rails61_postgres.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    ddtrace (1.10.1)
+    ddtrace (1.11.0.beta1)
       debase-ruby_core_source (>= 0.10.16, <= 3.2.0)
       libdatadog (~> 2.0.0.1.0)
       libddwaf (~> 1.8.2.0.0)

--- a/gemfiles/ruby_3.1.2_rails61_postgres_redis.gemfile.lock
+++ b/gemfiles/ruby_3.1.2_rails61_postgres_redis.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    ddtrace (1.10.1)
+    ddtrace (1.11.0.beta1)
       debase-ruby_core_source (>= 0.10.16, <= 3.2.0)
       libdatadog (~> 2.0.0.1.0)
       libddwaf (~> 1.8.2.0.0)

--- a/gemfiles/ruby_3.1.2_rails61_postgres_sidekiq.gemfile.lock
+++ b/gemfiles/ruby_3.1.2_rails61_postgres_sidekiq.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    ddtrace (1.10.1)
+    ddtrace (1.11.0.beta1)
       debase-ruby_core_source (>= 0.10.16, <= 3.2.0)
       libdatadog (~> 2.0.0.1.0)
       libddwaf (~> 1.8.2.0.0)

--- a/gemfiles/ruby_3.1.2_rails61_semantic_logger.gemfile.lock
+++ b/gemfiles/ruby_3.1.2_rails61_semantic_logger.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    ddtrace (1.10.1)
+    ddtrace (1.11.0.beta1)
       debase-ruby_core_source (>= 0.10.16, <= 3.2.0)
       libdatadog (~> 2.0.0.1.0)
       libddwaf (~> 1.8.2.0.0)

--- a/gemfiles/ruby_3.1.2_redis_3.gemfile.lock
+++ b/gemfiles/ruby_3.1.2_redis_3.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    ddtrace (1.10.1)
+    ddtrace (1.11.0.beta1)
       debase-ruby_core_source (>= 0.10.16, <= 3.2.0)
       libdatadog (~> 2.0.0.1.0)
       libddwaf (~> 1.8.2.0.0)

--- a/gemfiles/ruby_3.1.2_redis_4.gemfile.lock
+++ b/gemfiles/ruby_3.1.2_redis_4.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    ddtrace (1.10.1)
+    ddtrace (1.11.0.beta1)
       debase-ruby_core_source (>= 0.10.16, <= 3.2.0)
       libdatadog (~> 2.0.0.1.0)
       libddwaf (~> 1.8.2.0.0)

--- a/gemfiles/ruby_3.1.2_redis_5.gemfile.lock
+++ b/gemfiles/ruby_3.1.2_redis_5.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    ddtrace (1.10.1)
+    ddtrace (1.11.0.beta1)
       debase-ruby_core_source (>= 0.10.16, <= 3.2.0)
       libdatadog (~> 2.0.0.1.0)
       libddwaf (~> 1.8.2.0.0)

--- a/gemfiles/ruby_3.1.2_resque2_redis3.gemfile.lock
+++ b/gemfiles/ruby_3.1.2_resque2_redis3.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    ddtrace (1.10.1)
+    ddtrace (1.11.0.beta1)
       debase-ruby_core_source (>= 0.10.16, <= 3.2.0)
       libdatadog (~> 2.0.0.1.0)
       libddwaf (~> 1.8.2.0.0)

--- a/gemfiles/ruby_3.1.2_resque2_redis4.gemfile.lock
+++ b/gemfiles/ruby_3.1.2_resque2_redis4.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    ddtrace (1.10.1)
+    ddtrace (1.11.0.beta1)
       debase-ruby_core_source (>= 0.10.16, <= 3.2.0)
       libdatadog (~> 2.0.0.1.0)
       libddwaf (~> 1.8.2.0.0)

--- a/gemfiles/ruby_3.1.2_sinatra.gemfile.lock
+++ b/gemfiles/ruby_3.1.2_sinatra.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    ddtrace (1.10.1)
+    ddtrace (1.11.0.beta1)
       debase-ruby_core_source (>= 0.10.16, <= 3.2.0)
       libdatadog (~> 2.0.0.1.0)
       libddwaf (~> 1.8.2.0.0)

--- a/gemfiles/ruby_3.2.0_contrib.gemfile.lock
+++ b/gemfiles/ruby_3.2.0_contrib.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    ddtrace (1.10.1)
+    ddtrace (1.11.0.beta1)
       debase-ruby_core_source (>= 0.10.16, <= 3.2.0)
       libdatadog (~> 2.0.0.1.0)
       libddwaf (~> 1.8.2.0.0)

--- a/gemfiles/ruby_3.2.0_contrib_old.gemfile.lock
+++ b/gemfiles/ruby_3.2.0_contrib_old.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    ddtrace (1.10.1)
+    ddtrace (1.11.0.beta1)
       debase-ruby_core_source (>= 0.10.16, <= 3.2.0)
       libdatadog (~> 2.0.0.1.0)
       libddwaf (~> 1.8.2.0.0)

--- a/gemfiles/ruby_3.2.0_core_old.gemfile.lock
+++ b/gemfiles/ruby_3.2.0_core_old.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    ddtrace (1.10.1)
+    ddtrace (1.11.0.beta1)
       debase-ruby_core_source (>= 0.10.16, <= 3.2.0)
       libdatadog (~> 2.0.0.1.0)
       libddwaf (~> 1.8.2.0.0)

--- a/gemfiles/ruby_3.2.0_cucumber3.gemfile.lock
+++ b/gemfiles/ruby_3.2.0_cucumber3.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    ddtrace (1.10.1)
+    ddtrace (1.11.0.beta1)
       debase-ruby_core_source (>= 0.10.16, <= 3.2.0)
       libdatadog (~> 2.0.0.1.0)
       libddwaf (~> 1.8.2.0.0)

--- a/gemfiles/ruby_3.2.0_cucumber4.gemfile.lock
+++ b/gemfiles/ruby_3.2.0_cucumber4.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    ddtrace (1.10.1)
+    ddtrace (1.11.0.beta1)
       debase-ruby_core_source (>= 0.10.16, <= 3.2.0)
       libdatadog (~> 2.0.0.1.0)
       libddwaf (~> 1.8.2.0.0)

--- a/gemfiles/ruby_3.2.0_cucumber5.gemfile.lock
+++ b/gemfiles/ruby_3.2.0_cucumber5.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    ddtrace (1.10.1)
+    ddtrace (1.11.0.beta1)
       debase-ruby_core_source (>= 0.10.16, <= 3.2.0)
       libdatadog (~> 2.0.0.1.0)
       libddwaf (~> 1.8.2.0.0)

--- a/gemfiles/ruby_3.2.0_opentelemetry.gemfile.lock
+++ b/gemfiles/ruby_3.2.0_opentelemetry.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    ddtrace (1.10.1)
+    ddtrace (1.11.0.beta1)
       debase-ruby_core_source (>= 0.10.16, <= 3.2.0)
       libdatadog (~> 2.0.0.1.0)
       libddwaf (~> 1.8.2.0.0)

--- a/gemfiles/ruby_3.2.0_rails61_mysql2.gemfile.lock
+++ b/gemfiles/ruby_3.2.0_rails61_mysql2.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    ddtrace (1.10.1)
+    ddtrace (1.11.0.beta1)
       debase-ruby_core_source (>= 0.10.16, <= 3.2.0)
       libdatadog (~> 2.0.0.1.0)
       libddwaf (~> 1.8.2.0.0)

--- a/gemfiles/ruby_3.2.0_rails61_postgres.gemfile.lock
+++ b/gemfiles/ruby_3.2.0_rails61_postgres.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    ddtrace (1.10.1)
+    ddtrace (1.11.0.beta1)
       debase-ruby_core_source (>= 0.10.16, <= 3.2.0)
       libdatadog (~> 2.0.0.1.0)
       libddwaf (~> 1.8.2.0.0)

--- a/gemfiles/ruby_3.2.0_rails61_postgres_redis.gemfile.lock
+++ b/gemfiles/ruby_3.2.0_rails61_postgres_redis.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    ddtrace (1.10.1)
+    ddtrace (1.11.0.beta1)
       debase-ruby_core_source (>= 0.10.16, <= 3.2.0)
       libdatadog (~> 2.0.0.1.0)
       libddwaf (~> 1.8.2.0.0)

--- a/gemfiles/ruby_3.2.0_rails61_postgres_sidekiq.gemfile.lock
+++ b/gemfiles/ruby_3.2.0_rails61_postgres_sidekiq.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    ddtrace (1.10.1)
+    ddtrace (1.11.0.beta1)
       debase-ruby_core_source (>= 0.10.16, <= 3.2.0)
       libdatadog (~> 2.0.0.1.0)
       libddwaf (~> 1.8.2.0.0)

--- a/gemfiles/ruby_3.2.0_rails61_semantic_logger.gemfile.lock
+++ b/gemfiles/ruby_3.2.0_rails61_semantic_logger.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    ddtrace (1.10.1)
+    ddtrace (1.11.0.beta1)
       debase-ruby_core_source (>= 0.10.16, <= 3.2.0)
       libdatadog (~> 2.0.0.1.0)
       libddwaf (~> 1.8.2.0.0)

--- a/gemfiles/ruby_3.2.0_redis_3.gemfile.lock
+++ b/gemfiles/ruby_3.2.0_redis_3.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    ddtrace (1.10.1)
+    ddtrace (1.11.0.beta1)
       debase-ruby_core_source (>= 0.10.16, <= 3.2.0)
       libdatadog (~> 2.0.0.1.0)
       libddwaf (~> 1.8.2.0.0)

--- a/gemfiles/ruby_3.2.0_redis_4.gemfile.lock
+++ b/gemfiles/ruby_3.2.0_redis_4.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    ddtrace (1.10.1)
+    ddtrace (1.11.0.beta1)
       debase-ruby_core_source (>= 0.10.16, <= 3.2.0)
       libdatadog (~> 2.0.0.1.0)
       libddwaf (~> 1.8.2.0.0)

--- a/gemfiles/ruby_3.2.0_redis_5.gemfile.lock
+++ b/gemfiles/ruby_3.2.0_redis_5.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    ddtrace (1.10.1)
+    ddtrace (1.11.0.beta1)
       debase-ruby_core_source (>= 0.10.16, <= 3.2.0)
       libdatadog (~> 2.0.0.1.0)
       libddwaf (~> 1.8.2.0.0)

--- a/gemfiles/ruby_3.2.0_resque2_redis3.gemfile.lock
+++ b/gemfiles/ruby_3.2.0_resque2_redis3.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    ddtrace (1.10.1)
+    ddtrace (1.11.0.beta1)
       debase-ruby_core_source (>= 0.10.16, <= 3.2.0)
       libdatadog (~> 2.0.0.1.0)
       libddwaf (~> 1.8.2.0.0)

--- a/gemfiles/ruby_3.2.0_resque2_redis4.gemfile.lock
+++ b/gemfiles/ruby_3.2.0_resque2_redis4.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    ddtrace (1.10.1)
+    ddtrace (1.11.0.beta1)
       debase-ruby_core_source (>= 0.10.16, <= 3.2.0)
       libdatadog (~> 2.0.0.1.0)
       libddwaf (~> 1.8.2.0.0)

--- a/gemfiles/ruby_3.2.0_sinatra.gemfile.lock
+++ b/gemfiles/ruby_3.2.0_sinatra.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    ddtrace (1.10.1)
+    ddtrace (1.11.0.beta1)
       debase-ruby_core_source (>= 0.10.16, <= 3.2.0)
       libdatadog (~> 2.0.0.1.0)
       libddwaf (~> 1.8.2.0.0)

--- a/lib/ddtrace/version.rb
+++ b/lib/ddtrace/version.rb
@@ -1,13 +1,15 @@
+# frozen_string_literal: true
+
 module DDTrace
   module VERSION
     MAJOR = 1
-    MINOR = 10
-    PATCH = 1
-    PRE = nil
+    MINOR = 11
+    PATCH = 0
+    PRE = 'beta1'
 
     STRING = [MAJOR, MINOR, PATCH, PRE].compact.join('.')
 
-    MINIMUM_RUBY_VERSION = '2.1.0'.freeze
+    MINIMUM_RUBY_VERSION = '2.1.0'
 
     # A maximum version was initially added in https://github.com/DataDog/dd-trace-rb/pull/1495 because we expected
     # the `ruby2_keywords` method to be removed (see the PR for the discussion).
@@ -20,6 +22,6 @@ module DDTrace
     # So for now let's bump the maximum version to < 3.3 to allow the Ruby 3.2 series to be supported and we can keep
     # an eye on the Ruby 3.2 test releases to see if anything changes. (Otherwise, once Ruby 3.2.0 stable is out, we
     # should probably bump this to 3.4, and so on...)
-    MAXIMUM_RUBY_VERSION = '3.3'.freeze
+    MAXIMUM_RUBY_VERSION = '3.3'
   end
 end


### PR DESCRIPTION
<!--
Check out the
https://github.com/DataDog/dd-trace-rb/blob/master/docs/DevelopmentGuide.md
for guidance on how to set up your development environment,
run the test suite, write new integrations, and more.
-->

**What does this PR do?**

Bump to version 1.11.0.beta1

**Motivation**

Release 1.11.0.beta1

**Additional Notes**

This release is a bit out of the usual flow, but we followed the release process as close as possible still.

**How to test the change?**

N/A