### PR TITLE
rename core configuration option on_set to after_set

### DIFF
--- a/lib/datadog/core/configuration/option.rb
+++ b/lib/datadog/core/configuration/option.rb
@@ -264,7 +264,7 @@ module Datadog
             # when restoring a value from `@value_per_precedence`, and we are only running `definition.setter`
             # on the original value, not on a valud that has already been processed by `definition.setter`.
             @value_per_precedence[precedence] = value
-            context_exec(v, old_value, &definition.on_set) if definition.on_set
+            context_exec(v, old_value, &definition.after_set) if definition.after_set
           end
         end
 

--- a/lib/datadog/core/configuration/option_definition.rb
+++ b/lib/datadog/core/configuration/option_definition.rb
@@ -16,7 +16,7 @@ module Datadog
           :deprecated_env,
           :env_parser,
           :name,
-          :on_set,
+          :after_set,
           :resetter,
           :setter,
           :type,
@@ -29,7 +29,7 @@ module Datadog
           @deprecated_env = meta[:deprecated_env]
           @env_parser = meta[:env_parser]
           @name = name.to_sym
-          @on_set = meta[:on_set]
+          @after_set = meta[:after_set]
           @resetter = meta[:resetter]
           @setter = meta[:setter] || block || IDENTITY
           @type = meta[:type]
@@ -57,7 +57,7 @@ module Datadog
             @default_proc = nil
             @helpers = {}
             @name = name.to_sym
-            @on_set = nil
+            @after_set = nil
             @resetter = nil
             @setter = OptionDefinition::IDENTITY
             @type = nil
@@ -105,8 +105,8 @@ module Datadog
             end
           end
 
-          def on_set(&block)
-            @on_set = block
+          def after_set(&block)
+            @after_set = block
           end
 
           def resetter(&block)
@@ -134,7 +134,7 @@ module Datadog
             deprecated_env(options[:deprecated_env]) if options.key?(:deprecated_env)
             env_parser(&options[:env_parser]) if options.key?(:env_parser)
             lazy(options[:lazy]) if options.key?(:lazy)
-            on_set(&options[:on_set]) if options.key?(:on_set)
+            after_set(&options[:after_set]) if options.key?(:after_set)
             resetter(&options[:resetter]) if options.key?(:resetter)
             setter(&options[:setter]) if options.key?(:setter)
             type(options[:type], **(options[:type_options] || {})) if options.key?(:type)
@@ -151,7 +151,7 @@ module Datadog
               env: @env,
               deprecated_env: @deprecated_env,
               env_parser: @env_parser,
-              on_set: @on_set,
+              after_set: @after_set,
               resetter: @resetter,
               setter: @setter,
               type: @type,

--- a/lib/datadog/core/configuration/settings.rb
+++ b/lib/datadog/core/configuration/settings.rb
@@ -103,7 +103,7 @@ module Datadog
             o.env Datadog::Core::Configuration::Ext::Diagnostics::ENV_DEBUG_ENABLED
             o.default false
             o.type :bool
-            o.on_set do |enabled|
+            o.after_set do |enabled|
               # Enable rich debug print statements.
               # We do not need to unnecessarily load 'pp' unless in debugging mode.
               require 'pp' if enabled
@@ -177,7 +177,7 @@ module Datadog
           #
           # @return Logger::Severity
           option :instance do |o|
-            o.on_set { |value| set_option(:level, value.level) unless value.nil? }
+            o.after_set { |value| set_option(:level, value.level) unless value.nil? }
           end
 
           # Log level for `Datadog.logger`.
@@ -215,7 +215,7 @@ module Datadog
             # per second for a 60 second period.
             option :max_events do |o|
               o.default 32768
-              o.on_set do |value|
+              o.after_set do |value|
                 if value != 32768
                   Datadog.logger.warn(
                     'The profiling.advanced.max_events setting has been deprecated for removal. It no longer does ' \
@@ -261,7 +261,7 @@ module Datadog
             # This was added as a temporary support option in case of issues with the new `Profiling::HttpTransport` class
             # but we're now confident it's working nicely so we've removed the old code path.
             option :legacy_transport_enabled do |o|
-              o.on_set do
+              o.after_set do
                 Datadog.logger.warn(
                   'The profiling.advanced.legacy_transport_enabled setting has been deprecated for removal and no ' \
                   'longer does anything. Please remove it from your Datadog.configure block.'
@@ -274,7 +274,7 @@ module Datadog
             # This was used prior to the GA of the new CPU Profiling 2.0 profiler. Using CPU Profiling 2.0 is now the
             # default and this doesn't do anything.
             option :force_enable_new_profiler do |o|
-              o.on_set do
+              o.after_set do
                 Datadog.logger.warn(
                   'The profiling.advanced.force_enable_new_profiler setting has been deprecated for removal and no ' \
                   'longer does anything. Please remove it from your Datadog.configure block.'
@@ -292,7 +292,7 @@ module Datadog
               o.env 'DD_PROFILING_FORCE_ENABLE_LEGACY'
               o.default false
               o.type :bool
-              o.on_set do |value|
+              o.after_set do |value|
                 if value
                   Datadog.logger.warn(
                     'The profiling.advanced.force_enable_legacy_profiler setting has been deprecated for removal. ' \
@@ -530,7 +530,7 @@ module Datadog
           o.default_proc { ::Time.now }
           o.type :proc
 
-          o.on_set do |time_provider|
+          o.after_set do |time_provider|
             Core::Utils::Time.now_provider = time_provider
           end
 

--- a/lib/datadog/tracing/configuration/settings.rb
+++ b/lib/datadog/tracing/configuration/settings.rb
@@ -64,7 +64,7 @@ module Datadog
                       Tracing::Configuration::Ext::Distributed::PROPAGATION_STYLE_B3_SINGLE_HEADER,
                     ]
                   )
-                  o.on_set do |styles|
+                  o.after_set do |styles|
                     # Modernize B3 options
                     # DEV-2.0: Can be removed with the removal of deprecated B3 constants.
                     styles.map! do |style|
@@ -93,7 +93,7 @@ module Datadog
                   o.env Tracing::Configuration::Ext::Distributed::ENV_PROPAGATION_STYLE_INJECT
                   # DEV-2.0: Change default value to `tracecontext, Datadog`.
                   o.default [Tracing::Configuration::Ext::Distributed::PROPAGATION_STYLE_DATADOG]
-                  o.on_set do |styles|
+                  o.after_set do |styles|
                     # Modernize B3 options
                     # DEV-2.0: Can be removed with the removal of deprecated B3 constants.
                     styles.map! do |style|
@@ -121,7 +121,7 @@ module Datadog
                   o.type :array
                   o.env Configuration::Ext::Distributed::ENV_PROPAGATION_STYLE
                   o.default []
-                  o.on_set do |styles|
+                  o.after_set do |styles|
                     next if styles.empty?
 
                     # Modernize B3 options

--- a/lib/datadog/tracing/contrib/action_pack/configuration/settings.rb
+++ b/lib/datadog/tracing/contrib/action_pack/configuration/settings.rb
@@ -30,7 +30,7 @@ module Datadog
 
             # DEV-2.0: Breaking changes for removal.
             option :exception_controller do |o|
-              o.on_set do |value|
+              o.after_set do |value|
                 if value
                   Datadog::Core.log_deprecation do
                     'The error controller is now automatically detected. '\

--- a/lib/datadog/tracing/contrib/rails/configuration/settings.rb
+++ b/lib/datadog/tracing/contrib/rails/configuration/settings.rb
@@ -32,7 +32,7 @@ module Datadog
             option :analytics_enabled do |o|
               o.type :bool, nilable: true
               o.env Ext::ENV_ANALYTICS_ENABLED
-              o.on_set do |value|
+              o.after_set do |value|
                 # Update ActionPack analytics too
                 Datadog.configuration.tracing[:action_pack][:analytics_enabled] = value
               end
@@ -42,7 +42,7 @@ module Datadog
               o.type :float
               o.env Ext::ENV_ANALYTICS_SAMPLE_RATE
               o.default 1.0
-              o.on_set do |value|
+              o.after_set do |value|
                 # Update ActionPack analytics too
                 Datadog.configuration.tracing[:action_pack][:analytics_sample_rate] = value
               end
@@ -55,7 +55,7 @@ module Datadog
             end
             # DEV-2.0: Breaking changes for removal.
             option :exception_controller do |o|
-              o.on_set do |value|
+              o.after_set do |value|
                 if value
                   Datadog::Core.log_deprecation do
                     'The error controller is now automatically detected. '\
@@ -70,7 +70,7 @@ module Datadog
             option :template_base_path do |o|
               o.type :string
               o.default 'views/'
-              o.on_set do |value|
+              o.after_set do |value|
                 # Update ActionView template base path too
                 Datadog.configuration.tracing[:action_view][:template_base_path] = value
               end

--- a/lib/datadog/tracing/contrib/rake/configuration/settings.rb
+++ b/lib/datadog/tracing/contrib/rake/configuration/settings.rb
@@ -41,7 +41,7 @@ module Datadog
             option :tasks do |o|
               o.type :array
               o.default []
-              o.on_set do |value|
+              o.after_set do |value|
                 # DEV: It should be possible to modify the value after it's set. E.g. for normalization.
                 options[:tasks].instance_variable_set(:@value, value.map(&:to_s).to_set)
               end

--- a/lib/datadog/tracing/distributed/propagation.rb
+++ b/lib/datadog/tracing/distributed/propagation.rb
@@ -19,7 +19,7 @@ module Datadog
         def initialize(propagation_styles:)
           @propagation_styles = propagation_styles
           # We need to make sure propagation_style option is evaluated.
-          # Our options are lazy evaluated and it happens that propagation_style has the on_set callback
+          # Our options are lazy evaluated and it happens that propagation_style has the after_set callback
           # that affect Datadog.configuration.tracing.distributed_tracing.propagation_inject_style and
           # Datadog.configuration.tracing.distributed_tracing.propagation_extract_style
           # By calling it here, we make sure if the customers has set any value either via code or ENV variable is applied.

--- a/sig/datadog/core/configuration/option_definition.rbs
+++ b/sig/datadog/core/configuration/option_definition.rbs
@@ -18,7 +18,7 @@ module Datadog
 
         attr_reader name: untyped
 
-        attr_reader on_set: untyped
+        attr_reader after_set: untyped
 
         attr_reader resetter: untyped
 
@@ -49,7 +49,7 @@ module Datadog
 
           def helper: (untyped name, *untyped _args) { () -> untyped } -> untyped
 
-          def on_set: () { (untyped value) -> untyped } -> untyped
+          def after_set: () { (untyped value) -> untyped } -> untyped
 
           def resetter: () { (untyped value) -> untyped } -> untyped
 
@@ -59,7 +59,7 @@ module Datadog
 
           def to_definition: () -> untyped
 
-          def meta: () -> { default: untyped, on_set: untyped, resetter: untyped, setter: untyped }
+          def meta: () -> { default: untyped, after_set: untyped, resetter: untyped, setter: untyped }
         end
       end
     end

--- a/spec/datadog/core/configuration/option_definition_spec.rb
+++ b/spec/datadog/core/configuration/option_definition_spec.rb
@@ -40,14 +40,14 @@ RSpec.describe Datadog::Core::Configuration::OptionDefinition do
     end
   end
 
-  describe '#on_set' do
-    subject(:on_set) { definition.on_set }
+  describe '#after_set' do
+    subject(:after_set) { definition.after_set }
 
     context 'when given a value' do
-      let(:meta) { { on_set: on_set_value } }
-      let(:on_set_value) { double('on_set') }
+      let(:meta) { { after_set: after_set_value } }
+      let(:after_set_value) { double('after_set') }
 
-      it { is_expected.to be on_set_value }
+      it { is_expected.to be after_set_value }
     end
 
     context 'when not initialized' do
@@ -148,7 +148,7 @@ RSpec.describe Datadog::Core::Configuration::OptionDefinition::Builder do
               default: nil,
               default_proc: nil,
               name: name,
-              on_set: nil,
+              after_set: nil,
               resetter: nil,
               setter: Datadog::Core::Configuration::OptionDefinition::IDENTITY,
               type: nil,
@@ -270,8 +270,8 @@ RSpec.describe Datadog::Core::Configuration::OptionDefinition::Builder do
     end
   end
 
-  describe '#on_set' do
-    subject(:on_set) { builder.on_set(&block) }
+  describe '#after_set' do
+    subject(:after_set) { builder.after_set(&block) }
 
     let(:block) { proc {} }
 
@@ -361,12 +361,12 @@ RSpec.describe Datadog::Core::Configuration::OptionDefinition::Builder do
       end
     end
 
-    context 'given :on_set' do
-      let(:options) { { on_set: value } }
+    context 'given :after_set' do
+      let(:options) { { after_set: value } }
       let(:value) { proc {} }
 
       it do
-        expect(builder).to receive(:on_set) do |&block|
+        expect(builder).to receive(:after_set) do |&block|
           expect(block).to be value
         end
 
@@ -424,7 +424,7 @@ RSpec.describe Datadog::Core::Configuration::OptionDefinition::Builder do
       expect(meta.keys).to include(
         :default,
         :default_proc,
-        :on_set,
+        :after_set,
         :resetter,
         :setter,
         :type,

--- a/spec/datadog/core/configuration/option_spec.rb
+++ b/spec/datadog/core/configuration/option_spec.rb
@@ -14,7 +14,7 @@ RSpec.describe Datadog::Core::Configuration::Option do
       env: env,
       deprecated_env: deprecated_env,
       env_parser: env_parser,
-      on_set: nil,
+      after_set: nil,
       resetter: nil,
       setter: setter,
       type: type,
@@ -52,7 +52,7 @@ RSpec.describe Datadog::Core::Configuration::Option do
 
     context 'when no value has been set' do
       before do
-        allow(definition).to receive(:on_set).and_return nil
+        allow(definition).to receive(:after_set).and_return nil
         expect(context).to receive(:instance_exec) do |*args, &block|
           expect(args.first).to be(value)
           expect(block).to be setter
@@ -62,17 +62,17 @@ RSpec.describe Datadog::Core::Configuration::Option do
 
       it { is_expected.to be(setter_value) }
 
-      context 'when an :on_set event is defined' do
-        let(:on_set) { proc { on_set_value } }
-        let(:on_set_value) { double('on_set_value') }
+      context 'when an :after_set event is defined' do
+        let(:after_set) { proc { after_set_value } }
+        let(:after_set_value) { double('after_set_value') }
 
         before do
-          allow(definition).to receive(:on_set).and_return(on_set)
+          allow(definition).to receive(:after_set).and_return(after_set)
 
           expect(context).to receive(:instance_exec) do |*args, &block|
             expect(args.first).to be(setter_value)
-            expect(block).to be on_set
-            on_set.call
+            expect(block).to be after_set
+            after_set.call
           end
         end
 
@@ -89,10 +89,10 @@ RSpec.describe Datadog::Core::Configuration::Option do
     context 'when a value has already been set' do
       let(:old_value) { double('old value') }
 
-      context 'when an :on_set event is not defined' do
+      context 'when an :after_set event is not defined' do
         before do
           allow(context).to receive(:instance_exec)
-          allow(definition).to receive(:on_set).and_return nil
+          allow(definition).to receive(:after_set).and_return nil
 
           # Set original value
           allow(context).to receive(:instance_exec)
@@ -115,12 +115,12 @@ RSpec.describe Datadog::Core::Configuration::Option do
         end
       end
 
-      context 'when an :on_set event is defined' do
-        let(:on_set) { proc { on_set_value } }
-        let(:on_set_value) { double('on_set_value') }
+      context 'when an :after_set event is defined' do
+        let(:after_set) { proc { after_set_value } }
+        let(:after_set_value) { double('after_set_value') }
 
         before do
-          allow(definition).to receive(:on_set).and_return(on_set)
+          allow(definition).to receive(:after_set).and_return(after_set)
 
           allow(context).to receive(:instance_exec) do |*args, &block|
             if args.first == old_value
@@ -130,11 +130,11 @@ RSpec.describe Datadog::Core::Configuration::Option do
               # Invoked first
               expect(args).to include(value, old_value)
               setter.call
-            elsif block == on_set && args.first == setter_value
+            elsif block == after_set && args.first == setter_value
               # Invoked second
               expect(args).to include(setter_value, old_value)
-              expect(block).to be on_set
-              on_set.call
+              expect(block).to be after_set
+              after_set.call
             else
               # Unknown test scenario
               raise ArgumentError


### PR DESCRIPTION
<!--
Check out the
https://github.com/DataDog/dd-trace-rb/blob/master/docs/DevelopmentGuide.md
for guidance on how to set up your development environment,
run the test suite, write new integrations, and more.
-->

**What does this PR do?**
<!-- A brief description of the change being made with this pull request. -->

Rename the configuration `on_set` to `after_set` to better reflect the nature of it. It is a callback executed after the value has been set. 

**Motivation:**
<!-- What inspired you to submit this pull request? -->

**Additional Notes:**
<!-- Anything else we should know when reviewing? -->

**How to test the change?**
<!--
Describe here how the change can be validated.
You are strongly encouraged to provide automated tests for this PR (unit or integration).
If this change cannot be feasibly tested, please explain why,
unless the change does not modify code (e.g. only modifies docs, comments).
-->

**For Datadog employees:**
- [ ] If this PR touches code that signs or publishes builds or packages, or handles
credentials of any kind, I've requested a review from `@DataDog/security-design-and-guidance`.
- [ ] This PR doesn't touch any of that.

Unsure? Have a question? Request a review!
