### PR TITLE
Avoid diagnostics on rails console

### DIFF
--- a/lib/datadog/core/diagnostics/environment_logger.rb
+++ b/lib/datadog/core/diagnostics/environment_logger.rb
@@ -46,7 +46,8 @@ module Datadog
         REPL_PROGRAM_NAMES = %w[irb pry].freeze
 
         def repl?
-          REPL_PROGRAM_NAMES.include?($PROGRAM_NAME)
+          REPL_PROGRAM_NAMES.include?($PROGRAM_NAME) ||
+            defined?(Rails::Console)
         end
 
         def rspec?


### PR DESCRIPTION
Currently I get a huge DATADOG CONFIGURATION payload output when starting a rails console.

The `Rails::Console` constant is only loaded when the `rails console` command is run:

https://github.com/rails/rails/blob/main/railties/lib/rails/commands/console/console_command.rb

It's a semi-conventional way to detect if we're running in a rails console. This PR uses its presence as a signal that we're in a repl, and so avoiding printing the diagnostic information by default.