### PR TITLE
Check if `:appsec` setting is enabled before accessing it in remote component

### DIFF
--- a/lib/datadog/core/remote/client/capabilities.rb
+++ b/lib/datadog/core/remote/client/capabilities.rb
@@ -23,7 +23,7 @@ module Datadog
           private
 
           def register(settings)
-            if settings.appsec.enabled
+            if settings.respond_to?(:appsec) && settings.appsec.enabled
               register_capabilities(Datadog::AppSec::Remote.capabilities)
               register_products(Datadog::AppSec::Remote.products)
               register_receivers(Datadog::AppSec::Remote.receivers)

--- a/spec/datadog/core/remote/client/capabilities_spec.rb
+++ b/spec/datadog/core/remote/client/capabilities_spec.rb
@@ -11,54 +11,74 @@ RSpec.describe Datadog::Core::Remote::Client::Capabilities do
     capabilities
   end
 
-  context 'when no component enabled' do
-    let(:settings) do
-      appsec_settings = Datadog::AppSec::Configuration::Settings.new
-      dsl = Datadog::AppSec::Configuration::DSL.new
-      dsl.enabled = false
-      appsec_settings.merge(dsl)
+  context 'AppSec component' do
+    context 'when disabled' do
+      let(:settings) do
+        appsec_settings = Datadog::AppSec::Configuration::Settings.new
+        dsl = Datadog::AppSec::Configuration::DSL.new
+        dsl.enabled = false
+        appsec_settings.merge(dsl)
 
-      settings = Datadog::Core::Configuration::Settings.new
-      expect(settings).to receive(:appsec).at_least(:once).and_return(appsec_settings)
+        settings = Datadog::Core::Configuration::Settings.new
+        expect(settings).to receive(:appsec).at_least(:once).and_return(appsec_settings)
 
-      settings
-    end
+        settings
+      end
 
-    it 'does not register any capabilities, products, and receivers' do
-      expect(capabilities.capabilities).to be_empty
-      expect(capabilities.products).to be_empty
-      expect(capabilities.receivers).to be_empty
-    end
+      it 'does not register any capabilities, products, and receivers' do
+        expect(capabilities.capabilities).to be_empty
+        expect(capabilities.products).to be_empty
+        expect(capabilities.receivers).to be_empty
+      end
 
-    describe '#base64_capabilities' do
-      it 'returns an empty string' do
-        expect(capabilities.base64_capabilities).to eq('')
+      describe '#base64_capabilities' do
+        it 'returns an empty string' do
+          expect(capabilities.base64_capabilities).to eq('')
+        end
       end
     end
-  end
 
-  context 'when a component enabled' do
-    let(:settings) do
-      appsec_settings = Datadog::AppSec::Configuration::Settings.new
-      dsl = Datadog::AppSec::Configuration::DSL.new
-      dsl.enabled = true
-      appsec_settings.merge(dsl)
+    context 'when not present' do
+      let(:settings) do
+        double(Datadog::Core::Configuration)
+      end
 
-      settings = Datadog::Core::Configuration::Settings.new
-      expect(settings).to receive(:appsec).and_return(appsec_settings)
+      it 'does not register any capabilities, products, and receivers' do
+        expect(capabilities.capabilities).to be_empty
+        expect(capabilities.products).to be_empty
+        expect(capabilities.receivers).to be_empty
+      end
 
-      settings
+      describe '#base64_capabilities' do
+        it 'returns an empty string' do
+          expect(capabilities.base64_capabilities).to eq('')
+        end
+      end
     end
 
-    it 'register capabilities, products, and receivers' do
-      expect(capabilities.capabilities).to_not be_empty
-      expect(capabilities.products).to_not be_empty
-      expect(capabilities.receivers).to_not be_empty
-    end
+    context 'when enabled' do
+      let(:settings) do
+        appsec_settings = Datadog::AppSec::Configuration::Settings.new
+        dsl = Datadog::AppSec::Configuration::DSL.new
+        dsl.enabled = true
+        appsec_settings.merge(dsl)
 
-    describe '#base64_capabilities' do
-      it 'returns binary capabilities' do
-        expect(capabilities.base64_capabilities).to eq('/A==')
+        settings = Datadog::Core::Configuration::Settings.new
+        expect(settings).to receive(:appsec).and_return(appsec_settings)
+
+        settings
+      end
+
+      it 'register capabilities, products, and receivers' do
+        expect(capabilities.capabilities).to_not be_empty
+        expect(capabilities.products).to_not be_empty
+        expect(capabilities.receivers).to_not be_empty
+      end
+
+      describe '#base64_capabilities' do
+        it 'returns binary capabilities' do
+          expect(capabilities.base64_capabilities).to eq('/A==')
+        end
       end
     end
   end


### PR DESCRIPTION
<!--
Check out the
https://github.com/DataDog/dd-trace-rb/blob/master/docs/DevelopmentGuide.md
for guidance on how to set up your development environment,
run the test suite, write new integrations, and more.
-->

**What does this PR do?**
<!-- A brief description of the change being made with this pull request. -->

Fixes a regression previously fixed https://github.com/DataDog/dd-trace-rb/issues/2677.

Since the introduction of remote components, the CI configuration for some projects has been broken. 

The issue comes from the remote component checking `appsec` settings. In the context of CI, most users do not load appsec, which is causing issues. This PR fixes it 

**Motivation**
<!-- What inspired you to submit this pull request? -->

**Additional Notes**
<!-- Anything else we should know when reviewing? -->

**How to test the change?**
<!--
Describe here how the change can be validated.
You are strongly encouraged to provide automated tests for this PR (unit or integration).
If this change cannot be feasibly tested, please explain why,
unless the change does not modify code (e.g. only modifies docs, comments).
-->
