### PR TITLE
[PROF-7786] Include _dd.profiling.enabled tag

### DIFF
--- a/lib/datadog/core/workers/async.rb
+++ b/lib/datadog/core/workers/async.rb
@@ -90,7 +90,7 @@ module Datadog
             :result
 
           def mutex
-            @mutex || MUTEX_INIT.synchronize { @mutex ||= Mutex.new }
+            (defined?(@mutex) && @mutex) || MUTEX_INIT.synchronize { @mutex ||= Mutex.new }
           end
 
           def after_fork
@@ -103,7 +103,7 @@ module Datadog
             :pid
 
           def mutex_after_fork
-            @mutex_after_fork || MUTEX_INIT.synchronize { @mutex_after_fork ||= Mutex.new }
+            (defined?(@mutex_after_fork) && @mutex_after_fork) || MUTEX_INIT.synchronize { @mutex_after_fork ||= Mutex.new }
           end
 
           def worker

--- a/lib/datadog/profiling.rb
+++ b/lib/datadog/profiling.rb
@@ -66,6 +66,11 @@ module Datadog
       nil
     end
 
+    def self.enabled?
+      profiler = Datadog.send(:components).profiler
+      !!(profiler.scheduler.running? if profiler)
+    end
+
     private_class_method def self.replace_noop_allocation_count
       def self.allocation_count # rubocop:disable Lint/DuplicateMethods, Lint/NestedMethodDefinition (On purpose!)
         Datadog::Profiling::Collectors::CpuAndWallTimeWorker._native_allocation_count

--- a/lib/datadog/tracing/metadata/ext.rb
+++ b/lib/datadog/tracing/metadata/ext.rb
@@ -23,6 +23,10 @@ module Datadog
         # Set this tag to `1.0` if the span is a Service Entry span.
         TAG_TOP_LEVEL = '_dd.top_level'
 
+        # Set to `1.0` if profiling is enabled together with tracing, and `0.0` otherwise
+        # See Datadog-internal "RFC: Identifying whether a span’s host has profiling enabled" for details
+        TAG_PROFILING_ENABLED = '_dd.profiling.enabled'
+
         # Defines constants for trace analytics
         # @public_api
         module Analytics

--- a/lib/datadog/tracing/metadata/ext.rb
+++ b/lib/datadog/tracing/metadata/ext.rb
@@ -24,7 +24,7 @@ module Datadog
         TAG_TOP_LEVEL = '_dd.top_level'
 
         # Set to `1.0` if profiling is enabled together with tracing, and `0.0` otherwise
-        # See Datadog-internal "RFC: Identifying whether a span’s host has profiling enabled" for details
+        # See Datadog-internal "RFC: Identifying which spans have profiling enabled " for details
         TAG_PROFILING_ENABLED = '_dd.profiling.enabled'
 
         # Defines constants for trace analytics

--- a/lib/datadog/tracing/trace_operation.rb
+++ b/lib/datadog/tracing/trace_operation.rb
@@ -450,7 +450,9 @@ module Datadog
           service: service,
           tags: meta,
           metrics: metrics,
-          root_span_id: !partial ? root_span && root_span.id : nil
+          root_span_id: !partial ? root_span && root_span.id : nil,
+          profiling_enabled:
+            !!(defined?(Datadog::Profiling) && Datadog::Profiling.respond_to?(:enabled?) && Datadog::Profiling.enabled?), # rubocop:disable Style/DoubleNegation
         )
       end
 

--- a/lib/datadog/tracing/trace_operation.rb
+++ b/lib/datadog/tracing/trace_operation.rb
@@ -64,6 +64,7 @@ module Datadog
         sampled: nil,
         sampling_priority: nil,
         service: nil,
+        profiling_enabled: nil,
         tags: nil,
         metrics: nil
       )
@@ -84,6 +85,7 @@ module Datadog
         @sample_rate = sample_rate
         @sampling_priority = sampling_priority
         @service = service
+        @profiling_enabled = profiling_enabled
 
         # Generic tags
         set_tags(tags) if tags
@@ -451,8 +453,7 @@ module Datadog
           tags: meta,
           metrics: metrics,
           root_span_id: !partial ? root_span && root_span.id : nil,
-          profiling_enabled:
-            !!(defined?(Datadog::Profiling) && Datadog::Profiling.respond_to?(:enabled?) && Datadog::Profiling.enabled?), # rubocop:disable Style/DoubleNegation
+          profiling_enabled: @profiling_enabled,
         )
       end
 

--- a/lib/datadog/tracing/trace_segment.rb
+++ b/lib/datadog/tracing/trace_segment.rb
@@ -31,7 +31,8 @@ module Datadog
         :sample_rate,
         :sampling_decision_maker,
         :sampling_priority,
-        :service
+        :service,
+        :profiling_enabled
 
       # rubocop:disable Metrics/CyclomaticComplexity
       # rubocop:disable Metrics/PerceivedComplexity
@@ -54,7 +55,8 @@ module Datadog
         sampling_priority: nil,
         service: nil,
         tags: nil,
-        metrics: nil
+        metrics: nil,
+        profiling_enabled: nil
       )
         @id = id
         @root_span_id = root_span_id
@@ -80,6 +82,7 @@ module Datadog
         @sampling_decision_maker = sampling_decision_maker_tag
         @sampling_priority = sampling_priority || sampling_priority_tag
         @service = Core::Utils::SafeDup.frozen_or_dup(service || service_tag)
+        @profiling_enabled = profiling_enabled
       end
       # rubocop:enable Metrics/PerceivedComplexity
       # rubocop:enable Metrics/CyclomaticComplexity

--- a/lib/datadog/tracing/tracer.rb
+++ b/lib/datadog/tracing/tracer.rb
@@ -320,6 +320,7 @@ module Datadog
         if digest
           TraceOperation.new(
             hostname: hostname,
+            profiling_enabled: profiling_enabled,
             id: digest.trace_id,
             origin: digest.trace_origin,
             parent_span_id: digest.span_id,
@@ -329,7 +330,8 @@ module Datadog
           )
         else
           TraceOperation.new(
-            hostname: hostname
+            hostname: hostname,
+            profiling_enabled: profiling_enabled,
           )
         end
       end
@@ -524,6 +526,11 @@ module Datadog
         else
           span
         end
+      end
+
+      def profiling_enabled
+        @profiling_enabled ||=
+          !!(defined?(Datadog::Profiling) && Datadog::Profiling.respond_to?(:enabled?) && Datadog::Profiling.enabled?)
       end
     end
   end

--- a/lib/ddtrace/transport/trace_formatter.rb
+++ b/lib/ddtrace/transport/trace_formatter.rb
@@ -51,6 +51,7 @@ module Datadog
         tag_sampling_decision_maker!
         tag_high_order_trace_id!
         tag_sampling_priority!
+        tag_profiling_enabled!
 
         trace
       end
@@ -173,6 +174,14 @@ module Datadog
         return unless (high_order_tid = trace.high_order_tid)
 
         root_span.set_tag(Tracing::Metadata::Ext::Distributed::TAG_TID, high_order_tid)
+      end
+
+      def tag_profiling_enabled!
+        return if trace.profiling_enabled.nil?
+
+        root_span.set_tag(
+          Tracing::Metadata::Ext::TAG_PROFILING_ENABLED, trace.profiling_enabled ? 1 : 0
+        )
       end
 
       private

--- a/spec/datadog/profiling_spec.rb
+++ b/spec/datadog/profiling_spec.rb
@@ -60,6 +60,35 @@ RSpec.describe Datadog::Profiling do
     end
   end
 
+  describe '.enabled?' do
+    subject(:enabled?) { described_class.enabled? }
+
+    before do
+      allow(Datadog.send(:components)).to receive(:profiler).and_return(profiler)
+    end
+
+    context 'when no profiler is available' do
+      let(:profiler) { nil }
+
+      it { is_expected.to be(false) }
+    end
+
+    context 'when a profiler is available' do
+      let(:profiler) { instance_double('Datadog::Profiling::Profiler', scheduler: scheduler) }
+      let(:scheduler) { instance_double('Datadog::Profiling::Scheduler', running?: running) }
+
+      context 'when the profiler is running' do
+        let(:running) { true }
+        it { is_expected.to be(true) }
+      end
+
+      context 'when the profiler is not running' do
+        let(:running) { false }
+        it { is_expected.to be(false) }
+      end
+    end
+  end
+
   describe '::supported?' do
     subject(:supported?) { described_class.supported? }
 

--- a/spec/datadog/tracing/trace_operation_spec.rb
+++ b/spec/datadog/tracing/trace_operation_spec.rb
@@ -1641,6 +1641,16 @@ RSpec.describe Datadog::Tracing::TraceOperation do
             service: service
           )
         end
+
+        context 'and profiling is enabled' do
+          before { expect(Datadog::Profiling).to receive(:enabled?).and_return(true) }
+          it { is_expected.to have_attributes(profiling_enabled: true) }
+        end
+
+        context 'and profiling is disabled' do
+          before { expect(Datadog::Profiling).to receive(:enabled?).and_return(false) }
+          it { is_expected.to have_attributes(profiling_enabled: false) }
+        end
       end
 
       context 'is finished' do

--- a/spec/datadog/tracing/trace_operation_spec.rb
+++ b/spec/datadog/tracing/trace_operation_spec.rb
@@ -31,8 +31,9 @@ RSpec.describe Datadog::Tracing::TraceOperation do
         sampled: sampled,
         sampling_priority: sampling_priority,
         service: service,
+        profiling_enabled: profiling_enabled,
         tags: tags,
-        metrics: metrics
+        metrics: metrics,
       }
     end
 
@@ -48,6 +49,7 @@ RSpec.describe Datadog::Tracing::TraceOperation do
     let(:sampled) { true }
     let(:sampling_priority) { Datadog::Tracing::Sampling::Ext::Priority::USER_KEEP }
     let(:service) { 'billing-api' }
+    let(:profiling_enabled) { 'profiling_enabled' }
     let(:tags) { { 'foo' => 'bar' }.merge(distributed_tags) }
     let(:metrics) { { 'baz' => 42.0 } }
 
@@ -1636,20 +1638,10 @@ RSpec.describe Datadog::Tracing::TraceOperation do
             rule_sample_rate: rule_sample_rate,
             runtime_id: Datadog::Core::Environment::Identity.id,
             sample_rate: sample_rate,
-
             sampling_priority: sampling_priority,
-            service: service
+            service: service,
+            profiling_enabled: profiling_enabled,
           )
-        end
-
-        context 'and profiling is enabled' do
-          before { expect(Datadog::Profiling).to receive(:enabled?).and_return(true) }
-          it { is_expected.to have_attributes(profiling_enabled: true) }
-        end
-
-        context 'and profiling is disabled' do
-          before { expect(Datadog::Profiling).to receive(:enabled?).and_return(false) }
-          it { is_expected.to have_attributes(profiling_enabled: false) }
         end
       end
 

--- a/spec/datadog/tracing/trace_segment_spec.rb
+++ b/spec/datadog/tracing/trace_segment_spec.rb
@@ -45,6 +45,7 @@ RSpec.describe Datadog::Tracing::TraceSegment do
           sampling_priority: nil,
           service: nil,
           spans: spans,
+          profiling_enabled: nil,
         )
       end
 
@@ -161,6 +162,12 @@ RSpec.describe Datadog::Tracing::TraceSegment do
         let(:metrics) { { 'foo' => 42.0 } }
 
         it { expect(trace_segment.send(:metrics)).to eq({ 'foo' => 42.0 }) }
+      end
+
+      context ':profiling_enabled' do
+        let(:options) { { profiling_enabled: true } }
+
+        it { is_expected.to have_attributes(profiling_enabled: true) }
       end
     end
 

--- a/spec/datadog/tracing/tracer_spec.rb
+++ b/spec/datadog/tracing/tracer_spec.rb
@@ -236,6 +236,26 @@ RSpec.describe Datadog::Tracing::Tracer do
             end
           end
         end
+
+        it 'adds profiling_enabled to the trace' do
+          expect(Datadog::Profiling).to receive(:enabled?).and_return(true)
+
+          tracer.trace(name) {}
+
+          expect(traces.first.profiling_enabled).to be true
+        end
+
+        context 'when profiler is not available' do
+          before do
+            expect(Datadog::Profiling).to receive(:respond_to?).with(:enabled?).and_return(false)
+          end
+
+          it 'adds profiling_enabled as false to the trace' do
+            tracer.trace(name) {}
+
+            expect(traces.first.profiling_enabled).to be false
+          end
+        end
       end
 
       context 'when nesting spans' do

--- a/spec/ddtrace/transport/trace_formatter_spec.rb
+++ b/spec/ddtrace/transport/trace_formatter_spec.rb
@@ -34,7 +34,8 @@ RSpec.describe Datadog::Transport::TraceFormatter do
         runtime_id: runtime_id,
         sample_rate: sample_rate,
         sampling_priority: sampling_priority,
-        tags: trace_tags
+        tags: trace_tags,
+        profiling_enabled: profiling_enabled,
       }
     end
 
@@ -49,6 +50,7 @@ RSpec.describe Datadog::Transport::TraceFormatter do
     let(:runtime_id) { 'trace.runtime_id' }
     let(:sample_rate) { rand }
     let(:sampling_priority) { Datadog::Tracing::Sampling::Ext::Priority::USER_KEEP }
+    let(:profiling_enabled) { true }
   end
 
   shared_context 'trace metadata with tags' do
@@ -133,7 +135,8 @@ RSpec.describe Datadog::Transport::TraceFormatter do
             Datadog::Tracing::Metadata::Ext::Sampling::TAG_RULE_SAMPLE_RATE => nil,
             Datadog::Core::Runtime::Ext::TAG_ID => nil,
             Datadog::Tracing::Metadata::Ext::Sampling::TAG_SAMPLE_RATE => nil,
-            Datadog::Tracing::Metadata::Ext::Distributed::TAG_SAMPLING_PRIORITY => nil
+            Datadog::Tracing::Metadata::Ext::Distributed::TAG_SAMPLING_PRIORITY => nil,
+            Datadog::Tracing::Metadata::Ext::TAG_PROFILING_ENABLED => nil,
           )
         end
       end
@@ -152,6 +155,7 @@ RSpec.describe Datadog::Transport::TraceFormatter do
             Datadog::Core::Runtime::Ext::TAG_ID => runtime_id,
             Datadog::Tracing::Metadata::Ext::Sampling::TAG_SAMPLE_RATE => sample_rate,
             Datadog::Tracing::Metadata::Ext::Distributed::TAG_SAMPLING_PRIORITY => sampling_priority,
+            Datadog::Tracing::Metadata::Ext::TAG_PROFILING_ENABLED => 1.0,
           )
         end
       end


### PR DESCRIPTION
**What does this PR do?**:

This PR implements the Datadog-internal
"RFC: Identifying whether a span’s host has profiling enabled" similar to what
[dd-trace-java](https://github.com/DataDog/dd-trace-java/pull/5395) does by including a `_dd.profiling.enabled` tag when profiling is enabled.

This is similar to the existing `_dd.appsec.enabled` tag.

**Motivation**:

This enables a better user experience in the "Code Hotspots" tab, e.g. for users that run profiling in a subset of their fleet.

This way we can immediately tell them "hey, there's no profiling data" rather than making them wait a few minutes and then telling them that we didn't find anything.

**Additional Notes**:

N/A

**How to test the change?**:

Validate that the `_dd.profiling.enabled` tag shows up in the UX.
