### PR TITLE
Test:Remove explicit dependency on `addressable`

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -3,7 +3,6 @@ source 'https://rubygems.org'
 gemspec
 
 # Development dependencies
-gem 'addressable', '~> 2.4.0' # locking transitive dependency of webmock
 if RUBY_VERSION < '2.3'
   gem 'appraisal', '~> 2.2.0'
 else

--- a/gemfiles/jruby_9.2.21.0_aws.gemfile
+++ b/gemfiles/jruby_9.2.21.0_aws.gemfile
@@ -2,7 +2,6 @@
 
 source "https://rubygems.org"
 
-gem "addressable", "~> 2.4.0"
 gem "appraisal", "~> 2.4.0"
 gem "benchmark-ips", "~> 2.8"
 gem "benchmark-memory", "< 0.2"

--- a/gemfiles/jruby_9.2.21.0_aws.gemfile.lock
+++ b/gemfiles/jruby_9.2.21.0_aws.gemfile.lock
@@ -1534,7 +1534,6 @@ PLATFORMS
   universal-java-1.8
 
 DEPENDENCIES
-  addressable (~> 2.4.0)
   appraisal (~> 2.4.0)
   aws-sdk
   benchmark-ips (~> 2.8)

--- a/gemfiles/jruby_9.2.21.0_contrib.gemfile
+++ b/gemfiles/jruby_9.2.21.0_contrib.gemfile
@@ -2,7 +2,6 @@
 
 source "https://rubygems.org"
 
-gem "addressable", "~> 2.4.0"
 gem "appraisal", "~> 2.4.0"
 gem "benchmark-ips", "~> 2.8"
 gem "benchmark-memory", "< 0.2"

--- a/gemfiles/jruby_9.2.21.0_contrib.gemfile.lock
+++ b/gemfiles/jruby_9.2.21.0_contrib.gemfile.lock
@@ -273,7 +273,6 @@ DEPENDENCIES
   actionpack
   actionview
   active_model_serializers (>= 0.10.0)
-  addressable (~> 2.4.0)
   appraisal (~> 2.4.0)
   benchmark-ips (~> 2.8)
   benchmark-memory (< 0.2)

--- a/gemfiles/jruby_9.2.21.0_contrib_old.gemfile
+++ b/gemfiles/jruby_9.2.21.0_contrib_old.gemfile
@@ -2,7 +2,6 @@
 
 source "https://rubygems.org"
 
-gem "addressable", "~> 2.4.0"
 gem "appraisal", "~> 2.4.0"
 gem "benchmark-ips", "~> 2.8"
 gem "benchmark-memory", "< 0.2"

--- a/gemfiles/jruby_9.2.21.0_contrib_old.gemfile.lock
+++ b/gemfiles/jruby_9.2.21.0_contrib_old.gemfile.lock
@@ -133,7 +133,6 @@ PLATFORMS
   universal-java-1.8
 
 DEPENDENCIES
-  addressable (~> 2.4.0)
   appraisal (~> 2.4.0)
   benchmark-ips (~> 2.8)
   benchmark-memory (< 0.2)

--- a/gemfiles/jruby_9.2.21.0_core_old.gemfile
+++ b/gemfiles/jruby_9.2.21.0_core_old.gemfile
@@ -2,7 +2,6 @@
 
 source "https://rubygems.org"
 
-gem "addressable", "~> 2.4.0"
 gem "appraisal", "~> 2.4.0"
 gem "benchmark-ips", "~> 2.8"
 gem "benchmark-memory", "< 0.2"

--- a/gemfiles/jruby_9.2.21.0_core_old.gemfile.lock
+++ b/gemfiles/jruby_9.2.21.0_core_old.gemfile.lock
@@ -110,7 +110,6 @@ PLATFORMS
   universal-java-1.8
 
 DEPENDENCIES
-  addressable (~> 2.4.0)
   appraisal (~> 2.4.0)
   benchmark-ips (~> 2.8)
   benchmark-memory (< 0.2)

--- a/gemfiles/jruby_9.2.21.0_hanami_1.gemfile
+++ b/gemfiles/jruby_9.2.21.0_hanami_1.gemfile
@@ -2,7 +2,6 @@
 
 source "https://rubygems.org"
 
-gem "addressable", "~> 2.4.0"
 gem "appraisal", "~> 2.4.0"
 gem "benchmark-ips", "~> 2.8"
 gem "benchmark-memory", "< 0.2"

--- a/gemfiles/jruby_9.2.21.0_hanami_1.gemfile.lock
+++ b/gemfiles/jruby_9.2.21.0_hanami_1.gemfile.lock
@@ -214,7 +214,6 @@ PLATFORMS
   universal-java-1.8
 
 DEPENDENCIES
-  addressable (~> 2.4.0)
   appraisal (~> 2.4.0)
   benchmark-ips (~> 2.8)
   benchmark-memory (< 0.2)

--- a/gemfiles/jruby_9.2.21.0_http.gemfile
+++ b/gemfiles/jruby_9.2.21.0_http.gemfile
@@ -2,7 +2,6 @@
 
 source "https://rubygems.org"
 
-gem "addressable", "~> 2.4.0"
 gem "appraisal", "~> 2.4.0"
 gem "benchmark-ips", "~> 2.8"
 gem "benchmark-memory", "< 0.2"

--- a/gemfiles/jruby_9.2.21.0_http.gemfile.lock
+++ b/gemfiles/jruby_9.2.21.0_http.gemfile.lock
@@ -183,7 +183,6 @@ PLATFORMS
   universal-java-1.8
 
 DEPENDENCIES
-  addressable (~> 2.4.0)
   appraisal (~> 2.4.0)
   benchmark-ips (~> 2.8)
   benchmark-memory (< 0.2)

--- a/gemfiles/jruby_9.2.21.0_rails5_mysql2.gemfile
+++ b/gemfiles/jruby_9.2.21.0_rails5_mysql2.gemfile
@@ -2,7 +2,6 @@
 
 source "https://rubygems.org"
 
-gem "addressable", "~> 2.4.0"
 gem "appraisal", "~> 2.4.0"
 gem "benchmark-ips", "~> 2.8"
 gem "benchmark-memory", "< 0.2"

--- a/gemfiles/jruby_9.2.21.0_rails5_mysql2.gemfile.lock
+++ b/gemfiles/jruby_9.2.21.0_rails5_mysql2.gemfile.lock
@@ -224,7 +224,6 @@ PLATFORMS
 
 DEPENDENCIES
   activerecord-jdbcmysql-adapter
-  addressable (~> 2.4.0)
   appraisal (~> 2.4.0)
   benchmark-ips (~> 2.8)
   benchmark-memory (< 0.2)

--- a/gemfiles/jruby_9.2.21.0_rails5_postgres.gemfile
+++ b/gemfiles/jruby_9.2.21.0_rails5_postgres.gemfile
@@ -2,7 +2,6 @@
 
 source "https://rubygems.org"
 
-gem "addressable", "~> 2.4.0"
 gem "appraisal", "~> 2.4.0"
 gem "benchmark-ips", "~> 2.8"
 gem "benchmark-memory", "< 0.2"

--- a/gemfiles/jruby_9.2.21.0_rails5_postgres.gemfile.lock
+++ b/gemfiles/jruby_9.2.21.0_rails5_postgres.gemfile.lock
@@ -244,7 +244,6 @@ PLATFORMS
 
 DEPENDENCIES
   activerecord-jdbcpostgresql-adapter
-  addressable (~> 2.4.0)
   appraisal (~> 2.4.0)
   benchmark-ips (~> 2.8)
   benchmark-memory (< 0.2)

--- a/gemfiles/jruby_9.2.21.0_rails5_postgres_redis.gemfile
+++ b/gemfiles/jruby_9.2.21.0_rails5_postgres_redis.gemfile
@@ -2,7 +2,6 @@
 
 source "https://rubygems.org"
 
-gem "addressable", "~> 2.4.0"
 gem "appraisal", "~> 2.4.0"
 gem "benchmark-ips", "~> 2.8"
 gem "benchmark-memory", "< 0.2"

--- a/gemfiles/jruby_9.2.21.0_rails5_postgres_redis.gemfile.lock
+++ b/gemfiles/jruby_9.2.21.0_rails5_postgres_redis.gemfile.lock
@@ -249,7 +249,6 @@ PLATFORMS
 
 DEPENDENCIES
   activerecord-jdbcpostgresql-adapter
-  addressable (~> 2.4.0)
   appraisal (~> 2.4.0)
   benchmark-ips (~> 2.8)
   benchmark-memory (< 0.2)

--- a/gemfiles/jruby_9.2.21.0_rails5_postgres_redis_activesupport.gemfile
+++ b/gemfiles/jruby_9.2.21.0_rails5_postgres_redis_activesupport.gemfile
@@ -2,7 +2,6 @@
 
 source "https://rubygems.org"
 
-gem "addressable", "~> 2.4.0"
 gem "appraisal", "~> 2.4.0"
 gem "benchmark-ips", "~> 2.8"
 gem "benchmark-memory", "< 0.2"

--- a/gemfiles/jruby_9.2.21.0_rails5_postgres_redis_activesupport.gemfile.lock
+++ b/gemfiles/jruby_9.2.21.0_rails5_postgres_redis_activesupport.gemfile.lock
@@ -261,7 +261,6 @@ PLATFORMS
 
 DEPENDENCIES
   activerecord-jdbcpostgresql-adapter
-  addressable (~> 2.4.0)
   appraisal (~> 2.4.0)
   benchmark-ips (~> 2.8)
   benchmark-memory (< 0.2)

--- a/gemfiles/jruby_9.2.21.0_rails5_postgres_sidekiq.gemfile
+++ b/gemfiles/jruby_9.2.21.0_rails5_postgres_sidekiq.gemfile
@@ -2,7 +2,6 @@
 
 source "https://rubygems.org"
 
-gem "addressable", "~> 2.4.0"
 gem "appraisal", "~> 2.4.0"
 gem "benchmark-ips", "~> 2.8"
 gem "benchmark-memory", "< 0.2"

--- a/gemfiles/jruby_9.2.21.0_rails5_postgres_sidekiq.gemfile.lock
+++ b/gemfiles/jruby_9.2.21.0_rails5_postgres_sidekiq.gemfile.lock
@@ -251,7 +251,6 @@ PLATFORMS
 DEPENDENCIES
   activejob
   activerecord-jdbcpostgresql-adapter
-  addressable (~> 2.4.0)
   appraisal (~> 2.4.0)
   benchmark-ips (~> 2.8)
   benchmark-memory (< 0.2)

--- a/gemfiles/jruby_9.2.21.0_rails5_semantic_logger.gemfile
+++ b/gemfiles/jruby_9.2.21.0_rails5_semantic_logger.gemfile
@@ -2,7 +2,6 @@
 
 source "https://rubygems.org"
 
-gem "addressable", "~> 2.4.0"
 gem "appraisal", "~> 2.4.0"
 gem "benchmark-ips", "~> 2.8"
 gem "benchmark-memory", "< 0.2"

--- a/gemfiles/jruby_9.2.21.0_rails5_semantic_logger.gemfile.lock
+++ b/gemfiles/jruby_9.2.21.0_rails5_semantic_logger.gemfile.lock
@@ -243,7 +243,6 @@ PLATFORMS
 
 DEPENDENCIES
   activerecord-jdbcpostgresql-adapter
-  addressable (~> 2.4.0)
   appraisal (~> 2.4.0)
   benchmark-ips (~> 2.8)
   benchmark-memory (< 0.2)

--- a/gemfiles/jruby_9.2.21.0_rails61_mysql2.gemfile
+++ b/gemfiles/jruby_9.2.21.0_rails61_mysql2.gemfile
@@ -2,7 +2,6 @@
 
 source "https://rubygems.org"
 
-gem "addressable", "~> 2.4.0"
 gem "appraisal", "~> 2.4.0"
 gem "benchmark-ips", "~> 2.8"
 gem "benchmark-memory", "< 0.2"

--- a/gemfiles/jruby_9.2.21.0_rails61_mysql2.gemfile.lock
+++ b/gemfiles/jruby_9.2.21.0_rails61_mysql2.gemfile.lock
@@ -243,7 +243,6 @@ PLATFORMS
 
 DEPENDENCIES
   activerecord-jdbcmysql-adapter (>= 61)
-  addressable (~> 2.4.0)
   appraisal (~> 2.4.0)
   benchmark-ips (~> 2.8)
   benchmark-memory (< 0.2)

--- a/gemfiles/jruby_9.2.21.0_rails61_postgres.gemfile
+++ b/gemfiles/jruby_9.2.21.0_rails61_postgres.gemfile
@@ -2,7 +2,6 @@
 
 source "https://rubygems.org"
 
-gem "addressable", "~> 2.4.0"
 gem "appraisal", "~> 2.4.0"
 gem "benchmark-ips", "~> 2.8"
 gem "benchmark-memory", "< 0.2"

--- a/gemfiles/jruby_9.2.21.0_rails61_postgres.gemfile.lock
+++ b/gemfiles/jruby_9.2.21.0_rails61_postgres.gemfile.lock
@@ -263,7 +263,6 @@ PLATFORMS
 
 DEPENDENCIES
   activerecord-jdbcpostgresql-adapter (>= 61)
-  addressable (~> 2.4.0)
   appraisal (~> 2.4.0)
   benchmark-ips (~> 2.8)
   benchmark-memory (< 0.2)

--- a/gemfiles/jruby_9.2.21.0_rails61_postgres_redis.gemfile
+++ b/gemfiles/jruby_9.2.21.0_rails61_postgres_redis.gemfile
@@ -2,7 +2,6 @@
 
 source "https://rubygems.org"
 
-gem "addressable", "~> 2.4.0"
 gem "appraisal", "~> 2.4.0"
 gem "benchmark-ips", "~> 2.8"
 gem "benchmark-memory", "< 0.2"

--- a/gemfiles/jruby_9.2.21.0_rails61_postgres_redis.gemfile.lock
+++ b/gemfiles/jruby_9.2.21.0_rails61_postgres_redis.gemfile.lock
@@ -268,7 +268,6 @@ PLATFORMS
 
 DEPENDENCIES
   activerecord-jdbcpostgresql-adapter (>= 61)
-  addressable (~> 2.4.0)
   appraisal (~> 2.4.0)
   benchmark-ips (~> 2.8)
   benchmark-memory (< 0.2)

--- a/gemfiles/jruby_9.2.21.0_rails61_postgres_sidekiq.gemfile
+++ b/gemfiles/jruby_9.2.21.0_rails61_postgres_sidekiq.gemfile
@@ -2,7 +2,6 @@
 
 source "https://rubygems.org"
 
-gem "addressable", "~> 2.4.0"
 gem "appraisal", "~> 2.4.0"
 gem "benchmark-ips", "~> 2.8"
 gem "benchmark-memory", "< 0.2"

--- a/gemfiles/jruby_9.2.21.0_rails61_postgres_sidekiq.gemfile.lock
+++ b/gemfiles/jruby_9.2.21.0_rails61_postgres_sidekiq.gemfile.lock
@@ -269,7 +269,6 @@ PLATFORMS
 
 DEPENDENCIES
   activerecord-jdbcpostgresql-adapter (>= 61)
-  addressable (~> 2.4.0)
   appraisal (~> 2.4.0)
   benchmark-ips (~> 2.8)
   benchmark-memory (< 0.2)

--- a/gemfiles/jruby_9.2.21.0_rails61_semantic_logger.gemfile
+++ b/gemfiles/jruby_9.2.21.0_rails61_semantic_logger.gemfile
@@ -2,7 +2,6 @@
 
 source "https://rubygems.org"
 
-gem "addressable", "~> 2.4.0"
 gem "appraisal", "~> 2.4.0"
 gem "benchmark-ips", "~> 2.8"
 gem "benchmark-memory", "< 0.2"

--- a/gemfiles/jruby_9.2.21.0_rails61_semantic_logger.gemfile.lock
+++ b/gemfiles/jruby_9.2.21.0_rails61_semantic_logger.gemfile.lock
@@ -262,7 +262,6 @@ PLATFORMS
 
 DEPENDENCIES
   activerecord-jdbcpostgresql-adapter (>= 61)
-  addressable (~> 2.4.0)
   appraisal (~> 2.4.0)
   benchmark-ips (~> 2.8)
   benchmark-memory (< 0.2)

--- a/gemfiles/jruby_9.2.21.0_rails6_mysql2.gemfile
+++ b/gemfiles/jruby_9.2.21.0_rails6_mysql2.gemfile
@@ -2,7 +2,6 @@
 
 source "https://rubygems.org"
 
-gem "addressable", "~> 2.4.0"
 gem "appraisal", "~> 2.4.0"
 gem "benchmark-ips", "~> 2.8"
 gem "benchmark-memory", "< 0.2"

--- a/gemfiles/jruby_9.2.21.0_rails6_mysql2.gemfile.lock
+++ b/gemfiles/jruby_9.2.21.0_rails6_mysql2.gemfile.lock
@@ -240,7 +240,6 @@ PLATFORMS
 
 DEPENDENCIES
   activerecord-jdbcmysql-adapter (>= 60)
-  addressable (~> 2.4.0)
   appraisal (~> 2.4.0)
   benchmark-ips (~> 2.8)
   benchmark-memory (< 0.2)

--- a/gemfiles/jruby_9.2.21.0_rails6_postgres.gemfile
+++ b/gemfiles/jruby_9.2.21.0_rails6_postgres.gemfile
@@ -2,7 +2,6 @@
 
 source "https://rubygems.org"
 
-gem "addressable", "~> 2.4.0"
 gem "appraisal", "~> 2.4.0"
 gem "benchmark-ips", "~> 2.8"
 gem "benchmark-memory", "< 0.2"

--- a/gemfiles/jruby_9.2.21.0_rails6_postgres.gemfile.lock
+++ b/gemfiles/jruby_9.2.21.0_rails6_postgres.gemfile.lock
@@ -260,7 +260,6 @@ PLATFORMS
 
 DEPENDENCIES
   activerecord-jdbcpostgresql-adapter (>= 60)
-  addressable (~> 2.4.0)
   appraisal (~> 2.4.0)
   benchmark-ips (~> 2.8)
   benchmark-memory (< 0.2)

--- a/gemfiles/jruby_9.2.21.0_rails6_postgres_redis.gemfile
+++ b/gemfiles/jruby_9.2.21.0_rails6_postgres_redis.gemfile
@@ -2,7 +2,6 @@
 
 source "https://rubygems.org"
 
-gem "addressable", "~> 2.4.0"
 gem "appraisal", "~> 2.4.0"
 gem "benchmark-ips", "~> 2.8"
 gem "benchmark-memory", "< 0.2"

--- a/gemfiles/jruby_9.2.21.0_rails6_postgres_redis.gemfile.lock
+++ b/gemfiles/jruby_9.2.21.0_rails6_postgres_redis.gemfile.lock
@@ -265,7 +265,6 @@ PLATFORMS
 
 DEPENDENCIES
   activerecord-jdbcpostgresql-adapter (>= 60)
-  addressable (~> 2.4.0)
   appraisal (~> 2.4.0)
   benchmark-ips (~> 2.8)
   benchmark-memory (< 0.2)

--- a/gemfiles/jruby_9.2.21.0_rails6_postgres_redis_activesupport.gemfile
+++ b/gemfiles/jruby_9.2.21.0_rails6_postgres_redis_activesupport.gemfile
@@ -2,7 +2,6 @@
 
 source "https://rubygems.org"
 
-gem "addressable", "~> 2.4.0"
 gem "appraisal", "~> 2.4.0"
 gem "benchmark-ips", "~> 2.8"
 gem "benchmark-memory", "< 0.2"

--- a/gemfiles/jruby_9.2.21.0_rails6_postgres_redis_activesupport.gemfile.lock
+++ b/gemfiles/jruby_9.2.21.0_rails6_postgres_redis_activesupport.gemfile.lock
@@ -277,7 +277,6 @@ PLATFORMS
 
 DEPENDENCIES
   activerecord-jdbcpostgresql-adapter (>= 60)
-  addressable (~> 2.4.0)
   appraisal (~> 2.4.0)
   benchmark-ips (~> 2.8)
   benchmark-memory (< 0.2)

--- a/gemfiles/jruby_9.2.21.0_rails6_postgres_sidekiq.gemfile
+++ b/gemfiles/jruby_9.2.21.0_rails6_postgres_sidekiq.gemfile
@@ -2,7 +2,6 @@
 
 source "https://rubygems.org"
 
-gem "addressable", "~> 2.4.0"
 gem "appraisal", "~> 2.4.0"
 gem "benchmark-ips", "~> 2.8"
 gem "benchmark-memory", "< 0.2"

--- a/gemfiles/jruby_9.2.21.0_rails6_postgres_sidekiq.gemfile.lock
+++ b/gemfiles/jruby_9.2.21.0_rails6_postgres_sidekiq.gemfile.lock
@@ -267,7 +267,6 @@ PLATFORMS
 DEPENDENCIES
   activejob
   activerecord-jdbcpostgresql-adapter (>= 60)
-  addressable (~> 2.4.0)
   appraisal (~> 2.4.0)
   benchmark-ips (~> 2.8)
   benchmark-memory (< 0.2)

--- a/gemfiles/jruby_9.2.21.0_rails6_semantic_logger.gemfile
+++ b/gemfiles/jruby_9.2.21.0_rails6_semantic_logger.gemfile
@@ -2,7 +2,6 @@
 
 source "https://rubygems.org"
 
-gem "addressable", "~> 2.4.0"
 gem "appraisal", "~> 2.4.0"
 gem "benchmark-ips", "~> 2.8"
 gem "benchmark-memory", "< 0.2"

--- a/gemfiles/jruby_9.2.21.0_rails6_semantic_logger.gemfile.lock
+++ b/gemfiles/jruby_9.2.21.0_rails6_semantic_logger.gemfile.lock
@@ -259,7 +259,6 @@ PLATFORMS
 
 DEPENDENCIES
   activerecord-jdbcpostgresql-adapter (>= 60)
-  addressable (~> 2.4.0)
   appraisal (~> 2.4.0)
   benchmark-ips (~> 2.8)
   benchmark-memory (< 0.2)

--- a/gemfiles/jruby_9.2.21.0_redis_3.gemfile
+++ b/gemfiles/jruby_9.2.21.0_redis_3.gemfile
@@ -2,7 +2,6 @@
 
 source "https://rubygems.org"
 
-gem "addressable", "~> 2.4.0"
 gem "appraisal", "~> 2.4.0"
 gem "benchmark-ips", "~> 2.8"
 gem "benchmark-memory", "< 0.2"

--- a/gemfiles/jruby_9.2.21.0_redis_3.gemfile.lock
+++ b/gemfiles/jruby_9.2.21.0_redis_3.gemfile.lock
@@ -111,7 +111,6 @@ PLATFORMS
   universal-java-1.8
 
 DEPENDENCIES
-  addressable (~> 2.4.0)
   appraisal (~> 2.4.0)
   benchmark-ips (~> 2.8)
   benchmark-memory (< 0.2)

--- a/gemfiles/jruby_9.2.21.0_redis_4.gemfile
+++ b/gemfiles/jruby_9.2.21.0_redis_4.gemfile
@@ -2,7 +2,6 @@
 
 source "https://rubygems.org"
 
-gem "addressable", "~> 2.4.0"
 gem "appraisal", "~> 2.4.0"
 gem "benchmark-ips", "~> 2.8"
 gem "benchmark-memory", "< 0.2"

--- a/gemfiles/jruby_9.2.21.0_redis_4.gemfile.lock
+++ b/gemfiles/jruby_9.2.21.0_redis_4.gemfile.lock
@@ -111,7 +111,6 @@ PLATFORMS
   universal-java-1.8
 
 DEPENDENCIES
-  addressable (~> 2.4.0)
   appraisal (~> 2.4.0)
   benchmark-ips (~> 2.8)
   benchmark-memory (< 0.2)

--- a/gemfiles/jruby_9.2.21.0_redis_5.gemfile
+++ b/gemfiles/jruby_9.2.21.0_redis_5.gemfile
@@ -2,7 +2,6 @@
 
 source "https://rubygems.org"
 
-gem "addressable", "~> 2.4.0"
 gem "appraisal", "~> 2.4.0"
 gem "benchmark-ips", "~> 2.8"
 gem "benchmark-memory", "< 0.2"

--- a/gemfiles/jruby_9.2.21.0_redis_5.gemfile.lock
+++ b/gemfiles/jruby_9.2.21.0_redis_5.gemfile.lock
@@ -115,7 +115,6 @@ PLATFORMS
   universal-java-1.8
 
 DEPENDENCIES
-  addressable (~> 2.4.0)
   appraisal (~> 2.4.0)
   benchmark-ips (~> 2.8)
   benchmark-memory (< 0.2)

--- a/gemfiles/jruby_9.2.21.0_relational_db.gemfile
+++ b/gemfiles/jruby_9.2.21.0_relational_db.gemfile
@@ -2,7 +2,6 @@
 
 source "https://rubygems.org"
 
-gem "addressable", "~> 2.4.0"
 gem "appraisal", "~> 2.4.0"
 gem "benchmark-ips", "~> 2.8"
 gem "benchmark-memory", "< 0.2"

--- a/gemfiles/jruby_9.2.21.0_relational_db.gemfile.lock
+++ b/gemfiles/jruby_9.2.21.0_relational_db.gemfile.lock
@@ -152,7 +152,6 @@ DEPENDENCIES
   activerecord-jdbcmysql-adapter (>= 52)
   activerecord-jdbcpostgresql-adapter (>= 52)
   activerecord-jdbcsqlite3-adapter (>= 52)
-  addressable (~> 2.4.0)
   appraisal (~> 2.4.0)
   benchmark-ips (~> 2.8)
   benchmark-memory (< 0.2)

--- a/gemfiles/jruby_9.2.21.0_resque2_redis3.gemfile
+++ b/gemfiles/jruby_9.2.21.0_resque2_redis3.gemfile
@@ -2,7 +2,6 @@
 
 source "https://rubygems.org"
 
-gem "addressable", "~> 2.4.0"
 gem "appraisal", "~> 2.4.0"
 gem "benchmark-ips", "~> 2.8"
 gem "benchmark-memory", "< 0.2"

--- a/gemfiles/jruby_9.2.21.0_resque2_redis3.gemfile.lock
+++ b/gemfiles/jruby_9.2.21.0_resque2_redis3.gemfile.lock
@@ -132,7 +132,6 @@ PLATFORMS
   universal-java-1.8
 
 DEPENDENCIES
-  addressable (~> 2.4.0)
   appraisal (~> 2.4.0)
   benchmark-ips (~> 2.8)
   benchmark-memory (< 0.2)

--- a/gemfiles/jruby_9.2.21.0_resque2_redis4.gemfile
+++ b/gemfiles/jruby_9.2.21.0_resque2_redis4.gemfile
@@ -2,7 +2,6 @@
 
 source "https://rubygems.org"
 
-gem "addressable", "~> 2.4.0"
 gem "appraisal", "~> 2.4.0"
 gem "benchmark-ips", "~> 2.8"
 gem "benchmark-memory", "< 0.2"

--- a/gemfiles/jruby_9.2.21.0_resque2_redis4.gemfile.lock
+++ b/gemfiles/jruby_9.2.21.0_resque2_redis4.gemfile.lock
@@ -136,7 +136,6 @@ PLATFORMS
   universal-java-1.8
 
 DEPENDENCIES
-  addressable (~> 2.4.0)
   appraisal (~> 2.4.0)
   benchmark-ips (~> 2.8)
   benchmark-memory (< 0.2)

--- a/gemfiles/jruby_9.2.21.0_sinatra.gemfile
+++ b/gemfiles/jruby_9.2.21.0_sinatra.gemfile
@@ -2,7 +2,6 @@
 
 source "https://rubygems.org"
 
-gem "addressable", "~> 2.4.0"
 gem "appraisal", "~> 2.4.0"
 gem "benchmark-ips", "~> 2.8"
 gem "benchmark-memory", "< 0.2"

--- a/gemfiles/jruby_9.2.21.0_sinatra.gemfile.lock
+++ b/gemfiles/jruby_9.2.21.0_sinatra.gemfile.lock
@@ -124,7 +124,6 @@ PLATFORMS
   universal-java-1.8
 
 DEPENDENCIES
-  addressable (~> 2.4.0)
   appraisal (~> 2.4.0)
   benchmark-ips (~> 2.8)
   benchmark-memory (< 0.2)

--- a/gemfiles/jruby_9.3.9.0_aws.gemfile
+++ b/gemfiles/jruby_9.3.9.0_aws.gemfile
@@ -2,7 +2,6 @@
 
 source "https://rubygems.org"
 
-gem "addressable", "~> 2.4.0"
 gem "appraisal", "~> 2.4.0"
 gem "benchmark-ips", "~> 2.8"
 gem "benchmark-memory", "< 0.2"

--- a/gemfiles/jruby_9.3.9.0_aws.gemfile.lock
+++ b/gemfiles/jruby_9.3.9.0_aws.gemfile.lock
@@ -1564,7 +1564,6 @@ PLATFORMS
   universal-java-11
 
 DEPENDENCIES
-  addressable (~> 2.4.0)
   appraisal (~> 2.4.0)
   aws-sdk
   benchmark-ips (~> 2.8)

--- a/gemfiles/jruby_9.3.9.0_contrib.gemfile
+++ b/gemfiles/jruby_9.3.9.0_contrib.gemfile
@@ -2,7 +2,6 @@
 
 source "https://rubygems.org"
 
-gem "addressable", "~> 2.4.0"
 gem "appraisal", "~> 2.4.0"
 gem "benchmark-ips", "~> 2.8"
 gem "benchmark-memory", "< 0.2"

--- a/gemfiles/jruby_9.3.9.0_contrib.gemfile.lock
+++ b/gemfiles/jruby_9.3.9.0_contrib.gemfile.lock
@@ -302,7 +302,6 @@ DEPENDENCIES
   actionpack
   actionview
   active_model_serializers (>= 0.10.0)
-  addressable (~> 2.4.0)
   appraisal (~> 2.4.0)
   benchmark-ips (~> 2.8)
   benchmark-memory (< 0.2)

--- a/gemfiles/jruby_9.3.9.0_contrib_old.gemfile
+++ b/gemfiles/jruby_9.3.9.0_contrib_old.gemfile
@@ -2,7 +2,6 @@
 
 source "https://rubygems.org"
 
-gem "addressable", "~> 2.4.0"
 gem "appraisal", "~> 2.4.0"
 gem "benchmark-ips", "~> 2.8"
 gem "benchmark-memory", "< 0.2"

--- a/gemfiles/jruby_9.3.9.0_contrib_old.gemfile.lock
+++ b/gemfiles/jruby_9.3.9.0_contrib_old.gemfile.lock
@@ -161,7 +161,6 @@ PLATFORMS
   universal-java-11
 
 DEPENDENCIES
-  addressable (~> 2.4.0)
   appraisal (~> 2.4.0)
   benchmark-ips (~> 2.8)
   benchmark-memory (< 0.2)

--- a/gemfiles/jruby_9.3.9.0_core_old.gemfile
+++ b/gemfiles/jruby_9.3.9.0_core_old.gemfile
@@ -2,7 +2,6 @@
 
 source "https://rubygems.org"
 
-gem "addressable", "~> 2.4.0"
 gem "appraisal", "~> 2.4.0"
 gem "benchmark-ips", "~> 2.8"
 gem "benchmark-memory", "< 0.2"

--- a/gemfiles/jruby_9.3.9.0_core_old.gemfile.lock
+++ b/gemfiles/jruby_9.3.9.0_core_old.gemfile.lock
@@ -138,7 +138,6 @@ PLATFORMS
   universal-java-11
 
 DEPENDENCIES
-  addressable (~> 2.4.0)
   appraisal (~> 2.4.0)
   benchmark-ips (~> 2.8)
   benchmark-memory (< 0.2)

--- a/gemfiles/jruby_9.3.9.0_hanami_1.gemfile
+++ b/gemfiles/jruby_9.3.9.0_hanami_1.gemfile
@@ -2,7 +2,6 @@
 
 source "https://rubygems.org"
 
-gem "addressable", "~> 2.4.0"
 gem "appraisal", "~> 2.4.0"
 gem "benchmark-ips", "~> 2.8"
 gem "benchmark-memory", "< 0.2"

--- a/gemfiles/jruby_9.3.9.0_hanami_1.gemfile.lock
+++ b/gemfiles/jruby_9.3.9.0_hanami_1.gemfile.lock
@@ -236,7 +236,6 @@ PLATFORMS
   universal-java-11
 
 DEPENDENCIES
-  addressable (~> 2.4.0)
   appraisal (~> 2.4.0)
   benchmark-ips (~> 2.8)
   benchmark-memory (< 0.2)

--- a/gemfiles/jruby_9.3.9.0_http.gemfile
+++ b/gemfiles/jruby_9.3.9.0_http.gemfile
@@ -2,7 +2,6 @@
 
 source "https://rubygems.org"
 
-gem "addressable", "~> 2.4.0"
 gem "appraisal", "~> 2.4.0"
 gem "benchmark-ips", "~> 2.8"
 gem "benchmark-memory", "< 0.2"

--- a/gemfiles/jruby_9.3.9.0_http.gemfile.lock
+++ b/gemfiles/jruby_9.3.9.0_http.gemfile.lock
@@ -193,7 +193,6 @@ PLATFORMS
   universal-java-11
 
 DEPENDENCIES
-  addressable (~> 2.4.0)
   appraisal (~> 2.4.0)
   benchmark-ips (~> 2.8)
   benchmark-memory (< 0.2)

--- a/gemfiles/jruby_9.3.9.0_rails5_mysql2.gemfile
+++ b/gemfiles/jruby_9.3.9.0_rails5_mysql2.gemfile
@@ -2,7 +2,6 @@
 
 source "https://rubygems.org"
 
-gem "addressable", "~> 2.4.0"
 gem "appraisal", "~> 2.4.0"
 gem "benchmark-ips", "~> 2.8"
 gem "benchmark-memory", "< 0.2"

--- a/gemfiles/jruby_9.3.9.0_rails5_mysql2.gemfile.lock
+++ b/gemfiles/jruby_9.3.9.0_rails5_mysql2.gemfile.lock
@@ -266,7 +266,6 @@ PLATFORMS
 
 DEPENDENCIES
   activerecord-jdbcmysql-adapter
-  addressable (~> 2.4.0)
   appraisal (~> 2.4.0)
   benchmark-ips (~> 2.8)
   benchmark-memory (< 0.2)

--- a/gemfiles/jruby_9.3.9.0_rails5_postgres.gemfile
+++ b/gemfiles/jruby_9.3.9.0_rails5_postgres.gemfile
@@ -2,7 +2,6 @@
 
 source "https://rubygems.org"
 
-gem "addressable", "~> 2.4.0"
 gem "appraisal", "~> 2.4.0"
 gem "benchmark-ips", "~> 2.8"
 gem "benchmark-memory", "< 0.2"

--- a/gemfiles/jruby_9.3.9.0_rails5_postgres.gemfile.lock
+++ b/gemfiles/jruby_9.3.9.0_rails5_postgres.gemfile.lock
@@ -266,7 +266,6 @@ PLATFORMS
 
 DEPENDENCIES
   activerecord-jdbcpostgresql-adapter
-  addressable (~> 2.4.0)
   appraisal (~> 2.4.0)
   benchmark-ips (~> 2.8)
   benchmark-memory (< 0.2)

--- a/gemfiles/jruby_9.3.9.0_rails5_postgres_redis.gemfile
+++ b/gemfiles/jruby_9.3.9.0_rails5_postgres_redis.gemfile
@@ -2,7 +2,6 @@
 
 source "https://rubygems.org"
 
-gem "addressable", "~> 2.4.0"
 gem "appraisal", "~> 2.4.0"
 gem "benchmark-ips", "~> 2.8"
 gem "benchmark-memory", "< 0.2"

--- a/gemfiles/jruby_9.3.9.0_rails5_postgres_redis.gemfile.lock
+++ b/gemfiles/jruby_9.3.9.0_rails5_postgres_redis.gemfile.lock
@@ -267,7 +267,6 @@ PLATFORMS
 
 DEPENDENCIES
   activerecord-jdbcpostgresql-adapter
-  addressable (~> 2.4.0)
   appraisal (~> 2.4.0)
   benchmark-ips (~> 2.8)
   benchmark-memory (< 0.2)

--- a/gemfiles/jruby_9.3.9.0_rails5_postgres_redis_activesupport.gemfile
+++ b/gemfiles/jruby_9.3.9.0_rails5_postgres_redis_activesupport.gemfile
@@ -2,7 +2,6 @@
 
 source "https://rubygems.org"
 
-gem "addressable", "~> 2.4.0"
 gem "appraisal", "~> 2.4.0"
 gem "benchmark-ips", "~> 2.8"
 gem "benchmark-memory", "< 0.2"

--- a/gemfiles/jruby_9.3.9.0_rails5_postgres_redis_activesupport.gemfile.lock
+++ b/gemfiles/jruby_9.3.9.0_rails5_postgres_redis_activesupport.gemfile.lock
@@ -283,7 +283,6 @@ PLATFORMS
 
 DEPENDENCIES
   activerecord-jdbcpostgresql-adapter
-  addressable (~> 2.4.0)
   appraisal (~> 2.4.0)
   benchmark-ips (~> 2.8)
   benchmark-memory (< 0.2)

--- a/gemfiles/jruby_9.3.9.0_rails5_postgres_sidekiq.gemfile
+++ b/gemfiles/jruby_9.3.9.0_rails5_postgres_sidekiq.gemfile
@@ -2,7 +2,6 @@
 
 source "https://rubygems.org"
 
-gem "addressable", "~> 2.4.0"
 gem "appraisal", "~> 2.4.0"
 gem "benchmark-ips", "~> 2.8"
 gem "benchmark-memory", "< 0.2"

--- a/gemfiles/jruby_9.3.9.0_rails5_postgres_sidekiq.gemfile.lock
+++ b/gemfiles/jruby_9.3.9.0_rails5_postgres_sidekiq.gemfile.lock
@@ -273,7 +273,6 @@ PLATFORMS
 DEPENDENCIES
   activejob
   activerecord-jdbcpostgresql-adapter
-  addressable (~> 2.4.0)
   appraisal (~> 2.4.0)
   benchmark-ips (~> 2.8)
   benchmark-memory (< 0.2)

--- a/gemfiles/jruby_9.3.9.0_rails5_semantic_logger.gemfile
+++ b/gemfiles/jruby_9.3.9.0_rails5_semantic_logger.gemfile
@@ -2,7 +2,6 @@
 
 source "https://rubygems.org"
 
-gem "addressable", "~> 2.4.0"
 gem "appraisal", "~> 2.4.0"
 gem "benchmark-ips", "~> 2.8"
 gem "benchmark-memory", "< 0.2"

--- a/gemfiles/jruby_9.3.9.0_rails5_semantic_logger.gemfile.lock
+++ b/gemfiles/jruby_9.3.9.0_rails5_semantic_logger.gemfile.lock
@@ -265,7 +265,6 @@ PLATFORMS
 
 DEPENDENCIES
   activerecord-jdbcpostgresql-adapter
-  addressable (~> 2.4.0)
   appraisal (~> 2.4.0)
   benchmark-ips (~> 2.8)
   benchmark-memory (< 0.2)

--- a/gemfiles/jruby_9.3.9.0_rails61_mysql2.gemfile
+++ b/gemfiles/jruby_9.3.9.0_rails61_mysql2.gemfile
@@ -2,7 +2,6 @@
 
 source "https://rubygems.org"
 
-gem "addressable", "~> 2.4.0"
 gem "appraisal", "~> 2.4.0"
 gem "benchmark-ips", "~> 2.8"
 gem "benchmark-memory", "< 0.2"

--- a/gemfiles/jruby_9.3.9.0_rails61_mysql2.gemfile.lock
+++ b/gemfiles/jruby_9.3.9.0_rails61_mysql2.gemfile.lock
@@ -285,7 +285,6 @@ PLATFORMS
 
 DEPENDENCIES
   activerecord-jdbcmysql-adapter
-  addressable (~> 2.4.0)
   appraisal (~> 2.4.0)
   benchmark-ips (~> 2.8)
   benchmark-memory (< 0.2)

--- a/gemfiles/jruby_9.3.9.0_rails61_postgres.gemfile
+++ b/gemfiles/jruby_9.3.9.0_rails61_postgres.gemfile
@@ -2,7 +2,6 @@
 
 source "https://rubygems.org"
 
-gem "addressable", "~> 2.4.0"
 gem "appraisal", "~> 2.4.0"
 gem "benchmark-ips", "~> 2.8"
 gem "benchmark-memory", "< 0.2"

--- a/gemfiles/jruby_9.3.9.0_rails61_postgres.gemfile.lock
+++ b/gemfiles/jruby_9.3.9.0_rails61_postgres.gemfile.lock
@@ -285,7 +285,6 @@ PLATFORMS
 
 DEPENDENCIES
   activerecord-jdbcpostgresql-adapter
-  addressable (~> 2.4.0)
   appraisal (~> 2.4.0)
   benchmark-ips (~> 2.8)
   benchmark-memory (< 0.2)

--- a/gemfiles/jruby_9.3.9.0_rails61_postgres_redis.gemfile
+++ b/gemfiles/jruby_9.3.9.0_rails61_postgres_redis.gemfile
@@ -2,7 +2,6 @@
 
 source "https://rubygems.org"
 
-gem "addressable", "~> 2.4.0"
 gem "appraisal", "~> 2.4.0"
 gem "benchmark-ips", "~> 2.8"
 gem "benchmark-memory", "< 0.2"

--- a/gemfiles/jruby_9.3.9.0_rails61_postgres_redis.gemfile.lock
+++ b/gemfiles/jruby_9.3.9.0_rails61_postgres_redis.gemfile.lock
@@ -286,7 +286,6 @@ PLATFORMS
 
 DEPENDENCIES
   activerecord-jdbcpostgresql-adapter
-  addressable (~> 2.4.0)
   appraisal (~> 2.4.0)
   benchmark-ips (~> 2.8)
   benchmark-memory (< 0.2)

--- a/gemfiles/jruby_9.3.9.0_rails61_postgres_sidekiq.gemfile
+++ b/gemfiles/jruby_9.3.9.0_rails61_postgres_sidekiq.gemfile
@@ -2,7 +2,6 @@
 
 source "https://rubygems.org"
 
-gem "addressable", "~> 2.4.0"
 gem "appraisal", "~> 2.4.0"
 gem "benchmark-ips", "~> 2.8"
 gem "benchmark-memory", "< 0.2"

--- a/gemfiles/jruby_9.3.9.0_rails61_postgres_sidekiq.gemfile.lock
+++ b/gemfiles/jruby_9.3.9.0_rails61_postgres_sidekiq.gemfile.lock
@@ -291,7 +291,6 @@ PLATFORMS
 
 DEPENDENCIES
   activerecord-jdbcpostgresql-adapter
-  addressable (~> 2.4.0)
   appraisal (~> 2.4.0)
   benchmark-ips (~> 2.8)
   benchmark-memory (< 0.2)

--- a/gemfiles/jruby_9.3.9.0_rails61_semantic_logger.gemfile
+++ b/gemfiles/jruby_9.3.9.0_rails61_semantic_logger.gemfile
@@ -2,7 +2,6 @@
 
 source "https://rubygems.org"
 
-gem "addressable", "~> 2.4.0"
 gem "appraisal", "~> 2.4.0"
 gem "benchmark-ips", "~> 2.8"
 gem "benchmark-memory", "< 0.2"

--- a/gemfiles/jruby_9.3.9.0_rails61_semantic_logger.gemfile.lock
+++ b/gemfiles/jruby_9.3.9.0_rails61_semantic_logger.gemfile.lock
@@ -284,7 +284,6 @@ PLATFORMS
 
 DEPENDENCIES
   activerecord-jdbcpostgresql-adapter
-  addressable (~> 2.4.0)
   appraisal (~> 2.4.0)
   benchmark-ips (~> 2.8)
   benchmark-memory (< 0.2)

--- a/gemfiles/jruby_9.3.9.0_rails6_mysql2.gemfile
+++ b/gemfiles/jruby_9.3.9.0_rails6_mysql2.gemfile
@@ -2,7 +2,6 @@
 
 source "https://rubygems.org"
 
-gem "addressable", "~> 2.4.0"
 gem "appraisal", "~> 2.4.0"
 gem "benchmark-ips", "~> 2.8"
 gem "benchmark-memory", "< 0.2"

--- a/gemfiles/jruby_9.3.9.0_rails6_mysql2.gemfile.lock
+++ b/gemfiles/jruby_9.3.9.0_rails6_mysql2.gemfile.lock
@@ -282,7 +282,6 @@ PLATFORMS
 
 DEPENDENCIES
   activerecord-jdbcmysql-adapter
-  addressable (~> 2.4.0)
   appraisal (~> 2.4.0)
   benchmark-ips (~> 2.8)
   benchmark-memory (< 0.2)

--- a/gemfiles/jruby_9.3.9.0_rails6_postgres.gemfile
+++ b/gemfiles/jruby_9.3.9.0_rails6_postgres.gemfile
@@ -2,7 +2,6 @@
 
 source "https://rubygems.org"
 
-gem "addressable", "~> 2.4.0"
 gem "appraisal", "~> 2.4.0"
 gem "benchmark-ips", "~> 2.8"
 gem "benchmark-memory", "< 0.2"

--- a/gemfiles/jruby_9.3.9.0_rails6_postgres.gemfile.lock
+++ b/gemfiles/jruby_9.3.9.0_rails6_postgres.gemfile.lock
@@ -282,7 +282,6 @@ PLATFORMS
 
 DEPENDENCIES
   activerecord-jdbcpostgresql-adapter
-  addressable (~> 2.4.0)
   appraisal (~> 2.4.0)
   benchmark-ips (~> 2.8)
   benchmark-memory (< 0.2)

--- a/gemfiles/jruby_9.3.9.0_rails6_postgres_redis.gemfile
+++ b/gemfiles/jruby_9.3.9.0_rails6_postgres_redis.gemfile
@@ -2,7 +2,6 @@
 
 source "https://rubygems.org"
 
-gem "addressable", "~> 2.4.0"
 gem "appraisal", "~> 2.4.0"
 gem "benchmark-ips", "~> 2.8"
 gem "benchmark-memory", "< 0.2"

--- a/gemfiles/jruby_9.3.9.0_rails6_postgres_redis.gemfile.lock
+++ b/gemfiles/jruby_9.3.9.0_rails6_postgres_redis.gemfile.lock
@@ -283,7 +283,6 @@ PLATFORMS
 
 DEPENDENCIES
   activerecord-jdbcpostgresql-adapter
-  addressable (~> 2.4.0)
   appraisal (~> 2.4.0)
   benchmark-ips (~> 2.8)
   benchmark-memory (< 0.2)

--- a/gemfiles/jruby_9.3.9.0_rails6_postgres_redis_activesupport.gemfile
+++ b/gemfiles/jruby_9.3.9.0_rails6_postgres_redis_activesupport.gemfile
@@ -2,7 +2,6 @@
 
 source "https://rubygems.org"
 
-gem "addressable", "~> 2.4.0"
 gem "appraisal", "~> 2.4.0"
 gem "benchmark-ips", "~> 2.8"
 gem "benchmark-memory", "< 0.2"

--- a/gemfiles/jruby_9.3.9.0_rails6_postgres_redis_activesupport.gemfile.lock
+++ b/gemfiles/jruby_9.3.9.0_rails6_postgres_redis_activesupport.gemfile.lock
@@ -299,7 +299,6 @@ PLATFORMS
 
 DEPENDENCIES
   activerecord-jdbcpostgresql-adapter
-  addressable (~> 2.4.0)
   appraisal (~> 2.4.0)
   benchmark-ips (~> 2.8)
   benchmark-memory (< 0.2)

--- a/gemfiles/jruby_9.3.9.0_rails6_postgres_sidekiq.gemfile
+++ b/gemfiles/jruby_9.3.9.0_rails6_postgres_sidekiq.gemfile
@@ -2,7 +2,6 @@
 
 source "https://rubygems.org"
 
-gem "addressable", "~> 2.4.0"
 gem "appraisal", "~> 2.4.0"
 gem "benchmark-ips", "~> 2.8"
 gem "benchmark-memory", "< 0.2"

--- a/gemfiles/jruby_9.3.9.0_rails6_postgres_sidekiq.gemfile.lock
+++ b/gemfiles/jruby_9.3.9.0_rails6_postgres_sidekiq.gemfile.lock
@@ -289,7 +289,6 @@ PLATFORMS
 DEPENDENCIES
   activejob
   activerecord-jdbcpostgresql-adapter
-  addressable (~> 2.4.0)
   appraisal (~> 2.4.0)
   benchmark-ips (~> 2.8)
   benchmark-memory (< 0.2)

--- a/gemfiles/jruby_9.3.9.0_rails6_semantic_logger.gemfile
+++ b/gemfiles/jruby_9.3.9.0_rails6_semantic_logger.gemfile
@@ -2,7 +2,6 @@
 
 source "https://rubygems.org"
 
-gem "addressable", "~> 2.4.0"
 gem "appraisal", "~> 2.4.0"
 gem "benchmark-ips", "~> 2.8"
 gem "benchmark-memory", "< 0.2"

--- a/gemfiles/jruby_9.3.9.0_rails6_semantic_logger.gemfile.lock
+++ b/gemfiles/jruby_9.3.9.0_rails6_semantic_logger.gemfile.lock
@@ -281,7 +281,6 @@ PLATFORMS
 
 DEPENDENCIES
   activerecord-jdbcpostgresql-adapter
-  addressable (~> 2.4.0)
   appraisal (~> 2.4.0)
   benchmark-ips (~> 2.8)
   benchmark-memory (< 0.2)

--- a/gemfiles/jruby_9.3.9.0_redis_3.gemfile
+++ b/gemfiles/jruby_9.3.9.0_redis_3.gemfile
@@ -2,7 +2,6 @@
 
 source "https://rubygems.org"
 
-gem "addressable", "~> 2.4.0"
 gem "appraisal", "~> 2.4.0"
 gem "benchmark-ips", "~> 2.8"
 gem "benchmark-memory", "< 0.2"

--- a/gemfiles/jruby_9.3.9.0_redis_3.gemfile.lock
+++ b/gemfiles/jruby_9.3.9.0_redis_3.gemfile.lock
@@ -139,7 +139,6 @@ PLATFORMS
   universal-java-11
 
 DEPENDENCIES
-  addressable (~> 2.4.0)
   appraisal (~> 2.4.0)
   benchmark-ips (~> 2.8)
   benchmark-memory (< 0.2)

--- a/gemfiles/jruby_9.3.9.0_redis_4.gemfile
+++ b/gemfiles/jruby_9.3.9.0_redis_4.gemfile
@@ -2,7 +2,6 @@
 
 source "https://rubygems.org"
 
-gem "addressable", "~> 2.4.0"
 gem "appraisal", "~> 2.4.0"
 gem "benchmark-ips", "~> 2.8"
 gem "benchmark-memory", "< 0.2"

--- a/gemfiles/jruby_9.3.9.0_redis_4.gemfile.lock
+++ b/gemfiles/jruby_9.3.9.0_redis_4.gemfile.lock
@@ -139,7 +139,6 @@ PLATFORMS
   universal-java-11
 
 DEPENDENCIES
-  addressable (~> 2.4.0)
   appraisal (~> 2.4.0)
   benchmark-ips (~> 2.8)
   benchmark-memory (< 0.2)

--- a/gemfiles/jruby_9.3.9.0_redis_5.gemfile
+++ b/gemfiles/jruby_9.3.9.0_redis_5.gemfile
@@ -2,7 +2,6 @@
 
 source "https://rubygems.org"
 
-gem "addressable", "~> 2.4.0"
 gem "appraisal", "~> 2.4.0"
 gem "benchmark-ips", "~> 2.8"
 gem "benchmark-memory", "< 0.2"

--- a/gemfiles/jruby_9.3.9.0_redis_5.gemfile.lock
+++ b/gemfiles/jruby_9.3.9.0_redis_5.gemfile.lock
@@ -143,7 +143,6 @@ PLATFORMS
   universal-java-11
 
 DEPENDENCIES
-  addressable (~> 2.4.0)
   appraisal (~> 2.4.0)
   benchmark-ips (~> 2.8)
   benchmark-memory (< 0.2)

--- a/gemfiles/jruby_9.3.9.0_relational_db.gemfile
+++ b/gemfiles/jruby_9.3.9.0_relational_db.gemfile
@@ -2,7 +2,6 @@
 
 source "https://rubygems.org"
 
-gem "addressable", "~> 2.4.0"
 gem "appraisal", "~> 2.4.0"
 gem "benchmark-ips", "~> 2.8"
 gem "benchmark-memory", "< 0.2"

--- a/gemfiles/jruby_9.3.9.0_relational_db.gemfile.lock
+++ b/gemfiles/jruby_9.3.9.0_relational_db.gemfile.lock
@@ -178,7 +178,6 @@ DEPENDENCIES
   activerecord (~> 6.0.0)
   activerecord-jdbcmysql-adapter
   activerecord-jdbcpostgresql-adapter
-  addressable (~> 2.4.0)
   appraisal (~> 2.4.0)
   benchmark-ips (~> 2.8)
   benchmark-memory (< 0.2)

--- a/gemfiles/jruby_9.3.9.0_resque2_redis3.gemfile
+++ b/gemfiles/jruby_9.3.9.0_resque2_redis3.gemfile
@@ -2,7 +2,6 @@
 
 source "https://rubygems.org"
 
-gem "addressable", "~> 2.4.0"
 gem "appraisal", "~> 2.4.0"
 gem "benchmark-ips", "~> 2.8"
 gem "benchmark-memory", "< 0.2"

--- a/gemfiles/jruby_9.3.9.0_resque2_redis3.gemfile.lock
+++ b/gemfiles/jruby_9.3.9.0_resque2_redis3.gemfile.lock
@@ -160,7 +160,6 @@ PLATFORMS
   universal-java-11
 
 DEPENDENCIES
-  addressable (~> 2.4.0)
   appraisal (~> 2.4.0)
   benchmark-ips (~> 2.8)
   benchmark-memory (< 0.2)

--- a/gemfiles/jruby_9.3.9.0_resque2_redis4.gemfile
+++ b/gemfiles/jruby_9.3.9.0_resque2_redis4.gemfile
@@ -2,7 +2,6 @@
 
 source "https://rubygems.org"
 
-gem "addressable", "~> 2.4.0"
 gem "appraisal", "~> 2.4.0"
 gem "benchmark-ips", "~> 2.8"
 gem "benchmark-memory", "< 0.2"

--- a/gemfiles/jruby_9.3.9.0_resque2_redis4.gemfile.lock
+++ b/gemfiles/jruby_9.3.9.0_resque2_redis4.gemfile.lock
@@ -160,7 +160,6 @@ PLATFORMS
   universal-java-11
 
 DEPENDENCIES
-  addressable (~> 2.4.0)
   appraisal (~> 2.4.0)
   benchmark-ips (~> 2.8)
   benchmark-memory (< 0.2)

--- a/gemfiles/jruby_9.3.9.0_sinatra.gemfile
+++ b/gemfiles/jruby_9.3.9.0_sinatra.gemfile
@@ -2,7 +2,6 @@
 
 source "https://rubygems.org"
 
-gem "addressable", "~> 2.4.0"
 gem "appraisal", "~> 2.4.0"
 gem "benchmark-ips", "~> 2.8"
 gem "benchmark-memory", "< 0.2"

--- a/gemfiles/jruby_9.3.9.0_sinatra.gemfile.lock
+++ b/gemfiles/jruby_9.3.9.0_sinatra.gemfile.lock
@@ -152,7 +152,6 @@ PLATFORMS
   universal-java-11
 
 DEPENDENCIES
-  addressable (~> 2.4.0)
   appraisal (~> 2.4.0)
   benchmark-ips (~> 2.8)
   benchmark-memory (< 0.2)

--- a/gemfiles/jruby_9.4.0.0_aws.gemfile
+++ b/gemfiles/jruby_9.4.0.0_aws.gemfile
@@ -2,7 +2,6 @@
 
 source "https://rubygems.org"
 
-gem "addressable", "~> 2.4.0"
 gem "appraisal", "~> 2.4.0"
 gem "benchmark-ips", "~> 2.8"
 gem "benchmark-memory", "< 0.2"

--- a/gemfiles/jruby_9.4.0.0_aws.gemfile.lock
+++ b/gemfiles/jruby_9.4.0.0_aws.gemfile.lock
@@ -1565,7 +1565,6 @@ PLATFORMS
   universal-java-11
 
 DEPENDENCIES
-  addressable (~> 2.4.0)
   appraisal (~> 2.4.0)
   aws-sdk
   benchmark-ips (~> 2.8)

--- a/gemfiles/jruby_9.4.0.0_contrib.gemfile
+++ b/gemfiles/jruby_9.4.0.0_contrib.gemfile
@@ -2,7 +2,6 @@
 
 source "https://rubygems.org"
 
-gem "addressable", "~> 2.4.0"
 gem "appraisal", "~> 2.4.0"
 gem "benchmark-ips", "~> 2.8"
 gem "benchmark-memory", "< 0.2"

--- a/gemfiles/jruby_9.4.0.0_contrib.gemfile.lock
+++ b/gemfiles/jruby_9.4.0.0_contrib.gemfile.lock
@@ -305,7 +305,6 @@ DEPENDENCIES
   actionpack (~> 7)
   actionview (~> 7)
   active_model_serializers (>= 0.10.0)
-  addressable (~> 2.4.0)
   appraisal (~> 2.4.0)
   benchmark-ips (~> 2.8)
   benchmark-memory (< 0.2)

--- a/gemfiles/jruby_9.4.0.0_contrib_old.gemfile
+++ b/gemfiles/jruby_9.4.0.0_contrib_old.gemfile
@@ -2,7 +2,6 @@
 
 source "https://rubygems.org"
 
-gem "addressable", "~> 2.4.0"
 gem "appraisal", "~> 2.4.0"
 gem "benchmark-ips", "~> 2.8"
 gem "benchmark-memory", "< 0.2"

--- a/gemfiles/jruby_9.4.0.0_contrib_old.gemfile.lock
+++ b/gemfiles/jruby_9.4.0.0_contrib_old.gemfile.lock
@@ -161,7 +161,6 @@ PLATFORMS
   universal-java-11
 
 DEPENDENCIES
-  addressable (~> 2.4.0)
   appraisal (~> 2.4.0)
   benchmark-ips (~> 2.8)
   benchmark-memory (< 0.2)

--- a/gemfiles/jruby_9.4.0.0_core_old.gemfile
+++ b/gemfiles/jruby_9.4.0.0_core_old.gemfile
@@ -2,7 +2,6 @@
 
 source "https://rubygems.org"
 
-gem "addressable", "~> 2.4.0"
 gem "appraisal", "~> 2.4.0"
 gem "benchmark-ips", "~> 2.8"
 gem "benchmark-memory", "< 0.2"

--- a/gemfiles/jruby_9.4.0.0_core_old.gemfile.lock
+++ b/gemfiles/jruby_9.4.0.0_core_old.gemfile.lock
@@ -138,7 +138,6 @@ PLATFORMS
   universal-java-11
 
 DEPENDENCIES
-  addressable (~> 2.4.0)
   appraisal (~> 2.4.0)
   benchmark-ips (~> 2.8)
   benchmark-memory (< 0.2)

--- a/gemfiles/jruby_9.4.0.0_http.gemfile
+++ b/gemfiles/jruby_9.4.0.0_http.gemfile
@@ -2,7 +2,6 @@
 
 source "https://rubygems.org"
 
-gem "addressable", "~> 2.4.0"
 gem "appraisal", "~> 2.4.0"
 gem "benchmark-ips", "~> 2.8"
 gem "benchmark-memory", "< 0.2"

--- a/gemfiles/jruby_9.4.0.0_http.gemfile.lock
+++ b/gemfiles/jruby_9.4.0.0_http.gemfile.lock
@@ -194,7 +194,6 @@ PLATFORMS
   universal-java-11
 
 DEPENDENCIES
-  addressable (~> 2.4.0)
   appraisal (~> 2.4.0)
   benchmark-ips (~> 2.8)
   benchmark-memory (< 0.2)

--- a/gemfiles/jruby_9.4.0.0_rails61_mysql2.gemfile
+++ b/gemfiles/jruby_9.4.0.0_rails61_mysql2.gemfile
@@ -2,7 +2,6 @@
 
 source "https://rubygems.org"
 
-gem "addressable", "~> 2.4.0"
 gem "appraisal", "~> 2.4.0"
 gem "benchmark-ips", "~> 2.8"
 gem "benchmark-memory", "< 0.2"

--- a/gemfiles/jruby_9.4.0.0_rails61_mysql2.gemfile.lock
+++ b/gemfiles/jruby_9.4.0.0_rails61_mysql2.gemfile.lock
@@ -285,7 +285,6 @@ PLATFORMS
 
 DEPENDENCIES
   activerecord-jdbcmysql-adapter
-  addressable (~> 2.4.0)
   appraisal (~> 2.4.0)
   benchmark-ips (~> 2.8)
   benchmark-memory (< 0.2)

--- a/gemfiles/jruby_9.4.0.0_rails61_postgres.gemfile
+++ b/gemfiles/jruby_9.4.0.0_rails61_postgres.gemfile
@@ -2,7 +2,6 @@
 
 source "https://rubygems.org"
 
-gem "addressable", "~> 2.4.0"
 gem "appraisal", "~> 2.4.0"
 gem "benchmark-ips", "~> 2.8"
 gem "benchmark-memory", "< 0.2"

--- a/gemfiles/jruby_9.4.0.0_rails61_postgres.gemfile.lock
+++ b/gemfiles/jruby_9.4.0.0_rails61_postgres.gemfile.lock
@@ -285,7 +285,6 @@ PLATFORMS
 
 DEPENDENCIES
   activerecord-jdbcpostgresql-adapter
-  addressable (~> 2.4.0)
   appraisal (~> 2.4.0)
   benchmark-ips (~> 2.8)
   benchmark-memory (< 0.2)

--- a/gemfiles/jruby_9.4.0.0_rails61_postgres_redis.gemfile
+++ b/gemfiles/jruby_9.4.0.0_rails61_postgres_redis.gemfile
@@ -2,7 +2,6 @@
 
 source "https://rubygems.org"
 
-gem "addressable", "~> 2.4.0"
 gem "appraisal", "~> 2.4.0"
 gem "benchmark-ips", "~> 2.8"
 gem "benchmark-memory", "< 0.2"

--- a/gemfiles/jruby_9.4.0.0_rails61_postgres_redis.gemfile.lock
+++ b/gemfiles/jruby_9.4.0.0_rails61_postgres_redis.gemfile.lock
@@ -286,7 +286,6 @@ PLATFORMS
 
 DEPENDENCIES
   activerecord-jdbcpostgresql-adapter
-  addressable (~> 2.4.0)
   appraisal (~> 2.4.0)
   benchmark-ips (~> 2.8)
   benchmark-memory (< 0.2)

--- a/gemfiles/jruby_9.4.0.0_rails61_postgres_sidekiq.gemfile
+++ b/gemfiles/jruby_9.4.0.0_rails61_postgres_sidekiq.gemfile
@@ -2,7 +2,6 @@
 
 source "https://rubygems.org"
 
-gem "addressable", "~> 2.4.0"
 gem "appraisal", "~> 2.4.0"
 gem "benchmark-ips", "~> 2.8"
 gem "benchmark-memory", "< 0.2"

--- a/gemfiles/jruby_9.4.0.0_rails61_postgres_sidekiq.gemfile.lock
+++ b/gemfiles/jruby_9.4.0.0_rails61_postgres_sidekiq.gemfile.lock
@@ -299,7 +299,6 @@ PLATFORMS
 
 DEPENDENCIES
   activerecord-jdbcpostgresql-adapter
-  addressable (~> 2.4.0)
   appraisal (~> 2.4.0)
   benchmark-ips (~> 2.8)
   benchmark-memory (< 0.2)

--- a/gemfiles/jruby_9.4.0.0_rails61_semantic_logger.gemfile
+++ b/gemfiles/jruby_9.4.0.0_rails61_semantic_logger.gemfile
@@ -2,7 +2,6 @@
 
 source "https://rubygems.org"
 
-gem "addressable", "~> 2.4.0"
 gem "appraisal", "~> 2.4.0"
 gem "benchmark-ips", "~> 2.8"
 gem "benchmark-memory", "< 0.2"

--- a/gemfiles/jruby_9.4.0.0_rails61_semantic_logger.gemfile.lock
+++ b/gemfiles/jruby_9.4.0.0_rails61_semantic_logger.gemfile.lock
@@ -284,7 +284,6 @@ PLATFORMS
 
 DEPENDENCIES
   activerecord-jdbcpostgresql-adapter
-  addressable (~> 2.4.0)
   appraisal (~> 2.4.0)
   benchmark-ips (~> 2.8)
   benchmark-memory (< 0.2)

--- a/gemfiles/jruby_9.4.0.0_redis_3.gemfile
+++ b/gemfiles/jruby_9.4.0.0_redis_3.gemfile
@@ -2,7 +2,6 @@
 
 source "https://rubygems.org"
 
-gem "addressable", "~> 2.4.0"
 gem "appraisal", "~> 2.4.0"
 gem "benchmark-ips", "~> 2.8"
 gem "benchmark-memory", "< 0.2"

--- a/gemfiles/jruby_9.4.0.0_redis_3.gemfile.lock
+++ b/gemfiles/jruby_9.4.0.0_redis_3.gemfile.lock
@@ -139,7 +139,6 @@ PLATFORMS
   universal-java-11
 
 DEPENDENCIES
-  addressable (~> 2.4.0)
   appraisal (~> 2.4.0)
   benchmark-ips (~> 2.8)
   benchmark-memory (< 0.2)

--- a/gemfiles/jruby_9.4.0.0_redis_4.gemfile
+++ b/gemfiles/jruby_9.4.0.0_redis_4.gemfile
@@ -2,7 +2,6 @@
 
 source "https://rubygems.org"
 
-gem "addressable", "~> 2.4.0"
 gem "appraisal", "~> 2.4.0"
 gem "benchmark-ips", "~> 2.8"
 gem "benchmark-memory", "< 0.2"

--- a/gemfiles/jruby_9.4.0.0_redis_4.gemfile.lock
+++ b/gemfiles/jruby_9.4.0.0_redis_4.gemfile.lock
@@ -139,7 +139,6 @@ PLATFORMS
   universal-java-11
 
 DEPENDENCIES
-  addressable (~> 2.4.0)
   appraisal (~> 2.4.0)
   benchmark-ips (~> 2.8)
   benchmark-memory (< 0.2)

--- a/gemfiles/jruby_9.4.0.0_redis_5.gemfile
+++ b/gemfiles/jruby_9.4.0.0_redis_5.gemfile
@@ -2,7 +2,6 @@
 
 source "https://rubygems.org"
 
-gem "addressable", "~> 2.4.0"
 gem "appraisal", "~> 2.4.0"
 gem "benchmark-ips", "~> 2.8"
 gem "benchmark-memory", "< 0.2"

--- a/gemfiles/jruby_9.4.0.0_redis_5.gemfile.lock
+++ b/gemfiles/jruby_9.4.0.0_redis_5.gemfile.lock
@@ -143,7 +143,6 @@ PLATFORMS
   universal-java-11
 
 DEPENDENCIES
-  addressable (~> 2.4.0)
   appraisal (~> 2.4.0)
   benchmark-ips (~> 2.8)
   benchmark-memory (< 0.2)

--- a/gemfiles/jruby_9.4.0.0_relational_db.gemfile
+++ b/gemfiles/jruby_9.4.0.0_relational_db.gemfile
@@ -2,7 +2,6 @@
 
 source "https://rubygems.org"
 
-gem "addressable", "~> 2.4.0"
 gem "appraisal", "~> 2.4.0"
 gem "benchmark-ips", "~> 2.8"
 gem "benchmark-memory", "< 0.2"

--- a/gemfiles/jruby_9.4.0.0_relational_db.gemfile.lock
+++ b/gemfiles/jruby_9.4.0.0_relational_db.gemfile.lock
@@ -176,7 +176,6 @@ DEPENDENCIES
   activerecord (~> 7)
   activerecord-jdbcmysql-adapter
   activerecord-jdbcpostgresql-adapter
-  addressable (~> 2.4.0)
   appraisal (~> 2.4.0)
   benchmark-ips (~> 2.8)
   benchmark-memory (< 0.2)

--- a/gemfiles/jruby_9.4.0.0_resque2_redis3.gemfile
+++ b/gemfiles/jruby_9.4.0.0_resque2_redis3.gemfile
@@ -2,7 +2,6 @@
 
 source "https://rubygems.org"
 
-gem "addressable", "~> 2.4.0"
 gem "appraisal", "~> 2.4.0"
 gem "benchmark-ips", "~> 2.8"
 gem "benchmark-memory", "< 0.2"

--- a/gemfiles/jruby_9.4.0.0_resque2_redis3.gemfile.lock
+++ b/gemfiles/jruby_9.4.0.0_resque2_redis3.gemfile.lock
@@ -160,7 +160,6 @@ PLATFORMS
   universal-java-11
 
 DEPENDENCIES
-  addressable (~> 2.4.0)
   appraisal (~> 2.4.0)
   benchmark-ips (~> 2.8)
   benchmark-memory (< 0.2)

--- a/gemfiles/jruby_9.4.0.0_resque2_redis4.gemfile
+++ b/gemfiles/jruby_9.4.0.0_resque2_redis4.gemfile
@@ -2,7 +2,6 @@
 
 source "https://rubygems.org"
 
-gem "addressable", "~> 2.4.0"
 gem "appraisal", "~> 2.4.0"
 gem "benchmark-ips", "~> 2.8"
 gem "benchmark-memory", "< 0.2"

--- a/gemfiles/jruby_9.4.0.0_resque2_redis4.gemfile.lock
+++ b/gemfiles/jruby_9.4.0.0_resque2_redis4.gemfile.lock
@@ -164,7 +164,6 @@ PLATFORMS
   universal-java-11
 
 DEPENDENCIES
-  addressable (~> 2.4.0)
   appraisal (~> 2.4.0)
   benchmark-ips (~> 2.8)
   benchmark-memory (< 0.2)

--- a/gemfiles/jruby_9.4.0.0_sinatra.gemfile
+++ b/gemfiles/jruby_9.4.0.0_sinatra.gemfile
@@ -2,7 +2,6 @@
 
 source "https://rubygems.org"
 
-gem "addressable", "~> 2.4.0"
 gem "appraisal", "~> 2.4.0"
 gem "benchmark-ips", "~> 2.8"
 gem "benchmark-memory", "< 0.2"

--- a/gemfiles/jruby_9.4.0.0_sinatra.gemfile.lock
+++ b/gemfiles/jruby_9.4.0.0_sinatra.gemfile.lock
@@ -152,7 +152,6 @@ PLATFORMS
   universal-java-11
 
 DEPENDENCIES
-  addressable (~> 2.4.0)
   appraisal (~> 2.4.0)
   benchmark-ips (~> 2.8)
   benchmark-memory (< 0.2)

--- a/gemfiles/ruby_2.1.10_aws.gemfile
+++ b/gemfiles/ruby_2.1.10_aws.gemfile
@@ -2,7 +2,6 @@
 
 source "https://rubygems.org"
 
-gem "addressable", "~> 2.4.0"
 gem "appraisal", "~> 2.2.0"
 gem "benchmark-ips", "~> 2.8"
 gem "benchmark-memory", "< 0.2"

--- a/gemfiles/ruby_2.1.10_aws.gemfile.lock
+++ b/gemfiles/ruby_2.1.10_aws.gemfile.lock
@@ -105,7 +105,6 @@ PLATFORMS
   x86_64-linux
 
 DEPENDENCIES
-  addressable (~> 2.4.0)
   appraisal (~> 2.2.0)
   aws-sdk (~> 2.0)
   benchmark-ips (~> 2.8)

--- a/gemfiles/ruby_2.1.10_contrib.gemfile
+++ b/gemfiles/ruby_2.1.10_contrib.gemfile
@@ -2,7 +2,6 @@
 
 source "https://rubygems.org"
 
-gem "addressable", "~> 2.4.0"
 gem "appraisal", "~> 2.2.0"
 gem "benchmark-ips", "~> 2.8"
 gem "benchmark-memory", "< 0.2"

--- a/gemfiles/ruby_2.1.10_contrib.gemfile.lock
+++ b/gemfiles/ruby_2.1.10_contrib.gemfile.lock
@@ -183,7 +183,6 @@ PLATFORMS
 
 DEPENDENCIES
   active_model_serializers (~> 0.9.0)
-  addressable (~> 2.4.0)
   appraisal (~> 2.2.0)
   benchmark-ips (~> 2.8)
   benchmark-memory (< 0.2)

--- a/gemfiles/ruby_2.1.10_core_old.gemfile
+++ b/gemfiles/ruby_2.1.10_core_old.gemfile
@@ -2,7 +2,6 @@
 
 source "https://rubygems.org"
 
-gem "addressable", "~> 2.4.0"
 gem "appraisal", "~> 2.2.0"
 gem "benchmark-ips", "~> 2.8"
 gem "benchmark-memory", "< 0.2"

--- a/gemfiles/ruby_2.1.10_core_old.gemfile.lock
+++ b/gemfiles/ruby_2.1.10_core_old.gemfile.lock
@@ -94,7 +94,6 @@ PLATFORMS
   x86_64-linux
 
 DEPENDENCIES
-  addressable (~> 2.4.0)
   appraisal (~> 2.2.0)
   benchmark-ips (~> 2.8)
   benchmark-memory (< 0.2)

--- a/gemfiles/ruby_2.1.10_http.gemfile
+++ b/gemfiles/ruby_2.1.10_http.gemfile
@@ -2,7 +2,6 @@
 
 source "https://rubygems.org"
 
-gem "addressable", "~> 2.4.0"
 gem "appraisal", "~> 2.2.0"
 gem "benchmark-ips", "~> 2.8"
 gem "benchmark-memory", "< 0.2"

--- a/gemfiles/ruby_2.1.10_http.gemfile.lock
+++ b/gemfiles/ruby_2.1.10_http.gemfile.lock
@@ -133,7 +133,6 @@ PLATFORMS
   ruby
 
 DEPENDENCIES
-  addressable (~> 2.4.0)
   appraisal (~> 2.2.0)
   benchmark-ips (~> 2.8)
   benchmark-memory (< 0.2)

--- a/gemfiles/ruby_2.1.10_rails32_mysql2.gemfile
+++ b/gemfiles/ruby_2.1.10_rails32_mysql2.gemfile
@@ -2,7 +2,6 @@
 
 source "https://rubygems.org"
 
-gem "addressable", "~> 2.4.0"
 gem "appraisal", "~> 2.2.0"
 gem "benchmark-ips", "~> 2.8"
 gem "benchmark-memory", "< 0.2"

--- a/gemfiles/ruby_2.1.10_rails32_mysql2.gemfile.lock
+++ b/gemfiles/ruby_2.1.10_rails32_mysql2.gemfile.lock
@@ -179,7 +179,6 @@ PLATFORMS
 
 DEPENDENCIES
   activerecord-mysql-adapter
-  addressable (~> 2.4.0)
   appraisal (~> 2.2.0)
   benchmark-ips (~> 2.8)
   benchmark-memory (< 0.2)

--- a/gemfiles/ruby_2.1.10_rails32_postgres.gemfile
+++ b/gemfiles/ruby_2.1.10_rails32_postgres.gemfile
@@ -2,7 +2,6 @@
 
 source "https://rubygems.org"
 
-gem "addressable", "~> 2.4.0"
 gem "appraisal", "~> 2.2.0"
 gem "benchmark-ips", "~> 2.8"
 gem "benchmark-memory", "< 0.2"

--- a/gemfiles/ruby_2.1.10_rails32_postgres.gemfile.lock
+++ b/gemfiles/ruby_2.1.10_rails32_postgres.gemfile.lock
@@ -170,7 +170,6 @@ PLATFORMS
   x86_64-linux
 
 DEPENDENCIES
-  addressable (~> 2.4.0)
   appraisal (~> 2.2.0)
   benchmark-ips (~> 2.8)
   benchmark-memory (< 0.2)

--- a/gemfiles/ruby_2.1.10_rails32_postgres_redis.gemfile
+++ b/gemfiles/ruby_2.1.10_rails32_postgres_redis.gemfile
@@ -2,7 +2,6 @@
 
 source "https://rubygems.org"
 
-gem "addressable", "~> 2.4.0"
 gem "appraisal", "~> 2.2.0"
 gem "benchmark-ips", "~> 2.8"
 gem "benchmark-memory", "< 0.2"

--- a/gemfiles/ruby_2.1.10_rails32_postgres_redis.gemfile.lock
+++ b/gemfiles/ruby_2.1.10_rails32_postgres_redis.gemfile.lock
@@ -187,7 +187,6 @@ PLATFORMS
   x86_64-linux
 
 DEPENDENCIES
-  addressable (~> 2.4.0)
   appraisal (~> 2.2.0)
   benchmark-ips (~> 2.8)
   benchmark-memory (< 0.2)

--- a/gemfiles/ruby_2.1.10_rails32_postgres_sidekiq.gemfile
+++ b/gemfiles/ruby_2.1.10_rails32_postgres_sidekiq.gemfile
@@ -2,7 +2,6 @@
 
 source "https://rubygems.org"
 
-gem "addressable", "~> 2.4.0"
 gem "appraisal", "~> 2.2.0"
 gem "benchmark-ips", "~> 2.8"
 gem "benchmark-memory", "< 0.2"

--- a/gemfiles/ruby_2.1.10_rails32_postgres_sidekiq.gemfile.lock
+++ b/gemfiles/ruby_2.1.10_rails32_postgres_sidekiq.gemfile.lock
@@ -178,7 +178,6 @@ PLATFORMS
   x86_64-linux
 
 DEPENDENCIES
-  addressable (~> 2.4.0)
   appraisal (~> 2.2.0)
   benchmark-ips (~> 2.8)
   benchmark-memory (< 0.2)

--- a/gemfiles/ruby_2.1.10_rails4_mysql2.gemfile
+++ b/gemfiles/ruby_2.1.10_rails4_mysql2.gemfile
@@ -2,7 +2,6 @@
 
 source "https://rubygems.org"
 
-gem "addressable", "~> 2.4.0"
 gem "appraisal", "~> 2.2.0"
 gem "benchmark-ips", "~> 2.8"
 gem "benchmark-memory", "< 0.2"

--- a/gemfiles/ruby_2.1.10_rails4_mysql2.gemfile.lock
+++ b/gemfiles/ruby_2.1.10_rails4_mysql2.gemfile.lock
@@ -190,7 +190,6 @@ PLATFORMS
   x86_64-linux
 
 DEPENDENCIES
-  addressable (~> 2.4.0)
   appraisal (~> 2.2.0)
   benchmark-ips (~> 2.8)
   benchmark-memory (< 0.2)

--- a/gemfiles/ruby_2.1.10_rails4_postgres.gemfile
+++ b/gemfiles/ruby_2.1.10_rails4_postgres.gemfile
@@ -2,7 +2,6 @@
 
 source "https://rubygems.org"
 
-gem "addressable", "~> 2.4.0"
 gem "appraisal", "~> 2.2.0"
 gem "benchmark-ips", "~> 2.8"
 gem "benchmark-memory", "< 0.2"

--- a/gemfiles/ruby_2.1.10_rails4_postgres.gemfile.lock
+++ b/gemfiles/ruby_2.1.10_rails4_postgres.gemfile.lock
@@ -190,7 +190,6 @@ PLATFORMS
   x86_64-linux
 
 DEPENDENCIES
-  addressable (~> 2.4.0)
   appraisal (~> 2.2.0)
   benchmark-ips (~> 2.8)
   benchmark-memory (< 0.2)

--- a/gemfiles/ruby_2.1.10_rails4_postgres_redis.gemfile
+++ b/gemfiles/ruby_2.1.10_rails4_postgres_redis.gemfile
@@ -2,7 +2,6 @@
 
 source "https://rubygems.org"
 
-gem "addressable", "~> 2.4.0"
 gem "appraisal", "~> 2.2.0"
 gem "benchmark-ips", "~> 2.8"
 gem "benchmark-memory", "< 0.2"

--- a/gemfiles/ruby_2.1.10_rails4_postgres_redis.gemfile.lock
+++ b/gemfiles/ruby_2.1.10_rails4_postgres_redis.gemfile.lock
@@ -207,7 +207,6 @@ PLATFORMS
   x86_64-linux
 
 DEPENDENCIES
-  addressable (~> 2.4.0)
   appraisal (~> 2.2.0)
   benchmark-ips (~> 2.8)
   benchmark-memory (< 0.2)

--- a/gemfiles/ruby_2.1.10_rails4_semantic_logger.gemfile
+++ b/gemfiles/ruby_2.1.10_rails4_semantic_logger.gemfile
@@ -2,7 +2,6 @@
 
 source "https://rubygems.org"
 
-gem "addressable", "~> 2.4.0"
 gem "appraisal", "~> 2.2.0"
 gem "benchmark-ips", "~> 2.8"
 gem "benchmark-memory", "< 0.2"

--- a/gemfiles/ruby_2.1.10_rails4_semantic_logger.gemfile.lock
+++ b/gemfiles/ruby_2.1.10_rails4_semantic_logger.gemfile.lock
@@ -188,7 +188,6 @@ PLATFORMS
   x86_64-linux
 
 DEPENDENCIES
-  addressable (~> 2.4.0)
   appraisal (~> 2.2.0)
   benchmark-ips (~> 2.8)
   benchmark-memory (< 0.2)

--- a/gemfiles/ruby_2.1.10_redis_3.gemfile
+++ b/gemfiles/ruby_2.1.10_redis_3.gemfile
@@ -2,7 +2,6 @@
 
 source "https://rubygems.org"
 
-gem "addressable", "~> 2.4.0"
 gem "appraisal", "~> 2.2.0"
 gem "benchmark-ips", "~> 2.8"
 gem "benchmark-memory", "< 0.2"

--- a/gemfiles/ruby_2.1.10_redis_3.gemfile.lock
+++ b/gemfiles/ruby_2.1.10_redis_3.gemfile.lock
@@ -95,7 +95,6 @@ PLATFORMS
   x86_64-linux
 
 DEPENDENCIES
-  addressable (~> 2.4.0)
   appraisal (~> 2.2.0)
   benchmark-ips (~> 2.8)
   benchmark-memory (< 0.2)

--- a/gemfiles/ruby_2.1.10_relational_db.gemfile
+++ b/gemfiles/ruby_2.1.10_relational_db.gemfile
@@ -2,7 +2,6 @@
 
 source "https://rubygems.org"
 
-gem "addressable", "~> 2.4.0"
 gem "appraisal", "~> 2.2.0"
 gem "benchmark-ips", "~> 2.8"
 gem "benchmark-memory", "< 0.2"

--- a/gemfiles/ruby_2.1.10_relational_db.gemfile.lock
+++ b/gemfiles/ruby_2.1.10_relational_db.gemfile.lock
@@ -125,7 +125,6 @@ PLATFORMS
 DEPENDENCIES
   activerecord (= 3.2.22.5)
   activerecord-mysql-adapter
-  addressable (~> 2.4.0)
   appraisal (~> 2.2.0)
   benchmark-ips (~> 2.8)
   benchmark-memory (< 0.2)

--- a/gemfiles/ruby_2.1.10_sinatra.gemfile
+++ b/gemfiles/ruby_2.1.10_sinatra.gemfile
@@ -2,7 +2,6 @@
 
 source "https://rubygems.org"
 
-gem "addressable", "~> 2.4.0"
 gem "appraisal", "~> 2.2.0"
 gem "benchmark-ips", "~> 2.8"
 gem "benchmark-memory", "< 0.2"

--- a/gemfiles/ruby_2.1.10_sinatra.gemfile.lock
+++ b/gemfiles/ruby_2.1.10_sinatra.gemfile.lock
@@ -104,7 +104,6 @@ PLATFORMS
   x86_64-linux
 
 DEPENDENCIES
-  addressable (~> 2.4.0)
   appraisal (~> 2.2.0)
   benchmark-ips (~> 2.8)
   benchmark-memory (< 0.2)

--- a/gemfiles/ruby_2.2.10_aws.gemfile
+++ b/gemfiles/ruby_2.2.10_aws.gemfile
@@ -2,7 +2,6 @@
 
 source "https://rubygems.org"
 
-gem "addressable", "~> 2.4.0"
 gem "appraisal", "~> 2.2.0"
 gem "benchmark-ips", "~> 2.8"
 gem "benchmark-memory", "< 0.2"

--- a/gemfiles/ruby_2.2.10_aws.gemfile.lock
+++ b/gemfiles/ruby_2.2.10_aws.gemfile.lock
@@ -1218,7 +1218,6 @@ PLATFORMS
   ruby
 
 DEPENDENCIES
-  addressable (~> 2.4.0)
   appraisal (~> 2.2.0)
   aws-sdk
   benchmark-ips (~> 2.8)

--- a/gemfiles/ruby_2.2.10_contrib.gemfile
+++ b/gemfiles/ruby_2.2.10_contrib.gemfile
@@ -2,7 +2,6 @@
 
 source "https://rubygems.org"
 
-gem "addressable", "~> 2.4.0"
 gem "appraisal", "~> 2.2.0"
 gem "benchmark-ips", "~> 2.8"
 gem "benchmark-memory", "< 0.2"

--- a/gemfiles/ruby_2.2.10_contrib.gemfile.lock
+++ b/gemfiles/ruby_2.2.10_contrib.gemfile.lock
@@ -265,7 +265,6 @@ DEPENDENCIES
   actionpack
   actionview
   active_model_serializers (>= 0.10.0)
-  addressable (~> 2.4.0)
   appraisal (~> 2.2.0)
   benchmark-ips (~> 2.8)
   benchmark-memory (< 0.2)

--- a/gemfiles/ruby_2.2.10_core_old.gemfile
+++ b/gemfiles/ruby_2.2.10_core_old.gemfile
@@ -2,7 +2,6 @@
 
 source "https://rubygems.org"
 
-gem "addressable", "~> 2.4.0"
 gem "appraisal", "~> 2.2.0"
 gem "benchmark-ips", "~> 2.8"
 gem "benchmark-memory", "< 0.2"

--- a/gemfiles/ruby_2.2.10_core_old.gemfile.lock
+++ b/gemfiles/ruby_2.2.10_core_old.gemfile.lock
@@ -94,7 +94,6 @@ PLATFORMS
   x86_64-linux
 
 DEPENDENCIES
-  addressable (~> 2.4.0)
   appraisal (~> 2.2.0)
   benchmark-ips (~> 2.8)
   benchmark-memory (< 0.2)

--- a/gemfiles/ruby_2.2.10_http.gemfile
+++ b/gemfiles/ruby_2.2.10_http.gemfile
@@ -2,7 +2,6 @@
 
 source "https://rubygems.org"
 
-gem "addressable", "~> 2.4.0"
 gem "appraisal", "~> 2.2.0"
 gem "benchmark-ips", "~> 2.8"
 gem "benchmark-memory", "< 0.2"

--- a/gemfiles/ruby_2.2.10_http.gemfile.lock
+++ b/gemfiles/ruby_2.2.10_http.gemfile.lock
@@ -133,7 +133,6 @@ PLATFORMS
   ruby
 
 DEPENDENCIES
-  addressable (~> 2.4.0)
   appraisal (~> 2.2.0)
   benchmark-ips (~> 2.8)
   benchmark-memory (< 0.2)

--- a/gemfiles/ruby_2.2.10_rails32_mysql2.gemfile
+++ b/gemfiles/ruby_2.2.10_rails32_mysql2.gemfile
@@ -2,7 +2,6 @@
 
 source "https://rubygems.org"
 
-gem "addressable", "~> 2.4.0"
 gem "appraisal", "~> 2.2.0"
 gem "benchmark-ips", "~> 2.8"
 gem "benchmark-memory", "< 0.2"

--- a/gemfiles/ruby_2.2.10_rails32_mysql2.gemfile.lock
+++ b/gemfiles/ruby_2.2.10_rails32_mysql2.gemfile.lock
@@ -177,7 +177,6 @@ PLATFORMS
 
 DEPENDENCIES
   activerecord-mysql-adapter
-  addressable (~> 2.4.0)
   appraisal (~> 2.2.0)
   benchmark-ips (~> 2.8)
   benchmark-memory (< 0.2)

--- a/gemfiles/ruby_2.2.10_rails32_postgres.gemfile
+++ b/gemfiles/ruby_2.2.10_rails32_postgres.gemfile
@@ -2,7 +2,6 @@
 
 source "https://rubygems.org"
 
-gem "addressable", "~> 2.4.0"
 gem "appraisal", "~> 2.2.0"
 gem "benchmark-ips", "~> 2.8"
 gem "benchmark-memory", "< 0.2"

--- a/gemfiles/ruby_2.2.10_rails32_postgres.gemfile.lock
+++ b/gemfiles/ruby_2.2.10_rails32_postgres.gemfile.lock
@@ -170,7 +170,6 @@ PLATFORMS
   x86_64-linux
 
 DEPENDENCIES
-  addressable (~> 2.4.0)
   appraisal (~> 2.2.0)
   benchmark-ips (~> 2.8)
   benchmark-memory (< 0.2)

--- a/gemfiles/ruby_2.2.10_rails32_postgres_redis.gemfile
+++ b/gemfiles/ruby_2.2.10_rails32_postgres_redis.gemfile
@@ -2,7 +2,6 @@
 
 source "https://rubygems.org"
 
-gem "addressable", "~> 2.4.0"
 gem "appraisal", "~> 2.2.0"
 gem "benchmark-ips", "~> 2.8"
 gem "benchmark-memory", "< 0.2"

--- a/gemfiles/ruby_2.2.10_rails32_postgres_redis.gemfile.lock
+++ b/gemfiles/ruby_2.2.10_rails32_postgres_redis.gemfile.lock
@@ -187,7 +187,6 @@ PLATFORMS
   x86_64-linux
 
 DEPENDENCIES
-  addressable (~> 2.4.0)
   appraisal (~> 2.2.0)
   benchmark-ips (~> 2.8)
   benchmark-memory (< 0.2)

--- a/gemfiles/ruby_2.2.10_rails32_postgres_sidekiq.gemfile
+++ b/gemfiles/ruby_2.2.10_rails32_postgres_sidekiq.gemfile
@@ -2,7 +2,6 @@
 
 source "https://rubygems.org"
 
-gem "addressable", "~> 2.4.0"
 gem "appraisal", "~> 2.2.0"
 gem "benchmark-ips", "~> 2.8"
 gem "benchmark-memory", "< 0.2"

--- a/gemfiles/ruby_2.2.10_rails32_postgres_sidekiq.gemfile.lock
+++ b/gemfiles/ruby_2.2.10_rails32_postgres_sidekiq.gemfile.lock
@@ -178,7 +178,6 @@ PLATFORMS
   x86_64-linux
 
 DEPENDENCIES
-  addressable (~> 2.4.0)
   appraisal (~> 2.2.0)
   benchmark-ips (~> 2.8)
   benchmark-memory (< 0.2)

--- a/gemfiles/ruby_2.2.10_rails4_mysql2.gemfile
+++ b/gemfiles/ruby_2.2.10_rails4_mysql2.gemfile
@@ -2,7 +2,6 @@
 
 source "https://rubygems.org"
 
-gem "addressable", "~> 2.4.0"
 gem "appraisal", "~> 2.2.0"
 gem "benchmark-ips", "~> 2.8"
 gem "benchmark-memory", "< 0.2"

--- a/gemfiles/ruby_2.2.10_rails4_mysql2.gemfile.lock
+++ b/gemfiles/ruby_2.2.10_rails4_mysql2.gemfile.lock
@@ -190,7 +190,6 @@ PLATFORMS
   x86_64-linux
 
 DEPENDENCIES
-  addressable (~> 2.4.0)
   appraisal (~> 2.2.0)
   benchmark-ips (~> 2.8)
   benchmark-memory (< 0.2)

--- a/gemfiles/ruby_2.2.10_rails4_postgres.gemfile
+++ b/gemfiles/ruby_2.2.10_rails4_postgres.gemfile
@@ -2,7 +2,6 @@
 
 source "https://rubygems.org"
 
-gem "addressable", "~> 2.4.0"
 gem "appraisal", "~> 2.2.0"
 gem "benchmark-ips", "~> 2.8"
 gem "benchmark-memory", "< 0.2"

--- a/gemfiles/ruby_2.2.10_rails4_postgres.gemfile.lock
+++ b/gemfiles/ruby_2.2.10_rails4_postgres.gemfile.lock
@@ -190,7 +190,6 @@ PLATFORMS
   x86_64-linux
 
 DEPENDENCIES
-  addressable (~> 2.4.0)
   appraisal (~> 2.2.0)
   benchmark-ips (~> 2.8)
   benchmark-memory (< 0.2)

--- a/gemfiles/ruby_2.2.10_rails4_postgres_redis.gemfile
+++ b/gemfiles/ruby_2.2.10_rails4_postgres_redis.gemfile
@@ -2,7 +2,6 @@
 
 source "https://rubygems.org"
 
-gem "addressable", "~> 2.4.0"
 gem "appraisal", "~> 2.2.0"
 gem "benchmark-ips", "~> 2.8"
 gem "benchmark-memory", "< 0.2"

--- a/gemfiles/ruby_2.2.10_rails4_postgres_redis.gemfile.lock
+++ b/gemfiles/ruby_2.2.10_rails4_postgres_redis.gemfile.lock
@@ -207,7 +207,6 @@ PLATFORMS
   x86_64-linux
 
 DEPENDENCIES
-  addressable (~> 2.4.0)
   appraisal (~> 2.2.0)
   benchmark-ips (~> 2.8)
   benchmark-memory (< 0.2)

--- a/gemfiles/ruby_2.2.10_rails4_postgres_sidekiq.gemfile
+++ b/gemfiles/ruby_2.2.10_rails4_postgres_sidekiq.gemfile
@@ -2,7 +2,6 @@
 
 source "https://rubygems.org"
 
-gem "addressable", "~> 2.4.0"
 gem "appraisal", "~> 2.2.0"
 gem "benchmark-ips", "~> 2.8"
 gem "benchmark-memory", "< 0.2"

--- a/gemfiles/ruby_2.2.10_rails4_postgres_sidekiq.gemfile.lock
+++ b/gemfiles/ruby_2.2.10_rails4_postgres_sidekiq.gemfile.lock
@@ -200,7 +200,6 @@ PLATFORMS
 
 DEPENDENCIES
   activejob
-  addressable (~> 2.4.0)
   appraisal (~> 2.2.0)
   benchmark-ips (~> 2.8)
   benchmark-memory (< 0.2)

--- a/gemfiles/ruby_2.2.10_rails4_semantic_logger.gemfile
+++ b/gemfiles/ruby_2.2.10_rails4_semantic_logger.gemfile
@@ -2,7 +2,6 @@
 
 source "https://rubygems.org"
 
-gem "addressable", "~> 2.4.0"
 gem "appraisal", "~> 2.2.0"
 gem "benchmark-ips", "~> 2.8"
 gem "benchmark-memory", "< 0.2"

--- a/gemfiles/ruby_2.2.10_rails4_semantic_logger.gemfile.lock
+++ b/gemfiles/ruby_2.2.10_rails4_semantic_logger.gemfile.lock
@@ -188,7 +188,6 @@ PLATFORMS
   x86_64-linux
 
 DEPENDENCIES
-  addressable (~> 2.4.0)
   appraisal (~> 2.2.0)
   benchmark-ips (~> 2.8)
   benchmark-memory (< 0.2)

--- a/gemfiles/ruby_2.2.10_rails5_mysql2.gemfile
+++ b/gemfiles/ruby_2.2.10_rails5_mysql2.gemfile
@@ -2,7 +2,6 @@
 
 source "https://rubygems.org"
 
-gem "addressable", "~> 2.4.0"
 gem "appraisal", "~> 2.2.0"
 gem "benchmark-ips", "~> 2.8"
 gem "benchmark-memory", "< 0.2"

--- a/gemfiles/ruby_2.2.10_rails5_mysql2.gemfile.lock
+++ b/gemfiles/ruby_2.2.10_rails5_mysql2.gemfile.lock
@@ -206,7 +206,6 @@ PLATFORMS
   x86_64-linux
 
 DEPENDENCIES
-  addressable (~> 2.4.0)
   appraisal (~> 2.2.0)
   benchmark-ips (~> 2.8)
   benchmark-memory (< 0.2)

--- a/gemfiles/ruby_2.2.10_rails5_postgres.gemfile
+++ b/gemfiles/ruby_2.2.10_rails5_postgres.gemfile
@@ -2,7 +2,6 @@
 
 source "https://rubygems.org"
 
-gem "addressable", "~> 2.4.0"
 gem "appraisal", "~> 2.2.0"
 gem "benchmark-ips", "~> 2.8"
 gem "benchmark-memory", "< 0.2"

--- a/gemfiles/ruby_2.2.10_rails5_postgres.gemfile.lock
+++ b/gemfiles/ruby_2.2.10_rails5_postgres.gemfile.lock
@@ -206,7 +206,6 @@ PLATFORMS
   x86_64-linux
 
 DEPENDENCIES
-  addressable (~> 2.4.0)
   appraisal (~> 2.2.0)
   benchmark-ips (~> 2.8)
   benchmark-memory (< 0.2)

--- a/gemfiles/ruby_2.2.10_rails5_postgres_redis.gemfile
+++ b/gemfiles/ruby_2.2.10_rails5_postgres_redis.gemfile
@@ -2,7 +2,6 @@
 
 source "https://rubygems.org"
 
-gem "addressable", "~> 2.4.0"
 gem "appraisal", "~> 2.2.0"
 gem "benchmark-ips", "~> 2.8"
 gem "benchmark-memory", "< 0.2"

--- a/gemfiles/ruby_2.2.10_rails5_postgres_redis.gemfile.lock
+++ b/gemfiles/ruby_2.2.10_rails5_postgres_redis.gemfile.lock
@@ -207,7 +207,6 @@ PLATFORMS
   x86_64-linux
 
 DEPENDENCIES
-  addressable (~> 2.4.0)
   appraisal (~> 2.2.0)
   benchmark-ips (~> 2.8)
   benchmark-memory (< 0.2)

--- a/gemfiles/ruby_2.2.10_rails5_postgres_redis_activesupport.gemfile
+++ b/gemfiles/ruby_2.2.10_rails5_postgres_redis_activesupport.gemfile
@@ -2,7 +2,6 @@
 
 source "https://rubygems.org"
 
-gem "addressable", "~> 2.4.0"
 gem "appraisal", "~> 2.2.0"
 gem "benchmark-ips", "~> 2.8"
 gem "benchmark-memory", "< 0.2"

--- a/gemfiles/ruby_2.2.10_rails5_postgres_redis_activesupport.gemfile.lock
+++ b/gemfiles/ruby_2.2.10_rails5_postgres_redis_activesupport.gemfile.lock
@@ -223,7 +223,6 @@ PLATFORMS
   x86_64-linux
 
 DEPENDENCIES
-  addressable (~> 2.4.0)
   appraisal (~> 2.2.0)
   benchmark-ips (~> 2.8)
   benchmark-memory (< 0.2)

--- a/gemfiles/ruby_2.2.10_rails5_postgres_sidekiq.gemfile
+++ b/gemfiles/ruby_2.2.10_rails5_postgres_sidekiq.gemfile
@@ -2,7 +2,6 @@
 
 source "https://rubygems.org"
 
-gem "addressable", "~> 2.4.0"
 gem "appraisal", "~> 2.2.0"
 gem "benchmark-ips", "~> 2.8"
 gem "benchmark-memory", "< 0.2"

--- a/gemfiles/ruby_2.2.10_rails5_postgres_sidekiq.gemfile.lock
+++ b/gemfiles/ruby_2.2.10_rails5_postgres_sidekiq.gemfile.lock
@@ -216,7 +216,6 @@ PLATFORMS
 
 DEPENDENCIES
   activejob
-  addressable (~> 2.4.0)
   appraisal (~> 2.2.0)
   benchmark-ips (~> 2.8)
   benchmark-memory (< 0.2)

--- a/gemfiles/ruby_2.2.10_rails5_semantic_logger.gemfile
+++ b/gemfiles/ruby_2.2.10_rails5_semantic_logger.gemfile
@@ -2,7 +2,6 @@
 
 source "https://rubygems.org"
 
-gem "addressable", "~> 2.4.0"
 gem "appraisal", "~> 2.2.0"
 gem "benchmark-ips", "~> 2.8"
 gem "benchmark-memory", "< 0.2"

--- a/gemfiles/ruby_2.2.10_rails5_semantic_logger.gemfile.lock
+++ b/gemfiles/ruby_2.2.10_rails5_semantic_logger.gemfile.lock
@@ -204,7 +204,6 @@ PLATFORMS
   x86_64-linux
 
 DEPENDENCIES
-  addressable (~> 2.4.0)
   appraisal (~> 2.2.0)
   benchmark-ips (~> 2.8)
   benchmark-memory (< 0.2)

--- a/gemfiles/ruby_2.2.10_redis_3.gemfile
+++ b/gemfiles/ruby_2.2.10_redis_3.gemfile
@@ -2,7 +2,6 @@
 
 source "https://rubygems.org"
 
-gem "addressable", "~> 2.4.0"
 gem "appraisal", "~> 2.2.0"
 gem "benchmark-ips", "~> 2.8"
 gem "benchmark-memory", "< 0.2"

--- a/gemfiles/ruby_2.2.10_redis_3.gemfile.lock
+++ b/gemfiles/ruby_2.2.10_redis_3.gemfile.lock
@@ -95,7 +95,6 @@ PLATFORMS
   x86_64-linux
 
 DEPENDENCIES
-  addressable (~> 2.4.0)
   appraisal (~> 2.2.0)
   benchmark-ips (~> 2.8)
   benchmark-memory (< 0.2)

--- a/gemfiles/ruby_2.2.10_relational_db.gemfile
+++ b/gemfiles/ruby_2.2.10_relational_db.gemfile
@@ -2,7 +2,6 @@
 
 source "https://rubygems.org"
 
-gem "addressable", "~> 2.4.0"
 gem "appraisal", "~> 2.2.0"
 gem "benchmark-ips", "~> 2.8"
 gem "benchmark-memory", "< 0.2"

--- a/gemfiles/ruby_2.2.10_relational_db.gemfile.lock
+++ b/gemfiles/ruby_2.2.10_relational_db.gemfile.lock
@@ -121,7 +121,6 @@ PLATFORMS
 
 DEPENDENCIES
   activerecord (< 5.1.5)
-  addressable (~> 2.4.0)
   appraisal (~> 2.2.0)
   benchmark-ips (~> 2.8)
   benchmark-memory (< 0.2)

--- a/gemfiles/ruby_2.2.10_sinatra.gemfile
+++ b/gemfiles/ruby_2.2.10_sinatra.gemfile
@@ -2,7 +2,6 @@
 
 source "https://rubygems.org"
 
-gem "addressable", "~> 2.4.0"
 gem "appraisal", "~> 2.2.0"
 gem "benchmark-ips", "~> 2.8"
 gem "benchmark-memory", "< 0.2"

--- a/gemfiles/ruby_2.2.10_sinatra.gemfile.lock
+++ b/gemfiles/ruby_2.2.10_sinatra.gemfile.lock
@@ -108,7 +108,6 @@ PLATFORMS
   x86_64-linux
 
 DEPENDENCIES
-  addressable (~> 2.4.0)
   appraisal (~> 2.2.0)
   benchmark-ips (~> 2.8)
   benchmark-memory (< 0.2)

--- a/gemfiles/ruby_2.3.8_activerecord_3.gemfile
+++ b/gemfiles/ruby_2.3.8_activerecord_3.gemfile
@@ -2,7 +2,6 @@
 
 source "https://rubygems.org"
 
-gem "addressable", "~> 2.4.0"
 gem "appraisal", "~> 2.4.0"
 gem "benchmark-ips", "~> 2.8"
 gem "benchmark-memory", "< 0.2"

--- a/gemfiles/ruby_2.3.8_activerecord_3.gemfile.lock
+++ b/gemfiles/ruby_2.3.8_activerecord_3.gemfile.lock
@@ -118,7 +118,6 @@ PLATFORMS
 DEPENDENCIES
   activerecord (~> 3)
   activerecord-mysql-adapter
-  addressable (~> 2.4.0)
   appraisal (~> 2.4.0)
   benchmark-ips (~> 2.8)
   benchmark-memory (< 0.2)

--- a/gemfiles/ruby_2.3.8_aws.gemfile
+++ b/gemfiles/ruby_2.3.8_aws.gemfile
@@ -2,7 +2,6 @@
 
 source "https://rubygems.org"
 
-gem "addressable", "~> 2.4.0"
 gem "appraisal", "~> 2.4.0"
 gem "benchmark-ips", "~> 2.8"
 gem "benchmark-memory", "< 0.2"

--- a/gemfiles/ruby_2.3.8_aws.gemfile.lock
+++ b/gemfiles/ruby_2.3.8_aws.gemfile.lock
@@ -1517,7 +1517,6 @@ PLATFORMS
   ruby
 
 DEPENDENCIES
-  addressable (~> 2.4.0)
   appraisal (~> 2.4.0)
   aws-sdk
   benchmark-ips (~> 2.8)

--- a/gemfiles/ruby_2.3.8_contrib.gemfile
+++ b/gemfiles/ruby_2.3.8_contrib.gemfile
@@ -2,7 +2,6 @@
 
 source "https://rubygems.org"
 
-gem "addressable", "~> 2.4.0"
 gem "appraisal", "~> 2.4.0"
 gem "benchmark-ips", "~> 2.8"
 gem "benchmark-memory", "< 0.2"

--- a/gemfiles/ruby_2.3.8_contrib.gemfile.lock
+++ b/gemfiles/ruby_2.3.8_contrib.gemfile.lock
@@ -261,7 +261,6 @@ DEPENDENCIES
   actionpack
   actionview
   active_model_serializers (>= 0.10.0)
-  addressable (~> 2.4.0)
   appraisal (~> 2.4.0)
   benchmark-ips (~> 2.8)
   benchmark-memory (< 0.2)

--- a/gemfiles/ruby_2.3.8_contrib_old.gemfile
+++ b/gemfiles/ruby_2.3.8_contrib_old.gemfile
@@ -2,7 +2,6 @@
 
 source "https://rubygems.org"
 
-gem "addressable", "~> 2.4.0"
 gem "appraisal", "~> 2.4.0"
 gem "benchmark-ips", "~> 2.8"
 gem "benchmark-memory", "< 0.2"

--- a/gemfiles/ruby_2.3.8_contrib_old.gemfile.lock
+++ b/gemfiles/ruby_2.3.8_contrib_old.gemfile.lock
@@ -114,7 +114,6 @@ PLATFORMS
   x86_64-linux
 
 DEPENDENCIES
-  addressable (~> 2.4.0)
   appraisal (~> 2.4.0)
   benchmark-ips (~> 2.8)
   benchmark-memory (< 0.2)

--- a/gemfiles/ruby_2.3.8_core_old.gemfile
+++ b/gemfiles/ruby_2.3.8_core_old.gemfile
@@ -2,7 +2,6 @@
 
 source "https://rubygems.org"
 
-gem "addressable", "~> 2.4.0"
 gem "appraisal", "~> 2.4.0"
 gem "benchmark-ips", "~> 2.8"
 gem "benchmark-memory", "< 0.2"

--- a/gemfiles/ruby_2.3.8_core_old.gemfile.lock
+++ b/gemfiles/ruby_2.3.8_core_old.gemfile.lock
@@ -96,7 +96,6 @@ PLATFORMS
   x86_64-linux
 
 DEPENDENCIES
-  addressable (~> 2.4.0)
   appraisal (~> 2.4.0)
   benchmark-ips (~> 2.8)
   benchmark-memory (< 0.2)

--- a/gemfiles/ruby_2.3.8_hanami_1.gemfile
+++ b/gemfiles/ruby_2.3.8_hanami_1.gemfile
@@ -2,7 +2,6 @@
 
 source "https://rubygems.org"
 
-gem "addressable", "~> 2.4.0"
 gem "appraisal", "~> 2.4.0"
 gem "benchmark-ips", "~> 2.8"
 gem "benchmark-memory", "< 0.2"

--- a/gemfiles/ruby_2.3.8_hanami_1.gemfile.lock
+++ b/gemfiles/ruby_2.3.8_hanami_1.gemfile.lock
@@ -181,7 +181,6 @@ PLATFORMS
   x86_64-linux
 
 DEPENDENCIES
-  addressable (~> 2.4.0)
   appraisal (~> 2.4.0)
   benchmark-ips (~> 2.8)
   benchmark-memory (< 0.2)

--- a/gemfiles/ruby_2.3.8_http.gemfile
+++ b/gemfiles/ruby_2.3.8_http.gemfile
@@ -2,7 +2,6 @@
 
 source "https://rubygems.org"
 
-gem "addressable", "~> 2.4.0"
 gem "appraisal", "~> 2.4.0"
 gem "benchmark-ips", "~> 2.8"
 gem "benchmark-memory", "< 0.2"

--- a/gemfiles/ruby_2.3.8_http.gemfile.lock
+++ b/gemfiles/ruby_2.3.8_http.gemfile.lock
@@ -129,7 +129,6 @@ PLATFORMS
   ruby
 
 DEPENDENCIES
-  addressable (~> 2.4.0)
   appraisal (~> 2.4.0)
   benchmark-ips (~> 2.8)
   benchmark-memory (< 0.2)

--- a/gemfiles/ruby_2.3.8_rails32_mysql2.gemfile
+++ b/gemfiles/ruby_2.3.8_rails32_mysql2.gemfile
@@ -2,7 +2,6 @@
 
 source "https://rubygems.org"
 
-gem "addressable", "~> 2.4.0"
 gem "appraisal", "~> 2.4.0"
 gem "benchmark-ips", "~> 2.8"
 gem "benchmark-memory", "< 0.2"

--- a/gemfiles/ruby_2.3.8_rails32_mysql2.gemfile.lock
+++ b/gemfiles/ruby_2.3.8_rails32_mysql2.gemfile.lock
@@ -179,7 +179,6 @@ PLATFORMS
 
 DEPENDENCIES
   activerecord-mysql-adapter
-  addressable (~> 2.4.0)
   appraisal (~> 2.4.0)
   benchmark-ips (~> 2.8)
   benchmark-memory (< 0.2)

--- a/gemfiles/ruby_2.3.8_rails32_postgres.gemfile
+++ b/gemfiles/ruby_2.3.8_rails32_postgres.gemfile
@@ -2,7 +2,6 @@
 
 source "https://rubygems.org"
 
-gem "addressable", "~> 2.4.0"
 gem "appraisal", "~> 2.4.0"
 gem "benchmark-ips", "~> 2.8"
 gem "benchmark-memory", "< 0.2"

--- a/gemfiles/ruby_2.3.8_rails32_postgres.gemfile.lock
+++ b/gemfiles/ruby_2.3.8_rails32_postgres.gemfile.lock
@@ -172,7 +172,6 @@ PLATFORMS
   x86_64-linux
 
 DEPENDENCIES
-  addressable (~> 2.4.0)
   appraisal (~> 2.4.0)
   benchmark-ips (~> 2.8)
   benchmark-memory (< 0.2)

--- a/gemfiles/ruby_2.3.8_rails32_postgres_redis.gemfile
+++ b/gemfiles/ruby_2.3.8_rails32_postgres_redis.gemfile
@@ -2,7 +2,6 @@
 
 source "https://rubygems.org"
 
-gem "addressable", "~> 2.4.0"
 gem "appraisal", "~> 2.4.0"
 gem "benchmark-ips", "~> 2.8"
 gem "benchmark-memory", "< 0.2"

--- a/gemfiles/ruby_2.3.8_rails32_postgres_redis.gemfile.lock
+++ b/gemfiles/ruby_2.3.8_rails32_postgres_redis.gemfile.lock
@@ -189,7 +189,6 @@ PLATFORMS
   x86_64-linux
 
 DEPENDENCIES
-  addressable (~> 2.4.0)
   appraisal (~> 2.4.0)
   benchmark-ips (~> 2.8)
   benchmark-memory (< 0.2)

--- a/gemfiles/ruby_2.3.8_rails32_postgres_sidekiq.gemfile
+++ b/gemfiles/ruby_2.3.8_rails32_postgres_sidekiq.gemfile
@@ -2,7 +2,6 @@
 
 source "https://rubygems.org"
 
-gem "addressable", "~> 2.4.0"
 gem "appraisal", "~> 2.4.0"
 gem "benchmark-ips", "~> 2.8"
 gem "benchmark-memory", "< 0.2"

--- a/gemfiles/ruby_2.3.8_rails32_postgres_sidekiq.gemfile.lock
+++ b/gemfiles/ruby_2.3.8_rails32_postgres_sidekiq.gemfile.lock
@@ -180,7 +180,6 @@ PLATFORMS
   x86_64-linux
 
 DEPENDENCIES
-  addressable (~> 2.4.0)
   appraisal (~> 2.4.0)
   benchmark-ips (~> 2.8)
   benchmark-memory (< 0.2)

--- a/gemfiles/ruby_2.3.8_rails4_mysql2.gemfile
+++ b/gemfiles/ruby_2.3.8_rails4_mysql2.gemfile
@@ -2,7 +2,6 @@
 
 source "https://rubygems.org"
 
-gem "addressable", "~> 2.4.0"
 gem "appraisal", "~> 2.4.0"
 gem "benchmark-ips", "~> 2.8"
 gem "benchmark-memory", "< 0.2"

--- a/gemfiles/ruby_2.3.8_rails4_mysql2.gemfile.lock
+++ b/gemfiles/ruby_2.3.8_rails4_mysql2.gemfile.lock
@@ -192,7 +192,6 @@ PLATFORMS
   x86_64-linux
 
 DEPENDENCIES
-  addressable (~> 2.4.0)
   appraisal (~> 2.4.0)
   benchmark-ips (~> 2.8)
   benchmark-memory (< 0.2)

--- a/gemfiles/ruby_2.3.8_rails4_postgres.gemfile
+++ b/gemfiles/ruby_2.3.8_rails4_postgres.gemfile
@@ -2,7 +2,6 @@
 
 source "https://rubygems.org"
 
-gem "addressable", "~> 2.4.0"
 gem "appraisal", "~> 2.4.0"
 gem "benchmark-ips", "~> 2.8"
 gem "benchmark-memory", "< 0.2"

--- a/gemfiles/ruby_2.3.8_rails4_postgres.gemfile.lock
+++ b/gemfiles/ruby_2.3.8_rails4_postgres.gemfile.lock
@@ -192,7 +192,6 @@ PLATFORMS
   x86_64-linux
 
 DEPENDENCIES
-  addressable (~> 2.4.0)
   appraisal (~> 2.4.0)
   benchmark-ips (~> 2.8)
   benchmark-memory (< 0.2)

--- a/gemfiles/ruby_2.3.8_rails4_postgres_redis.gemfile
+++ b/gemfiles/ruby_2.3.8_rails4_postgres_redis.gemfile
@@ -2,7 +2,6 @@
 
 source "https://rubygems.org"
 
-gem "addressable", "~> 2.4.0"
 gem "appraisal", "~> 2.4.0"
 gem "benchmark-ips", "~> 2.8"
 gem "benchmark-memory", "< 0.2"

--- a/gemfiles/ruby_2.3.8_rails4_postgres_redis.gemfile.lock
+++ b/gemfiles/ruby_2.3.8_rails4_postgres_redis.gemfile.lock
@@ -209,7 +209,6 @@ PLATFORMS
   x86_64-linux
 
 DEPENDENCIES
-  addressable (~> 2.4.0)
   appraisal (~> 2.4.0)
   benchmark-ips (~> 2.8)
   benchmark-memory (< 0.2)

--- a/gemfiles/ruby_2.3.8_rails4_postgres_sidekiq.gemfile
+++ b/gemfiles/ruby_2.3.8_rails4_postgres_sidekiq.gemfile
@@ -2,7 +2,6 @@
 
 source "https://rubygems.org"
 
-gem "addressable", "~> 2.4.0"
 gem "appraisal", "~> 2.4.0"
 gem "benchmark-ips", "~> 2.8"
 gem "benchmark-memory", "< 0.2"

--- a/gemfiles/ruby_2.3.8_rails4_postgres_sidekiq.gemfile.lock
+++ b/gemfiles/ruby_2.3.8_rails4_postgres_sidekiq.gemfile.lock
@@ -202,7 +202,6 @@ PLATFORMS
 
 DEPENDENCIES
   activejob
-  addressable (~> 2.4.0)
   appraisal (~> 2.4.0)
   benchmark-ips (~> 2.8)
   benchmark-memory (< 0.2)

--- a/gemfiles/ruby_2.3.8_rails4_semantic_logger.gemfile
+++ b/gemfiles/ruby_2.3.8_rails4_semantic_logger.gemfile
@@ -2,7 +2,6 @@
 
 source "https://rubygems.org"
 
-gem "addressable", "~> 2.4.0"
 gem "appraisal", "~> 2.4.0"
 gem "benchmark-ips", "~> 2.8"
 gem "benchmark-memory", "< 0.2"

--- a/gemfiles/ruby_2.3.8_rails4_semantic_logger.gemfile.lock
+++ b/gemfiles/ruby_2.3.8_rails4_semantic_logger.gemfile.lock
@@ -191,7 +191,6 @@ PLATFORMS
   x86_64-linux
 
 DEPENDENCIES
-  addressable (~> 2.4.0)
   appraisal (~> 2.4.0)
   benchmark-ips (~> 2.8)
   benchmark-memory (< 0.2)

--- a/gemfiles/ruby_2.3.8_rails5_mysql2.gemfile
+++ b/gemfiles/ruby_2.3.8_rails5_mysql2.gemfile
@@ -2,7 +2,6 @@
 
 source "https://rubygems.org"
 
-gem "addressable", "~> 2.4.0"
 gem "appraisal", "~> 2.4.0"
 gem "benchmark-ips", "~> 2.8"
 gem "benchmark-memory", "< 0.2"

--- a/gemfiles/ruby_2.3.8_rails5_mysql2.gemfile.lock
+++ b/gemfiles/ruby_2.3.8_rails5_mysql2.gemfile.lock
@@ -204,7 +204,6 @@ PLATFORMS
   x86_64-linux
 
 DEPENDENCIES
-  addressable (~> 2.4.0)
   appraisal (~> 2.4.0)
   benchmark-ips (~> 2.8)
   benchmark-memory (< 0.2)

--- a/gemfiles/ruby_2.3.8_rails5_postgres.gemfile
+++ b/gemfiles/ruby_2.3.8_rails5_postgres.gemfile
@@ -2,7 +2,6 @@
 
 source "https://rubygems.org"
 
-gem "addressable", "~> 2.4.0"
 gem "appraisal", "~> 2.4.0"
 gem "benchmark-ips", "~> 2.8"
 gem "benchmark-memory", "< 0.2"

--- a/gemfiles/ruby_2.3.8_rails5_postgres.gemfile.lock
+++ b/gemfiles/ruby_2.3.8_rails5_postgres.gemfile.lock
@@ -204,7 +204,6 @@ PLATFORMS
   x86_64-linux
 
 DEPENDENCIES
-  addressable (~> 2.4.0)
   appraisal (~> 2.4.0)
   benchmark-ips (~> 2.8)
   benchmark-memory (< 0.2)

--- a/gemfiles/ruby_2.3.8_rails5_postgres_redis.gemfile
+++ b/gemfiles/ruby_2.3.8_rails5_postgres_redis.gemfile
@@ -2,7 +2,6 @@
 
 source "https://rubygems.org"
 
-gem "addressable", "~> 2.4.0"
 gem "appraisal", "~> 2.4.0"
 gem "benchmark-ips", "~> 2.8"
 gem "benchmark-memory", "< 0.2"

--- a/gemfiles/ruby_2.3.8_rails5_postgres_redis.gemfile.lock
+++ b/gemfiles/ruby_2.3.8_rails5_postgres_redis.gemfile.lock
@@ -205,7 +205,6 @@ PLATFORMS
   x86_64-linux
 
 DEPENDENCIES
-  addressable (~> 2.4.0)
   appraisal (~> 2.4.0)
   benchmark-ips (~> 2.8)
   benchmark-memory (< 0.2)

--- a/gemfiles/ruby_2.3.8_rails5_postgres_redis_activesupport.gemfile
+++ b/gemfiles/ruby_2.3.8_rails5_postgres_redis_activesupport.gemfile
@@ -2,7 +2,6 @@
 
 source "https://rubygems.org"
 
-gem "addressable", "~> 2.4.0"
 gem "appraisal", "~> 2.4.0"
 gem "benchmark-ips", "~> 2.8"
 gem "benchmark-memory", "< 0.2"

--- a/gemfiles/ruby_2.3.8_rails5_postgres_redis_activesupport.gemfile.lock
+++ b/gemfiles/ruby_2.3.8_rails5_postgres_redis_activesupport.gemfile.lock
@@ -221,7 +221,6 @@ PLATFORMS
   x86_64-linux
 
 DEPENDENCIES
-  addressable (~> 2.4.0)
   appraisal (~> 2.4.0)
   benchmark-ips (~> 2.8)
   benchmark-memory (< 0.2)

--- a/gemfiles/ruby_2.3.8_rails5_postgres_sidekiq.gemfile
+++ b/gemfiles/ruby_2.3.8_rails5_postgres_sidekiq.gemfile
@@ -2,7 +2,6 @@
 
 source "https://rubygems.org"
 
-gem "addressable", "~> 2.4.0"
 gem "appraisal", "~> 2.4.0"
 gem "benchmark-ips", "~> 2.8"
 gem "benchmark-memory", "< 0.2"

--- a/gemfiles/ruby_2.3.8_rails5_postgres_sidekiq.gemfile.lock
+++ b/gemfiles/ruby_2.3.8_rails5_postgres_sidekiq.gemfile.lock
@@ -214,7 +214,6 @@ PLATFORMS
 
 DEPENDENCIES
   activejob
-  addressable (~> 2.4.0)
   appraisal (~> 2.4.0)
   benchmark-ips (~> 2.8)
   benchmark-memory (< 0.2)

--- a/gemfiles/ruby_2.3.8_rails5_semantic_logger.gemfile
+++ b/gemfiles/ruby_2.3.8_rails5_semantic_logger.gemfile
@@ -2,7 +2,6 @@
 
 source "https://rubygems.org"
 
-gem "addressable", "~> 2.4.0"
 gem "appraisal", "~> 2.4.0"
 gem "benchmark-ips", "~> 2.8"
 gem "benchmark-memory", "< 0.2"

--- a/gemfiles/ruby_2.3.8_rails5_semantic_logger.gemfile.lock
+++ b/gemfiles/ruby_2.3.8_rails5_semantic_logger.gemfile.lock
@@ -203,7 +203,6 @@ PLATFORMS
   x86_64-linux
 
 DEPENDENCIES
-  addressable (~> 2.4.0)
   appraisal (~> 2.4.0)
   benchmark-ips (~> 2.8)
   benchmark-memory (< 0.2)

--- a/gemfiles/ruby_2.3.8_redis_3.gemfile
+++ b/gemfiles/ruby_2.3.8_redis_3.gemfile
@@ -2,7 +2,6 @@
 
 source "https://rubygems.org"
 
-gem "addressable", "~> 2.4.0"
 gem "appraisal", "~> 2.4.0"
 gem "benchmark-ips", "~> 2.8"
 gem "benchmark-memory", "< 0.2"

--- a/gemfiles/ruby_2.3.8_redis_3.gemfile.lock
+++ b/gemfiles/ruby_2.3.8_redis_3.gemfile.lock
@@ -97,7 +97,6 @@ PLATFORMS
   x86_64-linux
 
 DEPENDENCIES
-  addressable (~> 2.4.0)
   appraisal (~> 2.4.0)
   benchmark-ips (~> 2.8)
   benchmark-memory (< 0.2)

--- a/gemfiles/ruby_2.3.8_relational_db.gemfile
+++ b/gemfiles/ruby_2.3.8_relational_db.gemfile
@@ -2,7 +2,6 @@
 
 source "https://rubygems.org"
 
-gem "addressable", "~> 2.4.0"
 gem "appraisal", "~> 2.4.0"
 gem "benchmark-ips", "~> 2.8"
 gem "benchmark-memory", "< 0.2"

--- a/gemfiles/ruby_2.3.8_relational_db.gemfile.lock
+++ b/gemfiles/ruby_2.3.8_relational_db.gemfile.lock
@@ -121,7 +121,6 @@ PLATFORMS
 
 DEPENDENCIES
   activerecord (< 5.1.5)
-  addressable (~> 2.4.0)
   appraisal (~> 2.4.0)
   benchmark-ips (~> 2.8)
   benchmark-memory (< 0.2)

--- a/gemfiles/ruby_2.3.8_resque2_redis3.gemfile
+++ b/gemfiles/ruby_2.3.8_resque2_redis3.gemfile
@@ -2,7 +2,6 @@
 
 source "https://rubygems.org"
 
-gem "addressable", "~> 2.4.0"
 gem "appraisal", "~> 2.4.0"
 gem "benchmark-ips", "~> 2.8"
 gem "benchmark-memory", "< 0.2"

--- a/gemfiles/ruby_2.3.8_resque2_redis3.gemfile.lock
+++ b/gemfiles/ruby_2.3.8_resque2_redis3.gemfile.lock
@@ -118,7 +118,6 @@ PLATFORMS
   x86_64-linux
 
 DEPENDENCIES
-  addressable (~> 2.4.0)
   appraisal (~> 2.4.0)
   benchmark-ips (~> 2.8)
   benchmark-memory (< 0.2)

--- a/gemfiles/ruby_2.3.8_resque2_redis4.gemfile
+++ b/gemfiles/ruby_2.3.8_resque2_redis4.gemfile
@@ -2,7 +2,6 @@
 
 source "https://rubygems.org"
 
-gem "addressable", "~> 2.4.0"
 gem "appraisal", "~> 2.4.0"
 gem "benchmark-ips", "~> 2.8"
 gem "benchmark-memory", "< 0.2"

--- a/gemfiles/ruby_2.3.8_resque2_redis4.gemfile.lock
+++ b/gemfiles/ruby_2.3.8_resque2_redis4.gemfile.lock
@@ -118,7 +118,6 @@ PLATFORMS
   x86_64-linux
 
 DEPENDENCIES
-  addressable (~> 2.4.0)
   appraisal (~> 2.4.0)
   benchmark-ips (~> 2.8)
   benchmark-memory (< 0.2)

--- a/gemfiles/ruby_2.3.8_sinatra.gemfile
+++ b/gemfiles/ruby_2.3.8_sinatra.gemfile
@@ -2,7 +2,6 @@
 
 source "https://rubygems.org"
 
-gem "addressable", "~> 2.4.0"
 gem "appraisal", "~> 2.4.0"
 gem "benchmark-ips", "~> 2.8"
 gem "benchmark-memory", "< 0.2"

--- a/gemfiles/ruby_2.3.8_sinatra.gemfile.lock
+++ b/gemfiles/ruby_2.3.8_sinatra.gemfile.lock
@@ -110,7 +110,6 @@ PLATFORMS
   x86_64-linux
 
 DEPENDENCIES
-  addressable (~> 2.4.0)
   appraisal (~> 2.4.0)
   benchmark-ips (~> 2.8)
   benchmark-memory (< 0.2)

--- a/gemfiles/ruby_2.4.10_activerecord_4.gemfile
+++ b/gemfiles/ruby_2.4.10_activerecord_4.gemfile
@@ -2,7 +2,6 @@
 
 source "https://rubygems.org"
 
-gem "addressable", "~> 2.4.0"
 gem "appraisal", "~> 2.4.0"
 gem "benchmark-ips", "~> 2.8"
 gem "benchmark-memory", "< 0.2"

--- a/gemfiles/ruby_2.4.10_activerecord_4.gemfile.lock
+++ b/gemfiles/ruby_2.4.10_activerecord_4.gemfile.lock
@@ -48,13 +48,17 @@ GEM
     extlz4 (0.3.4)
     ffi (1.15.5)
     google-protobuf (3.19.1)
+    google-protobuf (3.19.1-x86_64-linux)
     hashdiff (1.0.1)
     i18n (0.9.5)
       concurrent-ruby (~> 1.0)
     json-schema (2.8.1)
       addressable (>= 2.4)
     libdatadog (4.0.0.1.0-aarch64-linux)
+    libdatadog (4.0.0.1.0-x86_64-linux)
     libddwaf (1.14.0.0.0-aarch64-linux)
+      ffi (~> 1.0)
+    libddwaf (1.14.0.0.0-x86_64-linux)
       ffi (~> 1.0)
     makara (0.3.10)
       activerecord (>= 3.0.0)
@@ -116,10 +120,10 @@ GEM
 
 PLATFORMS
   aarch64-linux
+  x86_64-linux
 
 DEPENDENCIES
   activerecord (~> 4)
-  addressable (~> 2.4.0)
   appraisal (~> 2.4.0)
   benchmark-ips (~> 2.8)
   benchmark-memory (< 0.2)

--- a/gemfiles/ruby_2.4.10_aws.gemfile
+++ b/gemfiles/ruby_2.4.10_aws.gemfile
@@ -2,7 +2,6 @@
 
 source "https://rubygems.org"
 
-gem "addressable", "~> 2.4.0"
 gem "appraisal", "~> 2.4.0"
 gem "benchmark-ips", "~> 2.8"
 gem "benchmark-memory", "< 0.2"

--- a/gemfiles/ruby_2.4.10_aws.gemfile.lock
+++ b/gemfiles/ruby_2.4.10_aws.gemfile.lock
@@ -1456,12 +1456,16 @@ GEM
     extlz4 (0.3.4)
     ffi (1.15.5)
     google-protobuf (3.19.1)
+    google-protobuf (3.19.1-x86_64-linux)
     hashdiff (1.0.1)
     jmespath (1.6.2)
     json-schema (2.8.1)
       addressable (>= 2.4)
     libdatadog (4.0.0.1.0-aarch64-linux)
+    libdatadog (4.0.0.1.0-x86_64-linux)
     libddwaf (1.14.0.0.0-aarch64-linux)
+      ffi (~> 1.0)
+    libddwaf (1.14.0.0.0-x86_64-linux)
       ffi (~> 1.0)
     memory_profiler (0.9.14)
     method_source (1.0.0)
@@ -1519,9 +1523,9 @@ GEM
 
 PLATFORMS
   aarch64-linux
+  x86_64-linux
 
 DEPENDENCIES
-  addressable (~> 2.4.0)
   appraisal (~> 2.4.0)
   aws-sdk
   benchmark-ips (~> 2.8)

--- a/gemfiles/ruby_2.4.10_contrib.gemfile
+++ b/gemfiles/ruby_2.4.10_contrib.gemfile
@@ -2,7 +2,6 @@
 
 source "https://rubygems.org"
 
-gem "addressable", "~> 2.4.0"
 gem "appraisal", "~> 2.4.0"
 gem "benchmark-ips", "~> 2.8"
 gem "benchmark-memory", "< 0.2"

--- a/gemfiles/ruby_2.4.10_contrib.gemfile.lock
+++ b/gemfiles/ruby_2.4.10_contrib.gemfile.lock
@@ -280,7 +280,6 @@ DEPENDENCIES
   actionpack
   actionview
   active_model_serializers (>= 0.10.0)
-  addressable (~> 2.4.0)
   appraisal (~> 2.4.0)
   benchmark-ips (~> 2.8)
   benchmark-memory (< 0.2)

--- a/gemfiles/ruby_2.4.10_contrib_old.gemfile
+++ b/gemfiles/ruby_2.4.10_contrib_old.gemfile
@@ -2,7 +2,6 @@
 
 source "https://rubygems.org"
 
-gem "addressable", "~> 2.4.0"
 gem "appraisal", "~> 2.4.0"
 gem "benchmark-ips", "~> 2.8"
 gem "benchmark-memory", "< 0.2"

--- a/gemfiles/ruby_2.4.10_contrib_old.gemfile.lock
+++ b/gemfiles/ruby_2.4.10_contrib_old.gemfile.lock
@@ -121,7 +121,6 @@ PLATFORMS
   x86_64-linux
 
 DEPENDENCIES
-  addressable (~> 2.4.0)
   appraisal (~> 2.4.0)
   benchmark-ips (~> 2.8)
   benchmark-memory (< 0.2)

--- a/gemfiles/ruby_2.4.10_core_old.gemfile
+++ b/gemfiles/ruby_2.4.10_core_old.gemfile
@@ -2,7 +2,6 @@
 
 source "https://rubygems.org"
 
-gem "addressable", "~> 2.4.0"
 gem "appraisal", "~> 2.4.0"
 gem "benchmark-ips", "~> 2.8"
 gem "benchmark-memory", "< 0.2"

--- a/gemfiles/ruby_2.4.10_core_old.gemfile.lock
+++ b/gemfiles/ruby_2.4.10_core_old.gemfile.lock
@@ -102,7 +102,6 @@ PLATFORMS
   x86_64-linux
 
 DEPENDENCIES
-  addressable (~> 2.4.0)
   appraisal (~> 2.4.0)
   benchmark-ips (~> 2.8)
   benchmark-memory (< 0.2)

--- a/gemfiles/ruby_2.4.10_hanami_1.gemfile
+++ b/gemfiles/ruby_2.4.10_hanami_1.gemfile
@@ -2,7 +2,6 @@
 
 source "https://rubygems.org"
 
-gem "addressable", "~> 2.4.0"
 gem "appraisal", "~> 2.4.0"
 gem "benchmark-ips", "~> 2.8"
 gem "benchmark-memory", "< 0.2"

--- a/gemfiles/ruby_2.4.10_hanami_1.gemfile.lock
+++ b/gemfiles/ruby_2.4.10_hanami_1.gemfile.lock
@@ -187,7 +187,6 @@ PLATFORMS
   x86_64-linux
 
 DEPENDENCIES
-  addressable (~> 2.4.0)
   appraisal (~> 2.4.0)
   benchmark-ips (~> 2.8)
   benchmark-memory (< 0.2)

--- a/gemfiles/ruby_2.4.10_http.gemfile
+++ b/gemfiles/ruby_2.4.10_http.gemfile
@@ -2,7 +2,6 @@
 
 source "https://rubygems.org"
 
-gem "addressable", "~> 2.4.0"
 gem "appraisal", "~> 2.4.0"
 gem "benchmark-ips", "~> 2.8"
 gem "benchmark-memory", "< 0.2"

--- a/gemfiles/ruby_2.4.10_http.gemfile.lock
+++ b/gemfiles/ruby_2.4.10_http.gemfile.lock
@@ -66,6 +66,7 @@ GEM
       ffi (>= 1.0.0)
       rake
     google-protobuf (3.19.1)
+    google-protobuf (3.19.1-x86_64-linux)
     hashdiff (1.0.1)
     http (4.4.1)
       addressable (~> 2.3)
@@ -82,7 +83,10 @@ GEM
     json-schema (2.8.1)
       addressable (>= 2.4)
     libdatadog (4.0.0.1.0-aarch64-linux)
+    libdatadog (4.0.0.1.0-x86_64-linux)
     libddwaf (1.14.0.0.0-aarch64-linux)
+      ffi (~> 1.0)
+    libddwaf (1.14.0.0.0-x86_64-linux)
       ffi (~> 1.0)
     memory_profiler (0.9.14)
     method_source (1.0.0)
@@ -162,9 +166,9 @@ GEM
 
 PLATFORMS
   aarch64-linux
+  x86_64-linux
 
 DEPENDENCIES
-  addressable (~> 2.4.0)
   appraisal (~> 2.4.0)
   benchmark-ips (~> 2.8)
   benchmark-memory (< 0.2)

--- a/gemfiles/ruby_2.4.10_rails5_mysql2.gemfile
+++ b/gemfiles/ruby_2.4.10_rails5_mysql2.gemfile
@@ -2,7 +2,6 @@
 
 source "https://rubygems.org"
 
-gem "addressable", "~> 2.4.0"
 gem "appraisal", "~> 2.4.0"
 gem "benchmark-ips", "~> 2.8"
 gem "benchmark-memory", "< 0.2"

--- a/gemfiles/ruby_2.4.10_rails5_mysql2.gemfile.lock
+++ b/gemfiles/ruby_2.4.10_rails5_mysql2.gemfile.lock
@@ -210,7 +210,6 @@ PLATFORMS
   x86_64-linux
 
 DEPENDENCIES
-  addressable (~> 2.4.0)
   appraisal (~> 2.4.0)
   benchmark-ips (~> 2.8)
   benchmark-memory (< 0.2)

--- a/gemfiles/ruby_2.4.10_rails5_postgres.gemfile
+++ b/gemfiles/ruby_2.4.10_rails5_postgres.gemfile
@@ -2,7 +2,6 @@
 
 source "https://rubygems.org"
 
-gem "addressable", "~> 2.4.0"
 gem "appraisal", "~> 2.4.0"
 gem "benchmark-ips", "~> 2.8"
 gem "benchmark-memory", "< 0.2"

--- a/gemfiles/ruby_2.4.10_rails5_postgres.gemfile.lock
+++ b/gemfiles/ruby_2.4.10_rails5_postgres.gemfile.lock
@@ -210,7 +210,6 @@ PLATFORMS
   x86_64-linux
 
 DEPENDENCIES
-  addressable (~> 2.4.0)
   appraisal (~> 2.4.0)
   benchmark-ips (~> 2.8)
   benchmark-memory (< 0.2)

--- a/gemfiles/ruby_2.4.10_rails5_postgres_redis.gemfile
+++ b/gemfiles/ruby_2.4.10_rails5_postgres_redis.gemfile
@@ -2,7 +2,6 @@
 
 source "https://rubygems.org"
 
-gem "addressable", "~> 2.4.0"
 gem "appraisal", "~> 2.4.0"
 gem "benchmark-ips", "~> 2.8"
 gem "benchmark-memory", "< 0.2"

--- a/gemfiles/ruby_2.4.10_rails5_postgres_redis.gemfile.lock
+++ b/gemfiles/ruby_2.4.10_rails5_postgres_redis.gemfile.lock
@@ -211,7 +211,6 @@ PLATFORMS
   x86_64-linux
 
 DEPENDENCIES
-  addressable (~> 2.4.0)
   appraisal (~> 2.4.0)
   benchmark-ips (~> 2.8)
   benchmark-memory (< 0.2)

--- a/gemfiles/ruby_2.4.10_rails5_postgres_redis_activesupport.gemfile
+++ b/gemfiles/ruby_2.4.10_rails5_postgres_redis_activesupport.gemfile
@@ -2,7 +2,6 @@
 
 source "https://rubygems.org"
 
-gem "addressable", "~> 2.4.0"
 gem "appraisal", "~> 2.4.0"
 gem "benchmark-ips", "~> 2.8"
 gem "benchmark-memory", "< 0.2"

--- a/gemfiles/ruby_2.4.10_rails5_postgres_redis_activesupport.gemfile.lock
+++ b/gemfiles/ruby_2.4.10_rails5_postgres_redis_activesupport.gemfile.lock
@@ -227,7 +227,6 @@ PLATFORMS
   x86_64-linux
 
 DEPENDENCIES
-  addressable (~> 2.4.0)
   appraisal (~> 2.4.0)
   benchmark-ips (~> 2.8)
   benchmark-memory (< 0.2)

--- a/gemfiles/ruby_2.4.10_rails5_postgres_sidekiq.gemfile
+++ b/gemfiles/ruby_2.4.10_rails5_postgres_sidekiq.gemfile
@@ -2,7 +2,6 @@
 
 source "https://rubygems.org"
 
-gem "addressable", "~> 2.4.0"
 gem "appraisal", "~> 2.4.0"
 gem "benchmark-ips", "~> 2.8"
 gem "benchmark-memory", "< 0.2"

--- a/gemfiles/ruby_2.4.10_rails5_postgres_sidekiq.gemfile.lock
+++ b/gemfiles/ruby_2.4.10_rails5_postgres_sidekiq.gemfile.lock
@@ -220,7 +220,6 @@ PLATFORMS
 
 DEPENDENCIES
   activejob
-  addressable (~> 2.4.0)
   appraisal (~> 2.4.0)
   benchmark-ips (~> 2.8)
   benchmark-memory (< 0.2)

--- a/gemfiles/ruby_2.4.10_rails5_semantic_logger.gemfile
+++ b/gemfiles/ruby_2.4.10_rails5_semantic_logger.gemfile
@@ -2,7 +2,6 @@
 
 source "https://rubygems.org"
 
-gem "addressable", "~> 2.4.0"
 gem "appraisal", "~> 2.4.0"
 gem "benchmark-ips", "~> 2.8"
 gem "benchmark-memory", "< 0.2"

--- a/gemfiles/ruby_2.4.10_rails5_semantic_logger.gemfile.lock
+++ b/gemfiles/ruby_2.4.10_rails5_semantic_logger.gemfile.lock
@@ -209,7 +209,6 @@ PLATFORMS
   x86_64-linux
 
 DEPENDENCIES
-  addressable (~> 2.4.0)
   appraisal (~> 2.4.0)
   benchmark-ips (~> 2.8)
   benchmark-memory (< 0.2)

--- a/gemfiles/ruby_2.4.10_redis_3.gemfile
+++ b/gemfiles/ruby_2.4.10_redis_3.gemfile
@@ -2,7 +2,6 @@
 
 source "https://rubygems.org"
 
-gem "addressable", "~> 2.4.0"
 gem "appraisal", "~> 2.4.0"
 gem "benchmark-ips", "~> 2.8"
 gem "benchmark-memory", "< 0.2"

--- a/gemfiles/ruby_2.4.10_redis_3.gemfile.lock
+++ b/gemfiles/ruby_2.4.10_redis_3.gemfile.lock
@@ -103,7 +103,6 @@ PLATFORMS
   x86_64-linux
 
 DEPENDENCIES
-  addressable (~> 2.4.0)
   appraisal (~> 2.4.0)
   benchmark-ips (~> 2.8)
   benchmark-memory (< 0.2)

--- a/gemfiles/ruby_2.4.10_redis_4.gemfile
+++ b/gemfiles/ruby_2.4.10_redis_4.gemfile
@@ -2,7 +2,6 @@
 
 source "https://rubygems.org"
 
-gem "addressable", "~> 2.4.0"
 gem "appraisal", "~> 2.4.0"
 gem "benchmark-ips", "~> 2.8"
 gem "benchmark-memory", "< 0.2"

--- a/gemfiles/ruby_2.4.10_redis_4.gemfile.lock
+++ b/gemfiles/ruby_2.4.10_redis_4.gemfile.lock
@@ -103,7 +103,6 @@ PLATFORMS
   x86_64-linux
 
 DEPENDENCIES
-  addressable (~> 2.4.0)
   appraisal (~> 2.4.0)
   benchmark-ips (~> 2.8)
   benchmark-memory (< 0.2)

--- a/gemfiles/ruby_2.4.10_relational_db.gemfile
+++ b/gemfiles/ruby_2.4.10_relational_db.gemfile
@@ -2,7 +2,6 @@
 
 source "https://rubygems.org"
 
-gem "addressable", "~> 2.4.0"
 gem "appraisal", "~> 2.4.0"
 gem "benchmark-ips", "~> 2.8"
 gem "benchmark-memory", "< 0.2"

--- a/gemfiles/ruby_2.4.10_relational_db.gemfile.lock
+++ b/gemfiles/ruby_2.4.10_relational_db.gemfile.lock
@@ -52,6 +52,7 @@ GEM
     extlz4 (0.3.4)
     ffi (1.15.5)
     google-protobuf (3.19.1)
+    google-protobuf (3.19.1-x86_64-linux)
     hashdiff (1.0.1)
     i18n (0.9.5)
       concurrent-ruby (~> 1.0)
@@ -63,6 +64,8 @@ GEM
       ffi (~> 1.0)
     libddwaf (1.14.0.0.0-x86_64-linux)
       ffi (~> 1.0)
+    makara (0.5.0)
+      activerecord (>= 3.0.0)
     memory_profiler (0.9.14)
     method_source (1.0.0)
     minitest (5.15.0)
@@ -123,10 +126,10 @@ GEM
 
 PLATFORMS
   aarch64-linux
+  x86_64-linux
 
 DEPENDENCIES
   activerecord (< 5.1.5)
-  addressable (~> 2.4.0)
   appraisal (~> 2.4.0)
   benchmark-ips (~> 2.8)
   benchmark-memory (< 0.2)

--- a/gemfiles/ruby_2.4.10_resque2_redis3.gemfile
+++ b/gemfiles/ruby_2.4.10_resque2_redis3.gemfile
@@ -2,7 +2,6 @@
 
 source "https://rubygems.org"
 
-gem "addressable", "~> 2.4.0"
 gem "appraisal", "~> 2.4.0"
 gem "benchmark-ips", "~> 2.8"
 gem "benchmark-memory", "< 0.2"

--- a/gemfiles/ruby_2.4.10_resque2_redis3.gemfile.lock
+++ b/gemfiles/ruby_2.4.10_resque2_redis3.gemfile.lock
@@ -124,7 +124,6 @@ PLATFORMS
   x86_64-linux
 
 DEPENDENCIES
-  addressable (~> 2.4.0)
   appraisal (~> 2.4.0)
   benchmark-ips (~> 2.8)
   benchmark-memory (< 0.2)

--- a/gemfiles/ruby_2.4.10_resque2_redis4.gemfile
+++ b/gemfiles/ruby_2.4.10_resque2_redis4.gemfile
@@ -2,7 +2,6 @@
 
 source "https://rubygems.org"
 
-gem "addressable", "~> 2.4.0"
 gem "appraisal", "~> 2.4.0"
 gem "benchmark-ips", "~> 2.8"
 gem "benchmark-memory", "< 0.2"

--- a/gemfiles/ruby_2.4.10_resque2_redis4.gemfile.lock
+++ b/gemfiles/ruby_2.4.10_resque2_redis4.gemfile.lock
@@ -124,7 +124,6 @@ PLATFORMS
   x86_64-linux
 
 DEPENDENCIES
-  addressable (~> 2.4.0)
   appraisal (~> 2.4.0)
   benchmark-ips (~> 2.8)
   benchmark-memory (< 0.2)

--- a/gemfiles/ruby_2.4.10_sinatra.gemfile
+++ b/gemfiles/ruby_2.4.10_sinatra.gemfile
@@ -2,7 +2,6 @@
 
 source "https://rubygems.org"
 
-gem "addressable", "~> 2.4.0"
 gem "appraisal", "~> 2.4.0"
 gem "benchmark-ips", "~> 2.8"
 gem "benchmark-memory", "< 0.2"

--- a/gemfiles/ruby_2.4.10_sinatra.gemfile.lock
+++ b/gemfiles/ruby_2.4.10_sinatra.gemfile.lock
@@ -116,7 +116,6 @@ PLATFORMS
   x86_64-linux
 
 DEPENDENCIES
-  addressable (~> 2.4.0)
   appraisal (~> 2.4.0)
   benchmark-ips (~> 2.8)
   benchmark-memory (< 0.2)

--- a/gemfiles/ruby_2.5.9_aws.gemfile
+++ b/gemfiles/ruby_2.5.9_aws.gemfile
@@ -2,7 +2,6 @@
 
 source "https://rubygems.org"
 
-gem "addressable", "~> 2.4.0"
 gem "appraisal", "~> 2.4.0"
 gem "benchmark-ips", "~> 2.8"
 gem "benchmark-memory", "< 0.2"

--- a/gemfiles/ruby_2.5.9_aws.gemfile.lock
+++ b/gemfiles/ruby_2.5.9_aws.gemfile.lock
@@ -1469,12 +1469,16 @@ GEM
     extlz4 (0.3.4)
     ffi (1.15.5)
     google-protobuf (3.19.1)
+    google-protobuf (3.19.1-x86_64-linux)
     hashdiff (1.0.1)
     jmespath (1.6.2)
     json-schema (2.8.1)
       addressable (>= 2.4)
     libdatadog (4.0.0.1.0-aarch64-linux)
+    libdatadog (4.0.0.1.0-x86_64-linux)
     libddwaf (1.14.0.0.0-aarch64-linux)
+      ffi (~> 1.0)
+    libddwaf (1.14.0.0.0-x86_64-linux)
       ffi (~> 1.0)
     memory_profiler (0.9.14)
     method_source (1.0.0)
@@ -1537,9 +1541,9 @@ GEM
 
 PLATFORMS
   aarch64-linux
+  x86_64-linux
 
 DEPENDENCIES
-  addressable (~> 2.4.0)
   appraisal (~> 2.4.0)
   aws-sdk
   benchmark-ips (~> 2.8)

--- a/gemfiles/ruby_2.5.9_contrib.gemfile
+++ b/gemfiles/ruby_2.5.9_contrib.gemfile
@@ -2,7 +2,6 @@
 
 source "https://rubygems.org"
 
-gem "addressable", "~> 2.4.0"
 gem "appraisal", "~> 2.4.0"
 gem "benchmark-ips", "~> 2.8"
 gem "benchmark-memory", "< 0.2"

--- a/gemfiles/ruby_2.5.9_contrib.gemfile.lock
+++ b/gemfiles/ruby_2.5.9_contrib.gemfile.lock
@@ -298,7 +298,6 @@ DEPENDENCIES
   actionpack
   actionview
   active_model_serializers (>= 0.10.0)
-  addressable (~> 2.4.0)
   appraisal (~> 2.4.0)
   benchmark-ips (~> 2.8)
   benchmark-memory (< 0.2)

--- a/gemfiles/ruby_2.5.9_contrib_old.gemfile
+++ b/gemfiles/ruby_2.5.9_contrib_old.gemfile
@@ -2,7 +2,6 @@
 
 source "https://rubygems.org"
 
-gem "addressable", "~> 2.4.0"
 gem "appraisal", "~> 2.4.0"
 gem "benchmark-ips", "~> 2.8"
 gem "benchmark-memory", "< 0.2"

--- a/gemfiles/ruby_2.5.9_contrib_old.gemfile.lock
+++ b/gemfiles/ruby_2.5.9_contrib_old.gemfile.lock
@@ -183,7 +183,6 @@ PLATFORMS
   x86_64-linux
 
 DEPENDENCIES
-  addressable (~> 2.4.0)
   appraisal (~> 2.4.0)
   benchmark-ips (~> 2.8)
   benchmark-memory (< 0.2)

--- a/gemfiles/ruby_2.5.9_core_old.gemfile
+++ b/gemfiles/ruby_2.5.9_core_old.gemfile
@@ -2,7 +2,6 @@
 
 source "https://rubygems.org"
 
-gem "addressable", "~> 2.4.0"
 gem "appraisal", "~> 2.4.0"
 gem "benchmark-ips", "~> 2.8"
 gem "benchmark-memory", "< 0.2"

--- a/gemfiles/ruby_2.5.9_core_old.gemfile.lock
+++ b/gemfiles/ruby_2.5.9_core_old.gemfile.lock
@@ -120,7 +120,6 @@ PLATFORMS
   x86_64-linux
 
 DEPENDENCIES
-  addressable (~> 2.4.0)
   appraisal (~> 2.4.0)
   benchmark-ips (~> 2.8)
   benchmark-memory (< 0.2)

--- a/gemfiles/ruby_2.5.9_hanami_1.gemfile
+++ b/gemfiles/ruby_2.5.9_hanami_1.gemfile
@@ -2,7 +2,6 @@
 
 source "https://rubygems.org"
 
-gem "addressable", "~> 2.4.0"
 gem "appraisal", "~> 2.4.0"
 gem "benchmark-ips", "~> 2.8"
 gem "benchmark-memory", "< 0.2"

--- a/gemfiles/ruby_2.5.9_hanami_1.gemfile.lock
+++ b/gemfiles/ruby_2.5.9_hanami_1.gemfile.lock
@@ -224,7 +224,6 @@ PLATFORMS
   x86_64-linux
 
 DEPENDENCIES
-  addressable (~> 2.4.0)
   appraisal (~> 2.4.0)
   benchmark-ips (~> 2.8)
   benchmark-memory (< 0.2)

--- a/gemfiles/ruby_2.5.9_http.gemfile
+++ b/gemfiles/ruby_2.5.9_http.gemfile
@@ -2,7 +2,6 @@
 
 source "https://rubygems.org"
 
-gem "addressable", "~> 2.4.0"
 gem "appraisal", "~> 2.4.0"
 gem "benchmark-ips", "~> 2.8"
 gem "benchmark-memory", "< 0.2"

--- a/gemfiles/ruby_2.5.9_http.gemfile.lock
+++ b/gemfiles/ruby_2.5.9_http.gemfile.lock
@@ -87,6 +87,7 @@ GEM
       ffi (>= 1.0.0)
       rake
     google-protobuf (3.19.1)
+    google-protobuf (3.19.1-x86_64-linux)
     hashdiff (1.0.1)
     http (5.0.1)
       addressable (~> 2.3)
@@ -101,7 +102,10 @@ GEM
     json-schema (2.8.1)
       addressable (>= 2.4)
     libdatadog (4.0.0.1.0-aarch64-linux)
+    libdatadog (4.0.0.1.0-x86_64-linux)
     libddwaf (1.14.0.0.0-aarch64-linux)
+      ffi (~> 1.0)
+    libddwaf (1.14.0.0.0-x86_64-linux)
       ffi (~> 1.0)
     llhttp-ffi (0.3.1)
       ffi-compiler (~> 1.0)
@@ -189,9 +193,9 @@ GEM
 
 PLATFORMS
   aarch64-linux
+  x86_64-linux
 
 DEPENDENCIES
-  addressable (~> 2.4.0)
   appraisal (~> 2.4.0)
   benchmark-ips (~> 2.8)
   benchmark-memory (< 0.2)

--- a/gemfiles/ruby_2.5.9_rails5_mysql2.gemfile
+++ b/gemfiles/ruby_2.5.9_rails5_mysql2.gemfile
@@ -2,7 +2,6 @@
 
 source "https://rubygems.org"
 
-gem "addressable", "~> 2.4.0"
 gem "appraisal", "~> 2.4.0"
 gem "benchmark-ips", "~> 2.8"
 gem "benchmark-memory", "< 0.2"

--- a/gemfiles/ruby_2.5.9_rails5_mysql2.gemfile.lock
+++ b/gemfiles/ruby_2.5.9_rails5_mysql2.gemfile.lock
@@ -232,7 +232,6 @@ PLATFORMS
   x86_64-linux
 
 DEPENDENCIES
-  addressable (~> 2.4.0)
   appraisal (~> 2.4.0)
   benchmark-ips (~> 2.8)
   benchmark-memory (< 0.2)

--- a/gemfiles/ruby_2.5.9_rails5_postgres.gemfile
+++ b/gemfiles/ruby_2.5.9_rails5_postgres.gemfile
@@ -2,7 +2,6 @@
 
 source "https://rubygems.org"
 
-gem "addressable", "~> 2.4.0"
 gem "appraisal", "~> 2.4.0"
 gem "benchmark-ips", "~> 2.8"
 gem "benchmark-memory", "< 0.2"

--- a/gemfiles/ruby_2.5.9_rails5_postgres.gemfile.lock
+++ b/gemfiles/ruby_2.5.9_rails5_postgres.gemfile.lock
@@ -252,7 +252,6 @@ PLATFORMS
   x86_64-linux
 
 DEPENDENCIES
-  addressable (~> 2.4.0)
   appraisal (~> 2.4.0)
   benchmark-ips (~> 2.8)
   benchmark-memory (< 0.2)

--- a/gemfiles/ruby_2.5.9_rails5_postgres_redis.gemfile
+++ b/gemfiles/ruby_2.5.9_rails5_postgres_redis.gemfile
@@ -2,7 +2,6 @@
 
 source "https://rubygems.org"
 
-gem "addressable", "~> 2.4.0"
 gem "appraisal", "~> 2.4.0"
 gem "benchmark-ips", "~> 2.8"
 gem "benchmark-memory", "< 0.2"

--- a/gemfiles/ruby_2.5.9_rails5_postgres_redis.gemfile.lock
+++ b/gemfiles/ruby_2.5.9_rails5_postgres_redis.gemfile.lock
@@ -257,7 +257,6 @@ PLATFORMS
   x86_64-linux
 
 DEPENDENCIES
-  addressable (~> 2.4.0)
   appraisal (~> 2.4.0)
   benchmark-ips (~> 2.8)
   benchmark-memory (< 0.2)

--- a/gemfiles/ruby_2.5.9_rails5_postgres_redis_activesupport.gemfile
+++ b/gemfiles/ruby_2.5.9_rails5_postgres_redis_activesupport.gemfile
@@ -2,7 +2,6 @@
 
 source "https://rubygems.org"
 
-gem "addressable", "~> 2.4.0"
 gem "appraisal", "~> 2.4.0"
 gem "benchmark-ips", "~> 2.8"
 gem "benchmark-memory", "< 0.2"

--- a/gemfiles/ruby_2.5.9_rails5_postgres_redis_activesupport.gemfile.lock
+++ b/gemfiles/ruby_2.5.9_rails5_postgres_redis_activesupport.gemfile.lock
@@ -269,7 +269,6 @@ PLATFORMS
   x86_64-linux
 
 DEPENDENCIES
-  addressable (~> 2.4.0)
   appraisal (~> 2.4.0)
   benchmark-ips (~> 2.8)
   benchmark-memory (< 0.2)

--- a/gemfiles/ruby_2.5.9_rails5_postgres_sidekiq.gemfile
+++ b/gemfiles/ruby_2.5.9_rails5_postgres_sidekiq.gemfile
@@ -2,7 +2,6 @@
 
 source "https://rubygems.org"
 
-gem "addressable", "~> 2.4.0"
 gem "appraisal", "~> 2.4.0"
 gem "benchmark-ips", "~> 2.8"
 gem "benchmark-memory", "< 0.2"

--- a/gemfiles/ruby_2.5.9_rails5_postgres_sidekiq.gemfile.lock
+++ b/gemfiles/ruby_2.5.9_rails5_postgres_sidekiq.gemfile.lock
@@ -259,7 +259,6 @@ PLATFORMS
 
 DEPENDENCIES
   activejob
-  addressable (~> 2.4.0)
   appraisal (~> 2.4.0)
   benchmark-ips (~> 2.8)
   benchmark-memory (< 0.2)

--- a/gemfiles/ruby_2.5.9_rails5_semantic_logger.gemfile
+++ b/gemfiles/ruby_2.5.9_rails5_semantic_logger.gemfile
@@ -2,7 +2,6 @@
 
 source "https://rubygems.org"
 
-gem "addressable", "~> 2.4.0"
 gem "appraisal", "~> 2.4.0"
 gem "benchmark-ips", "~> 2.8"
 gem "benchmark-memory", "< 0.2"

--- a/gemfiles/ruby_2.5.9_rails5_semantic_logger.gemfile.lock
+++ b/gemfiles/ruby_2.5.9_rails5_semantic_logger.gemfile.lock
@@ -251,7 +251,6 @@ PLATFORMS
   x86_64-linux
 
 DEPENDENCIES
-  addressable (~> 2.4.0)
   appraisal (~> 2.4.0)
   benchmark-ips (~> 2.8)
   benchmark-memory (< 0.2)

--- a/gemfiles/ruby_2.5.9_rails61_mysql2.gemfile
+++ b/gemfiles/ruby_2.5.9_rails61_mysql2.gemfile
@@ -2,7 +2,6 @@
 
 source "https://rubygems.org"
 
-gem "addressable", "~> 2.4.0"
 gem "appraisal", "~> 2.4.0"
 gem "benchmark-ips", "~> 2.8"
 gem "benchmark-memory", "< 0.2"

--- a/gemfiles/ruby_2.5.9_rails61_mysql2.gemfile.lock
+++ b/gemfiles/ruby_2.5.9_rails61_mysql2.gemfile.lock
@@ -251,7 +251,6 @@ PLATFORMS
   x86_64-linux
 
 DEPENDENCIES
-  addressable (~> 2.4.0)
   appraisal (~> 2.4.0)
   benchmark-ips (~> 2.8)
   benchmark-memory (< 0.2)

--- a/gemfiles/ruby_2.5.9_rails61_postgres.gemfile
+++ b/gemfiles/ruby_2.5.9_rails61_postgres.gemfile
@@ -2,7 +2,6 @@
 
 source "https://rubygems.org"
 
-gem "addressable", "~> 2.4.0"
 gem "appraisal", "~> 2.4.0"
 gem "benchmark-ips", "~> 2.8"
 gem "benchmark-memory", "< 0.2"

--- a/gemfiles/ruby_2.5.9_rails61_postgres.gemfile.lock
+++ b/gemfiles/ruby_2.5.9_rails61_postgres.gemfile.lock
@@ -271,7 +271,6 @@ PLATFORMS
   x86_64-linux
 
 DEPENDENCIES
-  addressable (~> 2.4.0)
   appraisal (~> 2.4.0)
   benchmark-ips (~> 2.8)
   benchmark-memory (< 0.2)

--- a/gemfiles/ruby_2.5.9_rails61_postgres_redis.gemfile
+++ b/gemfiles/ruby_2.5.9_rails61_postgres_redis.gemfile
@@ -2,7 +2,6 @@
 
 source "https://rubygems.org"
 
-gem "addressable", "~> 2.4.0"
 gem "appraisal", "~> 2.4.0"
 gem "benchmark-ips", "~> 2.8"
 gem "benchmark-memory", "< 0.2"

--- a/gemfiles/ruby_2.5.9_rails61_postgres_redis.gemfile.lock
+++ b/gemfiles/ruby_2.5.9_rails61_postgres_redis.gemfile.lock
@@ -276,7 +276,6 @@ PLATFORMS
   x86_64-linux
 
 DEPENDENCIES
-  addressable (~> 2.4.0)
   appraisal (~> 2.4.0)
   benchmark-ips (~> 2.8)
   benchmark-memory (< 0.2)

--- a/gemfiles/ruby_2.5.9_rails61_postgres_sidekiq.gemfile
+++ b/gemfiles/ruby_2.5.9_rails61_postgres_sidekiq.gemfile
@@ -2,7 +2,6 @@
 
 source "https://rubygems.org"
 
-gem "addressable", "~> 2.4.0"
 gem "appraisal", "~> 2.4.0"
 gem "benchmark-ips", "~> 2.8"
 gem "benchmark-memory", "< 0.2"

--- a/gemfiles/ruby_2.5.9_rails61_postgres_sidekiq.gemfile.lock
+++ b/gemfiles/ruby_2.5.9_rails61_postgres_sidekiq.gemfile.lock
@@ -277,7 +277,6 @@ PLATFORMS
   x86_64-linux
 
 DEPENDENCIES
-  addressable (~> 2.4.0)
   appraisal (~> 2.4.0)
   benchmark-ips (~> 2.8)
   benchmark-memory (< 0.2)

--- a/gemfiles/ruby_2.5.9_rails61_semantic_logger.gemfile
+++ b/gemfiles/ruby_2.5.9_rails61_semantic_logger.gemfile
@@ -2,7 +2,6 @@
 
 source "https://rubygems.org"
 
-gem "addressable", "~> 2.4.0"
 gem "appraisal", "~> 2.4.0"
 gem "benchmark-ips", "~> 2.8"
 gem "benchmark-memory", "< 0.2"

--- a/gemfiles/ruby_2.5.9_rails61_semantic_logger.gemfile.lock
+++ b/gemfiles/ruby_2.5.9_rails61_semantic_logger.gemfile.lock
@@ -270,7 +270,6 @@ PLATFORMS
   x86_64-linux
 
 DEPENDENCIES
-  addressable (~> 2.4.0)
   appraisal (~> 2.4.0)
   benchmark-ips (~> 2.8)
   benchmark-memory (< 0.2)

--- a/gemfiles/ruby_2.5.9_rails6_mysql2.gemfile
+++ b/gemfiles/ruby_2.5.9_rails6_mysql2.gemfile
@@ -2,7 +2,6 @@
 
 source "https://rubygems.org"
 
-gem "addressable", "~> 2.4.0"
 gem "appraisal", "~> 2.4.0"
 gem "benchmark-ips", "~> 2.8"
 gem "benchmark-memory", "< 0.2"

--- a/gemfiles/ruby_2.5.9_rails6_mysql2.gemfile.lock
+++ b/gemfiles/ruby_2.5.9_rails6_mysql2.gemfile.lock
@@ -248,7 +248,6 @@ PLATFORMS
   x86_64-linux
 
 DEPENDENCIES
-  addressable (~> 2.4.0)
   appraisal (~> 2.4.0)
   benchmark-ips (~> 2.8)
   benchmark-memory (< 0.2)

--- a/gemfiles/ruby_2.5.9_rails6_postgres.gemfile
+++ b/gemfiles/ruby_2.5.9_rails6_postgres.gemfile
@@ -2,7 +2,6 @@
 
 source "https://rubygems.org"
 
-gem "addressable", "~> 2.4.0"
 gem "appraisal", "~> 2.4.0"
 gem "benchmark-ips", "~> 2.8"
 gem "benchmark-memory", "< 0.2"

--- a/gemfiles/ruby_2.5.9_rails6_postgres.gemfile.lock
+++ b/gemfiles/ruby_2.5.9_rails6_postgres.gemfile.lock
@@ -268,7 +268,6 @@ PLATFORMS
   x86_64-linux
 
 DEPENDENCIES
-  addressable (~> 2.4.0)
   appraisal (~> 2.4.0)
   benchmark-ips (~> 2.8)
   benchmark-memory (< 0.2)

--- a/gemfiles/ruby_2.5.9_rails6_postgres_redis.gemfile
+++ b/gemfiles/ruby_2.5.9_rails6_postgres_redis.gemfile
@@ -2,7 +2,6 @@
 
 source "https://rubygems.org"
 
-gem "addressable", "~> 2.4.0"
 gem "appraisal", "~> 2.4.0"
 gem "benchmark-ips", "~> 2.8"
 gem "benchmark-memory", "< 0.2"

--- a/gemfiles/ruby_2.5.9_rails6_postgres_redis.gemfile.lock
+++ b/gemfiles/ruby_2.5.9_rails6_postgres_redis.gemfile.lock
@@ -273,7 +273,6 @@ PLATFORMS
   x86_64-linux
 
 DEPENDENCIES
-  addressable (~> 2.4.0)
   appraisal (~> 2.4.0)
   benchmark-ips (~> 2.8)
   benchmark-memory (< 0.2)

--- a/gemfiles/ruby_2.5.9_rails6_postgres_redis_activesupport.gemfile
+++ b/gemfiles/ruby_2.5.9_rails6_postgres_redis_activesupport.gemfile
@@ -2,7 +2,6 @@
 
 source "https://rubygems.org"
 
-gem "addressable", "~> 2.4.0"
 gem "appraisal", "~> 2.4.0"
 gem "benchmark-ips", "~> 2.8"
 gem "benchmark-memory", "< 0.2"

--- a/gemfiles/ruby_2.5.9_rails6_postgres_redis_activesupport.gemfile.lock
+++ b/gemfiles/ruby_2.5.9_rails6_postgres_redis_activesupport.gemfile.lock
@@ -285,7 +285,6 @@ PLATFORMS
   x86_64-linux
 
 DEPENDENCIES
-  addressable (~> 2.4.0)
   appraisal (~> 2.4.0)
   benchmark-ips (~> 2.8)
   benchmark-memory (< 0.2)

--- a/gemfiles/ruby_2.5.9_rails6_postgres_sidekiq.gemfile
+++ b/gemfiles/ruby_2.5.9_rails6_postgres_sidekiq.gemfile
@@ -2,7 +2,6 @@
 
 source "https://rubygems.org"
 
-gem "addressable", "~> 2.4.0"
 gem "appraisal", "~> 2.4.0"
 gem "benchmark-ips", "~> 2.8"
 gem "benchmark-memory", "< 0.2"

--- a/gemfiles/ruby_2.5.9_rails6_postgres_sidekiq.gemfile.lock
+++ b/gemfiles/ruby_2.5.9_rails6_postgres_sidekiq.gemfile.lock
@@ -275,7 +275,6 @@ PLATFORMS
 
 DEPENDENCIES
   activejob
-  addressable (~> 2.4.0)
   appraisal (~> 2.4.0)
   benchmark-ips (~> 2.8)
   benchmark-memory (< 0.2)

--- a/gemfiles/ruby_2.5.9_rails6_semantic_logger.gemfile
+++ b/gemfiles/ruby_2.5.9_rails6_semantic_logger.gemfile
@@ -2,7 +2,6 @@
 
 source "https://rubygems.org"
 
-gem "addressable", "~> 2.4.0"
 gem "appraisal", "~> 2.4.0"
 gem "benchmark-ips", "~> 2.8"
 gem "benchmark-memory", "< 0.2"

--- a/gemfiles/ruby_2.5.9_rails6_semantic_logger.gemfile.lock
+++ b/gemfiles/ruby_2.5.9_rails6_semantic_logger.gemfile.lock
@@ -267,7 +267,6 @@ PLATFORMS
   x86_64-linux
 
 DEPENDENCIES
-  addressable (~> 2.4.0)
   appraisal (~> 2.4.0)
   benchmark-ips (~> 2.8)
   benchmark-memory (< 0.2)

--- a/gemfiles/ruby_2.5.9_redis_3.gemfile
+++ b/gemfiles/ruby_2.5.9_redis_3.gemfile
@@ -2,7 +2,6 @@
 
 source "https://rubygems.org"
 
-gem "addressable", "~> 2.4.0"
 gem "appraisal", "~> 2.4.0"
 gem "benchmark-ips", "~> 2.8"
 gem "benchmark-memory", "< 0.2"

--- a/gemfiles/ruby_2.5.9_redis_3.gemfile.lock
+++ b/gemfiles/ruby_2.5.9_redis_3.gemfile.lock
@@ -121,7 +121,6 @@ PLATFORMS
   x86_64-linux
 
 DEPENDENCIES
-  addressable (~> 2.4.0)
   appraisal (~> 2.4.0)
   benchmark-ips (~> 2.8)
   benchmark-memory (< 0.2)

--- a/gemfiles/ruby_2.5.9_redis_4.gemfile
+++ b/gemfiles/ruby_2.5.9_redis_4.gemfile
@@ -2,7 +2,6 @@
 
 source "https://rubygems.org"
 
-gem "addressable", "~> 2.4.0"
 gem "appraisal", "~> 2.4.0"
 gem "benchmark-ips", "~> 2.8"
 gem "benchmark-memory", "< 0.2"

--- a/gemfiles/ruby_2.5.9_redis_4.gemfile.lock
+++ b/gemfiles/ruby_2.5.9_redis_4.gemfile.lock
@@ -121,7 +121,6 @@ PLATFORMS
   x86_64-linux
 
 DEPENDENCIES
-  addressable (~> 2.4.0)
   appraisal (~> 2.4.0)
   benchmark-ips (~> 2.8)
   benchmark-memory (< 0.2)

--- a/gemfiles/ruby_2.5.9_redis_5.gemfile
+++ b/gemfiles/ruby_2.5.9_redis_5.gemfile
@@ -2,7 +2,6 @@
 
 source "https://rubygems.org"
 
-gem "addressable", "~> 2.4.0"
 gem "appraisal", "~> 2.4.0"
 gem "benchmark-ips", "~> 2.8"
 gem "benchmark-memory", "< 0.2"

--- a/gemfiles/ruby_2.5.9_redis_5.gemfile.lock
+++ b/gemfiles/ruby_2.5.9_redis_5.gemfile.lock
@@ -125,7 +125,6 @@ PLATFORMS
   x86_64-linux
 
 DEPENDENCIES
-  addressable (~> 2.4.0)
   appraisal (~> 2.4.0)
   benchmark-ips (~> 2.8)
   benchmark-memory (< 0.2)

--- a/gemfiles/ruby_2.5.9_relational_db.gemfile
+++ b/gemfiles/ruby_2.5.9_relational_db.gemfile
@@ -2,7 +2,6 @@
 
 source "https://rubygems.org"
 
-gem "addressable", "~> 2.4.0"
 gem "appraisal", "~> 2.4.0"
 gem "benchmark-ips", "~> 2.8"
 gem "benchmark-memory", "< 0.2"

--- a/gemfiles/ruby_2.5.9_relational_db.gemfile.lock
+++ b/gemfiles/ruby_2.5.9_relational_db.gemfile.lock
@@ -65,6 +65,7 @@ GEM
     extlz4 (0.3.4)
     ffi (1.15.5)
     google-protobuf (3.19.1)
+    google-protobuf (3.19.1-x86_64-linux)
     hashdiff (1.0.1)
     i18n (1.14.1)
       concurrent-ruby (~> 1.0)
@@ -76,6 +77,8 @@ GEM
       ffi (~> 1.0)
     libddwaf (1.14.0.0.0-x86_64-linux)
       ffi (~> 1.0)
+    makara (0.5.1)
+      activerecord (>= 5.2.0)
     memory_profiler (0.9.14)
     method_source (1.0.0)
     minitest (5.15.0)
@@ -141,10 +144,10 @@ GEM
 
 PLATFORMS
   aarch64-linux
+  x86_64-linux
 
 DEPENDENCIES
   activerecord (~> 5)
-  addressable (~> 2.4.0)
   appraisal (~> 2.4.0)
   benchmark-ips (~> 2.8)
   benchmark-memory (< 0.2)

--- a/gemfiles/ruby_2.5.9_resque2_redis3.gemfile
+++ b/gemfiles/ruby_2.5.9_resque2_redis3.gemfile
@@ -2,7 +2,6 @@
 
 source "https://rubygems.org"
 
-gem "addressable", "~> 2.4.0"
 gem "appraisal", "~> 2.4.0"
 gem "benchmark-ips", "~> 2.8"
 gem "benchmark-memory", "< 0.2"

--- a/gemfiles/ruby_2.5.9_resque2_redis3.gemfile.lock
+++ b/gemfiles/ruby_2.5.9_resque2_redis3.gemfile.lock
@@ -142,7 +142,6 @@ PLATFORMS
   x86_64-linux
 
 DEPENDENCIES
-  addressable (~> 2.4.0)
   appraisal (~> 2.4.0)
   benchmark-ips (~> 2.8)
   benchmark-memory (< 0.2)

--- a/gemfiles/ruby_2.5.9_resque2_redis4.gemfile
+++ b/gemfiles/ruby_2.5.9_resque2_redis4.gemfile
@@ -2,7 +2,6 @@
 
 source "https://rubygems.org"
 
-gem "addressable", "~> 2.4.0"
 gem "appraisal", "~> 2.4.0"
 gem "benchmark-ips", "~> 2.8"
 gem "benchmark-memory", "< 0.2"

--- a/gemfiles/ruby_2.5.9_resque2_redis4.gemfile.lock
+++ b/gemfiles/ruby_2.5.9_resque2_redis4.gemfile.lock
@@ -146,7 +146,6 @@ PLATFORMS
   x86_64-linux
 
 DEPENDENCIES
-  addressable (~> 2.4.0)
   appraisal (~> 2.4.0)
   benchmark-ips (~> 2.8)
   benchmark-memory (< 0.2)

--- a/gemfiles/ruby_2.5.9_sinatra.gemfile
+++ b/gemfiles/ruby_2.5.9_sinatra.gemfile
@@ -2,7 +2,6 @@
 
 source "https://rubygems.org"
 
-gem "addressable", "~> 2.4.0"
 gem "appraisal", "~> 2.4.0"
 gem "benchmark-ips", "~> 2.8"
 gem "benchmark-memory", "< 0.2"

--- a/gemfiles/ruby_2.5.9_sinatra.gemfile.lock
+++ b/gemfiles/ruby_2.5.9_sinatra.gemfile.lock
@@ -134,7 +134,6 @@ PLATFORMS
   x86_64-linux
 
 DEPENDENCIES
-  addressable (~> 2.4.0)
   appraisal (~> 2.4.0)
   benchmark-ips (~> 2.8)
   benchmark-memory (< 0.2)

--- a/gemfiles/ruby_2.6.10_aws.gemfile
+++ b/gemfiles/ruby_2.6.10_aws.gemfile
@@ -2,7 +2,6 @@
 
 source "https://rubygems.org"
 
-gem "addressable", "~> 2.4.0"
 gem "appraisal", "~> 2.4.0"
 gem "benchmark-ips", "~> 2.8"
 gem "benchmark-memory", "< 0.2"

--- a/gemfiles/ruby_2.6.10_aws.gemfile.lock
+++ b/gemfiles/ruby_2.6.10_aws.gemfile.lock
@@ -1471,13 +1471,17 @@ GEM
     extlz4 (0.3.4)
     ffi (1.15.5)
     google-protobuf (3.19.1)
+    google-protobuf (3.19.1-x86_64-linux)
     hashdiff (1.0.1)
     jmespath (1.6.2)
     json (2.6.3)
     json-schema (2.8.1)
       addressable (>= 2.4)
     libdatadog (4.0.0.1.0-aarch64-linux)
+    libdatadog (4.0.0.1.0-x86_64-linux)
     libddwaf (1.14.0.0.0-aarch64-linux)
+      ffi (~> 1.0)
+    libddwaf (1.14.0.0.0-x86_64-linux)
       ffi (~> 1.0)
     memory_profiler (0.9.14)
     method_source (1.0.0)
@@ -1569,9 +1573,9 @@ GEM
 
 PLATFORMS
   aarch64-linux
+  x86_64-linux
 
 DEPENDENCIES
-  addressable (~> 2.4.0)
   appraisal (~> 2.4.0)
   aws-sdk
   benchmark-ips (~> 2.8)

--- a/gemfiles/ruby_2.6.10_contrib.gemfile
+++ b/gemfiles/ruby_2.6.10_contrib.gemfile
@@ -2,7 +2,6 @@
 
 source "https://rubygems.org"
 
-gem "addressable", "~> 2.4.0"
 gem "appraisal", "~> 2.4.0"
 gem "benchmark-ips", "~> 2.8"
 gem "benchmark-memory", "< 0.2"

--- a/gemfiles/ruby_2.6.10_contrib.gemfile.lock
+++ b/gemfiles/ruby_2.6.10_contrib.gemfile.lock
@@ -334,7 +334,6 @@ DEPENDENCIES
   actionpack
   actionview
   active_model_serializers (>= 0.10.0)
-  addressable (~> 2.4.0)
   appraisal (~> 2.4.0)
   benchmark-ips (~> 2.8)
   benchmark-memory (< 0.2)

--- a/gemfiles/ruby_2.6.10_contrib_old.gemfile
+++ b/gemfiles/ruby_2.6.10_contrib_old.gemfile
@@ -2,7 +2,6 @@
 
 source "https://rubygems.org"
 
-gem "addressable", "~> 2.4.0"
 gem "appraisal", "~> 2.4.0"
 gem "benchmark-ips", "~> 2.8"
 gem "benchmark-memory", "< 0.2"

--- a/gemfiles/ruby_2.6.10_contrib_old.gemfile.lock
+++ b/gemfiles/ruby_2.6.10_contrib_old.gemfile.lock
@@ -213,7 +213,6 @@ PLATFORMS
   x86_64-linux
 
 DEPENDENCIES
-  addressable (~> 2.4.0)
   appraisal (~> 2.4.0)
   benchmark-ips (~> 2.8)
   benchmark-memory (< 0.2)

--- a/gemfiles/ruby_2.6.10_core_old.gemfile
+++ b/gemfiles/ruby_2.6.10_core_old.gemfile
@@ -2,7 +2,6 @@
 
 source "https://rubygems.org"
 
-gem "addressable", "~> 2.4.0"
 gem "appraisal", "~> 2.4.0"
 gem "benchmark-ips", "~> 2.8"
 gem "benchmark-memory", "< 0.2"

--- a/gemfiles/ruby_2.6.10_core_old.gemfile.lock
+++ b/gemfiles/ruby_2.6.10_core_old.gemfile.lock
@@ -150,7 +150,6 @@ PLATFORMS
   x86_64-linux
 
 DEPENDENCIES
-  addressable (~> 2.4.0)
   appraisal (~> 2.4.0)
   benchmark-ips (~> 2.8)
   benchmark-memory (< 0.2)

--- a/gemfiles/ruby_2.6.10_hanami_1.gemfile
+++ b/gemfiles/ruby_2.6.10_hanami_1.gemfile
@@ -2,7 +2,6 @@
 
 source "https://rubygems.org"
 
-gem "addressable", "~> 2.4.0"
 gem "appraisal", "~> 2.4.0"
 gem "benchmark-ips", "~> 2.8"
 gem "benchmark-memory", "< 0.2"

--- a/gemfiles/ruby_2.6.10_hanami_1.gemfile.lock
+++ b/gemfiles/ruby_2.6.10_hanami_1.gemfile.lock
@@ -248,7 +248,6 @@ PLATFORMS
   x86_64-linux
 
 DEPENDENCIES
-  addressable (~> 2.4.0)
   appraisal (~> 2.4.0)
   benchmark-ips (~> 2.8)
   benchmark-memory (< 0.2)

--- a/gemfiles/ruby_2.6.10_http.gemfile
+++ b/gemfiles/ruby_2.6.10_http.gemfile
@@ -2,7 +2,6 @@
 
 source "https://rubygems.org"
 
-gem "addressable", "~> 2.4.0"
 gem "appraisal", "~> 2.4.0"
 gem "benchmark-ips", "~> 2.8"
 gem "benchmark-memory", "< 0.2"

--- a/gemfiles/ruby_2.6.10_http.gemfile.lock
+++ b/gemfiles/ruby_2.6.10_http.gemfile.lock
@@ -70,6 +70,7 @@ GEM
       ffi (>= 1.0.0)
       rake
     google-protobuf (3.19.1)
+    google-protobuf (3.19.1-x86_64-linux)
     hashdiff (1.0.1)
     http (5.0.1)
       addressable (~> 2.3)
@@ -85,7 +86,10 @@ GEM
     json-schema (2.8.1)
       addressable (>= 2.4)
     libdatadog (4.0.0.1.0-aarch64-linux)
+    libdatadog (4.0.0.1.0-x86_64-linux)
     libddwaf (1.14.0.0.0-aarch64-linux)
+      ffi (~> 1.0)
+    libddwaf (1.14.0.0.0-x86_64-linux)
       ffi (~> 1.0)
     llhttp-ffi (0.3.1)
       ffi-compiler (~> 1.0)
@@ -201,9 +205,9 @@ GEM
 
 PLATFORMS
   aarch64-linux
+  x86_64-linux
 
 DEPENDENCIES
-  addressable (~> 2.4.0)
   appraisal (~> 2.4.0)
   benchmark-ips (~> 2.8)
   benchmark-memory (< 0.2)

--- a/gemfiles/ruby_2.6.10_opentelemetry.gemfile
+++ b/gemfiles/ruby_2.6.10_opentelemetry.gemfile
@@ -2,7 +2,6 @@
 
 source "https://rubygems.org"
 
-gem "addressable", "~> 2.4.0"
 gem "appraisal", "~> 2.4.0"
 gem "benchmark-ips", "~> 2.8"
 gem "benchmark-memory", "< 0.2"

--- a/gemfiles/ruby_2.6.10_opentelemetry.gemfile.lock
+++ b/gemfiles/ruby_2.6.10_opentelemetry.gemfile.lock
@@ -162,7 +162,6 @@ PLATFORMS
   x86_64-linux
 
 DEPENDENCIES
-  addressable (~> 2.4.0)
   appraisal (~> 2.4.0)
   benchmark-ips (~> 2.8)
   benchmark-memory (< 0.2)

--- a/gemfiles/ruby_2.6.10_rails5_mysql2.gemfile
+++ b/gemfiles/ruby_2.6.10_rails5_mysql2.gemfile
@@ -2,7 +2,6 @@
 
 source "https://rubygems.org"
 
-gem "addressable", "~> 2.4.0"
 gem "appraisal", "~> 2.4.0"
 gem "benchmark-ips", "~> 2.8"
 gem "benchmark-memory", "< 0.2"

--- a/gemfiles/ruby_2.6.10_rails5_mysql2.gemfile.lock
+++ b/gemfiles/ruby_2.6.10_rails5_mysql2.gemfile.lock
@@ -274,7 +274,6 @@ PLATFORMS
   x86_64-linux
 
 DEPENDENCIES
-  addressable (~> 2.4.0)
   appraisal (~> 2.4.0)
   benchmark-ips (~> 2.8)
   benchmark-memory (< 0.2)

--- a/gemfiles/ruby_2.6.10_rails5_postgres.gemfile
+++ b/gemfiles/ruby_2.6.10_rails5_postgres.gemfile
@@ -2,7 +2,6 @@
 
 source "https://rubygems.org"
 
-gem "addressable", "~> 2.4.0"
 gem "appraisal", "~> 2.4.0"
 gem "benchmark-ips", "~> 2.8"
 gem "benchmark-memory", "< 0.2"

--- a/gemfiles/ruby_2.6.10_rails5_postgres.gemfile.lock
+++ b/gemfiles/ruby_2.6.10_rails5_postgres.gemfile.lock
@@ -274,7 +274,6 @@ PLATFORMS
   x86_64-linux
 
 DEPENDENCIES
-  addressable (~> 2.4.0)
   appraisal (~> 2.4.0)
   benchmark-ips (~> 2.8)
   benchmark-memory (< 0.2)

--- a/gemfiles/ruby_2.6.10_rails5_postgres_redis.gemfile
+++ b/gemfiles/ruby_2.6.10_rails5_postgres_redis.gemfile
@@ -2,7 +2,6 @@
 
 source "https://rubygems.org"
 
-gem "addressable", "~> 2.4.0"
 gem "appraisal", "~> 2.4.0"
 gem "benchmark-ips", "~> 2.8"
 gem "benchmark-memory", "< 0.2"

--- a/gemfiles/ruby_2.6.10_rails5_postgres_redis.gemfile.lock
+++ b/gemfiles/ruby_2.6.10_rails5_postgres_redis.gemfile.lock
@@ -275,7 +275,6 @@ PLATFORMS
   x86_64-linux
 
 DEPENDENCIES
-  addressable (~> 2.4.0)
   appraisal (~> 2.4.0)
   benchmark-ips (~> 2.8)
   benchmark-memory (< 0.2)

--- a/gemfiles/ruby_2.6.10_rails5_postgres_redis_activesupport.gemfile
+++ b/gemfiles/ruby_2.6.10_rails5_postgres_redis_activesupport.gemfile
@@ -2,7 +2,6 @@
 
 source "https://rubygems.org"
 
-gem "addressable", "~> 2.4.0"
 gem "appraisal", "~> 2.4.0"
 gem "benchmark-ips", "~> 2.8"
 gem "benchmark-memory", "< 0.2"

--- a/gemfiles/ruby_2.6.10_rails5_postgres_redis_activesupport.gemfile.lock
+++ b/gemfiles/ruby_2.6.10_rails5_postgres_redis_activesupport.gemfile.lock
@@ -291,7 +291,6 @@ PLATFORMS
   x86_64-linux
 
 DEPENDENCIES
-  addressable (~> 2.4.0)
   appraisal (~> 2.4.0)
   benchmark-ips (~> 2.8)
   benchmark-memory (< 0.2)

--- a/gemfiles/ruby_2.6.10_rails5_postgres_sidekiq.gemfile
+++ b/gemfiles/ruby_2.6.10_rails5_postgres_sidekiq.gemfile
@@ -2,7 +2,6 @@
 
 source "https://rubygems.org"
 
-gem "addressable", "~> 2.4.0"
 gem "appraisal", "~> 2.4.0"
 gem "benchmark-ips", "~> 2.8"
 gem "benchmark-memory", "< 0.2"

--- a/gemfiles/ruby_2.6.10_rails5_postgres_sidekiq.gemfile.lock
+++ b/gemfiles/ruby_2.6.10_rails5_postgres_sidekiq.gemfile.lock
@@ -281,7 +281,6 @@ PLATFORMS
 
 DEPENDENCIES
   activejob
-  addressable (~> 2.4.0)
   appraisal (~> 2.4.0)
   benchmark-ips (~> 2.8)
   benchmark-memory (< 0.2)

--- a/gemfiles/ruby_2.6.10_rails5_semantic_logger.gemfile
+++ b/gemfiles/ruby_2.6.10_rails5_semantic_logger.gemfile
@@ -2,7 +2,6 @@
 
 source "https://rubygems.org"
 
-gem "addressable", "~> 2.4.0"
 gem "appraisal", "~> 2.4.0"
 gem "benchmark-ips", "~> 2.8"
 gem "benchmark-memory", "< 0.2"

--- a/gemfiles/ruby_2.6.10_rails5_semantic_logger.gemfile.lock
+++ b/gemfiles/ruby_2.6.10_rails5_semantic_logger.gemfile.lock
@@ -273,7 +273,6 @@ PLATFORMS
   x86_64-linux
 
 DEPENDENCIES
-  addressable (~> 2.4.0)
   appraisal (~> 2.4.0)
   benchmark-ips (~> 2.8)
   benchmark-memory (< 0.2)

--- a/gemfiles/ruby_2.6.10_rails61_mysql2.gemfile
+++ b/gemfiles/ruby_2.6.10_rails61_mysql2.gemfile
@@ -2,7 +2,6 @@
 
 source "https://rubygems.org"
 
-gem "addressable", "~> 2.4.0"
 gem "appraisal", "~> 2.4.0"
 gem "benchmark-ips", "~> 2.8"
 gem "benchmark-memory", "< 0.2"

--- a/gemfiles/ruby_2.6.10_rails61_mysql2.gemfile.lock
+++ b/gemfiles/ruby_2.6.10_rails61_mysql2.gemfile.lock
@@ -293,7 +293,6 @@ PLATFORMS
   x86_64-linux
 
 DEPENDENCIES
-  addressable (~> 2.4.0)
   appraisal (~> 2.4.0)
   benchmark-ips (~> 2.8)
   benchmark-memory (< 0.2)

--- a/gemfiles/ruby_2.6.10_rails61_postgres.gemfile
+++ b/gemfiles/ruby_2.6.10_rails61_postgres.gemfile
@@ -2,7 +2,6 @@
 
 source "https://rubygems.org"
 
-gem "addressable", "~> 2.4.0"
 gem "appraisal", "~> 2.4.0"
 gem "benchmark-ips", "~> 2.8"
 gem "benchmark-memory", "< 0.2"

--- a/gemfiles/ruby_2.6.10_rails61_postgres.gemfile.lock
+++ b/gemfiles/ruby_2.6.10_rails61_postgres.gemfile.lock
@@ -293,7 +293,6 @@ PLATFORMS
   x86_64-linux
 
 DEPENDENCIES
-  addressable (~> 2.4.0)
   appraisal (~> 2.4.0)
   benchmark-ips (~> 2.8)
   benchmark-memory (< 0.2)

--- a/gemfiles/ruby_2.6.10_rails61_postgres_redis.gemfile
+++ b/gemfiles/ruby_2.6.10_rails61_postgres_redis.gemfile
@@ -2,7 +2,6 @@
 
 source "https://rubygems.org"
 
-gem "addressable", "~> 2.4.0"
 gem "appraisal", "~> 2.4.0"
 gem "benchmark-ips", "~> 2.8"
 gem "benchmark-memory", "< 0.2"

--- a/gemfiles/ruby_2.6.10_rails61_postgres_redis.gemfile.lock
+++ b/gemfiles/ruby_2.6.10_rails61_postgres_redis.gemfile.lock
@@ -294,7 +294,6 @@ PLATFORMS
   x86_64-linux
 
 DEPENDENCIES
-  addressable (~> 2.4.0)
   appraisal (~> 2.4.0)
   benchmark-ips (~> 2.8)
   benchmark-memory (< 0.2)

--- a/gemfiles/ruby_2.6.10_rails61_postgres_sidekiq.gemfile
+++ b/gemfiles/ruby_2.6.10_rails61_postgres_sidekiq.gemfile
@@ -2,7 +2,6 @@
 
 source "https://rubygems.org"
 
-gem "addressable", "~> 2.4.0"
 gem "appraisal", "~> 2.4.0"
 gem "benchmark-ips", "~> 2.8"
 gem "benchmark-memory", "< 0.2"

--- a/gemfiles/ruby_2.6.10_rails61_postgres_sidekiq.gemfile.lock
+++ b/gemfiles/ruby_2.6.10_rails61_postgres_sidekiq.gemfile.lock
@@ -299,7 +299,6 @@ PLATFORMS
   x86_64-linux
 
 DEPENDENCIES
-  addressable (~> 2.4.0)
   appraisal (~> 2.4.0)
   benchmark-ips (~> 2.8)
   benchmark-memory (< 0.2)

--- a/gemfiles/ruby_2.6.10_rails61_semantic_logger.gemfile
+++ b/gemfiles/ruby_2.6.10_rails61_semantic_logger.gemfile
@@ -2,7 +2,6 @@
 
 source "https://rubygems.org"
 
-gem "addressable", "~> 2.4.0"
 gem "appraisal", "~> 2.4.0"
 gem "benchmark-ips", "~> 2.8"
 gem "benchmark-memory", "< 0.2"

--- a/gemfiles/ruby_2.6.10_rails61_semantic_logger.gemfile.lock
+++ b/gemfiles/ruby_2.6.10_rails61_semantic_logger.gemfile.lock
@@ -292,7 +292,6 @@ PLATFORMS
   x86_64-linux
 
 DEPENDENCIES
-  addressable (~> 2.4.0)
   appraisal (~> 2.4.0)
   benchmark-ips (~> 2.8)
   benchmark-memory (< 0.2)

--- a/gemfiles/ruby_2.6.10_rails6_mysql2.gemfile
+++ b/gemfiles/ruby_2.6.10_rails6_mysql2.gemfile
@@ -2,7 +2,6 @@
 
 source "https://rubygems.org"
 
-gem "addressable", "~> 2.4.0"
 gem "appraisal", "~> 2.4.0"
 gem "benchmark-ips", "~> 2.8"
 gem "benchmark-memory", "< 0.2"

--- a/gemfiles/ruby_2.6.10_rails6_mysql2.gemfile.lock
+++ b/gemfiles/ruby_2.6.10_rails6_mysql2.gemfile.lock
@@ -290,7 +290,6 @@ PLATFORMS
   x86_64-linux
 
 DEPENDENCIES
-  addressable (~> 2.4.0)
   appraisal (~> 2.4.0)
   benchmark-ips (~> 2.8)
   benchmark-memory (< 0.2)

--- a/gemfiles/ruby_2.6.10_rails6_postgres.gemfile
+++ b/gemfiles/ruby_2.6.10_rails6_postgres.gemfile
@@ -2,7 +2,6 @@
 
 source "https://rubygems.org"
 
-gem "addressable", "~> 2.4.0"
 gem "appraisal", "~> 2.4.0"
 gem "benchmark-ips", "~> 2.8"
 gem "benchmark-memory", "< 0.2"

--- a/gemfiles/ruby_2.6.10_rails6_postgres.gemfile.lock
+++ b/gemfiles/ruby_2.6.10_rails6_postgres.gemfile.lock
@@ -290,7 +290,6 @@ PLATFORMS
   x86_64-linux
 
 DEPENDENCIES
-  addressable (~> 2.4.0)
   appraisal (~> 2.4.0)
   benchmark-ips (~> 2.8)
   benchmark-memory (< 0.2)

--- a/gemfiles/ruby_2.6.10_rails6_postgres_redis.gemfile
+++ b/gemfiles/ruby_2.6.10_rails6_postgres_redis.gemfile
@@ -2,7 +2,6 @@
 
 source "https://rubygems.org"
 
-gem "addressable", "~> 2.4.0"
 gem "appraisal", "~> 2.4.0"
 gem "benchmark-ips", "~> 2.8"
 gem "benchmark-memory", "< 0.2"

--- a/gemfiles/ruby_2.6.10_rails6_postgres_redis.gemfile.lock
+++ b/gemfiles/ruby_2.6.10_rails6_postgres_redis.gemfile.lock
@@ -291,7 +291,6 @@ PLATFORMS
   x86_64-linux
 
 DEPENDENCIES
-  addressable (~> 2.4.0)
   appraisal (~> 2.4.0)
   benchmark-ips (~> 2.8)
   benchmark-memory (< 0.2)

--- a/gemfiles/ruby_2.6.10_rails6_postgres_redis_activesupport.gemfile
+++ b/gemfiles/ruby_2.6.10_rails6_postgres_redis_activesupport.gemfile
@@ -2,7 +2,6 @@
 
 source "https://rubygems.org"
 
-gem "addressable", "~> 2.4.0"
 gem "appraisal", "~> 2.4.0"
 gem "benchmark-ips", "~> 2.8"
 gem "benchmark-memory", "< 0.2"

--- a/gemfiles/ruby_2.6.10_rails6_postgres_redis_activesupport.gemfile.lock
+++ b/gemfiles/ruby_2.6.10_rails6_postgres_redis_activesupport.gemfile.lock
@@ -307,7 +307,6 @@ PLATFORMS
   x86_64-linux
 
 DEPENDENCIES
-  addressable (~> 2.4.0)
   appraisal (~> 2.4.0)
   benchmark-ips (~> 2.8)
   benchmark-memory (< 0.2)

--- a/gemfiles/ruby_2.6.10_rails6_postgres_sidekiq.gemfile
+++ b/gemfiles/ruby_2.6.10_rails6_postgres_sidekiq.gemfile
@@ -2,7 +2,6 @@
 
 source "https://rubygems.org"
 
-gem "addressable", "~> 2.4.0"
 gem "appraisal", "~> 2.4.0"
 gem "benchmark-ips", "~> 2.8"
 gem "benchmark-memory", "< 0.2"

--- a/gemfiles/ruby_2.6.10_rails6_postgres_sidekiq.gemfile.lock
+++ b/gemfiles/ruby_2.6.10_rails6_postgres_sidekiq.gemfile.lock
@@ -297,7 +297,6 @@ PLATFORMS
 
 DEPENDENCIES
   activejob
-  addressable (~> 2.4.0)
   appraisal (~> 2.4.0)
   benchmark-ips (~> 2.8)
   benchmark-memory (< 0.2)

--- a/gemfiles/ruby_2.6.10_rails6_semantic_logger.gemfile
+++ b/gemfiles/ruby_2.6.10_rails6_semantic_logger.gemfile
@@ -2,7 +2,6 @@
 
 source "https://rubygems.org"
 
-gem "addressable", "~> 2.4.0"
 gem "appraisal", "~> 2.4.0"
 gem "benchmark-ips", "~> 2.8"
 gem "benchmark-memory", "< 0.2"

--- a/gemfiles/ruby_2.6.10_rails6_semantic_logger.gemfile.lock
+++ b/gemfiles/ruby_2.6.10_rails6_semantic_logger.gemfile.lock
@@ -289,7 +289,6 @@ PLATFORMS
   x86_64-linux
 
 DEPENDENCIES
-  addressable (~> 2.4.0)
   appraisal (~> 2.4.0)
   benchmark-ips (~> 2.8)
   benchmark-memory (< 0.2)

--- a/gemfiles/ruby_2.6.10_redis_3.gemfile
+++ b/gemfiles/ruby_2.6.10_redis_3.gemfile
@@ -2,7 +2,6 @@
 
 source "https://rubygems.org"
 
-gem "addressable", "~> 2.4.0"
 gem "appraisal", "~> 2.4.0"
 gem "benchmark-ips", "~> 2.8"
 gem "benchmark-memory", "< 0.2"

--- a/gemfiles/ruby_2.6.10_redis_3.gemfile.lock
+++ b/gemfiles/ruby_2.6.10_redis_3.gemfile.lock
@@ -151,7 +151,6 @@ PLATFORMS
   x86_64-linux
 
 DEPENDENCIES
-  addressable (~> 2.4.0)
   appraisal (~> 2.4.0)
   benchmark-ips (~> 2.8)
   benchmark-memory (< 0.2)

--- a/gemfiles/ruby_2.6.10_redis_4.gemfile
+++ b/gemfiles/ruby_2.6.10_redis_4.gemfile
@@ -2,7 +2,6 @@
 
 source "https://rubygems.org"
 
-gem "addressable", "~> 2.4.0"
 gem "appraisal", "~> 2.4.0"
 gem "benchmark-ips", "~> 2.8"
 gem "benchmark-memory", "< 0.2"

--- a/gemfiles/ruby_2.6.10_redis_4.gemfile.lock
+++ b/gemfiles/ruby_2.6.10_redis_4.gemfile.lock
@@ -151,7 +151,6 @@ PLATFORMS
   x86_64-linux
 
 DEPENDENCIES
-  addressable (~> 2.4.0)
   appraisal (~> 2.4.0)
   benchmark-ips (~> 2.8)
   benchmark-memory (< 0.2)

--- a/gemfiles/ruby_2.6.10_redis_5.gemfile
+++ b/gemfiles/ruby_2.6.10_redis_5.gemfile
@@ -2,7 +2,6 @@
 
 source "https://rubygems.org"
 
-gem "addressable", "~> 2.4.0"
 gem "appraisal", "~> 2.4.0"
 gem "benchmark-ips", "~> 2.8"
 gem "benchmark-memory", "< 0.2"

--- a/gemfiles/ruby_2.6.10_redis_5.gemfile.lock
+++ b/gemfiles/ruby_2.6.10_redis_5.gemfile.lock
@@ -155,7 +155,6 @@ PLATFORMS
   x86_64-linux
 
 DEPENDENCIES
-  addressable (~> 2.4.0)
   appraisal (~> 2.4.0)
   benchmark-ips (~> 2.8)
   benchmark-memory (< 0.2)

--- a/gemfiles/ruby_2.6.10_relational_db.gemfile
+++ b/gemfiles/ruby_2.6.10_relational_db.gemfile
@@ -2,7 +2,6 @@
 
 source "https://rubygems.org"
 
-gem "addressable", "~> 2.4.0"
 gem "appraisal", "~> 2.4.0"
 gem "benchmark-ips", "~> 2.8"
 gem "benchmark-memory", "< 0.2"

--- a/gemfiles/ruby_2.6.10_relational_db.gemfile.lock
+++ b/gemfiles/ruby_2.6.10_relational_db.gemfile.lock
@@ -66,6 +66,7 @@ GEM
     extlz4 (0.3.4)
     ffi (1.15.5)
     google-protobuf (3.19.1)
+    google-protobuf (3.19.1-x86_64-linux)
     hashdiff (1.0.1)
     i18n (1.14.1)
       concurrent-ruby (~> 1.0)
@@ -78,6 +79,8 @@ GEM
       ffi (~> 1.0)
     libddwaf (1.14.0.0.0-x86_64-linux)
       ffi (~> 1.0)
+    makara (0.5.1)
+      activerecord (>= 5.2.0)
     memory_profiler (0.9.14)
     method_source (1.0.0)
     minitest (5.20.0)
@@ -173,10 +176,10 @@ GEM
 
 PLATFORMS
   aarch64-linux
+  x86_64-linux
 
 DEPENDENCIES
   activerecord (~> 6.0.0)
-  addressable (~> 2.4.0)
   appraisal (~> 2.4.0)
   benchmark-ips (~> 2.8)
   benchmark-memory (< 0.2)

--- a/gemfiles/ruby_2.6.10_resque2_redis3.gemfile
+++ b/gemfiles/ruby_2.6.10_resque2_redis3.gemfile
@@ -2,7 +2,6 @@
 
 source "https://rubygems.org"
 
-gem "addressable", "~> 2.4.0"
 gem "appraisal", "~> 2.4.0"
 gem "benchmark-ips", "~> 2.8"
 gem "benchmark-memory", "< 0.2"

--- a/gemfiles/ruby_2.6.10_resque2_redis3.gemfile.lock
+++ b/gemfiles/ruby_2.6.10_resque2_redis3.gemfile.lock
@@ -172,7 +172,6 @@ PLATFORMS
   x86_64-linux
 
 DEPENDENCIES
-  addressable (~> 2.4.0)
   appraisal (~> 2.4.0)
   benchmark-ips (~> 2.8)
   benchmark-memory (< 0.2)

--- a/gemfiles/ruby_2.6.10_resque2_redis4.gemfile
+++ b/gemfiles/ruby_2.6.10_resque2_redis4.gemfile
@@ -2,7 +2,6 @@
 
 source "https://rubygems.org"
 
-gem "addressable", "~> 2.4.0"
 gem "appraisal", "~> 2.4.0"
 gem "benchmark-ips", "~> 2.8"
 gem "benchmark-memory", "< 0.2"

--- a/gemfiles/ruby_2.6.10_resque2_redis4.gemfile.lock
+++ b/gemfiles/ruby_2.6.10_resque2_redis4.gemfile.lock
@@ -172,7 +172,6 @@ PLATFORMS
   x86_64-linux
 
 DEPENDENCIES
-  addressable (~> 2.4.0)
   appraisal (~> 2.4.0)
   benchmark-ips (~> 2.8)
   benchmark-memory (< 0.2)

--- a/gemfiles/ruby_2.6.10_sinatra.gemfile
+++ b/gemfiles/ruby_2.6.10_sinatra.gemfile
@@ -2,7 +2,6 @@
 
 source "https://rubygems.org"
 
-gem "addressable", "~> 2.4.0"
 gem "appraisal", "~> 2.4.0"
 gem "benchmark-ips", "~> 2.8"
 gem "benchmark-memory", "< 0.2"

--- a/gemfiles/ruby_2.6.10_sinatra.gemfile.lock
+++ b/gemfiles/ruby_2.6.10_sinatra.gemfile.lock
@@ -164,7 +164,6 @@ PLATFORMS
   x86_64-linux
 
 DEPENDENCIES
-  addressable (~> 2.4.0)
   appraisal (~> 2.4.0)
   benchmark-ips (~> 2.8)
   benchmark-memory (< 0.2)

--- a/gemfiles/ruby_2.7.6_aws.gemfile
+++ b/gemfiles/ruby_2.7.6_aws.gemfile
@@ -2,7 +2,6 @@
 
 source "https://rubygems.org"
 
-gem "addressable", "~> 2.4.0"
 gem "appraisal", "~> 2.4.0"
 gem "benchmark-ips", "~> 2.8"
 gem "benchmark-memory", "< 0.2"

--- a/gemfiles/ruby_2.7.6_aws.gemfile.lock
+++ b/gemfiles/ruby_2.7.6_aws.gemfile.lock
@@ -1471,13 +1471,17 @@ GEM
     extlz4 (0.3.4)
     ffi (1.15.5)
     google-protobuf (3.24.2-aarch64-linux)
+    google-protobuf (3.24.2-x86_64-linux)
     hashdiff (1.0.1)
     jmespath (1.6.2)
     json (2.6.3)
     json-schema (2.8.1)
       addressable (>= 2.4)
     libdatadog (4.0.0.1.0-aarch64-linux)
+    libdatadog (4.0.0.1.0-x86_64-linux)
     libddwaf (1.14.0.0.0-aarch64-linux)
+      ffi (~> 1.0)
+    libddwaf (1.14.0.0.0-x86_64-linux)
       ffi (~> 1.0)
     memory_profiler (0.9.14)
     method_source (1.0.0)
@@ -1569,9 +1573,9 @@ GEM
 
 PLATFORMS
   aarch64-linux
+  x86_64-linux
 
 DEPENDENCIES
-  addressable (~> 2.4.0)
   appraisal (~> 2.4.0)
   aws-sdk
   benchmark-ips (~> 2.8)

--- a/gemfiles/ruby_2.7.6_contrib.gemfile
+++ b/gemfiles/ruby_2.7.6_contrib.gemfile
@@ -2,7 +2,6 @@
 
 source "https://rubygems.org"
 
-gem "addressable", "~> 2.4.0"
 gem "appraisal", "~> 2.4.0"
 gem "benchmark-ips", "~> 2.8"
 gem "benchmark-memory", "< 0.2"

--- a/gemfiles/ruby_2.7.6_contrib.gemfile.lock
+++ b/gemfiles/ruby_2.7.6_contrib.gemfile.lock
@@ -324,7 +324,6 @@ DEPENDENCIES
   actionpack
   actionview
   active_model_serializers (>= 0.10.0)
-  addressable (~> 2.4.0)
   appraisal (~> 2.4.0)
   benchmark-ips (~> 2.8)
   benchmark-memory (< 0.2)

--- a/gemfiles/ruby_2.7.6_contrib_old.gemfile
+++ b/gemfiles/ruby_2.7.6_contrib_old.gemfile
@@ -2,7 +2,6 @@
 
 source "https://rubygems.org"
 
-gem "addressable", "~> 2.4.0"
 gem "appraisal", "~> 2.4.0"
 gem "benchmark-ips", "~> 2.8"
 gem "benchmark-memory", "< 0.2"

--- a/gemfiles/ruby_2.7.6_contrib_old.gemfile.lock
+++ b/gemfiles/ruby_2.7.6_contrib_old.gemfile.lock
@@ -213,7 +213,6 @@ PLATFORMS
   x86_64-linux
 
 DEPENDENCIES
-  addressable (~> 2.4.0)
   appraisal (~> 2.4.0)
   benchmark-ips (~> 2.8)
   benchmark-memory (< 0.2)

--- a/gemfiles/ruby_2.7.6_core_old.gemfile
+++ b/gemfiles/ruby_2.7.6_core_old.gemfile
@@ -2,7 +2,6 @@
 
 source "https://rubygems.org"
 
-gem "addressable", "~> 2.4.0"
 gem "appraisal", "~> 2.4.0"
 gem "benchmark-ips", "~> 2.8"
 gem "benchmark-memory", "< 0.2"

--- a/gemfiles/ruby_2.7.6_core_old.gemfile.lock
+++ b/gemfiles/ruby_2.7.6_core_old.gemfile.lock
@@ -150,7 +150,6 @@ PLATFORMS
   x86_64-linux
 
 DEPENDENCIES
-  addressable (~> 2.4.0)
   appraisal (~> 2.4.0)
   benchmark-ips (~> 2.8)
   benchmark-memory (< 0.2)

--- a/gemfiles/ruby_2.7.6_hanami_1.gemfile
+++ b/gemfiles/ruby_2.7.6_hanami_1.gemfile
@@ -2,7 +2,6 @@
 
 source "https://rubygems.org"
 
-gem "addressable", "~> 2.4.0"
 gem "appraisal", "~> 2.4.0"
 gem "benchmark-ips", "~> 2.8"
 gem "benchmark-memory", "< 0.2"

--- a/gemfiles/ruby_2.7.6_hanami_1.gemfile.lock
+++ b/gemfiles/ruby_2.7.6_hanami_1.gemfile.lock
@@ -250,7 +250,6 @@ PLATFORMS
   x86_64-linux
 
 DEPENDENCIES
-  addressable (~> 2.4.0)
   appraisal (~> 2.4.0)
   benchmark-ips (~> 2.8)
   benchmark-memory (< 0.2)

--- a/gemfiles/ruby_2.7.6_http.gemfile
+++ b/gemfiles/ruby_2.7.6_http.gemfile
@@ -2,7 +2,6 @@
 
 source "https://rubygems.org"
 
-gem "addressable", "~> 2.4.0"
 gem "appraisal", "~> 2.4.0"
 gem "benchmark-ips", "~> 2.8"
 gem "benchmark-memory", "< 0.2"

--- a/gemfiles/ruby_2.7.6_http.gemfile.lock
+++ b/gemfiles/ruby_2.7.6_http.gemfile.lock
@@ -70,6 +70,7 @@ GEM
       ffi (>= 1.0.0)
       rake
     google-protobuf (3.24.3-aarch64-linux)
+    google-protobuf (3.24.3-x86_64-linux)
     hashdiff (1.0.1)
     http (5.0.1)
       addressable (~> 2.3)
@@ -85,7 +86,10 @@ GEM
     json-schema (2.8.1)
       addressable (>= 2.4)
     libdatadog (4.0.0.1.0-aarch64-linux)
+    libdatadog (4.0.0.1.0-x86_64-linux)
     libddwaf (1.14.0.0.0-aarch64-linux)
+      ffi (~> 1.0)
+    libddwaf (1.14.0.0.0-x86_64-linux)
       ffi (~> 1.0)
     llhttp-ffi (0.3.1)
       ffi-compiler (~> 1.0)
@@ -201,9 +205,9 @@ GEM
 
 PLATFORMS
   aarch64-linux
+  x86_64-linux
 
 DEPENDENCIES
-  addressable (~> 2.4.0)
   appraisal (~> 2.4.0)
   benchmark-ips (~> 2.8)
   benchmark-memory (< 0.2)

--- a/gemfiles/ruby_2.7.6_opentelemetry.gemfile
+++ b/gemfiles/ruby_2.7.6_opentelemetry.gemfile
@@ -2,7 +2,6 @@
 
 source "https://rubygems.org"
 
-gem "addressable", "~> 2.4.0"
 gem "appraisal", "~> 2.4.0"
 gem "benchmark-ips", "~> 2.8"
 gem "benchmark-memory", "< 0.2"

--- a/gemfiles/ruby_2.7.6_opentelemetry.gemfile.lock
+++ b/gemfiles/ruby_2.7.6_opentelemetry.gemfile.lock
@@ -162,7 +162,6 @@ PLATFORMS
   x86_64-linux
 
 DEPENDENCIES
-  addressable (~> 2.4.0)
   appraisal (~> 2.4.0)
   benchmark-ips (~> 2.8)
   benchmark-memory (< 0.2)

--- a/gemfiles/ruby_2.7.6_rails5_mysql2.gemfile
+++ b/gemfiles/ruby_2.7.6_rails5_mysql2.gemfile
@@ -2,7 +2,6 @@
 
 source "https://rubygems.org"
 
-gem "addressable", "~> 2.4.0"
 gem "appraisal", "~> 2.4.0"
 gem "benchmark-ips", "~> 2.8"
 gem "benchmark-memory", "< 0.2"

--- a/gemfiles/ruby_2.7.6_rails5_mysql2.gemfile.lock
+++ b/gemfiles/ruby_2.7.6_rails5_mysql2.gemfile.lock
@@ -274,7 +274,6 @@ PLATFORMS
   x86_64-linux
 
 DEPENDENCIES
-  addressable (~> 2.4.0)
   appraisal (~> 2.4.0)
   benchmark-ips (~> 2.8)
   benchmark-memory (< 0.2)

--- a/gemfiles/ruby_2.7.6_rails5_postgres.gemfile
+++ b/gemfiles/ruby_2.7.6_rails5_postgres.gemfile
@@ -2,7 +2,6 @@
 
 source "https://rubygems.org"
 
-gem "addressable", "~> 2.4.0"
 gem "appraisal", "~> 2.4.0"
 gem "benchmark-ips", "~> 2.8"
 gem "benchmark-memory", "< 0.2"

--- a/gemfiles/ruby_2.7.6_rails5_postgres.gemfile.lock
+++ b/gemfiles/ruby_2.7.6_rails5_postgres.gemfile.lock
@@ -274,7 +274,6 @@ PLATFORMS
   x86_64-linux
 
 DEPENDENCIES
-  addressable (~> 2.4.0)
   appraisal (~> 2.4.0)
   benchmark-ips (~> 2.8)
   benchmark-memory (< 0.2)

--- a/gemfiles/ruby_2.7.6_rails5_postgres_redis.gemfile
+++ b/gemfiles/ruby_2.7.6_rails5_postgres_redis.gemfile
@@ -2,7 +2,6 @@
 
 source "https://rubygems.org"
 
-gem "addressable", "~> 2.4.0"
 gem "appraisal", "~> 2.4.0"
 gem "benchmark-ips", "~> 2.8"
 gem "benchmark-memory", "< 0.2"

--- a/gemfiles/ruby_2.7.6_rails5_postgres_redis.gemfile.lock
+++ b/gemfiles/ruby_2.7.6_rails5_postgres_redis.gemfile.lock
@@ -275,7 +275,6 @@ PLATFORMS
   x86_64-linux
 
 DEPENDENCIES
-  addressable (~> 2.4.0)
   appraisal (~> 2.4.0)
   benchmark-ips (~> 2.8)
   benchmark-memory (< 0.2)

--- a/gemfiles/ruby_2.7.6_rails5_postgres_redis_activesupport.gemfile
+++ b/gemfiles/ruby_2.7.6_rails5_postgres_redis_activesupport.gemfile
@@ -2,7 +2,6 @@
 
 source "https://rubygems.org"
 
-gem "addressable", "~> 2.4.0"
 gem "appraisal", "~> 2.4.0"
 gem "benchmark-ips", "~> 2.8"
 gem "benchmark-memory", "< 0.2"

--- a/gemfiles/ruby_2.7.6_rails5_postgres_redis_activesupport.gemfile.lock
+++ b/gemfiles/ruby_2.7.6_rails5_postgres_redis_activesupport.gemfile.lock
@@ -291,7 +291,6 @@ PLATFORMS
   x86_64-linux
 
 DEPENDENCIES
-  addressable (~> 2.4.0)
   appraisal (~> 2.4.0)
   benchmark-ips (~> 2.8)
   benchmark-memory (< 0.2)

--- a/gemfiles/ruby_2.7.6_rails5_postgres_sidekiq.gemfile
+++ b/gemfiles/ruby_2.7.6_rails5_postgres_sidekiq.gemfile
@@ -2,7 +2,6 @@
 
 source "https://rubygems.org"
 
-gem "addressable", "~> 2.4.0"
 gem "appraisal", "~> 2.4.0"
 gem "benchmark-ips", "~> 2.8"
 gem "benchmark-memory", "< 0.2"

--- a/gemfiles/ruby_2.7.6_rails5_postgres_sidekiq.gemfile.lock
+++ b/gemfiles/ruby_2.7.6_rails5_postgres_sidekiq.gemfile.lock
@@ -281,7 +281,6 @@ PLATFORMS
 
 DEPENDENCIES
   activejob
-  addressable (~> 2.4.0)
   appraisal (~> 2.4.0)
   benchmark-ips (~> 2.8)
   benchmark-memory (< 0.2)

--- a/gemfiles/ruby_2.7.6_rails5_semantic_logger.gemfile
+++ b/gemfiles/ruby_2.7.6_rails5_semantic_logger.gemfile
@@ -2,7 +2,6 @@
 
 source "https://rubygems.org"
 
-gem "addressable", "~> 2.4.0"
 gem "appraisal", "~> 2.4.0"
 gem "benchmark-ips", "~> 2.8"
 gem "benchmark-memory", "< 0.2"

--- a/gemfiles/ruby_2.7.6_rails5_semantic_logger.gemfile.lock
+++ b/gemfiles/ruby_2.7.6_rails5_semantic_logger.gemfile.lock
@@ -273,7 +273,6 @@ PLATFORMS
   x86_64-linux
 
 DEPENDENCIES
-  addressable (~> 2.4.0)
   appraisal (~> 2.4.0)
   benchmark-ips (~> 2.8)
   benchmark-memory (< 0.2)

--- a/gemfiles/ruby_2.7.6_rails61_mysql2.gemfile
+++ b/gemfiles/ruby_2.7.6_rails61_mysql2.gemfile
@@ -2,7 +2,6 @@
 
 source "https://rubygems.org"
 
-gem "addressable", "~> 2.4.0"
 gem "appraisal", "~> 2.4.0"
 gem "benchmark-ips", "~> 2.8"
 gem "benchmark-memory", "< 0.2"

--- a/gemfiles/ruby_2.7.6_rails61_mysql2.gemfile.lock
+++ b/gemfiles/ruby_2.7.6_rails61_mysql2.gemfile.lock
@@ -293,7 +293,6 @@ PLATFORMS
   x86_64-linux
 
 DEPENDENCIES
-  addressable (~> 2.4.0)
   appraisal (~> 2.4.0)
   benchmark-ips (~> 2.8)
   benchmark-memory (< 0.2)

--- a/gemfiles/ruby_2.7.6_rails61_postgres.gemfile
+++ b/gemfiles/ruby_2.7.6_rails61_postgres.gemfile
@@ -2,7 +2,6 @@
 
 source "https://rubygems.org"
 
-gem "addressable", "~> 2.4.0"
 gem "appraisal", "~> 2.4.0"
 gem "benchmark-ips", "~> 2.8"
 gem "benchmark-memory", "< 0.2"

--- a/gemfiles/ruby_2.7.6_rails61_postgres.gemfile.lock
+++ b/gemfiles/ruby_2.7.6_rails61_postgres.gemfile.lock
@@ -293,7 +293,6 @@ PLATFORMS
   x86_64-linux
 
 DEPENDENCIES
-  addressable (~> 2.4.0)
   appraisal (~> 2.4.0)
   benchmark-ips (~> 2.8)
   benchmark-memory (< 0.2)

--- a/gemfiles/ruby_2.7.6_rails61_postgres_redis.gemfile
+++ b/gemfiles/ruby_2.7.6_rails61_postgres_redis.gemfile
@@ -2,7 +2,6 @@
 
 source "https://rubygems.org"
 
-gem "addressable", "~> 2.4.0"
 gem "appraisal", "~> 2.4.0"
 gem "benchmark-ips", "~> 2.8"
 gem "benchmark-memory", "< 0.2"

--- a/gemfiles/ruby_2.7.6_rails61_postgres_redis.gemfile.lock
+++ b/gemfiles/ruby_2.7.6_rails61_postgres_redis.gemfile.lock
@@ -294,7 +294,6 @@ PLATFORMS
   x86_64-linux
 
 DEPENDENCIES
-  addressable (~> 2.4.0)
   appraisal (~> 2.4.0)
   benchmark-ips (~> 2.8)
   benchmark-memory (< 0.2)

--- a/gemfiles/ruby_2.7.6_rails61_postgres_sidekiq.gemfile
+++ b/gemfiles/ruby_2.7.6_rails61_postgres_sidekiq.gemfile
@@ -2,7 +2,6 @@
 
 source "https://rubygems.org"
 
-gem "addressable", "~> 2.4.0"
 gem "appraisal", "~> 2.4.0"
 gem "benchmark-ips", "~> 2.8"
 gem "benchmark-memory", "< 0.2"

--- a/gemfiles/ruby_2.7.6_rails61_postgres_sidekiq.gemfile.lock
+++ b/gemfiles/ruby_2.7.6_rails61_postgres_sidekiq.gemfile.lock
@@ -301,7 +301,6 @@ PLATFORMS
   x86_64-linux
 
 DEPENDENCIES
-  addressable (~> 2.4.0)
   appraisal (~> 2.4.0)
   benchmark-ips (~> 2.8)
   benchmark-memory (< 0.2)

--- a/gemfiles/ruby_2.7.6_rails61_semantic_logger.gemfile
+++ b/gemfiles/ruby_2.7.6_rails61_semantic_logger.gemfile
@@ -2,7 +2,6 @@
 
 source "https://rubygems.org"
 
-gem "addressable", "~> 2.4.0"
 gem "appraisal", "~> 2.4.0"
 gem "benchmark-ips", "~> 2.8"
 gem "benchmark-memory", "< 0.2"

--- a/gemfiles/ruby_2.7.6_rails61_semantic_logger.gemfile.lock
+++ b/gemfiles/ruby_2.7.6_rails61_semantic_logger.gemfile.lock
@@ -292,7 +292,6 @@ PLATFORMS
   x86_64-linux
 
 DEPENDENCIES
-  addressable (~> 2.4.0)
   appraisal (~> 2.4.0)
   benchmark-ips (~> 2.8)
   benchmark-memory (< 0.2)

--- a/gemfiles/ruby_2.7.6_rails6_mysql2.gemfile
+++ b/gemfiles/ruby_2.7.6_rails6_mysql2.gemfile
@@ -2,7 +2,6 @@
 
 source "https://rubygems.org"
 
-gem "addressable", "~> 2.4.0"
 gem "appraisal", "~> 2.4.0"
 gem "benchmark-ips", "~> 2.8"
 gem "benchmark-memory", "< 0.2"

--- a/gemfiles/ruby_2.7.6_rails6_mysql2.gemfile.lock
+++ b/gemfiles/ruby_2.7.6_rails6_mysql2.gemfile.lock
@@ -290,7 +290,6 @@ PLATFORMS
   x86_64-linux
 
 DEPENDENCIES
-  addressable (~> 2.4.0)
   appraisal (~> 2.4.0)
   benchmark-ips (~> 2.8)
   benchmark-memory (< 0.2)

--- a/gemfiles/ruby_2.7.6_rails6_postgres.gemfile
+++ b/gemfiles/ruby_2.7.6_rails6_postgres.gemfile
@@ -2,7 +2,6 @@
 
 source "https://rubygems.org"
 
-gem "addressable", "~> 2.4.0"
 gem "appraisal", "~> 2.4.0"
 gem "benchmark-ips", "~> 2.8"
 gem "benchmark-memory", "< 0.2"

--- a/gemfiles/ruby_2.7.6_rails6_postgres.gemfile.lock
+++ b/gemfiles/ruby_2.7.6_rails6_postgres.gemfile.lock
@@ -290,7 +290,6 @@ PLATFORMS
   x86_64-linux
 
 DEPENDENCIES
-  addressable (~> 2.4.0)
   appraisal (~> 2.4.0)
   benchmark-ips (~> 2.8)
   benchmark-memory (< 0.2)

--- a/gemfiles/ruby_2.7.6_rails6_postgres_redis.gemfile
+++ b/gemfiles/ruby_2.7.6_rails6_postgres_redis.gemfile
@@ -2,7 +2,6 @@
 
 source "https://rubygems.org"
 
-gem "addressable", "~> 2.4.0"
 gem "appraisal", "~> 2.4.0"
 gem "benchmark-ips", "~> 2.8"
 gem "benchmark-memory", "< 0.2"

--- a/gemfiles/ruby_2.7.6_rails6_postgres_redis.gemfile.lock
+++ b/gemfiles/ruby_2.7.6_rails6_postgres_redis.gemfile.lock
@@ -291,7 +291,6 @@ PLATFORMS
   x86_64-linux
 
 DEPENDENCIES
-  addressable (~> 2.4.0)
   appraisal (~> 2.4.0)
   benchmark-ips (~> 2.8)
   benchmark-memory (< 0.2)

--- a/gemfiles/ruby_2.7.6_rails6_postgres_redis_activesupport.gemfile
+++ b/gemfiles/ruby_2.7.6_rails6_postgres_redis_activesupport.gemfile
@@ -2,7 +2,6 @@
 
 source "https://rubygems.org"
 
-gem "addressable", "~> 2.4.0"
 gem "appraisal", "~> 2.4.0"
 gem "benchmark-ips", "~> 2.8"
 gem "benchmark-memory", "< 0.2"

--- a/gemfiles/ruby_2.7.6_rails6_postgres_redis_activesupport.gemfile.lock
+++ b/gemfiles/ruby_2.7.6_rails6_postgres_redis_activesupport.gemfile.lock
@@ -307,7 +307,6 @@ PLATFORMS
   x86_64-linux
 
 DEPENDENCIES
-  addressable (~> 2.4.0)
   appraisal (~> 2.4.0)
   benchmark-ips (~> 2.8)
   benchmark-memory (< 0.2)

--- a/gemfiles/ruby_2.7.6_rails6_postgres_sidekiq.gemfile
+++ b/gemfiles/ruby_2.7.6_rails6_postgres_sidekiq.gemfile
@@ -2,7 +2,6 @@
 
 source "https://rubygems.org"
 
-gem "addressable", "~> 2.4.0"
 gem "appraisal", "~> 2.4.0"
 gem "benchmark-ips", "~> 2.8"
 gem "benchmark-memory", "< 0.2"

--- a/gemfiles/ruby_2.7.6_rails6_postgres_sidekiq.gemfile.lock
+++ b/gemfiles/ruby_2.7.6_rails6_postgres_sidekiq.gemfile.lock
@@ -297,7 +297,6 @@ PLATFORMS
 
 DEPENDENCIES
   activejob
-  addressable (~> 2.4.0)
   appraisal (~> 2.4.0)
   benchmark-ips (~> 2.8)
   benchmark-memory (< 0.2)

--- a/gemfiles/ruby_2.7.6_rails6_semantic_logger.gemfile
+++ b/gemfiles/ruby_2.7.6_rails6_semantic_logger.gemfile
@@ -2,7 +2,6 @@
 
 source "https://rubygems.org"
 
-gem "addressable", "~> 2.4.0"
 gem "appraisal", "~> 2.4.0"
 gem "benchmark-ips", "~> 2.8"
 gem "benchmark-memory", "< 0.2"

--- a/gemfiles/ruby_2.7.6_rails6_semantic_logger.gemfile.lock
+++ b/gemfiles/ruby_2.7.6_rails6_semantic_logger.gemfile.lock
@@ -289,7 +289,6 @@ PLATFORMS
   x86_64-linux
 
 DEPENDENCIES
-  addressable (~> 2.4.0)
   appraisal (~> 2.4.0)
   benchmark-ips (~> 2.8)
   benchmark-memory (< 0.2)

--- a/gemfiles/ruby_2.7.6_redis_3.gemfile
+++ b/gemfiles/ruby_2.7.6_redis_3.gemfile
@@ -2,7 +2,6 @@
 
 source "https://rubygems.org"
 
-gem "addressable", "~> 2.4.0"
 gem "appraisal", "~> 2.4.0"
 gem "benchmark-ips", "~> 2.8"
 gem "benchmark-memory", "< 0.2"

--- a/gemfiles/ruby_2.7.6_redis_3.gemfile.lock
+++ b/gemfiles/ruby_2.7.6_redis_3.gemfile.lock
@@ -151,7 +151,6 @@ PLATFORMS
   x86_64-linux
 
 DEPENDENCIES
-  addressable (~> 2.4.0)
   appraisal (~> 2.4.0)
   benchmark-ips (~> 2.8)
   benchmark-memory (< 0.2)

--- a/gemfiles/ruby_2.7.6_redis_4.gemfile
+++ b/gemfiles/ruby_2.7.6_redis_4.gemfile
@@ -2,7 +2,6 @@
 
 source "https://rubygems.org"
 
-gem "addressable", "~> 2.4.0"
 gem "appraisal", "~> 2.4.0"
 gem "benchmark-ips", "~> 2.8"
 gem "benchmark-memory", "< 0.2"

--- a/gemfiles/ruby_2.7.6_redis_4.gemfile.lock
+++ b/gemfiles/ruby_2.7.6_redis_4.gemfile.lock
@@ -151,7 +151,6 @@ PLATFORMS
   x86_64-linux
 
 DEPENDENCIES
-  addressable (~> 2.4.0)
   appraisal (~> 2.4.0)
   benchmark-ips (~> 2.8)
   benchmark-memory (< 0.2)

--- a/gemfiles/ruby_2.7.6_redis_5.gemfile
+++ b/gemfiles/ruby_2.7.6_redis_5.gemfile
@@ -2,7 +2,6 @@
 
 source "https://rubygems.org"
 
-gem "addressable", "~> 2.4.0"
 gem "appraisal", "~> 2.4.0"
 gem "benchmark-ips", "~> 2.8"
 gem "benchmark-memory", "< 0.2"

--- a/gemfiles/ruby_2.7.6_redis_5.gemfile.lock
+++ b/gemfiles/ruby_2.7.6_redis_5.gemfile.lock
@@ -155,7 +155,6 @@ PLATFORMS
   x86_64-linux
 
 DEPENDENCIES
-  addressable (~> 2.4.0)
   appraisal (~> 2.4.0)
   benchmark-ips (~> 2.8)
   benchmark-memory (< 0.2)

--- a/gemfiles/ruby_2.7.6_relational_db.gemfile
+++ b/gemfiles/ruby_2.7.6_relational_db.gemfile
@@ -2,7 +2,6 @@
 
 source "https://rubygems.org"
 
-gem "addressable", "~> 2.4.0"
 gem "appraisal", "~> 2.4.0"
 gem "benchmark-ips", "~> 2.8"
 gem "benchmark-memory", "< 0.2"

--- a/gemfiles/ruby_2.7.6_relational_db.gemfile.lock
+++ b/gemfiles/ruby_2.7.6_relational_db.gemfile.lock
@@ -66,6 +66,7 @@ GEM
     extlz4 (0.3.4)
     ffi (1.15.5)
     google-protobuf (3.24.3-aarch64-linux)
+    google-protobuf (3.24.3-x86_64-linux)
     hashdiff (1.0.1)
     i18n (1.14.1)
       concurrent-ruby (~> 1.0)
@@ -78,6 +79,8 @@ GEM
       ffi (~> 1.0)
     libddwaf (1.14.0.0.0-x86_64-linux)
       ffi (~> 1.0)
+    makara (0.5.1)
+      activerecord (>= 5.2.0)
     memory_profiler (0.9.14)
     method_source (1.0.0)
     minitest (5.20.0)
@@ -172,10 +175,10 @@ GEM
 
 PLATFORMS
   aarch64-linux
+  x86_64-linux
 
 DEPENDENCIES
   activerecord (~> 6.1.0)
-  addressable (~> 2.4.0)
   appraisal (~> 2.4.0)
   benchmark-ips (~> 2.8)
   benchmark-memory (< 0.2)

--- a/gemfiles/ruby_2.7.6_resque2_redis3.gemfile
+++ b/gemfiles/ruby_2.7.6_resque2_redis3.gemfile
@@ -2,7 +2,6 @@
 
 source "https://rubygems.org"
 
-gem "addressable", "~> 2.4.0"
 gem "appraisal", "~> 2.4.0"
 gem "benchmark-ips", "~> 2.8"
 gem "benchmark-memory", "< 0.2"

--- a/gemfiles/ruby_2.7.6_resque2_redis3.gemfile.lock
+++ b/gemfiles/ruby_2.7.6_resque2_redis3.gemfile.lock
@@ -172,7 +172,6 @@ PLATFORMS
   x86_64-linux
 
 DEPENDENCIES
-  addressable (~> 2.4.0)
   appraisal (~> 2.4.0)
   benchmark-ips (~> 2.8)
   benchmark-memory (< 0.2)

--- a/gemfiles/ruby_2.7.6_resque2_redis4.gemfile
+++ b/gemfiles/ruby_2.7.6_resque2_redis4.gemfile
@@ -2,7 +2,6 @@
 
 source "https://rubygems.org"
 
-gem "addressable", "~> 2.4.0"
 gem "appraisal", "~> 2.4.0"
 gem "benchmark-ips", "~> 2.8"
 gem "benchmark-memory", "< 0.2"

--- a/gemfiles/ruby_2.7.6_resque2_redis4.gemfile.lock
+++ b/gemfiles/ruby_2.7.6_resque2_redis4.gemfile.lock
@@ -172,7 +172,6 @@ PLATFORMS
   x86_64-linux
 
 DEPENDENCIES
-  addressable (~> 2.4.0)
   appraisal (~> 2.4.0)
   benchmark-ips (~> 2.8)
   benchmark-memory (< 0.2)

--- a/gemfiles/ruby_2.7.6_sinatra.gemfile
+++ b/gemfiles/ruby_2.7.6_sinatra.gemfile
@@ -2,7 +2,6 @@
 
 source "https://rubygems.org"
 
-gem "addressable", "~> 2.4.0"
 gem "appraisal", "~> 2.4.0"
 gem "benchmark-ips", "~> 2.8"
 gem "benchmark-memory", "< 0.2"

--- a/gemfiles/ruby_2.7.6_sinatra.gemfile.lock
+++ b/gemfiles/ruby_2.7.6_sinatra.gemfile.lock
@@ -164,7 +164,6 @@ PLATFORMS
   x86_64-linux
 
 DEPENDENCIES
-  addressable (~> 2.4.0)
   appraisal (~> 2.4.0)
   benchmark-ips (~> 2.8)
   benchmark-memory (< 0.2)

--- a/gemfiles/ruby_3.0.4_aws.gemfile
+++ b/gemfiles/ruby_3.0.4_aws.gemfile
@@ -2,7 +2,6 @@
 
 source "https://rubygems.org"
 
-gem "addressable", "~> 2.4.0"
 gem "appraisal", "~> 2.4.0"
 gem "benchmark-ips", "~> 2.8"
 gem "benchmark-memory", "< 0.2"

--- a/gemfiles/ruby_3.0.4_aws.gemfile.lock
+++ b/gemfiles/ruby_3.0.4_aws.gemfile.lock
@@ -1471,13 +1471,17 @@ GEM
     extlz4 (0.3.4)
     ffi (1.15.5)
     google-protobuf (3.24.2-aarch64-linux)
+    google-protobuf (3.24.2-x86_64-linux)
     hashdiff (1.0.1)
     jmespath (1.6.2)
     json (2.6.3)
     json-schema (2.8.1)
       addressable (>= 2.4)
     libdatadog (4.0.0.1.0-aarch64-linux)
+    libdatadog (4.0.0.1.0-x86_64-linux)
     libddwaf (1.14.0.0.0-aarch64-linux)
+      ffi (~> 1.0)
+    libddwaf (1.14.0.0.0-x86_64-linux)
       ffi (~> 1.0)
     memory_profiler (0.9.14)
     method_source (1.0.0)
@@ -1570,9 +1574,9 @@ GEM
 
 PLATFORMS
   aarch64-linux
+  x86_64-linux
 
 DEPENDENCIES
-  addressable (~> 2.4.0)
   appraisal (~> 2.4.0)
   aws-sdk
   benchmark-ips (~> 2.8)

--- a/gemfiles/ruby_3.0.4_contrib.gemfile
+++ b/gemfiles/ruby_3.0.4_contrib.gemfile
@@ -2,7 +2,6 @@
 
 source "https://rubygems.org"
 
-gem "addressable", "~> 2.4.0"
 gem "appraisal", "~> 2.4.0"
 gem "benchmark-ips", "~> 2.8"
 gem "benchmark-memory", "< 0.2"

--- a/gemfiles/ruby_3.0.4_contrib.gemfile.lock
+++ b/gemfiles/ruby_3.0.4_contrib.gemfile.lock
@@ -331,7 +331,6 @@ DEPENDENCIES
   actionpack (~> 7)
   actionview (~> 7)
   active_model_serializers (>= 0.10.0)
-  addressable (~> 2.4.0)
   appraisal (~> 2.4.0)
   benchmark-ips (~> 2.8)
   benchmark-memory (< 0.2)

--- a/gemfiles/ruby_3.0.4_contrib_old.gemfile
+++ b/gemfiles/ruby_3.0.4_contrib_old.gemfile
@@ -2,7 +2,6 @@
 
 source "https://rubygems.org"
 
-gem "addressable", "~> 2.4.0"
 gem "appraisal", "~> 2.4.0"
 gem "benchmark-ips", "~> 2.8"
 gem "benchmark-memory", "< 0.2"

--- a/gemfiles/ruby_3.0.4_contrib_old.gemfile.lock
+++ b/gemfiles/ruby_3.0.4_contrib_old.gemfile.lock
@@ -213,7 +213,6 @@ PLATFORMS
   x86_64-linux
 
 DEPENDENCIES
-  addressable (~> 2.4.0)
   appraisal (~> 2.4.0)
   benchmark-ips (~> 2.8)
   benchmark-memory (< 0.2)

--- a/gemfiles/ruby_3.0.4_core_old.gemfile
+++ b/gemfiles/ruby_3.0.4_core_old.gemfile
@@ -2,7 +2,6 @@
 
 source "https://rubygems.org"
 
-gem "addressable", "~> 2.4.0"
 gem "appraisal", "~> 2.4.0"
 gem "benchmark-ips", "~> 2.8"
 gem "benchmark-memory", "< 0.2"

--- a/gemfiles/ruby_3.0.4_core_old.gemfile.lock
+++ b/gemfiles/ruby_3.0.4_core_old.gemfile.lock
@@ -150,7 +150,6 @@ PLATFORMS
   x86_64-linux
 
 DEPENDENCIES
-  addressable (~> 2.4.0)
   appraisal (~> 2.4.0)
   benchmark-ips (~> 2.8)
   benchmark-memory (< 0.2)

--- a/gemfiles/ruby_3.0.4_http.gemfile
+++ b/gemfiles/ruby_3.0.4_http.gemfile
@@ -2,7 +2,6 @@
 
 source "https://rubygems.org"
 
-gem "addressable", "~> 2.4.0"
 gem "appraisal", "~> 2.4.0"
 gem "benchmark-ips", "~> 2.8"
 gem "benchmark-memory", "< 0.2"

--- a/gemfiles/ruby_3.0.4_http.gemfile.lock
+++ b/gemfiles/ruby_3.0.4_http.gemfile.lock
@@ -70,6 +70,7 @@ GEM
       ffi (>= 1.0.0)
       rake
     google-protobuf (3.24.3-aarch64-linux)
+    google-protobuf (3.24.3-x86_64-linux)
     hashdiff (1.0.1)
     http (5.0.1)
       addressable (~> 2.3)
@@ -85,7 +86,10 @@ GEM
     json-schema (2.8.1)
       addressable (>= 2.4)
     libdatadog (4.0.0.1.0-aarch64-linux)
+    libdatadog (4.0.0.1.0-x86_64-linux)
     libddwaf (1.14.0.0.0-aarch64-linux)
+      ffi (~> 1.0)
+    libddwaf (1.14.0.0.0-x86_64-linux)
       ffi (~> 1.0)
     llhttp-ffi (0.3.1)
       ffi-compiler (~> 1.0)
@@ -202,9 +206,9 @@ GEM
 
 PLATFORMS
   aarch64-linux
+  x86_64-linux
 
 DEPENDENCIES
-  addressable (~> 2.4.0)
   appraisal (~> 2.4.0)
   benchmark-ips (~> 2.8)
   benchmark-memory (< 0.2)

--- a/gemfiles/ruby_3.0.4_opentelemetry.gemfile
+++ b/gemfiles/ruby_3.0.4_opentelemetry.gemfile
@@ -2,7 +2,6 @@
 
 source "https://rubygems.org"
 
-gem "addressable", "~> 2.4.0"
 gem "appraisal", "~> 2.4.0"
 gem "benchmark-ips", "~> 2.8"
 gem "benchmark-memory", "< 0.2"

--- a/gemfiles/ruby_3.0.4_opentelemetry.gemfile.lock
+++ b/gemfiles/ruby_3.0.4_opentelemetry.gemfile.lock
@@ -162,7 +162,6 @@ PLATFORMS
   x86_64-linux
 
 DEPENDENCIES
-  addressable (~> 2.4.0)
   appraisal (~> 2.4.0)
   benchmark-ips (~> 2.8)
   benchmark-memory (< 0.2)

--- a/gemfiles/ruby_3.0.4_rails61_mysql2.gemfile
+++ b/gemfiles/ruby_3.0.4_rails61_mysql2.gemfile
@@ -2,7 +2,6 @@
 
 source "https://rubygems.org"
 
-gem "addressable", "~> 2.4.0"
 gem "appraisal", "~> 2.4.0"
 gem "benchmark-ips", "~> 2.8"
 gem "benchmark-memory", "< 0.2"

--- a/gemfiles/ruby_3.0.4_rails61_mysql2.gemfile.lock
+++ b/gemfiles/ruby_3.0.4_rails61_mysql2.gemfile.lock
@@ -293,7 +293,6 @@ PLATFORMS
   x86_64-linux
 
 DEPENDENCIES
-  addressable (~> 2.4.0)
   appraisal (~> 2.4.0)
   benchmark-ips (~> 2.8)
   benchmark-memory (< 0.2)

--- a/gemfiles/ruby_3.0.4_rails61_postgres.gemfile
+++ b/gemfiles/ruby_3.0.4_rails61_postgres.gemfile
@@ -2,7 +2,6 @@
 
 source "https://rubygems.org"
 
-gem "addressable", "~> 2.4.0"
 gem "appraisal", "~> 2.4.0"
 gem "benchmark-ips", "~> 2.8"
 gem "benchmark-memory", "< 0.2"

--- a/gemfiles/ruby_3.0.4_rails61_postgres.gemfile.lock
+++ b/gemfiles/ruby_3.0.4_rails61_postgres.gemfile.lock
@@ -293,7 +293,6 @@ PLATFORMS
   x86_64-linux
 
 DEPENDENCIES
-  addressable (~> 2.4.0)
   appraisal (~> 2.4.0)
   benchmark-ips (~> 2.8)
   benchmark-memory (< 0.2)

--- a/gemfiles/ruby_3.0.4_rails61_postgres_redis.gemfile
+++ b/gemfiles/ruby_3.0.4_rails61_postgres_redis.gemfile
@@ -2,7 +2,6 @@
 
 source "https://rubygems.org"
 
-gem "addressable", "~> 2.4.0"
 gem "appraisal", "~> 2.4.0"
 gem "benchmark-ips", "~> 2.8"
 gem "benchmark-memory", "< 0.2"

--- a/gemfiles/ruby_3.0.4_rails61_postgres_redis.gemfile.lock
+++ b/gemfiles/ruby_3.0.4_rails61_postgres_redis.gemfile.lock
@@ -294,7 +294,6 @@ PLATFORMS
   x86_64-linux
 
 DEPENDENCIES
-  addressable (~> 2.4.0)
   appraisal (~> 2.4.0)
   benchmark-ips (~> 2.8)
   benchmark-memory (< 0.2)

--- a/gemfiles/ruby_3.0.4_rails61_postgres_sidekiq.gemfile
+++ b/gemfiles/ruby_3.0.4_rails61_postgres_sidekiq.gemfile
@@ -2,7 +2,6 @@
 
 source "https://rubygems.org"
 
-gem "addressable", "~> 2.4.0"
 gem "appraisal", "~> 2.4.0"
 gem "benchmark-ips", "~> 2.8"
 gem "benchmark-memory", "< 0.2"

--- a/gemfiles/ruby_3.0.4_rails61_postgres_sidekiq.gemfile.lock
+++ b/gemfiles/ruby_3.0.4_rails61_postgres_sidekiq.gemfile.lock
@@ -307,7 +307,6 @@ PLATFORMS
   x86_64-linux
 
 DEPENDENCIES
-  addressable (~> 2.4.0)
   appraisal (~> 2.4.0)
   benchmark-ips (~> 2.8)
   benchmark-memory (< 0.2)

--- a/gemfiles/ruby_3.0.4_rails61_semantic_logger.gemfile
+++ b/gemfiles/ruby_3.0.4_rails61_semantic_logger.gemfile
@@ -2,7 +2,6 @@
 
 source "https://rubygems.org"
 
-gem "addressable", "~> 2.4.0"
 gem "appraisal", "~> 2.4.0"
 gem "benchmark-ips", "~> 2.8"
 gem "benchmark-memory", "< 0.2"

--- a/gemfiles/ruby_3.0.4_rails61_semantic_logger.gemfile.lock
+++ b/gemfiles/ruby_3.0.4_rails61_semantic_logger.gemfile.lock
@@ -292,7 +292,6 @@ PLATFORMS
   x86_64-linux
 
 DEPENDENCIES
-  addressable (~> 2.4.0)
   appraisal (~> 2.4.0)
   benchmark-ips (~> 2.8)
   benchmark-memory (< 0.2)

--- a/gemfiles/ruby_3.0.4_redis_3.gemfile
+++ b/gemfiles/ruby_3.0.4_redis_3.gemfile
@@ -2,7 +2,6 @@
 
 source "https://rubygems.org"
 
-gem "addressable", "~> 2.4.0"
 gem "appraisal", "~> 2.4.0"
 gem "benchmark-ips", "~> 2.8"
 gem "benchmark-memory", "< 0.2"

--- a/gemfiles/ruby_3.0.4_redis_3.gemfile.lock
+++ b/gemfiles/ruby_3.0.4_redis_3.gemfile.lock
@@ -151,7 +151,6 @@ PLATFORMS
   x86_64-linux
 
 DEPENDENCIES
-  addressable (~> 2.4.0)
   appraisal (~> 2.4.0)
   benchmark-ips (~> 2.8)
   benchmark-memory (< 0.2)

--- a/gemfiles/ruby_3.0.4_redis_4.gemfile
+++ b/gemfiles/ruby_3.0.4_redis_4.gemfile
@@ -2,7 +2,6 @@
 
 source "https://rubygems.org"
 
-gem "addressable", "~> 2.4.0"
 gem "appraisal", "~> 2.4.0"
 gem "benchmark-ips", "~> 2.8"
 gem "benchmark-memory", "< 0.2"

--- a/gemfiles/ruby_3.0.4_redis_4.gemfile.lock
+++ b/gemfiles/ruby_3.0.4_redis_4.gemfile.lock
@@ -151,7 +151,6 @@ PLATFORMS
   x86_64-linux
 
 DEPENDENCIES
-  addressable (~> 2.4.0)
   appraisal (~> 2.4.0)
   benchmark-ips (~> 2.8)
   benchmark-memory (< 0.2)

--- a/gemfiles/ruby_3.0.4_redis_5.gemfile
+++ b/gemfiles/ruby_3.0.4_redis_5.gemfile
@@ -2,7 +2,6 @@
 
 source "https://rubygems.org"
 
-gem "addressable", "~> 2.4.0"
 gem "appraisal", "~> 2.4.0"
 gem "benchmark-ips", "~> 2.8"
 gem "benchmark-memory", "< 0.2"

--- a/gemfiles/ruby_3.0.4_redis_5.gemfile.lock
+++ b/gemfiles/ruby_3.0.4_redis_5.gemfile.lock
@@ -155,7 +155,6 @@ PLATFORMS
   x86_64-linux
 
 DEPENDENCIES
-  addressable (~> 2.4.0)
   appraisal (~> 2.4.0)
   benchmark-ips (~> 2.8)
   benchmark-memory (< 0.2)

--- a/gemfiles/ruby_3.0.4_relational_db.gemfile
+++ b/gemfiles/ruby_3.0.4_relational_db.gemfile
@@ -2,7 +2,6 @@
 
 source "https://rubygems.org"
 
-gem "addressable", "~> 2.4.0"
 gem "appraisal", "~> 2.4.0"
 gem "benchmark-ips", "~> 2.8"
 gem "benchmark-memory", "< 0.2"

--- a/gemfiles/ruby_3.0.4_relational_db.gemfile.lock
+++ b/gemfiles/ruby_3.0.4_relational_db.gemfile.lock
@@ -65,6 +65,7 @@ GEM
     extlz4 (0.3.4)
     ffi (1.15.5)
     google-protobuf (3.24.3-aarch64-linux)
+    google-protobuf (3.24.3-x86_64-linux)
     hashdiff (1.0.1)
     i18n (1.14.1)
       concurrent-ruby (~> 1.0)
@@ -159,6 +160,7 @@ GEM
     simplecov-html (0.12.3)
     simplecov_json_formatter (0.1.4)
     sqlite3 (1.6.6-aarch64-linux)
+    sqlite3 (1.6.6-x86_64-linux)
     thor (1.2.2)
     tzinfo (2.0.6)
       concurrent-ruby (~> 1.0)
@@ -173,10 +175,10 @@ GEM
 
 PLATFORMS
   aarch64-linux
+  x86_64-linux
 
 DEPENDENCIES
   activerecord (~> 7)
-  addressable (~> 2.4.0)
   appraisal (~> 2.4.0)
   benchmark-ips (~> 2.8)
   benchmark-memory (< 0.2)

--- a/gemfiles/ruby_3.0.4_resque2_redis3.gemfile
+++ b/gemfiles/ruby_3.0.4_resque2_redis3.gemfile
@@ -2,7 +2,6 @@
 
 source "https://rubygems.org"
 
-gem "addressable", "~> 2.4.0"
 gem "appraisal", "~> 2.4.0"
 gem "benchmark-ips", "~> 2.8"
 gem "benchmark-memory", "< 0.2"

--- a/gemfiles/ruby_3.0.4_resque2_redis3.gemfile.lock
+++ b/gemfiles/ruby_3.0.4_resque2_redis3.gemfile.lock
@@ -172,7 +172,6 @@ PLATFORMS
   x86_64-linux
 
 DEPENDENCIES
-  addressable (~> 2.4.0)
   appraisal (~> 2.4.0)
   benchmark-ips (~> 2.8)
   benchmark-memory (< 0.2)

--- a/gemfiles/ruby_3.0.4_resque2_redis4.gemfile
+++ b/gemfiles/ruby_3.0.4_resque2_redis4.gemfile
@@ -2,7 +2,6 @@
 
 source "https://rubygems.org"
 
-gem "addressable", "~> 2.4.0"
 gem "appraisal", "~> 2.4.0"
 gem "benchmark-ips", "~> 2.8"
 gem "benchmark-memory", "< 0.2"

--- a/gemfiles/ruby_3.0.4_resque2_redis4.gemfile.lock
+++ b/gemfiles/ruby_3.0.4_resque2_redis4.gemfile.lock
@@ -176,7 +176,6 @@ PLATFORMS
   x86_64-linux
 
 DEPENDENCIES
-  addressable (~> 2.4.0)
   appraisal (~> 2.4.0)
   benchmark-ips (~> 2.8)
   benchmark-memory (< 0.2)

--- a/gemfiles/ruby_3.0.4_sinatra.gemfile
+++ b/gemfiles/ruby_3.0.4_sinatra.gemfile
@@ -2,7 +2,6 @@
 
 source "https://rubygems.org"
 
-gem "addressable", "~> 2.4.0"
 gem "appraisal", "~> 2.4.0"
 gem "benchmark-ips", "~> 2.8"
 gem "benchmark-memory", "< 0.2"

--- a/gemfiles/ruby_3.0.4_sinatra.gemfile.lock
+++ b/gemfiles/ruby_3.0.4_sinatra.gemfile.lock
@@ -164,7 +164,6 @@ PLATFORMS
   x86_64-linux
 
 DEPENDENCIES
-  addressable (~> 2.4.0)
   appraisal (~> 2.4.0)
   benchmark-ips (~> 2.8)
   benchmark-memory (< 0.2)

--- a/gemfiles/ruby_3.1.2_aws.gemfile
+++ b/gemfiles/ruby_3.1.2_aws.gemfile
@@ -2,7 +2,6 @@
 
 source "https://rubygems.org"
 
-gem "addressable", "~> 2.4.0"
 gem "appraisal", "~> 2.4.0"
 gem "benchmark-ips", "~> 2.8"
 gem "benchmark-memory", "< 0.2"

--- a/gemfiles/ruby_3.1.2_aws.gemfile.lock
+++ b/gemfiles/ruby_3.1.2_aws.gemfile.lock
@@ -1471,13 +1471,17 @@ GEM
     extlz4 (0.3.4)
     ffi (1.15.5)
     google-protobuf (3.24.2-aarch64-linux)
+    google-protobuf (3.24.2-x86_64-linux)
     hashdiff (1.0.1)
     jmespath (1.6.2)
     json (2.6.3)
     json-schema (2.8.1)
       addressable (>= 2.4)
     libdatadog (4.0.0.1.0-aarch64-linux)
+    libdatadog (4.0.0.1.0-x86_64-linux)
     libddwaf (1.14.0.0.0-aarch64-linux)
+      ffi (~> 1.0)
+    libddwaf (1.14.0.0.0-x86_64-linux)
       ffi (~> 1.0)
     memory_profiler (0.9.14)
     method_source (1.0.0)
@@ -1570,9 +1574,9 @@ GEM
 
 PLATFORMS
   aarch64-linux
+  x86_64-linux
 
 DEPENDENCIES
-  addressable (~> 2.4.0)
   appraisal (~> 2.4.0)
   aws-sdk
   benchmark-ips (~> 2.8)

--- a/gemfiles/ruby_3.1.2_contrib.gemfile
+++ b/gemfiles/ruby_3.1.2_contrib.gemfile
@@ -2,7 +2,6 @@
 
 source "https://rubygems.org"
 
-gem "addressable", "~> 2.4.0"
 gem "appraisal", "~> 2.4.0"
 gem "benchmark-ips", "~> 2.8"
 gem "benchmark-memory", "< 0.2"

--- a/gemfiles/ruby_3.1.2_contrib.gemfile.lock
+++ b/gemfiles/ruby_3.1.2_contrib.gemfile.lock
@@ -331,7 +331,6 @@ DEPENDENCIES
   actionpack (~> 7)
   actionview (~> 7)
   active_model_serializers (>= 0.10.0)
-  addressable (~> 2.4.0)
   appraisal (~> 2.4.0)
   benchmark-ips (~> 2.8)
   benchmark-memory (< 0.2)

--- a/gemfiles/ruby_3.1.2_contrib_old.gemfile
+++ b/gemfiles/ruby_3.1.2_contrib_old.gemfile
@@ -2,7 +2,6 @@
 
 source "https://rubygems.org"
 
-gem "addressable", "~> 2.4.0"
 gem "appraisal", "~> 2.4.0"
 gem "benchmark-ips", "~> 2.8"
 gem "benchmark-memory", "< 0.2"

--- a/gemfiles/ruby_3.1.2_contrib_old.gemfile.lock
+++ b/gemfiles/ruby_3.1.2_contrib_old.gemfile.lock
@@ -213,7 +213,6 @@ PLATFORMS
   x86_64-linux
 
 DEPENDENCIES
-  addressable (~> 2.4.0)
   appraisal (~> 2.4.0)
   benchmark-ips (~> 2.8)
   benchmark-memory (< 0.2)

--- a/gemfiles/ruby_3.1.2_core_old.gemfile
+++ b/gemfiles/ruby_3.1.2_core_old.gemfile
@@ -2,7 +2,6 @@
 
 source "https://rubygems.org"
 
-gem "addressable", "~> 2.4.0"
 gem "appraisal", "~> 2.4.0"
 gem "benchmark-ips", "~> 2.8"
 gem "benchmark-memory", "< 0.2"

--- a/gemfiles/ruby_3.1.2_core_old.gemfile.lock
+++ b/gemfiles/ruby_3.1.2_core_old.gemfile.lock
@@ -150,7 +150,6 @@ PLATFORMS
   x86_64-linux
 
 DEPENDENCIES
-  addressable (~> 2.4.0)
   appraisal (~> 2.4.0)
   benchmark-ips (~> 2.8)
   benchmark-memory (< 0.2)

--- a/gemfiles/ruby_3.1.2_http.gemfile
+++ b/gemfiles/ruby_3.1.2_http.gemfile
@@ -2,7 +2,6 @@
 
 source "https://rubygems.org"
 
-gem "addressable", "~> 2.4.0"
 gem "appraisal", "~> 2.4.0"
 gem "benchmark-ips", "~> 2.8"
 gem "benchmark-memory", "< 0.2"

--- a/gemfiles/ruby_3.1.2_http.gemfile.lock
+++ b/gemfiles/ruby_3.1.2_http.gemfile.lock
@@ -70,6 +70,7 @@ GEM
       ffi (>= 1.0.0)
       rake
     google-protobuf (3.24.3-aarch64-linux)
+    google-protobuf (3.24.3-x86_64-linux)
     hashdiff (1.0.1)
     http (5.0.1)
       addressable (~> 2.3)
@@ -85,7 +86,10 @@ GEM
     json-schema (2.8.1)
       addressable (>= 2.4)
     libdatadog (4.0.0.1.0-aarch64-linux)
+    libdatadog (4.0.0.1.0-x86_64-linux)
     libddwaf (1.14.0.0.0-aarch64-linux)
+      ffi (~> 1.0)
+    libddwaf (1.14.0.0.0-x86_64-linux)
       ffi (~> 1.0)
     llhttp-ffi (0.3.1)
       ffi-compiler (~> 1.0)
@@ -202,9 +206,9 @@ GEM
 
 PLATFORMS
   aarch64-linux
+  x86_64-linux
 
 DEPENDENCIES
-  addressable (~> 2.4.0)
   appraisal (~> 2.4.0)
   benchmark-ips (~> 2.8)
   benchmark-memory (< 0.2)

--- a/gemfiles/ruby_3.1.2_opentelemetry.gemfile
+++ b/gemfiles/ruby_3.1.2_opentelemetry.gemfile
@@ -2,7 +2,6 @@
 
 source "https://rubygems.org"
 
-gem "addressable", "~> 2.4.0"
 gem "appraisal", "~> 2.4.0"
 gem "benchmark-ips", "~> 2.8"
 gem "benchmark-memory", "< 0.2"

--- a/gemfiles/ruby_3.1.2_opentelemetry.gemfile.lock
+++ b/gemfiles/ruby_3.1.2_opentelemetry.gemfile.lock
@@ -167,7 +167,6 @@ PLATFORMS
   x86_64-linux
 
 DEPENDENCIES
-  addressable (~> 2.4.0)
   appraisal (~> 2.4.0)
   benchmark-ips (~> 2.8)
   benchmark-memory (< 0.2)

--- a/gemfiles/ruby_3.1.2_rails61_mysql2.gemfile
+++ b/gemfiles/ruby_3.1.2_rails61_mysql2.gemfile
@@ -2,7 +2,6 @@
 
 source "https://rubygems.org"
 
-gem "addressable", "~> 2.4.0"
 gem "appraisal", "~> 2.4.0"
 gem "benchmark-ips", "~> 2.8"
 gem "benchmark-memory", "< 0.2"

--- a/gemfiles/ruby_3.1.2_rails61_mysql2.gemfile.lock
+++ b/gemfiles/ruby_3.1.2_rails61_mysql2.gemfile.lock
@@ -293,7 +293,6 @@ PLATFORMS
   x86_64-linux
 
 DEPENDENCIES
-  addressable (~> 2.4.0)
   appraisal (~> 2.4.0)
   benchmark-ips (~> 2.8)
   benchmark-memory (< 0.2)

--- a/gemfiles/ruby_3.1.2_rails61_postgres.gemfile
+++ b/gemfiles/ruby_3.1.2_rails61_postgres.gemfile
@@ -2,7 +2,6 @@
 
 source "https://rubygems.org"
 
-gem "addressable", "~> 2.4.0"
 gem "appraisal", "~> 2.4.0"
 gem "benchmark-ips", "~> 2.8"
 gem "benchmark-memory", "< 0.2"

--- a/gemfiles/ruby_3.1.2_rails61_postgres.gemfile.lock
+++ b/gemfiles/ruby_3.1.2_rails61_postgres.gemfile.lock
@@ -293,7 +293,6 @@ PLATFORMS
   x86_64-linux
 
 DEPENDENCIES
-  addressable (~> 2.4.0)
   appraisal (~> 2.4.0)
   benchmark-ips (~> 2.8)
   benchmark-memory (< 0.2)

--- a/gemfiles/ruby_3.1.2_rails61_postgres_redis.gemfile
+++ b/gemfiles/ruby_3.1.2_rails61_postgres_redis.gemfile
@@ -2,7 +2,6 @@
 
 source "https://rubygems.org"
 
-gem "addressable", "~> 2.4.0"
 gem "appraisal", "~> 2.4.0"
 gem "benchmark-ips", "~> 2.8"
 gem "benchmark-memory", "< 0.2"

--- a/gemfiles/ruby_3.1.2_rails61_postgres_redis.gemfile.lock
+++ b/gemfiles/ruby_3.1.2_rails61_postgres_redis.gemfile.lock
@@ -294,7 +294,6 @@ PLATFORMS
   x86_64-linux
 
 DEPENDENCIES
-  addressable (~> 2.4.0)
   appraisal (~> 2.4.0)
   benchmark-ips (~> 2.8)
   benchmark-memory (< 0.2)

--- a/gemfiles/ruby_3.1.2_rails61_postgres_sidekiq.gemfile
+++ b/gemfiles/ruby_3.1.2_rails61_postgres_sidekiq.gemfile
@@ -2,7 +2,6 @@
 
 source "https://rubygems.org"
 
-gem "addressable", "~> 2.4.0"
 gem "appraisal", "~> 2.4.0"
 gem "benchmark-ips", "~> 2.8"
 gem "benchmark-memory", "< 0.2"

--- a/gemfiles/ruby_3.1.2_rails61_postgres_sidekiq.gemfile.lock
+++ b/gemfiles/ruby_3.1.2_rails61_postgres_sidekiq.gemfile.lock
@@ -307,7 +307,6 @@ PLATFORMS
   x86_64-linux
 
 DEPENDENCIES
-  addressable (~> 2.4.0)
   appraisal (~> 2.4.0)
   benchmark-ips (~> 2.8)
   benchmark-memory (< 0.2)

--- a/gemfiles/ruby_3.1.2_rails61_semantic_logger.gemfile
+++ b/gemfiles/ruby_3.1.2_rails61_semantic_logger.gemfile
@@ -2,7 +2,6 @@
 
 source "https://rubygems.org"
 
-gem "addressable", "~> 2.4.0"
 gem "appraisal", "~> 2.4.0"
 gem "benchmark-ips", "~> 2.8"
 gem "benchmark-memory", "< 0.2"

--- a/gemfiles/ruby_3.1.2_rails61_semantic_logger.gemfile.lock
+++ b/gemfiles/ruby_3.1.2_rails61_semantic_logger.gemfile.lock
@@ -292,7 +292,6 @@ PLATFORMS
   x86_64-linux
 
 DEPENDENCIES
-  addressable (~> 2.4.0)
   appraisal (~> 2.4.0)
   benchmark-ips (~> 2.8)
   benchmark-memory (< 0.2)

--- a/gemfiles/ruby_3.1.2_redis_3.gemfile
+++ b/gemfiles/ruby_3.1.2_redis_3.gemfile
@@ -2,7 +2,6 @@
 
 source "https://rubygems.org"
 
-gem "addressable", "~> 2.4.0"
 gem "appraisal", "~> 2.4.0"
 gem "benchmark-ips", "~> 2.8"
 gem "benchmark-memory", "< 0.2"

--- a/gemfiles/ruby_3.1.2_redis_3.gemfile.lock
+++ b/gemfiles/ruby_3.1.2_redis_3.gemfile.lock
@@ -151,7 +151,6 @@ PLATFORMS
   x86_64-linux
 
 DEPENDENCIES
-  addressable (~> 2.4.0)
   appraisal (~> 2.4.0)
   benchmark-ips (~> 2.8)
   benchmark-memory (< 0.2)

--- a/gemfiles/ruby_3.1.2_redis_4.gemfile
+++ b/gemfiles/ruby_3.1.2_redis_4.gemfile
@@ -2,7 +2,6 @@
 
 source "https://rubygems.org"
 
-gem "addressable", "~> 2.4.0"
 gem "appraisal", "~> 2.4.0"
 gem "benchmark-ips", "~> 2.8"
 gem "benchmark-memory", "< 0.2"

--- a/gemfiles/ruby_3.1.2_redis_4.gemfile.lock
+++ b/gemfiles/ruby_3.1.2_redis_4.gemfile.lock
@@ -151,7 +151,6 @@ PLATFORMS
   x86_64-linux
 
 DEPENDENCIES
-  addressable (~> 2.4.0)
   appraisal (~> 2.4.0)
   benchmark-ips (~> 2.8)
   benchmark-memory (< 0.2)

--- a/gemfiles/ruby_3.1.2_redis_5.gemfile
+++ b/gemfiles/ruby_3.1.2_redis_5.gemfile
@@ -2,7 +2,6 @@
 
 source "https://rubygems.org"
 
-gem "addressable", "~> 2.4.0"
 gem "appraisal", "~> 2.4.0"
 gem "benchmark-ips", "~> 2.8"
 gem "benchmark-memory", "< 0.2"

--- a/gemfiles/ruby_3.1.2_redis_5.gemfile.lock
+++ b/gemfiles/ruby_3.1.2_redis_5.gemfile.lock
@@ -155,7 +155,6 @@ PLATFORMS
   x86_64-linux
 
 DEPENDENCIES
-  addressable (~> 2.4.0)
   appraisal (~> 2.4.0)
   benchmark-ips (~> 2.8)
   benchmark-memory (< 0.2)

--- a/gemfiles/ruby_3.1.2_relational_db.gemfile
+++ b/gemfiles/ruby_3.1.2_relational_db.gemfile
@@ -2,7 +2,6 @@
 
 source "https://rubygems.org"
 
-gem "addressable", "~> 2.4.0"
 gem "appraisal", "~> 2.4.0"
 gem "benchmark-ips", "~> 2.8"
 gem "benchmark-memory", "< 0.2"

--- a/gemfiles/ruby_3.1.2_relational_db.gemfile.lock
+++ b/gemfiles/ruby_3.1.2_relational_db.gemfile.lock
@@ -65,6 +65,7 @@ GEM
     extlz4 (0.3.4)
     ffi (1.15.5)
     google-protobuf (3.24.3-aarch64-linux)
+    google-protobuf (3.24.3-x86_64-linux)
     hashdiff (1.0.1)
     i18n (1.14.1)
       concurrent-ruby (~> 1.0)
@@ -77,6 +78,8 @@ GEM
       ffi (~> 1.0)
     libddwaf (1.14.0.0.0-x86_64-linux)
       ffi (~> 1.0)
+    makara (0.6.0.pre)
+      activerecord (>= 5.2.0)
     memory_profiler (0.9.14)
     method_source (1.0.0)
     minitest (5.20.0)
@@ -157,6 +160,7 @@ GEM
     simplecov-html (0.12.3)
     simplecov_json_formatter (0.1.4)
     sqlite3 (1.6.6-aarch64-linux)
+    sqlite3 (1.6.6-x86_64-linux)
     thor (1.2.2)
     tzinfo (2.0.6)
       concurrent-ruby (~> 1.0)
@@ -171,10 +175,10 @@ GEM
 
 PLATFORMS
   aarch64-linux
+  x86_64-linux
 
 DEPENDENCIES
   activerecord (~> 7)
-  addressable (~> 2.4.0)
   appraisal (~> 2.4.0)
   benchmark-ips (~> 2.8)
   benchmark-memory (< 0.2)

--- a/gemfiles/ruby_3.1.2_resque2_redis3.gemfile
+++ b/gemfiles/ruby_3.1.2_resque2_redis3.gemfile
@@ -2,7 +2,6 @@
 
 source "https://rubygems.org"
 
-gem "addressable", "~> 2.4.0"
 gem "appraisal", "~> 2.4.0"
 gem "benchmark-ips", "~> 2.8"
 gem "benchmark-memory", "< 0.2"

--- a/gemfiles/ruby_3.1.2_resque2_redis3.gemfile.lock
+++ b/gemfiles/ruby_3.1.2_resque2_redis3.gemfile.lock
@@ -172,7 +172,6 @@ PLATFORMS
   x86_64-linux
 
 DEPENDENCIES
-  addressable (~> 2.4.0)
   appraisal (~> 2.4.0)
   benchmark-ips (~> 2.8)
   benchmark-memory (< 0.2)

--- a/gemfiles/ruby_3.1.2_resque2_redis4.gemfile
+++ b/gemfiles/ruby_3.1.2_resque2_redis4.gemfile
@@ -2,7 +2,6 @@
 
 source "https://rubygems.org"
 
-gem "addressable", "~> 2.4.0"
 gem "appraisal", "~> 2.4.0"
 gem "benchmark-ips", "~> 2.8"
 gem "benchmark-memory", "< 0.2"

--- a/gemfiles/ruby_3.1.2_resque2_redis4.gemfile.lock
+++ b/gemfiles/ruby_3.1.2_resque2_redis4.gemfile.lock
@@ -176,7 +176,6 @@ PLATFORMS
   x86_64-linux
 
 DEPENDENCIES
-  addressable (~> 2.4.0)
   appraisal (~> 2.4.0)
   benchmark-ips (~> 2.8)
   benchmark-memory (< 0.2)

--- a/gemfiles/ruby_3.1.2_sinatra.gemfile
+++ b/gemfiles/ruby_3.1.2_sinatra.gemfile
@@ -2,7 +2,6 @@
 
 source "https://rubygems.org"
 
-gem "addressable", "~> 2.4.0"
 gem "appraisal", "~> 2.4.0"
 gem "benchmark-ips", "~> 2.8"
 gem "benchmark-memory", "< 0.2"

--- a/gemfiles/ruby_3.1.2_sinatra.gemfile.lock
+++ b/gemfiles/ruby_3.1.2_sinatra.gemfile.lock
@@ -164,7 +164,6 @@ PLATFORMS
   x86_64-linux
 
 DEPENDENCIES
-  addressable (~> 2.4.0)
   appraisal (~> 2.4.0)
   benchmark-ips (~> 2.8)
   benchmark-memory (< 0.2)

--- a/gemfiles/ruby_3.2.0_aws.gemfile
+++ b/gemfiles/ruby_3.2.0_aws.gemfile
@@ -2,7 +2,6 @@
 
 source "https://rubygems.org"
 
-gem "addressable", "~> 2.4.0"
 gem "appraisal", "~> 2.4.0"
 gem "benchmark-ips", "~> 2.8"
 gem "benchmark-memory", "< 0.2"

--- a/gemfiles/ruby_3.2.0_aws.gemfile.lock
+++ b/gemfiles/ruby_3.2.0_aws.gemfile.lock
@@ -1470,13 +1470,17 @@ GEM
     extlz4 (0.3.4)
     ffi (1.15.5)
     google-protobuf (3.24.2-aarch64-linux)
+    google-protobuf (3.24.2-x86_64-linux)
     hashdiff (1.0.1)
     jmespath (1.6.2)
     json (2.6.3)
     json-schema (2.8.1)
       addressable (>= 2.4)
     libdatadog (4.0.0.1.0-aarch64-linux)
+    libdatadog (4.0.0.1.0-x86_64-linux)
     libddwaf (1.14.0.0.0-aarch64-linux)
+      ffi (~> 1.0)
+    libddwaf (1.14.0.0.0-x86_64-linux)
       ffi (~> 1.0)
     memory_profiler (0.9.14)
     method_source (1.0.0)
@@ -1566,9 +1570,9 @@ GEM
 
 PLATFORMS
   aarch64-linux
+  x86_64-linux
 
 DEPENDENCIES
-  addressable (~> 2.4.0)
   appraisal (~> 2.4.0)
   aws-sdk
   benchmark-ips (~> 2.8)

--- a/gemfiles/ruby_3.2.0_contrib.gemfile
+++ b/gemfiles/ruby_3.2.0_contrib.gemfile
@@ -2,7 +2,6 @@
 
 source "https://rubygems.org"
 
-gem "addressable", "~> 2.4.0"
 gem "appraisal", "~> 2.4.0"
 gem "benchmark-ips", "~> 2.8"
 gem "benchmark-memory", "< 0.2"

--- a/gemfiles/ruby_3.2.0_contrib.gemfile.lock
+++ b/gemfiles/ruby_3.2.0_contrib.gemfile.lock
@@ -325,7 +325,6 @@ DEPENDENCIES
   actionpack (~> 7)
   actionview (~> 7)
   active_model_serializers (>= 0.10.0)
-  addressable (~> 2.4.0)
   appraisal (~> 2.4.0)
   benchmark-ips (~> 2.8)
   benchmark-memory (< 0.2)

--- a/gemfiles/ruby_3.2.0_contrib_old.gemfile
+++ b/gemfiles/ruby_3.2.0_contrib_old.gemfile
@@ -2,7 +2,6 @@
 
 source "https://rubygems.org"
 
-gem "addressable", "~> 2.4.0"
 gem "appraisal", "~> 2.4.0"
 gem "benchmark-ips", "~> 2.8"
 gem "benchmark-memory", "< 0.2"

--- a/gemfiles/ruby_3.2.0_contrib_old.gemfile.lock
+++ b/gemfiles/ruby_3.2.0_contrib_old.gemfile.lock
@@ -209,7 +209,6 @@ PLATFORMS
   x86_64-linux
 
 DEPENDENCIES
-  addressable (~> 2.4.0)
   appraisal (~> 2.4.0)
   benchmark-ips (~> 2.8)
   benchmark-memory (< 0.2)

--- a/gemfiles/ruby_3.2.0_core_old.gemfile
+++ b/gemfiles/ruby_3.2.0_core_old.gemfile
@@ -2,7 +2,6 @@
 
 source "https://rubygems.org"
 
-gem "addressable", "~> 2.4.0"
 gem "appraisal", "~> 2.4.0"
 gem "benchmark-ips", "~> 2.8"
 gem "benchmark-memory", "< 0.2"

--- a/gemfiles/ruby_3.2.0_core_old.gemfile.lock
+++ b/gemfiles/ruby_3.2.0_core_old.gemfile.lock
@@ -146,7 +146,6 @@ PLATFORMS
   x86_64-linux
 
 DEPENDENCIES
-  addressable (~> 2.4.0)
   appraisal (~> 2.4.0)
   benchmark-ips (~> 2.8)
   benchmark-memory (< 0.2)

--- a/gemfiles/ruby_3.2.0_http.gemfile
+++ b/gemfiles/ruby_3.2.0_http.gemfile
@@ -2,7 +2,6 @@
 
 source "https://rubygems.org"
 
-gem "addressable", "~> 2.4.0"
 gem "appraisal", "~> 2.4.0"
 gem "benchmark-ips", "~> 2.8"
 gem "benchmark-memory", "< 0.2"

--- a/gemfiles/ruby_3.2.0_http.gemfile.lock
+++ b/gemfiles/ruby_3.2.0_http.gemfile.lock
@@ -69,6 +69,7 @@ GEM
       ffi (>= 1.0.0)
       rake
     google-protobuf (3.24.3-aarch64-linux)
+    google-protobuf (3.24.3-x86_64-linux)
     hashdiff (1.0.1)
     http (5.0.1)
       addressable (~> 2.3)
@@ -84,7 +85,10 @@ GEM
     json-schema (2.8.1)
       addressable (>= 2.4)
     libdatadog (4.0.0.1.0-aarch64-linux)
+    libdatadog (4.0.0.1.0-x86_64-linux)
     libddwaf (1.14.0.0.0-aarch64-linux)
+      ffi (~> 1.0)
+    libddwaf (1.14.0.0.0-x86_64-linux)
       ffi (~> 1.0)
     llhttp-ffi (0.3.1)
       ffi-compiler (~> 1.0)
@@ -198,9 +202,9 @@ GEM
 
 PLATFORMS
   aarch64-linux
+  x86_64-linux
 
 DEPENDENCIES
-  addressable (~> 2.4.0)
   appraisal (~> 2.4.0)
   benchmark-ips (~> 2.8)
   benchmark-memory (< 0.2)

--- a/gemfiles/ruby_3.2.0_opentelemetry.gemfile
+++ b/gemfiles/ruby_3.2.0_opentelemetry.gemfile
@@ -2,7 +2,6 @@
 
 source "https://rubygems.org"
 
-gem "addressable", "~> 2.4.0"
 gem "appraisal", "~> 2.4.0"
 gem "benchmark-ips", "~> 2.8"
 gem "benchmark-memory", "< 0.2"

--- a/gemfiles/ruby_3.2.0_opentelemetry.gemfile.lock
+++ b/gemfiles/ruby_3.2.0_opentelemetry.gemfile.lock
@@ -158,7 +158,6 @@ PLATFORMS
   x86_64-linux
 
 DEPENDENCIES
-  addressable (~> 2.4.0)
   appraisal (~> 2.4.0)
   benchmark-ips (~> 2.8)
   benchmark-memory (< 0.2)

--- a/gemfiles/ruby_3.2.0_rails61_mysql2.gemfile
+++ b/gemfiles/ruby_3.2.0_rails61_mysql2.gemfile
@@ -2,7 +2,6 @@
 
 source "https://rubygems.org"
 
-gem "addressable", "~> 2.4.0"
 gem "appraisal", "~> 2.4.0"
 gem "benchmark-ips", "~> 2.8"
 gem "benchmark-memory", "< 0.2"

--- a/gemfiles/ruby_3.2.0_rails61_mysql2.gemfile.lock
+++ b/gemfiles/ruby_3.2.0_rails61_mysql2.gemfile.lock
@@ -287,7 +287,6 @@ PLATFORMS
   x86_64-linux
 
 DEPENDENCIES
-  addressable (~> 2.4.0)
   appraisal (~> 2.4.0)
   benchmark-ips (~> 2.8)
   benchmark-memory (< 0.2)

--- a/gemfiles/ruby_3.2.0_rails61_postgres.gemfile
+++ b/gemfiles/ruby_3.2.0_rails61_postgres.gemfile
@@ -2,7 +2,6 @@
 
 source "https://rubygems.org"
 
-gem "addressable", "~> 2.4.0"
 gem "appraisal", "~> 2.4.0"
 gem "benchmark-ips", "~> 2.8"
 gem "benchmark-memory", "< 0.2"

--- a/gemfiles/ruby_3.2.0_rails61_postgres.gemfile.lock
+++ b/gemfiles/ruby_3.2.0_rails61_postgres.gemfile.lock
@@ -289,7 +289,6 @@ PLATFORMS
   x86_64-linux
 
 DEPENDENCIES
-  addressable (~> 2.4.0)
   appraisal (~> 2.4.0)
   benchmark-ips (~> 2.8)
   benchmark-memory (< 0.2)

--- a/gemfiles/ruby_3.2.0_rails61_postgres_redis.gemfile
+++ b/gemfiles/ruby_3.2.0_rails61_postgres_redis.gemfile
@@ -2,7 +2,6 @@
 
 source "https://rubygems.org"
 
-gem "addressable", "~> 2.4.0"
 gem "appraisal", "~> 2.4.0"
 gem "benchmark-ips", "~> 2.8"
 gem "benchmark-memory", "< 0.2"

--- a/gemfiles/ruby_3.2.0_rails61_postgres_redis.gemfile.lock
+++ b/gemfiles/ruby_3.2.0_rails61_postgres_redis.gemfile.lock
@@ -290,7 +290,6 @@ PLATFORMS
   x86_64-linux
 
 DEPENDENCIES
-  addressable (~> 2.4.0)
   appraisal (~> 2.4.0)
   benchmark-ips (~> 2.8)
   benchmark-memory (< 0.2)

--- a/gemfiles/ruby_3.2.0_rails61_postgres_sidekiq.gemfile
+++ b/gemfiles/ruby_3.2.0_rails61_postgres_sidekiq.gemfile
@@ -2,7 +2,6 @@
 
 source "https://rubygems.org"
 
-gem "addressable", "~> 2.4.0"
 gem "appraisal", "~> 2.4.0"
 gem "benchmark-ips", "~> 2.8"
 gem "benchmark-memory", "< 0.2"

--- a/gemfiles/ruby_3.2.0_rails61_postgres_sidekiq.gemfile.lock
+++ b/gemfiles/ruby_3.2.0_rails61_postgres_sidekiq.gemfile.lock
@@ -303,7 +303,6 @@ PLATFORMS
   x86_64-linux
 
 DEPENDENCIES
-  addressable (~> 2.4.0)
   appraisal (~> 2.4.0)
   benchmark-ips (~> 2.8)
   benchmark-memory (< 0.2)

--- a/gemfiles/ruby_3.2.0_rails61_semantic_logger.gemfile
+++ b/gemfiles/ruby_3.2.0_rails61_semantic_logger.gemfile
@@ -2,7 +2,6 @@
 
 source "https://rubygems.org"
 
-gem "addressable", "~> 2.4.0"
 gem "appraisal", "~> 2.4.0"
 gem "benchmark-ips", "~> 2.8"
 gem "benchmark-memory", "< 0.2"

--- a/gemfiles/ruby_3.2.0_rails61_semantic_logger.gemfile.lock
+++ b/gemfiles/ruby_3.2.0_rails61_semantic_logger.gemfile.lock
@@ -288,7 +288,6 @@ PLATFORMS
   x86_64-linux
 
 DEPENDENCIES
-  addressable (~> 2.4.0)
   appraisal (~> 2.4.0)
   benchmark-ips (~> 2.8)
   benchmark-memory (< 0.2)

--- a/gemfiles/ruby_3.2.0_redis_3.gemfile
+++ b/gemfiles/ruby_3.2.0_redis_3.gemfile
@@ -2,7 +2,6 @@
 
 source "https://rubygems.org"
 
-gem "addressable", "~> 2.4.0"
 gem "appraisal", "~> 2.4.0"
 gem "benchmark-ips", "~> 2.8"
 gem "benchmark-memory", "< 0.2"

--- a/gemfiles/ruby_3.2.0_redis_3.gemfile.lock
+++ b/gemfiles/ruby_3.2.0_redis_3.gemfile.lock
@@ -147,7 +147,6 @@ PLATFORMS
   x86_64-linux
 
 DEPENDENCIES
-  addressable (~> 2.4.0)
   appraisal (~> 2.4.0)
   benchmark-ips (~> 2.8)
   benchmark-memory (< 0.2)

--- a/gemfiles/ruby_3.2.0_redis_4.gemfile
+++ b/gemfiles/ruby_3.2.0_redis_4.gemfile
@@ -2,7 +2,6 @@
 
 source "https://rubygems.org"
 
-gem "addressable", "~> 2.4.0"
 gem "appraisal", "~> 2.4.0"
 gem "benchmark-ips", "~> 2.8"
 gem "benchmark-memory", "< 0.2"

--- a/gemfiles/ruby_3.2.0_redis_4.gemfile.lock
+++ b/gemfiles/ruby_3.2.0_redis_4.gemfile.lock
@@ -147,7 +147,6 @@ PLATFORMS
   x86_64-linux
 
 DEPENDENCIES
-  addressable (~> 2.4.0)
   appraisal (~> 2.4.0)
   benchmark-ips (~> 2.8)
   benchmark-memory (< 0.2)

--- a/gemfiles/ruby_3.2.0_redis_5.gemfile
+++ b/gemfiles/ruby_3.2.0_redis_5.gemfile
@@ -2,7 +2,6 @@
 
 source "https://rubygems.org"
 
-gem "addressable", "~> 2.4.0"
 gem "appraisal", "~> 2.4.0"
 gem "benchmark-ips", "~> 2.8"
 gem "benchmark-memory", "< 0.2"

--- a/gemfiles/ruby_3.2.0_redis_5.gemfile.lock
+++ b/gemfiles/ruby_3.2.0_redis_5.gemfile.lock
@@ -151,7 +151,6 @@ PLATFORMS
   x86_64-linux
 
 DEPENDENCIES
-  addressable (~> 2.4.0)
   appraisal (~> 2.4.0)
   benchmark-ips (~> 2.8)
   benchmark-memory (< 0.2)

--- a/gemfiles/ruby_3.2.0_relational_db.gemfile
+++ b/gemfiles/ruby_3.2.0_relational_db.gemfile
@@ -2,7 +2,6 @@
 
 source "https://rubygems.org"
 
-gem "addressable", "~> 2.4.0"
 gem "appraisal", "~> 2.4.0"
 gem "benchmark-ips", "~> 2.8"
 gem "benchmark-memory", "< 0.2"

--- a/gemfiles/ruby_3.2.0_relational_db.gemfile.lock
+++ b/gemfiles/ruby_3.2.0_relational_db.gemfile.lock
@@ -64,6 +64,7 @@ GEM
     extlz4 (0.3.4)
     ffi (1.15.5)
     google-protobuf (3.24.3-aarch64-linux)
+    google-protobuf (3.24.3-x86_64-linux)
     hashdiff (1.0.1)
     i18n (1.14.1)
       concurrent-ruby (~> 1.0)
@@ -76,6 +77,8 @@ GEM
       ffi (~> 1.0)
     libddwaf (1.14.0.0.0-x86_64-linux)
       ffi (~> 1.0)
+    makara (0.6.0.pre)
+      activerecord (>= 5.2.0)
     memory_profiler (0.9.14)
     method_source (1.0.0)
     minitest (5.20.0)
@@ -153,6 +156,7 @@ GEM
     simplecov-html (0.12.3)
     simplecov_json_formatter (0.1.4)
     sqlite3 (1.6.6-aarch64-linux)
+    sqlite3 (1.6.6-x86_64-linux)
     thor (1.2.2)
     tzinfo (2.0.6)
       concurrent-ruby (~> 1.0)
@@ -167,10 +171,10 @@ GEM
 
 PLATFORMS
   aarch64-linux
+  x86_64-linux
 
 DEPENDENCIES
   activerecord (~> 7)
-  addressable (~> 2.4.0)
   appraisal (~> 2.4.0)
   benchmark-ips (~> 2.8)
   benchmark-memory (< 0.2)

--- a/gemfiles/ruby_3.2.0_resque2_redis3.gemfile
+++ b/gemfiles/ruby_3.2.0_resque2_redis3.gemfile
@@ -2,7 +2,6 @@
 
 source "https://rubygems.org"
 
-gem "addressable", "~> 2.4.0"
 gem "appraisal", "~> 2.4.0"
 gem "benchmark-ips", "~> 2.8"
 gem "benchmark-memory", "< 0.2"

--- a/gemfiles/ruby_3.2.0_resque2_redis3.gemfile.lock
+++ b/gemfiles/ruby_3.2.0_resque2_redis3.gemfile.lock
@@ -168,7 +168,6 @@ PLATFORMS
   x86_64-linux
 
 DEPENDENCIES
-  addressable (~> 2.4.0)
   appraisal (~> 2.4.0)
   benchmark-ips (~> 2.8)
   benchmark-memory (< 0.2)

--- a/gemfiles/ruby_3.2.0_resque2_redis4.gemfile
+++ b/gemfiles/ruby_3.2.0_resque2_redis4.gemfile
@@ -2,7 +2,6 @@
 
 source "https://rubygems.org"
 
-gem "addressable", "~> 2.4.0"
 gem "appraisal", "~> 2.4.0"
 gem "benchmark-ips", "~> 2.8"
 gem "benchmark-memory", "< 0.2"

--- a/gemfiles/ruby_3.2.0_resque2_redis4.gemfile.lock
+++ b/gemfiles/ruby_3.2.0_resque2_redis4.gemfile.lock
@@ -172,7 +172,6 @@ PLATFORMS
   x86_64-linux
 
 DEPENDENCIES
-  addressable (~> 2.4.0)
   appraisal (~> 2.4.0)
   benchmark-ips (~> 2.8)
   benchmark-memory (< 0.2)

--- a/gemfiles/ruby_3.2.0_sinatra.gemfile
+++ b/gemfiles/ruby_3.2.0_sinatra.gemfile
@@ -2,7 +2,6 @@
 
 source "https://rubygems.org"
 
-gem "addressable", "~> 2.4.0"
 gem "appraisal", "~> 2.4.0"
 gem "benchmark-ips", "~> 2.8"
 gem "benchmark-memory", "< 0.2"

--- a/gemfiles/ruby_3.2.0_sinatra.gemfile.lock
+++ b/gemfiles/ruby_3.2.0_sinatra.gemfile.lock
@@ -160,7 +160,6 @@ PLATFORMS
   x86_64-linux
 
 DEPENDENCIES
-  addressable (~> 2.4.0)
   appraisal (~> 2.4.0)
   benchmark-ips (~> 2.8)
   benchmark-memory (< 0.2)

--- a/gemfiles/ruby_3.3.0_aws.gemfile
+++ b/gemfiles/ruby_3.3.0_aws.gemfile
@@ -2,7 +2,6 @@
 
 source "https://rubygems.org"
 
-gem "addressable", "~> 2.4.0"
 gem "appraisal", "~> 2.4.0"
 gem "benchmark-ips", "~> 2.8"
 gem "benchmark-memory", "< 0.2"

--- a/gemfiles/ruby_3.3.0_aws.gemfile.lock
+++ b/gemfiles/ruby_3.3.0_aws.gemfile.lock
@@ -1476,7 +1476,10 @@ GEM
     json-schema (2.8.1)
       addressable (>= 2.4)
     libdatadog (4.0.0.1.0-aarch64-linux)
+    libdatadog (4.0.0.1.0-x86_64-linux)
     libddwaf (1.14.0.0.0-aarch64-linux)
+      ffi (~> 1.0)
+    libddwaf (1.14.0.0.0-x86_64-linux)
       ffi (~> 1.0)
     memory_profiler (0.9.14)
     method_source (1.0.0)
@@ -1566,9 +1569,9 @@ GEM
 
 PLATFORMS
   aarch64-linux
+  x86_64-linux
 
 DEPENDENCIES
-  addressable (~> 2.4.0)
   appraisal (~> 2.4.0)
   aws-sdk
   benchmark-ips (~> 2.8)

--- a/gemfiles/ruby_3.3.0_contrib.gemfile
+++ b/gemfiles/ruby_3.3.0_contrib.gemfile
@@ -2,7 +2,6 @@
 
 source "https://rubygems.org"
 
-gem "addressable", "~> 2.4.0"
 gem "appraisal", "~> 2.4.0"
 gem "benchmark-ips", "~> 2.8"
 gem "benchmark-memory", "< 0.2"

--- a/gemfiles/ruby_3.3.0_contrib.gemfile.lock
+++ b/gemfiles/ruby_3.3.0_contrib.gemfile.lock
@@ -322,7 +322,6 @@ DEPENDENCIES
   actionpack (~> 7)
   actionview (~> 7)
   active_model_serializers (>= 0.10.0)
-  addressable (~> 2.4.0)
   appraisal (~> 2.4.0)
   benchmark-ips (~> 2.8)
   benchmark-memory (< 0.2)

--- a/gemfiles/ruby_3.3.0_contrib_old.gemfile
+++ b/gemfiles/ruby_3.3.0_contrib_old.gemfile
@@ -2,7 +2,6 @@
 
 source "https://rubygems.org"
 
-gem "addressable", "~> 2.4.0"
 gem "appraisal", "~> 2.4.0"
 gem "benchmark-ips", "~> 2.8"
 gem "benchmark-memory", "< 0.2"

--- a/gemfiles/ruby_3.3.0_contrib_old.gemfile.lock
+++ b/gemfiles/ruby_3.3.0_contrib_old.gemfile.lock
@@ -207,7 +207,6 @@ PLATFORMS
   x86_64-linux
 
 DEPENDENCIES
-  addressable (~> 2.4.0)
   appraisal (~> 2.4.0)
   benchmark-ips (~> 2.8)
   benchmark-memory (< 0.2)

--- a/gemfiles/ruby_3.3.0_core_old.gemfile
+++ b/gemfiles/ruby_3.3.0_core_old.gemfile
@@ -2,7 +2,6 @@
 
 source "https://rubygems.org"
 
-gem "addressable", "~> 2.4.0"
 gem "appraisal", "~> 2.4.0"
 gem "benchmark-ips", "~> 2.8"
 gem "benchmark-memory", "< 0.2"

--- a/gemfiles/ruby_3.3.0_core_old.gemfile.lock
+++ b/gemfiles/ruby_3.3.0_core_old.gemfile.lock
@@ -144,7 +144,6 @@ PLATFORMS
   x86_64-linux
 
 DEPENDENCIES
-  addressable (~> 2.4.0)
   appraisal (~> 2.4.0)
   benchmark-ips (~> 2.8)
   benchmark-memory (< 0.2)

--- a/gemfiles/ruby_3.3.0_http.gemfile
+++ b/gemfiles/ruby_3.3.0_http.gemfile
@@ -2,7 +2,6 @@
 
 source "https://rubygems.org"
 
-gem "addressable", "~> 2.4.0"
 gem "appraisal", "~> 2.4.0"
 gem "benchmark-ips", "~> 2.8"
 gem "benchmark-memory", "< 0.2"

--- a/gemfiles/ruby_3.3.0_http.gemfile.lock
+++ b/gemfiles/ruby_3.3.0_http.gemfile.lock
@@ -84,7 +84,10 @@ GEM
     json-schema (2.8.1)
       addressable (>= 2.4)
     libdatadog (4.0.0.1.0-aarch64-linux)
+    libdatadog (4.0.0.1.0-x86_64-linux)
     libddwaf (1.14.0.0.0-aarch64-linux)
+      ffi (~> 1.0)
+    libddwaf (1.14.0.0.0-x86_64-linux)
       ffi (~> 1.0)
     llhttp-ffi (0.3.1)
       ffi-compiler (~> 1.0)
@@ -198,9 +201,9 @@ GEM
 
 PLATFORMS
   aarch64-linux
+  x86_64-linux
 
 DEPENDENCIES
-  addressable (~> 2.4.0)
   appraisal (~> 2.4.0)
   benchmark-ips (~> 2.8)
   benchmark-memory (< 0.2)

--- a/gemfiles/ruby_3.3.0_opentelemetry.gemfile
+++ b/gemfiles/ruby_3.3.0_opentelemetry.gemfile
@@ -2,7 +2,6 @@
 
 source "https://rubygems.org"
 
-gem "addressable", "~> 2.4.0"
 gem "appraisal", "~> 2.4.0"
 gem "benchmark-ips", "~> 2.8"
 gem "benchmark-memory", "< 0.2"

--- a/gemfiles/ruby_3.3.0_opentelemetry.gemfile.lock
+++ b/gemfiles/ruby_3.3.0_opentelemetry.gemfile.lock
@@ -156,7 +156,6 @@ PLATFORMS
   x86_64-linux
 
 DEPENDENCIES
-  addressable (~> 2.4.0)
   appraisal (~> 2.4.0)
   benchmark-ips (~> 2.8)
   benchmark-memory (< 0.2)

--- a/gemfiles/ruby_3.3.0_rails61_mysql2.gemfile
+++ b/gemfiles/ruby_3.3.0_rails61_mysql2.gemfile
@@ -2,7 +2,6 @@
 
 source "https://rubygems.org"
 
-gem "addressable", "~> 2.4.0"
 gem "appraisal", "~> 2.4.0"
 gem "benchmark-ips", "~> 2.8"
 gem "benchmark-memory", "< 0.2"

--- a/gemfiles/ruby_3.3.0_rails61_mysql2.gemfile.lock
+++ b/gemfiles/ruby_3.3.0_rails61_mysql2.gemfile.lock
@@ -287,7 +287,6 @@ PLATFORMS
   x86_64-linux
 
 DEPENDENCIES
-  addressable (~> 2.4.0)
   appraisal (~> 2.4.0)
   benchmark-ips (~> 2.8)
   benchmark-memory (< 0.2)

--- a/gemfiles/ruby_3.3.0_rails61_postgres.gemfile
+++ b/gemfiles/ruby_3.3.0_rails61_postgres.gemfile
@@ -2,7 +2,6 @@
 
 source "https://rubygems.org"
 
-gem "addressable", "~> 2.4.0"
 gem "appraisal", "~> 2.4.0"
 gem "benchmark-ips", "~> 2.8"
 gem "benchmark-memory", "< 0.2"

--- a/gemfiles/ruby_3.3.0_rails61_postgres.gemfile.lock
+++ b/gemfiles/ruby_3.3.0_rails61_postgres.gemfile.lock
@@ -287,7 +287,6 @@ PLATFORMS
   x86_64-linux
 
 DEPENDENCIES
-  addressable (~> 2.4.0)
   appraisal (~> 2.4.0)
   benchmark-ips (~> 2.8)
   benchmark-memory (< 0.2)

--- a/gemfiles/ruby_3.3.0_rails61_postgres_redis.gemfile
+++ b/gemfiles/ruby_3.3.0_rails61_postgres_redis.gemfile
@@ -2,7 +2,6 @@
 
 source "https://rubygems.org"
 
-gem "addressable", "~> 2.4.0"
 gem "appraisal", "~> 2.4.0"
 gem "benchmark-ips", "~> 2.8"
 gem "benchmark-memory", "< 0.2"

--- a/gemfiles/ruby_3.3.0_rails61_postgres_redis.gemfile.lock
+++ b/gemfiles/ruby_3.3.0_rails61_postgres_redis.gemfile.lock
@@ -288,7 +288,6 @@ PLATFORMS
   x86_64-linux
 
 DEPENDENCIES
-  addressable (~> 2.4.0)
   appraisal (~> 2.4.0)
   benchmark-ips (~> 2.8)
   benchmark-memory (< 0.2)

--- a/gemfiles/ruby_3.3.0_rails61_postgres_sidekiq.gemfile
+++ b/gemfiles/ruby_3.3.0_rails61_postgres_sidekiq.gemfile
@@ -2,7 +2,6 @@
 
 source "https://rubygems.org"
 
-gem "addressable", "~> 2.4.0"
 gem "appraisal", "~> 2.4.0"
 gem "benchmark-ips", "~> 2.8"
 gem "benchmark-memory", "< 0.2"

--- a/gemfiles/ruby_3.3.0_rails61_postgres_sidekiq.gemfile.lock
+++ b/gemfiles/ruby_3.3.0_rails61_postgres_sidekiq.gemfile.lock
@@ -301,7 +301,6 @@ PLATFORMS
   x86_64-linux
 
 DEPENDENCIES
-  addressable (~> 2.4.0)
   appraisal (~> 2.4.0)
   benchmark-ips (~> 2.8)
   benchmark-memory (< 0.2)

--- a/gemfiles/ruby_3.3.0_rails61_semantic_logger.gemfile
+++ b/gemfiles/ruby_3.3.0_rails61_semantic_logger.gemfile
@@ -2,7 +2,6 @@
 
 source "https://rubygems.org"
 
-gem "addressable", "~> 2.4.0"
 gem "appraisal", "~> 2.4.0"
 gem "benchmark-ips", "~> 2.8"
 gem "benchmark-memory", "< 0.2"

--- a/gemfiles/ruby_3.3.0_rails61_semantic_logger.gemfile.lock
+++ b/gemfiles/ruby_3.3.0_rails61_semantic_logger.gemfile.lock
@@ -286,7 +286,6 @@ PLATFORMS
   x86_64-linux
 
 DEPENDENCIES
-  addressable (~> 2.4.0)
   appraisal (~> 2.4.0)
   benchmark-ips (~> 2.8)
   benchmark-memory (< 0.2)

--- a/gemfiles/ruby_3.3.0_redis_3.gemfile
+++ b/gemfiles/ruby_3.3.0_redis_3.gemfile
@@ -2,7 +2,6 @@
 
 source "https://rubygems.org"
 
-gem "addressable", "~> 2.4.0"
 gem "appraisal", "~> 2.4.0"
 gem "benchmark-ips", "~> 2.8"
 gem "benchmark-memory", "< 0.2"

--- a/gemfiles/ruby_3.3.0_redis_3.gemfile.lock
+++ b/gemfiles/ruby_3.3.0_redis_3.gemfile.lock
@@ -145,7 +145,6 @@ PLATFORMS
   x86_64-linux
 
 DEPENDENCIES
-  addressable (~> 2.4.0)
   appraisal (~> 2.4.0)
   benchmark-ips (~> 2.8)
   benchmark-memory (< 0.2)

--- a/gemfiles/ruby_3.3.0_redis_4.gemfile
+++ b/gemfiles/ruby_3.3.0_redis_4.gemfile
@@ -2,7 +2,6 @@
 
 source "https://rubygems.org"
 
-gem "addressable", "~> 2.4.0"
 gem "appraisal", "~> 2.4.0"
 gem "benchmark-ips", "~> 2.8"
 gem "benchmark-memory", "< 0.2"

--- a/gemfiles/ruby_3.3.0_redis_4.gemfile.lock
+++ b/gemfiles/ruby_3.3.0_redis_4.gemfile.lock
@@ -145,7 +145,6 @@ PLATFORMS
   x86_64-linux
 
 DEPENDENCIES
-  addressable (~> 2.4.0)
   appraisal (~> 2.4.0)
   benchmark-ips (~> 2.8)
   benchmark-memory (< 0.2)

--- a/gemfiles/ruby_3.3.0_redis_5.gemfile
+++ b/gemfiles/ruby_3.3.0_redis_5.gemfile
@@ -2,7 +2,6 @@
 
 source "https://rubygems.org"
 
-gem "addressable", "~> 2.4.0"
 gem "appraisal", "~> 2.4.0"
 gem "benchmark-ips", "~> 2.8"
 gem "benchmark-memory", "< 0.2"

--- a/gemfiles/ruby_3.3.0_redis_5.gemfile.lock
+++ b/gemfiles/ruby_3.3.0_redis_5.gemfile.lock
@@ -149,7 +149,6 @@ PLATFORMS
   x86_64-linux
 
 DEPENDENCIES
-  addressable (~> 2.4.0)
   appraisal (~> 2.4.0)
   benchmark-ips (~> 2.8)
   benchmark-memory (< 0.2)

--- a/gemfiles/ruby_3.3.0_relational_db.gemfile
+++ b/gemfiles/ruby_3.3.0_relational_db.gemfile
@@ -2,7 +2,6 @@
 
 source "https://rubygems.org"
 
-gem "addressable", "~> 2.4.0"
 gem "appraisal", "~> 2.4.0"
 gem "benchmark-ips", "~> 2.8"
 gem "benchmark-memory", "< 0.2"

--- a/gemfiles/ruby_3.3.0_relational_db.gemfile.lock
+++ b/gemfiles/ruby_3.3.0_relational_db.gemfile.lock
@@ -76,6 +76,8 @@ GEM
       ffi (~> 1.0)
     libddwaf (1.14.0.0.0-x86_64-linux)
       ffi (~> 1.0)
+    makara (0.6.0.pre)
+      activerecord (>= 5.2.0)
     memory_profiler (0.9.14)
     method_source (1.0.0)
     mini_portile2 (2.8.4)
@@ -169,10 +171,10 @@ GEM
 
 PLATFORMS
   aarch64-linux
+  x86_64-linux
 
 DEPENDENCIES
   activerecord (~> 7)
-  addressable (~> 2.4.0)
   appraisal (~> 2.4.0)
   benchmark-ips (~> 2.8)
   benchmark-memory (< 0.2)

--- a/gemfiles/ruby_3.3.0_resque2_redis3.gemfile
+++ b/gemfiles/ruby_3.3.0_resque2_redis3.gemfile
@@ -2,7 +2,6 @@
 
 source "https://rubygems.org"
 
-gem "addressable", "~> 2.4.0"
 gem "appraisal", "~> 2.4.0"
 gem "benchmark-ips", "~> 2.8"
 gem "benchmark-memory", "< 0.2"

--- a/gemfiles/ruby_3.3.0_resque2_redis3.gemfile.lock
+++ b/gemfiles/ruby_3.3.0_resque2_redis3.gemfile.lock
@@ -166,7 +166,6 @@ PLATFORMS
   x86_64-linux
 
 DEPENDENCIES
-  addressable (~> 2.4.0)
   appraisal (~> 2.4.0)
   benchmark-ips (~> 2.8)
   benchmark-memory (< 0.2)

--- a/gemfiles/ruby_3.3.0_resque2_redis4.gemfile
+++ b/gemfiles/ruby_3.3.0_resque2_redis4.gemfile
@@ -2,7 +2,6 @@
 
 source "https://rubygems.org"
 
-gem "addressable", "~> 2.4.0"
 gem "appraisal", "~> 2.4.0"
 gem "benchmark-ips", "~> 2.8"
 gem "benchmark-memory", "< 0.2"

--- a/gemfiles/ruby_3.3.0_resque2_redis4.gemfile.lock
+++ b/gemfiles/ruby_3.3.0_resque2_redis4.gemfile.lock
@@ -170,7 +170,6 @@ PLATFORMS
   x86_64-linux
 
 DEPENDENCIES
-  addressable (~> 2.4.0)
   appraisal (~> 2.4.0)
   benchmark-ips (~> 2.8)
   benchmark-memory (< 0.2)

--- a/gemfiles/ruby_3.3.0_sinatra.gemfile
+++ b/gemfiles/ruby_3.3.0_sinatra.gemfile
@@ -2,7 +2,6 @@
 
 source "https://rubygems.org"
 
-gem "addressable", "~> 2.4.0"
 gem "appraisal", "~> 2.4.0"
 gem "benchmark-ips", "~> 2.8"
 gem "benchmark-memory", "< 0.2"

--- a/gemfiles/ruby_3.3.0_sinatra.gemfile.lock
+++ b/gemfiles/ruby_3.3.0_sinatra.gemfile.lock
@@ -158,7 +158,6 @@ PLATFORMS
   x86_64-linux
 
 DEPENDENCIES
-  addressable (~> 2.4.0)
   appraisal (~> 2.4.0)
   benchmark-ips (~> 2.8)
   benchmark-memory (< 0.2)


### PR DESCRIPTION
<!--
Check out the
https://github.com/DataDog/dd-trace-rb/blob/master/docs/DevelopmentGuide.md
for guidance on how to set up your development environment,
run the test suite, write new integrations, and more.
-->

**What does this PR do?**
<!-- A brief description of the change being made with this pull request. -->

This PR removes the unnecessary, and vulnerable explicit dependency on `addressable`.

**Motivation:**
<!-- What inspired you to submit this pull request? -->

[CVE-2021-32740](https://github.com/advisories/GHSA-jxhc-q857-3j6g) affected `addressable` < 2.8.

Even though we never ship code with `addressable` < 2.8, nor run it alongside non-public information, when possible, it's good security hygiene to remove vulnerable dependencies.

Also, this transitive dependency was added without any specific explanation for its introduction: https://github.com/DataDog/dd-trace-rb/pull/229/files#diff-8b1801e03e9a166eea28410efc558b347e0b4a3bc03ab6c7283afa4479e88756R44.

**Additional Notes:**
<!-- Anything else we should know when reviewing? -->

**How to test the change?**
<!--
Describe here how the change can be validated.
You are strongly encouraged to provide automated tests for this PR (unit or integration).
If this change cannot be feasibly tested, please explain why,
unless the change does not modify code (e.g. only modifies docs, comments).
-->

Green CI means this PR is good.

**For Datadog employees:**
- [ ] If this PR touches code that signs or publishes builds or packages, or handles
credentials of any kind, I've requested a review from `@DataDog/security-design-and-guidance`.
- [ ] This PR doesn't touch any of that.

Unsure? Have a question? Request a review!
