### PR TITLE
chore(test): rename system-tests scenario

### DIFF
--- a/.github/workflows/system-tests.yml
+++ b/.github/workflows/system-tests.yml
@@ -134,7 +134,7 @@ jobs:
         scenario:
           - DEFAULT
           - APPSEC_DISABLED
-          - APPSEC_IP_BLOCKING
+          - APPSEC_BLOCKING_FULL_DENYLIST
           - APPSEC_REQUEST_BLOCKING
         include:
           - library: ruby


### PR DESCRIPTION
<!--
Check out the
https://github.com/DataDog/dd-trace-rb/blob/master/docs/DevelopmentGuide.md
for guidance on how to set up your development environment,
run the test suite, write new integrations, and more.
-->

**What does this PR do?**
Following https://github.com/DataDog/system-tests/pull/1117, APPSEC_IP_BLOCKING and APPSEC_IP_BLOCKING_MAXED scenarios has been merged and renamed in APPSEC_BLOCKING_FULL_DENYLIST

**Motivation**
Do not keep legacy names


**How to test the change?**
System tests CI is green -> go
