### PR TITLE
Fix circular requires

### DIFF
--- a/lib/datadog/tracing/buffer.rb
+++ b/lib/datadog/tracing/buffer.rb
@@ -1,4 +1,3 @@
-require_relative '../core'
 require_relative '../core/environment/ext'
 require_relative '../core/buffer/thread_safe'
 require_relative '../core/buffer/cruby'

--- a/lib/datadog/tracing/contrib/patcher.rb
+++ b/lib/datadog/tracing/contrib/patcher.rb
@@ -1,4 +1,3 @@
-require_relative '../../core'
 require_relative '../../core/utils/only_once'
 
 module Datadog

--- a/lib/datadog/tracing/contrib/roda/patcher.rb
+++ b/lib/datadog/tracing/contrib/roda/patcher.rb
@@ -2,7 +2,7 @@
 
 # typed: ignore
 
-require_relative 'patcher'
+require_relative '../patcher'
 require_relative 'ext'
 require_relative 'instrumentation'
 

--- a/lib/datadog/tracing/contrib/status_code_matcher.rb
+++ b/lib/datadog/tracing/contrib/status_code_matcher.rb
@@ -1,6 +1,5 @@
 require 'set'
 
-require_relative '../../core'
 require_relative '../metadata/ext'
 
 module Datadog

--- a/lib/datadog/tracing/correlation.rb
+++ b/lib/datadog/tracing/correlation.rb
@@ -1,4 +1,3 @@
-require_relative '../core'
 require_relative 'utils'
 require_relative 'metadata/ext'
 

--- a/lib/datadog/tracing/event.rb
+++ b/lib/datadog/tracing/event.rb
@@ -1,5 +1,3 @@
-require_relative '../core'
-
 module Datadog
   module Tracing
     # Event behavior and DSL

--- a/lib/datadog/tracing/pipeline.rb
+++ b/lib/datadog/tracing/pipeline.rb
@@ -1,5 +1,3 @@
-require_relative '../core'
-
 require_relative 'pipeline/span_filter'
 require_relative 'pipeline/span_processor'
 

--- a/lib/datadog/tracing/runtime/metrics.rb
+++ b/lib/datadog/tracing/runtime/metrics.rb
@@ -1,7 +1,5 @@
 # frozen_string_literal: true
 
-require_relative '../../core'
-
 module Datadog
   module Tracing
     module Runtime

--- a/lib/datadog/tracing/sampling/rate_by_service_sampler.rb
+++ b/lib/datadog/tracing/sampling/rate_by_service_sampler.rb
@@ -1,4 +1,3 @@
-require_relative '../../core'
 require_relative 'rate_by_key_sampler'
 
 module Datadog

--- a/lib/datadog/tracing/sampling/rate_sampler.rb
+++ b/lib/datadog/tracing/sampling/rate_sampler.rb
@@ -1,5 +1,3 @@
-require_relative '../../core'
-
 require_relative 'sampler'
 require_relative '../utils'
 

--- a/lib/datadog/tracing/sampling/rule.rb
+++ b/lib/datadog/tracing/sampling/rule.rb
@@ -1,5 +1,3 @@
-require_relative '../../core'
-
 require_relative 'matcher'
 require_relative 'rate_sampler'
 

--- a/lib/datadog/tracing/sampling/rule_sampler.rb
+++ b/lib/datadog/tracing/sampling/rule_sampler.rb
@@ -1,5 +1,3 @@
-require_relative '../../core'
-
 require_relative 'ext'
 require_relative 'rate_limiter'
 require_relative 'rule'

--- a/lib/datadog/tracing/span_operation.rb
+++ b/lib/datadog/tracing/span_operation.rb
@@ -1,6 +1,5 @@
 require 'time'
 
-require_relative '../core'
 require_relative '../core/environment/identity'
 require_relative '../core/utils'
 require_relative '../core/utils/time'

--- a/lib/datadog/tracing/sync_writer.rb
+++ b/lib/datadog/tracing/sync_writer.rb
@@ -1,7 +1,5 @@
 # frozen_string_literal: true
 
-require_relative '../core'
-
 require_relative 'pipeline'
 require_relative 'runtime/metrics'
 require_relative 'writer'

--- a/lib/datadog/tracing/trace_operation.rb
+++ b/lib/datadog/tracing/trace_operation.rb
@@ -1,4 +1,3 @@
-require_relative '../core'
 require_relative '../core/environment/identity'
 require_relative '../core/utils'
 

--- a/lib/datadog/tracing/tracer.rb
+++ b/lib/datadog/tracing/tracer.rb
@@ -1,4 +1,3 @@
-require_relative '../core'
 require_relative '../core/environment/ext'
 require_relative '../core/environment/socket'
 

--- a/lib/datadog/tracing/workers.rb
+++ b/lib/datadog/tracing/workers.rb
@@ -1,5 +1,3 @@
-require_relative '../core'
-
 require_relative 'buffer'
 require_relative 'pipeline'
 

--- a/lib/datadog/tracing/workers/trace_writer.rb
+++ b/lib/datadog/tracing/workers/trace_writer.rb
@@ -1,4 +1,3 @@
-require_relative '../../core'
 require_relative '../../core/worker'
 require_relative '../../core/workers/async'
 require_relative '../../core/workers/polling'

--- a/lib/datadog/tracing/writer.rb
+++ b/lib/datadog/tracing/writer.rb
@@ -1,5 +1,3 @@
-require_relative '../core'
-
 require_relative 'event'
 require_relative 'runtime/metrics'
 require_relative 'workers'


### PR DESCRIPTION
**What does this PR do?**
This is to fix an issue we're seeing when running tests in our codebase. It should not be necessary to include core everywhere since these files should not be required directly as far as I understand.

**Motivation**
To fix this warning:

```
Users/michaelscrivo/.rbenv/versions/3.2.2/lib/ruby/gems/3.2.0/gems/ddtrace-1.11.0/lib/datadog/tracing/trace_operation.rb:1: warning:
/Users/michaelscrivo/.rbenv/versions/3.2.2/lib/ruby/gems/3.2.0/gems/ddtrace-1.11.0/lib/datadog/tracing/trace_operation.rb:1: warning: loading in progress, circular require considered harmful -
/Users/michaelscrivo/.rbenv/versions/3.2.2/lib/ruby/gems/3.2.0/gems/ddtrace-1.11.0/lib/datadog/core.rb
	from -e:1:in  `<main>'
	from <internal:/Users/michaelscrivo/.rbenv/versions/3.2.2/lib/ruby/3.2.0/rubygems/core_ext/kernel_require.rb>:37:in  `require'
	from <internal:/Users/michaelscrivo/.rbenv/versions/3.2.2/lib/ruby/3.2.0/rubygems/core_ext/kernel_require.rb>:37:in  `require'
	from /Users/michaelscrivo/affinity/ruby/gems/enrichers_datadog/test/lib/base.rb:2:in  `<top (required)>'
	from /Users/michaelscrivo/affinity/ruby/gems/enrichers_datadog/test/lib/base.rb:2:in  `require_relative'
	from /Users/michaelscrivo/affinity/ruby/gems/enrichers_datadog/lib/enrichers_datadog.rb:3:in  `<top (required)>'
	from /Users/michaelscrivo/affinity/ruby/gems/enrichers_datadog/lib/enrichers_datadog.rb:3:in  `require_relative'
	from /Users/michaelscrivo/affinity/ruby/gems/enrichers_datadog/lib/datadog_trace_enricher.rb:7:in  `<top (required)>'
	from <internal:/Users/michaelscrivo/.rbenv/versions/3.2.2/lib/ruby/3.2.0/rubygems/core_ext/kernel_require.rb>:37:in  `require'
	from <internal:/Users/michaelscrivo/.rbenv/versions/3.2.2/lib/ruby/3.2.0/rubygems/core_ext/kernel_require.rb>:37:in  `require'
	from /Users/michaelscrivo/.rbenv/versions/3.2.2/lib/ruby/gems/3.2.0/gems/ddtrace-1.11.0/lib/ddtrace.rb:4:in  `<top (required)>'
	from /Users/michaelscrivo/.rbenv/versions/3.2.2/lib/ruby/gems/3.2.0/gems/ddtrace-1.11.0/lib/ddtrace.rb:4:in  `require_relative'
	from /Users/michaelscrivo/.rbenv/versions/3.2.2/lib/ruby/gems/3.2.0/gems/ddtrace-1.11.0/lib/datadog/tracing.rb:3:in  `<top (required)>'
	from /Users/michaelscrivo/.rbenv/versions/3.2.2/lib/ruby/gems/3.2.0/gems/ddtrace-1.11.0/lib/datadog/tracing.rb:3:in  `require_relative'
	from /Users/michaelscrivo/.rbenv/versions/3.2.2/lib/ruby/gems/3.2.0/gems/ddtrace-1.11.0/lib/datadog/core.rb:3:in  `<top (required)>'
	from /Users/michaelscrivo/.rbenv/versions/3.2.2/lib/ruby/gems/3.2.0/gems/ddtrace-1.11.0/lib/datadog/core.rb:3:in  `require_relative'
	from /Users/michaelscrivo/.rbenv/versions/3.2.2/lib/ruby/gems/3.2.0/gems/ddtrace-1.11.0/lib/datadog/core/extensions.rb:3:in  `<top (required)>'
	from /Users/michaelscrivo/.rbenv/versions/3.2.2/lib/ruby/gems/3.2.0/gems/ddtrace-1.11.0/lib/datadog/core/extensions.rb:3:in  `require_relative'
	from /Users/michaelscrivo/.rbenv/versions/3.2.2/lib/ruby/gems/3.2.0/gems/ddtrace-1.11.0/lib/datadog/core/configuration.rb:1:in  `<top (required)>'
	from /Users/michaelscrivo/.rbenv/versions/3.2.2/lib/ruby/gems/3.2.0/gems/ddtrace-1.11.0/lib/datadog/core/configuration.rb:1:in  `require_relative'
	from /Users/michaelscrivo/.rbenv/versions/3.2.2/lib/ruby/gems/3.2.0/gems/ddtrace-1.11.0/lib/datadog/core/configuration/components.rb:10:in  `<top (required)>'
	from /Users/michaelscrivo/.rbenv/versions/3.2.2/lib/ruby/gems/3.2.0/gems/ddtrace-1.11.0/lib/datadog/core/configuration/components.rb:10:in  `require_relative'
	from /Users/michaelscrivo/.rbenv/versions/3.2.2/lib/ruby/gems/3.2.0/gems/ddtrace-1.11.0/lib/datadog/tracing/component.rb:3:in  `<top (required)>'
	from /Users/michaelscrivo/.rbenv/versions/3.2.2/lib/ruby/gems/3.2.0/gems/ddtrace-1.11.0/lib/datadog/tracing/component.rb:3:in  `require_relative'
	from /Users/michaelscrivo/.rbenv/versions/3.2.2/lib/ruby/gems/3.2.0/gems/ddtrace-1.11.0/lib/datadog/tracing/tracer.rb:15:in  `<top (required)>'
	from /Users/michaelscrivo/.rbenv/versions/3.2.2/lib/ruby/gems/3.2.0/gems/ddtrace-1.11.0/lib/datadog/tracing/tracer.rb:15:in  `require_relative'
	from /Users/michaelscrivo/.rbenv/versions/3.2.2/lib/ruby/gems/3.2.0/gems/ddtrace-1.11.0/lib/datadog/tracing/trace_operation.rb:1:in  `<top (required)>'
	from /Users/michaelscrivo/.rbenv/versions/3.2.2/lib/ruby/gems/3.2.0/gems/ddtrace-1.11.0/lib/datadog/tracing/trace_operation.rb:1:in  `require_relative'
```