### PR TITLE
[APPSEC-10967] ASM parse response body 

### DIFF
--- a/.gitlab/benchmarks.yml
+++ b/.gitlab/benchmarks.yml
@@ -122,7 +122,7 @@ profiling-and-tracing-and-appsec-timeline:
 candidate-tracer-appsec-with-api-security:
   extends: .benchmarks
   variables:
-    DD_BENCHMARKS_CONFIGURATION: "tracing-and-appsec-with-api-secuirty"
+    DD_BENCHMARKS_CONFIGURATION: "tracing-and-appsec-with-api-security"
     DD_PROFILING_ENABLED: "false"
     DD_APPSEC_ENABLED: "true"
     DD_EXPERIMENTAL_API_SECURITY_ENABLED: "true"
@@ -131,7 +131,7 @@ candidate-tracer-appsec-with-api-security:
 candidate-tracer-appsec-with-api-security-and-parse-response-body:
   extends: .benchmarks
   variables:
-    DD_BENCHMARKS_CONFIGURATION: "tracing-and-appsec-with-api-secuirty-and-parsed-body"
+    DD_BENCHMARKS_CONFIGURATION: "tracing-and-appsec-with-api-security-and-parsed-body"
     DD_PROFILING_ENABLED: "false"
     DD_APPSEC_ENABLED: "true"
     DD_EXPERIMENTAL_API_SECURITY_ENABLED: "true"

--- a/.gitlab/benchmarks.yml
+++ b/.gitlab/benchmarks.yml
@@ -119,6 +119,25 @@ profiling-and-tracing-and-appsec-timeline:
     DD_PROFILING_NO_SIGNALS_WORKAROUND_ENABLED: "false"
     DD_PROFILING_EXPERIMENTAL_TIMELINE_ENABLED: "true"
 
+candidate-tracer-appsec-with-api-security:
+  extends: .benchmarks
+  variables:
+    DD_BENCHMARKS_CONFIGURATION: "tracing-and-appsec-with-api-secuirty"
+    DD_PROFILING_ENABLED: "false"
+    DD_APPSEC_ENABLED: "true"
+    DD_EXPERIMENTAL_API_SECURITY_ENABLED: "true"
+    DD_API_SECURITY_REQUEST_SAMPLE_RATE: "1.0"
+
+candidate-tracer-appsec-with-api-security-and-parse-response-body:
+  extends: .benchmarks
+  variables:
+    DD_BENCHMARKS_CONFIGURATION: "tracing-and-appsec-with-api-secuirty-and-parsed-body"
+    DD_PROFILING_ENABLED: "false"
+    DD_APPSEC_ENABLED: "true"
+    DD_EXPERIMENTAL_API_SECURITY_ENABLED: "true"
+    DD_API_SECURITY_REQUEST_SAMPLE_RATE: "1.0"
+    DD_EXPERIMENTAL_API_SECURITY_PARSE_RESPONSE_BODY: "true"
+
 # -----------------------------------------------------
 # Microbenchmarks that report to statsd
 # -----------------------------------------------------

--- a/lib/datadog/appsec/configuration/settings.rb
+++ b/lib/datadog/appsec/configuration/settings.rb
@@ -191,7 +191,8 @@ module Datadog
 
               option :parse_response_body do |o|
                 o.type :bool
-                o.default true
+                o.env 'DD_EXPERIMENTAL_API_SECURITY_PARSE_RESPONSE_BODY'
+                o.default false
               end
             end
           end

--- a/lib/datadog/appsec/configuration/settings.rb
+++ b/lib/datadog/appsec/configuration/settings.rb
@@ -188,6 +188,11 @@ module Datadog
                   end
                 end
               end
+
+              option :parse_response_body do |o|
+                o.type :bool
+                o.default true
+              end
             end
           end
         end

--- a/lib/datadog/appsec/contrib/rack/gateway/response.rb
+++ b/lib/datadog/appsec/contrib/rack/gateway/response.rb
@@ -20,7 +20,7 @@ module Datadog
             end
 
             def parsed_body
-              return unless body.instance_of?(Array)
+              return unless body.instance_of?(Array) || body.instance_of?(::Rack::BodyProxy)
               return unless supported_response_type
 
               body_dup = body.dup # avoid interating over the body. This is just in case code.

--- a/lib/datadog/appsec/contrib/rack/gateway/response.rb
+++ b/lib/datadog/appsec/contrib/rack/gateway/response.rb
@@ -20,7 +20,16 @@ module Datadog
             end
 
             def parsed_body
-              return unless body.instance_of?(Array) || body.instance_of?(::Rack::BodyProxy)
+              return unless Datadog.configuration.appsec.parse_response_body
+
+              unless body.instance_of?(Array) || body.instance_of?(::Rack::BodyProxy)
+                if result.timeout
+                  Datadog.logger.debug do
+                    "Unable to parse response body because of unsupported body type: #{body.class}"
+                  end
+                end
+                return
+              end
               return unless supported_response_type
 
               body_dup = body.dup # avoid interating over the body. This is just in case code.

--- a/lib/datadog/appsec/contrib/rack/gateway/response.rb
+++ b/lib/datadog/appsec/contrib/rack/gateway/response.rb
@@ -22,19 +22,19 @@ module Datadog
             def parsed_body
               return unless Datadog.configuration.appsec.parse_response_body
 
-              unless body.instance_of?(Array) || body.instance_of?(::Rack::BodyProxy)
+              unless body.instance_of?(Array)
                 Datadog.logger.debug do
                   "Response body type unsupported: #{body.class}"
                 end
                 return
               end
+
               return unless json_content_type?
 
-              body_dup = body.dup # avoid interating over the body. This is just in case code.
               result = ''.dup
               all_body_parts_are_string = true
 
-              body_dup.each do |body_part|
+              body.each do |body_part|
                 if body_part.is_a?(String)
                   result.concat(body_part)
                 else
@@ -65,7 +65,8 @@ module Datadog
             ].freeze
 
             def json_content_type?
-              VALID_JSON_TYPES.include?(headers['content-type'])
+              content_type = headers['content-type']
+              VALID_JSON_TYPES.any? { |valid_type| content_type.include?(valid_type) }
             end
           end
         end

--- a/lib/datadog/appsec/contrib/rack/gateway/response.rb
+++ b/lib/datadog/appsec/contrib/rack/gateway/response.rb
@@ -19,8 +19,48 @@ module Datadog
               @scope = scope
             end
 
+            def parsed_body
+              return unless body.instance_of?(Array)
+              return unless supported_response_type
+
+              body_dup = body.dup # avoid interating over the body. This is just in case code.
+              result = ''.dup
+              all_body_parts_are_string = true
+
+              body_dup.each do |body_part|
+                if body_part.is_a?(String)
+                  result.concat(body_part)
+                else
+                  all_body_parts_are_string = false
+                  break
+                end
+              end
+
+              return unless all_body_parts_are_string
+
+              if json?
+                JSON.parse(result)
+              else
+                result
+              end
+            end
+
             def response
               @response ||= ::Rack::Response.new(body, status, headers)
+            end
+
+            private
+
+            def supported_response_type
+              json? || text?
+            end
+
+            def json?
+              headers['content-type'].include?('json')
+            end
+
+            def text?
+              headers['content-type'].include?('text')
             end
           end
         end

--- a/lib/datadog/appsec/contrib/rack/reactive/response.rb
+++ b/lib/datadog/appsec/contrib/rack/reactive/response.rb
@@ -10,6 +10,7 @@ module Datadog
             ADDRESSES = [
               'response.status',
               'response.headers',
+              'response.body',
             ].freeze
             private_constant :ADDRESSES
 
@@ -17,6 +18,7 @@ module Datadog
               catch(:block) do
                 op.publish('response.status', gateway_response.status)
                 op.publish('response.headers', gateway_response.headers)
+                op.publish('response.body', gateway_response.parsed_body)
 
                 nil
               end
@@ -29,12 +31,15 @@ module Datadog
                 response_status = values[0]
                 response_headers = values[1]
                 response_headers_no_cookies = response_headers.dup.tap { |h| h.delete('set-cookie') }
+                response_body = values[2]
 
                 waf_args = {
                   'server.response.status' => response_status.to_s,
                   'server.response.headers' => response_headers,
                   'server.response.headers.no_cookies' => response_headers_no_cookies,
                 }
+
+                waf_args['server.response.body'] = response_body if response_body
 
                 waf_timeout = Datadog.configuration.appsec.waf_timeout
                 result = waf_context.run(waf_args, waf_timeout)

--- a/lib/datadog/appsec/contrib/rack/request_middleware.rb
+++ b/lib/datadog/appsec/contrib/rack/request_middleware.rb
@@ -66,11 +66,21 @@ module Datadog
               request_return = AppSec::Response.negotiate(env, blocked_event.last[:actions]).to_rack if blocked_event
             end
 
+            if request_return[2].respond_to?(:to_ary)
+              # Following the Rack specification. The response body should only call :each once.
+              # Calling :to_ary returns an array with identical content as the produced when calling :each
+              # replacing request_return[2] with that new value allow us to safely operate on the response body.
+              # On Gateway::Response#parsed_body we might iterate over the reposne body using :each
+              # https://github.com/rack/rack/blob/main/SPEC.rdoc#enumerable-body-
+              consumed_body = request_return[2].to_ary
+              request_return[2] = consumed_body
+            end
+
             gateway_response = Gateway::Response.new(
               request_return[2],
               request_return[0],
               request_return[1],
-              scope: scope
+              scope: scope,
             )
 
             _response_return, response_response = Instrumentation.gateway.push('rack.response', gateway_response)

--- a/lib/datadog/appsec/contrib/rack/request_middleware.rb
+++ b/lib/datadog/appsec/contrib/rack/request_middleware.rb
@@ -73,7 +73,7 @@ module Datadog
               # On Gateway::Response#parsed_body we might iterate over the reposne body using :each
               # https://github.com/rack/rack/blob/main/SPEC.rdoc#enumerable-body-
               consumed_body = request_return[2].to_ary
-              request_return[2] = consumed_body
+              request_return[2] = consumed_body if consumed_body
             end
 
             gateway_response = Gateway::Response.new(

--- a/spec/datadog/appsec/configuration/settings_spec.rb
+++ b/spec/datadog/appsec/configuration/settings_spec.rb
@@ -711,5 +711,27 @@ RSpec.describe Datadog::AppSec::Configuration::Settings do
         end
       end
     end
+
+    describe 'parse_response_body' do
+      subject(:enabled) { settings.appsec.parse_response_body }
+
+      context 'default value' do
+        it { is_expected.to eq true }
+      end
+
+      context 'parse_response_body=' do
+        subject(:set_parse_response_body) { settings.appsec.parse_response_body = parse_response_body }
+
+        [true, false].each do |value|
+          context "when given #{value}" do
+            let(:parse_response_body) { value }
+
+            before { set_parse_response_body }
+
+            it { expect(settings.appsec.parse_response_body).to eq(value) }
+          end
+        end
+      end
+    end
   end
 end

--- a/spec/datadog/appsec/configuration/settings_spec.rb
+++ b/spec/datadog/appsec/configuration/settings_spec.rb
@@ -715,21 +715,37 @@ RSpec.describe Datadog::AppSec::Configuration::Settings do
     describe 'parse_response_body' do
       subject(:enabled) { settings.appsec.parse_response_body }
 
-      context 'default value' do
-        it { is_expected.to eq true }
-      end
-
-      context 'parse_response_body=' do
-        subject(:set_parse_response_body) { settings.appsec.parse_response_body = parse_response_body }
-
-        [true, false].each do |value|
-          context "when given #{value}" do
-            let(:parse_response_body) { value }
-
-            before { set_parse_response_body }
-
-            it { expect(settings.appsec.parse_response_body).to eq(value) }
+      context 'when DD_EXPERIMENTAL_API_SECURITY_PARSE_RESPONSE_BODY' do
+        around do |example|
+          ClimateControl.modify('DD_EXPERIMENTAL_API_SECURITY_PARSE_RESPONSE_BODY' => api_security_parse_response_body) do
+            example.run
           end
+        end
+
+        context 'is not defined' do
+          let(:api_security_parse_response_body) { nil }
+
+          it { is_expected.to eq false }
+        end
+
+        context 'is defined' do
+          let(:api_security_parse_response_body) { 'true' }
+
+          it { is_expected.to eq(true) }
+        end
+      end
+    end
+
+    context 'parse_response_body=' do
+      subject(:set_parse_response_body) { settings.appsec.parse_response_body = parse_response_body }
+
+      [true, false].each do |value|
+        context "when given #{value}" do
+          let(:parse_response_body) { value }
+
+          before { set_parse_response_body }
+
+          it { expect(settings.appsec.parse_response_body).to eq(value) }
         end
       end
     end

--- a/spec/datadog/appsec/contrib/rack/gateway/response_spec.rb
+++ b/spec/datadog/appsec/contrib/rack/gateway/response_spec.rb
@@ -65,6 +65,16 @@ RSpec.describe Datadog::AppSec::Contrib::Rack::Gateway::Response do
     end
 
     context 'text response' do
+      context 'disabled parse_response_body' do
+        before do
+          expect(Datadog.configuration.appsec).to receive(:parse_response_body).and_return(false)
+        end
+
+        it 'returns nil' do
+          expect(response.parsed_body).to be_nil
+        end
+      end
+
       context 'all body parts are strings' do
         let(:body) { ['{ "f', 'oo":', ' "ba', 'r" }'] }
 

--- a/spec/datadog/appsec/contrib/rack/gateway/response_spec.rb
+++ b/spec/datadog/appsec/contrib/rack/gateway/response_spec.rb
@@ -6,18 +6,21 @@ require 'datadog/appsec/scope'
 require 'rack'
 
 RSpec.describe Datadog::AppSec::Contrib::Rack::Gateway::Response do
+  let(:body) { ['Ok'] }
+  let(:content_type) { 'text/html' }
+
   let(:response) do
     described_class.new(
-      'Ok',
+      body,
       200,
-      { 'Content-Type' => 'text/html' },
+      { 'Content-Type' => content_type },
       scope: instance_double(Datadog::AppSec::Scope)
     )
   end
 
   describe '#body' do
     it 'returns the body' do
-      expect(response.body).to eq('Ok')
+      expect(response.body).to eq(['Ok'])
     end
   end
 
@@ -36,6 +39,79 @@ RSpec.describe Datadog::AppSec::Contrib::Rack::Gateway::Response do
   describe '#response' do
     it 'returns a rack response object' do
       expect(response.response).to be_a(Rack::Response)
+    end
+  end
+
+  describe '#parsed_body' do
+    context 'json response' do
+      let(:content_type) { 'appplication/json' }
+
+      context 'all body parts are strings' do
+        let(:body) { ['{ "f', 'oo":', ' "ba', 'r" }'] }
+
+        it 'returns a hash object' do
+          expect(response.parsed_body).to eq({ 'foo' => 'bar' })
+        end
+      end
+
+      context 'not all body parts are strings' do
+        let(:body_proc) { proc { ' "ba' } }
+        let(:body) { ['{ "f', 'oo":', body_proc, 'r" }'] }
+
+        it 'returns nil' do
+          expect(response.parsed_body).to be_nil
+        end
+      end
+    end
+
+    context 'text response' do
+      context 'all body parts are strings' do
+        let(:body) { ['{ "f', 'oo":', ' "ba', 'r" }'] }
+
+        it 'returns a hash object' do
+          expect(response.parsed_body).to eq('{ "foo": "bar" }')
+        end
+      end
+
+      context 'not all body parts are strings' do
+        let(:body_proc) { proc { ' "ba' } }
+        let(:body) { ['{ "f', 'oo":', body_proc, 'r" }'] }
+
+        it 'returns nil' do
+          expect(response.parsed_body).to be_nil
+        end
+      end
+    end
+
+    context 'non supported response type' do
+      let(:content_type) { 'video/mpeg' }
+
+      it 'returns nil' do
+        expect(response.parsed_body).to be_nil
+      end
+    end
+
+    context 'with a body that is not an Array' do
+      let(:body) { proc { ' "ba' } }
+
+      it 'returns nil' do
+        expect(response.parsed_body).to be_nil
+      end
+    end
+
+    context 'with a body that inherits from Array' do
+      let(:my_body_class) do
+        Class.new(Array) do
+        end
+      end
+
+      let(:body) do
+        my_body_class.new
+      end
+
+      it 'returns nil' do
+        expect(response.parsed_body).to be_nil
+      end
     end
   end
 end

--- a/spec/datadog/appsec/contrib/rack/gateway/response_spec.rb
+++ b/spec/datadog/appsec/contrib/rack/gateway/response_spec.rb
@@ -44,7 +44,7 @@ RSpec.describe Datadog::AppSec::Contrib::Rack::Gateway::Response do
 
   describe '#parsed_body' do
     context 'json response' do
-      let(:content_type) { 'appplication/json' }
+      let(:content_type) { 'application/json' }
 
       context 'all body parts are strings' do
         let(:body) { ['{ "f', 'oo":', ' "ba', 'r" }'] }
@@ -62,39 +62,26 @@ RSpec.describe Datadog::AppSec::Contrib::Rack::Gateway::Response do
           expect(response.parsed_body).to be_nil
         end
       end
-    end
 
-    context 'text response' do
-      context 'disabled parse_response_body' do
-        before do
-          expect(Datadog.configuration.appsec).to receive(:parse_response_body).and_return(false)
-        end
+      context 'fail to parse response body' do
+        let(:body) { [''] }
 
         it 'returns nil' do
           expect(response.parsed_body).to be_nil
         end
       end
 
-      context 'all body parts are strings' do
-        let(:body) { ['{ "f', 'oo":', ' "ba', 'r" }'] }
+      context 'with a body that is a Rack::BodyProxy' do
+        let(:body) { Rack::BodyProxy.new(['{ "foo":  "bar" }']) }
 
-        it 'returns a string' do
-          expect(response.parsed_body).to eq('{ "foo": "bar" }')
-        end
-      end
-
-      context 'not all body parts are strings' do
-        let(:body_proc) { proc { ' "ba' } }
-        let(:body) { ['{ "f', 'oo":', body_proc, 'r" }'] }
-
-        it 'returns nil' do
-          expect(response.parsed_body).to be_nil
+        it 'returns a hash object' do
+          expect(response.parsed_body).to eq({ 'foo' => 'bar' })
         end
       end
     end
 
     context 'non supported response type' do
-      let(:content_type) { 'video/mpeg' }
+      let(:content_type) { 'text/xml' }
 
       it 'returns nil' do
         expect(response.parsed_body).to be_nil
@@ -106,14 +93,6 @@ RSpec.describe Datadog::AppSec::Contrib::Rack::Gateway::Response do
 
       it 'returns nil' do
         expect(response.parsed_body).to be_nil
-      end
-    end
-
-    context 'with a body that is a Rack::BodyProxy' do
-      let(:body) { Rack::BodyProxy.new(['{ "foo":  "bar" }']) }
-
-      it 'returns a string' do
-        expect(response.parsed_body).to eq('{ "foo":  "bar" }')
       end
     end
 

--- a/spec/datadog/appsec/contrib/rack/gateway/response_spec.rb
+++ b/spec/datadog/appsec/contrib/rack/gateway/response_spec.rb
@@ -68,7 +68,7 @@ RSpec.describe Datadog::AppSec::Contrib::Rack::Gateway::Response do
       context 'all body parts are strings' do
         let(:body) { ['{ "f', 'oo":', ' "ba', 'r" }'] }
 
-        it 'returns a hash object' do
+        it 'returns a string' do
           expect(response.parsed_body).to eq('{ "foo": "bar" }')
         end
       end
@@ -96,6 +96,14 @@ RSpec.describe Datadog::AppSec::Contrib::Rack::Gateway::Response do
 
       it 'returns nil' do
         expect(response.parsed_body).to be_nil
+      end
+    end
+
+    context 'with a body that is a Rack::BodyProxy' do
+      let(:body) { Rack::BodyProxy.new(['{ "foo":  "bar" }']) }
+
+      it 'returns a string' do
+        expect(response.parsed_body).to eq('{ "foo":  "bar" }')
       end
     end
 

--- a/spec/datadog/appsec/contrib/rack/gateway/response_spec.rb
+++ b/spec/datadog/appsec/contrib/rack/gateway/response_spec.rb
@@ -70,14 +70,6 @@ RSpec.describe Datadog::AppSec::Contrib::Rack::Gateway::Response do
           expect(response.parsed_body).to be_nil
         end
       end
-
-      context 'with a body that is a Rack::BodyProxy' do
-        let(:body) { Rack::BodyProxy.new(['{ "foo":  "bar" }']) }
-
-        it 'returns a hash object' do
-          expect(response.parsed_body).to eq({ 'foo' => 'bar' })
-        end
-      end
     end
 
     context 'non supported response type' do

--- a/spec/datadog/appsec/contrib/rack/reactive/response_spec.rb
+++ b/spec/datadog/appsec/contrib/rack/reactive/response_spec.rb
@@ -10,10 +10,11 @@ RSpec.describe Datadog::AppSec::Contrib::Rack::Reactive::Response do
   let(:operation) { Datadog::AppSec::Reactive::Operation.new('test') }
   let(:processor_context) { instance_double(Datadog::AppSec::Processor::Context) }
   let(:scope) { instance_double(Datadog::AppSec::Scope, processor_context: processor_context) }
+  let(:body) { ['Ok'] }
 
   let(:response) do
     Datadog::AppSec::Contrib::Rack::Gateway::Response.new(
-      'Ok',
+      body,
       200,
       { 'content-type' => 'text/html', 'set-cookie' => 'foo' },
       scope: scope,
@@ -27,6 +28,10 @@ RSpec.describe Datadog::AppSec::Contrib::Rack::Reactive::Response do
         'response.headers',
         { 'content-type' => 'text/html', 'set-cookie' => 'foo' },
       )
+      expect(operation).to receive(:publish).with(
+        'response.body',
+        'Ok',
+      )
 
       described_class.publish(operation, response)
     end
@@ -35,35 +40,78 @@ RSpec.describe Datadog::AppSec::Contrib::Rack::Reactive::Response do
   describe '.subscribe' do
     context 'not all addresses have been published' do
       it 'does not call the waf context' do
-        expect(operation).to receive(:subscribe).with('response.status', 'response.headers').and_call_original
+        expect(operation).to receive(:subscribe).with(
+          'response.status',
+          'response.headers',
+          'response.body'
+        ).and_call_original
         expect(processor_context).to_not receive(:run)
         described_class.subscribe(operation, processor_context)
       end
     end
 
-    context 'all addresses have been published' do
-      it 'does call the waf context with the right arguments' do
+    context 'waf arguments' do
+      before do
         expect(operation).to receive(:subscribe).and_call_original
+      end
 
-        expected_waf_arguments = {
-          'server.response.status' => '200',
-          'server.response.headers' => {
-            'content-type' => 'text/html',
-            'set-cookie' => 'foo',
-          },
-          'server.response.headers.no_cookies' => {
-            'content-type' => 'text/html',
+      let(:waf_result) { double(:waf_result, status: :ok, timeout: false) }
+
+      context 'all addresses have been published' do
+        let(:expected_waf_arguments) do
+          {
+            'server.response.status' => '200',
+            'server.response.headers' => {
+              'content-type' => 'text/html',
+              'set-cookie' => 'foo',
+            },
+            'server.response.headers.no_cookies' => {
+              'content-type' => 'text/html',
+            },
+            'server.response.body' => 'Ok',
           }
-        }
+        end
 
-        waf_result = double(:waf_result, status: :ok, timeout: false)
-        expect(processor_context).to receive(:run).with(
-          expected_waf_arguments,
-          Datadog.configuration.appsec.waf_timeout
-        ).and_return(waf_result)
-        described_class.subscribe(operation, processor_context)
-        result = described_class.publish(operation, response)
-        expect(result).to be_nil
+        it 'does call the waf context with the right arguments' do
+          expect(processor_context).to receive(:run).with(
+            expected_waf_arguments,
+            Datadog.configuration.appsec.waf_timeout
+          ).and_return(waf_result)
+          described_class.subscribe(operation, processor_context)
+          result = described_class.publish(operation, response)
+          expect(result).to be_nil
+        end
+
+        context 'when parsed response body is nil' do
+          # since the body is not all string values we bail out in Datadog::AppSec::Contrib::Rack::Gateway::Response
+          let(:body) do
+            ['Ok', proc {
+            }]
+          end
+
+          let(:expected_waf_arguments) do
+            {
+              'server.response.status' => '200',
+              'server.response.headers' => {
+                'content-type' => 'text/html',
+                'set-cookie' => 'foo',
+              },
+              'server.response.headers.no_cookies' => {
+                'content-type' => 'text/html',
+              }
+            }
+          end
+
+          it 'does call the waf context with the right arguments' do
+            expect(processor_context).to receive(:run).with(
+              expected_waf_arguments,
+              Datadog.configuration.appsec.waf_timeout
+            ).and_return(waf_result)
+            described_class.subscribe(operation, processor_context)
+            result = described_class.publish(operation, response)
+            expect(result).to be_nil
+          end
+        end
       end
     end
 

--- a/spec/datadog/appsec/contrib/rack/reactive/response_spec.rb
+++ b/spec/datadog/appsec/contrib/rack/reactive/response_spec.rb
@@ -11,12 +11,13 @@ RSpec.describe Datadog::AppSec::Contrib::Rack::Reactive::Response do
   let(:processor_context) { instance_double(Datadog::AppSec::Processor::Context) }
   let(:scope) { instance_double(Datadog::AppSec::Scope, processor_context: processor_context) }
   let(:body) { ['Ok'] }
+  let(:headers) { { 'content-type' => 'text/html', 'set-cookie' => 'foo' } }
 
   let(:response) do
     Datadog::AppSec::Contrib::Rack::Gateway::Response.new(
       body,
       200,
-      { 'content-type' => 'text/html', 'set-cookie' => 'foo' },
+      headers,
       scope: scope,
     )
   end
@@ -26,14 +27,33 @@ RSpec.describe Datadog::AppSec::Contrib::Rack::Reactive::Response do
       expect(operation).to receive(:publish).with('response.status', 200)
       expect(operation).to receive(:publish).with(
         'response.headers',
-        { 'content-type' => 'text/html', 'set-cookie' => 'foo' },
+        headers,
       )
       expect(operation).to receive(:publish).with(
         'response.body',
-        'Ok',
+        nil,
       )
 
       described_class.publish(operation, response)
+    end
+
+    context 'JSON response' do
+      let(:headers) { { 'content-type' => 'application/json', 'set-cookie' => 'foo' } }
+      let(:body) { ['{"a":"b"}'] }
+
+      it 'propagates response attributes to the operation' do
+        expect(operation).to receive(:publish).with('response.status', 200)
+        expect(operation).to receive(:publish).with(
+          'response.headers',
+          headers,
+        )
+        expect(operation).to receive(:publish).with(
+          'response.body',
+          { 'a' => 'b' },
+        )
+
+        described_class.publish(operation, response)
+      end
     end
   end
 
@@ -68,7 +88,6 @@ RSpec.describe Datadog::AppSec::Contrib::Rack::Reactive::Response do
             'server.response.headers.no_cookies' => {
               'content-type' => 'text/html',
             },
-            'server.response.body' => 'Ok',
           }
         end
 
@@ -81,23 +100,53 @@ RSpec.describe Datadog::AppSec::Contrib::Rack::Reactive::Response do
           result = described_class.publish(operation, response)
           expect(result).to be_nil
         end
+      end
 
-        context 'when parsed response body is nil' do
+      context 'JSON response' do
+        let(:headers) { { 'content-type' => 'application/json', 'set-cookie' => 'foo' } }
+        let(:body) { ['{"a":"b"}'] }
+
+        context 'all addresses have been published' do
+          let(:expected_waf_arguments) do
+            {
+              'server.response.status' => '200',
+              'server.response.headers' => {
+                'content-type' => 'application/json',
+                'set-cookie' => 'foo',
+              },
+              'server.response.headers.no_cookies' => {
+                'content-type' => 'application/json',
+              },
+              'server.response.body' => { 'a' => 'b' },
+            }
+          end
+
+          it 'does call the waf context with the right arguments' do
+            expect(processor_context).to receive(:run).with(
+              expected_waf_arguments,
+              Datadog.configuration.appsec.waf_timeout
+            ).and_return(waf_result)
+            described_class.subscribe(operation, processor_context)
+            result = described_class.publish(operation, response)
+            expect(result).to be_nil
+          end
+        end
+
+        context 'when unparsable response body' do
           # since the body is not all string values we bail out in Datadog::AppSec::Contrib::Rack::Gateway::Response
           let(:body) do
-            ['Ok', proc {
-            }]
+            [proc {}]
           end
 
           let(:expected_waf_arguments) do
             {
               'server.response.status' => '200',
               'server.response.headers' => {
-                'content-type' => 'text/html',
+                'content-type' => 'application/json',
                 'set-cookie' => 'foo',
               },
               'server.response.headers.no_cookies' => {
-                'content-type' => 'text/html',
+                'content-type' => 'application/json',
               }
             }
           end

--- a/spec/datadog/appsec/contrib/rack/reactive/response_spec.rb
+++ b/spec/datadog/appsec/contrib/rack/reactive/response_spec.rb
@@ -41,18 +41,42 @@ RSpec.describe Datadog::AppSec::Contrib::Rack::Reactive::Response do
       let(:headers) { { 'content-type' => 'application/json', 'set-cookie' => 'foo' } }
       let(:body) { ['{"a":"b"}'] }
 
-      it 'propagates response attributes to the operation' do
-        expect(operation).to receive(:publish).with('response.status', 200)
-        expect(operation).to receive(:publish).with(
-          'response.headers',
-          headers,
-        )
-        expect(operation).to receive(:publish).with(
-          'response.body',
-          { 'a' => 'b' },
-        )
+      context 'when parsed_response_body is enabled' do
+        around do |example|
+          ClimateControl.modify('DD_EXPERIMENTAL_API_SECURITY_PARSE_RESPONSE_BODY' => 'true') do
+            example.run
+          end
+        end
 
-        described_class.publish(operation, response)
+        it 'propagates response attributes to the operation' do
+          expect(operation).to receive(:publish).with('response.status', 200)
+          expect(operation).to receive(:publish).with(
+            'response.headers',
+            headers,
+          )
+          expect(operation).to receive(:publish).with(
+            'response.body',
+            { 'a' => 'b' },
+          )
+
+          described_class.publish(operation, response)
+        end
+      end
+
+      context 'when parsed_response_body is disabled' do
+        it 'propagates response attributes to the operation' do
+          expect(operation).to receive(:publish).with('response.status', 200)
+          expect(operation).to receive(:publish).with(
+            'response.headers',
+            headers,
+          )
+          expect(operation).to receive(:publish).with(
+            'response.body',
+            nil,
+          )
+
+          described_class.publish(operation, response)
+        end
       end
     end
   end
@@ -106,38 +130,71 @@ RSpec.describe Datadog::AppSec::Contrib::Rack::Reactive::Response do
         let(:headers) { { 'content-type' => 'application/json', 'set-cookie' => 'foo' } }
         let(:body) { ['{"a":"b"}'] }
 
-        context 'all addresses have been published' do
-          let(:expected_waf_arguments) do
-            {
-              'server.response.status' => '200',
-              'server.response.headers' => {
-                'content-type' => 'application/json',
-                'set-cookie' => 'foo',
-              },
-              'server.response.headers.no_cookies' => {
-                'content-type' => 'application/json',
-              },
-              'server.response.body' => { 'a' => 'b' },
-            }
+        context 'when parsed_response_body is enabled' do
+          around do |example|
+            ClimateControl.modify('DD_EXPERIMENTAL_API_SECURITY_PARSE_RESPONSE_BODY' => 'true') do
+              example.run
+            end
           end
 
-          it 'does call the waf context with the right arguments' do
-            expect(processor_context).to receive(:run).with(
-              expected_waf_arguments,
-              Datadog.configuration.appsec.waf_timeout
-            ).and_return(waf_result)
-            described_class.subscribe(operation, processor_context)
-            result = described_class.publish(operation, response)
-            expect(result).to be_nil
+          context 'all addresses have been published' do
+            let(:expected_waf_arguments) do
+              {
+                'server.response.status' => '200',
+                'server.response.headers' => {
+                  'content-type' => 'application/json',
+                  'set-cookie' => 'foo',
+                },
+                'server.response.headers.no_cookies' => {
+                  'content-type' => 'application/json',
+                },
+                'server.response.body' => { 'a' => 'b' },
+              }
+            end
+
+            it 'does call the waf context with the right arguments' do
+              expect(processor_context).to receive(:run).with(
+                expected_waf_arguments,
+                Datadog.configuration.appsec.waf_timeout
+              ).and_return(waf_result)
+              described_class.subscribe(operation, processor_context)
+              result = described_class.publish(operation, response)
+              expect(result).to be_nil
+            end
+          end
+
+          context 'when unparsable response body' do
+            # since the body is not all string values we bail out in Datadog::AppSec::Contrib::Rack::Gateway::Response
+            let(:body) do
+              [proc {}]
+            end
+
+            let(:expected_waf_arguments) do
+              {
+                'server.response.status' => '200',
+                'server.response.headers' => {
+                  'content-type' => 'application/json',
+                  'set-cookie' => 'foo',
+                },
+                'server.response.headers.no_cookies' => {
+                  'content-type' => 'application/json',
+                }
+              }
+            end
+
+            it 'does call the waf context with the right arguments' do
+              expect(processor_context).to receive(:run).with(
+                expected_waf_arguments,
+                Datadog.configuration.appsec.waf_timeout
+              ).and_return(waf_result)
+              described_class.subscribe(operation, processor_context)
+              result = described_class.publish(operation, response)
+              expect(result).to be_nil
+            end
           end
         end
 
-        context 'when unparsable response body' do
-          # since the body is not all string values we bail out in Datadog::AppSec::Contrib::Rack::Gateway::Response
-          let(:body) do
-            [proc {}]
-          end
-
+        context 'when parsed_response_body is disabled' do
           let(:expected_waf_arguments) do
             {
               'server.response.status' => '200',
@@ -147,7 +204,7 @@ RSpec.describe Datadog::AppSec::Contrib::Rack::Reactive::Response do
               },
               'server.response.headers.no_cookies' => {
                 'content-type' => 'application/json',
-              }
+              },
             }
           end
 


### PR DESCRIPTION
<!--
Check out the
https://github.com/DataDog/dd-trace-rb/blob/master/docs/DevelopmentGuide.md
for guidance on how to set up your development environment,
run the test suite, write new integrations, and more.
-->

**What does this PR do?**
<!-- A brief description of the change being made with this pull request. -->

Parsed the response body and passed it to the waf as `server.response.body`.

We only parse bodies that are either an `Array` or a `Rack::BodyProxy`. Since we might not be the last middleware in the customer application, we can not consume the response body directly by calling `each`. To circumvent that, we make a copy of the body. 

Parsing the response body could lead to performance implications for our customers. Since we have yet to learn how this would impact our customers, I added a configuration entry for them to skip the response body parsing altogether. 

This documentation would remain undocumented, and we would only mention it to customers if they experience any performance degradation.


**Motivation:**
<!-- What inspired you to submit this pull request? -->

**Additional Notes:**
<!-- Anything else we should know when reviewing? -->

**How to test the change?**
<!--
Describe here how the change can be validated.
You are strongly encouraged to provide automated tests for this PR (unit or integration).
If this change cannot be feasibly tested, please explain why,
unless the change does not modify code (e.g. only modifies docs, comments).
-->

**For Datadog employees:**
- [ ] If this PR touches code that signs or publishes builds or packages, or handles
credentials of any kind, I've requested a review from `@DataDog/security-design-and-guidance`.
- [ ] This PR doesn't touch any of that.

Unsure? Have a question? Request a review!
