### PR TITLE
Allow blocking response configuration

### DIFF
--- a/lib/datadog/appsec/configuration/settings.rb
+++ b/lib/datadog/appsec/configuration/settings.rb
@@ -95,6 +95,62 @@ module Datadog
                 end
               end
 
+              settings :block do
+                # HTTP status code to block with
+                option :status do |o|
+                  o.default { 403 }
+                end
+
+                # only applies to redirect status codes
+                option :location do |o|
+                  o.setter { |v| URI(v) unless v.nil? }
+                end
+
+                # only applies to non-redirect status codes with bodies
+                option :templates do |o|
+                  o.default do
+                    json = ENV.fetch(
+                      'DD_APPSEC_HTTP_BLOCKED_TEMPLATE_JSON',
+                      :json
+                    )
+
+                    html = ENV.fetch(
+                      'DD_APPSEC_HTTP_BLOCKED_TEMPLATE_HTML',
+                      :html
+                    )
+
+                    text = ENV.fetch(
+                      'DD_APPSEC_HTTP_BLOCKED_TEMPLATE_TEXT',
+                      :text
+                    )
+
+                    {
+                      'application/json' => json,
+                      'text/html' => html,
+                      'text/plain' => text,
+                    }
+                  end
+                  o.setter do |v|
+                    next if v.nil?
+
+                    # TODO: should merge with o.default to allow overriding only one mime type
+
+                    v.each do |k, w|
+                      case w
+                      when :json, :html, :text
+                        next
+                      when String, Pathname
+                        next if File.exist?(w.to_s)
+
+                        raise(ArgumentError, "appsec.templates.#{k}: file not found: #{w}")
+                      else
+                        raise ArgumentError, "appsec.templates.#{k}: unexpected value: #{w.inspect}"
+                      end
+                    end
+                  end
+                end
+              end
+
               settings :track_user_events do
                 option :enabled do |o|
                   o.default do

--- a/sig/datadog/appsec/response.rbs
+++ b/sig/datadog/appsec/response.rbs
@@ -3,9 +3,10 @@ module Datadog
     class Response
       attr_reader status: ::Integer
       attr_reader headers: ::Hash[::String, ::String]
-      attr_reader body: ::Array[untyped]
+      attr_reader body: ::Array[::String]
 
-      def initialize: (status: ::Integer, ?headers: ::Hash[::String, ::String], ?body: ::Array[untyped]) -> void
+
+      def initialize: (status: ::Integer, ?headers: ::Hash[::String, ::String], ?body: ::Array[::String]) -> void
       def to_rack: () -> ::Array[untyped]
       def to_sinatra_response: () -> ::Sinatra::Response
       def to_action_dispatch_response: () -> ::ActionDispatch::Response
@@ -16,9 +17,16 @@ module Datadog
 
       CONTENT_TYPE_TO_FORMAT: ::Hash[::String, ::Symbol]
       DEFAULT_CONTENT_TYPE: ::String
+      REDIRECT_STATUS: ::Array[::Integer]
 
-      def self.format: (::Hash[untyped, untyped] env) -> ::Symbol
       def self.content_type: (::Hash[untyped, untyped] env) -> ::String
+      def self.content: (::String) -> ::String
+      def self.status: () -> ::Integer
+      def self.location: () -> ::URI?
+      def self.redirect?: () -> bool
+
+      self.@cache: ::Hash[::String, ::String]
+      def self.cache: () -> ::Hash[::String, ::String]
     end
   end
 end

--- a/sig/datadog/core/configuration/settings.rbs
+++ b/sig/datadog/core/configuration/settings.rbs
@@ -44,6 +44,23 @@ module Datadog
           def ruleset=: (String | Symbol |  File | StringIO | ::Hash[untyped, untyped]) -> void
 
           def using_default?: (Symbol option) -> bool
+
+          def block: () -> _AppSecBlock
+
+        end
+
+        interface _AppSecBlock
+          def templates=: (::Hash[::String, ::Symbol | ::String | ::Pathname]) -> void
+
+          def templates: () -> ::Hash[::String, ::Symbol | ::String | ::Pathname]
+
+          def status=: (::Integer) -> void
+
+          def status: () -> ::Integer
+
+          def location=: (::URI | ::String | nil) -> void
+
+          def location: () -> ::URI?
         end
 
         def initialize: (*untyped _) -> untyped


### PR DESCRIPTION
<!--
Check out the
https://github.com/DataDog/dd-trace-rb/blob/master/docs/DevelopmentGuide.md
for guidance on how to set up your development environment,
run the test suite, write new integrations, and more.
-->

**What does this PR do?**

Allow blocking response configuration:
- change status code
- change response body
- specify redirect target (location header)

**Motivation**

Enable users to customise attack response.

**Additional Notes**

- Initial implementation operates via static configuration.
- Then remote configuration support can be added by altering configuration fetching in `AppSec::Response`

**How to test the change?**

There will be specs