### PR TITLE
Tweak profiling benchmark settings + add timeline testing

### DIFF
--- a/.gitlab/benchmarks.yml
+++ b/.gitlab/benchmarks.yml
@@ -53,12 +53,18 @@ only-profiling-benchmarks:
   variables:
     DD_RELENV_CONFIGURATION: only-profiling
     DD_PROFILING_ENABLED: "true"
+    # Gitlab makes use of the rugged gem, which triggers the automatic no signals workaround use, see
+    # https://docs.datadoghq.com/profiler/profiler_troubleshooting/ruby/#unexpected-failures-or-errors-from-ruby-gems-that-use-native-extensions-in-dd-trace-rb-1110
+    # But in practice the endpoints we test it aren't affected, so we prefer to run the profiler in its default,
+    # better accuracy, mode.
+    DD_PROFILING_NO_SIGNALS_WORKAROUND_ENABLED: "false"
 
 profiling-and-tracing-benchmarks:
   extends: .benchmarks
   variables:
     DD_RELENV_CONFIGURATION: profiling-and-tracing
     DD_PROFILING_ENABLED: "true"
+    DD_PROFILING_NO_SIGNALS_WORKAROUND_ENABLED: "false"
 
 tracing-and-appsec-benchmarks:
   extends: .benchmarks
@@ -79,6 +85,7 @@ profiling-and-tracing-and-appsec-benchmarks:
     DD_RELENV_CONFIGURATION: profiling-and-tracing-and-appsec
     DD_APPSEC_ENABLED: "true"
     DD_PROFILING_ENABLED: "true"
+    DD_PROFILING_NO_SIGNALS_WORKAROUND_ENABLED: "false"
 
 # -----------------------------------------------------
 # Microbenchmarks that report to statsd

--- a/.gitlab/benchmarks.yml
+++ b/.gitlab/benchmarks.yml
@@ -59,6 +59,14 @@ only-profiling-benchmarks:
     # better accuracy, mode.
     DD_PROFILING_NO_SIGNALS_WORKAROUND_ENABLED: "false"
 
+only-profiling-timeline-benchmarks:
+  extends: .benchmarks
+  variables:
+    DD_RELENV_CONFIGURATION: only-profiling
+    DD_PROFILING_ENABLED: "true"
+    DD_PROFILING_NO_SIGNALS_WORKAROUND_ENABLED: "false"
+    DD_PROFILING_EXPERIMENTAL_TIMELINE_ENABLED: "true"
+
 profiling-and-tracing-benchmarks:
   extends: .benchmarks
   variables:
@@ -86,6 +94,15 @@ profiling-and-tracing-and-appsec-benchmarks:
     DD_APPSEC_ENABLED: "true"
     DD_PROFILING_ENABLED: "true"
     DD_PROFILING_NO_SIGNALS_WORKAROUND_ENABLED: "false"
+
+timeline-profiling-and-tracing-and-appsec-benchmarks:
+  extends: .benchmarks
+  variables:
+    DD_RELENV_CONFIGURATION: profiling-and-tracing-and-appsec
+    DD_APPSEC_ENABLED: "true"
+    DD_PROFILING_ENABLED: "true"
+    DD_PROFILING_NO_SIGNALS_WORKAROUND_ENABLED: "false"
+    DD_PROFILING_EXPERIMENTAL_TIMELINE_ENABLED: "true"
 
 # -----------------------------------------------------
 # Microbenchmarks that report to statsd


### PR DESCRIPTION
**What does this PR do?**:

This PR does two changes to the benchmark configuration related to profiling:
* Force-disable the no signals workaround for gitlab testing
* Add benchmarking configurations for profiling w/timeline

See individual commit message for details.

**Motivation**:

Increase coverage for profiler testing.

**Additional Notes**:

N/A

**How to test the change?**

I've manually triggered runs for the benchmarks with this configuration. See [gitlab (datadog-internal link only)](https://gitlab.ddbuild.io/DataDog/apm-reliability/dd-trace-rb/-/pipelines/18616381) for details.