### PR TITLE
Use alpine base for lib-injection image

### DIFF
--- a/lib-injection/Dockerfile
+++ b/lib-injection/Dockerfile
@@ -1,6 +1,6 @@
 # This image provides the files needed to install the dd-trace-rb
 # and auto instrument Ruby applications in containerized environments.
-FROM busybox
+FROM alpine:3.18.3
 
 # Set high UID to prevent possible conflict with existing users: http://www.linfo.org/uid.html
 ARG UID=10000


### PR DESCRIPTION
**What does this PR do?**

Change the base library injection image from `busybox` to `alpine` to make the image more compatible with other software environments.

**Motivation:**

`libdl.so.2: cannot open shared object file: No such file or directory` errors have been reported in customer environments which prevents application containers from starting up when using [library injection](https://docs.datadoghq.com/tracing/trace_collection/library_injection_local/?tab=kubernetes#step-3---tag-your-pods-with-unified-service-tags). Likely this is due to some other software such as instrumentation or security that modifies the command run in the container. The modified command fails as the `libdl.so.2` shared library isn't present in the `busybox`-based image.

The `busybox` image [lacks many standard C libraries](https://github.com/docker-library/busybox/issues/46). `alpine` is a similarly sized image which does provide the standard C libraries and mitigates the issue.

**Additional Notes:**

There is little risk in changing the base image to `alpine` as the only command required is to copy files from the image to a volume. However, it is possible that the command that is being added to the container is not compatible with alpine images.


**How to test the change?**

The existing tests should cover the change. We are continuing to investigate the customer environments that are resulting in the issue in order to reproduce the issue exactly.

**For Datadog employees:**
- [ ] If this PR touches code that signs or publishes builds or packages, or handles
credentials of any kind, I've requested a review from `@DataDog/security-design-and-guidance`.
- [x] This PR doesn't touch any of that.

