### PR TITLE
Add Docs team as code owners for single sourced docs 

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,5 @@
 * @DataDog/apm-ruby
+
+# Public Documentation
+/docs/Compatibility.md @DataDog/documentation
+/docs/GettingStarted.md @DataDog/documentation


### PR DESCRIPTION
<!--
Check out the
https://github.com/DataDog/dd-trace-rb/blob/master/docs/DevelopmentGuide.md
for guidance on how to set up your development environment,
run the test suite, write new integrations, and more.
-->

**What does this PR do?**
<!-- A brief description of the change being made with this pull request. -->
Adds Documentation team as reviewers to single sourced docs files.

**Motivation:**
<!-- What inspired you to submit this pull request? -->
This is part of our process for all docs single sourced from other repos.

**Additional Notes:**
<!-- Anything else we should know when reviewing? -->
Once we work on restructuring the docs more, we should put the public docs, currently GettingStarted and Compatibility, into a new folder point the CODEOWNERS to that whole folder. We'll have to reformat a few links before we do this though. 

**How to test the change?**
<!--
Describe here how the change can be validated.
You are strongly encouraged to provide automated tests for this PR (unit or integration).
If this change cannot be feasibly tested, please explain why,
unless the change does not modify code (e.g. only modifies docs, comments).
-->

**For Datadog employees:**
- [ ] If this PR touches code that signs or publishes builds or packages, or handles
credentials of any kind, I've requested a review from `@DataDog/security-design-and-guidance`.
- [x] This PR doesn't touch any of that.

Unsure? Have a question? Request a review!
