### PR TITLE
Tag AppSec on Rack top-level span

### DIFF
--- a/Steepfile
+++ b/Steepfile
@@ -568,7 +568,6 @@ target :ddtrace do
   ignore 'lib/datadog/tracing/distributed/trace_context.rb'
   ignore 'lib/datadog/tracing/event.rb'
   ignore 'lib/datadog/tracing/flush.rb'
-  ignore 'lib/datadog/tracing/metadata.rb'
   ignore 'lib/datadog/tracing/metadata/analytics.rb'
   ignore 'lib/datadog/tracing/metadata/errors.rb'
   ignore 'lib/datadog/tracing/metadata/ext.rb'

--- a/lib/datadog/appsec.rb
+++ b/lib/datadog/appsec.rb
@@ -2,6 +2,7 @@
 
 require_relative 'appsec/configuration'
 require_relative 'appsec/extensions'
+require_relative 'appsec/scope'
 
 module Datadog
   # Namespace for Datadog AppSec instrumentation
@@ -11,6 +12,10 @@ module Datadog
     class << self
       def enabled?
         Datadog.configuration.appsec.enabled
+      end
+
+      def active_scope
+        Datadog::AppSec::Scope.active_scope
       end
 
       def processor

--- a/lib/datadog/appsec.rb
+++ b/lib/datadog/appsec.rb
@@ -3,6 +3,7 @@
 require_relative 'appsec/configuration'
 require_relative 'appsec/extensions'
 require_relative 'appsec/scope'
+require_relative 'appsec/ext'
 
 module Datadog
   # Namespace for Datadog AppSec instrumentation

--- a/lib/datadog/appsec/contrib/rack/gateway/response.rb
+++ b/lib/datadog/appsec/contrib/rack/gateway/response.rb
@@ -9,14 +9,14 @@ module Datadog
         module Gateway
           # Gateway Response argument.
           class Response < Instrumentation::Gateway::Argument
-            attr_reader :body, :status, :headers, :active_context
+            attr_reader :body, :status, :headers, :scope
 
-            def initialize(body, status, headers, active_context:)
+            def initialize(body, status, headers, scope:)
               super()
               @body = body
               @status = status
               @headers = headers.each_with_object({}) { |(k, v), h| h[k.downcase] = v }
-              @active_context = active_context
+              @scope = scope
             end
 
             def response

--- a/lib/datadog/appsec/contrib/rack/gateway/watcher.rb
+++ b/lib/datadog/appsec/contrib/rack/gateway/watcher.rb
@@ -25,13 +25,13 @@ module Datadog
                 gateway.watch('rack.request', :appsec) do |stack, gateway_request|
                   block = false
                   event = nil
-                  waf_context = gateway_request.env['datadog.waf.context']
+                  scope = gateway_request.env['datadog.appsec.scope']
 
                   AppSec::Reactive::Operation.new('rack.request') do |op|
                     trace = active_trace
                     span = active_span
 
-                    Rack::Reactive::Request.subscribe(op, waf_context) do |result, _block|
+                    Rack::Reactive::Request.subscribe(op, scope.processor_context) do |result, _block|
                       if result.status == :match
                         # TODO: should this hash be an Event instance instead?
                         event = {
@@ -44,7 +44,7 @@ module Datadog
 
                         span.set_tag('appsec.event', 'true') if span
 
-                        waf_context.events << event
+                        scope.processor_context.events << event
                       end
                     end
 
@@ -68,13 +68,13 @@ module Datadog
                 gateway.watch('rack.response', :appsec) do |stack, gateway_response|
                   block = false
                   event = nil
-                  waf_context = gateway_response.active_context
+                  scope = gateway_response.scope
 
                   AppSec::Reactive::Operation.new('rack.response') do |op|
                     trace = active_trace
                     span = active_span
 
-                    Rack::Reactive::Response.subscribe(op, waf_context) do |result, _block|
+                    Rack::Reactive::Response.subscribe(op, scope.processor_context) do |result, _block|
                       if result.status == :match
                         # TODO: should this hash be an Event instance instead?
                         event = {
@@ -87,7 +87,7 @@ module Datadog
 
                         span.set_tag('appsec.event', 'true') if span
 
-                        waf_context.events << event
+                        scope.processor_context.events << event
                       end
                     end
 
@@ -111,13 +111,13 @@ module Datadog
                 gateway.watch('rack.request.body', :appsec) do |stack, gateway_request|
                   block = false
                   event = nil
-                  waf_context = gateway_request.env['datadog.waf.context']
+                  scope = gateway_request.env['datadog.appsec.scope']
 
                   AppSec::Reactive::Operation.new('rack.request.body') do |op|
                     trace = active_trace
                     span = active_span
 
-                    Rack::Reactive::RequestBody.subscribe(op, waf_context) do |result, _block|
+                    Rack::Reactive::RequestBody.subscribe(op, scope.processor_context) do |result, _block|
                       if result.status == :match
                         # TODO: should this hash be an Event instance instead?
                         event = {
@@ -130,7 +130,7 @@ module Datadog
 
                         span.set_tag('appsec.event', 'true') if span
 
-                        waf_context.events << event
+                        scope.processor_context.events << event
                       end
                     end
 

--- a/lib/datadog/appsec/contrib/rack/gateway/watcher.rb
+++ b/lib/datadog/appsec/contrib/rack/gateway/watcher.rb
@@ -25,7 +25,7 @@ module Datadog
                 gateway.watch('rack.request', :appsec) do |stack, gateway_request|
                   block = false
                   event = nil
-                  scope = gateway_request.env['datadog.appsec.scope']
+                  scope = gateway_request.env[Datadog::AppSec::Ext::SCOPE_KEY]
 
                   AppSec::Reactive::Operation.new('rack.request') do |op|
                     trace = active_trace
@@ -111,7 +111,7 @@ module Datadog
                 gateway.watch('rack.request.body', :appsec) do |stack, gateway_request|
                   block = false
                   event = nil
-                  scope = gateway_request.env['datadog.appsec.scope']
+                  scope = gateway_request.env[Datadog::AppSec::Ext::SCOPE_KEY]
 
                   AppSec::Reactive::Operation.new('rack.request.body') do |op|
                     trace = active_trace

--- a/lib/datadog/appsec/contrib/rack/request_body_middleware.rb
+++ b/lib/datadog/appsec/contrib/rack/request_body_middleware.rb
@@ -17,7 +17,7 @@ module Datadog
           end
 
           def call(env)
-            context = env['datadog.waf.context']
+            context = env['datadog.appsec.scope']
 
             return @app.call(env) unless context
 

--- a/lib/datadog/appsec/contrib/rack/request_body_middleware.rb
+++ b/lib/datadog/appsec/contrib/rack/request_body_middleware.rb
@@ -17,7 +17,7 @@ module Datadog
           end
 
           def call(env)
-            context = env['datadog.appsec.scope']
+            context = env[Datadog::AppSec::Ext::SCOPE_KEY]
 
             return @app.call(env) unless context
 

--- a/lib/datadog/appsec/contrib/rack/request_middleware.rb
+++ b/lib/datadog/appsec/contrib/rack/request_middleware.rb
@@ -2,7 +2,6 @@ require 'json'
 
 require_relative 'gateway/request'
 require_relative 'gateway/response'
-require_relative '../../ext'
 require_relative '../../instrumentation/gateway'
 require_relative '../../processor'
 require_relative '../../response'
@@ -43,7 +42,7 @@ module Datadog
 
               if !processor.nil? && processor.ready?
                 scope = Datadog::AppSec::Scope.activate_scope(active_trace, active_span, processor)
-                env['datadog.appsec.scope'] = scope
+                env[Datadog::AppSec::Ext::SCOPE_KEY] = scope
                 ready = true
               end
             end
@@ -98,7 +97,7 @@ module Datadog
           private
 
           def active_scope(env)
-            env['datadog.appsec.scope']
+            env[Datadog::AppSec::Ext::SCOPE_KEY]
           end
 
           def active_trace

--- a/lib/datadog/appsec/contrib/rails/gateway/watcher.rb
+++ b/lib/datadog/appsec/contrib/rails/gateway/watcher.rb
@@ -21,13 +21,13 @@ module Datadog
                 gateway.watch('rails.request.action', :appsec) do |stack, gateway_request|
                   block = false
                   event = nil
-                  waf_context = gateway_request.env['datadog.waf.context']
+                  scope = gateway_request.env['datadog.appsec.scope']
 
                   AppSec::Reactive::Operation.new('rails.request.action') do |op|
                     trace = active_trace
                     span = active_span
 
-                    Rails::Reactive::Action.subscribe(op, waf_context) do |result, _block|
+                    Rails::Reactive::Action.subscribe(op, scope.processor_context) do |result, _block|
                       if result.status == :match
                         # TODO: should this hash be an Event instance instead?
                         event = {
@@ -40,7 +40,7 @@ module Datadog
 
                         span.set_tag('appsec.event', 'true') if span
 
-                        waf_context.events << event
+                        scope.processor_context.events << event
                       end
                     end
 

--- a/lib/datadog/appsec/contrib/rails/gateway/watcher.rb
+++ b/lib/datadog/appsec/contrib/rails/gateway/watcher.rb
@@ -21,7 +21,7 @@ module Datadog
                 gateway.watch('rails.request.action', :appsec) do |stack, gateway_request|
                   block = false
                   event = nil
-                  scope = gateway_request.env['datadog.appsec.scope']
+                  scope = gateway_request.env[Datadog::AppSec::Ext::SCOPE_KEY]
 
                   AppSec::Reactive::Operation.new('rails.request.action') do |op|
                     trace = active_trace

--- a/lib/datadog/appsec/contrib/rails/patcher.rb
+++ b/lib/datadog/appsec/contrib/rails/patcher.rb
@@ -72,7 +72,7 @@ module Datadog
             def process_action(*args)
               env = request.env
 
-              context = env['datadog.appsec.scope']
+              context = env[Datadog::AppSec::Ext::SCOPE_KEY]
 
               return super unless context
 

--- a/lib/datadog/appsec/contrib/rails/patcher.rb
+++ b/lib/datadog/appsec/contrib/rails/patcher.rb
@@ -72,7 +72,7 @@ module Datadog
             def process_action(*args)
               env = request.env
 
-              context = env['datadog.waf.context']
+              context = env['datadog.appsec.scope']
 
               return super unless context
 

--- a/lib/datadog/appsec/contrib/sinatra/gateway/watcher.rb
+++ b/lib/datadog/appsec/contrib/sinatra/gateway/watcher.rb
@@ -23,13 +23,13 @@ module Datadog
                 gateway.watch('sinatra.request.dispatch', :appsec) do |stack, gateway_request|
                   block = false
                   event = nil
-                  waf_context = gateway_request.env['datadog.waf.context']
+                  scope = gateway_request.env['datadog.appsec.scope']
 
                   AppSec::Reactive::Operation.new('sinatra.request.dispatch') do |op|
                     trace = active_trace
                     span = active_span
 
-                    Rack::Reactive::RequestBody.subscribe(op, waf_context) do |result, _block|
+                    Rack::Reactive::RequestBody.subscribe(op, scope.processor_context) do |result, _block|
                       if result.status == :match
                         # TODO: should this hash be an Event instance instead?
                         event = {
@@ -42,7 +42,7 @@ module Datadog
 
                         span.set_tag('appsec.event', 'true') if span
 
-                        waf_context.events << event
+                        scope.processor_context.events << event
                       end
                     end
 
@@ -66,13 +66,13 @@ module Datadog
                 gateway.watch('sinatra.request.routed', :appsec) do |stack, (gateway_request, gateway_route_params)|
                   block = false
                   event = nil
-                  waf_context = gateway_request.env['datadog.waf.context']
+                  scope = gateway_request.env['datadog.appsec.scope']
 
                   AppSec::Reactive::Operation.new('sinatra.request.routed') do |op|
                     trace = active_trace
                     span = active_span
 
-                    Sinatra::Reactive::Routed.subscribe(op, waf_context) do |result, _block|
+                    Sinatra::Reactive::Routed.subscribe(op, scope.processor_context) do |result, _block|
                       if result.status == :match
                         # TODO: should this hash be an Event instance instead?
                         event = {
@@ -85,7 +85,7 @@ module Datadog
 
                         span.set_tag('appsec.event', 'true') if span
 
-                        waf_context.events << event
+                        scope.processor_context.events << event
                       end
                     end
 

--- a/lib/datadog/appsec/contrib/sinatra/gateway/watcher.rb
+++ b/lib/datadog/appsec/contrib/sinatra/gateway/watcher.rb
@@ -23,7 +23,7 @@ module Datadog
                 gateway.watch('sinatra.request.dispatch', :appsec) do |stack, gateway_request|
                   block = false
                   event = nil
-                  scope = gateway_request.env['datadog.appsec.scope']
+                  scope = gateway_request.env[Datadog::AppSec::Ext::SCOPE_KEY]
 
                   AppSec::Reactive::Operation.new('sinatra.request.dispatch') do |op|
                     trace = active_trace
@@ -66,7 +66,7 @@ module Datadog
                 gateway.watch('sinatra.request.routed', :appsec) do |stack, (gateway_request, gateway_route_params)|
                   block = false
                   event = nil
-                  scope = gateway_request.env['datadog.appsec.scope']
+                  scope = gateway_request.env[Datadog::AppSec::Ext::SCOPE_KEY]
 
                   AppSec::Reactive::Operation.new('sinatra.request.routed') do |op|
                     trace = active_trace

--- a/lib/datadog/appsec/contrib/sinatra/patcher.rb
+++ b/lib/datadog/appsec/contrib/sinatra/patcher.rb
@@ -52,7 +52,7 @@ module Datadog
           def dispatch!
             env = @request.env
 
-            context = env['datadog.waf.context']
+            context = env['datadog.appsec.scope']
 
             return super unless context
 
@@ -81,7 +81,7 @@ module Datadog
           def process_route(*)
             env = @request.env
 
-            context = env['datadog.waf.context']
+            context = env['datadog.appsec.scope']
 
             return super unless context
 

--- a/lib/datadog/appsec/contrib/sinatra/patcher.rb
+++ b/lib/datadog/appsec/contrib/sinatra/patcher.rb
@@ -52,7 +52,7 @@ module Datadog
           def dispatch!
             env = @request.env
 
-            context = env['datadog.appsec.scope']
+            context = env[Datadog::AppSec::Ext::SCOPE_KEY]
 
             return super unless context
 
@@ -81,7 +81,7 @@ module Datadog
           def process_route(*)
             env = @request.env
 
-            context = env['datadog.appsec.scope']
+            context = env[Datadog::AppSec::Ext::SCOPE_KEY]
 
             return super unless context
 

--- a/lib/datadog/appsec/ext.rb
+++ b/lib/datadog/appsec/ext.rb
@@ -4,6 +4,7 @@ module Datadog
   module AppSec
     module Ext
       INTERRUPT = :datadog_appsec_interrupt
+      SCOPE_KEY = 'datadog.appsec.scope'
     end
   end
 end

--- a/lib/datadog/appsec/monitor/gateway/watcher.rb
+++ b/lib/datadog/appsec/monitor/gateway/watcher.rb
@@ -1,6 +1,5 @@
 # frozen_string_literal: true
 
-require_relative '../../ext'
 require_relative '../../instrumentation/gateway'
 require_relative '../../reactive/operation'
 require_relative '../reactive/set_user'

--- a/lib/datadog/appsec/monitor/gateway/watcher.rb
+++ b/lib/datadog/appsec/monitor/gateway/watcher.rb
@@ -22,13 +22,13 @@ module Datadog
               gateway.watch('identity.set_user', :appsec) do |stack, user|
                 block = false
                 event = nil
-                waf_context = Datadog::AppSec::Processor.active_context
+                scope = Datadog::AppSec.active_scope
 
                 AppSec::Reactive::Operation.new('identity.set_user') do |op|
                   trace = active_trace
                   span = active_span
 
-                  Monitor::Reactive::SetUser.subscribe(op, waf_context) do |result, _block|
+                  Monitor::Reactive::SetUser.subscribe(op, scope.processor_context) do |result, _block|
                     if result.status == :match
                       # TODO: should this hash be an Event instance instead?
                       event = {
@@ -41,7 +41,7 @@ module Datadog
 
                       span.set_tag('appsec.event', 'true') if span
 
-                      waf_context.events << event
+                      scope.processor_context.events << event
                     end
                   end
 

--- a/lib/datadog/appsec/processor.rb
+++ b/lib/datadog/appsec/processor.rb
@@ -43,30 +43,6 @@ module Datadog
         end
       end
 
-      class << self
-        def active_context
-          Thread.current[:datadog_current_waf_context]
-        end
-
-        private
-
-        def active_context=(context)
-          unless context.instance_of?(Context)
-            raise ArgumentError,
-              "The context provide: #{context.inspect} is not a Datadog::AppSec::Processor::Context"
-          end
-
-          Thread.current[:datadog_current_waf_context] = context
-        end
-
-        def reset_active_context
-          Thread.current[:datadog_current_waf_context] = nil
-        end
-      end
-
-      class NoActiveContextError < StandardError; end
-      class AlreadyActiveContextError < StandardError; end
-
       attr_reader :ruleset_info, :addresses
 
       def initialize(ruleset:)
@@ -85,23 +61,6 @@ module Datadog
 
       def new_context
         Context.new(self)
-      end
-
-      def activate_context
-        existing_active_context = Processor.active_context
-        raise AlreadyActiveContextError if existing_active_context
-
-        context = new_context
-        Processor.send(:active_context=, context)
-        context
-      end
-
-      def deactivate_context
-        context = Processor.active_context
-        raise NoActiveContextError unless context
-
-        Processor.send(:reset_active_context)
-        context.finalize
       end
 
       def finalize

--- a/lib/datadog/appsec/processor.rb
+++ b/lib/datadog/appsec/processor.rb
@@ -59,10 +59,6 @@ module Datadog
         !@handle.nil?
       end
 
-      def new_context
-        Context.new(self)
-      end
-
       def finalize
         @handle.finalize
       end

--- a/lib/datadog/appsec/scope.rb
+++ b/lib/datadog/appsec/scope.rb
@@ -21,8 +21,9 @@ module Datadog
       class << self
         def activate_scope(trace, service_entry_span, processor)
           raise ActiveScopeError, 'another scope is active, nested scopes are not supported' if active_scope
+          context = Datadog::AppSec::Processor::Context.new(processor)
 
-          self.active_scope = new(trace, service_entry_span, processor.new_context)
+          self.active_scope = new(trace, service_entry_span, context)
         end
 
         def deactivate_scope
@@ -41,7 +42,7 @@ module Datadog
         private
 
         def active_scope=(scope)
-          raise ArgumentError, "#{scope.inspect} is not a Datadog::AppSec::Scope" unless scope.instance_of?(Scope)
+          raise ArgumentError, 'not a Datadog::AppSec::Scope' unless scope.instance_of?(Scope)
 
           Thread.current[:datadog_appsec_active_scope] = scope
         end

--- a/lib/datadog/appsec/scope.rb
+++ b/lib/datadog/appsec/scope.rb
@@ -21,6 +21,7 @@ module Datadog
       class << self
         def activate_scope(trace, service_entry_span, processor)
           raise ActiveScopeError, 'another scope is active, nested scopes are not supported' if active_scope
+
           context = Datadog::AppSec::Processor::Context.new(processor)
 
           self.active_scope = new(trace, service_entry_span, context)
@@ -28,6 +29,7 @@ module Datadog
 
         def deactivate_scope
           raise InactiveScopeError, 'no scope is active, nested scopes are not supported' unless active_scope
+
           scope = active_scope
 
           reset_active_scope

--- a/lib/datadog/appsec/scope.rb
+++ b/lib/datadog/appsec/scope.rb
@@ -1,5 +1,7 @@
 # frozen_string_literal: true
 
+require_relative 'processor'
+
 module Datadog
   module AppSec
     # Capture context essential to consistently call processor and report via traces
@@ -10,8 +12,6 @@ module Datadog
         @trace = trace
         @service_entry_span = service_entry_span
         @processor_context = processor_context
-
-        freeze
       end
 
       def finalize

--- a/lib/datadog/appsec/scope.rb
+++ b/lib/datadog/appsec/scope.rb
@@ -1,0 +1,58 @@
+# frozen_string_literal: true
+
+module Datadog
+  module AppSec
+    # Capture context essential to consistently call processor and report via traces
+    class Scope
+      attr_reader :trace, :service_entry_span, :processor_context
+
+      def initialize(trace, service_entry_span, processor_context)
+        @trace = trace
+        @service_entry_span = service_entry_span
+        @processor_context = processor_context
+
+        freeze
+      end
+
+      def finalize
+        @processor_context.finalize
+      end
+
+      class << self
+        def activate_scope(trace, service_entry_span, processor)
+          raise ActiveScopeError, 'another scope is active, nested scopes are not supported' if active_scope
+
+          self.active_scope = new(trace, service_entry_span, processor.new_context)
+        end
+
+        def deactivate_scope
+          raise InactiveScopeError, 'no scope is active, nested scopes are not supported' unless active_scope
+          scope = active_scope
+
+          reset_active_scope
+
+          scope.finalize
+        end
+
+        def active_scope
+          Thread.current[:datadog_appsec_active_scope]
+        end
+
+        private
+
+        def active_scope=(scope)
+          raise ArgumentError, "#{scope.inspect} is not a Datadog::AppSec::Scope" unless scope.instance_of?(Scope)
+
+          Thread.current[:datadog_appsec_active_scope] = scope
+        end
+
+        def reset_active_scope
+          Thread.current[:datadog_appsec_active_scope] = nil
+        end
+      end
+
+      class InactiveScopeError < StandardError; end
+      class ActiveScopeError < StandardError; end
+    end
+  end
+end

--- a/lib/datadog/kit/appsec/events.rb
+++ b/lib/datadog/kit/appsec/events.rb
@@ -27,15 +27,13 @@ module Datadog
         def self.track_login_success(trace = nil, span = nil, user:, **others)
           if (appsec_scope = Datadog::AppSec.active_scope)
             trace = appsec_scope.trace
-            span = appsec_scope.span
+            span = appsec_scope.service_entry_span
           end
 
           trace ||= Datadog::Tracing.active_trace
           span ||= trace.active_span || Datadog::Tracing.active_span
 
-          if trace.trace_id != span.trace_id
-            raise ArgumentError, "span #{span.span_id} does not belong to trace #{trace.trace_id}"
-          end
+          raise ArgumentError, "span #{span.span_id} does not belong to trace #{trace.id}" if trace.id != span.trace_id
 
           track(LOGIN_SUCCESS_EVENT, trace, span, **others)
 
@@ -64,15 +62,13 @@ module Datadog
         def self.track_login_failure(trace = nil, span = nil, user_id:, user_exists:, **others)
           if (appsec_scope = Datadog::AppSec.active_scope)
             trace = appsec_scope.trace
-            span = appsec_scope.span
+            span = appsec_scope.service_entry_span
           end
 
           trace ||= Datadog::Tracing.active_trace
           span ||= trace.active_span || Datadog::Tracing.active_span
 
-          if trace.trace_id != span.trace_id
-            raise ArgumentError, "span #{span.span_id} does not belong to trace #{trace.trace_id}"
-          end
+          raise ArgumentError, "span #{span.span_id} does not belong to trace #{trace.id}" if trace.id != span.trace_id
 
           track(LOGIN_FAILURE_EVENT, trace, span, **others)
 
@@ -99,15 +95,13 @@ module Datadog
         def self.track(event, trace = nil, span = nil, **others)
           if (appsec_scope = Datadog::AppSec.active_scope)
             trace = appsec_scope.trace
-            span = appsec_scope.span
+            span = appsec_scope.service_entry_span
           end
 
           trace ||= Datadog::Tracing.active_trace
           span ||= trace.active_span || Datadog::Tracing.active_span
 
-          if trace.trace_id != span.trace_id
-            raise ArgumentError, "span #{span.span_id} does not belong to trace #{trace.trace_id}"
-          end
+          raise ArgumentError, "span #{span.span_id} does not belong to trace #{trace.id}" if trace.id != span.trace_id
 
           span.set_tag("appsec.events.#{event}.track", 'true')
 

--- a/lib/datadog/kit/appsec/events.rb
+++ b/lib/datadog/kit/appsec/events.rb
@@ -14,38 +14,72 @@ module Datadog
         #
         # This method is experimental and may change in the future.
         #
-        # @param trace [TraceOperation] Trace to attach data to.
+        # @param trace [TraceOperation] Trace to attach data to. Defaults to
+        #   active trace.
+        # @param span [SpanOperation] Span to attach data to. Defaults to
+        #   active span on trace. Note that this should be a service entry span.
+        #   When AppSec is enabled, the expected span and trace are automatically
+        #   used as defaults.
         # @param user [Hash<Symbol, String>] User information to pass to
         #   Datadog::Kit::Identity.set_user. Must contain at least :id as key.
         # @param others [Hash<String || Symbol, String>] Additional free-form
         #   event information to attach to the trace.
-        def self.track_login_success(trace, user:, **others)
-          track(LOGIN_SUCCESS_EVENT, trace, **others)
+        def self.track_login_success(trace = nil, span = nil, user:, **others)
+          if (appsec_scope = Datadog::AppSec.active_scope)
+            trace = appsec_scope.trace
+            span = appsec_scope.span
+          end
+
+          trace ||= Datadog::Tracing.active_trace
+          span ||= trace.active_span || Datadog::Tracing.active_span
+
+          if trace.trace_id != span.trace_id
+            raise ArgumentError, "span #{span.span_id} does not belong to trace #{trace.trace_id}"
+          end
+
+          track(LOGIN_SUCCESS_EVENT, trace, span, **others)
 
           user_options = user.dup
           user_id = user_options.delete(:id)
 
           raise ArgumentError, 'missing required key: :user => { :id }' if user_id.nil?
 
-          Kit::Identity.set_user(trace, id: user_id, **user_options)
+          Kit::Identity.set_user(trace, span, id: user_id, **user_options)
         end
 
         # Attach login failure event information to the trace
         #
         # This method is experimental and may change in the future.
         #
-        # @param trace [TraceOperation] Trace to attach data to.
+        # @param trace [TraceOperation] Trace to attach data to. Defaults to
+        #   active trace.
+        # @param span [SpanOperation] Span to attach data to. Defaults to
+        #   active span on trace. Note that this should be a service entry span.
+        #   When AppSec is enabled, the expected span and trace are automatically
+        #   used as defaults.
         # @param user_id [String] User id that attempted login
         # @param user_exists [bool] Whether the user id that did a login attempt exists.
         # @param others [Hash<String || Symbol, String>] Additional free-form
         #   event information to attach to the trace.
-        def self.track_login_failure(trace, user_id:, user_exists:, **others)
-          track(LOGIN_FAILURE_EVENT, trace, **others)
+        def self.track_login_failure(trace = nil, span = nil, user_id:, user_exists:, **others)
+          if (appsec_scope = Datadog::AppSec.active_scope)
+            trace = appsec_scope.trace
+            span = appsec_scope.span
+          end
+
+          trace ||= Datadog::Tracing.active_trace
+          span ||= trace.active_span || Datadog::Tracing.active_span
+
+          if trace.trace_id != span.trace_id
+            raise ArgumentError, "span #{span.span_id} does not belong to trace #{trace.trace_id}"
+          end
+
+          track(LOGIN_FAILURE_EVENT, trace, span, **others)
 
           raise ArgumentError, 'user_id cannot be nil' if user_id.nil?
 
-          trace.set_tag('appsec.events.users.login.failure.usr.id', user_id)
-          trace.set_tag('appsec.events.users.login.failure.usr.exists', user_exists)
+          span.set_tag('appsec.events.users.login.failure.usr.id', user_id)
+          span.set_tag('appsec.events.users.login.failure.usr.exists', user_exists)
         end
 
         # Attach custom event information to the trace
@@ -53,17 +87,34 @@ module Datadog
         # This method is experimental and may change in the future.
         #
         # @param event [String] Mandatory. Event code.
-        # @param trace [TraceOperation] Trace to attach data to.
+        # @param trace [TraceOperation] Trace to attach data to. Defaults to
+        #   active trace.
+        # @param span [SpanOperation] Span to attach data to. Defaults to
+        #   active span on trace. Note that this should be a service entry span.
+        #   When AppSec is enabled, the expected span and trace are automatically
+        #   used as defaults.
         # @param others [Hash<Symbol, String>] Additional free-form
         #   event information to attach to the trace. Key must not
         #   be :track.
-        def self.track(event, trace, **others)
-          trace.set_tag("appsec.events.#{event}.track", 'true')
+        def self.track(event, trace = nil, span = nil, **others)
+          if (appsec_scope = Datadog::AppSec.active_scope)
+            trace = appsec_scope.trace
+            span = appsec_scope.span
+          end
+
+          trace ||= Datadog::Tracing.active_trace
+          span ||= trace.active_span || Datadog::Tracing.active_span
+
+          if trace.trace_id != span.trace_id
+            raise ArgumentError, "span #{span.span_id} does not belong to trace #{trace.trace_id}"
+          end
+
+          span.set_tag("appsec.events.#{event}.track", 'true')
 
           others.each do |k, v|
             raise ArgumentError, 'key cannot be :track' if k.to_sym == :track
 
-            trace.set_tag("appsec.events.#{event}.#{k}", v) unless v.nil?
+            span.set_tag("appsec.events.#{event}.#{k}", v) unless v.nil?
           end
 
           trace.keep!

--- a/lib/datadog/kit/identity.rb
+++ b/lib/datadog/kit/identity.rb
@@ -53,15 +53,13 @@ module Datadog
 
         if (appsec_scope = Datadog::AppSec.active_scope)
           trace = appsec_scope.trace
-          span = appsec_scope.span
+          span = appsec_scope.service_entry_span
         end
 
         trace ||= Datadog::Tracing.active_trace
         span ||= trace.active_span || Datadog::Tracing.active_span
 
-        if trace.trace_id != span.trace_id
-          raise ArgumentError, "span #{span.span_id} does not belong to trace #{trace.trace_id}"
-        end
+        raise ArgumentError, "span #{span.span_id} does not belong to trace #{trace.id}" if trace.id != span.trace_id
 
         # set tags once data is known consistent
 

--- a/lib/datadog/kit/identity.rb
+++ b/lib/datadog/kit/identity.rb
@@ -35,7 +35,9 @@ module Datadog
       # rubocop:disable Metrics/CyclomaticComplexity
       # rubocop:disable Metrics/PerceivedComplexity
       # rubocop:disable Metrics/AbcSize
-      def self.set_user(trace = nil, span = nil, id:, email: nil, name: nil, session_id: nil, role: nil, scope: nil, **others)
+      def self.set_user(
+        trace = nil, span = nil, id:, email: nil, name: nil, session_id: nil, role: nil, scope: nil, **others
+      )
         raise ArgumentError, 'missing required key: :id' if id.nil?
 
         # enforce types

--- a/sig/datadog/appsec/event.rbs
+++ b/sig/datadog/appsec/event.rbs
@@ -5,9 +5,9 @@ module Datadog
 
       ALLOWED_RESPONSE_HEADERS: untyped
 
-      def self.record: (*untyped events) -> (nil | untyped)
+      def self.record: (Datadog::Tracing::SpanOperation, *untyped events) -> (nil | untyped)
 
-      def self.record_via_span: (*untyped events) -> untyped
+      def self.record_via_span: (Datadog::Tracing::SpanOperation, *untyped events) -> untyped
     end
   end
 end

--- a/sig/datadog/appsec/ext.rbs
+++ b/sig/datadog/appsec/ext.rbs
@@ -2,6 +2,7 @@ module Datadog
   module AppSec
     module Ext
       INTERRUPT: Symbol
+      SCOPE_KEY: String
     end
   end
 end

--- a/sig/datadog/appsec/processor.rbs
+++ b/sig/datadog/appsec/processor.rbs
@@ -23,15 +23,6 @@ module Datadog
 
       private
 
-      def self.active_context=: (untyped context) -> untyped
-      def self.reset_active_context: () -> untyped
-
-      class NoActiveContextError < StandardError
-      end
-
-      class AlreadyActiveContextError < StandardError
-      end
-
       attr_reader ruleset_info: untyped
       attr_reader addresses: untyped
 
@@ -41,9 +32,6 @@ module Datadog
 
       def initialize: (ruleset: ::Hash[untyped, untyped]) -> void
       def ready?: () -> bool
-      def new_context: () -> Context
-      def activate_context: () -> Context
-      def deactivate_context: () -> void
       def finalize: () -> void
 
       attr_reader handle: untyped

--- a/sig/datadog/appsec/scope.rbs
+++ b/sig/datadog/appsec/scope.rbs
@@ -1,0 +1,35 @@
+module Datadog
+  module AppSec
+    class Scope
+      attr_reader trace: Datadog::Tracing::TraceOperation
+
+      attr_reader service_entry_span: Datadog::Tracing::SpanOperation
+
+      attr_reader processor_context: Datadog::AppSec::Processor::Context
+
+      def initialize: (Datadog::Tracing::TraceOperation trace, Datadog::Tracing::SpanOperation service_entry_span, Datadog::AppSec::Processor::Context processor_context) -> void
+
+      def finalize: () -> void
+
+      def self.activate_scope: (Datadog::Tracing::TraceOperation trace, Datadog::Tracing::SpanOperation service_entry_span, Datadog::AppSec::Processor processor) -> Scope
+
+      def self.deactivate_scope: () -> void
+
+      def self.active_scope: () -> Scope
+
+      private
+
+      def self.active_scope=: (Scope scope) -> Scope
+
+      def self.reset_active_scope: () -> void
+
+      public
+
+      class InactiveScopeError < StandardError
+      end
+
+      class ActiveScopeError < StandardError
+      end
+    end
+  end
+end

--- a/sig/datadog/tracing/span_operation.rbs
+++ b/sig/datadog/tracing/span_operation.rbs
@@ -2,31 +2,52 @@ module Datadog
   module Tracing
     class SpanOperation
       include Metadata
+      include Metadata::Tagging
+      include Metadata::Errors
+      prepend Metadata::Analytics
+
       attr_reader end_time: untyped
+
       attr_reader id: untyped
+
       attr_reader name: untyped
+
       attr_reader parent_id: untyped
+
       attr_reader resource: untyped
+
       attr_reader service: untyped
+
       attr_reader start_time: untyped
+
       attr_reader trace_id: untyped
+
       attr_reader type: untyped
 
       attr_accessor status: untyped
 
       def initialize: (untyped name, ?child_of: untyped?, ?events: untyped?, ?on_error: untyped?, ?parent_id: ::Integer, ?resource: untyped, ?service: untyped?, ?start_time: untyped?, ?tags: untyped?, ?trace_id: untyped?, ?type: untyped?) -> void
+
       def name=: (untyped name) -> untyped
+
       def type=: (untyped `type`) -> untyped
+
       def service=: (untyped service) -> untyped
+
       def resource=: (untyped resource) -> untyped
 
       def measure: () { (untyped) -> untyped } -> untyped
 
       def start: (?untyped? start_time) -> self
+
       def stop: (?untyped? stop_time) -> (nil | self)
+
       def started?: () -> untyped
+
       def stopped?: () -> untyped
+
       def start_time=: (untyped time) -> untyped
+
       def end_time=: (untyped time) -> untyped
 
       def finish: (?untyped? end_time) -> untyped
@@ -36,9 +57,13 @@ module Datadog
       def duration: () -> untyped
 
       def set_error: (untyped e) -> untyped
+
       def to_s: () -> ::String
+
       def to_hash: () -> untyped
+
       def pretty_print: (untyped q) -> untyped
+
       class Events
         include Tracing::Events
 
@@ -51,39 +76,55 @@ module Datadog
         attr_reader before_start: untyped
 
         def initialize: (?on_error: untyped?) -> void
+
         def on_error: () -> untyped
+
         class AfterFinish < Tracing::Event
           def initialize: () -> void
         end
+
         class AfterStop < Tracing::Event
           def initialize: () -> void
         end
+
         class BeforeStart < Tracing::Event
           def initialize: () -> void
         end
+
         class OnError
           def initialize: (untyped default) -> void
+
           def wrap_default: () { (untyped, untyped) -> untyped } -> untyped
 
           def publish: (*untyped args) -> true
         end
       end
+
       class AlreadyStartedError < StandardError
         def message: () -> "Cannot measure an already started span!"
       end
 
       private
+
       attr_reader events: untyped
+
       attr_reader parent: untyped
+
       attr_reader span: untyped
+
       module RefineNil
       end
+
       def build_span: () -> untyped
+
       def parent=: (untyped parent) -> untyped
 
       def duration_marker: () -> untyped
+
       def start_time_nano: () -> untyped
+
       def duration_nano: () -> untyped
+
       alias span_id id
 
       alias span_type type

--- a/spec/datadog/appsec/contrib/rack/gateway/response_spec.rb
+++ b/spec/datadog/appsec/contrib/rack/gateway/response_spec.rb
@@ -2,7 +2,7 @@
 
 require 'datadog/appsec/spec_helper'
 require 'datadog/appsec/contrib/rack/gateway/response'
-require 'datadog/appsec/processor'
+require 'datadog/appsec/scope'
 require 'rack'
 
 RSpec.describe Datadog::AppSec::Contrib::Rack::Gateway::Response do
@@ -11,7 +11,7 @@ RSpec.describe Datadog::AppSec::Contrib::Rack::Gateway::Response do
       'Ok',
       200,
       { 'Content-Type' => 'text/html' },
-      active_context: instance_double(Datadog::AppSec::Processor::Context)
+      scope: instance_double(Datadog::AppSec::Scope)
     )
   end
 

--- a/spec/datadog/appsec/contrib/rack/integration_test_spec.rb
+++ b/spec/datadog/appsec/contrib/rack/integration_test_spec.rb
@@ -164,13 +164,21 @@ RSpec.describe 'Rack integration tests' do
     end
 
     let(:triggers) do
-      json = trace.send(:meta)['_dd.appsec.json']
+      json = service_span.send(:meta)['_dd.appsec.json']
 
       JSON.parse(json).fetch('triggers', []) if json
     end
 
     let(:remote_addr) { '127.0.0.1' }
     let(:client_ip) { remote_addr }
+
+    let(:service_span) do
+      span = spans.find { |s| s.metrics.fetch('_dd.top_level', -1.0) > 0.0 }
+
+      expect(span.name).to eq 'rack.request'
+
+      span
+    end
 
     shared_examples 'a GET 200 span' do
       it do
@@ -264,18 +272,18 @@ RSpec.describe 'Rack integration tests' do
 
     shared_examples 'a trace without AppSec tags' do
       it do
-        expect(trace.send(:metrics)['_dd.appsec.enabled']).to be_nil
-        expect(trace.send(:meta)['_dd.runtime_family']).to be_nil
-        expect(trace.send(:meta)['_dd.appsec.waf.version']).to be_nil
+        expect(service_span.send(:metrics)['_dd.appsec.enabled']).to be_nil
+        expect(service_span.send(:meta)['_dd.runtime_family']).to be_nil
+        expect(service_span.send(:meta)['_dd.appsec.waf.version']).to be_nil
         expect(span.send(:meta)['http.client_ip']).to eq nil
       end
     end
 
     shared_examples 'a trace with AppSec tags' do
       it do
-        expect(trace.send(:metrics)['_dd.appsec.enabled']).to eq(1.0)
-        expect(trace.send(:meta)['_dd.runtime_family']).to eq('ruby')
-        expect(trace.send(:meta)['_dd.appsec.waf.version']).to match(/^\d+\.\d+\.\d+/)
+        expect(service_span.send(:metrics)['_dd.appsec.enabled']).to eq(1.0)
+        expect(service_span.send(:meta)['_dd.runtime_family']).to eq('ruby')
+        expect(service_span.send(:meta)['_dd.appsec.waf.version']).to match(/^\d+\.\d+\.\d+/)
         expect(span.send(:meta)['http.client_ip']).to eq client_ip
       end
 
@@ -289,14 +297,14 @@ RSpec.describe 'Rack integration tests' do
     shared_examples 'a trace without AppSec events' do
       it do
         expect(spans.select { |s| s.get_tag('appsec.event') }).to be_empty
-        expect(trace.send(:meta)['_dd.appsec.triggers']).to be_nil
+        expect(service_span.send(:meta)['_dd.appsec.triggers']).to be_nil
       end
     end
 
     shared_examples 'a trace with AppSec events' do
       it do
         expect(spans.select { |s| s.get_tag('appsec.event') }).to_not be_empty
-        expect(trace.send(:meta)['_dd.appsec.json']).to be_a String
+        expect(service_span.send(:meta)['_dd.appsec.json']).to be_a String
       end
 
       context 'with appsec disabled' do

--- a/spec/datadog/appsec/contrib/rack/integration_test_spec.rb
+++ b/spec/datadog/appsec/contrib/rack/integration_test_spec.rb
@@ -325,7 +325,7 @@ RSpec.describe 'Rack integration tests' do
             run(
               proc do |env|
                 # When appsec is enabled we want to force the 404 to trigger a rule match
-                if env['datadog.appsec.scope']
+                if env[Datadog::AppSec::Ext::SCOPE_KEY]
                   [404, { 'Content-Type' => 'text/html' }, ['NOT FOUND']]
                 else
                   [200, { 'Content-Type' => 'text/html' }, ['OK']]

--- a/spec/datadog/appsec/contrib/rack/integration_test_spec.rb
+++ b/spec/datadog/appsec/contrib/rack/integration_test_spec.rb
@@ -325,7 +325,7 @@ RSpec.describe 'Rack integration tests' do
             run(
               proc do |env|
                 # When appsec is enabled we want to force the 404 to trigger a rule match
-                if env['datadog.waf.context']
+                if env['datadog.appsec.scope']
                   [404, { 'Content-Type' => 'text/html' }, ['NOT FOUND']]
                 else
                   [200, { 'Content-Type' => 'text/html' }, ['OK']]

--- a/spec/datadog/appsec/contrib/rails/integration_test_spec.rb
+++ b/spec/datadog/appsec/contrib/rails/integration_test_spec.rb
@@ -135,13 +135,21 @@ RSpec.describe 'Rails integration tests' do
     end
 
     let(:triggers) do
-      json = trace.send(:meta)['_dd.appsec.json']
+      json = service_span.send(:meta)['_dd.appsec.json']
 
       JSON.parse(json).fetch('triggers', []) if json
     end
 
     let(:remote_addr) { '127.0.0.1' }
     let(:client_ip) { remote_addr }
+
+    let(:service_span) do
+      span = sorted_spans.reverse.find { |s| s.metrics.fetch('_dd.top_level', -1.0) > 0.0 }
+
+      expect(span.name).to eq 'rack.request'
+
+      span
+    end
 
     let(:span) { rack_span }
 
@@ -237,18 +245,18 @@ RSpec.describe 'Rails integration tests' do
 
     shared_examples 'a trace without AppSec tags' do
       it do
-        expect(trace.send(:metrics)['_dd.appsec.enabled']).to be_nil
-        expect(trace.send(:meta)['_dd.runtime_family']).to be_nil
-        expect(trace.send(:meta)['_dd.appsec.waf.version']).to be_nil
+        expect(service_span.send(:metrics)['_dd.appsec.enabled']).to be_nil
+        expect(service_span.send(:meta)['_dd.runtime_family']).to be_nil
+        expect(service_span.send(:meta)['_dd.appsec.waf.version']).to be_nil
         expect(span.send(:meta)['http.client_ip']).to eq nil
       end
     end
 
     shared_examples 'a trace with AppSec tags' do
       it do
-        expect(trace.send(:metrics)['_dd.appsec.enabled']).to eq(1.0)
-        expect(trace.send(:meta)['_dd.runtime_family']).to eq('ruby')
-        expect(trace.send(:meta)['_dd.appsec.waf.version']).to match(/^\d+\.\d+\.\d+/)
+        expect(service_span.send(:metrics)['_dd.appsec.enabled']).to eq(1.0)
+        expect(service_span.send(:meta)['_dd.runtime_family']).to eq('ruby')
+        expect(service_span.send(:meta)['_dd.appsec.waf.version']).to match(/^\d+\.\d+\.\d+/)
         expect(span.send(:meta)['http.client_ip']).to eq client_ip
       end
 
@@ -262,14 +270,14 @@ RSpec.describe 'Rails integration tests' do
     shared_examples 'a trace without AppSec events' do
       it do
         expect(spans.select { |s| s.get_tag('appsec.event') }).to be_empty
-        expect(trace.send(:meta)['_dd.appsec.triggers']).to be_nil
+        expect(service_span.send(:meta)['_dd.appsec.triggers']).to be_nil
       end
     end
 
     shared_examples 'a trace with AppSec events' do
       it do
         expect(spans.select { |s| s.get_tag('appsec.event') }).to_not be_empty
-        expect(trace.send(:meta)['_dd.appsec.json']).to be_a String
+        expect(service_span.send(:meta)['_dd.appsec.json']).to be_a String
       end
 
       context 'with appsec disabled' do

--- a/spec/datadog/appsec/contrib/sinatra/integration_test_spec.rb
+++ b/spec/datadog/appsec/contrib/sinatra/integration_test_spec.rb
@@ -130,13 +130,21 @@ RSpec.describe 'Sinatra integration tests' do
     end
 
     let(:triggers) do
-      json = trace.send(:meta)['_dd.appsec.json']
+      json = service_span.send(:meta)['_dd.appsec.json']
 
       JSON.parse(json).fetch('triggers', []) if json
     end
 
     let(:remote_addr) { '127.0.0.1' }
     let(:client_ip) { remote_addr }
+
+    let(:service_span) do
+      span = sorted_spans.reverse.find { |s| s.metrics.fetch('_dd.top_level', -1.0) > 0.0 }
+
+      expect(span.name).to eq 'rack.request'
+
+      span
+    end
 
     let(:span) { rack_span }
 
@@ -232,18 +240,18 @@ RSpec.describe 'Sinatra integration tests' do
 
     shared_examples 'a trace without AppSec tags' do
       it do
-        expect(trace.send(:metrics)['_dd.appsec.enabled']).to be_nil
-        expect(trace.send(:meta)['_dd.runtime_family']).to be_nil
-        expect(trace.send(:meta)['_dd.appsec.waf.version']).to be_nil
+        expect(service_span.send(:metrics)['_dd.appsec.enabled']).to be_nil
+        expect(service_span.send(:meta)['_dd.runtime_family']).to be_nil
+        expect(service_span.send(:meta)['_dd.appsec.waf.version']).to be_nil
         expect(span.send(:meta)['http.client_ip']).to eq nil
       end
     end
 
     shared_examples 'a trace with AppSec tags' do
       it do
-        expect(trace.send(:metrics)['_dd.appsec.enabled']).to eq(1.0)
-        expect(trace.send(:meta)['_dd.runtime_family']).to eq('ruby')
-        expect(trace.send(:meta)['_dd.appsec.waf.version']).to match(/^\d+\.\d+\.\d+/)
+        expect(service_span.send(:metrics)['_dd.appsec.enabled']).to eq(1.0)
+        expect(service_span.send(:meta)['_dd.runtime_family']).to eq('ruby')
+        expect(service_span.send(:meta)['_dd.appsec.waf.version']).to match(/^\d+\.\d+\.\d+/)
         expect(span.send(:meta)['http.client_ip']).to eq client_ip
       end
 
@@ -257,14 +265,14 @@ RSpec.describe 'Sinatra integration tests' do
     shared_examples 'a trace without AppSec events' do
       it do
         expect(spans.select { |s| s.get_tag('appsec.event') }).to be_empty
-        expect(trace.send(:meta)['_dd.appsec.triggers']).to be_nil
+        expect(service_span.send(:meta)['_dd.appsec.triggers']).to be_nil
       end
     end
 
     shared_examples 'a trace with AppSec events' do
       it do
         expect(spans.select { |s| s.get_tag('appsec.event') }).to_not be_empty
-        expect(trace.send(:meta)['_dd.appsec.json']).to be_a String
+        expect(service_span.send(:meta)['_dd.appsec.json']).to be_a String
       end
 
       context 'with appsec disabled' do

--- a/spec/datadog/appsec/processor_spec.rb
+++ b/spec/datadog/appsec/processor_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'datadog/appsec/spec_helper'
 require 'datadog/appsec/processor'
 require 'datadog/appsec/processor/rule_loader'
@@ -21,10 +23,6 @@ RSpec.describe Datadog::AppSec::Processor do
   end
 
   let(:ruleset) { Datadog::AppSec::Processor::RuleLoader.load_rules(ruleset: :recommended) }
-
-  after do
-    described_class.send(:reset_active_context)
-  end
 
   context 'self' do
     it 'detects if the WAF is unavailable' do
@@ -55,50 +53,6 @@ RSpec.describe Datadog::AppSec::Processor do
       allow(described_class).to receive(:require).with('libddwaf').and_return(false)
 
       expect(described_class.require_libddwaf).to be true
-    end
-
-    describe '.active_context' do
-      it 'return nil if not set earlier' do
-        expect(described_class.active_context).to be_nil
-      end
-
-      it 'return the previously set current context' do
-        processor = described_class.new(ruleset: ruleset)
-        context = processor.new_context
-
-        described_class.send(:active_context=, context)
-
-        expect(described_class.active_context).to eq(context)
-
-        context.finalize
-        processor.finalize
-        described_class.send(:reset_active_context)
-      end
-
-      describe '.active_context=' do
-        it 'raises ArgumentError when trying to setup current context to a non Context instance' do
-          expect do
-            described_class.send(:active_context=, 'foo')
-          end.to raise_error(ArgumentError)
-        end
-      end
-
-      describe '.reset_active_context' do
-        it 'sets active_context to nil' do
-          processor = described_class.new(ruleset: ruleset)
-          context = processor.new_context
-
-          described_class.send(:active_context=, context)
-
-          expect(described_class.active_context).to eq(context)
-
-          described_class.send(:reset_active_context)
-          expect(described_class.active_context).to be_nil
-
-          context.finalize
-          processor.finalize
-        end
-      end
     end
   end
 
@@ -170,207 +124,171 @@ RSpec.describe Datadog::AppSec::Processor do
       it { is_expected.to_not be_ready }
     end
   end
+end
 
-  describe '#new_context' do
-    let(:input_safe) { { 'server.request.headers.no_cookies' => { 'user-agent' => 'Ruby' } } }
-    let(:input_sqli) { { 'server.request.query' => { 'q' => '1 OR 1;' } } }
-    let(:input_scanner) { { 'server.request.headers.no_cookies' => { 'user-agent' => 'Nessus SOAP' } } }
-    let(:input_client_ip) { { 'http.client_ip' => '1.2.3.4' } }
+RSpec.describe Datadog::AppSec::Processor::Context do
+  let(:ruleset) { Datadog::AppSec::Processor::RuleLoader.load_rules(ruleset: :recommended) }
 
-    let(:client_ip) { '1.2.3.4' }
+  let(:input_safe) { { 'server.request.headers.no_cookies' => { 'user-agent' => 'Ruby' } } }
+  let(:input_sqli) { { 'server.request.query' => { 'q' => '1 OR 1;' } } }
+  let(:input_scanner) { { 'server.request.headers.no_cookies' => { 'user-agent' => 'Nessus SOAP' } } }
+  let(:input_client_ip) { { 'http.client_ip' => '1.2.3.4' } }
 
-    let(:input) { input_scanner }
+  let(:client_ip) { '1.2.3.4' }
 
-    let(:processor) { described_class.new(ruleset: ruleset) }
-    subject(:context) { processor.new_context }
+  let(:input) { input_scanner }
 
-    after do
-      context.finalize
-      processor.finalize
-    end
+  let(:processor) { Datadog::AppSec::Processor.new(ruleset: ruleset) }
 
-    it { is_expected.to be_a Datadog::AppSec::Processor::Context }
+  let(:run_count) { 1 }
+  let(:timeout) { 10_000_000_000 }
 
-    describe 'Context' do
-      let(:run_count) { 1 }
-      let(:timeout) { 10_000_000_000 }
+  let(:runs) { Array.new(run_count) { context.run(input, timeout) } }
+  let(:results) { runs }
+  let(:overall_runtime) { results.reduce(0) { |a, e| a + e.total_runtime } }
 
-      let(:runs) { Array.new(run_count) { context.run(input, timeout) } }
-      let(:results) { runs }
-      let(:overall_runtime) { results.reduce(0) { |a, e| a + e.total_runtime } }
+  let(:run) do
+    expect(runs).to have_attributes(count: 1)
 
-      let(:run) do
-        expect(runs).to have_attributes(count: 1)
+    runs.first
+  end
 
-        runs.first
-      end
+  let(:result) do
+    expect(results).to have_attributes(count: 1)
 
-      let(:result) do
-        expect(results).to have_attributes(count: 1)
+    results.first
+  end
 
-        results.first
-      end
+  subject(:context) { described_class.new(processor) }
 
-      before do
-        runs
-      end
+  before do
+    runs
+  end
 
-      it { expect(result.status).to eq :match }
-      it { expect(context.time_ns).to be > 0 }
+  after do
+    context.finalize
+    processor.finalize
+  end
+
+  it { expect(result.status).to eq :match }
+  it { expect(context.time_ns).to be > 0 }
+  it { expect(context.time_ext_ns).to be > 0 }
+  it { expect(context.time_ext_ns).to be > context.time_ns }
+  it { expect(context.time_ns).to eq(overall_runtime) }
+  it { expect(context.timeouts).to eq 0 }
+
+  context 'with timeout' do
+    let(:timeout) { 0 }
+
+    it { expect(result.status).to eq :ok }
+    it { expect(context.time_ns).to eq 0 }
+    it { expect(context.time_ext_ns).to be > 0 }
+    it { expect(context.timeouts).to eq run_count }
+  end
+
+  context 'with multiple runs' do
+    let(:run_count) { 10 }
+
+    it { expect(context.time_ns).to eq(overall_runtime) }
+
+    context 'with timeout' do
+      let(:timeout) { 0 }
+
+      it { expect(results.first.status).to eq :ok }
+      it { expect(context.time_ns).to eq 0 }
       it { expect(context.time_ext_ns).to be > 0 }
-      it { expect(context.time_ext_ns).to be > context.time_ns }
-      it { expect(context.time_ns).to eq(overall_runtime) }
-      it { expect(context.timeouts).to eq 0 }
-
-      context 'with timeout' do
-        let(:timeout) { 0 }
-
-        it { expect(result.status).to eq :ok }
-        it { expect(context.time_ns).to eq 0 }
-        it { expect(context.time_ext_ns).to be > 0 }
-        it { expect(context.timeouts).to eq run_count }
-      end
-
-      context 'with multiple runs' do
-        let(:run_count) { 10 }
-
-        it { expect(context.time_ns).to eq(overall_runtime) }
-
-        context 'with timeout' do
-          let(:timeout) { 0 }
-
-          it { expect(results.first.status).to eq :ok }
-          it { expect(context.time_ns).to eq 0 }
-          it { expect(context.time_ext_ns).to be > 0 }
-          it { expect(context.timeouts).to eq run_count }
-        end
-      end
-
-      describe '#run' do
-        let(:matches) do
-          results.reject { |r| r.status == :ok }
-        end
-
-        let(:data) do
-          matches.map(&:data).flatten
-        end
-
-        let(:actions) do
-          matches.map(&:actions)
-        end
-
-        context 'no attack' do
-          let(:input) { input_safe }
-
-          it { expect(matches).to eq [] }
-          it { expect(data).to eq [] }
-          it { expect(actions).to eq [] }
-        end
-
-        context 'one attack' do
-          let(:input) { input_scanner }
-
-          it { expect(matches).to have_attributes(count: 1) }
-          it { expect(data).to have_attributes(count: 1) }
-          it { expect(actions).to eq [[]] }
-        end
-
-        context 'multiple attacks per run' do
-          let(:input) { input_scanner.merge(input_sqli) }
-
-          it { expect(matches).to have_attributes(count: 1) }
-          it { expect(data).to have_attributes(count: 2) }
-          it { expect(actions).to eq [[]] }
-        end
-
-        context 'multiple runs' do
-          context 'same attack' do
-            let(:runs) do
-              [
-                context.run(input_scanner, timeout),
-                context.run(input_scanner, timeout)
-              ]
-            end
-
-            # when the same attack is detected twice in the same context, it's
-            # only matching once therefore there's only one match result, thus
-            # one action list returned.
-
-            it { expect(matches).to have_attributes(count: 1) }
-            it { expect(data).to have_attributes(count: 1) }
-            it { expect(actions).to eq [[]] }
-          end
-
-          context 'different attacks' do
-            let(:runs) do
-              [
-                context.run(input_sqli, timeout),
-                context.run(input_scanner, timeout)
-              ]
-            end
-
-            # when two attacks are detected in the same context there are two
-            # match results, thus two action lists, one for each.
-
-            it { expect(matches).to have_attributes(count: 2) }
-            it { expect(data).to have_attributes(count: 2) }
-            it { expect(actions).to eq [[], []] }
-          end
-        end
-
-        context 'one blockable attack' do
-          let(:input) { input_client_ip }
-
-          let(:ruleset) do
-            rules = Datadog::AppSec::Processor::RuleLoader.load_rules(ruleset: :recommended)
-            data = Datadog::AppSec::Processor::RuleLoader.load_data(ip_denylist: [client_ip])
-
-            Datadog::AppSec::Processor::RuleMerger.merge(
-              rules: [rules],
-              data: data,
-            )
-          end
-
-          it { expect(matches).to have_attributes(count: 1) }
-          it { expect(data).to have_attributes(count: 1) }
-          it { expect(actions).to eq [['block']] }
-        end
-      end
+      it { expect(context.timeouts).to eq run_count }
     end
   end
 
-  describe '#active_context' do
-    it 'creates a new context and store in the class .active_context variable' do
-      context = described_class.new(ruleset: ruleset).activate_context
-      expect(context).to eq(described_class.active_context)
+  describe '#run' do
+    let(:matches) do
+      results.reject { |r| r.status == :ok }
     end
 
-    context 'when an active context already exists' do
-      it 'raises AlreadyActiveContextError' do
-        described_class.new(ruleset: ruleset).activate_context
-        expect do
-          described_class.new(ruleset: ruleset).activate_context
-        end.to raise_error(described_class::AlreadyActiveContextError)
+    let(:data) do
+      matches.map(&:data).flatten
+    end
+
+    let(:actions) do
+      matches.map(&:actions)
+    end
+
+    context 'no attack' do
+      let(:input) { input_safe }
+
+      it { expect(matches).to eq [] }
+      it { expect(data).to eq [] }
+      it { expect(actions).to eq [] }
+    end
+
+    context 'one attack' do
+      let(:input) { input_scanner }
+
+      it { expect(matches).to have_attributes(count: 1) }
+      it { expect(data).to have_attributes(count: 1) }
+      it { expect(actions).to eq [[]] }
+    end
+
+    context 'multiple attacks per run' do
+      let(:input) { input_scanner.merge(input_sqli) }
+
+      it { expect(matches).to have_attributes(count: 1) }
+      it { expect(data).to have_attributes(count: 2) }
+      it { expect(actions).to eq [[]] }
+    end
+
+    context 'multiple runs' do
+      context 'same attack' do
+        let(:runs) do
+          [
+            context.run(input_scanner, timeout),
+            context.run(input_scanner, timeout)
+          ]
+        end
+
+        # when the same attack is detected twice in the same context, it's
+        # only matching once therefore there's only one match result, thus
+        # one action list returned.
+
+        it { expect(matches).to have_attributes(count: 1) }
+        it { expect(data).to have_attributes(count: 1) }
+        it { expect(actions).to eq [[]] }
+      end
+
+      context 'different attacks' do
+        let(:runs) do
+          [
+            context.run(input_sqli, timeout),
+            context.run(input_scanner, timeout)
+          ]
+        end
+
+        # when two attacks are detected in the same context there are two
+        # match results, thus two action lists, one for each.
+
+        it { expect(matches).to have_attributes(count: 2) }
+        it { expect(data).to have_attributes(count: 2) }
+        it { expect(actions).to eq [[], []] }
       end
     end
-  end
 
-  describe '#deactivate_context' do
-    it 'finalize the active context and reset the class .active_context variable' do
-      handler = described_class.new(ruleset: ruleset)
-      context = handler.activate_context
+    context 'one blockable attack' do
+      let(:input) { input_client_ip }
 
-      expect(context).to receive(:finalize)
-      handler.deactivate_context
-      expect(described_class.active_context).to be_nil
-    end
+      let(:ruleset) do
+        rules = Datadog::AppSec::Processor::RuleLoader.load_rules(ruleset: :recommended)
+        data = Datadog::AppSec::Processor::RuleLoader.load_data(ip_denylist: [client_ip])
 
-    context 'without an active_context' do
-      it 'raises NoActiveContextError' do
-        expect do
-          described_class.new(ruleset: ruleset).deactivate_context
-        end.to raise_error(described_class::NoActiveContextError)
+        Datadog::AppSec::Processor::RuleMerger.merge(
+          rules: [rules],
+          data: data,
+        )
       end
+
+      it { expect(matches).to have_attributes(count: 1) }
+      it { expect(data).to have_attributes(count: 1) }
+      it { expect(actions).to eq [['block']] }
     end
   end
 end

--- a/spec/datadog/appsec/scope_spec.rb
+++ b/spec/datadog/appsec/scope_spec.rb
@@ -1,0 +1,95 @@
+# frozen_string_literal: true
+
+require 'datadog/appsec/spec_helper'
+require 'datadog/appsec/scope'
+
+RSpec.describe Datadog::AppSec::Scope do
+  let(:trace) { double }
+  let(:span) { double }
+
+  let(:ruleset) { Datadog::AppSec::Processor::RuleLoader.load_rules(ruleset: :recommended) }
+  let(:processor) { Datadog::AppSec::Processor.new(ruleset: ruleset) }
+
+  after do
+    described_class.send(:reset_active_scope)
+    processor.finalize
+  end
+
+  describe '.activate_scope' do
+    context 'with no active scope' do
+      subject(:activate_scope) { described_class.activate_scope(trace, span, processor) }
+
+      it 'returns a new scope' do
+        expect(activate_scope).to be_a described_class
+      end
+
+      it 'sets the active scope' do
+        expect { activate_scope }.to change { described_class.active_scope }.from(nil).to be_a described_class
+      end
+    end
+
+    context 'with an active scope' do
+      before do
+        described_class.activate_scope(trace, span, processor)
+      end
+
+      subject(:activate_scope) { described_class.activate_scope(trace, span, processor) }
+
+      it 'raises ActiveScopeError' do
+        expect { activate_scope }.to raise_error Datadog::AppSec::Scope::ActiveScopeError
+      end
+
+      it 'does not change the active scope' do
+        expect { activate_scope rescue nil }.to_not(change { described_class.active_scope })
+      end
+    end
+  end
+
+  describe '.deactivate_scope' do
+    context 'with no active scope' do
+      subject(:deactivate_scope) { described_class.deactivate_scope }
+
+      it 'raises ActiveScopeError' do
+        expect { deactivate_scope }.to raise_error Datadog::AppSec::Scope::InactiveScopeError
+      end
+
+      it 'does not change the active scope' do
+        expect { deactivate_scope rescue nil }.to_not(change { described_class.active_scope })
+      end
+    end
+
+    context 'with an active scope' do
+      let(:active_scope) { described_class.active_scope }
+
+      subject(:deactivate_scope) { described_class.deactivate_scope }
+
+      before do
+        allow(described_class).to receive(:new).and_call_original
+
+        described_class.activate_scope(trace, span, processor)
+
+        expect(active_scope).to receive(:finalize).and_call_original
+      end
+
+      it 'unsets the active scope' do
+        expect { deactivate_scope }.to change { described_class.active_scope }.from(active_scope).to nil
+      end
+    end
+  end
+
+  describe '.active_scope' do
+    subject(:active_scope) { described_class.active_scope }
+
+    context 'with no active scope' do
+      it { is_expected.to be_nil }
+    end
+
+    context 'with an active scope' do
+      before do
+        described_class.activate_scope(trace, span, processor)
+      end
+
+      it { is_expected.to be_a described_class }
+    end
+  end
+end

--- a/spec/datadog/kit/appsec/events_spec.rb
+++ b/spec/datadog/kit/appsec/events_spec.rb
@@ -6,93 +6,135 @@ require 'datadog/tracing/trace_operation'
 require 'datadog/kit/appsec/events'
 
 RSpec.describe Datadog::Kit::AppSec::Events do
-  subject(:trace_op) { Datadog::Tracing::TraceOperation.new }
+  let(:trace_op) { Datadog::Tracing::TraceOperation.new }
 
-  let(:trace) { trace_op.flush! }
-  let(:meta) { trace.send(:meta) }
+  shared_context 'uses AppSec scope' do
+    before { allow(Datadog::AppSec).to receive(:active_scope).and_return(appsec_active_scope) }
+    let(:appsec_span) { trace_op.build_span('root') }
+
+    context 'when is present' do
+      let(:appsec_active_scope) do
+        processor = instance_double('Datadog::Appsec::Processor')
+
+        Datadog::AppSec::Scope.new(trace_op, appsec_span, processor)
+      end
+
+      it 'sets tags on AppSec scope' do
+        event
+        expect(appsec_span.has_tag?(event_tag)).to eq true
+      end
+    end
+
+    context 'when is not present' do
+      let(:appsec_active_scope) { nil }
+
+      it 'sets tags on active_span' do
+        trace_op.measure('root') do |span, _trace|
+          event
+          expect(span.has_tag?(event_tag)).to eq true
+        end
+        expect(appsec_span.has_tag?(event_tag)).to eq false
+      end
+    end
+  end
 
   describe '#track_login_success' do
     it 'sets event tracking key on trace' do
-      trace_op.measure('root') do
+      trace_op.measure('root') do |span, _trace|
         described_class.track_login_success(trace_op, user: { id: '42' })
+        expect(span.tags).to include('appsec.events.users.login.success.track' => 'true')
       end
-      expect(meta).to include('appsec.events.users.login.success.track' => 'true')
     end
 
     it 'sets successful user id on trace' do
-      trace_op.measure('root') do
+      trace_op.measure('root') do |span, _trace|
         described_class.track_login_success(trace_op, user: { id: '42' })
+        expect(span.tags).to include('usr.id' => '42')
       end
-      expect(meta).to include('usr.id' => '42')
     end
 
     it 'sets other keys on trace' do
-      trace_op.measure('root') do
+      trace_op.measure('root') do |span, _trace|
         described_class.track_login_success(trace_op, user: { id: '42' }, foo: 'bar')
+        expect(span.tags).to include('usr.id' => '42', 'appsec.events.users.login.success.foo' => 'bar')
       end
-      expect(meta).to include('usr.id' => '42', 'appsec.events.users.login.success.foo' => 'bar')
     end
 
     it 'maintains integrity of user argument' do
       user_argument = { id: '42' }
       user_argument_dup = user_argument.dup
-      trace_op.measure('root') do
+      trace_op.measure('root') do |_span, _trace|
         described_class.track_login_success(trace_op, user: user_argument, foo: 'bar')
       end
       expect(user_argument).to eql(user_argument_dup)
+    end
+
+    it_behaves_like 'uses AppSec scope' do
+      let(:event_tag) { 'appsec.events.users.login.success.track' }
+      subject(:event) { described_class.track_login_success(trace_op, user: { id: '42' }) }
     end
   end
 
   describe '#track_login_failure' do
     it 'sets event tracking key on trace' do
-      trace_op.measure('root') do
+      trace_op.measure('root') do |span, _trace|
         described_class.track_login_failure(trace_op, user_id: '42', user_exists: true)
+        expect(span.tags).to include('appsec.events.users.login.failure.track' => 'true')
       end
-      expect(meta).to include('appsec.events.users.login.failure.track' => 'true')
     end
 
     it 'sets failing user id on trace' do
-      trace_op.measure('root') do
+      trace_op.measure('root') do |span, _trace|
         described_class.track_login_failure(trace_op, user_id: '42', user_exists: true)
+        expect(span.tags).to include('appsec.events.users.login.failure.usr.id' => '42')
       end
-      expect(meta).to include('appsec.events.users.login.failure.usr.id' => '42')
     end
 
     it 'sets user existence on trace' do
-      trace_op.measure('root') do
+      trace_op.measure('root') do |span, _trace|
         described_class.track_login_failure(trace_op, user_id: '42', user_exists: true)
+        expect(span.tags).to include('appsec.events.users.login.failure.usr.exists' => 'true')
       end
-      expect(meta).to include('appsec.events.users.login.failure.usr.exists' => 'true')
     end
 
     it 'sets user non-existence  on trace' do
-      trace_op.measure('root') do
+      trace_op.measure('root') do |span, _trace|
         described_class.track_login_failure(trace_op, user_id: '42', user_exists: false)
+        expect(span.tags).to include('appsec.events.users.login.failure.usr.exists' => 'false')
       end
-      expect(meta).to include('appsec.events.users.login.failure.usr.exists' => 'false')
     end
 
     it 'sets other keys on trace' do
-      trace_op.measure('root') do
+      trace_op.measure('root') do |span, _trace|
         described_class.track_login_failure(trace_op, user_id: '42', user_exists: true, foo: 'bar')
+        expect(span.tags).to include('appsec.events.users.login.failure.foo' => 'bar')
       end
-      expect(meta).to include('appsec.events.users.login.failure.foo' => 'bar')
+    end
+
+    it_behaves_like 'uses AppSec scope' do
+      let(:event_tag) { 'appsec.events.users.login.failure.track' }
+      subject(:event) { described_class.track_login_failure(trace_op, user_id: '42', user_exists: true) }
     end
   end
 
   describe '#track' do
     it 'sets event tracking key on trace' do
-      trace_op.measure('root') do
+      trace_op.measure('root') do |span, _trace|
         described_class.track('foo', trace_op)
+        expect(span.tags).to include('appsec.events.foo.track' => 'true')
       end
-      expect(meta).to include('appsec.events.foo.track' => 'true')
     end
 
     it 'sets other keys on trace' do
-      trace_op.measure('root') do
+      trace_op.measure('root') do |span, _trace|
         described_class.track('foo', trace_op, bar: 'baz')
+        expect(span.tags).to include('appsec.events.foo.bar' => 'baz')
       end
-      expect(meta).to include('appsec.events.foo.bar' => 'baz')
+    end
+
+    it_behaves_like 'uses AppSec scope' do
+      let(:event_tag) { 'appsec.events.foo.track' }
+      subject(:event) { described_class.track('foo', trace_op) }
     end
   end
 end

--- a/spec/datadog/kit/identity_spec.rb
+++ b/spec/datadog/kit/identity_spec.rb
@@ -5,186 +5,168 @@ require 'time'
 require 'datadog/tracing/trace_operation'
 require 'datadog/kit/identity'
 
+require 'datadog/appsec/scope'
+
 RSpec.describe Datadog::Kit::Identity do
   subject(:trace_op) { Datadog::Tracing::TraceOperation.new }
 
   describe '#set_user' do
     it 'sets user id on trace' do
-      trace_op.measure('root') do
+      trace_op.measure('root') do |span, _trace|
         described_class.set_user(trace_op, id: '42')
+        expect(span.tags).to include('usr.id' => '42')
       end
-      trace = trace_op.flush!
-      expect(trace.send(:meta)).to include('usr.id' => '42')
     end
 
     it 'sets user email on trace' do
-      trace_op.measure('root') do
+      trace_op.measure('root') do |span, _trace|
         described_class.set_user(trace_op, id: '42', email: 'foo@example.com')
+        expect(span.tags).to include('usr.id' => '42', 'usr.email' => 'foo@example.com')
       end
-      trace = trace_op.flush!
-      expect(trace.send(:meta)).to include('usr.id' => '42', 'usr.email' => 'foo@example.com')
     end
 
     it 'sets user name on trace' do
-      trace_op.measure('root') do
+      trace_op.measure('root') do |span, _trace|
         described_class.set_user(trace_op, id: '42', name: 'bar')
+        expect(span.tags).to include('usr.id' => '42', 'usr.name' => 'bar')
       end
-      trace = trace_op.flush!
-      expect(trace.send(:meta)).to include('usr.id' => '42', 'usr.name' => 'bar')
     end
 
     it 'sets user session id on trace' do
-      trace_op.measure('root') do
+      trace_op.measure('root') do |span, _trace|
         described_class.set_user(trace_op, id: '42', session_id: 'bar')
+        expect(span.tags).to include('usr.id' => '42', 'usr.session_id' => 'bar')
       end
-      trace = trace_op.flush!
-      expect(trace.send(:meta)).to include('usr.id' => '42', 'usr.session_id' => 'bar')
     end
 
     it 'sets user role on trace' do
-      trace_op.measure('root') do
+      trace_op.measure('root') do |span, _trace|
         described_class.set_user(trace_op, id: '42', role: 'bar')
+        expect(span.tags).to include('usr.id' => '42', 'usr.role' => 'bar')
       end
-      trace = trace_op.flush!
-      expect(trace.send(:meta)).to include('usr.id' => '42', 'usr.role' => 'bar')
     end
 
     it 'sets user scope on trace' do
-      trace_op.measure('root') do
+      trace_op.measure('root') do |span, _trace|
         described_class.set_user(trace_op, id: '42', scope: 'bar')
+        expect(span.tags).to include('usr.id' => '42', 'usr.scope' => 'bar')
       end
-      trace = trace_op.flush!
-      expect(trace.send(:meta)).to include('usr.id' => '42', 'usr.scope' => 'bar')
     end
 
     it 'sets other keys on trace' do
-      trace_op.measure('root') do
+      trace_op.measure('root') do |span, _trace|
         described_class.set_user(trace_op, id: '42', foo: 'bar')
+        expect(span.tags).to include('usr.id' => '42', 'usr.foo' => 'bar')
       end
-      trace = trace_op.flush!
-      expect(trace.send(:meta)).to include('usr.id' => '42', 'usr.foo' => 'bar')
     end
 
     it 'sets both explicit keywords and other keys on trace' do
-      trace_op.measure('root') do
+      trace_op.measure('root') do |span, _trace|
         described_class.set_user(trace_op, id: '42', email: 'foo@example.com', foo: 'bar')
+        expect(span.tags).to include('usr.id' => '42', 'usr.email' => 'foo@example.com', 'usr.foo' => 'bar')
       end
-      trace = trace_op.flush!
-      expect(trace.send(:meta)).to include('usr.id' => '42', 'usr.email' => 'foo@example.com', 'usr.foo' => 'bar')
     end
 
     it 'enforces :id presence' do
-      trace_op.measure('root') do
+      trace_op.measure('root') do |_span, _trace|
         expect { described_class.set_user(trace_op, foo: 'bar') }.to raise_error(ArgumentError)
       end
     end
 
     it 'enforces :id value' do
-      trace_op.measure('root') do
+      trace_op.measure('root') do |_span, _trace|
         expect { described_class.set_user(trace_op, id: nil, foo: 'bar') }.to raise_error(ArgumentError)
       end
     end
 
     it 'ignores nil user email on trace' do
-      trace_op.measure('root') do
+      trace_op.measure('root') do |span, _trace|
         described_class.set_user(trace_op, id: '42', email: nil)
+        expect(span.tags).to include('usr.id' => '42')
       end
-      trace = trace_op.flush!
-      expect(trace.send(:meta)).to include('usr.id' => '42')
     end
 
     it 'ignores nil user name on trace' do
-      trace_op.measure('root') do
+      trace_op.measure('root') do |span, _trace|
         described_class.set_user(trace_op, id: '42', name: nil)
+        expect(span.tags).to include('usr.id' => '42')
       end
-      trace = trace_op.flush!
-      expect(trace.send(:meta)).to include('usr.id' => '42')
     end
 
     it 'ignores nil user session id on trace' do
-      trace_op.measure('root') do
+      trace_op.measure('root') do |span, _trace|
         described_class.set_user(trace_op, id: '42', session_id: nil)
+        expect(span.tags).to include('usr.id' => '42')
       end
-      trace = trace_op.flush!
-      expect(trace.send(:meta)).to include('usr.id' => '42')
     end
 
     it 'ignores nil user role on trace' do
-      trace_op.measure('root') do
+      trace_op.measure('root') do |span, _trace|
         described_class.set_user(trace_op, id: '42', role: nil)
+        expect(span.tags).to include('usr.id' => '42')
       end
-      trace = trace_op.flush!
-      expect(trace.send(:meta)).to include('usr.id' => '42')
     end
 
     it 'ignores nil user scope on trace' do
-      trace_op.measure('root') do
+      trace_op.measure('root') do |span, _trace|
         described_class.set_user(trace_op, id: '42', scope: nil)
+        expect(span.tags).to include('usr.id' => '42')
       end
-      trace = trace_op.flush!
-      expect(trace.send(:meta)).to include('usr.id' => '42')
     end
 
     it 'ignores nil other keys on trace' do
-      trace_op.measure('root') do
+      trace_op.measure('root') do |span, _trace|
         described_class.set_user(trace_op, id: '42', foo: nil)
+        expect(span.tags).to include('usr.id' => '42')
       end
-      trace = trace_op.flush!
-      expect(trace.send(:meta)).to include('usr.id' => '42')
     end
 
     it 'does not clear user email on trace' do
-      trace_op.measure('root') do
+      trace_op.measure('root') do |span, _trace|
         described_class.set_user(trace_op, id: '42', email: 'foo@example.com')
         described_class.set_user(trace_op, id: '42', email: nil)
+        expect(span.tags).to include('usr.id' => '42', 'usr.email' => 'foo@example.com')
       end
-      trace = trace_op.flush!
-      expect(trace.send(:meta)).to include('usr.id' => '42', 'usr.email' => 'foo@example.com')
     end
 
     it 'does not clear user name on trace' do
-      trace_op.measure('root') do
+      trace_op.measure('root') do |span, _trace|
         described_class.set_user(trace_op, id: '42', name: 'bar')
         described_class.set_user(trace_op, id: '42', name: nil)
+        expect(span.tags).to include('usr.id' => '42', 'usr.name' => 'bar')
       end
-      trace = trace_op.flush!
-      expect(trace.send(:meta)).to include('usr.id' => '42', 'usr.name' => 'bar')
     end
 
     it 'does not clear user session id on trace' do
-      trace_op.measure('root') do
+      trace_op.measure('root') do |span, _trace|
         described_class.set_user(trace_op, id: '42', session_id: 'bar')
         described_class.set_user(trace_op, id: '42', session_id: nil)
+        expect(span.tags).to include('usr.id' => '42', 'usr.session_id' => 'bar')
       end
-      trace = trace_op.flush!
-      expect(trace.send(:meta)).to include('usr.id' => '42', 'usr.session_id' => 'bar')
     end
 
     it 'does not clear user role on trace' do
-      trace_op.measure('root') do
+      trace_op.measure('root') do |span, _trace|
         described_class.set_user(trace_op, id: '42', role: 'bar')
         described_class.set_user(trace_op, id: '42', role: nil)
+        expect(span.tags).to include('usr.id' => '42', 'usr.role' => 'bar')
       end
-      trace = trace_op.flush!
-      expect(trace.send(:meta)).to include('usr.id' => '42', 'usr.role' => 'bar')
     end
 
     it 'does not clear user scope on trace' do
-      trace_op.measure('root') do
+      trace_op.measure('root') do |span, _trace|
         described_class.set_user(trace_op, id: '42', scope: 'bar')
         described_class.set_user(trace_op, id: '42', scope: nil)
+        expect(span.tags).to include('usr.id' => '42', 'usr.scope' => 'bar')
       end
-      trace = trace_op.flush!
-      expect(trace.send(:meta)).to include('usr.id' => '42', 'usr.scope' => 'bar')
     end
 
     it 'does not clear other keys on trace' do
-      trace_op.measure('root') do
+      trace_op.measure('root') do |span, _trace|
         described_class.set_user(trace_op, id: '42', foo: 'bar')
         described_class.set_user(trace_op, id: '42', foo: nil)
+        expect(span.tags).to include('usr.id' => '42', 'usr.foo' => 'bar')
       end
-      trace = trace_op.flush!
-      expect(trace.send(:meta)).to include('usr.id' => '42', 'usr.foo' => 'bar')
     end
 
     it 'enforces String value on id' do
@@ -230,24 +212,36 @@ RSpec.describe Datadog::Kit::Identity do
     end
 
     context 'appsec' do
-      after { Datadog.configuration.appsec.send(:reset!) }
+      let(:appsec_active_scope) { nil }
+      before { expect(Datadog::AppSec).to receive(:active_scope).and_return(appsec_active_scope) }
 
       context 'when is enabled' do
+        let(:appsec_active_scope) do
+          processor = instance_double('Datadog::Appsec::Processor')
+          trace = trace_op
+          span = trace.build_span('root')
+
+          Datadog::AppSec::Scope.new(trace, span, processor)
+        end
+
         it 'instruments the user information to appsec' do
           Datadog.configuration.appsec.enabled = true
           expect_any_instance_of(Datadog::AppSec::Instrumentation::Gateway).to receive(:push).with(
             'identity.set_user',
             instance_of(Datadog::AppSec::Instrumentation::Gateway::User)
           )
+
           described_class.set_user(trace_op, id: '42')
         end
       end
 
       context 'when is disabled' do
         it 'does not instrument the user information to appsec' do
-          Datadog.configuration.appsec.enabled = false
           expect_any_instance_of(Datadog::AppSec::Instrumentation::Gateway).to_not receive(:push).with('identity.set_user')
-          described_class.set_user(trace_op, id: '42')
+
+          trace_op.measure('root') do
+            described_class.set_user(trace_op, id: '42')
+          end
         end
       end
     end


### PR DESCRIPTION

<!--
Check out the
https://github.com/DataDog/dd-trace-rb/blob/master/docs/DevelopmentGuide.md
for guidance on how to set up your development environment,
run the test suite, write new integrations, and more.
-->

**What does this PR do?**
Tag AppSec on Rack top-level span

**Motivation**
AppSec discovers service name based on top-level span. Tagging at trace level results in tags on the trace root span, which is usually Rack's top-level span.

When request queuing is enabeld, though, a synthetic span is added in front, representing a service outside the application. This tag then gets mistakenly tagged with AppSec information, resulting in much confusion.

The situation gets even trickier with partial flushing, as partially flushed spans may receive a trace tag.

Ensuring we tag the proper span should solve both issues.

**Additional Notes**

Starting this PR as draft since I am still figuring out how to handle `Datadog::Kit` tagging in a backward compatible manner.

**How to test the change?**

Add `request_queuing: true` to Rack or Rails tracing integration, then:

```
curl -vvv -H 'User-Agent: Arachni/v2' -H "X-Request-Start: $(ruby -e 'puts "%d" % (Time.now.to_f * 1000)')" -H "X-Queue-Start: $(ruby -e 'puts "%d" % (Time.now.to_f * 1000)')" 'http://user:pass@127.0.0.1:9292/'
```