### PR TITLE
Telemetry:Do not send Dependency `hash` when `version` is present

### DIFF
--- a/lib/datadog/core/telemetry/collector.rb
+++ b/lib/datadog/core/telemetry/collector.rb
@@ -56,7 +56,8 @@ module Datadog
         def dependencies
           Gem.loaded_specs.collect do |name, loaded_gem|
             Datadog::Core::Telemetry::V1::Dependency.new(
-              name: name, version: loaded_gem.version.to_s, hash: loaded_gem.hash.to_s
+              # `hash` should be used when `version` is not available
+              name: name, version: loaded_gem.version.to_s, hash: nil
             )
           end
         end

--- a/lib/datadog/core/telemetry/v1/dependency.rb
+++ b/lib/datadog/core/telemetry/v1/dependency.rb
@@ -17,9 +17,10 @@ module Datadog
 
           # @param name [String] Module name
           # @param version [String] Version of resolved module
-          # @param hash [String] Dependency hash
+          # @param hash [String] Dependency hash, in case `version` is not available
           def initialize(name:, version: nil, hash: nil)
             raise ArgumentError, ERROR_NIL_NAME_MESSAGE if name.nil?
+            raise ArgumentError, 'if both :version and :hash exist, use :version only' if version && hash
 
             @hash = hash
             @name = name

--- a/spec/datadog/core/telemetry/v1/dependency_spec.rb
+++ b/spec/datadog/core/telemetry/v1/dependency_spec.rb
@@ -6,9 +6,9 @@ require 'datadog/core/telemetry/v1/shared_examples'
 RSpec.describe Datadog::Core::Telemetry::V1::Dependency do
   subject(:dependency) { described_class.new(name: name, version: version, hash: hash) }
 
-  let(:hash) { '3e2e2c2362c89aa01bc0e004681e' }
+  let(:hash) { nil }
   let(:name) { 'mongodb' }
-  let(:version) { '2.2.5' }
+  let(:version) { nil }
 
   it { is_expected.to have_attributes(name: name, hash: hash, version: version) }
 
@@ -18,7 +18,17 @@ RSpec.describe Datadog::Core::Telemetry::V1::Dependency do
     end
 
     context ':version' do
+      let(:version) { '2.2.5' }
+
       it_behaves_like 'an optional string parameter', 'version'
+
+      context 'and :hash' do
+        let(:hash) { 'test-hash' }
+
+        it 'report argument conflict' do
+          expect { dependency }.to raise_error(ArgumentError)
+        end
+      end
     end
 
     context ':hash' do
@@ -29,13 +39,12 @@ RSpec.describe Datadog::Core::Telemetry::V1::Dependency do
   describe '#to_h' do
     subject(:to_h) { dependency.to_h }
 
-    let(:hash) { '3e2e2c2362c89aa01bc0e004681e' }
+    let(:hash) { nil }
     let(:name) { 'mongodb' }
     let(:version) { '2.2.5' }
 
     it do
       is_expected.to eq(
-        hash: hash,
         name: name,
         version: version
       )


### PR DESCRIPTION
`Datadog::Core::Telemetry::V1::Dependency` is currently report both gem `version` and gem `hash` values.

The spec states that `hash` should only be used when the value for `version` cannot be provided, which doesn't happen with Ruby Gems.

This PR removes `hash`, cleaning up our telemetry data and preventing issues during data processing.