### PR TITLE
RFC: Remove CircleCI badge from README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,6 @@
 # Datadog Trace Client
 
 [![Gem](https://img.shields.io/gem/v/ddtrace)](https://rubygems.org/gems/ddtrace/)
-[![CircleCI](https://circleci.com/gh/DataDog/dd-trace-rb/tree/master.svg?style=svg)](https://circleci.com/gh/DataDog/dd-trace-rb/tree/master)
 [![codecov](https://codecov.io/gh/DataDog/dd-trace-rb/branch/master/graph/badge.svg)](https://app.codecov.io/gh/DataDog/dd-trace-rb/branch/master)
 [![YARD documentation](https://img.shields.io/badge/YARD-documentation-blue)][api docs]
 


### PR DESCRIPTION
**What does this PR do?**:

This PR removes the CircleCI badge from the README.

**Motivation**:

I don't think this badge provides a lot of value:
* We do a lot of validation that is not reflected in this badge, e.g. in GitHub Actions, as well as other internal validations
* The status of master doesn't really tell a lot about released versions
* We're still hunting down a few flaky tests, which make the badge show red from time to time.

...so my suggestion is to remove it.

**Additional Notes**:

N/A

**How to test the change?**:

Validate that badge is not there anymore ;)
