### PR TITLE
Fix symbol configuration for `env` and `service`

### DIFF
--- a/lib/datadog/core/configuration/settings.rb
+++ b/lib/datadog/core/configuration/settings.rb
@@ -154,6 +154,9 @@ module Datadog
         # @default `DD_ENV` environment variable, otherwise `nil`
         # @return [String,nil]
         option :env do |o|
+          # DEV-2.0: Remove this conversion for symbol.
+          o.setter { |v| v.to_s if v }
+
           # NOTE: env also gets set as a side effect of tags. See the WORKAROUND note in #initialize for details.
           o.default { ENV.fetch(Core::Environment::Ext::ENV_ENVIRONMENT, nil) }
           o.lazy
@@ -353,6 +356,9 @@ module Datadog
         # @default `DD_SERVICE` environment variable, otherwise the program name (e.g. `'ruby'`, `'rails'`, `'pry'`)
         # @return [String]
         option :service do |o|
+          # DEV-2.0: Remove this conversion for symbol.
+          o.setter { |v| v.to_s if v }
+
           # NOTE: service also gets set as a side effect of tags. See the WORKAROUND note in #initialize for details.
           o.default { ENV.fetch(Core::Environment::Ext::ENV_SERVICE, Core::Environment::Ext::FALLBACK_SERVICE_NAME) }
           o.lazy

--- a/spec/datadog/core/configuration/settings_spec.rb
+++ b/spec/datadog/core/configuration/settings_spec.rb
@@ -222,6 +222,22 @@ RSpec.describe Datadog::Core::Configuration::Settings do
 
       it { expect(settings.env).to eq(env) }
     end
+
+    context 'when given a symbol' do
+      let(:env) { :symbol }
+
+      before { set_env }
+
+      it { expect(settings.env).to eq('symbol') }
+    end
+
+    context 'when given `nil`' do
+      let(:env) { nil }
+
+      before { set_env }
+
+      it { expect(settings.env).to be_nil }
+    end
   end
 
   describe '#logger' do
@@ -765,6 +781,22 @@ RSpec.describe Datadog::Core::Configuration::Settings do
       before { set_service }
 
       it { expect(settings.service).to eq(service) }
+    end
+
+    context 'when given a symbol' do
+      let(:service) { :symbol }
+
+      before { set_service }
+
+      it { expect(settings.service).to eq('symbol') }
+    end
+
+    context 'when given `nil`' do
+      let(:service) { nil }
+
+      before { set_service }
+
+      it { expect(settings.service).to be_nil }
     end
   end
 

--- a/spec/datadog/core/utils/safe_dup_spec.rb
+++ b/spec/datadog/core/utils/safe_dup_spec.rb
@@ -1,0 +1,47 @@
+require 'datadog/core/utils/safe_dup'
+
+RSpec.describe Datadog::Core::Utils::SafeDup do
+  describe '.frozen_or_dup' do
+    it do
+      input = 'a_frozen_string'.freeze
+
+      result = described_class.frozen_or_dup(input)
+
+      expect(result).to eq(input)
+      expect(result).to equal(input)
+      expect(result).to be_frozen
+    end
+
+    it do
+      input = 'a_string'
+
+      result = described_class.frozen_or_dup(input)
+
+      expect(result).to eq(input)
+      expect(result).not_to equal(input)
+      expect(result).not_to be_frozen
+    end
+  end
+
+  describe '.frozen_dup' do
+    it do
+      input = 'a_frozen_string'.freeze
+
+      result = described_class.frozen_dup(input)
+
+      expect(result).to eq(input)
+      expect(result).to equal(input)
+      expect(result).to be_frozen
+    end
+
+    it do
+      input = 'a_string'
+
+      result = described_class.frozen_dup(input)
+
+      expect(result).to eq(input)
+      expect(result).not_to equal(input)
+      expect(result).to be_frozen
+    end
+  end
+end

--- a/spec/datadog/core/utils/safe_dup_spec.rb
+++ b/spec/datadog/core/utils/safe_dup_spec.rb
@@ -8,20 +8,24 @@ RSpec.describe Datadog::Core::Utils::SafeDup do
 
         result = described_class.frozen_or_dup(input)
 
+        expect(input).to be_frozen
+
         expect(result).to eq(input)
-        expect(result).to equal(input)
+        expect(result).to be(input)
         expect(result).to be_frozen
       end
     end
 
     context 'when given a string' do
-      it 'returns a duplicate' do
+      it 'returns a non frozen dupliacte' do
         input = 'a_string'
 
         result = described_class.frozen_or_dup(input)
 
+        expect(input).not_to be_frozen
+
         expect(result).to eq(input)
-        expect(result).not_to equal(input)
+        expect(result).not_to be(input)
         expect(result).not_to be_frozen
       end
     end
@@ -34,8 +38,10 @@ RSpec.describe Datadog::Core::Utils::SafeDup do
 
         result = described_class.frozen_dup(input)
 
+        expect(input).to be_frozen
+
         expect(result).to eq(input)
-        expect(result).to equal(input)
+        expect(result).to be(input)
         expect(result).to be_frozen
       end
     end
@@ -46,8 +52,10 @@ RSpec.describe Datadog::Core::Utils::SafeDup do
 
         result = described_class.frozen_dup(input)
 
+        expect(input).not_to be_frozen
+
         expect(result).to eq(input)
-        expect(result).not_to equal(input)
+        expect(result).not_to be(input)
         expect(result).to be_frozen
       end
     end

--- a/spec/datadog/core/utils/safe_dup_spec.rb
+++ b/spec/datadog/core/utils/safe_dup_spec.rb
@@ -2,46 +2,54 @@ require 'datadog/core/utils/safe_dup'
 
 RSpec.describe Datadog::Core::Utils::SafeDup do
   describe '.frozen_or_dup' do
-    it do
-      input = 'a_frozen_string'.freeze
+    context 'when given a frozen string' do
+      it 'returns the original input' do
+        input = 'a_frozen_string'.freeze
 
-      result = described_class.frozen_or_dup(input)
+        result = described_class.frozen_or_dup(input)
 
-      expect(result).to eq(input)
-      expect(result).to equal(input)
-      expect(result).to be_frozen
+        expect(result).to eq(input)
+        expect(result).to equal(input)
+        expect(result).to be_frozen
+      end
     end
 
-    it do
-      input = 'a_string'
+    context 'when given a string' do
+      it 'returns a duplicate' do
+        input = 'a_string'
 
-      result = described_class.frozen_or_dup(input)
+        result = described_class.frozen_or_dup(input)
 
-      expect(result).to eq(input)
-      expect(result).not_to equal(input)
-      expect(result).not_to be_frozen
+        expect(result).to eq(input)
+        expect(result).not_to equal(input)
+        expect(result).not_to be_frozen
+      end
     end
   end
 
   describe '.frozen_dup' do
-    it do
-      input = 'a_frozen_string'.freeze
+    context 'when given a frozen string' do
+      it 'returns the original input' do
+        input = 'a_frozen_string'.freeze
 
-      result = described_class.frozen_dup(input)
+        result = described_class.frozen_dup(input)
 
-      expect(result).to eq(input)
-      expect(result).to equal(input)
-      expect(result).to be_frozen
+        expect(result).to eq(input)
+        expect(result).to equal(input)
+        expect(result).to be_frozen
+      end
     end
 
-    it do
-      input = 'a_string'
+    context 'when given a string' do
+      it 'returns a frozen duplicate' do
+        input = 'a_string'
 
-      result = described_class.frozen_dup(input)
+        result = described_class.frozen_dup(input)
 
-      expect(result).to eq(input)
-      expect(result).not_to equal(input)
-      expect(result).to be_frozen
+        expect(result).to eq(input)
+        expect(result).not_to equal(input)
+        expect(result).to be_frozen
+      end
     end
   end
 end


### PR DESCRIPTION
**What does this PR do?**

1. Make `env` and `service` configuration backward compatible for symbol
2. Add missing spec for `SafeDup` 