### PR TITLE
Remove puts from test file

### DIFF
--- a/spec/datadog/tracing/span_operation_spec.rb
+++ b/spec/datadog/tracing/span_operation_spec.rb
@@ -930,7 +930,6 @@ RSpec.describe Datadog::Tracing::SpanOperation do
         sleep(duration_wall_time)
         span_op.stop
 
-        puts "\nduration: #{duration}\nwall_time: #{duration_wall_time * 1e9}\n"
         expect(duration).to be_within(1).of(duration_wall_time * 1e9)
       end
 


### PR DESCRIPTION
We forgot a `puts` in one of our tests files.