### PR TITLE
Enable type checking for `Profiling::Collectors::CpuAndWallTimeWorker`

### DIFF
--- a/Steepfile
+++ b/Steepfile
@@ -168,7 +168,6 @@ target :ddtrace do
   ignore 'lib/datadog/profiling/backtrace_location.rb'
   ignore 'lib/datadog/profiling/buffer.rb'
   ignore 'lib/datadog/profiling/collectors/code_provenance.rb'
-  ignore 'lib/datadog/profiling/collectors/cpu_and_wall_time_worker.rb'
   ignore 'lib/datadog/profiling/collectors/old_stack.rb'
   ignore 'lib/datadog/profiling/collectors/stack.rb'
   ignore 'lib/datadog/profiling/diagnostics/environment_logger.rb'

--- a/lib/datadog/profiling/collectors/cpu_and_wall_time_worker.rb
+++ b/lib/datadog/profiling/collectors/cpu_and_wall_time_worker.rb
@@ -77,7 +77,7 @@ module Datadog
         # Can be removed once we remove OldStack.
         def enabled=(_); end
 
-        def stop(*_)
+        def stop(*_unused)
           @start_stop_mutex.synchronize do
             Datadog.logger.debug('Requesting CpuAndWallTimeWorker thread shut down')
 

--- a/sig/datadog/profiling/collectors/cpu_and_wall_time_worker.rbs
+++ b/sig/datadog/profiling/collectors/cpu_and_wall_time_worker.rbs
@@ -2,7 +2,10 @@ module Datadog
   module Profiling
     module Collectors
       class CpuAndWallTimeWorker
-        def self._native_allocation_count: () -> ::Integer?
+        @worker_thread: untyped
+        @start_stop_mutex: ::Thread::Mutex
+        @failure_exception: ::Exception?
+        @idle_sampling_helper: IdleSamplingHelper
 
         def initialize: (
           gc_profiling_enabled: bool,
@@ -12,6 +15,31 @@ module Datadog
           ?idle_sampling_helper: Datadog::Profiling::Collectors::IdleSamplingHelper,
           ?dynamic_sampling_rate_enabled: bool,
         ) -> void
+
+        def self._native_initialize: (
+          CpuAndWallTimeWorker self_instance,
+          ThreadContext thread_context_collector,
+          bool gc_profiling_enabled,
+          IdleSamplingHelper idle_sampling_helper,
+          bool allocation_counting_enabled,
+          bool no_signals_workaround_enabled,
+          bool dynamic_sampling_rate_enabled,
+        ) -> true
+
+        def start: () -> bool?
+        def enabled=: (untyped) -> void
+
+        def stop: (*untyped _unused) -> void
+        def self._native_stop: (CpuAndWallTimeWorker self_instance, ::Thread worker_thread) -> true
+
+        def reset_after_fork: () -> true
+        def self._native_reset_after_fork: (CpuAndWallTimeWorker self_instance) -> true
+
+        def stats: () -> ::Hash[::Symbol, untyped]
+        def self._native_stats: (CpuAndWallTimeWorker self_instance) -> ::Hash[::Symbol, untyped]
+
+        def self._native_allocation_count: () -> ::Integer?
+        def self._native_sampling_loop: (CpuAndWallTimeWorker self_instance) -> void
       end
     end
   end


### PR DESCRIPTION
**What does this PR do?**

This PR adds the type signatures and enables type checking for the `Profiling::Collectors::CpuAndWallTimeWorker` class.

**Motivation:**

I've extracted this from another branch I was working on, as it can be cleanly merged right away.

**Additional Notes:**

This PR is on top of #3094 to avoid any conflicts, since that PR changed some of the arguments to this class.

**How to test the change?**

Validate that type checking still passes!

**For Datadog employees:**
- [ ] If this PR touches code that signs or publishes builds or packages, or handles
credentials of any kind, I've requested a review from `@DataDog/security-design-and-guidance`.
- [x] This PR doesn't touch any of that.

Unsure? Have a question? Request a review!
