### PR TITLE
Fix a bug with ASM span tags reporting the number of WAF failed loaded rules

### DIFF
--- a/.github/workflows/system-tests.yml
+++ b/.github/workflows/system-tests.yml
@@ -172,6 +172,9 @@ jobs:
             scenario: APPSEC_AUTO_EVENTS_EXTENDED
           - library: ruby
             app: rack
+            scenario: APPSEC_RULES_MONITORING_WITH_ERRORS
+          - library: ruby
+            app: rack
             scenario: SAMPLING
           - library: ruby
             app: rack

--- a/lib/datadog/appsec/contrib/rack/request_middleware.rb
+++ b/lib/datadog/appsec/contrib/rack/request_middleware.rb
@@ -148,7 +148,7 @@ module Datadog
                 @oneshot_tags_sent = true
 
                 span.set_tag('_dd.appsec.event_rules.loaded', diagnostics['rules']['loaded'].size.to_f)
-                span.set_tag('_dd.appsec.event_rules.error_count', diagnostics['rules']['loaded'].size.to_f)
+                span.set_tag('_dd.appsec.event_rules.error_count', diagnostics['rules']['failed'].size.to_f)
                 span.set_tag('_dd.appsec.event_rules.errors', JSON.dump(diagnostics['rules']['errors']))
                 span.set_tag('_dd.appsec.event_rules.addresses', JSON.dump(processor.addresses))
 


### PR DESCRIPTION
<!--
Check out the
https://github.com/DataDog/dd-trace-rb/blob/master/docs/DevelopmentGuide.md
for guidance on how to set up your development environment,
run the test suite, write new integrations, and more.
-->

**What does this PR do?**
<!-- A brief description of the change being made with this pull request. -->

Fix a bug introduced on https://github.com/DataDog/dd-trace-rb/pull/3087

Reported the loaded rules count on the `_dd.appsec.event_rules.error_count` tag. 

I also, added a new system test scenario on our GH actions to avoid introducing a regression again.  

**Motivation:**
<!-- What inspired you to submit this pull request? -->

**Additional Notes:**
<!-- Anything else we should know when reviewing? -->

**How to test the change?**
<!--
Describe here how the change can be validated.
You are strongly encouraged to provide automated tests for this PR (unit or integration).
If this change cannot be feasibly tested, please explain why,
unless the change does not modify code (e.g. only modifies docs, comments).
-->

**For Datadog employees:**
- [ ] If this PR touches code that signs or publishes builds or packages, or handles
credentials of any kind, I've requested a review from `@DataDog/security-design-and-guidance`.
- [ ] This PR doesn't touch any of that.

Unsure? Have a question? Request a review!
