### PR TITLE
Minor:Fix intialize typo

### DIFF
--- a/lib/datadog/appsec/contrib/rails/patcher.rb
+++ b/lib/datadog/appsec/contrib/rails/patcher.rb
@@ -33,19 +33,19 @@ module Datadog
 
           def patch
             Gateway::Watcher.watch
-            patch_before_intialize
-            patch_after_intialize
+            patch_before_initialize
+            patch_after_initialize
 
             Patcher.instance_variable_set(:@patched, true)
           end
 
-          def patch_before_intialize
+          def patch_before_initialize
             ::ActiveSupport.on_load(:before_initialize) do
-              Datadog::AppSec::Contrib::Rails::Patcher.before_intialize(self)
+              Datadog::AppSec::Contrib::Rails::Patcher.before_initialize(self)
             end
           end
 
-          def before_intialize(app)
+          def before_initialize(app)
             BEFORE_INITIALIZE_ONLY_ONCE_PER_APP[app].run do
               # Middleware must be added before the application is initialized.
               # Otherwise the middleware stack will be frozen.
@@ -134,13 +134,13 @@ module Datadog
             Datadog.logger.debug { 'Rails middlewares: ' << app.middleware.map(&:inspect).inspect }
           end
 
-          def patch_after_intialize
+          def patch_after_initialize
             ::ActiveSupport.on_load(:after_initialize) do
-              Datadog::AppSec::Contrib::Rails::Patcher.after_intialize(self)
+              Datadog::AppSec::Contrib::Rails::Patcher.after_initialize(self)
             end
           end
 
-          def after_intialize(app)
+          def after_initialize(app)
             AFTER_INITIALIZE_ONLY_ONCE_PER_APP[app].run do
               # Finish configuring the tracer after the application is initialized.
               # We need to wait for some things, like application name, middleware stack, etc.

--- a/lib/datadog/core/utils.rb
+++ b/lib/datadog/core/utils.rb
@@ -67,7 +67,7 @@ module Datadog
       # @!visibility private
       def self.without_warnings
         # This is typically used when monkey patching functions such as
-        # intialize, which Ruby advices you not to. Use cautiously.
+        # initialize, which Ruby advices you not to. Use cautiously.
         v = $VERBOSE
         $VERBOSE = nil
         begin

--- a/lib/datadog/tracing/contrib/rails/patcher.rb
+++ b/lib/datadog/tracing/contrib/rails/patcher.rb
@@ -24,17 +24,17 @@ module Datadog
           end
 
           def patch
-            patch_before_intialize
-            patch_after_intialize
+            patch_before_initialize
+            patch_after_initialize
           end
 
-          def patch_before_intialize
+          def patch_before_initialize
             ::ActiveSupport.on_load(:before_initialize) do
-              Contrib::Rails::Patcher.before_intialize(self)
+              Contrib::Rails::Patcher.before_initialize(self)
             end
           end
 
-          def before_intialize(app)
+          def before_initialize(app)
             BEFORE_INITIALIZE_ONLY_ONCE_PER_APP[app].run do
               # Middleware must be added before the application is initialized.
               # Otherwise the middleware stack will be frozen.
@@ -62,13 +62,13 @@ module Datadog
             app.middleware.insert_after(::ActionDispatch::DebugExceptions, Contrib::Rails::ExceptionMiddleware)
           end
 
-          def patch_after_intialize
+          def patch_after_initialize
             ::ActiveSupport.on_load(:after_initialize) do
-              Contrib::Rails::Patcher.after_intialize(self)
+              Contrib::Rails::Patcher.after_initialize(self)
             end
           end
 
-          def after_intialize(app)
+          def after_initialize(app)
             AFTER_INITIALIZE_ONLY_ONCE_PER_APP[app].run do
               # Finish configuring the tracer after the application is initialized.
               # We need to wait for some things, like application name, middleware stack, etc.

--- a/lib/datadog/tracing/contrib/rails/railtie.rb
+++ b/lib/datadog/tracing/contrib/rails/railtie.rb
@@ -6,12 +6,12 @@ module Datadog
   # Railtie class initializes
   class Railtie < Rails::Railtie
     # Add the trace middleware to the application stack
-    initializer 'datadog.before_intialize' do |app|
-      Tracing::Contrib::Rails::Patcher.before_intialize(app)
+    initializer 'datadog.before_initialize' do |app|
+      Tracing::Contrib::Rails::Patcher.before_initialize(app)
     end
 
     config.after_initialize do
-      Tracing::Contrib::Rails::Patcher.after_intialize(self)
+      Tracing::Contrib::Rails::Patcher.after_initialize(self)
     end
   end
 end

--- a/sig/datadog/appsec/contrib/rails/patcher.rbs
+++ b/sig/datadog/appsec/contrib/rails/patcher.rbs
@@ -15,9 +15,9 @@ module Datadog
 
           def self?.patch: () -> untyped
 
-          def self?.patch_before_intialize: () -> untyped
+          def self?.patch_before_initialize: () -> untyped
 
-          def self?.before_intialize: (untyped app) -> untyped
+          def self?.before_initialize: (untyped app) -> untyped
 
           def self?.add_middleware: (untyped app) -> untyped
 
@@ -31,9 +31,9 @@ module Datadog
 
           def self?.inspect_middlewares: (untyped app) -> untyped
 
-          def self?.patch_after_intialize: () -> untyped
+          def self?.patch_after_initialize: () -> untyped
 
-          def self?.after_intialize: (untyped app) -> untyped
+          def self?.after_initialize: (untyped app) -> untyped
 
           def self?.setup_security: () -> untyped
         end

--- a/sig/datadog/tracing/contrib/rails/patcher.rbs
+++ b/sig/datadog/tracing/contrib/rails/patcher.rbs
@@ -13,17 +13,17 @@ module Datadog
 
           def self?.patch: () -> untyped
 
-          def self?.patch_before_intialize: () -> untyped
+          def self?.patch_before_initialize: () -> untyped
 
-          def self?.before_intialize: (untyped app) -> untyped
+          def self?.before_initialize: (untyped app) -> untyped
 
           def self?.add_middleware: (untyped app) -> untyped
 
           def self?.add_logger: (untyped app) -> untyped
 
-          def self?.patch_after_intialize: () -> untyped
+          def self?.patch_after_initialize: () -> untyped
 
-          def self?.after_intialize: (untyped app) -> untyped
+          def self?.after_initialize: (untyped app) -> untyped
           def self?.setup_tracer: () -> untyped
         end
       end


### PR DESCRIPTION
While working on #2992, I noticed this typo.

This PR fixes the `intialize` typo.