### PR TITLE
report tested integrations and tested version ranges to APM analytics

### DIFF
--- a/.github/scripts/report-tested-integration-versions.rb
+++ b/.github/scripts/report-tested-integration-versions.rb
@@ -42,7 +42,7 @@ payload = {
     "type" => "supported_integrations",
     "id" => "1",
     "attributes" => {
-      "language_language" => "ruby",
+      "language_name" => "ruby",
       "tracer_version" => "add-version-here",
       "integrations" => []
     }

--- a/.github/scripts/report-tested-integration-versions.rb
+++ b/.github/scripts/report-tested-integration-versions.rb
@@ -1,8 +1,6 @@
 require 'bundler'
 require 'set'
 
-URL = 
-
 def parse_ddtrace_gemfiles(integrated_gems)
     # Find latest CRuby version
     cruby_paths = Dir['gemfiles/ruby_*.lock']

--- a/.github/scripts/report-tested-integration-versions.rb
+++ b/.github/scripts/report-tested-integration-versions.rb
@@ -1,9 +1,6 @@
 require 'bundler'
 require 'set'
 
-require 'datadog/core/environment/ext'
-
-
 def parse_ddtrace_gemfiles(integrated_gems)
     # Find latest CRuby version
     cruby_paths = Dir['gemfiles/ruby_*.lock']
@@ -32,7 +29,7 @@ def parse_ddtrace_gemfiles(integrated_gems)
       end
     end
 
-    gems.transform_values!(&:to_s)
+    gems
 end
 
 ddtrace_specs = `grep -Rho 'Gem.loaded_specs.*' lib/datadog/tracing/contrib/`
@@ -45,20 +42,23 @@ payload = {
     "id" => "1",
     "attributes" => {
       "language_language" => "ruby",
-      "tracer_version" => Datadog::Core::Environment::Ext::TRACER_VERSION,
+      "tracer_version" => "add-version-here",
       "integrations" => []
     }
   }
 }
 tested_integrations = parse_ddtrace_gemfiles(integrated_gems)
 integrated_gems.each do |integration|
-    puts integration + " " + tested_integrations[integration]
+    puts integration + " " + tested_integrations[integration].to_s
     
-    for v in tested_integrations[integration] do
-      payload["attributes"]["integrations"].append({
+    tested_integrations[integration].each do |v|
+      payload["data"]["attributes"]["integrations"].append({
         "integration_name" => integration,
         "integration_version" => v,
         "dependency_name" => integration
       })
     end
 end
+
+# send API call to endpoint
+puts payload

--- a/.github/scripts/report-tested-integration-versions.rb
+++ b/.github/scripts/report-tested-integration-versions.rb
@@ -1,6 +1,8 @@
 require 'bundler'
 require 'set'
 
+URL = 
+
 def parse_ddtrace_gemfiles(integrated_gems)
     # Find latest CRuby version
     cruby_paths = Dir['gemfiles/ruby_*.lock']
@@ -62,3 +64,4 @@ end
 
 # send API call to endpoint
 puts payload
+payload

--- a/.github/scripts/report-tested-integration-versions.rb
+++ b/.github/scripts/report-tested-integration-versions.rb
@@ -49,7 +49,7 @@ payload = {
 }
 tested_integrations = parse_ddtrace_gemfiles(integrated_gems)
 integrated_gems.each do |integration|
-    puts integration + " " + tested_integrations[integration].to_s
+    # puts integration + " " + tested_integrations[integration].to_s
     
     tested_integrations[integration].each do |v|
       payload["data"]["attributes"]["integrations"].append({

--- a/.github/scripts/report-tested-integration-versions.rb
+++ b/.github/scripts/report-tested-integration-versions.rb
@@ -1,0 +1,56 @@
+require 'bundler'
+require 'set'
+
+
+def parse_ddtrace_gemfiles(integrated_gems)
+    # Find latest CRuby version
+    cruby_paths = Dir['gemfiles/ruby_*.lock']
+
+    # Group gemfiles by CRuby version, with latest CRuby version first
+    gemfiles = cruby_paths.map { |p| [Gem::Version.new(p.match(/ruby_([^_]+)/)[1]), p] }
+                          .sort_by { |p| p.first }.reverse
+                          .chunk_while { |v1, v2| v1.first == v2.first }.map { |v| v.map(&:last) }
+
+    # Get all gem versions in the gemlock files
+    gems = {}
+    gemfiles.each do |files|
+      files.each do |file|
+
+        parser = Bundler::LockfileParser.new(File.read(file))
+        specs = parser.specs
+        specs.each do |spec|
+        #   if (version = gems[spec.name]).nil? || version < spec.version
+        #     gems[spec.name] = spec.version
+        #   end
+            (gems[spec.name] ||= Set[]).add(spec.version.to_s)
+        end
+      end
+
+      if (gems.keys & integrated_gems).size == integrated_gems.size
+        # If we didn't find all integrated gems, we should keep searching in older
+        # Ruby versions. Otherwise we can stop here.
+        break
+      end
+    end
+
+    gems.transform_values!(&:to_s)
+end
+
+ddtrace_specs = `grep -Rho 'Gem.loaded_specs.*' lib/datadog/tracing/contrib/`
+
+integrated_gems = ddtrace_specs.split.map { |m| m.match(/Gem.loaded_specs\[.([^\]]+).\]/)&.[](1) }.uniq.compact
+
+tested_integrations = parse_ddtrace_gemfiles(integrated_gems)
+integrated_gems.each do |integration|
+    puts integration + " " + tested_integrations[integration]
+    # for v in tested_integrations[integration] do
+    #     # make http post to telemetry
+    #     data = {
+    #         "tracer_version": nil,
+    #         "tracer_language": "ruby",
+    #         "integration_name": integration,
+    #         "integration_version": v
+    #     }
+    #     puts data
+    # end
+end

--- a/.github/scripts/report-tested-integration-versions.rb
+++ b/.github/scripts/report-tested-integration-versions.rb
@@ -37,13 +37,17 @@ ddtrace_specs = `grep -Rho 'Gem.loaded_specs.*' lib/datadog/tracing/contrib/`
 
 integrated_gems = ddtrace_specs.split.map { |m| m.match(/Gem.loaded_specs\[.([^\]]+).\]/)&.[](1) }.uniq.compact
 
+lib = File.expand_path('../../lib', __dir__)
+$LOAD_PATH.unshift(lib) unless $LOAD_PATH.include?(lib)
+require 'ddtrace/version'
+
 payload = {
   "data" => {
     "type" => "supported_integrations",
     "id" => "1",
     "attributes" => {
       "language_name" => "ruby",
-      "tracer_version" => "add-version-here",
+      "tracer_version" => DDTrace::VERSION::STRING,
       "integrations" => []
     }
   }

--- a/.github/scripts/report-tested-integration-versions.rb
+++ b/.github/scripts/report-tested-integration-versions.rb
@@ -1,4 +1,5 @@
 require 'bundler'
+require 'json'
 require 'set'
 
 def parse_ddtrace_gemfiles(integrated_gems)
@@ -61,5 +62,5 @@ integrated_gems.each do |integration|
 end
 
 # send API call to endpoint
-puts payload
-payload
+puts JSON.generate(payload)
+JSON.generate(payload)

--- a/.github/scripts/report-tested-integration-versions.rb
+++ b/.github/scripts/report-tested-integration-versions.rb
@@ -40,13 +40,13 @@ ddtrace_specs = `grep -Rho 'Gem.loaded_specs.*' lib/datadog/tracing/contrib/`
 integrated_gems = ddtrace_specs.split.map { |m| m.match(/Gem.loaded_specs\[.([^\]]+).\]/)&.[](1) }.uniq.compact
 
 payload = {
-  "data": {
-    "type" : "supported_integrations",
-    "id" : "1",
-    "attributes":{
-      "language_language": "ruby",
-      "tracer_version": Datadog::Core::Environment::Ext::TRACER_VERSION,
-      "integrations": []
+  "data" => {
+    "type" => "supported_integrations",
+    "id" => "1",
+    "attributes" => {
+      "language_language" => "ruby",
+      "tracer_version" => Datadog::Core::Environment::Ext::TRACER_VERSION,
+      "integrations" => []
     }
   }
 }
@@ -56,9 +56,9 @@ integrated_gems.each do |integration|
     
     for v in tested_integrations[integration] do
       payload["attributes"]["integrations"].append({
-        "integration_name": integration,
-        "integration_version": v,
-        "dependency_name": integration
+        "integration_name" => integration,
+        "integration_version" => v,
+        "dependency_name" => integration
       })
     end
 end

--- a/.github/workflows/report-tested-integration-versions.yml
+++ b/.github/workflows/report-tested-integration-versions.yml
@@ -1,0 +1,20 @@
+
+name: "Report dd-trace-rb tested integration versions to telemetry"
+on:
+  push:
+    # tags:
+    #   - 'v*.*.*'
+    branches:
+      - "**"
+
+jobs:
+  report-integration-telemetry:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: ruby/setup-ruby@v1
+        with:
+          ruby-version: '3.2'
+      - name: Report Ruby Tested Integration Versions to APM Analytics
+        run: ruby .github/scripts/report-tested-integration-versions.rb
+      


### PR DESCRIPTION
This PR adds a CI task that parses the gemfile to find what integrations we support and the range of versions that we test for each integration. This data will be emitted to APM analytics who will be creating dashboards for each tracer

**For Datadog employees:**
- [ ] If this PR touches code that signs or publishes builds or packages, or handles
credentials of any kind, I've requested a review from `@DataDog/security-design-and-guidance`.
- [ ] This PR doesn't touch any of that.

Unsure? Have a question? Request a review!
