### PR TITLE
Telemetry:Disable for non-HTTP agent connection

### DIFF
--- a/lib/datadog/core/telemetry/client.rb
+++ b/lib/datadog/core/telemetry/client.rb
@@ -5,7 +5,7 @@ require_relative '../utils/forking'
 module Datadog
   module Core
     module Telemetry
-      # Telemetry entrypoint, coordinates sending telemetry events at various points in app lifecyle
+      # Telemetry entrypoint, coordinates sending telemetry events at various points in app lifecycle.
       class Client
         attr_reader \
           :emitter,

--- a/lib/datadog/core/telemetry/http/transport.rb
+++ b/lib/datadog/core/telemetry/http/transport.rb
@@ -10,6 +10,7 @@ module Datadog
     module Telemetry
       module Http
         # Class to send telemetry data to Telemetry API
+        # Currently only supports the HTTP protocol.
         class Transport
           attr_reader \
             :host,


### PR DESCRIPTION
This PR addresses the debug error log that happens when `ddtrace` is configured to communicate with the agent through UDS: `Unable to send telemetry event to agent: Failed to open TCP connection to :80 (Connection refused - connect(2) for nil port 80)`.

This PR does not enable the `Telemetry` client when UDS connection is used, instead disabling Telemetry.