### PR TITLE
Add option to keep keys through obfuscation

### DIFF
--- a/lib/datadog/tracing/contrib/utils/quantization/http.rb
+++ b/lib/datadog/tracing/contrib/utils/quantization/http.rb
@@ -134,18 +134,18 @@ module Datadog
                  (?:"|%22)?
               )
               (?: # common keys
-                 (?:old_?|new_?)?p(?:ass)?w(?:or)?d(?:1|2)? # pw, password variants
-                |pass(?:_?phrase)?  # pass, passphrase variants
+                 (?:old[-_]?|new_?)?p(?:ass)?w(?:or)?d(?:1|2)? # pw, password variants
+                |pass(?:[-_]?phrase)?  # pass, passphrase variants
                 |secret
                 |(?: # key, key_id variants
-                     api_?
-                    |private_?
-                    |public_?
-                    |access_?
-                    |secret_?
-                 )key(?:_?id)?
+                     api[-_]?
+                    |private[-_]?
+                    |public[-_]?
+                    |access[-_]?
+                    |secret[-_]?
+                 )key(?:[-_]?id)?
                 |token
-                |consumer_?(?:id|key|secret)
+                |consumer[-_]?(?:id|key|secret)
                 |sign(?:ed|ature)?
                 |auth(?:entication|orization)?
               )

--- a/lib/datadog/tracing/contrib/utils/quantization/http.rb
+++ b/lib/datadog/tracing/contrib/utils/quantization/http.rb
@@ -165,7 +165,7 @@ module Datadog
                 |gh[opsu]_[0-9a-zA-Z]{36}
                 |ey[I-L](?:[\w=-]|%3D)+\.ey[I-L](?:[\w=-]|%3D)+(?:\.(?:[\w.+/=-]|%3D|%2F|%2B)+)?
                 |-{5}BEGIN(?:[a-z\s]|%20)+PRIVATE(?:\s|%20)KEY-{5}[^\-]+-{5}END(?:[a-z\s]|%20)+PRIVATE(?:\s|%20)KEY(?:-{5})?(?:\n|%0A)?
-                |(?:ssh-(?:rsa|dss)|ecdsa-[a-z0-9]+-[a-z0-9]+)(?:\s|%20)*(?:[a-z0-9/.+]|%2F|%5C|%2B){100,}(?:=|%3D)*(?:(?:\s+)[a-z0-9._-]+)?
+                |(?:ssh-(?:rsa|dss)|ecdsa-[a-z0-9]+-[a-z0-9]+)(?:\s|%20|%09)+(?:[a-z0-9/.+]|%2F|%5C|%2B){100,}(?:=|%3D)*(?:(?:\s|%20|%09)+[a-z0-9._-]+)?
               )
             }ix.freeze
             # rubocop:enable Layout/LineLength

--- a/spec/datadog/tracing/contrib/utils/quantization/http_spec.rb
+++ b/spec/datadog/tracing/contrib/utils/quantization/http_spec.rb
@@ -412,6 +412,13 @@ RSpec.describe Datadog::Tracing::Contrib::Utils::Quantization::HTTP do
           it { is_expected.to eq('k=<redacted>') }
         end
 
+        context 'with a freestanding value in URL-encoded JSON' do
+          let(:query) { 'json=%7B%20%22k%22%3A%20%22ssh-rsa%20AAAAB3NzaC1yc2EAAAADAQABAAABgQCxkfwLCG9IW32wN%2Bdbys1JP1qRTA9QRn8XnZdr5Irz7yGXCkPjr7e51F%2Fv73fRk4FOnaRjHartimlsb4NogaNN1clkHkvrRvjHyTzGBM%2FWgumEdco0Ay4H%2FBdyJwLNw88iUGVM3H93s%2BrP5a8u4Ptk4HZy1lSWAjg52ZhYv3V%2BcyQNjfHiOuHk2lChmtTE1FlKfc8pkxB4QnyG3EbQrEDzRkym8NTlvZIaOv01VdsmRXWurigI9AnqgoA43eD3JqWswjyCkmSnnW3h%2B9iB4bgRrSIT2QBugpIHVM4pbkT4UrlpcVEeAziYNPC4H61luX0d1%2FqOntaMFMtvJKuG%2F3Jj8t19O%2BnSTa9re%2BPzS5Qm8J%2F7xzaxxOIq94D7FnGPG5JifJ4WZRWF0PDptOXbJY72Yumb%2BxaJtr9LlqfS6fJzWkA68PT%2FZaEk5JgaPHhlvUvmx5JlmP7u2eFcbNHpHQHoIfJjXk8J3EDXjl5Rp6E9KxARD3p45Sh8b4LoVR8Z0%2Bk%3D%20dummy%22%7D' } # rubocop:disable Layout/LineLength
+          let(:options) { { obfuscate: :internal } }
+
+          it { is_expected.to eq('json=%7B%20%22k%22%3A%20%22<redacted>%22%7D') }
+        end
+
         context 'with a reduced show option overlapping with a potential obfuscation match' do
           let(:query) { 'pass=03cb9f67-dbbc-4cb8-b966-329951e10934&key2=val2&key3=val3' }
           let(:options) { { show: %w[pass key2], obfuscate: :internal } }

--- a/spec/datadog/tracing/contrib/utils/quantization/http_spec.rb
+++ b/spec/datadog/tracing/contrib/utils/quantization/http_spec.rb
@@ -21,6 +21,18 @@ RSpec.describe Datadog::Tracing::Contrib::Utils::Quantization::HTTP do
         it { is_expected.to eq('http://example.com/path?categories[]') }
       end
 
+      context 'default behavior for an array with indices' do
+        let(:url) { 'http://example.com/path?categories[0]=1&categories[1]=2' }
+
+        it { is_expected.to eq('http://example.com/path?categories[0]&categories[1]') }
+      end
+
+      context 'default behavior for a hash' do
+        let(:url) { 'http://example.com/path?categories[foo]=1&categories[bar]=2' }
+
+        it { is_expected.to eq('http://example.com/path?categories[foo]&categories[bar]') }
+      end
+
       context 'with query: show: value' do
         let(:options) { { query: { show: ['category_id'] } } }
 

--- a/spec/datadog/tracing/contrib/utils/quantization/http_spec.rb
+++ b/spec/datadog/tracing/contrib/utils/quantization/http_spec.rb
@@ -412,7 +412,7 @@ RSpec.describe Datadog::Tracing::Contrib::Utils::Quantization::HTTP do
           it { is_expected.to eq('<redacted>&key2=val2&key3') }
         end
 
-        context 'with a reduced show option distinct from a potentail obfuscation match' do
+        context 'with a reduced show option distinct from a potential obfuscation match' do
           let(:query) { 'pass=03cb9f67-dbbc-4cb8-b966-329951e10934&key2=val2&key3=val3' }
           let(:options) { { show: ['key2'], obfuscate: :internal } }
 

--- a/spec/datadog/tracing/contrib/utils/quantization/http_spec.rb
+++ b/spec/datadog/tracing/contrib/utils/quantization/http_spec.rb
@@ -405,6 +405,13 @@ RSpec.describe Datadog::Tracing::Contrib::Utils::Quantization::HTTP do
           it { is_expected.to eq('json=%7B%20<redacted>%7D') }
         end
 
+        context 'with a freestanding value match' do
+          let(:query) { 'k=ssh-rsa%20AAAAB3NzaC1yc2EAAAADAQABAAABgQCxkfwLCG9IW32wN+dbys1JP1qRTA9QRn8XnZdr5Irz7yGXCkPjr7e51F/v73fRk4FOnaRjHartimlsb4NogaNN1clkHkvrRvjHyTzGBM/WgumEdco0Ay4H/BdyJwLNw88iUGVM3H93s+rP5a8u4Ptk4HZy1lSWAjg52ZhYv3V+cyQNjfHiOuHk2lChmtTE1FlKfc8pkxB4QnyG3EbQrEDzRkym8NTlvZIaOv01VdsmRXWurigI9AnqgoA43eD3JqWswjyCkmSnnW3h+9iB4bgRrSIT2QBugpIHVM4pbkT4UrlpcVEeAziYNPC4H61luX0d1/qOntaMFMtvJKuG/3Jj8t19O+nSTa9re+PzS5Qm8J/7xzaxxOIq94D7FnGPG5JifJ4WZRWF0PDptOXbJY72Yumb+xaJtr9LlqfS6fJzWkA68PT/ZaEk5JgaPHhlvUvmx5JlmP7u2eFcbNHpHQHoIfJjXk8J3EDXjl5Rp6E9KxARD3p45Sh8b4LoVR8Z0+k=%20dummy' } # rubocop:disable Layout/LineLength
+          let(:options) { { obfuscate: :internal } }
+
+          it { is_expected.to eq('k=<redacted>') }
+        end
+
         context 'with a reduced show option overlapping with a potential obfuscation match' do
           let(:query) { 'pass=03cb9f67-dbbc-4cb8-b966-329951e10934&key2=val2&key3=val3' }
           let(:options) { { show: %w[pass key2], obfuscate: :internal } }

--- a/spec/datadog/tracing/contrib/utils/quantization/http_spec.rb
+++ b/spec/datadog/tracing/contrib/utils/quantization/http_spec.rb
@@ -496,6 +496,13 @@ RSpec.describe Datadog::Tracing::Contrib::Utils::Quantization::HTTP do
       public_key_id
       access_key_id
       secret_key_id
+      api-key
+      api-key-id
+      private-key
+      private-key-id
+      public-key-id
+      access-key-id
+      secret-key-id
       token
       consumerid
       consumerkey
@@ -503,6 +510,9 @@ RSpec.describe Datadog::Tracing::Contrib::Utils::Quantization::HTTP do
       consumer_id
       consumer_key
       consumer_secret
+      consumer-id
+      consumer-key
+      consumer-secret
       sign
       signed
       signature


### PR DESCRIPTION
<!--
Check out the
https://github.com/DataDog/dd-trace-rb/blob/master/docs/DevelopmentGuide.md
for guidance on how to set up your development environment,
run the test suite, write new integrations, and more.
-->

**What does this PR do?**

Allow keys not to be redacted when they match the obfuscation regex.

**Motivation**

Users may want to keep keys and only redact values.

**Additional Notes**

Some additional fixes and coverage increase have been folded in there.

**How to test the change?**

CI
