### PR TITLE
Fix:Elasticsearch Webmock testing

### DIFF
--- a/spec/datadog/tracing/contrib/elasticsearch/transport_spec.rb
+++ b/spec/datadog/tracing/contrib/elasticsearch/transport_spec.rb
@@ -14,7 +14,7 @@ RSpec.describe 'Elasticsearch::Transport::Client tracing' do
     # TODO: Find why using testagent changes the elasticsearch test service name despite no differences between other tests
     Datadog.configuration.agent.host = 'not-testagent'
     WebMock.enable!
-    WebMock.disable_net_connect!
+    WebMock.allow_net_connect!
   end
 
   after do


### PR DESCRIPTION
Elasticsearch tests started failing due to Webmock assertions recently.

This is caused by Elasticsearch using Webmock, but other processes like Telemetry still being executed in the background. This PR allows agent calls to go through, while still respecting Elasticsearch Webmock stubs.