### PR TITLE
Add fallback name for main thread in profiling data

### DIFF
--- a/ext/ddtrace_profiling_native_extension/collectors_thread_context.c
+++ b/ext/ddtrace_profiling_native_extension/collectors_thread_context.c
@@ -655,9 +655,10 @@ static void trigger_sample_for_thread(
       .str = char_slice_from_ruby_string(thread_name)
     };
   } else if (thread == state->main_thread) { // Threads are often not named, but we can have a nice fallback for this special thread
+    ddog_CharSlice main_thread_name = DDOG_CHARSLICE_C("main");
     labels[label_pos++] = (ddog_prof_Label) {
       .key = DDOG_CHARSLICE_C("thread name"),
-      .str = DDOG_CHARSLICE_C("main")
+      .str = main_thread_name
     };
   }
 

--- a/ext/ddtrace_profiling_native_extension/collectors_thread_context.c
+++ b/ext/ddtrace_profiling_native_extension/collectors_thread_context.c
@@ -102,6 +102,8 @@ struct thread_context_collector_state {
   bool timeline_enabled;
   // Used when calling monotonic_to_system_epoch_ns
   monotonic_to_system_epoch_state time_converter_state;
+  // Used to identify the main thread, to give it a fallback name
+  VALUE main_thread;
 
   struct stats {
     // Track how many garbage collection samples we've taken.
@@ -254,6 +256,7 @@ static void thread_context_collector_typed_data_mark(void *state_ptr) {
   rb_gc_mark(state->recorder_instance);
   st_foreach(state->hash_map_per_thread_context, hash_map_per_thread_context_mark, 0 /* unused */);
   rb_gc_mark(state->thread_list_buffer);
+  rb_gc_mark(state->main_thread);
 }
 
 static void thread_context_collector_typed_data_free(void *state_ptr) {
@@ -301,6 +304,7 @@ static VALUE _native_new(VALUE klass) {
   state->endpoint_collection_enabled = true;
   state->timeline_enabled = true;
   state->time_converter_state = (monotonic_to_system_epoch_state) MONOTONIC_TO_SYSTEM_EPOCH_INITIALIZER;
+  state->main_thread = rb_thread_main();
 
   return TypedData_Wrap_Struct(klass, &thread_context_collector_typed_data, state);
 }
@@ -650,6 +654,11 @@ static void trigger_sample_for_thread(
       .key = DDOG_CHARSLICE_C("thread name"),
       .str = char_slice_from_ruby_string(thread_name)
     };
+  } else if (thread == state->main_thread) { // Threads are often not named, but we can have a nice fallback for this special thread
+    labels[label_pos++] = (ddog_prof_Label) {
+      .key = DDOG_CHARSLICE_C("thread name"),
+      .str = DDOG_CHARSLICE_C("main")
+    };
   }
 
   struct trace_identifiers trace_identifiers_result = {.valid = false, .trace_endpoint = Qnil};
@@ -780,6 +789,7 @@ static VALUE _native_inspect(DDTRACE_UNUSED VALUE _self, VALUE collector_instanc
     state->time_converter_state.system_epoch_ns_reference,
     state->time_converter_state.delta_to_epoch_ns
   ));
+  rb_str_concat(result, rb_sprintf(" main_thread=%"PRIsVALUE, state->main_thread));
 
   return result;
 }

--- a/spec/datadog/profiling/collectors/thread_context_spec.rb
+++ b/spec/datadog/profiling/collectors/thread_context_spec.rb
@@ -132,6 +132,18 @@ RSpec.describe Datadog::Profiling::Collectors::ThreadContext do
       expect(t3_sample.labels).to include(:'thread name' => 'thread t3')
     end
 
+    it 'includes a fallback name for the main thread, when not set' do
+      expect(Thread.main.name).to eq('Thread.main') # We set this in the spec_helper.rb
+
+      Thread.main.name = nil
+
+      sample
+
+      expect(samples_for_thread(samples, Thread.main).first.labels).to include(:'thread name' => 'main')
+
+      Thread.main.name = 'Thread.main'
+    end
+
     it 'includes the wall-time elapsed between samples' do
       sample
       wall_time_at_first_sample =


### PR DESCRIPTION
**What does this PR do?**:

This PR adds a fallback name of "main" to the main Ruby thread.

The main Ruby thread is first thread created in the VM, and the one that is returned by `Thread.main` (when in the main Ractor).

**Motivation**:

As more profiling features start to show the name in the UX, it's annoying to often have the main thread not have a name.

**Additional Notes**:

This PR sits atop #2937 to avoid any merge conflicts (since both touch labels and the `ThreadContext` collector state), but is otherwise completely independent of that one.

**How to test the change?**:

This change includes test coverage.

You can see it in action by profiling a Ruby app that never names its main thread, and then confirming that profiling data for that thread is shown under the name `main` in the Datadog UX.
