### PR TITLE
fix flaky test by using expect API to make sure the original code doe…

### DIFF
--- a/lib/datadog/appsec/component.rb
+++ b/lib/datadog/appsec/component.rb
@@ -53,7 +53,7 @@ module Datadog
           if new && new.ready?
             old = @processor
             @processor = new
-            old.finalize
+            old.finalize if old
           end
         end
       end

--- a/lib/datadog/appsec/contrib/rack/request_middleware.rb
+++ b/lib/datadog/appsec/contrib/rack/request_middleware.rb
@@ -23,12 +23,11 @@ module Datadog
             @oneshot_tags_sent = false
           end
 
-          # rubocop:disable Metrics/AbcSize,Metrics/PerceivedComplexity,Metrics/CyclomaticComplexity,Metrics/MethodLength
+          # rubocop:disable Metrics/PerceivedComplexity,Metrics/CyclomaticComplexity,Metrics/MethodLength
           def call(env)
             return @app.call(env) unless Datadog::AppSec.enabled?
 
             Datadog::Core::Remote.active_remote.barrier(:once) unless Datadog::Core::Remote.active_remote.nil?
-            processor = Datadog::AppSec.processor
 
             processor = nil
             ready = false
@@ -89,7 +88,7 @@ module Datadog
               processor.deactivate_context
             end
           end
-          # rubocop:enable Metrics/AbcSize,Metrics/PerceivedComplexity,Metrics/CyclomaticComplexity,Metrics/MethodLength
+          # rubocop:enable Metrics/PerceivedComplexity,Metrics/CyclomaticComplexity,Metrics/MethodLength
 
           private
 

--- a/spec/datadog/appsec/remote_spec.rb
+++ b/spec/datadog/appsec/remote_spec.rb
@@ -164,12 +164,15 @@ RSpec.describe Datadog::AppSec::Remote do
 
         context 'when there is no ASM_DD information' do
           let(:transaction) { repository.transaction { |repository, transaction| } }
+
           it 'uses the rules from the appsec settings' do
+            ruleset = ''
             expect(Datadog::AppSec::Processor::RuleLoader).to receive(:load_rules).with(
               ruleset: Datadog.configuration.appsec.ruleset
-            ).at_least(:once).and_call_original
+            ).and_return(ruleset)
 
             changes = transaction
+            expect(Datadog::AppSec).to receive(:reconfigure).with(ruleset: ruleset)
             receiver.call(repository, changes)
           end
 

--- a/spec/datadog/appsec/remote_spec.rb
+++ b/spec/datadog/appsec/remote_spec.rb
@@ -158,6 +158,7 @@ RSpec.describe Datadog::AppSec::Remote do
           }
 
           expect(Datadog::AppSec).to receive(:reconfigure).with(ruleset: expected_ruleset)
+            .and_return(nil)
           changes = transaction
           receiver.call(repository, changes)
         end
@@ -166,13 +167,15 @@ RSpec.describe Datadog::AppSec::Remote do
           let(:transaction) { repository.transaction { |repository, transaction| } }
 
           it 'uses the rules from the appsec settings' do
-            ruleset = ''
+            ruleset = 'foo'
+
             expect(Datadog::AppSec::Processor::RuleLoader).to receive(:load_rules).with(
               ruleset: Datadog.configuration.appsec.ruleset
             ).and_return(ruleset)
 
             changes = transaction
             expect(Datadog::AppSec).to receive(:reconfigure).with(ruleset: ruleset)
+              .and_return(nil)
             receiver.call(repository, changes)
           end
 


### PR DESCRIPTION
<!--
Check out the
https://github.com/DataDog/dd-trace-rb/blob/master/docs/DevelopmentGuide.md
for guidance on how to set up your development environment,
run the test suite, write new integrations, and more.
-->

**What does this PR do?**
<!-- A brief description of the change being made with this pull request. -->

Fix flaky test 

The test break can be reproduced locally running `bundle exec appraisal ruby-3.2.0-core-old rake "spec:main[--seed 60499]"`

![image](https://user-images.githubusercontent.com/4672858/234840246-8246c464-8177-4a62-8f21-e918f5e3f925.png)

While working on the fix for the flaky test, I noticed we blindly call `finalize` on the old processor when calling `reconfigure`. There could be cases where the `old_processor` is `nil` . I added a test case and changed the code to avoid getting an unhandled exception in production.


**Motivation**
<!-- What inspired you to submit this pull request? -->

**Additional Notes**
<!-- Anything else we should know when reviewing? -->

**How to test the change?**
<!--
Describe here how the change can be validated.
You are strongly encouraged to provide automated tests for this PR (unit or integration).
If this change cannot be feasibly tested, please explain why,
unless the change does not modify code (e.g. only modifies docs, comments).
-->
