### PR TITLE
Measured tag for client/producer spans

### DIFF
--- a/lib/datadog/tracing/contrib/active_record/events/sql.rb
+++ b/lib/datadog/tracing/contrib/active_record/events/sql.rb
@@ -58,6 +58,9 @@ module Datadog
                 Contrib::Analytics.set_sample_rate(span, configuration[:analytics_sample_rate])
               end
 
+              # Measure service stats
+              Contrib::Analytics.set_measured(span)
+
               # Find out if the SQL query has been cached in this request. This meta is really
               # helpful to users because some spans may have 0ns of duration because the query
               # is simply cached from memory, so the notification is fired with start == finish.

--- a/lib/datadog/tracing/contrib/dalli/instrumentation.rb
+++ b/lib/datadog/tracing/contrib/dalli/instrumentation.rb
@@ -39,6 +39,9 @@ module Datadog
                   Contrib::Analytics.set_sample_rate(span, datadog_configuration[:analytics_sample_rate])
                 end
 
+                # Measure service stats
+                Contrib::Analytics.set_measured(span)
+
                 span.set_tag(Tracing::Metadata::Ext::NET::TAG_TARGET_HOST, hostname)
                 span.set_tag(Tracing::Metadata::Ext::NET::TAG_TARGET_PORT, port)
 

--- a/lib/datadog/tracing/contrib/elasticsearch/patcher.rb
+++ b/lib/datadog/tracing/contrib/elasticsearch/patcher.rb
@@ -101,6 +101,9 @@ module Datadog
                       Contrib::Analytics.set_sample_rate(span, datadog_configuration[:analytics_sample_rate])
                     end
 
+                    # Measure service stats
+                    Contrib::Analytics.set_measured(span)
+
                     span.set_tag(Datadog::Tracing::Contrib::Elasticsearch::Ext::TAG_METHOD, method)
                     span.set_tag(Datadog::Tracing::Contrib::Elasticsearch::Ext::TAG_URL, url)
                     span.set_tag(Datadog::Tracing::Contrib::Elasticsearch::Ext::TAG_PARAMS, params) if params

--- a/lib/datadog/tracing/contrib/ethon/easy_patch.rb
+++ b/lib/datadog/tracing/contrib/ethon/easy_patch.rb
@@ -129,6 +129,9 @@ module Datadog
               # Set analytics sample rate
               Contrib::Analytics.set_sample_rate(span, analytics_sample_rate) if analytics_enabled?
 
+              # Measure service stats
+              Contrib::Analytics.set_measured(span)
+
               span.set_tag(Tracing::Metadata::Ext::TAG_COMPONENT, Ext::TAG_COMPONENT)
               span.set_tag(Tracing::Metadata::Ext::TAG_OPERATION, Ext::TAG_OPERATION_REQUEST)
 

--- a/lib/datadog/tracing/contrib/excon/middleware.rb
+++ b/lib/datadog/tracing/contrib/excon/middleware.rb
@@ -129,6 +129,9 @@ module Datadog
             # Set analytics sample rate
             Contrib::Analytics.set_sample_rate(span, analytics_sample_rate) if analytics_enabled?
 
+            # Measure service stats
+            Contrib::Analytics.set_measured(span)
+
             span.set_tag(Tracing::Metadata::Ext::HTTP::TAG_URL, datum[:path])
             span.set_tag(Tracing::Metadata::Ext::HTTP::TAG_METHOD, datum[:method].to_s.upcase)
             span.set_tag(Tracing::Metadata::Ext::NET::TAG_TARGET_HOST, datum[:host])

--- a/lib/datadog/tracing/contrib/faraday/middleware.rb
+++ b/lib/datadog/tracing/contrib/faraday/middleware.rb
@@ -57,6 +57,9 @@ module Datadog
               Contrib::Analytics.set_sample_rate(span, options[:analytics_sample_rate])
             end
 
+            # Measure service stats
+            Contrib::Analytics.set_measured(span)
+
             span.set_tag(Tracing::Metadata::Ext::HTTP::TAG_URL, env[:url].path)
             span.set_tag(Tracing::Metadata::Ext::HTTP::TAG_METHOD, env[:method].to_s.upcase)
             span.set_tag(Tracing::Metadata::Ext::NET::TAG_TARGET_HOST, env[:url].host)

--- a/lib/datadog/tracing/contrib/grpc/datadog_interceptor/client.rb
+++ b/lib/datadog/tracing/contrib/grpc/datadog_interceptor/client.rb
@@ -48,6 +48,9 @@ module Datadog
                 span.set_tag(Tracing::Metadata::Ext::TAG_PEER_SERVICE, span.service)
               end
 
+              # Measure service stats
+              Contrib::Analytics.set_measured(span)
+
               host, _port = find_host_port(call)
               span.set_tag(Tracing::Metadata::Ext::TAG_PEER_HOSTNAME, host) if host
 

--- a/lib/datadog/tracing/contrib/http/instrumentation.rb
+++ b/lib/datadog/tracing/contrib/http/instrumentation.rb
@@ -85,6 +85,9 @@ module Datadog
                 span.set_tag(Tracing::Metadata::Ext::TAG_PEER_SERVICE, span.service)
               end
 
+              # Measure service stats
+              Contrib::Analytics.set_measured(span)
+
               span.set_tag(Tracing::Metadata::Ext::TAG_PEER_HOSTNAME, host)
 
               # Set analytics sample rate

--- a/lib/datadog/tracing/contrib/httpclient/instrumentation.rb
+++ b/lib/datadog/tracing/contrib/httpclient/instrumentation.rb
@@ -68,6 +68,9 @@ module Datadog
                 span.set_tag(Tracing::Metadata::Ext::TAG_PEER_SERVICE, span.service)
               end
 
+              # Measure service stats
+              Contrib::Analytics.set_measured(span)
+
               span.set_tag(Tracing::Metadata::Ext::TAG_PEER_HOSTNAME, uri.host)
 
               set_analytics_sample_rate(span, req_options)

--- a/lib/datadog/tracing/contrib/httprb/instrumentation.rb
+++ b/lib/datadog/tracing/contrib/httprb/instrumentation.rb
@@ -78,6 +78,9 @@ module Datadog
                 span.set_tag(Tracing::Metadata::Ext::TAG_PEER_SERVICE, span.service)
               end
 
+              # Measure service stats
+              Contrib::Analytics.set_measured(span)
+
               set_analytics_sample_rate(span, req_options)
             end
 

--- a/lib/datadog/tracing/contrib/mongodb/subscribers.rb
+++ b/lib/datadog/tracing/contrib/mongodb/subscribers.rb
@@ -46,6 +46,9 @@ module Datadog
             # Set analytics sample rate
             Contrib::Analytics.set_sample_rate(span, analytics_sample_rate) if analytics_enabled?
 
+            # Measure service stats
+            Contrib::Analytics.set_measured(span)
+
             # add operation tags; the full query is stored and used as a resource,
             # since it has been quantized and reduced
             span.set_tag(Ext::TAG_DB, query['database'])

--- a/lib/datadog/tracing/contrib/mysql2/instrumentation.rb
+++ b/lib/datadog/tracing/contrib/mysql2/instrumentation.rb
@@ -42,6 +42,9 @@ module Datadog
                 # Set analytics sample rate
                 Contrib::Analytics.set_sample_rate(span, analytics_sample_rate) if analytics_enabled?
 
+                # Measure service stats
+                Contrib::Analytics.set_measured(span)
+
                 span.set_tag(Ext::TAG_DB_NAME, query_options[:database])
                 span.set_tag(Tracing::Metadata::Ext::NET::TAG_TARGET_HOST, query_options[:host])
                 span.set_tag(Tracing::Metadata::Ext::NET::TAG_TARGET_PORT, query_options[:port])

--- a/lib/datadog/tracing/contrib/pg/instrumentation.rb
+++ b/lib/datadog/tracing/contrib/pg/instrumentation.rb
@@ -93,6 +93,9 @@ module Datadog
                 # Set analytics sample rate
                 Contrib::Analytics.set_sample_rate(span, analytics_sample_rate) if analytics_enabled?
 
+                # Measure service stats
+                Contrib::Analytics.set_measured(span)
+
                 if sql
                   propagation_mode = Contrib::Propagation::SqlComment::Mode.new(comment_propagation)
                   Contrib::Propagation::SqlComment.annotate!(span, propagation_mode)

--- a/lib/datadog/tracing/contrib/presto/instrumentation.rb
+++ b/lib/datadog/tracing/contrib/presto/instrumentation.rb
@@ -113,6 +113,9 @@ module Datadog
                 if Contrib::Analytics.enabled?(datadog_configuration[:analytics_enabled])
                   Contrib::Analytics.set_sample_rate(span, datadog_configuration[:analytics_sample_rate])
                 end
+
+                # Measure service stats
+                Contrib::Analytics.set_measured(span)
               end
 
               def set_nilable_tag!(span, key, tag_name)

--- a/lib/datadog/tracing/contrib/redis/tags.rb
+++ b/lib/datadog/tracing/contrib/redis/tags.rb
@@ -28,6 +28,9 @@ module Datadog
               # Set analytics sample rate
               Contrib::Analytics.set_sample_rate(span, analytics_sample_rate) if analytics_enabled?
 
+              # Measure service stats
+              Contrib::Analytics.set_measured(span)
+
               span.set_tag Contrib::Ext::DB::TAG_SYSTEM, Ext::TAG_SYSTEM
 
               span.set_tag Tracing::Metadata::Ext::NET::TAG_TARGET_HOST, client.host

--- a/lib/datadog/tracing/contrib/rest_client/request_patch.rb
+++ b/lib/datadog/tracing/contrib/rest_client/request_patch.rb
@@ -49,6 +49,9 @@ module Datadog
               # Set analytics sample rate
               Contrib::Analytics.set_sample_rate(span, analytics_sample_rate) if analytics_enabled?
 
+              # Measure service stats
+              Contrib::Analytics.set_measured(span)
+
               span.set_tag(Tracing::Metadata::Ext::HTTP::TAG_URL, uri.path)
               span.set_tag(Tracing::Metadata::Ext::HTTP::TAG_METHOD, method.to_s.upcase)
               span.set_tag(Tracing::Metadata::Ext::NET::TAG_TARGET_HOST, uri.host)

--- a/lib/datadog/tracing/contrib/sequel/utils.rb
+++ b/lib/datadog/tracing/contrib/sequel/utils.rb
@@ -65,6 +65,9 @@ module Datadog
 
               # Set analytics sample rate
               Contrib::Analytics.set_sample_rate(span, analytics_sample_rate) if analytics_enabled?
+
+              # Measure service stats
+              Contrib::Analytics.set_measured(span)
             end
 
             private

--- a/lib/datadog/tracing/contrib/sidekiq/client_tracer.rb
+++ b/lib/datadog/tracing/contrib/sidekiq/client_tracer.rb
@@ -42,6 +42,10 @@ module Datadog
               if Contrib::Analytics.enabled?(configuration[:analytics_enabled])
                 Contrib::Analytics.set_sample_rate(span, configuration[:analytics_sample_rate])
               end
+
+              # Measure service stats
+              Contrib::Analytics.set_measured(span)
+
               span.set_tag(Ext::TAG_JOB_ID, job['jid'])
               span.set_tag(Ext::TAG_JOB_QUEUE, job['queue'])
               span.set_tag(Ext::TAG_JOB_WRAPPER, job['class']) if job['wrapped']

--- a/spec/datadog/tracing/contrib/active_record/tracer_spec.rb
+++ b/spec/datadog/tracing/contrib/active_record/tracer_spec.rb
@@ -42,7 +42,7 @@ RSpec.describe 'ActiveRecord instrumentation' do
 
     it_behaves_like 'a peer service span'
 
-    it_behaves_like 'measured span for integration', false
+    it_behaves_like 'measured span for integration', true
 
     it 'calls the instrumentation when is used standalone' do
       expect(span.service).to eq('mysql2')

--- a/spec/datadog/tracing/contrib/dalli/instrumentation_spec.rb
+++ b/spec/datadog/tracing/contrib/dalli/instrumentation_spec.rb
@@ -54,7 +54,7 @@ RSpec.describe 'Dalli instrumentation' do
       let(:analytics_sample_rate_var) { Datadog::Tracing::Contrib::Dalli::Ext::ENV_ANALYTICS_SAMPLE_RATE }
     end
 
-    it_behaves_like 'measured span for integration', false
+    it_behaves_like 'measured span for integration', true
 
     it 'calls instrumentation' do
       expect(spans.size).to eq(1)

--- a/spec/datadog/tracing/contrib/elasticsearch/patcher_spec.rb
+++ b/spec/datadog/tracing/contrib/elasticsearch/patcher_spec.rb
@@ -126,7 +126,7 @@ RSpec.describe Datadog::Tracing::Contrib::Elasticsearch::Patcher do
         let(:analytics_sample_rate_var) { Datadog::Tracing::Contrib::Elasticsearch::Ext::ENV_ANALYTICS_SAMPLE_RATE }
       end
 
-      it_behaves_like 'measured span for integration', false
+      it_behaves_like 'measured span for integration', true
 
       it_behaves_like 'environment service name', 'DD_TRACE_ELASTICSEARCH_SERVICE_NAME'
       it_behaves_like 'schema version span'

--- a/spec/datadog/tracing/contrib/ethon/easy_patch_spec.rb
+++ b/spec/datadog/tracing/contrib/ethon/easy_patch_spec.rb
@@ -108,7 +108,7 @@ RSpec.describe Datadog::Tracing::Contrib::Ethon::EasyPatch do
       let(:analytics_sample_rate_var) { Datadog::Tracing::Contrib::Ethon::Ext::ENV_ANALYTICS_SAMPLE_RATE }
     end
 
-    it_behaves_like 'measured span for integration', false do
+    it_behaves_like 'measured span for integration', true do
       let(:span) { span_op }
       before { subject }
     end

--- a/spec/datadog/tracing/contrib/excon/instrumentation_spec.rb
+++ b/spec/datadog/tracing/contrib/excon/instrumentation_spec.rb
@@ -91,7 +91,7 @@ RSpec.describe Datadog::Tracing::Contrib::Excon::Middleware do
       let(:span) { request_span }
     end
 
-    it_behaves_like 'measured span for integration', false
+    it_behaves_like 'measured span for integration', true
 
     it do
       expect(request_span).to_not be nil

--- a/spec/datadog/tracing/contrib/faraday/middleware_spec.rb
+++ b/spec/datadog/tracing/contrib/faraday/middleware_spec.rb
@@ -155,7 +155,7 @@ RSpec.describe 'Faraday middleware' do
       let(:analytics_sample_rate_var) { Datadog::Tracing::Contrib::Faraday::Ext::ENV_ANALYTICS_SAMPLE_RATE }
     end
 
-    it_behaves_like 'measured span for integration', false
+    it_behaves_like 'measured span for integration', true
 
     it do
       expect(span).to_not be nil

--- a/spec/datadog/tracing/contrib/grpc/datadog_interceptor/client_spec.rb
+++ b/spec/datadog/tracing/contrib/grpc/datadog_interceptor/client_spec.rb
@@ -90,7 +90,7 @@ RSpec.describe 'tracing on the client connection' do
       let(:peer_hostname) { host }
     end
 
-    it_behaves_like 'measured span for integration', false
+    it_behaves_like 'measured span for integration', true
     it_behaves_like 'environment service name', 'DD_TRACE_GRPC_SERVICE_NAME' do
       let(:configuration_options) { {} }
     end

--- a/spec/datadog/tracing/contrib/http/request_spec.rb
+++ b/spec/datadog/tracing/contrib/http/request_spec.rb
@@ -74,7 +74,7 @@ RSpec.describe 'net/http requests' do
         before { response }
       end
 
-      it_behaves_like 'measured span for integration', false do
+      it_behaves_like 'measured span for integration', true do
         before { response }
       end
 

--- a/spec/datadog/tracing/contrib/httpclient/instrumentation_spec.rb
+++ b/spec/datadog/tracing/contrib/httpclient/instrumentation_spec.rb
@@ -138,6 +138,7 @@ RSpec.describe Datadog::Tracing::Contrib::Httpclient::Instrumentation do
             let(:peer_hostname) { host }
           end
 
+          it_behaves_like 'measured span for integration', true
           it_behaves_like 'environment service name', 'DD_TRACE_HTTPCLIENT_SERVICE_NAME'
           it_behaves_like 'schema version span'
 

--- a/spec/datadog/tracing/contrib/httprb/instrumentation_spec.rb
+++ b/spec/datadog/tracing/contrib/httprb/instrumentation_spec.rb
@@ -148,6 +148,7 @@ RSpec.describe Datadog::Tracing::Contrib::Httprb::Instrumentation do
             let(:analytics_sample_rate_var) { Datadog::Tracing::Contrib::Httprb::Ext::ENV_ANALYTICS_SAMPLE_RATE }
           end
 
+          it_behaves_like 'measured span for integration', true
           it_behaves_like 'environment service name', 'DD_TRACE_HTTPRB_SERVICE_NAME'
           it_behaves_like 'schema version span'
         end

--- a/spec/datadog/tracing/contrib/mongodb/client_spec.rb
+++ b/spec/datadog/tracing/contrib/mongodb/client_spec.rb
@@ -166,7 +166,7 @@ RSpec.describe 'Mongo::Client instrumentation' do
         let(:peer_hostname) { host }
       end
 
-      it_behaves_like 'measured span for integration', false
+      it_behaves_like 'measured span for integration', true
       it_behaves_like 'environment service name', 'DD_TRACE_MONGO_SERVICE_NAME'
       it_behaves_like 'schema version span'
     end

--- a/spec/datadog/tracing/contrib/mysql2/patcher_spec.rb
+++ b/spec/datadog/tracing/contrib/mysql2/patcher_spec.rb
@@ -103,7 +103,7 @@ RSpec.describe 'Mysql2::Client patcher' do
           let(:peer_hostname) { host }
         end
 
-        it_behaves_like 'measured span for integration', false do
+        it_behaves_like 'measured span for integration', true do
           before { query }
         end
 

--- a/spec/datadog/tracing/contrib/pg/patcher_spec.rb
+++ b/spec/datadog/tracing/contrib/pg/patcher_spec.rb
@@ -122,7 +122,7 @@ RSpec.describe 'PG::Connection patcher' do
             let(:peer_hostname) { host }
           end
 
-          it_behaves_like 'measured span for integration', false do
+          it_behaves_like 'measured span for integration', true do
             before { exec }
           end
 
@@ -229,7 +229,7 @@ RSpec.describe 'PG::Connection patcher' do
             let(:peer_hostname) { host }
           end
 
-          it_behaves_like 'measured span for integration', false do
+          it_behaves_like 'measured span for integration', true do
             before { exec }
           end
 
@@ -336,7 +336,7 @@ RSpec.describe 'PG::Connection patcher' do
             let(:peer_hostname) { host }
           end
 
-          it_behaves_like 'measured span for integration', false do
+          it_behaves_like 'measured span for integration', true do
             before { exec_params }
           end
 
@@ -445,7 +445,7 @@ RSpec.describe 'PG::Connection patcher' do
             let(:peer_hostname) { host }
           end
 
-          it_behaves_like 'measured span for integration', false do
+          it_behaves_like 'measured span for integration', true do
             before { exec_params }
           end
 
@@ -553,7 +553,7 @@ RSpec.describe 'PG::Connection patcher' do
             let(:peer_hostname) { host }
           end
 
-          it_behaves_like 'measured span for integration', false do
+          it_behaves_like 'measured span for integration', true do
             before { exec_prepared }
           end
 
@@ -653,7 +653,7 @@ RSpec.describe 'PG::Connection patcher' do
             let(:peer_hostname) { host }
           end
 
-          it_behaves_like 'measured span for integration', false do
+          it_behaves_like 'measured span for integration', true do
             before { exec_prepared }
           end
 
@@ -763,7 +763,7 @@ RSpec.describe 'PG::Connection patcher' do
             let(:peer_hostname) { host }
           end
 
-          it_behaves_like 'measured span for integration', false do
+          it_behaves_like 'measured span for integration', true do
             before { async_exec }
           end
 
@@ -871,7 +871,7 @@ RSpec.describe 'PG::Connection patcher' do
             let(:peer_hostname) { host }
           end
 
-          it_behaves_like 'measured span for integration', false do
+          it_behaves_like 'measured span for integration', true do
             before { async_exec }
           end
 
@@ -987,7 +987,7 @@ RSpec.describe 'PG::Connection patcher' do
             let(:peer_hostname) { host }
           end
 
-          it_behaves_like 'measured span for integration', false do
+          it_behaves_like 'measured span for integration', true do
             before { async_exec_params }
           end
 
@@ -1095,7 +1095,7 @@ RSpec.describe 'PG::Connection patcher' do
             let(:peer_hostname) { host }
           end
 
-          it_behaves_like 'measured span for integration', false do
+          it_behaves_like 'measured span for integration', true do
             before { async_exec_params }
           end
 
@@ -1202,7 +1202,7 @@ RSpec.describe 'PG::Connection patcher' do
             let(:peer_hostname) { host }
           end
 
-          it_behaves_like 'measured span for integration', false do
+          it_behaves_like 'measured span for integration', true do
             before { async_exec_prepared }
           end
 
@@ -1302,7 +1302,7 @@ RSpec.describe 'PG::Connection patcher' do
             let(:peer_hostname) { host }
           end
 
-          it_behaves_like 'measured span for integration', false do
+          it_behaves_like 'measured span for integration', true do
             before { async_exec_prepared }
           end
 
@@ -1418,7 +1418,7 @@ RSpec.describe 'PG::Connection patcher' do
             let(:peer_hostname) { host }
           end
 
-          it_behaves_like 'measured span for integration', false do
+          it_behaves_like 'measured span for integration', true do
             before { sync_exec }
           end
 
@@ -1524,7 +1524,7 @@ RSpec.describe 'PG::Connection patcher' do
             let(:peer_hostname) { host }
           end
 
-          it_behaves_like 'measured span for integration', false do
+          it_behaves_like 'measured span for integration', true do
             before { sync_exec }
           end
 
@@ -1632,7 +1632,7 @@ RSpec.describe 'PG::Connection patcher' do
             let(:peer_hostname) { host }
           end
 
-          it_behaves_like 'measured span for integration', false do
+          it_behaves_like 'measured span for integration', true do
             before { sync_exec_params }
           end
 
@@ -1739,7 +1739,7 @@ RSpec.describe 'PG::Connection patcher' do
             let(:peer_hostname) { host }
           end
 
-          it_behaves_like 'measured span for integration', false do
+          it_behaves_like 'measured span for integration', true do
             before { sync_exec_params }
           end
 
@@ -1845,7 +1845,7 @@ RSpec.describe 'PG::Connection patcher' do
             let(:peer_hostname) { host }
           end
 
-          it_behaves_like 'measured span for integration', false do
+          it_behaves_like 'measured span for integration', true do
             before { sync_exec_prepared }
           end
 
@@ -1944,7 +1944,7 @@ RSpec.describe 'PG::Connection patcher' do
             let(:peer_hostname) { host }
           end
 
-          it_behaves_like 'measured span for integration', false do
+          it_behaves_like 'measured span for integration', true do
             before { sync_exec_prepared }
           end
 

--- a/spec/datadog/tracing/contrib/presto/client_spec.rb
+++ b/spec/datadog/tracing/contrib/presto/client_spec.rb
@@ -224,7 +224,7 @@ RSpec.describe 'Presto::Client instrumentation' do
         let(:analytics_sample_rate_var) { Datadog::Tracing::Contrib::Presto::Ext::ENV_ANALYTICS_SAMPLE_RATE }
       end
 
-      it_behaves_like 'measured span for integration', false
+      it_behaves_like 'measured span for integration', true
 
       it_behaves_like 'a peer service span' do
         let(:peer_hostname) { host }

--- a/spec/datadog/tracing/contrib/redis/shared_examples.rb
+++ b/spec/datadog/tracing/contrib/redis/shared_examples.rb
@@ -39,7 +39,7 @@ RSpec.shared_examples_for 'redis instrumentation' do |options = {}|
       end
 
       it_behaves_like 'a redis span with common tags'
-      it_behaves_like 'measured span for integration', false
+      it_behaves_like 'measured span for integration', true
       it_behaves_like 'a peer service span' do
         let(:peer_hostname) { host }
       end
@@ -65,7 +65,7 @@ RSpec.shared_examples_for 'redis instrumentation' do |options = {}|
       end
 
       it_behaves_like 'a redis span with common tags'
-      it_behaves_like 'measured span for integration', false
+      it_behaves_like 'measured span for integration', true
       it_behaves_like 'a peer service span' do
         let(:peer_hostname) { host }
       end
@@ -87,7 +87,7 @@ RSpec.shared_examples_for 'redis instrumentation' do |options = {}|
       let(:span) { spans[-1] }
 
       it_behaves_like 'a redis span with common tags'
-      it_behaves_like 'measured span for integration', false
+      it_behaves_like 'measured span for integration', true
       it_behaves_like 'a peer service span' do
         let(:peer_hostname) { host }
       end
@@ -152,7 +152,7 @@ RSpec.shared_examples_for 'redis instrumentation' do |options = {}|
       end
 
       it_behaves_like 'a redis span with common tags'
-      it_behaves_like 'measured span for integration', false
+      it_behaves_like 'measured span for integration', true
       it_behaves_like 'a peer service span' do
         let(:peer_hostname) { host }
       end
@@ -196,7 +196,7 @@ RSpec.shared_examples_for 'redis instrumentation' do |options = {}|
       end
 
       it_behaves_like 'a redis span with common tags'
-      it_behaves_like 'measured span for integration', false
+      it_behaves_like 'measured span for integration', true
       it_behaves_like 'a peer service span' do
         let(:peer_hostname) { host }
       end
@@ -241,7 +241,7 @@ RSpec.shared_examples_for 'redis instrumentation' do |options = {}|
       end
 
       it_behaves_like 'a redis span with common tags'
-      it_behaves_like 'measured span for integration', false
+      it_behaves_like 'measured span for integration', true
       it_behaves_like 'a peer service span' do
         let(:peer_hostname) { host }
       end
@@ -269,7 +269,7 @@ RSpec.shared_examples_for 'redis instrumentation' do |options = {}|
       end
 
       it_behaves_like 'a redis span with common tags'
-      it_behaves_like 'measured span for integration', false
+      it_behaves_like 'measured span for integration', true
       it_behaves_like 'a peer service span' do
         let(:peer_hostname) { host }
       end
@@ -300,7 +300,7 @@ RSpec.shared_examples_for 'redis instrumentation' do |options = {}|
       end
 
       it_behaves_like 'a redis span with common tags'
-      it_behaves_like 'measured span for integration', false
+      it_behaves_like 'measured span for integration', true
       it_behaves_like 'a peer service span' do
         let(:peer_hostname) { host }
       end
@@ -354,7 +354,7 @@ RSpec.shared_examples_for 'an authenticated redis instrumentation' do |options =
 
       it_behaves_like 'an authentication span'
       it_behaves_like 'a redis span with common tags'
-      it_behaves_like 'measured span for integration', false
+      it_behaves_like 'measured span for integration', true
       it_behaves_like 'a peer service span' do
         let(:peer_hostname) { host }
       end
@@ -378,7 +378,7 @@ RSpec.shared_examples_for 'an authenticated redis instrumentation' do |options =
 
       it_behaves_like 'an authentication span'
       it_behaves_like 'a redis span with common tags'
-      it_behaves_like 'measured span for integration', false
+      it_behaves_like 'measured span for integration', true
       it_behaves_like 'a peer service span' do
         let(:peer_hostname) { host }
       end
@@ -403,7 +403,7 @@ RSpec.shared_examples_for 'an authenticated redis instrumentation' do |options =
 
       it_behaves_like 'an authentication span'
       it_behaves_like 'a redis span with common tags'
-      it_behaves_like 'measured span for integration', false
+      it_behaves_like 'measured span for integration', true
       it_behaves_like 'a peer service span' do
         let(:peer_hostname) { host }
       end

--- a/spec/datadog/tracing/contrib/rest_client/request_patch_spec.rb
+++ b/spec/datadog/tracing/contrib/rest_client/request_patch_spec.rb
@@ -111,7 +111,7 @@ RSpec.describe Datadog::Tracing::Contrib::RestClient::RequestPatch do
             let(:peer_hostname) { host }
           end
 
-          it_behaves_like 'measured span for integration', false
+          it_behaves_like 'measured span for integration', true
         end
 
         context 'response has internal server error status' do

--- a/spec/datadog/tracing/contrib/sequel/instrumentation_spec.rb
+++ b/spec/datadog/tracing/contrib/sequel/instrumentation_spec.rb
@@ -88,7 +88,7 @@ RSpec.describe 'Sequel instrumentation' do
           end
         end
 
-        it_behaves_like 'measured span for integration', false
+        it_behaves_like 'measured span for integration', true
         it_behaves_like 'schema version span'
       end
 
@@ -189,7 +189,7 @@ RSpec.describe 'Sequel instrumentation' do
         let(:analytics_sample_rate_var) { Datadog::Tracing::Contrib::Sequel::Ext::ENV_ANALYTICS_SAMPLE_RATE }
       end
 
-      it_behaves_like 'measured span for integration', false do
+      it_behaves_like 'measured span for integration', true do
         let(:span) { spans[2..5].sample }
       end
     end

--- a/spec/datadog/tracing/contrib/sidekiq/client_tracer_spec.rb
+++ b/spec/datadog/tracing/contrib/sidekiq/client_tracer_spec.rb
@@ -27,7 +27,7 @@ RSpec.describe 'ClientTracerTest' do
     expect(span.get_tag('sidekiq.job.queue')).to eq('default')
     expect(span.status).to eq(0)
     expect(span).to be_root_span
-    expect(span.get_metric('_dd.measured')).to be_nil
+    expect(span.get_metric('_dd.measured')).to not_be nil
     expect(span.get_tag(Datadog::Tracing::Metadata::Ext::TAG_COMPONENT)).to eq('sidekiq')
     expect(span.get_tag(Datadog::Tracing::Metadata::Ext::TAG_OPERATION)).to eq('push')
     expect(span.get_tag('span.kind')).to eq('producer')
@@ -53,7 +53,7 @@ RSpec.describe 'ClientTracerTest' do
       expect(child_span.get_tag('sidekiq.job.queue')).to eq('default')
       expect(child_span.status).to eq(0)
       expect(child_span.parent_id).to eq(parent_span.span_id)
-      expect(child_span.get_metric('_dd.measured')).to be_nil
+      expect(child_span.get_metric('_dd.measured')).to not_be nil
       expect(child_span.get_tag('span.kind')).to eq('producer')
       expect(child_span.get_tag('messaging.system')).to eq('sidekiq')
     end

--- a/spec/datadog/tracing/contrib/sidekiq/client_tracer_spec.rb
+++ b/spec/datadog/tracing/contrib/sidekiq/client_tracer_spec.rb
@@ -27,7 +27,7 @@ RSpec.describe 'ClientTracerTest' do
     expect(span.get_tag('sidekiq.job.queue')).to eq('default')
     expect(span.status).to eq(0)
     expect(span).to be_root_span
-    expect(span.get_metric('_dd.measured')).to not_be nil
+    expect(span.get_metric('_dd.measured')).to eq(1.0)
     expect(span.get_tag(Datadog::Tracing::Metadata::Ext::TAG_COMPONENT)).to eq('sidekiq')
     expect(span.get_tag(Datadog::Tracing::Metadata::Ext::TAG_OPERATION)).to eq('push')
     expect(span.get_tag('span.kind')).to eq('producer')
@@ -53,7 +53,7 @@ RSpec.describe 'ClientTracerTest' do
       expect(child_span.get_tag('sidekiq.job.queue')).to eq('default')
       expect(child_span.status).to eq(0)
       expect(child_span.parent_id).to eq(parent_span.span_id)
-      expect(child_span.get_metric('_dd.measured')).to not_be nil
+      expect(child_span.get_metric('_dd.measured')).to eq(1.0)
       expect(child_span.get_tag('span.kind')).to eq('producer')
       expect(child_span.get_tag('messaging.system')).to eq('sidekiq')
     end


### PR DESCRIPTION
Adds `_dd.measured` tag for client/producer spans as part of a greater intiative for improved future stats collection across all tracers.

For Ruby, this change should not impact anything in terms of customer visibility as most client/producer spans were top level spans already. However, this addition is necessary to explicitly define measured spans as it covers the changes from previous PRs that added the new `service_name` default values which removed the top_level status from these spans.