### PR TITLE
Automatically populate extra services

### DIFF
--- a/lib/datadog/core/configuration/settings.rb
+++ b/lib/datadog/core/configuration/settings.rb
@@ -643,13 +643,15 @@ module Datadog
           # configured to use names that differ from DD_SERVICE and should be
           # considered as a single remote configuration controllable service.
           #
-          # @default `nil`.
+          # @default `nil`. Automatically gathers service names from tracing configuration; use `[]` to disable.
           # @return [Array<String>,nil]
           option :extra_services do |o|
-            o.type :array
-            o.default []
+            o.type :array, nilable: true
+            o.default nil
             o.setter do |v|
-              if v.any? { |e| !e.is_a?(String) }
+              if v.nil?
+                v
+              elsif v.any? { |e| !e.is_a?(String) }
                 t = v.find { |e| !e.is_a?(String) }
 
                 raise ArgumentError, "Unexpected remote.extra_services element type #{t.class}, expected String."

--- a/lib/datadog/core/remote/client.rb
+++ b/lib/datadog/core/remote/client.rb
@@ -180,16 +180,16 @@ module Datadog
           config = Datadog.configuration.remote.extra_services
 
           if config.nil? && Datadog.configuration.tracing.enabled
-            return Datadog.configuration.tracing.instrumented_integrations.each_with_object([]) do |(k, v), a|
+            integrations = Datadog.configuration.tracing.instrumented_integrations.each_with_object([]) do |(k, v), a|
               next unless v.respond_to?(:service_name)
 
-              name = v.service_name.to_s
-
-              a << name unless name == service_name
+              a << v.service_name.to_s
             end
+
+            return integrations + [Datadog.configuration.service] - [service_name]
           end
 
-          config
+          config + [Datadog.configuration.service] - [service_name]
         end
 
         def tracer_version_semver2

--- a/lib/datadog/core/remote/client.rb
+++ b/lib/datadog/core/remote/client.rb
@@ -177,7 +177,19 @@ module Datadog
         end
 
         def extra_service_names
-          Datadog.configuration.remote.extra_services || []
+          config = Datadog.configuration.remote.extra_services
+
+          if config.nil? && Datadog.configuration.tracing.enabled
+            return Datadog.configuration.tracing.instrumented_integrations.each_with_object([]) do |(k, v), a|
+              next unless v.respond_to?(:service_name)
+
+              name = v.service_name.to_s
+
+              a << name unless name == service_name
+            end
+          end
+
+          config
         end
 
         def tracer_version_semver2

--- a/spec/datadog/core/configuration/settings_spec.rb
+++ b/spec/datadog/core/configuration/settings_spec.rb
@@ -1396,8 +1396,8 @@ RSpec.describe Datadog::Core::Configuration::Settings do
     describe '#extra_services' do
       subject(:extra_services) { settings.remote.extra_services }
 
-      context 'defaults to []' do
-        it { is_expected.to eq [] }
+      context 'defaults to nil' do
+        it { is_expected.to eq nil }
       end
     end
 
@@ -1405,13 +1405,8 @@ RSpec.describe Datadog::Core::Configuration::Settings do
       it 'updates the #extra_services setting' do
         expect { settings.remote.extra_services = ['foo'] }
           .to change { settings.remote.extra_services }
-          .from([])
+          .from(nil)
           .to(['foo'])
-      end
-
-      it 'rejects nil' do
-        expect { settings.remote.extra_services = nil }
-          .to raise_error(ArgumentError, /expects a array/)
       end
 
       it 'rejects nil items' do

--- a/spec/datadog/core/remote/client_spec.rb
+++ b/spec/datadog/core/remote/client_spec.rb
@@ -588,6 +588,43 @@ RSpec.describe Datadog::Core::Remote::Client do
               end
             end
 
+            context 'with remote extra_services setting default' do
+              it 'returns client_tracer' do
+                expect(Datadog.configuration.remote).to receive(:service).and_return('foo').at_least(:once)
+                expect(Datadog.configuration.tracing).to receive(:instrumented_integrations).and_return({ bar: Struct.new(:service_name).new(:bar) }).at_least(:once)
+                expect(Datadog.configuration.remote).to receive(:extra_services).and_return(nil).at_least(:once)
+
+                expected_client_tracer = {
+                  :runtime_id => Datadog::Core::Environment::Identity.id,
+                  :language => Datadog::Core::Environment::Identity.lang,
+                  :tracer_version => Datadog::Core::Environment::Identity.tracer_version_semver2,
+                  :service => Datadog.configuration.remote.service,
+                  :extra_services => ['bar'],
+                  :env => Datadog.configuration.env,
+                }
+
+                expect(client_payload[:client_tracer].tap { |h| h.delete(:tags) }).to eq(expected_client_tracer)
+              end
+            end
+
+            context 'with remote extra_services matching service' do
+              it 'returns client_tracer' do
+                expect(Datadog.configuration.remote).to receive(:service).and_return('foo').at_least(:once)
+                expect(Datadog.configuration.tracing).to receive(:instrumented_integrations).and_return({ foo: Struct.new(:service_name).new(:foo) }).at_least(:once)
+                expect(Datadog.configuration.remote).to receive(:extra_services).and_return(nil).at_least(:once)
+
+                expected_client_tracer = {
+                  :runtime_id => Datadog::Core::Environment::Identity.id,
+                  :language => Datadog::Core::Environment::Identity.lang,
+                  :tracer_version => Datadog::Core::Environment::Identity.tracer_version_semver2,
+                  :service => Datadog.configuration.remote.service,
+                  :env => Datadog.configuration.env,
+                }
+
+                expect(client_payload[:client_tracer].tap { |h| h.delete(:tags) }).to eq(expected_client_tracer)
+              end
+            end
+
             context 'with remote extra_services setting' do
               it 'returns client_tracer' do
                 expect(Datadog.configuration.remote).to receive(:service).and_return('foo').at_least(:once)


### PR DESCRIPTION
<!--
Check out the
https://github.com/DataDog/dd-trace-rb/blob/master/docs/DevelopmentGuide.md
for guidance on how to set up your development environment,
run the test suite, write new integrations, and more.
-->

**What does this PR do?**

Attempt to automatically populate service names from the process instrumented service names.

**Motivation:**

Follow-up to #3032 which is very manual and obscure to customers.

**Additional Notes:**

This may catch much more than is needed.

**How to test the change?**

- CI
- play with `c.remote.extra_services`

**For Datadog employees:**
- [ ] If this PR touches code that signs or publishes builds or packages, or handles
credentials of any kind, I've requested a review from `@DataDog/security-design-and-guidance`.
- [x] This PR doesn't touch any of that.

Unsure? Have a question? Request a review!
