### PR TITLE
RC:Add apply state and apply error

### DIFF
--- a/lib/datadog/core/remote/configuration/content.rb
+++ b/lib/datadog/core/remote/configuration/content.rb
@@ -41,6 +41,7 @@ module Datadog
           # Sets this configuration as successfully applied.
           def applied
             @apply_state = ApplyState::ACKNOWLEDGED
+            @apply_error = nil
           end
 
           # Sets this configuration as not successfully applied, with

--- a/lib/datadog/core/remote/configuration/content.rb
+++ b/lib/datadog/core/remote/configuration/content.rb
@@ -18,12 +18,14 @@ module Datadog
             end
           end
 
-          attr_reader :path, :data, :hashes
+          attr_reader :path, :data, :hashes, :apply_state, :apply_error
           attr_accessor :version
 
           def initialize(path:, data:)
             @path = path
             @data = data
+            @apply_state = ApplyState::UNACKNOWLEDGED
+            @apply_error = nil
             @hashes = {}
             @version = 0
           end
@@ -34,6 +36,30 @@ module Datadog
 
           def length
             @length ||= @data.size
+          end
+
+          # Sets this configuration as successfully applied.
+          def applied
+            @apply_state = ApplyState::ACKNOWLEDGED
+          end
+
+          # Sets this configuration as not successfully applied, with
+          # a message describing the error.
+          def errored(error_message)
+            @apply_state = ApplyState::ERROR
+            @apply_error = error_message
+          end
+
+          module ApplyState
+            # Default state of configurations.
+            # Set until the component consuming the configuration has acknowledged it was applied.
+            UNACKNOWLEDGED = 1
+
+            # Set when the configuration has been successfully applied.
+            ACKNOWLEDGED = 2
+
+            # Set when the configuration has been unsuccessfully applied.
+            ERROR = 3
           end
 
           private

--- a/lib/datadog/core/remote/configuration/repository.rb
+++ b/lib/datadog/core/remote/configuration/repository.rb
@@ -94,7 +94,9 @@ module Datadog
                 {
                   id: content.path.config_id,
                   version: content.version,
-                  product: content.path.product
+                  product: content.path.product,
+                  apply_state: content.apply_state,
+                  apply_error: content.apply_error,
                 }
               end
             end

--- a/sig/datadog/core/remote/configuration/content.rbs
+++ b/sig/datadog/core/remote/configuration/content.rbs
@@ -13,13 +13,27 @@ module Datadog
 
           attr_accessor version: Integer
 
+          attr_reader apply_state: Integer
+
+          attr_reader apply_error: String?
+
           @length: Integer
 
           def initialize: (path: Configuration::Path, data: StringIO) -> void
 
+          def applied: -> void
+
+          def errored: (String error_message) -> void
+
           def hexdigest: (Symbol type) -> String
 
           def length: () -> Integer
+
+          module ApplyState
+            ACKNOWLEDGED: Integer
+            ERROR: Integer
+            UNACKNOWLEDGED: Integer
+          end
 
           private
 

--- a/spec/datadog/core/remote/configuration/content_spec.rb
+++ b/spec/datadog/core/remote/configuration/content_spec.rb
@@ -264,5 +264,25 @@ RSpec.describe Datadog::Core::Remote::Configuration::ContentList do
         end
       end
     end
+
+    describe '#applied' do
+      subject(:applied) { content.applied }
+
+      it 'sets applied_state to acknowledged' do
+        applied
+        expect(content.apply_state).to eq(2)
+      end
+    end
+
+    describe '#errored' do
+      subject(:errored) { content.errored(message) }
+      let(:message) { 'test-message' }
+
+      it 'sets applied_state to error with message' do
+        errored
+        expect(content.apply_state).to eq(3)
+        expect(content.apply_error).to eq('test-message')
+      end
+    end
   end
 end

--- a/spec/datadog/core/remote/configuration/content_spec.rb
+++ b/spec/datadog/core/remote/configuration/content_spec.rb
@@ -272,6 +272,14 @@ RSpec.describe Datadog::Core::Remote::Configuration::ContentList do
         applied
         expect(content.apply_state).to eq(2)
       end
+
+      it 'clear errors' do
+        content.errored('error message')
+
+        applied
+
+        expect(content.apply_error).to be_nil
+      end
     end
 
     describe '#errored' do

--- a/spec/datadog/core/remote/configuration/respository_spec.rb
+++ b/spec/datadog/core/remote/configuration/respository_spec.rb
@@ -370,7 +370,7 @@ RSpec.describe Datadog::Core::Remote::Configuration::Repository do
       context 'with changes' do
         let(:expected_config_states) do
           [
-            { :id => path.config_id, :product => path.product, :version => 1 }
+            { :id => path.config_id, :product => path.product, :version => 1, apply_error: nil, apply_state: 1 }
           ]
         end
 
@@ -397,7 +397,7 @@ RSpec.describe Datadog::Core::Remote::Configuration::Repository do
             end
 
             expected_updated_config_states = [
-              { :id => path.config_id, :product => path.product, :version => 2 }
+              { :id => path.config_id, :product => path.product, :version => 2, apply_error: nil, apply_state: 1 }
             ]
 
             expect(repository.state.config_states).to_not eq(expected_config_states)


### PR DESCRIPTION
This PR adds the `apply_state` and `apply_error` fields to the configuration content payload we sent back to the agent.

This allows downstream systems to know if the configuration was correctly applied, and if not, why.

This is used to display to users that Remote Configuration was correctly applied, or if it was not, what was the reason.