### PR TITLE
[APPSEC-9341] Enable configuring blocking response via Remote Configuration 

### DIFF
--- a/lib/datadog/appsec.rb
+++ b/lib/datadog/appsec.rb
@@ -23,12 +23,12 @@ module Datadog
         appsec_component.processor if appsec_component
       end
 
-      def reconfigure(ruleset:)
+      def reconfigure(ruleset:, actions:)
         appsec_component = components.appsec
 
         return unless appsec_component
 
-        appsec_component.reconfigure(ruleset: ruleset)
+        appsec_component.reconfigure(ruleset: ruleset, actions: actions)
       end
 
       def reconfigure_lock(&block)

--- a/lib/datadog/appsec/component.rb
+++ b/lib/datadog/appsec/component.rb
@@ -14,12 +14,12 @@ module Datadog
           return unless settings.respond_to?(:appsec) && settings.appsec.enabled
 
           processor = create_processor(settings)
+
           # We want to always instrument user events when AppSec is enabled.
           # There could be cases in which users use the DD_APPSEC_ENABLED Env variable to
           # enable AppSec, in that case, Devise is already instrumented.
           # In the case that users do not use DD_APPSEC_ENABLED, we have to instrument it,
           # hence the lines above.
-
           devise_integration = Datadog::AppSec::Contrib::Devise::Integration.new
           settings.appsec.instrument(:devise) unless devise_integration.patcher.patched?
 
@@ -31,6 +31,10 @@ module Datadog
         def create_processor(settings)
           rules = AppSec::Processor::RuleLoader.load_rules(ruleset: settings.appsec.ruleset)
           return nil unless rules
+
+          actions = rules['actions']
+
+          AppSec::Processor::Actions.merge(actions) if actions
 
           data = AppSec::Processor::RuleLoader.load_data(
             ip_denylist: settings.appsec.ip_denylist,

--- a/lib/datadog/appsec/component.rb
+++ b/lib/datadog/appsec/component.rb
@@ -3,6 +3,7 @@
 require_relative 'processor'
 require_relative 'processor/rule_merger'
 require_relative 'processor/rule_loader'
+require_relative 'processor/actions'
 
 module Datadog
   module AppSec
@@ -55,8 +56,10 @@ module Datadog
         @mutex = Mutex.new
       end
 
-      def reconfigure(ruleset:)
+      def reconfigure(ruleset:, actions:)
         @mutex.synchronize do
+          AppSec::Processor::Actions.merge(actions)
+
           new = Processor.new(ruleset: ruleset)
 
           if new && new.ready?

--- a/lib/datadog/appsec/contrib/rack/gateway/watcher.rb
+++ b/lib/datadog/appsec/contrib/rack/gateway/watcher.rb
@@ -28,7 +28,7 @@ module Datadog
                   scope = gateway_request.env[Datadog::AppSec::Ext::SCOPE_KEY]
 
                   AppSec::Reactive::Operation.new('rack.request') do |op|
-                    Rack::Reactive::Request.subscribe(op, scope.processor_context) do |result, _block|
+                    Rack::Reactive::Request.subscribe(op, scope.processor_context) do |result|
                       if result.status == :match
                         # TODO: should this hash be an Event instance instead?
                         event = {
@@ -48,7 +48,7 @@ module Datadog
                       end
                     end
 
-                    _result, block = Rack::Reactive::Request.publish(op, gateway_request)
+                    block = Rack::Reactive::Request.publish(op, gateway_request)
                   end
 
                   next [nil, [[:block, event]]] if block
@@ -67,11 +67,12 @@ module Datadog
               def watch_response(gateway = Instrumentation.gateway)
                 gateway.watch('rack.response', :appsec) do |stack, gateway_response|
                   block = false
+
                   event = nil
                   scope = gateway_response.scope
 
                   AppSec::Reactive::Operation.new('rack.response') do |op|
-                    Rack::Reactive::Response.subscribe(op, scope.processor_context) do |result, _block|
+                    Rack::Reactive::Response.subscribe(op, scope.processor_context) do |result|
                       if result.status == :match
                         # TODO: should this hash be an Event instance instead?
                         event = {
@@ -91,7 +92,7 @@ module Datadog
                       end
                     end
 
-                    _result, block = Rack::Reactive::Response.publish(op, gateway_response)
+                    block = Rack::Reactive::Response.publish(op, gateway_response)
                   end
 
                   next [nil, [[:block, event]]] if block
@@ -110,11 +111,12 @@ module Datadog
               def watch_request_body(gateway = Instrumentation.gateway)
                 gateway.watch('rack.request.body', :appsec) do |stack, gateway_request|
                   block = false
+
                   event = nil
                   scope = gateway_request.env[Datadog::AppSec::Ext::SCOPE_KEY]
 
                   AppSec::Reactive::Operation.new('rack.request.body') do |op|
-                    Rack::Reactive::RequestBody.subscribe(op, scope.processor_context) do |result, _block|
+                    Rack::Reactive::RequestBody.subscribe(op, scope.processor_context) do |result|
                       if result.status == :match
                         # TODO: should this hash be an Event instance instead?
                         event = {
@@ -134,7 +136,7 @@ module Datadog
                       end
                     end
 
-                    _result, block = Rack::Reactive::RequestBody.publish(op, gateway_request)
+                    block = Rack::Reactive::RequestBody.publish(op, gateway_request)
                   end
 
                   next [nil, [[:block, event]]] if block

--- a/lib/datadog/appsec/contrib/rack/reactive/request.rb
+++ b/lib/datadog/appsec/contrib/rack/reactive/request.rb
@@ -30,7 +30,6 @@ module Datadog
               end
             end
 
-            # rubocop:disable Metrics/MethodLength
             def self.subscribe(op, waf_context)
               op.subscribe(*ADDRESSES) do |*values|
                 Datadog.logger.debug { "reacted to #{ADDRESSES.inspect}: #{values.inspect}" }
@@ -61,11 +60,8 @@ module Datadog
                 when :match
                   Datadog.logger.debug { "WAF: #{result.inspect}" }
 
-                  block = result.actions.include?('block')
-
-                  yield [result, block]
-
-                  throw(:block, [result, true]) if block
+                  yield result
+                  throw(:block, true) unless result.actions.empty?
                 when :ok
                   Datadog.logger.debug { "WAF OK: #{result.inspect}" }
                 when :invalid_call
@@ -76,7 +72,6 @@ module Datadog
                   Datadog.logger.debug { "WAF UNKNOWN: #{result.status.inspect} #{result.inspect}" }
                 end
               end
-              # rubocop:enable Metrics/MethodLength
             end
           end
         end

--- a/lib/datadog/appsec/contrib/rack/reactive/request_body.rb
+++ b/lib/datadog/appsec/contrib/rack/reactive/request_body.rb
@@ -39,11 +39,8 @@ module Datadog
                 when :match
                   Datadog.logger.debug { "WAF: #{result.inspect}" }
 
-                  block = result.actions.include?('block')
-
-                  yield [result, block]
-
-                  throw(:block, [result, true]) if block
+                  yield result
+                  throw(:block, true) unless result.actions.empty?
                 when :ok
                   Datadog.logger.debug { "WAF OK: #{result.inspect}" }
                 when :invalid_call

--- a/lib/datadog/appsec/contrib/rack/reactive/response.rb
+++ b/lib/datadog/appsec/contrib/rack/reactive/response.rb
@@ -45,11 +45,8 @@ module Datadog
                 when :match
                   Datadog.logger.debug { "WAF: #{result.inspect}" }
 
-                  block = result.actions.include?('block')
-
-                  yield [result, block]
-
-                  throw(:block, [result, true]) if block
+                  yield result
+                  throw(:block, true) unless result.actions.empty?
                 when :ok
                   Datadog.logger.debug { "WAF OK: #{result.inspect}" }
                 when :invalid_call

--- a/lib/datadog/appsec/contrib/rack/request_body_middleware.rb
+++ b/lib/datadog/appsec/contrib/rack/request_body_middleware.rb
@@ -30,8 +30,9 @@ module Datadog
               @app.call(env)
             end
 
-            if request_response && request_response.any? { |action, _event| action == :block }
-              request_return = AppSec::Response.negotiate(env).to_rack
+            if request_response
+              blocked_event = request_response.find { |action, _event| action == :block }
+              request_return = AppSec::Response.negotiate(env, blocked_event.last[:actions]).to_rack if blocked_event
             end
 
             request_return

--- a/lib/datadog/appsec/contrib/rack/request_middleware.rb
+++ b/lib/datadog/appsec/contrib/rack/request_middleware.rb
@@ -61,8 +61,9 @@ module Datadog
               end
             end
 
-            if request_response && request_response.any? { |action, _event| action == :block }
-              request_return = AppSec::Response.negotiate(env).to_rack
+            if request_response
+              blocked_event = request_response.find { |action, _options| action == :block }
+              request_return = AppSec::Response.negotiate(env, blocked_event.last[:actions]).to_rack if blocked_event
             end
 
             gateway_response = Gateway::Response.new(
@@ -81,8 +82,9 @@ module Datadog
 
             AppSec::Event.record(scope.service_entry_span, *scope.processor_context.events)
 
-            if response_response && response_response.any? { |action, _event| action == :block }
-              request_return = AppSec::Response.negotiate(env).to_rack
+            if response_response
+              blocked_event = response_response.find { |action, _options| action == :block }
+              request_return = AppSec::Response.negotiate(env, blocked_event.last[:actions]).to_rack if blocked_event
             end
 
             request_return

--- a/lib/datadog/appsec/contrib/rails/gateway/watcher.rb
+++ b/lib/datadog/appsec/contrib/rails/gateway/watcher.rb
@@ -20,11 +20,12 @@ module Datadog
               def watch_request_action(gateway = Instrumentation.gateway)
                 gateway.watch('rails.request.action', :appsec) do |stack, gateway_request|
                   block = false
+
                   event = nil
                   scope = gateway_request.env[Datadog::AppSec::Ext::SCOPE_KEY]
 
                   AppSec::Reactive::Operation.new('rails.request.action') do |op|
-                    Rails::Reactive::Action.subscribe(op, scope.processor_context) do |result, _block|
+                    Rails::Reactive::Action.subscribe(op, scope.processor_context) do |result|
                       if result.status == :match
                         # TODO: should this hash be an Event instance instead?
                         event = {
@@ -44,7 +45,7 @@ module Datadog
                       end
                     end
 
-                    _result, block = Rails::Reactive::Action.publish(op, gateway_request)
+                    block = Rails::Reactive::Action.publish(op, gateway_request)
                   end
 
                   next [nil, [[:block, event]]] if block

--- a/lib/datadog/appsec/contrib/rails/patcher.rb
+++ b/lib/datadog/appsec/contrib/rails/patcher.rb
@@ -83,9 +83,15 @@ module Datadog
                 super
               end
 
-              if request_response && request_response.any? { |action, _event| action == :block }
-                @_response = AppSec::Response.negotiate(env).to_action_dispatch_response
-                request_return = @_response.body
+              if request_response
+                blocked_event = request_response.find { |action, _options| action == :block }
+                if blocked_event
+                  @_response = AppSec::Response.negotiate(
+                    env,
+                    blocked_event.last[:actions]
+                  ).to_action_dispatch_response
+                  request_return = @_response.body
+                end
               end
 
               request_return

--- a/lib/datadog/appsec/contrib/rails/reactive/action.rb
+++ b/lib/datadog/appsec/contrib/rails/reactive/action.rb
@@ -45,11 +45,8 @@ module Datadog
                 when :match
                   Datadog.logger.debug { "WAF: #{result.inspect}" }
 
-                  block = result.actions.include?('block')
-
-                  yield [result, block]
-
-                  throw(:block, [result, true]) if block
+                  yield result
+                  throw(:block, true) unless result.actions.empty?
                 when :ok
                   Datadog.logger.debug { "WAF OK: #{result.inspect}" }
                 when :invalid_call

--- a/lib/datadog/appsec/contrib/sinatra/gateway/watcher.rb
+++ b/lib/datadog/appsec/contrib/sinatra/gateway/watcher.rb
@@ -22,11 +22,12 @@ module Datadog
               def watch_request_dispatch(gateway = Instrumentation.gateway)
                 gateway.watch('sinatra.request.dispatch', :appsec) do |stack, gateway_request|
                   block = false
+
                   event = nil
                   scope = gateway_request.env[Datadog::AppSec::Ext::SCOPE_KEY]
 
                   AppSec::Reactive::Operation.new('sinatra.request.dispatch') do |op|
-                    Rack::Reactive::RequestBody.subscribe(op, scope.processor_context) do |result, _block|
+                    Rack::Reactive::RequestBody.subscribe(op, scope.processor_context) do |result|
                       if result.status == :match
                         # TODO: should this hash be an Event instance instead?
                         event = {
@@ -46,7 +47,7 @@ module Datadog
                       end
                     end
 
-                    _result, block = Rack::Reactive::RequestBody.publish(op, gateway_request)
+                    block = Rack::Reactive::RequestBody.publish(op, gateway_request)
                   end
 
                   next [nil, [[:block, event]]] if block
@@ -65,11 +66,12 @@ module Datadog
               def watch_request_routed(gateway = Instrumentation.gateway)
                 gateway.watch('sinatra.request.routed', :appsec) do |stack, (gateway_request, gateway_route_params)|
                   block = false
+
                   event = nil
                   scope = gateway_request.env[Datadog::AppSec::Ext::SCOPE_KEY]
 
                   AppSec::Reactive::Operation.new('sinatra.request.routed') do |op|
-                    Sinatra::Reactive::Routed.subscribe(op, scope.processor_context) do |result, _block|
+                    Sinatra::Reactive::Routed.subscribe(op, scope.processor_context) do |result|
                       if result.status == :match
                         # TODO: should this hash be an Event instance instead?
                         event = {
@@ -89,7 +91,7 @@ module Datadog
                       end
                     end
 
-                    _result, block = Sinatra::Reactive::Routed.publish(op, [gateway_request, gateway_route_params])
+                    block = Sinatra::Reactive::Routed.publish(op, [gateway_request, gateway_route_params])
                   end
 
                   next [nil, [[:block, event]]] if block

--- a/lib/datadog/appsec/contrib/sinatra/patcher.rb
+++ b/lib/datadog/appsec/contrib/sinatra/patcher.rb
@@ -65,9 +65,12 @@ module Datadog
               catch(Datadog::AppSec::Contrib::Sinatra::Ext::ROUTE_INTERRUPT) { super }
             end
 
-            if request_response && request_response.any? { |action, _event| action == :block }
-              self.response = AppSec::Response.negotiate(env).to_sinatra_response
-              request_return = nil
+            if request_response
+              blocked_event = request_response.find { |action, _options| action == :block }
+              if blocked_event
+                self.response = AppSec::Response.negotiate(env, blocked_event.last[:actions]).to_sinatra_response
+                request_return = nil
+              end
             end
 
             request_return
@@ -103,11 +106,14 @@ module Datadog
                 [gateway_request, gateway_route_params]
               )
 
-              if request_response && request_response.any? { |action, _event| action == :block }
-                self.response = AppSec::Response.negotiate(env).to_sinatra_response
+              if request_response
+                blocked_event = request_response.find { |action, _options| action == :block }
+                if blocked_event
+                  self.response = AppSec::Response.negotiate(env, blocked_event.last[:actions]).to_sinatra_response
 
-                # interrupt request and return response to dispatch! for consistency
-                throw(Datadog::AppSec::Contrib::Sinatra::Ext::ROUTE_INTERRUPT, response)
+                  # interrupt request and return response to dispatch! for consistency
+                  throw(Datadog::AppSec::Contrib::Sinatra::Ext::ROUTE_INTERRUPT, response)
+                end
               end
 
               yield(*args)

--- a/lib/datadog/appsec/contrib/sinatra/reactive/routed.rb
+++ b/lib/datadog/appsec/contrib/sinatra/reactive/routed.rb
@@ -40,11 +40,8 @@ module Datadog
                 when :match
                   Datadog.logger.debug { "WAF: #{result.inspect}" }
 
-                  block = result.actions.include?('block')
-
-                  yield [result, block]
-
-                  throw(:block, [result, true]) if block
+                  yield result
+                  throw(:block, true) unless result.actions.empty?
                 when :ok
                   Datadog.logger.debug { "WAF OK: #{result.inspect}" }
                 when :invalid_call

--- a/lib/datadog/appsec/monitor/gateway/watcher.rb
+++ b/lib/datadog/appsec/monitor/gateway/watcher.rb
@@ -24,7 +24,7 @@ module Datadog
                 scope = Datadog::AppSec.active_scope
 
                 AppSec::Reactive::Operation.new('identity.set_user') do |op|
-                  Monitor::Reactive::SetUser.subscribe(op, scope.processor_context) do |result, _block|
+                  Monitor::Reactive::SetUser.subscribe(op, scope.processor_context) do |result|
                     if result.status == :match
                       # TODO: should this hash be an Event instance instead?
                       event = {
@@ -44,10 +44,10 @@ module Datadog
                     end
                   end
 
-                  _result, block = Monitor::Reactive::SetUser.publish(op, user)
+                  block = Monitor::Reactive::SetUser.publish(op, user)
                 end
 
-                throw(Datadog::AppSec::Ext::INTERRUPT, [nil, [:block, event]]) if block
+                throw(Datadog::AppSec::Ext::INTERRUPT, [nil, [[:block, event]]]) if block
 
                 ret, res = stack.call(user)
 

--- a/lib/datadog/appsec/monitor/reactive/set_user.rb
+++ b/lib/datadog/appsec/monitor/reactive/set_user.rb
@@ -38,11 +38,8 @@ module Datadog
               when :match
                 Datadog.logger.debug { "WAF: #{result.inspect}" }
 
-                block = result.actions.include?('block')
-
-                yield [result, block]
-
-                throw(:block, [result, true]) if block
+                yield result
+                throw(:block, true) unless result.actions.empty?
               when :ok
                 Datadog.logger.debug { "WAF OK: #{result.inspect}" }
               when :invalid_call

--- a/lib/datadog/appsec/processor/actions.rb
+++ b/lib/datadog/appsec/processor/actions.rb
@@ -1,0 +1,49 @@
+# frozen_string_literal: true
+
+module Datadog
+  module AppSec
+    class Processor
+      # Actions store the actions information in memory
+      # Also, takes care of merging when RC send new information
+      module Actions
+        class << self
+          def actions
+            @actions ||= []
+          end
+
+          def fecth_configuration(action)
+            actions.find { |action_configuration| action_configuration['id'] == action }
+          end
+
+          def merge(actions_to_merge)
+            return if actions_to_merge.empty?
+
+            if actions.empty?
+              @actions = actions_to_merge
+            else
+              merged_actions = []
+              actions_dup = actions.dup
+
+              actions_to_merge.each do |new_action|
+                existing_action = actions_dup.find { |action| new_action['id'] == action['id'] }
+
+                # the old action is discard and the new kept
+                actions_dup.delete(existing_action) if existing_action
+                merged_actions << new_action
+              end
+
+              @actions = merged_actions.concat(actions_dup)
+            end
+          end
+
+          private
+
+          # Used in tests
+          def reset
+            @actions = []
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/datadog/appsec/remote.rb
+++ b/lib/datadog/appsec/remote.rb
@@ -31,6 +31,7 @@ module Datadog
           CAP_ASM_RESPONSE_BLOCKING,
           CAP_ASM_DD_RULES,
           CAP_ASM_CUSTOM_RULES,
+          CAP_ASM_CUSTOM_BLOCKING_RESPONSE,
         ].freeze
 
         ASM_PRODUCTS = [
@@ -63,6 +64,7 @@ module Datadog
             data = []
             overrides = []
             exclusions = []
+            actions = []
 
             repository.contents.each do |content|
               parsed_content = parse_content(content)
@@ -76,6 +78,7 @@ module Datadog
                 overrides << parsed_content['rules_override'] if parsed_content['rules_override']
                 exclusions << parsed_content['exclusions'] if parsed_content['exclusions']
                 custom_rules << parsed_content['custom_rules'] if parsed_content['custom_rules']
+                actions.concat(parsed_content['actions']) if parsed_content['actions']
               end
             end
 
@@ -95,7 +98,7 @@ module Datadog
               custom_rules: custom_rules,
             )
 
-            Datadog::AppSec.reconfigure(ruleset: ruleset)
+            Datadog::AppSec.reconfigure(ruleset: ruleset, actions: actions)
           end
 
           [receiver]

--- a/lib/datadog/appsec/response.rb
+++ b/lib/datadog/appsec/response.rb
@@ -39,8 +39,8 @@ module Datadog
             action_configuration = AppSec::Processor::Actions.fecth_configuration(action)
             next unless action_configuration
 
-            configured_response = case action
-                                  when 'block'
+            configured_response = case action_configuration['type']
+                                  when 'block_request'
                                     block_response(env, action_configuration['parameters'])
                                   when 'redirect_request'
                                     redirect_response(env, action_configuration['parameters'])

--- a/lib/datadog/appsec/response.rb
+++ b/lib/datadog/appsec/response.rb
@@ -28,10 +28,32 @@ module Datadog
       end
 
       class << self
-        def negotiate(env)
-          content_type = content_type(env)
+        def negotiate(env, actions)
+          # @type var configured_response: Response?
+          configured_response = nil
+          actions.each do |action|
+            # Need to use next to make steep happy :(
+            # I rather use break to stop the execution
+            next if configured_response
 
-          Datadog.logger.debug { "negotiated response content type: #{content_type}" }
+            action_configuration = AppSec::Processor::Actions.fecth_configuration(action)
+            next unless action_configuration
+
+            configured_response = case action
+                                  when 'block'
+                                    block_response(env, action_configuration['parameters'])
+                                  when 'redirect_request'
+                                    redirect_response(env, action_configuration['parameters'])
+                                  end
+          end
+
+          configured_response || default_response(env)
+        end
+
+        private
+
+        def default_response(env)
+          content_type = content_type(env)
 
           body = []
           body << content(content_type)
@@ -43,12 +65,53 @@ module Datadog
           )
         end
 
-        private
+        def block_response(env, options)
+          content_type = if options['type'] == 'auto'
+                           content_type(env)
+                         else
+                           FORMAT_TO_CONTENT_TYPE[options['type']]
+                         end
+
+          body = []
+          body << content(content_type)
+
+          Response.new(
+            status: options['status_code'] || 403,
+            headers: { 'Content-Type' => content_type },
+            body: body,
+          )
+        end
+
+        def redirect_response(env, options)
+          if options['location'] && !options['location'].empty?
+            content_type = content_type(env)
+
+            status = options['status_code'] >= 300 && options['status_code'] < 400 ? options['status_code'] : 303
+
+            headers = {
+              'Content-Type' => content_type,
+              'Location' => options['location']
+            }
+
+            Response.new(
+              status: status,
+              headers: headers,
+              body: [],
+            )
+          else
+            default_response(env)
+          end
+        end
 
         CONTENT_TYPE_TO_FORMAT = {
           'application/json' => :json,
           'text/html' => :html,
           'text/plain' => :text,
+        }.freeze
+
+        FORMAT_TO_CONTENT_TYPE = {
+          'json' => 'application/json',
+          'html' => 'text/html',
         }.freeze
 
         DEFAULT_CONTENT_TYPE = 'application/json'

--- a/sig/datadog/appsec.rbs
+++ b/sig/datadog/appsec.rbs
@@ -4,7 +4,7 @@ module Datadog
 
     def self.processor: () -> Datadog::AppSec::Processor?
 
-    def self.reconfigure: (ruleset: ::Hash[untyped, untyped]) -> void
+    def self.reconfigure: (ruleset: ::Hash[untyped, untyped], actions: Array[Hash[String, untyped]]) -> void
 
     def self.reconfigure_lock: () { () -> void } -> void
 

--- a/sig/datadog/appsec/component.rbs
+++ b/sig/datadog/appsec/component.rbs
@@ -12,7 +12,7 @@ module Datadog
 
       def initialize: (processor: Datadog::AppSec::Processor?) -> void
 
-      def self.reconfigure: (ruleset: ::Hash[untyped, untyped]) -> void
+      def self.reconfigure: (ruleset: ::Hash[untyped, untyped], actions: Array[Hash[String, untyped]]) -> void
 
       def self.reconfigure_lock: () { () -> void } -> void
 

--- a/sig/datadog/appsec/processor/actions.rbs
+++ b/sig/datadog/appsec/processor/actions.rbs
@@ -1,0 +1,18 @@
+module Datadog
+  module AppSec
+    class Processor
+      module Actions
+        self.@actions: Array[Hash[String, untyped]]
+
+        def self.actions: () -> Array[Hash[String, untyped]]
+
+        def self.fecth_configuration: (String action) -> Hash[String, untyped]?
+
+        def self.merge: (Array[Hash[String, untyped]] actions_to_merge) -> Array[Hash[String, untyped]]?
+
+        private
+        def self.reset: () -> void
+      end
+    end
+  end
+end

--- a/sig/datadog/appsec/response.rbs
+++ b/sig/datadog/appsec/response.rbs
@@ -11,12 +11,17 @@ module Datadog
       def to_sinatra_response: () -> ::Sinatra::Response
       def to_action_dispatch_response: () -> ::ActionDispatch::Response
 
-      def self.negotiate: (::Hash[untyped, untyped] env) -> Response
+      def self.negotiate: (::Hash[untyped, untyped] env, Array[String] actions) -> Response
 
       private
 
       CONTENT_TYPE_TO_FORMAT: ::Hash[::String, ::Symbol]
+      FORMAT_TO_CONTENT_TYPE: ::Hash[::String, ::String]
       DEFAULT_CONTENT_TYPE: ::String
+
+      def self.default_response: (::Hash[untyped, untyped] env) -> Response
+      def self.block_response: (::Hash[untyped, untyped] env, ::Hash[String, untyped] options) -> Response
+      def self.redirect_response: (::Hash[untyped, untyped] env, ::Hash[String, untyped] options) -> Response
 
       def self.content_type: (::Hash[untyped, untyped] env) -> ::String
       def self.content: (::String) -> ::String

--- a/spec/datadog/appsec/contrib/rack/reactive/request_body_spec.rb
+++ b/spec/datadog/appsec/contrib/rack/reactive/request_body_spec.rb
@@ -57,11 +57,10 @@ RSpec.describe Datadog::AppSec::Contrib::Rack::Reactive::RequestBody do
       it 'yields result and no blocking action' do
         expect(operation).to receive(:subscribe).and_call_original
 
-        waf_result = double(:waf_result, status: :match, timeout: false, actions: [''])
+        waf_result = double(:waf_result, status: :match, timeout: false, actions: [])
         expect(waf_context).to receive(:run).and_return(waf_result)
-        described_class.subscribe(operation, waf_context) do |result, block|
+        described_class.subscribe(operation, waf_context) do |result|
           expect(result).to eq(waf_result)
-          expect(block).to eq(false)
         end
         result = described_class.publish(operation, request)
         expect(result).to be_nil
@@ -72,13 +71,11 @@ RSpec.describe Datadog::AppSec::Contrib::Rack::Reactive::RequestBody do
 
         waf_result = double(:waf_result, status: :match, timeout: false, actions: ['block'])
         expect(waf_context).to receive(:run).and_return(waf_result)
-        described_class.subscribe(operation, waf_context) do |result, block|
+        described_class.subscribe(operation, waf_context) do |result|
           expect(result).to eq(waf_result)
-          expect(block).to eq(true)
         end
-        publish_result, publish_block = described_class.publish(operation, request)
-        expect(publish_result).to eq(waf_result)
-        expect(publish_block).to eq(true)
+        block = described_class.publish(operation, request)
+        expect(block).to eq(true)
       end
     end
 

--- a/spec/datadog/appsec/contrib/rack/reactive/request_spec.rb
+++ b/spec/datadog/appsec/contrib/rack/reactive/request_spec.rb
@@ -76,11 +76,10 @@ RSpec.describe Datadog::AppSec::Contrib::Rack::Reactive::Request do
       it 'yields result and no blocking action' do
         expect(operation).to receive(:subscribe).and_call_original
 
-        waf_result = double(:waf_result, status: :match, timeout: false, actions: [''])
+        waf_result = double(:waf_result, status: :match, timeout: false, actions: [])
         expect(waf_context).to receive(:run).and_return(waf_result)
-        described_class.subscribe(operation, waf_context) do |result, block|
+        described_class.subscribe(operation, waf_context) do |result|
           expect(result).to eq(waf_result)
-          expect(block).to eq(false)
         end
         result = described_class.publish(operation, request)
         expect(result).to be_nil
@@ -91,13 +90,11 @@ RSpec.describe Datadog::AppSec::Contrib::Rack::Reactive::Request do
 
         waf_result = double(:waf_result, status: :match, timeout: false, actions: ['block'])
         expect(waf_context).to receive(:run).and_return(waf_result)
-        described_class.subscribe(operation, waf_context) do |result, block|
+        described_class.subscribe(operation, waf_context) do |result|
           expect(result).to eq(waf_result)
-          expect(block).to eq(true)
         end
-        publish_result, publish_block = described_class.publish(operation, request)
-        expect(publish_result).to eq(waf_result)
-        expect(publish_block).to eq(true)
+        block = described_class.publish(operation, request)
+        expect(block).to eq(true)
       end
     end
 

--- a/spec/datadog/appsec/contrib/rack/reactive/response_spec.rb
+++ b/spec/datadog/appsec/contrib/rack/reactive/response_spec.rb
@@ -71,11 +71,10 @@ RSpec.describe Datadog::AppSec::Contrib::Rack::Reactive::Response do
       it 'yields result and no blocking action' do
         expect(operation).to receive(:subscribe).and_call_original
 
-        waf_result = double(:waf_result, status: :match, timeout: false, actions: [''])
+        waf_result = double(:waf_result, status: :match, timeout: false, actions: [])
         expect(processor_context).to receive(:run).and_return(waf_result)
-        described_class.subscribe(operation, processor_context) do |result, block|
+        described_class.subscribe(operation, processor_context) do |result|
           expect(result).to eq(waf_result)
-          expect(block).to eq(false)
         end
         result = described_class.publish(operation, response)
         expect(result).to be_nil
@@ -86,13 +85,11 @@ RSpec.describe Datadog::AppSec::Contrib::Rack::Reactive::Response do
 
         waf_result = double(:waf_result, status: :match, timeout: false, actions: ['block'])
         expect(processor_context).to receive(:run).and_return(waf_result)
-        described_class.subscribe(operation, processor_context) do |result, block|
+        described_class.subscribe(operation, processor_context) do |result|
           expect(result).to eq(waf_result)
-          expect(block).to eq(true)
         end
-        publish_result, publish_block = described_class.publish(operation, response)
-        expect(publish_result).to eq(waf_result)
-        expect(publish_block).to eq(true)
+        block = described_class.publish(operation, response)
+        expect(block).to eq(true)
       end
     end
 

--- a/spec/datadog/appsec/contrib/rails/reactive/action_spec.rb
+++ b/spec/datadog/appsec/contrib/rails/reactive/action_spec.rb
@@ -65,14 +65,13 @@ RSpec.describe Datadog::AppSec::Contrib::Rails::Reactive::Action do
       it 'yields result and no blocking action' do
         expect(operation).to receive(:subscribe).and_call_original
 
-        waf_result = double(:waf_result, status: :match, timeout: false, actions: [''])
+        waf_result = double(:waf_result, status: :match, timeout: false, actions: [])
         expect(waf_context).to receive(:run).and_return(waf_result)
-        described_class.subscribe(operation, waf_context) do |result, block|
+        described_class.subscribe(operation, waf_context) do |result|
           expect(result).to eq(waf_result)
-          expect(block).to eq(false)
         end
-        result = described_class.publish(operation, request)
-        expect(result).to be_nil
+        block = described_class.publish(operation, request)
+        expect(block).to be_nil
       end
 
       it 'yields result and blocking action. The publish method catches the resul as well' do
@@ -80,13 +79,11 @@ RSpec.describe Datadog::AppSec::Contrib::Rails::Reactive::Action do
 
         waf_result = double(:waf_result, status: :match, timeout: false, actions: ['block'])
         expect(waf_context).to receive(:run).and_return(waf_result)
-        described_class.subscribe(operation, waf_context) do |result, block|
+        described_class.subscribe(operation, waf_context) do |result|
           expect(result).to eq(waf_result)
-          expect(block).to eq(true)
         end
-        publish_result, publish_block = described_class.publish(operation, request)
-        expect(publish_result).to eq(waf_result)
-        expect(publish_block).to eq(true)
+        block = described_class.publish(operation, request)
+        expect(block).to eq(true)
       end
     end
 

--- a/spec/datadog/appsec/contrib/sinatra/reactive/routed_spec.rb
+++ b/spec/datadog/appsec/contrib/sinatra/reactive/routed_spec.rb
@@ -61,11 +61,10 @@ RSpec.describe Datadog::AppSec::Contrib::Sinatra::Reactive::Routed do
       it 'yields result and no blocking action' do
         expect(operation).to receive(:subscribe).and_call_original
 
-        waf_result = double(:waf_result, status: :match, timeout: false, actions: [''])
+        waf_result = double(:waf_result, status: :match, timeout: false, actions: [])
         expect(waf_context).to receive(:run).and_return(waf_result)
-        described_class.subscribe(operation, waf_context) do |result, block|
+        described_class.subscribe(operation, waf_context) do |result|
           expect(result).to eq(waf_result)
-          expect(block).to eq(false)
         end
         result = described_class.publish(operation, [request, routed_params])
         expect(result).to be_nil
@@ -76,13 +75,11 @@ RSpec.describe Datadog::AppSec::Contrib::Sinatra::Reactive::Routed do
 
         waf_result = double(:waf_result, status: :match, timeout: false, actions: ['block'])
         expect(waf_context).to receive(:run).and_return(waf_result)
-        described_class.subscribe(operation, waf_context) do |result, block|
+        described_class.subscribe(operation, waf_context) do |result|
           expect(result).to eq(waf_result)
-          expect(block).to eq(true)
         end
-        publish_result, publish_block = described_class.publish(operation, [request, routed_params])
-        expect(publish_result).to eq(waf_result)
-        expect(publish_block).to eq(true)
+        block = described_class.publish(operation, [request, routed_params])
+        expect(block).to eq(true)
       end
     end
 

--- a/spec/datadog/appsec/monitor/reactive/set_user_spec.rb
+++ b/spec/datadog/appsec/monitor/reactive/set_user_spec.rb
@@ -48,11 +48,10 @@ RSpec.describe Datadog::AppSec::Monitor::Reactive::SetUser do
       it 'yields result and no blocking action' do
         expect(operation).to receive(:subscribe).and_call_original
 
-        waf_result = double(:waf_result, status: :match, timeout: false, actions: [''])
+        waf_result = double(:waf_result, status: :match, timeout: false, actions: [])
         expect(waf_context).to receive(:run).and_return(waf_result)
-        described_class.subscribe(operation, waf_context) do |result, block|
+        described_class.subscribe(operation, waf_context) do |result|
           expect(result).to eq(waf_result)
-          expect(block).to eq(false)
         end
         result = described_class.publish(operation, user)
         expect(result).to be_nil
@@ -63,13 +62,11 @@ RSpec.describe Datadog::AppSec::Monitor::Reactive::SetUser do
 
         waf_result = double(:waf_result, status: :match, timeout: false, actions: ['block'])
         expect(waf_context).to receive(:run).and_return(waf_result)
-        described_class.subscribe(operation, waf_context) do |result, block|
+        described_class.subscribe(operation, waf_context) do |result|
           expect(result).to eq(waf_result)
-          expect(block).to eq(true)
         end
-        publish_result, publish_block = described_class.publish(operation, user)
-        expect(publish_result).to eq(waf_result)
-        expect(publish_block).to eq(true)
+        block = described_class.publish(operation, user)
+        expect(block).to eq(true)
       end
     end
 

--- a/spec/datadog/appsec/processor/actions_spec.rb
+++ b/spec/datadog/appsec/processor/actions_spec.rb
@@ -1,0 +1,104 @@
+require 'datadog/appsec/spec_helper'
+require 'datadog/appsec/processor/actions'
+
+RSpec.describe Datadog::AppSec::Processor::Actions do
+  after do
+    described_class.send(:reset)
+  end
+
+  let(:actions) do
+    [
+      {
+        'id' => 'block',
+        'parameters' => {
+          'type' => 'auto',
+          'status_code' => 403,
+
+        }
+      }
+    ]
+  end
+
+  describe '.merge' do
+    context 'empty actions' do
+      it 'stores the actions' do
+        described_class.merge(actions)
+        expect(described_class.actions).to eq(actions)
+      end
+    end
+
+    context 'no empty actions' do
+      it 'merges' do
+        described_class.merge(actions)
+        expect(described_class.actions).to eq(actions)
+
+        actions_to_merge = [
+          {
+            'id' => 'redirect_request',
+            'parameters' => {
+              'location' => 'foo',
+              'status_code' => 303,
+
+            }
+          }
+        ]
+
+        expectd_result = []
+        expectd_result.concat(actions)
+        expectd_result.concat(actions_to_merge)
+
+        described_class.merge(actions_to_merge)
+
+        expect(described_class.actions).to match_array(expectd_result)
+      end
+
+      it 'merges and updates exiting ones' do
+        described_class.merge(actions)
+        expect(described_class.actions).to eq(actions)
+
+        actions_to_merge = [
+          {
+            'id' => 'block',
+            'parameters' => {
+              'type' => 'html',
+              'status_code' => 403,
+
+            }
+          },
+          {
+            'id' => 'redirect_request',
+            'parameters' => {
+              'location' => 'foo',
+              'status_code' => 303,
+
+            }
+          }
+        ]
+
+        described_class.merge(actions_to_merge)
+        expect(described_class.actions).to eq(actions_to_merge)
+      end
+    end
+  end
+
+  describe '.fecth_configuration' do
+    it 'returns the existing configuration' do
+      described_class.merge(actions)
+      expect(described_class.fecth_configuration('block')).to eq(
+        {
+          'id' => 'block',
+          'parameters' => {
+            'type' => 'auto',
+            'status_code' => 403,
+
+          }
+        }
+      )
+    end
+
+    it 'returns nil if no configuration matches' do
+      described_class.merge(actions)
+      expect(described_class.fecth_configuration('fake')).to be_nil
+    end
+  end
+end

--- a/spec/datadog/appsec/response_spec.rb
+++ b/spec/datadog/appsec/response_spec.rb
@@ -3,20 +3,203 @@ require 'datadog/appsec/response'
 RSpec.describe Datadog::AppSec::Response do
   describe '.negotiate' do
     let(:env) { double }
+    let(:actions) { [] }
 
     before do
       allow(env).to receive(:key?).with('HTTP_ACCEPT').and_return(true)
       allow(env).to receive(:[]).with('HTTP_ACCEPT').and_return('text/html')
+      Datadog::AppSec::Processor::Actions.merge(actions)
+    end
+
+    after do
+      Datadog::AppSec::Processor::Actions.send(:reset)
+    end
+
+    describe 'configured actions' do
+      describe 'block' do
+        let(:actions) do
+          [
+            {
+              'id' => 'block',
+              'parameters' => {
+                'type' => type,
+                'status_code' => status_code,
+
+              }
+            }
+          ]
+        end
+
+        let(:type) { 'html' }
+        let(:status_code) { 100 }
+
+        context 'status_code' do
+          subject(:status) { described_class.negotiate(env, ['block']).status }
+
+          it { is_expected.to eq 100 }
+
+          context 'configured action do not have status defined. Defaults to 403' do
+            let(:status_code) { nil }
+
+            it { is_expected.to eq 403 }
+          end
+        end
+
+        context 'body' do
+          subject(:body) { described_class.negotiate(env, ['block']).body }
+
+          it { is_expected.to eq [Datadog::AppSec::Assets.blocked(format: :html)] }
+
+          context 'type is auto it uses the HTTP_ACCEPT to decide the result' do
+            let(:type) { 'auto' }
+
+            before do
+              expect(env).to receive(:key?).with('HTTP_ACCEPT').and_return(true)
+              expect(env).to receive(:[]).with('HTTP_ACCEPT').and_return('application/json')
+            end
+
+            it { is_expected.to eq [Datadog::AppSec::Assets.blocked(format: :json)] }
+          end
+        end
+
+        context 'headers' do
+          subject(:header) { described_class.negotiate(env, ['block']).headers['Content-Type'] }
+
+          it { is_expected.to eq 'text/html' }
+
+          context 'type is auto it uses the HTTP_ACCEPT to decide the result' do
+            let(:type) { 'auto' }
+
+            before do
+              expect(env).to receive(:key?).with('HTTP_ACCEPT').and_return(true)
+              expect(env).to receive(:[]).with('HTTP_ACCEPT').and_return('application/json')
+            end
+
+            it { is_expected.to eq 'application/json' }
+          end
+        end
+
+        context 'no specify action' do
+          subject(:response) { described_class.negotiate(env, []) }
+
+          it 'uses default response' do
+            expect(response.status).to eq 403
+            expect(response.body).to eq [Datadog::AppSec::Assets.blocked(format: :html)]
+            expect(response.headers['Content-Type']).to eq 'text/html'
+          end
+        end
+
+        context 'no configured actions' do
+          let(:actions) { [] }
+          subject(:response) { described_class.negotiate(env, []) }
+
+          it 'uses default response' do
+            expect(response.status).to eq 403
+            expect(response.body).to eq [Datadog::AppSec::Assets.blocked(format: :html)]
+            expect(response.headers['Content-Type']).to eq 'text/html'
+          end
+        end
+      end
+
+      describe 'redirect_request' do
+        let(:actions) do
+          [
+            {
+              'id' => 'redirect_request',
+              'parameters' => {
+                'location' => location,
+                'status_code' => status_code,
+
+              }
+            }
+          ]
+        end
+
+        let(:location) { 'foo' }
+        let(:status_code) { 303 }
+
+        context 'status_code' do
+          subject(:status) { described_class.negotiate(env, ['redirect_request']).status }
+
+          it { is_expected.to eq 303 }
+
+          context 'when status code do not starts with 3' do
+            let(:status_code) { 202 }
+
+            it { is_expected.to eq 303 }
+          end
+        end
+
+        context 'body' do
+          subject(:body) { described_class.negotiate(env, ['redirect_request']).body }
+
+          it { is_expected.to eq [] }
+        end
+
+        context 'headers' do
+          subject(:headers) { described_class.negotiate(env, ['redirect_request']).headers }
+
+          context 'Content-Type' do
+            before do
+              expect(env).to receive(:key?).with('HTTP_ACCEPT').and_return(true)
+              expect(env).to receive(:[]).with('HTTP_ACCEPT').and_return('application/json')
+            end
+
+            it 'uses the one from HTTP_ACCEPT header' do
+              expect(headers['Content-Type']).to eq('application/json')
+            end
+          end
+
+          context 'Location' do
+            it 'uses the one from the configuration' do
+              expect(headers['Location']).to eq('foo')
+            end
+          end
+        end
+
+        context 'no specify action' do
+          subject(:response) { described_class.negotiate(env, []) }
+
+          it 'uses default response' do
+            expect(response.status).to eq 403
+            expect(response.body).to eq [Datadog::AppSec::Assets.blocked(format: :html)]
+            expect(response.headers['Content-Type']).to eq 'text/html'
+          end
+        end
+
+        context 'location is empty' do
+          let(:location) { '' }
+
+          subject(:response) { described_class.negotiate(env, []) }
+
+          it 'uses default response' do
+            expect(response.status).to eq 403
+            expect(response.body).to eq [Datadog::AppSec::Assets.blocked(format: :html)]
+            expect(response.headers['Content-Type']).to eq 'text/html'
+          end
+        end
+
+        context 'no configured actions' do
+          let(:actions) { [] }
+          subject(:response) { described_class.negotiate(env, []) }
+
+          it 'uses default response' do
+            expect(response.status).to eq 403
+            expect(response.body).to eq [Datadog::AppSec::Assets.blocked(format: :html)]
+            expect(response.headers['Content-Type']).to eq 'text/html'
+          end
+        end
+      end
     end
 
     describe '.status' do
-      subject(:status) { described_class.negotiate(env).status }
+      subject(:status) { described_class.negotiate(env, []).status }
 
       it { is_expected.to eq 403 }
     end
 
     describe '.body' do
-      subject(:body) { described_class.negotiate(env).body }
+      subject(:body) { described_class.negotiate(env, []).body }
 
       before do
         expect(env).to receive(:key?).with('HTTP_ACCEPT').and_return(true)
@@ -69,7 +252,7 @@ RSpec.describe Datadog::AppSec::Response do
     end
 
     describe ".headers['Content-Type']" do
-      subject(:content_type) { described_class.negotiate(env).headers['Content-Type'] }
+      subject(:content_type) { described_class.negotiate(env, []).headers['Content-Type'] }
 
       before do
         expect(env).to receive(:key?).with('HTTP_ACCEPT').and_return(respond_to?(:accept))

--- a/spec/datadog/appsec/response_spec.rb
+++ b/spec/datadog/appsec/response_spec.rb
@@ -21,6 +21,7 @@ RSpec.describe Datadog::AppSec::Response do
           [
             {
               'id' => 'block',
+              'type' => 'block_request',
               'parameters' => {
                 'type' => type,
                 'status_code' => status_code,
@@ -106,6 +107,7 @@ RSpec.describe Datadog::AppSec::Response do
           [
             {
               'id' => 'redirect_request',
+              'type' => 'redirect_request',
               'parameters' => {
                 'location' => location,
                 'status_code' => status_code,


### PR DESCRIPTION
<!--
Check out the
https://github.com/DataDog/dd-trace-rb/blob/master/docs/DevelopmentGuide.md
for guidance on how to set up your development environment,
run the test suite, write new integrations, and more.
-->

**What does this PR do?**
<!-- A brief description of the change being made with this pull request. -->

Update ASM to be able to configure the blocking response via Remote Configuration.

**Motivation:**
<!-- What inspired you to submit this pull request? -->

Allow customers to change the blocking response via the DD UI

The PR includes multiple changes:
- Update the ASM remote capabilities 
- Store in memory the actions configured via the DD UI. `AppSec::Processor::Actions` apart from storing in memory, we need to merge existing actions with the ones coming from the Remote Configuration and merging.  
The logic for merging replaces existing actions with new ones coming from remote configuration and keeps the ones not updated. 
- Modify the `AppSec::Response.negotiate` method to account for the WAF result actions and the configured information


**Additional Notes:**
<!-- Anything else we should know when reviewing? -->

I've removed unused returned values from the methods `Reactive::<Class>.subscribe`, and `Reactive::<Class>.publish`

The returned values from the reactive engine are plain arrays ex: `[:block, event]` or `[:monitor, event]` those could be refactored into their own classes `AppSec::Processor::Actions::Block` and `AppSec::Processor::Actions::Monitor`. I left that exercise to a future PR. 


**How to test the change?**
<!--
Describe here how the change can be validated.
You are strongly encouraged to provide automated tests for this PR (unit or integration).
If this change cannot be feasibly tested, please explain why,
unless the change does not modify code (e.g. only modifies docs, comments).
-->

**For Datadog employees:**
- [ ] If this PR touches code that signs or publishes builds or packages, or handles
credentials of any kind, I've requested a review from `@DataDog/security-design-and-guidance`.
- [x] This PR doesn't touch any of that.

Unsure? Have a question? Request a review!
