### PR TITLE
Memoize tracer_version_semver2

### DIFF
--- a/lib/datadog/core/remote/client.rb
+++ b/lib/datadog/core/remote/client.rb
@@ -135,7 +135,7 @@ module Datadog
           client_tracer = {
             runtime_id: Core::Environment::Identity.id,
             language: Core::Environment::Identity.lang,
-            tracer_version: Core::Environment::Identity.tracer_version_semver2,
+            tracer_version: tracer_version_semver2,
             service: Datadog.configuration.service,
             env: Datadog.configuration.env,
             tags: client_tracer_tags,
@@ -165,6 +165,10 @@ module Datadog
             },
             cached_target_files: state.cached_target_files,
           }
+        end
+
+        def tracer_version_semver2
+          @tracer_version_semver2 ||= Core::Environment::Identity.tracer_version_semver2
         end
 
         def ruby_engine_version

--- a/sig/datadog/core/remote/client.rbs
+++ b/sig/datadog/core/remote/client.rbs
@@ -24,9 +24,11 @@ module Datadog
         @gem_specs: ::Hash[::String, ::Gem::Specification | untyped]
         @native_platform: ::String
         @ruby_engine_version: ::String
+        @tracer_version_semver2: ::String
 
         def payload: () ->  ::Hash[Symbol, untyped]
         def gem_spec: (::String) -> (::Gem::Specification | untyped)
+        def tracer_version_semver2: () -> ::String
         def native_platform: () -> ::String
         def ruby_engine_version: () -> ::String
 


### PR DESCRIPTION
<!--
Check out the
https://github.com/DataDog/dd-trace-rb/blob/master/docs/DevelopmentGuide.md
for guidance on how to set up your development environment,
run the test suite, write new integrations, and more.
-->

**What does this PR do?**

Memoize tracer_version_semver2

**Motivation**

Followup to https://github.com/DataDog/dd-trace-rb/pull/2795#discussion_r1178058677

**Additional Notes**

Memoized in client instead of `Core::Environment::Identity` because the latter would make it global in the module singleton, and complicates testing. Also, none are memoized in there.

**How to test the change?**

CI