### PR TITLE
`peer.service` extraction logic w/AWS

### DIFF
--- a/lib/datadog/tracing/configuration/ext.rb
+++ b/lib/datadog/tracing/configuration/ext.rb
@@ -13,6 +13,7 @@ module Datadog
         module SpanAttributeSchema
           ENV_SPAN_ATTRIBUTE_SCHEMA = 'DD_TRACE_SPAN_ATTRIBUTE_SCHEMA'
           DEFAULT_VERSION = 'v0'
+          VERSION_ZERO = 'v0'
           VERSION_ONE = 'v1'
         end
 

--- a/lib/datadog/tracing/contrib/aws/ext.rb
+++ b/lib/datadog/tracing/contrib/aws/ext.rb
@@ -31,13 +31,16 @@ module Datadog
           TAG_RULE_NAME = 'rulename'
           TAG_STATE_MACHINE_NAME = 'statemachinename'
           TAG_BUCKET_NAME = 'bucketname'
-          PEER_SERVICE_SOURCE_AWS = Array[TAG_QUEUE_NAME,
-                                TAG_TOPIC_NAME,
-                                TAG_STREAM_NAME,
-                                TAG_TABLE_NAME,
-                                TAG_BUCKET_NAME,
-                                TAG_RULE_NAME,
-                                TAG_STATE_MACHINE_NAME,].freeze
+          PEER_SERVICE_SOURCES = Array[TAG_QUEUE_NAME,
+            TAG_TOPIC_NAME,
+            TAG_STREAM_NAME,
+            TAG_TABLE_NAME,
+            TAG_BUCKET_NAME,
+            TAG_RULE_NAME,
+            TAG_STATE_MACHINE_NAME,
+            Tracing::Metadata::Ext::NET::TAG_DESTINATION_NAME,
+            Tracing::Metadata::Ext::TAG_PEER_HOSTNAME,
+            Tracing::Metadata::Ext::NET::TAG_TARGET_HOST,].freeze
         end
       end
     end

--- a/lib/datadog/tracing/contrib/aws/ext.rb
+++ b/lib/datadog/tracing/contrib/aws/ext.rb
@@ -31,6 +31,13 @@ module Datadog
           TAG_RULE_NAME = 'rulename'
           TAG_STATE_MACHINE_NAME = 'statemachinename'
           TAG_BUCKET_NAME = 'bucketname'
+          PEER_SERVICE_SOURCE_AWS = Array[TAG_QUEUE_NAME,
+                                TAG_TOPIC_NAME,
+                                TAG_STREAM_NAME,
+                                TAG_TABLE_NAME,
+                                TAG_BUCKET_NAME,
+                                TAG_RULE_NAME,
+                                TAG_STATE_MACHINE_NAME,].freeze
         end
       end
     end

--- a/lib/datadog/tracing/contrib/aws/instrumentation.rb
+++ b/lib/datadog/tracing/contrib/aws/instrumentation.rb
@@ -66,7 +66,7 @@ module Datadog
             if Contrib::SpanAttributeSchema.default_span_attribute_schema?
               span.set_tag(Tracing::Metadata::Ext::TAG_PEER_SERVICE, span.service)
             else
-              Contrib::SpanAttributeSchema.set_peer_service(span)
+              Contrib::SpanAttributeSchema.set_peer_service(span, Ext::PEER_SERVICE_SOURCE_AWS)
             end
           end
 

--- a/lib/datadog/tracing/contrib/aws/instrumentation.rb
+++ b/lib/datadog/tracing/contrib/aws/instrumentation.rb
@@ -45,11 +45,6 @@ module Datadog
             span.set_tag(Tracing::Metadata::Ext::TAG_COMPONENT, Ext::TAG_COMPONENT)
             span.set_tag(Tracing::Metadata::Ext::TAG_OPERATION, Ext::TAG_OPERATION_COMMAND)
 
-            # Tag as an external peer service
-            if Contrib::SpanAttributeSchema.default_span_attribute_schema?
-              span.set_tag(Tracing::Metadata::Ext::TAG_PEER_SERVICE, span.service)
-            end
-
             span.set_tag(Tracing::Metadata::Ext::TAG_PEER_HOSTNAME, context.safely(:host))
 
             # Set analytics sample rate
@@ -66,6 +61,13 @@ module Datadog
             span.set_tag(Ext::TAG_HOST, context.safely(:host))
             span.set_tag(Tracing::Metadata::Ext::HTTP::TAG_METHOD, context.safely(:http_method))
             span.set_tag(Tracing::Metadata::Ext::HTTP::TAG_STATUS_CODE, context.safely(:status_code))
+
+            # Tag as an external peer service
+            if Contrib::SpanAttributeSchema.default_span_attribute_schema?
+              span.set_tag(Tracing::Metadata::Ext::TAG_PEER_SERVICE, span.service)
+            else
+              Contrib::SpanAttributeSchema.set_peer_service(span)
+            end
           end
 
           def configuration

--- a/lib/datadog/tracing/contrib/aws/instrumentation.rb
+++ b/lib/datadog/tracing/contrib/aws/instrumentation.rb
@@ -66,7 +66,7 @@ module Datadog
             if Contrib::SpanAttributeSchema.default_span_attribute_schema?
               span.set_tag(Tracing::Metadata::Ext::TAG_PEER_SERVICE, span.service)
             else
-              Contrib::SpanAttributeSchema.set_peer_service(span, Ext::PEER_SERVICE_SOURCE_AWS)
+              Contrib::SpanAttributeSchema.set_peer_service(span, Ext::PEER_SERVICE_SOURCES)
             end
           end
 

--- a/lib/datadog/tracing/contrib/aws/instrumentation.rb
+++ b/lib/datadog/tracing/contrib/aws/instrumentation.rb
@@ -62,12 +62,7 @@ module Datadog
             span.set_tag(Tracing::Metadata::Ext::HTTP::TAG_METHOD, context.safely(:http_method))
             span.set_tag(Tracing::Metadata::Ext::HTTP::TAG_STATUS_CODE, context.safely(:status_code))
 
-            # Tag as an external peer service
-            if Contrib::SpanAttributeSchema.default_span_attribute_schema?
-              span.set_tag(Tracing::Metadata::Ext::TAG_PEER_SERVICE, span.service)
-            else
-              Contrib::SpanAttributeSchema.set_peer_service(span, Ext::PEER_SERVICE_SOURCES)
-            end
+            Contrib::SpanAttributeSchema.set_peer_service!(span, Ext::PEER_SERVICE_SOURCES)
           end
 
           def configuration

--- a/lib/datadog/tracing/contrib/ext.rb
+++ b/lib/datadog/tracing/contrib/ext.rb
@@ -30,6 +30,24 @@ module Datadog
           TAG_RABBITMQ_ROUTING_KEY = 'messaging.rabbitmq.routing_key'
           TAG_KAFKA_BOOTSTRAP_SERVERS = 'messaging.kafka.bootstrap.servers'
         end
+
+        module SpanAttributeSchema
+          PEER_SERVICE_SOURCE_AWS = Array[Aws::Ext::TAG_QUEUE_NAME,
+            Aws::Ext::TAG_TOPIC_NAME,
+            Aws::Ext::TAG_STREAM_NAME,
+            Aws::Ext::TAG_TABLE_NAME,
+            Aws::Ext::TAG_BUCKET_NAME,
+            Aws::Ext::TAG_RULE_NAME,
+            Aws::Ext::TAG_STATE_MACHINE_NAME,]
+
+          # TODO: consolidate all db.name tags to 1 tag name and add to array here
+          PEER_SERVICE_SOURCE_DB = Array[Tracing::Contrib::Ext::DB::TAG_INSTANCE]
+
+          # TODO: add kafka bootstrap servers tag
+          PEER_SERVICE_SOURCE_MSG = Array[]
+
+          PEER_SERVICE_SOURCE_RPC = Array[Tracing::Contrib::Ext::RPC::TAG_SERVICE]
+        end
       end
     end
   end

--- a/lib/datadog/tracing/contrib/ext.rb
+++ b/lib/datadog/tracing/contrib/ext.rb
@@ -30,24 +30,6 @@ module Datadog
           TAG_RABBITMQ_ROUTING_KEY = 'messaging.rabbitmq.routing_key'
           TAG_KAFKA_BOOTSTRAP_SERVERS = 'messaging.kafka.bootstrap.servers'
         end
-
-        module SpanAttributeSchema
-          PEER_SERVICE_SOURCE_AWS = Array[Aws::Ext::TAG_QUEUE_NAME,
-            Aws::Ext::TAG_TOPIC_NAME,
-            Aws::Ext::TAG_STREAM_NAME,
-            Aws::Ext::TAG_TABLE_NAME,
-            Aws::Ext::TAG_BUCKET_NAME,
-            Aws::Ext::TAG_RULE_NAME,
-            Aws::Ext::TAG_STATE_MACHINE_NAME,]
-
-          # TODO: consolidate all db.name tags to 1 tag name and add to array here
-          PEER_SERVICE_SOURCE_DB = Array[Tracing::Contrib::Ext::DB::TAG_INSTANCE]
-
-          # TODO: add kafka bootstrap servers tag
-          PEER_SERVICE_SOURCE_MSG = Array[]
-
-          PEER_SERVICE_SOURCE_RPC = Array[Tracing::Contrib::Ext::RPC::TAG_SERVICE]
-        end
       end
     end
   end

--- a/lib/datadog/tracing/contrib/ext.rb
+++ b/lib/datadog/tracing/contrib/ext.rb
@@ -28,6 +28,7 @@ module Datadog
         module Messaging
           TAG_SYSTEM = 'messaging.system'
           TAG_RABBITMQ_ROUTING_KEY = 'messaging.rabbitmq.routing_key'
+          TAG_KAFKA_BOOTSTRAP_SERVERS = 'messaging.kafka.bootstrap.servers'
         end
       end
     end

--- a/lib/datadog/tracing/contrib/ext.rb
+++ b/lib/datadog/tracing/contrib/ext.rb
@@ -12,13 +12,20 @@ module Datadog
           TAG_SYSTEM = 'db.system'
           TAG_STATEMENT = 'db.statement'
           TAG_ROW_COUNT = 'db.row_count'
+          PEER_SERVICE_SOURCES = Array[TAG_INSTANCE,
+            Tracing::Metadata::Ext::NET::TAG_DESTINATION_NAME,
+            Tracing::Metadata::Ext::TAG_PEER_HOSTNAME,
+            Tracing::Metadata::Ext::NET::TAG_TARGET_HOST,].freeze
         end
 
         module RPC
           TAG_SYSTEM = 'rpc.system'
           TAG_SERVICE = 'rpc.service'
           TAG_METHOD = 'rpc.method'
-
+          PEER_SERVICE_SOURCES = Array[TAG_SERVICE,
+            Tracing::Metadata::Ext::NET::TAG_DESTINATION_NAME,
+            Tracing::Metadata::Ext::TAG_PEER_HOSTNAME,
+            Tracing::Metadata::Ext::NET::TAG_TARGET_HOST,].freeze
           module GRPC
             TAG_STATUS_CODE = 'rpc.grpc.status_code'
             TAG_FULL_METHOD = 'rpc.grpc.full_method'
@@ -27,8 +34,14 @@ module Datadog
 
         module Messaging
           TAG_SYSTEM = 'messaging.system'
-          TAG_RABBITMQ_ROUTING_KEY = 'messaging.rabbitmq.routing_key'
-          TAG_KAFKA_BOOTSTRAP_SERVERS = 'messaging.kafka.bootstrap.servers'
+          PEER_SERVICE_SOURCES = Array[Tracing::Metadata::Ext::NET::TAG_DESTINATION_NAME,
+            Tracing::Metadata::Ext::TAG_PEER_HOSTNAME,
+            Tracing::Metadata::Ext::NET::TAG_TARGET_HOST,].freeze
+        end
+
+        module Metadata
+          # Name of tag from which where peer.service information was extracted from
+          TAG_PEER_SERVICE_SOURCE = '_dd.peer.service.source'
         end
       end
     end

--- a/lib/datadog/tracing/contrib/kafka/ext.rb
+++ b/lib/datadog/tracing/contrib/kafka/ext.rb
@@ -46,6 +46,7 @@ module Datadog
           TAG_OPERATION_PROCESS_MESSAGE = 'consumer.process_message'
           TAG_OPERATION_SEND_MESSAGES = 'producer.send_messages'
           TAG_MESSAGING_SYSTEM = 'kafka'
+          TAG_KAFKA_BOOTSTRAP_SERVERS = 'messaging.kafka.bootstrap.servers'
         end
       end
     end

--- a/lib/datadog/tracing/contrib/sneakers/ext.rb
+++ b/lib/datadog/tracing/contrib/sneakers/ext.rb
@@ -18,6 +18,7 @@ module Datadog
           TAG_COMPONENT = 'sneakers'
           TAG_OPERATION_JOB = 'job'
           TAG_MESSAGING_SYSTEM = 'rabbitmq'
+          TAG_RABBITMQ_ROUTING_KEY = 'messaging.rabbitmq.routing_key'
         end
       end
     end

--- a/lib/datadog/tracing/contrib/sneakers/tracer.rb
+++ b/lib/datadog/tracing/contrib/sneakers/tracer.rb
@@ -37,7 +37,7 @@ module Datadog
 
               request_span.resource = @app.to_proc.binding.eval('self.class').to_s
               request_span.set_tag(Ext::TAG_JOB_ROUTING_KEY, delivery_info.routing_key)
-              request_span.set_tag(Contrib::Ext::Messaging::TAG_RABBITMQ_ROUTING_KEY, delivery_info.routing_key)
+              request_span.set_tag(Ext::TAG_RABBITMQ_ROUTING_KEY, delivery_info.routing_key)
               request_span.set_tag(Ext::TAG_JOB_QUEUE, delivery_info.consumer.queue.name)
 
               request_span.set_tag(Ext::TAG_JOB_BODY, deserialized_msg) if configuration[:tag_body]

--- a/lib/datadog/tracing/contrib/span_attribute_schema.rb
+++ b/lib/datadog/tracing/contrib/span_attribute_schema.rb
@@ -22,6 +22,61 @@ module Datadog
           Datadog.configuration.tracing.span_attribute_schema ==
             Tracing::Configuration::Ext::SpanAttributeSchema::DEFAULT_VERSION
         end
+
+
+        def should_set_peer_service(span)
+          if span.get_tag(Tracing::Metadata::Ext::TAG_PEER_SERVICE)
+            return false
+          end
+
+          if (span.get_tag(Tracing::Metadata::Ext::TAG_KIND) == Tracing::Metadata::Ext::SpanKind::TAG_CLIENT or
+            span.get_tag(Tracing::Metadata::Ext::TAG_KIND) == Tracing::Metadata::Ext::SpanKind::TAG_PRODUCER) and
+            Datadog.configuration.tracing.span_attribute_schema ==
+              Tracing::Configuration::Ext::SpanAttributeSchema::VERSION_ONE
+            return true
+          end
+          false
+        end
+
+        #implement this function in all target spans/integrations with spankind
+        def set_peer_service(span)
+          if should_set_peer_service(span) and set_peer_service_from_source(span)
+            # else remap + remapped from (SKIP)
+          else
+            # debug that peer service could not be set
+          end
+
+
+        end
+
+
+        def set_peer_service_from_source(span)
+          case
+            when span.get_tag(Aws::Ext::TAG_AWS_SERVICE)
+              sources = Array["queuename",
+                           "topicname",
+                           "streamname",
+                           "tablename",
+                           "bucketname"]
+            #when span.get_tag(DB_SYSTEM)
+            #when span.get_tag(MESSAGING_SYSTEM)
+            #when span.get_tag(RPC)
+          else
+            return false
+          end
+          sources.append(Tracing::Metadata::Ext::NET::TAG_DESTINATION_NAME, Tracing::Metadata::Ext::TAG_PEER_HOSTNAME,
+                        Tracing::Metadata::Ext::NET::TAG_TARGET_HOST)
+
+          for source in sources
+            sourceVal = span.get_tag(source)
+            if sourceVal
+              span.set_tag(Tracing::Metadata::Ext::TAG_PEER_SERVICE, sourceVal)
+              #set source tag here as well
+            end
+          end
+          # set tag + source if found else return nothing
+          # return tag value
+        end
       end
     end
   end

--- a/lib/datadog/tracing/contrib/span_attribute_schema.rb
+++ b/lib/datadog/tracing/contrib/span_attribute_schema.rb
@@ -23,55 +23,53 @@ module Datadog
             Tracing::Configuration::Ext::SpanAttributeSchema::DEFAULT_VERSION
         end
 
-
         def should_set_peer_service(span)
-          if span.get_tag(Tracing::Metadata::Ext::TAG_PEER_SERVICE)
-            return false
-          end
+          return false if span.get_tag(Tracing::Metadata::Ext::TAG_PEER_SERVICE)
 
-          if (span.get_tag(Tracing::Metadata::Ext::TAG_KIND) == Tracing::Metadata::Ext::SpanKind::TAG_CLIENT or
-            span.get_tag(Tracing::Metadata::Ext::TAG_KIND) == Tracing::Metadata::Ext::SpanKind::TAG_PRODUCER) and
-            Datadog.configuration.tracing.span_attribute_schema ==
-              Tracing::Configuration::Ext::SpanAttributeSchema::VERSION_ONE
+          if ((span.get_tag(Tracing::Metadata::Ext::TAG_KIND) == Tracing::Metadata::Ext::SpanKind::TAG_CLIENT) ||
+            (span.get_tag(Tracing::Metadata::Ext::TAG_KIND) == Tracing::Metadata::Ext::SpanKind::TAG_PRODUCER)) &&
+              (Datadog.configuration.tracing.span_attribute_schema ==
+                  Tracing::Configuration::Ext::SpanAttributeSchema::VERSION_ONE)
             return true
           end
+
           false
         end
 
-        #implement this function in all target spans/integrations with spankind
+        # implement this function in all target spans/integrations with spankind
         def set_peer_service(span)
-          if should_set_peer_service(span) and set_peer_service_from_source(span)
+          if should_set_peer_service(span) && set_peer_service_from_source(span)
             # else remap + remapped from (SKIP)
           else
             # debug that peer service could not be set
           end
-
-
         end
-
 
         def set_peer_service_from_source(span)
           case
-            when span.get_tag(Aws::Ext::TAG_AWS_SERVICE)
-              sources = Array["queuename",
-                           "topicname",
-                           "streamname",
-                           "tablename",
-                           "bucketname"]
-            #when span.get_tag(DB_SYSTEM)
-            #when span.get_tag(MESSAGING_SYSTEM)
-            #when span.get_tag(RPC)
+          when span.get_tag(Aws::Ext::TAG_AWS_SERVICE)
+            sources = Array['queuename',
+              'topicname',
+              'streamname',
+              'tablename',
+              'bucketname']
+            # when span.get_tag(DB_SYSTEM)
+            # when span.get_tag(MESSAGING_SYSTEM)
+            # when span.get_tag(RPC)
           else
             return false
           end
-          sources.append(Tracing::Metadata::Ext::NET::TAG_DESTINATION_NAME, Tracing::Metadata::Ext::TAG_PEER_HOSTNAME,
-                        Tracing::Metadata::Ext::NET::TAG_TARGET_HOST)
+          sources.append(
+            Tracing::Metadata::Ext::NET::TAG_DESTINATION_NAME,
+            Tracing::Metadata::Ext::TAG_PEER_HOSTNAME,
+            Tracing::Metadata::Ext::NET::TAG_TARGET_HOST
+          )
 
-          for source in sources
+          sources.each do |source|
             sourceVal = span.get_tag(source)
             if sourceVal
               span.set_tag(Tracing::Metadata::Ext::TAG_PEER_SERVICE, sourceVal)
-              #set source tag here as well
+              # set source tag here as well
             end
           end
           # set tag + source if found else return nothing

--- a/lib/datadog/tracing/contrib/span_attribute_schema.rb
+++ b/lib/datadog/tracing/contrib/span_attribute_schema.rb
@@ -34,11 +34,17 @@ module Datadog
         end
 
         def should_set_peer_service(span)
-          if span.get_tag(Tracing::Metadata::Ext::TAG_PEER_SERVICE)
-            # if peer.service does not equal span.service than set source and return false
-            span.set_tag(Tracing::Metadata::Ext::TAG_PEER_SERVICE_SOURCE, Tracing::Metadata::Ext::TAG_PEER_SERVICE)
-            return false
-            # if peer.service equals span.service if span.service does not equal DD.service then return false
+          ps = span.get_tag(Tracing::Metadata::Ext::TAG_PEER_SERVICE)
+          if ps && (ps != '')
+            if ps != span.service
+              span.set_tag(Tracing::Metadata::Ext::TAG_PEER_SERVICE_SOURCE, Tracing::Metadata::Ext::TAG_PEER_SERVICE)
+              return false
+            end
+
+            if (ps == span.service) && (span.service != Datadog.configuration.service)
+              span.set_tag(Tracing::Metadata::Ext::TAG_PEER_SERVICE_SOURCE, Tracing::Metadata::Ext::TAG_PEER_SERVICE)
+              return false
+            end
           end
 
           if ((span.get_tag(Tracing::Metadata::Ext::TAG_KIND) == Tracing::Metadata::Ext::SpanKind::TAG_CLIENT) ||

--- a/lib/datadog/tracing/contrib/span_attribute_schema.rb
+++ b/lib/datadog/tracing/contrib/span_attribute_schema.rb
@@ -9,94 +9,115 @@ module Datadog
       module SpanAttributeSchema
         module_function
 
-        def fetch_service_name(env, default)
-          ENV.fetch(env) do
-            if Datadog.configuration.tracing.span_attribute_schema ==
-                Tracing::Configuration::Ext::SpanAttributeSchema::VERSION_ONE
-              Datadog.configuration.service
-            else
-              default
-            end
-          end
-        end
-
         def default_span_attribute_schema?
           Datadog.configuration.tracing.span_attribute_schema ==
             Tracing::Configuration::Ext::SpanAttributeSchema::DEFAULT_VERSION
         end
 
-        # TODO: implement function in all integrations with spankind
-        def set_peer_service(span, sources)
-          set_peer_service_from_source(span, sources)
-          # TODO: add logic for remap as long as the above expression is true
-        end
-
-        # set_peer_service_from_source: Implements the extraction logic to determine the peer.service value
-        # based on the list of source tags passed as a parameter.
-        #
-        # If no values are found, it checks the default list for all spans before returning false for no result
-        # Sets the source of where the information for peer.service was extracted from
-        # Returns a boolean if peer.service was successfully set or not
-        def set_peer_service_from_source(span, sources = [])
-          return false unless set_peer_service?(span)
-
-          # Find a possible peer.service source from the list of source tags passed in
-          sources.each do |source|
-            source_val = span.get_tag(source)
-            next unless not_empty_tag?(source_val)
-
-            span.set_tag(Tracing::Metadata::Ext::TAG_PEER_SERVICE, source_val)
-            span.set_tag(Tracing::Contrib::Ext::Metadata::TAG_PEER_SERVICE_SOURCE, source)
-            return true
+        def active_version
+          case Datadog.configuration.tracing.span_attribute_schema
+          when 'v1'
+            VersionOne
+          else
+            VersionZero # Default Version
           end
-          false
         end
 
-        # set_peer_service?: returns boolean to reflect if peer.service should be set as long
-        # This is to prevent overwriting of pre-existing peer.service tags
-        def set_peer_service?(span)
-          # Do not override existing peer.service tag if it exists based on schema version
-          # if v0 then check if span.service != DD_service implying peer.service should be overrode so
-          # set peer source before returning
-          # if v1 then it is implied that peer.service is manually set by user so
-          # set peer source as well before return
-          ps = span.get_tag(Tracing::Metadata::Ext::TAG_PEER_SERVICE)
-          if not_empty_tag?(ps)
-            if Datadog.configuration.tracing.span_attribute_schema !=
-                Tracing::Configuration::Ext::SpanAttributeSchema::VERSION_ONE
-              if span.service != Datadog.configuration.service
-                span.set_tag(
-                  Tracing::Contrib::Ext::Metadata::TAG_PEER_SERVICE_SOURCE,
-                  Tracing::Metadata::Ext::TAG_PEER_SERVICE
-                )
-                return false
-              end
-            else
+        # TODO: add specific env var just for service naming independent of v1
+        def fetch_service_name(env, default)
+          active_version.fetch_service_name(env, default)
+        end
+
+        # TODO: implement function in all integrations with spankind
+        # TODO: add specific env var just for peer.service independent of v1
+        def set_peer_service!(span, sources)
+          active_version.set_peer_service!(span, sources)
+        end
+
+        private_class_method :active_version
+
+        # Contains implementation of methods specific to v0
+        module VersionZero
+          module_function
+
+          def fetch_service_name(env, default)
+            ENV.fetch(env) do
+              default
+            end
+          end
+
+          # TODO: add logic for env var enabling peer service in v0
+          def set_peer_service!(span, sources)
+            span.set_tag(Tracing::Metadata::Ext::TAG_PEER_SERVICE, span.service)
+            false
+            # TODO: add logic for remap if necessary
+          end
+        end
+
+        # Contains implementation of methods specific to v1
+        module VersionOne
+          module_function
+
+          def fetch_service_name(env, default)
+            ENV.fetch(env) do
+              Datadog.configuration.service
+            end
+          end
+
+          def set_peer_service!(span, sources)
+            set_peer_service_from_source(span, sources)
+            # TODO: add logic for remap as long as the above expression is true
+          end
+
+          # set_peer_service_from_source: Implements the extraction logic to determine the peer.service value
+          # based on the list of source tags passed as a parameter.
+          #
+          # If no values are found, it checks the default list for all spans before returning false for no result
+          # Sets the source of where the information for peer.service was extracted from
+          # Returns a boolean if peer.service was successfully set or not
+          def set_peer_service_from_source(span, sources = [])
+            return false unless set_peer_service?(span)
+
+            # Find a possible peer.service source from the list of source tags passed in
+            sources.each do |source|
+              source_val = span.get_tag(source)
+              next unless not_empty_tag?(source_val)
+
+              span.set_tag(Tracing::Metadata::Ext::TAG_PEER_SERVICE, source_val)
+              span.set_tag(Tracing::Contrib::Ext::Metadata::TAG_PEER_SERVICE_SOURCE, source)
+              return true
+            end
+            false
+          end
+
+          # set_peer_service?: returns boolean to reflect if peer.service should be set as long
+          # This is to prevent overwriting of pre-existing peer.service tags
+          def set_peer_service?(span)
+            # Do not override existing peer.service tag if it exists based on schema version
+            ps = span.get_tag(Tracing::Metadata::Ext::TAG_PEER_SERVICE)
+            if not_empty_tag?(ps)
               span.set_tag(
                 Tracing::Contrib::Ext::Metadata::TAG_PEER_SERVICE_SOURCE,
                 Tracing::Metadata::Ext::TAG_PEER_SERVICE
               )
               return false
             end
+
+            # Check that peer.service is only set on spankind client/producer spans while v1 is enabled
+            if (span.get_tag(Tracing::Metadata::Ext::TAG_KIND) == Tracing::Metadata::Ext::SpanKind::TAG_CLIENT) ||
+                (span.get_tag(Tracing::Metadata::Ext::TAG_KIND) == Tracing::Metadata::Ext::SpanKind::TAG_PRODUCER)
+              return true
+            end
+
+            false
           end
 
-          # Check that peer.service is only set on spankind client/producer spans while v1 is enabled
-          if ((span.get_tag(Tracing::Metadata::Ext::TAG_KIND) == Tracing::Metadata::Ext::SpanKind::TAG_CLIENT) ||
-            (span.get_tag(Tracing::Metadata::Ext::TAG_KIND) == Tracing::Metadata::Ext::SpanKind::TAG_PRODUCER)) &&
-              (Datadog.configuration.tracing.span_attribute_schema ==
-                Tracing::Configuration::Ext::SpanAttributeSchema::VERSION_ONE)
-            return true
-            # TODO: add specific env var just for peer.service independent of v1
+          def not_empty_tag?(tag)
+            tag && (tag != '')
           end
 
-          false
+          private_class_method :not_empty_tag?, :set_peer_service_from_source, :set_peer_service?
         end
-
-        def not_empty_tag?(tag)
-          tag && (tag != '')
-        end
-
-        private_class_method :not_empty_tag?, :set_peer_service_from_source, :set_peer_service?
       end
     end
   end

--- a/lib/datadog/tracing/contrib/span_attribute_schema.rb
+++ b/lib/datadog/tracing/contrib/span_attribute_schema.rb
@@ -65,7 +65,7 @@ module Datadog
           else
             return false
           end
-          sources.append(
+          sources.push(
             Tracing::Metadata::Ext::NET::TAG_DESTINATION_NAME,
             Tracing::Metadata::Ext::TAG_PEER_HOSTNAME,
             Tracing::Metadata::Ext::NET::TAG_TARGET_HOST

--- a/lib/datadog/tracing/contrib/span_attribute_schema.rb
+++ b/lib/datadog/tracing/contrib/span_attribute_schema.rb
@@ -29,25 +29,36 @@ module Datadog
           # TODO: add logic for remap as long as the above expression is true
         end
 
-        # set_peer_service?: checks to see if any edited peer.service tags exist so that they are not overwritten
+        # set_peer_service?: returns boolean to reflect if peer.service should be set as long
+        # This is to prevent overwriting of pre-existing peer.service tags
         def set_peer_service?(span)
           ps = span.get_tag(Tracing::Metadata::Ext::TAG_PEER_SERVICE)
           if ps && (ps != '')
 
-            # if peer.service is not equal to span.service we know it is edited
+            # In v0, peer.service is set directly equal to span.service by default.
+            # That value is not the expected functionality here so we can overwrite that peer.service tag
+            # assuming it is in the default state of being equal to the global service.
+            #
+            # If peer.service is not equal to span.service we know this value was explicitly set so we do not overwrite it
             if ps != span.service
               span.set_tag(Tracing::Metadata::Ext::TAG_PEER_SERVICE_SOURCE, Tracing::Metadata::Ext::TAG_PEER_SERVICE)
               return false
             end
 
-            # if span.service is not the global service, we know it was changed to change the peer.service value
+            # There is a unique scenario where the user enables peer.service while in v0.
+            # This means that the peer.service tag can be changed with span.service.
+            # In order to respect that change, we check if span.service was actually modified or in its default state.
+            # Thus if span.service is not equal to the global service,
+            # we can assume the user changed it meaning that this peer.service value must stay.
+            #
+            # If span.service is not the global service, we know it was changed and we keep the peer.service value
             if (ps == span.service) && (span.service != Datadog.configuration.service)
               span.set_tag(Tracing::Metadata::Ext::TAG_PEER_SERVICE_SOURCE, Tracing::Metadata::Ext::TAG_PEER_SERVICE)
               return false
             end
           end
 
-          # only allow peer.service to be changed if it is an outbound span with the correct schema version
+          # Check that peer.service is only set on spankind client/producer spans while v1 is enabled
           if ((span.get_tag(Tracing::Metadata::Ext::TAG_KIND) == Tracing::Metadata::Ext::SpanKind::TAG_CLIENT) ||
             (span.get_tag(Tracing::Metadata::Ext::TAG_KIND) == Tracing::Metadata::Ext::SpanKind::TAG_PRODUCER)) &&
               (Datadog.configuration.tracing.span_attribute_schema ==
@@ -65,6 +76,8 @@ module Datadog
         # Also sets the source of where the information for peer.service was extracted from
         # Returns a boolean if peer.service was successfully set or not
         def set_peer_service_from_source(span)
+
+          # outsource to each integration to make them provide it as a mandatory integration
           case
           when span.get_tag(Aws::Ext::TAG_AWS_SERVICE)
             sources = Tracing::Contrib::Ext::SpanAttributeSchema::PEER_SERVICE_SOURCE_AWS
@@ -77,6 +90,8 @@ module Datadog
           else
             return false
           end
+
+          # make separate array and freeze it as constant and search separately
           sources <<
             Tracing::Metadata::Ext::NET::TAG_DESTINATION_NAME <<
             Tracing::Metadata::Ext::TAG_PEER_HOSTNAME <<

--- a/lib/datadog/tracing/contrib/span_attribute_schema.rb
+++ b/lib/datadog/tracing/contrib/span_attribute_schema.rb
@@ -65,11 +65,10 @@ module Datadog
           else
             return false
           end
-          sources.push(
-            Tracing::Metadata::Ext::NET::TAG_DESTINATION_NAME,
-            Tracing::Metadata::Ext::TAG_PEER_HOSTNAME,
+          sources <<
+            Tracing::Metadata::Ext::NET::TAG_DESTINATION_NAME <<
+            Tracing::Metadata::Ext::TAG_PEER_HOSTNAME <<
             Tracing::Metadata::Ext::NET::TAG_TARGET_HOST
-          )
 
           sources.each do |source|
             source_val = span.get_tag(source)

--- a/lib/datadog/tracing/contrib/span_attribute_schema.rb
+++ b/lib/datadog/tracing/contrib/span_attribute_schema.rb
@@ -23,6 +23,16 @@ module Datadog
             Tracing::Configuration::Ext::SpanAttributeSchema::DEFAULT_VERSION
         end
 
+        # implement this function in all target spans/integrations with spankind
+        def set_peer_service(span)
+          should_set_peer_service(span) && set_peer_service_from_source(span)
+          # if above
+          # then remap + remapped from (SKIP)
+          # else
+          # debug that peer service could not be set
+          # end
+        end
+
         def should_set_peer_service(span)
           if span.get_tag(Tracing::Metadata::Ext::TAG_PEER_SERVICE)
             # if peer.service does not equal span.service than set source and return false
@@ -34,21 +44,11 @@ module Datadog
           if ((span.get_tag(Tracing::Metadata::Ext::TAG_KIND) == Tracing::Metadata::Ext::SpanKind::TAG_CLIENT) ||
             (span.get_tag(Tracing::Metadata::Ext::TAG_KIND) == Tracing::Metadata::Ext::SpanKind::TAG_PRODUCER)) &&
               (Datadog.configuration.tracing.span_attribute_schema ==
-                  Tracing::Configuration::Ext::SpanAttributeSchema::VERSION_ONE)
+                  Tracing::Configuration::Ext::SpanAttributeSchema::VERSION_ONE) # OR if env var is set
             return true
           end
 
           false
-        end
-
-        # implement this function in all target spans/integrations with spankind
-        def set_peer_service(span)
-          should_set_peer_service(span) && set_peer_service_from_source(span)
-          # if above
-          # then remap + remapped from (SKIP)
-          # else
-          # debug that peer service could not be set
-          # end
         end
 
         def set_peer_service_from_source(span)

--- a/lib/datadog/tracing/contrib/span_attribute_schema.rb
+++ b/lib/datadog/tracing/contrib/span_attribute_schema.rb
@@ -9,18 +9,6 @@ module Datadog
       module SpanAttributeSchema
         module_function
 
-        # TODO: consolidate all db.name tags to 1 tag name and add to array here
-        PEER_SERVICE_SOURCE_DB = Array[Tracing::Contrib::Ext::DB::TAG_INSTANCE].freeze
-
-        # TODO: add kafka bootstrap servers tag
-        PEER_SERVICE_SOURCE_MSG = Array[].freeze
-
-        PEER_SERVICE_SOURCE_RPC = Array[Tracing::Contrib::Ext::RPC::TAG_SERVICE].freeze
-
-        PEER_SERVICE_SOURCE_DEFAULT = Array[Tracing::Metadata::Ext::NET::TAG_DESTINATION_NAME,
-          Tracing::Metadata::Ext::TAG_PEER_HOSTNAME,
-          Tracing::Metadata::Ext::NET::TAG_TARGET_HOST,].freeze
-
         def fetch_service_name(env, default)
           ENV.fetch(env) do
             if Datadog.configuration.tracing.span_attribute_schema ==
@@ -39,37 +27,24 @@ module Datadog
 
         # TODO: implement function in all integrations with spankind
         def set_peer_service(span, sources)
-          set_peer_service?(span) && set_peer_service_from_source(span, sources)
+          set_peer_service_from_source(span, sources)
           # TODO: add logic for remap as long as the above expression is true
         end
 
         # set_peer_service?: returns boolean to reflect if peer.service should be set as long
         # This is to prevent overwriting of pre-existing peer.service tags
         def set_peer_service?(span)
-          ps = span.get_tag(Tracing::Metadata::Ext::TAG_PEER_SERVICE)
-          if ps && (ps != '')
-
-            # In v0, peer.service is set directly equal to span.service by default.
-            # That value is not the expected functionality here so we can overwrite that peer.service tag
-            # assuming it is in the default state of being equal to the global service.
-            #
-            # If peer.service is not equal to span.service we know this value was explicitly set so we do not overwrite it
-            if ps != span.service
-              span.set_tag(Tracing::Metadata::Ext::TAG_PEER_SERVICE_SOURCE, Tracing::Metadata::Ext::TAG_PEER_SERVICE)
-              return false
+          # Check if peer.service is set
+          if span.service != Datadog.configuration.service
+            if not_empty_tag?(span.get_tag(Tracing::Metadata::Ext::TAG_PEER_SERVICE))
+              span.set_tag(
+                Tracing::Contrib::Ext::Metadata::TAG_PEER_SERVICE_SOURCE,
+                Tracing::Metadata::Ext::TAG_PEER_SERVICE
+              )
             end
-
-            # There is a unique scenario where the user enables peer.service while in v0.
-            # This means that the peer.service tag can be changed with span.service.
-            # In order to respect that change, we check if span.service was actually modified or in its default state.
-            # Thus if span.service is not equal to the global service,
-            # we can assume the user changed it meaning that this peer.service value must stay.
-            #
-            # If span.service is not the global service, we know it was changed and we keep the peer.service value
-            if span.service != Datadog.configuration.service
-              span.set_tag(Tracing::Metadata::Ext::TAG_PEER_SERVICE_SOURCE, Tracing::Metadata::Ext::TAG_PEER_SERVICE)
-              return false
-            end
+          else
+            span.set_tag(Tracing::Metadata::Ext::TAG_PEER_SERVICE, span.service)
+            span.set_tag(Tracing::Contrib::Ext::Metadata::TAG_PEER_SERVICE_SOURCE, Tracing::Metadata::Ext::TAG_PEER_SERVICE)
           end
 
           # Check that peer.service is only set on spankind client/producer spans while v1 is enabled
@@ -78,7 +53,6 @@ module Datadog
               (Datadog.configuration.tracing.span_attribute_schema ==
                   Tracing::Configuration::Ext::SpanAttributeSchema::VERSION_ONE)
             return true
-
             # TODO: add specific env var just for peer.service independent of v1
           end
 
@@ -92,27 +66,22 @@ module Datadog
         # Sets the source of where the information for peer.service was extracted from
         # Returns a boolean if peer.service was successfully set or not
         def set_peer_service_from_source(span, sources = [])
+          return false unless set_peer_service?(span)
+
           # Find a possible peer.service source from the list of source tags passed in
           sources.each do |source|
             source_val = span.get_tag(source)
-            next unless source_val && source_val != ''
+            next unless not_empty_tag?(source_val)
 
             span.set_tag(Tracing::Metadata::Ext::TAG_PEER_SERVICE, source_val)
-            span.set_tag(Tracing::Metadata::Ext::TAG_PEER_SERVICE_SOURCE, source)
+            span.set_tag(Tracing::Contrib::Ext::Metadata::TAG_PEER_SERVICE_SOURCE, source)
             return true
           end
-
-          # Fina a backup peer.service source from list of default sources
-          PEER_SERVICE_SOURCE_DEFAULT.each do |default|
-            source_val = span.get_tag(default)
-            next unless source_val && source_val != ''
-
-            span.set_tag(Tracing::Metadata::Ext::TAG_PEER_SERVICE, source_val)
-            span.set_tag(Tracing::Metadata::Ext::TAG_PEER_SERVICE_SOURCE, default)
-            return true
-          end
-
           false
+        end
+
+        def not_empty_tag?(tag)
+          tag && (tag != '')
         end
       end
     end

--- a/lib/datadog/tracing/metadata/ext.rb
+++ b/lib/datadog/tracing/metadata/ext.rb
@@ -17,6 +17,8 @@ module Datadog
         TAG_PEER_HOSTNAME = 'peer.hostname'
         # Name of external service that performed the work
         TAG_PEER_SERVICE = 'peer.service'
+        # Name of tag from which where peer.service information was extracted from
+        TAG_PEER_SERVICE_SOURCE = '_dd.peer.service.source'
 
         TAG_KIND = 'span.kind'
 

--- a/lib/datadog/tracing/metadata/ext.rb
+++ b/lib/datadog/tracing/metadata/ext.rb
@@ -17,8 +17,6 @@ module Datadog
         TAG_PEER_HOSTNAME = 'peer.hostname'
         # Name of external service that performed the work
         TAG_PEER_SERVICE = 'peer.service'
-        # Name of tag from which where peer.service information was extracted from
-        TAG_PEER_SERVICE_SOURCE = '_dd.peer.service.source'
 
         TAG_KIND = 'span.kind'
 

--- a/sig/datadog/tracing/configuration/ext.rbs
+++ b/sig/datadog/tracing/configuration/ext.rbs
@@ -11,6 +11,7 @@ module Datadog
           DEFAULT_VERSION: "v0"
 
           VERSION_ONE: "v1"
+          VERSION_ZERO: "v0"
         end
         module Analytics
           ENV_TRACE_ANALYTICS_ENABLED: "DD_TRACE_ANALYTICS_ENABLED"

--- a/sig/datadog/tracing/contrib/aws/ext.rbs
+++ b/sig/datadog/tracing/contrib/aws/ext.rbs
@@ -13,6 +13,8 @@ module Datadog
 
           DEFAULT_PEER_SERVICE_NAME: "aws"
 
+          PEER_SERVICE_SOURCES: Array[String]
+
           SPAN_COMMAND: "aws.command"
 
           TAG_AGENT: "aws.agent"

--- a/sig/datadog/tracing/contrib/aws/ext.rbs
+++ b/sig/datadog/tracing/contrib/aws/ext.rbs
@@ -50,6 +50,8 @@ module Datadog
           TAG_STATE_MACHINE_NAME: "statemachinename"
 
           TAG_BUCKET_NAME: "bucketname"
+
+          PEER_SERVICE_SOURCE_AWS: Array[string]
         end
       end
     end

--- a/sig/datadog/tracing/contrib/ext.rbs
+++ b/sig/datadog/tracing/contrib/ext.rbs
@@ -23,6 +23,7 @@ module Datadog
         end
 
         module Messaging
+          TAG_KAFKA_BOOTSTRAP_SERVERS: "messaging.kafka.bootstrap.servers"
           TAG_SYSTEM: "messaging.system"
 
           TAG_RABBITMQ_ROUTING_KEY: "messaging.rabbitmq.routing_key"

--- a/sig/datadog/tracing/contrib/ext.rbs
+++ b/sig/datadog/tracing/contrib/ext.rbs
@@ -3,6 +3,7 @@ module Datadog
     module Contrib
       module Ext
         module DB
+          PEER_SERVICE_SOURCES: Array[string]
           TAG_INSTANCE: "db.instance"
 
           TAG_USER: "db.user"
@@ -15,25 +16,25 @@ module Datadog
         end
 
         module RPC
+          PEER_SERVICE_SOURCES: Array[string]
           TAG_SYSTEM: "rpc.system"
 
           TAG_SERVICE: "rpc.service"
 
           TAG_METHOD: "rpc.method"
+          module GRPC
+            TAG_STATUS_CODE: "rpc.grpc.status_code"
+            TAG_FULL_METHOD: "rpc.grpc.full_method"
+          end
         end
 
         module Messaging
-          TAG_KAFKA_BOOTSTRAP_SERVERS: "messaging.kafka.bootstrap.servers"
+          PEER_SERVICE_SOURCES: Array[string]
           TAG_SYSTEM: "messaging.system"
-
-          TAG_RABBITMQ_ROUTING_KEY: "messaging.rabbitmq.routing_key"
         end
 
-        module SpanAttributeSchema
-          PEER_SERVICE_SOURCE_AWS: Array[string]
-          PEER_SERVICE_SOURCE_DB: Array[string]
-          PEER_SERVICE_SOURCE_MSG: Array[string]
-          PEER_SERVICE_SOURCE_RPC: Array[string]
+        module Metadata
+          TAG_PEER_SERVICE_SOURCE: "_dd.peer.service.source"
         end
       end
     end

--- a/sig/datadog/tracing/contrib/ext.rbs
+++ b/sig/datadog/tracing/contrib/ext.rbs
@@ -28,6 +28,13 @@ module Datadog
 
           TAG_RABBITMQ_ROUTING_KEY: "messaging.rabbitmq.routing_key"
         end
+
+        module SpanAttributeSchema
+          PEER_SERVICE_SOURCE_AWS: Array[string]
+          PEER_SERVICE_SOURCE_DB: Array[string]
+          PEER_SERVICE_SOURCE_MSG: Array[string]
+          PEER_SERVICE_SOURCE_RPC: Array[string]
+        end
       end
     end
   end

--- a/sig/datadog/tracing/contrib/kafka/ext.rbs
+++ b/sig/datadog/tracing/contrib/kafka/ext.rbs
@@ -37,6 +37,7 @@ module Datadog
 
           TAG_HIGHWATER_MARK_OFFSET: "kafka.highwater_mark_offset"
 
+          TAG_KAFKA_BOOTSTRAP_SERVERS: "messaging.kafka.bootstrap.servers"
           TAG_MESSAGE_COUNT: "kafka.message_count"
 
           TAG_MESSAGE_KEY: "kafka.message_key"

--- a/sig/datadog/tracing/contrib/sneakers/ext.rbs
+++ b/sig/datadog/tracing/contrib/sneakers/ext.rbs
@@ -24,6 +24,7 @@ module Datadog
           TAG_OPERATION_JOB: "job"
 
           TAG_MESSAGING_SYSTEM: "rabbitmq"
+          TAG_RABBITMQ_ROUTING_KEY: "messaging.rabbitmq.routing_key"
         end
       end
     end

--- a/sig/datadog/tracing/contrib/span_attribute_schema.rbs
+++ b/sig/datadog/tracing/contrib/span_attribute_schema.rbs
@@ -2,9 +2,15 @@ module Datadog
   module Tracing
     module Contrib
       module SpanAttributeSchema
-        def self?.fetch_service_name: (untyped env, untyped default) -> untyped
+        def self?.fetch_service_name: (string env, string default) -> bool
 
-        def self?.default_span_attribute_schema?: () -> untyped
+        def self?.default_span_attribute_schema?: () -> bool
+
+        def set_peer_service: -> bool
+
+        def should_set_peer_service: -> bool
+
+        def set_peer_service_from_source: -> bool
       end
     end
   end

--- a/sig/datadog/tracing/contrib/span_attribute_schema.rbs
+++ b/sig/datadog/tracing/contrib/span_attribute_schema.rbs
@@ -11,6 +11,8 @@ module Datadog
 
         def self?.default_span_attribute_schema?: () -> bool
 
+        def not_empty_tag?: (string) -> bool
+
         def set_peer_service: -> bool
 
         def set_peer_service?: -> bool

--- a/sig/datadog/tracing/contrib/span_attribute_schema.rbs
+++ b/sig/datadog/tracing/contrib/span_attribute_schema.rbs
@@ -8,7 +8,7 @@ module Datadog
 
         def set_peer_service: -> bool
 
-        def should_set_peer_service: -> bool
+        def set_peer_service?: -> bool
 
         def set_peer_service_from_source: -> bool
       end

--- a/sig/datadog/tracing/contrib/span_attribute_schema.rbs
+++ b/sig/datadog/tracing/contrib/span_attribute_schema.rbs
@@ -2,6 +2,11 @@ module Datadog
   module Tracing
     module Contrib
       module SpanAttributeSchema
+        PEER_SERVICE_SOURCE_DB: Array[string]
+        PEER_SERVICE_SOURCE_DEFAULT: Array[string]
+        PEER_SERVICE_SOURCE_MSG: Array[string]
+        PEER_SERVICE_SOURCE_RPC: Array[string]
+
         def self?.fetch_service_name: (string env, string default) -> bool
 
         def self?.default_span_attribute_schema?: () -> bool

--- a/spec/datadog/tracing/contrib/aws/instrumentation_spec.rb
+++ b/spec/datadog/tracing/contrib/aws/instrumentation_spec.rb
@@ -44,7 +44,7 @@ RSpec.describe 'AWS instrumentation' do
       it_behaves_like 'measured span for integration'
       it_behaves_like 'a peer service span'
       it_behaves_like 'environment service name', 'DD_TRACE_AWS_SERVICE_NAME'
-      it_behaves_like 'schema version span', 'sts.us-stubbed-1.amazonaws.com'
+      it_behaves_like 'schema version span', 'sts.us-stubbed-1.amazonaws.com', 'peer.hostname'
 
       it 'generates a span' do
         expect(span.name).to eq('aws.command')
@@ -95,8 +95,9 @@ RSpec.describe 'AWS instrumentation' do
       end
 
       it_behaves_like 'measured span for integration'
+      it_behaves_like 'a peer service span'
       it_behaves_like 'environment service name', 'DD_TRACE_AWS_SERVICE_NAME'
-      it_behaves_like 'schema version span', 's3.us-stubbed-1.amazonaws.com'
+      it_behaves_like 'schema version span', 's3.us-stubbed-1.amazonaws.com', 'peer.hostname'
 
       it 'generates a span' do
         expect(span.name).to eq('aws.command')
@@ -126,8 +127,6 @@ RSpec.describe 'AWS instrumentation' do
           .to eq('s3.us-stubbed-1.amazonaws.com')
       end
 
-      it_behaves_like 'a peer service span'
-
       it 'returns an unmodified response' do
         expect(list_buckets.buckets.map(&:name)).to eq(['bucket1'])
       end
@@ -139,6 +138,11 @@ RSpec.describe 'AWS instrumentation' do
       let(:responses) do
         { list_objects: {} }
       end
+
+      it_behaves_like 'a peer service span'
+      it_behaves_like 'environment service name', 'DD_TRACE_AWS_SERVICE_NAME'
+      it_behaves_like 'schema version span', 'bucketname', 'bucketname'
+
       it 'generates a span' do
         expect(span.name).to eq('aws.command')
         expect(span.service).to eq('aws')
@@ -213,6 +217,10 @@ RSpec.describe 'AWS instrumentation' do
         } }
       end
 
+      it_behaves_like 'a peer service span'
+      it_behaves_like 'environment service name', 'DD_TRACE_AWS_SERVICE_NAME'
+      it_behaves_like 'schema version span', 'MyQueueName', 'queuename'
+
       it 'generates a span' do
         expect(span.name).to eq('aws.command')
         expect(span.service).to eq('aws')
@@ -284,6 +292,10 @@ RSpec.describe 'AWS instrumentation' do
         } }
       end
 
+      it_behaves_like 'a peer service span'
+      it_behaves_like 'environment service name', 'DD_TRACE_AWS_SERVICE_NAME'
+      it_behaves_like 'schema version span', 'MyQueueName', 'queuename'
+
       it 'generates a span' do
         expect(span.name).to eq('aws.command')
         expect(span.service).to eq('aws')
@@ -327,6 +339,10 @@ RSpec.describe 'AWS instrumentation' do
           queue_url: 'myQueueURL'
         } }
       end
+
+      it_behaves_like 'a peer service span'
+      it_behaves_like 'environment service name', 'DD_TRACE_AWS_SERVICE_NAME'
+      it_behaves_like 'schema version span', 'MyQueueName', 'queuename'
 
       it 'generates a span' do
         expect(span.name).to eq('aws.command')
@@ -375,6 +391,10 @@ RSpec.describe 'AWS instrumentation' do
           sequence_number: '5678'
         } }
       end
+
+      it_behaves_like 'a peer service span'
+      it_behaves_like 'environment service name', 'DD_TRACE_AWS_SERVICE_NAME'
+      it_behaves_like 'schema version span', 'my-topic-name', 'topicname'
 
       it 'generates a span' do
         expect(span.name).to eq('aws.command')
@@ -428,6 +448,10 @@ RSpec.describe 'AWS instrumentation' do
         } }
       end
 
+      it_behaves_like 'a peer service span'
+      it_behaves_like 'environment service name', 'DD_TRACE_AWS_SERVICE_NAME'
+      it_behaves_like 'schema version span', 'topicName', 'topicname'
+
       it 'generates a span' do
         expect(span.name).to eq('aws.command')
         expect(span.service).to eq('aws')
@@ -471,6 +495,10 @@ RSpec.describe 'AWS instrumentation' do
           }
         } }
       end
+
+      it_behaves_like 'a peer service span'
+      it_behaves_like 'environment service name', 'DD_TRACE_AWS_SERVICE_NAME'
+      it_behaves_like 'schema version span', 'my-table-name', 'tablename'
 
       it 'generates a span' do
         expect(span.name).to eq('aws.command')
@@ -520,6 +548,10 @@ RSpec.describe 'AWS instrumentation' do
         } }
       end
 
+      it_behaves_like 'a peer service span'
+      it_behaves_like 'environment service name', 'DD_TRACE_AWS_SERVICE_NAME'
+      it_behaves_like 'schema version span', 'my-stream-name', 'streamname'
+
       it 'generates a span' do
         expect(span.name).to eq('aws.command')
         expect(span.service).to eq('aws')
@@ -567,6 +599,11 @@ RSpec.describe 'AWS instrumentation' do
           }
         } }
       end
+
+      it_behaves_like 'a peer service span'
+      it_behaves_like 'environment service name', 'DD_TRACE_AWS_SERVICE_NAME'
+      it_behaves_like 'schema version span', 'my-stream', 'streamname'
+
       it 'generates a span' do
         expect(span.name).to eq('aws.command')
         expect(span.service).to eq('aws')
@@ -612,6 +649,11 @@ RSpec.describe 'AWS instrumentation' do
           }
         } }
       end
+
+      it_behaves_like 'a peer service span'
+      it_behaves_like 'environment service name', 'DD_TRACE_AWS_SERVICE_NAME'
+      it_behaves_like 'schema version span', 'my-stream', 'streamname'
+
       it 'generates a span' do
         expect(span.name).to eq('aws.command')
         expect(span.service).to eq('aws')
@@ -662,6 +704,10 @@ RSpec.describe 'AWS instrumentation' do
         } }
       end
 
+      it_behaves_like 'a peer service span'
+      it_behaves_like 'environment service name', 'DD_TRACE_AWS_SERVICE_NAME'
+      it_behaves_like 'schema version span', 'RuleName', 'rulename'
+
       it 'generates a span' do
         expect(span.name).to eq('aws.command')
         expect(span.service).to eq('aws')
@@ -703,6 +749,10 @@ RSpec.describe 'AWS instrumentation' do
           targets: []
         } }
       end
+
+      it_behaves_like 'a peer service span'
+      it_behaves_like 'environment service name', 'DD_TRACE_AWS_SERVICE_NAME'
+      it_behaves_like 'schema version span', 'RuleName', 'rulename'
 
       it 'generates a span' do
         expect(span.name).to eq('aws.command')
@@ -751,6 +801,10 @@ RSpec.describe 'AWS instrumentation' do
         } }
       end
 
+      it_behaves_like 'a peer service span'
+      it_behaves_like 'environment service name', 'DD_TRACE_AWS_SERVICE_NAME'
+      it_behaves_like 'schema version span', 'MyStateMachine', 'statemachinename'
+
       it 'generates a span' do
         expect(span.name).to eq('aws.command')
         expect(span.service).to eq('aws')
@@ -796,6 +850,10 @@ RSpec.describe 'AWS instrumentation' do
           creation_date: Time.new(2023, 3, 31, 12, 30, 0, '-04:00')
         } }
       end
+
+      it_behaves_like 'a peer service span'
+      it_behaves_like 'environment service name', 'DD_TRACE_AWS_SERVICE_NAME'
+      it_behaves_like 'schema version span', 'my-state-machine-name', 'statemachinename'
 
       it 'generates a span' do
         expect(span.name).to eq('aws.command')
@@ -849,6 +907,10 @@ RSpec.describe 'AWS instrumentation' do
         } }
       end
 
+      it_behaves_like 'a peer service span'
+      it_behaves_like 'environment service name', 'DD_TRACE_AWS_SERVICE_NAME'
+      it_behaves_like 'schema version span', 'my-state-machine-name', 'statemachinename'
+
       it 'generates a span' do
         expect(span.name).to eq('aws.command')
         expect(span.service).to eq('aws')
@@ -891,6 +953,10 @@ RSpec.describe 'AWS instrumentation' do
         } }
       end
 
+      it_behaves_like 'a peer service span'
+      it_behaves_like 'environment service name', 'DD_TRACE_AWS_SERVICE_NAME'
+      it_behaves_like 'schema version span', 'my-state-machine-name', 'statemachinename'
+
       it 'generates a span' do
         expect(span.name).to eq('aws.command')
         expect(span.service).to eq('aws')
@@ -930,6 +996,10 @@ RSpec.describe 'AWS instrumentation' do
       let(:responses) do
         { delete_state_machine: {} }
       end
+
+      it_behaves_like 'a peer service span'
+      it_behaves_like 'environment service name', 'DD_TRACE_AWS_SERVICE_NAME'
+      it_behaves_like 'schema version span', 'my-state-machine-name', 'statemachinename'
 
       it 'generates a span' do
         expect(span.name).to eq('aws.command')
@@ -987,6 +1057,10 @@ RSpec.describe 'AWS instrumentation' do
         } }
       end
 
+      it_behaves_like 'a peer service span'
+      it_behaves_like 'environment service name', 'DD_TRACE_AWS_SERVICE_NAME'
+      it_behaves_like 'schema version span', 'example-state-machine', 'statemachinename'
+
       it 'generates a span' do
         expect(span.name).to eq('aws.command')
         expect(span.service).to eq('aws')
@@ -1028,6 +1102,10 @@ RSpec.describe 'AWS instrumentation' do
           stop_date: Time.new(2023, 3, 31, 12, 30, 0, '-04:00'),
         } }
       end
+
+      it_behaves_like 'a peer service span'
+      it_behaves_like 'environment service name', 'DD_TRACE_AWS_SERVICE_NAME'
+      it_behaves_like 'schema version span', 'example-state-machine', 'statemachinename'
 
       it 'generates a span' do
         expect(span.name).to eq('aws.command')

--- a/spec/datadog/tracing/contrib/aws/instrumentation_spec.rb
+++ b/spec/datadog/tracing/contrib/aws/instrumentation_spec.rb
@@ -44,7 +44,7 @@ RSpec.describe 'AWS instrumentation' do
       it_behaves_like 'measured span for integration'
       it_behaves_like 'a peer service span'
       it_behaves_like 'environment service name', 'DD_TRACE_AWS_SERVICE_NAME'
-      it_behaves_like 'schema version span'
+      it_behaves_like 'schema version span', 'sts.us-stubbed-1.amazonaws.com'
 
       it 'generates a span' do
         expect(span.name).to eq('aws.command')
@@ -96,7 +96,7 @@ RSpec.describe 'AWS instrumentation' do
 
       it_behaves_like 'measured span for integration'
       it_behaves_like 'environment service name', 'DD_TRACE_AWS_SERVICE_NAME'
-      it_behaves_like 'schema version span'
+      it_behaves_like 'schema version span', 's3.us-stubbed-1.amazonaws.com'
 
       it 'generates a span' do
         expect(span.name).to eq('aws.command')

--- a/spec/datadog/tracing/contrib/span_attribute_schema_examples.rb
+++ b/spec/datadog/tracing/contrib/span_attribute_schema_examples.rb
@@ -1,4 +1,4 @@
-RSpec.shared_examples 'schema version span' do
+RSpec.shared_examples 'schema version span' do |peer_service_val|
   before do
     subject
   end
@@ -13,6 +13,9 @@ RSpec.shared_examples 'schema version span' do
     context 'test the v1 default' do
       it do
         expect(span.service).to eq('rspec')
+
+        # TODO: change when new peer.service tag is added for v1
+        expect(span.get_tag('peer.service')).to eq(peer_service_val)
       end
     end
 
@@ -20,6 +23,9 @@ RSpec.shared_examples 'schema version span' do
       let(:configuration_options) { { service_name: 'configured' } }
       it do
         expect(span.service).to eq(configuration_options[:service_name])
+
+        # TODO: change when new peer.service tag is added for v1
+        expect(span.get_tag('peer.service')).to eq(peer_service_val)
       end
     end
   end

--- a/spec/datadog/tracing/contrib/span_attribute_schema_examples.rb
+++ b/spec/datadog/tracing/contrib/span_attribute_schema_examples.rb
@@ -13,9 +13,6 @@ RSpec.shared_examples 'schema version span' do
     context 'test the v1 default' do
       it do
         expect(span.service).to eq('rspec')
-
-        # TODO: change when new peer.service tag is added for v1
-        expect(span.get_tag('peer.service')).to be nil
       end
     end
 
@@ -23,9 +20,6 @@ RSpec.shared_examples 'schema version span' do
       let(:configuration_options) { { service_name: 'configured' } }
       it do
         expect(span.service).to eq(configuration_options[:service_name])
-
-        # TODO: change when new peer.service tag is added for v1
-        expect(span.get_tag('peer.service')).to be nil
       end
     end
   end

--- a/spec/datadog/tracing/contrib/span_attribute_schema_examples.rb
+++ b/spec/datadog/tracing/contrib/span_attribute_schema_examples.rb
@@ -13,8 +13,6 @@ RSpec.shared_examples 'schema version span' do |peer_service_val, peer_service_s
     context 'test the v1 default' do
       it do
         expect(span.service).to eq('rspec')
-
-        # TODO: change when new peer.service tag is added for v1
         expect(span.get_tag('peer.service')).to eq(peer_service_val)
         expect(span.get_tag('_dd.peer.service.source')).to eq(peer_service_source)
       end
@@ -24,8 +22,6 @@ RSpec.shared_examples 'schema version span' do |peer_service_val, peer_service_s
       let(:configuration_options) { { service_name: 'configured' } }
       it do
         expect(span.service).to eq(configuration_options[:service_name])
-
-        # TODO: change when new peer.service tag is added for v1
         expect(span.get_tag('peer.service')).to eq(peer_service_val)
         expect(span.get_tag('_dd.peer.service.source')).to eq(peer_service_source)
       end

--- a/spec/datadog/tracing/contrib/span_attribute_schema_examples.rb
+++ b/spec/datadog/tracing/contrib/span_attribute_schema_examples.rb
@@ -1,4 +1,4 @@
-RSpec.shared_examples 'schema version span' do |peer_service_val|
+RSpec.shared_examples 'schema version span' do |peer_service_val, peer_service_source|
   before do
     subject
   end
@@ -16,6 +16,7 @@ RSpec.shared_examples 'schema version span' do |peer_service_val|
 
         # TODO: change when new peer.service tag is added for v1
         expect(span.get_tag('peer.service')).to eq(peer_service_val)
+        expect(span.get_tag('_dd.peer.service.source')).to eq(peer_service_source)
       end
     end
 
@@ -26,6 +27,7 @@ RSpec.shared_examples 'schema version span' do |peer_service_val|
 
         # TODO: change when new peer.service tag is added for v1
         expect(span.get_tag('peer.service')).to eq(peer_service_val)
+        expect(span.get_tag('_dd.peer.service.source')).to eq(peer_service_source)
       end
     end
   end

--- a/spec/datadog/tracing/contrib/span_attribute_schema_spec.rb
+++ b/spec/datadog/tracing/contrib/span_attribute_schema_spec.rb
@@ -209,7 +209,7 @@ RSpec.describe Datadog::Tracing::Contrib::SpanAttributeSchema do
         end
       end
 
-      context 'AWS Span' do
+      context 'DB Span' do
         it 'returns {PRECURSORs} as peer.service and source' do
           span.set_tag('db.system', 'test-db')
 

--- a/spec/datadog/tracing/contrib/span_attribute_schema_spec.rb
+++ b/spec/datadog/tracing/contrib/span_attribute_schema_spec.rb
@@ -80,7 +80,7 @@ RSpec.describe Datadog::Tracing::Contrib::SpanAttributeSchema do
   end
 
   # Add test return true if env var is true
-  describe '#should_set_peer_service' do
+  describe '#set_peer_service?' do
     let(:span) { Datadog::Tracing::Span.new('testPeerServiceSpan', parent_id: 0) }
     context 'when peer service is already set' do
       context 'when peer.service does not match span.service' do
@@ -88,7 +88,7 @@ RSpec.describe Datadog::Tracing::Contrib::SpanAttributeSchema do
           span.service = 'test-span-service'
           span.set_tag('peer.service', 'test-service')
           expect(span.get_tag('peer.service')).not_to eq(span.service)
-          expect(described_class.should_set_peer_service(span)).to be false
+          expect(described_class.set_peer_service?(span)).to be false
         end
       end
 
@@ -98,7 +98,7 @@ RSpec.describe Datadog::Tracing::Contrib::SpanAttributeSchema do
           span.set_tag('peer.service', 'test-service')
           expect(span.get_tag('peer.service')).to eq(span.service)
           expect(span.service).not_to eq(Datadog.configuration.service)
-          expect(described_class.should_set_peer_service(span)).to be false
+          expect(described_class.set_peer_service?(span)).to be false
         end
       end
     end
@@ -107,14 +107,14 @@ RSpec.describe Datadog::Tracing::Contrib::SpanAttributeSchema do
       context 'when span.kind is server' do
         it 'returns false' do
           span.set_tag('span.kind', 'server')
-          expect(described_class.should_set_peer_service(span)).to be false
+          expect(described_class.set_peer_service?(span)).to be false
         end
       end
 
       context 'when span.kind is consumer' do
         it 'returns false' do
           span.set_tag('span.kind', 'consumer')
-          expect(described_class.should_set_peer_service(span)).to be false
+          expect(described_class.set_peer_service?(span)).to be false
         end
       end
     end
@@ -123,7 +123,7 @@ RSpec.describe Datadog::Tracing::Contrib::SpanAttributeSchema do
       it 'returns false' do
         span.set_tag('span.kind', 'client')
         with_modified_env DD_TRACE_SPAN_ATTRIBUTE_SCHEMA: 'v0' do
-          expect(described_class.should_set_peer_service(span)).to be false
+          expect(described_class.set_peer_service?(span)).to be false
         end
       end
     end
@@ -132,7 +132,7 @@ RSpec.describe Datadog::Tracing::Contrib::SpanAttributeSchema do
       it 'returns true' do
         span.set_tag('span.kind', 'client')
         with_modified_env DD_TRACE_SPAN_ATTRIBUTE_SCHEMA: 'v1' do
-          expect(described_class.should_set_peer_service(span)).to be true
+          expect(described_class.set_peer_service?(span)).to be true
         end
       end
     end

--- a/spec/datadog/tracing/contrib/span_attribute_schema_spec.rb
+++ b/spec/datadog/tracing/contrib/span_attribute_schema_spec.rb
@@ -154,9 +154,13 @@ RSpec.describe Datadog::Tracing::Contrib::SpanAttributeSchema do
         precursors.each do |precursor|
           span.set_tag(precursor, 'test-' << precursor)
 
-          expect(described_class.set_peer_service_from_source(span)).to be true
+          expect(described_class.set_peer_service_from_source(span, precursors)).to be true
           expect(span.get_tag('peer.service')).to eq('test-' << precursor)
           expect(span.get_tag('_dd.peer.service.source')).to eq(precursor)
+
+          span.clear_tag('peer.service')
+          span.clear_tag('_dd.peer.service.source')
+          span.clear_tag(precursor)
         end
       end
     end
@@ -169,9 +173,13 @@ RSpec.describe Datadog::Tracing::Contrib::SpanAttributeSchema do
         precursors.each do |precursor|
           span.set_tag(precursor, 'test-' << precursor)
 
-          expect(described_class.set_peer_service_from_source(span)).to be true
+          expect(described_class.set_peer_service_from_source(span, precursors)).to be true
           expect(span.get_tag('peer.service')).to eq('test-' << precursor)
           expect(span.get_tag('_dd.peer.service.source')).to eq(precursor)
+
+          span.clear_tag('peer.service')
+          span.clear_tag('_dd.peer.service.source')
+          span.clear_tag(precursor)
         end
       end
     end
@@ -184,9 +192,13 @@ RSpec.describe Datadog::Tracing::Contrib::SpanAttributeSchema do
         precursors.each do |precursor|
           span.set_tag(precursor, 'test-' << precursor)
 
-          expect(described_class.set_peer_service_from_source(span)).to be true
+          expect(described_class.set_peer_service_from_source(span, precursors)).to be true
           expect(span.get_tag('peer.service')).to eq('test-' << precursor)
           expect(span.get_tag('_dd.peer.service.source')).to eq(precursor)
+
+          span.clear_tag('peer.service')
+          span.clear_tag('_dd.peer.service.source')
+          span.clear_tag(precursor)
         end
       end
     end
@@ -199,9 +211,13 @@ RSpec.describe Datadog::Tracing::Contrib::SpanAttributeSchema do
         precursors.each do |precursor|
           span.set_tag(precursor, 'test-' << precursor)
 
-          expect(described_class.set_peer_service_from_source(span)).to be true
+          expect(described_class.set_peer_service_from_source(span, precursors)).to be true
           expect(span.get_tag('peer.service')).to eq('test-' << precursor)
           expect(span.get_tag('_dd.peer.service.source')).to eq(precursor)
+
+          span.clear_tag('peer.service')
+          span.clear_tag('_dd.peer.service.source')
+          span.clear_tag(precursor)
         end
       end
     end
@@ -218,6 +234,10 @@ RSpec.describe Datadog::Tracing::Contrib::SpanAttributeSchema do
             expect(described_class.set_peer_service_from_source(span)).to be true
             expect(span.get_tag('peer.service')).to eq('test-' << precursor)
             expect(span.get_tag('_dd.peer.service.source')).to eq(precursor)
+
+            span.clear_tag('peer.service')
+            span.clear_tag('_dd.peer.service.source')
+            span.clear_tag(precursor)
           end
         end
       end
@@ -233,6 +253,10 @@ RSpec.describe Datadog::Tracing::Contrib::SpanAttributeSchema do
             expect(described_class.set_peer_service_from_source(span)).to be true
             expect(span.get_tag('peer.service')).to eq('test-' << precursor)
             expect(span.get_tag('_dd.peer.service.source')).to eq(precursor)
+
+            span.clear_tag('peer.service')
+            span.clear_tag('_dd.peer.service.source')
+            span.clear_tag(precursor)
           end
         end
       end
@@ -248,6 +272,10 @@ RSpec.describe Datadog::Tracing::Contrib::SpanAttributeSchema do
             expect(described_class.set_peer_service_from_source(span)).to be true
             expect(span.get_tag('peer.service')).to eq('test-' << precursor)
             expect(span.get_tag('_dd.peer.service.source')).to eq(precursor)
+
+            span.clear_tag('peer.service')
+            span.clear_tag('_dd.peer.service.source')
+            span.clear_tag(precursor)
           end
         end
       end
@@ -263,6 +291,10 @@ RSpec.describe Datadog::Tracing::Contrib::SpanAttributeSchema do
             expect(described_class.set_peer_service_from_source(span)).to be true
             expect(span.get_tag('peer.service')).to eq('test-' << precursor)
             expect(span.get_tag('_dd.peer.service.source')).to eq(precursor)
+
+            span.clear_tag('peer.service')
+            span.clear_tag('_dd.peer.service.source')
+            span.clear_tag(precursor)
           end
         end
       end

--- a/spec/datadog/tracing/contrib/span_attribute_schema_spec.rb
+++ b/spec/datadog/tracing/contrib/span_attribute_schema_spec.rb
@@ -25,222 +25,136 @@ RSpec.describe Datadog::Tracing::Contrib::SpanAttributeSchema do
     end
   end
 
-  describe '#fetch_service_name' do
-    context 'when integration service is set' do
-      it 'returns the integration specific service name' do
-        with_modified_env DD_INTEGRATION_SERVICE: 'integration-service-name' do
-          expect(
-            described_class
-                          .fetch_service_name('DD_INTEGRATION_SERVICE',
-                            'default-integration-service-name')
-          ).to eq('integration-service-name')
+  describe '#active_version' do
+    context 'when v0 set' do
+      it 'equals v0' do
+        with_modified_env DD_TRACE_SPAN_ATTRIBUTE_SCHEMA: 'v0' do
+          expect(described_class.send(:active_version)).to eq(described_class::VersionZero)
         end
       end
     end
 
-    context 'when integration service is not set' do
-      context 'when v1 schema is set' do
-        context 'when DD_SERVICE is set' do
-          it 'returns DD_SERVICE' do
-            with_modified_env DD_TRACE_SPAN_ATTRIBUTE_SCHEMA: 'v1', DD_SERVICE: 'service' do
-              expect(
-                described_class
-                                  .fetch_service_name('DD_INTEGRATION_SERVICE',
-                                    'default-integration-service-name')
-              ).to eq('service')
-            end
-          end
+    context 'when v1 is set' do
+      it 'equals v1' do
+        with_modified_env DD_TRACE_SPAN_ATTRIBUTE_SCHEMA: 'v1' do
+          expect(described_class.send(:active_version)).to eq(described_class::VersionOne)
         end
+      end
+    end
 
-        context 'when DD_SERVICE is not set' do
-          it 'returns default program name' do
-            with_modified_env DD_TRACE_SPAN_ATTRIBUTE_SCHEMA: 'v1' do
-              expect(
-                described_class
-                                  .fetch_service_name('DD_INTEGRATION_SERVICE',
-                                    'default-integration-service-name')
-              ).to eq('rspec')
-            end
+    context 'when no schema is set' do
+      it 'equals v0' do
+        expect(described_class.send(:active_version)).to eq(described_class::VersionZero)
+      end
+    end
+  end
+
+  describe '#fetch_service_name' do
+    context 'for v0' do
+      context 'when integration service is set' do
+        it 'returns the integration specific service name' do
+          with_modified_env DD_TRACE_SPAN_ATTRIBUTE_SCHEMA: 'v0', DD_INTEGRATION_SERVICE: 'integration-service-name' do
+            expect(
+              described_class
+                .fetch_service_name('DD_INTEGRATION_SERVICE',
+                  'default-integration-service-name')
+            ).to eq('integration-service-name')
           end
         end
       end
 
-      context 'when v0 schema is set' do
+      context 'when DD_SERVICE is set' do
         it 'returns default integration service name' do
           with_modified_env DD_TRACE_SPAN_ATTRIBUTE_SCHEMA: 'v0', DD_SERVICE: 'service' do
             expect(
               described_class
-                              .fetch_service_name('DD_INTEGRATION_SERVICE',
-                                'default-integration-service-name')
+                .fetch_service_name('DD_INTEGRATION_SERVICE',
+                  'default-integration-service-name')
+            ).to eq('default-integration-service-name')
+          end
+        end
+      end
+
+      context 'when DD_SERVICE is not set' do
+        it 'returns default integration service name' do
+          with_modified_env DD_TRACE_SPAN_ATTRIBUTE_SCHEMA: 'v0' do
+            expect(
+              described_class
+                .fetch_service_name('DD_INTEGRATION_SERVICE',
+                  'default-integration-service-name')
             ).to eq('default-integration-service-name')
           end
         end
       end
     end
-  end
 
-  # Add test return true if env var is true
-  describe '#set_peer_service?' do
-    let(:span) { Datadog::Tracing::Span.new('testPeerServiceSpan', parent_id: 0) }
-    context 'when peer service is already set' do
-      context 'when peer.service does not match span.service' do
-        it 'returns false' do
-          span.service = 'test-span-service'
-          span.set_tag('peer.service', 'test-service')
-          expect(span.get_tag('peer.service')).not_to eq(span.service)
-          expect(described_class.send(:set_peer_service?, span)).to be false
+    context 'for v1' do
+      context 'when integration service is set' do
+        it 'returns the integration specific service name' do
+          with_modified_env DD_TRACE_SPAN_ATTRIBUTE_SCHEMA: 'v1', DD_INTEGRATION_SERVICE: 'integration-service-name' do
+            expect(
+              described_class
+                .fetch_service_name('DD_INTEGRATION_SERVICE',
+                  'default-integration-service-name')
+            ).to eq('integration-service-name')
+          end
         end
       end
 
-      context 'when span.service does not equal global service' do
-        it 'returns false' do
-          span.service = 'test-service'
-          span.set_tag('peer.service', 'test-service')
-          expect(span.get_tag('peer.service')).to eq(span.service)
-          expect(span.service).not_to eq(Datadog.configuration.service)
-          expect(described_class.send(:set_peer_service?, span)).to be false
-        end
-      end
-    end
-
-    context 'when span is not outbound' do
-      context 'when span.kind is server' do
-        it 'returns false' do
-          span.set_tag('span.kind', 'server')
-          expect(described_class.send(:set_peer_service?, span)).to be false
+      context 'when DD_SERVICE is set' do
+        it 'returns default integration service name' do
+          with_modified_env DD_TRACE_SPAN_ATTRIBUTE_SCHEMA: 'v1', DD_SERVICE: 'service' do
+            expect(
+              described_class
+                .fetch_service_name('DD_INTEGRATION_SERVICE',
+                  'default-integration-service-name')
+            ).to eq('service')
+          end
         end
       end
 
-      context 'when span.kind is consumer' do
-        it 'returns false' do
-          span.set_tag('span.kind', 'consumer')
-          expect(described_class.send(:set_peer_service?, span)).to be false
-        end
-      end
-    end
-
-    context 'when v1 is not set' do
-      it 'returns false' do
-        span.set_tag('span.kind', 'client')
-        with_modified_env DD_TRACE_SPAN_ATTRIBUTE_SCHEMA: 'v0' do
-          expect(described_class.send(:set_peer_service?, span)).to be false
-        end
-      end
-    end
-
-    context 'when peer service is not set and span is outbound and v1 is set' do
-      it 'returns true' do
-        span.set_tag('span.kind', 'client')
-        with_modified_env DD_TRACE_SPAN_ATTRIBUTE_SCHEMA: 'v1' do
-          expect(described_class.send(:set_peer_service?, span)).to be true
+      context 'when DD_SERVICE is not set' do
+        it 'returns default integration service name' do
+          with_modified_env DD_TRACE_SPAN_ATTRIBUTE_SCHEMA: 'v1' do
+            expect(
+              described_class
+                .fetch_service_name('DD_INTEGRATION_SERVICE',
+                  'default-integration-service-name')
+            ).to eq('rspec')
+          end
         end
       end
     end
   end
 
-  describe '#set_peer_service_from_source' do
+  describe '#set_peer_service!' do
     let(:span) { Datadog::Tracing::Span.new('testPeerServiceLogicSpan', parent_id: 0) }
-    context 'AWS Span' do
-      it 'returns {AWS_PRECURSOR} as peer.service and source' do
-        span.set_tag('aws_service', 'test-service')
-        span.set_tag('span.kind', 'client')
-        with_modified_env DD_TRACE_SPAN_ATTRIBUTE_SCHEMA: 'v1' do
-          precursors = Array['statemachinename',
-            'rulename',
-            'bucketname',
-            'tablename',
-            'streamname',
-            'topicname',
-            'queuename']
-          precursors.each do |precursor|
-            span.set_tag(precursor, 'test-' << precursor)
-
-            expect(described_class.send(:set_peer_service_from_source, span, precursors)).to be true
-            expect(span.get_tag('peer.service')).to eq('test-' << precursor)
-            expect(span.get_tag('_dd.peer.service.source')).to eq(precursor)
-
-            span.clear_tag('peer.service')
-            span.clear_tag('_dd.peer.service.source')
-            span.clear_tag(precursor)
-          end
-        end
+    context 'for v0' do
+      it 'returns {span.service} and peer.service as source' do
+        span.service = 'test-peer.service'
+        expect(described_class.send(:set_peer_service!, span, [])).to be false
+        expect(span.get_tag('peer.service')).to eq('test-peer.service')
+        expect(span.get_tag('_dd.peer.service.source')).to eq nil
       end
     end
 
-    context 'DB Span' do
-      it 'returns {DB_PRECURSOR} as peer.service and source' do
-        span.set_tag('db.system', 'test-db')
-        span.set_tag('span.kind', 'client')
-        with_modified_env DD_TRACE_SPAN_ATTRIBUTE_SCHEMA: 'v1' do
-          precursors = Array['db.instance']
-          precursors.each do |precursor|
-            span.set_tag(precursor, 'test-' << precursor)
-
-            expect(described_class.send(:set_peer_service_from_source, span, precursors)).to be true
-            expect(span.get_tag('peer.service')).to eq('test-' << precursor)
-            expect(span.get_tag('_dd.peer.service.source')).to eq(precursor)
-
-            span.clear_tag('peer.service')
-            span.clear_tag('_dd.peer.service.source')
-            span.clear_tag(precursor)
-          end
-        end
-      end
-    end
-
-    context 'Messaging Span' do
-      it 'returns {MSG_PRECURSOR} as peer.service and source' do
-        span.set_tag('messaging.system', 'test-msg-system')
-        span.set_tag('span.kind', 'producer')
-        with_modified_env DD_TRACE_SPAN_ATTRIBUTE_SCHEMA: 'v1' do
-          precursors = Array[]
-          precursors.each do |precursor|
-            span.set_tag(precursor, 'test-' << precursor)
-
-            expect(described_class.send(:set_peer_service_from_source, span, precursors)).to be true
-            expect(span.get_tag('peer.service')).to eq('test-' << precursor)
-            expect(span.get_tag('_dd.peer.service.source')).to eq(precursor)
-
-            span.clear_tag('peer.service')
-            span.clear_tag('_dd.peer.service.source')
-            span.clear_tag(precursor)
-          end
-        end
-      end
-    end
-
-    context 'RPC Span' do
-      it 'returns {RPC_PRECURSOR} as peer.service and source' do
-        span.set_tag('rpc.system', 'test-rpc')
-        span.set_tag('span.kind', 'client')
-        with_modified_env DD_TRACE_SPAN_ATTRIBUTE_SCHEMA: 'v1' do
-          precursors = Array['rpc.service']
-          precursors.each do |precursor|
-            span.set_tag(precursor, 'test-' << precursor)
-
-            expect(described_class.send(:set_peer_service_from_source, span, precursors)).to be true
-            expect(span.get_tag('peer.service')).to eq('test-' << precursor)
-            expect(span.get_tag('_dd.peer.service.source')).to eq(precursor)
-
-            span.clear_tag('peer.service')
-            span.clear_tag('_dd.peer.service.source')
-            span.clear_tag(precursor)
-          end
-        end
-      end
-    end
-
-    context 'no precursor tags set' do
+    context 'for v1' do
       context 'AWS Span' do
-        it 'returns {PRECURSOR} as peer.service and source' do
+        it 'returns {AWS_PRECURSOR} as peer.service and source' do
           span.set_tag('aws_service', 'test-service')
           span.set_tag('span.kind', 'client')
           with_modified_env DD_TRACE_SPAN_ATTRIBUTE_SCHEMA: 'v1' do
-            precursors = Array['out.host', 'peer.hostname', 'network.destination.name']
+            precursors = Array['statemachinename',
+              'rulename',
+              'bucketname',
+              'tablename',
+              'streamname',
+              'topicname',
+              'queuename']
             precursors.each do |precursor|
               span.set_tag(precursor, 'test-' << precursor)
 
-              expect(described_class.send(:set_peer_service_from_source, span, precursors)).to be true
+              expect(described_class.send(:set_peer_service!, span, precursors)).to be true
               expect(span.get_tag('peer.service')).to eq('test-' << precursor)
               expect(span.get_tag('_dd.peer.service.source')).to eq(precursor)
 
@@ -253,15 +167,15 @@ RSpec.describe Datadog::Tracing::Contrib::SpanAttributeSchema do
       end
 
       context 'DB Span' do
-        it 'returns {PRECURSOR} as peer.service and source' do
+        it 'returns {DB_PRECURSOR} as peer.service and source' do
           span.set_tag('db.system', 'test-db')
           span.set_tag('span.kind', 'client')
           with_modified_env DD_TRACE_SPAN_ATTRIBUTE_SCHEMA: 'v1' do
-            precursors = Array['out.host', 'peer.hostname', 'network.destination.name']
+            precursors = Array['db.instance']
             precursors.each do |precursor|
               span.set_tag(precursor, 'test-' << precursor)
 
-              expect(described_class.send(:set_peer_service_from_source, span, precursors)).to be true
+              expect(described_class.send(:set_peer_service!, span, precursors)).to be true
               expect(span.get_tag('peer.service')).to eq('test-' << precursor)
               expect(span.get_tag('_dd.peer.service.source')).to eq(precursor)
 
@@ -274,15 +188,15 @@ RSpec.describe Datadog::Tracing::Contrib::SpanAttributeSchema do
       end
 
       context 'Messaging Span' do
-        it 'returns {PRECURSOR} as peer.service and source' do
+        it 'returns {MSG_PRECURSOR} as peer.service and source' do
           span.set_tag('messaging.system', 'test-msg-system')
-          span.set_tag('span.kind', 'client')
+          span.set_tag('span.kind', 'producer')
           with_modified_env DD_TRACE_SPAN_ATTRIBUTE_SCHEMA: 'v1' do
-            precursors = Array['out.host', 'peer.hostname', 'network.destination.name']
+            precursors = Array[]
             precursors.each do |precursor|
               span.set_tag(precursor, 'test-' << precursor)
 
-              expect(described_class.send(:set_peer_service_from_source, span, precursors)).to be true
+              expect(described_class.send(:set_peer_service!, span, precursors)).to be true
               expect(span.get_tag('peer.service')).to eq('test-' << precursor)
               expect(span.get_tag('_dd.peer.service.source')).to eq(precursor)
 
@@ -295,15 +209,15 @@ RSpec.describe Datadog::Tracing::Contrib::SpanAttributeSchema do
       end
 
       context 'RPC Span' do
-        it 'returns {PRECURSOR} as peer.service and source' do
+        it 'returns {RPC_PRECURSOR} as peer.service and source' do
           span.set_tag('rpc.system', 'test-rpc')
           span.set_tag('span.kind', 'client')
           with_modified_env DD_TRACE_SPAN_ATTRIBUTE_SCHEMA: 'v1' do
-            precursors = Array['out.host', 'peer.hostname', 'network.destination.name']
+            precursors = Array['rpc.service']
             precursors.each do |precursor|
               span.set_tag(precursor, 'test-' << precursor)
 
-              expect(described_class.send(:set_peer_service_from_source, span, precursors)).to be true
+              expect(described_class.send(:set_peer_service!, span, precursors)).to be true
               expect(span.get_tag('peer.service')).to eq('test-' << precursor)
               expect(span.get_tag('_dd.peer.service.source')).to eq(precursor)
 
@@ -311,6 +225,139 @@ RSpec.describe Datadog::Tracing::Contrib::SpanAttributeSchema do
               span.clear_tag('_dd.peer.service.source')
               span.clear_tag(precursor)
             end
+          end
+        end
+      end
+
+      context 'no precursor tags set' do
+        context 'AWS Span' do
+          it 'returns {PRECURSOR} as peer.service and source' do
+            span.set_tag('aws_service', 'test-service')
+            span.set_tag('span.kind', 'client')
+            with_modified_env DD_TRACE_SPAN_ATTRIBUTE_SCHEMA: 'v1' do
+              precursors = Array['out.host', 'peer.hostname', 'network.destination.name']
+              precursors.each do |precursor|
+                span.set_tag(precursor, 'test-' << precursor)
+
+                expect(described_class.send(:set_peer_service!, span, precursors)).to be true
+                expect(span.get_tag('peer.service')).to eq('test-' << precursor)
+                expect(span.get_tag('_dd.peer.service.source')).to eq(precursor)
+
+                span.clear_tag('peer.service')
+                span.clear_tag('_dd.peer.service.source')
+                span.clear_tag(precursor)
+              end
+            end
+          end
+        end
+
+        context 'DB Span' do
+          it 'returns {PRECURSOR} as peer.service and source' do
+            span.set_tag('db.system', 'test-db')
+            span.set_tag('span.kind', 'client')
+            with_modified_env DD_TRACE_SPAN_ATTRIBUTE_SCHEMA: 'v1' do
+              precursors = Array['out.host', 'peer.hostname', 'network.destination.name']
+              precursors.each do |precursor|
+                span.set_tag(precursor, 'test-' << precursor)
+
+                expect(described_class.send(:set_peer_service!, span, precursors)).to be true
+                expect(span.get_tag('peer.service')).to eq('test-' << precursor)
+                expect(span.get_tag('_dd.peer.service.source')).to eq(precursor)
+
+                span.clear_tag('peer.service')
+                span.clear_tag('_dd.peer.service.source')
+                span.clear_tag(precursor)
+              end
+            end
+          end
+        end
+
+        context 'Messaging Span' do
+          it 'returns {PRECURSOR} as peer.service and source' do
+            span.set_tag('messaging.system', 'test-msg-system')
+            span.set_tag('span.kind', 'client')
+            with_modified_env DD_TRACE_SPAN_ATTRIBUTE_SCHEMA: 'v1' do
+              precursors = Array['out.host', 'peer.hostname', 'network.destination.name']
+              precursors.each do |precursor|
+                span.set_tag(precursor, 'test-' << precursor)
+
+                expect(described_class.send(:set_peer_service!, span, precursors)).to be true
+                expect(span.get_tag('peer.service')).to eq('test-' << precursor)
+                expect(span.get_tag('_dd.peer.service.source')).to eq(precursor)
+
+                span.clear_tag('peer.service')
+                span.clear_tag('_dd.peer.service.source')
+                span.clear_tag(precursor)
+              end
+            end
+          end
+        end
+
+        context 'RPC Span' do
+          it 'returns {PRECURSOR} as peer.service and source' do
+            span.set_tag('rpc.system', 'test-rpc')
+            span.set_tag('span.kind', 'client')
+            with_modified_env DD_TRACE_SPAN_ATTRIBUTE_SCHEMA: 'v1' do
+              precursors = Array['out.host', 'peer.hostname', 'network.destination.name']
+              precursors.each do |precursor|
+                span.set_tag(precursor, 'test-' << precursor)
+
+                expect(described_class.send(:set_peer_service!, span, precursors)).to be true
+                expect(span.get_tag('peer.service')).to eq('test-' << precursor)
+                expect(span.get_tag('_dd.peer.service.source')).to eq(precursor)
+
+                span.clear_tag('peer.service')
+                span.clear_tag('_dd.peer.service.source')
+                span.clear_tag(precursor)
+              end
+            end
+          end
+        end
+      end
+    end
+  end
+
+  # Add test return true if env var is true
+  describe 'test VersionOne only sets peer.service when correct' do
+    let(:span) { Datadog::Tracing::Span.new('testPeerServiceSpan', parent_id: 0) }
+    context 'for v1' do
+      context 'when peer.service exists' do
+        it 'returns false' do
+          span.set_tag('peer.service', 'test')
+          with_modified_env DD_TRACE_SPAN_ATTRIBUTE_SCHEMA: 'v1' do
+            expect(described_class.send(:set_peer_service!, span, [])).to be false
+          end
+        end
+      end
+
+      context 'when span is not outbound' do
+        context 'when span.kind is server' do
+          it 'returns false' do
+            span.set_tag('span.kind', 'server')
+            with_modified_env DD_TRACE_SPAN_ATTRIBUTE_SCHEMA: 'v1' do
+              expect(described_class.send(:set_peer_service!, span, [])).to be false
+            end
+          end
+        end
+
+        context 'when span.kind is consumer' do
+          it 'returns false' do
+            span.set_tag('span.kind', 'consumer')
+            with_modified_env DD_TRACE_SPAN_ATTRIBUTE_SCHEMA: 'v1' do
+              expect(described_class.send(:set_peer_service!, span, [])).to be false
+            end
+          end
+        end
+      end
+
+      context 'when peer service is not set and span is outbound and v1 is set' do
+        it 'returns true' do
+          span.set_tag('span.kind', 'client')
+          span.set_tag('out.host', 'test')
+          span.set_tag('rpc.system', 'test-rpc')
+
+          with_modified_env DD_TRACE_SPAN_ATTRIBUTE_SCHEMA: 'v1' do
+            expect(described_class.send(:set_peer_service!, span, ['out.host'])).to be true
           end
         end
       end

--- a/spec/datadog/tracing/contrib/span_attribute_schema_spec.rb
+++ b/spec/datadog/tracing/contrib/span_attribute_schema_spec.rb
@@ -79,6 +79,178 @@ RSpec.describe Datadog::Tracing::Contrib::SpanAttributeSchema do
     end
   end
 
+  # Add test to check if peer.service is unchanged span.service val
+  # Add test return true if env var is true
+  describe '#should_set_peer_service' do
+    let(:span) {Datadog::Tracing::Span.new('testPeerServiceSpan', parent_id: 0)}
+    context 'when peer service is already set' do
+      it 'returns false' do
+        span.set_tag('peer.service', 'test-service')
+        expect(described_class.should_set_peer_service(span)).to be false
+      end
+    end
+
+    context 'when span is not outbound' do
+      context 'when span.kind is server' do
+        it 'returns false' do
+          span.set_tag('span.kind', 'server')
+          expect(described_class.should_set_peer_service(span)).to be false
+        end
+      end
+
+      context 'when span.kind is consumer' do
+        it 'returns false' do
+          span.set_tag('span.kind', 'consumer')
+          expect(described_class.should_set_peer_service(span)).to be false
+        end
+      end
+    end
+
+    context 'when v1 is not set' do
+        it 'returns false' do
+          span.set_tag('span.kind', 'client')
+          with_modified_env DD_TRACE_SPAN_ATTRIBUTE_SCHEMA: 'v0' do
+            expect(described_class.should_set_peer_service(span)).to be false
+          end
+        end
+    end
+
+    context 'when peer service is not set and span is outbound and v1 is set' do
+      it 'returns true' do
+        span.set_tag('span.kind', 'client')
+        with_modified_env DD_TRACE_SPAN_ATTRIBUTE_SCHEMA: 'v1' do
+          expect(described_class.should_set_peer_service(span)).to be true
+        end
+      end
+    end
+  end
+
+
+  describe '#set_peer_service_from_source' do
+    let(:span) {Datadog::Tracing::Span.new('testPeerServiceLogicSpan', parent_id: 0)}
+    context 'AWS Span' do
+        it 'returns {AWS_PRECURSOR} as peer.service and source' do
+          span.set_tag('aws_service', 'test-service')
+
+          precursors = Array['statemachinename', 'rulename', 'bucketname', 'tablename', 'streamname', 'topicname', 'queuename']
+          precursors.each do |precursor|
+            span.set_tag(precursor, 'test-' << precursor)
+
+            expect(described_class.set_peer_service_from_source(span)).to be true
+            expect(span.get_tag('peer.service')).to eq('test-' << precursor)
+            expect(span.get_tag('_dd.peer.service.source')).to eq(precursor)
+          end
+        end
+    end
+
+    context 'DB Span' do
+      it 'returns {DB_PRECURSOR} as peer.service and source' do
+        span.set_tag('db.system', 'test-db')
+
+        precursors = Array['db.instance']
+        precursors.each do |precursor|
+          span.set_tag(precursor, 'test-' << precursor)
+
+          expect(described_class.set_peer_service_from_source(span)).to be true
+          expect(span.get_tag('peer.service')).to eq('test-' << precursor)
+          expect(span.get_tag('_dd.peer.service.source')).to eq(precursor)
+        end
+      end
+    end
+
+    context 'Messaging Span' do
+      it 'returns {MSG_PRECURSOR} as peer.service and source' do
+        span.set_tag('messaging.system', 'test-msg-system')
+
+        precursors = Array[]
+        precursors.each do |precursor|
+          span.set_tag(precursor, 'test-' << precursor)
+
+          expect(described_class.set_peer_service_from_source(span)).to be true
+          expect(span.get_tag('peer.service')).to eq('test-' << precursor)
+          expect(span.get_tag('_dd.peer.service.source')).to eq(precursor)
+        end
+      end
+    end
+
+    context 'RPC Span' do
+      it 'returns {RPC_PRECURSOR} as peer.service and source' do
+        span.set_tag('rpc.system', 'test-rpc')
+
+        precursors = Array['rpc.service']
+        precursors.each do |precursor|
+          span.set_tag(precursor, 'test-' << precursor)
+
+          expect(described_class.set_peer_service_from_source(span)).to be true
+          expect(span.get_tag('peer.service')).to eq('test-' << precursor)
+          expect(span.get_tag('_dd.peer.service.source')).to eq(precursor)
+        end
+      end
+    end
+
+    context 'no precursor tags set' do
+      context 'AWS Span' do
+        it 'returns {PRECURSORs} as peer.service and source' do
+          span.set_tag('aws_service', 'test-service')
+
+          precursors = Array['out.host', 'peer.hostname', 'network.destination.name']
+          precursors.each do |precursor|
+            span.set_tag(precursor, 'test-' << precursor)
+
+            expect(described_class.set_peer_service_from_source(span)).to be true
+            expect(span.get_tag('peer.service')).to eq('test-' << precursor)
+            expect(span.get_tag('_dd.peer.service.source')).to eq(precursor)
+          end
+        end
+      end
+
+      context 'AWS Span' do
+        it 'returns {PRECURSORs} as peer.service and source' do
+          span.set_tag('db.system', 'test-db')
+
+          precursors = Array['out.host', 'peer.hostname', 'network.destination.name']
+          precursors.each do |precursor|
+            span.set_tag(precursor, 'test-' << precursor)
+
+            expect(described_class.set_peer_service_from_source(span)).to be true
+            expect(span.get_tag('peer.service')).to eq('test-' << precursor)
+            expect(span.get_tag('_dd.peer.service.source')).to eq(precursor)
+          end
+        end
+      end
+
+      context 'Messaging Span' do
+        it 'returns {PRECURSORs} as peer.service and source' do
+          span.set_tag('messaging.system', 'test-msg-system')
+
+          precursors = Array['out.host', 'peer.hostname', 'network.destination.name']
+          precursors.each do |precursor|
+            span.set_tag(precursor, 'test-' << precursor)
+
+            expect(described_class.set_peer_service_from_source(span)).to be true
+            expect(span.get_tag('peer.service')).to eq('test-' << precursor)
+            expect(span.get_tag('_dd.peer.service.source')).to eq(precursor)
+          end
+        end
+      end
+
+      context 'RPC Span' do
+        it 'returns {PRECURSORs} as peer.service and source' do
+          span.set_tag('rpc.system', 'test-rpc')
+
+          precursors = Array['out.host', 'peer.hostname', 'network.destination.name']
+          precursors.each do |precursor|
+            span.set_tag(precursor, 'test-' << precursor)
+
+            expect(described_class.set_peer_service_from_source(span)).to be true
+            expect(span.get_tag('peer.service')).to eq('test-' << precursor)
+            expect(span.get_tag('_dd.peer.service.source')).to eq(precursor)
+          end
+        end
+      end
+    end
+  end
+
   def with_modified_env(options = {}, &block)
     ClimateControl.modify(options, &block)
   end

--- a/spec/datadog/tracing/contrib/span_attribute_schema_spec.rb
+++ b/spec/datadog/tracing/contrib/span_attribute_schema_spec.rb
@@ -82,7 +82,7 @@ RSpec.describe Datadog::Tracing::Contrib::SpanAttributeSchema do
   # Add test to check if peer.service is unchanged span.service val
   # Add test return true if env var is true
   describe '#should_set_peer_service' do
-    let(:span) {Datadog::Tracing::Span.new('testPeerServiceSpan', parent_id: 0)}
+    let(:span) { Datadog::Tracing::Span.new('testPeerServiceSpan', parent_id: 0) }
     context 'when peer service is already set' do
       it 'returns false' do
         span.set_tag('peer.service', 'test-service')
@@ -107,12 +107,12 @@ RSpec.describe Datadog::Tracing::Contrib::SpanAttributeSchema do
     end
 
     context 'when v1 is not set' do
-        it 'returns false' do
-          span.set_tag('span.kind', 'client')
-          with_modified_env DD_TRACE_SPAN_ATTRIBUTE_SCHEMA: 'v0' do
-            expect(described_class.should_set_peer_service(span)).to be false
-          end
+      it 'returns false' do
+        span.set_tag('span.kind', 'client')
+        with_modified_env DD_TRACE_SPAN_ATTRIBUTE_SCHEMA: 'v0' do
+          expect(described_class.should_set_peer_service(span)).to be false
         end
+      end
     end
 
     context 'when peer service is not set and span is outbound and v1 is set' do
@@ -125,22 +125,27 @@ RSpec.describe Datadog::Tracing::Contrib::SpanAttributeSchema do
     end
   end
 
-
   describe '#set_peer_service_from_source' do
-    let(:span) {Datadog::Tracing::Span.new('testPeerServiceLogicSpan', parent_id: 0)}
+    let(:span) { Datadog::Tracing::Span.new('testPeerServiceLogicSpan', parent_id: 0) }
     context 'AWS Span' do
-        it 'returns {AWS_PRECURSOR} as peer.service and source' do
-          span.set_tag('aws_service', 'test-service')
+      it 'returns {AWS_PRECURSOR} as peer.service and source' do
+        span.set_tag('aws_service', 'test-service')
 
-          precursors = Array['statemachinename', 'rulename', 'bucketname', 'tablename', 'streamname', 'topicname', 'queuename']
-          precursors.each do |precursor|
-            span.set_tag(precursor, 'test-' << precursor)
+        precursors = Array['statemachinename',
+          'rulename',
+          'bucketname',
+          'tablename',
+          'streamname',
+          'topicname',
+          'queuename']
+        precursors.each do |precursor|
+          span.set_tag(precursor, 'test-' << precursor)
 
-            expect(described_class.set_peer_service_from_source(span)).to be true
-            expect(span.get_tag('peer.service')).to eq('test-' << precursor)
-            expect(span.get_tag('_dd.peer.service.source')).to eq(precursor)
-          end
+          expect(described_class.set_peer_service_from_source(span)).to be true
+          expect(span.get_tag('peer.service')).to eq('test-' << precursor)
+          expect(span.get_tag('_dd.peer.service.source')).to eq(precursor)
         end
+      end
     end
 
     context 'DB Span' do

--- a/spec/datadog/tracing/contrib/span_attribute_schema_spec.rb
+++ b/spec/datadog/tracing/contrib/span_attribute_schema_spec.rb
@@ -143,24 +143,26 @@ RSpec.describe Datadog::Tracing::Contrib::SpanAttributeSchema do
     context 'AWS Span' do
       it 'returns {AWS_PRECURSOR} as peer.service and source' do
         span.set_tag('aws_service', 'test-service')
+        span.set_tag('span.kind', 'client')
+        with_modified_env DD_TRACE_SPAN_ATTRIBUTE_SCHEMA: 'v1' do
+          precursors = Array['statemachinename',
+            'rulename',
+            'bucketname',
+            'tablename',
+            'streamname',
+            'topicname',
+            'queuename']
+          precursors.each do |precursor|
+            span.set_tag(precursor, 'test-' << precursor)
 
-        precursors = Array['statemachinename',
-          'rulename',
-          'bucketname',
-          'tablename',
-          'streamname',
-          'topicname',
-          'queuename']
-        precursors.each do |precursor|
-          span.set_tag(precursor, 'test-' << precursor)
+            expect(described_class.set_peer_service_from_source(span, precursors)).to be true
+            expect(span.get_tag('peer.service')).to eq('test-' << precursor)
+            expect(span.get_tag('_dd.peer.service.source')).to eq(precursor)
 
-          expect(described_class.set_peer_service_from_source(span, precursors)).to be true
-          expect(span.get_tag('peer.service')).to eq('test-' << precursor)
-          expect(span.get_tag('_dd.peer.service.source')).to eq(precursor)
-
-          span.clear_tag('peer.service')
-          span.clear_tag('_dd.peer.service.source')
-          span.clear_tag(precursor)
+            span.clear_tag('peer.service')
+            span.clear_tag('_dd.peer.service.source')
+            span.clear_tag(precursor)
+          end
         end
       end
     end
@@ -168,18 +170,20 @@ RSpec.describe Datadog::Tracing::Contrib::SpanAttributeSchema do
     context 'DB Span' do
       it 'returns {DB_PRECURSOR} as peer.service and source' do
         span.set_tag('db.system', 'test-db')
+        span.set_tag('span.kind', 'client')
+        with_modified_env DD_TRACE_SPAN_ATTRIBUTE_SCHEMA: 'v1' do
+          precursors = Array['db.instance']
+          precursors.each do |precursor|
+            span.set_tag(precursor, 'test-' << precursor)
 
-        precursors = Array['db.instance']
-        precursors.each do |precursor|
-          span.set_tag(precursor, 'test-' << precursor)
+            expect(described_class.set_peer_service_from_source(span, precursors)).to be true
+            expect(span.get_tag('peer.service')).to eq('test-' << precursor)
+            expect(span.get_tag('_dd.peer.service.source')).to eq(precursor)
 
-          expect(described_class.set_peer_service_from_source(span, precursors)).to be true
-          expect(span.get_tag('peer.service')).to eq('test-' << precursor)
-          expect(span.get_tag('_dd.peer.service.source')).to eq(precursor)
-
-          span.clear_tag('peer.service')
-          span.clear_tag('_dd.peer.service.source')
-          span.clear_tag(precursor)
+            span.clear_tag('peer.service')
+            span.clear_tag('_dd.peer.service.source')
+            span.clear_tag(precursor)
+          end
         end
       end
     end
@@ -187,18 +191,20 @@ RSpec.describe Datadog::Tracing::Contrib::SpanAttributeSchema do
     context 'Messaging Span' do
       it 'returns {MSG_PRECURSOR} as peer.service and source' do
         span.set_tag('messaging.system', 'test-msg-system')
+        span.set_tag('span.kind', 'producer')
+        with_modified_env DD_TRACE_SPAN_ATTRIBUTE_SCHEMA: 'v1' do
+          precursors = Array[]
+          precursors.each do |precursor|
+            span.set_tag(precursor, 'test-' << precursor)
 
-        precursors = Array[]
-        precursors.each do |precursor|
-          span.set_tag(precursor, 'test-' << precursor)
+            expect(described_class.set_peer_service_from_source(span, precursors)).to be true
+            expect(span.get_tag('peer.service')).to eq('test-' << precursor)
+            expect(span.get_tag('_dd.peer.service.source')).to eq(precursor)
 
-          expect(described_class.set_peer_service_from_source(span, precursors)).to be true
-          expect(span.get_tag('peer.service')).to eq('test-' << precursor)
-          expect(span.get_tag('_dd.peer.service.source')).to eq(precursor)
-
-          span.clear_tag('peer.service')
-          span.clear_tag('_dd.peer.service.source')
-          span.clear_tag(precursor)
+            span.clear_tag('peer.service')
+            span.clear_tag('_dd.peer.service.source')
+            span.clear_tag(precursor)
+          end
         end
       end
     end
@@ -206,89 +212,13 @@ RSpec.describe Datadog::Tracing::Contrib::SpanAttributeSchema do
     context 'RPC Span' do
       it 'returns {RPC_PRECURSOR} as peer.service and source' do
         span.set_tag('rpc.system', 'test-rpc')
-
-        precursors = Array['rpc.service']
-        precursors.each do |precursor|
-          span.set_tag(precursor, 'test-' << precursor)
-
-          expect(described_class.set_peer_service_from_source(span, precursors)).to be true
-          expect(span.get_tag('peer.service')).to eq('test-' << precursor)
-          expect(span.get_tag('_dd.peer.service.source')).to eq(precursor)
-
-          span.clear_tag('peer.service')
-          span.clear_tag('_dd.peer.service.source')
-          span.clear_tag(precursor)
-        end
-      end
-    end
-
-    context 'no precursor tags set' do
-      context 'AWS Span' do
-        it 'returns {PRECURSOR} as peer.service and source' do
-          span.set_tag('aws_service', 'test-service')
-
-          precursors = Array['out.host', 'peer.hostname', 'network.destination.name']
+        span.set_tag('span.kind', 'client')
+        with_modified_env DD_TRACE_SPAN_ATTRIBUTE_SCHEMA: 'v1' do
+          precursors = Array['rpc.service']
           precursors.each do |precursor|
             span.set_tag(precursor, 'test-' << precursor)
 
-            expect(described_class.set_peer_service_from_source(span)).to be true
-            expect(span.get_tag('peer.service')).to eq('test-' << precursor)
-            expect(span.get_tag('_dd.peer.service.source')).to eq(precursor)
-
-            span.clear_tag('peer.service')
-            span.clear_tag('_dd.peer.service.source')
-            span.clear_tag(precursor)
-          end
-        end
-      end
-
-      context 'DB Span' do
-        it 'returns {PRECURSOR} as peer.service and source' do
-          span.set_tag('db.system', 'test-db')
-
-          precursors = Array['out.host', 'peer.hostname', 'network.destination.name']
-          precursors.each do |precursor|
-            span.set_tag(precursor, 'test-' << precursor)
-
-            expect(described_class.set_peer_service_from_source(span)).to be true
-            expect(span.get_tag('peer.service')).to eq('test-' << precursor)
-            expect(span.get_tag('_dd.peer.service.source')).to eq(precursor)
-
-            span.clear_tag('peer.service')
-            span.clear_tag('_dd.peer.service.source')
-            span.clear_tag(precursor)
-          end
-        end
-      end
-
-      context 'Messaging Span' do
-        it 'returns {PRECURSOR} as peer.service and source' do
-          span.set_tag('messaging.system', 'test-msg-system')
-
-          precursors = Array['out.host', 'peer.hostname', 'network.destination.name']
-          precursors.each do |precursor|
-            span.set_tag(precursor, 'test-' << precursor)
-
-            expect(described_class.set_peer_service_from_source(span)).to be true
-            expect(span.get_tag('peer.service')).to eq('test-' << precursor)
-            expect(span.get_tag('_dd.peer.service.source')).to eq(precursor)
-
-            span.clear_tag('peer.service')
-            span.clear_tag('_dd.peer.service.source')
-            span.clear_tag(precursor)
-          end
-        end
-      end
-
-      context 'RPC Span' do
-        it 'returns {PRECURSOR} as peer.service and source' do
-          span.set_tag('rpc.system', 'test-rpc')
-
-          precursors = Array['out.host', 'peer.hostname', 'network.destination.name']
-          precursors.each do |precursor|
-            span.set_tag(precursor, 'test-' << precursor)
-
-            expect(described_class.set_peer_service_from_source(span)).to be true
+            expect(described_class.set_peer_service_from_source(span, precursors)).to be true
             expect(span.get_tag('peer.service')).to eq('test-' << precursor)
             expect(span.get_tag('_dd.peer.service.source')).to eq(precursor)
 


### PR DESCRIPTION
Adds `peer.service` extraction logic and implements it in the AWS integration

`peer.service` is a tag that needs to be set by extracting some values from certain "precursor" tags which vary based on span type and of which the complete list is already agreed upon internally which are checked for in this PR but may need to be fully implemented in the future for certain integrations. This PR implements the logic of checking and extracting these values within the `set_peer_service_from_source` method which checks span type and the existence of various "precursor" tags before setting `peer.service` and the source from which it was extracted.

Note however that `peer.service` is only extracted when not explicitly set by the user which is checked by the `should_set_peer_service` method which ensures that the existence of any `peer.service` tags implies that no further ones will be set. In addition, changing span.service ties directly with `peer.service` so we check if that value is unique to also imply `peer.service` is changed

Both the aforementioned methods are thoroughly tested as well.

The two methods are called in `set_peer_service` which in the future will be called in all target integrations. This PR has one complete working example with AWS as well as updated tests to cover all various AWS services.


NOTE: Please do not merge without @delner direct approval but feel free to review and ask questions for context to me.