### PR TITLE
Fix system tests CI jobs

### DIFF
--- a/.github/workflows/system-tests.yml
+++ b/.github/workflows/system-tests.yml
@@ -17,7 +17,6 @@ jobs:
       fail-fast: false
       matrix:
         image:
-          - runner
           - agent
     runs-on: ubuntu-latest
     name: Build (${{ matrix.image }})
@@ -204,10 +203,6 @@ jobs:
         run: |
           docker pull ghcr.io/datadog/dd-trace-rb/system-tests/agent:gha${{ github.run_id }}-g${{ github.sha }}
           docker tag ghcr.io/datadog/dd-trace-rb/system-tests/agent:gha${{ github.run_id }}-g${{ github.sha }} system_tests/agent:latest
-      - name: Pull runner image
-        run: |
-          docker pull ghcr.io/datadog/dd-trace-rb/system-tests/runner:gha${{ github.run_id }}-g${{ github.sha }}
-          docker tag ghcr.io/datadog/dd-trace-rb/system-tests/runner:gha${{ github.run_id }}-g${{ github.sha }} system_tests/runner:latest
       - name: Pull app image
         run: |
           docker pull ghcr.io/datadog/dd-trace-rb/system-tests/weblog-${{ matrix.app }}:gha${{ github.run_id }}-g${{ github.sha }}
@@ -216,7 +211,7 @@ jobs:
         run: |
           docker image list
       - name: Run scenario
-        run: ./run.sh ${{ matrix.scenario }}
+        run: ./build.sh --images runner && ./run.sh ${{ matrix.scenario }}
         env:
           DD_API_KEY: ${{ secrets.DD_APPSEC_SYSTEM_TESTS_API_KEY }}
       - name: Archive logs (per scenario)


### PR DESCRIPTION
<!--
Check out the
https://github.com/DataDog/dd-trace-rb/blob/master/docs/DevelopmentGuide.md
for guidance on how to set up your development environment,
run the test suite, write new integrations, and more.
-->

**What does this PR do?**
<!-- A brief description of the change being made with this pull request. -->

Since the system-tests changed to run their test in the host, rather than on a Docker container, rather than on a Docker container.
https://github.com/DataDog/system-tests/pull/958

We can no longer build the runner as a Docker image and push it to the registry.

This PR removes the step that builds the runner image as a Docker image and ensures all Python dependencies are still before running the tests.

The biggest downside of not being able to have the runner image as a Docker image, is that for every test scenario we have, we need to download the python packages. Making the tests suite take longer than before 😢 

With the fix the total time for the jobs is 15min. Not bad, but I will like to try other improvements on subsequent PRs, for now I think is important to unblock CI for running system tests. 

**Motivation**
<!-- What inspired you to submit this pull request? -->
Make sure we are running system tests 😄 

**Additional Notes**
<!-- Anything else we should know when reviewing? -->

**How to test the change?**
<!--
Describe here how the change can be validated.
You are strongly encouraged to provide automated tests for this PR (unit or integration).
If this change cannot be feasibly tested, please explain why,
unless the change does not modify code (e.g. only modifies docs, comments).
-->
