### PR TITLE
Tracing: Exclude query string for `http.url` tag from `net/http` instrumentation 

### DIFF
--- a/lib/datadog/tracing/contrib/http/instrumentation.rb
+++ b/lib/datadog/tracing/contrib/http/instrumentation.rb
@@ -3,6 +3,7 @@ require 'uri'
 require_relative '../../metadata/ext'
 require_relative '../analytics'
 require_relative '../http_annotation_helper'
+require_relative '../utils/quantization/http'
 
 module Datadog
   module Tracing
@@ -79,8 +80,10 @@ module Datadog
 
               span.set_tag(Tracing::Metadata::Ext::TAG_COMPONENT, Ext::TAG_COMPONENT)
               span.set_tag(Tracing::Metadata::Ext::TAG_OPERATION, Ext::TAG_OPERATION_REQUEST)
-
-              span.set_tag(Tracing::Metadata::Ext::HTTP::TAG_URL, request.path)
+              span.set_tag(
+                Tracing::Metadata::Ext::HTTP::TAG_URL,
+                Contrib::Utils::Quantization::HTTP.url(request.path, { query: { exclude: :all } })
+              )
               span.set_tag(Tracing::Metadata::Ext::HTTP::TAG_METHOD, request.method)
 
               host, port = host_and_port(request)

--- a/spec/datadog/tracing/contrib/ethon/easy_patch_spec.rb
+++ b/spec/datadog/tracing/contrib/ethon/easy_patch_spec.rb
@@ -248,4 +248,15 @@ RSpec.describe Datadog::Tracing::Contrib::Ethon::EasyPatch do
       expect(span.get_tag('out.host')).to eq('example.com')
     end
   end
+
+  context 'when query string in url' do
+    it 'does not collect string' do
+      easy = EthonSupport.ethon_easy_new(url: 'http://example.com/sample/path?foo=bar')
+
+      easy.perform
+
+      expect(span.get_tag('http.url')).to eq('/sample/path')
+      expect(span.get_tag('out.host')).to eq('example.com')
+    end
+  end
 end

--- a/spec/datadog/tracing/contrib/ethon/easy_patch_spec.rb
+++ b/spec/datadog/tracing/contrib/ethon/easy_patch_spec.rb
@@ -250,13 +250,12 @@ RSpec.describe Datadog::Tracing::Contrib::Ethon::EasyPatch do
   end
 
   context 'when query string in url' do
-    it 'does not collect string' do
+    it 'does not collect query string' do
       easy = EthonSupport.ethon_easy_new(url: 'http://example.com/sample/path?foo=bar')
 
       easy.perform
 
       expect(span.get_tag('http.url')).to eq('/sample/path')
-      expect(span.get_tag('out.host')).to eq('example.com')
     end
   end
 end

--- a/spec/datadog/tracing/contrib/excon/instrumentation_spec.rb
+++ b/spec/datadog/tracing/contrib/excon/instrumentation_spec.rb
@@ -425,7 +425,6 @@ RSpec.describe Datadog::Tracing::Contrib::Excon::Middleware do
       Excon.get('http://example.com/sample/path?foo=bar')
 
       expect(span.get_tag('http.url')).to eq('/sample/path')
-      expect(span.get_tag('out.host')).to eq('example.com')
     end
   end
 end

--- a/spec/datadog/tracing/contrib/excon/instrumentation_spec.rb
+++ b/spec/datadog/tracing/contrib/excon/instrumentation_spec.rb
@@ -412,4 +412,20 @@ RSpec.describe Datadog::Tracing::Contrib::Excon::Middleware do
       expect(span.get_tag('out.host')).to eq('example.com')
     end
   end
+
+  context 'when query string in url' do
+    before do
+      call_web_mock_function_with_agent_host_exclusions { |options| WebMock.enable! options }
+      stub_request(:get, /example.com/).to_return(status: 200)
+    end
+
+    after { WebMock.disable! }
+
+    it 'does not query string' do
+      Excon.get('http://example.com/sample/path?foo=bar')
+
+      expect(span.get_tag('http.url')).to eq('/sample/path')
+      expect(span.get_tag('out.host')).to eq('example.com')
+    end
+  end
 end

--- a/spec/datadog/tracing/contrib/faraday/middleware_spec.rb
+++ b/spec/datadog/tracing/contrib/faraday/middleware_spec.rb
@@ -152,6 +152,20 @@ RSpec.describe 'Faraday middleware' do
           expect { response }.to_not output(/WARNING/).to_stderr
         end
       end
+
+      context 'with query sting in url' do
+        subject(:response) { client.get('http://example.com/success?foo=bar') }
+
+        it 'does not collect query string' do
+          expect(response.status).to eq(200)
+
+          expect(span.get_tag('http.url')).to eq('/success')
+        end
+
+        it 'executes without warnings' do
+          expect { response }.to_not output(/WARNING/).to_stderr
+        end
+      end
     end
   end
 

--- a/spec/datadog/tracing/contrib/http/request_spec.rb
+++ b/spec/datadog/tracing/contrib/http/request_spec.rb
@@ -571,16 +571,5 @@ RSpec.describe 'net/http requests' do
       expect(span.get_tag('http.url')).to eq('/sample/path')
       expect(span.get_tag('out.host')).to eq('example.com')
     end
-
-    it 'does not collect query string' do
-      uri = URI('http://example.com/sample/path')
-      params = { :foo => "bar" }
-      uri.query = URI.encode_www_form(params)
-
-      Net::HTTP.get_response(uri)
-
-      expect(span.get_tag('http.url')).to eq('/sample/path')
-      expect(span.get_tag('out.host')).to eq('example.com')
-    end
   end
 end

--- a/spec/datadog/tracing/contrib/http/request_spec.rb
+++ b/spec/datadog/tracing/contrib/http/request_spec.rb
@@ -569,7 +569,6 @@ RSpec.describe 'net/http requests' do
       Net::HTTP.get_response(uri)
 
       expect(span.get_tag('http.url')).to eq('/sample/path')
-      expect(span.get_tag('out.host')).to eq('example.com')
     end
   end
 end

--- a/spec/datadog/tracing/contrib/httpclient/instrumentation_spec.rb
+++ b/spec/datadog/tracing/contrib/httpclient/instrumentation_spec.rb
@@ -342,7 +342,6 @@ RSpec.describe Datadog::Tracing::Contrib::Httpclient::Instrumentation do
         response
 
         expect(span.get_tag('http.url')).to eq('/sample/path')
-        expect(span.get_tag('out.host')).to eq('localhost')
       end
     end
   end

--- a/spec/datadog/tracing/contrib/httpclient/instrumentation_spec.rb
+++ b/spec/datadog/tracing/contrib/httpclient/instrumentation_spec.rb
@@ -334,5 +334,16 @@ RSpec.describe Datadog::Tracing::Contrib::Httpclient::Instrumentation do
         expect(span.get_tag('out.host')).to eq('localhost')
       end
     end
+
+    context 'when query string in url' do
+      let(:path) { '/sample/path?foo=bar' }
+
+      it 'does not collect query string' do
+        response
+
+        expect(span.get_tag('http.url')).to eq('/sample/path')
+        expect(span.get_tag('out.host')).to eq('localhost')
+      end
+    end
   end
 end

--- a/spec/datadog/tracing/contrib/httprb/instrumentation_spec.rb
+++ b/spec/datadog/tracing/contrib/httprb/instrumentation_spec.rb
@@ -345,7 +345,6 @@ RSpec.describe Datadog::Tracing::Contrib::Httprb::Instrumentation do
         response
 
         expect(span.get_tag('http.url')).to eq('/sample/path')
-        expect(span.get_tag('out.host')).to eq('localhost')
       end
     end
   end

--- a/spec/datadog/tracing/contrib/httprb/instrumentation_spec.rb
+++ b/spec/datadog/tracing/contrib/httprb/instrumentation_spec.rb
@@ -337,5 +337,16 @@ RSpec.describe Datadog::Tracing::Contrib::Httprb::Instrumentation do
         expect(span.get_tag('out.host')).to eq('localhost')
       end
     end
+
+    context 'when query string in url' do
+      let(:path) { '/sample/path?foo=bar' }
+
+      it 'does not collect auth info' do
+        response
+
+        expect(span.get_tag('http.url')).to eq('/sample/path')
+        expect(span.get_tag('out.host')).to eq('localhost')
+      end
+    end
   end
 end

--- a/spec/datadog/tracing/contrib/rest_client/request_patch_spec.rb
+++ b/spec/datadog/tracing/contrib/rest_client/request_patch_spec.rb
@@ -219,7 +219,6 @@ RSpec.describe Datadog::Tracing::Contrib::RestClient::RequestPatch do
         request
 
         expect(span.get_tag('http.url')).to eq('/sample/path')
-        expect(span.get_tag('out.host')).to eq('example.com')
       end
     end
 

--- a/spec/datadog/tracing/contrib/rest_client/request_patch_spec.rb
+++ b/spec/datadog/tracing/contrib/rest_client/request_patch_spec.rb
@@ -208,6 +208,21 @@ RSpec.describe Datadog::Tracing::Contrib::RestClient::RequestPatch do
       end
     end
 
+    context 'when query string in url' do
+      let(:path) { '/sample/path?foo=bar' }
+
+      before do
+        stub_request(:get, /example.com/).to_return(status: status, body: response)
+      end
+
+      it 'does not collect query string' do
+        request
+
+        expect(span.get_tag('http.url')).to eq('/sample/path')
+        expect(span.get_tag('out.host')).to eq('example.com')
+      end
+    end
+
     context 'that returns a custom response object' do
       subject(:request) do
         RestClient::Request.execute(method: :get, url: url) { response }


### PR DESCRIPTION
**What does this PR do?**

Exclude query string for `http.url` tag from `net/http` instrumentation 