### PR TITLE
Fixes `web_service_name` default for rack integration

### DIFF
--- a/lib/datadog/tracing/contrib/rack/configuration/settings.rb
+++ b/lib/datadog/tracing/contrib/rack/configuration/settings.rb
@@ -37,7 +37,14 @@ module Datadog
 
             option :service_name
 
-            option :web_service_name, default: Ext::DEFAULT_PEER_WEBSERVER_SERVICE_NAME
+            option :web_service_name do |o|
+              o.default do
+                Contrib::SpanAttributeSchema.fetch_service_name(
+                  '',
+                  Ext::DEFAULT_PEER_WEBSERVER_SERVICE_NAME
+                )
+              end
+            end
           end
         end
       end


### PR DESCRIPTION
The introduction of the `SpanAttributeSchema` module, all service names in integrations default to global `$DD_SERVICE` when enabled. 

This PR adds that functionality to the `web_service_name` option as well for rack such that intermediate spans can also be flattened to `$DD_SERVICE` when enabled