### PR TITLE
Disable profiler on Ruby 3.3 due to incompatibility

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -21,7 +21,8 @@ namespace :spec do
                         ' spec/**/{auto_instrument,opentelemetry}_spec.rb'
     t.rspec_opts = args.to_a.join(' ')
   end
-  if RUBY_ENGINE == 'ruby' && OS.linux? && Gem::Version.new(RUBY_VERSION) >= Gem::Version.new('2.3.0')
+  if RUBY_ENGINE == 'ruby' && OS.linux? && Gem::Version.new(RUBY_VERSION) >= Gem::Version.new('2.3.0') \
+    && Gem::Version.new(RUBY_VERSION) < Gem::Version.new('3.3.0')
     # "bundle exec rake compile" currently only works on MRI Ruby on Linux
     Rake::Task[:main].enhance([:clean])
     Rake::Task[:main].enhance([:compile])

--- a/ext/ddtrace_profiling_native_extension/native_extension_helpers.rb
+++ b/ext/ddtrace_profiling_native_extension/native_extension_helpers.rb
@@ -87,6 +87,7 @@ module Datadog
             on_unknown_os? ||
             on_unsupported_cpu_arch? ||
             on_unsupported_ruby_version? ||
+            on_ruby_3_3? ||
             expected_to_use_mjit_but_mjit_is_disabled? ||
             libdatadog_not_available? ||
             libdatadog_not_usable?
@@ -267,6 +268,20 @@ module Datadog
           )
 
           ruby_version_not_supported if RUBY_VERSION.start_with?('2.1.', '2.2.')
+        end
+
+        private_class_method def self.on_ruby_3_3?
+          incompatible_with_3_3 = explain_issue(
+            'the profiler in the current version of ddtrace does not yet support',
+            'Ruby version 3.3.',
+            '(See https://github.com/datadog/dd-trace-rb/issues/3053 for details).',
+            suggested: [
+              'Try upgrading to the latest ddtrace, as this issue may have been',
+              'fixed by now.',
+            ] + CONTACT_SUPPORT,
+          )
+
+          incompatible_with_3_3 if RUBY_VERSION.start_with?('3.3.')
         end
 
         # On some Rubies, we require the mjit header to be present. If Ruby was installed without MJIT support, we also skip

--- a/integration/apps/rack/spec/integration/basic_spec.rb
+++ b/integration/apps/rack/spec/integration/basic_spec.rb
@@ -11,14 +11,14 @@ RSpec.describe 'Basic scenarios' do
     it { is_expected.to be_a_kind_of(Net::HTTPOK) }
   end
 
-  let(:expected_profiler_available) { RUBY_VERSION >= '2.3' }
+  let(:expected_profiler_available) { RUBY_VERSION >= '2.3' && !RUBY_VERSION.start_with?('3.3.') }
 
   let(:expected_profiler_threads) do
     contain_exactly(
       'Datadog::Profiling::Collectors::IdleSamplingHelper',
       'Datadog::Profiling::Collectors::CpuAndWallTimeWorker',
       'Datadog::Profiling::Scheduler',
-    ) if RUBY_VERSION >= '2.3.'
+    ) if expected_profiler_available
   end
 
   context 'component checks' do

--- a/integration/apps/rack/spec/integration/basic_spec.rb
+++ b/integration/apps/rack/spec/integration/basic_spec.rb
@@ -14,11 +14,11 @@ RSpec.describe 'Basic scenarios' do
   let(:expected_profiler_available) { RUBY_VERSION >= '2.3' && !RUBY_VERSION.start_with?('3.3.') }
 
   let(:expected_profiler_threads) do
-    contain_exactly(
+    expected_profiler_available ? contain_exactly(
       'Datadog::Profiling::Collectors::IdleSamplingHelper',
       'Datadog::Profiling::Collectors::CpuAndWallTimeWorker',
       'Datadog::Profiling::Scheduler',
-    ) if expected_profiler_available
+    ) : eq(nil).or(eq([]))
   end
 
   context 'component checks' do

--- a/integration/apps/rails-five/spec/integration/basic_spec.rb
+++ b/integration/apps/rails-five/spec/integration/basic_spec.rb
@@ -15,11 +15,11 @@ RSpec.describe 'Basic scenarios' do
     let(:json_result) { JSON.parse(subject.body, symbolize_names: true) }
 
     let(:expected_profiler_threads) do
-      expected_profiler_available ? contain_exactly(
+      contain_exactly(
         'Datadog::Profiling::Collectors::IdleSamplingHelper',
         'Datadog::Profiling::Collectors::CpuAndWallTimeWorker',
         'Datadog::Profiling::Scheduler',
-      ) : eq(nil).or(eq([]))
+      )
     end
 
     it { is_expected.to be_a_kind_of(Net::HTTPOK) }

--- a/integration/apps/rails-five/spec/integration/basic_spec.rb
+++ b/integration/apps/rails-five/spec/integration/basic_spec.rb
@@ -15,11 +15,11 @@ RSpec.describe 'Basic scenarios' do
     let(:json_result) { JSON.parse(subject.body, symbolize_names: true) }
 
     let(:expected_profiler_threads) do
-      contain_exactly(
+      expected_profiler_available ? contain_exactly(
         'Datadog::Profiling::Collectors::IdleSamplingHelper',
         'Datadog::Profiling::Collectors::CpuAndWallTimeWorker',
         'Datadog::Profiling::Scheduler',
-      )
+      ) : eq(nil).or(eq([]))
     end
 
     it { is_expected.to be_a_kind_of(Net::HTTPOK) }

--- a/integration/apps/rails-seven/spec/integration/basic_spec.rb
+++ b/integration/apps/rails-seven/spec/integration/basic_spec.rb
@@ -17,11 +17,11 @@ RSpec.describe 'Basic scenarios' do
     let(:expected_profiler_available) { RUBY_VERSION >= '2.3' && !RUBY_VERSION.start_with?('3.3.') }
 
     let(:expected_profiler_threads) do
-      contain_exactly(
+      expected_profiler_available ? contain_exactly(
         'Datadog::Profiling::Collectors::IdleSamplingHelper',
         'Datadog::Profiling::Collectors::CpuAndWallTimeWorker',
         'Datadog::Profiling::Scheduler',
-      ) if expected_profiler_available
+      ) : eq(nil).or(eq([]))
     end
 
     it { is_expected.to be_a_kind_of(Net::HTTPOK) }

--- a/integration/apps/rails-seven/spec/integration/basic_spec.rb
+++ b/integration/apps/rails-seven/spec/integration/basic_spec.rb
@@ -1,3 +1,4 @@
+require 'spec_helper'
 require 'json'
 
 RSpec.describe 'Basic scenarios' do
@@ -13,16 +14,22 @@ RSpec.describe 'Basic scenarios' do
 
     let(:json_result) { JSON.parse(subject.body, symbolize_names: true) }
 
+    let(:expected_profiler_available) { RUBY_VERSION >= '2.3' && !RUBY_VERSION.start_with?('3.3.') }
+
+    let(:expected_profiler_threads) do
+      contain_exactly(
+        'Datadog::Profiling::Collectors::IdleSamplingHelper',
+        'Datadog::Profiling::Collectors::CpuAndWallTimeWorker',
+        'Datadog::Profiling::Scheduler',
+      ) if expected_profiler_available
+    end
+
     it { is_expected.to be_a_kind_of(Net::HTTPOK) }
 
     it 'should be profiling' do
       expect(json_result).to include(
-        profiler_available: true,
-        profiler_threads: contain_exactly(
-          'Datadog::Profiling::Collectors::IdleSamplingHelper',
-          'Datadog::Profiling::Collectors::CpuAndWallTimeWorker',
-          'Datadog::Profiling::Scheduler',
-        ),
+        profiler_available: expected_profiler_available,
+        profiler_threads: expected_profiler_threads,
       )
     end
 

--- a/integration/apps/rails-six/spec/integration/basic_spec.rb
+++ b/integration/apps/rails-six/spec/integration/basic_spec.rb
@@ -17,11 +17,11 @@ RSpec.describe 'Basic scenarios' do
     let(:expected_profiler_available) { RUBY_VERSION >= '2.3' && !RUBY_VERSION.start_with?('3.3.') }
 
     let(:expected_profiler_threads) do
-      contain_exactly(
+      expected_profiler_available ? contain_exactly(
         'Datadog::Profiling::Collectors::IdleSamplingHelper',
         'Datadog::Profiling::Collectors::CpuAndWallTimeWorker',
         'Datadog::Profiling::Scheduler',
-      ) if expected_profiler_available
+      ) : eq(nil).or(eq([]))
     end
 
     it { is_expected.to be_a_kind_of(Net::HTTPOK) }

--- a/integration/apps/rails-six/spec/integration/basic_spec.rb
+++ b/integration/apps/rails-six/spec/integration/basic_spec.rb
@@ -14,19 +14,21 @@ RSpec.describe 'Basic scenarios' do
 
     let(:json_result) { JSON.parse(subject.body, symbolize_names: true) }
 
+    let(:expected_profiler_available) { RUBY_VERSION >= '2.3' && !RUBY_VERSION.start_with?('3.3.') }
+
     let(:expected_profiler_threads) do
       contain_exactly(
         'Datadog::Profiling::Collectors::IdleSamplingHelper',
         'Datadog::Profiling::Collectors::CpuAndWallTimeWorker',
         'Datadog::Profiling::Scheduler',
-      )
+      ) if expected_profiler_available
     end
 
     it { is_expected.to be_a_kind_of(Net::HTTPOK) }
 
     it 'should be profiling' do
       expect(json_result).to include(
-        profiler_available: true,
+        profiler_available: expected_profiler_available,
         profiler_threads: expected_profiler_threads,
       )
     end

--- a/integration/apps/sinatra2-classic/spec/integration/basic_spec.rb
+++ b/integration/apps/sinatra2-classic/spec/integration/basic_spec.rb
@@ -14,11 +14,11 @@ RSpec.describe 'Basic scenarios' do
   let(:expected_profiler_available) { RUBY_VERSION >= '2.3' && !RUBY_VERSION.start_with?('3.3.') }
 
   let(:expected_profiler_threads) do
-    contain_exactly(
+    expected_profiler_available ? contain_exactly(
       'Datadog::Profiling::Collectors::IdleSamplingHelper',
       'Datadog::Profiling::Collectors::CpuAndWallTimeWorker',
       'Datadog::Profiling::Scheduler',
-    ) if expected_profiler_available
+    ) : eq(nil).or(eq([]))
   end
 
   context 'component checks' do

--- a/integration/apps/sinatra2-classic/spec/integration/basic_spec.rb
+++ b/integration/apps/sinatra2-classic/spec/integration/basic_spec.rb
@@ -11,14 +11,14 @@ RSpec.describe 'Basic scenarios' do
     it { is_expected.to be_a_kind_of(Net::HTTPOK) }
   end
 
-  let(:expected_profiler_available) { RUBY_VERSION >= '2.3' }
+  let(:expected_profiler_available) { RUBY_VERSION >= '2.3' && !RUBY_VERSION.start_with?('3.3.') }
 
   let(:expected_profiler_threads) do
     contain_exactly(
       'Datadog::Profiling::Collectors::IdleSamplingHelper',
       'Datadog::Profiling::Collectors::CpuAndWallTimeWorker',
       'Datadog::Profiling::Scheduler',
-    )
+    ) if expected_profiler_available
   end
 
   context 'component checks' do

--- a/integration/apps/sinatra2-modular/spec/integration/basic_spec.rb
+++ b/integration/apps/sinatra2-modular/spec/integration/basic_spec.rb
@@ -14,11 +14,11 @@ RSpec.describe 'Basic scenarios' do
   let(:expected_profiler_available) { RUBY_VERSION >= '2.3' && !RUBY_VERSION.start_with?('3.3.') }
 
   let(:expected_profiler_threads) do
-    contain_exactly(
+    expected_profiler_available ? contain_exactly(
       'Datadog::Profiling::Collectors::IdleSamplingHelper',
       'Datadog::Profiling::Collectors::CpuAndWallTimeWorker',
       'Datadog::Profiling::Scheduler',
-    ) if expected_profiler_available
+    ) : eq(nil).or(eq([]))
   end
 
   context 'component checks' do

--- a/integration/apps/sinatra2-modular/spec/integration/basic_spec.rb
+++ b/integration/apps/sinatra2-modular/spec/integration/basic_spec.rb
@@ -11,14 +11,14 @@ RSpec.describe 'Basic scenarios' do
     it { is_expected.to be_a_kind_of(Net::HTTPOK) }
   end
 
-  let(:expected_profiler_available) { RUBY_VERSION >= '2.3' }
+  let(:expected_profiler_available) { RUBY_VERSION >= '2.3' && !RUBY_VERSION.start_with?('3.3.') }
 
   let(:expected_profiler_threads) do
     contain_exactly(
       'Datadog::Profiling::Collectors::IdleSamplingHelper',
       'Datadog::Profiling::Collectors::CpuAndWallTimeWorker',
       'Datadog::Profiling::Scheduler',
-    )
+    ) if expected_profiler_available
   end
 
   context 'component checks' do

--- a/integration/images/include/build_ddtrace_profiling_native_extension.rb
+++ b/integration/images/include/build_ddtrace_profiling_native_extension.rb
@@ -1,8 +1,8 @@
 #!/usr/bin/env ruby
 
 if local_gem_path = ENV['DD_DEMO_ENV_GEM_LOCAL_DDTRACE']
-  if RUBY_VERSION.start_with?('2.1.', '2.2.')
-    puts "\n== Skipping build of profiler native extension on Ruby 2.1/2.2 =="
+  if RUBY_VERSION.start_with?('2.1.', '2.2.', '3.3.')
+    puts "\n== Skipping build of profiler native extension on Ruby 2.1/2.2 + 3.3 =="
   else
     puts "\n== Building profiler native extension =="
     success =

--- a/spec/datadog/profiling/native_extension_helpers_spec.rb
+++ b/spec/datadog/profiling/native_extension_helpers_spec.rb
@@ -197,6 +197,12 @@ RSpec.describe Datadog::Profiling::NativeExtensionHelpers::Supported do
 
             it { is_expected.to include 'profiler only supports Ruby 2.3 or newer' }
           end
+
+          context 'when on Ruby 3.3' do
+            before { stub_const('RUBY_VERSION', '3.3.0') }
+
+            it { is_expected.to include "does not yet support\nRuby version 3.3." }
+          end
         end
 
         context 'when on amd64 (x86-64) linux' do

--- a/spec/datadog/profiling/spec_helper.rb
+++ b/spec/datadog/profiling/spec_helper.rb
@@ -35,6 +35,9 @@ module ProfileHelpers
     testcase.skip('Profiling is not supported on JRuby') if PlatformHelpers.jruby?
     testcase.skip('Profiling is not supported on TruffleRuby') if PlatformHelpers.truffleruby?
     testcase.skip('Profiling is not supported on Ruby 2.1/2.2') if RUBY_VERSION.start_with?('2.1.', '2.2.')
+    if RUBY_VERSION.start_with?('3.3.')
+      testcase.skip('Profiling is currently not supported on Ruby 3.3 (https://github.com/DataDog/dd-trace-rb/issues/3053)')
+    end
 
     # Profiling is not officially supported on macOS due to missing libdatadog binaries,
     # but it's still useful to allow it to be enabled for development.


### PR DESCRIPTION
**What does this PR do?**:

In #3053 I reported the discovery that the profiler is currently not working on Ruby 3.3-head (reported by a customer that tests with head in CI).

A full fix for #3053 seems like it may take a while, so until it's available, let's gracefully disable the profiler in Ruby 3.3, so that instead of a compilation failure, customers just get a nice message saying we don't support 3.3 right now.

**Motivation**:

Improve experience for current customers testing with 3.3-head and future customers trying to profile 3.3.

**Additional Notes**:

Customers will be shown the following message when trying to profile on Ruby 3.3:

> WARN -- ddtrace: [ddtrace] Profiling was requested but is not supported, profiling disabled: Your ddtrace installation is missing support for the Continuous Profiler because the profiler in the current version of ddtrace does not yet support Ruby version 3.3. (See https://github.com/datadog/dd-trace-rb/issues/3053 for details). Try upgrading to the latest ddtrace, as this issue may have been fixed by now. For help solving this issue, please contact Datadog support at <https://docs.datadoghq.com/help/>. You can also check out the
Continuous Profiler troubleshooting page at <https://dtdg.co/ruby-profiler-troubleshooting>.

**How to test the change?**:

Try to profile ruby-3.3 (any version) and confirm the profiler disables itself gracefully.