### PR TITLE
Evalute tracing.distributed_tracing.propagation_style option before accesing tracing.distributed_tracing.propagation_inject_style and tracing.distributed_tracing.propagation_extract_style

### DIFF
--- a/lib/datadog/tracing/distributed/propagation.rb
+++ b/lib/datadog/tracing/distributed/propagation.rb
@@ -18,6 +18,12 @@ module Datadog
         # @param propagation_styles [Hash<String,Object>]
         def initialize(propagation_styles:)
           @propagation_styles = propagation_styles
+          # We need to make sure propagation_style option is evaluated.
+          # Our options are lazy evaluated and it happens that propagation_style has the on_set callback
+          # that affect Datadog.configuration.tracing.distributed_tracing.propagation_inject_style and
+          # Datadog.configuration.tracing.distributed_tracing.propagation_extract_style
+          # By calling it here, we make sure if the customers has set any value either via code or ENV variable is applied.
+          Datadog.configuration.tracing.distributed_tracing.propagation_style
         end
 
         # inject! populates the env with span ID, trace ID and sampling priority


### PR DESCRIPTION
<!--
Check out the
https://github.com/DataDog/dd-trace-rb/blob/master/docs/DevelopmentGuide.md
for guidance on how to set up your development environment,
run the test suite, write new integrations, and more.
-->

**What does this PR do?**
<!-- A brief description of the change being made with this pull request. -->

Make sure `Datadog.configuration.tracing.distributed_tracing.propagation_style` is evaluated before accessing `tracing.distributed_tracing.propagation_inject_style` and `tracing.distributed_tracing.propagation_inject_style and tracing.distributed_tracing.propagation_extract_style`

The solution could be better. the Propagation class is used as the parent class for other propagation-specific integrations. So if a customer has multiple distributed integrations, we might evaluate `Datadog.configuration.tracing.distributed_tracing.propagation_style` multiple times. 

**Motivation**
<!-- What inspired you to submit this pull request? -->

**Additional Notes**
<!-- Anything else we should know when reviewing? -->

**How to test the change?**
<!--
Describe here how the change can be validated.
You are strongly encouraged to provide automated tests for this PR (unit or integration).
If this change cannot be feasibly tested, please explain why,
unless the change does not modify code (e.g. only modifies docs, comments).
-->
