### PR TITLE
Fix ASM setting for automated user events.

### DIFF
--- a/lib/datadog/appsec/configuration/settings.rb
+++ b/lib/datadog/appsec/configuration/settings.rb
@@ -15,6 +15,10 @@ module Datadog
           'safe',
           'extended'
         ].freeze
+        APPSEC_VALID_TRACK_USER_EVENTS_ENABLED_VALUES = [
+          '1',
+          'true'
+        ].concat(APPSEC_VALID_TRACK_USER_EVENTS_MODE).freeze
 
         def self.extended(base)
           base = base.singleton_class unless base.is_a?(Class)
@@ -100,7 +104,7 @@ module Datadog
                     if env_value == 'disabled'
                       false
                     else
-                      ['1', 'true'].include?(env_value.strip.downcase)
+                      APPSEC_VALID_TRACK_USER_EVENTS_ENABLED_VALUES.include?(env_value.strip.downcase)
                     end
                   end
                 end
@@ -112,6 +116,8 @@ module Datadog
                   o.setter do |v|
                     if APPSEC_VALID_TRACK_USER_EVENTS_MODE.include?(v)
                       v
+                    elsif v == 'disabled'
+                      'safe'
                     else
                       Datadog.logger.warn(
                         'The appsec.track_user_events.mode value provided is not supported.' \

--- a/sig/datadog/appsec/configuration/settings.rbs
+++ b/sig/datadog/appsec/configuration/settings.rbs
@@ -12,6 +12,7 @@ module Datadog
         DEFAULT_OBFUSCATOR_KEY_REGEX: ::String
         DEFAULT_OBFUSCATOR_VALUE_REGEX: ::String
         APPSEC_VALID_TRACK_USER_EVENTS_MODE: ::Array[String]
+        APPSEC_VALID_TRACK_USER_EVENTS_ENABLED_VALUES: ::Array[String]
 
         def self.extended: (untyped base) -> untyped
 

--- a/spec/datadog/appsec/configuration/settings_spec.rb
+++ b/spec/datadog/appsec/configuration/settings_spec.rb
@@ -475,6 +475,14 @@ RSpec.describe Datadog::AppSec::Configuration::Settings do
 
               it { is_expected.to eq(false) }
             end
+
+            context 'using the mode values: extended | safe' do
+              ['extended', 'safe'].each do |value|
+                let(:track_user_events_enabled) { value }
+
+                it { is_expected.to eq(true) }
+              end
+            end
           end
         end
       end


### PR DESCRIPTION
<!--
Check out the
https://github.com/DataDog/dd-trace-rb/blob/master/docs/DevelopmentGuide.md
for guidance on how to set up your development environment,
run the test suite, write new integrations, and more.
-->

**What does this PR do?**
<!-- A brief description of the change being made with this pull request. -->

The automated user events feature has two settings: `enable` and `mode` both can be configured via code or using a single ENV var `DD_APPSEC_AUTOMATED_USER_EVENTS_TRACKING` 

The corner case found is that setting `DD_APPSEC_AUTOMATED_USER_EVENTS_TRACKING=extended|safe` is disabling automated user events. 

This PR ensures the `enabled` setting supports `extended` and `safe` as valid values.

**Motivation**
<!-- What inspired you to submit this pull request? -->

**Additional Notes**
<!-- Anything else we should know when reviewing? -->

**How to test the change?**
<!--
Describe here how the change can be validated.
You are strongly encouraged to provide automated tests for this PR (unit or integration).
If this change cannot be feasibly tested, please explain why,
unless the change does not modify code (e.g. only modifies docs, comments).
-->
