### PR TITLE
[PROF-7654] Bump libdatadog dependency to version 3

### DIFF
--- a/ddtrace.gemspec
+++ b/ddtrace.gemspec
@@ -66,7 +66,7 @@ Gem::Specification.new do |spec|
 
   # Used by profiling (and possibly others in the future)
   # When updating the version here, please also update the version in `native_extension_helpers.rb` (and yes we have a test for it)
-  spec.add_dependency 'libdatadog', '~> 2.0.0.1.0'
+  spec.add_dependency 'libdatadog', '~> 3.0.0.1.0'
 
   spec.extensions = ['ext/ddtrace_profiling_native_extension/extconf.rb', 'ext/ddtrace_profiling_loader/extconf.rb']
 end

--- a/ext/ddtrace_profiling_native_extension/http_transport.c
+++ b/ext/ddtrace_profiling_native_extension/http_transport.c
@@ -205,8 +205,16 @@ static VALUE perform_export(
   uint64_t timeout_milliseconds
 ) {
   ddog_prof_ProfiledEndpointsStats *endpoints_stats = NULL; // Not in use yet
-  ddog_prof_Exporter_Request_BuildResult build_result =
-    ddog_prof_Exporter_Request_build(exporter, start, finish, slice_files, additional_tags, endpoints_stats, timeout_milliseconds);
+  ddog_prof_Exporter_Request_BuildResult build_result = ddog_prof_Exporter_Request_build(
+    exporter,
+    start,
+    finish,
+    slice_files,
+    additional_tags,
+    endpoints_stats,
+    NULL, // TODO: PR #2927 will start to use this
+    timeout_milliseconds
+  );
 
   if (build_result.tag == DDOG_PROF_EXPORTER_REQUEST_BUILD_RESULT_ERR) {
     ddog_prof_Exporter_drop(exporter);

--- a/ext/ddtrace_profiling_native_extension/native_extension_helpers.rb
+++ b/ext/ddtrace_profiling_native_extension/native_extension_helpers.rb
@@ -15,7 +15,7 @@ module Datadog
       # The MJIT header was introduced on 2.6 and removed on 3.3; for other Rubies we rely on debase-ruby_core_source
       CAN_USE_MJIT_HEADER = RUBY_VERSION.start_with?('2.6', '2.7', '3.0.', '3.1.', '3.2.')
 
-      LIBDATADOG_VERSION = '~> 2.0.0.1.0'
+      LIBDATADOG_VERSION = '~> 3.0.0.1.0'
 
       def self.fail_install_if_missing_extension?
         ENV[ENV_FAIL_INSTALL_IF_MISSING_EXTENSION].to_s.strip.downcase == 'true'

--- a/spec/datadog/profiling/http_transport_spec.rb
+++ b/spec/datadog/profiling/http_transport_spec.rb
@@ -307,6 +307,7 @@ RSpec.describe Datadog::Profiling::HttpTransport do
           'family' => 'ruby',
           'version' => '4',
           'endpoint_counts' => nil,
+          'internal' => {},
         )
       end
 
@@ -354,6 +355,7 @@ RSpec.describe Datadog::Profiling::HttpTransport do
           'family' => 'ruby',
           'version' => '4',
           'endpoint_counts' => nil,
+          'internal' => {},
         )
 
         expect(body[code_provenance_file_name]).to be nil


### PR DESCRIPTION
**What does this PR do?**:

This PR bumps the libdatadog dependency on dd-trace-rb to version 3 (specifically, '~> 3.0.0.1.0').

It also includes small changes to code/tests to adapt to changes in libdatadog and get a green CI.

**Motivation**:

Libdatadog 3 includes the new "internal metadata" feature which we'll use in #2927.

**Additional Notes**:

Despite the jump in major version, the changes between libdatadog 2 and 3 were minimal. The version was bumped because the library is following semantic versioning, and a public API was changed.

**How to test the change?**:

Running the profiling specs exercises libdatadog, and thus we have quite a lot of test coverage for it.