### PR TITLE
Fix test runner for jruby

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -291,7 +291,11 @@ namespace :test do
       spec_arguments = args.task_args
 
       candidates = spec_metadata.select do |_, rubies|
-        (RUBY_PLATFORM == 'java' && rubies.include?('✅ jruby')) || rubies.include?("✅ #{ruby_version}")
+        if RUBY_PLATFORM == 'java'
+          rubies.include?("✅ #{ruby_version}") && rubies.include?('✅ jruby')
+        else
+          rubies.include?("✅ #{ruby_version}")
+        end
       end
 
       candidates.each do |appraisal_group, _|


### PR DESCRIPTION
**What does this PR do?**

This mistake is introduce from https://github.com/DataDog/dd-trace-rb/pull/3111

Which JRuby runner only checks for `.include?('✅ jruby')` , it should check for ruby version as well

This could be reproduce with `bundle exec rake test:cucumber` in a Jruby container