### PR TITLE
Refactor: Simplify `Profiler` instance

### DIFF
--- a/benchmarks/profiler_sample_loop.rb
+++ b/benchmarks/profiler_sample_loop.rb
@@ -28,7 +28,8 @@ class ProfilerSampleLoopBenchmark
     Datadog.shutdown!
 
     # Call collection directly
-    @stack_collector = Datadog.send(:components).profiler.collectors.first
+    # Note -- this is going to be deprecated/removed soon
+    @stack_collector = Datadog.send(:components).profiler.send(:worker)
     @recorder = @stack_collector.recorder
   end
 

--- a/lib/datadog/profiling.rb
+++ b/lib/datadog/profiling.rb
@@ -68,7 +68,8 @@ module Datadog
 
     def self.enabled?
       profiler = Datadog.send(:components).profiler
-      !!(profiler.scheduler.running? if profiler)
+      # Use .send(...) to avoid exposing the attr_reader as an API to the outside
+      !!(profiler.send(:scheduler).running? if profiler)
     end
 
     private_class_method def self.replace_noop_allocation_count

--- a/lib/datadog/profiling/component.rb
+++ b/lib/datadog/profiling/component.rb
@@ -70,6 +70,7 @@ module Datadog
 
         no_signals_workaround_enabled = false
         timeline_enabled = false
+        worker = nil
 
         if enable_new_profiler?(settings)
           no_signals_workaround_enabled = no_signals_workaround_enabled?(settings)
@@ -86,7 +87,7 @@ module Datadog
             endpoint_collection_enabled: settings.profiling.advanced.endpoint.collection.enabled,
             timeline_enabled: timeline_enabled,
           )
-          collector = Datadog::Profiling::Collectors::CpuAndWallTimeWorker.new(
+          worker = Datadog::Profiling::Collectors::CpuAndWallTimeWorker.new(
             gc_profiling_enabled: enable_gc_profiling?(settings),
             allocation_counting_enabled: settings.profiling.advanced.allocation_counting_enabled,
             no_signals_workaround_enabled: no_signals_workaround_enabled,
@@ -97,7 +98,7 @@ module Datadog
           load_pprof_support
 
           recorder = build_profiler_old_recorder(settings)
-          collector = build_profiler_oldstack_collector(settings, recorder, optional_tracer)
+          worker = build_profiler_oldstack_collector(settings, recorder, optional_tracer)
         end
 
         internal_metadata = {
@@ -109,7 +110,7 @@ module Datadog
         transport = build_profiler_transport(settings, agent_settings)
         scheduler = Profiling::Scheduler.new(exporter: exporter, transport: transport)
 
-        Profiling::Profiler.new([collector], scheduler)
+        Profiling::Profiler.new(worker: worker, scheduler: scheduler)
       end
 
       private_class_method def self.build_profiler_old_recorder(settings)

--- a/sig/datadog/profiling/profiler.rbs
+++ b/sig/datadog/profiling/profiler.rbs
@@ -3,13 +3,16 @@ module Datadog
     class Profiler
       include Datadog::Core::Utils::Forking
 
-      attr_reader collectors: Array[untyped]
+      private
 
+      attr_reader worker: untyped # TODO: Change this to CpuAndWallTimeWorker once legacy profiler is retired
       attr_reader scheduler: Datadog::Profiling::Scheduler
 
+      public
+
       def initialize: (
-        [Datadog::Profiling::Collectors::OldStack | Datadog::Profiling::Collectors::CpuAndWallTimeWorker] collectors,
-        Datadog::Profiling::Scheduler scheduler,
+        worker: Datadog::Profiling::Collectors::OldStack | Datadog::Profiling::Collectors::CpuAndWallTimeWorker,
+        scheduler: Datadog::Profiling::Scheduler,
       ) -> void
 
       def start: () -> void

--- a/spec/datadog/profiling/component_spec.rb
+++ b/spec/datadog/profiling/component_spec.rb
@@ -59,8 +59,8 @@ RSpec.describe Datadog::Profiling::Component do
 
         it 'sets up the Profiler with the OldStack collector' do
           expect(Datadog::Profiling::Profiler).to receive(:new).with(
-            [instance_of(Datadog::Profiling::Collectors::OldStack)],
-            anything,
+            worker: instance_of(Datadog::Profiling::Collectors::OldStack),
+            scheduler: anything,
           )
 
           build_profiler_component
@@ -244,8 +244,8 @@ RSpec.describe Datadog::Profiling::Component do
 
         it 'sets up the Profiler with the CpuAndWallTimeWorker collector' do
           expect(Datadog::Profiling::Profiler).to receive(:new).with(
-            [instance_of(Datadog::Profiling::Collectors::CpuAndWallTimeWorker)],
-            anything,
+            worker: instance_of(Datadog::Profiling::Collectors::CpuAndWallTimeWorker),
+            scheduler: anything,
           )
 
           build_profiler_component

--- a/spec/datadog/profiling/profiler_spec.rb
+++ b/spec/datadog/profiling/profiler_spec.rb
@@ -1,33 +1,21 @@
 require 'spec_helper'
 require 'datadog/profiling/spec_helper'
 
-require 'datadog/profiling'
 require 'datadog/profiling/profiler'
-require 'datadog/profiling/collectors/old_stack'
-require 'datadog/profiling/scheduler'
 
 RSpec.describe Datadog::Profiling::Profiler do
   before { skip_if_profiling_not_supported(self) }
 
-  subject(:profiler) { described_class.new(collectors, scheduler) }
+  subject(:profiler) { described_class.new(worker: worker, scheduler: scheduler) }
 
-  let(:collectors) { Array.new(2) { instance_double(Datadog::Profiling::Collectors::OldStack) } }
+  let(:worker) { instance_double(Datadog::Profiling::Collectors::CpuAndWallTimeWorker) }
   let(:scheduler) { instance_double(Datadog::Profiling::Scheduler) }
-
-  describe '::new' do
-    it do
-      is_expected.to have_attributes(
-        collectors: collectors,
-        scheduler: scheduler
-      )
-    end
-  end
 
   describe '#start' do
     subject(:start) { profiler.start }
 
     it 'signals collectors and scheduler to start' do
-      expect(collectors).to all(receive(:start))
+      expect(worker).to receive(:start)
       expect(scheduler).to receive(:start)
 
       start
@@ -36,14 +24,14 @@ RSpec.describe Datadog::Profiling::Profiler do
     context 'when called after a fork' do
       before { skip('Spec requires Ruby VM supporting fork') unless PlatformHelpers.supports_fork? }
 
-      it 'resets the collectors and the scheduler before starting them' do
+      it 'resets the worker and the scheduler before starting them' do
         profiler # make sure instance is created in parent, so it detects the forking
 
         expect_in_fork do
-          expect(collectors).to all(receive(:reset_after_fork).ordered)
+          expect(worker).to receive(:reset_after_fork).ordered
           expect(scheduler).to receive(:reset_after_fork).ordered
 
-          expect(collectors).to all(receive(:start).ordered)
+          expect(worker).to receive(:start).ordered
           expect(scheduler).to receive(:start).ordered
 
           start
@@ -55,9 +43,9 @@ RSpec.describe Datadog::Profiling::Profiler do
   describe '#shutdown!' do
     subject(:shutdown!) { profiler.shutdown! }
 
-    it 'signals collectors and scheduler to disable and stop' do
-      expect(collectors).to all(receive(:enabled=).with(false))
-      expect(collectors).to all(receive(:stop).with(true))
+    it 'signals worker and scheduler to disable and stop' do
+      expect(worker).to receive(:enabled=).with(false)
+      expect(worker).to receive(:stop).with(true)
 
       expect(scheduler).to receive(:enabled=).with(false)
       expect(scheduler).to receive(:stop).with(true)


### PR DESCRIPTION
**What does this PR do?**

This PR simplifies the `Profiler` class to receive only a single `worker`, instead of a `collectors` array.

**Motivation:**

The `collectors` array was added a long time ago when we expected that we may add more `collectors` in the future.

We never ended up making use of this extra flexibility, so I've decided to simplify the code to remove this feature.

**Additional Notes:**

N/A

**How to test the change?**

This change includes code coverage. Since this is the core of starting the profiler, it's pretty visible when it doesn't work ;)


**For Datadog employees:**
- [ ] If this PR touches code that signs or publishes builds or packages, or handles
credentials of any kind, I've requested a review from `@DataDog/security-design-and-guidance`.
- [x] This PR doesn't touch any of that.