### PR TITLE
make sure to convert error-handler default proc to blocks using &

### DIFF
--- a/lib/datadog/tracing/contrib/active_job/configuration/settings.rb
+++ b/lib/datadog/tracing/contrib/active_job/configuration/settings.rb
@@ -25,7 +25,9 @@ module Datadog
             end
 
             option :service_name
-            option :error_handler, experimental_default_proc: Tracing::SpanOperation::Events::DEFAULT_ON_ERROR
+            option :error_handler do |o|
+              o.experimental_default_proc(&Tracing::SpanOperation::Events::DEFAULT_ON_ERROR)
+            end
           end
         end
       end

--- a/lib/datadog/tracing/contrib/delayed_job/configuration/settings.rb
+++ b/lib/datadog/tracing/contrib/delayed_job/configuration/settings.rb
@@ -26,7 +26,9 @@ module Datadog
 
             option :service_name
             option :client_service_name
-            option :error_handler, experimental_default_proc: Tracing::SpanOperation::Events::DEFAULT_ON_ERROR
+            option :error_handler do |o|
+              o.experimental_default_proc(&Tracing::SpanOperation::Events::DEFAULT_ON_ERROR)
+            end
           end
         end
       end

--- a/lib/datadog/tracing/contrib/faraday/configuration/settings.rb
+++ b/lib/datadog/tracing/contrib/faraday/configuration/settings.rb
@@ -28,7 +28,9 @@ module Datadog
             end
 
             option :distributed_tracing, default: true
-            option :error_handler, experimental_default_proc: DEFAULT_ERROR_HANDLER
+            option :error_handler do |o|
+              o.experimental_default_proc(&DEFAULT_ERROR_HANDLER)
+            end
             option :split_by_domain, default: false
 
             option :service_name do |o|

--- a/lib/datadog/tracing/contrib/grpc/configuration/settings.rb
+++ b/lib/datadog/tracing/contrib/grpc/configuration/settings.rb
@@ -35,7 +35,9 @@ module Datadog
               end
             end
 
-            option :error_handler, experimental_default_proc: Tracing::SpanOperation::Events::DEFAULT_ON_ERROR
+            option :error_handler do |o|
+              o.experimental_default_proc(&Tracing::SpanOperation::Events::DEFAULT_ON_ERROR)
+            end
           end
         end
       end

--- a/lib/datadog/tracing/contrib/que/configuration/settings.rb
+++ b/lib/datadog/tracing/contrib/que/configuration/settings.rb
@@ -33,7 +33,9 @@ module Datadog
             option :tag_data do |o|
               o.default { env_to_bool(Ext::ENV_TAG_DATA_ENABLED, false) }
             end
-            option :error_handler, experimental_default_proc: Tracing::SpanOperation::Events::DEFAULT_ON_ERROR
+            option :error_handler do |o|
+              o.experimental_default_proc(&Tracing::SpanOperation::Events::DEFAULT_ON_ERROR)
+            end
           end
         end
       end

--- a/lib/datadog/tracing/contrib/resque/configuration/settings.rb
+++ b/lib/datadog/tracing/contrib/resque/configuration/settings.rb
@@ -25,7 +25,9 @@ module Datadog
             end
 
             option :service_name
-            option :error_handler, experimental_default_proc: Tracing::SpanOperation::Events::DEFAULT_ON_ERROR
+            option :error_handler do |o|
+              o.experimental_default_proc(&Tracing::SpanOperation::Events::DEFAULT_ON_ERROR)
+            end
           end
         end
       end

--- a/lib/datadog/tracing/contrib/shoryuken/configuration/settings.rb
+++ b/lib/datadog/tracing/contrib/shoryuken/configuration/settings.rb
@@ -25,7 +25,9 @@ module Datadog
             end
 
             option :service_name
-            option :error_handler, experimental_default_proc: Tracing::SpanOperation::Events::DEFAULT_ON_ERROR
+            option :error_handler do |o|
+              o.experimental_default_proc(&Tracing::SpanOperation::Events::DEFAULT_ON_ERROR)
+            end
             option :tag_body, default: false
           end
         end

--- a/lib/datadog/tracing/contrib/sidekiq/configuration/settings.rb
+++ b/lib/datadog/tracing/contrib/sidekiq/configuration/settings.rb
@@ -30,7 +30,9 @@ module Datadog
 
             option :service_name
             option :client_service_name
-            option :error_handler, experimental_default_proc: Tracing::SpanOperation::Events::DEFAULT_ON_ERROR
+            option :error_handler do |o|
+              o.experimental_default_proc(&Tracing::SpanOperation::Events::DEFAULT_ON_ERROR)
+            end
             option :quantize, default: {}
             option :distributed_tracing, default: false
           end

--- a/lib/datadog/tracing/contrib/sneakers/configuration/settings.rb
+++ b/lib/datadog/tracing/contrib/sneakers/configuration/settings.rb
@@ -23,7 +23,9 @@ module Datadog
             end
 
             option :service_name
-            option :error_handler, experimental_default_proc: Tracing::SpanOperation::Events::DEFAULT_ON_ERROR
+            option :error_handler do |o|
+              o.experimental_default_proc(&Tracing::SpanOperation::Events::DEFAULT_ON_ERROR)
+            end
             option :tag_body, default: false
           end
         end


### PR DESCRIPTION
<!--
Check out the
https://github.com/DataDog/dd-trace-rb/blob/master/docs/DevelopmentGuide.md
for guidance on how to set up your development environment,
run the test suite, write new integrations, and more.
-->

**What does this PR do?**
<!-- A brief description of the change being made with this pull request. -->

While working on https://github.com/DataDog/dd-trace-rb/pull/2983, I noticed that we were expecting a block when calling `experimental_default_proc`, but error-handler defined there  `experimental_default_proc` as a proc

**Motivation**
<!-- What inspired you to submit this pull request? -->

**Additional Notes**
<!-- Anything else we should know when reviewing? -->

**How to test the change?**
<!--
Describe here how the change can be validated.
You are strongly encouraged to provide automated tests for this PR (unit or integration).
If this change cannot be feasibly tested, please explain why,
unless the change does not modify code (e.g. only modifies docs, comments).
-->
