### PR TITLE
[APPSEC-9143] Extract expires information from target map payload.

### DIFF
--- a/Steepfile
+++ b/Steepfile
@@ -637,7 +637,7 @@ target :ddtrace do
   ignore 'lib/ddtrace/transport/traces.rb'
   ignore 'lib/ddtrace/version.rb'
 
-  library 'pathname', 'set'
+  library 'pathname', 'set', 'date'
   library 'cgi'
   library 'logger', 'monitor'
   library 'tsort'

--- a/lib/datadog/core/remote/client.rb
+++ b/lib/datadog/core/remote/client.rb
@@ -46,7 +46,7 @@ module Datadog
 
             targets = Configuration::TargetMap.parse(response.targets)
 
-            contents = Configuration::ContentList.parse(response.target_files)
+            contents = Configuration::ContentList.parse(response.target_files, targets.expires)
 
             # TODO: sometimes it can strangely be so that paths.empty?
             # TODO: sometimes it can strangely be so that targets.empty?

--- a/lib/datadog/core/remote/configuration/content.rb
+++ b/lib/datadog/core/remote/configuration/content.rb
@@ -10,20 +10,21 @@ module Datadog
         # Content stores the information associated with a specific Configuration::Path
         class Content
           class << self
-            def parse(hash)
+            def parse(hash, expires)
               path = Path.parse(hash[:path])
               data = hash[:content]
 
-              new(path: path, data: data)
+              new(path: path, data: data, expires: expires)
             end
           end
 
-          attr_reader :path, :data, :hashes
+          attr_reader :path, :data, :hashes, :expires
           attr_accessor :version
 
-          def initialize(path:, data:)
+          def initialize(path:, data:, expires:)
             @path = path
             @data = data
+            @expires = expires
             @hashes = {}
             @version = 0
           end
@@ -49,8 +50,8 @@ module Datadog
         # It provides convinient methods for finding content base on Configuration::Path and Configuration::Target
         class ContentList < Array
           class << self
-            def parse(array)
-              new.concat(array.map { |c| Content.parse(c) })
+            def parse(array, expires)
+              new.concat(array.map { |c| Content.parse(c, expires) })
             end
           end
 

--- a/lib/datadog/core/remote/configuration/repository.rb
+++ b/lib/datadog/core/remote/configuration/repository.rb
@@ -1,5 +1,6 @@
 # frozen_string_literal: true
 
+require 'date'
 require_relative 'content'
 
 module Datadog
@@ -90,8 +91,12 @@ module Datadog
             def contents_to_config_states(contents)
               return [] if contents.empty?
 
-              contents.map do |content|
-                {
+              contents.each_with_object([]) do |content, acc|
+                # content expires datetime has zero offset
+                # new_offset return the current time with zero offset
+                next if content.expires && (content.expires < DateTime.now.new_offset)
+
+                acc << {
                   id: content.path.config_id,
                   version: content.version,
                   product: content.path.product

--- a/sig/datadog/core/remote/configuration/content.rbs
+++ b/sig/datadog/core/remote/configuration/content.rbs
@@ -3,7 +3,7 @@ module Datadog
     module Remote
       class Configuration
         class Content
-          def self.parse: (::Hash[Symbol, untyped] hash) -> Content
+          def self.parse: (::Hash[Symbol, untyped] hash, DateTime? expires) -> Content
 
           attr_reader path: Configuration::Path
 
@@ -11,11 +11,13 @@ module Datadog
 
           attr_reader hashes: Hash[Symbol, String]
 
+          attr_reader expires: DateTime?
+
           attr_accessor version: Integer
 
           @length: Integer
 
-          def initialize: (path: Configuration::Path, data: StringIO) -> void
+          def initialize: (path: Configuration::Path, data: StringIO, expires: DateTime?) -> void
 
           def hexdigest: (Symbol type) -> String
 
@@ -27,7 +29,7 @@ module Datadog
         end
 
         class ContentList < Array[Content]
-          def self.parse: (::Array[::Hash[Symbol, untyped]] array) -> ContentList
+          def self.parse: (::Array[::Hash[Symbol, untyped]] array, DateTime? expires) -> ContentList
 
           def find_content: (Configuration::Path path, Configuration::Target target) -> Content?
 

--- a/sig/datadog/core/remote/configuration/target.rbs
+++ b/sig/datadog/core/remote/configuration/target.rbs
@@ -3,11 +3,16 @@ module Datadog
     module Remote
       class Configuration
         class TargetMap < Hash[Configuration::Path, Configuration::Target]
+          class ParseError < StandardError
+          end
+
           def self.parse: (::Hash[::String, untyped] hash) -> TargetMap
 
           attr_reader opaque_backend_state: ::String?
 
           attr_reader version: ::Integer?
+
+          attr_reader expires: DateTime?
 
           def initialize: () -> void
         end

--- a/spec/datadog/appsec/remote_spec.rb
+++ b/spec/datadog/appsec/remote_spec.rb
@@ -59,6 +59,7 @@ RSpec.describe Datadog::AppSec::Remote do
     end
 
     context 'remote configuration enabled' do
+      let(:expires) { DateTime.now.new_offset.to_date.next_year }
       before do
         expect(Datadog::AppSec).to receive(:default_setting?).with(:ruleset).and_return(true)
       end
@@ -122,7 +123,8 @@ RSpec.describe Datadog::AppSec::Remote do
             {
               path: 'datadog/603646/ASM_DD/latest/config',
               content: StringIO.new(rules_data)
-            }
+            },
+            expires
           )
         end
         let(:transaction) do

--- a/spec/datadog/core/remote/client_spec.rb
+++ b/spec/datadog/core/remote/client_spec.rb
@@ -449,8 +449,8 @@ RSpec.describe Datadog::Core::Remote::Client do
             }
           end
 
-          it 'raises Path::ParseError' do
-            expect { client.sync }.to raise_error(Datadog::Core::Remote::Configuration::Path::ParseError)
+          it 'raises TargetMap::ParseError' do
+            expect { client.sync }.to raise_error(Datadog::Core::Remote::Configuration::TargetMap::ParseError)
           end
         end
       end

--- a/spec/datadog/core/remote/configuration/content_spec.rb
+++ b/spec/datadog/core/remote/configuration/content_spec.rb
@@ -89,13 +89,15 @@ RSpec.describe Datadog::Core::Remote::Configuration::ContentList do
       rules_override: []
     }
   end
+  let(:expires) { DateTime.now.new_offset.to_date.next_year }
   let(:string_io_content) { StringIO.new(raw.to_json) }
   subject(:content_list) do
     described_class.parse(
       [{
         :path => path.to_s,
         :content => string_io_content
-      }]
+      }],
+      expires
     )
   end
 
@@ -113,7 +115,8 @@ RSpec.describe Datadog::Core::Remote::Configuration::ContentList do
             [{
               :path => 'invalid path',
               :content => string_io_content
-            }]
+            }],
+            expires
           )
         end.to raise_error(Datadog::Core::Remote::Configuration::Path::ParseError)
       end
@@ -178,7 +181,8 @@ RSpec.describe Datadog::Core::Remote::Configuration::ContentList do
         {
           :path => path.to_s,
           :content => updated_string_io
-        }
+        },
+        expires
       )
     end
 
@@ -230,7 +234,8 @@ RSpec.describe Datadog::Core::Remote::Configuration::ContentList do
         {
           :path => path.to_s,
           :content => string_io_content
-        }
+        },
+        expires
       )
     end
 

--- a/spec/datadog/core/remote/configuration/digest_spec.rb
+++ b/spec/datadog/core/remote/configuration/digest_spec.rb
@@ -6,12 +6,14 @@ require 'datadog/core/remote/configuration/content'
 
 RSpec.describe Datadog::Core::Remote::Configuration::Digest do
   let(:data) { StringIO.new('Hello World') }
+  let(:expires) { DateTime.now.new_offset.to_date.next_year }
   let(:content) do
     Datadog::Core::Remote::Configuration::Content.parse(
       {
         :path => 'datadog/603646/ASM/exclusion_filters/config',
         :content => data
-      }
+      },
+      expires
     )
   end
 

--- a/spec/datadog/core/remote/dispatcher_spec.rb
+++ b/spec/datadog/core/remote/dispatcher_spec.rb
@@ -20,6 +20,7 @@ RSpec.describe Datadog::Core::Remote::Dispatcher do
       'length' => 645
     }
   end
+  let(:expires) { DateTime.now.new_offset.to_date.next_year }
   let(:target) { Datadog::Core::Remote::Configuration::Target.parse(raw_target) }
   let(:path) { Datadog::Core::Remote::Configuration::Path.parse('datadog/603646/ASM/exclusion_filters/config') }
   let(:raw) do
@@ -94,7 +95,13 @@ RSpec.describe Datadog::Core::Remote::Dispatcher do
   end
   let(:string_io_content) { StringIO.new(raw.to_json) }
   let(:content) do
-    Datadog::Core::Remote::Configuration::Content.parse({ :path => path.to_s, :content => string_io_content })
+    Datadog::Core::Remote::Configuration::Content.parse(
+      {
+        :path => path.to_s,
+        :content => string_io_content,
+      },
+      expires
+    )
   end
   let(:repository) { Datadog::Core::Remote::Configuration::Repository.new }
 


### PR DESCRIPTION
<!--
Check out the
https://github.com/DataDog/dd-trace-rb/blob/master/docs/DevelopmentGuide.md
for guidance on how to set up your development environment,
run the test suite, write new integrations, and more.
-->

**What does this PR do?**
<!-- A brief description of the change being made with this pull request. -->

Propagate expires information to content instances. 
Make sure to remove content information from `config_state` when content has expired.

**Motivation**
<!-- What inspired you to submit this pull request? -->

The `config_states` information have to change based on expiration information 

**Additional Notes**
<!-- Anything else we should know when reviewing? -->

**How to test the change?**
<!--
Describe here how the change can be validated.
You are strongly encouraged to provide automated tests for this PR (unit or integration).
If this change cannot be feasibly tested, please explain why,
unless the change does not modify code (e.g. only modifies docs, comments).
-->

CI
