### PR TITLE
Make sure the GRPC client interceptor actually returns the response

### DIFF
--- a/lib/datadog/tracing/contrib/grpc/datadog_interceptor/client.rb
+++ b/lib/datadog/tracing/contrib/grpc/datadog_interceptor/client.rb
@@ -29,15 +29,15 @@ module Datadog
                 annotate!(trace, span, keywords, formatter)
 
                 begin
-                  yield
+                  result = yield
                 rescue StandardError => e
                   code = e.is_a?(::GRPC::BadStatus) ? e.code : ::GRPC::Core::StatusCodes::UNKNOWN
                   span.set_tag(Contrib::Ext::RPC::GRPC::TAG_STATUS_CODE, code)
 
                   raise
-                else
-                  span.set_tag(Contrib::Ext::RPC::GRPC::TAG_STATUS_CODE, ::GRPC::Core::StatusCodes::OK)
                 end
+                span.set_tag(Contrib::Ext::RPC::GRPC::TAG_STATUS_CODE, ::GRPC::Core::StatusCodes::OK)
+                result
               end
             end
 

--- a/spec/datadog/tracing/contrib/grpc/datadog_interceptor/client_spec.rb
+++ b/spec/datadog/tracing/contrib/grpc/datadog_interceptor/client_spec.rb
@@ -125,13 +125,21 @@ RSpec.describe 'tracing on the client connection' do
 
     let(:original_metadata) { { some: 'datum' } }
 
+    let(:request_response) do
+      subject.request_response(**keywords) { :returned_object }
+    end
+
     before do
-      subject.request_response(**keywords) {}
+      request_response
     end
 
     it_behaves_like 'span data contents'
 
     it_behaves_like 'inject distributed tracing metadata'
+
+    it 'actually returns the client response' do
+      expect(request_response).to be(:returned_object)
+    end
   end
 
   describe '#client_streamer' do


### PR DESCRIPTION
<!--
Check out the
https://github.com/DataDog/dd-trace-rb/blob/master/docs/DevelopmentGuide.md
for guidance on how to set up your development environment,
run the test suite, write new integrations, and more.
-->

**What does this PR do?**
Datadog::Tracing::Contrib::GRPC::DatadogInterceptor::Client#trace is currently causing all GRPC client operations to return 0.0 instead of whatever they were supposed to return. This is a bit of a Ruby gotcha.

This method returns :three

```ruby
def broken_method
    begin
        :one
    rescue => e
        :two
    else
        :three
    end
end
```

So when `#trace` is putting `yield` in a `begin` block with an `else`, it's not actually returning the result of yield; it's returning the result of the else block. I guess this was broken in https://github.com/DataDog/dd-trace-rb/pull/2620

Fix it by explicitly returning the result of yield.

**Motivation**
All my GRPC client methods started returning `0.0` after upgrading ddtrace 😱 

**Additional Notes**
<!-- Anything else we should know when reviewing? -->

**How to test the change?**
Now my GRPC client methods don't return 0.0! I included a test in this patch.