### PR TITLE
Implement `peer.service` for grpc

### DIFF
--- a/lib/datadog/tracing/contrib/grpc/datadog_interceptor/client.rb
+++ b/lib/datadog/tracing/contrib/grpc/datadog_interceptor/client.rb
@@ -53,11 +53,6 @@ module Datadog
               span.set_tag(Tracing::Metadata::Ext::TAG_COMPONENT, Ext::TAG_COMPONENT)
               span.set_tag(Tracing::Metadata::Ext::TAG_OPERATION, Ext::TAG_OPERATION_CLIENT)
 
-              if Contrib::SpanAttributeSchema.default_span_attribute_schema?
-                # Tag as an external peer service
-                span.set_tag(Tracing::Metadata::Ext::TAG_PEER_SERVICE, span.service)
-              end
-
               span.set_tag(Contrib::Ext::RPC::TAG_SYSTEM, Ext::TAG_SYSTEM)
               span.set_tag(Contrib::Ext::RPC::GRPC::TAG_FULL_METHOD, formatter.grpc_full_method)
               span.set_tag(Contrib::Ext::RPC::TAG_SERVICE, formatter.rpc_service)
@@ -72,6 +67,7 @@ module Datadog
               Contrib::Analytics.set_sample_rate(span, analytics_sample_rate) if analytics_enabled?
 
               Distributed::Propagation::INSTANCE.inject!(trace, metadata) if distributed_tracing?
+              Contrib::SpanAttributeSchema.set_peer_service!(span, Ext::PEER_SERVICE_SOURCES)
             rescue StandardError => e
               Datadog.logger.debug("GRPC client trace failed: #{e}")
             end

--- a/lib/datadog/tracing/contrib/grpc/ext.rb
+++ b/lib/datadog/tracing/contrib/grpc/ext.rb
@@ -18,8 +18,8 @@ module Datadog
           TAG_COMPONENT = 'grpc'
           TAG_OPERATION_CLIENT = 'client'
           TAG_OPERATION_SERVICE = 'service'
-
           TAG_SYSTEM = 'grpc'
+          PEER_SERVICE_SOURCES = Contrib::Ext::RPC::PEER_SERVICE_SOURCES.freeze
         end
       end
     end

--- a/lib/datadog/tracing/contrib/grpc/formatting.rb
+++ b/lib/datadog/tracing/contrib/grpc/formatting.rb
@@ -114,7 +114,7 @@ module Datadog
             def extract_grpc_service(grpc_full_method)
               parts = grpc_full_method.split('/')
               if parts.length < 3
-                VALUE_UNKNOWN
+                ''
               else
                 parts[1]
               end

--- a/sig/datadog/tracing/contrib/grpc/ext.rbs
+++ b/sig/datadog/tracing/contrib/grpc/ext.rbs
@@ -13,6 +13,7 @@ module Datadog
 
           DEFAULT_PEER_SERVICE_NAME: "grpc"
 
+          PEER_SERVICE_SOURCES: Array[String]
           SPAN_CLIENT: "grpc.client"
 
           SPAN_SERVICE: "grpc.service"

--- a/spec/datadog/tracing/contrib/grpc/datadog_interceptor/client_spec.rb
+++ b/spec/datadog/tracing/contrib/grpc/datadog_interceptor/client_spec.rb
@@ -33,7 +33,7 @@ RSpec.describe 'tracing on the client connection' do
     let(:keywords) do
       { request: instance_double(Object),
         call: instance_double('GRPC::ActiveCall', peer: peer, deadline: deadline),
-        method: 'MyService.Endpoint',
+        method: '/ruby.test.Testing/Basic',
         metadata: { some: 'datum' } }
     end
 
@@ -51,14 +51,12 @@ RSpec.describe 'tracing on the client connection' do
       default_client_interceptor.request_response(**keywords) {}
       span = fetch_spans.first
       expect(span.service).to eq 'rspec'
-      expect(span.get_tag(Datadog::Tracing::Metadata::Ext::TAG_PEER_SERVICE)).to eq('rspec')
 
       clear_traces!
 
       configured_client_interceptor.request_response(**keywords) {}
       span = fetch_spans.last
       expect(span.service).to eq 'cepsr'
-      expect(span.get_tag(Datadog::Tracing::Metadata::Ext::TAG_PEER_SERVICE)).to eq('cepsr')
       expect(
         span.get_tag(Datadog::Tracing::Contrib::GRPC::Ext::TAG_CLIENT_DEADLINE)
       ).to eq '2022-01-02T03:04:05.678Z'
@@ -69,7 +67,7 @@ RSpec.describe 'tracing on the client connection' do
     it { expect(span.name).to eq 'grpc.client' }
     it { expect(span.span_type).to eq 'http' }
     it { expect(span.service).to eq 'rspec' }
-    it { expect(span.resource).to eq 'myservice.endpoint' }
+    it { expect(span.resource).to eq 'ruby.test.testing.basic' }
     it { expect(span.get_tag('grpc.client.deadline')).to be_nil }
     it { expect(span.get_tag('error.stack')).to be_nil }
     it { expect(span.get_tag('some')).to eq 'datum' }
@@ -87,7 +85,8 @@ RSpec.describe 'tracing on the client connection' do
     end
 
     it_behaves_like 'a peer service span' do
-      let(:peer_hostname) { host }
+      let(:peer_service_val) { 'ruby.test.Testing' }
+      let(:peer_service_source) { 'rpc.service' }
     end
 
     it_behaves_like 'measured span for integration', false
@@ -119,7 +118,7 @@ RSpec.describe 'tracing on the client connection' do
     let(:keywords) do
       { request: instance_double(Object),
         call: instance_double('GRPC::ActiveCall', peer: peer),
-        method: 'MyService.Endpoint',
+        method: '/ruby.test.Testing/Basic',
         metadata: original_metadata.clone }
     end
 
@@ -145,7 +144,7 @@ RSpec.describe 'tracing on the client connection' do
   describe '#client_streamer' do
     let(:keywords) do
       { call: instance_double('GRPC::ActiveCall', peer: peer),
-        method: 'MyService.Endpoint',
+        method: '/ruby.test.Testing/Basic',
         metadata: original_metadata.clone }
     end
     let(:original_metadata) { { some: 'datum' } }
@@ -163,7 +162,7 @@ RSpec.describe 'tracing on the client connection' do
     let(:keywords) do
       { request: instance_double(Object),
         call: instance_double('GRPC::ActiveCall', peer: peer),
-        method: 'MyService.Endpoint',
+        method: '/ruby.test.Testing/Basic',
         metadata: original_metadata.clone }
     end
 
@@ -182,7 +181,7 @@ RSpec.describe 'tracing on the client connection' do
     let(:keywords) do
       { requests: instance_double(Array),
         call: instance_double('GRPC::ActiveCall', peer: peer),
-        method: 'MyService.Endpoint',
+        method: '/ruby.test.Testing/Basic',
         metadata: original_metadata.clone }
     end
 

--- a/spec/datadog/tracing/contrib/grpc/integration_test_spec.rb
+++ b/spec/datadog/tracing/contrib/grpc/integration_test_spec.rb
@@ -54,7 +54,8 @@ RSpec.describe 'gRPC integration test' do
 
     it_behaves_like 'a peer service span' do
       let(:span) { parent_span }
-      let(:peer_hostname) { '0.0.0.0' }
+      let(:peer_service_val) { 'ruby.test.Testing' }
+      let(:peer_service_source) { 'rpc.service' }
     end
   end
 

--- a/spec/datadog/tracing/contrib/grpc/interception_context_spec.rb
+++ b/spec/datadog/tracing/contrib/grpc/interception_context_spec.rb
@@ -33,7 +33,7 @@ RSpec.describe GRPC::InterceptionContext do
         specify { expect(span.name).to eq 'grpc.client' }
         specify { expect(span.span_type).to eq 'http' }
         specify { expect(span.service).to eq 'rspec' }
-        specify { expect(span.resource).to eq 'myservice.endpoint' }
+        specify { expect(span.resource).to eq 'ruby.test.testing.basic' }
         specify { expect(span.get_tag('error.stack')).to be_nil }
         specify { expect(span.get_tag('some')).to eq 'datum' }
 
@@ -42,7 +42,10 @@ RSpec.describe GRPC::InterceptionContext do
           let(:analytics_sample_rate_var) { Datadog::Tracing::Contrib::GRPC::Ext::ENV_ANALYTICS_SAMPLE_RATE }
         end
 
-        it_behaves_like 'a peer service span'
+        it_behaves_like 'a peer service span' do
+          let(:peer_service_val) { 'ruby.test.Testing' }
+          let(:peer_service_source) { 'rpc.service' }
+        end
         it_behaves_like 'environment service name', 'DD_TRACE_GRPC_SERVICE_NAME' do
           let(:configuration_options) { {} }
         end
@@ -54,7 +57,7 @@ RSpec.describe GRPC::InterceptionContext do
         let(:keywords) do
           { request: instance_double(Object),
             call: instance_double('GRPC::ActiveCall'),
-            method: 'MyService.Endpoint',
+            method: '/ruby.test.Testing/Basic',
             metadata: { some: 'datum' } }
         end
 
@@ -65,7 +68,7 @@ RSpec.describe GRPC::InterceptionContext do
         let(:type) { :client_streamer }
         let(:keywords) do
           { call: instance_double('GRPC::ActiveCall'),
-            method: 'MyService.Endpoint',
+            method: '/ruby.test.Testing/Basic',
             metadata: { some: 'datum' } }
         end
 
@@ -77,7 +80,7 @@ RSpec.describe GRPC::InterceptionContext do
         let(:keywords) do
           { request: instance_double(Object),
             call: instance_double('GRPC::ActiveCall'),
-            method: 'MyService.Endpoint',
+            method: '/ruby.test.Testing/Basic',
             metadata: { some: 'datum' } }
         end
 
@@ -85,12 +88,15 @@ RSpec.describe GRPC::InterceptionContext do
           expect(span.name).to eq 'grpc.client'
           expect(span.span_type).to eq 'http'
           expect(span.service).to eq 'rspec'
-          expect(span.resource).to eq 'myservice.endpoint'
+          expect(span.resource).to eq 'ruby.test.testing.basic'
           expect(span.get_tag('error.stack')).to be_nil
           expect(span.get_tag('some')).to eq 'datum'
         end
 
-        it_behaves_like 'a peer service span'
+        it_behaves_like 'a peer service span' do
+          let(:peer_service_val) { 'ruby.test.Testing' }
+          let(:peer_service_source) { 'rpc.service' }
+        end
       end
 
       context 'bidirectional streaming call type' do
@@ -98,7 +104,7 @@ RSpec.describe GRPC::InterceptionContext do
         let(:keywords) do
           { requests: instance_double(Array),
             call: instance_double('GRPC::ActiveCall'),
-            method: 'MyService.Endpoint',
+            method: '/ruby.test.Testing/Basic',
             metadata: { some: 'datum' } }
         end
 


### PR DESCRIPTION
Continuing off of #2943, this PR implements `peer.service` in grpc utilizing the newly added `rpc.service` tag.

Updates all tests to use proper GRPC methods such that `peer.service` can be properly tested as well

As usual for this feature, feel free to review but please do not merge without @delner explicitly approving it