### PR TITLE
Bump stuff in nix shell

### DIFF
--- a/.github/workflows/nix.yml
+++ b/.github/workflows/nix.yml
@@ -18,6 +18,10 @@ jobs:
           - unstable
     name: Test Nix (${{ matrix.os }}, ${{ matrix.nix }})
     runs-on: ${{ matrix.os }}
+    env:
+      SKIP_SIMPLECOV: 1
+      DD_INSTRUMENTATION_TELEMETRY_ENABLED: false
+      DD_REMOTE_CONFIGURATION_ENABLED: false
     steps:
       - uses: cachix/install-nix-action@v22
         with:
@@ -30,6 +34,11 @@ jobs:
       - name: Print nixpkgs version
         run: nix-instantiate --eval -E '(import <nixpkgs> {}).lib.version'
       - uses: actions/checkout@v3
-      - run: |
+      - name: Print ruby version
+        run: |
           nix-shell --run 'which ruby'
           nix-shell --run 'ruby --version'
+      - name: Bundle install
+        run: nix-shell --run 'bundle install'
+      - name: Run spec:main
+        run: nix-shell --run 'bundle exec rake spec:main'

--- a/.github/workflows/nix.yml
+++ b/.github/workflows/nix.yml
@@ -1,0 +1,30 @@
+name: Test Nix
+
+on:
+  push:
+    branches:
+      - "**"
+
+jobs:
+  test:
+    strategy:
+      fail-fast: false
+      matrix:
+        os:
+          - ubuntu-2204
+          - macos-13
+        nix:
+          - 23.05
+          - unstable
+    name: Test Nix (${{ matrix.os }}, ${{ matrix.nix }})
+    runs-on: ${{ matrix.os }}
+    steps:
+      - uses: cachix/install-nix-action@v22
+        with:
+          nix_path: nixpkgs=channel:nixos-${{ matrix.nix }}
+      - name: Print nixpkgs version
+        run: nix-instantiate --eval -E '(import <nixpkgs> {}).lib.version'
+      - uses: actions/checkout@v3
+      - run: |
+          nix-shell --run 'which ruby'
+          nix-shell --run 'ruby --version'

--- a/.github/workflows/nix.yml
+++ b/.github/workflows/nix.yml
@@ -22,6 +22,11 @@ jobs:
       - uses: cachix/install-nix-action@v22
         with:
           nix_path: nixpkgs=channel:nixos-${{ matrix.nix }}
+      - uses: cachix/cachix-action@v12
+        with:
+          name: datadog
+          authToken: '${{ secrets.CACHIX_AUTH_TOKEN }}'
+          extraPullNames: nix-community
       - name: Print nixpkgs version
         run: nix-instantiate --eval -E '(import <nixpkgs> {}).lib.version'
       - uses: actions/checkout@v3

--- a/.github/workflows/nix.yml
+++ b/.github/workflows/nix.yml
@@ -11,8 +11,8 @@ jobs:
       fail-fast: false
       matrix:
         os:
-          - ubuntu-2204
-          - macos-13
+          - ubuntu-latest
+          - macos-latest
         nix:
           - 23.05
           - unstable

--- a/shell.nix
+++ b/shell.nix
@@ -21,6 +21,9 @@ in llvm.stdenv.mkDerivation {
   buildInputs = [
     ruby
 
+    # for profiler
+    pinned.pkgconfig
+
     # TODO: some gems insist on using `gcc` on Linux, satisfy them for now:
     # - json
     # - protobuf

--- a/shell.nix
+++ b/shell.nix
@@ -3,11 +3,11 @@
   pkgs ? import <nixpkgs> {},
 
   # use a pinned package state
-  pinned ? import(fetchTarball("https://github.com/NixOS/nixpkgs/archive/14d9b465c71.tar.gz")) {},
+  pinned ? import(fetchTarball("https://github.com/NixOS/nixpkgs/archive/88f63d51109.tar.gz")) {},
 }:
 let
   # specify ruby version to use
-  ruby = pinned.ruby_3_1;
+  ruby = pinned.ruby_3_2;
 
   # control llvm/clang version (e.g for packages built from source)
   llvm = pinned.llvmPackages_12;


### PR DESCRIPTION
<!--
Check out the
https://github.com/DataDog/dd-trace-rb/blob/master/docs/DevelopmentGuide.md
for guidance on how to set up your development environment,
run the test suite, write new integrations, and more.
-->

**What does this PR do?**

- Bump nix channel
- Bump ruby to 3.2
- Add simple test in CI to ensure no breakage happens
- Introduce Nix derivation caching via cachix (this adds a secret to push to cachix)

**Motivation**

Keeping things up to date

**Additional Notes**

Derivations are cached publicly, therefore care must be taken not to store secrets as files, but that's already the current practice knowing that:

- it's a public repo with public CI
- we generate docker images that could capture the filesystem state and are published
- all secrets should be CI env vars

**How to test the change?**

- Manually

```
nix-shell
bundle install
# do stuff
```

- CI