### PR TITLE
[APPSEC-9343] [WIP] Initial suggestion for allowing appsec monitoring nested apps

### DIFF
--- a/lib/datadog/appsec/processor.rb
+++ b/lib/datadog/appsec/processor.rb
@@ -64,9 +64,6 @@ module Datadog
         end
       end
 
-      class NoActiveContextError < StandardError; end
-      class AlreadyActiveContextError < StandardError; end
-
       attr_reader :ruleset_info, :addresses
 
       def initialize(ruleset:)
@@ -88,20 +85,13 @@ module Datadog
       end
 
       def activate_context
-        existing_active_context = Processor.active_context
-        raise AlreadyActiveContextError if existing_active_context
-
         context = new_context
         Processor.send(:active_context=, context)
-        context
-      end
 
-      def deactivate_context
-        context = Processor.active_context
-        raise NoActiveContextError unless context
-
-        Processor.send(:reset_active_context)
+        yield context
+      ensure
         context.finalize
+        Processor.send(:reset_active_context)
       end
 
       def finalize

--- a/sig/datadog/appsec/processor.rbs
+++ b/sig/datadog/appsec/processor.rbs
@@ -26,12 +26,6 @@ module Datadog
       def self.active_context=: (untyped context) -> untyped
       def self.reset_active_context: () -> untyped
 
-      class NoActiveContextError < StandardError
-      end
-
-      class AlreadyActiveContextError < StandardError
-      end
-
       attr_reader ruleset_info: untyped
       attr_reader addresses: untyped
 
@@ -42,8 +36,7 @@ module Datadog
       def initialize: (ruleset: ::Hash[untyped, untyped]) -> void
       def ready?: () -> bool
       def new_context: () -> Context
-      def activate_context: () -> Context
-      def deactivate_context: () -> void
+      def activate_context: () { (untyped) -> Context } -> void
       def finalize: () -> void
 
       attr_reader handle: untyped

--- a/spec/datadog/appsec/processor_spec.rb
+++ b/spec/datadog/appsec/processor_spec.rb
@@ -340,37 +340,14 @@ RSpec.describe Datadog::AppSec::Processor do
   end
 
   describe '#active_context' do
-    it 'creates a new context and store in the class .active_context variable' do
-      context = described_class.new(ruleset: ruleset).activate_context
-      expect(context).to eq(described_class.active_context)
-    end
-
-    context 'when an active context already exists' do
-      it 'raises AlreadyActiveContextError' do
-        described_class.new(ruleset: ruleset).activate_context
-        expect do
-          described_class.new(ruleset: ruleset).activate_context
-        end.to raise_error(described_class::AlreadyActiveContextError)
-      end
-    end
-  end
-
-  describe '#deactivate_context' do
-    it 'finalize the active context and reset the class .active_context variable' do
-      handler = described_class.new(ruleset: ruleset)
-      context = handler.activate_context
-
-      expect(context).to receive(:finalize)
-      handler.deactivate_context
+    it 'creates a new context and store in the class .active_context variable for the duration of the block' do
       expect(described_class.active_context).to be_nil
-    end
 
-    context 'without an active_context' do
-      it 'raises NoActiveContextError' do
-        expect do
-          described_class.new(ruleset: ruleset).deactivate_context
-        end.to raise_error(described_class::NoActiveContextError)
+      described_class.new(ruleset: ruleset).activate_context do |context|
+        expect(context).to eq(described_class.active_context)
       end
+
+      expect(described_class.active_context).to be_nil
     end
   end
 end


### PR DESCRIPTION
<!--
Check out the
https://github.com/DataDog/dd-trace-rb/blob/master/docs/DevelopmentGuide.md
for guidance on how to set up your development environment,
run the test suite, write new integrations, and more.
-->

**What does this PR do?**
<!-- A brief description of the change being made with this pull request. -->

This is an initial suggestion for fixing https://github.com/DataDog/dd-trace-rb/issues/2722

I tested the code against a local Rails app that mounts a Sinatra App.

The configuration on the Rails app looks like this:

```ruby
# config/initializers/datadog.rb
Datadog.configure do |c|
  c.tracing.instrument :rails, service_name: 'gustavo-nested-apps'
  c.appsec.enabled = true
  c.appsec.instrument :rails
  c.appsec.instrument :sinatra
end
```

```ruby
# config/routes.rb

require_relative '../app/rack_apps/my_sinatra_app'

Rails.application.routes.draw do
  root "home#index"
  mount RackApps::MySinatraApp.new => '/api'
end
```

We do not get a `Datadog::AppSec::Processor::AlreadyActiveContextError` with the suggested changes.

Because:
- We have removed that particular error from the codebase 
- We changed the API of `Processor#activate_context`. The new API, rather than checking for an active context creates a new context every time we call the method, store it on the globally accessible `Thread.current[:datadog_current_waf_context]`, and make sure once the block has executed to finalize the context and reset ``Thread.current[:datadog_current_waf_context]`

This new API ensures that each request gets its new context and does not break the ability to access the active context globally outside of a rack context. Such as for `identity.set_user` appsec event within the [Monitor's watcher](https://github.com/DataDog/dd-trace-rb/blob/013813d0c5b9ceb5809beb3b9c4225be907b03f5/lib/datadog/appsec/monitor/gateway/watcher.rb#L25) 

**Motivation**
<!-- What inspired you to submit this pull request? -->

**Additional Notes**
<!-- Anything else we should know when reviewing? -->

I added a basic integration test to validate that things work as expected. If we like the approach I would improve the test coverage for nested apps.

**How to test the change?**
<!--
Describe here how the change can be validated.
You are strongly encouraged to provide automated tests for this PR (unit or integration).
If this change cannot be feasibly tested, please explain why,
unless the change does not modify code (e.g. only modifies docs, comments).
-->
