### PR TITLE
[APPSEC-6712] Remote configuration `config_state`

### DIFF
--- a/lib/datadog/core/remote/configuration/content.rb
+++ b/lib/datadog/core/remote/configuration/content.rb
@@ -19,11 +19,13 @@ module Datadog
           end
 
           attr_reader :path, :data, :hashes
+          attr_accessor :version
 
           def initialize(path:, data:)
             @path = path
             @data = data
             @hashes = {}
+            @version = 0
           end
 
           def hexdigest(type)

--- a/lib/datadog/core/remote/configuration/repository.rb
+++ b/lib/datadog/core/remote/configuration/repository.rb
@@ -78,7 +78,7 @@ module Datadog
               @repository = repository
               @root_version = repository.root_version
               @targets_version = repository.targets_version
-              @config_states = []
+              @config_states = contents_to_config_states(repository.contents)
               @has_error = false
               @error = ''
               @opaque_backend_state = repository.opaque_backend_state
@@ -86,6 +86,18 @@ module Datadog
             end
 
             private
+
+            def contents_to_config_states(contents)
+              return [] if contents.empty?
+
+              contents.map do |content|
+                {
+                  id: content.path.config_id,
+                  version: content.version,
+                  product: content.path.product
+                }
+              end
+            end
 
             def contents_to_cached_target_files(contents)
               return [] if contents.empty?
@@ -164,6 +176,7 @@ module Datadog
               def apply(repository)
                 return unless repository[@path].nil?
 
+                @content.version = @target.version
                 repository.contents << @content
 
                 @path
@@ -184,6 +197,7 @@ module Datadog
               def apply(repository)
                 return if repository[@path].nil?
 
+                @content.version = @target.version
                 repository.contents[@path] = @content
 
                 @path

--- a/lib/datadog/core/remote/configuration/target.rb
+++ b/lib/datadog/core/remote/configuration/target.rb
@@ -48,16 +48,18 @@ module Datadog
             def parse(hash)
               length = Integer(hash['length'])
               digests = Configuration::DigestList.parse(hash['hashes'])
+              version = Integer(hash['custom']['v'])
 
-              new(digests: digests, length: length)
+              new(digests: digests, length: length, version: version)
             end
           end
 
-          attr_reader :length, :digests
+          attr_reader :length, :digests, :version
 
-          def initialize(digests:, length:)
+          def initialize(digests:, length:, version:)
             @digests = digests
             @length = length
+            @version = version
           end
 
           private_class_method :new

--- a/sig/datadog/core/remote/configuration/content.rbs
+++ b/sig/datadog/core/remote/configuration/content.rbs
@@ -11,6 +11,8 @@ module Datadog
 
           attr_reader hashes: Hash[Symbol, String]
 
+          attr_accessor version: Integer
+
           @length: Integer
 
           def initialize: (path: Configuration::Path, data: StringIO) -> void

--- a/sig/datadog/core/remote/configuration/repository.rbs
+++ b/sig/datadog/core/remote/configuration/repository.rbs
@@ -34,7 +34,7 @@ module Datadog
 
             attr_reader repository: Repository
 
-            attr_reader config_states: Array[untyped]
+            attr_reader config_states: Array[Hash[Symbol, untyped]]
 
             attr_reader cached_target_files: Array[Hash[Symbol, untyped]]
 
@@ -49,6 +49,8 @@ module Datadog
             private
 
             def contents_to_cached_target_files: (ContentList contents) -> Array[Hash[Symbol, untyped]]
+
+            def contents_to_config_states: (ContentList contents) -> Array[Hash[Symbol, untyped]]
           end
 
           class Transaction

--- a/sig/datadog/core/remote/configuration/target.rbs
+++ b/sig/datadog/core/remote/configuration/target.rbs
@@ -18,9 +18,11 @@ module Datadog
 
           attr_reader digests: DigestList
 
+          attr_reader version: Integer
+
           def self.parse: (::Hash[::String, untyped] hash) -> Target
 
-          def initialize: (digests: DigestList, length: ::Integer) -> void
+          def initialize: (digests: DigestList, length: ::Integer, version: Integer) -> void
 
           def check: (untyped content) -> bool
         end

--- a/spec/datadog/appsec/remote_spec.rb
+++ b/spec/datadog/appsec/remote_spec.rb
@@ -106,15 +106,28 @@ RSpec.describe Datadog::AppSec::Remote do
           }.to_json
         end
         let(:receiver) { described_class.receivers[0] }
+        let(:target) do
+          Datadog::Core::Remote::Configuration::Target.parse(
+            {
+              'custom' => {
+                'v' => 1,
+              },
+              'hashes' => { 'sha256' => Digest::SHA256.hexdigest(rules_data.to_json) },
+              'length' => rules_data.to_s.length
+            }
+          )
+        end
+        let(:content) do
+          Datadog::Core::Remote::Configuration::Content.parse(
+            {
+              path: 'datadog/603646/ASM_DD/latest/config',
+              content: StringIO.new(rules_data)
+            }
+          )
+        end
         let(:transaction) do
           repository.transaction do |_repository, transaction|
-            content = Datadog::Core::Remote::Configuration::Content.parse(
-              {
-                path: 'datadog/603646/ASM_DD/latest/config',
-                content: StringIO.new(rules_data)
-              }
-            )
-            transaction.insert(content.path, nil, content)
+            transaction.insert(content.path, target, content)
           end
         end
         let(:repository) { Datadog::Core::Remote::Configuration::Repository.new }

--- a/spec/datadog/core/remote/configuration/target_spec.rb
+++ b/spec/datadog/core/remote/configuration/target_spec.rb
@@ -170,6 +170,9 @@ RSpec.describe Datadog::Core::Remote::Configuration::TargetMap do
   describe Datadog::Core::Remote::Configuration::Target do
     let(:raw_target) do
       {
+        'custom' => {
+          'v' => 1,
+        },
         'hashes' => { 'sha256' => Digest::SHA256.hexdigest(raw.to_json) },
         'length' => 645
       }


### PR DESCRIPTION

<!--
Check out the
https://github.com/DataDog/dd-trace-rb/blob/master/docs/DevelopmentGuide.md
for guidance on how to set up your development environment,
run the test suite, write new integrations, and more.
-->

**What does this PR do?**
Stores and set remote configuration content version. Is that information to populate the client `config_state`

@lloeki will work on the remaining portion of `config_state`, which is adding the information if any error occurred during the remote configuration sync 

**Motivation**
<!-- What inspired you to submit this pull request? -->

**Additional Notes**
<!-- Anything else we should know when reviewing? -->

Here are the [system test assertions](https://github.com/DataDog/system-tests/blob/main/tests/remote_config/rc_expected_requests_asm_dd.json) on the expected values for `config_states`

**How to test the change?**
<!--
Describe here how the change can be validated.
You are strongly encouraged to provide automated tests for this PR (unit or integration).
If this change cannot be feasibly tested, please explain why,
unless the change does not modify code (e.g. only modifies docs, comments).
-->

CI
