### PR TITLE
Continue with remote configuration when agent is not reachable

### DIFF
--- a/lib/datadog/core/remote/component.rb
+++ b/lib/datadog/core/remote/component.rb
@@ -123,15 +123,11 @@ module Datadog
 
             negotiation = Negotiation.new(settings, agent_settings)
 
-            unless negotiation.endpoint?('/v0.7/config')
-              Datadog.logger.error do
-                'endpoint unavailable: disabling remote configuration for this process.'
-              end
-
-              return
+            if negotiation.endpoint?('/v0.7/config')
+              Datadog.logger.debug { 'agent reachable and reports remote configuration endpoint' }
+            else
+              Datadog.logger.error { 'agent unreachable or endpoint unavailable: check configuration or use a healthcheck' }
             end
-
-            Datadog.logger.debug { 'agent reachable and reports remote configuration endpoint' }
 
             new(settings, capabilities, agent_settings)
           end

--- a/spec/datadog/core/remote/component_spec.rb
+++ b/spec/datadog/core/remote/component_spec.rb
@@ -81,8 +81,8 @@ RSpec.describe Datadog::Core::Remote::Component do
                 component
               end
 
-              it 'returns nil ' do
-                expect(component).to be_nil
+              it 'returns component' do
+                expect(component).to be_a(described_class)
               end
             end
 
@@ -100,10 +100,8 @@ RSpec.describe Datadog::Core::Remote::Component do
                 component
               end
 
-              it 'returns nil ' do
-                expect(Datadog.logger).to receive(:error).and_return(nil)
-
-                expect(component).to be_nil
+              it 'returns component' do
+                expect(component).to be_a(described_class)
               end
             end
 


### PR DESCRIPTION
<!--
Check out the
https://github.com/DataDog/dd-trace-rb/blob/master/docs/DevelopmentGuide.md
for guidance on how to set up your development environment,
run the test suite, write new integrations, and more.
-->

**What does this PR do?**

Continue with remote configuration when agent is not reachable or has no RC enabled 

**Motivation**

If the agent is not available on startup, RC will bail out and never be able to recover even if the agent appears or gets fixed down the road, thus requiring an app restart.

**Additional Notes**

If the agent is not available or RC is not enabled in the agent this will continuously produce error logs. This is expected as there is misconfiguration that the user must address (either by disabling RC or by fixing the agent)

**How to test the change?**

- start app with rc enabled and without agent (or with agent lacking rc)
- a log message should appear that RC is not as expected
- start rc thread by hitting the app
- error messages should appear continously
- start agent with RC enabled
- RC should recover