### PR TITLE
Add `using_default?` method to Core::Configuration

### DIFF
--- a/lib/datadog/core/configuration/option.rb
+++ b/lib/datadog/core/configuration/option.rb
@@ -6,8 +6,7 @@ module Datadog
       # Represents an instance of an integration configuration option
       # @public_api
       class Option
-        attr_reader \
-          :definition
+        attr_reader :definition
 
         # Option setting precedence. Higher number means higher precedence.
         module Precedence
@@ -73,6 +72,10 @@ module Datadog
           else
             definition.default
           end
+        end
+
+        def default_precedence?
+          precedence_set == Precedence::DEFAULT
         end
 
         private

--- a/lib/datadog/core/configuration/options.rb
+++ b/lib/datadog/core/configuration/options.rb
@@ -84,6 +84,12 @@ module Datadog
             self.class.options.key?(name)
           end
 
+          def using_default?(option)
+            return options[option].default_precedence? if options[option]
+
+            !self.class.options[option].default.nil?
+          end
+
           def options_hash
             self.class.options.merge(options).each_with_object({}) do |(key, _), hash|
               hash[key] = get_option(key)

--- a/spec/datadog/core/configuration/base_spec.rb
+++ b/spec/datadog/core/configuration/base_spec.rb
@@ -142,6 +142,81 @@ RSpec.describe Datadog::Core::Configuration::Base do
         end
       end
 
+      describe '#using_default?' do
+        let(:configuration) do
+          Class.new do
+            include Datadog::Core::Configuration::Base
+
+            settings :fake_test do
+              option :enabled, default: true
+              option :without_default
+            end
+          end.new
+        end
+
+        context 'with default option' do
+          context 'when not set' do
+            it 'returns true' do
+              expect(configuration.fake_test.using_default?(:enabled)).to be(true)
+            end
+          end
+
+          context 'when not set but accessed' do
+            it 'returns true' do
+              configuration.fake_test.enabled
+              expect(configuration.fake_test.using_default?(:enabled)).to be(true)
+            end
+          end
+
+          context 'when set' do
+            it 'returns false' do
+              configuration.fake_test.enabled = false
+              expect(configuration.fake_test.using_default?(:enabled)).to be(false)
+            end
+          end
+
+          context 'when set and reset' do
+            it 'returns false' do
+              configuration.fake_test.enabled = false
+              expect(configuration.fake_test.using_default?(:enabled)).to be(false)
+              configuration.fake_test.reset!
+              expect(configuration.fake_test.using_default?(:enabled)).to be(true)
+            end
+          end
+        end
+
+        context 'without default option' do
+          context 'when not set' do
+            it 'returns false' do
+              expect(configuration.fake_test.using_default?(:without_default)).to be(false)
+            end
+          end
+
+          context 'when not set but accessed' do
+            it 'returns true' do
+              configuration.fake_test.without_default
+              expect(configuration.fake_test.using_default?(:without_default)).to be(true)
+            end
+          end
+
+          context 'when set' do
+            it 'returns false' do
+              configuration.fake_test.without_default = false
+              expect(configuration.fake_test.using_default?(:without_default)).to be(false)
+            end
+          end
+
+          context 'when set and reset' do
+            it 'returns false' do
+              configuration.fake_test.without_default = false
+              expect(configuration.fake_test.using_default?(:without_default)).to be(false)
+              configuration.fake_test.reset!
+              expect(configuration.fake_test.using_default?(:without_default)).to be(true)
+            end
+          end
+        end
+      end
+
       describe '#reset!' do
         subject(:reset!) { base_object.reset! }
 


### PR DESCRIPTION
<!--
Check out the
https://github.com/DataDog/dd-trace-rb/blob/master/docs/DevelopmentGuide.md
for guidance on how to set up your development environment,
run the test suite, write new integrations, and more.
-->

**What does this PR do?**
<!-- A brief description of the change being made with this pull request. -->

This PR adds  the `using_default?` to `Core::Configuration` 

**Motivation**
<!-- What inspired you to submit this pull request? -->

I will port AppSec (ASM) configuration to use the one in `Core::Configuration`. The one key feature that the ASM configuration has that the core configuration has is the ability to check if a value has been set or if it is using the default value.

Here is the code ASM:

https://github.com/DataDog/dd-trace-rb/blob/f7d1e5e42419e9adced5e05d82eda8bdd59d5b48/lib/datadog/appsec/configuration.rb#L88-L90

https://github.com/DataDog/dd-trace-rb/blob/cbbd7490274f0b483fa59486647a78be45979d82/lib/datadog/appsec/remote.rb#L107-L109

Once the code is merged, we can migrate the ASM configuration to use the core configuration 


**Additional Notes**
<!-- Anything else we should know when reviewing? -->

**How to test the change?**
<!--
Describe here how the change can be validated.
You are strongly encouraged to provide automated tests for this PR (unit or integration).
If this change cannot be feasibly tested, please explain why,
unless the change does not modify code (e.g. only modifies docs, comments).
-->
