### PR TITLE
Remote configuration handle Client SyncError

### DIFF
--- a/lib/datadog/core/remote/component.rb
+++ b/lib/datadog/core/remote/component.rb
@@ -30,9 +30,14 @@ module Datadog
           @worker = Worker.new(interval: settings.remote.poll_interval_seconds) do
             begin
               @client.sync
+            rescue Client::SyncError => e
+              Datadog.logger.error do
+                "remote worker client sync error: #{e.message} location: #{Array(e.backtrace).first}. skipping sync"
+              end
             rescue StandardError => e
               Datadog.logger.error do
-                "remote worker error: #{e.class.name} #{e.message} location: #{Array(e.backtrace).first}"
+                "remote worker error: #{e.class.name} #{e.message} location: #{Array(e.backtrace).first}. "\
+                'reseting client state'
               end
 
               # client state is unknown, state might be corrupted

--- a/spec/datadog/core/remote/client_spec.rb
+++ b/spec/datadog/core/remote/client_spec.rb
@@ -236,6 +236,7 @@ RSpec.describe Datadog::Core::Remote::Client do
 
   describe '#sync' do
     include_context 'HTTP connection stub'
+    let(:response_code) { 200 }
 
     let(:client_configs) do
       [
@@ -254,8 +255,6 @@ RSpec.describe Datadog::Core::Remote::Client do
     end
 
     context 'valid response' do
-      let(:response_code) { 200 }
-
       it 'store all changes into the repository' do
         expect(repository.opaque_backend_state).to be_nil
         expect(repository.targets_version).to eq(0)
@@ -361,16 +360,7 @@ RSpec.describe Datadog::Core::Remote::Client do
     end
 
     context 'invalid response' do
-      context 'not a 200 response' do
-        let(:response_code) { 401 }
-
-        it 'raises SyncError' do
-          expect { client.sync }.to raise_error(described_class::SyncError)
-        end
-      end
-
       context 'invalid response body' do
-        let(:response_code) { 200 }
         let(:response_body) do
           {
             'roots' => roots.map { |r| Base64.strict_encode64(r.to_json).chomp },
@@ -399,7 +389,6 @@ RSpec.describe Datadog::Core::Remote::Client do
         end
 
         context 'missing target for path from the response' do
-          let(:response_code) { 200 }
           let(:target_content) do
             {
               'datadog/603646/ASM/exclusion_filters/config' => {
@@ -449,8 +438,8 @@ RSpec.describe Datadog::Core::Remote::Client do
             }
           end
 
-          it 'raises Path::ParseError' do
-            expect { client.sync }.to raise_error(Datadog::Core::Remote::Configuration::Path::ParseError)
+          it 'raises SyncError' do
+            expect { client.sync }.to raise_error(described_class::SyncError, /could not parse: "invalid path"/)
           end
         end
       end


### PR DESCRIPTION
<!--
Check out the
https://github.com/DataDog/dd-trace-rb/blob/master/docs/DevelopmentGuide.md
for guidance on how to set up your development environment,
run the test suite, write new integrations, and more.
-->

**What does this PR do?**
<!-- A brief description of the change being made with this pull request. -->

Whenever a Client::SyncError is raised when calling `client.sync` the remote component rescues it, logs the sync error information and continues with the execution.

The remote configuration backend expects to maintain the state between requests even if there is a SyncError.

In the case of an unhandled error, we are still resting the client's state.

**Motivation**
<!-- What inspired you to submit this pull request? -->

**Additional Notes**
<!-- Anything else we should know when reviewing? -->

**How to test the change?**
<!--
Describe here how the change can be validated.
You are strongly encouraged to provide automated tests for this PR (unit or integration).
If this change cannot be feasibly tested, please explain why,
unless the change does not modify code (e.g. only modifies docs, comments).
-->

CI
