### PR TITLE
[APPSEC-9936] Update AppSec response content_type resolution

### DIFF
--- a/lib/datadog/appsec/response.rb
+++ b/lib/datadog/appsec/response.rb
@@ -36,13 +36,13 @@ module Datadog
           Response.new(
             status: 403,
             headers: { 'Content-Type' => content_type },
-            body: [Datadog::AppSec::Assets.blocked(format: FORMAT_MAP[content_type])]
+            body: [Datadog::AppSec::Assets.blocked(format: CONTENT_TYPE_TO_FORMAT[content_type])]
           )
         end
 
         private
 
-        FORMAT_MAP = {
+        CONTENT_TYPE_TO_FORMAT = {
           'application/json' => :json,
           'text/html' => :html,
           'text/plain' => :text,
@@ -58,10 +58,12 @@ module Datadog
           accepted = accept_types.map { |m| Utils::HTTP::MediaRange.new(m) }.sort!.reverse!
 
           accepted.each do |range|
-            match = FORMAT_MAP.keys.find { |key| range === key }
+            type_match = CONTENT_TYPE_TO_FORMAT.keys.find { |type| range === type }
 
-            return match if match
+            return type_match if type_match
           end
+
+          DEFAULT_CONTENT_TYPE
         rescue Datadog::AppSec::Utils::HTTP::MediaRange::ParseError
           DEFAULT_CONTENT_TYPE
         end

--- a/lib/datadog/appsec/response.rb
+++ b/lib/datadog/appsec/response.rb
@@ -43,20 +43,22 @@ module Datadog
         private
 
         FORMAT_MAP = {
-          'text/plain' => :text,
-          'text/html' => :html,
           'application/json' => :json,
+          'text/html' => :html,
+          'text/plain' => :text,
         }.freeze
 
-        DEFAULT_CONTENT_TYPE = 'text/plain'
+        DEFAULT_CONTENT_TYPE = 'application/json'
 
         def content_type(env)
           return DEFAULT_CONTENT_TYPE unless env.key?('HTTP_ACCEPT')
 
-          accepted = env['HTTP_ACCEPT'].split(',').map { |m| Utils::HTTP::MediaRange.new(m) }.sort!.reverse!
+          accept_types = env['HTTP_ACCEPT'].split(',').map(&:strip)
 
-          accepted.each_with_object(DEFAULT_CONTENT_TYPE) do |range, _default|
-            match = FORMAT_MAP.keys.find { |type| range === type }
+          accepted = accept_types.map { |m| Utils::HTTP::MediaRange.new(m) }.sort!.reverse!
+
+          accepted.each do |range|
+            match = FORMAT_MAP.keys.find { |key| range === key }
 
             return match if match
           end

--- a/sig/datadog/appsec/response.rbs
+++ b/sig/datadog/appsec/response.rbs
@@ -14,7 +14,7 @@ module Datadog
 
       private
 
-      FORMAT_MAP: ::Hash[::String, ::Symbol]
+      CONTENT_TYPE_TO_FORMAT: ::Hash[::String, ::Symbol]
       DEFAULT_CONTENT_TYPE: ::String
 
       def self.format: (::Hash[untyped, untyped] env) -> ::Symbol

--- a/spec/datadog/appsec/response_spec.rb
+++ b/spec/datadog/appsec/response_spec.rb
@@ -74,19 +74,37 @@ RSpec.describe Datadog::AppSec::Response do
       end
 
       context('without Accept header') do
-        it { is_expected.to eq 'text/plain' }
+        it { is_expected.to eq 'application/json' }
       end
 
       context('with Accept: */*') do
         let(:accept) { '*/*' }
 
-        it { is_expected.to eq 'text/plain' }
+        it { is_expected.to eq 'application/json' }
+      end
+
+      context('with Accept: text/*') do
+        let(:accept) { 'text/*' }
+
+        it { is_expected.to eq 'text/html' }
+      end
+
+      context('with Accept: application/*') do
+        let(:accept) { 'application/*' }
+
+        it { is_expected.to eq 'application/json' }
       end
 
       context('with unparseable Accept header') do
         let(:accept) { 'invalid' }
 
-        it { is_expected.to eq 'text/plain' }
+        it { is_expected.to eq 'application/json' }
+      end
+
+      context('with Accept: text/*;q=0.7, application/*;q=0.8, */*;q=0.9') do
+        let(:accept) { 'text/*;q=0.7, application/*;q=0.8, */*;q=0.9' }
+
+        it { is_expected.to eq 'application/json' }
       end
 
       context('with Mozilla Firefox Accept') do

--- a/spec/datadog/appsec/response_spec.rb
+++ b/spec/datadog/appsec/response_spec.rb
@@ -107,6 +107,12 @@ RSpec.describe Datadog::AppSec::Response do
         it { is_expected.to eq 'application/json' }
       end
 
+      context('with unsupported Accept header') do
+        let(:accept) { 'image/webp' }
+
+        it { is_expected.to eq 'application/json' }
+      end
+
       context('with Mozilla Firefox Accept') do
         let(:accept) { 'text/html,application/xhtml+xml,application/xml;q=0.9,image/avif,image/webp,*/*;q=0.8' }
 


### PR DESCRIPTION
<!--
Check out the
https://github.com/DataDog/dd-trace-rb/blob/master/docs/DevelopmentGuide.md
for guidance on how to set up your development environment,
run the test suite, write new integrations, and more.
-->

**What does this PR do?**
<!-- A brief description of the change being made with this pull request. -->

Based on the [internal] specs. The default content type and the response of the blocked page should be `JSON`. 

I update the code that handles that, I also added a bunch os new specs. I fixed an issue in which spaces between the `,` for separating multiple HTTP accept values.

**Motivation**
<!-- What inspired you to submit this pull request? -->

**Additional Notes**
<!-- Anything else we should know when reviewing? -->

**How to test the change?**
<!--
Describe here how the change can be validated.
You are strongly encouraged to provide automated tests for this PR (unit or integration).
If this change cannot be feasibly tested, please explain why,
unless the change does not modify code (e.g. only modifies docs, comments).
-->

CI
