### PR TITLE
Pin rake-compiler version as workaround for issue with Ruby <= 2.5

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -45,7 +45,8 @@ if RUBY_VERSION >= '2.2.0'
 else
   gem 'rake', '~> 12.3'
 end
-gem 'rake-compiler', '~> 1.1', '>= 1.1.1' # To compile native extensions
+# rake-compiler version 1.2.4 is broken on Ruby 2.5 and below
+gem 'rake-compiler', '~> 1.2', '< 1.2.4' # To compile native extensions
 gem 'redcarpet', '~> 3.4' if RUBY_PLATFORM != 'java'
 gem 'rspec', '~> 3.12'
 gem 'rspec-collection_matchers', '~> 1.1'


### PR DESCRIPTION
**What does this PR do?**:

This PR pins the version of the `rake-compiler` dependency to fix an incompatibility between version 1.2.4 and Ruby <= 2.5.

(Version 1.2.4 was just released on 2023-08-01)

Those versions fail when running `bundle exec rake clean compile` to compile the profiling native extension with:

```
rake aborted!
NoMethodError: undefined method `cleanpath' for #<String:0x00005eaf10da03e0>
rake-compiler-1.2.4/lib/rake/extensiontask.rb:166:in `block in define_compile_tasks'
```

**Motivation**:

Unbreak our CI.

**Additional Notes**:

I plan to also report this upstream.

This will not affect customers, as `rake-compiler` is only used in development.

**How to test the change?**:

Validate that CI is back to green (or run `bundle exec rake clean compile` on Ruby <= 2.5 and validate it works).
