### PR TITLE
Upgrade to steep 1.4 and remove workarounds

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -112,26 +112,9 @@ if RUBY_PLATFORM != 'java'
 end
 
 group :check do
-  # The steep gem requires pathname >= 0.2.1, which clashes with the default 0.1.0 (on Ruby 3.0) and 0.2.0 (on Ruby 3.1)
-  # on github actions.
-  #
-  # The full error is:
-  # /Users/runner/hostedtoolcache/Ruby/3.1.3/x64/lib/ruby/gems/3.1.0/gems/bundler-2.4.7/lib/bundler/runtime.rb:304:in
-  # `check_for_activated_spec!': You have already activated pathname 0.2.0, but your Gemfile requires pathname 0.2.1.
-  # Since pathname is a default gem, you can either remove your dependency on it or try updating to a newer version of
-  # bundler that supports pathname as a default gem. (Gem::LoadError)
-  #
-  # @ivoanjo: For the life of me, I tried updating to the latest bundler, different ways of invoking rake (binstubs, ...)
-  # and could not fix this issue. As a final workaround, I decided to not install steep on the affected Ruby versions on
-  # GitHub Actions.
-  steep_ci_workaround = ENV['GITHUB_ACTIONS'] == 'true' && RUBY_VERSION.start_with?('3.0.', '3.1.')
-  if RUBY_VERSION >= '2.7.0' && RUBY_PLATFORM != 'java' && !steep_ci_workaround
-    gem 'rbs', '~> 2.8.1', require: false
-    gem 'steep', '~> 1.3.1', require: false
-
-    # parallel 1.23 seems to annoy steep:
-    # cannot load such file -- parallel/processor_count (LoadError)
-    gem 'parallel', '< 1.23'
+  if RUBY_VERSION >= '2.7.0' && RUBY_PLATFORM != 'java'
+    gem 'rbs', '~> 3.1.0', require: false
+    gem 'steep', '~> 1.4.0', require: false
   end
 end
 

--- a/Steepfile
+++ b/Steepfile
@@ -637,7 +637,7 @@ target :ddtrace do
   ignore 'lib/ddtrace/transport/traces.rb'
   ignore 'lib/ddtrace/version.rb'
 
-  library 'pathname', 'set'
+  library 'pathname'
   library 'cgi'
   library 'logger', 'monitor'
   library 'tsort'


### PR DESCRIPTION
**What does this PR do?**:

This PR upgrades the `steep` typechecker gem to version 1.4.

This version no longer uses the `pathname` nor `parallel` gems that previously required workarounds, which I've also removed.

Additionally, it drops the `set` library from the `Steepfile`, since it's now built-in and was causing warnings:

```
W, [2023-05-22T14:09:26.592230 #373829]  WARN -- rbs: `set` has been
moved to core library, so it is always loaded. Remove explicit
loading `set`
```

**Motivation**:

Use latest typechecking goodness, drop painful workarounds.

**Additional Notes**:

N/A

**How to test the change?**:

Validate that type checking still passes.
