### PR TITLE
Add Minitest CI integration

### DIFF
--- a/Appraisals
+++ b/Appraisals
@@ -151,6 +151,7 @@ if ruby_version?('2.1')
     gem 'httpclient'
     gem 'makara', '< 0.5.0' # >= 0.5.0 contain Ruby 2.3+ syntax
     gem 'mongo', '< 2.5'
+    gem 'minitest', '>= 5.0.0'
     gem 'mysql2', '0.3.21'
     gem 'pg', '>= 0.18.4', '< 1.0'
     gem 'rack', '1.4.7'
@@ -338,6 +339,7 @@ elsif ruby_version?('2.2')
     gem 'lograge', '~> 0.11'
     gem 'makara', '< 0.5.0' # >= 0.5.0 contain Ruby 2.3+ syntax
     gem 'mongo', '>= 2.8.0'
+    gem 'minitest', '>= 5.0.0'
     gem 'mysql2', '< 0.5'
     gem 'pg', '>= 0.18.4'
     gem 'presto-client', '>=  0.5.14'
@@ -539,6 +541,7 @@ elsif ruby_version?('2.3')
     gem 'lograge', '~> 0.11'
     gem 'makara'
     gem 'mongo', '>= 2.8.0', '< 2.15.0' # TODO: FIX TEST BREAKAGES ON >= 2.15 https://github.com/DataDog/dd-trace-rb/issues/1596
+    gem 'minitest', '>= 5.0.0'
     gem 'mysql2', '< 0.5'
     gem 'pg', '>= 0.18.4'
     gem 'racecar', '>= 0.3.5'
@@ -674,6 +677,7 @@ elsif ruby_version?('2.4')
     gem 'lograge', '~> 0.11'
     gem 'makara'
     gem 'mongo', '>= 2.8.0', '< 2.15.0' # TODO: FIX TEST BREAKAGES ON >= 2.15 https://github.com/DataDog/dd-trace-rb/issues/1596
+    gem 'minitest', '>= 5.0.0'
     gem 'mysql2', '< 0.5'
     gem 'pg', '>= 0.18.4'
     gem 'racecar', '>= 0.3.5'
@@ -940,6 +944,7 @@ elsif ruby_version?('2.5')
     gem 'lograge', '~> 0.11'
     gem 'i18n', '1.8.7', platform: :jruby # Removal pending: https://github.com/ruby-i18n/i18n/issues/555#issuecomment-772112169
     gem 'makara'
+    gem 'minitest', '>= 5.0.0'
     gem 'mongo', '>= 2.8.0', '< 2.15.0' # TODO: FIX TEST BREAKAGES ON >= 2.15 https://github.com/DataDog/dd-trace-rb/issues/1596
     gem 'mysql2', '< 1', platform: :ruby
     gem 'activerecord-jdbcmysql-adapter', '>= 60.2', platform: :jruby
@@ -1190,6 +1195,7 @@ elsif ruby_version?('2.6')
       gem 'httpclient'
       gem 'lograge', '~> 0.11'
       gem 'makara'
+      gem 'minitest', '>= 5.0.0'
       gem 'mongo', '>= 2.8.0', '< 2.15.0' # TODO: FIX TEST BREAKAGES ON >= 2.15 https://github.com/DataDog/dd-trace-rb/issues/1596
       gem 'mysql2', '< 1', platform: :ruby
       gem 'activerecord-jdbcmysql-adapter', platform: :jruby
@@ -1426,6 +1432,7 @@ elsif ruby_version?('2.7')
       gem 'httpclient'
       gem 'lograge', '~> 0.11'
       gem 'makara'
+      gem 'minitest', '>= 5.0.0'
       gem 'mongo', '>= 2.8.0', '< 2.15.0' # TODO: FIX TEST BREAKAGES ON >= 2.15 https://github.com/DataDog/dd-trace-rb/issues/1596
       gem 'mysql2', '< 1', platform: :ruby
       gem 'pg', '>= 0.18.4', platform: :ruby
@@ -1561,6 +1568,7 @@ elsif ruby_version?('3.0') || ruby_version?('3.1') || ruby_version?('3.2') || ru
     gem 'httpclient'
     gem 'lograge'
     gem 'makara', '>= 0.6.0.pre' # Ruby 3 requires >= 0.6.0, which is currently in pre-release: https://rubygems.org/gems/makara/versions
+    gem 'minitest', '>= 5.0.0'
     gem 'mongo', '>= 2.8.0', '< 2.15.0' # TODO: FIX TEST BREAKAGES ON >= 2.15 https://github.com/DataDog/dd-trace-rb/issues/1596
     gem 'mysql2', '>= 0.5.3', platform: :ruby
     gem 'activerecord-jdbcmysql-adapter', platform: :jruby

--- a/Rakefile
+++ b/Rakefile
@@ -184,7 +184,8 @@ namespace :spec do
   # Datadog CI integrations
   [
     :cucumber,
-    :rspec
+    :rspec,
+    :minitest
   ].each do |contrib|
     RSpec::Core::RakeTask.new(contrib) do |t, args|
       t.pattern = "spec/datadog/ci/contrib/#{contrib}/**/*_spec.rb"

--- a/docs/GettingStarted.md
+++ b/docs/GettingStarted.md
@@ -60,6 +60,7 @@ To contribute, check out the [contribution guidelines][contribution docs] and [d
      - [httpclient](#httpclient)
      - [httpx](#httpx)
      - [Kafka](#kafka)
+     - [Minitest](#minitest)
      - [MongoDB](#mongodb)
      - [MySQL2](#mysql2)
      - [Net/HTTP](#nethttp)
@@ -1284,6 +1285,30 @@ Datadog.configure do |c|
   c.tracing.instrument :kafka
 end
 ```
+
+### Minitest
+
+The Minitest integration will trace all executions of tests when using `minitest` test framework.
+
+To activate your integration, use the `Datadog.configure` method:
+
+```ruby
+require 'minitest'
+require 'ddtrace'
+
+# Configure default Minitest integration
+Datadog.configure do |c|
+  c.ci.instrument :minitest, **options
+end
+```
+
+`options` are the following keyword arguments:
+
+| Key | Description | Default |
+| --- | ----------- | ------- |
+| `enabled` | Defines whether Minitest tests should be traced. Useful for temporarily disabling tracing. `true` or `false` | `true` |
+| `service_name` | Service name used for `minitest` instrumentation. | `'minitest'` |
+| `operation_name` | Operation name used for `minitest` instrumentation. Useful if you want rename automatic trace metrics e.g. `trace.#{operation_name}.errors`. | `'minitest.test'` |
 
 ### MongoDB
 

--- a/lib/datadog/ci.rb
+++ b/lib/datadog/ci.rb
@@ -14,6 +14,7 @@ end
 # Integrations
 require_relative 'ci/contrib/cucumber/integration'
 require_relative 'ci/contrib/rspec/integration'
+require_relative 'ci/contrib/minitest/integration'
 
 # Extensions
 require_relative 'ci/extensions'

--- a/lib/datadog/ci/contrib/minitest/configuration/settings.rb
+++ b/lib/datadog/ci/contrib/minitest/configuration/settings.rb
@@ -1,0 +1,33 @@
+# frozen_string_literal: true
+
+require_relative '../../../../tracing/contrib/configuration/settings'
+require_relative '../ext'
+
+module Datadog
+  module CI
+    module Contrib
+      module Minitest
+        module Configuration
+          # Custom settings for the Minitest integration
+          # TODO: mark as `@public_api` when GA
+          class Settings < Datadog::Tracing::Contrib::Configuration::Settings
+            option :enabled do |o|
+              o.default { env_to_bool(Ext::ENV_ENABLED, true) }
+              o.lazy
+            end
+
+            option :service_name do |o|
+              o.default { Datadog.configuration.service_without_fallback || Ext::SERVICE_NAME }
+              o.lazy
+            end
+
+            option :operation_name do |o|
+              o.default { ENV.key?(Ext::ENV_OPERATION_NAME) ? ENV[Ext::ENV_OPERATION_NAME] : Ext::OPERATION_NAME }
+              o.lazy
+            end
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/datadog/ci/contrib/minitest/ext.rb
+++ b/lib/datadog/ci/contrib/minitest/ext.rb
@@ -1,0 +1,21 @@
+# frozen_string_literal: true
+
+module Datadog
+  module CI
+    module Contrib
+      module Minitest
+        # Minitest integration constants
+        # TODO: mark as `@public_api` when GA, to protect from resource and tag name changes.
+        module Ext
+          APP = 'minitest'
+          ENV_ENABLED = 'DD_TRACE_MINITEST_ENABLED'
+          ENV_OPERATION_NAME = 'DD_TRACE_MINITEST_OPERATION_NAME'
+          FRAMEWORK = 'minitest'
+          OPERATION_NAME = 'minitest.test'
+          SERVICE_NAME = 'minitest'
+          TEST_TYPE = 'test'
+        end
+      end
+    end
+  end
+end

--- a/lib/datadog/ci/contrib/minitest/integration.rb
+++ b/lib/datadog/ci/contrib/minitest/integration.rb
@@ -1,0 +1,49 @@
+# frozen_string_literal: true
+
+require_relative '../../../tracing/contrib/integration'
+
+require_relative 'configuration/settings'
+require_relative 'patcher'
+
+module Datadog
+  module CI
+    module Contrib
+      module Minitest
+        # Description of Minitest integration
+        class Integration
+          include Datadog::Tracing::Contrib::Integration
+
+          MINIMUM_VERSION = Gem::Version.new('5.0.0')
+
+          register_as :minitest, auto_patch: true
+
+          def self.version
+            Gem.loaded_specs['minitest'] \
+              && Gem.loaded_specs['minitest'].version
+          end
+
+          def self.loaded?
+            !defined?(::Minitest).nil?
+          end
+
+          def self.compatible?
+            super && version >= MINIMUM_VERSION
+          end
+
+          # test environments should not auto instrument test libraries
+          def auto_instrument?
+            false
+          end
+
+          def new_configuration
+            Configuration::Settings.new
+          end
+
+          def patcher
+            Patcher
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/datadog/ci/contrib/minitest/patcher.rb
+++ b/lib/datadog/ci/contrib/minitest/patcher.rb
@@ -1,0 +1,27 @@
+# frozen_string_literal: true
+
+require_relative '../../../tracing/contrib/patcher'
+require_relative 'test_helper'
+
+module Datadog
+  module CI
+    module Contrib
+      module Minitest
+        # Patcher enables patching of 'minitest' module.
+        module Patcher
+          include Datadog::Tracing::Contrib::Patcher
+
+          module_function
+
+          def target_version
+            Integration.version
+          end
+
+          def patch
+            ::Minitest::Test.include(TestHelper)
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/datadog/ci/contrib/minitest/test_helper.rb
+++ b/lib/datadog/ci/contrib/minitest/test_helper.rb
@@ -1,0 +1,68 @@
+# frozen_string_literal: true
+
+require_relative 'ext'
+
+module Datadog
+  module CI
+    module Contrib
+      module Minitest
+        # Instrument Minitest::Test
+        module TestHelper
+          def before_setup
+            super
+            return unless configuration[:enabled]
+
+            test_name = "#{class_name}##{name}"
+
+            path, = method(name).source_location
+            test_suite = Pathname.new(path).relative_path_from(Pathname.pwd).to_s
+
+            span = CI::Test.trace(
+              configuration[:operation_name],
+              {
+                span_options: {
+                  resource: test_name,
+                  service: configuration[:service_name],
+                },
+                framework: Ext::FRAMEWORK,
+                framework_version: CI::Contrib::Minitest::Integration.version.to_s,
+                test_name: test_name,
+                test_suite: test_suite,
+                test_type: Ext::TEST_TYPE,
+              },
+            )
+
+            Thread.current[:_datadog_test_span] = span
+          end
+
+          def after_teardown
+            span = Thread.current[:_datadog_test_span]
+            return super unless span
+
+            Thread.current[:_datadog_test_span] = nil
+
+            case result_code
+            when '.'
+              CI::Test.passed!(span)
+            when 'E', 'F'
+              CI::Test.failed!(span, failure)
+            when 'S'
+              CI::Test.skipped!(span)
+              span.set_tag(CI::Ext::Test::TAG_SKIP_REASON, failure.message)
+            end
+
+            span.finish
+
+            super
+          end
+
+          private
+
+          def configuration
+            ::Datadog.configuration.ci[:minitest]
+          end
+        end
+      end
+    end
+  end
+end

--- a/sig/datadog/ci/contrib/minitest/configuration/settings.rbs
+++ b/sig/datadog/ci/contrib/minitest/configuration/settings.rbs
@@ -1,0 +1,12 @@
+module Datadog
+  module CI
+    module Contrib
+      module Minitest
+        module Configuration
+          class Settings < Datadog::Tracing::Contrib::Configuration::Settings
+          end
+        end
+      end
+    end
+  end
+end

--- a/sig/datadog/ci/contrib/minitest/ext.rbs
+++ b/sig/datadog/ci/contrib/minitest/ext.rbs
@@ -1,0 +1,23 @@
+module Datadog
+  module CI
+    module Contrib
+      module Minitest
+        module Ext
+          APP: "minitest"
+
+          ENV_ENABLED: "DD_TRACE_MINITEST_ENABLED"
+
+          ENV_OPERATION_NAME: "DD_TRACE_MINITEST_OPERATION_NAME"
+
+          FRAMEWORK: "minitest"
+
+          OPERATION_NAME: "minitest.test"
+
+          SERVICE_NAME: "minitest"
+
+          TEST_TYPE: "test"
+        end
+      end
+    end
+  end
+end

--- a/sig/datadog/ci/contrib/minitest/integration.rbs
+++ b/sig/datadog/ci/contrib/minitest/integration.rbs
@@ -1,0 +1,24 @@
+module Datadog
+  module CI
+    module Contrib
+      module Minitest
+        class Integration
+          include Datadog::Tracing::Contrib::Integration
+
+          MINIMUM_VERSION: untyped
+
+          def self.version: () -> untyped
+
+          def self.loaded?: () -> untyped
+
+          def self.compatible?: () -> untyped
+          def auto_instrument?: () -> false
+
+          def new_configuration: () -> untyped
+
+          def patcher: () -> untyped
+        end
+      end
+    end
+  end
+end

--- a/sig/datadog/ci/contrib/minitest/patcher.rbs
+++ b/sig/datadog/ci/contrib/minitest/patcher.rbs
@@ -1,0 +1,15 @@
+module Datadog
+  module CI
+    module Contrib
+      module Minitest
+        module Patcher
+          include Datadog::Tracing::Contrib::Patcher
+
+          def self?.target_version: () -> untyped
+
+          def self?.patch: () -> untyped
+        end
+      end
+    end
+  end
+end

--- a/sig/datadog/ci/contrib/minitest/test_helper.rbs
+++ b/sig/datadog/ci/contrib/minitest/test_helper.rbs
@@ -1,0 +1,17 @@
+module Datadog
+  module CI
+    module Contrib
+      module Minitest
+        module TestHelper
+          def before_setup: () -> (nil | untyped)
+
+          def after_teardown: () -> untyped
+
+          private
+
+          def configuration: () -> untyped
+        end
+      end
+    end
+  end
+end

--- a/spec/datadog/ci/contrib/minitest/instrumentation_spec.rb
+++ b/spec/datadog/ci/contrib/minitest/instrumentation_spec.rb
@@ -31,7 +31,9 @@ RSpec.describe 'Minitest hooks' do
     expect(span.resource).to eq('SomeTest#test_foo')
     expect(span.service).to eq('ltest')
     expect(span.get_tag(Datadog::CI::Ext::Test::TAG_NAME)).to eq('SomeTest#test_foo')
-    # expect(span.get_tag(Datadog::CI::Ext::Test::TAG_SUITE)).to eq(spec.file_path)
+    expect(span.get_tag(Datadog::CI::Ext::Test::TAG_SUITE)).to eq(
+      'spec/datadog/ci/contrib/minitest/instrumentation_spec.rb'
+    )
     expect(span.get_tag(Datadog::CI::Ext::Test::TAG_SPAN_KIND)).to eq(Datadog::CI::Ext::AppTypes::TYPE_TEST)
     expect(span.get_tag(Datadog::CI::Ext::Test::TAG_TYPE)).to eq(Datadog::CI::Contrib::Minitest::Ext::TEST_TYPE)
     expect(span.get_tag(Datadog::CI::Ext::Test::TAG_FRAMEWORK)).to eq(Datadog::CI::Contrib::Minitest::Ext::FRAMEWORK)
@@ -299,21 +301,5 @@ RSpec.describe 'Minitest hooks' do
 
       expect_skip
     end
-  end
-
-  it 'uses relative path for test suite' do
-    klass = Class.new(Minitest::Test) do
-      def self.name
-        'SomeTest'
-      end
-
-      def test_foo; end
-    end
-
-    klass.new(:test_foo).run
-
-    expect(
-      span.get_tag(Datadog::CI::Ext::Test::TAG_SUITE)
-    ).to eq('spec/datadog/ci/contrib/minitest/instrumentation_spec.rb')
   end
 end

--- a/spec/datadog/ci/contrib/minitest/instrumentation_spec.rb
+++ b/spec/datadog/ci/contrib/minitest/instrumentation_spec.rb
@@ -1,0 +1,319 @@
+require 'time'
+
+require 'datadog/tracing'
+require 'datadog/tracing/metadata/ext'
+
+require 'datadog/ci/contrib/support/spec_helper'
+require 'datadog/ci/contrib/minitest/integration'
+
+RSpec.describe 'Minitest hooks' do
+  include_context 'CI mode activated'
+
+  before do
+    Datadog.configure do |c|
+      c.ci.instrument :minitest, service_name: 'ltest'
+    end
+  end
+
+  it 'creates span for test' do
+    klass = Class.new(Minitest::Test) do
+      def self.name
+        'SomeTest'
+      end
+
+      def test_foo; end
+    end
+
+    klass.new(:test_foo).run
+
+    expect(span.span_type).to eq(Datadog::CI::Ext::AppTypes::TYPE_TEST)
+    expect(span.name).to eq(Datadog::CI::Contrib::Minitest::Ext::OPERATION_NAME)
+    expect(span.resource).to eq('SomeTest#test_foo')
+    expect(span.service).to eq('ltest')
+    expect(span.get_tag(Datadog::CI::Ext::Test::TAG_NAME)).to eq('SomeTest#test_foo')
+    # expect(span.get_tag(Datadog::CI::Ext::Test::TAG_SUITE)).to eq(spec.file_path)
+    expect(span.get_tag(Datadog::CI::Ext::Test::TAG_SPAN_KIND)).to eq(Datadog::CI::Ext::AppTypes::TYPE_TEST)
+    expect(span.get_tag(Datadog::CI::Ext::Test::TAG_TYPE)).to eq(Datadog::CI::Contrib::Minitest::Ext::TEST_TYPE)
+    expect(span.get_tag(Datadog::CI::Ext::Test::TAG_FRAMEWORK)).to eq(Datadog::CI::Contrib::Minitest::Ext::FRAMEWORK)
+    expect(span.get_tag(Datadog::CI::Ext::Test::TAG_FRAMEWORK_VERSION)).to eq(
+      Datadog::CI::Contrib::Minitest::Integration.version.to_s
+    )
+    expect(span.get_tag(Datadog::CI::Ext::Test::TAG_STATUS)).to eq(Datadog::CI::Ext::Test::Status::PASS)
+  end
+
+  it 'creates spans for several tests' do
+    num_tests = 20
+
+    klass = Class.new(Minitest::Test) do
+      def self.name
+        'SomeTest'
+      end
+
+      num_tests.times do |i|
+        define_method("test_#{i}") { ; }
+      end
+    end
+
+    num_tests.times do |i|
+      klass.new("test_#{i}").run
+    end
+
+    expect(spans).to have(num_tests).items
+  end
+
+  it 'creates spans for example with instrumentation' do
+    klass = Class.new(Minitest::Test) do
+      def self.name
+        'SomeTest'
+      end
+
+      def test_foo
+        Datadog::Tracing.trace('get_time') do
+          Time.now
+        end
+      end
+    end
+
+    klass.new(:test_foo).run
+
+    expect(spans).to have(2).items
+
+    spans.each do |span|
+      expect(span.get_tag(Datadog::Tracing::Metadata::Ext::Distributed::TAG_ORIGIN))
+        .to eq(Datadog::CI::Ext::Test::CONTEXT_ORIGIN)
+    end
+  end
+
+  context 'catches failures' do
+    def expect_failure
+      expect(span.get_tag(Datadog::CI::Ext::Test::TAG_STATUS)).to eq(Datadog::CI::Ext::Test::Status::FAIL)
+      expect(span).to have_error
+      expect(span).to have_error_type
+      expect(span).to have_error_message
+      expect(span).to have_error_stack
+    end
+
+    it 'within test' do
+      klass = Class.new(Minitest::Test) do
+        def self.name
+          'SomeTest'
+        end
+
+        def test_foo
+          assert false
+        end
+      end
+
+      klass.new(:test_foo).run
+
+      expect_failure
+    end
+
+    it 'within setup' do
+      klass = Class.new(Minitest::Test) do
+        def self.name
+          'SomeTest'
+        end
+
+        def setup
+          assert false
+        end
+
+        def test_foo; end
+      end
+
+      klass.new(:test_foo).run
+
+      expect_failure
+    end
+
+    it 'within teardown' do
+      klass = Class.new(Minitest::Test) do
+        def self.name
+          'SomeTest'
+        end
+
+        def teardown
+          assert false
+        end
+
+        def test_foo; end
+      end
+
+      klass.new(:test_foo).run
+
+      expect_failure
+    end
+  end
+
+  context 'catches errors' do
+    def expect_failure
+      expect(span.get_tag(Datadog::CI::Ext::Test::TAG_STATUS)).to eq(Datadog::CI::Ext::Test::Status::FAIL)
+      expect(span).to have_error
+      expect(span).to have_error_type
+      expect(span).to have_error_message
+      expect(span).to have_error_stack
+    end
+
+    it 'within test' do
+      klass = Class.new(Minitest::Test) do
+        def self.name
+          'SomeTest'
+        end
+
+        def test_foo
+          raise 'Error!'
+        end
+      end
+
+      klass.new(:test_foo).run
+
+      expect_failure
+    end
+
+    it 'within setup' do
+      klass = Class.new(Minitest::Test) do
+        def self.name
+          'SomeTest'
+        end
+
+        def setup
+          raise 'Error!'
+        end
+
+        def test_foo; end
+      end
+
+      klass.new(:test_foo).run
+
+      expect_failure
+    end
+
+    it 'within teardown' do
+      klass = Class.new(Minitest::Test) do
+        def self.name
+          'SomeTest'
+        end
+
+        def teardown
+          raise 'Error!'
+        end
+
+        def test_foo; end
+      end
+
+      klass.new(:test_foo).run
+
+      expect_failure
+    end
+  end
+
+  context 'catches skips' do
+    def expect_skip
+      expect(span.get_tag(Datadog::CI::Ext::Test::TAG_STATUS)).to eq(Datadog::CI::Ext::Test::Status::SKIP)
+      expect(span).to_not have_error
+    end
+
+    it 'with reason' do
+      klass = Class.new(Minitest::Test) do
+        def self.name
+          'SomeTest'
+        end
+
+        def test_foo
+          skip 'Skip!'
+        end
+      end
+
+      klass.new(:test_foo).run
+
+      expect_skip
+      expect(span.get_tag(Datadog::CI::Ext::Test::TAG_SKIP_REASON)).to eq('Skip!')
+    end
+
+    it 'without reason' do
+      klass = Class.new(Minitest::Test) do
+        def self.name
+          'SomeTest'
+        end
+
+        def test_foo
+          skip
+        end
+      end
+
+      klass.new(:test_foo).run
+
+      expect_skip
+      expect(span.get_tag(Datadog::CI::Ext::Test::TAG_SKIP_REASON)).to eq('Skipped, no message given')
+    end
+
+    it 'within test' do
+      klass = Class.new(Minitest::Test) do
+        def self.name
+          'SomeTest'
+        end
+
+        def test_foo
+          skip 'Skip!'
+        end
+      end
+
+      klass.new(:test_foo).run
+
+      expect_skip
+    end
+
+    it 'within setup' do
+      klass = Class.new(Minitest::Test) do
+        def self.name
+          'SomeTest'
+        end
+
+        def setup
+          skip 'Skip!'
+        end
+
+        def test_foo; end
+      end
+
+      klass.new(:test_foo).run
+
+      expect_skip
+    end
+
+    it 'within teardown' do
+      klass = Class.new(Minitest::Test) do
+        def self.name
+          'SomeTest'
+        end
+
+        def teardown
+          skip 'Skip!'
+        end
+
+        def test_foo; end
+      end
+
+      klass.new(:test_foo).run
+
+      expect_skip
+    end
+  end
+
+  it 'uses relative path for test suite' do
+    klass = Class.new(Minitest::Test) do
+      def self.name
+        'SomeTest'
+      end
+
+      def test_foo; end
+    end
+
+    klass.new(:test_foo).run
+
+    expect(
+      span.get_tag(Datadog::CI::Ext::Test::TAG_SUITE)
+    ).to eq('spec/datadog/ci/contrib/minitest/instrumentation_spec.rb')
+  end
+end

--- a/spec/datadog/ci/contrib/minitest/integration_spec.rb
+++ b/spec/datadog/ci/contrib/minitest/integration_spec.rb
@@ -1,0 +1,70 @@
+require 'datadog/ci/contrib/support/spec_helper'
+
+require 'datadog/ci/contrib/minitest/integration'
+
+RSpec.describe Datadog::CI::Contrib::Minitest::Integration do
+  extend ConfigurationHelpers
+
+  let(:integration) { described_class.new(:minitest) }
+
+  describe '.version' do
+    subject(:version) { described_class.version }
+
+    context 'when the "minitest" gem is loaded' do
+      include_context 'loaded gems', 'minitest' => described_class::MINIMUM_VERSION
+      it { is_expected.to be_a_kind_of(Gem::Version) }
+    end
+
+    context 'when "minitest" gem is not loaded' do
+      include_context 'loaded gems', 'minitest' => nil
+      it { is_expected.to be nil }
+    end
+  end
+
+  describe '.loaded?' do
+    subject(:loaded?) { described_class.loaded? }
+
+    context 'when Minitest is defined' do
+      it { is_expected.to be true }
+    end
+  end
+
+  describe '.compatible?' do
+    subject(:compatible?) { described_class.compatible? }
+
+    context 'when "minitest" gem is loaded with a version' do
+      context 'that is less than the minimum' do
+        include_context 'loaded gems', 'minitest' => decrement_gem_version(described_class::MINIMUM_VERSION)
+        it { is_expected.to be false }
+      end
+
+      context 'that meets the minimum version' do
+        include_context 'loaded gems', 'minitest' => described_class::MINIMUM_VERSION
+        it { is_expected.to be true }
+      end
+    end
+
+    context 'when gem is not loaded' do
+      include_context 'loaded gems', 'minitest' => nil
+      it { is_expected.to be false }
+    end
+  end
+
+  describe '#auto_instrument?' do
+    subject(:auto_instrument?) { integration.auto_instrument? }
+
+    it { is_expected.to be(false) }
+  end
+
+  describe '#default_configuration' do
+    subject(:default_configuration) { integration.default_configuration }
+
+    it { is_expected.to be_a_kind_of(Datadog::CI::Contrib::Minitest::Configuration::Settings) }
+  end
+
+  describe '#patcher' do
+    subject(:patcher) { integration.patcher }
+
+    it { is_expected.to be Datadog::CI::Contrib::Minitest::Patcher }
+  end
+end

--- a/spec/datadog/ci/contrib/minitest/patcher_spec.rb
+++ b/spec/datadog/ci/contrib/minitest/patcher_spec.rb
@@ -1,0 +1,18 @@
+require 'datadog/ci/contrib/support/spec_helper'
+require 'datadog/ci/contrib/minitest/patcher'
+
+require 'minitest'
+
+RSpec.describe Datadog::CI::Contrib::Minitest::Patcher do
+  describe '.patch' do
+    subject!(:patch) { described_class.patch }
+
+    let(:test) { Minitest::Test }
+
+    context 'is patched' do
+      it 'has a custom bases' do
+        expect(test.ancestors).to include(Datadog::CI::Contrib::Minitest::TestHelper)
+      end
+    end
+  end
+end


### PR DESCRIPTION
<!--
Check out the
https://github.com/DataDog/dd-trace-rb/blob/master/docs/DevelopmentGuide.md
for guidance on how to set up your development environment,
run the test suite, write new integrations, and more.
-->

**What does this PR do?**

Add CI Visibility support for the Minitest framework.

**Motivation**

Datadog doesn't currently support using Minitest with the CI Visibility feature. It's easy enough to add your own custom integration, but I think it makes sense for `dd-trace-rb` to provide first-class support for Minitest given that it's the default testing framework for Ruby on Rails.

**Additional Notes**

- RSpec uses a relative path with the `./` prefix for the test suite name. Right now, we're using `Pathname.new(path).relative_path_from(Pathname.pwd).to_s` which doesn't include the `./` prefix. Should we mirror the RSpec setup?
- Currently, it only supports `minitest/unit`, I haven't dug into what it would take to support `minitest/spec`.
- Minitest supports skip reasons, but provides a default message of "Skipped, no message given". Should we exclude the default message assuming that it doesn't provide much value?

I realize this is a pretty big patch that you might not want to accept from an outside contributor, but I figured I'd put together a PR since we've been using this internally.

**How to test the change?**

- Added unit tests for instrumentation
