### PR TITLE
Remove `lazy` option from the configuration option

### DIFF
--- a/lib/datadog/appsec/configuration/settings.rb
+++ b/lib/datadog/appsec/configuration/settings.rb
@@ -37,7 +37,6 @@ module Datadog
                 o.setter do |v|
                   v ? true : false
                 end
-                o.lazy
               end
 
               define_method(:instrument) do |integration_name|
@@ -55,17 +54,14 @@ module Datadog
 
               option :ruleset do |o|
                 o.default { ENV.fetch('DD_APPSEC_RULES', DEFAULT_APPSEC_RULESET) }
-                o.lazy
               end
 
               option :ip_denylist do |o|
                 o.default { [] }
-                o.lazy
               end
 
               option :user_id_denylist do |o|
                 o.default { [] }
-                o.lazy
               end
 
               option :waf_timeout do |o|
@@ -73,7 +69,6 @@ module Datadog
                 o.setter do |v|
                   Datadog::Core::Utils::Duration.call(v.to_s, base: :us)
                 end
-                o.lazy
               end
 
               option :waf_debug do |o|
@@ -81,17 +76,14 @@ module Datadog
                 o.setter do |v|
                   v ? true : false
                 end
-                o.lazy
               end
 
               option :trace_rate_limit do |o|
                 o.default { env_to_int('DD_APPSEC_TRACE_RATE_LIMIT', DEFAULT_APPSEC_TRACE_RATE_LIMIT) } # trace/s
-                o.lazy
               end
 
               option :obfuscator_key_regex do |o|
                 o.default { ENV.fetch('DD_APPSEC_OBFUSCATION_PARAMETER_KEY_REGEXP', DEFAULT_OBFUSCATOR_KEY_REGEX) }
-                o.lazy
               end
 
               option :obfuscator_value_regex do |o|
@@ -101,7 +93,6 @@ module Datadog
                     DEFAULT_OBFUSCATOR_VALUE_REGEX
                   )
                 end
-                o.lazy
               end
 
               settings :track_user_events do
@@ -119,7 +110,6 @@ module Datadog
                       false
                     end
                   end
-                  o.lazy
                 end
 
                 option :mode do |o|
@@ -139,7 +129,6 @@ module Datadog
                       DEFAULT_APPSEC_AUTOMATED_TRACK_USER_EVENTS_MODE
                     end
                   end
-                  o.lazy
                 end
               end
             end

--- a/lib/datadog/ci/configuration/settings.rb
+++ b/lib/datadog/ci/configuration/settings.rb
@@ -17,7 +17,6 @@ module Datadog
             settings :ci do
               option :enabled do |o|
                 o.default { env_to_bool(CI::Ext::Settings::ENV_MODE_ENABLED, false) }
-                o.lazy
               end
 
               # DEV: Alias to Datadog::Tracing::Contrib::Extensions::Configuration::Settings#instrument.
@@ -37,12 +36,10 @@ module Datadog
 
               option :trace_flush do |o|
                 o.default { nil }
-                o.lazy
               end
 
               option :writer_options do |o|
                 o.default { {} }
-                o.lazy
               end
             end
           end

--- a/lib/datadog/ci/contrib/cucumber/configuration/settings.rb
+++ b/lib/datadog/ci/contrib/cucumber/configuration/settings.rb
@@ -13,17 +13,14 @@ module Datadog
           class Settings < Datadog::Tracing::Contrib::Configuration::Settings
             option :enabled do |o|
               o.default { env_to_bool(Ext::ENV_ENABLED, true) }
-              o.lazy
             end
 
             option :service_name do |o|
               o.default { Datadog.configuration.service_without_fallback || Ext::SERVICE_NAME }
-              o.lazy
             end
 
             option :operation_name do |o|
-              o.default { ENV.key?(Ext::ENV_OPERATION_NAME) ? ENV[Ext::ENV_OPERATION_NAME] : Ext::OPERATION_NAME }
-              o.lazy
+              o.default { ENV.fetch(Ext::ENV_OPERATION_NAME, Ext::OPERATION_NAME) }
             end
           end
         end

--- a/lib/datadog/ci/contrib/rspec/configuration/settings.rb
+++ b/lib/datadog/ci/contrib/rspec/configuration/settings.rb
@@ -13,17 +13,14 @@ module Datadog
           class Settings < Datadog::Tracing::Contrib::Configuration::Settings
             option :enabled do |o|
               o.default { env_to_bool(Ext::ENV_ENABLED, true) }
-              o.lazy
             end
 
             option :service_name do |o|
               o.default { Datadog.configuration.service_without_fallback || Ext::SERVICE_NAME }
-              o.lazy
             end
 
             option :operation_name do |o|
-              o.default { ENV.key?(Ext::ENV_OPERATION_NAME) ? ENV[Ext::ENV_OPERATION_NAME] : Ext::OPERATION_NAME }
-              o.lazy
+              o.default { ENV.fetch(Ext::ENV_OPERATION_NAME, Ext::OPERATION_NAME) }
             end
           end
         end

--- a/lib/datadog/core/configuration/base.rb
+++ b/lib/datadog/core/configuration/base.rb
@@ -29,7 +29,6 @@ module Datadog
 
             option(name) do |o|
               o.default { settings_class.new }
-              o.lazy
 
               o.resetter do |value|
                 value.reset! if value.respond_to?(:reset!)

--- a/lib/datadog/core/configuration/option.rb
+++ b/lib/datadog/core/configuration/option.rb
@@ -84,7 +84,7 @@ module Datadog
           if definition.default.instance_of?(Proc)
             context_eval(&definition.default)
           else
-            definition.default
+            definition.default_proc || definition.default
           end
         end
 

--- a/lib/datadog/core/configuration/option.rb
+++ b/lib/datadog/core/configuration/option.rb
@@ -84,7 +84,7 @@ module Datadog
           if definition.default.instance_of?(Proc)
             context_eval(&definition.default)
           else
-            definition.default_proc || definition.default
+            definition.experimental_default_proc || definition.default
           end
         end
 

--- a/lib/datadog/core/configuration/option.rb
+++ b/lib/datadog/core/configuration/option.rb
@@ -81,7 +81,7 @@ module Datadog
         end
 
         def default_value
-          if definition.lazy
+          if definition.default.instance_of?(Proc)
             context_eval(&definition.default)
           else
             definition.default

--- a/lib/datadog/core/configuration/option_definition.rb
+++ b/lib/datadog/core/configuration/option_definition.rb
@@ -13,7 +13,6 @@ module Datadog
           :default,
           :delegate_to,
           :depends_on,
-          :lazy,
           :name,
           :on_set,
           :resetter,
@@ -24,7 +23,6 @@ module Datadog
           @default = meta[:default]
           @delegate_to = meta[:delegate_to]
           @depends_on = meta[:depends_on] || []
-          @lazy = meta[:lazy] || false
           @name = name.to_sym
           @on_set = meta[:on_set]
           @resetter = meta[:resetter]
@@ -48,7 +46,6 @@ module Datadog
             @delegate_to = nil
             @depends_on = []
             @helpers = {}
-            @lazy = false
             @name = name.to_sym
             @on_set = nil
             @resetter = nil
@@ -78,10 +75,6 @@ module Datadog
             @helpers[name] = block
           end
 
-          def lazy(value = true)
-            @lazy = value
-          end
-
           def on_set(&block)
             @on_set = block
           end
@@ -105,7 +98,6 @@ module Datadog
             default(options[:default]) if options.key?(:default)
             delegate_to(&options[:delegate_to]) if options.key?(:delegate_to)
             depends_on(*options[:depends_on]) if options.key?(:depends_on)
-            lazy(options[:lazy]) if options.key?(:lazy)
             on_set(&options[:on_set]) if options.key?(:on_set)
             resetter(&options[:resetter]) if options.key?(:resetter)
             setter(&options[:setter]) if options.key?(:setter)
@@ -121,7 +113,6 @@ module Datadog
               default: @default,
               delegate_to: @delegate_to,
               depends_on: @depends_on,
-              lazy: @lazy,
               on_set: @on_set,
               resetter: @resetter,
               setter: @setter,

--- a/lib/datadog/core/configuration/option_definition.rb
+++ b/lib/datadog/core/configuration/option_definition.rb
@@ -11,6 +11,7 @@ module Datadog
 
         attr_reader \
           :default,
+          :default_proc,
           :delegate_to,
           :depends_on,
           :name,
@@ -21,6 +22,7 @@ module Datadog
 
         def initialize(name, meta = {}, &block)
           @default = meta[:default]
+          @default_proc = meta[:default_proc]
           @delegate_to = meta[:delegate_to]
           @depends_on = meta[:depends_on] || []
           @name = name.to_sym
@@ -38,11 +40,14 @@ module Datadog
         # Acts as DSL for building OptionDefinitions
         # @public_api
         class Builder
+          class InvalidOptionError < StandardError; end
+
           attr_reader \
             :helpers
 
           def initialize(name, options = {})
             @default = nil
+            @default_proc = nil
             @delegate_to = nil
             @depends_on = []
             @helpers = {}
@@ -57,6 +62,8 @@ module Datadog
 
             # Apply block if given.
             yield(self) if block_given?
+
+            validate_options!
           end
 
           def depends_on(*values)
@@ -65,6 +72,10 @@ module Datadog
 
           def default(value = nil, &block)
             @default = block || value
+          end
+
+          def default_proc(&block)
+            @default_proc = block
           end
 
           def delegate_to(&block)
@@ -96,6 +107,7 @@ module Datadog
             return if options.nil? || options.empty?
 
             default(options[:default]) if options.key?(:default)
+            default_proc(&options[:default_proc]) if options.key?(:default_proc)
             delegate_to(&options[:delegate_to]) if options.key?(:delegate_to)
             depends_on(*options[:depends_on]) if options.key?(:depends_on)
             on_set(&options[:on_set]) if options.key?(:on_set)
@@ -111,6 +123,7 @@ module Datadog
           def meta
             {
               default: @default,
+              default_proc: @default_proc,
               delegate_to: @delegate_to,
               depends_on: @depends_on,
               on_set: @on_set,
@@ -118,6 +131,17 @@ module Datadog
               setter: @setter,
               type: @type
             }
+          end
+
+          private
+
+          def validate_options!
+            if !@default.nil? && @default_proc
+              raise InvalidOptionError,
+                'Using `default` and `default_proc` is not allowed. Please use one or the other.' \
+                                'If you want to store a block as the default value use `default_proc`'\
+                                ' otherwise use `default`'
+            end
           end
         end
       end

--- a/lib/datadog/core/configuration/option_definition.rb
+++ b/lib/datadog/core/configuration/option_definition.rb
@@ -11,7 +11,7 @@ module Datadog
 
         attr_reader \
           :default,
-          :default_proc,
+          :experimental_default_proc,
           :delegate_to,
           :depends_on,
           :name,
@@ -22,7 +22,7 @@ module Datadog
 
         def initialize(name, meta = {}, &block)
           @default = meta[:default]
-          @default_proc = meta[:default_proc]
+          @experimental_default_proc = meta[:experimental_default_proc]
           @delegate_to = meta[:delegate_to]
           @depends_on = meta[:depends_on] || []
           @name = name.to_sym
@@ -47,7 +47,7 @@ module Datadog
 
           def initialize(name, options = {})
             @default = nil
-            @default_proc = nil
+            @experimental_default_proc = nil
             @delegate_to = nil
             @depends_on = []
             @helpers = {}
@@ -74,8 +74,8 @@ module Datadog
             @default = block || value
           end
 
-          def default_proc(&block)
-            @default_proc = block
+          def experimental_default_proc(&block)
+            @experimental_default_proc = block
           end
 
           def delegate_to(&block)
@@ -107,7 +107,7 @@ module Datadog
             return if options.nil? || options.empty?
 
             default(options[:default]) if options.key?(:default)
-            default_proc(&options[:default_proc]) if options.key?(:default_proc)
+            experimental_default_proc(&options[:experimental_default_proc]) if options.key?(:experimental_default_proc)
             delegate_to(&options[:delegate_to]) if options.key?(:delegate_to)
             depends_on(*options[:depends_on]) if options.key?(:depends_on)
             on_set(&options[:on_set]) if options.key?(:on_set)
@@ -123,7 +123,7 @@ module Datadog
           def meta
             {
               default: @default,
-              default_proc: @default_proc,
+              experimental_default_proc: @experimental_default_proc,
               delegate_to: @delegate_to,
               depends_on: @depends_on,
               on_set: @on_set,
@@ -136,10 +136,10 @@ module Datadog
           private
 
           def validate_options!
-            if !@default.nil? && @default_proc
+            if !@default.nil? && @experimental_default_proc
               raise InvalidOptionError,
-                'Using `default` and `default_proc` is not allowed. Please use one or the other.' \
-                                'If you want to store a block as the default value use `default_proc`'\
+                'Using `default` and `experimental_default_proc` is not allowed. Please use one or the other.' \
+                                'If you want to store a block as the default value use `experimental_default_proc`'\
                                 ' otherwise use `default`'
             end
           end

--- a/lib/datadog/core/configuration/option_definition.rb
+++ b/lib/datadog/core/configuration/option_definition.rb
@@ -11,6 +11,10 @@ module Datadog
 
         attr_reader \
           :default,
+          # experimental_default_proc is used when we want to store a block as part of the option value.
+          # Since this new option is experimental and we might not need it in the near future, I gave it a name that is
+          # clear to the reader that they should not rely on it and that is subject to change.
+          # Currently is only use internally.
           :experimental_default_proc,
           :delegate_to,
           :depends_on,
@@ -88,10 +92,11 @@ module Datadog
 
           def lazy(_value = true)
             Datadog::Core.log_deprecation do
-              'The `lazy` option is deprecated. You no longer need to specify an option to be lazy '\
-              "when the default value is a block.\n"\
-              'In the case edge case that you need the default value to be a block, please use the the expriemntal option:'\
-              'experimental_default_proc'
+              'Defining an option as lazy is deprecated for removal. Options now always behave as lazy. '\
+              "Please remove all references to the lazy setting.\n"\
+              'Non-lazy options that were previously stored as blocks are no longer supported. '\
+              'If you used this feature, please let us know by opening an issue on: '\
+              'https://github.com/datadog/dd-trace-rb/issues/new so we can better understand and support your use case.'
             end
           end
 

--- a/lib/datadog/core/configuration/option_definition.rb
+++ b/lib/datadog/core/configuration/option_definition.rb
@@ -86,6 +86,15 @@ module Datadog
             @helpers[name] = block
           end
 
+          def lazy(_value = true)
+            Datadog::Core.log_deprecation do
+              'The `lazy` option is deprecated. You no longer need to specify an option to be lazy '\
+              "when the default value is a block.\n"\
+              'In the case edge case that you need the default value to be a block, please use the the expriemntal option:'\
+              'experimental_default_proc'
+            end
+          end
+
           def on_set(&block)
             @on_set = block
           end
@@ -110,6 +119,7 @@ module Datadog
             experimental_default_proc(&options[:experimental_default_proc]) if options.key?(:experimental_default_proc)
             delegate_to(&options[:delegate_to]) if options.key?(:delegate_to)
             depends_on(*options[:depends_on]) if options.key?(:depends_on)
+            lazy(options[:lazy]) if options.key?(:lazy)
             on_set(&options[:on_set]) if options.key?(:on_set)
             resetter(&options[:resetter]) if options.key?(:resetter)
             setter(&options[:setter]) if options.key?(:setter)

--- a/lib/datadog/core/configuration/settings.rb
+++ b/lib/datadog/core/configuration/settings.rb
@@ -480,7 +480,7 @@ module Datadog
         # @default `->{ Time.now }`
         # @return [Proc<Time>]
         option :time_now_provider do |o|
-          o.default_proc do
+          o.experimental_default_proc do
             ::Time.now
           end
           o.on_set do |time_provider|

--- a/lib/datadog/core/configuration/settings.rb
+++ b/lib/datadog/core/configuration/settings.rb
@@ -480,8 +480,9 @@ module Datadog
         # @default `->{ Time.now }`
         # @return [Proc<Time>]
         option :time_now_provider do |o|
-          o.default { -> { ::Time.now } }
-
+          o.default_proc do
+            ::Time.now
+          end
           o.on_set do |time_provider|
             Core::Utils::Time.now_provider = time_provider
           end

--- a/lib/datadog/core/configuration/settings.rb
+++ b/lib/datadog/core/configuration/settings.rb
@@ -360,7 +360,6 @@ module Datadog
             # @default `DD_PROFILING_EXPERIMENTAL_TIMELINE_ENABLED` environment variable as a boolean, otherwise `false`
             option :experimental_timeline_enabled do |o|
               o.default { env_to_bool('DD_PROFILING_EXPERIMENTAL_TIMELINE_ENABLED', false) }
-              o.lazy
             end
           end
 

--- a/lib/datadog/core/configuration/settings.rb
+++ b/lib/datadog/core/configuration/settings.rb
@@ -80,7 +80,6 @@ module Datadog
         # @return [String,nil]
         option :api_key do |o|
           o.default { ENV.fetch(Core::Environment::Ext::ENV_API_KEY, nil) }
-          o.lazy
         end
 
         # Datadog diagnostic settings.
@@ -100,7 +99,6 @@ module Datadog
           # @return [Boolean]
           option :debug do |o|
             o.default { env_to_bool(Datadog::Core::Configuration::Ext::Diagnostics::ENV_DEBUG_ENABLED, false) }
-            o.lazy
             o.on_set do |enabled|
               # Enable rich debug print statements.
               # We do not need to unnecessarily load 'pp' unless in debugging mode.
@@ -118,7 +116,6 @@ module Datadog
             # @return [Boolean]
             option :enabled do |o|
               o.default { env_to_bool(Datadog::Core::Configuration::Ext::Diagnostics::ENV_HEALTH_METRICS_ENABLED, false) }
-              o.lazy
             end
 
             # {Datadog::Statsd} instance to collect health metrics.
@@ -144,7 +141,6 @@ module Datadog
             option :enabled do |o|
               # Defaults to nil as we want to know when the default value is being used
               o.default { env_to_bool(Datadog::Core::Configuration::Ext::Diagnostics::ENV_STARTUP_LOGS_ENABLED, nil) }
-              o.lazy
             end
           end
         end
@@ -159,7 +155,6 @@ module Datadog
 
           # NOTE: env also gets set as a side effect of tags. See the WORKAROUND note in #initialize for details.
           o.default { ENV.fetch(Core::Environment::Ext::ENV_ENVIRONMENT, nil) }
-          o.lazy
         end
 
         # Internal `Datadog.logger` configuration.
@@ -195,7 +190,6 @@ module Datadog
           # @return [Boolean]
           option :enabled do |o|
             o.default { env_to_bool(Profiling::Ext::ENV_ENABLED, false) }
-            o.lazy
           end
 
           # @public_api
@@ -229,7 +223,6 @@ module Datadog
             # @default `DD_PROFILING_MAX_FRAMES` environment variable, otherwise 400
             option :max_frames do |o|
               o.default { env_to_int(Profiling::Ext::ENV_MAX_FRAMES, 400) }
-              o.lazy
             end
 
             # @public_api
@@ -242,7 +235,6 @@ module Datadog
                 # @return [Boolean]
                 option :enabled do |o|
                   o.default { env_to_bool(Profiling::Ext::ENV_ENDPOINT_COLLECTION_ENABLED, true) }
-                  o.lazy
                 end
               end
             end
@@ -285,7 +277,6 @@ module Datadog
             # @default `DD_PROFILING_FORCE_ENABLE_LEGACY` environment variable, otherwise `false`
             option :force_enable_legacy_profiler do |o|
               o.default { env_to_bool('DD_PROFILING_FORCE_ENABLE_LEGACY', false) }
-              o.lazy
               o.on_set do |value|
                 if value
                   Datadog.logger.warn(
@@ -318,7 +309,6 @@ module Datadog
             # @default `DD_PROFILING_FORCE_ENABLE_GC` environment variable, otherwise `false`
             option :force_enable_gc_profiling do |o|
               o.default { env_to_bool('DD_PROFILING_FORCE_ENABLE_GC', false) }
-              o.lazy
             end
 
             # Can be used to enable/disable the Datadog::Profiling.allocation_count feature.
@@ -340,7 +330,6 @@ module Datadog
             # @default `DD_PROFILING_SKIP_MYSQL2_CHECK` environment variable, otherwise `false`
             option :skip_mysql2_check do |o|
               o.default { env_to_bool('DD_PROFILING_SKIP_MYSQL2_CHECK', false) }
-              o.lazy
             end
 
             # The profiler gathers data by sending `SIGPROF` unix signals to Ruby application threads.
@@ -364,7 +353,6 @@ module Datadog
             # @default `DD_PROFILING_NO_SIGNALS_WORKAROUND_ENABLED` environment variable as a boolean, otherwise `:auto`
             option :no_signals_workaround_enabled do |o|
               o.default { env_to_bool('DD_PROFILING_NO_SIGNALS_WORKAROUND_ENABLED', :auto) }
-              o.lazy
             end
 
             # Enables data collection for the timeline feature. This is still experimental and not recommended yet.
@@ -384,7 +372,6 @@ module Datadog
             option :timeout_seconds do |o|
               o.setter { |value| value.nil? ? 30.0 : value.to_f }
               o.default { env_to_float(Profiling::Ext::ENV_UPLOAD_TIMEOUT, 30.0) }
-              o.lazy
             end
           end
         end
@@ -398,10 +385,9 @@ module Datadog
           # @return [Boolean]
           option :enabled do |o|
             o.default { env_to_bool(Core::Runtime::Ext::Metrics::ENV_ENABLED, false) }
-            o.lazy
           end
 
-          option :opts, default: ->(_i) { {} }, lazy: true
+          option :opts, default: ->(_i) { {} }
           option :statsd
         end
 
@@ -415,7 +401,6 @@ module Datadog
 
           # NOTE: service also gets set as a side effect of tags. See the WORKAROUND note in #initialize for details.
           o.default { ENV.fetch(Core::Environment::Ext::ENV_SERVICE, Core::Environment::Ext::FALLBACK_SERVICE_NAME) }
-          o.lazy
 
           # There's a few cases where we don't want to use the fallback service name, so this helper allows us to get a
           # nil instead so that one can do
@@ -438,7 +423,6 @@ module Datadog
         # @return [String,nil]
         option :site do |o|
           o.default { ENV.fetch(Core::Environment::Ext::ENV_SITE, nil) }
-          o.lazy
         end
 
         # Default tags
@@ -484,8 +468,6 @@ module Datadog
             # Merge with previous tags
             (old_value || {}).merge(string_tags)
           end
-
-          o.lazy
         end
 
         # The time provider used by Datadog. It must respect the interface of [Time](https://ruby-doc.org/core-3.0.1/Time.html).
@@ -498,7 +480,7 @@ module Datadog
         # @default `->{ Time.now }`
         # @return [Proc<Time>]
         option :time_now_provider do |o|
-          o.default { ::Time.now }
+          o.default { -> { ::Time.now } }
 
           o.on_set do |time_provider|
             Core::Utils::Time.now_provider = time_provider
@@ -520,7 +502,6 @@ module Datadog
         option :version do |o|
           # NOTE: version also gets set as a side effect of tags. See the WORKAROUND note in #initialize for details.
           o.default { ENV.fetch(Core::Environment::Ext::ENV_VERSION, nil) }
-          o.lazy
         end
 
         # Client-side telemetry configuration
@@ -533,7 +514,6 @@ module Datadog
           # @return [Boolean]
           option :enabled do |o|
             o.default { env_to_bool(Core::Telemetry::Ext::ENV_ENABLED, true) }
-            o.lazy
           end
 
           # The interval in seconds when telemetry must be sent.
@@ -545,7 +525,6 @@ module Datadog
           # @!visibility private
           option :heartbeat_interval_seconds do |o|
             o.default { env_to_float(Core::Telemetry::Ext::ENV_HEARTBEAT_INTERVAL, 60) }
-            o.lazy
           end
         end
 
@@ -558,7 +537,6 @@ module Datadog
           # @return [Boolean]
           option :enabled do |o|
             o.default { env_to_bool(Core::Remote::Ext::ENV_ENABLED, true) }
-            o.lazy
           end
 
           # Tune remote configuration polling interval.
@@ -567,7 +545,6 @@ module Datadog
           # @return [Float]
           option :poll_interval_seconds do |o|
             o.default { env_to_float(Core::Remote::Ext::ENV_POLL_INTERVAL_SECONDS, 5.0) }
-            o.lazy
           end
 
           # Declare service name to bind to remote configuration. Use when

--- a/lib/datadog/tracing/configuration/settings.rb
+++ b/lib/datadog/tracing/configuration/settings.rb
@@ -27,7 +27,6 @@ module Datadog
                 # @return [Boolean,nil]
                 option :enabled do |o|
                   o.default { env_to_bool(Tracing::Configuration::Ext::Analytics::ENV_TRACE_ANALYTICS_ENABLED, nil) }
-                  o.lazy
                 end
               end
 
@@ -82,8 +81,6 @@ module Datadog
                       end
                     end
                   end
-
-                  o.lazy
                 end
 
                 # The data propagation styles the tracer will use to inject distributed tracing propagation
@@ -120,8 +117,6 @@ module Datadog
                       end
                     end
                   end
-
-                  o.lazy
                 end
 
                 # An ordered list of what data propagation styles the tracer will use to extract distributed tracing propagation
@@ -156,8 +151,6 @@ module Datadog
                     set_option(:propagation_extract_style, styles)
                     set_option(:propagation_inject_style, styles)
                   end
-
-                  o.lazy
                 end
               end
 
@@ -170,7 +163,6 @@ module Datadog
               # @return [Boolean]
               option :enabled do |o|
                 o.default { env_to_bool(Tracing::Configuration::Ext::ENV_ENABLED, true) }
-                o.lazy
               end
 
               # Enable 128 bit trace id generation.
@@ -179,7 +171,6 @@ module Datadog
               # @return [Boolean]
               option :trace_id_128_bit_generation_enabled do |o|
                 o.default { env_to_bool(Tracing::Configuration::Ext::ENV_TRACE_ID_128_BIT_GENERATION_ENABLED, false) }
-                o.lazy
               end
 
               # Enable 128 bit trace id injected for logging.
@@ -190,7 +181,6 @@ module Datadog
               # It is not supported by our backend yet. Do not enable it.
               option :trace_id_128_bit_logging_enabled do |o|
                 o.default { env_to_bool(Tracing::Configuration::Ext::Correlation::ENV_TRACE_ID_128_BIT_LOGGING_ENABLED, false) }
-                o.lazy
               end
 
               # A custom tracer instance.
@@ -212,7 +202,6 @@ module Datadog
               # @return [Boolean]
               option :log_injection do |o|
                 o.default { env_to_bool(Tracing::Configuration::Ext::Correlation::ENV_LOGS_INJECTION_ENABLED, true) }
-                o.lazy
               end
 
               # Configures an alternative trace transport behavior, where
@@ -253,7 +242,6 @@ module Datadog
 
               option :report_hostname do |o|
                 o.default { env_to_bool(Tracing::Configuration::Ext::NET::ENV_REPORT_HOSTNAME, false) }
-                o.lazy
               end
 
               # A custom sampler instance.
@@ -276,7 +264,6 @@ module Datadog
                 # @return [Float,nil]
                 option :default_rate do |o|
                   o.default { env_to_float(Tracing::Configuration::Ext::Sampling::ENV_SAMPLE_RATE, nil) }
-                  o.lazy
                 end
 
                 # Rate limit for number of spans per second.
@@ -288,7 +275,6 @@ module Datadog
                 # @return [Numeric,nil]
                 option :rate_limit do |o|
                   o.default { env_to_float(Tracing::Configuration::Ext::Sampling::ENV_RATE_LIMIT, 100) }
-                  o.lazy
                 end
 
                 # Single span sampling rules.
@@ -330,7 +316,6 @@ module Datadog
                       end
                     end
                   end
-                  o.lazy
                 end
               end
 
@@ -345,17 +330,14 @@ module Datadog
                 # @return [Boolean]
                 option :enabled do |o|
                   o.default { env_to_bool(Tracing::Configuration::Ext::Test::ENV_MODE_ENABLED, false) }
-                  o.lazy
                 end
 
                 option :trace_flush do |o|
                   o.default { nil }
-                  o.lazy
                 end
 
                 option :writer_options do |o|
                   o.default { {} }
-                  o.lazy
                 end
               end
 
@@ -383,7 +365,7 @@ module Datadog
               #
               # @default `{}`
               # @return [Hash,nil]
-              option :writer_options, default: ->(_i) { {} }, lazy: true
+              option :writer_options, default: ->(_i) { {} }
 
               # Client IP configuration
               # @public_api
@@ -412,7 +394,6 @@ module Datadog
                     # ENABLED env var takes precedence over deprecated DISABLED
                     env_to_bool(Tracing::Configuration::Ext::ClientIp::ENV_ENABLED, enabled)
                   end
-                  o.lazy
                 end
 
                 # An optional name of a custom header to resolve the client IP from.
@@ -421,7 +402,6 @@ module Datadog
                 # @return [String,nil]
                 option :header_name do |o|
                   o.default { ENV.fetch(Tracing::Configuration::Ext::ClientIp::ENV_HEADER_NAME, nil) }
-                  o.lazy
                 end
               end
 
@@ -435,7 +415,6 @@ module Datadog
               # @return [Integer]
               option :x_datadog_tags_max_length do |o|
                 o.default { env_to_int(Tracing::Configuration::Ext::Distributed::ENV_X_DATADOG_TAGS_MAX_LENGTH, 512) }
-                o.lazy
               end
 
               # Schema version for span attributes that enables various features
@@ -449,7 +428,6 @@ module Datadog
                     Tracing::Configuration::Ext::SpanAttributeSchema::DEFAULT_VERSION
                   )
                 end
-                o.lazy
               end
             end
           end

--- a/lib/datadog/tracing/contrib/action_cable/configuration/settings.rb
+++ b/lib/datadog/tracing/contrib/action_cable/configuration/settings.rb
@@ -13,17 +13,14 @@ module Datadog
           class Settings < Contrib::Configuration::Settings
             option :enabled do |o|
               o.default { env_to_bool(Ext::ENV_ENABLED, true) }
-              o.lazy
             end
 
             option :analytics_enabled do |o|
               o.default { env_to_bool(Ext::ENV_ANALYTICS_ENABLED, false) }
-              o.lazy
             end
 
             option :analytics_sample_rate do |o|
               o.default { env_to_float(Ext::ENV_ANALYTICS_SAMPLE_RATE, 1.0) }
-              o.lazy
             end
 
             option :service_name

--- a/lib/datadog/tracing/contrib/action_mailer/configuration/settings.rb
+++ b/lib/datadog/tracing/contrib/action_mailer/configuration/settings.rb
@@ -13,17 +13,14 @@ module Datadog
           class Settings < Contrib::Configuration::Settings
             option :enabled do |o|
               o.default { env_to_bool(Ext::ENV_ENABLED, true) }
-              o.lazy
             end
 
             option :analytics_enabled do |o|
               o.default { env_to_bool(Ext::ENV_ANALYTICS_ENABLED, false) }
-              o.lazy
             end
 
             option :analytics_sample_rate do |o|
               o.default { env_to_float(Ext::ENV_ANALYTICS_SAMPLE_RATE, 1.0) }
-              o.lazy
             end
 
             option :service_name

--- a/lib/datadog/tracing/contrib/action_pack/configuration/settings.rb
+++ b/lib/datadog/tracing/contrib/action_pack/configuration/settings.rb
@@ -13,17 +13,14 @@ module Datadog
           class Settings < Contrib::Configuration::Settings
             option :enabled do |o|
               o.default { env_to_bool(Ext::ENV_ENABLED, true) }
-              o.lazy
             end
 
             option :analytics_enabled do |o|
               o.default { env_to_bool(Ext::ENV_ANALYTICS_ENABLED, nil) }
-              o.lazy
             end
 
             option :analytics_sample_rate do |o|
               o.default { env_to_float(Ext::ENV_ANALYTICS_SAMPLE_RATE, 1.0) }
-              o.lazy
             end
 
             # DEV-2.0: Breaking changes for removal.

--- a/lib/datadog/tracing/contrib/action_view/configuration/settings.rb
+++ b/lib/datadog/tracing/contrib/action_view/configuration/settings.rb
@@ -11,17 +11,14 @@ module Datadog
           class Settings < Contrib::Configuration::Settings
             option :enabled do |o|
               o.default { env_to_bool(Ext::ENV_ENABLED, true) }
-              o.lazy
             end
 
             option :analytics_enabled do |o|
               o.default { env_to_bool(Ext::ENV_ANALYTICS_ENABLED, false) }
-              o.lazy
             end
 
             option :analytics_sample_rate do |o|
               o.default { env_to_float(Ext::ENV_ANALYTICS_SAMPLE_RATE, 1.0) }
-              o.lazy
             end
 
             option :service_name

--- a/lib/datadog/tracing/contrib/active_job/configuration/settings.rb
+++ b/lib/datadog/tracing/contrib/active_job/configuration/settings.rb
@@ -25,7 +25,7 @@ module Datadog
             end
 
             option :service_name
-            option :error_handler, default_proc: Tracing::SpanOperation::Events::DEFAULT_ON_ERROR
+            option :error_handler, experimental_default_proc: Tracing::SpanOperation::Events::DEFAULT_ON_ERROR
           end
         end
       end

--- a/lib/datadog/tracing/contrib/active_job/configuration/settings.rb
+++ b/lib/datadog/tracing/contrib/active_job/configuration/settings.rb
@@ -25,7 +25,7 @@ module Datadog
             end
 
             option :service_name
-            option :error_handler, default: Tracing::SpanOperation::Events::DEFAULT_ON_ERROR
+            option :error_handler, default_proc: Tracing::SpanOperation::Events::DEFAULT_ON_ERROR
           end
         end
       end

--- a/lib/datadog/tracing/contrib/active_job/configuration/settings.rb
+++ b/lib/datadog/tracing/contrib/active_job/configuration/settings.rb
@@ -14,17 +14,14 @@ module Datadog
           class Settings < Contrib::Configuration::Settings
             option :enabled do |o|
               o.default { env_to_bool(Ext::ENV_ENABLED, true) }
-              o.lazy
             end
 
             option :analytics_enabled do |o|
               o.default { env_to_bool(Ext::ENV_ANALYTICS_ENABLED, false) }
-              o.lazy
             end
 
             option :analytics_sample_rate do |o|
               o.default { env_to_float(Ext::ENV_ANALYTICS_SAMPLE_RATE, 1.0) }
-              o.lazy
             end
 
             option :service_name

--- a/lib/datadog/tracing/contrib/active_model_serializers/configuration/settings.rb
+++ b/lib/datadog/tracing/contrib/active_model_serializers/configuration/settings.rb
@@ -13,17 +13,14 @@ module Datadog
           class Settings < Contrib::Configuration::Settings
             option :enabled do |o|
               o.default { env_to_bool(Ext::ENV_ENABLED, true) }
-              o.lazy
             end
 
             option :analytics_enabled do |o|
               o.default { env_to_bool(Ext::ENV_ANALYTICS_ENABLED, false) }
-              o.lazy
             end
 
             option :analytics_sample_rate do |o|
               o.default { env_to_float(Ext::ENV_ANALYTICS_SAMPLE_RATE, 1.0) }
-              o.lazy
             end
           end
         end

--- a/lib/datadog/tracing/contrib/active_record/configuration/settings.rb
+++ b/lib/datadog/tracing/contrib/active_record/configuration/settings.rb
@@ -14,17 +14,14 @@ module Datadog
           class Settings < Contrib::Configuration::Settings
             option :enabled do |o|
               o.default { env_to_bool(Ext::ENV_ENABLED, true) }
-              o.lazy
             end
 
             option :analytics_enabled do |o|
               o.default { env_to_bool(Ext::ENV_ANALYTICS_ENABLED, false) }
-              o.lazy
             end
 
             option :analytics_sample_rate do |o|
               o.default { env_to_float(Ext::ENV_ANALYTICS_SAMPLE_RATE, 1.0) }
-              o.lazy
             end
 
             option :service_name do |o|
@@ -34,7 +31,6 @@ module Datadog
                   Utils.adapter_name
                 )
               end
-              o.lazy
             end
           end
         end

--- a/lib/datadog/tracing/contrib/active_support/configuration/settings.rb
+++ b/lib/datadog/tracing/contrib/active_support/configuration/settings.rb
@@ -13,17 +13,14 @@ module Datadog
           class Settings < Contrib::Configuration::Settings
             option :enabled do |o|
               o.default { env_to_bool(Ext::ENV_ENABLED, true) }
-              o.lazy
             end
 
             option :analytics_enabled do |o|
               o.default { env_to_bool(Ext::ENV_ANALYTICS_ENABLED, false) }
-              o.lazy
             end
 
             option :analytics_sample_rate do |o|
               o.default { env_to_float(Ext::ENV_ANALYTICS_SAMPLE_RATE, 1.0) }
-              o.lazy
             end
 
             option :cache_service do |o|
@@ -33,7 +30,6 @@ module Datadog
                   Ext::SERVICE_CACHE
                 )
               end
-              o.lazy
             end
           end
         end

--- a/lib/datadog/tracing/contrib/aws/configuration/settings.rb
+++ b/lib/datadog/tracing/contrib/aws/configuration/settings.rb
@@ -14,17 +14,14 @@ module Datadog
           class Settings < Contrib::Configuration::Settings
             option :enabled do |o|
               o.default { env_to_bool(Ext::ENV_ENABLED, true) }
-              o.lazy
             end
 
             option :analytics_enabled do |o|
               o.default { env_to_bool(Ext::ENV_ANALYTICS_ENABLED, false) }
-              o.lazy
             end
 
             option :analytics_sample_rate do |o|
               o.default { env_to_float(Ext::ENV_ANALYTICS_SAMPLE_RATE, 1.0) }
-              o.lazy
             end
 
             option :service_name do |o|
@@ -34,7 +31,6 @@ module Datadog
                   Ext::DEFAULT_PEER_SERVICE_NAME
                 )
               end
-              o.lazy
             end
           end
         end

--- a/lib/datadog/tracing/contrib/concurrent_ruby/configuration/settings.rb
+++ b/lib/datadog/tracing/contrib/concurrent_ruby/configuration/settings.rb
@@ -13,7 +13,6 @@ module Datadog
           class Settings < Contrib::Configuration::Settings
             option :enabled do |o|
               o.default { env_to_bool(Ext::ENV_ENABLED, true) }
-              o.lazy
             end
           end
         end

--- a/lib/datadog/tracing/contrib/dalli/configuration/settings.rb
+++ b/lib/datadog/tracing/contrib/dalli/configuration/settings.rb
@@ -13,17 +13,14 @@ module Datadog
           class Settings < Contrib::Configuration::Settings
             option :enabled do |o|
               o.default { env_to_bool(Ext::ENV_ENABLED, true) }
-              o.lazy
             end
 
             option :analytics_enabled do |o|
               o.default { env_to_bool(Ext::ENV_ANALYTICS_ENABLED, false) }
-              o.lazy
             end
 
             option :analytics_sample_rate do |o|
               o.default { env_to_float(Ext::ENV_ANALYTICS_SAMPLE_RATE, 1.0) }
-              o.lazy
             end
 
             option :service_name do |o|
@@ -33,7 +30,6 @@ module Datadog
                   Ext::DEFAULT_PEER_SERVICE_NAME
                 )
               end
-              o.lazy
             end
           end
         end

--- a/lib/datadog/tracing/contrib/delayed_job/configuration/settings.rb
+++ b/lib/datadog/tracing/contrib/delayed_job/configuration/settings.rb
@@ -14,17 +14,14 @@ module Datadog
           class Settings < Contrib::Configuration::Settings
             option :enabled do |o|
               o.default { env_to_bool(Ext::ENV_ENABLED, true) }
-              o.lazy
             end
 
             option :analytics_enabled do |o|
               o.default { env_to_bool(Ext::ENV_ANALYTICS_ENABLED, false) }
-              o.lazy
             end
 
             option :analytics_sample_rate do |o|
               o.default { env_to_float(Ext::ENV_ANALYTICS_SAMPLE_RATE, 1.0) }
-              o.lazy
             end
 
             option :service_name

--- a/lib/datadog/tracing/contrib/delayed_job/configuration/settings.rb
+++ b/lib/datadog/tracing/contrib/delayed_job/configuration/settings.rb
@@ -26,7 +26,7 @@ module Datadog
 
             option :service_name
             option :client_service_name
-            option :error_handler, default_proc: Tracing::SpanOperation::Events::DEFAULT_ON_ERROR
+            option :error_handler, experimental_default_proc: Tracing::SpanOperation::Events::DEFAULT_ON_ERROR
           end
         end
       end

--- a/lib/datadog/tracing/contrib/delayed_job/configuration/settings.rb
+++ b/lib/datadog/tracing/contrib/delayed_job/configuration/settings.rb
@@ -26,7 +26,7 @@ module Datadog
 
             option :service_name
             option :client_service_name
-            option :error_handler, default: Tracing::SpanOperation::Events::DEFAULT_ON_ERROR
+            option :error_handler, default_proc: Tracing::SpanOperation::Events::DEFAULT_ON_ERROR
           end
         end
       end

--- a/lib/datadog/tracing/contrib/elasticsearch/configuration/settings.rb
+++ b/lib/datadog/tracing/contrib/elasticsearch/configuration/settings.rb
@@ -13,17 +13,14 @@ module Datadog
           class Settings < Contrib::Configuration::Settings
             option :enabled do |o|
               o.default { env_to_bool(Ext::ENV_ENABLED, true) }
-              o.lazy
             end
 
             option :analytics_enabled do |o|
               o.default { env_to_bool(Ext::ENV_ANALYTICS_ENABLED, false) }
-              o.lazy
             end
 
             option :analytics_sample_rate do |o|
               o.default { env_to_float(Ext::ENV_ANALYTICS_SAMPLE_RATE, 1.0) }
-              o.lazy
             end
 
             option :quantize, default: {}
@@ -35,7 +32,6 @@ module Datadog
                   Ext::DEFAULT_PEER_SERVICE_NAME
                 )
               end
-              o.lazy
             end
           end
         end

--- a/lib/datadog/tracing/contrib/ethon/configuration/settings.rb
+++ b/lib/datadog/tracing/contrib/ethon/configuration/settings.rb
@@ -13,17 +13,14 @@ module Datadog
           class Settings < Contrib::Configuration::Settings
             option :enabled do |o|
               o.default { env_to_bool(Ext::ENV_ENABLED, true) }
-              o.lazy
             end
 
             option :analytics_enabled do |o|
               o.default { env_to_bool(Ext::ENV_ANALYTICS_ENABLED, false) }
-              o.lazy
             end
 
             option :analytics_sample_rate do |o|
               o.default { env_to_float(Ext::ENV_ANALYTICS_SAMPLE_RATE, 1.0) }
-              o.lazy
             end
 
             option :distributed_tracing, default: true
@@ -37,7 +34,6 @@ module Datadog
                   Ext::DEFAULT_PEER_SERVICE_NAME
                 )
               end
-              o.lazy
             end
           end
         end

--- a/lib/datadog/tracing/contrib/excon/configuration/settings.rb
+++ b/lib/datadog/tracing/contrib/excon/configuration/settings.rb
@@ -13,17 +13,14 @@ module Datadog
           class Settings < Contrib::Configuration::Settings
             option :enabled do |o|
               o.default { env_to_bool(Ext::ENV_ENABLED, true) }
-              o.lazy
             end
 
             option :analytics_enabled do |o|
               o.default { env_to_bool(Ext::ENV_ANALYTICS_ENABLED, false) }
-              o.lazy
             end
 
             option :analytics_sample_rate do |o|
               o.default { env_to_float(Ext::ENV_ANALYTICS_SAMPLE_RATE, 1.0) }
-              o.lazy
             end
 
             option :distributed_tracing, default: true
@@ -37,7 +34,6 @@ module Datadog
                   Ext::DEFAULT_PEER_SERVICE_NAME
                 )
               end
-              o.lazy
             end
           end
         end

--- a/lib/datadog/tracing/contrib/faraday/configuration/settings.rb
+++ b/lib/datadog/tracing/contrib/faraday/configuration/settings.rb
@@ -17,17 +17,14 @@ module Datadog
 
             option :enabled do |o|
               o.default { env_to_bool(Ext::ENV_ENABLED, true) }
-              o.lazy
             end
 
             option :analytics_enabled do |o|
               o.default { env_to_bool(Ext::ENV_ANALYTICS_ENABLED, false) }
-              o.lazy
             end
 
             option :analytics_sample_rate do |o|
               o.default { env_to_float(Ext::ENV_ANALYTICS_SAMPLE_RATE, 1.0) }
-              o.lazy
             end
 
             option :distributed_tracing, default: true
@@ -41,7 +38,6 @@ module Datadog
                   Ext::DEFAULT_PEER_SERVICE_NAME
                 )
               end
-              o.lazy
             end
           end
         end

--- a/lib/datadog/tracing/contrib/faraday/configuration/settings.rb
+++ b/lib/datadog/tracing/contrib/faraday/configuration/settings.rb
@@ -28,7 +28,7 @@ module Datadog
             end
 
             option :distributed_tracing, default: true
-            option :error_handler, default: DEFAULT_ERROR_HANDLER
+            option :error_handler, default_proc: DEFAULT_ERROR_HANDLER
             option :split_by_domain, default: false
 
             option :service_name do |o|

--- a/lib/datadog/tracing/contrib/faraday/configuration/settings.rb
+++ b/lib/datadog/tracing/contrib/faraday/configuration/settings.rb
@@ -28,7 +28,7 @@ module Datadog
             end
 
             option :distributed_tracing, default: true
-            option :error_handler, default_proc: DEFAULT_ERROR_HANDLER
+            option :error_handler, experimental_default_proc: DEFAULT_ERROR_HANDLER
             option :split_by_domain, default: false
 
             option :service_name do |o|

--- a/lib/datadog/tracing/contrib/grape/configuration/settings.rb
+++ b/lib/datadog/tracing/contrib/grape/configuration/settings.rb
@@ -14,17 +14,14 @@ module Datadog
           class Settings < Contrib::Configuration::Settings
             option :enabled do |o|
               o.default { env_to_bool(Ext::ENV_ENABLED, true) }
-              o.lazy
             end
 
             option :analytics_enabled do |o|
               o.default { env_to_bool(Ext::ENV_ANALYTICS_ENABLED, nil) }
-              o.lazy
             end
 
             option :analytics_sample_rate do |o|
               o.default { env_to_float(Ext::ENV_ANALYTICS_SAMPLE_RATE, 1.0) }
-              o.lazy
             end
 
             option :service_name

--- a/lib/datadog/tracing/contrib/graphql/configuration/settings.rb
+++ b/lib/datadog/tracing/contrib/graphql/configuration/settings.rb
@@ -13,17 +13,14 @@ module Datadog
           class Settings < Contrib::Configuration::Settings
             option :enabled do |o|
               o.default { env_to_bool(Ext::ENV_ENABLED, true) }
-              o.lazy
             end
 
             option :analytics_enabled do |o|
               o.default { env_to_bool(Ext::ENV_ANALYTICS_ENABLED, nil) }
-              o.lazy
             end
 
             option :analytics_sample_rate do |o|
               o.default { env_to_float(Ext::ENV_ANALYTICS_SAMPLE_RATE, 1.0) }
-              o.lazy
             end
 
             option :schemas

--- a/lib/datadog/tracing/contrib/grpc/configuration/settings.rb
+++ b/lib/datadog/tracing/contrib/grpc/configuration/settings.rb
@@ -35,7 +35,7 @@ module Datadog
               end
             end
 
-            option :error_handler, default: Tracing::SpanOperation::Events::DEFAULT_ON_ERROR
+            option :error_handler, default_proc: Tracing::SpanOperation::Events::DEFAULT_ON_ERROR
           end
         end
       end

--- a/lib/datadog/tracing/contrib/grpc/configuration/settings.rb
+++ b/lib/datadog/tracing/contrib/grpc/configuration/settings.rb
@@ -14,17 +14,14 @@ module Datadog
           class Settings < Contrib::Configuration::Settings
             option :enabled do |o|
               o.default { env_to_bool(Ext::ENV_ENABLED, true) }
-              o.lazy
             end
 
             option :analytics_enabled do |o|
               o.default { env_to_bool(Ext::ENV_ANALYTICS_ENABLED, false) }
-              o.lazy
             end
 
             option :analytics_sample_rate do |o|
               o.default { env_to_float(Ext::ENV_ANALYTICS_SAMPLE_RATE, 1.0) }
-              o.lazy
             end
 
             option :distributed_tracing, default: true
@@ -36,7 +33,6 @@ module Datadog
                   Ext::DEFAULT_PEER_SERVICE_NAME
                 )
               end
-              o.lazy
             end
 
             option :error_handler, default: Tracing::SpanOperation::Events::DEFAULT_ON_ERROR

--- a/lib/datadog/tracing/contrib/grpc/configuration/settings.rb
+++ b/lib/datadog/tracing/contrib/grpc/configuration/settings.rb
@@ -35,7 +35,7 @@ module Datadog
               end
             end
 
-            option :error_handler, default_proc: Tracing::SpanOperation::Events::DEFAULT_ON_ERROR
+            option :error_handler, experimental_default_proc: Tracing::SpanOperation::Events::DEFAULT_ON_ERROR
           end
         end
       end

--- a/lib/datadog/tracing/contrib/hanami/configuration/settings.rb
+++ b/lib/datadog/tracing/contrib/hanami/configuration/settings.rb
@@ -12,7 +12,6 @@ module Datadog
           class Settings < Contrib::Configuration::Settings
             option :enabled do |o|
               o.default { env_to_bool(Ext::ENV_ENABLED, true) }
-              o.lazy
             end
           end
         end

--- a/lib/datadog/tracing/contrib/http/configuration/settings.rb
+++ b/lib/datadog/tracing/contrib/http/configuration/settings.rb
@@ -13,17 +13,14 @@ module Datadog
           class Settings < Contrib::Configuration::Settings
             option :enabled do |o|
               o.default { env_to_bool(Ext::ENV_ENABLED, true) }
-              o.lazy
             end
 
             option :analytics_enabled do |o|
               o.default { env_to_bool(Ext::ENV_ANALYTICS_ENABLED, false) }
-              o.lazy
             end
 
             option :analytics_sample_rate do |o|
               o.default { env_to_float(Ext::ENV_ANALYTICS_SAMPLE_RATE, 1.0) }
-              o.lazy
             end
 
             option :distributed_tracing, default: true
@@ -35,12 +32,10 @@ module Datadog
                   Ext::DEFAULT_PEER_SERVICE_NAME
                 )
               end
-              o.lazy
             end
 
             option :error_status_codes do |o|
               o.default { env_to_list(Ext::ENV_ERROR_STATUS_CODES, 400...600, comma_separated_only: false) }
-              o.lazy
             end
 
             option :split_by_domain, default: false

--- a/lib/datadog/tracing/contrib/httpclient/configuration/settings.rb
+++ b/lib/datadog/tracing/contrib/httpclient/configuration/settings.rb
@@ -13,17 +13,14 @@ module Datadog
           class Settings < Contrib::Configuration::Settings
             option :enabled do |o|
               o.default { env_to_bool(Ext::ENV_ENABLED, true) }
-              o.lazy
             end
 
             option :analytics_enabled do |o|
               o.default { env_to_bool(Ext::ENV_ANALYTICS_ENABLED, false) }
-              o.lazy
             end
 
             option :analytics_sample_rate do |o|
               o.default { env_to_float(Ext::ENV_ANALYTICS_SAMPLE_RATE, 1.0) }
-              o.lazy
             end
 
             option :distributed_tracing, default: true
@@ -35,12 +32,10 @@ module Datadog
                   Ext::DEFAULT_PEER_SERVICE_NAME
                 )
               end
-              o.lazy
             end
 
             option :error_status_codes do |o|
               o.default { env_to_list(Ext::ENV_ERROR_STATUS_CODES, 400...600, comma_separated_only: false) }
-              o.lazy
             end
 
             option :split_by_domain, default: false

--- a/lib/datadog/tracing/contrib/httprb/configuration/settings.rb
+++ b/lib/datadog/tracing/contrib/httprb/configuration/settings.rb
@@ -13,17 +13,14 @@ module Datadog
           class Settings < Contrib::Configuration::Settings
             option :enabled do |o|
               o.default { env_to_bool(Ext::ENV_ENABLED, true) }
-              o.lazy
             end
 
             option :analytics_enabled do |o|
               o.default { env_to_bool(Ext::ENV_ANALYTICS_ENABLED, false) }
-              o.lazy
             end
 
             option :analytics_sample_rate do |o|
               o.default { env_to_float(Ext::ENV_ANALYTICS_SAMPLE_RATE, 1.0) }
-              o.lazy
             end
 
             option :distributed_tracing, default: true
@@ -35,12 +32,10 @@ module Datadog
                   Ext::DEFAULT_PEER_SERVICE_NAME
                 )
               end
-              o.lazy
             end
 
             option :error_status_codes do |o|
               o.default { env_to_list(Ext::ENV_ERROR_STATUS_CODES, 400...600, comma_separated_only: false) }
-              o.lazy
             end
 
             option :split_by_domain, default: false

--- a/lib/datadog/tracing/contrib/kafka/configuration/settings.rb
+++ b/lib/datadog/tracing/contrib/kafka/configuration/settings.rb
@@ -13,17 +13,14 @@ module Datadog
           class Settings < Contrib::Configuration::Settings
             option :enabled do |o|
               o.default { env_to_bool(Ext::ENV_ENABLED, true) }
-              o.lazy
             end
 
             option :analytics_enabled do |o|
               o.default { env_to_bool(Ext::ENV_ANALYTICS_ENABLED, false) }
-              o.lazy
             end
 
             option :analytics_sample_rate do |o|
               o.default { env_to_float(Ext::ENV_ANALYTICS_SAMPLE_RATE, 1.0) }
-              o.lazy
             end
 
             option :service_name

--- a/lib/datadog/tracing/contrib/lograge/configuration/settings.rb
+++ b/lib/datadog/tracing/contrib/lograge/configuration/settings.rb
@@ -13,7 +13,6 @@ module Datadog
           class Settings < Contrib::Configuration::Settings
             option :enabled do |o|
               o.default { env_to_bool(Ext::ENV_ENABLED, true) }
-              o.lazy
             end
           end
         end

--- a/lib/datadog/tracing/contrib/mongodb/configuration/settings.rb
+++ b/lib/datadog/tracing/contrib/mongodb/configuration/settings.rb
@@ -15,17 +15,14 @@ module Datadog
 
             option :enabled do |o|
               o.default { env_to_bool(Ext::ENV_ENABLED, true) }
-              o.lazy
             end
 
             option :analytics_enabled do |o|
               o.default { env_to_bool(Ext::ENV_ANALYTICS_ENABLED, false) }
-              o.lazy
             end
 
             option :analytics_sample_rate do |o|
               o.default { env_to_float(Ext::ENV_ANALYTICS_SAMPLE_RATE, 1.0) }
-              o.lazy
             end
 
             option :quantize, default: DEFAULT_QUANTIZE
@@ -37,7 +34,6 @@ module Datadog
                   Ext::DEFAULT_PEER_SERVICE_NAME
                 )
               end
-              o.lazy
             end
           end
         end

--- a/lib/datadog/tracing/contrib/mysql2/configuration/settings.rb
+++ b/lib/datadog/tracing/contrib/mysql2/configuration/settings.rb
@@ -15,17 +15,14 @@ module Datadog
           class Settings < Contrib::Configuration::Settings
             option :enabled do |o|
               o.default { env_to_bool(Ext::ENV_ENABLED, true) }
-              o.lazy
             end
 
             option :analytics_enabled do |o|
               o.default { env_to_bool(Ext::ENV_ANALYTICS_ENABLED, false) }
-              o.lazy
             end
 
             option :analytics_sample_rate do |o|
               o.default { env_to_float(Ext::ENV_ANALYTICS_SAMPLE_RATE, 1.0) }
-              o.lazy
             end
 
             option :service_name do |o|
@@ -35,7 +32,6 @@ module Datadog
                   Ext::DEFAULT_PEER_SERVICE_NAME
                 )
               end
-              o.lazy
             end
 
             option :comment_propagation do |o|
@@ -45,7 +41,6 @@ module Datadog
                   Contrib::Propagation::SqlComment::Ext::DISABLED
                 )
               end
-              o.lazy
             end
           end
         end

--- a/lib/datadog/tracing/contrib/pg/configuration/settings.rb
+++ b/lib/datadog/tracing/contrib/pg/configuration/settings.rb
@@ -15,17 +15,14 @@ module Datadog
           class Settings < Contrib::Configuration::Settings
             option :enabled do |o|
               o.default { env_to_bool(Ext::ENV_ENABLED, true) }
-              o.lazy
             end
 
             option :analytics_enabled do |o|
               o.default { env_to_bool(Ext::ENV_ANALYTICS_ENABLED, false) }
-              o.lazy
             end
 
             option :analytics_sample_rate do |o|
               o.default { env_to_float(Ext::ENV_ANALYTICS_SAMPLE_RATE, 1.0) }
-              o.lazy
             end
 
             option :service_name do |o|
@@ -35,7 +32,6 @@ module Datadog
                   Ext::DEFAULT_PEER_SERVICE_NAME
                 )
               end
-              o.lazy
             end
 
             option :comment_propagation do |o|
@@ -45,7 +41,6 @@ module Datadog
                   Contrib::Propagation::SqlComment::Ext::DISABLED
                 )
               end
-              o.lazy
             end
           end
         end

--- a/lib/datadog/tracing/contrib/presto/configuration/settings.rb
+++ b/lib/datadog/tracing/contrib/presto/configuration/settings.rb
@@ -13,17 +13,14 @@ module Datadog
           class Settings < Contrib::Configuration::Settings
             option :enabled do |o|
               o.default { env_to_bool(Ext::ENV_ENABLED, true) }
-              o.lazy
             end
 
             option :analytics_enabled do |o|
               o.default { env_to_bool(Ext::ENV_ANALYTICS_ENABLED, false) }
-              o.lazy
             end
 
             option :analytics_sample_rate do |o|
               o.default { env_to_float(Ext::ENV_ANALYTICS_SAMPLE_RATE, 1.0) }
-              o.lazy
             end
 
             option :service_name do |o|
@@ -33,7 +30,6 @@ module Datadog
                   Ext::DEFAULT_PEER_SERVICE_NAME
                 )
               end
-              o.lazy
             end
           end
         end

--- a/lib/datadog/tracing/contrib/qless/configuration/settings.rb
+++ b/lib/datadog/tracing/contrib/qless/configuration/settings.rb
@@ -13,22 +13,18 @@ module Datadog
           class Settings < Contrib::Configuration::Settings
             option :analytics_enabled do |o|
               o.default { env_to_bool(Ext::ENV_ANALYTICS_ENABLED, false) }
-              o.lazy
             end
 
             option :analytics_sample_rate do |o|
               o.default { env_to_float(Ext::ENV_ANALYTICS_SAMPLE_RATE, 1.0) }
-              o.lazy
             end
 
             option :tag_job_data do |o|
               o.default { env_to_bool(Ext::ENV_TAG_JOB_DATA, false) }
-              o.lazy
             end
 
             option :tag_job_tags do |o|
               o.default { env_to_bool(Ext::ENV_TAG_JOB_TAGS, false) }
-              o.lazy
             end
 
             option :service_name

--- a/lib/datadog/tracing/contrib/que/configuration/settings.rb
+++ b/lib/datadog/tracing/contrib/que/configuration/settings.rb
@@ -33,7 +33,7 @@ module Datadog
             option :tag_data do |o|
               o.default { env_to_bool(Ext::ENV_TAG_DATA_ENABLED, false) }
             end
-            option :error_handler, default: Tracing::SpanOperation::Events::DEFAULT_ON_ERROR
+            option :error_handler, default_proc: Tracing::SpanOperation::Events::DEFAULT_ON_ERROR
           end
         end
       end

--- a/lib/datadog/tracing/contrib/que/configuration/settings.rb
+++ b/lib/datadog/tracing/contrib/que/configuration/settings.rb
@@ -16,27 +16,22 @@ module Datadog
 
             option :enabled do |o|
               o.default { env_to_bool(Ext::ENV_ENABLED, true) }
-              o.lazy
             end
 
             option :analytics_enabled do |o|
               o.default { env_to_bool(Ext::ENV_ANALYTICS_ENABLED, false) }
-              o.lazy
             end
 
             option :analytics_sample_rate do |o|
               o.default { env_to_float(Ext::ENV_ANALYTICS_SAMPLE_RATE, 1.0) }
-              o.lazy
             end
 
             option :tag_args do |o|
               o.default { env_to_bool(Ext::ENV_TAG_ARGS_ENABLED, false) }
-              o.lazy
             end
 
             option :tag_data do |o|
               o.default { env_to_bool(Ext::ENV_TAG_DATA_ENABLED, false) }
-              o.lazy
             end
             option :error_handler, default: Tracing::SpanOperation::Events::DEFAULT_ON_ERROR
           end

--- a/lib/datadog/tracing/contrib/que/configuration/settings.rb
+++ b/lib/datadog/tracing/contrib/que/configuration/settings.rb
@@ -33,7 +33,7 @@ module Datadog
             option :tag_data do |o|
               o.default { env_to_bool(Ext::ENV_TAG_DATA_ENABLED, false) }
             end
-            option :error_handler, default_proc: Tracing::SpanOperation::Events::DEFAULT_ON_ERROR
+            option :error_handler, experimental_default_proc: Tracing::SpanOperation::Events::DEFAULT_ON_ERROR
           end
         end
       end

--- a/lib/datadog/tracing/contrib/racecar/configuration/settings.rb
+++ b/lib/datadog/tracing/contrib/racecar/configuration/settings.rb
@@ -13,17 +13,14 @@ module Datadog
           class Settings < Contrib::Configuration::Settings
             option :enabled do |o|
               o.default { env_to_bool(Ext::ENV_ENABLED, true) }
-              o.lazy
             end
 
             option :analytics_enabled do |o|
               o.default { env_to_bool(Ext::ENV_ANALYTICS_ENABLED, false) }
-              o.lazy
             end
 
             option :analytics_sample_rate do |o|
               o.default { env_to_float(Ext::ENV_ANALYTICS_SAMPLE_RATE, 1.0) }
-              o.lazy
             end
 
             option :service_name do |o|
@@ -33,7 +30,6 @@ module Datadog
                   Ext::DEFAULT_PEER_SERVICE_NAME
                 )
               end
-              o.lazy
             end
           end
         end

--- a/lib/datadog/tracing/contrib/rack/configuration/settings.rb
+++ b/lib/datadog/tracing/contrib/rack/configuration/settings.rb
@@ -18,17 +18,14 @@ module Datadog
 
             option :enabled do |o|
               o.default { env_to_bool(Ext::ENV_ENABLED, true) }
-              o.lazy
             end
 
             option :analytics_enabled do |o|
               o.default { env_to_bool(Ext::ENV_ANALYTICS_ENABLED, nil) }
-              o.lazy
             end
 
             option :analytics_sample_rate do |o|
               o.default { env_to_float(Ext::ENV_ANALYTICS_SAMPLE_RATE, 1.0) }
-              o.lazy
             end
 
             option :application

--- a/lib/datadog/tracing/contrib/rails/configuration/settings.rb
+++ b/lib/datadog/tracing/contrib/rails/configuration/settings.rb
@@ -25,12 +25,11 @@ module Datadog
 
             option :enabled do |o|
               o.default { env_to_bool(Ext::ENV_ENABLED, true) }
-              o.lazy
             end
 
             option :analytics_enabled do |o|
               o.default { env_to_bool(Ext::ENV_ANALYTICS_ENABLED, nil) }
-              o.lazy
+
               o.on_set do |value|
                 # Update ActionPack analytics too
                 Datadog.configuration.tracing[:action_pack][:analytics_enabled] = value
@@ -39,7 +38,6 @@ module Datadog
 
             option :analytics_sample_rate do |o|
               o.default { env_to_float(Ext::ENV_ANALYTICS_SAMPLE_RATE, 1.0) }
-              o.lazy
               o.on_set do |value|
                 # Update ActionPack analytics too
                 Datadog.configuration.tracing[:action_pack][:analytics_sample_rate] = value

--- a/lib/datadog/tracing/contrib/rake/configuration/settings.rb
+++ b/lib/datadog/tracing/contrib/rake/configuration/settings.rb
@@ -15,17 +15,14 @@ module Datadog
           class Settings < Contrib::Configuration::Settings
             option :enabled do |o|
               o.default { env_to_bool(Ext::ENV_ENABLED, true) }
-              o.lazy
             end
 
             option :analytics_enabled do |o|
               o.default { env_to_bool(Ext::ENV_ANALYTICS_ENABLED, false) }
-              o.lazy
             end
 
             option :analytics_sample_rate do |o|
               o.default { env_to_float(Ext::ENV_ANALYTICS_SAMPLE_RATE, 1.0) }
-              o.lazy
             end
 
             option :quantize, default: {}
@@ -37,7 +34,6 @@ module Datadog
             # causing undue memory accumulation, as the trace for such tasks is never flushed.
             option :tasks do |o|
               o.default { [] }
-              o.lazy
               o.on_set do |value|
                 # DEV: It should be possible to modify the value after it's set. E.g. for normalization.
                 options[:tasks].instance_variable_set(:@value, value.map(&:to_s).to_set)

--- a/lib/datadog/tracing/contrib/redis/configuration/settings.rb
+++ b/lib/datadog/tracing/contrib/redis/configuration/settings.rb
@@ -13,22 +13,18 @@ module Datadog
           class Settings < Contrib::Configuration::Settings
             option :enabled do |o|
               o.default { env_to_bool(Ext::ENV_ENABLED, true) }
-              o.lazy
             end
 
             option :analytics_enabled do |o|
               o.default { env_to_bool(Ext::ENV_ANALYTICS_ENABLED, false) }
-              o.lazy
             end
 
             option :analytics_sample_rate do |o|
               o.default { env_to_float(Ext::ENV_ANALYTICS_SAMPLE_RATE, 1.0) }
-              o.lazy
             end
 
             option :command_args do |o|
               o.default { env_to_bool(Ext::ENV_COMMAND_ARGS, true) }
-              o.lazy
             end
 
             option :service_name do |o|
@@ -38,7 +34,6 @@ module Datadog
                   Ext::DEFAULT_PEER_SERVICE_NAME
                 )
               end
-              o.lazy
             end
           end
         end

--- a/lib/datadog/tracing/contrib/resque/configuration/settings.rb
+++ b/lib/datadog/tracing/contrib/resque/configuration/settings.rb
@@ -25,7 +25,7 @@ module Datadog
             end
 
             option :service_name
-            option :error_handler, default_proc: Tracing::SpanOperation::Events::DEFAULT_ON_ERROR
+            option :error_handler, experimental_default_proc: Tracing::SpanOperation::Events::DEFAULT_ON_ERROR
           end
         end
       end

--- a/lib/datadog/tracing/contrib/resque/configuration/settings.rb
+++ b/lib/datadog/tracing/contrib/resque/configuration/settings.rb
@@ -25,7 +25,7 @@ module Datadog
             end
 
             option :service_name
-            option :error_handler, default: Tracing::SpanOperation::Events::DEFAULT_ON_ERROR
+            option :error_handler, default_proc: Tracing::SpanOperation::Events::DEFAULT_ON_ERROR
           end
         end
       end

--- a/lib/datadog/tracing/contrib/resque/configuration/settings.rb
+++ b/lib/datadog/tracing/contrib/resque/configuration/settings.rb
@@ -14,17 +14,14 @@ module Datadog
           class Settings < Contrib::Configuration::Settings
             option :enabled do |o|
               o.default { env_to_bool(Ext::ENV_ENABLED, true) }
-              o.lazy
             end
 
             option :analytics_enabled do |o|
               o.default { env_to_bool(Ext::ENV_ANALYTICS_ENABLED, false) }
-              o.lazy
             end
 
             option :analytics_sample_rate do |o|
               o.default { env_to_float(Ext::ENV_ANALYTICS_SAMPLE_RATE, 1.0) }
-              o.lazy
             end
 
             option :service_name

--- a/lib/datadog/tracing/contrib/rest_client/configuration/settings.rb
+++ b/lib/datadog/tracing/contrib/rest_client/configuration/settings.rb
@@ -13,17 +13,14 @@ module Datadog
           class Settings < Contrib::Configuration::Settings
             option :enabled do |o|
               o.default { env_to_bool(Ext::ENV_ENABLED, true) }
-              o.lazy
             end
 
             option :analytics_enabled do |o|
               o.default { env_to_bool(Ext::ENV_ANALYTICS_ENABLED, false) }
-              o.lazy
             end
 
             option :analytics_sample_rate do |o|
               o.default { env_to_float(Ext::ENV_ANALYTICS_SAMPLE_RATE, 1.0) }
-              o.lazy
             end
 
             option :distributed_tracing, default: true
@@ -35,7 +32,6 @@ module Datadog
                   Ext::DEFAULT_PEER_SERVICE_NAME
                 )
               end
-              o.lazy
             end
 
             option :split_by_domain, default: false

--- a/lib/datadog/tracing/contrib/roda/configuration/settings.rb
+++ b/lib/datadog/tracing/contrib/roda/configuration/settings.rb
@@ -12,17 +12,14 @@ module Datadog
           class Settings < Contrib::Configuration::Settings
             option :enabled do |o|
               o.default { env_to_bool(Ext::ENV_ENABLED, true) }
-              o.lazy
             end
 
             option :analytics_enabled do |o|
               o.default { env_to_bool(Ext::ENV_ANALYTICS_ENABLED, false) }
-              o.lazy
             end
 
             option :analytics_sample_rate do |o|
               o.default { env_to_float(Ext::ENV_ANALYTICS_SAMPLE_RATE, 1.0) }
-              o.lazy
             end
 
             option :service_name

--- a/lib/datadog/tracing/contrib/semantic_logger/configuration/settings.rb
+++ b/lib/datadog/tracing/contrib/semantic_logger/configuration/settings.rb
@@ -13,7 +13,6 @@ module Datadog
           class Settings < Contrib::Configuration::Settings
             option :enabled do |o|
               o.default { env_to_bool(Ext::ENV_ENABLED, true) }
-              o.lazy
             end
           end
         end

--- a/lib/datadog/tracing/contrib/sequel/configuration/settings.rb
+++ b/lib/datadog/tracing/contrib/sequel/configuration/settings.rb
@@ -13,17 +13,14 @@ module Datadog
           class Settings < Contrib::Configuration::Settings
             option :enabled do |o|
               o.default { env_to_bool(Ext::ENV_ENABLED, true) }
-              o.lazy
             end
 
             option :analytics_enabled do |o|
               o.default { env_to_bool(Ext::ENV_ANALYTICS_ENABLED, false) }
-              o.lazy
             end
 
             option :analytics_sample_rate do |o|
               o.default { env_to_float(Ext::ENV_ANALYTICS_SAMPLE_RATE, 1.0) }
-              o.lazy
             end
           end
         end

--- a/lib/datadog/tracing/contrib/shoryuken/configuration/settings.rb
+++ b/lib/datadog/tracing/contrib/shoryuken/configuration/settings.rb
@@ -25,7 +25,7 @@ module Datadog
             end
 
             option :service_name
-            option :error_handler, default_proc: Tracing::SpanOperation::Events::DEFAULT_ON_ERROR
+            option :error_handler, experimental_default_proc: Tracing::SpanOperation::Events::DEFAULT_ON_ERROR
             option :tag_body, default: false
           end
         end

--- a/lib/datadog/tracing/contrib/shoryuken/configuration/settings.rb
+++ b/lib/datadog/tracing/contrib/shoryuken/configuration/settings.rb
@@ -14,17 +14,14 @@ module Datadog
           class Settings < Contrib::Configuration::Settings
             option :enabled do |o|
               o.default { env_to_bool(Ext::ENV_ENABLED, true) }
-              o.lazy
             end
 
             option :analytics_enabled do |o|
               o.default { env_to_bool(Ext::ENV_ANALYTICS_ENABLED, false) }
-              o.lazy
             end
 
             option :analytics_sample_rate do |o|
               o.default { env_to_float(Ext::ENV_ANALYTICS_SAMPLE_RATE, 1.0) }
-              o.lazy
             end
 
             option :service_name

--- a/lib/datadog/tracing/contrib/shoryuken/configuration/settings.rb
+++ b/lib/datadog/tracing/contrib/shoryuken/configuration/settings.rb
@@ -25,7 +25,7 @@ module Datadog
             end
 
             option :service_name
-            option :error_handler, default: Tracing::SpanOperation::Events::DEFAULT_ON_ERROR
+            option :error_handler, default_proc: Tracing::SpanOperation::Events::DEFAULT_ON_ERROR
             option :tag_body, default: false
           end
         end

--- a/lib/datadog/tracing/contrib/sidekiq/configuration/settings.rb
+++ b/lib/datadog/tracing/contrib/sidekiq/configuration/settings.rb
@@ -14,22 +14,18 @@ module Datadog
           class Settings < Contrib::Configuration::Settings
             option :enabled do |o|
               o.default { env_to_bool(Ext::ENV_ENABLED, true) }
-              o.lazy
             end
 
             option :analytics_enabled do |o|
               o.default { env_to_bool(Ext::ENV_ANALYTICS_ENABLED, false) }
-              o.lazy
             end
 
             option :analytics_sample_rate do |o|
               o.default { env_to_float(Ext::ENV_ANALYTICS_SAMPLE_RATE, 1.0) }
-              o.lazy
             end
 
             option :tag_args do |o|
               o.default { env_to_bool(Ext::ENV_TAG_JOB_ARGS, false) }
-              o.lazy
             end
 
             option :service_name

--- a/lib/datadog/tracing/contrib/sidekiq/configuration/settings.rb
+++ b/lib/datadog/tracing/contrib/sidekiq/configuration/settings.rb
@@ -30,7 +30,7 @@ module Datadog
 
             option :service_name
             option :client_service_name
-            option :error_handler, default_proc: Tracing::SpanOperation::Events::DEFAULT_ON_ERROR
+            option :error_handler, experimental_default_proc: Tracing::SpanOperation::Events::DEFAULT_ON_ERROR
             option :quantize, default: {}
             option :distributed_tracing, default: false
           end

--- a/lib/datadog/tracing/contrib/sidekiq/configuration/settings.rb
+++ b/lib/datadog/tracing/contrib/sidekiq/configuration/settings.rb
@@ -30,7 +30,7 @@ module Datadog
 
             option :service_name
             option :client_service_name
-            option :error_handler, default: Tracing::SpanOperation::Events::DEFAULT_ON_ERROR
+            option :error_handler, default_proc: Tracing::SpanOperation::Events::DEFAULT_ON_ERROR
             option :quantize, default: {}
             option :distributed_tracing, default: false
           end

--- a/lib/datadog/tracing/contrib/sinatra/configuration/settings.rb
+++ b/lib/datadog/tracing/contrib/sinatra/configuration/settings.rb
@@ -15,17 +15,14 @@ module Datadog
 
             option :enabled do |o|
               o.default { env_to_bool(Ext::ENV_ENABLED, true) }
-              o.lazy
             end
 
             option :analytics_enabled do |o|
               o.default { env_to_bool(Ext::ENV_ANALYTICS_ENABLED, nil) }
-              o.lazy
             end
 
             option :analytics_sample_rate do |o|
               o.default { env_to_float(Ext::ENV_ANALYTICS_SAMPLE_RATE, 1.0) }
-              o.lazy
             end
 
             option :distributed_tracing, default: true

--- a/lib/datadog/tracing/contrib/sneakers/configuration/settings.rb
+++ b/lib/datadog/tracing/contrib/sneakers/configuration/settings.rb
@@ -12,17 +12,14 @@ module Datadog
           class Settings < Contrib::Configuration::Settings
             option :enabled do |o|
               o.default { env_to_bool(Ext::ENV_ENABLED, true) }
-              o.lazy
             end
 
             option :analytics_enabled do |o|
               o.default { env_to_bool(Ext::ENV_ANALYTICS_ENABLED, false) }
-              o.lazy
             end
 
             option :analytics_sample_rate do |o|
               o.default { env_to_float(Ext::ENV_ANALYTICS_SAMPLE_RATE, 1.0) }
-              o.lazy
             end
 
             option :service_name

--- a/lib/datadog/tracing/contrib/sneakers/configuration/settings.rb
+++ b/lib/datadog/tracing/contrib/sneakers/configuration/settings.rb
@@ -23,7 +23,7 @@ module Datadog
             end
 
             option :service_name
-            option :error_handler, default: Tracing::SpanOperation::Events::DEFAULT_ON_ERROR
+            option :error_handler, default_proc: Tracing::SpanOperation::Events::DEFAULT_ON_ERROR
             option :tag_body, default: false
           end
         end

--- a/lib/datadog/tracing/contrib/sneakers/configuration/settings.rb
+++ b/lib/datadog/tracing/contrib/sneakers/configuration/settings.rb
@@ -23,7 +23,7 @@ module Datadog
             end
 
             option :service_name
-            option :error_handler, default_proc: Tracing::SpanOperation::Events::DEFAULT_ON_ERROR
+            option :error_handler, experimental_default_proc: Tracing::SpanOperation::Events::DEFAULT_ON_ERROR
             option :tag_body, default: false
           end
         end

--- a/lib/datadog/tracing/contrib/stripe/configuration/settings.rb
+++ b/lib/datadog/tracing/contrib/stripe/configuration/settings.rb
@@ -13,17 +13,14 @@ module Datadog
           class Settings < Contrib::Configuration::Settings
             option :enabled do |o|
               o.default { env_to_bool(Ext::ENV_ENABLED, true) }
-              o.lazy
             end
 
             option :analytics_enabled do |o|
               o.default { env_to_bool(Ext::ENV_ANALYTICS_ENABLED, false) }
-              o.lazy
             end
 
             option :analytics_sample_rate do |o|
               o.default { env_to_float(Ext::ENV_ANALYTICS_SAMPLE_RATE, 1.0) }
-              o.lazy
             end
           end
         end

--- a/lib/datadog/tracing/contrib/sucker_punch/configuration/settings.rb
+++ b/lib/datadog/tracing/contrib/sucker_punch/configuration/settings.rb
@@ -13,17 +13,14 @@ module Datadog
           class Settings < Contrib::Configuration::Settings
             option :enabled do |o|
               o.default { env_to_bool(Ext::ENV_ENABLED, true) }
-              o.lazy
             end
 
             option :analytics_enabled do |o|
               o.default { env_to_bool(Ext::ENV_ANALYTICS_ENABLED, false) }
-              o.lazy
             end
 
             option :analytics_sample_rate do |o|
               o.default { env_to_float(Ext::ENV_ANALYTICS_SAMPLE_RATE, 1.0) }
-              o.lazy
             end
 
             option :service_name

--- a/sig/datadog/core/configuration/option_definition.rbs
+++ b/sig/datadog/core/configuration/option_definition.rbs
@@ -10,8 +10,6 @@ module Datadog
 
         attr_reader depends_on: untyped
 
-        attr_reader lazy: untyped
-
         attr_reader name: untyped
 
         attr_reader on_set: untyped
@@ -37,8 +35,6 @@ module Datadog
 
           def helper: (untyped name, *untyped _args) { () -> untyped } -> untyped
 
-          def lazy: (?bool value) -> untyped
-
           def on_set: () { () -> untyped } -> untyped
 
           def resetter: () { () -> untyped } -> untyped
@@ -49,7 +45,7 @@ module Datadog
 
           def to_definition: () -> untyped
 
-          def meta: () -> { default: untyped, delegate_to: untyped, depends_on: untyped, lazy: untyped, on_set: untyped, resetter: untyped, setter: untyped }
+          def meta: () -> { default: untyped, delegate_to: untyped, depends_on: untyped, on_set: untyped, resetter: untyped, setter: untyped }
         end
       end
     end

--- a/sig/datadog/core/configuration/option_definition.rbs
+++ b/sig/datadog/core/configuration/option_definition.rbs
@@ -6,6 +6,8 @@ module Datadog
 
         attr_reader default: untyped
 
+        attr_reader experimental_default_proc: untyped
+
         attr_reader delegate_to: untyped
 
         attr_reader depends_on: untyped
@@ -31,7 +33,7 @@ module Datadog
 
           def default: (?untyped? value) { () -> untyped } -> untyped
 
-          def default_proc: () { () -> untyped } -> untyped
+          def experimental_default_proc: () { () -> untyped } -> untyped
 
           def delegate_to: () { () -> untyped } -> untyped
 

--- a/sig/datadog/core/configuration/option_definition.rbs
+++ b/sig/datadog/core/configuration/option_definition.rbs
@@ -31,6 +31,8 @@ module Datadog
 
           def default: (?untyped? value) { () -> untyped } -> untyped
 
+          def default_proc: () { () -> untyped } -> untyped
+
           def delegate_to: () { () -> untyped } -> untyped
 
           def helper: (untyped name, *untyped _args) { () -> untyped } -> untyped

--- a/spec/datadog/core/configuration/base_spec.rb
+++ b/spec/datadog/core/configuration/base_spec.rb
@@ -31,7 +31,6 @@ RSpec.describe Datadog::Core::Configuration::Base do
 
               is_expected.to have_attributes(
                 default: kind_of(Proc),
-                lazy: true,
                 resetter: kind_of(Proc)
               )
             end

--- a/spec/datadog/core/configuration/option_definition_spec.rb
+++ b/spec/datadog/core/configuration/option_definition_spec.rb
@@ -54,21 +54,6 @@ RSpec.describe Datadog::Core::Configuration::OptionDefinition do
     end
   end
 
-  describe '#lazy' do
-    subject(:lazy) { definition.lazy }
-
-    context 'when not initialized with a value' do
-      it { is_expected.to be false }
-    end
-
-    context 'when initialized with a value' do
-      let(:meta) { { lazy: lazy_value } }
-      let(:lazy_value) { double('lazy') }
-
-      it { is_expected.to be lazy_value }
-    end
-  end
-
   describe '#name' do
     subject(:result) { definition.name }
 
@@ -193,7 +178,6 @@ RSpec.describe Datadog::Core::Configuration::OptionDefinition::Builder do
               default: nil,
               delegate_to: nil,
               depends_on: [],
-              lazy: false,
               name: name,
               on_set: nil,
               resetter: nil,
@@ -303,22 +287,6 @@ RSpec.describe Datadog::Core::Configuration::OptionDefinition::Builder do
     end
   end
 
-  describe '#lazy' do
-    context 'given no arguments' do
-      subject(:lazy) { builder.lazy }
-
-      it { is_expected.to be true }
-    end
-
-    context 'given a value' do
-      subject(:lazy) { builder.lazy(value) }
-
-      let(:value) { double('value') }
-
-      it { is_expected.to be value }
-    end
-  end
-
   describe '#on_set' do
     subject(:on_set) { builder.on_set(&block) }
 
@@ -394,16 +362,6 @@ RSpec.describe Datadog::Core::Configuration::OptionDefinition::Builder do
       end
     end
 
-    context 'given :lazy' do
-      let(:options) { { lazy: value } }
-      let(:value) { double('value') }
-
-      it do
-        expect(builder).to receive(:lazy).with(value)
-        apply_options!
-      end
-    end
-
     context 'given :on_set' do
       let(:options) { { on_set: value } }
       let(:value) { proc {} }
@@ -468,7 +426,6 @@ RSpec.describe Datadog::Core::Configuration::OptionDefinition::Builder do
         :default,
         :delegate_to,
         :depends_on,
-        :lazy,
         :on_set,
         :resetter,
         :setter,

--- a/spec/datadog/core/configuration/option_definition_spec.rb
+++ b/spec/datadog/core/configuration/option_definition_spec.rb
@@ -315,6 +315,13 @@ RSpec.describe Datadog::Core::Configuration::OptionDefinition::Builder do
     end
   end
 
+  describe '#lazy' do
+    it 'logs deprecation warning' do
+      expect(Datadog::Core).to receive(:log_deprecation)
+      builder.lazy
+    end
+  end
+
   describe '#on_set' do
     subject(:on_set) { builder.on_set(&block) }
 

--- a/spec/datadog/core/configuration/option_definition_spec.rb
+++ b/spec/datadog/core/configuration/option_definition_spec.rb
@@ -176,6 +176,7 @@ RSpec.describe Datadog::Core::Configuration::OptionDefinition::Builder do
           it 'generates an OptionDefinition with defaults' do
             is_expected.to have_attributes(
               default: nil,
+              default_proc: nil,
               delegate_to: nil,
               depends_on: [],
               name: name,
@@ -206,6 +207,23 @@ RSpec.describe Datadog::Core::Configuration::OptionDefinition::Builder do
           it 'yields an OptionDefinition with the block\'s value' do
             is_expected.to have_attributes(default: false)
           end
+        end
+      end
+    end
+
+    context 'validate_options!' do
+      context 'when default and default_proc is provided' do
+        let(:initialize_block) do
+          proc do |o|
+            o.default false
+            o.default_proc { true }
+          end
+        end
+
+        it do
+          expect do
+            is_expected
+          end.to raise_error(described_class::InvalidOptionError)
         end
       end
     end
@@ -247,6 +265,16 @@ RSpec.describe Datadog::Core::Configuration::OptionDefinition::Builder do
 
     context 'given a value and block' do
       let(:value) { true }
+      let(:block) { proc { false } }
+
+      it { is_expected.to be block }
+    end
+  end
+
+  describe '#default_proc' do
+    subject(:default_proc) { builder.default_proc(&block) }
+
+    context 'given a block' do
       let(:block) { proc { false } }
 
       it { is_expected.to be block }
@@ -424,6 +452,7 @@ RSpec.describe Datadog::Core::Configuration::OptionDefinition::Builder do
     it 'contains the arguments for OptionDefinition' do
       expect(meta.keys).to include(
         :default,
+        :default_proc,
         :delegate_to,
         :depends_on,
         :on_set,

--- a/spec/datadog/core/configuration/option_definition_spec.rb
+++ b/spec/datadog/core/configuration/option_definition_spec.rb
@@ -176,7 +176,7 @@ RSpec.describe Datadog::Core::Configuration::OptionDefinition::Builder do
           it 'generates an OptionDefinition with defaults' do
             is_expected.to have_attributes(
               default: nil,
-              default_proc: nil,
+              experimental_default_proc: nil,
               delegate_to: nil,
               depends_on: [],
               name: name,
@@ -212,11 +212,11 @@ RSpec.describe Datadog::Core::Configuration::OptionDefinition::Builder do
     end
 
     context 'validate_options!' do
-      context 'when default and default_proc is provided' do
+      context 'when default and experimental_default_proc is provided' do
         let(:initialize_block) do
           proc do |o|
             o.default false
-            o.default_proc { true }
+            o.experimental_default_proc { true }
           end
         end
 
@@ -271,8 +271,8 @@ RSpec.describe Datadog::Core::Configuration::OptionDefinition::Builder do
     end
   end
 
-  describe '#default_proc' do
-    subject(:default_proc) { builder.default_proc(&block) }
+  describe '#experimental_default_proc' do
+    subject(:experimental_default_proc) { builder.experimental_default_proc(&block) }
 
     context 'given a block' do
       let(:block) { proc { false } }
@@ -452,7 +452,7 @@ RSpec.describe Datadog::Core::Configuration::OptionDefinition::Builder do
     it 'contains the arguments for OptionDefinition' do
       expect(meta.keys).to include(
         :default,
-        :default_proc,
+        :experimental_default_proc,
         :delegate_to,
         :depends_on,
         :on_set,

--- a/spec/datadog/core/configuration/option_spec.rb
+++ b/spec/datadog/core/configuration/option_spec.rb
@@ -10,6 +10,7 @@ RSpec.describe Datadog::Core::Configuration::Option do
       Datadog::Core::Configuration::OptionDefinition,
       name: :test_name,
       default: default,
+      default_proc: default_proc,
       delegate_to: delegate,
       on_set: nil,
       resetter: nil,
@@ -17,6 +18,7 @@ RSpec.describe Datadog::Core::Configuration::Option do
     )
   end
   let(:default) { double('default') }
+  let(:default_proc) { nil }
   let(:delegate) { nil }
   let(:setter) { proc { setter_value } }
   let(:setter_value) { double('setter_value') }
@@ -339,6 +341,12 @@ RSpec.describe Datadog::Core::Configuration::Option do
 
     context 'when default is not a block' do
       it { is_expected.to be default }
+    end
+
+    context 'when default_proc is defined' do
+      let(:default_proc) { proc { 'default_proc' } }
+
+      it { is_expected.to be default_proc }
     end
   end
 end

--- a/spec/datadog/core/configuration/option_spec.rb
+++ b/spec/datadog/core/configuration/option_spec.rb
@@ -11,7 +11,6 @@ RSpec.describe Datadog::Core::Configuration::Option do
       name: :test_name,
       default: default,
       delegate_to: delegate,
-      lazy: lazy,
       on_set: nil,
       resetter: nil,
       setter: setter
@@ -19,7 +18,6 @@ RSpec.describe Datadog::Core::Configuration::Option do
   end
   let(:default) { double('default') }
   let(:delegate) { nil }
-  let(:lazy) { false }
   let(:setter) { proc { setter_value } }
   let(:setter_value) { double('setter_value') }
   let(:context) { double('configuration object') }
@@ -238,8 +236,7 @@ RSpec.describe Datadog::Core::Configuration::Option do
 
         context 'and #get is called twice' do
           before do
-            expect(definition).to receive(:default)
-              .once
+            allow(definition).to receive(:default)
               .and_return(default)
           end
 
@@ -326,8 +323,7 @@ RSpec.describe Datadog::Core::Configuration::Option do
 
     let(:default) { double('default') }
 
-    context 'when lazy is true' do
-      let(:lazy) { true }
+    context 'when default is a block' do
       let(:default) { proc {} }
       let(:block_default) { double('block default') }
 
@@ -341,9 +337,7 @@ RSpec.describe Datadog::Core::Configuration::Option do
       it { is_expected.to be block_default }
     end
 
-    context 'when lazy is false' do
-      let(:lazy) { false }
-
+    context 'when default is not a block' do
       it { is_expected.to be default }
     end
   end

--- a/spec/datadog/core/configuration/option_spec.rb
+++ b/spec/datadog/core/configuration/option_spec.rb
@@ -10,7 +10,7 @@ RSpec.describe Datadog::Core::Configuration::Option do
       Datadog::Core::Configuration::OptionDefinition,
       name: :test_name,
       default: default,
-      default_proc: default_proc,
+      experimental_default_proc: experimental_default_proc,
       delegate_to: delegate,
       on_set: nil,
       resetter: nil,
@@ -18,7 +18,7 @@ RSpec.describe Datadog::Core::Configuration::Option do
     )
   end
   let(:default) { double('default') }
-  let(:default_proc) { nil }
+  let(:experimental_default_proc) { nil }
   let(:delegate) { nil }
   let(:setter) { proc { setter_value } }
   let(:setter_value) { double('setter_value') }
@@ -343,10 +343,10 @@ RSpec.describe Datadog::Core::Configuration::Option do
       it { is_expected.to be default }
     end
 
-    context 'when default_proc is defined' do
-      let(:default_proc) { proc { 'default_proc' } }
+    context 'when experimental_default_proc is defined' do
+      let(:experimental_default_proc) { proc { 'experimental_default_proc' } }
 
-      it { is_expected.to be default_proc }
+      it { is_expected.to be experimental_default_proc }
     end
   end
 end


### PR DESCRIPTION
<!--
Check out the
https://github.com/DataDog/dd-trace-rb/blob/master/docs/DevelopmentGuide.md
for guidance on how to set up your development environment,
run the test suite, write new integrations, and more.
-->

**What does this PR do?**
<!-- A brief description of the change being made with this pull request. -->

This PR removes the `lazy` option in favour of checking the content of `default.` 

These changes are part of an internal discussion of the ruby team 😄 

**Motivation**
<!-- What inspired you to submit this pull request? -->

The `lazy` option is superfluous, the check to either evaluate `default` as a block or a static value could be achieved by checking the type of value `default` is. `default.is_a?(Proc)`

There is an edge case: 
The default value is a block.

When we provide a block to `default` and do not specify it as `lazy`, we store the block as the default value. I added a new option, `experimental_default_proc`, to circumvent that edge case. Pushing us to be more explicit about those edge cases makes the code more readable and easier to grok.

Since this new option is experimental and we might not need it in the near future, I gave it a name that it clear to the reader that they should not rely on it and that is subject to change.

I added a deprecation warning to `lazy,` so if anyone is using the core code to build their settings, they can migrate to the new system. 

**Additional Notes**
<!-- Anything else we should know when reviewing? -->

**How to test the change?**
<!--
Describe here how the change can be validated.
You are strongly encouraged to provide automated tests for this PR (unit or integration).
If this change cannot be feasibly tested, please explain why,
unless the change does not modify code (e.g. only modifies docs, comments).
-->

CI 
