### PR TITLE
Log pkg-config command when building profiling native extension

### DIFF
--- a/ext/ddtrace_profiling_native_extension/extconf.rb
+++ b/ext/ddtrace_profiling_native_extension/extconf.rb
@@ -175,6 +175,8 @@ Logging.message("[ddtrace] PKG_CONFIG_PATH set to #{ENV['PKG_CONFIG_PATH'].inspe
 $stderr.puts("Using libdatadog #{Libdatadog::VERSION} from #{Libdatadog.pkgconfig_folder}")
 
 unless pkg_config('datadog_profiling_with_rpath')
+  Logging.message("[ddtrace] Ruby detected the pkg-config command is #{$PKGCONFIG.inspect}\n")
+
   skip_building_extension!(
     if Datadog::Profiling::NativeExtensionHelpers::Supported.pkg_config_missing?
       Datadog::Profiling::NativeExtensionHelpers::Supported::PKG_CONFIG_IS_MISSING


### PR DESCRIPTION
**What does this PR do?**:

This PR adds a new log message to the profiling native extension build log (`mkmf.log`) containing the pkg-config command detected by Ruby.

**Motivation**:

I'm currently debugging a customer issue where Ruby does not seem to be detecting the correct path for `pkg-config`.

I'm adding this extra logging so we can figure out where Ruby thinks `pkg-config` is.

**Additional Notes**:

N/A

**How to test the change?**:

Check that new log message shows up in `mkmf.log`.

Here's an example where Ruby doesn't find `pkg-config`:

```
[ddtrace] Ruby detected the pkg-config command is nil
```

...and here's one where it does:

```
[ddtrace] Ruby detected the pkg-config command is "pkg-config"
```
