### PR TITLE
Start RC on demand

### DIFF
--- a/lib/datadog/core/configuration/components.rb
+++ b/lib/datadog/core/configuration/components.rb
@@ -110,9 +110,6 @@ module Datadog
           else
             @logger.debug('Profiling is disabled')
           end
-
-          # Start remote configuration worker
-          @remote.start if @remote
         end
 
         # Shuts down all the components in use.

--- a/lib/datadog/tracing/contrib/rack/middlewares.rb
+++ b/lib/datadog/tracing/contrib/rack/middlewares.rb
@@ -71,6 +71,8 @@ module Datadog
 
             return @app.call(env) if previous_request_span
 
+            Datadog::Core::Remote.active_remote.barrier(:once) unless Datadog::Core::Remote.active_remote.nil?
+
             # Extract distributed tracing context before creating any spans,
             # so that all spans will be added to the distributed trace.
             if configuration[:distributed_tracing]

--- a/spec/datadog/core/configuration/components_spec.rb
+++ b/spec/datadog/core/configuration/components_spec.rb
@@ -1098,15 +1098,6 @@ RSpec.describe Datadog::Core::Configuration::Components do
         let(:info_response) { { endpoints: ['/v0.7/config'] }.to_json }
       end
 
-      context 'enabled' do
-        before { allow(settings.remote).to receive(:enabled).and_return(true) }
-
-        it 'starts the remote manager' do
-          expect(components.remote).to receive(:start)
-          startup!
-        end
-      end
-
       context 'disabled' do
         before { allow(settings.remote).to receive(:enabled).and_return(false) }
 

--- a/spec/datadog/tracing/contrib/suite/integration_spec.rb
+++ b/spec/datadog/tracing/contrib/suite/integration_spec.rb
@@ -99,6 +99,8 @@ RSpec.describe 'contrib integration testing' do
       let(:tracing_header_tags) { [{ 'header' => 'test-header', 'tag_name' => '' }] }
 
       it 'overrides the local values' do
+        Datadog::Core::Remote.active_remote.barrier(:once)
+
         expect(Datadog.configuration.tracing.sampling.default_rate).to be_nil
         expect(Datadog.configuration.tracing.log_injection).to eq(true)
         expect(Datadog.configuration.tracing.header_tags.to_s).to be_empty
@@ -116,6 +118,8 @@ RSpec.describe 'contrib integration testing' do
         let(:empty_data) { { 'lib_config' => {} } }
 
         it 'restore the local values' do
+          Datadog::Core::Remote.active_remote.barrier(:once)
+
           update_config
 
           wait_for { Datadog.configuration.tracing.sampling.default_rate }.to eq(0.7)
@@ -205,6 +209,7 @@ RSpec.describe 'contrib integration testing' do
 
         it 'changes default sampling rate and sampling decision' do
           # Before
+          Datadog::Core::Remote.active_remote.barrier(:once)
           tracer.trace('test') {}
 
           expect(trace.rule_sample_rate).to be_nil
@@ -241,6 +246,7 @@ RSpec.describe 'contrib integration testing' do
 
         it 'changes disables log injection' do
           # Before
+          Datadog::Core::Remote.active_remote.barrier(:once)
           expect(Datadog.configuration.tracing.log_injection).to eq(true)
 
           tracer.trace('test') { logger.error('test-log') }


### PR DESCRIPTION
<!--
Check out the
https://github.com/DataDog/dd-trace-rb/blob/master/docs/DevelopmentGuide.md
for guidance on how to set up your development environment,
run the test suite, write new integrations, and more.
-->

**What does this PR do?**

Start RC on demand.

**Motivation**

System tests fail on Sinatra because of corrupted RC state + unfortunate timing when a forking puma is involved. Starting on demand ensures that it happens in the process that needs RC + that no resource is wasted when RC is not needed.

**Additional Notes**

The above can be reevaluated.

**How to test the change?**

System tests should pass