### PR TITLE
Switch reliability env deploys to be scheduled

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -13,16 +13,17 @@ variables:
   DOWNSTREAM_BRANCH:
     value: "master"
     description: "Run a specific datadog-reliability-env branch downstream"
-  FORCE_TRIGGER:
-    value: "false"
-    description: "Set to true to override rules in the reliability-env pipeline (e.g. override 'only deploy master')"
 
 .common: &common
   tags: [ "runner:main", "size:large" ]
 
 deploy_to_reliability_env:
   stage: deploy
-  when: on_success
+  rules:
+    - if: $CI_PIPELINE_SOURCE == "scheduled"
+      when: on_success
+    - when: manual
+      allow_failure: true
   trigger:
     project: DataDog/apm-reliability/datadog-reliability-env
     branch: $DOWNSTREAM_BRANCH
@@ -31,7 +32,6 @@ deploy_to_reliability_env:
     UPSTREAM_PROJECT_ID: $CI_PROJECT_ID
     UPSTREAM_PROJECT_NAME: $CI_PROJECT_NAME
     UPSTREAM_COMMIT_SHA: $CI_COMMIT_SHA
-    FORCE_TRIGGER: $FORCE_TRIGGER
 
 deploy_to_docker_registries:
   stage: deploy


### PR DESCRIPTION
<!--
Check out the
https://github.com/DataDog/dd-trace-rb/blob/master/docs/DevelopmentGuide.md
for guidance on how to set up your development environment,
run the test suite, write new integrations, and more.
-->

**What does this PR do?**
This PR changes reliability env deploys to only happen when scheduled or manually triggered.

**Motivation**
Deploying on commits to the main branch are too noisy to see medium-term trends. Switching to a scheduled deploy should help.
