### PR TITLE
Update ruby/gitlab macrobenchmark

### DIFF
--- a/.gitlab/benchmarks.yml
+++ b/.gitlab/benchmarks.yml
@@ -41,17 +41,17 @@ variables:
 baseline-benchmarks:
   extends: .benchmarks
   variables:
-    DD_RELENV_CONFIGURATION: baseline
+    DD_BENCHMARKS_CONFIGURATION: baseline
 
 only-tracing-benchmarks:
   extends: .benchmarks
   variables:
-    DD_RELENV_CONFIGURATION: only-tracing
+    DD_BENCHMARKS_CONFIGURATION: only-tracing
 
 only-profiling-benchmarks:
   extends: .benchmarks
   variables:
-    DD_RELENV_CONFIGURATION: only-profiling
+    DD_BENCHMARKS_CONFIGURATION: only-profiling
     DD_PROFILING_ENABLED: "true"
     # Gitlab makes use of the rugged gem, which triggers the automatic no signals workaround use, see
     # https://docs.datadoghq.com/profiler/profiler_troubleshooting/ruby/#unexpected-failures-or-errors-from-ruby-gems-that-use-native-extensions-in-dd-trace-rb-1110
@@ -62,7 +62,7 @@ only-profiling-benchmarks:
 only-profiling-timeline-benchmarks:
   extends: .benchmarks
   variables:
-    DD_RELENV_CONFIGURATION: only-profiling
+    DD_BENCHMARKS_CONFIGURATION: only-profiling
     DD_PROFILING_ENABLED: "true"
     DD_PROFILING_NO_SIGNALS_WORKAROUND_ENABLED: "false"
     DD_PROFILING_EXPERIMENTAL_TIMELINE_ENABLED: "true"
@@ -70,27 +70,27 @@ only-profiling-timeline-benchmarks:
 profiling-and-tracing-benchmarks:
   extends: .benchmarks
   variables:
-    DD_RELENV_CONFIGURATION: profiling-and-tracing
+    DD_BENCHMARKS_CONFIGURATION: profiling-and-tracing
     DD_PROFILING_ENABLED: "true"
     DD_PROFILING_NO_SIGNALS_WORKAROUND_ENABLED: "false"
 
 tracing-and-appsec-benchmarks:
   extends: .benchmarks
   variables:
-    DD_RELENV_CONFIGURATION: tracing-and-appsec
+    DD_BENCHMARKS_CONFIGURATION: tracing-and-appsec
     DD_APPSEC_ENABLED: "true"
 
 tracing-and-appsec-and-no-remote-configuration-benchmarks:
   extends: .benchmarks
   variables:
-    DD_RELENV_CONFIGURATION: tracing-and-appsec-and-no-remote-configuration
+    DD_BENCHMARKS_CONFIGURATION: tracing-and-appsec-and-no-remote-configuration
     DD_APPSEC_ENABLED: "true"
     DD_REMOTE_CONFIGURATION_ENABLED: "false"
 
 profiling-and-tracing-and-appsec-benchmarks:
   extends: .benchmarks
   variables:
-    DD_RELENV_CONFIGURATION: profiling-and-tracing-and-appsec
+    DD_BENCHMARKS_CONFIGURATION: profiling-and-tracing-and-appsec
     DD_APPSEC_ENABLED: "true"
     DD_PROFILING_ENABLED: "true"
     DD_PROFILING_NO_SIGNALS_WORKAROUND_ENABLED: "false"
@@ -98,7 +98,7 @@ profiling-and-tracing-and-appsec-benchmarks:
 timeline-profiling-and-tracing-and-appsec-benchmarks:
   extends: .benchmarks
   variables:
-    DD_RELENV_CONFIGURATION: profiling-and-tracing-and-appsec
+    DD_BENCHMARKS_CONFIGURATION: profiling-and-tracing-and-appsec
     DD_APPSEC_ENABLED: "true"
     DD_PROFILING_ENABLED: "true"
     DD_PROFILING_NO_SIGNALS_WORKAROUND_ENABLED: "false"

--- a/.gitlab/benchmarks.yml
+++ b/.gitlab/benchmarks.yml
@@ -33,22 +33,35 @@ variables:
     DD_RELENV_DDTRACE_COMMIT_ID: $CI_COMMIT_SHORT_SHA
     K6_RUN_ID_PREFIX: ci_rb
     KUBERNETES_SERVICE_ACCOUNT_OVERWRITE: dd-trace-rb
+
+    K6_OPTIONS_NORMAL_OPERATION_RATE: 30
+    K6_OPTIONS_NORMAL_OPERATION_DURATION: 10m
+    K6_OPTIONS_NORMAL_OPERATION_GRACEFUL_STOP: 1m
+    K6_OPTIONS_NORMAL_OPERATION_PRE_ALLOCATED_VUS: 4
+    K6_OPTIONS_NORMAL_OPERATION_MAX_VUS: 4
+
+    K6_OPTIONS_HIGH_LOAD_RATE: 200
+    K6_OPTIONS_HIGH_LOAD_DURATION: 5m
+    K6_OPTIONS_HIGH_LOAD_GRACEFUL_STOP: 30s
+    K6_OPTIONS_HIGH_LOAD_PRE_ALLOCATED_VUS: 4
+    K6_OPTIONS_HIGH_LOAD_MAX_VUS: 4
+
   # Workaround: Currently we're not running the benchmarks on every PR, but GitHub still shows them as pending.
   # By marking the benchmarks as allow_failure, this should go away. (This workaround should be removed once the
   # benchmarks get changed to run on every PR)
   allow_failure: true
 
-baseline-benchmarks:
+baseline:
   extends: .benchmarks
   variables:
     DD_BENCHMARKS_CONFIGURATION: baseline
 
-only-tracing-benchmarks:
+only-tracing:
   extends: .benchmarks
   variables:
     DD_BENCHMARKS_CONFIGURATION: only-tracing
 
-only-profiling-benchmarks:
+only-profiling:
   extends: .benchmarks
   variables:
     DD_BENCHMARKS_CONFIGURATION: only-profiling
@@ -59,7 +72,7 @@ only-profiling-benchmarks:
     # better accuracy, mode.
     DD_PROFILING_NO_SIGNALS_WORKAROUND_ENABLED: "false"
 
-only-profiling-timeline-benchmarks:
+only-profiling-timeline:
   extends: .benchmarks
   variables:
     DD_BENCHMARKS_CONFIGURATION: only-profiling
@@ -67,27 +80,27 @@ only-profiling-timeline-benchmarks:
     DD_PROFILING_NO_SIGNALS_WORKAROUND_ENABLED: "false"
     DD_PROFILING_EXPERIMENTAL_TIMELINE_ENABLED: "true"
 
-profiling-and-tracing-benchmarks:
+profiling-and-tracing:
   extends: .benchmarks
   variables:
     DD_BENCHMARKS_CONFIGURATION: profiling-and-tracing
     DD_PROFILING_ENABLED: "true"
     DD_PROFILING_NO_SIGNALS_WORKAROUND_ENABLED: "false"
 
-tracing-and-appsec-benchmarks:
+tracing-and-appsec:
   extends: .benchmarks
   variables:
     DD_BENCHMARKS_CONFIGURATION: tracing-and-appsec
     DD_APPSEC_ENABLED: "true"
 
-tracing-and-appsec-and-no-remote-configuration-benchmarks:
+tracing-and-appsec-and-no-remote-configuration:
   extends: .benchmarks
   variables:
     DD_BENCHMARKS_CONFIGURATION: tracing-and-appsec-and-no-remote-configuration
     DD_APPSEC_ENABLED: "true"
     DD_REMOTE_CONFIGURATION_ENABLED: "false"
 
-profiling-and-tracing-and-appsec-benchmarks:
+profiling-and-tracing-and-appsec:
   extends: .benchmarks
   variables:
     DD_BENCHMARKS_CONFIGURATION: profiling-and-tracing-and-appsec
@@ -95,7 +108,7 @@ profiling-and-tracing-and-appsec-benchmarks:
     DD_PROFILING_ENABLED: "true"
     DD_PROFILING_NO_SIGNALS_WORKAROUND_ENABLED: "false"
 
-timeline-profiling-and-tracing-and-appsec-benchmarks:
+profiling-and-tracing-and-appsec-timeline:
   extends: .benchmarks
   variables:
     DD_BENCHMARKS_CONFIGURATION: profiling-and-tracing-and-appsec


### PR DESCRIPTION
<!--
Check out the
https://github.com/DataDog/dd-trace-rb/blob/master/docs/DevelopmentGuide.md
for guidance on how to set up your development environment,
run the test suite, write new integrations, and more.
-->

**What does this PR do?**
<!-- A brief description of the change being made with this pull request. -->
This PR aligns macrobenchmarks CI jobs with updates made to the `ruby/gitlab` branch in the `benchmarking-platform` repo: https://github.com/DataDog/benchmarking-platform/pull/23.

> - Updated benchmarking platform tags:
    - `perf_*` -> `bp_*`
    - `perf_sub_configuration` deprecated
    - `perf_lang`->`bp_project`
    - `perf_configuration`->`perf_app`

> - Exposed k6 options through environment variables in `gitlab-ci.yml` and in `.env`.
> - Summarized the k6 execution information into a single script, `k6/script.js`. The scenarios are chosen through the environment variable `SCENARIO`. The `EXTENDED_SCENARIO_NAME` environment variable is built with `SCENARIO` and `DD_BENCHMARKS_CONFIGURATION`, and is the scenario name exported to the BP UI.
> - Fixed a bug where data from CI jobs that used the `DD_PROFILING_EXPERIMENTAL_TIMELINE_ENABLED` sent data under incorrect extended scenario names (for example, the CI job `only-profiling-timeline` sent data under the extended scenario name `normal_operation--only-profiling` and not `normal_operation--only-profiling-timeline`).

**Motivation:**
<!-- What inspired you to submit this pull request? -->
https://datadoghq.atlassian.net/browse/AIT-8098

**Additional Notes:**
<!-- Anything else we should know when reviewing? -->

**How to test the change?**
<!--
Describe here how the change can be validated.
You are strongly encouraged to provide automated tests for this PR (unit or integration).
If this change cannot be feasibly tested, please explain why,
unless the change does not modify code (e.g. only modifies docs, comments).
-->
- Pipeline for `dd-trace-rb` that uses the new `ruby/gitlab` changes: [#19297727](https://gitlab.ddbuild.io/DataDog/apm-reliability/dd-trace-rb/-/pipelines/19297727)
- Results can be seen on the [Ruby Dashboard](https://ddstaging.datadoghq.com/dashboard/b55-xcc-wf2?tpl_var_bp_app%5B0%5D=dd-trace-rb%2Fgitlab&from_ts=1692956260342&to_ts=1692957400387&live=false).
- Results can be seen on the [BP UI](https://benchmarking.us1.prod.dog/benchmarks?ciJobDateStart=1690381440075&ciJobDateEnd=1692973440075&projectId=5&ciPipelineId=19297727).

**For Datadog employees:**
- [ ] If this PR touches code that signs or publishes builds or packages, or handles
credentials of any kind, I've requested a review from `@DataDog/security-design-and-guidance`.
- [x] This PR doesn't touch any of that.