### PR TITLE
Fix theoretical line number calculation bug in profiler for Ruby 3.2+

### DIFF
--- a/ext/ddtrace_profiling_native_extension/extconf.rb
+++ b/ext/ddtrace_profiling_native_extension/extconf.rb
@@ -143,6 +143,9 @@ $defs << '-DNO_RB_NATIVE_THREAD' if RUBY_VERSION < '3.2'
 # On older Rubies, there was no struct rb_thread_sched (it was struct rb_global_vm_lock_struct)
 $defs << '-DNO_RB_THREAD_SCHED' if RUBY_VERSION < '3.2'
 
+# On older Rubies, the first_lineno inside a location was a VALUE and not a int (https://github.com/ruby/ruby/pull/6430)
+$defs << '-DNO_INT_FIRST_LINENO' if RUBY_VERSION < '3.2'
+
 # On older Rubies, there was no tid member in the internal thread structure
 $defs << '-DNO_THREAD_TID' if RUBY_VERSION < '3.1'
 

--- a/ext/ddtrace_profiling_native_extension/private_vm_api_access.c
+++ b/ext/ddtrace_profiling_native_extension/private_vm_api_access.c
@@ -302,7 +302,8 @@ VALUE thread_name_for(VALUE thread) {
 // Taken from upstream vm_backtrace.c at commit 5f10bd634fb6ae8f74a4ea730176233b0ca96954 (March 2022, Ruby 3.2 trunk)
 // Copyright (C) 1993-2012 Yukihiro Matsumoto
 // to support our custom rb_profile_frames (see below)
-// Modifications: None
+// Modifications:
+// * Support int first_lineno for Ruby 3.2.0+ (https://github.com/ruby/ruby/pull/6430)
 //
 // `node_id` gets used depending on Ruby VM compilation settings (USE_ISEQ_NODE_ID being defined).
 // To avoid getting false "unused argument" warnings in setups where it's not used, we need to do this weird dance
@@ -322,7 +323,11 @@ calc_pos(const rb_iseq_t *iseq, const VALUE *pc, int *lineno, int *node_id)
             VM_ASSERT(! ISEQ_BODY(iseq)->local_table_size);
             return 0;
         }
-        if (lineno) *lineno = FIX2INT(ISEQ_BODY(iseq)->location.first_lineno);
+        # ifndef NO_INT_FIRST_LINENO // Ruby 3.2+
+          if (lineno) *lineno = ISEQ_BODY(iseq)->location.first_lineno;
+        # else
+          if (lineno) *lineno = FIX2INT(ISEQ_BODY(iseq)->location.first_lineno);
+        #endif
 #ifdef USE_ISEQ_NODE_ID
         if (node_id) *node_id = -1;
 #endif


### PR DESCRIPTION
**What does this PR do?**:

This PR fixes a theoretical line number calculation bug in the profiler.

Why theoretical?

Because the `! pc` branch it's under is never called by the profiler currently (the `ddtrace_rb_profile_frames` checks for a valid `pc` before calling the line number calculation). Nevertheless, I think it's worth fixing as in the future our code may change.

Since Ruby 3.2.0+ (<https://github.com/ruby/ruby/pull/6430>) the `first_lineno` that Ruby stores for a set of instructions is stored as a regular `int` and not as a Ruby `VALUE`.

The `calc_pos` function inside `private_vm_api_access.c` was copied from the Ruby sources before that refactoring, and thus was still trying to convert the Ruby `VALUE` to an `int`, which is not correct for modern Rubies.

Since this code path is only for really rare situations -- In fact, older versions of the VM code
(see https://github.com/ruby/ruby/commit/ea6062898ad0d66ede0a1866028c0605c357e2cb ) even had a comment saying this could happen "during VM bootup", this was not caught on any of our testing.

TL;DR I discovered this when I was reading the code and working on something else and got curious, and tested this by manually forcing `pc = NULL` and then re-running our test suite.

**Motivation**:

Make sure in the future we don't get tripped by this potential bug.

**Additional Notes**:

N/A

**How to test the change?**:

As I mentioned above, this issue is for something we don't expect can happen currently, deep inside `private_vm_api_access.c`.

Exposing this function for unit testing would be more work and add more complexity for something that's not expected to trigger, so I've opted to only test manually with the change exposed above.