### PR TITLE
Disable Telemetry and Remote Configuration in development environments

### DIFF
--- a/lib/datadog/core/configuration/settings.rb
+++ b/lib/datadog/core/configuration/settings.rb
@@ -2,6 +2,7 @@ require 'logger'
 
 require_relative 'base'
 require_relative 'ext'
+require_relative '../environment/execution'
 require_relative '../environment/ext'
 require_relative '../runtime/ext'
 require_relative '../telemetry/ext'
@@ -559,10 +560,21 @@ module Datadog
           #
           # @default `DD_INSTRUMENTATION_TELEMETRY_ENABLED` environment variable, otherwise `true`.
           #   Can be disabled as documented [here](https://docs.datadoghq.com/tracing/configure_data_security/#telemetry-collection).
+          #   By default, telemetry is disabled in development environments.
           # @return [Boolean]
           option :enabled do |o|
             o.env Core::Telemetry::Ext::ENV_ENABLED
-            o.default true
+            o.default do
+              if Datadog::Core::Environment::Execution.development?
+                Datadog.logger.debug do
+                  'Development environment detected, disabling Telemetry. ' \
+                    'You can enable it with DD_INSTRUMENTATION_TELEMETRY_ENABLED=true.'
+                end
+                false
+              else
+                true
+              end
+            end
             o.type :bool
           end
 
@@ -586,10 +598,21 @@ module Datadog
           # Enable remote configuration. This allows fetching of remote configuration for live updates.
           #
           # @default `DD_REMOTE_CONFIGURATION_ENABLED` environment variable, otherwise `true`.
+          #   By default, remote configuration is disabled in development environments.
           # @return [Boolean]
           option :enabled do |o|
             o.env Core::Remote::Ext::ENV_ENABLED
-            o.default true
+            o.default do
+              if Datadog::Core::Environment::Execution.development?
+                Datadog.logger.debug do
+                  'Development environment detected, disabling Remote Configuration. ' \
+                    'You can enable it with DD_REMOTE_CONFIGURATION_ENABLED=true.'
+                end
+                false
+              else
+                true
+              end
+            end
             o.type :bool
           end
 

--- a/spec/datadog/core/configuration/components_spec.rb
+++ b/spec/datadog/core/configuration/components_spec.rb
@@ -41,6 +41,8 @@ RSpec.describe Datadog::Core::Configuration::Components do
   let(:remote) { instance_double(Datadog::Core::Remote::Component, start: nil, shutdown!: nil) }
   let(:telemetry) { instance_double(Datadog::Core::Telemetry::Client) }
 
+  include_context 'non-development execution environment'
+
   before do
     # Ensure the real task never gets run (so it doesn't apply our thread patches and other extensions to our test env)
     if Datadog::Profiling.supported?

--- a/spec/datadog/core/configuration/settings_spec.rb
+++ b/spec/datadog/core/configuration/settings_spec.rb
@@ -1236,7 +1236,15 @@ RSpec.describe Datadog::Core::Configuration::Settings do
         context 'is not defined' do
           let(:env_var_value) { nil }
 
-          it { is_expected.to be true }
+          context 'in a development environment' do
+            it { is_expected.to be false }
+          end
+
+          context 'not in a development environment' do
+            before { allow(Datadog::Core::Environment::Execution).to receive(:development?).and_return(false) }
+
+            it { is_expected.to be true }
+          end
         end
 
         [true, false].each do |value|
@@ -1305,7 +1313,15 @@ RSpec.describe Datadog::Core::Configuration::Settings do
         context 'is not defined' do
           let(:environment) { nil }
 
-          it { is_expected.to be true }
+          context 'in a development environment' do
+            it { is_expected.to be false }
+          end
+
+          context 'not in a development environment' do
+            before { allow(Datadog::Core::Environment::Execution).to receive(:development?).and_return(false) }
+
+            it { is_expected.to be true }
+          end
         end
 
         context 'is defined' do
@@ -1317,6 +1333,8 @@ RSpec.describe Datadog::Core::Configuration::Settings do
     end
 
     describe '#enabled=' do
+      before { allow(Datadog::Core::Environment::Execution).to receive(:development?).and_return(false) }
+
       it 'updates the #enabled setting' do
         expect { settings.remote.enabled = false }
           .to change { settings.remote.enabled }

--- a/spec/datadog/core/configuration/settings_spec.rb
+++ b/spec/datadog/core/configuration/settings_spec.rb
@@ -1241,7 +1241,7 @@ RSpec.describe Datadog::Core::Configuration::Settings do
           end
 
           context 'not in a development environment' do
-            before { allow(Datadog::Core::Environment::Execution).to receive(:development?).and_return(false) }
+            include_context 'non-development execution environment'
 
             it { is_expected.to be true }
           end
@@ -1318,7 +1318,7 @@ RSpec.describe Datadog::Core::Configuration::Settings do
           end
 
           context 'not in a development environment' do
-            before { allow(Datadog::Core::Environment::Execution).to receive(:development?).and_return(false) }
+            include_context 'non-development execution environment'
 
             it { is_expected.to be true }
           end
@@ -1333,7 +1333,7 @@ RSpec.describe Datadog::Core::Configuration::Settings do
     end
 
     describe '#enabled=' do
-      before { allow(Datadog::Core::Environment::Execution).to receive(:development?).and_return(false) }
+      include_context 'non-development execution environment'
 
       it 'updates the #enabled setting' do
         expect { settings.remote.enabled = false }

--- a/spec/datadog/core/remote/component_spec.rb
+++ b/spec/datadog/core/remote/component_spec.rb
@@ -3,7 +3,7 @@
 require 'spec_helper'
 require 'datadog/core/remote/component'
 
-RSpec.describe Datadog::Core::Remote::Component do
+RSpec.describe Datadog::Core::Remote::Component, :integration do
   let(:settings) { Datadog::Core::Configuration::Settings.new }
   let(:agent_settings) { Datadog::Core::Configuration::AgentSettingsResolver.call(settings, logger: nil) }
   let(:capabilities) { Datadog::Core::Remote::Client::Capabilities.new(settings) }

--- a/spec/datadog/tracing/contrib/suite/integration_spec.rb
+++ b/spec/datadog/tracing/contrib/suite/integration_spec.rb
@@ -10,7 +10,7 @@ require 'rack'
 require 'rackup' if Rack::VERSION[0] >= 3
 require 'webrick'
 
-RSpec.describe 'contrib integration testing' do
+RSpec.describe 'contrib integration testing', :integration do
   around do |example|
     ClimateControl.modify('DD_REMOTE_CONFIGURATION_ENABLED' => nil) { example.run }
   end

--- a/spec/support/core_helpers.rb
+++ b/spec/support/core_helpers.rb
@@ -1,4 +1,8 @@
 module CoreHelpers
+  RSpec.shared_context 'non-development execution environment' do
+    before { allow(Datadog::Core::Environment::Execution).to receive(:development?).and_return(false) }
+  end
+
   # Asserts that a deprecated action is recorded by the `subject` execution.
   RSpec.shared_examples 'records deprecated action' do |matcher = nil|
     it 'records deprecated action in the deprecation log' do

--- a/spec/support/test_helpers.rb
+++ b/spec/support/test_helpers.rb
@@ -24,6 +24,8 @@ module TestHelpers
               skip('Integration tests can be enabled by setting the environment variable `TEST_DATADOG_INTEGRATION=1`')
             end
           end
+
+          include_context 'non-development execution environment'
         end
       end
     end


### PR DESCRIPTION
<!--
Check out the
https://github.com/DataDog/dd-trace-rb/blob/master/docs/DevelopmentGuide.md
for guidance on how to set up your development environment,
run the test suite, write new integrations, and more.
-->

**What does this PR do?**

By default, it disables the Telemetry and Remote Configuration background workers, which can send HTTP requests, in any environment that is detected as a development environment. See https://github.com/DataDog/dd-trace-rb/pull/3036 for the information about the detection logic.

**Motivation**
<!-- What inspired you to submit this pull request? -->

Fixes https://github.com/DataDog/dd-trace-rb/issues/2823

`ddtrace` can cause the test suite for the application to fail when `ddtrace` sends unexpected HTTP requests in the background. These requests are rarely desired and only cause noise add overhead.

**Additional Notes**
<!-- Anything else we should know when reviewing? -->

It's still possible to enable these features in a development environment by using their respective environment variables.

**How to test the change?**
<!--
Describe here how the change can be validated.
You are strongly encouraged to provide automated tests for this PR (unit or integration).
If this change cannot be feasibly tested, please explain why,
unless the change does not modify code (e.g. only modifies docs, comments).
-->

Without the agent running, run any project's test suite with `ddtrace` enabled and noticed that there's no warning about Telemetry or Remote Configuration not reaching the agent (because their background workers are not running at all).

The same is true for an `irb` or `pry` environment.