### PR TITLE
Document issue with Resque workers hanging

### DIFF
--- a/docs/GettingStarted.md
+++ b/docs/GettingStarted.md
@@ -109,6 +109,7 @@ To contribute, check out the [contribution guidelines][contribution docs] and [d
  - [Known issues and suggested configurations](#known-issues-and-suggested-configurations)
     - [Payload too large](#payload-too-large)
     - [Stack level too deep](#stack-level-too-deep)
+    - [Resque workers hang on exit](#resque-workers-hang-on-exit)
 
 ## Compatibility
 
@@ -2975,6 +2976,16 @@ As the implementation of `alias_method` exists within those libraries, Datadog g
 
 For libraries without a known workaround, consider removing the library using `alias` or `Module#alias_method` or separating libraries into different environments for testing.
 
-For any further questions or to report an occurence of this issue, please [reach out to Datadog support](https://docs.datadoghq.com/help)
+For any further questions or to report an occurrence of this issue, please [reach out to Datadog support](https://docs.datadoghq.com/help)
+
+### Resque workers hang on exit
+
+Resque's default of forking a process per job can, in rare situations, result in resque processes hanging on exit when instrumented with ddtrace.
+
+As a workaround, we recommend setting the `FORK_PER_JOB` environment variable to `false` to disable this behavior.
+
+See [this issue](https://github.com/DataDog/dd-trace-rb/issues/3015) for a discussion of the problem.
+
+<!---->
 
 [header tags]: https://docs.datadoghq.com/tracing/configure_data_security/#applying-header-tags-to-root-spans


### PR DESCRIPTION
**What does this PR do?**:

This PR adds the "Resque workers hang on exit" issue discussed in https://github.com/DataDog/dd-trace-rb/issues/3015 to the "Known issues and suggested configurations" section of our docs.

**Motivation**:

This issue seems to come up a few times, e.g. in:
* https://github.com/DataDog/dd-trace-rb/issues/466
* https://github.com/DataDog/dd-trace-rb/issues/2379
* https://github.com/DataDog/dd-trace-rb/issues/3015

...so I've decided to document the issue and the best-known workaround so that other customers than unfortunately run into it may find our suggested solution.

**Additional Notes**:

N/A

**How to test the change?**:

Docs-only change.
