### PR TITLE
ddtrace gem 0.x does not support for Ruby 3.2+

### DIFF
--- a/docs/GettingStarted.md
+++ b/docs/GettingStarted.md
@@ -122,7 +122,7 @@ To contribute, check out the [contribution guidelines][contribution docs] and [d
 
 | Type  | Documentation              | Version | Support type                         | Gem version support |
 | ----- | -------------------------- | -----   | ------------------------------------ | ------------------- |
-| MRI   | https://www.ruby-lang.org/ | 3.2     | Full                                 | Latest              |
+| MRI   | https://www.ruby-lang.org/ | 3.2     | Full                                 | > 1.0.0             |
 |       |                            | 3.1     | Full                                 | Latest              |
 |       |                            | 3.0     | Full                                 | Latest              |
 |       |                            | 2.7     | Full                                 | Latest              |


### PR DESCRIPTION
**What does this PR do?**

Changes in #2971 are incorrect. This indicates Ruby 3.2 is now supported only with ddtrace gem 1.0.0 or higher.

**Motivation**

Accuracy is required.

**Additional Notes**

https://rubygems.org/gems/ddtrace/versions/0.54.2

**How to test the change?**

n/a
