### PR TITLE
Test:Capture output on fork test failures

### DIFF
--- a/spec/support/synchronization_helpers.rb
+++ b/spec/support/synchronization_helpers.rb
@@ -25,13 +25,24 @@ module SynchronizationHelpers
       # Enforce timeout to ensure test fork doesn't hang the test suite.
       _, status = try_wait_until(seconds: timeout_seconds) { Process.wait2(pid, Process::WNOHANG) }
 
+      stdout = File.read(fork_stdout.path)
+      stderr = File.read(fork_stderr.path)
+
       # Capture forked execution information
-      result = { status: status, stdout: File.read(fork_stdout.path), stderr: File.read(fork_stderr.path) }
+      result = { status: status, stdout: stdout, stderr: stderr }
 
       # Expect fork and assertions to have completed successfully.
       fork_expectations.call(**result)
 
       result
+    rescue => e
+      stdout ||= File.read(fork_stdout.path)
+      stderr ||= File.read(fork_stderr.path)
+
+      puts stdout
+      warn stderr
+
+      raise e
     ensure
       fork_stdout.unlink
       fork_stderr.unlink


### PR DESCRIPTION
For the currently flaky Sidekiq test, https://app.circleci.com/pipelines/github/DataDog/dd-trace-rb/11471/workflows/136d17b9-9561-4937-b59c-66fb2dbadd0c/jobs/430307, the failure information is a rather generic `Wait time exhausted!` error.

I can make Sidekiq tests fail with `Wait time exhausted!` locally, by not having Redis running.

But this doesn't explain the CI failures because only a single Sidekiq test failes, while if Redis wasn't running virtually all of them would fail.
Also, the Redis containers' output in CircleCI's log looks nominal.

## What this PR does

One thing that I notice lacking in the Sidekiq tests is any useful output during a failure.
This happens because tests executed in a forked process, and that fork's STDOUT and STDERR are not directly printed in the RSpec process.

This PR captures the forked process' outputs and prints them out **when there's a test failure**.

This should allow us to debug this Sidekiq issue better when it happens again in CircleCI.

This change should improving the debug of all forked test process, given it affect the shared test helper.