### PR TITLE
make sure to not execute to many request for appsec integration specs

### DIFF
--- a/spec/datadog/appsec/contrib/rack/integration_test_spec.rb
+++ b/spec/datadog/appsec/contrib/rack/integration_test_spec.rb
@@ -173,87 +173,111 @@ RSpec.describe 'Rack integration tests' do
     let(:client_ip) { remote_addr }
 
     shared_examples 'a GET 200 span' do
-      it { expect(span.get_tag('http.method')).to eq('GET') }
-      it { expect(span.get_tag('http.status_code')).to eq('200') }
-      it { expect(span.status).to eq(0) }
+      it do
+        expect(span.get_tag('http.method')).to eq('GET')
+        expect(span.get_tag('http.status_code')).to eq('200')
+        expect(span.status).to eq(0)
+      end
 
       context 'with appsec disabled' do
         let(:appsec_enabled) { false }
 
-        it { expect(span.get_tag('http.method')).to eq('GET') }
-        it { expect(span.get_tag('http.status_code')).to eq('200') }
-        it { expect(span.status).to eq(0) }
+        it do
+          expect(span.get_tag('http.method')).to eq('GET')
+          expect(span.get_tag('http.status_code')).to eq('200')
+          expect(span.status).to eq(0)
+        end
       end
     end
 
     shared_examples 'a GET 403 span' do
-      it { expect(span.get_tag('http.method')).to eq('GET') }
-      it { expect(span.get_tag('http.status_code')).to eq('403') }
-      it { expect(span.status).to eq(0) }
+      it do
+        expect(span.get_tag('http.method')).to eq('GET')
+        expect(span.get_tag('http.status_code')).to eq('403')
+        expect(span.status).to eq(0)
+      end
 
       context 'with appsec disabled' do
         let(:appsec_enabled) { false }
 
-        it { expect(span.get_tag('http.method')).to eq('GET') }
-        it { expect(span.get_tag('http.status_code')).to eq('200') }
-        it { expect(span.status).to eq(0) }
+        it do
+          expect(span.get_tag('http.method')).to eq('GET')
+          expect(span.get_tag('http.status_code')).to eq('200')
+          expect(span.status).to eq(0)
+        end
       end
     end
 
     shared_examples 'a GET 404 span' do
-      it { expect(span.get_tag('http.method')).to eq('GET') }
-      it { expect(span.get_tag('http.status_code')).to eq('404') }
-      it { expect(span.status).to eq(0) }
+      it do
+        expect(span.get_tag('http.method')).to eq('GET')
+        expect(span.get_tag('http.status_code')).to eq('404')
+        expect(span.status).to eq(0)
+      end
 
       context 'with appsec disabled' do
         let(:appsec_enabled) { false }
 
-        it { expect(span.get_tag('http.method')).to eq('GET') }
-        it { expect(span.get_tag('http.status_code')).to eq('404') }
-        it { expect(span.status).to eq(0) }
+        it do
+          expect(span.get_tag('http.method')).to eq('GET')
+          expect(span.get_tag('http.status_code')).to eq('404')
+          expect(span.status).to eq(0)
+        end
       end
     end
 
     shared_examples 'a POST 200 span' do
-      it { expect(span.get_tag('http.method')).to eq('POST') }
-      it { expect(span.get_tag('http.status_code')).to eq('200') }
-      it { expect(span.status).to eq(0) }
+      it do
+        expect(span.get_tag('http.method')).to eq('POST')
+        expect(span.get_tag('http.status_code')).to eq('200')
+        expect(span.status).to eq(0)
+      end
 
       context 'with appsec disabled' do
         let(:appsec_enabled) { false }
 
-        it { expect(span.get_tag('http.method')).to eq('POST') }
-        it { expect(span.get_tag('http.status_code')).to eq('200') }
-        it { expect(span.status).to eq(0) }
+        it do
+          expect(span.get_tag('http.method')).to eq('POST')
+          expect(span.get_tag('http.status_code')).to eq('200')
+          expect(span.status).to eq(0)
+        end
       end
     end
 
     shared_examples 'a POST 403 span' do
-      it { expect(span.get_tag('http.method')).to eq('POST') }
-      it { expect(span.get_tag('http.status_code')).to eq('403') }
-      it { expect(span.status).to eq(0) }
+      it do
+        expect(span.get_tag('http.method')).to eq('POST')
+        expect(span.get_tag('http.status_code')).to eq('403')
+        expect(span.status).to eq(0)
+      end
 
       context 'with appsec disabled' do
         let(:appsec_enabled) { false }
 
-        it { expect(span.get_tag('http.method')).to eq('POST') }
-        it { expect(span.get_tag('http.status_code')).to eq('200') }
-        it { expect(span.status).to eq(0) }
+        it do
+          expect(span.get_tag('http.method')).to eq('POST')
+          expect(span.get_tag('http.status_code')).to eq('200')
+          expect(span.status).to eq(0)
+        end
       end
     end
 
     shared_examples 'a trace without AppSec tags' do
-      it { expect(trace.send(:metrics)['_dd.appsec.enabled']).to be_nil }
-      it { expect(trace.send(:meta)['_dd.runtime_family']).to be_nil }
-      it { expect(trace.send(:meta)['_dd.appsec.waf.version']).to be_nil }
-      it { expect(span.send(:meta)['http.client_ip']).to eq nil }
+      it do
+        expect(trace.send(:metrics)['_dd.appsec.enabled']).to be_nil
+        expect(trace.send(:meta)['_dd.runtime_family']).to be_nil
+        expect(trace.send(:meta)['_dd.appsec.waf.version']).to be_nil
+        expect(span.send(:meta)['http.client_ip']).to eq nil
+      end
     end
 
     shared_examples 'a trace with AppSec tags' do
-      it { expect(trace.send(:metrics)['_dd.appsec.enabled']).to eq(1.0) }
-      it { expect(trace.send(:meta)['_dd.runtime_family']).to eq('ruby') }
-      it { expect(trace.send(:meta)['_dd.appsec.waf.version']).to match(/^\d+\.\d+\.\d+/) }
-      it { expect(span.send(:meta)['http.client_ip']).to eq client_ip }
+      it do
+        expect(trace.send(:metrics)['_dd.appsec.enabled']).to eq(1.0)
+        expect(trace.send(:meta)['_dd.runtime_family']).to eq('ruby')
+        expect(trace.send(:meta)['_dd.appsec.waf.version']).to match(/^\d+\.\d+\.\d+/)
+        expect(span.send(:meta)['http.client_ip']).to eq client_ip
+      end
 
       context 'with appsec disabled' do
         let(:appsec_enabled) { false }
@@ -263,13 +287,17 @@ RSpec.describe 'Rack integration tests' do
     end
 
     shared_examples 'a trace without AppSec events' do
-      it { expect(spans.select { |s| s.get_tag('appsec.event') }).to be_empty }
-      it { expect(trace.send(:meta)['_dd.appsec.triggers']).to be_nil }
+      it do
+        expect(spans.select { |s| s.get_tag('appsec.event') }).to be_empty
+        expect(trace.send(:meta)['_dd.appsec.triggers']).to be_nil
+      end
     end
 
     shared_examples 'a trace with AppSec events' do
-      it { expect(spans.select { |s| s.get_tag('appsec.event') }).to_not be_empty }
-      it { expect(trace.send(:meta)['_dd.appsec.json']).to be_a String }
+      it do
+        expect(spans.select { |s| s.get_tag('appsec.event') }).to_not be_empty
+        expect(trace.send(:meta)['_dd.appsec.json']).to be_a String
+      end
 
       context 'with appsec disabled' do
         let(:appsec_enabled) { false }

--- a/spec/datadog/appsec/contrib/rails/integration_test_spec.rb
+++ b/spec/datadog/appsec/contrib/rails/integration_test_spec.rb
@@ -146,87 +146,111 @@ RSpec.describe 'Rails integration tests' do
     let(:span) { rack_span }
 
     shared_examples 'a GET 200 span' do
-      it { expect(span.get_tag('http.method')).to eq('GET') }
-      it { expect(span.get_tag('http.status_code')).to eq('200') }
-      it { expect(span.status).to eq(0) }
+      it do
+        expect(span.get_tag('http.method')).to eq('GET')
+        expect(span.get_tag('http.status_code')).to eq('200')
+        expect(span.status).to eq(0)
+      end
 
       context 'with appsec disabled' do
         let(:appsec_enabled) { false }
 
-        it { expect(span.get_tag('http.method')).to eq('GET') }
-        it { expect(span.get_tag('http.status_code')).to eq('200') }
-        it { expect(span.status).to eq(0) }
+        it do
+          expect(span.get_tag('http.method')).to eq('GET')
+          expect(span.get_tag('http.status_code')).to eq('200')
+          expect(span.status).to eq(0)
+        end
       end
     end
 
     shared_examples 'a GET 403 span' do
-      it { expect(span.get_tag('http.method')).to eq('GET') }
-      it { expect(span.get_tag('http.status_code')).to eq('403') }
-      it { expect(span.status).to eq(0) }
+      it do
+        expect(span.get_tag('http.method')).to eq('GET')
+        expect(span.get_tag('http.status_code')).to eq('403')
+        expect(span.status).to eq(0)
+      end
 
       context 'with appsec disabled' do
         let(:appsec_enabled) { false }
 
-        it { expect(span.get_tag('http.method')).to eq('GET') }
-        it { expect(span.get_tag('http.status_code')).to eq('200') }
-        it { expect(span.status).to eq(0) }
+        it do
+          expect(span.get_tag('http.method')).to eq('GET')
+          expect(span.get_tag('http.status_code')).to eq('200')
+          expect(span.status).to eq(0)
+        end
       end
     end
 
     shared_examples 'a GET 404 span' do
-      it { expect(span.get_tag('http.method')).to eq('GET') }
-      it { expect(span.get_tag('http.status_code')).to eq('404') }
-      it { expect(span.status).to eq(0) }
+      it do
+        expect(span.get_tag('http.method')).to eq('GET')
+        expect(span.get_tag('http.status_code')).to eq('404')
+        expect(span.status).to eq(0)
+      end
 
       context 'with appsec disabled' do
         let(:appsec_enabled) { false }
 
-        it { expect(span.get_tag('http.method')).to eq('GET') }
-        it { expect(span.get_tag('http.status_code')).to eq('404') }
-        it { expect(span.status).to eq(0) }
+        it do
+          expect(span.get_tag('http.method')).to eq('GET')
+          expect(span.get_tag('http.status_code')).to eq('404')
+          expect(span.status).to eq(0)
+        end
       end
     end
 
     shared_examples 'a POST 200 span' do
-      it { expect(span.get_tag('http.method')).to eq('POST') }
-      it { expect(span.get_tag('http.status_code')).to eq('200') }
-      it { expect(span.status).to eq(0) }
+      it do
+        expect(span.get_tag('http.method')).to eq('POST')
+        expect(span.get_tag('http.status_code')).to eq('200')
+        expect(span.status).to eq(0)
+      end
 
       context 'with appsec disabled' do
         let(:appsec_enabled) { false }
 
-        it { expect(span.get_tag('http.method')).to eq('POST') }
-        it { expect(span.get_tag('http.status_code')).to eq('200') }
-        it { expect(span.status).to eq(0) }
+        it do
+          expect(span.get_tag('http.method')).to eq('POST')
+          expect(span.get_tag('http.status_code')).to eq('200')
+          expect(span.status).to eq(0)
+        end
       end
     end
 
     shared_examples 'a POST 403 span' do
-      it { expect(span.get_tag('http.method')).to eq('POST') }
-      it { expect(span.get_tag('http.status_code')).to eq('403') }
-      it { expect(span.status).to eq(0) }
+      it do
+        expect(span.get_tag('http.method')).to eq('POST')
+        expect(span.get_tag('http.status_code')).to eq('403')
+        expect(span.status).to eq(0)
+      end
 
       context 'with appsec disabled' do
         let(:appsec_enabled) { false }
 
-        it { expect(span.get_tag('http.method')).to eq('POST') }
-        it { expect(span.get_tag('http.status_code')).to eq('200') }
-        it { expect(span.status).to eq(0) }
+        it do
+          expect(span.get_tag('http.method')).to eq('POST')
+          expect(span.get_tag('http.status_code')).to eq('200')
+          expect(span.status).to eq(0)
+        end
       end
     end
 
     shared_examples 'a trace without AppSec tags' do
-      it { expect(trace.send(:metrics)['_dd.appsec.enabled']).to be_nil }
-      it { expect(trace.send(:meta)['_dd.runtime_family']).to be_nil }
-      it { expect(trace.send(:meta)['_dd.appsec.waf.version']).to be_nil }
-      it { expect(span.send(:meta)['http.client_ip']).to eq nil }
+      it do
+        expect(trace.send(:metrics)['_dd.appsec.enabled']).to be_nil
+        expect(trace.send(:meta)['_dd.runtime_family']).to be_nil
+        expect(trace.send(:meta)['_dd.appsec.waf.version']).to be_nil
+        expect(span.send(:meta)['http.client_ip']).to eq nil
+      end
     end
 
     shared_examples 'a trace with AppSec tags' do
-      it { expect(trace.send(:metrics)['_dd.appsec.enabled']).to eq(1.0) }
-      it { expect(trace.send(:meta)['_dd.runtime_family']).to eq('ruby') }
-      it { expect(trace.send(:meta)['_dd.appsec.waf.version']).to match(/^\d+\.\d+\.\d+/) }
-      it { expect(span.send(:meta)['http.client_ip']).to eq client_ip }
+      it do
+        expect(trace.send(:metrics)['_dd.appsec.enabled']).to eq(1.0)
+        expect(trace.send(:meta)['_dd.runtime_family']).to eq('ruby')
+        expect(trace.send(:meta)['_dd.appsec.waf.version']).to match(/^\d+\.\d+\.\d+/)
+        expect(span.send(:meta)['http.client_ip']).to eq client_ip
+      end
 
       context 'with appsec disabled' do
         let(:appsec_enabled) { false }
@@ -236,13 +260,17 @@ RSpec.describe 'Rails integration tests' do
     end
 
     shared_examples 'a trace without AppSec events' do
-      it { expect(spans.select { |s| s.get_tag('appsec.event') }).to be_empty }
-      it { expect(trace.send(:meta)['_dd.appsec.triggers']).to be_nil }
+      it do
+        expect(spans.select { |s| s.get_tag('appsec.event') }).to be_empty
+        expect(trace.send(:meta)['_dd.appsec.triggers']).to be_nil
+      end
     end
 
     shared_examples 'a trace with AppSec events' do
-      it { expect(spans.select { |s| s.get_tag('appsec.event') }).to_not be_empty }
-      it { expect(trace.send(:meta)['_dd.appsec.json']).to be_a String }
+      it do
+        expect(spans.select { |s| s.get_tag('appsec.event') }).to_not be_empty
+        expect(trace.send(:meta)['_dd.appsec.json']).to be_a String
+      end
 
       context 'with appsec disabled' do
         let(:appsec_enabled) { false }

--- a/spec/datadog/appsec/contrib/sinatra/integration_test_spec.rb
+++ b/spec/datadog/appsec/contrib/sinatra/integration_test_spec.rb
@@ -141,87 +141,111 @@ RSpec.describe 'Sinatra integration tests' do
     let(:span) { rack_span }
 
     shared_examples 'a GET 200 span' do
-      it { expect(span.get_tag('http.method')).to eq('GET') }
-      it { expect(span.get_tag('http.status_code')).to eq('200') }
-      it { expect(span.status).to eq(0) }
+      it do
+        expect(span.get_tag('http.method')).to eq('GET')
+        expect(span.get_tag('http.status_code')).to eq('200')
+        expect(span.status).to eq(0)
+      end
 
       context 'with appsec disabled' do
         let(:appsec_enabled) { false }
 
-        it { expect(span.get_tag('http.method')).to eq('GET') }
-        it { expect(span.get_tag('http.status_code')).to eq('200') }
-        it { expect(span.status).to eq(0) }
+        it do
+          expect(span.get_tag('http.method')).to eq('GET')
+          expect(span.get_tag('http.status_code')).to eq('200')
+          expect(span.status).to eq(0)
+        end
       end
     end
 
     shared_examples 'a GET 403 span' do
-      it { expect(span.get_tag('http.method')).to eq('GET') }
-      it { expect(span.get_tag('http.status_code')).to eq('403') }
-      it { expect(span.status).to eq(0) }
+      it do
+        expect(span.get_tag('http.method')).to eq('GET')
+        expect(span.get_tag('http.status_code')).to eq('403')
+        expect(span.status).to eq(0)
+      end
 
       context 'with appsec disabled' do
         let(:appsec_enabled) { false }
 
-        it { expect(span.get_tag('http.method')).to eq('GET') }
-        it { expect(span.get_tag('http.status_code')).to eq('200') }
-        it { expect(span.status).to eq(0) }
+        it do
+          expect(span.get_tag('http.method')).to eq('GET')
+          expect(span.get_tag('http.status_code')).to eq('200')
+          expect(span.status).to eq(0)
+        end
       end
     end
 
     shared_examples 'a GET 404 span' do
-      it { expect(span.get_tag('http.method')).to eq('GET') }
-      it { expect(span.get_tag('http.status_code')).to eq('404') }
-      it { expect(span.status).to eq(0) }
+      it do
+        expect(span.get_tag('http.method')).to eq('GET')
+        expect(span.get_tag('http.status_code')).to eq('404')
+        expect(span.status).to eq(0)
+      end
 
       context 'with appsec disabled' do
         let(:appsec_enabled) { false }
 
-        it { expect(span.get_tag('http.method')).to eq('GET') }
-        it { expect(span.get_tag('http.status_code')).to eq('404') }
-        it { expect(span.status).to eq(0) }
+        it do
+          expect(span.get_tag('http.method')).to eq('GET')
+          expect(span.get_tag('http.status_code')).to eq('404')
+          expect(span.status).to eq(0)
+        end
       end
     end
 
     shared_examples 'a POST 200 span' do
-      it { expect(span.get_tag('http.method')).to eq('POST') }
-      it { expect(span.get_tag('http.status_code')).to eq('200') }
-      it { expect(span.status).to eq(0) }
+      it do
+        expect(span.get_tag('http.method')).to eq('POST')
+        expect(span.get_tag('http.status_code')).to eq('200')
+        expect(span.status).to eq(0)
+      end
 
       context 'with appsec disabled' do
         let(:appsec_enabled) { false }
 
-        it { expect(span.get_tag('http.method')).to eq('POST') }
-        it { expect(span.get_tag('http.status_code')).to eq('200') }
-        it { expect(span.status).to eq(0) }
+        it do
+          expect(span.get_tag('http.method')).to eq('POST')
+          expect(span.get_tag('http.status_code')).to eq('200')
+          expect(span.status).to eq(0)
+        end
       end
     end
 
     shared_examples 'a POST 403 span' do
-      it { expect(span.get_tag('http.method')).to eq('POST') }
-      it { expect(span.get_tag('http.status_code')).to eq('403') }
-      it { expect(span.status).to eq(0) }
+      it do
+        expect(span.get_tag('http.method')).to eq('POST')
+        expect(span.get_tag('http.status_code')).to eq('403')
+        expect(span.status).to eq(0)
+      end
 
       context 'with appsec disabled' do
         let(:appsec_enabled) { false }
 
-        it { expect(span.get_tag('http.method')).to eq('POST') }
-        it { expect(span.get_tag('http.status_code')).to eq('200') }
-        it { expect(span.status).to eq(0) }
+        it do
+          expect(span.get_tag('http.method')).to eq('POST')
+          expect(span.get_tag('http.status_code')).to eq('200')
+          expect(span.status).to eq(0)
+        end
       end
     end
 
     shared_examples 'a trace without AppSec tags' do
-      it { expect(trace.send(:metrics)['_dd.appsec.enabled']).to be_nil }
-      it { expect(trace.send(:meta)['_dd.runtime_family']).to be_nil }
-      it { expect(trace.send(:meta)['_dd.appsec.waf.version']).to be_nil }
-      it { expect(span.send(:meta)['http.client_ip']).to eq nil }
+      it do
+        expect(trace.send(:metrics)['_dd.appsec.enabled']).to be_nil
+        expect(trace.send(:meta)['_dd.runtime_family']).to be_nil
+        expect(trace.send(:meta)['_dd.appsec.waf.version']).to be_nil
+        expect(span.send(:meta)['http.client_ip']).to eq nil
+      end
     end
 
     shared_examples 'a trace with AppSec tags' do
-      it { expect(trace.send(:metrics)['_dd.appsec.enabled']).to eq(1.0) }
-      it { expect(trace.send(:meta)['_dd.runtime_family']).to eq('ruby') }
-      it { expect(trace.send(:meta)['_dd.appsec.waf.version']).to match(/^\d+\.\d+\.\d+/) }
-      it { expect(span.send(:meta)['http.client_ip']).to eq client_ip }
+      it do
+        expect(trace.send(:metrics)['_dd.appsec.enabled']).to eq(1.0)
+        expect(trace.send(:meta)['_dd.runtime_family']).to eq('ruby')
+        expect(trace.send(:meta)['_dd.appsec.waf.version']).to match(/^\d+\.\d+\.\d+/)
+        expect(span.send(:meta)['http.client_ip']).to eq client_ip
+      end
 
       context 'with appsec disabled' do
         let(:appsec_enabled) { false }
@@ -231,13 +255,17 @@ RSpec.describe 'Sinatra integration tests' do
     end
 
     shared_examples 'a trace without AppSec events' do
-      it { expect(spans.select { |s| s.get_tag('appsec.event') }).to be_empty }
-      it { expect(trace.send(:meta)['_dd.appsec.triggers']).to be_nil }
+      it do
+        expect(spans.select { |s| s.get_tag('appsec.event') }).to be_empty
+        expect(trace.send(:meta)['_dd.appsec.triggers']).to be_nil
+      end
     end
 
     shared_examples 'a trace with AppSec events' do
-      it { expect(spans.select { |s| s.get_tag('appsec.event') }).to_not be_empty }
-      it { expect(trace.send(:meta)['_dd.appsec.json']).to be_a String }
+      it do
+        expect(spans.select { |s| s.get_tag('appsec.event') }).to_not be_empty
+        expect(trace.send(:meta)['_dd.appsec.json']).to be_a String
+      end
 
       context 'with appsec disabled' do
         let(:appsec_enabled) { false }


### PR DESCRIPTION
<!--
Check out the
https://github.com/DataDog/dd-trace-rb/blob/master/docs/DevelopmentGuide.md
for guidance on how to set up your development environment,
run the test suite, write new integrations, and more.
-->

**What does this PR do?**
<!-- A brief description of the change being made with this pull request. -->

Improve CI time for appsec integration specs. 

We have divided all specs into single specs. The way tests were organized meant that for every assertion, we were making a new request to the test app. By groping the specs into a bigger block we can improve CI time.

For future we can extract those shared examples into a separate file

**Motivation**
<!-- What inspired you to submit this pull request? -->


**Additional Notes**
<!-- Anything else we should know when reviewing? -->

**How to test the change?**
<!--
Describe here how the change can be validated.
You are strongly encouraged to provide automated tests for this PR (unit or integration).
If this change cannot be feasibly tested, please explain why,
unless the change does not modify code (e.g. only modifies docs, comments).
-->
