### PR TITLE
[PROF-8139] Upgrade to libdatadog 4

### DIFF
--- a/ddtrace.gemspec
+++ b/ddtrace.gemspec
@@ -66,7 +66,7 @@ Gem::Specification.new do |spec|
 
   # Used by profiling (and possibly others in the future)
   # When updating the version here, please also update the version in `native_extension_helpers.rb` (and yes we have a test for it)
-  spec.add_dependency 'libdatadog', '~> 3.0.0.1.0'
+  spec.add_dependency 'libdatadog', '~> 4.0.0.1.0'
 
   spec.extensions = ['ext/ddtrace_profiling_native_extension/extconf.rb', 'ext/ddtrace_profiling_loader/extconf.rb']
 end

--- a/ext/ddtrace_profiling_native_extension/native_extension_helpers.rb
+++ b/ext/ddtrace_profiling_native_extension/native_extension_helpers.rb
@@ -15,7 +15,7 @@ module Datadog
       # The MJIT header was introduced on 2.6 and removed on 3.3; for other Rubies we rely on debase-ruby_core_source
       CAN_USE_MJIT_HEADER = RUBY_VERSION.start_with?('2.6', '2.7', '3.0.', '3.1.', '3.2.')
 
-      LIBDATADOG_VERSION = '~> 3.0.0.1.0'
+      LIBDATADOG_VERSION = '~> 4.0.0.1.0'
 
       def self.fail_install_if_missing_extension?
         ENV[ENV_FAIL_INSTALL_IF_MISSING_EXTENSION].to_s.strip.downcase == 'true'

--- a/ext/ddtrace_profiling_native_extension/stack_recorder.c
+++ b/ext/ddtrace_profiling_native_extension/stack_recorder.c
@@ -165,10 +165,10 @@ static const uint8_t all_value_types_positions[] = {CPU_TIME_VALUE_ID, CPU_SAMPL
 // Contains native state for each instance
 struct stack_recorder_state {
   pthread_mutex_t slot_one_mutex;
-  ddog_prof_Profile *slot_one_profile;
+  ddog_prof_Profile slot_one_profile;
 
   pthread_mutex_t slot_two_mutex;
-  ddog_prof_Profile *slot_two_profile;
+  ddog_prof_Profile slot_two_profile;
 
   short active_slot; // MUST NEVER BE ACCESSED FROM record_sample; this is NOT for the sampler thread to use.
 
@@ -211,8 +211,9 @@ static VALUE _native_is_slot_two_mutex_locked(DDTRACE_UNUSED VALUE _self, VALUE 
 static VALUE test_slot_mutex_state(VALUE recorder_instance, int slot);
 static ddog_Timespec system_epoch_now_timespec(void);
 static VALUE _native_reset_after_fork(DDTRACE_UNUSED VALUE self, VALUE recorder_instance);
-static void serializer_set_start_timestamp_for_next_profile(struct stack_recorder_state *state, ddog_Timespec timestamp);
+static void serializer_set_start_timestamp_for_next_profile(struct stack_recorder_state *state, ddog_Timespec start_time);
 static VALUE _native_record_endpoint(DDTRACE_UNUSED VALUE _self, VALUE recorder_instance, VALUE local_root_span_id, VALUE endpoint);
+static void reset_profile(ddog_prof_Profile *profile, ddog_Timespec *start_time /* Can be null */);
 
 void stack_recorder_init(VALUE profiling_module) {
   stack_recorder_class = rb_define_class_under(profiling_module, "StackRecorder", rb_cObject);
@@ -284,10 +285,10 @@ static void stack_recorder_typed_data_free(void *state_ptr) {
   struct stack_recorder_state *state = (struct stack_recorder_state *) state_ptr;
 
   pthread_mutex_destroy(&state->slot_one_mutex);
-  ddog_prof_Profile_drop(state->slot_one_profile);
+  ddog_prof_Profile_drop(&state->slot_one_profile);
 
   pthread_mutex_destroy(&state->slot_two_mutex);
-  ddog_prof_Profile_drop(state->slot_two_profile);
+  ddog_prof_Profile_drop(&state->slot_two_profile);
 
   ruby_xfree(state);
 }
@@ -335,8 +336,8 @@ static VALUE _native_initialize(DDTRACE_UNUSED VALUE _self, VALUE recorder_insta
 
   ddog_prof_Slice_ValueType sample_types = {.ptr = enabled_value_types, .len = state->enabled_values_count};
 
-  ddog_prof_Profile_drop(state->slot_one_profile);
-  ddog_prof_Profile_drop(state->slot_two_profile);
+  ddog_prof_Profile_drop(&state->slot_one_profile);
+  ddog_prof_Profile_drop(&state->slot_two_profile);
 
   state->slot_one_profile = ddog_prof_Profile_new(sample_types, NULL /* period is optional */, NULL /* start_time is optional */);
   state->slot_two_profile = ddog_prof_Profile_new(sample_types, NULL /* period is optional */, NULL /* start_time is optional */);
@@ -386,8 +387,9 @@ static VALUE _native_serialize(DDTRACE_UNUSED VALUE _self, VALUE recorder_instan
   VALUE start = ruby_time_from(ddprof_start);
   VALUE finish = ruby_time_from(ddprof_finish);
 
-  if (!ddog_prof_Profile_reset(args.profile, NULL /* start_time is optional */ )) {
-    return rb_ary_new_from_args(2, error_symbol, rb_str_new_cstr("Failed to reset profile"));
+  ddog_prof_Profile_Result reset_result = ddog_prof_Profile_reset(args.profile, NULL /* start_time is optional */ );
+  if (reset_result.tag == DDOG_PROF_PROFILE_RESULT_ERR) {
+    return rb_ary_new_from_args(2, error_symbol, rb_sprintf("Failed to reset profile: %"PRIsVALUE, get_error_details_and_drop(&reset_result.err)));
   }
 
   return rb_ary_new_from_args(2, ok_symbol, rb_ary_new_from_args(3, start, finish, encoded_pprof));
@@ -417,7 +419,7 @@ void record_sample(VALUE recorder_instance, ddog_prof_Slice_Location locations, 
   metric_values[position_for[WALL_TIME_VALUE_ID]]     = values.wall_time_ns;
   metric_values[position_for[ALLOC_SAMPLES_VALUE_ID]] = values.alloc_samples;
 
-  ddog_prof_Profile_AddResult result = ddog_prof_Profile_add(
+  ddog_prof_Profile_Result result = ddog_prof_Profile_add(
     active_slot.profile,
     (ddog_prof_Sample) {
       .locations = locations,
@@ -428,7 +430,7 @@ void record_sample(VALUE recorder_instance, ddog_prof_Slice_Location locations, 
 
   sampler_unlock_active_profile(active_slot);
 
-  if (result.tag == DDOG_PROF_PROFILE_ADD_RESULT_ERR) {
+  if (result.tag == DDOG_PROF_PROFILE_RESULT_ERR) {
     rb_raise(rb_eArgError, "Failed to record sample: %"PRIsVALUE, get_error_details_and_drop(&result.err));
   }
 }
@@ -439,9 +441,13 @@ void record_endpoint(VALUE recorder_instance, uint64_t local_root_span_id, ddog_
 
   struct active_slot_pair active_slot = sampler_lock_active_profile(state);
 
-  ddog_prof_Profile_set_endpoint(active_slot.profile, local_root_span_id, endpoint);
+  ddog_prof_Profile_Result result = ddog_prof_Profile_set_endpoint(active_slot.profile, local_root_span_id, endpoint);
 
   sampler_unlock_active_profile(active_slot);
+
+  if (result.tag == DDOG_PROF_PROFILE_RESULT_ERR) {
+    rb_raise(rb_eArgError, "Failed to record endpoint: %"PRIsVALUE, get_error_details_and_drop(&result.err));
+  }
 }
 
 static void *call_serialize_without_gvl(void *call_args) {
@@ -467,7 +473,7 @@ static struct active_slot_pair sampler_lock_active_profile(struct stack_recorder
     if (error && error != EBUSY) ENFORCE_SUCCESS_GVL(error);
 
     // Slot one is active
-    if (!error) return (struct active_slot_pair) {.mutex = &state->slot_one_mutex, .profile = state->slot_one_profile};
+    if (!error) return (struct active_slot_pair) {.mutex = &state->slot_one_mutex, .profile = &state->slot_one_profile};
 
     // If we got here, slot one was not active, let's try slot two
 
@@ -475,7 +481,7 @@ static struct active_slot_pair sampler_lock_active_profile(struct stack_recorder
     if (error && error != EBUSY) ENFORCE_SUCCESS_GVL(error);
 
     // Slot two is active
-    if (!error) return (struct active_slot_pair) {.mutex = &state->slot_two_mutex, .profile = state->slot_two_profile};
+    if (!error) return (struct active_slot_pair) {.mutex = &state->slot_two_mutex, .profile = &state->slot_two_profile};
   }
 
   // We already tried both multiple times, and we did not succeed. This is not expected to happen. Let's stop sampling.
@@ -506,7 +512,7 @@ static ddog_prof_Profile *serializer_flip_active_and_inactive_slots(struct stack
   state->active_slot = (previously_active_slot == 1) ? 2 : 1;
 
   // Return profile for previously active slot (now inactive)
-  return (previously_active_slot == 1) ? state->slot_one_profile : state->slot_two_profile;
+  return (previously_active_slot == 1) ? &state->slot_one_profile : &state->slot_two_profile;
 }
 
 // This method exists only to enable testing Datadog::Profiling::StackRecorder behavior using RSpec.
@@ -565,23 +571,29 @@ static VALUE _native_reset_after_fork(DDTRACE_UNUSED VALUE self, VALUE recorder_
   // resulting state is inconsistent, we make sure to reset it back to the initial state.
   initialize_slot_concurrency_control(state);
 
-  ddog_prof_Profile_reset(state->slot_one_profile, /* start_time: */ NULL);
-  ddog_prof_Profile_reset(state->slot_two_profile, /* start_time: */ NULL);
+  reset_profile(&state->slot_one_profile, /* start_time: */ NULL);
+  reset_profile(&state->slot_two_profile, /* start_time: */ NULL);
 
   return Qtrue;
 }
 
-// Assumption 1: This method is called with the GVL being held, because `ddog_prof_Profile_reset` mutates the profile and should
+// Assumption 1: This method is called with the GVL being held, because `ddog_prof_Profile_reset` mutates the profile and must
 // not be interrupted part-way through by a VM fork.
-static void serializer_set_start_timestamp_for_next_profile(struct stack_recorder_state *state, ddog_Timespec timestamp) {
-  // Before making this profile active, we reset it so that it uses the correct timestamp for its start
-  ddog_prof_Profile *next_profile = (state->active_slot == 1) ? state->slot_two_profile : state->slot_one_profile;
-
-  if (!ddog_prof_Profile_reset(next_profile, &timestamp)) rb_raise(rb_eRuntimeError, "Failed to reset profile");
+static void serializer_set_start_timestamp_for_next_profile(struct stack_recorder_state *state, ddog_Timespec start_time) {
+  // Before making this profile active, we reset it so that it uses the correct start_time for its start
+  ddog_prof_Profile *next_profile = (state->active_slot == 1) ? &state->slot_two_profile : &state->slot_one_profile;
+  reset_profile(next_profile, &start_time);
 }
 
 static VALUE _native_record_endpoint(DDTRACE_UNUSED VALUE _self, VALUE recorder_instance, VALUE local_root_span_id, VALUE endpoint) {
   ENFORCE_TYPE(local_root_span_id, T_FIXNUM);
   record_endpoint(recorder_instance, NUM2ULL(local_root_span_id), char_slice_from_ruby_string(endpoint));
   return Qtrue;
+}
+
+static void reset_profile(ddog_prof_Profile *profile, ddog_Timespec *start_time /* Can be null */) {
+  ddog_prof_Profile_Result reset_result = ddog_prof_Profile_reset(profile, start_time);
+  if (reset_result.tag == DDOG_PROF_PROFILE_RESULT_ERR) {
+    rb_raise(rb_eRuntimeError, "Failed to reset profile: %"PRIsVALUE, get_error_details_and_drop(&reset_result.err));
+  }
 }

--- a/ext/ddtrace_profiling_native_extension/stack_recorder.c
+++ b/ext/ddtrace_profiling_native_extension/stack_recorder.c
@@ -387,10 +387,8 @@ static VALUE _native_serialize(DDTRACE_UNUSED VALUE _self, VALUE recorder_instan
   VALUE start = ruby_time_from(ddprof_start);
   VALUE finish = ruby_time_from(ddprof_finish);
 
-  ddog_prof_Profile_Result reset_result = ddog_prof_Profile_reset(args.profile, NULL /* start_time is optional */ );
-  if (reset_result.tag == DDOG_PROF_PROFILE_RESULT_ERR) {
-    return rb_ary_new_from_args(2, error_symbol, rb_sprintf("Failed to reset profile: %"PRIsVALUE, get_error_details_and_drop(&reset_result.err)));
-  }
+  // This will raise on error
+  reset_profile(args.profile, /* start_time: */ NULL);
 
   return rb_ary_new_from_args(2, ok_symbol, rb_ary_new_from_args(3, start, finish, encoded_pprof));
 }

--- a/gemfiles/jruby_9.2.21.0_contrib.gemfile.lock
+++ b/gemfiles/jruby_9.2.21.0_contrib.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.14.0)
       debase-ruby_core_source (= 3.2.1)
-      libdatadog (~> 3.0.0.1.0)
+      libdatadog (~> 4.0.0.1.0)
       libddwaf (~> 1.11.0.0.0)
       msgpack
 
@@ -1609,7 +1609,7 @@ GEM
       addressable (>= 2.4)
     jsonapi-renderer (0.2.2)
     king_konf (1.0.1)
-    libdatadog (3.0.0.1.0)
+    libdatadog (4.0.0.1.0)
     libddwaf (1.11.0.0.0-java)
       ffi (~> 1.0)
     lograge (0.13.0)

--- a/gemfiles/jruby_9.2.21.0_contrib_old.gemfile.lock
+++ b/gemfiles/jruby_9.2.21.0_contrib_old.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.14.0)
       debase-ruby_core_source (= 3.2.1)
-      libdatadog (~> 3.0.0.1.0)
+      libdatadog (~> 4.0.0.1.0)
       libddwaf (~> 1.11.0.0.0)
       msgpack
 
@@ -58,7 +58,7 @@ GEM
     hashdiff (1.0.1)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (3.0.0.1.0)
+    libdatadog (4.0.0.1.0)
     libddwaf (1.11.0.0.0-java)
       ffi (~> 1.0)
     memory_profiler (0.9.14)

--- a/gemfiles/jruby_9.2.21.0_core_old.gemfile.lock
+++ b/gemfiles/jruby_9.2.21.0_core_old.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.14.0)
       debase-ruby_core_source (= 3.2.1)
-      libdatadog (~> 3.0.0.1.0)
+      libdatadog (~> 4.0.0.1.0)
       libddwaf (~> 1.11.0.0.0)
       msgpack
 
@@ -44,7 +44,7 @@ GEM
     hashdiff (1.0.1)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (3.0.0.1.0)
+    libdatadog (4.0.0.1.0)
     libddwaf (1.11.0.0.0-java)
       ffi (~> 1.0)
     memory_profiler (0.9.14)

--- a/gemfiles/jruby_9.2.21.0_cucumber3.gemfile.lock
+++ b/gemfiles/jruby_9.2.21.0_cucumber3.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.14.0)
       debase-ruby_core_source (= 3.2.1)
-      libdatadog (~> 3.0.0.1.0)
+      libdatadog (~> 4.0.0.1.0)
       libddwaf (~> 1.11.0.0.0)
       msgpack
 
@@ -62,7 +62,7 @@ GEM
     hashdiff (1.0.1)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (3.0.0.1.0)
+    libdatadog (4.0.0.1.0)
     libddwaf (1.11.0.0.0-java)
       ffi (~> 1.0)
     memory_profiler (0.9.14)

--- a/gemfiles/jruby_9.2.21.0_cucumber4.gemfile.lock
+++ b/gemfiles/jruby_9.2.21.0_cucumber4.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.14.0)
       debase-ruby_core_source (= 3.2.1)
-      libdatadog (~> 3.0.0.1.0)
+      libdatadog (~> 4.0.0.1.0)
       libddwaf (~> 1.11.0.0.0)
       msgpack
 
@@ -83,7 +83,7 @@ GEM
       concurrent-ruby (~> 1.0)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (3.0.0.1.0)
+    libdatadog (4.0.0.1.0)
     libddwaf (1.11.0.0.0-java)
       ffi (~> 1.0)
     memory_profiler (0.9.14)

--- a/gemfiles/jruby_9.2.21.0_cucumber5.gemfile.lock
+++ b/gemfiles/jruby_9.2.21.0_cucumber5.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.14.0)
       debase-ruby_core_source (= 3.2.1)
-      libdatadog (~> 3.0.0.1.0)
+      libdatadog (~> 4.0.0.1.0)
       libddwaf (~> 1.11.0.0.0)
       msgpack
 
@@ -83,7 +83,7 @@ GEM
       concurrent-ruby (~> 1.0)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (3.0.0.1.0)
+    libdatadog (4.0.0.1.0)
     libddwaf (1.11.0.0.0-java)
       ffi (~> 1.0)
     memory_profiler (0.9.14)

--- a/gemfiles/jruby_9.2.21.0_hanami_1.gemfile.lock
+++ b/gemfiles/jruby_9.2.21.0_hanami_1.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.14.0)
       debase-ruby_core_source (= 3.2.1)
-      libdatadog (~> 3.0.0.1.0)
+      libdatadog (~> 4.0.0.1.0)
       libddwaf (~> 1.11.0.0.0)
       msgpack
 
@@ -120,7 +120,7 @@ GEM
     io-wait (0.3.0-java)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (3.0.0.1.0)
+    libdatadog (4.0.0.1.0)
     libddwaf (1.11.0.0.0-java)
       ffi (~> 1.0)
     mail (2.8.0.1)

--- a/gemfiles/jruby_9.2.21.0_rails5_mysql2.gemfile.lock
+++ b/gemfiles/jruby_9.2.21.0_rails5_mysql2.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.14.0)
       debase-ruby_core_source (= 3.2.1)
-      libdatadog (~> 3.0.0.1.0)
+      libdatadog (~> 4.0.0.1.0)
       libddwaf (~> 1.11.0.0.0)
       msgpack
 
@@ -98,7 +98,7 @@ GEM
     jdbc-mysql (8.0.27)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (3.0.0.1.0)
+    libdatadog (4.0.0.1.0)
     libddwaf (1.11.0.0.0-java)
       ffi (~> 1.0)
     lograge (0.12.0)

--- a/gemfiles/jruby_9.2.21.0_rails5_postgres.gemfile.lock
+++ b/gemfiles/jruby_9.2.21.0_rails5_postgres.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.14.0)
       debase-ruby_core_source (= 3.2.1)
-      libdatadog (~> 3.0.0.1.0)
+      libdatadog (~> 4.0.0.1.0)
       libddwaf (~> 1.11.0.0.0)
       msgpack
 
@@ -100,7 +100,7 @@ GEM
     jdbc-postgres (42.2.25)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (3.0.0.1.0)
+    libdatadog (4.0.0.1.0)
     libddwaf (1.11.0.0.0-java)
       ffi (~> 1.0)
     lograge (0.12.0)

--- a/gemfiles/jruby_9.2.21.0_rails5_postgres_redis.gemfile.lock
+++ b/gemfiles/jruby_9.2.21.0_rails5_postgres_redis.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.14.0)
       debase-ruby_core_source (= 3.2.1)
-      libdatadog (~> 3.0.0.1.0)
+      libdatadog (~> 4.0.0.1.0)
       libddwaf (~> 1.11.0.0.0)
       msgpack
 
@@ -101,7 +101,7 @@ GEM
     jdbc-postgres (42.2.25)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (3.0.0.1.0)
+    libdatadog (4.0.0.1.0)
     libddwaf (1.11.0.0.0-java)
       ffi (~> 1.0)
     lograge (0.12.0)

--- a/gemfiles/jruby_9.2.21.0_rails5_postgres_redis_activesupport.gemfile.lock
+++ b/gemfiles/jruby_9.2.21.0_rails5_postgres_redis_activesupport.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.14.0)
       debase-ruby_core_source (= 3.2.1)
-      libdatadog (~> 3.0.0.1.0)
+      libdatadog (~> 4.0.0.1.0)
       libddwaf (~> 1.11.0.0.0)
       msgpack
 
@@ -100,7 +100,7 @@ GEM
     jdbc-postgres (42.2.25)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (3.0.0.1.0)
+    libdatadog (4.0.0.1.0)
     libddwaf (1.11.0.0.0-java)
       ffi (~> 1.0)
     lograge (0.12.0)

--- a/gemfiles/jruby_9.2.21.0_rails5_postgres_sidekiq.gemfile.lock
+++ b/gemfiles/jruby_9.2.21.0_rails5_postgres_sidekiq.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.14.0)
       debase-ruby_core_source (= 3.2.1)
-      libdatadog (~> 3.0.0.1.0)
+      libdatadog (~> 4.0.0.1.0)
       libddwaf (~> 1.11.0.0.0)
       msgpack
 
@@ -101,7 +101,7 @@ GEM
     jdbc-postgres (42.2.25)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (3.0.0.1.0)
+    libdatadog (4.0.0.1.0)
     libddwaf (1.11.0.0.0-java)
       ffi (~> 1.0)
     lograge (0.12.0)

--- a/gemfiles/jruby_9.2.21.0_rails5_semantic_logger.gemfile.lock
+++ b/gemfiles/jruby_9.2.21.0_rails5_semantic_logger.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.14.0)
       debase-ruby_core_source (= 3.2.1)
-      libdatadog (~> 3.0.0.1.0)
+      libdatadog (~> 4.0.0.1.0)
       libddwaf (~> 1.11.0.0.0)
       msgpack
 
@@ -100,7 +100,7 @@ GEM
     jdbc-postgres (42.2.25)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (3.0.0.1.0)
+    libdatadog (4.0.0.1.0)
     libddwaf (1.11.0.0.0-java)
       ffi (~> 1.0)
     loofah (2.19.1)

--- a/gemfiles/jruby_9.2.21.0_rails61_mysql2.gemfile.lock
+++ b/gemfiles/jruby_9.2.21.0_rails61_mysql2.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.14.0)
       debase-ruby_core_source (= 3.2.1)
-      libdatadog (~> 3.0.0.1.0)
+      libdatadog (~> 4.0.0.1.0)
       libddwaf (~> 1.11.0.0.0)
       msgpack
 
@@ -115,7 +115,7 @@ GEM
     jdbc-mysql (8.0.27)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (3.0.0.1.0)
+    libdatadog (4.0.0.1.0)
     libddwaf (1.11.0.0.0-java)
       ffi (~> 1.0)
     lograge (0.12.0)

--- a/gemfiles/jruby_9.2.21.0_rails61_postgres.gemfile.lock
+++ b/gemfiles/jruby_9.2.21.0_rails61_postgres.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.14.0)
       debase-ruby_core_source (= 3.2.1)
-      libdatadog (~> 3.0.0.1.0)
+      libdatadog (~> 4.0.0.1.0)
       libddwaf (~> 1.11.0.0.0)
       msgpack
 
@@ -117,7 +117,7 @@ GEM
     jdbc-postgres (42.2.25)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (3.0.0.1.0)
+    libdatadog (4.0.0.1.0)
     libddwaf (1.11.0.0.0-java)
       ffi (~> 1.0)
     lograge (0.12.0)

--- a/gemfiles/jruby_9.2.21.0_rails61_postgres_redis.gemfile.lock
+++ b/gemfiles/jruby_9.2.21.0_rails61_postgres_redis.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.14.0)
       debase-ruby_core_source (= 3.2.1)
-      libdatadog (~> 3.0.0.1.0)
+      libdatadog (~> 4.0.0.1.0)
       libddwaf (~> 1.11.0.0.0)
       msgpack
 
@@ -118,7 +118,7 @@ GEM
     jdbc-postgres (42.2.25)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (3.0.0.1.0)
+    libdatadog (4.0.0.1.0)
     libddwaf (1.11.0.0.0-java)
       ffi (~> 1.0)
     lograge (0.12.0)

--- a/gemfiles/jruby_9.2.21.0_rails61_postgres_sidekiq.gemfile.lock
+++ b/gemfiles/jruby_9.2.21.0_rails61_postgres_sidekiq.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.14.0)
       debase-ruby_core_source (= 3.2.1)
-      libdatadog (~> 3.0.0.1.0)
+      libdatadog (~> 4.0.0.1.0)
       libddwaf (~> 1.11.0.0.0)
       msgpack
 
@@ -118,7 +118,7 @@ GEM
     jdbc-postgres (42.2.25)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (3.0.0.1.0)
+    libdatadog (4.0.0.1.0)
     libddwaf (1.11.0.0.0-java)
       ffi (~> 1.0)
     lograge (0.12.0)

--- a/gemfiles/jruby_9.2.21.0_rails61_semantic_logger.gemfile.lock
+++ b/gemfiles/jruby_9.2.21.0_rails61_semantic_logger.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.14.0)
       debase-ruby_core_source (= 3.2.1)
-      libdatadog (~> 3.0.0.1.0)
+      libdatadog (~> 4.0.0.1.0)
       libddwaf (~> 1.11.0.0.0)
       msgpack
 
@@ -117,7 +117,7 @@ GEM
     jdbc-postgres (42.2.25)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (3.0.0.1.0)
+    libdatadog (4.0.0.1.0)
     libddwaf (1.11.0.0.0-java)
       ffi (~> 1.0)
     loofah (2.19.1)

--- a/gemfiles/jruby_9.2.21.0_rails6_mysql2.gemfile.lock
+++ b/gemfiles/jruby_9.2.21.0_rails6_mysql2.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.14.0)
       debase-ruby_core_source (= 3.2.1)
-      libdatadog (~> 3.0.0.1.0)
+      libdatadog (~> 4.0.0.1.0)
       libddwaf (~> 1.11.0.0.0)
       msgpack
 
@@ -111,7 +111,7 @@ GEM
     jdbc-mysql (8.0.27)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (3.0.0.1.0)
+    libdatadog (4.0.0.1.0)
     libddwaf (1.11.0.0.0-java)
       ffi (~> 1.0)
     lograge (0.12.0)

--- a/gemfiles/jruby_9.2.21.0_rails6_postgres.gemfile.lock
+++ b/gemfiles/jruby_9.2.21.0_rails6_postgres.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.14.0)
       debase-ruby_core_source (= 3.2.1)
-      libdatadog (~> 3.0.0.1.0)
+      libdatadog (~> 4.0.0.1.0)
       libddwaf (~> 1.11.0.0.0)
       msgpack
 
@@ -113,7 +113,7 @@ GEM
     jdbc-postgres (42.2.25)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (3.0.0.1.0)
+    libdatadog (4.0.0.1.0)
     libddwaf (1.11.0.0.0-java)
       ffi (~> 1.0)
     lograge (0.12.0)

--- a/gemfiles/jruby_9.2.21.0_rails6_postgres_redis.gemfile.lock
+++ b/gemfiles/jruby_9.2.21.0_rails6_postgres_redis.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.14.0)
       debase-ruby_core_source (= 3.2.1)
-      libdatadog (~> 3.0.0.1.0)
+      libdatadog (~> 4.0.0.1.0)
       libddwaf (~> 1.11.0.0.0)
       msgpack
 
@@ -114,7 +114,7 @@ GEM
     jdbc-postgres (42.2.25)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (3.0.0.1.0)
+    libdatadog (4.0.0.1.0)
     libddwaf (1.11.0.0.0-java)
       ffi (~> 1.0)
     lograge (0.12.0)

--- a/gemfiles/jruby_9.2.21.0_rails6_postgres_redis_activesupport.gemfile.lock
+++ b/gemfiles/jruby_9.2.21.0_rails6_postgres_redis_activesupport.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.14.0)
       debase-ruby_core_source (= 3.2.1)
-      libdatadog (~> 3.0.0.1.0)
+      libdatadog (~> 4.0.0.1.0)
       libddwaf (~> 1.11.0.0.0)
       msgpack
 
@@ -113,7 +113,7 @@ GEM
     jdbc-postgres (42.2.25)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (3.0.0.1.0)
+    libdatadog (4.0.0.1.0)
     libddwaf (1.11.0.0.0-java)
       ffi (~> 1.0)
     lograge (0.12.0)

--- a/gemfiles/jruby_9.2.21.0_rails6_postgres_sidekiq.gemfile.lock
+++ b/gemfiles/jruby_9.2.21.0_rails6_postgres_sidekiq.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.14.0)
       debase-ruby_core_source (= 3.2.1)
-      libdatadog (~> 3.0.0.1.0)
+      libdatadog (~> 4.0.0.1.0)
       libddwaf (~> 1.11.0.0.0)
       msgpack
 
@@ -114,7 +114,7 @@ GEM
     jdbc-postgres (42.2.25)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (3.0.0.1.0)
+    libdatadog (4.0.0.1.0)
     libddwaf (1.11.0.0.0-java)
       ffi (~> 1.0)
     lograge (0.12.0)

--- a/gemfiles/jruby_9.2.21.0_rails6_semantic_logger.gemfile.lock
+++ b/gemfiles/jruby_9.2.21.0_rails6_semantic_logger.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.14.0)
       debase-ruby_core_source (= 3.2.1)
-      libdatadog (~> 3.0.0.1.0)
+      libdatadog (~> 4.0.0.1.0)
       libddwaf (~> 1.11.0.0.0)
       msgpack
 
@@ -113,7 +113,7 @@ GEM
     jdbc-postgres (42.2.25)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (3.0.0.1.0)
+    libdatadog (4.0.0.1.0)
     libddwaf (1.11.0.0.0-java)
       ffi (~> 1.0)
     loofah (2.19.1)

--- a/gemfiles/jruby_9.2.21.0_redis_3.gemfile.lock
+++ b/gemfiles/jruby_9.2.21.0_redis_3.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.14.0)
       debase-ruby_core_source (= 3.2.1)
-      libdatadog (~> 3.0.0.1.0)
+      libdatadog (~> 4.0.0.1.0)
       libddwaf (~> 1.11.0.0.0)
       msgpack
 
@@ -44,7 +44,7 @@ GEM
     hashdiff (1.0.1)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (3.0.0.1.0)
+    libdatadog (4.0.0.1.0)
     libddwaf (1.11.0.0.0-java)
       ffi (~> 1.0)
     memory_profiler (0.9.14)

--- a/gemfiles/jruby_9.2.21.0_redis_4.gemfile.lock
+++ b/gemfiles/jruby_9.2.21.0_redis_4.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.14.0)
       debase-ruby_core_source (= 3.2.1)
-      libdatadog (~> 3.0.0.1.0)
+      libdatadog (~> 4.0.0.1.0)
       libddwaf (~> 1.11.0.0.0)
       msgpack
 
@@ -44,7 +44,7 @@ GEM
     hashdiff (1.0.1)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (3.0.0.1.0)
+    libdatadog (4.0.0.1.0)
     libddwaf (1.11.0.0.0-java)
       ffi (~> 1.0)
     memory_profiler (0.9.14)

--- a/gemfiles/jruby_9.2.21.0_redis_5.gemfile.lock
+++ b/gemfiles/jruby_9.2.21.0_redis_5.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.14.0)
       debase-ruby_core_source (= 3.2.1)
-      libdatadog (~> 3.0.0.1.0)
+      libdatadog (~> 4.0.0.1.0)
       libddwaf (~> 1.11.0.0.0)
       msgpack
 
@@ -45,7 +45,7 @@ GEM
     hashdiff (1.0.1)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (3.0.0.1.0)
+    libdatadog (4.0.0.1.0)
     libddwaf (1.11.0.0.0-java)
       ffi (~> 1.0)
     memory_profiler (0.9.14)

--- a/gemfiles/jruby_9.2.21.0_resque2_redis3.gemfile.lock
+++ b/gemfiles/jruby_9.2.21.0_resque2_redis3.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.14.0)
       debase-ruby_core_source (= 3.2.1)
-      libdatadog (~> 3.0.0.1.0)
+      libdatadog (~> 4.0.0.1.0)
       libddwaf (~> 1.11.0.0.0)
       msgpack
 
@@ -44,7 +44,7 @@ GEM
     hashdiff (1.0.1)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (3.0.0.1.0)
+    libdatadog (4.0.0.1.0)
     libddwaf (1.11.0.0.0-java)
       ffi (~> 1.0)
     memory_profiler (0.9.14)

--- a/gemfiles/jruby_9.2.21.0_resque2_redis4.gemfile.lock
+++ b/gemfiles/jruby_9.2.21.0_resque2_redis4.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.14.0)
       debase-ruby_core_source (= 3.2.1)
-      libdatadog (~> 3.0.0.1.0)
+      libdatadog (~> 4.0.0.1.0)
       libddwaf (~> 1.11.0.0.0)
       msgpack
 
@@ -45,7 +45,7 @@ GEM
     hashdiff (1.0.1)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (3.0.0.1.0)
+    libdatadog (4.0.0.1.0)
     libddwaf (1.11.0.0.0-java)
       ffi (~> 1.0)
     memory_profiler (0.9.14)

--- a/gemfiles/jruby_9.2.21.0_sinatra.gemfile.lock
+++ b/gemfiles/jruby_9.2.21.0_sinatra.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.14.0)
       debase-ruby_core_source (= 3.2.1)
-      libdatadog (~> 3.0.0.1.0)
+      libdatadog (~> 4.0.0.1.0)
       libddwaf (~> 1.11.0.0.0)
       msgpack
 
@@ -44,7 +44,7 @@ GEM
     hashdiff (1.0.1)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (3.0.0.1.0)
+    libdatadog (4.0.0.1.0)
     libddwaf (1.11.0.0.0-java)
       ffi (~> 1.0)
     memory_profiler (0.9.14)

--- a/gemfiles/jruby_9.3.9.0_contrib.gemfile.lock
+++ b/gemfiles/jruby_9.3.9.0_contrib.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.14.0)
       debase-ruby_core_source (= 3.2.1)
-      libdatadog (~> 3.0.0.1.0)
+      libdatadog (~> 4.0.0.1.0)
       libddwaf (~> 1.11.0.0.0)
       msgpack
 
@@ -1528,7 +1528,7 @@ GEM
       addressable (>= 2.4)
     jsonapi-renderer (0.2.2)
     king_konf (1.0.1)
-    libdatadog (3.0.0.1.0)
+    libdatadog (4.0.0.1.0)
     libddwaf (1.11.0.0.0-java)
       ffi (~> 1.0)
     lograge (0.12.0)

--- a/gemfiles/jruby_9.3.9.0_contrib_old.gemfile.lock
+++ b/gemfiles/jruby_9.3.9.0_contrib_old.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.14.0)
       debase-ruby_core_source (= 3.2.1)
-      libdatadog (~> 3.0.0.1.0)
+      libdatadog (~> 4.0.0.1.0)
       libddwaf (~> 1.11.0.0.0)
       msgpack
 
@@ -60,7 +60,7 @@ GEM
     json (2.6.3-java)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (3.0.0.1.0)
+    libdatadog (4.0.0.1.0)
     libddwaf (1.11.0.0.0-java)
       ffi (~> 1.0)
     memory_profiler (0.9.14)

--- a/gemfiles/jruby_9.3.9.0_core_old.gemfile.lock
+++ b/gemfiles/jruby_9.3.9.0_core_old.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.14.0)
       debase-ruby_core_source (= 3.2.1)
-      libdatadog (~> 3.0.0.1.0)
+      libdatadog (~> 4.0.0.1.0)
       libddwaf (~> 1.11.0.0.0)
       msgpack
 
@@ -46,7 +46,7 @@ GEM
     json (2.6.3-java)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (3.0.0.1.0)
+    libdatadog (4.0.0.1.0)
     libddwaf (1.11.0.0.0-java)
       ffi (~> 1.0)
     memory_profiler (0.9.14)

--- a/gemfiles/jruby_9.3.9.0_cucumber3.gemfile.lock
+++ b/gemfiles/jruby_9.3.9.0_cucumber3.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.14.0)
       debase-ruby_core_source (= 3.2.1)
-      libdatadog (~> 3.0.0.1.0)
+      libdatadog (~> 4.0.0.1.0)
       libddwaf (~> 1.11.0.0.0)
       msgpack
 
@@ -64,7 +64,7 @@ GEM
     json (2.6.3-java)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (3.0.0.1.0)
+    libdatadog (4.0.0.1.0)
     libddwaf (1.11.0.0.0-java)
       ffi (~> 1.0)
     memory_profiler (0.9.14)

--- a/gemfiles/jruby_9.3.9.0_cucumber4.gemfile.lock
+++ b/gemfiles/jruby_9.3.9.0_cucumber4.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.14.0)
       debase-ruby_core_source (= 3.2.1)
-      libdatadog (~> 3.0.0.1.0)
+      libdatadog (~> 4.0.0.1.0)
       libddwaf (~> 1.11.0.0.0)
       msgpack
 
@@ -85,7 +85,7 @@ GEM
     json (2.6.3-java)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (3.0.0.1.0)
+    libdatadog (4.0.0.1.0)
     libddwaf (1.11.0.0.0-java)
       ffi (~> 1.0)
     memory_profiler (0.9.14)

--- a/gemfiles/jruby_9.3.9.0_cucumber5.gemfile.lock
+++ b/gemfiles/jruby_9.3.9.0_cucumber5.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.14.0)
       debase-ruby_core_source (= 3.2.1)
-      libdatadog (~> 3.0.0.1.0)
+      libdatadog (~> 4.0.0.1.0)
       libddwaf (~> 1.11.0.0.0)
       msgpack
 
@@ -85,7 +85,7 @@ GEM
     json (2.6.3-java)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (3.0.0.1.0)
+    libdatadog (4.0.0.1.0)
     libddwaf (1.11.0.0.0-java)
       ffi (~> 1.0)
     memory_profiler (0.9.14)

--- a/gemfiles/jruby_9.3.9.0_hanami_1.gemfile.lock
+++ b/gemfiles/jruby_9.3.9.0_hanami_1.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.14.0)
       debase-ruby_core_source (= 3.2.1)
-      libdatadog (~> 3.0.0.1.0)
+      libdatadog (~> 4.0.0.1.0)
       libddwaf (~> 1.11.0.0.0)
       msgpack
 
@@ -121,7 +121,7 @@ GEM
     json (2.6.3-java)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (3.0.0.1.0)
+    libdatadog (4.0.0.1.0)
     libddwaf (1.11.0.0.0-java)
       ffi (~> 1.0)
     mail (2.8.0.1)

--- a/gemfiles/jruby_9.3.9.0_rails5_mysql2.gemfile.lock
+++ b/gemfiles/jruby_9.3.9.0_rails5_mysql2.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.14.0)
       debase-ruby_core_source (= 3.2.1)
-      libdatadog (~> 3.0.0.1.0)
+      libdatadog (~> 4.0.0.1.0)
       libddwaf (~> 1.11.0.0.0)
       msgpack
 
@@ -101,7 +101,7 @@ GEM
     json (2.6.3-java)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (3.0.0.1.0)
+    libdatadog (4.0.0.1.0)
     libddwaf (1.11.0.0.0-java)
       ffi (~> 1.0)
     lograge (0.12.0)

--- a/gemfiles/jruby_9.3.9.0_rails5_postgres.gemfile.lock
+++ b/gemfiles/jruby_9.3.9.0_rails5_postgres.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.14.0)
       debase-ruby_core_source (= 3.2.1)
-      libdatadog (~> 3.0.0.1.0)
+      libdatadog (~> 4.0.0.1.0)
       libddwaf (~> 1.11.0.0.0)
       msgpack
 
@@ -101,7 +101,7 @@ GEM
     json (2.6.3-java)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (3.0.0.1.0)
+    libdatadog (4.0.0.1.0)
     libddwaf (1.11.0.0.0-java)
       ffi (~> 1.0)
     lograge (0.12.0)

--- a/gemfiles/jruby_9.3.9.0_rails5_postgres_redis.gemfile.lock
+++ b/gemfiles/jruby_9.3.9.0_rails5_postgres_redis.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.14.0)
       debase-ruby_core_source (= 3.2.1)
-      libdatadog (~> 3.0.0.1.0)
+      libdatadog (~> 4.0.0.1.0)
       libddwaf (~> 1.11.0.0.0)
       msgpack
 
@@ -101,7 +101,7 @@ GEM
     json (2.6.3-java)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (3.0.0.1.0)
+    libdatadog (4.0.0.1.0)
     libddwaf (1.11.0.0.0-java)
       ffi (~> 1.0)
     lograge (0.12.0)

--- a/gemfiles/jruby_9.3.9.0_rails5_postgres_redis_activesupport.gemfile.lock
+++ b/gemfiles/jruby_9.3.9.0_rails5_postgres_redis_activesupport.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.14.0)
       debase-ruby_core_source (= 3.2.1)
-      libdatadog (~> 3.0.0.1.0)
+      libdatadog (~> 4.0.0.1.0)
       libddwaf (~> 1.11.0.0.0)
       msgpack
 
@@ -101,7 +101,7 @@ GEM
     json (2.6.3-java)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (3.0.0.1.0)
+    libdatadog (4.0.0.1.0)
     libddwaf (1.11.0.0.0-java)
       ffi (~> 1.0)
     lograge (0.12.0)

--- a/gemfiles/jruby_9.3.9.0_rails5_postgres_sidekiq.gemfile.lock
+++ b/gemfiles/jruby_9.3.9.0_rails5_postgres_sidekiq.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.14.0)
       debase-ruby_core_source (= 3.2.1)
-      libdatadog (~> 3.0.0.1.0)
+      libdatadog (~> 4.0.0.1.0)
       libddwaf (~> 1.11.0.0.0)
       msgpack
 
@@ -102,7 +102,7 @@ GEM
     json (2.6.3-java)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (3.0.0.1.0)
+    libdatadog (4.0.0.1.0)
     libddwaf (1.11.0.0.0-java)
       ffi (~> 1.0)
     lograge (0.12.0)

--- a/gemfiles/jruby_9.3.9.0_rails5_semantic_logger.gemfile.lock
+++ b/gemfiles/jruby_9.3.9.0_rails5_semantic_logger.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.14.0)
       debase-ruby_core_source (= 3.2.1)
-      libdatadog (~> 3.0.0.1.0)
+      libdatadog (~> 4.0.0.1.0)
       libddwaf (~> 1.11.0.0.0)
       msgpack
 
@@ -101,7 +101,7 @@ GEM
     json (2.6.3-java)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (3.0.0.1.0)
+    libdatadog (4.0.0.1.0)
     libddwaf (1.11.0.0.0-java)
       ffi (~> 1.0)
     loofah (2.19.1)

--- a/gemfiles/jruby_9.3.9.0_rails61_mysql2.gemfile.lock
+++ b/gemfiles/jruby_9.3.9.0_rails61_mysql2.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.14.0)
       debase-ruby_core_source (= 3.2.1)
-      libdatadog (~> 3.0.0.1.0)
+      libdatadog (~> 4.0.0.1.0)
       libddwaf (~> 1.11.0.0.0)
       msgpack
 
@@ -118,7 +118,7 @@ GEM
     json (2.6.3-java)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (3.0.0.1.0)
+    libdatadog (4.0.0.1.0)
     libddwaf (1.11.0.0.0-java)
       ffi (~> 1.0)
     lograge (0.12.0)

--- a/gemfiles/jruby_9.3.9.0_rails61_postgres.gemfile.lock
+++ b/gemfiles/jruby_9.3.9.0_rails61_postgres.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.14.0)
       debase-ruby_core_source (= 3.2.1)
-      libdatadog (~> 3.0.0.1.0)
+      libdatadog (~> 4.0.0.1.0)
       libddwaf (~> 1.11.0.0.0)
       msgpack
 
@@ -118,7 +118,7 @@ GEM
     json (2.6.3-java)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (3.0.0.1.0)
+    libdatadog (4.0.0.1.0)
     libddwaf (1.11.0.0.0-java)
       ffi (~> 1.0)
     lograge (0.12.0)

--- a/gemfiles/jruby_9.3.9.0_rails61_postgres_redis.gemfile.lock
+++ b/gemfiles/jruby_9.3.9.0_rails61_postgres_redis.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.14.0)
       debase-ruby_core_source (= 3.2.1)
-      libdatadog (~> 3.0.0.1.0)
+      libdatadog (~> 4.0.0.1.0)
       libddwaf (~> 1.11.0.0.0)
       msgpack
 
@@ -118,7 +118,7 @@ GEM
     json (2.6.3-java)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (3.0.0.1.0)
+    libdatadog (4.0.0.1.0)
     libddwaf (1.11.0.0.0-java)
       ffi (~> 1.0)
     lograge (0.12.0)

--- a/gemfiles/jruby_9.3.9.0_rails61_postgres_sidekiq.gemfile.lock
+++ b/gemfiles/jruby_9.3.9.0_rails61_postgres_sidekiq.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.14.0)
       debase-ruby_core_source (= 3.2.1)
-      libdatadog (~> 3.0.0.1.0)
+      libdatadog (~> 4.0.0.1.0)
       libddwaf (~> 1.11.0.0.0)
       msgpack
 
@@ -119,7 +119,7 @@ GEM
     json (2.6.3-java)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (3.0.0.1.0)
+    libdatadog (4.0.0.1.0)
     libddwaf (1.11.0.0.0-java)
       ffi (~> 1.0)
     lograge (0.12.0)

--- a/gemfiles/jruby_9.3.9.0_rails61_semantic_logger.gemfile.lock
+++ b/gemfiles/jruby_9.3.9.0_rails61_semantic_logger.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.14.0)
       debase-ruby_core_source (= 3.2.1)
-      libdatadog (~> 3.0.0.1.0)
+      libdatadog (~> 4.0.0.1.0)
       libddwaf (~> 1.11.0.0.0)
       msgpack
 
@@ -118,7 +118,7 @@ GEM
     json (2.6.3-java)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (3.0.0.1.0)
+    libdatadog (4.0.0.1.0)
     libddwaf (1.11.0.0.0-java)
       ffi (~> 1.0)
     loofah (2.19.1)

--- a/gemfiles/jruby_9.3.9.0_rails6_mysql2.gemfile.lock
+++ b/gemfiles/jruby_9.3.9.0_rails6_mysql2.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.14.0)
       debase-ruby_core_source (= 3.2.1)
-      libdatadog (~> 3.0.0.1.0)
+      libdatadog (~> 4.0.0.1.0)
       libddwaf (~> 1.11.0.0.0)
       msgpack
 
@@ -114,7 +114,7 @@ GEM
     json (2.6.3-java)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (3.0.0.1.0)
+    libdatadog (4.0.0.1.0)
     libddwaf (1.11.0.0.0-java)
       ffi (~> 1.0)
     lograge (0.12.0)

--- a/gemfiles/jruby_9.3.9.0_rails6_postgres.gemfile.lock
+++ b/gemfiles/jruby_9.3.9.0_rails6_postgres.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.14.0)
       debase-ruby_core_source (= 3.2.1)
-      libdatadog (~> 3.0.0.1.0)
+      libdatadog (~> 4.0.0.1.0)
       libddwaf (~> 1.11.0.0.0)
       msgpack
 
@@ -114,7 +114,7 @@ GEM
     json (2.6.3-java)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (3.0.0.1.0)
+    libdatadog (4.0.0.1.0)
     libddwaf (1.11.0.0.0-java)
       ffi (~> 1.0)
     lograge (0.12.0)

--- a/gemfiles/jruby_9.3.9.0_rails6_postgres_redis.gemfile.lock
+++ b/gemfiles/jruby_9.3.9.0_rails6_postgres_redis.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.14.0)
       debase-ruby_core_source (= 3.2.1)
-      libdatadog (~> 3.0.0.1.0)
+      libdatadog (~> 4.0.0.1.0)
       libddwaf (~> 1.11.0.0.0)
       msgpack
 
@@ -114,7 +114,7 @@ GEM
     json (2.6.3-java)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (3.0.0.1.0)
+    libdatadog (4.0.0.1.0)
     libddwaf (1.11.0.0.0-java)
       ffi (~> 1.0)
     lograge (0.12.0)

--- a/gemfiles/jruby_9.3.9.0_rails6_postgres_redis_activesupport.gemfile.lock
+++ b/gemfiles/jruby_9.3.9.0_rails6_postgres_redis_activesupport.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.14.0)
       debase-ruby_core_source (= 3.2.1)
-      libdatadog (~> 3.0.0.1.0)
+      libdatadog (~> 4.0.0.1.0)
       libddwaf (~> 1.11.0.0.0)
       msgpack
 
@@ -114,7 +114,7 @@ GEM
     json (2.6.3-java)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (3.0.0.1.0)
+    libdatadog (4.0.0.1.0)
     libddwaf (1.11.0.0.0-java)
       ffi (~> 1.0)
     lograge (0.12.0)

--- a/gemfiles/jruby_9.3.9.0_rails6_postgres_sidekiq.gemfile.lock
+++ b/gemfiles/jruby_9.3.9.0_rails6_postgres_sidekiq.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.14.0)
       debase-ruby_core_source (= 3.2.1)
-      libdatadog (~> 3.0.0.1.0)
+      libdatadog (~> 4.0.0.1.0)
       libddwaf (~> 1.11.0.0.0)
       msgpack
 
@@ -115,7 +115,7 @@ GEM
     json (2.6.3-java)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (3.0.0.1.0)
+    libdatadog (4.0.0.1.0)
     libddwaf (1.11.0.0.0-java)
       ffi (~> 1.0)
     lograge (0.12.0)

--- a/gemfiles/jruby_9.3.9.0_rails6_semantic_logger.gemfile.lock
+++ b/gemfiles/jruby_9.3.9.0_rails6_semantic_logger.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.14.0)
       debase-ruby_core_source (= 3.2.1)
-      libdatadog (~> 3.0.0.1.0)
+      libdatadog (~> 4.0.0.1.0)
       libddwaf (~> 1.11.0.0.0)
       msgpack
 
@@ -114,7 +114,7 @@ GEM
     json (2.6.3-java)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (3.0.0.1.0)
+    libdatadog (4.0.0.1.0)
     libddwaf (1.11.0.0.0-java)
       ffi (~> 1.0)
     loofah (2.19.1)

--- a/gemfiles/jruby_9.3.9.0_redis_3.gemfile.lock
+++ b/gemfiles/jruby_9.3.9.0_redis_3.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.14.0)
       debase-ruby_core_source (= 3.2.1)
-      libdatadog (~> 3.0.0.1.0)
+      libdatadog (~> 4.0.0.1.0)
       libddwaf (~> 1.11.0.0.0)
       msgpack
 
@@ -46,7 +46,7 @@ GEM
     json (2.6.3-java)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (3.0.0.1.0)
+    libdatadog (4.0.0.1.0)
     libddwaf (1.11.0.0.0-java)
       ffi (~> 1.0)
     memory_profiler (0.9.14)

--- a/gemfiles/jruby_9.3.9.0_redis_4.gemfile.lock
+++ b/gemfiles/jruby_9.3.9.0_redis_4.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.14.0)
       debase-ruby_core_source (= 3.2.1)
-      libdatadog (~> 3.0.0.1.0)
+      libdatadog (~> 4.0.0.1.0)
       libddwaf (~> 1.11.0.0.0)
       msgpack
 
@@ -46,7 +46,7 @@ GEM
     json (2.6.3-java)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (3.0.0.1.0)
+    libdatadog (4.0.0.1.0)
     libddwaf (1.11.0.0.0-java)
       ffi (~> 1.0)
     memory_profiler (0.9.14)

--- a/gemfiles/jruby_9.3.9.0_redis_5.gemfile.lock
+++ b/gemfiles/jruby_9.3.9.0_redis_5.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.14.0)
       debase-ruby_core_source (= 3.2.1)
-      libdatadog (~> 3.0.0.1.0)
+      libdatadog (~> 4.0.0.1.0)
       libddwaf (~> 1.11.0.0.0)
       msgpack
 
@@ -47,7 +47,7 @@ GEM
     json (2.6.3-java)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (3.0.0.1.0)
+    libdatadog (4.0.0.1.0)
     libddwaf (1.11.0.0.0-java)
       ffi (~> 1.0)
     memory_profiler (0.9.14)

--- a/gemfiles/jruby_9.3.9.0_resque2_redis3.gemfile.lock
+++ b/gemfiles/jruby_9.3.9.0_resque2_redis3.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.14.0)
       debase-ruby_core_source (= 3.2.1)
-      libdatadog (~> 3.0.0.1.0)
+      libdatadog (~> 4.0.0.1.0)
       libddwaf (~> 1.11.0.0.0)
       msgpack
 
@@ -46,7 +46,7 @@ GEM
     json (2.6.3-java)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (3.0.0.1.0)
+    libdatadog (4.0.0.1.0)
     libddwaf (1.11.0.0.0-java)
       ffi (~> 1.0)
     memory_profiler (0.9.14)

--- a/gemfiles/jruby_9.3.9.0_resque2_redis4.gemfile.lock
+++ b/gemfiles/jruby_9.3.9.0_resque2_redis4.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.14.0)
       debase-ruby_core_source (= 3.2.1)
-      libdatadog (~> 3.0.0.1.0)
+      libdatadog (~> 4.0.0.1.0)
       libddwaf (~> 1.11.0.0.0)
       msgpack
 
@@ -46,7 +46,7 @@ GEM
     json (2.6.3-java)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (3.0.0.1.0)
+    libdatadog (4.0.0.1.0)
     libddwaf (1.11.0.0.0-java)
       ffi (~> 1.0)
     memory_profiler (0.9.14)

--- a/gemfiles/jruby_9.3.9.0_sinatra.gemfile.lock
+++ b/gemfiles/jruby_9.3.9.0_sinatra.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.14.0)
       debase-ruby_core_source (= 3.2.1)
-      libdatadog (~> 3.0.0.1.0)
+      libdatadog (~> 4.0.0.1.0)
       libddwaf (~> 1.11.0.0.0)
       msgpack
 
@@ -46,7 +46,7 @@ GEM
     json (2.6.3-java)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (3.0.0.1.0)
+    libdatadog (4.0.0.1.0)
     libddwaf (1.11.0.0.0-java)
       ffi (~> 1.0)
     memory_profiler (0.9.14)

--- a/gemfiles/jruby_9.4.0.0_contrib.gemfile.lock
+++ b/gemfiles/jruby_9.4.0.0_contrib.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.14.0)
       debase-ruby_core_source (= 3.2.1)
-      libdatadog (~> 3.0.0.1.0)
+      libdatadog (~> 4.0.0.1.0)
       libddwaf (~> 1.11.0.0.0)
       msgpack
 
@@ -1523,7 +1523,7 @@ GEM
       addressable (>= 2.4)
     jsonapi-renderer (0.2.2)
     king_konf (1.0.1)
-    libdatadog (3.0.0.1.0)
+    libdatadog (4.0.0.1.0)
     libddwaf (1.11.0.0.0-java)
       ffi (~> 1.0)
     lograge (0.12.0)

--- a/gemfiles/jruby_9.4.0.0_contrib_old.gemfile.lock
+++ b/gemfiles/jruby_9.4.0.0_contrib_old.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.14.0)
       debase-ruby_core_source (= 3.2.1)
-      libdatadog (~> 3.0.0.1.0)
+      libdatadog (~> 4.0.0.1.0)
       libddwaf (~> 1.11.0.0.0)
       msgpack
 
@@ -60,7 +60,7 @@ GEM
     json (2.6.3-java)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (3.0.0.1.0)
+    libdatadog (4.0.0.1.0)
     libddwaf (1.11.0.0.0-java)
       ffi (~> 1.0)
     memory_profiler (0.9.14)

--- a/gemfiles/jruby_9.4.0.0_core_old.gemfile.lock
+++ b/gemfiles/jruby_9.4.0.0_core_old.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.14.0)
       debase-ruby_core_source (= 3.2.1)
-      libdatadog (~> 3.0.0.1.0)
+      libdatadog (~> 4.0.0.1.0)
       libddwaf (~> 1.11.0.0.0)
       msgpack
 
@@ -46,7 +46,7 @@ GEM
     json (2.6.3-java)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (3.0.0.1.0)
+    libdatadog (4.0.0.1.0)
     libddwaf (1.11.0.0.0-java)
       ffi (~> 1.0)
     memory_profiler (0.9.14)

--- a/gemfiles/jruby_9.4.0.0_cucumber3.gemfile.lock
+++ b/gemfiles/jruby_9.4.0.0_cucumber3.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.14.0)
       debase-ruby_core_source (= 3.2.1)
-      libdatadog (~> 3.0.0.1.0)
+      libdatadog (~> 4.0.0.1.0)
       libddwaf (~> 1.11.0.0.0)
       msgpack
 
@@ -64,7 +64,7 @@ GEM
     json (2.6.3-java)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (3.0.0.1.0)
+    libdatadog (4.0.0.1.0)
     libddwaf (1.11.0.0.0-java)
       ffi (~> 1.0)
     memory_profiler (0.9.14)

--- a/gemfiles/jruby_9.4.0.0_cucumber4.gemfile.lock
+++ b/gemfiles/jruby_9.4.0.0_cucumber4.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.14.0)
       debase-ruby_core_source (= 3.2.1)
-      libdatadog (~> 3.0.0.1.0)
+      libdatadog (~> 4.0.0.1.0)
       libddwaf (~> 1.11.0.0.0)
       msgpack
 
@@ -84,7 +84,7 @@ GEM
     json (2.6.3-java)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (3.0.0.1.0)
+    libdatadog (4.0.0.1.0)
     libddwaf (1.11.0.0.0-java)
       ffi (~> 1.0)
     memory_profiler (0.9.14)

--- a/gemfiles/jruby_9.4.0.0_cucumber5.gemfile.lock
+++ b/gemfiles/jruby_9.4.0.0_cucumber5.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.14.0)
       debase-ruby_core_source (= 3.2.1)
-      libdatadog (~> 3.0.0.1.0)
+      libdatadog (~> 4.0.0.1.0)
       libddwaf (~> 1.11.0.0.0)
       msgpack
 
@@ -84,7 +84,7 @@ GEM
     json (2.6.3-java)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (3.0.0.1.0)
+    libdatadog (4.0.0.1.0)
     libddwaf (1.11.0.0.0-java)
       ffi (~> 1.0)
     memory_profiler (0.9.14)

--- a/gemfiles/jruby_9.4.0.0_cucumber6.gemfile.lock
+++ b/gemfiles/jruby_9.4.0.0_cucumber6.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.14.0)
       debase-ruby_core_source (= 3.2.1)
-      libdatadog (~> 3.0.0.1.0)
+      libdatadog (~> 4.0.0.1.0)
       libddwaf (~> 1.11.0.0.0)
       msgpack
 
@@ -85,7 +85,7 @@ GEM
     json (2.6.3-java)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (3.0.0.1.0)
+    libdatadog (4.0.0.1.0)
     libddwaf (1.11.0.0.0-java)
       ffi (~> 1.0)
     memory_profiler (0.9.14)

--- a/gemfiles/jruby_9.4.0.0_cucumber7.gemfile.lock
+++ b/gemfiles/jruby_9.4.0.0_cucumber7.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.14.0)
       debase-ruby_core_source (= 3.2.1)
-      libdatadog (~> 3.0.0.1.0)
+      libdatadog (~> 4.0.0.1.0)
       libddwaf (~> 1.11.0.0.0)
       msgpack
 
@@ -76,7 +76,7 @@ GEM
     json (2.6.3-java)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (3.0.0.1.0)
+    libdatadog (4.0.0.1.0)
     libddwaf (1.11.0.0.0-java)
       ffi (~> 1.0)
     memory_profiler (0.9.14)

--- a/gemfiles/jruby_9.4.0.0_cucumber8.gemfile.lock
+++ b/gemfiles/jruby_9.4.0.0_cucumber8.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.14.0)
       debase-ruby_core_source (= 3.2.1)
-      libdatadog (~> 3.0.0.1.0)
+      libdatadog (~> 4.0.0.1.0)
       libddwaf (~> 1.11.0.0.0)
       msgpack
 
@@ -70,7 +70,7 @@ GEM
     json (2.6.3-java)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (3.0.0.1.0)
+    libdatadog (4.0.0.1.0)
     libddwaf (1.11.0.0.0-java)
       ffi (~> 1.0)
     memory_profiler (0.9.14)

--- a/gemfiles/jruby_9.4.0.0_rails61_mysql2.gemfile.lock
+++ b/gemfiles/jruby_9.4.0.0_rails61_mysql2.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.14.0)
       debase-ruby_core_source (= 3.2.1)
-      libdatadog (~> 3.0.0.1.0)
+      libdatadog (~> 4.0.0.1.0)
       libddwaf (~> 1.11.0.0.0)
       msgpack
 
@@ -118,7 +118,7 @@ GEM
     json (2.6.3-java)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (3.0.0.1.0)
+    libdatadog (4.0.0.1.0)
     libddwaf (1.11.0.0.0-java)
       ffi (~> 1.0)
     lograge (0.12.0)

--- a/gemfiles/jruby_9.4.0.0_rails61_postgres.gemfile.lock
+++ b/gemfiles/jruby_9.4.0.0_rails61_postgres.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.14.0)
       debase-ruby_core_source (= 3.2.1)
-      libdatadog (~> 3.0.0.1.0)
+      libdatadog (~> 4.0.0.1.0)
       libddwaf (~> 1.11.0.0.0)
       msgpack
 
@@ -118,7 +118,7 @@ GEM
     json (2.6.3-java)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (3.0.0.1.0)
+    libdatadog (4.0.0.1.0)
     libddwaf (1.11.0.0.0-java)
       ffi (~> 1.0)
     lograge (0.12.0)

--- a/gemfiles/jruby_9.4.0.0_rails61_postgres_redis.gemfile.lock
+++ b/gemfiles/jruby_9.4.0.0_rails61_postgres_redis.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.14.0)
       debase-ruby_core_source (= 3.2.1)
-      libdatadog (~> 3.0.0.1.0)
+      libdatadog (~> 4.0.0.1.0)
       libddwaf (~> 1.11.0.0.0)
       msgpack
 
@@ -118,7 +118,7 @@ GEM
     json (2.6.3-java)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (3.0.0.1.0)
+    libdatadog (4.0.0.1.0)
     libddwaf (1.11.0.0.0-java)
       ffi (~> 1.0)
     lograge (0.12.0)

--- a/gemfiles/jruby_9.4.0.0_rails61_postgres_sidekiq.gemfile.lock
+++ b/gemfiles/jruby_9.4.0.0_rails61_postgres_sidekiq.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.14.0)
       debase-ruby_core_source (= 3.2.1)
-      libdatadog (~> 3.0.0.1.0)
+      libdatadog (~> 4.0.0.1.0)
       libddwaf (~> 1.11.0.0.0)
       msgpack
 
@@ -119,7 +119,7 @@ GEM
     json (2.6.3-java)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (3.0.0.1.0)
+    libdatadog (4.0.0.1.0)
     libddwaf (1.11.0.0.0-java)
       ffi (~> 1.0)
     lograge (0.12.0)

--- a/gemfiles/jruby_9.4.0.0_rails61_semantic_logger.gemfile.lock
+++ b/gemfiles/jruby_9.4.0.0_rails61_semantic_logger.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.14.0)
       debase-ruby_core_source (= 3.2.1)
-      libdatadog (~> 3.0.0.1.0)
+      libdatadog (~> 4.0.0.1.0)
       libddwaf (~> 1.11.0.0.0)
       msgpack
 
@@ -118,7 +118,7 @@ GEM
     json (2.6.3-java)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (3.0.0.1.0)
+    libdatadog (4.0.0.1.0)
     libddwaf (1.11.0.0.0-java)
       ffi (~> 1.0)
     loofah (2.19.1)

--- a/gemfiles/jruby_9.4.0.0_redis_3.gemfile.lock
+++ b/gemfiles/jruby_9.4.0.0_redis_3.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.14.0)
       debase-ruby_core_source (= 3.2.1)
-      libdatadog (~> 3.0.0.1.0)
+      libdatadog (~> 4.0.0.1.0)
       libddwaf (~> 1.11.0.0.0)
       msgpack
 
@@ -46,7 +46,7 @@ GEM
     json (2.6.3-java)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (3.0.0.1.0)
+    libdatadog (4.0.0.1.0)
     libddwaf (1.11.0.0.0-java)
       ffi (~> 1.0)
     memory_profiler (0.9.14)

--- a/gemfiles/jruby_9.4.0.0_redis_4.gemfile.lock
+++ b/gemfiles/jruby_9.4.0.0_redis_4.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.14.0)
       debase-ruby_core_source (= 3.2.1)
-      libdatadog (~> 3.0.0.1.0)
+      libdatadog (~> 4.0.0.1.0)
       libddwaf (~> 1.11.0.0.0)
       msgpack
 
@@ -46,7 +46,7 @@ GEM
     json (2.6.3-java)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (3.0.0.1.0)
+    libdatadog (4.0.0.1.0)
     libddwaf (1.11.0.0.0-java)
       ffi (~> 1.0)
     memory_profiler (0.9.14)

--- a/gemfiles/jruby_9.4.0.0_redis_5.gemfile.lock
+++ b/gemfiles/jruby_9.4.0.0_redis_5.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.14.0)
       debase-ruby_core_source (= 3.2.1)
-      libdatadog (~> 3.0.0.1.0)
+      libdatadog (~> 4.0.0.1.0)
       libddwaf (~> 1.11.0.0.0)
       msgpack
 
@@ -47,7 +47,7 @@ GEM
     json (2.6.3-java)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (3.0.0.1.0)
+    libdatadog (4.0.0.1.0)
     libddwaf (1.11.0.0.0-java)
       ffi (~> 1.0)
     memory_profiler (0.9.14)

--- a/gemfiles/jruby_9.4.0.0_resque2_redis3.gemfile.lock
+++ b/gemfiles/jruby_9.4.0.0_resque2_redis3.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.14.0)
       debase-ruby_core_source (= 3.2.1)
-      libdatadog (~> 3.0.0.1.0)
+      libdatadog (~> 4.0.0.1.0)
       libddwaf (~> 1.11.0.0.0)
       msgpack
 
@@ -46,7 +46,7 @@ GEM
     json (2.6.3-java)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (3.0.0.1.0)
+    libdatadog (4.0.0.1.0)
     libddwaf (1.11.0.0.0-java)
       ffi (~> 1.0)
     memory_profiler (0.9.14)

--- a/gemfiles/jruby_9.4.0.0_resque2_redis4.gemfile.lock
+++ b/gemfiles/jruby_9.4.0.0_resque2_redis4.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.14.0)
       debase-ruby_core_source (= 3.2.1)
-      libdatadog (~> 3.0.0.1.0)
+      libdatadog (~> 4.0.0.1.0)
       libddwaf (~> 1.11.0.0.0)
       msgpack
 
@@ -47,7 +47,7 @@ GEM
     json (2.6.3-java)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (3.0.0.1.0)
+    libdatadog (4.0.0.1.0)
     libddwaf (1.11.0.0.0-java)
       ffi (~> 1.0)
     memory_profiler (0.9.14)

--- a/gemfiles/jruby_9.4.0.0_sinatra.gemfile.lock
+++ b/gemfiles/jruby_9.4.0.0_sinatra.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.14.0)
       debase-ruby_core_source (= 3.2.1)
-      libdatadog (~> 3.0.0.1.0)
+      libdatadog (~> 4.0.0.1.0)
       libddwaf (~> 1.11.0.0.0)
       msgpack
 
@@ -46,7 +46,7 @@ GEM
     json (2.6.3-java)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (3.0.0.1.0)
+    libdatadog (4.0.0.1.0)
     libddwaf (1.11.0.0.0-java)
       ffi (~> 1.0)
     memory_profiler (0.9.14)

--- a/gemfiles/ruby_2.1.10_contrib.gemfile.lock
+++ b/gemfiles/ruby_2.1.10_contrib.gemfile.lock
@@ -3,7 +3,7 @@ PATH
   specs:
     ddtrace (1.14.0)
       debase-ruby_core_source (= 3.2.1)
-      libdatadog (~> 3.0.0.1.0)
+      libdatadog (~> 4.0.0.1.0)
       libddwaf (~> 1.11.0.0.0)
       msgpack
 
@@ -124,7 +124,7 @@ GEM
     json (1.8.6)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (3.0.0.1.0)
+    libdatadog (4.0.0.1.0)
     libddwaf (1.11.0.0.0)
       ffi (~> 1.0)
     makara (0.4.1)

--- a/gemfiles/ruby_2.1.10_core_old.gemfile.lock
+++ b/gemfiles/ruby_2.1.10_core_old.gemfile.lock
@@ -3,7 +3,7 @@ PATH
   specs:
     ddtrace (1.14.0)
       debase-ruby_core_source (= 3.2.1)
-      libdatadog (~> 3.0.0.1.0)
+      libdatadog (~> 4.0.0.1.0)
       libddwaf (~> 1.11.0.0.0)
       msgpack
 
@@ -36,7 +36,7 @@ GEM
     json (2.5.1)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (3.0.0.1.0)
+    libdatadog (4.0.0.1.0)
     libddwaf (1.11.0.0.0)
       ffi (~> 1.0)
     memory_profiler (0.9.12)

--- a/gemfiles/ruby_2.1.10_rails32_mysql2.gemfile.lock
+++ b/gemfiles/ruby_2.1.10_rails32_mysql2.gemfile.lock
@@ -3,7 +3,7 @@ PATH
   specs:
     ddtrace (1.14.0)
       debase-ruby_core_source (= 3.2.1)
-      libdatadog (~> 3.0.0.1.0)
+      libdatadog (~> 4.0.0.1.0)
       libddwaf (~> 1.11.0.0.0)
       msgpack
 
@@ -73,7 +73,7 @@ GEM
     json (2.5.1)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (3.0.0.1.0)
+    libdatadog (4.0.0.1.0)
     libddwaf (1.11.0.0.0)
       ffi (~> 1.0)
     mail (2.5.5)

--- a/gemfiles/ruby_2.1.10_rails32_postgres.gemfile.lock
+++ b/gemfiles/ruby_2.1.10_rails32_postgres.gemfile.lock
@@ -3,7 +3,7 @@ PATH
   specs:
     ddtrace (1.14.0)
       debase-ruby_core_source (= 3.2.1)
-      libdatadog (~> 3.0.0.1.0)
+      libdatadog (~> 4.0.0.1.0)
       libddwaf (~> 1.11.0.0.0)
       msgpack
 
@@ -69,7 +69,7 @@ GEM
     json (2.5.1)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (3.0.0.1.0)
+    libdatadog (4.0.0.1.0)
     libddwaf (1.11.0.0.0)
       ffi (~> 1.0)
     mail (2.5.5)

--- a/gemfiles/ruby_2.1.10_rails32_postgres_redis.gemfile.lock
+++ b/gemfiles/ruby_2.1.10_rails32_postgres_redis.gemfile.lock
@@ -3,7 +3,7 @@ PATH
   specs:
     ddtrace (1.14.0)
       debase-ruby_core_source (= 3.2.1)
-      libdatadog (~> 3.0.0.1.0)
+      libdatadog (~> 4.0.0.1.0)
       libddwaf (~> 1.11.0.0.0)
       msgpack
 
@@ -69,7 +69,7 @@ GEM
     json (2.5.1)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (3.0.0.1.0)
+    libdatadog (4.0.0.1.0)
     libddwaf (1.11.0.0.0)
       ffi (~> 1.0)
     mail (2.5.5)

--- a/gemfiles/ruby_2.1.10_rails32_postgres_sidekiq.gemfile.lock
+++ b/gemfiles/ruby_2.1.10_rails32_postgres_sidekiq.gemfile.lock
@@ -3,7 +3,7 @@ PATH
   specs:
     ddtrace (1.14.0)
       debase-ruby_core_source (= 3.2.1)
-      libdatadog (~> 3.0.0.1.0)
+      libdatadog (~> 4.0.0.1.0)
       libddwaf (~> 1.11.0.0.0)
       msgpack
 
@@ -70,7 +70,7 @@ GEM
     json (1.8.6)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (3.0.0.1.0)
+    libdatadog (4.0.0.1.0)
     libddwaf (1.11.0.0.0)
       ffi (~> 1.0)
     mail (2.5.5)

--- a/gemfiles/ruby_2.1.10_rails4_mysql2.gemfile.lock
+++ b/gemfiles/ruby_2.1.10_rails4_mysql2.gemfile.lock
@@ -3,7 +3,7 @@ PATH
   specs:
     ddtrace (1.14.0)
       debase-ruby_core_source (= 3.2.1)
-      libdatadog (~> 3.0.0.1.0)
+      libdatadog (~> 4.0.0.1.0)
       libddwaf (~> 1.11.0.0.0)
       msgpack
 
@@ -77,7 +77,7 @@ GEM
     json (2.5.1)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (3.0.0.1.0)
+    libdatadog (4.0.0.1.0)
     libddwaf (1.11.0.0.0)
       ffi (~> 1.0)
     lograge (0.11.2)

--- a/gemfiles/ruby_2.1.10_rails4_postgres.gemfile.lock
+++ b/gemfiles/ruby_2.1.10_rails4_postgres.gemfile.lock
@@ -3,7 +3,7 @@ PATH
   specs:
     ddtrace (1.14.0)
       debase-ruby_core_source (= 3.2.1)
-      libdatadog (~> 3.0.0.1.0)
+      libdatadog (~> 4.0.0.1.0)
       libddwaf (~> 1.11.0.0.0)
       msgpack
 
@@ -77,7 +77,7 @@ GEM
     json (2.5.1)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (3.0.0.1.0)
+    libdatadog (4.0.0.1.0)
     libddwaf (1.11.0.0.0)
       ffi (~> 1.0)
     lograge (0.11.2)

--- a/gemfiles/ruby_2.1.10_rails4_postgres_redis.gemfile.lock
+++ b/gemfiles/ruby_2.1.10_rails4_postgres_redis.gemfile.lock
@@ -3,7 +3,7 @@ PATH
   specs:
     ddtrace (1.14.0)
       debase-ruby_core_source (= 3.2.1)
-      libdatadog (~> 3.0.0.1.0)
+      libdatadog (~> 4.0.0.1.0)
       libddwaf (~> 1.11.0.0.0)
       msgpack
 
@@ -77,7 +77,7 @@ GEM
     json (2.5.1)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (3.0.0.1.0)
+    libdatadog (4.0.0.1.0)
     libddwaf (1.11.0.0.0)
       ffi (~> 1.0)
     lograge (0.11.2)

--- a/gemfiles/ruby_2.1.10_rails4_semantic_logger.gemfile.lock
+++ b/gemfiles/ruby_2.1.10_rails4_semantic_logger.gemfile.lock
@@ -3,7 +3,7 @@ PATH
   specs:
     ddtrace (1.14.0)
       debase-ruby_core_source (= 3.2.1)
-      libdatadog (~> 3.0.0.1.0)
+      libdatadog (~> 4.0.0.1.0)
       libddwaf (~> 1.11.0.0.0)
       msgpack
 
@@ -77,7 +77,7 @@ GEM
     json (2.5.1)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (3.0.0.1.0)
+    libdatadog (4.0.0.1.0)
     libddwaf (1.11.0.0.0)
       ffi (~> 1.0)
     loofah (2.19.1)

--- a/gemfiles/ruby_2.1.10_redis_3.gemfile.lock
+++ b/gemfiles/ruby_2.1.10_redis_3.gemfile.lock
@@ -3,7 +3,7 @@ PATH
   specs:
     ddtrace (1.14.0)
       debase-ruby_core_source (= 3.2.1)
-      libdatadog (~> 3.0.0.1.0)
+      libdatadog (~> 4.0.0.1.0)
       libddwaf (~> 1.11.0.0.0)
       msgpack
 
@@ -36,7 +36,7 @@ GEM
     json (2.5.1)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (3.0.0.1.0)
+    libdatadog (4.0.0.1.0)
     libddwaf (1.11.0.0.0)
       ffi (~> 1.0)
     memory_profiler (0.9.12)

--- a/gemfiles/ruby_2.1.10_sinatra.gemfile.lock
+++ b/gemfiles/ruby_2.1.10_sinatra.gemfile.lock
@@ -3,7 +3,7 @@ PATH
   specs:
     ddtrace (1.14.0)
       debase-ruby_core_source (= 3.2.1)
-      libdatadog (~> 3.0.0.1.0)
+      libdatadog (~> 4.0.0.1.0)
       libddwaf (~> 1.11.0.0.0)
       msgpack
 
@@ -36,7 +36,7 @@ GEM
     json (2.5.1)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (3.0.0.1.0)
+    libdatadog (4.0.0.1.0)
     libddwaf (1.11.0.0.0)
       ffi (~> 1.0)
     memory_profiler (0.9.12)

--- a/gemfiles/ruby_2.2.10_contrib.gemfile.lock
+++ b/gemfiles/ruby_2.2.10_contrib.gemfile.lock
@@ -3,7 +3,7 @@ PATH
   specs:
     ddtrace (1.14.0)
       debase-ruby_core_source (= 3.2.1)
-      libdatadog (~> 3.0.0.1.0)
+      libdatadog (~> 4.0.0.1.0)
       libddwaf (~> 1.11.0.0.0)
       msgpack
 
@@ -1263,7 +1263,7 @@ GEM
       addressable (>= 2.4)
     jsonapi-renderer (0.2.2)
     king_konf (1.0.1)
-    libdatadog (3.0.0.1.0)
+    libdatadog (4.0.0.1.0)
     libddwaf (1.11.0.0.0)
       ffi (~> 1.0)
     lograge (0.11.2)

--- a/gemfiles/ruby_2.2.10_core_old.gemfile.lock
+++ b/gemfiles/ruby_2.2.10_core_old.gemfile.lock
@@ -3,7 +3,7 @@ PATH
   specs:
     ddtrace (1.14.0)
       debase-ruby_core_source (= 3.2.1)
-      libdatadog (~> 3.0.0.1.0)
+      libdatadog (~> 4.0.0.1.0)
       libddwaf (~> 1.11.0.0.0)
       msgpack
 
@@ -36,7 +36,7 @@ GEM
     json (2.5.1)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (3.0.0.1.0)
+    libdatadog (4.0.0.1.0)
     libddwaf (1.11.0.0.0)
       ffi (~> 1.0)
     memory_profiler (0.9.12)

--- a/gemfiles/ruby_2.2.10_rails32_mysql2.gemfile.lock
+++ b/gemfiles/ruby_2.2.10_rails32_mysql2.gemfile.lock
@@ -3,7 +3,7 @@ PATH
   specs:
     ddtrace (1.14.0)
       debase-ruby_core_source (= 3.2.1)
-      libdatadog (~> 3.0.0.1.0)
+      libdatadog (~> 4.0.0.1.0)
       libddwaf (~> 1.11.0.0.0)
       msgpack
 
@@ -73,7 +73,7 @@ GEM
     json (2.5.1)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (3.0.0.1.0)
+    libdatadog (4.0.0.1.0)
     libddwaf (1.11.0.0.0)
       ffi (~> 1.0)
     mail (2.5.5)

--- a/gemfiles/ruby_2.2.10_rails32_postgres.gemfile.lock
+++ b/gemfiles/ruby_2.2.10_rails32_postgres.gemfile.lock
@@ -3,7 +3,7 @@ PATH
   specs:
     ddtrace (1.14.0)
       debase-ruby_core_source (= 3.2.1)
-      libdatadog (~> 3.0.0.1.0)
+      libdatadog (~> 4.0.0.1.0)
       libddwaf (~> 1.11.0.0.0)
       msgpack
 
@@ -69,7 +69,7 @@ GEM
     json (2.5.1)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (3.0.0.1.0)
+    libdatadog (4.0.0.1.0)
     libddwaf (1.11.0.0.0)
       ffi (~> 1.0)
     mail (2.5.5)

--- a/gemfiles/ruby_2.2.10_rails32_postgres_redis.gemfile.lock
+++ b/gemfiles/ruby_2.2.10_rails32_postgres_redis.gemfile.lock
@@ -3,7 +3,7 @@ PATH
   specs:
     ddtrace (1.14.0)
       debase-ruby_core_source (= 3.2.1)
-      libdatadog (~> 3.0.0.1.0)
+      libdatadog (~> 4.0.0.1.0)
       libddwaf (~> 1.11.0.0.0)
       msgpack
 
@@ -69,7 +69,7 @@ GEM
     json (2.5.1)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (3.0.0.1.0)
+    libdatadog (4.0.0.1.0)
     libddwaf (1.11.0.0.0)
       ffi (~> 1.0)
     mail (2.5.5)

--- a/gemfiles/ruby_2.2.10_rails32_postgres_sidekiq.gemfile.lock
+++ b/gemfiles/ruby_2.2.10_rails32_postgres_sidekiq.gemfile.lock
@@ -3,7 +3,7 @@ PATH
   specs:
     ddtrace (1.14.0)
       debase-ruby_core_source (= 3.2.1)
-      libdatadog (~> 3.0.0.1.0)
+      libdatadog (~> 4.0.0.1.0)
       libddwaf (~> 1.11.0.0.0)
       msgpack
 
@@ -70,7 +70,7 @@ GEM
     json (1.8.6)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (3.0.0.1.0)
+    libdatadog (4.0.0.1.0)
     libddwaf (1.11.0.0.0)
       ffi (~> 1.0)
     mail (2.5.5)

--- a/gemfiles/ruby_2.2.10_rails4_mysql2.gemfile.lock
+++ b/gemfiles/ruby_2.2.10_rails4_mysql2.gemfile.lock
@@ -3,7 +3,7 @@ PATH
   specs:
     ddtrace (1.14.0)
       debase-ruby_core_source (= 3.2.1)
-      libdatadog (~> 3.0.0.1.0)
+      libdatadog (~> 4.0.0.1.0)
       libddwaf (~> 1.11.0.0.0)
       msgpack
 
@@ -77,7 +77,7 @@ GEM
     json (2.5.1)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (3.0.0.1.0)
+    libdatadog (4.0.0.1.0)
     libddwaf (1.11.0.0.0)
       ffi (~> 1.0)
     lograge (0.11.2)

--- a/gemfiles/ruby_2.2.10_rails4_postgres.gemfile.lock
+++ b/gemfiles/ruby_2.2.10_rails4_postgres.gemfile.lock
@@ -3,7 +3,7 @@ PATH
   specs:
     ddtrace (1.14.0)
       debase-ruby_core_source (= 3.2.1)
-      libdatadog (~> 3.0.0.1.0)
+      libdatadog (~> 4.0.0.1.0)
       libddwaf (~> 1.11.0.0.0)
       msgpack
 
@@ -77,7 +77,7 @@ GEM
     json (2.5.1)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (3.0.0.1.0)
+    libdatadog (4.0.0.1.0)
     libddwaf (1.11.0.0.0)
       ffi (~> 1.0)
     lograge (0.11.2)

--- a/gemfiles/ruby_2.2.10_rails4_postgres_redis.gemfile.lock
+++ b/gemfiles/ruby_2.2.10_rails4_postgres_redis.gemfile.lock
@@ -3,7 +3,7 @@ PATH
   specs:
     ddtrace (1.14.0)
       debase-ruby_core_source (= 3.2.1)
-      libdatadog (~> 3.0.0.1.0)
+      libdatadog (~> 4.0.0.1.0)
       libddwaf (~> 1.11.0.0.0)
       msgpack
 
@@ -77,7 +77,7 @@ GEM
     json (2.5.1)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (3.0.0.1.0)
+    libdatadog (4.0.0.1.0)
     libddwaf (1.11.0.0.0)
       ffi (~> 1.0)
     lograge (0.11.2)

--- a/gemfiles/ruby_2.2.10_rails4_postgres_sidekiq.gemfile.lock
+++ b/gemfiles/ruby_2.2.10_rails4_postgres_sidekiq.gemfile.lock
@@ -3,7 +3,7 @@ PATH
   specs:
     ddtrace (1.14.0)
       debase-ruby_core_source (= 3.2.1)
-      libdatadog (~> 3.0.0.1.0)
+      libdatadog (~> 4.0.0.1.0)
       libddwaf (~> 1.11.0.0.0)
       msgpack
 
@@ -78,7 +78,7 @@ GEM
     json (2.5.1)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (3.0.0.1.0)
+    libdatadog (4.0.0.1.0)
     libddwaf (1.11.0.0.0)
       ffi (~> 1.0)
     lograge (0.11.2)

--- a/gemfiles/ruby_2.2.10_rails4_semantic_logger.gemfile.lock
+++ b/gemfiles/ruby_2.2.10_rails4_semantic_logger.gemfile.lock
@@ -3,7 +3,7 @@ PATH
   specs:
     ddtrace (1.14.0)
       debase-ruby_core_source (= 3.2.1)
-      libdatadog (~> 3.0.0.1.0)
+      libdatadog (~> 4.0.0.1.0)
       libddwaf (~> 1.11.0.0.0)
       msgpack
 
@@ -77,7 +77,7 @@ GEM
     json (2.5.1)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (3.0.0.1.0)
+    libdatadog (4.0.0.1.0)
     libddwaf (1.11.0.0.0)
       ffi (~> 1.0)
     loofah (2.19.1)

--- a/gemfiles/ruby_2.2.10_rails5_mysql2.gemfile.lock
+++ b/gemfiles/ruby_2.2.10_rails5_mysql2.gemfile.lock
@@ -3,7 +3,7 @@ PATH
   specs:
     ddtrace (1.14.0)
       debase-ruby_core_source (= 3.2.1)
-      libdatadog (~> 3.0.0.1.0)
+      libdatadog (~> 4.0.0.1.0)
       libddwaf (~> 1.11.0.0.0)
       msgpack
 
@@ -84,7 +84,7 @@ GEM
     json (2.5.1)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (3.0.0.1.0)
+    libdatadog (4.0.0.1.0)
     libddwaf (1.11.0.0.0)
       ffi (~> 1.0)
     lograge (0.11.2)

--- a/gemfiles/ruby_2.2.10_rails5_postgres.gemfile.lock
+++ b/gemfiles/ruby_2.2.10_rails5_postgres.gemfile.lock
@@ -3,7 +3,7 @@ PATH
   specs:
     ddtrace (1.14.0)
       debase-ruby_core_source (= 3.2.1)
-      libdatadog (~> 3.0.0.1.0)
+      libdatadog (~> 4.0.0.1.0)
       libddwaf (~> 1.11.0.0.0)
       msgpack
 
@@ -84,7 +84,7 @@ GEM
     json (2.5.1)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (3.0.0.1.0)
+    libdatadog (4.0.0.1.0)
     libddwaf (1.11.0.0.0)
       ffi (~> 1.0)
     lograge (0.11.2)

--- a/gemfiles/ruby_2.2.10_rails5_postgres_redis.gemfile.lock
+++ b/gemfiles/ruby_2.2.10_rails5_postgres_redis.gemfile.lock
@@ -3,7 +3,7 @@ PATH
   specs:
     ddtrace (1.14.0)
       debase-ruby_core_source (= 3.2.1)
-      libdatadog (~> 3.0.0.1.0)
+      libdatadog (~> 4.0.0.1.0)
       libddwaf (~> 1.11.0.0.0)
       msgpack
 
@@ -84,7 +84,7 @@ GEM
     json (2.5.1)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (3.0.0.1.0)
+    libdatadog (4.0.0.1.0)
     libddwaf (1.11.0.0.0)
       ffi (~> 1.0)
     lograge (0.11.2)

--- a/gemfiles/ruby_2.2.10_rails5_postgres_redis_activesupport.gemfile.lock
+++ b/gemfiles/ruby_2.2.10_rails5_postgres_redis_activesupport.gemfile.lock
@@ -3,7 +3,7 @@ PATH
   specs:
     ddtrace (1.14.0)
       debase-ruby_core_source (= 3.2.1)
-      libdatadog (~> 3.0.0.1.0)
+      libdatadog (~> 4.0.0.1.0)
       libddwaf (~> 1.11.0.0.0)
       msgpack
 
@@ -84,7 +84,7 @@ GEM
     json (2.5.1)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (3.0.0.1.0)
+    libdatadog (4.0.0.1.0)
     libddwaf (1.11.0.0.0)
       ffi (~> 1.0)
     lograge (0.11.2)

--- a/gemfiles/ruby_2.2.10_rails5_postgres_sidekiq.gemfile.lock
+++ b/gemfiles/ruby_2.2.10_rails5_postgres_sidekiq.gemfile.lock
@@ -3,7 +3,7 @@ PATH
   specs:
     ddtrace (1.14.0)
       debase-ruby_core_source (= 3.2.1)
-      libdatadog (~> 3.0.0.1.0)
+      libdatadog (~> 4.0.0.1.0)
       libddwaf (~> 1.11.0.0.0)
       msgpack
 
@@ -85,7 +85,7 @@ GEM
     json (2.5.1)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (3.0.0.1.0)
+    libdatadog (4.0.0.1.0)
     libddwaf (1.11.0.0.0)
       ffi (~> 1.0)
     lograge (0.11.2)

--- a/gemfiles/ruby_2.2.10_rails5_semantic_logger.gemfile.lock
+++ b/gemfiles/ruby_2.2.10_rails5_semantic_logger.gemfile.lock
@@ -3,7 +3,7 @@ PATH
   specs:
     ddtrace (1.14.0)
       debase-ruby_core_source (= 3.2.1)
-      libdatadog (~> 3.0.0.1.0)
+      libdatadog (~> 4.0.0.1.0)
       libddwaf (~> 1.11.0.0.0)
       msgpack
 
@@ -84,7 +84,7 @@ GEM
     json (2.5.1)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (3.0.0.1.0)
+    libdatadog (4.0.0.1.0)
     libddwaf (1.11.0.0.0)
       ffi (~> 1.0)
     loofah (2.19.1)

--- a/gemfiles/ruby_2.2.10_redis_3.gemfile.lock
+++ b/gemfiles/ruby_2.2.10_redis_3.gemfile.lock
@@ -3,7 +3,7 @@ PATH
   specs:
     ddtrace (1.14.0)
       debase-ruby_core_source (= 3.2.1)
-      libdatadog (~> 3.0.0.1.0)
+      libdatadog (~> 4.0.0.1.0)
       libddwaf (~> 1.11.0.0.0)
       msgpack
 
@@ -36,7 +36,7 @@ GEM
     json (2.5.1)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (3.0.0.1.0)
+    libdatadog (4.0.0.1.0)
     libddwaf (1.11.0.0.0)
       ffi (~> 1.0)
     memory_profiler (0.9.12)

--- a/gemfiles/ruby_2.2.10_sinatra.gemfile.lock
+++ b/gemfiles/ruby_2.2.10_sinatra.gemfile.lock
@@ -3,7 +3,7 @@ PATH
   specs:
     ddtrace (1.14.0)
       debase-ruby_core_source (= 3.2.1)
-      libdatadog (~> 3.0.0.1.0)
+      libdatadog (~> 4.0.0.1.0)
       libddwaf (~> 1.11.0.0.0)
       msgpack
 
@@ -36,7 +36,7 @@ GEM
     json (2.5.1)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (3.0.0.1.0)
+    libdatadog (4.0.0.1.0)
     libddwaf (1.11.0.0.0)
       ffi (~> 1.0)
     memory_profiler (0.9.12)

--- a/gemfiles/ruby_2.3.8_activerecord_3.gemfile.lock
+++ b/gemfiles/ruby_2.3.8_activerecord_3.gemfile.lock
@@ -3,7 +3,7 @@ PATH
   specs:
     ddtrace (1.14.0)
       debase-ruby_core_source (= 3.2.1)
-      libdatadog (~> 3.0.0.1.0)
+      libdatadog (~> 4.0.0.1.0)
       libddwaf (~> 1.11.0.0.0)
       msgpack
 
@@ -53,7 +53,7 @@ GEM
     json (2.6.3)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (3.0.0.1.0)
+    libdatadog (4.0.0.1.0)
     libddwaf (1.11.0.0.0)
       ffi (~> 1.0)
     makara (0.3.10)

--- a/gemfiles/ruby_2.3.8_contrib.gemfile.lock
+++ b/gemfiles/ruby_2.3.8_contrib.gemfile.lock
@@ -3,7 +3,7 @@ PATH
   specs:
     ddtrace (1.14.0)
       debase-ruby_core_source (= 3.2.1)
-      libdatadog (~> 3.0.0.1.0)
+      libdatadog (~> 4.0.0.1.0)
       libddwaf (~> 1.11.0.0.0)
       msgpack
 
@@ -1509,7 +1509,7 @@ GEM
       addressable (>= 2.4)
     jsonapi-renderer (0.2.2)
     king_konf (1.0.1)
-    libdatadog (3.0.0.1.0)
+    libdatadog (4.0.0.1.0)
     libddwaf (1.11.0.0.0)
       ffi (~> 1.0)
     lograge (0.11.2)

--- a/gemfiles/ruby_2.3.8_contrib_old.gemfile.lock
+++ b/gemfiles/ruby_2.3.8_contrib_old.gemfile.lock
@@ -3,7 +3,7 @@ PATH
   specs:
     ddtrace (1.14.0)
       debase-ruby_core_source (= 3.2.1)
-      libdatadog (~> 3.0.0.1.0)
+      libdatadog (~> 4.0.0.1.0)
       libddwaf (~> 1.11.0.0.0)
       msgpack
 
@@ -48,7 +48,7 @@ GEM
     json (2.6.3)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (3.0.0.1.0)
+    libdatadog (4.0.0.1.0)
     libddwaf (1.11.0.0.0)
       ffi (~> 1.0)
     memory_profiler (0.9.14)

--- a/gemfiles/ruby_2.3.8_core_old.gemfile.lock
+++ b/gemfiles/ruby_2.3.8_core_old.gemfile.lock
@@ -3,7 +3,7 @@ PATH
   specs:
     ddtrace (1.14.0)
       debase-ruby_core_source (= 3.2.1)
-      libdatadog (~> 3.0.0.1.0)
+      libdatadog (~> 4.0.0.1.0)
       libddwaf (~> 1.11.0.0.0)
       msgpack
 
@@ -36,7 +36,7 @@ GEM
     json (2.6.3)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (3.0.0.1.0)
+    libdatadog (4.0.0.1.0)
     libddwaf (1.11.0.0.0)
       ffi (~> 1.0)
     memory_profiler (0.9.14)

--- a/gemfiles/ruby_2.3.8_cucumber3.gemfile.lock
+++ b/gemfiles/ruby_2.3.8_cucumber3.gemfile.lock
@@ -3,7 +3,7 @@ PATH
   specs:
     ddtrace (1.14.0)
       debase-ruby_core_source (= 3.2.1)
-      libdatadog (~> 3.0.0.1.0)
+      libdatadog (~> 4.0.0.1.0)
       libddwaf (~> 1.11.0.0.0)
       msgpack
 
@@ -54,7 +54,7 @@ GEM
     json (2.6.3)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (3.0.0.1.0)
+    libdatadog (4.0.0.1.0)
     libddwaf (1.11.0.0.0)
       ffi (~> 1.0)
     memory_profiler (0.9.14)

--- a/gemfiles/ruby_2.3.8_cucumber4.gemfile.lock
+++ b/gemfiles/ruby_2.3.8_cucumber4.gemfile.lock
@@ -3,7 +3,7 @@ PATH
   specs:
     ddtrace (1.14.0)
       debase-ruby_core_source (= 3.2.1)
-      libdatadog (~> 3.0.0.1.0)
+      libdatadog (~> 4.0.0.1.0)
       libddwaf (~> 1.11.0.0.0)
       msgpack
 
@@ -74,7 +74,7 @@ GEM
     json (2.6.3)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (3.0.0.1.0)
+    libdatadog (4.0.0.1.0)
     libddwaf (1.11.0.0.0)
       ffi (~> 1.0)
     memory_profiler (0.9.14)

--- a/gemfiles/ruby_2.3.8_hanami_1.gemfile.lock
+++ b/gemfiles/ruby_2.3.8_hanami_1.gemfile.lock
@@ -3,7 +3,7 @@ PATH
   specs:
     ddtrace (1.14.0)
       debase-ruby_core_source (= 3.2.1)
-      libdatadog (~> 3.0.0.1.0)
+      libdatadog (~> 4.0.0.1.0)
       libddwaf (~> 1.11.0.0.0)
       msgpack
 
@@ -111,7 +111,7 @@ GEM
     json (2.6.3)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (3.0.0.1.0)
+    libdatadog (4.0.0.1.0)
     libddwaf (1.11.0.0.0)
       ffi (~> 1.0)
     mail (2.7.1)

--- a/gemfiles/ruby_2.3.8_rails32_mysql2.gemfile.lock
+++ b/gemfiles/ruby_2.3.8_rails32_mysql2.gemfile.lock
@@ -3,7 +3,7 @@ PATH
   specs:
     ddtrace (1.14.0)
       debase-ruby_core_source (= 3.2.1)
-      libdatadog (~> 3.0.0.1.0)
+      libdatadog (~> 4.0.0.1.0)
       libddwaf (~> 1.11.0.0.0)
       msgpack
 
@@ -73,7 +73,7 @@ GEM
     json (2.6.3)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (3.0.0.1.0)
+    libdatadog (4.0.0.1.0)
     libddwaf (1.11.0.0.0)
       ffi (~> 1.0)
     mail (2.5.5)

--- a/gemfiles/ruby_2.3.8_rails32_postgres.gemfile.lock
+++ b/gemfiles/ruby_2.3.8_rails32_postgres.gemfile.lock
@@ -3,7 +3,7 @@ PATH
   specs:
     ddtrace (1.14.0)
       debase-ruby_core_source (= 3.2.1)
-      libdatadog (~> 3.0.0.1.0)
+      libdatadog (~> 4.0.0.1.0)
       libddwaf (~> 1.11.0.0.0)
       msgpack
 
@@ -69,7 +69,7 @@ GEM
     json (2.6.3)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (3.0.0.1.0)
+    libdatadog (4.0.0.1.0)
     libddwaf (1.11.0.0.0)
       ffi (~> 1.0)
     mail (2.5.5)

--- a/gemfiles/ruby_2.3.8_rails32_postgres_redis.gemfile.lock
+++ b/gemfiles/ruby_2.3.8_rails32_postgres_redis.gemfile.lock
@@ -3,7 +3,7 @@ PATH
   specs:
     ddtrace (1.14.0)
       debase-ruby_core_source (= 3.2.1)
-      libdatadog (~> 3.0.0.1.0)
+      libdatadog (~> 4.0.0.1.0)
       libddwaf (~> 1.11.0.0.0)
       msgpack
 
@@ -69,7 +69,7 @@ GEM
     json (2.6.3)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (3.0.0.1.0)
+    libdatadog (4.0.0.1.0)
     libddwaf (1.11.0.0.0)
       ffi (~> 1.0)
     mail (2.5.5)

--- a/gemfiles/ruby_2.3.8_rails32_postgres_sidekiq.gemfile.lock
+++ b/gemfiles/ruby_2.3.8_rails32_postgres_sidekiq.gemfile.lock
@@ -3,7 +3,7 @@ PATH
   specs:
     ddtrace (1.14.0)
       debase-ruby_core_source (= 3.2.1)
-      libdatadog (~> 3.0.0.1.0)
+      libdatadog (~> 4.0.0.1.0)
       libddwaf (~> 1.11.0.0.0)
       msgpack
 
@@ -70,7 +70,7 @@ GEM
     json (1.8.6)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (3.0.0.1.0)
+    libdatadog (4.0.0.1.0)
     libddwaf (1.11.0.0.0)
       ffi (~> 1.0)
     mail (2.5.5)

--- a/gemfiles/ruby_2.3.8_rails4_mysql2.gemfile.lock
+++ b/gemfiles/ruby_2.3.8_rails4_mysql2.gemfile.lock
@@ -3,7 +3,7 @@ PATH
   specs:
     ddtrace (1.14.0)
       debase-ruby_core_source (= 3.2.1)
-      libdatadog (~> 3.0.0.1.0)
+      libdatadog (~> 4.0.0.1.0)
       libddwaf (~> 1.11.0.0.0)
       msgpack
 
@@ -77,7 +77,7 @@ GEM
     json (2.6.3)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (3.0.0.1.0)
+    libdatadog (4.0.0.1.0)
     libddwaf (1.11.0.0.0)
       ffi (~> 1.0)
     lograge (0.11.2)

--- a/gemfiles/ruby_2.3.8_rails4_postgres.gemfile.lock
+++ b/gemfiles/ruby_2.3.8_rails4_postgres.gemfile.lock
@@ -3,7 +3,7 @@ PATH
   specs:
     ddtrace (1.14.0)
       debase-ruby_core_source (= 3.2.1)
-      libdatadog (~> 3.0.0.1.0)
+      libdatadog (~> 4.0.0.1.0)
       libddwaf (~> 1.11.0.0.0)
       msgpack
 
@@ -77,7 +77,7 @@ GEM
     json (2.6.3)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (3.0.0.1.0)
+    libdatadog (4.0.0.1.0)
     libddwaf (1.11.0.0.0)
       ffi (~> 1.0)
     lograge (0.11.2)

--- a/gemfiles/ruby_2.3.8_rails4_postgres_redis.gemfile.lock
+++ b/gemfiles/ruby_2.3.8_rails4_postgres_redis.gemfile.lock
@@ -3,7 +3,7 @@ PATH
   specs:
     ddtrace (1.14.0)
       debase-ruby_core_source (= 3.2.1)
-      libdatadog (~> 3.0.0.1.0)
+      libdatadog (~> 4.0.0.1.0)
       libddwaf (~> 1.11.0.0.0)
       msgpack
 
@@ -77,7 +77,7 @@ GEM
     json (2.6.3)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (3.0.0.1.0)
+    libdatadog (4.0.0.1.0)
     libddwaf (1.11.0.0.0)
       ffi (~> 1.0)
     lograge (0.11.2)

--- a/gemfiles/ruby_2.3.8_rails4_postgres_sidekiq.gemfile.lock
+++ b/gemfiles/ruby_2.3.8_rails4_postgres_sidekiq.gemfile.lock
@@ -3,7 +3,7 @@ PATH
   specs:
     ddtrace (1.14.0)
       debase-ruby_core_source (= 3.2.1)
-      libdatadog (~> 3.0.0.1.0)
+      libdatadog (~> 4.0.0.1.0)
       libddwaf (~> 1.11.0.0.0)
       msgpack
 
@@ -78,7 +78,7 @@ GEM
     json (2.6.3)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (3.0.0.1.0)
+    libdatadog (4.0.0.1.0)
     libddwaf (1.11.0.0.0)
       ffi (~> 1.0)
     lograge (0.11.2)

--- a/gemfiles/ruby_2.3.8_rails4_semantic_logger.gemfile.lock
+++ b/gemfiles/ruby_2.3.8_rails4_semantic_logger.gemfile.lock
@@ -3,7 +3,7 @@ PATH
   specs:
     ddtrace (1.14.0)
       debase-ruby_core_source (= 3.2.1)
-      libdatadog (~> 3.0.0.1.0)
+      libdatadog (~> 4.0.0.1.0)
       libddwaf (~> 1.11.0.0.0)
       msgpack
 
@@ -77,7 +77,7 @@ GEM
     json (2.6.3)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (3.0.0.1.0)
+    libdatadog (4.0.0.1.0)
     libddwaf (1.11.0.0.0)
       ffi (~> 1.0)
     loofah (2.19.1)

--- a/gemfiles/ruby_2.3.8_rails5_mysql2.gemfile.lock
+++ b/gemfiles/ruby_2.3.8_rails5_mysql2.gemfile.lock
@@ -3,7 +3,7 @@ PATH
   specs:
     ddtrace (1.14.0)
       debase-ruby_core_source (= 3.2.1)
-      libdatadog (~> 3.0.0.1.0)
+      libdatadog (~> 4.0.0.1.0)
       libddwaf (~> 1.11.0.0.0)
       msgpack
 
@@ -84,7 +84,7 @@ GEM
     json (2.6.3)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (3.0.0.1.0)
+    libdatadog (4.0.0.1.0)
     libddwaf (1.11.0.0.0)
       ffi (~> 1.0)
     lograge (0.11.2)

--- a/gemfiles/ruby_2.3.8_rails5_postgres.gemfile.lock
+++ b/gemfiles/ruby_2.3.8_rails5_postgres.gemfile.lock
@@ -3,7 +3,7 @@ PATH
   specs:
     ddtrace (1.14.0)
       debase-ruby_core_source (= 3.2.1)
-      libdatadog (~> 3.0.0.1.0)
+      libdatadog (~> 4.0.0.1.0)
       libddwaf (~> 1.11.0.0.0)
       msgpack
 
@@ -84,7 +84,7 @@ GEM
     json (2.6.3)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (3.0.0.1.0)
+    libdatadog (4.0.0.1.0)
     libddwaf (1.11.0.0.0)
       ffi (~> 1.0)
     lograge (0.11.2)

--- a/gemfiles/ruby_2.3.8_rails5_postgres_redis.gemfile.lock
+++ b/gemfiles/ruby_2.3.8_rails5_postgres_redis.gemfile.lock
@@ -3,7 +3,7 @@ PATH
   specs:
     ddtrace (1.14.0)
       debase-ruby_core_source (= 3.2.1)
-      libdatadog (~> 3.0.0.1.0)
+      libdatadog (~> 4.0.0.1.0)
       libddwaf (~> 1.11.0.0.0)
       msgpack
 
@@ -84,7 +84,7 @@ GEM
     json (2.6.3)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (3.0.0.1.0)
+    libdatadog (4.0.0.1.0)
     libddwaf (1.11.0.0.0)
       ffi (~> 1.0)
     lograge (0.11.2)

--- a/gemfiles/ruby_2.3.8_rails5_postgres_redis_activesupport.gemfile.lock
+++ b/gemfiles/ruby_2.3.8_rails5_postgres_redis_activesupport.gemfile.lock
@@ -3,7 +3,7 @@ PATH
   specs:
     ddtrace (1.14.0)
       debase-ruby_core_source (= 3.2.1)
-      libdatadog (~> 3.0.0.1.0)
+      libdatadog (~> 4.0.0.1.0)
       libddwaf (~> 1.11.0.0.0)
       msgpack
 
@@ -84,7 +84,7 @@ GEM
     json (2.6.3)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (3.0.0.1.0)
+    libdatadog (4.0.0.1.0)
     libddwaf (1.11.0.0.0)
       ffi (~> 1.0)
     lograge (0.11.2)

--- a/gemfiles/ruby_2.3.8_rails5_postgres_sidekiq.gemfile.lock
+++ b/gemfiles/ruby_2.3.8_rails5_postgres_sidekiq.gemfile.lock
@@ -3,7 +3,7 @@ PATH
   specs:
     ddtrace (1.14.0)
       debase-ruby_core_source (= 3.2.1)
-      libdatadog (~> 3.0.0.1.0)
+      libdatadog (~> 4.0.0.1.0)
       libddwaf (~> 1.11.0.0.0)
       msgpack
 
@@ -85,7 +85,7 @@ GEM
     json (2.6.3)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (3.0.0.1.0)
+    libdatadog (4.0.0.1.0)
     libddwaf (1.11.0.0.0)
       ffi (~> 1.0)
     lograge (0.11.2)

--- a/gemfiles/ruby_2.3.8_rails5_semantic_logger.gemfile.lock
+++ b/gemfiles/ruby_2.3.8_rails5_semantic_logger.gemfile.lock
@@ -3,7 +3,7 @@ PATH
   specs:
     ddtrace (1.14.0)
       debase-ruby_core_source (= 3.2.1)
-      libdatadog (~> 3.0.0.1.0)
+      libdatadog (~> 4.0.0.1.0)
       libddwaf (~> 1.11.0.0.0)
       msgpack
 
@@ -84,7 +84,7 @@ GEM
     json (2.6.3)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (3.0.0.1.0)
+    libdatadog (4.0.0.1.0)
     libddwaf (1.11.0.0.0)
       ffi (~> 1.0)
     loofah (2.19.1)

--- a/gemfiles/ruby_2.3.8_redis_3.gemfile.lock
+++ b/gemfiles/ruby_2.3.8_redis_3.gemfile.lock
@@ -3,7 +3,7 @@ PATH
   specs:
     ddtrace (1.14.0)
       debase-ruby_core_source (= 3.2.1)
-      libdatadog (~> 3.0.0.1.0)
+      libdatadog (~> 4.0.0.1.0)
       libddwaf (~> 1.11.0.0.0)
       msgpack
 
@@ -36,7 +36,7 @@ GEM
     json (2.6.3)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (3.0.0.1.0)
+    libdatadog (4.0.0.1.0)
     libddwaf (1.11.0.0.0)
       ffi (~> 1.0)
     memory_profiler (0.9.14)

--- a/gemfiles/ruby_2.3.8_resque2_redis3.gemfile.lock
+++ b/gemfiles/ruby_2.3.8_resque2_redis3.gemfile.lock
@@ -3,7 +3,7 @@ PATH
   specs:
     ddtrace (1.14.0)
       debase-ruby_core_source (= 3.2.1)
-      libdatadog (~> 3.0.0.1.0)
+      libdatadog (~> 4.0.0.1.0)
       libddwaf (~> 1.11.0.0.0)
       msgpack
 
@@ -36,7 +36,7 @@ GEM
     json (2.6.3)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (3.0.0.1.0)
+    libdatadog (4.0.0.1.0)
     libddwaf (1.11.0.0.0)
       ffi (~> 1.0)
     memory_profiler (0.9.14)

--- a/gemfiles/ruby_2.3.8_resque2_redis4.gemfile.lock
+++ b/gemfiles/ruby_2.3.8_resque2_redis4.gemfile.lock
@@ -3,7 +3,7 @@ PATH
   specs:
     ddtrace (1.14.0)
       debase-ruby_core_source (= 3.2.1)
-      libdatadog (~> 3.0.0.1.0)
+      libdatadog (~> 4.0.0.1.0)
       libddwaf (~> 1.11.0.0.0)
       msgpack
 
@@ -36,7 +36,7 @@ GEM
     json (2.6.3)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (3.0.0.1.0)
+    libdatadog (4.0.0.1.0)
     libddwaf (1.11.0.0.0)
       ffi (~> 1.0)
     memory_profiler (0.9.14)

--- a/gemfiles/ruby_2.3.8_sinatra.gemfile.lock
+++ b/gemfiles/ruby_2.3.8_sinatra.gemfile.lock
@@ -3,7 +3,7 @@ PATH
   specs:
     ddtrace (1.14.0)
       debase-ruby_core_source (= 3.2.1)
-      libdatadog (~> 3.0.0.1.0)
+      libdatadog (~> 4.0.0.1.0)
       libddwaf (~> 1.11.0.0.0)
       msgpack
 
@@ -36,7 +36,7 @@ GEM
     json (2.6.3)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (3.0.0.1.0)
+    libdatadog (4.0.0.1.0)
     libddwaf (1.11.0.0.0)
       ffi (~> 1.0)
     memory_profiler (0.9.14)

--- a/gemfiles/ruby_2.4.10_activerecord_4.gemfile.lock
+++ b/gemfiles/ruby_2.4.10_activerecord_4.gemfile.lock
@@ -3,7 +3,7 @@ PATH
   specs:
     ddtrace (1.14.0)
       debase-ruby_core_source (= 3.2.1)
-      libdatadog (~> 3.0.0.1.0)
+      libdatadog (~> 4.0.0.1.0)
       libddwaf (~> 1.11.0.0.0)
       msgpack
 
@@ -51,7 +51,7 @@ GEM
       concurrent-ruby (~> 1.0)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (3.0.0.1.0-aarch64-linux)
+    libdatadog (4.0.0.1.0-aarch64-linux)
     libddwaf (1.11.0.0.0-aarch64-linux)
       ffi (~> 1.0)
     makara (0.3.10)

--- a/gemfiles/ruby_2.4.10_contrib.gemfile.lock
+++ b/gemfiles/ruby_2.4.10_contrib.gemfile.lock
@@ -3,7 +3,7 @@ PATH
   specs:
     ddtrace (1.14.0)
       debase-ruby_core_source (= 3.2.1)
-      libdatadog (~> 3.0.0.1.0)
+      libdatadog (~> 4.0.0.1.0)
       libddwaf (~> 1.11.0.0.0)
       msgpack
 
@@ -1544,8 +1544,8 @@ GEM
       addressable (>= 2.4)
     jsonapi-renderer (0.2.2)
     king_konf (1.0.1)
-    libdatadog (3.0.0.1.0-aarch64-linux)
-    libdatadog (3.0.0.1.0-x86_64-linux)
+    libdatadog (4.0.0.1.0-aarch64-linux)
+    libdatadog (4.0.0.1.0-x86_64-linux)
     libddwaf (1.11.0.0.0-aarch64-linux)
       ffi (~> 1.0)
     libddwaf (1.11.0.0.0-x86_64-linux)

--- a/gemfiles/ruby_2.4.10_contrib_old.gemfile.lock
+++ b/gemfiles/ruby_2.4.10_contrib_old.gemfile.lock
@@ -3,7 +3,7 @@ PATH
   specs:
     ddtrace (1.14.0)
       debase-ruby_core_source (= 3.2.1)
-      libdatadog (~> 3.0.0.1.0)
+      libdatadog (~> 4.0.0.1.0)
       libddwaf (~> 1.11.0.0.0)
       msgpack
 
@@ -50,8 +50,8 @@ GEM
     hashdiff (1.0.1)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (3.0.0.1.0-aarch64-linux)
-    libdatadog (3.0.0.1.0-x86_64-linux)
+    libdatadog (4.0.0.1.0-aarch64-linux)
+    libdatadog (4.0.0.1.0-x86_64-linux)
     libddwaf (1.11.0.0.0-aarch64-linux)
       ffi (~> 1.0)
     libddwaf (1.11.0.0.0-x86_64-linux)

--- a/gemfiles/ruby_2.4.10_core_old.gemfile.lock
+++ b/gemfiles/ruby_2.4.10_core_old.gemfile.lock
@@ -3,7 +3,7 @@ PATH
   specs:
     ddtrace (1.14.0)
       debase-ruby_core_source (= 3.2.1)
-      libdatadog (~> 3.0.0.1.0)
+      libdatadog (~> 4.0.0.1.0)
       libddwaf (~> 1.11.0.0.0)
       msgpack
 
@@ -37,8 +37,8 @@ GEM
     hashdiff (1.0.1)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (3.0.0.1.0-aarch64-linux)
-    libdatadog (3.0.0.1.0-x86_64-linux)
+    libdatadog (4.0.0.1.0-aarch64-linux)
+    libdatadog (4.0.0.1.0-x86_64-linux)
     libddwaf (1.11.0.0.0-aarch64-linux)
       ffi (~> 1.0)
     libddwaf (1.11.0.0.0-x86_64-linux)

--- a/gemfiles/ruby_2.4.10_cucumber3.gemfile.lock
+++ b/gemfiles/ruby_2.4.10_cucumber3.gemfile.lock
@@ -3,7 +3,7 @@ PATH
   specs:
     ddtrace (1.14.0)
       debase-ruby_core_source (= 3.2.1)
-      libdatadog (~> 3.0.0.1.0)
+      libdatadog (~> 4.0.0.1.0)
       libddwaf (~> 1.11.0.0.0)
       msgpack
 
@@ -55,8 +55,8 @@ GEM
     hashdiff (1.0.1)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (3.0.0.1.0-aarch64-linux)
-    libdatadog (3.0.0.1.0-x86_64-linux)
+    libdatadog (4.0.0.1.0-aarch64-linux)
+    libdatadog (4.0.0.1.0-x86_64-linux)
     libddwaf (1.11.0.0.0-aarch64-linux)
       ffi (~> 1.0)
     libddwaf (1.11.0.0.0-x86_64-linux)

--- a/gemfiles/ruby_2.4.10_cucumber4.gemfile.lock
+++ b/gemfiles/ruby_2.4.10_cucumber4.gemfile.lock
@@ -3,7 +3,7 @@ PATH
   specs:
     ddtrace (1.14.0)
       debase-ruby_core_source (= 3.2.1)
-      libdatadog (~> 3.0.0.1.0)
+      libdatadog (~> 4.0.0.1.0)
       libddwaf (~> 1.11.0.0.0)
       msgpack
 
@@ -75,8 +75,8 @@ GEM
       concurrent-ruby (~> 1.0)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (3.0.0.1.0-aarch64-linux)
-    libdatadog (3.0.0.1.0-x86_64-linux)
+    libdatadog (4.0.0.1.0-aarch64-linux)
+    libdatadog (4.0.0.1.0-x86_64-linux)
     libddwaf (1.11.0.0.0-aarch64-linux)
       ffi (~> 1.0)
     libddwaf (1.11.0.0.0-x86_64-linux)

--- a/gemfiles/ruby_2.4.10_hanami_1.gemfile.lock
+++ b/gemfiles/ruby_2.4.10_hanami_1.gemfile.lock
@@ -3,7 +3,7 @@ PATH
   specs:
     ddtrace (1.14.0)
       debase-ruby_core_source (= 3.2.1)
-      libdatadog (~> 3.0.0.1.0)
+      libdatadog (~> 4.0.0.1.0)
       libddwaf (~> 1.11.0.0.0)
       msgpack
 
@@ -112,8 +112,8 @@ GEM
     inflecto (0.0.2)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (3.0.0.1.0-aarch64-linux)
-    libdatadog (3.0.0.1.0-x86_64-linux)
+    libdatadog (4.0.0.1.0-aarch64-linux)
+    libdatadog (4.0.0.1.0-x86_64-linux)
     libddwaf (1.11.0.0.0-aarch64-linux)
       ffi (~> 1.0)
     libddwaf (1.11.0.0.0-x86_64-linux)

--- a/gemfiles/ruby_2.4.10_rails5_mysql2.gemfile.lock
+++ b/gemfiles/ruby_2.4.10_rails5_mysql2.gemfile.lock
@@ -3,7 +3,7 @@ PATH
   specs:
     ddtrace (1.14.0)
       debase-ruby_core_source (= 3.2.1)
-      libdatadog (~> 3.0.0.1.0)
+      libdatadog (~> 4.0.0.1.0)
       libddwaf (~> 1.11.0.0.0)
       msgpack
 
@@ -85,8 +85,8 @@ GEM
       concurrent-ruby (~> 1.0)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (3.0.0.1.0-aarch64-linux)
-    libdatadog (3.0.0.1.0-x86_64-linux)
+    libdatadog (4.0.0.1.0-aarch64-linux)
+    libdatadog (4.0.0.1.0-x86_64-linux)
     libddwaf (1.11.0.0.0-aarch64-linux)
       ffi (~> 1.0)
     libddwaf (1.11.0.0.0-x86_64-linux)

--- a/gemfiles/ruby_2.4.10_rails5_postgres.gemfile.lock
+++ b/gemfiles/ruby_2.4.10_rails5_postgres.gemfile.lock
@@ -3,7 +3,7 @@ PATH
   specs:
     ddtrace (1.14.0)
       debase-ruby_core_source (= 3.2.1)
-      libdatadog (~> 3.0.0.1.0)
+      libdatadog (~> 4.0.0.1.0)
       libddwaf (~> 1.11.0.0.0)
       msgpack
 
@@ -85,8 +85,8 @@ GEM
       concurrent-ruby (~> 1.0)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (3.0.0.1.0-aarch64-linux)
-    libdatadog (3.0.0.1.0-x86_64-linux)
+    libdatadog (4.0.0.1.0-aarch64-linux)
+    libdatadog (4.0.0.1.0-x86_64-linux)
     libddwaf (1.11.0.0.0-aarch64-linux)
       ffi (~> 1.0)
     libddwaf (1.11.0.0.0-x86_64-linux)

--- a/gemfiles/ruby_2.4.10_rails5_postgres_redis.gemfile.lock
+++ b/gemfiles/ruby_2.4.10_rails5_postgres_redis.gemfile.lock
@@ -3,7 +3,7 @@ PATH
   specs:
     ddtrace (1.14.0)
       debase-ruby_core_source (= 3.2.1)
-      libdatadog (~> 3.0.0.1.0)
+      libdatadog (~> 4.0.0.1.0)
       libddwaf (~> 1.11.0.0.0)
       msgpack
 
@@ -85,8 +85,8 @@ GEM
       concurrent-ruby (~> 1.0)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (3.0.0.1.0-aarch64-linux)
-    libdatadog (3.0.0.1.0-x86_64-linux)
+    libdatadog (4.0.0.1.0-aarch64-linux)
+    libdatadog (4.0.0.1.0-x86_64-linux)
     libddwaf (1.11.0.0.0-aarch64-linux)
       ffi (~> 1.0)
     libddwaf (1.11.0.0.0-x86_64-linux)

--- a/gemfiles/ruby_2.4.10_rails5_postgres_redis_activesupport.gemfile.lock
+++ b/gemfiles/ruby_2.4.10_rails5_postgres_redis_activesupport.gemfile.lock
@@ -3,7 +3,7 @@ PATH
   specs:
     ddtrace (1.14.0)
       debase-ruby_core_source (= 3.2.1)
-      libdatadog (~> 3.0.0.1.0)
+      libdatadog (~> 4.0.0.1.0)
       libddwaf (~> 1.11.0.0.0)
       msgpack
 
@@ -85,8 +85,8 @@ GEM
       concurrent-ruby (~> 1.0)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (3.0.0.1.0-aarch64-linux)
-    libdatadog (3.0.0.1.0-x86_64-linux)
+    libdatadog (4.0.0.1.0-aarch64-linux)
+    libdatadog (4.0.0.1.0-x86_64-linux)
     libddwaf (1.11.0.0.0-aarch64-linux)
       ffi (~> 1.0)
     libddwaf (1.11.0.0.0-x86_64-linux)

--- a/gemfiles/ruby_2.4.10_rails5_postgres_sidekiq.gemfile.lock
+++ b/gemfiles/ruby_2.4.10_rails5_postgres_sidekiq.gemfile.lock
@@ -3,7 +3,7 @@ PATH
   specs:
     ddtrace (1.14.0)
       debase-ruby_core_source (= 3.2.1)
-      libdatadog (~> 3.0.0.1.0)
+      libdatadog (~> 4.0.0.1.0)
       libddwaf (~> 1.11.0.0.0)
       msgpack
 
@@ -86,8 +86,8 @@ GEM
       concurrent-ruby (~> 1.0)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (3.0.0.1.0-aarch64-linux)
-    libdatadog (3.0.0.1.0-x86_64-linux)
+    libdatadog (4.0.0.1.0-aarch64-linux)
+    libdatadog (4.0.0.1.0-x86_64-linux)
     libddwaf (1.11.0.0.0-aarch64-linux)
       ffi (~> 1.0)
     libddwaf (1.11.0.0.0-x86_64-linux)

--- a/gemfiles/ruby_2.4.10_rails5_semantic_logger.gemfile.lock
+++ b/gemfiles/ruby_2.4.10_rails5_semantic_logger.gemfile.lock
@@ -3,7 +3,7 @@ PATH
   specs:
     ddtrace (1.14.0)
       debase-ruby_core_source (= 3.2.1)
-      libdatadog (~> 3.0.0.1.0)
+      libdatadog (~> 4.0.0.1.0)
       libddwaf (~> 1.11.0.0.0)
       msgpack
 
@@ -85,8 +85,8 @@ GEM
       concurrent-ruby (~> 1.0)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (3.0.0.1.0-aarch64-linux)
-    libdatadog (3.0.0.1.0-x86_64-linux)
+    libdatadog (4.0.0.1.0-aarch64-linux)
+    libdatadog (4.0.0.1.0-x86_64-linux)
     libddwaf (1.11.0.0.0-aarch64-linux)
       ffi (~> 1.0)
     libddwaf (1.11.0.0.0-x86_64-linux)

--- a/gemfiles/ruby_2.4.10_redis_3.gemfile.lock
+++ b/gemfiles/ruby_2.4.10_redis_3.gemfile.lock
@@ -3,7 +3,7 @@ PATH
   specs:
     ddtrace (1.14.0)
       debase-ruby_core_source (= 3.2.1)
-      libdatadog (~> 3.0.0.1.0)
+      libdatadog (~> 4.0.0.1.0)
       libddwaf (~> 1.11.0.0.0)
       msgpack
 
@@ -37,8 +37,8 @@ GEM
     hashdiff (1.0.1)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (3.0.0.1.0-aarch64-linux)
-    libdatadog (3.0.0.1.0-x86_64-linux)
+    libdatadog (4.0.0.1.0-aarch64-linux)
+    libdatadog (4.0.0.1.0-x86_64-linux)
     libddwaf (1.11.0.0.0-aarch64-linux)
       ffi (~> 1.0)
     libddwaf (1.11.0.0.0-x86_64-linux)

--- a/gemfiles/ruby_2.4.10_redis_4.gemfile.lock
+++ b/gemfiles/ruby_2.4.10_redis_4.gemfile.lock
@@ -3,7 +3,7 @@ PATH
   specs:
     ddtrace (1.14.0)
       debase-ruby_core_source (= 3.2.1)
-      libdatadog (~> 3.0.0.1.0)
+      libdatadog (~> 4.0.0.1.0)
       libddwaf (~> 1.11.0.0.0)
       msgpack
 
@@ -37,8 +37,8 @@ GEM
     hashdiff (1.0.1)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (3.0.0.1.0-aarch64-linux)
-    libdatadog (3.0.0.1.0-x86_64-linux)
+    libdatadog (4.0.0.1.0-aarch64-linux)
+    libdatadog (4.0.0.1.0-x86_64-linux)
     libddwaf (1.11.0.0.0-aarch64-linux)
       ffi (~> 1.0)
     libddwaf (1.11.0.0.0-x86_64-linux)

--- a/gemfiles/ruby_2.4.10_resque2_redis3.gemfile.lock
+++ b/gemfiles/ruby_2.4.10_resque2_redis3.gemfile.lock
@@ -3,7 +3,7 @@ PATH
   specs:
     ddtrace (1.14.0)
       debase-ruby_core_source (= 3.2.1)
-      libdatadog (~> 3.0.0.1.0)
+      libdatadog (~> 4.0.0.1.0)
       libddwaf (~> 1.11.0.0.0)
       msgpack
 
@@ -37,8 +37,8 @@ GEM
     hashdiff (1.0.1)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (3.0.0.1.0-aarch64-linux)
-    libdatadog (3.0.0.1.0-x86_64-linux)
+    libdatadog (4.0.0.1.0-aarch64-linux)
+    libdatadog (4.0.0.1.0-x86_64-linux)
     libddwaf (1.11.0.0.0-aarch64-linux)
       ffi (~> 1.0)
     libddwaf (1.11.0.0.0-x86_64-linux)

--- a/gemfiles/ruby_2.4.10_resque2_redis4.gemfile.lock
+++ b/gemfiles/ruby_2.4.10_resque2_redis4.gemfile.lock
@@ -3,7 +3,7 @@ PATH
   specs:
     ddtrace (1.14.0)
       debase-ruby_core_source (= 3.2.1)
-      libdatadog (~> 3.0.0.1.0)
+      libdatadog (~> 4.0.0.1.0)
       libddwaf (~> 1.11.0.0.0)
       msgpack
 
@@ -37,8 +37,8 @@ GEM
     hashdiff (1.0.1)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (3.0.0.1.0-aarch64-linux)
-    libdatadog (3.0.0.1.0-x86_64-linux)
+    libdatadog (4.0.0.1.0-aarch64-linux)
+    libdatadog (4.0.0.1.0-x86_64-linux)
     libddwaf (1.11.0.0.0-aarch64-linux)
       ffi (~> 1.0)
     libddwaf (1.11.0.0.0-x86_64-linux)

--- a/gemfiles/ruby_2.4.10_sinatra.gemfile.lock
+++ b/gemfiles/ruby_2.4.10_sinatra.gemfile.lock
@@ -3,7 +3,7 @@ PATH
   specs:
     ddtrace (1.14.0)
       debase-ruby_core_source (= 3.2.1)
-      libdatadog (~> 3.0.0.1.0)
+      libdatadog (~> 4.0.0.1.0)
       libddwaf (~> 1.11.0.0.0)
       msgpack
 
@@ -37,8 +37,8 @@ GEM
     hashdiff (1.0.1)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (3.0.0.1.0-aarch64-linux)
-    libdatadog (3.0.0.1.0-x86_64-linux)
+    libdatadog (4.0.0.1.0-aarch64-linux)
+    libdatadog (4.0.0.1.0-x86_64-linux)
     libddwaf (1.11.0.0.0-aarch64-linux)
       ffi (~> 1.0)
     libddwaf (1.11.0.0.0-x86_64-linux)

--- a/gemfiles/ruby_2.5.9_contrib.gemfile.lock
+++ b/gemfiles/ruby_2.5.9_contrib.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.14.0)
       debase-ruby_core_source (= 3.2.1)
-      libdatadog (~> 3.0.0.1.0)
+      libdatadog (~> 4.0.0.1.0)
       libddwaf (~> 1.11.0.0.0)
       msgpack
 
@@ -1561,8 +1561,8 @@ GEM
       addressable (>= 2.4)
     jsonapi-renderer (0.2.2)
     king_konf (1.0.1)
-    libdatadog (3.0.0.1.0-aarch64-linux)
-    libdatadog (3.0.0.1.0-x86_64-linux)
+    libdatadog (4.0.0.1.0-aarch64-linux)
+    libdatadog (4.0.0.1.0-x86_64-linux)
     libddwaf (1.11.0.0.0-aarch64-linux)
       ffi (~> 1.0)
     libddwaf (1.11.0.0.0-x86_64-linux)

--- a/gemfiles/ruby_2.5.9_contrib_old.gemfile.lock
+++ b/gemfiles/ruby_2.5.9_contrib_old.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.14.0)
       debase-ruby_core_source (= 3.2.1)
-      libdatadog (~> 3.0.0.1.0)
+      libdatadog (~> 4.0.0.1.0)
       libddwaf (~> 1.11.0.0.0)
       msgpack
 
@@ -70,8 +70,8 @@ GEM
     hitimes (1.3.1)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (3.0.0.1.0-aarch64-linux)
-    libdatadog (3.0.0.1.0-x86_64-linux)
+    libdatadog (4.0.0.1.0-aarch64-linux)
+    libdatadog (4.0.0.1.0-x86_64-linux)
     libddwaf (1.11.0.0.0-aarch64-linux)
       ffi (~> 1.0)
     libddwaf (1.11.0.0.0-x86_64-linux)

--- a/gemfiles/ruby_2.5.9_core_old.gemfile.lock
+++ b/gemfiles/ruby_2.5.9_core_old.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.14.0)
       debase-ruby_core_source (= 3.2.1)
-      libdatadog (~> 3.0.0.1.0)
+      libdatadog (~> 4.0.0.1.0)
       libddwaf (~> 1.11.0.0.0)
       msgpack
 
@@ -50,8 +50,8 @@ GEM
     hashdiff (1.0.1)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (3.0.0.1.0-aarch64-linux)
-    libdatadog (3.0.0.1.0-x86_64-linux)
+    libdatadog (4.0.0.1.0-aarch64-linux)
+    libdatadog (4.0.0.1.0-x86_64-linux)
     libddwaf (1.11.0.0.0-aarch64-linux)
       ffi (~> 1.0)
     libddwaf (1.11.0.0.0-x86_64-linux)

--- a/gemfiles/ruby_2.5.9_cucumber3.gemfile.lock
+++ b/gemfiles/ruby_2.5.9_cucumber3.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.14.0)
       debase-ruby_core_source (= 3.2.1)
-      libdatadog (~> 3.0.0.1.0)
+      libdatadog (~> 4.0.0.1.0)
       libddwaf (~> 1.11.0.0.0)
       msgpack
 
@@ -68,8 +68,8 @@ GEM
     hashdiff (1.0.1)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (3.0.0.1.0-aarch64-linux)
-    libdatadog (3.0.0.1.0-x86_64-linux)
+    libdatadog (4.0.0.1.0-aarch64-linux)
+    libdatadog (4.0.0.1.0-x86_64-linux)
     libddwaf (1.11.0.0.0-aarch64-linux)
       ffi (~> 1.0)
     libddwaf (1.11.0.0.0-x86_64-linux)

--- a/gemfiles/ruby_2.5.9_cucumber4.gemfile.lock
+++ b/gemfiles/ruby_2.5.9_cucumber4.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.14.0)
       debase-ruby_core_source (= 3.2.1)
-      libdatadog (~> 3.0.0.1.0)
+      libdatadog (~> 4.0.0.1.0)
       libddwaf (~> 1.11.0.0.0)
       msgpack
 
@@ -89,8 +89,8 @@ GEM
       concurrent-ruby (~> 1.0)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (3.0.0.1.0-aarch64-linux)
-    libdatadog (3.0.0.1.0-x86_64-linux)
+    libdatadog (4.0.0.1.0-aarch64-linux)
+    libdatadog (4.0.0.1.0-x86_64-linux)
     libddwaf (1.11.0.0.0-aarch64-linux)
       ffi (~> 1.0)
     libddwaf (1.11.0.0.0-x86_64-linux)

--- a/gemfiles/ruby_2.5.9_cucumber5.gemfile.lock
+++ b/gemfiles/ruby_2.5.9_cucumber5.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.14.0)
       debase-ruby_core_source (= 3.2.1)
-      libdatadog (~> 3.0.0.1.0)
+      libdatadog (~> 4.0.0.1.0)
       libddwaf (~> 1.11.0.0.0)
       msgpack
 
@@ -89,8 +89,8 @@ GEM
       concurrent-ruby (~> 1.0)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (3.0.0.1.0-aarch64-linux)
-    libdatadog (3.0.0.1.0-x86_64-linux)
+    libdatadog (4.0.0.1.0-aarch64-linux)
+    libdatadog (4.0.0.1.0-x86_64-linux)
     libddwaf (1.11.0.0.0-aarch64-linux)
       ffi (~> 1.0)
     libddwaf (1.11.0.0.0-x86_64-linux)

--- a/gemfiles/ruby_2.5.9_hanami_1.gemfile.lock
+++ b/gemfiles/ruby_2.5.9_hanami_1.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.14.0)
       debase-ruby_core_source (= 3.2.1)
-      libdatadog (~> 3.0.0.1.0)
+      libdatadog (~> 4.0.0.1.0)
       libddwaf (~> 1.11.0.0.0)
       msgpack
 
@@ -126,8 +126,8 @@ GEM
     io-wait (0.3.0)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (3.0.0.1.0-aarch64-linux)
-    libdatadog (3.0.0.1.0-x86_64-linux)
+    libdatadog (4.0.0.1.0-aarch64-linux)
+    libdatadog (4.0.0.1.0-x86_64-linux)
     libddwaf (1.11.0.0.0-aarch64-linux)
       ffi (~> 1.0)
     libddwaf (1.11.0.0.0-x86_64-linux)

--- a/gemfiles/ruby_2.5.9_rails5_mysql2.gemfile.lock
+++ b/gemfiles/ruby_2.5.9_rails5_mysql2.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.14.0)
       debase-ruby_core_source (= 3.2.1)
-      libdatadog (~> 3.0.0.1.0)
+      libdatadog (~> 4.0.0.1.0)
       libddwaf (~> 1.11.0.0.0)
       msgpack
 
@@ -98,8 +98,8 @@ GEM
       concurrent-ruby (~> 1.0)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (3.0.0.1.0-aarch64-linux)
-    libdatadog (3.0.0.1.0-x86_64-linux)
+    libdatadog (4.0.0.1.0-aarch64-linux)
+    libdatadog (4.0.0.1.0-x86_64-linux)
     libddwaf (1.11.0.0.0-aarch64-linux)
       ffi (~> 1.0)
     libddwaf (1.11.0.0.0-x86_64-linux)

--- a/gemfiles/ruby_2.5.9_rails5_postgres.gemfile.lock
+++ b/gemfiles/ruby_2.5.9_rails5_postgres.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.14.0)
       debase-ruby_core_source (= 3.2.1)
-      libdatadog (~> 3.0.0.1.0)
+      libdatadog (~> 4.0.0.1.0)
       libddwaf (~> 1.11.0.0.0)
       msgpack
 
@@ -100,8 +100,8 @@ GEM
     io-wait (0.3.0)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (3.0.0.1.0-aarch64-linux)
-    libdatadog (3.0.0.1.0-x86_64-linux)
+    libdatadog (4.0.0.1.0-aarch64-linux)
+    libdatadog (4.0.0.1.0-x86_64-linux)
     libddwaf (1.11.0.0.0-aarch64-linux)
       ffi (~> 1.0)
     libddwaf (1.11.0.0.0-x86_64-linux)

--- a/gemfiles/ruby_2.5.9_rails5_postgres_redis.gemfile.lock
+++ b/gemfiles/ruby_2.5.9_rails5_postgres_redis.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.14.0)
       debase-ruby_core_source (= 3.2.1)
-      libdatadog (~> 3.0.0.1.0)
+      libdatadog (~> 4.0.0.1.0)
       libddwaf (~> 1.11.0.0.0)
       msgpack
 
@@ -101,8 +101,8 @@ GEM
     io-wait (0.3.0)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (3.0.0.1.0-aarch64-linux)
-    libdatadog (3.0.0.1.0-x86_64-linux)
+    libdatadog (4.0.0.1.0-aarch64-linux)
+    libdatadog (4.0.0.1.0-x86_64-linux)
     libddwaf (1.11.0.0.0-aarch64-linux)
       ffi (~> 1.0)
     libddwaf (1.11.0.0.0-x86_64-linux)

--- a/gemfiles/ruby_2.5.9_rails5_postgres_redis_activesupport.gemfile.lock
+++ b/gemfiles/ruby_2.5.9_rails5_postgres_redis_activesupport.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.14.0)
       debase-ruby_core_source (= 3.2.1)
-      libdatadog (~> 3.0.0.1.0)
+      libdatadog (~> 4.0.0.1.0)
       libddwaf (~> 1.11.0.0.0)
       msgpack
 
@@ -100,8 +100,8 @@ GEM
     io-wait (0.3.0)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (3.0.0.1.0-aarch64-linux)
-    libdatadog (3.0.0.1.0-x86_64-linux)
+    libdatadog (4.0.0.1.0-aarch64-linux)
+    libdatadog (4.0.0.1.0-x86_64-linux)
     libddwaf (1.11.0.0.0-aarch64-linux)
       ffi (~> 1.0)
     libddwaf (1.11.0.0.0-x86_64-linux)

--- a/gemfiles/ruby_2.5.9_rails5_postgres_sidekiq.gemfile.lock
+++ b/gemfiles/ruby_2.5.9_rails5_postgres_sidekiq.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.14.0)
       debase-ruby_core_source (= 3.2.1)
-      libdatadog (~> 3.0.0.1.0)
+      libdatadog (~> 4.0.0.1.0)
       libddwaf (~> 1.11.0.0.0)
       msgpack
 
@@ -101,8 +101,8 @@ GEM
     io-wait (0.3.0)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (3.0.0.1.0-aarch64-linux)
-    libdatadog (3.0.0.1.0-x86_64-linux)
+    libdatadog (4.0.0.1.0-aarch64-linux)
+    libdatadog (4.0.0.1.0-x86_64-linux)
     libddwaf (1.11.0.0.0-aarch64-linux)
       ffi (~> 1.0)
     libddwaf (1.11.0.0.0-x86_64-linux)

--- a/gemfiles/ruby_2.5.9_rails5_semantic_logger.gemfile.lock
+++ b/gemfiles/ruby_2.5.9_rails5_semantic_logger.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.14.0)
       debase-ruby_core_source (= 3.2.1)
-      libdatadog (~> 3.0.0.1.0)
+      libdatadog (~> 4.0.0.1.0)
       libddwaf (~> 1.11.0.0.0)
       msgpack
 
@@ -100,8 +100,8 @@ GEM
     io-wait (0.3.0)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (3.0.0.1.0-aarch64-linux)
-    libdatadog (3.0.0.1.0-x86_64-linux)
+    libdatadog (4.0.0.1.0-aarch64-linux)
+    libdatadog (4.0.0.1.0-x86_64-linux)
     libddwaf (1.11.0.0.0-aarch64-linux)
       ffi (~> 1.0)
     libddwaf (1.11.0.0.0-x86_64-linux)

--- a/gemfiles/ruby_2.5.9_rails61_mysql2.gemfile.lock
+++ b/gemfiles/ruby_2.5.9_rails61_mysql2.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.14.0)
       debase-ruby_core_source (= 3.2.1)
-      libdatadog (~> 3.0.0.1.0)
+      libdatadog (~> 4.0.0.1.0)
       libddwaf (~> 1.11.0.0.0)
       msgpack
 
@@ -115,8 +115,8 @@ GEM
       concurrent-ruby (~> 1.0)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (3.0.0.1.0-aarch64-linux)
-    libdatadog (3.0.0.1.0-x86_64-linux)
+    libdatadog (4.0.0.1.0-aarch64-linux)
+    libdatadog (4.0.0.1.0-x86_64-linux)
     libddwaf (1.11.0.0.0-aarch64-linux)
       ffi (~> 1.0)
     libddwaf (1.11.0.0.0-x86_64-linux)

--- a/gemfiles/ruby_2.5.9_rails61_postgres.gemfile.lock
+++ b/gemfiles/ruby_2.5.9_rails61_postgres.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.14.0)
       debase-ruby_core_source (= 3.2.1)
-      libdatadog (~> 3.0.0.1.0)
+      libdatadog (~> 4.0.0.1.0)
       libddwaf (~> 1.11.0.0.0)
       msgpack
 
@@ -117,8 +117,8 @@ GEM
     io-wait (0.3.0)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (3.0.0.1.0-aarch64-linux)
-    libdatadog (3.0.0.1.0-x86_64-linux)
+    libdatadog (4.0.0.1.0-aarch64-linux)
+    libdatadog (4.0.0.1.0-x86_64-linux)
     libddwaf (1.11.0.0.0-aarch64-linux)
       ffi (~> 1.0)
     libddwaf (1.11.0.0.0-x86_64-linux)

--- a/gemfiles/ruby_2.5.9_rails61_postgres_redis.gemfile.lock
+++ b/gemfiles/ruby_2.5.9_rails61_postgres_redis.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.14.0)
       debase-ruby_core_source (= 3.2.1)
-      libdatadog (~> 3.0.0.1.0)
+      libdatadog (~> 4.0.0.1.0)
       libddwaf (~> 1.11.0.0.0)
       msgpack
 
@@ -118,8 +118,8 @@ GEM
     io-wait (0.3.0)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (3.0.0.1.0-aarch64-linux)
-    libdatadog (3.0.0.1.0-x86_64-linux)
+    libdatadog (4.0.0.1.0-aarch64-linux)
+    libdatadog (4.0.0.1.0-x86_64-linux)
     libddwaf (1.11.0.0.0-aarch64-linux)
       ffi (~> 1.0)
     libddwaf (1.11.0.0.0-x86_64-linux)

--- a/gemfiles/ruby_2.5.9_rails61_postgres_sidekiq.gemfile.lock
+++ b/gemfiles/ruby_2.5.9_rails61_postgres_sidekiq.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.14.0)
       debase-ruby_core_source (= 3.2.1)
-      libdatadog (~> 3.0.0.1.0)
+      libdatadog (~> 4.0.0.1.0)
       libddwaf (~> 1.11.0.0.0)
       msgpack
 
@@ -118,8 +118,8 @@ GEM
     io-wait (0.3.0)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (3.0.0.1.0-aarch64-linux)
-    libdatadog (3.0.0.1.0-x86_64-linux)
+    libdatadog (4.0.0.1.0-aarch64-linux)
+    libdatadog (4.0.0.1.0-x86_64-linux)
     libddwaf (1.11.0.0.0-aarch64-linux)
       ffi (~> 1.0)
     libddwaf (1.11.0.0.0-x86_64-linux)

--- a/gemfiles/ruby_2.5.9_rails61_semantic_logger.gemfile.lock
+++ b/gemfiles/ruby_2.5.9_rails61_semantic_logger.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.14.0)
       debase-ruby_core_source (= 3.2.1)
-      libdatadog (~> 3.0.0.1.0)
+      libdatadog (~> 4.0.0.1.0)
       libddwaf (~> 1.11.0.0.0)
       msgpack
 
@@ -117,8 +117,8 @@ GEM
     io-wait (0.3.0)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (3.0.0.1.0-aarch64-linux)
-    libdatadog (3.0.0.1.0-x86_64-linux)
+    libdatadog (4.0.0.1.0-aarch64-linux)
+    libdatadog (4.0.0.1.0-x86_64-linux)
     libddwaf (1.11.0.0.0-aarch64-linux)
       ffi (~> 1.0)
     libddwaf (1.11.0.0.0-x86_64-linux)

--- a/gemfiles/ruby_2.5.9_rails6_mysql2.gemfile.lock
+++ b/gemfiles/ruby_2.5.9_rails6_mysql2.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.14.0)
       debase-ruby_core_source (= 3.2.1)
-      libdatadog (~> 3.0.0.1.0)
+      libdatadog (~> 4.0.0.1.0)
       libddwaf (~> 1.11.0.0.0)
       msgpack
 
@@ -111,8 +111,8 @@ GEM
       concurrent-ruby (~> 1.0)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (3.0.0.1.0-aarch64-linux)
-    libdatadog (3.0.0.1.0-x86_64-linux)
+    libdatadog (4.0.0.1.0-aarch64-linux)
+    libdatadog (4.0.0.1.0-x86_64-linux)
     libddwaf (1.11.0.0.0-aarch64-linux)
       ffi (~> 1.0)
     libddwaf (1.11.0.0.0-x86_64-linux)

--- a/gemfiles/ruby_2.5.9_rails6_postgres.gemfile.lock
+++ b/gemfiles/ruby_2.5.9_rails6_postgres.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.14.0)
       debase-ruby_core_source (= 3.2.1)
-      libdatadog (~> 3.0.0.1.0)
+      libdatadog (~> 4.0.0.1.0)
       libddwaf (~> 1.11.0.0.0)
       msgpack
 
@@ -113,8 +113,8 @@ GEM
     io-wait (0.3.0)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (3.0.0.1.0-aarch64-linux)
-    libdatadog (3.0.0.1.0-x86_64-linux)
+    libdatadog (4.0.0.1.0-aarch64-linux)
+    libdatadog (4.0.0.1.0-x86_64-linux)
     libddwaf (1.11.0.0.0-aarch64-linux)
       ffi (~> 1.0)
     libddwaf (1.11.0.0.0-x86_64-linux)

--- a/gemfiles/ruby_2.5.9_rails6_postgres_redis.gemfile.lock
+++ b/gemfiles/ruby_2.5.9_rails6_postgres_redis.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.14.0)
       debase-ruby_core_source (= 3.2.1)
-      libdatadog (~> 3.0.0.1.0)
+      libdatadog (~> 4.0.0.1.0)
       libddwaf (~> 1.11.0.0.0)
       msgpack
 
@@ -114,8 +114,8 @@ GEM
     io-wait (0.3.0)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (3.0.0.1.0-aarch64-linux)
-    libdatadog (3.0.0.1.0-x86_64-linux)
+    libdatadog (4.0.0.1.0-aarch64-linux)
+    libdatadog (4.0.0.1.0-x86_64-linux)
     libddwaf (1.11.0.0.0-aarch64-linux)
       ffi (~> 1.0)
     libddwaf (1.11.0.0.0-x86_64-linux)

--- a/gemfiles/ruby_2.5.9_rails6_postgres_redis_activesupport.gemfile.lock
+++ b/gemfiles/ruby_2.5.9_rails6_postgres_redis_activesupport.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.14.0)
       debase-ruby_core_source (= 3.2.1)
-      libdatadog (~> 3.0.0.1.0)
+      libdatadog (~> 4.0.0.1.0)
       libddwaf (~> 1.11.0.0.0)
       msgpack
 
@@ -113,8 +113,8 @@ GEM
     io-wait (0.3.0)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (3.0.0.1.0-aarch64-linux)
-    libdatadog (3.0.0.1.0-x86_64-linux)
+    libdatadog (4.0.0.1.0-aarch64-linux)
+    libdatadog (4.0.0.1.0-x86_64-linux)
     libddwaf (1.11.0.0.0-aarch64-linux)
       ffi (~> 1.0)
     libddwaf (1.11.0.0.0-x86_64-linux)

--- a/gemfiles/ruby_2.5.9_rails6_postgres_sidekiq.gemfile.lock
+++ b/gemfiles/ruby_2.5.9_rails6_postgres_sidekiq.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.14.0)
       debase-ruby_core_source (= 3.2.1)
-      libdatadog (~> 3.0.0.1.0)
+      libdatadog (~> 4.0.0.1.0)
       libddwaf (~> 1.11.0.0.0)
       msgpack
 
@@ -114,8 +114,8 @@ GEM
     io-wait (0.3.0)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (3.0.0.1.0-aarch64-linux)
-    libdatadog (3.0.0.1.0-x86_64-linux)
+    libdatadog (4.0.0.1.0-aarch64-linux)
+    libdatadog (4.0.0.1.0-x86_64-linux)
     libddwaf (1.11.0.0.0-aarch64-linux)
       ffi (~> 1.0)
     libddwaf (1.11.0.0.0-x86_64-linux)

--- a/gemfiles/ruby_2.5.9_rails6_semantic_logger.gemfile.lock
+++ b/gemfiles/ruby_2.5.9_rails6_semantic_logger.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.14.0)
       debase-ruby_core_source (= 3.2.1)
-      libdatadog (~> 3.0.0.1.0)
+      libdatadog (~> 4.0.0.1.0)
       libddwaf (~> 1.11.0.0.0)
       msgpack
 
@@ -113,8 +113,8 @@ GEM
     io-wait (0.3.0)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (3.0.0.1.0-aarch64-linux)
-    libdatadog (3.0.0.1.0-x86_64-linux)
+    libdatadog (4.0.0.1.0-aarch64-linux)
+    libdatadog (4.0.0.1.0-x86_64-linux)
     libddwaf (1.11.0.0.0-aarch64-linux)
       ffi (~> 1.0)
     libddwaf (1.11.0.0.0-x86_64-linux)

--- a/gemfiles/ruby_2.5.9_redis_3.gemfile.lock
+++ b/gemfiles/ruby_2.5.9_redis_3.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.14.0)
       debase-ruby_core_source (= 3.2.1)
-      libdatadog (~> 3.0.0.1.0)
+      libdatadog (~> 4.0.0.1.0)
       libddwaf (~> 1.11.0.0.0)
       msgpack
 
@@ -50,8 +50,8 @@ GEM
     hashdiff (1.0.1)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (3.0.0.1.0-aarch64-linux)
-    libdatadog (3.0.0.1.0-x86_64-linux)
+    libdatadog (4.0.0.1.0-aarch64-linux)
+    libdatadog (4.0.0.1.0-x86_64-linux)
     libddwaf (1.11.0.0.0-aarch64-linux)
       ffi (~> 1.0)
     libddwaf (1.11.0.0.0-x86_64-linux)

--- a/gemfiles/ruby_2.5.9_redis_4.gemfile.lock
+++ b/gemfiles/ruby_2.5.9_redis_4.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.14.0)
       debase-ruby_core_source (= 3.2.1)
-      libdatadog (~> 3.0.0.1.0)
+      libdatadog (~> 4.0.0.1.0)
       libddwaf (~> 1.11.0.0.0)
       msgpack
 
@@ -50,8 +50,8 @@ GEM
     hashdiff (1.0.1)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (3.0.0.1.0-aarch64-linux)
-    libdatadog (3.0.0.1.0-x86_64-linux)
+    libdatadog (4.0.0.1.0-aarch64-linux)
+    libdatadog (4.0.0.1.0-x86_64-linux)
     libddwaf (1.11.0.0.0-aarch64-linux)
       ffi (~> 1.0)
     libddwaf (1.11.0.0.0-x86_64-linux)

--- a/gemfiles/ruby_2.5.9_redis_5.gemfile.lock
+++ b/gemfiles/ruby_2.5.9_redis_5.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.14.0)
       debase-ruby_core_source (= 3.2.1)
-      libdatadog (~> 3.0.0.1.0)
+      libdatadog (~> 4.0.0.1.0)
       libddwaf (~> 1.11.0.0.0)
       msgpack
 
@@ -51,8 +51,8 @@ GEM
     hashdiff (1.0.1)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (3.0.0.1.0-aarch64-linux)
-    libdatadog (3.0.0.1.0-x86_64-linux)
+    libdatadog (4.0.0.1.0-aarch64-linux)
+    libdatadog (4.0.0.1.0-x86_64-linux)
     libddwaf (1.11.0.0.0-aarch64-linux)
       ffi (~> 1.0)
     libddwaf (1.11.0.0.0-x86_64-linux)

--- a/gemfiles/ruby_2.5.9_resque2_redis3.gemfile.lock
+++ b/gemfiles/ruby_2.5.9_resque2_redis3.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.14.0)
       debase-ruby_core_source (= 3.2.1)
-      libdatadog (~> 3.0.0.1.0)
+      libdatadog (~> 4.0.0.1.0)
       libddwaf (~> 1.11.0.0.0)
       msgpack
 
@@ -50,8 +50,8 @@ GEM
     hashdiff (1.0.1)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (3.0.0.1.0-aarch64-linux)
-    libdatadog (3.0.0.1.0-x86_64-linux)
+    libdatadog (4.0.0.1.0-aarch64-linux)
+    libdatadog (4.0.0.1.0-x86_64-linux)
     libddwaf (1.11.0.0.0-aarch64-linux)
       ffi (~> 1.0)
     libddwaf (1.11.0.0.0-x86_64-linux)

--- a/gemfiles/ruby_2.5.9_resque2_redis4.gemfile.lock
+++ b/gemfiles/ruby_2.5.9_resque2_redis4.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.14.0)
       debase-ruby_core_source (= 3.2.1)
-      libdatadog (~> 3.0.0.1.0)
+      libdatadog (~> 4.0.0.1.0)
       libddwaf (~> 1.11.0.0.0)
       msgpack
 
@@ -51,8 +51,8 @@ GEM
     hashdiff (1.0.1)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (3.0.0.1.0-aarch64-linux)
-    libdatadog (3.0.0.1.0-x86_64-linux)
+    libdatadog (4.0.0.1.0-aarch64-linux)
+    libdatadog (4.0.0.1.0-x86_64-linux)
     libddwaf (1.11.0.0.0-aarch64-linux)
       ffi (~> 1.0)
     libddwaf (1.11.0.0.0-x86_64-linux)

--- a/gemfiles/ruby_2.5.9_sinatra.gemfile.lock
+++ b/gemfiles/ruby_2.5.9_sinatra.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.14.0)
       debase-ruby_core_source (= 3.2.1)
-      libdatadog (~> 3.0.0.1.0)
+      libdatadog (~> 4.0.0.1.0)
       libddwaf (~> 1.11.0.0.0)
       msgpack
 
@@ -50,8 +50,8 @@ GEM
     hashdiff (1.0.1)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (3.0.0.1.0-aarch64-linux)
-    libdatadog (3.0.0.1.0-x86_64-linux)
+    libdatadog (4.0.0.1.0-aarch64-linux)
+    libdatadog (4.0.0.1.0-x86_64-linux)
     libddwaf (1.11.0.0.0-aarch64-linux)
       ffi (~> 1.0)
     libddwaf (1.11.0.0.0-x86_64-linux)

--- a/gemfiles/ruby_2.6.10_contrib.gemfile.lock
+++ b/gemfiles/ruby_2.6.10_contrib.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.14.0)
       debase-ruby_core_source (= 3.2.1)
-      libdatadog (~> 3.0.0.1.0)
+      libdatadog (~> 4.0.0.1.0)
       libddwaf (~> 1.11.0.0.0)
       msgpack
 
@@ -1544,8 +1544,8 @@ GEM
       addressable (>= 2.4)
     jsonapi-renderer (0.2.2)
     king_konf (1.0.1)
-    libdatadog (3.0.0.1.0-aarch64-linux)
-    libdatadog (3.0.0.1.0-x86_64-linux)
+    libdatadog (4.0.0.1.0-aarch64-linux)
+    libdatadog (4.0.0.1.0-x86_64-linux)
     libddwaf (1.11.0.0.0-aarch64-linux)
       ffi (~> 1.0)
     libddwaf (1.11.0.0.0-x86_64-linux)

--- a/gemfiles/ruby_2.6.10_contrib_old.gemfile.lock
+++ b/gemfiles/ruby_2.6.10_contrib_old.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.14.0)
       debase-ruby_core_source (= 3.2.1)
-      libdatadog (~> 3.0.0.1.0)
+      libdatadog (~> 4.0.0.1.0)
       libddwaf (~> 1.11.0.0.0)
       msgpack
 
@@ -73,8 +73,8 @@ GEM
     json (2.6.3)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (3.0.0.1.0-aarch64-linux)
-    libdatadog (3.0.0.1.0-x86_64-linux)
+    libdatadog (4.0.0.1.0-aarch64-linux)
+    libdatadog (4.0.0.1.0-x86_64-linux)
     libddwaf (1.11.0.0.0-aarch64-linux)
       ffi (~> 1.0)
     libddwaf (1.11.0.0.0-x86_64-linux)

--- a/gemfiles/ruby_2.6.10_core_old.gemfile.lock
+++ b/gemfiles/ruby_2.6.10_core_old.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.14.0)
       debase-ruby_core_source (= 3.2.1)
-      libdatadog (~> 3.0.0.1.0)
+      libdatadog (~> 4.0.0.1.0)
       libddwaf (~> 1.11.0.0.0)
       msgpack
 
@@ -53,8 +53,8 @@ GEM
     json (2.6.3)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (3.0.0.1.0-aarch64-linux)
-    libdatadog (3.0.0.1.0-x86_64-linux)
+    libdatadog (4.0.0.1.0-aarch64-linux)
+    libdatadog (4.0.0.1.0-x86_64-linux)
     libddwaf (1.11.0.0.0-aarch64-linux)
       ffi (~> 1.0)
     libddwaf (1.11.0.0.0-x86_64-linux)

--- a/gemfiles/ruby_2.6.10_cucumber3.gemfile.lock
+++ b/gemfiles/ruby_2.6.10_cucumber3.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.14.0)
       debase-ruby_core_source (= 3.2.1)
-      libdatadog (~> 3.0.0.1.0)
+      libdatadog (~> 4.0.0.1.0)
       libddwaf (~> 1.11.0.0.0)
       msgpack
 
@@ -71,8 +71,8 @@ GEM
     json (2.6.3)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (3.0.0.1.0-aarch64-linux)
-    libdatadog (3.0.0.1.0-x86_64-linux)
+    libdatadog (4.0.0.1.0-aarch64-linux)
+    libdatadog (4.0.0.1.0-x86_64-linux)
     libddwaf (1.11.0.0.0-aarch64-linux)
       ffi (~> 1.0)
     libddwaf (1.11.0.0.0-x86_64-linux)

--- a/gemfiles/ruby_2.6.10_cucumber4.gemfile.lock
+++ b/gemfiles/ruby_2.6.10_cucumber4.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.14.0)
       debase-ruby_core_source (= 3.2.1)
-      libdatadog (~> 3.0.0.1.0)
+      libdatadog (~> 4.0.0.1.0)
       libddwaf (~> 1.11.0.0.0)
       msgpack
 
@@ -92,8 +92,8 @@ GEM
     json (2.6.3)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (3.0.0.1.0-aarch64-linux)
-    libdatadog (3.0.0.1.0-x86_64-linux)
+    libdatadog (4.0.0.1.0-aarch64-linux)
+    libdatadog (4.0.0.1.0-x86_64-linux)
     libddwaf (1.11.0.0.0-aarch64-linux)
       ffi (~> 1.0)
     libddwaf (1.11.0.0.0-x86_64-linux)

--- a/gemfiles/ruby_2.6.10_cucumber5.gemfile.lock
+++ b/gemfiles/ruby_2.6.10_cucumber5.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.14.0)
       debase-ruby_core_source (= 3.2.1)
-      libdatadog (~> 3.0.0.1.0)
+      libdatadog (~> 4.0.0.1.0)
       libddwaf (~> 1.11.0.0.0)
       msgpack
 
@@ -92,8 +92,8 @@ GEM
     json (2.6.3)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (3.0.0.1.0-aarch64-linux)
-    libdatadog (3.0.0.1.0-x86_64-linux)
+    libdatadog (4.0.0.1.0-aarch64-linux)
+    libdatadog (4.0.0.1.0-x86_64-linux)
     libddwaf (1.11.0.0.0-aarch64-linux)
       ffi (~> 1.0)
     libddwaf (1.11.0.0.0-x86_64-linux)

--- a/gemfiles/ruby_2.6.10_hanami_1.gemfile.lock
+++ b/gemfiles/ruby_2.6.10_hanami_1.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.14.0)
       debase-ruby_core_source (= 3.2.1)
-      libdatadog (~> 3.0.0.1.0)
+      libdatadog (~> 4.0.0.1.0)
       libddwaf (~> 1.11.0.0.0)
       msgpack
 
@@ -128,8 +128,8 @@ GEM
     json (2.6.3)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (3.0.0.1.0-aarch64-linux)
-    libdatadog (3.0.0.1.0-x86_64-linux)
+    libdatadog (4.0.0.1.0-aarch64-linux)
+    libdatadog (4.0.0.1.0-x86_64-linux)
     libddwaf (1.11.0.0.0-aarch64-linux)
       ffi (~> 1.0)
     libddwaf (1.11.0.0.0-x86_64-linux)

--- a/gemfiles/ruby_2.6.10_opentelemetry.gemfile.lock
+++ b/gemfiles/ruby_2.6.10_opentelemetry.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.14.0)
       debase-ruby_core_source (= 3.2.1)
-      libdatadog (~> 3.0.0.1.0)
+      libdatadog (~> 4.0.0.1.0)
       libddwaf (~> 1.11.0.0.0)
       msgpack
 
@@ -53,8 +53,8 @@ GEM
     json (2.6.3)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (3.0.0.1.0-aarch64-linux)
-    libdatadog (3.0.0.1.0-x86_64-linux)
+    libdatadog (4.0.0.1.0-aarch64-linux)
+    libdatadog (4.0.0.1.0-x86_64-linux)
     libddwaf (1.11.0.0.0-aarch64-linux)
       ffi (~> 1.0)
     libddwaf (1.11.0.0.0-x86_64-linux)

--- a/gemfiles/ruby_2.6.10_rails5_mysql2.gemfile.lock
+++ b/gemfiles/ruby_2.6.10_rails5_mysql2.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.14.0)
       debase-ruby_core_source (= 3.2.1)
-      libdatadog (~> 3.0.0.1.0)
+      libdatadog (~> 4.0.0.1.0)
       libddwaf (~> 1.11.0.0.0)
       msgpack
 
@@ -102,8 +102,8 @@ GEM
     json (2.6.3)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (3.0.0.1.0-aarch64-linux)
-    libdatadog (3.0.0.1.0-x86_64-linux)
+    libdatadog (4.0.0.1.0-aarch64-linux)
+    libdatadog (4.0.0.1.0-x86_64-linux)
     libddwaf (1.11.0.0.0-aarch64-linux)
       ffi (~> 1.0)
     libddwaf (1.11.0.0.0-x86_64-linux)

--- a/gemfiles/ruby_2.6.10_rails5_postgres.gemfile.lock
+++ b/gemfiles/ruby_2.6.10_rails5_postgres.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.14.0)
       debase-ruby_core_source (= 3.2.1)
-      libdatadog (~> 3.0.0.1.0)
+      libdatadog (~> 4.0.0.1.0)
       libddwaf (~> 1.11.0.0.0)
       msgpack
 
@@ -102,8 +102,8 @@ GEM
     json (2.6.3)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (3.0.0.1.0-aarch64-linux)
-    libdatadog (3.0.0.1.0-x86_64-linux)
+    libdatadog (4.0.0.1.0-aarch64-linux)
+    libdatadog (4.0.0.1.0-x86_64-linux)
     libddwaf (1.11.0.0.0-aarch64-linux)
       ffi (~> 1.0)
     libddwaf (1.11.0.0.0-x86_64-linux)

--- a/gemfiles/ruby_2.6.10_rails5_postgres_redis.gemfile.lock
+++ b/gemfiles/ruby_2.6.10_rails5_postgres_redis.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.14.0)
       debase-ruby_core_source (= 3.2.1)
-      libdatadog (~> 3.0.0.1.0)
+      libdatadog (~> 4.0.0.1.0)
       libddwaf (~> 1.11.0.0.0)
       msgpack
 
@@ -102,8 +102,8 @@ GEM
     json (2.6.3)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (3.0.0.1.0-aarch64-linux)
-    libdatadog (3.0.0.1.0-x86_64-linux)
+    libdatadog (4.0.0.1.0-aarch64-linux)
+    libdatadog (4.0.0.1.0-x86_64-linux)
     libddwaf (1.11.0.0.0-aarch64-linux)
       ffi (~> 1.0)
     libddwaf (1.11.0.0.0-x86_64-linux)

--- a/gemfiles/ruby_2.6.10_rails5_postgres_redis_activesupport.gemfile.lock
+++ b/gemfiles/ruby_2.6.10_rails5_postgres_redis_activesupport.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.14.0)
       debase-ruby_core_source (= 3.2.1)
-      libdatadog (~> 3.0.0.1.0)
+      libdatadog (~> 4.0.0.1.0)
       libddwaf (~> 1.11.0.0.0)
       msgpack
 
@@ -102,8 +102,8 @@ GEM
     json (2.6.3)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (3.0.0.1.0-aarch64-linux)
-    libdatadog (3.0.0.1.0-x86_64-linux)
+    libdatadog (4.0.0.1.0-aarch64-linux)
+    libdatadog (4.0.0.1.0-x86_64-linux)
     libddwaf (1.11.0.0.0-aarch64-linux)
       ffi (~> 1.0)
     libddwaf (1.11.0.0.0-x86_64-linux)

--- a/gemfiles/ruby_2.6.10_rails5_postgres_sidekiq.gemfile.lock
+++ b/gemfiles/ruby_2.6.10_rails5_postgres_sidekiq.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.14.0)
       debase-ruby_core_source (= 3.2.1)
-      libdatadog (~> 3.0.0.1.0)
+      libdatadog (~> 4.0.0.1.0)
       libddwaf (~> 1.11.0.0.0)
       msgpack
 
@@ -103,8 +103,8 @@ GEM
     json (2.6.3)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (3.0.0.1.0-aarch64-linux)
-    libdatadog (3.0.0.1.0-x86_64-linux)
+    libdatadog (4.0.0.1.0-aarch64-linux)
+    libdatadog (4.0.0.1.0-x86_64-linux)
     libddwaf (1.11.0.0.0-aarch64-linux)
       ffi (~> 1.0)
     libddwaf (1.11.0.0.0-x86_64-linux)

--- a/gemfiles/ruby_2.6.10_rails5_semantic_logger.gemfile.lock
+++ b/gemfiles/ruby_2.6.10_rails5_semantic_logger.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.14.0)
       debase-ruby_core_source (= 3.2.1)
-      libdatadog (~> 3.0.0.1.0)
+      libdatadog (~> 4.0.0.1.0)
       libddwaf (~> 1.11.0.0.0)
       msgpack
 
@@ -102,8 +102,8 @@ GEM
     json (2.6.3)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (3.0.0.1.0-aarch64-linux)
-    libdatadog (3.0.0.1.0-x86_64-linux)
+    libdatadog (4.0.0.1.0-aarch64-linux)
+    libdatadog (4.0.0.1.0-x86_64-linux)
     libddwaf (1.11.0.0.0-aarch64-linux)
       ffi (~> 1.0)
     libddwaf (1.11.0.0.0-x86_64-linux)

--- a/gemfiles/ruby_2.6.10_rails61_mysql2.gemfile.lock
+++ b/gemfiles/ruby_2.6.10_rails61_mysql2.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.14.0)
       debase-ruby_core_source (= 3.2.1)
-      libdatadog (~> 3.0.0.1.0)
+      libdatadog (~> 4.0.0.1.0)
       libddwaf (~> 1.11.0.0.0)
       msgpack
 
@@ -119,8 +119,8 @@ GEM
     json (2.6.3)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (3.0.0.1.0-aarch64-linux)
-    libdatadog (3.0.0.1.0-x86_64-linux)
+    libdatadog (4.0.0.1.0-aarch64-linux)
+    libdatadog (4.0.0.1.0-x86_64-linux)
     libddwaf (1.11.0.0.0-aarch64-linux)
       ffi (~> 1.0)
     libddwaf (1.11.0.0.0-x86_64-linux)

--- a/gemfiles/ruby_2.6.10_rails61_postgres.gemfile.lock
+++ b/gemfiles/ruby_2.6.10_rails61_postgres.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.14.0)
       debase-ruby_core_source (= 3.2.1)
-      libdatadog (~> 3.0.0.1.0)
+      libdatadog (~> 4.0.0.1.0)
       libddwaf (~> 1.11.0.0.0)
       msgpack
 
@@ -119,8 +119,8 @@ GEM
     json (2.6.3)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (3.0.0.1.0-aarch64-linux)
-    libdatadog (3.0.0.1.0-x86_64-linux)
+    libdatadog (4.0.0.1.0-aarch64-linux)
+    libdatadog (4.0.0.1.0-x86_64-linux)
     libddwaf (1.11.0.0.0-aarch64-linux)
       ffi (~> 1.0)
     libddwaf (1.11.0.0.0-x86_64-linux)

--- a/gemfiles/ruby_2.6.10_rails61_postgres_redis.gemfile.lock
+++ b/gemfiles/ruby_2.6.10_rails61_postgres_redis.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.14.0)
       debase-ruby_core_source (= 3.2.1)
-      libdatadog (~> 3.0.0.1.0)
+      libdatadog (~> 4.0.0.1.0)
       libddwaf (~> 1.11.0.0.0)
       msgpack
 
@@ -119,8 +119,8 @@ GEM
     json (2.6.3)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (3.0.0.1.0-aarch64-linux)
-    libdatadog (3.0.0.1.0-x86_64-linux)
+    libdatadog (4.0.0.1.0-aarch64-linux)
+    libdatadog (4.0.0.1.0-x86_64-linux)
     libddwaf (1.11.0.0.0-aarch64-linux)
       ffi (~> 1.0)
     libddwaf (1.11.0.0.0-x86_64-linux)

--- a/gemfiles/ruby_2.6.10_rails61_postgres_sidekiq.gemfile.lock
+++ b/gemfiles/ruby_2.6.10_rails61_postgres_sidekiq.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.14.0)
       debase-ruby_core_source (= 3.2.1)
-      libdatadog (~> 3.0.0.1.0)
+      libdatadog (~> 4.0.0.1.0)
       libddwaf (~> 1.11.0.0.0)
       msgpack
 
@@ -120,8 +120,8 @@ GEM
     json (2.6.3)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (3.0.0.1.0-aarch64-linux)
-    libdatadog (3.0.0.1.0-x86_64-linux)
+    libdatadog (4.0.0.1.0-aarch64-linux)
+    libdatadog (4.0.0.1.0-x86_64-linux)
     libddwaf (1.11.0.0.0-aarch64-linux)
       ffi (~> 1.0)
     libddwaf (1.11.0.0.0-x86_64-linux)

--- a/gemfiles/ruby_2.6.10_rails61_semantic_logger.gemfile.lock
+++ b/gemfiles/ruby_2.6.10_rails61_semantic_logger.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.14.0)
       debase-ruby_core_source (= 3.2.1)
-      libdatadog (~> 3.0.0.1.0)
+      libdatadog (~> 4.0.0.1.0)
       libddwaf (~> 1.11.0.0.0)
       msgpack
 
@@ -119,8 +119,8 @@ GEM
     json (2.6.3)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (3.0.0.1.0-aarch64-linux)
-    libdatadog (3.0.0.1.0-x86_64-linux)
+    libdatadog (4.0.0.1.0-aarch64-linux)
+    libdatadog (4.0.0.1.0-x86_64-linux)
     libddwaf (1.11.0.0.0-aarch64-linux)
       ffi (~> 1.0)
     libddwaf (1.11.0.0.0-x86_64-linux)

--- a/gemfiles/ruby_2.6.10_rails6_mysql2.gemfile.lock
+++ b/gemfiles/ruby_2.6.10_rails6_mysql2.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.14.0)
       debase-ruby_core_source (= 3.2.1)
-      libdatadog (~> 3.0.0.1.0)
+      libdatadog (~> 4.0.0.1.0)
       libddwaf (~> 1.11.0.0.0)
       msgpack
 
@@ -115,8 +115,8 @@ GEM
     json (2.6.3)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (3.0.0.1.0-aarch64-linux)
-    libdatadog (3.0.0.1.0-x86_64-linux)
+    libdatadog (4.0.0.1.0-aarch64-linux)
+    libdatadog (4.0.0.1.0-x86_64-linux)
     libddwaf (1.11.0.0.0-aarch64-linux)
       ffi (~> 1.0)
     libddwaf (1.11.0.0.0-x86_64-linux)

--- a/gemfiles/ruby_2.6.10_rails6_postgres.gemfile.lock
+++ b/gemfiles/ruby_2.6.10_rails6_postgres.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.14.0)
       debase-ruby_core_source (= 3.2.1)
-      libdatadog (~> 3.0.0.1.0)
+      libdatadog (~> 4.0.0.1.0)
       libddwaf (~> 1.11.0.0.0)
       msgpack
 
@@ -115,8 +115,8 @@ GEM
     json (2.6.3)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (3.0.0.1.0-aarch64-linux)
-    libdatadog (3.0.0.1.0-x86_64-linux)
+    libdatadog (4.0.0.1.0-aarch64-linux)
+    libdatadog (4.0.0.1.0-x86_64-linux)
     libddwaf (1.11.0.0.0-aarch64-linux)
       ffi (~> 1.0)
     libddwaf (1.11.0.0.0-x86_64-linux)

--- a/gemfiles/ruby_2.6.10_rails6_postgres_redis.gemfile.lock
+++ b/gemfiles/ruby_2.6.10_rails6_postgres_redis.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.14.0)
       debase-ruby_core_source (= 3.2.1)
-      libdatadog (~> 3.0.0.1.0)
+      libdatadog (~> 4.0.0.1.0)
       libddwaf (~> 1.11.0.0.0)
       msgpack
 
@@ -115,8 +115,8 @@ GEM
     json (2.6.3)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (3.0.0.1.0-aarch64-linux)
-    libdatadog (3.0.0.1.0-x86_64-linux)
+    libdatadog (4.0.0.1.0-aarch64-linux)
+    libdatadog (4.0.0.1.0-x86_64-linux)
     libddwaf (1.11.0.0.0-aarch64-linux)
       ffi (~> 1.0)
     libddwaf (1.11.0.0.0-x86_64-linux)

--- a/gemfiles/ruby_2.6.10_rails6_postgres_redis_activesupport.gemfile.lock
+++ b/gemfiles/ruby_2.6.10_rails6_postgres_redis_activesupport.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.14.0)
       debase-ruby_core_source (= 3.2.1)
-      libdatadog (~> 3.0.0.1.0)
+      libdatadog (~> 4.0.0.1.0)
       libddwaf (~> 1.11.0.0.0)
       msgpack
 
@@ -115,8 +115,8 @@ GEM
     json (2.6.3)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (3.0.0.1.0-aarch64-linux)
-    libdatadog (3.0.0.1.0-x86_64-linux)
+    libdatadog (4.0.0.1.0-aarch64-linux)
+    libdatadog (4.0.0.1.0-x86_64-linux)
     libddwaf (1.11.0.0.0-aarch64-linux)
       ffi (~> 1.0)
     libddwaf (1.11.0.0.0-x86_64-linux)

--- a/gemfiles/ruby_2.6.10_rails6_postgres_sidekiq.gemfile.lock
+++ b/gemfiles/ruby_2.6.10_rails6_postgres_sidekiq.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.14.0)
       debase-ruby_core_source (= 3.2.1)
-      libdatadog (~> 3.0.0.1.0)
+      libdatadog (~> 4.0.0.1.0)
       libddwaf (~> 1.11.0.0.0)
       msgpack
 
@@ -116,8 +116,8 @@ GEM
     json (2.6.3)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (3.0.0.1.0-aarch64-linux)
-    libdatadog (3.0.0.1.0-x86_64-linux)
+    libdatadog (4.0.0.1.0-aarch64-linux)
+    libdatadog (4.0.0.1.0-x86_64-linux)
     libddwaf (1.11.0.0.0-aarch64-linux)
       ffi (~> 1.0)
     libddwaf (1.11.0.0.0-x86_64-linux)

--- a/gemfiles/ruby_2.6.10_rails6_semantic_logger.gemfile.lock
+++ b/gemfiles/ruby_2.6.10_rails6_semantic_logger.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.14.0)
       debase-ruby_core_source (= 3.2.1)
-      libdatadog (~> 3.0.0.1.0)
+      libdatadog (~> 4.0.0.1.0)
       libddwaf (~> 1.11.0.0.0)
       msgpack
 
@@ -115,8 +115,8 @@ GEM
     json (2.6.3)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (3.0.0.1.0-aarch64-linux)
-    libdatadog (3.0.0.1.0-x86_64-linux)
+    libdatadog (4.0.0.1.0-aarch64-linux)
+    libdatadog (4.0.0.1.0-x86_64-linux)
     libddwaf (1.11.0.0.0-aarch64-linux)
       ffi (~> 1.0)
     libddwaf (1.11.0.0.0-x86_64-linux)

--- a/gemfiles/ruby_2.6.10_redis_3.gemfile.lock
+++ b/gemfiles/ruby_2.6.10_redis_3.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.14.0)
       debase-ruby_core_source (= 3.2.1)
-      libdatadog (~> 3.0.0.1.0)
+      libdatadog (~> 4.0.0.1.0)
       libddwaf (~> 1.11.0.0.0)
       msgpack
 
@@ -53,8 +53,8 @@ GEM
     json (2.6.3)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (3.0.0.1.0-aarch64-linux)
-    libdatadog (3.0.0.1.0-x86_64-linux)
+    libdatadog (4.0.0.1.0-aarch64-linux)
+    libdatadog (4.0.0.1.0-x86_64-linux)
     libddwaf (1.11.0.0.0-aarch64-linux)
       ffi (~> 1.0)
     libddwaf (1.11.0.0.0-x86_64-linux)

--- a/gemfiles/ruby_2.6.10_redis_4.gemfile.lock
+++ b/gemfiles/ruby_2.6.10_redis_4.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.14.0)
       debase-ruby_core_source (= 3.2.1)
-      libdatadog (~> 3.0.0.1.0)
+      libdatadog (~> 4.0.0.1.0)
       libddwaf (~> 1.11.0.0.0)
       msgpack
 
@@ -53,8 +53,8 @@ GEM
     json (2.6.3)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (3.0.0.1.0-aarch64-linux)
-    libdatadog (3.0.0.1.0-x86_64-linux)
+    libdatadog (4.0.0.1.0-aarch64-linux)
+    libdatadog (4.0.0.1.0-x86_64-linux)
     libddwaf (1.11.0.0.0-aarch64-linux)
       ffi (~> 1.0)
     libddwaf (1.11.0.0.0-x86_64-linux)

--- a/gemfiles/ruby_2.6.10_redis_5.gemfile.lock
+++ b/gemfiles/ruby_2.6.10_redis_5.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.14.0)
       debase-ruby_core_source (= 3.2.1)
-      libdatadog (~> 3.0.0.1.0)
+      libdatadog (~> 4.0.0.1.0)
       libddwaf (~> 1.11.0.0.0)
       msgpack
 
@@ -54,8 +54,8 @@ GEM
     json (2.6.3)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (3.0.0.1.0-aarch64-linux)
-    libdatadog (3.0.0.1.0-x86_64-linux)
+    libdatadog (4.0.0.1.0-aarch64-linux)
+    libdatadog (4.0.0.1.0-x86_64-linux)
     libddwaf (1.11.0.0.0-aarch64-linux)
       ffi (~> 1.0)
     libddwaf (1.11.0.0.0-x86_64-linux)

--- a/gemfiles/ruby_2.6.10_resque2_redis3.gemfile.lock
+++ b/gemfiles/ruby_2.6.10_resque2_redis3.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.14.0)
       debase-ruby_core_source (= 3.2.1)
-      libdatadog (~> 3.0.0.1.0)
+      libdatadog (~> 4.0.0.1.0)
       libddwaf (~> 1.11.0.0.0)
       msgpack
 
@@ -53,8 +53,8 @@ GEM
     json (2.6.3)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (3.0.0.1.0-aarch64-linux)
-    libdatadog (3.0.0.1.0-x86_64-linux)
+    libdatadog (4.0.0.1.0-aarch64-linux)
+    libdatadog (4.0.0.1.0-x86_64-linux)
     libddwaf (1.11.0.0.0-aarch64-linux)
       ffi (~> 1.0)
     libddwaf (1.11.0.0.0-x86_64-linux)

--- a/gemfiles/ruby_2.6.10_resque2_redis4.gemfile.lock
+++ b/gemfiles/ruby_2.6.10_resque2_redis4.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.14.0)
       debase-ruby_core_source (= 3.2.1)
-      libdatadog (~> 3.0.0.1.0)
+      libdatadog (~> 4.0.0.1.0)
       libddwaf (~> 1.11.0.0.0)
       msgpack
 
@@ -53,8 +53,8 @@ GEM
     json (2.6.3)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (3.0.0.1.0-aarch64-linux)
-    libdatadog (3.0.0.1.0-x86_64-linux)
+    libdatadog (4.0.0.1.0-aarch64-linux)
+    libdatadog (4.0.0.1.0-x86_64-linux)
     libddwaf (1.11.0.0.0-aarch64-linux)
       ffi (~> 1.0)
     libddwaf (1.11.0.0.0-x86_64-linux)

--- a/gemfiles/ruby_2.6.10_sinatra.gemfile.lock
+++ b/gemfiles/ruby_2.6.10_sinatra.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.14.0)
       debase-ruby_core_source (= 3.2.1)
-      libdatadog (~> 3.0.0.1.0)
+      libdatadog (~> 4.0.0.1.0)
       libddwaf (~> 1.11.0.0.0)
       msgpack
 
@@ -53,8 +53,8 @@ GEM
     json (2.6.3)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (3.0.0.1.0-aarch64-linux)
-    libdatadog (3.0.0.1.0-x86_64-linux)
+    libdatadog (4.0.0.1.0-aarch64-linux)
+    libdatadog (4.0.0.1.0-x86_64-linux)
     libddwaf (1.11.0.0.0-aarch64-linux)
       ffi (~> 1.0)
     libddwaf (1.11.0.0.0-x86_64-linux)

--- a/gemfiles/ruby_2.7.6_contrib.gemfile.lock
+++ b/gemfiles/ruby_2.7.6_contrib.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.14.0)
       debase-ruby_core_source (= 3.2.1)
-      libdatadog (~> 3.0.0.1.0)
+      libdatadog (~> 4.0.0.1.0)
       libddwaf (~> 1.11.0.0.0)
       msgpack
 
@@ -1540,8 +1540,8 @@ GEM
       addressable (>= 2.4)
     jsonapi-renderer (0.2.2)
     king_konf (1.0.1)
-    libdatadog (3.0.0.1.0-aarch64-linux)
-    libdatadog (3.0.0.1.0-x86_64-linux)
+    libdatadog (4.0.0.1.0-aarch64-linux)
+    libdatadog (4.0.0.1.0-x86_64-linux)
     libddwaf (1.11.0.0.0-aarch64-linux)
       ffi (~> 1.0)
     libddwaf (1.11.0.0.0-x86_64-linux)

--- a/gemfiles/ruby_2.7.6_contrib_old.gemfile.lock
+++ b/gemfiles/ruby_2.7.6_contrib_old.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.14.0)
       debase-ruby_core_source (= 3.2.1)
-      libdatadog (~> 3.0.0.1.0)
+      libdatadog (~> 4.0.0.1.0)
       libddwaf (~> 1.11.0.0.0)
       msgpack
 
@@ -73,8 +73,8 @@ GEM
     json (2.6.3)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (3.0.0.1.0-aarch64-linux)
-    libdatadog (3.0.0.1.0-x86_64-linux)
+    libdatadog (4.0.0.1.0-aarch64-linux)
+    libdatadog (4.0.0.1.0-x86_64-linux)
     libddwaf (1.11.0.0.0-aarch64-linux)
       ffi (~> 1.0)
     libddwaf (1.11.0.0.0-x86_64-linux)

--- a/gemfiles/ruby_2.7.6_core_old.gemfile.lock
+++ b/gemfiles/ruby_2.7.6_core_old.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.14.0)
       debase-ruby_core_source (= 3.2.1)
-      libdatadog (~> 3.0.0.1.0)
+      libdatadog (~> 4.0.0.1.0)
       libddwaf (~> 1.11.0.0.0)
       msgpack
 
@@ -53,8 +53,8 @@ GEM
     json (2.6.3)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (3.0.0.1.0-aarch64-linux)
-    libdatadog (3.0.0.1.0-x86_64-linux)
+    libdatadog (4.0.0.1.0-aarch64-linux)
+    libdatadog (4.0.0.1.0-x86_64-linux)
     libddwaf (1.11.0.0.0-aarch64-linux)
       ffi (~> 1.0)
     libddwaf (1.11.0.0.0-x86_64-linux)

--- a/gemfiles/ruby_2.7.6_cucumber3.gemfile.lock
+++ b/gemfiles/ruby_2.7.6_cucumber3.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.14.0)
       debase-ruby_core_source (= 3.2.1)
-      libdatadog (~> 3.0.0.1.0)
+      libdatadog (~> 4.0.0.1.0)
       libddwaf (~> 1.11.0.0.0)
       msgpack
 
@@ -71,8 +71,8 @@ GEM
     json (2.6.3)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (3.0.0.1.0-aarch64-linux)
-    libdatadog (3.0.0.1.0-x86_64-linux)
+    libdatadog (4.0.0.1.0-aarch64-linux)
+    libdatadog (4.0.0.1.0-x86_64-linux)
     libddwaf (1.11.0.0.0-aarch64-linux)
       ffi (~> 1.0)
     libddwaf (1.11.0.0.0-x86_64-linux)

--- a/gemfiles/ruby_2.7.6_cucumber4.gemfile.lock
+++ b/gemfiles/ruby_2.7.6_cucumber4.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.14.0)
       debase-ruby_core_source (= 3.2.1)
-      libdatadog (~> 3.0.0.1.0)
+      libdatadog (~> 4.0.0.1.0)
       libddwaf (~> 1.11.0.0.0)
       msgpack
 
@@ -91,8 +91,8 @@ GEM
     json (2.6.3)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (3.0.0.1.0-aarch64-linux)
-    libdatadog (3.0.0.1.0-x86_64-linux)
+    libdatadog (4.0.0.1.0-aarch64-linux)
+    libdatadog (4.0.0.1.0-x86_64-linux)
     libddwaf (1.11.0.0.0-aarch64-linux)
       ffi (~> 1.0)
     libddwaf (1.11.0.0.0-x86_64-linux)

--- a/gemfiles/ruby_2.7.6_cucumber5.gemfile.lock
+++ b/gemfiles/ruby_2.7.6_cucumber5.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.14.0)
       debase-ruby_core_source (= 3.2.1)
-      libdatadog (~> 3.0.0.1.0)
+      libdatadog (~> 4.0.0.1.0)
       libddwaf (~> 1.11.0.0.0)
       msgpack
 
@@ -91,8 +91,8 @@ GEM
     json (2.6.3)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (3.0.0.1.0-aarch64-linux)
-    libdatadog (3.0.0.1.0-x86_64-linux)
+    libdatadog (4.0.0.1.0-aarch64-linux)
+    libdatadog (4.0.0.1.0-x86_64-linux)
     libddwaf (1.11.0.0.0-aarch64-linux)
       ffi (~> 1.0)
     libddwaf (1.11.0.0.0-x86_64-linux)

--- a/gemfiles/ruby_2.7.6_cucumber6.gemfile.lock
+++ b/gemfiles/ruby_2.7.6_cucumber6.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.14.0)
       debase-ruby_core_source (= 3.2.1)
-      libdatadog (~> 3.0.0.1.0)
+      libdatadog (~> 4.0.0.1.0)
       libddwaf (~> 1.11.0.0.0)
       msgpack
 
@@ -91,7 +91,7 @@ GEM
     json (2.6.3)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (3.0.0.1.0-aarch64-linux)
+    libdatadog (4.0.0.1.0-aarch64-linux)
     libddwaf (1.11.0.0.0-aarch64-linux)
       ffi (~> 1.0)
     memory_profiler (0.9.14)

--- a/gemfiles/ruby_2.7.6_cucumber7.gemfile.lock
+++ b/gemfiles/ruby_2.7.6_cucumber7.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.14.0)
       debase-ruby_core_source (= 3.2.1)
-      libdatadog (~> 3.0.0.1.0)
+      libdatadog (~> 4.0.0.1.0)
       libddwaf (~> 1.11.0.0.0)
       msgpack
 
@@ -82,7 +82,7 @@ GEM
     json (2.6.3)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (3.0.0.1.0-aarch64-linux)
+    libdatadog (4.0.0.1.0-aarch64-linux)
     libddwaf (1.11.0.0.0-aarch64-linux)
       ffi (~> 1.0)
     memory_profiler (0.9.14)

--- a/gemfiles/ruby_2.7.6_cucumber8.gemfile.lock
+++ b/gemfiles/ruby_2.7.6_cucumber8.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.14.0)
       debase-ruby_core_source (= 3.2.1)
-      libdatadog (~> 3.0.0.1.0)
+      libdatadog (~> 4.0.0.1.0)
       libddwaf (~> 1.11.0.0.0)
       msgpack
 
@@ -76,7 +76,7 @@ GEM
     json (2.6.3)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (3.0.0.1.0-aarch64-linux)
+    libdatadog (4.0.0.1.0-aarch64-linux)
     libddwaf (1.11.0.0.0-aarch64-linux)
       ffi (~> 1.0)
     memory_profiler (0.9.14)

--- a/gemfiles/ruby_2.7.6_hanami_1.gemfile.lock
+++ b/gemfiles/ruby_2.7.6_hanami_1.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.14.0)
       debase-ruby_core_source (= 3.2.1)
-      libdatadog (~> 3.0.0.1.0)
+      libdatadog (~> 4.0.0.1.0)
       libddwaf (~> 1.11.0.0.0)
       msgpack
 
@@ -129,8 +129,8 @@ GEM
     json (2.6.3)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (3.0.0.1.0-aarch64-linux)
-    libdatadog (3.0.0.1.0-x86_64-linux)
+    libdatadog (4.0.0.1.0-aarch64-linux)
+    libdatadog (4.0.0.1.0-x86_64-linux)
     libddwaf (1.11.0.0.0-aarch64-linux)
       ffi (~> 1.0)
     libddwaf (1.11.0.0.0-x86_64-linux)

--- a/gemfiles/ruby_2.7.6_opentelemetry.gemfile.lock
+++ b/gemfiles/ruby_2.7.6_opentelemetry.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.14.0)
       debase-ruby_core_source (= 3.2.1)
-      libdatadog (~> 3.0.0.1.0)
+      libdatadog (~> 4.0.0.1.0)
       libddwaf (~> 1.11.0.0.0)
       msgpack
 
@@ -53,8 +53,8 @@ GEM
     json (2.6.3)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (3.0.0.1.0-aarch64-linux)
-    libdatadog (3.0.0.1.0-x86_64-linux)
+    libdatadog (4.0.0.1.0-aarch64-linux)
+    libdatadog (4.0.0.1.0-x86_64-linux)
     libddwaf (1.11.0.0.0-aarch64-linux)
       ffi (~> 1.0)
     libddwaf (1.11.0.0.0-x86_64-linux)

--- a/gemfiles/ruby_2.7.6_rails5_mysql2.gemfile.lock
+++ b/gemfiles/ruby_2.7.6_rails5_mysql2.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.14.0)
       debase-ruby_core_source (= 3.2.1)
-      libdatadog (~> 3.0.0.1.0)
+      libdatadog (~> 4.0.0.1.0)
       libddwaf (~> 1.11.0.0.0)
       msgpack
 
@@ -102,8 +102,8 @@ GEM
     json (2.6.3)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (3.0.0.1.0-aarch64-linux)
-    libdatadog (3.0.0.1.0-x86_64-linux)
+    libdatadog (4.0.0.1.0-aarch64-linux)
+    libdatadog (4.0.0.1.0-x86_64-linux)
     libddwaf (1.11.0.0.0-aarch64-linux)
       ffi (~> 1.0)
     libddwaf (1.11.0.0.0-x86_64-linux)

--- a/gemfiles/ruby_2.7.6_rails5_postgres.gemfile.lock
+++ b/gemfiles/ruby_2.7.6_rails5_postgres.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.14.0)
       debase-ruby_core_source (= 3.2.1)
-      libdatadog (~> 3.0.0.1.0)
+      libdatadog (~> 4.0.0.1.0)
       libddwaf (~> 1.11.0.0.0)
       msgpack
 
@@ -102,8 +102,8 @@ GEM
     json (2.6.3)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (3.0.0.1.0-aarch64-linux)
-    libdatadog (3.0.0.1.0-x86_64-linux)
+    libdatadog (4.0.0.1.0-aarch64-linux)
+    libdatadog (4.0.0.1.0-x86_64-linux)
     libddwaf (1.11.0.0.0-aarch64-linux)
       ffi (~> 1.0)
     libddwaf (1.11.0.0.0-x86_64-linux)

--- a/gemfiles/ruby_2.7.6_rails5_postgres_redis.gemfile.lock
+++ b/gemfiles/ruby_2.7.6_rails5_postgres_redis.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.14.0)
       debase-ruby_core_source (= 3.2.1)
-      libdatadog (~> 3.0.0.1.0)
+      libdatadog (~> 4.0.0.1.0)
       libddwaf (~> 1.11.0.0.0)
       msgpack
 
@@ -102,8 +102,8 @@ GEM
     json (2.6.3)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (3.0.0.1.0-aarch64-linux)
-    libdatadog (3.0.0.1.0-x86_64-linux)
+    libdatadog (4.0.0.1.0-aarch64-linux)
+    libdatadog (4.0.0.1.0-x86_64-linux)
     libddwaf (1.11.0.0.0-aarch64-linux)
       ffi (~> 1.0)
     libddwaf (1.11.0.0.0-x86_64-linux)

--- a/gemfiles/ruby_2.7.6_rails5_postgres_redis_activesupport.gemfile.lock
+++ b/gemfiles/ruby_2.7.6_rails5_postgres_redis_activesupport.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.14.0)
       debase-ruby_core_source (= 3.2.1)
-      libdatadog (~> 3.0.0.1.0)
+      libdatadog (~> 4.0.0.1.0)
       libddwaf (~> 1.11.0.0.0)
       msgpack
 
@@ -102,8 +102,8 @@ GEM
     json (2.6.3)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (3.0.0.1.0-aarch64-linux)
-    libdatadog (3.0.0.1.0-x86_64-linux)
+    libdatadog (4.0.0.1.0-aarch64-linux)
+    libdatadog (4.0.0.1.0-x86_64-linux)
     libddwaf (1.11.0.0.0-aarch64-linux)
       ffi (~> 1.0)
     libddwaf (1.11.0.0.0-x86_64-linux)

--- a/gemfiles/ruby_2.7.6_rails5_postgres_sidekiq.gemfile.lock
+++ b/gemfiles/ruby_2.7.6_rails5_postgres_sidekiq.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.14.0)
       debase-ruby_core_source (= 3.2.1)
-      libdatadog (~> 3.0.0.1.0)
+      libdatadog (~> 4.0.0.1.0)
       libddwaf (~> 1.11.0.0.0)
       msgpack
 
@@ -103,8 +103,8 @@ GEM
     json (2.6.3)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (3.0.0.1.0-aarch64-linux)
-    libdatadog (3.0.0.1.0-x86_64-linux)
+    libdatadog (4.0.0.1.0-aarch64-linux)
+    libdatadog (4.0.0.1.0-x86_64-linux)
     libddwaf (1.11.0.0.0-aarch64-linux)
       ffi (~> 1.0)
     libddwaf (1.11.0.0.0-x86_64-linux)

--- a/gemfiles/ruby_2.7.6_rails5_semantic_logger.gemfile.lock
+++ b/gemfiles/ruby_2.7.6_rails5_semantic_logger.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.14.0)
       debase-ruby_core_source (= 3.2.1)
-      libdatadog (~> 3.0.0.1.0)
+      libdatadog (~> 4.0.0.1.0)
       libddwaf (~> 1.11.0.0.0)
       msgpack
 
@@ -102,8 +102,8 @@ GEM
     json (2.6.3)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (3.0.0.1.0-aarch64-linux)
-    libdatadog (3.0.0.1.0-x86_64-linux)
+    libdatadog (4.0.0.1.0-aarch64-linux)
+    libdatadog (4.0.0.1.0-x86_64-linux)
     libddwaf (1.11.0.0.0-aarch64-linux)
       ffi (~> 1.0)
     libddwaf (1.11.0.0.0-x86_64-linux)

--- a/gemfiles/ruby_2.7.6_rails61_mysql2.gemfile.lock
+++ b/gemfiles/ruby_2.7.6_rails61_mysql2.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.14.0)
       debase-ruby_core_source (= 3.2.1)
-      libdatadog (~> 3.0.0.1.0)
+      libdatadog (~> 4.0.0.1.0)
       libddwaf (~> 1.11.0.0.0)
       msgpack
 
@@ -119,8 +119,8 @@ GEM
     json (2.6.3)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (3.0.0.1.0-aarch64-linux)
-    libdatadog (3.0.0.1.0-x86_64-linux)
+    libdatadog (4.0.0.1.0-aarch64-linux)
+    libdatadog (4.0.0.1.0-x86_64-linux)
     libddwaf (1.11.0.0.0-aarch64-linux)
       ffi (~> 1.0)
     libddwaf (1.11.0.0.0-x86_64-linux)

--- a/gemfiles/ruby_2.7.6_rails61_postgres.gemfile.lock
+++ b/gemfiles/ruby_2.7.6_rails61_postgres.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.14.0)
       debase-ruby_core_source (= 3.2.1)
-      libdatadog (~> 3.0.0.1.0)
+      libdatadog (~> 4.0.0.1.0)
       libddwaf (~> 1.11.0.0.0)
       msgpack
 
@@ -119,8 +119,8 @@ GEM
     json (2.6.3)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (3.0.0.1.0-aarch64-linux)
-    libdatadog (3.0.0.1.0-x86_64-linux)
+    libdatadog (4.0.0.1.0-aarch64-linux)
+    libdatadog (4.0.0.1.0-x86_64-linux)
     libddwaf (1.11.0.0.0-aarch64-linux)
       ffi (~> 1.0)
     libddwaf (1.11.0.0.0-x86_64-linux)

--- a/gemfiles/ruby_2.7.6_rails61_postgres_redis.gemfile.lock
+++ b/gemfiles/ruby_2.7.6_rails61_postgres_redis.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.14.0)
       debase-ruby_core_source (= 3.2.1)
-      libdatadog (~> 3.0.0.1.0)
+      libdatadog (~> 4.0.0.1.0)
       libddwaf (~> 1.11.0.0.0)
       msgpack
 
@@ -119,8 +119,8 @@ GEM
     json (2.6.3)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (3.0.0.1.0-aarch64-linux)
-    libdatadog (3.0.0.1.0-x86_64-linux)
+    libdatadog (4.0.0.1.0-aarch64-linux)
+    libdatadog (4.0.0.1.0-x86_64-linux)
     libddwaf (1.11.0.0.0-aarch64-linux)
       ffi (~> 1.0)
     libddwaf (1.11.0.0.0-x86_64-linux)

--- a/gemfiles/ruby_2.7.6_rails61_postgres_sidekiq.gemfile.lock
+++ b/gemfiles/ruby_2.7.6_rails61_postgres_sidekiq.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.14.0)
       debase-ruby_core_source (= 3.2.1)
-      libdatadog (~> 3.0.0.1.0)
+      libdatadog (~> 4.0.0.1.0)
       libddwaf (~> 1.11.0.0.0)
       msgpack
 
@@ -120,8 +120,8 @@ GEM
     json (2.6.3)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (3.0.0.1.0-aarch64-linux)
-    libdatadog (3.0.0.1.0-x86_64-linux)
+    libdatadog (4.0.0.1.0-aarch64-linux)
+    libdatadog (4.0.0.1.0-x86_64-linux)
     libddwaf (1.11.0.0.0-aarch64-linux)
       ffi (~> 1.0)
     libddwaf (1.11.0.0.0-x86_64-linux)

--- a/gemfiles/ruby_2.7.6_rails61_semantic_logger.gemfile.lock
+++ b/gemfiles/ruby_2.7.6_rails61_semantic_logger.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.14.0)
       debase-ruby_core_source (= 3.2.1)
-      libdatadog (~> 3.0.0.1.0)
+      libdatadog (~> 4.0.0.1.0)
       libddwaf (~> 1.11.0.0.0)
       msgpack
 
@@ -119,8 +119,8 @@ GEM
     json (2.6.3)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (3.0.0.1.0-aarch64-linux)
-    libdatadog (3.0.0.1.0-x86_64-linux)
+    libdatadog (4.0.0.1.0-aarch64-linux)
+    libdatadog (4.0.0.1.0-x86_64-linux)
     libddwaf (1.11.0.0.0-aarch64-linux)
       ffi (~> 1.0)
     libddwaf (1.11.0.0.0-x86_64-linux)

--- a/gemfiles/ruby_2.7.6_rails6_mysql2.gemfile.lock
+++ b/gemfiles/ruby_2.7.6_rails6_mysql2.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.14.0)
       debase-ruby_core_source (= 3.2.1)
-      libdatadog (~> 3.0.0.1.0)
+      libdatadog (~> 4.0.0.1.0)
       libddwaf (~> 1.11.0.0.0)
       msgpack
 
@@ -115,8 +115,8 @@ GEM
     json (2.6.3)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (3.0.0.1.0-aarch64-linux)
-    libdatadog (3.0.0.1.0-x86_64-linux)
+    libdatadog (4.0.0.1.0-aarch64-linux)
+    libdatadog (4.0.0.1.0-x86_64-linux)
     libddwaf (1.11.0.0.0-aarch64-linux)
       ffi (~> 1.0)
     libddwaf (1.11.0.0.0-x86_64-linux)

--- a/gemfiles/ruby_2.7.6_rails6_postgres.gemfile.lock
+++ b/gemfiles/ruby_2.7.6_rails6_postgres.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.14.0)
       debase-ruby_core_source (= 3.2.1)
-      libdatadog (~> 3.0.0.1.0)
+      libdatadog (~> 4.0.0.1.0)
       libddwaf (~> 1.11.0.0.0)
       msgpack
 
@@ -115,8 +115,8 @@ GEM
     json (2.6.3)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (3.0.0.1.0-aarch64-linux)
-    libdatadog (3.0.0.1.0-x86_64-linux)
+    libdatadog (4.0.0.1.0-aarch64-linux)
+    libdatadog (4.0.0.1.0-x86_64-linux)
     libddwaf (1.11.0.0.0-aarch64-linux)
       ffi (~> 1.0)
     libddwaf (1.11.0.0.0-x86_64-linux)

--- a/gemfiles/ruby_2.7.6_rails6_postgres_redis.gemfile.lock
+++ b/gemfiles/ruby_2.7.6_rails6_postgres_redis.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.14.0)
       debase-ruby_core_source (= 3.2.1)
-      libdatadog (~> 3.0.0.1.0)
+      libdatadog (~> 4.0.0.1.0)
       libddwaf (~> 1.11.0.0.0)
       msgpack
 
@@ -115,8 +115,8 @@ GEM
     json (2.6.3)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (3.0.0.1.0-aarch64-linux)
-    libdatadog (3.0.0.1.0-x86_64-linux)
+    libdatadog (4.0.0.1.0-aarch64-linux)
+    libdatadog (4.0.0.1.0-x86_64-linux)
     libddwaf (1.11.0.0.0-aarch64-linux)
       ffi (~> 1.0)
     libddwaf (1.11.0.0.0-x86_64-linux)

--- a/gemfiles/ruby_2.7.6_rails6_postgres_redis_activesupport.gemfile.lock
+++ b/gemfiles/ruby_2.7.6_rails6_postgres_redis_activesupport.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.14.0)
       debase-ruby_core_source (= 3.2.1)
-      libdatadog (~> 3.0.0.1.0)
+      libdatadog (~> 4.0.0.1.0)
       libddwaf (~> 1.11.0.0.0)
       msgpack
 
@@ -115,8 +115,8 @@ GEM
     json (2.6.3)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (3.0.0.1.0-aarch64-linux)
-    libdatadog (3.0.0.1.0-x86_64-linux)
+    libdatadog (4.0.0.1.0-aarch64-linux)
+    libdatadog (4.0.0.1.0-x86_64-linux)
     libddwaf (1.11.0.0.0-aarch64-linux)
       ffi (~> 1.0)
     libddwaf (1.11.0.0.0-x86_64-linux)

--- a/gemfiles/ruby_2.7.6_rails6_postgres_sidekiq.gemfile.lock
+++ b/gemfiles/ruby_2.7.6_rails6_postgres_sidekiq.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.14.0)
       debase-ruby_core_source (= 3.2.1)
-      libdatadog (~> 3.0.0.1.0)
+      libdatadog (~> 4.0.0.1.0)
       libddwaf (~> 1.11.0.0.0)
       msgpack
 
@@ -116,8 +116,8 @@ GEM
     json (2.6.3)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (3.0.0.1.0-aarch64-linux)
-    libdatadog (3.0.0.1.0-x86_64-linux)
+    libdatadog (4.0.0.1.0-aarch64-linux)
+    libdatadog (4.0.0.1.0-x86_64-linux)
     libddwaf (1.11.0.0.0-aarch64-linux)
       ffi (~> 1.0)
     libddwaf (1.11.0.0.0-x86_64-linux)

--- a/gemfiles/ruby_2.7.6_rails6_semantic_logger.gemfile.lock
+++ b/gemfiles/ruby_2.7.6_rails6_semantic_logger.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.14.0)
       debase-ruby_core_source (= 3.2.1)
-      libdatadog (~> 3.0.0.1.0)
+      libdatadog (~> 4.0.0.1.0)
       libddwaf (~> 1.11.0.0.0)
       msgpack
 
@@ -115,8 +115,8 @@ GEM
     json (2.6.3)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (3.0.0.1.0-aarch64-linux)
-    libdatadog (3.0.0.1.0-x86_64-linux)
+    libdatadog (4.0.0.1.0-aarch64-linux)
+    libdatadog (4.0.0.1.0-x86_64-linux)
     libddwaf (1.11.0.0.0-aarch64-linux)
       ffi (~> 1.0)
     libddwaf (1.11.0.0.0-x86_64-linux)

--- a/gemfiles/ruby_2.7.6_redis_3.gemfile.lock
+++ b/gemfiles/ruby_2.7.6_redis_3.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.14.0)
       debase-ruby_core_source (= 3.2.1)
-      libdatadog (~> 3.0.0.1.0)
+      libdatadog (~> 4.0.0.1.0)
       libddwaf (~> 1.11.0.0.0)
       msgpack
 
@@ -53,8 +53,8 @@ GEM
     json (2.6.3)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (3.0.0.1.0-aarch64-linux)
-    libdatadog (3.0.0.1.0-x86_64-linux)
+    libdatadog (4.0.0.1.0-aarch64-linux)
+    libdatadog (4.0.0.1.0-x86_64-linux)
     libddwaf (1.11.0.0.0-aarch64-linux)
       ffi (~> 1.0)
     libddwaf (1.11.0.0.0-x86_64-linux)

--- a/gemfiles/ruby_2.7.6_redis_4.gemfile.lock
+++ b/gemfiles/ruby_2.7.6_redis_4.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.14.0)
       debase-ruby_core_source (= 3.2.1)
-      libdatadog (~> 3.0.0.1.0)
+      libdatadog (~> 4.0.0.1.0)
       libddwaf (~> 1.11.0.0.0)
       msgpack
 
@@ -53,8 +53,8 @@ GEM
     json (2.6.3)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (3.0.0.1.0-aarch64-linux)
-    libdatadog (3.0.0.1.0-x86_64-linux)
+    libdatadog (4.0.0.1.0-aarch64-linux)
+    libdatadog (4.0.0.1.0-x86_64-linux)
     libddwaf (1.11.0.0.0-aarch64-linux)
       ffi (~> 1.0)
     libddwaf (1.11.0.0.0-x86_64-linux)

--- a/gemfiles/ruby_2.7.6_redis_5.gemfile.lock
+++ b/gemfiles/ruby_2.7.6_redis_5.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.14.0)
       debase-ruby_core_source (= 3.2.1)
-      libdatadog (~> 3.0.0.1.0)
+      libdatadog (~> 4.0.0.1.0)
       libddwaf (~> 1.11.0.0.0)
       msgpack
 
@@ -54,8 +54,8 @@ GEM
     json (2.6.3)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (3.0.0.1.0-aarch64-linux)
-    libdatadog (3.0.0.1.0-x86_64-linux)
+    libdatadog (4.0.0.1.0-aarch64-linux)
+    libdatadog (4.0.0.1.0-x86_64-linux)
     libddwaf (1.11.0.0.0-aarch64-linux)
       ffi (~> 1.0)
     libddwaf (1.11.0.0.0-x86_64-linux)

--- a/gemfiles/ruby_2.7.6_resque2_redis3.gemfile.lock
+++ b/gemfiles/ruby_2.7.6_resque2_redis3.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.14.0)
       debase-ruby_core_source (= 3.2.1)
-      libdatadog (~> 3.0.0.1.0)
+      libdatadog (~> 4.0.0.1.0)
       libddwaf (~> 1.11.0.0.0)
       msgpack
 
@@ -53,8 +53,8 @@ GEM
     json (2.6.3)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (3.0.0.1.0-aarch64-linux)
-    libdatadog (3.0.0.1.0-x86_64-linux)
+    libdatadog (4.0.0.1.0-aarch64-linux)
+    libdatadog (4.0.0.1.0-x86_64-linux)
     libddwaf (1.11.0.0.0-aarch64-linux)
       ffi (~> 1.0)
     libddwaf (1.11.0.0.0-x86_64-linux)

--- a/gemfiles/ruby_2.7.6_resque2_redis4.gemfile.lock
+++ b/gemfiles/ruby_2.7.6_resque2_redis4.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.14.0)
       debase-ruby_core_source (= 3.2.1)
-      libdatadog (~> 3.0.0.1.0)
+      libdatadog (~> 4.0.0.1.0)
       libddwaf (~> 1.11.0.0.0)
       msgpack
 
@@ -53,8 +53,8 @@ GEM
     json (2.6.3)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (3.0.0.1.0-aarch64-linux)
-    libdatadog (3.0.0.1.0-x86_64-linux)
+    libdatadog (4.0.0.1.0-aarch64-linux)
+    libdatadog (4.0.0.1.0-x86_64-linux)
     libddwaf (1.11.0.0.0-aarch64-linux)
       ffi (~> 1.0)
     libddwaf (1.11.0.0.0-x86_64-linux)

--- a/gemfiles/ruby_2.7.6_sinatra.gemfile.lock
+++ b/gemfiles/ruby_2.7.6_sinatra.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.14.0)
       debase-ruby_core_source (= 3.2.1)
-      libdatadog (~> 3.0.0.1.0)
+      libdatadog (~> 4.0.0.1.0)
       libddwaf (~> 1.11.0.0.0)
       msgpack
 
@@ -53,8 +53,8 @@ GEM
     json (2.6.3)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (3.0.0.1.0-aarch64-linux)
-    libdatadog (3.0.0.1.0-x86_64-linux)
+    libdatadog (4.0.0.1.0-aarch64-linux)
+    libdatadog (4.0.0.1.0-x86_64-linux)
     libddwaf (1.11.0.0.0-aarch64-linux)
       ffi (~> 1.0)
     libddwaf (1.11.0.0.0-x86_64-linux)

--- a/gemfiles/ruby_3.0.4_contrib.gemfile.lock
+++ b/gemfiles/ruby_3.0.4_contrib.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.14.0)
       debase-ruby_core_source (= 3.2.1)
-      libdatadog (~> 3.0.0.1.0)
+      libdatadog (~> 4.0.0.1.0)
       libddwaf (~> 1.11.0.0.0)
       msgpack
 
@@ -1539,8 +1539,8 @@ GEM
       addressable (>= 2.4)
     jsonapi-renderer (0.2.2)
     king_konf (1.0.1)
-    libdatadog (3.0.0.1.0-aarch64-linux)
-    libdatadog (3.0.0.1.0-x86_64-linux)
+    libdatadog (4.0.0.1.0-aarch64-linux)
+    libdatadog (4.0.0.1.0-x86_64-linux)
     libddwaf (1.11.0.0.0-aarch64-linux)
       ffi (~> 1.0)
     libddwaf (1.11.0.0.0-x86_64-linux)

--- a/gemfiles/ruby_3.0.4_contrib_old.gemfile.lock
+++ b/gemfiles/ruby_3.0.4_contrib_old.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.14.0)
       debase-ruby_core_source (= 3.2.1)
-      libdatadog (~> 3.0.0.1.0)
+      libdatadog (~> 4.0.0.1.0)
       libddwaf (~> 1.11.0.0.0)
       msgpack
 
@@ -73,8 +73,8 @@ GEM
     json (2.6.3)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (3.0.0.1.0-aarch64-linux)
-    libdatadog (3.0.0.1.0-x86_64-linux)
+    libdatadog (4.0.0.1.0-aarch64-linux)
+    libdatadog (4.0.0.1.0-x86_64-linux)
     libddwaf (1.11.0.0.0-aarch64-linux)
       ffi (~> 1.0)
     libddwaf (1.11.0.0.0-x86_64-linux)

--- a/gemfiles/ruby_3.0.4_core_old.gemfile.lock
+++ b/gemfiles/ruby_3.0.4_core_old.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.14.0)
       debase-ruby_core_source (= 3.2.1)
-      libdatadog (~> 3.0.0.1.0)
+      libdatadog (~> 4.0.0.1.0)
       libddwaf (~> 1.11.0.0.0)
       msgpack
 
@@ -53,8 +53,8 @@ GEM
     json (2.6.3)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (3.0.0.1.0-aarch64-linux)
-    libdatadog (3.0.0.1.0-x86_64-linux)
+    libdatadog (4.0.0.1.0-aarch64-linux)
+    libdatadog (4.0.0.1.0-x86_64-linux)
     libddwaf (1.11.0.0.0-aarch64-linux)
       ffi (~> 1.0)
     libddwaf (1.11.0.0.0-x86_64-linux)

--- a/gemfiles/ruby_3.0.4_cucumber3.gemfile.lock
+++ b/gemfiles/ruby_3.0.4_cucumber3.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.14.0)
       debase-ruby_core_source (= 3.2.1)
-      libdatadog (~> 3.0.0.1.0)
+      libdatadog (~> 4.0.0.1.0)
       libddwaf (~> 1.11.0.0.0)
       msgpack
 
@@ -71,8 +71,8 @@ GEM
     json (2.6.3)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (3.0.0.1.0-aarch64-linux)
-    libdatadog (3.0.0.1.0-x86_64-linux)
+    libdatadog (4.0.0.1.0-aarch64-linux)
+    libdatadog (4.0.0.1.0-x86_64-linux)
     libddwaf (1.11.0.0.0-aarch64-linux)
       ffi (~> 1.0)
     libddwaf (1.11.0.0.0-x86_64-linux)

--- a/gemfiles/ruby_3.0.4_cucumber4.gemfile.lock
+++ b/gemfiles/ruby_3.0.4_cucumber4.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.14.0)
       debase-ruby_core_source (= 3.2.1)
-      libdatadog (~> 3.0.0.1.0)
+      libdatadog (~> 4.0.0.1.0)
       libddwaf (~> 1.11.0.0.0)
       msgpack
 
@@ -91,8 +91,8 @@ GEM
     json (2.6.3)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (3.0.0.1.0-aarch64-linux)
-    libdatadog (3.0.0.1.0-x86_64-linux)
+    libdatadog (4.0.0.1.0-aarch64-linux)
+    libdatadog (4.0.0.1.0-x86_64-linux)
     libddwaf (1.11.0.0.0-aarch64-linux)
       ffi (~> 1.0)
     libddwaf (1.11.0.0.0-x86_64-linux)

--- a/gemfiles/ruby_3.0.4_cucumber5.gemfile.lock
+++ b/gemfiles/ruby_3.0.4_cucumber5.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.14.0)
       debase-ruby_core_source (= 3.2.1)
-      libdatadog (~> 3.0.0.1.0)
+      libdatadog (~> 4.0.0.1.0)
       libddwaf (~> 1.11.0.0.0)
       msgpack
 
@@ -91,8 +91,8 @@ GEM
     json (2.6.3)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (3.0.0.1.0-aarch64-linux)
-    libdatadog (3.0.0.1.0-x86_64-linux)
+    libdatadog (4.0.0.1.0-aarch64-linux)
+    libdatadog (4.0.0.1.0-x86_64-linux)
     libddwaf (1.11.0.0.0-aarch64-linux)
       ffi (~> 1.0)
     libddwaf (1.11.0.0.0-x86_64-linux)

--- a/gemfiles/ruby_3.0.4_cucumber6.gemfile.lock
+++ b/gemfiles/ruby_3.0.4_cucumber6.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.14.0)
       debase-ruby_core_source (= 3.2.1)
-      libdatadog (~> 3.0.0.1.0)
+      libdatadog (~> 4.0.0.1.0)
       libddwaf (~> 1.11.0.0.0)
       msgpack
 
@@ -91,7 +91,7 @@ GEM
     json (2.6.3)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (3.0.0.1.0-aarch64-linux)
+    libdatadog (4.0.0.1.0-aarch64-linux)
     libddwaf (1.11.0.0.0-aarch64-linux)
       ffi (~> 1.0)
     memory_profiler (0.9.14)

--- a/gemfiles/ruby_3.0.4_cucumber7.gemfile.lock
+++ b/gemfiles/ruby_3.0.4_cucumber7.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.14.0)
       debase-ruby_core_source (= 3.2.1)
-      libdatadog (~> 3.0.0.1.0)
+      libdatadog (~> 4.0.0.1.0)
       libddwaf (~> 1.11.0.0.0)
       msgpack
 
@@ -82,7 +82,7 @@ GEM
     json (2.6.3)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (3.0.0.1.0-aarch64-linux)
+    libdatadog (4.0.0.1.0-aarch64-linux)
     libddwaf (1.11.0.0.0-aarch64-linux)
       ffi (~> 1.0)
     memory_profiler (0.9.14)

--- a/gemfiles/ruby_3.0.4_cucumber8.gemfile.lock
+++ b/gemfiles/ruby_3.0.4_cucumber8.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.14.0)
       debase-ruby_core_source (= 3.2.1)
-      libdatadog (~> 3.0.0.1.0)
+      libdatadog (~> 4.0.0.1.0)
       libddwaf (~> 1.11.0.0.0)
       msgpack
 
@@ -76,7 +76,7 @@ GEM
     json (2.6.3)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (3.0.0.1.0-aarch64-linux)
+    libdatadog (4.0.0.1.0-aarch64-linux)
     libddwaf (1.11.0.0.0-aarch64-linux)
       ffi (~> 1.0)
     memory_profiler (0.9.14)

--- a/gemfiles/ruby_3.0.4_opentelemetry.gemfile.lock
+++ b/gemfiles/ruby_3.0.4_opentelemetry.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.14.0)
       debase-ruby_core_source (= 3.2.1)
-      libdatadog (~> 3.0.0.1.0)
+      libdatadog (~> 4.0.0.1.0)
       libddwaf (~> 1.11.0.0.0)
       msgpack
 
@@ -53,8 +53,8 @@ GEM
     json (2.6.3)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (3.0.0.1.0-aarch64-linux)
-    libdatadog (3.0.0.1.0-x86_64-linux)
+    libdatadog (4.0.0.1.0-aarch64-linux)
+    libdatadog (4.0.0.1.0-x86_64-linux)
     libddwaf (1.11.0.0.0-aarch64-linux)
       ffi (~> 1.0)
     libddwaf (1.11.0.0.0-x86_64-linux)

--- a/gemfiles/ruby_3.0.4_rails61_mysql2.gemfile.lock
+++ b/gemfiles/ruby_3.0.4_rails61_mysql2.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.14.0)
       debase-ruby_core_source (= 3.2.1)
-      libdatadog (~> 3.0.0.1.0)
+      libdatadog (~> 4.0.0.1.0)
       libddwaf (~> 1.11.0.0.0)
       msgpack
 
@@ -119,8 +119,8 @@ GEM
     json (2.6.3)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (3.0.0.1.0-aarch64-linux)
-    libdatadog (3.0.0.1.0-x86_64-linux)
+    libdatadog (4.0.0.1.0-aarch64-linux)
+    libdatadog (4.0.0.1.0-x86_64-linux)
     libddwaf (1.11.0.0.0-aarch64-linux)
       ffi (~> 1.0)
     libddwaf (1.11.0.0.0-x86_64-linux)

--- a/gemfiles/ruby_3.0.4_rails61_postgres.gemfile.lock
+++ b/gemfiles/ruby_3.0.4_rails61_postgres.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.14.0)
       debase-ruby_core_source (= 3.2.1)
-      libdatadog (~> 3.0.0.1.0)
+      libdatadog (~> 4.0.0.1.0)
       libddwaf (~> 1.11.0.0.0)
       msgpack
 
@@ -119,8 +119,8 @@ GEM
     json (2.6.3)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (3.0.0.1.0-aarch64-linux)
-    libdatadog (3.0.0.1.0-x86_64-linux)
+    libdatadog (4.0.0.1.0-aarch64-linux)
+    libdatadog (4.0.0.1.0-x86_64-linux)
     libddwaf (1.11.0.0.0-aarch64-linux)
       ffi (~> 1.0)
     libddwaf (1.11.0.0.0-x86_64-linux)

--- a/gemfiles/ruby_3.0.4_rails61_postgres_redis.gemfile.lock
+++ b/gemfiles/ruby_3.0.4_rails61_postgres_redis.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.14.0)
       debase-ruby_core_source (= 3.2.1)
-      libdatadog (~> 3.0.0.1.0)
+      libdatadog (~> 4.0.0.1.0)
       libddwaf (~> 1.11.0.0.0)
       msgpack
 
@@ -119,8 +119,8 @@ GEM
     json (2.6.3)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (3.0.0.1.0-aarch64-linux)
-    libdatadog (3.0.0.1.0-x86_64-linux)
+    libdatadog (4.0.0.1.0-aarch64-linux)
+    libdatadog (4.0.0.1.0-x86_64-linux)
     libddwaf (1.11.0.0.0-aarch64-linux)
       ffi (~> 1.0)
     libddwaf (1.11.0.0.0-x86_64-linux)

--- a/gemfiles/ruby_3.0.4_rails61_postgres_sidekiq.gemfile.lock
+++ b/gemfiles/ruby_3.0.4_rails61_postgres_sidekiq.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.14.0)
       debase-ruby_core_source (= 3.2.1)
-      libdatadog (~> 3.0.0.1.0)
+      libdatadog (~> 4.0.0.1.0)
       libddwaf (~> 1.11.0.0.0)
       msgpack
 
@@ -120,8 +120,8 @@ GEM
     json (2.6.3)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (3.0.0.1.0-aarch64-linux)
-    libdatadog (3.0.0.1.0-x86_64-linux)
+    libdatadog (4.0.0.1.0-aarch64-linux)
+    libdatadog (4.0.0.1.0-x86_64-linux)
     libddwaf (1.11.0.0.0-aarch64-linux)
       ffi (~> 1.0)
     libddwaf (1.11.0.0.0-x86_64-linux)

--- a/gemfiles/ruby_3.0.4_rails61_semantic_logger.gemfile.lock
+++ b/gemfiles/ruby_3.0.4_rails61_semantic_logger.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.14.0)
       debase-ruby_core_source (= 3.2.1)
-      libdatadog (~> 3.0.0.1.0)
+      libdatadog (~> 4.0.0.1.0)
       libddwaf (~> 1.11.0.0.0)
       msgpack
 
@@ -119,8 +119,8 @@ GEM
     json (2.6.3)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (3.0.0.1.0-aarch64-linux)
-    libdatadog (3.0.0.1.0-x86_64-linux)
+    libdatadog (4.0.0.1.0-aarch64-linux)
+    libdatadog (4.0.0.1.0-x86_64-linux)
     libddwaf (1.11.0.0.0-aarch64-linux)
       ffi (~> 1.0)
     libddwaf (1.11.0.0.0-x86_64-linux)

--- a/gemfiles/ruby_3.0.4_redis_3.gemfile.lock
+++ b/gemfiles/ruby_3.0.4_redis_3.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.14.0)
       debase-ruby_core_source (= 3.2.1)
-      libdatadog (~> 3.0.0.1.0)
+      libdatadog (~> 4.0.0.1.0)
       libddwaf (~> 1.11.0.0.0)
       msgpack
 
@@ -53,8 +53,8 @@ GEM
     json (2.6.3)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (3.0.0.1.0-aarch64-linux)
-    libdatadog (3.0.0.1.0-x86_64-linux)
+    libdatadog (4.0.0.1.0-aarch64-linux)
+    libdatadog (4.0.0.1.0-x86_64-linux)
     libddwaf (1.11.0.0.0-aarch64-linux)
       ffi (~> 1.0)
     libddwaf (1.11.0.0.0-x86_64-linux)

--- a/gemfiles/ruby_3.0.4_redis_4.gemfile.lock
+++ b/gemfiles/ruby_3.0.4_redis_4.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.14.0)
       debase-ruby_core_source (= 3.2.1)
-      libdatadog (~> 3.0.0.1.0)
+      libdatadog (~> 4.0.0.1.0)
       libddwaf (~> 1.11.0.0.0)
       msgpack
 
@@ -53,8 +53,8 @@ GEM
     json (2.6.3)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (3.0.0.1.0-aarch64-linux)
-    libdatadog (3.0.0.1.0-x86_64-linux)
+    libdatadog (4.0.0.1.0-aarch64-linux)
+    libdatadog (4.0.0.1.0-x86_64-linux)
     libddwaf (1.11.0.0.0-aarch64-linux)
       ffi (~> 1.0)
     libddwaf (1.11.0.0.0-x86_64-linux)

--- a/gemfiles/ruby_3.0.4_redis_5.gemfile.lock
+++ b/gemfiles/ruby_3.0.4_redis_5.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.14.0)
       debase-ruby_core_source (= 3.2.1)
-      libdatadog (~> 3.0.0.1.0)
+      libdatadog (~> 4.0.0.1.0)
       libddwaf (~> 1.11.0.0.0)
       msgpack
 
@@ -54,8 +54,8 @@ GEM
     json (2.6.3)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (3.0.0.1.0-aarch64-linux)
-    libdatadog (3.0.0.1.0-x86_64-linux)
+    libdatadog (4.0.0.1.0-aarch64-linux)
+    libdatadog (4.0.0.1.0-x86_64-linux)
     libddwaf (1.11.0.0.0-aarch64-linux)
       ffi (~> 1.0)
     libddwaf (1.11.0.0.0-x86_64-linux)

--- a/gemfiles/ruby_3.0.4_resque2_redis3.gemfile.lock
+++ b/gemfiles/ruby_3.0.4_resque2_redis3.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.14.0)
       debase-ruby_core_source (= 3.2.1)
-      libdatadog (~> 3.0.0.1.0)
+      libdatadog (~> 4.0.0.1.0)
       libddwaf (~> 1.11.0.0.0)
       msgpack
 
@@ -53,8 +53,8 @@ GEM
     json (2.6.3)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (3.0.0.1.0-aarch64-linux)
-    libdatadog (3.0.0.1.0-x86_64-linux)
+    libdatadog (4.0.0.1.0-aarch64-linux)
+    libdatadog (4.0.0.1.0-x86_64-linux)
     libddwaf (1.11.0.0.0-aarch64-linux)
       ffi (~> 1.0)
     libddwaf (1.11.0.0.0-x86_64-linux)

--- a/gemfiles/ruby_3.0.4_resque2_redis4.gemfile.lock
+++ b/gemfiles/ruby_3.0.4_resque2_redis4.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.14.0)
       debase-ruby_core_source (= 3.2.1)
-      libdatadog (~> 3.0.0.1.0)
+      libdatadog (~> 4.0.0.1.0)
       libddwaf (~> 1.11.0.0.0)
       msgpack
 
@@ -54,8 +54,8 @@ GEM
     json (2.6.3)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (3.0.0.1.0-aarch64-linux)
-    libdatadog (3.0.0.1.0-x86_64-linux)
+    libdatadog (4.0.0.1.0-aarch64-linux)
+    libdatadog (4.0.0.1.0-x86_64-linux)
     libddwaf (1.11.0.0.0-aarch64-linux)
       ffi (~> 1.0)
     libddwaf (1.11.0.0.0-x86_64-linux)

--- a/gemfiles/ruby_3.0.4_sinatra.gemfile.lock
+++ b/gemfiles/ruby_3.0.4_sinatra.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.14.0)
       debase-ruby_core_source (= 3.2.1)
-      libdatadog (~> 3.0.0.1.0)
+      libdatadog (~> 4.0.0.1.0)
       libddwaf (~> 1.11.0.0.0)
       msgpack
 
@@ -53,8 +53,8 @@ GEM
     json (2.6.3)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (3.0.0.1.0-aarch64-linux)
-    libdatadog (3.0.0.1.0-x86_64-linux)
+    libdatadog (4.0.0.1.0-aarch64-linux)
+    libdatadog (4.0.0.1.0-x86_64-linux)
     libddwaf (1.11.0.0.0-aarch64-linux)
       ffi (~> 1.0)
     libddwaf (1.11.0.0.0-x86_64-linux)

--- a/gemfiles/ruby_3.1.2_contrib.gemfile.lock
+++ b/gemfiles/ruby_3.1.2_contrib.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.14.0)
       debase-ruby_core_source (= 3.2.1)
-      libdatadog (~> 3.0.0.1.0)
+      libdatadog (~> 4.0.0.1.0)
       libddwaf (~> 1.11.0.0.0)
       msgpack
 
@@ -1539,8 +1539,8 @@ GEM
       addressable (>= 2.4)
     jsonapi-renderer (0.2.2)
     king_konf (1.0.1)
-    libdatadog (3.0.0.1.0-aarch64-linux)
-    libdatadog (3.0.0.1.0-x86_64-linux)
+    libdatadog (4.0.0.1.0-aarch64-linux)
+    libdatadog (4.0.0.1.0-x86_64-linux)
     libddwaf (1.11.0.0.0-aarch64-linux)
       ffi (~> 1.0)
     lograge (0.12.0)

--- a/gemfiles/ruby_3.1.2_contrib_old.gemfile.lock
+++ b/gemfiles/ruby_3.1.2_contrib_old.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.14.0)
       debase-ruby_core_source (= 3.2.1)
-      libdatadog (~> 3.0.0.1.0)
+      libdatadog (~> 4.0.0.1.0)
       libddwaf (~> 1.11.0.0.0)
       msgpack
 
@@ -73,8 +73,8 @@ GEM
     json (2.6.3)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (3.0.0.1.0-aarch64-linux)
-    libdatadog (3.0.0.1.0-x86_64-linux)
+    libdatadog (4.0.0.1.0-aarch64-linux)
+    libdatadog (4.0.0.1.0-x86_64-linux)
     libddwaf (1.11.0.0.0-aarch64-linux)
       ffi (~> 1.0)
     memory_profiler (0.9.14)

--- a/gemfiles/ruby_3.1.2_core_old.gemfile.lock
+++ b/gemfiles/ruby_3.1.2_core_old.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.14.0)
       debase-ruby_core_source (= 3.2.1)
-      libdatadog (~> 3.0.0.1.0)
+      libdatadog (~> 4.0.0.1.0)
       libddwaf (~> 1.11.0.0.0)
       msgpack
 
@@ -53,8 +53,8 @@ GEM
     json (2.6.3)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (3.0.0.1.0-aarch64-linux)
-    libdatadog (3.0.0.1.0-x86_64-linux)
+    libdatadog (4.0.0.1.0-aarch64-linux)
+    libdatadog (4.0.0.1.0-x86_64-linux)
     libddwaf (1.11.0.0.0-aarch64-linux)
       ffi (~> 1.0)
     memory_profiler (0.9.14)

--- a/gemfiles/ruby_3.1.2_cucumber3.gemfile.lock
+++ b/gemfiles/ruby_3.1.2_cucumber3.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.14.0)
       debase-ruby_core_source (= 3.2.1)
-      libdatadog (~> 3.0.0.1.0)
+      libdatadog (~> 4.0.0.1.0)
       libddwaf (~> 1.11.0.0.0)
       msgpack
 
@@ -71,8 +71,8 @@ GEM
     json (2.6.3)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (3.0.0.1.0-aarch64-linux)
-    libdatadog (3.0.0.1.0-x86_64-linux)
+    libdatadog (4.0.0.1.0-aarch64-linux)
+    libdatadog (4.0.0.1.0-x86_64-linux)
     libddwaf (1.11.0.0.0-aarch64-linux)
       ffi (~> 1.0)
     memory_profiler (0.9.14)

--- a/gemfiles/ruby_3.1.2_cucumber4.gemfile.lock
+++ b/gemfiles/ruby_3.1.2_cucumber4.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.14.0)
       debase-ruby_core_source (= 3.2.1)
-      libdatadog (~> 3.0.0.1.0)
+      libdatadog (~> 4.0.0.1.0)
       libddwaf (~> 1.11.0.0.0)
       msgpack
 
@@ -91,8 +91,8 @@ GEM
     json (2.6.3)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (3.0.0.1.0-aarch64-linux)
-    libdatadog (3.0.0.1.0-x86_64-linux)
+    libdatadog (4.0.0.1.0-aarch64-linux)
+    libdatadog (4.0.0.1.0-x86_64-linux)
     libddwaf (1.11.0.0.0-aarch64-linux)
       ffi (~> 1.0)
     memory_profiler (0.9.14)

--- a/gemfiles/ruby_3.1.2_cucumber5.gemfile.lock
+++ b/gemfiles/ruby_3.1.2_cucumber5.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.14.0)
       debase-ruby_core_source (= 3.2.1)
-      libdatadog (~> 3.0.0.1.0)
+      libdatadog (~> 4.0.0.1.0)
       libddwaf (~> 1.11.0.0.0)
       msgpack
 
@@ -91,8 +91,8 @@ GEM
     json (2.6.3)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (3.0.0.1.0-aarch64-linux)
-    libdatadog (3.0.0.1.0-x86_64-linux)
+    libdatadog (4.0.0.1.0-aarch64-linux)
+    libdatadog (4.0.0.1.0-x86_64-linux)
     libddwaf (1.11.0.0.0-aarch64-linux)
       ffi (~> 1.0)
     memory_profiler (0.9.14)

--- a/gemfiles/ruby_3.1.2_cucumber6.gemfile.lock
+++ b/gemfiles/ruby_3.1.2_cucumber6.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.14.0)
       debase-ruby_core_source (= 3.2.1)
-      libdatadog (~> 3.0.0.1.0)
+      libdatadog (~> 4.0.0.1.0)
       libddwaf (~> 1.11.0.0.0)
       msgpack
 
@@ -91,7 +91,7 @@ GEM
     json (2.6.3)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (3.0.0.1.0-aarch64-linux)
+    libdatadog (4.0.0.1.0-aarch64-linux)
     libddwaf (1.11.0.0.0-aarch64-linux)
       ffi (~> 1.0)
     memory_profiler (0.9.14)

--- a/gemfiles/ruby_3.1.2_cucumber7.gemfile.lock
+++ b/gemfiles/ruby_3.1.2_cucumber7.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.14.0)
       debase-ruby_core_source (= 3.2.1)
-      libdatadog (~> 3.0.0.1.0)
+      libdatadog (~> 4.0.0.1.0)
       libddwaf (~> 1.11.0.0.0)
       msgpack
 
@@ -82,7 +82,7 @@ GEM
     json (2.6.3)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (3.0.0.1.0-aarch64-linux)
+    libdatadog (4.0.0.1.0-aarch64-linux)
     libddwaf (1.11.0.0.0-aarch64-linux)
       ffi (~> 1.0)
     memory_profiler (0.9.14)

--- a/gemfiles/ruby_3.1.2_cucumber8.gemfile.lock
+++ b/gemfiles/ruby_3.1.2_cucumber8.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.14.0)
       debase-ruby_core_source (= 3.2.1)
-      libdatadog (~> 3.0.0.1.0)
+      libdatadog (~> 4.0.0.1.0)
       libddwaf (~> 1.11.0.0.0)
       msgpack
 
@@ -76,7 +76,7 @@ GEM
     json (2.6.3)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (3.0.0.1.0-aarch64-linux)
+    libdatadog (4.0.0.1.0-aarch64-linux)
     libddwaf (1.11.0.0.0-aarch64-linux)
       ffi (~> 1.0)
     memory_profiler (0.9.14)

--- a/gemfiles/ruby_3.1.2_opentelemetry.gemfile.lock
+++ b/gemfiles/ruby_3.1.2_opentelemetry.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.14.0)
       debase-ruby_core_source (= 3.2.1)
-      libdatadog (~> 3.0.0.1.0)
+      libdatadog (~> 4.0.0.1.0)
       libddwaf (~> 1.11.0.0.0)
       msgpack
 
@@ -54,9 +54,9 @@ GEM
     json (2.6.3)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (3.0.0.1.0)
-    libdatadog (3.0.0.1.0-aarch64-linux)
-    libdatadog (3.0.0.1.0-x86_64-linux)
+    libdatadog (4.0.0.1.0)
+    libdatadog (4.0.0.1.0-aarch64-linux)
+    libdatadog (4.0.0.1.0-x86_64-linux)
     libddwaf (1.11.0.0.0-aarch64-linux)
       ffi (~> 1.0)
     memory_profiler (0.9.14)

--- a/gemfiles/ruby_3.1.2_rails61_mysql2.gemfile.lock
+++ b/gemfiles/ruby_3.1.2_rails61_mysql2.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.14.0)
       debase-ruby_core_source (= 3.2.1)
-      libdatadog (~> 3.0.0.1.0)
+      libdatadog (~> 4.0.0.1.0)
       libddwaf (~> 1.11.0.0.0)
       msgpack
 
@@ -119,8 +119,8 @@ GEM
     json (2.6.3)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (3.0.0.1.0-aarch64-linux)
-    libdatadog (3.0.0.1.0-x86_64-linux)
+    libdatadog (4.0.0.1.0-aarch64-linux)
+    libdatadog (4.0.0.1.0-x86_64-linux)
     libddwaf (1.11.0.0.0-aarch64-linux)
       ffi (~> 1.0)
     lograge (0.12.0)

--- a/gemfiles/ruby_3.1.2_rails61_postgres.gemfile.lock
+++ b/gemfiles/ruby_3.1.2_rails61_postgres.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.14.0)
       debase-ruby_core_source (= 3.2.1)
-      libdatadog (~> 3.0.0.1.0)
+      libdatadog (~> 4.0.0.1.0)
       libddwaf (~> 1.11.0.0.0)
       msgpack
 
@@ -119,8 +119,8 @@ GEM
     json (2.6.3)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (3.0.0.1.0-aarch64-linux)
-    libdatadog (3.0.0.1.0-x86_64-linux)
+    libdatadog (4.0.0.1.0-aarch64-linux)
+    libdatadog (4.0.0.1.0-x86_64-linux)
     libddwaf (1.11.0.0.0-aarch64-linux)
       ffi (~> 1.0)
     lograge (0.12.0)

--- a/gemfiles/ruby_3.1.2_rails61_postgres_redis.gemfile.lock
+++ b/gemfiles/ruby_3.1.2_rails61_postgres_redis.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.14.0)
       debase-ruby_core_source (= 3.2.1)
-      libdatadog (~> 3.0.0.1.0)
+      libdatadog (~> 4.0.0.1.0)
       libddwaf (~> 1.11.0.0.0)
       msgpack
 
@@ -119,8 +119,8 @@ GEM
     json (2.6.3)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (3.0.0.1.0-aarch64-linux)
-    libdatadog (3.0.0.1.0-x86_64-linux)
+    libdatadog (4.0.0.1.0-aarch64-linux)
+    libdatadog (4.0.0.1.0-x86_64-linux)
     libddwaf (1.11.0.0.0-aarch64-linux)
       ffi (~> 1.0)
     lograge (0.12.0)

--- a/gemfiles/ruby_3.1.2_rails61_postgres_sidekiq.gemfile.lock
+++ b/gemfiles/ruby_3.1.2_rails61_postgres_sidekiq.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.14.0)
       debase-ruby_core_source (= 3.2.1)
-      libdatadog (~> 3.0.0.1.0)
+      libdatadog (~> 4.0.0.1.0)
       libddwaf (~> 1.11.0.0.0)
       msgpack
 
@@ -120,8 +120,8 @@ GEM
     json (2.6.3)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (3.0.0.1.0-aarch64-linux)
-    libdatadog (3.0.0.1.0-x86_64-linux)
+    libdatadog (4.0.0.1.0-aarch64-linux)
+    libdatadog (4.0.0.1.0-x86_64-linux)
     libddwaf (1.11.0.0.0-aarch64-linux)
       ffi (~> 1.0)
     lograge (0.12.0)

--- a/gemfiles/ruby_3.1.2_rails61_semantic_logger.gemfile.lock
+++ b/gemfiles/ruby_3.1.2_rails61_semantic_logger.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.14.0)
       debase-ruby_core_source (= 3.2.1)
-      libdatadog (~> 3.0.0.1.0)
+      libdatadog (~> 4.0.0.1.0)
       libddwaf (~> 1.11.0.0.0)
       msgpack
 
@@ -119,8 +119,8 @@ GEM
     json (2.6.3)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (3.0.0.1.0-aarch64-linux)
-    libdatadog (3.0.0.1.0-x86_64-linux)
+    libdatadog (4.0.0.1.0-aarch64-linux)
+    libdatadog (4.0.0.1.0-x86_64-linux)
     libddwaf (1.11.0.0.0-aarch64-linux)
       ffi (~> 1.0)
     loofah (2.19.1)

--- a/gemfiles/ruby_3.1.2_redis_3.gemfile.lock
+++ b/gemfiles/ruby_3.1.2_redis_3.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.14.0)
       debase-ruby_core_source (= 3.2.1)
-      libdatadog (~> 3.0.0.1.0)
+      libdatadog (~> 4.0.0.1.0)
       libddwaf (~> 1.11.0.0.0)
       msgpack
 
@@ -53,8 +53,8 @@ GEM
     json (2.6.3)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (3.0.0.1.0-aarch64-linux)
-    libdatadog (3.0.0.1.0-x86_64-linux)
+    libdatadog (4.0.0.1.0-aarch64-linux)
+    libdatadog (4.0.0.1.0-x86_64-linux)
     libddwaf (1.11.0.0.0-aarch64-linux)
       ffi (~> 1.0)
     memory_profiler (0.9.14)

--- a/gemfiles/ruby_3.1.2_redis_4.gemfile.lock
+++ b/gemfiles/ruby_3.1.2_redis_4.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.14.0)
       debase-ruby_core_source (= 3.2.1)
-      libdatadog (~> 3.0.0.1.0)
+      libdatadog (~> 4.0.0.1.0)
       libddwaf (~> 1.11.0.0.0)
       msgpack
 
@@ -53,8 +53,8 @@ GEM
     json (2.6.3)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (3.0.0.1.0-aarch64-linux)
-    libdatadog (3.0.0.1.0-x86_64-linux)
+    libdatadog (4.0.0.1.0-aarch64-linux)
+    libdatadog (4.0.0.1.0-x86_64-linux)
     libddwaf (1.11.0.0.0-aarch64-linux)
       ffi (~> 1.0)
     memory_profiler (0.9.14)

--- a/gemfiles/ruby_3.1.2_redis_5.gemfile.lock
+++ b/gemfiles/ruby_3.1.2_redis_5.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.14.0)
       debase-ruby_core_source (= 3.2.1)
-      libdatadog (~> 3.0.0.1.0)
+      libdatadog (~> 4.0.0.1.0)
       libddwaf (~> 1.11.0.0.0)
       msgpack
 
@@ -54,8 +54,8 @@ GEM
     json (2.6.3)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (3.0.0.1.0-aarch64-linux)
-    libdatadog (3.0.0.1.0-x86_64-linux)
+    libdatadog (4.0.0.1.0-aarch64-linux)
+    libdatadog (4.0.0.1.0-x86_64-linux)
     libddwaf (1.11.0.0.0-aarch64-linux)
       ffi (~> 1.0)
     memory_profiler (0.9.14)

--- a/gemfiles/ruby_3.1.2_resque2_redis3.gemfile.lock
+++ b/gemfiles/ruby_3.1.2_resque2_redis3.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.14.0)
       debase-ruby_core_source (= 3.2.1)
-      libdatadog (~> 3.0.0.1.0)
+      libdatadog (~> 4.0.0.1.0)
       libddwaf (~> 1.11.0.0.0)
       msgpack
 
@@ -53,8 +53,8 @@ GEM
     json (2.6.3)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (3.0.0.1.0-aarch64-linux)
-    libdatadog (3.0.0.1.0-x86_64-linux)
+    libdatadog (4.0.0.1.0-aarch64-linux)
+    libdatadog (4.0.0.1.0-x86_64-linux)
     libddwaf (1.11.0.0.0-aarch64-linux)
       ffi (~> 1.0)
     memory_profiler (0.9.14)

--- a/gemfiles/ruby_3.1.2_resque2_redis4.gemfile.lock
+++ b/gemfiles/ruby_3.1.2_resque2_redis4.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.14.0)
       debase-ruby_core_source (= 3.2.1)
-      libdatadog (~> 3.0.0.1.0)
+      libdatadog (~> 4.0.0.1.0)
       libddwaf (~> 1.11.0.0.0)
       msgpack
 
@@ -54,8 +54,8 @@ GEM
     json (2.6.3)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (3.0.0.1.0-aarch64-linux)
-    libdatadog (3.0.0.1.0-x86_64-linux)
+    libdatadog (4.0.0.1.0-aarch64-linux)
+    libdatadog (4.0.0.1.0-x86_64-linux)
     libddwaf (1.11.0.0.0-aarch64-linux)
       ffi (~> 1.0)
     memory_profiler (0.9.14)

--- a/gemfiles/ruby_3.1.2_sinatra.gemfile.lock
+++ b/gemfiles/ruby_3.1.2_sinatra.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.14.0)
       debase-ruby_core_source (= 3.2.1)
-      libdatadog (~> 3.0.0.1.0)
+      libdatadog (~> 4.0.0.1.0)
       libddwaf (~> 1.11.0.0.0)
       msgpack
 
@@ -53,8 +53,8 @@ GEM
     json (2.6.3)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (3.0.0.1.0-aarch64-linux)
-    libdatadog (3.0.0.1.0-x86_64-linux)
+    libdatadog (4.0.0.1.0-aarch64-linux)
+    libdatadog (4.0.0.1.0-x86_64-linux)
     libddwaf (1.11.0.0.0-aarch64-linux)
       ffi (~> 1.0)
     memory_profiler (0.9.14)

--- a/gemfiles/ruby_3.2.0_contrib.gemfile.lock
+++ b/gemfiles/ruby_3.2.0_contrib.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.14.0)
       debase-ruby_core_source (= 3.2.1)
-      libdatadog (~> 3.0.0.1.0)
+      libdatadog (~> 4.0.0.1.0)
       libddwaf (~> 1.11.0.0.0)
       msgpack
 
@@ -1538,8 +1538,8 @@ GEM
       addressable (>= 2.4)
     jsonapi-renderer (0.2.2)
     king_konf (1.0.1)
-    libdatadog (3.0.0.1.0-aarch64-linux)
-    libdatadog (3.0.0.1.0-x86_64-linux)
+    libdatadog (4.0.0.1.0-aarch64-linux)
+    libdatadog (4.0.0.1.0-x86_64-linux)
     libddwaf (1.11.0.0.0-aarch64-linux)
       ffi (~> 1.0)
     libddwaf (1.11.0.0.0-x86_64-linux)

--- a/gemfiles/ruby_3.2.0_contrib_old.gemfile.lock
+++ b/gemfiles/ruby_3.2.0_contrib_old.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.14.0)
       debase-ruby_core_source (= 3.2.1)
-      libdatadog (~> 3.0.0.1.0)
+      libdatadog (~> 4.0.0.1.0)
       libddwaf (~> 1.11.0.0.0)
       msgpack
 
@@ -72,8 +72,8 @@ GEM
     json (2.6.3)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (3.0.0.1.0-aarch64-linux)
-    libdatadog (3.0.0.1.0-x86_64-linux)
+    libdatadog (4.0.0.1.0-aarch64-linux)
+    libdatadog (4.0.0.1.0-x86_64-linux)
     libddwaf (1.11.0.0.0-aarch64-linux)
       ffi (~> 1.0)
     libddwaf (1.11.0.0.0-x86_64-linux)

--- a/gemfiles/ruby_3.2.0_core_old.gemfile.lock
+++ b/gemfiles/ruby_3.2.0_core_old.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.14.0)
       debase-ruby_core_source (= 3.2.1)
-      libdatadog (~> 3.0.0.1.0)
+      libdatadog (~> 4.0.0.1.0)
       libddwaf (~> 1.11.0.0.0)
       msgpack
 
@@ -52,8 +52,8 @@ GEM
     json (2.6.3)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (3.0.0.1.0-aarch64-linux)
-    libdatadog (3.0.0.1.0-x86_64-linux)
+    libdatadog (4.0.0.1.0-aarch64-linux)
+    libdatadog (4.0.0.1.0-x86_64-linux)
     libddwaf (1.11.0.0.0-aarch64-linux)
       ffi (~> 1.0)
     libddwaf (1.11.0.0.0-x86_64-linux)

--- a/gemfiles/ruby_3.2.0_cucumber3.gemfile.lock
+++ b/gemfiles/ruby_3.2.0_cucumber3.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.14.0)
       debase-ruby_core_source (= 3.2.1)
-      libdatadog (~> 3.0.0.1.0)
+      libdatadog (~> 4.0.0.1.0)
       libddwaf (~> 1.11.0.0.0)
       msgpack
 
@@ -70,8 +70,8 @@ GEM
     json (2.6.3)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (3.0.0.1.0-aarch64-linux)
-    libdatadog (3.0.0.1.0-x86_64-linux)
+    libdatadog (4.0.0.1.0-aarch64-linux)
+    libdatadog (4.0.0.1.0-x86_64-linux)
     libddwaf (1.11.0.0.0-aarch64-linux)
       ffi (~> 1.0)
     libddwaf (1.11.0.0.0-x86_64-linux)

--- a/gemfiles/ruby_3.2.0_cucumber4.gemfile.lock
+++ b/gemfiles/ruby_3.2.0_cucumber4.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.14.0)
       debase-ruby_core_source (= 3.2.1)
-      libdatadog (~> 3.0.0.1.0)
+      libdatadog (~> 4.0.0.1.0)
       libddwaf (~> 1.11.0.0.0)
       msgpack
 
@@ -90,8 +90,8 @@ GEM
     json (2.6.3)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (3.0.0.1.0-aarch64-linux)
-    libdatadog (3.0.0.1.0-x86_64-linux)
+    libdatadog (4.0.0.1.0-aarch64-linux)
+    libdatadog (4.0.0.1.0-x86_64-linux)
     libddwaf (1.11.0.0.0-aarch64-linux)
       ffi (~> 1.0)
     libddwaf (1.11.0.0.0-x86_64-linux)

--- a/gemfiles/ruby_3.2.0_cucumber5.gemfile.lock
+++ b/gemfiles/ruby_3.2.0_cucumber5.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.14.0)
       debase-ruby_core_source (= 3.2.1)
-      libdatadog (~> 3.0.0.1.0)
+      libdatadog (~> 4.0.0.1.0)
       libddwaf (~> 1.11.0.0.0)
       msgpack
 
@@ -90,8 +90,8 @@ GEM
     json (2.6.3)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (3.0.0.1.0-aarch64-linux)
-    libdatadog (3.0.0.1.0-x86_64-linux)
+    libdatadog (4.0.0.1.0-aarch64-linux)
+    libdatadog (4.0.0.1.0-x86_64-linux)
     libddwaf (1.11.0.0.0-aarch64-linux)
       ffi (~> 1.0)
     libddwaf (1.11.0.0.0-x86_64-linux)

--- a/gemfiles/ruby_3.2.0_cucumber6.gemfile.lock
+++ b/gemfiles/ruby_3.2.0_cucumber6.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.14.0)
       debase-ruby_core_source (= 3.2.1)
-      libdatadog (~> 3.0.0.1.0)
+      libdatadog (~> 4.0.0.1.0)
       libddwaf (~> 1.11.0.0.0)
       msgpack
 
@@ -90,7 +90,7 @@ GEM
     json (2.6.3)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (3.0.0.1.0-aarch64-linux)
+    libdatadog (4.0.0.1.0-aarch64-linux)
     libddwaf (1.11.0.0.0-aarch64-linux)
       ffi (~> 1.0)
     memory_profiler (0.9.14)

--- a/gemfiles/ruby_3.2.0_cucumber7.gemfile.lock
+++ b/gemfiles/ruby_3.2.0_cucumber7.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.14.0)
       debase-ruby_core_source (= 3.2.1)
-      libdatadog (~> 3.0.0.1.0)
+      libdatadog (~> 4.0.0.1.0)
       libddwaf (~> 1.11.0.0.0)
       msgpack
 
@@ -81,7 +81,7 @@ GEM
     json (2.6.3)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (3.0.0.1.0-aarch64-linux)
+    libdatadog (4.0.0.1.0-aarch64-linux)
     libddwaf (1.11.0.0.0-aarch64-linux)
       ffi (~> 1.0)
     memory_profiler (0.9.14)

--- a/gemfiles/ruby_3.2.0_cucumber8.gemfile.lock
+++ b/gemfiles/ruby_3.2.0_cucumber8.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.14.0)
       debase-ruby_core_source (= 3.2.1)
-      libdatadog (~> 3.0.0.1.0)
+      libdatadog (~> 4.0.0.1.0)
       libddwaf (~> 1.11.0.0.0)
       msgpack
 
@@ -75,7 +75,7 @@ GEM
     json (2.6.3)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (3.0.0.1.0-aarch64-linux)
+    libdatadog (4.0.0.1.0-aarch64-linux)
     libddwaf (1.11.0.0.0-aarch64-linux)
       ffi (~> 1.0)
     memory_profiler (0.9.14)

--- a/gemfiles/ruby_3.2.0_opentelemetry.gemfile.lock
+++ b/gemfiles/ruby_3.2.0_opentelemetry.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.14.0)
       debase-ruby_core_source (= 3.2.1)
-      libdatadog (~> 3.0.0.1.0)
+      libdatadog (~> 4.0.0.1.0)
       libddwaf (~> 1.11.0.0.0)
       msgpack
 
@@ -52,8 +52,8 @@ GEM
     json (2.6.3)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (3.0.0.1.0-aarch64-linux)
-    libdatadog (3.0.0.1.0-x86_64-linux)
+    libdatadog (4.0.0.1.0-aarch64-linux)
+    libdatadog (4.0.0.1.0-x86_64-linux)
     libddwaf (1.11.0.0.0-aarch64-linux)
       ffi (~> 1.0)
     libddwaf (1.11.0.0.0-x86_64-linux)

--- a/gemfiles/ruby_3.2.0_rails61_mysql2.gemfile.lock
+++ b/gemfiles/ruby_3.2.0_rails61_mysql2.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.14.0)
       debase-ruby_core_source (= 3.2.1)
-      libdatadog (~> 3.0.0.1.0)
+      libdatadog (~> 4.0.0.1.0)
       libddwaf (~> 1.11.0.0.0)
       msgpack
 
@@ -118,8 +118,8 @@ GEM
     json (2.6.3)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (3.0.0.1.0-aarch64-linux)
-    libdatadog (3.0.0.1.0-x86_64-linux)
+    libdatadog (4.0.0.1.0-aarch64-linux)
+    libdatadog (4.0.0.1.0-x86_64-linux)
     libddwaf (1.11.0.0.0-aarch64-linux)
       ffi (~> 1.0)
     libddwaf (1.11.0.0.0-x86_64-linux)

--- a/gemfiles/ruby_3.2.0_rails61_postgres.gemfile.lock
+++ b/gemfiles/ruby_3.2.0_rails61_postgres.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.14.0)
       debase-ruby_core_source (= 3.2.1)
-      libdatadog (~> 3.0.0.1.0)
+      libdatadog (~> 4.0.0.1.0)
       libddwaf (~> 1.11.0.0.0)
       msgpack
 
@@ -118,8 +118,8 @@ GEM
     json (2.6.3)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (3.0.0.1.0-aarch64-linux)
-    libdatadog (3.0.0.1.0-x86_64-linux)
+    libdatadog (4.0.0.1.0-aarch64-linux)
+    libdatadog (4.0.0.1.0-x86_64-linux)
     libddwaf (1.11.0.0.0-aarch64-linux)
       ffi (~> 1.0)
     libddwaf (1.11.0.0.0-x86_64-linux)

--- a/gemfiles/ruby_3.2.0_rails61_postgres_redis.gemfile.lock
+++ b/gemfiles/ruby_3.2.0_rails61_postgres_redis.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.14.0)
       debase-ruby_core_source (= 3.2.1)
-      libdatadog (~> 3.0.0.1.0)
+      libdatadog (~> 4.0.0.1.0)
       libddwaf (~> 1.11.0.0.0)
       msgpack
 
@@ -118,8 +118,8 @@ GEM
     json (2.6.3)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (3.0.0.1.0-aarch64-linux)
-    libdatadog (3.0.0.1.0-x86_64-linux)
+    libdatadog (4.0.0.1.0-aarch64-linux)
+    libdatadog (4.0.0.1.0-x86_64-linux)
     libddwaf (1.11.0.0.0-aarch64-linux)
       ffi (~> 1.0)
     libddwaf (1.11.0.0.0-x86_64-linux)

--- a/gemfiles/ruby_3.2.0_rails61_postgres_sidekiq.gemfile.lock
+++ b/gemfiles/ruby_3.2.0_rails61_postgres_sidekiq.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.14.0)
       debase-ruby_core_source (= 3.2.1)
-      libdatadog (~> 3.0.0.1.0)
+      libdatadog (~> 4.0.0.1.0)
       libddwaf (~> 1.11.0.0.0)
       msgpack
 
@@ -119,8 +119,8 @@ GEM
     json (2.6.3)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (3.0.0.1.0-aarch64-linux)
-    libdatadog (3.0.0.1.0-x86_64-linux)
+    libdatadog (4.0.0.1.0-aarch64-linux)
+    libdatadog (4.0.0.1.0-x86_64-linux)
     libddwaf (1.11.0.0.0-aarch64-linux)
       ffi (~> 1.0)
     libddwaf (1.11.0.0.0-x86_64-linux)

--- a/gemfiles/ruby_3.2.0_rails61_semantic_logger.gemfile.lock
+++ b/gemfiles/ruby_3.2.0_rails61_semantic_logger.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.14.0)
       debase-ruby_core_source (= 3.2.1)
-      libdatadog (~> 3.0.0.1.0)
+      libdatadog (~> 4.0.0.1.0)
       libddwaf (~> 1.11.0.0.0)
       msgpack
 
@@ -118,8 +118,8 @@ GEM
     json (2.6.3)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (3.0.0.1.0-aarch64-linux)
-    libdatadog (3.0.0.1.0-x86_64-linux)
+    libdatadog (4.0.0.1.0-aarch64-linux)
+    libdatadog (4.0.0.1.0-x86_64-linux)
     libddwaf (1.11.0.0.0-aarch64-linux)
       ffi (~> 1.0)
     libddwaf (1.11.0.0.0-x86_64-linux)

--- a/gemfiles/ruby_3.2.0_redis_3.gemfile.lock
+++ b/gemfiles/ruby_3.2.0_redis_3.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.14.0)
       debase-ruby_core_source (= 3.2.1)
-      libdatadog (~> 3.0.0.1.0)
+      libdatadog (~> 4.0.0.1.0)
       libddwaf (~> 1.11.0.0.0)
       msgpack
 
@@ -52,8 +52,8 @@ GEM
     json (2.6.3)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (3.0.0.1.0-aarch64-linux)
-    libdatadog (3.0.0.1.0-x86_64-linux)
+    libdatadog (4.0.0.1.0-aarch64-linux)
+    libdatadog (4.0.0.1.0-x86_64-linux)
     libddwaf (1.11.0.0.0-aarch64-linux)
       ffi (~> 1.0)
     libddwaf (1.11.0.0.0-x86_64-linux)

--- a/gemfiles/ruby_3.2.0_redis_4.gemfile.lock
+++ b/gemfiles/ruby_3.2.0_redis_4.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.14.0)
       debase-ruby_core_source (= 3.2.1)
-      libdatadog (~> 3.0.0.1.0)
+      libdatadog (~> 4.0.0.1.0)
       libddwaf (~> 1.11.0.0.0)
       msgpack
 
@@ -52,8 +52,8 @@ GEM
     json (2.6.3)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (3.0.0.1.0-aarch64-linux)
-    libdatadog (3.0.0.1.0-x86_64-linux)
+    libdatadog (4.0.0.1.0-aarch64-linux)
+    libdatadog (4.0.0.1.0-x86_64-linux)
     libddwaf (1.11.0.0.0-aarch64-linux)
       ffi (~> 1.0)
     libddwaf (1.11.0.0.0-x86_64-linux)

--- a/gemfiles/ruby_3.2.0_redis_5.gemfile.lock
+++ b/gemfiles/ruby_3.2.0_redis_5.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.14.0)
       debase-ruby_core_source (= 3.2.1)
-      libdatadog (~> 3.0.0.1.0)
+      libdatadog (~> 4.0.0.1.0)
       libddwaf (~> 1.11.0.0.0)
       msgpack
 
@@ -53,8 +53,8 @@ GEM
     json (2.6.3)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (3.0.0.1.0-aarch64-linux)
-    libdatadog (3.0.0.1.0-x86_64-linux)
+    libdatadog (4.0.0.1.0-aarch64-linux)
+    libdatadog (4.0.0.1.0-x86_64-linux)
     libddwaf (1.11.0.0.0-aarch64-linux)
       ffi (~> 1.0)
     libddwaf (1.11.0.0.0-x86_64-linux)

--- a/gemfiles/ruby_3.2.0_resque2_redis3.gemfile.lock
+++ b/gemfiles/ruby_3.2.0_resque2_redis3.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.14.0)
       debase-ruby_core_source (= 3.2.1)
-      libdatadog (~> 3.0.0.1.0)
+      libdatadog (~> 4.0.0.1.0)
       libddwaf (~> 1.11.0.0.0)
       msgpack
 
@@ -52,8 +52,8 @@ GEM
     json (2.6.3)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (3.0.0.1.0-aarch64-linux)
-    libdatadog (3.0.0.1.0-x86_64-linux)
+    libdatadog (4.0.0.1.0-aarch64-linux)
+    libdatadog (4.0.0.1.0-x86_64-linux)
     libddwaf (1.11.0.0.0-aarch64-linux)
       ffi (~> 1.0)
     libddwaf (1.11.0.0.0-x86_64-linux)

--- a/gemfiles/ruby_3.2.0_resque2_redis4.gemfile.lock
+++ b/gemfiles/ruby_3.2.0_resque2_redis4.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.14.0)
       debase-ruby_core_source (= 3.2.1)
-      libdatadog (~> 3.0.0.1.0)
+      libdatadog (~> 4.0.0.1.0)
       libddwaf (~> 1.11.0.0.0)
       msgpack
 
@@ -53,8 +53,8 @@ GEM
     json (2.6.3)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (3.0.0.1.0-aarch64-linux)
-    libdatadog (3.0.0.1.0-x86_64-linux)
+    libdatadog (4.0.0.1.0-aarch64-linux)
+    libdatadog (4.0.0.1.0-x86_64-linux)
     libddwaf (1.11.0.0.0-aarch64-linux)
       ffi (~> 1.0)
     libddwaf (1.11.0.0.0-x86_64-linux)

--- a/gemfiles/ruby_3.2.0_sinatra.gemfile.lock
+++ b/gemfiles/ruby_3.2.0_sinatra.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.14.0)
       debase-ruby_core_source (= 3.2.1)
-      libdatadog (~> 3.0.0.1.0)
+      libdatadog (~> 4.0.0.1.0)
       libddwaf (~> 1.11.0.0.0)
       msgpack
 
@@ -52,8 +52,8 @@ GEM
     json (2.6.3)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (3.0.0.1.0-aarch64-linux)
-    libdatadog (3.0.0.1.0-x86_64-linux)
+    libdatadog (4.0.0.1.0-aarch64-linux)
+    libdatadog (4.0.0.1.0-x86_64-linux)
     libddwaf (1.11.0.0.0-aarch64-linux)
       ffi (~> 1.0)
     libddwaf (1.11.0.0.0-x86_64-linux)

--- a/gemfiles/ruby_3.3.0_contrib.gemfile.lock
+++ b/gemfiles/ruby_3.3.0_contrib.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.14.0)
       debase-ruby_core_source (= 3.2.1)
-      libdatadog (~> 3.0.0.1.0)
+      libdatadog (~> 4.0.0.1.0)
       libddwaf (~> 1.11.0.0.0)
       msgpack
 
@@ -1546,8 +1546,8 @@ GEM
       addressable (>= 2.4)
     jsonapi-renderer (0.2.2)
     king_konf (1.0.1)
-    libdatadog (3.0.0.1.0-aarch64-linux)
-    libdatadog (3.0.0.1.0-x86_64-linux)
+    libdatadog (4.0.0.1.0-aarch64-linux)
+    libdatadog (4.0.0.1.0-x86_64-linux)
     libddwaf (1.11.0.0.0-aarch64-linux)
       ffi (~> 1.0)
     libddwaf (1.11.0.0.0-x86_64-linux)

--- a/gemfiles/ruby_3.3.0_contrib_old.gemfile.lock
+++ b/gemfiles/ruby_3.3.0_contrib_old.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.14.0)
       debase-ruby_core_source (= 3.2.1)
-      libdatadog (~> 3.0.0.1.0)
+      libdatadog (~> 4.0.0.1.0)
       libddwaf (~> 1.11.0.0.0)
       msgpack
 
@@ -71,8 +71,8 @@ GEM
     json (2.6.3)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (3.0.0.1.0-aarch64-linux)
-    libdatadog (3.0.0.1.0-x86_64-linux)
+    libdatadog (4.0.0.1.0-aarch64-linux)
+    libdatadog (4.0.0.1.0-x86_64-linux)
     libddwaf (1.11.0.0.0-aarch64-linux)
       ffi (~> 1.0)
     libddwaf (1.11.0.0.0-x86_64-linux)

--- a/gemfiles/ruby_3.3.0_core_old.gemfile.lock
+++ b/gemfiles/ruby_3.3.0_core_old.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.14.0)
       debase-ruby_core_source (= 3.2.1)
-      libdatadog (~> 3.0.0.1.0)
+      libdatadog (~> 4.0.0.1.0)
       libddwaf (~> 1.11.0.0.0)
       msgpack
 
@@ -51,8 +51,8 @@ GEM
     json (2.6.3)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (3.0.0.1.0-aarch64-linux)
-    libdatadog (3.0.0.1.0-x86_64-linux)
+    libdatadog (4.0.0.1.0-aarch64-linux)
+    libdatadog (4.0.0.1.0-x86_64-linux)
     libddwaf (1.11.0.0.0-aarch64-linux)
       ffi (~> 1.0)
     libddwaf (1.11.0.0.0-x86_64-linux)

--- a/gemfiles/ruby_3.3.0_cucumber3.gemfile.lock
+++ b/gemfiles/ruby_3.3.0_cucumber3.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.14.0)
       debase-ruby_core_source (= 3.2.1)
-      libdatadog (~> 3.0.0.1.0)
+      libdatadog (~> 4.0.0.1.0)
       libddwaf (~> 1.11.0.0.0)
       msgpack
 
@@ -69,8 +69,8 @@ GEM
     json (2.6.3)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (3.0.0.1.0-aarch64-linux)
-    libdatadog (3.0.0.1.0-x86_64-linux)
+    libdatadog (4.0.0.1.0-aarch64-linux)
+    libdatadog (4.0.0.1.0-x86_64-linux)
     libddwaf (1.11.0.0.0-aarch64-linux)
       ffi (~> 1.0)
     libddwaf (1.11.0.0.0-x86_64-linux)

--- a/gemfiles/ruby_3.3.0_cucumber4.gemfile.lock
+++ b/gemfiles/ruby_3.3.0_cucumber4.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.14.0)
       debase-ruby_core_source (= 3.2.1)
-      libdatadog (~> 3.0.0.1.0)
+      libdatadog (~> 4.0.0.1.0)
       libddwaf (~> 1.11.0.0.0)
       msgpack
 
@@ -90,8 +90,8 @@ GEM
     json (2.6.3)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (3.0.0.1.0-aarch64-linux)
-    libdatadog (3.0.0.1.0-x86_64-linux)
+    libdatadog (4.0.0.1.0-aarch64-linux)
+    libdatadog (4.0.0.1.0-x86_64-linux)
     libddwaf (1.11.0.0.0-aarch64-linux)
       ffi (~> 1.0)
     libddwaf (1.11.0.0.0-x86_64-linux)

--- a/gemfiles/ruby_3.3.0_cucumber5.gemfile.lock
+++ b/gemfiles/ruby_3.3.0_cucumber5.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.14.0)
       debase-ruby_core_source (= 3.2.1)
-      libdatadog (~> 3.0.0.1.0)
+      libdatadog (~> 4.0.0.1.0)
       libddwaf (~> 1.11.0.0.0)
       msgpack
 
@@ -90,8 +90,8 @@ GEM
     json (2.6.3)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (3.0.0.1.0-aarch64-linux)
-    libdatadog (3.0.0.1.0-x86_64-linux)
+    libdatadog (4.0.0.1.0-aarch64-linux)
+    libdatadog (4.0.0.1.0-x86_64-linux)
     libddwaf (1.11.0.0.0-aarch64-linux)
       ffi (~> 1.0)
     libddwaf (1.11.0.0.0-x86_64-linux)

--- a/gemfiles/ruby_3.3.0_cucumber6.gemfile.lock
+++ b/gemfiles/ruby_3.3.0_cucumber6.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.14.0)
       debase-ruby_core_source (= 3.2.1)
-      libdatadog (~> 3.0.0.1.0)
+      libdatadog (~> 4.0.0.1.0)
       libddwaf (~> 1.11.0.0.0)
       msgpack
 
@@ -90,7 +90,7 @@ GEM
     json (2.6.3)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (3.0.0.1.0-aarch64-linux)
+    libdatadog (4.0.0.1.0-aarch64-linux)
     libddwaf (1.11.0.0.0-aarch64-linux)
       ffi (~> 1.0)
     memory_profiler (0.9.14)

--- a/gemfiles/ruby_3.3.0_cucumber7.gemfile.lock
+++ b/gemfiles/ruby_3.3.0_cucumber7.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.14.0)
       debase-ruby_core_source (= 3.2.1)
-      libdatadog (~> 3.0.0.1.0)
+      libdatadog (~> 4.0.0.1.0)
       libddwaf (~> 1.11.0.0.0)
       msgpack
 
@@ -81,7 +81,7 @@ GEM
     json (2.6.3)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (3.0.0.1.0-aarch64-linux)
+    libdatadog (4.0.0.1.0-aarch64-linux)
     libddwaf (1.11.0.0.0-aarch64-linux)
       ffi (~> 1.0)
     memory_profiler (0.9.14)

--- a/gemfiles/ruby_3.3.0_cucumber8.gemfile.lock
+++ b/gemfiles/ruby_3.3.0_cucumber8.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.14.0)
       debase-ruby_core_source (= 3.2.1)
-      libdatadog (~> 3.0.0.1.0)
+      libdatadog (~> 4.0.0.1.0)
       libddwaf (~> 1.11.0.0.0)
       msgpack
 
@@ -75,7 +75,7 @@ GEM
     json (2.6.3)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (3.0.0.1.0-aarch64-linux)
+    libdatadog (4.0.0.1.0-aarch64-linux)
     libddwaf (1.11.0.0.0-aarch64-linux)
       ffi (~> 1.0)
     memory_profiler (0.9.14)

--- a/gemfiles/ruby_3.3.0_opentelemetry.gemfile.lock
+++ b/gemfiles/ruby_3.3.0_opentelemetry.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.14.0)
       debase-ruby_core_source (= 3.2.1)
-      libdatadog (~> 3.0.0.1.0)
+      libdatadog (~> 4.0.0.1.0)
       libddwaf (~> 1.11.0.0.0)
       msgpack
 
@@ -51,8 +51,8 @@ GEM
     json (2.6.3)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (3.0.0.1.0-aarch64-linux)
-    libdatadog (3.0.0.1.0-x86_64-linux)
+    libdatadog (4.0.0.1.0-aarch64-linux)
+    libdatadog (4.0.0.1.0-x86_64-linux)
     libddwaf (1.11.0.0.0-aarch64-linux)
       ffi (~> 1.0)
     libddwaf (1.11.0.0.0-x86_64-linux)

--- a/gemfiles/ruby_3.3.0_rails61_mysql2.gemfile.lock
+++ b/gemfiles/ruby_3.3.0_rails61_mysql2.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.14.0)
       debase-ruby_core_source (= 3.2.1)
-      libdatadog (~> 3.0.0.1.0)
+      libdatadog (~> 4.0.0.1.0)
       libddwaf (~> 1.11.0.0.0)
       msgpack
 
@@ -117,8 +117,8 @@ GEM
     json (2.6.3)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (3.0.0.1.0-aarch64-linux)
-    libdatadog (3.0.0.1.0-x86_64-linux)
+    libdatadog (4.0.0.1.0-aarch64-linux)
+    libdatadog (4.0.0.1.0-x86_64-linux)
     libddwaf (1.11.0.0.0-aarch64-linux)
       ffi (~> 1.0)
     libddwaf (1.11.0.0.0-x86_64-linux)

--- a/gemfiles/ruby_3.3.0_rails61_postgres.gemfile.lock
+++ b/gemfiles/ruby_3.3.0_rails61_postgres.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.14.0)
       debase-ruby_core_source (= 3.2.1)
-      libdatadog (~> 3.0.0.1.0)
+      libdatadog (~> 4.0.0.1.0)
       libddwaf (~> 1.11.0.0.0)
       msgpack
 
@@ -117,8 +117,8 @@ GEM
     json (2.6.3)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (3.0.0.1.0-aarch64-linux)
-    libdatadog (3.0.0.1.0-x86_64-linux)
+    libdatadog (4.0.0.1.0-aarch64-linux)
+    libdatadog (4.0.0.1.0-x86_64-linux)
     libddwaf (1.11.0.0.0-aarch64-linux)
       ffi (~> 1.0)
     libddwaf (1.11.0.0.0-x86_64-linux)

--- a/gemfiles/ruby_3.3.0_rails61_postgres_redis.gemfile.lock
+++ b/gemfiles/ruby_3.3.0_rails61_postgres_redis.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.14.0)
       debase-ruby_core_source (= 3.2.1)
-      libdatadog (~> 3.0.0.1.0)
+      libdatadog (~> 4.0.0.1.0)
       libddwaf (~> 1.11.0.0.0)
       msgpack
 
@@ -117,8 +117,8 @@ GEM
     json (2.6.3)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (3.0.0.1.0-aarch64-linux)
-    libdatadog (3.0.0.1.0-x86_64-linux)
+    libdatadog (4.0.0.1.0-aarch64-linux)
+    libdatadog (4.0.0.1.0-x86_64-linux)
     libddwaf (1.11.0.0.0-aarch64-linux)
       ffi (~> 1.0)
     libddwaf (1.11.0.0.0-x86_64-linux)

--- a/gemfiles/ruby_3.3.0_rails61_postgres_sidekiq.gemfile.lock
+++ b/gemfiles/ruby_3.3.0_rails61_postgres_sidekiq.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.14.0)
       debase-ruby_core_source (= 3.2.1)
-      libdatadog (~> 3.0.0.1.0)
+      libdatadog (~> 4.0.0.1.0)
       libddwaf (~> 1.11.0.0.0)
       msgpack
 
@@ -118,8 +118,8 @@ GEM
     json (2.6.3)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (3.0.0.1.0-aarch64-linux)
-    libdatadog (3.0.0.1.0-x86_64-linux)
+    libdatadog (4.0.0.1.0-aarch64-linux)
+    libdatadog (4.0.0.1.0-x86_64-linux)
     libddwaf (1.11.0.0.0-aarch64-linux)
       ffi (~> 1.0)
     libddwaf (1.11.0.0.0-x86_64-linux)

--- a/gemfiles/ruby_3.3.0_rails61_semantic_logger.gemfile.lock
+++ b/gemfiles/ruby_3.3.0_rails61_semantic_logger.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.14.0)
       debase-ruby_core_source (= 3.2.1)
-      libdatadog (~> 3.0.0.1.0)
+      libdatadog (~> 4.0.0.1.0)
       libddwaf (~> 1.11.0.0.0)
       msgpack
 
@@ -117,8 +117,8 @@ GEM
     json (2.6.3)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (3.0.0.1.0-aarch64-linux)
-    libdatadog (3.0.0.1.0-x86_64-linux)
+    libdatadog (4.0.0.1.0-aarch64-linux)
+    libdatadog (4.0.0.1.0-x86_64-linux)
     libddwaf (1.11.0.0.0-aarch64-linux)
       ffi (~> 1.0)
     libddwaf (1.11.0.0.0-x86_64-linux)

--- a/gemfiles/ruby_3.3.0_redis_3.gemfile.lock
+++ b/gemfiles/ruby_3.3.0_redis_3.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.14.0)
       debase-ruby_core_source (= 3.2.1)
-      libdatadog (~> 3.0.0.1.0)
+      libdatadog (~> 4.0.0.1.0)
       libddwaf (~> 1.11.0.0.0)
       msgpack
 
@@ -51,8 +51,8 @@ GEM
     json (2.6.3)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (3.0.0.1.0-aarch64-linux)
-    libdatadog (3.0.0.1.0-x86_64-linux)
+    libdatadog (4.0.0.1.0-aarch64-linux)
+    libdatadog (4.0.0.1.0-x86_64-linux)
     libddwaf (1.11.0.0.0-aarch64-linux)
       ffi (~> 1.0)
     libddwaf (1.11.0.0.0-x86_64-linux)

--- a/gemfiles/ruby_3.3.0_redis_4.gemfile.lock
+++ b/gemfiles/ruby_3.3.0_redis_4.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.14.0)
       debase-ruby_core_source (= 3.2.1)
-      libdatadog (~> 3.0.0.1.0)
+      libdatadog (~> 4.0.0.1.0)
       libddwaf (~> 1.11.0.0.0)
       msgpack
 
@@ -51,8 +51,8 @@ GEM
     json (2.6.3)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (3.0.0.1.0-aarch64-linux)
-    libdatadog (3.0.0.1.0-x86_64-linux)
+    libdatadog (4.0.0.1.0-aarch64-linux)
+    libdatadog (4.0.0.1.0-x86_64-linux)
     libddwaf (1.11.0.0.0-aarch64-linux)
       ffi (~> 1.0)
     libddwaf (1.11.0.0.0-x86_64-linux)

--- a/gemfiles/ruby_3.3.0_redis_5.gemfile.lock
+++ b/gemfiles/ruby_3.3.0_redis_5.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.14.0)
       debase-ruby_core_source (= 3.2.1)
-      libdatadog (~> 3.0.0.1.0)
+      libdatadog (~> 4.0.0.1.0)
       libddwaf (~> 1.11.0.0.0)
       msgpack
 
@@ -52,8 +52,8 @@ GEM
     json (2.6.3)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (3.0.0.1.0-aarch64-linux)
-    libdatadog (3.0.0.1.0-x86_64-linux)
+    libdatadog (4.0.0.1.0-aarch64-linux)
+    libdatadog (4.0.0.1.0-x86_64-linux)
     libddwaf (1.11.0.0.0-aarch64-linux)
       ffi (~> 1.0)
     libddwaf (1.11.0.0.0-x86_64-linux)

--- a/gemfiles/ruby_3.3.0_resque2_redis3.gemfile.lock
+++ b/gemfiles/ruby_3.3.0_resque2_redis3.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.14.0)
       debase-ruby_core_source (= 3.2.1)
-      libdatadog (~> 3.0.0.1.0)
+      libdatadog (~> 4.0.0.1.0)
       libddwaf (~> 1.11.0.0.0)
       msgpack
 
@@ -51,8 +51,8 @@ GEM
     json (2.6.3)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (3.0.0.1.0-aarch64-linux)
-    libdatadog (3.0.0.1.0-x86_64-linux)
+    libdatadog (4.0.0.1.0-aarch64-linux)
+    libdatadog (4.0.0.1.0-x86_64-linux)
     libddwaf (1.11.0.0.0-aarch64-linux)
       ffi (~> 1.0)
     libddwaf (1.11.0.0.0-x86_64-linux)

--- a/gemfiles/ruby_3.3.0_resque2_redis4.gemfile.lock
+++ b/gemfiles/ruby_3.3.0_resque2_redis4.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.14.0)
       debase-ruby_core_source (= 3.2.1)
-      libdatadog (~> 3.0.0.1.0)
+      libdatadog (~> 4.0.0.1.0)
       libddwaf (~> 1.11.0.0.0)
       msgpack
 
@@ -52,8 +52,8 @@ GEM
     json (2.6.3)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (3.0.0.1.0-aarch64-linux)
-    libdatadog (3.0.0.1.0-x86_64-linux)
+    libdatadog (4.0.0.1.0-aarch64-linux)
+    libdatadog (4.0.0.1.0-x86_64-linux)
     libddwaf (1.11.0.0.0-aarch64-linux)
       ffi (~> 1.0)
     libddwaf (1.11.0.0.0-x86_64-linux)

--- a/gemfiles/ruby_3.3.0_sinatra.gemfile.lock
+++ b/gemfiles/ruby_3.3.0_sinatra.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.14.0)
       debase-ruby_core_source (= 3.2.1)
-      libdatadog (~> 3.0.0.1.0)
+      libdatadog (~> 4.0.0.1.0)
       libddwaf (~> 1.11.0.0.0)
       msgpack
 
@@ -51,8 +51,8 @@ GEM
     json (2.6.3)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (3.0.0.1.0-aarch64-linux)
-    libdatadog (3.0.0.1.0-x86_64-linux)
+    libdatadog (4.0.0.1.0-aarch64-linux)
+    libdatadog (4.0.0.1.0-x86_64-linux)
     libddwaf (1.11.0.0.0-aarch64-linux)
       ffi (~> 1.0)
     libddwaf (1.11.0.0.0-x86_64-linux)


### PR DESCRIPTION
**What does this PR do?**

This PR upgrades dd-trace-rb to use libdatadog 4. This release includes a number of memory footprint improvements, but there were also a few breaking API changes, which needed adjustments in our code.

**Motivation:**

Use the latest libdatadog release.

**Additional Notes:**

✅ Done ~~**I'm opening this PR as a draft until the libdatadog 4 release is up on rubygems.org, but I've already tested it locally.**~~

✅ Done ~~**After libdatadog 4 gets released on rubygems.org, we should update the appraisals and then mark the PR as non-draft**.~~

The backwards incompatible changes were mainly these 3:
* Instead of having a `ddog_prof_Location` be able to include multiple `ddog_prof_Line`s, now a location can only include a single line.

  In our code we already always used 1-line-per-location only, so we only had to adjust to the `ddog_pprof_Line` getting removed.

* The `ddog_prof_Profile_new` now returns a `ddog_prof_Profile`, instead of a pointer; conversely, a bunch of other APIs now want a pointer to a `ddog_prof_Profile` instead of the `ddog_prof_Profile` directly.

* A bunch of APIs started returning `ddog_prof_Profile_Result`.

**How to test the change?**

Our existing test coverage already exercises all of these code paths.

**For Datadog employees:**
- [ ] If this PR touches code that signs or publishes builds or packages, or handles
credentials of any kind, I've requested a review from `@DataDog/security-design-and-guidance`.
- [x] This PR doesn't touch any of that.