### PR TITLE
Test:Fix race condition on spec:suite

### DIFF
--- a/spec/datadog/tracing/contrib/suite/integration_spec.rb
+++ b/spec/datadog/tracing/contrib/suite/integration_spec.rb
@@ -17,12 +17,13 @@ RSpec.describe 'contrib integration testing' do
 
   describe 'dynamic configuration' do
     subject(:update_config) do
-      stub_rc!
-
       @reconfigured = false
       allow(Datadog::Tracing::Remote).to receive(:process_config).and_wrap_original do |m, *args|
         m.call(*args).tap { @reconfigured = true }
       end
+
+      stub_rc!
+
       try_wait_until { @reconfigured }
     end
 


### PR DESCRIPTION
This PR fixes a race condition that happens when Remote Configuration runs before we are able to install the reconfiguration check in `spec/datadog/tracing/contrib/suite/integration_spec.rb`. [Example CI failures](https://app.circleci.com/pipelines/github/DataDog/dd-trace-rb/11429/workflows/f0394859-3aa5-43d0-8d54-da40707e0760/jobs/428683):
```
  1) contrib integration testing dynamic configuration with dynamic configuration data for tracing_sampling_rate changes default sampling rate and sampling decision
     Failure/Error: raise('Wait time exhausted!')
     
     RuntimeError:
       Wait time exhausted!
     # ./spec/support/synchronization_helpers.rb:84:in `try_wait_until'
     # ./spec/datadog/tracing/contrib/suite/integration_spec.rb:26:in `block in update_config'
     # ./spec/datadog/tracing/contrib/suite/integration_spec.rb:226:in `block in <main>'
     # ./spec/datadog/tracing/contrib/suite/integration_spec.rb:15:in `block in <main>'
     # /usr/local/bundle/gems/climate_control-0.2.0/lib/climate_control/modifier.rb:31:in `run_block'
     # /usr/local/bundle/gems/climate_control-0.2.0/lib/climate_control/modifier.rb:13:in `block in process'
     # /usr/local/bundle/gems/climate_control-0.2.0/lib/climate_control/environment.rb:23:in `block in synchronize'
     # /usr/local/bundle/gems/climate_control-0.2.0/lib/climate_control/environment.rb:20:in `synchronize'
     # /usr/local/bundle/gems/climate_control-0.2.0/lib/climate_control/modifier.rb:10:in `process'
     # /usr/local/bundle/gems/climate_control-0.2.0/lib/climate_control.rb:10:in `modify'
     # ./spec/datadog/tracing/contrib/suite/integration_spec.rb:15:in `block in <main>'
     # ./spec/datadog/tracing/contrib/support/tracer_helpers.rb:96:in `block in TracerHelpers'
     # ./spec/spec_helper.rb:233:in `block in <main>'
     # ./spec/spec_helper.rb:118:in `block in <main>'
     # /usr/local/bundle/gems/webmock-3.13.0/lib/webmock/rspec.rb:37:in `block in <main>'
     # /usr/local/bundle/gems/rspec-wait-0.0.9/lib/rspec/wait.rb:46:in `block in <main>'
```

I was able to reproduce the issue by adding a sleep between `stub_rc!` and `allow(Datadog::Tracing::Remote).to receive(:process_config)`.
After this PR, I cannot reproduce the issue anymore.