### PR TITLE
Fix tagging with empty data

### DIFF
--- a/lib/datadog/tracing/metadata/tagging.rb
+++ b/lib/datadog/tracing/metadata/tagging.rb
@@ -59,8 +59,8 @@ module Datadog
         # A valid example is:
         #
         #   span.set_tags({ "http.method" => "GET", "user.id" => "234" })
-        def set_tags(tags)
-          tags.each { |k, v| set_tag(k, v) }
+        def set_tags(hash)
+          hash.each { |k, v| set_tag(k, v) }
         end
 
         # Returns true if the provided `tag` was set to a non-nil value.
@@ -111,7 +111,7 @@ module Datadog
         # Returns a copy of all metadata.
         # Keys for `@meta` and `@metrics` don't collide, by construction.
         def tags
-          @meta.merge(@metrics)
+          meta.merge(metrics)
         end
 
         protected

--- a/spec/datadog/tracing/metadata/tagging_spec.rb
+++ b/spec/datadog/tracing/metadata/tagging_spec.rb
@@ -370,4 +370,22 @@ RSpec.describe Datadog::Tracing::Metadata::Tagging do
       expect(test_object.send(:metrics)).to_not have_key(key)
     end
   end
+
+  describe '#tags' do
+    it 'returns a hash' do
+      expect(test_object.tags).to eq({})
+    end
+
+    it 'returns a hash contains meta' do
+      test_object.set_tag('foo', 'bar')
+
+      expect(test_object.tags).to eq({ 'foo' => 'bar' })
+    end
+
+    it 'returns a hash contains metric' do
+      test_object.set_metric('count', 1.0)
+
+      expect(test_object.tags).to eq({ 'count' => 1.0 })
+    end
+  end
 end


### PR DESCRIPTION

fixes https://github.com/DataDog/dd-trace-rb/issues/3088

**What does this PR do?**

An object includes Tagging module, but `#tags` method raise `NoMethodError: undefined method 'merge' for nil:NilClass` or `TypeError: no implicit conversion of nil into Hash` 

Because the instance variables are `nil`. 

The fix is to replace instance variable with protected attribute reader.