### PR TITLE
Bump debase-ruby_core_source dependency to 3.2.2

### DIFF
--- a/ddtrace.gemspec
+++ b/ddtrace.gemspec
@@ -59,7 +59,7 @@ Gem::Specification.new do |spec|
   # Used by the profiler native extension to support Ruby < 2.6 and > 3.2
   #
   # We decided to pin it at the latest available version and will manually bump the dependency as needed.
-  spec.add_dependency 'debase-ruby_core_source', '= 3.2.1'
+  spec.add_dependency 'debase-ruby_core_source', '= 3.2.2'
 
   # Used by appsec
   spec.add_dependency 'libddwaf', '~> 1.14.0.0.0'

--- a/gemfiles/jruby_9.2.21.0_activesupport.gemfile.lock
+++ b/gemfiles/jruby_9.2.21.0_activesupport.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.14.0)
       datadog-ci (~> 0.1.0)
-      debase-ruby_core_source (= 3.2.1)
+      debase-ruby_core_source (= 3.2.2)
       libdatadog (~> 4.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
@@ -66,7 +66,7 @@ GEM
     crass (1.0.6)
     cri (2.15.11)
     datadog-ci (0.1.1)
-    debase-ruby_core_source (3.2.1)
+    debase-ruby_core_source (3.2.2)
     diff-lcs (1.5.0)
     digest-crc (0.6.5)
       rake (>= 12.0.0, < 14.0.0)

--- a/gemfiles/jruby_9.2.21.0_aws.gemfile.lock
+++ b/gemfiles/jruby_9.2.21.0_aws.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.14.0)
       datadog-ci (~> 0.1.0)
-      debase-ruby_core_source (= 3.2.1)
+      debase-ruby_core_source (= 3.2.2)
       libdatadog (~> 4.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
@@ -1459,7 +1459,7 @@ GEM
       rexml
     cri (2.15.11)
     datadog-ci (0.1.1)
-    debase-ruby_core_source (3.2.1)
+    debase-ruby_core_source (3.2.2)
     diff-lcs (1.5.0)
     docile (1.4.0)
     dogstatsd-ruby (5.6.0)

--- a/gemfiles/jruby_9.2.21.0_contrib.gemfile.lock
+++ b/gemfiles/jruby_9.2.21.0_contrib.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.14.0)
       datadog-ci (~> 0.1.0)
-      debase-ruby_core_source (= 3.2.1)
+      debase-ruby_core_source (= 3.2.2)
       libdatadog (~> 4.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
@@ -45,7 +45,7 @@ GEM
     cri (2.15.11)
     dalli (3.2.0)
     datadog-ci (0.1.1)
-    debase-ruby_core_source (3.2.1)
+    debase-ruby_core_source (3.2.2)
     diff-lcs (1.5.0)
     docile (1.4.0)
     dogstatsd-ruby (5.6.0)

--- a/gemfiles/jruby_9.2.21.0_contrib_old.gemfile.lock
+++ b/gemfiles/jruby_9.2.21.0_contrib_old.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.14.0)
       datadog-ci (~> 0.1.0)
-      debase-ruby_core_source (= 3.2.1)
+      debase-ruby_core_source (= 3.2.2)
       libdatadog (~> 4.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
@@ -39,7 +39,7 @@ GEM
     cri (2.15.11)
     dalli (2.7.11)
     datadog-ci (0.1.1)
-    debase-ruby_core_source (3.2.1)
+    debase-ruby_core_source (3.2.2)
     diff-lcs (1.5.0)
     docile (1.4.0)
     dogstatsd-ruby (5.5.0)

--- a/gemfiles/jruby_9.2.21.0_core_old.gemfile.lock
+++ b/gemfiles/jruby_9.2.21.0_core_old.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.14.0)
       datadog-ci (~> 0.1.0)
-      debase-ruby_core_source (= 3.2.1)
+      debase-ruby_core_source (= 3.2.2)
       libdatadog (~> 4.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
@@ -38,7 +38,7 @@ GEM
       rexml
     cri (2.15.11)
     datadog-ci (0.1.1)
-    debase-ruby_core_source (3.2.1)
+    debase-ruby_core_source (3.2.2)
     diff-lcs (1.5.0)
     docile (1.4.0)
     dogstatsd-ruby (4.8.3)

--- a/gemfiles/jruby_9.2.21.0_hanami_1.gemfile.lock
+++ b/gemfiles/jruby_9.2.21.0_hanami_1.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.14.0)
       datadog-ci (~> 0.1.0)
-      debase-ruby_core_source (= 3.2.1)
+      debase-ruby_core_source (= 3.2.2)
       libdatadog (~> 4.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
@@ -38,7 +38,7 @@ GEM
       rexml
     cri (2.15.11)
     datadog-ci (0.1.1)
-    debase-ruby_core_source (3.2.1)
+    debase-ruby_core_source (3.2.2)
     diff-lcs (1.5.0)
     digest (3.1.1-java)
     docile (1.4.0)

--- a/gemfiles/jruby_9.2.21.0_http.gemfile.lock
+++ b/gemfiles/jruby_9.2.21.0_http.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.14.0)
       datadog-ci (~> 0.1.0)
-      debase-ruby_core_source (= 3.2.1)
+      debase-ruby_core_source (= 3.2.2)
       libdatadog (~> 4.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
@@ -38,7 +38,7 @@ GEM
       rexml
     cri (2.15.11)
     datadog-ci (0.1.1)
-    debase-ruby_core_source (3.2.1)
+    debase-ruby_core_source (3.2.2)
     diff-lcs (1.5.0)
     docile (1.4.0)
     dogstatsd-ruby (5.6.1)

--- a/gemfiles/jruby_9.2.21.0_opentracing.gemfile.lock
+++ b/gemfiles/jruby_9.2.21.0_opentracing.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.14.0)
       datadog-ci (~> 0.1.0)
-      debase-ruby_core_source (= 3.2.1)
+      debase-ruby_core_source (= 3.2.2)
       libdatadog (~> 4.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
@@ -39,7 +39,7 @@ GEM
       rexml
     cri (2.15.11)
     datadog-ci (0.1.1)
-    debase-ruby_core_source (3.2.1)
+    debase-ruby_core_source (3.2.2)
     diff-lcs (1.5.0)
     docile (1.4.0)
     dogstatsd-ruby (5.6.1)

--- a/gemfiles/jruby_9.2.21.0_rack_1.gemfile.lock
+++ b/gemfiles/jruby_9.2.21.0_rack_1.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.14.0)
       datadog-ci (~> 0.1.0)
-      debase-ruby_core_source (= 3.2.1)
+      debase-ruby_core_source (= 3.2.2)
       libdatadog (~> 4.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
@@ -38,7 +38,7 @@ GEM
       rexml
     cri (2.15.11)
     datadog-ci (0.1.1)
-    debase-ruby_core_source (3.2.1)
+    debase-ruby_core_source (3.2.2)
     diff-lcs (1.5.0)
     docile (1.4.0)
     dogstatsd-ruby (5.6.1)

--- a/gemfiles/jruby_9.2.21.0_rack_2.gemfile.lock
+++ b/gemfiles/jruby_9.2.21.0_rack_2.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.14.0)
       datadog-ci (~> 0.1.0)
-      debase-ruby_core_source (= 3.2.1)
+      debase-ruby_core_source (= 3.2.2)
       libdatadog (~> 4.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
@@ -38,7 +38,7 @@ GEM
       rexml
     cri (2.15.11)
     datadog-ci (0.1.1)
-    debase-ruby_core_source (3.2.1)
+    debase-ruby_core_source (3.2.2)
     diff-lcs (1.5.0)
     docile (1.4.0)
     dogstatsd-ruby (5.6.1)

--- a/gemfiles/jruby_9.2.21.0_rack_3.gemfile.lock
+++ b/gemfiles/jruby_9.2.21.0_rack_3.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.14.0)
       datadog-ci (~> 0.1.0)
-      debase-ruby_core_source (= 3.2.1)
+      debase-ruby_core_source (= 3.2.2)
       libdatadog (~> 4.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
@@ -38,7 +38,7 @@ GEM
       rexml
     cri (2.15.11)
     datadog-ci (0.1.1)
-    debase-ruby_core_source (3.2.1)
+    debase-ruby_core_source (3.2.2)
     diff-lcs (1.5.0)
     docile (1.4.0)
     dogstatsd-ruby (5.6.1)

--- a/gemfiles/jruby_9.2.21.0_rails5_mysql2.gemfile.lock
+++ b/gemfiles/jruby_9.2.21.0_rails5_mysql2.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.14.0)
       datadog-ci (~> 0.1.0)
-      debase-ruby_core_source (= 3.2.1)
+      debase-ruby_core_source (= 3.2.2)
       libdatadog (~> 4.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
@@ -86,7 +86,7 @@ GEM
     crass (1.0.6)
     cri (2.15.11)
     datadog-ci (0.1.1)
-    debase-ruby_core_source (3.2.1)
+    debase-ruby_core_source (3.2.2)
     diff-lcs (1.5.0)
     docile (1.4.0)
     dogstatsd-ruby (5.5.0)

--- a/gemfiles/jruby_9.2.21.0_rails5_postgres.gemfile.lock
+++ b/gemfiles/jruby_9.2.21.0_rails5_postgres.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.14.0)
       datadog-ci (~> 0.1.0)
-      debase-ruby_core_source (= 3.2.1)
+      debase-ruby_core_source (= 3.2.2)
       libdatadog (~> 4.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
@@ -86,7 +86,7 @@ GEM
     crass (1.0.6)
     cri (2.15.11)
     datadog-ci (0.1.1)
-    debase-ruby_core_source (3.2.1)
+    debase-ruby_core_source (3.2.2)
     diff-lcs (1.5.0)
     digest (3.1.1-java)
     docile (1.4.0)

--- a/gemfiles/jruby_9.2.21.0_rails5_postgres_redis.gemfile.lock
+++ b/gemfiles/jruby_9.2.21.0_rails5_postgres_redis.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.14.0)
       datadog-ci (~> 0.1.0)
-      debase-ruby_core_source (= 3.2.1)
+      debase-ruby_core_source (= 3.2.2)
       libdatadog (~> 4.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
@@ -87,7 +87,7 @@ GEM
     crass (1.0.6)
     cri (2.15.11)
     datadog-ci (0.1.1)
-    debase-ruby_core_source (3.2.1)
+    debase-ruby_core_source (3.2.2)
     diff-lcs (1.5.0)
     digest (3.1.1-java)
     docile (1.4.0)

--- a/gemfiles/jruby_9.2.21.0_rails5_postgres_redis_activesupport.gemfile.lock
+++ b/gemfiles/jruby_9.2.21.0_rails5_postgres_redis_activesupport.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.14.0)
       datadog-ci (~> 0.1.0)
-      debase-ruby_core_source (= 3.2.1)
+      debase-ruby_core_source (= 3.2.2)
       libdatadog (~> 4.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
@@ -86,7 +86,7 @@ GEM
     crass (1.0.6)
     cri (2.15.11)
     datadog-ci (0.1.1)
-    debase-ruby_core_source (3.2.1)
+    debase-ruby_core_source (3.2.2)
     diff-lcs (1.5.0)
     digest (3.1.1-java)
     docile (1.4.0)

--- a/gemfiles/jruby_9.2.21.0_rails5_postgres_sidekiq.gemfile.lock
+++ b/gemfiles/jruby_9.2.21.0_rails5_postgres_sidekiq.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.14.0)
       datadog-ci (~> 0.1.0)
-      debase-ruby_core_source (= 3.2.1)
+      debase-ruby_core_source (= 3.2.2)
       libdatadog (~> 4.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
@@ -87,7 +87,7 @@ GEM
     crass (1.0.6)
     cri (2.15.11)
     datadog-ci (0.1.1)
-    debase-ruby_core_source (3.2.1)
+    debase-ruby_core_source (3.2.2)
     diff-lcs (1.5.0)
     digest (3.1.1-java)
     docile (1.4.0)

--- a/gemfiles/jruby_9.2.21.0_rails5_semantic_logger.gemfile.lock
+++ b/gemfiles/jruby_9.2.21.0_rails5_semantic_logger.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.14.0)
       datadog-ci (~> 0.1.0)
-      debase-ruby_core_source (= 3.2.1)
+      debase-ruby_core_source (= 3.2.2)
       libdatadog (~> 4.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
@@ -86,7 +86,7 @@ GEM
     crass (1.0.6)
     cri (2.15.11)
     datadog-ci (0.1.1)
-    debase-ruby_core_source (3.2.1)
+    debase-ruby_core_source (3.2.2)
     diff-lcs (1.5.0)
     digest (3.1.1-java)
     docile (1.4.0)

--- a/gemfiles/jruby_9.2.21.0_rails61_mysql2.gemfile.lock
+++ b/gemfiles/jruby_9.2.21.0_rails61_mysql2.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.14.0)
       datadog-ci (~> 0.1.0)
-      debase-ruby_core_source (= 3.2.1)
+      debase-ruby_core_source (= 3.2.2)
       libdatadog (~> 4.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
@@ -103,7 +103,7 @@ GEM
     crass (1.0.6)
     cri (2.15.11)
     datadog-ci (0.1.1)
-    debase-ruby_core_source (3.2.1)
+    debase-ruby_core_source (3.2.2)
     diff-lcs (1.5.0)
     docile (1.4.0)
     dogstatsd-ruby (5.5.0)

--- a/gemfiles/jruby_9.2.21.0_rails61_postgres.gemfile.lock
+++ b/gemfiles/jruby_9.2.21.0_rails61_postgres.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.14.0)
       datadog-ci (~> 0.1.0)
-      debase-ruby_core_source (= 3.2.1)
+      debase-ruby_core_source (= 3.2.2)
       libdatadog (~> 4.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
@@ -103,7 +103,7 @@ GEM
     crass (1.0.6)
     cri (2.15.11)
     datadog-ci (0.1.1)
-    debase-ruby_core_source (3.2.1)
+    debase-ruby_core_source (3.2.2)
     diff-lcs (1.5.0)
     digest (3.1.1-java)
     docile (1.4.0)

--- a/gemfiles/jruby_9.2.21.0_rails61_postgres_redis.gemfile.lock
+++ b/gemfiles/jruby_9.2.21.0_rails61_postgres_redis.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.14.0)
       datadog-ci (~> 0.1.0)
-      debase-ruby_core_source (= 3.2.1)
+      debase-ruby_core_source (= 3.2.2)
       libdatadog (~> 4.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
@@ -104,7 +104,7 @@ GEM
     crass (1.0.6)
     cri (2.15.11)
     datadog-ci (0.1.1)
-    debase-ruby_core_source (3.2.1)
+    debase-ruby_core_source (3.2.2)
     diff-lcs (1.5.0)
     digest (3.1.1-java)
     docile (1.4.0)

--- a/gemfiles/jruby_9.2.21.0_rails61_postgres_sidekiq.gemfile.lock
+++ b/gemfiles/jruby_9.2.21.0_rails61_postgres_sidekiq.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.14.0)
       datadog-ci (~> 0.1.0)
-      debase-ruby_core_source (= 3.2.1)
+      debase-ruby_core_source (= 3.2.2)
       libdatadog (~> 4.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
@@ -104,7 +104,7 @@ GEM
     crass (1.0.6)
     cri (2.15.11)
     datadog-ci (0.1.1)
-    debase-ruby_core_source (3.2.1)
+    debase-ruby_core_source (3.2.2)
     diff-lcs (1.5.0)
     digest (3.1.1-java)
     docile (1.4.0)

--- a/gemfiles/jruby_9.2.21.0_rails61_semantic_logger.gemfile.lock
+++ b/gemfiles/jruby_9.2.21.0_rails61_semantic_logger.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.14.0)
       datadog-ci (~> 0.1.0)
-      debase-ruby_core_source (= 3.2.1)
+      debase-ruby_core_source (= 3.2.2)
       libdatadog (~> 4.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
@@ -103,7 +103,7 @@ GEM
     crass (1.0.6)
     cri (2.15.11)
     datadog-ci (0.1.1)
-    debase-ruby_core_source (3.2.1)
+    debase-ruby_core_source (3.2.2)
     diff-lcs (1.5.0)
     digest (3.1.1-java)
     docile (1.4.0)

--- a/gemfiles/jruby_9.2.21.0_rails6_mysql2.gemfile.lock
+++ b/gemfiles/jruby_9.2.21.0_rails6_mysql2.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.14.0)
       datadog-ci (~> 0.1.0)
-      debase-ruby_core_source (= 3.2.1)
+      debase-ruby_core_source (= 3.2.2)
       libdatadog (~> 4.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
@@ -99,7 +99,7 @@ GEM
     crass (1.0.6)
     cri (2.15.11)
     datadog-ci (0.1.1)
-    debase-ruby_core_source (3.2.1)
+    debase-ruby_core_source (3.2.2)
     diff-lcs (1.5.0)
     docile (1.4.0)
     dogstatsd-ruby (5.5.0)

--- a/gemfiles/jruby_9.2.21.0_rails6_postgres.gemfile.lock
+++ b/gemfiles/jruby_9.2.21.0_rails6_postgres.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.14.0)
       datadog-ci (~> 0.1.0)
-      debase-ruby_core_source (= 3.2.1)
+      debase-ruby_core_source (= 3.2.2)
       libdatadog (~> 4.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
@@ -99,7 +99,7 @@ GEM
     crass (1.0.6)
     cri (2.15.11)
     datadog-ci (0.1.1)
-    debase-ruby_core_source (3.2.1)
+    debase-ruby_core_source (3.2.2)
     diff-lcs (1.5.0)
     digest (3.1.1-java)
     docile (1.4.0)

--- a/gemfiles/jruby_9.2.21.0_rails6_postgres_redis.gemfile.lock
+++ b/gemfiles/jruby_9.2.21.0_rails6_postgres_redis.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.14.0)
       datadog-ci (~> 0.1.0)
-      debase-ruby_core_source (= 3.2.1)
+      debase-ruby_core_source (= 3.2.2)
       libdatadog (~> 4.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
@@ -100,7 +100,7 @@ GEM
     crass (1.0.6)
     cri (2.15.11)
     datadog-ci (0.1.1)
-    debase-ruby_core_source (3.2.1)
+    debase-ruby_core_source (3.2.2)
     diff-lcs (1.5.0)
     digest (3.1.1-java)
     docile (1.4.0)

--- a/gemfiles/jruby_9.2.21.0_rails6_postgres_redis_activesupport.gemfile.lock
+++ b/gemfiles/jruby_9.2.21.0_rails6_postgres_redis_activesupport.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.14.0)
       datadog-ci (~> 0.1.0)
-      debase-ruby_core_source (= 3.2.1)
+      debase-ruby_core_source (= 3.2.2)
       libdatadog (~> 4.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
@@ -99,7 +99,7 @@ GEM
     crass (1.0.6)
     cri (2.15.11)
     datadog-ci (0.1.1)
-    debase-ruby_core_source (3.2.1)
+    debase-ruby_core_source (3.2.2)
     diff-lcs (1.5.0)
     digest (3.1.1-java)
     docile (1.4.0)

--- a/gemfiles/jruby_9.2.21.0_rails6_postgres_sidekiq.gemfile.lock
+++ b/gemfiles/jruby_9.2.21.0_rails6_postgres_sidekiq.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.14.0)
       datadog-ci (~> 0.1.0)
-      debase-ruby_core_source (= 3.2.1)
+      debase-ruby_core_source (= 3.2.2)
       libdatadog (~> 4.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
@@ -100,7 +100,7 @@ GEM
     crass (1.0.6)
     cri (2.15.11)
     datadog-ci (0.1.1)
-    debase-ruby_core_source (3.2.1)
+    debase-ruby_core_source (3.2.2)
     diff-lcs (1.5.0)
     digest (3.1.1-java)
     docile (1.4.0)

--- a/gemfiles/jruby_9.2.21.0_rails6_semantic_logger.gemfile.lock
+++ b/gemfiles/jruby_9.2.21.0_rails6_semantic_logger.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.14.0)
       datadog-ci (~> 0.1.0)
-      debase-ruby_core_source (= 3.2.1)
+      debase-ruby_core_source (= 3.2.2)
       libdatadog (~> 4.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
@@ -99,7 +99,7 @@ GEM
     crass (1.0.6)
     cri (2.15.11)
     datadog-ci (0.1.1)
-    debase-ruby_core_source (3.2.1)
+    debase-ruby_core_source (3.2.2)
     diff-lcs (1.5.0)
     digest (3.1.1-java)
     docile (1.4.0)

--- a/gemfiles/jruby_9.2.21.0_redis_3.gemfile.lock
+++ b/gemfiles/jruby_9.2.21.0_redis_3.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.14.0)
       datadog-ci (~> 0.1.0)
-      debase-ruby_core_source (= 3.2.1)
+      debase-ruby_core_source (= 3.2.2)
       libdatadog (~> 4.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
@@ -38,7 +38,7 @@ GEM
       rexml
     cri (2.15.11)
     datadog-ci (0.1.1)
-    debase-ruby_core_source (3.2.1)
+    debase-ruby_core_source (3.2.2)
     diff-lcs (1.5.0)
     docile (1.4.0)
     dogstatsd-ruby (5.5.0)

--- a/gemfiles/jruby_9.2.21.0_redis_4.gemfile.lock
+++ b/gemfiles/jruby_9.2.21.0_redis_4.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.14.0)
       datadog-ci (~> 0.1.0)
-      debase-ruby_core_source (= 3.2.1)
+      debase-ruby_core_source (= 3.2.2)
       libdatadog (~> 4.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
@@ -38,7 +38,7 @@ GEM
       rexml
     cri (2.15.11)
     datadog-ci (0.1.1)
-    debase-ruby_core_source (3.2.1)
+    debase-ruby_core_source (3.2.2)
     diff-lcs (1.5.0)
     docile (1.4.0)
     dogstatsd-ruby (5.5.0)

--- a/gemfiles/jruby_9.2.21.0_redis_5.gemfile.lock
+++ b/gemfiles/jruby_9.2.21.0_redis_5.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.14.0)
       datadog-ci (~> 0.1.0)
-      debase-ruby_core_source (= 3.2.1)
+      debase-ruby_core_source (= 3.2.2)
       libdatadog (~> 4.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
@@ -39,7 +39,7 @@ GEM
       rexml
     cri (2.15.11)
     datadog-ci (0.1.1)
-    debase-ruby_core_source (3.2.1)
+    debase-ruby_core_source (3.2.2)
     diff-lcs (1.5.0)
     docile (1.4.0)
     dogstatsd-ruby (5.5.0)

--- a/gemfiles/jruby_9.2.21.0_relational_db.gemfile.lock
+++ b/gemfiles/jruby_9.2.21.0_relational_db.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.14.0)
       datadog-ci (~> 0.1.0)
-      debase-ruby_core_source (= 3.2.1)
+      debase-ruby_core_source (= 3.2.2)
       libdatadog (~> 4.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
@@ -61,7 +61,7 @@ GEM
       rexml
     cri (2.15.11)
     datadog-ci (0.1.1)
-    debase-ruby_core_source (3.2.1)
+    debase-ruby_core_source (3.2.2)
     delayed_job (4.1.11)
       activesupport (>= 3.0, < 8.0)
     delayed_job_active_record (4.1.7)

--- a/gemfiles/jruby_9.2.21.0_resque2_redis3.gemfile.lock
+++ b/gemfiles/jruby_9.2.21.0_resque2_redis3.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.14.0)
       datadog-ci (~> 0.1.0)
-      debase-ruby_core_source (= 3.2.1)
+      debase-ruby_core_source (= 3.2.2)
       libdatadog (~> 4.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
@@ -38,7 +38,7 @@ GEM
       rexml
     cri (2.15.11)
     datadog-ci (0.1.1)
-    debase-ruby_core_source (3.2.1)
+    debase-ruby_core_source (3.2.2)
     diff-lcs (1.5.0)
     docile (1.4.0)
     dogstatsd-ruby (5.5.0)

--- a/gemfiles/jruby_9.2.21.0_resque2_redis4.gemfile.lock
+++ b/gemfiles/jruby_9.2.21.0_resque2_redis4.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.14.0)
       datadog-ci (~> 0.1.0)
-      debase-ruby_core_source (= 3.2.1)
+      debase-ruby_core_source (= 3.2.2)
       libdatadog (~> 4.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
@@ -39,7 +39,7 @@ GEM
       rexml
     cri (2.15.11)
     datadog-ci (0.1.1)
-    debase-ruby_core_source (3.2.1)
+    debase-ruby_core_source (3.2.2)
     diff-lcs (1.5.0)
     docile (1.4.0)
     dogstatsd-ruby (5.5.0)

--- a/gemfiles/jruby_9.2.21.0_sinatra.gemfile.lock
+++ b/gemfiles/jruby_9.2.21.0_sinatra.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.14.0)
       datadog-ci (~> 0.1.0)
-      debase-ruby_core_source (= 3.2.1)
+      debase-ruby_core_source (= 3.2.2)
       libdatadog (~> 4.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
@@ -38,7 +38,7 @@ GEM
       rexml
     cri (2.15.11)
     datadog-ci (0.1.1)
-    debase-ruby_core_source (3.2.1)
+    debase-ruby_core_source (3.2.2)
     diff-lcs (1.5.0)
     docile (1.4.0)
     dogstatsd-ruby (5.5.0)

--- a/gemfiles/jruby_9.3.9.0_activesupport.gemfile.lock
+++ b/gemfiles/jruby_9.3.9.0_activesupport.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.14.0)
       datadog-ci (~> 0.1.0)
-      debase-ruby_core_source (= 3.2.1)
+      debase-ruby_core_source (= 3.2.2)
       libdatadog (~> 4.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
@@ -68,7 +68,7 @@ GEM
     crass (1.0.6)
     cri (2.15.11)
     datadog-ci (0.1.1)
-    debase-ruby_core_source (3.2.1)
+    debase-ruby_core_source (3.2.2)
     diff-lcs (1.5.0)
     digest-crc (0.6.5)
       rake (>= 12.0.0, < 14.0.0)

--- a/gemfiles/jruby_9.3.9.0_aws.gemfile.lock
+++ b/gemfiles/jruby_9.3.9.0_aws.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.14.0)
       datadog-ci (~> 0.1.0)
-      debase-ruby_core_source (= 3.2.1)
+      debase-ruby_core_source (= 3.2.2)
       libdatadog (~> 4.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
@@ -1460,7 +1460,7 @@ GEM
       rexml
     cri (2.15.11)
     datadog-ci (0.1.1)
-    debase-ruby_core_source (3.2.1)
+    debase-ruby_core_source (3.2.2)
     diff-lcs (1.5.0)
     docile (1.4.0)
     dogstatsd-ruby (5.6.0)

--- a/gemfiles/jruby_9.3.9.0_contrib.gemfile.lock
+++ b/gemfiles/jruby_9.3.9.0_contrib.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.14.0)
       datadog-ci (~> 0.1.0)
-      debase-ruby_core_source (= 3.2.1)
+      debase-ruby_core_source (= 3.2.2)
       libdatadog (~> 4.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
@@ -46,7 +46,7 @@ GEM
     cri (2.15.11)
     dalli (3.2.3)
     datadog-ci (0.1.1)
-    debase-ruby_core_source (3.2.1)
+    debase-ruby_core_source (3.2.2)
     diff-lcs (1.5.0)
     docile (1.4.0)
     dogstatsd-ruby (5.6.1)

--- a/gemfiles/jruby_9.3.9.0_contrib_old.gemfile.lock
+++ b/gemfiles/jruby_9.3.9.0_contrib_old.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.14.0)
       datadog-ci (~> 0.1.0)
-      debase-ruby_core_source (= 3.2.1)
+      debase-ruby_core_source (= 3.2.2)
       libdatadog (~> 4.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
@@ -40,7 +40,7 @@ GEM
     cri (2.15.11)
     dalli (2.7.11)
     datadog-ci (0.1.1)
-    debase-ruby_core_source (3.2.1)
+    debase-ruby_core_source (3.2.2)
     diff-lcs (1.5.0)
     docile (1.4.0)
     dogstatsd-ruby (5.6.1)

--- a/gemfiles/jruby_9.3.9.0_core_old.gemfile.lock
+++ b/gemfiles/jruby_9.3.9.0_core_old.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.14.0)
       datadog-ci (~> 0.1.0)
-      debase-ruby_core_source (= 3.2.1)
+      debase-ruby_core_source (= 3.2.2)
       libdatadog (~> 4.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
@@ -39,7 +39,7 @@ GEM
       rexml
     cri (2.15.11)
     datadog-ci (0.1.1)
-    debase-ruby_core_source (3.2.1)
+    debase-ruby_core_source (3.2.2)
     diff-lcs (1.5.0)
     docile (1.4.0)
     dogstatsd-ruby (4.8.3)

--- a/gemfiles/jruby_9.3.9.0_hanami_1.gemfile.lock
+++ b/gemfiles/jruby_9.3.9.0_hanami_1.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.14.0)
       datadog-ci (~> 0.1.0)
-      debase-ruby_core_source (= 3.2.1)
+      debase-ruby_core_source (= 3.2.2)
       libdatadog (~> 4.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
@@ -40,7 +40,7 @@ GEM
     cri (2.15.11)
     datadog-ci (0.1.1)
     date (3.3.3-java)
-    debase-ruby_core_source (3.2.1)
+    debase-ruby_core_source (3.2.2)
     diff-lcs (1.5.0)
     docile (1.4.0)
     dogstatsd-ruby (5.6.1)

--- a/gemfiles/jruby_9.3.9.0_http.gemfile.lock
+++ b/gemfiles/jruby_9.3.9.0_http.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.14.0)
       datadog-ci (~> 0.1.0)
-      debase-ruby_core_source (= 3.2.1)
+      debase-ruby_core_source (= 3.2.2)
       libdatadog (~> 4.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
@@ -39,7 +39,7 @@ GEM
       rexml
     cri (2.15.11)
     datadog-ci (0.1.1)
-    debase-ruby_core_source (3.2.1)
+    debase-ruby_core_source (3.2.2)
     diff-lcs (1.5.0)
     docile (1.4.0)
     dogstatsd-ruby (5.6.1)

--- a/gemfiles/jruby_9.3.9.0_opentracing.gemfile.lock
+++ b/gemfiles/jruby_9.3.9.0_opentracing.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.14.0)
       datadog-ci (~> 0.1.0)
-      debase-ruby_core_source (= 3.2.1)
+      debase-ruby_core_source (= 3.2.2)
       libdatadog (~> 4.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
@@ -40,7 +40,7 @@ GEM
       rexml
     cri (2.15.11)
     datadog-ci (0.1.1)
-    debase-ruby_core_source (3.2.1)
+    debase-ruby_core_source (3.2.2)
     diff-lcs (1.5.0)
     docile (1.4.0)
     dogstatsd-ruby (5.6.1)

--- a/gemfiles/jruby_9.3.9.0_rack_1.gemfile.lock
+++ b/gemfiles/jruby_9.3.9.0_rack_1.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.14.0)
       datadog-ci (~> 0.1.0)
-      debase-ruby_core_source (= 3.2.1)
+      debase-ruby_core_source (= 3.2.2)
       libdatadog (~> 4.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
@@ -39,7 +39,7 @@ GEM
       rexml
     cri (2.15.11)
     datadog-ci (0.1.1)
-    debase-ruby_core_source (3.2.1)
+    debase-ruby_core_source (3.2.2)
     diff-lcs (1.5.0)
     docile (1.4.0)
     dogstatsd-ruby (5.6.1)

--- a/gemfiles/jruby_9.3.9.0_rack_2.gemfile.lock
+++ b/gemfiles/jruby_9.3.9.0_rack_2.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.14.0)
       datadog-ci (~> 0.1.0)
-      debase-ruby_core_source (= 3.2.1)
+      debase-ruby_core_source (= 3.2.2)
       libdatadog (~> 4.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
@@ -39,7 +39,7 @@ GEM
       rexml
     cri (2.15.11)
     datadog-ci (0.1.1)
-    debase-ruby_core_source (3.2.1)
+    debase-ruby_core_source (3.2.2)
     diff-lcs (1.5.0)
     docile (1.4.0)
     dogstatsd-ruby (5.6.1)

--- a/gemfiles/jruby_9.3.9.0_rack_3.gemfile.lock
+++ b/gemfiles/jruby_9.3.9.0_rack_3.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.14.0)
       datadog-ci (~> 0.1.0)
-      debase-ruby_core_source (= 3.2.1)
+      debase-ruby_core_source (= 3.2.2)
       libdatadog (~> 4.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
@@ -39,7 +39,7 @@ GEM
       rexml
     cri (2.15.11)
     datadog-ci (0.1.1)
-    debase-ruby_core_source (3.2.1)
+    debase-ruby_core_source (3.2.2)
     diff-lcs (1.5.0)
     docile (1.4.0)
     dogstatsd-ruby (5.6.1)

--- a/gemfiles/jruby_9.3.9.0_rails5_mysql2.gemfile.lock
+++ b/gemfiles/jruby_9.3.9.0_rails5_mysql2.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.14.0)
       datadog-ci (~> 0.1.0)
-      debase-ruby_core_source (= 3.2.1)
+      debase-ruby_core_source (= 3.2.2)
       libdatadog (~> 4.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
@@ -88,7 +88,7 @@ GEM
     cri (2.15.11)
     datadog-ci (0.1.1)
     date (3.3.3-java)
-    debase-ruby_core_source (3.2.1)
+    debase-ruby_core_source (3.2.2)
     diff-lcs (1.5.0)
     docile (1.4.0)
     dogstatsd-ruby (5.6.1)

--- a/gemfiles/jruby_9.3.9.0_rails5_postgres.gemfile.lock
+++ b/gemfiles/jruby_9.3.9.0_rails5_postgres.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.14.0)
       datadog-ci (~> 0.1.0)
-      debase-ruby_core_source (= 3.2.1)
+      debase-ruby_core_source (= 3.2.2)
       libdatadog (~> 4.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
@@ -88,7 +88,7 @@ GEM
     cri (2.15.11)
     datadog-ci (0.1.1)
     date (3.3.3-java)
-    debase-ruby_core_source (3.2.1)
+    debase-ruby_core_source (3.2.2)
     diff-lcs (1.5.0)
     docile (1.4.0)
     dogstatsd-ruby (5.6.1)

--- a/gemfiles/jruby_9.3.9.0_rails5_postgres_redis.gemfile.lock
+++ b/gemfiles/jruby_9.3.9.0_rails5_postgres_redis.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.14.0)
       datadog-ci (~> 0.1.0)
-      debase-ruby_core_source (= 3.2.1)
+      debase-ruby_core_source (= 3.2.2)
       libdatadog (~> 4.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
@@ -88,7 +88,7 @@ GEM
     cri (2.15.11)
     datadog-ci (0.1.1)
     date (3.3.3-java)
-    debase-ruby_core_source (3.2.1)
+    debase-ruby_core_source (3.2.2)
     diff-lcs (1.5.0)
     docile (1.4.0)
     dogstatsd-ruby (5.6.1)

--- a/gemfiles/jruby_9.3.9.0_rails5_postgres_redis_activesupport.gemfile.lock
+++ b/gemfiles/jruby_9.3.9.0_rails5_postgres_redis_activesupport.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.14.0)
       datadog-ci (~> 0.1.0)
-      debase-ruby_core_source (= 3.2.1)
+      debase-ruby_core_source (= 3.2.2)
       libdatadog (~> 4.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
@@ -88,7 +88,7 @@ GEM
     cri (2.15.11)
     datadog-ci (0.1.1)
     date (3.3.3-java)
-    debase-ruby_core_source (3.2.1)
+    debase-ruby_core_source (3.2.2)
     diff-lcs (1.5.0)
     docile (1.4.0)
     dogstatsd-ruby (5.6.1)

--- a/gemfiles/jruby_9.3.9.0_rails5_postgres_sidekiq.gemfile.lock
+++ b/gemfiles/jruby_9.3.9.0_rails5_postgres_sidekiq.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.14.0)
       datadog-ci (~> 0.1.0)
-      debase-ruby_core_source (= 3.2.1)
+      debase-ruby_core_source (= 3.2.2)
       libdatadog (~> 4.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
@@ -89,7 +89,7 @@ GEM
     cri (2.15.11)
     datadog-ci (0.1.1)
     date (3.3.3-java)
-    debase-ruby_core_source (3.2.1)
+    debase-ruby_core_source (3.2.2)
     diff-lcs (1.5.0)
     docile (1.4.0)
     dogstatsd-ruby (5.6.1)

--- a/gemfiles/jruby_9.3.9.0_rails5_semantic_logger.gemfile.lock
+++ b/gemfiles/jruby_9.3.9.0_rails5_semantic_logger.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.14.0)
       datadog-ci (~> 0.1.0)
-      debase-ruby_core_source (= 3.2.1)
+      debase-ruby_core_source (= 3.2.2)
       libdatadog (~> 4.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
@@ -88,7 +88,7 @@ GEM
     cri (2.15.11)
     datadog-ci (0.1.1)
     date (3.3.3-java)
-    debase-ruby_core_source (3.2.1)
+    debase-ruby_core_source (3.2.2)
     diff-lcs (1.5.0)
     docile (1.4.0)
     dogstatsd-ruby (5.6.1)

--- a/gemfiles/jruby_9.3.9.0_rails61_mysql2.gemfile.lock
+++ b/gemfiles/jruby_9.3.9.0_rails61_mysql2.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.14.0)
       datadog-ci (~> 0.1.0)
-      debase-ruby_core_source (= 3.2.1)
+      debase-ruby_core_source (= 3.2.2)
       libdatadog (~> 4.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
@@ -105,7 +105,7 @@ GEM
     cri (2.15.11)
     datadog-ci (0.1.1)
     date (3.3.3-java)
-    debase-ruby_core_source (3.2.1)
+    debase-ruby_core_source (3.2.2)
     diff-lcs (1.5.0)
     docile (1.4.0)
     dogstatsd-ruby (5.6.1)

--- a/gemfiles/jruby_9.3.9.0_rails61_postgres.gemfile.lock
+++ b/gemfiles/jruby_9.3.9.0_rails61_postgres.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.14.0)
       datadog-ci (~> 0.1.0)
-      debase-ruby_core_source (= 3.2.1)
+      debase-ruby_core_source (= 3.2.2)
       libdatadog (~> 4.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
@@ -105,7 +105,7 @@ GEM
     cri (2.15.11)
     datadog-ci (0.1.1)
     date (3.3.3-java)
-    debase-ruby_core_source (3.2.1)
+    debase-ruby_core_source (3.2.2)
     diff-lcs (1.5.0)
     docile (1.4.0)
     dogstatsd-ruby (5.6.1)

--- a/gemfiles/jruby_9.3.9.0_rails61_postgres_redis.gemfile.lock
+++ b/gemfiles/jruby_9.3.9.0_rails61_postgres_redis.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.14.0)
       datadog-ci (~> 0.1.0)
-      debase-ruby_core_source (= 3.2.1)
+      debase-ruby_core_source (= 3.2.2)
       libdatadog (~> 4.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
@@ -105,7 +105,7 @@ GEM
     cri (2.15.11)
     datadog-ci (0.1.1)
     date (3.3.3-java)
-    debase-ruby_core_source (3.2.1)
+    debase-ruby_core_source (3.2.2)
     diff-lcs (1.5.0)
     docile (1.4.0)
     dogstatsd-ruby (5.6.1)

--- a/gemfiles/jruby_9.3.9.0_rails61_postgres_sidekiq.gemfile.lock
+++ b/gemfiles/jruby_9.3.9.0_rails61_postgres_sidekiq.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.14.0)
       datadog-ci (~> 0.1.0)
-      debase-ruby_core_source (= 3.2.1)
+      debase-ruby_core_source (= 3.2.2)
       libdatadog (~> 4.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
@@ -106,7 +106,7 @@ GEM
     cri (2.15.11)
     datadog-ci (0.1.1)
     date (3.3.3-java)
-    debase-ruby_core_source (3.2.1)
+    debase-ruby_core_source (3.2.2)
     diff-lcs (1.5.0)
     docile (1.4.0)
     dogstatsd-ruby (5.6.1)

--- a/gemfiles/jruby_9.3.9.0_rails61_semantic_logger.gemfile.lock
+++ b/gemfiles/jruby_9.3.9.0_rails61_semantic_logger.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.14.0)
       datadog-ci (~> 0.1.0)
-      debase-ruby_core_source (= 3.2.1)
+      debase-ruby_core_source (= 3.2.2)
       libdatadog (~> 4.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
@@ -105,7 +105,7 @@ GEM
     cri (2.15.11)
     datadog-ci (0.1.1)
     date (3.3.3-java)
-    debase-ruby_core_source (3.2.1)
+    debase-ruby_core_source (3.2.2)
     diff-lcs (1.5.0)
     docile (1.4.0)
     dogstatsd-ruby (5.6.1)

--- a/gemfiles/jruby_9.3.9.0_rails6_mysql2.gemfile.lock
+++ b/gemfiles/jruby_9.3.9.0_rails6_mysql2.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.14.0)
       datadog-ci (~> 0.1.0)
-      debase-ruby_core_source (= 3.2.1)
+      debase-ruby_core_source (= 3.2.2)
       libdatadog (~> 4.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
@@ -101,7 +101,7 @@ GEM
     cri (2.15.11)
     datadog-ci (0.1.1)
     date (3.3.3-java)
-    debase-ruby_core_source (3.2.1)
+    debase-ruby_core_source (3.2.2)
     diff-lcs (1.5.0)
     docile (1.4.0)
     dogstatsd-ruby (5.6.1)

--- a/gemfiles/jruby_9.3.9.0_rails6_postgres.gemfile.lock
+++ b/gemfiles/jruby_9.3.9.0_rails6_postgres.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.14.0)
       datadog-ci (~> 0.1.0)
-      debase-ruby_core_source (= 3.2.1)
+      debase-ruby_core_source (= 3.2.2)
       libdatadog (~> 4.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
@@ -101,7 +101,7 @@ GEM
     cri (2.15.11)
     datadog-ci (0.1.1)
     date (3.3.3-java)
-    debase-ruby_core_source (3.2.1)
+    debase-ruby_core_source (3.2.2)
     diff-lcs (1.5.0)
     docile (1.4.0)
     dogstatsd-ruby (5.6.1)

--- a/gemfiles/jruby_9.3.9.0_rails6_postgres_redis.gemfile.lock
+++ b/gemfiles/jruby_9.3.9.0_rails6_postgres_redis.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.14.0)
       datadog-ci (~> 0.1.0)
-      debase-ruby_core_source (= 3.2.1)
+      debase-ruby_core_source (= 3.2.2)
       libdatadog (~> 4.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
@@ -101,7 +101,7 @@ GEM
     cri (2.15.11)
     datadog-ci (0.1.1)
     date (3.3.3-java)
-    debase-ruby_core_source (3.2.1)
+    debase-ruby_core_source (3.2.2)
     diff-lcs (1.5.0)
     docile (1.4.0)
     dogstatsd-ruby (5.6.1)

--- a/gemfiles/jruby_9.3.9.0_rails6_postgres_redis_activesupport.gemfile.lock
+++ b/gemfiles/jruby_9.3.9.0_rails6_postgres_redis_activesupport.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.14.0)
       datadog-ci (~> 0.1.0)
-      debase-ruby_core_source (= 3.2.1)
+      debase-ruby_core_source (= 3.2.2)
       libdatadog (~> 4.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
@@ -101,7 +101,7 @@ GEM
     cri (2.15.11)
     datadog-ci (0.1.1)
     date (3.3.3-java)
-    debase-ruby_core_source (3.2.1)
+    debase-ruby_core_source (3.2.2)
     diff-lcs (1.5.0)
     docile (1.4.0)
     dogstatsd-ruby (5.6.1)

--- a/gemfiles/jruby_9.3.9.0_rails6_postgres_sidekiq.gemfile.lock
+++ b/gemfiles/jruby_9.3.9.0_rails6_postgres_sidekiq.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.14.0)
       datadog-ci (~> 0.1.0)
-      debase-ruby_core_source (= 3.2.1)
+      debase-ruby_core_source (= 3.2.2)
       libdatadog (~> 4.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
@@ -102,7 +102,7 @@ GEM
     cri (2.15.11)
     datadog-ci (0.1.1)
     date (3.3.3-java)
-    debase-ruby_core_source (3.2.1)
+    debase-ruby_core_source (3.2.2)
     diff-lcs (1.5.0)
     docile (1.4.0)
     dogstatsd-ruby (5.6.1)

--- a/gemfiles/jruby_9.3.9.0_rails6_semantic_logger.gemfile.lock
+++ b/gemfiles/jruby_9.3.9.0_rails6_semantic_logger.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.14.0)
       datadog-ci (~> 0.1.0)
-      debase-ruby_core_source (= 3.2.1)
+      debase-ruby_core_source (= 3.2.2)
       libdatadog (~> 4.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
@@ -101,7 +101,7 @@ GEM
     cri (2.15.11)
     datadog-ci (0.1.1)
     date (3.3.3-java)
-    debase-ruby_core_source (3.2.1)
+    debase-ruby_core_source (3.2.2)
     diff-lcs (1.5.0)
     docile (1.4.0)
     dogstatsd-ruby (5.6.1)

--- a/gemfiles/jruby_9.3.9.0_redis_3.gemfile.lock
+++ b/gemfiles/jruby_9.3.9.0_redis_3.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.14.0)
       datadog-ci (~> 0.1.0)
-      debase-ruby_core_source (= 3.2.1)
+      debase-ruby_core_source (= 3.2.2)
       libdatadog (~> 4.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
@@ -39,7 +39,7 @@ GEM
       rexml
     cri (2.15.11)
     datadog-ci (0.1.1)
-    debase-ruby_core_source (3.2.1)
+    debase-ruby_core_source (3.2.2)
     diff-lcs (1.5.0)
     docile (1.4.0)
     dogstatsd-ruby (5.6.1)

--- a/gemfiles/jruby_9.3.9.0_redis_4.gemfile.lock
+++ b/gemfiles/jruby_9.3.9.0_redis_4.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.14.0)
       datadog-ci (~> 0.1.0)
-      debase-ruby_core_source (= 3.2.1)
+      debase-ruby_core_source (= 3.2.2)
       libdatadog (~> 4.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
@@ -39,7 +39,7 @@ GEM
       rexml
     cri (2.15.11)
     datadog-ci (0.1.1)
-    debase-ruby_core_source (3.2.1)
+    debase-ruby_core_source (3.2.2)
     diff-lcs (1.5.0)
     docile (1.4.0)
     dogstatsd-ruby (5.6.1)

--- a/gemfiles/jruby_9.3.9.0_redis_5.gemfile.lock
+++ b/gemfiles/jruby_9.3.9.0_redis_5.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.14.0)
       datadog-ci (~> 0.1.0)
-      debase-ruby_core_source (= 3.2.1)
+      debase-ruby_core_source (= 3.2.2)
       libdatadog (~> 4.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
@@ -40,7 +40,7 @@ GEM
       rexml
     cri (2.15.11)
     datadog-ci (0.1.1)
-    debase-ruby_core_source (3.2.1)
+    debase-ruby_core_source (3.2.2)
     diff-lcs (1.5.0)
     docile (1.4.0)
     dogstatsd-ruby (5.6.1)

--- a/gemfiles/jruby_9.3.9.0_relational_db.gemfile.lock
+++ b/gemfiles/jruby_9.3.9.0_relational_db.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.14.0)
       datadog-ci (~> 0.1.0)
-      debase-ruby_core_source (= 3.2.1)
+      debase-ruby_core_source (= 3.2.2)
       libdatadog (~> 4.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
@@ -58,7 +58,7 @@ GEM
       rexml
     cri (2.15.11)
     datadog-ci (0.1.1)
-    debase-ruby_core_source (3.2.1)
+    debase-ruby_core_source (3.2.2)
     delayed_job (4.1.11)
       activesupport (>= 3.0, < 8.0)
     delayed_job_active_record (4.1.7)

--- a/gemfiles/jruby_9.3.9.0_resque2_redis3.gemfile.lock
+++ b/gemfiles/jruby_9.3.9.0_resque2_redis3.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.14.0)
       datadog-ci (~> 0.1.0)
-      debase-ruby_core_source (= 3.2.1)
+      debase-ruby_core_source (= 3.2.2)
       libdatadog (~> 4.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
@@ -39,7 +39,7 @@ GEM
       rexml
     cri (2.15.11)
     datadog-ci (0.1.1)
-    debase-ruby_core_source (3.2.1)
+    debase-ruby_core_source (3.2.2)
     diff-lcs (1.5.0)
     docile (1.4.0)
     dogstatsd-ruby (5.6.1)

--- a/gemfiles/jruby_9.3.9.0_resque2_redis4.gemfile.lock
+++ b/gemfiles/jruby_9.3.9.0_resque2_redis4.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.14.0)
       datadog-ci (~> 0.1.0)
-      debase-ruby_core_source (= 3.2.1)
+      debase-ruby_core_source (= 3.2.2)
       libdatadog (~> 4.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
@@ -39,7 +39,7 @@ GEM
       rexml
     cri (2.15.11)
     datadog-ci (0.1.1)
-    debase-ruby_core_source (3.2.1)
+    debase-ruby_core_source (3.2.2)
     diff-lcs (1.5.0)
     docile (1.4.0)
     dogstatsd-ruby (5.6.1)

--- a/gemfiles/jruby_9.3.9.0_sinatra.gemfile.lock
+++ b/gemfiles/jruby_9.3.9.0_sinatra.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.14.0)
       datadog-ci (~> 0.1.0)
-      debase-ruby_core_source (= 3.2.1)
+      debase-ruby_core_source (= 3.2.2)
       libdatadog (~> 4.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
@@ -39,7 +39,7 @@ GEM
       rexml
     cri (2.15.11)
     datadog-ci (0.1.1)
-    debase-ruby_core_source (3.2.1)
+    debase-ruby_core_source (3.2.2)
     diff-lcs (1.5.0)
     docile (1.4.0)
     dogstatsd-ruby (5.6.1)

--- a/gemfiles/jruby_9.4.0.0_activesupport.gemfile.lock
+++ b/gemfiles/jruby_9.4.0.0_activesupport.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.14.0)
       datadog-ci (~> 0.1.0)
-      debase-ruby_core_source (= 3.2.1)
+      debase-ruby_core_source (= 3.2.2)
       libdatadog (~> 4.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
@@ -67,7 +67,7 @@ GEM
     crass (1.0.6)
     cri (2.15.11)
     datadog-ci (0.1.1)
-    debase-ruby_core_source (3.2.1)
+    debase-ruby_core_source (3.2.2)
     diff-lcs (1.5.0)
     digest-crc (0.6.5)
       rake (>= 12.0.0, < 14.0.0)

--- a/gemfiles/jruby_9.4.0.0_aws.gemfile.lock
+++ b/gemfiles/jruby_9.4.0.0_aws.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.14.0)
       datadog-ci (~> 0.1.0)
-      debase-ruby_core_source (= 3.2.1)
+      debase-ruby_core_source (= 3.2.2)
       libdatadog (~> 4.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
@@ -1460,7 +1460,7 @@ GEM
       rexml
     cri (2.15.11)
     datadog-ci (0.1.1)
-    debase-ruby_core_source (3.2.1)
+    debase-ruby_core_source (3.2.2)
     diff-lcs (1.5.0)
     docile (1.4.0)
     dogstatsd-ruby (5.6.0)

--- a/gemfiles/jruby_9.4.0.0_contrib.gemfile.lock
+++ b/gemfiles/jruby_9.4.0.0_contrib.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.14.0)
       datadog-ci (~> 0.1.0)
-      debase-ruby_core_source (= 3.2.1)
+      debase-ruby_core_source (= 3.2.2)
       libdatadog (~> 4.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
@@ -46,7 +46,7 @@ GEM
     cri (2.15.11)
     dalli (3.2.3)
     datadog-ci (0.1.1)
-    debase-ruby_core_source (3.2.1)
+    debase-ruby_core_source (3.2.2)
     diff-lcs (1.5.0)
     docile (1.4.0)
     dogstatsd-ruby (5.5.0)

--- a/gemfiles/jruby_9.4.0.0_contrib_old.gemfile.lock
+++ b/gemfiles/jruby_9.4.0.0_contrib_old.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.14.0)
       datadog-ci (~> 0.1.0)
-      debase-ruby_core_source (= 3.2.1)
+      debase-ruby_core_source (= 3.2.2)
       libdatadog (~> 4.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
@@ -40,7 +40,7 @@ GEM
     cri (2.15.11)
     dalli (2.7.11)
     datadog-ci (0.1.1)
-    debase-ruby_core_source (3.2.1)
+    debase-ruby_core_source (3.2.2)
     diff-lcs (1.5.0)
     docile (1.4.0)
     dogstatsd-ruby (5.5.0)

--- a/gemfiles/jruby_9.4.0.0_core_old.gemfile.lock
+++ b/gemfiles/jruby_9.4.0.0_core_old.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.14.0)
       datadog-ci (~> 0.1.0)
-      debase-ruby_core_source (= 3.2.1)
+      debase-ruby_core_source (= 3.2.2)
       libdatadog (~> 4.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
@@ -39,7 +39,7 @@ GEM
       rexml
     cri (2.15.11)
     datadog-ci (0.1.1)
-    debase-ruby_core_source (3.2.1)
+    debase-ruby_core_source (3.2.2)
     diff-lcs (1.5.0)
     docile (1.4.0)
     dogstatsd-ruby (4.8.3)

--- a/gemfiles/jruby_9.4.0.0_http.gemfile.lock
+++ b/gemfiles/jruby_9.4.0.0_http.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.14.0)
       datadog-ci (~> 0.1.0)
-      debase-ruby_core_source (= 3.2.1)
+      debase-ruby_core_source (= 3.2.2)
       libdatadog (~> 4.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
@@ -39,7 +39,7 @@ GEM
       rexml
     cri (2.15.11)
     datadog-ci (0.1.1)
-    debase-ruby_core_source (3.2.1)
+    debase-ruby_core_source (3.2.2)
     diff-lcs (1.5.0)
     docile (1.4.0)
     dogstatsd-ruby (5.6.1)

--- a/gemfiles/jruby_9.4.0.0_opentracing.gemfile.lock
+++ b/gemfiles/jruby_9.4.0.0_opentracing.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.14.0)
       datadog-ci (~> 0.1.0)
-      debase-ruby_core_source (= 3.2.1)
+      debase-ruby_core_source (= 3.2.2)
       libdatadog (~> 4.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
@@ -40,7 +40,7 @@ GEM
       rexml
     cri (2.15.11)
     datadog-ci (0.1.1)
-    debase-ruby_core_source (3.2.1)
+    debase-ruby_core_source (3.2.2)
     diff-lcs (1.5.0)
     docile (1.4.0)
     dogstatsd-ruby (5.6.1)

--- a/gemfiles/jruby_9.4.0.0_rack_1.gemfile.lock
+++ b/gemfiles/jruby_9.4.0.0_rack_1.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.14.0)
       datadog-ci (~> 0.1.0)
-      debase-ruby_core_source (= 3.2.1)
+      debase-ruby_core_source (= 3.2.2)
       libdatadog (~> 4.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
@@ -39,7 +39,7 @@ GEM
       rexml
     cri (2.15.11)
     datadog-ci (0.1.1)
-    debase-ruby_core_source (3.2.1)
+    debase-ruby_core_source (3.2.2)
     diff-lcs (1.5.0)
     docile (1.4.0)
     dogstatsd-ruby (5.6.1)

--- a/gemfiles/jruby_9.4.0.0_rack_2.gemfile.lock
+++ b/gemfiles/jruby_9.4.0.0_rack_2.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.14.0)
       datadog-ci (~> 0.1.0)
-      debase-ruby_core_source (= 3.2.1)
+      debase-ruby_core_source (= 3.2.2)
       libdatadog (~> 4.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
@@ -39,7 +39,7 @@ GEM
       rexml
     cri (2.15.11)
     datadog-ci (0.1.1)
-    debase-ruby_core_source (3.2.1)
+    debase-ruby_core_source (3.2.2)
     diff-lcs (1.5.0)
     docile (1.4.0)
     dogstatsd-ruby (5.6.1)

--- a/gemfiles/jruby_9.4.0.0_rack_3.gemfile.lock
+++ b/gemfiles/jruby_9.4.0.0_rack_3.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.14.0)
       datadog-ci (~> 0.1.0)
-      debase-ruby_core_source (= 3.2.1)
+      debase-ruby_core_source (= 3.2.2)
       libdatadog (~> 4.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
@@ -39,7 +39,7 @@ GEM
       rexml
     cri (2.15.11)
     datadog-ci (0.1.1)
-    debase-ruby_core_source (3.2.1)
+    debase-ruby_core_source (3.2.2)
     diff-lcs (1.5.0)
     docile (1.4.0)
     dogstatsd-ruby (5.6.1)

--- a/gemfiles/jruby_9.4.0.0_rails61_mysql2.gemfile.lock
+++ b/gemfiles/jruby_9.4.0.0_rails61_mysql2.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.14.0)
       datadog-ci (~> 0.1.0)
-      debase-ruby_core_source (= 3.2.1)
+      debase-ruby_core_source (= 3.2.2)
       libdatadog (~> 4.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
@@ -105,7 +105,7 @@ GEM
     cri (2.15.11)
     datadog-ci (0.1.1)
     date (3.3.3-java)
-    debase-ruby_core_source (3.2.1)
+    debase-ruby_core_source (3.2.2)
     diff-lcs (1.5.0)
     docile (1.4.0)
     dogstatsd-ruby (5.5.0)

--- a/gemfiles/jruby_9.4.0.0_rails61_postgres.gemfile.lock
+++ b/gemfiles/jruby_9.4.0.0_rails61_postgres.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.14.0)
       datadog-ci (~> 0.1.0)
-      debase-ruby_core_source (= 3.2.1)
+      debase-ruby_core_source (= 3.2.2)
       libdatadog (~> 4.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
@@ -105,7 +105,7 @@ GEM
     cri (2.15.11)
     datadog-ci (0.1.1)
     date (3.3.3-java)
-    debase-ruby_core_source (3.2.1)
+    debase-ruby_core_source (3.2.2)
     diff-lcs (1.5.0)
     docile (1.4.0)
     dogstatsd-ruby (5.5.0)

--- a/gemfiles/jruby_9.4.0.0_rails61_postgres_redis.gemfile.lock
+++ b/gemfiles/jruby_9.4.0.0_rails61_postgres_redis.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.14.0)
       datadog-ci (~> 0.1.0)
-      debase-ruby_core_source (= 3.2.1)
+      debase-ruby_core_source (= 3.2.2)
       libdatadog (~> 4.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
@@ -105,7 +105,7 @@ GEM
     cri (2.15.11)
     datadog-ci (0.1.1)
     date (3.3.3-java)
-    debase-ruby_core_source (3.2.1)
+    debase-ruby_core_source (3.2.2)
     diff-lcs (1.5.0)
     docile (1.4.0)
     dogstatsd-ruby (5.5.0)

--- a/gemfiles/jruby_9.4.0.0_rails61_postgres_sidekiq.gemfile.lock
+++ b/gemfiles/jruby_9.4.0.0_rails61_postgres_sidekiq.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.14.0)
       datadog-ci (~> 0.1.0)
-      debase-ruby_core_source (= 3.2.1)
+      debase-ruby_core_source (= 3.2.2)
       libdatadog (~> 4.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
@@ -106,7 +106,7 @@ GEM
     cri (2.15.11)
     datadog-ci (0.1.1)
     date (3.3.3-java)
-    debase-ruby_core_source (3.2.1)
+    debase-ruby_core_source (3.2.2)
     diff-lcs (1.5.0)
     docile (1.4.0)
     dogstatsd-ruby (5.5.0)

--- a/gemfiles/jruby_9.4.0.0_rails61_semantic_logger.gemfile.lock
+++ b/gemfiles/jruby_9.4.0.0_rails61_semantic_logger.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.14.0)
       datadog-ci (~> 0.1.0)
-      debase-ruby_core_source (= 3.2.1)
+      debase-ruby_core_source (= 3.2.2)
       libdatadog (~> 4.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
@@ -105,7 +105,7 @@ GEM
     cri (2.15.11)
     datadog-ci (0.1.1)
     date (3.3.3-java)
-    debase-ruby_core_source (3.2.1)
+    debase-ruby_core_source (3.2.2)
     diff-lcs (1.5.0)
     docile (1.4.0)
     dogstatsd-ruby (5.5.0)

--- a/gemfiles/jruby_9.4.0.0_redis_3.gemfile.lock
+++ b/gemfiles/jruby_9.4.0.0_redis_3.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.14.0)
       datadog-ci (~> 0.1.0)
-      debase-ruby_core_source (= 3.2.1)
+      debase-ruby_core_source (= 3.2.2)
       libdatadog (~> 4.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
@@ -39,7 +39,7 @@ GEM
       rexml
     cri (2.15.11)
     datadog-ci (0.1.1)
-    debase-ruby_core_source (3.2.1)
+    debase-ruby_core_source (3.2.2)
     diff-lcs (1.5.0)
     docile (1.4.0)
     dogstatsd-ruby (5.5.0)

--- a/gemfiles/jruby_9.4.0.0_redis_4.gemfile.lock
+++ b/gemfiles/jruby_9.4.0.0_redis_4.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.14.0)
       datadog-ci (~> 0.1.0)
-      debase-ruby_core_source (= 3.2.1)
+      debase-ruby_core_source (= 3.2.2)
       libdatadog (~> 4.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
@@ -39,7 +39,7 @@ GEM
       rexml
     cri (2.15.11)
     datadog-ci (0.1.1)
-    debase-ruby_core_source (3.2.1)
+    debase-ruby_core_source (3.2.2)
     diff-lcs (1.5.0)
     docile (1.4.0)
     dogstatsd-ruby (5.5.0)

--- a/gemfiles/jruby_9.4.0.0_redis_5.gemfile.lock
+++ b/gemfiles/jruby_9.4.0.0_redis_5.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.14.0)
       datadog-ci (~> 0.1.0)
-      debase-ruby_core_source (= 3.2.1)
+      debase-ruby_core_source (= 3.2.2)
       libdatadog (~> 4.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
@@ -40,7 +40,7 @@ GEM
       rexml
     cri (2.15.11)
     datadog-ci (0.1.1)
-    debase-ruby_core_source (3.2.1)
+    debase-ruby_core_source (3.2.2)
     diff-lcs (1.5.0)
     docile (1.4.0)
     dogstatsd-ruby (5.5.0)

--- a/gemfiles/jruby_9.4.0.0_relational_db.gemfile.lock
+++ b/gemfiles/jruby_9.4.0.0_relational_db.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.14.0)
       datadog-ci (~> 0.1.0)
-      debase-ruby_core_source (= 3.2.1)
+      debase-ruby_core_source (= 3.2.2)
       libdatadog (~> 4.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
@@ -57,7 +57,7 @@ GEM
       rexml
     cri (2.15.11)
     datadog-ci (0.1.1)
-    debase-ruby_core_source (3.2.1)
+    debase-ruby_core_source (3.2.2)
     delayed_job (4.1.11)
       activesupport (>= 3.0, < 8.0)
     delayed_job_active_record (4.1.7)

--- a/gemfiles/jruby_9.4.0.0_resque2_redis3.gemfile.lock
+++ b/gemfiles/jruby_9.4.0.0_resque2_redis3.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.14.0)
       datadog-ci (~> 0.1.0)
-      debase-ruby_core_source (= 3.2.1)
+      debase-ruby_core_source (= 3.2.2)
       libdatadog (~> 4.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
@@ -39,7 +39,7 @@ GEM
       rexml
     cri (2.15.11)
     datadog-ci (0.1.1)
-    debase-ruby_core_source (3.2.1)
+    debase-ruby_core_source (3.2.2)
     diff-lcs (1.5.0)
     docile (1.4.0)
     dogstatsd-ruby (5.5.0)

--- a/gemfiles/jruby_9.4.0.0_resque2_redis4.gemfile.lock
+++ b/gemfiles/jruby_9.4.0.0_resque2_redis4.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.14.0)
       datadog-ci (~> 0.1.0)
-      debase-ruby_core_source (= 3.2.1)
+      debase-ruby_core_source (= 3.2.2)
       libdatadog (~> 4.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
@@ -40,7 +40,7 @@ GEM
       rexml
     cri (2.15.11)
     datadog-ci (0.1.1)
-    debase-ruby_core_source (3.2.1)
+    debase-ruby_core_source (3.2.2)
     diff-lcs (1.5.0)
     docile (1.4.0)
     dogstatsd-ruby (5.5.0)

--- a/gemfiles/jruby_9.4.0.0_sinatra.gemfile.lock
+++ b/gemfiles/jruby_9.4.0.0_sinatra.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.14.0)
       datadog-ci (~> 0.1.0)
-      debase-ruby_core_source (= 3.2.1)
+      debase-ruby_core_source (= 3.2.2)
       libdatadog (~> 4.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
@@ -39,7 +39,7 @@ GEM
       rexml
     cri (2.15.11)
     datadog-ci (0.1.1)
-    debase-ruby_core_source (3.2.1)
+    debase-ruby_core_source (3.2.2)
     diff-lcs (1.5.0)
     docile (1.4.0)
     dogstatsd-ruby (5.5.0)

--- a/gemfiles/ruby_2.1.10_activesupport.gemfile.lock
+++ b/gemfiles/ruby_2.1.10_activesupport.gemfile.lock
@@ -3,7 +3,7 @@ PATH
   specs:
     ddtrace (1.14.0)
       datadog-ci (~> 0.1.0)
-      debase-ruby_core_source (= 3.2.1)
+      debase-ruby_core_source (= 3.2.2)
       libdatadog (~> 4.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
@@ -37,7 +37,7 @@ GEM
     crack (0.4.5)
       rexml
     datadog-ci (0.1.1)
-    debase-ruby_core_source (3.2.1)
+    debase-ruby_core_source (3.2.2)
     diff-lcs (1.5.0)
     digest-crc (0.6.5)
       rake (>= 12.0.0, < 14.0.0)

--- a/gemfiles/ruby_2.1.10_aws.gemfile.lock
+++ b/gemfiles/ruby_2.1.10_aws.gemfile.lock
@@ -3,7 +3,7 @@ PATH
   specs:
     ddtrace (1.14.0)
       datadog-ci (~> 0.1.0)
-      debase-ruby_core_source (= 3.2.1)
+      debase-ruby_core_source (= 3.2.2)
       libdatadog (~> 4.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
@@ -36,7 +36,7 @@ GEM
     crack (0.4.5)
       rexml
     datadog-ci (0.1.1)
-    debase-ruby_core_source (3.2.1)
+    debase-ruby_core_source (3.2.2)
     diff-lcs (1.5.0)
     docile (1.3.5)
     dogstatsd-ruby (5.6.0)

--- a/gemfiles/ruby_2.1.10_contrib.gemfile.lock
+++ b/gemfiles/ruby_2.1.10_contrib.gemfile.lock
@@ -3,7 +3,7 @@ PATH
   specs:
     ddtrace (1.14.0)
       datadog-ci (~> 0.1.0)
-      debase-ruby_core_source (= 3.2.1)
+      debase-ruby_core_source (= 3.2.2)
       libdatadog (~> 4.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
@@ -46,7 +46,7 @@ GEM
       rexml
     dalli (2.7.11)
     datadog-ci (0.1.1)
-    debase-ruby_core_source (3.2.1)
+    debase-ruby_core_source (3.2.2)
     diff-lcs (1.5.0)
     docile (1.3.5)
     dogstatsd-ruby (5.5.0)

--- a/gemfiles/ruby_2.1.10_core_old.gemfile.lock
+++ b/gemfiles/ruby_2.1.10_core_old.gemfile.lock
@@ -3,7 +3,7 @@ PATH
   specs:
     ddtrace (1.14.0)
       datadog-ci (~> 0.1.0)
-      debase-ruby_core_source (= 3.2.1)
+      debase-ruby_core_source (= 3.2.2)
       libdatadog (~> 4.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
@@ -26,7 +26,7 @@ GEM
     crack (0.4.5)
       rexml
     datadog-ci (0.1.1)
-    debase-ruby_core_source (3.2.1)
+    debase-ruby_core_source (3.2.2)
     diff-lcs (1.5.0)
     docile (1.3.5)
     dogstatsd-ruby (4.8.3)

--- a/gemfiles/ruby_2.1.10_http.gemfile.lock
+++ b/gemfiles/ruby_2.1.10_http.gemfile.lock
@@ -3,7 +3,7 @@ PATH
   specs:
     ddtrace (1.14.0)
       datadog-ci (~> 0.1.0)
-      debase-ruby_core_source (= 3.2.1)
+      debase-ruby_core_source (= 3.2.2)
       libdatadog (~> 4.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
@@ -26,7 +26,7 @@ GEM
     crack (0.4.5)
       rexml
     datadog-ci (0.1.1)
-    debase-ruby_core_source (3.2.1)
+    debase-ruby_core_source (3.2.2)
     diff-lcs (1.5.0)
     docile (1.3.5)
     dogstatsd-ruby (5.6.1)

--- a/gemfiles/ruby_2.1.10_opentracing.gemfile.lock
+++ b/gemfiles/ruby_2.1.10_opentracing.gemfile.lock
@@ -3,7 +3,7 @@ PATH
   specs:
     ddtrace (1.14.0)
       datadog-ci (~> 0.1.0)
-      debase-ruby_core_source (= 3.2.1)
+      debase-ruby_core_source (= 3.2.2)
       libdatadog (~> 4.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
@@ -27,7 +27,7 @@ GEM
     crack (0.4.5)
       rexml
     datadog-ci (0.1.1)
-    debase-ruby_core_source (3.2.1)
+    debase-ruby_core_source (3.2.2)
     diff-lcs (1.5.0)
     docile (1.3.5)
     dogstatsd-ruby (5.6.1)

--- a/gemfiles/ruby_2.1.10_rack_1.gemfile.lock
+++ b/gemfiles/ruby_2.1.10_rack_1.gemfile.lock
@@ -3,7 +3,7 @@ PATH
   specs:
     ddtrace (1.14.0)
       datadog-ci (~> 0.1.0)
-      debase-ruby_core_source (= 3.2.1)
+      debase-ruby_core_source (= 3.2.2)
       libdatadog (~> 4.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
@@ -26,7 +26,7 @@ GEM
     crack (0.4.5)
       rexml
     datadog-ci (0.1.1)
-    debase-ruby_core_source (3.2.1)
+    debase-ruby_core_source (3.2.2)
     diff-lcs (1.5.0)
     docile (1.3.5)
     dogstatsd-ruby (5.6.1)

--- a/gemfiles/ruby_2.1.10_rails32_mysql2.gemfile.lock
+++ b/gemfiles/ruby_2.1.10_rails32_mysql2.gemfile.lock
@@ -3,7 +3,7 @@ PATH
   specs:
     ddtrace (1.14.0)
       datadog-ci (~> 0.1.0)
-      debase-ruby_core_source (= 3.2.1)
+      debase-ruby_core_source (= 3.2.2)
       libdatadog (~> 4.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
@@ -58,7 +58,7 @@ GEM
     crack (0.4.5)
       rexml
     datadog-ci (0.1.1)
-    debase-ruby_core_source (3.2.1)
+    debase-ruby_core_source (3.2.2)
     diff-lcs (1.5.0)
     docile (1.3.5)
     dogstatsd-ruby (5.5.0)

--- a/gemfiles/ruby_2.1.10_rails32_postgres.gemfile.lock
+++ b/gemfiles/ruby_2.1.10_rails32_postgres.gemfile.lock
@@ -3,7 +3,7 @@ PATH
   specs:
     ddtrace (1.14.0)
       datadog-ci (~> 0.1.0)
-      debase-ruby_core_source (= 3.2.1)
+      debase-ruby_core_source (= 3.2.2)
       libdatadog (~> 4.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
@@ -54,7 +54,7 @@ GEM
     crack (0.4.5)
       rexml
     datadog-ci (0.1.1)
-    debase-ruby_core_source (3.2.1)
+    debase-ruby_core_source (3.2.2)
     diff-lcs (1.5.0)
     docile (1.3.5)
     dogstatsd-ruby (5.5.0)

--- a/gemfiles/ruby_2.1.10_rails32_postgres_redis.gemfile.lock
+++ b/gemfiles/ruby_2.1.10_rails32_postgres_redis.gemfile.lock
@@ -3,7 +3,7 @@ PATH
   specs:
     ddtrace (1.14.0)
       datadog-ci (~> 0.1.0)
-      debase-ruby_core_source (= 3.2.1)
+      debase-ruby_core_source (= 3.2.2)
       libdatadog (~> 4.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
@@ -54,7 +54,7 @@ GEM
     crack (0.4.5)
       rexml
     datadog-ci (0.1.1)
-    debase-ruby_core_source (3.2.1)
+    debase-ruby_core_source (3.2.2)
     diff-lcs (1.5.0)
     docile (1.3.5)
     dogstatsd-ruby (5.5.0)

--- a/gemfiles/ruby_2.1.10_rails32_postgres_sidekiq.gemfile.lock
+++ b/gemfiles/ruby_2.1.10_rails32_postgres_sidekiq.gemfile.lock
@@ -3,7 +3,7 @@ PATH
   specs:
     ddtrace (1.14.0)
       datadog-ci (~> 0.1.0)
-      debase-ruby_core_source (= 3.2.1)
+      debase-ruby_core_source (= 3.2.2)
       libdatadog (~> 4.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
@@ -55,7 +55,7 @@ GEM
     crack (0.4.5)
       rexml
     datadog-ci (0.1.1)
-    debase-ruby_core_source (3.2.1)
+    debase-ruby_core_source (3.2.2)
     diff-lcs (1.5.0)
     docile (1.3.5)
     dogstatsd-ruby (5.5.0)

--- a/gemfiles/ruby_2.1.10_rails4_mysql2.gemfile.lock
+++ b/gemfiles/ruby_2.1.10_rails4_mysql2.gemfile.lock
@@ -3,7 +3,7 @@ PATH
   specs:
     ddtrace (1.14.0)
       datadog-ci (~> 0.1.0)
-      debase-ruby_core_source (= 3.2.1)
+      debase-ruby_core_source (= 3.2.2)
       libdatadog (~> 4.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
@@ -62,7 +62,7 @@ GEM
       rexml
     crass (1.0.6)
     datadog-ci (0.1.1)
-    debase-ruby_core_source (3.2.1)
+    debase-ruby_core_source (3.2.2)
     diff-lcs (1.5.0)
     docile (1.3.5)
     dogstatsd-ruby (5.5.0)

--- a/gemfiles/ruby_2.1.10_rails4_postgres.gemfile.lock
+++ b/gemfiles/ruby_2.1.10_rails4_postgres.gemfile.lock
@@ -3,7 +3,7 @@ PATH
   specs:
     ddtrace (1.14.0)
       datadog-ci (~> 0.1.0)
-      debase-ruby_core_source (= 3.2.1)
+      debase-ruby_core_source (= 3.2.2)
       libdatadog (~> 4.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
@@ -62,7 +62,7 @@ GEM
       rexml
     crass (1.0.6)
     datadog-ci (0.1.1)
-    debase-ruby_core_source (3.2.1)
+    debase-ruby_core_source (3.2.2)
     diff-lcs (1.5.0)
     docile (1.3.5)
     dogstatsd-ruby (5.5.0)

--- a/gemfiles/ruby_2.1.10_rails4_postgres_redis.gemfile.lock
+++ b/gemfiles/ruby_2.1.10_rails4_postgres_redis.gemfile.lock
@@ -3,7 +3,7 @@ PATH
   specs:
     ddtrace (1.14.0)
       datadog-ci (~> 0.1.0)
-      debase-ruby_core_source (= 3.2.1)
+      debase-ruby_core_source (= 3.2.2)
       libdatadog (~> 4.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
@@ -62,7 +62,7 @@ GEM
       rexml
     crass (1.0.6)
     datadog-ci (0.1.1)
-    debase-ruby_core_source (3.2.1)
+    debase-ruby_core_source (3.2.2)
     diff-lcs (1.5.0)
     docile (1.3.5)
     dogstatsd-ruby (5.5.0)

--- a/gemfiles/ruby_2.1.10_rails4_semantic_logger.gemfile.lock
+++ b/gemfiles/ruby_2.1.10_rails4_semantic_logger.gemfile.lock
@@ -3,7 +3,7 @@ PATH
   specs:
     ddtrace (1.14.0)
       datadog-ci (~> 0.1.0)
-      debase-ruby_core_source (= 3.2.1)
+      debase-ruby_core_source (= 3.2.2)
       libdatadog (~> 4.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
@@ -62,7 +62,7 @@ GEM
       rexml
     crass (1.0.6)
     datadog-ci (0.1.1)
-    debase-ruby_core_source (3.2.1)
+    debase-ruby_core_source (3.2.2)
     diff-lcs (1.5.0)
     docile (1.3.5)
     dogstatsd-ruby (5.5.0)

--- a/gemfiles/ruby_2.1.10_redis_3.gemfile.lock
+++ b/gemfiles/ruby_2.1.10_redis_3.gemfile.lock
@@ -3,7 +3,7 @@ PATH
   specs:
     ddtrace (1.14.0)
       datadog-ci (~> 0.1.0)
-      debase-ruby_core_source (= 3.2.1)
+      debase-ruby_core_source (= 3.2.2)
       libdatadog (~> 4.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
@@ -26,7 +26,7 @@ GEM
     crack (0.4.5)
       rexml
     datadog-ci (0.1.1)
-    debase-ruby_core_source (3.2.1)
+    debase-ruby_core_source (3.2.2)
     diff-lcs (1.5.0)
     docile (1.3.5)
     dogstatsd-ruby (5.5.0)

--- a/gemfiles/ruby_2.1.10_relational_db.gemfile.lock
+++ b/gemfiles/ruby_2.1.10_relational_db.gemfile.lock
@@ -3,7 +3,7 @@ PATH
   specs:
     ddtrace (1.14.0)
       datadog-ci (~> 0.1.0)
-      debase-ruby_core_source (= 3.2.1)
+      debase-ruby_core_source (= 3.2.2)
       libdatadog (~> 4.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
@@ -42,7 +42,7 @@ GEM
     crack (0.4.5)
       rexml
     datadog-ci (0.1.1)
-    debase-ruby_core_source (3.2.1)
+    debase-ruby_core_source (3.2.2)
     delayed_job (4.1.11)
       activesupport (>= 3.0, < 8.0)
     delayed_job_active_record (4.1.7)

--- a/gemfiles/ruby_2.1.10_sinatra.gemfile.lock
+++ b/gemfiles/ruby_2.1.10_sinatra.gemfile.lock
@@ -3,7 +3,7 @@ PATH
   specs:
     ddtrace (1.14.0)
       datadog-ci (~> 0.1.0)
-      debase-ruby_core_source (= 3.2.1)
+      debase-ruby_core_source (= 3.2.2)
       libdatadog (~> 4.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
@@ -26,7 +26,7 @@ GEM
     crack (0.4.5)
       rexml
     datadog-ci (0.1.1)
-    debase-ruby_core_source (3.2.1)
+    debase-ruby_core_source (3.2.2)
     diff-lcs (1.5.0)
     docile (1.3.5)
     dogstatsd-ruby (5.5.0)

--- a/gemfiles/ruby_2.2.10_activesupport.gemfile.lock
+++ b/gemfiles/ruby_2.2.10_activesupport.gemfile.lock
@@ -3,7 +3,7 @@ PATH
   specs:
     ddtrace (1.14.0)
       datadog-ci (~> 0.1.0)
-      debase-ruby_core_source (= 3.2.1)
+      debase-ruby_core_source (= 3.2.2)
       libdatadog (~> 4.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
@@ -61,7 +61,7 @@ GEM
       rexml
     crass (1.0.6)
     datadog-ci (0.1.1)
-    debase-ruby_core_source (3.2.1)
+    debase-ruby_core_source (3.2.2)
     descendants_tracker (0.0.4)
       thread_safe (~> 0.3, >= 0.3.1)
     diff-lcs (1.5.0)

--- a/gemfiles/ruby_2.2.10_aws.gemfile.lock
+++ b/gemfiles/ruby_2.2.10_aws.gemfile.lock
@@ -3,7 +3,7 @@ PATH
   specs:
     ddtrace (1.14.0)
       datadog-ci (~> 0.1.0)
-      debase-ruby_core_source (= 3.2.1)
+      debase-ruby_core_source (= 3.2.2)
       libdatadog (~> 4.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
@@ -1148,7 +1148,7 @@ GEM
     crack (0.4.5)
       rexml
     datadog-ci (0.1.1)
-    debase-ruby_core_source (3.2.1)
+    debase-ruby_core_source (3.2.2)
     diff-lcs (1.5.0)
     docile (1.3.5)
     dogstatsd-ruby (5.6.0)

--- a/gemfiles/ruby_2.2.10_contrib.gemfile.lock
+++ b/gemfiles/ruby_2.2.10_contrib.gemfile.lock
@@ -3,7 +3,7 @@ PATH
   specs:
     ddtrace (1.14.0)
       datadog-ci (~> 0.1.0)
-      debase-ruby_core_source (= 3.2.1)
+      debase-ruby_core_source (= 3.2.2)
       libdatadog (~> 4.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
@@ -32,7 +32,7 @@ GEM
       rexml
     dalli (2.7.11)
     datadog-ci (0.1.1)
-    debase-ruby_core_source (3.2.1)
+    debase-ruby_core_source (3.2.2)
     diff-lcs (1.5.0)
     docile (1.3.5)
     dogstatsd-ruby (5.5.0)

--- a/gemfiles/ruby_2.2.10_core_old.gemfile.lock
+++ b/gemfiles/ruby_2.2.10_core_old.gemfile.lock
@@ -3,7 +3,7 @@ PATH
   specs:
     ddtrace (1.14.0)
       datadog-ci (~> 0.1.0)
-      debase-ruby_core_source (= 3.2.1)
+      debase-ruby_core_source (= 3.2.2)
       libdatadog (~> 4.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
@@ -26,7 +26,7 @@ GEM
     crack (0.4.5)
       rexml
     datadog-ci (0.1.1)
-    debase-ruby_core_source (3.2.1)
+    debase-ruby_core_source (3.2.2)
     diff-lcs (1.5.0)
     docile (1.3.5)
     dogstatsd-ruby (4.8.3)

--- a/gemfiles/ruby_2.2.10_http.gemfile.lock
+++ b/gemfiles/ruby_2.2.10_http.gemfile.lock
@@ -3,7 +3,7 @@ PATH
   specs:
     ddtrace (1.14.0)
       datadog-ci (~> 0.1.0)
-      debase-ruby_core_source (= 3.2.1)
+      debase-ruby_core_source (= 3.2.2)
       libdatadog (~> 4.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
@@ -26,7 +26,7 @@ GEM
     crack (0.4.5)
       rexml
     datadog-ci (0.1.1)
-    debase-ruby_core_source (3.2.1)
+    debase-ruby_core_source (3.2.2)
     diff-lcs (1.5.0)
     docile (1.3.5)
     dogstatsd-ruby (5.6.1)

--- a/gemfiles/ruby_2.2.10_opentracing.gemfile.lock
+++ b/gemfiles/ruby_2.2.10_opentracing.gemfile.lock
@@ -3,7 +3,7 @@ PATH
   specs:
     ddtrace (1.14.0)
       datadog-ci (~> 0.1.0)
-      debase-ruby_core_source (= 3.2.1)
+      debase-ruby_core_source (= 3.2.2)
       libdatadog (~> 4.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
@@ -27,7 +27,7 @@ GEM
     crack (0.4.5)
       rexml
     datadog-ci (0.1.1)
-    debase-ruby_core_source (3.2.1)
+    debase-ruby_core_source (3.2.2)
     diff-lcs (1.5.0)
     docile (1.3.5)
     dogstatsd-ruby (5.6.1)

--- a/gemfiles/ruby_2.2.10_rack_1.gemfile.lock
+++ b/gemfiles/ruby_2.2.10_rack_1.gemfile.lock
@@ -3,7 +3,7 @@ PATH
   specs:
     ddtrace (1.14.0)
       datadog-ci (~> 0.1.0)
-      debase-ruby_core_source (= 3.2.1)
+      debase-ruby_core_source (= 3.2.2)
       libdatadog (~> 4.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
@@ -26,7 +26,7 @@ GEM
     crack (0.4.5)
       rexml
     datadog-ci (0.1.1)
-    debase-ruby_core_source (3.2.1)
+    debase-ruby_core_source (3.2.2)
     diff-lcs (1.5.0)
     docile (1.3.5)
     dogstatsd-ruby (5.6.1)

--- a/gemfiles/ruby_2.2.10_rails32_mysql2.gemfile.lock
+++ b/gemfiles/ruby_2.2.10_rails32_mysql2.gemfile.lock
@@ -3,7 +3,7 @@ PATH
   specs:
     ddtrace (1.14.0)
       datadog-ci (~> 0.1.0)
-      debase-ruby_core_source (= 3.2.1)
+      debase-ruby_core_source (= 3.2.2)
       libdatadog (~> 4.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
@@ -58,7 +58,7 @@ GEM
     crack (0.4.5)
       rexml
     datadog-ci (0.1.1)
-    debase-ruby_core_source (3.2.1)
+    debase-ruby_core_source (3.2.2)
     diff-lcs (1.5.0)
     docile (1.3.5)
     dogstatsd-ruby (5.5.0)

--- a/gemfiles/ruby_2.2.10_rails32_postgres.gemfile.lock
+++ b/gemfiles/ruby_2.2.10_rails32_postgres.gemfile.lock
@@ -3,7 +3,7 @@ PATH
   specs:
     ddtrace (1.14.0)
       datadog-ci (~> 0.1.0)
-      debase-ruby_core_source (= 3.2.1)
+      debase-ruby_core_source (= 3.2.2)
       libdatadog (~> 4.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
@@ -54,7 +54,7 @@ GEM
     crack (0.4.5)
       rexml
     datadog-ci (0.1.1)
-    debase-ruby_core_source (3.2.1)
+    debase-ruby_core_source (3.2.2)
     diff-lcs (1.5.0)
     docile (1.3.5)
     dogstatsd-ruby (5.5.0)

--- a/gemfiles/ruby_2.2.10_rails32_postgres_redis.gemfile.lock
+++ b/gemfiles/ruby_2.2.10_rails32_postgres_redis.gemfile.lock
@@ -3,7 +3,7 @@ PATH
   specs:
     ddtrace (1.14.0)
       datadog-ci (~> 0.1.0)
-      debase-ruby_core_source (= 3.2.1)
+      debase-ruby_core_source (= 3.2.2)
       libdatadog (~> 4.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
@@ -54,7 +54,7 @@ GEM
     crack (0.4.5)
       rexml
     datadog-ci (0.1.1)
-    debase-ruby_core_source (3.2.1)
+    debase-ruby_core_source (3.2.2)
     diff-lcs (1.5.0)
     docile (1.3.5)
     dogstatsd-ruby (5.5.0)

--- a/gemfiles/ruby_2.2.10_rails32_postgres_sidekiq.gemfile.lock
+++ b/gemfiles/ruby_2.2.10_rails32_postgres_sidekiq.gemfile.lock
@@ -3,7 +3,7 @@ PATH
   specs:
     ddtrace (1.14.0)
       datadog-ci (~> 0.1.0)
-      debase-ruby_core_source (= 3.2.1)
+      debase-ruby_core_source (= 3.2.2)
       libdatadog (~> 4.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
@@ -55,7 +55,7 @@ GEM
     crack (0.4.5)
       rexml
     datadog-ci (0.1.1)
-    debase-ruby_core_source (3.2.1)
+    debase-ruby_core_source (3.2.2)
     diff-lcs (1.5.0)
     docile (1.3.5)
     dogstatsd-ruby (5.5.0)

--- a/gemfiles/ruby_2.2.10_rails4_mysql2.gemfile.lock
+++ b/gemfiles/ruby_2.2.10_rails4_mysql2.gemfile.lock
@@ -3,7 +3,7 @@ PATH
   specs:
     ddtrace (1.14.0)
       datadog-ci (~> 0.1.0)
-      debase-ruby_core_source (= 3.2.1)
+      debase-ruby_core_source (= 3.2.2)
       libdatadog (~> 4.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
@@ -62,7 +62,7 @@ GEM
       rexml
     crass (1.0.6)
     datadog-ci (0.1.1)
-    debase-ruby_core_source (3.2.1)
+    debase-ruby_core_source (3.2.2)
     diff-lcs (1.5.0)
     docile (1.3.5)
     dogstatsd-ruby (5.5.0)

--- a/gemfiles/ruby_2.2.10_rails4_postgres.gemfile.lock
+++ b/gemfiles/ruby_2.2.10_rails4_postgres.gemfile.lock
@@ -3,7 +3,7 @@ PATH
   specs:
     ddtrace (1.14.0)
       datadog-ci (~> 0.1.0)
-      debase-ruby_core_source (= 3.2.1)
+      debase-ruby_core_source (= 3.2.2)
       libdatadog (~> 4.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
@@ -62,7 +62,7 @@ GEM
       rexml
     crass (1.0.6)
     datadog-ci (0.1.1)
-    debase-ruby_core_source (3.2.1)
+    debase-ruby_core_source (3.2.2)
     diff-lcs (1.5.0)
     docile (1.3.5)
     dogstatsd-ruby (5.5.0)

--- a/gemfiles/ruby_2.2.10_rails4_postgres_redis.gemfile.lock
+++ b/gemfiles/ruby_2.2.10_rails4_postgres_redis.gemfile.lock
@@ -3,7 +3,7 @@ PATH
   specs:
     ddtrace (1.14.0)
       datadog-ci (~> 0.1.0)
-      debase-ruby_core_source (= 3.2.1)
+      debase-ruby_core_source (= 3.2.2)
       libdatadog (~> 4.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
@@ -62,7 +62,7 @@ GEM
       rexml
     crass (1.0.6)
     datadog-ci (0.1.1)
-    debase-ruby_core_source (3.2.1)
+    debase-ruby_core_source (3.2.2)
     diff-lcs (1.5.0)
     docile (1.3.5)
     dogstatsd-ruby (5.5.0)

--- a/gemfiles/ruby_2.2.10_rails4_postgres_sidekiq.gemfile.lock
+++ b/gemfiles/ruby_2.2.10_rails4_postgres_sidekiq.gemfile.lock
@@ -3,7 +3,7 @@ PATH
   specs:
     ddtrace (1.14.0)
       datadog-ci (~> 0.1.0)
-      debase-ruby_core_source (= 3.2.1)
+      debase-ruby_core_source (= 3.2.2)
       libdatadog (~> 4.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
@@ -63,7 +63,7 @@ GEM
       rexml
     crass (1.0.6)
     datadog-ci (0.1.1)
-    debase-ruby_core_source (3.2.1)
+    debase-ruby_core_source (3.2.2)
     diff-lcs (1.5.0)
     docile (1.3.5)
     dogstatsd-ruby (5.5.0)

--- a/gemfiles/ruby_2.2.10_rails4_semantic_logger.gemfile.lock
+++ b/gemfiles/ruby_2.2.10_rails4_semantic_logger.gemfile.lock
@@ -3,7 +3,7 @@ PATH
   specs:
     ddtrace (1.14.0)
       datadog-ci (~> 0.1.0)
-      debase-ruby_core_source (= 3.2.1)
+      debase-ruby_core_source (= 3.2.2)
       libdatadog (~> 4.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
@@ -62,7 +62,7 @@ GEM
       rexml
     crass (1.0.6)
     datadog-ci (0.1.1)
-    debase-ruby_core_source (3.2.1)
+    debase-ruby_core_source (3.2.2)
     diff-lcs (1.5.0)
     docile (1.3.5)
     dogstatsd-ruby (5.5.0)

--- a/gemfiles/ruby_2.2.10_rails5_mysql2.gemfile.lock
+++ b/gemfiles/ruby_2.2.10_rails5_mysql2.gemfile.lock
@@ -3,7 +3,7 @@ PATH
   specs:
     ddtrace (1.14.0)
       datadog-ci (~> 0.1.0)
-      debase-ruby_core_source (= 3.2.1)
+      debase-ruby_core_source (= 3.2.2)
       libdatadog (~> 4.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
@@ -69,7 +69,7 @@ GEM
       rexml
     crass (1.0.6)
     datadog-ci (0.1.1)
-    debase-ruby_core_source (3.2.1)
+    debase-ruby_core_source (3.2.2)
     diff-lcs (1.5.0)
     docile (1.3.5)
     dogstatsd-ruby (5.5.0)

--- a/gemfiles/ruby_2.2.10_rails5_postgres.gemfile.lock
+++ b/gemfiles/ruby_2.2.10_rails5_postgres.gemfile.lock
@@ -3,7 +3,7 @@ PATH
   specs:
     ddtrace (1.14.0)
       datadog-ci (~> 0.1.0)
-      debase-ruby_core_source (= 3.2.1)
+      debase-ruby_core_source (= 3.2.2)
       libdatadog (~> 4.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
@@ -69,7 +69,7 @@ GEM
       rexml
     crass (1.0.6)
     datadog-ci (0.1.1)
-    debase-ruby_core_source (3.2.1)
+    debase-ruby_core_source (3.2.2)
     diff-lcs (1.5.0)
     docile (1.3.5)
     dogstatsd-ruby (5.5.0)

--- a/gemfiles/ruby_2.2.10_rails5_postgres_redis.gemfile.lock
+++ b/gemfiles/ruby_2.2.10_rails5_postgres_redis.gemfile.lock
@@ -3,7 +3,7 @@ PATH
   specs:
     ddtrace (1.14.0)
       datadog-ci (~> 0.1.0)
-      debase-ruby_core_source (= 3.2.1)
+      debase-ruby_core_source (= 3.2.2)
       libdatadog (~> 4.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
@@ -69,7 +69,7 @@ GEM
       rexml
     crass (1.0.6)
     datadog-ci (0.1.1)
-    debase-ruby_core_source (3.2.1)
+    debase-ruby_core_source (3.2.2)
     diff-lcs (1.5.0)
     docile (1.3.5)
     dogstatsd-ruby (5.5.0)

--- a/gemfiles/ruby_2.2.10_rails5_postgres_redis_activesupport.gemfile.lock
+++ b/gemfiles/ruby_2.2.10_rails5_postgres_redis_activesupport.gemfile.lock
@@ -3,7 +3,7 @@ PATH
   specs:
     ddtrace (1.14.0)
       datadog-ci (~> 0.1.0)
-      debase-ruby_core_source (= 3.2.1)
+      debase-ruby_core_source (= 3.2.2)
       libdatadog (~> 4.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
@@ -69,7 +69,7 @@ GEM
       rexml
     crass (1.0.6)
     datadog-ci (0.1.1)
-    debase-ruby_core_source (3.2.1)
+    debase-ruby_core_source (3.2.2)
     diff-lcs (1.5.0)
     docile (1.3.5)
     dogstatsd-ruby (5.5.0)

--- a/gemfiles/ruby_2.2.10_rails5_postgres_sidekiq.gemfile.lock
+++ b/gemfiles/ruby_2.2.10_rails5_postgres_sidekiq.gemfile.lock
@@ -3,7 +3,7 @@ PATH
   specs:
     ddtrace (1.14.0)
       datadog-ci (~> 0.1.0)
-      debase-ruby_core_source (= 3.2.1)
+      debase-ruby_core_source (= 3.2.2)
       libdatadog (~> 4.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
@@ -70,7 +70,7 @@ GEM
       rexml
     crass (1.0.6)
     datadog-ci (0.1.1)
-    debase-ruby_core_source (3.2.1)
+    debase-ruby_core_source (3.2.2)
     diff-lcs (1.5.0)
     docile (1.3.5)
     dogstatsd-ruby (5.5.0)

--- a/gemfiles/ruby_2.2.10_rails5_semantic_logger.gemfile.lock
+++ b/gemfiles/ruby_2.2.10_rails5_semantic_logger.gemfile.lock
@@ -3,7 +3,7 @@ PATH
   specs:
     ddtrace (1.14.0)
       datadog-ci (~> 0.1.0)
-      debase-ruby_core_source (= 3.2.1)
+      debase-ruby_core_source (= 3.2.2)
       libdatadog (~> 4.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
@@ -69,7 +69,7 @@ GEM
       rexml
     crass (1.0.6)
     datadog-ci (0.1.1)
-    debase-ruby_core_source (3.2.1)
+    debase-ruby_core_source (3.2.2)
     diff-lcs (1.5.0)
     docile (1.3.5)
     dogstatsd-ruby (5.5.0)

--- a/gemfiles/ruby_2.2.10_redis_3.gemfile.lock
+++ b/gemfiles/ruby_2.2.10_redis_3.gemfile.lock
@@ -3,7 +3,7 @@ PATH
   specs:
     ddtrace (1.14.0)
       datadog-ci (~> 0.1.0)
-      debase-ruby_core_source (= 3.2.1)
+      debase-ruby_core_source (= 3.2.2)
       libdatadog (~> 4.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
@@ -26,7 +26,7 @@ GEM
     crack (0.4.5)
       rexml
     datadog-ci (0.1.1)
-    debase-ruby_core_source (3.2.1)
+    debase-ruby_core_source (3.2.2)
     diff-lcs (1.5.0)
     docile (1.3.5)
     dogstatsd-ruby (5.5.0)

--- a/gemfiles/ruby_2.2.10_relational_db.gemfile.lock
+++ b/gemfiles/ruby_2.2.10_relational_db.gemfile.lock
@@ -3,7 +3,7 @@ PATH
   specs:
     ddtrace (1.14.0)
       datadog-ci (~> 0.1.0)
-      debase-ruby_core_source (= 3.2.1)
+      debase-ruby_core_source (= 3.2.2)
       libdatadog (~> 4.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
@@ -38,7 +38,7 @@ GEM
     crack (0.4.5)
       rexml
     datadog-ci (0.1.1)
-    debase-ruby_core_source (3.2.1)
+    debase-ruby_core_source (3.2.2)
     delayed_job (4.1.11)
       activesupport (>= 3.0, < 8.0)
     delayed_job_active_record (4.1.7)

--- a/gemfiles/ruby_2.2.10_sinatra.gemfile.lock
+++ b/gemfiles/ruby_2.2.10_sinatra.gemfile.lock
@@ -3,7 +3,7 @@ PATH
   specs:
     ddtrace (1.14.0)
       datadog-ci (~> 0.1.0)
-      debase-ruby_core_source (= 3.2.1)
+      debase-ruby_core_source (= 3.2.2)
       libdatadog (~> 4.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
@@ -26,7 +26,7 @@ GEM
     crack (0.4.5)
       rexml
     datadog-ci (0.1.1)
-    debase-ruby_core_source (3.2.1)
+    debase-ruby_core_source (3.2.2)
     diff-lcs (1.5.0)
     docile (1.3.5)
     dogstatsd-ruby (5.5.0)

--- a/gemfiles/ruby_2.3.8_activerecord_3.gemfile.lock
+++ b/gemfiles/ruby_2.3.8_activerecord_3.gemfile.lock
@@ -3,7 +3,7 @@ PATH
   specs:
     ddtrace (1.14.0)
       datadog-ci (~> 0.1.0)
-      debase-ruby_core_source (= 3.2.1)
+      debase-ruby_core_source (= 3.2.2)
       libdatadog (~> 4.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
@@ -42,7 +42,7 @@ GEM
     crack (0.4.5)
       rexml
     datadog-ci (0.1.1)
-    debase-ruby_core_source (3.2.1)
+    debase-ruby_core_source (3.2.2)
     diff-lcs (1.5.0)
     docile (1.3.5)
     dogstatsd-ruby (5.6.0)

--- a/gemfiles/ruby_2.3.8_activesupport.gemfile.lock
+++ b/gemfiles/ruby_2.3.8_activesupport.gemfile.lock
@@ -3,7 +3,7 @@ PATH
   specs:
     ddtrace (1.14.0)
       datadog-ci (~> 0.1.0)
-      debase-ruby_core_source (= 3.2.1)
+      debase-ruby_core_source (= 3.2.2)
       libdatadog (~> 4.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
@@ -61,7 +61,7 @@ GEM
       rexml
     crass (1.0.6)
     datadog-ci (0.1.1)
-    debase-ruby_core_source (3.2.1)
+    debase-ruby_core_source (3.2.2)
     descendants_tracker (0.0.4)
       thread_safe (~> 0.3, >= 0.3.1)
     diff-lcs (1.5.0)

--- a/gemfiles/ruby_2.3.8_aws.gemfile.lock
+++ b/gemfiles/ruby_2.3.8_aws.gemfile.lock
@@ -3,7 +3,7 @@ PATH
   specs:
     ddtrace (1.14.0)
       datadog-ci (~> 0.1.0)
-      debase-ruby_core_source (= 3.2.1)
+      debase-ruby_core_source (= 3.2.2)
       libdatadog (~> 4.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
@@ -1447,7 +1447,7 @@ GEM
     crack (0.4.5)
       rexml
     datadog-ci (0.1.1)
-    debase-ruby_core_source (3.2.1)
+    debase-ruby_core_source (3.2.2)
     diff-lcs (1.5.0)
     docile (1.3.5)
     dogstatsd-ruby (5.6.0)

--- a/gemfiles/ruby_2.3.8_contrib.gemfile.lock
+++ b/gemfiles/ruby_2.3.8_contrib.gemfile.lock
@@ -3,7 +3,7 @@ PATH
   specs:
     ddtrace (1.14.0)
       datadog-ci (~> 0.1.0)
-      debase-ruby_core_source (= 3.2.1)
+      debase-ruby_core_source (= 3.2.2)
       libdatadog (~> 4.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
@@ -33,7 +33,7 @@ GEM
       rexml
     dalli (2.7.11)
     datadog-ci (0.1.1)
-    debase-ruby_core_source (3.2.1)
+    debase-ruby_core_source (3.2.2)
     diff-lcs (1.5.0)
     docile (1.3.5)
     dogstatsd-ruby (5.5.0)

--- a/gemfiles/ruby_2.3.8_contrib_old.gemfile.lock
+++ b/gemfiles/ruby_2.3.8_contrib_old.gemfile.lock
@@ -3,7 +3,7 @@ PATH
   specs:
     ddtrace (1.14.0)
       datadog-ci (~> 0.1.0)
-      debase-ruby_core_source (= 3.2.1)
+      debase-ruby_core_source (= 3.2.2)
       libdatadog (~> 4.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
@@ -26,7 +26,7 @@ GEM
     crack (0.4.5)
       rexml
     datadog-ci (0.1.1)
-    debase-ruby_core_source (3.2.1)
+    debase-ruby_core_source (3.2.2)
     diff-lcs (1.5.0)
     docile (1.3.5)
     dogstatsd-ruby (5.5.0)

--- a/gemfiles/ruby_2.3.8_core_old.gemfile.lock
+++ b/gemfiles/ruby_2.3.8_core_old.gemfile.lock
@@ -3,7 +3,7 @@ PATH
   specs:
     ddtrace (1.14.0)
       datadog-ci (~> 0.1.0)
-      debase-ruby_core_source (= 3.2.1)
+      debase-ruby_core_source (= 3.2.2)
       libdatadog (~> 4.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
@@ -26,7 +26,7 @@ GEM
     crack (0.4.5)
       rexml
     datadog-ci (0.1.1)
-    debase-ruby_core_source (3.2.1)
+    debase-ruby_core_source (3.2.2)
     diff-lcs (1.5.0)
     docile (1.3.5)
     dogstatsd-ruby (4.8.3)

--- a/gemfiles/ruby_2.3.8_hanami_1.gemfile.lock
+++ b/gemfiles/ruby_2.3.8_hanami_1.gemfile.lock
@@ -3,7 +3,7 @@ PATH
   specs:
     ddtrace (1.14.0)
       datadog-ci (~> 0.1.0)
-      debase-ruby_core_source (= 3.2.1)
+      debase-ruby_core_source (= 3.2.2)
       libdatadog (~> 4.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
@@ -26,7 +26,7 @@ GEM
     crack (0.4.5)
       rexml
     datadog-ci (0.1.1)
-    debase-ruby_core_source (3.2.1)
+    debase-ruby_core_source (3.2.2)
     diff-lcs (1.5.0)
     docile (1.3.5)
     dogstatsd-ruby (5.5.0)

--- a/gemfiles/ruby_2.3.8_http.gemfile.lock
+++ b/gemfiles/ruby_2.3.8_http.gemfile.lock
@@ -3,7 +3,7 @@ PATH
   specs:
     ddtrace (1.14.0)
       datadog-ci (~> 0.1.0)
-      debase-ruby_core_source (= 3.2.1)
+      debase-ruby_core_source (= 3.2.2)
       libdatadog (~> 4.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
@@ -26,7 +26,7 @@ GEM
     crack (0.4.5)
       rexml
     datadog-ci (0.1.1)
-    debase-ruby_core_source (3.2.1)
+    debase-ruby_core_source (3.2.2)
     diff-lcs (1.5.0)
     docile (1.3.5)
     dogstatsd-ruby (5.6.1)

--- a/gemfiles/ruby_2.3.8_opentracing.gemfile.lock
+++ b/gemfiles/ruby_2.3.8_opentracing.gemfile.lock
@@ -3,7 +3,7 @@ PATH
   specs:
     ddtrace (1.14.0)
       datadog-ci (~> 0.1.0)
-      debase-ruby_core_source (= 3.2.1)
+      debase-ruby_core_source (= 3.2.2)
       libdatadog (~> 4.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
@@ -27,7 +27,7 @@ GEM
     crack (0.4.5)
       rexml
     datadog-ci (0.1.1)
-    debase-ruby_core_source (3.2.1)
+    debase-ruby_core_source (3.2.2)
     diff-lcs (1.5.0)
     docile (1.3.5)
     dogstatsd-ruby (5.6.1)

--- a/gemfiles/ruby_2.3.8_rack_1.gemfile.lock
+++ b/gemfiles/ruby_2.3.8_rack_1.gemfile.lock
@@ -3,7 +3,7 @@ PATH
   specs:
     ddtrace (1.14.0)
       datadog-ci (~> 0.1.0)
-      debase-ruby_core_source (= 3.2.1)
+      debase-ruby_core_source (= 3.2.2)
       libdatadog (~> 4.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
@@ -26,7 +26,7 @@ GEM
     crack (0.4.5)
       rexml
     datadog-ci (0.1.1)
-    debase-ruby_core_source (3.2.1)
+    debase-ruby_core_source (3.2.2)
     diff-lcs (1.5.0)
     docile (1.3.5)
     dogstatsd-ruby (5.6.1)

--- a/gemfiles/ruby_2.3.8_rack_2.gemfile.lock
+++ b/gemfiles/ruby_2.3.8_rack_2.gemfile.lock
@@ -3,7 +3,7 @@ PATH
   specs:
     ddtrace (1.14.0)
       datadog-ci (~> 0.1.0)
-      debase-ruby_core_source (= 3.2.1)
+      debase-ruby_core_source (= 3.2.2)
       libdatadog (~> 4.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
@@ -26,7 +26,7 @@ GEM
     crack (0.4.5)
       rexml
     datadog-ci (0.1.1)
-    debase-ruby_core_source (3.2.1)
+    debase-ruby_core_source (3.2.2)
     diff-lcs (1.5.0)
     docile (1.3.5)
     dogstatsd-ruby (5.6.1)

--- a/gemfiles/ruby_2.3.8_rails32_mysql2.gemfile.lock
+++ b/gemfiles/ruby_2.3.8_rails32_mysql2.gemfile.lock
@@ -3,7 +3,7 @@ PATH
   specs:
     ddtrace (1.14.0)
       datadog-ci (~> 0.1.0)
-      debase-ruby_core_source (= 3.2.1)
+      debase-ruby_core_source (= 3.2.2)
       libdatadog (~> 4.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
@@ -58,7 +58,7 @@ GEM
     crack (0.4.5)
       rexml
     datadog-ci (0.1.1)
-    debase-ruby_core_source (3.2.1)
+    debase-ruby_core_source (3.2.2)
     diff-lcs (1.5.0)
     docile (1.3.5)
     dogstatsd-ruby (5.5.0)

--- a/gemfiles/ruby_2.3.8_rails32_postgres.gemfile.lock
+++ b/gemfiles/ruby_2.3.8_rails32_postgres.gemfile.lock
@@ -3,7 +3,7 @@ PATH
   specs:
     ddtrace (1.14.0)
       datadog-ci (~> 0.1.0)
-      debase-ruby_core_source (= 3.2.1)
+      debase-ruby_core_source (= 3.2.2)
       libdatadog (~> 4.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
@@ -54,7 +54,7 @@ GEM
     crack (0.4.5)
       rexml
     datadog-ci (0.1.1)
-    debase-ruby_core_source (3.2.1)
+    debase-ruby_core_source (3.2.2)
     diff-lcs (1.5.0)
     docile (1.3.5)
     dogstatsd-ruby (5.5.0)

--- a/gemfiles/ruby_2.3.8_rails32_postgres_redis.gemfile.lock
+++ b/gemfiles/ruby_2.3.8_rails32_postgres_redis.gemfile.lock
@@ -3,7 +3,7 @@ PATH
   specs:
     ddtrace (1.14.0)
       datadog-ci (~> 0.1.0)
-      debase-ruby_core_source (= 3.2.1)
+      debase-ruby_core_source (= 3.2.2)
       libdatadog (~> 4.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
@@ -54,7 +54,7 @@ GEM
     crack (0.4.5)
       rexml
     datadog-ci (0.1.1)
-    debase-ruby_core_source (3.2.1)
+    debase-ruby_core_source (3.2.2)
     diff-lcs (1.5.0)
     docile (1.3.5)
     dogstatsd-ruby (5.5.0)

--- a/gemfiles/ruby_2.3.8_rails32_postgres_sidekiq.gemfile.lock
+++ b/gemfiles/ruby_2.3.8_rails32_postgres_sidekiq.gemfile.lock
@@ -3,7 +3,7 @@ PATH
   specs:
     ddtrace (1.14.0)
       datadog-ci (~> 0.1.0)
-      debase-ruby_core_source (= 3.2.1)
+      debase-ruby_core_source (= 3.2.2)
       libdatadog (~> 4.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
@@ -55,7 +55,7 @@ GEM
     crack (0.4.5)
       rexml
     datadog-ci (0.1.1)
-    debase-ruby_core_source (3.2.1)
+    debase-ruby_core_source (3.2.2)
     diff-lcs (1.5.0)
     docile (1.3.5)
     dogstatsd-ruby (5.5.0)

--- a/gemfiles/ruby_2.3.8_rails4_mysql2.gemfile.lock
+++ b/gemfiles/ruby_2.3.8_rails4_mysql2.gemfile.lock
@@ -3,7 +3,7 @@ PATH
   specs:
     ddtrace (1.14.0)
       datadog-ci (~> 0.1.0)
-      debase-ruby_core_source (= 3.2.1)
+      debase-ruby_core_source (= 3.2.2)
       libdatadog (~> 4.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
@@ -62,7 +62,7 @@ GEM
       rexml
     crass (1.0.6)
     datadog-ci (0.1.1)
-    debase-ruby_core_source (3.2.1)
+    debase-ruby_core_source (3.2.2)
     diff-lcs (1.5.0)
     docile (1.3.5)
     dogstatsd-ruby (5.5.0)

--- a/gemfiles/ruby_2.3.8_rails4_postgres.gemfile.lock
+++ b/gemfiles/ruby_2.3.8_rails4_postgres.gemfile.lock
@@ -3,7 +3,7 @@ PATH
   specs:
     ddtrace (1.14.0)
       datadog-ci (~> 0.1.0)
-      debase-ruby_core_source (= 3.2.1)
+      debase-ruby_core_source (= 3.2.2)
       libdatadog (~> 4.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
@@ -62,7 +62,7 @@ GEM
       rexml
     crass (1.0.6)
     datadog-ci (0.1.1)
-    debase-ruby_core_source (3.2.1)
+    debase-ruby_core_source (3.2.2)
     diff-lcs (1.5.0)
     docile (1.3.5)
     dogstatsd-ruby (5.5.0)

--- a/gemfiles/ruby_2.3.8_rails4_postgres_redis.gemfile.lock
+++ b/gemfiles/ruby_2.3.8_rails4_postgres_redis.gemfile.lock
@@ -3,7 +3,7 @@ PATH
   specs:
     ddtrace (1.14.0)
       datadog-ci (~> 0.1.0)
-      debase-ruby_core_source (= 3.2.1)
+      debase-ruby_core_source (= 3.2.2)
       libdatadog (~> 4.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
@@ -62,7 +62,7 @@ GEM
       rexml
     crass (1.0.6)
     datadog-ci (0.1.1)
-    debase-ruby_core_source (3.2.1)
+    debase-ruby_core_source (3.2.2)
     diff-lcs (1.5.0)
     docile (1.3.5)
     dogstatsd-ruby (5.5.0)

--- a/gemfiles/ruby_2.3.8_rails4_postgres_sidekiq.gemfile.lock
+++ b/gemfiles/ruby_2.3.8_rails4_postgres_sidekiq.gemfile.lock
@@ -3,7 +3,7 @@ PATH
   specs:
     ddtrace (1.14.0)
       datadog-ci (~> 0.1.0)
-      debase-ruby_core_source (= 3.2.1)
+      debase-ruby_core_source (= 3.2.2)
       libdatadog (~> 4.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
@@ -63,7 +63,7 @@ GEM
       rexml
     crass (1.0.6)
     datadog-ci (0.1.1)
-    debase-ruby_core_source (3.2.1)
+    debase-ruby_core_source (3.2.2)
     diff-lcs (1.5.0)
     docile (1.3.5)
     dogstatsd-ruby (5.5.0)

--- a/gemfiles/ruby_2.3.8_rails4_semantic_logger.gemfile.lock
+++ b/gemfiles/ruby_2.3.8_rails4_semantic_logger.gemfile.lock
@@ -3,7 +3,7 @@ PATH
   specs:
     ddtrace (1.14.0)
       datadog-ci (~> 0.1.0)
-      debase-ruby_core_source (= 3.2.1)
+      debase-ruby_core_source (= 3.2.2)
       libdatadog (~> 4.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
@@ -62,7 +62,7 @@ GEM
       rexml
     crass (1.0.6)
     datadog-ci (0.1.1)
-    debase-ruby_core_source (3.2.1)
+    debase-ruby_core_source (3.2.2)
     diff-lcs (1.5.0)
     docile (1.3.5)
     dogstatsd-ruby (5.5.0)

--- a/gemfiles/ruby_2.3.8_rails5_mysql2.gemfile.lock
+++ b/gemfiles/ruby_2.3.8_rails5_mysql2.gemfile.lock
@@ -3,7 +3,7 @@ PATH
   specs:
     ddtrace (1.14.0)
       datadog-ci (~> 0.1.0)
-      debase-ruby_core_source (= 3.2.1)
+      debase-ruby_core_source (= 3.2.2)
       libdatadog (~> 4.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
@@ -69,7 +69,7 @@ GEM
       rexml
     crass (1.0.6)
     datadog-ci (0.1.1)
-    debase-ruby_core_source (3.2.1)
+    debase-ruby_core_source (3.2.2)
     diff-lcs (1.5.0)
     docile (1.3.5)
     dogstatsd-ruby (5.5.0)

--- a/gemfiles/ruby_2.3.8_rails5_postgres.gemfile.lock
+++ b/gemfiles/ruby_2.3.8_rails5_postgres.gemfile.lock
@@ -3,7 +3,7 @@ PATH
   specs:
     ddtrace (1.14.0)
       datadog-ci (~> 0.1.0)
-      debase-ruby_core_source (= 3.2.1)
+      debase-ruby_core_source (= 3.2.2)
       libdatadog (~> 4.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
@@ -69,7 +69,7 @@ GEM
       rexml
     crass (1.0.6)
     datadog-ci (0.1.1)
-    debase-ruby_core_source (3.2.1)
+    debase-ruby_core_source (3.2.2)
     diff-lcs (1.5.0)
     docile (1.3.5)
     dogstatsd-ruby (5.5.0)

--- a/gemfiles/ruby_2.3.8_rails5_postgres_redis.gemfile.lock
+++ b/gemfiles/ruby_2.3.8_rails5_postgres_redis.gemfile.lock
@@ -3,7 +3,7 @@ PATH
   specs:
     ddtrace (1.14.0)
       datadog-ci (~> 0.1.0)
-      debase-ruby_core_source (= 3.2.1)
+      debase-ruby_core_source (= 3.2.2)
       libdatadog (~> 4.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
@@ -69,7 +69,7 @@ GEM
       rexml
     crass (1.0.6)
     datadog-ci (0.1.1)
-    debase-ruby_core_source (3.2.1)
+    debase-ruby_core_source (3.2.2)
     diff-lcs (1.5.0)
     docile (1.3.5)
     dogstatsd-ruby (5.5.0)

--- a/gemfiles/ruby_2.3.8_rails5_postgres_redis_activesupport.gemfile.lock
+++ b/gemfiles/ruby_2.3.8_rails5_postgres_redis_activesupport.gemfile.lock
@@ -3,7 +3,7 @@ PATH
   specs:
     ddtrace (1.14.0)
       datadog-ci (~> 0.1.0)
-      debase-ruby_core_source (= 3.2.1)
+      debase-ruby_core_source (= 3.2.2)
       libdatadog (~> 4.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
@@ -69,7 +69,7 @@ GEM
       rexml
     crass (1.0.6)
     datadog-ci (0.1.1)
-    debase-ruby_core_source (3.2.1)
+    debase-ruby_core_source (3.2.2)
     diff-lcs (1.5.0)
     docile (1.3.5)
     dogstatsd-ruby (5.5.0)

--- a/gemfiles/ruby_2.3.8_rails5_postgres_sidekiq.gemfile.lock
+++ b/gemfiles/ruby_2.3.8_rails5_postgres_sidekiq.gemfile.lock
@@ -3,7 +3,7 @@ PATH
   specs:
     ddtrace (1.14.0)
       datadog-ci (~> 0.1.0)
-      debase-ruby_core_source (= 3.2.1)
+      debase-ruby_core_source (= 3.2.2)
       libdatadog (~> 4.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
@@ -70,7 +70,7 @@ GEM
       rexml
     crass (1.0.6)
     datadog-ci (0.1.1)
-    debase-ruby_core_source (3.2.1)
+    debase-ruby_core_source (3.2.2)
     diff-lcs (1.5.0)
     docile (1.3.5)
     dogstatsd-ruby (5.5.0)

--- a/gemfiles/ruby_2.3.8_rails5_semantic_logger.gemfile.lock
+++ b/gemfiles/ruby_2.3.8_rails5_semantic_logger.gemfile.lock
@@ -3,7 +3,7 @@ PATH
   specs:
     ddtrace (1.14.0)
       datadog-ci (~> 0.1.0)
-      debase-ruby_core_source (= 3.2.1)
+      debase-ruby_core_source (= 3.2.2)
       libdatadog (~> 4.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
@@ -69,7 +69,7 @@ GEM
       rexml
     crass (1.0.6)
     datadog-ci (0.1.1)
-    debase-ruby_core_source (3.2.1)
+    debase-ruby_core_source (3.2.2)
     diff-lcs (1.5.0)
     docile (1.3.5)
     dogstatsd-ruby (5.5.0)

--- a/gemfiles/ruby_2.3.8_redis_3.gemfile.lock
+++ b/gemfiles/ruby_2.3.8_redis_3.gemfile.lock
@@ -3,7 +3,7 @@ PATH
   specs:
     ddtrace (1.14.0)
       datadog-ci (~> 0.1.0)
-      debase-ruby_core_source (= 3.2.1)
+      debase-ruby_core_source (= 3.2.2)
       libdatadog (~> 4.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
@@ -26,7 +26,7 @@ GEM
     crack (0.4.5)
       rexml
     datadog-ci (0.1.1)
-    debase-ruby_core_source (3.2.1)
+    debase-ruby_core_source (3.2.2)
     diff-lcs (1.5.0)
     docile (1.3.5)
     dogstatsd-ruby (5.5.0)

--- a/gemfiles/ruby_2.3.8_relational_db.gemfile.lock
+++ b/gemfiles/ruby_2.3.8_relational_db.gemfile.lock
@@ -3,7 +3,7 @@ PATH
   specs:
     ddtrace (1.14.0)
       datadog-ci (~> 0.1.0)
-      debase-ruby_core_source (= 3.2.1)
+      debase-ruby_core_source (= 3.2.2)
       libdatadog (~> 4.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
@@ -38,7 +38,7 @@ GEM
     crack (0.4.5)
       rexml
     datadog-ci (0.1.1)
-    debase-ruby_core_source (3.2.1)
+    debase-ruby_core_source (3.2.2)
     delayed_job (4.1.11)
       activesupport (>= 3.0, < 8.0)
     delayed_job_active_record (4.1.7)

--- a/gemfiles/ruby_2.3.8_resque2_redis3.gemfile.lock
+++ b/gemfiles/ruby_2.3.8_resque2_redis3.gemfile.lock
@@ -3,7 +3,7 @@ PATH
   specs:
     ddtrace (1.14.0)
       datadog-ci (~> 0.1.0)
-      debase-ruby_core_source (= 3.2.1)
+      debase-ruby_core_source (= 3.2.2)
       libdatadog (~> 4.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
@@ -26,7 +26,7 @@ GEM
     crack (0.4.5)
       rexml
     datadog-ci (0.1.1)
-    debase-ruby_core_source (3.2.1)
+    debase-ruby_core_source (3.2.2)
     diff-lcs (1.5.0)
     docile (1.3.5)
     dogstatsd-ruby (5.5.0)

--- a/gemfiles/ruby_2.3.8_resque2_redis4.gemfile.lock
+++ b/gemfiles/ruby_2.3.8_resque2_redis4.gemfile.lock
@@ -3,7 +3,7 @@ PATH
   specs:
     ddtrace (1.14.0)
       datadog-ci (~> 0.1.0)
-      debase-ruby_core_source (= 3.2.1)
+      debase-ruby_core_source (= 3.2.2)
       libdatadog (~> 4.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
@@ -26,7 +26,7 @@ GEM
     crack (0.4.5)
       rexml
     datadog-ci (0.1.1)
-    debase-ruby_core_source (3.2.1)
+    debase-ruby_core_source (3.2.2)
     diff-lcs (1.5.0)
     docile (1.3.5)
     dogstatsd-ruby (5.5.0)

--- a/gemfiles/ruby_2.3.8_sinatra.gemfile.lock
+++ b/gemfiles/ruby_2.3.8_sinatra.gemfile.lock
@@ -3,7 +3,7 @@ PATH
   specs:
     ddtrace (1.14.0)
       datadog-ci (~> 0.1.0)
-      debase-ruby_core_source (= 3.2.1)
+      debase-ruby_core_source (= 3.2.2)
       libdatadog (~> 4.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
@@ -26,7 +26,7 @@ GEM
     crack (0.4.5)
       rexml
     datadog-ci (0.1.1)
-    debase-ruby_core_source (3.2.1)
+    debase-ruby_core_source (3.2.2)
     diff-lcs (1.5.0)
     docile (1.3.5)
     dogstatsd-ruby (5.5.0)

--- a/gemfiles/ruby_2.4.10_activerecord_4.gemfile.lock
+++ b/gemfiles/ruby_2.4.10_activerecord_4.gemfile.lock
@@ -3,7 +3,7 @@ PATH
   specs:
     ddtrace (1.14.0)
       datadog-ci (~> 0.1.0)
-      debase-ruby_core_source (= 3.2.1)
+      debase-ruby_core_source (= 3.2.2)
       libdatadog (~> 4.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
@@ -41,7 +41,7 @@ GEM
       rexml
     cri (2.15.10)
     datadog-ci (0.1.1)
-    debase-ruby_core_source (3.2.1)
+    debase-ruby_core_source (3.2.2)
     diff-lcs (1.5.0)
     docile (1.3.5)
     dogstatsd-ruby (5.6.0)

--- a/gemfiles/ruby_2.4.10_activesupport.gemfile.lock
+++ b/gemfiles/ruby_2.4.10_activesupport.gemfile.lock
@@ -3,7 +3,7 @@ PATH
   specs:
     ddtrace (1.14.0)
       datadog-ci (~> 0.1.0)
-      debase-ruby_core_source (= 3.2.1)
+      debase-ruby_core_source (= 3.2.2)
       libdatadog (~> 4.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
@@ -56,7 +56,7 @@ GEM
     crass (1.0.6)
     cri (2.15.10)
     datadog-ci (0.1.1)
-    debase-ruby_core_source (3.2.1)
+    debase-ruby_core_source (3.2.2)
     diff-lcs (1.5.0)
     digest-crc (0.6.5)
       rake (>= 12.0.0, < 14.0.0)

--- a/gemfiles/ruby_2.4.10_aws.gemfile.lock
+++ b/gemfiles/ruby_2.4.10_aws.gemfile.lock
@@ -3,7 +3,7 @@ PATH
   specs:
     ddtrace (1.14.0)
       datadog-ci (~> 0.1.0)
-      debase-ruby_core_source (= 3.2.1)
+      debase-ruby_core_source (= 3.2.2)
       libdatadog (~> 4.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
@@ -1449,7 +1449,7 @@ GEM
       rexml
     cri (2.15.10)
     datadog-ci (0.1.1)
-    debase-ruby_core_source (3.2.1)
+    debase-ruby_core_source (3.2.2)
     diff-lcs (1.5.0)
     docile (1.3.5)
     dogstatsd-ruby (5.6.0)

--- a/gemfiles/ruby_2.4.10_contrib.gemfile.lock
+++ b/gemfiles/ruby_2.4.10_contrib.gemfile.lock
@@ -3,7 +3,7 @@ PATH
   specs:
     ddtrace (1.14.0)
       datadog-ci (~> 0.1.0)
-      debase-ruby_core_source (= 3.2.1)
+      debase-ruby_core_source (= 3.2.2)
       libdatadog (~> 4.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
@@ -35,7 +35,7 @@ GEM
     cri (2.15.10)
     dalli (2.7.11)
     datadog-ci (0.1.1)
-    debase-ruby_core_source (3.2.1)
+    debase-ruby_core_source (3.2.2)
     diff-lcs (1.3)
     docile (1.3.5)
     dogstatsd-ruby (5.5.0)

--- a/gemfiles/ruby_2.4.10_contrib_old.gemfile.lock
+++ b/gemfiles/ruby_2.4.10_contrib_old.gemfile.lock
@@ -3,7 +3,7 @@ PATH
   specs:
     ddtrace (1.14.0)
       datadog-ci (~> 0.1.0)
-      debase-ruby_core_source (= 3.2.1)
+      debase-ruby_core_source (= 3.2.2)
       libdatadog (~> 4.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
@@ -28,7 +28,7 @@ GEM
       rexml
     cri (2.15.10)
     datadog-ci (0.1.1)
-    debase-ruby_core_source (3.2.1)
+    debase-ruby_core_source (3.2.2)
     diff-lcs (1.5.0)
     docile (1.3.5)
     dogstatsd-ruby (5.5.0)

--- a/gemfiles/ruby_2.4.10_core_old.gemfile.lock
+++ b/gemfiles/ruby_2.4.10_core_old.gemfile.lock
@@ -3,7 +3,7 @@ PATH
   specs:
     ddtrace (1.14.0)
       datadog-ci (~> 0.1.0)
-      debase-ruby_core_source (= 3.2.1)
+      debase-ruby_core_source (= 3.2.2)
       libdatadog (~> 4.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
@@ -28,7 +28,7 @@ GEM
       rexml
     cri (2.15.10)
     datadog-ci (0.1.1)
-    debase-ruby_core_source (3.2.1)
+    debase-ruby_core_source (3.2.2)
     diff-lcs (1.5.0)
     docile (1.3.5)
     dogstatsd-ruby (4.8.3)

--- a/gemfiles/ruby_2.4.10_hanami_1.gemfile.lock
+++ b/gemfiles/ruby_2.4.10_hanami_1.gemfile.lock
@@ -3,7 +3,7 @@ PATH
   specs:
     ddtrace (1.14.0)
       datadog-ci (~> 0.1.0)
-      debase-ruby_core_source (= 3.2.1)
+      debase-ruby_core_source (= 3.2.2)
       libdatadog (~> 4.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
@@ -28,7 +28,7 @@ GEM
       rexml
     cri (2.15.10)
     datadog-ci (0.1.1)
-    debase-ruby_core_source (3.2.1)
+    debase-ruby_core_source (3.2.2)
     diff-lcs (1.5.0)
     docile (1.3.5)
     dogstatsd-ruby (5.5.0)

--- a/gemfiles/ruby_2.4.10_http.gemfile.lock
+++ b/gemfiles/ruby_2.4.10_http.gemfile.lock
@@ -3,7 +3,7 @@ PATH
   specs:
     ddtrace (1.14.0)
       datadog-ci (~> 0.1.0)
-      debase-ruby_core_source (= 3.2.1)
+      debase-ruby_core_source (= 3.2.2)
       libdatadog (~> 4.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
@@ -28,7 +28,7 @@ GEM
       rexml
     cri (2.15.10)
     datadog-ci (0.1.1)
-    debase-ruby_core_source (3.2.1)
+    debase-ruby_core_source (3.2.2)
     diff-lcs (1.5.0)
     docile (1.3.5)
     dogstatsd-ruby (5.6.1)

--- a/gemfiles/ruby_2.4.10_opentracing.gemfile.lock
+++ b/gemfiles/ruby_2.4.10_opentracing.gemfile.lock
@@ -3,7 +3,7 @@ PATH
   specs:
     ddtrace (1.14.0)
       datadog-ci (~> 0.1.0)
-      debase-ruby_core_source (= 3.2.1)
+      debase-ruby_core_source (= 3.2.2)
       libdatadog (~> 4.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
@@ -29,7 +29,7 @@ GEM
       rexml
     cri (2.15.10)
     datadog-ci (0.1.1)
-    debase-ruby_core_source (3.2.1)
+    debase-ruby_core_source (3.2.2)
     diff-lcs (1.5.0)
     docile (1.3.5)
     dogstatsd-ruby (5.6.1)

--- a/gemfiles/ruby_2.4.10_rack_1.gemfile.lock
+++ b/gemfiles/ruby_2.4.10_rack_1.gemfile.lock
@@ -3,7 +3,7 @@ PATH
   specs:
     ddtrace (1.14.0)
       datadog-ci (~> 0.1.0)
-      debase-ruby_core_source (= 3.2.1)
+      debase-ruby_core_source (= 3.2.2)
       libdatadog (~> 4.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
@@ -28,7 +28,7 @@ GEM
       rexml
     cri (2.15.10)
     datadog-ci (0.1.1)
-    debase-ruby_core_source (3.2.1)
+    debase-ruby_core_source (3.2.2)
     diff-lcs (1.5.0)
     docile (1.3.5)
     dogstatsd-ruby (5.6.1)

--- a/gemfiles/ruby_2.4.10_rack_2.gemfile.lock
+++ b/gemfiles/ruby_2.4.10_rack_2.gemfile.lock
@@ -3,7 +3,7 @@ PATH
   specs:
     ddtrace (1.14.0)
       datadog-ci (~> 0.1.0)
-      debase-ruby_core_source (= 3.2.1)
+      debase-ruby_core_source (= 3.2.2)
       libdatadog (~> 4.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
@@ -28,7 +28,7 @@ GEM
       rexml
     cri (2.15.10)
     datadog-ci (0.1.1)
-    debase-ruby_core_source (3.2.1)
+    debase-ruby_core_source (3.2.2)
     diff-lcs (1.5.0)
     docile (1.3.5)
     dogstatsd-ruby (5.6.1)

--- a/gemfiles/ruby_2.4.10_rack_3.gemfile.lock
+++ b/gemfiles/ruby_2.4.10_rack_3.gemfile.lock
@@ -3,7 +3,7 @@ PATH
   specs:
     ddtrace (1.14.0)
       datadog-ci (~> 0.1.0)
-      debase-ruby_core_source (= 3.2.1)
+      debase-ruby_core_source (= 3.2.2)
       libdatadog (~> 4.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
@@ -28,7 +28,7 @@ GEM
       rexml
     cri (2.15.10)
     datadog-ci (0.1.1)
-    debase-ruby_core_source (3.2.1)
+    debase-ruby_core_source (3.2.2)
     diff-lcs (1.5.0)
     docile (1.3.5)
     dogstatsd-ruby (5.6.1)

--- a/gemfiles/ruby_2.4.10_rails5_mysql2.gemfile.lock
+++ b/gemfiles/ruby_2.4.10_rails5_mysql2.gemfile.lock
@@ -3,7 +3,7 @@ PATH
   specs:
     ddtrace (1.14.0)
       datadog-ci (~> 0.1.0)
-      debase-ruby_core_source (= 3.2.1)
+      debase-ruby_core_source (= 3.2.2)
       libdatadog (~> 4.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
@@ -71,7 +71,7 @@ GEM
     crass (1.0.6)
     cri (2.15.10)
     datadog-ci (0.1.1)
-    debase-ruby_core_source (3.2.1)
+    debase-ruby_core_source (3.2.2)
     diff-lcs (1.5.0)
     docile (1.3.5)
     dogstatsd-ruby (5.5.0)

--- a/gemfiles/ruby_2.4.10_rails5_postgres.gemfile.lock
+++ b/gemfiles/ruby_2.4.10_rails5_postgres.gemfile.lock
@@ -3,7 +3,7 @@ PATH
   specs:
     ddtrace (1.14.0)
       datadog-ci (~> 0.1.0)
-      debase-ruby_core_source (= 3.2.1)
+      debase-ruby_core_source (= 3.2.2)
       libdatadog (~> 4.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
@@ -71,7 +71,7 @@ GEM
     crass (1.0.6)
     cri (2.15.10)
     datadog-ci (0.1.1)
-    debase-ruby_core_source (3.2.1)
+    debase-ruby_core_source (3.2.2)
     diff-lcs (1.5.0)
     docile (1.3.5)
     dogstatsd-ruby (5.5.0)

--- a/gemfiles/ruby_2.4.10_rails5_postgres_redis.gemfile.lock
+++ b/gemfiles/ruby_2.4.10_rails5_postgres_redis.gemfile.lock
@@ -3,7 +3,7 @@ PATH
   specs:
     ddtrace (1.14.0)
       datadog-ci (~> 0.1.0)
-      debase-ruby_core_source (= 3.2.1)
+      debase-ruby_core_source (= 3.2.2)
       libdatadog (~> 4.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
@@ -71,7 +71,7 @@ GEM
     crass (1.0.6)
     cri (2.15.10)
     datadog-ci (0.1.1)
-    debase-ruby_core_source (3.2.1)
+    debase-ruby_core_source (3.2.2)
     diff-lcs (1.5.0)
     docile (1.3.5)
     dogstatsd-ruby (5.5.0)

--- a/gemfiles/ruby_2.4.10_rails5_postgres_redis_activesupport.gemfile.lock
+++ b/gemfiles/ruby_2.4.10_rails5_postgres_redis_activesupport.gemfile.lock
@@ -3,7 +3,7 @@ PATH
   specs:
     ddtrace (1.14.0)
       datadog-ci (~> 0.1.0)
-      debase-ruby_core_source (= 3.2.1)
+      debase-ruby_core_source (= 3.2.2)
       libdatadog (~> 4.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
@@ -71,7 +71,7 @@ GEM
     crass (1.0.6)
     cri (2.15.10)
     datadog-ci (0.1.1)
-    debase-ruby_core_source (3.2.1)
+    debase-ruby_core_source (3.2.2)
     diff-lcs (1.5.0)
     docile (1.3.5)
     dogstatsd-ruby (5.5.0)

--- a/gemfiles/ruby_2.4.10_rails5_postgres_sidekiq.gemfile.lock
+++ b/gemfiles/ruby_2.4.10_rails5_postgres_sidekiq.gemfile.lock
@@ -3,7 +3,7 @@ PATH
   specs:
     ddtrace (1.14.0)
       datadog-ci (~> 0.1.0)
-      debase-ruby_core_source (= 3.2.1)
+      debase-ruby_core_source (= 3.2.2)
       libdatadog (~> 4.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
@@ -72,7 +72,7 @@ GEM
     crass (1.0.6)
     cri (2.15.10)
     datadog-ci (0.1.1)
-    debase-ruby_core_source (3.2.1)
+    debase-ruby_core_source (3.2.2)
     diff-lcs (1.5.0)
     docile (1.3.5)
     dogstatsd-ruby (5.5.0)

--- a/gemfiles/ruby_2.4.10_rails5_semantic_logger.gemfile.lock
+++ b/gemfiles/ruby_2.4.10_rails5_semantic_logger.gemfile.lock
@@ -3,7 +3,7 @@ PATH
   specs:
     ddtrace (1.14.0)
       datadog-ci (~> 0.1.0)
-      debase-ruby_core_source (= 3.2.1)
+      debase-ruby_core_source (= 3.2.2)
       libdatadog (~> 4.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
@@ -71,7 +71,7 @@ GEM
     crass (1.0.6)
     cri (2.15.10)
     datadog-ci (0.1.1)
-    debase-ruby_core_source (3.2.1)
+    debase-ruby_core_source (3.2.2)
     diff-lcs (1.5.0)
     docile (1.3.5)
     dogstatsd-ruby (5.5.0)

--- a/gemfiles/ruby_2.4.10_redis_3.gemfile.lock
+++ b/gemfiles/ruby_2.4.10_redis_3.gemfile.lock
@@ -3,7 +3,7 @@ PATH
   specs:
     ddtrace (1.14.0)
       datadog-ci (~> 0.1.0)
-      debase-ruby_core_source (= 3.2.1)
+      debase-ruby_core_source (= 3.2.2)
       libdatadog (~> 4.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
@@ -28,7 +28,7 @@ GEM
       rexml
     cri (2.15.10)
     datadog-ci (0.1.1)
-    debase-ruby_core_source (3.2.1)
+    debase-ruby_core_source (3.2.2)
     diff-lcs (1.5.0)
     docile (1.3.5)
     dogstatsd-ruby (5.5.0)

--- a/gemfiles/ruby_2.4.10_redis_4.gemfile.lock
+++ b/gemfiles/ruby_2.4.10_redis_4.gemfile.lock
@@ -3,7 +3,7 @@ PATH
   specs:
     ddtrace (1.14.0)
       datadog-ci (~> 0.1.0)
-      debase-ruby_core_source (= 3.2.1)
+      debase-ruby_core_source (= 3.2.2)
       libdatadog (~> 4.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
@@ -28,7 +28,7 @@ GEM
       rexml
     cri (2.15.10)
     datadog-ci (0.1.1)
-    debase-ruby_core_source (3.2.1)
+    debase-ruby_core_source (3.2.2)
     diff-lcs (1.5.0)
     docile (1.3.5)
     dogstatsd-ruby (5.5.0)

--- a/gemfiles/ruby_2.4.10_relational_db.gemfile.lock
+++ b/gemfiles/ruby_2.4.10_relational_db.gemfile.lock
@@ -3,7 +3,7 @@ PATH
   specs:
     ddtrace (1.14.0)
       datadog-ci (~> 0.1.0)
-      debase-ruby_core_source (= 3.2.1)
+      debase-ruby_core_source (= 3.2.2)
       libdatadog (~> 4.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
@@ -40,7 +40,7 @@ GEM
       rexml
     cri (2.15.10)
     datadog-ci (0.1.1)
-    debase-ruby_core_source (3.2.1)
+    debase-ruby_core_source (3.2.2)
     delayed_job (4.1.11)
       activesupport (>= 3.0, < 8.0)
     delayed_job_active_record (4.1.7)

--- a/gemfiles/ruby_2.4.10_resque2_redis3.gemfile.lock
+++ b/gemfiles/ruby_2.4.10_resque2_redis3.gemfile.lock
@@ -3,7 +3,7 @@ PATH
   specs:
     ddtrace (1.14.0)
       datadog-ci (~> 0.1.0)
-      debase-ruby_core_source (= 3.2.1)
+      debase-ruby_core_source (= 3.2.2)
       libdatadog (~> 4.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
@@ -28,7 +28,7 @@ GEM
       rexml
     cri (2.15.10)
     datadog-ci (0.1.1)
-    debase-ruby_core_source (3.2.1)
+    debase-ruby_core_source (3.2.2)
     diff-lcs (1.5.0)
     docile (1.3.5)
     dogstatsd-ruby (5.5.0)

--- a/gemfiles/ruby_2.4.10_resque2_redis4.gemfile.lock
+++ b/gemfiles/ruby_2.4.10_resque2_redis4.gemfile.lock
@@ -3,7 +3,7 @@ PATH
   specs:
     ddtrace (1.14.0)
       datadog-ci (~> 0.1.0)
-      debase-ruby_core_source (= 3.2.1)
+      debase-ruby_core_source (= 3.2.2)
       libdatadog (~> 4.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
@@ -28,7 +28,7 @@ GEM
       rexml
     cri (2.15.10)
     datadog-ci (0.1.1)
-    debase-ruby_core_source (3.2.1)
+    debase-ruby_core_source (3.2.2)
     diff-lcs (1.5.0)
     docile (1.3.5)
     dogstatsd-ruby (5.5.0)

--- a/gemfiles/ruby_2.4.10_sinatra.gemfile.lock
+++ b/gemfiles/ruby_2.4.10_sinatra.gemfile.lock
@@ -3,7 +3,7 @@ PATH
   specs:
     ddtrace (1.14.0)
       datadog-ci (~> 0.1.0)
-      debase-ruby_core_source (= 3.2.1)
+      debase-ruby_core_source (= 3.2.2)
       libdatadog (~> 4.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
@@ -28,7 +28,7 @@ GEM
       rexml
     cri (2.15.10)
     datadog-ci (0.1.1)
-    debase-ruby_core_source (3.2.1)
+    debase-ruby_core_source (3.2.2)
     diff-lcs (1.5.0)
     docile (1.3.5)
     dogstatsd-ruby (5.5.0)

--- a/gemfiles/ruby_2.5.9_activesupport.gemfile.lock
+++ b/gemfiles/ruby_2.5.9_activesupport.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.14.0)
       datadog-ci (~> 0.1.0)
-      debase-ruby_core_source (= 3.2.1)
+      debase-ruby_core_source (= 3.2.2)
       libdatadog (~> 4.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
@@ -68,7 +68,7 @@ GEM
     crass (1.0.6)
     cri (2.15.11)
     datadog-ci (0.1.1)
-    debase-ruby_core_source (3.2.1)
+    debase-ruby_core_source (3.2.2)
     debug_inspector (1.1.0)
     diff-lcs (1.5.0)
     digest-crc (0.6.5)

--- a/gemfiles/ruby_2.5.9_aws.gemfile.lock
+++ b/gemfiles/ruby_2.5.9_aws.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.14.0)
       datadog-ci (~> 0.1.0)
-      debase-ruby_core_source (= 3.2.1)
+      debase-ruby_core_source (= 3.2.2)
       libdatadog (~> 4.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
@@ -1461,7 +1461,7 @@ GEM
       rexml
     cri (2.15.11)
     datadog-ci (0.1.1)
-    debase-ruby_core_source (3.2.1)
+    debase-ruby_core_source (3.2.2)
     debug_inspector (1.1.0)
     diff-lcs (1.5.0)
     docile (1.4.0)

--- a/gemfiles/ruby_2.5.9_contrib.gemfile.lock
+++ b/gemfiles/ruby_2.5.9_contrib.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.14.0)
       datadog-ci (~> 0.1.0)
-      debase-ruby_core_source (= 3.2.1)
+      debase-ruby_core_source (= 3.2.2)
       libdatadog (~> 4.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
@@ -47,7 +47,7 @@ GEM
     cri (2.15.11)
     dalli (3.2.0)
     datadog-ci (0.1.1)
-    debase-ruby_core_source (3.2.1)
+    debase-ruby_core_source (3.2.2)
     debug_inspector (1.1.0)
     diff-lcs (1.5.0)
     docile (1.4.0)

--- a/gemfiles/ruby_2.5.9_contrib_old.gemfile.lock
+++ b/gemfiles/ruby_2.5.9_contrib_old.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.14.0)
       datadog-ci (~> 0.1.0)
-      debase-ruby_core_source (= 3.2.1)
+      debase-ruby_core_source (= 3.2.2)
       libdatadog (~> 4.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
@@ -45,7 +45,7 @@ GEM
     daemons (1.4.1)
     dalli (2.7.11)
     datadog-ci (0.1.1)
-    debase-ruby_core_source (3.2.1)
+    debase-ruby_core_source (3.2.2)
     debug_inspector (1.1.0)
     diff-lcs (1.5.0)
     docile (1.4.0)

--- a/gemfiles/ruby_2.5.9_core_old.gemfile.lock
+++ b/gemfiles/ruby_2.5.9_core_old.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.14.0)
       datadog-ci (~> 0.1.0)
-      debase-ruby_core_source (= 3.2.1)
+      debase-ruby_core_source (= 3.2.2)
       libdatadog (~> 4.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
@@ -40,7 +40,7 @@ GEM
       rexml
     cri (2.15.11)
     datadog-ci (0.1.1)
-    debase-ruby_core_source (3.2.1)
+    debase-ruby_core_source (3.2.2)
     debug_inspector (1.1.0)
     diff-lcs (1.5.0)
     docile (1.4.0)

--- a/gemfiles/ruby_2.5.9_hanami_1.gemfile.lock
+++ b/gemfiles/ruby_2.5.9_hanami_1.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.14.0)
       datadog-ci (~> 0.1.0)
-      debase-ruby_core_source (= 3.2.1)
+      debase-ruby_core_source (= 3.2.2)
       libdatadog (~> 4.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
@@ -40,7 +40,7 @@ GEM
       rexml
     cri (2.15.11)
     datadog-ci (0.1.1)
-    debase-ruby_core_source (3.2.1)
+    debase-ruby_core_source (3.2.2)
     debug_inspector (1.1.0)
     diff-lcs (1.5.0)
     digest (3.1.1)

--- a/gemfiles/ruby_2.5.9_http.gemfile.lock
+++ b/gemfiles/ruby_2.5.9_http.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.14.0)
       datadog-ci (~> 0.1.0)
-      debase-ruby_core_source (= 3.2.1)
+      debase-ruby_core_source (= 3.2.2)
       libdatadog (~> 4.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
@@ -40,7 +40,7 @@ GEM
       rexml
     cri (2.15.11)
     datadog-ci (0.1.1)
-    debase-ruby_core_source (3.2.1)
+    debase-ruby_core_source (3.2.2)
     debug_inspector (1.1.0)
     diff-lcs (1.5.0)
     docile (1.4.0)

--- a/gemfiles/ruby_2.5.9_opentracing.gemfile.lock
+++ b/gemfiles/ruby_2.5.9_opentracing.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.14.0)
       datadog-ci (~> 0.1.0)
-      debase-ruby_core_source (= 3.2.1)
+      debase-ruby_core_source (= 3.2.2)
       libdatadog (~> 4.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
@@ -41,7 +41,7 @@ GEM
       rexml
     cri (2.15.11)
     datadog-ci (0.1.1)
-    debase-ruby_core_source (3.2.1)
+    debase-ruby_core_source (3.2.2)
     debug_inspector (1.1.0)
     diff-lcs (1.5.0)
     docile (1.4.0)

--- a/gemfiles/ruby_2.5.9_rack_1.gemfile.lock
+++ b/gemfiles/ruby_2.5.9_rack_1.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.14.0)
       datadog-ci (~> 0.1.0)
-      debase-ruby_core_source (= 3.2.1)
+      debase-ruby_core_source (= 3.2.2)
       libdatadog (~> 4.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
@@ -40,7 +40,7 @@ GEM
       rexml
     cri (2.15.11)
     datadog-ci (0.1.1)
-    debase-ruby_core_source (3.2.1)
+    debase-ruby_core_source (3.2.2)
     debug_inspector (1.1.0)
     diff-lcs (1.5.0)
     docile (1.4.0)

--- a/gemfiles/ruby_2.5.9_rack_2.gemfile.lock
+++ b/gemfiles/ruby_2.5.9_rack_2.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.14.0)
       datadog-ci (~> 0.1.0)
-      debase-ruby_core_source (= 3.2.1)
+      debase-ruby_core_source (= 3.2.2)
       libdatadog (~> 4.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
@@ -40,7 +40,7 @@ GEM
       rexml
     cri (2.15.11)
     datadog-ci (0.1.1)
-    debase-ruby_core_source (3.2.1)
+    debase-ruby_core_source (3.2.2)
     debug_inspector (1.1.0)
     diff-lcs (1.5.0)
     docile (1.4.0)

--- a/gemfiles/ruby_2.5.9_rack_3.gemfile.lock
+++ b/gemfiles/ruby_2.5.9_rack_3.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.14.0)
       datadog-ci (~> 0.1.0)
-      debase-ruby_core_source (= 3.2.1)
+      debase-ruby_core_source (= 3.2.2)
       libdatadog (~> 4.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
@@ -40,7 +40,7 @@ GEM
       rexml
     cri (2.15.11)
     datadog-ci (0.1.1)
-    debase-ruby_core_source (3.2.1)
+    debase-ruby_core_source (3.2.2)
     debug_inspector (1.1.0)
     diff-lcs (1.5.0)
     docile (1.4.0)

--- a/gemfiles/ruby_2.5.9_rails5_mysql2.gemfile.lock
+++ b/gemfiles/ruby_2.5.9_rails5_mysql2.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.14.0)
       datadog-ci (~> 0.1.0)
-      debase-ruby_core_source (= 3.2.1)
+      debase-ruby_core_source (= 3.2.2)
       libdatadog (~> 4.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
@@ -83,7 +83,7 @@ GEM
     crass (1.0.6)
     cri (2.15.11)
     datadog-ci (0.1.1)
-    debase-ruby_core_source (3.2.1)
+    debase-ruby_core_source (3.2.2)
     debug_inspector (1.1.0)
     diff-lcs (1.5.0)
     docile (1.4.0)

--- a/gemfiles/ruby_2.5.9_rails5_postgres.gemfile.lock
+++ b/gemfiles/ruby_2.5.9_rails5_postgres.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.14.0)
       datadog-ci (~> 0.1.0)
-      debase-ruby_core_source (= 3.2.1)
+      debase-ruby_core_source (= 3.2.2)
       libdatadog (~> 4.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
@@ -83,7 +83,7 @@ GEM
     crass (1.0.6)
     cri (2.15.11)
     datadog-ci (0.1.1)
-    debase-ruby_core_source (3.2.1)
+    debase-ruby_core_source (3.2.2)
     debug_inspector (1.1.0)
     diff-lcs (1.5.0)
     digest (3.1.1)

--- a/gemfiles/ruby_2.5.9_rails5_postgres_redis.gemfile.lock
+++ b/gemfiles/ruby_2.5.9_rails5_postgres_redis.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.14.0)
       datadog-ci (~> 0.1.0)
-      debase-ruby_core_source (= 3.2.1)
+      debase-ruby_core_source (= 3.2.2)
       libdatadog (~> 4.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
@@ -84,7 +84,7 @@ GEM
     crass (1.0.6)
     cri (2.15.11)
     datadog-ci (0.1.1)
-    debase-ruby_core_source (3.2.1)
+    debase-ruby_core_source (3.2.2)
     debug_inspector (1.1.0)
     diff-lcs (1.5.0)
     digest (3.1.1)

--- a/gemfiles/ruby_2.5.9_rails5_postgres_redis_activesupport.gemfile.lock
+++ b/gemfiles/ruby_2.5.9_rails5_postgres_redis_activesupport.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.14.0)
       datadog-ci (~> 0.1.0)
-      debase-ruby_core_source (= 3.2.1)
+      debase-ruby_core_source (= 3.2.2)
       libdatadog (~> 4.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
@@ -83,7 +83,7 @@ GEM
     crass (1.0.6)
     cri (2.15.11)
     datadog-ci (0.1.1)
-    debase-ruby_core_source (3.2.1)
+    debase-ruby_core_source (3.2.2)
     debug_inspector (1.1.0)
     diff-lcs (1.5.0)
     digest (3.1.1)

--- a/gemfiles/ruby_2.5.9_rails5_postgres_sidekiq.gemfile.lock
+++ b/gemfiles/ruby_2.5.9_rails5_postgres_sidekiq.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.14.0)
       datadog-ci (~> 0.1.0)
-      debase-ruby_core_source (= 3.2.1)
+      debase-ruby_core_source (= 3.2.2)
       libdatadog (~> 4.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
@@ -84,7 +84,7 @@ GEM
     crass (1.0.6)
     cri (2.15.11)
     datadog-ci (0.1.1)
-    debase-ruby_core_source (3.2.1)
+    debase-ruby_core_source (3.2.2)
     debug_inspector (1.1.0)
     diff-lcs (1.5.0)
     digest (3.1.1)

--- a/gemfiles/ruby_2.5.9_rails5_semantic_logger.gemfile.lock
+++ b/gemfiles/ruby_2.5.9_rails5_semantic_logger.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.14.0)
       datadog-ci (~> 0.1.0)
-      debase-ruby_core_source (= 3.2.1)
+      debase-ruby_core_source (= 3.2.2)
       libdatadog (~> 4.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
@@ -83,7 +83,7 @@ GEM
     crass (1.0.6)
     cri (2.15.11)
     datadog-ci (0.1.1)
-    debase-ruby_core_source (3.2.1)
+    debase-ruby_core_source (3.2.2)
     debug_inspector (1.1.0)
     diff-lcs (1.5.0)
     digest (3.1.1)

--- a/gemfiles/ruby_2.5.9_rails61_mysql2.gemfile.lock
+++ b/gemfiles/ruby_2.5.9_rails61_mysql2.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.14.0)
       datadog-ci (~> 0.1.0)
-      debase-ruby_core_source (= 3.2.1)
+      debase-ruby_core_source (= 3.2.2)
       libdatadog (~> 4.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
@@ -100,7 +100,7 @@ GEM
     crass (1.0.6)
     cri (2.15.11)
     datadog-ci (0.1.1)
-    debase-ruby_core_source (3.2.1)
+    debase-ruby_core_source (3.2.2)
     debug_inspector (1.1.0)
     diff-lcs (1.5.0)
     docile (1.4.0)

--- a/gemfiles/ruby_2.5.9_rails61_postgres.gemfile.lock
+++ b/gemfiles/ruby_2.5.9_rails61_postgres.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.14.0)
       datadog-ci (~> 0.1.0)
-      debase-ruby_core_source (= 3.2.1)
+      debase-ruby_core_source (= 3.2.2)
       libdatadog (~> 4.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
@@ -100,7 +100,7 @@ GEM
     crass (1.0.6)
     cri (2.15.11)
     datadog-ci (0.1.1)
-    debase-ruby_core_source (3.2.1)
+    debase-ruby_core_source (3.2.2)
     debug_inspector (1.1.0)
     diff-lcs (1.5.0)
     digest (3.1.1)

--- a/gemfiles/ruby_2.5.9_rails61_postgres_redis.gemfile.lock
+++ b/gemfiles/ruby_2.5.9_rails61_postgres_redis.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.14.0)
       datadog-ci (~> 0.1.0)
-      debase-ruby_core_source (= 3.2.1)
+      debase-ruby_core_source (= 3.2.2)
       libdatadog (~> 4.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
@@ -101,7 +101,7 @@ GEM
     crass (1.0.6)
     cri (2.15.11)
     datadog-ci (0.1.1)
-    debase-ruby_core_source (3.2.1)
+    debase-ruby_core_source (3.2.2)
     debug_inspector (1.1.0)
     diff-lcs (1.5.0)
     digest (3.1.1)

--- a/gemfiles/ruby_2.5.9_rails61_postgres_sidekiq.gemfile.lock
+++ b/gemfiles/ruby_2.5.9_rails61_postgres_sidekiq.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.14.0)
       datadog-ci (~> 0.1.0)
-      debase-ruby_core_source (= 3.2.1)
+      debase-ruby_core_source (= 3.2.2)
       libdatadog (~> 4.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
@@ -101,7 +101,7 @@ GEM
     crass (1.0.6)
     cri (2.15.11)
     datadog-ci (0.1.1)
-    debase-ruby_core_source (3.2.1)
+    debase-ruby_core_source (3.2.2)
     debug_inspector (1.1.0)
     diff-lcs (1.5.0)
     digest (3.1.1)

--- a/gemfiles/ruby_2.5.9_rails61_semantic_logger.gemfile.lock
+++ b/gemfiles/ruby_2.5.9_rails61_semantic_logger.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.14.0)
       datadog-ci (~> 0.1.0)
-      debase-ruby_core_source (= 3.2.1)
+      debase-ruby_core_source (= 3.2.2)
       libdatadog (~> 4.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
@@ -100,7 +100,7 @@ GEM
     crass (1.0.6)
     cri (2.15.11)
     datadog-ci (0.1.1)
-    debase-ruby_core_source (3.2.1)
+    debase-ruby_core_source (3.2.2)
     debug_inspector (1.1.0)
     diff-lcs (1.5.0)
     digest (3.1.1)

--- a/gemfiles/ruby_2.5.9_rails6_mysql2.gemfile.lock
+++ b/gemfiles/ruby_2.5.9_rails6_mysql2.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.14.0)
       datadog-ci (~> 0.1.0)
-      debase-ruby_core_source (= 3.2.1)
+      debase-ruby_core_source (= 3.2.2)
       libdatadog (~> 4.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
@@ -96,7 +96,7 @@ GEM
     crass (1.0.6)
     cri (2.15.11)
     datadog-ci (0.1.1)
-    debase-ruby_core_source (3.2.1)
+    debase-ruby_core_source (3.2.2)
     debug_inspector (1.1.0)
     diff-lcs (1.5.0)
     docile (1.4.0)

--- a/gemfiles/ruby_2.5.9_rails6_postgres.gemfile.lock
+++ b/gemfiles/ruby_2.5.9_rails6_postgres.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.14.0)
       datadog-ci (~> 0.1.0)
-      debase-ruby_core_source (= 3.2.1)
+      debase-ruby_core_source (= 3.2.2)
       libdatadog (~> 4.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
@@ -96,7 +96,7 @@ GEM
     crass (1.0.6)
     cri (2.15.11)
     datadog-ci (0.1.1)
-    debase-ruby_core_source (3.2.1)
+    debase-ruby_core_source (3.2.2)
     debug_inspector (1.1.0)
     diff-lcs (1.5.0)
     digest (3.1.1)

--- a/gemfiles/ruby_2.5.9_rails6_postgres_redis.gemfile.lock
+++ b/gemfiles/ruby_2.5.9_rails6_postgres_redis.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.14.0)
       datadog-ci (~> 0.1.0)
-      debase-ruby_core_source (= 3.2.1)
+      debase-ruby_core_source (= 3.2.2)
       libdatadog (~> 4.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
@@ -97,7 +97,7 @@ GEM
     crass (1.0.6)
     cri (2.15.11)
     datadog-ci (0.1.1)
-    debase-ruby_core_source (3.2.1)
+    debase-ruby_core_source (3.2.2)
     debug_inspector (1.1.0)
     diff-lcs (1.5.0)
     digest (3.1.1)

--- a/gemfiles/ruby_2.5.9_rails6_postgres_redis_activesupport.gemfile.lock
+++ b/gemfiles/ruby_2.5.9_rails6_postgres_redis_activesupport.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.14.0)
       datadog-ci (~> 0.1.0)
-      debase-ruby_core_source (= 3.2.1)
+      debase-ruby_core_source (= 3.2.2)
       libdatadog (~> 4.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
@@ -96,7 +96,7 @@ GEM
     crass (1.0.6)
     cri (2.15.11)
     datadog-ci (0.1.1)
-    debase-ruby_core_source (3.2.1)
+    debase-ruby_core_source (3.2.2)
     debug_inspector (1.1.0)
     diff-lcs (1.5.0)
     digest (3.1.1)

--- a/gemfiles/ruby_2.5.9_rails6_postgres_sidekiq.gemfile.lock
+++ b/gemfiles/ruby_2.5.9_rails6_postgres_sidekiq.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.14.0)
       datadog-ci (~> 0.1.0)
-      debase-ruby_core_source (= 3.2.1)
+      debase-ruby_core_source (= 3.2.2)
       libdatadog (~> 4.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
@@ -97,7 +97,7 @@ GEM
     crass (1.0.6)
     cri (2.15.11)
     datadog-ci (0.1.1)
-    debase-ruby_core_source (3.2.1)
+    debase-ruby_core_source (3.2.2)
     debug_inspector (1.1.0)
     diff-lcs (1.5.0)
     digest (3.1.1)

--- a/gemfiles/ruby_2.5.9_rails6_semantic_logger.gemfile.lock
+++ b/gemfiles/ruby_2.5.9_rails6_semantic_logger.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.14.0)
       datadog-ci (~> 0.1.0)
-      debase-ruby_core_source (= 3.2.1)
+      debase-ruby_core_source (= 3.2.2)
       libdatadog (~> 4.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
@@ -96,7 +96,7 @@ GEM
     crass (1.0.6)
     cri (2.15.11)
     datadog-ci (0.1.1)
-    debase-ruby_core_source (3.2.1)
+    debase-ruby_core_source (3.2.2)
     debug_inspector (1.1.0)
     diff-lcs (1.5.0)
     digest (3.1.1)

--- a/gemfiles/ruby_2.5.9_redis_3.gemfile.lock
+++ b/gemfiles/ruby_2.5.9_redis_3.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.14.0)
       datadog-ci (~> 0.1.0)
-      debase-ruby_core_source (= 3.2.1)
+      debase-ruby_core_source (= 3.2.2)
       libdatadog (~> 4.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
@@ -40,7 +40,7 @@ GEM
       rexml
     cri (2.15.11)
     datadog-ci (0.1.1)
-    debase-ruby_core_source (3.2.1)
+    debase-ruby_core_source (3.2.2)
     debug_inspector (1.1.0)
     diff-lcs (1.5.0)
     docile (1.4.0)

--- a/gemfiles/ruby_2.5.9_redis_4.gemfile.lock
+++ b/gemfiles/ruby_2.5.9_redis_4.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.14.0)
       datadog-ci (~> 0.1.0)
-      debase-ruby_core_source (= 3.2.1)
+      debase-ruby_core_source (= 3.2.2)
       libdatadog (~> 4.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
@@ -40,7 +40,7 @@ GEM
       rexml
     cri (2.15.11)
     datadog-ci (0.1.1)
-    debase-ruby_core_source (3.2.1)
+    debase-ruby_core_source (3.2.2)
     debug_inspector (1.1.0)
     diff-lcs (1.5.0)
     docile (1.4.0)

--- a/gemfiles/ruby_2.5.9_redis_5.gemfile.lock
+++ b/gemfiles/ruby_2.5.9_redis_5.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.14.0)
       datadog-ci (~> 0.1.0)
-      debase-ruby_core_source (= 3.2.1)
+      debase-ruby_core_source (= 3.2.2)
       libdatadog (~> 4.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
@@ -41,7 +41,7 @@ GEM
       rexml
     cri (2.15.11)
     datadog-ci (0.1.1)
-    debase-ruby_core_source (3.2.1)
+    debase-ruby_core_source (3.2.2)
     debug_inspector (1.1.0)
     diff-lcs (1.5.0)
     docile (1.4.0)

--- a/gemfiles/ruby_2.5.9_relational_db.gemfile.lock
+++ b/gemfiles/ruby_2.5.9_relational_db.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.14.0)
       datadog-ci (~> 0.1.0)
-      debase-ruby_core_source (= 3.2.1)
+      debase-ruby_core_source (= 3.2.2)
       libdatadog (~> 4.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
@@ -52,7 +52,7 @@ GEM
       rexml
     cri (2.15.11)
     datadog-ci (0.1.1)
-    debase-ruby_core_source (3.2.1)
+    debase-ruby_core_source (3.2.2)
     debug_inspector (1.1.0)
     delayed_job (4.1.11)
       activesupport (>= 3.0, < 8.0)

--- a/gemfiles/ruby_2.5.9_resque2_redis3.gemfile.lock
+++ b/gemfiles/ruby_2.5.9_resque2_redis3.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.14.0)
       datadog-ci (~> 0.1.0)
-      debase-ruby_core_source (= 3.2.1)
+      debase-ruby_core_source (= 3.2.2)
       libdatadog (~> 4.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
@@ -40,7 +40,7 @@ GEM
       rexml
     cri (2.15.11)
     datadog-ci (0.1.1)
-    debase-ruby_core_source (3.2.1)
+    debase-ruby_core_source (3.2.2)
     debug_inspector (1.1.0)
     diff-lcs (1.5.0)
     docile (1.4.0)

--- a/gemfiles/ruby_2.5.9_resque2_redis4.gemfile.lock
+++ b/gemfiles/ruby_2.5.9_resque2_redis4.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.14.0)
       datadog-ci (~> 0.1.0)
-      debase-ruby_core_source (= 3.2.1)
+      debase-ruby_core_source (= 3.2.2)
       libdatadog (~> 4.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
@@ -41,7 +41,7 @@ GEM
       rexml
     cri (2.15.11)
     datadog-ci (0.1.1)
-    debase-ruby_core_source (3.2.1)
+    debase-ruby_core_source (3.2.2)
     debug_inspector (1.1.0)
     diff-lcs (1.5.0)
     docile (1.4.0)

--- a/gemfiles/ruby_2.5.9_sinatra.gemfile.lock
+++ b/gemfiles/ruby_2.5.9_sinatra.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.14.0)
       datadog-ci (~> 0.1.0)
-      debase-ruby_core_source (= 3.2.1)
+      debase-ruby_core_source (= 3.2.2)
       libdatadog (~> 4.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
@@ -40,7 +40,7 @@ GEM
       rexml
     cri (2.15.11)
     datadog-ci (0.1.1)
-    debase-ruby_core_source (3.2.1)
+    debase-ruby_core_source (3.2.2)
     debug_inspector (1.1.0)
     diff-lcs (1.5.0)
     docile (1.4.0)

--- a/gemfiles/ruby_2.6.10_activesupport.gemfile.lock
+++ b/gemfiles/ruby_2.6.10_activesupport.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.14.0)
       datadog-ci (~> 0.1.0)
-      debase-ruby_core_source (= 3.2.1)
+      debase-ruby_core_source (= 3.2.2)
       libdatadog (~> 4.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
@@ -71,7 +71,7 @@ GEM
     crass (1.0.6)
     cri (2.15.11)
     datadog-ci (0.1.1)
-    debase-ruby_core_source (3.2.1)
+    debase-ruby_core_source (3.2.2)
     debug_inspector (1.1.0)
     diff-lcs (1.5.0)
     digest-crc (0.6.5)

--- a/gemfiles/ruby_2.6.10_aws.gemfile.lock
+++ b/gemfiles/ruby_2.6.10_aws.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.14.0)
       datadog-ci (~> 0.1.0)
-      debase-ruby_core_source (= 3.2.1)
+      debase-ruby_core_source (= 3.2.2)
       libdatadog (~> 4.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
@@ -1463,7 +1463,7 @@ GEM
       rexml
     cri (2.15.11)
     datadog-ci (0.1.1)
-    debase-ruby_core_source (3.2.1)
+    debase-ruby_core_source (3.2.2)
     debug_inspector (1.1.0)
     diff-lcs (1.5.0)
     docile (1.4.0)

--- a/gemfiles/ruby_2.6.10_contrib.gemfile.lock
+++ b/gemfiles/ruby_2.6.10_contrib.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.14.0)
       datadog-ci (~> 0.1.0)
-      debase-ruby_core_source (= 3.2.1)
+      debase-ruby_core_source (= 3.2.2)
       libdatadog (~> 4.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
@@ -49,7 +49,7 @@ GEM
     cri (2.15.11)
     dalli (3.2.4)
     datadog-ci (0.1.1)
-    debase-ruby_core_source (3.2.1)
+    debase-ruby_core_source (3.2.2)
     debug_inspector (1.1.0)
     diff-lcs (1.5.0)
     docile (1.4.0)

--- a/gemfiles/ruby_2.6.10_contrib_old.gemfile.lock
+++ b/gemfiles/ruby_2.6.10_contrib_old.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.14.0)
       datadog-ci (~> 0.1.0)
-      debase-ruby_core_source (= 3.2.1)
+      debase-ruby_core_source (= 3.2.2)
       libdatadog (~> 4.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
@@ -47,7 +47,7 @@ GEM
     daemons (1.4.1)
     dalli (2.7.11)
     datadog-ci (0.1.1)
-    debase-ruby_core_source (3.2.1)
+    debase-ruby_core_source (3.2.2)
     debug_inspector (1.1.0)
     diff-lcs (1.5.0)
     docile (1.4.0)

--- a/gemfiles/ruby_2.6.10_core_old.gemfile.lock
+++ b/gemfiles/ruby_2.6.10_core_old.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.14.0)
       datadog-ci (~> 0.1.0)
-      debase-ruby_core_source (= 3.2.1)
+      debase-ruby_core_source (= 3.2.2)
       libdatadog (~> 4.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
@@ -42,7 +42,7 @@ GEM
       rexml
     cri (2.15.11)
     datadog-ci (0.1.1)
-    debase-ruby_core_source (3.2.1)
+    debase-ruby_core_source (3.2.2)
     debug_inspector (1.1.0)
     diff-lcs (1.5.0)
     docile (1.4.0)

--- a/gemfiles/ruby_2.6.10_hanami_1.gemfile.lock
+++ b/gemfiles/ruby_2.6.10_hanami_1.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.14.0)
       datadog-ci (~> 0.1.0)
-      debase-ruby_core_source (= 3.2.1)
+      debase-ruby_core_source (= 3.2.2)
       libdatadog (~> 4.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
@@ -43,7 +43,7 @@ GEM
     cri (2.15.11)
     datadog-ci (0.1.1)
     date (3.3.3)
-    debase-ruby_core_source (3.2.1)
+    debase-ruby_core_source (3.2.2)
     debug_inspector (1.1.0)
     diff-lcs (1.5.0)
     docile (1.4.0)

--- a/gemfiles/ruby_2.6.10_http.gemfile.lock
+++ b/gemfiles/ruby_2.6.10_http.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.14.0)
       datadog-ci (~> 0.1.0)
-      debase-ruby_core_source (= 3.2.1)
+      debase-ruby_core_source (= 3.2.2)
       libdatadog (~> 4.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
@@ -42,7 +42,7 @@ GEM
       rexml
     cri (2.15.11)
     datadog-ci (0.1.1)
-    debase-ruby_core_source (3.2.1)
+    debase-ruby_core_source (3.2.2)
     debug_inspector (1.1.0)
     diff-lcs (1.5.0)
     docile (1.4.0)

--- a/gemfiles/ruby_2.6.10_opentelemetry.gemfile.lock
+++ b/gemfiles/ruby_2.6.10_opentelemetry.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.14.0)
       datadog-ci (~> 0.1.0)
-      debase-ruby_core_source (= 3.2.1)
+      debase-ruby_core_source (= 3.2.2)
       libdatadog (~> 4.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
@@ -42,7 +42,7 @@ GEM
       rexml
     cri (2.15.11)
     datadog-ci (0.1.1)
-    debase-ruby_core_source (3.2.1)
+    debase-ruby_core_source (3.2.2)
     debug_inspector (1.1.0)
     diff-lcs (1.5.0)
     docile (1.4.0)

--- a/gemfiles/ruby_2.6.10_opentracing.gemfile.lock
+++ b/gemfiles/ruby_2.6.10_opentracing.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.14.0)
       datadog-ci (~> 0.1.0)
-      debase-ruby_core_source (= 3.2.1)
+      debase-ruby_core_source (= 3.2.2)
       libdatadog (~> 4.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
@@ -43,7 +43,7 @@ GEM
       rexml
     cri (2.15.11)
     datadog-ci (0.1.1)
-    debase-ruby_core_source (3.2.1)
+    debase-ruby_core_source (3.2.2)
     debug_inspector (1.1.0)
     diff-lcs (1.5.0)
     docile (1.4.0)

--- a/gemfiles/ruby_2.6.10_rack_1.gemfile.lock
+++ b/gemfiles/ruby_2.6.10_rack_1.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.14.0)
       datadog-ci (~> 0.1.0)
-      debase-ruby_core_source (= 3.2.1)
+      debase-ruby_core_source (= 3.2.2)
       libdatadog (~> 4.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
@@ -42,7 +42,7 @@ GEM
       rexml
     cri (2.15.11)
     datadog-ci (0.1.1)
-    debase-ruby_core_source (3.2.1)
+    debase-ruby_core_source (3.2.2)
     debug_inspector (1.1.0)
     diff-lcs (1.5.0)
     docile (1.4.0)

--- a/gemfiles/ruby_2.6.10_rack_2.gemfile.lock
+++ b/gemfiles/ruby_2.6.10_rack_2.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.14.0)
       datadog-ci (~> 0.1.0)
-      debase-ruby_core_source (= 3.2.1)
+      debase-ruby_core_source (= 3.2.2)
       libdatadog (~> 4.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
@@ -42,7 +42,7 @@ GEM
       rexml
     cri (2.15.11)
     datadog-ci (0.1.1)
-    debase-ruby_core_source (3.2.1)
+    debase-ruby_core_source (3.2.2)
     debug_inspector (1.1.0)
     diff-lcs (1.5.0)
     docile (1.4.0)

--- a/gemfiles/ruby_2.6.10_rack_3.gemfile.lock
+++ b/gemfiles/ruby_2.6.10_rack_3.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.14.0)
       datadog-ci (~> 0.1.0)
-      debase-ruby_core_source (= 3.2.1)
+      debase-ruby_core_source (= 3.2.2)
       libdatadog (~> 4.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
@@ -42,7 +42,7 @@ GEM
       rexml
     cri (2.15.11)
     datadog-ci (0.1.1)
-    debase-ruby_core_source (3.2.1)
+    debase-ruby_core_source (3.2.2)
     debug_inspector (1.1.0)
     diff-lcs (1.5.0)
     docile (1.4.0)

--- a/gemfiles/ruby_2.6.10_rails5_mysql2.gemfile.lock
+++ b/gemfiles/ruby_2.6.10_rails5_mysql2.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.14.0)
       datadog-ci (~> 0.1.0)
-      debase-ruby_core_source (= 3.2.1)
+      debase-ruby_core_source (= 3.2.2)
       libdatadog (~> 4.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
@@ -86,7 +86,7 @@ GEM
     cri (2.15.11)
     datadog-ci (0.1.1)
     date (3.3.3)
-    debase-ruby_core_source (3.2.1)
+    debase-ruby_core_source (3.2.2)
     debug_inspector (1.1.0)
     diff-lcs (1.5.0)
     docile (1.4.0)

--- a/gemfiles/ruby_2.6.10_rails5_postgres.gemfile.lock
+++ b/gemfiles/ruby_2.6.10_rails5_postgres.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.14.0)
       datadog-ci (~> 0.1.0)
-      debase-ruby_core_source (= 3.2.1)
+      debase-ruby_core_source (= 3.2.2)
       libdatadog (~> 4.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
@@ -86,7 +86,7 @@ GEM
     cri (2.15.11)
     datadog-ci (0.1.1)
     date (3.3.3)
-    debase-ruby_core_source (3.2.1)
+    debase-ruby_core_source (3.2.2)
     debug_inspector (1.1.0)
     diff-lcs (1.5.0)
     docile (1.4.0)

--- a/gemfiles/ruby_2.6.10_rails5_postgres_redis.gemfile.lock
+++ b/gemfiles/ruby_2.6.10_rails5_postgres_redis.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.14.0)
       datadog-ci (~> 0.1.0)
-      debase-ruby_core_source (= 3.2.1)
+      debase-ruby_core_source (= 3.2.2)
       libdatadog (~> 4.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
@@ -86,7 +86,7 @@ GEM
     cri (2.15.11)
     datadog-ci (0.1.1)
     date (3.3.3)
-    debase-ruby_core_source (3.2.1)
+    debase-ruby_core_source (3.2.2)
     debug_inspector (1.1.0)
     diff-lcs (1.5.0)
     docile (1.4.0)

--- a/gemfiles/ruby_2.6.10_rails5_postgres_redis_activesupport.gemfile.lock
+++ b/gemfiles/ruby_2.6.10_rails5_postgres_redis_activesupport.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.14.0)
       datadog-ci (~> 0.1.0)
-      debase-ruby_core_source (= 3.2.1)
+      debase-ruby_core_source (= 3.2.2)
       libdatadog (~> 4.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
@@ -86,7 +86,7 @@ GEM
     cri (2.15.11)
     datadog-ci (0.1.1)
     date (3.3.3)
-    debase-ruby_core_source (3.2.1)
+    debase-ruby_core_source (3.2.2)
     debug_inspector (1.1.0)
     diff-lcs (1.5.0)
     docile (1.4.0)

--- a/gemfiles/ruby_2.6.10_rails5_postgres_sidekiq.gemfile.lock
+++ b/gemfiles/ruby_2.6.10_rails5_postgres_sidekiq.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.14.0)
       datadog-ci (~> 0.1.0)
-      debase-ruby_core_source (= 3.2.1)
+      debase-ruby_core_source (= 3.2.2)
       libdatadog (~> 4.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
@@ -87,7 +87,7 @@ GEM
     cri (2.15.11)
     datadog-ci (0.1.1)
     date (3.3.3)
-    debase-ruby_core_source (3.2.1)
+    debase-ruby_core_source (3.2.2)
     debug_inspector (1.1.0)
     diff-lcs (1.5.0)
     docile (1.4.0)

--- a/gemfiles/ruby_2.6.10_rails5_semantic_logger.gemfile.lock
+++ b/gemfiles/ruby_2.6.10_rails5_semantic_logger.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.14.0)
       datadog-ci (~> 0.1.0)
-      debase-ruby_core_source (= 3.2.1)
+      debase-ruby_core_source (= 3.2.2)
       libdatadog (~> 4.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
@@ -86,7 +86,7 @@ GEM
     cri (2.15.11)
     datadog-ci (0.1.1)
     date (3.3.3)
-    debase-ruby_core_source (3.2.1)
+    debase-ruby_core_source (3.2.2)
     debug_inspector (1.1.0)
     diff-lcs (1.5.0)
     docile (1.4.0)

--- a/gemfiles/ruby_2.6.10_rails61_mysql2.gemfile.lock
+++ b/gemfiles/ruby_2.6.10_rails61_mysql2.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.14.0)
       datadog-ci (~> 0.1.0)
-      debase-ruby_core_source (= 3.2.1)
+      debase-ruby_core_source (= 3.2.2)
       libdatadog (~> 4.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
@@ -103,7 +103,7 @@ GEM
     cri (2.15.11)
     datadog-ci (0.1.1)
     date (3.3.3)
-    debase-ruby_core_source (3.2.1)
+    debase-ruby_core_source (3.2.2)
     debug_inspector (1.1.0)
     diff-lcs (1.5.0)
     docile (1.4.0)

--- a/gemfiles/ruby_2.6.10_rails61_postgres.gemfile.lock
+++ b/gemfiles/ruby_2.6.10_rails61_postgres.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.14.0)
       datadog-ci (~> 0.1.0)
-      debase-ruby_core_source (= 3.2.1)
+      debase-ruby_core_source (= 3.2.2)
       libdatadog (~> 4.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
@@ -103,7 +103,7 @@ GEM
     cri (2.15.11)
     datadog-ci (0.1.1)
     date (3.3.3)
-    debase-ruby_core_source (3.2.1)
+    debase-ruby_core_source (3.2.2)
     debug_inspector (1.1.0)
     diff-lcs (1.5.0)
     docile (1.4.0)

--- a/gemfiles/ruby_2.6.10_rails61_postgres_redis.gemfile.lock
+++ b/gemfiles/ruby_2.6.10_rails61_postgres_redis.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.14.0)
       datadog-ci (~> 0.1.0)
-      debase-ruby_core_source (= 3.2.1)
+      debase-ruby_core_source (= 3.2.2)
       libdatadog (~> 4.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
@@ -103,7 +103,7 @@ GEM
     cri (2.15.11)
     datadog-ci (0.1.1)
     date (3.3.3)
-    debase-ruby_core_source (3.2.1)
+    debase-ruby_core_source (3.2.2)
     debug_inspector (1.1.0)
     diff-lcs (1.5.0)
     docile (1.4.0)

--- a/gemfiles/ruby_2.6.10_rails61_postgres_sidekiq.gemfile.lock
+++ b/gemfiles/ruby_2.6.10_rails61_postgres_sidekiq.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.14.0)
       datadog-ci (~> 0.1.0)
-      debase-ruby_core_source (= 3.2.1)
+      debase-ruby_core_source (= 3.2.2)
       libdatadog (~> 4.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
@@ -104,7 +104,7 @@ GEM
     cri (2.15.11)
     datadog-ci (0.1.1)
     date (3.3.3)
-    debase-ruby_core_source (3.2.1)
+    debase-ruby_core_source (3.2.2)
     debug_inspector (1.1.0)
     diff-lcs (1.5.0)
     docile (1.4.0)

--- a/gemfiles/ruby_2.6.10_rails61_semantic_logger.gemfile.lock
+++ b/gemfiles/ruby_2.6.10_rails61_semantic_logger.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.14.0)
       datadog-ci (~> 0.1.0)
-      debase-ruby_core_source (= 3.2.1)
+      debase-ruby_core_source (= 3.2.2)
       libdatadog (~> 4.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
@@ -103,7 +103,7 @@ GEM
     cri (2.15.11)
     datadog-ci (0.1.1)
     date (3.3.3)
-    debase-ruby_core_source (3.2.1)
+    debase-ruby_core_source (3.2.2)
     debug_inspector (1.1.0)
     diff-lcs (1.5.0)
     docile (1.4.0)

--- a/gemfiles/ruby_2.6.10_rails6_mysql2.gemfile.lock
+++ b/gemfiles/ruby_2.6.10_rails6_mysql2.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.14.0)
       datadog-ci (~> 0.1.0)
-      debase-ruby_core_source (= 3.2.1)
+      debase-ruby_core_source (= 3.2.2)
       libdatadog (~> 4.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
@@ -99,7 +99,7 @@ GEM
     cri (2.15.11)
     datadog-ci (0.1.1)
     date (3.3.3)
-    debase-ruby_core_source (3.2.1)
+    debase-ruby_core_source (3.2.2)
     debug_inspector (1.1.0)
     diff-lcs (1.5.0)
     docile (1.4.0)

--- a/gemfiles/ruby_2.6.10_rails6_postgres.gemfile.lock
+++ b/gemfiles/ruby_2.6.10_rails6_postgres.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.14.0)
       datadog-ci (~> 0.1.0)
-      debase-ruby_core_source (= 3.2.1)
+      debase-ruby_core_source (= 3.2.2)
       libdatadog (~> 4.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
@@ -99,7 +99,7 @@ GEM
     cri (2.15.11)
     datadog-ci (0.1.1)
     date (3.3.3)
-    debase-ruby_core_source (3.2.1)
+    debase-ruby_core_source (3.2.2)
     debug_inspector (1.1.0)
     diff-lcs (1.5.0)
     docile (1.4.0)

--- a/gemfiles/ruby_2.6.10_rails6_postgres_redis.gemfile.lock
+++ b/gemfiles/ruby_2.6.10_rails6_postgres_redis.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.14.0)
       datadog-ci (~> 0.1.0)
-      debase-ruby_core_source (= 3.2.1)
+      debase-ruby_core_source (= 3.2.2)
       libdatadog (~> 4.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
@@ -99,7 +99,7 @@ GEM
     cri (2.15.11)
     datadog-ci (0.1.1)
     date (3.3.3)
-    debase-ruby_core_source (3.2.1)
+    debase-ruby_core_source (3.2.2)
     debug_inspector (1.1.0)
     diff-lcs (1.5.0)
     docile (1.4.0)

--- a/gemfiles/ruby_2.6.10_rails6_postgres_redis_activesupport.gemfile.lock
+++ b/gemfiles/ruby_2.6.10_rails6_postgres_redis_activesupport.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.14.0)
       datadog-ci (~> 0.1.0)
-      debase-ruby_core_source (= 3.2.1)
+      debase-ruby_core_source (= 3.2.2)
       libdatadog (~> 4.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
@@ -99,7 +99,7 @@ GEM
     cri (2.15.11)
     datadog-ci (0.1.1)
     date (3.3.3)
-    debase-ruby_core_source (3.2.1)
+    debase-ruby_core_source (3.2.2)
     debug_inspector (1.1.0)
     diff-lcs (1.5.0)
     docile (1.4.0)

--- a/gemfiles/ruby_2.6.10_rails6_postgres_sidekiq.gemfile.lock
+++ b/gemfiles/ruby_2.6.10_rails6_postgres_sidekiq.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.14.0)
       datadog-ci (~> 0.1.0)
-      debase-ruby_core_source (= 3.2.1)
+      debase-ruby_core_source (= 3.2.2)
       libdatadog (~> 4.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
@@ -100,7 +100,7 @@ GEM
     cri (2.15.11)
     datadog-ci (0.1.1)
     date (3.3.3)
-    debase-ruby_core_source (3.2.1)
+    debase-ruby_core_source (3.2.2)
     debug_inspector (1.1.0)
     diff-lcs (1.5.0)
     docile (1.4.0)

--- a/gemfiles/ruby_2.6.10_rails6_semantic_logger.gemfile.lock
+++ b/gemfiles/ruby_2.6.10_rails6_semantic_logger.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.14.0)
       datadog-ci (~> 0.1.0)
-      debase-ruby_core_source (= 3.2.1)
+      debase-ruby_core_source (= 3.2.2)
       libdatadog (~> 4.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
@@ -99,7 +99,7 @@ GEM
     cri (2.15.11)
     datadog-ci (0.1.1)
     date (3.3.3)
-    debase-ruby_core_source (3.2.1)
+    debase-ruby_core_source (3.2.2)
     debug_inspector (1.1.0)
     diff-lcs (1.5.0)
     docile (1.4.0)

--- a/gemfiles/ruby_2.6.10_redis_3.gemfile.lock
+++ b/gemfiles/ruby_2.6.10_redis_3.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.14.0)
       datadog-ci (~> 0.1.0)
-      debase-ruby_core_source (= 3.2.1)
+      debase-ruby_core_source (= 3.2.2)
       libdatadog (~> 4.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
@@ -42,7 +42,7 @@ GEM
       rexml
     cri (2.15.11)
     datadog-ci (0.1.1)
-    debase-ruby_core_source (3.2.1)
+    debase-ruby_core_source (3.2.2)
     debug_inspector (1.1.0)
     diff-lcs (1.5.0)
     docile (1.4.0)

--- a/gemfiles/ruby_2.6.10_redis_4.gemfile.lock
+++ b/gemfiles/ruby_2.6.10_redis_4.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.14.0)
       datadog-ci (~> 0.1.0)
-      debase-ruby_core_source (= 3.2.1)
+      debase-ruby_core_source (= 3.2.2)
       libdatadog (~> 4.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
@@ -42,7 +42,7 @@ GEM
       rexml
     cri (2.15.11)
     datadog-ci (0.1.1)
-    debase-ruby_core_source (3.2.1)
+    debase-ruby_core_source (3.2.2)
     debug_inspector (1.1.0)
     diff-lcs (1.5.0)
     docile (1.4.0)

--- a/gemfiles/ruby_2.6.10_redis_5.gemfile.lock
+++ b/gemfiles/ruby_2.6.10_redis_5.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.14.0)
       datadog-ci (~> 0.1.0)
-      debase-ruby_core_source (= 3.2.1)
+      debase-ruby_core_source (= 3.2.2)
       libdatadog (~> 4.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
@@ -43,7 +43,7 @@ GEM
       rexml
     cri (2.15.11)
     datadog-ci (0.1.1)
-    debase-ruby_core_source (3.2.1)
+    debase-ruby_core_source (3.2.2)
     debug_inspector (1.1.0)
     diff-lcs (1.5.0)
     docile (1.4.0)

--- a/gemfiles/ruby_2.6.10_relational_db.gemfile.lock
+++ b/gemfiles/ruby_2.6.10_relational_db.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.14.0)
       datadog-ci (~> 0.1.0)
-      debase-ruby_core_source (= 3.2.1)
+      debase-ruby_core_source (= 3.2.2)
       libdatadog (~> 4.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
@@ -53,7 +53,7 @@ GEM
       rexml
     cri (2.15.11)
     datadog-ci (0.1.1)
-    debase-ruby_core_source (3.2.1)
+    debase-ruby_core_source (3.2.2)
     debug_inspector (1.1.0)
     delayed_job (4.1.11)
       activesupport (>= 3.0, < 8.0)

--- a/gemfiles/ruby_2.6.10_resque2_redis3.gemfile.lock
+++ b/gemfiles/ruby_2.6.10_resque2_redis3.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.14.0)
       datadog-ci (~> 0.1.0)
-      debase-ruby_core_source (= 3.2.1)
+      debase-ruby_core_source (= 3.2.2)
       libdatadog (~> 4.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
@@ -42,7 +42,7 @@ GEM
       rexml
     cri (2.15.11)
     datadog-ci (0.1.1)
-    debase-ruby_core_source (3.2.1)
+    debase-ruby_core_source (3.2.2)
     debug_inspector (1.1.0)
     diff-lcs (1.5.0)
     docile (1.4.0)

--- a/gemfiles/ruby_2.6.10_resque2_redis4.gemfile.lock
+++ b/gemfiles/ruby_2.6.10_resque2_redis4.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.14.0)
       datadog-ci (~> 0.1.0)
-      debase-ruby_core_source (= 3.2.1)
+      debase-ruby_core_source (= 3.2.2)
       libdatadog (~> 4.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
@@ -42,7 +42,7 @@ GEM
       rexml
     cri (2.15.11)
     datadog-ci (0.1.1)
-    debase-ruby_core_source (3.2.1)
+    debase-ruby_core_source (3.2.2)
     debug_inspector (1.1.0)
     diff-lcs (1.5.0)
     docile (1.4.0)

--- a/gemfiles/ruby_2.6.10_sinatra.gemfile.lock
+++ b/gemfiles/ruby_2.6.10_sinatra.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.14.0)
       datadog-ci (~> 0.1.0)
-      debase-ruby_core_source (= 3.2.1)
+      debase-ruby_core_source (= 3.2.2)
       libdatadog (~> 4.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
@@ -42,7 +42,7 @@ GEM
       rexml
     cri (2.15.11)
     datadog-ci (0.1.1)
-    debase-ruby_core_source (3.2.1)
+    debase-ruby_core_source (3.2.2)
     debug_inspector (1.1.0)
     diff-lcs (1.5.0)
     docile (1.4.0)

--- a/gemfiles/ruby_2.7.6_activesupport.gemfile.lock
+++ b/gemfiles/ruby_2.7.6_activesupport.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.14.0)
       datadog-ci (~> 0.1.0)
-      debase-ruby_core_source (= 3.2.1)
+      debase-ruby_core_source (= 3.2.2)
       libdatadog (~> 4.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
@@ -71,7 +71,7 @@ GEM
     crass (1.0.6)
     cri (2.15.11)
     datadog-ci (0.1.1)
-    debase-ruby_core_source (3.2.1)
+    debase-ruby_core_source (3.2.2)
     debug_inspector (1.1.0)
     diff-lcs (1.5.0)
     digest-crc (0.6.5)

--- a/gemfiles/ruby_2.7.6_aws.gemfile.lock
+++ b/gemfiles/ruby_2.7.6_aws.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.14.0)
       datadog-ci (~> 0.1.0)
-      debase-ruby_core_source (= 3.2.1)
+      debase-ruby_core_source (= 3.2.2)
       libdatadog (~> 4.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
@@ -1463,7 +1463,7 @@ GEM
       rexml
     cri (2.15.11)
     datadog-ci (0.1.1)
-    debase-ruby_core_source (3.2.1)
+    debase-ruby_core_source (3.2.2)
     debug_inspector (1.1.0)
     diff-lcs (1.5.0)
     docile (1.4.0)

--- a/gemfiles/ruby_2.7.6_contrib.gemfile.lock
+++ b/gemfiles/ruby_2.7.6_contrib.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.14.0)
       datadog-ci (~> 0.1.0)
-      debase-ruby_core_source (= 3.2.1)
+      debase-ruby_core_source (= 3.2.2)
       libdatadog (~> 4.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
@@ -49,7 +49,7 @@ GEM
     cri (2.15.11)
     dalli (3.2.4)
     datadog-ci (0.1.1)
-    debase-ruby_core_source (3.2.1)
+    debase-ruby_core_source (3.2.2)
     debug_inspector (1.1.0)
     diff-lcs (1.5.0)
     docile (1.4.0)

--- a/gemfiles/ruby_2.7.6_contrib_old.gemfile.lock
+++ b/gemfiles/ruby_2.7.6_contrib_old.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.14.0)
       datadog-ci (~> 0.1.0)
-      debase-ruby_core_source (= 3.2.1)
+      debase-ruby_core_source (= 3.2.2)
       libdatadog (~> 4.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
@@ -47,7 +47,7 @@ GEM
     daemons (1.4.1)
     dalli (2.7.11)
     datadog-ci (0.1.1)
-    debase-ruby_core_source (3.2.1)
+    debase-ruby_core_source (3.2.2)
     debug_inspector (1.1.0)
     diff-lcs (1.5.0)
     docile (1.4.0)

--- a/gemfiles/ruby_2.7.6_core_old.gemfile.lock
+++ b/gemfiles/ruby_2.7.6_core_old.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.14.0)
       datadog-ci (~> 0.1.0)
-      debase-ruby_core_source (= 3.2.1)
+      debase-ruby_core_source (= 3.2.2)
       libdatadog (~> 4.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
@@ -42,7 +42,7 @@ GEM
       rexml
     cri (2.15.11)
     datadog-ci (0.1.1)
-    debase-ruby_core_source (3.2.1)
+    debase-ruby_core_source (3.2.2)
     debug_inspector (1.1.0)
     diff-lcs (1.5.0)
     docile (1.4.0)

--- a/gemfiles/ruby_2.7.6_hanami_1.gemfile.lock
+++ b/gemfiles/ruby_2.7.6_hanami_1.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.14.0)
       datadog-ci (~> 0.1.0)
-      debase-ruby_core_source (= 3.2.1)
+      debase-ruby_core_source (= 3.2.2)
       libdatadog (~> 4.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
@@ -43,7 +43,7 @@ GEM
     cri (2.15.11)
     datadog-ci (0.1.1)
     date (3.3.3)
-    debase-ruby_core_source (3.2.1)
+    debase-ruby_core_source (3.2.2)
     debug_inspector (1.1.0)
     diff-lcs (1.5.0)
     docile (1.4.0)

--- a/gemfiles/ruby_2.7.6_http.gemfile.lock
+++ b/gemfiles/ruby_2.7.6_http.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.14.0)
       datadog-ci (~> 0.1.0)
-      debase-ruby_core_source (= 3.2.1)
+      debase-ruby_core_source (= 3.2.2)
       libdatadog (~> 4.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
@@ -42,7 +42,7 @@ GEM
       rexml
     cri (2.15.11)
     datadog-ci (0.1.1)
-    debase-ruby_core_source (3.2.1)
+    debase-ruby_core_source (3.2.2)
     debug_inspector (1.1.0)
     diff-lcs (1.5.0)
     docile (1.4.0)

--- a/gemfiles/ruby_2.7.6_opentelemetry.gemfile.lock
+++ b/gemfiles/ruby_2.7.6_opentelemetry.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.14.0)
       datadog-ci (~> 0.1.0)
-      debase-ruby_core_source (= 3.2.1)
+      debase-ruby_core_source (= 3.2.2)
       libdatadog (~> 4.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
@@ -42,7 +42,7 @@ GEM
       rexml
     cri (2.15.11)
     datadog-ci (0.1.1)
-    debase-ruby_core_source (3.2.1)
+    debase-ruby_core_source (3.2.2)
     debug_inspector (1.1.0)
     diff-lcs (1.5.0)
     docile (1.4.0)

--- a/gemfiles/ruby_2.7.6_opentracing.gemfile.lock
+++ b/gemfiles/ruby_2.7.6_opentracing.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.14.0)
       datadog-ci (~> 0.1.0)
-      debase-ruby_core_source (= 3.2.1)
+      debase-ruby_core_source (= 3.2.2)
       libdatadog (~> 4.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
@@ -43,7 +43,7 @@ GEM
       rexml
     cri (2.15.11)
     datadog-ci (0.1.1)
-    debase-ruby_core_source (3.2.1)
+    debase-ruby_core_source (3.2.2)
     debug_inspector (1.1.0)
     diff-lcs (1.5.0)
     docile (1.4.0)

--- a/gemfiles/ruby_2.7.6_rack_1.gemfile.lock
+++ b/gemfiles/ruby_2.7.6_rack_1.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.14.0)
       datadog-ci (~> 0.1.0)
-      debase-ruby_core_source (= 3.2.1)
+      debase-ruby_core_source (= 3.2.2)
       libdatadog (~> 4.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
@@ -42,7 +42,7 @@ GEM
       rexml
     cri (2.15.11)
     datadog-ci (0.1.1)
-    debase-ruby_core_source (3.2.1)
+    debase-ruby_core_source (3.2.2)
     debug_inspector (1.1.0)
     diff-lcs (1.5.0)
     docile (1.4.0)

--- a/gemfiles/ruby_2.7.6_rack_2.gemfile.lock
+++ b/gemfiles/ruby_2.7.6_rack_2.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.14.0)
       datadog-ci (~> 0.1.0)
-      debase-ruby_core_source (= 3.2.1)
+      debase-ruby_core_source (= 3.2.2)
       libdatadog (~> 4.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
@@ -42,7 +42,7 @@ GEM
       rexml
     cri (2.15.11)
     datadog-ci (0.1.1)
-    debase-ruby_core_source (3.2.1)
+    debase-ruby_core_source (3.2.2)
     debug_inspector (1.1.0)
     diff-lcs (1.5.0)
     docile (1.4.0)

--- a/gemfiles/ruby_2.7.6_rack_3.gemfile.lock
+++ b/gemfiles/ruby_2.7.6_rack_3.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.14.0)
       datadog-ci (~> 0.1.0)
-      debase-ruby_core_source (= 3.2.1)
+      debase-ruby_core_source (= 3.2.2)
       libdatadog (~> 4.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
@@ -42,7 +42,7 @@ GEM
       rexml
     cri (2.15.11)
     datadog-ci (0.1.1)
-    debase-ruby_core_source (3.2.1)
+    debase-ruby_core_source (3.2.2)
     debug_inspector (1.1.0)
     diff-lcs (1.5.0)
     docile (1.4.0)

--- a/gemfiles/ruby_2.7.6_rails5_mysql2.gemfile.lock
+++ b/gemfiles/ruby_2.7.6_rails5_mysql2.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.14.0)
       datadog-ci (~> 0.1.0)
-      debase-ruby_core_source (= 3.2.1)
+      debase-ruby_core_source (= 3.2.2)
       libdatadog (~> 4.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
@@ -86,7 +86,7 @@ GEM
     cri (2.15.11)
     datadog-ci (0.1.1)
     date (3.3.3)
-    debase-ruby_core_source (3.2.1)
+    debase-ruby_core_source (3.2.2)
     debug_inspector (1.1.0)
     diff-lcs (1.5.0)
     docile (1.4.0)

--- a/gemfiles/ruby_2.7.6_rails5_postgres.gemfile.lock
+++ b/gemfiles/ruby_2.7.6_rails5_postgres.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.14.0)
       datadog-ci (~> 0.1.0)
-      debase-ruby_core_source (= 3.2.1)
+      debase-ruby_core_source (= 3.2.2)
       libdatadog (~> 4.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
@@ -86,7 +86,7 @@ GEM
     cri (2.15.11)
     datadog-ci (0.1.1)
     date (3.3.3)
-    debase-ruby_core_source (3.2.1)
+    debase-ruby_core_source (3.2.2)
     debug_inspector (1.1.0)
     diff-lcs (1.5.0)
     docile (1.4.0)

--- a/gemfiles/ruby_2.7.6_rails5_postgres_redis.gemfile.lock
+++ b/gemfiles/ruby_2.7.6_rails5_postgres_redis.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.14.0)
       datadog-ci (~> 0.1.0)
-      debase-ruby_core_source (= 3.2.1)
+      debase-ruby_core_source (= 3.2.2)
       libdatadog (~> 4.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
@@ -86,7 +86,7 @@ GEM
     cri (2.15.11)
     datadog-ci (0.1.1)
     date (3.3.3)
-    debase-ruby_core_source (3.2.1)
+    debase-ruby_core_source (3.2.2)
     debug_inspector (1.1.0)
     diff-lcs (1.5.0)
     docile (1.4.0)

--- a/gemfiles/ruby_2.7.6_rails5_postgres_redis_activesupport.gemfile.lock
+++ b/gemfiles/ruby_2.7.6_rails5_postgres_redis_activesupport.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.14.0)
       datadog-ci (~> 0.1.0)
-      debase-ruby_core_source (= 3.2.1)
+      debase-ruby_core_source (= 3.2.2)
       libdatadog (~> 4.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
@@ -86,7 +86,7 @@ GEM
     cri (2.15.11)
     datadog-ci (0.1.1)
     date (3.3.3)
-    debase-ruby_core_source (3.2.1)
+    debase-ruby_core_source (3.2.2)
     debug_inspector (1.1.0)
     diff-lcs (1.5.0)
     docile (1.4.0)

--- a/gemfiles/ruby_2.7.6_rails5_postgres_sidekiq.gemfile.lock
+++ b/gemfiles/ruby_2.7.6_rails5_postgres_sidekiq.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.14.0)
       datadog-ci (~> 0.1.0)
-      debase-ruby_core_source (= 3.2.1)
+      debase-ruby_core_source (= 3.2.2)
       libdatadog (~> 4.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
@@ -87,7 +87,7 @@ GEM
     cri (2.15.11)
     datadog-ci (0.1.1)
     date (3.3.3)
-    debase-ruby_core_source (3.2.1)
+    debase-ruby_core_source (3.2.2)
     debug_inspector (1.1.0)
     diff-lcs (1.5.0)
     docile (1.4.0)

--- a/gemfiles/ruby_2.7.6_rails5_semantic_logger.gemfile.lock
+++ b/gemfiles/ruby_2.7.6_rails5_semantic_logger.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.14.0)
       datadog-ci (~> 0.1.0)
-      debase-ruby_core_source (= 3.2.1)
+      debase-ruby_core_source (= 3.2.2)
       libdatadog (~> 4.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
@@ -86,7 +86,7 @@ GEM
     cri (2.15.11)
     datadog-ci (0.1.1)
     date (3.3.3)
-    debase-ruby_core_source (3.2.1)
+    debase-ruby_core_source (3.2.2)
     debug_inspector (1.1.0)
     diff-lcs (1.5.0)
     docile (1.4.0)

--- a/gemfiles/ruby_2.7.6_rails61_mysql2.gemfile.lock
+++ b/gemfiles/ruby_2.7.6_rails61_mysql2.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.14.0)
       datadog-ci (~> 0.1.0)
-      debase-ruby_core_source (= 3.2.1)
+      debase-ruby_core_source (= 3.2.2)
       libdatadog (~> 4.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
@@ -103,7 +103,7 @@ GEM
     cri (2.15.11)
     datadog-ci (0.1.1)
     date (3.3.3)
-    debase-ruby_core_source (3.2.1)
+    debase-ruby_core_source (3.2.2)
     debug_inspector (1.1.0)
     diff-lcs (1.5.0)
     docile (1.4.0)

--- a/gemfiles/ruby_2.7.6_rails61_postgres.gemfile.lock
+++ b/gemfiles/ruby_2.7.6_rails61_postgres.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.14.0)
       datadog-ci (~> 0.1.0)
-      debase-ruby_core_source (= 3.2.1)
+      debase-ruby_core_source (= 3.2.2)
       libdatadog (~> 4.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
@@ -103,7 +103,7 @@ GEM
     cri (2.15.11)
     datadog-ci (0.1.1)
     date (3.3.3)
-    debase-ruby_core_source (3.2.1)
+    debase-ruby_core_source (3.2.2)
     debug_inspector (1.1.0)
     diff-lcs (1.5.0)
     docile (1.4.0)

--- a/gemfiles/ruby_2.7.6_rails61_postgres_redis.gemfile.lock
+++ b/gemfiles/ruby_2.7.6_rails61_postgres_redis.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.14.0)
       datadog-ci (~> 0.1.0)
-      debase-ruby_core_source (= 3.2.1)
+      debase-ruby_core_source (= 3.2.2)
       libdatadog (~> 4.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
@@ -103,7 +103,7 @@ GEM
     cri (2.15.11)
     datadog-ci (0.1.1)
     date (3.3.3)
-    debase-ruby_core_source (3.2.1)
+    debase-ruby_core_source (3.2.2)
     debug_inspector (1.1.0)
     diff-lcs (1.5.0)
     docile (1.4.0)

--- a/gemfiles/ruby_2.7.6_rails61_postgres_sidekiq.gemfile.lock
+++ b/gemfiles/ruby_2.7.6_rails61_postgres_sidekiq.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.14.0)
       datadog-ci (~> 0.1.0)
-      debase-ruby_core_source (= 3.2.1)
+      debase-ruby_core_source (= 3.2.2)
       libdatadog (~> 4.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
@@ -104,7 +104,7 @@ GEM
     cri (2.15.11)
     datadog-ci (0.1.1)
     date (3.3.3)
-    debase-ruby_core_source (3.2.1)
+    debase-ruby_core_source (3.2.2)
     debug_inspector (1.1.0)
     diff-lcs (1.5.0)
     docile (1.4.0)

--- a/gemfiles/ruby_2.7.6_rails61_semantic_logger.gemfile.lock
+++ b/gemfiles/ruby_2.7.6_rails61_semantic_logger.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.14.0)
       datadog-ci (~> 0.1.0)
-      debase-ruby_core_source (= 3.2.1)
+      debase-ruby_core_source (= 3.2.2)
       libdatadog (~> 4.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
@@ -103,7 +103,7 @@ GEM
     cri (2.15.11)
     datadog-ci (0.1.1)
     date (3.3.3)
-    debase-ruby_core_source (3.2.1)
+    debase-ruby_core_source (3.2.2)
     debug_inspector (1.1.0)
     diff-lcs (1.5.0)
     docile (1.4.0)

--- a/gemfiles/ruby_2.7.6_rails6_mysql2.gemfile.lock
+++ b/gemfiles/ruby_2.7.6_rails6_mysql2.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.14.0)
       datadog-ci (~> 0.1.0)
-      debase-ruby_core_source (= 3.2.1)
+      debase-ruby_core_source (= 3.2.2)
       libdatadog (~> 4.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
@@ -99,7 +99,7 @@ GEM
     cri (2.15.11)
     datadog-ci (0.1.1)
     date (3.3.3)
-    debase-ruby_core_source (3.2.1)
+    debase-ruby_core_source (3.2.2)
     debug_inspector (1.1.0)
     diff-lcs (1.5.0)
     docile (1.4.0)

--- a/gemfiles/ruby_2.7.6_rails6_postgres.gemfile.lock
+++ b/gemfiles/ruby_2.7.6_rails6_postgres.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.14.0)
       datadog-ci (~> 0.1.0)
-      debase-ruby_core_source (= 3.2.1)
+      debase-ruby_core_source (= 3.2.2)
       libdatadog (~> 4.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
@@ -99,7 +99,7 @@ GEM
     cri (2.15.11)
     datadog-ci (0.1.1)
     date (3.3.3)
-    debase-ruby_core_source (3.2.1)
+    debase-ruby_core_source (3.2.2)
     debug_inspector (1.1.0)
     diff-lcs (1.5.0)
     docile (1.4.0)

--- a/gemfiles/ruby_2.7.6_rails6_postgres_redis.gemfile.lock
+++ b/gemfiles/ruby_2.7.6_rails6_postgres_redis.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.14.0)
       datadog-ci (~> 0.1.0)
-      debase-ruby_core_source (= 3.2.1)
+      debase-ruby_core_source (= 3.2.2)
       libdatadog (~> 4.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
@@ -99,7 +99,7 @@ GEM
     cri (2.15.11)
     datadog-ci (0.1.1)
     date (3.3.3)
-    debase-ruby_core_source (3.2.1)
+    debase-ruby_core_source (3.2.2)
     debug_inspector (1.1.0)
     diff-lcs (1.5.0)
     docile (1.4.0)

--- a/gemfiles/ruby_2.7.6_rails6_postgres_redis_activesupport.gemfile.lock
+++ b/gemfiles/ruby_2.7.6_rails6_postgres_redis_activesupport.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.14.0)
       datadog-ci (~> 0.1.0)
-      debase-ruby_core_source (= 3.2.1)
+      debase-ruby_core_source (= 3.2.2)
       libdatadog (~> 4.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
@@ -99,7 +99,7 @@ GEM
     cri (2.15.11)
     datadog-ci (0.1.1)
     date (3.3.3)
-    debase-ruby_core_source (3.2.1)
+    debase-ruby_core_source (3.2.2)
     debug_inspector (1.1.0)
     diff-lcs (1.5.0)
     docile (1.4.0)

--- a/gemfiles/ruby_2.7.6_rails6_postgres_sidekiq.gemfile.lock
+++ b/gemfiles/ruby_2.7.6_rails6_postgres_sidekiq.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.14.0)
       datadog-ci (~> 0.1.0)
-      debase-ruby_core_source (= 3.2.1)
+      debase-ruby_core_source (= 3.2.2)
       libdatadog (~> 4.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
@@ -100,7 +100,7 @@ GEM
     cri (2.15.11)
     datadog-ci (0.1.1)
     date (3.3.3)
-    debase-ruby_core_source (3.2.1)
+    debase-ruby_core_source (3.2.2)
     debug_inspector (1.1.0)
     diff-lcs (1.5.0)
     docile (1.4.0)

--- a/gemfiles/ruby_2.7.6_rails6_semantic_logger.gemfile.lock
+++ b/gemfiles/ruby_2.7.6_rails6_semantic_logger.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.14.0)
       datadog-ci (~> 0.1.0)
-      debase-ruby_core_source (= 3.2.1)
+      debase-ruby_core_source (= 3.2.2)
       libdatadog (~> 4.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
@@ -99,7 +99,7 @@ GEM
     cri (2.15.11)
     datadog-ci (0.1.1)
     date (3.3.3)
-    debase-ruby_core_source (3.2.1)
+    debase-ruby_core_source (3.2.2)
     debug_inspector (1.1.0)
     diff-lcs (1.5.0)
     docile (1.4.0)

--- a/gemfiles/ruby_2.7.6_redis_3.gemfile.lock
+++ b/gemfiles/ruby_2.7.6_redis_3.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.14.0)
       datadog-ci (~> 0.1.0)
-      debase-ruby_core_source (= 3.2.1)
+      debase-ruby_core_source (= 3.2.2)
       libdatadog (~> 4.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
@@ -42,7 +42,7 @@ GEM
       rexml
     cri (2.15.11)
     datadog-ci (0.1.1)
-    debase-ruby_core_source (3.2.1)
+    debase-ruby_core_source (3.2.2)
     debug_inspector (1.1.0)
     diff-lcs (1.5.0)
     docile (1.4.0)

--- a/gemfiles/ruby_2.7.6_redis_4.gemfile.lock
+++ b/gemfiles/ruby_2.7.6_redis_4.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.14.0)
       datadog-ci (~> 0.1.0)
-      debase-ruby_core_source (= 3.2.1)
+      debase-ruby_core_source (= 3.2.2)
       libdatadog (~> 4.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
@@ -42,7 +42,7 @@ GEM
       rexml
     cri (2.15.11)
     datadog-ci (0.1.1)
-    debase-ruby_core_source (3.2.1)
+    debase-ruby_core_source (3.2.2)
     debug_inspector (1.1.0)
     diff-lcs (1.5.0)
     docile (1.4.0)

--- a/gemfiles/ruby_2.7.6_redis_5.gemfile.lock
+++ b/gemfiles/ruby_2.7.6_redis_5.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.14.0)
       datadog-ci (~> 0.1.0)
-      debase-ruby_core_source (= 3.2.1)
+      debase-ruby_core_source (= 3.2.2)
       libdatadog (~> 4.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
@@ -43,7 +43,7 @@ GEM
       rexml
     cri (2.15.11)
     datadog-ci (0.1.1)
-    debase-ruby_core_source (3.2.1)
+    debase-ruby_core_source (3.2.2)
     debug_inspector (1.1.0)
     diff-lcs (1.5.0)
     docile (1.4.0)

--- a/gemfiles/ruby_2.7.6_relational_db.gemfile.lock
+++ b/gemfiles/ruby_2.7.6_relational_db.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.14.0)
       datadog-ci (~> 0.1.0)
-      debase-ruby_core_source (= 3.2.1)
+      debase-ruby_core_source (= 3.2.2)
       libdatadog (~> 4.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
@@ -53,7 +53,7 @@ GEM
       rexml
     cri (2.15.11)
     datadog-ci (0.1.1)
-    debase-ruby_core_source (3.2.1)
+    debase-ruby_core_source (3.2.2)
     debug_inspector (1.1.0)
     delayed_job (4.1.11)
       activesupport (>= 3.0, < 8.0)

--- a/gemfiles/ruby_2.7.6_resque2_redis3.gemfile.lock
+++ b/gemfiles/ruby_2.7.6_resque2_redis3.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.14.0)
       datadog-ci (~> 0.1.0)
-      debase-ruby_core_source (= 3.2.1)
+      debase-ruby_core_source (= 3.2.2)
       libdatadog (~> 4.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
@@ -42,7 +42,7 @@ GEM
       rexml
     cri (2.15.11)
     datadog-ci (0.1.1)
-    debase-ruby_core_source (3.2.1)
+    debase-ruby_core_source (3.2.2)
     debug_inspector (1.1.0)
     diff-lcs (1.5.0)
     docile (1.4.0)

--- a/gemfiles/ruby_2.7.6_resque2_redis4.gemfile.lock
+++ b/gemfiles/ruby_2.7.6_resque2_redis4.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.14.0)
       datadog-ci (~> 0.1.0)
-      debase-ruby_core_source (= 3.2.1)
+      debase-ruby_core_source (= 3.2.2)
       libdatadog (~> 4.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
@@ -42,7 +42,7 @@ GEM
       rexml
     cri (2.15.11)
     datadog-ci (0.1.1)
-    debase-ruby_core_source (3.2.1)
+    debase-ruby_core_source (3.2.2)
     debug_inspector (1.1.0)
     diff-lcs (1.5.0)
     docile (1.4.0)

--- a/gemfiles/ruby_2.7.6_sinatra.gemfile.lock
+++ b/gemfiles/ruby_2.7.6_sinatra.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.14.0)
       datadog-ci (~> 0.1.0)
-      debase-ruby_core_source (= 3.2.1)
+      debase-ruby_core_source (= 3.2.2)
       libdatadog (~> 4.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
@@ -42,7 +42,7 @@ GEM
       rexml
     cri (2.15.11)
     datadog-ci (0.1.1)
-    debase-ruby_core_source (3.2.1)
+    debase-ruby_core_source (3.2.2)
     debug_inspector (1.1.0)
     diff-lcs (1.5.0)
     docile (1.4.0)

--- a/gemfiles/ruby_3.0.4_activesupport.gemfile.lock
+++ b/gemfiles/ruby_3.0.4_activesupport.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.14.0)
       datadog-ci (~> 0.1.0)
-      debase-ruby_core_source (= 3.2.1)
+      debase-ruby_core_source (= 3.2.2)
       libdatadog (~> 4.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
@@ -70,7 +70,7 @@ GEM
     crass (1.0.6)
     cri (2.15.11)
     datadog-ci (0.1.1)
-    debase-ruby_core_source (3.2.1)
+    debase-ruby_core_source (3.2.2)
     debug_inspector (1.1.0)
     diff-lcs (1.5.0)
     digest-crc (0.6.5)

--- a/gemfiles/ruby_3.0.4_aws.gemfile.lock
+++ b/gemfiles/ruby_3.0.4_aws.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.14.0)
       datadog-ci (~> 0.1.0)
-      debase-ruby_core_source (= 3.2.1)
+      debase-ruby_core_source (= 3.2.2)
       libdatadog (~> 4.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
@@ -1463,7 +1463,7 @@ GEM
       rexml
     cri (2.15.11)
     datadog-ci (0.1.1)
-    debase-ruby_core_source (3.2.1)
+    debase-ruby_core_source (3.2.2)
     debug_inspector (1.1.0)
     diff-lcs (1.5.0)
     docile (1.4.0)

--- a/gemfiles/ruby_3.0.4_contrib.gemfile.lock
+++ b/gemfiles/ruby_3.0.4_contrib.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.14.0)
       datadog-ci (~> 0.1.0)
-      debase-ruby_core_source (= 3.2.1)
+      debase-ruby_core_source (= 3.2.2)
       libdatadog (~> 4.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
@@ -49,7 +49,7 @@ GEM
     cri (2.15.11)
     dalli (3.2.4)
     datadog-ci (0.1.1)
-    debase-ruby_core_source (3.2.1)
+    debase-ruby_core_source (3.2.2)
     debug_inspector (1.1.0)
     diff-lcs (1.5.0)
     docile (1.4.0)

--- a/gemfiles/ruby_3.0.4_contrib_old.gemfile.lock
+++ b/gemfiles/ruby_3.0.4_contrib_old.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.14.0)
       datadog-ci (~> 0.1.0)
-      debase-ruby_core_source (= 3.2.1)
+      debase-ruby_core_source (= 3.2.2)
       libdatadog (~> 4.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
@@ -47,7 +47,7 @@ GEM
     daemons (1.4.1)
     dalli (2.7.11)
     datadog-ci (0.1.1)
-    debase-ruby_core_source (3.2.1)
+    debase-ruby_core_source (3.2.2)
     debug_inspector (1.1.0)
     diff-lcs (1.5.0)
     docile (1.4.0)

--- a/gemfiles/ruby_3.0.4_core_old.gemfile.lock
+++ b/gemfiles/ruby_3.0.4_core_old.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.14.0)
       datadog-ci (~> 0.1.0)
-      debase-ruby_core_source (= 3.2.1)
+      debase-ruby_core_source (= 3.2.2)
       libdatadog (~> 4.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
@@ -42,7 +42,7 @@ GEM
       rexml
     cri (2.15.11)
     datadog-ci (0.1.1)
-    debase-ruby_core_source (3.2.1)
+    debase-ruby_core_source (3.2.2)
     debug_inspector (1.1.0)
     diff-lcs (1.5.0)
     docile (1.4.0)

--- a/gemfiles/ruby_3.0.4_http.gemfile.lock
+++ b/gemfiles/ruby_3.0.4_http.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.14.0)
       datadog-ci (~> 0.1.0)
-      debase-ruby_core_source (= 3.2.1)
+      debase-ruby_core_source (= 3.2.2)
       libdatadog (~> 4.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
@@ -42,7 +42,7 @@ GEM
       rexml
     cri (2.15.11)
     datadog-ci (0.1.1)
-    debase-ruby_core_source (3.2.1)
+    debase-ruby_core_source (3.2.2)
     debug_inspector (1.1.0)
     diff-lcs (1.5.0)
     docile (1.4.0)

--- a/gemfiles/ruby_3.0.4_opentelemetry.gemfile.lock
+++ b/gemfiles/ruby_3.0.4_opentelemetry.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.14.0)
       datadog-ci (~> 0.1.0)
-      debase-ruby_core_source (= 3.2.1)
+      debase-ruby_core_source (= 3.2.2)
       libdatadog (~> 4.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
@@ -42,7 +42,7 @@ GEM
       rexml
     cri (2.15.11)
     datadog-ci (0.1.1)
-    debase-ruby_core_source (3.2.1)
+    debase-ruby_core_source (3.2.2)
     debug_inspector (1.1.0)
     diff-lcs (1.5.0)
     docile (1.4.0)

--- a/gemfiles/ruby_3.0.4_opentracing.gemfile.lock
+++ b/gemfiles/ruby_3.0.4_opentracing.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.14.0)
       datadog-ci (~> 0.1.0)
-      debase-ruby_core_source (= 3.2.1)
+      debase-ruby_core_source (= 3.2.2)
       libdatadog (~> 4.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
@@ -43,7 +43,7 @@ GEM
       rexml
     cri (2.15.11)
     datadog-ci (0.1.1)
-    debase-ruby_core_source (3.2.1)
+    debase-ruby_core_source (3.2.2)
     debug_inspector (1.1.0)
     diff-lcs (1.5.0)
     docile (1.4.0)

--- a/gemfiles/ruby_3.0.4_rack_1.gemfile.lock
+++ b/gemfiles/ruby_3.0.4_rack_1.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.14.0)
       datadog-ci (~> 0.1.0)
-      debase-ruby_core_source (= 3.2.1)
+      debase-ruby_core_source (= 3.2.2)
       libdatadog (~> 4.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
@@ -42,7 +42,7 @@ GEM
       rexml
     cri (2.15.11)
     datadog-ci (0.1.1)
-    debase-ruby_core_source (3.2.1)
+    debase-ruby_core_source (3.2.2)
     debug_inspector (1.1.0)
     diff-lcs (1.5.0)
     docile (1.4.0)

--- a/gemfiles/ruby_3.0.4_rack_2.gemfile.lock
+++ b/gemfiles/ruby_3.0.4_rack_2.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.14.0)
       datadog-ci (~> 0.1.0)
-      debase-ruby_core_source (= 3.2.1)
+      debase-ruby_core_source (= 3.2.2)
       libdatadog (~> 4.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
@@ -42,7 +42,7 @@ GEM
       rexml
     cri (2.15.11)
     datadog-ci (0.1.1)
-    debase-ruby_core_source (3.2.1)
+    debase-ruby_core_source (3.2.2)
     debug_inspector (1.1.0)
     diff-lcs (1.5.0)
     docile (1.4.0)

--- a/gemfiles/ruby_3.0.4_rack_3.gemfile.lock
+++ b/gemfiles/ruby_3.0.4_rack_3.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.14.0)
       datadog-ci (~> 0.1.0)
-      debase-ruby_core_source (= 3.2.1)
+      debase-ruby_core_source (= 3.2.2)
       libdatadog (~> 4.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
@@ -42,7 +42,7 @@ GEM
       rexml
     cri (2.15.11)
     datadog-ci (0.1.1)
-    debase-ruby_core_source (3.2.1)
+    debase-ruby_core_source (3.2.2)
     debug_inspector (1.1.0)
     diff-lcs (1.5.0)
     docile (1.4.0)

--- a/gemfiles/ruby_3.0.4_rails61_mysql2.gemfile.lock
+++ b/gemfiles/ruby_3.0.4_rails61_mysql2.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.14.0)
       datadog-ci (~> 0.1.0)
-      debase-ruby_core_source (= 3.2.1)
+      debase-ruby_core_source (= 3.2.2)
       libdatadog (~> 4.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
@@ -103,7 +103,7 @@ GEM
     cri (2.15.11)
     datadog-ci (0.1.1)
     date (3.3.3)
-    debase-ruby_core_source (3.2.1)
+    debase-ruby_core_source (3.2.2)
     debug_inspector (1.1.0)
     diff-lcs (1.5.0)
     docile (1.4.0)

--- a/gemfiles/ruby_3.0.4_rails61_postgres.gemfile.lock
+++ b/gemfiles/ruby_3.0.4_rails61_postgres.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.14.0)
       datadog-ci (~> 0.1.0)
-      debase-ruby_core_source (= 3.2.1)
+      debase-ruby_core_source (= 3.2.2)
       libdatadog (~> 4.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
@@ -103,7 +103,7 @@ GEM
     cri (2.15.11)
     datadog-ci (0.1.1)
     date (3.3.3)
-    debase-ruby_core_source (3.2.1)
+    debase-ruby_core_source (3.2.2)
     debug_inspector (1.1.0)
     diff-lcs (1.5.0)
     docile (1.4.0)

--- a/gemfiles/ruby_3.0.4_rails61_postgres_redis.gemfile.lock
+++ b/gemfiles/ruby_3.0.4_rails61_postgres_redis.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.14.0)
       datadog-ci (~> 0.1.0)
-      debase-ruby_core_source (= 3.2.1)
+      debase-ruby_core_source (= 3.2.2)
       libdatadog (~> 4.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
@@ -103,7 +103,7 @@ GEM
     cri (2.15.11)
     datadog-ci (0.1.1)
     date (3.3.3)
-    debase-ruby_core_source (3.2.1)
+    debase-ruby_core_source (3.2.2)
     debug_inspector (1.1.0)
     diff-lcs (1.5.0)
     docile (1.4.0)

--- a/gemfiles/ruby_3.0.4_rails61_postgres_sidekiq.gemfile.lock
+++ b/gemfiles/ruby_3.0.4_rails61_postgres_sidekiq.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.14.0)
       datadog-ci (~> 0.1.0)
-      debase-ruby_core_source (= 3.2.1)
+      debase-ruby_core_source (= 3.2.2)
       libdatadog (~> 4.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
@@ -104,7 +104,7 @@ GEM
     cri (2.15.11)
     datadog-ci (0.1.1)
     date (3.3.3)
-    debase-ruby_core_source (3.2.1)
+    debase-ruby_core_source (3.2.2)
     debug_inspector (1.1.0)
     diff-lcs (1.5.0)
     docile (1.4.0)

--- a/gemfiles/ruby_3.0.4_rails61_semantic_logger.gemfile.lock
+++ b/gemfiles/ruby_3.0.4_rails61_semantic_logger.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.14.0)
       datadog-ci (~> 0.1.0)
-      debase-ruby_core_source (= 3.2.1)
+      debase-ruby_core_source (= 3.2.2)
       libdatadog (~> 4.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
@@ -103,7 +103,7 @@ GEM
     cri (2.15.11)
     datadog-ci (0.1.1)
     date (3.3.3)
-    debase-ruby_core_source (3.2.1)
+    debase-ruby_core_source (3.2.2)
     debug_inspector (1.1.0)
     diff-lcs (1.5.0)
     docile (1.4.0)

--- a/gemfiles/ruby_3.0.4_redis_3.gemfile.lock
+++ b/gemfiles/ruby_3.0.4_redis_3.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.14.0)
       datadog-ci (~> 0.1.0)
-      debase-ruby_core_source (= 3.2.1)
+      debase-ruby_core_source (= 3.2.2)
       libdatadog (~> 4.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
@@ -42,7 +42,7 @@ GEM
       rexml
     cri (2.15.11)
     datadog-ci (0.1.1)
-    debase-ruby_core_source (3.2.1)
+    debase-ruby_core_source (3.2.2)
     debug_inspector (1.1.0)
     diff-lcs (1.5.0)
     docile (1.4.0)

--- a/gemfiles/ruby_3.0.4_redis_4.gemfile.lock
+++ b/gemfiles/ruby_3.0.4_redis_4.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.14.0)
       datadog-ci (~> 0.1.0)
-      debase-ruby_core_source (= 3.2.1)
+      debase-ruby_core_source (= 3.2.2)
       libdatadog (~> 4.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
@@ -42,7 +42,7 @@ GEM
       rexml
     cri (2.15.11)
     datadog-ci (0.1.1)
-    debase-ruby_core_source (3.2.1)
+    debase-ruby_core_source (3.2.2)
     debug_inspector (1.1.0)
     diff-lcs (1.5.0)
     docile (1.4.0)

--- a/gemfiles/ruby_3.0.4_redis_5.gemfile.lock
+++ b/gemfiles/ruby_3.0.4_redis_5.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.14.0)
       datadog-ci (~> 0.1.0)
-      debase-ruby_core_source (= 3.2.1)
+      debase-ruby_core_source (= 3.2.2)
       libdatadog (~> 4.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
@@ -43,7 +43,7 @@ GEM
       rexml
     cri (2.15.11)
     datadog-ci (0.1.1)
-    debase-ruby_core_source (3.2.1)
+    debase-ruby_core_source (3.2.2)
     debug_inspector (1.1.0)
     diff-lcs (1.5.0)
     docile (1.4.0)

--- a/gemfiles/ruby_3.0.4_relational_db.gemfile.lock
+++ b/gemfiles/ruby_3.0.4_relational_db.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.14.0)
       datadog-ci (~> 0.1.0)
-      debase-ruby_core_source (= 3.2.1)
+      debase-ruby_core_source (= 3.2.2)
       libdatadog (~> 4.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
@@ -52,7 +52,7 @@ GEM
       rexml
     cri (2.15.11)
     datadog-ci (0.1.1)
-    debase-ruby_core_source (3.2.1)
+    debase-ruby_core_source (3.2.2)
     debug_inspector (1.1.0)
     delayed_job (4.1.11)
       activesupport (>= 3.0, < 8.0)

--- a/gemfiles/ruby_3.0.4_resque2_redis3.gemfile.lock
+++ b/gemfiles/ruby_3.0.4_resque2_redis3.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.14.0)
       datadog-ci (~> 0.1.0)
-      debase-ruby_core_source (= 3.2.1)
+      debase-ruby_core_source (= 3.2.2)
       libdatadog (~> 4.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
@@ -42,7 +42,7 @@ GEM
       rexml
     cri (2.15.11)
     datadog-ci (0.1.1)
-    debase-ruby_core_source (3.2.1)
+    debase-ruby_core_source (3.2.2)
     debug_inspector (1.1.0)
     diff-lcs (1.5.0)
     docile (1.4.0)

--- a/gemfiles/ruby_3.0.4_resque2_redis4.gemfile.lock
+++ b/gemfiles/ruby_3.0.4_resque2_redis4.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.14.0)
       datadog-ci (~> 0.1.0)
-      debase-ruby_core_source (= 3.2.1)
+      debase-ruby_core_source (= 3.2.2)
       libdatadog (~> 4.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
@@ -43,7 +43,7 @@ GEM
       rexml
     cri (2.15.11)
     datadog-ci (0.1.1)
-    debase-ruby_core_source (3.2.1)
+    debase-ruby_core_source (3.2.2)
     debug_inspector (1.1.0)
     diff-lcs (1.5.0)
     docile (1.4.0)

--- a/gemfiles/ruby_3.0.4_sinatra.gemfile.lock
+++ b/gemfiles/ruby_3.0.4_sinatra.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.14.0)
       datadog-ci (~> 0.1.0)
-      debase-ruby_core_source (= 3.2.1)
+      debase-ruby_core_source (= 3.2.2)
       libdatadog (~> 4.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
@@ -42,7 +42,7 @@ GEM
       rexml
     cri (2.15.11)
     datadog-ci (0.1.1)
-    debase-ruby_core_source (3.2.1)
+    debase-ruby_core_source (3.2.2)
     debug_inspector (1.1.0)
     diff-lcs (1.5.0)
     docile (1.4.0)

--- a/gemfiles/ruby_3.1.2_activesupport.gemfile.lock
+++ b/gemfiles/ruby_3.1.2_activesupport.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.14.0)
       datadog-ci (~> 0.1.0)
-      debase-ruby_core_source (= 3.2.1)
+      debase-ruby_core_source (= 3.2.2)
       libdatadog (~> 4.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
@@ -70,7 +70,7 @@ GEM
     crass (1.0.6)
     cri (2.15.11)
     datadog-ci (0.1.1)
-    debase-ruby_core_source (3.2.1)
+    debase-ruby_core_source (3.2.2)
     debug_inspector (1.1.0)
     diff-lcs (1.5.0)
     digest-crc (0.6.5)

--- a/gemfiles/ruby_3.1.2_aws.gemfile.lock
+++ b/gemfiles/ruby_3.1.2_aws.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.14.0)
       datadog-ci (~> 0.1.0)
-      debase-ruby_core_source (= 3.2.1)
+      debase-ruby_core_source (= 3.2.2)
       libdatadog (~> 4.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
@@ -1463,7 +1463,7 @@ GEM
       rexml
     cri (2.15.11)
     datadog-ci (0.1.1)
-    debase-ruby_core_source (3.2.1)
+    debase-ruby_core_source (3.2.2)
     debug_inspector (1.1.0)
     diff-lcs (1.5.0)
     docile (1.4.0)

--- a/gemfiles/ruby_3.1.2_contrib.gemfile.lock
+++ b/gemfiles/ruby_3.1.2_contrib.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.14.0)
       datadog-ci (~> 0.1.0)
-      debase-ruby_core_source (= 3.2.1)
+      debase-ruby_core_source (= 3.2.2)
       libdatadog (~> 4.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
@@ -49,7 +49,7 @@ GEM
     cri (2.15.11)
     dalli (3.2.4)
     datadog-ci (0.1.1)
-    debase-ruby_core_source (3.2.1)
+    debase-ruby_core_source (3.2.2)
     debug_inspector (1.1.0)
     diff-lcs (1.5.0)
     docile (1.4.0)

--- a/gemfiles/ruby_3.1.2_contrib_old.gemfile.lock
+++ b/gemfiles/ruby_3.1.2_contrib_old.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.14.0)
       datadog-ci (~> 0.1.0)
-      debase-ruby_core_source (= 3.2.1)
+      debase-ruby_core_source (= 3.2.2)
       libdatadog (~> 4.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
@@ -47,7 +47,7 @@ GEM
     daemons (1.4.1)
     dalli (2.7.11)
     datadog-ci (0.1.1)
-    debase-ruby_core_source (3.2.1)
+    debase-ruby_core_source (3.2.2)
     debug_inspector (1.1.0)
     diff-lcs (1.5.0)
     docile (1.4.0)

--- a/gemfiles/ruby_3.1.2_core_old.gemfile.lock
+++ b/gemfiles/ruby_3.1.2_core_old.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.14.0)
       datadog-ci (~> 0.1.0)
-      debase-ruby_core_source (= 3.2.1)
+      debase-ruby_core_source (= 3.2.2)
       libdatadog (~> 4.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
@@ -42,7 +42,7 @@ GEM
       rexml
     cri (2.15.11)
     datadog-ci (0.1.1)
-    debase-ruby_core_source (3.2.1)
+    debase-ruby_core_source (3.2.2)
     debug_inspector (1.1.0)
     diff-lcs (1.5.0)
     docile (1.4.0)

--- a/gemfiles/ruby_3.1.2_http.gemfile.lock
+++ b/gemfiles/ruby_3.1.2_http.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.14.0)
       datadog-ci (~> 0.1.0)
-      debase-ruby_core_source (= 3.2.1)
+      debase-ruby_core_source (= 3.2.2)
       libdatadog (~> 4.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
@@ -42,7 +42,7 @@ GEM
       rexml
     cri (2.15.11)
     datadog-ci (0.1.1)
-    debase-ruby_core_source (3.2.1)
+    debase-ruby_core_source (3.2.2)
     debug_inspector (1.1.0)
     diff-lcs (1.5.0)
     docile (1.4.0)

--- a/gemfiles/ruby_3.1.2_opentelemetry.gemfile.lock
+++ b/gemfiles/ruby_3.1.2_opentelemetry.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.14.0)
       datadog-ci (~> 0.1.0)
-      debase-ruby_core_source (= 3.2.1)
+      debase-ruby_core_source (= 3.2.2)
       libdatadog (~> 4.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
@@ -42,7 +42,7 @@ GEM
       rexml
     cri (2.15.11)
     datadog-ci (0.1.1)
-    debase-ruby_core_source (3.2.1)
+    debase-ruby_core_source (3.2.2)
     debug_inspector (1.1.0)
     diff-lcs (1.5.0)
     docile (1.4.0)

--- a/gemfiles/ruby_3.1.2_opentracing.gemfile.lock
+++ b/gemfiles/ruby_3.1.2_opentracing.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.14.0)
       datadog-ci (~> 0.1.0)
-      debase-ruby_core_source (= 3.2.1)
+      debase-ruby_core_source (= 3.2.2)
       libdatadog (~> 4.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
@@ -43,7 +43,7 @@ GEM
       rexml
     cri (2.15.11)
     datadog-ci (0.1.1)
-    debase-ruby_core_source (3.2.1)
+    debase-ruby_core_source (3.2.2)
     debug_inspector (1.1.0)
     diff-lcs (1.5.0)
     docile (1.4.0)

--- a/gemfiles/ruby_3.1.2_rack_1.gemfile.lock
+++ b/gemfiles/ruby_3.1.2_rack_1.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.14.0)
       datadog-ci (~> 0.1.0)
-      debase-ruby_core_source (= 3.2.1)
+      debase-ruby_core_source (= 3.2.2)
       libdatadog (~> 4.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
@@ -42,7 +42,7 @@ GEM
       rexml
     cri (2.15.11)
     datadog-ci (0.1.1)
-    debase-ruby_core_source (3.2.1)
+    debase-ruby_core_source (3.2.2)
     debug_inspector (1.1.0)
     diff-lcs (1.5.0)
     docile (1.4.0)

--- a/gemfiles/ruby_3.1.2_rack_2.gemfile.lock
+++ b/gemfiles/ruby_3.1.2_rack_2.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.14.0)
       datadog-ci (~> 0.1.0)
-      debase-ruby_core_source (= 3.2.1)
+      debase-ruby_core_source (= 3.2.2)
       libdatadog (~> 4.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
@@ -42,7 +42,7 @@ GEM
       rexml
     cri (2.15.11)
     datadog-ci (0.1.1)
-    debase-ruby_core_source (3.2.1)
+    debase-ruby_core_source (3.2.2)
     debug_inspector (1.1.0)
     diff-lcs (1.5.0)
     docile (1.4.0)

--- a/gemfiles/ruby_3.1.2_rack_3.gemfile.lock
+++ b/gemfiles/ruby_3.1.2_rack_3.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.14.0)
       datadog-ci (~> 0.1.0)
-      debase-ruby_core_source (= 3.2.1)
+      debase-ruby_core_source (= 3.2.2)
       libdatadog (~> 4.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
@@ -42,7 +42,7 @@ GEM
       rexml
     cri (2.15.11)
     datadog-ci (0.1.1)
-    debase-ruby_core_source (3.2.1)
+    debase-ruby_core_source (3.2.2)
     debug_inspector (1.1.0)
     diff-lcs (1.5.0)
     docile (1.4.0)

--- a/gemfiles/ruby_3.1.2_rails61_mysql2.gemfile.lock
+++ b/gemfiles/ruby_3.1.2_rails61_mysql2.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.14.0)
       datadog-ci (~> 0.1.0)
-      debase-ruby_core_source (= 3.2.1)
+      debase-ruby_core_source (= 3.2.2)
       libdatadog (~> 4.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
@@ -103,7 +103,7 @@ GEM
     cri (2.15.11)
     datadog-ci (0.1.1)
     date (3.3.3)
-    debase-ruby_core_source (3.2.1)
+    debase-ruby_core_source (3.2.2)
     debug_inspector (1.1.0)
     diff-lcs (1.5.0)
     docile (1.4.0)

--- a/gemfiles/ruby_3.1.2_rails61_postgres.gemfile.lock
+++ b/gemfiles/ruby_3.1.2_rails61_postgres.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.14.0)
       datadog-ci (~> 0.1.0)
-      debase-ruby_core_source (= 3.2.1)
+      debase-ruby_core_source (= 3.2.2)
       libdatadog (~> 4.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
@@ -103,7 +103,7 @@ GEM
     cri (2.15.11)
     datadog-ci (0.1.1)
     date (3.3.3)
-    debase-ruby_core_source (3.2.1)
+    debase-ruby_core_source (3.2.2)
     debug_inspector (1.1.0)
     diff-lcs (1.5.0)
     docile (1.4.0)

--- a/gemfiles/ruby_3.1.2_rails61_postgres_redis.gemfile.lock
+++ b/gemfiles/ruby_3.1.2_rails61_postgres_redis.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.14.0)
       datadog-ci (~> 0.1.0)
-      debase-ruby_core_source (= 3.2.1)
+      debase-ruby_core_source (= 3.2.2)
       libdatadog (~> 4.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
@@ -103,7 +103,7 @@ GEM
     cri (2.15.11)
     datadog-ci (0.1.1)
     date (3.3.3)
-    debase-ruby_core_source (3.2.1)
+    debase-ruby_core_source (3.2.2)
     debug_inspector (1.1.0)
     diff-lcs (1.5.0)
     docile (1.4.0)

--- a/gemfiles/ruby_3.1.2_rails61_postgres_sidekiq.gemfile.lock
+++ b/gemfiles/ruby_3.1.2_rails61_postgres_sidekiq.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.14.0)
       datadog-ci (~> 0.1.0)
-      debase-ruby_core_source (= 3.2.1)
+      debase-ruby_core_source (= 3.2.2)
       libdatadog (~> 4.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
@@ -104,7 +104,7 @@ GEM
     cri (2.15.11)
     datadog-ci (0.1.1)
     date (3.3.3)
-    debase-ruby_core_source (3.2.1)
+    debase-ruby_core_source (3.2.2)
     debug_inspector (1.1.0)
     diff-lcs (1.5.0)
     docile (1.4.0)

--- a/gemfiles/ruby_3.1.2_rails61_semantic_logger.gemfile.lock
+++ b/gemfiles/ruby_3.1.2_rails61_semantic_logger.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.14.0)
       datadog-ci (~> 0.1.0)
-      debase-ruby_core_source (= 3.2.1)
+      debase-ruby_core_source (= 3.2.2)
       libdatadog (~> 4.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
@@ -103,7 +103,7 @@ GEM
     cri (2.15.11)
     datadog-ci (0.1.1)
     date (3.3.3)
-    debase-ruby_core_source (3.2.1)
+    debase-ruby_core_source (3.2.2)
     debug_inspector (1.1.0)
     diff-lcs (1.5.0)
     docile (1.4.0)

--- a/gemfiles/ruby_3.1.2_redis_3.gemfile.lock
+++ b/gemfiles/ruby_3.1.2_redis_3.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.14.0)
       datadog-ci (~> 0.1.0)
-      debase-ruby_core_source (= 3.2.1)
+      debase-ruby_core_source (= 3.2.2)
       libdatadog (~> 4.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
@@ -42,7 +42,7 @@ GEM
       rexml
     cri (2.15.11)
     datadog-ci (0.1.1)
-    debase-ruby_core_source (3.2.1)
+    debase-ruby_core_source (3.2.2)
     debug_inspector (1.1.0)
     diff-lcs (1.5.0)
     docile (1.4.0)

--- a/gemfiles/ruby_3.1.2_redis_4.gemfile.lock
+++ b/gemfiles/ruby_3.1.2_redis_4.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.14.0)
       datadog-ci (~> 0.1.0)
-      debase-ruby_core_source (= 3.2.1)
+      debase-ruby_core_source (= 3.2.2)
       libdatadog (~> 4.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
@@ -42,7 +42,7 @@ GEM
       rexml
     cri (2.15.11)
     datadog-ci (0.1.1)
-    debase-ruby_core_source (3.2.1)
+    debase-ruby_core_source (3.2.2)
     debug_inspector (1.1.0)
     diff-lcs (1.5.0)
     docile (1.4.0)

--- a/gemfiles/ruby_3.1.2_redis_5.gemfile.lock
+++ b/gemfiles/ruby_3.1.2_redis_5.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.14.0)
       datadog-ci (~> 0.1.0)
-      debase-ruby_core_source (= 3.2.1)
+      debase-ruby_core_source (= 3.2.2)
       libdatadog (~> 4.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
@@ -43,7 +43,7 @@ GEM
       rexml
     cri (2.15.11)
     datadog-ci (0.1.1)
-    debase-ruby_core_source (3.2.1)
+    debase-ruby_core_source (3.2.2)
     debug_inspector (1.1.0)
     diff-lcs (1.5.0)
     docile (1.4.0)

--- a/gemfiles/ruby_3.1.2_relational_db.gemfile.lock
+++ b/gemfiles/ruby_3.1.2_relational_db.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.14.0)
       datadog-ci (~> 0.1.0)
-      debase-ruby_core_source (= 3.2.1)
+      debase-ruby_core_source (= 3.2.2)
       libdatadog (~> 4.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
@@ -52,7 +52,7 @@ GEM
       rexml
     cri (2.15.11)
     datadog-ci (0.1.1)
-    debase-ruby_core_source (3.2.1)
+    debase-ruby_core_source (3.2.2)
     debug_inspector (1.1.0)
     delayed_job (4.1.11)
       activesupport (>= 3.0, < 8.0)

--- a/gemfiles/ruby_3.1.2_resque2_redis3.gemfile.lock
+++ b/gemfiles/ruby_3.1.2_resque2_redis3.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.14.0)
       datadog-ci (~> 0.1.0)
-      debase-ruby_core_source (= 3.2.1)
+      debase-ruby_core_source (= 3.2.2)
       libdatadog (~> 4.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
@@ -42,7 +42,7 @@ GEM
       rexml
     cri (2.15.11)
     datadog-ci (0.1.1)
-    debase-ruby_core_source (3.2.1)
+    debase-ruby_core_source (3.2.2)
     debug_inspector (1.1.0)
     diff-lcs (1.5.0)
     docile (1.4.0)

--- a/gemfiles/ruby_3.1.2_resque2_redis4.gemfile.lock
+++ b/gemfiles/ruby_3.1.2_resque2_redis4.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.14.0)
       datadog-ci (~> 0.1.0)
-      debase-ruby_core_source (= 3.2.1)
+      debase-ruby_core_source (= 3.2.2)
       libdatadog (~> 4.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
@@ -43,7 +43,7 @@ GEM
       rexml
     cri (2.15.11)
     datadog-ci (0.1.1)
-    debase-ruby_core_source (3.2.1)
+    debase-ruby_core_source (3.2.2)
     debug_inspector (1.1.0)
     diff-lcs (1.5.0)
     docile (1.4.0)

--- a/gemfiles/ruby_3.1.2_sinatra.gemfile.lock
+++ b/gemfiles/ruby_3.1.2_sinatra.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.14.0)
       datadog-ci (~> 0.1.0)
-      debase-ruby_core_source (= 3.2.1)
+      debase-ruby_core_source (= 3.2.2)
       libdatadog (~> 4.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
@@ -42,7 +42,7 @@ GEM
       rexml
     cri (2.15.11)
     datadog-ci (0.1.1)
-    debase-ruby_core_source (3.2.1)
+    debase-ruby_core_source (3.2.2)
     debug_inspector (1.1.0)
     diff-lcs (1.5.0)
     docile (1.4.0)

--- a/gemfiles/ruby_3.2.0_activesupport.gemfile.lock
+++ b/gemfiles/ruby_3.2.0_activesupport.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.14.0)
       datadog-ci (~> 0.1.0)
-      debase-ruby_core_source (= 3.2.1)
+      debase-ruby_core_source (= 3.2.2)
       libdatadog (~> 4.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
@@ -69,7 +69,7 @@ GEM
     crass (1.0.6)
     cri (2.15.11)
     datadog-ci (0.1.1)
-    debase-ruby_core_source (3.2.1)
+    debase-ruby_core_source (3.2.2)
     debug_inspector (1.1.0)
     diff-lcs (1.5.0)
     digest-crc (0.6.5)

--- a/gemfiles/ruby_3.2.0_aws.gemfile.lock
+++ b/gemfiles/ruby_3.2.0_aws.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.14.0)
       datadog-ci (~> 0.1.0)
-      debase-ruby_core_source (= 3.2.1)
+      debase-ruby_core_source (= 3.2.2)
       libdatadog (~> 4.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
@@ -1462,7 +1462,7 @@ GEM
       rexml
     cri (2.15.11)
     datadog-ci (0.1.1)
-    debase-ruby_core_source (3.2.1)
+    debase-ruby_core_source (3.2.2)
     debug_inspector (1.1.0)
     diff-lcs (1.5.0)
     docile (1.4.0)

--- a/gemfiles/ruby_3.2.0_contrib.gemfile.lock
+++ b/gemfiles/ruby_3.2.0_contrib.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.14.0)
       datadog-ci (~> 0.1.0)
-      debase-ruby_core_source (= 3.2.1)
+      debase-ruby_core_source (= 3.2.2)
       libdatadog (~> 4.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
@@ -48,7 +48,7 @@ GEM
     cri (2.15.11)
     dalli (3.2.4)
     datadog-ci (0.1.1)
-    debase-ruby_core_source (3.2.1)
+    debase-ruby_core_source (3.2.2)
     debug_inspector (1.1.0)
     diff-lcs (1.5.0)
     docile (1.4.0)

--- a/gemfiles/ruby_3.2.0_contrib_old.gemfile.lock
+++ b/gemfiles/ruby_3.2.0_contrib_old.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.14.0)
       datadog-ci (~> 0.1.0)
-      debase-ruby_core_source (= 3.2.1)
+      debase-ruby_core_source (= 3.2.2)
       libdatadog (~> 4.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
@@ -46,7 +46,7 @@ GEM
     daemons (1.4.1)
     dalli (2.7.11)
     datadog-ci (0.1.1)
-    debase-ruby_core_source (3.2.1)
+    debase-ruby_core_source (3.2.2)
     debug_inspector (1.1.0)
     diff-lcs (1.5.0)
     docile (1.4.0)

--- a/gemfiles/ruby_3.2.0_core_old.gemfile.lock
+++ b/gemfiles/ruby_3.2.0_core_old.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.14.0)
       datadog-ci (~> 0.1.0)
-      debase-ruby_core_source (= 3.2.1)
+      debase-ruby_core_source (= 3.2.2)
       libdatadog (~> 4.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
@@ -41,7 +41,7 @@ GEM
       rexml
     cri (2.15.11)
     datadog-ci (0.1.1)
-    debase-ruby_core_source (3.2.1)
+    debase-ruby_core_source (3.2.2)
     debug_inspector (1.1.0)
     diff-lcs (1.5.0)
     docile (1.4.0)

--- a/gemfiles/ruby_3.2.0_http.gemfile.lock
+++ b/gemfiles/ruby_3.2.0_http.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.14.0)
       datadog-ci (~> 0.1.0)
-      debase-ruby_core_source (= 3.2.1)
+      debase-ruby_core_source (= 3.2.2)
       libdatadog (~> 4.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
@@ -41,7 +41,7 @@ GEM
       rexml
     cri (2.15.11)
     datadog-ci (0.1.1)
-    debase-ruby_core_source (3.2.1)
+    debase-ruby_core_source (3.2.2)
     debug_inspector (1.1.0)
     diff-lcs (1.5.0)
     docile (1.4.0)

--- a/gemfiles/ruby_3.2.0_opentelemetry.gemfile.lock
+++ b/gemfiles/ruby_3.2.0_opentelemetry.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.14.0)
       datadog-ci (~> 0.1.0)
-      debase-ruby_core_source (= 3.2.1)
+      debase-ruby_core_source (= 3.2.2)
       libdatadog (~> 4.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
@@ -41,7 +41,7 @@ GEM
       rexml
     cri (2.15.11)
     datadog-ci (0.1.1)
-    debase-ruby_core_source (3.2.1)
+    debase-ruby_core_source (3.2.2)
     debug_inspector (1.1.0)
     diff-lcs (1.5.0)
     docile (1.4.0)

--- a/gemfiles/ruby_3.2.0_opentracing.gemfile.lock
+++ b/gemfiles/ruby_3.2.0_opentracing.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.14.0)
       datadog-ci (~> 0.1.0)
-      debase-ruby_core_source (= 3.2.1)
+      debase-ruby_core_source (= 3.2.2)
       libdatadog (~> 4.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
@@ -42,7 +42,7 @@ GEM
       rexml
     cri (2.15.11)
     datadog-ci (0.1.1)
-    debase-ruby_core_source (3.2.1)
+    debase-ruby_core_source (3.2.2)
     debug_inspector (1.1.0)
     diff-lcs (1.5.0)
     docile (1.4.0)

--- a/gemfiles/ruby_3.2.0_rack_1.gemfile.lock
+++ b/gemfiles/ruby_3.2.0_rack_1.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.14.0)
       datadog-ci (~> 0.1.0)
-      debase-ruby_core_source (= 3.2.1)
+      debase-ruby_core_source (= 3.2.2)
       libdatadog (~> 4.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
@@ -41,7 +41,7 @@ GEM
       rexml
     cri (2.15.11)
     datadog-ci (0.1.1)
-    debase-ruby_core_source (3.2.1)
+    debase-ruby_core_source (3.2.2)
     debug_inspector (1.1.0)
     diff-lcs (1.5.0)
     docile (1.4.0)

--- a/gemfiles/ruby_3.2.0_rack_2.gemfile.lock
+++ b/gemfiles/ruby_3.2.0_rack_2.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.14.0)
       datadog-ci (~> 0.1.0)
-      debase-ruby_core_source (= 3.2.1)
+      debase-ruby_core_source (= 3.2.2)
       libdatadog (~> 4.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
@@ -41,7 +41,7 @@ GEM
       rexml
     cri (2.15.11)
     datadog-ci (0.1.1)
-    debase-ruby_core_source (3.2.1)
+    debase-ruby_core_source (3.2.2)
     debug_inspector (1.1.0)
     diff-lcs (1.5.0)
     docile (1.4.0)

--- a/gemfiles/ruby_3.2.0_rack_3.gemfile.lock
+++ b/gemfiles/ruby_3.2.0_rack_3.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.14.0)
       datadog-ci (~> 0.1.0)
-      debase-ruby_core_source (= 3.2.1)
+      debase-ruby_core_source (= 3.2.2)
       libdatadog (~> 4.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
@@ -41,7 +41,7 @@ GEM
       rexml
     cri (2.15.11)
     datadog-ci (0.1.1)
-    debase-ruby_core_source (3.2.1)
+    debase-ruby_core_source (3.2.2)
     debug_inspector (1.1.0)
     diff-lcs (1.5.0)
     docile (1.4.0)

--- a/gemfiles/ruby_3.2.0_rails61_mysql2.gemfile.lock
+++ b/gemfiles/ruby_3.2.0_rails61_mysql2.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.14.0)
       datadog-ci (~> 0.1.0)
-      debase-ruby_core_source (= 3.2.1)
+      debase-ruby_core_source (= 3.2.2)
       libdatadog (~> 4.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
@@ -102,7 +102,7 @@ GEM
     cri (2.15.11)
     datadog-ci (0.1.1)
     date (3.3.3)
-    debase-ruby_core_source (3.2.1)
+    debase-ruby_core_source (3.2.2)
     debug_inspector (1.1.0)
     diff-lcs (1.5.0)
     docile (1.4.0)

--- a/gemfiles/ruby_3.2.0_rails61_postgres.gemfile.lock
+++ b/gemfiles/ruby_3.2.0_rails61_postgres.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.14.0)
       datadog-ci (~> 0.1.0)
-      debase-ruby_core_source (= 3.2.1)
+      debase-ruby_core_source (= 3.2.2)
       libdatadog (~> 4.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
@@ -102,7 +102,7 @@ GEM
     cri (2.15.11)
     datadog-ci (0.1.1)
     date (3.3.3)
-    debase-ruby_core_source (3.2.1)
+    debase-ruby_core_source (3.2.2)
     debug_inspector (1.1.0)
     diff-lcs (1.5.0)
     docile (1.4.0)

--- a/gemfiles/ruby_3.2.0_rails61_postgres_redis.gemfile.lock
+++ b/gemfiles/ruby_3.2.0_rails61_postgres_redis.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.14.0)
       datadog-ci (~> 0.1.0)
-      debase-ruby_core_source (= 3.2.1)
+      debase-ruby_core_source (= 3.2.2)
       libdatadog (~> 4.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
@@ -102,7 +102,7 @@ GEM
     cri (2.15.11)
     datadog-ci (0.1.1)
     date (3.3.3)
-    debase-ruby_core_source (3.2.1)
+    debase-ruby_core_source (3.2.2)
     debug_inspector (1.1.0)
     diff-lcs (1.5.0)
     docile (1.4.0)

--- a/gemfiles/ruby_3.2.0_rails61_postgres_sidekiq.gemfile.lock
+++ b/gemfiles/ruby_3.2.0_rails61_postgres_sidekiq.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.14.0)
       datadog-ci (~> 0.1.0)
-      debase-ruby_core_source (= 3.2.1)
+      debase-ruby_core_source (= 3.2.2)
       libdatadog (~> 4.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
@@ -103,7 +103,7 @@ GEM
     cri (2.15.11)
     datadog-ci (0.1.1)
     date (3.3.3)
-    debase-ruby_core_source (3.2.1)
+    debase-ruby_core_source (3.2.2)
     debug_inspector (1.1.0)
     diff-lcs (1.5.0)
     docile (1.4.0)

--- a/gemfiles/ruby_3.2.0_rails61_semantic_logger.gemfile.lock
+++ b/gemfiles/ruby_3.2.0_rails61_semantic_logger.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.14.0)
       datadog-ci (~> 0.1.0)
-      debase-ruby_core_source (= 3.2.1)
+      debase-ruby_core_source (= 3.2.2)
       libdatadog (~> 4.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
@@ -102,7 +102,7 @@ GEM
     cri (2.15.11)
     datadog-ci (0.1.1)
     date (3.3.3)
-    debase-ruby_core_source (3.2.1)
+    debase-ruby_core_source (3.2.2)
     debug_inspector (1.1.0)
     diff-lcs (1.5.0)
     docile (1.4.0)

--- a/gemfiles/ruby_3.2.0_redis_3.gemfile.lock
+++ b/gemfiles/ruby_3.2.0_redis_3.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.14.0)
       datadog-ci (~> 0.1.0)
-      debase-ruby_core_source (= 3.2.1)
+      debase-ruby_core_source (= 3.2.2)
       libdatadog (~> 4.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
@@ -41,7 +41,7 @@ GEM
       rexml
     cri (2.15.11)
     datadog-ci (0.1.1)
-    debase-ruby_core_source (3.2.1)
+    debase-ruby_core_source (3.2.2)
     debug_inspector (1.1.0)
     diff-lcs (1.5.0)
     docile (1.4.0)

--- a/gemfiles/ruby_3.2.0_redis_4.gemfile.lock
+++ b/gemfiles/ruby_3.2.0_redis_4.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.14.0)
       datadog-ci (~> 0.1.0)
-      debase-ruby_core_source (= 3.2.1)
+      debase-ruby_core_source (= 3.2.2)
       libdatadog (~> 4.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
@@ -41,7 +41,7 @@ GEM
       rexml
     cri (2.15.11)
     datadog-ci (0.1.1)
-    debase-ruby_core_source (3.2.1)
+    debase-ruby_core_source (3.2.2)
     debug_inspector (1.1.0)
     diff-lcs (1.5.0)
     docile (1.4.0)

--- a/gemfiles/ruby_3.2.0_redis_5.gemfile.lock
+++ b/gemfiles/ruby_3.2.0_redis_5.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.14.0)
       datadog-ci (~> 0.1.0)
-      debase-ruby_core_source (= 3.2.1)
+      debase-ruby_core_source (= 3.2.2)
       libdatadog (~> 4.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
@@ -42,7 +42,7 @@ GEM
       rexml
     cri (2.15.11)
     datadog-ci (0.1.1)
-    debase-ruby_core_source (3.2.1)
+    debase-ruby_core_source (3.2.2)
     debug_inspector (1.1.0)
     diff-lcs (1.5.0)
     docile (1.4.0)

--- a/gemfiles/ruby_3.2.0_relational_db.gemfile.lock
+++ b/gemfiles/ruby_3.2.0_relational_db.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.14.0)
       datadog-ci (~> 0.1.0)
-      debase-ruby_core_source (= 3.2.1)
+      debase-ruby_core_source (= 3.2.2)
       libdatadog (~> 4.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
@@ -51,7 +51,7 @@ GEM
       rexml
     cri (2.15.11)
     datadog-ci (0.1.1)
-    debase-ruby_core_source (3.2.1)
+    debase-ruby_core_source (3.2.2)
     debug_inspector (1.1.0)
     delayed_job (4.1.11)
       activesupport (>= 3.0, < 8.0)

--- a/gemfiles/ruby_3.2.0_resque2_redis3.gemfile.lock
+++ b/gemfiles/ruby_3.2.0_resque2_redis3.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.14.0)
       datadog-ci (~> 0.1.0)
-      debase-ruby_core_source (= 3.2.1)
+      debase-ruby_core_source (= 3.2.2)
       libdatadog (~> 4.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
@@ -41,7 +41,7 @@ GEM
       rexml
     cri (2.15.11)
     datadog-ci (0.1.1)
-    debase-ruby_core_source (3.2.1)
+    debase-ruby_core_source (3.2.2)
     debug_inspector (1.1.0)
     diff-lcs (1.5.0)
     docile (1.4.0)

--- a/gemfiles/ruby_3.2.0_resque2_redis4.gemfile.lock
+++ b/gemfiles/ruby_3.2.0_resque2_redis4.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.14.0)
       datadog-ci (~> 0.1.0)
-      debase-ruby_core_source (= 3.2.1)
+      debase-ruby_core_source (= 3.2.2)
       libdatadog (~> 4.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
@@ -42,7 +42,7 @@ GEM
       rexml
     cri (2.15.11)
     datadog-ci (0.1.1)
-    debase-ruby_core_source (3.2.1)
+    debase-ruby_core_source (3.2.2)
     debug_inspector (1.1.0)
     diff-lcs (1.5.0)
     docile (1.4.0)

--- a/gemfiles/ruby_3.2.0_sinatra.gemfile.lock
+++ b/gemfiles/ruby_3.2.0_sinatra.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.14.0)
       datadog-ci (~> 0.1.0)
-      debase-ruby_core_source (= 3.2.1)
+      debase-ruby_core_source (= 3.2.2)
       libdatadog (~> 4.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
@@ -41,7 +41,7 @@ GEM
       rexml
     cri (2.15.11)
     datadog-ci (0.1.1)
-    debase-ruby_core_source (3.2.1)
+    debase-ruby_core_source (3.2.2)
     debug_inspector (1.1.0)
     diff-lcs (1.5.0)
     docile (1.4.0)

--- a/gemfiles/ruby_3.3.0_activesupport.gemfile.lock
+++ b/gemfiles/ruby_3.3.0_activesupport.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.14.0)
       datadog-ci (~> 0.1.0)
-      debase-ruby_core_source (= 3.2.1)
+      debase-ruby_core_source (= 3.2.2)
       libdatadog (~> 4.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
@@ -69,7 +69,7 @@ GEM
     crass (1.0.6)
     cri (2.15.11)
     datadog-ci (0.1.1)
-    debase-ruby_core_source (3.2.1)
+    debase-ruby_core_source (3.2.2)
     debug_inspector (1.1.0)
     diff-lcs (1.5.0)
     digest-crc (0.6.5)

--- a/gemfiles/ruby_3.3.0_aws.gemfile.lock
+++ b/gemfiles/ruby_3.3.0_aws.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.14.0)
       datadog-ci (~> 0.1.0)
-      debase-ruby_core_source (= 3.2.1)
+      debase-ruby_core_source (= 3.2.2)
       libdatadog (~> 4.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
@@ -1462,7 +1462,7 @@ GEM
       rexml
     cri (2.15.11)
     datadog-ci (0.1.1)
-    debase-ruby_core_source (3.2.1)
+    debase-ruby_core_source (3.2.2)
     debug_inspector (1.1.0)
     diff-lcs (1.5.0)
     docile (1.4.0)

--- a/gemfiles/ruby_3.3.0_contrib.gemfile.lock
+++ b/gemfiles/ruby_3.3.0_contrib.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.14.0)
       datadog-ci (~> 0.1.0)
-      debase-ruby_core_source (= 3.2.1)
+      debase-ruby_core_source (= 3.2.2)
       libdatadog (~> 4.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
@@ -48,7 +48,7 @@ GEM
     cri (2.15.11)
     dalli (3.2.4)
     datadog-ci (0.1.1)
-    debase-ruby_core_source (3.2.1)
+    debase-ruby_core_source (3.2.2)
     debug_inspector (1.1.0)
     diff-lcs (1.5.0)
     docile (1.4.0)

--- a/gemfiles/ruby_3.3.0_contrib_old.gemfile.lock
+++ b/gemfiles/ruby_3.3.0_contrib_old.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.14.0)
       datadog-ci (~> 0.1.0)
-      debase-ruby_core_source (= 3.2.1)
+      debase-ruby_core_source (= 3.2.2)
       libdatadog (~> 4.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
@@ -46,7 +46,7 @@ GEM
     daemons (1.4.1)
     dalli (2.7.11)
     datadog-ci (0.1.1)
-    debase-ruby_core_source (3.2.1)
+    debase-ruby_core_source (3.2.2)
     debug_inspector (1.1.0)
     diff-lcs (1.5.0)
     docile (1.4.0)

--- a/gemfiles/ruby_3.3.0_core_old.gemfile.lock
+++ b/gemfiles/ruby_3.3.0_core_old.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.14.0)
       datadog-ci (~> 0.1.0)
-      debase-ruby_core_source (= 3.2.1)
+      debase-ruby_core_source (= 3.2.2)
       libdatadog (~> 4.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
@@ -41,7 +41,7 @@ GEM
       rexml
     cri (2.15.11)
     datadog-ci (0.1.1)
-    debase-ruby_core_source (3.2.1)
+    debase-ruby_core_source (3.2.2)
     debug_inspector (1.1.0)
     diff-lcs (1.5.0)
     docile (1.4.0)

--- a/gemfiles/ruby_3.3.0_http.gemfile.lock
+++ b/gemfiles/ruby_3.3.0_http.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.14.0)
       datadog-ci (~> 0.1.0)
-      debase-ruby_core_source (= 3.2.1)
+      debase-ruby_core_source (= 3.2.2)
       libdatadog (~> 4.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
@@ -41,7 +41,7 @@ GEM
       rexml
     cri (2.15.11)
     datadog-ci (0.1.1)
-    debase-ruby_core_source (3.2.1)
+    debase-ruby_core_source (3.2.2)
     debug_inspector (1.1.0)
     diff-lcs (1.5.0)
     docile (1.4.0)

--- a/gemfiles/ruby_3.3.0_opentelemetry.gemfile.lock
+++ b/gemfiles/ruby_3.3.0_opentelemetry.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.14.0)
       datadog-ci (~> 0.1.0)
-      debase-ruby_core_source (= 3.2.1)
+      debase-ruby_core_source (= 3.2.2)
       libdatadog (~> 4.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
@@ -41,7 +41,7 @@ GEM
       rexml
     cri (2.15.11)
     datadog-ci (0.1.1)
-    debase-ruby_core_source (3.2.1)
+    debase-ruby_core_source (3.2.2)
     debug_inspector (1.1.0)
     diff-lcs (1.5.0)
     docile (1.4.0)

--- a/gemfiles/ruby_3.3.0_opentracing.gemfile.lock
+++ b/gemfiles/ruby_3.3.0_opentracing.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.14.0)
       datadog-ci (~> 0.1.0)
-      debase-ruby_core_source (= 3.2.1)
+      debase-ruby_core_source (= 3.2.2)
       libdatadog (~> 4.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
@@ -42,7 +42,7 @@ GEM
       rexml
     cri (2.15.11)
     datadog-ci (0.1.1)
-    debase-ruby_core_source (3.2.1)
+    debase-ruby_core_source (3.2.2)
     debug_inspector (1.1.0)
     diff-lcs (1.5.0)
     docile (1.4.0)

--- a/gemfiles/ruby_3.3.0_rack_1.gemfile.lock
+++ b/gemfiles/ruby_3.3.0_rack_1.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.14.0)
       datadog-ci (~> 0.1.0)
-      debase-ruby_core_source (= 3.2.1)
+      debase-ruby_core_source (= 3.2.2)
       libdatadog (~> 4.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
@@ -41,7 +41,7 @@ GEM
       rexml
     cri (2.15.11)
     datadog-ci (0.1.1)
-    debase-ruby_core_source (3.2.1)
+    debase-ruby_core_source (3.2.2)
     debug_inspector (1.1.0)
     diff-lcs (1.5.0)
     docile (1.4.0)

--- a/gemfiles/ruby_3.3.0_rack_2.gemfile.lock
+++ b/gemfiles/ruby_3.3.0_rack_2.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.14.0)
       datadog-ci (~> 0.1.0)
-      debase-ruby_core_source (= 3.2.1)
+      debase-ruby_core_source (= 3.2.2)
       libdatadog (~> 4.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
@@ -41,7 +41,7 @@ GEM
       rexml
     cri (2.15.11)
     datadog-ci (0.1.1)
-    debase-ruby_core_source (3.2.1)
+    debase-ruby_core_source (3.2.2)
     debug_inspector (1.1.0)
     diff-lcs (1.5.0)
     docile (1.4.0)

--- a/gemfiles/ruby_3.3.0_rack_3.gemfile.lock
+++ b/gemfiles/ruby_3.3.0_rack_3.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.14.0)
       datadog-ci (~> 0.1.0)
-      debase-ruby_core_source (= 3.2.1)
+      debase-ruby_core_source (= 3.2.2)
       libdatadog (~> 4.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
@@ -41,7 +41,7 @@ GEM
       rexml
     cri (2.15.11)
     datadog-ci (0.1.1)
-    debase-ruby_core_source (3.2.1)
+    debase-ruby_core_source (3.2.2)
     debug_inspector (1.1.0)
     diff-lcs (1.5.0)
     docile (1.4.0)

--- a/gemfiles/ruby_3.3.0_rails61_mysql2.gemfile.lock
+++ b/gemfiles/ruby_3.3.0_rails61_mysql2.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.14.0)
       datadog-ci (~> 0.1.0)
-      debase-ruby_core_source (= 3.2.1)
+      debase-ruby_core_source (= 3.2.2)
       libdatadog (~> 4.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
@@ -102,7 +102,7 @@ GEM
     cri (2.15.11)
     datadog-ci (0.1.1)
     date (3.3.3)
-    debase-ruby_core_source (3.2.1)
+    debase-ruby_core_source (3.2.2)
     debug_inspector (1.1.0)
     diff-lcs (1.5.0)
     docile (1.4.0)

--- a/gemfiles/ruby_3.3.0_rails61_postgres.gemfile.lock
+++ b/gemfiles/ruby_3.3.0_rails61_postgres.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.14.0)
       datadog-ci (~> 0.1.0)
-      debase-ruby_core_source (= 3.2.1)
+      debase-ruby_core_source (= 3.2.2)
       libdatadog (~> 4.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
@@ -102,7 +102,7 @@ GEM
     cri (2.15.11)
     datadog-ci (0.1.1)
     date (3.3.3)
-    debase-ruby_core_source (3.2.1)
+    debase-ruby_core_source (3.2.2)
     debug_inspector (1.1.0)
     diff-lcs (1.5.0)
     docile (1.4.0)

--- a/gemfiles/ruby_3.3.0_rails61_postgres_redis.gemfile.lock
+++ b/gemfiles/ruby_3.3.0_rails61_postgres_redis.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.14.0)
       datadog-ci (~> 0.1.0)
-      debase-ruby_core_source (= 3.2.1)
+      debase-ruby_core_source (= 3.2.2)
       libdatadog (~> 4.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
@@ -102,7 +102,7 @@ GEM
     cri (2.15.11)
     datadog-ci (0.1.1)
     date (3.3.3)
-    debase-ruby_core_source (3.2.1)
+    debase-ruby_core_source (3.2.2)
     debug_inspector (1.1.0)
     diff-lcs (1.5.0)
     docile (1.4.0)

--- a/gemfiles/ruby_3.3.0_rails61_postgres_sidekiq.gemfile.lock
+++ b/gemfiles/ruby_3.3.0_rails61_postgres_sidekiq.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.14.0)
       datadog-ci (~> 0.1.0)
-      debase-ruby_core_source (= 3.2.1)
+      debase-ruby_core_source (= 3.2.2)
       libdatadog (~> 4.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
@@ -103,7 +103,7 @@ GEM
     cri (2.15.11)
     datadog-ci (0.1.1)
     date (3.3.3)
-    debase-ruby_core_source (3.2.1)
+    debase-ruby_core_source (3.2.2)
     debug_inspector (1.1.0)
     diff-lcs (1.5.0)
     docile (1.4.0)

--- a/gemfiles/ruby_3.3.0_rails61_semantic_logger.gemfile.lock
+++ b/gemfiles/ruby_3.3.0_rails61_semantic_logger.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.14.0)
       datadog-ci (~> 0.1.0)
-      debase-ruby_core_source (= 3.2.1)
+      debase-ruby_core_source (= 3.2.2)
       libdatadog (~> 4.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
@@ -102,7 +102,7 @@ GEM
     cri (2.15.11)
     datadog-ci (0.1.1)
     date (3.3.3)
-    debase-ruby_core_source (3.2.1)
+    debase-ruby_core_source (3.2.2)
     debug_inspector (1.1.0)
     diff-lcs (1.5.0)
     docile (1.4.0)

--- a/gemfiles/ruby_3.3.0_redis_3.gemfile.lock
+++ b/gemfiles/ruby_3.3.0_redis_3.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.14.0)
       datadog-ci (~> 0.1.0)
-      debase-ruby_core_source (= 3.2.1)
+      debase-ruby_core_source (= 3.2.2)
       libdatadog (~> 4.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
@@ -41,7 +41,7 @@ GEM
       rexml
     cri (2.15.11)
     datadog-ci (0.1.1)
-    debase-ruby_core_source (3.2.1)
+    debase-ruby_core_source (3.2.2)
     debug_inspector (1.1.0)
     diff-lcs (1.5.0)
     docile (1.4.0)

--- a/gemfiles/ruby_3.3.0_redis_4.gemfile.lock
+++ b/gemfiles/ruby_3.3.0_redis_4.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.14.0)
       datadog-ci (~> 0.1.0)
-      debase-ruby_core_source (= 3.2.1)
+      debase-ruby_core_source (= 3.2.2)
       libdatadog (~> 4.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
@@ -41,7 +41,7 @@ GEM
       rexml
     cri (2.15.11)
     datadog-ci (0.1.1)
-    debase-ruby_core_source (3.2.1)
+    debase-ruby_core_source (3.2.2)
     debug_inspector (1.1.0)
     diff-lcs (1.5.0)
     docile (1.4.0)

--- a/gemfiles/ruby_3.3.0_redis_5.gemfile.lock
+++ b/gemfiles/ruby_3.3.0_redis_5.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.14.0)
       datadog-ci (~> 0.1.0)
-      debase-ruby_core_source (= 3.2.1)
+      debase-ruby_core_source (= 3.2.2)
       libdatadog (~> 4.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
@@ -42,7 +42,7 @@ GEM
       rexml
     cri (2.15.11)
     datadog-ci (0.1.1)
-    debase-ruby_core_source (3.2.1)
+    debase-ruby_core_source (3.2.2)
     debug_inspector (1.1.0)
     diff-lcs (1.5.0)
     docile (1.4.0)

--- a/gemfiles/ruby_3.3.0_relational_db.gemfile.lock
+++ b/gemfiles/ruby_3.3.0_relational_db.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.14.0)
       datadog-ci (~> 0.1.0)
-      debase-ruby_core_source (= 3.2.1)
+      debase-ruby_core_source (= 3.2.2)
       libdatadog (~> 4.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
@@ -51,7 +51,7 @@ GEM
       rexml
     cri (2.15.11)
     datadog-ci (0.1.1)
-    debase-ruby_core_source (3.2.1)
+    debase-ruby_core_source (3.2.2)
     debug_inspector (1.1.0)
     delayed_job (4.1.11)
       activesupport (>= 3.0, < 8.0)

--- a/gemfiles/ruby_3.3.0_resque2_redis3.gemfile.lock
+++ b/gemfiles/ruby_3.3.0_resque2_redis3.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.14.0)
       datadog-ci (~> 0.1.0)
-      debase-ruby_core_source (= 3.2.1)
+      debase-ruby_core_source (= 3.2.2)
       libdatadog (~> 4.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
@@ -41,7 +41,7 @@ GEM
       rexml
     cri (2.15.11)
     datadog-ci (0.1.1)
-    debase-ruby_core_source (3.2.1)
+    debase-ruby_core_source (3.2.2)
     debug_inspector (1.1.0)
     diff-lcs (1.5.0)
     docile (1.4.0)

--- a/gemfiles/ruby_3.3.0_resque2_redis4.gemfile.lock
+++ b/gemfiles/ruby_3.3.0_resque2_redis4.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.14.0)
       datadog-ci (~> 0.1.0)
-      debase-ruby_core_source (= 3.2.1)
+      debase-ruby_core_source (= 3.2.2)
       libdatadog (~> 4.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
@@ -42,7 +42,7 @@ GEM
       rexml
     cri (2.15.11)
     datadog-ci (0.1.1)
-    debase-ruby_core_source (3.2.1)
+    debase-ruby_core_source (3.2.2)
     debug_inspector (1.1.0)
     diff-lcs (1.5.0)
     docile (1.4.0)

--- a/gemfiles/ruby_3.3.0_sinatra.gemfile.lock
+++ b/gemfiles/ruby_3.3.0_sinatra.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.14.0)
       datadog-ci (~> 0.1.0)
-      debase-ruby_core_source (= 3.2.1)
+      debase-ruby_core_source (= 3.2.2)
       libdatadog (~> 4.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
@@ -41,7 +41,7 @@ GEM
       rexml
     cri (2.15.11)
     datadog-ci (0.1.1)
-    debase-ruby_core_source (3.2.1)
+    debase-ruby_core_source (3.2.2)
     debug_inspector (1.1.0)
     diff-lcs (1.5.0)
     docile (1.4.0)


### PR DESCRIPTION
**What does this PR do?**:

This PR bumps our dependency on `debase-ruby_core_source` to version 3.2.2. This version is needed to support profiling Ruby 3.3.0-preview2.

**Motivation**:

Support profiling on Ruby 3.3.0-preview2.

**Additional Notes**:

I've updated the appraisal gemfiles as well.

The profiler is currently disabled on Ruby 3.3 (see #3053 for details). This PR is the first step towards re-enabling it again.

**How to test the change?**:

Validate that CI is green.

**For Datadog employees:**
- [ ] If this PR touches code that signs or publishes builds or packages, or handles
credentials of any kind, I've requested a review from `@DataDog/security-design-and-guidance`.
- [x] This PR doesn't touch any of that.