### PR TITLE
Try to fix race condition on Barrier

### DIFF
--- a/spec/datadog/core/remote/component_spec.rb
+++ b/spec/datadog/core/remote/component_spec.rb
@@ -443,7 +443,7 @@ RSpec.describe Datadog::Core::Remote::Component::Barrier do
     end
 
     context('with a local timeout') do
-      let(:timeout) { delay / 4 }
+      let(:timeout) { delay / 100 }
 
       context('shorter than lift') do
         it 'unblocks on timeout' do
@@ -451,9 +451,8 @@ RSpec.describe Datadog::Core::Remote::Component::Barrier do
           barrier.wait_next(timeout)
           record << :two
           barrier.wait_next(timeout)
-          record << :three
 
-          expect(record).to eq [:one, :two, :three]
+          expect(record).to eq [:one, :two]
         end
       end
 
@@ -488,16 +487,15 @@ RSpec.describe Datadog::Core::Remote::Component::Barrier do
     end
 
     context('with an instance timeout') do
-      let(:instance_timeout) { delay / 4 }
+      let(:instance_timeout) { delay / 100 }
 
       it 'unblocks on timeout' do
         record << :one
         barrier.wait_next
         record << :two
         barrier.wait_next
-        record << :three
 
-        expect(record).to eq [:one, :two, :three]
+        expect(record).to eq [:one, :two]
       end
     end
   end


### PR DESCRIPTION
We have failures like
```
  1) Datadog::Core::Remote::Component::Barrier#wait_next with an instance timeout unblocks on timeout
     Failure/Error: expect(record).to eq [:one, :two, :three]

       expected: [:one, :two, :three]
            got: [:one, :two, :lift, :three]

       (compared using ==)

       Diff:
       @@ -1 +1 @@
       -[:one, :two, :three]
       +[:one, :two, :lift, :three]
     # ./spec/datadog/core/remote/component_spec.rb:500:in `block (4 levels) in <top (required)>'
     # ./spec/spec_helper.rb:229:in `block (2 levels) in <top (required)>'
     # ./spec/spec_helper.rb:118:in `block (2 levels) in <top (required)>'
     # ./vendor/bundle/ruby/2.4.0/gems/webmock-3.13.0/lib/webmock/rspec.rb:37:in `block (2 levels) in <top (required)>'
     # ./vendor/bundle/ruby/2.4.0/gems/rspec-wait-0.0.9/lib/rspec/wait.rb:46:in `block (2 levels) in <top (required)>'
```
in our MacOS GitHub actions sometimes.

These happen in our Barrier tests because
* Tests have background thread that tries to race each RSpec example:
```ruby
      Thread.new do
        loop do
          sleep delay
          record << :lift
          barrier.lift
        end
      end
```
* `delay` is 0.5 seconds.
* The flaky test in question calls `barrier.wait_next` 3 times, with a timeout of `delay/4` or `0.5/4=0.125` seconds on each `#wait_next` call.
* This leaves little time for the test to finish before `sleep delay` in the background thread finishes executing.

This PR increases the time leeway quite a bit, and also reduces the number of `barrier.wait_next` calls, as we don't need all 3 calls to ensure we are unblocking `barrier.wait_next` on timeout.