### PR TITLE
Removed unused constants from Appsec::Contrib::*::Ext modules

### DIFF
--- a/lib/datadog/appsec/contrib/devise/ext.rb
+++ b/lib/datadog/appsec/contrib/devise/ext.rb
@@ -6,7 +6,6 @@ module Datadog
       module Devise
         # Devise integration constants
         module Ext
-          APP = 'devise'
         end
       end
     end

--- a/lib/datadog/appsec/contrib/rack/ext.rb
+++ b/lib/datadog/appsec/contrib/rack/ext.rb
@@ -6,7 +6,6 @@ module Datadog
       module Rack
         # Rack integration constants
         module Ext
-          APP = 'rack'
         end
       end
     end

--- a/lib/datadog/appsec/contrib/rails/ext.rb
+++ b/lib/datadog/appsec/contrib/rails/ext.rb
@@ -4,9 +4,8 @@ module Datadog
   module AppSec
     module Contrib
       module Rails
-        # Rack integration constants
+        # Rails integration constants
         module Ext
-          APP = 'rails'
         end
       end
     end

--- a/lib/datadog/appsec/contrib/sinatra/ext.rb
+++ b/lib/datadog/appsec/contrib/sinatra/ext.rb
@@ -6,7 +6,6 @@ module Datadog
       module Sinatra
         # Sinatra integration constants
         module Ext
-          APP = 'sinatra'
           ROUTE_INTERRUPT = :datadog_appsec_contrib_sinatra_route_interrupt
         end
       end


### PR DESCRIPTION
<!--
Check out the
https://github.com/DataDog/dd-trace-rb/blob/master/docs/DevelopmentGuide.md
for guidance on how to set up your development environment,
run the test suite, write new integrations, and more.
-->

**What does this PR do?**
<!-- A brief description of the change being made with this pull request. -->

Based on the thread https://github.com/DataDog/dd-trace-rb/pull/2877#discussion_r1231102591 

Removed unused constants from appsec contrib folder 

**Motivation**
<!-- What inspired you to submit this pull request? -->

**Additional Notes**
<!-- Anything else we should know when reviewing? -->

**How to test the change?**
<!--
Describe here how the change can be validated.
You are strongly encouraged to provide automated tests for this PR (unit or integration).
If this change cannot be feasibly tested, please explain why,
unless the change does not modify code (e.g. only modifies docs, comments).
-->
