### PR TITLE
Fix bug where Tracing::AgentSettingsResolver wasn't being passed param logger

### DIFF
--- a/lib/datadog/tracing/component.rb
+++ b/lib/datadog/tracing/component.rb
@@ -29,7 +29,7 @@ module Datadog
         tracer = settings.tracing.instance
         return tracer unless tracer.nil?
 
-        agent_settings = Configuration::AgentSettingsResolver.call(settings, logger: @logger)
+        agent_settings = Configuration::AgentSettingsResolver.call(settings, logger: logger)
 
         # Apply test mode settings if test mode is activated
         if settings.tracing.test_mode.enabled

--- a/sig/datadog/profiling/component.rbs
+++ b/sig/datadog/profiling/component.rbs
@@ -28,8 +28,6 @@ module Datadog
 
       def self.enable_gc_profiling?: (untyped settings) -> bool
 
-      def self.print_new_profiler_warnings: () -> void
-
       def self.enable_new_profiler?: (untyped settings) -> bool
 
       def self.no_signals_workaround_enabled?: (untyped settings) -> bool

--- a/sig/datadog/profiling/component.rbs
+++ b/sig/datadog/profiling/component.rbs
@@ -1,23 +1,42 @@
 module Datadog
   module Profiling
     module Component
-      def self.build_profiler_component: (settings: untyped, logger: untyped, optional_tracer: untyped) -> (nil | untyped)
+      def self.build_profiler_component: (
+        settings: untyped,
+        logger: untyped,
+        optional_tracer: Datadog::Tracing::Tracer?,
+      ) -> Datadog::Profiling::Profiler?
 
-      def self.build_profiler_old_recorder: (untyped settings) -> untyped
+      def self.build_profiler_old_recorder: (untyped settings) -> Datadog::Profiling::OldRecorder
 
-      def self.build_profiler_exporter: (untyped settings, untyped recorder, internal_metadata: untyped) -> untyped
+      def self.build_profiler_exporter: (
+        untyped settings,
+        (Datadog::Profiling::StackRecorder | Datadog::Profiling::OldRecorder) recorder,
+        internal_metadata: ::Hash[::Symbol, ::String | bool | ::Numeric],
+      ) -> Datadog::Profiling::Exporter
 
-      def self.build_profiler_oldstack_collector: (untyped settings, untyped old_recorder, untyped tracer) -> untyped
+      def self.build_profiler_oldstack_collector: (
+        untyped settings,
+        Datadog::Profiling::OldRecorder old_recorder,
+        Datadog::Tracing::Tracer? tracer,
+      ) -> Datadog::Profiling::Collectors::OldStack
 
-      def self.build_profiler_transport: (untyped settings, untyped agent_settings) -> untyped
+      def self.build_profiler_transport: (
+        untyped settings,
+        Datadog::Core::Configuration::AgentSettingsResolver::AgentSettings agent_settings
+      ) -> untyped
 
-      def self.enable_gc_profiling?: (untyped settings) -> (true | false)
+      def self.enable_gc_profiling?: (untyped settings) -> bool
 
-      def self.enable_new_profiler?: (untyped settings) -> (false | true)
+      def self.print_new_profiler_warnings: () -> void
 
-      def self.no_signals_workaround_enabled?: (untyped settings) -> (false | true)
-      def self.incompatible_libmysqlclient_version?: (untyped settings) -> (true | untyped)
-      def self.load_pprof_support: () -> untyped
+      def self.enable_new_profiler?: (untyped settings) -> bool
+
+      def self.no_signals_workaround_enabled?: (untyped settings) -> bool
+
+      def self.incompatible_libmysqlclient_version?: (untyped settings) -> bool
+
+      def self.load_pprof_support: () -> void
     end
   end
 end

--- a/spec/datadog/core/configuration/components_spec.rb
+++ b/spec/datadog/core/configuration/components_spec.rb
@@ -457,6 +457,10 @@ RSpec.describe Datadog::Core::Configuration::Components do
           allow(Datadog::Tracing::Writer).to receive(:new)
             .with(agent_settings: agent_settings, **writer_options)
             .and_return(writer)
+
+          expect(Datadog::Tracing::Configuration::AgentSettingsResolver).to receive(:call)
+            .with(settings, logger: logger)
+            .and_return(agent_settings)
         end
 
         after do

--- a/spec/datadog/profiling/component_spec.rb
+++ b/spec/datadog/profiling/component_spec.rb
@@ -49,6 +49,10 @@ RSpec.describe Datadog::Profiling::Component do
 
         settings.profiling.enabled = true
         allow(profiler_setup_task).to receive(:run)
+
+        expect(Datadog::Profiling::AgentSettingsResolver).to receive(:call)
+          .with(settings, logger: logger)
+          .and_return(agent_settings)
       end
 
       context 'when using the legacy profiler' do


### PR DESCRIPTION

<!--
Check out the
https://github.com/DataDog/dd-trace-rb/blob/master/docs/DevelopmentGuide.md
for guidance on how to set up your development environment,
run the test suite, write new integrations, and more.
-->

**What does this PR do?**
Fixes a bug introduced in 94158dbfa631cba05bae43f5bdea10e7d99a2ec8 where the tracing component was passing the AgentSettingsResolver `@logger` which isn't initialized at that point. It should be passing AgentSettingsResolver the `logger` passed to the method instead.

Also, re-add types that were accidentally removed in 94158dbfa631cba05bae43f5bdea10e7d99a2ec8 for profiling/component.rbs.

**Motivation**
CI is emitting warnings about `@logger` not being initialized.

**Additional Notes**
<!-- Anything else we should know when reviewing? -->

**How to test the change?**
CI should no longer emit warnings. Spec tests added to make sure correct logger is passed.