### PR TITLE
Remote client use app version on request payload

### DIFF
--- a/lib/datadog/core/remote/client.rb
+++ b/lib/datadog/core/remote/client.rb
@@ -111,6 +111,19 @@ module Datadog
         def payload
           state = repository.state
 
+          client_tracer = {
+            runtime_id: Core::Environment::Identity.id,
+            language: Core::Environment::Identity.lang,
+            tracer_version: Core::Environment::Identity.tracer_version,
+            service: Datadog.configuration.service,
+            env: Datadog.configuration.env,
+            tags: [], # TODO: add nice tags!
+          }
+
+          app_version = Datadog.configuration.version
+
+          client_tracer[:app_version] = app_version if app_version
+
           {
             client: {
               state: {
@@ -125,15 +138,7 @@ module Datadog
               products: @capabilities.products,
               is_tracer: true,
               is_agent: false,
-              client_tracer: {
-                runtime_id: Core::Environment::Identity.id,
-                language: Core::Environment::Identity.lang,
-                tracer_version: Core::Environment::Identity.tracer_version,
-                service: Datadog.configuration.service,
-                env: Datadog.configuration.env,
-                # app_version: app_version, # TODO: I don't know what this is
-                tags: [], # TODO: add nice tags!
-              },
+              client_tracer: client_tracer,
               # base64 is needed otherwise the Go agent fails with an unmarshal error
               capabilities: @capabilities.base64_capabilities
             },

--- a/sig/datadog/core/configuration/settings.rbs
+++ b/sig/datadog/core/configuration/settings.rbs
@@ -20,6 +20,8 @@ module Datadog
 
         def service: -> String
 
+        def version: -> String?
+
         def logger=: (untyped logger) -> untyped
 
         def runtime_metrics: (?untyped? options) -> untyped

--- a/spec/datadog/core/remote/client_spec.rb
+++ b/spec/datadog/core/remote/client_spec.rb
@@ -455,5 +455,109 @@ RSpec.describe Datadog::Core::Remote::Client do
         end
       end
     end
+
+    describe '#payload' do
+      context 'no sync errors' do
+        let(:response_code) { 200 }
+
+        before { client.sync }
+
+        context 'client' do
+          let(:client_payload) { client.send(:payload)[:client] }
+
+          context 'state' do
+            it 'returns client state' do
+              state = repository.state
+
+              expected_state = {
+                :root_version => state.root_version,
+                :targets_version => state.targets_version,
+                :config_states => state.config_states,
+                :has_error => state.has_error,
+                :error => state.error,
+                :backend_client_state => state.opaque_backend_state
+              }
+
+              expect(client_payload[:state]).to eq(expected_state)
+            end
+          end
+
+          context 'id' do
+            it 'returns id' do
+              expect(client_payload[:id]).to eq(client.instance_variable_get(:@id))
+            end
+          end
+
+          context 'products' do
+            it 'returns products' do
+              expect(client_payload[:products]).to eq(capabilities.products)
+            end
+          end
+
+          context 'capabilities' do
+            it 'returns capabilities' do
+              expect(client_payload[:capabilities]).to eq(capabilities.base64_capabilities)
+            end
+          end
+
+          context 'is_tracer' do
+            it 'returns true' do
+              expect(client_payload[:is_tracer]).to eq(true)
+            end
+          end
+
+          context 'is_agent' do
+            it 'returns false' do
+              expect(client_payload[:is_agent]).to eq(false)
+            end
+          end
+
+          context 'client_tracer' do
+            context 'with app_version' do
+              it 'returns client_tracer' do
+                expect(Datadog.configuration).to receive(:version).and_return('hello').at_least(:once)
+
+                expected_client_tracer = {
+                  :runtime_id => Datadog::Core::Environment::Identity.id,
+                  :language => Datadog::Core::Environment::Identity.lang,
+                  :tracer_version => Datadog::Core::Environment::Identity.tracer_version,
+                  :service => Datadog.configuration.service,
+                  :env => Datadog.configuration.env,
+                  :app_version => Datadog.configuration.version,
+                  :tags => []
+                }
+
+                expect(client_payload[:client_tracer]).to eq(expected_client_tracer)
+              end
+            end
+
+            context 'without app_version' do
+              it 'returns client_tracer' do
+                expect(Datadog.configuration).to receive(:version).and_return(nil).at_least(:once)
+
+                expected_client_tracer = {
+                  :runtime_id => Datadog::Core::Environment::Identity.id,
+                  :language => Datadog::Core::Environment::Identity.lang,
+                  :tracer_version => Datadog::Core::Environment::Identity.tracer_version,
+                  :service => Datadog.configuration.service,
+                  :env => Datadog.configuration.env,
+                  :tags => []
+                }
+
+                expect(client_payload[:client_tracer]).to eq(expected_client_tracer)
+              end
+            end
+          end
+        end
+
+        context 'cached_target_files' do
+          it 'returns cached_target_files' do
+            state = repository.state
+
+            expect(client.send(:payload)[:cached_target_files]).to eq(state.cached_target_files)
+          end
+        end
+      end
+    end
   end
 end


### PR DESCRIPTION
<!--
Check out the
https://github.com/DataDog/dd-trace-rb/blob/master/docs/DevelopmentGuide.md
for guidance on how to set up your development environment,
run the test suite, write new integrations, and more.
-->

**What does this PR do?**

The remote configuration specs say `app_version` MUST be set if present. The `configuration.version` is populated by the customer and provides no sane fallback. For that, in the case of it being `nil`, we do not include the `app_version` property

More context on the `configuration.version` tag can be found [here](https://docs.datadoghq.com/getting_started/tagging/unified_service_tagging/)

Also, adds specs to validate that the payload has all the necessary attributes.

**Motivation**
<!-- What inspired you to submit this pull request? -->

**Additional Notes**
<!-- Anything else we should know when reviewing? -->

**How to test the change?**
<!--
Describe here how the change can be validated.
You are strongly encouraged to provide automated tests for this PR (unit or integration).
If this change cannot be feasibly tested, please explain why,
unless the change does not modify code (e.g. only modifies docs, comments).
-->

CI
