### PR TITLE
[APPSEC-10049] Appsec handle tracing disabled and appsec events

### DIFF
--- a/lib/datadog/appsec/contrib/rack/request_middleware.rb
+++ b/lib/datadog/appsec/contrib/rack/request_middleware.rb
@@ -53,7 +53,7 @@ module Datadog
 
             gateway_request = Gateway::Request.new(env)
 
-            add_appsec_tags(processor, scope.trace, scope.service_entry_span, env)
+            add_appsec_tags(processor, scope, env)
 
             request_return, request_response = catch(::Datadog::AppSec::Ext::INTERRUPT) do
               Instrumentation.gateway.push('rack.request', gateway_request) do
@@ -88,7 +88,7 @@ module Datadog
             request_return
           ensure
             if scope
-              add_waf_runtime_tags(scope.service_entry_span, scope.processor_context)
+              add_waf_runtime_tags(scope)
               Datadog::AppSec::Scope.deactivate_scope
             end
           end
@@ -116,8 +116,11 @@ module Datadog
             Datadog::Tracing.active_span
           end
 
-          def add_appsec_tags(processor, trace, span, env)
-            return unless trace
+          def add_appsec_tags(processor, scope, env)
+            span = scope.service_entry_span
+            trace = scope.trace
+
+            return unless trace && span
 
             span.set_tag('_dd.appsec.enabled', 1)
             span.set_tag('_dd.runtime_family', 'ruby')
@@ -157,9 +160,11 @@ module Datadog
             end
           end
 
-          def add_waf_runtime_tags(span, context)
-            return unless span
-            return unless context
+          def add_waf_runtime_tags(scope)
+            span = scope.service_entry_span
+            context = scope.processor_context
+
+            return unless span && context
 
             span.set_tag('_dd.appsec.waf.timeouts', context.timeouts)
 

--- a/lib/datadog/appsec/event.rb
+++ b/lib/datadog/appsec/event.rb
@@ -40,7 +40,7 @@ module Datadog
       # to properly apply
       def self.record(span, *events)
         # ensure rate limiter is called only when there are events to record
-        return if events.empty?
+        return if events.empty? || span.nil?
 
         Datadog::AppSec::RateLimiter.limit(:traces) do
           record_via_span(span, *events)

--- a/lib/datadog/kit/appsec/events.rb
+++ b/lib/datadog/kit/appsec/events.rb
@@ -27,24 +27,16 @@ module Datadog
           # @param others [Hash<String || Symbol, String>] Additional free-form
           #   event information to attach to the trace.
           def track_login_success(trace = nil, span = nil, user:, **others)
-            if (appsec_scope = Datadog::AppSec.active_scope)
-              trace = appsec_scope.trace
-              span = appsec_scope.service_entry_span
+            set_trace_and_span_context('track_login_success', trace, span) do |active_trace, active_span|
+              track(LOGIN_SUCCESS_EVENT, active_trace, active_span, **others)
+
+              user_options = user.dup
+              user_id = user_options.delete(:id)
+
+              raise ArgumentError, 'missing required key: :user => { :id }' if user_id.nil?
+
+              Kit::Identity.set_user(active_trace, active_span, id: user_id, **user_options)
             end
-
-            trace ||= Datadog::Tracing.active_trace
-            span ||= trace.active_span || Datadog::Tracing.active_span
-
-            raise ArgumentError, "span #{span.span_id} does not belong to trace #{trace.id}" if trace.id != span.trace_id
-
-            track(LOGIN_SUCCESS_EVENT, trace, span, **others)
-
-            user_options = user.dup
-            user_id = user_options.delete(:id)
-
-            raise ArgumentError, 'missing required key: :user => { :id }' if user_id.nil?
-
-            Kit::Identity.set_user(trace, span, id: user_id, **user_options)
           end
 
           # Attach login failure event information to the trace
@@ -62,22 +54,14 @@ module Datadog
           # @param others [Hash<String || Symbol, String>] Additional free-form
           #   event information to attach to the trace.
           def track_login_failure(trace = nil, span = nil, user_id:, user_exists:, **others)
-            if (appsec_scope = Datadog::AppSec.active_scope)
-              trace = appsec_scope.trace
-              span = appsec_scope.service_entry_span
+            set_trace_and_span_context('track_login_failure', trace, span) do |active_trace, active_span|
+              track(LOGIN_FAILURE_EVENT, active_trace, active_span, **others)
+
+              raise ArgumentError, 'user_id cannot be nil' if user_id.nil?
+
+              active_span.set_tag('appsec.events.users.login.failure.usr.id', user_id)
+              active_span.set_tag('appsec.events.users.login.failure.usr.exists', user_exists)
             end
-
-            trace ||= Datadog::Tracing.active_trace
-            span ||= trace.active_span || Datadog::Tracing.active_span
-
-            raise ArgumentError, "span #{span.span_id} does not belong to trace #{trace.id}" if trace.id != span.trace_id
-
-            track(LOGIN_FAILURE_EVENT, trace, span, **others)
-
-            raise ArgumentError, 'user_id cannot be nil' if user_id.nil?
-
-            span.set_tag('appsec.events.users.login.failure.usr.id', user_id)
-            span.set_tag('appsec.events.users.login.failure.usr.exists', user_exists)
           end
 
           # Attach signup event information to the trace
@@ -95,23 +79,16 @@ module Datadog
           # @param others [Hash<String || Symbol, String>] Additional free-form
           #   event information to attach to the trace.
           def track_signup(trace = nil, span = nil, user:, **others)
-            user_options = user.dup
-            user_id = user_options.delete(:id)
+            set_trace_and_span_context('track_signup', trace, span) do |active_trace, active_span|
+              user_options = user.dup
+              user_id = user_options.delete(:id)
 
-            raise ArgumentError, 'missing required key: :user => { :id }' if user_id.nil?
+              raise ArgumentError, 'missing required key: :user => { :id }' if user_id.nil?
 
-            if (appsec_scope = Datadog::AppSec.active_scope)
-              trace = appsec_scope.trace
-              span = appsec_scope.service_entry_span
+              track(SIGNUP_EVENT, active_trace, active_span, **others)
+
+              Kit::Identity.set_user(trace, id: user_id, **user_options)
             end
-
-            trace ||= Datadog::Tracing.active_trace
-            span ||= trace.active_span || Datadog::Tracing.active_span
-
-            raise ArgumentError, "span #{span.span_id} does not belong to trace #{trace.id}" if trace.id != span.trace_id
-
-            track(SIGNUP_EVENT, trace, **others)
-            Kit::Identity.set_user(trace, id: user_id, **user_options)
           end
 
           # Attach custom event information to the trace
@@ -129,26 +106,61 @@ module Datadog
           #   event information to attach to the trace. Key must not
           #   be :track.
           def track(event, trace = nil, span = nil, **others)
+            if trace && span
+              check_trace_span_integrity(trace, span)
+
+              span.set_tag("appsec.events.#{event}.track", 'true')
+              span.set_tag("_dd.appsec.appsec.events.#{event}.sdk", 'true')
+
+              others.each do |k, v|
+                raise ArgumentError, 'key cannot be :track' if k.to_sym == :track
+
+                span.set_tag("appsec.events.#{event}.#{k}", v) unless v.nil?
+              end
+
+              trace.keep!
+            else
+              set_trace_and_span_context('track', trace, span) do |active_trace, active_span|
+                active_span.set_tag("appsec.events.#{event}.track", 'true')
+                active_span.set_tag("_dd.appsec.appsec.events.#{event}.sdk", 'true')
+
+                others.each do |k, v|
+                  raise ArgumentError, 'key cannot be :track' if k.to_sym == :track
+
+                  active_span.set_tag("appsec.events.#{event}.#{k}", v) unless v.nil?
+                end
+
+                active_trace.keep!
+              end
+            end
+          end
+
+          private
+
+          def set_trace_and_span_context(method, trace = nil, span = nil)
             if (appsec_scope = Datadog::AppSec.active_scope)
               trace = appsec_scope.trace
               span = appsec_scope.service_entry_span
             end
 
             trace ||= Datadog::Tracing.active_trace
-            span ||= trace.active_span || Datadog::Tracing.active_span
+            span ||=  trace && trace.active_span || Datadog::Tracing.active_span
 
-            raise ArgumentError, "span #{span.span_id} does not belong to trace #{trace.id}" if trace.id != span.trace_id
-
-            span.set_tag("appsec.events.#{event}.track", 'true')
-            span.set_tag("_dd.appsec.appsec.events.#{event}.sdk", 'true')
-
-            others.each do |k, v|
-              raise ArgumentError, 'key cannot be :track' if k.to_sym == :track
-
-              span.set_tag("appsec.events.#{event}.#{k}", v) unless v.nil?
+            unless trace && span
+              Datadog.logger.debug(
+                "Tracing not enabled. Method ##{method} is a no-op. Please enmnable tracing if you want ##{method}"\
+                ' to set information on the span'
+              )
+              return
             end
 
-            trace.keep!
+            check_trace_span_integrity(trace, span)
+
+            yield(trace, span)
+          end
+
+          def check_trace_span_integrity(trace, span)
+            raise ArgumentError, "span #{span.span_id} does not belong to trace #{trace.id}" if trace.id != span.trace_id
           end
         end
       end

--- a/lib/datadog/kit/appsec/events.rb
+++ b/lib/datadog/kit/appsec/events.rb
@@ -28,12 +28,12 @@ module Datadog
           #   event information to attach to the trace.
           def track_login_success(trace = nil, span = nil, user:, **others)
             set_trace_and_span_context('track_login_success', trace, span) do |active_trace, active_span|
-              track(LOGIN_SUCCESS_EVENT, active_trace, active_span, **others)
-
               user_options = user.dup
               user_id = user_options.delete(:id)
 
               raise ArgumentError, 'missing required key: :user => { :id }' if user_id.nil?
+
+              track(LOGIN_SUCCESS_EVENT, active_trace, active_span, **others)
 
               Kit::Identity.set_user(active_trace, active_span, id: user_id, **user_options)
             end
@@ -55,9 +55,9 @@ module Datadog
           #   event information to attach to the trace.
           def track_login_failure(trace = nil, span = nil, user_id:, user_exists:, **others)
             set_trace_and_span_context('track_login_failure', trace, span) do |active_trace, active_span|
-              track(LOGIN_FAILURE_EVENT, active_trace, active_span, **others)
-
               raise ArgumentError, 'user_id cannot be nil' if user_id.nil?
+
+              track(LOGIN_FAILURE_EVENT, active_trace, active_span, **others)
 
               active_span.set_tag('appsec.events.users.login.failure.usr.id', user_id)
               active_span.set_tag('appsec.events.users.login.failure.usr.exists', user_exists)

--- a/lib/datadog/kit/appsec/events.rb
+++ b/lib/datadog/kit/appsec/events.rb
@@ -148,8 +148,8 @@ module Datadog
 
             unless trace && span
               Datadog.logger.debug(
-                "Tracing not enabled. Method ##{method} is a no-op. Please enmnable tracing if you want ##{method}"\
-                ' to set information on the span'
+                "Tracing not enabled. Method ##{method} is a no-op. Please enable tracing if you want ##{method}"\
+                ' to track this events'
               )
               return
             end

--- a/lib/datadog/kit/appsec/events.rb
+++ b/lib/datadog/kit/appsec/events.rb
@@ -11,143 +11,145 @@ module Datadog
         LOGIN_FAILURE_EVENT = 'users.login.failure'
         SIGNUP_EVENT = 'users.signup'
 
-        # Attach login success event information to the trace
-        #
-        # This method is experimental and may change in the future.
-        #
-        # @param trace [TraceOperation] Trace to attach data to. Defaults to
-        #   active trace.
-        # @param span [SpanOperation] Span to attach data to. Defaults to
-        #   active span on trace. Note that this should be a service entry span.
-        #   When AppSec is enabled, the expected span and trace are automatically
-        #   used as defaults.
-        # @param user [Hash<Symbol, String>] User information to pass to
-        #   Datadog::Kit::Identity.set_user. Must contain at least :id as key.
-        # @param others [Hash<String || Symbol, String>] Additional free-form
-        #   event information to attach to the trace.
-        def self.track_login_success(trace = nil, span = nil, user:, **others)
-          if (appsec_scope = Datadog::AppSec.active_scope)
-            trace = appsec_scope.trace
-            span = appsec_scope.service_entry_span
+        class << self
+          # Attach login success event information to the trace
+          #
+          # This method is experimental and may change in the future.
+          #
+          # @param trace [TraceOperation] Trace to attach data to. Defaults to
+          #   active trace.
+          # @param span [SpanOperation] Span to attach data to. Defaults to
+          #   active span on trace. Note that this should be a service entry span.
+          #   When AppSec is enabled, the expected span and trace are automatically
+          #   used as defaults.
+          # @param user [Hash<Symbol, String>] User information to pass to
+          #   Datadog::Kit::Identity.set_user. Must contain at least :id as key.
+          # @param others [Hash<String || Symbol, String>] Additional free-form
+          #   event information to attach to the trace.
+          def track_login_success(trace = nil, span = nil, user:, **others)
+            if (appsec_scope = Datadog::AppSec.active_scope)
+              trace = appsec_scope.trace
+              span = appsec_scope.service_entry_span
+            end
+
+            trace ||= Datadog::Tracing.active_trace
+            span ||= trace.active_span || Datadog::Tracing.active_span
+
+            raise ArgumentError, "span #{span.span_id} does not belong to trace #{trace.id}" if trace.id != span.trace_id
+
+            track(LOGIN_SUCCESS_EVENT, trace, span, **others)
+
+            user_options = user.dup
+            user_id = user_options.delete(:id)
+
+            raise ArgumentError, 'missing required key: :user => { :id }' if user_id.nil?
+
+            Kit::Identity.set_user(trace, span, id: user_id, **user_options)
           end
 
-          trace ||= Datadog::Tracing.active_trace
-          span ||= trace.active_span || Datadog::Tracing.active_span
+          # Attach login failure event information to the trace
+          #
+          # This method is experimental and may change in the future.
+          #
+          # @param trace [TraceOperation] Trace to attach data to. Defaults to
+          #   active trace.
+          # @param span [SpanOperation] Span to attach data to. Defaults to
+          #   active span on trace. Note that this should be a service entry span.
+          #   When AppSec is enabled, the expected span and trace are automatically
+          #   used as defaults.
+          # @param user_id [String] User id that attempted login
+          # @param user_exists [bool] Whether the user id that did a login attempt exists.
+          # @param others [Hash<String || Symbol, String>] Additional free-form
+          #   event information to attach to the trace.
+          def track_login_failure(trace = nil, span = nil, user_id:, user_exists:, **others)
+            if (appsec_scope = Datadog::AppSec.active_scope)
+              trace = appsec_scope.trace
+              span = appsec_scope.service_entry_span
+            end
 
-          raise ArgumentError, "span #{span.span_id} does not belong to trace #{trace.id}" if trace.id != span.trace_id
+            trace ||= Datadog::Tracing.active_trace
+            span ||= trace.active_span || Datadog::Tracing.active_span
 
-          track(LOGIN_SUCCESS_EVENT, trace, span, **others)
+            raise ArgumentError, "span #{span.span_id} does not belong to trace #{trace.id}" if trace.id != span.trace_id
 
-          user_options = user.dup
-          user_id = user_options.delete(:id)
+            track(LOGIN_FAILURE_EVENT, trace, span, **others)
 
-          raise ArgumentError, 'missing required key: :user => { :id }' if user_id.nil?
+            raise ArgumentError, 'user_id cannot be nil' if user_id.nil?
 
-          Kit::Identity.set_user(trace, span, id: user_id, **user_options)
-        end
-
-        # Attach login failure event information to the trace
-        #
-        # This method is experimental and may change in the future.
-        #
-        # @param trace [TraceOperation] Trace to attach data to. Defaults to
-        #   active trace.
-        # @param span [SpanOperation] Span to attach data to. Defaults to
-        #   active span on trace. Note that this should be a service entry span.
-        #   When AppSec is enabled, the expected span and trace are automatically
-        #   used as defaults.
-        # @param user_id [String] User id that attempted login
-        # @param user_exists [bool] Whether the user id that did a login attempt exists.
-        # @param others [Hash<String || Symbol, String>] Additional free-form
-        #   event information to attach to the trace.
-        def self.track_login_failure(trace = nil, span = nil, user_id:, user_exists:, **others)
-          if (appsec_scope = Datadog::AppSec.active_scope)
-            trace = appsec_scope.trace
-            span = appsec_scope.service_entry_span
+            span.set_tag('appsec.events.users.login.failure.usr.id', user_id)
+            span.set_tag('appsec.events.users.login.failure.usr.exists', user_exists)
           end
 
-          trace ||= Datadog::Tracing.active_trace
-          span ||= trace.active_span || Datadog::Tracing.active_span
+          # Attach signup event information to the trace
+          #
+          # This method is experimental and may change in the future.
+          #
+          # @param trace [TraceOperation] Trace to attach data to. Defaults to
+          #   active trace.
+          # @param span [SpanOperation] Span to attach data to. Defaults to
+          #   active span on trace. Note that this should be a service entry span.
+          #   When AppSec is enabled, the expected span and trace are automatically
+          #   used as defaults.
+          # @param user [Hash<Symbol, String>] User information to pass to
+          #   Datadog::Kit::Identity.set_user. Must contain at least :id as key.
+          # @param others [Hash<String || Symbol, String>] Additional free-form
+          #   event information to attach to the trace.
+          def track_signup(trace = nil, span = nil, user:, **others)
+            user_options = user.dup
+            user_id = user_options.delete(:id)
 
-          raise ArgumentError, "span #{span.span_id} does not belong to trace #{trace.id}" if trace.id != span.trace_id
+            raise ArgumentError, 'missing required key: :user => { :id }' if user_id.nil?
 
-          track(LOGIN_FAILURE_EVENT, trace, span, **others)
+            if (appsec_scope = Datadog::AppSec.active_scope)
+              trace = appsec_scope.trace
+              span = appsec_scope.service_entry_span
+            end
 
-          raise ArgumentError, 'user_id cannot be nil' if user_id.nil?
+            trace ||= Datadog::Tracing.active_trace
+            span ||= trace.active_span || Datadog::Tracing.active_span
 
-          span.set_tag('appsec.events.users.login.failure.usr.id', user_id)
-          span.set_tag('appsec.events.users.login.failure.usr.exists', user_exists)
-        end
+            raise ArgumentError, "span #{span.span_id} does not belong to trace #{trace.id}" if trace.id != span.trace_id
 
-        # Attach signup event information to the trace
-        #
-        # This method is experimental and may change in the future.
-        #
-        # @param trace [TraceOperation] Trace to attach data to. Defaults to
-        #   active trace.
-        # @param span [SpanOperation] Span to attach data to. Defaults to
-        #   active span on trace. Note that this should be a service entry span.
-        #   When AppSec is enabled, the expected span and trace are automatically
-        #   used as defaults.
-        # @param user [Hash<Symbol, String>] User information to pass to
-        #   Datadog::Kit::Identity.set_user. Must contain at least :id as key.
-        # @param others [Hash<String || Symbol, String>] Additional free-form
-        #   event information to attach to the trace.
-        def self.track_signup(trace = nil, span = nil, user:, **others)
-          user_options = user.dup
-          user_id = user_options.delete(:id)
-
-          raise ArgumentError, 'missing required key: :user => { :id }' if user_id.nil?
-
-          if (appsec_scope = Datadog::AppSec.active_scope)
-            trace = appsec_scope.trace
-            span = appsec_scope.service_entry_span
+            track(SIGNUP_EVENT, trace, **others)
+            Kit::Identity.set_user(trace, id: user_id, **user_options)
           end
 
-          trace ||= Datadog::Tracing.active_trace
-          span ||= trace.active_span || Datadog::Tracing.active_span
+          # Attach custom event information to the trace
+          #
+          # This method is experimental and may change in the future.
+          #
+          # @param event [String] Mandatory. Event code.
+          # @param trace [TraceOperation] Trace to attach data to. Defaults to
+          #   active trace.
+          # @param span [SpanOperation] Span to attach data to. Defaults to
+          #   active span on trace. Note that this should be a service entry span.
+          #   When AppSec is enabled, the expected span and trace are automatically
+          #   used as defaults.
+          # @param others [Hash<Symbol, String>] Additional free-form
+          #   event information to attach to the trace. Key must not
+          #   be :track.
+          def track(event, trace = nil, span = nil, **others)
+            if (appsec_scope = Datadog::AppSec.active_scope)
+              trace = appsec_scope.trace
+              span = appsec_scope.service_entry_span
+            end
 
-          raise ArgumentError, "span #{span.span_id} does not belong to trace #{trace.id}" if trace.id != span.trace_id
+            trace ||= Datadog::Tracing.active_trace
+            span ||= trace.active_span || Datadog::Tracing.active_span
 
-          track(SIGNUP_EVENT, trace, **others)
-          Kit::Identity.set_user(trace, id: user_id, **user_options)
-        end
+            raise ArgumentError, "span #{span.span_id} does not belong to trace #{trace.id}" if trace.id != span.trace_id
 
-        # Attach custom event information to the trace
-        #
-        # This method is experimental and may change in the future.
-        #
-        # @param event [String] Mandatory. Event code.
-        # @param trace [TraceOperation] Trace to attach data to. Defaults to
-        #   active trace.
-        # @param span [SpanOperation] Span to attach data to. Defaults to
-        #   active span on trace. Note that this should be a service entry span.
-        #   When AppSec is enabled, the expected span and trace are automatically
-        #   used as defaults.
-        # @param others [Hash<Symbol, String>] Additional free-form
-        #   event information to attach to the trace. Key must not
-        #   be :track.
-        def self.track(event, trace = nil, span = nil, **others)
-          if (appsec_scope = Datadog::AppSec.active_scope)
-            trace = appsec_scope.trace
-            span = appsec_scope.service_entry_span
+            span.set_tag("appsec.events.#{event}.track", 'true')
+            span.set_tag("_dd.appsec.appsec.events.#{event}.sdk", 'true')
+
+            others.each do |k, v|
+              raise ArgumentError, 'key cannot be :track' if k.to_sym == :track
+
+              span.set_tag("appsec.events.#{event}.#{k}", v) unless v.nil?
+            end
+
+            trace.keep!
           end
-
-          trace ||= Datadog::Tracing.active_trace
-          span ||= trace.active_span || Datadog::Tracing.active_span
-
-          raise ArgumentError, "span #{span.span_id} does not belong to trace #{trace.id}" if trace.id != span.trace_id
-
-          span.set_tag("appsec.events.#{event}.track", 'true')
-          span.set_tag("_dd.appsec.appsec.events.#{event}.sdk", 'true')
-
-          others.each do |k, v|
-            raise ArgumentError, 'key cannot be :track' if k.to_sym == :track
-
-            span.set_tag("appsec.events.#{event}.#{k}", v) unless v.nil?
-          end
-
-          trace.keep!
         end
       end
     end

--- a/lib/datadog/kit/identity.rb
+++ b/lib/datadog/kit/identity.rb
@@ -6,84 +6,86 @@ module Datadog
   module Kit
     # Tracking identity via traces
     module Identity
-      # Attach user information to the trace
-      #
-      # @param trace [TraceOperation] Trace to attach data to. Defaults to
-      #   active trace.
-      # @param span [SpanOperation] Span to attach data to. Defaults to
-      #   active span on trace. Note that this should be a service entry span.
-      #   When AppSec is enabled, the expected span and trace are automatically
-      #   used as defaults.
-      # @param id [String] Mandatory. Username or client id extracted
-      #   from the access token or Authorization header in the inbound request
-      #   from outside the system.
-      # @param email [String] Email of the authenticated user associated
-      #   to the trace.
-      # @param name [String] User-friendly name. To be displayed in the
-      #   UI if set.
-      # @param session_id [String] Session ID of the authenticated user.
-      # @param role [String] Actual/assumed role the client is making
-      #   the request under extracted from token or application security
-      #   context.
-      # @param scope [String] Scopes or granted authorities the client
-      #   currently possesses extracted from token or application security
-      #   context. The value would come from the scope associated with an OAuth
-      #   2.0 Access Token or an attribute value in a SAML 2.0 Assertion.
-      # @param others [Hash<Symbol, String>] Additional free-form
-      #   user information to attach to the trace.
-      #
-      # rubocop:disable Metrics/CyclomaticComplexity
-      # rubocop:disable Metrics/PerceivedComplexity
-      # rubocop:disable Metrics/AbcSize
-      def self.set_user(
-        trace = nil, span = nil, id:, email: nil, name: nil, session_id: nil, role: nil, scope: nil, **others
-      )
-        raise ArgumentError, 'missing required key: :id' if id.nil?
+      class << self
+        # Attach user information to the trace
+        #
+        # @param trace [TraceOperation] Trace to attach data to. Defaults to
+        #   active trace.
+        # @param span [SpanOperation] Span to attach data to. Defaults to
+        #   active span on trace. Note that this should be a service entry span.
+        #   When AppSec is enabled, the expected span and trace are automatically
+        #   used as defaults.
+        # @param id [String] Mandatory. Username or client id extracted
+        #   from the access token or Authorization header in the inbound request
+        #   from outside the system.
+        # @param email [String] Email of the authenticated user associated
+        #   to the trace.
+        # @param name [String] User-friendly name. To be displayed in the
+        #   UI if set.
+        # @param session_id [String] Session ID of the authenticated user.
+        # @param role [String] Actual/assumed role the client is making
+        #   the request under extracted from token or application security
+        #   context.
+        # @param scope [String] Scopes or granted authorities the client
+        #   currently possesses extracted from token or application security
+        #   context. The value would come from the scope associated with an OAuth
+        #   2.0 Access Token or an attribute value in a SAML 2.0 Assertion.
+        # @param others [Hash<Symbol, String>] Additional free-form
+        #   user information to attach to the trace.
+        #
+        # rubocop:disable Metrics/CyclomaticComplexity
+        # rubocop:disable Metrics/PerceivedComplexity
+        # rubocop:disable Metrics/AbcSize
+        def set_user(
+          trace = nil, span = nil, id:, email: nil, name: nil, session_id: nil, role: nil, scope: nil, **others
+        )
+          raise ArgumentError, 'missing required key: :id' if id.nil?
 
-        # enforce types
+          # enforce types
 
-        raise TypeError, ':id must be a String'         unless id.is_a?(String)
-        raise TypeError, ':email must be a String'      unless email.nil? || email.is_a?(String)
-        raise TypeError, ':name must be a String'       unless name.nil? || name.is_a?(String)
-        raise TypeError, ':session_id must be a String' unless session_id.nil? || session_id.is_a?(String)
-        raise TypeError, ':role must be a String'       unless role.nil? || role.is_a?(String)
-        raise TypeError, ':scope must be a String'      unless scope.nil? || scope.is_a?(String)
+          raise TypeError, ':id must be a String'         unless id.is_a?(String)
+          raise TypeError, ':email must be a String'      unless email.nil? || email.is_a?(String)
+          raise TypeError, ':name must be a String'       unless name.nil? || name.is_a?(String)
+          raise TypeError, ':session_id must be a String' unless session_id.nil? || session_id.is_a?(String)
+          raise TypeError, ':role must be a String'       unless role.nil? || role.is_a?(String)
+          raise TypeError, ':scope must be a String'      unless scope.nil? || scope.is_a?(String)
 
-        others.each do |k, v|
-          raise TypeError, "#{k.inspect} must be a String" unless v.nil? || v.is_a?(String)
+          others.each do |k, v|
+            raise TypeError, "#{k.inspect} must be a String" unless v.nil? || v.is_a?(String)
+          end
+
+          if (appsec_scope = Datadog::AppSec.active_scope)
+            trace = appsec_scope.trace
+            span = appsec_scope.service_entry_span
+          end
+
+          trace ||= Datadog::Tracing.active_trace
+          span ||= trace.active_span || Datadog::Tracing.active_span
+
+          raise ArgumentError, "span #{span.span_id} does not belong to trace #{trace.id}" if trace.id != span.trace_id
+
+          # set tags once data is known consistent
+
+          span.set_tag('usr.id', id)
+          span.set_tag('usr.email', email)           unless email.nil?
+          span.set_tag('usr.name', name)             unless name.nil?
+          span.set_tag('usr.session_id', session_id) unless session_id.nil?
+          span.set_tag('usr.role', role)             unless role.nil?
+          span.set_tag('usr.scope', scope)           unless scope.nil?
+
+          others.each do |k, v|
+            span.set_tag("usr.#{k}", v) unless v.nil?
+          end
+
+          if appsec_scope
+            user = ::Datadog::AppSec::Instrumentation::Gateway::User.new(id)
+            ::Datadog::AppSec::Instrumentation.gateway.push('identity.set_user', user)
+          end
         end
-
-        if (appsec_scope = Datadog::AppSec.active_scope)
-          trace = appsec_scope.trace
-          span = appsec_scope.service_entry_span
-        end
-
-        trace ||= Datadog::Tracing.active_trace
-        span ||= trace.active_span || Datadog::Tracing.active_span
-
-        raise ArgumentError, "span #{span.span_id} does not belong to trace #{trace.id}" if trace.id != span.trace_id
-
-        # set tags once data is known consistent
-
-        span.set_tag('usr.id', id)
-        span.set_tag('usr.email', email)           unless email.nil?
-        span.set_tag('usr.name', name)             unless name.nil?
-        span.set_tag('usr.session_id', session_id) unless session_id.nil?
-        span.set_tag('usr.role', role)             unless role.nil?
-        span.set_tag('usr.scope', scope)           unless scope.nil?
-
-        others.each do |k, v|
-          span.set_tag("usr.#{k}", v) unless v.nil?
-        end
-
-        if appsec_scope
-          user = ::Datadog::AppSec::Instrumentation::Gateway::User.new(id)
-          ::Datadog::AppSec::Instrumentation.gateway.push('identity.set_user', user)
-        end
+        # rubocop:enable Metrics/AbcSize
+        # rubocop:enable Metrics/PerceivedComplexity
+        # rubocop:enable Metrics/CyclomaticComplexity
       end
-      # rubocop:enable Metrics/AbcSize
-      # rubocop:enable Metrics/PerceivedComplexity
-      # rubocop:enable Metrics/CyclomaticComplexity
     end
   end
 end

--- a/lib/datadog/kit/identity.rb
+++ b/lib/datadog/kit/identity.rb
@@ -88,8 +88,8 @@ module Datadog
 
           unless trace && span
             Datadog.logger.debug(
-              "Tracing not enabled. Method ##{method} is a no-op. Please enmnable tracing if you want ##{method}"\
-              ' to set information on the span'
+              "Tracing not enabled. Method ##{method} is a no-op. Please enable tracing if you want ##{method}"\
+              ' to track this events'
             )
             return
           end

--- a/spec/datadog/appsec/contrib/rack/integration_test_spec.rb
+++ b/spec/datadog/appsec/contrib/rack/integration_test_spec.rb
@@ -214,7 +214,6 @@ RSpec.describe 'Rack integration tests' do
 
       before do
         response
-        expect(spans).to have(1).items
       end
 
       describe 'GET request' do
@@ -228,6 +227,7 @@ RSpec.describe 'Rack integration tests' do
         context 'with a non-event-triggering request' do
           it { is_expected.to be_ok }
 
+          it_behaves_like 'normal with tracing disable'
           it_behaves_like 'a GET 200 span'
           it_behaves_like 'a trace with AppSec tags'
           it_behaves_like 'a trace without AppSec events'
@@ -239,6 +239,7 @@ RSpec.describe 'Rack integration tests' do
           it { is_expected.to be_ok }
           it { expect(triggers).to be_a Array }
 
+          it_behaves_like 'normal with tracing disable'
           it_behaves_like 'a GET 200 span'
           it_behaves_like 'a trace with AppSec tags'
           it_behaves_like 'a trace with AppSec events'
@@ -249,6 +250,7 @@ RSpec.describe 'Rack integration tests' do
 
           it { is_expected.to be_ok }
 
+          it_behaves_like 'normal with tracing disable'
           it_behaves_like 'a GET 200 span'
           it_behaves_like 'a trace with AppSec tags'
           it_behaves_like 'a trace with AppSec events'
@@ -258,6 +260,7 @@ RSpec.describe 'Rack integration tests' do
 
             it { is_expected.to be_forbidden }
 
+            it_behaves_like 'normal with tracing disable'
             it_behaves_like 'a GET 403 span'
             it_behaves_like 'a trace with AppSec tags'
             it_behaves_like 'a trace with AppSec events', { blocking: true }
@@ -271,6 +274,7 @@ RSpec.describe 'Rack integration tests' do
 
           it { is_expected.to be_forbidden }
 
+          it_behaves_like 'normal with tracing disable'
           it_behaves_like 'a GET 403 span'
           it_behaves_like 'a trace with AppSec tags'
           it_behaves_like 'a trace with AppSec events'
@@ -282,6 +286,7 @@ RSpec.describe 'Rack integration tests' do
           it { is_expected.to be_not_found }
           it { expect(triggers).to be_a Array }
 
+          it_behaves_like 'normal with tracing disable'
           it_behaves_like 'a GET 404 span'
           it_behaves_like 'a trace with AppSec tags'
           it_behaves_like 'a trace with AppSec events'
@@ -293,6 +298,7 @@ RSpec.describe 'Rack integration tests' do
 
             it { is_expected.to be_forbidden }
 
+            it_behaves_like 'normal with tracing disable'
             it_behaves_like 'a GET 403 span'
             it_behaves_like 'a trace with AppSec tags'
             it_behaves_like 'a trace with AppSec events', { blocking: true }
@@ -304,6 +310,7 @@ RSpec.describe 'Rack integration tests' do
 
           it { is_expected.to be_ok }
 
+          it_behaves_like 'normal with tracing disable'
           it_behaves_like 'a GET 200 span'
           it_behaves_like 'a trace with AppSec tags'
           it_behaves_like 'a trace without AppSec events'
@@ -313,6 +320,7 @@ RSpec.describe 'Rack integration tests' do
 
             it { is_expected.to be_forbidden }
 
+            it_behaves_like 'normal with tracing disable'
             it_behaves_like 'a GET 403 span'
             it_behaves_like 'a trace with AppSec tags'
             it_behaves_like 'a trace with AppSec events', { blocking: true }
@@ -331,6 +339,7 @@ RSpec.describe 'Rack integration tests' do
         context 'with a non-event-triggering request' do
           it { is_expected.to be_ok }
 
+          it_behaves_like 'normal with tracing disable'
           it_behaves_like 'a POST 200 span'
           it_behaves_like 'a trace with AppSec tags'
           it_behaves_like 'a trace without AppSec events'
@@ -358,6 +367,7 @@ RSpec.describe 'Rack integration tests' do
 
             it { is_expected.to be_forbidden }
 
+            it_behaves_like 'normal with tracing disable'
             it_behaves_like 'a POST 403 span'
             it_behaves_like 'a trace with AppSec tags'
             it_behaves_like 'a trace with AppSec events', { blocking: true }
@@ -379,6 +389,7 @@ RSpec.describe 'Rack integration tests' do
 
             it { is_expected.to be_ok }
 
+            it_behaves_like 'normal with tracing disable'
             it_behaves_like 'a POST 200 span'
             it_behaves_like 'a trace with AppSec tags'
             it_behaves_like 'a trace with AppSec events'
@@ -388,6 +399,7 @@ RSpec.describe 'Rack integration tests' do
 
               it { is_expected.to be_forbidden }
 
+              it_behaves_like 'normal with tracing disable'
               it_behaves_like 'a POST 403 span'
               it_behaves_like 'a trace with AppSec tags'
               it_behaves_like 'a trace with AppSec events', { blocking: true }
@@ -419,6 +431,7 @@ RSpec.describe 'Rack integration tests' do
 
           it { is_expected.to be_ok }
 
+          it_behaves_like 'normal with tracing disable'
           it_behaves_like 'a POST 200 span'
           it_behaves_like 'a trace with AppSec tags'
           it_behaves_like 'a trace with AppSec events'
@@ -428,6 +441,7 @@ RSpec.describe 'Rack integration tests' do
 
             it { is_expected.to be_forbidden }
 
+            it_behaves_like 'normal with tracing disable'
             it_behaves_like 'a POST 403 span'
             it_behaves_like 'a trace with AppSec tags'
             it_behaves_like 'a trace with AppSec events', { blocking: true }

--- a/spec/datadog/appsec/contrib/rails/integration_test_spec.rb
+++ b/spec/datadog/appsec/contrib/rails/integration_test_spec.rb
@@ -165,7 +165,6 @@ RSpec.describe 'Rails integration tests' do
 
       before do
         response
-        expect(spans).to_not be_empty
       end
 
       describe 'GET request' do
@@ -179,6 +178,7 @@ RSpec.describe 'Rails integration tests' do
         context 'with a non-event-triggering request' do
           it { is_expected.to be_ok }
 
+          it_behaves_like 'normal with tracing disable'
           it_behaves_like 'a GET 200 span'
           it_behaves_like 'a trace with AppSec tags'
           it_behaves_like 'a trace without AppSec events'
@@ -190,6 +190,7 @@ RSpec.describe 'Rails integration tests' do
           it { is_expected.to be_ok }
           it { expect(triggers).to be_a Array }
 
+          it_behaves_like 'normal with tracing disable'
           it_behaves_like 'a GET 200 span'
           it_behaves_like 'a trace with AppSec tags'
           it_behaves_like 'a trace with AppSec events'
@@ -200,6 +201,7 @@ RSpec.describe 'Rails integration tests' do
 
           it { is_expected.to be_ok }
 
+          it_behaves_like 'normal with tracing disable'
           it_behaves_like 'a GET 200 span'
           it_behaves_like 'a trace with AppSec tags'
           it_behaves_like 'a trace with AppSec events'
@@ -209,6 +211,7 @@ RSpec.describe 'Rails integration tests' do
 
             it { is_expected.to be_forbidden }
 
+            it_behaves_like 'normal with tracing disable'
             it_behaves_like 'a GET 403 span'
             it_behaves_like 'a trace with AppSec tags'
             it_behaves_like 'a trace with AppSec events', { blocking: true }
@@ -226,6 +229,7 @@ RSpec.describe 'Rails integration tests' do
 
           it { is_expected.to be_ok }
 
+          it_behaves_like 'normal with tracing disable'
           it_behaves_like 'a GET 200 span'
           it_behaves_like 'a trace with AppSec tags'
           it_behaves_like 'a trace with AppSec events'
@@ -235,6 +239,7 @@ RSpec.describe 'Rails integration tests' do
 
             it { is_expected.to be_forbidden }
 
+            it_behaves_like 'normal with tracing disable'
             it_behaves_like 'a GET 403 span'
             it_behaves_like 'a trace with AppSec tags'
             it_behaves_like 'a trace with AppSec events', { blocking: true }
@@ -248,6 +253,7 @@ RSpec.describe 'Rails integration tests' do
 
           it { is_expected.to be_forbidden }
 
+          it_behaves_like 'normal with tracing disable'
           it_behaves_like 'a GET 403 span'
           it_behaves_like 'a trace with AppSec tags'
           it_behaves_like 'a trace with AppSec events', { blocking: true }
@@ -259,6 +265,7 @@ RSpec.describe 'Rails integration tests' do
           it { is_expected.to be_not_found }
           it { expect(triggers).to be_a Array }
 
+          it_behaves_like 'normal with tracing disable'
           it_behaves_like 'a GET 404 span'
           it_behaves_like 'a trace with AppSec tags'
           it_behaves_like 'a trace with AppSec events'
@@ -269,6 +276,7 @@ RSpec.describe 'Rails integration tests' do
 
           it { is_expected.to be_ok }
 
+          it_behaves_like 'normal with tracing disable'
           it_behaves_like 'a GET 200 span'
           it_behaves_like 'a trace with AppSec tags'
           it_behaves_like 'a trace without AppSec events'
@@ -278,6 +286,7 @@ RSpec.describe 'Rails integration tests' do
 
             it { is_expected.to be_forbidden }
 
+            it_behaves_like 'normal with tracing disable'
             it_behaves_like 'a GET 403 span'
             it_behaves_like 'a trace with AppSec tags'
             it_behaves_like 'a trace with AppSec events'
@@ -296,6 +305,7 @@ RSpec.describe 'Rails integration tests' do
         context 'with a non-event-triggering request' do
           it { is_expected.to be_ok }
 
+          it_behaves_like 'normal with tracing disable'
           it_behaves_like 'a POST 200 span'
           it_behaves_like 'a trace with AppSec tags'
           it_behaves_like 'a trace without AppSec events'
@@ -306,6 +316,7 @@ RSpec.describe 'Rails integration tests' do
 
           it { is_expected.to be_ok }
 
+          it_behaves_like 'normal with tracing disable'
           it_behaves_like 'a POST 200 span'
           it_behaves_like 'a trace with AppSec tags'
           it_behaves_like 'a trace with AppSec events'
@@ -315,6 +326,7 @@ RSpec.describe 'Rails integration tests' do
 
             it { is_expected.to be_forbidden }
 
+            it_behaves_like 'normal with tracing disable'
             it_behaves_like 'a POST 403 span'
             it_behaves_like 'a trace with AppSec tags'
             it_behaves_like 'a trace with AppSec events', { blocking: true }
@@ -328,6 +340,7 @@ RSpec.describe 'Rails integration tests' do
 
             it { is_expected.to be_ok }
 
+            it_behaves_like 'normal with tracing disable'
             it_behaves_like 'a POST 200 span'
             it_behaves_like 'a trace with AppSec tags'
             it_behaves_like 'a trace with AppSec events'
@@ -337,6 +350,7 @@ RSpec.describe 'Rails integration tests' do
 
               it { is_expected.to be_forbidden }
 
+              it_behaves_like 'normal with tracing disable'
               it_behaves_like 'a POST 403 span'
               it_behaves_like 'a trace with AppSec tags'
               it_behaves_like 'a trace with AppSec events', { blocking: true }
@@ -350,6 +364,7 @@ RSpec.describe 'Rails integration tests' do
 
           it { is_expected.to be_ok }
 
+          it_behaves_like 'normal with tracing disable'
           it_behaves_like 'a POST 200 span'
           it_behaves_like 'a trace with AppSec tags'
           it_behaves_like 'a trace with AppSec events'
@@ -359,6 +374,7 @@ RSpec.describe 'Rails integration tests' do
 
             it { is_expected.to be_forbidden }
 
+            it_behaves_like 'normal with tracing disable'
             it_behaves_like 'a POST 403 span'
             it_behaves_like 'a trace with AppSec tags'
             it_behaves_like 'a trace with AppSec events', { blocking: true }
@@ -403,6 +419,7 @@ RSpec.describe 'Rails integration tests' do
           context 'with a non-event-triggering request' do
             it { is_expected.to be_ok }
 
+            it_behaves_like 'normal with tracing disable'
             it_behaves_like 'a GET 200 span'
             it_behaves_like 'a trace with AppSec tags'
             it_behaves_like 'a trace without AppSec events'
@@ -414,6 +431,7 @@ RSpec.describe 'Rails integration tests' do
             it { is_expected.to be_ok }
             it { expect(triggers).to be_a Array }
 
+            it_behaves_like 'normal with tracing disable'
             it_behaves_like 'a GET 200 span'
             it_behaves_like 'a trace with AppSec tags'
             it_behaves_like 'a trace with AppSec events'
@@ -424,6 +442,7 @@ RSpec.describe 'Rails integration tests' do
 
             it { is_expected.to be_ok }
 
+            it_behaves_like 'normal with tracing disable'
             it_behaves_like 'a GET 200 span'
             it_behaves_like 'a trace with AppSec tags'
             it_behaves_like 'a trace with AppSec events'
@@ -433,6 +452,7 @@ RSpec.describe 'Rails integration tests' do
 
               it { is_expected.to be_forbidden }
 
+              it_behaves_like 'normal with tracing disable'
               it_behaves_like 'a GET 403 span'
               it_behaves_like 'a trace with AppSec tags'
               it_behaves_like 'a trace with AppSec events', { blocking: true }

--- a/spec/datadog/appsec/contrib/sinatra/integration_test_spec.rb
+++ b/spec/datadog/appsec/contrib/sinatra/integration_test_spec.rb
@@ -169,7 +169,6 @@ RSpec.describe 'Sinatra integration tests' do
 
       before do
         response
-        expect(spans).to_not be_empty
       end
 
       describe 'GET request' do
@@ -183,6 +182,7 @@ RSpec.describe 'Sinatra integration tests' do
         context 'with a non-event-triggering request' do
           it { is_expected.to be_ok }
 
+          it_behaves_like 'normal with tracing disable'
           it_behaves_like 'a GET 200 span'
           it_behaves_like 'a trace with AppSec tags'
           it_behaves_like 'a trace without AppSec events'
@@ -194,6 +194,7 @@ RSpec.describe 'Sinatra integration tests' do
           it { is_expected.to be_ok }
           it { expect(triggers).to be_a Array }
 
+          it_behaves_like 'normal with tracing disable'
           it_behaves_like 'a GET 200 span'
           it_behaves_like 'a trace with AppSec tags'
           it_behaves_like 'a trace with AppSec events'
@@ -204,6 +205,7 @@ RSpec.describe 'Sinatra integration tests' do
 
           it { is_expected.to be_ok }
 
+          it_behaves_like 'normal with tracing disable'
           it_behaves_like 'a GET 200 span'
           it_behaves_like 'a trace with AppSec tags'
           it_behaves_like 'a trace with AppSec events'
@@ -213,6 +215,7 @@ RSpec.describe 'Sinatra integration tests' do
 
             it { is_expected.to be_forbidden }
 
+            it_behaves_like 'normal with tracing disable'
             it_behaves_like 'a GET 403 span'
             it_behaves_like 'a trace with AppSec tags'
             it_behaves_like 'a trace with AppSec events', { blocking: true }
@@ -232,6 +235,7 @@ RSpec.describe 'Sinatra integration tests' do
 
           it { is_expected.to be_ok }
 
+          it_behaves_like 'normal with tracing disable'
           it_behaves_like 'a GET 200 span'
           it_behaves_like 'a trace with AppSec tags'
           it_behaves_like 'a trace with AppSec events'
@@ -241,6 +245,7 @@ RSpec.describe 'Sinatra integration tests' do
 
             it { is_expected.to be_forbidden }
 
+            it_behaves_like 'normal with tracing disable'
             it_behaves_like 'a GET 403 span'
             it_behaves_like 'a trace with AppSec tags'
             it_behaves_like 'a trace with AppSec events', { blocking: true }
@@ -254,6 +259,7 @@ RSpec.describe 'Sinatra integration tests' do
 
           it { is_expected.to be_forbidden }
 
+          it_behaves_like 'normal with tracing disable'
           it_behaves_like 'a GET 403 span'
           it_behaves_like 'a trace with AppSec tags'
           it_behaves_like 'a trace with AppSec events', { blocking: true }
@@ -265,6 +271,7 @@ RSpec.describe 'Sinatra integration tests' do
           it { is_expected.to be_not_found }
           it { expect(triggers).to be_a Array }
 
+          it_behaves_like 'normal with tracing disable'
           it_behaves_like 'a GET 404 span'
           it_behaves_like 'a trace with AppSec tags'
           it_behaves_like 'a trace with AppSec events'
@@ -275,6 +282,7 @@ RSpec.describe 'Sinatra integration tests' do
 
           it { is_expected.to be_ok }
 
+          it_behaves_like 'normal with tracing disable'
           it_behaves_like 'a GET 200 span'
           it_behaves_like 'a trace with AppSec tags'
           it_behaves_like 'a trace without AppSec events'
@@ -284,6 +292,7 @@ RSpec.describe 'Sinatra integration tests' do
 
             it { is_expected.to be_forbidden }
 
+            it_behaves_like 'normal with tracing disable'
             it_behaves_like 'a GET 403 span'
             it_behaves_like 'a trace with AppSec tags'
             it_behaves_like 'a trace with AppSec events', { blocking: true }
@@ -302,6 +311,7 @@ RSpec.describe 'Sinatra integration tests' do
         context 'with a non-event-triggering request' do
           it { is_expected.to be_ok }
 
+          it_behaves_like 'normal with tracing disable'
           it_behaves_like 'a POST 200 span'
           it_behaves_like 'a trace with AppSec tags'
           it_behaves_like 'a trace without AppSec events'
@@ -312,6 +322,7 @@ RSpec.describe 'Sinatra integration tests' do
 
           it { is_expected.to be_ok }
 
+          it_behaves_like 'normal with tracing disable'
           it_behaves_like 'a POST 200 span'
           it_behaves_like 'a trace with AppSec tags'
           it_behaves_like 'a trace with AppSec events'
@@ -321,6 +332,7 @@ RSpec.describe 'Sinatra integration tests' do
 
             it { is_expected.to be_forbidden }
 
+            it_behaves_like 'normal with tracing disable'
             it_behaves_like 'a POST 403 span'
             it_behaves_like 'a trace with AppSec tags'
             it_behaves_like 'a trace with AppSec events', { blocking: true }
@@ -334,6 +346,7 @@ RSpec.describe 'Sinatra integration tests' do
 
             it { is_expected.to be_ok }
 
+            it_behaves_like 'normal with tracing disable'
             it_behaves_like 'a POST 200 span'
             it_behaves_like 'a trace with AppSec tags'
             it_behaves_like 'a trace with AppSec events'
@@ -361,6 +374,7 @@ RSpec.describe 'Sinatra integration tests' do
 
           it { is_expected.to be_ok }
 
+          it_behaves_like 'normal with tracing disable'
           it_behaves_like 'a POST 200 span'
           it_behaves_like 'a trace with AppSec tags'
           it_behaves_like 'a trace with AppSec events'

--- a/spec/datadog/appsec/contrib/support/integration/shared_examples.rb
+++ b/spec/datadog/appsec/contrib/support/integration/shared_examples.rb
@@ -1,3 +1,11 @@
+RSpec.shared_examples 'normal with tracing disable' do
+  let(:tracing_enabled) { false }
+
+  it do
+    expect(spans).to have(0).items
+  end
+end
+
 RSpec.shared_examples 'a GET 200 span' do
   it do
     expect(span.get_tag('http.method')).to eq('GET')

--- a/spec/datadog/appsec/event_spec.rb
+++ b/spec/datadog/appsec/event_spec.rb
@@ -134,6 +134,22 @@ RSpec.describe Datadog::AppSec::Event do
         end
       end
 
+      context 'with no span' do
+        let(:event_count) { 1 }
+
+        it 'does not attempt to record in the trace' do
+          expect(described_class).to_not receive(:record_via_span)
+
+          described_class.record(nil, events)
+        end
+
+        it 'does not call the rate limiter' do
+          expect(Datadog::AppSec::RateLimiter).to_not receive(:limit)
+
+          described_class.record(nil, events)
+        end
+      end
+
       context 'with many traces' do
         let(:rate_limit) { 100 }
         let(:trace_count) { rate_limit * 2 }

--- a/spec/datadog/kit/appsec/events_spec.rb
+++ b/spec/datadog/kit/appsec/events_spec.rb
@@ -38,6 +38,15 @@ RSpec.describe Datadog::Kit::AppSec::Events do
     end
   end
 
+  shared_examples 'when tracing disabled' do
+    it 'does mark trace for keeping' do
+      expect(Datadog::Tracing.active_trace).to_not receive(:keep!)
+      expect do
+        event
+      end.to_not raise_error
+    end
+  end
+
   describe '#track_login_success' do
     it 'sets event tracking key on trace' do
       trace_op.measure('root') do |span, _trace|
@@ -81,6 +90,10 @@ RSpec.describe Datadog::Kit::AppSec::Events do
       let(:event_tag) { 'appsec.events.users.login.success.track' }
       subject(:event) { described_class.track_login_success(trace_op, user: { id: '42' }) }
     end
+
+    it_behaves_like 'when tracing disabled' do
+      subject(:event) { described_class.track_login_success(user: { id: '42' }) }
+    end
   end
 
   describe '#track_login_failure' do
@@ -123,6 +136,10 @@ RSpec.describe Datadog::Kit::AppSec::Events do
       let(:event_tag) { 'appsec.events.users.login.failure.track' }
       subject(:event) { described_class.track_login_failure(trace_op, user_id: '42', user_exists: true) }
     end
+
+    it_behaves_like 'when tracing disabled' do
+      subject(:event) { described_class.track_login_failure(user_id: '42', user_exists: true) }
+    end
   end
 
   describe '#track_signup' do
@@ -163,6 +180,15 @@ RSpec.describe Datadog::Kit::AppSec::Events do
       end
       expect(user_argument).to eql(user_argument_dup)
     end
+
+    it_behaves_like 'uses AppSec scope' do
+      let(:event_tag) { 'appsec.events.users.signup.track' }
+      subject(:event) { described_class.track_signup(trace_op, user: { id: '42' }, foo: 'bar') }
+    end
+
+    it_behaves_like 'when tracing disabled' do
+      subject(:event) { described_class.track_signup(user: { id: '42' }, foo: 'bar') }
+    end
   end
 
   describe '#track' do
@@ -183,6 +209,10 @@ RSpec.describe Datadog::Kit::AppSec::Events do
     it_behaves_like 'uses AppSec scope' do
       let(:event_tag) { 'appsec.events.foo.track' }
       subject(:event) { described_class.track('foo', trace_op) }
+    end
+
+    it_behaves_like 'when tracing disabled' do
+      subject(:event) { described_class.track('foo') }
     end
   end
 end

--- a/spec/datadog/kit/identity_spec.rb
+++ b/spec/datadog/kit/identity_spec.rb
@@ -213,7 +213,7 @@ RSpec.describe Datadog::Kit::Identity do
 
     context 'appsec' do
       let(:appsec_active_scope) { nil }
-      before { expect(Datadog::AppSec).to receive(:active_scope).and_return(appsec_active_scope) }
+      before { allow(Datadog::AppSec).to receive(:active_scope).and_return(appsec_active_scope) }
 
       context 'when is enabled' do
         let(:appsec_active_scope) do
@@ -243,6 +243,15 @@ RSpec.describe Datadog::Kit::Identity do
             described_class.set_user(trace_op, id: '42')
           end
         end
+      end
+    end
+
+    context 'when tracing disabled' do
+      it 'does mark trace for keeping' do
+        expect(Datadog::Tracing.active_trace).to_not receive(:keep!)
+        expect do
+          described_class.set_user(id: '42')
+        end.to_not raise_error
       end
     end
   end


### PR DESCRIPTION
<!--
Check out the
https://github.com/DataDog/dd-trace-rb/blob/master/docs/DevelopmentGuide.md
for guidance on how to set up your development environment,
run the test suite, write new integrations, and more.
-->

**What does this PR do?**
<!-- A brief description of the change being made with this pull request. -->

With `1.11.x`, we introduce a new way to manage the AppSec scope: https://github.com/DataDog/dd-trace-rb/pull/2858, which fundamentally changed how we tag spans and traces. Before that change, we used to tag traces rather than spans. 

When tracing is disabled, fetching the `active_trace` works, but the `active_span` is `nil`. So to keep working as before, we need to ensure that appsec works as expected when tracing is disabled, making everything a no-op as contradicting as it sounds since AppSec needs tracing as the transport layer. So in those weird cases where someone disable tracing and not appsec, things should not break. 

**Motivation**
<!-- What inspired you to submit this pull request? -->

**Additional Notes**
<!-- Anything else we should know when reviewing? -->

**How to test the change?**
<!--
Describe here how the change can be validated.
You are strongly encouraged to provide automated tests for this PR (unit or integration).
If this change cannot be feasibly tested, please explain why,
unless the change does not modify code (e.g. only modifies docs, comments).
-->

CI