### PR TITLE
[PROF-7440] Bootstrap support for timeline feature in profiler, off by default

### DIFF
--- a/benchmarks/profiler_sample_loop_v2.rb
+++ b/benchmarks/profiler_sample_loop_v2.rb
@@ -17,8 +17,9 @@ class ProfilerSampleLoopBenchmark
 
   def create_profiler
     @recorder = Datadog::Profiling::StackRecorder.new(cpu_time_enabled: true, alloc_samples_enabled: true)
-    @collector =
-      Datadog::Profiling::Collectors::ThreadContext.new(recorder: @recorder, max_frames: 400, tracer: nil, endpoint_collection_enabled: false)
+    @collector = Datadog::Profiling::Collectors::ThreadContext.new(
+      recorder: @recorder, max_frames: 400, tracer: nil, endpoint_collection_enabled: false, timeline_enabled: false
+    )
   end
 
   def thread_with_very_deep_stack(depth: 500)

--- a/ext/ddtrace_profiling_native_extension/collectors_thread_context.c
+++ b/ext/ddtrace_profiling_native_extension/collectors_thread_context.c
@@ -672,8 +672,8 @@ static void trigger_sample_for_thread(
 
   // The number of times `label_pos++` shows up in this function needs to match `max_label_count`. To avoid "oops I
   // forgot to update max_label_count" in the future, we've also added this validation.
-  // @ivoanjo: I wonder if C compilers are smart enough to statically prove when this check never triggers happens and
-  // remove it entirely.
+  // @ivoanjo: I wonder if C compilers are smart enough to statically prove when this check never triggers and
+  // remove it entirely?
   if (label_pos > max_label_count) {
     rb_raise(rb_eRuntimeError, "BUG: Unexpected label_pos (%d) > max_label_count (%d)", label_pos, max_label_count);
   }

--- a/ext/ddtrace_profiling_native_extension/collectors_thread_context.c
+++ b/ext/ddtrace_profiling_native_extension/collectors_thread_context.c
@@ -693,8 +693,8 @@ static void trigger_sample_for_thread(
 
   // The number of times `label_pos++` shows up in this function needs to match `max_label_count`. To avoid "oops I
   // forgot to update max_label_count" in the future, we've also added this validation.
-  // @ivoanjo: I wonder if C compilers are smart enough to statically prove when this check never triggers and
-  // remove it entirely?
+  // @ivoanjo: I wonder if C compilers are smart enough to statically prove this check never triggers unless someone
+  // changes the code erroneously and remove it entirely?
   if (label_pos > max_label_count) {
     rb_raise(rb_eRuntimeError, "BUG: Unexpected label_pos (%d) > max_label_count (%d)", label_pos, max_label_count);
   }

--- a/ext/ddtrace_profiling_native_extension/time_helpers.c
+++ b/ext/ddtrace_profiling_native_extension/time_helpers.c
@@ -5,13 +5,16 @@
 #include "time_helpers.h"
 
 // Safety: This function is assumed never to raise exceptions by callers when raise_on_failure == false
-long monotonic_wall_time_now_ns(bool raise_on_failure) {
-  struct timespec current_monotonic;
+long retrieve_clock_as_ns(clockid_t clock_id, bool raise_on_failure) {
+  struct timespec clock_value;
 
-  if (clock_gettime(CLOCK_MONOTONIC, &current_monotonic) != 0) {
+  if (clock_gettime(clock_id, &clock_value) != 0) {
     if (raise_on_failure) ENFORCE_SUCCESS_GVL(errno);
     return 0;
   }
 
-  return current_monotonic.tv_nsec + SECONDS_AS_NS(current_monotonic.tv_sec);
+  return clock_value.tv_nsec + SECONDS_AS_NS(clock_value.tv_sec);
 }
+
+long monotonic_wall_time_now_ns(bool raise_on_failure) { return retrieve_clock_as_ns(CLOCK_MONOTONIC, raise_on_failure); }
+long system_epoch_time_now_ns(bool raise_on_failure)   { return retrieve_clock_as_ns(CLOCK_REALTIME,  raise_on_failure); }

--- a/ext/ddtrace_profiling_native_extension/time_helpers.c
+++ b/ext/ddtrace_profiling_native_extension/time_helpers.c
@@ -18,3 +18,36 @@ long retrieve_clock_as_ns(clockid_t clock_id, bool raise_on_failure) {
 
 long monotonic_wall_time_now_ns(bool raise_on_failure) { return retrieve_clock_as_ns(CLOCK_MONOTONIC, raise_on_failure); }
 long system_epoch_time_now_ns(bool raise_on_failure)   { return retrieve_clock_as_ns(CLOCK_REALTIME,  raise_on_failure); }
+
+// Design: The monotonic_to_system_epoch_state struct is kept somewhere by the caller, and MUST be initialized to
+// MONOTONIC_TO_SYSTEM_EPOCH_INITIALIZER.
+//
+// This function is used by the ThreadContext collector to convert monotonic wall time timestamps which are used
+// basically everywhere else in the codebase, into system epoch timestamps, which are needed by the timeline feature.
+//
+// There's a few ways we could have tackled this conversion, e.g. check the system clock on every call, or even
+// use system clock timestamps elsewhere in the code.
+// Using a system clock elsewhere has a few disadvantages (e.g. because it can move around if users adjust the system
+// time). I also wanted to avoid calling system_epoch_time_now_ns(...) on every conversion.
+//
+// Thus I arrived at this solution: we calculate a delta between the monotonic clock and the system clock, and use
+// that to convert the timestamps.
+//
+// To avoid the results of the system clock being off in cases where the system clock is adjusted while the profiler
+// is running, every ~60 seconds of observed monotonic wall time we recalculate the delta. This means that worst case
+// we'll have ~60 seconds of wrongly-timestamped data when the system clock jumps around, and in return we save the
+// overhead of having to look up the system clock on every call to this function.
+long monotonic_to_system_epoch_ns(monotonic_to_system_epoch_state *state, long monotonic_wall_time_ns) {
+  bool reference_needs_update =
+    (state->system_epoch_ns_reference == INVALID_TIME) ||
+    (state->delta_to_epoch_ns + monotonic_wall_time_ns > state->system_epoch_ns_reference + SECONDS_AS_NS(60));
+
+  if (reference_needs_update) {
+    state->system_epoch_ns_reference = system_epoch_time_now_ns(RAISE_ON_FAILURE);
+    long current_monotonic_wall_time_ns = monotonic_wall_time_now_ns(RAISE_ON_FAILURE);
+
+    state->delta_to_epoch_ns = state->system_epoch_ns_reference - current_monotonic_wall_time_ns;
+  }
+
+  return state->delta_to_epoch_ns + monotonic_wall_time_ns;
+}

--- a/ext/ddtrace_profiling_native_extension/time_helpers.h
+++ b/ext/ddtrace_profiling_native_extension/time_helpers.h
@@ -8,3 +8,6 @@
 
 // Safety: This function is assumed never to raise exceptions by callers when raise_on_failure == false
 long monotonic_wall_time_now_ns(bool raise_on_failure);
+
+// Safety: This function is assumed never to raise exceptions by callers when raise_on_failure == false
+long system_epoch_time_now_ns(bool raise_on_failure);

--- a/ext/ddtrace_profiling_native_extension/time_helpers.h
+++ b/ext/ddtrace_profiling_native_extension/time_helpers.h
@@ -6,8 +6,19 @@
 #define RAISE_ON_FAILURE true
 #define DO_NOT_RAISE_ON_FAILURE false
 
+#define INVALID_TIME -1
+
+typedef struct {
+  long system_epoch_ns_reference;
+  long delta_to_epoch_ns;
+} monotonic_to_system_epoch_state;
+
+#define MONOTONIC_TO_SYSTEM_EPOCH_INITIALIZER {.system_epoch_ns_reference = INVALID_TIME, .delta_to_epoch_ns = INVALID_TIME}
+
 // Safety: This function is assumed never to raise exceptions by callers when raise_on_failure == false
 long monotonic_wall_time_now_ns(bool raise_on_failure);
 
 // Safety: This function is assumed never to raise exceptions by callers when raise_on_failure == false
 long system_epoch_time_now_ns(bool raise_on_failure);
+
+long monotonic_to_system_epoch_ns(monotonic_to_system_epoch_state *state, long monotonic_wall_time_ns);

--- a/lib/datadog/core/configuration/settings.rb
+++ b/lib/datadog/core/configuration/settings.rb
@@ -366,6 +366,14 @@ module Datadog
               o.default { env_to_bool('DD_PROFILING_NO_SIGNALS_WORKAROUND_ENABLED', :auto) }
               o.lazy
             end
+
+            # Enables data collection for the timeline feature. This is still experimental and not recommended yet.
+            #
+            # @default `DD_PROFILING_EXPERIMENTAL_TIMELINE_ENABLED` environment variable as a boolean, otherwise `false`
+            option :experimental_timeline_enabled do |o|
+              o.default { env_to_bool('DD_PROFILING_EXPERIMENTAL_TIMELINE_ENABLED', false) }
+              o.lazy
+            end
           end
 
           # @public_api

--- a/lib/datadog/profiling/collectors/cpu_and_wall_time_worker.rb
+++ b/lib/datadog/profiling/collectors/cpu_and_wall_time_worker.rb
@@ -21,6 +21,7 @@ module Datadog
           gc_profiling_enabled:,
           allocation_counting_enabled:,
           no_signals_workaround_enabled:,
+          timeline_enabled:,
           thread_context_collector: ThreadContext.new(
             recorder: recorder,
             max_frames: max_frames,

--- a/lib/datadog/profiling/collectors/cpu_and_wall_time_worker.rb
+++ b/lib/datadog/profiling/collectors/cpu_and_wall_time_worker.rb
@@ -27,6 +27,7 @@ module Datadog
             max_frames: max_frames,
             tracer: tracer,
             endpoint_collection_enabled: endpoint_collection_enabled,
+            timeline_enabled: timeline_enabled,
           ),
           idle_sampling_helper: IdleSamplingHelper.new,
           # **NOTE**: This should only be used for testing; disabling the dynamic sampling rate will increase the

--- a/lib/datadog/profiling/collectors/thread_context.rb
+++ b/lib/datadog/profiling/collectors/thread_context.rb
@@ -14,9 +14,16 @@ module Datadog
       #
       # Methods prefixed with _native_ are implemented in `collectors_thread_context.c`
       class ThreadContext
-        def initialize(recorder:, max_frames:, tracer:, endpoint_collection_enabled:)
+        def initialize(recorder:, max_frames:, tracer:, endpoint_collection_enabled:, timeline_enabled:)
           tracer_context_key = safely_extract_context_key_from(tracer)
-          self.class._native_initialize(self, recorder, max_frames, tracer_context_key, endpoint_collection_enabled)
+          self.class._native_initialize(
+            self,
+            recorder,
+            max_frames,
+            tracer_context_key,
+            endpoint_collection_enabled,
+            timeline_enabled,
+          )
         end
 
         def inspect

--- a/lib/datadog/profiling/component.rb
+++ b/lib/datadog/profiling/component.rb
@@ -77,6 +77,7 @@ module Datadog
             gc_profiling_enabled: enable_gc_profiling?(settings),
             allocation_counting_enabled: settings.profiling.advanced.allocation_counting_enabled,
             no_signals_workaround_enabled: no_signals_workaround_enabled?(settings),
+            timeline_enabled: settings.profiling.advanced.experimental_timeline_enabled,
           )
         else
           load_pprof_support

--- a/sig/datadog/profiling/collectors/cpu_and_wall_time_worker.rbs
+++ b/sig/datadog/profiling/collectors/cpu_and_wall_time_worker.rbs
@@ -12,6 +12,7 @@ module Datadog
           gc_profiling_enabled: bool,
           allocation_counting_enabled: bool,
           no_signals_workaround_enabled: bool,
+          timeline_enabled: bool,
           ?thread_context_collector: Datadog::Profiling::Collectors::ThreadContext,
           ?idle_sampling_helper: Datadog::Profiling::Collectors::IdleSamplingHelper,
           ?dynamic_sampling_rate_enabled: bool,

--- a/sig/datadog/profiling/collectors/thread_context.rbs
+++ b/sig/datadog/profiling/collectors/thread_context.rbs
@@ -7,6 +7,7 @@ module Datadog
           max_frames: ::Integer,
           tracer: Datadog::Tracing::Tracer?,
           endpoint_collection_enabled: bool,
+          timeline_enabled: bool,
         ) -> void
 
         def self._native_initialize: (
@@ -15,6 +16,7 @@ module Datadog
           ::Integer max_frames,
           ::Symbol? tracer_context_key,
           bool endpoint_collection_enabled,
+          bool timeline_enabled,
         ) -> void
 
         def inspect: () -> ::String

--- a/spec/datadog/core/configuration/settings_spec.rb
+++ b/spec/datadog/core/configuration/settings_spec.rb
@@ -659,6 +659,41 @@ RSpec.describe Datadog::Core::Configuration::Settings do
             .to(false)
         end
       end
+
+      describe '#experimental_timeline_enabled' do
+        subject(:experimental_timeline_enabled) { settings.profiling.advanced.experimental_timeline_enabled }
+
+        context 'when DD_PROFILING_EXPERIMENTAL_TIMELINE_ENABLED' do
+          around do |example|
+            ClimateControl.modify('DD_PROFILING_EXPERIMENTAL_TIMELINE_ENABLED' => environment) do
+              example.run
+            end
+          end
+
+          context 'is not defined' do
+            let(:environment) { nil }
+
+            it { is_expected.to be false }
+          end
+
+          [true, false].each do |value|
+            context "is defined as #{value}" do
+              let(:environment) { value.to_s }
+
+              it { is_expected.to be value }
+            end
+          end
+        end
+      end
+
+      describe '#experimental_timeline_enabled=' do
+        it 'updates the #experimental_timeline_enabled setting' do
+          expect { settings.profiling.advanced.experimental_timeline_enabled = true }
+            .to change { settings.profiling.advanced.experimental_timeline_enabled }
+            .from(false)
+            .to(true)
+        end
+      end
     end
 
     describe '#upload' do

--- a/spec/datadog/profiling/collectors/cpu_and_wall_time_worker_spec.rb
+++ b/spec/datadog/profiling/collectors/cpu_and_wall_time_worker_spec.rb
@@ -42,6 +42,17 @@ RSpec.describe Datadog::Profiling::Collectors::CpuAndWallTimeWorker do
           cpu_and_wall_time_worker
         end
       end
+
+      context "when timeline_enabled is #{value}" do
+        let(:timeline_enabled) { value }
+
+        it "initializes the ThreadContext collector with timeline_enabled: #{value}" do
+          expect(Datadog::Profiling::Collectors::ThreadContext)
+            .to receive(:new).with(hash_including(timeline_enabled: value)).and_call_original
+
+          cpu_and_wall_time_worker
+        end
+      end
     end
   end
 
@@ -547,7 +558,11 @@ RSpec.describe Datadog::Profiling::Collectors::CpuAndWallTimeWorker do
 
     let(:thread_context_collector) do
       Datadog::Profiling::Collectors::ThreadContext.new(
-        recorder: recorder, max_frames: 400, tracer: nil, endpoint_collection_enabled: endpoint_collection_enabled,
+        recorder: recorder,
+        max_frames: 400,
+        tracer: nil,
+        endpoint_collection_enabled: endpoint_collection_enabled,
+        timeline_enabled: timeline_enabled,
       )
     end
     let(:options) { { thread_context_collector: thread_context_collector } }

--- a/spec/datadog/profiling/collectors/cpu_and_wall_time_worker_spec.rb
+++ b/spec/datadog/profiling/collectors/cpu_and_wall_time_worker_spec.rb
@@ -9,6 +9,7 @@ RSpec.describe Datadog::Profiling::Collectors::CpuAndWallTimeWorker do
   let(:gc_profiling_enabled) { true }
   let(:allocation_counting_enabled) { true }
   let(:no_signals_workaround_enabled) { false }
+  let(:timeline_enabled) { false }
   let(:options) { {} }
 
   subject(:cpu_and_wall_time_worker) do
@@ -20,6 +21,7 @@ RSpec.describe Datadog::Profiling::Collectors::CpuAndWallTimeWorker do
       gc_profiling_enabled: gc_profiling_enabled,
       allocation_counting_enabled: allocation_counting_enabled,
       no_signals_workaround_enabled: no_signals_workaround_enabled,
+      timeline_enabled: timeline_enabled,
       **options
     )
   end
@@ -692,6 +694,7 @@ RSpec.describe Datadog::Profiling::Collectors::CpuAndWallTimeWorker do
       gc_profiling_enabled: gc_profiling_enabled,
       allocation_counting_enabled: allocation_counting_enabled,
       no_signals_workaround_enabled: no_signals_workaround_enabled,
+      timeline_enabled: timeline_enabled,
     )
   end
 end

--- a/spec/datadog/profiling/collectors/thread_context_spec.rb
+++ b/spec/datadog/profiling/collectors/thread_context_spec.rb
@@ -38,6 +38,7 @@ RSpec.describe Datadog::Profiling::Collectors::ThreadContext do
   let(:invalid_time) { -1 }
   let(:tracer) { nil }
   let(:endpoint_collection_enabled) { true }
+  let(:timeline_enabled) { false }
 
   subject(:cpu_and_wall_time_collector) do
     described_class.new(
@@ -45,6 +46,7 @@ RSpec.describe Datadog::Profiling::Collectors::ThreadContext do
       max_frames: max_frames,
       tracer: tracer,
       endpoint_collection_enabled: endpoint_collection_enabled,
+      timeline_enabled: timeline_enabled,
     )
   end
 

--- a/spec/datadog/profiling/component_spec.rb
+++ b/spec/datadog/profiling/component_spec.rb
@@ -125,14 +125,18 @@ RSpec.describe Datadog::Profiling::Component do
         end
 
         it 'initializes a CpuAndWallTimeWorker collector' do
+          expect(settings.profiling.advanced).to receive(:max_frames).and_return(:max_frames_config)
+          expect(settings.profiling.advanced).to receive(:experimental_timeline_enabled).and_return(:experimental_timeline_enabled_config)
+
           expect(Datadog::Profiling::Collectors::CpuAndWallTimeWorker).to receive(:new).with(
             recorder: instance_of(Datadog::Profiling::StackRecorder),
-            max_frames: settings.profiling.advanced.max_frames,
+            max_frames: :max_frames_config,
             tracer: tracer,
             endpoint_collection_enabled: anything,
             gc_profiling_enabled: anything,
             allocation_counting_enabled: anything,
             no_signals_workaround_enabled: eq(true).or(eq(false)),
+            timeline_enabled: :experimental_timeline_enabled_config,
           )
 
           build_profiler_component

--- a/spec/datadog/profiling/component_spec.rb
+++ b/spec/datadog/profiling/component_spec.rb
@@ -126,7 +126,8 @@ RSpec.describe Datadog::Profiling::Component do
 
         it 'initializes a CpuAndWallTimeWorker collector' do
           expect(settings.profiling.advanced).to receive(:max_frames).and_return(:max_frames_config)
-          expect(settings.profiling.advanced).to receive(:experimental_timeline_enabled).and_return(:experimental_timeline_enabled_config)
+          expect(settings.profiling.advanced)
+            .to receive(:experimental_timeline_enabled).and_return(:experimental_timeline_enabled_config)
 
           expect(Datadog::Profiling::Collectors::CpuAndWallTimeWorker).to receive(:new).with(
             recorder: instance_of(Datadog::Profiling::StackRecorder),


### PR DESCRIPTION
**What does this PR do?**:

This PR bootstraps support for collecting data to power the upcoming timeline feature. Specifically it:

* Introduces a new `DD_PROFILING_EXPERIMENTAL_TIMELINE_ENABLED` environment variable, as well as a `c.profiling.advanced.experimental_timeline_enabled` setting to turn on collection of this data.
* Changes the `ThreadContext` collector to include timestamps of when cpu/wall-time events happen as a label in profiling samples

**The new changes are off by default**, and are not expected to have any impact on customer applications (hence this is safe to merge into master and release).

**Motivation**:

The key part of the "timeline" feature is to start assigning timestamps to when things happen, rather than a profile being an aggregation of 60 seconds of events, where you can't really tell what came before and what came after.

**Additional Notes**:

At this moment, it's not possible for customers to see this data in the profiling UX. But with the correct set of backend branches and feature flags I was able to see what looks like correct timeline data from this change. The plan is to obviously iterate a lot from here on, to get to the point where we'll be enabling the feature by default.

**How to test the change?**:

The changes to add the new parameter and the timestamps include test coverage. The overall feature needs a few internal things to see working, ping me if you want to try it out.