### PR TITLE
[PROF-7622] Add support for profiling Ruby 3.3.0-preview1

### DIFF
--- a/ext/ddtrace_profiling_native_extension/NativeExtensionDesign.md
+++ b/ext/ddtrace_profiling_native_extension/NativeExtensionDesign.md
@@ -68,19 +68,19 @@ internal types, structures and functions).
 
 Because these private header files are not included in regular Ruby installations, we have two different workarounds:
 
-1. for Ruby versions >= 2.6 we make use use the Ruby private MJIT header
-2. for Ruby versions < 2.6 (legacy Rubies) we make use of the `debase-ruby_core_source` gem
+1. for Ruby versions 2.6 to 3.2 we make use use the Ruby private MJIT header
+2. for Ruby versions < 2.6 and > 3.2 we make use of the `debase-ruby_core_source` gem
 
 Functions which make use of these headers are defined in the <private_vm_api_acccess.c> file.
 
-There is currently no way for disabling usage of the private MJIT header for Ruby 2.6+.
+There is currently no way for disabling usage of the private MJIT header for Ruby 2.6 to 3.2.
 
 **Important Note**: Our medium/long-term plan is to stop relying on all private Ruby headers, and instead request and
 contribute upstream changes so that they become official public VM APIs.
 
 ### Approach 1: Using the Ruby private MJIT header
 
-Ruby versions >= 2.6 introduced a JIT compiler called MJIT. This compiler does not directly generate machine code;
+Ruby versions 2.6 to 3.2 shipped a JIT compiler called MJIT. This compiler does not directly generate machine code;
 instead it generates C code and uses the system C compiler to turn it into machine code.
 
 The generated C code `#include`s a private header -- which we reference as "the MJIT header" everywhere.
@@ -89,6 +89,8 @@ and of course the intention is that it is only used by the Ruby MJIT compiler.
 
 This header is placed inside the `include/` directory in a Ruby installation, and is named for that specific Ruby
 version. e.g. `rb_mjit_min_header-2.7.4.h`.
+
+This header was removed in Ruby 3.3.
 
 ### Approach 2: Using the `debase-ruby_core_source` gem
 

--- a/ext/ddtrace_profiling_native_extension/native_extension_helpers.rb
+++ b/ext/ddtrace_profiling_native_extension/native_extension_helpers.rb
@@ -12,8 +12,8 @@ module Datadog
       # Can be set to force rubygems to fail gem installation when profiling extension could not be built
       ENV_FAIL_INSTALL_IF_MISSING_EXTENSION = 'DD_PROFILING_FAIL_INSTALL_IF_MISSING_EXTENSION'
 
-      # Older Rubies don't have the MJIT header, used by the JIT compiler, so we need to use a different approach
-      CAN_USE_MJIT_HEADER = RUBY_VERSION >= '2.6'
+      # The MJIT header was introduced on 2.6 and removed on 3.3; for other Rubies we rely on debase-ruby_core_source
+      CAN_USE_MJIT_HEADER = RUBY_VERSION.start_with?('2.6', '2.7', '3.0.', '3.1.', '3.2.')
 
       LIBDATADOG_VERSION = '~> 2.0.0.1.0'
 

--- a/ext/ddtrace_profiling_native_extension/private_vm_api_access.c
+++ b/ext/ddtrace_profiling_native_extension/private_vm_api_access.c
@@ -735,8 +735,7 @@ check_method_entry(VALUE obj, int can_be_svar)
     // to allow us to ensure that we're always operating on the main ractor (if Ruby has ractors)
     // Modifications:
     // * None
-    bool
-    rb_ractor_main_p_(void)
+    bool rb_ractor_main_p_(void)
     {
         VM_ASSERT(rb_multi_ractor_p());
         rb_execution_context_t *ec = GET_EC();

--- a/ext/ddtrace_profiling_native_extension/private_vm_api_access.c
+++ b/ext/ddtrace_profiling_native_extension/private_vm_api_access.c
@@ -12,7 +12,8 @@
   // Pick up internal structures from the private Ruby MJIT header file
   #include RUBY_MJIT_HEADER
 #else
-  // On older Rubies, use a copy of the VM internal headers shipped in the debase-ruby_core_source gem
+  // The MJIT header was introduced on 2.6 and removed on 3.3; for other Rubies we rely on
+  // the debase-ruby_core_source gem to get access to private VM headers.
 
   // We can't do anything about warnings in VM headers, so we just use this technique to suppress them.
   // See https://nelkinda.com/blog/suppress-warnings-in-gcc-and-clang/#d11e364 for details.
@@ -23,7 +24,20 @@
   #pragma GCC diagnostic ignored "-Wexpansion-to-defined"
     #include <vm_core.h>
   #pragma GCC diagnostic pop
-  #include <iseq.h>
+
+  #pragma GCC diagnostic push
+  #pragma GCC diagnostic ignored "-Wunused-parameter"
+    #include <iseq.h>
+  #pragma GCC diagnostic pop
+
+  #include <ruby.h>
+
+  #ifndef NO_RACTOR_HEADER_INCLUDE
+    #pragma GCC diagnostic push
+    #pragma GCC diagnostic ignored "-Wunused-parameter"
+      #include <ractor_core.h>
+    #pragma GCC diagnostic pop
+  #endif
 #endif
 
 #define PRIVATE_VM_API_ACCESS_SKIP_RUBY_INCLUDES
@@ -712,8 +726,29 @@ check_method_entry(VALUE obj, int can_be_svar)
 #ifndef NO_RACTORS
   // This API and definition are exported as a public symbol by the VM BUT the function header is not defined in any public header, so we
   // repeat it here to be able to use in our code.
-  bool rb_ractor_main_p_(void);
-  extern struct rb_ractor_struct *ruby_single_main_ractor;
+  #ifndef USE_RACTOR_INTERNAL_APIS_DIRECTLY
+    // Disable fast path for detecting multiple Ractors. Unfortunately this symbol is no longer visible on modern Ruby
+    // versions, so we need to do a bit more work.
+    struct rb_ractor_struct *ruby_single_main_ractor = NULL;
+
+    // Taken from upstream ractor.c at commit a1b01e7701f9fc370f8dff777aad6d39a2c5a3e3 (May 2023, Ruby 3.3.0-preview1)
+    // to allow us to ensure that we're always operating on the main ractor (if Ruby has ractors)
+    // Modifications:
+    // * None
+    bool
+    rb_ractor_main_p_(void)
+    {
+        VM_ASSERT(rb_multi_ractor_p());
+        rb_execution_context_t *ec = GET_EC();
+        return rb_ec_ractor_ptr(ec) == rb_ec_vm_ptr(ec)->ractor.main_ractor;
+    }
+  #else
+    // Directly access Ruby internal fast path for detecting multiple Ractors.
+    extern struct rb_ractor_struct *ruby_single_main_ractor;
+
+    // Ruby 3.0 to 3.2 directly expose this symbol, we just need to tell the compiler it exists.
+    bool rb_ractor_main_p_(void);
+  #endif
 
   // Taken from upstream ractor_core.h at commit d9cf0388599a3234b9f3c06ddd006cd59a58ab8b (November 2022, Ruby 3.2 trunk)
   // to allow us to ensure that we're always operating on the main ractor (if Ruby has ractors)


### PR DESCRIPTION
**What does this PR do?**:

Ruby 3.3.0-preview1 is the first release of the 3.3 branch. It includes a pretty big change: it drops MJIT (one of the two JIT implementations being shipped, the other being YJIT).

This affects the profiler because we were (ab)using an internal header that Ruby included only for supporting MJIT, and this header is no more.

The solution here is to use the same solution we were using for Ruby < 2.6. Quoting the `NativeExtensionDesign.md` file:

> Because these private header files are not included in regular Ruby installations, we have two different workarounds:
>
> 1. for Ruby versions >= 2.6 we make use use the Ruby private MJIT header
> 2. for Ruby versions < 2.6 (legacy Rubies) we make use of the `debase-ruby_core_source` gem

Thus, the strategy going forward will be to also use the `debase-ruby_core_source` gem to support Ruby 3.3+.

Furthermore, there were a few changes to the APIs exported by Ruby around ractors, that I also had to fix.

**Motivation**:

Make sure we keep up-to-date with latest Rubies, and that we don't block our, and our client's experiments with these versions.

**Additional Notes**:

Because we aren't yet running Ruby 3.3 on our CI, you'll have to take my word for it that this change is correct. (Or check for yourself locally).

Separately from this PR, I'll submit a PR to add the 3.3.0-preview1 headers to `debase-ruby_core_source`, as I've been testing using a local fork.

Furthermore, I plan to bootstrap Ruby 3.3 testing in our CI so that we can validate that support for 3.3 keeps working.

But I don't see any reason to delay this PR before those two others.

**How to test the change?**:

This change can only be tested locally at the moment: install Ruby 3.3.0-preview1 in your favorite way, and then point your `Gemfile` to use <https://github.com/DataDog/debase-ruby_core_source/tree/datadog/add-ruby-3.3.0-preview1-headers>, and you'll be able to run the profiling specs as usual.

Fixes #2845