### PR TITLE
Use relative URI for server.request.uri.raw

### DIFF
--- a/lib/datadog/appsec/contrib/rack/gateway/request.rb
+++ b/lib/datadog/appsec/contrib/rack/gateway/request.rb
@@ -47,10 +47,12 @@ module Datadog
               request.url
             end
 
-            def relative_uri
-              if (m = %r{^(?<scheme>[a-z]+)://(?<authority>[^/]+)?(?<relative_uri>/.*)}.match(url))
-                m['relative_uri']
-              end
+            def fullpath
+              request.fullpath
+            end
+
+            def path
+              request.path
             end
 
             def cookies

--- a/lib/datadog/appsec/contrib/rack/gateway/request.rb
+++ b/lib/datadog/appsec/contrib/rack/gateway/request.rb
@@ -47,6 +47,12 @@ module Datadog
               request.url
             end
 
+            def relative_uri
+              if (m = %r{^(?<scheme>[a-z]+)://(?<authority>[^/]+)?(?<relative_uri>/.*)}.match(url))
+                m['relative_uri']
+              end
+            end
+
             def cookies
               request.cookies
             end

--- a/lib/datadog/appsec/contrib/rack/reactive/request.rb
+++ b/lib/datadog/appsec/contrib/rack/reactive/request.rb
@@ -28,7 +28,7 @@ module Datadog
               end
             end
 
-            def self.subscribe(op, waf_context)
+            def self.subscribe(op, waf_context) # rubocop:disable Metrics/MethodLength
               op.subscribe(*ADDRESSES) do |*values|
                 Datadog.logger.debug { "reacted to #{ADDRESSES.inspect}: #{values.inspect}" }
                 headers = values[0]
@@ -38,10 +38,15 @@ module Datadog
                 cookies = values[3]
                 client_ip = values[4]
 
+                # rules such as coming from the passlist feature assume a relative URI
+                if uri_raw && (m = %r{^(?<scheme>[a-z]+)://(?<authority>[^/]+)?(?<relative_uri>/.*)}.match(uri_raw))
+                  relative_uri = m['relative_uri']
+                end
+
                 waf_args = {
                   'server.request.cookies' => cookies,
                   'server.request.query' => query,
-                  'server.request.uri.raw' => uri_raw,
+                  'server.request.uri.raw' => relative_uri,
                   'server.request.headers' => headers,
                   'server.request.headers.no_cookies' => headers_no_cookies,
                   'http.client_ip' => client_ip,

--- a/lib/datadog/appsec/contrib/rack/reactive/request.rb
+++ b/lib/datadog/appsec/contrib/rack/reactive/request.rb
@@ -20,7 +20,7 @@ module Datadog
               catch(:block) do
                 op.publish('request.query', gateway_request.query)
                 op.publish('request.headers', gateway_request.headers)
-                op.publish('request.uri.raw', gateway_request.relative_uri)
+                op.publish('request.uri.raw', gateway_request.fullpath)
                 op.publish('request.cookies', gateway_request.cookies)
                 op.publish('request.client_ip', gateway_request.client_ip)
 

--- a/lib/datadog/appsec/contrib/rack/reactive/request.rb
+++ b/lib/datadog/appsec/contrib/rack/reactive/request.rb
@@ -20,7 +20,7 @@ module Datadog
               catch(:block) do
                 op.publish('request.query', gateway_request.query)
                 op.publish('request.headers', gateway_request.headers)
-                op.publish('request.uri.raw', gateway_request.url)
+                op.publish('request.uri.raw', gateway_request.relative_uri)
                 op.publish('request.cookies', gateway_request.cookies)
                 op.publish('request.client_ip', gateway_request.client_ip)
 
@@ -28,7 +28,7 @@ module Datadog
               end
             end
 
-            def self.subscribe(op, waf_context) # rubocop:disable Metrics/MethodLength
+            def self.subscribe(op, waf_context)
               op.subscribe(*ADDRESSES) do |*values|
                 Datadog.logger.debug { "reacted to #{ADDRESSES.inspect}: #{values.inspect}" }
                 headers = values[0]
@@ -38,15 +38,10 @@ module Datadog
                 cookies = values[3]
                 client_ip = values[4]
 
-                # rules such as coming from the passlist feature assume a relative URI
-                if uri_raw && (m = %r{^(?<scheme>[a-z]+)://(?<authority>[^/]+)?(?<relative_uri>/.*)}.match(uri_raw))
-                  relative_uri = m['relative_uri']
-                end
-
                 waf_args = {
                   'server.request.cookies' => cookies,
                   'server.request.query' => query,
-                  'server.request.uri.raw' => relative_uri,
+                  'server.request.uri.raw' => uri_raw,
                   'server.request.headers' => headers,
                   'server.request.headers.no_cookies' => headers_no_cookies,
                   'http.client_ip' => client_ip,

--- a/spec/datadog/appsec/contrib/rack/gateway/request_spec.rb
+++ b/spec/datadog/appsec/contrib/rack/gateway/request_spec.rb
@@ -40,9 +40,15 @@ RSpec.describe Datadog::AppSec::Contrib::Rack::Gateway::Request do
     end
   end
 
-  describe '#uri' do
-    it 'returns the relative uri' do
-      expect(request.url).to eq('/?a=foo')
+  describe '#path' do
+    it 'returns the path' do
+      expect(request.path).to eq('/')
+    end
+  end
+
+  describe '#fullpath' do
+    it 'returns the path with query string' do
+      expect(request.fullpath).to eq('/?a=foo')
     end
   end
 

--- a/spec/datadog/appsec/contrib/rack/gateway/request_spec.rb
+++ b/spec/datadog/appsec/contrib/rack/gateway/request_spec.rb
@@ -40,6 +40,12 @@ RSpec.describe Datadog::AppSec::Contrib::Rack::Gateway::Request do
     end
   end
 
+  describe '#uri' do
+    it 'returns the relative uri' do
+      expect(request.url).to eq('/?a=foo')
+    end
+  end
+
   describe '#host' do
     it 'returns the host' do
       expect(request.host).to eq('example.com')

--- a/spec/datadog/appsec/contrib/rack/reactive/request_spec.rb
+++ b/spec/datadog/appsec/contrib/rack/reactive/request_spec.rb
@@ -52,7 +52,7 @@ RSpec.describe Datadog::AppSec::Contrib::Rack::Reactive::Request do
         expected_waf_arguments = {
           'server.request.cookies' => {},
           'server.request.query' => [{ 'a' => 'foo' }],
-          'server.request.uri.raw' => 'http://example.com:8080/?a=foo',
+          'server.request.uri.raw' => '/?a=foo',
           'server.request.headers' => { 'content-type' => 'text/html' },
           'server.request.headers.no_cookies' => { 'content-type' => 'text/html' },
           'http.client_ip' => '10.10.10.10'

--- a/spec/datadog/appsec/contrib/rack/reactive/request_spec.rb
+++ b/spec/datadog/appsec/contrib/rack/reactive/request_spec.rb
@@ -21,7 +21,7 @@ RSpec.describe Datadog::AppSec::Contrib::Rack::Reactive::Request do
     it 'propagates request attributes to the operation' do
       expect(operation).to receive(:publish).with('request.query', [{ 'a' => 'foo' }])
       expect(operation).to receive(:publish).with('request.headers', { 'content-type' => 'text/html' })
-      expect(operation).to receive(:publish).with('request.uri.raw', 'http://example.com:8080/?a=foo')
+      expect(operation).to receive(:publish).with('request.uri.raw', '/?a=foo')
       expect(operation).to receive(:publish).with('request.cookies', {})
       expect(operation).to receive(:publish).with('request.client_ip', '10.10.10.10')
       described_class.publish(operation, request)


### PR DESCRIPTION
<!--
Check out the
https://github.com/DataDog/dd-trace-rb/blob/master/docs/DevelopmentGuide.md
for guidance on how to set up your development environment,
run the test suite, write new integrations, and more.
-->

**What does this PR do?**

Reduce the raw URI to a relative URI

**Motivation**

Rules for path passlisting match against `server.request.uri.raw` but do not take into account absolute URIs (that include scheme and authority), instead assuming path only (or rather, relative URI, since strangely they could technically match against the query string, which is not part of the URI path definition). Witness the `regex:` key of such a rule:

```
 "conditions": [
    {
      "operator": "match_regex",
      "parameters": {
        "inputs": [
          {
            "address": "server.request.uri.raw"
          }
        ],
        "options": {
          "case_sensitive": false
        },
        "regex": "^/error.*"
      }
    }
  ],
```

Which should have read something like:

```
"regex": "^([a-z]+://[^/]+)?/error.*"
```

As a workaround we partially parse the URI and strip the scheme and authority components.

**Additional Notes**

None

**How to test the change?**

CI
