### PR TITLE
Test:Fix flaky loofah+nokogiri version mismatching

### DIFF
--- a/integration/apps/rails-five/Gemfile
+++ b/integration/apps/rails-five/Gemfile
@@ -31,6 +31,11 @@ gem 'mysql2'
 gem 'puma'
 gem 'unicorn'
 
+# Lock loofah's version as there were issues between specific loofah and nokogiri (a loofah dependency)
+# around loofah 2.20. We can't upgrade both loofah and nokogiri to their latest version because
+# they are not supported by Ruby < 2.5.
+gem 'loofah', '2.19.1'
+
 # Choose correct specs for 'ddtrace' demo environment
 gem 'ddtrace', *Datadog::DemoEnv.gem_spec('ddtrace')
 


### PR DESCRIPTION
<!--
Check out the
https://github.com/DataDog/dd-trace-rb/blob/master/docs/DevelopmentGuide.md
for guidance on how to set up your development environment,
run the test suite, write new integrations, and more.
-->

**What does this PR do?**
<!-- A brief description of the change being made with this pull request. -->

Fixes a flaky `rails-five` dependency version issue affecting [build_and_test_integration-2.3](https://app.circleci.com/pipelines/github/DataDog/dd-trace-rb/11850/workflows/1be5e47a-aea2-4d81-9806-a32fbf9fc389/jobs/445272) and 
[build_and_test_integration-2.4](https://app.circleci.com/pipelines/github/DataDog/dd-trace-rb/11850/workflows/1be5e47a-aea2-4d81-9806-a32fbf9fc389/jobs/445285):

```
app_1                 | NameError: uninitialized constant Nokogiri::HTML4
app_1                 | /usr/local/bundle/gems/loofah-2.21.1/lib/loofah/html4/document.rb:10:in `<module:HTML4>'
```

This happens because there were issues between specific `loofah` and `nokogiri` (a `loofah` dependency)
around `loofah` 2.20. We can't upgrade both `loofah` and `nokogiri` to their latest version because they are not supported by Ruby < 2.5.



**Additional Notes:**
<!-- Anything else we should know when reviewing? -->

Here's an example public discussion about this: https://www.ruby-forum.com/t/i-am-using-ruby-version-2-3-8-and-rails-version-5-2-6-to-develop-my-application-since-yesterday-i-am-getting-the-error-i-tried-to-find-the-occurrence-of-this-nokogiri-html4-in-my-application-but-i-didnt-find-any-of-the-occurrence-like-this/263852

**How to test the change?**
<!--
Describe here how the change can be validated.
You are strongly encouraged to provide automated tests for this PR (unit or integration).
If this change cannot be feasibly tested, please explain why,
unless the change does not modify code (e.g. only modifies docs, comments).
-->

build_and_test_integration-2.3 and build_and_test_integration-2.4 should not flake on `uninitialized constant Nokogiri::HTML4` after this change.

**For Datadog employees:**
- [ ] If this PR touches code that signs or publishes builds or packages, or handles
credentials of any kind, I've requested a review from `@DataDog/security-design-and-guidance`.
- [ ] This PR doesn't touch any of that.

Unsure? Have a question? Request a review!
