### PR TITLE
Update robocop version to work with ruby 3.2

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -82,14 +82,9 @@ else
   gem 'yard', ['~> 0.9', '< 0.9.27'] # yard 0.9.27 starts pulling webrick as a gem dependency
 end
 
-if RUBY_VERSION >= '2.4.0'
-  if RUBY_VERSION >= '2.6.0'
-    gem 'rubocop', '~> 1.34.0', require: false
-    gem 'rubocop-packaging', '~> 0.5.2', require: false
-  else
-    gem 'rubocop', ['~> 1.10', '< 1.33.0'], require: false
-    gem 'rubocop-packaging', '~> 0.5', require: false
-  end
+if RUBY_VERSION >= '2.6.0'
+  gem 'rubocop', '~> 1.34.0', require: false
+  gem 'rubocop-packaging', '~> 0.5.2', require: false
   gem 'rubocop-performance', '~> 1.9', require: false
   gem 'rubocop-rspec', '~> 2.2', require: false
 end

--- a/Gemfile
+++ b/Gemfile
@@ -83,8 +83,13 @@ else
 end
 
 if RUBY_VERSION >= '2.4.0'
-  gem 'rubocop', ['~> 1.10', '< 1.33.0'], require: false
-  gem 'rubocop-packaging', '~> 0.5', require: false
+  if RUBY_VERSION >= '2.6.0'
+    gem 'rubocop', '~> 1.34.0', require: false
+    gem 'rubocop-packaging', '~> 0.5.2', require: false
+  else
+    gem 'rubocop', ['~> 1.10', '< 1.33.0'], require: false
+    gem 'rubocop-packaging', '~> 0.5', require: false
+  end
   gem 'rubocop-performance', '~> 1.9', require: false
   gem 'rubocop-rspec', '~> 2.2', require: false
 end

--- a/spec/datadog/ci/ext/environment_spec.rb
+++ b/spec/datadog/ci/ext/environment_spec.rb
@@ -30,7 +30,7 @@ RSpec.describe Datadog::CI::Ext::Environment do
         context "for fixture #{File.basename(filename)}" do
           # Create a context for each example inside the JSON fixture file
           JSON.parse(f.read).each_with_index do |(env, tags), i|
-            context "##{i}" do
+            context i.to_s do
               # Modify HOME so that '~' expansion matches CI home directory.
               let(:environment_variables) { super().merge('HOME' => env['HOME']) }
               let(:env) { env }


### PR DESCRIPTION
<!--
Check out the
https://github.com/DataDog/dd-trace-rb/blob/master/docs/DevelopmentGuide.md
for guidance on how to set up your development environment,
run the test suite, write new integrations, and more.
-->

**What does this PR do?**
<!-- A brief description of the change being made with this pull request. -->

I Updated the rubocop version for the newer version of Ruby. 

I primarily work on the latest version of ruby, and my IDE was complaining the rubocop version installed did not recognise ruby `3.2`

I added a condition on our `Gemfile` to fix that. 

Here is the [rubocop file](https://github.com/rubocop/rubocop/blob/v1.33.0/lib/rubocop/target_ruby.rb#L7) that specifies which ruby version is supported. The update I did was a bit on the conservative side. There is a newer version of Rubocop [1.51.0](https://github.com/rubocop/rubocop/releases/tag/v1.51.0). 

If we feel courageous, we can try the latest version 😄 



**Motivation**
<!-- What inspired you to submit this pull request? -->

**Additional Notes**
<!-- Anything else we should know when reviewing? -->

**How to test the change?**
<!--
Describe here how the change can be validated.
You are strongly encouraged to provide automated tests for this PR (unit or integration).
If this change cannot be feasibly tested, please explain why,
unless the change does not modify code (e.g. only modifies docs, comments).
-->
