### PR TITLE
OpenSearch Integration Version Update

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -78,6 +78,11 @@ test_containers:
     environment:
       - discovery.type=single-node
       - DISABLE_SECURITY_PLUGIN=true
+      # make sure it works on nearly full disk
+      - cluster.routing.allocation.disk.watermark.low=3gb
+      - cluster.routing.allocation.disk.watermark.high=2gb
+      - cluster.routing.allocation.disk.watermark.flood_stage=1gb
+      - cluster.routing.allocation.disk.threshold_enabled=false
   - &opensearch_port 9200
   - &container_elasticsearch
     image: elasticsearch:8.1.3

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -73,12 +73,13 @@ test_containers:
   - &mysql_port 3306
   - &opensearch_host opensearch
   - &container_opensearch
-    image: opensearchproject/opensearch:2.8.0
+    image: opensearchproject/opensearch:1.3.6  # Version 2.8.0 causes flaky error (https://github.com/opensearch-project/docker-images/issues/31).
     name: *opensearch_host
     environment:
       - discovery.type=single-node
       - DISABLE_SECURITY_PLUGIN=true
-      # make sure it works on nearly full disk
+      # Make sure it works on nearly full disk.
+      - cluster.routing.allocation.disk.threshold_enabled=true
       - cluster.routing.allocation.disk.watermark.low=3gb
       - cluster.routing.allocation.disk.watermark.high=2gb
       - cluster.routing.allocation.disk.watermark.flood_stage=1gb

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -464,11 +464,12 @@ services:
     ports:
       - "127.0.0.1:${TEST_MYSQL_PORT}:3306"
   opensearch:
-    image: opensearchproject/opensearch:2.8.0
+    image: opensearchproject/opensearch:1.3.6 # Version 2.8.0 causes flaky error (https://github.com/opensearch-project/docker-images/issues/31).
     environment:
       - discovery.type=single-node
       - DISABLE_SECURITY_PLUGIN=true
-      # make sure it works on nearly full disk
+      # Make sure it works on nearly full disk.
+      - cluster.routing.allocation.disk.threshold_enabled=true
       - cluster.routing.allocation.disk.watermark.low=3gb
       - cluster.routing.allocation.disk.watermark.high=2gb
       - cluster.routing.allocation.disk.watermark.flood_stage=1gb

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -468,6 +468,11 @@ services:
     environment:
       - discovery.type=single-node
       - DISABLE_SECURITY_PLUGIN=true
+      # make sure it works on nearly full disk
+      - cluster.routing.allocation.disk.watermark.low=3gb
+      - cluster.routing.allocation.disk.watermark.high=2gb
+      - cluster.routing.allocation.disk.watermark.flood_stage=1gb
+      - cluster.routing.allocation.disk.threshold_enabled=false
     ports:
       - 9201:9200
   postgres:


### PR DESCRIPTION
<!--
Check out the
https://github.com/DataDog/dd-trace-rb/blob/master/docs/DevelopmentGuide.md
for guidance on how to set up your development environment,
run the test suite, write new integrations, and more.
-->

**What does this PR do?**
Changes OpenSearch version from 2.8.0 to 1.3.6 in order to resolve flaky CircleCI tests.

**Motivation**
Previous version was occasionally causing the OpenSearch container to error out.

**Additional Notes**
N/A

**How to test the change?**
Changes can be tested by pushing to CircleCI. Previous run results are located [here](https://app.circleci.com/pipelines/github/DataDog/dd-trace-rb?branch=feature%2Fopensearch_from_scratch). Note that the test runs are currently all showing as errors due to google-protobuf dropping support for Ruby 2.6. This causes `build_and_test_integration-2.6` to fail each time. There are other flaky tests present as well (see [here](https://app.circleci.com/pipelines/github/DataDog/dd-trace-rb/10882/workflows/59ec0697-665b-4a5d-adc4-9227cc1841d0/jobs/406914) and [here](https://app.circleci.com/pipelines/github/DataDog/dd-trace-rb/10882/workflows/adba5663-cac8-4a92-b8bd-2a533c5950f7/jobs/406672)); however, they are not related to the OpenSearch container spinning up.
