### PR TITLE
Detect Cucumber as a development environment

### DIFF
--- a/Steepfile
+++ b/Steepfile
@@ -652,6 +652,7 @@ target :ddtrace do
   library 'digest'
 
   repo_path 'vendor/rbs'
+  library 'cucumber'
   library 'ffi'
   library 'jruby'
   library 'gem'

--- a/lib/datadog/core/environment/execution.rb
+++ b/lib/datadog/core/environment/execution.rb
@@ -34,7 +34,7 @@ module Datadog
 
           # Is this process running a test?
           def test?
-            rspec? || minitest?
+            rspec? || minitest? || cucumber?
           end
 
           # Is this process running inside on a Read–eval–print loop?
@@ -64,6 +64,11 @@ module Datadog
               (defined?(::Minitest::Unit) &&
                 ::Minitest::Unit.class_variable_defined?(:@@installed_at_exit) &&
                 ::Minitest::Unit.class_variable_get(:@@installed_at_exit))
+          end
+
+          # Check if we are running from `bin/cucumber` or `cucumber/rake/task`.
+          def cucumber?
+            defined?(::Cucumber::Cli)
           end
 
           # If this is a Rails application, use different heuristics to detect

--- a/sig/datadog/core/environment/execution.rbs
+++ b/sig/datadog/core/environment/execution.rbs
@@ -5,6 +5,8 @@ module Datadog
         def self.development?: () -> bool
         def self.webmock_enabled?: () -> bool
 
+        def self.cucumber?: -> bool
+
         private
         def self.test?: () -> bool
         def self.repl?: () -> bool

--- a/spec/datadog/core/environment/execution_spec.rb
+++ b/spec/datadog/core/environment/execution_spec.rb
@@ -178,7 +178,7 @@ RSpec.describe Datadog::Core::Environment::Execution do
               # Add our script to `env.rb`, which is always run before any feature is executed.
               File.write('features/support/env.rb', repl_script)
 
-              _, err = Bundler.with_clean_env do # Ruby 2.6 does not have irb by default in a bundle, but has it outside of it.
+              _, err = Bundler.with_clean_env do
                 Open3.capture3('ruby', stdin_data: script)
               end
               expect(err).to include('ACTUAL:true')

--- a/spec/datadog/core/environment/execution_spec.rb
+++ b/spec/datadog/core/environment/execution_spec.rb
@@ -71,7 +71,7 @@ RSpec.describe Datadog::Core::Environment::Execution do
             f.close
 
             out, = Open3.capture2e('pry', '-f', '--noprompt', f.path)
-            expect(out).to eq('true')
+            expect(out).to eq('ACTUAL:true')
           end
         end
       end

--- a/vendor/rbs/cucumber/0/cucumber.rbs
+++ b/vendor/rbs/cucumber/0/cucumber.rbs
@@ -1,0 +1,4 @@
+module Cucumber
+  module Cli
+  end
+end


### PR DESCRIPTION
<!--
Check out the
https://github.com/DataDog/dd-trace-rb/blob/master/docs/DevelopmentGuide.md
for guidance on how to set up your development environment,
run the test suite, write new integrations, and more.
-->

**What does this PR do?**

Ensures [`cucumber`](https://github.com/cucumber/cucumber-ruby) test execution is considered a development environment for the host application.

**Motivation:**
<!-- What inspired you to submit this pull request? -->

We do not want production-tailored features to pollute developers' test environments.

We already detect RSpec and Minitest test runs and skip some of our production features. This PR adds Cucumber to the detection list.

**Additional Notes:**
<!-- Anything else we should know when reviewing? -->

**How to test the change?**
<!--
Describe here how the change can be validated.
You are strongly encouraged to provide automated tests for this PR (unit or integration).
If this change cannot be feasibly tested, please explain why,
unless the change does not modify code (e.g. only modifies docs, comments).
-->

There's an integration test in this PR.

**For Datadog employees:**
- [ ] If this PR touches code that signs or publishes builds or packages, or handles
credentials of any kind, I've requested a review from `@DataDog/security-design-and-guidance`.
- [ ] This PR doesn't touch any of that.

Unsure? Have a question? Request a review!
