### PR TITLE
[PROF-7307] Include 'ruby vm type' in profiler allocation samples

### DIFF
--- a/ext/ddtrace_profiling_native_extension/collectors_thread_context.h
+++ b/ext/ddtrace_profiling_native_extension/collectors_thread_context.h
@@ -7,7 +7,7 @@ void thread_context_collector_sample(
   long current_monotonic_wall_time_ns,
   VALUE profiler_overhead_stack_thread
 );
-void thread_context_collector_sample_allocation(VALUE self_instance, unsigned int sample_weight);
+void thread_context_collector_sample_allocation(VALUE self_instance, unsigned int sample_weight, VALUE new_object);
 VALUE thread_context_collector_sample_after_gc(VALUE self_instance);
 void thread_context_collector_on_gc_start(VALUE self_instance);
 void thread_context_collector_on_gc_finish(VALUE self_instance);

--- a/ext/ddtrace_profiling_native_extension/extconf.rb
+++ b/ext/ddtrace_profiling_native_extension/extconf.rb
@@ -155,6 +155,9 @@ $defs << '-DUSE_BACKPORTED_RB_PROFILE_FRAME_METHOD_NAME' if RUBY_VERSION < '3'
 # On older Rubies, there are no Ractors
 $defs << '-DNO_RACTORS' if RUBY_VERSION < '3'
 
+# On older Rubies, objects would not move
+$defs << '-DNO_T_MOVED' if RUBY_VERSION < '2.7'
+
 # On older Rubies, rb_global_vm_lock_struct did not include the owner field
 $defs << '-DNO_GVL_OWNER' if RUBY_VERSION < '2.6'
 

--- a/ext/ddtrace_profiling_native_extension/libdatadog_helpers.c
+++ b/ext/ddtrace_profiling_native_extension/libdatadog_helpers.c
@@ -3,38 +3,7 @@
 #include <ruby.h>
 
 const char *ruby_value_type_to_string(enum ruby_value_type type) {
-  switch (type) {
-    case(RUBY_T_NONE    ): return "T_NONE";
-    case(RUBY_T_OBJECT  ): return "T_OBJECT";
-    case(RUBY_T_CLASS   ): return "T_CLASS";
-    case(RUBY_T_MODULE  ): return "T_MODULE";
-    case(RUBY_T_FLOAT   ): return "T_FLOAT";
-    case(RUBY_T_STRING  ): return "T_STRING";
-    case(RUBY_T_REGEXP  ): return "T_REGEXP";
-    case(RUBY_T_ARRAY   ): return "T_ARRAY";
-    case(RUBY_T_HASH    ): return "T_HASH";
-    case(RUBY_T_STRUCT  ): return "T_STRUCT";
-    case(RUBY_T_BIGNUM  ): return "T_BIGNUM";
-    case(RUBY_T_FILE    ): return "T_FILE";
-    case(RUBY_T_DATA    ): return "T_DATA";
-    case(RUBY_T_MATCH   ): return "T_MATCH";
-    case(RUBY_T_COMPLEX ): return "T_COMPLEX";
-    case(RUBY_T_RATIONAL): return "T_RATIONAL";
-    case(RUBY_T_NIL     ): return "T_NIL";
-    case(RUBY_T_TRUE    ): return "T_TRUE";
-    case(RUBY_T_FALSE   ): return "T_FALSE";
-    case(RUBY_T_SYMBOL  ): return "T_SYMBOL";
-    case(RUBY_T_FIXNUM  ): return "T_FIXNUM";
-    case(RUBY_T_UNDEF   ): return "T_UNDEF";
-    case(RUBY_T_IMEMO   ): return "T_IMEMO";
-    case(RUBY_T_NODE    ): return "T_NODE";
-    case(RUBY_T_ICLASS  ): return "T_ICLASS";
-    case(RUBY_T_ZOMBIE  ): return "T_ZOMBIE";
-    #ifdef RUBY_T_MOVED // Introduced in Ruby 2.7
-    case(RUBY_T_MOVED   ): return "T_MOVED";
-    #endif
-                  default: return "T_UNKNOWN_OR_MISSING_RUBY_VALUE_TYPE_ENTRY";
-  }
+  return ruby_value_type_to_char_slice(type).ptr;
 }
 
 ddog_CharSlice ruby_value_type_to_char_slice(enum ruby_value_type type) {

--- a/ext/ddtrace_profiling_native_extension/libdatadog_helpers.c
+++ b/ext/ddtrace_profiling_native_extension/libdatadog_helpers.c
@@ -37,6 +37,6 @@ ddog_CharSlice ruby_value_type_to_char_slice(enum ruby_value_type type) {
     #ifdef RUBY_T_MOVED // Introduced in Ruby 2.7
     case(RUBY_T_MOVED   ): return DDOG_CHARSLICE_C("T_MOVED");
     #endif
-                  default: return DDOG_CHARSLICE_C("T_UNKNOWN_OR_MISSING_RUBY_VALUE_TYPE_ENTRY");
+                  default: return DDOG_CHARSLICE_C("BUG: Unknown value for ruby_value_type");
   }
 }

--- a/ext/ddtrace_profiling_native_extension/libdatadog_helpers.c
+++ b/ext/ddtrace_profiling_native_extension/libdatadog_helpers.c
@@ -34,7 +34,7 @@ ddog_CharSlice ruby_value_type_to_char_slice(enum ruby_value_type type) {
     case(RUBY_T_NODE    ): return DDOG_CHARSLICE_C("T_NODE");
     case(RUBY_T_ICLASS  ): return DDOG_CHARSLICE_C("T_ICLASS");
     case(RUBY_T_ZOMBIE  ): return DDOG_CHARSLICE_C("T_ZOMBIE");
-    #ifdef RUBY_T_MOVED // Introduced in Ruby 2.7
+    #ifndef NO_T_MOVED
     case(RUBY_T_MOVED   ): return DDOG_CHARSLICE_C("T_MOVED");
     #endif
                   default: return DDOG_CHARSLICE_C("BUG: Unknown value for ruby_value_type");

--- a/ext/ddtrace_profiling_native_extension/libdatadog_helpers.c
+++ b/ext/ddtrace_profiling_native_extension/libdatadog_helpers.c
@@ -1,0 +1,73 @@
+#include "libdatadog_helpers.h"
+
+#include <ruby.h>
+
+const char *ruby_value_type_to_string(enum ruby_value_type type) {
+  switch (type) {
+    case(RUBY_T_NONE    ): return "T_NONE";
+    case(RUBY_T_OBJECT  ): return "T_OBJECT";
+    case(RUBY_T_CLASS   ): return "T_CLASS";
+    case(RUBY_T_MODULE  ): return "T_MODULE";
+    case(RUBY_T_FLOAT   ): return "T_FLOAT";
+    case(RUBY_T_STRING  ): return "T_STRING";
+    case(RUBY_T_REGEXP  ): return "T_REGEXP";
+    case(RUBY_T_ARRAY   ): return "T_ARRAY";
+    case(RUBY_T_HASH    ): return "T_HASH";
+    case(RUBY_T_STRUCT  ): return "T_STRUCT";
+    case(RUBY_T_BIGNUM  ): return "T_BIGNUM";
+    case(RUBY_T_FILE    ): return "T_FILE";
+    case(RUBY_T_DATA    ): return "T_DATA";
+    case(RUBY_T_MATCH   ): return "T_MATCH";
+    case(RUBY_T_COMPLEX ): return "T_COMPLEX";
+    case(RUBY_T_RATIONAL): return "T_RATIONAL";
+    case(RUBY_T_NIL     ): return "T_NIL";
+    case(RUBY_T_TRUE    ): return "T_TRUE";
+    case(RUBY_T_FALSE   ): return "T_FALSE";
+    case(RUBY_T_SYMBOL  ): return "T_SYMBOL";
+    case(RUBY_T_FIXNUM  ): return "T_FIXNUM";
+    case(RUBY_T_UNDEF   ): return "T_UNDEF";
+    case(RUBY_T_IMEMO   ): return "T_IMEMO";
+    case(RUBY_T_NODE    ): return "T_NODE";
+    case(RUBY_T_ICLASS  ): return "T_ICLASS";
+    case(RUBY_T_ZOMBIE  ): return "T_ZOMBIE";
+    #ifdef RUBY_T_MOVED // Introduced in Ruby 2.7
+    case(RUBY_T_MOVED   ): return "T_MOVED";
+    #endif
+                  default: return "T_UNKNOWN_OR_MISSING_RUBY_VALUE_TYPE_ENTRY";
+  }
+}
+
+ddog_CharSlice ruby_value_type_to_char_slice(enum ruby_value_type type) {
+  switch (type) {
+    case(RUBY_T_NONE    ): return DDOG_CHARSLICE_C("T_NONE");
+    case(RUBY_T_OBJECT  ): return DDOG_CHARSLICE_C("T_OBJECT");
+    case(RUBY_T_CLASS   ): return DDOG_CHARSLICE_C("T_CLASS");
+    case(RUBY_T_MODULE  ): return DDOG_CHARSLICE_C("T_MODULE");
+    case(RUBY_T_FLOAT   ): return DDOG_CHARSLICE_C("T_FLOAT");
+    case(RUBY_T_STRING  ): return DDOG_CHARSLICE_C("T_STRING");
+    case(RUBY_T_REGEXP  ): return DDOG_CHARSLICE_C("T_REGEXP");
+    case(RUBY_T_ARRAY   ): return DDOG_CHARSLICE_C("T_ARRAY");
+    case(RUBY_T_HASH    ): return DDOG_CHARSLICE_C("T_HASH");
+    case(RUBY_T_STRUCT  ): return DDOG_CHARSLICE_C("T_STRUCT");
+    case(RUBY_T_BIGNUM  ): return DDOG_CHARSLICE_C("T_BIGNUM");
+    case(RUBY_T_FILE    ): return DDOG_CHARSLICE_C("T_FILE");
+    case(RUBY_T_DATA    ): return DDOG_CHARSLICE_C("T_DATA");
+    case(RUBY_T_MATCH   ): return DDOG_CHARSLICE_C("T_MATCH");
+    case(RUBY_T_COMPLEX ): return DDOG_CHARSLICE_C("T_COMPLEX");
+    case(RUBY_T_RATIONAL): return DDOG_CHARSLICE_C("T_RATIONAL");
+    case(RUBY_T_NIL     ): return DDOG_CHARSLICE_C("T_NIL");
+    case(RUBY_T_TRUE    ): return DDOG_CHARSLICE_C("T_TRUE");
+    case(RUBY_T_FALSE   ): return DDOG_CHARSLICE_C("T_FALSE");
+    case(RUBY_T_SYMBOL  ): return DDOG_CHARSLICE_C("T_SYMBOL");
+    case(RUBY_T_FIXNUM  ): return DDOG_CHARSLICE_C("T_FIXNUM");
+    case(RUBY_T_UNDEF   ): return DDOG_CHARSLICE_C("T_UNDEF");
+    case(RUBY_T_IMEMO   ): return DDOG_CHARSLICE_C("T_IMEMO");
+    case(RUBY_T_NODE    ): return DDOG_CHARSLICE_C("T_NODE");
+    case(RUBY_T_ICLASS  ): return DDOG_CHARSLICE_C("T_ICLASS");
+    case(RUBY_T_ZOMBIE  ): return DDOG_CHARSLICE_C("T_ZOMBIE");
+    #ifdef RUBY_T_MOVED // Introduced in Ruby 2.7
+    case(RUBY_T_MOVED   ): return DDOG_CHARSLICE_C("T_MOVED");
+    #endif
+                  default: return DDOG_CHARSLICE_C("T_UNKNOWN_OR_MISSING_RUBY_VALUE_TYPE_ENTRY");
+  }
+}

--- a/ext/ddtrace_profiling_native_extension/libdatadog_helpers.h
+++ b/ext/ddtrace_profiling_native_extension/libdatadog_helpers.h
@@ -23,3 +23,9 @@ inline static VALUE get_error_details_and_drop(ddog_Error *error) {
   ddog_Error_drop(error);
   return result;
 }
+
+// Used for pretty printing this Ruby enum. Returns "T_UNKNOWN_OR_MISSING_RUBY_VALUE_TYPE_ENTRY" for unknown elements.
+// In practice, there's a few types that the profiler will probably never encounter, but I've added all entries of
+// ruby_value_type that Ruby uses so that we can also use this for debugging.
+const char *ruby_value_type_to_string(enum ruby_value_type type);
+ddog_CharSlice ruby_value_type_to_char_slice(enum ruby_value_type type);


### PR DESCRIPTION
**What does this PR do?**:

This PR builds extends the existing support for the `ThreadContext` collector to sample allocations to also record the "ruby vm type" of sampled objects.

This "ruby vm type" is what Ruby internally represents in its `enum ruby_value_type`, see
https://github.com/ruby/ruby/blob/84a12d657848dfb54f8cc556d344f017a793e95a/include/ruby/internal/value_type.h#L112

**Motivation**:

I'm working on tagging stacks of sampled objects with both the object class, as well as the ruby vm type.

I'm not yet sure how we may expose the ruby vm type in the UX, but having it is useful for development and debugging, and I can imagine it being useful in advanced use cases (e.g. a customer downloading a pprof to look at this data).

As libdatadog interns labels (https://github.com/DataDog/libdatadog/pull/205), the cost of tracking this data is quite low.

**Additional Notes**:

Allocation profiling is still not something that can be enabled; e.g. right now we can only exercise it directly by calling the `ThreadContext` collector.

**How to test the change?**:

Change includes test coverage.