### PR TITLE
Ensure Rails running on Spring is considered a development environment

### DIFF
--- a/Steepfile
+++ b/Steepfile
@@ -657,6 +657,7 @@ target :ddtrace do
   library 'jruby'
   library 'gem'
   library 'rails'
+  library 'spring'
   library 'sinatra'
   library 'google-protobuf'
   library 'protobuf-cucumber'

--- a/lib/datadog/core/environment/execution.rb
+++ b/lib/datadog/core/environment/execution.rb
@@ -10,7 +10,7 @@ module Datadog
           # This can be used to make decisions about when to enable
           # background systems like worker threads or telemetry.
           def development?
-            !!(repl? || test?)
+            !!(repl? || test? || rails_development?)
           end
 
           private
@@ -47,6 +47,16 @@ module Datadog
               (defined?(::Minitest::Unit) &&
                 ::Minitest::Unit.class_variable_defined?(:@@installed_at_exit) &&
                 ::Minitest::Unit.class_variable_get(:@@installed_at_exit))
+          end
+
+          # A Rails Spring Ruby process is a bit peculiar: the process is agnostic
+          # whether the application is running as a console or server.
+          # Luckily, the Spring gem *must not* be installed in a production environment so
+          # detecting its presence is enough to deduct if this is a development environment.
+          #
+          # @see https://github.com/rails/spring/blob/48b299348ace2188444489a0c216a6f3e9687281/README.md?plain=1#L204-L207
+          def rails_development?
+            defined?(::Spring)
           end
         end
       end

--- a/sig/datadog/core/environment/execution.rbs
+++ b/sig/datadog/core/environment/execution.rbs
@@ -13,6 +13,8 @@ module Datadog
 
         RSPEC_PROGRAM_NAME: ::String
         def self.minitest?: () -> bool
+
+        def self.rails_development?: -> bool
       end
     end
   end

--- a/spec/datadog/core/environment/execution_spec.rb
+++ b/spec/datadog/core/environment/execution_spec.rb
@@ -82,6 +82,32 @@ RSpec.describe Datadog::Core::Environment::Execution do
           end
         end
       end
+
+      context 'when in a Rails Spring process' do
+        before do
+          unless PlatformHelpers.ci? || Gem.loaded_specs['spring']
+            skip('spring gem not present. In CI, this test is never skipped.')
+          end
+        end
+
+        it 'returns true' do
+          expect_in_fork do
+            require 'bundler/inline'
+
+            gemfile do
+              source 'https://rubygems.org'
+              gem 'spring', '>= 2.0.2'
+            end
+
+            # Load the `bin/spring` file, just like a real Spring application would.
+            # https://github.com/rails/spring/blob/0a80019e1abdedb3291afb13e8cfb72f3992da90/bin/spring
+            stub_const('ARGV', ['help']) # Let's ask for a simple Spring command, so that it returns quickly.
+            load Gem.bin_path('spring', 'spring')
+
+            is_expected.to eq(true)
+          end
+        end
+      end
     end
   end
 end

--- a/spec/datadog/core/environment/execution_spec.rb
+++ b/spec/datadog/core/environment/execution_spec.rb
@@ -90,22 +90,27 @@ RSpec.describe Datadog::Core::Environment::Execution do
           end
         end
 
-        it 'returns true' do
-          expect_in_fork do
+        let(:script) do
+          <<-RUBY
             require 'bundler/inline'
 
-            gemfile do
+            gemfile(true) do
               source 'https://rubygems.org'
               gem 'spring', '>= 2.0.2'
             end
 
             # Load the `bin/spring` file, just like a real Spring application would.
             # https://github.com/rails/spring/blob/0a80019e1abdedb3291afb13e8cfb72f3992da90/bin/spring
-            stub_const('ARGV', ['help']) # Let's ask for a simple Spring command, so that it returns quickly.
+            ARGV = ['help'] # Let's ask for a simple Spring command, so that it returns quickly.
             load Gem.bin_path('spring', 'spring')
 
-            is_expected.to eq(true)
-          end
+            #{repl_script}
+          RUBY
+        end
+
+        it 'returns true' do
+          _, err, = Open3.capture3('ruby', stdin_data: script)
+          expect(err).to end_with('true')
         end
       end
     end

--- a/spec/support/synchronization_helpers.rb
+++ b/spec/support/synchronization_helpers.rb
@@ -44,6 +44,8 @@ module SynchronizationHelpers
 
       raise e
     ensure
+      Process.kill('KILL', pid) rescue nil # Prevent zombie processes on failure
+
       fork_stdout.unlink
       fork_stderr.unlink
     end

--- a/vendor/rbs/spring/0/spring.rbs
+++ b/vendor/rbs/spring/0/spring.rbs
@@ -1,0 +1,2 @@
+module Spring
+end


### PR DESCRIPTION
Helps address #3050 

This PR ensures that applications preloaded with [Spring](https://github.com/rails/spring) are considered as a "development environment" application, and thus `ddtrace` skips background worker initialization on Spring-enabled environments.

Spring [**must not** be installed in production environments](https://github.com/rails/spring#deployment), giving us confidence that detecting Spring loading won't cause false positives for development environment detection.