### PR TITLE
Automatically enable profiler "no signals" workaround for passenger web server

### DIFF
--- a/Steepfile
+++ b/Steepfile
@@ -668,6 +668,7 @@ target :ddtrace do
   library 'grpc'
   library 'delayed_job'
   library 'opentelemetry-api'
+  library 'passenger'
 
   # TODO: gem 'libddwaf'
   library 'libddwaf'

--- a/lib/datadog/profiling/component.rb
+++ b/lib/datadog/profiling/component.rb
@@ -223,6 +223,16 @@ module Datadog
           return true
         end
 
+        if defined?(::PhusionPassenger)
+          Datadog.logger.warn(
+            'Enabling the profiling "no signals" workaround because the passenger web server is in use. ' \
+            'This is needed because passenger is currently incompatible with the normal working mode ' \
+            'of the profiler, as detailed in <https://github.com/DataDog/dd-trace-rb/issues/2976>. ' \
+            'Profiling data will have lower quality.'
+          )
+          return true
+        end
+
         false
       end
 

--- a/spec/datadog/profiling/component_spec.rb
+++ b/spec/datadog/profiling/component_spec.rb
@@ -594,7 +594,22 @@ RSpec.describe Datadog::Profiling::Component do
           end
         end
 
-        context 'when mysql2 / rugged gem are not available' do
+        context 'when running inside the passenger web server' do
+          before do
+            stub_const('::PhusionPassenger', Module.new)
+            allow(Datadog.logger).to receive(:warn)
+          end
+
+          it { is_expected.to be true }
+
+          it 'logs a warning message mentioning that the no signals workaround is going to be used' do
+            expect(Datadog.logger).to receive(:warn).with(/Enabling the profiling "no signals" workaround/)
+
+            no_signals_workaround_enabled?
+          end
+        end
+
+        context 'when mysql2 / rugged gems + passenger are not available' do
           include_context('loaded gems', mysql2: nil, rugged: nil)
 
           it { is_expected.to be false }

--- a/vendor/rbs/passenger/0/passenger.rbs
+++ b/vendor/rbs/passenger/0/passenger.rbs
@@ -1,0 +1,2 @@
+module PhusionPassenger
+end


### PR DESCRIPTION
**What does this PR do?**:

This PR adds one more case where we automatically need to apply the profiler "no signals" workaround (added in #2873): when the Ruby app is running inside the passenger web server.

**Motivation**:

This makes sure the profiler does not cause issues out-of-the-box for customers running passenger.

**Additional Notes**:

Passenger detection was inspired on https://stackoverflow.com/a/12246652/4432562 .

This was reported in https://github.com/datadog/dd-trace-rb/issues/2976 and ~I suspect~ (now confirmed) at least one other customer has ran into this issue.

Separate from this PR, I plan to improve our documentation, as well as try to get in touch with the passenger folks to get a fix upstream. I'm tracking that work in the mentioned issue.

I'm also considering updating the integration apps to include passenger, but I wanted to get in the fix asap, and will circle back to that one in a separate PR if I can get it to work sanely.

**How to test the change?**:

Running the test-case submitted for #2976: https://github.com/elliterate/ddtrace-passenger-example can be used to validate that the profiler auto-enables the no signals workaround.
