### PR TITLE
[EXPERIMENTAL] Add `env_var` and `deprecated_env_var` configuration options

### DIFF
--- a/Steepfile
+++ b/Steepfile
@@ -9,6 +9,7 @@ target :ddtrace do
 
   ignore 'lib/datadog/appsec.rb'
   ignore 'lib/datadog/appsec/component.rb'
+  ignore 'lib/datadog/appsec/configuration/settings.rb'
   ignore 'lib/datadog/appsec/contrib/auto_instrument.rb'
   ignore 'lib/datadog/appsec/contrib/integration.rb'
   ignore 'lib/datadog/appsec/contrib/rack/gateway/request.rb'

--- a/lib/datadog/appsec/configuration/settings.rb
+++ b/lib/datadog/appsec/configuration/settings.rb
@@ -33,10 +33,9 @@ module Datadog
           base.class_eval do
             settings :appsec do
               option :enabled do |o|
-                o.default { env_to_bool('DD_APPSEC_ENABLED', DEFAULT_APPSEC_ENABLED) }
-                o.setter do |v|
-                  v ? true : false
-                end
+                o.type :bool
+                o.env_var 'DD_APPSEC_ENABLED'
+                o.default DEFAULT_APPSEC_ENABLED
               end
 
               define_method(:instrument) do |integration_name|
@@ -53,73 +52,71 @@ module Datadog
               end
 
               option :ruleset do |o|
-                o.default { ENV.fetch('DD_APPSEC_RULES', DEFAULT_APPSEC_RULESET) }
+                o.env_var 'DD_APPSEC_RULES'
+                o.default DEFAULT_APPSEC_RULESET
               end
 
               option :ip_denylist do |o|
-                o.default { [] }
+                o.type :array
+                o.default []
               end
 
               option :user_id_denylist do |o|
-                o.default { [] }
+                o.type :array
+                o.default []
               end
 
               option :waf_timeout do |o|
-                o.default { ENV.fetch('DD_APPSEC_WAF_TIMEOUT', DEFAULT_APPSEC_WAF_TIMEOUT) } # us
+                o.env_var 'DD_APPSEC_WAF_TIMEOUT'
+                o.default DEFAULT_APPSEC_WAF_TIMEOUT
                 o.setter do |v|
                   Datadog::Core::Utils::Duration.call(v.to_s, base: :us)
                 end
               end
 
               option :waf_debug do |o|
-                o.default { env_to_bool('DD_APPSEC_WAF_DEBUG', DEFAULT_APPSEC_WAF_DEBUG) }
-                o.setter do |v|
-                  v ? true : false
-                end
+                o.env_var 'DD_APPSEC_WAF_DEBUG'
+                o.default DEFAULT_APPSEC_WAF_DEBUG
+                o.type :bool
               end
 
               option :trace_rate_limit do |o|
-                o.default { env_to_int('DD_APPSEC_TRACE_RATE_LIMIT', DEFAULT_APPSEC_TRACE_RATE_LIMIT) } # trace/s
+                o.type :int
+                o.env_var 'DD_APPSEC_TRACE_RATE_LIMIT'
+                o.default DEFAULT_APPSEC_TRACE_RATE_LIMIT
               end
 
               option :obfuscator_key_regex do |o|
-                o.default { ENV.fetch('DD_APPSEC_OBFUSCATION_PARAMETER_KEY_REGEXP', DEFAULT_OBFUSCATOR_KEY_REGEX) }
+                o.type :string
+                o.env_var 'DD_APPSEC_OBFUSCATION_PARAMETER_KEY_REGEXP'
+                o.default DEFAULT_OBFUSCATOR_KEY_REGEX
               end
 
               option :obfuscator_value_regex do |o|
-                o.default do
-                  ENV.fetch(
-                    'DD_APPSEC_OBFUSCATION_PARAMETER_VALUE_REGEXP',
-                    DEFAULT_OBFUSCATOR_VALUE_REGEX
-                  )
-                end
+                o.type :string
+                o.env_var 'DD_APPSEC_OBFUSCATION_PARAMETER_VALUE_REGEXP'
+                o.default DEFAULT_OBFUSCATOR_VALUE_REGEX
               end
 
               settings :track_user_events do
                 option :enabled do |o|
-                  o.default do
-                    ENV.fetch(
-                      'DD_APPSEC_AUTOMATED_USER_EVENTS_TRACKING',
-                      DEFAULT_APPSEC_AUTOMATED_TRACK_USER_EVENTS_ENABLED
-                    )
-                  end
-                  o.setter do |v|
-                    if v
-                      v.to_s != 'disabled'
+                  o.env_var 'DD_APPSEC_AUTOMATED_USER_EVENTS_TRACKING'
+                  o.default DEFAULT_APPSEC_AUTOMATED_TRACK_USER_EVENTS_ENABLED
+                  o.setter do |value|
+                    if value.is_a?(String)
+                      value != 'disabled'
                     else
-                      false
+                      !!value # rubocop:disable Style/DoubleNegation
                     end
                   end
                 end
 
                 option :mode do |o|
-                  o.default do
-                    ENV.fetch('DD_APPSEC_AUTOMATED_USER_EVENTS_TRACKING', DEFAULT_APPSEC_AUTOMATED_TRACK_USER_EVENTS_MODE)
-                  end
+                  o.env_var 'DD_APPSEC_AUTOMATED_USER_EVENTS_TRACKING'
+                  o.default DEFAULT_APPSEC_AUTOMATED_TRACK_USER_EVENTS_MODE
                   o.setter do |v|
-                    string_value = v.to_s
-                    if APPSEC_VALID_TRACK_USER_EVENTS_MODE.include?(string_value)
-                      string_value
+                    if APPSEC_VALID_TRACK_USER_EVENTS_MODE.include?(v.to_s)
+                      v.to_s
                     else
                       Datadog.logger.warn(
                         'The appsec.track_user_events.mode value provided is not supported.' \

--- a/lib/datadog/ci/configuration/settings.rb
+++ b/lib/datadog/ci/configuration/settings.rb
@@ -16,7 +16,9 @@ module Datadog
           base.class_eval do
             settings :ci do
               option :enabled do |o|
-                o.default { env_to_bool(CI::Ext::Settings::ENV_MODE_ENABLED, false) }
+                o.type :bool
+                o.env_var CI::Ext::Settings::ENV_MODE_ENABLED
+                o.default false
               end
 
               # DEV: Alias to Datadog::Tracing::Contrib::Extensions::Configuration::Settings#instrument.
@@ -34,12 +36,11 @@ module Datadog
               # TODO: Deprecate in the next major version, as `instrument` better describes this method's purpose
               alias_method :use, :instrument
 
-              option :trace_flush do |o|
-                o.default { nil }
-              end
+              option :trace_flush
 
               option :writer_options do |o|
-                o.default { {} }
+                o.type :hash
+                o.default({})
               end
             end
           end

--- a/lib/datadog/ci/contrib/cucumber/configuration/settings.rb
+++ b/lib/datadog/ci/contrib/cucumber/configuration/settings.rb
@@ -12,15 +12,20 @@ module Datadog
           # TODO: mark as `@public_api` when GA
           class Settings < Datadog::Tracing::Contrib::Configuration::Settings
             option :enabled do |o|
-              o.default { env_to_bool(Ext::ENV_ENABLED, true) }
+              o.type :bool
+              o.env_var Ext::ENV_ENABLED
+              o.default true
             end
 
             option :service_name do |o|
+              o.type :string
               o.default { Datadog.configuration.service_without_fallback || Ext::SERVICE_NAME }
             end
 
             option :operation_name do |o|
-              o.default { ENV.fetch(Ext::ENV_OPERATION_NAME, Ext::OPERATION_NAME) }
+              o.type :string
+              o.env_var Ext::ENV_OPERATION_NAME
+              o.default Ext::OPERATION_NAME
             end
           end
         end

--- a/lib/datadog/ci/contrib/minitest/configuration/settings.rb
+++ b/lib/datadog/ci/contrib/minitest/configuration/settings.rb
@@ -12,15 +12,20 @@ module Datadog
           # TODO: mark as `@public_api` when GA
           class Settings < Datadog::Tracing::Contrib::Configuration::Settings
             option :enabled do |o|
-              o.default { env_to_bool(Ext::ENV_ENABLED, true) }
+              o.type :bool
+              o.env_var Ext::ENV_ENABLED
+              o.default true
             end
 
             option :service_name do |o|
+              o.type :string
               o.default { Datadog.configuration.service_without_fallback || Ext::SERVICE_NAME }
             end
 
             option :operation_name do |o|
-              o.default { ENV.key?(Ext::ENV_OPERATION_NAME) ? ENV[Ext::ENV_OPERATION_NAME] : Ext::OPERATION_NAME }
+              o.type :string
+              o.env_var Ext::ENV_OPERATION_NAME
+              o.default Ext::OPERATION_NAME
             end
           end
         end

--- a/lib/datadog/ci/contrib/rspec/configuration/settings.rb
+++ b/lib/datadog/ci/contrib/rspec/configuration/settings.rb
@@ -12,15 +12,20 @@ module Datadog
           # TODO: mark as `@public_api` when GA
           class Settings < Datadog::Tracing::Contrib::Configuration::Settings
             option :enabled do |o|
-              o.default { env_to_bool(Ext::ENV_ENABLED, true) }
+              o.type :bool
+              o.env_var Ext::ENV_ENABLED
+              o.default true
             end
 
             option :service_name do |o|
+              o.type :string
               o.default { Datadog.configuration.service_without_fallback || Ext::SERVICE_NAME }
             end
 
             option :operation_name do |o|
-              o.default { ENV.fetch(Ext::ENV_OPERATION_NAME, Ext::OPERATION_NAME) }
+              o.type :string
+              o.env_var Ext::ENV_OPERATION_NAME
+              o.default Ext::OPERATION_NAME
             end
           end
         end

--- a/lib/datadog/core/configuration/base.rb
+++ b/lib/datadog/core/configuration/base.rb
@@ -34,8 +34,6 @@ module Datadog
                 value.reset! if value.respond_to?(:reset!)
                 value
               end
-
-              o.type settings_class
             end
           end
 

--- a/lib/datadog/core/configuration/option.rb
+++ b/lib/datadog/core/configuration/option.rb
@@ -1,5 +1,7 @@
 # frozen_string_literal: true
 
+require_relative '../utils/safe_dup'
+
 module Datadog
   module Core
     module Configuration
@@ -49,7 +51,7 @@ module Datadog
           end
 
           old_value = @value
-          (@value = context_exec(value, old_value, &definition.setter)).tap do |v|
+          (@value = context_exec(validate_type(value), old_value, &definition.setter)).tap do |v|
             @is_set = true
             @precedence_set = precedence
             context_exec(v, old_value, &definition.on_set) if definition.on_set
@@ -62,7 +64,7 @@ module Datadog
           elsif definition.delegate_to
             context_eval(&definition.delegate_to)
           else
-            set(default_value, precedence: Precedence::DEFAULT)
+            set_value_from_env_or_default
           end
         end
 
@@ -84,7 +86,7 @@ module Datadog
           if definition.default.instance_of?(Proc)
             context_eval(&definition.default)
           else
-            definition.experimental_default_proc || definition.default
+            definition.experimental_default_proc || Core::Utils::SafeDup.frozen_or_dup(definition.default)
           end
         end
 
@@ -94,12 +96,108 @@ module Datadog
 
         private
 
+        def coerce_env_variable(value)
+          case @definition.type
+          when :int
+            value.to_i
+          when :float
+            value.to_f
+          when :array
+            values = if value.include?(',')
+                       value.split(',')
+                     else
+                       value.split(' ') # rubocop:disable Style/RedundantArgument
+                     end
+
+            values.map! do |v|
+              v.gsub!(/\A[\s,]*|[\s,]*\Z/, '')
+
+              v.empty? ? nil : v
+            end
+
+            values.compact!
+            values
+          when :bool
+            string_value = value
+            string_value = string_value.downcase
+            string_value == 'true' || string_value == '1' # rubocop:disable Style/MultipleComparison
+          else
+            value
+          end
+        end
+
+        def validate_type(value)
+          raise_error = false
+
+          valid_type = validate(@definition.type, value)
+
+          unless valid_type
+            raise_error = if @definition.type_options[:nil]
+                            !value.is_a?(NilClass)
+                          else
+                            true
+                          end
+          end
+
+          if raise_error
+            error_msg = if @definition.type_options[:nil]
+                          "The option #{@definition.name} support this type `#{@definition.type}` "\
+                                      "and `nil` but the value provided is #{value.class}"
+                        else
+                          "The option #{@definition.name} support this type `#{@definition.type}` "\
+                          "but the value provided is #{value.class}"
+                        end
+
+            raise ArgumentError, error_msg
+          end
+
+          value
+        end
+
+        def validate(type, value)
+          case type
+          when :string
+            value.is_a?(String)
+          when :int
+            value.is_a?(Integer)
+          when :float
+            value.is_a?(Float)
+          when :array
+            value.is_a?(Array)
+          when :hash
+            value.is_a?(Hash)
+          when :bool
+            value.is_a?(TrueClass) || value.is_a?(FalseClass)
+          when :block
+            value.is_a?(Proc)
+          when :nil
+            value.is_a?(NilClass)
+          when :symbol
+            value.is_a?(Symbol)
+          else
+            true
+          end
+        end
+
         def context_exec(*args, &block)
           @context.instance_exec(*args, &block)
         end
 
         def context_eval(&block)
           @context.instance_eval(&block)
+        end
+
+        def set_value_from_env_or_default
+          if definition.env_var && ENV[definition.env_var]
+            set(coerce_env_variable(ENV[definition.env_var]), precedence: Precedence::PROGRAMMATIC)
+          elsif definition.deprecated_env_var && ENV[definition.deprecated_env_var]
+            Datadog::Core.log_deprecation do
+              "#{definition.deprecated_env_var} environment variable is deprecated, use #{definition.env_var} instead."
+            end
+            set(coerce_env_variable(ENV[definition.deprecated_env_var]), precedence: Precedence::PROGRAMMATIC)
+          else
+            set(default_value, precedence: Precedence::DEFAULT)
+          end
         end
 
         # Used for testing

--- a/lib/datadog/core/configuration/settings.rb
+++ b/lib/datadog/core/configuration/settings.rb
@@ -79,7 +79,8 @@ module Datadog
         # @default `DD_API_KEY` environment variable, otherwise `nil`
         # @return [String,nil]
         option :api_key do |o|
-          o.default { ENV.fetch(Core::Environment::Ext::ENV_API_KEY, nil) }
+          o.type :string, nil: true
+          o.env_var Core::Environment::Ext::ENV_API_KEY
         end
 
         # Datadog diagnostic settings.
@@ -98,7 +99,9 @@ module Datadog
           # @default `DD_TRACE_DEBUG` environment variable, otherwise `false`
           # @return [Boolean]
           option :debug do |o|
-            o.default { env_to_bool(Datadog::Core::Configuration::Ext::Diagnostics::ENV_DEBUG_ENABLED, false) }
+            o.env_var Datadog::Core::Configuration::Ext::Diagnostics::ENV_DEBUG_ENABLED
+            o.default false
+            o.type :bool
             o.on_set do |enabled|
               # Enable rich debug print statements.
               # We do not need to unnecessarily load 'pp' unless in debugging mode.
@@ -115,7 +118,9 @@ module Datadog
             # @default `DD_HEALTH_METRICS_ENABLED` environment variable, otherwise `false`
             # @return [Boolean]
             option :enabled do |o|
-              o.default { env_to_bool(Datadog::Core::Configuration::Ext::Diagnostics::ENV_HEALTH_METRICS_ENABLED, false) }
+              o.env_var Datadog::Core::Configuration::Ext::Diagnostics::ENV_HEALTH_METRICS_ENABLED
+              o.default false
+              o.type :bool
             end
 
             # {Datadog::Statsd} instance to collect health metrics.
@@ -136,11 +141,12 @@ module Datadog
             # If `nil`, defaults to logging startup logs when `ddtrace` detects that the application
             # is *not* running in a development environment.
             #
-            # @default `DD_TRACE_STARTUP_LOGS` environment variable, otherwise `nil`
-            # @return [Boolean,nil]
+            # @default `DD_TRACE_STARTUP_LOGS` environment variable, otherwise `false`
+            # @return [Boolean]
             option :enabled do |o|
-              # Defaults to nil as we want to know when the default value is being used
-              o.default { env_to_bool(Datadog::Core::Configuration::Ext::Diagnostics::ENV_STARTUP_LOGS_ENABLED, nil) }
+              o.env_var Datadog::Core::Configuration::Ext::Diagnostics::ENV_STARTUP_LOGS_ENABLED
+              o.default false
+              o.type :bool
             end
           end
         end
@@ -154,7 +160,7 @@ module Datadog
           o.setter { |v| v.to_s if v }
 
           # NOTE: env also gets set as a side effect of tags. See the WORKAROUND note in #initialize for details.
-          o.default { ENV.fetch(Core::Environment::Ext::ENV_ENVIRONMENT, nil) }
+          o.env_var Core::Environment::Ext::ENV_ENVIRONMENT
         end
 
         # Internal `Datadog.logger` configuration.
@@ -189,7 +195,9 @@ module Datadog
           # @default `DD_PROFILING_ENABLED` environment variable, otherwise `false`
           # @return [Boolean]
           option :enabled do |o|
-            o.default { env_to_bool(Profiling::Ext::ENV_ENABLED, false) }
+            o.env_var Profiling::Ext::ENV_ENABLED
+            o.default false
+            o.type :bool
           end
 
           # @public_api
@@ -222,7 +230,9 @@ module Datadog
             #
             # @default `DD_PROFILING_MAX_FRAMES` environment variable, otherwise 400
             option :max_frames do |o|
-              o.default { env_to_int(Profiling::Ext::ENV_MAX_FRAMES, 400) }
+              o.type :int
+              o.env_var Profiling::Ext::ENV_MAX_FRAMES
+              o.default 400
             end
 
             # @public_api
@@ -234,7 +244,9 @@ module Datadog
                 # @default `DD_PROFILING_ENDPOINT_COLLECTION_ENABLED` environment variable, otherwise `true`
                 # @return [Boolean]
                 option :enabled do |o|
-                  o.default { env_to_bool(Profiling::Ext::ENV_ENDPOINT_COLLECTION_ENABLED, true) }
+                  o.env_var Profiling::Ext::ENV_ENDPOINT_COLLECTION_ENABLED
+                  o.default true
+                  o.type :bool
                 end
               end
             end
@@ -276,7 +288,9 @@ module Datadog
             #
             # @default `DD_PROFILING_FORCE_ENABLE_LEGACY` environment variable, otherwise `false`
             option :force_enable_legacy_profiler do |o|
-              o.default { env_to_bool('DD_PROFILING_FORCE_ENABLE_LEGACY', false) }
+              o.env_var 'DD_PROFILING_FORCE_ENABLE_LEGACY'
+              o.default false
+              o.type :bool
               o.on_set do |value|
                 if value
                   Datadog.logger.warn(
@@ -308,7 +322,9 @@ module Datadog
             #
             # @default `DD_PROFILING_FORCE_ENABLE_GC` environment variable, otherwise `false`
             option :force_enable_gc_profiling do |o|
-              o.default { env_to_bool('DD_PROFILING_FORCE_ENABLE_GC', false) }
+              o.env_var 'DD_PROFILING_FORCE_ENABLE_GC'
+              o.type :bool
+              o.default false
             end
 
             # Can be used to enable/disable the Datadog::Profiling.allocation_count feature.
@@ -329,7 +345,18 @@ module Datadog
             #
             # @default `DD_PROFILING_SKIP_MYSQL2_CHECK` environment variable, otherwise `false`
             option :skip_mysql2_check do |o|
-              o.default { env_to_bool('DD_PROFILING_SKIP_MYSQL2_CHECK', false) }
+              o.type :bool
+              o.env_var 'DD_PROFILING_SKIP_MYSQL2_CHECK'
+              o.default false
+            end
+
+            # Enables data collection for the timeline feature. This is still experimental and not recommended yet.
+            #
+            # @default `DD_PROFILING_EXPERIMENTAL_TIMELINE_ENABLED` environment variable as a boolean, otherwise `false`
+            option :experimental_timeline_enabled do |o|
+              o.type :bool
+              o.env_var 'DD_PROFILING_EXPERIMENTAL_TIMELINE_ENABLED'
+              o.default false
             end
 
             # The profiler gathers data by sending `SIGPROF` unix signals to Ruby application threads.
@@ -352,14 +379,19 @@ module Datadog
             #
             # @default `DD_PROFILING_NO_SIGNALS_WORKAROUND_ENABLED` environment variable as a boolean, otherwise `:auto`
             option :no_signals_workaround_enabled do |o|
-              o.default { env_to_bool('DD_PROFILING_NO_SIGNALS_WORKAROUND_ENABLED', :auto) }
-            end
-
-            # Enables data collection for the timeline feature. This is still experimental and not recommended yet.
-            #
-            # @default `DD_PROFILING_EXPERIMENTAL_TIMELINE_ENABLED` environment variable as a boolean, otherwise `false`
-            option :experimental_timeline_enabled do |o|
-              o.default { env_to_bool('DD_PROFILING_EXPERIMENTAL_TIMELINE_ENABLED', false) }
+              o.env_var 'DD_PROFILING_NO_SIGNALS_WORKAROUND_ENABLED'
+              o.default :auto
+              o.setter do |value|
+                if ['true', true, '1', 'false', false, :auto].include?(value)
+                  if value == :auto
+                    value
+                  else
+                    ['true', true, '1'].include?(value)
+                  end
+                else
+                  value
+                end
+              end
             end
           end
 
@@ -369,8 +401,9 @@ module Datadog
             #
             # @default `DD_PROFILING_UPLOAD_TIMEOUT` environment variable, otherwise `30.0`
             option :timeout_seconds do |o|
-              o.setter { |value| value.nil? ? 30.0 : value.to_f }
-              o.default { env_to_float(Profiling::Ext::ENV_UPLOAD_TIMEOUT, 30.0) }
+              o.type :float
+              o.env_var Profiling::Ext::ENV_UPLOAD_TIMEOUT
+              o.default 30.0
             end
           end
         end
@@ -383,10 +416,12 @@ module Datadog
           # @default `DD_RUNTIME_METRICS_ENABLED` environment variable, otherwise `false`
           # @return [Boolean]
           option :enabled do |o|
-            o.default { env_to_bool(Core::Runtime::Ext::Metrics::ENV_ENABLED, false) }
+            o.env_var Core::Runtime::Ext::Metrics::ENV_ENABLED
+            o.default false
+            o.type :bool
           end
 
-          option :opts, default: ->(_i) { {} }
+          option :opts, default: {}, type: :hash
           option :statsd
         end
 
@@ -399,14 +434,15 @@ module Datadog
           o.setter { |v| v.to_s if v }
 
           # NOTE: service also gets set as a side effect of tags. See the WORKAROUND note in #initialize for details.
-          o.default { ENV.fetch(Core::Environment::Ext::ENV_SERVICE, Core::Environment::Ext::FALLBACK_SERVICE_NAME) }
+          o.env_var Core::Environment::Ext::ENV_SERVICE
+          o.default Core::Environment::Ext::FALLBACK_SERVICE_NAME
 
           # There's a few cases where we don't want to use the fallback service name, so this helper allows us to get a
           # nil instead so that one can do
           # nice_service_name = Datadog.configuration.service_without_fallback || nice_service_name_default
           o.helper(:service_without_fallback) do
             service_name = service
-            service_name unless service_name.equal?(Core::Environment::Ext::FALLBACK_SERVICE_NAME)
+            service_name unless service_name === Core::Environment::Ext::FALLBACK_SERVICE_NAME
           end
         end
 
@@ -421,7 +457,8 @@ module Datadog
         # @default `DD_SITE` environment variable, otherwise `nil` which sends data to `app.datadoghq.com`
         # @return [String,nil]
         option :site do |o|
-          o.default { ENV.fetch(Core::Environment::Ext::ENV_SITE, nil) }
+          o.type :string, nil: true
+          o.env_var Core::Environment::Ext::ENV_SITE
         end
 
         # Default tags
@@ -431,36 +468,54 @@ module Datadog
         # @default `DD_TAGS` environment variable (in the format `'tag1:value1,tag2:value2'`), otherwise `{}`
         # @return [Hash<String,String>]
         option :tags do |o|
-          o.default do
-            tags = {}
+          o.env_var Core::Environment::Ext::ENV_TAGS
+          o.setter do |new_value, old_value|
+            tag_list = case new_value
+                       when String
+                         values = if new_value.include?(',')
+                                    new_value.split(',')
+                                  else
+                                    new_value.split(' ') # rubocop:disable Style/RedundantArgument
+                                  end
 
-            # Parse tags from environment
-            env_to_list(Core::Environment::Ext::ENV_TAGS, comma_separated_only: false).each do |tag|
-              key, value = tag.split(':', 2)
-              tags[key] = value if value && !value.empty?
-            end
+                         values.map! do |v|
+                           v.gsub!(/\A[\s,]*|[\s,]*\Z/, '')
+
+                           v.empty? ? nil : v
+                         end
+
+                         values.compact!
+                         values.each_with_object({}) do |tag, tags|
+                           key, value = tag.split(':', 2)
+                           tags[key] = value if value && !value.empty?
+                         end
+                       when Hash
+                         new_value
+                       else
+                         {}
+                       end
+
+            env_value = env
+            version_value = version
+            service_name = service_without_fallback
 
             # Override tags if defined
-            tags[Core::Environment::Ext::TAG_ENV] = env unless env.nil?
-            tags[Core::Environment::Ext::TAG_VERSION] = version unless version.nil?
+            tag_list[Core::Environment::Ext::TAG_ENV] = env_value unless env_value.nil?
+            tag_list[Core::Environment::Ext::TAG_VERSION] = version_value unless version_value.nil?
 
-            tags
-          end
-
-          o.setter do |new_value, old_value|
             # Coerce keys to strings
-            string_tags = new_value.collect { |k, v| [k.to_s, v] }.to_h
+            string_tags = tag_list.collect { |k, v| [k.to_s, v] }.to_h
 
             # Cross-populate tag values with other settings
             if env.nil? && string_tags.key?(Core::Environment::Ext::TAG_ENV)
               self.env = string_tags[Core::Environment::Ext::TAG_ENV]
             end
 
-            if version.nil? && string_tags.key?(Core::Environment::Ext::TAG_VERSION)
+            if version_value.nil? && string_tags.key?(Core::Environment::Ext::TAG_VERSION)
               self.version = string_tags[Core::Environment::Ext::TAG_VERSION]
             end
 
-            if service_without_fallback.nil? && string_tags.key?(Core::Environment::Ext::TAG_SERVICE)
+            if service_name.nil? && string_tags.key?(Core::Environment::Ext::TAG_SERVICE)
               self.service = string_tags[Core::Environment::Ext::TAG_SERVICE]
             end
 
@@ -479,9 +534,9 @@ module Datadog
         # @default `->{ Time.now }`
         # @return [Proc<Time>]
         option :time_now_provider do |o|
-          o.experimental_default_proc do
-            ::Time.now
-          end
+          o.experimental_default_proc { ::Time.now }
+          o.type :block
+
           o.on_set do |time_provider|
             Core::Utils::Time.now_provider = time_provider
           end
@@ -501,7 +556,8 @@ module Datadog
         # @return [String,nil]
         option :version do |o|
           # NOTE: version also gets set as a side effect of tags. See the WORKAROUND note in #initialize for details.
-          o.default { ENV.fetch(Core::Environment::Ext::ENV_VERSION, nil) }
+          o.type :string, nil: true
+          o.env_var Core::Environment::Ext::ENV_VERSION
         end
 
         # Client-side telemetry configuration
@@ -513,7 +569,9 @@ module Datadog
           #   Can be disabled as documented [here](https://docs.datadoghq.com/tracing/configure_data_security/#telemetry-collection).
           # @return [Boolean]
           option :enabled do |o|
-            o.default { env_to_bool(Core::Telemetry::Ext::ENV_ENABLED, true) }
+            o.env_var Core::Telemetry::Ext::ENV_ENABLED
+            o.default true
+            o.type :bool
           end
 
           # The interval in seconds when telemetry must be sent.
@@ -524,7 +582,9 @@ module Datadog
           # @return [Float]
           # @!visibility private
           option :heartbeat_interval_seconds do |o|
-            o.default { env_to_float(Core::Telemetry::Ext::ENV_HEARTBEAT_INTERVAL, 60) }
+            o.type :float
+            o.env_var Core::Telemetry::Ext::ENV_HEARTBEAT_INTERVAL
+            o.default 60.0
           end
         end
 
@@ -536,7 +596,9 @@ module Datadog
           # @default `DD_REMOTE_CONFIGURATION_ENABLED` environment variable, otherwise `true`.
           # @return [Boolean]
           option :enabled do |o|
-            o.default { env_to_bool(Core::Remote::Ext::ENV_ENABLED, true) }
+            o.env_var Core::Remote::Ext::ENV_ENABLED
+            o.default true
+            o.type :bool
           end
 
           # Tune remote configuration polling interval.
@@ -544,7 +606,9 @@ module Datadog
           # @default `DD_REMOTE_CONFIGURATION_POLL_INTERVAL_SECONDS` environment variable, otherwise `5.0` seconds.
           # @return [Float]
           option :poll_interval_seconds do |o|
-            o.default { env_to_float(Core::Remote::Ext::ENV_POLL_INTERVAL_SECONDS, 5.0) }
+            o.env_var Core::Remote::Ext::ENV_POLL_INTERVAL_SECONDS
+            o.type :float
+            o.default 5.0
           end
 
           # Declare service name to bind to remote configuration. Use when

--- a/lib/datadog/core/diagnostics/environment_logger.rb
+++ b/lib/datadog/core/diagnostics/environment_logger.rb
@@ -38,12 +38,11 @@ module Datadog
 
           # Are we logging the environment data?
           def log?
-            startup_logs_enabled = Datadog.configuration.diagnostics.startup_logs.enabled
-            if startup_logs_enabled.nil?
-              !repl? # Suppress logs if we running in a REPL
-            else
-              startup_logs_enabled
+            if Datadog.configuration.diagnostics.startup_logs.using_default?(:enabled)
+              return !repl? # Suppress logs if we running in a REPL
             end
+
+            Datadog.configuration.diagnostics.startup_logs.enabled
           end
 
           REPL_PROGRAM_NAMES = %w[irb pry].freeze

--- a/lib/datadog/tracing/configuration/settings.rb
+++ b/lib/datadog/tracing/configuration/settings.rb
@@ -26,7 +26,8 @@ module Datadog
                 # @default `DD_TRACE_ANALYTICS_ENABLED` environment variable, otherwise `nil`
                 # @return [Boolean,nil]
                 option :enabled do |o|
-                  o.default { env_to_bool(Tracing::Configuration::Ext::Analytics::ENV_TRACE_ANALYTICS_ENABLED, nil) }
+                  o.type :bool, nil: true
+                  o.env_var Tracing::Configuration::Ext::Analytics::ENV_TRACE_ANALYTICS_ENABLED
                 end
               end
 
@@ -50,23 +51,16 @@ module Datadog
                 #   otherwise `['Datadog','b3multi','b3']`.
                 # @return [Array<String>]
                 option :propagation_extract_style do |o|
-                  o.default do
-                    # DEV-2.0: Change default value to `tracecontext, Datadog`.
-                    # Look for all headers by default
-                    env_to_list(
-                      [
-                        Tracing::Configuration::Ext::Distributed::ENV_PROPAGATION_STYLE_EXTRACT,
-                        Tracing::Configuration::Ext::Distributed::ENV_PROPAGATION_STYLE_EXTRACT_OLD
-                      ],
-                      [
-                        Tracing::Configuration::Ext::Distributed::PROPAGATION_STYLE_DATADOG,
-                        Tracing::Configuration::Ext::Distributed::PROPAGATION_STYLE_B3_MULTI_HEADER,
-                        Tracing::Configuration::Ext::Distributed::PROPAGATION_STYLE_B3_SINGLE_HEADER
-                      ],
-                      comma_separated_only: true
-                    )
-                  end
-
+                  o.type :array
+                  o.deprecated_env_var Tracing::Configuration::Ext::Distributed::ENV_PROPAGATION_STYLE_EXTRACT_OLD
+                  o.env_var Tracing::Configuration::Ext::Distributed::ENV_PROPAGATION_STYLE_EXTRACT
+                  o.default(
+                    [
+                      Tracing::Configuration::Ext::Distributed::PROPAGATION_STYLE_DATADOG,
+                      Tracing::Configuration::Ext::Distributed::PROPAGATION_STYLE_B3_MULTI_HEADER,
+                      Tracing::Configuration::Ext::Distributed::PROPAGATION_STYLE_B3_SINGLE_HEADER,
+                    ]
+                  )
                   o.on_set do |styles|
                     # Modernize B3 options
                     # DEV-2.0: Can be removed with the removal of deprecated B3 constants.
@@ -91,18 +85,10 @@ module Datadog
                 # @default `DD_TRACE_PROPAGATION_STYLE_INJECT` environment variable (comma-separated list), otherwise `['Datadog']`.
                 # @return [Array<String>]
                 option :propagation_inject_style do |o|
-                  o.default do
-                    # DEV-2.0: Change default value to `tracecontext, Datadog`.
-                    env_to_list(
-                      [
-                        Tracing::Configuration::Ext::Distributed::ENV_PROPAGATION_STYLE_INJECT,
-                        Tracing::Configuration::Ext::Distributed::ENV_PROPAGATION_STYLE_INJECT_OLD
-                      ],
-                      [Tracing::Configuration::Ext::Distributed::PROPAGATION_STYLE_DATADOG],
-                      comma_separated_only: true # Only inject Datadog headers by default
-                    )
-                  end
-
+                  o.type :array
+                  o.deprecated_env_var Tracing::Configuration::Ext::Distributed::ENV_PROPAGATION_STYLE_INJECT_OLD
+                  o.env_var Tracing::Configuration::Ext::Distributed::ENV_PROPAGATION_STYLE_INJECT
+                  o.default [Tracing::Configuration::Ext::Distributed::PROPAGATION_STYLE_DATADOG]
                   o.on_set do |styles|
                     # Modernize B3 options
                     # DEV-2.0: Can be removed with the removal of deprecated B3 constants.
@@ -128,12 +114,11 @@ module Datadog
                 # @default `DD_TRACE_PROPAGATION_STYLE` environment variable (comma-separated list).
                 # @return [Array<String>]
                 option :propagation_style do |o|
-                  o.default do
-                    env_to_list(Configuration::Ext::Distributed::ENV_PROPAGATION_STYLE, nil, comma_separated_only: true)
-                  end
-
+                  o.type :array
+                  o.env_var Configuration::Ext::Distributed::ENV_PROPAGATION_STYLE
+                  o.default []
                   o.on_set do |styles|
-                    next unless styles
+                    next if styles.empty?
 
                     # Modernize B3 options
                     # DEV-2.0: Can be removed with the removal of deprecated B3 constants.
@@ -162,7 +147,9 @@ module Datadog
               # @default `DD_TRACE_ENABLED` environment variable, otherwise `true`
               # @return [Boolean]
               option :enabled do |o|
-                o.default { env_to_bool(Tracing::Configuration::Ext::ENV_ENABLED, true) }
+                o.env_var Tracing::Configuration::Ext::ENV_ENABLED
+                o.default true
+                o.type :bool
               end
 
               # Enable 128 bit trace id generation.
@@ -170,7 +157,9 @@ module Datadog
               # @default `DD_TRACE_128_BIT_TRACEID_GENERATION_ENABLED` environment variable, otherwise `false`
               # @return [Boolean]
               option :trace_id_128_bit_generation_enabled do |o|
-                o.default { env_to_bool(Tracing::Configuration::Ext::ENV_TRACE_ID_128_BIT_GENERATION_ENABLED, false) }
+                o.env_var Tracing::Configuration::Ext::ENV_TRACE_ID_128_BIT_GENERATION_ENABLED
+                o.default false
+                o.type :bool
               end
 
               # Enable 128 bit trace id injected for logging.
@@ -180,7 +169,9 @@ module Datadog
               #
               # It is not supported by our backend yet. Do not enable it.
               option :trace_id_128_bit_logging_enabled do |o|
-                o.default { env_to_bool(Tracing::Configuration::Ext::Correlation::ENV_TRACE_ID_128_BIT_LOGGING_ENABLED, false) }
+                o.env_var Tracing::Configuration::Ext::Correlation::ENV_TRACE_ID_128_BIT_LOGGING_ENABLED
+                o.default false
+                o.type :bool
               end
 
               # A custom tracer instance.
@@ -201,7 +192,9 @@ module Datadog
               # @see https://docs.datadoghq.com/tracing/setup_overview/setup/ruby/#trace-correlation
               # @return [Boolean]
               option :log_injection do |o|
-                o.default { env_to_bool(Tracing::Configuration::Ext::Correlation::ENV_LOGS_INJECTION_ENABLED, true) }
+                o.env_var Tracing::Configuration::Ext::Correlation::ENV_LOGS_INJECTION_ENABLED
+                o.default true
+                o.type :bool
               end
 
               # Configures an alternative trace transport behavior, where
@@ -218,7 +211,7 @@ module Datadog
                 #
                 # @default `false`
                 # @return [Boolean]
-                option :enabled, default: false
+                option :enabled, default: false, type: :bool
 
                 # Minimum number of finished spans required in a single unfinished trace before
                 # the tracer will consider that trace for partial flushing.
@@ -231,7 +224,7 @@ module Datadog
                 #
                 # @default 500
                 # @return [Integer]
-                option :min_spans_threshold, default: 500
+                option :min_spans_threshold, default: 500, type: :int
               end
 
               # Enables {https://docs.datadoghq.com/tracing/trace_retention_and_ingestion/#datadog-intelligent-retention-filter
@@ -241,7 +234,9 @@ module Datadog
               option :priority_sampling
 
               option :report_hostname do |o|
-                o.default { env_to_bool(Tracing::Configuration::Ext::NET::ENV_REPORT_HOSTNAME, false) }
+                o.env_var Tracing::Configuration::Ext::NET::ENV_REPORT_HOSTNAME
+                o.default false
+                o.type :bool
               end
 
               # A custom sampler instance.
@@ -261,9 +256,10 @@ module Datadog
                 # for resources not seen recently).
                 #
                 # @default `DD_TRACE_SAMPLE_RATE` environment variable, otherwise `nil`.
-                # @return [Float,nil]
+                # @return [Float]
                 option :default_rate do |o|
-                  o.default { env_to_float(Tracing::Configuration::Ext::Sampling::ENV_SAMPLE_RATE, nil) }
+                  o.type :float, nil: true
+                  o.env_var Tracing::Configuration::Ext::Sampling::ENV_SAMPLE_RATE
                 end
 
                 # Rate limit for number of spans per second.
@@ -274,7 +270,9 @@ module Datadog
                 # @default `DD_TRACE_RATE_LIMIT` environment variable, otherwise 100.
                 # @return [Numeric,nil]
                 option :rate_limit do |o|
-                  o.default { env_to_float(Tracing::Configuration::Ext::Sampling::ENV_RATE_LIMIT, 100) }
+                  o.type :int, nil: true
+                  o.env_var Tracing::Configuration::Ext::Sampling::ENV_RATE_LIMIT
+                  o.default 100
                 end
 
                 # Single span sampling rules.
@@ -289,6 +287,7 @@ module Datadog
                 # @return [String,nil]
                 # @public_api
                 option :span_rules do |o|
+                  o.type :string, nil: true
                   o.default do
                     rules = ENV[Tracing::Configuration::Ext::Sampling::Span::ENV_SPAN_SAMPLING_RULES]
                     rules_file = ENV[Tracing::Configuration::Ext::Sampling::Span::ENV_SPAN_SAMPLING_RULES_FILE]
@@ -329,15 +328,16 @@ module Datadog
                 # @default `DD_TRACE_TEST_MODE_ENABLED` environment variable, otherwise `false`
                 # @return [Boolean]
                 option :enabled do |o|
-                  o.default { env_to_bool(Tracing::Configuration::Ext::Test::ENV_MODE_ENABLED, false) }
+                  o.type :bool
+                  o.default false
+                  o.env_var Tracing::Configuration::Ext::Test::ENV_MODE_ENABLED
                 end
 
-                option :trace_flush do |o|
-                  o.default { nil }
-                end
+                option :trace_flush
 
                 option :writer_options do |o|
-                  o.default { {} }
+                  o.type :hash
+                  o.default({})
                 end
               end
 
@@ -348,8 +348,10 @@ module Datadog
               # @yieldparam [Datadog::Transport::HTTP] t transport to be configured.
               # @default `nil`
               # @return [Proc,nil]
-              option :transport_options, default: nil
-
+              option :transport_options do |o|
+                o.type :proc, nil: true
+                o.default nil
+              end
               # A custom writer instance.
               # The object must respect the {Datadog::Tracing::Writer} interface.
               #
@@ -364,8 +366,11 @@ module Datadog
               # This option is recommended for internal use only.
               #
               # @default `{}`
-              # @return [Hash,nil]
-              option :writer_options, default: ->(_i) { {} }
+              # @return [Hash]
+              option :writer_options do |o|
+                o.type :hash
+                o.default({})
+              end
 
               # Client IP configuration
               # @public_api
@@ -380,13 +385,16 @@ module Datadog
                 # @default `DD_TRACE_CLIENT_IP_ENABLED` environment variable, otherwise `false`.
                 # @return [Boolean]
                 option :enabled do |o|
+                  o.type :bool
                   o.default do
                     disabled = env_to_bool(Tracing::Configuration::Ext::ClientIp::ENV_DISABLED)
 
                     enabled = if disabled.nil?
                                 false
                               else
-                                Datadog.logger.warn { "#{Tracing::Configuration::Ext::ClientIp::ENV_DISABLED} environment variable is deprecated, found set to #{disabled}, use #{Tracing::Configuration::Ext::ClientIp::ENV_ENABLED}=#{!disabled}" }
+                                Datadog::Core.log_deprecation do
+                                  "#{Tracing::Configuration::Ext::ClientIp::ENV_DISABLED} environment variable is deprecated, use #{Tracing::Configuration::Ext::ClientIp::ENV_ENABLED} instead."
+                                end
 
                                 !disabled
                               end
@@ -401,7 +409,8 @@ module Datadog
                 # @default `DD_TRACE_CLIENT_IP_HEADER` environment variable, otherwise `nil`.
                 # @return [String,nil]
                 option :header_name do |o|
-                  o.default { ENV.fetch(Tracing::Configuration::Ext::ClientIp::ENV_HEADER_NAME, nil) }
+                  o.type :string, nil: true
+                  o.env_var Tracing::Configuration::Ext::ClientIp::ENV_HEADER_NAME
                 end
               end
 
@@ -414,7 +423,9 @@ module Datadog
               # @default `DD_TRACE_X_DATADOG_TAGS_MAX_LENGTH` environment variable, otherwise `512`
               # @return [Integer]
               option :x_datadog_tags_max_length do |o|
-                o.default { env_to_int(Tracing::Configuration::Ext::Distributed::ENV_X_DATADOG_TAGS_MAX_LENGTH, 512) }
+                o.type :int
+                o.env_var Tracing::Configuration::Ext::Distributed::ENV_X_DATADOG_TAGS_MAX_LENGTH
+                o.default 512
               end
 
               # Schema version for span attributes that enables various features
@@ -422,12 +433,9 @@ module Datadog
               # @default `DD_TRACE_SPAN_ATTRIBUTE_SCHEMA` environment variable, otherwise default `v0` currently
               # @return [String]
               option :span_attribute_schema do |o|
-                o.default do
-                  ENV.fetch(
-                    Tracing::Configuration::Ext::SpanAttributeSchema::ENV_SPAN_ATTRIBUTE_SCHEMA,
-                    Tracing::Configuration::Ext::SpanAttributeSchema::DEFAULT_VERSION
-                  )
-                end
+                o.type :string
+                o.env_var Tracing::Configuration::Ext::SpanAttributeSchema::ENV_SPAN_ATTRIBUTE_SCHEMA
+                o.default Tracing::Configuration::Ext::SpanAttributeSchema::DEFAULT_VERSION
               end
             end
           end

--- a/lib/datadog/tracing/contrib/action_cable/configuration/settings.rb
+++ b/lib/datadog/tracing/contrib/action_cable/configuration/settings.rb
@@ -12,15 +12,21 @@ module Datadog
           # @public_api
           class Settings < Contrib::Configuration::Settings
             option :enabled do |o|
-              o.default { env_to_bool(Ext::ENV_ENABLED, true) }
+              o.type :bool
+              o.env_var Ext::ENV_ENABLED
+              o.default true
             end
 
             option :analytics_enabled do |o|
-              o.default { env_to_bool(Ext::ENV_ANALYTICS_ENABLED, false) }
+              o.type :bool
+              o.env_var Ext::ENV_ANALYTICS_ENABLED
+              o.default false
             end
 
             option :analytics_sample_rate do |o|
-              o.default { env_to_float(Ext::ENV_ANALYTICS_SAMPLE_RATE, 1.0) }
+              o.type :float
+              o.env_var Ext::ENV_ANALYTICS_SAMPLE_RATE
+              o.default 1.0
             end
 
             option :service_name

--- a/lib/datadog/tracing/contrib/action_mailer/configuration/settings.rb
+++ b/lib/datadog/tracing/contrib/action_mailer/configuration/settings.rb
@@ -12,15 +12,21 @@ module Datadog
           # @public_api
           class Settings < Contrib::Configuration::Settings
             option :enabled do |o|
-              o.default { env_to_bool(Ext::ENV_ENABLED, true) }
+              o.type :bool
+              o.env_var Ext::ENV_ENABLED
+              o.default true
             end
 
             option :analytics_enabled do |o|
-              o.default { env_to_bool(Ext::ENV_ANALYTICS_ENABLED, false) }
+              o.type :bool
+              o.env_var Ext::ENV_ANALYTICS_ENABLED
+              o.default false
             end
 
             option :analytics_sample_rate do |o|
-              o.default { env_to_float(Ext::ENV_ANALYTICS_SAMPLE_RATE, 1.0) }
+              o.type :float
+              o.env_var Ext::ENV_ANALYTICS_SAMPLE_RATE
+              o.default 1.0
             end
 
             option :service_name

--- a/lib/datadog/tracing/contrib/action_pack/configuration/settings.rb
+++ b/lib/datadog/tracing/contrib/action_pack/configuration/settings.rb
@@ -12,15 +12,20 @@ module Datadog
           # @public_api
           class Settings < Contrib::Configuration::Settings
             option :enabled do |o|
-              o.default { env_to_bool(Ext::ENV_ENABLED, true) }
+              o.type :bool
+              o.env_var Ext::ENV_ENABLED
+              o.default true
             end
 
             option :analytics_enabled do |o|
-              o.default { env_to_bool(Ext::ENV_ANALYTICS_ENABLED, nil) }
+              o.type :bool, nil: true
+              o.env_var Ext::ENV_ANALYTICS_ENABLED
             end
 
             option :analytics_sample_rate do |o|
-              o.default { env_to_float(Ext::ENV_ANALYTICS_SAMPLE_RATE, 1.0) }
+              o.type :float
+              o.env_var Ext::ENV_ANALYTICS_SAMPLE_RATE
+              o.default 1.0
             end
 
             # DEV-2.0: Breaking changes for removal.

--- a/lib/datadog/tracing/contrib/action_view/configuration/settings.rb
+++ b/lib/datadog/tracing/contrib/action_view/configuration/settings.rb
@@ -10,15 +10,21 @@ module Datadog
           # @public_api
           class Settings < Contrib::Configuration::Settings
             option :enabled do |o|
-              o.default { env_to_bool(Ext::ENV_ENABLED, true) }
+              o.type :bool
+              o.env_var Ext::ENV_ENABLED
+              o.default true
             end
 
             option :analytics_enabled do |o|
-              o.default { env_to_bool(Ext::ENV_ANALYTICS_ENABLED, false) }
+              o.type :bool
+              o.env_var Ext::ENV_ANALYTICS_ENABLED
+              o.default false
             end
 
             option :analytics_sample_rate do |o|
-              o.default { env_to_float(Ext::ENV_ANALYTICS_SAMPLE_RATE, 1.0) }
+              o.type :float
+              o.env_var Ext::ENV_ANALYTICS_SAMPLE_RATE
+              o.default 1.0
             end
 
             option :service_name

--- a/lib/datadog/tracing/contrib/active_job/configuration/settings.rb
+++ b/lib/datadog/tracing/contrib/active_job/configuration/settings.rb
@@ -13,19 +13,25 @@ module Datadog
           # @public_api
           class Settings < Contrib::Configuration::Settings
             option :enabled do |o|
-              o.default { env_to_bool(Ext::ENV_ENABLED, true) }
+              o.type :bool
+              o.env_var Ext::ENV_ENABLED
+              o.default true
             end
 
             option :analytics_enabled do |o|
-              o.default { env_to_bool(Ext::ENV_ANALYTICS_ENABLED, false) }
+              o.type :bool
+              o.env_var Ext::ENV_ANALYTICS_ENABLED
+              o.default false
             end
 
             option :analytics_sample_rate do |o|
-              o.default { env_to_float(Ext::ENV_ANALYTICS_SAMPLE_RATE, 1.0) }
+              o.type :float
+              o.env_var Ext::ENV_ANALYTICS_SAMPLE_RATE
+              o.default 1.0
             end
 
             option :service_name
-            option :error_handler, experimental_default_proc: Tracing::SpanOperation::Events::DEFAULT_ON_ERROR
+            option :error_handler, type: :proc, experimental_default_proc: Tracing::SpanOperation::Events::DEFAULT_ON_ERROR
           end
         end
       end

--- a/lib/datadog/tracing/contrib/active_model_serializers/configuration/settings.rb
+++ b/lib/datadog/tracing/contrib/active_model_serializers/configuration/settings.rb
@@ -12,15 +12,21 @@ module Datadog
           # @public_api
           class Settings < Contrib::Configuration::Settings
             option :enabled do |o|
-              o.default { env_to_bool(Ext::ENV_ENABLED, true) }
+              o.type :bool
+              o.env_var Ext::ENV_ENABLED
+              o.default true
             end
 
             option :analytics_enabled do |o|
-              o.default { env_to_bool(Ext::ENV_ANALYTICS_ENABLED, false) }
+              o.type :bool
+              o.env_var Ext::ENV_ANALYTICS_ENABLED
+              o.default false
             end
 
             option :analytics_sample_rate do |o|
-              o.default { env_to_float(Ext::ENV_ANALYTICS_SAMPLE_RATE, 1.0) }
+              o.type :float
+              o.env_var Ext::ENV_ANALYTICS_SAMPLE_RATE
+              o.default 1.0
             end
           end
         end

--- a/lib/datadog/tracing/contrib/active_record/configuration/settings.rb
+++ b/lib/datadog/tracing/contrib/active_record/configuration/settings.rb
@@ -13,21 +13,26 @@ module Datadog
           # @public_api
           class Settings < Contrib::Configuration::Settings
             option :enabled do |o|
-              o.default { env_to_bool(Ext::ENV_ENABLED, true) }
+              o.type :bool
+              o.env_var Ext::ENV_ENABLED
+              o.default true
             end
 
             option :analytics_enabled do |o|
-              o.default { env_to_bool(Ext::ENV_ANALYTICS_ENABLED, false) }
+              o.type :bool
+              o.env_var Ext::ENV_ANALYTICS_ENABLED
+              o.default false
             end
 
             option :analytics_sample_rate do |o|
-              o.default { env_to_float(Ext::ENV_ANALYTICS_SAMPLE_RATE, 1.0) }
+              o.type :float
+              o.env_var Ext::ENV_ANALYTICS_SAMPLE_RATE
+              o.default 1.0
             end
 
             option :service_name do |o|
               o.default do
                 Contrib::SpanAttributeSchema.fetch_service_name(
-                  '',
                   Utils.adapter_name
                 )
               end

--- a/lib/datadog/tracing/contrib/active_support/configuration/settings.rb
+++ b/lib/datadog/tracing/contrib/active_support/configuration/settings.rb
@@ -12,21 +12,26 @@ module Datadog
           # @public_api
           class Settings < Contrib::Configuration::Settings
             option :enabled do |o|
-              o.default { env_to_bool(Ext::ENV_ENABLED, true) }
+              o.type :bool
+              o.env_var Ext::ENV_ENABLED
+              o.default true
             end
 
             option :analytics_enabled do |o|
-              o.default { env_to_bool(Ext::ENV_ANALYTICS_ENABLED, false) }
+              o.type :bool
+              o.env_var Ext::ENV_ANALYTICS_ENABLED
+              o.default false
             end
 
             option :analytics_sample_rate do |o|
-              o.default { env_to_float(Ext::ENV_ANALYTICS_SAMPLE_RATE, 1.0) }
+              o.type :float
+              o.env_var Ext::ENV_ANALYTICS_SAMPLE_RATE
+              o.default 1.0
             end
 
             option :cache_service do |o|
               o.default do
                 Contrib::SpanAttributeSchema.fetch_service_name(
-                  '',
                   Ext::SERVICE_CACHE
                 )
               end

--- a/lib/datadog/tracing/contrib/aws/configuration/settings.rb
+++ b/lib/datadog/tracing/contrib/aws/configuration/settings.rb
@@ -13,21 +13,29 @@ module Datadog
           # @public_api
           class Settings < Contrib::Configuration::Settings
             option :enabled do |o|
-              o.default { env_to_bool(Ext::ENV_ENABLED, true) }
+              o.type :bool
+              o.env_var Ext::ENV_ENABLED
+              o.default true
             end
 
             option :analytics_enabled do |o|
-              o.default { env_to_bool(Ext::ENV_ANALYTICS_ENABLED, false) }
+              o.type :bool
+              o.env_var Ext::ENV_ANALYTICS_ENABLED
+              o.default false
             end
 
             option :analytics_sample_rate do |o|
-              o.default { env_to_float(Ext::ENV_ANALYTICS_SAMPLE_RATE, 1.0) }
+              o.type :float
+              o.env_var Ext::ENV_ANALYTICS_SAMPLE_RATE
+              o.default 1.0
             end
 
             option :service_name do |o|
-              o.default do
+              o.type :string, nil: true
+              o.env_var Ext::ENV_SERVICE_NAME
+              o.setter do |value|
                 Contrib::SpanAttributeSchema.fetch_service_name(
-                  Ext::ENV_SERVICE_NAME,
+                  value,
                   Ext::DEFAULT_PEER_SERVICE_NAME
                 )
               end

--- a/lib/datadog/tracing/contrib/concurrent_ruby/configuration/settings.rb
+++ b/lib/datadog/tracing/contrib/concurrent_ruby/configuration/settings.rb
@@ -12,7 +12,9 @@ module Datadog
           # @public_api
           class Settings < Contrib::Configuration::Settings
             option :enabled do |o|
-              o.default { env_to_bool(Ext::ENV_ENABLED, true) }
+              o.type :bool
+              o.env_var Ext::ENV_ENABLED
+              o.default true
             end
           end
         end

--- a/lib/datadog/tracing/contrib/dalli/configuration/settings.rb
+++ b/lib/datadog/tracing/contrib/dalli/configuration/settings.rb
@@ -12,21 +12,29 @@ module Datadog
           # @public_api
           class Settings < Contrib::Configuration::Settings
             option :enabled do |o|
-              o.default { env_to_bool(Ext::ENV_ENABLED, true) }
+              o.type :bool
+              o.env_var Ext::ENV_ENABLED
+              o.default true
             end
 
             option :analytics_enabled do |o|
-              o.default { env_to_bool(Ext::ENV_ANALYTICS_ENABLED, false) }
+              o.type :bool
+              o.env_var Ext::ENV_ANALYTICS_ENABLED
+              o.default false
             end
 
             option :analytics_sample_rate do |o|
-              o.default { env_to_float(Ext::ENV_ANALYTICS_SAMPLE_RATE, 1.0) }
+              o.type :float
+              o.env_var Ext::ENV_ANALYTICS_SAMPLE_RATE
+              o.default 1.0
             end
 
             option :service_name do |o|
-              o.default do
+              o.type :string, nil: true
+              o.env_var Ext::ENV_SERVICE_NAME
+              o.setter do |value|
                 Contrib::SpanAttributeSchema.fetch_service_name(
-                  Ext::ENV_SERVICE_NAME,
+                  value,
                   Ext::DEFAULT_PEER_SERVICE_NAME
                 )
               end

--- a/lib/datadog/tracing/contrib/delayed_job/configuration/settings.rb
+++ b/lib/datadog/tracing/contrib/delayed_job/configuration/settings.rb
@@ -13,20 +13,26 @@ module Datadog
           # @public_api
           class Settings < Contrib::Configuration::Settings
             option :enabled do |o|
-              o.default { env_to_bool(Ext::ENV_ENABLED, true) }
+              o.type :bool
+              o.env_var Ext::ENV_ENABLED
+              o.default true
             end
 
             option :analytics_enabled do |o|
-              o.default { env_to_bool(Ext::ENV_ANALYTICS_ENABLED, false) }
+              o.type :bool
+              o.env_var Ext::ENV_ANALYTICS_ENABLED
+              o.default false
             end
 
             option :analytics_sample_rate do |o|
-              o.default { env_to_float(Ext::ENV_ANALYTICS_SAMPLE_RATE, 1.0) }
+              o.type :float
+              o.env_var Ext::ENV_ANALYTICS_SAMPLE_RATE
+              o.default 1.0
             end
 
             option :service_name
             option :client_service_name
-            option :error_handler, experimental_default_proc: Tracing::SpanOperation::Events::DEFAULT_ON_ERROR
+            option :error_handler, type: :proc, experimental_default_proc: Tracing::SpanOperation::Events::DEFAULT_ON_ERROR
           end
         end
       end

--- a/lib/datadog/tracing/contrib/elasticsearch/configuration/settings.rb
+++ b/lib/datadog/tracing/contrib/elasticsearch/configuration/settings.rb
@@ -12,23 +12,31 @@ module Datadog
           # @public_api
           class Settings < Contrib::Configuration::Settings
             option :enabled do |o|
-              o.default { env_to_bool(Ext::ENV_ENABLED, true) }
+              o.type :bool
+              o.env_var Ext::ENV_ENABLED
+              o.default true
             end
 
             option :analytics_enabled do |o|
-              o.default { env_to_bool(Ext::ENV_ANALYTICS_ENABLED, false) }
+              o.type :bool
+              o.env_var Ext::ENV_ANALYTICS_ENABLED
+              o.default false
             end
 
             option :analytics_sample_rate do |o|
-              o.default { env_to_float(Ext::ENV_ANALYTICS_SAMPLE_RATE, 1.0) }
+              o.type :float
+              o.env_var Ext::ENV_ANALYTICS_SAMPLE_RATE
+              o.default 1.0
             end
 
             option :quantize, default: {}
 
             option :service_name do |o|
-              o.default do
+              o.type :string, nil: true
+              o.env_var Ext::ENV_SERVICE_NAME
+              o.setter do |value|
                 Contrib::SpanAttributeSchema.fetch_service_name(
-                  Ext::ENV_SERVICE_NAME,
+                  value,
                   Ext::DEFAULT_PEER_SERVICE_NAME
                 )
               end

--- a/lib/datadog/tracing/contrib/ethon/configuration/settings.rb
+++ b/lib/datadog/tracing/contrib/ethon/configuration/settings.rb
@@ -12,25 +12,33 @@ module Datadog
           # @public_api
           class Settings < Contrib::Configuration::Settings
             option :enabled do |o|
-              o.default { env_to_bool(Ext::ENV_ENABLED, true) }
+              o.type :bool
+              o.env_var Ext::ENV_ENABLED
+              o.default true
             end
 
             option :analytics_enabled do |o|
-              o.default { env_to_bool(Ext::ENV_ANALYTICS_ENABLED, false) }
+              o.type :bool
+              o.env_var Ext::ENV_ANALYTICS_ENABLED
+              o.default false
             end
 
             option :analytics_sample_rate do |o|
-              o.default { env_to_float(Ext::ENV_ANALYTICS_SAMPLE_RATE, 1.0) }
+              o.type :float
+              o.env_var Ext::ENV_ANALYTICS_SAMPLE_RATE
+              o.default 1.0
             end
 
-            option :distributed_tracing, default: true
+            option :distributed_tracing, default: true, type: :bool
 
-            option :split_by_domain, default: false
+            option :split_by_domain, default: false, type: :bool
 
             option :service_name do |o|
-              o.default do
+              o.type :string, nil: true
+              o.env_var Ext::ENV_SERVICE_NAME
+              o.setter do |value|
                 Contrib::SpanAttributeSchema.fetch_service_name(
-                  Ext::ENV_SERVICE_NAME,
+                  value,
                   Ext::DEFAULT_PEER_SERVICE_NAME
                 )
               end

--- a/lib/datadog/tracing/contrib/excon/configuration/settings.rb
+++ b/lib/datadog/tracing/contrib/excon/configuration/settings.rb
@@ -12,25 +12,35 @@ module Datadog
           # @public_api
           class Settings < Contrib::Configuration::Settings
             option :enabled do |o|
-              o.default { env_to_bool(Ext::ENV_ENABLED, true) }
+              o.type :bool
+              o.env_var Ext::ENV_ENABLED
+              o.default true
             end
 
             option :analytics_enabled do |o|
-              o.default { env_to_bool(Ext::ENV_ANALYTICS_ENABLED, false) }
+              o.type :bool
+              o.env_var Ext::ENV_ANALYTICS_ENABLED
+              o.default false
             end
 
             option :analytics_sample_rate do |o|
-              o.default { env_to_float(Ext::ENV_ANALYTICS_SAMPLE_RATE, 1.0) }
+              o.type :float
+              o.env_var Ext::ENV_ANALYTICS_SAMPLE_RATE
+              o.default 1.0
             end
 
-            option :distributed_tracing, default: true
-            option :error_handler
-            option :split_by_domain, default: false
+            option :distributed_tracing, default: true, type: :bool
+            option :error_handler do |o|
+              o.type :proc, nil: true
+            end
+            option :split_by_domain, default: false, type: :bool
 
             option :service_name do |o|
-              o.default do
+              o.type :string, nil: true
+              o.env_var Ext::ENV_SERVICE_NAME
+              o.setter do |value|
                 Contrib::SpanAttributeSchema.fetch_service_name(
-                  Ext::ENV_SERVICE_NAME,
+                  value,
                   Ext::DEFAULT_PEER_SERVICE_NAME
                 )
               end

--- a/lib/datadog/tracing/contrib/extensions.rb
+++ b/lib/datadog/tracing/contrib/extensions.rb
@@ -122,7 +122,6 @@ module Datadog
             # @return [Datadog::Tracing::Contrib::Integration]
             def instrument(integration_name, options = {}, &block)
               integration = fetch_integration(integration_name)
-
               unless integration.nil? || !integration.default_configuration.enabled
                 configuration_name = options[:describes] || :default
                 filtered_options = options.reject { |k, _v| k == :describes }

--- a/lib/datadog/tracing/contrib/faraday/configuration/settings.rb
+++ b/lib/datadog/tracing/contrib/faraday/configuration/settings.rb
@@ -16,25 +16,33 @@ module Datadog
             end
 
             option :enabled do |o|
-              o.default { env_to_bool(Ext::ENV_ENABLED, true) }
+              o.type :bool
+              o.env_var Ext::ENV_ENABLED
+              o.default true
             end
 
             option :analytics_enabled do |o|
-              o.default { env_to_bool(Ext::ENV_ANALYTICS_ENABLED, false) }
+              o.type :bool
+              o.env_var Ext::ENV_ANALYTICS_ENABLED
+              o.default false
             end
 
             option :analytics_sample_rate do |o|
-              o.default { env_to_float(Ext::ENV_ANALYTICS_SAMPLE_RATE, 1.0) }
+              o.type :float
+              o.env_var Ext::ENV_ANALYTICS_SAMPLE_RATE
+              o.default 1.0
             end
 
-            option :distributed_tracing, default: true
-            option :error_handler, experimental_default_proc: DEFAULT_ERROR_HANDLER
-            option :split_by_domain, default: false
+            option :distributed_tracing, default: true, type: :bool
+            option :error_handler, type: :proc, experimental_default_proc: DEFAULT_ERROR_HANDLER
+            option :split_by_domain, default: false, type: :bool
 
             option :service_name do |o|
-              o.default do
+              o.type :string, nil: true
+              o.env_var Ext::ENV_SERVICE_NAME
+              o.setter do |value|
                 Contrib::SpanAttributeSchema.fetch_service_name(
-                  Ext::ENV_SERVICE_NAME,
+                  value,
                   Ext::DEFAULT_PEER_SERVICE_NAME
                 )
               end

--- a/lib/datadog/tracing/contrib/faraday/middleware.rb
+++ b/lib/datadog/tracing/contrib/faraday/middleware.rb
@@ -64,7 +64,9 @@ module Datadog
           end
 
           def handle_response(span, env, options)
-            span.set_error(["Error #{env[:status]}", env[:body]]) if options.fetch(:error_handler).call(env)
+            if options[:error_handler] && options[:error_handler].call(env)
+              span.set_error(["Error #{env[:status]}", env[:body]])
+            end
 
             span.set_tag(Tracing::Metadata::Ext::HTTP::TAG_STATUS_CODE, env[:status])
           end

--- a/lib/datadog/tracing/contrib/grape/configuration/settings.rb
+++ b/lib/datadog/tracing/contrib/grape/configuration/settings.rb
@@ -13,15 +13,20 @@ module Datadog
           # @public_api
           class Settings < Contrib::Configuration::Settings
             option :enabled do |o|
-              o.default { env_to_bool(Ext::ENV_ENABLED, true) }
+              o.type :bool
+              o.env_var Ext::ENV_ENABLED
+              o.default true
             end
 
             option :analytics_enabled do |o|
-              o.default { env_to_bool(Ext::ENV_ANALYTICS_ENABLED, nil) }
+              o.type :bool, nil: true
+              o.env_var Ext::ENV_ANALYTICS_ENABLED
             end
 
             option :analytics_sample_rate do |o|
-              o.default { env_to_float(Ext::ENV_ANALYTICS_SAMPLE_RATE, 1.0) }
+              o.type :float
+              o.env_var Ext::ENV_ANALYTICS_SAMPLE_RATE
+              o.default 1.0
             end
 
             option :service_name

--- a/lib/datadog/tracing/contrib/graphql/configuration/settings.rb
+++ b/lib/datadog/tracing/contrib/graphql/configuration/settings.rb
@@ -12,15 +12,20 @@ module Datadog
           # @public_api
           class Settings < Contrib::Configuration::Settings
             option :enabled do |o|
-              o.default { env_to_bool(Ext::ENV_ENABLED, true) }
+              o.type :bool
+              o.env_var Ext::ENV_ENABLED
+              o.default true
             end
 
             option :analytics_enabled do |o|
-              o.default { env_to_bool(Ext::ENV_ANALYTICS_ENABLED, nil) }
+              o.type :bool, nil: true
+              o.env_var Ext::ENV_ANALYTICS_ENABLED
             end
 
             option :analytics_sample_rate do |o|
-              o.default { env_to_float(Ext::ENV_ANALYTICS_SAMPLE_RATE, 1.0) }
+              o.type :float
+              o.env_var Ext::ENV_ANALYTICS_SAMPLE_RATE
+              o.default 1.0
             end
 
             option :schemas

--- a/lib/datadog/tracing/contrib/grpc/configuration/settings.rb
+++ b/lib/datadog/tracing/contrib/grpc/configuration/settings.rb
@@ -13,29 +13,37 @@ module Datadog
           # @public_api
           class Settings < Contrib::Configuration::Settings
             option :enabled do |o|
-              o.default { env_to_bool(Ext::ENV_ENABLED, true) }
+              o.type :bool
+              o.env_var Ext::ENV_ENABLED
+              o.default true
             end
 
             option :analytics_enabled do |o|
-              o.default { env_to_bool(Ext::ENV_ANALYTICS_ENABLED, false) }
+              o.type :bool
+              o.env_var Ext::ENV_ANALYTICS_ENABLED
+              o.default false
             end
 
             option :analytics_sample_rate do |o|
-              o.default { env_to_float(Ext::ENV_ANALYTICS_SAMPLE_RATE, 1.0) }
+              o.type :float
+              o.env_var Ext::ENV_ANALYTICS_SAMPLE_RATE
+              o.default 1.0
             end
 
-            option :distributed_tracing, default: true
+            option :distributed_tracing, default: true, type: :bool
 
             option :service_name do |o|
-              o.default do
+              o.type :string, nil: true
+              o.env_var Ext::ENV_SERVICE_NAME
+              o.setter do |value|
                 Contrib::SpanAttributeSchema.fetch_service_name(
-                  Ext::ENV_SERVICE_NAME,
+                  value,
                   Ext::DEFAULT_PEER_SERVICE_NAME
                 )
               end
             end
 
-            option :error_handler, experimental_default_proc: Tracing::SpanOperation::Events::DEFAULT_ON_ERROR
+            option :error_handler, type: :proc, experimental_default_proc: Tracing::SpanOperation::Events::DEFAULT_ON_ERROR
           end
         end
       end

--- a/lib/datadog/tracing/contrib/hanami/configuration/settings.rb
+++ b/lib/datadog/tracing/contrib/hanami/configuration/settings.rb
@@ -11,7 +11,9 @@ module Datadog
           # Configuration for Hanami instrumentation
           class Settings < Contrib::Configuration::Settings
             option :enabled do |o|
-              o.default { env_to_bool(Ext::ENV_ENABLED, true) }
+              o.type :bool
+              o.env_var Ext::ENV_ENABLED
+              o.default true
             end
           end
         end

--- a/lib/datadog/tracing/contrib/http/configuration/settings.rb
+++ b/lib/datadog/tracing/contrib/http/configuration/settings.rb
@@ -12,33 +12,43 @@ module Datadog
           # @public_api
           class Settings < Contrib::Configuration::Settings
             option :enabled do |o|
-              o.default { env_to_bool(Ext::ENV_ENABLED, true) }
+              o.type :bool
+              o.env_var Ext::ENV_ENABLED
+              o.default true
             end
 
             option :analytics_enabled do |o|
-              o.default { env_to_bool(Ext::ENV_ANALYTICS_ENABLED, false) }
+              o.type :bool
+              o.env_var Ext::ENV_ANALYTICS_ENABLED
+              o.default false
             end
 
             option :analytics_sample_rate do |o|
-              o.default { env_to_float(Ext::ENV_ANALYTICS_SAMPLE_RATE, 1.0) }
+              o.type :float
+              o.env_var Ext::ENV_ANALYTICS_SAMPLE_RATE
+              o.default 1.0
             end
 
-            option :distributed_tracing, default: true
+            option :distributed_tracing, default: true, type: :bool
 
             option :service_name do |o|
-              o.default do
+              o.type :string, nil: true
+              o.env_var Ext::ENV_SERVICE_NAME
+              o.setter do |value|
                 Contrib::SpanAttributeSchema.fetch_service_name(
-                  Ext::ENV_SERVICE_NAME,
+                  value,
                   Ext::DEFAULT_PEER_SERVICE_NAME
                 )
               end
             end
 
             option :error_status_codes do |o|
-              o.default { env_to_list(Ext::ENV_ERROR_STATUS_CODES, 400...600, comma_separated_only: false) }
+              o.type :array
+              o.env_var Ext::ENV_ERROR_STATUS_CODES
+              o.default Array(400...600)
             end
 
-            option :split_by_domain, default: false
+            option :split_by_domain, default: false, type: :bool
           end
         end
       end

--- a/lib/datadog/tracing/contrib/httpclient/configuration/settings.rb
+++ b/lib/datadog/tracing/contrib/httpclient/configuration/settings.rb
@@ -12,33 +12,43 @@ module Datadog
           # @public_api
           class Settings < Contrib::Configuration::Settings
             option :enabled do |o|
-              o.default { env_to_bool(Ext::ENV_ENABLED, true) }
+              o.type :bool
+              o.env_var Ext::ENV_ENABLED
+              o.default true
             end
 
             option :analytics_enabled do |o|
-              o.default { env_to_bool(Ext::ENV_ANALYTICS_ENABLED, false) }
+              o.type :bool
+              o.env_var Ext::ENV_ANALYTICS_ENABLED
+              o.default false
             end
 
             option :analytics_sample_rate do |o|
-              o.default { env_to_float(Ext::ENV_ANALYTICS_SAMPLE_RATE, 1.0) }
+              o.type :float
+              o.env_var Ext::ENV_ANALYTICS_SAMPLE_RATE
+              o.default 1.0
             end
 
-            option :distributed_tracing, default: true
+            option :distributed_tracing, default: true, type: :bool
 
             option :service_name do |o|
-              o.default do
+              o.type :string, nil: true
+              o.env_var Ext::ENV_SERVICE_NAME
+              o.setter do |value|
                 Contrib::SpanAttributeSchema.fetch_service_name(
-                  Ext::ENV_SERVICE_NAME,
+                  value,
                   Ext::DEFAULT_PEER_SERVICE_NAME
                 )
               end
             end
 
             option :error_status_codes do |o|
-              o.default { env_to_list(Ext::ENV_ERROR_STATUS_CODES, 400...600, comma_separated_only: false) }
+              o.type :array
+              o.env_var Ext::ENV_ERROR_STATUS_CODES
+              o.default Array(400...600)
             end
 
-            option :split_by_domain, default: false
+            option :split_by_domain, default: false, type: :bool
           end
         end
       end

--- a/lib/datadog/tracing/contrib/httprb/configuration/settings.rb
+++ b/lib/datadog/tracing/contrib/httprb/configuration/settings.rb
@@ -12,33 +12,43 @@ module Datadog
           # @public_api
           class Settings < Contrib::Configuration::Settings
             option :enabled do |o|
-              o.default { env_to_bool(Ext::ENV_ENABLED, true) }
+              o.type :bool
+              o.env_var Ext::ENV_ENABLED
+              o.default true
             end
 
             option :analytics_enabled do |o|
-              o.default { env_to_bool(Ext::ENV_ANALYTICS_ENABLED, false) }
+              o.type :bool
+              o.env_var Ext::ENV_ANALYTICS_ENABLED
+              o.default false
             end
 
             option :analytics_sample_rate do |o|
-              o.default { env_to_float(Ext::ENV_ANALYTICS_SAMPLE_RATE, 1.0) }
+              o.type :float
+              o.env_var Ext::ENV_ANALYTICS_SAMPLE_RATE
+              o.default 1.0
             end
 
-            option :distributed_tracing, default: true
+            option :distributed_tracing, default: true, type: :bool
 
             option :service_name do |o|
-              o.default do
+              o.type :string, nil: true
+              o.env_var Ext::ENV_SERVICE_NAME
+              o.setter do |value|
                 Contrib::SpanAttributeSchema.fetch_service_name(
-                  Ext::ENV_SERVICE_NAME,
+                  value,
                   Ext::DEFAULT_PEER_SERVICE_NAME
                 )
               end
             end
 
             option :error_status_codes do |o|
-              o.default { env_to_list(Ext::ENV_ERROR_STATUS_CODES, 400...600, comma_separated_only: false) }
+              o.type :array
+              o.env_var Ext::ENV_ERROR_STATUS_CODES
+              o.default Array(400...600)
             end
 
-            option :split_by_domain, default: false
+            option :split_by_domain, default: false, type: :bool
           end
         end
       end

--- a/lib/datadog/tracing/contrib/kafka/configuration/settings.rb
+++ b/lib/datadog/tracing/contrib/kafka/configuration/settings.rb
@@ -12,15 +12,21 @@ module Datadog
           # @public_api
           class Settings < Contrib::Configuration::Settings
             option :enabled do |o|
-              o.default { env_to_bool(Ext::ENV_ENABLED, true) }
+              o.type :bool
+              o.env_var Ext::ENV_ENABLED
+              o.default true
             end
 
             option :analytics_enabled do |o|
-              o.default { env_to_bool(Ext::ENV_ANALYTICS_ENABLED, false) }
+              o.type :bool
+              o.env_var Ext::ENV_ANALYTICS_ENABLED
+              o.default false
             end
 
             option :analytics_sample_rate do |o|
-              o.default { env_to_float(Ext::ENV_ANALYTICS_SAMPLE_RATE, 1.0) }
+              o.type :float
+              o.env_var Ext::ENV_ANALYTICS_SAMPLE_RATE
+              o.default 1.0
             end
 
             option :service_name

--- a/lib/datadog/tracing/contrib/lograge/configuration/settings.rb
+++ b/lib/datadog/tracing/contrib/lograge/configuration/settings.rb
@@ -12,7 +12,9 @@ module Datadog
           # @public_api
           class Settings < Contrib::Configuration::Settings
             option :enabled do |o|
-              o.default { env_to_bool(Ext::ENV_ENABLED, true) }
+              o.type :bool
+              o.env_var Ext::ENV_ENABLED
+              o.default true
             end
           end
         end

--- a/lib/datadog/tracing/contrib/mongodb/configuration/settings.rb
+++ b/lib/datadog/tracing/contrib/mongodb/configuration/settings.rb
@@ -14,23 +14,31 @@ module Datadog
             DEFAULT_QUANTIZE = { show: [:collection, :database, :operation] }.freeze
 
             option :enabled do |o|
-              o.default { env_to_bool(Ext::ENV_ENABLED, true) }
+              o.type :bool
+              o.env_var Ext::ENV_ENABLED
+              o.default true
             end
 
             option :analytics_enabled do |o|
-              o.default { env_to_bool(Ext::ENV_ANALYTICS_ENABLED, false) }
+              o.type :bool
+              o.env_var Ext::ENV_ANALYTICS_ENABLED
+              o.default false
             end
 
             option :analytics_sample_rate do |o|
-              o.default { env_to_float(Ext::ENV_ANALYTICS_SAMPLE_RATE, 1.0) }
+              o.type :float
+              o.env_var Ext::ENV_ANALYTICS_SAMPLE_RATE
+              o.default 1.0
             end
 
             option :quantize, default: DEFAULT_QUANTIZE
 
             option :service_name do |o|
-              o.default do
+              o.type :string, nil: true
+              o.env_var Ext::ENV_SERVICE_NAME
+              o.setter do |value|
                 Contrib::SpanAttributeSchema.fetch_service_name(
-                  Ext::ENV_SERVICE_NAME,
+                  value,
                   Ext::DEFAULT_PEER_SERVICE_NAME
                 )
               end

--- a/lib/datadog/tracing/contrib/mysql2/configuration/settings.rb
+++ b/lib/datadog/tracing/contrib/mysql2/configuration/settings.rb
@@ -14,33 +14,38 @@ module Datadog
           # @public_api
           class Settings < Contrib::Configuration::Settings
             option :enabled do |o|
-              o.default { env_to_bool(Ext::ENV_ENABLED, true) }
+              o.type :bool
+              o.env_var Ext::ENV_ENABLED
+              o.default true
             end
 
             option :analytics_enabled do |o|
-              o.default { env_to_bool(Ext::ENV_ANALYTICS_ENABLED, false) }
+              o.type :bool
+              o.env_var Ext::ENV_ANALYTICS_ENABLED
+              o.default false
             end
 
             option :analytics_sample_rate do |o|
-              o.default { env_to_float(Ext::ENV_ANALYTICS_SAMPLE_RATE, 1.0) }
+              o.type :float
+              o.env_var Ext::ENV_ANALYTICS_SAMPLE_RATE
+              o.default 1.0
             end
 
             option :service_name do |o|
-              o.default do
+              o.type :string, nil: true
+              o.env_var Ext::ENV_SERVICE_NAME
+              o.setter do |value|
                 Contrib::SpanAttributeSchema.fetch_service_name(
-                  Ext::ENV_SERVICE_NAME,
+                  value,
                   Ext::DEFAULT_PEER_SERVICE_NAME
                 )
               end
             end
 
             option :comment_propagation do |o|
-              o.default do
-                ENV.fetch(
-                  Contrib::Propagation::SqlComment::Ext::ENV_DBM_PROPAGATION_MODE,
-                  Contrib::Propagation::SqlComment::Ext::DISABLED
-                )
-              end
+              o.type :string
+              o.env_var Contrib::Propagation::SqlComment::Ext::ENV_DBM_PROPAGATION_MODE
+              o.default Contrib::Propagation::SqlComment::Ext::DISABLED
             end
           end
         end

--- a/lib/datadog/tracing/contrib/opensearch/configuration/settings.rb
+++ b/lib/datadog/tracing/contrib/opensearch/configuration/settings.rb
@@ -12,30 +12,34 @@ module Datadog
           # @public_api
           class Settings < Contrib::Configuration::Settings
             option :enabled do |o|
-              o.default { env_to_bool(Ext::ENV_ENABLED, true) }
-              o.lazy
+              o.type :bool
+              o.env_var Ext::ENV_ENABLED
+              o.default true
             end
 
             option :analytics_enabled do |o|
-              o.default { env_to_bool(Ext::ENV_ANALYTICS_ENABLED, false) }
-              o.lazy
+              o.type :bool
+              o.env_var Ext::ENV_ANALYTICS_ENABLED
+              o.default false
             end
 
             option :analytics_sample_rate do |o|
-              o.default { env_to_float(Ext::ENV_ANALYTICS_SAMPLE_RATE, 1.0) }
-              o.lazy
+              o.type :float
+              o.env_var Ext::ENV_ANALYTICS_SAMPLE_RATE
+              o.default 1.0
             end
 
             option :quantize, default: {}
 
             option :service_name do |o|
-              o.default do
+              o.type :string, nil: true
+              o.env_var Ext::ENV_SERVICE_NAME
+              o.setter do |value|
                 Contrib::SpanAttributeSchema.fetch_service_name(
-                  Ext::ENV_SERVICE_NAME,
+                  value,
                   Ext::DEFAULT_PEER_SERVICE_NAME
                 )
               end
-              o.lazy
             end
           end
         end

--- a/lib/datadog/tracing/contrib/pg/configuration/settings.rb
+++ b/lib/datadog/tracing/contrib/pg/configuration/settings.rb
@@ -14,33 +14,38 @@ module Datadog
           # @public_api
           class Settings < Contrib::Configuration::Settings
             option :enabled do |o|
-              o.default { env_to_bool(Ext::ENV_ENABLED, true) }
+              o.type :bool
+              o.env_var Ext::ENV_ENABLED
+              o.default true
             end
 
             option :analytics_enabled do |o|
-              o.default { env_to_bool(Ext::ENV_ANALYTICS_ENABLED, false) }
+              o.type :bool
+              o.env_var Ext::ENV_ANALYTICS_ENABLED
+              o.default false
             end
 
             option :analytics_sample_rate do |o|
-              o.default { env_to_float(Ext::ENV_ANALYTICS_SAMPLE_RATE, 1.0) }
+              o.type :float
+              o.env_var Ext::ENV_ANALYTICS_SAMPLE_RATE
+              o.default 1.0
             end
 
             option :service_name do |o|
-              o.default do
+              o.type :string, nil: true
+              o.env_var Ext::ENV_SERVICE_NAME
+              o.setter do |value|
                 Contrib::SpanAttributeSchema.fetch_service_name(
-                  Ext::ENV_SERVICE_NAME,
+                  value,
                   Ext::DEFAULT_PEER_SERVICE_NAME
                 )
               end
             end
 
             option :comment_propagation do |o|
-              o.default do
-                ENV.fetch(
-                  Contrib::Propagation::SqlComment::Ext::ENV_DBM_PROPAGATION_MODE,
-                  Contrib::Propagation::SqlComment::Ext::DISABLED
-                )
-              end
+              o.type :string
+              o.env_var Contrib::Propagation::SqlComment::Ext::ENV_DBM_PROPAGATION_MODE
+              o.default Contrib::Propagation::SqlComment::Ext::DISABLED
             end
           end
         end

--- a/lib/datadog/tracing/contrib/presto/configuration/settings.rb
+++ b/lib/datadog/tracing/contrib/presto/configuration/settings.rb
@@ -12,21 +12,29 @@ module Datadog
           # @public_api
           class Settings < Contrib::Configuration::Settings
             option :enabled do |o|
-              o.default { env_to_bool(Ext::ENV_ENABLED, true) }
+              o.type :bool
+              o.env_var Ext::ENV_ENABLED
+              o.default true
             end
 
             option :analytics_enabled do |o|
-              o.default { env_to_bool(Ext::ENV_ANALYTICS_ENABLED, false) }
+              o.type :bool
+              o.env_var Ext::ENV_ANALYTICS_ENABLED
+              o.default false
             end
 
             option :analytics_sample_rate do |o|
-              o.default { env_to_float(Ext::ENV_ANALYTICS_SAMPLE_RATE, 1.0) }
+              o.type :float
+              o.env_var Ext::ENV_ANALYTICS_SAMPLE_RATE
+              o.default 1.0
             end
 
             option :service_name do |o|
-              o.default do
+              o.type :string, nil: true
+              o.env_var Ext::ENV_SERVICE_NAME
+              o.setter do |value|
                 Contrib::SpanAttributeSchema.fetch_service_name(
-                  Ext::ENV_SERVICE_NAME,
+                  value,
                   Ext::DEFAULT_PEER_SERVICE_NAME
                 )
               end

--- a/lib/datadog/tracing/contrib/qless/configuration/settings.rb
+++ b/lib/datadog/tracing/contrib/qless/configuration/settings.rb
@@ -12,19 +12,27 @@ module Datadog
           # @public_api
           class Settings < Contrib::Configuration::Settings
             option :analytics_enabled do |o|
-              o.default { env_to_bool(Ext::ENV_ANALYTICS_ENABLED, false) }
+              o.type :bool
+              o.env_var Ext::ENV_ANALYTICS_ENABLED
+              o.default false
             end
 
             option :analytics_sample_rate do |o|
-              o.default { env_to_float(Ext::ENV_ANALYTICS_SAMPLE_RATE, 1.0) }
+              o.type :float
+              o.env_var Ext::ENV_ANALYTICS_SAMPLE_RATE
+              o.default 1.0
             end
 
             option :tag_job_data do |o|
-              o.default { env_to_bool(Ext::ENV_TAG_JOB_DATA, false) }
+              o.type :bool
+              o.env_var Ext::ENV_TAG_JOB_DATA
+              o.default false
             end
 
             option :tag_job_tags do |o|
-              o.default { env_to_bool(Ext::ENV_TAG_JOB_TAGS, false) }
+              o.type :bool
+              o.env_var Ext::ENV_TAG_JOB_TAGS
+              o.default false
             end
 
             option :service_name

--- a/lib/datadog/tracing/contrib/que/configuration/settings.rb
+++ b/lib/datadog/tracing/contrib/que/configuration/settings.rb
@@ -12,28 +12,39 @@ module Datadog
           # Default settings for the Que integration
           class Settings < Contrib::Configuration::Settings
             option :service_name
-            option :distributed_tracing, default: true
+            option :distributed_tracing, default: true, type: :bool
 
             option :enabled do |o|
-              o.default { env_to_bool(Ext::ENV_ENABLED, true) }
+              o.type :bool
+              o.env_var Ext::ENV_ENABLED
+              o.default true
             end
 
             option :analytics_enabled do |o|
-              o.default { env_to_bool(Ext::ENV_ANALYTICS_ENABLED, false) }
+              o.type :bool
+              o.env_var Ext::ENV_ANALYTICS_ENABLED
+              o.default false
             end
 
             option :analytics_sample_rate do |o|
-              o.default { env_to_float(Ext::ENV_ANALYTICS_SAMPLE_RATE, 1.0) }
+              o.type :float
+              o.env_var Ext::ENV_ANALYTICS_SAMPLE_RATE
+              o.default 1.0
             end
 
             option :tag_args do |o|
-              o.default { env_to_bool(Ext::ENV_TAG_ARGS_ENABLED, false) }
+              o.type :bool
+              o.env_var Ext::ENV_TAG_ARGS_ENABLED
+              o.default false
             end
 
             option :tag_data do |o|
-              o.default { env_to_bool(Ext::ENV_TAG_DATA_ENABLED, false) }
+              o.type :bool
+              o.env_var Ext::ENV_TAG_DATA_ENABLED
+              o.default false
             end
-            option :error_handler, experimental_default_proc: Tracing::SpanOperation::Events::DEFAULT_ON_ERROR
+
+            option :error_handler, type: :proc, experimental_default_proc: Tracing::SpanOperation::Events::DEFAULT_ON_ERROR
           end
         end
       end

--- a/lib/datadog/tracing/contrib/racecar/configuration/settings.rb
+++ b/lib/datadog/tracing/contrib/racecar/configuration/settings.rb
@@ -12,21 +12,28 @@ module Datadog
           # @public_api
           class Settings < Contrib::Configuration::Settings
             option :enabled do |o|
-              o.default { env_to_bool(Ext::ENV_ENABLED, true) }
+              o.type :bool
+              o.env_var Ext::ENV_ENABLED
+              o.default true
             end
 
             option :analytics_enabled do |o|
-              o.default { env_to_bool(Ext::ENV_ANALYTICS_ENABLED, false) }
+              o.type :bool
+              o.env_var Ext::ENV_ANALYTICS_ENABLED
+              o.default false
             end
 
             option :analytics_sample_rate do |o|
-              o.default { env_to_float(Ext::ENV_ANALYTICS_SAMPLE_RATE, 1.0) }
+              o.type :float
+              o.env_var Ext::ENV_ANALYTICS_SAMPLE_RATE
+              o.default 1.0
             end
 
             option :service_name do |o|
-              o.default do
+              o.type :string, nil: true
+              o.setter do |value|
                 Contrib::SpanAttributeSchema.fetch_service_name(
-                  '',
+                  value,
                   Ext::DEFAULT_PEER_SERVICE_NAME
                 )
               end

--- a/lib/datadog/tracing/contrib/rack/configuration/settings.rb
+++ b/lib/datadog/tracing/contrib/rack/configuration/settings.rb
@@ -17,27 +17,34 @@ module Datadog
             }.freeze
 
             option :enabled do |o|
-              o.default { env_to_bool(Ext::ENV_ENABLED, true) }
+              o.type :bool
+              o.env_var Ext::ENV_ENABLED
+              o.default true
             end
 
             option :analytics_enabled do |o|
-              o.default { env_to_bool(Ext::ENV_ANALYTICS_ENABLED, nil) }
+              o.type :bool, nil: true
+              o.env_var Ext::ENV_ANALYTICS_ENABLED
             end
 
             option :analytics_sample_rate do |o|
-              o.default { env_to_float(Ext::ENV_ANALYTICS_SAMPLE_RATE, 1.0) }
+              o.type :float
+              o.env_var Ext::ENV_ANALYTICS_SAMPLE_RATE
+              o.default 1.0
             end
 
             option :application
-            option :distributed_tracing, default: true
-            option :headers, default: DEFAULT_HEADERS
-            option :middleware_names, default: false
-            option :quantize, default: {}
-            option :request_queuing, default: false
+            option :distributed_tracing, default: true, type: :bool
+            option :headers, default: DEFAULT_HEADERS, type: :hash
+            option :middleware_names, default: false, type: :bool
+            option :quantize, default: {}, type: :hash
+            option :request_queuing do |o|
+              o.default false
+            end
 
             option :service_name
 
-            option :web_service_name, default: Ext::DEFAULT_PEER_WEBSERVER_SERVICE_NAME
+            option :web_service_name, default: Ext::DEFAULT_PEER_WEBSERVER_SERVICE_NAME, type: :string
           end
         end
       end

--- a/lib/datadog/tracing/contrib/rails/configuration/settings.rb
+++ b/lib/datadog/tracing/contrib/rails/configuration/settings.rb
@@ -24,30 +24,35 @@ module Datadog
             end
 
             option :enabled do |o|
-              o.default { env_to_bool(Ext::ENV_ENABLED, true) }
+              o.type :bool
+              o.env_var Ext::ENV_ENABLED
+              o.default true
             end
 
             option :analytics_enabled do |o|
-              o.default { env_to_bool(Ext::ENV_ANALYTICS_ENABLED, nil) }
-
+              o.type :bool, nil: true
+              o.env_var Ext::ENV_ANALYTICS_ENABLED
               o.on_set do |value|
                 # Update ActionPack analytics too
-                Datadog.configuration.tracing[:action_pack][:analytics_enabled] = value
+                Datadog.configuration.tracing[:action_pack][:analytics_enabled] = value unless value.nil?
               end
             end
 
             option :analytics_sample_rate do |o|
-              o.default { env_to_float(Ext::ENV_ANALYTICS_SAMPLE_RATE, 1.0) }
+              o.type :float
+              o.env_var Ext::ENV_ANALYTICS_SAMPLE_RATE
+              o.default 1.0
               o.on_set do |value|
                 # Update ActionPack analytics too
                 Datadog.configuration.tracing[:action_pack][:analytics_sample_rate] = value
               end
             end
 
-            option :distributed_tracing, default: true
+            option :distributed_tracing, default: true, type: :bool
 
-            option :request_queuing, default: false
-
+            option :request_queuing do |o|
+              o.default false
+            end
             # DEV-2.0: Breaking changes for removal.
             option :exception_controller do |o|
               o.on_set do |value|
@@ -60,9 +65,10 @@ module Datadog
               end
             end
 
-            option :middleware, default: true
-            option :middleware_names, default: false
+            option :middleware, default: true, type: :bool
+            option :middleware_names, default: false, type: :bool
             option :template_base_path do |o|
+              o.type :string
               o.default 'views/'
               o.on_set do |value|
                 # Update ActionView template base path too

--- a/lib/datadog/tracing/contrib/rake/configuration/settings.rb
+++ b/lib/datadog/tracing/contrib/rake/configuration/settings.rb
@@ -14,18 +14,24 @@ module Datadog
           # @public_api
           class Settings < Contrib::Configuration::Settings
             option :enabled do |o|
-              o.default { env_to_bool(Ext::ENV_ENABLED, true) }
+              o.type :bool
+              o.env_var Ext::ENV_ENABLED
+              o.default true
             end
 
             option :analytics_enabled do |o|
-              o.default { env_to_bool(Ext::ENV_ANALYTICS_ENABLED, false) }
+              o.type :bool
+              o.env_var Ext::ENV_ANALYTICS_ENABLED
+              o.default false
             end
 
             option :analytics_sample_rate do |o|
-              o.default { env_to_float(Ext::ENV_ANALYTICS_SAMPLE_RATE, 1.0) }
+              o.type :float
+              o.env_var Ext::ENV_ANALYTICS_SAMPLE_RATE
+              o.default 1.0
             end
 
-            option :quantize, default: {}
+            option :quantize, default: {}, type: :hash
             option :service_name
 
             # A list of rake tasks, using their string names, to be instrumented.
@@ -33,7 +39,8 @@ module Datadog
             # Automatically instrumenting all Rake tasks can lead to long-running tasks
             # causing undue memory accumulation, as the trace for such tasks is never flushed.
             option :tasks do |o|
-              o.default { [] }
+              o.type :array
+              o.default []
               o.on_set do |value|
                 # DEV: It should be possible to modify the value after it's set. E.g. for normalization.
                 options[:tasks].instance_variable_set(:@value, value.map(&:to_s).to_set)

--- a/lib/datadog/tracing/contrib/redis/configuration/settings.rb
+++ b/lib/datadog/tracing/contrib/redis/configuration/settings.rb
@@ -12,25 +12,35 @@ module Datadog
           # @public_api
           class Settings < Contrib::Configuration::Settings
             option :enabled do |o|
-              o.default { env_to_bool(Ext::ENV_ENABLED, true) }
+              o.type :bool
+              o.env_var Ext::ENV_ENABLED
+              o.default true
             end
 
             option :analytics_enabled do |o|
-              o.default { env_to_bool(Ext::ENV_ANALYTICS_ENABLED, false) }
+              o.type :bool
+              o.env_var Ext::ENV_ANALYTICS_ENABLED
+              o.default false
             end
 
             option :analytics_sample_rate do |o|
-              o.default { env_to_float(Ext::ENV_ANALYTICS_SAMPLE_RATE, 1.0) }
+              o.type :float
+              o.env_var Ext::ENV_ANALYTICS_SAMPLE_RATE
+              o.default 1.0
             end
 
             option :command_args do |o|
-              o.default { env_to_bool(Ext::ENV_COMMAND_ARGS, true) }
+              o.type :bool
+              o.env_var Ext::ENV_COMMAND_ARGS
+              o.default true
             end
 
             option :service_name do |o|
-              o.default do
+              o.type :string, nil: true
+              o.env_var Ext::ENV_SERVICE_NAME
+              o.setter do |value|
                 Contrib::SpanAttributeSchema.fetch_service_name(
-                  Ext::ENV_SERVICE_NAME,
+                  value,
                   Ext::DEFAULT_PEER_SERVICE_NAME
                 )
               end

--- a/lib/datadog/tracing/contrib/resque/configuration/settings.rb
+++ b/lib/datadog/tracing/contrib/resque/configuration/settings.rb
@@ -13,19 +13,25 @@ module Datadog
           # @public_api
           class Settings < Contrib::Configuration::Settings
             option :enabled do |o|
-              o.default { env_to_bool(Ext::ENV_ENABLED, true) }
+              o.type :bool
+              o.env_var Ext::ENV_ENABLED
+              o.default true
             end
 
             option :analytics_enabled do |o|
-              o.default { env_to_bool(Ext::ENV_ANALYTICS_ENABLED, false) }
+              o.type :bool
+              o.env_var Ext::ENV_ANALYTICS_ENABLED
+              o.default false
             end
 
             option :analytics_sample_rate do |o|
-              o.default { env_to_float(Ext::ENV_ANALYTICS_SAMPLE_RATE, 1.0) }
+              o.type :float
+              o.env_var Ext::ENV_ANALYTICS_SAMPLE_RATE
+              o.default 1.0
             end
 
             option :service_name
-            option :error_handler, experimental_default_proc: Tracing::SpanOperation::Events::DEFAULT_ON_ERROR
+            option :error_handler, type: :proc, experimental_default_proc: Tracing::SpanOperation::Events::DEFAULT_ON_ERROR
           end
         end
       end

--- a/lib/datadog/tracing/contrib/rest_client/configuration/settings.rb
+++ b/lib/datadog/tracing/contrib/rest_client/configuration/settings.rb
@@ -12,29 +12,37 @@ module Datadog
           # @public_api
           class Settings < Contrib::Configuration::Settings
             option :enabled do |o|
-              o.default { env_to_bool(Ext::ENV_ENABLED, true) }
+              o.type :bool
+              o.env_var Ext::ENV_ENABLED
+              o.default true
             end
 
             option :analytics_enabled do |o|
-              o.default { env_to_bool(Ext::ENV_ANALYTICS_ENABLED, false) }
+              o.type :bool
+              o.env_var Ext::ENV_ANALYTICS_ENABLED
+              o.default false
             end
 
             option :analytics_sample_rate do |o|
-              o.default { env_to_float(Ext::ENV_ANALYTICS_SAMPLE_RATE, 1.0) }
+              o.type :float
+              o.env_var Ext::ENV_ANALYTICS_SAMPLE_RATE
+              o.default 1.0
             end
 
-            option :distributed_tracing, default: true
+            option :distributed_tracing, default: true, type: :bool
 
             option :service_name do |o|
-              o.default do
+              o.type :string, nil: true
+              o.env_var Ext::ENV_SERVICE_NAME
+              o.setter do |value|
                 Contrib::SpanAttributeSchema.fetch_service_name(
-                  Ext::ENV_SERVICE_NAME,
+                  value,
                   Ext::DEFAULT_PEER_SERVICE_NAME
                 )
               end
             end
 
-            option :split_by_domain, default: false
+            option :split_by_domain, default: false, type: :bool
           end
         end
       end

--- a/lib/datadog/tracing/contrib/roda/configuration/settings.rb
+++ b/lib/datadog/tracing/contrib/roda/configuration/settings.rb
@@ -11,15 +11,21 @@ module Datadog
           # Custom settings for the Roda integration
           class Settings < Contrib::Configuration::Settings
             option :enabled do |o|
-              o.default { env_to_bool(Ext::ENV_ENABLED, true) }
+              o.type :bool
+              o.env_var Ext::ENV_ENABLED
+              o.default true
             end
 
             option :analytics_enabled do |o|
-              o.default { env_to_bool(Ext::ENV_ANALYTICS_ENABLED, false) }
+              o.type :bool
+              o.env_var Ext::ENV_ANALYTICS_ENABLED
+              o.default false
             end
 
             option :analytics_sample_rate do |o|
-              o.default { env_to_float(Ext::ENV_ANALYTICS_SAMPLE_RATE, 1.0) }
+              o.type :float
+              o.env_var Ext::ENV_ANALYTICS_SAMPLE_RATE
+              o.default 1.0
             end
 
             option :service_name

--- a/lib/datadog/tracing/contrib/semantic_logger/configuration/settings.rb
+++ b/lib/datadog/tracing/contrib/semantic_logger/configuration/settings.rb
@@ -12,7 +12,9 @@ module Datadog
           # @public_api
           class Settings < Contrib::Configuration::Settings
             option :enabled do |o|
-              o.default { env_to_bool(Ext::ENV_ENABLED, true) }
+              o.type :bool
+              o.env_var Ext::ENV_ENABLED
+              o.default true
             end
           end
         end

--- a/lib/datadog/tracing/contrib/sequel/configuration/settings.rb
+++ b/lib/datadog/tracing/contrib/sequel/configuration/settings.rb
@@ -12,15 +12,21 @@ module Datadog
           # @public_api
           class Settings < Contrib::Configuration::Settings
             option :enabled do |o|
-              o.default { env_to_bool(Ext::ENV_ENABLED, true) }
+              o.type :bool
+              o.env_var Ext::ENV_ENABLED
+              o.default true
             end
 
             option :analytics_enabled do |o|
-              o.default { env_to_bool(Ext::ENV_ANALYTICS_ENABLED, false) }
+              o.type :bool
+              o.env_var Ext::ENV_ANALYTICS_ENABLED
+              o.default false
             end
 
             option :analytics_sample_rate do |o|
-              o.default { env_to_float(Ext::ENV_ANALYTICS_SAMPLE_RATE, 1.0) }
+              o.type :float
+              o.env_var Ext::ENV_ANALYTICS_SAMPLE_RATE
+              o.default 1.0
             end
           end
         end

--- a/lib/datadog/tracing/contrib/sequel/database.rb
+++ b/lib/datadog/tracing/contrib/sequel/database.rb
@@ -23,10 +23,7 @@ module Datadog
               Tracing.trace(Ext::SPAN_QUERY) do |span|
                 span.service =  Datadog.configuration_for(self, :service_name) \
                                 || Datadog.configuration.tracing[:sequel][:service_name] \
-                                || Contrib::SpanAttributeSchema.fetch_service_name(
-                                  '',
-                                  adapter_name
-                                )
+                                || Contrib::SpanAttributeSchema.fetch_service_name(adapter_name)
                 span.resource = opts[:query]
                 span.span_type = Tracing::Metadata::Ext::SQL::TYPE
                 Utils.set_common_tags(span, self)

--- a/lib/datadog/tracing/contrib/sequel/dataset.rb
+++ b/lib/datadog/tracing/contrib/sequel/dataset.rb
@@ -42,10 +42,7 @@ module Datadog
               Tracing.trace(Ext::SPAN_QUERY) do |span|
                 span.service =  Datadog.configuration_for(db, :service_name) \
                                 || Datadog.configuration.tracing[:sequel][:service_name] \
-                                || Contrib::SpanAttributeSchema.fetch_service_name(
-                                  '',
-                                  adapter_name
-                                )
+                                || Contrib::SpanAttributeSchema.fetch_service_name(adapter_name)
                 span.resource = opts[:query]
                 span.span_type = Tracing::Metadata::Ext::SQL::TYPE
                 Utils.set_common_tags(span, db)

--- a/lib/datadog/tracing/contrib/shoryuken/configuration/settings.rb
+++ b/lib/datadog/tracing/contrib/shoryuken/configuration/settings.rb
@@ -13,20 +13,26 @@ module Datadog
           # @public_api
           class Settings < Contrib::Configuration::Settings
             option :enabled do |o|
-              o.default { env_to_bool(Ext::ENV_ENABLED, true) }
+              o.type :bool
+              o.env_var Ext::ENV_ENABLED
+              o.default true
             end
 
             option :analytics_enabled do |o|
-              o.default { env_to_bool(Ext::ENV_ANALYTICS_ENABLED, false) }
+              o.type :bool
+              o.env_var Ext::ENV_ANALYTICS_ENABLED
+              o.default false
             end
 
             option :analytics_sample_rate do |o|
-              o.default { env_to_float(Ext::ENV_ANALYTICS_SAMPLE_RATE, 1.0) }
+              o.type :float
+              o.env_var Ext::ENV_ANALYTICS_SAMPLE_RATE
+              o.default 1.0
             end
 
             option :service_name
-            option :error_handler, experimental_default_proc: Tracing::SpanOperation::Events::DEFAULT_ON_ERROR
-            option :tag_body, default: false
+            option :error_handler, type: :proc, experimental_default_proc: Tracing::SpanOperation::Events::DEFAULT_ON_ERROR
+            option :tag_body, default: false, type: :bool
           end
         end
       end

--- a/lib/datadog/tracing/contrib/sidekiq/configuration/settings.rb
+++ b/lib/datadog/tracing/contrib/sidekiq/configuration/settings.rb
@@ -13,26 +13,34 @@ module Datadog
           # @public_api
           class Settings < Contrib::Configuration::Settings
             option :enabled do |o|
-              o.default { env_to_bool(Ext::ENV_ENABLED, true) }
+              o.type :bool
+              o.env_var Ext::ENV_ENABLED
+              o.default true
             end
 
             option :analytics_enabled do |o|
-              o.default { env_to_bool(Ext::ENV_ANALYTICS_ENABLED, false) }
+              o.type :bool
+              o.env_var Ext::ENV_ANALYTICS_ENABLED
+              o.default false
             end
 
             option :analytics_sample_rate do |o|
-              o.default { env_to_float(Ext::ENV_ANALYTICS_SAMPLE_RATE, 1.0) }
+              o.type :float
+              o.env_var Ext::ENV_ANALYTICS_SAMPLE_RATE
+              o.default 1.0
             end
 
             option :tag_args do |o|
-              o.default { env_to_bool(Ext::ENV_TAG_JOB_ARGS, false) }
+              o.type :bool
+              o.env_var Ext::ENV_TAG_JOB_ARGS
+              o.default false
             end
 
             option :service_name
             option :client_service_name
-            option :error_handler, experimental_default_proc: Tracing::SpanOperation::Events::DEFAULT_ON_ERROR
-            option :quantize, default: {}
-            option :distributed_tracing, default: false
+            option :error_handler, type: :proc, experimental_default_proc: Tracing::SpanOperation::Events::DEFAULT_ON_ERROR
+            option :quantize, default: {}, type: :hash
+            option :distributed_tracing, default: false, type: :bool
           end
         end
       end

--- a/lib/datadog/tracing/contrib/sinatra/configuration/settings.rb
+++ b/lib/datadog/tracing/contrib/sinatra/configuration/settings.rb
@@ -14,20 +14,25 @@ module Datadog
             }.freeze
 
             option :enabled do |o|
-              o.default { env_to_bool(Ext::ENV_ENABLED, true) }
+              o.type :bool
+              o.env_var Ext::ENV_ENABLED
+              o.default true
             end
 
             option :analytics_enabled do |o|
-              o.default { env_to_bool(Ext::ENV_ANALYTICS_ENABLED, nil) }
+              o.type :bool, nil: true
+              o.env_var Ext::ENV_ANALYTICS_ENABLED
             end
 
             option :analytics_sample_rate do |o|
-              o.default { env_to_float(Ext::ENV_ANALYTICS_SAMPLE_RATE, 1.0) }
+              o.type :float
+              o.env_var Ext::ENV_ANALYTICS_SAMPLE_RATE
+              o.default 1.0
             end
 
-            option :distributed_tracing, default: true
-            option :headers, default: DEFAULT_HEADERS
-            option :resource_script_names, default: false
+            option :distributed_tracing, default: true, type: :bool
+            option :headers, default: DEFAULT_HEADERS, type: :hash
+            option :resource_script_names, default: false, type: :bool
 
             option :service_name
           end

--- a/lib/datadog/tracing/contrib/sneakers/configuration/settings.rb
+++ b/lib/datadog/tracing/contrib/sneakers/configuration/settings.rb
@@ -11,20 +11,26 @@ module Datadog
           # Default settings for the Shoryuken integration
           class Settings < Contrib::Configuration::Settings
             option :enabled do |o|
-              o.default { env_to_bool(Ext::ENV_ENABLED, true) }
+              o.type :bool
+              o.env_var Ext::ENV_ENABLED
+              o.default true
             end
 
             option :analytics_enabled do |o|
-              o.default { env_to_bool(Ext::ENV_ANALYTICS_ENABLED, false) }
+              o.type :bool
+              o.env_var Ext::ENV_ANALYTICS_ENABLED
+              o.default false
             end
 
             option :analytics_sample_rate do |o|
-              o.default { env_to_float(Ext::ENV_ANALYTICS_SAMPLE_RATE, 1.0) }
+              o.type :float
+              o.env_var Ext::ENV_ANALYTICS_SAMPLE_RATE
+              o.default 1.0
             end
 
             option :service_name
-            option :error_handler, experimental_default_proc: Tracing::SpanOperation::Events::DEFAULT_ON_ERROR
-            option :tag_body, default: false
+            option :error_handler, type: :proc, experimental_default_proc: Tracing::SpanOperation::Events::DEFAULT_ON_ERROR
+            option :tag_body, default: false, type: :bool
           end
         end
       end

--- a/lib/datadog/tracing/contrib/span_attribute_schema.rb
+++ b/lib/datadog/tracing/contrib/span_attribute_schema.rb
@@ -7,16 +7,18 @@ module Datadog
       module SpanAttributeSchema
         module_function
 
-        def fetch_service_name(env, default)
-          ENV.fetch(env) do
-            if Datadog.configuration.tracing.span_attribute_schema ==
-                Tracing::Configuration::Ext::SpanAttributeSchema::VERSION_ONE
-              Datadog.configuration.service
-            else
-              default
-            end
+        # rubocop:disable Style/OptionalArguments
+        def fetch_service_name(value = nil, default)
+          if value
+            value
+          elsif Datadog.configuration.tracing.span_attribute_schema ==
+              Tracing::Configuration::Ext::SpanAttributeSchema::VERSION_ONE
+            Datadog.configuration.service
+          else
+            default
           end
         end
+        # rubocop:enable Style/OptionalArguments
 
         def default_span_attribute_schema?
           Datadog.configuration.tracing.span_attribute_schema ==

--- a/lib/datadog/tracing/contrib/stripe/configuration/settings.rb
+++ b/lib/datadog/tracing/contrib/stripe/configuration/settings.rb
@@ -12,15 +12,21 @@ module Datadog
           # @public_api
           class Settings < Contrib::Configuration::Settings
             option :enabled do |o|
-              o.default { env_to_bool(Ext::ENV_ENABLED, true) }
+              o.type :bool
+              o.env_var Ext::ENV_ENABLED
+              o.default true
             end
 
             option :analytics_enabled do |o|
-              o.default { env_to_bool(Ext::ENV_ANALYTICS_ENABLED, false) }
+              o.type :bool
+              o.env_var Ext::ENV_ANALYTICS_ENABLED
+              o.default false
             end
 
             option :analytics_sample_rate do |o|
-              o.default { env_to_float(Ext::ENV_ANALYTICS_SAMPLE_RATE, 1.0) }
+              o.type :float
+              o.env_var Ext::ENV_ANALYTICS_SAMPLE_RATE
+              o.default 1.0
             end
           end
         end

--- a/lib/datadog/tracing/contrib/sucker_punch/configuration/settings.rb
+++ b/lib/datadog/tracing/contrib/sucker_punch/configuration/settings.rb
@@ -12,15 +12,21 @@ module Datadog
           # @public_api
           class Settings < Contrib::Configuration::Settings
             option :enabled do |o|
-              o.default { env_to_bool(Ext::ENV_ENABLED, true) }
+              o.type :bool
+              o.env_var Ext::ENV_ENABLED
+              o.default true
             end
 
             option :analytics_enabled do |o|
-              o.default { env_to_bool(Ext::ENV_ANALYTICS_ENABLED, false) }
+              o.type :bool
+              o.env_var Ext::ENV_ANALYTICS_ENABLED
+              o.default false
             end
 
             option :analytics_sample_rate do |o|
-              o.default { env_to_float(Ext::ENV_ANALYTICS_SAMPLE_RATE, 1.0) }
+              o.type :float
+              o.env_var Ext::ENV_ANALYTICS_SAMPLE_RATE
+              o.default 1.0
             end
 
             option :service_name

--- a/sig/datadog/core/configuration/option_definition.rbs
+++ b/sig/datadog/core/configuration/option_definition.rbs
@@ -8,6 +8,10 @@ module Datadog
 
         attr_reader experimental_default_proc: untyped
 
+        attr_reader env_var: untyped
+
+        attr_reader deprecated_env_var: untyped
+
         attr_reader delegate_to: untyped
 
         attr_reader depends_on: untyped
@@ -31,11 +35,17 @@ module Datadog
 
           def depends_on: (*untyped values) -> untyped
 
-          def default: (?untyped? value) { () -> untyped } -> untyped
+          def default: (?untyped? value) ?{ () -> untyped } -> untyped
 
           def experimental_default_proc: () { () -> untyped } -> untyped
 
           def delegate_to: () { () -> untyped } -> untyped
+
+          def env_var: (untyped value) -> untyped
+
+          def deprecated_env_var: (untyped value) -> untyped
+
+          def type: (Symbol value, ?::Hash[untyped, untyped] type_options) -> untyped
 
           def helper: (untyped name, *untyped _args) { () -> untyped } -> untyped
 

--- a/sig/datadog/tracing/contrib/span_attribute_schema.rbs
+++ b/sig/datadog/tracing/contrib/span_attribute_schema.rbs
@@ -2,7 +2,7 @@ module Datadog
   module Tracing
     module Contrib
       module SpanAttributeSchema
-        def self?.fetch_service_name: (untyped env, untyped default) -> untyped
+        def self?.fetch_service_name: (untyped value, untyped default) -> untyped
 
         def self?.default_span_attribute_schema?: () -> untyped
       end

--- a/spec/datadog/appsec/configuration/settings_spec.rb
+++ b/spec/datadog/appsec/configuration/settings_spec.rb
@@ -66,16 +66,8 @@ RSpec.describe Datadog::AppSec::Configuration::Settings do
     describe '#enabled=' do
       subject(:set_appsec_enabled) { settings.appsec.enabled = appsec_enabled }
 
-      context 'when given a falsy value' do
-        let(:appsec_enabled) { nil }
-
-        before { set_appsec_enabled }
-
-        it { expect(settings.appsec.enabled).to eq(false) }
-      end
-
       context 'when given a truthy value' do
-        let(:appsec_enabled) { 'enabled' }
+        let(:appsec_enabled) { true }
 
         before { set_appsec_enabled }
 
@@ -191,7 +183,7 @@ RSpec.describe Datadog::AppSec::Configuration::Settings do
 
         before { set_appsec_ruleset }
 
-        it { expect(settings.appsec.ruleset).to eq(nil) }
+        it { expect(settings.appsec.ruleset).to be_nil }
       end
     end
 
@@ -333,16 +325,8 @@ RSpec.describe Datadog::AppSec::Configuration::Settings do
     describe '#waf_debug=' do
       subject(:set_appsec_waf_debug) { settings.appsec.waf_debug = appsec_waf_debug }
 
-      context 'when given a falsy value' do
-        let(:appsec_waf_debug) { nil }
-
-        before { set_appsec_waf_debug }
-
-        it { expect(settings.appsec.waf_debug).to eq(false) }
-      end
-
       context 'when given a truthy value' do
-        let(:appsec_waf_debug) { 'waf_debug' }
+        let(:appsec_waf_debug) { true }
 
         before { set_appsec_waf_debug }
 
@@ -399,7 +383,7 @@ RSpec.describe Datadog::AppSec::Configuration::Settings do
         context 'is not defined' do
           let(:appsec_obfuscator_key_regex) { nil }
 
-          it { is_expected.to be described_class::DEFAULT_OBFUSCATOR_KEY_REGEX }
+          it { is_expected.to eq described_class::DEFAULT_OBFUSCATOR_KEY_REGEX }
         end
 
         context 'is defined' do
@@ -435,7 +419,7 @@ RSpec.describe Datadog::AppSec::Configuration::Settings do
         context 'is not defined' do
           let(:appsec_obfuscator_value_regex) { nil }
 
-          it { is_expected.to be described_class::DEFAULT_OBFUSCATOR_VALUE_REGEX }
+          it { is_expected.to eq described_class::DEFAULT_OBFUSCATOR_VALUE_REGEX }
         end
 
         context 'is defined' do
@@ -496,8 +480,8 @@ RSpec.describe Datadog::AppSec::Configuration::Settings do
           settings.appsec.track_user_events.enabled = track_user_events_enabled
         end
 
-        context 'when given a falsy value' do
-          let(:track_user_events_enabled) { nil }
+        context 'when given a disabled' do
+          let(:track_user_events_enabled) { 'disabled' }
 
           before { set_appsec_track_user_events_enabled }
 
@@ -505,7 +489,7 @@ RSpec.describe Datadog::AppSec::Configuration::Settings do
         end
 
         context 'when given a truthy value' do
-          let(:track_user_events_enabled) { 'enabled' }
+          let(:track_user_events_enabled) { true }
 
           before { set_appsec_track_user_events_enabled }
 
@@ -526,7 +510,7 @@ RSpec.describe Datadog::AppSec::Configuration::Settings do
           context 'is not defined' do
             let(:track_user_events_mode) { nil }
 
-            it { is_expected.to be described_class::DEFAULT_APPSEC_AUTOMATED_TRACK_USER_EVENTS_MODE }
+            it { is_expected.to eq described_class::DEFAULT_APPSEC_AUTOMATED_TRACK_USER_EVENTS_MODE }
           end
 
           context 'is defined' do

--- a/spec/datadog/ci/configuration/settings_spec.rb
+++ b/spec/datadog/ci/configuration/settings_spec.rb
@@ -18,6 +18,10 @@ RSpec.describe Datadog::CI::Configuration::Settings do
     end
 
     describe '#ci' do
+      after do
+        settings.reset!
+      end
+
       describe '#enabled' do
         subject(:enabled) { settings.ci.enabled }
 

--- a/spec/datadog/core/configuration/base_spec.rb
+++ b/spec/datadog/core/configuration/base_spec.rb
@@ -26,9 +26,6 @@ RSpec.describe Datadog::Core::Configuration::Base do
             it { is_expected.to be_a_kind_of(Datadog::Core::Configuration::OptionDefinition) }
 
             it 'sets default properties' do
-              expect(definition.type).to be_a_kind_of(Class)
-              expect(definition.type.ancestors).to include(described_class)
-
               is_expected.to have_attributes(
                 default: kind_of(Proc),
                 resetter: kind_of(Proc)

--- a/spec/datadog/core/configuration/option_definition_spec.rb
+++ b/spec/datadog/core/configuration/option_definition_spec.rb
@@ -347,15 +347,27 @@ RSpec.describe Datadog::Core::Configuration::OptionDefinition::Builder do
   end
 
   describe '#type' do
-    subject(:type) { builder.type(value) }
-
+    subject(:type) do
+      builder.type(value, opts)
+      builder.meta[:type]
+    end
     let(:value) { nil }
+    let(:opts) { {} }
 
     context 'given a value' do
-      let(:value) { String }
+      let(:value) { :string }
 
       it { is_expected.to be value }
       it { expect { type }.to change { builder.meta[:type] }.from(nil).to(value) }
+    end
+
+    context 'given options' do
+      let(:value) { :string }
+      let(:opts) { { nil: true } }
+
+      it { is_expected.to be value }
+      it { expect { type }.to change { builder.meta[:type] }.from(nil).to(value) }
+      it { expect { type }.to change { builder.meta[:type_options] }.from({}).to(opts) }
     end
   end
 

--- a/spec/datadog/core/configuration/options_spec.rb
+++ b/spec/datadog/core/configuration/options_spec.rb
@@ -160,7 +160,11 @@ RSpec.describe Datadog::Core::Configuration::Options do
             let(:meta) { super().merge(default: default_value) }
             let(:default_value) { double('default_value') }
 
-            it { is_expected.to be(default_value) }
+            it do
+              # mock .dup lib/datadog/core/configuration/option.rbL87
+              expect(default_value).to receive(:dup).and_return(default_value)
+              is_expected.to be(default_value)
+            end
           end
         end
 
@@ -185,6 +189,8 @@ RSpec.describe Datadog::Core::Configuration::Options do
             before { options_object.set_option(name, value) }
 
             it do
+              # mock .dup lib/datadog/core/configuration/option.rbL87
+              expect(default_value).to receive(:dup).and_return(default_value)
               expect { reset_option }.to change { options_object.get_option(name) }
                 .from(value)
                 .to(default_value)

--- a/spec/datadog/core/configuration/settings_spec.rb
+++ b/spec/datadog/core/configuration/settings_spec.rb
@@ -12,6 +12,10 @@ require 'datadog/profiling/ext'
 RSpec.describe Datadog::Core::Configuration::Settings do
   subject(:settings) { described_class.new(options) }
 
+  after do
+    settings.reset!
+  end
+
   let(:options) { {} }
 
   describe '#api_key' do
@@ -516,7 +520,7 @@ RSpec.describe Datadog::Core::Configuration::Settings do
         it 'logs a warning informing customers this has been deprecated for removal' do
           expect(Datadog.logger).to receive(:warn).with(/deprecated for removal/)
 
-          settings.profiling.advanced.force_enable_legacy_profiler = 1234
+          settings.profiling.advanced.force_enable_legacy_profiler = true
         end
 
         context 'when value is set to false' do
@@ -723,18 +727,10 @@ RSpec.describe Datadog::Core::Configuration::Settings do
 
       describe '#timeout_seconds=' do
         it 'updates the #timeout_seconds setting' do
-          expect { settings.profiling.upload.timeout_seconds = 10 }
+          expect { settings.profiling.upload.timeout_seconds = 10.0 }
             .to change { settings.profiling.upload.timeout_seconds }
             .from(30.0)
             .to(10.0)
-        end
-
-        context 'given nil' do
-          it 'uses the default setting' do
-            expect { settings.profiling.upload.timeout_seconds = nil }
-              .to_not change { settings.profiling.upload.timeout_seconds }
-              .from(30.0)
-          end
         end
       end
     end
@@ -783,7 +779,7 @@ RSpec.describe Datadog::Core::Configuration::Settings do
     end
 
     describe '#opts=' do
-      let(:opts) { double('opts') }
+      let(:opts) { { a: :b } }
 
       it 'changes the #opts setting' do
         expect { settings.runtime_metrics.opts = opts }
@@ -1273,7 +1269,7 @@ RSpec.describe Datadog::Core::Configuration::Settings do
         context 'is not defined' do
           let(:env_var_value) { nil }
 
-          it { is_expected.to be 60 }
+          it { is_expected.to eq 60.0 }
         end
 
         context 'is defined' do
@@ -1355,7 +1351,7 @@ RSpec.describe Datadog::Core::Configuration::Settings do
 
     describe '#poll_interval_seconds=' do
       it 'updates the #poll_interval_seconds setting' do
-        expect { settings.remote.poll_interval_seconds = 1 }
+        expect { settings.remote.poll_interval_seconds = 1.0 }
           .to change { settings.remote.poll_interval_seconds }
           .from(5.0)
           .to(1.0)

--- a/spec/datadog/core/diagnostics/environment_logger_spec.rb
+++ b/spec/datadog/core/diagnostics/environment_logger_spec.rb
@@ -2,6 +2,7 @@ require 'spec_helper'
 
 require 'datadog/core/diagnostics/environment_logger'
 require 'ddtrace/transport/io'
+require 'datadog/profiling/profiler'
 
 RSpec.describe Datadog::Core::Diagnostics::EnvironmentLogger do
   subject(:env_logger) { described_class }
@@ -289,14 +290,6 @@ RSpec.describe Datadog::Core::Diagnostics::EnvironmentLogger do
           it { is_expected.to include integration_http_service_name: 'my-http' }
           it { is_expected.to include integration_http_distributed_tracing: 'true' }
           it { is_expected.to include integration_http_split_by_domain: 'false' }
-        end
-
-        context 'with a complex setting value' do
-          let(:options) { { service_name: Class.new } }
-
-          it 'converts to a string' do
-            is_expected.to include integration_http_service_name: start_with('#<Class:')
-          end
         end
       end
 

--- a/spec/datadog/core/telemetry/collector_spec.rb
+++ b/spec/datadog/core/telemetry/collector_spec.rb
@@ -10,6 +10,7 @@ require 'datadog/core/telemetry/v1/host'
 require 'datadog/core/telemetry/v1/integration'
 require 'datadog/core/telemetry/v1/product'
 require 'ddtrace/transport/ext'
+require 'datadog/profiling/profiler'
 
 require 'ddtrace'
 require 'ddtrace/version'

--- a/spec/datadog/tracing/configuration/settings_spec.rb
+++ b/spec/datadog/tracing/configuration/settings_spec.rb
@@ -18,6 +18,10 @@ RSpec.describe Datadog::Tracing::Configuration::Settings do
   let(:options) { {} }
 
   describe '#tracing' do
+    after do
+      settings.reset!
+    end
+
     describe '#analytics' do
       describe '#enabled' do
         subject(:enabled) { settings.tracing.analytics.enabled }
@@ -207,7 +211,7 @@ RSpec.describe Datadog::Tracing::Configuration::Settings do
           context 'is not defined' do
             let(:var_value) { nil }
 
-            it { is_expected.to be_nil }
+            it { is_expected.to eq [] }
 
             it 'does not change propagation_extract_style' do
               expect { propagation_style }.to_not change { propagation_extract_style }

--- a/spec/datadog/tracing/contrib/faraday/middleware_spec.rb
+++ b/spec/datadog/tracing/contrib/faraday/middleware_spec.rb
@@ -25,6 +25,7 @@ RSpec.describe 'Faraday middleware' do
   let(:use_middleware) { true }
   let(:middleware_options) { {} }
   let(:configuration_options) { {} }
+  let(:custom_handler) { ->(env) { (400...600).cover?(env[:status]) } }
 
   before do
     Datadog.configure do |c|
@@ -181,6 +182,7 @@ RSpec.describe 'Faraday middleware' do
   end
 
   context 'when there is a failing request' do
+    let(:middleware_options) { { error_handler: custom_handler } }
     subject!(:response) { client.post('/failure') }
 
     it_behaves_like 'environment service name', 'DD_TRACE_FARADAY_SERVICE_NAME'
@@ -261,7 +263,6 @@ RSpec.describe 'Faraday middleware' do
     subject!(:response) { client.get('not_found') }
 
     let(:middleware_options) { { error_handler: custom_handler } }
-    let(:custom_handler) { ->(env) { (400...600).cover?(env[:status]) } }
 
     it { expect(span).to have_error }
 

--- a/spec/datadog/tracing/contrib/http_examples.rb
+++ b/spec/datadog/tracing/contrib/http_examples.rb
@@ -3,7 +3,7 @@ RSpec.shared_examples 'with error status code configuration' do
 
   context 'with a custom range' do
     context 'with an Range object' do
-      let(:configuration_options) { { error_status_codes: 500..502 } }
+      let(:configuration_options) { { error_status_codes: (500..502).to_a } }
 
       context 'with a status code within the range' do
         let(:status_code) { 501 }


### PR DESCRIPTION
<!--
Check out the
https://github.com/DataDog/dd-trace-rb/blob/master/docs/DevelopmentGuide.md
for guidance on how to set up your development environment,
run the test suite, write new integrations, and more.
-->

**What does this PR do?**
<!-- A brief description of the change being made with this pull request. -->

I'm exploring trying to try solve some problems from a private discussion about how to track the configuration option using the ENV variable or the fallback.

The PR explores adding `env_var` and `deprecatated_env_var` as configuration options. Those options would be used to fetch the value from ENV. If the values are present, we treat them as being set programmatically by the customer. That way, we can later use the `using_default?`  method to know if a configuration is using the default value or the one set by the customer. 

I had to refactor the functions `env_to_*` into `val_to_*`, since they no longer deal with ENV variables. The methods still live under `Core::Environment::VariableHelpers`; that namespace is wrong. 

The intent of the PR is for people to see the approach and comment on anything they would change or miss. 

If people like this addition, I will address all the missing and failing specs and any feedback from comments. Finish adding `o.default` to some settings


**Motivation**
<!-- What inspired you to submit this pull request? -->

**Additional Notes**
<!-- Anything else we should know when reviewing? -->

**How to test the change?**
<!--
Describe here how the change can be validated.
You are strongly encouraged to provide automated tests for this PR (unit or integration).
If this change cannot be feasibly tested, please explain why,
unless the change does not modify code (e.g. only modifies docs, comments).
-->
