### PR TITLE
Fix block response content negotiation

### DIFF
--- a/lib/datadog/appsec/assets/blocked.html
+++ b/lib/datadog/appsec/assets/blocked.html
@@ -1,4 +1,4 @@
-<!-- Sorry, you’ve been blocked -->
+<!-- Sorry, you've been blocked -->
 <!DOCTYPE html>
 <html lang="en">
 

--- a/lib/datadog/appsec/response.rb
+++ b/lib/datadog/appsec/response.rb
@@ -49,7 +49,7 @@ module Datadog
 
           accepted = env['HTTP_ACCEPT'].split(',').map { |m| Utils::HTTP::MediaRange.new(m) }.sort
 
-          accepted.each_with_object(DEFAULT_FORMAT) do |_default, range|
+          accepted.each_with_object(DEFAULT_FORMAT) do |range, _default|
             format = FORMAT_MAP.keys.find { |type, _format| range === type }
 
             return FORMAT_MAP[format] if format

--- a/sig/datadog/appsec/response.rbs
+++ b/sig/datadog/appsec/response.rbs
@@ -15,9 +15,10 @@ module Datadog
       private
 
       FORMAT_MAP: ::Hash[::String, ::Symbol]
-      DEFAULT_FORMAT: ::Symbol
+      DEFAULT_CONTENT_TYPE: ::String
 
       def self.format: (::Hash[untyped, untyped] env) -> ::Symbol
+      def self.content_type: (::Hash[untyped, untyped] env) -> ::String
     end
   end
 end

--- a/spec/datadog/appsec/response_spec.rb
+++ b/spec/datadog/appsec/response_spec.rb
@@ -1,0 +1,111 @@
+require 'datadog/appsec/response'
+
+RSpec.describe Datadog::AppSec::Response do
+  describe '.negotiate' do
+    let(:env) { double }
+
+    before do
+      allow(env).to receive(:key?).with('HTTP_ACCEPT').and_return(true)
+      allow(env).to receive(:[]).with('HTTP_ACCEPT').and_return('text/html')
+    end
+
+    describe '.status' do
+      subject(:content_type) { described_class.negotiate(env).status }
+
+      it { is_expected.to eq 403 }
+    end
+
+    describe '.body' do
+      subject(:body) { described_class.negotiate(env).body }
+
+      before do
+        expect(env).to receive(:key?).with('HTTP_ACCEPT').and_return(true)
+        expect(env).to receive(:[]).with('HTTP_ACCEPT').and_return(accept)
+      end
+
+      context('with Accept: text/html') do
+        let(:accept) { 'text/html' }
+
+        it { is_expected.to eq [Datadog::AppSec::Assets.blocked(format: :html)] }
+      end
+
+      context('with Accept: application/json') do
+        let(:accept) { 'application/json' }
+
+        it { is_expected.to eq [Datadog::AppSec::Assets.blocked(format: :json)] }
+      end
+
+      context('with Accept: text/plain') do
+        let(:accept) { 'text/plain' }
+
+        it { is_expected.to eq [Datadog::AppSec::Assets.blocked(format: :text)] }
+      end
+    end
+
+    describe ".headers['Content-Type']" do
+      subject(:content_type) { described_class.negotiate(env).headers['Content-Type'] }
+
+      before do
+        expect(env).to receive(:key?).with('HTTP_ACCEPT').and_return(respond_to?(:accept))
+
+        if respond_to?(:accept)
+          expect(env).to receive(:[]).with('HTTP_ACCEPT').and_return(accept)
+        else
+          expect(env).to_not receive(:[]).with('HTTP_ACCEPT')
+        end
+      end
+
+      context('with Accept: text/html') do
+        let(:accept) { 'text/html' }
+
+        it { is_expected.to eq accept }
+      end
+
+      context('with Accept: application/json') do
+        let(:accept) { 'application/json' }
+
+        it { is_expected.to eq accept }
+      end
+
+      context('with Accept: text/plain') do
+        let(:accept) { 'text/plain' }
+
+        it { is_expected.to eq accept }
+      end
+
+      context('without Accept header') do
+        it { is_expected.to eq 'text/plain' }
+      end
+
+      context('with Accept: */*') do
+        let(:accept) { '*/*' }
+
+        it { is_expected.to eq 'text/plain' }
+      end
+
+      context('with unparseable Accept header') do
+        let(:accept) { 'invalid' }
+
+        it { is_expected.to eq 'text/plain' }
+      end
+
+      context('with Mozilla Firefox Accept') do
+        let(:accept) { 'text/html,application/xhtml+xml,application/xml;q=0.9,image/avif,image/webp,*/*;q=0.8' }
+
+        it { is_expected.to eq 'text/html' }
+      end
+
+      context('with Google Chrome Accept') do
+        let(:accept) { 'text/html,application/xhtml+xml,application/xml;q=0.9,image/avif,image/webp,image/apng,*/*;q=0.8,application/signed-exchange;v=b3;q=0.7' } # rubocop:disable Layout/LineLength
+
+        it { is_expected.to eq 'text/html' }
+      end
+
+      context('with Apple Safari Accept') do
+        let(:accept) { 'text/html,application/xhtml+xml,application/xml;q=0.9,*/*;q=0.8' }
+
+        it { is_expected.to eq 'text/html' }
+      end
+    end
+  end
+end


### PR DESCRIPTION
<!--
Check out the
https://github.com/DataDog/dd-trace-rb/blob/master/docs/DevelopmentGuide.md
for guidance on how to set up your development environment,
run the test suite, write new integrations, and more.
-->

**What does this PR do?**

Reimplement response negotiation

This covers:
- unparseable Accept headers
- missing Accept headers
- proper ordering to handle priority
- defaulting to the first map element
- specs to avoid regressions

**Motivation**

A swapped argument prompted a deeper analysis of the response negotiation implementation, which uncovered many corner case issues.

**Additional Notes**

Specs were added to cover the most important main and corner cases 

**How to test the change?**

Perform a request that generates a blocking response, e.g (with remote configuration disabled) using:

```
    c.appsec.ip_denylist = [
      '127.0.0.1',
      '::1',
    ]
```