### PR TITLE
Avoid override Rails config 'log_tags' when SemanticLogger used

### DIFF
--- a/lib/datadog/tracing/contrib/rails/log_injection.rb
+++ b/lib/datadog/tracing/contrib/rails/log_injection.rb
@@ -9,6 +9,8 @@ module Datadog
 
           # Use `app.config.log_tags` to inject propagation tags into the default Rails logger.
           def configure_log_tags(app)
+            return if defined?(::SemanticLogger) && app.cofig.logger.is_a?(::SemanticLogger::Logger)
+
             app.config.log_tags ||= [] # Can be nil, we initialized it if so
             app.config.log_tags << proc { Tracing.log_correlation if Datadog.configuration.tracing.log_injection }
           rescue StandardError => e


### PR DESCRIPTION
Avoid override Rails application config `log_tags` option when SemanticLogger used as application logger.

Gem `rails_semantic_logger` configuration partially relies on common Rails configuration. More specifically to the case `log_tags` option.
While Rails [specification](https://guides.rubyonrails.org/configuring.html#config-log-tags) says it is expected to be an `Array` of `Symbol`s and `Proc`s `rails_semantic_logger` also expects that it might be `Hash` and `nil`, see [Named Tags](https://logger.rocketjob.io/rails.html)

With this PR `log_tags` won't be overriden if `SemanticLogger` is used on an application and it's used as main logger.
This way "Named Tags" functionality won't be broken in case there already present some configuration that uses `Hash`, like it's provided in documentation:
```ruby
config.log_tags = {
  request_id: :request_id,
  ip: :remote_ip,
  user: -> request { request.cookie_jar["login"] }
}
```

Also we don't need to provide some extra configuration for `SemanticLogger` in the file to inject correlation info because it's already added within `SemanticLogger` [integration](https://github.com/DataDog/dd-trace-rb/blob/master/lib/datadog/tracing/contrib/semantic_logger/instrumentation.rb#L28-L44) via `named_tags`.


**Steps to Reproduce issue with relevant dependencies versions**:

Setup Project:
```sh
gem install rails -v 7.0.6
rails new ddtest
cd ddtest
bundle add ddtrace -v 1.13.0
bundle add rails_semantic_logger -v 4.12.0

sed -i '/^    config.load_defaults/a \ \ \ \ config.log_tags = {request_id: :request_id}' config/application.rb
cat <<EOT > config/initializers/ddtrace.rb
Datadog.configure do |c|
  c.service = 'ddtest'
  c.env = 'development'
  c.tracing.instrument(:rails)
end
EOT
```

Run console:
```sh
bin/rails c
```
Expect warn output:
```
W, [2023-08-05T01:38:01.776314 #3470025]  WARN -- ddtrace: [ddtrace] Unable to add Datadog Trace context to ActiveSupport::TaggedLogging: NoMethodError undefined method `<<' for {:request_id=>:request_id}:Hash
```
