### PR TITLE
Fix default hostname/port not being used when mixing http and uds configuration + improve warning message

### DIFF
--- a/lib/datadog/core/configuration/agent_settings_resolver.rb
+++ b/lib/datadog/core/configuration/agent_settings_resolver.rb
@@ -276,7 +276,7 @@ module Datadog
             'Configuration mismatch: values differ between ' \
             "#{detected_configurations_in_priority_order
               .map { |config| "#{config.friendly_name} (#{config.value.inspect})" }.join(' and ')}" \
-            ". Using #{detected_configurations_in_priority_order.first.value.inspect}."
+            ". Using #{detected_configurations_in_priority_order.first.value.inspect} and ignoring other configuration."
           )
         end
 

--- a/lib/datadog/core/configuration/agent_settings_resolver.rb
+++ b/lib/datadog/core/configuration/agent_settings_resolver.rb
@@ -95,7 +95,7 @@ module Datadog
         end
 
         def adapter
-          if should_use_uds? && !mixed_http_and_uds?
+          if should_use_uds?
             Datadog::Transport::Ext::UnixSocket::ADAPTER
           else
             Datadog::Transport::Ext::HTTP::ADAPTER
@@ -222,6 +222,10 @@ module Datadog
         end
 
         def should_use_uds?
+          can_use_uds? && !mixed_http_and_uds?
+        end
+
+        def can_use_uds?
           parsed_url && unix_scheme?(parsed_url) ||
             # If no agent settings have been provided, we try to connect using a local unix socket.
             # We only do so if the socket is present when `ddtrace` runs.
@@ -297,7 +301,7 @@ module Datadog
         def mixed_http_and_uds?
           return @mixed_http_and_uds if defined?(@mixed_http_and_uds)
 
-          @mixed_http_and_uds = (configured_hostname || configured_port) && should_use_uds?
+          @mixed_http_and_uds = (configured_hostname || configured_port) && can_use_uds?
 
           if @mixed_http_and_uds
             warn_if_configuration_mismatch(

--- a/lib/datadog/core/configuration/agent_settings_resolver.rb
+++ b/lib/datadog/core/configuration/agent_settings_resolver.rb
@@ -312,7 +312,7 @@ module Datadog
                 ),
                 DetectedConfiguration.new(
                   friendly_name: 'configuration for unix domain socket',
-                  value: "unix://#{uds_path}",
+                  value: parsed_url.to_s,
                 ),
               ]
             )

--- a/lib/datadog/core/configuration/agent_settings_resolver.rb
+++ b/lib/datadog/core/configuration/agent_settings_resolver.rb
@@ -308,7 +308,7 @@ module Datadog
               [
                 DetectedConfiguration.new(
                   friendly_name: 'configuration of hostname/port for http/https use',
-                  value: "hostname: '#{configured_hostname}', port: #{configured_port.inspect}",
+                  value: "hostname: '#{hostname}', port: '#{port}'",
                 ),
                 DetectedConfiguration.new(
                   friendly_name: 'configuration for unix domain socket',

--- a/spec/datadog/core/configuration/agent_settings_resolver_spec.rb
+++ b/spec/datadog/core/configuration/agent_settings_resolver_spec.rb
@@ -227,6 +227,16 @@ RSpec.describe Datadog::Core::Configuration::AgentSettingsResolver do
             it 'prioritizes the http configuration and uses the default port' do
               expect(resolver).to have_attributes(port: 8126, hostname: 'custom-hostname', adapter: :net_http)
             end
+
+            it 'logs a warning including the hostname and default port' do
+              expect(logger).to receive(:warn)
+                .with(/
+                  Configuration\ mismatch:\ values\ differ\ between\ configuration.*
+                  Using\ "hostname:\ 'custom-hostname',\ port:\ '8126'".*
+                /x)
+
+              resolver
+            end
           end
 
           context 'when there is a port specified' do
@@ -234,6 +244,16 @@ RSpec.describe Datadog::Core::Configuration::AgentSettingsResolver do
 
             it 'prioritizes the http configuration and uses the specified port' do
               expect(resolver).to have_attributes(port: 1234, hostname: 'custom-hostname', adapter: :net_http)
+            end
+
+            it 'logs a warning including the hostname and port' do
+              expect(logger).to receive(:warn)
+                .with(/
+                  Configuration\ mismatch:\ values\ differ\ between\ configuration.*
+                  Using\ "hostname:\ 'custom-hostname',\ port:\ '1234'".*
+                /x)
+
+              resolver
             end
           end
         end
@@ -259,6 +279,16 @@ RSpec.describe Datadog::Core::Configuration::AgentSettingsResolver do
             it 'prioritizes the http configuration and uses the default hostname' do
               expect(resolver).to have_attributes(port: 5678, hostname: '127.0.0.1', adapter: :net_http)
             end
+
+            it 'logs a warning including the default hostname and port' do
+              expect(logger).to receive(:warn)
+                .with(/
+                  Configuration\ mismatch:\ values\ differ\ between\ configuration.*
+                  Using\ "hostname:\ '127.0.0.1',\ port:\ '5678'".*
+                /x)
+
+              resolver
+            end
           end
 
           context 'when there is a hostname specified' do
@@ -266,6 +296,16 @@ RSpec.describe Datadog::Core::Configuration::AgentSettingsResolver do
 
             it 'prioritizes the http configuration and uses the specified hostname' do
               expect(resolver).to have_attributes(port: 5678, hostname: 'custom-hostname', adapter: :net_http)
+            end
+
+            it 'logs a warning including the hostname and port' do
+              expect(logger).to receive(:warn)
+                .with(/
+                  Configuration\ mismatch:\ values\ differ\ between\ configuration.*
+                  Using\ "hostname:\ 'custom-hostname',\ port:\ '5678'".*
+                /x)
+
+              resolver
             end
           end
         end

--- a/spec/datadog/core/configuration/agent_settings_resolver_spec.rb
+++ b/spec/datadog/core/configuration/agent_settings_resolver_spec.rb
@@ -117,6 +117,7 @@ RSpec.describe Datadog::Core::Configuration::AgentSettingsResolver do
     describe 'priority' do
       let(:with_transport_options) { nil }
       let(:with_agent_host) { nil }
+      let(:with_agent_port) { nil }
       let(:with_trace_agent_url) { nil }
       let(:with_environment_agent_host) { nil }
       let(:environment) do
@@ -135,6 +136,7 @@ RSpec.describe Datadog::Core::Configuration::AgentSettingsResolver do
             proc { |t| t.adapter(:net_http, hostname: with_transport_options) }
         end
         (ddtrace_settings.agent.host = with_agent_host) if with_agent_host
+        (ddtrace_settings.agent.port = with_agent_port) if with_agent_port
       end
 
       context 'when tracing.transport_options, agent.host, DD_TRACE_AGENT_URL, DD_AGENT_HOST are provided' do
@@ -202,21 +204,70 @@ RSpec.describe Datadog::Core::Configuration::AgentSettingsResolver do
       end
 
       context 'when there is a mix of http configuration and uds configuration' do
-        let(:with_agent_host) { 'custom-hostname' }
         let(:environment) { super().merge('DD_TRACE_AGENT_URL' => 'unix:///some/path') }
 
-        it 'prioritizes the http configuration' do
-          expect(resolver).to have_attributes(hostname: 'custom-hostname', adapter: :net_http)
+        context 'when there is a hostname specified along with uds configuration' do
+          let(:with_agent_host) { 'custom-hostname' }
+
+          it 'prioritizes the http configuration' do
+            expect(resolver).to have_attributes(hostname: 'custom-hostname', adapter: :net_http)
+          end
+
+          it 'logs a warning' do
+            expect(logger).to receive(:warn).with(/Configuration mismatch.*configuration for unix domain socket/)
+
+            resolver
+          end
+
+          it 'does not include a uds_path in the configuration' do
+            expect(resolver).to have_attributes(uds_path: nil)
+          end
+
+          context 'when there is no port specified' do
+            it 'prioritizes the http configuration and uses the default port' do
+              expect(resolver).to have_attributes(port: 8126, hostname: 'custom-hostname', adapter: :net_http)
+            end
+          end
+
+          context 'when there is a port specified' do
+            let(:with_agent_port) { 1234 }
+
+            it 'prioritizes the http configuration and uses the specified port' do
+              expect(resolver).to have_attributes(port: 1234, hostname: 'custom-hostname', adapter: :net_http)
+            end
+          end
         end
 
-        it 'logs a warning' do
-          expect(logger).to receive(:warn).with(/Configuration mismatch.*configuration for unix domain socket/)
+        context 'when there is a port specified along with uds configuration' do
+          let(:with_agent_port) { 5678 }
 
-          resolver
-        end
+          it 'prioritizes the http configuration' do
+            expect(resolver).to have_attributes(port: 5678, adapter: :net_http)
+          end
 
-        it 'does not include a uds_path in the configuration' do
-          expect(resolver).to have_attributes(uds_path: nil)
+          it 'logs a warning' do
+            expect(logger).to receive(:warn).with(/Configuration mismatch.*configuration for unix domain socket/)
+
+            resolver
+          end
+
+          it 'does not include a uds_path in the configuration' do
+            expect(resolver).to have_attributes(uds_path: nil)
+          end
+
+          context 'when there is no hostname specified' do
+            it 'prioritizes the http configuration and uses the default hostname' do
+              expect(resolver).to have_attributes(port: 5678, hostname: '127.0.0.1', adapter: :net_http)
+            end
+          end
+
+          context 'when there is a hostname specified' do
+            let(:with_agent_host) { 'custom-hostname' }
+
+            it 'prioritizes the http configuration and uses the specified hostname' do
+              expect(resolver).to have_attributes(port: 5678, hostname: 'custom-hostname', adapter: :net_http)
+            end
+          end
         end
       end
     end

--- a/spec/datadog/core/configuration/agent_settings_resolver_spec.rb
+++ b/spec/datadog/core/configuration/agent_settings_resolver_spec.rb
@@ -213,8 +213,9 @@ RSpec.describe Datadog::Core::Configuration::AgentSettingsResolver do
             expect(resolver).to have_attributes(hostname: 'custom-hostname', adapter: :net_http)
           end
 
-          it 'logs a warning' do
-            expect(logger).to receive(:warn).with(/Configuration mismatch.*configuration for unix domain socket/)
+          it 'logs a warning including the uds path' do
+            expect(logger).to receive(:warn)
+              .with(%r{Configuration mismatch.*configuration for unix domain socket \("unix:.*/some/path"\)})
 
             resolver
           end
@@ -265,8 +266,9 @@ RSpec.describe Datadog::Core::Configuration::AgentSettingsResolver do
             expect(resolver).to have_attributes(port: 5678, adapter: :net_http)
           end
 
-          it 'logs a warning' do
-            expect(logger).to receive(:warn).with(/Configuration mismatch.*configuration for unix domain socket/)
+          it 'logs a warning including the uds path' do
+            expect(logger).to receive(:warn)
+              .with(%r{Configuration mismatch.*configuration for unix domain socket \("unix:.*/some/path"\)})
 
             resolver
           end


### PR DESCRIPTION
**What does this PR do?**:

This PR fixes a corner case bug introduced in #2806 when we added support for configuration unix domain socket (UDS) via the `DD_TRACE_AGENT_URL` environment variable.

Specifically, when a mix of http and uds configuration was specified, we printed a warning and used the http configuration instead.

But, if only the hostname or only the port + uds configuration was provided, we did not correctly use the default hostname and default port as a replacement.

That is:

* `DD_AGENT_HOST=10.128.186.61 DD_TRACE_AGENT_URL=unix:///var/run/datadog/apm.socket` resulted in `hostname="10.128.186.61", port=nil`
* `DD_TRACE_AGENT_PORT=1234 DD_TRACE_AGENT_URL=unix:///var/run/datadog/apm.socket` resulted in `hostname=nil, port=1234`

This led to a failure to communicate with the Datadog agent in these situations.

**Motivation**:

Fix issue when communicating with the agent.

**Additional Notes**:

We caught this issue while testing internal apps. On the plus side, we did not get any customer reports for this issue, so hopefully nobody was bitten by it.

Also included are a few tweaks to the warning message generated + tests for it. See individual commits for detail.

I've tested the fix in the KTG and can confirm data is showing up again for "candidate" releases.

**How to test the change?**:

Change includes test coverage. You can also compare the output of the `AgentSettingsResolver` before/after the issue was fixed:

```
 # Before
$ DD_AGENT_HOST=10.128.186.61 DD_TRACE_AGENT_URL=unix:///var/run/datadog/apm.socket bundle exec ruby -e "require 'ddtrace'; pp(Datadog::Core::Configuration::AgentSettingsResolver.call(Datadog.configuration))"
 #<struct Datadog::Core::Configuration::AgentSettingsResolver::AgentSettings
 adapter=:net_http,
 ssl=false,
 hostname="10.128.186.61",
 port=nil,
 uds_path=nil,
 timeout_seconds=nil,
 deprecated_for_removal_transport_configuration_proc=nil>
$ DD_TRACE_AGENT_PORT=1234 DD_TRACE_AGENT_URL=unix:///var/run/datadog/apm.socket bundle exec ruby -e "require 'ddtrace'; pp(Datadog::Core::Configuration::AgentSettingsResolver.call(Datadog.configuration))"
 #<struct Datadog::Core::Configuration::AgentSettingsResolver::AgentSettings
 adapter=:net_http,
 ssl=false,
 hostname=nil,
 port=1234,
 uds_path=nil,
 timeout_seconds=nil,
 deprecated_for_removal_transport_configuration_proc=nil>

 # After
$ DD_AGENT_HOST=10.128.186.61 DD_TRACE_AGENT_URL=unix:///var/run/datadog/apm.socket bundle exec ruby -e "require 'ddtrace'; pp(Datadog::Core::Configuration::AgentSettingsResolver.call(Datadog.configuration))"
 #<struct Datadog::Core::Configuration::AgentSettingsResolver::AgentSettings
 adapter=:net_http,
 ssl=false,
 hostname="10.128.186.61",
 port=8126,
 uds_path=nil,
 timeout_seconds=nil,
 deprecated_for_removal_transport_configuration_proc=nil>
$ DD_TRACE_AGENT_PORT=1234 DD_TRACE_AGENT_URL=unix:///var/run/datadog/apm.socket bundle exec ruby -e "require 'ddtrace'; pp(Datadog::Core::Configuration::AgentSettingsResolver.call(Datadog.configuration))"
 #<struct Datadog::Core::Configuration::AgentSettingsResolver::AgentSettings
 adapter=:net_http,
 ssl=false,
 hostname="127.0.0.1",
 port=1234,
 uds_path=nil,
 timeout_seconds=nil,
 deprecated_for_removal_transport_configuration_proc=nil>
```
