### PR TITLE
[PROF-7966] Add passenger testing to rack integration app

### DIFF
--- a/integration/apps/rack/Gemfile
+++ b/integration/apps/rack/Gemfile
@@ -4,6 +4,7 @@ source "https://rubygems.org"
 
 gem 'puma'
 gem 'unicorn'
+gem 'passenger'
 gem 'rack'
 gem 'rackup' if RUBY_VERSION >= '2.4'  # The `rackup` is its own gem since Rack 3.0
 

--- a/integration/apps/rack/README.md
+++ b/integration/apps/rack/README.md
@@ -61,6 +61,7 @@ Within the container, run `bin/run <process>` where `<process>` is one of the fo
  - `puma`: Puma web server
  - `unicorn`: Unicorn web server
  - `webrick`: WEBrick web server
+ - `passenger`: Passenger web server
  - `irb`: IRB session
 
  Alternatively, set `DD_DEMO_ENV_PROCESS` to run a particular process by default when `bin/run` is run.

--- a/integration/apps/rack/bin/run
+++ b/integration/apps/rack/bin/run
@@ -14,6 +14,8 @@ command = case process
             "bundle exec ddtracerb exec rackup -s webrick -o 0.0.0.0 -p 80 /app/config.ru"
           when 'irb'
             "bundle exec ddtracerb exec irb"
+          when 'passenger'
+            "bundle exec ddtracerb exec passenger start --port 80 -R /app/config.ru"
           when nil, ''
             abort("\n== ERROR: Must specify a application process! ==")
           else

--- a/integration/apps/rack/script/ci
+++ b/integration/apps/rack/script/ci
@@ -44,7 +44,7 @@ echo ""
 APP_IMAGE=$APP_IMAGE docker-compose $APP_COMPOSE_FILES build
 
 # Run the test suite with the different web servers
-for DD_DEMO_ENV_PROCESS in puma unicorn webrick
+for DD_DEMO_ENV_PROCESS in puma unicorn webrick passenger
 do
   echo -e "\n== Running with $DD_DEMO_ENV_PROCESS ================================================\n"
 


### PR DESCRIPTION
**What does this PR do?**:

This PR adds one more webserver to the rack integration testing app: Phusion Passenger.

**Motivation**:

In #2976 a customer reported an issue with profiling apps running on passenger. I'm adding passenger to our test suite to avoid any future regressions.

**Additional Notes**:

I've actually tested that the customer issue does show up on our integration app if I revert the changes from #2978.

**How to test the change?**:

Validate that the rack CI app is running with passenger as well.