### PR TITLE
remove lazy call for minitest settings

### DIFF
--- a/lib/datadog/ci/contrib/minitest/configuration/settings.rb
+++ b/lib/datadog/ci/contrib/minitest/configuration/settings.rb
@@ -13,17 +13,14 @@ module Datadog
           class Settings < Datadog::Tracing::Contrib::Configuration::Settings
             option :enabled do |o|
               o.default { env_to_bool(Ext::ENV_ENABLED, true) }
-              o.lazy
             end
 
             option :service_name do |o|
               o.default { Datadog.configuration.service_without_fallback || Ext::SERVICE_NAME }
-              o.lazy
             end
 
             option :operation_name do |o|
               o.default { ENV.key?(Ext::ENV_OPERATION_NAME) ? ENV[Ext::ENV_OPERATION_NAME] : Ext::OPERATION_NAME }
-              o.lazy
             end
           end
         end


### PR DESCRIPTION
<!--
Check out the
https://github.com/DataDog/dd-trace-rb/blob/master/docs/DevelopmentGuide.md
for guidance on how to set up your development environment,
run the test suite, write new integrations, and more.
-->

**What does this PR do?**
<!-- A brief description of the change being made with this pull request. -->

The PR that introduced the minitest integration https://github.com/DataDog/dd-trace-rb/pull/2932 and the PR that removed the `lazy` options from the settings DSL https://github.com/DataDog/dd-trace-rb/pull/2931 got merged in parallel. Causing a deprecation warning to show up:

```
W, [2023-07-06T09:48:06.238562 #150779]  WARN -- ddtrace: [ddtrace] Defining an option as lazy is deprecated for removal. Options now always behave as lazy. Please remove all references to the lazy setting.
Non-lazy options that were previously stored as blocks are no longer supported. If you used this feature, please let us know by opening an issue on: https://github.com/datadog/dd-trace-rb/issues/new so we can better understand and support your use case. This will be enforced in the next major release.
W, [2023-07-06T09:48:06.238599 #150779]  WARN -- ddtrace: [ddtrace] Defining an option as lazy is deprecated for removal. Options now always behave as lazy. Please remove all references to the lazy setting.
Non-lazy options that were previously stored as blocks are no longer supported. If you used this feature, please let us know by opening an issue on: https://github.com/datadog/dd-trace-rb/issues/new so we can better understand and support your use case. This will be enforced in the next major release.
W, [2023-07-06T09:48:06.238611 #150779]  WARN -- ddtrace: [ddtrace] Defining an option as lazy is deprecated for removal. Options now always behave as lazy. Please remove all references to the lazy setting.
Non-lazy options that were previously stored as blocks are no longer supported. If you used this feature, please let us know by opening an issue on: https://github.com/datadog/dd-trace-rb/issues/new so we can better understand and support your use case. This will be enforced in the next major release.
```

This PR removes the call to `o.lazy` from the minitest settings


**Motivation**
<!-- What inspired you to submit this pull request? -->

**Additional Notes**
<!-- Anything else we should know when reviewing? -->

**How to test the change?**
<!--
Describe here how the change can be validated.
You are strongly encouraged to provide automated tests for this PR (unit or integration).
If this change cannot be feasibly tested, please explain why,
unless the change does not modify code (e.g. only modifies docs, comments).
-->
