### PR TITLE
Use dummy job to know when all the system test are successful 

### DIFF
--- a/.github/workflows/system-tests.yml
+++ b/.github/workflows/system-tests.yml
@@ -111,7 +111,6 @@ jobs:
           docker push ghcr.io/datadog/dd-trace-rb/system-tests/${{ matrix.image }}-${{ matrix.app }}:latest
 
   test:
-    name: System Tests
     strategy:
       fail-fast: false
       matrix:
@@ -196,6 +195,7 @@ jobs:
     needs:
       - build-harness
       - build-apps
+    name: Test (${{ matrix.app }}, ${{ matrix.scenario }})
     steps:
       - name: Setup python 3.9
         uses: actions/setup-python@v4
@@ -216,7 +216,7 @@ jobs:
       - name: List images
         run: |
           docker image list
-      - name: Run scenario ${{ matrix.scenario }}
+      - name: Run scenario
         run: ./build.sh --images runner && ./run.sh ${{ matrix.scenario }}
         env:
           DD_API_KEY: ${{ secrets.DD_APPSEC_SYSTEM_TESTS_API_KEY }}
@@ -232,6 +232,15 @@ jobs:
         with:
           name: system-tests-${{ matrix.library }}-${{ matrix.app }}-logs-gha${{ github.run_id }}-g${{ github.sha }}
           path: logs*
+
+  all_test_successful:
+    name: System tests successful
+    runs-on: ubuntu-latest
+    needs:
+      - test
+    steps:
+      - name: System tests successful
+        run: echo "Done"
 
   aggregate:
     strategy:

--- a/.github/workflows/system-tests.yml
+++ b/.github/workflows/system-tests.yml
@@ -1,4 +1,4 @@
-name: "SystemTests"
+name: System Tests
 
 on:
   push:
@@ -111,6 +111,7 @@ jobs:
           docker push ghcr.io/datadog/dd-trace-rb/system-tests/${{ matrix.image }}-${{ matrix.app }}:latest
 
   test:
+    name: System Tests
     strategy:
       fail-fast: false
       matrix:
@@ -195,7 +196,6 @@ jobs:
     needs:
       - build-harness
       - build-apps
-    name: Test (${{ matrix.app }}, ${{ matrix.scenario }})
     steps:
       - name: Setup python 3.9
         uses: actions/setup-python@v4
@@ -216,7 +216,7 @@ jobs:
       - name: List images
         run: |
           docker image list
-      - name: Run scenario
+      - name: Run scenario ${{ matrix.scenario }}
         run: ./build.sh --images runner && ./run.sh ${{ matrix.scenario }}
         env:
           DD_API_KEY: ${{ secrets.DD_APPSEC_SYSTEM_TESTS_API_KEY }}


### PR DESCRIPTION
<!--
Check out the
https://github.com/DataDog/dd-trace-rb/blob/master/docs/DevelopmentGuide.md
for guidance on how to set up your development environment,
run the test suite, write new integrations, and more.
-->

**What does this PR do?**
<!-- A brief description of the change being made with this pull request. -->

Working on setting branch protection to avoid having broken system tests. My previous attempt did not work https://github.com/DataDog/dd-trace-rb/pull/3110

Having a dummy job works I believe it might be a good solution. We do not have to select all the system test jobs, but rather just this dummy job check that only is successful if the `test` is successful. the `test` would run all the scenarios.

<img width="1107" alt="image" src="https://github.com/DataDog/dd-trace-rb/assets/4672858/f2e9d29d-8e5c-41a5-9e16-5b1dd89581a7">


**Motivation:**
<!-- What inspired you to submit this pull request? -->

**Additional Notes:**
<!-- Anything else we should know when reviewing? -->

**How to test the change?**
<!--
Describe here how the change can be validated.
You are strongly encouraged to provide automated tests for this PR (unit or integration).
If this change cannot be feasibly tested, please explain why,
unless the change does not modify code (e.g. only modifies docs, comments).
-->

**For Datadog employees:**
- [ ] If this PR touches code that signs or publishes builds or packages, or handles
credentials of any kind, I've requested a review from `@DataDog/security-design-and-guidance`.
- [x] This PR doesn't touch any of that.

Unsure? Have a question? Request a review!
