### PR TITLE
Add simple task to update rules to a specific version

### DIFF
--- a/tasks/appsec.rake
+++ b/tasks/appsec.rake
@@ -1,0 +1,16 @@
+namespace :appsec do
+  namespace :ruleset do
+    task :update do |_task, args|
+      require 'uri'
+      require 'net/http'
+
+      version = args.to_a[0]
+
+      ['recommended', 'strict'].each do |ruleset|
+        uri = URI("https://raw.githubusercontent.com/DataDog/appsec-event-rules/#{version}/build/#{ruleset}.json")
+
+        File.open("lib/datadog/appsec/assets/waf_rules/#{ruleset}.json", 'wb') { |f| f << Net::HTTP::get(uri) }
+      end
+    end
+  end
+end


### PR DESCRIPTION
<!--
Check out the
https://github.com/DataDog/dd-trace-rb/blob/master/docs/DevelopmentGuide.md
for guidance on how to set up your development environment,
run the test suite, write new integrations, and more.
-->

**What does this PR do?**

Add simple task to update rules to a specific version

**Motivation:**

It's cumbersome and error prone to do it manually.

**Additional Notes:**

Usage is:

    rake appsec:ruleset:update[x.y.z]

Possible future improvements:

- without argument, download the last released version (not `master`)
- run the above automatically in CI and check if there's a git diff and be warned that there is
- automatically open a PR with everything ready for review

**How to test the change?**

Try the above!

**For Datadog employees:**
- [ ] If this PR touches code that signs or publishes builds or packages, or handles
credentials of any kind, I've requested a review from `@DataDog/security-design-and-guidance`.
- [x] This PR doesn't touch any of that.

Unsure? Have a question? Request a review!
