### PR TITLE
[APPSEC-9177] Enable Remote configuration by default

### DIFF
--- a/lib/datadog/core/configuration/settings.rb
+++ b/lib/datadog/core/configuration/settings.rb
@@ -482,11 +482,10 @@ module Datadog
         settings :remote do
           # Enable remote configuration. This allows fetching of remote configuration for live updates.
           #
-          # @default `DD_REMOTE_CONFIGURATION_ENABLED` environment variable, otherwise `false`. In a future release,
-          #   this value will be changed to `true` by default.
+          # @default `DD_REMOTE_CONFIGURATION_ENABLED` environment variable, otherwise `true`.
           # @return [Boolean]
           option :enabled do |o|
-            o.default { env_to_bool(Core::Remote::Ext::ENV_ENABLED, false) }
+            o.default { env_to_bool(Core::Remote::Ext::ENV_ENABLED, true) }
             o.lazy
           end
 

--- a/lib/datadog/core/remote/component.rb
+++ b/lib/datadog/core/remote/component.rb
@@ -16,13 +16,11 @@ module Datadog
 
         attr_reader :client
 
-        def initialize(settings, agent_settings)
+        def initialize(settings, capabilities, agent_settings)
           transport_options = {}
           transport_options[:agent_settings] = agent_settings if agent_settings
 
           transport_v7 = Datadog::Core::Transport::HTTP.v7(**transport_options.dup)
-
-          capabilities = Client::Capabilities.new(settings)
 
           @barrier = Barrier.new(BARRIER_TIMEOUT)
 
@@ -121,6 +119,10 @@ module Datadog
           def build(settings, agent_settings)
             return unless settings.remote.enabled
 
+            capabilities = Client::Capabilities.new(settings)
+
+            return if capabilities.products.empty?
+
             transport_options = {}
             transport_options[:agent_settings] = agent_settings if agent_settings
 
@@ -146,7 +148,7 @@ module Datadog
               return
             end
 
-            new(settings, agent_settings)
+            new(settings, capabilities, agent_settings)
           end
         end
       end

--- a/sig/datadog/core/remote/component.rbs
+++ b/sig/datadog/core/remote/component.rbs
@@ -9,7 +9,7 @@ module Datadog
 
         @barrier: Barrier
 
-        def initialize: (Datadog::Core::Configuration::Settings settings, Datadog::Core::Configuration::AgentSettingsResolver::AgentSettings agent_settings) -> void
+        def initialize: (Datadog::Core::Configuration::Settings settings, Datadog::Core::Remote::Client::Capabilities capabilities, Datadog::Core::Configuration::AgentSettingsResolver::AgentSettings agent_settings) -> void
 
         def sync: () -> void
 

--- a/spec/datadog/core/configuration/settings_spec.rb
+++ b/spec/datadog/core/configuration/settings_spec.rb
@@ -1159,7 +1159,7 @@ RSpec.describe Datadog::Core::Configuration::Settings do
         context 'is not defined' do
           let(:environment) { nil }
 
-          it { is_expected.to be false }
+          it { is_expected.to be true }
         end
 
         context 'is defined' do
@@ -1172,10 +1172,10 @@ RSpec.describe Datadog::Core::Configuration::Settings do
 
     describe '#enabled=' do
       it 'updates the #enabled setting' do
-        expect { settings.remote.enabled = true }
+        expect { settings.remote.enabled = false }
           .to change { settings.remote.enabled }
-          .from(false)
-          .to(true)
+          .from(true)
+          .to(false)
       end
     end
 

--- a/spec/datadog/core/remote/component_spec.rb
+++ b/spec/datadog/core/remote/component_spec.rb
@@ -6,104 +6,204 @@ require 'datadog/core/remote/component'
 RSpec.describe Datadog::Core::Remote::Component do
   let(:settings) { Datadog::Core::Configuration::Settings.new }
   let(:agent_settings) { Datadog::Core::Configuration::AgentSettingsResolver.call(settings, logger: nil) }
+  let(:capabilities) { Datadog::Core::Remote::Client::Capabilities.new(settings) }
+
+  describe '.build' do
+    subject(:component) { described_class.build(settings, agent_settings) }
+
+    context 'remote disabled' do
+      let(:remote) do
+        mock = double('remote')
+        expect(mock).to receive(:enabled).and_return(false)
+        mock
+      end
+
+      before { expect(settings).to receive(:remote).and_return(remote) }
+
+      it 'returns nil ' do
+        expect(component).to be_nil
+      end
+    end
+
+    context 'remote enabled' do
+      context 'appsec' do
+        before { expect(settings).to receive(:appsec).and_return(appsec) }
+
+        let(:appsec) do
+          mock = double('appsec')
+          expect(mock).to receive(:enabled).and_return(appsec_enabled)
+          mock
+        end
+
+        context 'disabled' do
+          let(:appsec_enabled) { false }
+
+          it 'returns nil ' do
+            expect(component).to be_nil
+          end
+        end
+
+        context 'enabled' do
+          let(:appsec_enabled) { true }
+
+          context 'agent comunication' do
+            before do
+              request_class = ::Net::HTTP::Get
+              http_request = instance_double(request_class)
+              allow(http_request).to receive(:body=)
+              allow(request_class).to receive(:new).and_return(http_request)
+
+              http_connection = instance_double(::Net::HTTP)
+              allow(::Net::HTTP).to receive(:new).and_return(http_connection)
+
+              allow(http_connection).to receive(:open_timeout=)
+              allow(http_connection).to receive(:read_timeout=)
+              allow(http_connection).to receive(:use_ssl=)
+
+              allow(http_connection).to receive(:start).and_yield(http_connection)
+              http_response = instance_double(::Net::HTTPResponse, body: response_body, code: response_code)
+              allow(http_connection).to receive(:request).with(http_request).and_return(http_response)
+            end
+
+            context 'agent unreacheable' do
+              let(:response_code) { 500 }
+              let(:response_body) { {}.to_json }
+
+              it 'returns nil ' do
+                expect(component).to be_nil
+              end
+            end
+
+            context 'agent reachable but no support for remote configuration' do
+              let(:response_code) { 500 }
+              let(:response_body) do
+                {
+                  'endpoints' => ['no_config']
+                }.to_json
+              end
+
+              it 'returns nil ' do
+                expect(component).to be_nil
+              end
+            end
+
+            context 'agent reachable with support for remote configuration' do
+              let(:response_code) { 200 }
+              let(:response_body) do
+                {
+                  'endpoints' => ['/v0.7/config']
+                }.to_json
+              end
+
+              it 'returns component' do
+                expect(component).to be_a(described_class)
+              end
+            end
+          end
+        end
+      end
+    end
+  end
 
   describe '#initialize' do
-    subject(:component) { described_class.new(settings, agent_settings) }
-
-    let(:transport_v7) { double }
-    let(:client) { double }
-    let(:worker) { component.instance_eval { @worker } }
-
-    before do
-      expect(Datadog::Core::Transport::HTTP).to receive(:v7).and_return(transport_v7)
-      expect(Datadog::Core::Remote::Client).to receive(:new).and_return(client)
-
-      expect(worker).to receive(:start).and_call_original
-      expect(worker).to receive(:stop).and_call_original
-    end
+    subject(:component) { described_class.new(settings, capabilities, agent_settings) }
 
     after do
       component.shutdown!
     end
 
-    context 'when client sync succeeds' do
+    context 'worker' do
+      let(:worker) { component.instance_eval { @worker } }
+      let(:client) { double }
+      let(:transport_v7) { double }
+
       before do
-        expect(worker).to receive(:call).and_call_original
-        expect(client).to receive(:sync).and_return(nil)
+        expect(Datadog::Core::Transport::HTTP).to receive(:v7).and_return(transport_v7)
+        expect(Datadog::Core::Remote::Client).to receive(:new).and_return(client)
+
+        expect(worker).to receive(:start).and_call_original
+        expect(worker).to receive(:stop).and_call_original
       end
 
-      it 'does not log any error' do
-        expect(Datadog.logger).to_not receive(:error)
-
-        component.barrier(:once)
-      end
-    end
-
-    context 'when client sync raises' do
-      before do
-        expect(worker).to receive(:call).and_call_original
-        expect(client).to receive(:sync).and_raise(exception, 'test')
-        allow(Datadog.logger).to receive(:error).and_return(nil)
-      end
-
-      context 'StandardError' do
-        let(:second_client) { double }
-        let(:exception) { Class.new(StandardError) }
-
-        it 'logs an error' do
-          allow(Datadog::Core::Remote::Client).to receive(:new).and_return(client)
-
-          expect(Datadog.logger).to receive(:error).and_return(nil)
-
-          component.barrier(:once)
+      context 'when client sync succeeds' do
+        before do
+          expect(worker).to receive(:call).and_call_original
+          expect(client).to receive(:sync).and_return(nil)
         end
 
-        it 'catches exceptions' do
-          allow(Datadog::Core::Remote::Client).to receive(:new).and_return(client)
-
-          # if the error is uncaught it will crash the test, so a mere passing is good
+        it 'does not log any error' do
+          expect(Datadog.logger).to_not receive(:error)
 
           component.barrier(:once)
-        end
-
-        it 'creates a new client' do
-          expect(Datadog::Core::Remote::Client).to receive(:new).and_return(second_client)
-
-          expect(component.client.object_id).to eql(client.object_id)
-
-          component.barrier(:once)
-
-          expect(component.client.object_id).to eql(second_client.object_id)
         end
       end
 
-      context 'Client::SyncError' do
-        let(:exception) { Class.new(Datadog::Core::Remote::Client::SyncError) }
-
-        it 'logs an error' do
-          allow(Datadog::Core::Remote::Client).to receive(:new).and_return(client)
-
-          expect(Datadog.logger).to receive(:error).and_return(nil)
-
-          component.barrier(:once)
+      context 'when client sync raises' do
+        before do
+          expect(worker).to receive(:call).and_call_original
+          expect(client).to receive(:sync).and_raise(exception, 'test')
+          allow(Datadog.logger).to receive(:error).and_return(nil)
         end
 
-        it 'catches exceptions' do
-          allow(Datadog::Core::Remote::Client).to receive(:new).and_return(client)
+        context 'StandardError' do
+          let(:second_client) { double }
+          let(:exception) { Class.new(StandardError) }
 
-          # if the error is uncaught it will crash the test, so a mere passing is good
+          it 'logs an error' do
+            allow(Datadog::Core::Remote::Client).to receive(:new).and_return(client)
 
-          component.barrier(:once)
+            expect(Datadog.logger).to receive(:error).and_return(nil)
+
+            component.barrier(:once)
+          end
+
+          it 'catches exceptions' do
+            allow(Datadog::Core::Remote::Client).to receive(:new).and_return(client)
+
+            # if the error is uncaught it will crash the test, so a mere passing is good
+
+            component.barrier(:once)
+          end
+
+          it 'creates a new client' do
+            expect(Datadog::Core::Remote::Client).to receive(:new).and_return(second_client)
+
+            expect(component.client.object_id).to eql(client.object_id)
+
+            component.barrier(:once)
+
+            expect(component.client.object_id).to eql(second_client.object_id)
+          end
         end
 
-        it 'does not creates a new client' do
-          expect(Datadog::Core::Remote::Client).to_not receive(:new)
+        context 'Client::SyncError' do
+          let(:exception) { Class.new(Datadog::Core::Remote::Client::SyncError) }
 
-          expect(component.client.object_id).to eql(client.object_id)
+          it 'logs an error' do
+            allow(Datadog::Core::Remote::Client).to receive(:new).and_return(client)
 
-          component.barrier(:once)
+            expect(Datadog.logger).to receive(:error).and_return(nil)
 
-          expect(component.client.object_id).to eql(client.object_id)
+            component.barrier(:once)
+          end
+
+          it 'catches exceptions' do
+            allow(Datadog::Core::Remote::Client).to receive(:new).and_return(client)
+
+            # if the error is uncaught it will crash the test, so a mere passing is good
+
+            component.barrier(:once)
+          end
+
+          it 'does not creates a new client' do
+            expect(Datadog::Core::Remote::Client).to_not receive(:new)
+
+            expect(component.client.object_id).to eql(client.object_id)
+
+            component.barrier(:once)
+
+            expect(component.client.object_id).to eql(client.object_id)
+          end
         end
       end
     end


### PR DESCRIPTION


<!--
Check out the
https://github.com/DataDog/dd-trace-rb/blob/master/docs/DevelopmentGuide.md
for guidance on how to set up your development environment,
run the test suite, write new integrations, and more.
-->

**What does this PR do?**
<!-- A brief description of the change being made with this pull request. -->

Even with remote configuration enabled by default,  on this version of remote configuration and appsec. 
If AppSec is disabled, the remote configuration worker thread won't start.

Since in AppSec, we do not support the feature of remote activation. There is no need to have a background thread opening HTTP connections to the agent to request remote configuration information.

This might change once we support ASM remote activation or other components, such as tracer, start using remote configuration since there would be remote configuration information to listen to. 

**Motivation**
<!-- What inspired you to submit this pull request? -->

**Additional Notes**
<!-- Anything else we should know when reviewing? -->

**How to test the change?**
<!--
Describe here how the change can be validated.
You are strongly encouraged to provide automated tests for this PR (unit or integration).
If this change cannot be feasibly tested, please explain why,
unless the change does not modify code (e.g. only modifies docs, comments).
-->

CI
