### PR TITLE
Fix flaky profiler integration test due to thread naming race

### DIFF
--- a/lib/datadog/profiling/collectors/cpu_and_wall_time_worker.rb
+++ b/lib/datadog/profiling/collectors/cpu_and_wall_time_worker.rb
@@ -76,6 +76,7 @@ module Datadog
                 )
               end
             end
+            @worker_thread.name = self.class.name # Repeated from above to make sure thread gets named asap
           end
 
           true

--- a/lib/datadog/profiling/collectors/idle_sampling_helper.rb
+++ b/lib/datadog/profiling/collectors/idle_sampling_helper.rb
@@ -42,6 +42,7 @@ module Datadog
                 )
               end
             end
+            @worker_thread.name = self.class.name # Repeated from above to make sure thread gets named asap
           end
 
           true

--- a/spec/datadog/profiling/collectors/idle_sampling_helper_spec.rb
+++ b/spec/datadog/profiling/collectors/idle_sampling_helper_spec.rb
@@ -15,13 +15,13 @@ RSpec.describe Datadog::Profiling::Collectors::IdleSamplingHelper do
 
     it 'resets the IdleSamplingHelper before creating a new thread' do
       expect(described_class).to receive(:_native_reset).with(idle_sampling_helper).ordered
-      expect(Thread).to receive(:new).ordered
+      expect(Thread).to receive(:new).ordered.and_call_original
 
       start
     end
 
     it 'creates a new thread' do
-      expect(Thread).to receive(:new)
+      expect(Thread).to receive(:new).ordered.and_call_original
 
       start
     end


### PR DESCRIPTION
**What does this PR do?**:

This PR tweaks the way we set the thread names in the profiler threads.

Previously, each worker thread set its own name; now, the caller thread also sets the name.

**Motivation**:

Because Ruby threads cannot be named at creation (which is weird -- Java allows this), setting the name of a thread is always a race: there's a period after the `Thread` object is created where the thread will have no name.

In that period, calling `Thread.list` will not see the name.

I suspect this is the issue that led to a flaky test reported by @tonycthsu
(<https://app.circleci.com/pipelines/github/DataDog/dd-trace-rb/10382/workflows/ed4867b5-aa41-4179-a27c-fdb73b8d86c2/jobs/385644>): the integration tests check that all profiler threads are alive by checking for their names, but the thread may not have yet set its own name.

Setting the name twice is harmless, so I went for this approach of setting it in both the parent as well as the created threads.

**Additional Notes**:

N/A

**How to test the change?**:

I was able to reproduce the "missing names" issue on a trivial Ruby script that did

```ruby
require 'ddtrace'

Datadog::Profiling.start_if_enabled
puts Thread.list
```