### PR TITLE
miscellaneous `peer.service` precursor tags

### DIFF
--- a/lib/datadog/tracing/contrib/mongodb/subscribers.rb
+++ b/lib/datadog/tracing/contrib/mongodb/subscribers.rb
@@ -55,6 +55,7 @@ module Datadog
             span.set_tag(Ext::TAG_QUERY, serialized_query)
             span.set_tag(Tracing::Metadata::Ext::NET::TAG_TARGET_HOST, event.address.host)
             span.set_tag(Tracing::Metadata::Ext::NET::TAG_TARGET_PORT, event.address.port)
+            span.set_tag(Tracing::Contrib::Ext::DB::TAG_INSTANCE, query['database'])
 
             # set the resource with the quantized query
             span.resource = serialized_query

--- a/lib/datadog/tracing/contrib/mysql2/instrumentation.rb
+++ b/lib/datadog/tracing/contrib/mysql2/instrumentation.rb
@@ -45,6 +45,7 @@ module Datadog
                 span.set_tag(Ext::TAG_DB_NAME, query_options[:database])
                 span.set_tag(Tracing::Metadata::Ext::NET::TAG_TARGET_HOST, query_options[:host])
                 span.set_tag(Tracing::Metadata::Ext::NET::TAG_TARGET_PORT, query_options[:port])
+                span.set_tag(Tracing::Contrib::Ext::DB::TAG_INSTANCE, query_options[:database])
 
                 propagation_mode = Contrib::Propagation::SqlComment::Mode.new(comment_propagation)
 

--- a/spec/datadog/tracing/contrib/mongodb/client_spec.rb
+++ b/spec/datadog/tracing/contrib/mongodb/client_spec.rb
@@ -155,6 +155,7 @@ RSpec.describe 'Mongo::Client instrumentation' do
         expect(span.get_tag(Datadog::Tracing::Metadata::Ext::TAG_COMPONENT)).to eq('mongodb')
         expect(span.get_tag(Datadog::Tracing::Metadata::Ext::TAG_OPERATION)).to eq('command')
         expect(span.get_tag('span.kind')).to eq('client')
+        expect(span.get_tag('db.instance')).to eq(database)
       end
 
       it_behaves_like 'analytics for integration' do

--- a/spec/datadog/tracing/contrib/mysql2/patcher_spec.rb
+++ b/spec/datadog/tracing/contrib/mysql2/patcher_spec.rb
@@ -73,6 +73,7 @@ RSpec.describe 'Mysql2::Client patcher' do
           expect(span.get_tag('span.kind')).to eq('client')
           expect(span.get_tag('db.system')).to eq('mysql')
           expect(span.get_tag(Datadog::Tracing::Metadata::Ext::TAG_PEER_SERVICE)).to eq(service_name)
+          expect(span.get_tag('db.instance')).to eq(database)
         end
 
         it_behaves_like 'with sql comment propagation', span_op_name: 'mysql2.query'
@@ -90,6 +91,7 @@ RSpec.describe 'Mysql2::Client patcher' do
           expect(span.get_tag('db.system')).to eq('mysql')
           expect(span.get_tag(Datadog::Tracing::Metadata::Ext::TAG_COMPONENT)).to eq('mysql2')
           expect(span.get_tag(Datadog::Tracing::Metadata::Ext::TAG_OPERATION)).to eq('query')
+          expect(span.get_tag('db.instance')).to eq(database)
         end
 
         it_behaves_like 'analytics for integration' do
@@ -130,6 +132,7 @@ RSpec.describe 'Mysql2::Client patcher' do
           expect(span.get_tag('db.system')).to eq('mysql')
           expect(span.get_tag('error.message'))
             .to eq("Unknown column 'INVALID' in 'field list'")
+          expect(span.get_tag('db.instance')).to eq(database)
         end
 
         it_behaves_like 'with sql comment propagation', span_op_name: 'mysql2.query', error: Mysql2::Error


### PR DESCRIPTION
Adds a few missing `peer.service` precursor source tags that are necessary:

- mysql2: adds `db.instance` tag
- mongodb: add `db.instance` tag