### PR TITLE
Update actions/checkout

### DIFF
--- a/.github/workflows/build-gem.yml
+++ b/.github/workflows/build-gem.yml
@@ -27,7 +27,7 @@ jobs:
     name: Build gem (${{ matrix.type }})
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
       - uses: ruby/setup-ruby@31a7f6d628878b80bc63375a93ae079ec50a1601 # v1.143.0
         with:
           ruby-version: '3.2'

--- a/.github/workflows/build-ruby.yml
+++ b/.github/workflows/build-ruby.yml
@@ -68,7 +68,7 @@ jobs:
     name: Build (${{ matrix.engine }} ${{ matrix.version }})
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       # Using docker-container engine enables advanced buildx features
       - name: Set up Docker container engine

--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -10,7 +10,7 @@ jobs:
     name: Check types
     runs-on: ubuntu-22.04
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - uses: ruby/setup-ruby@31a7f6d628878b80bc63375a93ae079ec50a1601 # v1.143.0
         with:
           ruby-version: '3.2'

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -25,7 +25,7 @@ jobs:
 
     steps:
     - name: Checkout repository
-      uses: actions/checkout@v3
+      uses: actions/checkout@v4
 
     # Initializes the CodeQL tools for scanning.
     - name: Initialize CodeQL

--- a/.github/workflows/lib-injection.yml
+++ b/.github/workflows/lib-injection.yml
@@ -7,7 +7,7 @@ jobs:
   build-and-publish-test-image:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - name: Set up QEMU
         uses: docker/setup-qemu-action@v2
       - name: Set up Docker Buildx
@@ -68,9 +68,9 @@ jobs:
           - dd-lib-ruby-init-test-rails-bundle-deploy
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
       - name: Checkout system-tests
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           repository: DataDog/system-tests
           path: system-tests

--- a/.github/workflows/release-lib-injection.yml
+++ b/.github/workflows/release-lib-injection.yml
@@ -9,7 +9,7 @@ jobs:
   build-and-publish-release-image:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - name: Set version
         id: version
         run: echo "version=${GITHUB_REF#refs/*/}" >> $GITHUB_OUTPUT

--- a/.github/workflows/semgrep.yml
+++ b/.github/workflows/semgrep.yml
@@ -18,7 +18,7 @@ jobs:
       image: returntocorp/semgrep
 
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - run: |
           semgrep ci \
           --include=bin/* --include=ext/* --include=lib/* \

--- a/.github/workflows/system-tests.yml
+++ b/.github/workflows/system-tests.yml
@@ -22,7 +22,7 @@ jobs:
     name: Build (${{ matrix.image }})
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           repository: 'DataDog/system-tests'
       - name: Pull released image
@@ -79,11 +79,11 @@ jobs:
     name: Build (${{ matrix.app }})
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           repository: 'DataDog/system-tests'
       - name: Checkout dd-trace-rb
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           path: 'binaries/dd-trace-rb'
       - name: Pull released image
@@ -202,7 +202,7 @@ jobs:
         with:
           python-version: '3.9'
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           repository: 'DataDog/system-tests'
       - name: Pull agent image
@@ -274,7 +274,7 @@ jobs:
         with:
           python-version: '3.9'
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           repository: 'DataDog/system-tests'
       - name: Retrieve logs

--- a/.github/workflows/test-head.yaml
+++ b/.github/workflows/test-head.yaml
@@ -13,7 +13,7 @@ jobs:
       DD_INSTRUMENTATION_TELEMETRY_ENABLED: false
       DD_REMOTE_CONFIGURATION_ENABLED: false
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       # bundler appears to match both prerelease and release rubies when we
       # want the former only. relax the constraint to allow any version for
       # head rubies

--- a/.github/workflows/test-macos.yaml
+++ b/.github/workflows/test-macos.yaml
@@ -32,7 +32,7 @@ jobs:
       DD_INSTRUMENTATION_TELEMETRY_ENABLED: false
       DD_REMOTE_CONFIGURATION_ENABLED: false
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       # bundler appears to match both prerelease and release rubies when we
       # want the former only. relax the constraint to allow any version for
       # head rubies

--- a/.github/workflows/test-yjit.yaml
+++ b/.github/workflows/test-yjit.yaml
@@ -18,7 +18,7 @@ jobs:
       DD_INSTRUMENTATION_TELEMETRY_ENABLED: false
       DD_REMOTE_CONFIGURATION_ENABLED: false
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       # bundler appears to match both prerelease and release rubies when we
       # want the former only. relax the constraint to allow any version for
       # head rubies

--- a/.github/workflows/yard.yml
+++ b/.github/workflows/yard.yml
@@ -27,7 +27,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
       - uses: ruby/setup-ruby@v1
         with:
           ruby-version: '3.2'


### PR DESCRIPTION
<!--
Check out the
https://github.com/DataDog/dd-trace-rb/blob/master/docs/DevelopmentGuide.md
for guidance on how to set up your development environment,
run the test suite, write new integrations, and more.
-->

**What does this PR do?**
* Update actions/checkout

**Motivation:**
actions/checkout v3 is using Node.js 16, which has reached its End of Life (EOL).

**Additional Notes:**
* https://github.com/actions/checkout/blob/main/CHANGELOG.md
* https://nodejs.dev/en/about/releases/
