### PR TITLE
Fix typo of active_trace in GettingStarted.md

### DIFF
--- a/docs/GettingStarted.md
+++ b/docs/GettingStarted.md
@@ -2396,7 +2396,7 @@ It's safe to use `Datadog::Tracing.reject!` and `Datadog::Tracing.keep!` when no
 You can also reject a specific trace instance:
 
 ```ruby
-# First, grab the active span
+# First, grab the active trace
 trace = Datadog::Tracing.active_trace
 
 # Rejects the trace


### PR DESCRIPTION

**What does this PR do?**

Was browsing Getting Started guide and noticed this typo.

**Motivation:**

intrinsic desire.

**Additional Notes:**

Nope

**How to test the change?**

Docs-only, so only need to review the change.

**For Datadog employees:**
- [ ] If this PR touches code that signs or publishes builds or packages, or handles
credentials of any kind, I've requested a review from `@DataDog/security-design-and-guidance`.
- [ ] This PR doesn't touch any of that.

Unsure? Have a question? Request a review!
