### PR TITLE
Improve quantization

### DIFF
--- a/lib/datadog/tracing/contrib/utils/quantization/http.rb
+++ b/lib/datadog/tracing/contrib/utils/quantization/http.rb
@@ -134,18 +134,18 @@ module Datadog
                  (?:"|%22)?
               )
               (?: # common keys
-                 (?:old_?|new_?)?p(?:ass)?w(?:or)?d(?:1|2)? # pw, password variants
-                |pass(?:_?phrase)?  # pass, passphrase variants
+                 (?:old[-_]?|new_?)?p(?:ass)?w(?:or)?d(?:1|2)? # pw, password variants
+                |pass(?:[-_]?phrase)?  # pass, passphrase variants
                 |secret
                 |(?: # key, key_id variants
-                     api_?
-                    |private_?
-                    |public_?
-                    |access_?
-                    |secret_?
-                 )key(?:_?id)?
+                     api[-_]?
+                    |private[-_]?
+                    |public[-_]?
+                    |access[-_]?
+                    |secret[-_]?
+                 )key(?:[-_]?id)?
                 |token
-                |consumer_?(?:id|key|secret)
+                |consumer[-_]?(?:id|key|secret)
                 |sign(?:ed|ature)?
                 |auth(?:entication|orization)?
               )

--- a/spec/datadog/tracing/contrib/utils/quantization/http_spec.rb
+++ b/spec/datadog/tracing/contrib/utils/quantization/http_spec.rb
@@ -21,6 +21,18 @@ RSpec.describe Datadog::Tracing::Contrib::Utils::Quantization::HTTP do
         it { is_expected.to eq('http://example.com/path?categories[]') }
       end
 
+      context 'default behavior for an array with indices' do
+        let(:url) { 'http://example.com/path?categories[0]=1&categories[1]=2' }
+
+        it { is_expected.to eq('http://example.com/path?categories[0]&categories[1]') }
+      end
+
+      context 'default behavior for a hash' do
+        let(:url) { 'http://example.com/path?categories[foo]=1&categories[bar]=2' }
+
+        it { is_expected.to eq('http://example.com/path?categories[foo]&categories[bar]') }
+      end
+
       context 'with query: show: value' do
         let(:options) { { query: { show: ['category_id'] } } }
 

--- a/spec/datadog/tracing/contrib/utils/quantization/http_spec.rb
+++ b/spec/datadog/tracing/contrib/utils/quantization/http_spec.rb
@@ -496,6 +496,13 @@ RSpec.describe Datadog::Tracing::Contrib::Utils::Quantization::HTTP do
       public_key_id
       access_key_id
       secret_key_id
+      api-key
+      api-key-id
+      private-key
+      private-key-id
+      public-key-id
+      access-key-id
+      secret-key-id
       token
       consumerid
       consumerkey
@@ -503,6 +510,9 @@ RSpec.describe Datadog::Tracing::Contrib::Utils::Quantization::HTTP do
       consumer_id
       consumer_key
       consumer_secret
+      consumer-id
+      consumer-key
+      consumer-secret
       sign
       signed
       signature


### PR DESCRIPTION
<!--
Check out the
https://github.com/DataDog/dd-trace-rb/blob/master/docs/DevelopmentGuide.md
for guidance on how to set up your development environment,
run the test suite, write new integrations, and more.
-->

**What does this PR do?**

Small bits of improvement to quantization and obfuscation.

**Motivation**

Stumbled upon a few areas that were lacking.

**Additional Notes**

Regex has been checked for linearity with the new Ruby 3.3 `Regexp.linear_time?`.

**How to test the change?**

```
env SKIP_SIMPLECOV=1 bundle exec rspec spec/datadog/tracing/contrib/utils/quantization/http_spec.rb
```
