### PR TITLE
Add description for test task

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -270,6 +270,7 @@ TEST_METADATA = {
 }.freeze
 # rubocop:enable Layout/HashAlignment
 
+desc 'Run test with its coresponding dependencies, example: `bundle exec rake test[spec:redis]`'
 task :test, [:rake_task, :task_args] do |_, args|
   spec_task = args.rake_task
   spec_arguments = args.task_args

--- a/Rakefile
+++ b/Rakefile
@@ -270,7 +270,7 @@ TEST_METADATA = {
 }.freeze
 # rubocop:enable Layout/HashAlignment
 
-desc 'Run test with its coresponding dependencies, example: `bundle exec rake test[spec:redis]`'
+desc "Run test with its coresponding dependencies, example: `bundle exec rake test'[spec:redis]'`"
 task :test, [:rake_task, :task_args] do |_, args|
   spec_task = args.rake_task
   spec_arguments = args.task_args


### PR DESCRIPTION
**What does this PR do?**

When `bundle exec rake -T test`, the information is missing because the rake task does not have a description. So I added a description with example to help people understand how to invoke the task. 

```
dd-trace-rb tonycthsu/add-test-task-description % bundle exec rake -T test
rake spec:minitest              # Run RSpec code examples
rake test[rake_task,task_args]  # Run test with its coresponding dependencies, example: `bundle exec rake test[spec:redis]`
```