### PR TITLE
[Tracer] Introduce async configuration for test mode to use standard writer when needed

### DIFF
--- a/lib/datadog/core/workers/polling.rb
+++ b/lib/datadog/core/workers/polling.rb
@@ -6,7 +6,7 @@ module Datadog
     module Workers
       # Adds polling (async looping) behavior to workers
       module Polling
-        SHUTDOWN_TIMEOUT = 1
+        DEFAULT_SHUTDOWN_TIMEOUT = 1
 
         def self.included(base)
           base.include(Workers::IntervalLoop)
@@ -21,7 +21,7 @@ module Datadog
           end
         end
 
-        def stop(force_stop = false, timeout = SHUTDOWN_TIMEOUT)
+        def stop(force_stop = false, timeout = DEFAULT_SHUTDOWN_TIMEOUT)
           if running?
             # Attempt graceful stop and wait
             stop_loop

--- a/lib/datadog/tracing/component.rb
+++ b/lib/datadog/tracing/component.rb
@@ -134,12 +134,12 @@ module Datadog
       # process, but can take a variety of options (including
       # a fully custom instance) that makes the Tracer
       # initialization process complex.
-      def build_writer(settings, agent_settings)
+      def build_writer(settings, agent_settings, options = settings.tracing.writer_options)
         if (writer = settings.tracing.writer)
           return writer
         end
 
-        Tracing::Writer.new(agent_settings: agent_settings, **settings.tracing.writer_options)
+        Tracing::Writer.new(agent_settings: agent_settings, **options)
       end
 
       def subscribe_to_writer_events!(writer, sampler_delegator, test_mode)
@@ -223,8 +223,11 @@ module Datadog
       end
 
       def build_test_mode_writer(settings, agent_settings)
-        # Flush traces synchronously, to guarantee they are written.
         writer_options = settings.tracing.test_mode.writer_options || {}
+
+        return build_writer(settings, agent_settings, writer_options) if settings.tracing.test_mode.async
+
+        # Flush traces synchronously, to guarantee they are written.
         Tracing::SyncWriter.new(agent_settings: agent_settings, **writer_options)
       end
     end

--- a/lib/datadog/tracing/configuration/settings.rb
+++ b/lib/datadog/tracing/configuration/settings.rb
@@ -371,6 +371,12 @@ module Datadog
                   o.env Tracing::Configuration::Ext::Test::ENV_MODE_ENABLED
                 end
 
+                # Use async writer in test mode
+                option :async do |o|
+                  o.type :bool
+                  o.default false
+                end
+
                 option :trace_flush
 
                 option :writer_options do |o|

--- a/lib/datadog/tracing/workers.rb
+++ b/lib/datadog/tracing/workers.rb
@@ -14,7 +14,7 @@ module Datadog
         DEFAULT_TIMEOUT = 5
         BACK_OFF_RATIO = 1.2
         BACK_OFF_MAX = 5
-        SHUTDOWN_TIMEOUT = 1
+        DEFAULT_SHUTDOWN_TIMEOUT = 1
 
         attr_reader \
           :trace_buffer
@@ -36,6 +36,7 @@ module Datadog
 
           # Threading
           @shutdown = ConditionVariable.new
+          @shutdown_timeout = options.fetch(:shutdown_timeout, DEFAULT_SHUTDOWN_TIMEOUT)
           @mutex = Mutex.new
           @worker = nil
           @run = false
@@ -89,7 +90,7 @@ module Datadog
 
         # Block until executor shutdown is complete or until timeout seconds have passed.
         def join
-          @worker.join(SHUTDOWN_TIMEOUT)
+          @worker.join(@shutdown_timeout)
         end
 
         # Enqueue an item in the trace internal buffer. This operation is thread-safe

--- a/lib/datadog/tracing/workers/trace_writer.rb
+++ b/lib/datadog/tracing/workers/trace_writer.rb
@@ -104,6 +104,8 @@ module Datadog
           # Workers::Queue settings
           @buffer_size = options.fetch(:buffer_size, DEFAULT_BUFFER_MAX_SIZE)
           self.buffer = TraceBuffer.new(@buffer_size)
+
+          @shutdown_timeout = options.fetch(:shutdown_timeout, Core::Workers::Polling::DEFAULT_SHUTDOWN_TIMEOUT)
         end
 
         # NOTE: #perform is wrapped by other modules:
@@ -119,7 +121,7 @@ module Datadog
           nil
         end
 
-        def stop(*args)
+        def stop(force_stop = false, timeout = @shutdown_timeout)
           buffer.close if running?
           super
         end

--- a/lib/datadog/tracing/writer.rb
+++ b/lib/datadog/tracing/writer.rb
@@ -28,6 +28,8 @@ module Datadog
           Transport::HTTP.default(**transport_options)
         end
 
+        @shutdown_timeout = options.fetch(:shutdown_timeout, Workers::AsyncTransport::DEFAULT_SHUTDOWN_TIMEOUT)
+
         # handles the thread creation after an eventual fork
         @mutex_after_fork = Mutex.new
         @pid = nil
@@ -72,7 +74,8 @@ module Datadog
           transport: @transport,
           buffer_size: @buff_size,
           on_trace: @trace_handler,
-          interval: @flush_interval
+          interval: @flush_interval,
+          shutdown_timeout: @shutdown_timeout
         )
 
         @worker.start

--- a/sig/datadog/tracing/component.rbs
+++ b/sig/datadog/tracing/component.rbs
@@ -7,7 +7,7 @@ module Datadog
       def build_sampler: (untyped settings) -> untyped
 
       def ensure_priority_sampling: (untyped sampler, untyped settings) -> untyped
-      def build_writer: (untyped settings, untyped agent_settings) -> untyped
+      def build_writer: (untyped settings, untyped agent_settings, ?Hash[Symbol, untyped] options) -> untyped
 
       def subscribe_to_writer_events!: (untyped writer, untyped sampler, untyped test_mode) -> (nil | untyped)
 

--- a/spec/datadog/core/configuration/components_spec.rb
+++ b/spec/datadog/core/configuration/components_spec.rb
@@ -785,73 +785,104 @@ RSpec.describe Datadog::Core::Configuration::Components do
 
           context 'set to true' do
             let(:enabled) { true }
-            let(:sync_writer) { Datadog::Tracing::SyncWriter.new }
 
-            before do
-              expect(Datadog::Tracing::SyncWriter)
-                .to receive(:new)
-                .with(agent_settings: agent_settings, **writer_options)
-                .and_return(writer)
-            end
+            context 'and :async' do
+              context 'is set' do
+                let(:writer) { Datadog::Tracing::Writer.new }
+                let(:writer_options) { { transport_options: :bar } }
+                let(:writer_options_test_mode) { { transport_options: :baz } }
 
-            context 'and :trace_flush' do
-              before do
-                allow(settings.tracing.test_mode)
-                  .to receive(:trace_flush)
-                  .and_return(trace_flush)
+                before do
+                  allow(settings.tracing.test_mode)
+                    .to receive(:async)
+                    .and_return(true)
+
+                  allow(settings.tracing.test_mode)
+                    .to receive(:writer_options)
+                    .and_return(writer_options_test_mode)
+
+                  expect(Datadog::Tracing::SyncWriter)
+                    .not_to receive(:new)
+
+                  expect(Datadog::Tracing::Writer)
+                    .to receive(:new)
+                    .with(agent_settings: agent_settings, **writer_options_test_mode)
+                    .and_return(writer)
+                end
+
+                it_behaves_like 'event publishing writer'
               end
 
               context 'is not set' do
-                let(:trace_flush) { nil }
+                let(:sync_writer) { Datadog::Tracing::SyncWriter.new }
 
-                it_behaves_like 'new tracer' do
-                  let(:options) do
-                    {
-                      writer: kind_of(Datadog::Tracing::SyncWriter)
-                    }
-                  end
-                  let(:writer) { sync_writer }
-
-                  it_behaves_like 'event publishing writer'
+                before do
+                  expect(Datadog::Tracing::SyncWriter)
+                    .to receive(:new)
+                    .with(agent_settings: agent_settings, **writer_options)
+                    .and_return(writer)
                 end
-              end
 
-              context 'is set' do
-                let(:trace_flush) { instance_double(Datadog::Tracing::Flush::Finished) }
-
-                it_behaves_like 'new tracer' do
-                  let(:options) do
-                    {
-                      trace_flush: trace_flush,
-                      writer: kind_of(Datadog::Tracing::SyncWriter)
-                    }
+                context 'and :trace_flush' do
+                  before do
+                    allow(settings.tracing.test_mode)
+                      .to receive(:trace_flush)
+                      .and_return(trace_flush)
                   end
-                  let(:writer) { sync_writer }
 
-                  it_behaves_like 'event publishing writer'
+                  context 'is not set' do
+                    let(:trace_flush) { nil }
+
+                    it_behaves_like 'new tracer' do
+                      let(:options) do
+                        {
+                          writer: kind_of(Datadog::Tracing::SyncWriter)
+                        }
+                      end
+                      let(:writer) { sync_writer }
+
+                      it_behaves_like 'event publishing writer'
+                    end
+                  end
+
+                  context 'is set' do
+                    let(:trace_flush) { instance_double(Datadog::Tracing::Flush::Finished) }
+
+                    it_behaves_like 'new tracer' do
+                      let(:options) do
+                        {
+                          trace_flush: trace_flush,
+                          writer: kind_of(Datadog::Tracing::SyncWriter)
+                        }
+                      end
+                      let(:writer) { sync_writer }
+
+                      it_behaves_like 'event publishing writer'
+                    end
+                  end
                 end
-              end
-            end
 
-            context 'and :writer_options' do
-              before do
-                allow(settings.tracing.test_mode)
-                  .to receive(:writer_options)
-                  .and_return(writer_options)
-              end
-
-              context 'are set' do
-                let(:writer_options) { { transport_options: :bar } }
-
-                it_behaves_like 'new tracer' do
-                  let(:options) do
-                    {
-                      writer: writer
-                    }
+                context 'and :writer_options' do
+                  before do
+                    allow(settings.tracing.test_mode)
+                      .to receive(:writer_options)
+                      .and_return(writer_options)
                   end
-                  let(:writer) { sync_writer }
 
-                  it_behaves_like 'event publishing writer'
+                  context 'are set' do
+                    let(:writer_options) { { transport_options: :bar } }
+
+                    it_behaves_like 'new tracer' do
+                      let(:options) do
+                        {
+                          writer: writer
+                        }
+                      end
+                      let(:writer) { sync_writer }
+
+                      it_behaves_like 'event publishing writer'
+                    end
+                  end
                 end
               end
             end

--- a/spec/datadog/core/workers/polling_spec.rb
+++ b/spec/datadog/core/workers/polling_spec.rb
@@ -47,7 +47,7 @@ RSpec.describe Datadog::Core::Workers::Polling do
       shared_context 'graceful stop' do
         before do
           allow(worker).to receive(:join)
-            .with(described_class::SHUTDOWN_TIMEOUT)
+            .with(described_class::DEFAULT_SHUTDOWN_TIMEOUT)
             .and_return(true)
         end
       end
@@ -55,7 +55,7 @@ RSpec.describe Datadog::Core::Workers::Polling do
       context 'when the worker has not been started' do
         before do
           allow(worker).to receive(:join)
-            .with(described_class::SHUTDOWN_TIMEOUT)
+            .with(described_class::DEFAULT_SHUTDOWN_TIMEOUT)
             .and_return(true)
         end
 
@@ -112,6 +112,22 @@ RSpec.describe Datadog::Core::Workers::Polling do
             end
           end
         end
+      end
+
+      context 'given shutdown timeout' do
+        subject(:stop) { worker.stop(false, 1000) }
+        include_context 'graceful stop'
+
+        before do
+          expect(worker).to receive(:join)
+            .with(1000)
+            .and_return(true)
+
+          worker.perform
+          try_wait_until { worker.running? && worker.run_loop? }
+        end
+
+        it { is_expected.to be true }
       end
     end
 

--- a/spec/datadog/tracing/configuration/settings_spec.rb
+++ b/spec/datadog/tracing/configuration/settings_spec.rb
@@ -631,6 +631,21 @@ RSpec.describe Datadog::Tracing::Configuration::Settings do
         end
       end
 
+      describe '#async' do
+        subject(:enabled) { settings.tracing.test_mode.async }
+
+        it { is_expected.to be false }
+      end
+
+      describe '#async=' do
+        it 'updates the #async setting' do
+          expect { settings.tracing.test_mode.async = true }
+            .to change { settings.tracing.test_mode.async }
+            .from(false)
+            .to(true)
+        end
+      end
+
       describe '#writer_options' do
         subject(:writer_options) { settings.tracing.test_mode.writer_options }
 

--- a/spec/datadog/tracing/workers/trace_writer_spec.rb
+++ b/spec/datadog/tracing/workers/trace_writer_spec.rb
@@ -397,6 +397,22 @@ RSpec.describe Datadog::Tracing::Workers::AsyncTraceWriter do
         end
       end
     end
+
+    context 'given shutdown_timeout' do
+      let(:options) { { shutdown_timeout: 1000 } }
+      include_context 'shuts down the worker'
+
+      context 'and the worker has been started' do
+        before do
+          expect(writer).to receive(:join).with(1000).and_return(true)
+
+          writer.perform
+          try_wait_until { writer.running? && writer.run_loop? }
+        end
+
+        it { is_expected.to be true }
+      end
+    end
   end
 
   describe '#work_pending?' do

--- a/spec/datadog/tracing/workers_integration_spec.rb
+++ b/spec/datadog/tracing/workers_integration_spec.rb
@@ -236,7 +236,7 @@ RSpec.describe 'Datadog::Workers::AsyncTransport integration tests' do
         expect(trace_task).to have_received(:call).once
         expect(service_task).to_not have_received(:call)
         expect(@shutdown_end - @shutdown_beg)
-          .to be < Datadog::Tracing::Workers::AsyncTransport::SHUTDOWN_TIMEOUT
+          .to be < Datadog::Tracing::Workers::AsyncTransport::DEFAULT_SHUTDOWN_TIMEOUT
       end
     end
 
@@ -248,7 +248,7 @@ RSpec.describe 'Datadog::Workers::AsyncTransport integration tests' do
       it 'interrupts the worker to speed up shutdown' do
         expect(@shutdown_end - @shutdown_beg)
           .to be_within(5).of(
-            Datadog::Tracing::Workers::AsyncTransport::SHUTDOWN_TIMEOUT
+            Datadog::Tracing::Workers::AsyncTransport::DEFAULT_SHUTDOWN_TIMEOUT
           )
       end
     end

--- a/spec/datadog/tracing/workers_spec.rb
+++ b/spec/datadog/tracing/workers_spec.rb
@@ -72,34 +72,4 @@ RSpec.describe Datadog::Tracing::Workers::AsyncTransport do
       expect(worker.start).to be nil
     end
   end
-
-  describe '#stop' do
-    it 'stops underlying thread with default timeout' do
-      expect_any_instance_of(Thread).to receive(:join).with(
-        Datadog::Tracing::Workers::AsyncTransport::DEFAULT_SHUTDOWN_TIMEOUT
-      ).and_call_original
-
-      worker.start
-      worker.stop
-    end
-
-    context 'with shutdown timeout configured' do
-      let(:worker) do
-        described_class.new(
-          transport: nil,
-          buffer_size: 100,
-          on_trace: task,
-          interval: 0.5,
-          shutdown_timeout: 1000
-        )
-      end
-
-      it 'stops underlying thread with configured timeout' do
-        expect_any_instance_of(Thread).to receive(:join).with(1000).and_call_original
-
-        worker.start
-        worker.stop
-      end
-    end
-  end
 end

--- a/spec/datadog/tracing/workers_spec.rb
+++ b/spec/datadog/tracing/workers_spec.rb
@@ -77,7 +77,7 @@ RSpec.describe Datadog::Tracing::Workers::AsyncTransport do
     it 'stops underlying thread with default timeout' do
       expect_any_instance_of(Thread).to receive(:join).with(
         Datadog::Tracing::Workers::AsyncTransport::DEFAULT_SHUTDOWN_TIMEOUT
-      )
+      ).and_call_original
 
       worker.start
       worker.stop
@@ -95,7 +95,7 @@ RSpec.describe Datadog::Tracing::Workers::AsyncTransport do
       end
 
       it 'stops underlying thread with configured timeout' do
-        expect_any_instance_of(Thread).to receive(:join).with(1000)
+        expect_any_instance_of(Thread).to receive(:join).with(1000).and_call_original
 
         worker.start
         worker.stop

--- a/spec/datadog/tracing/workers_spec.rb
+++ b/spec/datadog/tracing/workers_spec.rb
@@ -72,4 +72,34 @@ RSpec.describe Datadog::Tracing::Workers::AsyncTransport do
       expect(worker.start).to be nil
     end
   end
+
+  describe '#stop' do
+    it 'stops underlying thread with default timeout' do
+      expect_any_instance_of(Thread).to receive(:join).with(
+        Datadog::Tracing::Workers::AsyncTransport::DEFAULT_SHUTDOWN_TIMEOUT
+      )
+
+      worker.start
+      worker.stop
+    end
+
+    context 'with shutdown timeout configured' do
+      let(:worker) do
+        described_class.new(
+          transport: nil,
+          buffer_size: 100,
+          on_trace: task,
+          interval: 0.5,
+          shutdown_timeout: 1000
+        )
+      end
+
+      it 'stops underlying thread with configured timeout' do
+        expect_any_instance_of(Thread).to receive(:join).with(1000)
+
+        worker.start
+        worker.stop
+      end
+    end
+  end
 end


### PR DESCRIPTION
**What does this PR do?**

This PR extends Tracer's configurability:

1. `settings.tracing.test_mode.async` configuration is added. When `async` is set to true, Datadog::Tracer is created with async writer (currently `Datadog::Tracing::Writer`) in test mode
2. SHUTDOWN_TIMEOUT (determines how long to wait until worker's thread is stopped on shutdown) can be now configured via writer_options (supported both by `Datadog::Tracing::Writer` and `Datadog::Tracing::Workers::TraceWriter`)

**Motivation:**

Sometimes SyncWriter can cause performance issues in test mode for several reasons:
1. It doesn't support batching and sends traces one by one
2. It doesn't use additional threads and blocks on IO operation when using HTTP connection

An example when this behaviour is problematic is CI visibility library that uses Tracer in test mode in order to disable sampling and guarantee traces delivery.
See how this configuration is used [here](https://github.com/DataDog/datadog-ci-rb/pull/33/files#diff-ba3d685743e82a993103582af6a918cfd857a39437f005b0172d67b30dabcd94):

```ruby
agentless_transport = Datadog::CI::TestVisibility::Transport.new(api_key: settings.api_key)

writer_options = settings.ci.writer_options
writer_options[:transport] = agentless_transport
writer_options[:shutdown_timeout] = 1000

settings.tracing.test_mode.async = true
settings.tracing.test_mode.writer_options = writer_options
```

Tracing's test mode is set to use async and we provide a large number as shutdown timeout for the worker to make sure that leftover traces are delivered after test suite run has ended.

**Pros of this approach**
- makes test mode more flexible to be useful in more use cases
- lets CI visibility library reuse most of the existing tracer infrastructure by substituting only the transport layer
- do not require external libraries to use internal private class of Tracing module to achieve 

**Cons of this approach**
- adds coupling between Datadog::CI::TestVisibility::Transport and Datadog::Tracing::Writer because writer currently expects specific shape of Response object returned from Transport ([traces_count method](https://github.com/DataDog/datadog-ci-rb/pull/33/files#diff-8d1baa335fb7e91eabadc4e884c782732a68015a18a265615ba5ba576f936fb2R96))
- the interface between Writer and Transport is not really stable in Tracing and can cause issues for datadog-ci-rb gem

**Alternative approaches**

1. Datadog CI Visibility library creates its own Writer, Worker and buffering logic using Datadog::Core::Workers primitives: this will require duplicating (aka copy-pasting) a lot of logic from Tracing as currently CI visibility uses Tracing public API for instrumentation and traces and spans as primitives. Currently we have no plans of changing it and developing our own set of primitives as it requires a substantial effort and all the other CI visibility libraries are built upon tracing.
2. Datadog CI Visibility library **does not use test mode**: this approach would work if we make `Datadog::Tracing::Sampler` configurable and public which brings its own set of challenges and issues

**How to test the change?**
Tested in https://github.com/DataDog/datadog-ci-rb/pull/33 by running sidekiq/sidekiq test suite with local versions of ddtrace + datadog-ci and agentless mode enabled

**For Datadog employees:**
- [ ] If this PR touches code that signs or publishes builds or packages, or handles
credentials of any kind, I've requested a review from `@DataDog/security-design-and-guidance`.
- [x] This PR doesn't touch any of that.

Unsure? Have a question? Request a review!
