### PR TITLE
Fix steep parallel crash

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -128,6 +128,10 @@ group :check do
   if RUBY_VERSION >= '2.7.0' && RUBY_PLATFORM != 'java' && !steep_ci_workaround
     gem 'rbs', '~> 2.8.1', require: false
     gem 'steep', '~> 1.3.1', require: false
+
+    # parallel 1.23 seems to annoy steep:
+    # cannot load such file -- parallel/processor_count (LoadError)
+    gem 'parallel', '< 1.23'
   end
 end
 


### PR DESCRIPTION
<!--
Check out the
https://github.com/DataDog/dd-trace-rb/blob/master/docs/DevelopmentGuide.md
for guidance on how to set up your development environment,
run the test suite, write new integrations, and more.
-->

**What does this PR do?**

Fix steep parallel crash

**Motivation**

Parallell 1.23 seems to annoy steep:

```
cannot load such file -- parallel/processor_count (LoadError)
```

**Additional Notes**

Maybe an upgrade to steep could help.

**How to test the change?**

This should not crash:

```
bundle exec steep check
```