### PR TITLE
Telemetry:add app-client-configuration-change event

### DIFF
--- a/lib/datadog/core/telemetry/client.rb
+++ b/lib/datadog/core/telemetry/client.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require_relative 'emitter'
 require_relative 'heartbeat'
 require_relative '../utils/forking'
@@ -63,6 +65,13 @@ module Datadog
           return if !@enabled || forked?
 
           @emitter.request(:'app-integrations-change')
+        end
+
+        # Report configuration changes caused by Dynamic Configuration.
+        def dynamic_configuration_change!(changes)
+          return if !@enabled || forked?
+
+          @emitter.request('app-client-configuration-change', data: { changes: changes, origin: 'remote_config' })
         end
 
         private

--- a/lib/datadog/core/telemetry/client.rb
+++ b/lib/datadog/core/telemetry/client.rb
@@ -67,8 +67,8 @@ module Datadog
           @emitter.request(:'app-integrations-change')
         end
 
-        # Report configuration changes caused by Dynamic Configuration.
-        def dynamic_configuration_change!(changes)
+        # Report configuration changes caused by Remote Configuration.
+        def client_configuration_change!(changes)
           return if !@enabled || forked?
 
           @emitter.request('app-client-configuration-change', data: { changes: changes, origin: 'remote_config' })

--- a/lib/datadog/core/telemetry/emitter.rb
+++ b/lib/datadog/core/telemetry/emitter.rb
@@ -21,11 +21,13 @@ module Datadog
 
         # Retrieves and emits a TelemetryRequest object based on the request type specified
         # @param request_type [String] the type of telemetry request to collect data for
-        def request(request_type)
+        # @param data [Object] arbitrary object to be passed to the respective `request_type` handler
+        def request(request_type, data: nil)
           begin
             request = Datadog::Core::Telemetry::Event.new.telemetry_request(
               request_type: request_type,
-              seq_id: self.class.sequence.next
+              seq_id: self.class.sequence.next,
+              data: data,
             ).to_h
             @http_transport.request(request_type: request_type.to_s, payload: request.to_json)
           rescue StandardError => e

--- a/lib/datadog/core/telemetry/event.rb
+++ b/lib/datadog/core/telemetry/event.rb
@@ -1,6 +1,9 @@
+# frozen_string_literal: true
+
 require_relative 'collector'
 require_relative 'v1/app_event'
 require_relative 'v1/telemetry_request'
+require_relative 'v2/app_client_configuration_change'
 
 module Datadog
   module Core
@@ -9,7 +12,7 @@ module Datadog
       class Event
         include Telemetry::Collector
 
-        API_VERSION = 'v1'.freeze
+        API_VERSION = 'v1'
 
         attr_reader \
           :api_version
@@ -21,12 +24,13 @@ module Datadog
         # Forms a TelemetryRequest object based on the event request_type
         # @param request_type [String] the type of telemetry request to collect data for
         # @param seq_id [Integer] the ID of the request; incremented each time a telemetry request is sent to the API
-        def telemetry_request(request_type:, seq_id:)
+        # @param data [Object] arbitrary object to be passed to the respective `request_type` handler
+        def telemetry_request(request_type:, seq_id:, data: nil)
           Telemetry::V1::TelemetryRequest.new(
             api_version: @api_version,
             application: application,
             host: host,
-            payload: payload(request_type),
+            payload: payload(request_type, data),
             request_type: request_type,
             runtime_id: runtime_id,
             seq_id: seq_id,
@@ -36,7 +40,7 @@ module Datadog
 
         private
 
-        def payload(request_type)
+        def payload(request_type, data)
           case request_type
           when :'app-started'
             app_started
@@ -44,6 +48,8 @@ module Datadog
             {}
           when :'app-integrations-change'
             app_integrations_change
+          when 'app-client-configuration-change'
+            app_client_configuration_change(data)
           else
             raise ArgumentError, "Request type invalid, received request_type: #{@request_type}"
           end
@@ -60,6 +66,15 @@ module Datadog
 
         def app_integrations_change
           Telemetry::V1::AppEvent.new(integrations: integrations)
+        end
+
+        # DEV: During the transition from V1 to V2, the backend accepts many V2
+        # DEV: payloads through the V1 transport protocol.
+        # DEV: The `app-client-configuration-change` payload is one of them.
+        # DEV: Once V2 is fully implemented, `Telemetry::V2::AppClientConfigurationChange`
+        # DEV: should be reusable without major modifications.
+        def app_client_configuration_change(data)
+          Telemetry::V2::AppClientConfigurationChange.new(data[:changes], origin: data[:origin])
         end
       end
     end

--- a/lib/datadog/core/telemetry/v2/app_client_configuration_change.rb
+++ b/lib/datadog/core/telemetry/v2/app_client_configuration_change.rb
@@ -1,0 +1,41 @@
+# frozen_string_literal: true
+
+require_relative 'request'
+
+module Datadog
+  module Core
+    module Telemetry
+      module V2
+        # Telemetry 'app-client-configuration-change' event.
+        # This request should contain client library configuration that have changes since the app-started event.
+        class AppClientConfigurationChange < Request
+          def initialize(configuration_changes, origin: 'unknown')
+            super('app-client-configuration-change')
+
+            @configuration_changes = configuration_changes
+            @origin = origin
+          end
+
+          # @see [Request#to_h]
+          def to_h
+            super.merge(payload: payload)
+          end
+
+          private
+
+          def payload
+            {
+              configuration: @configuration_changes.map do |name, value|
+                {
+                  name: name,
+                  value: value,
+                  origin: @origin,
+                }
+              end
+            }
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/datadog/core/telemetry/v2/request.rb
+++ b/lib/datadog/core/telemetry/v2/request.rb
@@ -1,0 +1,29 @@
+# frozen_string_literal: true
+
+module Datadog
+  module Core
+    module Telemetry
+      module V2
+        # Base request object for Telemetry V2.
+        #
+        # `#to_h` is the main API, which returns a Ruby
+        # Hash that will be serialized as JSON.
+        class Request
+          # @param [String] request_type the Telemetry request type, which dictates how the Hash payload should be processed
+          def initialize(request_type)
+            @request_type = request_type
+          end
+
+          # Converts this request to a Hash that will
+          # be serialized as JSON.
+          # @return [Hash]
+          def to_h
+            {
+              request_type: @request_type
+            }
+          end
+        end
+      end
+    end
+  end
+end

--- a/sig/datadog/core/telemetry/client.rbs
+++ b/sig/datadog/core/telemetry/client.rbs
@@ -15,6 +15,8 @@ module Datadog
 
         def disable!: () -> untyped
 
+        def dynamic_configuration_change!: (Enumerable[[String, Numeric | bool | String]] changes) -> void
+
         def started!: () -> (nil | untyped)
 
         def emit_closing!: () -> (nil | untyped)

--- a/sig/datadog/core/telemetry/client.rbs
+++ b/sig/datadog/core/telemetry/client.rbs
@@ -15,7 +15,7 @@ module Datadog
 
         def disable!: () -> untyped
 
-        def dynamic_configuration_change!: (Enumerable[[String, Numeric | bool | String]] changes) -> void
+        def client_configuration_change!: (Enumerable[[String, Numeric | bool | String]] changes) -> void
 
         def started!: () -> (nil | untyped)
 

--- a/sig/datadog/core/telemetry/emitter.rbs
+++ b/sig/datadog/core/telemetry/emitter.rbs
@@ -6,7 +6,7 @@ module Datadog
 
         extend Core::Utils::Forking
         def initialize: (?http_transport: untyped) -> void
-        def request: (untyped request_type) -> untyped
+        def request: (String request_type, data: Object?) -> Datadog::Core::Telemetry::Http::Adapters::Net::Response
         def self.sequence: () -> untyped
       end
     end

--- a/sig/datadog/core/telemetry/event.rbs
+++ b/sig/datadog/core/telemetry/event.rbs
@@ -13,6 +13,8 @@ module Datadog
 
         private
 
+        def app_client_configuration_change: (Enumerable[[String, Numeric | bool | String]] changes)-> Datadog::Core::Telemetry::V2::AppClientConfigurationChange
+
         def payload: (untyped request_type) -> untyped
 
         def app_started: () -> untyped

--- a/sig/datadog/core/telemetry/http/adapters/net.rbs
+++ b/sig/datadog/core/telemetry/http/adapters/net.rbs
@@ -18,7 +18,7 @@ module Datadog
 
             def open: () ?{ () -> untyped } -> untyped
 
-            def post: (untyped env) -> untyped
+            def post: (untyped env) -> Datadog::Core::Telemetry::Http::Adapters::Net::Response
             class Response
               include Datadog::Core::Telemetry::Http::Response
 

--- a/sig/datadog/core/telemetry/http/transport.rbs
+++ b/sig/datadog/core/telemetry/http/transport.rbs
@@ -13,7 +13,7 @@ module Datadog
 
           def initialize: () -> void
 
-          def request: (request_type: untyped, payload: untyped) -> untyped
+          def request: (request_type: String, payload: String) -> Datadog::Core::Telemetry::Http::Adapters::Net::Response
 
           private
 

--- a/sig/datadog/core/telemetry/v2/app_client_configuration_change.rbs
+++ b/sig/datadog/core/telemetry/v2/app_client_configuration_change.rbs
@@ -1,0 +1,21 @@
+module Datadog
+  module Core
+    module Telemetry
+      module V2
+        class AppClientConfigurationChange < Request
+          @configuration_changes: Enumerable[[String, Numeric | bool | String]]
+
+          @origin: String
+
+          def initialize: (Enumerable[[String, Numeric | bool | String]] configuration_changes, ?origin: String) -> void
+
+          def to_h: () -> Hash[Symbol, Object]
+
+          private
+
+          def payload: () -> Hash[Symbol, Array[Hash[Symbol, Numeric | bool | String]]]
+        end
+      end
+    end
+  end
+end

--- a/sig/datadog/core/telemetry/v2/request.rbs
+++ b/sig/datadog/core/telemetry/v2/request.rbs
@@ -1,0 +1,15 @@
+module Datadog
+  module Core
+    module Telemetry
+      module V2
+        class Request
+          @request_type: String
+
+          def initialize: (String request_type) -> void
+
+          def to_h: () -> Hash[Symbol, Object]
+        end
+      end
+    end
+  end
+end

--- a/spec/datadog/core/telemetry/client_spec.rb
+++ b/spec/datadog/core/telemetry/client_spec.rb
@@ -240,4 +240,47 @@ RSpec.describe Datadog::Core::Telemetry::Client do
       end
     end
   end
+
+  describe '#dynamic_configuration_change!' do
+    subject(:dynamic_configuration_change!) { client.dynamic_configuration_change!(changes) }
+    let(:changes) { double('changes') }
+
+    after do
+      client.worker.stop(true)
+      client.worker.join
+    end
+
+    context 'when disabled' do
+      let(:enabled) { false }
+      it do
+        dynamic_configuration_change!
+        expect(emitter).to_not have_received(:request)
+      end
+    end
+
+    context 'when enabled' do
+      let(:enabled) { true }
+      it do
+        dynamic_configuration_change!
+        expect(emitter).to have_received(:request).with(
+          'app-client-configuration-change',
+          data: { changes: changes, origin: 'remote_config' }
+        )
+      end
+
+      it { is_expected.to be(response) }
+    end
+
+    context 'when in fork' do
+      before { skip 'Fork not supported on current platform' unless Process.respond_to?(:fork) }
+
+      it do
+        client
+        expect_in_fork do
+          client.started!
+          expect(emitter).to_not have_received(:request)
+        end
+      end
+    end
+  end
 end

--- a/spec/datadog/core/telemetry/client_spec.rb
+++ b/spec/datadog/core/telemetry/client_spec.rb
@@ -241,8 +241,8 @@ RSpec.describe Datadog::Core::Telemetry::Client do
     end
   end
 
-  describe '#dynamic_configuration_change!' do
-    subject(:dynamic_configuration_change!) { client.dynamic_configuration_change!(changes) }
+  describe '#client_configuration_change!' do
+    subject(:client_configuration_change!) { client.client_configuration_change!(changes) }
     let(:changes) { double('changes') }
 
     after do
@@ -253,7 +253,7 @@ RSpec.describe Datadog::Core::Telemetry::Client do
     context 'when disabled' do
       let(:enabled) { false }
       it do
-        dynamic_configuration_change!
+        client_configuration_change!
         expect(emitter).to_not have_received(:request)
       end
     end
@@ -261,7 +261,7 @@ RSpec.describe Datadog::Core::Telemetry::Client do
     context 'when enabled' do
       let(:enabled) { true }
       it do
-        dynamic_configuration_change!
+        client_configuration_change!
         expect(emitter).to have_received(:request).with(
           'app-client-configuration-change',
           data: { changes: changes, origin: 'remote_config' }

--- a/spec/datadog/core/telemetry/emitter_spec.rb
+++ b/spec/datadog/core/telemetry/emitter_spec.rb
@@ -79,10 +79,12 @@ RSpec.describe Datadog::Core::Telemetry::Emitter do
       subject(:request) { emitter.request(request_type, data: data) }
       let(:data) { { changes: ['test-data'] } }
       let(:request_type) { 'app-client-configuration-change' }
+      let(:event) { double('event') }
 
-      it 'sends data to the emitter' do
+      it 'creates a telemetry event with data' do
+        expect(Datadog::Core::Telemetry::Event).to receive(:new).and_return(event)
+        expect(event).to receive(:telemetry_request).with(request_type: request_type, seq_id: be_a(Integer), data: data)
         request
-        expect(http_transport).to have_received(:request).with(payload: include('test-data'), request_type: anything)
       end
     end
   end

--- a/spec/datadog/core/telemetry/emitter_spec.rb
+++ b/spec/datadog/core/telemetry/emitter_spec.rb
@@ -74,6 +74,17 @@ RSpec.describe Datadog::Core::Telemetry::Emitter do
         end
       end
     end
+
+    context 'with data' do
+      subject(:request) { emitter.request(request_type, data: data) }
+      let(:data) { { changes: ['test-data'] } }
+      let(:request_type) { 'app-client-configuration-change' }
+
+      it 'sends data to the emitter' do
+        request
+        expect(http_transport).to have_received(:request).with(payload: include('test-data'), request_type: anything)
+      end
+    end
   end
 
   describe 'when initialized multiple times' do

--- a/spec/datadog/core/telemetry/event_spec.rb
+++ b/spec/datadog/core/telemetry/event_spec.rb
@@ -14,10 +14,11 @@ RSpec.describe Datadog::Core::Telemetry::Event do
   end
 
   describe '#telemetry_request' do
-    subject(:telemetry_request) { event.telemetry_request(request_type: request_type, seq_id: seq_id) }
+    subject(:telemetry_request) { event.telemetry_request(request_type: request_type, seq_id: seq_id, data: data) }
 
     let(:request_type) { :'app-started' }
     let(:seq_id) { 1 }
+    let(:data) { nil }
 
     it { is_expected.to be_a_kind_of(Datadog::Core::Telemetry::V1::TelemetryRequest) }
     it { expect(telemetry_request.api_version).to eql('v1') }
@@ -47,6 +48,18 @@ RSpec.describe Datadog::Core::Telemetry::Event do
         let(:request_type) { :'app-integrations-change' }
 
         it { expect(telemetry_request.payload).to be_a_kind_of(Datadog::Core::Telemetry::V1::AppEvent) }
+      end
+
+      context 'is app-client-configuration-change' do
+        let(:request_type) { 'app-client-configuration-change' }
+        let(:data) { { changes: [double('my-changes')], origin: 'my-origin' } }
+
+        it { expect(telemetry_request.payload).to be_a_kind_of(Datadog::Core::Telemetry::V2::AppClientConfigurationChange) }
+        it { expect(telemetry_request.request_type).to eq(request_type) }
+
+        it 'passes data to the event object' do
+          expect(telemetry_request.payload.to_h.to_json).to include('my-changes') & include('my-origin')
+        end
       end
 
       context 'is nil' do

--- a/spec/datadog/core/telemetry/v2/app_client_configuration_change_spec.rb
+++ b/spec/datadog/core/telemetry/v2/app_client_configuration_change_spec.rb
@@ -1,0 +1,43 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+require 'datadog/core/telemetry/v2/app_client_configuration_change'
+
+RSpec.describe Datadog::Core::Telemetry::V2::AppClientConfigurationChange do
+  subject(:app_client_configuration_change) { described_class.new(configuration_changes, origin: origin) }
+
+  let(:origin) { 'test-origin' }
+  let(:configuration_changes) do
+    [
+      ['name1', 'value1'],
+      ['name2', 'value2']
+    ]
+  end
+
+  describe '#to_h' do
+    subject(:to_h) { app_client_configuration_change.to_h }
+
+    it 'includes request_type, configuration changes, and origin' do
+      is_expected.to eq(
+        {
+          request_type: 'app-client-configuration-change',
+          payload: {
+            configuration: [
+              {
+                name: 'name1',
+                value: 'value1',
+                origin: 'test-origin',
+              },
+              {
+                name: 'name2',
+                value: 'value2',
+                origin: 'test-origin',
+              }
+            ]
+          }
+        }
+      )
+    end
+  end
+end

--- a/spec/datadog/core/telemetry/v2/request_spec.rb
+++ b/spec/datadog/core/telemetry/v2/request_spec.rb
@@ -1,0 +1,19 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+require 'datadog/core/telemetry/v2/request'
+
+RSpec.describe Datadog::Core::Telemetry::V2::Request do
+  subject(:request) { described_class.new(request_type) }
+
+  let(:request_type) { 'test-type' }
+
+  describe '#to_h' do
+    subject(:to_h) { request.to_h }
+
+    it 'includes request_type' do
+      is_expected.to eq({ request_type: 'test-type' })
+    end
+  end
+end


### PR DESCRIPTION
This PR adds the telemetry event `app-client-configuration-change`, which reports that configuration at the Client Library (`ddtrace`) has changed.
This event captures the changes themselves and a change source (called `origin` in the event).

The first use case is reporting changes from Dynamic Configuration. These have the origin `remote_config`.
The changes are a list of 2-tuples (`List<String, Integer | Boolean | String>`) representing the configuration that was just set.

One thing to noticed is that `app-client-configuration-change` is a Telemetry V2 event, but `ddtrace` currently implements Telemetry V1.
To aid with the migration to V2, the Datadog backend supports a few V2 events through the V1 pipeline. This is one of them.

This PR does not actually report the new event, only creates the API to trigger this event.

This event is crucial to Dynamic Configuration because it reports back to Datadog that the changes have been applied successfully to the current Ruby process.