### PR TITLE
Update Elasticsearch patcher from using alias method to prepend method

### DIFF
--- a/lib/datadog/tracing/contrib/elasticsearch/patcher.rb
+++ b/lib/datadog/tracing/contrib/elasticsearch/patcher.rb
@@ -19,129 +19,118 @@ module Datadog
             Integration.version
           end
 
+          # `Elasticsearch` namespace renamed to `Elastic` in version 8.0.0 of the transport gem:
+          # @see https://github.com/elastic/elastic-transport-ruby/commit/ef804cbbd284f2a82d825221f87124f8b5ff823c
+          def transport_module
+            if Integration.version >= Gem::Version.new('8.0.0')
+              ::Elastic::Transport
+            else
+              ::Elasticsearch::Transport
+            end
+          end
+
           def patch
             require 'uri'
             require 'json'
             require_relative 'quantize'
 
-            patch_elasticsearch_transport_client
+            transport_module::Client.prepend(Client)
           end
 
-          SELF_DEPRECATION_ONLY_ONCE = Core::Utils::OnlyOnce.new
+          # Patches Elasticsearch::Transport::Client module
+          module Client
+            def perform_request(method, path, params = {}, body = nil)
+              # DEV-2.0: Remove this access, as `Client#self` in this context is not exposed to the user
+              # since `elasticsearch` v8.0.0. In contrast, `Client#transport` is always available across
+              # all `elasticsearch` gem versions and should be used instead.
+              service = Datadog.configuration_for(self, :service_name)
 
-          # rubocop:disable Metrics/MethodLength
-          # rubocop:disable Metrics/AbcSize
-          # rubocop:disable Metrics/CyclomaticComplexity
-          # rubocop:disable Metrics/PerceivedComplexity
-          def patch_elasticsearch_transport_client
-            # rubocop:disable Metrics/BlockLength
-            transport_module::Client.class_eval do
-              alias_method :perform_request_without_datadog, :perform_request
-              remove_method :perform_request
+              if service
+                SELF_DEPRECATION_ONLY_ONCE.run do
+                  Datadog.logger.warn(
+                    'Providing configuration though the Elasticsearch client object is deprecated.' \
+                    'Configure the `client#transport` object instead: ' \
+                    'Datadog.configure_onto(client.transport, service_name: service_name, ...)'
+                  )
+                end
+              end
+              
+              # `Client#transport` is most convenient object both this integration and the library
+              # user have shared access to across all `elasticsearch` versions.
+              #
+              # `Client#self` in this context is an internal object that the library user
+              # does not have access to since `elasticsearch` v8.0.0.
+              service ||= Datadog.configuration_for(transport, :service_name) || datadog_configuration[:service_name]
 
-              def perform_request(*args)
-                # DEV-2.0: Remove this access, as `Client#self` in this context is not exposed to the user
-                # since `elasticsearch` v8.0.0. In contrast, `Client#transport` is always available across
-                # all `elasticsearch` gem versions and should be used instead.
-                service = Datadog.configuration_for(self, :service_name)
+              full_url = URI.parse(path)
+              url = full_url.path
+              response = nil
 
-                if service
-                  SELF_DEPRECATION_ONLY_ONCE.run do
-                    Datadog.logger.warn(
-                      'Providing configuration though the Elasticsearch client object is deprecated.' \
-                      'Configure the `client#transport` object instead: ' \
-                      'Datadog.configure_onto(client.transport, service_name: service_name, ...)'
+              Tracing.trace(Datadog::Tracing::Contrib::Elasticsearch::Ext::SPAN_QUERY, service: service) do |span|
+                begin
+                  connection = transport.connections.first
+                  host = connection.host[:host] if connection
+                  port = connection.host[:port] if connection
+
+                  if datadog_configuration[:peer_service]
+                    span.set_tag(
+                      Tracing::Metadata::Ext::TAG_PEER_SERVICE,
+                      datadog_configuration[:peer_service]
                     )
                   end
-                end
 
-                # `Client#transport` is most convenient object both this integration and the library
-                # user have shared access to across all `elasticsearch` versions.
-                #
-                # `Client#self` in this context is an internal object that the library user
-                # does not have access to since `elasticsearch` v8.0.0.
-                service ||= Datadog.configuration_for(transport, :service_name) || datadog_configuration[:service_name]
+                  span.span_type = Datadog::Tracing::Contrib::Elasticsearch::Ext::SPAN_TYPE_QUERY
 
-                method = args[0]
-                path = args[1]
-                params = args[2]
-                body = args[3]
-                full_url = URI.parse(path)
+                  span.set_tag(Tracing::Metadata::Ext::TAG_COMPONENT, Ext::TAG_COMPONENT)
+                  span.set_tag(Tracing::Metadata::Ext::TAG_OPERATION, Ext::TAG_OPERATION_QUERY)
+                  span.set_tag(Tracing::Metadata::Ext::TAG_KIND, Tracing::Metadata::Ext::SpanKind::TAG_CLIENT)
 
-                url = full_url.path
-                response = nil
+                  span.set_tag(Contrib::Ext::DB::TAG_SYSTEM, Ext::TAG_SYSTEM)
 
-                Tracing.trace(Datadog::Tracing::Contrib::Elasticsearch::Ext::SPAN_QUERY, service: service) do |span|
-                  begin
-                    connection = transport.connections.first
-                    host = connection.host[:host] if connection
-                    port = connection.host[:port] if connection
+                  # load JSON for the following fields unless they're already strings
+                  params = JSON.generate(params) if params && !params.is_a?(String)
+                  body = JSON.generate(body) if body && !body.is_a?(String)
 
-                    if datadog_configuration[:peer_service]
-                      span.set_tag(
-                        Tracing::Metadata::Ext::TAG_PEER_SERVICE,
-                        datadog_configuration[:peer_service]
-                      )
-                    end
+                  span.set_tag(Tracing::Metadata::Ext::TAG_PEER_HOSTNAME, host) if host
 
-                    span.span_type = Datadog::Tracing::Contrib::Elasticsearch::Ext::SPAN_TYPE_QUERY
-
-                    span.set_tag(Tracing::Metadata::Ext::TAG_COMPONENT, Ext::TAG_COMPONENT)
-                    span.set_tag(Tracing::Metadata::Ext::TAG_OPERATION, Ext::TAG_OPERATION_QUERY)
-                    span.set_tag(Tracing::Metadata::Ext::TAG_KIND, Tracing::Metadata::Ext::SpanKind::TAG_CLIENT)
-
-                    span.set_tag(Contrib::Ext::DB::TAG_SYSTEM, Ext::TAG_SYSTEM)
-
-                    # load JSON for the following fields unless they're already strings
-                    params = JSON.generate(params) if params && !params.is_a?(String)
-                    body = JSON.generate(body) if body && !body.is_a?(String)
-
-                    span.set_tag(Tracing::Metadata::Ext::TAG_PEER_HOSTNAME, host) if host
-
-                    # Set analytics sample rate
-                    if Contrib::Analytics.enabled?(datadog_configuration[:analytics_enabled])
-                      Contrib::Analytics.set_sample_rate(span, datadog_configuration[:analytics_sample_rate])
-                    end
-
-                    span.set_tag(Datadog::Tracing::Contrib::Elasticsearch::Ext::TAG_METHOD, method)
-                    span.set_tag(Datadog::Tracing::Contrib::Elasticsearch::Ext::TAG_URL, url)
-                    span.set_tag(Datadog::Tracing::Contrib::Elasticsearch::Ext::TAG_PARAMS, params) if params
-                    if body
-                      quantize_options = datadog_configuration[:quantize]
-                      quantized_body = Datadog::Tracing::Contrib::Elasticsearch::Quantize.format_body(
-                        body,
-                        quantize_options
-                      )
-                      span.set_tag(Datadog::Tracing::Contrib::Elasticsearch::Ext::TAG_BODY, quantized_body)
-                    end
-                    span.set_tag(Tracing::Metadata::Ext::NET::TAG_TARGET_HOST, host) if host
-                    span.set_tag(Tracing::Metadata::Ext::NET::TAG_TARGET_PORT, port) if port
-
-                    quantized_url = Datadog::Tracing::Contrib::Elasticsearch::Quantize.format_url(url)
-                    span.resource = "#{method} #{quantized_url}"
-                    Contrib::SpanAttributeSchema.set_peer_service!(span, Ext::PEER_SERVICE_SOURCES)
-                  rescue StandardError => e
-                    Datadog.logger.error(e.message)
-                  ensure
-                    # the call is still executed
-                    response = perform_request_without_datadog(*args)
-                    span.set_tag(Tracing::Metadata::Ext::HTTP::TAG_STATUS_CODE, response.status)
+                  # Set analytics sample rate
+                  if Contrib::Analytics.enabled?(datadog_configuration[:analytics_enabled])
+                    Contrib::Analytics.set_sample_rate(span, datadog_configuration[:analytics_sample_rate])
                   end
+
+                  span.set_tag(Datadog::Tracing::Contrib::Elasticsearch::Ext::TAG_METHOD, method)
+                  span.set_tag(Datadog::Tracing::Contrib::Elasticsearch::Ext::TAG_URL, url)
+                  span.set_tag(Datadog::Tracing::Contrib::Elasticsearch::Ext::TAG_PARAMS, params) if params
+                  if body
+                    quantize_options = datadog_configuration[:quantize]
+                    quantized_body = Datadog::Tracing::Contrib::Elasticsearch::Quantize.format_body(
+                      body,
+                      quantize_options
+                    )
+                    span.set_tag(Datadog::Tracing::Contrib::Elasticsearch::Ext::TAG_BODY, quantized_body)
+                  end
+                  span.set_tag(Tracing::Metadata::Ext::NET::TAG_TARGET_HOST, host) if host
+                  span.set_tag(Tracing::Metadata::Ext::NET::TAG_TARGET_PORT, port) if port
+
+                  quantized_url = Datadog::Tracing::Contrib::Elasticsearch::Quantize.format_url(url)
+                  span.resource = "#{method} #{quantized_url}"
+                  Contrib::SpanAttributeSchema.set_peer_service!(span, Ext::PEER_SERVICE_SOURCES)
+                rescue StandardError => e
+                  Datadog.logger.error(e.message)
+                ensure
+                  # the call is still executed
+                  response = perform_request_without_datadog(*args)
+                  span.set_tag(Tracing::Metadata::Ext::HTTP::TAG_STATUS_CODE, response.status)
                 end
-                response
               end
-
-              def datadog_configuration
-                Datadog.configuration.tracing[:elasticsearch]
-              end
+              response
             end
-            # rubocop:enable Metrics/BlockLength
-          end
-          # rubocop:enable Metrics/MethodLength
-          # rubocop:enable Metrics/AbcSize
-          # rubocop:enable Metrics/CyclomaticComplexity
-          # rubocop:enable Metrics/PerceivedComplexity
 
+            def datadog_configuration
+              Datadog.configuration.tracing[:elasticsearch]
+            end
+          end
+          
           # `Elasticsearch` namespace renamed to `Elastic` in version 8.0.0 of the transport gem:
           # @see https://github.com/elastic/elastic-transport-ruby/commit/ef804cbbd284f2a82d825221f87124f8b5ff823c
           def transport_module


### PR DESCRIPTION
<!--
Check out the
https://github.com/DataDog/dd-trace-rb/blob/master/docs/DevelopmentGuide.md
for guidance on how to set up your development environment,
run the test suite, write new integrations, and more.
-->

**What does this PR do?**
This PR updates the Elasticsearch patcher. Originally, the patcher was using an alias and remove method to instrument the `perform_request` method; now it uses the more modern prepend technique.

**Motivation**
In an effort to update the codebase, the new patcher should be cleaner and clearer.

**Additional Notes**
No changes were made to the patcher_spec file.

**How to test the change?**
These changes can be tested by running the unit tests in `spec/datadog/tracing/contrib/elasticsearch/patcher_spec.rb`, by passing Github tests, and by checking CircleCI.
