### PR TITLE
Make sure to dup the default value when setting it

### DIFF
--- a/lib/datadog/core/configuration/option.rb
+++ b/lib/datadog/core/configuration/option.rb
@@ -1,5 +1,7 @@
 # frozen_string_literal: true
 
+require_relative '../utils/safe_dup'
+
 module Datadog
   module Core
     module Configuration
@@ -137,7 +139,7 @@ module Datadog
           if definition.default.instance_of?(Proc)
             context_eval(&definition.default)
           else
-            definition.experimental_default_proc || definition.default
+            definition.experimental_default_proc || Core::Utils::SafeDup.frozen_or_dup(definition.default)
           end
         end
 

--- a/spec/datadog/appsec/configuration/settings_spec.rb
+++ b/spec/datadog/appsec/configuration/settings_spec.rb
@@ -387,7 +387,7 @@ RSpec.describe Datadog::AppSec::Configuration::Settings do
         context 'is not defined' do
           let(:appsec_obfuscator_key_regex) { nil }
 
-          it { is_expected.to be described_class::DEFAULT_OBFUSCATOR_KEY_REGEX }
+          it { is_expected.to eq described_class::DEFAULT_OBFUSCATOR_KEY_REGEX }
         end
 
         context 'is defined' do
@@ -423,7 +423,7 @@ RSpec.describe Datadog::AppSec::Configuration::Settings do
         context 'is not defined' do
           let(:appsec_obfuscator_value_regex) { nil }
 
-          it { is_expected.to be described_class::DEFAULT_OBFUSCATOR_VALUE_REGEX }
+          it { is_expected.to eq described_class::DEFAULT_OBFUSCATOR_VALUE_REGEX }
         end
 
         context 'is defined' do

--- a/spec/datadog/core/configuration/option_spec.rb
+++ b/spec/datadog/core/configuration/option_spec.rb
@@ -34,6 +34,9 @@ RSpec.describe Datadog::Core::Configuration::Option do
   let(:setter_value) { double('setter_value') }
   let(:context) { double('configuration object') }
 
+  # When setting the setting value, we make sure to duplicate it to avoid unwanted modifications
+  # to make sure specs pass when comparing result ex. expect(result).to be value
+  # we ensure that frozen_or_dup returns the same instance
   before do
     allow(Datadog::Core::Utils::SafeDup).to receive(:frozen_or_dup) do |args, _block|
       args

--- a/spec/datadog/core/configuration/option_spec.rb
+++ b/spec/datadog/core/configuration/option_spec.rb
@@ -34,6 +34,12 @@ RSpec.describe Datadog::Core::Configuration::Option do
   let(:setter_value) { double('setter_value') }
   let(:context) { double('configuration object') }
 
+  before do
+    allow(Datadog::Core::Utils::SafeDup).to receive(:frozen_or_dup) do |args, _block|
+      args
+    end
+  end
+
   describe '#initialize' do
     it { expect(option.definition).to be(definition) }
   end

--- a/spec/datadog/core/configuration/options_spec.rb
+++ b/spec/datadog/core/configuration/options_spec.rb
@@ -10,6 +10,9 @@ RSpec.describe Datadog::Core::Configuration::Options do
       end
     end
 
+    # When setting the setting value, we make sure to duplicate it to avoid unwanted modifications
+    # to make sure specs pass when comparing result ex. expect(result).to be value
+    # we ensure that frozen_or_dup returns the same instance
     before do
       allow(Datadog::Core::Utils::SafeDup).to receive(:frozen_or_dup) do |args, _block|
         args

--- a/spec/datadog/core/configuration/options_spec.rb
+++ b/spec/datadog/core/configuration/options_spec.rb
@@ -10,6 +10,12 @@ RSpec.describe Datadog::Core::Configuration::Options do
       end
     end
 
+    before do
+      allow(Datadog::Core::Utils::SafeDup).to receive(:frozen_or_dup) do |args, _block|
+        args
+      end
+    end
+
     describe 'class behavior' do
       describe '#options' do
         subject(:options) { options_class.options }


### PR DESCRIPTION
<!--
Check out the
https://github.com/DataDog/dd-trace-rb/blob/master/docs/DevelopmentGuide.md
for guidance on how to set up your development environment,
run the test suite, write new integrations, and more.
-->

**What does this PR do?**
<!-- A brief description of the change being made with this pull request. -->

Extracted from https://github.com/DataDog/dd-trace-rb/pull/2988/commits/ce03d1921fe2f2ee561ac8750fec76b4fba03239#r1273320023

The PR ensures that the default values get duplicated before storing as the setting value 

**Motivation**
<!-- What inspired you to submit this pull request? -->

**Additional Notes**
<!-- Anything else we should know when reviewing? -->

**How to test the change?**
<!--
Describe here how the change can be validated.
You are strongly encouraged to provide automated tests for this PR (unit or integration).
If this change cannot be feasibly tested, please explain why,
unless the change does not modify code (e.g. only modifies docs, comments).
-->
