### PR TITLE
remove `delegate_to` configuration option from our DSL

### DIFF
--- a/lib/datadog/core/configuration/option.rb
+++ b/lib/datadog/core/configuration/option.rb
@@ -113,8 +113,6 @@ module Datadog
         def get
           if @is_set
             @value
-          elsif definition.delegate_to
-            context_eval(&definition.delegate_to)
           else
             set_value_from_env_or_default
           end

--- a/lib/datadog/core/configuration/option_definition.rb
+++ b/lib/datadog/core/configuration/option_definition.rb
@@ -19,7 +19,6 @@ module Datadog
           :env,
           :deprecated_env,
           :env_parser,
-          :delegate_to,
           :name,
           :on_set,
           :resetter,
@@ -33,7 +32,6 @@ module Datadog
           @env = meta[:env]
           @deprecated_env = meta[:deprecated_env]
           @env_parser = meta[:env_parser]
-          @delegate_to = meta[:delegate_to]
           @name = name.to_sym
           @on_set = meta[:on_set]
           @resetter = meta[:resetter]
@@ -61,7 +59,6 @@ module Datadog
             @env_parser = nil
             @default = nil
             @experimental_default_proc = nil
-            @delegate_to = nil
             @helpers = {}
             @name = name.to_sym
             @on_set = nil
@@ -96,10 +93,6 @@ module Datadog
 
           def experimental_default_proc(&block)
             @experimental_default_proc = block
-          end
-
-          def delegate_to(&block)
-            @delegate_to = block
           end
 
           def helper(name, *_args, &block)
@@ -144,7 +137,6 @@ module Datadog
             env(options[:env]) if options.key?(:env)
             deprecated_env(options[:deprecated_env]) if options.key?(:deprecated_env)
             env_parser(&options[:env_parser]) if options.key?(:env_parser)
-            delegate_to(&options[:delegate_to]) if options.key?(:delegate_to)
             lazy(options[:lazy]) if options.key?(:lazy)
             on_set(&options[:on_set]) if options.key?(:on_set)
             resetter(&options[:resetter]) if options.key?(:resetter)
@@ -163,7 +155,6 @@ module Datadog
               env: @env,
               deprecated_env: @deprecated_env,
               env_parser: @env_parser,
-              delegate_to: @delegate_to,
               on_set: @on_set,
               resetter: @resetter,
               setter: @setter,

--- a/sig/datadog/core/configuration/option_definition.rbs
+++ b/sig/datadog/core/configuration/option_definition.rbs
@@ -14,8 +14,6 @@ module Datadog
 
         attr_reader env_parser: untyped
 
-        attr_reader delegate_to: untyped
-
         attr_reader depends_on: untyped
 
         attr_reader name: untyped
@@ -41,8 +39,6 @@ module Datadog
 
           def experimental_default_proc: () { () -> untyped } -> untyped
 
-          def delegate_to: () { () -> untyped } -> untyped
-
           def env: (untyped value) -> untyped
 
           def deprecated_env: (untyped value) -> untyped
@@ -63,7 +59,7 @@ module Datadog
 
           def to_definition: () -> untyped
 
-          def meta: () -> { default: untyped, delegate_to: untyped, depends_on: untyped, on_set: untyped, resetter: untyped, setter: untyped }
+          def meta: () -> { default: untyped, on_set: untyped, resetter: untyped, setter: untyped }
         end
       end
     end

--- a/spec/datadog/core/configuration/option_definition_spec.rb
+++ b/spec/datadog/core/configuration/option_definition_spec.rb
@@ -24,21 +24,6 @@ RSpec.describe Datadog::Core::Configuration::OptionDefinition do
     end
   end
 
-  describe '#delegate_to' do
-    subject(:delegate_to) { definition.delegate_to }
-
-    context 'when given a value' do
-      let(:meta) { { delegate_to: delegate_to_value } }
-      let(:delegate_to_value) { double('delegate_to') }
-
-      it { is_expected.to be delegate_to_value }
-    end
-
-    context 'when not initialized' do
-      it { is_expected.to be nil }
-    end
-  end
-
   describe '#name' do
     subject(:result) { definition.name }
 
@@ -162,7 +147,6 @@ RSpec.describe Datadog::Core::Configuration::OptionDefinition::Builder do
             is_expected.to have_attributes(
               default: nil,
               experimental_default_proc: nil,
-              delegate_to: nil,
               name: name,
               on_set: nil,
               resetter: nil,
@@ -251,14 +235,6 @@ RSpec.describe Datadog::Core::Configuration::OptionDefinition::Builder do
 
       it { is_expected.to be block }
     end
-  end
-
-  describe '#delegate_to' do
-    subject(:delegate_to) { builder.delegate_to(&block) }
-
-    let(:block) { proc {} }
-
-    it { is_expected.to be block }
   end
 
   describe '#helper' do
@@ -385,19 +361,6 @@ RSpec.describe Datadog::Core::Configuration::OptionDefinition::Builder do
       end
     end
 
-    context 'given :delegate_to' do
-      let(:options) { { delegate_to: value } }
-      let(:value) { proc {} }
-
-      it do
-        expect(builder).to receive(:delegate_to) do |&block|
-          expect(block).to be value
-        end
-
-        apply_options!
-      end
-    end
-
     context 'given :on_set' do
       let(:options) { { on_set: value } }
       let(:value) { proc {} }
@@ -461,7 +424,6 @@ RSpec.describe Datadog::Core::Configuration::OptionDefinition::Builder do
       expect(meta.keys).to include(
         :default,
         :experimental_default_proc,
-        :delegate_to,
         :on_set,
         :resetter,
         :setter,

--- a/spec/datadog/core/configuration/option_spec.rb
+++ b/spec/datadog/core/configuration/option_spec.rb
@@ -14,7 +14,6 @@ RSpec.describe Datadog::Core::Configuration::Option do
       env: env,
       deprecated_env: deprecated_env,
       env_parser: env_parser,
-      delegate_to: delegate,
       on_set: nil,
       resetter: nil,
       setter: setter,
@@ -24,7 +23,6 @@ RSpec.describe Datadog::Core::Configuration::Option do
   end
   let(:default) { double('default') }
   let(:experimental_default_proc) { nil }
-  let(:delegate) { nil }
   let(:env) { nil }
   let(:env_parser) { nil }
   let(:type) { nil }


### PR DESCRIPTION
<!--
Check out the
https://github.com/DataDog/dd-trace-rb/blob/master/docs/DevelopmentGuide.md
for guidance on how to set up your development environment,
run the test suite, write new integrations, and more.
-->

**What does this PR do?**
<!-- A brief description of the change being made with this pull request. -->

In our initial discussion, we agreed that the `delegate_to` option's main functionality was not to cache the result when configuring. For that reason, renaming it to `cache` would express with more accuracy the intent of the option. 

I started by renaming it, but after seeing how much the option code has evolved since the initial conversation with the introduction of precedence, parsing env vars, etc... While trying to rename it to `cache` I realized that it would be more complicated than it seems, more importantly we have no idea how an option would work using `delegate_to` in the current system. 

For the reason outlined above I think is best to remove the option since no configuration definition is using it, and if we ever want to introduce the ability to configure if an option is cached we could do it in the future, hopefully with some requirements defined. 

**Motivation:**
<!-- What inspired you to submit this pull request? -->

**Additional Notes:**
<!-- Anything else we should know when reviewing? -->

**How to test the change?**
<!--
Describe here how the change can be validated.
You are strongly encouraged to provide automated tests for this PR (unit or integration).
If this change cannot be feasibly tested, please explain why,
unless the change does not modify code (e.g. only modifies docs, comments).
-->

**For Datadog employees:**
- [ ] If this PR touches code that signs or publishes builds or packages, or handles
credentials of any kind, I've requested a review from `@DataDog/security-design-and-guidance`.
- [x] This PR doesn't touch any of that.

Unsure? Have a question? Request a review!
