### PR TITLE
Set 'changelog_uri' in gemspec to point to CHANGELOG.md

### DIFF
--- a/ddtrace.gemspec
+++ b/ddtrace.gemspec
@@ -25,6 +25,7 @@ Gem::Specification.new do |spec|
 
   if spec.respond_to?(:metadata)
     spec.metadata['allowed_push_host'] = 'https://rubygems.org'
+    spec.metadata['changelog_uri'] = 'https://github.com/DataDog/dd-trace-rb/blob/master/CHANGELOG.md'
   else
     raise 'RubyGems 2.0 or newer is required to protect against public gem pushes.'
   end


### PR DESCRIPTION

<!--
Check out the
https://github.com/DataDog/dd-trace-rb/blob/master/docs/DevelopmentGuide.md
for guidance on how to set up your development environment,
run the test suite, write new integrations, and more.
-->

**What does this PR do?**
<!-- A brief description of the change being made with this pull request. -->
Add `changelog_uri` to the gem metadata.

**Motivation**
<!-- What inspired you to submit this pull request? -->
Changelog URLs have been valid [metadata](https://guides.rubygems.org/specification-reference/#metadata) since 2017 on RubyGems.org. Setting `changelog_uri` will add a "Changelog" link to the Rubygems page for ddtrace https://rubygems.org/gems/ddtrace/

**Additional Notes**
<!-- Anything else we should know when reviewing? -->

**How to test the change?**
<!--
Describe here how the change can be validated.
You are strongly encouraged to provide automated tests for this PR (unit or integration).
If this change cannot be feasibly tested, please explain why,
unless the change does not modify code (e.g. only modifies docs, comments).
-->
