### PR TITLE
Add remote configuration tags

### DIFF
--- a/lib/datadog/core/remote/client.rb
+++ b/lib/datadog/core/remote/client.rb
@@ -108,7 +108,7 @@ module Datadog
 
         private
 
-        def payload
+        def payload # rubocop:disable Metrics/MethodLength
           state = repository.state
 
           client_tracer = {
@@ -117,7 +117,14 @@ module Datadog
             tracer_version: Core::Environment::Identity.tracer_version,
             service: Datadog.configuration.service,
             env: Datadog.configuration.env,
-            tags: [], # TODO: add nice tags!
+            tags: [
+              format('ruby.tracer.version:%s', Core::Environment::Identity.tracer_version),
+              format('ruby.runtime.platform:%s', RUBY_PLATFORM),
+              format('ruby.runtime.version:%s', RUBY_VERSION),
+              format('ruby.runtime.engine.name:%s', RUBY_ENGINE),
+              format('ruby.runtime.engine.version:%s', RUBY_ENGINE_VERSION),
+              format('ruby.rubygems.platform.local:%s', Gem::Platform.local.to_s),
+            ],
           }
 
           app_version = Datadog.configuration.version

--- a/lib/datadog/core/remote/client.rb
+++ b/lib/datadog/core/remote/client.rb
@@ -179,7 +179,7 @@ module Datadog
                  case os_name
                  when /linux/i then 'linux'
                  when /mac/i   then 'darwin'
-                 else raise PlatformError, "unsupported JRuby os.name: #{os_name.inspect}"
+                 else os_name
                  end
                else
                  Gem::Platform.local.os
@@ -200,7 +200,7 @@ module Datadog
                   case os_arch
                   when 'amd64' then 'x86_64'
                   when 'aarch64' then os == 'darwin' ? 'arm64' : 'aarch64'
-                  else raise PlatformError, "unsupported JRuby os.arch: #{os_arch.inspect}"
+                  else os_arch
                   end
                 else
                   Gem::Platform.local.cpu
@@ -208,8 +208,6 @@ module Datadog
 
           @native_platform = [cpu, os, version].compact.join('-')
         end
-
-        class PlatformError < RuntimeError; end
 
         GemSpecificationFallback = _ = Struct.new(:version, :platform) # rubocop:disable Naming/ConstantName
       end

--- a/lib/datadog/core/remote/client.rb
+++ b/lib/datadog/core/remote/client.rb
@@ -122,7 +122,10 @@ module Datadog
               format('ruby.runtime.platform:%s', RUBY_PLATFORM),
               format('ruby.runtime.version:%s', RUBY_VERSION),
               format('ruby.runtime.engine.name:%s', RUBY_ENGINE),
-              format('ruby.runtime.engine.version:%s', RUBY_ENGINE_VERSION),
+              format(
+                'ruby.runtime.engine.version:%s',
+                (defined?(RUBY_ENGINE_VERSION) ? RUBY_ENGINE_VERSION : RUBY_VERSION)
+              ),
               format('ruby.rubygems.platform.local:%s', Gem::Platform.local.to_s),
             ],
           }

--- a/lib/datadog/core/remote/client.rb
+++ b/lib/datadog/core/remote/client.rb
@@ -118,15 +118,12 @@ module Datadog
             service: Datadog.configuration.service,
             env: Datadog.configuration.env,
             tags: [
-              format('ruby.tracer.version:%s', Core::Environment::Identity.tracer_version),
-              format('ruby.runtime.platform:%s', RUBY_PLATFORM),
-              format('ruby.runtime.version:%s', RUBY_VERSION),
-              format('ruby.runtime.engine.name:%s', RUBY_ENGINE),
-              format(
-                'ruby.runtime.engine.version:%s',
-                (defined?(RUBY_ENGINE_VERSION) ? RUBY_ENGINE_VERSION : RUBY_VERSION)
-              ),
-              format('ruby.rubygems.platform.local:%s', Gem::Platform.local.to_s),
+              "ruby.tracer.version:#{Core::Environment::Identity.tracer_version}",
+              "ruby.runtime.platform:#{RUBY_PLATFORM}",
+              "ruby.runtime.version:#{RUBY_VERSION}",
+              "ruby.runtime.engine.name:#{RUBY_ENGINE}",
+              "ruby.runtime.engine.version:#{defined?(RUBY_ENGINE_VERSION) ? RUBY_ENGINE_VERSION : RUBY_VERSION}",
+              "ruby.rubygems.platform.local:#{Gem::Platform.local}",
             ],
           }
 

--- a/sig/datadog/core/remote/client.rbs
+++ b/sig/datadog/core/remote/client.rbs
@@ -30,9 +30,6 @@ module Datadog
         def native_platform: () -> ::String
         def ruby_engine_version: () -> ::String
 
-        class PlatformError < RuntimeError
-        end
-
         class GemSpecificationFallback
           def initialize: (::String?, ::String?) -> void
 

--- a/sig/datadog/core/remote/client.rbs
+++ b/sig/datadog/core/remote/client.rbs
@@ -21,10 +21,23 @@ module Datadog
 
         private
 
+        @gem_specs: ::Hash[::String, ::Gem::Specification | untyped]
+        @native_platform: ::String
+        @ruby_engine_version: ::String
+
         def payload: () ->  ::Hash[Symbol, untyped]
+        def gem_spec: (::String) -> (::Gem::Specification | untyped)
         def native_platform: () -> ::String
+        def ruby_engine_version: () -> ::String
 
         class PlatformError < RuntimeError
+        end
+
+        class GemSpecificationFallback
+          def initialize: (::String?, ::String?) -> void
+
+          attr_reader version: ::String?
+          attr_reader platform: ::String?
         end
       end
     end

--- a/sig/datadog/core/remote/client.rbs
+++ b/sig/datadog/core/remote/client.rbs
@@ -22,6 +22,10 @@ module Datadog
         private
 
         def payload: () ->  ::Hash[Symbol, untyped]
+        def native_platform: () -> ::String
+
+        class PlatformError < RuntimeError
+        end
       end
     end
   end

--- a/spec/datadog/core/remote/client_spec.rb
+++ b/spec/datadog/core/remote/client_spec.rb
@@ -529,7 +529,10 @@ RSpec.describe Datadog::Core::Remote::Client do
                     format('ruby.runtime.platform:%s', RUBY_PLATFORM),
                     format('ruby.runtime.version:%s', RUBY_VERSION),
                     format('ruby.runtime.engine.name:%s', RUBY_ENGINE),
-                    format('ruby.runtime.engine.version:%s', RUBY_ENGINE_VERSION),
+                    format(
+                      'ruby.runtime.engine.version:%s',
+                      (defined?(RUBY_ENGINE_VERSION) ? RUBY_ENGINE_VERSION : RUBY_VERSION)
+                    ),
                     format('ruby.rubygems.platform.local:%s', Gem::Platform.local.to_s),
                   ]
                 }
@@ -553,7 +556,10 @@ RSpec.describe Datadog::Core::Remote::Client do
                     format('ruby.runtime.platform:%s', RUBY_PLATFORM),
                     format('ruby.runtime.version:%s', RUBY_VERSION),
                     format('ruby.runtime.engine.name:%s', RUBY_ENGINE),
-                    format('ruby.runtime.engine.version:%s', RUBY_ENGINE_VERSION),
+                    format(
+                      'ruby.runtime.engine.version:%s',
+                      (defined?(RUBY_ENGINE_VERSION) ? RUBY_ENGINE_VERSION : RUBY_VERSION)
+                    ),
                     format('ruby.rubygems.platform.local:%s', Gem::Platform.local.to_s),
                   ]
                 }

--- a/spec/datadog/core/remote/client_spec.rb
+++ b/spec/datadog/core/remote/client_spec.rb
@@ -524,7 +524,14 @@ RSpec.describe Datadog::Core::Remote::Client do
                   :service => Datadog.configuration.service,
                   :env => Datadog.configuration.env,
                   :app_version => Datadog.configuration.version,
-                  :tags => []
+                  :tags => [
+                    format('ruby.tracer.version:%s', Datadog::Core::Environment::Identity.tracer_version),
+                    format('ruby.runtime.platform:%s', RUBY_PLATFORM),
+                    format('ruby.runtime.version:%s', RUBY_VERSION),
+                    format('ruby.runtime.engine.name:%s', RUBY_ENGINE),
+                    format('ruby.runtime.engine.version:%s', RUBY_ENGINE_VERSION),
+                    format('ruby.rubygems.platform.local:%s', Gem::Platform.local.to_s),
+                  ]
                 }
 
                 expect(client_payload[:client_tracer]).to eq(expected_client_tracer)
@@ -541,7 +548,14 @@ RSpec.describe Datadog::Core::Remote::Client do
                   :tracer_version => Datadog::Core::Environment::Identity.tracer_version,
                   :service => Datadog.configuration.service,
                   :env => Datadog.configuration.env,
-                  :tags => []
+                  :tags => [
+                    format('ruby.tracer.version:%s', Datadog::Core::Environment::Identity.tracer_version),
+                    format('ruby.runtime.platform:%s', RUBY_PLATFORM),
+                    format('ruby.runtime.version:%s', RUBY_VERSION),
+                    format('ruby.runtime.engine.name:%s', RUBY_ENGINE),
+                    format('ruby.runtime.engine.version:%s', RUBY_ENGINE_VERSION),
+                    format('ruby.rubygems.platform.local:%s', Gem::Platform.local.to_s),
+                  ]
                 }
 
                 expect(client_payload[:client_tracer]).to eq(expected_client_tracer)

--- a/spec/datadog/core/remote/client_spec.rb
+++ b/spec/datadog/core/remote/client_spec.rb
@@ -513,6 +513,52 @@ RSpec.describe Datadog::Core::Remote::Client do
           end
 
           context 'client_tracer' do
+            context 'tags' do
+              let(:tracer_version) { '1.1.1' }
+              let(:ruby_platform) { 'ruby-platform' }
+              let(:ruby_version) { '2.2.2' }
+              let(:ruby_engine) { 'ruby_engine_name' }
+              let(:ruby_engine_version) { '3.3.3' }
+              let(:gem_platform_local) { 'gem-platform' }
+              let(:native_platform) { 'native-platform' }
+              let(:libddwaf_gem_spec) { Struct.new(:version, :platform).new('4.4.4', 'libddwaf-platform') }
+              let(:libdatadog_gem_spec) { Struct.new(:version, :platform).new('5.5.5', 'libdatadog-platform') }
+
+              before do
+                stub_const('RUBY_PLATFORM', ruby_platform)
+                stub_const('RUBY_VERSION', ruby_version)
+                stub_const('RUBY_ENGINE', ruby_engine)
+                stub_const('RUBY_ENGINE_VERSION', ruby_engine_version)
+
+                allow(Gem::Platform).to receive(:local).and_return(gem_platform_local)
+                allow(Datadog::Core::Environment::Identity).to receive(:tracer_version).and_return(tracer_version)
+                allow(client).to receive(:ruby_engine_version).and_return(ruby_engine_version)
+                allow(client).to receive(:native_platform).and_return(native_platform)
+                allow(client).to receive(:gem_spec).with('libddwaf').and_return(libddwaf_gem_spec)
+                allow(client).to receive(:gem_spec).with('libdatadog').and_return(libdatadog_gem_spec)
+              end
+
+              it 'returns client_tracer tags' do
+                expect(Datadog.configuration).to receive(:version).and_return('hello').at_least(:once)
+
+                expected_client_tracer_tags = [
+                  "platform:#{native_platform}",
+                  "ruby.tracer.version:#{tracer_version}",
+                  "ruby.runtime.platform:#{ruby_platform}",
+                  "ruby.runtime.version:#{ruby_version}",
+                  "ruby.runtime.engine.name:#{ruby_engine}",
+                  "ruby.runtime.engine.version:#{ruby_engine_version}",
+                  "ruby.rubygems.platform.local:#{gem_platform_local}",
+                  "ruby.gem.libddwaf.version:#{libddwaf_gem_spec.version}",
+                  "ruby.gem.libddwaf.platform:#{libddwaf_gem_spec.platform}",
+                  "ruby.gem.libdatadog.version:#{libdatadog_gem_spec.version}",
+                  "ruby.gem.libdatadog.platform:#{libdatadog_gem_spec.platform}",
+                ]
+
+                expect(client_payload[:client_tracer][:tags]).to eq(expected_client_tracer_tags)
+              end
+            end
+
             context 'with app_version' do
               it 'returns client_tracer' do
                 expect(Datadog.configuration).to receive(:version).and_return('hello').at_least(:once)
@@ -524,20 +570,9 @@ RSpec.describe Datadog::Core::Remote::Client do
                   :service => Datadog.configuration.service,
                   :env => Datadog.configuration.env,
                   :app_version => Datadog.configuration.version,
-                  :tags => [
-                    format('ruby.tracer.version:%s', Datadog::Core::Environment::Identity.tracer_version),
-                    format('ruby.runtime.platform:%s', RUBY_PLATFORM),
-                    format('ruby.runtime.version:%s', RUBY_VERSION),
-                    format('ruby.runtime.engine.name:%s', RUBY_ENGINE),
-                    format(
-                      'ruby.runtime.engine.version:%s',
-                      (defined?(RUBY_ENGINE_VERSION) ? RUBY_ENGINE_VERSION : RUBY_VERSION)
-                    ),
-                    format('ruby.rubygems.platform.local:%s', Gem::Platform.local.to_s),
-                  ]
                 }
 
-                expect(client_payload[:client_tracer]).to eq(expected_client_tracer)
+                expect(client_payload[:client_tracer].tap { |h| h.delete(:tags) }).to eq(expected_client_tracer)
               end
             end
 
@@ -551,20 +586,9 @@ RSpec.describe Datadog::Core::Remote::Client do
                   :tracer_version => Datadog::Core::Environment::Identity.tracer_version,
                   :service => Datadog.configuration.service,
                   :env => Datadog.configuration.env,
-                  :tags => [
-                    format('ruby.tracer.version:%s', Datadog::Core::Environment::Identity.tracer_version),
-                    format('ruby.runtime.platform:%s', RUBY_PLATFORM),
-                    format('ruby.runtime.version:%s', RUBY_VERSION),
-                    format('ruby.runtime.engine.name:%s', RUBY_ENGINE),
-                    format(
-                      'ruby.runtime.engine.version:%s',
-                      (defined?(RUBY_ENGINE_VERSION) ? RUBY_ENGINE_VERSION : RUBY_VERSION)
-                    ),
-                    format('ruby.rubygems.platform.local:%s', Gem::Platform.local.to_s),
-                  ]
                 }
 
-                expect(client_payload[:client_tracer]).to eq(expected_client_tracer)
+                expect(client_payload[:client_tracer].tap { |h| h.delete(:tags) }).to eq(expected_client_tracer)
               end
             end
           end


### PR DESCRIPTION
<!--
Check out the
https://github.com/DataDog/dd-trace-rb/blob/master/docs/DevelopmentGuide.md
for guidance on how to set up your development environment,
run the test suite, write new integrations, and more.
-->

**What does this PR do?**

Add remote configuration tags

**Motivation**

- version is mangled through semver, report the exact original gem version string
- ruby runtime information is gold to debug issues

**Additional Notes**

Ideally runtime information should go through telemetry but it is currently lacking in some departments.

**How to test the change?**

- Automatically: CI
- Manually: start a process with RC, go to the RC admin, and see the tags.