### PR TITLE
Add support for Unix Domain Socket (UDS) configuration via `DD_TRACE_AGENT_URL`

### DIFF
--- a/lib/datadog/core/configuration/agent_settings_resolver.rb
+++ b/lib/datadog/core/configuration/agent_settings_resolver.rb
@@ -95,9 +95,23 @@ module Datadog
         end
 
         def adapter
-          # If no agent settings have been provided, we try to connect using a local unix socket.
-          # We only do so if the socket is present when `ddtrace` runs.
-          if should_use_uds_fallback?
+          if (configured_hostname || configured_port) && should_use_uds?
+            warn_if_configuration_mismatch(
+              [
+                DetectedConfiguration.new(
+                  friendly_name: 'configuration of hostname/port for http/https use',
+                  value: "hostname: '#{configured_hostname}', port: #{configured_port.inspect}",
+                ),
+                DetectedConfiguration.new(
+                  friendly_name: 'configuration for unix domain socket',
+                  value: "unix://#{uds_path}",
+                ),
+              ]
+            )
+
+            # We still want to use http in this case
+            Datadog::Transport::Ext::HTTP::ADAPTER
+          elsif should_use_uds?
             Datadog::Transport::Ext::UnixSocket::ADAPTER
           else
             Datadog::Transport::Ext::HTTP::ADAPTER
@@ -118,7 +132,7 @@ module Datadog
             ),
             DetectedConfiguration.new(
               friendly_name: "#{Datadog::Tracing::Configuration::Ext::Transport::ENV_DEFAULT_URL} environment variable",
-              value: parsed_url && parsed_url.hostname
+              value: parsed_http_url && parsed_http_url.hostname
             ),
             DetectedConfiguration.new(
               friendly_name: "#{Datadog::Core::Configuration::Ext::Transport::ENV_DEFAULT_HOST} environment variable",
@@ -141,7 +155,7 @@ module Datadog
             ),
             DetectedConfiguration.new(
               friendly_name: "#{Datadog::Tracing::Configuration::Ext::Transport::ENV_DEFAULT_URL} environment variable",
-              value: parsed_url && parsed_url.port,
+              value: parsed_http_url && parsed_http_url.port,
             ),
             try_parsing_as_integer(
               friendly_name: "#{Datadog::Tracing::Configuration::Ext::Transport::ENV_DEFAULT_PORT} environment variable",
@@ -169,16 +183,20 @@ module Datadog
         end
 
         def hostname
-          configured_hostname || (should_use_uds_fallback? ? nil : Datadog::Transport::Ext::HTTP::DEFAULT_HOST)
+          configured_hostname || (should_use_uds? ? nil : Datadog::Transport::Ext::HTTP::DEFAULT_HOST)
         end
 
         def port
-          configured_port || (should_use_uds_fallback? ? nil : Datadog::Transport::Ext::HTTP::DEFAULT_PORT)
+          configured_port || (should_use_uds? ? nil : Datadog::Transport::Ext::HTTP::DEFAULT_PORT)
         end
 
         # Unix socket path in the file system
         def uds_path
-          uds_fallback
+          if parsed_url && unix_scheme?(parsed_url)
+            parsed_url.to_s.sub('unix://', '')
+          else
+            uds_fallback
+          end
         end
 
         # Defaults to +nil+, letting the adapter choose what default
@@ -210,8 +228,11 @@ module Datadog
             end
         end
 
-        def should_use_uds_fallback?
-          uds_fallback != nil
+        def should_use_uds?
+          parsed_url && unix_scheme?(parsed_url) ||
+            # If no agent settings have been provided, we try to connect using a local unix socket.
+            # We only do so if the socket is present when `ddtrace` runs.
+            !uds_fallback.nil?
         end
 
         def parsed_url
@@ -223,7 +244,7 @@ module Datadog
             if unparsed_url_from_env
               parsed = URI.parse(unparsed_url_from_env)
 
-              if %w[http https].include?(parsed.scheme)
+              if http_scheme?(parsed) || unix_scheme?(parsed)
                 parsed
               else
                 # rubocop:disable Layout/LineLength
@@ -264,6 +285,19 @@ module Datadog
 
         def log_warning(message)
           logger.warn(message) if logger
+        end
+
+        def http_scheme?(uri)
+          ['http', 'https'].include?(uri.scheme)
+        end
+
+        # Expected to return nil (not false!) when it's not http
+        def parsed_http_url
+          parsed_url if parsed_url && http_scheme?(parsed_url)
+        end
+
+        def unix_scheme?(uri)
+          uri.scheme == 'unix'
         end
 
         # The settings.tracing.transport_options allows users to have full control over the settings used to

--- a/lib/datadog/core/configuration/agent_settings_resolver.rb
+++ b/lib/datadog/core/configuration/agent_settings_resolver.rb
@@ -193,7 +193,14 @@ module Datadog
         # Unix socket path in the file system
         def uds_path
           if parsed_url && unix_scheme?(parsed_url)
-            parsed_url.to_s.sub('unix://', '')
+            path = parsed_url.to_s
+            # Some versions of the built-in uri gem leave the original url untouched, and others remove the //, so this
+            # supports both
+            if path.start_with?('unix://')
+              path.sub('unix://', '')
+            else
+              path.sub('unix:', '')
+            end
           else
             uds_fallback
           end

--- a/spec/datadog/core/configuration/agent_settings_resolver_spec.rb
+++ b/spec/datadog/core/configuration/agent_settings_resolver_spec.rb
@@ -34,6 +34,7 @@ RSpec.describe Datadog::Core::Configuration::AgentSettingsResolver do
 
   before do
     # Environment does not have existing unix socket for the base testing case
+    allow(File).to receive(:exist?).and_call_original # To avoid breaking debugging
     allow(File).to receive(:exist?).with('/var/run/datadog/apm.socket').and_return(false)
   end
 

--- a/spec/datadog/core/configuration/agent_settings_resolver_spec.rb
+++ b/spec/datadog/core/configuration/agent_settings_resolver_spec.rb
@@ -214,6 +214,10 @@ RSpec.describe Datadog::Core::Configuration::AgentSettingsResolver do
 
           resolver
         end
+
+        it 'does not include a uds_path in the configuration' do
+          expect(resolver).to have_attributes(uds_path: nil)
+        end
       end
     end
   end


### PR DESCRIPTION
**What does this PR do?**:

This PR extends the `AgentSettingsResolver` to allow the `DD_TRACE_AGENT_URL` to contain a Unix Domain Socket (UDS) configuration string, for instance `unix:///some/path/to/the/apm.socket`.

It also adds a warning if there's configuration for both http and unix domain socket (and in that case it will prioritize the http variant).

**Motivation**:

This was missing for feature parity with other Datadog client libraries, and it was annoying a lot of customers in #1967 (thanks for the patience, folks!).

**Additional Notes**:

The change is quite small because dd-trace-rb already supported using unix domain sockets -- you just couldn't configure them via this environment variable. Thus, the only thing that changed was parsing it correctly.

**How to test the change?**:

Configure an agent with a uds socket and report data through it.

Fixes #1967