### PR TITLE
Add extra service configuration for RC

### DIFF
--- a/lib/datadog/core/configuration/settings.rb
+++ b/lib/datadog/core/configuration/settings.rb
@@ -646,23 +646,13 @@ module Datadog
           # @default `nil`.
           # @return [Array<String>,nil]
           option :extra_services do |o|
+            o.type :array
+            o.default []
             o.setter do |v|
-              if v.nil?
-                []
-              elsif !v.is_a?(Array)
-                Datadog.logger.warn(
-                  "Unexpected remote.extra_services type #{v.class}, expected Array. " \
-                  'Using default value `[]`'
-                )
+              if v.any? { |e| !e.is_a?(String) }
+                t = v.find { |e| !e.is_a?(String) }
 
-                []
-              elsif (t = v.find { |e| !e.is_a?(String) })
-                Datadog.logger.warn(
-                  "Unexpected remote.extra_services element type #{t.class}, expected String. " \
-                  'Using default value `[]`'
-                )
-
-                []
+                raise ArgumentError, "Unexpected remote.extra_services element type #{t.class}, expected String."
               else
                 v
               end

--- a/lib/datadog/core/configuration/settings.rb
+++ b/lib/datadog/core/configuration/settings.rb
@@ -635,6 +635,13 @@ module Datadog
           # @default `nil`.
           # @return [String,nil]
           option :service
+
+          # Declare additional service names to bind to remote configuration. Use when
+          # integrations are configured to use names that differ from DD_SERVICE.
+          #
+          # @default `nil`.
+          # @return [Array<String>,nil]
+          option :extra_services
         end
 
         # TODO: Tracing should manage its own settings.

--- a/lib/datadog/core/configuration/settings.rb
+++ b/lib/datadog/core/configuration/settings.rb
@@ -634,14 +634,36 @@ module Datadog
           #
           # @default `nil`.
           # @return [String,nil]
-          option :service
+          option :service do |o|
+            o.type :string, nilable: true
+          end
 
           # Declare additional service names to bind to remote configuration. Use when
           # integrations are configured to use names that differ from DD_SERVICE.
           #
           # @default `nil`.
           # @return [Array<String>,nil]
-          option :extra_services
+          option :extra_services do |o|
+            o.setter do |v|
+              if !v.is_a?(Array)
+                Datadog.logger.warn(
+                  "Unexpected remote.extra_services type #{v.class}, expected Array. " \
+                  'Using default value `[]`'
+                )
+
+                []
+              elsif (t = v.find { |e| !e.is_a?(String) })
+                Datadog.logger.warn(
+                  "Unexpected remote.extra_services element type #{t.class}, expected String. " \
+                  'Using default value `[]`'
+                )
+
+                []
+              else
+                v
+              end
+            end
+          end
         end
 
         # TODO: Tracing should manage its own settings.

--- a/lib/datadog/core/configuration/settings.rb
+++ b/lib/datadog/core/configuration/settings.rb
@@ -645,7 +645,9 @@ module Datadog
           # @return [Array<String>,nil]
           option :extra_services do |o|
             o.setter do |v|
-              if !v.is_a?(Array)
+              if v.nil?
+                []
+              elsif !v.is_a?(Array)
                 Datadog.logger.warn(
                   "Unexpected remote.extra_services type #{v.class}, expected Array. " \
                   'Using default value `[]`'

--- a/lib/datadog/core/configuration/settings.rb
+++ b/lib/datadog/core/configuration/settings.rb
@@ -638,8 +638,10 @@ module Datadog
             o.type :string, nilable: true
           end
 
-          # Declare additional service names to bind to remote configuration. Use when
-          # integrations are configured to use names that differ from DD_SERVICE.
+          # Declare additional service names to fold under the main service
+          # name used by remote configuration. Use when integrations are
+          # configured to use names that differ from DD_SERVICE and should be
+          # considered as a single remote configuration controllable service.
           #
           # @default `nil`.
           # @return [Array<String>,nil]

--- a/lib/datadog/core/remote/client.rb
+++ b/lib/datadog/core/remote/client.rb
@@ -140,14 +140,15 @@ module Datadog
             language: Core::Environment::Identity.lang,
             tracer_version: tracer_version_semver2,
             service: service_name,
-            extra_services: extra_service_names,
             env: Datadog.configuration.env,
             tags: client_tracer_tags,
           }
 
           app_version = Datadog.configuration.version
-
           client_tracer[:app_version] = app_version if app_version
+
+          extra_services = extra_service_names
+          client_tracer[:extra_services] = extra_services if extra_services.any?
 
           {
             client: {

--- a/lib/datadog/core/remote/client.rb
+++ b/lib/datadog/core/remote/client.rb
@@ -140,6 +140,7 @@ module Datadog
             language: Core::Environment::Identity.lang,
             tracer_version: tracer_version_semver2,
             service: service_name,
+            extra_services: extra_service_names,
             env: Datadog.configuration.env,
             tags: client_tracer_tags,
           }
@@ -172,6 +173,10 @@ module Datadog
 
         def service_name
           Datadog.configuration.remote.service || Datadog.configuration.service
+        end
+
+        def extra_service_names
+          Datadog.configuration.remote.extra_services || []
         end
 
         def tracer_version_semver2

--- a/sig/datadog/core/remote/client.rbs
+++ b/sig/datadog/core/remote/client.rbs
@@ -30,6 +30,7 @@ module Datadog
         @tracer_version_semver2: ::String
 
         def payload: () ->  ::Hash[Symbol, untyped]
+        def extra_service_names: () -> ::Array[::String]
         def service_name: () -> ::String
         def gem_spec: (::String) -> (::Gem::Specification | untyped)
         def tracer_version_semver2: () -> ::String

--- a/spec/datadog/core/configuration/settings_spec.rb
+++ b/spec/datadog/core/configuration/settings_spec.rb
@@ -1392,5 +1392,37 @@ RSpec.describe Datadog::Core::Configuration::Settings do
           .to('foo')
       end
     end
+
+    describe '#extra_services' do
+      subject(:extra_services) { settings.remote.extra_services }
+
+      context 'defaults to []' do
+        it { is_expected.to eq [] }
+      end
+    end
+
+    describe '#extra_services=' do
+      it 'updates the #extra_services setting' do
+        expect { settings.remote.extra_services = ['foo'] }
+          .to change { settings.remote.extra_services }
+          .from([])
+          .to(['foo'])
+      end
+
+      it 'rejects nil' do
+        expect { settings.remote.extra_services = nil }
+          .to raise_error(ArgumentError, /expects a array/)
+      end
+
+      it 'rejects nil items' do
+        expect { settings.remote.extra_services = [nil] }
+          .to raise_error(ArgumentError, /expected String/)
+      end
+
+      it 'rejects non-string items' do
+        expect { settings.remote.extra_services = [42] }
+          .to raise_error(ArgumentError, /expected String/)
+      end
+    end
   end
 end

--- a/spec/datadog/core/remote/client_spec.rb
+++ b/spec/datadog/core/remote/client_spec.rb
@@ -588,6 +588,24 @@ RSpec.describe Datadog::Core::Remote::Client do
               end
             end
 
+            context 'with remote extra_services setting' do
+              it 'returns client_tracer' do
+                expect(Datadog.configuration.remote).to receive(:service).and_return('foo').at_least(:once)
+                expect(Datadog.configuration.remote).to receive(:extra_services).and_return(['foo']).at_least(:once)
+
+                expected_client_tracer = {
+                  :runtime_id => Datadog::Core::Environment::Identity.id,
+                  :language => Datadog::Core::Environment::Identity.lang,
+                  :tracer_version => Datadog::Core::Environment::Identity.tracer_version_semver2,
+                  :service => Datadog.configuration.remote.service,
+                  :extra_services => Datadog.configuration.remote.extra_services,
+                  :env => Datadog.configuration.env,
+                }
+
+                expect(client_payload[:client_tracer].tap { |h| h.delete(:tags) }).to eq(expected_client_tracer)
+              end
+            end
+
             context 'with app_version' do
               it 'returns client_tracer' do
                 expect(Datadog.configuration).to receive(:version).and_return('hello').at_least(:once)


### PR DESCRIPTION
<!--
Check out the
https://github.com/DataDog/dd-trace-rb/blob/master/docs/DevelopmentGuide.md
for guidance on how to set up your development environment,
run the test suite, write new integrations, and more.
-->

**What does this PR do?**

Add extra service configuration for RC

**Motivation**

Service names can be mixed and matched in many ways, sometimes in complex ways that cannot be automatically inferred. For this information to be properly relayed in the most complex cases manual configuration is necessary.

**Additional Notes**

It may be possible to automate population of this field in the future (depends on configuration system evolution).

**How to test the change?**

Here's a typical configuration example, where:

- main service name is different from sub-services provided by integrations
- remote service name is made to match main service name
- rack and rails service names are different, and subject to remote configuration for this process as well
- request queuing is handled, creates a synthetic span which belongs to another service in another process, and so is not provided as extra service for RC.

```
  Datadog.configure do |c|
    c.service = 'web'

    c.tracing.enabled = true
    c.tracing.instrument :rack, service_name: 'web-rack', request_queuing: true, web_service_name: 'nginx'
    c.tracing.instrument :rails, service_name: 'web-rails'

    c.remote.enabled = true
    c.remote.service = 'web'
    c.remote.extra_services = ['web-rack', 'web-rails']
  end
```
