### PR TITLE
Fix integration apps ruby image build for Ruby 3.1/3.2/3.3

### DIFF
--- a/integration/images/ruby/3.1/Dockerfile
+++ b/integration/images/ruby/3.1/Dockerfile
@@ -26,7 +26,7 @@ RUN set -ex && \
         mkdir -p /usr/share/man/man1 && \
         apt-get install -y --force-yes --no-install-recommends \
             sudo git openssh-client rsync vim \
-            net-tools netcat parallel unzip zip bzip2 && \
+            net-tools netcat-openbsd parallel unzip zip bzip2 && \
         \
         echo "===> Cleaning up" && \
         rm -rf /var/lib/apt/lists/*;

--- a/integration/images/ruby/3.2/Dockerfile
+++ b/integration/images/ruby/3.2/Dockerfile
@@ -26,7 +26,7 @@ RUN set -ex && \
         mkdir -p /usr/share/man/man1 && \
         apt-get install -y --force-yes --no-install-recommends \
             sudo git openssh-client rsync vim \
-            net-tools netcat parallel unzip zip bzip2 && \
+            net-tools netcat-openbsd parallel unzip zip bzip2 && \
         \
         echo "===> Cleaning up" && \
         rm -rf /var/lib/apt/lists/*;

--- a/integration/images/ruby/3.3/Dockerfile
+++ b/integration/images/ruby/3.3/Dockerfile
@@ -26,7 +26,7 @@ RUN set -ex && \
         mkdir -p /usr/share/man/man1 && \
         apt-get install -y --force-yes --no-install-recommends \
             sudo git openssh-client rsync vim \
-            net-tools netcat parallel unzip zip bzip2 && \
+            net-tools netcat-openbsd parallel unzip zip bzip2 && \
         \
         echo "===> Cleaning up" && \
         rm -rf /var/lib/apt/lists/*;


### PR DESCRIPTION
**What does this PR do?**:

This PR replaces `netcat` with `netcat-openbsd` in the `Dockerfile`s used for the Ruby 3.1, 3.2 and 3.3 integration images.

I did this change after running into the following issue in one of my latest PRs
(<https://app.circleci.com/pipelines/github/DataDog/dd-trace-rb/10471/workflows/398f98c3-8d84-4d94-afff-8c92370be60d/jobs/389184>):

```
===> Installing dependencies
+ echo ===> Installing dependencies
+ apt-get -y update
Get:1 http://deb.debian.org/debian bookworm InRelease [147 kB]
Get:2 http://deb.debian.org/debian bookworm-updates InRelease [52.1 kB]
Get:3 http://deb.debian.org/debian-security bookworm-security InRelease [48.0 kB]
Get:4 http://deb.debian.org/debian bookworm/main amd64 Packages [8904 kB]
Get:5 http://deb.debian.org/debian-security bookworm-security/main amd64 Packages [28.3 kB]
Fetched 9180 kB in 1s (8684 kB/s)
Reading package lists...
E: Problem executing scripts APT::Update::Post-Invoke 'rm -f /var/cache/apt/archives/*.deb /var/cache/apt/archives/partial/*.deb /var/cache/apt/*.bin || true'
E: Sub-process returned an error code
The command '/bin/sh -c set -ex &&         echo "===> Installing dependencies" &&         apt-get -y update &&         apt-get install -y --force-yes --no-install-recommends             curl wget tar gzip gnupg apt-transport-https ca-certificates tzdata locales &&                 echo "===> Installing NodeJS" &&         apt-get install -y --force-yes --no-install-recommends nodejs &&                 echo "===> Installing Yarn" &&         curl -sS https://dl.yarnpkg.com/debian/pubkey.gpg | apt-key add - &&         echo "deb https://dl.yarnpkg.com/debian/ stable main" | tee /etc/apt/sources.list.d/yarn.list &&         apt-get update &&         apt-get install -y --force-yes --no-install-recommends yarn &&                 echo "===> Installing database libraries" &&         apt-get install -y --force-yes --no-install-recommends             postgresql-client sqlite3 &&                 echo "===> Installing dev tools" &&         mkdir -p /usr/share/man/man1 &&         apt-get install -y --force-yes --no-install-recommends             sudo git openssh-client rsync vim             net-tools netcat parallel unzip zip bzip2 &&                 echo "===> Cleaning up" &&         rm -rf /var/lib/apt/lists/*;' returned a non-zero code: 100

Exited with code exit status 100
```

In CI it wasn't clear _why_ the step was failing, but when I ran the command locally I got a more detailed:

```
 #0 21.93 ===> Installing dev tools
 #0 21.93 + apt-get install -y --force-yes --no-install-recommends sudo git openssh-client rsync vim net-tools netcat parallel unzip zip bzip2
 #0 21.94 Reading package lists...
 #0 22.94 Building dependency tree...
 #0 23.14 Reading state information...
 #0 23.15 Package netcat is a virtual package provided by:
 #0 23.15   netcat-openbsd 1.219-1
 #0 23.15   netcat-traditional 1.10-47
 #0 23.15
 #0 23.15 W: --force-yes is deprecated, use one of the options starting with --allow instead.
 #0 23.15 E: Package 'netcat' has no installation candidate
------
Dockerfile:6
--------------------
   5 |     # Install prerequisites
   6 | >>> RUN set -ex && \
   7 | >>>         echo "===> Installing dependencies" && \
   8 | >>>         apt-get -y update && \
   9 | >>>         apt-get install -y --force-yes --no-install-recommends \
  10 | >>>             curl wget tar gzip gnupg apt-transport-https ca-certificates tzdata locales && \
  11 | >>>         \
  12 | >>>         echo "===> Installing NodeJS" && \
  13 | >>>         apt-get install -y --force-yes --no-install-recommends nodejs && \
  14 | >>>         \
  15 | >>>         echo "===> Installing Yarn" && \
  16 | >>>         curl -sS https://dl.yarnpkg.com/debian/pubkey.gpg | apt-key add - && \
  17 | >>>         echo "deb https://dl.yarnpkg.com/debian/ stable main" | tee /etc/apt/sources.list.d/yarn.list && \
  18 | >>>         apt-get update && \
  19 | >>>         apt-get install -y --force-yes --no-install-recommends yarn && \
  20 | >>>         \
  21 | >>>         echo "===> Installing database libraries" && \
  22 | >>>         apt-get install -y --force-yes --no-install-recommends \
  23 | >>>             postgresql-client sqlite3 && \
  24 | >>>         \
  25 | >>>         echo "===> Installing dev tools" && \
  26 | >>>         mkdir -p /usr/share/man/man1 && \
  27 | >>>         apt-get install -y --force-yes --no-install-recommends \
  28 | >>>             sudo git openssh-client rsync vim \
  29 | >>>             net-tools netcat parallel unzip zip bzip2 && \
  30 | >>>         \
  31 | >>>         echo "===> Cleaning up" && \
  32 | >>>         rm -rf /var/lib/apt/lists/*;
  33 |
--------------------
ERROR: failed to solve: process "/bin/sh -c set -ex &&         echo \"===> Installing dependencies\" &&         apt-get -y update &&         apt-get install -y --force-yes --no-install-recommends             curl wget tar gzip gnupg apt-transport-https ca-certificates tzdata locales &&                 echo \"===> Installing NodeJS\" &&         apt-get install -y --force-yes --no-install-recommends nodejs &&                 echo \"===> Installing Yarn\" &&         curl -sS https://dl.yarnpkg.com/debian/pubkey.gpg | apt-key add - &&         echo \"deb https://dl.yarnpkg.com/debian/ stable main\" | tee /etc/apt/sources.list.d/yarn.list &&         apt-get update &&         apt-get install -y --force-yes --no-install-recommends yarn &&                 echo \"===> Installing database libraries\" &&         apt-get install -y --force-yes --no-install-recommends             postgresql-client sqlite3 &&                 echo \"===> Installing dev tools\" &&         mkdir -p /usr/share/man/man1 &&         apt-get install -y --force-yes --no-install-recommends             sudo git openssh-client rsync vim             net-tools netcat parallel unzip zip bzip2 &&                 echo \"===> Cleaning up\" &&         rm -rf /var/lib/apt/lists/*;" did not complete successfully: exit code: 100
```

Thus, I replaced `netcat` with `netcat-openbsd` and the local image build started passing again.

Why `netcat-openbsd` and not `netcat-traditional`? That's because `netcat-openbsd` is a default dependency on ubuntu (see <https://packages.ubuntu.com/jammy/ubuntu-minimal>) and that seemed to be a good reason to select this version over the other.

**Motivation**:

Make sure CI is always green.

**Additional Notes**:

N/A

**How to test the change?**:

Make sure `integration/script/build-images -v 3.1` (or 3.2/3.3) works again.
