### PR TITLE
Update macrobenchmarks

### DIFF
--- a/.gitlab/benchmarks.yml
+++ b/.gitlab/benchmarks.yml
@@ -11,28 +11,28 @@ variables:
   tags: ["runner:apm-k8s-same-cpu"]
   timeout: 1h
   rules:
+    - if: $CI_COMMIT_REF_NAME == "master"
+      when: always
     - if: $CI_PIPELINE_SOURCE == "schedule"
       when: always
     - when: manual
   # If you have a problem with Gitlab cache, see Troubleshooting section in Benchmarking Platform docs
   image: $GITLAB_BENCHMARKS_CI_IMAGE
   script:
-    - export ARTIFACTS_DIR="$(pwd)/reports" && (mkdir "${ARTIFACTS_DIR}" || :)
-    - export DD_API_KEY=$(aws ssm get-parameter --region us-east-1 --name ci.dd-trace-rb.dd_api_key --with-decryption --query "Parameter.Value" --out text)
-    - git clone --branch ruby/gitlab https://gitlab-ci-token:${CI_JOB_TOKEN}@gitlab.ddbuild.io/DataDog/benchmarking-platform /platform && cd /platform
-    - ./steps/capture-hardware-software-info.sh
-    - ./steps/run-benchmarks.sh
-    - "./steps/upload-results-to-s3.sh || :"
+    - git clone --branch ruby/gitlab https://gitlab-ci-token:${CI_JOB_TOKEN}@gitlab.ddbuild.io/DataDog/benchmarking-platform platform && cd platform
+    - bp-runner bp-runner.yml --debug
   artifacts:
-    name: "reports"
+    name: "artifacts"
+    when: always
     paths:
-      - reports/
+      - platform/artifacts/
     expire_in: 3 months
   variables:
-    FF_USE_LEGACY_KUBERNETES_EXECUTION_STRATEGY: "true" # Important tweak for stability of benchmarks
+    # Benchmark's env variables. Modify to tweak benchmark parameters.
+    DD_TRACE_DEBUG: "false"
+    DD_RUNTIME_METRICS_ENABLED: "true"
+
     DD_RELENV_DDTRACE_COMMIT_ID: $CI_COMMIT_SHORT_SHA
-    K6_RUN_ID_PREFIX: ci_rb
-    KUBERNETES_SERVICE_ACCOUNT_OVERWRITE: dd-trace-rb
 
     K6_OPTIONS_NORMAL_OPERATION_RATE: 30
     K6_OPTIONS_NORMAL_OPERATION_DURATION: 10m
@@ -45,6 +45,10 @@ variables:
     K6_OPTIONS_HIGH_LOAD_GRACEFUL_STOP: 30s
     K6_OPTIONS_HIGH_LOAD_PRE_ALLOCATED_VUS: 4
     K6_OPTIONS_HIGH_LOAD_MAX_VUS: 4
+
+    # Gitlab and BP specific env vars. Do not modify.
+    KUBERNETES_SERVICE_ACCOUNT_OVERWRITE: dd-trace-rb
+    FF_USE_LEGACY_KUBERNETES_EXECUTION_STRATEGY: "true"
 
   # Workaround: Currently we're not running the benchmarks on every PR, but GitHub still shows them as pending.
   # By marking the benchmarks as allow_failure, this should go away. (This workaround should be removed once the


### PR DESCRIPTION
**What does this PR do?**

1. Replace ben-runner with bp-runner.
2. Ensure job artifacts are uploaded even if job fails.
3. Run macrobenchmark on every merge commit in master branch.

**Motivation:**

We are replacing ben-runner with bp-runner to simplify maintenance. A lot of glue code is now removed / became transparent in ruby/gitlab branch in benchmarking-platform repo.

**How to test the change?**

Trigger the macrobenchmark in Gitlab CI and see that it works correctly.

**For Datadog employees:**
- [ ] If this PR touches code that signs or publishes builds or packages, or handles
credentials of any kind, I've requested a review from `@DataDog/security-design-and-guidance`.
- [ ] This PR doesn't touch any of that.

Unsure? Have a question? Request a review!
