### PR TITLE
Fix missing endpoint profiling when request_queuing is enabled in rack instrumentation

### DIFF
--- a/spec/datadog/profiling/collectors/thread_context_spec.rb
+++ b/spec/datadog/profiling/collectors/thread_context_spec.rb
@@ -411,9 +411,7 @@ RSpec.describe Datadog::Profiling::Collectors::ThreadContext do
             expect(t1_sample.labels).to_not include(:'trace endpoint' => anything)
           end
 
-          context 'when local root span type is web' do
-            let(:root_span_type) { 'web' }
-
+          shared_examples_for 'samples with code hotspots information' do
             it 'includes the "trace endpoint" label in the samples' do
               sample
 
@@ -522,6 +520,19 @@ RSpec.describe Datadog::Profiling::Collectors::ThreadContext do
                 end
               end
             end
+          end
+
+          context 'when local root span type is web' do
+            let(:root_span_type) { 'web' }
+
+            it_behaves_like 'samples with code hotspots information'
+          end
+
+          # Used by the rack integration with request_queuing: true
+          context 'when local root span type is proxy' do
+            let(:root_span_type) { 'proxy' }
+
+            it_behaves_like 'samples with code hotspots information'
           end
         end
       end


### PR DESCRIPTION
**What does this PR do?**

This PR tweaks the logic that decides if the profiler should collect the resource from an active trace to also consider the span type `proxy`, which is used when the `request_queuing` feature is in use in the rack instrumentation.

Without this fix, the endpoint profiling feature (e.g. allowing customers to drill into their profiles by endpoint) does not work in combination with `request_queuing`, and the feature is hidden in the profiler UX.

**Motivation:**

Make sure that customers that enable `request_queuing` are still able to look at their profiles per-endpoint.

**Additional Notes:**

N/A

**How to test the change?**

The change includes test coverage. If you're interested in testing it out with a real http app, you can do so by enabling the `request_queuing` feature:

```ruby
Datadog.configure do |c|
  c.tracing.instrument :rack, request_queuing: true
end
```

and then perform a request to the app including the `X-Request-Start` header:

```
$ curl --header "X-Request-Start: t=1693901946000" http://localhost:8080/foo
```

This will generate a `queue` span, and with this change, the endpoint will show up in the right sidebar when looking at profiles for this application. Without this change, it would not show up at all for requests with the `queue` span.

**For Datadog employees:**
- [ ] If this PR touches code that signs or publishes builds or packages, or handles
credentials of any kind, I've requested a review from `@DataDog/security-design-and-guidance`.
- [x] This PR doesn't touch any of that.