### PR TITLE
Fix Timeout leaky thread detection

### DIFF
--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -143,6 +143,10 @@ RSpec.configure do |config|
         t == Thread.current ||
           # Thread has shut down, but we caught it right as it was still alive
           !t.alive? ||
+          # Long-lived Timeout thread created by `Timeout.create_timeout_thread`.
+          t.name == 'Timeout stdlib thread' ||
+          # JRuby: Long-lived Timeout thread created by `Timeout.create_timeout_thread`.
+          t == Timeout.instance_variable_get(:@timeout_thread) ||
           # Internal JRuby thread
           defined?(JRuby) && JRuby.reference(t).native_thread.name == 'Finalizer' ||
           # WEBrick singleton thread for handling timeouts
@@ -286,13 +290,3 @@ end
 
 # Helper matchers
 RSpec::Matchers.define_negated_matcher :not_be, :be
-
-ThreadHelpers.with_leaky_thread_creation("Timeout's internal thread") do
-  # The Ruby Timeout class uses a long-lived class-level thread that is never terminated.
-  # Creating it early here ensures tests that tests that check for leaking threads are not
-  # triggered by the creation of this thread.
-  #
-  # This has to be one once for the lifetime of this process, and was introduced in Ruby 3.1.
-  # Before 3.1, a thread was created and destroyed on every Timeout#timeout call.
-  Timeout.ensure_timeout_thread_created if Timeout.respond_to?(:ensure_timeout_thread_created)
-end


### PR DESCRIPTION
Leaky thread detection for the internal `Timeout` thread has been reporting it as leaky for a while.

This PR changes the checking to ensure we actually filter it out.

The reason `ThreadHelpers.with_leaky_thread_creation` doesn't work is because it uses ThreadGroups, and `Timeout.create_timeout_thread` overrides the thread group, leaving us with no tracking information: https://github.com/ruby/ruby/blob/11deab7906bd12d3c706aa162cb082e8bccbd2a8/lib/timeout.rb#L120

This PR uses the thread name, which has been consistent since this thread was introduced.

For Ruby, there's no clear signal, so we detect that the thread instance is the same.