### PR TITLE
Prevent telemetry requests from being traced

### DIFF
--- a/lib/datadog/core/telemetry/http/transport.rb
+++ b/lib/datadog/core/telemetry/http/transport.rb
@@ -38,6 +38,7 @@ module Datadog
 
           def headers(request_type:, api_version: Http::Ext::API_VERSION)
             {
+              Datadog::Transport::Ext::HTTP::HEADER_DD_INTERNAL_UNTRACED_REQUEST => '1',
               Http::Ext::HEADER_CONTENT_TYPE => Http::Ext::CONTENT_TYPE_APPLICATION_JSON,
               Http::Ext::HEADER_DD_TELEMETRY_API_VERSION => api_version,
               Http::Ext::HEADER_DD_TELEMETRY_REQUEST_TYPE => request_type,

--- a/lib/datadog/tracing/contrib/http/circuit_breaker.rb
+++ b/lib/datadog/tracing/contrib/http/circuit_breaker.rb
@@ -10,7 +10,7 @@ module Datadog
         # For avoiding recursive traces.
         module CircuitBreaker
           def should_skip_tracing?(request)
-            return true if datadog_http_request?(request) || datadog_test_agent_http_request?(request)
+            return true if internal_request?(request)
 
             # we don't want a "shotgun" effect with two nested traces for one
             # logical get, and request is likely to call itself recursively
@@ -23,23 +23,9 @@ module Datadog
           # We don't want to trace our own call to the API (they use net/http)
           # TODO: We don't want this kind of soft-check on HTTP requests.
           #       Remove this when transport implements its own "skip tracing" mechanism.
-          def datadog_http_request?(request)
-            if request[Datadog::Transport::Ext::HTTP::HEADER_META_TRACER_VERSION]
-              true
-            else
-              false
-            end
-          end
-
-          # Check if there is header present for not tracing this request. Necessary to prevent http requests
-          # used for checking if the APM Test Agent is running from being traced.
-          # TODO: Remove this when transport implements its own "skip tracing" mechanism.
-          def datadog_test_agent_http_request?(request)
-            if request['X-Datadog-Untraced-Request']
-              true
-            else
-              false
-            end
+          def internal_request?(request)
+            !!(request[Datadog::Transport::Ext::HTTP::HEADER_META_TRACER_VERSION] ||
+              request[Transport::Ext::HTTP::HEADER_DD_INTERNAL_UNTRACED_REQUEST])
           end
 
           def should_skip_distributed_tracing?(client_config)

--- a/lib/ddtrace/transport/ext.rb
+++ b/lib/ddtrace/transport/ext.rb
@@ -25,6 +25,7 @@ module Datadog
         HEADER_META_TRACER_VERSION = 'Datadog-Meta-Tracer-Version'
 
         # Header that prevents the Net::HTTP integration from tracing internal trace requests.
+        # Set it to any value to skip tracing.
         HEADER_DD_INTERNAL_UNTRACED_REQUEST = 'DD-Internal-Untraced-Request'
       end
 

--- a/lib/ddtrace/transport/ext.rb
+++ b/lib/ddtrace/transport/ext.rb
@@ -23,6 +23,9 @@ module Datadog
         HEADER_META_LANG_VERSION = 'Datadog-Meta-Lang-Version'
         HEADER_META_LANG_INTERPRETER = 'Datadog-Meta-Lang-Interpreter'
         HEADER_META_TRACER_VERSION = 'Datadog-Meta-Tracer-Version'
+
+        # Header that prevents the Net::HTTP integration from tracing internal trace requests.
+        HEADER_DD_INTERNAL_UNTRACED_REQUEST = 'DD-Internal-Untraced-Request'
       end
 
       # @public_api

--- a/sig/datadog/tracing/contrib/http/circuit_breaker.rbs
+++ b/sig/datadog/tracing/contrib/http/circuit_breaker.rbs
@@ -4,7 +4,7 @@ module Datadog
       module HTTP
         module CircuitBreaker
           def should_skip_tracing?: (untyped request) -> (true | false)
-          def datadog_http_request?: (untyped request) -> (true | false)
+          def internal_request?: (untyped request) -> bool
 
           def should_skip_distributed_tracing?: (untyped client_config) -> untyped
         end

--- a/spec/datadog/core/telemetry/http/transport_spec.rb
+++ b/spec/datadog/core/telemetry/http/transport_spec.rb
@@ -27,9 +27,10 @@ RSpec.describe Datadog::Core::Telemetry::Http::Transport do
     let(:env) { instance_double(Datadog::Core::Telemetry::Http::Env, body: payload, path: path) }
     let(:headers) do
       {
-        Datadog::Core::Telemetry::Http::Ext::HEADER_CONTENT_TYPE => 'application/json',
-        Datadog::Core::Telemetry::Http::Ext::HEADER_DD_TELEMETRY_API_VERSION => 'v1',
-        Datadog::Core::Telemetry::Http::Ext::HEADER_DD_TELEMETRY_REQUEST_TYPE => request_type,
+        'Content-Type' => 'application/json',
+        'DD-Telemetry-API-Version' => 'v1',
+        'DD-Telemetry-Request-Type' => 'app-started',
+        'DD-Internal-Untraced-Request' => '1',
       }
     end
     let(:hostname) { 'foo' }

--- a/spec/datadog/tracing/contrib/http/request_spec.rb
+++ b/spec/datadog/tracing/contrib/http/request_spec.rb
@@ -223,6 +223,30 @@ RSpec.describe 'net/http requests' do
     end
   end
 
+  describe 'with an internal HTTP request' do
+    subject(:response) { client.get(path, headers) }
+    let(:headers) { { 'DD-Internal-Untraced-Request' => '1' } }
+
+    before { stub_request(:get, "#{uri}#{path}") }
+
+    it 'does not trace internal requests' do
+      response
+      expect(spans).to be_empty
+    end
+
+    describe 'integration' do
+      let(:transport) { Datadog::Transport::HTTP.default }
+
+      it 'does not create a span for the transport request' do
+        expect(Datadog::Tracing).to_not receive(:trace)
+
+        transport.send_traces(get_test_traces(1))
+
+        expect(WebMock).to have_requested(:post, %r{/v0.4/traces})
+      end
+    end
+  end
+
   describe 'Net::HTTP object pin' do
     context 'when overriden with a different #service value' do
       subject(:response) { client.get(path) }

--- a/spec/support/network_helpers.rb
+++ b/spec/support/network_helpers.rb
@@ -43,7 +43,7 @@ module NetworkHelpers
   def check_availability_by_http_request(host, port)
     uri = URI("http://#{host}:#{port}/info")
     request = Net::HTTP::Get.new(uri)
-    request['X-Datadog-Untraced-Request'] = true
+    request[Datadog::Transport::Ext::HTTP::HEADER_DD_INTERNAL_UNTRACED_REQUEST] = true
     response = Net::HTTP.start(uri.hostname, uri.port) do |http|
       http.request(request)
     end

--- a/spec/support/network_helpers.rb
+++ b/spec/support/network_helpers.rb
@@ -43,7 +43,7 @@ module NetworkHelpers
   def check_availability_by_http_request(host, port)
     uri = URI("http://#{host}:#{port}/info")
     request = Net::HTTP::Get.new(uri)
-    request[Datadog::Transport::Ext::HTTP::HEADER_DD_INTERNAL_UNTRACED_REQUEST] = true
+    request[Datadog::Transport::Ext::HTTP::HEADER_DD_INTERNAL_UNTRACED_REQUEST] = '1'
     response = Net::HTTP.start(uri.hostname, uri.port) do |http|
       http.request(request)
     end


### PR DESCRIPTION
Telemetry has its own custom transport, and it was missing a flag that lets the `Net::HTTP` tracing integration know to skip instrumenting the telemetry request.

This PR adds that flag, as an HTTP header, similar to how other `ddtrace` components operate.

There is also a bit of refactoring around this flag, to easy clarity during future use and simplify the circuit breaker implementation.