### PR TITLE
Fix version format in remote configuration payload

### DIFF
--- a/lib/datadog/core/environment/identity.rb
+++ b/lib/datadog/core/environment/identity.rb
@@ -49,8 +49,17 @@ module Datadog
           Core::Environment::Ext::LANG_VERSION
         end
 
+        # Returns tracer version, rubygems-style
         def tracer_version
           Core::Environment::Ext::TRACER_VERSION
+        end
+
+        # Returns tracer version, comforming to https://semver.org/spec/v2.0.0.html
+        def tracer_version_semver2
+          # from ddtrace/version.rb, we have MAJOR.MINOR.PATCH plus an optional .PRE
+          # - transform .PRE to -PRE if present
+          # - keep triplet before that
+          tracer_version.sub(/\.([a-zA-Z0-9]*[a-zA-Z][a-zA-Z0-9]*.*)$/, '-\1')
         end
       end
     end

--- a/lib/datadog/core/environment/identity.rb
+++ b/lib/datadog/core/environment/identity.rb
@@ -56,11 +56,58 @@ module Datadog
 
         # Returns tracer version, comforming to https://semver.org/spec/v2.0.0.html
         def tracer_version_semver2
-          # from ddtrace/version.rb, we have MAJOR.MINOR.PATCH plus an optional .PRE
+          # from ddtrace/version.rb, we have MAJOR.MINOR.PATCH plus optional .PRE and .BUILD
           # - transform .PRE to -PRE if present
-          # - keep triplet before that
-          tracer_version.sub(/\.([a-zA-Z0-9]*[a-zA-Z][a-zA-Z0-9]*.*)$/, '-\1')
+          # - transform .BUILD to +BUILD if present
+          # - keep triplet segments before that
+
+          m = SEMVER2_RE.match(tracer_version)
+
+          pre = "-#{m[:pre]}" if m[:pre]
+          build = "+gha#{m[:gha_run_id]}.g#{m[:git_sha]}.#{m[:branch].tr('.', '-')}" if m[:build]
+
+          "#{m[:major]}.#{m[:minor]}.#{m[:patch]}#{pre}#{build}"
         end
+
+        SEMVER2_RE = /
+          ^
+          # mandatory segments
+          (?<major>\d+)
+          \.
+          (?<minor>\d+)
+          \.
+          (?<patch>\d+)
+
+          # pre segments start with a value
+          # - containing at least one alpha
+          # - that is not part of our build segments expected values
+          # and stop with a value that is not part of our build segments expected values
+          (?:
+            \.
+            (?<pre>
+              (?!gha)
+              [a-zA-Z0-9]*[a-zA-Z][a-zA-Z0-9]*
+              (?:
+                \.
+                (?!gha)
+                [a-zA-Z0-9]+
+              )*
+            )
+          )?
+
+          # build segments: ours include CI info (`gha`), then git (`g`), then branch name
+          (?:
+            \.
+            (?<build>
+              gha(?<gha_run_id>\d+)
+              \.
+              g(?<git_sha>[a-f0-9]+)
+              \.
+              (?<branch>(?:[a-zA-Z0-9.])+)
+            )
+          )?
+          $
+        /xm.freeze
       end
     end
   end

--- a/lib/datadog/core/remote/client.rb
+++ b/lib/datadog/core/remote/client.rb
@@ -119,7 +119,7 @@ module Datadog
           client_tracer = {
             runtime_id: Core::Environment::Identity.id,
             language: Core::Environment::Identity.lang,
-            tracer_version: Core::Environment::Identity.tracer_version,
+            tracer_version: Core::Environment::Identity.tracer_version_semver2,
             service: Datadog.configuration.service,
             env: Datadog.configuration.env,
             tags: [], # TODO: add nice tags!

--- a/sig/datadog/core/environment/identity.rbs
+++ b/sig/datadog/core/environment/identity.rbs
@@ -4,19 +4,21 @@ module Datadog
       module Identity
         extend Datadog::Core::Utils::Forking
 
-        def self?.id: () -> untyped
+        def self?.id: () -> ::String
 
-        def self?.lang: () -> untyped
+        def self?.lang: () -> ::String
 
-        def self?.lang_engine: () -> untyped
+        def self?.lang_engine: () -> ::String
 
-        def self?.lang_interpreter: () -> untyped
+        def self?.lang_interpreter: () -> ::String
 
-        def self?.lang_platform: () -> untyped
+        def self?.lang_platform: () -> ::String
 
-        def self?.lang_version: () -> untyped
+        def self?.lang_version: () -> ::String
 
-        def self?.tracer_version: () -> untyped
+        def self?.tracer_version: () -> ::String
+
+        def self?.tracer_version_semver2: () -> ::String
       end
     end
   end

--- a/spec/datadog/core/environment/identity_spec.rb
+++ b/spec/datadog/core/environment/identity_spec.rb
@@ -69,4 +69,24 @@ RSpec.describe Datadog::Core::Environment::Identity do
 
     it { is_expected.to eq(Datadog::Core::Environment::Ext::TRACER_VERSION) }
   end
+
+  describe '::tracer_version_semver2' do
+    subject(:tracer_version) { described_class.tracer_version_semver2 }
+
+    context 'when not prerelease' do
+      before do
+        expect(described_class).to receive(:tracer_version).and_return('10.20.30')
+      end
+
+      it { is_expected.to eq('10.20.30') }
+    end
+
+    context 'when prerelease' do
+      before do
+        expect(described_class).to receive(:tracer_version).and_return('10.20.30.beta40')
+      end
+
+      it { is_expected.to eq('10.20.30-beta40') }
+    end
+  end
 end

--- a/spec/datadog/core/environment/identity_spec.rb
+++ b/spec/datadog/core/environment/identity_spec.rb
@@ -88,5 +88,21 @@ RSpec.describe Datadog::Core::Environment::Identity do
 
       it { is_expected.to eq('10.20.30-beta40') }
     end
+
+    context 'when development' do
+      before do
+        expect(described_class).to receive(:tracer_version).and_return('10.20.30.gha12345.ga1b2c3d4.a.branch.name')
+      end
+
+      it { is_expected.to eq('10.20.30+gha12345.ga1b2c3d4.a-branch-name') }
+    end
+
+    context 'when prerelease and development' do
+      before do
+        expect(described_class).to receive(:tracer_version).and_return('10.20.30.beta40.gha12345.ga1b2c3d4.a.branch.name')
+      end
+
+      it { is_expected.to eq('10.20.30-beta40+gha12345.ga1b2c3d4.a-branch-name') }
+    end
   end
 end

--- a/spec/datadog/core/remote/client_spec.rb
+++ b/spec/datadog/core/remote/client_spec.rb
@@ -509,7 +509,7 @@ RSpec.describe Datadog::Core::Remote::Client do
                 expected_client_tracer = {
                   :runtime_id => Datadog::Core::Environment::Identity.id,
                   :language => Datadog::Core::Environment::Identity.lang,
-                  :tracer_version => Datadog::Core::Environment::Identity.tracer_version,
+                  :tracer_version => Datadog::Core::Environment::Identity.tracer_version_semver2,
                   :service => Datadog.configuration.service,
                   :env => Datadog.configuration.env,
                   :app_version => Datadog.configuration.version,
@@ -527,7 +527,7 @@ RSpec.describe Datadog::Core::Remote::Client do
                 expected_client_tracer = {
                   :runtime_id => Datadog::Core::Environment::Identity.id,
                   :language => Datadog::Core::Environment::Identity.lang,
-                  :tracer_version => Datadog::Core::Environment::Identity.tracer_version,
+                  :tracer_version => Datadog::Core::Environment::Identity.tracer_version_semver2,
                   :service => Datadog.configuration.service,
                   :env => Datadog.configuration.env,
                   :tags => []


### PR DESCRIPTION
<!--
Check out the
https://github.com/DataDog/dd-trace-rb/blob/master/docs/DevelopmentGuide.md
for guidance on how to set up your development environment,
run the test suite, write new integrations, and more.
-->

**What does this PR do?**

Fix version format in remote configuration payload.

**Motivation**

RFC mandates Semantic Versioning 2.0.0. Without this format, the payload gets silently rejected and RC response is always lacking targets, thus inoperative.

A workaround specifically for the already published `1.11.0.beta1` version which is affected has been deployed backend-side.

**Additional Notes**

The implementation hinges on the version pattern being enforced by `[MAJOR, MINOR, PATH, PRE].compact.join('.')`

Side note: I'm wondering why we have so many constants regarding versions, all computed from one another. I feel it makes it hard to test and refactor.

**How to test the change?**

A bit tough since a fix has been deployed:

- alter version to have PRE be e.g `'beta2'`
- start an app with RC and debug level logger
- witness configuration paths being updated

This should ultimately be covered by CI, but attempts at calling to RC from integration specs has proven unfruitful for setup+infrastructure reasons.