### PR TITLE
[APPSEC-9343] Appsec support nested apps

### DIFF
--- a/lib/datadog/appsec/contrib/rack/request_middleware.rb
+++ b/lib/datadog/appsec/contrib/rack/request_middleware.rb
@@ -33,19 +33,9 @@ module Datadog
             ready = false
             context = nil
 
-            # If a customer has mounted a nested Rack app within their main app
-            # and instrumented boths apps:
-            #
-            # Datadog.configure do |c|
-            #   c.appsec.enabled = true
-            #   c.appsec.instrument :rails
-            #   c.appsec.instrument :sinatra
-            # end
-            #
-            # We have to avoid calling processor.activate_context twice.
-            # To achive that we check the value of env['datadog.waf.context']
-            # If the waf context is part of the env, it means that we are on the nested app
-            # context. In that case we need process the request without any new appsec related code.
+            # For a given request, keep using the first Rack stack context for
+            # nested apps. Don't set `context` local variable so that on popping
+            # out of this nested stack we don't finalize the parent's context
             return @app.call(env) if env['datadog.waf.context']
 
             Datadog::AppSec.reconfigure_lock do


### PR DESCRIPTION
<!--
Check out the
https://github.com/DataDog/dd-trace-rb/blob/master/docs/DevelopmentGuide.md
for guidance on how to set up your development environment,
run the test suite, write new integrations, and more.
-->

**What does this PR do?**
<!-- A brief description of the change being made with this pull request. -->

Fix https://github.com/DataDog/dd-trace-rb/issues/2722

I tested the code against a local Rails app that mounts a Sinatra App.

The configuration on the Rails app looks like this:

```ruby
# config/initializers/datadog.rb
Datadog.configure do |c|
  c.tracing.instrument :rails, service_name: 'gustavo-nested-apps'
  c.appsec.enabled = true
  c.appsec.instrument :rails
  c.appsec.instrument :sinatra
end
```

```ruby
# config/routes.rb

require_relative '../app/rack_apps/my_sinatra_app'

Rails.application.routes.draw do
  root "home#index"
  mount RackApps::MySinatraApp.new => '/api'
end
```

To ensure we are not re-executing the request middleware code multiple times with the context of nested apps, we need to make sure we bail out at the proper time. 

That removes the 🐛 that some customers are experiencing, which raises `Datadog::AppSec::Processor::AlreadyActiveContextError`

Also, by making sure we continue the execution of the request without adding any extra calls to the WAF, we make sure to only calls the WAF the right amount of times 😄 

**Motivation**
<!-- What inspired you to submit this pull request? -->

**Additional Notes**
<!-- Anything else we should know when reviewing? -->

I added a basic integration test to validate that things work as expected.

**How to test the change?**
<!--
Describe here how the change can be validated.
You are strongly encouraged to provide automated tests for this PR (unit or integration).
If this change cannot be feasibly tested, please explain why,
unless the change does not modify code (e.g. only modifies docs, comments).
-->
