### PR TITLE
rename experimental_default_proc to default_proc

### DIFF
--- a/lib/datadog/core/configuration/option.rb
+++ b/lib/datadog/core/configuration/option.rb
@@ -139,7 +139,7 @@ module Datadog
           if definition.default.instance_of?(Proc)
             context_eval(&definition.default)
           else
-            definition.experimental_default_proc || Core::Utils::SafeDup.frozen_or_dup(definition.default)
+            definition.default_proc || Core::Utils::SafeDup.frozen_or_dup(definition.default)
           end
         end
 

--- a/lib/datadog/core/configuration/option_definition.rb
+++ b/lib/datadog/core/configuration/option_definition.rb
@@ -11,11 +11,7 @@ module Datadog
 
         attr_reader \
           :default,
-          # experimental_default_proc is used when we want to store a block as part of the option value.
-          # Since this new option is experimental and we might not need it in the near future, I gave it a name that is
-          # clear to the reader that they should not rely on it and that is subject to change.
-          # Currently is only use internally.
-          :experimental_default_proc,
+          :default_proc,
           :env,
           :deprecated_env,
           :env_parser,
@@ -28,7 +24,7 @@ module Datadog
 
         def initialize(name, meta = {}, &block)
           @default = meta[:default]
-          @experimental_default_proc = meta[:experimental_default_proc]
+          @default_proc = meta[:default_proc]
           @env = meta[:env]
           @deprecated_env = meta[:deprecated_env]
           @env_parser = meta[:env_parser]
@@ -58,7 +54,7 @@ module Datadog
             @deprecated_env = nil
             @env_parser = nil
             @default = nil
-            @experimental_default_proc = nil
+            @default_proc = nil
             @helpers = {}
             @name = name.to_sym
             @on_set = nil
@@ -91,8 +87,8 @@ module Datadog
             @default = block || value
           end
 
-          def experimental_default_proc(&block)
-            @experimental_default_proc = block
+          def default_proc(&block)
+            @default_proc = block
           end
 
           def helper(name, *_args, &block)
@@ -133,7 +129,7 @@ module Datadog
             return if options.nil? || options.empty?
 
             default(options[:default]) if options.key?(:default)
-            experimental_default_proc(&options[:experimental_default_proc]) if options.key?(:experimental_default_proc)
+            default_proc(&options[:default_proc]) if options.key?(:default_proc)
             env(options[:env]) if options.key?(:env)
             deprecated_env(options[:deprecated_env]) if options.key?(:deprecated_env)
             env_parser(&options[:env_parser]) if options.key?(:env_parser)
@@ -151,7 +147,7 @@ module Datadog
           def meta
             {
               default: @default,
-              experimental_default_proc: @experimental_default_proc,
+              default_proc: @default_proc,
               env: @env,
               deprecated_env: @deprecated_env,
               env_parser: @env_parser,
@@ -166,10 +162,10 @@ module Datadog
           private
 
           def validate_options!
-            if !@default.nil? && @experimental_default_proc
+            if !@default.nil? && @default_proc
               raise InvalidOptionError,
-                'Using `default` and `experimental_default_proc` is not allowed. Please use one or the other.' \
-                                'If you want to store a block as the default value use `experimental_default_proc`'\
+                'Using `default` and `default_proc` is not allowed. Please use one or the other.' \
+                                'If you want to store a block as the default value use `default_proc`'\
                                 ' otherwise use `default`'
             end
           end

--- a/lib/datadog/core/configuration/settings.rb
+++ b/lib/datadog/core/configuration/settings.rb
@@ -527,7 +527,7 @@ module Datadog
         # @default `->{ Time.now }`
         # @return [Proc<Time>]
         option :time_now_provider do |o|
-          o.experimental_default_proc { ::Time.now }
+          o.default_proc { ::Time.now }
           o.type :proc
 
           o.on_set do |time_provider|

--- a/lib/datadog/tracing/contrib/active_job/configuration/settings.rb
+++ b/lib/datadog/tracing/contrib/active_job/configuration/settings.rb
@@ -33,7 +33,7 @@ module Datadog
             option :service_name
             option :error_handler do |o|
               o.type :proc
-              o.experimental_default_proc(&Tracing::SpanOperation::Events::DEFAULT_ON_ERROR)
+              o.default_proc(&Tracing::SpanOperation::Events::DEFAULT_ON_ERROR)
             end
           end
         end

--- a/lib/datadog/tracing/contrib/delayed_job/configuration/settings.rb
+++ b/lib/datadog/tracing/contrib/delayed_job/configuration/settings.rb
@@ -34,7 +34,7 @@ module Datadog
             option :client_service_name
             option :error_handler do |o|
               o.type :proc
-              o.experimental_default_proc(&Tracing::SpanOperation::Events::DEFAULT_ON_ERROR)
+              o.default_proc(&Tracing::SpanOperation::Events::DEFAULT_ON_ERROR)
             end
           end
         end

--- a/lib/datadog/tracing/contrib/faraday/configuration/settings.rb
+++ b/lib/datadog/tracing/contrib/faraday/configuration/settings.rb
@@ -36,7 +36,7 @@ module Datadog
             option :distributed_tracing, default: true, type: :bool
             option :error_handler do |o|
               o.type :proc
-              o.experimental_default_proc(&DEFAULT_ERROR_HANDLER)
+              o.default_proc(&DEFAULT_ERROR_HANDLER)
             end
             option :split_by_domain, default: false, type: :bool
 

--- a/lib/datadog/tracing/contrib/grpc/configuration/settings.rb
+++ b/lib/datadog/tracing/contrib/grpc/configuration/settings.rb
@@ -48,7 +48,7 @@ module Datadog
 
             option :error_handler do |o|
               o.type :proc
-              o.experimental_default_proc(&Tracing::SpanOperation::Events::DEFAULT_ON_ERROR)
+              o.default_proc(&Tracing::SpanOperation::Events::DEFAULT_ON_ERROR)
             end
           end
         end

--- a/lib/datadog/tracing/contrib/que/configuration/settings.rb
+++ b/lib/datadog/tracing/contrib/que/configuration/settings.rb
@@ -46,7 +46,7 @@ module Datadog
 
             option :error_handler do |o|
               o.type :proc
-              o.experimental_default_proc(&Tracing::SpanOperation::Events::DEFAULT_ON_ERROR)
+              o.default_proc(&Tracing::SpanOperation::Events::DEFAULT_ON_ERROR)
             end
           end
         end

--- a/lib/datadog/tracing/contrib/resque/configuration/settings.rb
+++ b/lib/datadog/tracing/contrib/resque/configuration/settings.rb
@@ -33,7 +33,7 @@ module Datadog
             option :service_name
             option :error_handler do |o|
               o.type :proc
-              o.experimental_default_proc(&Tracing::SpanOperation::Events::DEFAULT_ON_ERROR)
+              o.default_proc(&Tracing::SpanOperation::Events::DEFAULT_ON_ERROR)
             end
           end
         end

--- a/lib/datadog/tracing/contrib/shoryuken/configuration/settings.rb
+++ b/lib/datadog/tracing/contrib/shoryuken/configuration/settings.rb
@@ -33,7 +33,7 @@ module Datadog
             option :service_name
             option :error_handler do |o|
               o.type :proc
-              o.experimental_default_proc(&Tracing::SpanOperation::Events::DEFAULT_ON_ERROR)
+              o.default_proc(&Tracing::SpanOperation::Events::DEFAULT_ON_ERROR)
             end
             option :tag_body, default: false, type: :bool
           end

--- a/lib/datadog/tracing/contrib/sidekiq/configuration/settings.rb
+++ b/lib/datadog/tracing/contrib/sidekiq/configuration/settings.rb
@@ -40,7 +40,7 @@ module Datadog
             option :client_service_name
             option :error_handler do |o|
               o.type :proc
-              o.experimental_default_proc(&Tracing::SpanOperation::Events::DEFAULT_ON_ERROR)
+              o.default_proc(&Tracing::SpanOperation::Events::DEFAULT_ON_ERROR)
             end
             option :quantize, default: {}, type: :hash
             option :distributed_tracing, default: false, type: :bool

--- a/lib/datadog/tracing/contrib/sneakers/configuration/settings.rb
+++ b/lib/datadog/tracing/contrib/sneakers/configuration/settings.rb
@@ -31,7 +31,7 @@ module Datadog
             option :service_name
             option :error_handler do |o|
               o.type :proc
-              o.experimental_default_proc(&Tracing::SpanOperation::Events::DEFAULT_ON_ERROR)
+              o.default_proc(&Tracing::SpanOperation::Events::DEFAULT_ON_ERROR)
             end
             option :tag_body, default: false, type: :bool
           end

--- a/sig/datadog/core/configuration/option_definition.rbs
+++ b/sig/datadog/core/configuration/option_definition.rbs
@@ -6,7 +6,7 @@ module Datadog
 
         attr_reader default: untyped
 
-        attr_reader experimental_default_proc: untyped
+        attr_reader default_proc: untyped
 
         attr_reader env: untyped
 
@@ -37,7 +37,7 @@ module Datadog
 
           def default: (?untyped? value) ?{ () -> untyped } -> untyped
 
-          def experimental_default_proc: () { () -> untyped } -> untyped
+          def default_proc: () { () -> untyped } -> untyped
 
           def env: (untyped value) -> untyped
 

--- a/spec/datadog/core/configuration/option_definition_spec.rb
+++ b/spec/datadog/core/configuration/option_definition_spec.rb
@@ -146,7 +146,7 @@ RSpec.describe Datadog::Core::Configuration::OptionDefinition::Builder do
           it 'generates an OptionDefinition with defaults' do
             is_expected.to have_attributes(
               default: nil,
-              experimental_default_proc: nil,
+              default_proc: nil,
               name: name,
               on_set: nil,
               resetter: nil,
@@ -184,11 +184,11 @@ RSpec.describe Datadog::Core::Configuration::OptionDefinition::Builder do
     end
 
     context 'validate_options!' do
-      context 'when default and experimental_default_proc is provided' do
+      context 'when default and default_proc is provided' do
         let(:initialize_block) do
           proc do |o|
             o.default false
-            o.experimental_default_proc { true }
+            o.default_proc { true }
           end
         end
 
@@ -227,8 +227,8 @@ RSpec.describe Datadog::Core::Configuration::OptionDefinition::Builder do
     end
   end
 
-  describe '#experimental_default_proc' do
-    subject(:experimental_default_proc) { builder.experimental_default_proc(&block) }
+  describe '#default_proc' do
+    subject(:default_proc) { builder.default_proc(&block) }
 
     context 'given a block' do
       let(:block) { proc { false } }
@@ -423,7 +423,7 @@ RSpec.describe Datadog::Core::Configuration::OptionDefinition::Builder do
     it 'contains the arguments for OptionDefinition' do
       expect(meta.keys).to include(
         :default,
-        :experimental_default_proc,
+        :default_proc,
         :on_set,
         :resetter,
         :setter,

--- a/spec/datadog/core/configuration/option_spec.rb
+++ b/spec/datadog/core/configuration/option_spec.rb
@@ -10,7 +10,7 @@ RSpec.describe Datadog::Core::Configuration::Option do
       Datadog::Core::Configuration::OptionDefinition,
       name: :test_name,
       default: default,
-      experimental_default_proc: experimental_default_proc,
+      default_proc: default_proc,
       env: env,
       deprecated_env: deprecated_env,
       env_parser: env_parser,
@@ -22,7 +22,7 @@ RSpec.describe Datadog::Core::Configuration::Option do
     )
   end
   let(:default) { double('default') }
-  let(:experimental_default_proc) { nil }
+  let(:default_proc) { nil }
   let(:env) { nil }
   let(:env_parser) { nil }
   let(:type) { nil }
@@ -1015,10 +1015,10 @@ RSpec.describe Datadog::Core::Configuration::Option do
       end
     end
 
-    context 'when experimental_default_proc is defined' do
-      let(:experimental_default_proc) { proc { 'experimental_default_proc' } }
+    context 'when default_proc is defined' do
+      let(:default_proc) { proc { 'default_proc' } }
 
-      it { is_expected.to be experimental_default_proc }
+      it { is_expected.to be default_proc }
     end
   end
 end


### PR DESCRIPTION
<!--
Check out the
https://github.com/DataDog/dd-trace-rb/blob/master/docs/DevelopmentGuide.md
for guidance on how to set up your development environment,
run the test suite, write new integrations, and more.
-->

**What does this PR do?**
<!-- A brief description of the change being made with this pull request. -->

Rename `experimental_default_proc` to `default_proc`

Check this thread for more context https://github.com/DataDog/dd-trace-rb/pull/2988#discussion_r1273366809

**Motivation:**
<!-- What inspired you to submit this pull request? -->

**Additional Notes:**
<!-- Anything else we should know when reviewing? -->

**How to test the change?**
<!--
Describe here how the change can be validated.
You are strongly encouraged to provide automated tests for this PR (unit or integration).
If this change cannot be feasibly tested, please explain why,
unless the change does not modify code (e.g. only modifies docs, comments).
-->

**For Datadog employees:**
- [ ] If this PR touches code that signs or publishes builds or packages, or handles
credentials of any kind, I've requested a review from `@DataDog/security-design-and-guidance`.
- [ ] This PR doesn't touch any of that.

Unsure? Have a question? Request a review!
