### PR TITLE
Fix "Problem executing scripts APT::Update::Post-Invoke" issue breaking 3.1/3.2/3.3 integration apps CI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -242,7 +242,6 @@ orbs:
           - checkout
           - setup_remote_docker:
               docker_layer_caching: true
-              version: 20.10.6
           - run:
               name: Build integration base images
               command: ./integration/script/build-images -v <<parameters.ruby_version>>


### PR DESCRIPTION
**What does this PR do?**:

This PR is a follow-up to #2917. When I started investigating the issue we saw in CI
(https://app.circleci.com/pipelines/github/DataDog/dd-trace-rb/10471/workflows/398f98c3-8d84-4d94-afff-8c92370be60d/jobs/389184):

```
E: Problem executing scripts APT::Update::Post-Invoke 'rm -f /var/cache/apt/archives/*.deb /var/cache/apt/archives/partial/*.deb /var/cache/apt/*.bin || true'
E: Sub-process returned an error code
```

... I saw an issue locally that I fixed in #2917, but it turns out that was not the issue we were seeing.

In fact, there were two issues, but CI was failing with an earlier one, whereas I fixed the later one only (which is the only one that I saw locally).

What happened was that our CI integration apps Ruby images use the latest upstream Ruby images, and those have shifted to use the new Debian 12 "bookworm" release.

The new base OS change triggered both issues.

TL;DR the glibc version on Debian 12 triggers a bug on the docker version we were using in CI:

* https://stackoverflow.com/questions/71941032/why-i-cannot-run-apt-update-inside-a-fresh-ubuntu22-04
* https://pascalroeleven.nl/2021/09/09/ubuntu-21-10-and-fedora-35-in-docker/

The fix here is simple: we were overriding the docker version used by CircleCI to use an older version of docker. I've removed the override, which will make CircleCI use the latest docker version they have available (20.10.18 as I'm writing this), which has a fix for the bug triggered by the newer glibc.

**Motivation**:

Fix CI.

**Additional Notes**:

This is one of those "a lot of time spent for a one-liner fix" PRs.

**How to test the change?**:

Validate that CI is green.