### PR TITLE
Minor: Improve error message when ddtrace_profiling_loader fails to load

### DIFF
--- a/lib/datadog/profiling/load_native_extension.rb
+++ b/lib/datadog/profiling/load_native_extension.rb
@@ -9,7 +9,13 @@
 # All code on this file is on-purpose at the top-level; this makes it so this file is executed only once,
 # the first time it gets required, to avoid any issues with the native extension being initialized more than once.
 
-require "ddtrace_profiling_loader.#{RUBY_VERSION}_#{RUBY_PLATFORM}"
+begin
+  require "ddtrace_profiling_loader.#{RUBY_VERSION}_#{RUBY_PLATFORM}"
+rescue LoadError => e
+  raise LoadError,
+    'Failed to load the profiling loader extension. To fix this, please remove and then reinstall ddtrace ' \
+    "(Details: #{e.message})"
+end
 
 extension_name = "ddtrace_profiling_native_extension.#{RUBY_VERSION}_#{RUBY_PLATFORM}"
 full_file_path = "#{__dir__}/../../#{extension_name}.#{RbConfig::CONFIG['DLEXT']}"


### PR DESCRIPTION
**What does this PR do?**:

This PR tweaks the error message for when `ddtrace_profiling_loader` fails to load to suggest to customers that they reinstall ddtrace.

This came out of a customer running into this issue in <https://github.com/DataDog/dd-trace-rb/issues/2242#issuecomment-1620191535>

Here's how it looks now when it fails:

```
$ DD_PROFILING_ENABLED=true bundle exec ruby -e "require 'datadog/profiling/preload'"
WARN -- ddtrace: [ddtrace] Profiling was requested but is not supported,
profiling disabled: There was an error loading the profiling native extension due to
'LoadError Failed to load the profiling loader extension. To fix this, please remove
and then reinstall ddtrace (Details: cannot load such file --
ddtrace_profiling_loader.2.7.7_x86_64-linux)' at
'load_native_extension.rb:15:in `rescue in <top (required)>''
```

**Motivation**:

Suggest the most common fix for this issue instead of leaving customers to wonder about the next steps.

**Additional Notes**:

Since the `ddtrace_profiling_loader` is very very simple, it should always be available and be found. When it's not found, on all cases I've seen it's because it hardcodes the current Ruby version it its name, and thus it needs to be rebuilt after upgrading Ruby.

Thus it makes sense to suggest rebuilding it.

(The loader doesn't strictly need to include the Ruby version, but doing so makes it easier to switch Rubies during development, and it acts as a canary for the profiling native extension as well -- if this one fails to load, the native extension will also for the same reason).

**How to test the change?**:

This issue can be triggered with the example command-line above by not compiling profiler (or running `bundle exec rake clean`) and then removing any pre-existing profiling extensions
(`rm lib/ddtrace_profiling_*`).
