### PR TITLE
Lint:Disable double negation cop

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -440,3 +440,7 @@ Gemspec/RequiredRubyVersion:
 
 Style/WordArray:
   Enabled: false
+
+# `!!` is the de facto way in Ruby to cast an Object to boolean.
+Style/DoubleNegation:
+  Enabled: false

--- a/lib/datadog/profiling/flush.rb
+++ b/lib/datadog/profiling/flush.rb
@@ -37,7 +37,7 @@ module Datadog
         @code_provenance_data = code_provenance_data
         @tags_as_array = tags_as_array
         @internal_metadata_json = JSON.fast_generate(
-          no_signals_workaround_enabled: (!!no_signals_workaround_enabled).to_s, # rubocop:disable Style/DoubleNegation
+          no_signals_workaround_enabled: (!!no_signals_workaround_enabled).to_s,
         )
       end
     end


### PR DESCRIPTION
`!!` is the de facto way in Ruby to cast an Object to boolean.

We should allow this pattern in the repository.