### PR TITLE
make sure ENV variables are strings

### DIFF
--- a/.gitlab/benchmarks.yml
+++ b/.gitlab/benchmarks.yml
@@ -52,33 +52,33 @@ only-profiling-benchmarks:
   extends: .benchmarks
   variables:
     DD_RELENV_CONFIGURATION: only-profiling
-    DD_PROFILING_ENABLED: true
+    DD_PROFILING_ENABLED: "true"
 
 profiling-and-tracing-benchmarks:
   extends: .benchmarks
   variables:
     DD_RELENV_CONFIGURATION: profiling-and-tracing
-    DD_PROFILING_ENABLED: true
+    DD_PROFILING_ENABLED: "true"
 
 tracing-and-appsec-benchmarks:
   extends: .benchmarks
   variables:
     DD_RELENV_CONFIGURATION: tracing-and-appsec
-    DD_APPSEC_ENABLED: true
+    DD_APPSEC_ENABLED: "true"
 
 tracing-and-appsec-and-no-remote-configuration-benchmarks:
   extends: .benchmarks
   variables:
     DD_RELENV_CONFIGURATION: tracing-and-appsec-and-no-remote-configuration
-    DD_APPSEC_ENABLED: true
-    DD_REMOTE_CONFIGURATION_ENABLED: false
+    DD_APPSEC_ENABLED: "true"
+    DD_REMOTE_CONFIGURATION_ENABLED: "false"
 
 profiling-and-tracing-and-appsec-benchmarks:
   extends: .benchmarks
   variables:
     DD_RELENV_CONFIGURATION: profiling-and-tracing-and-appsec
-    DD_APPSEC_ENABLED: true
-    DD_PROFILING_ENABLED: true
+    DD_APPSEC_ENABLED: "true"
+    DD_PROFILING_ENABLED: "true"
 
 # -----------------------------------------------------
 # Microbenchmarks that report to statsd


### PR DESCRIPTION
<!--
Check out the
https://github.com/DataDog/dd-trace-rb/blob/master/docs/DevelopmentGuide.md
for guidance on how to set up your development environment,
run the test suite, write new integrations, and more.
-->

**What does this PR do?**
<!-- A brief description of the change being made with this pull request. -->

Fix the problem with our GitLab pipeline. It complains that the value definition must be a string or a hash

<img width="2484" alt="image" src="https://user-images.githubusercontent.com/4672858/234580726-b9772a8b-5289-4929-92db-638146824290.png">


**Motivation**
<!-- What inspired you to submit this pull request? -->

**Additional Notes**
<!-- Anything else we should know when reviewing? -->

**How to test the change?**
<!--
Describe here how the change can be validated.
You are strongly encouraged to provide automated tests for this PR (unit or integration).
If this change cannot be feasibly tested, please explain why,
unless the change does not modify code (e.g. only modifies docs, comments).
-->
