### PR TITLE
[APPSEC-9935] AppSec, make sure to use service entry span.

### DIFF
--- a/lib/datadog/appsec/contrib/rails/gateway/watcher.rb
+++ b/lib/datadog/appsec/contrib/rails/gateway/watcher.rb
@@ -24,23 +24,20 @@ module Datadog
                   scope = gateway_request.env[Datadog::AppSec::Ext::SCOPE_KEY]
 
                   AppSec::Reactive::Operation.new('rails.request.action') do |op|
-                    trace = active_trace
-                    span = active_span
-
                     Rails::Reactive::Action.subscribe(op, scope.processor_context) do |result, _block|
                       if result.status == :match
                         # TODO: should this hash be an Event instance instead?
                         event = {
                           waf_result: result,
-                          trace: trace,
-                          span: span,
+                          trace: scope.trace,
+                          span: scope.service_entry_span,
                           request: gateway_request,
                           actions: result.actions
                         }
 
-                        if span
-                          span.set_tag('appsec.blocked', 'true') if result.actions.include?('block')
-                          span.set_tag('appsec.event', 'true')
+                        if scope.service_entry_span
+                          scope.service_entry_span.set_tag('appsec.blocked', 'true') if result.actions.include?('block')
+                          scope.service_entry_span.set_tag('appsec.event', 'true')
                         end
 
                         scope.processor_context.events << event
@@ -61,24 +58,6 @@ module Datadog
 
                   [ret, res]
                 end
-              end
-
-              private
-
-              def active_trace
-                # TODO: factor out tracing availability detection
-
-                return unless defined?(Datadog::Tracing)
-
-                Datadog::Tracing.active_trace
-              end
-
-              def active_span
-                # TODO: factor out tracing availability detection
-
-                return unless defined?(Datadog::Tracing)
-
-                Datadog::Tracing.active_span
               end
             end
           end

--- a/lib/datadog/appsec/contrib/sinatra/gateway/watcher.rb
+++ b/lib/datadog/appsec/contrib/sinatra/gateway/watcher.rb
@@ -26,23 +26,20 @@ module Datadog
                   scope = gateway_request.env[Datadog::AppSec::Ext::SCOPE_KEY]
 
                   AppSec::Reactive::Operation.new('sinatra.request.dispatch') do |op|
-                    trace = active_trace
-                    span = active_span
-
                     Rack::Reactive::RequestBody.subscribe(op, scope.processor_context) do |result, _block|
                       if result.status == :match
                         # TODO: should this hash be an Event instance instead?
                         event = {
                           waf_result: result,
-                          trace: trace,
-                          span: span,
+                          trace: scope.trace,
+                          span: scope.service_entry_span,
                           request: gateway_request,
                           actions: result.actions
                         }
 
-                        if span
-                          span.set_tag('appsec.blocked', 'true') if result.actions.include?('block')
-                          span.set_tag('appsec.event', 'true')
+                        if scope.service_entry_span
+                          scope.service_entry_span.set_tag('appsec.blocked', 'true') if result.actions.include?('block')
+                          scope.service_entry_span.set_tag('appsec.event', 'true')
                         end
 
                         scope.processor_context.events << event
@@ -72,23 +69,20 @@ module Datadog
                   scope = gateway_request.env[Datadog::AppSec::Ext::SCOPE_KEY]
 
                   AppSec::Reactive::Operation.new('sinatra.request.routed') do |op|
-                    trace = active_trace
-                    span = active_span
-
                     Sinatra::Reactive::Routed.subscribe(op, scope.processor_context) do |result, _block|
                       if result.status == :match
                         # TODO: should this hash be an Event instance instead?
                         event = {
                           waf_result: result,
-                          trace: trace,
-                          span: span,
+                          trace: scope.trace,
+                          span: scope.service_entry_span,
                           request: gateway_request,
                           actions: result.actions
                         }
 
-                        if span
-                          span.set_tag('appsec.blocked', 'true') if result.actions.include?('block')
-                          span.set_tag('appsec.event', 'true')
+                        if scope.service_entry_span
+                          scope.service_entry_span.set_tag('appsec.blocked', 'true') if result.actions.include?('block')
+                          scope.service_entry_span.set_tag('appsec.event', 'true')
                         end
 
                         scope.processor_context.events << event
@@ -109,24 +103,6 @@ module Datadog
 
                   [ret, res]
                 end
-              end
-
-              private
-
-              def active_trace
-                # TODO: factor out tracing availability detection
-
-                return unless defined?(Datadog::Tracing)
-
-                Datadog::Tracing.active_trace
-              end
-
-              def active_span
-                # TODO: factor out tracing availability detection
-
-                return unless defined?(Datadog::Tracing)
-
-                Datadog::Tracing.active_span
               end
             end
           end

--- a/sig/datadog/appsec/contrib/rack/gateway/watcher.rbs
+++ b/sig/datadog/appsec/contrib/rack/gateway/watcher.rbs
@@ -11,12 +11,6 @@ module Datadog
             def self.watch_response: (?Datadog::AppSec::Instrumentation::Gateway gateway) -> untyped
 
             def self.watch_request_body: (?Datadog::AppSec::Instrumentation::Gateway gateway) -> untyped
-
-            private
-
-            def self.active_trace: () -> (nil | untyped)
-
-            def self.active_span: () -> (nil | untyped)
           end
         end
       end

--- a/sig/datadog/appsec/contrib/rails/gateway/watcher.rbs
+++ b/sig/datadog/appsec/contrib/rails/gateway/watcher.rbs
@@ -7,12 +7,6 @@ module Datadog
             def self.watch: () -> untyped
 
             def self.watch_request_action: (?Datadog::AppSec::Instrumentation::Gateway gateway) -> untyped
-
-            private
-
-            def self.active_trace: () -> (nil | untyped)
-
-            def self.active_span: () -> (nil | untyped)
           end
         end
       end

--- a/sig/datadog/appsec/contrib/sinatra/gateway/watcher.rbs
+++ b/sig/datadog/appsec/contrib/sinatra/gateway/watcher.rbs
@@ -9,12 +9,6 @@ module Datadog
             def self.watch_request_dispatch: (?Datadog::AppSec::Instrumentation::Gateway gateway) -> untyped
 
             def self.watch_request_routed: (?Datadog::AppSec::Instrumentation::Gateway gateway) -> untyped
-
-            private
-
-            def self.active_trace: () -> (nil | untyped)
-
-            def self.active_span: () -> (nil | untyped)
           end
         end
       end

--- a/sig/datadog/appsec/monitor/gateway/watcher.rbs
+++ b/sig/datadog/appsec/monitor/gateway/watcher.rbs
@@ -6,12 +6,6 @@ module Datadog
           def self.watch: () -> untyped
 
           def self.watch_user_id: (?Datadog::AppSec::Instrumentation::Gateway gateway) -> untyped
-
-          private
-
-          def self.active_trace: () -> (nil | untyped)
-
-          def self.active_span: () -> (nil | untyped)
         end
       end
     end


### PR DESCRIPTION
<!--
Check out the
https://github.com/DataDog/dd-trace-rb/blob/master/docs/DevelopmentGuide.md
for guidance on how to set up your development environment,
run the test suite, write new integrations, and more.
-->

**What does this PR do?**
<!-- A brief description of the change being made with this pull request. -->

Use the `scope.service_entry_span` when tagging a span with appsec related tags.

**Motivation**
<!-- What inspired you to submit this pull request? -->

Make sure AppSec features work as expected, and confront to the system tests specs 

**Additional Notes**
<!-- Anything else we should know when reviewing? -->

**How to test the change?**
<!--
Describe here how the change can be validated.
You are strongly encouraged to provide automated tests for this PR (unit or integration).
If this change cannot be feasibly tested, please explain why,
unless the change does not modify code (e.g. only modifies docs, comments).
-->

CI
