### PR TITLE
Allow for dynamic log injection configuration

### DIFF
--- a/lib/datadog/appsec/contrib/rails/patcher.rb
+++ b/lib/datadog/appsec/contrib/rails/patcher.rb
@@ -33,19 +33,19 @@ module Datadog
 
           def patch
             Gateway::Watcher.watch
-            patch_before_intialize
-            patch_after_intialize
+            patch_before_initialize
+            patch_after_initialize
 
             Patcher.instance_variable_set(:@patched, true)
           end
 
-          def patch_before_intialize
+          def patch_before_initialize
             ::ActiveSupport.on_load(:before_initialize) do
-              Datadog::AppSec::Contrib::Rails::Patcher.before_intialize(self)
+              Datadog::AppSec::Contrib::Rails::Patcher.before_initialize(self)
             end
           end
 
-          def before_intialize(app)
+          def before_initialize(app)
             BEFORE_INITIALIZE_ONLY_ONCE_PER_APP[app].run do
               # Middleware must be added before the application is initialized.
               # Otherwise the middleware stack will be frozen.
@@ -134,13 +134,13 @@ module Datadog
             Datadog.logger.debug { 'Rails middlewares: ' << app.middleware.map(&:inspect).inspect }
           end
 
-          def patch_after_intialize
+          def patch_after_initialize
             ::ActiveSupport.on_load(:after_initialize) do
-              Datadog::AppSec::Contrib::Rails::Patcher.after_intialize(self)
+              Datadog::AppSec::Contrib::Rails::Patcher.after_initialize(self)
             end
           end
 
-          def after_intialize(app)
+          def after_initialize(app)
             AFTER_INITIALIZE_ONLY_ONCE_PER_APP[app].run do
               # Finish configuring the tracer after the application is initialized.
               # We need to wait for some things, like application name, middleware stack, etc.

--- a/lib/datadog/core/utils.rb
+++ b/lib/datadog/core/utils.rb
@@ -67,7 +67,7 @@ module Datadog
       # @!visibility private
       def self.without_warnings
         # This is typically used when monkey patching functions such as
-        # intialize, which Ruby advices you not to. Use cautiously.
+        # initialize, which Ruby advices you not to. Use cautiously.
         v = $VERBOSE
         $VERBOSE = nil
         begin

--- a/lib/datadog/tracing/contrib/active_job/log_injection.rb
+++ b/lib/datadog/tracing/contrib/active_job/log_injection.rb
@@ -9,7 +9,7 @@ module Datadog
           def self.included(base)
             base.class_eval do
               around_perform do |_, block|
-                if logger.respond_to?(:tagged)
+                if Datadog.configuration.tracing.log_injection && logger.respond_to?(:tagged)
                   logger.tagged(Tracing.log_correlation, &block)
                 else
                   block.call

--- a/lib/datadog/tracing/contrib/active_job/patcher.rb
+++ b/lib/datadog/tracing/contrib/active_job/patcher.rb
@@ -21,7 +21,7 @@ module Datadog
 
           def patch
             Events.subscribe!
-            inject_log_correlation if Datadog.configuration.tracing.log_injection
+            inject_log_correlation
           end
 
           def inject_log_correlation

--- a/lib/datadog/tracing/contrib/rails/patcher.rb
+++ b/lib/datadog/tracing/contrib/rails/patcher.rb
@@ -41,12 +41,7 @@ module Datadog
               # Sometimes we don't want to activate middleware e.g. OpenTracing, etc.
               add_middleware(app) if Datadog.configuration.tracing[:rails][:middleware]
 
-              # Initialize Rails::Rack::Logger with a mutable taggers
-              # that can be modified by after_initialize hook
-              #
-              # https://github.com/rails/rails/blob/e88857bbb9d4e1dd64555c34541301870de4a45b/railties/lib/rails/rack/logger.rb#L16-L19
-              #
-              Contrib::Rails::LogInjection.set_mutatable_default(app)
+              Rails::LogInjection.configure_log_tags(app)
             end
           end
 
@@ -67,18 +62,6 @@ module Datadog
             app.middleware.insert_after(::ActionDispatch::DebugExceptions, Contrib::Rails::ExceptionMiddleware)
           end
 
-          def add_tags_to_logger(app)
-            # `::Rails.logger` has already been assigned during `initialize_logger`
-            logger = ::Rails.logger
-
-            if logger \
-                && defined?(::ActiveSupport::TaggedLogging) \
-                && logger.is_a?(::ActiveSupport::TaggedLogging)
-
-              Contrib::Rails::LogInjection.append_datadog_correlation_tags(app)
-            end
-          end
-
           def patch_after_intialize
             ::ActiveSupport.on_load(:after_initialize) do
               Contrib::Rails::Patcher.after_intialize(self)
@@ -90,10 +73,6 @@ module Datadog
               # Finish configuring the tracer after the application is initialized.
               # We need to wait for some things, like application name, middleware stack, etc.
               setup_tracer
-
-              # `after_initialize` will respect the configuration from `config/initializers/datadog.rb`
-              # and add tags to `::ActiveSupport::TaggedLogging`
-              add_tags_to_logger(app) if Datadog.configuration.tracing.log_injection
             end
           end
 

--- a/lib/datadog/tracing/contrib/rails/patcher.rb
+++ b/lib/datadog/tracing/contrib/rails/patcher.rb
@@ -24,17 +24,17 @@ module Datadog
           end
 
           def patch
-            patch_before_intialize
-            patch_after_intialize
+            patch_before_initialize
+            patch_after_initialize
           end
 
-          def patch_before_intialize
+          def patch_before_initialize
             ::ActiveSupport.on_load(:before_initialize) do
-              Contrib::Rails::Patcher.before_intialize(self)
+              Contrib::Rails::Patcher.before_initialize(self)
             end
           end
 
-          def before_intialize(app)
+          def before_initialize(app)
             BEFORE_INITIALIZE_ONLY_ONCE_PER_APP[app].run do
               # Middleware must be added before the application is initialized.
               # Otherwise the middleware stack will be frozen.
@@ -62,13 +62,13 @@ module Datadog
             app.middleware.insert_after(::ActionDispatch::DebugExceptions, Contrib::Rails::ExceptionMiddleware)
           end
 
-          def patch_after_intialize
+          def patch_after_initialize
             ::ActiveSupport.on_load(:after_initialize) do
-              Contrib::Rails::Patcher.after_intialize(self)
+              Contrib::Rails::Patcher.after_initialize(self)
             end
           end
 
-          def after_intialize(app)
+          def after_initialize(app)
             AFTER_INITIALIZE_ONLY_ONCE_PER_APP[app].run do
               # Finish configuring the tracer after the application is initialized.
               # We need to wait for some things, like application name, middleware stack, etc.

--- a/lib/datadog/tracing/contrib/rails/railtie.rb
+++ b/lib/datadog/tracing/contrib/rails/railtie.rb
@@ -6,12 +6,12 @@ module Datadog
   # Railtie class initializes
   class Railtie < Rails::Railtie
     # Add the trace middleware to the application stack
-    initializer 'datadog.before_intialize' do |app|
-      Tracing::Contrib::Rails::Patcher.before_intialize(app)
+    initializer 'datadog.before_initialize' do |app|
+      Tracing::Contrib::Rails::Patcher.before_initialize(app)
     end
 
     config.after_initialize do
-      Tracing::Contrib::Rails::Patcher.after_intialize(self)
+      Tracing::Contrib::Rails::Patcher.after_initialize(self)
     end
   end
 end

--- a/sig/datadog/appsec/contrib/rails/patcher.rbs
+++ b/sig/datadog/appsec/contrib/rails/patcher.rbs
@@ -15,9 +15,9 @@ module Datadog
 
           def self?.patch: () -> untyped
 
-          def self?.patch_before_intialize: () -> untyped
+          def self?.patch_before_initialize: () -> untyped
 
-          def self?.before_intialize: (untyped app) -> untyped
+          def self?.before_initialize: (untyped app) -> untyped
 
           def self?.add_middleware: (untyped app) -> untyped
 
@@ -31,9 +31,9 @@ module Datadog
 
           def self?.inspect_middlewares: (untyped app) -> untyped
 
-          def self?.patch_after_intialize: () -> untyped
+          def self?.patch_after_initialize: () -> untyped
 
-          def self?.after_intialize: (untyped app) -> untyped
+          def self?.after_initialize: (untyped app) -> untyped
 
           def self?.setup_security: () -> untyped
         end

--- a/sig/datadog/tracing/contrib/rails/patcher.rbs
+++ b/sig/datadog/tracing/contrib/rails/patcher.rbs
@@ -13,17 +13,17 @@ module Datadog
 
           def self?.patch: () -> untyped
 
-          def self?.patch_before_intialize: () -> untyped
+          def self?.patch_before_initialize: () -> untyped
 
-          def self?.before_intialize: (untyped app) -> untyped
+          def self?.before_initialize: (untyped app) -> untyped
 
           def self?.add_middleware: (untyped app) -> untyped
 
           def self?.add_logger: (untyped app) -> untyped
 
-          def self?.patch_after_intialize: () -> untyped
+          def self?.patch_after_initialize: () -> untyped
 
-          def self?.after_intialize: (untyped app) -> untyped
+          def self?.after_initialize: (untyped app) -> untyped
           def self?.setup_tracer: () -> untyped
         end
       end

--- a/spec/datadog/tracing/contrib/rails/rails_log_auto_injection_spec.rb
+++ b/spec/datadog/tracing/contrib/rails/rails_log_auto_injection_spec.rb
@@ -462,6 +462,26 @@ RSpec.describe 'Rails Log Auto Injection' do
           expect(my_entry).to include '[some_other_info]'
         end
       end
+
+      context 'then enabled at runtime' do
+        context 'with Tagged logging setup and no tags' do
+          before do
+            app # Initialize app before enabling log injection
+            Datadog.configure { |c| c.tracing.log_injection = true }
+          end
+
+          it 'injects trace_id into logs' do
+            is_expected.to be_ok
+
+            expect(logs).to_not be_empty
+            expect(log_entries).to have(2).items
+
+            rack_rails_logger_entry, my_entry = log_entries
+            expect(rack_rails_logger_entry).to include "dd.trace_id=#{trace.id}"
+            expect(my_entry).to include "dd.trace_id=#{trace.id}"
+          end
+        end
+      end
     end
 
     if Rails.version >= '4'


### PR DESCRIPTION
Fixes #2542

As part of Dynamic Configuration, we want to allow users to enable or disable log injection at any time.

The main limitation we have in Ruby Tracing is that we need to patch an integration to enable log injection.

This PR enables all integrations that perform log correlation to always inject the correlation patch methods, but allow it to be safely disabled when `Datadog.configuration.tracing.log_injection` is set to `false` at runtime.

Rails, for example, was making decision at the application startup that couldn't be changed later. This PR addresses that.

We still depend on users having instrumented the integration itself for correlation to work.

Our `SemanticLogger` and `Lograge` integrations already support dynamic configuration of log injection; only `Rails` core logger and `ActiveJob` logging needed changes.