### PR TITLE
[APPSEC-9989] Allow setting remote configuration service name

### DIFF
--- a/lib/datadog/core/configuration/settings.rb
+++ b/lib/datadog/core/configuration/settings.rb
@@ -549,6 +549,14 @@ module Datadog
             o.default { env_to_float(Core::Remote::Ext::ENV_POLL_INTERVAL_SECONDS, 5.0) }
             o.lazy
           end
+
+          # Declare service name to bind to remote configuration. Use when
+          # DD_SERVICE does not match the correct integration for which remote
+          # configuration applies.
+          #
+          # @default `nil`.
+          # @return [String,nil]
+          option :service
         end
 
         # TODO: Tracing should manage its own settings.

--- a/lib/datadog/core/remote/client.rb
+++ b/lib/datadog/core/remote/client.rb
@@ -136,7 +136,7 @@ module Datadog
             runtime_id: Core::Environment::Identity.id,
             language: Core::Environment::Identity.lang,
             tracer_version: tracer_version_semver2,
-            service: Datadog.configuration.service,
+            service: service_name,
             env: Datadog.configuration.env,
             tags: client_tracer_tags,
           }
@@ -165,6 +165,10 @@ module Datadog
             },
             cached_target_files: state.cached_target_files,
           }
+        end
+
+        def service_name
+          Datadog.configuration.remote.service || Datadog.configuration.service
         end
 
         def tracer_version_semver2

--- a/sig/datadog/core/configuration/settings.rbs
+++ b/sig/datadog/core/configuration/settings.rbs
@@ -12,6 +12,10 @@ module Datadog
           def poll_interval_seconds: () -> ::Float
 
           def poll_interval_seconds=: (::Float) -> void
+
+          def service: () -> ::String?
+
+          def service=: (::String) -> void
         end
 
         def initialize: (*untyped _) -> untyped

--- a/sig/datadog/core/remote/client.rbs
+++ b/sig/datadog/core/remote/client.rbs
@@ -27,6 +27,7 @@ module Datadog
         @tracer_version_semver2: ::String
 
         def payload: () ->  ::Hash[Symbol, untyped]
+        def service_name: () -> ::String
         def gem_spec: (::String) -> (::Gem::Specification | untyped)
         def tracer_version_semver2: () -> ::String
         def native_platform: () -> ::String

--- a/spec/datadog/core/configuration/settings_spec.rb
+++ b/spec/datadog/core/configuration/settings_spec.rb
@@ -1295,5 +1295,22 @@ RSpec.describe Datadog::Core::Configuration::Settings do
           .to(1.0)
       end
     end
+
+    describe '#service' do
+      subject(:service) { settings.remote.service }
+
+      context 'defaults to nil' do
+        it { is_expected.to be nil }
+      end
+    end
+
+    describe '#service=' do
+      it 'updates the #service setting' do
+        expect { settings.remote.service = 'foo' }
+          .to change { settings.remote.service }
+          .from(nil)
+          .to('foo')
+      end
+    end
   end
 end

--- a/spec/datadog/core/remote/client_spec.rb
+++ b/spec/datadog/core/remote/client_spec.rb
@@ -564,6 +564,22 @@ RSpec.describe Datadog::Core::Remote::Client do
               end
             end
 
+            context 'with remote service setting' do
+              it 'returns client_tracer' do
+                expect(Datadog.configuration.remote).to receive(:service).and_return('foo').at_least(:once)
+
+                expected_client_tracer = {
+                  :runtime_id => Datadog::Core::Environment::Identity.id,
+                  :language => Datadog::Core::Environment::Identity.lang,
+                  :tracer_version => Datadog::Core::Environment::Identity.tracer_version_semver2,
+                  :service => Datadog.configuration.remote.service,
+                  :env => Datadog.configuration.env,
+                }
+
+                expect(client_payload[:client_tracer].tap { |h| h.delete(:tags) }).to eq(expected_client_tracer)
+              end
+            end
+
             context 'with app_version' do
               it 'returns client_tracer' do
                 expect(Datadog.configuration).to receive(:version).and_return('hello').at_least(:once)


### PR DESCRIPTION
<!--
Check out the
https://github.com/DataDog/dd-trace-rb/blob/master/docs/DevelopmentGuide.md
for guidance on how to set up your development environment,
run the test suite, write new integrations, and more.
-->

**What does this PR do?**

Allow setting remote configuration service name

**Motivation**

Service name set by `DD_SERVICE` or `Datadog.configure { |c| c.service = ... }` may be absent or differ from integration service name configuration in advanced sub-service naming configuration cases.

**Additional Notes**

Having it default to Rack's service name could be a thing, but was found to be a bit unreliable in such advanced configurations. It needs a bit more testing so we'll land this as a stopgap.

This does not address the case of `request_queuing`.

**How to test the change?**

CI
