### PR TITLE
Remove unused Barrier#wait_next functionality

### DIFF
--- a/lib/datadog/core/remote/component.rb
+++ b/lib/datadog/core/remote/component.rb
@@ -62,13 +62,9 @@ module Datadog
           end
         end
 
-        def barrier(kind)
+        def barrier(_kind)
           @worker.start
-
-          case kind
-          when :once
-            @barrier.wait_once
-          end
+          @barrier.wait_once
         end
 
         def shutdown!
@@ -103,18 +99,6 @@ module Datadog
             ensure
               @mutex.unlock
             end
-          end
-
-          # Wait for next lift to happen
-          def wait_next(timeout = nil)
-            @mutex.lock
-
-            timeout ||= @timeout
-
-            # rbs/core has a bug, timeout type is incorrectly ?Integer
-            @condition.wait(@mutex, _ = timeout)
-          ensure
-            @mutex.unlock
           end
 
           # Release all current waiters


### PR DESCRIPTION
**What does this PR do?**:

This PR removes the `Barrier#wait_next` functionality which we ended up not making use of.

**Motivation**:

In #2990 we ran into issues with its current specs, and since we're not using this functionality, it seems like removing it for now seems to be easier than investing more time to fix flakiness in the specs.

**Additional Notes**:

N/A

**How to test the change?**:

Existing tests already cover the `Barrier` APIs.
