### PR TITLE
Action:Fix semgrep truncated rule name

### DIFF
--- a/.github/workflows/semgrep.yml
+++ b/.github/workflows/semgrep.yml
@@ -22,6 +22,6 @@ jobs:
       - run: |
           semgrep ci \
           --include=bin/* --include=ext/* --include=lib/* \
-          --exclude-rule=ruby.lang.security.model-attributes-attr-accessible.model-attributes-attr
+          --exclude-rule=ruby.lang.security.model-attributes-attr-accessible.model-attributes-attr-accessible
         env:
           SEMGREP_RULES: p/default


### PR DESCRIPTION
<!--
Check out the
https://github.com/DataDog/dd-trace-rb/blob/master/docs/DevelopmentGuide.md
for guidance on how to set up your development environment,
run the test suite, write new integrations, and more.
-->

**What does this PR do?**
<!-- A brief description of the change being made with this pull request. -->

Fixes the excluded rule name.

**Motivation:**
<!-- What inspired you to submit this pull request? -->

I miscopied a truncated rule name from a shell `semgrep` run: it was missing the lats part.

**Additional Notes:**
<!-- Anything else we should know when reviewing? -->

Master Semgrep CI action is correctly failing because of this: https://github.com/DataDog/dd-trace-rb/actions/runs/6177220252

**How to test the change?**
<!--
Describe here how the change can be validated.
You are strongly encouraged to provide automated tests for this PR (unit or integration).
If this change cannot be feasibly tested, please explain why,
unless the change does not modify code (e.g. only modifies docs, comments).
-->

**For Datadog employees:**
- [ ] If this PR touches code that signs or publishes builds or packages, or handles
credentials of any kind, I've requested a review from `@DataDog/security-design-and-guidance`.
- [ ] This PR doesn't touch any of that.

Unsure? Have a question? Request a review!
