### PR TITLE
[PROF-7440] Report status of timeline feature as internal metadata

### DIFF
--- a/benchmarks/profiler_http_transport.rb
+++ b/benchmarks/profiler_http_transport.rb
@@ -50,7 +50,7 @@ class ProfilerHttpTransportBenchmark
       code_provenance_file_name: 'example_code_provenance_file_name.json',
       code_provenance_data: '', # Random.new(1).bytes(4_000),
       tags_as_array: [],
-      no_signals_workaround_enabled: false,
+      internal_metadata: {no_signals_workaround_enabled: false},
     )
   end
 

--- a/lib/datadog/profiling/component.rb
+++ b/lib/datadog/profiling/component.rb
@@ -65,9 +65,11 @@ module Datadog
         # NOTE: Please update the Initialization section of ProfilingDevelopment.md with any changes to this method
 
         no_signals_workaround_enabled = false
+        timeline_enabled = false
 
         if enable_new_profiler?(settings)
           no_signals_workaround_enabled = no_signals_workaround_enabled?(settings)
+          timeline_enabled = settings.profiling.advanced.experimental_timeline_enabled
 
           recorder = Datadog::Profiling::StackRecorder.new(
             cpu_time_enabled: RUBY_PLATFORM.include?('linux'), # Only supported on Linux currently
@@ -81,7 +83,7 @@ module Datadog
             gc_profiling_enabled: enable_gc_profiling?(settings),
             allocation_counting_enabled: settings.profiling.advanced.allocation_counting_enabled,
             no_signals_workaround_enabled: no_signals_workaround_enabled,
-            timeline_enabled: settings.profiling.advanced.experimental_timeline_enabled,
+            timeline_enabled: timeline_enabled,
           )
         else
           load_pprof_support
@@ -92,6 +94,7 @@ module Datadog
 
         internal_metadata = {
           no_signals_workaround_enabled: no_signals_workaround_enabled,
+          timeline_enabled: timeline_enabled,
         }.freeze
 
         exporter = build_profiler_exporter(settings, recorder, internal_metadata: internal_metadata)

--- a/lib/datadog/profiling/component.rb
+++ b/lib/datadog/profiling/component.rb
@@ -90,7 +90,11 @@ module Datadog
           collector = build_profiler_oldstack_collector(settings, recorder, optional_tracer)
         end
 
-        exporter = build_profiler_exporter(settings, recorder, no_signals_workaround_enabled: no_signals_workaround_enabled)
+        internal_metadata = {
+          no_signals_workaround_enabled: no_signals_workaround_enabled,
+        }.freeze
+
+        exporter = build_profiler_exporter(settings, recorder, internal_metadata: internal_metadata)
         transport = build_profiler_transport(settings, agent_settings)
         scheduler = Profiling::Scheduler.new(exporter: exporter, transport: transport)
 
@@ -101,14 +105,14 @@ module Datadog
         Profiling::OldRecorder.new([Profiling::Events::StackSample], settings.profiling.advanced.max_events)
       end
 
-      private_class_method def self.build_profiler_exporter(settings, recorder, no_signals_workaround_enabled:)
+      private_class_method def self.build_profiler_exporter(settings, recorder, internal_metadata:)
         code_provenance_collector =
           (Profiling::Collectors::CodeProvenance.new if settings.profiling.advanced.code_provenance_enabled)
 
         Profiling::Exporter.new(
           pprof_recorder: recorder,
           code_provenance_collector: code_provenance_collector,
-          internal_metadata: { no_signals_workaround_enabled: no_signals_workaround_enabled },
+          internal_metadata: internal_metadata,
         )
       end
 

--- a/lib/datadog/profiling/component.rb
+++ b/lib/datadog/profiling/component.rb
@@ -108,7 +108,7 @@ module Datadog
         Profiling::Exporter.new(
           pprof_recorder: recorder,
           code_provenance_collector: code_provenance_collector,
-          no_signals_workaround_enabled: no_signals_workaround_enabled,
+          internal_metadata: { no_signals_workaround_enabled: no_signals_workaround_enabled },
         )
       end
 

--- a/lib/datadog/profiling/exporter.rb
+++ b/lib/datadog/profiling/exporter.rb
@@ -64,7 +64,7 @@ module Datadog
           code_provenance_file_name: Datadog::Profiling::Ext::Transport::HTTP::CODE_PROVENANCE_FILENAME,
           code_provenance_data: uncompressed_code_provenance,
           tags_as_array: Datadog::Profiling::TagBuilder.call(settings: Datadog.configuration).to_a,
-          no_signals_workaround_enabled: no_signals_workaround_enabled,
+          internal_metadata: { no_signals_workaround_enabled: no_signals_workaround_enabled },
         )
       end
 

--- a/lib/datadog/profiling/exporter.rb
+++ b/lib/datadog/profiling/exporter.rb
@@ -30,7 +30,7 @@ module Datadog
       def initialize(
         pprof_recorder:,
         code_provenance_collector:,
-        no_signals_workaround_enabled:,
+        internal_metadata:,
         minimum_duration_seconds: PROFILE_DURATION_THRESHOLD_SECONDS,
         time_provider: Time
       )
@@ -40,7 +40,7 @@ module Datadog
         @time_provider = time_provider
         @last_flush_finish_at = nil
         @created_at = time_provider.now.utc
-        @internal_metadata = {no_signals_workaround_enabled: no_signals_workaround_enabled}
+        @internal_metadata = internal_metadata
       end
 
       def flush

--- a/lib/datadog/profiling/exporter.rb
+++ b/lib/datadog/profiling/exporter.rb
@@ -23,7 +23,7 @@ module Datadog
         :time_provider,
         :last_flush_finish_at,
         :created_at,
-        :no_signals_workaround_enabled
+        :internal_metadata
 
       public
 
@@ -40,7 +40,7 @@ module Datadog
         @time_provider = time_provider
         @last_flush_finish_at = nil
         @created_at = time_provider.now.utc
-        @no_signals_workaround_enabled = no_signals_workaround_enabled
+        @internal_metadata = {no_signals_workaround_enabled: no_signals_workaround_enabled}
       end
 
       def flush
@@ -64,7 +64,7 @@ module Datadog
           code_provenance_file_name: Datadog::Profiling::Ext::Transport::HTTP::CODE_PROVENANCE_FILENAME,
           code_provenance_data: uncompressed_code_provenance,
           tags_as_array: Datadog::Profiling::TagBuilder.call(settings: Datadog.configuration).to_a,
-          internal_metadata: { no_signals_workaround_enabled: no_signals_workaround_enabled },
+          internal_metadata: internal_metadata,
         )
       end
 

--- a/lib/datadog/profiling/flush.rb
+++ b/lib/datadog/profiling/flush.rb
@@ -27,7 +27,7 @@ module Datadog
         code_provenance_file_name:,
         code_provenance_data:,
         tags_as_array:,
-        no_signals_workaround_enabled:
+        internal_metadata:
       )
         @start = start
         @finish = finish
@@ -36,9 +36,7 @@ module Datadog
         @code_provenance_file_name = code_provenance_file_name
         @code_provenance_data = code_provenance_data
         @tags_as_array = tags_as_array
-        @internal_metadata_json = JSON.fast_generate(
-          no_signals_workaround_enabled: (!!no_signals_workaround_enabled).to_s,
-        )
+        @internal_metadata_json = JSON.fast_generate(internal_metadata.map { |k, v| [k, v.to_s] }.to_h)
       end
     end
   end

--- a/sig/datadog/profiling/component.rbs
+++ b/sig/datadog/profiling/component.rbs
@@ -12,7 +12,7 @@ module Datadog
       def self.build_profiler_exporter: (
         untyped settings,
         (Datadog::Profiling::StackRecorder | Datadog::Profiling::OldRecorder) recorder,
-        no_signals_workaround_enabled: bool,
+        internal_metadata: ::Hash[::Symbol, ::String | bool | ::Numeric],
       ) -> Datadog::Profiling::Exporter
 
       def self.build_profiler_oldstack_collector: (

--- a/sig/datadog/profiling/exporter.rbs
+++ b/sig/datadog/profiling/exporter.rbs
@@ -11,14 +11,14 @@ module Datadog
       attr_reader time_provider: untyped
       attr_reader last_flush_finish_at: ::Time?
       attr_reader created_at: ::Time
-      attr_reader no_signals_workaround_enabled: bool
+      attr_reader internal_metadata: ::Hash[::Symbol, ::String | bool | ::Numeric]
 
       public
 
       def initialize: (
         pprof_recorder: (Datadog::Profiling::StackRecorder | Datadog::Profiling::OldRecorder),
         code_provenance_collector: Datadog::Profiling::Collectors::CodeProvenance?,
-        no_signals_workaround_enabled: bool,
+        internal_metadata: ::Hash[::Symbol, ::String | bool | ::Numeric],
         ?minimum_duration_seconds: ::Integer,
         ?time_provider: untyped
       ) -> void

--- a/sig/datadog/profiling/flush.rbs
+++ b/sig/datadog/profiling/flush.rbs
@@ -20,7 +20,7 @@ module Datadog
         code_provenance_file_name: ::String,
         code_provenance_data: ::String?,
         tags_as_array: Array[[::String, ::String]],
-        no_signals_workaround_enabled: bool,
+        internal_metadata: ::Hash[::Symbol, ::String | bool | ::Numeric],
       ) -> void
     end
   end

--- a/spec/datadog/profiling/component_spec.rb
+++ b/spec/datadog/profiling/component_spec.rb
@@ -92,7 +92,7 @@ RSpec.describe Datadog::Profiling::Component do
 
         it 'sets up the Exporter with no_signals_workaround_enabled: false' do
           expect(Datadog::Profiling::Exporter)
-            .to receive(:new).with(hash_including(no_signals_workaround_enabled: false))
+            .to receive(:new).with(hash_including(internal_metadata: { no_signals_workaround_enabled: false }))
 
           build_profiler_component
         end
@@ -263,7 +263,7 @@ RSpec.describe Datadog::Profiling::Component do
 
           expect(described_class).to receive(:no_signals_workaround_enabled?).and_return(:no_signals_result)
           expect(Datadog::Profiling::Exporter)
-            .to receive(:new).with(hash_including(no_signals_workaround_enabled: :no_signals_result))
+            .to receive(:new).with(hash_including(internal_metadata: { no_signals_workaround_enabled: :no_signals_result }))
 
           build_profiler_component
         end

--- a/spec/datadog/profiling/component_spec.rb
+++ b/spec/datadog/profiling/component_spec.rb
@@ -90,9 +90,16 @@ RSpec.describe Datadog::Profiling::Component do
           build_profiler_component
         end
 
-        it 'sets up the Exporter with no_signals_workaround_enabled: false' do
+        it 'sets up the Exporter internal_metadata with no_signals_workaround_enabled: false, timeline_enabled: false' do
           expect(Datadog::Profiling::Exporter)
-            .to receive(:new).with(hash_including(internal_metadata: { no_signals_workaround_enabled: false }))
+            .to receive(:new).with(
+              hash_including(
+                internal_metadata: {
+                  no_signals_workaround_enabled: false,
+                  timeline_enabled: false,
+                }
+              )
+            )
 
           build_profiler_component
         end
@@ -258,12 +265,19 @@ RSpec.describe Datadog::Profiling::Component do
           build_profiler_component
         end
 
-        it 'sets up the Exporter with no_signals_workaround_enabled setting' do
+        it 'sets up the Exporter internal_metadata with no_signals_workaround_enabled and timeline_enabled settings' do
           allow(Datadog::Profiling::Collectors::CpuAndWallTimeWorker).to receive(:new)
 
           expect(described_class).to receive(:no_signals_workaround_enabled?).and_return(:no_signals_result)
-          expect(Datadog::Profiling::Exporter)
-            .to receive(:new).with(hash_including(internal_metadata: { no_signals_workaround_enabled: :no_signals_result }))
+          expect(settings.profiling.advanced).to receive(:experimental_timeline_enabled).and_return(:timeline_result)
+          expect(Datadog::Profiling::Exporter).to receive(:new).with(
+            hash_including(
+              internal_metadata: {
+                no_signals_workaround_enabled: :no_signals_result,
+                timeline_enabled: :timeline_result,
+              }
+            )
+          )
 
           build_profiler_component
         end

--- a/spec/datadog/profiling/exporter_spec.rb
+++ b/spec/datadog/profiling/exporter_spec.rb
@@ -8,7 +8,7 @@ RSpec.describe Datadog::Profiling::Exporter do
     described_class.new(
       pprof_recorder: pprof_recorder,
       code_provenance_collector: code_provenance_collector,
-      no_signals_workaround_enabled: no_signals_workaround_enabled,
+      internal_metadata: internal_metadata,
       **options
     )
   end
@@ -24,6 +24,7 @@ RSpec.describe Datadog::Profiling::Exporter do
     allow(collector).to receive(:refresh).and_return(collector)
     collector
   end
+  let(:internal_metadata) { { no_signals_workaround_enabled: no_signals_workaround_enabled } }
   let(:no_signals_workaround_enabled) { false }
   let(:logger) { Datadog.logger }
   let(:options) { {} }

--- a/spec/datadog/profiling/flush_spec.rb
+++ b/spec/datadog/profiling/flush_spec.rb
@@ -7,6 +7,7 @@ RSpec.describe Datadog::Profiling::Flush do
     let(:code_provenance_file_name) { 'the_code_provenance_file_name.json' }
     let(:code_provenance_data) { 'the_code_provenance_data' }
     let(:tags_as_array) { [%w[tag_a value_a], %w[tag_b value_b]] }
+    let(:internal_metadata) { { no_signals_workaround_enabled: false } }
 
     subject(:flush) do
       described_class.new(
@@ -17,7 +18,7 @@ RSpec.describe Datadog::Profiling::Flush do
         code_provenance_file_name: code_provenance_file_name,
         code_provenance_data: code_provenance_data,
         tags_as_array: tags_as_array,
-        no_signals_workaround_enabled: false,
+        internal_metadata: internal_metadata,
       )
     end
 

--- a/spec/datadog/profiling/http_transport_spec.rb
+++ b/spec/datadog/profiling/http_transport_spec.rb
@@ -55,7 +55,7 @@ RSpec.describe Datadog::Profiling::HttpTransport do
       code_provenance_file_name: code_provenance_file_name,
       code_provenance_data: code_provenance_data,
       tags_as_array: tags_as_array,
-      no_signals_workaround_enabled: true,
+      internal_metadata: { no_signals_workaround_enabled: true },
     )
   end
   let(:start_timestamp) { '2022-02-07T15:59:53.987654321Z' }

--- a/spec/datadog/profiling/integration_spec.rb
+++ b/spec/datadog/profiling/integration_spec.rb
@@ -90,7 +90,9 @@ RSpec.describe 'profiling integration test' do
     end
     let(:exporter) do
       Datadog::Profiling::Exporter.new(
-        pprof_recorder: old_recorder, code_provenance_collector: nil, no_signals_workaround_enabled: false
+        pprof_recorder: old_recorder,
+        code_provenance_collector: nil,
+        internal_metadata: { no_signals_workaround_enabled: false },
       )
     end
     let(:collector) do


### PR DESCRIPTION
**What does this PR do?**:

This PR adds support for reporting the status of the timeline feature together with profiles, via the internal metadata field.

I ended up doing a bunch of refactoring to make it easier to adds new reported fields as internal metadata; it may be easier to review this PR commit-by-commit.

**Motivation**:

While this feature is off-by-default, having this internal metadata makes it easier to spot profiles that have/don't have this data without actually opening them up in the UX.

**Additional Notes**:

N/A

**How to test the change?**:

This change includes test coverage. It's possible internally at Datadog to see this information in profile listings (ping me if you'd like to know more).
