### PR TITLE
Actions:Allow type check to run at PR level

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -1,5 +1,10 @@
 name: Check
-on: [push]
+on:
+  push:
+    branches: [ master ]
+  pull_request:
+    # The branches below must be a subset of the branches above
+    branches: [ master ]
 jobs:
   check:
     name: Check types


### PR DESCRIPTION
All external PRs are stuck because "Check types" does run for external contributors, not even after manual approval (see https://github.com/DataDog/dd-trace-rb/pull/2928, for example):
![Screenshot 2023-06-23 at 2 09 41 PM](https://github.com/DataDog/dd-trace-rb/assets/583503/47b42763-91f4-41c5-a176-c183bb261a29)

Interestingly CodeQL does work correctly, running on approval:
![Screenshot 2023-06-23 at 2 10 37 PM](https://github.com/DataDog/dd-trace-rb/assets/583503/dbaf88f3-be5b-4fee-baa7-cbd7be01051f)

My research was not 100% conclusive, but I believe that the `on` trigger is the reason.

This PR change the `on` trigger to look more similar to CodeQL's, specifically regarding having an explicit `pull_request` trigger.