### PR TITLE
Core configuration add env and type backend logic

### DIFF
--- a/lib/datadog/core/configuration/base.rb
+++ b/lib/datadog/core/configuration/base.rb
@@ -34,8 +34,6 @@ module Datadog
                 value.reset! if value.respond_to?(:reset!)
                 value
               end
-
-              o.type settings_class
             end
           end
 

--- a/lib/datadog/core/configuration/base.rb
+++ b/lib/datadog/core/configuration/base.rb
@@ -25,7 +25,7 @@ module Datadog
           # e.g. `settings :foo { option :bar }` --> `config.foo.bar`
           # @param [Symbol] name option name. Methods will be created based on this name.
           def settings(name, &block)
-            settings_class = new_settings_class(&block)
+            settings_class = new_settings_class(name, &block)
 
             option(name) do |o|
               o.default { settings_class.new }
@@ -35,12 +35,15 @@ module Datadog
                 value
               end
             end
+
+            settings_class
           end
 
           private
 
-          def new_settings_class(&block)
+          def new_settings_class(name, &block)
             Class.new { include Configuration::Base }.tap do |klass|
+              klass.instance_variable_set(:@settings_name, name)
               klass.instance_eval(&block) if block
             end
           end

--- a/lib/datadog/core/configuration/option.rb
+++ b/lib/datadog/core/configuration/option.rb
@@ -13,11 +13,11 @@ module Datadog
           # Remote configuration provided through the Datadog app.
           REMOTE_CONFIGURATION = [2, :remote_configuration].freeze
 
-          # Configuration provided in Ruby code, in this same process.
+          # Configuration provided in Ruby code, in this same process
+          # or via Environment variable
           PROGRAMMATIC = [1, :programmatic].freeze
 
-          # Configuration that comes either from environment variables,
-          # or fallback values.
+          # Configuration that comes from default values
           DEFAULT = [0, :default].freeze
         end
 
@@ -49,7 +49,7 @@ module Datadog
           end
 
           old_value = @value
-          (@value = context_exec(value, old_value, &definition.setter)).tap do |v|
+          (@value = context_exec(validate_type(value), old_value, &definition.setter)).tap do |v|
             @is_set = true
             @precedence_set = precedence
             context_exec(v, old_value, &definition.on_set) if definition.on_set
@@ -62,7 +62,7 @@ module Datadog
           elsif definition.delegate_to
             context_eval(&definition.delegate_to)
           else
-            set(default_value, precedence: Precedence::DEFAULT)
+            set_value_from_env_or_default
           end
         end
 
@@ -94,12 +94,118 @@ module Datadog
 
         private
 
+        def coerce_env_variable(value)
+          return context_exec(value, &@definition.env_parser) if @definition.env_parser
+
+          case @definition.type
+          when :int
+            # DEV-2.0: Change to a more strict coercion method. Integer(value).
+            value.to_i
+          when :float
+            # DEV-2.0: Change to a more strict coercion method. Float(value).
+            value.to_f
+          when :array
+            values = value.split(',')
+
+            values.map! do |v|
+              v.gsub!(/\A[\s,]*|[\s,]*\Z/, '')
+
+              v.empty? ? nil : v
+            end
+
+            values.compact!
+            values
+          when :bool
+            string_value = value.strip
+            string_value = string_value.downcase
+            string_value == 'true' || string_value == '1' # rubocop:disable Style/MultipleComparison
+          when :string, NilClass
+            value
+          else
+            raise ArgumentError, "The option #{@definition.name} is using an unknown type option `#{@definition.type}`"
+          end
+        end
+
+        def validate_type(value)
+          raise_error = false
+
+          valid_type = validate(@definition.type, value)
+
+          unless valid_type
+            raise_error = if @definition.type_options[:nilable]
+                            !value.is_a?(NilClass)
+                          else
+                            true
+                          end
+          end
+
+          if raise_error
+            error_msg = if @definition.type_options[:nilable]
+                          "The option #{@definition.name} support this type `#{@definition.type}` "\
+                                      "and `nil` but the value provided is #{value.class}"
+                        else
+                          "The option #{@definition.name} support this type `#{@definition.type}` "\
+                          "but the value provided is #{value.class}"
+                        end
+
+            raise ArgumentError, error_msg
+          end
+
+          value
+        end
+
+        def validate(type, value)
+          case type
+          when :string
+            value.is_a?(String)
+          when :int, :float
+            value.is_a?(Numeric)
+          when :array
+            value.is_a?(Array)
+          when :hash
+            value.is_a?(Hash)
+          when :bool
+            value.is_a?(TrueClass) || value.is_a?(FalseClass)
+          when :proc
+            value.is_a?(Proc)
+          when :symbol
+            value.is_a?(Symbol)
+          when NilClass
+            true
+          else
+            raise ArgumentError, "The option #{@definition.name} is using an unknown type option `#{@definition.type}`"
+          end
+        end
+
         def context_exec(*args, &block)
           @context.instance_exec(*args, &block)
         end
 
         def context_eval(&block)
           @context.instance_eval(&block)
+        end
+
+        def set_value_from_env_or_default
+          value = nil
+          precedence = nil
+
+          if definition.env && ENV[definition.env]
+            value = coerce_env_variable(ENV[definition.env])
+            precedence = Precedence::PROGRAMMATIC
+          end
+
+          if value.nil? && definition.deprecated_env && ENV[definition.deprecated_env]
+            value = coerce_env_variable(ENV[definition.deprecated_env])
+            precedence = Precedence::PROGRAMMATIC
+
+            Datadog::Core.log_deprecation do
+              "#{definition.deprecated_env} environment variable is deprecated, use #{definition.env} instead."
+            end
+          end
+
+          option_value = value.nil? ? default_value : value
+
+          set(option_value, precedence: precedence || Precedence::DEFAULT)
         end
 
         # Used for testing

--- a/lib/datadog/core/configuration/option.rb
+++ b/lib/datadog/core/configuration/option.rb
@@ -122,7 +122,8 @@ module Datadog
           when :string, NilClass
             value
           else
-            raise ArgumentError, "The option #{@definition.name} is using an unknown type option `#{@definition.type}`"
+            raise ArgumentError,
+              "The option #{@definition.name} is using an unsupported type option for env coercion `#{@definition.type}`"
           end
         end
 
@@ -143,16 +144,17 @@ module Datadog
 
           if raise_error
             error_msg = if @definition.type_options[:nilable]
-                          "The setting `#{@definition.name}` inside the `Datadog.configure` block expects a "\
+                          "The setting `#{@definition.name}` inside your app's `Datadog.configure` block expects a "\
                           "#{@definition.type} or `nil`, but a `#{value.class}` was provided (#{value.inspect})."\
                         else
-                          "The setting `#{@definition.name}` inside the `Datadog.configure` block expects a "\
-                          "#{@definition.type} , but a `#{value.class}` was provided (#{value.inspect})."\
+                          "The setting `#{@definition.name}` inside your app's `Datadog.configure` block expects a "\
+                          "#{@definition.type}, but a `#{value.class}` was provided (#{value.inspect})."\
                         end
 
             error_msg = "#{error_msg} Please update your `configure` block. "\
-            'Alternatively, you can disable this validation using `DD_EXPERIMENTAL_SKIP_CONFIGURATION_VALIDATION=1`. '\
-            'For help, please open an issue on https://github.com/DataDog/dd-trace-rb/issues/new/choose.'
+            'Alternatively, you can disable this validation using the '\
+            '`DD_EXPERIMENTAL_SKIP_CONFIGURATION_VALIDATION=true`environment variable. '\
+            'For help, please open an issue on <https://github.com/datadog/dd-trace-rb/issues/new/choose>.'
 
             raise ArgumentError, error_msg
           end
@@ -177,9 +179,9 @@ module Datadog
           when :symbol
             value.is_a?(Symbol)
           when NilClass
-            true
+            true # No validation is performed when option is typeless
           else
-            raise ArgumentError, "The option #{@definition.name} is using an unknown type option `#{@definition.type}`"
+            raise ArgumentError, "The option #{@definition.name} is using an unsupported type option `#{@definition.type}`"
           end
         end
 
@@ -215,7 +217,7 @@ module Datadog
         end
 
         def skip_validation?
-          !!ENV['DD_EXPERIMENTAL_SKIP_CONFIGURATION_VALIDATION']
+          ['true', '1'].include?(ENV.fetch('DD_EXPERIMENTAL_SKIP_CONFIGURATION_VALIDATION', '').strip)
         end
 
         # Used for testing

--- a/lib/datadog/core/configuration/option.rb
+++ b/lib/datadog/core/configuration/option.rb
@@ -127,6 +127,8 @@ module Datadog
         end
 
         def validate_type(value)
+          return value if skip_validation?
+
           raise_error = false
 
           valid_type = validate(@definition.type, value)
@@ -206,6 +208,10 @@ module Datadog
           option_value = value.nil? ? default_value : value
 
           set(option_value, precedence: precedence || Precedence::DEFAULT)
+        end
+
+        def skip_validation?
+          !!ENV['DD_EXPERIMENTAL_SKIP_CONFIGURATION_VALIDATION']
         end
 
         # Used for testing

--- a/lib/datadog/core/configuration/option.rb
+++ b/lib/datadog/core/configuration/option.rb
@@ -143,12 +143,16 @@ module Datadog
 
           if raise_error
             error_msg = if @definition.type_options[:nilable]
-                          "The option #{@definition.name} support this type `#{@definition.type}` "\
-                                      "and `nil` but the value provided is #{value.class}"
+                          "The setting `#{@definition.name}` inside the `Datadog.configure` block expects a "\
+                          "#{@definition.type} or `nil`, but a `#{value.class}` was provided (#{value.inspect})."\
                         else
-                          "The option #{@definition.name} support this type `#{@definition.type}` "\
-                          "but the value provided is #{value.class}"
+                          "The setting `#{@definition.name}` inside the `Datadog.configure` block expects a "\
+                          "#{@definition.type} , but a `#{value.class}` was provided (#{value.inspect})."\
                         end
+
+            error_msg = "#{error_msg} Please update your `configure` block. "\
+            'Alternatively, you can disable this validation using `DD_EXPERIMENTAL_SKIP_CONFIGURATION_VALIDATION=1`. '\
+            'For help, please open an issue on https://github.com/DataDog/dd-trace-rb/issues/new/choose.'
 
             raise ArgumentError, error_msg
           end

--- a/lib/datadog/core/configuration/option_definition.rb
+++ b/lib/datadog/core/configuration/option_definition.rb
@@ -143,6 +143,7 @@ module Datadog
           end
 
           # For applying options for OptionDefinition
+          # rubocop:disable Metrics/CyclomaticComplexity, Metrics/PerceivedComplexity
           def apply_options!(options = {})
             return if options.nil? || options.empty?
 
@@ -157,8 +158,9 @@ module Datadog
             on_set(&options[:on_set]) if options.key?(:on_set)
             resetter(&options[:resetter]) if options.key?(:resetter)
             setter(&options[:setter]) if options.key?(:setter)
-            type(options[:type]) if options.key?(:type)
+            type(options[:type], **(options[:type_options] || {})) if options.key?(:type)
           end
+          # rubocop:enable Metrics/CyclomaticComplexity, Metrics/PerceivedComplexity
 
           def to_definition
             OptionDefinition.new(@name, meta)

--- a/lib/datadog/core/configuration/option_definition.rb
+++ b/lib/datadog/core/configuration/option_definition.rb
@@ -16,17 +16,24 @@ module Datadog
           # clear to the reader that they should not rely on it and that is subject to change.
           # Currently is only use internally.
           :experimental_default_proc,
+          :env,
+          :deprecated_env,
+          :env_parser,
           :delegate_to,
           :depends_on,
           :name,
           :on_set,
           :resetter,
           :setter,
-          :type
+          :type,
+          :type_options
 
         def initialize(name, meta = {}, &block)
           @default = meta[:default]
           @experimental_default_proc = meta[:experimental_default_proc]
+          @env = meta[:env]
+          @deprecated_env = meta[:deprecated_env]
+          @env_parser = meta[:env_parser]
           @delegate_to = meta[:delegate_to]
           @depends_on = meta[:depends_on] || []
           @name = name.to_sym
@@ -34,6 +41,7 @@ module Datadog
           @resetter = meta[:resetter]
           @setter = meta[:setter] || block || IDENTITY
           @type = meta[:type]
+          @type_options = meta[:type_options]
         end
 
         # Creates a new Option, bound to the context provided.
@@ -50,6 +58,9 @@ module Datadog
             :helpers
 
           def initialize(name, options = {})
+            @env = nil
+            @deprecated_env = nil
+            @env_parser = nil
             @default = nil
             @experimental_default_proc = nil
             @delegate_to = nil
@@ -60,7 +71,7 @@ module Datadog
             @resetter = nil
             @setter = OptionDefinition::IDENTITY
             @type = nil
-
+            @type_options = {}
             # If options were supplied, apply them.
             apply_options!(options)
 
@@ -72,6 +83,18 @@ module Datadog
 
           def depends_on(*values)
             @depends_on = values.flatten
+          end
+
+          def env(value)
+            @env = value
+          end
+
+          def deprecated_env(value)
+            @deprecated_env = value
+          end
+
+          def env_parser(&block)
+            @env_parser = block
           end
 
           def default(value = nil, &block)
@@ -112,8 +135,11 @@ module Datadog
             @setter = block
           end
 
-          def type(value = nil)
+          def type(value, nilable: false)
             @type = value
+            @type_options = { nilable: nilable }
+
+            value
           end
 
           # For applying options for OptionDefinition
@@ -122,13 +148,16 @@ module Datadog
 
             default(options[:default]) if options.key?(:default)
             experimental_default_proc(&options[:experimental_default_proc]) if options.key?(:experimental_default_proc)
+            env(options[:env]) if options.key?(:env)
+            deprecated_env(options[:deprecated_env]) if options.key?(:deprecated_env)
+            env_parser(&options[:env_parser]) if options.key?(:env_parser)
             delegate_to(&options[:delegate_to]) if options.key?(:delegate_to)
             depends_on(*options[:depends_on]) if options.key?(:depends_on)
             lazy(options[:lazy]) if options.key?(:lazy)
             on_set(&options[:on_set]) if options.key?(:on_set)
             resetter(&options[:resetter]) if options.key?(:resetter)
             setter(&options[:setter]) if options.key?(:setter)
-            type(&options[:type]) if options.key?(:type)
+            type(options[:type]) if options.key?(:type)
           end
 
           def to_definition
@@ -139,12 +168,16 @@ module Datadog
             {
               default: @default,
               experimental_default_proc: @experimental_default_proc,
+              env: @env,
+              deprecated_env: @deprecated_env,
+              env_parser: @env_parser,
               delegate_to: @delegate_to,
               depends_on: @depends_on,
               on_set: @on_set,
               resetter: @resetter,
               setter: @setter,
-              type: @type
+              type: @type,
+              type_options: @type_options
             }
           end
 

--- a/lib/datadog/core/configuration/options.rb
+++ b/lib/datadog/core/configuration/options.rb
@@ -24,7 +24,9 @@ module Datadog
           protected
 
           def option(name, meta = {}, &block)
-            builder = OptionDefinition::Builder.new(name, meta, &block)
+            settings_name = instance_variable_get(:@settings_name)
+            option_name = settings_name ? "#{settings_name}.#{name}" : name
+            builder = OptionDefinition::Builder.new(option_name, meta, &block)
             options[name] = builder.to_definition.tap do
               # Resolve and define helper functions
               helpers = default_helpers(name)

--- a/lib/datadog/core/configuration/options.rb
+++ b/lib/datadog/core/configuration/options.rb
@@ -24,7 +24,7 @@ module Datadog
           protected
 
           def option(name, meta = {}, &block)
-            settings_name = instance_variable_get(:@settings_name)
+            settings_name = @settings_name
             option_name = settings_name ? "#{settings_name}.#{name}" : name
             builder = OptionDefinition::Builder.new(option_name, meta, &block)
             options[name] = builder.to_definition.tap do

--- a/sig/datadog/core/configuration/option.rbs
+++ b/sig/datadog/core/configuration/option.rbs
@@ -4,9 +4,15 @@ module Datadog
       class Option
         attr_reader definition: untyped
 
-        def initialize: (untyped definition, untyped context) -> untyped
+        module Precedence
+          REMOTE_CONFIGURATION: ::Array[2 | :remote_configuration]
+          PROGRAMMATIC: ::Array[1 | :programmatic]
+          DEFAULT: ::Array[0 | :default]
+        end
 
-        def set: (untyped value) -> untyped
+        def initialize: (untyped definition, untyped context) -> void
+
+        def set: (untyped value, ?precedence: untyped) -> untyped
 
         def get: () -> untyped
 
@@ -14,11 +20,23 @@ module Datadog
 
         def default_value: () -> untyped
 
+        def default_precedence?: () -> untyped
+
         private
+
+        def coerce_env_variable: (untyped value) -> untyped
+
+        def validate_type: (untyped value) -> untyped
+
+        def validate: (untyped type, untyped value) -> untyped
 
         def context_exec: (*untyped args) { () -> untyped } -> untyped
 
         def context_eval: () { () -> untyped } -> untyped
+
+        def set_value_from_env_or_default: () -> untyped
+
+        attr_reader precedence_set: untyped
       end
     end
   end

--- a/sig/datadog/core/configuration/option_definition.rbs
+++ b/sig/datadog/core/configuration/option_definition.rbs
@@ -8,6 +8,12 @@ module Datadog
 
         attr_reader experimental_default_proc: untyped
 
+        attr_reader env: untyped
+
+        attr_reader deprecated_env: untyped
+
+        attr_reader env_parser: untyped
+
         attr_reader delegate_to: untyped
 
         attr_reader depends_on: untyped
@@ -31,11 +37,19 @@ module Datadog
 
           def depends_on: (*untyped values) -> untyped
 
-          def default: (?untyped? value) { () -> untyped } -> untyped
+          def default: (?untyped? value) ?{ () -> untyped } -> untyped
 
           def experimental_default_proc: () { () -> untyped } -> untyped
 
           def delegate_to: () { () -> untyped } -> untyped
+
+          def env: (untyped value) -> untyped
+
+          def deprecated_env: (untyped value) -> untyped
+
+          def env_parser: () { () -> untyped } -> untyped
+
+          def type: (Symbol value, ?::Hash[untyped, untyped] type_options) -> untyped
 
           def helper: (untyped name, *untyped _args) { () -> untyped } -> untyped
 

--- a/spec/datadog/core/configuration/base_spec.rb
+++ b/spec/datadog/core/configuration/base_spec.rb
@@ -26,9 +26,6 @@ RSpec.describe Datadog::Core::Configuration::Base do
             it { is_expected.to be_a_kind_of(Datadog::Core::Configuration::OptionDefinition) }
 
             it 'sets default properties' do
-              expect(definition.type).to be_a_kind_of(Class)
-              expect(definition.type.ancestors).to include(described_class)
-
               is_expected.to have_attributes(
                 default: kind_of(Proc),
                 resetter: kind_of(Proc)

--- a/spec/datadog/core/configuration/base_spec.rb
+++ b/spec/datadog/core/configuration/base_spec.rb
@@ -18,6 +18,10 @@ RSpec.describe Datadog::Core::Configuration::Base do
           let(:name) { :debug }
           let(:block) { proc { option :enabled } }
 
+          context 'settings name' do
+            it { expect(settings.instance_variable_get(:@settings_name)).to eq :debug }
+          end
+
           describe 'defines a settings option' do
             subject(:definition) { base_class.options[name] }
 

--- a/spec/datadog/core/configuration/option_definition_spec.rb
+++ b/spec/datadog/core/configuration/option_definition_spec.rb
@@ -183,7 +183,10 @@ RSpec.describe Datadog::Core::Configuration::OptionDefinition::Builder do
               on_set: nil,
               resetter: nil,
               setter: Datadog::Core::Configuration::OptionDefinition::IDENTITY,
-              type: nil
+              type: nil,
+              env: nil,
+              deprecated_env: nil,
+              env_parser: nil
             )
           end
         end
@@ -347,15 +350,37 @@ RSpec.describe Datadog::Core::Configuration::OptionDefinition::Builder do
   end
 
   describe '#type' do
-    subject(:type) { builder.type(value) }
-
+    subject(:type) do
+      builder.type(value, **opts)
+      builder.meta[:type]
+    end
     let(:value) { nil }
+    let(:opts) { {} }
 
     context 'given a value' do
-      let(:value) { String }
+      let(:value) { :string }
 
       it { is_expected.to be value }
       it { expect { type }.to change { builder.meta[:type] }.from(nil).to(value) }
+    end
+
+    context 'given options' do
+      let(:value) { :string }
+      let(:opts) { { nilable: true } }
+
+      it { is_expected.to be value }
+      it { expect { type }.to change { builder.meta[:type] }.from(nil).to(value) }
+      it { expect { type }.to change { builder.meta[:type_options] }.from({}).to(opts) }
+    end
+  end
+
+  describe '#env_parser' do
+    subject(:env_parser) { builder.env_parser(&block) }
+
+    context 'given a block' do
+      let(:block) { proc { false } }
+
+      it { is_expected.to be block }
     end
   end
 
@@ -465,7 +490,10 @@ RSpec.describe Datadog::Core::Configuration::OptionDefinition::Builder do
         :on_set,
         :resetter,
         :setter,
-        :type
+        :type,
+        :env,
+        :deprecated_env,
+        :env_parser,
       )
     end
   end

--- a/spec/datadog/core/configuration/option_definition_spec.rb
+++ b/spec/datadog/core/configuration/option_definition_spec.rb
@@ -184,6 +184,7 @@ RSpec.describe Datadog::Core::Configuration::OptionDefinition::Builder do
               resetter: nil,
               setter: Datadog::Core::Configuration::OptionDefinition::IDENTITY,
               type: nil,
+              type_options: {},
               env: nil,
               deprecated_env: nil,
               env_parser: nil
@@ -350,10 +351,7 @@ RSpec.describe Datadog::Core::Configuration::OptionDefinition::Builder do
   end
 
   describe '#type' do
-    subject(:type) do
-      builder.type(value, **opts)
-      builder.meta[:type]
-    end
+    subject(:type) { builder.type(value, **opts) }
     let(:value) { nil }
     let(:opts) { {} }
 
@@ -371,6 +369,26 @@ RSpec.describe Datadog::Core::Configuration::OptionDefinition::Builder do
       it { is_expected.to be value }
       it { expect { type }.to change { builder.meta[:type] }.from(nil).to(value) }
       it { expect { type }.to change { builder.meta[:type_options] }.from({}).to(opts) }
+    end
+  end
+
+  describe '#env' do
+    subject(:env) { builder.env(value) }
+
+    context 'given a value' do
+      let(:value) { 'TEST' }
+
+      it { is_expected.to be value }
+    end
+  end
+
+  describe '#deprecated_env' do
+    subject(:deprecated_env) { builder.deprecated_env(value) }
+
+    context 'given a value' do
+      let(:value) { 'TEST' }
+
+      it { is_expected.to be value }
     end
   end
 
@@ -491,6 +509,7 @@ RSpec.describe Datadog::Core::Configuration::OptionDefinition::Builder do
         :resetter,
         :setter,
         :type,
+        :type_options,
         :env,
         :deprecated_env,
         :env_parser,

--- a/spec/datadog/core/configuration/option_spec.rb
+++ b/spec/datadog/core/configuration/option_spec.rb
@@ -246,6 +246,14 @@ RSpec.describe Datadog::Core::Configuration::Option do
           it 'raise exception' do
             expect { set }.to raise_exception(ArgumentError)
           end
+
+          context 'set DD_EXPERIMENTAL_SKIP_CONFIGURATION_VALIDATION' do
+            it 'does not raise exception' do
+              ClimateControl.modify('DD_EXPERIMENTAL_SKIP_CONFIGURATION_VALIDATION' => '1') do
+                expect { set }.to_not raise_exception
+              end
+            end
+          end
         end
 
         context 'Integer' do

--- a/spec/datadog/core/configuration/option_spec.rb
+++ b/spec/datadog/core/configuration/option_spec.rb
@@ -11,15 +11,25 @@ RSpec.describe Datadog::Core::Configuration::Option do
       name: :test_name,
       default: default,
       experimental_default_proc: experimental_default_proc,
+      env: env,
+      deprecated_env: deprecated_env,
+      env_parser: env_parser,
       delegate_to: delegate,
       on_set: nil,
       resetter: nil,
-      setter: setter
+      setter: setter,
+      type: type,
+      type_options: type_options,
     )
   end
   let(:default) { double('default') }
   let(:experimental_default_proc) { nil }
   let(:delegate) { nil }
+  let(:env) { nil }
+  let(:env_parser) { nil }
+  let(:type) { nil }
+  let(:type_options) { {} }
+  let(:deprecated_env) { nil }
   let(:setter) { proc { setter_value } }
   let(:setter_value) { double('setter_value') }
   let(:context) { double('configuration object') }
@@ -219,10 +229,465 @@ RSpec.describe Datadog::Core::Configuration::Option do
         end
       end
     end
+
+    context 'value validation' do
+      before { allow(context).to receive(:instance_exec) }
+
+      context 'when type is not defined' do
+        it 'does not raise exception' do
+          expect { set }.not_to raise_exception
+        end
+      end
+
+      context 'when type is defined' do
+        context 'type is invalid value' do
+          let(:type) { :nullable_string }
+          let(:value) { 'Hello' }
+          it 'raise exception' do
+            expect { set }.to raise_exception(ArgumentError)
+          end
+        end
+
+        context 'Integer' do
+          let(:type) { :int }
+
+          context 'valid value' do
+            let(:value) { 1 }
+
+            it 'does not raise exception' do
+              expect { set }.not_to raise_exception
+            end
+
+            context 'allow floats too' do
+              let(:value) { 10.0 }
+
+              it 'does not raise exception' do
+                expect { set }.not_to raise_exception
+              end
+            end
+          end
+
+          context 'invalid value' do
+            let(:value) { true }
+
+            it 'raise exception' do
+              expect { set }.to raise_exception(ArgumentError)
+            end
+          end
+        end
+
+        context 'Float' do
+          let(:type) { :float }
+
+          context 'valid value' do
+            let(:value) { 10.0 }
+
+            it 'does not raise exception' do
+              expect { set }.not_to raise_exception
+            end
+
+            context 'allow integers too' do
+              let(:value) { 10 }
+
+              it 'does not raise exception' do
+                expect { set }.not_to raise_exception
+              end
+            end
+          end
+
+          context 'invalid value' do
+            let(:value) { true }
+
+            it 'raise exception' do
+              expect { set }.to raise_exception(ArgumentError)
+            end
+          end
+        end
+
+        context 'String' do
+          let(:type) { :string }
+
+          context 'valid value' do
+            let(:value) { 'Hello' }
+
+            it 'does not raise exception' do
+              expect { set }.not_to raise_exception
+            end
+          end
+
+          context 'invalid value' do
+            let(:value) { ['Hello'] }
+
+            it 'raise exception' do
+              expect { set }.to raise_exception(ArgumentError)
+            end
+          end
+        end
+
+        context 'Array' do
+          let(:type) { :array }
+
+          context 'valid value' do
+            let(:value) { [] }
+
+            it 'does not raise exception' do
+              expect { set }.not_to raise_exception
+            end
+          end
+
+          context 'invalid value' do
+            let(:value) { 'Hello' }
+
+            it 'raise exception' do
+              expect { set }.to raise_exception(ArgumentError)
+            end
+          end
+        end
+
+        context 'Hash' do
+          let(:type) { :hash }
+
+          context 'valid value' do
+            let(:value) { {} }
+
+            it 'does not raise exception' do
+              expect { set }.not_to raise_exception
+            end
+          end
+
+          context 'invalid value' do
+            let(:value) { ['Hello'] }
+
+            it 'raise exception' do
+              expect { set }.to raise_exception(ArgumentError)
+            end
+          end
+        end
+
+        context 'Bool' do
+          let(:type) { :bool }
+
+          context 'valid value' do
+            let(:value) { true }
+
+            it 'does not raise exception' do
+              expect { set }.not_to raise_exception
+            end
+          end
+
+          context 'invalid value' do
+            let(:value) { :hello }
+
+            it 'raise exception' do
+              expect { set }.to raise_exception(ArgumentError)
+            end
+          end
+        end
+
+        context 'Proc' do
+          let(:type) { :proc }
+
+          context 'valid value' do
+            let(:value) { -> {} }
+
+            it 'does not raise exception' do
+              expect { set }.not_to raise_exception
+            end
+          end
+
+          context 'invalid value' do
+            let(:value) { ['Hello'] }
+
+            it 'raise exception' do
+              expect { set }.to raise_exception(ArgumentError)
+            end
+          end
+        end
+
+        context 'Symbol' do
+          let(:type) { :symbol }
+
+          context 'valid value' do
+            let(:value) { :hello }
+
+            it 'does not raise exception' do
+              expect { set }.not_to raise_exception
+            end
+          end
+
+          context 'invalid value' do
+            let(:value) { true }
+
+            it 'raise exception' do
+              expect { set }.to raise_exception(ArgumentError)
+            end
+          end
+        end
+
+        context 'Nil values' do
+          let(:type) { :string }
+          let(:type_options) { { nilable: true } }
+          let(:value) { nil }
+
+          it 'does not raise exception' do
+            expect { set }.to_not raise_exception
+          end
+
+          context 'value is not nil' do
+            let(:value) { ['Hello'] }
+
+            it 'does raise exception' do
+              expect { set }.to raise_exception(ArgumentError)
+            end
+          end
+        end
+      end
+    end
   end
 
   describe '#get' do
     subject(:get) { option.get }
+
+    shared_examples_for 'env coercion' do
+      context 'when type is defined' do
+        context ':int' do
+          let(:type) { :int }
+          let(:env_value) { '1234' }
+
+          it 'coerce valule' do
+            expect(option.get).to eq 1234
+          end
+        end
+
+        context ':float' do
+          let(:type) { :float }
+          let(:env_value) { '12.34' }
+
+          it 'coerce valule' do
+            expect(option.get).to eq 12.34
+          end
+        end
+
+        context ':array' do
+          let(:type) { :array }
+
+          context 'value with commas' do
+            let(:env_value) { '12,34' }
+
+            it 'coerce valule' do
+              expect(option.get).to eq ['12', '34']
+            end
+
+            context 'remove empty values' do
+              let(:env_value) { '12,34,,,56,' }
+
+              it 'coerce valule' do
+                expect(option.get).to eq ['12', '34', '56']
+              end
+            end
+          end
+        end
+
+        context ':bool' do
+          let(:type) { :bool }
+
+          context 'truthy value' do
+            let(:env_value) { '1' }
+
+            it 'cource value' do
+              expect(option.get).to eq true
+            end
+          end
+
+          context 'non-truthy value' do
+            let(:env_value) { 'something' }
+
+            it 'cource value' do
+              expect(option.get).to eq false
+            end
+          end
+        end
+
+        context 'invalid type' do
+          let(:type) { :invalid_type }
+          let(:env_value) { '1' }
+
+          it 'raise exception' do
+            expect { option.get }.to raise_exception(ArgumentError)
+          end
+        end
+      end
+    end
+
+    shared_context 'with env_parser' do
+      let(:env_parser) do
+        proc do |env_value|
+          env_value
+        end
+      end
+
+      it 'passes the env varaible value to the env_parser' do
+        expect(context).to receive(:instance_exec) do |*args, &block|
+          expect(args.first).to eq(env_value)
+          expect(block).to eq env_parser
+        end
+
+        get
+      end
+    end
+
+    context 'when env is defined' do
+      before do
+        allow(context).to receive(:instance_exec) do |*args|
+          args[0]
+        end
+      end
+
+      let(:env) { 'TEST' }
+
+      context 'when env is not set' do
+        it 'use default value' do
+          expect(option.get).to be default
+        end
+      end
+
+      context 'when env is set' do
+        around do |example|
+          ClimateControl.modify(env => env_value) do
+            example.run
+          end
+        end
+
+        let(:env_value) { 'test' }
+
+        it 'uses env var value' do
+          expect(option.get).to eq env_value
+        end
+
+        it 'set precedence_set to programmatic' do
+          option.get
+          expect(option.send(:precedence_set)).to eq described_class::Precedence::PROGRAMMATIC
+        end
+
+        it_behaves_like 'env coercion'
+        it_behaves_like 'with env_parser'
+      end
+    end
+
+    context 'when deprecated_env is defined' do
+      before do
+        allow(context).to receive(:instance_exec) do |*args|
+          args[0]
+        end
+      end
+
+      let(:deprecated_env) { 'TEST' }
+      context 'when env var is not set' do
+        it do
+          expect(option.get).to be default
+        end
+      end
+
+      context 'when env var is set' do
+        around do |example|
+          ClimateControl.modify(deprecated_env => env_value) do
+            example.run
+          end
+        end
+
+        let(:env_value) { 'test' }
+
+        it 'uses env var value' do
+          expect(option.get).to eq 'test'
+        end
+
+        it 'set precedence_set to programmatic' do
+          option.get
+          expect(option.send(:precedence_set)).to eq described_class::Precedence::PROGRAMMATIC
+        end
+
+        it 'log deprecation warning' do
+          expect(Datadog::Core).to receive(:log_deprecation)
+          option.get
+        end
+
+        it_behaves_like 'env coercion'
+        it_behaves_like 'with env_parser'
+      end
+    end
+
+    context 'when env and deprecated_env are defined' do
+      before do
+        allow(context).to receive(:instance_exec) do |*args|
+          args[0]
+        end
+      end
+
+      let(:env) { 'TEST' }
+      let(:deprecated_env) { 'DEPRECATED_TEST' }
+      let(:env_value) { 'test' }
+      let(:deprecated_env_value) { 'old test' }
+
+      context 'env found' do
+        around do |example|
+          ClimateControl.modify(env => env_value, deprecated_env => deprecated_env_value) do
+            example.run
+          end
+        end
+
+        it 'uses env var value' do
+          expect(option.get).to eq 'test'
+        end
+
+        it 'set precedence_set to programmatic' do
+          option.get
+          expect(option.send(:precedence_set)).to eq described_class::Precedence::PROGRAMMATIC
+        end
+
+        it 'do not log deprecation warning' do
+          expect(Datadog::Core).to_not receive(:log_deprecation)
+          option.get
+        end
+      end
+
+      context 'env not found and deprecated_env found' do
+        around do |example|
+          ClimateControl.modify(deprecated_env => deprecated_env_value) do
+            example.run
+          end
+        end
+
+        it 'uses env var value' do
+          expect(option.get).to eq 'old test'
+        end
+
+        it 'set precedence_set to programmatic' do
+          option.get
+          expect(option.send(:precedence_set)).to eq described_class::Precedence::PROGRAMMATIC
+        end
+
+        it 'log deprecation warning' do
+          expect(Datadog::Core).to receive(:log_deprecation)
+          option.get
+        end
+      end
+
+      context 'env and deprecated_env not found' do
+        it 'uses default value' do
+          expect(option.get).to eq default
+        end
+
+        it 'set precedence_set to default' do
+          option.get
+          expect(option.send(:precedence_set)).to eq described_class::Precedence::DEFAULT
+        end
+
+        it 'do not log deprecation warning' do
+          expect(Datadog::Core).to_not receive(:log_deprecation)
+          option.get
+        end
+      end
+    end
 
     context 'when #set' do
       context 'hasn\'t been called' do
@@ -286,7 +751,9 @@ RSpec.describe Datadog::Core::Configuration::Option do
 
           before { reset }
 
-          it { is_expected.to be(default) }
+          it do
+            is_expected.to be(default)
+          end
         end
       end
 
@@ -331,7 +798,7 @@ RSpec.describe Datadog::Core::Configuration::Option do
 
       before do
         expect(context).to receive(:instance_eval) do |&block|
-          expect(block).to be default
+          expect(block).to eq(default)
           block_default
         end
       end
@@ -340,7 +807,9 @@ RSpec.describe Datadog::Core::Configuration::Option do
     end
 
     context 'when default is not a block' do
-      it { is_expected.to be default }
+      it do
+        is_expected.to be default
+      end
     end
 
     context 'when experimental_default_proc is defined' do

--- a/spec/datadog/core/configuration/option_spec.rb
+++ b/spec/datadog/core/configuration/option_spec.rb
@@ -248,9 +248,21 @@ RSpec.describe Datadog::Core::Configuration::Option do
           end
 
           context 'set DD_EXPERIMENTAL_SKIP_CONFIGURATION_VALIDATION' do
-            it 'does not raise exception' do
-              ClimateControl.modify('DD_EXPERIMENTAL_SKIP_CONFIGURATION_VALIDATION' => '1') do
-                expect { set }.to_not raise_exception
+            ['1', 'true'].each do |value|
+              context "with #{value}" do
+                it 'does not raise exception' do
+                  ClimateControl.modify('DD_EXPERIMENTAL_SKIP_CONFIGURATION_VALIDATION' => '1') do
+                    expect { set }.to_not raise_exception
+                  end
+                end
+              end
+            end
+
+            context 'with something else' do
+              it 'does not raise exception' do
+                ClimateControl.modify('DD_EXPERIMENTAL_SKIP_CONFIGURATION_VALIDATION' => 'esle') do
+                  expect { set }.to raise_exception(ArgumentError)
+                end
               end
             end
           end
@@ -462,7 +474,7 @@ RSpec.describe Datadog::Core::Configuration::Option do
           let(:type) { :int }
           let(:env_value) { '1234' }
 
-          it 'coerce valule' do
+          it 'coerce value' do
             expect(option.get).to eq 1234
           end
         end
@@ -471,7 +483,7 @@ RSpec.describe Datadog::Core::Configuration::Option do
           let(:type) { :float }
           let(:env_value) { '12.34' }
 
-          it 'coerce valule' do
+          it 'coerce value' do
             expect(option.get).to eq 12.34
           end
         end
@@ -482,14 +494,14 @@ RSpec.describe Datadog::Core::Configuration::Option do
           context 'value with commas' do
             let(:env_value) { '12,34' }
 
-            it 'coerce valule' do
+            it 'coerce value' do
               expect(option.get).to eq ['12', '34']
             end
 
             context 'remove empty values' do
               let(:env_value) { '12,34,,,56,' }
 
-              it 'coerce valule' do
+              it 'coerce value' do
                 expect(option.get).to eq ['12', '34', '56']
               end
             end
@@ -499,7 +511,7 @@ RSpec.describe Datadog::Core::Configuration::Option do
         context ':bool' do
           let(:type) { :bool }
 
-          context 'truthy value' do
+          context 'with value 1' do
             let(:env_value) { '1' }
 
             it 'cource value' do
@@ -507,7 +519,15 @@ RSpec.describe Datadog::Core::Configuration::Option do
             end
           end
 
-          context 'non-truthy value' do
+          context 'with value true' do
+            let(:env_value) { 'true' }
+
+            it 'cource value' do
+              expect(option.get).to eq true
+            end
+          end
+
+          context 'other value' do
             let(:env_value) { 'something' }
 
             it 'cource value' do
@@ -534,7 +554,7 @@ RSpec.describe Datadog::Core::Configuration::Option do
         end
       end
 
-      it 'passes the env varaible value to the env_parser' do
+      it 'passes the env variable value to the env_parser' do
         expect(context).to receive(:instance_exec) do |*args, &block|
           expect(args.first).to eq(env_value)
           expect(block).to eq env_parser


### PR DESCRIPTION
<!--
Check out the
https://github.com/DataDog/dd-trace-rb/blob/master/docs/DevelopmentGuide.md
for guidance on how to set up your development environment,
run the test suite, write new integrations, and more.
-->

**What does this PR do?**
<!-- A brief description of the change being made with this pull request. -->

This PR extracts the logic for adding support for `env`, `deprecated_env`, `env_parser`, and `type` validation from https://github.com/DataDog/dd-trace-rb/pull/2970

For a more detail discussion on these changes please refer to the PR linked above 

**Motivation**
<!-- What inspired you to submit this pull request? -->

**Additional Notes**
<!-- Anything else we should know when reviewing? -->

**How to test the change?**
<!--
Describe here how the change can be validated.
You are strongly encouraged to provide automated tests for this PR (unit or integration).
If this change cannot be feasibly tested, please explain why,
unless the change does not modify code (e.g. only modifies docs, comments).
-->
