### PR TITLE
[APPSEC-10967] ASM API security. Schema extraction

### DIFF
--- a/ddtrace.gemspec
+++ b/ddtrace.gemspec
@@ -62,7 +62,7 @@ Gem::Specification.new do |spec|
   spec.add_dependency 'debase-ruby_core_source', '= 3.2.1'
 
   # Used by appsec
-  spec.add_dependency 'libddwaf', '~> 1.11.0.0.0'
+  spec.add_dependency 'libddwaf', '~> 1.14.0.0.0'
 
   # Used by profiling (and possibly others in the future)
   # When updating the version here, please also update the version in `native_extension_helpers.rb` (and yes we have a test for it)

--- a/gemfiles/jruby_9.2.21.0_aws.gemfile.lock
+++ b/gemfiles/jruby_9.2.21.0_aws.gemfile.lock
@@ -15,7 +15,7 @@ PATH
       datadog-ci (~> 0.1.0)
       debase-ruby_core_source (= 3.2.1)
       libdatadog (~> 4.0.0.1.0)
-      libddwaf (~> 1.11.0.0.0)
+      libddwaf (~> 1.14.0.0.0)
       msgpack
 
 GEM
@@ -1469,7 +1469,7 @@ GEM
     json-schema (2.8.1)
       addressable (>= 2.4)
     libdatadog (4.0.0.1.0)
-    libddwaf (1.11.0.0.0-java)
+    libddwaf (1.14.0.0.0-java)
       ffi (~> 1.0)
     memory_profiler (0.9.14)
     method_source (1.0.0)

--- a/gemfiles/jruby_9.2.21.0_contrib.gemfile.lock
+++ b/gemfiles/jruby_9.2.21.0_contrib.gemfile.lock
@@ -15,7 +15,7 @@ PATH
       datadog-ci (~> 0.1.0)
       debase-ruby_core_source (= 3.2.1)
       libdatadog (~> 4.0.0.1.0)
-      libddwaf (~> 1.11.0.0.0)
+      libddwaf (~> 1.14.0.0.0)
       msgpack
 
 GEM
@@ -115,7 +115,7 @@ GEM
     jsonapi-renderer (0.2.2)
     king_konf (1.0.1)
     libdatadog (4.0.0.1.0)
-    libddwaf (1.11.0.0.0-java)
+    libddwaf (1.14.0.0.0-java)
       ffi (~> 1.0)
     lograge (0.13.0)
       actionpack (>= 4)

--- a/gemfiles/jruby_9.2.21.0_contrib_old.gemfile.lock
+++ b/gemfiles/jruby_9.2.21.0_contrib_old.gemfile.lock
@@ -15,7 +15,7 @@ PATH
       datadog-ci (~> 0.1.0)
       debase-ruby_core_source (= 3.2.1)
       libdatadog (~> 4.0.0.1.0)
-      libddwaf (~> 1.11.0.0.0)
+      libddwaf (~> 1.14.0.0.0)
       msgpack
 
 GEM
@@ -61,7 +61,7 @@ GEM
     json-schema (2.8.1)
       addressable (>= 2.4)
     libdatadog (4.0.0.1.0)
-    libddwaf (1.11.0.0.0-java)
+    libddwaf (1.14.0.0.0-java)
       ffi (~> 1.0)
     memory_profiler (0.9.14)
     method_source (1.0.0)

--- a/gemfiles/jruby_9.2.21.0_core_old.gemfile.lock
+++ b/gemfiles/jruby_9.2.21.0_core_old.gemfile.lock
@@ -15,7 +15,7 @@ PATH
       datadog-ci (~> 0.1.0)
       debase-ruby_core_source (= 3.2.1)
       libdatadog (~> 4.0.0.1.0)
-      libddwaf (~> 1.11.0.0.0)
+      libddwaf (~> 1.14.0.0.0)
       msgpack
 
 GEM
@@ -47,7 +47,7 @@ GEM
     json-schema (2.8.1)
       addressable (>= 2.4)
     libdatadog (4.0.0.1.0)
-    libddwaf (1.11.0.0.0-java)
+    libddwaf (1.14.0.0.0-java)
       ffi (~> 1.0)
     memory_profiler (0.9.14)
     method_source (1.0.0)

--- a/gemfiles/jruby_9.2.21.0_hanami_1.gemfile.lock
+++ b/gemfiles/jruby_9.2.21.0_hanami_1.gemfile.lock
@@ -15,7 +15,7 @@ PATH
       datadog-ci (~> 0.1.0)
       debase-ruby_core_source (= 3.2.1)
       libdatadog (~> 4.0.0.1.0)
-      libddwaf (~> 1.11.0.0.0)
+      libddwaf (~> 1.14.0.0.0)
       msgpack
 
 GEM
@@ -123,7 +123,7 @@ GEM
     json-schema (2.8.1)
       addressable (>= 2.4)
     libdatadog (4.0.0.1.0)
-    libddwaf (1.11.0.0.0-java)
+    libddwaf (1.14.0.0.0-java)
       ffi (~> 1.0)
     mail (2.8.0.1)
       mini_mime (>= 0.1.1)

--- a/gemfiles/jruby_9.2.21.0_http.gemfile.lock
+++ b/gemfiles/jruby_9.2.21.0_http.gemfile.lock
@@ -15,7 +15,7 @@ PATH
       datadog-ci (~> 0.1.0)
       debase-ruby_core_source (= 3.2.1)
       libdatadog (~> 4.0.0.1.0)
-      libddwaf (~> 1.11.0.0.0)
+      libddwaf (~> 1.14.0.0.0)
       msgpack
 
 GEM
@@ -98,7 +98,7 @@ GEM
     json-schema (2.8.1)
       addressable (>= 2.4)
     libdatadog (4.0.0.1.0)
-    libddwaf (1.11.0.0.0-java)
+    libddwaf (1.14.0.0.0-java)
       ffi (~> 1.0)
     memory_profiler (0.9.14)
     method_source (1.0.0)

--- a/gemfiles/jruby_9.2.21.0_rails5_mysql2.gemfile.lock
+++ b/gemfiles/jruby_9.2.21.0_rails5_mysql2.gemfile.lock
@@ -15,7 +15,7 @@ PATH
       datadog-ci (~> 0.1.0)
       debase-ruby_core_source (= 3.2.1)
       libdatadog (~> 4.0.0.1.0)
-      libddwaf (~> 1.11.0.0.0)
+      libddwaf (~> 1.14.0.0.0)
       msgpack
 
 GEM
@@ -101,7 +101,7 @@ GEM
     json-schema (2.8.1)
       addressable (>= 2.4)
     libdatadog (4.0.0.1.0)
-    libddwaf (1.11.0.0.0-java)
+    libddwaf (1.14.0.0.0-java)
       ffi (~> 1.0)
     lograge (0.12.0)
       actionpack (>= 4)

--- a/gemfiles/jruby_9.2.21.0_rails5_postgres.gemfile.lock
+++ b/gemfiles/jruby_9.2.21.0_rails5_postgres.gemfile.lock
@@ -15,7 +15,7 @@ PATH
       datadog-ci (~> 0.1.0)
       debase-ruby_core_source (= 3.2.1)
       libdatadog (~> 4.0.0.1.0)
-      libddwaf (~> 1.11.0.0.0)
+      libddwaf (~> 1.14.0.0.0)
       msgpack
 
 GEM
@@ -103,7 +103,7 @@ GEM
     json-schema (2.8.1)
       addressable (>= 2.4)
     libdatadog (4.0.0.1.0)
-    libddwaf (1.11.0.0.0-java)
+    libddwaf (1.14.0.0.0-java)
       ffi (~> 1.0)
     lograge (0.12.0)
       actionpack (>= 4)

--- a/gemfiles/jruby_9.2.21.0_rails5_postgres_redis.gemfile.lock
+++ b/gemfiles/jruby_9.2.21.0_rails5_postgres_redis.gemfile.lock
@@ -15,7 +15,7 @@ PATH
       datadog-ci (~> 0.1.0)
       debase-ruby_core_source (= 3.2.1)
       libdatadog (~> 4.0.0.1.0)
-      libddwaf (~> 1.11.0.0.0)
+      libddwaf (~> 1.14.0.0.0)
       msgpack
 
 GEM
@@ -104,7 +104,7 @@ GEM
     json-schema (2.8.1)
       addressable (>= 2.4)
     libdatadog (4.0.0.1.0)
-    libddwaf (1.11.0.0.0-java)
+    libddwaf (1.14.0.0.0-java)
       ffi (~> 1.0)
     lograge (0.12.0)
       actionpack (>= 4)

--- a/gemfiles/jruby_9.2.21.0_rails5_postgres_redis_activesupport.gemfile.lock
+++ b/gemfiles/jruby_9.2.21.0_rails5_postgres_redis_activesupport.gemfile.lock
@@ -15,7 +15,7 @@ PATH
       datadog-ci (~> 0.1.0)
       debase-ruby_core_source (= 3.2.1)
       libdatadog (~> 4.0.0.1.0)
-      libddwaf (~> 1.11.0.0.0)
+      libddwaf (~> 1.14.0.0.0)
       msgpack
 
 GEM
@@ -103,7 +103,7 @@ GEM
     json-schema (2.8.1)
       addressable (>= 2.4)
     libdatadog (4.0.0.1.0)
-    libddwaf (1.11.0.0.0-java)
+    libddwaf (1.14.0.0.0-java)
       ffi (~> 1.0)
     lograge (0.12.0)
       actionpack (>= 4)

--- a/gemfiles/jruby_9.2.21.0_rails5_postgres_sidekiq.gemfile.lock
+++ b/gemfiles/jruby_9.2.21.0_rails5_postgres_sidekiq.gemfile.lock
@@ -15,7 +15,7 @@ PATH
       datadog-ci (~> 0.1.0)
       debase-ruby_core_source (= 3.2.1)
       libdatadog (~> 4.0.0.1.0)
-      libddwaf (~> 1.11.0.0.0)
+      libddwaf (~> 1.14.0.0.0)
       msgpack
 
 GEM
@@ -104,7 +104,7 @@ GEM
     json-schema (2.8.1)
       addressable (>= 2.4)
     libdatadog (4.0.0.1.0)
-    libddwaf (1.11.0.0.0-java)
+    libddwaf (1.14.0.0.0-java)
       ffi (~> 1.0)
     lograge (0.12.0)
       actionpack (>= 4)

--- a/gemfiles/jruby_9.2.21.0_rails5_semantic_logger.gemfile.lock
+++ b/gemfiles/jruby_9.2.21.0_rails5_semantic_logger.gemfile.lock
@@ -15,7 +15,7 @@ PATH
       datadog-ci (~> 0.1.0)
       debase-ruby_core_source (= 3.2.1)
       libdatadog (~> 4.0.0.1.0)
-      libddwaf (~> 1.11.0.0.0)
+      libddwaf (~> 1.14.0.0.0)
       msgpack
 
 GEM
@@ -103,7 +103,7 @@ GEM
     json-schema (2.8.1)
       addressable (>= 2.4)
     libdatadog (4.0.0.1.0)
-    libddwaf (1.11.0.0.0-java)
+    libddwaf (1.14.0.0.0-java)
       ffi (~> 1.0)
     loofah (2.19.1)
       crass (~> 1.0.2)

--- a/gemfiles/jruby_9.2.21.0_rails61_mysql2.gemfile.lock
+++ b/gemfiles/jruby_9.2.21.0_rails61_mysql2.gemfile.lock
@@ -15,7 +15,7 @@ PATH
       datadog-ci (~> 0.1.0)
       debase-ruby_core_source (= 3.2.1)
       libdatadog (~> 4.0.0.1.0)
-      libddwaf (~> 1.11.0.0.0)
+      libddwaf (~> 1.14.0.0.0)
       msgpack
 
 GEM
@@ -118,7 +118,7 @@ GEM
     json-schema (2.8.1)
       addressable (>= 2.4)
     libdatadog (4.0.0.1.0)
-    libddwaf (1.11.0.0.0-java)
+    libddwaf (1.14.0.0.0-java)
       ffi (~> 1.0)
     lograge (0.12.0)
       actionpack (>= 4)

--- a/gemfiles/jruby_9.2.21.0_rails61_postgres.gemfile.lock
+++ b/gemfiles/jruby_9.2.21.0_rails61_postgres.gemfile.lock
@@ -15,7 +15,7 @@ PATH
       datadog-ci (~> 0.1.0)
       debase-ruby_core_source (= 3.2.1)
       libdatadog (~> 4.0.0.1.0)
-      libddwaf (~> 1.11.0.0.0)
+      libddwaf (~> 1.14.0.0.0)
       msgpack
 
 GEM
@@ -120,7 +120,7 @@ GEM
     json-schema (2.8.1)
       addressable (>= 2.4)
     libdatadog (4.0.0.1.0)
-    libddwaf (1.11.0.0.0-java)
+    libddwaf (1.14.0.0.0-java)
       ffi (~> 1.0)
     lograge (0.12.0)
       actionpack (>= 4)

--- a/gemfiles/jruby_9.2.21.0_rails61_postgres_redis.gemfile.lock
+++ b/gemfiles/jruby_9.2.21.0_rails61_postgres_redis.gemfile.lock
@@ -15,7 +15,7 @@ PATH
       datadog-ci (~> 0.1.0)
       debase-ruby_core_source (= 3.2.1)
       libdatadog (~> 4.0.0.1.0)
-      libddwaf (~> 1.11.0.0.0)
+      libddwaf (~> 1.14.0.0.0)
       msgpack
 
 GEM
@@ -121,7 +121,7 @@ GEM
     json-schema (2.8.1)
       addressable (>= 2.4)
     libdatadog (4.0.0.1.0)
-    libddwaf (1.11.0.0.0-java)
+    libddwaf (1.14.0.0.0-java)
       ffi (~> 1.0)
     lograge (0.12.0)
       actionpack (>= 4)

--- a/gemfiles/jruby_9.2.21.0_rails61_postgres_sidekiq.gemfile.lock
+++ b/gemfiles/jruby_9.2.21.0_rails61_postgres_sidekiq.gemfile.lock
@@ -15,7 +15,7 @@ PATH
       datadog-ci (~> 0.1.0)
       debase-ruby_core_source (= 3.2.1)
       libdatadog (~> 4.0.0.1.0)
-      libddwaf (~> 1.11.0.0.0)
+      libddwaf (~> 1.14.0.0.0)
       msgpack
 
 GEM
@@ -121,7 +121,7 @@ GEM
     json-schema (2.8.1)
       addressable (>= 2.4)
     libdatadog (4.0.0.1.0)
-    libddwaf (1.11.0.0.0-java)
+    libddwaf (1.14.0.0.0-java)
       ffi (~> 1.0)
     lograge (0.12.0)
       actionpack (>= 4)

--- a/gemfiles/jruby_9.2.21.0_rails61_semantic_logger.gemfile.lock
+++ b/gemfiles/jruby_9.2.21.0_rails61_semantic_logger.gemfile.lock
@@ -15,7 +15,7 @@ PATH
       datadog-ci (~> 0.1.0)
       debase-ruby_core_source (= 3.2.1)
       libdatadog (~> 4.0.0.1.0)
-      libddwaf (~> 1.11.0.0.0)
+      libddwaf (~> 1.14.0.0.0)
       msgpack
 
 GEM
@@ -120,7 +120,7 @@ GEM
     json-schema (2.8.1)
       addressable (>= 2.4)
     libdatadog (4.0.0.1.0)
-    libddwaf (1.11.0.0.0-java)
+    libddwaf (1.14.0.0.0-java)
       ffi (~> 1.0)
     loofah (2.19.1)
       crass (~> 1.0.2)

--- a/gemfiles/jruby_9.2.21.0_rails6_mysql2.gemfile.lock
+++ b/gemfiles/jruby_9.2.21.0_rails6_mysql2.gemfile.lock
@@ -15,7 +15,7 @@ PATH
       datadog-ci (~> 0.1.0)
       debase-ruby_core_source (= 3.2.1)
       libdatadog (~> 4.0.0.1.0)
-      libddwaf (~> 1.11.0.0.0)
+      libddwaf (~> 1.14.0.0.0)
       msgpack
 
 GEM
@@ -114,7 +114,7 @@ GEM
     json-schema (2.8.1)
       addressable (>= 2.4)
     libdatadog (4.0.0.1.0)
-    libddwaf (1.11.0.0.0-java)
+    libddwaf (1.14.0.0.0-java)
       ffi (~> 1.0)
     lograge (0.12.0)
       actionpack (>= 4)

--- a/gemfiles/jruby_9.2.21.0_rails6_postgres.gemfile.lock
+++ b/gemfiles/jruby_9.2.21.0_rails6_postgres.gemfile.lock
@@ -15,7 +15,7 @@ PATH
       datadog-ci (~> 0.1.0)
       debase-ruby_core_source (= 3.2.1)
       libdatadog (~> 4.0.0.1.0)
-      libddwaf (~> 1.11.0.0.0)
+      libddwaf (~> 1.14.0.0.0)
       msgpack
 
 GEM
@@ -116,7 +116,7 @@ GEM
     json-schema (2.8.1)
       addressable (>= 2.4)
     libdatadog (4.0.0.1.0)
-    libddwaf (1.11.0.0.0-java)
+    libddwaf (1.14.0.0.0-java)
       ffi (~> 1.0)
     lograge (0.12.0)
       actionpack (>= 4)

--- a/gemfiles/jruby_9.2.21.0_rails6_postgres_redis.gemfile.lock
+++ b/gemfiles/jruby_9.2.21.0_rails6_postgres_redis.gemfile.lock
@@ -15,7 +15,7 @@ PATH
       datadog-ci (~> 0.1.0)
       debase-ruby_core_source (= 3.2.1)
       libdatadog (~> 4.0.0.1.0)
-      libddwaf (~> 1.11.0.0.0)
+      libddwaf (~> 1.14.0.0.0)
       msgpack
 
 GEM
@@ -117,7 +117,7 @@ GEM
     json-schema (2.8.1)
       addressable (>= 2.4)
     libdatadog (4.0.0.1.0)
-    libddwaf (1.11.0.0.0-java)
+    libddwaf (1.14.0.0.0-java)
       ffi (~> 1.0)
     lograge (0.12.0)
       actionpack (>= 4)

--- a/gemfiles/jruby_9.2.21.0_rails6_postgres_redis_activesupport.gemfile.lock
+++ b/gemfiles/jruby_9.2.21.0_rails6_postgres_redis_activesupport.gemfile.lock
@@ -15,7 +15,7 @@ PATH
       datadog-ci (~> 0.1.0)
       debase-ruby_core_source (= 3.2.1)
       libdatadog (~> 4.0.0.1.0)
-      libddwaf (~> 1.11.0.0.0)
+      libddwaf (~> 1.14.0.0.0)
       msgpack
 
 GEM
@@ -116,7 +116,7 @@ GEM
     json-schema (2.8.1)
       addressable (>= 2.4)
     libdatadog (4.0.0.1.0)
-    libddwaf (1.11.0.0.0-java)
+    libddwaf (1.14.0.0.0-java)
       ffi (~> 1.0)
     lograge (0.12.0)
       actionpack (>= 4)

--- a/gemfiles/jruby_9.2.21.0_rails6_postgres_sidekiq.gemfile.lock
+++ b/gemfiles/jruby_9.2.21.0_rails6_postgres_sidekiq.gemfile.lock
@@ -15,7 +15,7 @@ PATH
       datadog-ci (~> 0.1.0)
       debase-ruby_core_source (= 3.2.1)
       libdatadog (~> 4.0.0.1.0)
-      libddwaf (~> 1.11.0.0.0)
+      libddwaf (~> 1.14.0.0.0)
       msgpack
 
 GEM
@@ -117,7 +117,7 @@ GEM
     json-schema (2.8.1)
       addressable (>= 2.4)
     libdatadog (4.0.0.1.0)
-    libddwaf (1.11.0.0.0-java)
+    libddwaf (1.14.0.0.0-java)
       ffi (~> 1.0)
     lograge (0.12.0)
       actionpack (>= 4)

--- a/gemfiles/jruby_9.2.21.0_rails6_semantic_logger.gemfile.lock
+++ b/gemfiles/jruby_9.2.21.0_rails6_semantic_logger.gemfile.lock
@@ -15,7 +15,7 @@ PATH
       datadog-ci (~> 0.1.0)
       debase-ruby_core_source (= 3.2.1)
       libdatadog (~> 4.0.0.1.0)
-      libddwaf (~> 1.11.0.0.0)
+      libddwaf (~> 1.14.0.0.0)
       msgpack
 
 GEM
@@ -116,7 +116,7 @@ GEM
     json-schema (2.8.1)
       addressable (>= 2.4)
     libdatadog (4.0.0.1.0)
-    libddwaf (1.11.0.0.0-java)
+    libddwaf (1.14.0.0.0-java)
       ffi (~> 1.0)
     loofah (2.19.1)
       crass (~> 1.0.2)

--- a/gemfiles/jruby_9.2.21.0_redis_3.gemfile.lock
+++ b/gemfiles/jruby_9.2.21.0_redis_3.gemfile.lock
@@ -15,7 +15,7 @@ PATH
       datadog-ci (~> 0.1.0)
       debase-ruby_core_source (= 3.2.1)
       libdatadog (~> 4.0.0.1.0)
-      libddwaf (~> 1.11.0.0.0)
+      libddwaf (~> 1.14.0.0.0)
       msgpack
 
 GEM
@@ -47,7 +47,7 @@ GEM
     json-schema (2.8.1)
       addressable (>= 2.4)
     libdatadog (4.0.0.1.0)
-    libddwaf (1.11.0.0.0-java)
+    libddwaf (1.14.0.0.0-java)
       ffi (~> 1.0)
     memory_profiler (0.9.14)
     method_source (1.0.0)

--- a/gemfiles/jruby_9.2.21.0_redis_4.gemfile.lock
+++ b/gemfiles/jruby_9.2.21.0_redis_4.gemfile.lock
@@ -15,7 +15,7 @@ PATH
       datadog-ci (~> 0.1.0)
       debase-ruby_core_source (= 3.2.1)
       libdatadog (~> 4.0.0.1.0)
-      libddwaf (~> 1.11.0.0.0)
+      libddwaf (~> 1.14.0.0.0)
       msgpack
 
 GEM
@@ -47,7 +47,7 @@ GEM
     json-schema (2.8.1)
       addressable (>= 2.4)
     libdatadog (4.0.0.1.0)
-    libddwaf (1.11.0.0.0-java)
+    libddwaf (1.14.0.0.0-java)
       ffi (~> 1.0)
     memory_profiler (0.9.14)
     method_source (1.0.0)

--- a/gemfiles/jruby_9.2.21.0_redis_5.gemfile.lock
+++ b/gemfiles/jruby_9.2.21.0_redis_5.gemfile.lock
@@ -15,7 +15,7 @@ PATH
       datadog-ci (~> 0.1.0)
       debase-ruby_core_source (= 3.2.1)
       libdatadog (~> 4.0.0.1.0)
-      libddwaf (~> 1.11.0.0.0)
+      libddwaf (~> 1.14.0.0.0)
       msgpack
 
 GEM
@@ -48,7 +48,7 @@ GEM
     json-schema (2.8.1)
       addressable (>= 2.4)
     libdatadog (4.0.0.1.0)
-    libddwaf (1.11.0.0.0-java)
+    libddwaf (1.14.0.0.0-java)
       ffi (~> 1.0)
     memory_profiler (0.9.14)
     method_source (1.0.0)

--- a/gemfiles/jruby_9.2.21.0_relational_db.gemfile.lock
+++ b/gemfiles/jruby_9.2.21.0_relational_db.gemfile.lock
@@ -15,7 +15,7 @@ PATH
       datadog-ci (~> 0.1.0)
       debase-ruby_core_source (= 3.2.1)
       libdatadog (~> 4.0.0.1.0)
-      libddwaf (~> 1.11.0.0.0)
+      libddwaf (~> 1.14.0.0.0)
       msgpack
 
 GEM
@@ -80,7 +80,7 @@ GEM
     json-schema (2.8.1)
       addressable (>= 2.4)
     libdatadog (4.0.0.1.0)
-    libddwaf (1.11.0.0.0-java)
+    libddwaf (1.14.0.0.0-java)
       ffi (~> 1.0)
     makara (0.5.1)
       activerecord (>= 5.2.0)

--- a/gemfiles/jruby_9.2.21.0_resque2_redis3.gemfile.lock
+++ b/gemfiles/jruby_9.2.21.0_resque2_redis3.gemfile.lock
@@ -15,7 +15,7 @@ PATH
       datadog-ci (~> 0.1.0)
       debase-ruby_core_source (= 3.2.1)
       libdatadog (~> 4.0.0.1.0)
-      libddwaf (~> 1.11.0.0.0)
+      libddwaf (~> 1.14.0.0.0)
       msgpack
 
 GEM
@@ -47,7 +47,7 @@ GEM
     json-schema (2.8.1)
       addressable (>= 2.4)
     libdatadog (4.0.0.1.0)
-    libddwaf (1.11.0.0.0-java)
+    libddwaf (1.14.0.0.0-java)
       ffi (~> 1.0)
     memory_profiler (0.9.14)
     method_source (1.0.0)

--- a/gemfiles/jruby_9.2.21.0_resque2_redis4.gemfile.lock
+++ b/gemfiles/jruby_9.2.21.0_resque2_redis4.gemfile.lock
@@ -15,7 +15,7 @@ PATH
       datadog-ci (~> 0.1.0)
       debase-ruby_core_source (= 3.2.1)
       libdatadog (~> 4.0.0.1.0)
-      libddwaf (~> 1.11.0.0.0)
+      libddwaf (~> 1.14.0.0.0)
       msgpack
 
 GEM
@@ -48,7 +48,7 @@ GEM
     json-schema (2.8.1)
       addressable (>= 2.4)
     libdatadog (4.0.0.1.0)
-    libddwaf (1.11.0.0.0-java)
+    libddwaf (1.14.0.0.0-java)
       ffi (~> 1.0)
     memory_profiler (0.9.14)
     method_source (1.0.0)

--- a/gemfiles/jruby_9.2.21.0_sinatra.gemfile.lock
+++ b/gemfiles/jruby_9.2.21.0_sinatra.gemfile.lock
@@ -15,7 +15,7 @@ PATH
       datadog-ci (~> 0.1.0)
       debase-ruby_core_source (= 3.2.1)
       libdatadog (~> 4.0.0.1.0)
-      libddwaf (~> 1.11.0.0.0)
+      libddwaf (~> 1.14.0.0.0)
       msgpack
 
 GEM
@@ -47,7 +47,7 @@ GEM
     json-schema (2.8.1)
       addressable (>= 2.4)
     libdatadog (4.0.0.1.0)
-    libddwaf (1.11.0.0.0-java)
+    libddwaf (1.14.0.0.0-java)
       ffi (~> 1.0)
     memory_profiler (0.9.14)
     method_source (1.0.0)

--- a/gemfiles/jruby_9.3.9.0_aws.gemfile.lock
+++ b/gemfiles/jruby_9.3.9.0_aws.gemfile.lock
@@ -15,7 +15,7 @@ PATH
       datadog-ci (~> 0.1.0)
       debase-ruby_core_source (= 3.2.1)
       libdatadog (~> 4.0.0.1.0)
-      libddwaf (~> 1.11.0.0.0)
+      libddwaf (~> 1.14.0.0.0)
       msgpack
 
 GEM
@@ -1471,7 +1471,7 @@ GEM
     json-schema (2.8.1)
       addressable (>= 2.4)
     libdatadog (4.0.0.1.0)
-    libddwaf (1.11.0.0.0-java)
+    libddwaf (1.14.0.0.0-java)
       ffi (~> 1.0)
     memory_profiler (0.9.14)
     method_source (1.0.0)

--- a/gemfiles/jruby_9.3.9.0_contrib.gemfile.lock
+++ b/gemfiles/jruby_9.3.9.0_contrib.gemfile.lock
@@ -15,7 +15,7 @@ PATH
       datadog-ci (~> 0.1.0)
       debase-ruby_core_source (= 3.2.1)
       libdatadog (~> 4.0.0.1.0)
-      libddwaf (~> 1.11.0.0.0)
+      libddwaf (~> 1.14.0.0.0)
       msgpack
 
 GEM
@@ -118,7 +118,7 @@ GEM
     jsonapi-renderer (0.2.2)
     king_konf (1.0.1)
     libdatadog (4.0.0.1.0)
-    libddwaf (1.11.0.0.0-java)
+    libddwaf (1.14.0.0.0-java)
       ffi (~> 1.0)
     lograge (0.12.0)
       actionpack (>= 4)

--- a/gemfiles/jruby_9.3.9.0_contrib_old.gemfile.lock
+++ b/gemfiles/jruby_9.3.9.0_contrib_old.gemfile.lock
@@ -15,7 +15,7 @@ PATH
       datadog-ci (~> 0.1.0)
       debase-ruby_core_source (= 3.2.1)
       libdatadog (~> 4.0.0.1.0)
-      libddwaf (~> 1.11.0.0.0)
+      libddwaf (~> 1.14.0.0.0)
       msgpack
 
 GEM
@@ -63,7 +63,7 @@ GEM
     json-schema (2.8.1)
       addressable (>= 2.4)
     libdatadog (4.0.0.1.0)
-    libddwaf (1.11.0.0.0-java)
+    libddwaf (1.14.0.0.0-java)
       ffi (~> 1.0)
     memory_profiler (0.9.14)
     method_source (1.0.0)

--- a/gemfiles/jruby_9.3.9.0_core_old.gemfile.lock
+++ b/gemfiles/jruby_9.3.9.0_core_old.gemfile.lock
@@ -15,7 +15,7 @@ PATH
       datadog-ci (~> 0.1.0)
       debase-ruby_core_source (= 3.2.1)
       libdatadog (~> 4.0.0.1.0)
-      libddwaf (~> 1.11.0.0.0)
+      libddwaf (~> 1.14.0.0.0)
       msgpack
 
 GEM
@@ -49,7 +49,7 @@ GEM
     json-schema (2.8.1)
       addressable (>= 2.4)
     libdatadog (4.0.0.1.0)
-    libddwaf (1.11.0.0.0-java)
+    libddwaf (1.14.0.0.0-java)
       ffi (~> 1.0)
     memory_profiler (0.9.14)
     method_source (1.0.0)

--- a/gemfiles/jruby_9.3.9.0_hanami_1.gemfile.lock
+++ b/gemfiles/jruby_9.3.9.0_hanami_1.gemfile.lock
@@ -15,7 +15,7 @@ PATH
       datadog-ci (~> 0.1.0)
       debase-ruby_core_source (= 3.2.1)
       libdatadog (~> 4.0.0.1.0)
-      libddwaf (~> 1.11.0.0.0)
+      libddwaf (~> 1.14.0.0.0)
       msgpack
 
 GEM
@@ -124,7 +124,7 @@ GEM
     json-schema (2.8.1)
       addressable (>= 2.4)
     libdatadog (4.0.0.1.0)
-    libddwaf (1.11.0.0.0-java)
+    libddwaf (1.14.0.0.0-java)
       ffi (~> 1.0)
     mail (2.8.0.1)
       mini_mime (>= 0.1.1)

--- a/gemfiles/jruby_9.3.9.0_http.gemfile.lock
+++ b/gemfiles/jruby_9.3.9.0_http.gemfile.lock
@@ -15,7 +15,7 @@ PATH
       datadog-ci (~> 0.1.0)
       debase-ruby_core_source (= 3.2.1)
       libdatadog (~> 4.0.0.1.0)
-      libddwaf (~> 1.11.0.0.0)
+      libddwaf (~> 1.14.0.0.0)
       msgpack
 
 GEM
@@ -81,7 +81,7 @@ GEM
     json-schema (2.8.1)
       addressable (>= 2.4)
     libdatadog (4.0.0.1.0)
-    libddwaf (1.11.0.0.0-java)
+    libddwaf (1.14.0.0.0-java)
       ffi (~> 1.0)
     memory_profiler (0.9.14)
     method_source (1.0.0)

--- a/gemfiles/jruby_9.3.9.0_rails5_mysql2.gemfile.lock
+++ b/gemfiles/jruby_9.3.9.0_rails5_mysql2.gemfile.lock
@@ -15,7 +15,7 @@ PATH
       datadog-ci (~> 0.1.0)
       debase-ruby_core_source (= 3.2.1)
       libdatadog (~> 4.0.0.1.0)
-      libddwaf (~> 1.11.0.0.0)
+      libddwaf (~> 1.14.0.0.0)
       msgpack
 
 GEM
@@ -104,7 +104,7 @@ GEM
     json-schema (2.8.1)
       addressable (>= 2.4)
     libdatadog (4.0.0.1.0)
-    libddwaf (1.11.0.0.0-java)
+    libddwaf (1.14.0.0.0-java)
       ffi (~> 1.0)
     lograge (0.12.0)
       actionpack (>= 4)

--- a/gemfiles/jruby_9.3.9.0_rails5_postgres.gemfile.lock
+++ b/gemfiles/jruby_9.3.9.0_rails5_postgres.gemfile.lock
@@ -15,7 +15,7 @@ PATH
       datadog-ci (~> 0.1.0)
       debase-ruby_core_source (= 3.2.1)
       libdatadog (~> 4.0.0.1.0)
-      libddwaf (~> 1.11.0.0.0)
+      libddwaf (~> 1.14.0.0.0)
       msgpack
 
 GEM
@@ -104,7 +104,7 @@ GEM
     json-schema (2.8.1)
       addressable (>= 2.4)
     libdatadog (4.0.0.1.0)
-    libddwaf (1.11.0.0.0-java)
+    libddwaf (1.14.0.0.0-java)
       ffi (~> 1.0)
     lograge (0.12.0)
       actionpack (>= 4)

--- a/gemfiles/jruby_9.3.9.0_rails5_postgres_redis.gemfile.lock
+++ b/gemfiles/jruby_9.3.9.0_rails5_postgres_redis.gemfile.lock
@@ -15,7 +15,7 @@ PATH
       datadog-ci (~> 0.1.0)
       debase-ruby_core_source (= 3.2.1)
       libdatadog (~> 4.0.0.1.0)
-      libddwaf (~> 1.11.0.0.0)
+      libddwaf (~> 1.14.0.0.0)
       msgpack
 
 GEM
@@ -104,7 +104,7 @@ GEM
     json-schema (2.8.1)
       addressable (>= 2.4)
     libdatadog (4.0.0.1.0)
-    libddwaf (1.11.0.0.0-java)
+    libddwaf (1.14.0.0.0-java)
       ffi (~> 1.0)
     lograge (0.12.0)
       actionpack (>= 4)

--- a/gemfiles/jruby_9.3.9.0_rails5_postgres_redis_activesupport.gemfile.lock
+++ b/gemfiles/jruby_9.3.9.0_rails5_postgres_redis_activesupport.gemfile.lock
@@ -15,7 +15,7 @@ PATH
       datadog-ci (~> 0.1.0)
       debase-ruby_core_source (= 3.2.1)
       libdatadog (~> 4.0.0.1.0)
-      libddwaf (~> 1.11.0.0.0)
+      libddwaf (~> 1.14.0.0.0)
       msgpack
 
 GEM
@@ -104,7 +104,7 @@ GEM
     json-schema (2.8.1)
       addressable (>= 2.4)
     libdatadog (4.0.0.1.0)
-    libddwaf (1.11.0.0.0-java)
+    libddwaf (1.14.0.0.0-java)
       ffi (~> 1.0)
     lograge (0.12.0)
       actionpack (>= 4)

--- a/gemfiles/jruby_9.3.9.0_rails5_postgres_sidekiq.gemfile.lock
+++ b/gemfiles/jruby_9.3.9.0_rails5_postgres_sidekiq.gemfile.lock
@@ -15,7 +15,7 @@ PATH
       datadog-ci (~> 0.1.0)
       debase-ruby_core_source (= 3.2.1)
       libdatadog (~> 4.0.0.1.0)
-      libddwaf (~> 1.11.0.0.0)
+      libddwaf (~> 1.14.0.0.0)
       msgpack
 
 GEM
@@ -105,7 +105,7 @@ GEM
     json-schema (2.8.1)
       addressable (>= 2.4)
     libdatadog (4.0.0.1.0)
-    libddwaf (1.11.0.0.0-java)
+    libddwaf (1.14.0.0.0-java)
       ffi (~> 1.0)
     lograge (0.12.0)
       actionpack (>= 4)

--- a/gemfiles/jruby_9.3.9.0_rails5_semantic_logger.gemfile.lock
+++ b/gemfiles/jruby_9.3.9.0_rails5_semantic_logger.gemfile.lock
@@ -15,7 +15,7 @@ PATH
       datadog-ci (~> 0.1.0)
       debase-ruby_core_source (= 3.2.1)
       libdatadog (~> 4.0.0.1.0)
-      libddwaf (~> 1.11.0.0.0)
+      libddwaf (~> 1.14.0.0.0)
       msgpack
 
 GEM
@@ -104,7 +104,7 @@ GEM
     json-schema (2.8.1)
       addressable (>= 2.4)
     libdatadog (4.0.0.1.0)
-    libddwaf (1.11.0.0.0-java)
+    libddwaf (1.14.0.0.0-java)
       ffi (~> 1.0)
     loofah (2.19.1)
       crass (~> 1.0.2)

--- a/gemfiles/jruby_9.3.9.0_rails61_mysql2.gemfile.lock
+++ b/gemfiles/jruby_9.3.9.0_rails61_mysql2.gemfile.lock
@@ -15,7 +15,7 @@ PATH
       datadog-ci (~> 0.1.0)
       debase-ruby_core_source (= 3.2.1)
       libdatadog (~> 4.0.0.1.0)
-      libddwaf (~> 1.11.0.0.0)
+      libddwaf (~> 1.14.0.0.0)
       msgpack
 
 GEM
@@ -121,7 +121,7 @@ GEM
     json-schema (2.8.1)
       addressable (>= 2.4)
     libdatadog (4.0.0.1.0)
-    libddwaf (1.11.0.0.0-java)
+    libddwaf (1.14.0.0.0-java)
       ffi (~> 1.0)
     lograge (0.12.0)
       actionpack (>= 4)

--- a/gemfiles/jruby_9.3.9.0_rails61_postgres.gemfile.lock
+++ b/gemfiles/jruby_9.3.9.0_rails61_postgres.gemfile.lock
@@ -15,7 +15,7 @@ PATH
       datadog-ci (~> 0.1.0)
       debase-ruby_core_source (= 3.2.1)
       libdatadog (~> 4.0.0.1.0)
-      libddwaf (~> 1.11.0.0.0)
+      libddwaf (~> 1.14.0.0.0)
       msgpack
 
 GEM
@@ -121,7 +121,7 @@ GEM
     json-schema (2.8.1)
       addressable (>= 2.4)
     libdatadog (4.0.0.1.0)
-    libddwaf (1.11.0.0.0-java)
+    libddwaf (1.14.0.0.0-java)
       ffi (~> 1.0)
     lograge (0.12.0)
       actionpack (>= 4)

--- a/gemfiles/jruby_9.3.9.0_rails61_postgres_redis.gemfile.lock
+++ b/gemfiles/jruby_9.3.9.0_rails61_postgres_redis.gemfile.lock
@@ -15,7 +15,7 @@ PATH
       datadog-ci (~> 0.1.0)
       debase-ruby_core_source (= 3.2.1)
       libdatadog (~> 4.0.0.1.0)
-      libddwaf (~> 1.11.0.0.0)
+      libddwaf (~> 1.14.0.0.0)
       msgpack
 
 GEM
@@ -121,7 +121,7 @@ GEM
     json-schema (2.8.1)
       addressable (>= 2.4)
     libdatadog (4.0.0.1.0)
-    libddwaf (1.11.0.0.0-java)
+    libddwaf (1.14.0.0.0-java)
       ffi (~> 1.0)
     lograge (0.12.0)
       actionpack (>= 4)

--- a/gemfiles/jruby_9.3.9.0_rails61_postgres_sidekiq.gemfile.lock
+++ b/gemfiles/jruby_9.3.9.0_rails61_postgres_sidekiq.gemfile.lock
@@ -15,7 +15,7 @@ PATH
       datadog-ci (~> 0.1.0)
       debase-ruby_core_source (= 3.2.1)
       libdatadog (~> 4.0.0.1.0)
-      libddwaf (~> 1.11.0.0.0)
+      libddwaf (~> 1.14.0.0.0)
       msgpack
 
 GEM
@@ -122,7 +122,7 @@ GEM
     json-schema (2.8.1)
       addressable (>= 2.4)
     libdatadog (4.0.0.1.0)
-    libddwaf (1.11.0.0.0-java)
+    libddwaf (1.14.0.0.0-java)
       ffi (~> 1.0)
     lograge (0.12.0)
       actionpack (>= 4)

--- a/gemfiles/jruby_9.3.9.0_rails61_semantic_logger.gemfile.lock
+++ b/gemfiles/jruby_9.3.9.0_rails61_semantic_logger.gemfile.lock
@@ -15,7 +15,7 @@ PATH
       datadog-ci (~> 0.1.0)
       debase-ruby_core_source (= 3.2.1)
       libdatadog (~> 4.0.0.1.0)
-      libddwaf (~> 1.11.0.0.0)
+      libddwaf (~> 1.14.0.0.0)
       msgpack
 
 GEM
@@ -121,7 +121,7 @@ GEM
     json-schema (2.8.1)
       addressable (>= 2.4)
     libdatadog (4.0.0.1.0)
-    libddwaf (1.11.0.0.0-java)
+    libddwaf (1.14.0.0.0-java)
       ffi (~> 1.0)
     loofah (2.19.1)
       crass (~> 1.0.2)

--- a/gemfiles/jruby_9.3.9.0_rails6_mysql2.gemfile.lock
+++ b/gemfiles/jruby_9.3.9.0_rails6_mysql2.gemfile.lock
@@ -15,7 +15,7 @@ PATH
       datadog-ci (~> 0.1.0)
       debase-ruby_core_source (= 3.2.1)
       libdatadog (~> 4.0.0.1.0)
-      libddwaf (~> 1.11.0.0.0)
+      libddwaf (~> 1.14.0.0.0)
       msgpack
 
 GEM
@@ -117,7 +117,7 @@ GEM
     json-schema (2.8.1)
       addressable (>= 2.4)
     libdatadog (4.0.0.1.0)
-    libddwaf (1.11.0.0.0-java)
+    libddwaf (1.14.0.0.0-java)
       ffi (~> 1.0)
     lograge (0.12.0)
       actionpack (>= 4)

--- a/gemfiles/jruby_9.3.9.0_rails6_postgres.gemfile.lock
+++ b/gemfiles/jruby_9.3.9.0_rails6_postgres.gemfile.lock
@@ -15,7 +15,7 @@ PATH
       datadog-ci (~> 0.1.0)
       debase-ruby_core_source (= 3.2.1)
       libdatadog (~> 4.0.0.1.0)
-      libddwaf (~> 1.11.0.0.0)
+      libddwaf (~> 1.14.0.0.0)
       msgpack
 
 GEM
@@ -117,7 +117,7 @@ GEM
     json-schema (2.8.1)
       addressable (>= 2.4)
     libdatadog (4.0.0.1.0)
-    libddwaf (1.11.0.0.0-java)
+    libddwaf (1.14.0.0.0-java)
       ffi (~> 1.0)
     lograge (0.12.0)
       actionpack (>= 4)

--- a/gemfiles/jruby_9.3.9.0_rails6_postgres_redis.gemfile.lock
+++ b/gemfiles/jruby_9.3.9.0_rails6_postgres_redis.gemfile.lock
@@ -15,7 +15,7 @@ PATH
       datadog-ci (~> 0.1.0)
       debase-ruby_core_source (= 3.2.1)
       libdatadog (~> 4.0.0.1.0)
-      libddwaf (~> 1.11.0.0.0)
+      libddwaf (~> 1.14.0.0.0)
       msgpack
 
 GEM
@@ -117,7 +117,7 @@ GEM
     json-schema (2.8.1)
       addressable (>= 2.4)
     libdatadog (4.0.0.1.0)
-    libddwaf (1.11.0.0.0-java)
+    libddwaf (1.14.0.0.0-java)
       ffi (~> 1.0)
     lograge (0.12.0)
       actionpack (>= 4)

--- a/gemfiles/jruby_9.3.9.0_rails6_postgres_redis_activesupport.gemfile.lock
+++ b/gemfiles/jruby_9.3.9.0_rails6_postgres_redis_activesupport.gemfile.lock
@@ -15,7 +15,7 @@ PATH
       datadog-ci (~> 0.1.0)
       debase-ruby_core_source (= 3.2.1)
       libdatadog (~> 4.0.0.1.0)
-      libddwaf (~> 1.11.0.0.0)
+      libddwaf (~> 1.14.0.0.0)
       msgpack
 
 GEM
@@ -117,7 +117,7 @@ GEM
     json-schema (2.8.1)
       addressable (>= 2.4)
     libdatadog (4.0.0.1.0)
-    libddwaf (1.11.0.0.0-java)
+    libddwaf (1.14.0.0.0-java)
       ffi (~> 1.0)
     lograge (0.12.0)
       actionpack (>= 4)

--- a/gemfiles/jruby_9.3.9.0_rails6_postgres_sidekiq.gemfile.lock
+++ b/gemfiles/jruby_9.3.9.0_rails6_postgres_sidekiq.gemfile.lock
@@ -15,7 +15,7 @@ PATH
       datadog-ci (~> 0.1.0)
       debase-ruby_core_source (= 3.2.1)
       libdatadog (~> 4.0.0.1.0)
-      libddwaf (~> 1.11.0.0.0)
+      libddwaf (~> 1.14.0.0.0)
       msgpack
 
 GEM
@@ -118,7 +118,7 @@ GEM
     json-schema (2.8.1)
       addressable (>= 2.4)
     libdatadog (4.0.0.1.0)
-    libddwaf (1.11.0.0.0-java)
+    libddwaf (1.14.0.0.0-java)
       ffi (~> 1.0)
     lograge (0.12.0)
       actionpack (>= 4)

--- a/gemfiles/jruby_9.3.9.0_rails6_semantic_logger.gemfile.lock
+++ b/gemfiles/jruby_9.3.9.0_rails6_semantic_logger.gemfile.lock
@@ -15,7 +15,7 @@ PATH
       datadog-ci (~> 0.1.0)
       debase-ruby_core_source (= 3.2.1)
       libdatadog (~> 4.0.0.1.0)
-      libddwaf (~> 1.11.0.0.0)
+      libddwaf (~> 1.14.0.0.0)
       msgpack
 
 GEM
@@ -117,7 +117,7 @@ GEM
     json-schema (2.8.1)
       addressable (>= 2.4)
     libdatadog (4.0.0.1.0)
-    libddwaf (1.11.0.0.0-java)
+    libddwaf (1.14.0.0.0-java)
       ffi (~> 1.0)
     loofah (2.19.1)
       crass (~> 1.0.2)

--- a/gemfiles/jruby_9.3.9.0_redis_3.gemfile.lock
+++ b/gemfiles/jruby_9.3.9.0_redis_3.gemfile.lock
@@ -15,7 +15,7 @@ PATH
       datadog-ci (~> 0.1.0)
       debase-ruby_core_source (= 3.2.1)
       libdatadog (~> 4.0.0.1.0)
-      libddwaf (~> 1.11.0.0.0)
+      libddwaf (~> 1.14.0.0.0)
       msgpack
 
 GEM
@@ -49,7 +49,7 @@ GEM
     json-schema (2.8.1)
       addressable (>= 2.4)
     libdatadog (4.0.0.1.0)
-    libddwaf (1.11.0.0.0-java)
+    libddwaf (1.14.0.0.0-java)
       ffi (~> 1.0)
     memory_profiler (0.9.14)
     method_source (1.0.0)

--- a/gemfiles/jruby_9.3.9.0_redis_4.gemfile.lock
+++ b/gemfiles/jruby_9.3.9.0_redis_4.gemfile.lock
@@ -15,7 +15,7 @@ PATH
       datadog-ci (~> 0.1.0)
       debase-ruby_core_source (= 3.2.1)
       libdatadog (~> 4.0.0.1.0)
-      libddwaf (~> 1.11.0.0.0)
+      libddwaf (~> 1.14.0.0.0)
       msgpack
 
 GEM
@@ -49,7 +49,7 @@ GEM
     json-schema (2.8.1)
       addressable (>= 2.4)
     libdatadog (4.0.0.1.0)
-    libddwaf (1.11.0.0.0-java)
+    libddwaf (1.14.0.0.0-java)
       ffi (~> 1.0)
     memory_profiler (0.9.14)
     method_source (1.0.0)

--- a/gemfiles/jruby_9.3.9.0_redis_5.gemfile.lock
+++ b/gemfiles/jruby_9.3.9.0_redis_5.gemfile.lock
@@ -15,7 +15,7 @@ PATH
       datadog-ci (~> 0.1.0)
       debase-ruby_core_source (= 3.2.1)
       libdatadog (~> 4.0.0.1.0)
-      libddwaf (~> 1.11.0.0.0)
+      libddwaf (~> 1.14.0.0.0)
       msgpack
 
 GEM
@@ -50,7 +50,7 @@ GEM
     json-schema (2.8.1)
       addressable (>= 2.4)
     libdatadog (4.0.0.1.0)
-    libddwaf (1.11.0.0.0-java)
+    libddwaf (1.14.0.0.0-java)
       ffi (~> 1.0)
     memory_profiler (0.9.14)
     method_source (1.0.0)

--- a/gemfiles/jruby_9.3.9.0_relational_db.gemfile.lock
+++ b/gemfiles/jruby_9.3.9.0_relational_db.gemfile.lock
@@ -15,7 +15,7 @@ PATH
       datadog-ci (~> 0.1.0)
       debase-ruby_core_source (= 3.2.1)
       libdatadog (~> 4.0.0.1.0)
-      libddwaf (~> 1.11.0.0.0)
+      libddwaf (~> 1.14.0.0.0)
       msgpack
 
 GEM
@@ -78,7 +78,7 @@ GEM
     json-schema (2.8.1)
       addressable (>= 2.4)
     libdatadog (4.0.0.1.0)
-    libddwaf (1.11.0.0.0-java)
+    libddwaf (1.14.0.0.0-java)
       ffi (~> 1.0)
     makara (0.5.1)
       activerecord (>= 5.2.0)

--- a/gemfiles/jruby_9.3.9.0_resque2_redis3.gemfile.lock
+++ b/gemfiles/jruby_9.3.9.0_resque2_redis3.gemfile.lock
@@ -15,7 +15,7 @@ PATH
       datadog-ci (~> 0.1.0)
       debase-ruby_core_source (= 3.2.1)
       libdatadog (~> 4.0.0.1.0)
-      libddwaf (~> 1.11.0.0.0)
+      libddwaf (~> 1.14.0.0.0)
       msgpack
 
 GEM
@@ -49,7 +49,7 @@ GEM
     json-schema (2.8.1)
       addressable (>= 2.4)
     libdatadog (4.0.0.1.0)
-    libddwaf (1.11.0.0.0-java)
+    libddwaf (1.14.0.0.0-java)
       ffi (~> 1.0)
     memory_profiler (0.9.14)
     method_source (1.0.0)

--- a/gemfiles/jruby_9.3.9.0_resque2_redis4.gemfile.lock
+++ b/gemfiles/jruby_9.3.9.0_resque2_redis4.gemfile.lock
@@ -15,7 +15,7 @@ PATH
       datadog-ci (~> 0.1.0)
       debase-ruby_core_source (= 3.2.1)
       libdatadog (~> 4.0.0.1.0)
-      libddwaf (~> 1.11.0.0.0)
+      libddwaf (~> 1.14.0.0.0)
       msgpack
 
 GEM
@@ -49,7 +49,7 @@ GEM
     json-schema (2.8.1)
       addressable (>= 2.4)
     libdatadog (4.0.0.1.0)
-    libddwaf (1.11.0.0.0-java)
+    libddwaf (1.14.0.0.0-java)
       ffi (~> 1.0)
     memory_profiler (0.9.14)
     method_source (1.0.0)

--- a/gemfiles/jruby_9.3.9.0_sinatra.gemfile.lock
+++ b/gemfiles/jruby_9.3.9.0_sinatra.gemfile.lock
@@ -15,7 +15,7 @@ PATH
       datadog-ci (~> 0.1.0)
       debase-ruby_core_source (= 3.2.1)
       libdatadog (~> 4.0.0.1.0)
-      libddwaf (~> 1.11.0.0.0)
+      libddwaf (~> 1.14.0.0.0)
       msgpack
 
 GEM
@@ -49,7 +49,7 @@ GEM
     json-schema (2.8.1)
       addressable (>= 2.4)
     libdatadog (4.0.0.1.0)
-    libddwaf (1.11.0.0.0-java)
+    libddwaf (1.14.0.0.0-java)
       ffi (~> 1.0)
     memory_profiler (0.9.14)
     method_source (1.0.0)

--- a/gemfiles/jruby_9.4.0.0_aws.gemfile.lock
+++ b/gemfiles/jruby_9.4.0.0_aws.gemfile.lock
@@ -15,7 +15,7 @@ PATH
       datadog-ci (~> 0.1.0)
       debase-ruby_core_source (= 3.2.1)
       libdatadog (~> 4.0.0.1.0)
-      libddwaf (~> 1.11.0.0.0)
+      libddwaf (~> 1.14.0.0.0)
       msgpack
 
 GEM
@@ -1471,7 +1471,7 @@ GEM
     json-schema (2.8.1)
       addressable (>= 2.4)
     libdatadog (4.0.0.1.0)
-    libddwaf (1.11.0.0.0-java)
+    libddwaf (1.14.0.0.0-java)
       ffi (~> 1.0)
     memory_profiler (0.9.14)
     method_source (1.0.0)

--- a/gemfiles/jruby_9.4.0.0_contrib.gemfile.lock
+++ b/gemfiles/jruby_9.4.0.0_contrib.gemfile.lock
@@ -15,7 +15,7 @@ PATH
       datadog-ci (~> 0.1.0)
       debase-ruby_core_source (= 3.2.1)
       libdatadog (~> 4.0.0.1.0)
-      libddwaf (~> 1.11.0.0.0)
+      libddwaf (~> 1.14.0.0.0)
       msgpack
 
 GEM
@@ -113,7 +113,7 @@ GEM
     jsonapi-renderer (0.2.2)
     king_konf (1.0.1)
     libdatadog (4.0.0.1.0)
-    libddwaf (1.11.0.0.0-java)
+    libddwaf (1.14.0.0.0-java)
       ffi (~> 1.0)
     lograge (0.12.0)
       actionpack (>= 4)

--- a/gemfiles/jruby_9.4.0.0_contrib_old.gemfile.lock
+++ b/gemfiles/jruby_9.4.0.0_contrib_old.gemfile.lock
@@ -15,7 +15,7 @@ PATH
       datadog-ci (~> 0.1.0)
       debase-ruby_core_source (= 3.2.1)
       libdatadog (~> 4.0.0.1.0)
-      libddwaf (~> 1.11.0.0.0)
+      libddwaf (~> 1.14.0.0.0)
       msgpack
 
 GEM
@@ -63,7 +63,7 @@ GEM
     json-schema (2.8.1)
       addressable (>= 2.4)
     libdatadog (4.0.0.1.0)
-    libddwaf (1.11.0.0.0-java)
+    libddwaf (1.14.0.0.0-java)
       ffi (~> 1.0)
     memory_profiler (0.9.14)
     method_source (1.0.0)

--- a/gemfiles/jruby_9.4.0.0_core_old.gemfile.lock
+++ b/gemfiles/jruby_9.4.0.0_core_old.gemfile.lock
@@ -15,7 +15,7 @@ PATH
       datadog-ci (~> 0.1.0)
       debase-ruby_core_source (= 3.2.1)
       libdatadog (~> 4.0.0.1.0)
-      libddwaf (~> 1.11.0.0.0)
+      libddwaf (~> 1.14.0.0.0)
       msgpack
 
 GEM
@@ -49,7 +49,7 @@ GEM
     json-schema (2.8.1)
       addressable (>= 2.4)
     libdatadog (4.0.0.1.0)
-    libddwaf (1.11.0.0.0-java)
+    libddwaf (1.14.0.0.0-java)
       ffi (~> 1.0)
     memory_profiler (0.9.14)
     method_source (1.0.0)

--- a/gemfiles/jruby_9.4.0.0_http.gemfile.lock
+++ b/gemfiles/jruby_9.4.0.0_http.gemfile.lock
@@ -15,7 +15,7 @@ PATH
       datadog-ci (~> 0.1.0)
       debase-ruby_core_source (= 3.2.1)
       libdatadog (~> 4.0.0.1.0)
-      libddwaf (~> 1.11.0.0.0)
+      libddwaf (~> 1.14.0.0.0)
       msgpack
 
 GEM
@@ -81,7 +81,7 @@ GEM
     json-schema (2.8.1)
       addressable (>= 2.4)
     libdatadog (4.0.0.1.0)
-    libddwaf (1.11.0.0.0-java)
+    libddwaf (1.14.0.0.0-java)
       ffi (~> 1.0)
     memory_profiler (0.9.14)
     method_source (1.0.0)

--- a/gemfiles/jruby_9.4.0.0_rails61_mysql2.gemfile.lock
+++ b/gemfiles/jruby_9.4.0.0_rails61_mysql2.gemfile.lock
@@ -15,7 +15,7 @@ PATH
       datadog-ci (~> 0.1.0)
       debase-ruby_core_source (= 3.2.1)
       libdatadog (~> 4.0.0.1.0)
-      libddwaf (~> 1.11.0.0.0)
+      libddwaf (~> 1.14.0.0.0)
       msgpack
 
 GEM
@@ -121,7 +121,7 @@ GEM
     json-schema (2.8.1)
       addressable (>= 2.4)
     libdatadog (4.0.0.1.0)
-    libddwaf (1.11.0.0.0-java)
+    libddwaf (1.14.0.0.0-java)
       ffi (~> 1.0)
     lograge (0.12.0)
       actionpack (>= 4)

--- a/gemfiles/jruby_9.4.0.0_rails61_postgres.gemfile.lock
+++ b/gemfiles/jruby_9.4.0.0_rails61_postgres.gemfile.lock
@@ -15,7 +15,7 @@ PATH
       datadog-ci (~> 0.1.0)
       debase-ruby_core_source (= 3.2.1)
       libdatadog (~> 4.0.0.1.0)
-      libddwaf (~> 1.11.0.0.0)
+      libddwaf (~> 1.14.0.0.0)
       msgpack
 
 GEM
@@ -121,7 +121,7 @@ GEM
     json-schema (2.8.1)
       addressable (>= 2.4)
     libdatadog (4.0.0.1.0)
-    libddwaf (1.11.0.0.0-java)
+    libddwaf (1.14.0.0.0-java)
       ffi (~> 1.0)
     lograge (0.12.0)
       actionpack (>= 4)

--- a/gemfiles/jruby_9.4.0.0_rails61_postgres_redis.gemfile.lock
+++ b/gemfiles/jruby_9.4.0.0_rails61_postgres_redis.gemfile.lock
@@ -15,7 +15,7 @@ PATH
       datadog-ci (~> 0.1.0)
       debase-ruby_core_source (= 3.2.1)
       libdatadog (~> 4.0.0.1.0)
-      libddwaf (~> 1.11.0.0.0)
+      libddwaf (~> 1.14.0.0.0)
       msgpack
 
 GEM
@@ -121,7 +121,7 @@ GEM
     json-schema (2.8.1)
       addressable (>= 2.4)
     libdatadog (4.0.0.1.0)
-    libddwaf (1.11.0.0.0-java)
+    libddwaf (1.14.0.0.0-java)
       ffi (~> 1.0)
     lograge (0.12.0)
       actionpack (>= 4)

--- a/gemfiles/jruby_9.4.0.0_rails61_postgres_sidekiq.gemfile.lock
+++ b/gemfiles/jruby_9.4.0.0_rails61_postgres_sidekiq.gemfile.lock
@@ -15,7 +15,7 @@ PATH
       datadog-ci (~> 0.1.0)
       debase-ruby_core_source (= 3.2.1)
       libdatadog (~> 4.0.0.1.0)
-      libddwaf (~> 1.11.0.0.0)
+      libddwaf (~> 1.14.0.0.0)
       msgpack
 
 GEM
@@ -122,7 +122,7 @@ GEM
     json-schema (2.8.1)
       addressable (>= 2.4)
     libdatadog (4.0.0.1.0)
-    libddwaf (1.11.0.0.0-java)
+    libddwaf (1.14.0.0.0-java)
       ffi (~> 1.0)
     lograge (0.12.0)
       actionpack (>= 4)

--- a/gemfiles/jruby_9.4.0.0_rails61_semantic_logger.gemfile.lock
+++ b/gemfiles/jruby_9.4.0.0_rails61_semantic_logger.gemfile.lock
@@ -15,7 +15,7 @@ PATH
       datadog-ci (~> 0.1.0)
       debase-ruby_core_source (= 3.2.1)
       libdatadog (~> 4.0.0.1.0)
-      libddwaf (~> 1.11.0.0.0)
+      libddwaf (~> 1.14.0.0.0)
       msgpack
 
 GEM
@@ -121,7 +121,7 @@ GEM
     json-schema (2.8.1)
       addressable (>= 2.4)
     libdatadog (4.0.0.1.0)
-    libddwaf (1.11.0.0.0-java)
+    libddwaf (1.14.0.0.0-java)
       ffi (~> 1.0)
     loofah (2.19.1)
       crass (~> 1.0.2)

--- a/gemfiles/jruby_9.4.0.0_redis_3.gemfile.lock
+++ b/gemfiles/jruby_9.4.0.0_redis_3.gemfile.lock
@@ -15,7 +15,7 @@ PATH
       datadog-ci (~> 0.1.0)
       debase-ruby_core_source (= 3.2.1)
       libdatadog (~> 4.0.0.1.0)
-      libddwaf (~> 1.11.0.0.0)
+      libddwaf (~> 1.14.0.0.0)
       msgpack
 
 GEM
@@ -49,7 +49,7 @@ GEM
     json-schema (2.8.1)
       addressable (>= 2.4)
     libdatadog (4.0.0.1.0)
-    libddwaf (1.11.0.0.0-java)
+    libddwaf (1.14.0.0.0-java)
       ffi (~> 1.0)
     memory_profiler (0.9.14)
     method_source (1.0.0)

--- a/gemfiles/jruby_9.4.0.0_redis_4.gemfile.lock
+++ b/gemfiles/jruby_9.4.0.0_redis_4.gemfile.lock
@@ -15,7 +15,7 @@ PATH
       datadog-ci (~> 0.1.0)
       debase-ruby_core_source (= 3.2.1)
       libdatadog (~> 4.0.0.1.0)
-      libddwaf (~> 1.11.0.0.0)
+      libddwaf (~> 1.14.0.0.0)
       msgpack
 
 GEM
@@ -49,7 +49,7 @@ GEM
     json-schema (2.8.1)
       addressable (>= 2.4)
     libdatadog (4.0.0.1.0)
-    libddwaf (1.11.0.0.0-java)
+    libddwaf (1.14.0.0.0-java)
       ffi (~> 1.0)
     memory_profiler (0.9.14)
     method_source (1.0.0)

--- a/gemfiles/jruby_9.4.0.0_redis_5.gemfile.lock
+++ b/gemfiles/jruby_9.4.0.0_redis_5.gemfile.lock
@@ -15,7 +15,7 @@ PATH
       datadog-ci (~> 0.1.0)
       debase-ruby_core_source (= 3.2.1)
       libdatadog (~> 4.0.0.1.0)
-      libddwaf (~> 1.11.0.0.0)
+      libddwaf (~> 1.14.0.0.0)
       msgpack
 
 GEM
@@ -50,7 +50,7 @@ GEM
     json-schema (2.8.1)
       addressable (>= 2.4)
     libdatadog (4.0.0.1.0)
-    libddwaf (1.11.0.0.0-java)
+    libddwaf (1.14.0.0.0-java)
       ffi (~> 1.0)
     memory_profiler (0.9.14)
     method_source (1.0.0)

--- a/gemfiles/jruby_9.4.0.0_relational_db.gemfile.lock
+++ b/gemfiles/jruby_9.4.0.0_relational_db.gemfile.lock
@@ -15,7 +15,7 @@ PATH
       datadog-ci (~> 0.1.0)
       debase-ruby_core_source (= 3.2.1)
       libdatadog (~> 4.0.0.1.0)
-      libddwaf (~> 1.11.0.0.0)
+      libddwaf (~> 1.14.0.0.0)
       msgpack
 
 GEM
@@ -77,7 +77,7 @@ GEM
     json-schema (2.8.1)
       addressable (>= 2.4)
     libdatadog (4.0.0.1.0)
-    libddwaf (1.11.0.0.0-java)
+    libddwaf (1.14.0.0.0-java)
       ffi (~> 1.0)
     makara (0.6.0.pre)
       activerecord (>= 5.2.0)

--- a/gemfiles/jruby_9.4.0.0_resque2_redis3.gemfile.lock
+++ b/gemfiles/jruby_9.4.0.0_resque2_redis3.gemfile.lock
@@ -15,7 +15,7 @@ PATH
       datadog-ci (~> 0.1.0)
       debase-ruby_core_source (= 3.2.1)
       libdatadog (~> 4.0.0.1.0)
-      libddwaf (~> 1.11.0.0.0)
+      libddwaf (~> 1.14.0.0.0)
       msgpack
 
 GEM
@@ -49,7 +49,7 @@ GEM
     json-schema (2.8.1)
       addressable (>= 2.4)
     libdatadog (4.0.0.1.0)
-    libddwaf (1.11.0.0.0-java)
+    libddwaf (1.14.0.0.0-java)
       ffi (~> 1.0)
     memory_profiler (0.9.14)
     method_source (1.0.0)

--- a/gemfiles/jruby_9.4.0.0_resque2_redis4.gemfile.lock
+++ b/gemfiles/jruby_9.4.0.0_resque2_redis4.gemfile.lock
@@ -15,7 +15,7 @@ PATH
       datadog-ci (~> 0.1.0)
       debase-ruby_core_source (= 3.2.1)
       libdatadog (~> 4.0.0.1.0)
-      libddwaf (~> 1.11.0.0.0)
+      libddwaf (~> 1.14.0.0.0)
       msgpack
 
 GEM
@@ -50,7 +50,7 @@ GEM
     json-schema (2.8.1)
       addressable (>= 2.4)
     libdatadog (4.0.0.1.0)
-    libddwaf (1.11.0.0.0-java)
+    libddwaf (1.14.0.0.0-java)
       ffi (~> 1.0)
     memory_profiler (0.9.14)
     method_source (1.0.0)

--- a/gemfiles/jruby_9.4.0.0_sinatra.gemfile.lock
+++ b/gemfiles/jruby_9.4.0.0_sinatra.gemfile.lock
@@ -15,7 +15,7 @@ PATH
       datadog-ci (~> 0.1.0)
       debase-ruby_core_source (= 3.2.1)
       libdatadog (~> 4.0.0.1.0)
-      libddwaf (~> 1.11.0.0.0)
+      libddwaf (~> 1.14.0.0.0)
       msgpack
 
 GEM
@@ -49,7 +49,7 @@ GEM
     json-schema (2.8.1)
       addressable (>= 2.4)
     libdatadog (4.0.0.1.0)
-    libddwaf (1.11.0.0.0-java)
+    libddwaf (1.14.0.0.0-java)
       ffi (~> 1.0)
     memory_profiler (0.9.14)
     method_source (1.0.0)

--- a/gemfiles/ruby_2.1.10_aws.gemfile.lock
+++ b/gemfiles/ruby_2.1.10_aws.gemfile.lock
@@ -5,7 +5,7 @@ PATH
       datadog-ci (~> 0.1.0)
       debase-ruby_core_source (= 3.2.1)
       libdatadog (~> 4.0.0.1.0)
-      libddwaf (~> 1.11.0.0.0)
+      libddwaf (~> 1.14.0.0.0)
       msgpack
 
 GEM
@@ -50,7 +50,7 @@ GEM
     json-schema (2.8.1)
       addressable (>= 2.4)
     libdatadog (4.0.0.1.0)
-    libddwaf (1.11.0.0.0)
+    libddwaf (1.14.0.0.0)
       ffi (~> 1.0)
     memory_profiler (0.9.12)
     method_source (1.0.0)

--- a/gemfiles/ruby_2.1.10_contrib.gemfile.lock
+++ b/gemfiles/ruby_2.1.10_contrib.gemfile.lock
@@ -5,7 +5,7 @@ PATH
       datadog-ci (~> 0.1.0)
       debase-ruby_core_source (= 3.2.1)
       libdatadog (~> 4.0.0.1.0)
-      libddwaf (~> 1.11.0.0.0)
+      libddwaf (~> 1.14.0.0.0)
       msgpack
 
 GEM
@@ -77,7 +77,7 @@ GEM
     json-schema (2.8.1)
       addressable (>= 2.4)
     libdatadog (4.0.0.1.0)
-    libddwaf (1.11.0.0.0)
+    libddwaf (1.14.0.0.0)
       ffi (~> 1.0)
     memory_profiler (0.9.12)
     method_source (1.0.0)

--- a/gemfiles/ruby_2.1.10_core_old.gemfile.lock
+++ b/gemfiles/ruby_2.1.10_core_old.gemfile.lock
@@ -5,7 +5,7 @@ PATH
       datadog-ci (~> 0.1.0)
       debase-ruby_core_source (= 3.2.1)
       libdatadog (~> 4.0.0.1.0)
-      libddwaf (~> 1.11.0.0.0)
+      libddwaf (~> 1.14.0.0.0)
       msgpack
 
 GEM
@@ -39,7 +39,7 @@ GEM
     json-schema (2.8.1)
       addressable (>= 2.4)
     libdatadog (4.0.0.1.0)
-    libddwaf (1.11.0.0.0)
+    libddwaf (1.14.0.0.0)
       ffi (~> 1.0)
     memory_profiler (0.9.12)
     method_source (1.0.0)

--- a/gemfiles/ruby_2.1.10_http.gemfile.lock
+++ b/gemfiles/ruby_2.1.10_http.gemfile.lock
@@ -5,7 +5,7 @@ PATH
       datadog-ci (~> 0.1.0)
       debase-ruby_core_source (= 3.2.1)
       libdatadog (~> 4.0.0.1.0)
-      libddwaf (~> 1.11.0.0.0)
+      libddwaf (~> 1.14.0.0.0)
       msgpack
 
 GEM
@@ -64,7 +64,7 @@ GEM
     json-schema (2.8.1)
       addressable (>= 2.4)
     libdatadog (4.0.0.1.0)
-    libddwaf (1.11.0.0.0)
+    libddwaf (1.14.0.0.0)
       ffi (~> 1.0)
     memory_profiler (0.9.12)
     method_source (1.0.0)

--- a/gemfiles/ruby_2.1.10_rails32_mysql2.gemfile.lock
+++ b/gemfiles/ruby_2.1.10_rails32_mysql2.gemfile.lock
@@ -5,7 +5,7 @@ PATH
       datadog-ci (~> 0.1.0)
       debase-ruby_core_source (= 3.2.1)
       libdatadog (~> 4.0.0.1.0)
-      libddwaf (~> 1.11.0.0.0)
+      libddwaf (~> 1.14.0.0.0)
       msgpack
 
 GEM
@@ -76,7 +76,7 @@ GEM
     json-schema (2.8.1)
       addressable (>= 2.4)
     libdatadog (4.0.0.1.0)
-    libddwaf (1.11.0.0.0)
+    libddwaf (1.14.0.0.0)
       ffi (~> 1.0)
     mail (2.5.5)
       mime-types (~> 1.16)

--- a/gemfiles/ruby_2.1.10_rails32_postgres.gemfile.lock
+++ b/gemfiles/ruby_2.1.10_rails32_postgres.gemfile.lock
@@ -5,7 +5,7 @@ PATH
       datadog-ci (~> 0.1.0)
       debase-ruby_core_source (= 3.2.1)
       libdatadog (~> 4.0.0.1.0)
-      libddwaf (~> 1.11.0.0.0)
+      libddwaf (~> 1.14.0.0.0)
       msgpack
 
 GEM
@@ -72,7 +72,7 @@ GEM
     json-schema (2.8.1)
       addressable (>= 2.4)
     libdatadog (4.0.0.1.0)
-    libddwaf (1.11.0.0.0)
+    libddwaf (1.14.0.0.0)
       ffi (~> 1.0)
     mail (2.5.5)
       mime-types (~> 1.16)

--- a/gemfiles/ruby_2.1.10_rails32_postgres_redis.gemfile.lock
+++ b/gemfiles/ruby_2.1.10_rails32_postgres_redis.gemfile.lock
@@ -5,7 +5,7 @@ PATH
       datadog-ci (~> 0.1.0)
       debase-ruby_core_source (= 3.2.1)
       libdatadog (~> 4.0.0.1.0)
-      libddwaf (~> 1.11.0.0.0)
+      libddwaf (~> 1.14.0.0.0)
       msgpack
 
 GEM
@@ -72,7 +72,7 @@ GEM
     json-schema (2.8.1)
       addressable (>= 2.4)
     libdatadog (4.0.0.1.0)
-    libddwaf (1.11.0.0.0)
+    libddwaf (1.14.0.0.0)
       ffi (~> 1.0)
     mail (2.5.5)
       mime-types (~> 1.16)

--- a/gemfiles/ruby_2.1.10_rails32_postgres_sidekiq.gemfile.lock
+++ b/gemfiles/ruby_2.1.10_rails32_postgres_sidekiq.gemfile.lock
@@ -5,7 +5,7 @@ PATH
       datadog-ci (~> 0.1.0)
       debase-ruby_core_source (= 3.2.1)
       libdatadog (~> 4.0.0.1.0)
-      libddwaf (~> 1.11.0.0.0)
+      libddwaf (~> 1.14.0.0.0)
       msgpack
 
 GEM
@@ -73,7 +73,7 @@ GEM
     json-schema (2.8.1)
       addressable (>= 2.4)
     libdatadog (4.0.0.1.0)
-    libddwaf (1.11.0.0.0)
+    libddwaf (1.14.0.0.0)
       ffi (~> 1.0)
     mail (2.5.5)
       mime-types (~> 1.16)

--- a/gemfiles/ruby_2.1.10_rails4_mysql2.gemfile.lock
+++ b/gemfiles/ruby_2.1.10_rails4_mysql2.gemfile.lock
@@ -5,7 +5,7 @@ PATH
       datadog-ci (~> 0.1.0)
       debase-ruby_core_source (= 3.2.1)
       libdatadog (~> 4.0.0.1.0)
-      libddwaf (~> 1.11.0.0.0)
+      libddwaf (~> 1.14.0.0.0)
       msgpack
 
 GEM
@@ -80,7 +80,7 @@ GEM
     json-schema (2.8.1)
       addressable (>= 2.4)
     libdatadog (4.0.0.1.0)
-    libddwaf (1.11.0.0.0)
+    libddwaf (1.14.0.0.0)
       ffi (~> 1.0)
     lograge (0.11.2)
       actionpack (>= 4)

--- a/gemfiles/ruby_2.1.10_rails4_postgres.gemfile.lock
+++ b/gemfiles/ruby_2.1.10_rails4_postgres.gemfile.lock
@@ -5,7 +5,7 @@ PATH
       datadog-ci (~> 0.1.0)
       debase-ruby_core_source (= 3.2.1)
       libdatadog (~> 4.0.0.1.0)
-      libddwaf (~> 1.11.0.0.0)
+      libddwaf (~> 1.14.0.0.0)
       msgpack
 
 GEM
@@ -80,7 +80,7 @@ GEM
     json-schema (2.8.1)
       addressable (>= 2.4)
     libdatadog (4.0.0.1.0)
-    libddwaf (1.11.0.0.0)
+    libddwaf (1.14.0.0.0)
       ffi (~> 1.0)
     lograge (0.11.2)
       actionpack (>= 4)

--- a/gemfiles/ruby_2.1.10_rails4_postgres_redis.gemfile.lock
+++ b/gemfiles/ruby_2.1.10_rails4_postgres_redis.gemfile.lock
@@ -5,7 +5,7 @@ PATH
       datadog-ci (~> 0.1.0)
       debase-ruby_core_source (= 3.2.1)
       libdatadog (~> 4.0.0.1.0)
-      libddwaf (~> 1.11.0.0.0)
+      libddwaf (~> 1.14.0.0.0)
       msgpack
 
 GEM
@@ -80,7 +80,7 @@ GEM
     json-schema (2.8.1)
       addressable (>= 2.4)
     libdatadog (4.0.0.1.0)
-    libddwaf (1.11.0.0.0)
+    libddwaf (1.14.0.0.0)
       ffi (~> 1.0)
     lograge (0.11.2)
       actionpack (>= 4)

--- a/gemfiles/ruby_2.1.10_rails4_semantic_logger.gemfile.lock
+++ b/gemfiles/ruby_2.1.10_rails4_semantic_logger.gemfile.lock
@@ -5,7 +5,7 @@ PATH
       datadog-ci (~> 0.1.0)
       debase-ruby_core_source (= 3.2.1)
       libdatadog (~> 4.0.0.1.0)
-      libddwaf (~> 1.11.0.0.0)
+      libddwaf (~> 1.14.0.0.0)
       msgpack
 
 GEM
@@ -80,7 +80,7 @@ GEM
     json-schema (2.8.1)
       addressable (>= 2.4)
     libdatadog (4.0.0.1.0)
-    libddwaf (1.11.0.0.0)
+    libddwaf (1.14.0.0.0)
       ffi (~> 1.0)
     loofah (2.19.1)
       crass (~> 1.0.2)

--- a/gemfiles/ruby_2.1.10_redis_3.gemfile.lock
+++ b/gemfiles/ruby_2.1.10_redis_3.gemfile.lock
@@ -5,7 +5,7 @@ PATH
       datadog-ci (~> 0.1.0)
       debase-ruby_core_source (= 3.2.1)
       libdatadog (~> 4.0.0.1.0)
-      libddwaf (~> 1.11.0.0.0)
+      libddwaf (~> 1.14.0.0.0)
       msgpack
 
 GEM
@@ -39,7 +39,7 @@ GEM
     json-schema (2.8.1)
       addressable (>= 2.4)
     libdatadog (4.0.0.1.0)
-    libddwaf (1.11.0.0.0)
+    libddwaf (1.14.0.0.0)
       ffi (~> 1.0)
     memory_profiler (0.9.12)
     method_source (1.0.0)

--- a/gemfiles/ruby_2.1.10_relational_db.gemfile.lock
+++ b/gemfiles/ruby_2.1.10_relational_db.gemfile.lock
@@ -5,7 +5,7 @@ PATH
       datadog-ci (~> 0.1.0)
       debase-ruby_core_source (= 3.2.1)
       libdatadog (~> 4.0.0.1.0)
-      libddwaf (~> 1.11.0.0.0)
+      libddwaf (~> 1.14.0.0.0)
       msgpack
 
 GEM
@@ -61,7 +61,7 @@ GEM
     json-schema (2.8.1)
       addressable (>= 2.4)
     libdatadog (4.0.0.1.0)
-    libddwaf (1.11.0.0.0)
+    libddwaf (1.14.0.0.0)
       ffi (~> 1.0)
     makara (0.4.1)
       activerecord (>= 3.0.0)

--- a/gemfiles/ruby_2.1.10_sinatra.gemfile.lock
+++ b/gemfiles/ruby_2.1.10_sinatra.gemfile.lock
@@ -5,7 +5,7 @@ PATH
       datadog-ci (~> 0.1.0)
       debase-ruby_core_source (= 3.2.1)
       libdatadog (~> 4.0.0.1.0)
-      libddwaf (~> 1.11.0.0.0)
+      libddwaf (~> 1.14.0.0.0)
       msgpack
 
 GEM
@@ -39,7 +39,7 @@ GEM
     json-schema (2.8.1)
       addressable (>= 2.4)
     libdatadog (4.0.0.1.0)
-    libddwaf (1.11.0.0.0)
+    libddwaf (1.14.0.0.0)
       ffi (~> 1.0)
     memory_profiler (0.9.12)
     method_source (1.0.0)

--- a/gemfiles/ruby_2.2.10_aws.gemfile.lock
+++ b/gemfiles/ruby_2.2.10_aws.gemfile.lock
@@ -5,7 +5,7 @@ PATH
       datadog-ci (~> 0.1.0)
       debase-ruby_core_source (= 3.2.1)
       libdatadog (~> 4.0.0.1.0)
-      libddwaf (~> 1.11.0.0.0)
+      libddwaf (~> 1.14.0.0.0)
       msgpack
 
 GEM
@@ -1161,7 +1161,7 @@ GEM
     json-schema (2.8.1)
       addressable (>= 2.4)
     libdatadog (4.0.0.1.0)
-    libddwaf (1.11.0.0.0)
+    libddwaf (1.14.0.0.0)
       ffi (~> 1.0)
     memory_profiler (0.9.12)
     method_source (1.0.0)

--- a/gemfiles/ruby_2.2.10_contrib.gemfile.lock
+++ b/gemfiles/ruby_2.2.10_contrib.gemfile.lock
@@ -5,7 +5,7 @@ PATH
       datadog-ci (~> 0.1.0)
       debase-ruby_core_source (= 3.2.1)
       libdatadog (~> 4.0.0.1.0)
-      libddwaf (~> 1.11.0.0.0)
+      libddwaf (~> 1.14.0.0.0)
       msgpack
 
 GEM
@@ -109,7 +109,7 @@ GEM
     jsonapi-renderer (0.2.2)
     king_konf (1.0.1)
     libdatadog (4.0.0.1.0)
-    libddwaf (1.11.0.0.0)
+    libddwaf (1.14.0.0.0)
       ffi (~> 1.0)
     lograge (0.11.2)
       actionpack (>= 4)

--- a/gemfiles/ruby_2.2.10_core_old.gemfile.lock
+++ b/gemfiles/ruby_2.2.10_core_old.gemfile.lock
@@ -5,7 +5,7 @@ PATH
       datadog-ci (~> 0.1.0)
       debase-ruby_core_source (= 3.2.1)
       libdatadog (~> 4.0.0.1.0)
-      libddwaf (~> 1.11.0.0.0)
+      libddwaf (~> 1.14.0.0.0)
       msgpack
 
 GEM
@@ -39,7 +39,7 @@ GEM
     json-schema (2.8.1)
       addressable (>= 2.4)
     libdatadog (4.0.0.1.0)
-    libddwaf (1.11.0.0.0)
+    libddwaf (1.14.0.0.0)
       ffi (~> 1.0)
     memory_profiler (0.9.12)
     method_source (1.0.0)

--- a/gemfiles/ruby_2.2.10_http.gemfile.lock
+++ b/gemfiles/ruby_2.2.10_http.gemfile.lock
@@ -5,7 +5,7 @@ PATH
       datadog-ci (~> 0.1.0)
       debase-ruby_core_source (= 3.2.1)
       libdatadog (~> 4.0.0.1.0)
-      libddwaf (~> 1.11.0.0.0)
+      libddwaf (~> 1.14.0.0.0)
       msgpack
 
 GEM
@@ -64,7 +64,7 @@ GEM
     json-schema (2.8.1)
       addressable (>= 2.4)
     libdatadog (4.0.0.1.0)
-    libddwaf (1.11.0.0.0)
+    libddwaf (1.14.0.0.0)
       ffi (~> 1.0)
     memory_profiler (0.9.12)
     method_source (1.0.0)

--- a/gemfiles/ruby_2.2.10_rails32_mysql2.gemfile.lock
+++ b/gemfiles/ruby_2.2.10_rails32_mysql2.gemfile.lock
@@ -5,7 +5,7 @@ PATH
       datadog-ci (~> 0.1.0)
       debase-ruby_core_source (= 3.2.1)
       libdatadog (~> 4.0.0.1.0)
-      libddwaf (~> 1.11.0.0.0)
+      libddwaf (~> 1.14.0.0.0)
       msgpack
 
 GEM
@@ -76,7 +76,7 @@ GEM
     json-schema (2.8.1)
       addressable (>= 2.4)
     libdatadog (4.0.0.1.0)
-    libddwaf (1.11.0.0.0)
+    libddwaf (1.14.0.0.0)
       ffi (~> 1.0)
     mail (2.5.5)
       mime-types (~> 1.16)

--- a/gemfiles/ruby_2.2.10_rails32_postgres.gemfile.lock
+++ b/gemfiles/ruby_2.2.10_rails32_postgres.gemfile.lock
@@ -5,7 +5,7 @@ PATH
       datadog-ci (~> 0.1.0)
       debase-ruby_core_source (= 3.2.1)
       libdatadog (~> 4.0.0.1.0)
-      libddwaf (~> 1.11.0.0.0)
+      libddwaf (~> 1.14.0.0.0)
       msgpack
 
 GEM
@@ -72,7 +72,7 @@ GEM
     json-schema (2.8.1)
       addressable (>= 2.4)
     libdatadog (4.0.0.1.0)
-    libddwaf (1.11.0.0.0)
+    libddwaf (1.14.0.0.0)
       ffi (~> 1.0)
     mail (2.5.5)
       mime-types (~> 1.16)

--- a/gemfiles/ruby_2.2.10_rails32_postgres_redis.gemfile.lock
+++ b/gemfiles/ruby_2.2.10_rails32_postgres_redis.gemfile.lock
@@ -5,7 +5,7 @@ PATH
       datadog-ci (~> 0.1.0)
       debase-ruby_core_source (= 3.2.1)
       libdatadog (~> 4.0.0.1.0)
-      libddwaf (~> 1.11.0.0.0)
+      libddwaf (~> 1.14.0.0.0)
       msgpack
 
 GEM
@@ -72,7 +72,7 @@ GEM
     json-schema (2.8.1)
       addressable (>= 2.4)
     libdatadog (4.0.0.1.0)
-    libddwaf (1.11.0.0.0)
+    libddwaf (1.14.0.0.0)
       ffi (~> 1.0)
     mail (2.5.5)
       mime-types (~> 1.16)

--- a/gemfiles/ruby_2.2.10_rails32_postgres_sidekiq.gemfile.lock
+++ b/gemfiles/ruby_2.2.10_rails32_postgres_sidekiq.gemfile.lock
@@ -5,7 +5,7 @@ PATH
       datadog-ci (~> 0.1.0)
       debase-ruby_core_source (= 3.2.1)
       libdatadog (~> 4.0.0.1.0)
-      libddwaf (~> 1.11.0.0.0)
+      libddwaf (~> 1.14.0.0.0)
       msgpack
 
 GEM
@@ -73,7 +73,7 @@ GEM
     json-schema (2.8.1)
       addressable (>= 2.4)
     libdatadog (4.0.0.1.0)
-    libddwaf (1.11.0.0.0)
+    libddwaf (1.14.0.0.0)
       ffi (~> 1.0)
     mail (2.5.5)
       mime-types (~> 1.16)

--- a/gemfiles/ruby_2.2.10_rails4_mysql2.gemfile.lock
+++ b/gemfiles/ruby_2.2.10_rails4_mysql2.gemfile.lock
@@ -5,7 +5,7 @@ PATH
       datadog-ci (~> 0.1.0)
       debase-ruby_core_source (= 3.2.1)
       libdatadog (~> 4.0.0.1.0)
-      libddwaf (~> 1.11.0.0.0)
+      libddwaf (~> 1.14.0.0.0)
       msgpack
 
 GEM
@@ -80,7 +80,7 @@ GEM
     json-schema (2.8.1)
       addressable (>= 2.4)
     libdatadog (4.0.0.1.0)
-    libddwaf (1.11.0.0.0)
+    libddwaf (1.14.0.0.0)
       ffi (~> 1.0)
     lograge (0.11.2)
       actionpack (>= 4)

--- a/gemfiles/ruby_2.2.10_rails4_postgres.gemfile.lock
+++ b/gemfiles/ruby_2.2.10_rails4_postgres.gemfile.lock
@@ -5,7 +5,7 @@ PATH
       datadog-ci (~> 0.1.0)
       debase-ruby_core_source (= 3.2.1)
       libdatadog (~> 4.0.0.1.0)
-      libddwaf (~> 1.11.0.0.0)
+      libddwaf (~> 1.14.0.0.0)
       msgpack
 
 GEM
@@ -80,7 +80,7 @@ GEM
     json-schema (2.8.1)
       addressable (>= 2.4)
     libdatadog (4.0.0.1.0)
-    libddwaf (1.11.0.0.0)
+    libddwaf (1.14.0.0.0)
       ffi (~> 1.0)
     lograge (0.11.2)
       actionpack (>= 4)

--- a/gemfiles/ruby_2.2.10_rails4_postgres_redis.gemfile.lock
+++ b/gemfiles/ruby_2.2.10_rails4_postgres_redis.gemfile.lock
@@ -5,7 +5,7 @@ PATH
       datadog-ci (~> 0.1.0)
       debase-ruby_core_source (= 3.2.1)
       libdatadog (~> 4.0.0.1.0)
-      libddwaf (~> 1.11.0.0.0)
+      libddwaf (~> 1.14.0.0.0)
       msgpack
 
 GEM
@@ -80,7 +80,7 @@ GEM
     json-schema (2.8.1)
       addressable (>= 2.4)
     libdatadog (4.0.0.1.0)
-    libddwaf (1.11.0.0.0)
+    libddwaf (1.14.0.0.0)
       ffi (~> 1.0)
     lograge (0.11.2)
       actionpack (>= 4)

--- a/gemfiles/ruby_2.2.10_rails4_postgres_sidekiq.gemfile.lock
+++ b/gemfiles/ruby_2.2.10_rails4_postgres_sidekiq.gemfile.lock
@@ -5,7 +5,7 @@ PATH
       datadog-ci (~> 0.1.0)
       debase-ruby_core_source (= 3.2.1)
       libdatadog (~> 4.0.0.1.0)
-      libddwaf (~> 1.11.0.0.0)
+      libddwaf (~> 1.14.0.0.0)
       msgpack
 
 GEM
@@ -81,7 +81,7 @@ GEM
     json-schema (2.8.1)
       addressable (>= 2.4)
     libdatadog (4.0.0.1.0)
-    libddwaf (1.11.0.0.0)
+    libddwaf (1.14.0.0.0)
       ffi (~> 1.0)
     lograge (0.11.2)
       actionpack (>= 4)

--- a/gemfiles/ruby_2.2.10_rails4_semantic_logger.gemfile.lock
+++ b/gemfiles/ruby_2.2.10_rails4_semantic_logger.gemfile.lock
@@ -5,7 +5,7 @@ PATH
       datadog-ci (~> 0.1.0)
       debase-ruby_core_source (= 3.2.1)
       libdatadog (~> 4.0.0.1.0)
-      libddwaf (~> 1.11.0.0.0)
+      libddwaf (~> 1.14.0.0.0)
       msgpack
 
 GEM
@@ -80,7 +80,7 @@ GEM
     json-schema (2.8.1)
       addressable (>= 2.4)
     libdatadog (4.0.0.1.0)
-    libddwaf (1.11.0.0.0)
+    libddwaf (1.14.0.0.0)
       ffi (~> 1.0)
     loofah (2.19.1)
       crass (~> 1.0.2)

--- a/gemfiles/ruby_2.2.10_rails5_mysql2.gemfile.lock
+++ b/gemfiles/ruby_2.2.10_rails5_mysql2.gemfile.lock
@@ -5,7 +5,7 @@ PATH
       datadog-ci (~> 0.1.0)
       debase-ruby_core_source (= 3.2.1)
       libdatadog (~> 4.0.0.1.0)
-      libddwaf (~> 1.11.0.0.0)
+      libddwaf (~> 1.14.0.0.0)
       msgpack
 
 GEM
@@ -87,7 +87,7 @@ GEM
     json-schema (2.8.1)
       addressable (>= 2.4)
     libdatadog (4.0.0.1.0)
-    libddwaf (1.11.0.0.0)
+    libddwaf (1.14.0.0.0)
       ffi (~> 1.0)
     lograge (0.11.2)
       actionpack (>= 4)

--- a/gemfiles/ruby_2.2.10_rails5_postgres.gemfile.lock
+++ b/gemfiles/ruby_2.2.10_rails5_postgres.gemfile.lock
@@ -5,7 +5,7 @@ PATH
       datadog-ci (~> 0.1.0)
       debase-ruby_core_source (= 3.2.1)
       libdatadog (~> 4.0.0.1.0)
-      libddwaf (~> 1.11.0.0.0)
+      libddwaf (~> 1.14.0.0.0)
       msgpack
 
 GEM
@@ -87,7 +87,7 @@ GEM
     json-schema (2.8.1)
       addressable (>= 2.4)
     libdatadog (4.0.0.1.0)
-    libddwaf (1.11.0.0.0)
+    libddwaf (1.14.0.0.0)
       ffi (~> 1.0)
     lograge (0.11.2)
       actionpack (>= 4)

--- a/gemfiles/ruby_2.2.10_rails5_postgres_redis.gemfile.lock
+++ b/gemfiles/ruby_2.2.10_rails5_postgres_redis.gemfile.lock
@@ -5,7 +5,7 @@ PATH
       datadog-ci (~> 0.1.0)
       debase-ruby_core_source (= 3.2.1)
       libdatadog (~> 4.0.0.1.0)
-      libddwaf (~> 1.11.0.0.0)
+      libddwaf (~> 1.14.0.0.0)
       msgpack
 
 GEM
@@ -87,7 +87,7 @@ GEM
     json-schema (2.8.1)
       addressable (>= 2.4)
     libdatadog (4.0.0.1.0)
-    libddwaf (1.11.0.0.0)
+    libddwaf (1.14.0.0.0)
       ffi (~> 1.0)
     lograge (0.11.2)
       actionpack (>= 4)

--- a/gemfiles/ruby_2.2.10_rails5_postgres_redis_activesupport.gemfile.lock
+++ b/gemfiles/ruby_2.2.10_rails5_postgres_redis_activesupport.gemfile.lock
@@ -5,7 +5,7 @@ PATH
       datadog-ci (~> 0.1.0)
       debase-ruby_core_source (= 3.2.1)
       libdatadog (~> 4.0.0.1.0)
-      libddwaf (~> 1.11.0.0.0)
+      libddwaf (~> 1.14.0.0.0)
       msgpack
 
 GEM
@@ -87,7 +87,7 @@ GEM
     json-schema (2.8.1)
       addressable (>= 2.4)
     libdatadog (4.0.0.1.0)
-    libddwaf (1.11.0.0.0)
+    libddwaf (1.14.0.0.0)
       ffi (~> 1.0)
     lograge (0.11.2)
       actionpack (>= 4)

--- a/gemfiles/ruby_2.2.10_rails5_postgres_sidekiq.gemfile.lock
+++ b/gemfiles/ruby_2.2.10_rails5_postgres_sidekiq.gemfile.lock
@@ -5,7 +5,7 @@ PATH
       datadog-ci (~> 0.1.0)
       debase-ruby_core_source (= 3.2.1)
       libdatadog (~> 4.0.0.1.0)
-      libddwaf (~> 1.11.0.0.0)
+      libddwaf (~> 1.14.0.0.0)
       msgpack
 
 GEM
@@ -88,7 +88,7 @@ GEM
     json-schema (2.8.1)
       addressable (>= 2.4)
     libdatadog (4.0.0.1.0)
-    libddwaf (1.11.0.0.0)
+    libddwaf (1.14.0.0.0)
       ffi (~> 1.0)
     lograge (0.11.2)
       actionpack (>= 4)

--- a/gemfiles/ruby_2.2.10_rails5_semantic_logger.gemfile.lock
+++ b/gemfiles/ruby_2.2.10_rails5_semantic_logger.gemfile.lock
@@ -5,7 +5,7 @@ PATH
       datadog-ci (~> 0.1.0)
       debase-ruby_core_source (= 3.2.1)
       libdatadog (~> 4.0.0.1.0)
-      libddwaf (~> 1.11.0.0.0)
+      libddwaf (~> 1.14.0.0.0)
       msgpack
 
 GEM
@@ -87,7 +87,7 @@ GEM
     json-schema (2.8.1)
       addressable (>= 2.4)
     libdatadog (4.0.0.1.0)
-    libddwaf (1.11.0.0.0)
+    libddwaf (1.14.0.0.0)
       ffi (~> 1.0)
     loofah (2.19.1)
       crass (~> 1.0.2)

--- a/gemfiles/ruby_2.2.10_redis_3.gemfile.lock
+++ b/gemfiles/ruby_2.2.10_redis_3.gemfile.lock
@@ -5,7 +5,7 @@ PATH
       datadog-ci (~> 0.1.0)
       debase-ruby_core_source (= 3.2.1)
       libdatadog (~> 4.0.0.1.0)
-      libddwaf (~> 1.11.0.0.0)
+      libddwaf (~> 1.14.0.0.0)
       msgpack
 
 GEM
@@ -39,7 +39,7 @@ GEM
     json-schema (2.8.1)
       addressable (>= 2.4)
     libdatadog (4.0.0.1.0)
-    libddwaf (1.11.0.0.0)
+    libddwaf (1.14.0.0.0)
       ffi (~> 1.0)
     memory_profiler (0.9.12)
     method_source (1.0.0)

--- a/gemfiles/ruby_2.2.10_relational_db.gemfile.lock
+++ b/gemfiles/ruby_2.2.10_relational_db.gemfile.lock
@@ -5,7 +5,7 @@ PATH
       datadog-ci (~> 0.1.0)
       debase-ruby_core_source (= 3.2.1)
       libdatadog (~> 4.0.0.1.0)
-      libddwaf (~> 1.11.0.0.0)
+      libddwaf (~> 1.14.0.0.0)
       msgpack
 
 GEM
@@ -57,7 +57,7 @@ GEM
     json-schema (2.8.1)
       addressable (>= 2.4)
     libdatadog (4.0.0.1.0)
-    libddwaf (1.11.0.0.0)
+    libddwaf (1.14.0.0.0)
       ffi (~> 1.0)
     makara (0.4.1)
       activerecord (>= 3.0.0)

--- a/gemfiles/ruby_2.2.10_sinatra.gemfile.lock
+++ b/gemfiles/ruby_2.2.10_sinatra.gemfile.lock
@@ -5,7 +5,7 @@ PATH
       datadog-ci (~> 0.1.0)
       debase-ruby_core_source (= 3.2.1)
       libdatadog (~> 4.0.0.1.0)
-      libddwaf (~> 1.11.0.0.0)
+      libddwaf (~> 1.14.0.0.0)
       msgpack
 
 GEM
@@ -39,7 +39,7 @@ GEM
     json-schema (2.8.1)
       addressable (>= 2.4)
     libdatadog (4.0.0.1.0)
-    libddwaf (1.11.0.0.0)
+    libddwaf (1.14.0.0.0)
       ffi (~> 1.0)
     memory_profiler (0.9.12)
     method_source (1.0.0)

--- a/gemfiles/ruby_2.3.8_activerecord_3.gemfile.lock
+++ b/gemfiles/ruby_2.3.8_activerecord_3.gemfile.lock
@@ -5,7 +5,7 @@ PATH
       datadog-ci (~> 0.1.0)
       debase-ruby_core_source (= 3.2.1)
       libdatadog (~> 4.0.0.1.0)
-      libddwaf (~> 1.11.0.0.0)
+      libddwaf (~> 1.14.0.0.0)
       msgpack
 
 GEM
@@ -56,7 +56,7 @@ GEM
     json-schema (2.8.1)
       addressable (>= 2.4)
     libdatadog (4.0.0.1.0)
-    libddwaf (1.11.0.0.0)
+    libddwaf (1.14.0.0.0)
       ffi (~> 1.0)
     makara (0.3.10)
       activerecord (>= 3.0.0)

--- a/gemfiles/ruby_2.3.8_aws.gemfile.lock
+++ b/gemfiles/ruby_2.3.8_aws.gemfile.lock
@@ -5,7 +5,7 @@ PATH
       datadog-ci (~> 0.1.0)
       debase-ruby_core_source (= 3.2.1)
       libdatadog (~> 4.0.0.1.0)
-      libddwaf (~> 1.11.0.0.0)
+      libddwaf (~> 1.14.0.0.0)
       msgpack
 
 GEM
@@ -1460,7 +1460,7 @@ GEM
     json-schema (2.8.1)
       addressable (>= 2.4)
     libdatadog (4.0.0.1.0)
-    libddwaf (1.11.0.0.0)
+    libddwaf (1.14.0.0.0)
       ffi (~> 1.0)
     memory_profiler (0.9.14)
     method_source (1.0.0)

--- a/gemfiles/ruby_2.3.8_contrib.gemfile.lock
+++ b/gemfiles/ruby_2.3.8_contrib.gemfile.lock
@@ -5,7 +5,7 @@ PATH
       datadog-ci (~> 0.1.0)
       debase-ruby_core_source (= 3.2.1)
       libdatadog (~> 4.0.0.1.0)
-      libddwaf (~> 1.11.0.0.0)
+      libddwaf (~> 1.14.0.0.0)
       msgpack
 
 GEM
@@ -106,7 +106,7 @@ GEM
     jsonapi-renderer (0.2.2)
     king_konf (1.0.1)
     libdatadog (4.0.0.1.0)
-    libddwaf (1.11.0.0.0)
+    libddwaf (1.14.0.0.0)
       ffi (~> 1.0)
     lograge (0.11.2)
       actionpack (>= 4)

--- a/gemfiles/ruby_2.3.8_contrib_old.gemfile.lock
+++ b/gemfiles/ruby_2.3.8_contrib_old.gemfile.lock
@@ -5,7 +5,7 @@ PATH
       datadog-ci (~> 0.1.0)
       debase-ruby_core_source (= 3.2.1)
       libdatadog (~> 4.0.0.1.0)
-      libddwaf (~> 1.11.0.0.0)
+      libddwaf (~> 1.14.0.0.0)
       msgpack
 
 GEM
@@ -51,7 +51,7 @@ GEM
     json-schema (2.8.1)
       addressable (>= 2.4)
     libdatadog (4.0.0.1.0)
-    libddwaf (1.11.0.0.0)
+    libddwaf (1.14.0.0.0)
       ffi (~> 1.0)
     memory_profiler (0.9.14)
     method_source (1.0.0)

--- a/gemfiles/ruby_2.3.8_core_old.gemfile.lock
+++ b/gemfiles/ruby_2.3.8_core_old.gemfile.lock
@@ -5,7 +5,7 @@ PATH
       datadog-ci (~> 0.1.0)
       debase-ruby_core_source (= 3.2.1)
       libdatadog (~> 4.0.0.1.0)
-      libddwaf (~> 1.11.0.0.0)
+      libddwaf (~> 1.14.0.0.0)
       msgpack
 
 GEM
@@ -39,7 +39,7 @@ GEM
     json-schema (2.8.1)
       addressable (>= 2.4)
     libdatadog (4.0.0.1.0)
-    libddwaf (1.11.0.0.0)
+    libddwaf (1.14.0.0.0)
       ffi (~> 1.0)
     memory_profiler (0.9.14)
     method_source (1.0.0)

--- a/gemfiles/ruby_2.3.8_hanami_1.gemfile.lock
+++ b/gemfiles/ruby_2.3.8_hanami_1.gemfile.lock
@@ -5,7 +5,7 @@ PATH
       datadog-ci (~> 0.1.0)
       debase-ruby_core_source (= 3.2.1)
       libdatadog (~> 4.0.0.1.0)
-      libddwaf (~> 1.11.0.0.0)
+      libddwaf (~> 1.14.0.0.0)
       msgpack
 
 GEM
@@ -114,7 +114,7 @@ GEM
     json-schema (2.8.1)
       addressable (>= 2.4)
     libdatadog (4.0.0.1.0)
-    libddwaf (1.11.0.0.0)
+    libddwaf (1.14.0.0.0)
       ffi (~> 1.0)
     mail (2.7.1)
       mini_mime (>= 0.1.1)

--- a/gemfiles/ruby_2.3.8_http.gemfile.lock
+++ b/gemfiles/ruby_2.3.8_http.gemfile.lock
@@ -5,7 +5,7 @@ PATH
       datadog-ci (~> 0.1.0)
       debase-ruby_core_source (= 3.2.1)
       libdatadog (~> 4.0.0.1.0)
-      libddwaf (~> 1.11.0.0.0)
+      libddwaf (~> 1.14.0.0.0)
       msgpack
 
 GEM
@@ -60,7 +60,7 @@ GEM
     json-schema (2.8.1)
       addressable (>= 2.4)
     libdatadog (4.0.0.1.0)
-    libddwaf (1.11.0.0.0)
+    libddwaf (1.14.0.0.0)
       ffi (~> 1.0)
     memory_profiler (0.9.14)
     method_source (1.0.0)

--- a/gemfiles/ruby_2.3.8_rails32_mysql2.gemfile.lock
+++ b/gemfiles/ruby_2.3.8_rails32_mysql2.gemfile.lock
@@ -5,7 +5,7 @@ PATH
       datadog-ci (~> 0.1.0)
       debase-ruby_core_source (= 3.2.1)
       libdatadog (~> 4.0.0.1.0)
-      libddwaf (~> 1.11.0.0.0)
+      libddwaf (~> 1.14.0.0.0)
       msgpack
 
 GEM
@@ -76,7 +76,7 @@ GEM
     json-schema (2.8.1)
       addressable (>= 2.4)
     libdatadog (4.0.0.1.0)
-    libddwaf (1.11.0.0.0)
+    libddwaf (1.14.0.0.0)
       ffi (~> 1.0)
     mail (2.5.5)
       mime-types (~> 1.16)

--- a/gemfiles/ruby_2.3.8_rails32_postgres.gemfile.lock
+++ b/gemfiles/ruby_2.3.8_rails32_postgres.gemfile.lock
@@ -5,7 +5,7 @@ PATH
       datadog-ci (~> 0.1.0)
       debase-ruby_core_source (= 3.2.1)
       libdatadog (~> 4.0.0.1.0)
-      libddwaf (~> 1.11.0.0.0)
+      libddwaf (~> 1.14.0.0.0)
       msgpack
 
 GEM
@@ -72,7 +72,7 @@ GEM
     json-schema (2.8.1)
       addressable (>= 2.4)
     libdatadog (4.0.0.1.0)
-    libddwaf (1.11.0.0.0)
+    libddwaf (1.14.0.0.0)
       ffi (~> 1.0)
     mail (2.5.5)
       mime-types (~> 1.16)

--- a/gemfiles/ruby_2.3.8_rails32_postgres_redis.gemfile.lock
+++ b/gemfiles/ruby_2.3.8_rails32_postgres_redis.gemfile.lock
@@ -5,7 +5,7 @@ PATH
       datadog-ci (~> 0.1.0)
       debase-ruby_core_source (= 3.2.1)
       libdatadog (~> 4.0.0.1.0)
-      libddwaf (~> 1.11.0.0.0)
+      libddwaf (~> 1.14.0.0.0)
       msgpack
 
 GEM
@@ -72,7 +72,7 @@ GEM
     json-schema (2.8.1)
       addressable (>= 2.4)
     libdatadog (4.0.0.1.0)
-    libddwaf (1.11.0.0.0)
+    libddwaf (1.14.0.0.0)
       ffi (~> 1.0)
     mail (2.5.5)
       mime-types (~> 1.16)

--- a/gemfiles/ruby_2.3.8_rails32_postgres_sidekiq.gemfile.lock
+++ b/gemfiles/ruby_2.3.8_rails32_postgres_sidekiq.gemfile.lock
@@ -5,7 +5,7 @@ PATH
       datadog-ci (~> 0.1.0)
       debase-ruby_core_source (= 3.2.1)
       libdatadog (~> 4.0.0.1.0)
-      libddwaf (~> 1.11.0.0.0)
+      libddwaf (~> 1.14.0.0.0)
       msgpack
 
 GEM
@@ -73,7 +73,7 @@ GEM
     json-schema (2.8.1)
       addressable (>= 2.4)
     libdatadog (4.0.0.1.0)
-    libddwaf (1.11.0.0.0)
+    libddwaf (1.14.0.0.0)
       ffi (~> 1.0)
     mail (2.5.5)
       mime-types (~> 1.16)

--- a/gemfiles/ruby_2.3.8_rails4_mysql2.gemfile.lock
+++ b/gemfiles/ruby_2.3.8_rails4_mysql2.gemfile.lock
@@ -5,7 +5,7 @@ PATH
       datadog-ci (~> 0.1.0)
       debase-ruby_core_source (= 3.2.1)
       libdatadog (~> 4.0.0.1.0)
-      libddwaf (~> 1.11.0.0.0)
+      libddwaf (~> 1.14.0.0.0)
       msgpack
 
 GEM
@@ -80,7 +80,7 @@ GEM
     json-schema (2.8.1)
       addressable (>= 2.4)
     libdatadog (4.0.0.1.0)
-    libddwaf (1.11.0.0.0)
+    libddwaf (1.14.0.0.0)
       ffi (~> 1.0)
     lograge (0.11.2)
       actionpack (>= 4)

--- a/gemfiles/ruby_2.3.8_rails4_postgres.gemfile.lock
+++ b/gemfiles/ruby_2.3.8_rails4_postgres.gemfile.lock
@@ -5,7 +5,7 @@ PATH
       datadog-ci (~> 0.1.0)
       debase-ruby_core_source (= 3.2.1)
       libdatadog (~> 4.0.0.1.0)
-      libddwaf (~> 1.11.0.0.0)
+      libddwaf (~> 1.14.0.0.0)
       msgpack
 
 GEM
@@ -80,7 +80,7 @@ GEM
     json-schema (2.8.1)
       addressable (>= 2.4)
     libdatadog (4.0.0.1.0)
-    libddwaf (1.11.0.0.0)
+    libddwaf (1.14.0.0.0)
       ffi (~> 1.0)
     lograge (0.11.2)
       actionpack (>= 4)

--- a/gemfiles/ruby_2.3.8_rails4_postgres_redis.gemfile.lock
+++ b/gemfiles/ruby_2.3.8_rails4_postgres_redis.gemfile.lock
@@ -5,7 +5,7 @@ PATH
       datadog-ci (~> 0.1.0)
       debase-ruby_core_source (= 3.2.1)
       libdatadog (~> 4.0.0.1.0)
-      libddwaf (~> 1.11.0.0.0)
+      libddwaf (~> 1.14.0.0.0)
       msgpack
 
 GEM
@@ -80,7 +80,7 @@ GEM
     json-schema (2.8.1)
       addressable (>= 2.4)
     libdatadog (4.0.0.1.0)
-    libddwaf (1.11.0.0.0)
+    libddwaf (1.14.0.0.0)
       ffi (~> 1.0)
     lograge (0.11.2)
       actionpack (>= 4)

--- a/gemfiles/ruby_2.3.8_rails4_postgres_sidekiq.gemfile.lock
+++ b/gemfiles/ruby_2.3.8_rails4_postgres_sidekiq.gemfile.lock
@@ -5,7 +5,7 @@ PATH
       datadog-ci (~> 0.1.0)
       debase-ruby_core_source (= 3.2.1)
       libdatadog (~> 4.0.0.1.0)
-      libddwaf (~> 1.11.0.0.0)
+      libddwaf (~> 1.14.0.0.0)
       msgpack
 
 GEM
@@ -81,7 +81,7 @@ GEM
     json-schema (2.8.1)
       addressable (>= 2.4)
     libdatadog (4.0.0.1.0)
-    libddwaf (1.11.0.0.0)
+    libddwaf (1.14.0.0.0)
       ffi (~> 1.0)
     lograge (0.11.2)
       actionpack (>= 4)

--- a/gemfiles/ruby_2.3.8_rails4_semantic_logger.gemfile.lock
+++ b/gemfiles/ruby_2.3.8_rails4_semantic_logger.gemfile.lock
@@ -5,7 +5,7 @@ PATH
       datadog-ci (~> 0.1.0)
       debase-ruby_core_source (= 3.2.1)
       libdatadog (~> 4.0.0.1.0)
-      libddwaf (~> 1.11.0.0.0)
+      libddwaf (~> 1.14.0.0.0)
       msgpack
 
 GEM
@@ -80,7 +80,7 @@ GEM
     json-schema (2.8.1)
       addressable (>= 2.4)
     libdatadog (4.0.0.1.0)
-    libddwaf (1.11.0.0.0)
+    libddwaf (1.14.0.0.0)
       ffi (~> 1.0)
     loofah (2.19.1)
       crass (~> 1.0.2)

--- a/gemfiles/ruby_2.3.8_rails5_mysql2.gemfile.lock
+++ b/gemfiles/ruby_2.3.8_rails5_mysql2.gemfile.lock
@@ -5,7 +5,7 @@ PATH
       datadog-ci (~> 0.1.0)
       debase-ruby_core_source (= 3.2.1)
       libdatadog (~> 4.0.0.1.0)
-      libddwaf (~> 1.11.0.0.0)
+      libddwaf (~> 1.14.0.0.0)
       msgpack
 
 GEM
@@ -87,7 +87,7 @@ GEM
     json-schema (2.8.1)
       addressable (>= 2.4)
     libdatadog (4.0.0.1.0)
-    libddwaf (1.11.0.0.0)
+    libddwaf (1.14.0.0.0)
       ffi (~> 1.0)
     lograge (0.11.2)
       actionpack (>= 4)

--- a/gemfiles/ruby_2.3.8_rails5_postgres.gemfile.lock
+++ b/gemfiles/ruby_2.3.8_rails5_postgres.gemfile.lock
@@ -5,7 +5,7 @@ PATH
       datadog-ci (~> 0.1.0)
       debase-ruby_core_source (= 3.2.1)
       libdatadog (~> 4.0.0.1.0)
-      libddwaf (~> 1.11.0.0.0)
+      libddwaf (~> 1.14.0.0.0)
       msgpack
 
 GEM
@@ -87,7 +87,7 @@ GEM
     json-schema (2.8.1)
       addressable (>= 2.4)
     libdatadog (4.0.0.1.0)
-    libddwaf (1.11.0.0.0)
+    libddwaf (1.14.0.0.0)
       ffi (~> 1.0)
     lograge (0.11.2)
       actionpack (>= 4)

--- a/gemfiles/ruby_2.3.8_rails5_postgres_redis.gemfile.lock
+++ b/gemfiles/ruby_2.3.8_rails5_postgres_redis.gemfile.lock
@@ -5,7 +5,7 @@ PATH
       datadog-ci (~> 0.1.0)
       debase-ruby_core_source (= 3.2.1)
       libdatadog (~> 4.0.0.1.0)
-      libddwaf (~> 1.11.0.0.0)
+      libddwaf (~> 1.14.0.0.0)
       msgpack
 
 GEM
@@ -87,7 +87,7 @@ GEM
     json-schema (2.8.1)
       addressable (>= 2.4)
     libdatadog (4.0.0.1.0)
-    libddwaf (1.11.0.0.0)
+    libddwaf (1.14.0.0.0)
       ffi (~> 1.0)
     lograge (0.11.2)
       actionpack (>= 4)

--- a/gemfiles/ruby_2.3.8_rails5_postgres_redis_activesupport.gemfile.lock
+++ b/gemfiles/ruby_2.3.8_rails5_postgres_redis_activesupport.gemfile.lock
@@ -5,7 +5,7 @@ PATH
       datadog-ci (~> 0.1.0)
       debase-ruby_core_source (= 3.2.1)
       libdatadog (~> 4.0.0.1.0)
-      libddwaf (~> 1.11.0.0.0)
+      libddwaf (~> 1.14.0.0.0)
       msgpack
 
 GEM
@@ -87,7 +87,7 @@ GEM
     json-schema (2.8.1)
       addressable (>= 2.4)
     libdatadog (4.0.0.1.0)
-    libddwaf (1.11.0.0.0)
+    libddwaf (1.14.0.0.0)
       ffi (~> 1.0)
     lograge (0.11.2)
       actionpack (>= 4)

--- a/gemfiles/ruby_2.3.8_rails5_postgres_sidekiq.gemfile.lock
+++ b/gemfiles/ruby_2.3.8_rails5_postgres_sidekiq.gemfile.lock
@@ -5,7 +5,7 @@ PATH
       datadog-ci (~> 0.1.0)
       debase-ruby_core_source (= 3.2.1)
       libdatadog (~> 4.0.0.1.0)
-      libddwaf (~> 1.11.0.0.0)
+      libddwaf (~> 1.14.0.0.0)
       msgpack
 
 GEM
@@ -88,7 +88,7 @@ GEM
     json-schema (2.8.1)
       addressable (>= 2.4)
     libdatadog (4.0.0.1.0)
-    libddwaf (1.11.0.0.0)
+    libddwaf (1.14.0.0.0)
       ffi (~> 1.0)
     lograge (0.11.2)
       actionpack (>= 4)

--- a/gemfiles/ruby_2.3.8_rails5_semantic_logger.gemfile.lock
+++ b/gemfiles/ruby_2.3.8_rails5_semantic_logger.gemfile.lock
@@ -5,7 +5,7 @@ PATH
       datadog-ci (~> 0.1.0)
       debase-ruby_core_source (= 3.2.1)
       libdatadog (~> 4.0.0.1.0)
-      libddwaf (~> 1.11.0.0.0)
+      libddwaf (~> 1.14.0.0.0)
       msgpack
 
 GEM
@@ -87,7 +87,7 @@ GEM
     json-schema (2.8.1)
       addressable (>= 2.4)
     libdatadog (4.0.0.1.0)
-    libddwaf (1.11.0.0.0)
+    libddwaf (1.14.0.0.0)
       ffi (~> 1.0)
     loofah (2.19.1)
       crass (~> 1.0.2)

--- a/gemfiles/ruby_2.3.8_redis_3.gemfile.lock
+++ b/gemfiles/ruby_2.3.8_redis_3.gemfile.lock
@@ -5,7 +5,7 @@ PATH
       datadog-ci (~> 0.1.0)
       debase-ruby_core_source (= 3.2.1)
       libdatadog (~> 4.0.0.1.0)
-      libddwaf (~> 1.11.0.0.0)
+      libddwaf (~> 1.14.0.0.0)
       msgpack
 
 GEM
@@ -39,7 +39,7 @@ GEM
     json-schema (2.8.1)
       addressable (>= 2.4)
     libdatadog (4.0.0.1.0)
-    libddwaf (1.11.0.0.0)
+    libddwaf (1.14.0.0.0)
       ffi (~> 1.0)
     memory_profiler (0.9.14)
     method_source (1.0.0)

--- a/gemfiles/ruby_2.3.8_relational_db.gemfile.lock
+++ b/gemfiles/ruby_2.3.8_relational_db.gemfile.lock
@@ -5,7 +5,7 @@ PATH
       datadog-ci (~> 0.1.0)
       debase-ruby_core_source (= 3.2.1)
       libdatadog (~> 4.0.0.1.0)
-      libddwaf (~> 1.11.0.0.0)
+      libddwaf (~> 1.14.0.0.0)
       msgpack
 
 GEM
@@ -57,7 +57,7 @@ GEM
     json-schema (2.8.1)
       addressable (>= 2.4)
     libdatadog (4.0.0.1.0)
-    libddwaf (1.11.0.0.0)
+    libddwaf (1.14.0.0.0)
       ffi (~> 1.0)
     makara (0.5.0)
       activerecord (>= 3.0.0)

--- a/gemfiles/ruby_2.3.8_resque2_redis3.gemfile.lock
+++ b/gemfiles/ruby_2.3.8_resque2_redis3.gemfile.lock
@@ -5,7 +5,7 @@ PATH
       datadog-ci (~> 0.1.0)
       debase-ruby_core_source (= 3.2.1)
       libdatadog (~> 4.0.0.1.0)
-      libddwaf (~> 1.11.0.0.0)
+      libddwaf (~> 1.14.0.0.0)
       msgpack
 
 GEM
@@ -39,7 +39,7 @@ GEM
     json-schema (2.8.1)
       addressable (>= 2.4)
     libdatadog (4.0.0.1.0)
-    libddwaf (1.11.0.0.0)
+    libddwaf (1.14.0.0.0)
       ffi (~> 1.0)
     memory_profiler (0.9.14)
     method_source (1.0.0)

--- a/gemfiles/ruby_2.3.8_resque2_redis4.gemfile.lock
+++ b/gemfiles/ruby_2.3.8_resque2_redis4.gemfile.lock
@@ -5,7 +5,7 @@ PATH
       datadog-ci (~> 0.1.0)
       debase-ruby_core_source (= 3.2.1)
       libdatadog (~> 4.0.0.1.0)
-      libddwaf (~> 1.11.0.0.0)
+      libddwaf (~> 1.14.0.0.0)
       msgpack
 
 GEM
@@ -39,7 +39,7 @@ GEM
     json-schema (2.8.1)
       addressable (>= 2.4)
     libdatadog (4.0.0.1.0)
-    libddwaf (1.11.0.0.0)
+    libddwaf (1.14.0.0.0)
       ffi (~> 1.0)
     memory_profiler (0.9.14)
     method_source (1.0.0)

--- a/gemfiles/ruby_2.3.8_sinatra.gemfile.lock
+++ b/gemfiles/ruby_2.3.8_sinatra.gemfile.lock
@@ -5,7 +5,7 @@ PATH
       datadog-ci (~> 0.1.0)
       debase-ruby_core_source (= 3.2.1)
       libdatadog (~> 4.0.0.1.0)
-      libddwaf (~> 1.11.0.0.0)
+      libddwaf (~> 1.14.0.0.0)
       msgpack
 
 GEM
@@ -39,7 +39,7 @@ GEM
     json-schema (2.8.1)
       addressable (>= 2.4)
     libdatadog (4.0.0.1.0)
-    libddwaf (1.11.0.0.0)
+    libddwaf (1.14.0.0.0)
       ffi (~> 1.0)
     memory_profiler (0.9.14)
     method_source (1.0.0)

--- a/gemfiles/ruby_2.4.10_activerecord_4.gemfile.lock
+++ b/gemfiles/ruby_2.4.10_activerecord_4.gemfile.lock
@@ -5,7 +5,7 @@ PATH
       datadog-ci (~> 0.1.0)
       debase-ruby_core_source (= 3.2.1)
       libdatadog (~> 4.0.0.1.0)
-      libddwaf (~> 1.11.0.0.0)
+      libddwaf (~> 1.14.0.0.0)
       msgpack
 
 GEM
@@ -54,7 +54,7 @@ GEM
     json-schema (2.8.1)
       addressable (>= 2.4)
     libdatadog (4.0.0.1.0-aarch64-linux)
-    libddwaf (1.11.0.0.0-aarch64-linux)
+    libddwaf (1.14.0.0.0-aarch64-linux)
       ffi (~> 1.0)
     makara (0.3.10)
       activerecord (>= 3.0.0)

--- a/gemfiles/ruby_2.4.10_aws.gemfile.lock
+++ b/gemfiles/ruby_2.4.10_aws.gemfile.lock
@@ -5,7 +5,7 @@ PATH
       datadog-ci (~> 0.1.0)
       debase-ruby_core_source (= 3.2.1)
       libdatadog (~> 4.0.0.1.0)
-      libddwaf (~> 1.11.0.0.0)
+      libddwaf (~> 1.14.0.0.0)
       msgpack
 
 GEM
@@ -1461,7 +1461,7 @@ GEM
     json-schema (2.8.1)
       addressable (>= 2.4)
     libdatadog (4.0.0.1.0-aarch64-linux)
-    libddwaf (1.11.0.0.0-aarch64-linux)
+    libddwaf (1.14.0.0.0-aarch64-linux)
       ffi (~> 1.0)
     memory_profiler (0.9.14)
     method_source (1.0.0)

--- a/gemfiles/ruby_2.4.10_contrib.gemfile.lock
+++ b/gemfiles/ruby_2.4.10_contrib.gemfile.lock
@@ -5,7 +5,7 @@ PATH
       datadog-ci (~> 0.1.0)
       debase-ruby_core_source (= 3.2.1)
       libdatadog (~> 4.0.0.1.0)
-      libddwaf (~> 1.11.0.0.0)
+      libddwaf (~> 1.14.0.0.0)
       msgpack
 
 GEM
@@ -121,9 +121,9 @@ GEM
     king_konf (1.0.1)
     libdatadog (4.0.0.1.0-aarch64-linux)
     libdatadog (4.0.0.1.0-x86_64-linux)
-    libddwaf (1.11.0.0.0-aarch64-linux)
+    libddwaf (1.14.0.0.0-aarch64-linux)
       ffi (~> 1.0)
-    libddwaf (1.11.0.0.0-x86_64-linux)
+    libddwaf (1.14.0.0.0-x86_64-linux)
       ffi (~> 1.0)
     lograge (0.11.2)
       actionpack (>= 4)

--- a/gemfiles/ruby_2.4.10_contrib_old.gemfile.lock
+++ b/gemfiles/ruby_2.4.10_contrib_old.gemfile.lock
@@ -5,7 +5,7 @@ PATH
       datadog-ci (~> 0.1.0)
       debase-ruby_core_source (= 3.2.1)
       libdatadog (~> 4.0.0.1.0)
-      libddwaf (~> 1.11.0.0.0)
+      libddwaf (~> 1.14.0.0.0)
       msgpack
 
 GEM
@@ -54,9 +54,9 @@ GEM
       addressable (>= 2.4)
     libdatadog (4.0.0.1.0-aarch64-linux)
     libdatadog (4.0.0.1.0-x86_64-linux)
-    libddwaf (1.11.0.0.0-aarch64-linux)
+    libddwaf (1.14.0.0.0-aarch64-linux)
       ffi (~> 1.0)
-    libddwaf (1.11.0.0.0-x86_64-linux)
+    libddwaf (1.14.0.0.0-x86_64-linux)
       ffi (~> 1.0)
     memory_profiler (0.9.14)
     method_source (1.0.0)

--- a/gemfiles/ruby_2.4.10_core_old.gemfile.lock
+++ b/gemfiles/ruby_2.4.10_core_old.gemfile.lock
@@ -5,7 +5,7 @@ PATH
       datadog-ci (~> 0.1.0)
       debase-ruby_core_source (= 3.2.1)
       libdatadog (~> 4.0.0.1.0)
-      libddwaf (~> 1.11.0.0.0)
+      libddwaf (~> 1.14.0.0.0)
       msgpack
 
 GEM
@@ -41,9 +41,9 @@ GEM
       addressable (>= 2.4)
     libdatadog (4.0.0.1.0-aarch64-linux)
     libdatadog (4.0.0.1.0-x86_64-linux)
-    libddwaf (1.11.0.0.0-aarch64-linux)
+    libddwaf (1.14.0.0.0-aarch64-linux)
       ffi (~> 1.0)
-    libddwaf (1.11.0.0.0-x86_64-linux)
+    libddwaf (1.14.0.0.0-x86_64-linux)
       ffi (~> 1.0)
     memory_profiler (0.9.14)
     method_source (1.0.0)

--- a/gemfiles/ruby_2.4.10_hanami_1.gemfile.lock
+++ b/gemfiles/ruby_2.4.10_hanami_1.gemfile.lock
@@ -5,7 +5,7 @@ PATH
       datadog-ci (~> 0.1.0)
       debase-ruby_core_source (= 3.2.1)
       libdatadog (~> 4.0.0.1.0)
-      libddwaf (~> 1.11.0.0.0)
+      libddwaf (~> 1.14.0.0.0)
       msgpack
 
 GEM
@@ -116,9 +116,9 @@ GEM
       addressable (>= 2.4)
     libdatadog (4.0.0.1.0-aarch64-linux)
     libdatadog (4.0.0.1.0-x86_64-linux)
-    libddwaf (1.11.0.0.0-aarch64-linux)
+    libddwaf (1.14.0.0.0-aarch64-linux)
       ffi (~> 1.0)
-    libddwaf (1.11.0.0.0-x86_64-linux)
+    libddwaf (1.14.0.0.0-x86_64-linux)
       ffi (~> 1.0)
     mail (2.7.1)
       mini_mime (>= 0.1.1)

--- a/gemfiles/ruby_2.4.10_http.gemfile.lock
+++ b/gemfiles/ruby_2.4.10_http.gemfile.lock
@@ -5,7 +5,7 @@ PATH
       datadog-ci (~> 0.1.0)
       debase-ruby_core_source (= 3.2.1)
       libdatadog (~> 4.0.0.1.0)
-      libddwaf (~> 1.11.0.0.0)
+      libddwaf (~> 1.14.0.0.0)
       msgpack
 
 GEM
@@ -82,7 +82,7 @@ GEM
     json-schema (2.8.1)
       addressable (>= 2.4)
     libdatadog (4.0.0.1.0-aarch64-linux)
-    libddwaf (1.11.0.0.0-aarch64-linux)
+    libddwaf (1.14.0.0.0-aarch64-linux)
       ffi (~> 1.0)
     memory_profiler (0.9.14)
     method_source (1.0.0)

--- a/gemfiles/ruby_2.4.10_rails5_mysql2.gemfile.lock
+++ b/gemfiles/ruby_2.4.10_rails5_mysql2.gemfile.lock
@@ -5,7 +5,7 @@ PATH
       datadog-ci (~> 0.1.0)
       debase-ruby_core_source (= 3.2.1)
       libdatadog (~> 4.0.0.1.0)
-      libddwaf (~> 1.11.0.0.0)
+      libddwaf (~> 1.14.0.0.0)
       msgpack
 
 GEM
@@ -89,9 +89,9 @@ GEM
       addressable (>= 2.4)
     libdatadog (4.0.0.1.0-aarch64-linux)
     libdatadog (4.0.0.1.0-x86_64-linux)
-    libddwaf (1.11.0.0.0-aarch64-linux)
+    libddwaf (1.14.0.0.0-aarch64-linux)
       ffi (~> 1.0)
-    libddwaf (1.11.0.0.0-x86_64-linux)
+    libddwaf (1.14.0.0.0-x86_64-linux)
       ffi (~> 1.0)
     lograge (0.11.2)
       actionpack (>= 4)

--- a/gemfiles/ruby_2.4.10_rails5_postgres.gemfile.lock
+++ b/gemfiles/ruby_2.4.10_rails5_postgres.gemfile.lock
@@ -5,7 +5,7 @@ PATH
       datadog-ci (~> 0.1.0)
       debase-ruby_core_source (= 3.2.1)
       libdatadog (~> 4.0.0.1.0)
-      libddwaf (~> 1.11.0.0.0)
+      libddwaf (~> 1.14.0.0.0)
       msgpack
 
 GEM
@@ -89,9 +89,9 @@ GEM
       addressable (>= 2.4)
     libdatadog (4.0.0.1.0-aarch64-linux)
     libdatadog (4.0.0.1.0-x86_64-linux)
-    libddwaf (1.11.0.0.0-aarch64-linux)
+    libddwaf (1.14.0.0.0-aarch64-linux)
       ffi (~> 1.0)
-    libddwaf (1.11.0.0.0-x86_64-linux)
+    libddwaf (1.14.0.0.0-x86_64-linux)
       ffi (~> 1.0)
     lograge (0.11.2)
       actionpack (>= 4)

--- a/gemfiles/ruby_2.4.10_rails5_postgres_redis.gemfile.lock
+++ b/gemfiles/ruby_2.4.10_rails5_postgres_redis.gemfile.lock
@@ -5,7 +5,7 @@ PATH
       datadog-ci (~> 0.1.0)
       debase-ruby_core_source (= 3.2.1)
       libdatadog (~> 4.0.0.1.0)
-      libddwaf (~> 1.11.0.0.0)
+      libddwaf (~> 1.14.0.0.0)
       msgpack
 
 GEM
@@ -89,9 +89,9 @@ GEM
       addressable (>= 2.4)
     libdatadog (4.0.0.1.0-aarch64-linux)
     libdatadog (4.0.0.1.0-x86_64-linux)
-    libddwaf (1.11.0.0.0-aarch64-linux)
+    libddwaf (1.14.0.0.0-aarch64-linux)
       ffi (~> 1.0)
-    libddwaf (1.11.0.0.0-x86_64-linux)
+    libddwaf (1.14.0.0.0-x86_64-linux)
       ffi (~> 1.0)
     lograge (0.11.2)
       actionpack (>= 4)

--- a/gemfiles/ruby_2.4.10_rails5_postgres_redis_activesupport.gemfile.lock
+++ b/gemfiles/ruby_2.4.10_rails5_postgres_redis_activesupport.gemfile.lock
@@ -5,7 +5,7 @@ PATH
       datadog-ci (~> 0.1.0)
       debase-ruby_core_source (= 3.2.1)
       libdatadog (~> 4.0.0.1.0)
-      libddwaf (~> 1.11.0.0.0)
+      libddwaf (~> 1.14.0.0.0)
       msgpack
 
 GEM
@@ -89,9 +89,9 @@ GEM
       addressable (>= 2.4)
     libdatadog (4.0.0.1.0-aarch64-linux)
     libdatadog (4.0.0.1.0-x86_64-linux)
-    libddwaf (1.11.0.0.0-aarch64-linux)
+    libddwaf (1.14.0.0.0-aarch64-linux)
       ffi (~> 1.0)
-    libddwaf (1.11.0.0.0-x86_64-linux)
+    libddwaf (1.14.0.0.0-x86_64-linux)
       ffi (~> 1.0)
     lograge (0.11.2)
       actionpack (>= 4)

--- a/gemfiles/ruby_2.4.10_rails5_postgres_sidekiq.gemfile.lock
+++ b/gemfiles/ruby_2.4.10_rails5_postgres_sidekiq.gemfile.lock
@@ -5,7 +5,7 @@ PATH
       datadog-ci (~> 0.1.0)
       debase-ruby_core_source (= 3.2.1)
       libdatadog (~> 4.0.0.1.0)
-      libddwaf (~> 1.11.0.0.0)
+      libddwaf (~> 1.14.0.0.0)
       msgpack
 
 GEM
@@ -90,9 +90,9 @@ GEM
       addressable (>= 2.4)
     libdatadog (4.0.0.1.0-aarch64-linux)
     libdatadog (4.0.0.1.0-x86_64-linux)
-    libddwaf (1.11.0.0.0-aarch64-linux)
+    libddwaf (1.14.0.0.0-aarch64-linux)
       ffi (~> 1.0)
-    libddwaf (1.11.0.0.0-x86_64-linux)
+    libddwaf (1.14.0.0.0-x86_64-linux)
       ffi (~> 1.0)
     lograge (0.11.2)
       actionpack (>= 4)

--- a/gemfiles/ruby_2.4.10_rails5_semantic_logger.gemfile.lock
+++ b/gemfiles/ruby_2.4.10_rails5_semantic_logger.gemfile.lock
@@ -5,7 +5,7 @@ PATH
       datadog-ci (~> 0.1.0)
       debase-ruby_core_source (= 3.2.1)
       libdatadog (~> 4.0.0.1.0)
-      libddwaf (~> 1.11.0.0.0)
+      libddwaf (~> 1.14.0.0.0)
       msgpack
 
 GEM
@@ -89,9 +89,9 @@ GEM
       addressable (>= 2.4)
     libdatadog (4.0.0.1.0-aarch64-linux)
     libdatadog (4.0.0.1.0-x86_64-linux)
-    libddwaf (1.11.0.0.0-aarch64-linux)
+    libddwaf (1.14.0.0.0-aarch64-linux)
       ffi (~> 1.0)
-    libddwaf (1.11.0.0.0-x86_64-linux)
+    libddwaf (1.14.0.0.0-x86_64-linux)
       ffi (~> 1.0)
     loofah (2.19.1)
       crass (~> 1.0.2)

--- a/gemfiles/ruby_2.4.10_redis_3.gemfile.lock
+++ b/gemfiles/ruby_2.4.10_redis_3.gemfile.lock
@@ -5,7 +5,7 @@ PATH
       datadog-ci (~> 0.1.0)
       debase-ruby_core_source (= 3.2.1)
       libdatadog (~> 4.0.0.1.0)
-      libddwaf (~> 1.11.0.0.0)
+      libddwaf (~> 1.14.0.0.0)
       msgpack
 
 GEM
@@ -41,9 +41,9 @@ GEM
       addressable (>= 2.4)
     libdatadog (4.0.0.1.0-aarch64-linux)
     libdatadog (4.0.0.1.0-x86_64-linux)
-    libddwaf (1.11.0.0.0-aarch64-linux)
+    libddwaf (1.14.0.0.0-aarch64-linux)
       ffi (~> 1.0)
-    libddwaf (1.11.0.0.0-x86_64-linux)
+    libddwaf (1.14.0.0.0-x86_64-linux)
       ffi (~> 1.0)
     memory_profiler (0.9.14)
     method_source (1.0.0)

--- a/gemfiles/ruby_2.4.10_redis_4.gemfile.lock
+++ b/gemfiles/ruby_2.4.10_redis_4.gemfile.lock
@@ -5,7 +5,7 @@ PATH
       datadog-ci (~> 0.1.0)
       debase-ruby_core_source (= 3.2.1)
       libdatadog (~> 4.0.0.1.0)
-      libddwaf (~> 1.11.0.0.0)
+      libddwaf (~> 1.14.0.0.0)
       msgpack
 
 GEM
@@ -41,9 +41,9 @@ GEM
       addressable (>= 2.4)
     libdatadog (4.0.0.1.0-aarch64-linux)
     libdatadog (4.0.0.1.0-x86_64-linux)
-    libddwaf (1.11.0.0.0-aarch64-linux)
+    libddwaf (1.14.0.0.0-aarch64-linux)
       ffi (~> 1.0)
-    libddwaf (1.11.0.0.0-x86_64-linux)
+    libddwaf (1.14.0.0.0-x86_64-linux)
       ffi (~> 1.0)
     memory_profiler (0.9.14)
     method_source (1.0.0)

--- a/gemfiles/ruby_2.4.10_relational_db.gemfile.lock
+++ b/gemfiles/ruby_2.4.10_relational_db.gemfile.lock
@@ -5,7 +5,7 @@ PATH
       datadog-ci (~> 0.1.0)
       debase-ruby_core_source (= 3.2.1)
       libdatadog (~> 4.0.0.1.0)
-      libddwaf (~> 1.11.0.0.0)
+      libddwaf (~> 1.14.0.0.0)
       msgpack
 
 GEM
@@ -58,10 +58,11 @@ GEM
     json-schema (2.8.1)
       addressable (>= 2.4)
     libdatadog (4.0.0.1.0-aarch64-linux)
-    libddwaf (1.11.0.0.0-aarch64-linux)
+    libdatadog (4.0.0.1.0-x86_64-linux)
+    libddwaf (1.14.0.0.0-aarch64-linux)
       ffi (~> 1.0)
-    makara (0.5.0)
-      activerecord (>= 3.0.0)
+    libddwaf (1.14.0.0.0-x86_64-linux)
+      ffi (~> 1.0)
     memory_profiler (0.9.14)
     method_source (1.0.0)
     minitest (5.15.0)

--- a/gemfiles/ruby_2.4.10_resque2_redis3.gemfile.lock
+++ b/gemfiles/ruby_2.4.10_resque2_redis3.gemfile.lock
@@ -5,7 +5,7 @@ PATH
       datadog-ci (~> 0.1.0)
       debase-ruby_core_source (= 3.2.1)
       libdatadog (~> 4.0.0.1.0)
-      libddwaf (~> 1.11.0.0.0)
+      libddwaf (~> 1.14.0.0.0)
       msgpack
 
 GEM
@@ -41,9 +41,9 @@ GEM
       addressable (>= 2.4)
     libdatadog (4.0.0.1.0-aarch64-linux)
     libdatadog (4.0.0.1.0-x86_64-linux)
-    libddwaf (1.11.0.0.0-aarch64-linux)
+    libddwaf (1.14.0.0.0-aarch64-linux)
       ffi (~> 1.0)
-    libddwaf (1.11.0.0.0-x86_64-linux)
+    libddwaf (1.14.0.0.0-x86_64-linux)
       ffi (~> 1.0)
     memory_profiler (0.9.14)
     method_source (1.0.0)

--- a/gemfiles/ruby_2.4.10_resque2_redis4.gemfile.lock
+++ b/gemfiles/ruby_2.4.10_resque2_redis4.gemfile.lock
@@ -5,7 +5,7 @@ PATH
       datadog-ci (~> 0.1.0)
       debase-ruby_core_source (= 3.2.1)
       libdatadog (~> 4.0.0.1.0)
-      libddwaf (~> 1.11.0.0.0)
+      libddwaf (~> 1.14.0.0.0)
       msgpack
 
 GEM
@@ -41,9 +41,9 @@ GEM
       addressable (>= 2.4)
     libdatadog (4.0.0.1.0-aarch64-linux)
     libdatadog (4.0.0.1.0-x86_64-linux)
-    libddwaf (1.11.0.0.0-aarch64-linux)
+    libddwaf (1.14.0.0.0-aarch64-linux)
       ffi (~> 1.0)
-    libddwaf (1.11.0.0.0-x86_64-linux)
+    libddwaf (1.14.0.0.0-x86_64-linux)
       ffi (~> 1.0)
     memory_profiler (0.9.14)
     method_source (1.0.0)

--- a/gemfiles/ruby_2.4.10_sinatra.gemfile.lock
+++ b/gemfiles/ruby_2.4.10_sinatra.gemfile.lock
@@ -5,7 +5,7 @@ PATH
       datadog-ci (~> 0.1.0)
       debase-ruby_core_source (= 3.2.1)
       libdatadog (~> 4.0.0.1.0)
-      libddwaf (~> 1.11.0.0.0)
+      libddwaf (~> 1.14.0.0.0)
       msgpack
 
 GEM
@@ -41,9 +41,9 @@ GEM
       addressable (>= 2.4)
     libdatadog (4.0.0.1.0-aarch64-linux)
     libdatadog (4.0.0.1.0-x86_64-linux)
-    libddwaf (1.11.0.0.0-aarch64-linux)
+    libddwaf (1.14.0.0.0-aarch64-linux)
       ffi (~> 1.0)
-    libddwaf (1.11.0.0.0-x86_64-linux)
+    libddwaf (1.14.0.0.0-x86_64-linux)
       ffi (~> 1.0)
     memory_profiler (0.9.14)
     method_source (1.0.0)

--- a/gemfiles/ruby_2.5.9_aws.gemfile.lock
+++ b/gemfiles/ruby_2.5.9_aws.gemfile.lock
@@ -15,7 +15,7 @@ PATH
       datadog-ci (~> 0.1.0)
       debase-ruby_core_source (= 3.2.1)
       libdatadog (~> 4.0.0.1.0)
-      libddwaf (~> 1.11.0.0.0)
+      libddwaf (~> 1.14.0.0.0)
       msgpack
 
 GEM
@@ -1474,7 +1474,7 @@ GEM
     json-schema (2.8.1)
       addressable (>= 2.4)
     libdatadog (4.0.0.1.0-aarch64-linux)
-    libddwaf (1.11.0.0.0-aarch64-linux)
+    libddwaf (1.14.0.0.0-aarch64-linux)
       ffi (~> 1.0)
     memory_profiler (0.9.14)
     method_source (1.0.0)

--- a/gemfiles/ruby_2.5.9_contrib.gemfile.lock
+++ b/gemfiles/ruby_2.5.9_contrib.gemfile.lock
@@ -15,7 +15,7 @@ PATH
       datadog-ci (~> 0.1.0)
       debase-ruby_core_source (= 3.2.1)
       libdatadog (~> 4.0.0.1.0)
-      libddwaf (~> 1.11.0.0.0)
+      libddwaf (~> 1.14.0.0.0)
       msgpack
 
 GEM
@@ -130,9 +130,9 @@ GEM
     king_konf (1.0.1)
     libdatadog (4.0.0.1.0-aarch64-linux)
     libdatadog (4.0.0.1.0-x86_64-linux)
-    libddwaf (1.11.0.0.0-aarch64-linux)
+    libddwaf (1.14.0.0.0-aarch64-linux)
       ffi (~> 1.0)
-    libddwaf (1.11.0.0.0-x86_64-linux)
+    libddwaf (1.14.0.0.0-x86_64-linux)
       ffi (~> 1.0)
     lograge (0.13.0)
       actionpack (>= 4)

--- a/gemfiles/ruby_2.5.9_contrib_old.gemfile.lock
+++ b/gemfiles/ruby_2.5.9_contrib_old.gemfile.lock
@@ -15,7 +15,7 @@ PATH
       datadog-ci (~> 0.1.0)
       debase-ruby_core_source (= 3.2.1)
       libdatadog (~> 4.0.0.1.0)
-      libddwaf (~> 1.11.0.0.0)
+      libddwaf (~> 1.14.0.0.0)
       msgpack
 
 GEM
@@ -74,9 +74,9 @@ GEM
       addressable (>= 2.4)
     libdatadog (4.0.0.1.0-aarch64-linux)
     libdatadog (4.0.0.1.0-x86_64-linux)
-    libddwaf (1.11.0.0.0-aarch64-linux)
+    libddwaf (1.14.0.0.0-aarch64-linux)
       ffi (~> 1.0)
-    libddwaf (1.11.0.0.0-x86_64-linux)
+    libddwaf (1.14.0.0.0-x86_64-linux)
       ffi (~> 1.0)
     memory_profiler (0.9.14)
     method_source (1.0.0)

--- a/gemfiles/ruby_2.5.9_core_old.gemfile.lock
+++ b/gemfiles/ruby_2.5.9_core_old.gemfile.lock
@@ -15,7 +15,7 @@ PATH
       datadog-ci (~> 0.1.0)
       debase-ruby_core_source (= 3.2.1)
       libdatadog (~> 4.0.0.1.0)
-      libddwaf (~> 1.11.0.0.0)
+      libddwaf (~> 1.14.0.0.0)
       msgpack
 
 GEM
@@ -54,9 +54,9 @@ GEM
       addressable (>= 2.4)
     libdatadog (4.0.0.1.0-aarch64-linux)
     libdatadog (4.0.0.1.0-x86_64-linux)
-    libddwaf (1.11.0.0.0-aarch64-linux)
+    libddwaf (1.14.0.0.0-aarch64-linux)
       ffi (~> 1.0)
-    libddwaf (1.11.0.0.0-x86_64-linux)
+    libddwaf (1.14.0.0.0-x86_64-linux)
       ffi (~> 1.0)
     memory_profiler (0.9.14)
     method_source (1.0.0)

--- a/gemfiles/ruby_2.5.9_hanami_1.gemfile.lock
+++ b/gemfiles/ruby_2.5.9_hanami_1.gemfile.lock
@@ -15,7 +15,7 @@ PATH
       datadog-ci (~> 0.1.0)
       debase-ruby_core_source (= 3.2.1)
       libdatadog (~> 4.0.0.1.0)
-      libddwaf (~> 1.11.0.0.0)
+      libddwaf (~> 1.14.0.0.0)
       msgpack
 
 GEM
@@ -130,9 +130,9 @@ GEM
       addressable (>= 2.4)
     libdatadog (4.0.0.1.0-aarch64-linux)
     libdatadog (4.0.0.1.0-x86_64-linux)
-    libddwaf (1.11.0.0.0-aarch64-linux)
+    libddwaf (1.14.0.0.0-aarch64-linux)
       ffi (~> 1.0)
-    libddwaf (1.11.0.0.0-x86_64-linux)
+    libddwaf (1.14.0.0.0-x86_64-linux)
       ffi (~> 1.0)
     mail (2.8.1)
       mini_mime (>= 0.1.1)

--- a/gemfiles/ruby_2.5.9_http.gemfile.lock
+++ b/gemfiles/ruby_2.5.9_http.gemfile.lock
@@ -15,7 +15,7 @@ PATH
       datadog-ci (~> 0.1.0)
       debase-ruby_core_source (= 3.2.1)
       libdatadog (~> 4.0.0.1.0)
-      libddwaf (~> 1.11.0.0.0)
+      libddwaf (~> 1.14.0.0.0)
       msgpack
 
 GEM
@@ -101,7 +101,7 @@ GEM
     json-schema (2.8.1)
       addressable (>= 2.4)
     libdatadog (4.0.0.1.0-aarch64-linux)
-    libddwaf (1.11.0.0.0-aarch64-linux)
+    libddwaf (1.14.0.0.0-aarch64-linux)
       ffi (~> 1.0)
     llhttp-ffi (0.3.1)
       ffi-compiler (~> 1.0)

--- a/gemfiles/ruby_2.5.9_rails5_mysql2.gemfile.lock
+++ b/gemfiles/ruby_2.5.9_rails5_mysql2.gemfile.lock
@@ -15,7 +15,7 @@ PATH
       datadog-ci (~> 0.1.0)
       debase-ruby_core_source (= 3.2.1)
       libdatadog (~> 4.0.0.1.0)
-      libddwaf (~> 1.11.0.0.0)
+      libddwaf (~> 1.14.0.0.0)
       msgpack
 
 GEM
@@ -102,9 +102,9 @@ GEM
       addressable (>= 2.4)
     libdatadog (4.0.0.1.0-aarch64-linux)
     libdatadog (4.0.0.1.0-x86_64-linux)
-    libddwaf (1.11.0.0.0-aarch64-linux)
+    libddwaf (1.14.0.0.0-aarch64-linux)
       ffi (~> 1.0)
-    libddwaf (1.11.0.0.0-x86_64-linux)
+    libddwaf (1.14.0.0.0-x86_64-linux)
       ffi (~> 1.0)
     lograge (0.12.0)
       actionpack (>= 4)

--- a/gemfiles/ruby_2.5.9_rails5_postgres.gemfile.lock
+++ b/gemfiles/ruby_2.5.9_rails5_postgres.gemfile.lock
@@ -15,7 +15,7 @@ PATH
       datadog-ci (~> 0.1.0)
       debase-ruby_core_source (= 3.2.1)
       libdatadog (~> 4.0.0.1.0)
-      libddwaf (~> 1.11.0.0.0)
+      libddwaf (~> 1.14.0.0.0)
       msgpack
 
 GEM
@@ -104,9 +104,9 @@ GEM
       addressable (>= 2.4)
     libdatadog (4.0.0.1.0-aarch64-linux)
     libdatadog (4.0.0.1.0-x86_64-linux)
-    libddwaf (1.11.0.0.0-aarch64-linux)
+    libddwaf (1.14.0.0.0-aarch64-linux)
       ffi (~> 1.0)
-    libddwaf (1.11.0.0.0-x86_64-linux)
+    libddwaf (1.14.0.0.0-x86_64-linux)
       ffi (~> 1.0)
     lograge (0.12.0)
       actionpack (>= 4)

--- a/gemfiles/ruby_2.5.9_rails5_postgres_redis.gemfile.lock
+++ b/gemfiles/ruby_2.5.9_rails5_postgres_redis.gemfile.lock
@@ -15,7 +15,7 @@ PATH
       datadog-ci (~> 0.1.0)
       debase-ruby_core_source (= 3.2.1)
       libdatadog (~> 4.0.0.1.0)
-      libddwaf (~> 1.11.0.0.0)
+      libddwaf (~> 1.14.0.0.0)
       msgpack
 
 GEM
@@ -105,9 +105,9 @@ GEM
       addressable (>= 2.4)
     libdatadog (4.0.0.1.0-aarch64-linux)
     libdatadog (4.0.0.1.0-x86_64-linux)
-    libddwaf (1.11.0.0.0-aarch64-linux)
+    libddwaf (1.14.0.0.0-aarch64-linux)
       ffi (~> 1.0)
-    libddwaf (1.11.0.0.0-x86_64-linux)
+    libddwaf (1.14.0.0.0-x86_64-linux)
       ffi (~> 1.0)
     lograge (0.12.0)
       actionpack (>= 4)

--- a/gemfiles/ruby_2.5.9_rails5_postgres_redis_activesupport.gemfile.lock
+++ b/gemfiles/ruby_2.5.9_rails5_postgres_redis_activesupport.gemfile.lock
@@ -15,7 +15,7 @@ PATH
       datadog-ci (~> 0.1.0)
       debase-ruby_core_source (= 3.2.1)
       libdatadog (~> 4.0.0.1.0)
-      libddwaf (~> 1.11.0.0.0)
+      libddwaf (~> 1.14.0.0.0)
       msgpack
 
 GEM
@@ -104,9 +104,9 @@ GEM
       addressable (>= 2.4)
     libdatadog (4.0.0.1.0-aarch64-linux)
     libdatadog (4.0.0.1.0-x86_64-linux)
-    libddwaf (1.11.0.0.0-aarch64-linux)
+    libddwaf (1.14.0.0.0-aarch64-linux)
       ffi (~> 1.0)
-    libddwaf (1.11.0.0.0-x86_64-linux)
+    libddwaf (1.14.0.0.0-x86_64-linux)
       ffi (~> 1.0)
     lograge (0.12.0)
       actionpack (>= 4)

--- a/gemfiles/ruby_2.5.9_rails5_postgres_sidekiq.gemfile.lock
+++ b/gemfiles/ruby_2.5.9_rails5_postgres_sidekiq.gemfile.lock
@@ -15,7 +15,7 @@ PATH
       datadog-ci (~> 0.1.0)
       debase-ruby_core_source (= 3.2.1)
       libdatadog (~> 4.0.0.1.0)
-      libddwaf (~> 1.11.0.0.0)
+      libddwaf (~> 1.14.0.0.0)
       msgpack
 
 GEM
@@ -105,9 +105,9 @@ GEM
       addressable (>= 2.4)
     libdatadog (4.0.0.1.0-aarch64-linux)
     libdatadog (4.0.0.1.0-x86_64-linux)
-    libddwaf (1.11.0.0.0-aarch64-linux)
+    libddwaf (1.14.0.0.0-aarch64-linux)
       ffi (~> 1.0)
-    libddwaf (1.11.0.0.0-x86_64-linux)
+    libddwaf (1.14.0.0.0-x86_64-linux)
       ffi (~> 1.0)
     lograge (0.12.0)
       actionpack (>= 4)

--- a/gemfiles/ruby_2.5.9_rails5_semantic_logger.gemfile.lock
+++ b/gemfiles/ruby_2.5.9_rails5_semantic_logger.gemfile.lock
@@ -15,7 +15,7 @@ PATH
       datadog-ci (~> 0.1.0)
       debase-ruby_core_source (= 3.2.1)
       libdatadog (~> 4.0.0.1.0)
-      libddwaf (~> 1.11.0.0.0)
+      libddwaf (~> 1.14.0.0.0)
       msgpack
 
 GEM
@@ -104,9 +104,9 @@ GEM
       addressable (>= 2.4)
     libdatadog (4.0.0.1.0-aarch64-linux)
     libdatadog (4.0.0.1.0-x86_64-linux)
-    libddwaf (1.11.0.0.0-aarch64-linux)
+    libddwaf (1.14.0.0.0-aarch64-linux)
       ffi (~> 1.0)
-    libddwaf (1.11.0.0.0-x86_64-linux)
+    libddwaf (1.14.0.0.0-x86_64-linux)
       ffi (~> 1.0)
     loofah (2.19.1)
       crass (~> 1.0.2)

--- a/gemfiles/ruby_2.5.9_rails61_mysql2.gemfile.lock
+++ b/gemfiles/ruby_2.5.9_rails61_mysql2.gemfile.lock
@@ -15,7 +15,7 @@ PATH
       datadog-ci (~> 0.1.0)
       debase-ruby_core_source (= 3.2.1)
       libdatadog (~> 4.0.0.1.0)
-      libddwaf (~> 1.11.0.0.0)
+      libddwaf (~> 1.14.0.0.0)
       msgpack
 
 GEM
@@ -119,9 +119,9 @@ GEM
       addressable (>= 2.4)
     libdatadog (4.0.0.1.0-aarch64-linux)
     libdatadog (4.0.0.1.0-x86_64-linux)
-    libddwaf (1.11.0.0.0-aarch64-linux)
+    libddwaf (1.14.0.0.0-aarch64-linux)
       ffi (~> 1.0)
-    libddwaf (1.11.0.0.0-x86_64-linux)
+    libddwaf (1.14.0.0.0-x86_64-linux)
       ffi (~> 1.0)
     lograge (0.12.0)
       actionpack (>= 4)

--- a/gemfiles/ruby_2.5.9_rails61_postgres.gemfile.lock
+++ b/gemfiles/ruby_2.5.9_rails61_postgres.gemfile.lock
@@ -15,7 +15,7 @@ PATH
       datadog-ci (~> 0.1.0)
       debase-ruby_core_source (= 3.2.1)
       libdatadog (~> 4.0.0.1.0)
-      libddwaf (~> 1.11.0.0.0)
+      libddwaf (~> 1.14.0.0.0)
       msgpack
 
 GEM
@@ -121,9 +121,9 @@ GEM
       addressable (>= 2.4)
     libdatadog (4.0.0.1.0-aarch64-linux)
     libdatadog (4.0.0.1.0-x86_64-linux)
-    libddwaf (1.11.0.0.0-aarch64-linux)
+    libddwaf (1.14.0.0.0-aarch64-linux)
       ffi (~> 1.0)
-    libddwaf (1.11.0.0.0-x86_64-linux)
+    libddwaf (1.14.0.0.0-x86_64-linux)
       ffi (~> 1.0)
     lograge (0.12.0)
       actionpack (>= 4)

--- a/gemfiles/ruby_2.5.9_rails61_postgres_redis.gemfile.lock
+++ b/gemfiles/ruby_2.5.9_rails61_postgres_redis.gemfile.lock
@@ -15,7 +15,7 @@ PATH
       datadog-ci (~> 0.1.0)
       debase-ruby_core_source (= 3.2.1)
       libdatadog (~> 4.0.0.1.0)
-      libddwaf (~> 1.11.0.0.0)
+      libddwaf (~> 1.14.0.0.0)
       msgpack
 
 GEM
@@ -122,9 +122,9 @@ GEM
       addressable (>= 2.4)
     libdatadog (4.0.0.1.0-aarch64-linux)
     libdatadog (4.0.0.1.0-x86_64-linux)
-    libddwaf (1.11.0.0.0-aarch64-linux)
+    libddwaf (1.14.0.0.0-aarch64-linux)
       ffi (~> 1.0)
-    libddwaf (1.11.0.0.0-x86_64-linux)
+    libddwaf (1.14.0.0.0-x86_64-linux)
       ffi (~> 1.0)
     lograge (0.12.0)
       actionpack (>= 4)

--- a/gemfiles/ruby_2.5.9_rails61_postgres_sidekiq.gemfile.lock
+++ b/gemfiles/ruby_2.5.9_rails61_postgres_sidekiq.gemfile.lock
@@ -15,7 +15,7 @@ PATH
       datadog-ci (~> 0.1.0)
       debase-ruby_core_source (= 3.2.1)
       libdatadog (~> 4.0.0.1.0)
-      libddwaf (~> 1.11.0.0.0)
+      libddwaf (~> 1.14.0.0.0)
       msgpack
 
 GEM
@@ -122,9 +122,9 @@ GEM
       addressable (>= 2.4)
     libdatadog (4.0.0.1.0-aarch64-linux)
     libdatadog (4.0.0.1.0-x86_64-linux)
-    libddwaf (1.11.0.0.0-aarch64-linux)
+    libddwaf (1.14.0.0.0-aarch64-linux)
       ffi (~> 1.0)
-    libddwaf (1.11.0.0.0-x86_64-linux)
+    libddwaf (1.14.0.0.0-x86_64-linux)
       ffi (~> 1.0)
     lograge (0.12.0)
       actionpack (>= 4)

--- a/gemfiles/ruby_2.5.9_rails61_semantic_logger.gemfile.lock
+++ b/gemfiles/ruby_2.5.9_rails61_semantic_logger.gemfile.lock
@@ -15,7 +15,7 @@ PATH
       datadog-ci (~> 0.1.0)
       debase-ruby_core_source (= 3.2.1)
       libdatadog (~> 4.0.0.1.0)
-      libddwaf (~> 1.11.0.0.0)
+      libddwaf (~> 1.14.0.0.0)
       msgpack
 
 GEM
@@ -121,9 +121,9 @@ GEM
       addressable (>= 2.4)
     libdatadog (4.0.0.1.0-aarch64-linux)
     libdatadog (4.0.0.1.0-x86_64-linux)
-    libddwaf (1.11.0.0.0-aarch64-linux)
+    libddwaf (1.14.0.0.0-aarch64-linux)
       ffi (~> 1.0)
-    libddwaf (1.11.0.0.0-x86_64-linux)
+    libddwaf (1.14.0.0.0-x86_64-linux)
       ffi (~> 1.0)
     loofah (2.19.1)
       crass (~> 1.0.2)

--- a/gemfiles/ruby_2.5.9_rails6_mysql2.gemfile.lock
+++ b/gemfiles/ruby_2.5.9_rails6_mysql2.gemfile.lock
@@ -15,7 +15,7 @@ PATH
       datadog-ci (~> 0.1.0)
       debase-ruby_core_source (= 3.2.1)
       libdatadog (~> 4.0.0.1.0)
-      libddwaf (~> 1.11.0.0.0)
+      libddwaf (~> 1.14.0.0.0)
       msgpack
 
 GEM
@@ -115,9 +115,9 @@ GEM
       addressable (>= 2.4)
     libdatadog (4.0.0.1.0-aarch64-linux)
     libdatadog (4.0.0.1.0-x86_64-linux)
-    libddwaf (1.11.0.0.0-aarch64-linux)
+    libddwaf (1.14.0.0.0-aarch64-linux)
       ffi (~> 1.0)
-    libddwaf (1.11.0.0.0-x86_64-linux)
+    libddwaf (1.14.0.0.0-x86_64-linux)
       ffi (~> 1.0)
     lograge (0.12.0)
       actionpack (>= 4)

--- a/gemfiles/ruby_2.5.9_rails6_postgres.gemfile.lock
+++ b/gemfiles/ruby_2.5.9_rails6_postgres.gemfile.lock
@@ -15,7 +15,7 @@ PATH
       datadog-ci (~> 0.1.0)
       debase-ruby_core_source (= 3.2.1)
       libdatadog (~> 4.0.0.1.0)
-      libddwaf (~> 1.11.0.0.0)
+      libddwaf (~> 1.14.0.0.0)
       msgpack
 
 GEM
@@ -117,9 +117,9 @@ GEM
       addressable (>= 2.4)
     libdatadog (4.0.0.1.0-aarch64-linux)
     libdatadog (4.0.0.1.0-x86_64-linux)
-    libddwaf (1.11.0.0.0-aarch64-linux)
+    libddwaf (1.14.0.0.0-aarch64-linux)
       ffi (~> 1.0)
-    libddwaf (1.11.0.0.0-x86_64-linux)
+    libddwaf (1.14.0.0.0-x86_64-linux)
       ffi (~> 1.0)
     lograge (0.12.0)
       actionpack (>= 4)

--- a/gemfiles/ruby_2.5.9_rails6_postgres_redis.gemfile.lock
+++ b/gemfiles/ruby_2.5.9_rails6_postgres_redis.gemfile.lock
@@ -15,7 +15,7 @@ PATH
       datadog-ci (~> 0.1.0)
       debase-ruby_core_source (= 3.2.1)
       libdatadog (~> 4.0.0.1.0)
-      libddwaf (~> 1.11.0.0.0)
+      libddwaf (~> 1.14.0.0.0)
       msgpack
 
 GEM
@@ -118,9 +118,9 @@ GEM
       addressable (>= 2.4)
     libdatadog (4.0.0.1.0-aarch64-linux)
     libdatadog (4.0.0.1.0-x86_64-linux)
-    libddwaf (1.11.0.0.0-aarch64-linux)
+    libddwaf (1.14.0.0.0-aarch64-linux)
       ffi (~> 1.0)
-    libddwaf (1.11.0.0.0-x86_64-linux)
+    libddwaf (1.14.0.0.0-x86_64-linux)
       ffi (~> 1.0)
     lograge (0.12.0)
       actionpack (>= 4)

--- a/gemfiles/ruby_2.5.9_rails6_postgres_redis_activesupport.gemfile.lock
+++ b/gemfiles/ruby_2.5.9_rails6_postgres_redis_activesupport.gemfile.lock
@@ -15,7 +15,7 @@ PATH
       datadog-ci (~> 0.1.0)
       debase-ruby_core_source (= 3.2.1)
       libdatadog (~> 4.0.0.1.0)
-      libddwaf (~> 1.11.0.0.0)
+      libddwaf (~> 1.14.0.0.0)
       msgpack
 
 GEM
@@ -117,9 +117,9 @@ GEM
       addressable (>= 2.4)
     libdatadog (4.0.0.1.0-aarch64-linux)
     libdatadog (4.0.0.1.0-x86_64-linux)
-    libddwaf (1.11.0.0.0-aarch64-linux)
+    libddwaf (1.14.0.0.0-aarch64-linux)
       ffi (~> 1.0)
-    libddwaf (1.11.0.0.0-x86_64-linux)
+    libddwaf (1.14.0.0.0-x86_64-linux)
       ffi (~> 1.0)
     lograge (0.12.0)
       actionpack (>= 4)

--- a/gemfiles/ruby_2.5.9_rails6_postgres_sidekiq.gemfile.lock
+++ b/gemfiles/ruby_2.5.9_rails6_postgres_sidekiq.gemfile.lock
@@ -15,7 +15,7 @@ PATH
       datadog-ci (~> 0.1.0)
       debase-ruby_core_source (= 3.2.1)
       libdatadog (~> 4.0.0.1.0)
-      libddwaf (~> 1.11.0.0.0)
+      libddwaf (~> 1.14.0.0.0)
       msgpack
 
 GEM
@@ -118,9 +118,9 @@ GEM
       addressable (>= 2.4)
     libdatadog (4.0.0.1.0-aarch64-linux)
     libdatadog (4.0.0.1.0-x86_64-linux)
-    libddwaf (1.11.0.0.0-aarch64-linux)
+    libddwaf (1.14.0.0.0-aarch64-linux)
       ffi (~> 1.0)
-    libddwaf (1.11.0.0.0-x86_64-linux)
+    libddwaf (1.14.0.0.0-x86_64-linux)
       ffi (~> 1.0)
     lograge (0.12.0)
       actionpack (>= 4)

--- a/gemfiles/ruby_2.5.9_rails6_semantic_logger.gemfile.lock
+++ b/gemfiles/ruby_2.5.9_rails6_semantic_logger.gemfile.lock
@@ -15,7 +15,7 @@ PATH
       datadog-ci (~> 0.1.0)
       debase-ruby_core_source (= 3.2.1)
       libdatadog (~> 4.0.0.1.0)
-      libddwaf (~> 1.11.0.0.0)
+      libddwaf (~> 1.14.0.0.0)
       msgpack
 
 GEM
@@ -117,9 +117,9 @@ GEM
       addressable (>= 2.4)
     libdatadog (4.0.0.1.0-aarch64-linux)
     libdatadog (4.0.0.1.0-x86_64-linux)
-    libddwaf (1.11.0.0.0-aarch64-linux)
+    libddwaf (1.14.0.0.0-aarch64-linux)
       ffi (~> 1.0)
-    libddwaf (1.11.0.0.0-x86_64-linux)
+    libddwaf (1.14.0.0.0-x86_64-linux)
       ffi (~> 1.0)
     loofah (2.19.1)
       crass (~> 1.0.2)

--- a/gemfiles/ruby_2.5.9_redis_3.gemfile.lock
+++ b/gemfiles/ruby_2.5.9_redis_3.gemfile.lock
@@ -15,7 +15,7 @@ PATH
       datadog-ci (~> 0.1.0)
       debase-ruby_core_source (= 3.2.1)
       libdatadog (~> 4.0.0.1.0)
-      libddwaf (~> 1.11.0.0.0)
+      libddwaf (~> 1.14.0.0.0)
       msgpack
 
 GEM
@@ -54,9 +54,9 @@ GEM
       addressable (>= 2.4)
     libdatadog (4.0.0.1.0-aarch64-linux)
     libdatadog (4.0.0.1.0-x86_64-linux)
-    libddwaf (1.11.0.0.0-aarch64-linux)
+    libddwaf (1.14.0.0.0-aarch64-linux)
       ffi (~> 1.0)
-    libddwaf (1.11.0.0.0-x86_64-linux)
+    libddwaf (1.14.0.0.0-x86_64-linux)
       ffi (~> 1.0)
     memory_profiler (0.9.14)
     method_source (1.0.0)

--- a/gemfiles/ruby_2.5.9_redis_4.gemfile.lock
+++ b/gemfiles/ruby_2.5.9_redis_4.gemfile.lock
@@ -15,7 +15,7 @@ PATH
       datadog-ci (~> 0.1.0)
       debase-ruby_core_source (= 3.2.1)
       libdatadog (~> 4.0.0.1.0)
-      libddwaf (~> 1.11.0.0.0)
+      libddwaf (~> 1.14.0.0.0)
       msgpack
 
 GEM
@@ -54,9 +54,9 @@ GEM
       addressable (>= 2.4)
     libdatadog (4.0.0.1.0-aarch64-linux)
     libdatadog (4.0.0.1.0-x86_64-linux)
-    libddwaf (1.11.0.0.0-aarch64-linux)
+    libddwaf (1.14.0.0.0-aarch64-linux)
       ffi (~> 1.0)
-    libddwaf (1.11.0.0.0-x86_64-linux)
+    libddwaf (1.14.0.0.0-x86_64-linux)
       ffi (~> 1.0)
     memory_profiler (0.9.14)
     method_source (1.0.0)

--- a/gemfiles/ruby_2.5.9_redis_5.gemfile.lock
+++ b/gemfiles/ruby_2.5.9_redis_5.gemfile.lock
@@ -15,7 +15,7 @@ PATH
       datadog-ci (~> 0.1.0)
       debase-ruby_core_source (= 3.2.1)
       libdatadog (~> 4.0.0.1.0)
-      libddwaf (~> 1.11.0.0.0)
+      libddwaf (~> 1.14.0.0.0)
       msgpack
 
 GEM
@@ -55,9 +55,9 @@ GEM
       addressable (>= 2.4)
     libdatadog (4.0.0.1.0-aarch64-linux)
     libdatadog (4.0.0.1.0-x86_64-linux)
-    libddwaf (1.11.0.0.0-aarch64-linux)
+    libddwaf (1.14.0.0.0-aarch64-linux)
       ffi (~> 1.0)
-    libddwaf (1.11.0.0.0-x86_64-linux)
+    libddwaf (1.14.0.0.0-x86_64-linux)
       ffi (~> 1.0)
     memory_profiler (0.9.14)
     method_source (1.0.0)

--- a/gemfiles/ruby_2.5.9_relational_db.gemfile.lock
+++ b/gemfiles/ruby_2.5.9_relational_db.gemfile.lock
@@ -15,7 +15,7 @@ PATH
       datadog-ci (~> 0.1.0)
       debase-ruby_core_source (= 3.2.1)
       libdatadog (~> 4.0.0.1.0)
-      libddwaf (~> 1.11.0.0.0)
+      libddwaf (~> 1.14.0.0.0)
       msgpack
 
 GEM
@@ -71,10 +71,11 @@ GEM
     json-schema (2.8.1)
       addressable (>= 2.4)
     libdatadog (4.0.0.1.0-aarch64-linux)
-    libddwaf (1.11.0.0.0-aarch64-linux)
+    libdatadog (4.0.0.1.0-x86_64-linux)
+    libddwaf (1.14.0.0.0-aarch64-linux)
       ffi (~> 1.0)
-    makara (0.5.1)
-      activerecord (>= 5.2.0)
+    libddwaf (1.14.0.0.0-x86_64-linux)
+      ffi (~> 1.0)
     memory_profiler (0.9.14)
     method_source (1.0.0)
     minitest (5.15.0)

--- a/gemfiles/ruby_2.5.9_resque2_redis3.gemfile.lock
+++ b/gemfiles/ruby_2.5.9_resque2_redis3.gemfile.lock
@@ -15,7 +15,7 @@ PATH
       datadog-ci (~> 0.1.0)
       debase-ruby_core_source (= 3.2.1)
       libdatadog (~> 4.0.0.1.0)
-      libddwaf (~> 1.11.0.0.0)
+      libddwaf (~> 1.14.0.0.0)
       msgpack
 
 GEM
@@ -54,9 +54,9 @@ GEM
       addressable (>= 2.4)
     libdatadog (4.0.0.1.0-aarch64-linux)
     libdatadog (4.0.0.1.0-x86_64-linux)
-    libddwaf (1.11.0.0.0-aarch64-linux)
+    libddwaf (1.14.0.0.0-aarch64-linux)
       ffi (~> 1.0)
-    libddwaf (1.11.0.0.0-x86_64-linux)
+    libddwaf (1.14.0.0.0-x86_64-linux)
       ffi (~> 1.0)
     memory_profiler (0.9.14)
     method_source (1.0.0)

--- a/gemfiles/ruby_2.5.9_resque2_redis4.gemfile.lock
+++ b/gemfiles/ruby_2.5.9_resque2_redis4.gemfile.lock
@@ -15,7 +15,7 @@ PATH
       datadog-ci (~> 0.1.0)
       debase-ruby_core_source (= 3.2.1)
       libdatadog (~> 4.0.0.1.0)
-      libddwaf (~> 1.11.0.0.0)
+      libddwaf (~> 1.14.0.0.0)
       msgpack
 
 GEM
@@ -55,9 +55,9 @@ GEM
       addressable (>= 2.4)
     libdatadog (4.0.0.1.0-aarch64-linux)
     libdatadog (4.0.0.1.0-x86_64-linux)
-    libddwaf (1.11.0.0.0-aarch64-linux)
+    libddwaf (1.14.0.0.0-aarch64-linux)
       ffi (~> 1.0)
-    libddwaf (1.11.0.0.0-x86_64-linux)
+    libddwaf (1.14.0.0.0-x86_64-linux)
       ffi (~> 1.0)
     memory_profiler (0.9.14)
     method_source (1.0.0)

--- a/gemfiles/ruby_2.5.9_sinatra.gemfile.lock
+++ b/gemfiles/ruby_2.5.9_sinatra.gemfile.lock
@@ -15,7 +15,7 @@ PATH
       datadog-ci (~> 0.1.0)
       debase-ruby_core_source (= 3.2.1)
       libdatadog (~> 4.0.0.1.0)
-      libddwaf (~> 1.11.0.0.0)
+      libddwaf (~> 1.14.0.0.0)
       msgpack
 
 GEM
@@ -54,9 +54,9 @@ GEM
       addressable (>= 2.4)
     libdatadog (4.0.0.1.0-aarch64-linux)
     libdatadog (4.0.0.1.0-x86_64-linux)
-    libddwaf (1.11.0.0.0-aarch64-linux)
+    libddwaf (1.14.0.0.0-aarch64-linux)
       ffi (~> 1.0)
-    libddwaf (1.11.0.0.0-x86_64-linux)
+    libddwaf (1.14.0.0.0-x86_64-linux)
       ffi (~> 1.0)
     memory_profiler (0.9.14)
     method_source (1.0.0)

--- a/gemfiles/ruby_2.6.10_aws.gemfile.lock
+++ b/gemfiles/ruby_2.6.10_aws.gemfile.lock
@@ -15,7 +15,7 @@ PATH
       datadog-ci (~> 0.1.0)
       debase-ruby_core_source (= 3.2.1)
       libdatadog (~> 4.0.0.1.0)
-      libddwaf (~> 1.11.0.0.0)
+      libddwaf (~> 1.14.0.0.0)
       msgpack
 
 GEM
@@ -1477,7 +1477,7 @@ GEM
     json-schema (2.8.1)
       addressable (>= 2.4)
     libdatadog (4.0.0.1.0-aarch64-linux)
-    libddwaf (1.11.0.0.0-aarch64-linux)
+    libddwaf (1.14.0.0.0-aarch64-linux)
       ffi (~> 1.0)
     memory_profiler (0.9.14)
     method_source (1.0.0)

--- a/gemfiles/ruby_2.6.10_contrib.gemfile.lock
+++ b/gemfiles/ruby_2.6.10_contrib.gemfile.lock
@@ -15,7 +15,7 @@ PATH
       datadog-ci (~> 0.1.0)
       debase-ruby_core_source (= 3.2.1)
       libdatadog (~> 4.0.0.1.0)
-      libddwaf (~> 1.11.0.0.0)
+      libddwaf (~> 1.14.0.0.0)
       msgpack
 
 GEM
@@ -137,9 +137,9 @@ GEM
     king_konf (1.0.1)
     libdatadog (4.0.0.1.0-aarch64-linux)
     libdatadog (4.0.0.1.0-x86_64-linux)
-    libddwaf (1.11.0.0.0-aarch64-linux)
+    libddwaf (1.14.0.0.0-aarch64-linux)
       ffi (~> 1.0)
-    libddwaf (1.11.0.0.0-x86_64-linux)
+    libddwaf (1.14.0.0.0-x86_64-linux)
       ffi (~> 1.0)
     lograge (0.13.0)
       actionpack (>= 4)

--- a/gemfiles/ruby_2.6.10_contrib_old.gemfile.lock
+++ b/gemfiles/ruby_2.6.10_contrib_old.gemfile.lock
@@ -15,7 +15,7 @@ PATH
       datadog-ci (~> 0.1.0)
       debase-ruby_core_source (= 3.2.1)
       libdatadog (~> 4.0.0.1.0)
-      libddwaf (~> 1.11.0.0.0)
+      libddwaf (~> 1.14.0.0.0)
       msgpack
 
 GEM
@@ -77,9 +77,9 @@ GEM
       addressable (>= 2.4)
     libdatadog (4.0.0.1.0-aarch64-linux)
     libdatadog (4.0.0.1.0-x86_64-linux)
-    libddwaf (1.11.0.0.0-aarch64-linux)
+    libddwaf (1.14.0.0.0-aarch64-linux)
       ffi (~> 1.0)
-    libddwaf (1.11.0.0.0-x86_64-linux)
+    libddwaf (1.14.0.0.0-x86_64-linux)
       ffi (~> 1.0)
     memory_profiler (0.9.14)
     method_source (1.0.0)

--- a/gemfiles/ruby_2.6.10_core_old.gemfile.lock
+++ b/gemfiles/ruby_2.6.10_core_old.gemfile.lock
@@ -15,7 +15,7 @@ PATH
       datadog-ci (~> 0.1.0)
       debase-ruby_core_source (= 3.2.1)
       libdatadog (~> 4.0.0.1.0)
-      libddwaf (~> 1.11.0.0.0)
+      libddwaf (~> 1.14.0.0.0)
       msgpack
 
 GEM
@@ -57,9 +57,9 @@ GEM
       addressable (>= 2.4)
     libdatadog (4.0.0.1.0-aarch64-linux)
     libdatadog (4.0.0.1.0-x86_64-linux)
-    libddwaf (1.11.0.0.0-aarch64-linux)
+    libddwaf (1.14.0.0.0-aarch64-linux)
       ffi (~> 1.0)
-    libddwaf (1.11.0.0.0-x86_64-linux)
+    libddwaf (1.14.0.0.0-x86_64-linux)
       ffi (~> 1.0)
     memory_profiler (0.9.14)
     method_source (1.0.0)

--- a/gemfiles/ruby_2.6.10_hanami_1.gemfile.lock
+++ b/gemfiles/ruby_2.6.10_hanami_1.gemfile.lock
@@ -15,7 +15,7 @@ PATH
       datadog-ci (~> 0.1.0)
       debase-ruby_core_source (= 3.2.1)
       libdatadog (~> 4.0.0.1.0)
-      libddwaf (~> 1.11.0.0.0)
+      libddwaf (~> 1.14.0.0.0)
       msgpack
 
 GEM
@@ -132,9 +132,9 @@ GEM
       addressable (>= 2.4)
     libdatadog (4.0.0.1.0-aarch64-linux)
     libdatadog (4.0.0.1.0-x86_64-linux)
-    libddwaf (1.11.0.0.0-aarch64-linux)
+    libddwaf (1.14.0.0.0-aarch64-linux)
       ffi (~> 1.0)
-    libddwaf (1.11.0.0.0-x86_64-linux)
+    libddwaf (1.14.0.0.0-x86_64-linux)
       ffi (~> 1.0)
     mail (2.8.1)
       mini_mime (>= 0.1.1)

--- a/gemfiles/ruby_2.6.10_http.gemfile.lock
+++ b/gemfiles/ruby_2.6.10_http.gemfile.lock
@@ -15,7 +15,7 @@ PATH
       datadog-ci (~> 0.1.0)
       debase-ruby_core_source (= 3.2.1)
       libdatadog (~> 4.0.0.1.0)
-      libddwaf (~> 1.11.0.0.0)
+      libddwaf (~> 1.14.0.0.0)
       msgpack
 
 GEM
@@ -85,7 +85,7 @@ GEM
     json-schema (2.8.1)
       addressable (>= 2.4)
     libdatadog (4.0.0.1.0-aarch64-linux)
-    libddwaf (1.11.0.0.0-aarch64-linux)
+    libddwaf (1.14.0.0.0-aarch64-linux)
       ffi (~> 1.0)
     llhttp-ffi (0.3.1)
       ffi-compiler (~> 1.0)

--- a/gemfiles/ruby_2.6.10_opentelemetry.gemfile.lock
+++ b/gemfiles/ruby_2.6.10_opentelemetry.gemfile.lock
@@ -15,7 +15,7 @@ PATH
       datadog-ci (~> 0.1.0)
       debase-ruby_core_source (= 3.2.1)
       libdatadog (~> 4.0.0.1.0)
-      libddwaf (~> 1.11.0.0.0)
+      libddwaf (~> 1.14.0.0.0)
       msgpack
 
 GEM
@@ -57,9 +57,9 @@ GEM
       addressable (>= 2.4)
     libdatadog (4.0.0.1.0-aarch64-linux)
     libdatadog (4.0.0.1.0-x86_64-linux)
-    libddwaf (1.11.0.0.0-aarch64-linux)
+    libddwaf (1.14.0.0.0-aarch64-linux)
       ffi (~> 1.0)
-    libddwaf (1.11.0.0.0-x86_64-linux)
+    libddwaf (1.14.0.0.0-x86_64-linux)
       ffi (~> 1.0)
     memory_profiler (0.9.14)
     method_source (1.0.0)

--- a/gemfiles/ruby_2.6.10_rails5_mysql2.gemfile.lock
+++ b/gemfiles/ruby_2.6.10_rails5_mysql2.gemfile.lock
@@ -15,7 +15,7 @@ PATH
       datadog-ci (~> 0.1.0)
       debase-ruby_core_source (= 3.2.1)
       libdatadog (~> 4.0.0.1.0)
-      libddwaf (~> 1.11.0.0.0)
+      libddwaf (~> 1.14.0.0.0)
       msgpack
 
 GEM
@@ -106,9 +106,9 @@ GEM
       addressable (>= 2.4)
     libdatadog (4.0.0.1.0-aarch64-linux)
     libdatadog (4.0.0.1.0-x86_64-linux)
-    libddwaf (1.11.0.0.0-aarch64-linux)
+    libddwaf (1.14.0.0.0-aarch64-linux)
       ffi (~> 1.0)
-    libddwaf (1.11.0.0.0-x86_64-linux)
+    libddwaf (1.14.0.0.0-x86_64-linux)
       ffi (~> 1.0)
     lograge (0.12.0)
       actionpack (>= 4)

--- a/gemfiles/ruby_2.6.10_rails5_postgres.gemfile.lock
+++ b/gemfiles/ruby_2.6.10_rails5_postgres.gemfile.lock
@@ -15,7 +15,7 @@ PATH
       datadog-ci (~> 0.1.0)
       debase-ruby_core_source (= 3.2.1)
       libdatadog (~> 4.0.0.1.0)
-      libddwaf (~> 1.11.0.0.0)
+      libddwaf (~> 1.14.0.0.0)
       msgpack
 
 GEM
@@ -106,9 +106,9 @@ GEM
       addressable (>= 2.4)
     libdatadog (4.0.0.1.0-aarch64-linux)
     libdatadog (4.0.0.1.0-x86_64-linux)
-    libddwaf (1.11.0.0.0-aarch64-linux)
+    libddwaf (1.14.0.0.0-aarch64-linux)
       ffi (~> 1.0)
-    libddwaf (1.11.0.0.0-x86_64-linux)
+    libddwaf (1.14.0.0.0-x86_64-linux)
       ffi (~> 1.0)
     lograge (0.12.0)
       actionpack (>= 4)

--- a/gemfiles/ruby_2.6.10_rails5_postgres_redis.gemfile.lock
+++ b/gemfiles/ruby_2.6.10_rails5_postgres_redis.gemfile.lock
@@ -15,7 +15,7 @@ PATH
       datadog-ci (~> 0.1.0)
       debase-ruby_core_source (= 3.2.1)
       libdatadog (~> 4.0.0.1.0)
-      libddwaf (~> 1.11.0.0.0)
+      libddwaf (~> 1.14.0.0.0)
       msgpack
 
 GEM
@@ -106,9 +106,9 @@ GEM
       addressable (>= 2.4)
     libdatadog (4.0.0.1.0-aarch64-linux)
     libdatadog (4.0.0.1.0-x86_64-linux)
-    libddwaf (1.11.0.0.0-aarch64-linux)
+    libddwaf (1.14.0.0.0-aarch64-linux)
       ffi (~> 1.0)
-    libddwaf (1.11.0.0.0-x86_64-linux)
+    libddwaf (1.14.0.0.0-x86_64-linux)
       ffi (~> 1.0)
     lograge (0.12.0)
       actionpack (>= 4)

--- a/gemfiles/ruby_2.6.10_rails5_postgres_redis_activesupport.gemfile.lock
+++ b/gemfiles/ruby_2.6.10_rails5_postgres_redis_activesupport.gemfile.lock
@@ -15,7 +15,7 @@ PATH
       datadog-ci (~> 0.1.0)
       debase-ruby_core_source (= 3.2.1)
       libdatadog (~> 4.0.0.1.0)
-      libddwaf (~> 1.11.0.0.0)
+      libddwaf (~> 1.14.0.0.0)
       msgpack
 
 GEM
@@ -106,9 +106,9 @@ GEM
       addressable (>= 2.4)
     libdatadog (4.0.0.1.0-aarch64-linux)
     libdatadog (4.0.0.1.0-x86_64-linux)
-    libddwaf (1.11.0.0.0-aarch64-linux)
+    libddwaf (1.14.0.0.0-aarch64-linux)
       ffi (~> 1.0)
-    libddwaf (1.11.0.0.0-x86_64-linux)
+    libddwaf (1.14.0.0.0-x86_64-linux)
       ffi (~> 1.0)
     lograge (0.12.0)
       actionpack (>= 4)

--- a/gemfiles/ruby_2.6.10_rails5_postgres_sidekiq.gemfile.lock
+++ b/gemfiles/ruby_2.6.10_rails5_postgres_sidekiq.gemfile.lock
@@ -15,7 +15,7 @@ PATH
       datadog-ci (~> 0.1.0)
       debase-ruby_core_source (= 3.2.1)
       libdatadog (~> 4.0.0.1.0)
-      libddwaf (~> 1.11.0.0.0)
+      libddwaf (~> 1.14.0.0.0)
       msgpack
 
 GEM
@@ -107,9 +107,9 @@ GEM
       addressable (>= 2.4)
     libdatadog (4.0.0.1.0-aarch64-linux)
     libdatadog (4.0.0.1.0-x86_64-linux)
-    libddwaf (1.11.0.0.0-aarch64-linux)
+    libddwaf (1.14.0.0.0-aarch64-linux)
       ffi (~> 1.0)
-    libddwaf (1.11.0.0.0-x86_64-linux)
+    libddwaf (1.14.0.0.0-x86_64-linux)
       ffi (~> 1.0)
     lograge (0.12.0)
       actionpack (>= 4)

--- a/gemfiles/ruby_2.6.10_rails5_semantic_logger.gemfile.lock
+++ b/gemfiles/ruby_2.6.10_rails5_semantic_logger.gemfile.lock
@@ -15,7 +15,7 @@ PATH
       datadog-ci (~> 0.1.0)
       debase-ruby_core_source (= 3.2.1)
       libdatadog (~> 4.0.0.1.0)
-      libddwaf (~> 1.11.0.0.0)
+      libddwaf (~> 1.14.0.0.0)
       msgpack
 
 GEM
@@ -106,9 +106,9 @@ GEM
       addressable (>= 2.4)
     libdatadog (4.0.0.1.0-aarch64-linux)
     libdatadog (4.0.0.1.0-x86_64-linux)
-    libddwaf (1.11.0.0.0-aarch64-linux)
+    libddwaf (1.14.0.0.0-aarch64-linux)
       ffi (~> 1.0)
-    libddwaf (1.11.0.0.0-x86_64-linux)
+    libddwaf (1.14.0.0.0-x86_64-linux)
       ffi (~> 1.0)
     loofah (2.19.1)
       crass (~> 1.0.2)

--- a/gemfiles/ruby_2.6.10_rails61_mysql2.gemfile.lock
+++ b/gemfiles/ruby_2.6.10_rails61_mysql2.gemfile.lock
@@ -15,7 +15,7 @@ PATH
       datadog-ci (~> 0.1.0)
       debase-ruby_core_source (= 3.2.1)
       libdatadog (~> 4.0.0.1.0)
-      libddwaf (~> 1.11.0.0.0)
+      libddwaf (~> 1.14.0.0.0)
       msgpack
 
 GEM
@@ -123,9 +123,9 @@ GEM
       addressable (>= 2.4)
     libdatadog (4.0.0.1.0-aarch64-linux)
     libdatadog (4.0.0.1.0-x86_64-linux)
-    libddwaf (1.11.0.0.0-aarch64-linux)
+    libddwaf (1.14.0.0.0-aarch64-linux)
       ffi (~> 1.0)
-    libddwaf (1.11.0.0.0-x86_64-linux)
+    libddwaf (1.14.0.0.0-x86_64-linux)
       ffi (~> 1.0)
     lograge (0.12.0)
       actionpack (>= 4)

--- a/gemfiles/ruby_2.6.10_rails61_postgres.gemfile.lock
+++ b/gemfiles/ruby_2.6.10_rails61_postgres.gemfile.lock
@@ -15,7 +15,7 @@ PATH
       datadog-ci (~> 0.1.0)
       debase-ruby_core_source (= 3.2.1)
       libdatadog (~> 4.0.0.1.0)
-      libddwaf (~> 1.11.0.0.0)
+      libddwaf (~> 1.14.0.0.0)
       msgpack
 
 GEM
@@ -123,9 +123,9 @@ GEM
       addressable (>= 2.4)
     libdatadog (4.0.0.1.0-aarch64-linux)
     libdatadog (4.0.0.1.0-x86_64-linux)
-    libddwaf (1.11.0.0.0-aarch64-linux)
+    libddwaf (1.14.0.0.0-aarch64-linux)
       ffi (~> 1.0)
-    libddwaf (1.11.0.0.0-x86_64-linux)
+    libddwaf (1.14.0.0.0-x86_64-linux)
       ffi (~> 1.0)
     lograge (0.12.0)
       actionpack (>= 4)

--- a/gemfiles/ruby_2.6.10_rails61_postgres_redis.gemfile.lock
+++ b/gemfiles/ruby_2.6.10_rails61_postgres_redis.gemfile.lock
@@ -15,7 +15,7 @@ PATH
       datadog-ci (~> 0.1.0)
       debase-ruby_core_source (= 3.2.1)
       libdatadog (~> 4.0.0.1.0)
-      libddwaf (~> 1.11.0.0.0)
+      libddwaf (~> 1.14.0.0.0)
       msgpack
 
 GEM
@@ -123,9 +123,9 @@ GEM
       addressable (>= 2.4)
     libdatadog (4.0.0.1.0-aarch64-linux)
     libdatadog (4.0.0.1.0-x86_64-linux)
-    libddwaf (1.11.0.0.0-aarch64-linux)
+    libddwaf (1.14.0.0.0-aarch64-linux)
       ffi (~> 1.0)
-    libddwaf (1.11.0.0.0-x86_64-linux)
+    libddwaf (1.14.0.0.0-x86_64-linux)
       ffi (~> 1.0)
     lograge (0.12.0)
       actionpack (>= 4)

--- a/gemfiles/ruby_2.6.10_rails61_postgres_sidekiq.gemfile.lock
+++ b/gemfiles/ruby_2.6.10_rails61_postgres_sidekiq.gemfile.lock
@@ -15,7 +15,7 @@ PATH
       datadog-ci (~> 0.1.0)
       debase-ruby_core_source (= 3.2.1)
       libdatadog (~> 4.0.0.1.0)
-      libddwaf (~> 1.11.0.0.0)
+      libddwaf (~> 1.14.0.0.0)
       msgpack
 
 GEM
@@ -124,9 +124,9 @@ GEM
       addressable (>= 2.4)
     libdatadog (4.0.0.1.0-aarch64-linux)
     libdatadog (4.0.0.1.0-x86_64-linux)
-    libddwaf (1.11.0.0.0-aarch64-linux)
+    libddwaf (1.14.0.0.0-aarch64-linux)
       ffi (~> 1.0)
-    libddwaf (1.11.0.0.0-x86_64-linux)
+    libddwaf (1.14.0.0.0-x86_64-linux)
       ffi (~> 1.0)
     lograge (0.12.0)
       actionpack (>= 4)

--- a/gemfiles/ruby_2.6.10_rails61_semantic_logger.gemfile.lock
+++ b/gemfiles/ruby_2.6.10_rails61_semantic_logger.gemfile.lock
@@ -15,7 +15,7 @@ PATH
       datadog-ci (~> 0.1.0)
       debase-ruby_core_source (= 3.2.1)
       libdatadog (~> 4.0.0.1.0)
-      libddwaf (~> 1.11.0.0.0)
+      libddwaf (~> 1.14.0.0.0)
       msgpack
 
 GEM
@@ -123,9 +123,9 @@ GEM
       addressable (>= 2.4)
     libdatadog (4.0.0.1.0-aarch64-linux)
     libdatadog (4.0.0.1.0-x86_64-linux)
-    libddwaf (1.11.0.0.0-aarch64-linux)
+    libddwaf (1.14.0.0.0-aarch64-linux)
       ffi (~> 1.0)
-    libddwaf (1.11.0.0.0-x86_64-linux)
+    libddwaf (1.14.0.0.0-x86_64-linux)
       ffi (~> 1.0)
     loofah (2.19.1)
       crass (~> 1.0.2)

--- a/gemfiles/ruby_2.6.10_rails6_mysql2.gemfile.lock
+++ b/gemfiles/ruby_2.6.10_rails6_mysql2.gemfile.lock
@@ -15,7 +15,7 @@ PATH
       datadog-ci (~> 0.1.0)
       debase-ruby_core_source (= 3.2.1)
       libdatadog (~> 4.0.0.1.0)
-      libddwaf (~> 1.11.0.0.0)
+      libddwaf (~> 1.14.0.0.0)
       msgpack
 
 GEM
@@ -119,9 +119,9 @@ GEM
       addressable (>= 2.4)
     libdatadog (4.0.0.1.0-aarch64-linux)
     libdatadog (4.0.0.1.0-x86_64-linux)
-    libddwaf (1.11.0.0.0-aarch64-linux)
+    libddwaf (1.14.0.0.0-aarch64-linux)
       ffi (~> 1.0)
-    libddwaf (1.11.0.0.0-x86_64-linux)
+    libddwaf (1.14.0.0.0-x86_64-linux)
       ffi (~> 1.0)
     lograge (0.12.0)
       actionpack (>= 4)

--- a/gemfiles/ruby_2.6.10_rails6_postgres.gemfile.lock
+++ b/gemfiles/ruby_2.6.10_rails6_postgres.gemfile.lock
@@ -15,7 +15,7 @@ PATH
       datadog-ci (~> 0.1.0)
       debase-ruby_core_source (= 3.2.1)
       libdatadog (~> 4.0.0.1.0)
-      libddwaf (~> 1.11.0.0.0)
+      libddwaf (~> 1.14.0.0.0)
       msgpack
 
 GEM
@@ -119,9 +119,9 @@ GEM
       addressable (>= 2.4)
     libdatadog (4.0.0.1.0-aarch64-linux)
     libdatadog (4.0.0.1.0-x86_64-linux)
-    libddwaf (1.11.0.0.0-aarch64-linux)
+    libddwaf (1.14.0.0.0-aarch64-linux)
       ffi (~> 1.0)
-    libddwaf (1.11.0.0.0-x86_64-linux)
+    libddwaf (1.14.0.0.0-x86_64-linux)
       ffi (~> 1.0)
     lograge (0.12.0)
       actionpack (>= 4)

--- a/gemfiles/ruby_2.6.10_rails6_postgres_redis.gemfile.lock
+++ b/gemfiles/ruby_2.6.10_rails6_postgres_redis.gemfile.lock
@@ -15,7 +15,7 @@ PATH
       datadog-ci (~> 0.1.0)
       debase-ruby_core_source (= 3.2.1)
       libdatadog (~> 4.0.0.1.0)
-      libddwaf (~> 1.11.0.0.0)
+      libddwaf (~> 1.14.0.0.0)
       msgpack
 
 GEM
@@ -119,9 +119,9 @@ GEM
       addressable (>= 2.4)
     libdatadog (4.0.0.1.0-aarch64-linux)
     libdatadog (4.0.0.1.0-x86_64-linux)
-    libddwaf (1.11.0.0.0-aarch64-linux)
+    libddwaf (1.14.0.0.0-aarch64-linux)
       ffi (~> 1.0)
-    libddwaf (1.11.0.0.0-x86_64-linux)
+    libddwaf (1.14.0.0.0-x86_64-linux)
       ffi (~> 1.0)
     lograge (0.12.0)
       actionpack (>= 4)

--- a/gemfiles/ruby_2.6.10_rails6_postgres_redis_activesupport.gemfile.lock
+++ b/gemfiles/ruby_2.6.10_rails6_postgres_redis_activesupport.gemfile.lock
@@ -15,7 +15,7 @@ PATH
       datadog-ci (~> 0.1.0)
       debase-ruby_core_source (= 3.2.1)
       libdatadog (~> 4.0.0.1.0)
-      libddwaf (~> 1.11.0.0.0)
+      libddwaf (~> 1.14.0.0.0)
       msgpack
 
 GEM
@@ -119,9 +119,9 @@ GEM
       addressable (>= 2.4)
     libdatadog (4.0.0.1.0-aarch64-linux)
     libdatadog (4.0.0.1.0-x86_64-linux)
-    libddwaf (1.11.0.0.0-aarch64-linux)
+    libddwaf (1.14.0.0.0-aarch64-linux)
       ffi (~> 1.0)
-    libddwaf (1.11.0.0.0-x86_64-linux)
+    libddwaf (1.14.0.0.0-x86_64-linux)
       ffi (~> 1.0)
     lograge (0.12.0)
       actionpack (>= 4)

--- a/gemfiles/ruby_2.6.10_rails6_postgres_sidekiq.gemfile.lock
+++ b/gemfiles/ruby_2.6.10_rails6_postgres_sidekiq.gemfile.lock
@@ -15,7 +15,7 @@ PATH
       datadog-ci (~> 0.1.0)
       debase-ruby_core_source (= 3.2.1)
       libdatadog (~> 4.0.0.1.0)
-      libddwaf (~> 1.11.0.0.0)
+      libddwaf (~> 1.14.0.0.0)
       msgpack
 
 GEM
@@ -120,9 +120,9 @@ GEM
       addressable (>= 2.4)
     libdatadog (4.0.0.1.0-aarch64-linux)
     libdatadog (4.0.0.1.0-x86_64-linux)
-    libddwaf (1.11.0.0.0-aarch64-linux)
+    libddwaf (1.14.0.0.0-aarch64-linux)
       ffi (~> 1.0)
-    libddwaf (1.11.0.0.0-x86_64-linux)
+    libddwaf (1.14.0.0.0-x86_64-linux)
       ffi (~> 1.0)
     lograge (0.12.0)
       actionpack (>= 4)

--- a/gemfiles/ruby_2.6.10_rails6_semantic_logger.gemfile.lock
+++ b/gemfiles/ruby_2.6.10_rails6_semantic_logger.gemfile.lock
@@ -15,7 +15,7 @@ PATH
       datadog-ci (~> 0.1.0)
       debase-ruby_core_source (= 3.2.1)
       libdatadog (~> 4.0.0.1.0)
-      libddwaf (~> 1.11.0.0.0)
+      libddwaf (~> 1.14.0.0.0)
       msgpack
 
 GEM
@@ -119,9 +119,9 @@ GEM
       addressable (>= 2.4)
     libdatadog (4.0.0.1.0-aarch64-linux)
     libdatadog (4.0.0.1.0-x86_64-linux)
-    libddwaf (1.11.0.0.0-aarch64-linux)
+    libddwaf (1.14.0.0.0-aarch64-linux)
       ffi (~> 1.0)
-    libddwaf (1.11.0.0.0-x86_64-linux)
+    libddwaf (1.14.0.0.0-x86_64-linux)
       ffi (~> 1.0)
     loofah (2.19.1)
       crass (~> 1.0.2)

--- a/gemfiles/ruby_2.6.10_redis_3.gemfile.lock
+++ b/gemfiles/ruby_2.6.10_redis_3.gemfile.lock
@@ -15,7 +15,7 @@ PATH
       datadog-ci (~> 0.1.0)
       debase-ruby_core_source (= 3.2.1)
       libdatadog (~> 4.0.0.1.0)
-      libddwaf (~> 1.11.0.0.0)
+      libddwaf (~> 1.14.0.0.0)
       msgpack
 
 GEM
@@ -57,9 +57,9 @@ GEM
       addressable (>= 2.4)
     libdatadog (4.0.0.1.0-aarch64-linux)
     libdatadog (4.0.0.1.0-x86_64-linux)
-    libddwaf (1.11.0.0.0-aarch64-linux)
+    libddwaf (1.14.0.0.0-aarch64-linux)
       ffi (~> 1.0)
-    libddwaf (1.11.0.0.0-x86_64-linux)
+    libddwaf (1.14.0.0.0-x86_64-linux)
       ffi (~> 1.0)
     memory_profiler (0.9.14)
     method_source (1.0.0)

--- a/gemfiles/ruby_2.6.10_redis_4.gemfile.lock
+++ b/gemfiles/ruby_2.6.10_redis_4.gemfile.lock
@@ -15,7 +15,7 @@ PATH
       datadog-ci (~> 0.1.0)
       debase-ruby_core_source (= 3.2.1)
       libdatadog (~> 4.0.0.1.0)
-      libddwaf (~> 1.11.0.0.0)
+      libddwaf (~> 1.14.0.0.0)
       msgpack
 
 GEM
@@ -57,9 +57,9 @@ GEM
       addressable (>= 2.4)
     libdatadog (4.0.0.1.0-aarch64-linux)
     libdatadog (4.0.0.1.0-x86_64-linux)
-    libddwaf (1.11.0.0.0-aarch64-linux)
+    libddwaf (1.14.0.0.0-aarch64-linux)
       ffi (~> 1.0)
-    libddwaf (1.11.0.0.0-x86_64-linux)
+    libddwaf (1.14.0.0.0-x86_64-linux)
       ffi (~> 1.0)
     memory_profiler (0.9.14)
     method_source (1.0.0)

--- a/gemfiles/ruby_2.6.10_redis_5.gemfile.lock
+++ b/gemfiles/ruby_2.6.10_redis_5.gemfile.lock
@@ -15,7 +15,7 @@ PATH
       datadog-ci (~> 0.1.0)
       debase-ruby_core_source (= 3.2.1)
       libdatadog (~> 4.0.0.1.0)
-      libddwaf (~> 1.11.0.0.0)
+      libddwaf (~> 1.14.0.0.0)
       msgpack
 
 GEM
@@ -58,9 +58,9 @@ GEM
       addressable (>= 2.4)
     libdatadog (4.0.0.1.0-aarch64-linux)
     libdatadog (4.0.0.1.0-x86_64-linux)
-    libddwaf (1.11.0.0.0-aarch64-linux)
+    libddwaf (1.14.0.0.0-aarch64-linux)
       ffi (~> 1.0)
-    libddwaf (1.11.0.0.0-x86_64-linux)
+    libddwaf (1.14.0.0.0-x86_64-linux)
       ffi (~> 1.0)
     memory_profiler (0.9.14)
     method_source (1.0.0)

--- a/gemfiles/ruby_2.6.10_relational_db.gemfile.lock
+++ b/gemfiles/ruby_2.6.10_relational_db.gemfile.lock
@@ -15,7 +15,7 @@ PATH
       datadog-ci (~> 0.1.0)
       debase-ruby_core_source (= 3.2.1)
       libdatadog (~> 4.0.0.1.0)
-      libddwaf (~> 1.11.0.0.0)
+      libddwaf (~> 1.14.0.0.0)
       msgpack
 
 GEM
@@ -73,10 +73,11 @@ GEM
     json-schema (2.8.1)
       addressable (>= 2.4)
     libdatadog (4.0.0.1.0-aarch64-linux)
-    libddwaf (1.11.0.0.0-aarch64-linux)
+    libdatadog (4.0.0.1.0-x86_64-linux)
+    libddwaf (1.14.0.0.0-aarch64-linux)
       ffi (~> 1.0)
-    makara (0.5.1)
-      activerecord (>= 5.2.0)
+    libddwaf (1.14.0.0.0-x86_64-linux)
+      ffi (~> 1.0)
     memory_profiler (0.9.14)
     method_source (1.0.0)
     minitest (5.20.0)

--- a/gemfiles/ruby_2.6.10_resque2_redis3.gemfile.lock
+++ b/gemfiles/ruby_2.6.10_resque2_redis3.gemfile.lock
@@ -15,7 +15,7 @@ PATH
       datadog-ci (~> 0.1.0)
       debase-ruby_core_source (= 3.2.1)
       libdatadog (~> 4.0.0.1.0)
-      libddwaf (~> 1.11.0.0.0)
+      libddwaf (~> 1.14.0.0.0)
       msgpack
 
 GEM
@@ -57,9 +57,9 @@ GEM
       addressable (>= 2.4)
     libdatadog (4.0.0.1.0-aarch64-linux)
     libdatadog (4.0.0.1.0-x86_64-linux)
-    libddwaf (1.11.0.0.0-aarch64-linux)
+    libddwaf (1.14.0.0.0-aarch64-linux)
       ffi (~> 1.0)
-    libddwaf (1.11.0.0.0-x86_64-linux)
+    libddwaf (1.14.0.0.0-x86_64-linux)
       ffi (~> 1.0)
     memory_profiler (0.9.14)
     method_source (1.0.0)

--- a/gemfiles/ruby_2.6.10_resque2_redis4.gemfile.lock
+++ b/gemfiles/ruby_2.6.10_resque2_redis4.gemfile.lock
@@ -15,7 +15,7 @@ PATH
       datadog-ci (~> 0.1.0)
       debase-ruby_core_source (= 3.2.1)
       libdatadog (~> 4.0.0.1.0)
-      libddwaf (~> 1.11.0.0.0)
+      libddwaf (~> 1.14.0.0.0)
       msgpack
 
 GEM
@@ -57,9 +57,9 @@ GEM
       addressable (>= 2.4)
     libdatadog (4.0.0.1.0-aarch64-linux)
     libdatadog (4.0.0.1.0-x86_64-linux)
-    libddwaf (1.11.0.0.0-aarch64-linux)
+    libddwaf (1.14.0.0.0-aarch64-linux)
       ffi (~> 1.0)
-    libddwaf (1.11.0.0.0-x86_64-linux)
+    libddwaf (1.14.0.0.0-x86_64-linux)
       ffi (~> 1.0)
     memory_profiler (0.9.14)
     method_source (1.0.0)

--- a/gemfiles/ruby_2.6.10_sinatra.gemfile.lock
+++ b/gemfiles/ruby_2.6.10_sinatra.gemfile.lock
@@ -15,7 +15,7 @@ PATH
       datadog-ci (~> 0.1.0)
       debase-ruby_core_source (= 3.2.1)
       libdatadog (~> 4.0.0.1.0)
-      libddwaf (~> 1.11.0.0.0)
+      libddwaf (~> 1.14.0.0.0)
       msgpack
 
 GEM
@@ -57,9 +57,9 @@ GEM
       addressable (>= 2.4)
     libdatadog (4.0.0.1.0-aarch64-linux)
     libdatadog (4.0.0.1.0-x86_64-linux)
-    libddwaf (1.11.0.0.0-aarch64-linux)
+    libddwaf (1.14.0.0.0-aarch64-linux)
       ffi (~> 1.0)
-    libddwaf (1.11.0.0.0-x86_64-linux)
+    libddwaf (1.14.0.0.0-x86_64-linux)
       ffi (~> 1.0)
     memory_profiler (0.9.14)
     method_source (1.0.0)

--- a/gemfiles/ruby_2.7.6_aws.gemfile.lock
+++ b/gemfiles/ruby_2.7.6_aws.gemfile.lock
@@ -15,7 +15,7 @@ PATH
       datadog-ci (~> 0.1.0)
       debase-ruby_core_source (= 3.2.1)
       libdatadog (~> 4.0.0.1.0)
-      libddwaf (~> 1.11.0.0.0)
+      libddwaf (~> 1.14.0.0.0)
       msgpack
 
 GEM
@@ -1477,7 +1477,7 @@ GEM
     json-schema (2.8.1)
       addressable (>= 2.4)
     libdatadog (4.0.0.1.0-aarch64-linux)
-    libddwaf (1.11.0.0.0-aarch64-linux)
+    libddwaf (1.14.0.0.0-aarch64-linux)
       ffi (~> 1.0)
     memory_profiler (0.9.14)
     method_source (1.0.0)

--- a/gemfiles/ruby_2.7.6_contrib.gemfile.lock
+++ b/gemfiles/ruby_2.7.6_contrib.gemfile.lock
@@ -15,7 +15,7 @@ PATH
       datadog-ci (~> 0.1.0)
       debase-ruby_core_source (= 3.2.1)
       libdatadog (~> 4.0.0.1.0)
-      libddwaf (~> 1.11.0.0.0)
+      libddwaf (~> 1.14.0.0.0)
       msgpack
 
 GEM
@@ -130,9 +130,9 @@ GEM
     king_konf (1.0.1)
     libdatadog (4.0.0.1.0-aarch64-linux)
     libdatadog (4.0.0.1.0-x86_64-linux)
-    libddwaf (1.11.0.0.0-aarch64-linux)
+    libddwaf (1.14.0.0.0-aarch64-linux)
       ffi (~> 1.0)
-    libddwaf (1.11.0.0.0-x86_64-linux)
+    libddwaf (1.14.0.0.0-x86_64-linux)
       ffi (~> 1.0)
     lograge (0.13.0)
       actionpack (>= 4)

--- a/gemfiles/ruby_2.7.6_contrib_old.gemfile.lock
+++ b/gemfiles/ruby_2.7.6_contrib_old.gemfile.lock
@@ -15,7 +15,7 @@ PATH
       datadog-ci (~> 0.1.0)
       debase-ruby_core_source (= 3.2.1)
       libdatadog (~> 4.0.0.1.0)
-      libddwaf (~> 1.11.0.0.0)
+      libddwaf (~> 1.14.0.0.0)
       msgpack
 
 GEM
@@ -77,9 +77,9 @@ GEM
       addressable (>= 2.4)
     libdatadog (4.0.0.1.0-aarch64-linux)
     libdatadog (4.0.0.1.0-x86_64-linux)
-    libddwaf (1.11.0.0.0-aarch64-linux)
+    libddwaf (1.14.0.0.0-aarch64-linux)
       ffi (~> 1.0)
-    libddwaf (1.11.0.0.0-x86_64-linux)
+    libddwaf (1.14.0.0.0-x86_64-linux)
       ffi (~> 1.0)
     memory_profiler (0.9.14)
     method_source (1.0.0)

--- a/gemfiles/ruby_2.7.6_core_old.gemfile.lock
+++ b/gemfiles/ruby_2.7.6_core_old.gemfile.lock
@@ -15,7 +15,7 @@ PATH
       datadog-ci (~> 0.1.0)
       debase-ruby_core_source (= 3.2.1)
       libdatadog (~> 4.0.0.1.0)
-      libddwaf (~> 1.11.0.0.0)
+      libddwaf (~> 1.14.0.0.0)
       msgpack
 
 GEM
@@ -57,9 +57,9 @@ GEM
       addressable (>= 2.4)
     libdatadog (4.0.0.1.0-aarch64-linux)
     libdatadog (4.0.0.1.0-x86_64-linux)
-    libddwaf (1.11.0.0.0-aarch64-linux)
+    libddwaf (1.14.0.0.0-aarch64-linux)
       ffi (~> 1.0)
-    libddwaf (1.11.0.0.0-x86_64-linux)
+    libddwaf (1.14.0.0.0-x86_64-linux)
       ffi (~> 1.0)
     memory_profiler (0.9.14)
     method_source (1.0.0)

--- a/gemfiles/ruby_2.7.6_hanami_1.gemfile.lock
+++ b/gemfiles/ruby_2.7.6_hanami_1.gemfile.lock
@@ -15,7 +15,7 @@ PATH
       datadog-ci (~> 0.1.0)
       debase-ruby_core_source (= 3.2.1)
       libdatadog (~> 4.0.0.1.0)
-      libddwaf (~> 1.11.0.0.0)
+      libddwaf (~> 1.14.0.0.0)
       msgpack
 
 GEM
@@ -133,9 +133,9 @@ GEM
       addressable (>= 2.4)
     libdatadog (4.0.0.1.0-aarch64-linux)
     libdatadog (4.0.0.1.0-x86_64-linux)
-    libddwaf (1.11.0.0.0-aarch64-linux)
+    libddwaf (1.14.0.0.0-aarch64-linux)
       ffi (~> 1.0)
-    libddwaf (1.11.0.0.0-x86_64-linux)
+    libddwaf (1.14.0.0.0-x86_64-linux)
       ffi (~> 1.0)
     mail (2.8.1)
       mini_mime (>= 0.1.1)

--- a/gemfiles/ruby_2.7.6_http.gemfile.lock
+++ b/gemfiles/ruby_2.7.6_http.gemfile.lock
@@ -15,7 +15,7 @@ PATH
       datadog-ci (~> 0.1.0)
       debase-ruby_core_source (= 3.2.1)
       libdatadog (~> 4.0.0.1.0)
-      libddwaf (~> 1.11.0.0.0)
+      libddwaf (~> 1.14.0.0.0)
       msgpack
 
 GEM
@@ -85,7 +85,7 @@ GEM
     json-schema (2.8.1)
       addressable (>= 2.4)
     libdatadog (4.0.0.1.0-aarch64-linux)
-    libddwaf (1.11.0.0.0-aarch64-linux)
+    libddwaf (1.14.0.0.0-aarch64-linux)
       ffi (~> 1.0)
     llhttp-ffi (0.3.1)
       ffi-compiler (~> 1.0)

--- a/gemfiles/ruby_2.7.6_opentelemetry.gemfile.lock
+++ b/gemfiles/ruby_2.7.6_opentelemetry.gemfile.lock
@@ -15,7 +15,7 @@ PATH
       datadog-ci (~> 0.1.0)
       debase-ruby_core_source (= 3.2.1)
       libdatadog (~> 4.0.0.1.0)
-      libddwaf (~> 1.11.0.0.0)
+      libddwaf (~> 1.14.0.0.0)
       msgpack
 
 GEM
@@ -57,9 +57,9 @@ GEM
       addressable (>= 2.4)
     libdatadog (4.0.0.1.0-aarch64-linux)
     libdatadog (4.0.0.1.0-x86_64-linux)
-    libddwaf (1.11.0.0.0-aarch64-linux)
+    libddwaf (1.14.0.0.0-aarch64-linux)
       ffi (~> 1.0)
-    libddwaf (1.11.0.0.0-x86_64-linux)
+    libddwaf (1.14.0.0.0-x86_64-linux)
       ffi (~> 1.0)
     memory_profiler (0.9.14)
     method_source (1.0.0)

--- a/gemfiles/ruby_2.7.6_rails5_mysql2.gemfile.lock
+++ b/gemfiles/ruby_2.7.6_rails5_mysql2.gemfile.lock
@@ -15,7 +15,7 @@ PATH
       datadog-ci (~> 0.1.0)
       debase-ruby_core_source (= 3.2.1)
       libdatadog (~> 4.0.0.1.0)
-      libddwaf (~> 1.11.0.0.0)
+      libddwaf (~> 1.14.0.0.0)
       msgpack
 
 GEM
@@ -106,9 +106,9 @@ GEM
       addressable (>= 2.4)
     libdatadog (4.0.0.1.0-aarch64-linux)
     libdatadog (4.0.0.1.0-x86_64-linux)
-    libddwaf (1.11.0.0.0-aarch64-linux)
+    libddwaf (1.14.0.0.0-aarch64-linux)
       ffi (~> 1.0)
-    libddwaf (1.11.0.0.0-x86_64-linux)
+    libddwaf (1.14.0.0.0-x86_64-linux)
       ffi (~> 1.0)
     lograge (0.12.0)
       actionpack (>= 4)

--- a/gemfiles/ruby_2.7.6_rails5_postgres.gemfile.lock
+++ b/gemfiles/ruby_2.7.6_rails5_postgres.gemfile.lock
@@ -15,7 +15,7 @@ PATH
       datadog-ci (~> 0.1.0)
       debase-ruby_core_source (= 3.2.1)
       libdatadog (~> 4.0.0.1.0)
-      libddwaf (~> 1.11.0.0.0)
+      libddwaf (~> 1.14.0.0.0)
       msgpack
 
 GEM
@@ -106,9 +106,9 @@ GEM
       addressable (>= 2.4)
     libdatadog (4.0.0.1.0-aarch64-linux)
     libdatadog (4.0.0.1.0-x86_64-linux)
-    libddwaf (1.11.0.0.0-aarch64-linux)
+    libddwaf (1.14.0.0.0-aarch64-linux)
       ffi (~> 1.0)
-    libddwaf (1.11.0.0.0-x86_64-linux)
+    libddwaf (1.14.0.0.0-x86_64-linux)
       ffi (~> 1.0)
     lograge (0.12.0)
       actionpack (>= 4)

--- a/gemfiles/ruby_2.7.6_rails5_postgres_redis.gemfile.lock
+++ b/gemfiles/ruby_2.7.6_rails5_postgres_redis.gemfile.lock
@@ -15,7 +15,7 @@ PATH
       datadog-ci (~> 0.1.0)
       debase-ruby_core_source (= 3.2.1)
       libdatadog (~> 4.0.0.1.0)
-      libddwaf (~> 1.11.0.0.0)
+      libddwaf (~> 1.14.0.0.0)
       msgpack
 
 GEM
@@ -106,9 +106,9 @@ GEM
       addressable (>= 2.4)
     libdatadog (4.0.0.1.0-aarch64-linux)
     libdatadog (4.0.0.1.0-x86_64-linux)
-    libddwaf (1.11.0.0.0-aarch64-linux)
+    libddwaf (1.14.0.0.0-aarch64-linux)
       ffi (~> 1.0)
-    libddwaf (1.11.0.0.0-x86_64-linux)
+    libddwaf (1.14.0.0.0-x86_64-linux)
       ffi (~> 1.0)
     lograge (0.12.0)
       actionpack (>= 4)

--- a/gemfiles/ruby_2.7.6_rails5_postgres_redis_activesupport.gemfile.lock
+++ b/gemfiles/ruby_2.7.6_rails5_postgres_redis_activesupport.gemfile.lock
@@ -15,7 +15,7 @@ PATH
       datadog-ci (~> 0.1.0)
       debase-ruby_core_source (= 3.2.1)
       libdatadog (~> 4.0.0.1.0)
-      libddwaf (~> 1.11.0.0.0)
+      libddwaf (~> 1.14.0.0.0)
       msgpack
 
 GEM
@@ -106,9 +106,9 @@ GEM
       addressable (>= 2.4)
     libdatadog (4.0.0.1.0-aarch64-linux)
     libdatadog (4.0.0.1.0-x86_64-linux)
-    libddwaf (1.11.0.0.0-aarch64-linux)
+    libddwaf (1.14.0.0.0-aarch64-linux)
       ffi (~> 1.0)
-    libddwaf (1.11.0.0.0-x86_64-linux)
+    libddwaf (1.14.0.0.0-x86_64-linux)
       ffi (~> 1.0)
     lograge (0.12.0)
       actionpack (>= 4)

--- a/gemfiles/ruby_2.7.6_rails5_postgres_sidekiq.gemfile.lock
+++ b/gemfiles/ruby_2.7.6_rails5_postgres_sidekiq.gemfile.lock
@@ -15,7 +15,7 @@ PATH
       datadog-ci (~> 0.1.0)
       debase-ruby_core_source (= 3.2.1)
       libdatadog (~> 4.0.0.1.0)
-      libddwaf (~> 1.11.0.0.0)
+      libddwaf (~> 1.14.0.0.0)
       msgpack
 
 GEM
@@ -107,9 +107,9 @@ GEM
       addressable (>= 2.4)
     libdatadog (4.0.0.1.0-aarch64-linux)
     libdatadog (4.0.0.1.0-x86_64-linux)
-    libddwaf (1.11.0.0.0-aarch64-linux)
+    libddwaf (1.14.0.0.0-aarch64-linux)
       ffi (~> 1.0)
-    libddwaf (1.11.0.0.0-x86_64-linux)
+    libddwaf (1.14.0.0.0-x86_64-linux)
       ffi (~> 1.0)
     lograge (0.12.0)
       actionpack (>= 4)

--- a/gemfiles/ruby_2.7.6_rails5_semantic_logger.gemfile.lock
+++ b/gemfiles/ruby_2.7.6_rails5_semantic_logger.gemfile.lock
@@ -15,7 +15,7 @@ PATH
       datadog-ci (~> 0.1.0)
       debase-ruby_core_source (= 3.2.1)
       libdatadog (~> 4.0.0.1.0)
-      libddwaf (~> 1.11.0.0.0)
+      libddwaf (~> 1.14.0.0.0)
       msgpack
 
 GEM
@@ -106,9 +106,9 @@ GEM
       addressable (>= 2.4)
     libdatadog (4.0.0.1.0-aarch64-linux)
     libdatadog (4.0.0.1.0-x86_64-linux)
-    libddwaf (1.11.0.0.0-aarch64-linux)
+    libddwaf (1.14.0.0.0-aarch64-linux)
       ffi (~> 1.0)
-    libddwaf (1.11.0.0.0-x86_64-linux)
+    libddwaf (1.14.0.0.0-x86_64-linux)
       ffi (~> 1.0)
     loofah (2.19.1)
       crass (~> 1.0.2)

--- a/gemfiles/ruby_2.7.6_rails61_mysql2.gemfile.lock
+++ b/gemfiles/ruby_2.7.6_rails61_mysql2.gemfile.lock
@@ -15,7 +15,7 @@ PATH
       datadog-ci (~> 0.1.0)
       debase-ruby_core_source (= 3.2.1)
       libdatadog (~> 4.0.0.1.0)
-      libddwaf (~> 1.11.0.0.0)
+      libddwaf (~> 1.14.0.0.0)
       msgpack
 
 GEM
@@ -123,9 +123,9 @@ GEM
       addressable (>= 2.4)
     libdatadog (4.0.0.1.0-aarch64-linux)
     libdatadog (4.0.0.1.0-x86_64-linux)
-    libddwaf (1.11.0.0.0-aarch64-linux)
+    libddwaf (1.14.0.0.0-aarch64-linux)
       ffi (~> 1.0)
-    libddwaf (1.11.0.0.0-x86_64-linux)
+    libddwaf (1.14.0.0.0-x86_64-linux)
       ffi (~> 1.0)
     lograge (0.12.0)
       actionpack (>= 4)

--- a/gemfiles/ruby_2.7.6_rails61_postgres.gemfile.lock
+++ b/gemfiles/ruby_2.7.6_rails61_postgres.gemfile.lock
@@ -15,7 +15,7 @@ PATH
       datadog-ci (~> 0.1.0)
       debase-ruby_core_source (= 3.2.1)
       libdatadog (~> 4.0.0.1.0)
-      libddwaf (~> 1.11.0.0.0)
+      libddwaf (~> 1.14.0.0.0)
       msgpack
 
 GEM
@@ -123,9 +123,9 @@ GEM
       addressable (>= 2.4)
     libdatadog (4.0.0.1.0-aarch64-linux)
     libdatadog (4.0.0.1.0-x86_64-linux)
-    libddwaf (1.11.0.0.0-aarch64-linux)
+    libddwaf (1.14.0.0.0-aarch64-linux)
       ffi (~> 1.0)
-    libddwaf (1.11.0.0.0-x86_64-linux)
+    libddwaf (1.14.0.0.0-x86_64-linux)
       ffi (~> 1.0)
     lograge (0.12.0)
       actionpack (>= 4)

--- a/gemfiles/ruby_2.7.6_rails61_postgres_redis.gemfile.lock
+++ b/gemfiles/ruby_2.7.6_rails61_postgres_redis.gemfile.lock
@@ -15,7 +15,7 @@ PATH
       datadog-ci (~> 0.1.0)
       debase-ruby_core_source (= 3.2.1)
       libdatadog (~> 4.0.0.1.0)
-      libddwaf (~> 1.11.0.0.0)
+      libddwaf (~> 1.14.0.0.0)
       msgpack
 
 GEM
@@ -123,9 +123,9 @@ GEM
       addressable (>= 2.4)
     libdatadog (4.0.0.1.0-aarch64-linux)
     libdatadog (4.0.0.1.0-x86_64-linux)
-    libddwaf (1.11.0.0.0-aarch64-linux)
+    libddwaf (1.14.0.0.0-aarch64-linux)
       ffi (~> 1.0)
-    libddwaf (1.11.0.0.0-x86_64-linux)
+    libddwaf (1.14.0.0.0-x86_64-linux)
       ffi (~> 1.0)
     lograge (0.12.0)
       actionpack (>= 4)

--- a/gemfiles/ruby_2.7.6_rails61_postgres_sidekiq.gemfile.lock
+++ b/gemfiles/ruby_2.7.6_rails61_postgres_sidekiq.gemfile.lock
@@ -15,7 +15,7 @@ PATH
       datadog-ci (~> 0.1.0)
       debase-ruby_core_source (= 3.2.1)
       libdatadog (~> 4.0.0.1.0)
-      libddwaf (~> 1.11.0.0.0)
+      libddwaf (~> 1.14.0.0.0)
       msgpack
 
 GEM
@@ -124,9 +124,9 @@ GEM
       addressable (>= 2.4)
     libdatadog (4.0.0.1.0-aarch64-linux)
     libdatadog (4.0.0.1.0-x86_64-linux)
-    libddwaf (1.11.0.0.0-aarch64-linux)
+    libddwaf (1.14.0.0.0-aarch64-linux)
       ffi (~> 1.0)
-    libddwaf (1.11.0.0.0-x86_64-linux)
+    libddwaf (1.14.0.0.0-x86_64-linux)
       ffi (~> 1.0)
     lograge (0.12.0)
       actionpack (>= 4)

--- a/gemfiles/ruby_2.7.6_rails61_semantic_logger.gemfile.lock
+++ b/gemfiles/ruby_2.7.6_rails61_semantic_logger.gemfile.lock
@@ -15,7 +15,7 @@ PATH
       datadog-ci (~> 0.1.0)
       debase-ruby_core_source (= 3.2.1)
       libdatadog (~> 4.0.0.1.0)
-      libddwaf (~> 1.11.0.0.0)
+      libddwaf (~> 1.14.0.0.0)
       msgpack
 
 GEM
@@ -123,9 +123,9 @@ GEM
       addressable (>= 2.4)
     libdatadog (4.0.0.1.0-aarch64-linux)
     libdatadog (4.0.0.1.0-x86_64-linux)
-    libddwaf (1.11.0.0.0-aarch64-linux)
+    libddwaf (1.14.0.0.0-aarch64-linux)
       ffi (~> 1.0)
-    libddwaf (1.11.0.0.0-x86_64-linux)
+    libddwaf (1.14.0.0.0-x86_64-linux)
       ffi (~> 1.0)
     loofah (2.19.1)
       crass (~> 1.0.2)

--- a/gemfiles/ruby_2.7.6_rails6_mysql2.gemfile.lock
+++ b/gemfiles/ruby_2.7.6_rails6_mysql2.gemfile.lock
@@ -15,7 +15,7 @@ PATH
       datadog-ci (~> 0.1.0)
       debase-ruby_core_source (= 3.2.1)
       libdatadog (~> 4.0.0.1.0)
-      libddwaf (~> 1.11.0.0.0)
+      libddwaf (~> 1.14.0.0.0)
       msgpack
 
 GEM
@@ -119,9 +119,9 @@ GEM
       addressable (>= 2.4)
     libdatadog (4.0.0.1.0-aarch64-linux)
     libdatadog (4.0.0.1.0-x86_64-linux)
-    libddwaf (1.11.0.0.0-aarch64-linux)
+    libddwaf (1.14.0.0.0-aarch64-linux)
       ffi (~> 1.0)
-    libddwaf (1.11.0.0.0-x86_64-linux)
+    libddwaf (1.14.0.0.0-x86_64-linux)
       ffi (~> 1.0)
     lograge (0.12.0)
       actionpack (>= 4)

--- a/gemfiles/ruby_2.7.6_rails6_postgres.gemfile.lock
+++ b/gemfiles/ruby_2.7.6_rails6_postgres.gemfile.lock
@@ -15,7 +15,7 @@ PATH
       datadog-ci (~> 0.1.0)
       debase-ruby_core_source (= 3.2.1)
       libdatadog (~> 4.0.0.1.0)
-      libddwaf (~> 1.11.0.0.0)
+      libddwaf (~> 1.14.0.0.0)
       msgpack
 
 GEM
@@ -119,9 +119,9 @@ GEM
       addressable (>= 2.4)
     libdatadog (4.0.0.1.0-aarch64-linux)
     libdatadog (4.0.0.1.0-x86_64-linux)
-    libddwaf (1.11.0.0.0-aarch64-linux)
+    libddwaf (1.14.0.0.0-aarch64-linux)
       ffi (~> 1.0)
-    libddwaf (1.11.0.0.0-x86_64-linux)
+    libddwaf (1.14.0.0.0-x86_64-linux)
       ffi (~> 1.0)
     lograge (0.12.0)
       actionpack (>= 4)

--- a/gemfiles/ruby_2.7.6_rails6_postgres_redis.gemfile.lock
+++ b/gemfiles/ruby_2.7.6_rails6_postgres_redis.gemfile.lock
@@ -15,7 +15,7 @@ PATH
       datadog-ci (~> 0.1.0)
       debase-ruby_core_source (= 3.2.1)
       libdatadog (~> 4.0.0.1.0)
-      libddwaf (~> 1.11.0.0.0)
+      libddwaf (~> 1.14.0.0.0)
       msgpack
 
 GEM
@@ -119,9 +119,9 @@ GEM
       addressable (>= 2.4)
     libdatadog (4.0.0.1.0-aarch64-linux)
     libdatadog (4.0.0.1.0-x86_64-linux)
-    libddwaf (1.11.0.0.0-aarch64-linux)
+    libddwaf (1.14.0.0.0-aarch64-linux)
       ffi (~> 1.0)
-    libddwaf (1.11.0.0.0-x86_64-linux)
+    libddwaf (1.14.0.0.0-x86_64-linux)
       ffi (~> 1.0)
     lograge (0.12.0)
       actionpack (>= 4)

--- a/gemfiles/ruby_2.7.6_rails6_postgres_redis_activesupport.gemfile.lock
+++ b/gemfiles/ruby_2.7.6_rails6_postgres_redis_activesupport.gemfile.lock
@@ -15,7 +15,7 @@ PATH
       datadog-ci (~> 0.1.0)
       debase-ruby_core_source (= 3.2.1)
       libdatadog (~> 4.0.0.1.0)
-      libddwaf (~> 1.11.0.0.0)
+      libddwaf (~> 1.14.0.0.0)
       msgpack
 
 GEM
@@ -119,9 +119,9 @@ GEM
       addressable (>= 2.4)
     libdatadog (4.0.0.1.0-aarch64-linux)
     libdatadog (4.0.0.1.0-x86_64-linux)
-    libddwaf (1.11.0.0.0-aarch64-linux)
+    libddwaf (1.14.0.0.0-aarch64-linux)
       ffi (~> 1.0)
-    libddwaf (1.11.0.0.0-x86_64-linux)
+    libddwaf (1.14.0.0.0-x86_64-linux)
       ffi (~> 1.0)
     lograge (0.12.0)
       actionpack (>= 4)

--- a/gemfiles/ruby_2.7.6_rails6_postgres_sidekiq.gemfile.lock
+++ b/gemfiles/ruby_2.7.6_rails6_postgres_sidekiq.gemfile.lock
@@ -15,7 +15,7 @@ PATH
       datadog-ci (~> 0.1.0)
       debase-ruby_core_source (= 3.2.1)
       libdatadog (~> 4.0.0.1.0)
-      libddwaf (~> 1.11.0.0.0)
+      libddwaf (~> 1.14.0.0.0)
       msgpack
 
 GEM
@@ -120,9 +120,9 @@ GEM
       addressable (>= 2.4)
     libdatadog (4.0.0.1.0-aarch64-linux)
     libdatadog (4.0.0.1.0-x86_64-linux)
-    libddwaf (1.11.0.0.0-aarch64-linux)
+    libddwaf (1.14.0.0.0-aarch64-linux)
       ffi (~> 1.0)
-    libddwaf (1.11.0.0.0-x86_64-linux)
+    libddwaf (1.14.0.0.0-x86_64-linux)
       ffi (~> 1.0)
     lograge (0.12.0)
       actionpack (>= 4)

--- a/gemfiles/ruby_2.7.6_rails6_semantic_logger.gemfile.lock
+++ b/gemfiles/ruby_2.7.6_rails6_semantic_logger.gemfile.lock
@@ -15,7 +15,7 @@ PATH
       datadog-ci (~> 0.1.0)
       debase-ruby_core_source (= 3.2.1)
       libdatadog (~> 4.0.0.1.0)
-      libddwaf (~> 1.11.0.0.0)
+      libddwaf (~> 1.14.0.0.0)
       msgpack
 
 GEM
@@ -119,9 +119,9 @@ GEM
       addressable (>= 2.4)
     libdatadog (4.0.0.1.0-aarch64-linux)
     libdatadog (4.0.0.1.0-x86_64-linux)
-    libddwaf (1.11.0.0.0-aarch64-linux)
+    libddwaf (1.14.0.0.0-aarch64-linux)
       ffi (~> 1.0)
-    libddwaf (1.11.0.0.0-x86_64-linux)
+    libddwaf (1.14.0.0.0-x86_64-linux)
       ffi (~> 1.0)
     loofah (2.19.1)
       crass (~> 1.0.2)

--- a/gemfiles/ruby_2.7.6_redis_3.gemfile.lock
+++ b/gemfiles/ruby_2.7.6_redis_3.gemfile.lock
@@ -15,7 +15,7 @@ PATH
       datadog-ci (~> 0.1.0)
       debase-ruby_core_source (= 3.2.1)
       libdatadog (~> 4.0.0.1.0)
-      libddwaf (~> 1.11.0.0.0)
+      libddwaf (~> 1.14.0.0.0)
       msgpack
 
 GEM
@@ -57,9 +57,9 @@ GEM
       addressable (>= 2.4)
     libdatadog (4.0.0.1.0-aarch64-linux)
     libdatadog (4.0.0.1.0-x86_64-linux)
-    libddwaf (1.11.0.0.0-aarch64-linux)
+    libddwaf (1.14.0.0.0-aarch64-linux)
       ffi (~> 1.0)
-    libddwaf (1.11.0.0.0-x86_64-linux)
+    libddwaf (1.14.0.0.0-x86_64-linux)
       ffi (~> 1.0)
     memory_profiler (0.9.14)
     method_source (1.0.0)

--- a/gemfiles/ruby_2.7.6_redis_4.gemfile.lock
+++ b/gemfiles/ruby_2.7.6_redis_4.gemfile.lock
@@ -15,7 +15,7 @@ PATH
       datadog-ci (~> 0.1.0)
       debase-ruby_core_source (= 3.2.1)
       libdatadog (~> 4.0.0.1.0)
-      libddwaf (~> 1.11.0.0.0)
+      libddwaf (~> 1.14.0.0.0)
       msgpack
 
 GEM
@@ -57,9 +57,9 @@ GEM
       addressable (>= 2.4)
     libdatadog (4.0.0.1.0-aarch64-linux)
     libdatadog (4.0.0.1.0-x86_64-linux)
-    libddwaf (1.11.0.0.0-aarch64-linux)
+    libddwaf (1.14.0.0.0-aarch64-linux)
       ffi (~> 1.0)
-    libddwaf (1.11.0.0.0-x86_64-linux)
+    libddwaf (1.14.0.0.0-x86_64-linux)
       ffi (~> 1.0)
     memory_profiler (0.9.14)
     method_source (1.0.0)

--- a/gemfiles/ruby_2.7.6_redis_5.gemfile.lock
+++ b/gemfiles/ruby_2.7.6_redis_5.gemfile.lock
@@ -15,7 +15,7 @@ PATH
       datadog-ci (~> 0.1.0)
       debase-ruby_core_source (= 3.2.1)
       libdatadog (~> 4.0.0.1.0)
-      libddwaf (~> 1.11.0.0.0)
+      libddwaf (~> 1.14.0.0.0)
       msgpack
 
 GEM
@@ -58,9 +58,9 @@ GEM
       addressable (>= 2.4)
     libdatadog (4.0.0.1.0-aarch64-linux)
     libdatadog (4.0.0.1.0-x86_64-linux)
-    libddwaf (1.11.0.0.0-aarch64-linux)
+    libddwaf (1.14.0.0.0-aarch64-linux)
       ffi (~> 1.0)
-    libddwaf (1.11.0.0.0-x86_64-linux)
+    libddwaf (1.14.0.0.0-x86_64-linux)
       ffi (~> 1.0)
     memory_profiler (0.9.14)
     method_source (1.0.0)

--- a/gemfiles/ruby_2.7.6_relational_db.gemfile.lock
+++ b/gemfiles/ruby_2.7.6_relational_db.gemfile.lock
@@ -15,7 +15,7 @@ PATH
       datadog-ci (~> 0.1.0)
       debase-ruby_core_source (= 3.2.1)
       libdatadog (~> 4.0.0.1.0)
-      libddwaf (~> 1.11.0.0.0)
+      libddwaf (~> 1.14.0.0.0)
       msgpack
 
 GEM
@@ -73,10 +73,11 @@ GEM
     json-schema (2.8.1)
       addressable (>= 2.4)
     libdatadog (4.0.0.1.0-aarch64-linux)
-    libddwaf (1.11.0.0.0-aarch64-linux)
+    libdatadog (4.0.0.1.0-x86_64-linux)
+    libddwaf (1.14.0.0.0-aarch64-linux)
       ffi (~> 1.0)
-    makara (0.5.1)
-      activerecord (>= 5.2.0)
+    libddwaf (1.14.0.0.0-x86_64-linux)
+      ffi (~> 1.0)
     memory_profiler (0.9.14)
     method_source (1.0.0)
     minitest (5.20.0)

--- a/gemfiles/ruby_2.7.6_resque2_redis3.gemfile.lock
+++ b/gemfiles/ruby_2.7.6_resque2_redis3.gemfile.lock
@@ -15,7 +15,7 @@ PATH
       datadog-ci (~> 0.1.0)
       debase-ruby_core_source (= 3.2.1)
       libdatadog (~> 4.0.0.1.0)
-      libddwaf (~> 1.11.0.0.0)
+      libddwaf (~> 1.14.0.0.0)
       msgpack
 
 GEM
@@ -57,9 +57,9 @@ GEM
       addressable (>= 2.4)
     libdatadog (4.0.0.1.0-aarch64-linux)
     libdatadog (4.0.0.1.0-x86_64-linux)
-    libddwaf (1.11.0.0.0-aarch64-linux)
+    libddwaf (1.14.0.0.0-aarch64-linux)
       ffi (~> 1.0)
-    libddwaf (1.11.0.0.0-x86_64-linux)
+    libddwaf (1.14.0.0.0-x86_64-linux)
       ffi (~> 1.0)
     memory_profiler (0.9.14)
     method_source (1.0.0)

--- a/gemfiles/ruby_2.7.6_resque2_redis4.gemfile.lock
+++ b/gemfiles/ruby_2.7.6_resque2_redis4.gemfile.lock
@@ -15,7 +15,7 @@ PATH
       datadog-ci (~> 0.1.0)
       debase-ruby_core_source (= 3.2.1)
       libdatadog (~> 4.0.0.1.0)
-      libddwaf (~> 1.11.0.0.0)
+      libddwaf (~> 1.14.0.0.0)
       msgpack
 
 GEM
@@ -57,9 +57,9 @@ GEM
       addressable (>= 2.4)
     libdatadog (4.0.0.1.0-aarch64-linux)
     libdatadog (4.0.0.1.0-x86_64-linux)
-    libddwaf (1.11.0.0.0-aarch64-linux)
+    libddwaf (1.14.0.0.0-aarch64-linux)
       ffi (~> 1.0)
-    libddwaf (1.11.0.0.0-x86_64-linux)
+    libddwaf (1.14.0.0.0-x86_64-linux)
       ffi (~> 1.0)
     memory_profiler (0.9.14)
     method_source (1.0.0)

--- a/gemfiles/ruby_2.7.6_sinatra.gemfile.lock
+++ b/gemfiles/ruby_2.7.6_sinatra.gemfile.lock
@@ -15,7 +15,7 @@ PATH
       datadog-ci (~> 0.1.0)
       debase-ruby_core_source (= 3.2.1)
       libdatadog (~> 4.0.0.1.0)
-      libddwaf (~> 1.11.0.0.0)
+      libddwaf (~> 1.14.0.0.0)
       msgpack
 
 GEM
@@ -57,9 +57,9 @@ GEM
       addressable (>= 2.4)
     libdatadog (4.0.0.1.0-aarch64-linux)
     libdatadog (4.0.0.1.0-x86_64-linux)
-    libddwaf (1.11.0.0.0-aarch64-linux)
+    libddwaf (1.14.0.0.0-aarch64-linux)
       ffi (~> 1.0)
-    libddwaf (1.11.0.0.0-x86_64-linux)
+    libddwaf (1.14.0.0.0-x86_64-linux)
       ffi (~> 1.0)
     memory_profiler (0.9.14)
     method_source (1.0.0)

--- a/gemfiles/ruby_3.0.4_aws.gemfile.lock
+++ b/gemfiles/ruby_3.0.4_aws.gemfile.lock
@@ -15,7 +15,7 @@ PATH
       datadog-ci (~> 0.1.0)
       debase-ruby_core_source (= 3.2.1)
       libdatadog (~> 4.0.0.1.0)
-      libddwaf (~> 1.11.0.0.0)
+      libddwaf (~> 1.14.0.0.0)
       msgpack
 
 GEM
@@ -1477,7 +1477,7 @@ GEM
     json-schema (2.8.1)
       addressable (>= 2.4)
     libdatadog (4.0.0.1.0-aarch64-linux)
-    libddwaf (1.11.0.0.0-aarch64-linux)
+    libddwaf (1.14.0.0.0-aarch64-linux)
       ffi (~> 1.0)
     memory_profiler (0.9.14)
     method_source (1.0.0)

--- a/gemfiles/ruby_3.0.4_contrib.gemfile.lock
+++ b/gemfiles/ruby_3.0.4_contrib.gemfile.lock
@@ -15,7 +15,7 @@ PATH
       datadog-ci (~> 0.1.0)
       debase-ruby_core_source (= 3.2.1)
       libdatadog (~> 4.0.0.1.0)
-      libddwaf (~> 1.11.0.0.0)
+      libddwaf (~> 1.14.0.0.0)
       msgpack
 
 GEM
@@ -129,9 +129,9 @@ GEM
     king_konf (1.0.1)
     libdatadog (4.0.0.1.0-aarch64-linux)
     libdatadog (4.0.0.1.0-x86_64-linux)
-    libddwaf (1.11.0.0.0-aarch64-linux)
+    libddwaf (1.14.0.0.0-aarch64-linux)
       ffi (~> 1.0)
-    libddwaf (1.11.0.0.0-x86_64-linux)
+    libddwaf (1.14.0.0.0-x86_64-linux)
       ffi (~> 1.0)
     lograge (0.12.0)
       actionpack (>= 4)

--- a/gemfiles/ruby_3.0.4_contrib_old.gemfile.lock
+++ b/gemfiles/ruby_3.0.4_contrib_old.gemfile.lock
@@ -15,7 +15,7 @@ PATH
       datadog-ci (~> 0.1.0)
       debase-ruby_core_source (= 3.2.1)
       libdatadog (~> 4.0.0.1.0)
-      libddwaf (~> 1.11.0.0.0)
+      libddwaf (~> 1.14.0.0.0)
       msgpack
 
 GEM
@@ -77,9 +77,9 @@ GEM
       addressable (>= 2.4)
     libdatadog (4.0.0.1.0-aarch64-linux)
     libdatadog (4.0.0.1.0-x86_64-linux)
-    libddwaf (1.11.0.0.0-aarch64-linux)
+    libddwaf (1.14.0.0.0-aarch64-linux)
       ffi (~> 1.0)
-    libddwaf (1.11.0.0.0-x86_64-linux)
+    libddwaf (1.14.0.0.0-x86_64-linux)
       ffi (~> 1.0)
     memory_profiler (0.9.14)
     method_source (1.0.0)

--- a/gemfiles/ruby_3.0.4_core_old.gemfile.lock
+++ b/gemfiles/ruby_3.0.4_core_old.gemfile.lock
@@ -15,7 +15,7 @@ PATH
       datadog-ci (~> 0.1.0)
       debase-ruby_core_source (= 3.2.1)
       libdatadog (~> 4.0.0.1.0)
-      libddwaf (~> 1.11.0.0.0)
+      libddwaf (~> 1.14.0.0.0)
       msgpack
 
 GEM
@@ -57,9 +57,9 @@ GEM
       addressable (>= 2.4)
     libdatadog (4.0.0.1.0-aarch64-linux)
     libdatadog (4.0.0.1.0-x86_64-linux)
-    libddwaf (1.11.0.0.0-aarch64-linux)
+    libddwaf (1.14.0.0.0-aarch64-linux)
       ffi (~> 1.0)
-    libddwaf (1.11.0.0.0-x86_64-linux)
+    libddwaf (1.14.0.0.0-x86_64-linux)
       ffi (~> 1.0)
     memory_profiler (0.9.14)
     method_source (1.0.0)

--- a/gemfiles/ruby_3.0.4_http.gemfile.lock
+++ b/gemfiles/ruby_3.0.4_http.gemfile.lock
@@ -15,7 +15,7 @@ PATH
       datadog-ci (~> 0.1.0)
       debase-ruby_core_source (= 3.2.1)
       libdatadog (~> 4.0.0.1.0)
-      libddwaf (~> 1.11.0.0.0)
+      libddwaf (~> 1.14.0.0.0)
       msgpack
 
 GEM
@@ -85,7 +85,7 @@ GEM
     json-schema (2.8.1)
       addressable (>= 2.4)
     libdatadog (4.0.0.1.0-aarch64-linux)
-    libddwaf (1.11.0.0.0-aarch64-linux)
+    libddwaf (1.14.0.0.0-aarch64-linux)
       ffi (~> 1.0)
     llhttp-ffi (0.3.1)
       ffi-compiler (~> 1.0)

--- a/gemfiles/ruby_3.0.4_opentelemetry.gemfile.lock
+++ b/gemfiles/ruby_3.0.4_opentelemetry.gemfile.lock
@@ -15,7 +15,7 @@ PATH
       datadog-ci (~> 0.1.0)
       debase-ruby_core_source (= 3.2.1)
       libdatadog (~> 4.0.0.1.0)
-      libddwaf (~> 1.11.0.0.0)
+      libddwaf (~> 1.14.0.0.0)
       msgpack
 
 GEM
@@ -57,9 +57,9 @@ GEM
       addressable (>= 2.4)
     libdatadog (4.0.0.1.0-aarch64-linux)
     libdatadog (4.0.0.1.0-x86_64-linux)
-    libddwaf (1.11.0.0.0-aarch64-linux)
+    libddwaf (1.14.0.0.0-aarch64-linux)
       ffi (~> 1.0)
-    libddwaf (1.11.0.0.0-x86_64-linux)
+    libddwaf (1.14.0.0.0-x86_64-linux)
       ffi (~> 1.0)
     memory_profiler (0.9.14)
     method_source (1.0.0)

--- a/gemfiles/ruby_3.0.4_rails61_mysql2.gemfile.lock
+++ b/gemfiles/ruby_3.0.4_rails61_mysql2.gemfile.lock
@@ -15,7 +15,7 @@ PATH
       datadog-ci (~> 0.1.0)
       debase-ruby_core_source (= 3.2.1)
       libdatadog (~> 4.0.0.1.0)
-      libddwaf (~> 1.11.0.0.0)
+      libddwaf (~> 1.14.0.0.0)
       msgpack
 
 GEM
@@ -123,9 +123,9 @@ GEM
       addressable (>= 2.4)
     libdatadog (4.0.0.1.0-aarch64-linux)
     libdatadog (4.0.0.1.0-x86_64-linux)
-    libddwaf (1.11.0.0.0-aarch64-linux)
+    libddwaf (1.14.0.0.0-aarch64-linux)
       ffi (~> 1.0)
-    libddwaf (1.11.0.0.0-x86_64-linux)
+    libddwaf (1.14.0.0.0-x86_64-linux)
       ffi (~> 1.0)
     lograge (0.12.0)
       actionpack (>= 4)

--- a/gemfiles/ruby_3.0.4_rails61_postgres.gemfile.lock
+++ b/gemfiles/ruby_3.0.4_rails61_postgres.gemfile.lock
@@ -15,7 +15,7 @@ PATH
       datadog-ci (~> 0.1.0)
       debase-ruby_core_source (= 3.2.1)
       libdatadog (~> 4.0.0.1.0)
-      libddwaf (~> 1.11.0.0.0)
+      libddwaf (~> 1.14.0.0.0)
       msgpack
 
 GEM
@@ -123,9 +123,9 @@ GEM
       addressable (>= 2.4)
     libdatadog (4.0.0.1.0-aarch64-linux)
     libdatadog (4.0.0.1.0-x86_64-linux)
-    libddwaf (1.11.0.0.0-aarch64-linux)
+    libddwaf (1.14.0.0.0-aarch64-linux)
       ffi (~> 1.0)
-    libddwaf (1.11.0.0.0-x86_64-linux)
+    libddwaf (1.14.0.0.0-x86_64-linux)
       ffi (~> 1.0)
     lograge (0.12.0)
       actionpack (>= 4)

--- a/gemfiles/ruby_3.0.4_rails61_postgres_redis.gemfile.lock
+++ b/gemfiles/ruby_3.0.4_rails61_postgres_redis.gemfile.lock
@@ -15,7 +15,7 @@ PATH
       datadog-ci (~> 0.1.0)
       debase-ruby_core_source (= 3.2.1)
       libdatadog (~> 4.0.0.1.0)
-      libddwaf (~> 1.11.0.0.0)
+      libddwaf (~> 1.14.0.0.0)
       msgpack
 
 GEM
@@ -123,9 +123,9 @@ GEM
       addressable (>= 2.4)
     libdatadog (4.0.0.1.0-aarch64-linux)
     libdatadog (4.0.0.1.0-x86_64-linux)
-    libddwaf (1.11.0.0.0-aarch64-linux)
+    libddwaf (1.14.0.0.0-aarch64-linux)
       ffi (~> 1.0)
-    libddwaf (1.11.0.0.0-x86_64-linux)
+    libddwaf (1.14.0.0.0-x86_64-linux)
       ffi (~> 1.0)
     lograge (0.12.0)
       actionpack (>= 4)

--- a/gemfiles/ruby_3.0.4_rails61_postgres_sidekiq.gemfile.lock
+++ b/gemfiles/ruby_3.0.4_rails61_postgres_sidekiq.gemfile.lock
@@ -15,7 +15,7 @@ PATH
       datadog-ci (~> 0.1.0)
       debase-ruby_core_source (= 3.2.1)
       libdatadog (~> 4.0.0.1.0)
-      libddwaf (~> 1.11.0.0.0)
+      libddwaf (~> 1.14.0.0.0)
       msgpack
 
 GEM
@@ -124,9 +124,9 @@ GEM
       addressable (>= 2.4)
     libdatadog (4.0.0.1.0-aarch64-linux)
     libdatadog (4.0.0.1.0-x86_64-linux)
-    libddwaf (1.11.0.0.0-aarch64-linux)
+    libddwaf (1.14.0.0.0-aarch64-linux)
       ffi (~> 1.0)
-    libddwaf (1.11.0.0.0-x86_64-linux)
+    libddwaf (1.14.0.0.0-x86_64-linux)
       ffi (~> 1.0)
     lograge (0.12.0)
       actionpack (>= 4)

--- a/gemfiles/ruby_3.0.4_rails61_semantic_logger.gemfile.lock
+++ b/gemfiles/ruby_3.0.4_rails61_semantic_logger.gemfile.lock
@@ -15,7 +15,7 @@ PATH
       datadog-ci (~> 0.1.0)
       debase-ruby_core_source (= 3.2.1)
       libdatadog (~> 4.0.0.1.0)
-      libddwaf (~> 1.11.0.0.0)
+      libddwaf (~> 1.14.0.0.0)
       msgpack
 
 GEM
@@ -123,9 +123,9 @@ GEM
       addressable (>= 2.4)
     libdatadog (4.0.0.1.0-aarch64-linux)
     libdatadog (4.0.0.1.0-x86_64-linux)
-    libddwaf (1.11.0.0.0-aarch64-linux)
+    libddwaf (1.14.0.0.0-aarch64-linux)
       ffi (~> 1.0)
-    libddwaf (1.11.0.0.0-x86_64-linux)
+    libddwaf (1.14.0.0.0-x86_64-linux)
       ffi (~> 1.0)
     loofah (2.19.1)
       crass (~> 1.0.2)

--- a/gemfiles/ruby_3.0.4_redis_3.gemfile.lock
+++ b/gemfiles/ruby_3.0.4_redis_3.gemfile.lock
@@ -15,7 +15,7 @@ PATH
       datadog-ci (~> 0.1.0)
       debase-ruby_core_source (= 3.2.1)
       libdatadog (~> 4.0.0.1.0)
-      libddwaf (~> 1.11.0.0.0)
+      libddwaf (~> 1.14.0.0.0)
       msgpack
 
 GEM
@@ -57,9 +57,9 @@ GEM
       addressable (>= 2.4)
     libdatadog (4.0.0.1.0-aarch64-linux)
     libdatadog (4.0.0.1.0-x86_64-linux)
-    libddwaf (1.11.0.0.0-aarch64-linux)
+    libddwaf (1.14.0.0.0-aarch64-linux)
       ffi (~> 1.0)
-    libddwaf (1.11.0.0.0-x86_64-linux)
+    libddwaf (1.14.0.0.0-x86_64-linux)
       ffi (~> 1.0)
     memory_profiler (0.9.14)
     method_source (1.0.0)

--- a/gemfiles/ruby_3.0.4_redis_4.gemfile.lock
+++ b/gemfiles/ruby_3.0.4_redis_4.gemfile.lock
@@ -15,7 +15,7 @@ PATH
       datadog-ci (~> 0.1.0)
       debase-ruby_core_source (= 3.2.1)
       libdatadog (~> 4.0.0.1.0)
-      libddwaf (~> 1.11.0.0.0)
+      libddwaf (~> 1.14.0.0.0)
       msgpack
 
 GEM
@@ -57,9 +57,9 @@ GEM
       addressable (>= 2.4)
     libdatadog (4.0.0.1.0-aarch64-linux)
     libdatadog (4.0.0.1.0-x86_64-linux)
-    libddwaf (1.11.0.0.0-aarch64-linux)
+    libddwaf (1.14.0.0.0-aarch64-linux)
       ffi (~> 1.0)
-    libddwaf (1.11.0.0.0-x86_64-linux)
+    libddwaf (1.14.0.0.0-x86_64-linux)
       ffi (~> 1.0)
     memory_profiler (0.9.14)
     method_source (1.0.0)

--- a/gemfiles/ruby_3.0.4_redis_5.gemfile.lock
+++ b/gemfiles/ruby_3.0.4_redis_5.gemfile.lock
@@ -15,7 +15,7 @@ PATH
       datadog-ci (~> 0.1.0)
       debase-ruby_core_source (= 3.2.1)
       libdatadog (~> 4.0.0.1.0)
-      libddwaf (~> 1.11.0.0.0)
+      libddwaf (~> 1.14.0.0.0)
       msgpack
 
 GEM
@@ -58,9 +58,9 @@ GEM
       addressable (>= 2.4)
     libdatadog (4.0.0.1.0-aarch64-linux)
     libdatadog (4.0.0.1.0-x86_64-linux)
-    libddwaf (1.11.0.0.0-aarch64-linux)
+    libddwaf (1.14.0.0.0-aarch64-linux)
       ffi (~> 1.0)
-    libddwaf (1.11.0.0.0-x86_64-linux)
+    libddwaf (1.14.0.0.0-x86_64-linux)
       ffi (~> 1.0)
     memory_profiler (0.9.14)
     method_source (1.0.0)

--- a/gemfiles/ruby_3.0.4_relational_db.gemfile.lock
+++ b/gemfiles/ruby_3.0.4_relational_db.gemfile.lock
@@ -15,7 +15,7 @@ PATH
       datadog-ci (~> 0.1.0)
       debase-ruby_core_source (= 3.2.1)
       libdatadog (~> 4.0.0.1.0)
-      libddwaf (~> 1.11.0.0.0)
+      libddwaf (~> 1.14.0.0.0)
       msgpack
 
 GEM
@@ -72,7 +72,10 @@ GEM
     json-schema (2.8.1)
       addressable (>= 2.4)
     libdatadog (4.0.0.1.0-aarch64-linux)
-    libddwaf (1.11.0.0.0-aarch64-linux)
+    libdatadog (4.0.0.1.0-x86_64-linux)
+    libddwaf (1.14.0.0.0-aarch64-linux)
+      ffi (~> 1.0)
+    libddwaf (1.14.0.0.0-x86_64-linux)
       ffi (~> 1.0)
     makara (0.6.0.pre)
       activerecord (>= 5.2.0)

--- a/gemfiles/ruby_3.0.4_resque2_redis3.gemfile.lock
+++ b/gemfiles/ruby_3.0.4_resque2_redis3.gemfile.lock
@@ -15,7 +15,7 @@ PATH
       datadog-ci (~> 0.1.0)
       debase-ruby_core_source (= 3.2.1)
       libdatadog (~> 4.0.0.1.0)
-      libddwaf (~> 1.11.0.0.0)
+      libddwaf (~> 1.14.0.0.0)
       msgpack
 
 GEM
@@ -57,9 +57,9 @@ GEM
       addressable (>= 2.4)
     libdatadog (4.0.0.1.0-aarch64-linux)
     libdatadog (4.0.0.1.0-x86_64-linux)
-    libddwaf (1.11.0.0.0-aarch64-linux)
+    libddwaf (1.14.0.0.0-aarch64-linux)
       ffi (~> 1.0)
-    libddwaf (1.11.0.0.0-x86_64-linux)
+    libddwaf (1.14.0.0.0-x86_64-linux)
       ffi (~> 1.0)
     memory_profiler (0.9.14)
     method_source (1.0.0)

--- a/gemfiles/ruby_3.0.4_resque2_redis4.gemfile.lock
+++ b/gemfiles/ruby_3.0.4_resque2_redis4.gemfile.lock
@@ -15,7 +15,7 @@ PATH
       datadog-ci (~> 0.1.0)
       debase-ruby_core_source (= 3.2.1)
       libdatadog (~> 4.0.0.1.0)
-      libddwaf (~> 1.11.0.0.0)
+      libddwaf (~> 1.14.0.0.0)
       msgpack
 
 GEM
@@ -58,9 +58,9 @@ GEM
       addressable (>= 2.4)
     libdatadog (4.0.0.1.0-aarch64-linux)
     libdatadog (4.0.0.1.0-x86_64-linux)
-    libddwaf (1.11.0.0.0-aarch64-linux)
+    libddwaf (1.14.0.0.0-aarch64-linux)
       ffi (~> 1.0)
-    libddwaf (1.11.0.0.0-x86_64-linux)
+    libddwaf (1.14.0.0.0-x86_64-linux)
       ffi (~> 1.0)
     memory_profiler (0.9.14)
     method_source (1.0.0)

--- a/gemfiles/ruby_3.0.4_sinatra.gemfile.lock
+++ b/gemfiles/ruby_3.0.4_sinatra.gemfile.lock
@@ -15,7 +15,7 @@ PATH
       datadog-ci (~> 0.1.0)
       debase-ruby_core_source (= 3.2.1)
       libdatadog (~> 4.0.0.1.0)
-      libddwaf (~> 1.11.0.0.0)
+      libddwaf (~> 1.14.0.0.0)
       msgpack
 
 GEM
@@ -57,9 +57,9 @@ GEM
       addressable (>= 2.4)
     libdatadog (4.0.0.1.0-aarch64-linux)
     libdatadog (4.0.0.1.0-x86_64-linux)
-    libddwaf (1.11.0.0.0-aarch64-linux)
+    libddwaf (1.14.0.0.0-aarch64-linux)
       ffi (~> 1.0)
-    libddwaf (1.11.0.0.0-x86_64-linux)
+    libddwaf (1.14.0.0.0-x86_64-linux)
       ffi (~> 1.0)
     memory_profiler (0.9.14)
     method_source (1.0.0)

--- a/gemfiles/ruby_3.1.2_aws.gemfile.lock
+++ b/gemfiles/ruby_3.1.2_aws.gemfile.lock
@@ -15,7 +15,7 @@ PATH
       datadog-ci (~> 0.1.0)
       debase-ruby_core_source (= 3.2.1)
       libdatadog (~> 4.0.0.1.0)
-      libddwaf (~> 1.11.0.0.0)
+      libddwaf (~> 1.14.0.0.0)
       msgpack
 
 GEM
@@ -1477,7 +1477,7 @@ GEM
     json-schema (2.8.1)
       addressable (>= 2.4)
     libdatadog (4.0.0.1.0-aarch64-linux)
-    libddwaf (1.11.0.0.0-aarch64-linux)
+    libddwaf (1.14.0.0.0-aarch64-linux)
       ffi (~> 1.0)
     memory_profiler (0.9.14)
     method_source (1.0.0)

--- a/gemfiles/ruby_3.1.2_contrib.gemfile.lock
+++ b/gemfiles/ruby_3.1.2_contrib.gemfile.lock
@@ -15,7 +15,7 @@ PATH
       datadog-ci (~> 0.1.0)
       debase-ruby_core_source (= 3.2.1)
       libdatadog (~> 4.0.0.1.0)
-      libddwaf (~> 1.11.0.0.0)
+      libddwaf (~> 1.14.0.0.0)
       msgpack
 
 GEM
@@ -129,9 +129,9 @@ GEM
     king_konf (1.0.1)
     libdatadog (4.0.0.1.0-aarch64-linux)
     libdatadog (4.0.0.1.0-x86_64-linux)
-    libddwaf (1.11.0.0.0-aarch64-linux)
+    libddwaf (1.14.0.0.0-aarch64-linux)
       ffi (~> 1.0)
-    libddwaf (1.11.0.0.0-x86_64-linux)
+    libddwaf (1.14.0.0.0-x86_64-linux)
       ffi (~> 1.0)
     lograge (0.12.0)
       actionpack (>= 4)

--- a/gemfiles/ruby_3.1.2_contrib_old.gemfile.lock
+++ b/gemfiles/ruby_3.1.2_contrib_old.gemfile.lock
@@ -15,7 +15,7 @@ PATH
       datadog-ci (~> 0.1.0)
       debase-ruby_core_source (= 3.2.1)
       libdatadog (~> 4.0.0.1.0)
-      libddwaf (~> 1.11.0.0.0)
+      libddwaf (~> 1.14.0.0.0)
       msgpack
 
 GEM
@@ -77,9 +77,9 @@ GEM
       addressable (>= 2.4)
     libdatadog (4.0.0.1.0-aarch64-linux)
     libdatadog (4.0.0.1.0-x86_64-linux)
-    libddwaf (1.11.0.0.0-aarch64-linux)
+    libddwaf (1.14.0.0.0-aarch64-linux)
       ffi (~> 1.0)
-    libddwaf (1.11.0.0.0-x86_64-linux)
+    libddwaf (1.14.0.0.0-x86_64-linux)
       ffi (~> 1.0)
     memory_profiler (0.9.14)
     method_source (1.0.0)

--- a/gemfiles/ruby_3.1.2_core_old.gemfile.lock
+++ b/gemfiles/ruby_3.1.2_core_old.gemfile.lock
@@ -15,7 +15,7 @@ PATH
       datadog-ci (~> 0.1.0)
       debase-ruby_core_source (= 3.2.1)
       libdatadog (~> 4.0.0.1.0)
-      libddwaf (~> 1.11.0.0.0)
+      libddwaf (~> 1.14.0.0.0)
       msgpack
 
 GEM
@@ -57,9 +57,9 @@ GEM
       addressable (>= 2.4)
     libdatadog (4.0.0.1.0-aarch64-linux)
     libdatadog (4.0.0.1.0-x86_64-linux)
-    libddwaf (1.11.0.0.0-aarch64-linux)
+    libddwaf (1.14.0.0.0-aarch64-linux)
       ffi (~> 1.0)
-    libddwaf (1.11.0.0.0-x86_64-linux)
+    libddwaf (1.14.0.0.0-x86_64-linux)
       ffi (~> 1.0)
     memory_profiler (0.9.14)
     method_source (1.0.0)

--- a/gemfiles/ruby_3.1.2_http.gemfile.lock
+++ b/gemfiles/ruby_3.1.2_http.gemfile.lock
@@ -15,7 +15,7 @@ PATH
       datadog-ci (~> 0.1.0)
       debase-ruby_core_source (= 3.2.1)
       libdatadog (~> 4.0.0.1.0)
-      libddwaf (~> 1.11.0.0.0)
+      libddwaf (~> 1.14.0.0.0)
       msgpack
 
 GEM
@@ -85,7 +85,7 @@ GEM
     json-schema (2.8.1)
       addressable (>= 2.4)
     libdatadog (4.0.0.1.0-aarch64-linux)
-    libddwaf (1.11.0.0.0-aarch64-linux)
+    libddwaf (1.14.0.0.0-aarch64-linux)
       ffi (~> 1.0)
     llhttp-ffi (0.3.1)
       ffi-compiler (~> 1.0)

--- a/gemfiles/ruby_3.1.2_opentelemetry.gemfile.lock
+++ b/gemfiles/ruby_3.1.2_opentelemetry.gemfile.lock
@@ -15,7 +15,7 @@ PATH
       datadog-ci (~> 0.1.0)
       debase-ruby_core_source (= 3.2.1)
       libdatadog (~> 4.0.0.1.0)
-      libddwaf (~> 1.11.0.0.0)
+      libddwaf (~> 1.14.0.0.0)
       msgpack
 
 GEM
@@ -59,11 +59,11 @@ GEM
     libdatadog (4.0.0.1.0)
     libdatadog (4.0.0.1.0-aarch64-linux)
     libdatadog (4.0.0.1.0-x86_64-linux)
-    libddwaf (1.11.0.0.0-aarch64-linux)
+    libddwaf (1.14.0.0.0-aarch64-linux)
       ffi (~> 1.0)
-    libddwaf (1.11.0.0.0-x86_64-darwin)
+    libddwaf (1.14.0.0.0-x86_64-darwin)
       ffi (~> 1.0)
-    libddwaf (1.11.0.0.0-x86_64-linux)
+    libddwaf (1.14.0.0.0-x86_64-linux)
       ffi (~> 1.0)
     memory_profiler (0.9.14)
     method_source (1.0.0)

--- a/gemfiles/ruby_3.1.2_rails61_mysql2.gemfile.lock
+++ b/gemfiles/ruby_3.1.2_rails61_mysql2.gemfile.lock
@@ -15,7 +15,7 @@ PATH
       datadog-ci (~> 0.1.0)
       debase-ruby_core_source (= 3.2.1)
       libdatadog (~> 4.0.0.1.0)
-      libddwaf (~> 1.11.0.0.0)
+      libddwaf (~> 1.14.0.0.0)
       msgpack
 
 GEM
@@ -123,9 +123,9 @@ GEM
       addressable (>= 2.4)
     libdatadog (4.0.0.1.0-aarch64-linux)
     libdatadog (4.0.0.1.0-x86_64-linux)
-    libddwaf (1.11.0.0.0-aarch64-linux)
+    libddwaf (1.14.0.0.0-aarch64-linux)
       ffi (~> 1.0)
-    libddwaf (1.11.0.0.0-x86_64-linux)
+    libddwaf (1.14.0.0.0-x86_64-linux)
       ffi (~> 1.0)
     lograge (0.12.0)
       actionpack (>= 4)

--- a/gemfiles/ruby_3.1.2_rails61_postgres.gemfile.lock
+++ b/gemfiles/ruby_3.1.2_rails61_postgres.gemfile.lock
@@ -15,7 +15,7 @@ PATH
       datadog-ci (~> 0.1.0)
       debase-ruby_core_source (= 3.2.1)
       libdatadog (~> 4.0.0.1.0)
-      libddwaf (~> 1.11.0.0.0)
+      libddwaf (~> 1.14.0.0.0)
       msgpack
 
 GEM
@@ -123,9 +123,9 @@ GEM
       addressable (>= 2.4)
     libdatadog (4.0.0.1.0-aarch64-linux)
     libdatadog (4.0.0.1.0-x86_64-linux)
-    libddwaf (1.11.0.0.0-aarch64-linux)
+    libddwaf (1.14.0.0.0-aarch64-linux)
       ffi (~> 1.0)
-    libddwaf (1.11.0.0.0-x86_64-linux)
+    libddwaf (1.14.0.0.0-x86_64-linux)
       ffi (~> 1.0)
     lograge (0.12.0)
       actionpack (>= 4)

--- a/gemfiles/ruby_3.1.2_rails61_postgres_redis.gemfile.lock
+++ b/gemfiles/ruby_3.1.2_rails61_postgres_redis.gemfile.lock
@@ -15,7 +15,7 @@ PATH
       datadog-ci (~> 0.1.0)
       debase-ruby_core_source (= 3.2.1)
       libdatadog (~> 4.0.0.1.0)
-      libddwaf (~> 1.11.0.0.0)
+      libddwaf (~> 1.14.0.0.0)
       msgpack
 
 GEM
@@ -123,9 +123,9 @@ GEM
       addressable (>= 2.4)
     libdatadog (4.0.0.1.0-aarch64-linux)
     libdatadog (4.0.0.1.0-x86_64-linux)
-    libddwaf (1.11.0.0.0-aarch64-linux)
+    libddwaf (1.14.0.0.0-aarch64-linux)
       ffi (~> 1.0)
-    libddwaf (1.11.0.0.0-x86_64-linux)
+    libddwaf (1.14.0.0.0-x86_64-linux)
       ffi (~> 1.0)
     lograge (0.12.0)
       actionpack (>= 4)

--- a/gemfiles/ruby_3.1.2_rails61_postgres_sidekiq.gemfile.lock
+++ b/gemfiles/ruby_3.1.2_rails61_postgres_sidekiq.gemfile.lock
@@ -15,7 +15,7 @@ PATH
       datadog-ci (~> 0.1.0)
       debase-ruby_core_source (= 3.2.1)
       libdatadog (~> 4.0.0.1.0)
-      libddwaf (~> 1.11.0.0.0)
+      libddwaf (~> 1.14.0.0.0)
       msgpack
 
 GEM
@@ -124,9 +124,9 @@ GEM
       addressable (>= 2.4)
     libdatadog (4.0.0.1.0-aarch64-linux)
     libdatadog (4.0.0.1.0-x86_64-linux)
-    libddwaf (1.11.0.0.0-aarch64-linux)
+    libddwaf (1.14.0.0.0-aarch64-linux)
       ffi (~> 1.0)
-    libddwaf (1.11.0.0.0-x86_64-linux)
+    libddwaf (1.14.0.0.0-x86_64-linux)
       ffi (~> 1.0)
     lograge (0.12.0)
       actionpack (>= 4)

--- a/gemfiles/ruby_3.1.2_rails61_semantic_logger.gemfile.lock
+++ b/gemfiles/ruby_3.1.2_rails61_semantic_logger.gemfile.lock
@@ -15,7 +15,7 @@ PATH
       datadog-ci (~> 0.1.0)
       debase-ruby_core_source (= 3.2.1)
       libdatadog (~> 4.0.0.1.0)
-      libddwaf (~> 1.11.0.0.0)
+      libddwaf (~> 1.14.0.0.0)
       msgpack
 
 GEM
@@ -123,9 +123,9 @@ GEM
       addressable (>= 2.4)
     libdatadog (4.0.0.1.0-aarch64-linux)
     libdatadog (4.0.0.1.0-x86_64-linux)
-    libddwaf (1.11.0.0.0-aarch64-linux)
+    libddwaf (1.14.0.0.0-aarch64-linux)
       ffi (~> 1.0)
-    libddwaf (1.11.0.0.0-x86_64-linux)
+    libddwaf (1.14.0.0.0-x86_64-linux)
       ffi (~> 1.0)
     loofah (2.19.1)
       crass (~> 1.0.2)

--- a/gemfiles/ruby_3.1.2_redis_3.gemfile.lock
+++ b/gemfiles/ruby_3.1.2_redis_3.gemfile.lock
@@ -15,7 +15,7 @@ PATH
       datadog-ci (~> 0.1.0)
       debase-ruby_core_source (= 3.2.1)
       libdatadog (~> 4.0.0.1.0)
-      libddwaf (~> 1.11.0.0.0)
+      libddwaf (~> 1.14.0.0.0)
       msgpack
 
 GEM
@@ -57,9 +57,9 @@ GEM
       addressable (>= 2.4)
     libdatadog (4.0.0.1.0-aarch64-linux)
     libdatadog (4.0.0.1.0-x86_64-linux)
-    libddwaf (1.11.0.0.0-aarch64-linux)
+    libddwaf (1.14.0.0.0-aarch64-linux)
       ffi (~> 1.0)
-    libddwaf (1.11.0.0.0-x86_64-linux)
+    libddwaf (1.14.0.0.0-x86_64-linux)
       ffi (~> 1.0)
     memory_profiler (0.9.14)
     method_source (1.0.0)

--- a/gemfiles/ruby_3.1.2_redis_4.gemfile.lock
+++ b/gemfiles/ruby_3.1.2_redis_4.gemfile.lock
@@ -15,7 +15,7 @@ PATH
       datadog-ci (~> 0.1.0)
       debase-ruby_core_source (= 3.2.1)
       libdatadog (~> 4.0.0.1.0)
-      libddwaf (~> 1.11.0.0.0)
+      libddwaf (~> 1.14.0.0.0)
       msgpack
 
 GEM
@@ -57,9 +57,9 @@ GEM
       addressable (>= 2.4)
     libdatadog (4.0.0.1.0-aarch64-linux)
     libdatadog (4.0.0.1.0-x86_64-linux)
-    libddwaf (1.11.0.0.0-aarch64-linux)
+    libddwaf (1.14.0.0.0-aarch64-linux)
       ffi (~> 1.0)
-    libddwaf (1.11.0.0.0-x86_64-linux)
+    libddwaf (1.14.0.0.0-x86_64-linux)
       ffi (~> 1.0)
     memory_profiler (0.9.14)
     method_source (1.0.0)

--- a/gemfiles/ruby_3.1.2_redis_5.gemfile.lock
+++ b/gemfiles/ruby_3.1.2_redis_5.gemfile.lock
@@ -15,7 +15,7 @@ PATH
       datadog-ci (~> 0.1.0)
       debase-ruby_core_source (= 3.2.1)
       libdatadog (~> 4.0.0.1.0)
-      libddwaf (~> 1.11.0.0.0)
+      libddwaf (~> 1.14.0.0.0)
       msgpack
 
 GEM
@@ -58,9 +58,9 @@ GEM
       addressable (>= 2.4)
     libdatadog (4.0.0.1.0-aarch64-linux)
     libdatadog (4.0.0.1.0-x86_64-linux)
-    libddwaf (1.11.0.0.0-aarch64-linux)
+    libddwaf (1.14.0.0.0-aarch64-linux)
       ffi (~> 1.0)
-    libddwaf (1.11.0.0.0-x86_64-linux)
+    libddwaf (1.14.0.0.0-x86_64-linux)
       ffi (~> 1.0)
     memory_profiler (0.9.14)
     method_source (1.0.0)

--- a/gemfiles/ruby_3.1.2_relational_db.gemfile.lock
+++ b/gemfiles/ruby_3.1.2_relational_db.gemfile.lock
@@ -15,7 +15,7 @@ PATH
       datadog-ci (~> 0.1.0)
       debase-ruby_core_source (= 3.2.1)
       libdatadog (~> 4.0.0.1.0)
-      libddwaf (~> 1.11.0.0.0)
+      libddwaf (~> 1.14.0.0.0)
       msgpack
 
 GEM
@@ -72,10 +72,11 @@ GEM
     json-schema (2.8.1)
       addressable (>= 2.4)
     libdatadog (4.0.0.1.0-aarch64-linux)
-    libddwaf (1.11.0.0.0-aarch64-linux)
+    libdatadog (4.0.0.1.0-x86_64-linux)
+    libddwaf (1.14.0.0.0-aarch64-linux)
       ffi (~> 1.0)
-    makara (0.6.0.pre)
-      activerecord (>= 5.2.0)
+    libddwaf (1.14.0.0.0-x86_64-linux)
+      ffi (~> 1.0)
     memory_profiler (0.9.14)
     method_source (1.0.0)
     minitest (5.20.0)

--- a/gemfiles/ruby_3.1.2_resque2_redis3.gemfile.lock
+++ b/gemfiles/ruby_3.1.2_resque2_redis3.gemfile.lock
@@ -15,7 +15,7 @@ PATH
       datadog-ci (~> 0.1.0)
       debase-ruby_core_source (= 3.2.1)
       libdatadog (~> 4.0.0.1.0)
-      libddwaf (~> 1.11.0.0.0)
+      libddwaf (~> 1.14.0.0.0)
       msgpack
 
 GEM
@@ -57,9 +57,9 @@ GEM
       addressable (>= 2.4)
     libdatadog (4.0.0.1.0-aarch64-linux)
     libdatadog (4.0.0.1.0-x86_64-linux)
-    libddwaf (1.11.0.0.0-aarch64-linux)
+    libddwaf (1.14.0.0.0-aarch64-linux)
       ffi (~> 1.0)
-    libddwaf (1.11.0.0.0-x86_64-linux)
+    libddwaf (1.14.0.0.0-x86_64-linux)
       ffi (~> 1.0)
     memory_profiler (0.9.14)
     method_source (1.0.0)

--- a/gemfiles/ruby_3.1.2_resque2_redis4.gemfile.lock
+++ b/gemfiles/ruby_3.1.2_resque2_redis4.gemfile.lock
@@ -15,7 +15,7 @@ PATH
       datadog-ci (~> 0.1.0)
       debase-ruby_core_source (= 3.2.1)
       libdatadog (~> 4.0.0.1.0)
-      libddwaf (~> 1.11.0.0.0)
+      libddwaf (~> 1.14.0.0.0)
       msgpack
 
 GEM
@@ -58,9 +58,9 @@ GEM
       addressable (>= 2.4)
     libdatadog (4.0.0.1.0-aarch64-linux)
     libdatadog (4.0.0.1.0-x86_64-linux)
-    libddwaf (1.11.0.0.0-aarch64-linux)
+    libddwaf (1.14.0.0.0-aarch64-linux)
       ffi (~> 1.0)
-    libddwaf (1.11.0.0.0-x86_64-linux)
+    libddwaf (1.14.0.0.0-x86_64-linux)
       ffi (~> 1.0)
     memory_profiler (0.9.14)
     method_source (1.0.0)

--- a/gemfiles/ruby_3.1.2_sinatra.gemfile.lock
+++ b/gemfiles/ruby_3.1.2_sinatra.gemfile.lock
@@ -15,7 +15,7 @@ PATH
       datadog-ci (~> 0.1.0)
       debase-ruby_core_source (= 3.2.1)
       libdatadog (~> 4.0.0.1.0)
-      libddwaf (~> 1.11.0.0.0)
+      libddwaf (~> 1.14.0.0.0)
       msgpack
 
 GEM
@@ -57,9 +57,9 @@ GEM
       addressable (>= 2.4)
     libdatadog (4.0.0.1.0-aarch64-linux)
     libdatadog (4.0.0.1.0-x86_64-linux)
-    libddwaf (1.11.0.0.0-aarch64-linux)
+    libddwaf (1.14.0.0.0-aarch64-linux)
       ffi (~> 1.0)
-    libddwaf (1.11.0.0.0-x86_64-linux)
+    libddwaf (1.14.0.0.0-x86_64-linux)
       ffi (~> 1.0)
     memory_profiler (0.9.14)
     method_source (1.0.0)

--- a/gemfiles/ruby_3.2.0_aws.gemfile.lock
+++ b/gemfiles/ruby_3.2.0_aws.gemfile.lock
@@ -15,7 +15,7 @@ PATH
       datadog-ci (~> 0.1.0)
       debase-ruby_core_source (= 3.2.1)
       libdatadog (~> 4.0.0.1.0)
-      libddwaf (~> 1.11.0.0.0)
+      libddwaf (~> 1.14.0.0.0)
       msgpack
 
 GEM
@@ -1476,7 +1476,7 @@ GEM
     json-schema (2.8.1)
       addressable (>= 2.4)
     libdatadog (4.0.0.1.0-aarch64-linux)
-    libddwaf (1.11.0.0.0-aarch64-linux)
+    libddwaf (1.14.0.0.0-aarch64-linux)
       ffi (~> 1.0)
     memory_profiler (0.9.14)
     method_source (1.0.0)

--- a/gemfiles/ruby_3.2.0_contrib.gemfile.lock
+++ b/gemfiles/ruby_3.2.0_contrib.gemfile.lock
@@ -15,7 +15,7 @@ PATH
       datadog-ci (~> 0.1.0)
       debase-ruby_core_source (= 3.2.1)
       libdatadog (~> 4.0.0.1.0)
-      libddwaf (~> 1.11.0.0.0)
+      libddwaf (~> 1.14.0.0.0)
       msgpack
 
 GEM
@@ -128,9 +128,7 @@ GEM
     king_konf (1.0.1)
     libdatadog (4.0.0.1.0-aarch64-linux)
     libdatadog (4.0.0.1.0-x86_64-linux)
-    libddwaf (1.11.0.0.0-aarch64-linux)
-      ffi (~> 1.0)
-    libddwaf (1.11.0.0.0-x86_64-linux)
+    libddwaf (1.14.0.0.0-aarch64-linux)
       ffi (~> 1.0)
     lograge (0.12.0)
       actionpack (>= 4)

--- a/gemfiles/ruby_3.2.0_contrib_old.gemfile.lock
+++ b/gemfiles/ruby_3.2.0_contrib_old.gemfile.lock
@@ -15,7 +15,7 @@ PATH
       datadog-ci (~> 0.1.0)
       debase-ruby_core_source (= 3.2.1)
       libdatadog (~> 4.0.0.1.0)
-      libddwaf (~> 1.11.0.0.0)
+      libddwaf (~> 1.14.0.0.0)
       msgpack
 
 GEM
@@ -76,9 +76,9 @@ GEM
       addressable (>= 2.4)
     libdatadog (4.0.0.1.0-aarch64-linux)
     libdatadog (4.0.0.1.0-x86_64-linux)
-    libddwaf (1.11.0.0.0-aarch64-linux)
+    libddwaf (1.14.0.0.0-aarch64-linux)
       ffi (~> 1.0)
-    libddwaf (1.11.0.0.0-x86_64-linux)
+    libddwaf (1.14.0.0.0-x86_64-linux)
       ffi (~> 1.0)
     memory_profiler (0.9.14)
     method_source (1.0.0)

--- a/gemfiles/ruby_3.2.0_core_old.gemfile.lock
+++ b/gemfiles/ruby_3.2.0_core_old.gemfile.lock
@@ -15,7 +15,7 @@ PATH
       datadog-ci (~> 0.1.0)
       debase-ruby_core_source (= 3.2.1)
       libdatadog (~> 4.0.0.1.0)
-      libddwaf (~> 1.11.0.0.0)
+      libddwaf (~> 1.14.0.0.0)
       msgpack
 
 GEM
@@ -56,9 +56,9 @@ GEM
       addressable (>= 2.4)
     libdatadog (4.0.0.1.0-aarch64-linux)
     libdatadog (4.0.0.1.0-x86_64-linux)
-    libddwaf (1.11.0.0.0-aarch64-linux)
+    libddwaf (1.14.0.0.0-aarch64-linux)
       ffi (~> 1.0)
-    libddwaf (1.11.0.0.0-x86_64-linux)
+    libddwaf (1.14.0.0.0-x86_64-linux)
       ffi (~> 1.0)
     memory_profiler (0.9.14)
     method_source (1.0.0)

--- a/gemfiles/ruby_3.2.0_http.gemfile.lock
+++ b/gemfiles/ruby_3.2.0_http.gemfile.lock
@@ -15,7 +15,7 @@ PATH
       datadog-ci (~> 0.1.0)
       debase-ruby_core_source (= 3.2.1)
       libdatadog (~> 4.0.0.1.0)
-      libddwaf (~> 1.11.0.0.0)
+      libddwaf (~> 1.14.0.0.0)
       msgpack
 
 GEM
@@ -84,7 +84,7 @@ GEM
     json-schema (2.8.1)
       addressable (>= 2.4)
     libdatadog (4.0.0.1.0-aarch64-linux)
-    libddwaf (1.11.0.0.0-aarch64-linux)
+    libddwaf (1.14.0.0.0-aarch64-linux)
       ffi (~> 1.0)
     llhttp-ffi (0.3.1)
       ffi-compiler (~> 1.0)

--- a/gemfiles/ruby_3.2.0_opentelemetry.gemfile.lock
+++ b/gemfiles/ruby_3.2.0_opentelemetry.gemfile.lock
@@ -15,7 +15,7 @@ PATH
       datadog-ci (~> 0.1.0)
       debase-ruby_core_source (= 3.2.1)
       libdatadog (~> 4.0.0.1.0)
-      libddwaf (~> 1.11.0.0.0)
+      libddwaf (~> 1.14.0.0.0)
       msgpack
 
 GEM
@@ -56,9 +56,9 @@ GEM
       addressable (>= 2.4)
     libdatadog (4.0.0.1.0-aarch64-linux)
     libdatadog (4.0.0.1.0-x86_64-linux)
-    libddwaf (1.11.0.0.0-aarch64-linux)
+    libddwaf (1.14.0.0.0-aarch64-linux)
       ffi (~> 1.0)
-    libddwaf (1.11.0.0.0-x86_64-linux)
+    libddwaf (1.14.0.0.0-x86_64-linux)
       ffi (~> 1.0)
     memory_profiler (0.9.14)
     method_source (1.0.0)

--- a/gemfiles/ruby_3.2.0_rails61_mysql2.gemfile.lock
+++ b/gemfiles/ruby_3.2.0_rails61_mysql2.gemfile.lock
@@ -15,7 +15,7 @@ PATH
       datadog-ci (~> 0.1.0)
       debase-ruby_core_source (= 3.2.1)
       libdatadog (~> 4.0.0.1.0)
-      libddwaf (~> 1.11.0.0.0)
+      libddwaf (~> 1.14.0.0.0)
       msgpack
 
 GEM
@@ -122,9 +122,7 @@ GEM
       addressable (>= 2.4)
     libdatadog (4.0.0.1.0-aarch64-linux)
     libdatadog (4.0.0.1.0-x86_64-linux)
-    libddwaf (1.11.0.0.0-aarch64-linux)
-      ffi (~> 1.0)
-    libddwaf (1.11.0.0.0-x86_64-linux)
+    libddwaf (1.14.0.0.0-aarch64-linux)
       ffi (~> 1.0)
     lograge (0.12.0)
       actionpack (>= 4)

--- a/gemfiles/ruby_3.2.0_rails61_postgres.gemfile.lock
+++ b/gemfiles/ruby_3.2.0_rails61_postgres.gemfile.lock
@@ -15,7 +15,7 @@ PATH
       datadog-ci (~> 0.1.0)
       debase-ruby_core_source (= 3.2.1)
       libdatadog (~> 4.0.0.1.0)
-      libddwaf (~> 1.11.0.0.0)
+      libddwaf (~> 1.14.0.0.0)
       msgpack
 
 GEM
@@ -122,9 +122,9 @@ GEM
       addressable (>= 2.4)
     libdatadog (4.0.0.1.0-aarch64-linux)
     libdatadog (4.0.0.1.0-x86_64-linux)
-    libddwaf (1.11.0.0.0-aarch64-linux)
+    libddwaf (1.14.0.0.0-aarch64-linux)
       ffi (~> 1.0)
-    libddwaf (1.11.0.0.0-x86_64-linux)
+    libddwaf (1.14.0.0.0-x86_64-linux)
       ffi (~> 1.0)
     lograge (0.12.0)
       actionpack (>= 4)

--- a/gemfiles/ruby_3.2.0_rails61_postgres_redis.gemfile.lock
+++ b/gemfiles/ruby_3.2.0_rails61_postgres_redis.gemfile.lock
@@ -15,7 +15,7 @@ PATH
       datadog-ci (~> 0.1.0)
       debase-ruby_core_source (= 3.2.1)
       libdatadog (~> 4.0.0.1.0)
-      libddwaf (~> 1.11.0.0.0)
+      libddwaf (~> 1.14.0.0.0)
       msgpack
 
 GEM
@@ -122,9 +122,9 @@ GEM
       addressable (>= 2.4)
     libdatadog (4.0.0.1.0-aarch64-linux)
     libdatadog (4.0.0.1.0-x86_64-linux)
-    libddwaf (1.11.0.0.0-aarch64-linux)
+    libddwaf (1.14.0.0.0-aarch64-linux)
       ffi (~> 1.0)
-    libddwaf (1.11.0.0.0-x86_64-linux)
+    libddwaf (1.14.0.0.0-x86_64-linux)
       ffi (~> 1.0)
     lograge (0.12.0)
       actionpack (>= 4)

--- a/gemfiles/ruby_3.2.0_rails61_postgres_sidekiq.gemfile.lock
+++ b/gemfiles/ruby_3.2.0_rails61_postgres_sidekiq.gemfile.lock
@@ -15,7 +15,7 @@ PATH
       datadog-ci (~> 0.1.0)
       debase-ruby_core_source (= 3.2.1)
       libdatadog (~> 4.0.0.1.0)
-      libddwaf (~> 1.11.0.0.0)
+      libddwaf (~> 1.14.0.0.0)
       msgpack
 
 GEM
@@ -123,9 +123,9 @@ GEM
       addressable (>= 2.4)
     libdatadog (4.0.0.1.0-aarch64-linux)
     libdatadog (4.0.0.1.0-x86_64-linux)
-    libddwaf (1.11.0.0.0-aarch64-linux)
+    libddwaf (1.14.0.0.0-aarch64-linux)
       ffi (~> 1.0)
-    libddwaf (1.11.0.0.0-x86_64-linux)
+    libddwaf (1.14.0.0.0-x86_64-linux)
       ffi (~> 1.0)
     lograge (0.12.0)
       actionpack (>= 4)

--- a/gemfiles/ruby_3.2.0_rails61_semantic_logger.gemfile.lock
+++ b/gemfiles/ruby_3.2.0_rails61_semantic_logger.gemfile.lock
@@ -15,7 +15,7 @@ PATH
       datadog-ci (~> 0.1.0)
       debase-ruby_core_source (= 3.2.1)
       libdatadog (~> 4.0.0.1.0)
-      libddwaf (~> 1.11.0.0.0)
+      libddwaf (~> 1.14.0.0.0)
       msgpack
 
 GEM
@@ -122,9 +122,9 @@ GEM
       addressable (>= 2.4)
     libdatadog (4.0.0.1.0-aarch64-linux)
     libdatadog (4.0.0.1.0-x86_64-linux)
-    libddwaf (1.11.0.0.0-aarch64-linux)
+    libddwaf (1.14.0.0.0-aarch64-linux)
       ffi (~> 1.0)
-    libddwaf (1.11.0.0.0-x86_64-linux)
+    libddwaf (1.14.0.0.0-x86_64-linux)
       ffi (~> 1.0)
     loofah (2.19.1)
       crass (~> 1.0.2)

--- a/gemfiles/ruby_3.2.0_redis_3.gemfile.lock
+++ b/gemfiles/ruby_3.2.0_redis_3.gemfile.lock
@@ -15,7 +15,7 @@ PATH
       datadog-ci (~> 0.1.0)
       debase-ruby_core_source (= 3.2.1)
       libdatadog (~> 4.0.0.1.0)
-      libddwaf (~> 1.11.0.0.0)
+      libddwaf (~> 1.14.0.0.0)
       msgpack
 
 GEM
@@ -56,9 +56,9 @@ GEM
       addressable (>= 2.4)
     libdatadog (4.0.0.1.0-aarch64-linux)
     libdatadog (4.0.0.1.0-x86_64-linux)
-    libddwaf (1.11.0.0.0-aarch64-linux)
+    libddwaf (1.14.0.0.0-aarch64-linux)
       ffi (~> 1.0)
-    libddwaf (1.11.0.0.0-x86_64-linux)
+    libddwaf (1.14.0.0.0-x86_64-linux)
       ffi (~> 1.0)
     memory_profiler (0.9.14)
     method_source (1.0.0)

--- a/gemfiles/ruby_3.2.0_redis_4.gemfile.lock
+++ b/gemfiles/ruby_3.2.0_redis_4.gemfile.lock
@@ -15,7 +15,7 @@ PATH
       datadog-ci (~> 0.1.0)
       debase-ruby_core_source (= 3.2.1)
       libdatadog (~> 4.0.0.1.0)
-      libddwaf (~> 1.11.0.0.0)
+      libddwaf (~> 1.14.0.0.0)
       msgpack
 
 GEM
@@ -56,9 +56,9 @@ GEM
       addressable (>= 2.4)
     libdatadog (4.0.0.1.0-aarch64-linux)
     libdatadog (4.0.0.1.0-x86_64-linux)
-    libddwaf (1.11.0.0.0-aarch64-linux)
+    libddwaf (1.14.0.0.0-aarch64-linux)
       ffi (~> 1.0)
-    libddwaf (1.11.0.0.0-x86_64-linux)
+    libddwaf (1.14.0.0.0-x86_64-linux)
       ffi (~> 1.0)
     memory_profiler (0.9.14)
     method_source (1.0.0)

--- a/gemfiles/ruby_3.2.0_redis_5.gemfile.lock
+++ b/gemfiles/ruby_3.2.0_redis_5.gemfile.lock
@@ -15,7 +15,7 @@ PATH
       datadog-ci (~> 0.1.0)
       debase-ruby_core_source (= 3.2.1)
       libdatadog (~> 4.0.0.1.0)
-      libddwaf (~> 1.11.0.0.0)
+      libddwaf (~> 1.14.0.0.0)
       msgpack
 
 GEM
@@ -57,9 +57,9 @@ GEM
       addressable (>= 2.4)
     libdatadog (4.0.0.1.0-aarch64-linux)
     libdatadog (4.0.0.1.0-x86_64-linux)
-    libddwaf (1.11.0.0.0-aarch64-linux)
+    libddwaf (1.14.0.0.0-aarch64-linux)
       ffi (~> 1.0)
-    libddwaf (1.11.0.0.0-x86_64-linux)
+    libddwaf (1.14.0.0.0-x86_64-linux)
       ffi (~> 1.0)
     memory_profiler (0.9.14)
     method_source (1.0.0)

--- a/gemfiles/ruby_3.2.0_relational_db.gemfile.lock
+++ b/gemfiles/ruby_3.2.0_relational_db.gemfile.lock
@@ -15,7 +15,7 @@ PATH
       datadog-ci (~> 0.1.0)
       debase-ruby_core_source (= 3.2.1)
       libdatadog (~> 4.0.0.1.0)
-      libddwaf (~> 1.11.0.0.0)
+      libddwaf (~> 1.14.0.0.0)
       msgpack
 
 GEM
@@ -71,10 +71,11 @@ GEM
     json-schema (2.8.1)
       addressable (>= 2.4)
     libdatadog (4.0.0.1.0-aarch64-linux)
-    libddwaf (1.11.0.0.0-aarch64-linux)
+    libdatadog (4.0.0.1.0-x86_64-linux)
+    libddwaf (1.14.0.0.0-aarch64-linux)
       ffi (~> 1.0)
-    makara (0.6.0.pre)
-      activerecord (>= 5.2.0)
+    libddwaf (1.14.0.0.0-x86_64-linux)
+      ffi (~> 1.0)
     memory_profiler (0.9.14)
     method_source (1.0.0)
     minitest (5.20.0)

--- a/gemfiles/ruby_3.2.0_resque2_redis3.gemfile.lock
+++ b/gemfiles/ruby_3.2.0_resque2_redis3.gemfile.lock
@@ -15,7 +15,7 @@ PATH
       datadog-ci (~> 0.1.0)
       debase-ruby_core_source (= 3.2.1)
       libdatadog (~> 4.0.0.1.0)
-      libddwaf (~> 1.11.0.0.0)
+      libddwaf (~> 1.14.0.0.0)
       msgpack
 
 GEM
@@ -56,9 +56,9 @@ GEM
       addressable (>= 2.4)
     libdatadog (4.0.0.1.0-aarch64-linux)
     libdatadog (4.0.0.1.0-x86_64-linux)
-    libddwaf (1.11.0.0.0-aarch64-linux)
+    libddwaf (1.14.0.0.0-aarch64-linux)
       ffi (~> 1.0)
-    libddwaf (1.11.0.0.0-x86_64-linux)
+    libddwaf (1.14.0.0.0-x86_64-linux)
       ffi (~> 1.0)
     memory_profiler (0.9.14)
     method_source (1.0.0)

--- a/gemfiles/ruby_3.2.0_resque2_redis4.gemfile.lock
+++ b/gemfiles/ruby_3.2.0_resque2_redis4.gemfile.lock
@@ -15,7 +15,7 @@ PATH
       datadog-ci (~> 0.1.0)
       debase-ruby_core_source (= 3.2.1)
       libdatadog (~> 4.0.0.1.0)
-      libddwaf (~> 1.11.0.0.0)
+      libddwaf (~> 1.14.0.0.0)
       msgpack
 
 GEM
@@ -57,9 +57,9 @@ GEM
       addressable (>= 2.4)
     libdatadog (4.0.0.1.0-aarch64-linux)
     libdatadog (4.0.0.1.0-x86_64-linux)
-    libddwaf (1.11.0.0.0-aarch64-linux)
+    libddwaf (1.14.0.0.0-aarch64-linux)
       ffi (~> 1.0)
-    libddwaf (1.11.0.0.0-x86_64-linux)
+    libddwaf (1.14.0.0.0-x86_64-linux)
       ffi (~> 1.0)
     memory_profiler (0.9.14)
     method_source (1.0.0)

--- a/gemfiles/ruby_3.2.0_sinatra.gemfile.lock
+++ b/gemfiles/ruby_3.2.0_sinatra.gemfile.lock
@@ -15,7 +15,7 @@ PATH
       datadog-ci (~> 0.1.0)
       debase-ruby_core_source (= 3.2.1)
       libdatadog (~> 4.0.0.1.0)
-      libddwaf (~> 1.11.0.0.0)
+      libddwaf (~> 1.14.0.0.0)
       msgpack
 
 GEM
@@ -56,9 +56,9 @@ GEM
       addressable (>= 2.4)
     libdatadog (4.0.0.1.0-aarch64-linux)
     libdatadog (4.0.0.1.0-x86_64-linux)
-    libddwaf (1.11.0.0.0-aarch64-linux)
+    libddwaf (1.14.0.0.0-aarch64-linux)
       ffi (~> 1.0)
-    libddwaf (1.11.0.0.0-x86_64-linux)
+    libddwaf (1.14.0.0.0-x86_64-linux)
       ffi (~> 1.0)
     memory_profiler (0.9.14)
     method_source (1.0.0)

--- a/gemfiles/ruby_3.3.0_aws.gemfile.lock
+++ b/gemfiles/ruby_3.3.0_aws.gemfile.lock
@@ -15,7 +15,7 @@ PATH
       datadog-ci (~> 0.1.0)
       debase-ruby_core_source (= 3.2.1)
       libdatadog (~> 4.0.0.1.0)
-      libddwaf (~> 1.11.0.0.0)
+      libddwaf (~> 1.14.0.0.0)
       msgpack
 
 GEM
@@ -1476,7 +1476,7 @@ GEM
     json-schema (2.8.1)
       addressable (>= 2.4)
     libdatadog (4.0.0.1.0-aarch64-linux)
-    libddwaf (1.11.0.0.0-aarch64-linux)
+    libddwaf (1.14.0.0.0-aarch64-linux)
       ffi (~> 1.0)
     memory_profiler (0.9.14)
     method_source (1.0.0)

--- a/gemfiles/ruby_3.3.0_contrib.gemfile.lock
+++ b/gemfiles/ruby_3.3.0_contrib.gemfile.lock
@@ -15,7 +15,7 @@ PATH
       datadog-ci (~> 0.1.0)
       debase-ruby_core_source (= 3.2.1)
       libdatadog (~> 4.0.0.1.0)
-      libddwaf (~> 1.11.0.0.0)
+      libddwaf (~> 1.14.0.0.0)
       msgpack
 
 GEM
@@ -124,9 +124,9 @@ GEM
     king_konf (1.0.1)
     libdatadog (4.0.0.1.0-aarch64-linux)
     libdatadog (4.0.0.1.0-x86_64-linux)
-    libddwaf (1.11.0.0.0-aarch64-linux)
+    libddwaf (1.14.0.0.0-aarch64-linux)
       ffi (~> 1.0)
-    libddwaf (1.11.0.0.0-x86_64-linux)
+    libddwaf (1.14.0.0.0-x86_64-linux)
       ffi (~> 1.0)
     lograge (0.12.0)
       actionpack (>= 4)

--- a/gemfiles/ruby_3.3.0_contrib_old.gemfile.lock
+++ b/gemfiles/ruby_3.3.0_contrib_old.gemfile.lock
@@ -15,7 +15,7 @@ PATH
       datadog-ci (~> 0.1.0)
       debase-ruby_core_source (= 3.2.1)
       libdatadog (~> 4.0.0.1.0)
-      libddwaf (~> 1.11.0.0.0)
+      libddwaf (~> 1.14.0.0.0)
       msgpack
 
 GEM
@@ -75,9 +75,9 @@ GEM
       addressable (>= 2.4)
     libdatadog (4.0.0.1.0-aarch64-linux)
     libdatadog (4.0.0.1.0-x86_64-linux)
-    libddwaf (1.11.0.0.0-aarch64-linux)
+    libddwaf (1.14.0.0.0-aarch64-linux)
       ffi (~> 1.0)
-    libddwaf (1.11.0.0.0-x86_64-linux)
+    libddwaf (1.14.0.0.0-x86_64-linux)
       ffi (~> 1.0)
     memory_profiler (0.9.14)
     method_source (1.0.0)

--- a/gemfiles/ruby_3.3.0_core_old.gemfile.lock
+++ b/gemfiles/ruby_3.3.0_core_old.gemfile.lock
@@ -15,7 +15,7 @@ PATH
       datadog-ci (~> 0.1.0)
       debase-ruby_core_source (= 3.2.1)
       libdatadog (~> 4.0.0.1.0)
-      libddwaf (~> 1.11.0.0.0)
+      libddwaf (~> 1.14.0.0.0)
       msgpack
 
 GEM
@@ -55,9 +55,9 @@ GEM
       addressable (>= 2.4)
     libdatadog (4.0.0.1.0-aarch64-linux)
     libdatadog (4.0.0.1.0-x86_64-linux)
-    libddwaf (1.11.0.0.0-aarch64-linux)
+    libddwaf (1.14.0.0.0-aarch64-linux)
       ffi (~> 1.0)
-    libddwaf (1.11.0.0.0-x86_64-linux)
+    libddwaf (1.14.0.0.0-x86_64-linux)
       ffi (~> 1.0)
     memory_profiler (0.9.14)
     method_source (1.0.0)

--- a/gemfiles/ruby_3.3.0_http.gemfile.lock
+++ b/gemfiles/ruby_3.3.0_http.gemfile.lock
@@ -15,7 +15,7 @@ PATH
       datadog-ci (~> 0.1.0)
       debase-ruby_core_source (= 3.2.1)
       libdatadog (~> 4.0.0.1.0)
-      libddwaf (~> 1.11.0.0.0)
+      libddwaf (~> 1.14.0.0.0)
       msgpack
 
 GEM
@@ -84,7 +84,7 @@ GEM
     json-schema (2.8.1)
       addressable (>= 2.4)
     libdatadog (4.0.0.1.0-aarch64-linux)
-    libddwaf (1.11.0.0.0-aarch64-linux)
+    libddwaf (1.14.0.0.0-aarch64-linux)
       ffi (~> 1.0)
     llhttp-ffi (0.3.1)
       ffi-compiler (~> 1.0)

--- a/gemfiles/ruby_3.3.0_opentelemetry.gemfile.lock
+++ b/gemfiles/ruby_3.3.0_opentelemetry.gemfile.lock
@@ -15,7 +15,7 @@ PATH
       datadog-ci (~> 0.1.0)
       debase-ruby_core_source (= 3.2.1)
       libdatadog (~> 4.0.0.1.0)
-      libddwaf (~> 1.11.0.0.0)
+      libddwaf (~> 1.14.0.0.0)
       msgpack
 
 GEM
@@ -55,9 +55,9 @@ GEM
       addressable (>= 2.4)
     libdatadog (4.0.0.1.0-aarch64-linux)
     libdatadog (4.0.0.1.0-x86_64-linux)
-    libddwaf (1.11.0.0.0-aarch64-linux)
+    libddwaf (1.14.0.0.0-aarch64-linux)
       ffi (~> 1.0)
-    libddwaf (1.11.0.0.0-x86_64-linux)
+    libddwaf (1.14.0.0.0-x86_64-linux)
       ffi (~> 1.0)
     memory_profiler (0.9.14)
     method_source (1.0.0)

--- a/gemfiles/ruby_3.3.0_rails61_mysql2.gemfile.lock
+++ b/gemfiles/ruby_3.3.0_rails61_mysql2.gemfile.lock
@@ -15,7 +15,7 @@ PATH
       datadog-ci (~> 0.1.0)
       debase-ruby_core_source (= 3.2.1)
       libdatadog (~> 4.0.0.1.0)
-      libddwaf (~> 1.11.0.0.0)
+      libddwaf (~> 1.14.0.0.0)
       msgpack
 
 GEM
@@ -121,9 +121,9 @@ GEM
       addressable (>= 2.4)
     libdatadog (4.0.0.1.0-aarch64-linux)
     libdatadog (4.0.0.1.0-x86_64-linux)
-    libddwaf (1.11.0.0.0-aarch64-linux)
+    libddwaf (1.14.0.0.0-aarch64-linux)
       ffi (~> 1.0)
-    libddwaf (1.11.0.0.0-x86_64-linux)
+    libddwaf (1.14.0.0.0-x86_64-linux)
       ffi (~> 1.0)
     lograge (0.12.0)
       actionpack (>= 4)

--- a/gemfiles/ruby_3.3.0_rails61_postgres.gemfile.lock
+++ b/gemfiles/ruby_3.3.0_rails61_postgres.gemfile.lock
@@ -15,7 +15,7 @@ PATH
       datadog-ci (~> 0.1.0)
       debase-ruby_core_source (= 3.2.1)
       libdatadog (~> 4.0.0.1.0)
-      libddwaf (~> 1.11.0.0.0)
+      libddwaf (~> 1.14.0.0.0)
       msgpack
 
 GEM
@@ -121,9 +121,9 @@ GEM
       addressable (>= 2.4)
     libdatadog (4.0.0.1.0-aarch64-linux)
     libdatadog (4.0.0.1.0-x86_64-linux)
-    libddwaf (1.11.0.0.0-aarch64-linux)
+    libddwaf (1.14.0.0.0-aarch64-linux)
       ffi (~> 1.0)
-    libddwaf (1.11.0.0.0-x86_64-linux)
+    libddwaf (1.14.0.0.0-x86_64-linux)
       ffi (~> 1.0)
     lograge (0.12.0)
       actionpack (>= 4)

--- a/gemfiles/ruby_3.3.0_rails61_postgres_redis.gemfile.lock
+++ b/gemfiles/ruby_3.3.0_rails61_postgres_redis.gemfile.lock
@@ -15,7 +15,7 @@ PATH
       datadog-ci (~> 0.1.0)
       debase-ruby_core_source (= 3.2.1)
       libdatadog (~> 4.0.0.1.0)
-      libddwaf (~> 1.11.0.0.0)
+      libddwaf (~> 1.14.0.0.0)
       msgpack
 
 GEM
@@ -121,9 +121,9 @@ GEM
       addressable (>= 2.4)
     libdatadog (4.0.0.1.0-aarch64-linux)
     libdatadog (4.0.0.1.0-x86_64-linux)
-    libddwaf (1.11.0.0.0-aarch64-linux)
+    libddwaf (1.14.0.0.0-aarch64-linux)
       ffi (~> 1.0)
-    libddwaf (1.11.0.0.0-x86_64-linux)
+    libddwaf (1.14.0.0.0-x86_64-linux)
       ffi (~> 1.0)
     lograge (0.12.0)
       actionpack (>= 4)

--- a/gemfiles/ruby_3.3.0_rails61_postgres_sidekiq.gemfile.lock
+++ b/gemfiles/ruby_3.3.0_rails61_postgres_sidekiq.gemfile.lock
@@ -15,7 +15,7 @@ PATH
       datadog-ci (~> 0.1.0)
       debase-ruby_core_source (= 3.2.1)
       libdatadog (~> 4.0.0.1.0)
-      libddwaf (~> 1.11.0.0.0)
+      libddwaf (~> 1.14.0.0.0)
       msgpack
 
 GEM
@@ -122,9 +122,9 @@ GEM
       addressable (>= 2.4)
     libdatadog (4.0.0.1.0-aarch64-linux)
     libdatadog (4.0.0.1.0-x86_64-linux)
-    libddwaf (1.11.0.0.0-aarch64-linux)
+    libddwaf (1.14.0.0.0-aarch64-linux)
       ffi (~> 1.0)
-    libddwaf (1.11.0.0.0-x86_64-linux)
+    libddwaf (1.14.0.0.0-x86_64-linux)
       ffi (~> 1.0)
     lograge (0.12.0)
       actionpack (>= 4)

--- a/gemfiles/ruby_3.3.0_rails61_semantic_logger.gemfile.lock
+++ b/gemfiles/ruby_3.3.0_rails61_semantic_logger.gemfile.lock
@@ -15,7 +15,7 @@ PATH
       datadog-ci (~> 0.1.0)
       debase-ruby_core_source (= 3.2.1)
       libdatadog (~> 4.0.0.1.0)
-      libddwaf (~> 1.11.0.0.0)
+      libddwaf (~> 1.14.0.0.0)
       msgpack
 
 GEM
@@ -121,9 +121,9 @@ GEM
       addressable (>= 2.4)
     libdatadog (4.0.0.1.0-aarch64-linux)
     libdatadog (4.0.0.1.0-x86_64-linux)
-    libddwaf (1.11.0.0.0-aarch64-linux)
+    libddwaf (1.14.0.0.0-aarch64-linux)
       ffi (~> 1.0)
-    libddwaf (1.11.0.0.0-x86_64-linux)
+    libddwaf (1.14.0.0.0-x86_64-linux)
       ffi (~> 1.0)
     loofah (2.21.3)
       crass (~> 1.0.2)

--- a/gemfiles/ruby_3.3.0_redis_3.gemfile.lock
+++ b/gemfiles/ruby_3.3.0_redis_3.gemfile.lock
@@ -15,7 +15,7 @@ PATH
       datadog-ci (~> 0.1.0)
       debase-ruby_core_source (= 3.2.1)
       libdatadog (~> 4.0.0.1.0)
-      libddwaf (~> 1.11.0.0.0)
+      libddwaf (~> 1.14.0.0.0)
       msgpack
 
 GEM
@@ -55,9 +55,9 @@ GEM
       addressable (>= 2.4)
     libdatadog (4.0.0.1.0-aarch64-linux)
     libdatadog (4.0.0.1.0-x86_64-linux)
-    libddwaf (1.11.0.0.0-aarch64-linux)
+    libddwaf (1.14.0.0.0-aarch64-linux)
       ffi (~> 1.0)
-    libddwaf (1.11.0.0.0-x86_64-linux)
+    libddwaf (1.14.0.0.0-x86_64-linux)
       ffi (~> 1.0)
     memory_profiler (0.9.14)
     method_source (1.0.0)

--- a/gemfiles/ruby_3.3.0_redis_4.gemfile.lock
+++ b/gemfiles/ruby_3.3.0_redis_4.gemfile.lock
@@ -15,7 +15,7 @@ PATH
       datadog-ci (~> 0.1.0)
       debase-ruby_core_source (= 3.2.1)
       libdatadog (~> 4.0.0.1.0)
-      libddwaf (~> 1.11.0.0.0)
+      libddwaf (~> 1.14.0.0.0)
       msgpack
 
 GEM
@@ -55,9 +55,9 @@ GEM
       addressable (>= 2.4)
     libdatadog (4.0.0.1.0-aarch64-linux)
     libdatadog (4.0.0.1.0-x86_64-linux)
-    libddwaf (1.11.0.0.0-aarch64-linux)
+    libddwaf (1.14.0.0.0-aarch64-linux)
       ffi (~> 1.0)
-    libddwaf (1.11.0.0.0-x86_64-linux)
+    libddwaf (1.14.0.0.0-x86_64-linux)
       ffi (~> 1.0)
     memory_profiler (0.9.14)
     method_source (1.0.0)

--- a/gemfiles/ruby_3.3.0_redis_5.gemfile.lock
+++ b/gemfiles/ruby_3.3.0_redis_5.gemfile.lock
@@ -15,7 +15,7 @@ PATH
       datadog-ci (~> 0.1.0)
       debase-ruby_core_source (= 3.2.1)
       libdatadog (~> 4.0.0.1.0)
-      libddwaf (~> 1.11.0.0.0)
+      libddwaf (~> 1.14.0.0.0)
       msgpack
 
 GEM
@@ -56,9 +56,9 @@ GEM
       addressable (>= 2.4)
     libdatadog (4.0.0.1.0-aarch64-linux)
     libdatadog (4.0.0.1.0-x86_64-linux)
-    libddwaf (1.11.0.0.0-aarch64-linux)
+    libddwaf (1.14.0.0.0-aarch64-linux)
       ffi (~> 1.0)
-    libddwaf (1.11.0.0.0-x86_64-linux)
+    libddwaf (1.14.0.0.0-x86_64-linux)
       ffi (~> 1.0)
     memory_profiler (0.9.14)
     method_source (1.0.0)

--- a/gemfiles/ruby_3.3.0_relational_db.gemfile.lock
+++ b/gemfiles/ruby_3.3.0_relational_db.gemfile.lock
@@ -15,7 +15,7 @@ PATH
       datadog-ci (~> 0.1.0)
       debase-ruby_core_source (= 3.2.1)
       libdatadog (~> 4.0.0.1.0)
-      libddwaf (~> 1.11.0.0.0)
+      libddwaf (~> 1.14.0.0.0)
       msgpack
 
 GEM
@@ -71,10 +71,11 @@ GEM
     json-schema (2.8.1)
       addressable (>= 2.4)
     libdatadog (4.0.0.1.0-aarch64-linux)
-    libddwaf (1.11.0.0.0-aarch64-linux)
+    libdatadog (4.0.0.1.0-x86_64-linux)
+    libddwaf (1.14.0.0.0-aarch64-linux)
       ffi (~> 1.0)
-    makara (0.6.0.pre)
-      activerecord (>= 5.2.0)
+    libddwaf (1.14.0.0.0-x86_64-linux)
+      ffi (~> 1.0)
     memory_profiler (0.9.14)
     method_source (1.0.0)
     mini_portile2 (2.8.4)

--- a/gemfiles/ruby_3.3.0_resque2_redis3.gemfile.lock
+++ b/gemfiles/ruby_3.3.0_resque2_redis3.gemfile.lock
@@ -15,7 +15,7 @@ PATH
       datadog-ci (~> 0.1.0)
       debase-ruby_core_source (= 3.2.1)
       libdatadog (~> 4.0.0.1.0)
-      libddwaf (~> 1.11.0.0.0)
+      libddwaf (~> 1.14.0.0.0)
       msgpack
 
 GEM
@@ -55,9 +55,9 @@ GEM
       addressable (>= 2.4)
     libdatadog (4.0.0.1.0-aarch64-linux)
     libdatadog (4.0.0.1.0-x86_64-linux)
-    libddwaf (1.11.0.0.0-aarch64-linux)
+    libddwaf (1.14.0.0.0-aarch64-linux)
       ffi (~> 1.0)
-    libddwaf (1.11.0.0.0-x86_64-linux)
+    libddwaf (1.14.0.0.0-x86_64-linux)
       ffi (~> 1.0)
     memory_profiler (0.9.14)
     method_source (1.0.0)

--- a/gemfiles/ruby_3.3.0_resque2_redis4.gemfile.lock
+++ b/gemfiles/ruby_3.3.0_resque2_redis4.gemfile.lock
@@ -15,7 +15,7 @@ PATH
       datadog-ci (~> 0.1.0)
       debase-ruby_core_source (= 3.2.1)
       libdatadog (~> 4.0.0.1.0)
-      libddwaf (~> 1.11.0.0.0)
+      libddwaf (~> 1.14.0.0.0)
       msgpack
 
 GEM
@@ -56,9 +56,9 @@ GEM
       addressable (>= 2.4)
     libdatadog (4.0.0.1.0-aarch64-linux)
     libdatadog (4.0.0.1.0-x86_64-linux)
-    libddwaf (1.11.0.0.0-aarch64-linux)
+    libddwaf (1.14.0.0.0-aarch64-linux)
       ffi (~> 1.0)
-    libddwaf (1.11.0.0.0-x86_64-linux)
+    libddwaf (1.14.0.0.0-x86_64-linux)
       ffi (~> 1.0)
     memory_profiler (0.9.14)
     method_source (1.0.0)

--- a/gemfiles/ruby_3.3.0_sinatra.gemfile.lock
+++ b/gemfiles/ruby_3.3.0_sinatra.gemfile.lock
@@ -15,7 +15,7 @@ PATH
       datadog-ci (~> 0.1.0)
       debase-ruby_core_source (= 3.2.1)
       libdatadog (~> 4.0.0.1.0)
-      libddwaf (~> 1.11.0.0.0)
+      libddwaf (~> 1.14.0.0.0)
       msgpack
 
 GEM
@@ -55,9 +55,9 @@ GEM
       addressable (>= 2.4)
     libdatadog (4.0.0.1.0-aarch64-linux)
     libdatadog (4.0.0.1.0-x86_64-linux)
-    libddwaf (1.11.0.0.0-aarch64-linux)
+    libddwaf (1.14.0.0.0-aarch64-linux)
       ffi (~> 1.0)
-    libddwaf (1.11.0.0.0-x86_64-linux)
+    libddwaf (1.14.0.0.0-x86_64-linux)
       ffi (~> 1.0)
     memory_profiler (0.9.14)
     method_source (1.0.0)

--- a/lib/datadog/appsec/assets.rb
+++ b/lib/datadog/appsec/assets.rb
@@ -10,6 +10,10 @@ module Datadog
         read("waf_rules/#{kind}.json")
       end
 
+      def waf_processors
+        read('waf_rules/processors.json')
+      end
+
       def blocked(format: :html)
         (@blocked ||= {})[format] ||= read("blocked.#{format}")
       end

--- a/lib/datadog/appsec/assets/waf_rules/processors.json
+++ b/lib/datadog/appsec/assets/waf_rules/processors.json
@@ -1,0 +1,85 @@
+[
+  {
+    "id": "processor-001",
+    "generator": "extract_schema",
+    "conditions": [
+      {
+        "operator": "equals",
+        "parameters": {
+          "inputs": [
+            {
+              "address": "waf.context.processor",
+              "key_path": [
+                "extract-schema"
+              ]
+            }
+          ],
+          "type": "boolean",
+          "value": true
+        }
+      }
+    ],
+    "parameters": {
+      "mappings": [
+        {
+          "inputs": [
+            {
+              "address": "server.request.body"
+            }
+          ],
+          "output": "_dd.appsec.s.req.body"
+        },
+        {
+          "inputs": [
+            {
+              "address": "server.request.headers.no_cookies"
+            }
+          ],
+          "output": "_dd.appsec.s.req.headers"
+        },
+        {
+          "inputs": [
+            {
+              "address": "server.request.query"
+            }
+          ],
+          "output": "_dd.appsec.s.req.query"
+        },
+        {
+          "inputs": [
+            {
+              "address": "server.request.path_params"
+            }
+          ],
+          "output": "_dd.appsec.s.req.params"
+        },
+        {
+          "inputs": [
+            {
+              "address": "server.request.cookies"
+            }
+          ],
+          "output": "_dd.appsec.s.req.cookies"
+        },
+        {
+          "inputs": [
+            {
+              "address": "server.response.headers.no_cookies"
+            }
+          ],
+          "output": "_dd.appsec.s.res.headers"
+        },
+        {
+          "inputs": [
+            {
+              "address": "server.response.body"
+            }
+          ],
+          "output": "_dd.appsec.s.res.body"
+        }
+      ]
+    },
+    "evaluate": false,
+    "output": true
+  }
+]

--- a/lib/datadog/appsec/configuration/settings.rb
+++ b/lib/datadog/appsec/configuration/settings.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 require_relative '../../core/utils/duration'
+require_relative '../sample_rate'
 
 module Datadog
   module AppSec
@@ -166,6 +167,24 @@ module Datadog
                       )
                       'safe'
                     end
+                  end
+                end
+              end
+
+              settings :api_security do
+                option :enabled do |o|
+                  o.type :bool
+                  o.env 'DD_EXPERIMENTAL_API_SECURITY_ENABLED'
+                  o.default false
+                end
+
+                option :sample_rate do |o|
+                  o.type :float
+                  o.env 'DD_API_SECURITY_REQUEST_SAMPLE_RATE'
+                  o.default 0.1
+                  o.setter do |value|
+                    value = 1 if value > 1
+                    SampleRate.new(value)
                   end
                 end
               end

--- a/lib/datadog/appsec/contrib/rack/request_middleware.rb
+++ b/lib/datadog/appsec/contrib/rack/request_middleware.rb
@@ -75,6 +75,16 @@ module Datadog
 
             _response_return, response_response = Instrumentation.gateway.push('rack.response', gateway_response)
 
+            result = scope.processor_context.extract_schema
+
+            if result
+              scope.processor_context.events << {
+                trace: scope.trace,
+                span: scope.service_entry_span,
+                waf_result: result,
+              }
+            end
+
             scope.processor_context.events.each do |e|
               e[:response] ||= gateway_response
               e[:request]  ||= gateway_request

--- a/lib/datadog/appsec/event.rb
+++ b/lib/datadog/appsec/event.rb
@@ -62,6 +62,7 @@ module Datadog
 
           # prepare and gather tags to apply
           service_entry_tags = build_service_entry_tags(event_group)
+
           # complex types are unsupported, we need to serialize to a string
           triggers = service_entry_tags.delete('_dd.appsec.triggers')
           span.set_tag('_dd.appsec.json', JSON.dump({ triggers: triggers }))
@@ -104,8 +105,15 @@ module Datadog
           tags['_dd.origin'] = 'appsec'
 
           # accumulate triggers
+          waf_result = event[:waf_result]
           tags['_dd.appsec.triggers'] ||= []
-          tags['_dd.appsec.triggers'] += event[:waf_result].events
+          tags['_dd.appsec.triggers'] += waf_result.events
+
+          waf_result.derivatives.each do |key, value|
+            tags[key] = JSON.dump(value)
+          end
+
+          tags
         end
       end
     end

--- a/lib/datadog/appsec/processor/rule_merger.rb
+++ b/lib/datadog/appsec/processor/rule_merger.rb
@@ -18,12 +18,17 @@ module Datadog
           end
         end
 
-        DEFAULT_PROCESSORS = JSON.parse(Datadog::AppSec::Assets.waf_processors)
+        DEFAULT_WAF_PROCESSORS = begin
+          JSON.parse(Datadog::AppSec::Assets.waf_processors)
+        rescue StandardError => e
+          Datadog.logger.error { "libddwaf rulemerger failed to parse default waf processors. Error: #{e.inspect}" }
+          []
+        end
 
         class << self
           def merge(
             rules:, data: [], overrides: [], exclusions: [], custom_rules: [],
-            processors: DEFAULT_PROCESSORS
+            processors: DEFAULT_WAF_PROCESSORS
           )
             combined_rules = combine_rules(rules)
 

--- a/lib/datadog/appsec/processor/rule_merger.rb
+++ b/lib/datadog/appsec/processor/rule_merger.rb
@@ -1,5 +1,7 @@
 # frozen_string_literal: true
 
+require_relative '../assets'
+
 module Datadog
   module AppSec
     class Processor
@@ -16,8 +18,13 @@ module Datadog
           end
         end
 
+        DEFAULT_PROCESSORS = JSON.parse(Datadog::AppSec::Assets.waf_processors)
+
         class << self
-          def merge(rules:, data: [], overrides: [], exclusions: [], custom_rules: [])
+          def merge(
+            rules:, data: [], overrides: [], exclusions: [], custom_rules: [],
+            processors: DEFAULT_PROCESSORS
+          )
             combined_rules = combine_rules(rules)
 
             combined_data = combine_data(data) if data.any?
@@ -29,7 +36,7 @@ module Datadog
             combined_rules['rules_override'] = combined_overrides if combined_overrides
             combined_rules['exclusions'] = combined_exclusions if combined_exclusions
             combined_rules['custom_rules'] = combined_custom_rules if combined_custom_rules
-
+            combined_rules['processors'] = processors
             combined_rules
           end
 

--- a/lib/datadog/appsec/sample_rate.rb
+++ b/lib/datadog/appsec/sample_rate.rb
@@ -1,0 +1,21 @@
+# frozen_string_literal: true
+
+module Datadog
+  module AppSec
+    # SampleRate basic sample rate
+    class SampleRate
+      attr_reader :rate
+
+      def initialize(rate)
+        @rate = rate
+      end
+
+      def sample?
+        return false if rate <= 0
+        return true if rate >= 1
+
+        Kernel.rand < rate
+      end
+    end
+  end
+end

--- a/sig/datadog/appsec/assets.rbs
+++ b/sig/datadog/appsec/assets.rbs
@@ -5,6 +5,8 @@ module Datadog
 
       def self?.waf_rules: (?::Symbol kind) -> ::String
 
+      def self?.waf_processors: () -> ::String
+
       def self?.blocked: (?format: ::Symbol) -> ::String
 
       def self?.path: () -> ::Pathname

--- a/sig/datadog/appsec/processor.rbs
+++ b/sig/datadog/appsec/processor.rbs
@@ -16,7 +16,11 @@ module Datadog
 
         def initialize: (Processor processor) -> void
         def run: (data input, ?::Integer timeout) -> WAF::Result
+        def extract_schema: () -> WAF::Result?
         def finalize: () -> void
+
+        private
+        def extract_schema?: () -> bool
       end
 
       def self.active_context: () -> Context

--- a/sig/datadog/appsec/processor/rule_merger.rbs
+++ b/sig/datadog/appsec/processor/rule_merger.rbs
@@ -11,8 +11,11 @@ module Datadog
         type overrides = ::Array[::Hash[::String, untyped]]
         type exclusions = ::Array[::Hash[::String, untyped]]
         type custom_rules = ::Array[::Hash[::String, untyped]]
+        type processors = ::Hash[::String, untyped]
 
-        def self.merge: (rules: ::Array[rules], ?data: ::Array[data], ?overrides: ::Array[overrides], ?exclusions: ::Array[exclusions], ?custom_rules: ::Array[custom_rules]) -> rules
+        DEFAULT_PROCESSORS: ::Hash[::String, untyped]
+
+        def self.merge: (rules: ::Array[rules], ?data: ::Array[data], ?overrides: ::Array[overrides], ?exclusions: ::Array[exclusions], ?custom_rules: ::Array[custom_rules], ?processors: processors) -> rules
 
         private
 

--- a/sig/datadog/appsec/processor/rule_merger.rbs
+++ b/sig/datadog/appsec/processor/rule_merger.rbs
@@ -11,9 +11,9 @@ module Datadog
         type overrides = ::Array[::Hash[::String, untyped]]
         type exclusions = ::Array[::Hash[::String, untyped]]
         type custom_rules = ::Array[::Hash[::String, untyped]]
-        type processors = ::Hash[::String, untyped]
+        type processors = ::Array[::Hash[::String, untyped]]
 
-        DEFAULT_PROCESSORS: ::Hash[::String, untyped]
+        DEFAULT_WAF_PROCESSORS: processors
 
         def self.merge: (rules: ::Array[rules], ?data: ::Array[data], ?overrides: ::Array[overrides], ?exclusions: ::Array[exclusions], ?custom_rules: ::Array[custom_rules], ?processors: processors) -> rules
 

--- a/sig/datadog/appsec/sample_rate.rbs
+++ b/sig/datadog/appsec/sample_rate.rbs
@@ -1,0 +1,11 @@
+module Datadog
+  module AppSec
+    class SampleRate
+      attr_reader rate: Numeric
+
+      def initialize: (Numeric rate) -> void
+
+      def sample?: () -> (bool)
+    end
+  end
+end

--- a/spec/datadog/appsec/configuration/settings_spec.rb
+++ b/spec/datadog/appsec/configuration/settings_spec.rb
@@ -633,5 +633,83 @@ RSpec.describe Datadog::AppSec::Configuration::Settings do
         end
       end
     end
+
+    describe 'api_security' do
+      describe '#enabled' do
+        subject(:enabled) { settings.appsec.api_security.enabled }
+
+        context 'when DD_EXPERIMENTAL_API_SECURITY_ENABLED' do
+          around do |example|
+            ClimateControl.modify('DD_EXPERIMENTAL_API_SECURITY_ENABLED' => api_security_enabled) do
+              example.run
+            end
+          end
+
+          context 'is not defined' do
+            let(:api_security_enabled) { nil }
+
+            it { is_expected.to eq false }
+          end
+
+          context 'is defined' do
+            let(:api_security_enabled) { 'true' }
+
+            it { is_expected.to eq(true) }
+          end
+        end
+      end
+
+      describe '#enabled=' do
+        subject(:set_api_security_enabled) { settings.appsec.api_security.enabled = api_security_enabled }
+
+        [true, false].each do |value|
+          context "when given #{value}" do
+            let(:api_security_enabled) { value }
+
+            before { set_api_security_enabled }
+
+            it { expect(settings.appsec.api_security.enabled).to eq(value) }
+          end
+        end
+      end
+
+      describe '#sample_rate' do
+        subject(:sample_rate) { settings.appsec.api_security.sample_rate.rate }
+
+        context 'when DD_API_SECURITY_REQUEST_SAMPLE_RATE' do
+          around do |example|
+            ClimateControl.modify('DD_API_SECURITY_REQUEST_SAMPLE_RATE' => api_security_sample_rate) do
+              example.run
+            end
+          end
+
+          context 'is not defined' do
+            let(:api_security_sample_rate) { nil }
+
+            it { is_expected.to eq 0.1 }
+          end
+
+          context 'is defined' do
+            let(:api_security_sample_rate) { '0.3' }
+
+            it { is_expected.to eq 0.3 }
+          end
+        end
+      end
+
+      describe '#sample_rate=' do
+        subject(:set_api_security_sample_rate) do
+          settings.appsec.api_security.sample_rate = api_security_sample_rate
+        end
+
+        context 'when given a value higher than 1.0' do
+          let(:api_security_sample_rate) { 1.2 }
+
+          before { set_api_security_sample_rate }
+
+          it { expect(settings.appsec.api_security.sample_rate.rate).to eq 1.0 }
+        end
+      end
+    end
   end
 end

--- a/spec/datadog/appsec/contrib/rack/integration_test_spec.rb
+++ b/spec/datadog/appsec/contrib/rack/integration_test_spec.rb
@@ -23,6 +23,8 @@ RSpec.describe 'Rack integration tests' do
   let(:appsec_ip_denylist) { [] }
   let(:appsec_user_id_denylist) { [] }
   let(:appsec_ruleset) { :recommended }
+  let(:api_security_enabled) { false }
+  let(:api_security_sample) { 0.0 }
 
   let(:crs_942_100) do
     {
@@ -136,6 +138,8 @@ RSpec.describe 'Rack integration tests' do
       c.appsec.ip_denylist = appsec_ip_denylist
       c.appsec.user_id_denylist = appsec_user_id_denylist
       c.appsec.ruleset = appsec_ruleset
+      c.appsec.api_security.enabled = api_security_enabled
+      c.appsec.api_security.sample_rate = api_security_sample
     end
   end
 
@@ -231,6 +235,19 @@ RSpec.describe 'Rack integration tests' do
           it_behaves_like 'a GET 200 span'
           it_behaves_like 'a trace with AppSec tags'
           it_behaves_like 'a trace without AppSec events'
+
+          context 'with schema extraction' do
+            let(:api_security_enabled) { true }
+            let(:api_security_sample) { 1 }
+
+            it { is_expected.to be_ok }
+
+            it_behaves_like 'normal with tracing disable'
+            it_behaves_like 'a GET 200 span'
+            it_behaves_like 'a trace with AppSec tags'
+            it_behaves_like 'a trace without AppSec events'
+            it_behaves_like 'a trace with AppSec api security tags'
+          end
         end
 
         context 'with an event-triggering request in headers' do
@@ -243,6 +260,20 @@ RSpec.describe 'Rack integration tests' do
           it_behaves_like 'a GET 200 span'
           it_behaves_like 'a trace with AppSec tags'
           it_behaves_like 'a trace with AppSec events'
+
+          context 'with schema extraction' do
+            let(:api_security_enabled) { true }
+            let(:api_security_sample) { 1 }
+
+            it { is_expected.to be_ok }
+            it { expect(triggers).to be_a Array }
+
+            it_behaves_like 'normal with tracing disable'
+            it_behaves_like 'a GET 200 span'
+            it_behaves_like 'a trace with AppSec tags'
+            it_behaves_like 'a trace with AppSec events'
+            it_behaves_like 'a trace with AppSec api security tags'
+          end
         end
 
         context 'with an event-triggering request in query string' do
@@ -264,6 +295,19 @@ RSpec.describe 'Rack integration tests' do
             it_behaves_like 'a GET 403 span'
             it_behaves_like 'a trace with AppSec tags'
             it_behaves_like 'a trace with AppSec events', { blocking: true }
+
+            context 'with schema extraction' do
+              let(:api_security_enabled) { true }
+              let(:api_security_sample) { 1 }
+
+              it { is_expected.to be_forbidden }
+
+              it_behaves_like 'normal with tracing disable'
+              it_behaves_like 'a GET 403 span'
+              it_behaves_like 'a trace with AppSec api security tags'
+              it_behaves_like 'a trace with AppSec tags'
+              it_behaves_like 'a trace with AppSec events', { blocking: true }
+            end
           end
         end
 
@@ -278,6 +322,19 @@ RSpec.describe 'Rack integration tests' do
           it_behaves_like 'a GET 403 span'
           it_behaves_like 'a trace with AppSec tags'
           it_behaves_like 'a trace with AppSec events'
+
+          context 'with schema extraction' do
+            let(:api_security_enabled) { true }
+            let(:api_security_sample) { 1 }
+
+            it { is_expected.to be_forbidden }
+
+            it_behaves_like 'normal with tracing disable'
+            it_behaves_like 'a GET 403 span'
+            it_behaves_like 'a trace with AppSec tags'
+            it_behaves_like 'a trace with AppSec events'
+            it_behaves_like 'a trace with AppSec api security tags'
+          end
         end
 
         context 'with an event-triggering response' do
@@ -302,6 +359,19 @@ RSpec.describe 'Rack integration tests' do
             it_behaves_like 'a GET 403 span'
             it_behaves_like 'a trace with AppSec tags'
             it_behaves_like 'a trace with AppSec events', { blocking: true }
+
+            context 'with schema extraction' do
+              let(:api_security_enabled) { true }
+              let(:api_security_sample) { 1 }
+
+              it { is_expected.to be_forbidden }
+
+              it_behaves_like 'normal with tracing disable'
+              it_behaves_like 'a GET 403 span'
+              it_behaves_like 'a trace with AppSec tags'
+              it_behaves_like 'a trace with AppSec events', { blocking: true }
+              it_behaves_like 'a trace with AppSec api security tags'
+            end
           end
         end
 
@@ -324,6 +394,19 @@ RSpec.describe 'Rack integration tests' do
             it_behaves_like 'a GET 403 span'
             it_behaves_like 'a trace with AppSec tags'
             it_behaves_like 'a trace with AppSec events', { blocking: true }
+
+            context 'with schema extraction' do
+              let(:api_security_enabled) { true }
+              let(:api_security_sample) { 1 }
+
+              it { is_expected.to be_forbidden }
+
+              it_behaves_like 'normal with tracing disable'
+              it_behaves_like 'a GET 403 span'
+              it_behaves_like 'a trace with AppSec tags'
+              it_behaves_like 'a trace with AppSec events', { blocking: true }
+              it_behaves_like 'a trace with AppSec api security tags'
+            end
           end
         end
       end
@@ -343,6 +426,19 @@ RSpec.describe 'Rack integration tests' do
           it_behaves_like 'a POST 200 span'
           it_behaves_like 'a trace with AppSec tags'
           it_behaves_like 'a trace without AppSec events'
+
+          context 'with schema extraction' do
+            let(:api_security_enabled) { true }
+            let(:api_security_sample) { 1 }
+
+            it { is_expected.to be_ok }
+
+            it_behaves_like 'normal with tracing disable'
+            it_behaves_like 'a POST 200 span'
+            it_behaves_like 'a trace with AppSec tags'
+            it_behaves_like 'a trace without AppSec events'
+            it_behaves_like 'a trace with AppSec api security tags'
+          end
         end
 
         context 'with an event-triggering request in application/x-www-form-url-encoded body' do
@@ -362,6 +458,18 @@ RSpec.describe 'Rack integration tests' do
           it_behaves_like 'a trace with AppSec tags'
           it_behaves_like 'a trace with AppSec events'
 
+          context 'with schema extraction' do
+            let(:api_security_enabled) { true }
+            let(:api_security_sample) { 1 }
+
+            it { is_expected.to be_ok }
+
+            it_behaves_like 'a POST 200 span'
+            it_behaves_like 'a trace with AppSec tags'
+            it_behaves_like 'a trace with AppSec events'
+            it_behaves_like 'a trace with AppSec api security tags'
+          end
+
           context 'and a blocking rule' do
             let(:appsec_ruleset) { crs_942_100 }
 
@@ -371,6 +479,19 @@ RSpec.describe 'Rack integration tests' do
             it_behaves_like 'a POST 403 span'
             it_behaves_like 'a trace with AppSec tags'
             it_behaves_like 'a trace with AppSec events', { blocking: true }
+
+            context 'with schema extraction' do
+              let(:api_security_enabled) { true }
+              let(:api_security_sample) { 1 }
+
+              it { is_expected.to be_forbidden }
+
+              it_behaves_like 'normal with tracing disable'
+              it_behaves_like 'a POST 403 span'
+              it_behaves_like 'a trace with AppSec tags'
+              it_behaves_like 'a trace with AppSec events', { blocking: true }
+              it_behaves_like 'a trace with AppSec api security tags'
+            end
           end
         end
 
@@ -394,6 +515,19 @@ RSpec.describe 'Rack integration tests' do
             it_behaves_like 'a trace with AppSec tags'
             it_behaves_like 'a trace with AppSec events'
 
+            context 'with schema extraction' do
+              let(:api_security_enabled) { true }
+              let(:api_security_sample) { 1 }
+
+              it { is_expected.to be_ok }
+
+              it_behaves_like 'normal with tracing disable'
+              it_behaves_like 'a POST 200 span'
+              it_behaves_like 'a trace with AppSec tags'
+              it_behaves_like 'a trace with AppSec events'
+              it_behaves_like 'a trace with AppSec api security tags'
+            end
+
             context 'and a blocking rule' do
               let(:appsec_ruleset) { crs_942_100 }
 
@@ -403,6 +537,19 @@ RSpec.describe 'Rack integration tests' do
               it_behaves_like 'a POST 403 span'
               it_behaves_like 'a trace with AppSec tags'
               it_behaves_like 'a trace with AppSec events', { blocking: true }
+
+              context 'with schema extraction' do
+                let(:api_security_enabled) { true }
+                let(:api_security_sample) { 1 }
+
+                it { is_expected.to be_forbidden }
+
+                it_behaves_like 'normal with tracing disable'
+                it_behaves_like 'a POST 403 span'
+                it_behaves_like 'a trace with AppSec tags'
+                it_behaves_like 'a trace with AppSec events', { blocking: true }
+                it_behaves_like 'a trace with AppSec api security tags'
+              end
             end
           end
         end
@@ -436,6 +583,19 @@ RSpec.describe 'Rack integration tests' do
           it_behaves_like 'a trace with AppSec tags'
           it_behaves_like 'a trace with AppSec events'
 
+          context 'with schema extraction' do
+            let(:api_security_enabled) { true }
+            let(:api_security_sample) { 1 }
+
+            it { is_expected.to be_ok }
+
+            it_behaves_like 'normal with tracing disable'
+            it_behaves_like 'a POST 200 span'
+            it_behaves_like 'a trace with AppSec tags'
+            it_behaves_like 'a trace with AppSec events'
+            it_behaves_like 'a trace with AppSec api security tags'
+          end
+
           context 'and a blocking rule' do
             let(:appsec_ruleset) { crs_942_100 }
 
@@ -445,6 +605,19 @@ RSpec.describe 'Rack integration tests' do
             it_behaves_like 'a POST 403 span'
             it_behaves_like 'a trace with AppSec tags'
             it_behaves_like 'a trace with AppSec events', { blocking: true }
+
+            context 'with schema extraction' do
+              let(:api_security_enabled) { true }
+              let(:api_security_sample) { 1 }
+
+              it { is_expected.to be_forbidden }
+
+              it_behaves_like 'normal with tracing disable'
+              it_behaves_like 'a POST 403 span'
+              it_behaves_like 'a trace with AppSec tags'
+              it_behaves_like 'a trace with AppSec events', { blocking: true }
+              it_behaves_like 'a trace with AppSec api security tags'
+            end
           end
         end
       end

--- a/spec/datadog/appsec/contrib/rack/integration_test_spec.rb
+++ b/spec/datadog/appsec/contrib/rack/integration_test_spec.rb
@@ -235,19 +235,7 @@ RSpec.describe 'Rack integration tests' do
           it_behaves_like 'a GET 200 span'
           it_behaves_like 'a trace with AppSec tags'
           it_behaves_like 'a trace without AppSec events'
-
-          context 'with schema extraction' do
-            let(:api_security_enabled) { true }
-            let(:api_security_sample) { 1 }
-
-            it { is_expected.to be_ok }
-
-            it_behaves_like 'normal with tracing disable'
-            it_behaves_like 'a GET 200 span'
-            it_behaves_like 'a trace with AppSec tags'
-            it_behaves_like 'a trace without AppSec events'
-            it_behaves_like 'a trace with AppSec api security tags'
-          end
+          it_behaves_like 'a trace with AppSec api security tags'
         end
 
         context 'with an event-triggering request in headers' do
@@ -260,20 +248,7 @@ RSpec.describe 'Rack integration tests' do
           it_behaves_like 'a GET 200 span'
           it_behaves_like 'a trace with AppSec tags'
           it_behaves_like 'a trace with AppSec events'
-
-          context 'with schema extraction' do
-            let(:api_security_enabled) { true }
-            let(:api_security_sample) { 1 }
-
-            it { is_expected.to be_ok }
-            it { expect(triggers).to be_a Array }
-
-            it_behaves_like 'normal with tracing disable'
-            it_behaves_like 'a GET 200 span'
-            it_behaves_like 'a trace with AppSec tags'
-            it_behaves_like 'a trace with AppSec events'
-            it_behaves_like 'a trace with AppSec api security tags'
-          end
+          it_behaves_like 'a trace with AppSec api security tags'
         end
 
         context 'with an event-triggering request in query string' do
@@ -295,19 +270,7 @@ RSpec.describe 'Rack integration tests' do
             it_behaves_like 'a GET 403 span'
             it_behaves_like 'a trace with AppSec tags'
             it_behaves_like 'a trace with AppSec events', { blocking: true }
-
-            context 'with schema extraction' do
-              let(:api_security_enabled) { true }
-              let(:api_security_sample) { 1 }
-
-              it { is_expected.to be_forbidden }
-
-              it_behaves_like 'normal with tracing disable'
-              it_behaves_like 'a GET 403 span'
-              it_behaves_like 'a trace with AppSec api security tags'
-              it_behaves_like 'a trace with AppSec tags'
-              it_behaves_like 'a trace with AppSec events', { blocking: true }
-            end
+            it_behaves_like 'a trace with AppSec api security tags'
           end
         end
 
@@ -322,19 +285,7 @@ RSpec.describe 'Rack integration tests' do
           it_behaves_like 'a GET 403 span'
           it_behaves_like 'a trace with AppSec tags'
           it_behaves_like 'a trace with AppSec events'
-
-          context 'with schema extraction' do
-            let(:api_security_enabled) { true }
-            let(:api_security_sample) { 1 }
-
-            it { is_expected.to be_forbidden }
-
-            it_behaves_like 'normal with tracing disable'
-            it_behaves_like 'a GET 403 span'
-            it_behaves_like 'a trace with AppSec tags'
-            it_behaves_like 'a trace with AppSec events'
-            it_behaves_like 'a trace with AppSec api security tags'
-          end
+          it_behaves_like 'a trace with AppSec api security tags'
         end
 
         context 'with an event-triggering response' do
@@ -359,19 +310,7 @@ RSpec.describe 'Rack integration tests' do
             it_behaves_like 'a GET 403 span'
             it_behaves_like 'a trace with AppSec tags'
             it_behaves_like 'a trace with AppSec events', { blocking: true }
-
-            context 'with schema extraction' do
-              let(:api_security_enabled) { true }
-              let(:api_security_sample) { 1 }
-
-              it { is_expected.to be_forbidden }
-
-              it_behaves_like 'normal with tracing disable'
-              it_behaves_like 'a GET 403 span'
-              it_behaves_like 'a trace with AppSec tags'
-              it_behaves_like 'a trace with AppSec events', { blocking: true }
-              it_behaves_like 'a trace with AppSec api security tags'
-            end
+            it_behaves_like 'a trace with AppSec api security tags'
           end
         end
 
@@ -394,19 +333,7 @@ RSpec.describe 'Rack integration tests' do
             it_behaves_like 'a GET 403 span'
             it_behaves_like 'a trace with AppSec tags'
             it_behaves_like 'a trace with AppSec events', { blocking: true }
-
-            context 'with schema extraction' do
-              let(:api_security_enabled) { true }
-              let(:api_security_sample) { 1 }
-
-              it { is_expected.to be_forbidden }
-
-              it_behaves_like 'normal with tracing disable'
-              it_behaves_like 'a GET 403 span'
-              it_behaves_like 'a trace with AppSec tags'
-              it_behaves_like 'a trace with AppSec events', { blocking: true }
-              it_behaves_like 'a trace with AppSec api security tags'
-            end
+            it_behaves_like 'a trace with AppSec api security tags'
           end
         end
       end
@@ -426,19 +353,7 @@ RSpec.describe 'Rack integration tests' do
           it_behaves_like 'a POST 200 span'
           it_behaves_like 'a trace with AppSec tags'
           it_behaves_like 'a trace without AppSec events'
-
-          context 'with schema extraction' do
-            let(:api_security_enabled) { true }
-            let(:api_security_sample) { 1 }
-
-            it { is_expected.to be_ok }
-
-            it_behaves_like 'normal with tracing disable'
-            it_behaves_like 'a POST 200 span'
-            it_behaves_like 'a trace with AppSec tags'
-            it_behaves_like 'a trace without AppSec events'
-            it_behaves_like 'a trace with AppSec api security tags'
-          end
+          it_behaves_like 'a trace with AppSec api security tags'
         end
 
         context 'with an event-triggering request in application/x-www-form-url-encoded body' do
@@ -457,18 +372,7 @@ RSpec.describe 'Rack integration tests' do
           it_behaves_like 'a POST 200 span'
           it_behaves_like 'a trace with AppSec tags'
           it_behaves_like 'a trace with AppSec events'
-
-          context 'with schema extraction' do
-            let(:api_security_enabled) { true }
-            let(:api_security_sample) { 1 }
-
-            it { is_expected.to be_ok }
-
-            it_behaves_like 'a POST 200 span'
-            it_behaves_like 'a trace with AppSec tags'
-            it_behaves_like 'a trace with AppSec events'
-            it_behaves_like 'a trace with AppSec api security tags'
-          end
+          it_behaves_like 'a trace with AppSec api security tags'
 
           context 'and a blocking rule' do
             let(:appsec_ruleset) { crs_942_100 }
@@ -479,19 +383,7 @@ RSpec.describe 'Rack integration tests' do
             it_behaves_like 'a POST 403 span'
             it_behaves_like 'a trace with AppSec tags'
             it_behaves_like 'a trace with AppSec events', { blocking: true }
-
-            context 'with schema extraction' do
-              let(:api_security_enabled) { true }
-              let(:api_security_sample) { 1 }
-
-              it { is_expected.to be_forbidden }
-
-              it_behaves_like 'normal with tracing disable'
-              it_behaves_like 'a POST 403 span'
-              it_behaves_like 'a trace with AppSec tags'
-              it_behaves_like 'a trace with AppSec events', { blocking: true }
-              it_behaves_like 'a trace with AppSec api security tags'
-            end
+            it_behaves_like 'a trace with AppSec api security tags'
           end
         end
 
@@ -514,19 +406,7 @@ RSpec.describe 'Rack integration tests' do
             it_behaves_like 'a POST 200 span'
             it_behaves_like 'a trace with AppSec tags'
             it_behaves_like 'a trace with AppSec events'
-
-            context 'with schema extraction' do
-              let(:api_security_enabled) { true }
-              let(:api_security_sample) { 1 }
-
-              it { is_expected.to be_ok }
-
-              it_behaves_like 'normal with tracing disable'
-              it_behaves_like 'a POST 200 span'
-              it_behaves_like 'a trace with AppSec tags'
-              it_behaves_like 'a trace with AppSec events'
-              it_behaves_like 'a trace with AppSec api security tags'
-            end
+            it_behaves_like 'a trace with AppSec api security tags'
 
             context 'and a blocking rule' do
               let(:appsec_ruleset) { crs_942_100 }
@@ -537,19 +417,7 @@ RSpec.describe 'Rack integration tests' do
               it_behaves_like 'a POST 403 span'
               it_behaves_like 'a trace with AppSec tags'
               it_behaves_like 'a trace with AppSec events', { blocking: true }
-
-              context 'with schema extraction' do
-                let(:api_security_enabled) { true }
-                let(:api_security_sample) { 1 }
-
-                it { is_expected.to be_forbidden }
-
-                it_behaves_like 'normal with tracing disable'
-                it_behaves_like 'a POST 403 span'
-                it_behaves_like 'a trace with AppSec tags'
-                it_behaves_like 'a trace with AppSec events', { blocking: true }
-                it_behaves_like 'a trace with AppSec api security tags'
-              end
+              it_behaves_like 'a trace with AppSec api security tags'
             end
           end
         end
@@ -582,19 +450,7 @@ RSpec.describe 'Rack integration tests' do
           it_behaves_like 'a POST 200 span'
           it_behaves_like 'a trace with AppSec tags'
           it_behaves_like 'a trace with AppSec events'
-
-          context 'with schema extraction' do
-            let(:api_security_enabled) { true }
-            let(:api_security_sample) { 1 }
-
-            it { is_expected.to be_ok }
-
-            it_behaves_like 'normal with tracing disable'
-            it_behaves_like 'a POST 200 span'
-            it_behaves_like 'a trace with AppSec tags'
-            it_behaves_like 'a trace with AppSec events'
-            it_behaves_like 'a trace with AppSec api security tags'
-          end
+          it_behaves_like 'a trace with AppSec api security tags'
 
           context 'and a blocking rule' do
             let(:appsec_ruleset) { crs_942_100 }
@@ -605,19 +461,7 @@ RSpec.describe 'Rack integration tests' do
             it_behaves_like 'a POST 403 span'
             it_behaves_like 'a trace with AppSec tags'
             it_behaves_like 'a trace with AppSec events', { blocking: true }
-
-            context 'with schema extraction' do
-              let(:api_security_enabled) { true }
-              let(:api_security_sample) { 1 }
-
-              it { is_expected.to be_forbidden }
-
-              it_behaves_like 'normal with tracing disable'
-              it_behaves_like 'a POST 403 span'
-              it_behaves_like 'a trace with AppSec tags'
-              it_behaves_like 'a trace with AppSec events', { blocking: true }
-              it_behaves_like 'a trace with AppSec api security tags'
-            end
+            it_behaves_like 'a trace with AppSec api security tags'
           end
         end
       end

--- a/spec/datadog/appsec/contrib/rails/integration_test_spec.rb
+++ b/spec/datadog/appsec/contrib/rails/integration_test_spec.rb
@@ -186,19 +186,7 @@ RSpec.describe 'Rails integration tests' do
           it_behaves_like 'a GET 200 span'
           it_behaves_like 'a trace with AppSec tags'
           it_behaves_like 'a trace without AppSec events'
-
-          context 'with schema extraction' do
-            let(:api_security_enabled) { true }
-            let(:api_security_sample) { 1 }
-
-            it { is_expected.to be_ok }
-
-            it_behaves_like 'normal with tracing disable'
-            it_behaves_like 'a GET 200 span'
-            it_behaves_like 'a trace with AppSec tags'
-            it_behaves_like 'a trace without AppSec events'
-            it_behaves_like 'a trace with AppSec api security tags'
-          end
+          it_behaves_like 'a trace with AppSec api security tags'
         end
 
         context 'with an event-triggering request in headers' do
@@ -211,20 +199,7 @@ RSpec.describe 'Rails integration tests' do
           it_behaves_like 'a GET 200 span'
           it_behaves_like 'a trace with AppSec tags'
           it_behaves_like 'a trace with AppSec events'
-
-          context 'with schema extraction' do
-            let(:api_security_enabled) { true }
-            let(:api_security_sample) { 1 }
-
-            it { is_expected.to be_ok }
-            it { expect(triggers).to be_a Array }
-
-            it_behaves_like 'normal with tracing disable'
-            it_behaves_like 'a GET 200 span'
-            it_behaves_like 'a trace with AppSec tags'
-            it_behaves_like 'a trace with AppSec events'
-            it_behaves_like 'a trace with AppSec api security tags'
-          end
+          it_behaves_like 'a trace with AppSec api security tags'
         end
 
         context 'with an event-triggering request in query string' do
@@ -236,19 +211,7 @@ RSpec.describe 'Rails integration tests' do
           it_behaves_like 'a GET 200 span'
           it_behaves_like 'a trace with AppSec tags'
           it_behaves_like 'a trace with AppSec events'
-
-          context 'with schema extraction' do
-            let(:api_security_enabled) { true }
-            let(:api_security_sample) { 1 }
-
-            it { is_expected.to be_ok }
-
-            it_behaves_like 'normal with tracing disable'
-            it_behaves_like 'a GET 200 span'
-            it_behaves_like 'a trace with AppSec tags'
-            it_behaves_like 'a trace with AppSec events'
-            it_behaves_like 'a trace with AppSec api security tags'
-          end
+          it_behaves_like 'a trace with AppSec api security tags'
 
           context 'and a blocking rule' do
             let(:appsec_ruleset) { crs_942_100 }
@@ -259,19 +222,7 @@ RSpec.describe 'Rails integration tests' do
             it_behaves_like 'a GET 403 span'
             it_behaves_like 'a trace with AppSec tags'
             it_behaves_like 'a trace with AppSec events', { blocking: true }
-
-            context 'with schema extraction' do
-              let(:api_security_enabled) { true }
-              let(:api_security_sample) { 1 }
-
-              it { is_expected.to be_forbidden }
-
-              it_behaves_like 'normal with tracing disable'
-              it_behaves_like 'a GET 403 span'
-              it_behaves_like 'a trace with AppSec tags'
-              it_behaves_like 'a trace with AppSec events', { blocking: true }
-              it_behaves_like 'a trace with AppSec api security tags'
-            end
+            it_behaves_like 'a trace with AppSec api security tags'
           end
         end
 
@@ -290,19 +241,7 @@ RSpec.describe 'Rails integration tests' do
           it_behaves_like 'a GET 200 span'
           it_behaves_like 'a trace with AppSec tags'
           it_behaves_like 'a trace with AppSec events'
-
-          context 'with schema extraction' do
-            let(:api_security_enabled) { true }
-            let(:api_security_sample) { 1 }
-
-            it { is_expected.to be_ok }
-
-            it_behaves_like 'normal with tracing disable'
-            it_behaves_like 'a GET 200 span'
-            it_behaves_like 'a trace with AppSec tags'
-            it_behaves_like 'a trace with AppSec events'
-            it_behaves_like 'a trace with AppSec api security tags'
-          end
+          it_behaves_like 'a trace with AppSec api security tags'
 
           context 'and a blocking rule' do
             let(:appsec_ruleset) { crs_942_100 }
@@ -313,19 +252,7 @@ RSpec.describe 'Rails integration tests' do
             it_behaves_like 'a GET 403 span'
             it_behaves_like 'a trace with AppSec tags'
             it_behaves_like 'a trace with AppSec events', { blocking: true }
-
-            context 'with schema extraction' do
-              let(:api_security_enabled) { true }
-              let(:api_security_sample) { 1 }
-
-              it { is_expected.to be_forbidden }
-
-              it_behaves_like 'normal with tracing disable'
-              it_behaves_like 'a GET 403 span'
-              it_behaves_like 'a trace with AppSec tags'
-              it_behaves_like 'a trace with AppSec events', { blocking: true }
-              it_behaves_like 'a trace with AppSec api security tags'
-            end
+            it_behaves_like 'a trace with AppSec api security tags'
           end
         end
 
@@ -340,19 +267,7 @@ RSpec.describe 'Rails integration tests' do
           it_behaves_like 'a GET 403 span'
           it_behaves_like 'a trace with AppSec tags'
           it_behaves_like 'a trace with AppSec events', { blocking: true }
-
-          context 'with schema extraction' do
-            let(:api_security_enabled) { true }
-            let(:api_security_sample) { 1 }
-
-            it { is_expected.to be_forbidden }
-
-            it_behaves_like 'normal with tracing disable'
-            it_behaves_like 'a GET 403 span'
-            it_behaves_like 'a trace with AppSec tags'
-            it_behaves_like 'a trace with AppSec events', { blocking: true }
-            it_behaves_like 'a trace with AppSec api security tags'
-          end
+          it_behaves_like 'a trace with AppSec api security tags'
         end
 
         context 'with an event-triggering response' do
@@ -365,20 +280,7 @@ RSpec.describe 'Rails integration tests' do
           it_behaves_like 'a GET 404 span'
           it_behaves_like 'a trace with AppSec tags'
           it_behaves_like 'a trace with AppSec events'
-
-          context 'with schema extraction' do
-            let(:api_security_enabled) { true }
-            let(:api_security_sample) { 1 }
-
-            it { is_expected.to be_not_found }
-            it { expect(triggers).to be_a Array }
-
-            it_behaves_like 'normal with tracing disable'
-            it_behaves_like 'a GET 404 span'
-            it_behaves_like 'a trace with AppSec tags'
-            it_behaves_like 'a trace with AppSec events'
-            it_behaves_like 'a trace with AppSec api security tags'
-          end
+          it_behaves_like 'a trace with AppSec api security tags'
         end
 
         context 'with user blocking ID' do
@@ -390,19 +292,7 @@ RSpec.describe 'Rails integration tests' do
           it_behaves_like 'a GET 200 span'
           it_behaves_like 'a trace with AppSec tags'
           it_behaves_like 'a trace without AppSec events'
-
-          context 'with schema extraction' do
-            let(:api_security_enabled) { true }
-            let(:api_security_sample) { 1 }
-
-            it { is_expected.to be_ok }
-
-            it_behaves_like 'normal with tracing disable'
-            it_behaves_like 'a GET 200 span'
-            it_behaves_like 'a trace with AppSec tags'
-            it_behaves_like 'a trace without AppSec events'
-            it_behaves_like 'a trace with AppSec api security tags'
-          end
+          it_behaves_like 'a trace with AppSec api security tags'
 
           context 'with an event-triggering user ID' do
             let(:appsec_user_id_denylist) { ['blocked-user-id'] }
@@ -413,19 +303,7 @@ RSpec.describe 'Rails integration tests' do
             it_behaves_like 'a GET 403 span'
             it_behaves_like 'a trace with AppSec tags'
             it_behaves_like 'a trace with AppSec events'
-
-            context 'with schema extraction' do
-              let(:api_security_enabled) { true }
-              let(:api_security_sample) { 1 }
-
-              it { is_expected.to be_forbidden }
-
-              it_behaves_like 'normal with tracing disable'
-              it_behaves_like 'a GET 403 span'
-              it_behaves_like 'a trace with AppSec tags'
-              it_behaves_like 'a trace with AppSec events'
-              it_behaves_like 'a trace with AppSec api security tags'
-            end
+            it_behaves_like 'a trace with AppSec api security tags'
           end
         end
       end
@@ -445,19 +323,7 @@ RSpec.describe 'Rails integration tests' do
           it_behaves_like 'a POST 200 span'
           it_behaves_like 'a trace with AppSec tags'
           it_behaves_like 'a trace without AppSec events'
-
-          context 'with schema extraction' do
-            let(:api_security_enabled) { true }
-            let(:api_security_sample) { 1 }
-
-            it { is_expected.to be_ok }
-
-            it_behaves_like 'normal with tracing disable'
-            it_behaves_like 'a POST 200 span'
-            it_behaves_like 'a trace with AppSec tags'
-            it_behaves_like 'a trace without AppSec events'
-            it_behaves_like 'a trace with AppSec api security tags'
-          end
+          it_behaves_like 'a trace with AppSec api security tags'
         end
 
         context 'with an event-triggering request in application/x-www-form-url-encoded body' do
@@ -469,19 +335,7 @@ RSpec.describe 'Rails integration tests' do
           it_behaves_like 'a POST 200 span'
           it_behaves_like 'a trace with AppSec tags'
           it_behaves_like 'a trace with AppSec events'
-
-          context 'with schema extraction' do
-            let(:api_security_enabled) { true }
-            let(:api_security_sample) { 1 }
-
-            it { is_expected.to be_ok }
-
-            it_behaves_like 'normal with tracing disable'
-            it_behaves_like 'a POST 200 span'
-            it_behaves_like 'a trace with AppSec tags'
-            it_behaves_like 'a trace with AppSec events'
-            it_behaves_like 'a trace with AppSec api security tags'
-          end
+          it_behaves_like 'a trace with AppSec api security tags'
 
           context 'and a blocking rule' do
             let(:appsec_ruleset) { crs_942_100 }
@@ -492,19 +346,7 @@ RSpec.describe 'Rails integration tests' do
             it_behaves_like 'a POST 403 span'
             it_behaves_like 'a trace with AppSec tags'
             it_behaves_like 'a trace with AppSec events', { blocking: true }
-
-            context 'with schema extraction' do
-              let(:api_security_enabled) { true }
-              let(:api_security_sample) { 1 }
-
-              it { is_expected.to be_forbidden }
-
-              it_behaves_like 'normal with tracing disable'
-              it_behaves_like 'a POST 403 span'
-              it_behaves_like 'a trace with AppSec tags'
-              it_behaves_like 'a trace with AppSec events', { blocking: true }
-              it_behaves_like 'a trace with AppSec api security tags'
-            end
+            it_behaves_like 'a trace with AppSec api security tags'
           end
         end
 
@@ -519,19 +361,7 @@ RSpec.describe 'Rails integration tests' do
             it_behaves_like 'a POST 200 span'
             it_behaves_like 'a trace with AppSec tags'
             it_behaves_like 'a trace with AppSec events'
-
-            context 'with schema extraction' do
-              let(:api_security_enabled) { true }
-              let(:api_security_sample) { 1 }
-
-              it { is_expected.to be_ok }
-
-              it_behaves_like 'normal with tracing disable'
-              it_behaves_like 'a POST 200 span'
-              it_behaves_like 'a trace with AppSec tags'
-              it_behaves_like 'a trace with AppSec events'
-              it_behaves_like 'a trace with AppSec api security tags'
-            end
+            it_behaves_like 'a trace with AppSec api security tags'
 
             context 'and a blocking rule' do
               let(:appsec_ruleset) { crs_942_100 }
@@ -542,19 +372,7 @@ RSpec.describe 'Rails integration tests' do
               it_behaves_like 'a POST 403 span'
               it_behaves_like 'a trace with AppSec tags'
               it_behaves_like 'a trace with AppSec events', { blocking: true }
-
-              context 'with schema extraction' do
-                let(:api_security_enabled) { true }
-                let(:api_security_sample) { 1 }
-
-                it { is_expected.to be_forbidden }
-
-                it_behaves_like 'normal with tracing disable'
-                it_behaves_like 'a POST 403 span'
-                it_behaves_like 'a trace with AppSec tags'
-                it_behaves_like 'a trace with AppSec events', { blocking: true }
-                it_behaves_like 'a trace with AppSec api security tags'
-              end
+              it_behaves_like 'a trace with AppSec api security tags'
             end
           end
         end
@@ -569,19 +387,7 @@ RSpec.describe 'Rails integration tests' do
           it_behaves_like 'a POST 200 span'
           it_behaves_like 'a trace with AppSec tags'
           it_behaves_like 'a trace with AppSec events'
-
-          context 'with schema extraction' do
-            let(:api_security_enabled) { true }
-            let(:api_security_sample) { 1 }
-
-            it { is_expected.to be_ok }
-
-            it_behaves_like 'normal with tracing disable'
-            it_behaves_like 'a POST 200 span'
-            it_behaves_like 'a trace with AppSec tags'
-            it_behaves_like 'a trace with AppSec events'
-            it_behaves_like 'a trace with AppSec api security tags'
-          end
+          it_behaves_like 'a trace with AppSec api security tags'
 
           context 'and a blocking rule' do
             let(:appsec_ruleset) { crs_942_100 }
@@ -592,19 +398,7 @@ RSpec.describe 'Rails integration tests' do
             it_behaves_like 'a POST 403 span'
             it_behaves_like 'a trace with AppSec tags'
             it_behaves_like 'a trace with AppSec events', { blocking: true }
-
-            context 'with schema extraction' do
-              let(:api_security_enabled) { true }
-              let(:api_security_sample) { 1 }
-
-              it { is_expected.to be_forbidden }
-
-              it_behaves_like 'normal with tracing disable'
-              it_behaves_like 'a POST 403 span'
-              it_behaves_like 'a trace with AppSec tags'
-              it_behaves_like 'a trace with AppSec events', { blocking: true }
-              it_behaves_like 'a trace with AppSec api security tags'
-            end
+            it_behaves_like 'a trace with AppSec api security tags'
           end
         end
       end

--- a/spec/datadog/appsec/contrib/rails/integration_test_spec.rb
+++ b/spec/datadog/appsec/contrib/rails/integration_test_spec.rb
@@ -34,6 +34,8 @@ RSpec.describe 'Rails integration tests' do
   let(:appsec_user_id_denylist) { [] }
   let(:appsec_ruleset) { :recommended }
   let(:nested_app) { false }
+  let(:api_security_enabled) { false }
+  let(:api_security_sample) { 0.0 }
 
   let(:crs_942_100) do
     {
@@ -93,6 +95,8 @@ RSpec.describe 'Rails integration tests' do
       c.appsec.ip_denylist = appsec_ip_denylist
       c.appsec.user_id_denylist = appsec_user_id_denylist
       c.appsec.ruleset = appsec_ruleset
+      c.appsec.api_security.enabled = api_security_enabled
+      c.appsec.api_security.sample_rate = api_security_sample
 
       c.appsec.instrument :rack if nested_app
     end
@@ -182,6 +186,19 @@ RSpec.describe 'Rails integration tests' do
           it_behaves_like 'a GET 200 span'
           it_behaves_like 'a trace with AppSec tags'
           it_behaves_like 'a trace without AppSec events'
+
+          context 'with schema extraction' do
+            let(:api_security_enabled) { true }
+            let(:api_security_sample) { 1 }
+
+            it { is_expected.to be_ok }
+
+            it_behaves_like 'normal with tracing disable'
+            it_behaves_like 'a GET 200 span'
+            it_behaves_like 'a trace with AppSec tags'
+            it_behaves_like 'a trace without AppSec events'
+            it_behaves_like 'a trace with AppSec api security tags'
+          end
         end
 
         context 'with an event-triggering request in headers' do
@@ -194,6 +211,20 @@ RSpec.describe 'Rails integration tests' do
           it_behaves_like 'a GET 200 span'
           it_behaves_like 'a trace with AppSec tags'
           it_behaves_like 'a trace with AppSec events'
+
+          context 'with schema extraction' do
+            let(:api_security_enabled) { true }
+            let(:api_security_sample) { 1 }
+
+            it { is_expected.to be_ok }
+            it { expect(triggers).to be_a Array }
+
+            it_behaves_like 'normal with tracing disable'
+            it_behaves_like 'a GET 200 span'
+            it_behaves_like 'a trace with AppSec tags'
+            it_behaves_like 'a trace with AppSec events'
+            it_behaves_like 'a trace with AppSec api security tags'
+          end
         end
 
         context 'with an event-triggering request in query string' do
@@ -206,6 +237,19 @@ RSpec.describe 'Rails integration tests' do
           it_behaves_like 'a trace with AppSec tags'
           it_behaves_like 'a trace with AppSec events'
 
+          context 'with schema extraction' do
+            let(:api_security_enabled) { true }
+            let(:api_security_sample) { 1 }
+
+            it { is_expected.to be_ok }
+
+            it_behaves_like 'normal with tracing disable'
+            it_behaves_like 'a GET 200 span'
+            it_behaves_like 'a trace with AppSec tags'
+            it_behaves_like 'a trace with AppSec events'
+            it_behaves_like 'a trace with AppSec api security tags'
+          end
+
           context 'and a blocking rule' do
             let(:appsec_ruleset) { crs_942_100 }
 
@@ -215,6 +259,19 @@ RSpec.describe 'Rails integration tests' do
             it_behaves_like 'a GET 403 span'
             it_behaves_like 'a trace with AppSec tags'
             it_behaves_like 'a trace with AppSec events', { blocking: true }
+
+            context 'with schema extraction' do
+              let(:api_security_enabled) { true }
+              let(:api_security_sample) { 1 }
+
+              it { is_expected.to be_forbidden }
+
+              it_behaves_like 'normal with tracing disable'
+              it_behaves_like 'a GET 403 span'
+              it_behaves_like 'a trace with AppSec tags'
+              it_behaves_like 'a trace with AppSec events', { blocking: true }
+              it_behaves_like 'a trace with AppSec api security tags'
+            end
           end
         end
 
@@ -234,6 +291,19 @@ RSpec.describe 'Rails integration tests' do
           it_behaves_like 'a trace with AppSec tags'
           it_behaves_like 'a trace with AppSec events'
 
+          context 'with schema extraction' do
+            let(:api_security_enabled) { true }
+            let(:api_security_sample) { 1 }
+
+            it { is_expected.to be_ok }
+
+            it_behaves_like 'normal with tracing disable'
+            it_behaves_like 'a GET 200 span'
+            it_behaves_like 'a trace with AppSec tags'
+            it_behaves_like 'a trace with AppSec events'
+            it_behaves_like 'a trace with AppSec api security tags'
+          end
+
           context 'and a blocking rule' do
             let(:appsec_ruleset) { crs_942_100 }
 
@@ -243,6 +313,19 @@ RSpec.describe 'Rails integration tests' do
             it_behaves_like 'a GET 403 span'
             it_behaves_like 'a trace with AppSec tags'
             it_behaves_like 'a trace with AppSec events', { blocking: true }
+
+            context 'with schema extraction' do
+              let(:api_security_enabled) { true }
+              let(:api_security_sample) { 1 }
+
+              it { is_expected.to be_forbidden }
+
+              it_behaves_like 'normal with tracing disable'
+              it_behaves_like 'a GET 403 span'
+              it_behaves_like 'a trace with AppSec tags'
+              it_behaves_like 'a trace with AppSec events', { blocking: true }
+              it_behaves_like 'a trace with AppSec api security tags'
+            end
           end
         end
 
@@ -257,6 +340,19 @@ RSpec.describe 'Rails integration tests' do
           it_behaves_like 'a GET 403 span'
           it_behaves_like 'a trace with AppSec tags'
           it_behaves_like 'a trace with AppSec events', { blocking: true }
+
+          context 'with schema extraction' do
+            let(:api_security_enabled) { true }
+            let(:api_security_sample) { 1 }
+
+            it { is_expected.to be_forbidden }
+
+            it_behaves_like 'normal with tracing disable'
+            it_behaves_like 'a GET 403 span'
+            it_behaves_like 'a trace with AppSec tags'
+            it_behaves_like 'a trace with AppSec events', { blocking: true }
+            it_behaves_like 'a trace with AppSec api security tags'
+          end
         end
 
         context 'with an event-triggering response' do
@@ -269,6 +365,20 @@ RSpec.describe 'Rails integration tests' do
           it_behaves_like 'a GET 404 span'
           it_behaves_like 'a trace with AppSec tags'
           it_behaves_like 'a trace with AppSec events'
+
+          context 'with schema extraction' do
+            let(:api_security_enabled) { true }
+            let(:api_security_sample) { 1 }
+
+            it { is_expected.to be_not_found }
+            it { expect(triggers).to be_a Array }
+
+            it_behaves_like 'normal with tracing disable'
+            it_behaves_like 'a GET 404 span'
+            it_behaves_like 'a trace with AppSec tags'
+            it_behaves_like 'a trace with AppSec events'
+            it_behaves_like 'a trace with AppSec api security tags'
+          end
         end
 
         context 'with user blocking ID' do
@@ -281,6 +391,19 @@ RSpec.describe 'Rails integration tests' do
           it_behaves_like 'a trace with AppSec tags'
           it_behaves_like 'a trace without AppSec events'
 
+          context 'with schema extraction' do
+            let(:api_security_enabled) { true }
+            let(:api_security_sample) { 1 }
+
+            it { is_expected.to be_ok }
+
+            it_behaves_like 'normal with tracing disable'
+            it_behaves_like 'a GET 200 span'
+            it_behaves_like 'a trace with AppSec tags'
+            it_behaves_like 'a trace without AppSec events'
+            it_behaves_like 'a trace with AppSec api security tags'
+          end
+
           context 'with an event-triggering user ID' do
             let(:appsec_user_id_denylist) { ['blocked-user-id'] }
 
@@ -290,6 +413,19 @@ RSpec.describe 'Rails integration tests' do
             it_behaves_like 'a GET 403 span'
             it_behaves_like 'a trace with AppSec tags'
             it_behaves_like 'a trace with AppSec events'
+
+            context 'with schema extraction' do
+              let(:api_security_enabled) { true }
+              let(:api_security_sample) { 1 }
+
+              it { is_expected.to be_forbidden }
+
+              it_behaves_like 'normal with tracing disable'
+              it_behaves_like 'a GET 403 span'
+              it_behaves_like 'a trace with AppSec tags'
+              it_behaves_like 'a trace with AppSec events'
+              it_behaves_like 'a trace with AppSec api security tags'
+            end
           end
         end
       end
@@ -309,6 +445,19 @@ RSpec.describe 'Rails integration tests' do
           it_behaves_like 'a POST 200 span'
           it_behaves_like 'a trace with AppSec tags'
           it_behaves_like 'a trace without AppSec events'
+
+          context 'with schema extraction' do
+            let(:api_security_enabled) { true }
+            let(:api_security_sample) { 1 }
+
+            it { is_expected.to be_ok }
+
+            it_behaves_like 'normal with tracing disable'
+            it_behaves_like 'a POST 200 span'
+            it_behaves_like 'a trace with AppSec tags'
+            it_behaves_like 'a trace without AppSec events'
+            it_behaves_like 'a trace with AppSec api security tags'
+          end
         end
 
         context 'with an event-triggering request in application/x-www-form-url-encoded body' do
@@ -321,6 +470,19 @@ RSpec.describe 'Rails integration tests' do
           it_behaves_like 'a trace with AppSec tags'
           it_behaves_like 'a trace with AppSec events'
 
+          context 'with schema extraction' do
+            let(:api_security_enabled) { true }
+            let(:api_security_sample) { 1 }
+
+            it { is_expected.to be_ok }
+
+            it_behaves_like 'normal with tracing disable'
+            it_behaves_like 'a POST 200 span'
+            it_behaves_like 'a trace with AppSec tags'
+            it_behaves_like 'a trace with AppSec events'
+            it_behaves_like 'a trace with AppSec api security tags'
+          end
+
           context 'and a blocking rule' do
             let(:appsec_ruleset) { crs_942_100 }
 
@@ -330,6 +492,19 @@ RSpec.describe 'Rails integration tests' do
             it_behaves_like 'a POST 403 span'
             it_behaves_like 'a trace with AppSec tags'
             it_behaves_like 'a trace with AppSec events', { blocking: true }
+
+            context 'with schema extraction' do
+              let(:api_security_enabled) { true }
+              let(:api_security_sample) { 1 }
+
+              it { is_expected.to be_forbidden }
+
+              it_behaves_like 'normal with tracing disable'
+              it_behaves_like 'a POST 403 span'
+              it_behaves_like 'a trace with AppSec tags'
+              it_behaves_like 'a trace with AppSec events', { blocking: true }
+              it_behaves_like 'a trace with AppSec api security tags'
+            end
           end
         end
 
@@ -345,6 +520,19 @@ RSpec.describe 'Rails integration tests' do
             it_behaves_like 'a trace with AppSec tags'
             it_behaves_like 'a trace with AppSec events'
 
+            context 'with schema extraction' do
+              let(:api_security_enabled) { true }
+              let(:api_security_sample) { 1 }
+
+              it { is_expected.to be_ok }
+
+              it_behaves_like 'normal with tracing disable'
+              it_behaves_like 'a POST 200 span'
+              it_behaves_like 'a trace with AppSec tags'
+              it_behaves_like 'a trace with AppSec events'
+              it_behaves_like 'a trace with AppSec api security tags'
+            end
+
             context 'and a blocking rule' do
               let(:appsec_ruleset) { crs_942_100 }
 
@@ -354,6 +542,19 @@ RSpec.describe 'Rails integration tests' do
               it_behaves_like 'a POST 403 span'
               it_behaves_like 'a trace with AppSec tags'
               it_behaves_like 'a trace with AppSec events', { blocking: true }
+
+              context 'with schema extraction' do
+                let(:api_security_enabled) { true }
+                let(:api_security_sample) { 1 }
+
+                it { is_expected.to be_forbidden }
+
+                it_behaves_like 'normal with tracing disable'
+                it_behaves_like 'a POST 403 span'
+                it_behaves_like 'a trace with AppSec tags'
+                it_behaves_like 'a trace with AppSec events', { blocking: true }
+                it_behaves_like 'a trace with AppSec api security tags'
+              end
             end
           end
         end
@@ -369,6 +570,19 @@ RSpec.describe 'Rails integration tests' do
           it_behaves_like 'a trace with AppSec tags'
           it_behaves_like 'a trace with AppSec events'
 
+          context 'with schema extraction' do
+            let(:api_security_enabled) { true }
+            let(:api_security_sample) { 1 }
+
+            it { is_expected.to be_ok }
+
+            it_behaves_like 'normal with tracing disable'
+            it_behaves_like 'a POST 200 span'
+            it_behaves_like 'a trace with AppSec tags'
+            it_behaves_like 'a trace with AppSec events'
+            it_behaves_like 'a trace with AppSec api security tags'
+          end
+
           context 'and a blocking rule' do
             let(:appsec_ruleset) { crs_942_100 }
 
@@ -378,6 +592,19 @@ RSpec.describe 'Rails integration tests' do
             it_behaves_like 'a POST 403 span'
             it_behaves_like 'a trace with AppSec tags'
             it_behaves_like 'a trace with AppSec events', { blocking: true }
+
+            context 'with schema extraction' do
+              let(:api_security_enabled) { true }
+              let(:api_security_sample) { 1 }
+
+              it { is_expected.to be_forbidden }
+
+              it_behaves_like 'normal with tracing disable'
+              it_behaves_like 'a POST 403 span'
+              it_behaves_like 'a trace with AppSec tags'
+              it_behaves_like 'a trace with AppSec events', { blocking: true }
+              it_behaves_like 'a trace with AppSec api security tags'
+            end
           end
         end
       end

--- a/spec/datadog/appsec/contrib/sinatra/integration_test_spec.rb
+++ b/spec/datadog/appsec/contrib/sinatra/integration_test_spec.rb
@@ -190,19 +190,7 @@ RSpec.describe 'Sinatra integration tests' do
           it_behaves_like 'a GET 200 span'
           it_behaves_like 'a trace with AppSec tags'
           it_behaves_like 'a trace without AppSec events'
-
-          context 'with schema extraction' do
-            let(:api_security_enabled) { true }
-            let(:api_security_sample) { 1 }
-
-            it { is_expected.to be_ok }
-
-            it_behaves_like 'normal with tracing disable'
-            it_behaves_like 'a GET 200 span'
-            it_behaves_like 'a trace with AppSec tags'
-            it_behaves_like 'a trace without AppSec events'
-            it_behaves_like 'a trace with AppSec api security tags'
-          end
+          it_behaves_like 'a trace with AppSec api security tags'
         end
 
         context 'with an event-triggering request in headers' do
@@ -215,20 +203,7 @@ RSpec.describe 'Sinatra integration tests' do
           it_behaves_like 'a GET 200 span'
           it_behaves_like 'a trace with AppSec tags'
           it_behaves_like 'a trace with AppSec events'
-
-          context 'with schema extraction' do
-            let(:api_security_enabled) { true }
-            let(:api_security_sample) { 1 }
-
-            it { is_expected.to be_ok }
-            it { expect(triggers).to be_a Array }
-
-            it_behaves_like 'normal with tracing disable'
-            it_behaves_like 'a GET 200 span'
-            it_behaves_like 'a trace with AppSec tags'
-            it_behaves_like 'a trace with AppSec events'
-            it_behaves_like 'a trace with AppSec api security tags'
-          end
+          it_behaves_like 'a trace with AppSec api security tags'
         end
 
         context 'with an event-triggering request in query string' do
@@ -240,19 +215,7 @@ RSpec.describe 'Sinatra integration tests' do
           it_behaves_like 'a GET 200 span'
           it_behaves_like 'a trace with AppSec tags'
           it_behaves_like 'a trace with AppSec events'
-
-          context 'with schema extraction' do
-            let(:api_security_enabled) { true }
-            let(:api_security_sample) { 1 }
-
-            it { is_expected.to be_ok }
-
-            it_behaves_like 'normal with tracing disable'
-            it_behaves_like 'a GET 200 span'
-            it_behaves_like 'a trace with AppSec tags'
-            it_behaves_like 'a trace with AppSec events'
-            it_behaves_like 'a trace with AppSec api security tags'
-          end
+          it_behaves_like 'a trace with AppSec api security tags'
 
           context 'and a blocking rule' do
             let(:appsec_ruleset) { crs_942_100 }
@@ -263,19 +226,7 @@ RSpec.describe 'Sinatra integration tests' do
             it_behaves_like 'a GET 403 span'
             it_behaves_like 'a trace with AppSec tags'
             it_behaves_like 'a trace with AppSec events', { blocking: true }
-
-            context 'with schema extraction' do
-              let(:api_security_enabled) { true }
-              let(:api_security_sample) { 1 }
-
-              it { is_expected.to be_forbidden }
-
-              it_behaves_like 'normal with tracing disable'
-              it_behaves_like 'a GET 403 span'
-              it_behaves_like 'a trace with AppSec tags'
-              it_behaves_like 'a trace with AppSec events', { blocking: true }
-              it_behaves_like 'a trace with AppSec api security tags'
-            end
+            it_behaves_like 'a trace with AppSec api security tags'
           end
         end
 
@@ -296,19 +247,7 @@ RSpec.describe 'Sinatra integration tests' do
           it_behaves_like 'a GET 200 span'
           it_behaves_like 'a trace with AppSec tags'
           it_behaves_like 'a trace with AppSec events'
-
-          context 'with schema extraction' do
-            let(:api_security_enabled) { true }
-            let(:api_security_sample) { 1 }
-
-            it { is_expected.to be_ok }
-
-            it_behaves_like 'normal with tracing disable'
-            it_behaves_like 'a GET 200 span'
-            it_behaves_like 'a trace with AppSec tags'
-            it_behaves_like 'a trace with AppSec events'
-            it_behaves_like 'a trace with AppSec api security tags'
-          end
+          it_behaves_like 'a trace with AppSec api security tags'
 
           context 'and a blocking rule' do
             let(:appsec_ruleset) { crs_942_100 }
@@ -319,19 +258,7 @@ RSpec.describe 'Sinatra integration tests' do
             it_behaves_like 'a GET 403 span'
             it_behaves_like 'a trace with AppSec tags'
             it_behaves_like 'a trace with AppSec events', { blocking: true }
-
-            context 'with schema extraction' do
-              let(:api_security_enabled) { true }
-              let(:api_security_sample) { 1 }
-
-              it { is_expected.to be_forbidden }
-
-              it_behaves_like 'normal with tracing disable'
-              it_behaves_like 'a GET 403 span'
-              it_behaves_like 'a trace with AppSec tags'
-              it_behaves_like 'a trace with AppSec events', { blocking: true }
-              it_behaves_like 'a trace with AppSec api security tags'
-            end
+            it_behaves_like 'a trace with AppSec api security tags'
           end
         end
 
@@ -346,19 +273,7 @@ RSpec.describe 'Sinatra integration tests' do
           it_behaves_like 'a GET 403 span'
           it_behaves_like 'a trace with AppSec tags'
           it_behaves_like 'a trace with AppSec events', { blocking: true }
-
-          context 'with schema extraction' do
-            let(:api_security_enabled) { true }
-            let(:api_security_sample) { 1 }
-
-            it { is_expected.to be_forbidden }
-
-            it_behaves_like 'normal with tracing disable'
-            it_behaves_like 'a GET 403 span'
-            it_behaves_like 'a trace with AppSec tags'
-            it_behaves_like 'a trace with AppSec events', { blocking: true }
-            it_behaves_like 'a trace with AppSec api security tags'
-          end
+          it_behaves_like 'a trace with AppSec api security tags'
         end
 
         context 'with an event-triggering response' do
@@ -371,20 +286,7 @@ RSpec.describe 'Sinatra integration tests' do
           it_behaves_like 'a GET 404 span'
           it_behaves_like 'a trace with AppSec tags'
           it_behaves_like 'a trace with AppSec events'
-
-          context 'with schema extraction' do
-            let(:api_security_enabled) { true }
-            let(:api_security_sample) { 1 }
-
-            it { is_expected.to be_not_found }
-            it { expect(triggers).to be_a Array }
-
-            it_behaves_like 'normal with tracing disable'
-            it_behaves_like 'a GET 404 span'
-            it_behaves_like 'a trace with AppSec tags'
-            it_behaves_like 'a trace with AppSec events'
-            it_behaves_like 'a trace with AppSec api security tags'
-          end
+          it_behaves_like 'a trace with AppSec api security tags'
         end
 
         context 'with user blocking ID' do
@@ -396,19 +298,7 @@ RSpec.describe 'Sinatra integration tests' do
           it_behaves_like 'a GET 200 span'
           it_behaves_like 'a trace with AppSec tags'
           it_behaves_like 'a trace without AppSec events'
-
-          context 'with schema extraction' do
-            let(:api_security_enabled) { true }
-            let(:api_security_sample) { 1 }
-
-            it { is_expected.to be_ok }
-
-            it_behaves_like 'normal with tracing disable'
-            it_behaves_like 'a GET 200 span'
-            it_behaves_like 'a trace with AppSec tags'
-            it_behaves_like 'a trace without AppSec events'
-            it_behaves_like 'a trace with AppSec api security tags'
-          end
+          it_behaves_like 'a trace with AppSec api security tags'
 
           context 'with an event-triggering user ID' do
             let(:appsec_user_id_denylist) { ['blocked-user-id'] }
@@ -419,19 +309,7 @@ RSpec.describe 'Sinatra integration tests' do
             it_behaves_like 'a GET 403 span'
             it_behaves_like 'a trace with AppSec tags'
             it_behaves_like 'a trace with AppSec events', { blocking: true }
-
-            context 'with schema extraction' do
-              let(:api_security_enabled) { true }
-              let(:api_security_sample) { 1 }
-
-              it { is_expected.to be_forbidden }
-
-              it_behaves_like 'normal with tracing disable'
-              it_behaves_like 'a GET 403 span'
-              it_behaves_like 'a trace with AppSec tags'
-              it_behaves_like 'a trace with AppSec events', { blocking: true }
-              it_behaves_like 'a trace with AppSec api security tags'
-            end
+            it_behaves_like 'a trace with AppSec api security tags'
           end
         end
       end
@@ -451,19 +329,7 @@ RSpec.describe 'Sinatra integration tests' do
           it_behaves_like 'a POST 200 span'
           it_behaves_like 'a trace with AppSec tags'
           it_behaves_like 'a trace without AppSec events'
-
-          context 'with schema extraction' do
-            let(:api_security_enabled) { true }
-            let(:api_security_sample) { 1 }
-
-            it { is_expected.to be_ok }
-
-            it_behaves_like 'normal with tracing disable'
-            it_behaves_like 'a POST 200 span'
-            it_behaves_like 'a trace with AppSec tags'
-            it_behaves_like 'a trace without AppSec events'
-            it_behaves_like 'a trace with AppSec api security tags'
-          end
+          it_behaves_like 'a trace with AppSec api security tags'
         end
 
         context 'with an event-triggering request in application/x-www-form-url-encoded body' do
@@ -475,19 +341,7 @@ RSpec.describe 'Sinatra integration tests' do
           it_behaves_like 'a POST 200 span'
           it_behaves_like 'a trace with AppSec tags'
           it_behaves_like 'a trace with AppSec events'
-
-          context 'with schema extraction' do
-            let(:api_security_enabled) { true }
-            let(:api_security_sample) { 1 }
-
-            it { is_expected.to be_ok }
-
-            it_behaves_like 'normal with tracing disable'
-            it_behaves_like 'a POST 200 span'
-            it_behaves_like 'a trace with AppSec tags'
-            it_behaves_like 'a trace with AppSec events'
-            it_behaves_like 'a trace with AppSec api security tags'
-          end
+          it_behaves_like 'a trace with AppSec api security tags'
 
           context 'and a blocking rule' do
             let(:appsec_ruleset) { crs_942_100 }
@@ -498,19 +352,7 @@ RSpec.describe 'Sinatra integration tests' do
             it_behaves_like 'a POST 403 span'
             it_behaves_like 'a trace with AppSec tags'
             it_behaves_like 'a trace with AppSec events', { blocking: true }
-
-            context 'with schema extraction' do
-              let(:api_security_enabled) { true }
-              let(:api_security_sample) { 1 }
-
-              it { is_expected.to be_forbidden }
-
-              it_behaves_like 'normal with tracing disable'
-              it_behaves_like 'a POST 403 span'
-              it_behaves_like 'a trace with AppSec tags'
-              it_behaves_like 'a trace with AppSec events', { blocking: true }
-              it_behaves_like 'a trace with AppSec api security tags'
-            end
+            it_behaves_like 'a trace with AppSec api security tags'
           end
         end
 
@@ -525,19 +367,7 @@ RSpec.describe 'Sinatra integration tests' do
             it_behaves_like 'a POST 200 span'
             it_behaves_like 'a trace with AppSec tags'
             it_behaves_like 'a trace with AppSec events'
-
-            context 'with schema extraction' do
-              let(:api_security_enabled) { true }
-              let(:api_security_sample) { 1 }
-
-              it { is_expected.to be_ok }
-
-              it_behaves_like 'normal with tracing disable'
-              it_behaves_like 'a POST 200 span'
-              it_behaves_like 'a trace with AppSec tags'
-              it_behaves_like 'a trace with AppSec events'
-              it_behaves_like 'a trace with AppSec api security tags'
-            end
+            it_behaves_like 'a trace with AppSec api security tags'
           end
         end
 
@@ -566,19 +396,7 @@ RSpec.describe 'Sinatra integration tests' do
           it_behaves_like 'a POST 200 span'
           it_behaves_like 'a trace with AppSec tags'
           it_behaves_like 'a trace with AppSec events'
-
-          context 'with schema extraction' do
-            let(:api_security_enabled) { true }
-            let(:api_security_sample) { 1 }
-
-            it { is_expected.to be_ok }
-
-            it_behaves_like 'normal with tracing disable'
-            it_behaves_like 'a POST 200 span'
-            it_behaves_like 'a trace with AppSec tags'
-            it_behaves_like 'a trace with AppSec events'
-            it_behaves_like 'a trace with AppSec api security tags'
-          end
+          it_behaves_like 'a trace with AppSec api security tags'
         end
       end
     end

--- a/spec/datadog/appsec/contrib/sinatra/integration_test_spec.rb
+++ b/spec/datadog/appsec/contrib/sinatra/integration_test_spec.rb
@@ -45,6 +45,8 @@ RSpec.describe 'Sinatra integration tests' do
   let(:appsec_ip_denylist) { [] }
   let(:appsec_user_id_denylist) { [] }
   let(:appsec_ruleset) { :recommended }
+  let(:api_security_enabled) { false }
+  let(:api_security_sample) { 0.0 }
 
   let(:crs_942_100) do
     {
@@ -104,6 +106,8 @@ RSpec.describe 'Sinatra integration tests' do
       c.appsec.ip_denylist = appsec_ip_denylist
       c.appsec.user_id_denylist = appsec_user_id_denylist
       c.appsec.ruleset = appsec_ruleset
+      c.appsec.api_security.enabled = api_security_enabled
+      c.appsec.api_security.sample_rate = api_security_sample
 
       # TODO: test with c.appsec.instrument :rack
     end
@@ -186,6 +190,19 @@ RSpec.describe 'Sinatra integration tests' do
           it_behaves_like 'a GET 200 span'
           it_behaves_like 'a trace with AppSec tags'
           it_behaves_like 'a trace without AppSec events'
+
+          context 'with schema extraction' do
+            let(:api_security_enabled) { true }
+            let(:api_security_sample) { 1 }
+
+            it { is_expected.to be_ok }
+
+            it_behaves_like 'normal with tracing disable'
+            it_behaves_like 'a GET 200 span'
+            it_behaves_like 'a trace with AppSec tags'
+            it_behaves_like 'a trace without AppSec events'
+            it_behaves_like 'a trace with AppSec api security tags'
+          end
         end
 
         context 'with an event-triggering request in headers' do
@@ -198,6 +215,20 @@ RSpec.describe 'Sinatra integration tests' do
           it_behaves_like 'a GET 200 span'
           it_behaves_like 'a trace with AppSec tags'
           it_behaves_like 'a trace with AppSec events'
+
+          context 'with schema extraction' do
+            let(:api_security_enabled) { true }
+            let(:api_security_sample) { 1 }
+
+            it { is_expected.to be_ok }
+            it { expect(triggers).to be_a Array }
+
+            it_behaves_like 'normal with tracing disable'
+            it_behaves_like 'a GET 200 span'
+            it_behaves_like 'a trace with AppSec tags'
+            it_behaves_like 'a trace with AppSec events'
+            it_behaves_like 'a trace with AppSec api security tags'
+          end
         end
 
         context 'with an event-triggering request in query string' do
@@ -210,6 +241,19 @@ RSpec.describe 'Sinatra integration tests' do
           it_behaves_like 'a trace with AppSec tags'
           it_behaves_like 'a trace with AppSec events'
 
+          context 'with schema extraction' do
+            let(:api_security_enabled) { true }
+            let(:api_security_sample) { 1 }
+
+            it { is_expected.to be_ok }
+
+            it_behaves_like 'normal with tracing disable'
+            it_behaves_like 'a GET 200 span'
+            it_behaves_like 'a trace with AppSec tags'
+            it_behaves_like 'a trace with AppSec events'
+            it_behaves_like 'a trace with AppSec api security tags'
+          end
+
           context 'and a blocking rule' do
             let(:appsec_ruleset) { crs_942_100 }
 
@@ -219,6 +263,19 @@ RSpec.describe 'Sinatra integration tests' do
             it_behaves_like 'a GET 403 span'
             it_behaves_like 'a trace with AppSec tags'
             it_behaves_like 'a trace with AppSec events', { blocking: true }
+
+            context 'with schema extraction' do
+              let(:api_security_enabled) { true }
+              let(:api_security_sample) { 1 }
+
+              it { is_expected.to be_forbidden }
+
+              it_behaves_like 'normal with tracing disable'
+              it_behaves_like 'a GET 403 span'
+              it_behaves_like 'a trace with AppSec tags'
+              it_behaves_like 'a trace with AppSec events', { blocking: true }
+              it_behaves_like 'a trace with AppSec api security tags'
+            end
           end
         end
 
@@ -240,6 +297,19 @@ RSpec.describe 'Sinatra integration tests' do
           it_behaves_like 'a trace with AppSec tags'
           it_behaves_like 'a trace with AppSec events'
 
+          context 'with schema extraction' do
+            let(:api_security_enabled) { true }
+            let(:api_security_sample) { 1 }
+
+            it { is_expected.to be_ok }
+
+            it_behaves_like 'normal with tracing disable'
+            it_behaves_like 'a GET 200 span'
+            it_behaves_like 'a trace with AppSec tags'
+            it_behaves_like 'a trace with AppSec events'
+            it_behaves_like 'a trace with AppSec api security tags'
+          end
+
           context 'and a blocking rule' do
             let(:appsec_ruleset) { crs_942_100 }
 
@@ -249,6 +319,19 @@ RSpec.describe 'Sinatra integration tests' do
             it_behaves_like 'a GET 403 span'
             it_behaves_like 'a trace with AppSec tags'
             it_behaves_like 'a trace with AppSec events', { blocking: true }
+
+            context 'with schema extraction' do
+              let(:api_security_enabled) { true }
+              let(:api_security_sample) { 1 }
+
+              it { is_expected.to be_forbidden }
+
+              it_behaves_like 'normal with tracing disable'
+              it_behaves_like 'a GET 403 span'
+              it_behaves_like 'a trace with AppSec tags'
+              it_behaves_like 'a trace with AppSec events', { blocking: true }
+              it_behaves_like 'a trace with AppSec api security tags'
+            end
           end
         end
 
@@ -263,6 +346,19 @@ RSpec.describe 'Sinatra integration tests' do
           it_behaves_like 'a GET 403 span'
           it_behaves_like 'a trace with AppSec tags'
           it_behaves_like 'a trace with AppSec events', { blocking: true }
+
+          context 'with schema extraction' do
+            let(:api_security_enabled) { true }
+            let(:api_security_sample) { 1 }
+
+            it { is_expected.to be_forbidden }
+
+            it_behaves_like 'normal with tracing disable'
+            it_behaves_like 'a GET 403 span'
+            it_behaves_like 'a trace with AppSec tags'
+            it_behaves_like 'a trace with AppSec events', { blocking: true }
+            it_behaves_like 'a trace with AppSec api security tags'
+          end
         end
 
         context 'with an event-triggering response' do
@@ -275,6 +371,20 @@ RSpec.describe 'Sinatra integration tests' do
           it_behaves_like 'a GET 404 span'
           it_behaves_like 'a trace with AppSec tags'
           it_behaves_like 'a trace with AppSec events'
+
+          context 'with schema extraction' do
+            let(:api_security_enabled) { true }
+            let(:api_security_sample) { 1 }
+
+            it { is_expected.to be_not_found }
+            it { expect(triggers).to be_a Array }
+
+            it_behaves_like 'normal with tracing disable'
+            it_behaves_like 'a GET 404 span'
+            it_behaves_like 'a trace with AppSec tags'
+            it_behaves_like 'a trace with AppSec events'
+            it_behaves_like 'a trace with AppSec api security tags'
+          end
         end
 
         context 'with user blocking ID' do
@@ -287,6 +397,19 @@ RSpec.describe 'Sinatra integration tests' do
           it_behaves_like 'a trace with AppSec tags'
           it_behaves_like 'a trace without AppSec events'
 
+          context 'with schema extraction' do
+            let(:api_security_enabled) { true }
+            let(:api_security_sample) { 1 }
+
+            it { is_expected.to be_ok }
+
+            it_behaves_like 'normal with tracing disable'
+            it_behaves_like 'a GET 200 span'
+            it_behaves_like 'a trace with AppSec tags'
+            it_behaves_like 'a trace without AppSec events'
+            it_behaves_like 'a trace with AppSec api security tags'
+          end
+
           context 'with an event-triggering user ID' do
             let(:appsec_user_id_denylist) { ['blocked-user-id'] }
 
@@ -296,6 +419,19 @@ RSpec.describe 'Sinatra integration tests' do
             it_behaves_like 'a GET 403 span'
             it_behaves_like 'a trace with AppSec tags'
             it_behaves_like 'a trace with AppSec events', { blocking: true }
+
+            context 'with schema extraction' do
+              let(:api_security_enabled) { true }
+              let(:api_security_sample) { 1 }
+
+              it { is_expected.to be_forbidden }
+
+              it_behaves_like 'normal with tracing disable'
+              it_behaves_like 'a GET 403 span'
+              it_behaves_like 'a trace with AppSec tags'
+              it_behaves_like 'a trace with AppSec events', { blocking: true }
+              it_behaves_like 'a trace with AppSec api security tags'
+            end
           end
         end
       end
@@ -315,6 +451,19 @@ RSpec.describe 'Sinatra integration tests' do
           it_behaves_like 'a POST 200 span'
           it_behaves_like 'a trace with AppSec tags'
           it_behaves_like 'a trace without AppSec events'
+
+          context 'with schema extraction' do
+            let(:api_security_enabled) { true }
+            let(:api_security_sample) { 1 }
+
+            it { is_expected.to be_ok }
+
+            it_behaves_like 'normal with tracing disable'
+            it_behaves_like 'a POST 200 span'
+            it_behaves_like 'a trace with AppSec tags'
+            it_behaves_like 'a trace without AppSec events'
+            it_behaves_like 'a trace with AppSec api security tags'
+          end
         end
 
         context 'with an event-triggering request in application/x-www-form-url-encoded body' do
@@ -327,6 +476,19 @@ RSpec.describe 'Sinatra integration tests' do
           it_behaves_like 'a trace with AppSec tags'
           it_behaves_like 'a trace with AppSec events'
 
+          context 'with schema extraction' do
+            let(:api_security_enabled) { true }
+            let(:api_security_sample) { 1 }
+
+            it { is_expected.to be_ok }
+
+            it_behaves_like 'normal with tracing disable'
+            it_behaves_like 'a POST 200 span'
+            it_behaves_like 'a trace with AppSec tags'
+            it_behaves_like 'a trace with AppSec events'
+            it_behaves_like 'a trace with AppSec api security tags'
+          end
+
           context 'and a blocking rule' do
             let(:appsec_ruleset) { crs_942_100 }
 
@@ -336,6 +498,19 @@ RSpec.describe 'Sinatra integration tests' do
             it_behaves_like 'a POST 403 span'
             it_behaves_like 'a trace with AppSec tags'
             it_behaves_like 'a trace with AppSec events', { blocking: true }
+
+            context 'with schema extraction' do
+              let(:api_security_enabled) { true }
+              let(:api_security_sample) { 1 }
+
+              it { is_expected.to be_forbidden }
+
+              it_behaves_like 'normal with tracing disable'
+              it_behaves_like 'a POST 403 span'
+              it_behaves_like 'a trace with AppSec tags'
+              it_behaves_like 'a trace with AppSec events', { blocking: true }
+              it_behaves_like 'a trace with AppSec api security tags'
+            end
           end
         end
 
@@ -350,6 +525,19 @@ RSpec.describe 'Sinatra integration tests' do
             it_behaves_like 'a POST 200 span'
             it_behaves_like 'a trace with AppSec tags'
             it_behaves_like 'a trace with AppSec events'
+
+            context 'with schema extraction' do
+              let(:api_security_enabled) { true }
+              let(:api_security_sample) { 1 }
+
+              it { is_expected.to be_ok }
+
+              it_behaves_like 'normal with tracing disable'
+              it_behaves_like 'a POST 200 span'
+              it_behaves_like 'a trace with AppSec tags'
+              it_behaves_like 'a trace with AppSec events'
+              it_behaves_like 'a trace with AppSec api security tags'
+            end
           end
         end
 
@@ -378,6 +566,19 @@ RSpec.describe 'Sinatra integration tests' do
           it_behaves_like 'a POST 200 span'
           it_behaves_like 'a trace with AppSec tags'
           it_behaves_like 'a trace with AppSec events'
+
+          context 'with schema extraction' do
+            let(:api_security_enabled) { true }
+            let(:api_security_sample) { 1 }
+
+            it { is_expected.to be_ok }
+
+            it_behaves_like 'normal with tracing disable'
+            it_behaves_like 'a POST 200 span'
+            it_behaves_like 'a trace with AppSec tags'
+            it_behaves_like 'a trace with AppSec events'
+            it_behaves_like 'a trace with AppSec api security tags'
+          end
         end
       end
     end

--- a/spec/datadog/appsec/contrib/support/integration/shared_examples.rb
+++ b/spec/datadog/appsec/contrib/support/integration/shared_examples.rb
@@ -120,6 +120,20 @@ RSpec.shared_examples 'a trace with AppSec tags' do
   end
 end
 
+RSpec.shared_examples 'a trace with AppSec api security tags' do
+  it do
+    api_security_tags = service_span.send(:meta).select { |key, _value| key.include?('_dd.appsec.s') }
+
+    expect(api_security_tags).to_not be_empty
+  end
+
+  context 'with appsec disabled' do
+    let(:appsec_enabled) { false }
+
+    it_behaves_like 'a trace without AppSec tags'
+  end
+end
+
 RSpec.shared_examples 'a trace without AppSec events' do
   it do
     expect(spans.select { |s| s.get_tag('appsec.event') }).to be_empty

--- a/spec/datadog/appsec/contrib/support/integration/shared_examples.rb
+++ b/spec/datadog/appsec/contrib/support/integration/shared_examples.rb
@@ -121,16 +121,25 @@ RSpec.shared_examples 'a trace with AppSec tags' do
 end
 
 RSpec.shared_examples 'a trace with AppSec api security tags' do
-  it do
-    api_security_tags = service_span.send(:meta).select { |key, _value| key.include?('_dd.appsec.s') }
+  context 'with api security enabled' do
+    let(:api_security_enabled) { true }
+    let(:api_security_sample) { 1 }
 
-    expect(api_security_tags).to_not be_empty
+    it do
+      api_security_tags = service_span.send(:meta).select { |key, _value| key.include?('_dd.appsec.s') }
+
+      expect(api_security_tags).to_not be_empty
+    end
   end
 
-  context 'with appsec disabled' do
-    let(:appsec_enabled) { false }
+  context 'with api security disabled' do
+    let(:api_security_enabled) { false }
 
-    it_behaves_like 'a trace without AppSec tags'
+    it do
+      api_security_tags = service_span.send(:meta).select { |key, _value| key.include?('_dd.appsec.s') }
+
+      expect(api_security_tags).to be_empty
+    end
   end
 end
 

--- a/spec/datadog/appsec/event_spec.rb
+++ b/spec/datadog/appsec/event_spec.rb
@@ -41,11 +41,13 @@ RSpec.describe Datadog::AppSec::Event do
         dbl = double
 
         allow(dbl).to receive(:events).and_return([])
+        allow(dbl).to receive(:derivatives).and_return(derivatives)
 
         dbl
       end
 
       let(:event_count) { 1 }
+      let(:derivatives) { {} }
 
       let(:events) do
         Array.new(event_count) do
@@ -101,6 +103,19 @@ RSpec.describe Datadog::AppSec::Event do
 
         it 'marks the trace to be kept' do
           expect(trace.sampling_priority).to eq Datadog::Tracing::Sampling::Ext::Priority::USER_KEEP
+        end
+
+        context 'waf_result derivatives' do
+          let(:derivatives) do
+            {
+              '_dd.appsec.s.req.headers' => [{ 'host' => [8], 'version' => [8] }]
+            }
+          end
+
+          it 'adds derivatives to the top level span meta' do
+            meta = top_level_span.meta
+            expect(meta['_dd.appsec.s.req.headers']).to eq JSON.dump([{ 'host' => [8], 'version' => [8] }])
+          end
         end
       end
 

--- a/spec/datadog/appsec/processor/rule_merger_spec.rb
+++ b/spec/datadog/appsec/processor/rule_merger_spec.rb
@@ -88,73 +88,70 @@ RSpec.describe Datadog::AppSec::Processor::RuleMerger do
             ]
           }.freeze
 
-          expected_result = {
-            'version' => '2.2',
-            'rules' => [
-              {
-                'id' => 'usr-001-001',
-                'name' => 'Super rule',
-                'tags' => {
-                  'type' => 'security_scanner',
-                  'category' => 'scanners'
-                },
-                'conditions' => [
-                  {
-                    'parameters' => {
-                      'inputs' => [
-                        {
-                          'address' => 'server.request.headers',
-                          'key_path' => ['user-agent']
-                        }
-                      ],
-                      'regex' => '^SuperScanner$'
-                    },
-                    'operator' => 'regex_match'
-                  }
-                ],
-                'transformers' => []
+          expected_result = [
+            {
+              'id' => 'usr-001-001',
+              'name' => 'Super rule',
+              'tags' => {
+                'type' => 'security_scanner',
+                'category' => 'scanners'
               },
-              {
-                'id' => 'crs-942-100',
-                'name' => 'SQL Injection Attack Detected via libinjection',
-                'tags' => {
-                  'type' => 'sql_injection',
-                  'crs_id' => '942100',
-                  'category' => 'attack_attempt'
-                },
-                'conditions' => [
-                  {
-                    'parameters' => {
-                      'inputs' => [
-                        {
-                          'address' => 'server.request.query'
-                        },
-                        {
-                          'address' => 'server.request.body'
-                        },
-                        {
-                          'address' => 'server.request.path_params'
-                        },
-                        {
-                          'address' => 'grpc.server.request.message'
-                        }
-                      ]
-                    },
-                    'operator' => 'is_sqli'
-                  }
-                ],
-                'transformers' => [
-                  'removeNulls'
-                ],
-                'on_match' => [
-                  'block'
-                ]
+              'conditions' => [
+                {
+                  'parameters' => {
+                    'inputs' => [
+                      {
+                        'address' => 'server.request.headers',
+                        'key_path' => ['user-agent']
+                      }
+                    ],
+                    'regex' => '^SuperScanner$'
+                  },
+                  'operator' => 'regex_match'
+                }
+              ],
+              'transformers' => []
+            },
+            {
+              'id' => 'crs-942-100',
+              'name' => 'SQL Injection Attack Detected via libinjection',
+              'tags' => {
+                'type' => 'sql_injection',
+                'crs_id' => '942100',
+                'category' => 'attack_attempt'
               },
-            ]
-          }
+              'conditions' => [
+                {
+                  'parameters' => {
+                    'inputs' => [
+                      {
+                        'address' => 'server.request.query'
+                      },
+                      {
+                        'address' => 'server.request.body'
+                      },
+                      {
+                        'address' => 'server.request.path_params'
+                      },
+                      {
+                        'address' => 'grpc.server.request.message'
+                      }
+                    ]
+                  },
+                  'operator' => 'is_sqli'
+                }
+              ],
+              'transformers' => [
+                'removeNulls'
+              ],
+              'on_match' => [
+                'block'
+              ]
+            },
+          ]
 
           result = described_class.merge(rules: rules_dup.freeze)
-          expect(result).to eq(expected_result)
+          expect(result).to include('rules' => expected_result)
         end
 
         it 'raises RuleVersionMismatchError is the rules version is not the same' do
@@ -218,7 +215,7 @@ RSpec.describe Datadog::AppSec::Processor::RuleMerger do
         expected_result = rules[0]
 
         result = described_class.merge(rules: rules)
-        expect(result).to eq(expected_result)
+        expect(result).to include(expected_result)
       end
     end
 
@@ -239,23 +236,9 @@ RSpec.describe Datadog::AppSec::Processor::RuleMerger do
           ]
         ]
 
-        expected_result = rules[0].merge(
-          {
-            'rules_override' => [
-              {
-                'id' => 'usr-001-001',
-                'on_match' => ['block']
-              },
-              {
-                'id' => 'usr-001-001',
-                'enabled' => false
-              }
-            ]
-          }
-        )
-
         result = described_class.merge(rules: rules, overrides: rules_overrides)
-        expect(result).to eq(expected_result)
+        expect(result).to include('rules' => rules[0]['rules'])
+        expect(result).to include('rules_override' => rules_overrides.flatten)
       end
     end
   end
@@ -328,69 +311,9 @@ RSpec.describe Datadog::AppSec::Processor::RuleMerger do
         ],
       ]
 
-      expected_result = rules[0].merge(
-        {
-          'exclusions' => [
-            {
-              'conditions' => [
-                {
-                  'operator' => 'match_regex',
-                  'parameters' => {
-                    'inputs' => [
-                      { 'address' => 'server.request.uri.raw' }
-                    ],
-                    'options' => { 'case_sensitive' => false },
-                    'regex' => '^/api/v2/ci/pipeline/.*'
-                  }
-                }
-              ],
-              'id' => '1931d0f4-c521-4500-af34-6c4d8b8b3494'
-            },
-            {
-              'conditions' => [
-                {
-                  'operator' => 'match_regex',
-                  'parameters' => {
-                    'inputs' => [
-                      {
-                        'address' => 'server.request.uri.raw'
-                      }
-                    ],
-                    'options' => {
-                      'case_sensitive' => false
-                    },
-                    'regex' => '^/api/v2/source-code-integration/enrich-stack-trace'
-                  }
-                }
-              ],
-              'id' => 'f40fbf52-baec-42bd-9868-cf002b6cdbed',
-              'inputs' => [
-                {
-                  'address' => 'server.request.query',
-                  'key_path' => [
-                    'stack'
-                  ]
-                },
-                {
-                  'address' => 'server.request.body',
-                  'key_path' => [
-                    'stack'
-                  ]
-                },
-                {
-                  'address' => 'server.request.path_params',
-                  'key_path' => [
-                    'stack'
-                  ]
-                }
-              ]
-            }
-          ]
-        }
-      )
-
       result = described_class.merge(rules: rules, exclusions: exclusions)
-      expect(result).to eq(expected_result)
+      expect(result).to include('rules' => rules[0]['rules'])
+      expect(result).to include('exclusions' => exclusions.flatten)
     end
   end
 
@@ -435,39 +358,36 @@ RSpec.describe Datadog::AppSec::Processor::RuleMerger do
         ]
       ]
 
-      expected_result = rules[0].merge(
+      expected_result = [
         {
-          'rules_data' => [
+          'id' => 'blocked_users',
+          'type' => 'data_with_expiration',
+          'data' => [
             {
-              'id' => 'blocked_users',
-              'type' => 'data_with_expiration',
-              'data' => [
-                {
-                  'expiration' => 1677171437,
-                  'value' => 'this is a test'
-                },
-                {
-                  'expiration' => 1678279317,
-                  'value' => 'this is a second test'
-                }
-              ]
+              'expiration' => 1677171437,
+              'value' => 'this is a test'
             },
             {
-              'id' => 'blocked_ips',
-              'type' => 'ip_with_expiration',
-              'data' => [
-                {
-                  'expiration' => 1678279317,
-                  'value' => '9.9.9.9'
-                }
-              ]
-            },
+              'expiration' => 1678279317,
+              'value' => 'this is a second test'
+            }
           ]
-        }
-      )
+        },
+        {
+          'id' => 'blocked_ips',
+          'type' => 'ip_with_expiration',
+          'data' => [
+            {
+              'expiration' => 1678279317,
+              'value' => '9.9.9.9'
+            }
+          ]
+        },
+      ]
 
       result = described_class.merge(rules: rules, data: rules_data)
-      expect(result).to eq(expected_result)
+      expect(result).to include('rules' => rules[0]['rules'])
+      expect(result).to include('rules_data' => expected_result)
     end
 
     it 'merges data of different types' do
@@ -497,34 +417,31 @@ RSpec.describe Datadog::AppSec::Processor::RuleMerger do
         ]
       ]
 
-      expected_result = rules[0].merge(
+      expected_result = [
         {
-          'rules_data' => [
+          'id' => 'blocked_users',
+          'type' => 'data_with_expiration',
+          'data' => [
             {
-              'id' => 'blocked_users',
-              'type' => 'data_with_expiration',
-              'data' => [
-                {
-                  'expiration' => 1677171437,
-                  'value' => 'this is a test'
-                }
-              ]
-            },
-            {
-              'data' => [
-                {
-                  'value' => 'this is a test'
-                }
-              ],
-              'id' => 'blocked_users',
-              'type' => 'test_data'
+              'expiration' => 1677171437,
+              'value' => 'this is a test'
             }
           ]
+        },
+        {
+          'data' => [
+            {
+              'value' => 'this is a test'
+            }
+          ],
+          'id' => 'blocked_users',
+          'type' => 'test_data'
         }
-      )
+      ]
 
       result = described_class.merge(rules: rules, data: rules_data)
-      expect(result).to eq(expected_result)
+      expect(result).to include('rules' => rules[0]['rules'])
+      expect(result).to include('rules_data' => expected_result)
     end
 
     context 'with duplicates entries' do
@@ -556,25 +473,22 @@ RSpec.describe Datadog::AppSec::Processor::RuleMerger do
           ]
         ]
 
-        expected_result = rules[0].merge(
+        expected_result = [
           {
-            'rules_data' => [
+            'id' => 'blocked_users',
+            'type' => 'data_with_expiration',
+            'data' => [
               {
-                'id' => 'blocked_users',
-                'type' => 'data_with_expiration',
-                'data' => [
-                  {
-                    'expiration' => 1677171437,
-                    'value' => 'this is a test'
-                  }
-                ]
+                'expiration' => 1677171437,
+                'value' => 'this is a test'
               }
             ]
           }
-        )
+        ]
 
         result = described_class.merge(rules: rules, data: rules_data)
-        expect(result).to eq(expected_result)
+        expect(result).to include('rules' => rules[0]['rules'])
+        expect(result).to include('rules_data' => expected_result)
       end
 
       it 'removes expiration key if no experation is provided' do
@@ -604,24 +518,21 @@ RSpec.describe Datadog::AppSec::Processor::RuleMerger do
           ]
         ]
 
-        expected_result = rules[0].merge(
+        expected_result = [
           {
-            'rules_data' => [
+            'id' => 'blocked_users',
+            'type' => 'data_with_expiration',
+            'data' => [
               {
-                'id' => 'blocked_users',
-                'type' => 'data_with_expiration',
-                'data' => [
-                  {
-                    'value' => 'this is a test'
-                  }
-                ]
+                'value' => 'this is a test'
               }
             ]
           }
-        )
+        ]
 
         result = described_class.merge(rules: rules, data: rules_data)
-        expect(result).to eq(expected_result)
+        expect(result).to include('rules' => rules[0]['rules'])
+        expect(result).to include('rules_data' => expected_result)
       end
     end
 
@@ -680,61 +591,9 @@ RSpec.describe Datadog::AppSec::Processor::RuleMerger do
           ]
         ]
 
-        expected_result = rules[0].merge(
-          {
-            'custom_rules' => [
-              {
-                'id' => 'custom-rule-001',
-                'name' => 'Super custom rule 1',
-                'tags' => {
-                  'type' => 'security_scanner',
-                  'category' => 'scanners'
-                },
-                'conditions' => [
-                  {
-                    'parameters' => {
-                      'inputs' => [
-                        {
-                          'address' => 'server.request.headers',
-                          'key_path' => ['user-agent']
-                        }
-                      ],
-                      'regex' => '^SuperScanner1$'
-                    },
-                    'operator' => 'regex_match'
-                  }
-                ],
-                'transformers' => []
-              },
-              {
-                'id' => 'custom-rule-002',
-                'name' => 'Super custom rule 2',
-                'tags' => {
-                  'type' => 'security_scanner',
-                  'category' => 'scanners'
-                },
-                'conditions' => [
-                  {
-                    'parameters' => {
-                      'inputs' => [
-                        {
-                          'address' => 'server.request.headers',
-                          'key_path' => ['user-agent']
-                        }
-                      ],
-                      'regex' => '^SuperScanner2$'
-                    },
-                    'operator' => 'regex_match'
-                  }
-                ],
-                'transformers' => []
-              }
-            ]
-          }
-        )
-
         result = described_class.merge(rules: rules, custom_rules: custom_rules)
-        expect(result).to eq(expected_result)
+        expect(result).to include('rules' => rules[0]['rules'])
+        expect(result).to include('custom_rules' => custom_rules.flatten)
       end
     end
 
@@ -805,56 +664,38 @@ RSpec.describe Datadog::AppSec::Processor::RuleMerger do
           ]
         ]
 
-        expected_result = rules[0].merge(
+        expect_rules_data = [
           {
-            'rules_data' => [
+            'id' => 'blocked_users',
+            'type' => 'data_with_expiration',
+            'data' => [
               {
-                'id' => 'blocked_users',
-                'type' => 'data_with_expiration',
-                'data' => [
-                  {
-                    'value' => 'this is a test'
-                  }
-                ]
-              }
-            ],
-            'rules_override' => [
-              {
-                'id' => 'usr-001-001',
-                'on_match' => ['block']
-              },
-              {
-                'enabled' => false,
-                'id' => 'usr-001-001'
-              }
-            ],
-            'exclusions' => [
-              {
-                'conditions' => [
-                  {
-                    'operator' => 'match_regex',
-                    'parameters' => {
-                      'inputs' => [
-                        {
-                          'address' => 'server.request.uri.raw'
-                        }
-                      ],
-                      'options' => {
-                        'case_sensitive' => false
-                      },
-                      'regex' => '^/api/v2/ci/pipeline/.*'
-                    }
-                  }
-                ],
-                'id' => '1931d0f4-c521-4500-af34-6c4d8b8b3494'
+                'value' => 'this is a test'
               }
             ]
           }
-        )
+        ]
 
         result = described_class.merge(rules: rules, data: rules_data, overrides: rules_overrides, exclusions: exclusions)
-        expect(result).to eq(expected_result)
+        expect(result).to include('rules' => rules[0]['rules'])
+        expect(result).to include('rules_data' => expect_rules_data)
+        expect(result).to include('exclusions' => exclusions.flatten)
+        expect(result).to include('rules_override' => rules_overrides.flatten)
       end
+    end
+  end
+
+  context 'processors' do
+    it 'merges default processors' do
+      result = described_class.merge(rules: rules)
+      expect(result).to include('rules' => rules[0]['rules'])
+      expect(result).to include('processors' => described_class::DEFAULT_PROCESSORS)
+    end
+
+    it 'merges the provided processors' do
+      result = described_class.merge(rules: rules, processors: 'hello')
+      expect(result).to include('rules' => rules[0]['rules'])
+      expect(result).to include('processors' => 'hello')
     end
   end
 end

--- a/spec/datadog/appsec/processor/rule_merger_spec.rb
+++ b/spec/datadog/appsec/processor/rule_merger_spec.rb
@@ -689,7 +689,7 @@ RSpec.describe Datadog::AppSec::Processor::RuleMerger do
     it 'merges default processors' do
       result = described_class.merge(rules: rules)
       expect(result).to include('rules' => rules[0]['rules'])
-      expect(result).to include('processors' => described_class::DEFAULT_PROCESSORS)
+      expect(result).to include('processors' => described_class::DEFAULT_WAF_PROCESSORS)
     end
 
     it 'merges the provided processors' do

--- a/spec/datadog/appsec/remote_spec.rb
+++ b/spec/datadog/appsec/remote_spec.rb
@@ -159,7 +159,8 @@ RSpec.describe Datadog::AppSec::Remote do
               }],
               'transformers' => [],
               'on_match' => ['block']
-            }]
+            }],
+            'processors' => Datadog::AppSec::Processor::RuleMerger::DEFAULT_PROCESSORS
           }
 
           expect(Datadog::AppSec).to receive(:reconfigure).with(ruleset: expected_ruleset, actions: [])
@@ -368,7 +369,9 @@ RSpec.describe Datadog::AppSec::Remote do
               end
 
               it 'pass the actions to reconfigure' do
-                expect(Datadog::AppSec).to receive(:reconfigure).with(ruleset: default_ruleset[0], actions: actions)
+                ruleset = Datadog::AppSec::Processor::RuleMerger.merge(rules: default_ruleset)
+
+                expect(Datadog::AppSec).to receive(:reconfigure).with(ruleset: ruleset, actions: actions)
                   .and_return(nil)
 
                 changes = transaction
@@ -475,11 +478,7 @@ RSpec.describe Datadog::AppSec::Remote do
               let(:transaction) { repository.transaction { |repository, transaction| } }
 
               it 'uses the rules from the appsec settings' do
-                ruleset = 'foo'
-
-                expect(Datadog::AppSec::Processor::RuleLoader).to receive(:load_rules).with(
-                  ruleset: Datadog.configuration.appsec.ruleset
-                ).and_return(ruleset)
+                ruleset = Datadog::AppSec::Processor::RuleMerger.merge(rules: default_ruleset)
 
                 changes = transaction
                 expect(Datadog::AppSec).to receive(:reconfigure).with(ruleset: ruleset, actions: [])

--- a/spec/datadog/appsec/remote_spec.rb
+++ b/spec/datadog/appsec/remote_spec.rb
@@ -160,7 +160,7 @@ RSpec.describe Datadog::AppSec::Remote do
               'transformers' => [],
               'on_match' => ['block']
             }],
-            'processors' => Datadog::AppSec::Processor::RuleMerger::DEFAULT_PROCESSORS
+            'processors' => Datadog::AppSec::Processor::RuleMerger::DEFAULT_WAF_PROCESSORS
           }
 
           expect(Datadog::AppSec).to receive(:reconfigure).with(ruleset: expected_ruleset, actions: [])

--- a/spec/datadog/appsec/sample_rate_spec.rb
+++ b/spec/datadog/appsec/sample_rate_spec.rb
@@ -1,0 +1,49 @@
+require 'datadog/appsec/spec_helper'
+require 'datadog/appsec/sample_rate'
+
+RSpec.describe Datadog::AppSec::SampleRate do
+  subject(:sample_rate) { described_class.new(rate) }
+  describe '#sample?' do
+    context 'when sample rate is 0' do
+      let(:rate) { 0 }
+
+      it 'returns false' do
+        expect(sample_rate.sample?).to eq false
+      end
+    end
+
+    context 'when sample rate is bigger or equal to 1' do
+      [1, 2].each do |value|
+        let(:rate) { value }
+
+        it 'returns true' do
+          expect(sample_rate.sample?).to eq true
+        end
+      end
+    end
+
+    context 'when sample rate is differnt than 0 or 1' do
+      let(:rate) { 0.5 }
+
+      before do
+        expect(Kernel).to receive(:rand).and_return(random)
+      end
+
+      context 'when rand returns lower value than rate' do
+        let(:random) { 0.4 }
+
+        it 'returns true' do
+          expect(sample_rate.sample?).to eq true
+        end
+      end
+
+      context 'when rand returns higher value than rate' do
+        let(:random) { 0.6 }
+
+        it 'returns false' do
+          expect(sample_rate.sample?).to eq false
+        end
+      end
+    end
+  end
+end

--- a/vendor/rbs/libddwaf/0/datadog/appsec/waf.rbs
+++ b/vendor/rbs/libddwaf/0/datadog/appsec/waf.rbs
@@ -52,9 +52,11 @@ module Datadog
         def self.ddwaf_object_stringl_nc: (LibDDWAF::Object, ::String, ::Integer) -> ::FFI::Pointer
         def self.ddwaf_object_unsigned: (LibDDWAF::Object, ::Integer) -> ::FFI::Pointer
         def self.ddwaf_object_signed: (LibDDWAF::Object, ::Integer) -> ::FFI::Pointer
-        def self.ddwaf_object_unsigned_force: (LibDDWAF::Object, ::Integer) -> ::FFI::Pointer
-        def self.ddwaf_object_signed_force: (LibDDWAF::Object, ::Integer) -> ::FFI::Pointer
+        def self.ddwaf_object_string_from_unsigned: (LibDDWAF::Object, ::Integer) -> ::FFI::Pointer
+        def self.ddwaf_object_string_from_signed: (LibDDWAF::Object, ::Integer) -> ::FFI::Pointer
         def self.ddwaf_object_bool: (LibDDWAF::Object, bool) -> ::FFI::Pointer
+        def self.ddwaf_object_float: (LibDDWAF::Object, ::Float) -> ::FFI::Pointer
+        def self.ddwaf_object_null: (LibDDWAF::Object) -> ::FFI::Pointer
 
         def self.ddwaf_object_array: (LibDDWAF::Object) -> ::FFI::Pointer
         def self.ddwaf_object_array_add: (LibDDWAF::Object, LibDDWAF::Object) -> bool
@@ -75,6 +77,7 @@ module Datadog
         def self.ddwaf_object_get_signed: (LibDDWAF::Object, SizeTPtr) -> ::Integer
         def self.ddwaf_object_get_index: (LibDDWAF::Object, ::Integer) -> LibDDWAF::Object
         def self.ddwaf_object_get_bool: (LibDDWAF::Object) -> bool
+        def self.ddwaf_object_get_float: (LibDDWAF::Object) -> ::Float
 
         # freeers
 
@@ -93,15 +96,8 @@ module Datadog
           end
         end
 
-        class RuleSetInfo < ::FFI::Struct
-        end
-
-        RuleSetInfoNone: ::Datadog::AppSec::WAF::LibDDWAF::RuleSetInfo
-
-        def self.ddwaf_ruleset_info_free: (RuleSetInfo) -> void
-
-        def self.ddwaf_init: (top, Config, RuleSetInfo) -> ::FFI::Pointer
-        def self.ddwaf_update: (::FFI::Pointer, LibDDWAF::Object, RuleSetInfo) -> ::FFI::Pointer
+        def self.ddwaf_init: (top, Config, Object) -> ::FFI::Pointer
+        def self.ddwaf_update: (::FFI::Pointer, LibDDWAF::Object, LibDDWAF::Object) -> ::FFI::Pointer
         def self.ddwaf_destroy: (::FFI::Pointer) -> void
 
         def self.ddwaf_required_addresses: (::FFI::Pointer, UInt32Ptr) -> ::FFI::Pointer
@@ -115,9 +111,6 @@ module Datadog
 
         def self.ddwaf_context_init: (::FFI::Pointer) -> ::FFI::Pointer
         def self.ddwaf_context_destroy: (::FFI::Pointer) -> void
-
-        class ResultActions < ::FFI::Struct
-        end
 
         class Result < ::FFI::Struct
         end
@@ -149,9 +142,9 @@ module Datadog
 
       def self.version: () -> ::String
 
-      type data = String | Symbol | Integer | Float | TrueClass | FalseClass | Array[data] | Hash[String | Symbol, data] | nil
+      type data = String | Symbol | Integer | Float | TrueClass | FalseClass | Array[data] | Hash[(String | Symbol | nil), data] | nil
 
-      def self.ruby_to_object: (data val, ?max_container_size: ::Integer?, ?max_container_depth: ::Integer?, ?max_string_length: ::Integer?, ?coerce: bool?) -> ::Datadog::AppSec::WAF::LibDDWAF::Object
+      def self.ruby_to_object: (top val, ?max_container_size: ::Integer?, ?max_container_depth: ::Integer?, ?max_string_length: ::Integer?, ?coerce: bool?) -> ::Datadog::AppSec::WAF::LibDDWAF::Object
       def self.object_to_ruby: (::Datadog::AppSec::WAF::LibDDWAF::Object obj) -> data
 
       self.@logger: ::Logger
@@ -165,35 +158,34 @@ module Datadog
 
       class Handle
         attr_reader handle_obj: ::FFI::Pointer
-        attr_reader ruleset_info: Hash[Symbol, untyped]
+        attr_reader diagnostics: data
         attr_reader config: WAF::LibDDWAF::Config
 
         def initialize: (data rule, ?limits: ::Hash[::Symbol, ::Integer], ?obfuscator: ::Hash[::Symbol, ::String]) -> void
         def finalize: () -> untyped
         def required_addresses: () -> ::Array[::String]
-        def update: (untyped data) -> Handle
+        def merge: (untyped data) -> Handle?
 
         private
 
         @valid: bool
 
-        def new_from_handle: (::FFI::Pointer handle_object, Hash[Symbol, untyped] info, WAF::LibDDWAF::Config config) -> untyped
+        def new_from_handle: (::FFI::Pointer handle_object, data diagnostics, WAF::LibDDWAF::Config config) -> untyped
         def validate!: () -> void
         def invalidate!: () -> void
         def valid?: () -> (nil | bool)
         def valid!: () -> void
       end
 
-      type result_data = Array[untyped] | nil
-
       class Result
         attr_reader status: ::Symbol
-        attr_reader data: untyped
+        attr_reader events: data
         attr_reader total_runtime: ::Float
         attr_reader timeout: bool
-        attr_reader actions: ::Array[::String]
+        attr_reader actions: data
+        attr_reader derivatives: data
 
-        def initialize: (::Symbol, result_data, ::Float, bool, ::Array[::String]) -> void
+        def initialize: (::Symbol, data, ::Float, bool, data, data) -> void
       end
 
       class Context


### PR DESCRIPTION
<!--
Check out the
https://github.com/DataDog/dd-trace-rb/blob/master/docs/DevelopmentGuide.md
for guidance on how to set up your development environment,
run the test suite, write new integrations, and more.
-->

**What does this PR do?**
<!-- A brief description of the change being made with this pull request. -->

This PR adds the necessary bits to enable API Security's new feature. Schema Extraction 🎉 

To enable that, we need the latest version of libddwaf 1.14.0. At the end request lifecycle, we would call the WAF to extract the schema of the different WAF addresses. Calling schema extraction is gated via specific configuration: `DD_EXPERIMENTAL_API_SECURITY_ENABLED` and `DD_API_SECURITY_REQUEST_SAMPLE_RATE`

The schema extraction information is appended to the top-level span attributes so the backend can later process it.

At the moment, the processor configuration is not part of the static WAF rules, so we need to make sure we always include it as part of the Handle rules. We store the processor configuration at the same pace as the WAF rule. 

To better review the changes, I split the work into separate commits. I recommend reading individual commits to make it easier to understand the changes. Another suggestion is to filter out all the `.lock` file changes. Here is a handy [link](https://github.com/DataDog/dd-trace-rb/pull/3131/files?file-filters%5B%5D=.gemspec&file-filters%5B%5D=.json&file-filters%5B%5D=.rb&file-filters%5B%5D=.rbs&show-viewed-files=true) to filter out those files 


**Motivation:**
<!-- What inspired you to submit this pull request? -->

**Additional Notes:**
<!-- Anything else we should know when reviewing? -->

There are a few missing features of the API Secuirty RFC that would be implemented on the following PRs
- Compress schema information
- Add support for the new WAF address `server.response.body`

**How to test the change?**
<!--
Describe here how the change can be validated.
You are strongly encouraged to provide automated tests for this PR (unit or integration).
If this change cannot be feasibly tested, please explain why,
unless the change does not modify code (e.g. only modifies docs, comments).
-->

**For Datadog employees:**
- [ ] If this PR touches code that signs or publishes builds or packages, or handles
credentials of any kind, I've requested a review from `@DataDog/security-design-and-guidance`.
- [ ] This PR doesn't touch any of that.

Unsure? Have a question? Request a review!
