### PR TITLE
[APPSEC-9545] Devise integration and automatic user events 

### DIFF
--- a/lib/datadog/appsec.rb
+++ b/lib/datadog/appsec.rb
@@ -57,5 +57,6 @@ end
 require_relative 'appsec/contrib/rack/integration'
 require_relative 'appsec/contrib/sinatra/integration'
 require_relative 'appsec/contrib/rails/integration'
+require_relative 'appsec/contrib/devise/integration'
 
 require_relative 'appsec/autoload'

--- a/lib/datadog/appsec/component.rb
+++ b/lib/datadog/appsec/component.rb
@@ -13,6 +13,20 @@ module Datadog
           return unless settings.respond_to?(:appsec) && settings.appsec.enabled
 
           processor = create_processor(settings)
+
+          # We want to always instrument user events when AppSec is enabled.
+          # There could be cases in which users use the DD_APPSEC_ENABLED Env variable to
+          # enable AppSec, in that case, Devise is already instrumented.
+          # In the case that users do not use DD_APPSEC_ENABLED, we have to instrument it,
+          # hence the lines above.
+
+          devise_integration = Datadog::AppSec::Contrib::Devise::Integration.new
+          unless devise_integration.patcher.patched?
+            Datadog::AppSec.configure do |c|
+              c.instrument :devise
+            end
+          end
+
           new(processor: processor)
         end
 

--- a/lib/datadog/appsec/configuration.rb
+++ b/lib/datadog/appsec/configuration.rb
@@ -64,6 +64,10 @@ module Datadog
         def obfuscator_value_regex=(value)
           options[:obfuscator_value_regex] = value
         end
+
+        def automated_track_user_events=(value)
+          options[:automated_track_user_events] = value
+        end
       end
 
       # class-level methods for Configuration

--- a/lib/datadog/appsec/configuration/settings.rb
+++ b/lib/datadog/appsec/configuration/settings.rb
@@ -202,6 +202,8 @@ module Datadog
           dsl.instruments.each do |instrument|
             # TODO: error handling
             registered_integration = Datadog::AppSec::Contrib::Integration.registry[instrument.name]
+            next unless registered_integration
+
             @integrations << Integration.new(registered_integration)
 
             # TODO: move to a separate apply step

--- a/lib/datadog/appsec/contrib/devise/ext.rb
+++ b/lib/datadog/appsec/contrib/devise/ext.rb
@@ -7,8 +7,6 @@ module Datadog
         # Devise integration constants
         module Ext
           APP = 'devise'
-          DISABLED_MODE = 'disabled'
-          EXTENDED_MODE = 'extended'
         end
       end
     end

--- a/lib/datadog/appsec/contrib/devise/ext.rb
+++ b/lib/datadog/appsec/contrib/devise/ext.rb
@@ -1,0 +1,16 @@
+# frozen_string_literal: true
+
+module Datadog
+  module AppSec
+    module Contrib
+      module Devise
+        # Devise integration constants
+        module Ext
+          APP = 'devise'
+          DISABLED_MODE = 'disabled'
+          EXTENDED_MODE = 'extended'
+        end
+      end
+    end
+  end
+end

--- a/lib/datadog/appsec/contrib/devise/integration.rb
+++ b/lib/datadog/appsec/contrib/devise/integration.rb
@@ -14,7 +14,7 @@ module Datadog
 
           MINIMUM_VERSION = Gem::Version.new('3.2.1')
 
-          register_as :devise, auto_patch: false
+          register_as :devise, auto_patch: true
 
           def self.version
             Gem.loaded_specs['devise'] && Gem.loaded_specs['devise'].version
@@ -29,7 +29,7 @@ module Datadog
           end
 
           def self.auto_instrument?
-            false
+            true
           end
 
           def patcher

--- a/lib/datadog/appsec/contrib/devise/integration.rb
+++ b/lib/datadog/appsec/contrib/devise/integration.rb
@@ -1,0 +1,42 @@
+# frozen_string_literal: true
+
+require_relative '../integration'
+
+require_relative 'patcher'
+
+module Datadog
+  module AppSec
+    module Contrib
+      module Devise
+        # Description of Devise integration
+        class Integration
+          include Datadog::AppSec::Contrib::Integration
+
+          MINIMUM_VERSION = Gem::Version.new('3.2.1')
+
+          register_as :devise, auto_patch: false
+
+          def self.version
+            Gem.loaded_specs['devise'] && Gem.loaded_specs['devise'].version
+          end
+
+          def self.loaded?
+            !defined?(::Devise).nil?
+          end
+
+          def self.compatible?
+            super && version >= MINIMUM_VERSION
+          end
+
+          def self.auto_instrument?
+            false
+          end
+
+          def patcher
+            Patcher
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/datadog/appsec/contrib/devise/patcher.rb
+++ b/lib/datadog/appsec/contrib/devise/patcher.rb
@@ -10,7 +10,7 @@ module Datadog
     module Contrib
       module Devise
         # Hook in devise validate method
-        module AuthenticablePatch
+        module AuthenticatablePatch
           # rubocop:disable Metrics/MethodLength, Metrics/PerceivedComplexity
           def validate(resource, &block)
             result = super
@@ -139,7 +139,7 @@ module Datadog
           end
 
           def patch_authenticable_strategy
-            ::Devise::Strategies::Authenticatable.prepend(AuthenticablePatch)
+            ::Devise::Strategies::Authenticatable.prepend(AuthenticatablePatch)
           end
 
           def patch_registration_controller

--- a/lib/datadog/appsec/contrib/devise/patcher.rb
+++ b/lib/datadog/appsec/contrib/devise/patcher.rb
@@ -1,0 +1,160 @@
+# frozen_string_literal: true
+
+require_relative '../patcher'
+require_relative 'resource'
+require_relative 'ext'
+require_relative '../../../kit/appsec/events'
+
+module Datadog
+  module AppSec
+    module Contrib
+      module Devise
+        AUTOMATED_USER_EVENT_TAGGING_BLOCK = proc do |trace, event|
+          trace.set_tag("_dd.appsec.events.#{event}.auto.mode", AppSec.settings.automated_track_user_events)
+        end
+
+        private_constant :AUTOMATED_USER_EVENT_TAGGING_BLOCK
+
+        # Hook in devise validate method
+        module AuthenticablePatch
+          # rubocop:disable Metrics/MethodLength, Metrics/PerceivedComplexity
+          def validate(resource, &block)
+            result = super
+            return result unless AppSec.enabled?
+            return result if AppSec.settings.automated_track_user_events == Ext::DISABLED_MODE
+
+            active_trace = defined?(Datadog::Tracing) && Datadog::Tracing.active_trace
+
+            return result unless active_trace
+
+            devise_resource = resource ? Resource.new(resource) : nil
+
+            event_information = {}
+            user_id = nil
+
+            if AppSec.settings.automated_track_user_events == Ext::EXTENDED_MODE && devise_resource
+              resource_email = devise_resource.email
+              resource_username = devise_resource.username
+
+              event_information[:email] = resource_email if resource_email
+              event_information[:username] = resource_username if resource_username
+            end
+
+            user_id = devise_resource.id if devise_resource && devise_resource.id
+
+            if result
+              if user_id
+                Datadog::Kit::AppSec::Events.track_login_success(
+                  active_trace,
+                  user: { id: user_id.to_s },
+                  **event_information,
+                  &AUTOMATED_USER_EVENT_TAGGING_BLOCK
+                )
+                Datadog.logger.debug { 'User Login Event success' }
+              else
+                Datadog.logger.warn { 'User Login Event success, but can\'t extract user ID. No event emitted' }
+              end
+
+              return result
+            end
+
+            if devise_resource
+              Datadog::Kit::AppSec::Events.track_login_failure(
+                active_trace,
+                user_id: user_id,
+                user_exists: true,
+                **event_information,
+                &AUTOMATED_USER_EVENT_TAGGING_BLOCK
+              )
+              Datadog.logger.debug { 'User Login Event failure users exists' }
+            else
+              Datadog::Kit::AppSec::Events.track_login_failure(
+                active_trace,
+                user_id: nil,
+                user_exists: false,
+                **event_information,
+                &AUTOMATED_USER_EVENT_TAGGING_BLOCK
+              )
+              Datadog.logger.debug { 'User Login Event failure users do not exists' }
+            end
+
+            result
+          end
+          # rubocop:enable Metrics/MethodLength, Metrics/PerceivedComplexity
+        end
+
+        # Hook in devise registration controller
+        module ResgistrationControllerPatch
+          def create
+            return super unless AppSec.enabled?
+            return super if AppSec.settings.automated_track_user_events == Ext::DISABLED_MODE
+
+            active_trace = defined?(Datadog::Tracing) && Datadog::Tracing.active_trace
+            return super unless active_trace
+
+            super do |resource|
+              if resource.persisted?
+                devise_resource = Resource.new(resource)
+
+                event_information = {}
+                user_id = devise_resource.id if devise_resource && devise_resource.id
+
+                if AppSec.settings.automated_track_user_events == Ext::EXTENDED_MODE
+                  resource_email = devise_resource.email
+                  resource_username = devise_resource.username
+
+                  event_information[:email] = resource_email if resource_email
+                  event_information[:username] = resource_username if resource_username
+                end
+
+                if user_id
+                  Kit::AppSec::Events.track_signup(
+                    active_trace,
+                    user: { id: user_id.to_s },
+                    **event_information,
+                    &AUTOMATED_USER_EVENT_TAGGING_BLOCK
+                  )
+                  Datadog.logger.debug { 'User Signup Event' }
+                else
+                  Datadog.logger.warn { 'User Signup Event, but can\'t extract user ID. No event emitted' }
+                end
+              end
+            end
+          end
+        end
+
+        # Patcher for AppSec on Devise
+        module Patcher
+          include Datadog::AppSec::Contrib::Patcher
+
+          module_function
+
+          def patched?
+            Patcher.instance_variable_get(:@patched)
+          end
+
+          def target_version
+            Integration.version
+          end
+
+          def patch
+            patch_authenticable_strategy
+            patch_registration_controller
+
+            Patcher.instance_variable_set(:@patched, true)
+          end
+
+          def patch_authenticable_strategy
+            ::Devise::Strategies::Authenticatable.prepend(AuthenticablePatch)
+          end
+
+          def patch_registration_controller
+            ::ActiveSupport.on_load(:after_initialize) do
+              ::Devise::RegistrationsController.prepend(ResgistrationControllerPatch)
+            end
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/datadog/appsec/contrib/devise/patcher.rb
+++ b/lib/datadog/appsec/contrib/devise/patcher.rb
@@ -1,122 +1,13 @@
 # frozen_string_literal: true
 
 require_relative '../patcher'
-require_relative 'resource'
-require_relative 'ext'
-require_relative 'tracking'
+require_relative 'patcher/authenticatable_patch'
+require_relative 'patcher/regsitration_controller_patch'
 
 module Datadog
   module AppSec
     module Contrib
       module Devise
-        # Hook in devise validate method
-        module AuthenticatablePatch
-          # rubocop:disable Metrics/MethodLength, Metrics/PerceivedComplexity
-          def validate(resource, &block)
-            result = super
-            return result unless AppSec.enabled?
-            return result if AppSec.settings.automated_track_user_events == Ext::DISABLED_MODE
-
-            appsec_scope = Datadog::AppSec.active_scope
-
-            return result unless appsec_scope
-
-            devise_resource = resource ? Resource.new(resource) : nil
-
-            event_information = {}
-            user_id = nil
-
-            if AppSec.settings.automated_track_user_events == Ext::EXTENDED_MODE && devise_resource
-              resource_email = devise_resource.email
-              resource_username = devise_resource.username
-
-              event_information[:email] = resource_email if resource_email
-              event_information[:username] = resource_username if resource_username
-            end
-
-            user_id = devise_resource.id if devise_resource && devise_resource.id
-
-            if result
-              if user_id
-                Tracking.track_login_success(
-                  appsec_scope.trace,
-                  appsec_scope.service_entry_span,
-                  user: { id: user_id.to_s },
-                  **event_information
-                )
-                Datadog.logger.debug { 'User Login Event success' }
-              else
-                Datadog.logger.warn { 'User Login Event success, but can\'t extract user ID. No event emitted' }
-              end
-
-              return result
-            end
-
-            if devise_resource
-              Tracking.track_login_failure(
-                appsec_scope.trace,
-                appsec_scope.service_entry_span,
-                user_id: user_id,
-                user_exists: true,
-                **event_information
-              )
-              Datadog.logger.debug { 'User Login Event failure users exists' }
-            else
-              Tracking.track_login_failure(
-                appsec_scope.trace,
-                appsec_scope.service_entry_span,
-                user_id: nil,
-                user_exists: false,
-                **event_information
-              )
-              Datadog.logger.debug { 'User Login Event failure users do not exists' }
-            end
-
-            result
-          end
-          # rubocop:enable Metrics/MethodLength, Metrics/PerceivedComplexity
-        end
-
-        # Hook in devise registration controller
-        module ResgistrationControllerPatch
-          def create
-            return super unless AppSec.enabled?
-            return super if AppSec.settings.automated_track_user_events == Ext::DISABLED_MODE
-
-            appsec_scope = Datadog::AppSec.active_scope
-            return super unless appsec_scope
-
-            super do |resource|
-              if resource.persisted?
-                devise_resource = Resource.new(resource)
-
-                event_information = {}
-                user_id = devise_resource.id if devise_resource && devise_resource.id
-
-                if AppSec.settings.automated_track_user_events == Ext::EXTENDED_MODE
-                  resource_email = devise_resource.email
-                  resource_username = devise_resource.username
-
-                  event_information[:email] = resource_email if resource_email
-                  event_information[:username] = resource_username if resource_username
-                end
-
-                if user_id
-                  Tracking.track_signup(
-                    appsec_scope.trace,
-                    appsec_scope.service_entry_span,
-                    user: { id: user_id.to_s },
-                    **event_information
-                  )
-                  Datadog.logger.debug { 'User Signup Event' }
-                else
-                  Datadog.logger.warn { 'User Signup Event, but can\'t extract user ID. No event emitted' }
-                end
-              end
-            end
-          end
-        end
-
         # Patcher for AppSec on Devise
         module Patcher
           include Datadog::AppSec::Contrib::Patcher
@@ -144,7 +35,7 @@ module Datadog
 
           def patch_registration_controller
             ::ActiveSupport.on_load(:after_initialize) do
-              ::Devise::RegistrationsController.prepend(ResgistrationControllerPatch)
+              ::Devise::RegistrationsController.prepend(RegistrationControllerPatch)
             end
           end
         end

--- a/lib/datadog/appsec/contrib/devise/patcher.rb
+++ b/lib/datadog/appsec/contrib/devise/patcher.rb
@@ -2,7 +2,7 @@
 
 require_relative '../patcher'
 require_relative 'patcher/authenticatable_patch'
-require_relative 'patcher/regsitration_controller_patch'
+require_relative 'patcher/registration_controller_patch'
 
 module Datadog
   module AppSec
@@ -11,6 +11,9 @@ module Datadog
         # Patcher for AppSec on Devise
         module Patcher
           include Datadog::AppSec::Contrib::Patcher
+
+          DISABLED_MODE = 'disabled'
+          EXTENDED_MODE = 'extended'
 
           module_function
 

--- a/lib/datadog/appsec/contrib/devise/patcher/authenticatable_patch.rb
+++ b/lib/datadog/appsec/contrib/devise/patcher/authenticatable_patch.rb
@@ -1,6 +1,5 @@
 # frozen_string_literal: true
 
-require_relative '../ext'
 require_relative '../tracking'
 require_relative '../resource'
 
@@ -18,7 +17,7 @@ module Datadog
 
               automated_track_user_events_mode = AppSec.settings.automated_track_user_events
 
-              return result if automated_track_user_events_mode == Ext::DISABLED_MODE
+              return result if automated_track_user_events_mode == Patcher::DISABLED_MODE
 
               appsec_scope = Datadog::AppSec.active_scope
 
@@ -29,7 +28,7 @@ module Datadog
               event_information = {}
               user_id = nil
 
-              if automated_track_user_events_mode == Ext::EXTENDED_MODE && devise_resource
+              if automated_track_user_events_mode == Patcher::EXTENDED_MODE && devise_resource
                 resource_email = devise_resource.email
                 resource_username = devise_resource.username
 

--- a/lib/datadog/appsec/contrib/devise/patcher/authenticatable_patch.rb
+++ b/lib/datadog/appsec/contrib/devise/patcher/authenticatable_patch.rb
@@ -1,0 +1,92 @@
+# frozen_string_literal: true
+
+require_relative '../ext'
+require_relative '../tracking'
+require_relative '../resource'
+
+module Datadog
+  module AppSec
+    module Contrib
+      module Devise
+        module Patcher
+          # Hook in devise validate method
+          module AuthenticatablePatch
+            # rubocop:disable Metrics/MethodLength, Metrics/PerceivedComplexity
+            def validate(resource, &block)
+              result = super
+              return result unless AppSec.enabled?
+
+              automated_track_user_events_mode = AppSec.settings.automated_track_user_events
+
+              return result if automated_track_user_events_mode == Ext::DISABLED_MODE
+
+              appsec_scope = Datadog::AppSec.active_scope
+
+              return result unless appsec_scope
+
+              devise_resource = resource ? Resource.new(resource) : nil
+
+              event_information = {}
+              user_id = nil
+
+              if automated_track_user_events_mode == Ext::EXTENDED_MODE && devise_resource
+                resource_email = devise_resource.email
+                resource_username = devise_resource.username
+
+                event_information[:email] = resource_email if resource_email
+                event_information[:username] = resource_username if resource_username
+              end
+
+              user_id = devise_resource.id if devise_resource && devise_resource.id
+
+              if result
+                if user_id
+                  Tracking.track_login_success(
+                    appsec_scope.trace,
+                    appsec_scope.service_entry_span,
+                    user_id: user_id,
+                    **event_information
+                  )
+                  Datadog.logger.debug { 'User Login Event success' }
+                else
+                  Tracking.track_login_success(
+                    appsec_scope.trace,
+                    appsec_scope.service_entry_span,
+                    user_id: nil,
+                    **event_information
+                  )
+                  Datadog.logger.debug { 'User Login Event success, but can\'t extract user ID. Tracking empty event' }
+                end
+
+                return result
+              end
+
+              if devise_resource
+                Tracking.track_login_failure(
+                  appsec_scope.trace,
+                  appsec_scope.service_entry_span,
+                  user_id: user_id,
+                  user_exists: true,
+                  **event_information
+                )
+                Datadog.logger.debug { 'User Login Event failure users exists' }
+              else
+                Tracking.track_login_failure(
+                  appsec_scope.trace,
+                  appsec_scope.service_entry_span,
+                  user_id: nil,
+                  user_exists: false,
+                  **event_information
+                )
+                Datadog.logger.debug { 'User Login Event failure user do not exists' }
+              end
+
+              result
+            end
+            # rubocop:enable Metrics/MethodLength, Metrics/PerceivedComplexity
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/datadog/appsec/contrib/devise/patcher/registration_controller_patch.rb
+++ b/lib/datadog/appsec/contrib/devise/patcher/registration_controller_patch.rb
@@ -1,6 +1,5 @@
 # frozen_string_literal: true
 
-require_relative '../ext'
 require_relative '../tracking'
 require_relative '../resource'
 
@@ -16,7 +15,7 @@ module Datadog
 
               automated_track_user_events_mode = AppSec.settings.automated_track_user_events
 
-              return super if automated_track_user_events_mode == Ext::DISABLED_MODE
+              return super if automated_track_user_events_mode == Patcher::DISABLED_MODE
 
               appsec_scope = Datadog::AppSec.active_scope
               return super unless appsec_scope
@@ -28,7 +27,7 @@ module Datadog
                   event_information = {}
                   user_id = devise_resource.id if devise_resource && devise_resource.id
 
-                  if automated_track_user_events_mode == Ext::EXTENDED_MODE
+                  if automated_track_user_events_mode == Patcher::EXTENDED_MODE
                     resource_email = devise_resource.email
                     resource_username = devise_resource.username
 

--- a/lib/datadog/appsec/contrib/devise/patcher/registration_controller_patch.rb
+++ b/lib/datadog/appsec/contrib/devise/patcher/registration_controller_patch.rb
@@ -1,0 +1,64 @@
+# frozen_string_literal: true
+
+require_relative '../ext'
+require_relative '../tracking'
+require_relative '../resource'
+
+module Datadog
+  module AppSec
+    module Contrib
+      module Devise
+        module Patcher
+          # Hook in devise registration controller
+          module RegistrationControllerPatch
+            def create
+              return super unless AppSec.enabled?
+
+              automated_track_user_events_mode = AppSec.settings.automated_track_user_events
+
+              return super if automated_track_user_events_mode == Ext::DISABLED_MODE
+
+              appsec_scope = Datadog::AppSec.active_scope
+              return super unless appsec_scope
+
+              super do |resource|
+                if resource.persisted?
+                  devise_resource = Resource.new(resource)
+
+                  event_information = {}
+                  user_id = devise_resource.id if devise_resource && devise_resource.id
+
+                  if automated_track_user_events_mode == Ext::EXTENDED_MODE
+                    resource_email = devise_resource.email
+                    resource_username = devise_resource.username
+
+                    event_information[:email] = resource_email if resource_email
+                    event_information[:username] = resource_username if resource_username
+                  end
+
+                  if user_id
+                    Tracking.track_signup(
+                      appsec_scope.trace,
+                      appsec_scope.service_entry_span,
+                      user_id: user_id,
+                      **event_information
+                    )
+                    Datadog.logger.debug { 'User Signup Event' }
+                  else
+                    Tracking.track_signup(
+                      appsec_scope.trace,
+                      appsec_scope.service_entry_span,
+                      user_id: nil,
+                      **event_information
+                    )
+                    Datadog.logger.warn { 'User Signup Event, but can\'t extract user ID. Tracking empty event' }
+                  end
+                end
+              end
+            end
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/datadog/appsec/contrib/devise/resource.rb
+++ b/lib/datadog/appsec/contrib/devise/resource.rb
@@ -1,0 +1,30 @@
+# frozen_string_literal: true
+
+module Datadog
+  module AppSec
+    module Contrib
+      module Devise
+        # Class to encpasulate extracting information from a Devise resource
+        # TODO: Very barebone implementation. Improve before relase
+        #   - Check Devise configuration to infer used value to log in
+        class Resource
+          def initialize(resource)
+            @resource = resource
+          end
+
+          def id
+            @resource.try(:id)
+          end
+
+          def email
+            @resource.try(:email)
+          end
+
+          def username
+            @resource.try(:username)
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/datadog/appsec/contrib/devise/resource.rb
+++ b/lib/datadog/appsec/contrib/devise/resource.rb
@@ -5,23 +5,28 @@ module Datadog
     module Contrib
       module Devise
         # Class to encpasulate extracting information from a Devise resource
-        # TODO: Very barebone implementation. Improve before relase
-        #   - Check Devise configuration to infer used value to log in
+        # Normally a devise resource would be an Active::Record instance
         class Resource
           def initialize(resource)
             @resource = resource
           end
 
           def id
-            @resource.try(:id)
+            extract(:id) || extract(:uuid)
           end
 
           def email
-            @resource.try(:email)
+            extract(:email)
           end
 
           def username
-            @resource.try(:username)
+            extract(:username)
+          end
+
+          private
+
+          def extract(method)
+            @resource.send(method) if @resource.respond_to?(method)
           end
         end
       end

--- a/lib/datadog/appsec/contrib/devise/tracking.rb
+++ b/lib/datadog/appsec/contrib/devise/tracking.rb
@@ -1,0 +1,49 @@
+# frozen_string_literal: true
+
+require_relative '../../../kit/identity'
+
+module Datadog
+  module AppSec
+    module Contrib
+      module Devise
+        # Internal module to track user events
+        module Tracking
+          LOGIN_SUCCESS_EVENT = 'users.login.success'
+          LOGIN_FAILURE_EVENT = 'users.login.failure'
+          SIGNUP_EVENT = 'users.signup'
+
+          def self.track_login_success(trace, span, user_id:, **others)
+            track(LOGIN_SUCCESS_EVENT, trace, span, **others)
+
+            Kit::Identity.set_user(trace, span, id: user_id.to_s, **others) if user_id
+          end
+
+          def self.track_login_failure(trace, span, user_id:, user_exists:, **others)
+            track(LOGIN_FAILURE_EVENT, trace, span, **others)
+
+            span.set_tag('appsec.events.users.login.failure.usr.id', user_id) if user_id
+            span.set_tag('appsec.events.users.login.failure.usr.exists', user_exists)
+          end
+
+          def self.track_signup(trace, span, user_id:, **others)
+            track(SIGNUP_EVENT, trace, span, **others)
+            Kit::Identity.set_user(trace, id: user_id.to_s, **others) if user_id
+          end
+
+          def self.track(event, trace, span, **others)
+            span.set_tag("appsec.events.#{event}.track", 'true')
+            span.set_tag("_dd.appsec.events.#{event}.auto.mode", AppSec.settings.automated_track_user_events)
+
+            others.each do |k, v|
+              raise ArgumentError, 'key cannot be :track' if k.to_sym == :track
+
+              span.set_tag("appsec.events.#{event}.#{k}", v) unless v.nil?
+            end
+
+            trace.keep!
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/datadog/appsec/extensions.rb
+++ b/lib/datadog/appsec/extensions.rb
@@ -24,6 +24,21 @@ module Datadog
       # Merges {Datadog::AppSec::Configuration::Settings} and {Datadog::AppSec::Configuration::DSL}
       # into a single read/write object.
       class AppSecAdapter
+        VALID_AUTOMATED_TRACK_USER_EVENTS_VALUES = [
+          'safe',
+          'extended',
+          'disabled'
+        ].freeze
+
+        private_constant :VALID_AUTOMATED_TRACK_USER_EVENTS_VALUES
+
+        # InvalidConfigurationValue is raise when a configuration value is incorrect
+        class InvalidConfigurationValue < StandardError
+          def initialize(key, value, valid_values)
+            super("Invalid value: #{value} for configuration key: #{key}. Valid values: #{valid_values}")
+          end
+        end
+
         def initialize(settings)
           @settings = settings
         end
@@ -90,6 +105,20 @@ module Datadog
           @settings.merge(dsl)
         end
 
+        def automated_track_user_events=(value)
+          unless VALID_AUTOMATED_TRACK_USER_EVENTS_VALUES.include?(value.to_s)
+            raise InvalidConfigurationValue.new(
+              :automated_track_user_events,
+              value,
+              VALID_AUTOMATED_TRACK_USER_EVENTS_VALUES
+            )
+          end
+
+          dsl = AppSec::Configuration::DSL.new
+          dsl.automated_track_user_events = value
+          @settings.merge(dsl)
+        end
+
         # Reader methods
 
         def enabled
@@ -126,6 +155,10 @@ module Datadog
 
         def obfuscator_value_regex
           @settings.obfuscator_key_regex
+        end
+
+        def automated_track_user_events
+          @settings.automated_track_user_events
         end
 
         def merge(arg)

--- a/sig/datadog/appsec/configuration.rbs
+++ b/sig/datadog/appsec/configuration.rbs
@@ -34,6 +34,7 @@ module Datadog
         def trace_rate_limit=: (::Integer) -> void
         def obfuscator_key_regex=: (::String | ::Regexp) -> void
         def obfuscator_value_regex=: (::String | ::Regexp) -> void
+        def automated_track_user_events=: (String) -> void
       end
 
       module ClassMethods

--- a/sig/datadog/appsec/configuration/settings.rbs
+++ b/sig/datadog/appsec/configuration/settings.rbs
@@ -35,6 +35,7 @@ module Datadog
         def trace_rate_limit: () -> ::Integer
         def obfuscator_key_regex: () -> ::String
         def obfuscator_value_regex: () -> ::String
+        def automated_track_user_events:() -> ::String
 
         def merge: (DSL) -> Settings
 

--- a/sig/datadog/appsec/contrib/devise/ext.rbs
+++ b/sig/datadog/appsec/contrib/devise/ext.rbs
@@ -1,0 +1,11 @@
+module Datadog
+  module AppSec
+    module Contrib
+      module Devise
+        module Ext
+          APP: "devise"
+        end
+      end
+    end
+  end
+end

--- a/sig/datadog/appsec/contrib/devise/integration.rbs
+++ b/sig/datadog/appsec/contrib/devise/integration.rbs
@@ -1,0 +1,25 @@
+module Datadog
+  module AppSec
+    module Contrib
+      module Devise
+        class Integration
+          include Datadog::AppSec::Contrib::Integration
+
+          MINIMUM_VERSION: untyped
+
+          def self.version: () -> untyped
+
+          def self.loaded?: () -> untyped
+
+          def self.compatible?: () -> untyped
+
+          def self.auto_instrument?: () -> true
+
+          def default_configuration: () -> untyped
+
+          def patcher: () -> untyped
+        end
+      end
+    end
+  end
+end

--- a/sig/datadog/appsec/contrib/devise/patcher.rbs
+++ b/sig/datadog/appsec/contrib/devise/patcher.rbs
@@ -2,15 +2,6 @@ module Datadog
   module AppSec
     module Contrib
       module Devise
-        AUTOMATED_USER_EVENT_TAGGING_BLOCK: untyped
-        module AuthenticablePatch
-          def validate: (untyped resource) ?{ () -> untyped } -> untyped
-        end
-
-        module ResgistrationControllerPatch
-          def create: () -> untyped
-        end
-
         module Patcher
           include Datadog::AppSec::Contrib::Patcher
 

--- a/sig/datadog/appsec/contrib/devise/patcher.rbs
+++ b/sig/datadog/appsec/contrib/devise/patcher.rbs
@@ -1,0 +1,30 @@
+module Datadog
+  module AppSec
+    module Contrib
+      module Devise
+        AUTOMATED_USER_EVENT_TAGGING_BLOCK: untyped
+        module AuthenticablePatch
+          def validate: (untyped resource) ?{ () -> untyped } -> untyped
+        end
+
+        module ResgistrationControllerPatch
+          def create: () -> untyped
+        end
+
+        module Patcher
+          include Datadog::AppSec::Contrib::Patcher
+
+          def self?.patched?: () -> untyped
+
+          def self?.target_version: () -> untyped
+
+          def self?.patch: () -> untyped
+
+          def self?.patch_authenticable_strategy: () -> untyped
+
+          def self?.patch_registration_controller: () -> untyped
+        end
+      end
+    end
+  end
+end

--- a/sig/datadog/appsec/contrib/devise/patcher/authenticatable_patch.rbs
+++ b/sig/datadog/appsec/contrib/devise/patcher/authenticatable_patch.rbs
@@ -1,0 +1,13 @@
+module Datadog
+  module AppSec
+    module Contrib
+      module Devise
+        module Patcher
+          module AuthenticatablePatch
+            def validate: (untyped resource) { () -> untyped } -> untyped
+          end
+        end
+      end
+    end
+  end
+end

--- a/sig/datadog/appsec/contrib/devise/patcher/registration_controller_patch.rbs
+++ b/sig/datadog/appsec/contrib/devise/patcher/registration_controller_patch.rbs
@@ -1,0 +1,13 @@
+module Datadog
+  module AppSec
+    module Contrib
+      module Devise
+        module Patcher
+          module RegistrationControllerPatch
+            def create: () -> untyped
+          end
+        end
+      end
+    end
+  end
+end

--- a/sig/datadog/appsec/contrib/devise/resource.rbs
+++ b/sig/datadog/appsec/contrib/devise/resource.rbs
@@ -1,0 +1,17 @@
+module Datadog
+  module AppSec
+    module Contrib
+      module Devise
+        class Resource
+          def initialize: (untyped resource) -> void
+
+          def id: () -> untyped
+
+          def email: () -> untyped
+
+          def username: () -> untyped
+        end
+      end
+    end
+  end
+end

--- a/sig/datadog/appsec/contrib/devise/resource.rbs
+++ b/sig/datadog/appsec/contrib/devise/resource.rbs
@@ -5,11 +5,15 @@ module Datadog
         class Resource
           def initialize: (untyped resource) -> void
 
-          def id: () -> untyped
+          def id: () -> (untyped | nil)
 
-          def email: () -> untyped
+          def email: () -> (untyped | nil)
 
-          def username: () -> untyped
+          def username: () -> (untyped | nil)
+
+          private
+
+          def extract: (Symbol method) -> (untyped | nil)
         end
       end
     end

--- a/sig/datadog/appsec/contrib/devise/tracking.rbs
+++ b/sig/datadog/appsec/contrib/devise/tracking.rbs
@@ -1,0 +1,23 @@
+module Datadog
+  module AppSec
+    module Contrib
+      module Devise
+        module Tracking
+          LOGIN_SUCCESS_EVENT: String
+
+          LOGIN_FAILURE_EVENT: String
+
+          SIGNUP_EVENT: String
+
+          def self.track_login_success: (untyped trace, untyped span, user_id: untyped, **untyped others) -> untyped
+
+          def self.track_login_failure: (untyped trace, untyped span, user_id: untyped, user_exists: untyped, **untyped others) -> untyped
+
+          def self.track_signup: (untyped trace, untyped span, user_id: untyped, **untyped others) -> untyped
+
+          def self.track: (untyped event, untyped trace, untyped span, **untyped others) -> untyped
+        end
+      end
+    end
+  end
+end

--- a/sig/datadog/appsec/extensions.rbs
+++ b/sig/datadog/appsec/extensions.rbs
@@ -10,6 +10,12 @@ module Datadog
       end
 
       class AppSecAdapter
+        VALID_AUTOMATED_TRACK_USER_EVENTS_VALUES: ::Array[String]
+
+        # InvalidConfigurationValue is raise when a configuration value is incorrect
+        class InvalidConfigurationValue < StandardError
+          def initialize: (untyped key, untyped value, untyped valid_values) -> void
+        end
         @settings: Configuration::Settings
 
         def initialize: (Configuration::Settings settings) -> void

--- a/spec/datadog/appsec/configuration/settings_spec.rb
+++ b/spec/datadog/appsec/configuration/settings_spec.rb
@@ -1,281 +1,361 @@
 require 'datadog/appsec/spec_helper'
 
-RSpec.describe Datadog::AppSec::Configuration::Settings do
-  shared_context 'registry with integration' do
-    let(:registry) { {} }
-    let(:integration_name) { :example }
-    let(:integration_options) { double('integration integration_options') }
-    let(:integration_class) { double('integration class', loaded?: false) }
-    let(:integration) do
-      instance_double(
-        Datadog::AppSec::Contrib::Integration::RegisteredIntegration,
-        klass: integration_class,
-        options: integration_options
-      )
+# Dummy Integration
+class FakeIntegration
+  module Patcher
+    module_function
+
+    def patched?
+      @patched
     end
 
-    before do
-      registry[integration_name] = integration
+    def patch
+      @patched = true
+    end
 
-      allow(Datadog::AppSec::Contrib::Integration).to receive(:registry).and_return(registry)
+    def reset
+      @patched = nil
     end
   end
 
-  describe Datadog::AppSec::Configuration::Settings do
-    include_context 'registry with integration'
+  include Datadog::AppSec::Contrib::Integration
 
-    subject(:settings) { described_class.new }
+  register_as :fake
 
-    let(:dsl) { Datadog::AppSec::Configuration::DSL.new }
+  def self.loaded?
+    true
+  end
 
-    after { settings.send(:reset!) }
+  def self.compatible?
+    true
+  end
 
-    describe '#enabled' do
-      subject(:enabled) { settings.enabled }
-      it { is_expected.to eq(false) }
+  def self.auto_instrument?
+    false
+  end
+
+  def patcher
+    Patcher
+  end
+end
+
+RSpec.describe Datadog::AppSec::Configuration::Settings do
+  let(:dsl) { Datadog::AppSec::Configuration::DSL.new }
+  let(:integration_name) { :fake }
+
+  after do
+    FakeIntegration::Patcher.reset
+    settings.send(:reset!)
+  end
+
+  after(:context) do
+    Datadog::AppSec::Contrib::Integration.registry.delete(:fake)
+  end
+
+  subject(:settings) { described_class.new }
+
+  describe '#enabled' do
+    subject(:enabled) { settings.enabled }
+    it { is_expected.to eq(false) }
+  end
+
+  describe '#enabled=' do
+    subject(:enabled_) { settings.merge(dsl.tap { |c| c.enabled = true }) }
+    it { expect { enabled_ }.to change { settings.enabled }.from(false).to(true) }
+  end
+
+  describe '#ruleset' do
+    subject(:ruleset) { settings.ruleset }
+    it { is_expected.to eq(:recommended) }
+  end
+
+  describe '#ruleset=' do
+    subject(:ruleset_) { settings.merge(dsl.tap { |c| c.ruleset = :strict }) }
+    it { expect { ruleset_ }.to change { settings.ruleset }.from(:recommended).to(:strict) }
+  end
+
+  describe '#waf_timeout' do
+    subject(:waf_timeout) { settings.waf_timeout }
+    it { is_expected.to eq(5000) }
+  end
+
+  describe '#waf_timeout=' do
+    subject(:waf_timeout_) { settings.merge(dsl.tap { |c| c.waf_timeout = 3 }) }
+    it { expect { waf_timeout_ }.to change { settings.waf_timeout }.from(5000).to(3) }
+  end
+
+  describe '#waf_debug' do
+    subject(:waf_debug) { settings.waf_debug }
+    it { is_expected.to eq(false) }
+  end
+
+  describe '#waf_debug=' do
+    subject(:waf_debug_) { settings.merge(dsl.tap { |c| c.waf_debug = true }) }
+    it { expect { waf_debug_ }.to change { settings.waf_debug }.from(false).to(true) }
+  end
+
+  describe '#trace_rate_limit' do
+    subject(:trace_rate_limit) { settings.trace_rate_limit }
+    it { is_expected.to eq(100) }
+  end
+
+  describe '#trace_rate_limit=' do
+    subject(:trace_rate_limit_) { settings.merge(dsl.tap { |c| c.trace_rate_limit = 2 }) }
+    it { expect { trace_rate_limit_ }.to change { settings.trace_rate_limit }.from(100).to(2) }
+  end
+
+  describe '#ip_denylist' do
+    subject(:ip_denylist) { settings.ip_denylist }
+    it { is_expected.to eq([]) }
+  end
+
+  describe '#ip_denylist=' do
+    subject(:ip_denylist_) { settings.merge(dsl.tap { |c| c.ip_denylist = ['192.192.1.1'] }) }
+    it { expect { ip_denylist_ }.to change { settings.ip_denylist }.from([]).to(['192.192.1.1']) }
+  end
+
+  describe '#user_id_denylist' do
+    subject(:user_id_denylist) { settings.user_id_denylist }
+    it { is_expected.to eq([]) }
+  end
+
+  describe '#user_id_denylist=' do
+    subject(:user_id_denylist_) { settings.merge(dsl.tap { |c| c.user_id_denylist = ['8764937902709'] }) }
+    it { expect { user_id_denylist_ }.to change { settings.user_id_denylist }.from([]).to(['8764937902709']) }
+  end
+
+  describe '#obfuscator_key_regex' do
+    subject(:obfuscator_key_regex) { settings.obfuscator_key_regex }
+    it { is_expected.to include('token') }
+  end
+
+  describe '#obfuscator_key_regex=' do
+    subject(:obfuscator_key_regex_) { settings.merge(dsl.tap { |c| c.obfuscator_key_regex = 'bar' }) }
+    let(:default) { described_class::DEFAULT_OBFUSCATOR_KEY_REGEX }
+    it { expect { obfuscator_key_regex_ }.to change { settings.obfuscator_key_regex }.from(default).to('bar') }
+  end
+
+  describe '#obfuscator_value_regex' do
+    subject(:obfuscator_value_regex) { settings.obfuscator_value_regex }
+    it { is_expected.to include('token') }
+  end
+
+  describe '#obfuscator_value_regex=' do
+    subject(:obfuscator_value_regex_) { settings.merge(dsl.tap { |c| c.obfuscator_value_regex = 'bar' }) }
+    let(:default) { described_class::DEFAULT_OBFUSCATOR_VALUE_REGEX }
+    it { expect { obfuscator_value_regex_ }.to change { settings.obfuscator_value_regex }.from(default).to('bar') }
+  end
+
+  describe '#integrations' do
+    context 'appsec enabled' do
+      before { dsl.enabled = true }
+
+      context 'when loaded and compatible' do
+        it 'patches the integration' do
+          dsl.instrument(integration_name)
+
+          expect(FakeIntegration::Patcher).to receive(:patch)
+
+          settings.merge(dsl)
+        end
+      end
+
+      context 'only patches integration once' do
+        it 'does not patch the integration multiple times' do
+          dsl.instrument(integration_name)
+
+          expect(FakeIntegration::Patcher).to receive(:patch).and_call_original.once
+          settings.merge(dsl)
+          settings.merge(dsl)
+        end
+      end
+
+      context 'when not loaded' do
+        before { expect(FakeIntegration).to receive(:loaded?).and_return(false) }
+        it 'does not patch the integration' do
+          dsl.instrument(integration_name)
+
+          expect(FakeIntegration::Patcher).to_not receive(:patch)
+
+          settings.merge(dsl)
+        end
+      end
+
+      context 'when loaded and not compatible' do
+        before { expect(FakeIntegration).to receive(:compatible?).and_return(false) }
+        it 'does not patch the integration' do
+          dsl.instrument(integration_name)
+
+          expect(FakeIntegration::Patcher).to_not receive(:patch)
+
+          settings.merge(dsl)
+        end
+      end
     end
 
-    describe '#enabled=' do
-      subject(:enabled_) { settings.merge(dsl.tap { |c| c.enabled = true }) }
-      it { expect { enabled_ }.to change { settings.enabled }.from(false).to(true) }
+    context 'appsec is not enabled' do
+      it 'does not patch the integration multiple times' do
+        dsl.instrument(integration_name)
+
+        expect(FakeIntegration::Patcher).to_not receive(:patch)
+        settings.merge(dsl)
+      end
+    end
+  end
+
+  context 'with env vars' do
+    describe 'DD_APPSEC_ENABLED' do
+      around do |example|
+        ClimateControl.modify('DD_APPSEC_ENABLED' => '1') do
+          example.run
+        end
+      end
+
+      describe '#enabled' do
+        subject(:enabled) { settings.enabled }
+        it { is_expected.to eq(true) }
+      end
+
+      describe '#enabled=' do
+        subject(:enabled_) { settings.merge(dsl.tap { |c| c.enabled = false }) }
+        it { expect { enabled_ }.to change { settings.enabled }.from(true).to(false) }
+      end
     end
 
-    describe '#ruleset' do
-      subject(:ruleset) { settings.ruleset }
-      it { is_expected.to eq(:recommended) }
+    describe 'DD_APPSEC_RULES' do
+      around do |example|
+        ClimateControl.modify('DD_APPSEC_RULES' => '/some/path') do
+          example.run
+        end
+      end
+
+      describe '#ruleset' do
+        subject(:ruleset) { settings.ruleset }
+        it { is_expected.to eq('/some/path') }
+      end
+
+      describe '#ruleset=' do
+        subject(:ruleset_) { settings.merge(dsl.tap { |c| c.ruleset = :strict }) }
+        it { expect { ruleset_ }.to change { settings.ruleset }.from('/some/path').to(:strict) }
+      end
     end
 
-    describe '#ruleset=' do
-      subject(:ruleset_) { settings.merge(dsl.tap { |c| c.ruleset = :strict }) }
-      it { expect { ruleset_ }.to change { settings.ruleset }.from(:recommended).to(:strict) }
+    describe 'DD_APPSEC_WAF_TIMEOUT' do
+      around do |example|
+        ClimateControl.modify('DD_APPSEC_WAF_TIMEOUT' => '42') do
+          example.run
+        end
+      end
+
+      describe '#waf_timeout' do
+        subject(:waf_timeout) { settings.waf_timeout }
+        it { is_expected.to eq(42) }
+      end
+
+      describe '#waf_timeout=' do
+        subject(:waf_timeout_) { settings.merge(dsl.tap { |c| c.waf_timeout = 3 }) }
+        it { expect { waf_timeout_ }.to change { settings.waf_timeout }.from(42).to(3) }
+      end
     end
 
-    describe '#waf_timeout' do
-      subject(:waf_timeout) { settings.waf_timeout }
-      it { is_expected.to eq(5000) }
+    describe 'DD_APPSEC_WAF_DEBUG' do
+      around do |example|
+        ClimateControl.modify('DD_APPSEC_WAF_DEBUG' => '1') do
+          example.run
+        end
+      end
+
+      describe '#waf_debug' do
+        subject(:waf_debug) { settings.waf_debug }
+        it { is_expected.to eq(true) }
+      end
+
+      describe '#waf_debug=' do
+        subject(:waf_debug_) { settings.merge(dsl.tap { |c| c.waf_debug = false }) }
+        it { expect { waf_debug_ }.to change { settings.waf_debug }.from(true).to(false) }
+      end
     end
 
-    describe '#waf_timeout=' do
-      subject(:waf_timeout_) { settings.merge(dsl.tap { |c| c.waf_timeout = 3 }) }
-      it { expect { waf_timeout_ }.to change { settings.waf_timeout }.from(5000).to(3) }
+    describe 'DD_APPSEC_TRACE_RATE_LIMIT' do
+      around do |example|
+        ClimateControl.modify('DD_APPSEC_TRACE_RATE_LIMIT' => '1024') do
+          example.run
+        end
+      end
+
+      describe '#trace_rate_limit' do
+        subject(:trace_rate_limit) { settings.trace_rate_limit }
+        it { is_expected.to eq(1024) }
+      end
+
+      describe '#trace_rate_limit=' do
+        subject(:trace_rate_limit_) { settings.merge(dsl.tap { |c| c.trace_rate_limit = 2 }) }
+        it { expect { trace_rate_limit_ }.to change { settings.trace_rate_limit }.from(1024).to(2) }
+      end
     end
 
-    describe '#waf_debug' do
-      subject(:waf_debug) { settings.waf_debug }
-      it { is_expected.to eq(false) }
+    describe 'DD_APPSEC_OBFUSCATION_PARAMETER_KEY_REGEXP' do
+      around do |example|
+        ClimateControl.modify('DD_APPSEC_OBFUSCATION_PARAMETER_KEY_REGEXP' => 'bar') do
+          example.run
+        end
+      end
+
+      describe '#obfuscator_key_regex' do
+        subject(:obfuscator_key_regex) { settings.obfuscator_key_regex }
+        it { is_expected.to eq('bar') }
+      end
+
+      describe '#obfuscator_key_regex=' do
+        subject(:obfuscator_key_regex_) { settings.merge(dsl.tap { |c| c.obfuscator_key_regex = 'baz' }) }
+        it { expect { obfuscator_key_regex_ }.to change { settings.obfuscator_key_regex }.from('bar').to('baz') }
+      end
     end
 
-    describe '#waf_debug=' do
-      subject(:waf_debug_) { settings.merge(dsl.tap { |c| c.waf_debug = true }) }
-      it { expect { waf_debug_ }.to change { settings.waf_debug }.from(false).to(true) }
+    describe 'DD_APPSEC_OBFUSCATION_PARAMETER_VALUE_REGEXP' do
+      around do |example|
+        ClimateControl.modify('DD_APPSEC_OBFUSCATION_PARAMETER_VALUE_REGEXP' => 'bar') do
+          example.run
+        end
+      end
+
+      describe '#obfuscator_value_regex' do
+        subject(:obfuscator_value_regex) { settings.obfuscator_value_regex }
+        it { is_expected.to eq('bar') }
+      end
+
+      describe '#obfuscator_value_regex=' do
+        subject(:obfuscator_value_regex_) { settings.merge(dsl.tap { |c| c.obfuscator_value_regex = 'baz' }) }
+        it { expect { obfuscator_value_regex_ }.to change { settings.obfuscator_value_regex }.from('bar').to('baz') }
+      end
     end
 
-    describe '#trace_rate_limit' do
-      subject(:trace_rate_limit) { settings.trace_rate_limit }
-      it { is_expected.to eq(100) }
-    end
-
-    describe '#trace_rate_limit=' do
-      subject(:trace_rate_limit_) { settings.merge(dsl.tap { |c| c.trace_rate_limit = 2 }) }
-      it { expect { trace_rate_limit_ }.to change { settings.trace_rate_limit }.from(100).to(2) }
-    end
-
-    describe '#ip_denylist' do
-      subject(:ip_denylist) { settings.ip_denylist }
-      it { is_expected.to eq([]) }
-    end
-
-    describe '#ip_denylist=' do
-      subject(:ip_denylist_) { settings.merge(dsl.tap { |c| c.ip_denylist = ['192.192.1.1'] }) }
-      it { expect { ip_denylist_ }.to change { settings.ip_denylist }.from([]).to(['192.192.1.1']) }
-    end
-
-    describe '#user_id_denylist' do
-      subject(:user_id_denylist) { settings.user_id_denylist }
-      it { is_expected.to eq([]) }
-    end
-
-    describe '#user_id_denylist=' do
-      subject(:user_id_denylist_) { settings.merge(dsl.tap { |c| c.user_id_denylist = ['8764937902709'] }) }
-      it { expect { user_id_denylist_ }.to change { settings.user_id_denylist }.from([]).to(['8764937902709']) }
-    end
-
-    describe '#obfuscator_key_regex' do
-      subject(:obfuscator_key_regex) { settings.obfuscator_key_regex }
-      it { is_expected.to include('token') }
-    end
-
-    describe '#obfuscator_key_regex=' do
-      subject(:obfuscator_key_regex_) { settings.merge(dsl.tap { |c| c.obfuscator_key_regex = 'bar' }) }
-      let(:default) { described_class::DEFAULT_OBFUSCATOR_KEY_REGEX }
-      it { expect { obfuscator_key_regex_ }.to change { settings.obfuscator_key_regex }.from(default).to('bar') }
-    end
-
-    describe '#obfuscator_value_regex' do
-      subject(:obfuscator_value_regex) { settings.obfuscator_value_regex }
-      it { is_expected.to include('token') }
-    end
-
-    describe '#obfuscator_value_regex=' do
-      subject(:obfuscator_value_regex_) { settings.merge(dsl.tap { |c| c.obfuscator_value_regex = 'bar' }) }
-      let(:default) { described_class::DEFAULT_OBFUSCATOR_VALUE_REGEX }
-      it { expect { obfuscator_value_regex_ }.to change { settings.obfuscator_value_regex }.from(default).to('bar') }
-    end
-
-    context 'with env vars' do
-      describe 'DD_APPSEC_ENABLED' do
+    describe '#default?' do
+      context 'when the configuration option is configured via ENV var' do
         around do |example|
           ClimateControl.modify('DD_APPSEC_ENABLED' => '1') do
             example.run
           end
         end
 
-        describe '#enabled' do
-          subject(:enabled) { settings.enabled }
-          it { is_expected.to eq(true) }
-        end
-
-        describe '#enabled=' do
-          subject(:enabled_) { settings.merge(dsl.tap { |c| c.enabled = false }) }
-          it { expect { enabled_ }.to change { settings.enabled }.from(true).to(false) }
+        it 'returns false' do
+          expect(settings.send(:default?, :enabled)).to eq(false)
         end
       end
 
-      describe 'DD_APPSEC_RULES' do
-        around do |example|
-          ClimateControl.modify('DD_APPSEC_RULES' => '/some/path') do
-            example.run
-          end
+      context 'when the configuration option is configured via merge' do
+        before do
+          settings.merge(dsl.tap { |c| c.enabled = true })
         end
 
-        describe '#ruleset' do
-          subject(:ruleset) { settings.ruleset }
-          it { is_expected.to eq('/some/path') }
-        end
-
-        describe '#ruleset=' do
-          subject(:ruleset_) { settings.merge(dsl.tap { |c| c.ruleset = :strict }) }
-          it { expect { ruleset_ }.to change { settings.ruleset }.from('/some/path').to(:strict) }
+        it 'returns false' do
+          expect(settings.send(:default?, :enabled)).to eq(false)
         end
       end
 
-      describe 'DD_APPSEC_WAF_TIMEOUT' do
-        around do |example|
-          ClimateControl.modify('DD_APPSEC_WAF_TIMEOUT' => '42') do
-            example.run
-          end
-        end
-
-        describe '#waf_timeout' do
-          subject(:waf_timeout) { settings.waf_timeout }
-          it { is_expected.to eq(42) }
-        end
-
-        describe '#waf_timeout=' do
-          subject(:waf_timeout_) { settings.merge(dsl.tap { |c| c.waf_timeout = 3 }) }
-          it { expect { waf_timeout_ }.to change { settings.waf_timeout }.from(42).to(3) }
-        end
-      end
-
-      describe 'DD_APPSEC_WAF_DEBUG' do
-        around do |example|
-          ClimateControl.modify('DD_APPSEC_WAF_DEBUG' => '1') do
-            example.run
-          end
-        end
-
-        describe '#waf_debug' do
-          subject(:waf_debug) { settings.waf_debug }
-          it { is_expected.to eq(true) }
-        end
-
-        describe '#waf_debug=' do
-          subject(:waf_debug_) { settings.merge(dsl.tap { |c| c.waf_debug = false }) }
-          it { expect { waf_debug_ }.to change { settings.waf_debug }.from(true).to(false) }
-        end
-      end
-
-      describe 'DD_APPSEC_TRACE_RATE_LIMIT' do
-        around do |example|
-          ClimateControl.modify('DD_APPSEC_TRACE_RATE_LIMIT' => '1024') do
-            example.run
-          end
-        end
-
-        describe '#trace_rate_limit' do
-          subject(:trace_rate_limit) { settings.trace_rate_limit }
-          it { is_expected.to eq(1024) }
-        end
-
-        describe '#trace_rate_limit=' do
-          subject(:trace_rate_limit_) { settings.merge(dsl.tap { |c| c.trace_rate_limit = 2 }) }
-          it { expect { trace_rate_limit_ }.to change { settings.trace_rate_limit }.from(1024).to(2) }
-        end
-      end
-
-      describe 'DD_APPSEC_OBFUSCATION_PARAMETER_KEY_REGEXP' do
-        around do |example|
-          ClimateControl.modify('DD_APPSEC_OBFUSCATION_PARAMETER_KEY_REGEXP' => 'bar') do
-            example.run
-          end
-        end
-
-        describe '#obfuscator_key_regex' do
-          subject(:obfuscator_key_regex) { settings.obfuscator_key_regex }
-          it { is_expected.to eq('bar') }
-        end
-
-        describe '#obfuscator_key_regex=' do
-          subject(:obfuscator_key_regex_) { settings.merge(dsl.tap { |c| c.obfuscator_key_regex = 'baz' }) }
-          it { expect { obfuscator_key_regex_ }.to change { settings.obfuscator_key_regex }.from('bar').to('baz') }
-        end
-      end
-
-      describe 'DD_APPSEC_OBFUSCATION_PARAMETER_VALUE_REGEXP' do
-        around do |example|
-          ClimateControl.modify('DD_APPSEC_OBFUSCATION_PARAMETER_VALUE_REGEXP' => 'bar') do
-            example.run
-          end
-        end
-
-        describe '#obfuscator_value_regex' do
-          subject(:obfuscator_value_regex) { settings.obfuscator_value_regex }
-          it { is_expected.to eq('bar') }
-        end
-
-        describe '#obfuscator_value_regex=' do
-          subject(:obfuscator_value_regex_) { settings.merge(dsl.tap { |c| c.obfuscator_value_regex = 'baz' }) }
-          it { expect { obfuscator_value_regex_ }.to change { settings.obfuscator_value_regex }.from('bar').to('baz') }
-        end
-      end
-
-      describe '#default?' do
-        context 'when the configuration option is configured via ENV var' do
-          around do |example|
-            ClimateControl.modify('DD_APPSEC_ENABLED' => '1') do
-              example.run
-            end
-          end
-
-          it 'returns false' do
-            expect(settings.send(:default?, :enabled)).to eq(false)
-          end
-        end
-
-        context 'when the configuration option is configured via merge' do
-          before do
-            settings.merge(dsl.tap { |c| c.enabled = true })
-          end
-
-          it 'returns false' do
-            expect(settings.send(:default?, :enabled)).to eq(false)
-          end
-        end
-
-        context 'when the configuration option is not configured' do
-          it 'returns true' do
-            expect(settings.send(:default?, :enabled)).to eq(true)
-          end
+      context 'when the configuration option is not configured' do
+        it 'returns true' do
+          expect(settings.send(:default?, :enabled)).to eq(true)
         end
       end
     end

--- a/spec/datadog/appsec/contrib/devise/patcher/authenticatable_patch_spec.rb
+++ b/spec/datadog/appsec/contrib/devise/patcher/authenticatable_patch_spec.rb
@@ -26,10 +26,6 @@ RSpec.describe Datadog::AppSec::Contrib::Devise::Patcher::AuthenticatablePatch d
         @email = email
         @username = username
       end
-
-      def try(value)
-        send(value)
-      end
     end
   end
 

--- a/spec/datadog/appsec/contrib/devise/patcher/authenticatable_patch_spec.rb
+++ b/spec/datadog/appsec/contrib/devise/patcher/authenticatable_patch_spec.rb
@@ -1,5 +1,6 @@
 require 'datadog/appsec/spec_helper'
 
+require 'datadog/appsec/contrib/devise/patcher'
 require 'datadog/appsec/contrib/devise/patcher/authenticatable_patch'
 
 RSpec.describe Datadog::AppSec::Contrib::Devise::Patcher::AuthenticatablePatch do

--- a/spec/datadog/appsec/contrib/devise/patcher/authenticatable_patch_spec.rb
+++ b/spec/datadog/appsec/contrib/devise/patcher/authenticatable_patch_spec.rb
@@ -1,0 +1,215 @@
+require 'datadog/appsec/spec_helper'
+
+require 'datadog/appsec/contrib/devise/patcher/authenticatable_patch'
+
+RSpec.describe Datadog::AppSec::Contrib::Devise::Patcher::AuthenticatablePatch do
+  let(:mock_klass) do
+    Class.new do
+      prepend Datadog::AppSec::Contrib::Devise::Patcher::AuthenticatablePatch
+
+      def initialize(result)
+        @result = result
+      end
+
+      def validate(resource, &block)
+        @result
+      end
+    end
+  end
+
+  let(:mock_resource) do
+    Class.new do
+      attr_reader :id, :email, :username
+
+      def initialize(id, email, username)
+        @id = id
+        @email = email
+        @username = username
+      end
+
+      def try(value)
+        send(value)
+      end
+    end
+  end
+
+  let(:nil_resource) { nil }
+  let(:resource) { mock_resource.new(1, 'hello@gmail.com', 'John') }
+  let(:mode) { 'safe' }
+  let(:automated_track_user_events) { double(automated_track_user_events: mode) }
+  let(:success_login) { mock_klass.new(true) }
+  let(:failed_login) {  mock_klass.new(false) }
+
+  before do
+    expect(Datadog::AppSec).to receive(:enabled?).and_return(appsec_enabled)
+    expect(Datadog::AppSec).to receive(:settings).and_return(automated_track_user_events) if appsec_enabled
+
+    expect(Datadog::AppSec).to receive(:active_scope).and_return(appsec_scope) if appsec_enabled && mode != 'disable'
+  end
+
+  context 'AppSec disabled' do
+    let(:appsec_enabled) { false }
+
+    it 'do not tracks event' do
+      expect(Datadog::AppSec::Contrib::Devise::Tracking).to_not receive(:track_login_success)
+      expect(success_login.validate(resource)).to eq(true)
+    end
+  end
+
+  context 'Automated user tracking is disabled' do
+    let(:appsec_enabled) { true }
+    let(:mode) { 'disable' }
+
+    it 'do not tracks event' do
+      expect(Datadog::AppSec::Contrib::Devise::Tracking).to_not receive(:track_login_success)
+      expect(success_login.validate(resource)).to eq(true)
+    end
+  end
+
+  context 'AppSec scope is nil ' do
+    let(:appsec_enabled) { true }
+    let(:mode) { 'safe' }
+    let(:appsec_scope) { nil }
+
+    it 'do not tracks event' do
+      expect(Datadog::AppSec::Contrib::Devise::Tracking).to_not receive(:track_login_success)
+      expect(success_login.validate(resource)).to eq(true)
+    end
+  end
+
+  context 'successful login' do
+    let(:appsec_enabled) { true }
+    let(:appsec_scope) { instance_double(Datadog::AppSec::Scope, trace: double, service_entry_span: double) }
+
+    context 'with resource ID' do
+      context 'safe mode' do
+        let(:mode) { 'safe' }
+
+        it 'tracks event' do
+          expect(Datadog::AppSec::Contrib::Devise::Tracking).to receive(:track_login_success).with(
+            appsec_scope.trace,
+            appsec_scope.service_entry_span,
+            user_id: resource.id,
+            **{}
+          )
+          expect(success_login.validate(resource)).to eq(true)
+        end
+      end
+
+      context 'extended mode' do
+        let(:mode) { 'extended' }
+
+        it 'tracks event' do
+          expect(Datadog::AppSec::Contrib::Devise::Tracking).to receive(:track_login_success).with(
+            appsec_scope.trace,
+            appsec_scope.service_entry_span,
+            user_id: resource.id,
+            **{ username: 'John', email: 'hello@gmail.com' }
+          )
+          expect(success_login.validate(resource)).to eq(true)
+        end
+      end
+    end
+
+    context 'without resource ID' do
+      let(:resource) { mock_resource.new(nil, 'hello@gmail.com', 'John') }
+
+      context 'safe mode' do
+        let(:mode) { 'safe' }
+
+        it 'tracks event' do
+          expect(Datadog::AppSec::Contrib::Devise::Tracking).to receive(:track_login_success).with(
+            appsec_scope.trace,
+            appsec_scope.service_entry_span,
+            user_id: nil,
+            **{}
+          )
+          expect(success_login.validate(resource)).to eq(true)
+        end
+      end
+
+      context 'extended mode' do
+        let(:mode) { 'extended' }
+
+        it 'tracks event' do
+          expect(Datadog::AppSec::Contrib::Devise::Tracking).to receive(:track_login_success).with(
+            appsec_scope.trace,
+            appsec_scope.service_entry_span,
+            user_id: nil,
+            **{ username: 'John', email: 'hello@gmail.com' }
+          )
+          expect(success_login.validate(resource)).to eq(true)
+        end
+      end
+    end
+  end
+
+  context 'unsuccessful login' do
+    let(:appsec_enabled) { true }
+    let(:appsec_scope) { instance_double(Datadog::AppSec::Scope, trace: double, service_entry_span: double) }
+
+    context 'with resource' do
+      context 'safe mode' do
+        let(:mode) { 'safe' }
+
+        it 'tracks event' do
+          expect(Datadog::AppSec::Contrib::Devise::Tracking).to receive(:track_login_failure).with(
+            appsec_scope.trace,
+            appsec_scope.service_entry_span,
+            user_id: resource.id,
+            user_exists: true,
+            **{}
+          )
+          expect(failed_login.validate(resource)).to eq(false)
+        end
+      end
+
+      context 'extended mode' do
+        let(:mode) { 'extended' }
+
+        it 'tracks event' do
+          expect(Datadog::AppSec::Contrib::Devise::Tracking).to receive(:track_login_failure).with(
+            appsec_scope.trace,
+            appsec_scope.service_entry_span,
+            user_id: resource.id,
+            user_exists: true,
+            **{ username: 'John', email: 'hello@gmail.com' }
+          )
+          expect(failed_login.validate(resource)).to eq(false)
+        end
+      end
+    end
+
+    context 'without resource' do
+      context 'safe mode' do
+        let(:mode) { 'safe' }
+
+        it 'tracks event' do
+          expect(Datadog::AppSec::Contrib::Devise::Tracking).to receive(:track_login_failure).with(
+            appsec_scope.trace,
+            appsec_scope.service_entry_span,
+            user_id: nil,
+            user_exists: false,
+            **{}
+          )
+          expect(failed_login.validate(nil_resource)).to eq(false)
+        end
+      end
+
+      context 'extended mode' do
+        let(:mode) { 'extended' }
+
+        it 'tracks event' do
+          expect(Datadog::AppSec::Contrib::Devise::Tracking).to receive(:track_login_failure).with(
+            appsec_scope.trace,
+            appsec_scope.service_entry_span,
+            user_id: nil,
+            user_exists: false,
+            **{}
+          )
+          expect(failed_login.validate(nil_resource)).to eq(false)
+        end
+      end
+    end
+  end
+end

--- a/spec/datadog/appsec/contrib/devise/patcher/registration_controller_patch_spec.rb
+++ b/spec/datadog/appsec/contrib/devise/patcher/registration_controller_patch_spec.rb
@@ -1,5 +1,6 @@
 require 'datadog/appsec/spec_helper'
 
+require 'datadog/appsec/contrib/devise/patcher'
 require 'datadog/appsec/contrib/devise/patcher/registration_controller_patch'
 
 RSpec.describe Datadog::AppSec::Contrib::Devise::Patcher::RegistrationControllerPatch do

--- a/spec/datadog/appsec/contrib/devise/patcher/registration_controller_patch_spec.rb
+++ b/spec/datadog/appsec/contrib/devise/patcher/registration_controller_patch_spec.rb
@@ -1,0 +1,179 @@
+require 'datadog/appsec/spec_helper'
+
+require 'datadog/appsec/contrib/devise/patcher/registration_controller_patch'
+
+RSpec.describe Datadog::AppSec::Contrib::Devise::Patcher::RegistrationControllerPatch do
+  let(:mock_controller) do
+    Class.new do
+      prepend Datadog::AppSec::Contrib::Devise::Patcher::RegistrationControllerPatch
+
+      def initialize(result, resource)
+        @resource = resource
+        @result = result
+      end
+
+      def create
+        yield @resource if block_given?
+        @result
+      end
+    end
+  end
+
+  let(:mock_resource) do
+    Class.new do
+      attr_reader :id, :email, :username, :persisted
+
+      def initialize(id, email, username, persisted)
+        @id = id
+        @email = email
+        @username = username
+        @persisted = persisted
+      end
+
+      def persisted?
+        @persisted
+      end
+
+      def try(value)
+        send(value)
+      end
+    end
+  end
+
+  let(:non_persisted_resource) { mock_resource.new(nil, nil, nil, false) }
+  let(:persited_resource) { mock_resource.new(1, 'hello@gmail.com', 'John', true) }
+  let(:automated_track_user_events) { double(automated_track_user_events: mode) }
+  let(:controller) { mock_controller.new(true, resource) }
+
+  let(:resource) { non_persisted_resource }
+
+  before do
+    expect(Datadog::AppSec).to receive(:enabled?).and_return(appsec_enabled)
+    expect(Datadog::AppSec).to receive(:settings).and_return(automated_track_user_events) if appsec_enabled
+
+    expect(Datadog::AppSec).to receive(:active_scope).and_return(appsec_scope) if appsec_enabled && mode != 'disable'
+  end
+
+  context 'AppSec disabled' do
+    let(:appsec_enabled) { false }
+
+    it 'do not tracks event' do
+      expect(Datadog::AppSec::Contrib::Devise::Tracking).to_not receive(:track_signup)
+      expect(controller.create).to eq(true)
+    end
+  end
+
+  context 'Automated user tracking is disabled' do
+    let(:appsec_enabled) { true }
+    let(:mode) { 'disable' }
+
+    it 'do not tracks event' do
+      expect(Datadog::AppSec::Contrib::Devise::Tracking).to_not receive(:track_signup)
+      expect(controller.create).to eq(true)
+    end
+  end
+
+  context 'AppSec scope is nil ' do
+    let(:appsec_enabled) { true }
+    let(:mode) { 'safe' }
+    let(:appsec_scope) { nil }
+
+    it 'do not tracks event' do
+      expect(Datadog::AppSec::Contrib::Devise::Tracking).to_not receive(:track_signup)
+      expect(controller.create).to eq(true)
+    end
+  end
+
+  context 'with persisted resource' do
+    let(:appsec_enabled) { true }
+    let(:appsec_scope) { instance_double(Datadog::AppSec::Scope, trace: double, service_entry_span: double) }
+
+    context 'with resource ID' do
+      let(:resource) { persited_resource }
+
+      context 'safe mode' do
+        let(:mode) { 'safe' }
+
+        it 'tracks event' do
+          expect(Datadog::AppSec::Contrib::Devise::Tracking).to receive(:track_signup).with(
+            appsec_scope.trace,
+            appsec_scope.service_entry_span,
+            user_id: resource.id,
+            **{}
+          )
+          expect(controller.create).to eq(true)
+        end
+      end
+
+      context 'extended mode' do
+        let(:mode) { 'extended' }
+
+        it 'tracks event' do
+          expect(Datadog::AppSec::Contrib::Devise::Tracking).to receive(:track_signup).with(
+            appsec_scope.trace,
+            appsec_scope.service_entry_span,
+            user_id: resource.id,
+            **{ email: 'hello@gmail.com', username: 'John' }
+          )
+          expect(controller.create).to eq(true)
+        end
+      end
+    end
+
+    context 'without resource ID' do
+      let(:resource) { mock_resource.new(nil, 'hello@gmail.com', 'John', true) }
+
+      context 'safe mode' do
+        let(:mode) { 'safe' }
+
+        it 'tracks event' do
+          expect(Datadog::AppSec::Contrib::Devise::Tracking).to receive(:track_signup).with(
+            appsec_scope.trace,
+            appsec_scope.service_entry_span,
+            user_id: nil,
+            **{}
+          )
+          expect(controller.create).to eq(true)
+        end
+      end
+
+      context 'extended mode' do
+        let(:mode) { 'extended' }
+
+        it 'tracks event' do
+          expect(Datadog::AppSec::Contrib::Devise::Tracking).to receive(:track_signup).with(
+            appsec_scope.trace,
+            appsec_scope.service_entry_span,
+            user_id: nil,
+            **{ email: 'hello@gmail.com', username: 'John' }
+          )
+          expect(controller.create).to eq(true)
+        end
+      end
+    end
+  end
+
+  context 'with non persisted resource' do
+    let(:appsec_enabled) { true }
+    let(:appsec_scope) { instance_double(Datadog::AppSec::Scope, trace: double, service_entry_span: double) }
+    let(:resource) { non_persisted_resource }
+
+    context 'safe mode' do
+      let(:mode) { 'safe' }
+
+      it 'do not tracks event' do
+        expect(Datadog::AppSec::Contrib::Devise::Tracking).to_not receive(:track_signup)
+        expect(controller.create).to eq(true)
+      end
+    end
+
+    context 'extended mode' do
+      let(:mode) { 'extended' }
+
+      it 'tracks event' do
+        expect(Datadog::AppSec::Contrib::Devise::Tracking).to_not receive(:track_signup)
+        expect(controller.create).to eq(true)
+      end
+    end
+  end
+end

--- a/spec/datadog/appsec/contrib/devise/resource_spec.rb
+++ b/spec/datadog/appsec/contrib/devise/resource_spec.rb
@@ -1,0 +1,97 @@
+require 'datadog/appsec/spec_helper'
+require 'securerandom'
+require 'datadog/appsec/contrib/devise/resource'
+
+RSpec.describe Datadog::AppSec::Contrib::Devise::Resource do
+  subject(:resource) { described_class.new(object) }
+
+  let(:object_class) do
+    Class.new do
+      attr_reader :id, :uuid, :email, :username
+
+      def initialize(id: nil, uuid: nil, email: nil, username: nil)
+        @id = id
+        @uuid = uuid
+        @email = email
+        @username = username
+      end
+    end
+  end
+
+  let(:empty_class) do
+    Class.new {}
+  end
+
+  describe '#id' do
+    context 'resource respond to id' do
+      let(:object) { object_class.new(id: 1) }
+
+      it 'returns id' do
+        expect(resource.id).to eq(1)
+      end
+    end
+
+    context 'resource respond to uuid' do
+      let(:uuid) { SecureRandom.uuid }
+      let(:object) { object_class.new(uuid: uuid) }
+
+      it 'returns id' do
+        expect(resource.id).to eq(uuid)
+      end
+    end
+
+    context 'resource respond to id and uuid' do
+      let(:uuid) { SecureRandom.uuid }
+      let(:object) { object_class.new(id: 1, uuid: uuid) }
+
+      it 'returns id' do
+        expect(resource.id).to eq(1)
+      end
+    end
+
+    context 'resource does not respond to id or uuid' do
+      let(:uuid) { SecureRandom.uuid }
+      let(:object) { empty_class.new }
+
+      it 'returns nil' do
+        expect(resource.id).to be_nil
+      end
+    end
+  end
+
+  describe '#email' do
+    context 'resource respond to email' do
+      let(:object) { object_class.new(email: 'hello@gmail.com') }
+
+      it 'returns email' do
+        expect(resource.email).to eq('hello@gmail.com')
+      end
+    end
+
+    context 'resource do not respond to email' do
+      let(:object) { empty_class.new }
+
+      it 'returns nil' do
+        expect(resource.email).to be_nil
+      end
+    end
+  end
+
+  describe '#username' do
+    context 'resource respond to username' do
+      let(:object) { object_class.new(username: 'Joe') }
+
+      it 'returns email' do
+        expect(resource.username).to eq('Joe')
+      end
+    end
+
+    context 'resource do not respond to username' do
+      let(:object) { empty_class.new }
+
+      it 'returns nil' do
+        expect(resource.username).to be_nil
+      end
+    end
+  end
+end

--- a/spec/datadog/appsec/contrib/devise/tracking_spec.rb
+++ b/spec/datadog/appsec/contrib/devise/tracking_spec.rb
@@ -1,0 +1,132 @@
+require 'datadog/appsec/spec_helper'
+
+require 'datadog/appsec/contrib/devise/tracking'
+
+RSpec.describe Datadog::AppSec::Contrib::Devise::Tracking do
+  let(:trace_op) { Datadog::Tracing::TraceOperation.new }
+  let(:auto_mode) { Datadog::AppSec.settings.automated_track_user_events.to_s }
+
+  describe '#track_login_success' do
+    it 'sets event tracking key on trace' do
+      trace_op.measure('root') do |span, _trace|
+        described_class.track_login_success(trace_op, span, user_id: '42')
+        expect(span.tags).to include('appsec.events.users.login.success.track' => 'true')
+        expect(span.tags).to include('_dd.appsec.events.users.login.success.auto.mode' => auto_mode)
+      end
+    end
+
+    it 'sets successful user id on trace' do
+      trace_op.measure('root') do |span, _trace|
+        described_class.track_login_success(trace_op, span, user_id: '42')
+        expect(span.tags).to include('usr.id' => '42')
+      end
+    end
+
+    it 'sets other keys on trace' do
+      trace_op.measure('root') do |span, _trace|
+        described_class.track_login_success(trace_op, span, user_id: '42', foo: 'bar')
+        expect(span.tags).to include('usr.id' => '42', 'appsec.events.users.login.success.foo' => 'bar')
+      end
+    end
+
+    it 'if user ID is nil do not set user tag' do
+      trace_op.measure('root') do |span, _trace|
+        described_class.track_login_success(trace_op, span, user_id: nil, foo: 'bar')
+        expect(span.tags).to_not include('usr.id' => '42')
+      end
+    end
+  end
+
+  describe '#track_login_failure' do
+    it 'sets event tracking key on trace' do
+      trace_op.measure('root') do |span, _trace|
+        described_class.track_login_failure(trace_op, span, user_id: '42', user_exists: true)
+        expect(span.tags).to include('appsec.events.users.login.failure.track' => 'true')
+        expect(span.tags).to include('_dd.appsec.events.users.login.failure.auto.mode' => auto_mode)
+      end
+    end
+
+    it 'sets failing user id on trace' do
+      trace_op.measure('root') do |span, _trace|
+        described_class.track_login_failure(trace_op, span, user_id: '42', user_exists: true)
+        expect(span.tags).to include('appsec.events.users.login.failure.usr.id' => '42')
+      end
+    end
+
+    it 'do not sets failing user id on trace if user_id is nil' do
+      trace_op.measure('root') do |span, _trace|
+        described_class.track_login_failure(trace_op, span, user_id: nil, user_exists: true)
+        expect(span.tags).to_not include('appsec.events.users.login.failure.usr.id' => '42')
+      end
+    end
+
+    it 'sets user existence on trace' do
+      trace_op.measure('root') do |span, _trace|
+        described_class.track_login_failure(trace_op, span, user_id: '42', user_exists: true)
+        expect(span.tags).to include('appsec.events.users.login.failure.usr.exists' => 'true')
+      end
+    end
+
+    it 'sets user non-existence  on trace' do
+      trace_op.measure('root') do |span, _trace|
+        described_class.track_login_failure(trace_op, span, user_id: '42', user_exists: false)
+        expect(span.tags).to include('appsec.events.users.login.failure.usr.exists' => 'false')
+      end
+    end
+
+    it 'sets other keys on trace' do
+      trace_op.measure('root') do |span, _trace|
+        described_class.track_login_failure(trace_op, span, user_id: '42', user_exists: true, foo: 'bar')
+        expect(span.tags).to include('appsec.events.users.login.failure.foo' => 'bar')
+      end
+    end
+  end
+
+  describe '#track_signup' do
+    it 'sets event tracking key on trace' do
+      trace_op.measure('root') do |span, _trace|
+        described_class.track_signup(trace_op, span, user_id: '42')
+        expect(span.tags).to include('appsec.events.users.signup.track' => 'true')
+        expect(span.tags).to include('_dd.appsec.events.users.signup.auto.mode' => auto_mode)
+      end
+    end
+
+    it 'sets successful user id on trace' do
+      trace_op.measure('root') do |span, _trace|
+        described_class.track_signup(trace_op, span, user_id: '42')
+        expect(span.tags).to include('usr.id' => '42')
+      end
+    end
+
+    it 'sets other keys on trace' do
+      trace_op.measure('root') do |span, _trace|
+        described_class.track_signup(trace_op, span, user_id: '42', foo: 'bar')
+        expect(span.tags).to include('usr.id' => '42', 'appsec.events.users.signup.foo' => 'bar')
+      end
+    end
+
+    it 'if user ID is nil do not set user tag' do
+      trace_op.measure('root') do |span, _trace|
+        described_class.track_signup(trace_op, span, user_id: nil, foo: 'bar')
+        expect(span.tags).to_not include('usr.id' => '42')
+      end
+    end
+  end
+
+  describe '#track' do
+    it 'sets event tracking key on trace' do
+      trace_op.measure('root') do |span, _trace|
+        described_class.track('foo', trace_op, span)
+        expect(span.tags).to include('appsec.events.foo.track' => 'true')
+        expect(span.tags).to include('_dd.appsec.events.foo.auto.mode' => auto_mode)
+      end
+    end
+
+    it 'sets other keys on trace' do
+      trace_op.measure('root') do |span, _trace|
+        described_class.track('foo', trace_op, span, bar: 'baz')
+        expect(span.tags).to include('appsec.events.foo.bar' => 'baz')
+      end
+    end
+  end
+end

--- a/spec/datadog/appsec/extensions_spec.rb
+++ b/spec/datadog/appsec/extensions_spec.rb
@@ -127,6 +127,31 @@ RSpec.describe Datadog::AppSec::Extensions do
         subject(:user_id_denylist_) { settings.user_id_denylist = ['24528736564812'] }
         it { expect { user_id_denylist_ }.to change { settings.user_id_denylist }.from([]).to(['24528736564812']) }
       end
+
+      describe '#automated_track_user_events' do
+        subject(:automated_track_user_events) { settings.automated_track_user_events }
+        it { is_expected.to eq(:safe) }
+      end
+
+      describe '#automated_track_user_events=' do
+        context 'valid value' do
+          subject(:automated_track_user_events_) { settings.automated_track_user_events = 'extended' }
+          it do
+            expect { automated_track_user_events_ }.to change {
+              settings.automated_track_user_events
+            }.from(:safe).to('extended')
+          end
+        end
+
+        context 'invalid value' do
+          subject(:automated_track_user_events_) { settings.automated_track_user_events = 'invalid value' }
+          it 'raises exception' do
+            expect do
+              automated_track_user_events_
+            end.to raise_error(Datadog::AppSec::Extensions::AppSecAdapter::InvalidConfigurationValue)
+          end
+        end
+      end
     end
   end
 end

--- a/spec/datadog/kit/appsec/events_spec.rb
+++ b/spec/datadog/kit/appsec/events_spec.rb
@@ -62,7 +62,9 @@ RSpec.describe Datadog::Kit::AppSec::Events do
 
     it 'raises ArgumentError is user ID is nil' do
       expect do
-        described_class.track_login_success(trace_op, user: { id: nil }, foo: 'bar')
+        trace_op.measure('root') do |_span, _trace|
+          described_class.track_login_success(trace_op, user: { id: nil }, foo: 'bar')
+        end
       end.to raise_error(ArgumentError)
     end
 
@@ -96,13 +98,6 @@ RSpec.describe Datadog::Kit::AppSec::Events do
       end
     end
 
-    it 'do not sets failing user id on trace if user_id is nil' do
-      trace_op.measure('root') do
-        described_class.track_login_failure(trace_op, user_id: nil, user_exists: true)
-      end
-      expect(meta).to_not include('appsec.events.users.login.failure.usr.id' => '42')
-    end
-
     it 'sets user existence on trace' do
       trace_op.measure('root') do |span, _trace|
         described_class.track_login_failure(trace_op, user_id: '42', user_exists: true)
@@ -128,87 +123,45 @@ RSpec.describe Datadog::Kit::AppSec::Events do
       let(:event_tag) { 'appsec.events.users.login.failure.track' }
       subject(:event) { described_class.track_login_failure(trace_op, user_id: '42', user_exists: true) }
     end
-
-    context 'custom block' do
-      context 'without block' do
-        it 'sets sdk tag' do
-          trace_op.measure('root') do
-            described_class.track_login_failure(trace_op, user_id: '42', user_exists: true)
-          end
-          expect(meta).to include('appsec.events.users.login.failure.sdk' => 'true')
-          expect(meta).to_not include('appsec.events.users.login.failure.custom' => 'true')
-        end
-      end
-
-      context 'with block' do
-        it 'sets custom tag' do
-          trace_op.measure('root') do
-            described_class.track_login_failure(trace_op, user_id: '42', user_exists: true, &custom_block)
-          end
-          expect(meta).to_not include('appsec.events.users.login.failure.sdk' => 'true')
-          expect(meta).to include('appsec.events.users.login.failure.custom' => 'true')
-        end
-      end
-    end
   end
 
   describe '#track_signup' do
     it 'sets event tracking key on trace' do
-      trace_op.measure('root') do
+      trace_op.measure('root') do |span, _trace|
         described_class.track_signup(trace_op, user: { id: '42' })
+        expect(span.tags).to include('appsec.events.users.signup.track' => 'true')
       end
-      expect(meta).to include('appsec.events.users.signup.track' => 'true')
     end
 
     it 'sets successful user id on trace' do
-      trace_op.measure('root') do
+      trace_op.measure('root') do |span, _trace|
         described_class.track_signup(trace_op, user: { id: '42' })
+        expect(span.tags).to include('usr.id' => '42')
       end
-      expect(meta).to include('usr.id' => '42')
     end
 
     it 'sets other keys on trace' do
-      trace_op.measure('root') do
+      trace_op.measure('root') do |span, _trace|
         described_class.track_signup(trace_op, user: { id: '42' }, foo: 'bar')
+        expect(span.tags).to include('usr.id' => '42', 'appsec.events.users.signup.foo' => 'bar')
       end
-      expect(meta).to include('usr.id' => '42', 'appsec.events.users.signup.foo' => 'bar')
     end
 
     it 'raises ArgumentError is user ID is nil' do
       expect do
-        described_class.track_signup(trace_op, user: { id: nil }, foo: 'bar')
+        trace_op.measure('root') do
+          described_class.track_signup(trace_op, user: { id: nil }, foo: 'bar')
+        end
       end.to raise_error(ArgumentError)
     end
 
     it 'maintains integrity of user argument' do
       user_argument = { id: '42' }
       user_argument_dup = user_argument.dup
-      trace_op.measure('root') do
+      trace_op.measure('root') do |_span, _trace|
         described_class.track_signup(trace_op, user: user_argument, foo: 'bar')
       end
       expect(user_argument).to eql(user_argument_dup)
-    end
-
-    context 'custom block' do
-      context 'without block' do
-        it 'sets sdk tag' do
-          trace_op.measure('root') do
-            described_class.track_signup(trace_op, user: { id: '42' })
-          end
-          expect(meta).to include('appsec.events.users.signup.sdk' => 'true')
-          expect(meta).to_not include('appsec.events.users.signup.custom' => 'true')
-        end
-      end
-
-      context 'with block' do
-        it 'sets custom tag' do
-          trace_op.measure('root') do
-            described_class.track_signup(trace_op, user: { id: '42' }, &custom_block)
-          end
-          expect(meta).to_not include('appsec.events.users.signup.sdk' => 'true')
-          expect(meta).to include('appsec.events.users.signup.custom' => 'true')
-        end
-      end
     end
   end
 
@@ -230,28 +183,6 @@ RSpec.describe Datadog::Kit::AppSec::Events do
     it_behaves_like 'uses AppSec scope' do
       let(:event_tag) { 'appsec.events.foo.track' }
       subject(:event) { described_class.track('foo', trace_op) }
-    end
-
-    context 'custom block' do
-      context 'without block' do
-        it 'sets sdk tag' do
-          trace_op.measure('root') do
-            described_class.track('foo', trace_op)
-          end
-          expect(meta).to include('appsec.events.foo.sdk' => 'true')
-          expect(meta).to_not include('appsec.events.foo.custom' => 'true')
-        end
-      end
-
-      context 'with block' do
-        it 'sets custom tag' do
-          trace_op.measure('root') do
-            described_class.track('foo', trace_op, &custom_block)
-          end
-          expect(meta).to_not include('appsec.events.foo.sdk' => 'true')
-          expect(meta).to include('appsec.events.foo.custom' => 'true')
-        end
-      end
     end
   end
 end


### PR DESCRIPTION
<!--
Check out the
https://github.com/DataDog/dd-trace-rb/blob/master/docs/DevelopmentGuide.md
for guidance on how to set up your development environment,
run the test suite, write new integrations, and more.
-->

**What does this PR do?**
<!-- A brief description of the change being made with this pull request. -->

The PR adds a new AppSec integration `devise`. The integration is responsible for instrumenting User events: `login`, and `singup`. 

The PR also adds a couple of things:
- A new AppSec configuration `automated_track_user_events`
- Add a AppSec user event `track_signup`

**Motivation**
<!-- What inspired you to submit this pull request? -->

**Additional Notes**
<!-- Anything else we should know when reviewing? -->

**How to test the change?**
<!--
Describe here how the change can be validated.
You are strongly encouraged to provide automated tests for this PR (unit or integration).
If this change cannot be feasibly tested, please explain why,
unless the change does not modify code (e.g. only modifies docs, comments).
-->

CI
