### PR TITLE
Update the pull request template with a security-related section

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -8,10 +8,10 @@ run the test suite, write new integrations, and more.
 **What does this PR do?**
 <!-- A brief description of the change being made with this pull request. -->
 
-**Motivation**:
+**Motivation:**
 <!-- What inspired you to submit this pull request? -->
 
-**Additional Notes**:
+**Additional Notes:**
 <!-- Anything else we should know when reviewing? -->
 
 **How to test the change?**
@@ -22,7 +22,7 @@ If this change cannot be feasibly tested, please explain why,
 unless the change does not modify code (e.g. only modifies docs, comments).
 -->
 
-**For Datadog employees**:
+**For Datadog employees:**
 - [ ] If this PR touches code that signs or publishes builds or packages, or handles
 credentials of any kind, I've requested a review from `@DataDog/security-design-and-guidance`.
 - [ ] This PR doesn't touch any of that.

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -5,7 +5,7 @@ for guidance on how to set up your development environment,
 run the test suite, write new integrations, and more.
 -->
 
-**What does this PR do?**:
+**What does this PR do?**
 <!-- A brief description of the change being made with this pull request. -->
 
 **Motivation**:
@@ -14,7 +14,7 @@ run the test suite, write new integrations, and more.
 **Additional Notes**:
 <!-- Anything else we should know when reviewing? -->
 
-**How to test the change?**:
+**How to test the change?**
 <!--
 Describe here how the change can be validated.
 You are strongly encouraged to provide automated tests for this PR (unit or integration).

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -5,19 +5,26 @@ for guidance on how to set up your development environment,
 run the test suite, write new integrations, and more.
 -->
 
-**What does this PR do?**
+**What does this PR do?**:
 <!-- A brief description of the change being made with this pull request. -->
 
-**Motivation**
+**Motivation**:
 <!-- What inspired you to submit this pull request? -->
 
-**Additional Notes**
+**Additional Notes**:
 <!-- Anything else we should know when reviewing? -->
 
-**How to test the change?**
+**How to test the change?**:
 <!--
 Describe here how the change can be validated.
 You are strongly encouraged to provide automated tests for this PR (unit or integration).
 If this change cannot be feasibly tested, please explain why,
 unless the change does not modify code (e.g. only modifies docs, comments).
 -->
+
+**For Datadog employees**:
+- [ ] If this PR touches code that signs or publishes builds or packages, or handles
+credentials of any kind, I've requested a review from `@DataDog/security-design-and-guidance`.
+- [ ] This PR doesn't touch any of that.
+
+Unsure? Have a question? Request a review!


### PR DESCRIPTION
**What does this PR do?**:

This PR updates the pull request template with a security-related question, so we make sure folks remember to loop in the correct team if the PR can have an impact on "code that signs or publishes builds or packages, or handles credentials of any kind".

**Motivation**:

We're moving to standardize this on all Datadog libraries.

For Datadog employees, you can find the discussion on the internal "RFC: Security review for ci/cd changes in public repos" RFC.

**Additional Notes**:

N/A

**How to test the change?**:

Once this is merged, open a new PR, validate that the new items show up.

