### PR TITLE
Use first valid extracted style for distributed tracing

### DIFF
--- a/lib/datadog/tracing/distributed/propagation.rb
+++ b/lib/datadog/tracing/distributed/propagation.rb
@@ -72,8 +72,10 @@ module Datadog
         #
         # @param data [Hash]
         def extract(data)
-          trace_digest = nil
-          dd_trace_digest = nil
+          return unless data
+          return if data.empty?
+
+          extracted_trace_digest = nil
 
           ::Datadog.configuration.tracing.distributed_tracing.propagation_extract_style.each do |style|
             propagator = @propagation_styles[style]
@@ -83,42 +85,14 @@ module Datadog
               extracted_trace_digest = propagator.extract(data)
             rescue => e
               ::Datadog.logger.error(
-                'Error extracting distributed trace data. ' \
-              "Cause: #{e} Location: #{Array(e.backtrace).first}"
+                "Error extracting distributed trace data. Cause: #{e} Location: #{Array(e.backtrace).first}"
               )
             end
 
-            # Skip if no valid data was found
-            next if extracted_trace_digest.nil?
-
-            # Keep track of the Datadog extracted digest, we want to return it if we have it.
-            if extracted_trace_digest && style == Tracing::Configuration::Ext::Distributed::PROPAGATION_STYLE_DATADOG
-              dd_trace_digest = extracted_trace_digest
-            end
-
-            # No previously extracted trace data, use the one we just extracted
-            if trace_digest.nil?
-              trace_digest = extracted_trace_digest
-            else
-              unless trace_digest.trace_id == extracted_trace_digest.trace_id \
-                    && trace_digest.span_id == extracted_trace_digest.span_id
-                # We have two mismatched propagation contexts
-                ::Datadog.logger.debug do
-                  'Cannot extract distributed trace data: extracted styles differ, ' \
-                  "#{trace_digest.trace_id} != #{extracted_trace_digest.trace_id} && " \
-                  "#{trace_digest.span_id} != #{extracted_trace_digest.span_id}"
-                end
-
-                # It's safer to create a new context than to attach ourselves to the wrong context
-                return TraceDigest.new # Early return from the whole method
-              end
-            end
+            break if extracted_trace_digest
           end
 
-          # Return the extracted trace digest if we found one or else a new empty digest.
-          # Always return the Datadog trace digest if one exists since it has more
-          # information than the B3 digest, e.g. origin, priority sampling values.
-          dd_trace_digest || trace_digest || nil
+          extracted_trace_digest
         end
       end
     end

--- a/lib/datadog/tracing/distributed/propagation.rb
+++ b/lib/datadog/tracing/distributed/propagation.rb
@@ -18,6 +18,12 @@ module Datadog
         # @param propagation_styles [Hash<String,Object>]
         def initialize(propagation_styles:)
           @propagation_styles = propagation_styles
+          # We need to make sure propagation_style option is evaluated.
+          # Our options are lazy evaluated and it happens that propagation_style has the on_set callback
+          # that affect Datadog.configuration.tracing.distributed_tracing.propagation_inject_style and
+          # Datadog.configuration.tracing.distributed_tracing.propagation_extract_style
+          # By calling it here, we make sure if the customers has set any value either via code or ENV variable is applied.
+          Datadog.configuration.tracing.distributed_tracing.propagation_style
         end
 
         # inject! populates the env with span ID, trace ID and sampling priority

--- a/lib/datadog/tracing/distributed/propagation.rb
+++ b/lib/datadog/tracing/distributed/propagation.rb
@@ -23,7 +23,7 @@ module Datadog
           # that affect Datadog.configuration.tracing.distributed_tracing.propagation_inject_style and
           # Datadog.configuration.tracing.distributed_tracing.propagation_extract_style
           # By calling it here, we make sure if the customers has set any value either via code or ENV variable is applied.
-          Datadog.configuration.tracing.distributed_tracing.propagation_style
+          ::Datadog.configuration.tracing.distributed_tracing.propagation_style
         end
 
         # inject! populates the env with span ID, trace ID and sampling priority


### PR DESCRIPTION
**What does this PR do?**

Currently, when extracting from multiple contexts, our propagation would validate against each other to ensure the trace id and span id are identical. This approach ensure that if user includes `Datadog` proprietary propagation, those proprietary tags would be propagated and the user will remain having full functionalities that Datadog offers.

If there is a mismatched being detected, since we are not able to identify the source of truth, it would leads to a broken distributed trace. The third scenario on the right illustrated a possible scenario with a mismatched detected given 128 bits trace ID upstream.

![128-bit-trace-id-conflict](https://github.com/DataDog/dd-trace-rb/assets/16049123/5907a66b-84b4-40fa-ba27-430538f5d97f)

This PR changes the propagation behaviour by removing the validation phase for multiple extractions. This means the first successful extraction would always wins. W3C trace context propagation is fully compatible but user prioritizing `B3` extraction would lose Datadog's proprietary tags. 

System test for trace header precedence: https://github.com/DataDog/system-tests/pull/1454