### PR TITLE
Update CHANGELOG to mention YJIT stat tracking

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## [Unreleased]
 
+### Added
+* Runtime Metrics: YJIT statistics on Ruby 3.2 (when YJIT is enabled) ([#2711][])
+
 ## [1.12.1] - 2023-06-14
 
 ### Added


### PR DESCRIPTION
In #2711, I forgot to include an update to the CHANGELOG.

**What does this PR do?**
Only updates the CHANGELOG.

**Motivation**
Wanting to mention the YJIT stat tracking so that folks interested in tracking them don't miss it.

**Additional Notes**
n/a

**How to test the change?**
n/a documentation only