### PR TITLE
[APPSEC-9340] Appsec add support for custom rules

### DIFF
--- a/ddtrace.gemspec
+++ b/ddtrace.gemspec
@@ -66,7 +66,7 @@ Gem::Specification.new do |spec|
   spec.add_dependency 'debase-ruby_core_source', '>= 0.10.16', '<= 3.2.0'
 
   # Used by appsec
-  spec.add_dependency 'libddwaf', '~> 1.8.2.0.0'
+  spec.add_dependency 'libddwaf', '~> 1.9.0.0.0'
 
   # Used by profiling (and possibly others in the future)
   # When updating the version here, please also update the version in `native_extension_helpers.rb` (and yes we have a test for it)

--- a/lib/datadog/appsec/processor/rule_merger.rb
+++ b/lib/datadog/appsec/processor/rule_merger.rb
@@ -17,16 +17,18 @@ module Datadog
         end
 
         class << self
-          def merge(rules:, data: [], overrides: [], exclusions: [])
+          def merge(rules:, data: [], overrides: [], exclusions: [], custom_rules: [])
             combined_rules = combine_rules(rules)
 
-            rules_data = combine_data(data) if data.any?
-            rules_overrides = combine_overrides(overrides) if overrides.any?
-            rules_exclusions = combine_exclusions(exclusions) if exclusions.any?
+            combined_data = combine_data(data) if data.any?
+            combined_overrides = combine_overrides(overrides) if overrides.any?
+            combined_exclusions = combine_exclusions(exclusions) if exclusions.any?
+            combined_custom_rules = combine_custom_rules(custom_rules) if custom_rules.any?
 
-            combined_rules['rules_data'] = rules_data if rules_data
-            combined_rules['rules_override'] = rules_overrides if rules_overrides
-            combined_rules['exclusions'] = rules_exclusions if rules_exclusions
+            combined_rules['rules_data'] = combined_data if combined_data
+            combined_rules['rules_override'] = combined_overrides if combined_overrides
+            combined_rules['exclusions'] = combined_exclusions if combined_exclusions
+            combined_rules['custom_rules'] = combined_custom_rules if combined_custom_rules
 
             combined_rules
           end
@@ -118,6 +120,10 @@ module Datadog
 
           def combine_exclusions(exclusions)
             exclusions.flatten
+          end
+
+          def combine_custom_rules(custom_rules)
+            custom_rules.flatten
           end
         end
       end

--- a/lib/datadog/appsec/remote.rb
+++ b/lib/datadog/appsec/remote.rb
@@ -48,6 +48,7 @@ module Datadog
           remote_features_enabled? ? ASM_PRODUCTS : []
         end
 
+        # rubocop:disable Metrics/MethodLength
         def receivers
           return [] unless remote_features_enabled?
 
@@ -58,6 +59,7 @@ module Datadog
             end
 
             rules = []
+            custom_rules = []
             data = []
             overrides = []
             exclusions = []
@@ -73,6 +75,7 @@ module Datadog
               when 'ASM'
                 overrides << parsed_content['rules_override'] if parsed_content['rules_override']
                 exclusions << parsed_content['exclusions'] if parsed_content['exclusions']
+                custom_rules << parsed_content['custom_rules'] if parsed_content['custom_rules']
               end
             end
 
@@ -89,6 +92,7 @@ module Datadog
               data: data,
               overrides: overrides,
               exclusions: exclusions,
+              custom_rules: custom_rules,
             )
 
             Datadog::AppSec.reconfigure(ruleset: ruleset)
@@ -96,6 +100,7 @@ module Datadog
 
           [receiver]
         end
+        # rubocop:enable Metrics/MethodLength
 
         private
 

--- a/lib/datadog/appsec/remote.rb
+++ b/lib/datadog/appsec/remote.rb
@@ -30,6 +30,7 @@ module Datadog
           CAP_ASM_REQUEST_BLOCKING,
           CAP_ASM_RESPONSE_BLOCKING,
           CAP_ASM_DD_RULES,
+          CAP_ASM_CUSTOM_RULES,
         ].freeze
 
         ASM_PRODUCTS = [

--- a/sig/datadog/appsec/processor/rule_merger.rbs
+++ b/sig/datadog/appsec/processor/rule_merger.rbs
@@ -10,8 +10,9 @@ module Datadog
         type data = ::Array[::Hash[::String, untyped]]
         type overrides = ::Array[::Hash[::String, untyped]]
         type exclusions = ::Array[::Hash[::String, untyped]]
+        type custom_rules = ::Array[::Hash[::String, untyped]]
 
-        def self.merge: (rules: ::Array[rules], ?data: ::Array[data], ?overrides: ::Array[overrides], ?exclusions: ::Array[exclusions]) -> rules
+        def self.merge: (rules: ::Array[rules], ?data: ::Array[data], ?overrides: ::Array[overrides], ?exclusions: ::Array[exclusions], ?custom_rules: ::Array[custom_rules]) -> rules
 
         private
 
@@ -24,6 +25,8 @@ module Datadog
         def self.combine_overrides: (::Array[overrides] overrides) -> ::Array[overrides]?
 
         def self.combine_exclusions: (::Array[exclusions] exclusions) -> ::Array[exclusions]?
+
+        def self.combine_custom_rules: (::Array[custom_rules] custom_rules) -> ::Array[custom_rules]?
       end
     end
   end

--- a/spec/datadog/appsec/processor/rule_merger_spec.rb
+++ b/spec/datadog/appsec/processor/rule_merger_spec.rb
@@ -625,6 +625,119 @@ RSpec.describe Datadog::AppSec::Processor::RuleMerger do
       end
     end
 
+    context 'custom_rules' do
+      it 'merges custom_rules' do
+        custom_rules = [
+          [
+            {
+              'id' => 'custom-rule-001',
+              'name' => 'Super custom rule 1',
+              'tags' => {
+                'type' => 'security_scanner',
+                'category' => 'scanners'
+              },
+              'conditions' => [
+                {
+                  'parameters' => {
+                    'inputs' => [
+                      {
+                        'address' => 'server.request.headers',
+                        'key_path' => ['user-agent']
+                      }
+                    ],
+                    'regex' => '^SuperScanner1$'
+                  },
+                  'operator' => 'regex_match'
+                }
+              ],
+              'transformers' => []
+            }
+          ],
+          [
+            {
+              'id' => 'custom-rule-002',
+              'name' => 'Super custom rule 2',
+              'tags' => {
+                'type' => 'security_scanner',
+                'category' => 'scanners'
+              },
+              'conditions' => [
+                {
+                  'parameters' => {
+                    'inputs' => [
+                      {
+                        'address' => 'server.request.headers',
+                        'key_path' => ['user-agent']
+                      }
+                    ],
+                    'regex' => '^SuperScanner2$'
+                  },
+                  'operator' => 'regex_match'
+                }
+              ],
+              'transformers' => []
+            }
+          ]
+        ]
+
+        expected_result = rules[0].merge(
+          {
+            'custom_rules' => [
+              {
+                'id' => 'custom-rule-001',
+                'name' => 'Super custom rule 1',
+                'tags' => {
+                  'type' => 'security_scanner',
+                  'category' => 'scanners'
+                },
+                'conditions' => [
+                  {
+                    'parameters' => {
+                      'inputs' => [
+                        {
+                          'address' => 'server.request.headers',
+                          'key_path' => ['user-agent']
+                        }
+                      ],
+                      'regex' => '^SuperScanner1$'
+                    },
+                    'operator' => 'regex_match'
+                  }
+                ],
+                'transformers' => []
+              },
+              {
+                'id' => 'custom-rule-002',
+                'name' => 'Super custom rule 2',
+                'tags' => {
+                  'type' => 'security_scanner',
+                  'category' => 'scanners'
+                },
+                'conditions' => [
+                  {
+                    'parameters' => {
+                      'inputs' => [
+                        {
+                          'address' => 'server.request.headers',
+                          'key_path' => ['user-agent']
+                        }
+                      ],
+                      'regex' => '^SuperScanner2$'
+                    },
+                    'operator' => 'regex_match'
+                  }
+                ],
+                'transformers' => []
+              }
+            ]
+          }
+        )
+
+        result = described_class.merge(rules: rules, custom_rules: custom_rules)
+        expect(result).to eq(expected_result)
+      end
+    end
+
     context 'data, overrides, and exclusions' do
       it 'merges all information' do
         rules_data = [

--- a/spec/datadog/core/remote/client/capabilities_spec.rb
+++ b/spec/datadog/core/remote/client/capabilities_spec.rb
@@ -6,6 +6,9 @@ require 'datadog/appsec/configuration'
 
 RSpec.describe Datadog::Core::Remote::Client::Capabilities do
   subject(:capabilities) { described_class.new(settings) }
+  let(:settings) do
+    double(Datadog::Core::Configuration)
+  end
 
   before do
     capabilities
@@ -39,10 +42,6 @@ RSpec.describe Datadog::Core::Remote::Client::Capabilities do
     end
 
     context 'when not present' do
-      let(:settings) do
-        double(Datadog::Core::Configuration)
-      end
-
       it 'does not register any capabilities, products, and receivers' do
         expect(capabilities.capabilities).to be_empty
         expect(capabilities.products).to be_empty
@@ -77,9 +76,24 @@ RSpec.describe Datadog::Core::Remote::Client::Capabilities do
 
       describe '#base64_capabilities' do
         it 'returns binary capabilities' do
-          expect(capabilities.base64_capabilities).to eq('/A==')
+          expect(capabilities.base64_capabilities).to_not be_empty
         end
       end
+    end
+  end
+
+  describe '#capabilities_to_base64' do
+    before do
+      allow(capabilities).to receive(:capabilities).and_return(
+        [
+          1 << 1,
+          1 << 2,
+        ]
+      )
+    end
+
+    it 'returns base64 string' do
+      expect(capabilities.send(:capabilities_to_base64)).to eq('Bg==')
     end
   end
 end


### PR DESCRIPTION
<!--
Check out the
https://github.com/DataDog/dd-trace-rb/blob/master/docs/DevelopmentGuide.md
for guidance on how to set up your development environment,
run the test suite, write new integrations, and more.
-->

**What does this PR do?**
<!-- A brief description of the change being made with this pull request. -->

**Motivation**
<!-- What inspired you to submit this pull request? -->

We add support for In-App WAF Custom Rules. AppSec customers are going to be able to provide there own custom rules via remote configuration 🎉 


**Additional Notes**
<!-- Anything else we should know when reviewing? -->

I did an integration test using my local sandbox app. 

Here is the custom rule I created: 

<img width="2542" alt="image" src="https://github.com/DataDog/dd-trace-rb/assets/4672858/1ac259d6-385e-47dc-98a7-905c0889e102">

After getting the update on my app from the remote configuration. 

Hitting the app with `curl -H "User-Agent: Gustavo" 'localhost:3000'`, and we can see in the logs the WAF reacting to that value:

![image](https://github.com/DataDog/dd-trace-rb/assets/4672858/d0e52805-6205-4f39-bd80-9017fc3400fc)

```bash
DEBUG -- ddtrace: [ddtrace] (/Users/gustavo.caso/src/github.com/DataDog/dd-trace-rb/lib/datadog/appsec/contrib/rack/reactive/request.rb:57:in `block in subscribe') WAF: #<Datadog::AppSec::WAF::Result:0x000000010775edd0 @status=:match, @data=[{"rule"=>{"id"=>"3c3e5dbc-0ad3-439d-9a98-1304393c0cdf", "name"=>"Gustavo testing ", "tags"=>{"type"=>"custom", "category"=>"attack_attempt"}}, "rule_matches"=>[{"operator"=>"match_regex", "operator_value"=>"Gustavo", "parameters"=>[{"address"=>"server.request.headers.no_cookies", "key_path"=>["user-agent"], "value"=>"Gustavo", "highlight"=>["Gustavo"]}]}]}], @total_runtime=384417, @timeout=false, @actions=[]>
```

**How to test the change?**
<!--
Describe here how the change can be validated.
You are strongly encouraged to provide automated tests for this PR (unit or integration).
If this change cannot be feasibly tested, please explain why,
unless the change does not modify code (e.g. only modifies docs, comments).
-->

CI 
