### PR TITLE
Detect WebMock to disable telemetry and remote configuration 

### DIFF
--- a/Steepfile
+++ b/Steepfile
@@ -672,6 +672,7 @@ target :ddtrace do
   library 'delayed_job'
   library 'opentelemetry-api'
   library 'passenger'
+  library 'webmock'
 
   # TODO: gem 'libddwaf'
   library 'libddwaf'

--- a/lib/datadog/core/environment/execution.rb
+++ b/lib/datadog/core/environment/execution.rb
@@ -23,7 +23,7 @@ module Datadog
           #   2. Checking if `Net::HTTP` is referring to the original one
           #   => ::Net::HTTP.equal?(::WebMock::HttpLibAdapters::NetHttpAdapter::OriginalNetHTTP)
           def webmock_enabled?
-            defined?(::WebMock) &&
+            defined?(::WebMock::HttpLibAdapters::NetHttpAdapter) &&
               defined?(::Net::HTTP) &&
               ::Net::HTTP.equal?(::WebMock::HttpLibAdapters::NetHttpAdapter.instance_variable_get(:@webMockNetHTTP))
           end

--- a/lib/datadog/core/environment/execution.rb
+++ b/lib/datadog/core/environment/execution.rb
@@ -10,7 +10,7 @@ module Datadog
           # This can be used to make decisions about when to enable
           # background systems like worker threads or telemetry.
           def development?
-            !!(repl? || test? || rails_development? || webmock_enabled?)
+            !!(webmock_enabled? || repl? || test? || rails_development?)
           end
 
           # WebMock stores the reference to `Net::HTTP` with constant `OriginalNetHTTP`, and when WebMock enables,

--- a/lib/datadog/core/environment/execution.rb
+++ b/lib/datadog/core/environment/execution.rb
@@ -10,7 +10,22 @@ module Datadog
           # This can be used to make decisions about when to enable
           # background systems like worker threads or telemetry.
           def development?
-            !!(repl? || test? || rails_development?)
+            !!(repl? || test? || rails_development? || webmock_enabled?)
+          end
+
+          # WebMock stores the reference to `Net::HTTP` with constant `OriginalNetHTTP`, and when WebMock enables,
+          # the adapter swaps `Net::HTTP` reference to its mock object, @webMockNetHTTP.
+          #
+          # Hence, we can detect by
+          #   1. Checking if `Net::HTTP` is referring to mock object
+          #   => ::Net::HTTP.equal?(::WebMock::HttpLibAdapters::NetHttpAdapter.instance_variable_get(:@webMockNetHTTP))
+          #
+          #   2. Checking if `Net::HTTP` is referring to the original one
+          #   => ::Net::HTTP.equal?(::WebMock::HttpLibAdapters::NetHttpAdapter::OriginalNetHTTP)
+          def webmock_enabled?
+            defined?(::WebMock) &&
+              defined?(::Net::HTTP) &&
+              ::Net::HTTP.equal?(::WebMock::HttpLibAdapters::NetHttpAdapter.instance_variable_get(:@webMockNetHTTP))
           end
 
           private

--- a/sig/datadog/core/environment/execution.rbs
+++ b/sig/datadog/core/environment/execution.rbs
@@ -3,6 +3,7 @@ module Datadog
     module Environment
       module Execution
         def self.development?: () -> bool
+        def self.webmock_enabled?: () -> bool
 
         private
         def self.test?: () -> bool

--- a/spec/datadog/core/environment/execution_spec.rb
+++ b/spec/datadog/core/environment/execution_spec.rb
@@ -176,9 +176,9 @@ RSpec.describe Datadog::Core::Environment::Execution do
     end
 
     [1, 2, 3].each do |version|
-      context "when given WebMock version #{version}.x" do
+      context "when given WebMock version #{version}.x", skip: Gem::Version.new(Bundler::VERSION) < Gem::Version.new('2') do
         it do
-          out, _err = Bundler.with_clean_env do
+          out, err = Bundler.with_clean_env do
             Open3.capture3('ruby', stdin_data: <<-RUBY
               require 'bundler/inline'
 
@@ -202,6 +202,7 @@ RSpec.describe Datadog::Core::Environment::Execution do
             )
           end
 
+          expect(err).to be_empty
           expect(out).to end_with('true')
         end
       end

--- a/spec/datadog/core/environment/execution_spec.rb
+++ b/spec/datadog/core/environment/execution_spec.rb
@@ -175,36 +175,31 @@ RSpec.describe Datadog::Core::Environment::Execution do
       end
     end
 
-    [1, 2, 3].each do |version|
-      context "when given WebMock version #{version}.x", skip: Gem::Version.new(Bundler::VERSION) < Gem::Version.new('2') do
-        it do
-          out, err = Bundler.with_clean_env do
-            Open3.capture3('ruby', stdin_data: <<-RUBY
-              require 'bundler/inline'
+    context 'when given WebMock', skip: Gem::Version.new(Bundler::VERSION) < Gem::Version.new('2') do
+      it do
+        out, err = Bundler.with_clean_env do
+          Open3.capture3('ruby', stdin_data: <<-RUBY
+            require 'bundler/inline'
 
-              gemfile(true, quiet: true) do
-                source 'https://rubygems.org'
-                gem 'webmock', "~> #{version}"
-              end
+            gemfile(true, quiet: true) do
+              source 'https://rubygems.org'
+              gem 'webmock'
+            end
 
-              require 'webmock'
-              WebMock.enable!
+            require 'webmock'
+            WebMock.enable!
 
-              lib = File.expand_path('lib', __dir__)
-              $LOAD_PATH.unshift(lib) unless $LOAD_PATH.include?(lib)
-              require 'datadog/core/environment/execution'
+            lib = File.expand_path('lib', __dir__)
+            $LOAD_PATH.unshift(lib) unless $LOAD_PATH.include?(lib)
+            require 'datadog/core/environment/execution'
 
-              STDOUT.print "WebMock::VERSION:"
-              STDOUT.print WebMock::VERSION
-              STDOUT.print "=>"
-              STDOUT.print Datadog::Core::Environment::Execution.webmock_enabled?
-            RUBY
-            )
-          end
-
-          expect(err).to be_empty
-          expect(out).to end_with('true')
+            STDOUT.print Datadog::Core::Environment::Execution.webmock_enabled?
+          RUBY
+          )
         end
+
+        expect(err).to be_empty
+        expect(out).to eq('true')
       end
     end
   end

--- a/spec/datadog/core/environment/execution_spec.rb
+++ b/spec/datadog/core/environment/execution_spec.rb
@@ -133,9 +133,9 @@ RSpec.describe Datadog::Core::Environment::Execution do
   end
 
   describe '.webmock_enabled?' do
-    context 'when missing constant `WebMock`' do
+    context 'when missing constant `WebMock::HttpLibAdapters::NetHttpAdapter`' do
       it do
-        hide_const('::WebMock')
+        hide_const('::WebMock::HttpLibAdapters::NetHttpAdapter')
         expect(described_class).not_to be_webmock_enabled
       end
     end
@@ -147,7 +147,7 @@ RSpec.describe Datadog::Core::Environment::Execution do
       end
     end
 
-    context 'when `WebMock` and `Net::HTTP` constants both exist' do
+    context 'when `WebMock::HttpLibAdapters::NetHttpAdapter` and `Net::HTTP` constants both exist' do
       before do
         WebMock.enable!
       end

--- a/spec/datadog/core/environment/execution_spec.rb
+++ b/spec/datadog/core/environment/execution_spec.rb
@@ -5,6 +5,12 @@ require 'spec_helper'
 require 'datadog/core/environment/execution'
 
 RSpec.describe Datadog::Core::Environment::Execution do
+  around do |example|
+    WebMock.enable!
+    example.run
+    WebMock.disable!
+  end
+
   describe '.development?' do
     subject(:development?) { described_class.development? }
 
@@ -148,11 +154,9 @@ RSpec.describe Datadog::Core::Environment::Execution do
     end
 
     context 'when `WebMock::HttpLibAdapters::NetHttpAdapter` and `Net::HTTP` constants both exist' do
-      before do
-        WebMock.enable!
-      end
-
       it do
+        WebMock.enable!
+
         expect(described_class).to be_webmock_enabled
       end
 

--- a/vendor/rbs/webmock/0/webmock.rbs
+++ b/vendor/rbs/webmock/0/webmock.rbs
@@ -1,0 +1,9 @@
+module WebMock
+  module HttpLibAdapters
+    class NetHttpAdapter
+      def self.enable!: -> void
+
+      def self.disable!: -> void
+    end
+  end
+end


### PR DESCRIPTION
**What does this PR do?**

It has been reported by the community that `ddtrace` is breaking test suite with `WebMock`, since some components are sending http request in the background with `net/http` .

Hence this PR make an effort the detect `WebMock` to provide a better default value for `ddtrace` telemetry and remote configuration. 

`WebMock` does not offer an public API such as `WebMock.enabled?` to check the status. When `WebMock.enable!`, it iterates through http adapters to enable them. The net/http  adapter implements enablement by swapping the reference for `Net::HTTP` 