### PR TITLE
[PROF-7361] Implement "no signals" workaround for running CPU Profiling 2.0 without signals

### DIFF
--- a/ext/ddtrace_profiling_native_extension/collectors_cpu_and_wall_time_worker.c
+++ b/ext/ddtrace_profiling_native_extension/collectors_cpu_and_wall_time_worker.c
@@ -445,7 +445,7 @@ static void handle_sampling_signal(DDTRACE_UNUSED int _signal, DDTRACE_UNUSED si
   }
 
   // We implicitly assume there can be no concurrent nor nested calls to handle_sampling_signal because
-  // a) we get triggered using SIGPROF, and the docs state second SIGPROF will not interrupt an existing one
+  // a) we get triggered using SIGPROF, and the docs state a second SIGPROF will not interrupt an existing one
   // b) we validate we are in the thread that has the global VM lock; if a different thread gets a signal, it will return early
   //    because it will not have the global VM lock
 
@@ -509,7 +509,7 @@ static void *run_sampling_trigger_loop(void *state_ptr) {
       // Thus, we instead pretty please ask Ruby to let us run. This means profiling data can be biased by when the Ruby
       // scheduler chooses to schedule us.
       state->stats.trigger_simulated_signal_delivery_attempts++;
-      grab_gvl_and_sample();
+      grab_gvl_and_sample(); // Note: Can raise exceptions
     }
 
     sleep_for(minimum_time_between_signals);

--- a/ext/ddtrace_profiling_native_extension/collectors_cpu_and_wall_time_worker.c
+++ b/ext/ddtrace_profiling_native_extension/collectors_cpu_and_wall_time_worker.c
@@ -81,6 +81,7 @@ struct cpu_and_wall_time_worker_state {
 
   bool gc_profiling_enabled;
   bool allocation_counting_enabled;
+  bool no_signals_workaround_enabled;
   bool dynamic_sampling_rate_enabled;
   VALUE self_instance;
   VALUE thread_context_collector_instance;
@@ -148,6 +149,7 @@ static VALUE _native_initialize(
   VALUE gc_profiling_enabled,
   VALUE idle_sampling_helper_instance,
   VALUE allocation_counting_enabled,
+  VALUE no_signals_workaround_enabled,
   VALUE dynamic_sampling_rate_enabled
 );
 static void cpu_and_wall_time_worker_typed_data_mark(void *state_ptr);
@@ -221,7 +223,7 @@ void collectors_cpu_and_wall_time_worker_init(VALUE profiling_module) {
   // https://bugs.ruby-lang.org/issues/18007 for a discussion around this.
   rb_define_alloc_func(collectors_cpu_and_wall_time_worker_class, _native_new);
 
-  rb_define_singleton_method(collectors_cpu_and_wall_time_worker_class, "_native_initialize", _native_initialize, 6);
+  rb_define_singleton_method(collectors_cpu_and_wall_time_worker_class, "_native_initialize", _native_initialize, 7);
   rb_define_singleton_method(collectors_cpu_and_wall_time_worker_class, "_native_sampling_loop", _native_sampling_loop, 1);
   rb_define_singleton_method(collectors_cpu_and_wall_time_worker_class, "_native_stop", _native_stop, 2);
   rb_define_singleton_method(collectors_cpu_and_wall_time_worker_class, "_native_reset_after_fork", _native_reset_after_fork, 1);
@@ -257,6 +259,7 @@ static VALUE _native_new(VALUE klass) {
 
   state->gc_profiling_enabled = false;
   state->allocation_counting_enabled = false;
+  state->no_signals_workaround_enabled = false;
   state->dynamic_sampling_rate_enabled = true;
   state->thread_context_collector_instance = Qnil;
   state->idle_sampling_helper_instance = Qnil;
@@ -283,10 +286,12 @@ static VALUE _native_initialize(
   VALUE gc_profiling_enabled,
   VALUE idle_sampling_helper_instance,
   VALUE allocation_counting_enabled,
+  VALUE no_signals_workaround_enabled,
   VALUE dynamic_sampling_rate_enabled
 ) {
   ENFORCE_BOOLEAN(gc_profiling_enabled);
   ENFORCE_BOOLEAN(allocation_counting_enabled);
+  ENFORCE_BOOLEAN(no_signals_workaround_enabled);
   ENFORCE_BOOLEAN(dynamic_sampling_rate_enabled);
 
   struct cpu_and_wall_time_worker_state *state;
@@ -294,6 +299,7 @@ static VALUE _native_initialize(
 
   state->gc_profiling_enabled = (gc_profiling_enabled == Qtrue);
   state->allocation_counting_enabled = (allocation_counting_enabled == Qtrue);
+  state->no_signals_workaround_enabled = (no_signals_workaround_enabled == Qtrue);
   state->dynamic_sampling_rate_enabled = (dynamic_sampling_rate_enabled == Qtrue);
   state->thread_context_collector_instance = enforce_thread_context_collector_instance(thread_context_collector_instance);
   state->idle_sampling_helper_instance = idle_sampling_helper_instance;

--- a/integration/apps/rack/spec/integration/basic_spec.rb
+++ b/integration/apps/rack/spec/integration/basic_spec.rb
@@ -14,18 +14,11 @@ RSpec.describe 'Basic scenarios' do
   let(:expected_profiler_available) { RUBY_VERSION >= '2.3' }
 
   let(:expected_profiler_threads) do
-    if RUBY_VERSION >= '2.6.'
-      contain_exactly(
-        'Datadog::Profiling::Collectors::IdleSamplingHelper',
-        'Datadog::Profiling::Collectors::CpuAndWallTimeWorker',
-        'Datadog::Profiling::Scheduler',
-      )
-    elsif RUBY_VERSION >= '2.3'
-      contain_exactly(
-        'Datadog::Profiling::Collectors::OldStack',
-        'Datadog::Profiling::Scheduler',
-      )
-    end
+    contain_exactly(
+      'Datadog::Profiling::Collectors::IdleSamplingHelper',
+      'Datadog::Profiling::Collectors::CpuAndWallTimeWorker',
+      'Datadog::Profiling::Scheduler',
+    ) if RUBY_VERSION >= '2.3.'
   end
 
   context 'component checks' do

--- a/integration/apps/rails-five/spec/integration/basic_spec.rb
+++ b/integration/apps/rails-five/spec/integration/basic_spec.rb
@@ -15,18 +15,11 @@ RSpec.describe 'Basic scenarios' do
     let(:json_result) { JSON.parse(subject.body, symbolize_names: true) }
 
     let(:expected_profiler_threads) do
-      if RUBY_VERSION >= '2.6.'
-        contain_exactly(
-          'Datadog::Profiling::Collectors::IdleSamplingHelper',
-          'Datadog::Profiling::Collectors::CpuAndWallTimeWorker',
-          'Datadog::Profiling::Scheduler',
-        )
-      else
-        contain_exactly(
-          'Datadog::Profiling::Collectors::OldStack',
-          'Datadog::Profiling::Scheduler',
-        )
-      end
+      contain_exactly(
+        'Datadog::Profiling::Collectors::IdleSamplingHelper',
+        'Datadog::Profiling::Collectors::CpuAndWallTimeWorker',
+        'Datadog::Profiling::Scheduler',
+      )
     end
 
     it { is_expected.to be_a_kind_of(Net::HTTPOK) }

--- a/integration/apps/rails-six/spec/integration/basic_spec.rb
+++ b/integration/apps/rails-six/spec/integration/basic_spec.rb
@@ -15,18 +15,11 @@ RSpec.describe 'Basic scenarios' do
     let(:json_result) { JSON.parse(subject.body, symbolize_names: true) }
 
     let(:expected_profiler_threads) do
-      if RUBY_VERSION >= '2.6.'
-        contain_exactly(
-          'Datadog::Profiling::Collectors::IdleSamplingHelper',
-          'Datadog::Profiling::Collectors::CpuAndWallTimeWorker',
-          'Datadog::Profiling::Scheduler',
-        )
-      else
-        contain_exactly(
-          'Datadog::Profiling::Collectors::OldStack',
-          'Datadog::Profiling::Scheduler',
-        )
-      end
+      contain_exactly(
+        'Datadog::Profiling::Collectors::IdleSamplingHelper',
+        'Datadog::Profiling::Collectors::CpuAndWallTimeWorker',
+        'Datadog::Profiling::Scheduler',
+      )
     end
 
     it { is_expected.to be_a_kind_of(Net::HTTPOK) }

--- a/integration/apps/sinatra2-classic/spec/integration/basic_spec.rb
+++ b/integration/apps/sinatra2-classic/spec/integration/basic_spec.rb
@@ -14,18 +14,11 @@ RSpec.describe 'Basic scenarios' do
   let(:expected_profiler_available) { RUBY_VERSION >= '2.3' }
 
   let(:expected_profiler_threads) do
-    if RUBY_VERSION >= '2.6.'
-      contain_exactly(
-        'Datadog::Profiling::Collectors::IdleSamplingHelper',
-        'Datadog::Profiling::Collectors::CpuAndWallTimeWorker',
-        'Datadog::Profiling::Scheduler',
-      )
-    elsif RUBY_VERSION >= '2.3'
-      contain_exactly(
-        'Datadog::Profiling::Collectors::OldStack',
-        'Datadog::Profiling::Scheduler',
-      )
-    end
+    contain_exactly(
+      'Datadog::Profiling::Collectors::IdleSamplingHelper',
+      'Datadog::Profiling::Collectors::CpuAndWallTimeWorker',
+      'Datadog::Profiling::Scheduler',
+    )
   end
 
   context 'component checks' do

--- a/integration/apps/sinatra2-modular/spec/integration/basic_spec.rb
+++ b/integration/apps/sinatra2-modular/spec/integration/basic_spec.rb
@@ -14,18 +14,11 @@ RSpec.describe 'Basic scenarios' do
   let(:expected_profiler_available) { RUBY_VERSION >= '2.3' }
 
   let(:expected_profiler_threads) do
-    if RUBY_VERSION >= '2.6.'
-      contain_exactly(
-        'Datadog::Profiling::Collectors::IdleSamplingHelper',
-        'Datadog::Profiling::Collectors::CpuAndWallTimeWorker',
-        'Datadog::Profiling::Scheduler',
-      )
-    elsif RUBY_VERSION >= '2.3'
-      contain_exactly(
-        'Datadog::Profiling::Collectors::OldStack',
-        'Datadog::Profiling::Scheduler',
-      )
-    end
+    contain_exactly(
+      'Datadog::Profiling::Collectors::IdleSamplingHelper',
+      'Datadog::Profiling::Collectors::CpuAndWallTimeWorker',
+      'Datadog::Profiling::Scheduler',
+    )
   end
 
   context 'component checks' do

--- a/lib/datadog/core/configuration/settings.rb
+++ b/lib/datadog/core/configuration/settings.rb
@@ -284,11 +284,11 @@ module Datadog
             option :force_enable_legacy_profiler do |o|
               o.default { env_to_bool('DD_PROFILING_FORCE_ENABLE_LEGACY', false) }
               o.lazy
-              o.on_set do
+              o.on_set do |value|
                 Datadog.logger.warn(
                   'The profiling.advanced.force_enable_legacy_profiler setting has been deprecated for removal. ' \
                   'Do not use unless instructed to by support.'
-                )
+                ) if value
               end
             end
 

--- a/lib/datadog/core/configuration/settings.rb
+++ b/lib/datadog/core/configuration/settings.rb
@@ -275,16 +275,21 @@ module Datadog
               end
             end
 
-            # Forces enabling the *legacy* (non-CPU Profiling 2.0 profiler) even when it would otherwise NOT be enabled.
+            # @deprecated Will be removed for dd-trace-rb 2.0.
             #
-            # Temporarily added to ease migration to the new CPU Profiling 2.0 profiler, and will be removed soon.
+            # Forces enabling the *legacy* non-CPU Profiling 2.0 profiler.
             # Do not use unless instructed to by support.
-            # This option will be deprecated for removal once the legacy profiler is removed.
             #
             # @default `DD_PROFILING_FORCE_ENABLE_LEGACY` environment variable, otherwise `false`
             option :force_enable_legacy_profiler do |o|
               o.default { env_to_bool('DD_PROFILING_FORCE_ENABLE_LEGACY', false) }
               o.lazy
+              o.on_set do
+                Datadog.logger.warn(
+                  'The profiling.advanced.force_enable_legacy_profiler setting has been deprecated for removal. ' \
+                  'Do not use unless instructed to by support.'
+                )
+              end
             end
 
             # Forces enabling of profiling of time/resources spent in Garbage Collection.

--- a/lib/datadog/core/configuration/settings.rb
+++ b/lib/datadog/core/configuration/settings.rb
@@ -205,12 +205,21 @@ module Datadog
 
           # @public_api
           settings :advanced do
+            # @deprecated This setting is ignored when CPU Profiling 2.0 is in use, and will be removed on dd-trace-rb 2.0.
+            #
             # This should never be reduced, as it can cause the resulting profiles to become biased.
             # The default should be enough for most services, allowing 16 threads to be sampled around 30 times
             # per second for a 60 second period.
-            #
-            # @deprecated This setting is ignored when CPU Profiling 2.0 is in use.
-            option :max_events, default: 32768
+            option :max_events do |o|
+              o.default 32768
+              o.on_set do
+                Datadog.logger.warn(
+                  'The profiling.advanced.max_events setting has been deprecated for removal. It no longer does anything ' \
+                  'unless you the `force_enable_legacy_profiler` option is in use. ' \
+                  'Please remove it from your Datadog.configure block.'
+                )
+              end
+            end
 
             # Controls the maximum number of frames for each thread sampled. Can be tuned to avoid omitted frames in the
             # produced profiles. Increasing this may increase the overhead of profiling.

--- a/lib/datadog/core/configuration/settings.rb
+++ b/lib/datadog/core/configuration/settings.rb
@@ -212,12 +212,12 @@ module Datadog
             # per second for a 60 second period.
             option :max_events do |o|
               o.default 32768
-              o.on_set do
+              o.on_set do |value|
                 Datadog.logger.warn(
                   'The profiling.advanced.max_events setting has been deprecated for removal. It no longer does anything ' \
                   'unless you the `force_enable_legacy_profiler` option is in use. ' \
                   'Please remove it from your Datadog.configure block.'
-                )
+                ) if value != 32768
               end
             end
 

--- a/lib/datadog/core/configuration/settings.rb
+++ b/lib/datadog/core/configuration/settings.rb
@@ -320,6 +320,30 @@ module Datadog
               o.default { env_to_bool('DD_PROFILING_SKIP_MYSQL2_CHECK', false) }
               o.lazy
             end
+
+            # The profiler gathers data by sending `SIGPROF` unix signals to Ruby application threads.
+            #
+            # Sending `SIGPROF` is a common profiling approach, and may cause system calls from native
+            # extensions/libraries to be interrupted with a system
+            # [EINTR error code.](https://man7.org/linux/man-pages/man7/signal.7.html#:~:text=Interruption%20of%20system%20calls%20and%20library%20functions%20by%20signal%20handlers)
+            # Rarely, native extensions or libraries called by them may have missing or incorrect error handling for the
+            # `EINTR` error code.
+            #
+            # The "no signals" workaround, when enabled, enables an alternative mode for the profiler where it does not
+            # send `SIGPROF` unix signals. The downside of this approach is that the profiler data will have lower
+            # quality.
+            #
+            # This workaround is automatically enabled when gems that are known to have issues handling
+            # `EINTR` error codes are detected. If you suspect you may be seeing an issue due to the profiler's use of
+            # signals, you can try manually enabling this mode as a fallback.
+            # Please also report these issues to us on <https://github.com/DataDog/dd-trace-rb/issues/new>, so we can
+            # work with the gem authors to fix them!
+            #
+            # @default `DD_PROFILING_NO_SIGNALS_WORKAROUND_ENABLED` environment variable as a boolean, otherwise `:auto`
+            option :no_signals_workaround_enabled do |o|
+              o.default { env_to_bool('DD_PROFILING_NO_SIGNALS_WORKAROUND_ENABLED', :auto) }
+              o.lazy
+            end
           end
 
           # @public_api

--- a/lib/datadog/core/configuration/settings.rb
+++ b/lib/datadog/core/configuration/settings.rb
@@ -253,16 +253,17 @@ module Datadog
               end
             end
 
-            # Forces enabling the new CPU Profiling 2.0 profiler (see ddtrace release notes for more details).
+            # @deprecated No longer does anything, and will be removed on dd-trace-rb 2.0.
             #
-            # Note that setting this to "false" (or not setting it) will not prevent the new profiler from
-            # being automatically used.
-            # This option will be deprecated for removal once the legacy profiler is removed.
-            #
-            # @default `DD_PROFILING_FORCE_ENABLE_NEW` environment variable, otherwise `false`
+            # This was used prior to the GA of the new CPU Profiling 2.0 profiler. Using CPU Profiling 2.0 is now the
+            # default and this doesn't do anything.
             option :force_enable_new_profiler do |o|
-              o.default { env_to_bool('DD_PROFILING_FORCE_ENABLE_NEW', false) }
-              o.lazy
+              o.on_set do
+                Datadog.logger.warn(
+                  'The profiling.advanced.force_enable_new_profiler setting has been deprecated for removal and no ' \
+                  'longer does anything. Please remove it from your Datadog.configure block.'
+                )
+              end
             end
 
             # Forces enabling the *legacy* (non-CPU Profiling 2.0 profiler) even when it would otherwise NOT be enabled.

--- a/lib/datadog/core/configuration/settings.rb
+++ b/lib/datadog/core/configuration/settings.rb
@@ -287,7 +287,10 @@ module Datadog
               o.on_set do |value|
                 Datadog.logger.warn(
                   'The profiling.advanced.force_enable_legacy_profiler setting has been deprecated for removal. ' \
-                  'Do not use unless instructed to by support.'
+                  'Do not use unless instructed to by support. ' \
+                  'If you needed to use it due to incompatibilities with the CPU Profiling 2.0 profiler, consider ' \
+                  'using the profiling.advanced.no_signals_workaround_enabled setting instead. ' \
+                  'See <https://dtdg.co/ruby-profiler-troubleshooting> for details.'
                 ) if value
               end
             end

--- a/lib/datadog/core/configuration/settings.rb
+++ b/lib/datadog/core/configuration/settings.rb
@@ -213,11 +213,13 @@ module Datadog
             option :max_events do |o|
               o.default 32768
               o.on_set do |value|
-                Datadog.logger.warn(
-                  'The profiling.advanced.max_events setting has been deprecated for removal. It no longer does anything ' \
-                  'unless you the `force_enable_legacy_profiler` option is in use. ' \
-                  'Please remove it from your Datadog.configure block.'
-                ) if value != 32768
+                if value != 32768
+                  Datadog.logger.warn(
+                    'The profiling.advanced.max_events setting has been deprecated for removal. It no longer does ' \
+                    'anything unless you the `force_enable_legacy_profiler` option is in use. ' \
+                    'Please remove it from your Datadog.configure block.'
+                  )
+                end
               end
             end
 
@@ -285,13 +287,15 @@ module Datadog
               o.default { env_to_bool('DD_PROFILING_FORCE_ENABLE_LEGACY', false) }
               o.lazy
               o.on_set do |value|
-                Datadog.logger.warn(
-                  'The profiling.advanced.force_enable_legacy_profiler setting has been deprecated for removal. ' \
-                  'Do not use unless instructed to by support. ' \
-                  'If you needed to use it due to incompatibilities with the CPU Profiling 2.0 profiler, consider ' \
-                  'using the profiling.advanced.no_signals_workaround_enabled setting instead. ' \
-                  'See <https://dtdg.co/ruby-profiler-troubleshooting> for details.'
-                ) if value
+                if value
+                  Datadog.logger.warn(
+                    'The profiling.advanced.force_enable_legacy_profiler setting has been deprecated for removal. ' \
+                    'Do not use unless instructed to by support. ' \
+                    'If you needed to use it due to incompatibilities with the CPU Profiling 2.0 profiler, consider ' \
+                    'using the profiling.advanced.no_signals_workaround_enabled setting instead. ' \
+                    'See <https://dtdg.co/ruby-profiler-troubleshooting> for details.'
+                  )
+                end
               end
             end
 

--- a/lib/datadog/profiling/collectors/cpu_and_wall_time_worker.rb
+++ b/lib/datadog/profiling/collectors/cpu_and_wall_time_worker.rb
@@ -20,6 +20,7 @@ module Datadog
           endpoint_collection_enabled:,
           gc_profiling_enabled:,
           allocation_counting_enabled:,
+          no_signals_workaround_enabled:,
           thread_context_collector: ThreadContext.new(
             recorder: recorder,
             max_frames: max_frames,
@@ -43,6 +44,7 @@ module Datadog
             gc_profiling_enabled,
             idle_sampling_helper,
             allocation_counting_enabled,
+            no_signals_workaround_enabled,
             dynamic_sampling_rate_enabled,
           )
           @worker_thread = nil

--- a/lib/datadog/profiling/collectors/cpu_and_wall_time_worker.rb
+++ b/lib/datadog/profiling/collectors/cpu_and_wall_time_worker.rb
@@ -38,6 +38,10 @@ module Datadog
             )
           end
 
+          if no_signals_workaround_enabled
+            Datadog.logger.debug('Profiling no signals workaround is in use. Profiling data will have lower precision.')
+          end
+
           self.class._native_initialize(
             self,
             thread_context_collector,

--- a/lib/datadog/profiling/collectors/cpu_and_wall_time_worker.rb
+++ b/lib/datadog/profiling/collectors/cpu_and_wall_time_worker.rb
@@ -38,10 +38,6 @@ module Datadog
             )
           end
 
-          if no_signals_workaround_enabled
-            Datadog.logger.debug('Profiling no signals workaround is in use. Profiling data will have lower precision.')
-          end
-
           self.class._native_initialize(
             self,
             thread_context_collector,

--- a/lib/datadog/profiling/component.rb
+++ b/lib/datadog/profiling/component.rb
@@ -157,7 +157,8 @@ module Datadog
 
         unless [true, false, :auto].include?(setting_value)
           Datadog.logger.error(
-            "Ignoring invalid value for profiling no_signals_workaround_enabled setting: #{setting_value.inspect}"
+            "Ignoring invalid value for profiling no_signals_workaround_enabled setting: #{setting_value.inspect}. " \
+            'Valid options are `true`, `false` or (default) `:auto`.'
           )
 
           setting_value = :auto

--- a/lib/datadog/profiling/component.rb
+++ b/lib/datadog/profiling/component.rb
@@ -76,6 +76,8 @@ module Datadog
             endpoint_collection_enabled: settings.profiling.advanced.endpoint.collection.enabled,
             gc_profiling_enabled: enable_gc_profiling?(settings),
             allocation_counting_enabled: settings.profiling.advanced.allocation_counting_enabled,
+            # TODO: automatically enable this when needed
+            no_signals_workaround_enabled: !settings.profiling.advanced.no_signals_workaround_enabled.nil?,
           )
         else
           recorder = build_profiler_old_recorder(settings)

--- a/sig/datadog/profiling/collectors/cpu_and_wall_time_worker.rbs
+++ b/sig/datadog/profiling/collectors/cpu_and_wall_time_worker.rbs
@@ -11,6 +11,7 @@ module Datadog
           endpoint_collection_enabled: bool,
           gc_profiling_enabled: bool,
           allocation_counting_enabled: bool,
+          no_signals_workaround_enabled: bool,
           ?thread_context_collector: Datadog::Profiling::Collectors::ThreadContext,
           ?idle_sampling_helper: Datadog::Profiling::Collectors::IdleSamplingHelper,
           ?dynamic_sampling_rate_enabled: bool,

--- a/sig/datadog/profiling/component.rbs
+++ b/sig/datadog/profiling/component.rbs
@@ -31,6 +31,8 @@ module Datadog
 
       def self.enable_new_profiler?: (untyped settings) -> bool
 
+      def self.no_signals_workaround_enabled?: (untyped settings) -> bool
+
       def self.incompatible_libmysqlclient_version?: (untyped settings) -> bool
     end
   end

--- a/spec/datadog/core/configuration/settings_spec.rb
+++ b/spec/datadog/core/configuration/settings_spec.rb
@@ -449,6 +449,14 @@ RSpec.describe Datadog::Core::Configuration::Settings do
         end
       end
 
+      describe '#legacy_transport_enabled=' do
+        it 'logs a warning informing customers this no longer does anything' do
+          expect(Datadog.logger).to receive(:warn).with(/no longer does anything/)
+
+          settings.profiling.advanced.legacy_transport_enabled = true
+        end
+      end
+
       describe '#force_enable_legacy_profiler' do
         subject(:force_enable_legacy_profiler) { settings.profiling.advanced.force_enable_legacy_profiler }
 

--- a/spec/datadog/core/configuration/settings_spec.rb
+++ b/spec/datadog/core/configuration/settings_spec.rb
@@ -441,38 +441,11 @@ RSpec.describe Datadog::Core::Configuration::Settings do
         end
       end
 
-      describe '#force_enable_new_profiler' do
-        subject(:force_enable_new_profiler) { settings.profiling.advanced.force_enable_new_profiler }
-
-        context 'when DD_PROFILING_FORCE_ENABLE_NEW' do
-          around do |example|
-            ClimateControl.modify('DD_PROFILING_FORCE_ENABLE_NEW' => environment) do
-              example.run
-            end
-          end
-
-          context 'is not defined' do
-            let(:environment) { nil }
-
-            it { is_expected.to be false }
-          end
-
-          [true, false].each do |value|
-            context "is defined as #{value}" do
-              let(:environment) { value.to_s }
-
-              it { is_expected.to be value }
-            end
-          end
-        end
-      end
-
       describe '#force_enable_new_profiler=' do
-        it 'updates the #force_enable_new_profiler setting' do
-          expect { settings.profiling.advanced.force_enable_new_profiler = true }
-            .to change { settings.profiling.advanced.force_enable_new_profiler }
-            .from(false)
-            .to(true)
+        it 'logs a warning informing customers this no longer does anything' do
+          expect(Datadog.logger).to receive(:warn).with(/no longer does anything/)
+
+          settings.profiling.advanced.force_enable_new_profiler = true
         end
       end
 

--- a/spec/datadog/core/configuration/settings_spec.rb
+++ b/spec/datadog/core/configuration/settings_spec.rb
@@ -574,7 +574,7 @@ RSpec.describe Datadog::Core::Configuration::Settings do
       end
 
       describe '#skip_mysql2_check' do
-        subject(:force_enable_gc_profiling) { settings.profiling.advanced.skip_mysql2_check }
+        subject(:skip_mysql2_check) { settings.profiling.advanced.skip_mysql2_check }
 
         context 'when DD_PROFILING_SKIP_MYSQL2_CHECK' do
           around do |example|
@@ -605,6 +605,41 @@ RSpec.describe Datadog::Core::Configuration::Settings do
             .to change { settings.profiling.advanced.skip_mysql2_check }
             .from(false)
             .to(true)
+        end
+      end
+
+      describe '#no_signals_workaround_enabled' do
+        subject(:no_signals_workaround_enabled) { settings.profiling.advanced.no_signals_workaround_enabled }
+
+        context 'when DD_PROFILING_NO_SIGNALS_WORKAROUND_ENABLED' do
+          around do |example|
+            ClimateControl.modify('DD_PROFILING_NO_SIGNALS_WORKAROUND_ENABLED' => environment) do
+              example.run
+            end
+          end
+
+          context 'is not defined' do
+            let(:environment) { nil }
+
+            it { is_expected.to be :auto }
+          end
+
+          { 'true' => true, 'false' => false }.each do |string, value|
+            context "is defined as #{string}" do
+              let(:environment) { string }
+
+              it { is_expected.to be value }
+            end
+          end
+        end
+      end
+
+      describe '#no_signals_workaround_enabled=' do
+        it 'updates the #no_signals_workaround_enabled setting' do
+          expect { settings.profiling.advanced.no_signals_workaround_enabled = false }
+            .to change { settings.profiling.advanced.no_signals_workaround_enabled }
+            .from(:auto)
+            .to(false)
         end
       end
     end

--- a/spec/datadog/core/configuration/settings_spec.rb
+++ b/spec/datadog/core/configuration/settings_spec.rb
@@ -516,7 +516,15 @@ RSpec.describe Datadog::Core::Configuration::Settings do
         it 'logs a warning informing customers this has been deprecated for removal' do
           expect(Datadog.logger).to receive(:warn).with(/deprecated for removal/)
 
-          settings.profiling.advanced.max_events = 1234
+          settings.profiling.advanced.force_enable_legacy_profiler = 1234
+        end
+
+        context 'when value is set to false' do
+          it 'does not log a warning' do
+            expect(Datadog.logger).to_not receive(:warn)
+
+            settings.profiling.advanced.force_enable_legacy_profiler = false
+          end
         end
       end
 

--- a/spec/datadog/core/configuration/settings_spec.rb
+++ b/spec/datadog/core/configuration/settings_spec.rb
@@ -405,9 +405,9 @@ RSpec.describe Datadog::Core::Configuration::Settings do
                 it { is_expected.to be true }
               end
 
-              { 'true' => true, 'false' => false }.each do |string, value|
-                context "is defined as #{string}" do
-                  let(:environment) { string }
+              [true, false].each do |value|
+                context "is defined as #{value}" do
+                  let(:environment) { value.to_s }
 
                   it { is_expected.to be value }
                 end
@@ -457,9 +457,9 @@ RSpec.describe Datadog::Core::Configuration::Settings do
             it { is_expected.to be false }
           end
 
-          { 'true' => true, 'false' => false }.each do |string, value|
-            context "is defined as #{string}" do
-              let(:environment) { string }
+          [true, false].each do |value|
+            context "is defined as #{value}" do
+              let(:environment) { value.to_s }
 
               it { is_expected.to be value }
             end
@@ -492,9 +492,9 @@ RSpec.describe Datadog::Core::Configuration::Settings do
             it { is_expected.to be false }
           end
 
-          { 'true' => true, 'false' => false }.each do |string, value|
-            context "is defined as #{string}" do
-              let(:environment) { string }
+          [true, false].each do |value|
+            context "is defined as #{value}" do
+              let(:environment) { value.to_s }
 
               it { is_expected.to be value }
             end
@@ -527,9 +527,9 @@ RSpec.describe Datadog::Core::Configuration::Settings do
             it { is_expected.to be false }
           end
 
-          { 'true' => true, 'false' => false }.each do |string, value|
-            context "is defined as #{string}" do
-              let(:environment) { string }
+          [true, false].each do |value|
+            context "is defined as #{value}" do
+              let(:environment) { value.to_s }
 
               it { is_expected.to be value }
             end
@@ -589,9 +589,9 @@ RSpec.describe Datadog::Core::Configuration::Settings do
             it { is_expected.to be false }
           end
 
-          { 'true' => true, 'false' => false }.each do |string, value|
-            context "is defined as #{string}" do
-              let(:environment) { string }
+          [true, false].each do |value|
+            context "is defined as #{value}" do
+              let(:environment) { value.to_s }
 
               it { is_expected.to be value }
             end
@@ -624,9 +624,9 @@ RSpec.describe Datadog::Core::Configuration::Settings do
             it { is_expected.to be :auto }
           end
 
-          { 'true' => true, 'false' => false }.each do |string, value|
-            context "is defined as #{string}" do
-              let(:environment) { string }
+          [true, false].each do |value|
+            context "is defined as #{value}" do
+              let(:environment) { value.to_s }
 
               it { is_expected.to be value }
             end
@@ -1191,9 +1191,9 @@ RSpec.describe Datadog::Core::Configuration::Settings do
           it { is_expected.to be true }
         end
 
-        { 'true' => true, 'false' => false }.each do |string, value|
-          context "is defined as #{string}" do
-            let(:environment) { string }
+        [true, false].each do |value|
+          context "is defined as #{value}" do
+            let(:environment) { value.to_s }
 
             it { is_expected.to be value }
           end

--- a/spec/datadog/core/configuration/settings_spec.rb
+++ b/spec/datadog/core/configuration/settings_spec.rb
@@ -468,6 +468,8 @@ RSpec.describe Datadog::Core::Configuration::Settings do
       end
 
       describe '#force_enable_legacy_profiler' do
+        before { allow(Datadog.logger).to receive(:warn) }
+
         subject(:force_enable_legacy_profiler) { settings.profiling.advanced.force_enable_legacy_profiler }
 
         context 'when DD_PROFILING_FORCE_ENABLE_LEGACY' do
@@ -494,11 +496,19 @@ RSpec.describe Datadog::Core::Configuration::Settings do
       end
 
       describe '#force_enable_legacy_profiler=' do
+        before { allow(Datadog.logger).to receive(:warn) }
+
         it 'updates the #force_enable_legacy_profiler setting' do
           expect { settings.profiling.advanced.force_enable_legacy_profiler = true }
             .to change { settings.profiling.advanced.force_enable_legacy_profiler }
             .from(false)
             .to(true)
+        end
+
+        it 'logs a warning informing customers this has been deprecated for removal' do
+          expect(Datadog.logger).to receive(:warn).with(/deprecated for removal/)
+
+          settings.profiling.advanced.max_events = 1234
         end
       end
 

--- a/spec/datadog/core/configuration/settings_spec.rb
+++ b/spec/datadog/core/configuration/settings_spec.rb
@@ -362,6 +362,14 @@ RSpec.describe Datadog::Core::Configuration::Settings do
 
           settings.profiling.advanced.max_events = 1234
         end
+
+        context 'when value is set to default' do
+          it 'does not log a warning' do
+            expect(Datadog.logger).to_not receive(:warn)
+
+            settings.profiling.advanced.max_events = 32768
+          end
+        end
       end
 
       describe '#max_frames' do

--- a/spec/datadog/core/configuration/settings_spec.rb
+++ b/spec/datadog/core/configuration/settings_spec.rb
@@ -340,17 +340,27 @@ RSpec.describe Datadog::Core::Configuration::Settings do
 
     describe '#advanced' do
       describe '#max_events' do
+        before { allow(Datadog.logger).to receive(:warn) }
+
         subject(:max_events) { settings.profiling.advanced.max_events }
 
         it { is_expected.to eq(32768) }
       end
 
       describe '#max_events=' do
+        before { allow(Datadog.logger).to receive(:warn) }
+
         it 'updates the #max_events setting' do
           expect { settings.profiling.advanced.max_events = 1234 }
             .to change { settings.profiling.advanced.max_events }
             .from(32768)
             .to(1234)
+        end
+
+        it 'logs a warning informing customers this has been deprecated for removal' do
+          expect(Datadog.logger).to receive(:warn).with(/deprecated for removal/)
+
+          settings.profiling.advanced.max_events = 1234
         end
       end
 

--- a/spec/datadog/profiling/collectors/cpu_and_wall_time_worker_spec.rb
+++ b/spec/datadog/profiling/collectors/cpu_and_wall_time_worker_spec.rb
@@ -8,6 +8,7 @@ RSpec.describe Datadog::Profiling::Collectors::CpuAndWallTimeWorker do
   let(:endpoint_collection_enabled) { true }
   let(:gc_profiling_enabled) { true }
   let(:allocation_counting_enabled) { true }
+  let(:no_signals_workaround_enabled) { false }
   let(:options) { {} }
 
   subject(:cpu_and_wall_time_worker) do
@@ -18,6 +19,7 @@ RSpec.describe Datadog::Profiling::Collectors::CpuAndWallTimeWorker do
       endpoint_collection_enabled: endpoint_collection_enabled,
       gc_profiling_enabled: gc_profiling_enabled,
       allocation_counting_enabled: allocation_counting_enabled,
+      no_signals_workaround_enabled: no_signals_workaround_enabled,
       **options
     )
   end
@@ -661,6 +663,7 @@ RSpec.describe Datadog::Profiling::Collectors::CpuAndWallTimeWorker do
       endpoint_collection_enabled: endpoint_collection_enabled,
       gc_profiling_enabled: gc_profiling_enabled,
       allocation_counting_enabled: allocation_counting_enabled,
+      no_signals_workaround_enabled: no_signals_workaround_enabled,
     )
   end
 end

--- a/spec/datadog/profiling/collectors/cpu_and_wall_time_worker_spec.rb
+++ b/spec/datadog/profiling/collectors/cpu_and_wall_time_worker_spec.rb
@@ -41,16 +41,6 @@ RSpec.describe Datadog::Profiling::Collectors::CpuAndWallTimeWorker do
         end
       end
     end
-
-    context 'when using the no signals workaround' do
-      let(:no_signals_workaround_enabled) { true }
-
-      it 'logs a debug message' do
-        expect(Datadog.logger).to receive(:debug).with(/no signals workaround is in use/)
-
-        cpu_and_wall_time_worker
-      end
-    end
   end
 
   describe '#start' do

--- a/spec/datadog/profiling/component_spec.rb
+++ b/spec/datadog/profiling/component_spec.rb
@@ -50,7 +50,10 @@ RSpec.describe Datadog::Profiling::Component do
       end
 
       context 'when using the legacy profiler' do
-        before { expect(described_class).to receive(:enable_new_profiler?).with(settings).and_return(false) }
+        before do
+          settings.profiling.advanced.force_enable_legacy_profiler = true
+          allow(Datadog.logger).to receive(:warn).with(/Legacy profiler has been force-enabled/)
+        end
 
         it 'sets up the Profiler with the OldStack collector' do
           expect(Datadog::Profiling::Profiler).to receive(:new).with(
@@ -102,7 +105,7 @@ RSpec.describe Datadog::Profiling::Component do
 
       context 'when using the new CPU Profiling 2.0 profiler' do
         before do
-          expect(described_class).to receive(:enable_new_profiler?).with(settings).and_return(true)
+          settings.profiling.advanced.force_enable_new_profiler = true
           # Silence warning spam about using the new profiler on legacy Rubies
           allow(Datadog.logger).to receive(:warn) if RUBY_VERSION < '2.6.'
         end
@@ -371,12 +374,6 @@ RSpec.describe Datadog::Profiling::Component do
         before { skip 'Behavior does not apply to current Ruby version' if RUBY_VERSION >= '2.6.' }
 
         it { is_expected.to be false }
-
-        context 'when force_enable_new_profiler is enabled' do
-          before { settings.profiling.advanced.force_enable_new_profiler = true }
-
-          it { is_expected.to be true }
-        end
       end
 
       context 'on Ruby 2.6 and above' do

--- a/spec/datadog/profiling/component_spec.rb
+++ b/spec/datadog/profiling/component_spec.rb
@@ -51,8 +51,9 @@ RSpec.describe Datadog::Profiling::Component do
 
       context 'when using the legacy profiler' do
         before do
-          settings.profiling.advanced.force_enable_legacy_profiler = true
           allow(Datadog.logger).to receive(:warn).with(/Legacy profiler has been force-enabled/)
+          allow(Datadog.logger).to receive(:warn).with(/force_enable_legacy_profiler setting has been deprecated/)
+          settings.profiling.advanced.force_enable_legacy_profiler = true
         end
 
         it 'sets up the Profiler with the OldStack collector' do
@@ -336,9 +337,8 @@ RSpec.describe Datadog::Profiling::Component do
 
     context 'when force_enable_legacy_profiler is enabled' do
       before do
-        settings.profiling.advanced.force_enable_legacy_profiler = true
-
         allow(Datadog.logger).to receive(:warn)
+        settings.profiling.advanced.force_enable_legacy_profiler = true
       end
 
       it { is_expected.to be false }

--- a/spec/datadog/profiling/component_spec.rb
+++ b/spec/datadog/profiling/component_spec.rb
@@ -360,6 +360,8 @@ RSpec.describe Datadog::Profiling::Component do
   describe '.no_signals_workaround_enabled?' do
     subject(:no_signals_workaround_enabled?) { described_class.send(:no_signals_workaround_enabled?, settings) }
 
+    before { skip_if_profiling_not_supported(self) }
+
     context 'when no_signals_workaround_enabled is false' do
       before do
         settings.profiling.advanced.no_signals_workaround_enabled = false

--- a/spec/datadog/profiling/component_spec.rb
+++ b/spec/datadog/profiling/component_spec.rb
@@ -130,6 +130,7 @@ RSpec.describe Datadog::Profiling::Component do
             endpoint_collection_enabled: anything,
             gc_profiling_enabled: anything,
             allocation_counting_enabled: anything,
+            no_signals_workaround_enabled: eq(true).or(eq(false)),
           )
 
           build_profiler_component


### PR DESCRIPTION
**What does this PR do?**:

This PR adds a new mode to the profiler, which we're calling the "no signals" workaround.

It also makes the new CPU Profiling 2.0 the default for Ruby 2.3, 2.4 and 2.5, and automatically enables the "no signals" workaround on these Ruby versions.

**Motivation**:

This mode is a workaround for a few incompatibility issues with the new CPU Profiling 2.0 profiler. In #2702, when we made CPU Profiling 2.0 the default mode, we listed two cases where we were falling back to the legacy profiler:

* [Some gems use native libraries that don't handle the `EINTR` error code that can be caused by a signal handler interrupting a system call](https://docs.datadoghq.com/profiler/profiler_troubleshooting/ruby/#unexpected-run-time-failures-and-errors-from-ruby-gems-that-use-native-extensions-in-dd-trace-rb-1110)
* Ruby 2.5 or below are missing an API that allows the profiler to detect if the current thread is holding on to the Global VM Lock in the signal handler, which we suspect may lead to very rare crashes

The objective of the "no signals workaround" is to allow the new CPU Profiling 2.0 to be used by customers in the above situations, both of which are related to signal handling.

Thus, we're able to migrate every customer to the new codebase, allowing them to access the new features provided by the profiler, and allowing us to completely retire the legacy profiler.

(I'll still keep the legacy profiler alive for a couple more releases, but the plan is to delete it soon).

**Additional Notes**:

The "no signals workaround" mode works by making the CPU Profiling 2.0 profiler behave in a similar way to the legacy profiler when deciding to take samples.

That is, the CPU Profiling 2.0 profiler by default runs in a background thread that **does not hold the global VM lock** and thus is running in parallel with the Ruby application.

When it decides it wants to take a sample, it sends a unix SIGPROF signal to the currently-active Ruby thread, temporarily interrupting what that thread is doing to ask the VM to take a sample.

This allows us to get higher quality data, because it's the profiler that decides when it wants to take a sample and interrupts the code to do so.

The "no signals workaround" instead modifies the above to have the profiler **grab the global VM lock** when it wants to take a sample, instead of interrupting the currently-active Ruby thread.

This means that instead of sampling immediately, the profiler needs to wait for a Ruby VM scheduling switch point, and for the Ruby VM scheduler to actually schedule our thread to execute.

This means that the profiler may need to wait dozens or hundreds of milliseconds to sample. But... it works!

And the above is effectively how the legacy profiler worked -- since it was written in pure Ruby code, it always needed to wait for its turn to run.

Implementing the new behavior is not a lot of work because we already had the scaffolding to do it as part of being able to sample in periods of idleness (see #2468). So most of the work on this was validating and adding the needed configuration.

**How to test the change?**:

Validate that in the situations described above where the legacy profiler would be used no longer happen -- instead, the new profiler gets used, and the "no signals workaround" gets enabled.
