### PR TITLE
fix(grpc): allow custom error_handler for client interceptor

### DIFF
--- a/lib/datadog/tracing/contrib/grpc/configuration/settings.rb
+++ b/lib/datadog/tracing/contrib/grpc/configuration/settings.rb
@@ -49,6 +49,26 @@ module Datadog
             option :error_handler do |o|
               o.type :proc
               o.default_proc(&Tracing::SpanOperation::Events::DEFAULT_ON_ERROR)
+              o.on_set do |value|
+                if value != Tracing::SpanOperation::Events::DEFAULT_ON_ERROR
+                  Datadog.logger.warn(
+                    'The gRPC `error_handler` setting has been deprecated for removal. Please replace ' \
+                    'it with `server_error_handler` which is explicit about only handling errors from ' \
+                    'server interceptors. Alternatively, to handle errors from client interceptors use ' \
+                    'the `client_error_handler` setting instead.'
+                  )
+                end
+              end
+            end
+
+            option :server_error_handler do |o|
+              o.type :proc
+              o.default_proc(&Tracing::SpanOperation::Events::DEFAULT_ON_ERROR)
+            end
+
+            option :client_error_handler do |o|
+              o.type :proc
+              o.default_proc(&Tracing::SpanOperation::Events::DEFAULT_ON_ERROR)
             end
           end
         end

--- a/lib/datadog/tracing/contrib/grpc/datadog_interceptor.rb
+++ b/lib/datadog/tracing/contrib/grpc/datadog_interceptor.rb
@@ -58,10 +58,6 @@ module Datadog
               datadog_configuration[:analytics_sample_rate]
             end
 
-            def error_handler
-              Datadog.configuration_for(self, :error_handler) || datadog_configuration[:error_handler]
-            end
-
             # Allows interceptors to define settings using methods instead of `[]`
             class PinAdapter
               OPTIONS = Configuration::Settings.instance_methods(false).freeze

--- a/lib/datadog/tracing/contrib/grpc/datadog_interceptor.rb
+++ b/lib/datadog/tracing/contrib/grpc/datadog_interceptor.rb
@@ -59,7 +59,7 @@ module Datadog
             end
 
             def error_handler
-              datadog_configuration[:error_handler]
+              Datadog.configuration_for(self, :error_handler) || datadog_configuration[:error_handler]
             end
 
             # Allows interceptors to define settings using methods instead of `[]`

--- a/lib/datadog/tracing/contrib/grpc/datadog_interceptor/client.rb
+++ b/lib/datadog/tracing/contrib/grpc/datadog_interceptor/client.rb
@@ -102,6 +102,10 @@ module Datadog
               Datadog.logger.debug { "Could not parse host:port from #{call}: #{e}" }
               nil
             end
+
+            def error_handler
+              Datadog.configuration_for(self, :error_handler) || datadog_configuration[:client_error_handler]
+            end
           end
         end
       end

--- a/lib/datadog/tracing/contrib/grpc/datadog_interceptor/client.rb
+++ b/lib/datadog/tracing/contrib/grpc/datadog_interceptor/client.rb
@@ -22,7 +22,8 @@ module Datadog
               options = {
                 span_type: Tracing::Metadata::Ext::HTTP::TYPE_OUTBOUND,
                 service: service_name, # Maintain client-side service name configuration
-                resource: formatter.resource_name
+                resource: formatter.resource_name,
+                on_error: error_handler
               }
 
               Tracing.trace(Ext::SPAN_CLIENT, **options) do |span, trace|

--- a/lib/datadog/tracing/contrib/grpc/datadog_interceptor/server.rb
+++ b/lib/datadog/tracing/contrib/grpc/datadog_interceptor/server.rb
@@ -81,6 +81,19 @@ module Datadog
             rescue StandardError => e
               Datadog.logger.debug("GRPC server trace failed: #{e}")
             end
+
+            def error_handler
+              self_handler = Datadog.configuration_for(self, :error_handler)
+              return self_handler if self_handler
+
+              unless datadog_configuration.using_default?(:server_error_handler)
+                return datadog_configuration[:server_error_handler]
+              end
+
+              # As a last resort, fallback to the deprecated error_handler
+              # configuration option.
+              datadog_configuration[:error_handler]
+            end
           end
         end
       end

--- a/spec/datadog/tracing/contrib/grpc/datadog_interceptor/shared_examples.rb
+++ b/spec/datadog/tracing/contrib/grpc/datadog_interceptor/shared_examples.rb
@@ -1,0 +1,10 @@
+RSpec.shared_examples_for 'it handles the error' do |expected_error|
+  it do
+    expect { request_response }.to raise_error('test error')
+
+    expect(span).to_not have_error
+    expect(span.get_tag('custom.handler')).to eq(expected_error)
+    expect(span.get_tag('rpc.system')).to eq('grpc')
+    expect(span.get_tag('span.kind')).to eq(span_kind)
+  end
+end


### PR DESCRIPTION
**What does this PR do?**

In https://github.com/DataDog/dd-trace-rb/pull/1583, the option of passing a custom error_handler to gRPC interceptors was added. This is useful for e.g. selectively marking certain gRPC status codes as an APM error.

However, the change was implemented only for gRPC **server** interceptors. This patch:

* updates `DatadogInterceptor::Client` to pass the `error_handler` into the `Tracing.trace` call
* updates `DatadogInterceptor::Base` to read the error_handler from the interceptor itself (i.e. what's passed [here](https://github.com/DataDog/dd-trace-rb/blob/22d20fbd94a490d6a260b9f92c824b5cfd7122d4/lib/datadog/tracing/contrib/grpc/datadog_interceptor.rb#L20)) instead of the default/global configuration. It's not clear why this wasn't needed for the Server interceptor.

**Motivation:**

To allow `grpc.client` spans to be selectively marked as errors based on gRPC status codes.

**Additional Notes:**

N/A

**How to test the change?**

Example:

```ruby
interceptor = Datadog::Tracing::Contrib::GRPC::DatadogInterceptor::Client.new do |c|
  c.error_handler = proc { |span, error| span.set_error(error) unless error.is_a?(GRPC::NotFound) }
end

# then pass interceptor into gRPC stub
```

**For Datadog employees:**

- [ ] If this PR touches code that signs or publishes builds or packages, or handles
credentials of any kind, I've requested a review from `@DataDog/security-design-and-guidance`.
- [ ] This PR doesn't touch any of that.

Unsure? Have a question? Request a review!
