### PR TITLE
[PROF-7440] Use invoke location as a fallback for nameless threads in the profiler

### DIFF
--- a/ext/ddtrace_profiling_native_extension/collectors_thread_context.c
+++ b/ext/ddtrace_profiling_native_extension/collectors_thread_context.c
@@ -663,6 +663,13 @@ static void trigger_sample_for_thread(
       .key = DDOG_CHARSLICE_C("thread name"),
       .str = main_thread_name
     };
+  } else {
+    // For other threads without name, we use the "invoke location" (first file:line of the block used to start the thread), if any.
+    // This is what Ruby shows in `Thread#to_s`.
+    labels[label_pos++] = (ddog_prof_Label) {
+      .key = DDOG_CHARSLICE_C("thread name"),
+      .str = thread_context->thread_invoke_location_char_slice // This is an empty string if no invoke location was available
+    };
   }
 
   struct trace_identifiers trace_identifiers_result = {.valid = false, .trace_endpoint = Qnil};

--- a/ext/ddtrace_profiling_native_extension/collectors_thread_context.c
+++ b/ext/ddtrace_profiling_native_extension/collectors_thread_context.c
@@ -767,17 +767,15 @@ static void initialize_context(VALUE thread, struct per_thread_context *thread_c
   snprintf(thread_context->thread_id, THREAD_ID_LIMIT_CHARS, "%"PRIu64" (%lu)", native_thread_id_for(thread), (unsigned long) thread_id_for(thread));
   thread_context->thread_id_char_slice = (ddog_CharSlice) {.ptr = thread_context->thread_id, .len = strlen(thread_context->thread_id)};
 
-  VALUE invoke_file_location = invoke_file_location_for(thread);
-  VALUE invoke_line_location = invoke_line_location_for(thread);
+  int invoke_line_location;
+  VALUE invoke_file_location = invoke_location_for(thread, &invoke_line_location);
   if (invoke_file_location != Qnil) {
-    if (invoke_line_location == Qnil) invoke_line_location = RB_INT2NUM(0);
-
     snprintf(
       thread_context->thread_invoke_location,
       THREAD_INVOKE_LOCATION_LIMIT_CHARS,
       "%s:%d",
       StringValueCStr(invoke_file_location),
-      NUM2INT(invoke_line_location)
+      invoke_line_location
     );
   } else {
     snprintf(thread_context->thread_invoke_location, THREAD_INVOKE_LOCATION_LIMIT_CHARS, "%s", "");

--- a/ext/ddtrace_profiling_native_extension/extconf.rb
+++ b/ext/ddtrace_profiling_native_extension/extconf.rb
@@ -155,6 +155,9 @@ $defs << '-DNO_RACTORS' if RUBY_VERSION < '3'
 # On older Rubies, rb_global_vm_lock_struct did not include the owner field
 $defs << '-DNO_GVL_OWNER' if RUBY_VERSION < '2.6'
 
+# On older Rubies, there was no thread->invoke_arg
+$defs << '-DNO_THREAD_INVOKE_ARG' if RUBY_VERSION < '2.6'
+
 # On older Rubies, we need to use rb_thread_t instead of rb_execution_context_t
 $defs << '-DUSE_THREAD_INSTEAD_OF_EXECUTION_CONTEXT' if RUBY_VERSION < '2.5'
 

--- a/ext/ddtrace_profiling_native_extension/private_vm_api_access.c
+++ b/ext/ddtrace_profiling_native_extension/private_vm_api_access.c
@@ -798,14 +798,11 @@ static const rb_iseq_t *maybe_thread_invoke_proc_iseq(VALUE thread_value) {
   return iseq;
 }
 
-VALUE invoke_file_location_for(VALUE thread) {
+VALUE invoke_location_for(VALUE thread, int *line_location) {
   const rb_iseq_t *iseq = maybe_thread_invoke_proc_iseq(thread);
 
-  return iseq != NULL ? rb_iseq_path(iseq) : Qnil;
-}
+  if (iseq == NULL) return Qnil;
 
-VALUE invoke_line_location_for(VALUE thread) {
-  const rb_iseq_t *iseq = maybe_thread_invoke_proc_iseq(thread);
-
-  return iseq != NULL ? rb_iseq_first_lineno(iseq) : Qnil;
+  *line_location = NUM2INT(rb_iseq_first_lineno(iseq));
+  return rb_iseq_path(iseq);
 }

--- a/ext/ddtrace_profiling_native_extension/private_vm_api_access.c
+++ b/ext/ddtrace_profiling_native_extension/private_vm_api_access.c
@@ -776,9 +776,15 @@ check_method_entry(VALUE obj, int can_be_svar)
 static const rb_iseq_t *maybe_thread_invoke_proc_iseq(VALUE thread_value) {
   rb_thread_t *thread = thread_struct_from_object(thread_value);
 
-  if (thread->invoke_type != thread_invoke_type_proc) return NULL;
+  #ifndef NO_THREAD_INVOKE_ARG // Ruby 2.6+
+    if (thread->invoke_type != thread_invoke_type_proc) return NULL;
 
-  VALUE proc = thread->invoke_arg.proc.proc;
+    VALUE proc = thread->invoke_arg.proc.proc;
+  #else
+    if (thread->first_func || !thread->first_proc) return NULL;
+
+    VALUE proc = thread->first_proc;
+  #endif
 
   const rb_iseq_t *iseq = rb_proc_get_iseq(proc, 0);
   if (iseq == NULL) return NULL;

--- a/ext/ddtrace_profiling_native_extension/private_vm_api_access.c
+++ b/ext/ddtrace_profiling_native_extension/private_vm_api_access.c
@@ -778,9 +778,9 @@ static const rb_iseq_t *maybe_thread_invoke_proc_iseq(VALUE thread_value) {
 
   if (thread->invoke_type != thread_invoke_type_proc) return NULL;
 
-  VALUE iseq_value = thread->invoke_arg.proc.proc;
+  VALUE proc = thread->invoke_arg.proc.proc;
 
-  const rb_iseq_t *iseq = rb_proc_get_iseq(iseq_value, 0);
+  const rb_iseq_t *iseq = rb_proc_get_iseq(proc, 0);
   if (iseq == NULL) return NULL;
 
   rb_iseq_check(iseq);
@@ -796,5 +796,5 @@ VALUE invoke_file_location_for(VALUE thread) {
 VALUE invoke_line_location_for(VALUE thread) {
   const rb_iseq_t *iseq = maybe_thread_invoke_proc_iseq(thread);
 
-  return iseq != NULL ? RB_INT2NUM(ISEQ_BODY(iseq)->location.first_lineno) : Qnil;
+  return iseq != NULL ? rb_iseq_first_lineno(iseq) : Qnil;
 }

--- a/ext/ddtrace_profiling_native_extension/private_vm_api_access.h
+++ b/ext/ddtrace_profiling_native_extension/private_vm_api_access.h
@@ -44,8 +44,8 @@ bool ddtrace_rb_ractor_main_p(void);
 // See comment on `record_placeholder_stack_in_native_code` for a full explanation of what this means (and why we don't just return 0)
 #define PLACEHOLDER_STACK_IN_NATIVE_CODE -1
 
-// These methods provide the file and line of the "invoke location" of a thread (first file:line of the block used to
+// This method provides the file and line of the "invoke location" of a thread (first file:line of the block used to
 // start the thread), if any.
 // This is what Ruby shows in `Thread#to_s`.
-VALUE invoke_file_location_for(VALUE thread);
-VALUE invoke_line_location_for(VALUE thread);
+// The file is returned directly, and the line is recorded onto *line_location.
+VALUE invoke_location_for(VALUE thread, int *line_location);

--- a/ext/ddtrace_profiling_native_extension/private_vm_api_access.h
+++ b/ext/ddtrace_profiling_native_extension/private_vm_api_access.h
@@ -43,3 +43,9 @@ bool ddtrace_rb_ractor_main_p(void);
 
 // See comment on `record_placeholder_stack_in_native_code` for a full explanation of what this means (and why we don't just return 0)
 #define PLACEHOLDER_STACK_IN_NATIVE_CODE -1
+
+// These methods provide the file and line of the "invoke location" of a thread (first file:line of the block used to
+// start the thread), if any.
+// This is what Ruby shows in `Thread#to_s`.
+VALUE invoke_file_location_for(VALUE thread);
+VALUE invoke_line_location_for(VALUE thread);

--- a/spec/datadog/profiling/collectors/thread_context_spec.rb
+++ b/spec/datadog/profiling/collectors/thread_context_spec.rb
@@ -1107,7 +1107,7 @@ RSpec.describe Datadog::Profiling::Collectors::ThreadContext do
           [t1, t2, t3].each do |thread|
             invoke_location = per_thread_context.fetch(thread).fetch(:thread_invoke_location)
 
-            expect(thread.to_s).to include(invoke_location)
+            expect(thread.inspect).to include(invoke_location)
             expect(invoke_location).to match(/.+\.rb:\d+/)
           end
         end

--- a/spec/datadog/profiling/collectors/thread_context_spec.rb
+++ b/spec/datadog/profiling/collectors/thread_context_spec.rb
@@ -116,20 +116,31 @@ RSpec.describe Datadog::Profiling::Collectors::ThreadContext do
         .to include(*[Thread.main, t1, t2, t3].map(&:object_id))
     end
 
-    it 'includes the thread names, if available' do
+    it 'includes the thread names' do
       t1.name = 'thread t1'
-      t2.name = nil
-      t3.name = 'thread t3'
+      t2.name = 'thread t2'
 
       sample
 
       t1_sample = samples_for_thread(samples, t1).first
       t2_sample = samples_for_thread(samples, t2).first
-      t3_sample = samples_for_thread(samples, t3).first
 
       expect(t1_sample.labels).to include(:'thread name' => 'thread t1')
-      expect(t2_sample.labels.keys).to_not include(:'thread name')
-      expect(t3_sample.labels).to include(:'thread name' => 'thread t3')
+      expect(t2_sample.labels).to include(:'thread name' => 'thread t2')
+    end
+
+    context 'when no thread names are available' do
+      # NOTE: As of this writing, the dd-trace-rb spec_helper.rb includes a monkey patch to Thread creation that we use
+      # to track specs that leak threads. This means that the invoke_location of every thread will point at the
+      # spec_helper in our test suite. Just in case you're looking at the output and being a bit confused :)
+      it 'uses the thread_invoke_location as a thread name' do
+        t1.name = nil
+        sample
+        t1_sample = samples_for_thread(samples, t1).first
+
+        expect(t1_sample.labels).to include(:'thread name' => per_thread_context.fetch(t1).fetch(:thread_invoke_location))
+        expect(t1_sample.labels).to include(:'thread name' => match(/.+\.rb:\d+/))
+      end
     end
 
     it 'includes a fallback name for the main thread, when not set' do
@@ -918,13 +929,10 @@ RSpec.describe Datadog::Profiling::Collectors::ThreadContext do
         Thread.current.name = 'thread_with_name'
         sample_allocation(weight: 123)
       end.join
-      thread_without_name = Thread.new { sample_allocation(weight: 123) }.join
 
       sample_with_name = samples_for_thread(samples, thread_with_name).first
-      sample_without_name = samples_for_thread(samples, thread_without_name).first
 
       expect(sample_with_name.labels).to include(:'thread name' => 'thread_with_name')
-      expect(sample_without_name.labels).to_not include(:'thread name')
     end
 
     describe 'code hotspots' do


### PR DESCRIPTION
**What does this PR do?**:

Naming Ruby threads is optional, and a lot of Ruby code still creates threads and doesn't name them.

As a workaround for Ruby threads that have no name, this PR makes the profiler use the "thread invoke location", which is what Ruby shows in the `to_s`/`inspect` of a thread, for instance:

```
[1] pry(main)> Thread.list.last.name
=> nil
[2] pry(main)> Thread.list.last.to_s
=> "#<Thread:0x00005934cc0143e8 thread-name.rb:3 sleep>"
```

The "invoke location" is the file and line where the block that starts the thread is defined (`thread-name.rb:3` for the example above).

**Motivation**:

Having nameless threads is annoying because we show this information in several places of our UX, and with the timeline feature this will be even more visible.

**Additional Notes**:

Since Ruby doesn't have an API to get this information (other than calling `to_s` and then parsing its output), and because we want to avoid allocating any Ruby objects while the profiler is taking a sample, I chose to add to `private_vm_api_access.c` an API to get this information that is basically a heavily simplified version of `Thread#to_s`.

**How to test the change?**:

This change includes code coverage. Also, profile any app that starts and doesn't name threads, and you'll start seeing threads named "some_file.rb:some_line" in the profiler.
