### PR TITLE
Fix profiler libmysqlclient version detection with mysql2-aurora gem

### DIFF
--- a/Steepfile
+++ b/Steepfile
@@ -659,6 +659,7 @@ target :ddtrace do
   library 'google-protobuf'
   library 'protobuf-cucumber'
   library 'mysql2'
+  library 'mysql2-aurora'
   library 'opentracing'
   library 'concurrent-ruby'
   library 'faraday'

--- a/spec/datadog/profiling/component_spec.rb
+++ b/spec/datadog/profiling/component_spec.rb
@@ -551,6 +551,32 @@ RSpec.describe Datadog::Profiling::Component do
                 no_signals_workaround_enabled?
               end
             end
+
+            context 'when mysql2-aurora gem is loaded and libmysqlclient < 8.0.0' do
+              before do
+                fake_original_client = double('Fake original Mysql2::Client')
+                stub_const('Mysql2::Aurora::ORIGINAL_CLIENT_CLASS', fake_original_client)
+                expect(fake_original_client).to receive(:info).and_return({ version: '7.9.9' })
+
+                client_replaced_by_aurora = double('Fake Aurora Mysql2::Client')
+                stub_const('Mysql2::Client', client_replaced_by_aurora)
+              end
+
+              it { is_expected.to be true }
+            end
+
+            context 'when mysql2-aurora gem is loaded and libmysqlclient >= 8.0.0' do
+              before do
+                fake_original_client = double('Fake original Mysql2::Client')
+                stub_const('Mysql2::Aurora::ORIGINAL_CLIENT_CLASS', fake_original_client)
+                expect(fake_original_client).to receive(:info).and_return({ version: '8.0.0' })
+
+                client_replaced_by_aurora = double('Fake Aurora Mysql2::Client')
+                stub_const('Mysql2::Client', client_replaced_by_aurora)
+              end
+
+              it { is_expected.to be false }
+            end
           end
         end
 

--- a/vendor/rbs/mysql2-aurora/0/mysql2-aurora.rbs
+++ b/vendor/rbs/mysql2-aurora/0/mysql2-aurora.rbs
@@ -1,0 +1,5 @@
+module Mysql2
+  module Aurora
+    ORIGINAL_CLIENT_CLASS: untyped
+  end
+end


### PR DESCRIPTION
**What does this PR do?**:

This PR tweaks the libmysqlclient version detection code added in #2770 to also work when the `mysql2-aurora` gem is in use.

**Motivation**:

The way that the mysql2-aurora gem installs itself leads to the "no signals" workaround (#2873) being incorrectly enabled for customers that do have a modern version of libmysqlclient.

**Additional Notes**:

The mysql2-aurora gem likes to monkey patch itself in replacement of `Mysql2::Client`, and uses `method_missing` to delegate to the original BUT unfortunately does not implement `respond_to_missing?` and thus one of our checks (`respond_to?(:info)`) was incorrectly failing.

**How to test the change?**:

This change includes code coverage. This can also be reproduced easily by adding the `mysql2-aurora` gem to the `Gemfile` and then running a trivial Ruby app:

```
$ DD_PROFILING_ENABLED=true DD_TRACE_DEBUG=true bundle exec ruby -e "require 'mysql2/aurora';
require 'datadog/profiling/preload'"

 # Before

DEBUG -- ddtrace: [ddtrace] Requiring `mysql2` to check if the
`libmysqlclient` version it uses is compatible with profiling
 WARN -- ddtrace: [ddtrace] Enabling the profiling "no signals"
workaround because an incompatible version of the mysql2 gem is
installed. Profiling data will have lower quality. To fix this,
upgrade the libmysqlclient in your OS image to version 8.0.0 or above.

 # After

DEBUG -- ddtrace: [ddtrace] Requiring `mysql2` to check if the
`libmysqlclient` version it uses is compatible with profiling
DEBUG -- ddtrace: [ddtrace] The `mysql2` gem is using a compatible
version of the `libmysqlclient` library (8.0.33)
```