### PR TITLE
Prevent fork tests from hanging test suite

### DIFF
--- a/spec/datadog/tracing/benchmark/support/benchmark_helper.rb
+++ b/spec/datadog/tracing/benchmark/support/benchmark_helper.rb
@@ -291,7 +291,7 @@ RSpec.shared_context 'minimal agent' do
   after do
     if Process.respond_to?(:fork)
       Process.kill('TERM', @agent_runner) rescue nil
-      Process.wait(@agent_runner)
+      try_wait_until { Process.wait(@agent_runner, Process::WNOHANG) }
     else
       @agent_runner.kill
     end

--- a/spec/datadog/tracing/contrib/mongodb/regression_issue_1235_spec.rb
+++ b/spec/datadog/tracing/contrib/mongodb/regression_issue_1235_spec.rb
@@ -36,7 +36,7 @@ RSpec.describe 'Mongo crash regression #1235' do
       exit(true) # Forcing an immediate Ruby VM exit causes the crash
     end
 
-    _, status = Process.waitpid2(pid)
+    _, status = try_wait_until { Process.wait2(pid, Process::WNOHANG) }
     status
   end
 

--- a/spec/datadog/tracing/integration_spec.rb
+++ b/spec/datadog/tracing/integration_spec.rb
@@ -561,7 +561,7 @@ RSpec.describe 'Tracer integration tests' do
 
         # Read and return any output
         read.read.tap do
-          Process.waitpid(fork_id)
+          try_wait_until { Process.wait(fork_id, Process::WNOHANG) }
         end
       end
 

--- a/spec/support/synchronization_helpers.rb
+++ b/spec/support/synchronization_helpers.rb
@@ -1,7 +1,7 @@
 require 'English'
 
 module SynchronizationHelpers
-  def expect_in_fork(fork_expectations: nil, timeout_in_seconds: 10)
+  def expect_in_fork(fork_expectations: nil, timeout_seconds: 10)
     fork_expectations ||= proc { |status:, stdout:, stderr:|
       expect(status && status.success?).to be(true), "STDOUT:`#{stdout}` STDERR:`#{stderr}"
     }
@@ -23,7 +23,7 @@ module SynchronizationHelpers
 
       # Wait for fork to finish, retrieve its status.
       # Enforce timeout to ensure test fork doesn't hang the test suite.
-      _, status = try_wait_until(seconds: timeout_in_seconds) { Process.wait2(pid, Process::WNOHANG) }
+      _, status = try_wait_until(seconds: timeout_seconds) { Process.wait2(pid, Process::WNOHANG) }
 
       # Capture forked execution information
       result = { status: status, stdout: File.read(fork_stdout.path), stderr: File.read(fork_stderr.path) }

--- a/spec/support/synchronization_helpers.rb
+++ b/spec/support/synchronization_helpers.rb
@@ -1,7 +1,7 @@
 require 'English'
 
 module SynchronizationHelpers
-  def expect_in_fork(fork_expectations: nil)
+  def expect_in_fork(fork_expectations: nil, timeout_in_seconds: 10)
     fork_expectations ||= proc { |status:, stdout:, stderr:|
       expect(status && status.success?).to be(true), "STDOUT:`#{stdout}` STDERR:`#{stderr}"
     }
@@ -22,8 +22,8 @@ module SynchronizationHelpers
       fork_stdout.close
 
       # Wait for fork to finish, retrieve its status.
-      Process.wait(pid)
-      status = $CHILD_STATUS if $CHILD_STATUS && $CHILD_STATUS.pid == pid
+      # Enforce timeout to ensure test fork doesn't hang the test suite.
+      _, status = try_wait_until(seconds: timeout_in_seconds) { Process.wait2(pid, Process::WNOHANG) }
 
       # Capture forked execution information
       result = { status: status, stdout: File.read(fork_stdout.path), stderr: File.read(fork_stderr.path) }


### PR DESCRIPTION
While trying to debug the flaky test https://app.circleci.com/pipelines/github/DataDog/dd-trace-rb/10532/workflows/2959b319-e444-4122-927c-b8055d338d69/jobs/391689:
```
Server internal tracer
  traces the looping scheduled push
rake aborted!
SignalException: SIGTERM
/app/Rakefile:260:in `declare'
/app/Rakefile:317:in `block in <top (required)>'
/usr/local/bundle/gems/rake-13.0.6/exe/rake:27:in `<top (required)>'
/usr/local/bundle/gems/bundler-2.3.26/lib/bundler/cli/exec.rb:58:in `load'
/usr/local/bundle/gems/bundler-2.3.26/lib/bundler/cli/exec.rb:58:in `kernel_load'
/usr/local/bundle/gems/bundler-2.3.26/lib/bundler/cli/exec.rb:23:in `run'
/usr/local/bundle/gems/bundler-2.3.26/lib/bundler/cli.rb:486:in `exec'
/usr/local/bundle/gems/bundler-2.3.26/lib/bundler/vendor/thor/lib/thor/command.rb:27:in `run'
/usr/local/bundle/gems/bundler-2.3.26/lib/bundler/vendor/thor/lib/thor/invocation.rb:127:in `invoke_command'
/usr/local/bundle/gems/bundler-2.3.26/lib/bundler/vendor/thor/lib/thor.rb:392:in `dispatch'
/usr/local/bundle/gems/bundler-2.3.26/lib/bundler/cli.rb:31:in `dispatch'
/usr/local/bundle/gems/bundler-2.3.26/lib/bundler/vendor/thor/lib/thor/base.rb:485:in `start'
/usr/local/bundle/gems/bundler-2.3.26/lib/bundler/cli.rb:25:in `start'
/usr/local/bundle/gems/bundler-2.3.26/exe/bundle:48:in `block in <top (required)>'
/usr/local/bundle/gems/bundler-2.3.26/lib/bundler/friendly_errors.rb:120:in `with_friendly_errors'
/usr/local/bundle/gems/bundler-2.3.26/exe/bundle:36:in `<top (required)>'
/usr/local/bin/bundle:25:in `load'
/usr/local/bin/bundle:25:in `<main>'
Tasks: TOP => ci
(See full trace by running task with --trace)
rake aborted!
SignalException: SIGHUP
/usr/local/bundle/gems/rspec-core-3.12.1/lib/rspec/core/rake_task.rb:97:in `system'
/usr/local/bundle/gems/rspec-core-3.12.1/lib/rspec/core/rake_task.rb:97:in `run_task'
/usr/local/bundle/gems/rspec-core-3.12.1/lib/rspec/core/rake_task.rb:116:in `block (2 levels) in define'
/usr/local/bundle/gems/rspec-core-3.12.1/lib/rspec/core/rake_task.rb:114:in `block in define'
/usr/local/bundle/gems/rake-12.3.3/exe/rake:27:in `<top (required)>'
/usr/local/bundle/gems/bundler-2.3.26/lib/bundler/cli/exec.rb:58:in `load'
/usr/local/bundle/gems/bundler-2.3.26/lib/bundler/cli/exec.rb:58:in `kernel_load'
/usr/local/bundle/gems/bundler-2.3.26/lib/bundler/cli/exec.rb:23:in `run'
/usr/local/bundle/gems/bundler-2.3.26/lib/bundler/cli.rb:486:in `exec'
/usr/local/bundle/gems/bundler-2.3.26/lib/bundler/vendor/thor/lib/thor/command.rb:27:in `run'
/usr/local/bundle/gems/bundler-2.3.26/lib/bundler/vendor/thor/lib/thor/invocation.rb:127:in `invoke_command'
/usr/local/bundle/gems/bundler-2.3.26/lib/bundler/vendor/thor/lib/thor.rb:392:in `dispatch'
/usr/local/bundle/gems/bundler-2.3.26/lib/bundler/cli.rb:31:in `dispatch'
/usr/local/bundle/gems/bundler-2.3.26/lib/bundler/vendor/thor/lib/thor/base.rb:485:in `start'
/usr/local/bundle/gems/bundler-2.3.26/lib/bundler/cli.rb:25:in `start'
/usr/local/bundle/gems/bundler-2.3.26/exe/bundle:48:in `block in <top (required)>'
/usr/local/bundle/gems/bundler-2.3.26/lib/bundler/friendly_errors.rb:120:in `with_friendly_errors'
/usr/local/bundle/gems/bundler-2.3.26/exe/bundle:36:in `<top (required)>'
/usr/local/bundle/bin/bundle:25:in `load'
/usr/local/bundle/bin/bundle:25:in `<main>'
Tasks: TOP => spec:sidekiq
(See full trace by running task with --trace)

Finished in 10 minutes 5 seconds (files took 1.49 seconds to load)
```

I noticed that it took 10 minutes for CircleCI to forcefully kill the job, because a `Process.wait` call never finished.

This PR does not resolve the underlying issue, but ensure that test that get stuck on `Process.wait` provide a failure feedback much sooner (10 seconds), instead of getting stuck forever and hanging the test suite.