### PR TITLE
[PROF-8289] Upgrade to libdatadog 5

### DIFF
--- a/ddtrace.gemspec
+++ b/ddtrace.gemspec
@@ -66,7 +66,7 @@ Gem::Specification.new do |spec|
 
   # Used by profiling (and possibly others in the future)
   # When updating the version here, please also update the version in `native_extension_helpers.rb` (and yes we have a test for it)
-  spec.add_dependency 'libdatadog', '~> 4.0.0.1.0'
+  spec.add_dependency 'libdatadog', '~> 5.0.0.1.0'
 
   # used for CI visibility product until the next major version
   spec.add_dependency 'datadog-ci', '~> 0.1.0'

--- a/ext/ddtrace_profiling_native_extension/collectors_cpu_and_wall_time_worker.c
+++ b/ext/ddtrace_profiling_native_extension/collectors_cpu_and_wall_time_worker.c
@@ -260,6 +260,9 @@ static const rb_data_type_t cpu_and_wall_time_worker_typed_data = {
 static VALUE _native_new(VALUE klass) {
   struct cpu_and_wall_time_worker_state *state = ruby_xcalloc(1, sizeof(struct cpu_and_wall_time_worker_state));
 
+  // Note: Any exceptions raised from this note until the TypedData_Wrap_Struct call will lead to the state memory
+  // being leaked.
+
   state->gc_profiling_enabled = false;
   state->allocation_counting_enabled = false;
   state->no_signals_workaround_enabled = false;

--- a/ext/ddtrace_profiling_native_extension/collectors_idle_sampling_helper.c
+++ b/ext/ddtrace_profiling_native_extension/collectors_idle_sampling_helper.c
@@ -78,6 +78,9 @@ static const rb_data_type_t idle_sampling_helper_typed_data = {
 static VALUE _native_new(VALUE klass) {
   struct idle_sampling_loop_state *state = ruby_xcalloc(1, sizeof(struct idle_sampling_loop_state));
 
+  // Note: Any exceptions raised from this note until the TypedData_Wrap_Struct call will lead to the state memory
+  // being leaked.
+
   reset_state(state);
 
   return TypedData_Wrap_Struct(klass, &idle_sampling_helper_typed_data, state);

--- a/ext/ddtrace_profiling_native_extension/collectors_thread_context.c
+++ b/ext/ddtrace_profiling_native_extension/collectors_thread_context.c
@@ -304,6 +304,9 @@ static int hash_map_per_thread_context_free_values(DDTRACE_UNUSED st_data_t _thr
 static VALUE _native_new(VALUE klass) {
   struct thread_context_collector_state *state = ruby_xcalloc(1, sizeof(struct thread_context_collector_state));
 
+  // Note: Any exceptions raised from this note until the TypedData_Wrap_Struct call will lead to the state memory
+  // being leaked.
+
   // Update this when modifying state struct
   state->sampling_buffer = NULL;
   state->hash_map_per_thread_context =

--- a/ext/ddtrace_profiling_native_extension/http_transport.c
+++ b/ext/ddtrace_profiling_native_extension/http_transport.c
@@ -201,7 +201,8 @@ static VALUE perform_export(
   ddog_prof_Exporter *exporter,
   ddog_Timespec start,
   ddog_Timespec finish,
-  ddog_prof_Exporter_Slice_File slice_files,
+  ddog_prof_Exporter_Slice_File files_to_compress_and_export,
+  ddog_prof_Exporter_Slice_File files_to_export_unmodified,
   ddog_Vec_Tag *additional_tags,
   ddog_CharSlice internal_metadata,
   uint64_t timeout_milliseconds
@@ -211,7 +212,8 @@ static VALUE perform_export(
     exporter,
     start,
     finish,
-    slice_files,
+    files_to_compress_and_export,
+    files_to_export_unmodified,
     additional_tags,
     endpoints_stats,
     &internal_metadata,
@@ -308,18 +310,23 @@ static VALUE _native_do_export(
   ddog_Timespec finish =
     {.seconds = NUM2LONG(finish_timespec_seconds), .nanoseconds = NUM2UINT(finish_timespec_nanoseconds)};
 
-  int files_to_report = 1 + (have_code_provenance ? 1 : 0);
-  ddog_prof_Exporter_File files[files_to_report];
-  ddog_prof_Exporter_Slice_File slice_files = {.ptr = files, .len = files_to_report};
+  int to_compress_length = have_code_provenance ? 1 : 0;
+  ddog_prof_Exporter_File to_compress[to_compress_length];
+  int already_compressed_length = 1; // pprof
+  ddog_prof_Exporter_File already_compressed[already_compressed_length];
 
-  files[0] = (ddog_prof_Exporter_File) {
+  ddog_prof_Exporter_Slice_File files_to_compress_and_export = {.ptr = to_compress, .len = to_compress_length};
+  ddog_prof_Exporter_Slice_File files_to_export_unmodified = {.ptr = already_compressed, .len = already_compressed_length};
+
+  already_compressed[0] = (ddog_prof_Exporter_File) {
     .name = char_slice_from_ruby_string(pprof_file_name),
-    .file = byte_slice_from_ruby_string(pprof_data)
+    .file = byte_slice_from_ruby_string(pprof_data),
   };
+
   if (have_code_provenance) {
-    files[1] = (ddog_prof_Exporter_File) {
+    to_compress[0] = (ddog_prof_Exporter_File) {
       .name = char_slice_from_ruby_string(code_provenance_file_name),
-      .file = byte_slice_from_ruby_string(code_provenance_data)
+      .file = byte_slice_from_ruby_string(code_provenance_data),
     };
   }
 
@@ -332,7 +339,16 @@ static VALUE _native_do_export(
   VALUE failure_tuple = handle_exporter_failure(exporter_result);
   if (!NIL_P(failure_tuple)) return failure_tuple;
 
-  return perform_export(exporter_result.ok, start, finish, slice_files, null_additional_tags, internal_metadata, timeout_milliseconds);
+  return perform_export(
+    exporter_result.ok,
+    start,
+    finish,
+    files_to_compress_and_export,
+    files_to_export_unmodified,
+    null_additional_tags,
+    internal_metadata,
+    timeout_milliseconds
+  );
 }
 
 static void *call_exporter_without_gvl(void *call_args) {

--- a/ext/ddtrace_profiling_native_extension/native_extension_helpers.rb
+++ b/ext/ddtrace_profiling_native_extension/native_extension_helpers.rb
@@ -15,7 +15,7 @@ module Datadog
       # The MJIT header was introduced on 2.6 and removed on 3.3; for other Rubies we rely on debase-ruby_core_source
       CAN_USE_MJIT_HEADER = RUBY_VERSION.start_with?('2.6', '2.7', '3.0.', '3.1.', '3.2.')
 
-      LIBDATADOG_VERSION = '~> 4.0.0.1.0'
+      LIBDATADOG_VERSION = '~> 5.0.0.1.0'
 
       def self.fail_install_if_missing_extension?
         ENV[ENV_FAIL_INSTALL_IF_MISSING_EXTENSION].to_s.strip.downcase == 'true'

--- a/ext/ddtrace_profiling_native_extension/stack_recorder.c
+++ b/ext/ddtrace_profiling_native_extension/stack_recorder.c
@@ -387,9 +387,6 @@ static VALUE _native_serialize(DDTRACE_UNUSED VALUE _self, VALUE recorder_instan
   VALUE start = ruby_time_from(ddprof_start);
   VALUE finish = ruby_time_from(ddprof_finish);
 
-  // This will raise on error
-  reset_profile(args.profile, /* start_time: */ NULL);
-
   return rb_ary_new_from_args(2, ok_symbol, rb_ary_new_from_args(3, start, finish, encoded_pprof));
 }
 
@@ -453,7 +450,8 @@ static void *call_serialize_without_gvl(void *call_args) {
   struct call_serialize_without_gvl_arguments *args = (struct call_serialize_without_gvl_arguments *) call_args;
 
   args->profile = serializer_flip_active_and_inactive_slots(args->state);
-  args->result = ddog_prof_Profile_serialize(args->profile, &args->finish_timestamp, NULL /* duration_nanos is optional */);
+  // Note: The profile gets reset by the serialize call
+  args->result = ddog_prof_Profile_serialize(args->profile, &args->finish_timestamp, NULL /* duration_nanos is optional */, NULL /* start_time is optional */);
   args->serialize_ran = true;
 
   return NULL; // Unused

--- a/ext/ddtrace_profiling_native_extension/stack_recorder.c
+++ b/ext/ddtrace_profiling_native_extension/stack_recorder.c
@@ -423,7 +423,8 @@ void record_sample(VALUE recorder_instance, ddog_prof_Slice_Location locations, 
       .locations = locations,
       .values = (ddog_Slice_I64) {.ptr = metric_values, .len = state->enabled_values_count},
       .labels = labels.labels
-    }
+    },
+    labels.end_timestamp_ns
   );
 
   sampler_unlock_active_profile(active_slot);

--- a/ext/ddtrace_profiling_native_extension/stack_recorder.c
+++ b/ext/ddtrace_profiling_native_extension/stack_recorder.c
@@ -197,6 +197,7 @@ struct call_serialize_without_gvl_arguments {
 
 static VALUE _native_new(VALUE klass);
 static void initialize_slot_concurrency_control(struct stack_recorder_state *state);
+static void initialize_profiles(struct stack_recorder_state *state, ddog_prof_Slice_ValueType sample_types);
 static void stack_recorder_typed_data_free(void *data);
 static VALUE _native_initialize(DDTRACE_UNUSED VALUE _self, VALUE recorder_instance, VALUE cpu_time_enabled, VALUE alloc_samples_enabled);
 static VALUE _native_serialize(VALUE self, VALUE recorder_instance);
@@ -257,18 +258,25 @@ static const rb_data_type_t stack_recorder_typed_data = {
 static VALUE _native_new(VALUE klass) {
   struct stack_recorder_state *state = ruby_xcalloc(1, sizeof(struct stack_recorder_state));
 
+  // Note: Any exceptions raised from this note until the TypedData_Wrap_Struct call will lead to the state memory
+  // being leaked.
+
   ddog_prof_Slice_ValueType sample_types = {.ptr = all_value_types, .len = ALL_VALUE_TYPES_COUNT};
 
   initialize_slot_concurrency_control(state);
   for (uint8_t i = 0; i < ALL_VALUE_TYPES_COUNT; i++) { state->position_for[i] = all_value_types_positions[i]; }
   state->enabled_values_count = ALL_VALUE_TYPES_COUNT;
 
+  // Note: At this point, slot_one_profile and slot_two_profile contain null pointers. Libdatadog validates pointers
+  // before using them so it's ok for us to go ahead and create the StackRecorder object.
+
+  VALUE stack_recorder = TypedData_Wrap_Struct(klass, &stack_recorder_typed_data, state);
+
   // Note: Don't raise exceptions after this point, since it'll lead to libdatadog memory leaking!
 
-  state->slot_one_profile = ddog_prof_Profile_new(sample_types, NULL /* period is optional */, NULL /* start_time is optional */);
-  state->slot_two_profile = ddog_prof_Profile_new(sample_types, NULL /* period is optional */, NULL /* start_time is optional */);
+  initialize_profiles(state, sample_types);
 
-  return TypedData_Wrap_Struct(klass, &stack_recorder_typed_data, state);
+  return stack_recorder;
 }
 
 static void initialize_slot_concurrency_control(struct stack_recorder_state *state) {
@@ -279,6 +287,28 @@ static void initialize_slot_concurrency_control(struct stack_recorder_state *sta
   ENFORCE_SUCCESS_GVL(pthread_mutex_lock(&state->slot_two_mutex));
 
   state->active_slot = 1;
+}
+
+static void initialize_profiles(struct stack_recorder_state *state, ddog_prof_Slice_ValueType sample_types) {
+  ddog_prof_Profile_NewResult slot_one_profile_result =
+    ddog_prof_Profile_new(sample_types, NULL /* period is optional */, NULL /* start_time is optional */);
+
+  if (slot_one_profile_result.tag == DDOG_PROF_PROFILE_NEW_RESULT_ERR) {
+    rb_raise(rb_eRuntimeError, "Failed to initialize slot one profile: %"PRIsVALUE, get_error_details_and_drop(&slot_one_profile_result.err));
+  }
+
+  ddog_prof_Profile_NewResult slot_two_profile_result =
+    ddog_prof_Profile_new(sample_types, NULL /* period is optional */, NULL /* start_time is optional */);
+
+  if (slot_two_profile_result.tag == DDOG_PROF_PROFILE_NEW_RESULT_ERR) {
+    // Uff! Though spot. We need to make sure to properly clean up the other profile as well first
+    ddog_prof_Profile_drop(&slot_one_profile_result.ok);
+    // And now we can raise...
+    rb_raise(rb_eRuntimeError, "Failed to initialize slot two profile: %"PRIsVALUE, get_error_details_and_drop(&slot_two_profile_result.err));
+  }
+
+  state->slot_one_profile = slot_one_profile_result.ok;
+  state->slot_two_profile = slot_two_profile_result.ok;
 }
 
 static void stack_recorder_typed_data_free(void *state_ptr) {
@@ -334,13 +364,11 @@ static VALUE _native_initialize(DDTRACE_UNUSED VALUE _self, VALUE recorder_insta
     state->position_for[ALLOC_SAMPLES_VALUE_ID] = next_disabled_pos++;
   }
 
-  ddog_prof_Slice_ValueType sample_types = {.ptr = enabled_value_types, .len = state->enabled_values_count};
-
   ddog_prof_Profile_drop(&state->slot_one_profile);
   ddog_prof_Profile_drop(&state->slot_two_profile);
 
-  state->slot_one_profile = ddog_prof_Profile_new(sample_types, NULL /* period is optional */, NULL /* start_time is optional */);
-  state->slot_two_profile = ddog_prof_Profile_new(sample_types, NULL /* period is optional */, NULL /* start_time is optional */);
+  ddog_prof_Slice_ValueType sample_types = {.ptr = enabled_value_types, .len = state->enabled_values_count};
+  initialize_profiles(state, sample_types);
 
   return Qtrue;
 }

--- a/ext/ddtrace_profiling_native_extension/stack_recorder.h
+++ b/ext/ddtrace_profiling_native_extension/stack_recorder.h
@@ -15,6 +15,8 @@ typedef struct sample_labels {
   // This is used to allow the `Collectors::Stack` to modify the existing label, if any. This MUST be NULL or point
   // somewhere inside the labels slice above.
   ddog_prof_Label *state_label;
+
+  int64_t end_timestamp_ns;
 } sample_labels;
 
 void record_sample(VALUE recorder_instance, ddog_prof_Slice_Location locations, sample_values values, sample_labels labels);

--- a/gemfiles/jruby_9.2.21.0_sinatra.gemfile.lock
+++ b/gemfiles/jruby_9.2.21.0_sinatra.gemfile.lock
@@ -14,7 +14,7 @@ PATH
     ddtrace (1.14.0)
       datadog-ci (~> 0.1.0)
       debase-ruby_core_source (= 3.2.2)
-      libdatadog (~> 4.0.0.1.0)
+      libdatadog (~> 5.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
 
@@ -46,7 +46,7 @@ GEM
     hashdiff (1.0.1)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (4.0.0.1.0)
+    libdatadog (5.0.0.1.0)
     libddwaf (1.14.0.0.0-java)
       ffi (~> 1.0)
     memory_profiler (0.9.14)

--- a/gemfiles/jruby_9.2_activesupport.gemfile.lock
+++ b/gemfiles/jruby_9.2_activesupport.gemfile.lock
@@ -14,7 +14,7 @@ PATH
     ddtrace (1.14.0)
       datadog-ci (~> 0.1.0)
       debase-ruby_core_source (= 3.2.2)
-      libdatadog (~> 4.0.0.1.0)
+      libdatadog (~> 5.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
 
@@ -106,7 +106,7 @@ GEM
       addressable (>= 2.4)
     jsonapi-renderer (0.2.2)
     king_konf (1.0.1)
-    libdatadog (4.0.0.1.0)
+    libdatadog (5.0.0.1.0)
     libddwaf (1.14.0.0.0-java)
       ffi (~> 1.0)
     lograge (0.13.0)

--- a/gemfiles/jruby_9.2_aws.gemfile.lock
+++ b/gemfiles/jruby_9.2_aws.gemfile.lock
@@ -14,7 +14,7 @@ PATH
     ddtrace (1.14.0)
       datadog-ci (~> 0.1.0)
       debase-ruby_core_source (= 3.2.2)
-      libdatadog (~> 4.0.0.1.0)
+      libdatadog (~> 5.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
 
@@ -1468,7 +1468,7 @@ GEM
     jmespath (1.6.2)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (4.0.0.1.0)
+    libdatadog (5.0.0.1.0)
     libddwaf (1.14.0.0.0-java)
       ffi (~> 1.0)
     memory_profiler (0.9.14)

--- a/gemfiles/jruby_9.2_contrib.gemfile.lock
+++ b/gemfiles/jruby_9.2_contrib.gemfile.lock
@@ -14,7 +14,7 @@ PATH
     ddtrace (1.14.0)
       datadog-ci (~> 0.1.0)
       debase-ruby_core_source (= 3.2.2)
-      libdatadog (~> 4.0.0.1.0)
+      libdatadog (~> 5.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
 
@@ -56,7 +56,7 @@ GEM
       concurrent-ruby (~> 1.0)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (4.0.0.1.0)
+    libdatadog (5.0.0.1.0)
     libddwaf (1.14.0.0.0-java)
       ffi (~> 1.0)
     memory_profiler (0.9.14)

--- a/gemfiles/jruby_9.2_contrib_old.gemfile.lock
+++ b/gemfiles/jruby_9.2_contrib_old.gemfile.lock
@@ -14,7 +14,7 @@ PATH
     ddtrace (1.14.0)
       datadog-ci (~> 0.1.0)
       debase-ruby_core_source (= 3.2.2)
-      libdatadog (~> 4.0.0.1.0)
+      libdatadog (~> 5.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
 
@@ -60,7 +60,7 @@ GEM
     hashdiff (1.0.1)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (4.0.0.1.0)
+    libdatadog (5.0.0.1.0)
     libddwaf (1.14.0.0.0-java)
       ffi (~> 1.0)
     memory_profiler (0.9.14)

--- a/gemfiles/jruby_9.2_core_old.gemfile.lock
+++ b/gemfiles/jruby_9.2_core_old.gemfile.lock
@@ -14,7 +14,7 @@ PATH
     ddtrace (1.14.0)
       datadog-ci (~> 0.1.0)
       debase-ruby_core_source (= 3.2.2)
-      libdatadog (~> 4.0.0.1.0)
+      libdatadog (~> 5.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
 
@@ -46,7 +46,7 @@ GEM
     hashdiff (1.0.1)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (4.0.0.1.0)
+    libdatadog (5.0.0.1.0)
     libddwaf (1.14.0.0.0-java)
       ffi (~> 1.0)
     memory_profiler (0.9.14)

--- a/gemfiles/jruby_9.2_hanami_1.gemfile.lock
+++ b/gemfiles/jruby_9.2_hanami_1.gemfile.lock
@@ -14,7 +14,7 @@ PATH
     ddtrace (1.14.0)
       datadog-ci (~> 0.1.0)
       debase-ruby_core_source (= 3.2.2)
-      libdatadog (~> 4.0.0.1.0)
+      libdatadog (~> 5.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
 
@@ -122,7 +122,7 @@ GEM
     io-wait (0.3.0-java)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (4.0.0.1.0)
+    libdatadog (5.0.0.1.0)
     libddwaf (1.14.0.0.0-java)
       ffi (~> 1.0)
     mail (2.8.0.1)

--- a/gemfiles/jruby_9.2_http.gemfile.lock
+++ b/gemfiles/jruby_9.2_http.gemfile.lock
@@ -14,7 +14,7 @@ PATH
     ddtrace (1.14.0)
       datadog-ci (~> 0.1.0)
       debase-ruby_core_source (= 3.2.2)
-      libdatadog (~> 4.0.0.1.0)
+      libdatadog (~> 5.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
 
@@ -97,7 +97,7 @@ GEM
     httpclient (2.8.3)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (4.0.0.1.0)
+    libdatadog (5.0.0.1.0)
     libddwaf (1.14.0.0.0-java)
       ffi (~> 1.0)
     memory_profiler (0.9.14)

--- a/gemfiles/jruby_9.2_opentracing.gemfile.lock
+++ b/gemfiles/jruby_9.2_opentracing.gemfile.lock
@@ -14,7 +14,7 @@ PATH
     ddtrace (1.14.0)
       datadog-ci (~> 0.1.0)
       debase-ruby_core_source (= 3.2.2)
-      libdatadog (~> 4.0.0.1.0)
+      libdatadog (~> 5.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
 
@@ -47,7 +47,7 @@ GEM
     hashdiff (1.0.1)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (4.0.0.1.0)
+    libdatadog (5.0.0.1.0)
     libddwaf (1.14.0.0.0-java)
       ffi (~> 1.0)
     memory_profiler (0.9.14)

--- a/gemfiles/jruby_9.2_rack_1.gemfile.lock
+++ b/gemfiles/jruby_9.2_rack_1.gemfile.lock
@@ -14,7 +14,7 @@ PATH
     ddtrace (1.14.0)
       datadog-ci (~> 0.1.0)
       debase-ruby_core_source (= 3.2.2)
-      libdatadog (~> 4.0.0.1.0)
+      libdatadog (~> 5.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
 
@@ -46,7 +46,7 @@ GEM
     hashdiff (1.0.1)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (4.0.0.1.0)
+    libdatadog (5.0.0.1.0)
     libddwaf (1.14.0.0.0-java)
       ffi (~> 1.0)
     memory_profiler (0.9.14)

--- a/gemfiles/jruby_9.2_rack_2.gemfile.lock
+++ b/gemfiles/jruby_9.2_rack_2.gemfile.lock
@@ -14,7 +14,7 @@ PATH
     ddtrace (1.14.0)
       datadog-ci (~> 0.1.0)
       debase-ruby_core_source (= 3.2.2)
-      libdatadog (~> 4.0.0.1.0)
+      libdatadog (~> 5.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
 
@@ -46,7 +46,7 @@ GEM
     hashdiff (1.0.1)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (4.0.0.1.0)
+    libdatadog (5.0.0.1.0)
     libddwaf (1.14.0.0.0-java)
       ffi (~> 1.0)
     memory_profiler (0.9.14)

--- a/gemfiles/jruby_9.2_rack_3.gemfile.lock
+++ b/gemfiles/jruby_9.2_rack_3.gemfile.lock
@@ -14,7 +14,7 @@ PATH
     ddtrace (1.14.0)
       datadog-ci (~> 0.1.0)
       debase-ruby_core_source (= 3.2.2)
-      libdatadog (~> 4.0.0.1.0)
+      libdatadog (~> 5.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
 
@@ -46,7 +46,7 @@ GEM
     hashdiff (1.0.1)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (4.0.0.1.0)
+    libdatadog (5.0.0.1.0)
     libddwaf (1.14.0.0.0-java)
       ffi (~> 1.0)
     memory_profiler (0.9.14)

--- a/gemfiles/jruby_9.2_rails5_mysql2.gemfile.lock
+++ b/gemfiles/jruby_9.2_rails5_mysql2.gemfile.lock
@@ -14,7 +14,7 @@ PATH
     ddtrace (1.14.0)
       datadog-ci (~> 0.1.0)
       debase-ruby_core_source (= 3.2.2)
-      libdatadog (~> 4.0.0.1.0)
+      libdatadog (~> 5.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
 
@@ -100,7 +100,7 @@ GEM
     jdbc-mysql (8.0.27)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (4.0.0.1.0)
+    libdatadog (5.0.0.1.0)
     libddwaf (1.14.0.0.0-java)
       ffi (~> 1.0)
     lograge (0.12.0)

--- a/gemfiles/jruby_9.2_rails5_postgres.gemfile.lock
+++ b/gemfiles/jruby_9.2_rails5_postgres.gemfile.lock
@@ -14,7 +14,7 @@ PATH
     ddtrace (1.14.0)
       datadog-ci (~> 0.1.0)
       debase-ruby_core_source (= 3.2.2)
-      libdatadog (~> 4.0.0.1.0)
+      libdatadog (~> 5.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
 
@@ -102,7 +102,7 @@ GEM
     jdbc-postgres (42.2.25)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (4.0.0.1.0)
+    libdatadog (5.0.0.1.0)
     libddwaf (1.14.0.0.0-java)
       ffi (~> 1.0)
     lograge (0.12.0)

--- a/gemfiles/jruby_9.2_rails5_postgres_redis.gemfile.lock
+++ b/gemfiles/jruby_9.2_rails5_postgres_redis.gemfile.lock
@@ -14,7 +14,7 @@ PATH
     ddtrace (1.14.0)
       datadog-ci (~> 0.1.0)
       debase-ruby_core_source (= 3.2.2)
-      libdatadog (~> 4.0.0.1.0)
+      libdatadog (~> 5.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
 
@@ -103,7 +103,7 @@ GEM
     jdbc-postgres (42.2.25)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (4.0.0.1.0)
+    libdatadog (5.0.0.1.0)
     libddwaf (1.14.0.0.0-java)
       ffi (~> 1.0)
     lograge (0.12.0)

--- a/gemfiles/jruby_9.2_rails5_postgres_redis_activesupport.gemfile.lock
+++ b/gemfiles/jruby_9.2_rails5_postgres_redis_activesupport.gemfile.lock
@@ -14,7 +14,7 @@ PATH
     ddtrace (1.14.0)
       datadog-ci (~> 0.1.0)
       debase-ruby_core_source (= 3.2.2)
-      libdatadog (~> 4.0.0.1.0)
+      libdatadog (~> 5.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
 
@@ -102,7 +102,7 @@ GEM
     jdbc-postgres (42.2.25)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (4.0.0.1.0)
+    libdatadog (5.0.0.1.0)
     libddwaf (1.14.0.0.0-java)
       ffi (~> 1.0)
     lograge (0.12.0)

--- a/gemfiles/jruby_9.2_rails5_postgres_sidekiq.gemfile.lock
+++ b/gemfiles/jruby_9.2_rails5_postgres_sidekiq.gemfile.lock
@@ -14,7 +14,7 @@ PATH
     ddtrace (1.14.0)
       datadog-ci (~> 0.1.0)
       debase-ruby_core_source (= 3.2.2)
-      libdatadog (~> 4.0.0.1.0)
+      libdatadog (~> 5.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
 
@@ -103,7 +103,7 @@ GEM
     jdbc-postgres (42.2.25)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (4.0.0.1.0)
+    libdatadog (5.0.0.1.0)
     libddwaf (1.14.0.0.0-java)
       ffi (~> 1.0)
     lograge (0.12.0)

--- a/gemfiles/jruby_9.2_rails5_semantic_logger.gemfile.lock
+++ b/gemfiles/jruby_9.2_rails5_semantic_logger.gemfile.lock
@@ -14,7 +14,7 @@ PATH
     ddtrace (1.14.0)
       datadog-ci (~> 0.1.0)
       debase-ruby_core_source (= 3.2.2)
-      libdatadog (~> 4.0.0.1.0)
+      libdatadog (~> 5.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
 
@@ -102,7 +102,7 @@ GEM
     jdbc-postgres (42.2.25)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (4.0.0.1.0)
+    libdatadog (5.0.0.1.0)
     libddwaf (1.14.0.0.0-java)
       ffi (~> 1.0)
     loofah (2.19.1)

--- a/gemfiles/jruby_9.2_rails61_mysql2.gemfile.lock
+++ b/gemfiles/jruby_9.2_rails61_mysql2.gemfile.lock
@@ -14,7 +14,7 @@ PATH
     ddtrace (1.14.0)
       datadog-ci (~> 0.1.0)
       debase-ruby_core_source (= 3.2.2)
-      libdatadog (~> 4.0.0.1.0)
+      libdatadog (~> 5.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
 
@@ -117,7 +117,7 @@ GEM
     jdbc-mysql (8.0.27)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (4.0.0.1.0)
+    libdatadog (5.0.0.1.0)
     libddwaf (1.14.0.0.0-java)
       ffi (~> 1.0)
     lograge (0.12.0)

--- a/gemfiles/jruby_9.2_rails61_postgres.gemfile.lock
+++ b/gemfiles/jruby_9.2_rails61_postgres.gemfile.lock
@@ -14,7 +14,7 @@ PATH
     ddtrace (1.14.0)
       datadog-ci (~> 0.1.0)
       debase-ruby_core_source (= 3.2.2)
-      libdatadog (~> 4.0.0.1.0)
+      libdatadog (~> 5.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
 
@@ -119,7 +119,7 @@ GEM
     jdbc-postgres (42.2.25)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (4.0.0.1.0)
+    libdatadog (5.0.0.1.0)
     libddwaf (1.14.0.0.0-java)
       ffi (~> 1.0)
     lograge (0.12.0)

--- a/gemfiles/jruby_9.2_rails61_postgres_redis.gemfile.lock
+++ b/gemfiles/jruby_9.2_rails61_postgres_redis.gemfile.lock
@@ -14,7 +14,7 @@ PATH
     ddtrace (1.14.0)
       datadog-ci (~> 0.1.0)
       debase-ruby_core_source (= 3.2.2)
-      libdatadog (~> 4.0.0.1.0)
+      libdatadog (~> 5.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
 
@@ -120,7 +120,7 @@ GEM
     jdbc-postgres (42.2.25)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (4.0.0.1.0)
+    libdatadog (5.0.0.1.0)
     libddwaf (1.14.0.0.0-java)
       ffi (~> 1.0)
     lograge (0.12.0)

--- a/gemfiles/jruby_9.2_rails61_postgres_sidekiq.gemfile.lock
+++ b/gemfiles/jruby_9.2_rails61_postgres_sidekiq.gemfile.lock
@@ -14,7 +14,7 @@ PATH
     ddtrace (1.14.0)
       datadog-ci (~> 0.1.0)
       debase-ruby_core_source (= 3.2.2)
-      libdatadog (~> 4.0.0.1.0)
+      libdatadog (~> 5.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
 
@@ -120,7 +120,7 @@ GEM
     jdbc-postgres (42.2.25)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (4.0.0.1.0)
+    libdatadog (5.0.0.1.0)
     libddwaf (1.14.0.0.0-java)
       ffi (~> 1.0)
     lograge (0.12.0)

--- a/gemfiles/jruby_9.2_rails61_semantic_logger.gemfile.lock
+++ b/gemfiles/jruby_9.2_rails61_semantic_logger.gemfile.lock
@@ -14,7 +14,7 @@ PATH
     ddtrace (1.14.0)
       datadog-ci (~> 0.1.0)
       debase-ruby_core_source (= 3.2.2)
-      libdatadog (~> 4.0.0.1.0)
+      libdatadog (~> 5.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
 
@@ -119,7 +119,7 @@ GEM
     jdbc-postgres (42.2.25)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (4.0.0.1.0)
+    libdatadog (5.0.0.1.0)
     libddwaf (1.14.0.0.0-java)
       ffi (~> 1.0)
     loofah (2.19.1)

--- a/gemfiles/jruby_9.2_rails6_mysql2.gemfile.lock
+++ b/gemfiles/jruby_9.2_rails6_mysql2.gemfile.lock
@@ -14,7 +14,7 @@ PATH
     ddtrace (1.14.0)
       datadog-ci (~> 0.1.0)
       debase-ruby_core_source (= 3.2.2)
-      libdatadog (~> 4.0.0.1.0)
+      libdatadog (~> 5.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
 
@@ -113,7 +113,7 @@ GEM
     jdbc-mysql (8.0.27)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (4.0.0.1.0)
+    libdatadog (5.0.0.1.0)
     libddwaf (1.14.0.0.0-java)
       ffi (~> 1.0)
     lograge (0.12.0)

--- a/gemfiles/jruby_9.2_rails6_postgres.gemfile.lock
+++ b/gemfiles/jruby_9.2_rails6_postgres.gemfile.lock
@@ -14,7 +14,7 @@ PATH
     ddtrace (1.14.0)
       datadog-ci (~> 0.1.0)
       debase-ruby_core_source (= 3.2.2)
-      libdatadog (~> 4.0.0.1.0)
+      libdatadog (~> 5.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
 
@@ -115,7 +115,7 @@ GEM
     jdbc-postgres (42.2.25)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (4.0.0.1.0)
+    libdatadog (5.0.0.1.0)
     libddwaf (1.14.0.0.0-java)
       ffi (~> 1.0)
     lograge (0.12.0)

--- a/gemfiles/jruby_9.2_rails6_postgres_redis.gemfile.lock
+++ b/gemfiles/jruby_9.2_rails6_postgres_redis.gemfile.lock
@@ -14,7 +14,7 @@ PATH
     ddtrace (1.14.0)
       datadog-ci (~> 0.1.0)
       debase-ruby_core_source (= 3.2.2)
-      libdatadog (~> 4.0.0.1.0)
+      libdatadog (~> 5.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
 
@@ -116,7 +116,7 @@ GEM
     jdbc-postgres (42.2.25)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (4.0.0.1.0)
+    libdatadog (5.0.0.1.0)
     libddwaf (1.14.0.0.0-java)
       ffi (~> 1.0)
     lograge (0.12.0)

--- a/gemfiles/jruby_9.2_rails6_postgres_redis_activesupport.gemfile.lock
+++ b/gemfiles/jruby_9.2_rails6_postgres_redis_activesupport.gemfile.lock
@@ -14,7 +14,7 @@ PATH
     ddtrace (1.14.0)
       datadog-ci (~> 0.1.0)
       debase-ruby_core_source (= 3.2.2)
-      libdatadog (~> 4.0.0.1.0)
+      libdatadog (~> 5.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
 
@@ -115,7 +115,7 @@ GEM
     jdbc-postgres (42.2.25)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (4.0.0.1.0)
+    libdatadog (5.0.0.1.0)
     libddwaf (1.14.0.0.0-java)
       ffi (~> 1.0)
     lograge (0.12.0)

--- a/gemfiles/jruby_9.2_rails6_postgres_sidekiq.gemfile.lock
+++ b/gemfiles/jruby_9.2_rails6_postgres_sidekiq.gemfile.lock
@@ -14,7 +14,7 @@ PATH
     ddtrace (1.14.0)
       datadog-ci (~> 0.1.0)
       debase-ruby_core_source (= 3.2.2)
-      libdatadog (~> 4.0.0.1.0)
+      libdatadog (~> 5.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
 
@@ -116,7 +116,7 @@ GEM
     jdbc-postgres (42.2.25)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (4.0.0.1.0)
+    libdatadog (5.0.0.1.0)
     libddwaf (1.14.0.0.0-java)
       ffi (~> 1.0)
     lograge (0.12.0)

--- a/gemfiles/jruby_9.2_rails6_semantic_logger.gemfile.lock
+++ b/gemfiles/jruby_9.2_rails6_semantic_logger.gemfile.lock
@@ -14,7 +14,7 @@ PATH
     ddtrace (1.14.0)
       datadog-ci (~> 0.1.0)
       debase-ruby_core_source (= 3.2.2)
-      libdatadog (~> 4.0.0.1.0)
+      libdatadog (~> 5.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
 
@@ -115,7 +115,7 @@ GEM
     jdbc-postgres (42.2.25)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (4.0.0.1.0)
+    libdatadog (5.0.0.1.0)
     libddwaf (1.14.0.0.0-java)
       ffi (~> 1.0)
     loofah (2.19.1)

--- a/gemfiles/jruby_9.2_redis_3.gemfile.lock
+++ b/gemfiles/jruby_9.2_redis_3.gemfile.lock
@@ -14,7 +14,7 @@ PATH
     ddtrace (1.14.0)
       datadog-ci (~> 0.1.0)
       debase-ruby_core_source (= 3.2.2)
-      libdatadog (~> 4.0.0.1.0)
+      libdatadog (~> 5.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
 
@@ -46,7 +46,7 @@ GEM
     hashdiff (1.0.1)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (4.0.0.1.0)
+    libdatadog (5.0.0.1.0)
     libddwaf (1.14.0.0.0-java)
       ffi (~> 1.0)
     memory_profiler (0.9.14)

--- a/gemfiles/jruby_9.2_redis_4.gemfile.lock
+++ b/gemfiles/jruby_9.2_redis_4.gemfile.lock
@@ -14,7 +14,7 @@ PATH
     ddtrace (1.14.0)
       datadog-ci (~> 0.1.0)
       debase-ruby_core_source (= 3.2.2)
-      libdatadog (~> 4.0.0.1.0)
+      libdatadog (~> 5.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
 
@@ -46,7 +46,7 @@ GEM
     hashdiff (1.0.1)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (4.0.0.1.0)
+    libdatadog (5.0.0.1.0)
     libddwaf (1.14.0.0.0-java)
       ffi (~> 1.0)
     memory_profiler (0.9.14)

--- a/gemfiles/jruby_9.2_redis_5.gemfile.lock
+++ b/gemfiles/jruby_9.2_redis_5.gemfile.lock
@@ -14,7 +14,7 @@ PATH
     ddtrace (1.14.0)
       datadog-ci (~> 0.1.0)
       debase-ruby_core_source (= 3.2.2)
-      libdatadog (~> 4.0.0.1.0)
+      libdatadog (~> 5.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
 
@@ -47,7 +47,7 @@ GEM
     hashdiff (1.0.1)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (4.0.0.1.0)
+    libdatadog (5.0.0.1.0)
     libddwaf (1.14.0.0.0-java)
       ffi (~> 1.0)
     memory_profiler (0.9.14)

--- a/gemfiles/jruby_9.2_relational_db.gemfile.lock
+++ b/gemfiles/jruby_9.2_relational_db.gemfile.lock
@@ -14,7 +14,7 @@ PATH
     ddtrace (1.14.0)
       datadog-ci (~> 0.1.0)
       debase-ruby_core_source (= 3.2.2)
-      libdatadog (~> 4.0.0.1.0)
+      libdatadog (~> 5.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
 
@@ -79,7 +79,7 @@ GEM
     jdbc-sqlite3 (3.28.0)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (4.0.0.1.0)
+    libdatadog (5.0.0.1.0)
     libddwaf (1.14.0.0.0-java)
       ffi (~> 1.0)
     makara (0.5.1)

--- a/gemfiles/jruby_9.2_resque2_redis3.gemfile.lock
+++ b/gemfiles/jruby_9.2_resque2_redis3.gemfile.lock
@@ -14,7 +14,7 @@ PATH
     ddtrace (1.14.0)
       datadog-ci (~> 0.1.0)
       debase-ruby_core_source (= 3.2.2)
-      libdatadog (~> 4.0.0.1.0)
+      libdatadog (~> 5.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
 
@@ -46,7 +46,7 @@ GEM
     hashdiff (1.0.1)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (4.0.0.1.0)
+    libdatadog (5.0.0.1.0)
     libddwaf (1.14.0.0.0-java)
       ffi (~> 1.0)
     memory_profiler (0.9.14)

--- a/gemfiles/jruby_9.2_resque2_redis4.gemfile.lock
+++ b/gemfiles/jruby_9.2_resque2_redis4.gemfile.lock
@@ -14,7 +14,7 @@ PATH
     ddtrace (1.14.0)
       datadog-ci (~> 0.1.0)
       debase-ruby_core_source (= 3.2.2)
-      libdatadog (~> 4.0.0.1.0)
+      libdatadog (~> 5.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
 
@@ -47,7 +47,7 @@ GEM
     hashdiff (1.0.1)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (4.0.0.1.0)
+    libdatadog (5.0.0.1.0)
     libddwaf (1.14.0.0.0-java)
       ffi (~> 1.0)
     memory_profiler (0.9.14)

--- a/gemfiles/jruby_9.2_sinatra.gemfile.lock
+++ b/gemfiles/jruby_9.2_sinatra.gemfile.lock
@@ -14,7 +14,7 @@ PATH
     ddtrace (1.14.0)
       datadog-ci (~> 0.1.0)
       debase-ruby_core_source (= 3.2.2)
-      libdatadog (~> 4.0.0.1.0)
+      libdatadog (~> 5.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
 
@@ -46,7 +46,7 @@ GEM
     hashdiff (1.0.1)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (4.0.0.1.0)
+    libdatadog (5.0.0.1.0)
     libddwaf (1.14.0.0.0-java)
       ffi (~> 1.0)
     memory_profiler (0.9.14)

--- a/gemfiles/jruby_9.3_activesupport.gemfile.lock
+++ b/gemfiles/jruby_9.3_activesupport.gemfile.lock
@@ -14,7 +14,7 @@ PATH
     ddtrace (1.14.0)
       datadog-ci (~> 0.1.0)
       debase-ruby_core_source (= 3.2.2)
-      libdatadog (~> 4.0.0.1.0)
+      libdatadog (~> 5.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
 
@@ -109,7 +109,7 @@ GEM
       addressable (>= 2.4)
     jsonapi-renderer (0.2.2)
     king_konf (1.0.1)
-    libdatadog (4.0.0.1.0)
+    libdatadog (5.0.0.1.0)
     libddwaf (1.14.0.0.0-java)
       ffi (~> 1.0)
     lograge (0.13.0)

--- a/gemfiles/jruby_9.3_aws.gemfile.lock
+++ b/gemfiles/jruby_9.3_aws.gemfile.lock
@@ -14,7 +14,7 @@ PATH
     ddtrace (1.14.0)
       datadog-ci (~> 0.1.0)
       debase-ruby_core_source (= 3.2.2)
-      libdatadog (~> 4.0.0.1.0)
+      libdatadog (~> 5.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
 
@@ -1470,7 +1470,7 @@ GEM
     json (2.6.3-java)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (4.0.0.1.0)
+    libdatadog (5.0.0.1.0)
     libddwaf (1.14.0.0.0-java)
       ffi (~> 1.0)
     memory_profiler (0.9.14)

--- a/gemfiles/jruby_9.3_contrib.gemfile.lock
+++ b/gemfiles/jruby_9.3_contrib.gemfile.lock
@@ -14,7 +14,7 @@ PATH
     ddtrace (1.14.0)
       datadog-ci (~> 0.1.0)
       debase-ruby_core_source (= 3.2.2)
-      libdatadog (~> 4.0.0.1.0)
+      libdatadog (~> 5.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
 
@@ -56,7 +56,7 @@ GEM
     json (2.6.3-java)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (4.0.0.1.0)
+    libdatadog (5.0.0.1.0)
     libddwaf (1.14.0.0.0-java)
       ffi (~> 1.0)
     memory_profiler (0.9.14)

--- a/gemfiles/jruby_9.3_contrib_old.gemfile.lock
+++ b/gemfiles/jruby_9.3_contrib_old.gemfile.lock
@@ -14,7 +14,7 @@ PATH
     ddtrace (1.14.0)
       datadog-ci (~> 0.1.0)
       debase-ruby_core_source (= 3.2.2)
-      libdatadog (~> 4.0.0.1.0)
+      libdatadog (~> 5.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
 
@@ -62,7 +62,7 @@ GEM
     json (2.6.3-java)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (4.0.0.1.0)
+    libdatadog (5.0.0.1.0)
     libddwaf (1.14.0.0.0-java)
       ffi (~> 1.0)
     memory_profiler (0.9.14)

--- a/gemfiles/jruby_9.3_core_old.gemfile.lock
+++ b/gemfiles/jruby_9.3_core_old.gemfile.lock
@@ -14,7 +14,7 @@ PATH
     ddtrace (1.14.0)
       datadog-ci (~> 0.1.0)
       debase-ruby_core_source (= 3.2.2)
-      libdatadog (~> 4.0.0.1.0)
+      libdatadog (~> 5.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
 
@@ -48,7 +48,7 @@ GEM
     json (2.6.3-java)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (4.0.0.1.0)
+    libdatadog (5.0.0.1.0)
     libddwaf (1.14.0.0.0-java)
       ffi (~> 1.0)
     memory_profiler (0.9.14)

--- a/gemfiles/jruby_9.3_hanami_1.gemfile.lock
+++ b/gemfiles/jruby_9.3_hanami_1.gemfile.lock
@@ -14,7 +14,7 @@ PATH
     ddtrace (1.14.0)
       datadog-ci (~> 0.1.0)
       debase-ruby_core_source (= 3.2.2)
-      libdatadog (~> 4.0.0.1.0)
+      libdatadog (~> 5.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
 
@@ -123,7 +123,7 @@ GEM
     json (2.6.3-java)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (4.0.0.1.0)
+    libdatadog (5.0.0.1.0)
     libddwaf (1.14.0.0.0-java)
       ffi (~> 1.0)
     mail (2.8.0.1)

--- a/gemfiles/jruby_9.3_http.gemfile.lock
+++ b/gemfiles/jruby_9.3_http.gemfile.lock
@@ -14,7 +14,7 @@ PATH
     ddtrace (1.14.0)
       datadog-ci (~> 0.1.0)
       debase-ruby_core_source (= 3.2.2)
-      libdatadog (~> 4.0.0.1.0)
+      libdatadog (~> 5.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
 
@@ -80,7 +80,7 @@ GEM
     json (2.6.3-java)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (4.0.0.1.0)
+    libdatadog (5.0.0.1.0)
     libddwaf (1.14.0.0.0-java)
       ffi (~> 1.0)
     memory_profiler (0.9.14)

--- a/gemfiles/jruby_9.3_opentracing.gemfile.lock
+++ b/gemfiles/jruby_9.3_opentracing.gemfile.lock
@@ -14,7 +14,7 @@ PATH
     ddtrace (1.14.0)
       datadog-ci (~> 0.1.0)
       debase-ruby_core_source (= 3.2.2)
-      libdatadog (~> 4.0.0.1.0)
+      libdatadog (~> 5.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
 
@@ -49,7 +49,7 @@ GEM
     json (2.6.3-java)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (4.0.0.1.0)
+    libdatadog (5.0.0.1.0)
     libddwaf (1.14.0.0.0-java)
       ffi (~> 1.0)
     memory_profiler (0.9.14)

--- a/gemfiles/jruby_9.3_rack_1.gemfile.lock
+++ b/gemfiles/jruby_9.3_rack_1.gemfile.lock
@@ -14,7 +14,7 @@ PATH
     ddtrace (1.14.0)
       datadog-ci (~> 0.1.0)
       debase-ruby_core_source (= 3.2.2)
-      libdatadog (~> 4.0.0.1.0)
+      libdatadog (~> 5.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
 
@@ -48,7 +48,7 @@ GEM
     json (2.6.3-java)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (4.0.0.1.0)
+    libdatadog (5.0.0.1.0)
     libddwaf (1.14.0.0.0-java)
       ffi (~> 1.0)
     memory_profiler (0.9.14)

--- a/gemfiles/jruby_9.3_rack_2.gemfile.lock
+++ b/gemfiles/jruby_9.3_rack_2.gemfile.lock
@@ -14,7 +14,7 @@ PATH
     ddtrace (1.14.0)
       datadog-ci (~> 0.1.0)
       debase-ruby_core_source (= 3.2.2)
-      libdatadog (~> 4.0.0.1.0)
+      libdatadog (~> 5.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
 
@@ -48,7 +48,7 @@ GEM
     json (2.6.3-java)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (4.0.0.1.0)
+    libdatadog (5.0.0.1.0)
     libddwaf (1.14.0.0.0-java)
       ffi (~> 1.0)
     memory_profiler (0.9.14)

--- a/gemfiles/jruby_9.3_rack_3.gemfile.lock
+++ b/gemfiles/jruby_9.3_rack_3.gemfile.lock
@@ -14,7 +14,7 @@ PATH
     ddtrace (1.14.0)
       datadog-ci (~> 0.1.0)
       debase-ruby_core_source (= 3.2.2)
-      libdatadog (~> 4.0.0.1.0)
+      libdatadog (~> 5.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
 
@@ -48,7 +48,7 @@ GEM
     json (2.6.3-java)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (4.0.0.1.0)
+    libdatadog (5.0.0.1.0)
     libddwaf (1.14.0.0.0-java)
       ffi (~> 1.0)
     memory_profiler (0.9.14)

--- a/gemfiles/jruby_9.3_rails5_mysql2.gemfile.lock
+++ b/gemfiles/jruby_9.3_rails5_mysql2.gemfile.lock
@@ -14,7 +14,7 @@ PATH
     ddtrace (1.14.0)
       datadog-ci (~> 0.1.0)
       debase-ruby_core_source (= 3.2.2)
-      libdatadog (~> 4.0.0.1.0)
+      libdatadog (~> 5.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
 
@@ -103,7 +103,7 @@ GEM
     json (2.6.3-java)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (4.0.0.1.0)
+    libdatadog (5.0.0.1.0)
     libddwaf (1.14.0.0.0-java)
       ffi (~> 1.0)
     lograge (0.12.0)

--- a/gemfiles/jruby_9.3_rails5_postgres.gemfile.lock
+++ b/gemfiles/jruby_9.3_rails5_postgres.gemfile.lock
@@ -14,7 +14,7 @@ PATH
     ddtrace (1.14.0)
       datadog-ci (~> 0.1.0)
       debase-ruby_core_source (= 3.2.2)
-      libdatadog (~> 4.0.0.1.0)
+      libdatadog (~> 5.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
 
@@ -103,7 +103,7 @@ GEM
     json (2.6.3-java)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (4.0.0.1.0)
+    libdatadog (5.0.0.1.0)
     libddwaf (1.14.0.0.0-java)
       ffi (~> 1.0)
     lograge (0.12.0)

--- a/gemfiles/jruby_9.3_rails5_postgres_redis.gemfile.lock
+++ b/gemfiles/jruby_9.3_rails5_postgres_redis.gemfile.lock
@@ -14,7 +14,7 @@ PATH
     ddtrace (1.14.0)
       datadog-ci (~> 0.1.0)
       debase-ruby_core_source (= 3.2.2)
-      libdatadog (~> 4.0.0.1.0)
+      libdatadog (~> 5.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
 
@@ -103,7 +103,7 @@ GEM
     json (2.6.3-java)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (4.0.0.1.0)
+    libdatadog (5.0.0.1.0)
     libddwaf (1.14.0.0.0-java)
       ffi (~> 1.0)
     lograge (0.12.0)

--- a/gemfiles/jruby_9.3_rails5_postgres_redis_activesupport.gemfile.lock
+++ b/gemfiles/jruby_9.3_rails5_postgres_redis_activesupport.gemfile.lock
@@ -14,7 +14,7 @@ PATH
     ddtrace (1.14.0)
       datadog-ci (~> 0.1.0)
       debase-ruby_core_source (= 3.2.2)
-      libdatadog (~> 4.0.0.1.0)
+      libdatadog (~> 5.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
 
@@ -103,7 +103,7 @@ GEM
     json (2.6.3-java)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (4.0.0.1.0)
+    libdatadog (5.0.0.1.0)
     libddwaf (1.14.0.0.0-java)
       ffi (~> 1.0)
     lograge (0.12.0)

--- a/gemfiles/jruby_9.3_rails5_postgres_sidekiq.gemfile.lock
+++ b/gemfiles/jruby_9.3_rails5_postgres_sidekiq.gemfile.lock
@@ -14,7 +14,7 @@ PATH
     ddtrace (1.14.0)
       datadog-ci (~> 0.1.0)
       debase-ruby_core_source (= 3.2.2)
-      libdatadog (~> 4.0.0.1.0)
+      libdatadog (~> 5.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
 
@@ -104,7 +104,7 @@ GEM
     json (2.6.3-java)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (4.0.0.1.0)
+    libdatadog (5.0.0.1.0)
     libddwaf (1.14.0.0.0-java)
       ffi (~> 1.0)
     lograge (0.12.0)

--- a/gemfiles/jruby_9.3_rails5_semantic_logger.gemfile.lock
+++ b/gemfiles/jruby_9.3_rails5_semantic_logger.gemfile.lock
@@ -14,7 +14,7 @@ PATH
     ddtrace (1.14.0)
       datadog-ci (~> 0.1.0)
       debase-ruby_core_source (= 3.2.2)
-      libdatadog (~> 4.0.0.1.0)
+      libdatadog (~> 5.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
 
@@ -103,7 +103,7 @@ GEM
     json (2.6.3-java)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (4.0.0.1.0)
+    libdatadog (5.0.0.1.0)
     libddwaf (1.14.0.0.0-java)
       ffi (~> 1.0)
     loofah (2.21.3)

--- a/gemfiles/jruby_9.3_rails61_mysql2.gemfile.lock
+++ b/gemfiles/jruby_9.3_rails61_mysql2.gemfile.lock
@@ -14,7 +14,7 @@ PATH
     ddtrace (1.14.0)
       datadog-ci (~> 0.1.0)
       debase-ruby_core_source (= 3.2.2)
-      libdatadog (~> 4.0.0.1.0)
+      libdatadog (~> 5.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
 
@@ -120,7 +120,7 @@ GEM
     json (2.6.3-java)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (4.0.0.1.0)
+    libdatadog (5.0.0.1.0)
     libddwaf (1.14.0.0.0-java)
       ffi (~> 1.0)
     lograge (0.12.0)

--- a/gemfiles/jruby_9.3_rails61_postgres.gemfile.lock
+++ b/gemfiles/jruby_9.3_rails61_postgres.gemfile.lock
@@ -14,7 +14,7 @@ PATH
     ddtrace (1.14.0)
       datadog-ci (~> 0.1.0)
       debase-ruby_core_source (= 3.2.2)
-      libdatadog (~> 4.0.0.1.0)
+      libdatadog (~> 5.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
 
@@ -120,7 +120,7 @@ GEM
     json (2.6.3-java)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (4.0.0.1.0)
+    libdatadog (5.0.0.1.0)
     libddwaf (1.14.0.0.0-java)
       ffi (~> 1.0)
     lograge (0.12.0)

--- a/gemfiles/jruby_9.3_rails61_postgres_redis.gemfile.lock
+++ b/gemfiles/jruby_9.3_rails61_postgres_redis.gemfile.lock
@@ -14,7 +14,7 @@ PATH
     ddtrace (1.14.0)
       datadog-ci (~> 0.1.0)
       debase-ruby_core_source (= 3.2.2)
-      libdatadog (~> 4.0.0.1.0)
+      libdatadog (~> 5.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
 
@@ -120,7 +120,7 @@ GEM
     json (2.6.3-java)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (4.0.0.1.0)
+    libdatadog (5.0.0.1.0)
     libddwaf (1.14.0.0.0-java)
       ffi (~> 1.0)
     lograge (0.12.0)

--- a/gemfiles/jruby_9.3_rails61_postgres_sidekiq.gemfile.lock
+++ b/gemfiles/jruby_9.3_rails61_postgres_sidekiq.gemfile.lock
@@ -14,7 +14,7 @@ PATH
     ddtrace (1.14.0)
       datadog-ci (~> 0.1.0)
       debase-ruby_core_source (= 3.2.2)
-      libdatadog (~> 4.0.0.1.0)
+      libdatadog (~> 5.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
 
@@ -121,7 +121,7 @@ GEM
     json (2.6.3-java)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (4.0.0.1.0)
+    libdatadog (5.0.0.1.0)
     libddwaf (1.14.0.0.0-java)
       ffi (~> 1.0)
     lograge (0.12.0)

--- a/gemfiles/jruby_9.3_rails61_semantic_logger.gemfile.lock
+++ b/gemfiles/jruby_9.3_rails61_semantic_logger.gemfile.lock
@@ -14,7 +14,7 @@ PATH
     ddtrace (1.14.0)
       datadog-ci (~> 0.1.0)
       debase-ruby_core_source (= 3.2.2)
-      libdatadog (~> 4.0.0.1.0)
+      libdatadog (~> 5.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
 
@@ -120,7 +120,7 @@ GEM
     json (2.6.3-java)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (4.0.0.1.0)
+    libdatadog (5.0.0.1.0)
     libddwaf (1.14.0.0.0-java)
       ffi (~> 1.0)
     loofah (2.21.3)

--- a/gemfiles/jruby_9.3_rails6_mysql2.gemfile.lock
+++ b/gemfiles/jruby_9.3_rails6_mysql2.gemfile.lock
@@ -14,7 +14,7 @@ PATH
     ddtrace (1.14.0)
       datadog-ci (~> 0.1.0)
       debase-ruby_core_source (= 3.2.2)
-      libdatadog (~> 4.0.0.1.0)
+      libdatadog (~> 5.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
 
@@ -116,7 +116,7 @@ GEM
     json (2.6.3-java)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (4.0.0.1.0)
+    libdatadog (5.0.0.1.0)
     libddwaf (1.14.0.0.0-java)
       ffi (~> 1.0)
     lograge (0.12.0)

--- a/gemfiles/jruby_9.3_rails6_postgres.gemfile.lock
+++ b/gemfiles/jruby_9.3_rails6_postgres.gemfile.lock
@@ -14,7 +14,7 @@ PATH
     ddtrace (1.14.0)
       datadog-ci (~> 0.1.0)
       debase-ruby_core_source (= 3.2.2)
-      libdatadog (~> 4.0.0.1.0)
+      libdatadog (~> 5.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
 
@@ -116,7 +116,7 @@ GEM
     json (2.6.3-java)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (4.0.0.1.0)
+    libdatadog (5.0.0.1.0)
     libddwaf (1.14.0.0.0-java)
       ffi (~> 1.0)
     lograge (0.12.0)

--- a/gemfiles/jruby_9.3_rails6_postgres_redis.gemfile.lock
+++ b/gemfiles/jruby_9.3_rails6_postgres_redis.gemfile.lock
@@ -14,7 +14,7 @@ PATH
     ddtrace (1.14.0)
       datadog-ci (~> 0.1.0)
       debase-ruby_core_source (= 3.2.2)
-      libdatadog (~> 4.0.0.1.0)
+      libdatadog (~> 5.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
 
@@ -116,7 +116,7 @@ GEM
     json (2.6.3-java)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (4.0.0.1.0)
+    libdatadog (5.0.0.1.0)
     libddwaf (1.14.0.0.0-java)
       ffi (~> 1.0)
     lograge (0.12.0)

--- a/gemfiles/jruby_9.3_rails6_postgres_redis_activesupport.gemfile.lock
+++ b/gemfiles/jruby_9.3_rails6_postgres_redis_activesupport.gemfile.lock
@@ -14,7 +14,7 @@ PATH
     ddtrace (1.14.0)
       datadog-ci (~> 0.1.0)
       debase-ruby_core_source (= 3.2.2)
-      libdatadog (~> 4.0.0.1.0)
+      libdatadog (~> 5.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
 
@@ -116,7 +116,7 @@ GEM
     json (2.6.3-java)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (4.0.0.1.0)
+    libdatadog (5.0.0.1.0)
     libddwaf (1.14.0.0.0-java)
       ffi (~> 1.0)
     lograge (0.12.0)

--- a/gemfiles/jruby_9.3_rails6_postgres_sidekiq.gemfile.lock
+++ b/gemfiles/jruby_9.3_rails6_postgres_sidekiq.gemfile.lock
@@ -14,7 +14,7 @@ PATH
     ddtrace (1.14.0)
       datadog-ci (~> 0.1.0)
       debase-ruby_core_source (= 3.2.2)
-      libdatadog (~> 4.0.0.1.0)
+      libdatadog (~> 5.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
 
@@ -117,7 +117,7 @@ GEM
     json (2.6.3-java)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (4.0.0.1.0)
+    libdatadog (5.0.0.1.0)
     libddwaf (1.14.0.0.0-java)
       ffi (~> 1.0)
     lograge (0.12.0)

--- a/gemfiles/jruby_9.3_rails6_semantic_logger.gemfile.lock
+++ b/gemfiles/jruby_9.3_rails6_semantic_logger.gemfile.lock
@@ -14,7 +14,7 @@ PATH
     ddtrace (1.14.0)
       datadog-ci (~> 0.1.0)
       debase-ruby_core_source (= 3.2.2)
-      libdatadog (~> 4.0.0.1.0)
+      libdatadog (~> 5.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
 
@@ -116,7 +116,7 @@ GEM
     json (2.6.3-java)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (4.0.0.1.0)
+    libdatadog (5.0.0.1.0)
     libddwaf (1.14.0.0.0-java)
       ffi (~> 1.0)
     loofah (2.21.3)

--- a/gemfiles/jruby_9.3_redis_3.gemfile.lock
+++ b/gemfiles/jruby_9.3_redis_3.gemfile.lock
@@ -14,7 +14,7 @@ PATH
     ddtrace (1.14.0)
       datadog-ci (~> 0.1.0)
       debase-ruby_core_source (= 3.2.2)
-      libdatadog (~> 4.0.0.1.0)
+      libdatadog (~> 5.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
 
@@ -48,7 +48,7 @@ GEM
     json (2.6.3-java)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (4.0.0.1.0)
+    libdatadog (5.0.0.1.0)
     libddwaf (1.14.0.0.0-java)
       ffi (~> 1.0)
     memory_profiler (0.9.14)

--- a/gemfiles/jruby_9.3_redis_4.gemfile.lock
+++ b/gemfiles/jruby_9.3_redis_4.gemfile.lock
@@ -14,7 +14,7 @@ PATH
     ddtrace (1.14.0)
       datadog-ci (~> 0.1.0)
       debase-ruby_core_source (= 3.2.2)
-      libdatadog (~> 4.0.0.1.0)
+      libdatadog (~> 5.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
 
@@ -48,7 +48,7 @@ GEM
     json (2.6.3-java)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (4.0.0.1.0)
+    libdatadog (5.0.0.1.0)
     libddwaf (1.14.0.0.0-java)
       ffi (~> 1.0)
     memory_profiler (0.9.14)

--- a/gemfiles/jruby_9.3_redis_5.gemfile.lock
+++ b/gemfiles/jruby_9.3_redis_5.gemfile.lock
@@ -14,7 +14,7 @@ PATH
     ddtrace (1.14.0)
       datadog-ci (~> 0.1.0)
       debase-ruby_core_source (= 3.2.2)
-      libdatadog (~> 4.0.0.1.0)
+      libdatadog (~> 5.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
 
@@ -49,7 +49,7 @@ GEM
     json (2.6.3-java)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (4.0.0.1.0)
+    libdatadog (5.0.0.1.0)
     libddwaf (1.14.0.0.0-java)
       ffi (~> 1.0)
     memory_profiler (0.9.14)

--- a/gemfiles/jruby_9.3_relational_db.gemfile.lock
+++ b/gemfiles/jruby_9.3_relational_db.gemfile.lock
@@ -14,7 +14,7 @@ PATH
     ddtrace (1.14.0)
       datadog-ci (~> 0.1.0)
       debase-ruby_core_source (= 3.2.2)
-      libdatadog (~> 4.0.0.1.0)
+      libdatadog (~> 5.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
 
@@ -77,7 +77,7 @@ GEM
     json (2.6.3-java)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (4.0.0.1.0)
+    libdatadog (5.0.0.1.0)
     libddwaf (1.14.0.0.0-java)
       ffi (~> 1.0)
     makara (0.5.1)

--- a/gemfiles/jruby_9.3_resque2_redis3.gemfile.lock
+++ b/gemfiles/jruby_9.3_resque2_redis3.gemfile.lock
@@ -14,7 +14,7 @@ PATH
     ddtrace (1.14.0)
       datadog-ci (~> 0.1.0)
       debase-ruby_core_source (= 3.2.2)
-      libdatadog (~> 4.0.0.1.0)
+      libdatadog (~> 5.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
 
@@ -48,7 +48,7 @@ GEM
     json (2.6.3-java)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (4.0.0.1.0)
+    libdatadog (5.0.0.1.0)
     libddwaf (1.14.0.0.0-java)
       ffi (~> 1.0)
     memory_profiler (0.9.14)

--- a/gemfiles/jruby_9.3_resque2_redis4.gemfile.lock
+++ b/gemfiles/jruby_9.3_resque2_redis4.gemfile.lock
@@ -14,7 +14,7 @@ PATH
     ddtrace (1.14.0)
       datadog-ci (~> 0.1.0)
       debase-ruby_core_source (= 3.2.2)
-      libdatadog (~> 4.0.0.1.0)
+      libdatadog (~> 5.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
 
@@ -48,7 +48,7 @@ GEM
     json (2.6.3-java)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (4.0.0.1.0)
+    libdatadog (5.0.0.1.0)
     libddwaf (1.14.0.0.0-java)
       ffi (~> 1.0)
     memory_profiler (0.9.14)

--- a/gemfiles/jruby_9.3_sinatra.gemfile.lock
+++ b/gemfiles/jruby_9.3_sinatra.gemfile.lock
@@ -14,7 +14,7 @@ PATH
     ddtrace (1.14.0)
       datadog-ci (~> 0.1.0)
       debase-ruby_core_source (= 3.2.2)
-      libdatadog (~> 4.0.0.1.0)
+      libdatadog (~> 5.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
 
@@ -48,7 +48,7 @@ GEM
     json (2.6.3-java)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (4.0.0.1.0)
+    libdatadog (5.0.0.1.0)
     libddwaf (1.14.0.0.0-java)
       ffi (~> 1.0)
     memory_profiler (0.9.14)

--- a/gemfiles/jruby_9.4_activesupport.gemfile.lock
+++ b/gemfiles/jruby_9.4_activesupport.gemfile.lock
@@ -14,7 +14,7 @@ PATH
     ddtrace (1.14.0)
       datadog-ci (~> 0.1.0)
       debase-ruby_core_source (= 3.2.2)
-      libdatadog (~> 4.0.0.1.0)
+      libdatadog (~> 5.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
 
@@ -104,7 +104,7 @@ GEM
       addressable (>= 2.4)
     jsonapi-renderer (0.2.2)
     king_konf (1.0.1)
-    libdatadog (4.0.0.1.0)
+    libdatadog (5.0.0.1.0)
     libddwaf (1.14.0.0.0-java)
       ffi (~> 1.0)
     lograge (0.13.0)

--- a/gemfiles/jruby_9.4_aws.gemfile.lock
+++ b/gemfiles/jruby_9.4_aws.gemfile.lock
@@ -14,7 +14,7 @@ PATH
     ddtrace (1.14.0)
       datadog-ci (~> 0.1.0)
       debase-ruby_core_source (= 3.2.2)
-      libdatadog (~> 4.0.0.1.0)
+      libdatadog (~> 5.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
 
@@ -1470,7 +1470,7 @@ GEM
     json (2.6.3-java)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (4.0.0.1.0)
+    libdatadog (5.0.0.1.0)
     libddwaf (1.14.0.0.0-java)
       ffi (~> 1.0)
     memory_profiler (0.9.14)

--- a/gemfiles/jruby_9.4_contrib.gemfile.lock
+++ b/gemfiles/jruby_9.4_contrib.gemfile.lock
@@ -14,7 +14,7 @@ PATH
     ddtrace (1.14.0)
       datadog-ci (~> 0.1.0)
       debase-ruby_core_source (= 3.2.2)
-      libdatadog (~> 4.0.0.1.0)
+      libdatadog (~> 5.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
 
@@ -56,7 +56,7 @@ GEM
     json (2.6.3-java)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (4.0.0.1.0)
+    libdatadog (5.0.0.1.0)
     libddwaf (1.14.0.0.0-java)
       ffi (~> 1.0)
     memory_profiler (0.9.14)

--- a/gemfiles/jruby_9.4_contrib_old.gemfile.lock
+++ b/gemfiles/jruby_9.4_contrib_old.gemfile.lock
@@ -14,7 +14,7 @@ PATH
     ddtrace (1.14.0)
       datadog-ci (~> 0.1.0)
       debase-ruby_core_source (= 3.2.2)
-      libdatadog (~> 4.0.0.1.0)
+      libdatadog (~> 5.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
 
@@ -62,7 +62,7 @@ GEM
     json (2.6.3-java)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (4.0.0.1.0)
+    libdatadog (5.0.0.1.0)
     libddwaf (1.14.0.0.0-java)
       ffi (~> 1.0)
     memory_profiler (0.9.14)

--- a/gemfiles/jruby_9.4_core_old.gemfile.lock
+++ b/gemfiles/jruby_9.4_core_old.gemfile.lock
@@ -14,7 +14,7 @@ PATH
     ddtrace (1.14.0)
       datadog-ci (~> 0.1.0)
       debase-ruby_core_source (= 3.2.2)
-      libdatadog (~> 4.0.0.1.0)
+      libdatadog (~> 5.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
 
@@ -48,7 +48,7 @@ GEM
     json (2.6.3-java)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (4.0.0.1.0)
+    libdatadog (5.0.0.1.0)
     libddwaf (1.14.0.0.0-java)
       ffi (~> 1.0)
     memory_profiler (0.9.14)

--- a/gemfiles/jruby_9.4_http.gemfile.lock
+++ b/gemfiles/jruby_9.4_http.gemfile.lock
@@ -14,7 +14,7 @@ PATH
     ddtrace (1.14.0)
       datadog-ci (~> 0.1.0)
       debase-ruby_core_source (= 3.2.2)
-      libdatadog (~> 4.0.0.1.0)
+      libdatadog (~> 5.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
 
@@ -80,7 +80,7 @@ GEM
     json (2.6.3-java)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (4.0.0.1.0)
+    libdatadog (5.0.0.1.0)
     libddwaf (1.14.0.0.0-java)
       ffi (~> 1.0)
     memory_profiler (0.9.14)

--- a/gemfiles/jruby_9.4_opentracing.gemfile.lock
+++ b/gemfiles/jruby_9.4_opentracing.gemfile.lock
@@ -14,7 +14,7 @@ PATH
     ddtrace (1.14.0)
       datadog-ci (~> 0.1.0)
       debase-ruby_core_source (= 3.2.2)
-      libdatadog (~> 4.0.0.1.0)
+      libdatadog (~> 5.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
 
@@ -49,7 +49,7 @@ GEM
     json (2.6.3-java)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (4.0.0.1.0)
+    libdatadog (5.0.0.1.0)
     libddwaf (1.14.0.0.0-java)
       ffi (~> 1.0)
     memory_profiler (0.9.14)

--- a/gemfiles/jruby_9.4_rack_1.gemfile.lock
+++ b/gemfiles/jruby_9.4_rack_1.gemfile.lock
@@ -14,7 +14,7 @@ PATH
     ddtrace (1.14.0)
       datadog-ci (~> 0.1.0)
       debase-ruby_core_source (= 3.2.2)
-      libdatadog (~> 4.0.0.1.0)
+      libdatadog (~> 5.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
 
@@ -48,7 +48,7 @@ GEM
     json (2.6.3-java)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (4.0.0.1.0)
+    libdatadog (5.0.0.1.0)
     libddwaf (1.14.0.0.0-java)
       ffi (~> 1.0)
     memory_profiler (0.9.14)

--- a/gemfiles/jruby_9.4_rack_2.gemfile.lock
+++ b/gemfiles/jruby_9.4_rack_2.gemfile.lock
@@ -14,7 +14,7 @@ PATH
     ddtrace (1.14.0)
       datadog-ci (~> 0.1.0)
       debase-ruby_core_source (= 3.2.2)
-      libdatadog (~> 4.0.0.1.0)
+      libdatadog (~> 5.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
 
@@ -48,7 +48,7 @@ GEM
     json (2.6.3-java)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (4.0.0.1.0)
+    libdatadog (5.0.0.1.0)
     libddwaf (1.14.0.0.0-java)
       ffi (~> 1.0)
     memory_profiler (0.9.14)

--- a/gemfiles/jruby_9.4_rack_3.gemfile.lock
+++ b/gemfiles/jruby_9.4_rack_3.gemfile.lock
@@ -14,7 +14,7 @@ PATH
     ddtrace (1.14.0)
       datadog-ci (~> 0.1.0)
       debase-ruby_core_source (= 3.2.2)
-      libdatadog (~> 4.0.0.1.0)
+      libdatadog (~> 5.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
 
@@ -48,7 +48,7 @@ GEM
     json (2.6.3-java)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (4.0.0.1.0)
+    libdatadog (5.0.0.1.0)
     libddwaf (1.14.0.0.0-java)
       ffi (~> 1.0)
     memory_profiler (0.9.14)

--- a/gemfiles/jruby_9.4_rails61_mysql2.gemfile.lock
+++ b/gemfiles/jruby_9.4_rails61_mysql2.gemfile.lock
@@ -14,7 +14,7 @@ PATH
     ddtrace (1.14.0)
       datadog-ci (~> 0.1.0)
       debase-ruby_core_source (= 3.2.2)
-      libdatadog (~> 4.0.0.1.0)
+      libdatadog (~> 5.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
 
@@ -120,7 +120,7 @@ GEM
     json (2.6.3-java)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (4.0.0.1.0)
+    libdatadog (5.0.0.1.0)
     libddwaf (1.14.0.0.0-java)
       ffi (~> 1.0)
     lograge (0.12.0)

--- a/gemfiles/jruby_9.4_rails61_postgres.gemfile.lock
+++ b/gemfiles/jruby_9.4_rails61_postgres.gemfile.lock
@@ -14,7 +14,7 @@ PATH
     ddtrace (1.14.0)
       datadog-ci (~> 0.1.0)
       debase-ruby_core_source (= 3.2.2)
-      libdatadog (~> 4.0.0.1.0)
+      libdatadog (~> 5.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
 
@@ -120,7 +120,7 @@ GEM
     json (2.6.3-java)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (4.0.0.1.0)
+    libdatadog (5.0.0.1.0)
     libddwaf (1.14.0.0.0-java)
       ffi (~> 1.0)
     lograge (0.12.0)

--- a/gemfiles/jruby_9.4_rails61_postgres_redis.gemfile.lock
+++ b/gemfiles/jruby_9.4_rails61_postgres_redis.gemfile.lock
@@ -14,7 +14,7 @@ PATH
     ddtrace (1.14.0)
       datadog-ci (~> 0.1.0)
       debase-ruby_core_source (= 3.2.2)
-      libdatadog (~> 4.0.0.1.0)
+      libdatadog (~> 5.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
 
@@ -120,7 +120,7 @@ GEM
     json (2.6.3-java)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (4.0.0.1.0)
+    libdatadog (5.0.0.1.0)
     libddwaf (1.14.0.0.0-java)
       ffi (~> 1.0)
     lograge (0.12.0)

--- a/gemfiles/jruby_9.4_rails61_postgres_sidekiq.gemfile.lock
+++ b/gemfiles/jruby_9.4_rails61_postgres_sidekiq.gemfile.lock
@@ -14,7 +14,7 @@ PATH
     ddtrace (1.14.0)
       datadog-ci (~> 0.1.0)
       debase-ruby_core_source (= 3.2.2)
-      libdatadog (~> 4.0.0.1.0)
+      libdatadog (~> 5.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
 
@@ -121,7 +121,7 @@ GEM
     json (2.6.3-java)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (4.0.0.1.0)
+    libdatadog (5.0.0.1.0)
     libddwaf (1.14.0.0.0-java)
       ffi (~> 1.0)
     lograge (0.12.0)

--- a/gemfiles/jruby_9.4_rails61_semantic_logger.gemfile.lock
+++ b/gemfiles/jruby_9.4_rails61_semantic_logger.gemfile.lock
@@ -14,7 +14,7 @@ PATH
     ddtrace (1.14.0)
       datadog-ci (~> 0.1.0)
       debase-ruby_core_source (= 3.2.2)
-      libdatadog (~> 4.0.0.1.0)
+      libdatadog (~> 5.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
 
@@ -120,7 +120,7 @@ GEM
     json (2.6.3-java)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (4.0.0.1.0)
+    libdatadog (5.0.0.1.0)
     libddwaf (1.14.0.0.0-java)
       ffi (~> 1.0)
     loofah (2.19.1)

--- a/gemfiles/jruby_9.4_redis_3.gemfile.lock
+++ b/gemfiles/jruby_9.4_redis_3.gemfile.lock
@@ -14,7 +14,7 @@ PATH
     ddtrace (1.14.0)
       datadog-ci (~> 0.1.0)
       debase-ruby_core_source (= 3.2.2)
-      libdatadog (~> 4.0.0.1.0)
+      libdatadog (~> 5.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
 
@@ -48,7 +48,7 @@ GEM
     json (2.6.3-java)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (4.0.0.1.0)
+    libdatadog (5.0.0.1.0)
     libddwaf (1.14.0.0.0-java)
       ffi (~> 1.0)
     memory_profiler (0.9.14)

--- a/gemfiles/jruby_9.4_redis_4.gemfile.lock
+++ b/gemfiles/jruby_9.4_redis_4.gemfile.lock
@@ -14,7 +14,7 @@ PATH
     ddtrace (1.14.0)
       datadog-ci (~> 0.1.0)
       debase-ruby_core_source (= 3.2.2)
-      libdatadog (~> 4.0.0.1.0)
+      libdatadog (~> 5.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
 
@@ -48,7 +48,7 @@ GEM
     json (2.6.3-java)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (4.0.0.1.0)
+    libdatadog (5.0.0.1.0)
     libddwaf (1.14.0.0.0-java)
       ffi (~> 1.0)
     memory_profiler (0.9.14)

--- a/gemfiles/jruby_9.4_redis_5.gemfile.lock
+++ b/gemfiles/jruby_9.4_redis_5.gemfile.lock
@@ -14,7 +14,7 @@ PATH
     ddtrace (1.14.0)
       datadog-ci (~> 0.1.0)
       debase-ruby_core_source (= 3.2.2)
-      libdatadog (~> 4.0.0.1.0)
+      libdatadog (~> 5.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
 
@@ -49,7 +49,7 @@ GEM
     json (2.6.3-java)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (4.0.0.1.0)
+    libdatadog (5.0.0.1.0)
     libddwaf (1.14.0.0.0-java)
       ffi (~> 1.0)
     memory_profiler (0.9.14)

--- a/gemfiles/jruby_9.4_relational_db.gemfile.lock
+++ b/gemfiles/jruby_9.4_relational_db.gemfile.lock
@@ -14,7 +14,7 @@ PATH
     ddtrace (1.14.0)
       datadog-ci (~> 0.1.0)
       debase-ruby_core_source (= 3.2.2)
-      libdatadog (~> 4.0.0.1.0)
+      libdatadog (~> 5.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
 
@@ -76,7 +76,7 @@ GEM
     json (2.6.3-java)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (4.0.0.1.0)
+    libdatadog (5.0.0.1.0)
     libddwaf (1.14.0.0.0-java)
       ffi (~> 1.0)
     makara (0.6.0.pre)

--- a/gemfiles/jruby_9.4_resque2_redis3.gemfile.lock
+++ b/gemfiles/jruby_9.4_resque2_redis3.gemfile.lock
@@ -14,7 +14,7 @@ PATH
     ddtrace (1.14.0)
       datadog-ci (~> 0.1.0)
       debase-ruby_core_source (= 3.2.2)
-      libdatadog (~> 4.0.0.1.0)
+      libdatadog (~> 5.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
 
@@ -48,7 +48,7 @@ GEM
     json (2.6.3-java)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (4.0.0.1.0)
+    libdatadog (5.0.0.1.0)
     libddwaf (1.14.0.0.0-java)
       ffi (~> 1.0)
     memory_profiler (0.9.14)

--- a/gemfiles/jruby_9.4_resque2_redis4.gemfile.lock
+++ b/gemfiles/jruby_9.4_resque2_redis4.gemfile.lock
@@ -14,7 +14,7 @@ PATH
     ddtrace (1.14.0)
       datadog-ci (~> 0.1.0)
       debase-ruby_core_source (= 3.2.2)
-      libdatadog (~> 4.0.0.1.0)
+      libdatadog (~> 5.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
 
@@ -49,7 +49,7 @@ GEM
     json (2.6.3-java)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (4.0.0.1.0)
+    libdatadog (5.0.0.1.0)
     libddwaf (1.14.0.0.0-java)
       ffi (~> 1.0)
     memory_profiler (0.9.14)

--- a/gemfiles/jruby_9.4_sinatra.gemfile.lock
+++ b/gemfiles/jruby_9.4_sinatra.gemfile.lock
@@ -14,7 +14,7 @@ PATH
     ddtrace (1.14.0)
       datadog-ci (~> 0.1.0)
       debase-ruby_core_source (= 3.2.2)
-      libdatadog (~> 4.0.0.1.0)
+      libdatadog (~> 5.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
 
@@ -48,7 +48,7 @@ GEM
     json (2.6.3-java)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (4.0.0.1.0)
+    libdatadog (5.0.0.1.0)
     libddwaf (1.14.0.0.0-java)
       ffi (~> 1.0)
     memory_profiler (0.9.14)

--- a/gemfiles/ruby_2.1_activesupport.gemfile.lock
+++ b/gemfiles/ruby_2.1_activesupport.gemfile.lock
@@ -4,7 +4,7 @@ PATH
     ddtrace (1.14.0)
       datadog-ci (~> 0.1.0)
       debase-ruby_core_source (= 3.2.2)
-      libdatadog (~> 4.0.0.1.0)
+      libdatadog (~> 5.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
 
@@ -53,7 +53,7 @@ GEM
     json (2.5.1)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (4.0.0.1.0)
+    libdatadog (5.0.0.1.0)
     libddwaf (1.14.0.0.0)
       ffi (~> 1.0)
     memory_profiler (0.9.12)

--- a/gemfiles/ruby_2.1_aws.gemfile.lock
+++ b/gemfiles/ruby_2.1_aws.gemfile.lock
@@ -4,7 +4,7 @@ PATH
     ddtrace (1.14.0)
       datadog-ci (~> 0.1.0)
       debase-ruby_core_source (= 3.2.2)
-      libdatadog (~> 4.0.0.1.0)
+      libdatadog (~> 5.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
 
@@ -49,7 +49,7 @@ GEM
     json (2.5.1)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (4.0.0.1.0)
+    libdatadog (5.0.0.1.0)
     libddwaf (1.14.0.0.0)
       ffi (~> 1.0)
     memory_profiler (0.9.12)

--- a/gemfiles/ruby_2.1_contrib.gemfile.lock
+++ b/gemfiles/ruby_2.1_contrib.gemfile.lock
@@ -4,7 +4,7 @@ PATH
     ddtrace (1.14.0)
       datadog-ci (~> 0.1.0)
       debase-ruby_core_source (= 3.2.2)
-      libdatadog (~> 4.0.0.1.0)
+      libdatadog (~> 5.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
 
@@ -63,7 +63,7 @@ GEM
     json (1.8.6)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (4.0.0.1.0)
+    libdatadog (5.0.0.1.0)
     libddwaf (1.14.0.0.0)
       ffi (~> 1.0)
     memory_profiler (0.9.12)

--- a/gemfiles/ruby_2.1_core_old.gemfile.lock
+++ b/gemfiles/ruby_2.1_core_old.gemfile.lock
@@ -4,7 +4,7 @@ PATH
     ddtrace (1.14.0)
       datadog-ci (~> 0.1.0)
       debase-ruby_core_source (= 3.2.2)
-      libdatadog (~> 4.0.0.1.0)
+      libdatadog (~> 5.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
 
@@ -38,7 +38,7 @@ GEM
     json (2.5.1)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (4.0.0.1.0)
+    libdatadog (5.0.0.1.0)
     libddwaf (1.14.0.0.0)
       ffi (~> 1.0)
     memory_profiler (0.9.12)

--- a/gemfiles/ruby_2.1_http.gemfile.lock
+++ b/gemfiles/ruby_2.1_http.gemfile.lock
@@ -4,7 +4,7 @@ PATH
     ddtrace (1.14.0)
       datadog-ci (~> 0.1.0)
       debase-ruby_core_source (= 3.2.2)
-      libdatadog (~> 4.0.0.1.0)
+      libdatadog (~> 5.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
 
@@ -64,7 +64,7 @@ GEM
     json (2.5.1)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (4.0.0.1.0)
+    libdatadog (5.0.0.1.0)
     libddwaf (1.14.0.0.0)
       ffi (~> 1.0)
     memory_profiler (0.9.12)

--- a/gemfiles/ruby_2.1_opentracing.gemfile.lock
+++ b/gemfiles/ruby_2.1_opentracing.gemfile.lock
@@ -4,7 +4,7 @@ PATH
     ddtrace (1.14.0)
       datadog-ci (~> 0.1.0)
       debase-ruby_core_source (= 3.2.2)
-      libdatadog (~> 4.0.0.1.0)
+      libdatadog (~> 5.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
 
@@ -39,7 +39,7 @@ GEM
     json (2.5.1)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (4.0.0.1.0)
+    libdatadog (5.0.0.1.0)
     libddwaf (1.14.0.0.0)
       ffi (~> 1.0)
     memory_profiler (0.9.12)

--- a/gemfiles/ruby_2.1_rack_1.gemfile.lock
+++ b/gemfiles/ruby_2.1_rack_1.gemfile.lock
@@ -4,7 +4,7 @@ PATH
     ddtrace (1.14.0)
       datadog-ci (~> 0.1.0)
       debase-ruby_core_source (= 3.2.2)
-      libdatadog (~> 4.0.0.1.0)
+      libdatadog (~> 5.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
 
@@ -38,7 +38,7 @@ GEM
     json (2.5.1)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (4.0.0.1.0)
+    libdatadog (5.0.0.1.0)
     libddwaf (1.14.0.0.0)
       ffi (~> 1.0)
     memory_profiler (0.9.12)

--- a/gemfiles/ruby_2.1_rails32_mysql2.gemfile.lock
+++ b/gemfiles/ruby_2.1_rails32_mysql2.gemfile.lock
@@ -4,7 +4,7 @@ PATH
     ddtrace (1.14.0)
       datadog-ci (~> 0.1.0)
       debase-ruby_core_source (= 3.2.2)
-      libdatadog (~> 4.0.0.1.0)
+      libdatadog (~> 5.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
 
@@ -75,7 +75,7 @@ GEM
     json (2.5.1)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (4.0.0.1.0)
+    libdatadog (5.0.0.1.0)
     libddwaf (1.14.0.0.0)
       ffi (~> 1.0)
     mail (2.5.5)

--- a/gemfiles/ruby_2.1_rails32_postgres.gemfile.lock
+++ b/gemfiles/ruby_2.1_rails32_postgres.gemfile.lock
@@ -4,7 +4,7 @@ PATH
     ddtrace (1.14.0)
       datadog-ci (~> 0.1.0)
       debase-ruby_core_source (= 3.2.2)
-      libdatadog (~> 4.0.0.1.0)
+      libdatadog (~> 5.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
 
@@ -71,7 +71,7 @@ GEM
     json (2.5.1)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (4.0.0.1.0)
+    libdatadog (5.0.0.1.0)
     libddwaf (1.14.0.0.0)
       ffi (~> 1.0)
     mail (2.5.5)

--- a/gemfiles/ruby_2.1_rails32_postgres_redis.gemfile.lock
+++ b/gemfiles/ruby_2.1_rails32_postgres_redis.gemfile.lock
@@ -4,7 +4,7 @@ PATH
     ddtrace (1.14.0)
       datadog-ci (~> 0.1.0)
       debase-ruby_core_source (= 3.2.2)
-      libdatadog (~> 4.0.0.1.0)
+      libdatadog (~> 5.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
 
@@ -71,7 +71,7 @@ GEM
     json (2.5.1)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (4.0.0.1.0)
+    libdatadog (5.0.0.1.0)
     libddwaf (1.14.0.0.0)
       ffi (~> 1.0)
     mail (2.5.5)

--- a/gemfiles/ruby_2.1_rails32_postgres_sidekiq.gemfile.lock
+++ b/gemfiles/ruby_2.1_rails32_postgres_sidekiq.gemfile.lock
@@ -4,7 +4,7 @@ PATH
     ddtrace (1.14.0)
       datadog-ci (~> 0.1.0)
       debase-ruby_core_source (= 3.2.2)
-      libdatadog (~> 4.0.0.1.0)
+      libdatadog (~> 5.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
 
@@ -72,7 +72,7 @@ GEM
     json (1.8.6)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (4.0.0.1.0)
+    libdatadog (5.0.0.1.0)
     libddwaf (1.14.0.0.0)
       ffi (~> 1.0)
     mail (2.5.5)

--- a/gemfiles/ruby_2.1_rails4_mysql2.gemfile.lock
+++ b/gemfiles/ruby_2.1_rails4_mysql2.gemfile.lock
@@ -4,7 +4,7 @@ PATH
     ddtrace (1.14.0)
       datadog-ci (~> 0.1.0)
       debase-ruby_core_source (= 3.2.2)
-      libdatadog (~> 4.0.0.1.0)
+      libdatadog (~> 5.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
 
@@ -79,7 +79,7 @@ GEM
     json (2.5.1)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (4.0.0.1.0)
+    libdatadog (5.0.0.1.0)
     libddwaf (1.14.0.0.0)
       ffi (~> 1.0)
     lograge (0.11.2)

--- a/gemfiles/ruby_2.1_rails4_postgres.gemfile.lock
+++ b/gemfiles/ruby_2.1_rails4_postgres.gemfile.lock
@@ -4,7 +4,7 @@ PATH
     ddtrace (1.14.0)
       datadog-ci (~> 0.1.0)
       debase-ruby_core_source (= 3.2.2)
-      libdatadog (~> 4.0.0.1.0)
+      libdatadog (~> 5.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
 
@@ -79,7 +79,7 @@ GEM
     json (2.5.1)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (4.0.0.1.0)
+    libdatadog (5.0.0.1.0)
     libddwaf (1.14.0.0.0)
       ffi (~> 1.0)
     lograge (0.11.2)

--- a/gemfiles/ruby_2.1_rails4_postgres_redis.gemfile.lock
+++ b/gemfiles/ruby_2.1_rails4_postgres_redis.gemfile.lock
@@ -4,7 +4,7 @@ PATH
     ddtrace (1.14.0)
       datadog-ci (~> 0.1.0)
       debase-ruby_core_source (= 3.2.2)
-      libdatadog (~> 4.0.0.1.0)
+      libdatadog (~> 5.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
 
@@ -79,7 +79,7 @@ GEM
     json (2.5.1)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (4.0.0.1.0)
+    libdatadog (5.0.0.1.0)
     libddwaf (1.14.0.0.0)
       ffi (~> 1.0)
     lograge (0.11.2)

--- a/gemfiles/ruby_2.1_rails4_semantic_logger.gemfile.lock
+++ b/gemfiles/ruby_2.1_rails4_semantic_logger.gemfile.lock
@@ -4,7 +4,7 @@ PATH
     ddtrace (1.14.0)
       datadog-ci (~> 0.1.0)
       debase-ruby_core_source (= 3.2.2)
-      libdatadog (~> 4.0.0.1.0)
+      libdatadog (~> 5.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
 
@@ -79,7 +79,7 @@ GEM
     json (2.5.1)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (4.0.0.1.0)
+    libdatadog (5.0.0.1.0)
     libddwaf (1.14.0.0.0)
       ffi (~> 1.0)
     loofah (2.19.1)

--- a/gemfiles/ruby_2.1_redis_3.gemfile.lock
+++ b/gemfiles/ruby_2.1_redis_3.gemfile.lock
@@ -4,7 +4,7 @@ PATH
     ddtrace (1.14.0)
       datadog-ci (~> 0.1.0)
       debase-ruby_core_source (= 3.2.2)
-      libdatadog (~> 4.0.0.1.0)
+      libdatadog (~> 5.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
 
@@ -38,7 +38,7 @@ GEM
     json (2.5.1)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (4.0.0.1.0)
+    libdatadog (5.0.0.1.0)
     libddwaf (1.14.0.0.0)
       ffi (~> 1.0)
     memory_profiler (0.9.12)

--- a/gemfiles/ruby_2.1_relational_db.gemfile.lock
+++ b/gemfiles/ruby_2.1_relational_db.gemfile.lock
@@ -4,7 +4,7 @@ PATH
     ddtrace (1.14.0)
       datadog-ci (~> 0.1.0)
       debase-ruby_core_source (= 3.2.2)
-      libdatadog (~> 4.0.0.1.0)
+      libdatadog (~> 5.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
 
@@ -61,7 +61,7 @@ GEM
     json (2.5.1)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (4.0.0.1.0)
+    libdatadog (5.0.0.1.0)
     libddwaf (1.14.0.0.0)
       ffi (~> 1.0)
     makara (0.4.1)

--- a/gemfiles/ruby_2.1_sinatra.gemfile.lock
+++ b/gemfiles/ruby_2.1_sinatra.gemfile.lock
@@ -4,7 +4,7 @@ PATH
     ddtrace (1.14.0)
       datadog-ci (~> 0.1.0)
       debase-ruby_core_source (= 3.2.2)
-      libdatadog (~> 4.0.0.1.0)
+      libdatadog (~> 5.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
 
@@ -38,7 +38,7 @@ GEM
     json (2.5.1)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (4.0.0.1.0)
+    libdatadog (5.0.0.1.0)
     libddwaf (1.14.0.0.0)
       ffi (~> 1.0)
     memory_profiler (0.9.12)

--- a/gemfiles/ruby_2.2_activesupport.gemfile.lock
+++ b/gemfiles/ruby_2.2_activesupport.gemfile.lock
@@ -4,7 +4,7 @@ PATH
     ddtrace (1.14.0)
       datadog-ci (~> 0.1.0)
       debase-ruby_core_source (= 3.2.2)
-      libdatadog (~> 4.0.0.1.0)
+      libdatadog (~> 5.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
 
@@ -90,7 +90,7 @@ GEM
       addressable (>= 2.4)
     jsonapi-renderer (0.2.2)
     king_konf (1.0.1)
-    libdatadog (4.0.0.1.0)
+    libdatadog (5.0.0.1.0)
     libddwaf (1.14.0.0.0)
       ffi (~> 1.0)
     lograge (0.11.2)

--- a/gemfiles/ruby_2.2_aws.gemfile.lock
+++ b/gemfiles/ruby_2.2_aws.gemfile.lock
@@ -4,7 +4,7 @@ PATH
     ddtrace (1.14.0)
       datadog-ci (~> 0.1.0)
       debase-ruby_core_source (= 3.2.2)
-      libdatadog (~> 4.0.0.1.0)
+      libdatadog (~> 5.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
 
@@ -1161,7 +1161,7 @@ GEM
     json (2.5.1)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (4.0.0.1.0)
+    libdatadog (5.0.0.1.0)
     libddwaf (1.14.0.0.0)
       ffi (~> 1.0)
     memory_profiler (0.9.12)

--- a/gemfiles/ruby_2.2_contrib.gemfile.lock
+++ b/gemfiles/ruby_2.2_contrib.gemfile.lock
@@ -4,7 +4,7 @@ PATH
     ddtrace (1.14.0)
       datadog-ci (~> 0.1.0)
       debase-ruby_core_source (= 3.2.2)
-      libdatadog (~> 4.0.0.1.0)
+      libdatadog (~> 5.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
 
@@ -57,7 +57,7 @@ GEM
     json (2.5.1)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (4.0.0.1.0)
+    libdatadog (5.0.0.1.0)
     libddwaf (1.14.0.0.0)
       ffi (~> 1.0)
     memory_profiler (0.9.12)

--- a/gemfiles/ruby_2.2_core_old.gemfile.lock
+++ b/gemfiles/ruby_2.2_core_old.gemfile.lock
@@ -4,7 +4,7 @@ PATH
     ddtrace (1.14.0)
       datadog-ci (~> 0.1.0)
       debase-ruby_core_source (= 3.2.2)
-      libdatadog (~> 4.0.0.1.0)
+      libdatadog (~> 5.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
 
@@ -38,7 +38,7 @@ GEM
     json (2.5.1)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (4.0.0.1.0)
+    libdatadog (5.0.0.1.0)
     libddwaf (1.14.0.0.0)
       ffi (~> 1.0)
     memory_profiler (0.9.12)

--- a/gemfiles/ruby_2.2_http.gemfile.lock
+++ b/gemfiles/ruby_2.2_http.gemfile.lock
@@ -4,7 +4,7 @@ PATH
     ddtrace (1.14.0)
       datadog-ci (~> 0.1.0)
       debase-ruby_core_source (= 3.2.2)
-      libdatadog (~> 4.0.0.1.0)
+      libdatadog (~> 5.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
 
@@ -64,7 +64,7 @@ GEM
     json (2.5.1)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (4.0.0.1.0)
+    libdatadog (5.0.0.1.0)
     libddwaf (1.14.0.0.0)
       ffi (~> 1.0)
     memory_profiler (0.9.12)

--- a/gemfiles/ruby_2.2_opentracing.gemfile.lock
+++ b/gemfiles/ruby_2.2_opentracing.gemfile.lock
@@ -4,7 +4,7 @@ PATH
     ddtrace (1.14.0)
       datadog-ci (~> 0.1.0)
       debase-ruby_core_source (= 3.2.2)
-      libdatadog (~> 4.0.0.1.0)
+      libdatadog (~> 5.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
 
@@ -39,7 +39,7 @@ GEM
     json (2.5.1)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (4.0.0.1.0)
+    libdatadog (5.0.0.1.0)
     libddwaf (1.14.0.0.0)
       ffi (~> 1.0)
     memory_profiler (0.9.12)

--- a/gemfiles/ruby_2.2_rack_1.gemfile.lock
+++ b/gemfiles/ruby_2.2_rack_1.gemfile.lock
@@ -4,7 +4,7 @@ PATH
     ddtrace (1.14.0)
       datadog-ci (~> 0.1.0)
       debase-ruby_core_source (= 3.2.2)
-      libdatadog (~> 4.0.0.1.0)
+      libdatadog (~> 5.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
 
@@ -38,7 +38,7 @@ GEM
     json (2.5.1)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (4.0.0.1.0)
+    libdatadog (5.0.0.1.0)
     libddwaf (1.14.0.0.0)
       ffi (~> 1.0)
     memory_profiler (0.9.12)

--- a/gemfiles/ruby_2.2_rails32_mysql2.gemfile.lock
+++ b/gemfiles/ruby_2.2_rails32_mysql2.gemfile.lock
@@ -4,7 +4,7 @@ PATH
     ddtrace (1.14.0)
       datadog-ci (~> 0.1.0)
       debase-ruby_core_source (= 3.2.2)
-      libdatadog (~> 4.0.0.1.0)
+      libdatadog (~> 5.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
 
@@ -75,7 +75,7 @@ GEM
     json (2.5.1)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (4.0.0.1.0)
+    libdatadog (5.0.0.1.0)
     libddwaf (1.14.0.0.0)
       ffi (~> 1.0)
     mail (2.5.5)

--- a/gemfiles/ruby_2.2_rails32_postgres.gemfile.lock
+++ b/gemfiles/ruby_2.2_rails32_postgres.gemfile.lock
@@ -4,7 +4,7 @@ PATH
     ddtrace (1.14.0)
       datadog-ci (~> 0.1.0)
       debase-ruby_core_source (= 3.2.2)
-      libdatadog (~> 4.0.0.1.0)
+      libdatadog (~> 5.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
 
@@ -71,7 +71,7 @@ GEM
     json (2.5.1)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (4.0.0.1.0)
+    libdatadog (5.0.0.1.0)
     libddwaf (1.14.0.0.0)
       ffi (~> 1.0)
     mail (2.5.5)

--- a/gemfiles/ruby_2.2_rails32_postgres_redis.gemfile.lock
+++ b/gemfiles/ruby_2.2_rails32_postgres_redis.gemfile.lock
@@ -4,7 +4,7 @@ PATH
     ddtrace (1.14.0)
       datadog-ci (~> 0.1.0)
       debase-ruby_core_source (= 3.2.2)
-      libdatadog (~> 4.0.0.1.0)
+      libdatadog (~> 5.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
 
@@ -71,7 +71,7 @@ GEM
     json (2.5.1)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (4.0.0.1.0)
+    libdatadog (5.0.0.1.0)
     libddwaf (1.14.0.0.0)
       ffi (~> 1.0)
     mail (2.5.5)

--- a/gemfiles/ruby_2.2_rails32_postgres_sidekiq.gemfile.lock
+++ b/gemfiles/ruby_2.2_rails32_postgres_sidekiq.gemfile.lock
@@ -4,7 +4,7 @@ PATH
     ddtrace (1.14.0)
       datadog-ci (~> 0.1.0)
       debase-ruby_core_source (= 3.2.2)
-      libdatadog (~> 4.0.0.1.0)
+      libdatadog (~> 5.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
 
@@ -72,7 +72,7 @@ GEM
     json (1.8.6)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (4.0.0.1.0)
+    libdatadog (5.0.0.1.0)
     libddwaf (1.14.0.0.0)
       ffi (~> 1.0)
     mail (2.5.5)

--- a/gemfiles/ruby_2.2_rails4_mysql2.gemfile.lock
+++ b/gemfiles/ruby_2.2_rails4_mysql2.gemfile.lock
@@ -4,7 +4,7 @@ PATH
     ddtrace (1.14.0)
       datadog-ci (~> 0.1.0)
       debase-ruby_core_source (= 3.2.2)
-      libdatadog (~> 4.0.0.1.0)
+      libdatadog (~> 5.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
 
@@ -79,7 +79,7 @@ GEM
     json (2.5.1)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (4.0.0.1.0)
+    libdatadog (5.0.0.1.0)
     libddwaf (1.14.0.0.0)
       ffi (~> 1.0)
     lograge (0.11.2)

--- a/gemfiles/ruby_2.2_rails4_postgres.gemfile.lock
+++ b/gemfiles/ruby_2.2_rails4_postgres.gemfile.lock
@@ -4,7 +4,7 @@ PATH
     ddtrace (1.14.0)
       datadog-ci (~> 0.1.0)
       debase-ruby_core_source (= 3.2.2)
-      libdatadog (~> 4.0.0.1.0)
+      libdatadog (~> 5.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
 
@@ -79,7 +79,7 @@ GEM
     json (2.5.1)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (4.0.0.1.0)
+    libdatadog (5.0.0.1.0)
     libddwaf (1.14.0.0.0)
       ffi (~> 1.0)
     lograge (0.11.2)

--- a/gemfiles/ruby_2.2_rails4_postgres_redis.gemfile.lock
+++ b/gemfiles/ruby_2.2_rails4_postgres_redis.gemfile.lock
@@ -4,7 +4,7 @@ PATH
     ddtrace (1.14.0)
       datadog-ci (~> 0.1.0)
       debase-ruby_core_source (= 3.2.2)
-      libdatadog (~> 4.0.0.1.0)
+      libdatadog (~> 5.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
 
@@ -79,7 +79,7 @@ GEM
     json (2.5.1)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (4.0.0.1.0)
+    libdatadog (5.0.0.1.0)
     libddwaf (1.14.0.0.0)
       ffi (~> 1.0)
     lograge (0.11.2)

--- a/gemfiles/ruby_2.2_rails4_postgres_sidekiq.gemfile.lock
+++ b/gemfiles/ruby_2.2_rails4_postgres_sidekiq.gemfile.lock
@@ -4,7 +4,7 @@ PATH
     ddtrace (1.14.0)
       datadog-ci (~> 0.1.0)
       debase-ruby_core_source (= 3.2.2)
-      libdatadog (~> 4.0.0.1.0)
+      libdatadog (~> 5.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
 
@@ -80,7 +80,7 @@ GEM
     json (2.5.1)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (4.0.0.1.0)
+    libdatadog (5.0.0.1.0)
     libddwaf (1.14.0.0.0)
       ffi (~> 1.0)
     lograge (0.11.2)

--- a/gemfiles/ruby_2.2_rails4_semantic_logger.gemfile.lock
+++ b/gemfiles/ruby_2.2_rails4_semantic_logger.gemfile.lock
@@ -4,7 +4,7 @@ PATH
     ddtrace (1.14.0)
       datadog-ci (~> 0.1.0)
       debase-ruby_core_source (= 3.2.2)
-      libdatadog (~> 4.0.0.1.0)
+      libdatadog (~> 5.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
 
@@ -79,7 +79,7 @@ GEM
     json (2.5.1)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (4.0.0.1.0)
+    libdatadog (5.0.0.1.0)
     libddwaf (1.14.0.0.0)
       ffi (~> 1.0)
     loofah (2.19.1)

--- a/gemfiles/ruby_2.2_rails5_mysql2.gemfile.lock
+++ b/gemfiles/ruby_2.2_rails5_mysql2.gemfile.lock
@@ -4,7 +4,7 @@ PATH
     ddtrace (1.14.0)
       datadog-ci (~> 0.1.0)
       debase-ruby_core_source (= 3.2.2)
-      libdatadog (~> 4.0.0.1.0)
+      libdatadog (~> 5.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
 
@@ -86,7 +86,7 @@ GEM
     json (2.5.1)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (4.0.0.1.0)
+    libdatadog (5.0.0.1.0)
     libddwaf (1.14.0.0.0)
       ffi (~> 1.0)
     lograge (0.11.2)

--- a/gemfiles/ruby_2.2_rails5_postgres.gemfile.lock
+++ b/gemfiles/ruby_2.2_rails5_postgres.gemfile.lock
@@ -4,7 +4,7 @@ PATH
     ddtrace (1.14.0)
       datadog-ci (~> 0.1.0)
       debase-ruby_core_source (= 3.2.2)
-      libdatadog (~> 4.0.0.1.0)
+      libdatadog (~> 5.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
 
@@ -86,7 +86,7 @@ GEM
     json (2.5.1)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (4.0.0.1.0)
+    libdatadog (5.0.0.1.0)
     libddwaf (1.14.0.0.0)
       ffi (~> 1.0)
     lograge (0.11.2)

--- a/gemfiles/ruby_2.2_rails5_postgres_redis.gemfile.lock
+++ b/gemfiles/ruby_2.2_rails5_postgres_redis.gemfile.lock
@@ -4,7 +4,7 @@ PATH
     ddtrace (1.14.0)
       datadog-ci (~> 0.1.0)
       debase-ruby_core_source (= 3.2.2)
-      libdatadog (~> 4.0.0.1.0)
+      libdatadog (~> 5.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
 
@@ -86,7 +86,7 @@ GEM
     json (2.5.1)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (4.0.0.1.0)
+    libdatadog (5.0.0.1.0)
     libddwaf (1.14.0.0.0)
       ffi (~> 1.0)
     lograge (0.11.2)

--- a/gemfiles/ruby_2.2_rails5_postgres_redis_activesupport.gemfile.lock
+++ b/gemfiles/ruby_2.2_rails5_postgres_redis_activesupport.gemfile.lock
@@ -4,7 +4,7 @@ PATH
     ddtrace (1.14.0)
       datadog-ci (~> 0.1.0)
       debase-ruby_core_source (= 3.2.2)
-      libdatadog (~> 4.0.0.1.0)
+      libdatadog (~> 5.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
 
@@ -86,7 +86,7 @@ GEM
     json (2.5.1)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (4.0.0.1.0)
+    libdatadog (5.0.0.1.0)
     libddwaf (1.14.0.0.0)
       ffi (~> 1.0)
     lograge (0.11.2)

--- a/gemfiles/ruby_2.2_rails5_postgres_sidekiq.gemfile.lock
+++ b/gemfiles/ruby_2.2_rails5_postgres_sidekiq.gemfile.lock
@@ -4,7 +4,7 @@ PATH
     ddtrace (1.14.0)
       datadog-ci (~> 0.1.0)
       debase-ruby_core_source (= 3.2.2)
-      libdatadog (~> 4.0.0.1.0)
+      libdatadog (~> 5.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
 
@@ -87,7 +87,7 @@ GEM
     json (2.5.1)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (4.0.0.1.0)
+    libdatadog (5.0.0.1.0)
     libddwaf (1.14.0.0.0)
       ffi (~> 1.0)
     lograge (0.11.2)

--- a/gemfiles/ruby_2.2_rails5_semantic_logger.gemfile.lock
+++ b/gemfiles/ruby_2.2_rails5_semantic_logger.gemfile.lock
@@ -4,7 +4,7 @@ PATH
     ddtrace (1.14.0)
       datadog-ci (~> 0.1.0)
       debase-ruby_core_source (= 3.2.2)
-      libdatadog (~> 4.0.0.1.0)
+      libdatadog (~> 5.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
 
@@ -86,7 +86,7 @@ GEM
     json (2.5.1)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (4.0.0.1.0)
+    libdatadog (5.0.0.1.0)
     libddwaf (1.14.0.0.0)
       ffi (~> 1.0)
     loofah (2.19.1)

--- a/gemfiles/ruby_2.2_redis_3.gemfile.lock
+++ b/gemfiles/ruby_2.2_redis_3.gemfile.lock
@@ -4,7 +4,7 @@ PATH
     ddtrace (1.14.0)
       datadog-ci (~> 0.1.0)
       debase-ruby_core_source (= 3.2.2)
-      libdatadog (~> 4.0.0.1.0)
+      libdatadog (~> 5.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
 
@@ -38,7 +38,7 @@ GEM
     json (2.5.1)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (4.0.0.1.0)
+    libdatadog (5.0.0.1.0)
     libddwaf (1.14.0.0.0)
       ffi (~> 1.0)
     memory_profiler (0.9.12)

--- a/gemfiles/ruby_2.2_relational_db.gemfile.lock
+++ b/gemfiles/ruby_2.2_relational_db.gemfile.lock
@@ -4,7 +4,7 @@ PATH
     ddtrace (1.14.0)
       datadog-ci (~> 0.1.0)
       debase-ruby_core_source (= 3.2.2)
-      libdatadog (~> 4.0.0.1.0)
+      libdatadog (~> 5.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
 
@@ -57,7 +57,7 @@ GEM
     json (2.5.1)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (4.0.0.1.0)
+    libdatadog (5.0.0.1.0)
     libddwaf (1.14.0.0.0)
       ffi (~> 1.0)
     makara (0.4.1)

--- a/gemfiles/ruby_2.2_sinatra.gemfile.lock
+++ b/gemfiles/ruby_2.2_sinatra.gemfile.lock
@@ -4,7 +4,7 @@ PATH
     ddtrace (1.14.0)
       datadog-ci (~> 0.1.0)
       debase-ruby_core_source (= 3.2.2)
-      libdatadog (~> 4.0.0.1.0)
+      libdatadog (~> 5.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
 
@@ -38,7 +38,7 @@ GEM
     json (2.5.1)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (4.0.0.1.0)
+    libdatadog (5.0.0.1.0)
     libddwaf (1.14.0.0.0)
       ffi (~> 1.0)
     memory_profiler (0.9.12)

--- a/gemfiles/ruby_2.3_activerecord_3.gemfile.lock
+++ b/gemfiles/ruby_2.3_activerecord_3.gemfile.lock
@@ -4,7 +4,7 @@ PATH
     ddtrace (1.14.0)
       datadog-ci (~> 0.1.0)
       debase-ruby_core_source (= 3.2.2)
-      libdatadog (~> 4.0.0.1.0)
+      libdatadog (~> 5.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
 
@@ -56,7 +56,7 @@ GEM
     json (2.6.3)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (4.0.0.1.0)
+    libdatadog (5.0.0.1.0)
     libddwaf (1.14.0.0.0)
       ffi (~> 1.0)
     makara (0.3.10)

--- a/gemfiles/ruby_2.3_activesupport.gemfile.lock
+++ b/gemfiles/ruby_2.3_activesupport.gemfile.lock
@@ -4,7 +4,7 @@ PATH
     ddtrace (1.14.0)
       datadog-ci (~> 0.1.0)
       debase-ruby_core_source (= 3.2.2)
-      libdatadog (~> 4.0.0.1.0)
+      libdatadog (~> 5.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
 
@@ -90,7 +90,7 @@ GEM
       addressable (>= 2.4)
     jsonapi-renderer (0.2.2)
     king_konf (1.0.1)
-    libdatadog (4.0.0.1.0)
+    libdatadog (5.0.0.1.0)
     libddwaf (1.14.0.0.0)
       ffi (~> 1.0)
     lograge (0.11.2)

--- a/gemfiles/ruby_2.3_aws.gemfile.lock
+++ b/gemfiles/ruby_2.3_aws.gemfile.lock
@@ -4,7 +4,7 @@ PATH
     ddtrace (1.14.0)
       datadog-ci (~> 0.1.0)
       debase-ruby_core_source (= 3.2.2)
-      libdatadog (~> 4.0.0.1.0)
+      libdatadog (~> 5.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
 
@@ -1460,7 +1460,7 @@ GEM
     json (2.6.3)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (4.0.0.1.0)
+    libdatadog (5.0.0.1.0)
     libddwaf (1.14.0.0.0)
       ffi (~> 1.0)
     memory_profiler (0.9.14)

--- a/gemfiles/ruby_2.3_contrib.gemfile.lock
+++ b/gemfiles/ruby_2.3_contrib.gemfile.lock
@@ -4,7 +4,7 @@ PATH
     ddtrace (1.14.0)
       datadog-ci (~> 0.1.0)
       debase-ruby_core_source (= 3.2.2)
-      libdatadog (~> 4.0.0.1.0)
+      libdatadog (~> 5.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
 
@@ -54,7 +54,7 @@ GEM
     json (2.6.3)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (4.0.0.1.0)
+    libdatadog (5.0.0.1.0)
     libddwaf (1.14.0.0.0)
       ffi (~> 1.0)
     memory_profiler (0.9.14)

--- a/gemfiles/ruby_2.3_contrib_old.gemfile.lock
+++ b/gemfiles/ruby_2.3_contrib_old.gemfile.lock
@@ -4,7 +4,7 @@ PATH
     ddtrace (1.14.0)
       datadog-ci (~> 0.1.0)
       debase-ruby_core_source (= 3.2.2)
-      libdatadog (~> 4.0.0.1.0)
+      libdatadog (~> 5.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
 
@@ -50,7 +50,7 @@ GEM
     json (2.6.3)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (4.0.0.1.0)
+    libdatadog (5.0.0.1.0)
     libddwaf (1.14.0.0.0)
       ffi (~> 1.0)
     memory_profiler (0.9.14)

--- a/gemfiles/ruby_2.3_core_old.gemfile.lock
+++ b/gemfiles/ruby_2.3_core_old.gemfile.lock
@@ -4,7 +4,7 @@ PATH
     ddtrace (1.14.0)
       datadog-ci (~> 0.1.0)
       debase-ruby_core_source (= 3.2.2)
-      libdatadog (~> 4.0.0.1.0)
+      libdatadog (~> 5.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
 
@@ -38,7 +38,7 @@ GEM
     json (2.6.3)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (4.0.0.1.0)
+    libdatadog (5.0.0.1.0)
     libddwaf (1.14.0.0.0)
       ffi (~> 1.0)
     memory_profiler (0.9.14)

--- a/gemfiles/ruby_2.3_hanami_1.gemfile.lock
+++ b/gemfiles/ruby_2.3_hanami_1.gemfile.lock
@@ -4,7 +4,7 @@ PATH
     ddtrace (1.14.0)
       datadog-ci (~> 0.1.0)
       debase-ruby_core_source (= 3.2.2)
-      libdatadog (~> 4.0.0.1.0)
+      libdatadog (~> 5.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
 
@@ -113,7 +113,7 @@ GEM
     json (2.6.3)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (4.0.0.1.0)
+    libdatadog (5.0.0.1.0)
     libddwaf (1.14.0.0.0)
       ffi (~> 1.0)
     mail (2.7.1)

--- a/gemfiles/ruby_2.3_http.gemfile.lock
+++ b/gemfiles/ruby_2.3_http.gemfile.lock
@@ -4,7 +4,7 @@ PATH
     ddtrace (1.14.0)
       datadog-ci (~> 0.1.0)
       debase-ruby_core_source (= 3.2.2)
-      libdatadog (~> 4.0.0.1.0)
+      libdatadog (~> 5.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
 
@@ -60,7 +60,7 @@ GEM
     json (2.6.3)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (4.0.0.1.0)
+    libdatadog (5.0.0.1.0)
     libddwaf (1.14.0.0.0)
       ffi (~> 1.0)
     memory_profiler (0.9.14)

--- a/gemfiles/ruby_2.3_opentracing.gemfile.lock
+++ b/gemfiles/ruby_2.3_opentracing.gemfile.lock
@@ -4,7 +4,7 @@ PATH
     ddtrace (1.14.0)
       datadog-ci (~> 0.1.0)
       debase-ruby_core_source (= 3.2.2)
-      libdatadog (~> 4.0.0.1.0)
+      libdatadog (~> 5.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
 
@@ -39,7 +39,7 @@ GEM
     json (2.6.3)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (4.0.0.1.0)
+    libdatadog (5.0.0.1.0)
     libddwaf (1.14.0.0.0)
       ffi (~> 1.0)
     memory_profiler (0.9.14)

--- a/gemfiles/ruby_2.3_rack_1.gemfile.lock
+++ b/gemfiles/ruby_2.3_rack_1.gemfile.lock
@@ -4,7 +4,7 @@ PATH
     ddtrace (1.14.0)
       datadog-ci (~> 0.1.0)
       debase-ruby_core_source (= 3.2.2)
-      libdatadog (~> 4.0.0.1.0)
+      libdatadog (~> 5.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
 
@@ -38,7 +38,7 @@ GEM
     json (2.6.3)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (4.0.0.1.0)
+    libdatadog (5.0.0.1.0)
     libddwaf (1.14.0.0.0)
       ffi (~> 1.0)
     memory_profiler (0.9.14)

--- a/gemfiles/ruby_2.3_rack_2.gemfile.lock
+++ b/gemfiles/ruby_2.3_rack_2.gemfile.lock
@@ -4,7 +4,7 @@ PATH
     ddtrace (1.14.0)
       datadog-ci (~> 0.1.0)
       debase-ruby_core_source (= 3.2.2)
-      libdatadog (~> 4.0.0.1.0)
+      libdatadog (~> 5.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
 
@@ -38,7 +38,7 @@ GEM
     json (2.6.3)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (4.0.0.1.0)
+    libdatadog (5.0.0.1.0)
     libddwaf (1.14.0.0.0)
       ffi (~> 1.0)
     memory_profiler (0.9.14)

--- a/gemfiles/ruby_2.3_rails32_mysql2.gemfile.lock
+++ b/gemfiles/ruby_2.3_rails32_mysql2.gemfile.lock
@@ -4,7 +4,7 @@ PATH
     ddtrace (1.14.0)
       datadog-ci (~> 0.1.0)
       debase-ruby_core_source (= 3.2.2)
-      libdatadog (~> 4.0.0.1.0)
+      libdatadog (~> 5.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
 
@@ -75,7 +75,7 @@ GEM
     json (2.6.3)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (4.0.0.1.0)
+    libdatadog (5.0.0.1.0)
     libddwaf (1.14.0.0.0)
       ffi (~> 1.0)
     mail (2.5.5)

--- a/gemfiles/ruby_2.3_rails32_postgres.gemfile.lock
+++ b/gemfiles/ruby_2.3_rails32_postgres.gemfile.lock
@@ -4,7 +4,7 @@ PATH
     ddtrace (1.14.0)
       datadog-ci (~> 0.1.0)
       debase-ruby_core_source (= 3.2.2)
-      libdatadog (~> 4.0.0.1.0)
+      libdatadog (~> 5.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
 
@@ -71,7 +71,7 @@ GEM
     json (2.6.3)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (4.0.0.1.0)
+    libdatadog (5.0.0.1.0)
     libddwaf (1.14.0.0.0)
       ffi (~> 1.0)
     mail (2.5.5)

--- a/gemfiles/ruby_2.3_rails32_postgres_redis.gemfile.lock
+++ b/gemfiles/ruby_2.3_rails32_postgres_redis.gemfile.lock
@@ -4,7 +4,7 @@ PATH
     ddtrace (1.14.0)
       datadog-ci (~> 0.1.0)
       debase-ruby_core_source (= 3.2.2)
-      libdatadog (~> 4.0.0.1.0)
+      libdatadog (~> 5.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
 
@@ -71,7 +71,7 @@ GEM
     json (2.6.3)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (4.0.0.1.0)
+    libdatadog (5.0.0.1.0)
     libddwaf (1.14.0.0.0)
       ffi (~> 1.0)
     mail (2.5.5)

--- a/gemfiles/ruby_2.3_rails32_postgres_sidekiq.gemfile.lock
+++ b/gemfiles/ruby_2.3_rails32_postgres_sidekiq.gemfile.lock
@@ -4,7 +4,7 @@ PATH
     ddtrace (1.14.0)
       datadog-ci (~> 0.1.0)
       debase-ruby_core_source (= 3.2.2)
-      libdatadog (~> 4.0.0.1.0)
+      libdatadog (~> 5.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
 
@@ -72,7 +72,7 @@ GEM
     json (1.8.6)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (4.0.0.1.0)
+    libdatadog (5.0.0.1.0)
     libddwaf (1.14.0.0.0)
       ffi (~> 1.0)
     mail (2.5.5)

--- a/gemfiles/ruby_2.3_rails4_mysql2.gemfile.lock
+++ b/gemfiles/ruby_2.3_rails4_mysql2.gemfile.lock
@@ -4,7 +4,7 @@ PATH
     ddtrace (1.14.0)
       datadog-ci (~> 0.1.0)
       debase-ruby_core_source (= 3.2.2)
-      libdatadog (~> 4.0.0.1.0)
+      libdatadog (~> 5.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
 
@@ -79,7 +79,7 @@ GEM
     json (2.6.3)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (4.0.0.1.0)
+    libdatadog (5.0.0.1.0)
     libddwaf (1.14.0.0.0)
       ffi (~> 1.0)
     lograge (0.11.2)

--- a/gemfiles/ruby_2.3_rails4_postgres.gemfile.lock
+++ b/gemfiles/ruby_2.3_rails4_postgres.gemfile.lock
@@ -4,7 +4,7 @@ PATH
     ddtrace (1.14.0)
       datadog-ci (~> 0.1.0)
       debase-ruby_core_source (= 3.2.2)
-      libdatadog (~> 4.0.0.1.0)
+      libdatadog (~> 5.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
 
@@ -79,7 +79,7 @@ GEM
     json (2.6.3)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (4.0.0.1.0)
+    libdatadog (5.0.0.1.0)
     libddwaf (1.14.0.0.0)
       ffi (~> 1.0)
     lograge (0.11.2)

--- a/gemfiles/ruby_2.3_rails4_postgres_redis.gemfile.lock
+++ b/gemfiles/ruby_2.3_rails4_postgres_redis.gemfile.lock
@@ -4,7 +4,7 @@ PATH
     ddtrace (1.14.0)
       datadog-ci (~> 0.1.0)
       debase-ruby_core_source (= 3.2.2)
-      libdatadog (~> 4.0.0.1.0)
+      libdatadog (~> 5.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
 
@@ -79,7 +79,7 @@ GEM
     json (2.6.3)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (4.0.0.1.0)
+    libdatadog (5.0.0.1.0)
     libddwaf (1.14.0.0.0)
       ffi (~> 1.0)
     lograge (0.11.2)

--- a/gemfiles/ruby_2.3_rails4_postgres_sidekiq.gemfile.lock
+++ b/gemfiles/ruby_2.3_rails4_postgres_sidekiq.gemfile.lock
@@ -4,7 +4,7 @@ PATH
     ddtrace (1.14.0)
       datadog-ci (~> 0.1.0)
       debase-ruby_core_source (= 3.2.2)
-      libdatadog (~> 4.0.0.1.0)
+      libdatadog (~> 5.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
 
@@ -80,7 +80,7 @@ GEM
     json (2.6.3)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (4.0.0.1.0)
+    libdatadog (5.0.0.1.0)
     libddwaf (1.14.0.0.0)
       ffi (~> 1.0)
     lograge (0.11.2)

--- a/gemfiles/ruby_2.3_rails4_semantic_logger.gemfile.lock
+++ b/gemfiles/ruby_2.3_rails4_semantic_logger.gemfile.lock
@@ -4,7 +4,7 @@ PATH
     ddtrace (1.14.0)
       datadog-ci (~> 0.1.0)
       debase-ruby_core_source (= 3.2.2)
-      libdatadog (~> 4.0.0.1.0)
+      libdatadog (~> 5.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
 
@@ -79,7 +79,7 @@ GEM
     json (2.6.3)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (4.0.0.1.0)
+    libdatadog (5.0.0.1.0)
     libddwaf (1.14.0.0.0)
       ffi (~> 1.0)
     loofah (2.19.1)

--- a/gemfiles/ruby_2.3_rails5_mysql2.gemfile.lock
+++ b/gemfiles/ruby_2.3_rails5_mysql2.gemfile.lock
@@ -4,7 +4,7 @@ PATH
     ddtrace (1.14.0)
       datadog-ci (~> 0.1.0)
       debase-ruby_core_source (= 3.2.2)
-      libdatadog (~> 4.0.0.1.0)
+      libdatadog (~> 5.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
 
@@ -86,7 +86,7 @@ GEM
     json (2.6.3)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (4.0.0.1.0)
+    libdatadog (5.0.0.1.0)
     libddwaf (1.14.0.0.0)
       ffi (~> 1.0)
     lograge (0.11.2)

--- a/gemfiles/ruby_2.3_rails5_postgres.gemfile.lock
+++ b/gemfiles/ruby_2.3_rails5_postgres.gemfile.lock
@@ -4,7 +4,7 @@ PATH
     ddtrace (1.14.0)
       datadog-ci (~> 0.1.0)
       debase-ruby_core_source (= 3.2.2)
-      libdatadog (~> 4.0.0.1.0)
+      libdatadog (~> 5.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
 
@@ -86,7 +86,7 @@ GEM
     json (2.6.3)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (4.0.0.1.0)
+    libdatadog (5.0.0.1.0)
     libddwaf (1.14.0.0.0)
       ffi (~> 1.0)
     lograge (0.11.2)

--- a/gemfiles/ruby_2.3_rails5_postgres_redis.gemfile.lock
+++ b/gemfiles/ruby_2.3_rails5_postgres_redis.gemfile.lock
@@ -4,7 +4,7 @@ PATH
     ddtrace (1.14.0)
       datadog-ci (~> 0.1.0)
       debase-ruby_core_source (= 3.2.2)
-      libdatadog (~> 4.0.0.1.0)
+      libdatadog (~> 5.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
 
@@ -86,7 +86,7 @@ GEM
     json (2.6.3)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (4.0.0.1.0)
+    libdatadog (5.0.0.1.0)
     libddwaf (1.14.0.0.0)
       ffi (~> 1.0)
     lograge (0.11.2)

--- a/gemfiles/ruby_2.3_rails5_postgres_redis_activesupport.gemfile.lock
+++ b/gemfiles/ruby_2.3_rails5_postgres_redis_activesupport.gemfile.lock
@@ -4,7 +4,7 @@ PATH
     ddtrace (1.14.0)
       datadog-ci (~> 0.1.0)
       debase-ruby_core_source (= 3.2.2)
-      libdatadog (~> 4.0.0.1.0)
+      libdatadog (~> 5.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
 
@@ -86,7 +86,7 @@ GEM
     json (2.6.3)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (4.0.0.1.0)
+    libdatadog (5.0.0.1.0)
     libddwaf (1.14.0.0.0)
       ffi (~> 1.0)
     lograge (0.11.2)

--- a/gemfiles/ruby_2.3_rails5_postgres_sidekiq.gemfile.lock
+++ b/gemfiles/ruby_2.3_rails5_postgres_sidekiq.gemfile.lock
@@ -4,7 +4,7 @@ PATH
     ddtrace (1.14.0)
       datadog-ci (~> 0.1.0)
       debase-ruby_core_source (= 3.2.2)
-      libdatadog (~> 4.0.0.1.0)
+      libdatadog (~> 5.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
 
@@ -87,7 +87,7 @@ GEM
     json (2.6.3)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (4.0.0.1.0)
+    libdatadog (5.0.0.1.0)
     libddwaf (1.14.0.0.0)
       ffi (~> 1.0)
     lograge (0.11.2)

--- a/gemfiles/ruby_2.3_rails5_semantic_logger.gemfile.lock
+++ b/gemfiles/ruby_2.3_rails5_semantic_logger.gemfile.lock
@@ -4,7 +4,7 @@ PATH
     ddtrace (1.14.0)
       datadog-ci (~> 0.1.0)
       debase-ruby_core_source (= 3.2.2)
-      libdatadog (~> 4.0.0.1.0)
+      libdatadog (~> 5.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
 
@@ -86,7 +86,7 @@ GEM
     json (2.6.3)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (4.0.0.1.0)
+    libdatadog (5.0.0.1.0)
     libddwaf (1.14.0.0.0)
       ffi (~> 1.0)
     loofah (2.19.1)

--- a/gemfiles/ruby_2.3_redis_3.gemfile.lock
+++ b/gemfiles/ruby_2.3_redis_3.gemfile.lock
@@ -4,7 +4,7 @@ PATH
     ddtrace (1.14.0)
       datadog-ci (~> 0.1.0)
       debase-ruby_core_source (= 3.2.2)
-      libdatadog (~> 4.0.0.1.0)
+      libdatadog (~> 5.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
 
@@ -38,7 +38,7 @@ GEM
     json (2.6.3)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (4.0.0.1.0)
+    libdatadog (5.0.0.1.0)
     libddwaf (1.14.0.0.0)
       ffi (~> 1.0)
     memory_profiler (0.9.14)

--- a/gemfiles/ruby_2.3_relational_db.gemfile.lock
+++ b/gemfiles/ruby_2.3_relational_db.gemfile.lock
@@ -4,7 +4,7 @@ PATH
     ddtrace (1.14.0)
       datadog-ci (~> 0.1.0)
       debase-ruby_core_source (= 3.2.2)
-      libdatadog (~> 4.0.0.1.0)
+      libdatadog (~> 5.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
 
@@ -57,7 +57,7 @@ GEM
     json (2.6.3)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (4.0.0.1.0)
+    libdatadog (5.0.0.1.0)
     libddwaf (1.14.0.0.0)
       ffi (~> 1.0)
     makara (0.5.0)

--- a/gemfiles/ruby_2.3_resque2_redis3.gemfile.lock
+++ b/gemfiles/ruby_2.3_resque2_redis3.gemfile.lock
@@ -4,7 +4,7 @@ PATH
     ddtrace (1.14.0)
       datadog-ci (~> 0.1.0)
       debase-ruby_core_source (= 3.2.2)
-      libdatadog (~> 4.0.0.1.0)
+      libdatadog (~> 5.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
 
@@ -38,7 +38,7 @@ GEM
     json (2.6.3)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (4.0.0.1.0)
+    libdatadog (5.0.0.1.0)
     libddwaf (1.14.0.0.0)
       ffi (~> 1.0)
     memory_profiler (0.9.14)

--- a/gemfiles/ruby_2.3_resque2_redis4.gemfile.lock
+++ b/gemfiles/ruby_2.3_resque2_redis4.gemfile.lock
@@ -4,7 +4,7 @@ PATH
     ddtrace (1.14.0)
       datadog-ci (~> 0.1.0)
       debase-ruby_core_source (= 3.2.2)
-      libdatadog (~> 4.0.0.1.0)
+      libdatadog (~> 5.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
 
@@ -38,7 +38,7 @@ GEM
     json (2.6.3)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (4.0.0.1.0)
+    libdatadog (5.0.0.1.0)
     libddwaf (1.14.0.0.0)
       ffi (~> 1.0)
     memory_profiler (0.9.14)

--- a/gemfiles/ruby_2.3_sinatra.gemfile.lock
+++ b/gemfiles/ruby_2.3_sinatra.gemfile.lock
@@ -4,7 +4,7 @@ PATH
     ddtrace (1.14.0)
       datadog-ci (~> 0.1.0)
       debase-ruby_core_source (= 3.2.2)
-      libdatadog (~> 4.0.0.1.0)
+      libdatadog (~> 5.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
 
@@ -38,7 +38,7 @@ GEM
     json (2.6.3)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (4.0.0.1.0)
+    libdatadog (5.0.0.1.0)
     libddwaf (1.14.0.0.0)
       ffi (~> 1.0)
     memory_profiler (0.9.14)

--- a/gemfiles/ruby_2.4_activerecord_4.gemfile.lock
+++ b/gemfiles/ruby_2.4_activerecord_4.gemfile.lock
@@ -4,7 +4,7 @@ PATH
     ddtrace (1.14.0)
       datadog-ci (~> 0.1.0)
       debase-ruby_core_source (= 3.2.2)
-      libdatadog (~> 4.0.0.1.0)
+      libdatadog (~> 5.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
 
@@ -54,8 +54,8 @@ GEM
       concurrent-ruby (~> 1.0)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (4.0.0.1.0-aarch64-linux)
-    libdatadog (4.0.0.1.0-x86_64-linux)
+    libdatadog (5.0.0.1.0-aarch64-linux)
+    libdatadog (5.0.0.1.0-x86_64-linux)
     libddwaf (1.14.0.0.0-aarch64-linux)
       ffi (~> 1.0)
     libddwaf (1.14.0.0.0-x86_64-linux)

--- a/gemfiles/ruby_2.4_activesupport.gemfile.lock
+++ b/gemfiles/ruby_2.4_activesupport.gemfile.lock
@@ -4,7 +4,7 @@ PATH
     ddtrace (1.14.0)
       datadog-ci (~> 0.1.0)
       debase-ruby_core_source (= 3.2.2)
-      libdatadog (~> 4.0.0.1.0)
+      libdatadog (~> 5.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
 
@@ -103,8 +103,8 @@ GEM
       addressable (>= 2.4)
     jsonapi-renderer (0.2.2)
     king_konf (1.0.1)
-    libdatadog (4.0.0.1.0-aarch64-linux)
-    libdatadog (4.0.0.1.0-x86_64-linux)
+    libdatadog (5.0.0.1.0-aarch64-linux)
+    libdatadog (5.0.0.1.0-x86_64-linux)
     libddwaf (1.14.0.0.0-aarch64-linux)
       ffi (~> 1.0)
     libddwaf (1.14.0.0.0-x86_64-linux)

--- a/gemfiles/ruby_2.4_aws.gemfile.lock
+++ b/gemfiles/ruby_2.4_aws.gemfile.lock
@@ -4,7 +4,7 @@ PATH
     ddtrace (1.14.0)
       datadog-ci (~> 0.1.0)
       debase-ruby_core_source (= 3.2.2)
-      libdatadog (~> 4.0.0.1.0)
+      libdatadog (~> 5.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
 
@@ -1461,8 +1461,8 @@ GEM
     jmespath (1.6.2)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (4.0.0.1.0-aarch64-linux)
-    libdatadog (4.0.0.1.0-x86_64-linux)
+    libdatadog (5.0.0.1.0-aarch64-linux)
+    libdatadog (5.0.0.1.0-x86_64-linux)
     libddwaf (1.14.0.0.0-aarch64-linux)
       ffi (~> 1.0)
     libddwaf (1.14.0.0.0-x86_64-linux)

--- a/gemfiles/ruby_2.4_contrib.gemfile.lock
+++ b/gemfiles/ruby_2.4_contrib.gemfile.lock
@@ -4,7 +4,7 @@ PATH
     ddtrace (1.14.0)
       datadog-ci (~> 0.1.0)
       debase-ruby_core_source (= 3.2.2)
-      libdatadog (~> 4.0.0.1.0)
+      libdatadog (~> 5.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
 
@@ -55,8 +55,8 @@ GEM
     hashdiff (1.0.1)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (4.0.0.1.0-aarch64-linux)
-    libdatadog (4.0.0.1.0-x86_64-linux)
+    libdatadog (5.0.0.1.0-aarch64-linux)
+    libdatadog (5.0.0.1.0-x86_64-linux)
     libddwaf (1.14.0.0.0-aarch64-linux)
       ffi (~> 1.0)
     libddwaf (1.14.0.0.0-x86_64-linux)

--- a/gemfiles/ruby_2.4_contrib_old.gemfile.lock
+++ b/gemfiles/ruby_2.4_contrib_old.gemfile.lock
@@ -4,7 +4,7 @@ PATH
     ddtrace (1.14.0)
       datadog-ci (~> 0.1.0)
       debase-ruby_core_source (= 3.2.2)
-      libdatadog (~> 4.0.0.1.0)
+      libdatadog (~> 5.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
 
@@ -52,8 +52,8 @@ GEM
     hashdiff (1.0.1)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (4.0.0.1.0-aarch64-linux)
-    libdatadog (4.0.0.1.0-x86_64-linux)
+    libdatadog (5.0.0.1.0-aarch64-linux)
+    libdatadog (5.0.0.1.0-x86_64-linux)
     libddwaf (1.14.0.0.0-aarch64-linux)
       ffi (~> 1.0)
     libddwaf (1.14.0.0.0-x86_64-linux)

--- a/gemfiles/ruby_2.4_core_old.gemfile.lock
+++ b/gemfiles/ruby_2.4_core_old.gemfile.lock
@@ -4,7 +4,7 @@ PATH
     ddtrace (1.14.0)
       datadog-ci (~> 0.1.0)
       debase-ruby_core_source (= 3.2.2)
-      libdatadog (~> 4.0.0.1.0)
+      libdatadog (~> 5.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
 
@@ -39,8 +39,8 @@ GEM
     hashdiff (1.0.1)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (4.0.0.1.0-aarch64-linux)
-    libdatadog (4.0.0.1.0-x86_64-linux)
+    libdatadog (5.0.0.1.0-aarch64-linux)
+    libdatadog (5.0.0.1.0-x86_64-linux)
     libddwaf (1.14.0.0.0-aarch64-linux)
       ffi (~> 1.0)
     libddwaf (1.14.0.0.0-x86_64-linux)

--- a/gemfiles/ruby_2.4_hanami_1.gemfile.lock
+++ b/gemfiles/ruby_2.4_hanami_1.gemfile.lock
@@ -4,7 +4,7 @@ PATH
     ddtrace (1.14.0)
       datadog-ci (~> 0.1.0)
       debase-ruby_core_source (= 3.2.2)
-      libdatadog (~> 4.0.0.1.0)
+      libdatadog (~> 5.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
 
@@ -114,8 +114,8 @@ GEM
     inflecto (0.0.2)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (4.0.0.1.0-aarch64-linux)
-    libdatadog (4.0.0.1.0-x86_64-linux)
+    libdatadog (5.0.0.1.0-aarch64-linux)
+    libdatadog (5.0.0.1.0-x86_64-linux)
     libddwaf (1.14.0.0.0-aarch64-linux)
       ffi (~> 1.0)
     libddwaf (1.14.0.0.0-x86_64-linux)

--- a/gemfiles/ruby_2.4_http.gemfile.lock
+++ b/gemfiles/ruby_2.4_http.gemfile.lock
@@ -4,7 +4,7 @@ PATH
     ddtrace (1.14.0)
       datadog-ci (~> 0.1.0)
       debase-ruby_core_source (= 3.2.2)
-      libdatadog (~> 4.0.0.1.0)
+      libdatadog (~> 5.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
 
@@ -82,8 +82,8 @@ GEM
     httpclient (2.8.3)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (4.0.0.1.0-aarch64-linux)
-    libdatadog (4.0.0.1.0-x86_64-linux)
+    libdatadog (5.0.0.1.0-aarch64-linux)
+    libdatadog (5.0.0.1.0-x86_64-linux)
     libddwaf (1.14.0.0.0-aarch64-linux)
       ffi (~> 1.0)
     libddwaf (1.14.0.0.0-x86_64-linux)

--- a/gemfiles/ruby_2.4_opentracing.gemfile.lock
+++ b/gemfiles/ruby_2.4_opentracing.gemfile.lock
@@ -4,7 +4,7 @@ PATH
     ddtrace (1.14.0)
       datadog-ci (~> 0.1.0)
       debase-ruby_core_source (= 3.2.2)
-      libdatadog (~> 4.0.0.1.0)
+      libdatadog (~> 5.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
 
@@ -40,8 +40,8 @@ GEM
     hashdiff (1.0.1)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (4.0.0.1.0-aarch64-linux)
-    libdatadog (4.0.0.1.0-x86_64-linux)
+    libdatadog (5.0.0.1.0-aarch64-linux)
+    libdatadog (5.0.0.1.0-x86_64-linux)
     libddwaf (1.14.0.0.0-aarch64-linux)
       ffi (~> 1.0)
     libddwaf (1.14.0.0.0-x86_64-linux)

--- a/gemfiles/ruby_2.4_rack_1.gemfile.lock
+++ b/gemfiles/ruby_2.4_rack_1.gemfile.lock
@@ -4,7 +4,7 @@ PATH
     ddtrace (1.14.0)
       datadog-ci (~> 0.1.0)
       debase-ruby_core_source (= 3.2.2)
-      libdatadog (~> 4.0.0.1.0)
+      libdatadog (~> 5.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
 
@@ -39,8 +39,8 @@ GEM
     hashdiff (1.0.1)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (4.0.0.1.0-aarch64-linux)
-    libdatadog (4.0.0.1.0-x86_64-linux)
+    libdatadog (5.0.0.1.0-aarch64-linux)
+    libdatadog (5.0.0.1.0-x86_64-linux)
     libddwaf (1.14.0.0.0-aarch64-linux)
       ffi (~> 1.0)
     libddwaf (1.14.0.0.0-x86_64-linux)

--- a/gemfiles/ruby_2.4_rack_2.gemfile.lock
+++ b/gemfiles/ruby_2.4_rack_2.gemfile.lock
@@ -4,7 +4,7 @@ PATH
     ddtrace (1.14.0)
       datadog-ci (~> 0.1.0)
       debase-ruby_core_source (= 3.2.2)
-      libdatadog (~> 4.0.0.1.0)
+      libdatadog (~> 5.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
 
@@ -39,8 +39,8 @@ GEM
     hashdiff (1.0.1)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (4.0.0.1.0-aarch64-linux)
-    libdatadog (4.0.0.1.0-x86_64-linux)
+    libdatadog (5.0.0.1.0-aarch64-linux)
+    libdatadog (5.0.0.1.0-x86_64-linux)
     libddwaf (1.14.0.0.0-aarch64-linux)
       ffi (~> 1.0)
     libddwaf (1.14.0.0.0-x86_64-linux)

--- a/gemfiles/ruby_2.4_rack_3.gemfile.lock
+++ b/gemfiles/ruby_2.4_rack_3.gemfile.lock
@@ -4,7 +4,7 @@ PATH
     ddtrace (1.14.0)
       datadog-ci (~> 0.1.0)
       debase-ruby_core_source (= 3.2.2)
-      libdatadog (~> 4.0.0.1.0)
+      libdatadog (~> 5.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
 
@@ -39,8 +39,8 @@ GEM
     hashdiff (1.0.1)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (4.0.0.1.0-aarch64-linux)
-    libdatadog (4.0.0.1.0-x86_64-linux)
+    libdatadog (5.0.0.1.0-aarch64-linux)
+    libdatadog (5.0.0.1.0-x86_64-linux)
     libddwaf (1.14.0.0.0-aarch64-linux)
       ffi (~> 1.0)
     libddwaf (1.14.0.0.0-x86_64-linux)

--- a/gemfiles/ruby_2.4_rails5_mysql2.gemfile.lock
+++ b/gemfiles/ruby_2.4_rails5_mysql2.gemfile.lock
@@ -4,7 +4,7 @@ PATH
     ddtrace (1.14.0)
       datadog-ci (~> 0.1.0)
       debase-ruby_core_source (= 3.2.2)
-      libdatadog (~> 4.0.0.1.0)
+      libdatadog (~> 5.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
 
@@ -87,8 +87,8 @@ GEM
       concurrent-ruby (~> 1.0)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (4.0.0.1.0-aarch64-linux)
-    libdatadog (4.0.0.1.0-x86_64-linux)
+    libdatadog (5.0.0.1.0-aarch64-linux)
+    libdatadog (5.0.0.1.0-x86_64-linux)
     libddwaf (1.14.0.0.0-aarch64-linux)
       ffi (~> 1.0)
     libddwaf (1.14.0.0.0-x86_64-linux)

--- a/gemfiles/ruby_2.4_rails5_postgres.gemfile.lock
+++ b/gemfiles/ruby_2.4_rails5_postgres.gemfile.lock
@@ -4,7 +4,7 @@ PATH
     ddtrace (1.14.0)
       datadog-ci (~> 0.1.0)
       debase-ruby_core_source (= 3.2.2)
-      libdatadog (~> 4.0.0.1.0)
+      libdatadog (~> 5.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
 
@@ -87,8 +87,8 @@ GEM
       concurrent-ruby (~> 1.0)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (4.0.0.1.0-aarch64-linux)
-    libdatadog (4.0.0.1.0-x86_64-linux)
+    libdatadog (5.0.0.1.0-aarch64-linux)
+    libdatadog (5.0.0.1.0-x86_64-linux)
     libddwaf (1.14.0.0.0-aarch64-linux)
       ffi (~> 1.0)
     libddwaf (1.14.0.0.0-x86_64-linux)

--- a/gemfiles/ruby_2.4_rails5_postgres_redis.gemfile.lock
+++ b/gemfiles/ruby_2.4_rails5_postgres_redis.gemfile.lock
@@ -4,7 +4,7 @@ PATH
     ddtrace (1.14.0)
       datadog-ci (~> 0.1.0)
       debase-ruby_core_source (= 3.2.2)
-      libdatadog (~> 4.0.0.1.0)
+      libdatadog (~> 5.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
 
@@ -87,8 +87,8 @@ GEM
       concurrent-ruby (~> 1.0)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (4.0.0.1.0-aarch64-linux)
-    libdatadog (4.0.0.1.0-x86_64-linux)
+    libdatadog (5.0.0.1.0-aarch64-linux)
+    libdatadog (5.0.0.1.0-x86_64-linux)
     libddwaf (1.14.0.0.0-aarch64-linux)
       ffi (~> 1.0)
     libddwaf (1.14.0.0.0-x86_64-linux)

--- a/gemfiles/ruby_2.4_rails5_postgres_redis_activesupport.gemfile.lock
+++ b/gemfiles/ruby_2.4_rails5_postgres_redis_activesupport.gemfile.lock
@@ -4,7 +4,7 @@ PATH
     ddtrace (1.14.0)
       datadog-ci (~> 0.1.0)
       debase-ruby_core_source (= 3.2.2)
-      libdatadog (~> 4.0.0.1.0)
+      libdatadog (~> 5.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
 
@@ -87,8 +87,8 @@ GEM
       concurrent-ruby (~> 1.0)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (4.0.0.1.0-aarch64-linux)
-    libdatadog (4.0.0.1.0-x86_64-linux)
+    libdatadog (5.0.0.1.0-aarch64-linux)
+    libdatadog (5.0.0.1.0-x86_64-linux)
     libddwaf (1.14.0.0.0-aarch64-linux)
       ffi (~> 1.0)
     libddwaf (1.14.0.0.0-x86_64-linux)

--- a/gemfiles/ruby_2.4_rails5_postgres_sidekiq.gemfile.lock
+++ b/gemfiles/ruby_2.4_rails5_postgres_sidekiq.gemfile.lock
@@ -4,7 +4,7 @@ PATH
     ddtrace (1.14.0)
       datadog-ci (~> 0.1.0)
       debase-ruby_core_source (= 3.2.2)
-      libdatadog (~> 4.0.0.1.0)
+      libdatadog (~> 5.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
 
@@ -88,8 +88,8 @@ GEM
       concurrent-ruby (~> 1.0)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (4.0.0.1.0-aarch64-linux)
-    libdatadog (4.0.0.1.0-x86_64-linux)
+    libdatadog (5.0.0.1.0-aarch64-linux)
+    libdatadog (5.0.0.1.0-x86_64-linux)
     libddwaf (1.14.0.0.0-aarch64-linux)
       ffi (~> 1.0)
     libddwaf (1.14.0.0.0-x86_64-linux)

--- a/gemfiles/ruby_2.4_rails5_semantic_logger.gemfile.lock
+++ b/gemfiles/ruby_2.4_rails5_semantic_logger.gemfile.lock
@@ -4,7 +4,7 @@ PATH
     ddtrace (1.14.0)
       datadog-ci (~> 0.1.0)
       debase-ruby_core_source (= 3.2.2)
-      libdatadog (~> 4.0.0.1.0)
+      libdatadog (~> 5.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
 
@@ -87,8 +87,8 @@ GEM
       concurrent-ruby (~> 1.0)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (4.0.0.1.0-aarch64-linux)
-    libdatadog (4.0.0.1.0-x86_64-linux)
+    libdatadog (5.0.0.1.0-aarch64-linux)
+    libdatadog (5.0.0.1.0-x86_64-linux)
     libddwaf (1.14.0.0.0-aarch64-linux)
       ffi (~> 1.0)
     libddwaf (1.14.0.0.0-x86_64-linux)

--- a/gemfiles/ruby_2.4_redis_3.gemfile.lock
+++ b/gemfiles/ruby_2.4_redis_3.gemfile.lock
@@ -4,7 +4,7 @@ PATH
     ddtrace (1.14.0)
       datadog-ci (~> 0.1.0)
       debase-ruby_core_source (= 3.2.2)
-      libdatadog (~> 4.0.0.1.0)
+      libdatadog (~> 5.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
 
@@ -39,8 +39,8 @@ GEM
     hashdiff (1.0.1)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (4.0.0.1.0-aarch64-linux)
-    libdatadog (4.0.0.1.0-x86_64-linux)
+    libdatadog (5.0.0.1.0-aarch64-linux)
+    libdatadog (5.0.0.1.0-x86_64-linux)
     libddwaf (1.14.0.0.0-aarch64-linux)
       ffi (~> 1.0)
     libddwaf (1.14.0.0.0-x86_64-linux)

--- a/gemfiles/ruby_2.4_redis_4.gemfile.lock
+++ b/gemfiles/ruby_2.4_redis_4.gemfile.lock
@@ -4,7 +4,7 @@ PATH
     ddtrace (1.14.0)
       datadog-ci (~> 0.1.0)
       debase-ruby_core_source (= 3.2.2)
-      libdatadog (~> 4.0.0.1.0)
+      libdatadog (~> 5.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
 
@@ -39,8 +39,8 @@ GEM
     hashdiff (1.0.1)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (4.0.0.1.0-aarch64-linux)
-    libdatadog (4.0.0.1.0-x86_64-linux)
+    libdatadog (5.0.0.1.0-aarch64-linux)
+    libdatadog (5.0.0.1.0-x86_64-linux)
     libddwaf (1.14.0.0.0-aarch64-linux)
       ffi (~> 1.0)
     libddwaf (1.14.0.0.0-x86_64-linux)

--- a/gemfiles/ruby_2.4_relational_db.gemfile.lock
+++ b/gemfiles/ruby_2.4_relational_db.gemfile.lock
@@ -4,7 +4,7 @@ PATH
     ddtrace (1.14.0)
       datadog-ci (~> 0.1.0)
       debase-ruby_core_source (= 3.2.2)
-      libdatadog (~> 4.0.0.1.0)
+      libdatadog (~> 5.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
 
@@ -58,8 +58,8 @@ GEM
       concurrent-ruby (~> 1.0)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (4.0.0.1.0-aarch64-linux)
-    libdatadog (4.0.0.1.0-x86_64-linux)
+    libdatadog (5.0.0.1.0-aarch64-linux)
+    libdatadog (5.0.0.1.0-x86_64-linux)
     libddwaf (1.14.0.0.0-aarch64-linux)
       ffi (~> 1.0)
     libddwaf (1.14.0.0.0-x86_64-linux)

--- a/gemfiles/ruby_2.4_resque2_redis3.gemfile.lock
+++ b/gemfiles/ruby_2.4_resque2_redis3.gemfile.lock
@@ -4,7 +4,7 @@ PATH
     ddtrace (1.14.0)
       datadog-ci (~> 0.1.0)
       debase-ruby_core_source (= 3.2.2)
-      libdatadog (~> 4.0.0.1.0)
+      libdatadog (~> 5.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
 
@@ -39,8 +39,8 @@ GEM
     hashdiff (1.0.1)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (4.0.0.1.0-aarch64-linux)
-    libdatadog (4.0.0.1.0-x86_64-linux)
+    libdatadog (5.0.0.1.0-aarch64-linux)
+    libdatadog (5.0.0.1.0-x86_64-linux)
     libddwaf (1.14.0.0.0-aarch64-linux)
       ffi (~> 1.0)
     libddwaf (1.14.0.0.0-x86_64-linux)

--- a/gemfiles/ruby_2.4_resque2_redis4.gemfile.lock
+++ b/gemfiles/ruby_2.4_resque2_redis4.gemfile.lock
@@ -4,7 +4,7 @@ PATH
     ddtrace (1.14.0)
       datadog-ci (~> 0.1.0)
       debase-ruby_core_source (= 3.2.2)
-      libdatadog (~> 4.0.0.1.0)
+      libdatadog (~> 5.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
 
@@ -39,8 +39,8 @@ GEM
     hashdiff (1.0.1)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (4.0.0.1.0-aarch64-linux)
-    libdatadog (4.0.0.1.0-x86_64-linux)
+    libdatadog (5.0.0.1.0-aarch64-linux)
+    libdatadog (5.0.0.1.0-x86_64-linux)
     libddwaf (1.14.0.0.0-aarch64-linux)
       ffi (~> 1.0)
     libddwaf (1.14.0.0.0-x86_64-linux)

--- a/gemfiles/ruby_2.4_sinatra.gemfile.lock
+++ b/gemfiles/ruby_2.4_sinatra.gemfile.lock
@@ -4,7 +4,7 @@ PATH
     ddtrace (1.14.0)
       datadog-ci (~> 0.1.0)
       debase-ruby_core_source (= 3.2.2)
-      libdatadog (~> 4.0.0.1.0)
+      libdatadog (~> 5.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
 
@@ -39,8 +39,8 @@ GEM
     hashdiff (1.0.1)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (4.0.0.1.0-aarch64-linux)
-    libdatadog (4.0.0.1.0-x86_64-linux)
+    libdatadog (5.0.0.1.0-aarch64-linux)
+    libdatadog (5.0.0.1.0-x86_64-linux)
     libddwaf (1.14.0.0.0-aarch64-linux)
       ffi (~> 1.0)
     libddwaf (1.14.0.0.0-x86_64-linux)

--- a/gemfiles/ruby_2.5_activesupport.gemfile.lock
+++ b/gemfiles/ruby_2.5_activesupport.gemfile.lock
@@ -14,7 +14,7 @@ PATH
     ddtrace (1.14.0)
       datadog-ci (~> 0.1.0)
       debase-ruby_core_source (= 3.2.2)
-      libdatadog (~> 4.0.0.1.0)
+      libdatadog (~> 5.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
 
@@ -112,8 +112,8 @@ GEM
       addressable (>= 2.4)
     jsonapi-renderer (0.2.2)
     king_konf (1.0.1)
-    libdatadog (4.0.0.1.0-aarch64-linux)
-    libdatadog (4.0.0.1.0-x86_64-linux)
+    libdatadog (5.0.0.1.0-aarch64-linux)
+    libdatadog (5.0.0.1.0-x86_64-linux)
     libddwaf (1.14.0.0.0-aarch64-linux)
       ffi (~> 1.0)
     libddwaf (1.14.0.0.0-x86_64-linux)

--- a/gemfiles/ruby_2.5_aws.gemfile.lock
+++ b/gemfiles/ruby_2.5_aws.gemfile.lock
@@ -14,7 +14,7 @@ PATH
     ddtrace (1.14.0)
       datadog-ci (~> 0.1.0)
       debase-ruby_core_source (= 3.2.2)
-      libdatadog (~> 4.0.0.1.0)
+      libdatadog (~> 5.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
 
@@ -1474,8 +1474,8 @@ GEM
     jmespath (1.6.2)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (4.0.0.1.0-aarch64-linux)
-    libdatadog (4.0.0.1.0-x86_64-linux)
+    libdatadog (5.0.0.1.0-aarch64-linux)
+    libdatadog (5.0.0.1.0-x86_64-linux)
     libddwaf (1.14.0.0.0-aarch64-linux)
       ffi (~> 1.0)
     libddwaf (1.14.0.0.0-x86_64-linux)

--- a/gemfiles/ruby_2.5_contrib.gemfile.lock
+++ b/gemfiles/ruby_2.5_contrib.gemfile.lock
@@ -14,7 +14,7 @@ PATH
     ddtrace (1.14.0)
       datadog-ci (~> 0.1.0)
       debase-ruby_core_source (= 3.2.2)
-      libdatadog (~> 4.0.0.1.0)
+      libdatadog (~> 5.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
 
@@ -68,8 +68,8 @@ GEM
     hashdiff (1.0.1)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (4.0.0.1.0-aarch64-linux)
-    libdatadog (4.0.0.1.0-x86_64-linux)
+    libdatadog (5.0.0.1.0-aarch64-linux)
+    libdatadog (5.0.0.1.0-x86_64-linux)
     libddwaf (1.14.0.0.0-aarch64-linux)
       ffi (~> 1.0)
     libddwaf (1.14.0.0.0-x86_64-linux)

--- a/gemfiles/ruby_2.5_contrib_old.gemfile.lock
+++ b/gemfiles/ruby_2.5_contrib_old.gemfile.lock
@@ -14,7 +14,7 @@ PATH
     ddtrace (1.14.0)
       datadog-ci (~> 0.1.0)
       debase-ruby_core_source (= 3.2.2)
-      libdatadog (~> 4.0.0.1.0)
+      libdatadog (~> 5.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
 
@@ -72,8 +72,8 @@ GEM
     hitimes (1.3.1)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (4.0.0.1.0-aarch64-linux)
-    libdatadog (4.0.0.1.0-x86_64-linux)
+    libdatadog (5.0.0.1.0-aarch64-linux)
+    libdatadog (5.0.0.1.0-x86_64-linux)
     libddwaf (1.14.0.0.0-aarch64-linux)
       ffi (~> 1.0)
     libddwaf (1.14.0.0.0-x86_64-linux)

--- a/gemfiles/ruby_2.5_core_old.gemfile.lock
+++ b/gemfiles/ruby_2.5_core_old.gemfile.lock
@@ -14,7 +14,7 @@ PATH
     ddtrace (1.14.0)
       datadog-ci (~> 0.1.0)
       debase-ruby_core_source (= 3.2.2)
-      libdatadog (~> 4.0.0.1.0)
+      libdatadog (~> 5.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
 
@@ -52,8 +52,8 @@ GEM
     hashdiff (1.0.1)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (4.0.0.1.0-aarch64-linux)
-    libdatadog (4.0.0.1.0-x86_64-linux)
+    libdatadog (5.0.0.1.0-aarch64-linux)
+    libdatadog (5.0.0.1.0-x86_64-linux)
     libddwaf (1.14.0.0.0-aarch64-linux)
       ffi (~> 1.0)
     libddwaf (1.14.0.0.0-x86_64-linux)

--- a/gemfiles/ruby_2.5_hanami_1.gemfile.lock
+++ b/gemfiles/ruby_2.5_hanami_1.gemfile.lock
@@ -14,7 +14,7 @@ PATH
     ddtrace (1.14.0)
       datadog-ci (~> 0.1.0)
       debase-ruby_core_source (= 3.2.2)
-      libdatadog (~> 4.0.0.1.0)
+      libdatadog (~> 5.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
 
@@ -128,8 +128,8 @@ GEM
     io-wait (0.3.0)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (4.0.0.1.0-aarch64-linux)
-    libdatadog (4.0.0.1.0-x86_64-linux)
+    libdatadog (5.0.0.1.0-aarch64-linux)
+    libdatadog (5.0.0.1.0-x86_64-linux)
     libddwaf (1.14.0.0.0-aarch64-linux)
       ffi (~> 1.0)
     libddwaf (1.14.0.0.0-x86_64-linux)

--- a/gemfiles/ruby_2.5_http.gemfile.lock
+++ b/gemfiles/ruby_2.5_http.gemfile.lock
@@ -14,7 +14,7 @@ PATH
     ddtrace (1.14.0)
       datadog-ci (~> 0.1.0)
       debase-ruby_core_source (= 3.2.2)
-      libdatadog (~> 4.0.0.1.0)
+      libdatadog (~> 5.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
 
@@ -101,8 +101,8 @@ GEM
     httpclient (2.8.3)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (4.0.0.1.0-aarch64-linux)
-    libdatadog (4.0.0.1.0-x86_64-linux)
+    libdatadog (5.0.0.1.0-aarch64-linux)
+    libdatadog (5.0.0.1.0-x86_64-linux)
     libddwaf (1.14.0.0.0-aarch64-linux)
       ffi (~> 1.0)
     libddwaf (1.14.0.0.0-x86_64-linux)

--- a/gemfiles/ruby_2.5_opentracing.gemfile.lock
+++ b/gemfiles/ruby_2.5_opentracing.gemfile.lock
@@ -14,7 +14,7 @@ PATH
     ddtrace (1.14.0)
       datadog-ci (~> 0.1.0)
       debase-ruby_core_source (= 3.2.2)
-      libdatadog (~> 4.0.0.1.0)
+      libdatadog (~> 5.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
 
@@ -53,8 +53,8 @@ GEM
     hashdiff (1.0.1)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (4.0.0.1.0-aarch64-linux)
-    libdatadog (4.0.0.1.0-x86_64-linux)
+    libdatadog (5.0.0.1.0-aarch64-linux)
+    libdatadog (5.0.0.1.0-x86_64-linux)
     libddwaf (1.14.0.0.0-aarch64-linux)
       ffi (~> 1.0)
     libddwaf (1.14.0.0.0-x86_64-linux)

--- a/gemfiles/ruby_2.5_rack_1.gemfile.lock
+++ b/gemfiles/ruby_2.5_rack_1.gemfile.lock
@@ -14,7 +14,7 @@ PATH
     ddtrace (1.14.0)
       datadog-ci (~> 0.1.0)
       debase-ruby_core_source (= 3.2.2)
-      libdatadog (~> 4.0.0.1.0)
+      libdatadog (~> 5.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
 
@@ -52,8 +52,8 @@ GEM
     hashdiff (1.0.1)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (4.0.0.1.0-aarch64-linux)
-    libdatadog (4.0.0.1.0-x86_64-linux)
+    libdatadog (5.0.0.1.0-aarch64-linux)
+    libdatadog (5.0.0.1.0-x86_64-linux)
     libddwaf (1.14.0.0.0-aarch64-linux)
       ffi (~> 1.0)
     libddwaf (1.14.0.0.0-x86_64-linux)

--- a/gemfiles/ruby_2.5_rack_2.gemfile.lock
+++ b/gemfiles/ruby_2.5_rack_2.gemfile.lock
@@ -14,7 +14,7 @@ PATH
     ddtrace (1.14.0)
       datadog-ci (~> 0.1.0)
       debase-ruby_core_source (= 3.2.2)
-      libdatadog (~> 4.0.0.1.0)
+      libdatadog (~> 5.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
 
@@ -52,8 +52,8 @@ GEM
     hashdiff (1.0.1)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (4.0.0.1.0-aarch64-linux)
-    libdatadog (4.0.0.1.0-x86_64-linux)
+    libdatadog (5.0.0.1.0-aarch64-linux)
+    libdatadog (5.0.0.1.0-x86_64-linux)
     libddwaf (1.14.0.0.0-aarch64-linux)
       ffi (~> 1.0)
     libddwaf (1.14.0.0.0-x86_64-linux)

--- a/gemfiles/ruby_2.5_rack_3.gemfile.lock
+++ b/gemfiles/ruby_2.5_rack_3.gemfile.lock
@@ -14,7 +14,7 @@ PATH
     ddtrace (1.14.0)
       datadog-ci (~> 0.1.0)
       debase-ruby_core_source (= 3.2.2)
-      libdatadog (~> 4.0.0.1.0)
+      libdatadog (~> 5.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
 
@@ -52,8 +52,8 @@ GEM
     hashdiff (1.0.1)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (4.0.0.1.0-aarch64-linux)
-    libdatadog (4.0.0.1.0-x86_64-linux)
+    libdatadog (5.0.0.1.0-aarch64-linux)
+    libdatadog (5.0.0.1.0-x86_64-linux)
     libddwaf (1.14.0.0.0-aarch64-linux)
       ffi (~> 1.0)
     libddwaf (1.14.0.0.0-x86_64-linux)

--- a/gemfiles/ruby_2.5_rails5_mysql2.gemfile.lock
+++ b/gemfiles/ruby_2.5_rails5_mysql2.gemfile.lock
@@ -14,7 +14,7 @@ PATH
     ddtrace (1.14.0)
       datadog-ci (~> 0.1.0)
       debase-ruby_core_source (= 3.2.2)
-      libdatadog (~> 4.0.0.1.0)
+      libdatadog (~> 5.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
 
@@ -100,8 +100,8 @@ GEM
       concurrent-ruby (~> 1.0)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (4.0.0.1.0-aarch64-linux)
-    libdatadog (4.0.0.1.0-x86_64-linux)
+    libdatadog (5.0.0.1.0-aarch64-linux)
+    libdatadog (5.0.0.1.0-x86_64-linux)
     libddwaf (1.14.0.0.0-aarch64-linux)
       ffi (~> 1.0)
     libddwaf (1.14.0.0.0-x86_64-linux)

--- a/gemfiles/ruby_2.5_rails5_postgres.gemfile.lock
+++ b/gemfiles/ruby_2.5_rails5_postgres.gemfile.lock
@@ -14,7 +14,7 @@ PATH
     ddtrace (1.14.0)
       datadog-ci (~> 0.1.0)
       debase-ruby_core_source (= 3.2.2)
-      libdatadog (~> 4.0.0.1.0)
+      libdatadog (~> 5.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
 
@@ -102,8 +102,8 @@ GEM
     io-wait (0.3.0)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (4.0.0.1.0-aarch64-linux)
-    libdatadog (4.0.0.1.0-x86_64-linux)
+    libdatadog (5.0.0.1.0-aarch64-linux)
+    libdatadog (5.0.0.1.0-x86_64-linux)
     libddwaf (1.14.0.0.0-aarch64-linux)
       ffi (~> 1.0)
     libddwaf (1.14.0.0.0-x86_64-linux)

--- a/gemfiles/ruby_2.5_rails5_postgres_redis.gemfile.lock
+++ b/gemfiles/ruby_2.5_rails5_postgres_redis.gemfile.lock
@@ -14,7 +14,7 @@ PATH
     ddtrace (1.14.0)
       datadog-ci (~> 0.1.0)
       debase-ruby_core_source (= 3.2.2)
-      libdatadog (~> 4.0.0.1.0)
+      libdatadog (~> 5.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
 
@@ -103,8 +103,8 @@ GEM
     io-wait (0.3.0)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (4.0.0.1.0-aarch64-linux)
-    libdatadog (4.0.0.1.0-x86_64-linux)
+    libdatadog (5.0.0.1.0-aarch64-linux)
+    libdatadog (5.0.0.1.0-x86_64-linux)
     libddwaf (1.14.0.0.0-aarch64-linux)
       ffi (~> 1.0)
     libddwaf (1.14.0.0.0-x86_64-linux)

--- a/gemfiles/ruby_2.5_rails5_postgres_redis_activesupport.gemfile.lock
+++ b/gemfiles/ruby_2.5_rails5_postgres_redis_activesupport.gemfile.lock
@@ -14,7 +14,7 @@ PATH
     ddtrace (1.14.0)
       datadog-ci (~> 0.1.0)
       debase-ruby_core_source (= 3.2.2)
-      libdatadog (~> 4.0.0.1.0)
+      libdatadog (~> 5.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
 
@@ -102,8 +102,8 @@ GEM
     io-wait (0.3.0)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (4.0.0.1.0-aarch64-linux)
-    libdatadog (4.0.0.1.0-x86_64-linux)
+    libdatadog (5.0.0.1.0-aarch64-linux)
+    libdatadog (5.0.0.1.0-x86_64-linux)
     libddwaf (1.14.0.0.0-aarch64-linux)
       ffi (~> 1.0)
     libddwaf (1.14.0.0.0-x86_64-linux)

--- a/gemfiles/ruby_2.5_rails5_postgres_sidekiq.gemfile.lock
+++ b/gemfiles/ruby_2.5_rails5_postgres_sidekiq.gemfile.lock
@@ -14,7 +14,7 @@ PATH
     ddtrace (1.14.0)
       datadog-ci (~> 0.1.0)
       debase-ruby_core_source (= 3.2.2)
-      libdatadog (~> 4.0.0.1.0)
+      libdatadog (~> 5.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
 
@@ -103,8 +103,8 @@ GEM
     io-wait (0.3.0)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (4.0.0.1.0-aarch64-linux)
-    libdatadog (4.0.0.1.0-x86_64-linux)
+    libdatadog (5.0.0.1.0-aarch64-linux)
+    libdatadog (5.0.0.1.0-x86_64-linux)
     libddwaf (1.14.0.0.0-aarch64-linux)
       ffi (~> 1.0)
     libddwaf (1.14.0.0.0-x86_64-linux)

--- a/gemfiles/ruby_2.5_rails5_semantic_logger.gemfile.lock
+++ b/gemfiles/ruby_2.5_rails5_semantic_logger.gemfile.lock
@@ -14,7 +14,7 @@ PATH
     ddtrace (1.14.0)
       datadog-ci (~> 0.1.0)
       debase-ruby_core_source (= 3.2.2)
-      libdatadog (~> 4.0.0.1.0)
+      libdatadog (~> 5.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
 
@@ -102,8 +102,8 @@ GEM
     io-wait (0.3.0)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (4.0.0.1.0-aarch64-linux)
-    libdatadog (4.0.0.1.0-x86_64-linux)
+    libdatadog (5.0.0.1.0-aarch64-linux)
+    libdatadog (5.0.0.1.0-x86_64-linux)
     libddwaf (1.14.0.0.0-aarch64-linux)
       ffi (~> 1.0)
     libddwaf (1.14.0.0.0-x86_64-linux)

--- a/gemfiles/ruby_2.5_rails61_mysql2.gemfile.lock
+++ b/gemfiles/ruby_2.5_rails61_mysql2.gemfile.lock
@@ -14,7 +14,7 @@ PATH
     ddtrace (1.14.0)
       datadog-ci (~> 0.1.0)
       debase-ruby_core_source (= 3.2.2)
-      libdatadog (~> 4.0.0.1.0)
+      libdatadog (~> 5.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
 
@@ -117,8 +117,8 @@ GEM
       concurrent-ruby (~> 1.0)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (4.0.0.1.0-aarch64-linux)
-    libdatadog (4.0.0.1.0-x86_64-linux)
+    libdatadog (5.0.0.1.0-aarch64-linux)
+    libdatadog (5.0.0.1.0-x86_64-linux)
     libddwaf (1.14.0.0.0-aarch64-linux)
       ffi (~> 1.0)
     libddwaf (1.14.0.0.0-x86_64-linux)

--- a/gemfiles/ruby_2.5_rails61_postgres.gemfile.lock
+++ b/gemfiles/ruby_2.5_rails61_postgres.gemfile.lock
@@ -14,7 +14,7 @@ PATH
     ddtrace (1.14.0)
       datadog-ci (~> 0.1.0)
       debase-ruby_core_source (= 3.2.2)
-      libdatadog (~> 4.0.0.1.0)
+      libdatadog (~> 5.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
 
@@ -119,8 +119,8 @@ GEM
     io-wait (0.3.0)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (4.0.0.1.0-aarch64-linux)
-    libdatadog (4.0.0.1.0-x86_64-linux)
+    libdatadog (5.0.0.1.0-aarch64-linux)
+    libdatadog (5.0.0.1.0-x86_64-linux)
     libddwaf (1.14.0.0.0-aarch64-linux)
       ffi (~> 1.0)
     libddwaf (1.14.0.0.0-x86_64-linux)

--- a/gemfiles/ruby_2.5_rails61_postgres_redis.gemfile.lock
+++ b/gemfiles/ruby_2.5_rails61_postgres_redis.gemfile.lock
@@ -14,7 +14,7 @@ PATH
     ddtrace (1.14.0)
       datadog-ci (~> 0.1.0)
       debase-ruby_core_source (= 3.2.2)
-      libdatadog (~> 4.0.0.1.0)
+      libdatadog (~> 5.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
 
@@ -120,8 +120,8 @@ GEM
     io-wait (0.3.0)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (4.0.0.1.0-aarch64-linux)
-    libdatadog (4.0.0.1.0-x86_64-linux)
+    libdatadog (5.0.0.1.0-aarch64-linux)
+    libdatadog (5.0.0.1.0-x86_64-linux)
     libddwaf (1.14.0.0.0-aarch64-linux)
       ffi (~> 1.0)
     libddwaf (1.14.0.0.0-x86_64-linux)

--- a/gemfiles/ruby_2.5_rails61_postgres_sidekiq.gemfile.lock
+++ b/gemfiles/ruby_2.5_rails61_postgres_sidekiq.gemfile.lock
@@ -14,7 +14,7 @@ PATH
     ddtrace (1.14.0)
       datadog-ci (~> 0.1.0)
       debase-ruby_core_source (= 3.2.2)
-      libdatadog (~> 4.0.0.1.0)
+      libdatadog (~> 5.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
 
@@ -120,8 +120,8 @@ GEM
     io-wait (0.3.0)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (4.0.0.1.0-aarch64-linux)
-    libdatadog (4.0.0.1.0-x86_64-linux)
+    libdatadog (5.0.0.1.0-aarch64-linux)
+    libdatadog (5.0.0.1.0-x86_64-linux)
     libddwaf (1.14.0.0.0-aarch64-linux)
       ffi (~> 1.0)
     libddwaf (1.14.0.0.0-x86_64-linux)

--- a/gemfiles/ruby_2.5_rails61_semantic_logger.gemfile.lock
+++ b/gemfiles/ruby_2.5_rails61_semantic_logger.gemfile.lock
@@ -14,7 +14,7 @@ PATH
     ddtrace (1.14.0)
       datadog-ci (~> 0.1.0)
       debase-ruby_core_source (= 3.2.2)
-      libdatadog (~> 4.0.0.1.0)
+      libdatadog (~> 5.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
 
@@ -119,8 +119,8 @@ GEM
     io-wait (0.3.0)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (4.0.0.1.0-aarch64-linux)
-    libdatadog (4.0.0.1.0-x86_64-linux)
+    libdatadog (5.0.0.1.0-aarch64-linux)
+    libdatadog (5.0.0.1.0-x86_64-linux)
     libddwaf (1.14.0.0.0-aarch64-linux)
       ffi (~> 1.0)
     libddwaf (1.14.0.0.0-x86_64-linux)

--- a/gemfiles/ruby_2.5_rails6_mysql2.gemfile.lock
+++ b/gemfiles/ruby_2.5_rails6_mysql2.gemfile.lock
@@ -14,7 +14,7 @@ PATH
     ddtrace (1.14.0)
       datadog-ci (~> 0.1.0)
       debase-ruby_core_source (= 3.2.2)
-      libdatadog (~> 4.0.0.1.0)
+      libdatadog (~> 5.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
 
@@ -113,8 +113,8 @@ GEM
       concurrent-ruby (~> 1.0)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (4.0.0.1.0-aarch64-linux)
-    libdatadog (4.0.0.1.0-x86_64-linux)
+    libdatadog (5.0.0.1.0-aarch64-linux)
+    libdatadog (5.0.0.1.0-x86_64-linux)
     libddwaf (1.14.0.0.0-aarch64-linux)
       ffi (~> 1.0)
     libddwaf (1.14.0.0.0-x86_64-linux)

--- a/gemfiles/ruby_2.5_rails6_postgres.gemfile.lock
+++ b/gemfiles/ruby_2.5_rails6_postgres.gemfile.lock
@@ -14,7 +14,7 @@ PATH
     ddtrace (1.14.0)
       datadog-ci (~> 0.1.0)
       debase-ruby_core_source (= 3.2.2)
-      libdatadog (~> 4.0.0.1.0)
+      libdatadog (~> 5.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
 
@@ -115,8 +115,8 @@ GEM
     io-wait (0.3.0)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (4.0.0.1.0-aarch64-linux)
-    libdatadog (4.0.0.1.0-x86_64-linux)
+    libdatadog (5.0.0.1.0-aarch64-linux)
+    libdatadog (5.0.0.1.0-x86_64-linux)
     libddwaf (1.14.0.0.0-aarch64-linux)
       ffi (~> 1.0)
     libddwaf (1.14.0.0.0-x86_64-linux)

--- a/gemfiles/ruby_2.5_rails6_postgres_redis.gemfile.lock
+++ b/gemfiles/ruby_2.5_rails6_postgres_redis.gemfile.lock
@@ -14,7 +14,7 @@ PATH
     ddtrace (1.14.0)
       datadog-ci (~> 0.1.0)
       debase-ruby_core_source (= 3.2.2)
-      libdatadog (~> 4.0.0.1.0)
+      libdatadog (~> 5.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
 
@@ -116,8 +116,8 @@ GEM
     io-wait (0.3.0)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (4.0.0.1.0-aarch64-linux)
-    libdatadog (4.0.0.1.0-x86_64-linux)
+    libdatadog (5.0.0.1.0-aarch64-linux)
+    libdatadog (5.0.0.1.0-x86_64-linux)
     libddwaf (1.14.0.0.0-aarch64-linux)
       ffi (~> 1.0)
     libddwaf (1.14.0.0.0-x86_64-linux)

--- a/gemfiles/ruby_2.5_rails6_postgres_redis_activesupport.gemfile.lock
+++ b/gemfiles/ruby_2.5_rails6_postgres_redis_activesupport.gemfile.lock
@@ -14,7 +14,7 @@ PATH
     ddtrace (1.14.0)
       datadog-ci (~> 0.1.0)
       debase-ruby_core_source (= 3.2.2)
-      libdatadog (~> 4.0.0.1.0)
+      libdatadog (~> 5.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
 
@@ -115,8 +115,8 @@ GEM
     io-wait (0.3.0)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (4.0.0.1.0-aarch64-linux)
-    libdatadog (4.0.0.1.0-x86_64-linux)
+    libdatadog (5.0.0.1.0-aarch64-linux)
+    libdatadog (5.0.0.1.0-x86_64-linux)
     libddwaf (1.14.0.0.0-aarch64-linux)
       ffi (~> 1.0)
     libddwaf (1.14.0.0.0-x86_64-linux)

--- a/gemfiles/ruby_2.5_rails6_postgres_sidekiq.gemfile.lock
+++ b/gemfiles/ruby_2.5_rails6_postgres_sidekiq.gemfile.lock
@@ -14,7 +14,7 @@ PATH
     ddtrace (1.14.0)
       datadog-ci (~> 0.1.0)
       debase-ruby_core_source (= 3.2.2)
-      libdatadog (~> 4.0.0.1.0)
+      libdatadog (~> 5.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
 
@@ -116,8 +116,8 @@ GEM
     io-wait (0.3.0)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (4.0.0.1.0-aarch64-linux)
-    libdatadog (4.0.0.1.0-x86_64-linux)
+    libdatadog (5.0.0.1.0-aarch64-linux)
+    libdatadog (5.0.0.1.0-x86_64-linux)
     libddwaf (1.14.0.0.0-aarch64-linux)
       ffi (~> 1.0)
     libddwaf (1.14.0.0.0-x86_64-linux)

--- a/gemfiles/ruby_2.5_rails6_semantic_logger.gemfile.lock
+++ b/gemfiles/ruby_2.5_rails6_semantic_logger.gemfile.lock
@@ -14,7 +14,7 @@ PATH
     ddtrace (1.14.0)
       datadog-ci (~> 0.1.0)
       debase-ruby_core_source (= 3.2.2)
-      libdatadog (~> 4.0.0.1.0)
+      libdatadog (~> 5.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
 
@@ -115,8 +115,8 @@ GEM
     io-wait (0.3.0)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (4.0.0.1.0-aarch64-linux)
-    libdatadog (4.0.0.1.0-x86_64-linux)
+    libdatadog (5.0.0.1.0-aarch64-linux)
+    libdatadog (5.0.0.1.0-x86_64-linux)
     libddwaf (1.14.0.0.0-aarch64-linux)
       ffi (~> 1.0)
     libddwaf (1.14.0.0.0-x86_64-linux)

--- a/gemfiles/ruby_2.5_redis_3.gemfile.lock
+++ b/gemfiles/ruby_2.5_redis_3.gemfile.lock
@@ -14,7 +14,7 @@ PATH
     ddtrace (1.14.0)
       datadog-ci (~> 0.1.0)
       debase-ruby_core_source (= 3.2.2)
-      libdatadog (~> 4.0.0.1.0)
+      libdatadog (~> 5.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
 
@@ -52,8 +52,8 @@ GEM
     hashdiff (1.0.1)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (4.0.0.1.0-aarch64-linux)
-    libdatadog (4.0.0.1.0-x86_64-linux)
+    libdatadog (5.0.0.1.0-aarch64-linux)
+    libdatadog (5.0.0.1.0-x86_64-linux)
     libddwaf (1.14.0.0.0-aarch64-linux)
       ffi (~> 1.0)
     libddwaf (1.14.0.0.0-x86_64-linux)

--- a/gemfiles/ruby_2.5_redis_4.gemfile.lock
+++ b/gemfiles/ruby_2.5_redis_4.gemfile.lock
@@ -14,7 +14,7 @@ PATH
     ddtrace (1.14.0)
       datadog-ci (~> 0.1.0)
       debase-ruby_core_source (= 3.2.2)
-      libdatadog (~> 4.0.0.1.0)
+      libdatadog (~> 5.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
 
@@ -52,8 +52,8 @@ GEM
     hashdiff (1.0.1)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (4.0.0.1.0-aarch64-linux)
-    libdatadog (4.0.0.1.0-x86_64-linux)
+    libdatadog (5.0.0.1.0-aarch64-linux)
+    libdatadog (5.0.0.1.0-x86_64-linux)
     libddwaf (1.14.0.0.0-aarch64-linux)
       ffi (~> 1.0)
     libddwaf (1.14.0.0.0-x86_64-linux)

--- a/gemfiles/ruby_2.5_redis_5.gemfile.lock
+++ b/gemfiles/ruby_2.5_redis_5.gemfile.lock
@@ -14,7 +14,7 @@ PATH
     ddtrace (1.14.0)
       datadog-ci (~> 0.1.0)
       debase-ruby_core_source (= 3.2.2)
-      libdatadog (~> 4.0.0.1.0)
+      libdatadog (~> 5.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
 
@@ -53,8 +53,8 @@ GEM
     hashdiff (1.0.1)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (4.0.0.1.0-aarch64-linux)
-    libdatadog (4.0.0.1.0-x86_64-linux)
+    libdatadog (5.0.0.1.0-aarch64-linux)
+    libdatadog (5.0.0.1.0-x86_64-linux)
     libddwaf (1.14.0.0.0-aarch64-linux)
       ffi (~> 1.0)
     libddwaf (1.14.0.0.0-x86_64-linux)

--- a/gemfiles/ruby_2.5_relational_db.gemfile.lock
+++ b/gemfiles/ruby_2.5_relational_db.gemfile.lock
@@ -14,7 +14,7 @@ PATH
     ddtrace (1.14.0)
       datadog-ci (~> 0.1.0)
       debase-ruby_core_source (= 3.2.2)
-      libdatadog (~> 4.0.0.1.0)
+      libdatadog (~> 5.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
 
@@ -71,8 +71,8 @@ GEM
       concurrent-ruby (~> 1.0)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (4.0.0.1.0-aarch64-linux)
-    libdatadog (4.0.0.1.0-x86_64-linux)
+    libdatadog (5.0.0.1.0-aarch64-linux)
+    libdatadog (5.0.0.1.0-x86_64-linux)
     libddwaf (1.14.0.0.0-aarch64-linux)
       ffi (~> 1.0)
     libddwaf (1.14.0.0.0-x86_64-linux)

--- a/gemfiles/ruby_2.5_resque2_redis3.gemfile.lock
+++ b/gemfiles/ruby_2.5_resque2_redis3.gemfile.lock
@@ -14,7 +14,7 @@ PATH
     ddtrace (1.14.0)
       datadog-ci (~> 0.1.0)
       debase-ruby_core_source (= 3.2.2)
-      libdatadog (~> 4.0.0.1.0)
+      libdatadog (~> 5.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
 
@@ -52,8 +52,8 @@ GEM
     hashdiff (1.0.1)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (4.0.0.1.0-aarch64-linux)
-    libdatadog (4.0.0.1.0-x86_64-linux)
+    libdatadog (5.0.0.1.0-aarch64-linux)
+    libdatadog (5.0.0.1.0-x86_64-linux)
     libddwaf (1.14.0.0.0-aarch64-linux)
       ffi (~> 1.0)
     libddwaf (1.14.0.0.0-x86_64-linux)

--- a/gemfiles/ruby_2.5_resque2_redis4.gemfile.lock
+++ b/gemfiles/ruby_2.5_resque2_redis4.gemfile.lock
@@ -14,7 +14,7 @@ PATH
     ddtrace (1.14.0)
       datadog-ci (~> 0.1.0)
       debase-ruby_core_source (= 3.2.2)
-      libdatadog (~> 4.0.0.1.0)
+      libdatadog (~> 5.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
 
@@ -53,8 +53,8 @@ GEM
     hashdiff (1.0.1)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (4.0.0.1.0-aarch64-linux)
-    libdatadog (4.0.0.1.0-x86_64-linux)
+    libdatadog (5.0.0.1.0-aarch64-linux)
+    libdatadog (5.0.0.1.0-x86_64-linux)
     libddwaf (1.14.0.0.0-aarch64-linux)
       ffi (~> 1.0)
     libddwaf (1.14.0.0.0-x86_64-linux)

--- a/gemfiles/ruby_2.5_sinatra.gemfile.lock
+++ b/gemfiles/ruby_2.5_sinatra.gemfile.lock
@@ -14,7 +14,7 @@ PATH
     ddtrace (1.14.0)
       datadog-ci (~> 0.1.0)
       debase-ruby_core_source (= 3.2.2)
-      libdatadog (~> 4.0.0.1.0)
+      libdatadog (~> 5.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
 
@@ -52,8 +52,8 @@ GEM
     hashdiff (1.0.1)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (4.0.0.1.0-aarch64-linux)
-    libdatadog (4.0.0.1.0-x86_64-linux)
+    libdatadog (5.0.0.1.0-aarch64-linux)
+    libdatadog (5.0.0.1.0-x86_64-linux)
     libddwaf (1.14.0.0.0-aarch64-linux)
       ffi (~> 1.0)
     libddwaf (1.14.0.0.0-x86_64-linux)

--- a/gemfiles/ruby_2.6_activesupport.gemfile.lock
+++ b/gemfiles/ruby_2.6_activesupport.gemfile.lock
@@ -14,7 +14,7 @@ PATH
     ddtrace (1.14.0)
       datadog-ci (~> 0.1.0)
       debase-ruby_core_source (= 3.2.2)
-      libdatadog (~> 4.0.0.1.0)
+      libdatadog (~> 5.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
 
@@ -116,8 +116,8 @@ GEM
       addressable (>= 2.4)
     jsonapi-renderer (0.2.2)
     king_konf (1.0.1)
-    libdatadog (4.0.0.1.0-aarch64-linux)
-    libdatadog (4.0.0.1.0-x86_64-linux)
+    libdatadog (5.0.0.1.0-aarch64-linux)
+    libdatadog (5.0.0.1.0-x86_64-linux)
     libddwaf (1.14.0.0.0-aarch64-linux)
       ffi (~> 1.0)
     libddwaf (1.14.0.0.0-x86_64-linux)

--- a/gemfiles/ruby_2.6_aws.gemfile.lock
+++ b/gemfiles/ruby_2.6_aws.gemfile.lock
@@ -14,7 +14,7 @@ PATH
     ddtrace (1.14.0)
       datadog-ci (~> 0.1.0)
       debase-ruby_core_source (= 3.2.2)
-      libdatadog (~> 4.0.0.1.0)
+      libdatadog (~> 5.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
 
@@ -1477,8 +1477,8 @@ GEM
     json (2.6.3)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (4.0.0.1.0-aarch64-linux)
-    libdatadog (4.0.0.1.0-x86_64-linux)
+    libdatadog (5.0.0.1.0-aarch64-linux)
+    libdatadog (5.0.0.1.0-x86_64-linux)
     libddwaf (1.14.0.0.0-aarch64-linux)
       ffi (~> 1.0)
     libddwaf (1.14.0.0.0-x86_64-linux)

--- a/gemfiles/ruby_2.6_contrib.gemfile.lock
+++ b/gemfiles/ruby_2.6_contrib.gemfile.lock
@@ -14,7 +14,7 @@ PATH
     ddtrace (1.14.0)
       datadog-ci (~> 0.1.0)
       debase-ruby_core_source (= 3.2.2)
-      libdatadog (~> 4.0.0.1.0)
+      libdatadog (~> 5.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
 
@@ -71,8 +71,8 @@ GEM
     json (2.6.3)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (4.0.0.1.0-aarch64-linux)
-    libdatadog (4.0.0.1.0-x86_64-linux)
+    libdatadog (5.0.0.1.0-aarch64-linux)
+    libdatadog (5.0.0.1.0-x86_64-linux)
     libddwaf (1.14.0.0.0-aarch64-linux)
       ffi (~> 1.0)
     libddwaf (1.14.0.0.0-x86_64-linux)

--- a/gemfiles/ruby_2.6_contrib_old.gemfile.lock
+++ b/gemfiles/ruby_2.6_contrib_old.gemfile.lock
@@ -14,7 +14,7 @@ PATH
     ddtrace (1.14.0)
       datadog-ci (~> 0.1.0)
       debase-ruby_core_source (= 3.2.2)
-      libdatadog (~> 4.0.0.1.0)
+      libdatadog (~> 5.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
 
@@ -75,8 +75,8 @@ GEM
     json (2.6.3)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (4.0.0.1.0-aarch64-linux)
-    libdatadog (4.0.0.1.0-x86_64-linux)
+    libdatadog (5.0.0.1.0-aarch64-linux)
+    libdatadog (5.0.0.1.0-x86_64-linux)
     libddwaf (1.14.0.0.0-aarch64-linux)
       ffi (~> 1.0)
     libddwaf (1.14.0.0.0-x86_64-linux)

--- a/gemfiles/ruby_2.6_core_old.gemfile.lock
+++ b/gemfiles/ruby_2.6_core_old.gemfile.lock
@@ -14,7 +14,7 @@ PATH
     ddtrace (1.14.0)
       datadog-ci (~> 0.1.0)
       debase-ruby_core_source (= 3.2.2)
-      libdatadog (~> 4.0.0.1.0)
+      libdatadog (~> 5.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
 
@@ -55,8 +55,8 @@ GEM
     json (2.6.3)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (4.0.0.1.0-aarch64-linux)
-    libdatadog (4.0.0.1.0-x86_64-linux)
+    libdatadog (5.0.0.1.0-aarch64-linux)
+    libdatadog (5.0.0.1.0-x86_64-linux)
     libddwaf (1.14.0.0.0-aarch64-linux)
       ffi (~> 1.0)
     libddwaf (1.14.0.0.0-x86_64-linux)

--- a/gemfiles/ruby_2.6_hanami_1.gemfile.lock
+++ b/gemfiles/ruby_2.6_hanami_1.gemfile.lock
@@ -14,7 +14,7 @@ PATH
     ddtrace (1.14.0)
       datadog-ci (~> 0.1.0)
       debase-ruby_core_source (= 3.2.2)
-      libdatadog (~> 4.0.0.1.0)
+      libdatadog (~> 5.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
 
@@ -130,8 +130,8 @@ GEM
     json (2.6.3)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (4.0.0.1.0-aarch64-linux)
-    libdatadog (4.0.0.1.0-x86_64-linux)
+    libdatadog (5.0.0.1.0-aarch64-linux)
+    libdatadog (5.0.0.1.0-x86_64-linux)
     libddwaf (1.14.0.0.0-aarch64-linux)
       ffi (~> 1.0)
     libddwaf (1.14.0.0.0-x86_64-linux)

--- a/gemfiles/ruby_2.6_http.gemfile.lock
+++ b/gemfiles/ruby_2.6_http.gemfile.lock
@@ -14,7 +14,7 @@ PATH
     ddtrace (1.14.0)
       datadog-ci (~> 0.1.0)
       debase-ruby_core_source (= 3.2.2)
-      libdatadog (~> 4.0.0.1.0)
+      libdatadog (~> 5.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
 
@@ -85,8 +85,8 @@ GEM
     json (2.6.3)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (4.0.0.1.0-aarch64-linux)
-    libdatadog (4.0.0.1.0-x86_64-linux)
+    libdatadog (5.0.0.1.0-aarch64-linux)
+    libdatadog (5.0.0.1.0-x86_64-linux)
     libddwaf (1.14.0.0.0-aarch64-linux)
       ffi (~> 1.0)
     libddwaf (1.14.0.0.0-x86_64-linux)

--- a/gemfiles/ruby_2.6_opentelemetry.gemfile.lock
+++ b/gemfiles/ruby_2.6_opentelemetry.gemfile.lock
@@ -14,7 +14,7 @@ PATH
     ddtrace (1.14.0)
       datadog-ci (~> 0.1.0)
       debase-ruby_core_source (= 3.2.2)
-      libdatadog (~> 4.0.0.1.0)
+      libdatadog (~> 5.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
 
@@ -55,8 +55,8 @@ GEM
     json (2.6.3)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (4.0.0.1.0-aarch64-linux)
-    libdatadog (4.0.0.1.0-x86_64-linux)
+    libdatadog (5.0.0.1.0-aarch64-linux)
+    libdatadog (5.0.0.1.0-x86_64-linux)
     libddwaf (1.14.0.0.0-aarch64-linux)
       ffi (~> 1.0)
     libddwaf (1.14.0.0.0-x86_64-linux)

--- a/gemfiles/ruby_2.6_opentracing.gemfile.lock
+++ b/gemfiles/ruby_2.6_opentracing.gemfile.lock
@@ -14,7 +14,7 @@ PATH
     ddtrace (1.14.0)
       datadog-ci (~> 0.1.0)
       debase-ruby_core_source (= 3.2.2)
-      libdatadog (~> 4.0.0.1.0)
+      libdatadog (~> 5.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
 
@@ -56,8 +56,8 @@ GEM
     json (2.6.3)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (4.0.0.1.0-aarch64-linux)
-    libdatadog (4.0.0.1.0-x86_64-linux)
+    libdatadog (5.0.0.1.0-aarch64-linux)
+    libdatadog (5.0.0.1.0-x86_64-linux)
     libddwaf (1.14.0.0.0-aarch64-linux)
       ffi (~> 1.0)
     libddwaf (1.14.0.0.0-x86_64-linux)

--- a/gemfiles/ruby_2.6_rack_1.gemfile.lock
+++ b/gemfiles/ruby_2.6_rack_1.gemfile.lock
@@ -14,7 +14,7 @@ PATH
     ddtrace (1.14.0)
       datadog-ci (~> 0.1.0)
       debase-ruby_core_source (= 3.2.2)
-      libdatadog (~> 4.0.0.1.0)
+      libdatadog (~> 5.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
 
@@ -55,8 +55,8 @@ GEM
     json (2.6.3)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (4.0.0.1.0-aarch64-linux)
-    libdatadog (4.0.0.1.0-x86_64-linux)
+    libdatadog (5.0.0.1.0-aarch64-linux)
+    libdatadog (5.0.0.1.0-x86_64-linux)
     libddwaf (1.14.0.0.0-aarch64-linux)
       ffi (~> 1.0)
     libddwaf (1.14.0.0.0-x86_64-linux)

--- a/gemfiles/ruby_2.6_rack_2.gemfile.lock
+++ b/gemfiles/ruby_2.6_rack_2.gemfile.lock
@@ -14,7 +14,7 @@ PATH
     ddtrace (1.14.0)
       datadog-ci (~> 0.1.0)
       debase-ruby_core_source (= 3.2.2)
-      libdatadog (~> 4.0.0.1.0)
+      libdatadog (~> 5.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
 
@@ -55,8 +55,8 @@ GEM
     json (2.6.3)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (4.0.0.1.0-aarch64-linux)
-    libdatadog (4.0.0.1.0-x86_64-linux)
+    libdatadog (5.0.0.1.0-aarch64-linux)
+    libdatadog (5.0.0.1.0-x86_64-linux)
     libddwaf (1.14.0.0.0-aarch64-linux)
       ffi (~> 1.0)
     libddwaf (1.14.0.0.0-x86_64-linux)

--- a/gemfiles/ruby_2.6_rack_3.gemfile.lock
+++ b/gemfiles/ruby_2.6_rack_3.gemfile.lock
@@ -14,7 +14,7 @@ PATH
     ddtrace (1.14.0)
       datadog-ci (~> 0.1.0)
       debase-ruby_core_source (= 3.2.2)
-      libdatadog (~> 4.0.0.1.0)
+      libdatadog (~> 5.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
 
@@ -55,8 +55,8 @@ GEM
     json (2.6.3)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (4.0.0.1.0-aarch64-linux)
-    libdatadog (4.0.0.1.0-x86_64-linux)
+    libdatadog (5.0.0.1.0-aarch64-linux)
+    libdatadog (5.0.0.1.0-x86_64-linux)
     libddwaf (1.14.0.0.0-aarch64-linux)
       ffi (~> 1.0)
     libddwaf (1.14.0.0.0-x86_64-linux)

--- a/gemfiles/ruby_2.6_rails5_mysql2.gemfile.lock
+++ b/gemfiles/ruby_2.6_rails5_mysql2.gemfile.lock
@@ -14,7 +14,7 @@ PATH
     ddtrace (1.14.0)
       datadog-ci (~> 0.1.0)
       debase-ruby_core_source (= 3.2.2)
-      libdatadog (~> 4.0.0.1.0)
+      libdatadog (~> 5.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
 
@@ -104,8 +104,8 @@ GEM
     json (2.6.3)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (4.0.0.1.0-aarch64-linux)
-    libdatadog (4.0.0.1.0-x86_64-linux)
+    libdatadog (5.0.0.1.0-aarch64-linux)
+    libdatadog (5.0.0.1.0-x86_64-linux)
     libddwaf (1.14.0.0.0-aarch64-linux)
       ffi (~> 1.0)
     libddwaf (1.14.0.0.0-x86_64-linux)

--- a/gemfiles/ruby_2.6_rails5_postgres.gemfile.lock
+++ b/gemfiles/ruby_2.6_rails5_postgres.gemfile.lock
@@ -14,7 +14,7 @@ PATH
     ddtrace (1.14.0)
       datadog-ci (~> 0.1.0)
       debase-ruby_core_source (= 3.2.2)
-      libdatadog (~> 4.0.0.1.0)
+      libdatadog (~> 5.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
 
@@ -104,8 +104,8 @@ GEM
     json (2.6.3)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (4.0.0.1.0-aarch64-linux)
-    libdatadog (4.0.0.1.0-x86_64-linux)
+    libdatadog (5.0.0.1.0-aarch64-linux)
+    libdatadog (5.0.0.1.0-x86_64-linux)
     libddwaf (1.14.0.0.0-aarch64-linux)
       ffi (~> 1.0)
     libddwaf (1.14.0.0.0-x86_64-linux)

--- a/gemfiles/ruby_2.6_rails5_postgres_redis.gemfile.lock
+++ b/gemfiles/ruby_2.6_rails5_postgres_redis.gemfile.lock
@@ -14,7 +14,7 @@ PATH
     ddtrace (1.14.0)
       datadog-ci (~> 0.1.0)
       debase-ruby_core_source (= 3.2.2)
-      libdatadog (~> 4.0.0.1.0)
+      libdatadog (~> 5.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
 
@@ -104,8 +104,8 @@ GEM
     json (2.6.3)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (4.0.0.1.0-aarch64-linux)
-    libdatadog (4.0.0.1.0-x86_64-linux)
+    libdatadog (5.0.0.1.0-aarch64-linux)
+    libdatadog (5.0.0.1.0-x86_64-linux)
     libddwaf (1.14.0.0.0-aarch64-linux)
       ffi (~> 1.0)
     libddwaf (1.14.0.0.0-x86_64-linux)

--- a/gemfiles/ruby_2.6_rails5_postgres_redis_activesupport.gemfile.lock
+++ b/gemfiles/ruby_2.6_rails5_postgres_redis_activesupport.gemfile.lock
@@ -14,7 +14,7 @@ PATH
     ddtrace (1.14.0)
       datadog-ci (~> 0.1.0)
       debase-ruby_core_source (= 3.2.2)
-      libdatadog (~> 4.0.0.1.0)
+      libdatadog (~> 5.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
 
@@ -104,8 +104,8 @@ GEM
     json (2.6.3)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (4.0.0.1.0-aarch64-linux)
-    libdatadog (4.0.0.1.0-x86_64-linux)
+    libdatadog (5.0.0.1.0-aarch64-linux)
+    libdatadog (5.0.0.1.0-x86_64-linux)
     libddwaf (1.14.0.0.0-aarch64-linux)
       ffi (~> 1.0)
     libddwaf (1.14.0.0.0-x86_64-linux)

--- a/gemfiles/ruby_2.6_rails5_postgres_sidekiq.gemfile.lock
+++ b/gemfiles/ruby_2.6_rails5_postgres_sidekiq.gemfile.lock
@@ -14,7 +14,7 @@ PATH
     ddtrace (1.14.0)
       datadog-ci (~> 0.1.0)
       debase-ruby_core_source (= 3.2.2)
-      libdatadog (~> 4.0.0.1.0)
+      libdatadog (~> 5.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
 
@@ -105,8 +105,8 @@ GEM
     json (2.6.3)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (4.0.0.1.0-aarch64-linux)
-    libdatadog (4.0.0.1.0-x86_64-linux)
+    libdatadog (5.0.0.1.0-aarch64-linux)
+    libdatadog (5.0.0.1.0-x86_64-linux)
     libddwaf (1.14.0.0.0-aarch64-linux)
       ffi (~> 1.0)
     libddwaf (1.14.0.0.0-x86_64-linux)

--- a/gemfiles/ruby_2.6_rails5_semantic_logger.gemfile.lock
+++ b/gemfiles/ruby_2.6_rails5_semantic_logger.gemfile.lock
@@ -14,7 +14,7 @@ PATH
     ddtrace (1.14.0)
       datadog-ci (~> 0.1.0)
       debase-ruby_core_source (= 3.2.2)
-      libdatadog (~> 4.0.0.1.0)
+      libdatadog (~> 5.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
 
@@ -104,8 +104,8 @@ GEM
     json (2.6.3)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (4.0.0.1.0-aarch64-linux)
-    libdatadog (4.0.0.1.0-x86_64-linux)
+    libdatadog (5.0.0.1.0-aarch64-linux)
+    libdatadog (5.0.0.1.0-x86_64-linux)
     libddwaf (1.14.0.0.0-aarch64-linux)
       ffi (~> 1.0)
     libddwaf (1.14.0.0.0-x86_64-linux)

--- a/gemfiles/ruby_2.6_rails61_mysql2.gemfile.lock
+++ b/gemfiles/ruby_2.6_rails61_mysql2.gemfile.lock
@@ -14,7 +14,7 @@ PATH
     ddtrace (1.14.0)
       datadog-ci (~> 0.1.0)
       debase-ruby_core_source (= 3.2.2)
-      libdatadog (~> 4.0.0.1.0)
+      libdatadog (~> 5.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
 
@@ -121,8 +121,8 @@ GEM
     json (2.6.3)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (4.0.0.1.0-aarch64-linux)
-    libdatadog (4.0.0.1.0-x86_64-linux)
+    libdatadog (5.0.0.1.0-aarch64-linux)
+    libdatadog (5.0.0.1.0-x86_64-linux)
     libddwaf (1.14.0.0.0-aarch64-linux)
       ffi (~> 1.0)
     libddwaf (1.14.0.0.0-x86_64-linux)

--- a/gemfiles/ruby_2.6_rails61_postgres.gemfile.lock
+++ b/gemfiles/ruby_2.6_rails61_postgres.gemfile.lock
@@ -14,7 +14,7 @@ PATH
     ddtrace (1.14.0)
       datadog-ci (~> 0.1.0)
       debase-ruby_core_source (= 3.2.2)
-      libdatadog (~> 4.0.0.1.0)
+      libdatadog (~> 5.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
 
@@ -121,8 +121,8 @@ GEM
     json (2.6.3)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (4.0.0.1.0-aarch64-linux)
-    libdatadog (4.0.0.1.0-x86_64-linux)
+    libdatadog (5.0.0.1.0-aarch64-linux)
+    libdatadog (5.0.0.1.0-x86_64-linux)
     libddwaf (1.14.0.0.0-aarch64-linux)
       ffi (~> 1.0)
     libddwaf (1.14.0.0.0-x86_64-linux)

--- a/gemfiles/ruby_2.6_rails61_postgres_redis.gemfile.lock
+++ b/gemfiles/ruby_2.6_rails61_postgres_redis.gemfile.lock
@@ -14,7 +14,7 @@ PATH
     ddtrace (1.14.0)
       datadog-ci (~> 0.1.0)
       debase-ruby_core_source (= 3.2.2)
-      libdatadog (~> 4.0.0.1.0)
+      libdatadog (~> 5.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
 
@@ -121,8 +121,8 @@ GEM
     json (2.6.3)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (4.0.0.1.0-aarch64-linux)
-    libdatadog (4.0.0.1.0-x86_64-linux)
+    libdatadog (5.0.0.1.0-aarch64-linux)
+    libdatadog (5.0.0.1.0-x86_64-linux)
     libddwaf (1.14.0.0.0-aarch64-linux)
       ffi (~> 1.0)
     libddwaf (1.14.0.0.0-x86_64-linux)

--- a/gemfiles/ruby_2.6_rails61_postgres_sidekiq.gemfile.lock
+++ b/gemfiles/ruby_2.6_rails61_postgres_sidekiq.gemfile.lock
@@ -14,7 +14,7 @@ PATH
     ddtrace (1.14.0)
       datadog-ci (~> 0.1.0)
       debase-ruby_core_source (= 3.2.2)
-      libdatadog (~> 4.0.0.1.0)
+      libdatadog (~> 5.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
 
@@ -122,8 +122,8 @@ GEM
     json (2.6.3)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (4.0.0.1.0-aarch64-linux)
-    libdatadog (4.0.0.1.0-x86_64-linux)
+    libdatadog (5.0.0.1.0-aarch64-linux)
+    libdatadog (5.0.0.1.0-x86_64-linux)
     libddwaf (1.14.0.0.0-aarch64-linux)
       ffi (~> 1.0)
     libddwaf (1.14.0.0.0-x86_64-linux)

--- a/gemfiles/ruby_2.6_rails61_semantic_logger.gemfile.lock
+++ b/gemfiles/ruby_2.6_rails61_semantic_logger.gemfile.lock
@@ -14,7 +14,7 @@ PATH
     ddtrace (1.14.0)
       datadog-ci (~> 0.1.0)
       debase-ruby_core_source (= 3.2.2)
-      libdatadog (~> 4.0.0.1.0)
+      libdatadog (~> 5.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
 
@@ -121,8 +121,8 @@ GEM
     json (2.6.3)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (4.0.0.1.0-aarch64-linux)
-    libdatadog (4.0.0.1.0-x86_64-linux)
+    libdatadog (5.0.0.1.0-aarch64-linux)
+    libdatadog (5.0.0.1.0-x86_64-linux)
     libddwaf (1.14.0.0.0-aarch64-linux)
       ffi (~> 1.0)
     libddwaf (1.14.0.0.0-x86_64-linux)

--- a/gemfiles/ruby_2.6_rails6_mysql2.gemfile.lock
+++ b/gemfiles/ruby_2.6_rails6_mysql2.gemfile.lock
@@ -14,7 +14,7 @@ PATH
     ddtrace (1.14.0)
       datadog-ci (~> 0.1.0)
       debase-ruby_core_source (= 3.2.2)
-      libdatadog (~> 4.0.0.1.0)
+      libdatadog (~> 5.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
 
@@ -117,8 +117,8 @@ GEM
     json (2.6.3)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (4.0.0.1.0-aarch64-linux)
-    libdatadog (4.0.0.1.0-x86_64-linux)
+    libdatadog (5.0.0.1.0-aarch64-linux)
+    libdatadog (5.0.0.1.0-x86_64-linux)
     libddwaf (1.14.0.0.0-aarch64-linux)
       ffi (~> 1.0)
     libddwaf (1.14.0.0.0-x86_64-linux)

--- a/gemfiles/ruby_2.6_rails6_postgres.gemfile.lock
+++ b/gemfiles/ruby_2.6_rails6_postgres.gemfile.lock
@@ -14,7 +14,7 @@ PATH
     ddtrace (1.14.0)
       datadog-ci (~> 0.1.0)
       debase-ruby_core_source (= 3.2.2)
-      libdatadog (~> 4.0.0.1.0)
+      libdatadog (~> 5.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
 
@@ -117,8 +117,8 @@ GEM
     json (2.6.3)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (4.0.0.1.0-aarch64-linux)
-    libdatadog (4.0.0.1.0-x86_64-linux)
+    libdatadog (5.0.0.1.0-aarch64-linux)
+    libdatadog (5.0.0.1.0-x86_64-linux)
     libddwaf (1.14.0.0.0-aarch64-linux)
       ffi (~> 1.0)
     libddwaf (1.14.0.0.0-x86_64-linux)

--- a/gemfiles/ruby_2.6_rails6_postgres_redis.gemfile.lock
+++ b/gemfiles/ruby_2.6_rails6_postgres_redis.gemfile.lock
@@ -14,7 +14,7 @@ PATH
     ddtrace (1.14.0)
       datadog-ci (~> 0.1.0)
       debase-ruby_core_source (= 3.2.2)
-      libdatadog (~> 4.0.0.1.0)
+      libdatadog (~> 5.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
 
@@ -117,8 +117,8 @@ GEM
     json (2.6.3)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (4.0.0.1.0-aarch64-linux)
-    libdatadog (4.0.0.1.0-x86_64-linux)
+    libdatadog (5.0.0.1.0-aarch64-linux)
+    libdatadog (5.0.0.1.0-x86_64-linux)
     libddwaf (1.14.0.0.0-aarch64-linux)
       ffi (~> 1.0)
     libddwaf (1.14.0.0.0-x86_64-linux)

--- a/gemfiles/ruby_2.6_rails6_postgres_redis_activesupport.gemfile.lock
+++ b/gemfiles/ruby_2.6_rails6_postgres_redis_activesupport.gemfile.lock
@@ -14,7 +14,7 @@ PATH
     ddtrace (1.14.0)
       datadog-ci (~> 0.1.0)
       debase-ruby_core_source (= 3.2.2)
-      libdatadog (~> 4.0.0.1.0)
+      libdatadog (~> 5.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
 
@@ -117,8 +117,8 @@ GEM
     json (2.6.3)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (4.0.0.1.0-aarch64-linux)
-    libdatadog (4.0.0.1.0-x86_64-linux)
+    libdatadog (5.0.0.1.0-aarch64-linux)
+    libdatadog (5.0.0.1.0-x86_64-linux)
     libddwaf (1.14.0.0.0-aarch64-linux)
       ffi (~> 1.0)
     libddwaf (1.14.0.0.0-x86_64-linux)

--- a/gemfiles/ruby_2.6_rails6_postgres_sidekiq.gemfile.lock
+++ b/gemfiles/ruby_2.6_rails6_postgres_sidekiq.gemfile.lock
@@ -14,7 +14,7 @@ PATH
     ddtrace (1.14.0)
       datadog-ci (~> 0.1.0)
       debase-ruby_core_source (= 3.2.2)
-      libdatadog (~> 4.0.0.1.0)
+      libdatadog (~> 5.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
 
@@ -118,8 +118,8 @@ GEM
     json (2.6.3)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (4.0.0.1.0-aarch64-linux)
-    libdatadog (4.0.0.1.0-x86_64-linux)
+    libdatadog (5.0.0.1.0-aarch64-linux)
+    libdatadog (5.0.0.1.0-x86_64-linux)
     libddwaf (1.14.0.0.0-aarch64-linux)
       ffi (~> 1.0)
     libddwaf (1.14.0.0.0-x86_64-linux)

--- a/gemfiles/ruby_2.6_rails6_semantic_logger.gemfile.lock
+++ b/gemfiles/ruby_2.6_rails6_semantic_logger.gemfile.lock
@@ -14,7 +14,7 @@ PATH
     ddtrace (1.14.0)
       datadog-ci (~> 0.1.0)
       debase-ruby_core_source (= 3.2.2)
-      libdatadog (~> 4.0.0.1.0)
+      libdatadog (~> 5.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
 
@@ -117,8 +117,8 @@ GEM
     json (2.6.3)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (4.0.0.1.0-aarch64-linux)
-    libdatadog (4.0.0.1.0-x86_64-linux)
+    libdatadog (5.0.0.1.0-aarch64-linux)
+    libdatadog (5.0.0.1.0-x86_64-linux)
     libddwaf (1.14.0.0.0-aarch64-linux)
       ffi (~> 1.0)
     libddwaf (1.14.0.0.0-x86_64-linux)

--- a/gemfiles/ruby_2.6_redis_3.gemfile.lock
+++ b/gemfiles/ruby_2.6_redis_3.gemfile.lock
@@ -14,7 +14,7 @@ PATH
     ddtrace (1.14.0)
       datadog-ci (~> 0.1.0)
       debase-ruby_core_source (= 3.2.2)
-      libdatadog (~> 4.0.0.1.0)
+      libdatadog (~> 5.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
 
@@ -55,8 +55,8 @@ GEM
     json (2.6.3)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (4.0.0.1.0-aarch64-linux)
-    libdatadog (4.0.0.1.0-x86_64-linux)
+    libdatadog (5.0.0.1.0-aarch64-linux)
+    libdatadog (5.0.0.1.0-x86_64-linux)
     libddwaf (1.14.0.0.0-aarch64-linux)
       ffi (~> 1.0)
     libddwaf (1.14.0.0.0-x86_64-linux)

--- a/gemfiles/ruby_2.6_redis_4.gemfile.lock
+++ b/gemfiles/ruby_2.6_redis_4.gemfile.lock
@@ -14,7 +14,7 @@ PATH
     ddtrace (1.14.0)
       datadog-ci (~> 0.1.0)
       debase-ruby_core_source (= 3.2.2)
-      libdatadog (~> 4.0.0.1.0)
+      libdatadog (~> 5.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
 
@@ -55,8 +55,8 @@ GEM
     json (2.6.3)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (4.0.0.1.0-aarch64-linux)
-    libdatadog (4.0.0.1.0-x86_64-linux)
+    libdatadog (5.0.0.1.0-aarch64-linux)
+    libdatadog (5.0.0.1.0-x86_64-linux)
     libddwaf (1.14.0.0.0-aarch64-linux)
       ffi (~> 1.0)
     libddwaf (1.14.0.0.0-x86_64-linux)

--- a/gemfiles/ruby_2.6_redis_5.gemfile.lock
+++ b/gemfiles/ruby_2.6_redis_5.gemfile.lock
@@ -14,7 +14,7 @@ PATH
     ddtrace (1.14.0)
       datadog-ci (~> 0.1.0)
       debase-ruby_core_source (= 3.2.2)
-      libdatadog (~> 4.0.0.1.0)
+      libdatadog (~> 5.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
 
@@ -56,8 +56,8 @@ GEM
     json (2.6.3)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (4.0.0.1.0-aarch64-linux)
-    libdatadog (4.0.0.1.0-x86_64-linux)
+    libdatadog (5.0.0.1.0-aarch64-linux)
+    libdatadog (5.0.0.1.0-x86_64-linux)
     libddwaf (1.14.0.0.0-aarch64-linux)
       ffi (~> 1.0)
     libddwaf (1.14.0.0.0-x86_64-linux)

--- a/gemfiles/ruby_2.6_relational_db.gemfile.lock
+++ b/gemfiles/ruby_2.6_relational_db.gemfile.lock
@@ -14,7 +14,7 @@ PATH
     ddtrace (1.14.0)
       datadog-ci (~> 0.1.0)
       debase-ruby_core_source (= 3.2.2)
-      libdatadog (~> 4.0.0.1.0)
+      libdatadog (~> 5.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
 
@@ -73,8 +73,8 @@ GEM
     json (2.6.3)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (4.0.0.1.0-aarch64-linux)
-    libdatadog (4.0.0.1.0-x86_64-linux)
+    libdatadog (5.0.0.1.0-aarch64-linux)
+    libdatadog (5.0.0.1.0-x86_64-linux)
     libddwaf (1.14.0.0.0-aarch64-linux)
       ffi (~> 1.0)
     libddwaf (1.14.0.0.0-x86_64-linux)

--- a/gemfiles/ruby_2.6_resque2_redis3.gemfile.lock
+++ b/gemfiles/ruby_2.6_resque2_redis3.gemfile.lock
@@ -14,7 +14,7 @@ PATH
     ddtrace (1.14.0)
       datadog-ci (~> 0.1.0)
       debase-ruby_core_source (= 3.2.2)
-      libdatadog (~> 4.0.0.1.0)
+      libdatadog (~> 5.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
 
@@ -55,8 +55,8 @@ GEM
     json (2.6.3)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (4.0.0.1.0-aarch64-linux)
-    libdatadog (4.0.0.1.0-x86_64-linux)
+    libdatadog (5.0.0.1.0-aarch64-linux)
+    libdatadog (5.0.0.1.0-x86_64-linux)
     libddwaf (1.14.0.0.0-aarch64-linux)
       ffi (~> 1.0)
     libddwaf (1.14.0.0.0-x86_64-linux)

--- a/gemfiles/ruby_2.6_resque2_redis4.gemfile.lock
+++ b/gemfiles/ruby_2.6_resque2_redis4.gemfile.lock
@@ -14,7 +14,7 @@ PATH
     ddtrace (1.14.0)
       datadog-ci (~> 0.1.0)
       debase-ruby_core_source (= 3.2.2)
-      libdatadog (~> 4.0.0.1.0)
+      libdatadog (~> 5.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
 
@@ -55,8 +55,8 @@ GEM
     json (2.6.3)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (4.0.0.1.0-aarch64-linux)
-    libdatadog (4.0.0.1.0-x86_64-linux)
+    libdatadog (5.0.0.1.0-aarch64-linux)
+    libdatadog (5.0.0.1.0-x86_64-linux)
     libddwaf (1.14.0.0.0-aarch64-linux)
       ffi (~> 1.0)
     libddwaf (1.14.0.0.0-x86_64-linux)

--- a/gemfiles/ruby_2.6_sinatra.gemfile.lock
+++ b/gemfiles/ruby_2.6_sinatra.gemfile.lock
@@ -14,7 +14,7 @@ PATH
     ddtrace (1.14.0)
       datadog-ci (~> 0.1.0)
       debase-ruby_core_source (= 3.2.2)
-      libdatadog (~> 4.0.0.1.0)
+      libdatadog (~> 5.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
 
@@ -55,8 +55,8 @@ GEM
     json (2.6.3)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (4.0.0.1.0-aarch64-linux)
-    libdatadog (4.0.0.1.0-x86_64-linux)
+    libdatadog (5.0.0.1.0-aarch64-linux)
+    libdatadog (5.0.0.1.0-x86_64-linux)
     libddwaf (1.14.0.0.0-aarch64-linux)
       ffi (~> 1.0)
     libddwaf (1.14.0.0.0-x86_64-linux)

--- a/gemfiles/ruby_2.7.6_sinatra.gemfile.lock
+++ b/gemfiles/ruby_2.7.6_sinatra.gemfile.lock
@@ -15,7 +15,7 @@ PATH
     ddtrace (1.14.0)
       datadog-ci (~> 0.1.0)
       debase-ruby_core_source (= 3.2.2)
-      libdatadog (~> 4.0.0.1.0)
+      libdatadog (~> 5.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
 
@@ -56,8 +56,8 @@ GEM
     json (2.6.3)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (4.0.0.1.0-aarch64-linux)
-    libdatadog (4.0.0.1.0-x86_64-linux)
+    libdatadog (5.0.0.1.0-aarch64-linux)
+    libdatadog (5.0.0.1.0-x86_64-linux)
     libddwaf (1.14.0.0.0-aarch64-linux)
       ffi (~> 1.0)
     libddwaf (1.14.0.0.0-x86_64-linux)

--- a/gemfiles/ruby_2.7_activesupport.gemfile.lock
+++ b/gemfiles/ruby_2.7_activesupport.gemfile.lock
@@ -14,7 +14,7 @@ PATH
     ddtrace (1.14.0)
       datadog-ci (~> 0.1.0)
       debase-ruby_core_source (= 3.2.2)
-      libdatadog (~> 4.0.0.1.0)
+      libdatadog (~> 5.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
 
@@ -112,8 +112,8 @@ GEM
       addressable (>= 2.4)
     jsonapi-renderer (0.2.2)
     king_konf (1.0.1)
-    libdatadog (4.0.0.1.0-aarch64-linux)
-    libdatadog (4.0.0.1.0-x86_64-linux)
+    libdatadog (5.0.0.1.0-aarch64-linux)
+    libdatadog (5.0.0.1.0-x86_64-linux)
     libddwaf (1.14.0.0.0-aarch64-linux)
       ffi (~> 1.0)
     libddwaf (1.14.0.0.0-x86_64-linux)

--- a/gemfiles/ruby_2.7_aws.gemfile.lock
+++ b/gemfiles/ruby_2.7_aws.gemfile.lock
@@ -14,7 +14,7 @@ PATH
     ddtrace (1.14.0)
       datadog-ci (~> 0.1.0)
       debase-ruby_core_source (= 3.2.2)
-      libdatadog (~> 4.0.0.1.0)
+      libdatadog (~> 5.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
 
@@ -1477,8 +1477,8 @@ GEM
     json (2.6.3)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (4.0.0.1.0-aarch64-linux)
-    libdatadog (4.0.0.1.0-x86_64-linux)
+    libdatadog (5.0.0.1.0-aarch64-linux)
+    libdatadog (5.0.0.1.0-x86_64-linux)
     libddwaf (1.14.0.0.0-aarch64-linux)
       ffi (~> 1.0)
     libddwaf (1.14.0.0.0-x86_64-linux)

--- a/gemfiles/ruby_2.7_contrib.gemfile.lock
+++ b/gemfiles/ruby_2.7_contrib.gemfile.lock
@@ -14,7 +14,7 @@ PATH
     ddtrace (1.14.0)
       datadog-ci (~> 0.1.0)
       debase-ruby_core_source (= 3.2.2)
-      libdatadog (~> 4.0.0.1.0)
+      libdatadog (~> 5.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
 
@@ -71,8 +71,8 @@ GEM
     json (2.6.3)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (4.0.0.1.0-aarch64-linux)
-    libdatadog (4.0.0.1.0-x86_64-linux)
+    libdatadog (5.0.0.1.0-aarch64-linux)
+    libdatadog (5.0.0.1.0-x86_64-linux)
     libddwaf (1.14.0.0.0-aarch64-linux)
       ffi (~> 1.0)
     libddwaf (1.14.0.0.0-x86_64-linux)

--- a/gemfiles/ruby_2.7_contrib_old.gemfile.lock
+++ b/gemfiles/ruby_2.7_contrib_old.gemfile.lock
@@ -14,7 +14,7 @@ PATH
     ddtrace (1.14.0)
       datadog-ci (~> 0.1.0)
       debase-ruby_core_source (= 3.2.2)
-      libdatadog (~> 4.0.0.1.0)
+      libdatadog (~> 5.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
 
@@ -75,8 +75,8 @@ GEM
     json (2.6.3)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (4.0.0.1.0-aarch64-linux)
-    libdatadog (4.0.0.1.0-x86_64-linux)
+    libdatadog (5.0.0.1.0-aarch64-linux)
+    libdatadog (5.0.0.1.0-x86_64-linux)
     libddwaf (1.14.0.0.0-aarch64-linux)
       ffi (~> 1.0)
     libddwaf (1.14.0.0.0-x86_64-linux)

--- a/gemfiles/ruby_2.7_core_old.gemfile.lock
+++ b/gemfiles/ruby_2.7_core_old.gemfile.lock
@@ -14,7 +14,7 @@ PATH
     ddtrace (1.14.0)
       datadog-ci (~> 0.1.0)
       debase-ruby_core_source (= 3.2.2)
-      libdatadog (~> 4.0.0.1.0)
+      libdatadog (~> 5.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
 
@@ -55,8 +55,8 @@ GEM
     json (2.6.3)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (4.0.0.1.0-aarch64-linux)
-    libdatadog (4.0.0.1.0-x86_64-linux)
+    libdatadog (5.0.0.1.0-aarch64-linux)
+    libdatadog (5.0.0.1.0-x86_64-linux)
     libddwaf (1.14.0.0.0-aarch64-linux)
       ffi (~> 1.0)
     libddwaf (1.14.0.0.0-x86_64-linux)

--- a/gemfiles/ruby_2.7_hanami_1.gemfile.lock
+++ b/gemfiles/ruby_2.7_hanami_1.gemfile.lock
@@ -14,7 +14,7 @@ PATH
     ddtrace (1.14.0)
       datadog-ci (~> 0.1.0)
       debase-ruby_core_source (= 3.2.2)
-      libdatadog (~> 4.0.0.1.0)
+      libdatadog (~> 5.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
 
@@ -131,8 +131,8 @@ GEM
     json (2.6.3)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (4.0.0.1.0-aarch64-linux)
-    libdatadog (4.0.0.1.0-x86_64-linux)
+    libdatadog (5.0.0.1.0-aarch64-linux)
+    libdatadog (5.0.0.1.0-x86_64-linux)
     libddwaf (1.14.0.0.0-aarch64-linux)
       ffi (~> 1.0)
     libddwaf (1.14.0.0.0-x86_64-linux)

--- a/gemfiles/ruby_2.7_http.gemfile.lock
+++ b/gemfiles/ruby_2.7_http.gemfile.lock
@@ -14,7 +14,7 @@ PATH
     ddtrace (1.14.0)
       datadog-ci (~> 0.1.0)
       debase-ruby_core_source (= 3.2.2)
-      libdatadog (~> 4.0.0.1.0)
+      libdatadog (~> 5.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
 
@@ -85,8 +85,8 @@ GEM
     json (2.6.3)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (4.0.0.1.0-aarch64-linux)
-    libdatadog (4.0.0.1.0-x86_64-linux)
+    libdatadog (5.0.0.1.0-aarch64-linux)
+    libdatadog (5.0.0.1.0-x86_64-linux)
     libddwaf (1.14.0.0.0-aarch64-linux)
       ffi (~> 1.0)
     libddwaf (1.14.0.0.0-x86_64-linux)

--- a/gemfiles/ruby_2.7_opentelemetry.gemfile.lock
+++ b/gemfiles/ruby_2.7_opentelemetry.gemfile.lock
@@ -14,7 +14,7 @@ PATH
     ddtrace (1.14.0)
       datadog-ci (~> 0.1.0)
       debase-ruby_core_source (= 3.2.2)
-      libdatadog (~> 4.0.0.1.0)
+      libdatadog (~> 5.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
 
@@ -55,8 +55,8 @@ GEM
     json (2.6.3)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (4.0.0.1.0-aarch64-linux)
-    libdatadog (4.0.0.1.0-x86_64-linux)
+    libdatadog (5.0.0.1.0-aarch64-linux)
+    libdatadog (5.0.0.1.0-x86_64-linux)
     libddwaf (1.14.0.0.0-aarch64-linux)
       ffi (~> 1.0)
     libddwaf (1.14.0.0.0-x86_64-linux)

--- a/gemfiles/ruby_2.7_opentracing.gemfile.lock
+++ b/gemfiles/ruby_2.7_opentracing.gemfile.lock
@@ -14,7 +14,7 @@ PATH
     ddtrace (1.14.0)
       datadog-ci (~> 0.1.0)
       debase-ruby_core_source (= 3.2.2)
-      libdatadog (~> 4.0.0.1.0)
+      libdatadog (~> 5.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
 
@@ -56,8 +56,8 @@ GEM
     json (2.6.3)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (4.0.0.1.0-aarch64-linux)
-    libdatadog (4.0.0.1.0-x86_64-linux)
+    libdatadog (5.0.0.1.0-aarch64-linux)
+    libdatadog (5.0.0.1.0-x86_64-linux)
     libddwaf (1.14.0.0.0-aarch64-linux)
       ffi (~> 1.0)
     libddwaf (1.14.0.0.0-x86_64-linux)

--- a/gemfiles/ruby_2.7_rack_1.gemfile.lock
+++ b/gemfiles/ruby_2.7_rack_1.gemfile.lock
@@ -14,7 +14,7 @@ PATH
     ddtrace (1.14.0)
       datadog-ci (~> 0.1.0)
       debase-ruby_core_source (= 3.2.2)
-      libdatadog (~> 4.0.0.1.0)
+      libdatadog (~> 5.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
 
@@ -55,8 +55,8 @@ GEM
     json (2.6.3)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (4.0.0.1.0-aarch64-linux)
-    libdatadog (4.0.0.1.0-x86_64-linux)
+    libdatadog (5.0.0.1.0-aarch64-linux)
+    libdatadog (5.0.0.1.0-x86_64-linux)
     libddwaf (1.14.0.0.0-aarch64-linux)
       ffi (~> 1.0)
     libddwaf (1.14.0.0.0-x86_64-linux)

--- a/gemfiles/ruby_2.7_rack_2.gemfile.lock
+++ b/gemfiles/ruby_2.7_rack_2.gemfile.lock
@@ -14,7 +14,7 @@ PATH
     ddtrace (1.14.0)
       datadog-ci (~> 0.1.0)
       debase-ruby_core_source (= 3.2.2)
-      libdatadog (~> 4.0.0.1.0)
+      libdatadog (~> 5.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
 
@@ -55,8 +55,8 @@ GEM
     json (2.6.3)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (4.0.0.1.0-aarch64-linux)
-    libdatadog (4.0.0.1.0-x86_64-linux)
+    libdatadog (5.0.0.1.0-aarch64-linux)
+    libdatadog (5.0.0.1.0-x86_64-linux)
     libddwaf (1.14.0.0.0-aarch64-linux)
       ffi (~> 1.0)
     libddwaf (1.14.0.0.0-x86_64-linux)

--- a/gemfiles/ruby_2.7_rack_3.gemfile.lock
+++ b/gemfiles/ruby_2.7_rack_3.gemfile.lock
@@ -14,7 +14,7 @@ PATH
     ddtrace (1.14.0)
       datadog-ci (~> 0.1.0)
       debase-ruby_core_source (= 3.2.2)
-      libdatadog (~> 4.0.0.1.0)
+      libdatadog (~> 5.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
 
@@ -55,8 +55,8 @@ GEM
     json (2.6.3)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (4.0.0.1.0-aarch64-linux)
-    libdatadog (4.0.0.1.0-x86_64-linux)
+    libdatadog (5.0.0.1.0-aarch64-linux)
+    libdatadog (5.0.0.1.0-x86_64-linux)
     libddwaf (1.14.0.0.0-aarch64-linux)
       ffi (~> 1.0)
     libddwaf (1.14.0.0.0-x86_64-linux)

--- a/gemfiles/ruby_2.7_rails5_mysql2.gemfile.lock
+++ b/gemfiles/ruby_2.7_rails5_mysql2.gemfile.lock
@@ -14,7 +14,7 @@ PATH
     ddtrace (1.14.0)
       datadog-ci (~> 0.1.0)
       debase-ruby_core_source (= 3.2.2)
-      libdatadog (~> 4.0.0.1.0)
+      libdatadog (~> 5.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
 
@@ -104,8 +104,8 @@ GEM
     json (2.6.3)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (4.0.0.1.0-aarch64-linux)
-    libdatadog (4.0.0.1.0-x86_64-linux)
+    libdatadog (5.0.0.1.0-aarch64-linux)
+    libdatadog (5.0.0.1.0-x86_64-linux)
     libddwaf (1.14.0.0.0-aarch64-linux)
       ffi (~> 1.0)
     libddwaf (1.14.0.0.0-x86_64-linux)

--- a/gemfiles/ruby_2.7_rails5_postgres.gemfile.lock
+++ b/gemfiles/ruby_2.7_rails5_postgres.gemfile.lock
@@ -14,7 +14,7 @@ PATH
     ddtrace (1.14.0)
       datadog-ci (~> 0.1.0)
       debase-ruby_core_source (= 3.2.2)
-      libdatadog (~> 4.0.0.1.0)
+      libdatadog (~> 5.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
 
@@ -104,8 +104,8 @@ GEM
     json (2.6.3)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (4.0.0.1.0-aarch64-linux)
-    libdatadog (4.0.0.1.0-x86_64-linux)
+    libdatadog (5.0.0.1.0-aarch64-linux)
+    libdatadog (5.0.0.1.0-x86_64-linux)
     libddwaf (1.14.0.0.0-aarch64-linux)
       ffi (~> 1.0)
     libddwaf (1.14.0.0.0-x86_64-linux)

--- a/gemfiles/ruby_2.7_rails5_postgres_redis.gemfile.lock
+++ b/gemfiles/ruby_2.7_rails5_postgres_redis.gemfile.lock
@@ -14,7 +14,7 @@ PATH
     ddtrace (1.14.0)
       datadog-ci (~> 0.1.0)
       debase-ruby_core_source (= 3.2.2)
-      libdatadog (~> 4.0.0.1.0)
+      libdatadog (~> 5.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
 
@@ -104,8 +104,8 @@ GEM
     json (2.6.3)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (4.0.0.1.0-aarch64-linux)
-    libdatadog (4.0.0.1.0-x86_64-linux)
+    libdatadog (5.0.0.1.0-aarch64-linux)
+    libdatadog (5.0.0.1.0-x86_64-linux)
     libddwaf (1.14.0.0.0-aarch64-linux)
       ffi (~> 1.0)
     libddwaf (1.14.0.0.0-x86_64-linux)

--- a/gemfiles/ruby_2.7_rails5_postgres_redis_activesupport.gemfile.lock
+++ b/gemfiles/ruby_2.7_rails5_postgres_redis_activesupport.gemfile.lock
@@ -14,7 +14,7 @@ PATH
     ddtrace (1.14.0)
       datadog-ci (~> 0.1.0)
       debase-ruby_core_source (= 3.2.2)
-      libdatadog (~> 4.0.0.1.0)
+      libdatadog (~> 5.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
 
@@ -104,8 +104,8 @@ GEM
     json (2.6.3)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (4.0.0.1.0-aarch64-linux)
-    libdatadog (4.0.0.1.0-x86_64-linux)
+    libdatadog (5.0.0.1.0-aarch64-linux)
+    libdatadog (5.0.0.1.0-x86_64-linux)
     libddwaf (1.14.0.0.0-aarch64-linux)
       ffi (~> 1.0)
     libddwaf (1.14.0.0.0-x86_64-linux)

--- a/gemfiles/ruby_2.7_rails5_postgres_sidekiq.gemfile.lock
+++ b/gemfiles/ruby_2.7_rails5_postgres_sidekiq.gemfile.lock
@@ -14,7 +14,7 @@ PATH
     ddtrace (1.14.0)
       datadog-ci (~> 0.1.0)
       debase-ruby_core_source (= 3.2.2)
-      libdatadog (~> 4.0.0.1.0)
+      libdatadog (~> 5.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
 
@@ -105,8 +105,8 @@ GEM
     json (2.6.3)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (4.0.0.1.0-aarch64-linux)
-    libdatadog (4.0.0.1.0-x86_64-linux)
+    libdatadog (5.0.0.1.0-aarch64-linux)
+    libdatadog (5.0.0.1.0-x86_64-linux)
     libddwaf (1.14.0.0.0-aarch64-linux)
       ffi (~> 1.0)
     libddwaf (1.14.0.0.0-x86_64-linux)

--- a/gemfiles/ruby_2.7_rails5_semantic_logger.gemfile.lock
+++ b/gemfiles/ruby_2.7_rails5_semantic_logger.gemfile.lock
@@ -14,7 +14,7 @@ PATH
     ddtrace (1.14.0)
       datadog-ci (~> 0.1.0)
       debase-ruby_core_source (= 3.2.2)
-      libdatadog (~> 4.0.0.1.0)
+      libdatadog (~> 5.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
 
@@ -104,8 +104,8 @@ GEM
     json (2.6.3)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (4.0.0.1.0-aarch64-linux)
-    libdatadog (4.0.0.1.0-x86_64-linux)
+    libdatadog (5.0.0.1.0-aarch64-linux)
+    libdatadog (5.0.0.1.0-x86_64-linux)
     libddwaf (1.14.0.0.0-aarch64-linux)
       ffi (~> 1.0)
     libddwaf (1.14.0.0.0-x86_64-linux)

--- a/gemfiles/ruby_2.7_rails61_mysql2.gemfile.lock
+++ b/gemfiles/ruby_2.7_rails61_mysql2.gemfile.lock
@@ -14,7 +14,7 @@ PATH
     ddtrace (1.14.0)
       datadog-ci (~> 0.1.0)
       debase-ruby_core_source (= 3.2.2)
-      libdatadog (~> 4.0.0.1.0)
+      libdatadog (~> 5.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
 
@@ -121,8 +121,8 @@ GEM
     json (2.6.3)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (4.0.0.1.0-aarch64-linux)
-    libdatadog (4.0.0.1.0-x86_64-linux)
+    libdatadog (5.0.0.1.0-aarch64-linux)
+    libdatadog (5.0.0.1.0-x86_64-linux)
     libddwaf (1.14.0.0.0-aarch64-linux)
       ffi (~> 1.0)
     libddwaf (1.14.0.0.0-x86_64-linux)

--- a/gemfiles/ruby_2.7_rails61_postgres.gemfile.lock
+++ b/gemfiles/ruby_2.7_rails61_postgres.gemfile.lock
@@ -14,7 +14,7 @@ PATH
     ddtrace (1.14.0)
       datadog-ci (~> 0.1.0)
       debase-ruby_core_source (= 3.2.2)
-      libdatadog (~> 4.0.0.1.0)
+      libdatadog (~> 5.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
 
@@ -121,8 +121,8 @@ GEM
     json (2.6.3)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (4.0.0.1.0-aarch64-linux)
-    libdatadog (4.0.0.1.0-x86_64-linux)
+    libdatadog (5.0.0.1.0-aarch64-linux)
+    libdatadog (5.0.0.1.0-x86_64-linux)
     libddwaf (1.14.0.0.0-aarch64-linux)
       ffi (~> 1.0)
     libddwaf (1.14.0.0.0-x86_64-linux)

--- a/gemfiles/ruby_2.7_rails61_postgres_redis.gemfile.lock
+++ b/gemfiles/ruby_2.7_rails61_postgres_redis.gemfile.lock
@@ -14,7 +14,7 @@ PATH
     ddtrace (1.14.0)
       datadog-ci (~> 0.1.0)
       debase-ruby_core_source (= 3.2.2)
-      libdatadog (~> 4.0.0.1.0)
+      libdatadog (~> 5.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
 
@@ -121,8 +121,8 @@ GEM
     json (2.6.3)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (4.0.0.1.0-aarch64-linux)
-    libdatadog (4.0.0.1.0-x86_64-linux)
+    libdatadog (5.0.0.1.0-aarch64-linux)
+    libdatadog (5.0.0.1.0-x86_64-linux)
     libddwaf (1.14.0.0.0-aarch64-linux)
       ffi (~> 1.0)
     libddwaf (1.14.0.0.0-x86_64-linux)

--- a/gemfiles/ruby_2.7_rails61_postgres_sidekiq.gemfile.lock
+++ b/gemfiles/ruby_2.7_rails61_postgres_sidekiq.gemfile.lock
@@ -14,7 +14,7 @@ PATH
     ddtrace (1.14.0)
       datadog-ci (~> 0.1.0)
       debase-ruby_core_source (= 3.2.2)
-      libdatadog (~> 4.0.0.1.0)
+      libdatadog (~> 5.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
 
@@ -122,8 +122,8 @@ GEM
     json (2.6.3)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (4.0.0.1.0-aarch64-linux)
-    libdatadog (4.0.0.1.0-x86_64-linux)
+    libdatadog (5.0.0.1.0-aarch64-linux)
+    libdatadog (5.0.0.1.0-x86_64-linux)
     libddwaf (1.14.0.0.0-aarch64-linux)
       ffi (~> 1.0)
     libddwaf (1.14.0.0.0-x86_64-linux)

--- a/gemfiles/ruby_2.7_rails61_semantic_logger.gemfile.lock
+++ b/gemfiles/ruby_2.7_rails61_semantic_logger.gemfile.lock
@@ -14,7 +14,7 @@ PATH
     ddtrace (1.14.0)
       datadog-ci (~> 0.1.0)
       debase-ruby_core_source (= 3.2.2)
-      libdatadog (~> 4.0.0.1.0)
+      libdatadog (~> 5.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
 
@@ -121,8 +121,8 @@ GEM
     json (2.6.3)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (4.0.0.1.0-aarch64-linux)
-    libdatadog (4.0.0.1.0-x86_64-linux)
+    libdatadog (5.0.0.1.0-aarch64-linux)
+    libdatadog (5.0.0.1.0-x86_64-linux)
     libddwaf (1.14.0.0.0-aarch64-linux)
       ffi (~> 1.0)
     libddwaf (1.14.0.0.0-x86_64-linux)

--- a/gemfiles/ruby_2.7_rails6_mysql2.gemfile.lock
+++ b/gemfiles/ruby_2.7_rails6_mysql2.gemfile.lock
@@ -14,7 +14,7 @@ PATH
     ddtrace (1.14.0)
       datadog-ci (~> 0.1.0)
       debase-ruby_core_source (= 3.2.2)
-      libdatadog (~> 4.0.0.1.0)
+      libdatadog (~> 5.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
 
@@ -117,8 +117,8 @@ GEM
     json (2.6.3)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (4.0.0.1.0-aarch64-linux)
-    libdatadog (4.0.0.1.0-x86_64-linux)
+    libdatadog (5.0.0.1.0-aarch64-linux)
+    libdatadog (5.0.0.1.0-x86_64-linux)
     libddwaf (1.14.0.0.0-aarch64-linux)
       ffi (~> 1.0)
     libddwaf (1.14.0.0.0-x86_64-linux)

--- a/gemfiles/ruby_2.7_rails6_postgres.gemfile.lock
+++ b/gemfiles/ruby_2.7_rails6_postgres.gemfile.lock
@@ -14,7 +14,7 @@ PATH
     ddtrace (1.14.0)
       datadog-ci (~> 0.1.0)
       debase-ruby_core_source (= 3.2.2)
-      libdatadog (~> 4.0.0.1.0)
+      libdatadog (~> 5.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
 
@@ -117,8 +117,8 @@ GEM
     json (2.6.3)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (4.0.0.1.0-aarch64-linux)
-    libdatadog (4.0.0.1.0-x86_64-linux)
+    libdatadog (5.0.0.1.0-aarch64-linux)
+    libdatadog (5.0.0.1.0-x86_64-linux)
     libddwaf (1.14.0.0.0-aarch64-linux)
       ffi (~> 1.0)
     libddwaf (1.14.0.0.0-x86_64-linux)

--- a/gemfiles/ruby_2.7_rails6_postgres_redis.gemfile.lock
+++ b/gemfiles/ruby_2.7_rails6_postgres_redis.gemfile.lock
@@ -14,7 +14,7 @@ PATH
     ddtrace (1.14.0)
       datadog-ci (~> 0.1.0)
       debase-ruby_core_source (= 3.2.2)
-      libdatadog (~> 4.0.0.1.0)
+      libdatadog (~> 5.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
 
@@ -117,8 +117,8 @@ GEM
     json (2.6.3)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (4.0.0.1.0-aarch64-linux)
-    libdatadog (4.0.0.1.0-x86_64-linux)
+    libdatadog (5.0.0.1.0-aarch64-linux)
+    libdatadog (5.0.0.1.0-x86_64-linux)
     libddwaf (1.14.0.0.0-aarch64-linux)
       ffi (~> 1.0)
     libddwaf (1.14.0.0.0-x86_64-linux)

--- a/gemfiles/ruby_2.7_rails6_postgres_redis_activesupport.gemfile.lock
+++ b/gemfiles/ruby_2.7_rails6_postgres_redis_activesupport.gemfile.lock
@@ -14,7 +14,7 @@ PATH
     ddtrace (1.14.0)
       datadog-ci (~> 0.1.0)
       debase-ruby_core_source (= 3.2.2)
-      libdatadog (~> 4.0.0.1.0)
+      libdatadog (~> 5.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
 
@@ -117,8 +117,8 @@ GEM
     json (2.6.3)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (4.0.0.1.0-aarch64-linux)
-    libdatadog (4.0.0.1.0-x86_64-linux)
+    libdatadog (5.0.0.1.0-aarch64-linux)
+    libdatadog (5.0.0.1.0-x86_64-linux)
     libddwaf (1.14.0.0.0-aarch64-linux)
       ffi (~> 1.0)
     libddwaf (1.14.0.0.0-x86_64-linux)

--- a/gemfiles/ruby_2.7_rails6_postgres_sidekiq.gemfile.lock
+++ b/gemfiles/ruby_2.7_rails6_postgres_sidekiq.gemfile.lock
@@ -14,7 +14,7 @@ PATH
     ddtrace (1.14.0)
       datadog-ci (~> 0.1.0)
       debase-ruby_core_source (= 3.2.2)
-      libdatadog (~> 4.0.0.1.0)
+      libdatadog (~> 5.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
 
@@ -118,8 +118,8 @@ GEM
     json (2.6.3)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (4.0.0.1.0-aarch64-linux)
-    libdatadog (4.0.0.1.0-x86_64-linux)
+    libdatadog (5.0.0.1.0-aarch64-linux)
+    libdatadog (5.0.0.1.0-x86_64-linux)
     libddwaf (1.14.0.0.0-aarch64-linux)
       ffi (~> 1.0)
     libddwaf (1.14.0.0.0-x86_64-linux)

--- a/gemfiles/ruby_2.7_rails6_semantic_logger.gemfile.lock
+++ b/gemfiles/ruby_2.7_rails6_semantic_logger.gemfile.lock
@@ -14,7 +14,7 @@ PATH
     ddtrace (1.14.0)
       datadog-ci (~> 0.1.0)
       debase-ruby_core_source (= 3.2.2)
-      libdatadog (~> 4.0.0.1.0)
+      libdatadog (~> 5.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
 
@@ -117,8 +117,8 @@ GEM
     json (2.6.3)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (4.0.0.1.0-aarch64-linux)
-    libdatadog (4.0.0.1.0-x86_64-linux)
+    libdatadog (5.0.0.1.0-aarch64-linux)
+    libdatadog (5.0.0.1.0-x86_64-linux)
     libddwaf (1.14.0.0.0-aarch64-linux)
       ffi (~> 1.0)
     libddwaf (1.14.0.0.0-x86_64-linux)

--- a/gemfiles/ruby_2.7_redis_3.gemfile.lock
+++ b/gemfiles/ruby_2.7_redis_3.gemfile.lock
@@ -14,7 +14,7 @@ PATH
     ddtrace (1.14.0)
       datadog-ci (~> 0.1.0)
       debase-ruby_core_source (= 3.2.2)
-      libdatadog (~> 4.0.0.1.0)
+      libdatadog (~> 5.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
 
@@ -55,8 +55,8 @@ GEM
     json (2.6.3)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (4.0.0.1.0-aarch64-linux)
-    libdatadog (4.0.0.1.0-x86_64-linux)
+    libdatadog (5.0.0.1.0-aarch64-linux)
+    libdatadog (5.0.0.1.0-x86_64-linux)
     libddwaf (1.14.0.0.0-aarch64-linux)
       ffi (~> 1.0)
     libddwaf (1.14.0.0.0-x86_64-linux)

--- a/gemfiles/ruby_2.7_redis_4.gemfile.lock
+++ b/gemfiles/ruby_2.7_redis_4.gemfile.lock
@@ -14,7 +14,7 @@ PATH
     ddtrace (1.14.0)
       datadog-ci (~> 0.1.0)
       debase-ruby_core_source (= 3.2.2)
-      libdatadog (~> 4.0.0.1.0)
+      libdatadog (~> 5.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
 
@@ -55,8 +55,8 @@ GEM
     json (2.6.3)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (4.0.0.1.0-aarch64-linux)
-    libdatadog (4.0.0.1.0-x86_64-linux)
+    libdatadog (5.0.0.1.0-aarch64-linux)
+    libdatadog (5.0.0.1.0-x86_64-linux)
     libddwaf (1.14.0.0.0-aarch64-linux)
       ffi (~> 1.0)
     libddwaf (1.14.0.0.0-x86_64-linux)

--- a/gemfiles/ruby_2.7_redis_5.gemfile.lock
+++ b/gemfiles/ruby_2.7_redis_5.gemfile.lock
@@ -14,7 +14,7 @@ PATH
     ddtrace (1.14.0)
       datadog-ci (~> 0.1.0)
       debase-ruby_core_source (= 3.2.2)
-      libdatadog (~> 4.0.0.1.0)
+      libdatadog (~> 5.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
 
@@ -56,8 +56,8 @@ GEM
     json (2.6.3)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (4.0.0.1.0-aarch64-linux)
-    libdatadog (4.0.0.1.0-x86_64-linux)
+    libdatadog (5.0.0.1.0-aarch64-linux)
+    libdatadog (5.0.0.1.0-x86_64-linux)
     libddwaf (1.14.0.0.0-aarch64-linux)
       ffi (~> 1.0)
     libddwaf (1.14.0.0.0-x86_64-linux)

--- a/gemfiles/ruby_2.7_relational_db.gemfile.lock
+++ b/gemfiles/ruby_2.7_relational_db.gemfile.lock
@@ -14,7 +14,7 @@ PATH
     ddtrace (1.14.0)
       datadog-ci (~> 0.1.0)
       debase-ruby_core_source (= 3.2.2)
-      libdatadog (~> 4.0.0.1.0)
+      libdatadog (~> 5.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
 
@@ -73,8 +73,8 @@ GEM
     json (2.6.3)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (4.0.0.1.0-aarch64-linux)
-    libdatadog (4.0.0.1.0-x86_64-linux)
+    libdatadog (5.0.0.1.0-aarch64-linux)
+    libdatadog (5.0.0.1.0-x86_64-linux)
     libddwaf (1.14.0.0.0-aarch64-linux)
       ffi (~> 1.0)
     libddwaf (1.14.0.0.0-x86_64-linux)

--- a/gemfiles/ruby_2.7_resque2_redis3.gemfile.lock
+++ b/gemfiles/ruby_2.7_resque2_redis3.gemfile.lock
@@ -14,7 +14,7 @@ PATH
     ddtrace (1.14.0)
       datadog-ci (~> 0.1.0)
       debase-ruby_core_source (= 3.2.2)
-      libdatadog (~> 4.0.0.1.0)
+      libdatadog (~> 5.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
 
@@ -55,8 +55,8 @@ GEM
     json (2.6.3)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (4.0.0.1.0-aarch64-linux)
-    libdatadog (4.0.0.1.0-x86_64-linux)
+    libdatadog (5.0.0.1.0-aarch64-linux)
+    libdatadog (5.0.0.1.0-x86_64-linux)
     libddwaf (1.14.0.0.0-aarch64-linux)
       ffi (~> 1.0)
     libddwaf (1.14.0.0.0-x86_64-linux)

--- a/gemfiles/ruby_2.7_resque2_redis4.gemfile.lock
+++ b/gemfiles/ruby_2.7_resque2_redis4.gemfile.lock
@@ -14,7 +14,7 @@ PATH
     ddtrace (1.14.0)
       datadog-ci (~> 0.1.0)
       debase-ruby_core_source (= 3.2.2)
-      libdatadog (~> 4.0.0.1.0)
+      libdatadog (~> 5.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
 
@@ -55,8 +55,8 @@ GEM
     json (2.6.3)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (4.0.0.1.0-aarch64-linux)
-    libdatadog (4.0.0.1.0-x86_64-linux)
+    libdatadog (5.0.0.1.0-aarch64-linux)
+    libdatadog (5.0.0.1.0-x86_64-linux)
     libddwaf (1.14.0.0.0-aarch64-linux)
       ffi (~> 1.0)
     libddwaf (1.14.0.0.0-x86_64-linux)

--- a/gemfiles/ruby_2.7_sinatra.gemfile.lock
+++ b/gemfiles/ruby_2.7_sinatra.gemfile.lock
@@ -14,7 +14,7 @@ PATH
     ddtrace (1.14.0)
       datadog-ci (~> 0.1.0)
       debase-ruby_core_source (= 3.2.2)
-      libdatadog (~> 4.0.0.1.0)
+      libdatadog (~> 5.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
 
@@ -55,8 +55,8 @@ GEM
     json (2.6.3)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (4.0.0.1.0-aarch64-linux)
-    libdatadog (4.0.0.1.0-x86_64-linux)
+    libdatadog (5.0.0.1.0-aarch64-linux)
+    libdatadog (5.0.0.1.0-x86_64-linux)
     libddwaf (1.14.0.0.0-aarch64-linux)
       ffi (~> 1.0)
     libddwaf (1.14.0.0.0-x86_64-linux)

--- a/gemfiles/ruby_3.0_activesupport.gemfile.lock
+++ b/gemfiles/ruby_3.0_activesupport.gemfile.lock
@@ -14,7 +14,7 @@ PATH
     ddtrace (1.14.0)
       datadog-ci (~> 0.1.0)
       debase-ruby_core_source (= 3.2.2)
-      libdatadog (~> 4.0.0.1.0)
+      libdatadog (~> 5.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
 
@@ -111,8 +111,8 @@ GEM
       addressable (>= 2.4)
     jsonapi-renderer (0.2.2)
     king_konf (1.0.1)
-    libdatadog (4.0.0.1.0-aarch64-linux)
-    libdatadog (4.0.0.1.0-x86_64-linux)
+    libdatadog (5.0.0.1.0-aarch64-linux)
+    libdatadog (5.0.0.1.0-x86_64-linux)
     libddwaf (1.14.0.0.0-aarch64-linux)
       ffi (~> 1.0)
     libddwaf (1.14.0.0.0-x86_64-linux)

--- a/gemfiles/ruby_3.0_aws.gemfile.lock
+++ b/gemfiles/ruby_3.0_aws.gemfile.lock
@@ -14,7 +14,7 @@ PATH
     ddtrace (1.14.0)
       datadog-ci (~> 0.1.0)
       debase-ruby_core_source (= 3.2.2)
-      libdatadog (~> 4.0.0.1.0)
+      libdatadog (~> 5.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
 
@@ -1477,8 +1477,8 @@ GEM
     json (2.6.3)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (4.0.0.1.0-aarch64-linux)
-    libdatadog (4.0.0.1.0-x86_64-linux)
+    libdatadog (5.0.0.1.0-aarch64-linux)
+    libdatadog (5.0.0.1.0-x86_64-linux)
     libddwaf (1.14.0.0.0-aarch64-linux)
       ffi (~> 1.0)
     libddwaf (1.14.0.0.0-x86_64-linux)

--- a/gemfiles/ruby_3.0_contrib.gemfile.lock
+++ b/gemfiles/ruby_3.0_contrib.gemfile.lock
@@ -14,7 +14,7 @@ PATH
     ddtrace (1.14.0)
       datadog-ci (~> 0.1.0)
       debase-ruby_core_source (= 3.2.2)
-      libdatadog (~> 4.0.0.1.0)
+      libdatadog (~> 5.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
 
@@ -71,8 +71,8 @@ GEM
     json (2.6.3)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (4.0.0.1.0-aarch64-linux)
-    libdatadog (4.0.0.1.0-x86_64-linux)
+    libdatadog (5.0.0.1.0-aarch64-linux)
+    libdatadog (5.0.0.1.0-x86_64-linux)
     libddwaf (1.14.0.0.0-aarch64-linux)
       ffi (~> 1.0)
     libddwaf (1.14.0.0.0-x86_64-linux)

--- a/gemfiles/ruby_3.0_contrib_old.gemfile.lock
+++ b/gemfiles/ruby_3.0_contrib_old.gemfile.lock
@@ -14,7 +14,7 @@ PATH
     ddtrace (1.14.0)
       datadog-ci (~> 0.1.0)
       debase-ruby_core_source (= 3.2.2)
-      libdatadog (~> 4.0.0.1.0)
+      libdatadog (~> 5.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
 
@@ -75,8 +75,8 @@ GEM
     json (2.6.3)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (4.0.0.1.0-aarch64-linux)
-    libdatadog (4.0.0.1.0-x86_64-linux)
+    libdatadog (5.0.0.1.0-aarch64-linux)
+    libdatadog (5.0.0.1.0-x86_64-linux)
     libddwaf (1.14.0.0.0-aarch64-linux)
       ffi (~> 1.0)
     libddwaf (1.14.0.0.0-x86_64-linux)

--- a/gemfiles/ruby_3.0_core_old.gemfile.lock
+++ b/gemfiles/ruby_3.0_core_old.gemfile.lock
@@ -14,7 +14,7 @@ PATH
     ddtrace (1.14.0)
       datadog-ci (~> 0.1.0)
       debase-ruby_core_source (= 3.2.2)
-      libdatadog (~> 4.0.0.1.0)
+      libdatadog (~> 5.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
 
@@ -55,8 +55,8 @@ GEM
     json (2.6.3)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (4.0.0.1.0-aarch64-linux)
-    libdatadog (4.0.0.1.0-x86_64-linux)
+    libdatadog (5.0.0.1.0-aarch64-linux)
+    libdatadog (5.0.0.1.0-x86_64-linux)
     libddwaf (1.14.0.0.0-aarch64-linux)
       ffi (~> 1.0)
     libddwaf (1.14.0.0.0-x86_64-linux)

--- a/gemfiles/ruby_3.0_http.gemfile.lock
+++ b/gemfiles/ruby_3.0_http.gemfile.lock
@@ -14,7 +14,7 @@ PATH
     ddtrace (1.14.0)
       datadog-ci (~> 0.1.0)
       debase-ruby_core_source (= 3.2.2)
-      libdatadog (~> 4.0.0.1.0)
+      libdatadog (~> 5.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
 
@@ -85,8 +85,8 @@ GEM
     json (2.6.3)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (4.0.0.1.0-aarch64-linux)
-    libdatadog (4.0.0.1.0-x86_64-linux)
+    libdatadog (5.0.0.1.0-aarch64-linux)
+    libdatadog (5.0.0.1.0-x86_64-linux)
     libddwaf (1.14.0.0.0-aarch64-linux)
       ffi (~> 1.0)
     libddwaf (1.14.0.0.0-x86_64-linux)

--- a/gemfiles/ruby_3.0_opentelemetry.gemfile.lock
+++ b/gemfiles/ruby_3.0_opentelemetry.gemfile.lock
@@ -14,7 +14,7 @@ PATH
     ddtrace (1.14.0)
       datadog-ci (~> 0.1.0)
       debase-ruby_core_source (= 3.2.2)
-      libdatadog (~> 4.0.0.1.0)
+      libdatadog (~> 5.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
 
@@ -55,8 +55,8 @@ GEM
     json (2.6.3)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (4.0.0.1.0-aarch64-linux)
-    libdatadog (4.0.0.1.0-x86_64-linux)
+    libdatadog (5.0.0.1.0-aarch64-linux)
+    libdatadog (5.0.0.1.0-x86_64-linux)
     libddwaf (1.14.0.0.0-aarch64-linux)
       ffi (~> 1.0)
     libddwaf (1.14.0.0.0-x86_64-linux)

--- a/gemfiles/ruby_3.0_opentracing.gemfile.lock
+++ b/gemfiles/ruby_3.0_opentracing.gemfile.lock
@@ -14,7 +14,7 @@ PATH
     ddtrace (1.14.0)
       datadog-ci (~> 0.1.0)
       debase-ruby_core_source (= 3.2.2)
-      libdatadog (~> 4.0.0.1.0)
+      libdatadog (~> 5.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
 
@@ -56,8 +56,8 @@ GEM
     json (2.6.3)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (4.0.0.1.0-aarch64-linux)
-    libdatadog (4.0.0.1.0-x86_64-linux)
+    libdatadog (5.0.0.1.0-aarch64-linux)
+    libdatadog (5.0.0.1.0-x86_64-linux)
     libddwaf (1.14.0.0.0-aarch64-linux)
       ffi (~> 1.0)
     libddwaf (1.14.0.0.0-x86_64-linux)

--- a/gemfiles/ruby_3.0_rack_1.gemfile.lock
+++ b/gemfiles/ruby_3.0_rack_1.gemfile.lock
@@ -14,7 +14,7 @@ PATH
     ddtrace (1.14.0)
       datadog-ci (~> 0.1.0)
       debase-ruby_core_source (= 3.2.2)
-      libdatadog (~> 4.0.0.1.0)
+      libdatadog (~> 5.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
 
@@ -55,8 +55,8 @@ GEM
     json (2.6.3)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (4.0.0.1.0-aarch64-linux)
-    libdatadog (4.0.0.1.0-x86_64-linux)
+    libdatadog (5.0.0.1.0-aarch64-linux)
+    libdatadog (5.0.0.1.0-x86_64-linux)
     libddwaf (1.14.0.0.0-aarch64-linux)
       ffi (~> 1.0)
     libddwaf (1.14.0.0.0-x86_64-linux)

--- a/gemfiles/ruby_3.0_rack_2.gemfile.lock
+++ b/gemfiles/ruby_3.0_rack_2.gemfile.lock
@@ -14,7 +14,7 @@ PATH
     ddtrace (1.14.0)
       datadog-ci (~> 0.1.0)
       debase-ruby_core_source (= 3.2.2)
-      libdatadog (~> 4.0.0.1.0)
+      libdatadog (~> 5.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
 
@@ -55,8 +55,8 @@ GEM
     json (2.6.3)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (4.0.0.1.0-aarch64-linux)
-    libdatadog (4.0.0.1.0-x86_64-linux)
+    libdatadog (5.0.0.1.0-aarch64-linux)
+    libdatadog (5.0.0.1.0-x86_64-linux)
     libddwaf (1.14.0.0.0-aarch64-linux)
       ffi (~> 1.0)
     libddwaf (1.14.0.0.0-x86_64-linux)

--- a/gemfiles/ruby_3.0_rack_3.gemfile.lock
+++ b/gemfiles/ruby_3.0_rack_3.gemfile.lock
@@ -14,7 +14,7 @@ PATH
     ddtrace (1.14.0)
       datadog-ci (~> 0.1.0)
       debase-ruby_core_source (= 3.2.2)
-      libdatadog (~> 4.0.0.1.0)
+      libdatadog (~> 5.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
 
@@ -55,8 +55,8 @@ GEM
     json (2.6.3)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (4.0.0.1.0-aarch64-linux)
-    libdatadog (4.0.0.1.0-x86_64-linux)
+    libdatadog (5.0.0.1.0-aarch64-linux)
+    libdatadog (5.0.0.1.0-x86_64-linux)
     libddwaf (1.14.0.0.0-aarch64-linux)
       ffi (~> 1.0)
     libddwaf (1.14.0.0.0-x86_64-linux)

--- a/gemfiles/ruby_3.0_rails61_mysql2.gemfile.lock
+++ b/gemfiles/ruby_3.0_rails61_mysql2.gemfile.lock
@@ -14,7 +14,7 @@ PATH
     ddtrace (1.14.0)
       datadog-ci (~> 0.1.0)
       debase-ruby_core_source (= 3.2.2)
-      libdatadog (~> 4.0.0.1.0)
+      libdatadog (~> 5.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
 
@@ -121,8 +121,8 @@ GEM
     json (2.6.3)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (4.0.0.1.0-aarch64-linux)
-    libdatadog (4.0.0.1.0-x86_64-linux)
+    libdatadog (5.0.0.1.0-aarch64-linux)
+    libdatadog (5.0.0.1.0-x86_64-linux)
     libddwaf (1.14.0.0.0-aarch64-linux)
       ffi (~> 1.0)
     libddwaf (1.14.0.0.0-x86_64-linux)

--- a/gemfiles/ruby_3.0_rails61_postgres.gemfile.lock
+++ b/gemfiles/ruby_3.0_rails61_postgres.gemfile.lock
@@ -14,7 +14,7 @@ PATH
     ddtrace (1.14.0)
       datadog-ci (~> 0.1.0)
       debase-ruby_core_source (= 3.2.2)
-      libdatadog (~> 4.0.0.1.0)
+      libdatadog (~> 5.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
 
@@ -121,8 +121,8 @@ GEM
     json (2.6.3)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (4.0.0.1.0-aarch64-linux)
-    libdatadog (4.0.0.1.0-x86_64-linux)
+    libdatadog (5.0.0.1.0-aarch64-linux)
+    libdatadog (5.0.0.1.0-x86_64-linux)
     libddwaf (1.14.0.0.0-aarch64-linux)
       ffi (~> 1.0)
     libddwaf (1.14.0.0.0-x86_64-linux)

--- a/gemfiles/ruby_3.0_rails61_postgres_redis.gemfile.lock
+++ b/gemfiles/ruby_3.0_rails61_postgres_redis.gemfile.lock
@@ -14,7 +14,7 @@ PATH
     ddtrace (1.14.0)
       datadog-ci (~> 0.1.0)
       debase-ruby_core_source (= 3.2.2)
-      libdatadog (~> 4.0.0.1.0)
+      libdatadog (~> 5.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
 
@@ -121,8 +121,8 @@ GEM
     json (2.6.3)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (4.0.0.1.0-aarch64-linux)
-    libdatadog (4.0.0.1.0-x86_64-linux)
+    libdatadog (5.0.0.1.0-aarch64-linux)
+    libdatadog (5.0.0.1.0-x86_64-linux)
     libddwaf (1.14.0.0.0-aarch64-linux)
       ffi (~> 1.0)
     libddwaf (1.14.0.0.0-x86_64-linux)

--- a/gemfiles/ruby_3.0_rails61_postgres_sidekiq.gemfile.lock
+++ b/gemfiles/ruby_3.0_rails61_postgres_sidekiq.gemfile.lock
@@ -14,7 +14,7 @@ PATH
     ddtrace (1.14.0)
       datadog-ci (~> 0.1.0)
       debase-ruby_core_source (= 3.2.2)
-      libdatadog (~> 4.0.0.1.0)
+      libdatadog (~> 5.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
 
@@ -122,8 +122,8 @@ GEM
     json (2.6.3)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (4.0.0.1.0-aarch64-linux)
-    libdatadog (4.0.0.1.0-x86_64-linux)
+    libdatadog (5.0.0.1.0-aarch64-linux)
+    libdatadog (5.0.0.1.0-x86_64-linux)
     libddwaf (1.14.0.0.0-aarch64-linux)
       ffi (~> 1.0)
     libddwaf (1.14.0.0.0-x86_64-linux)

--- a/gemfiles/ruby_3.0_rails61_semantic_logger.gemfile.lock
+++ b/gemfiles/ruby_3.0_rails61_semantic_logger.gemfile.lock
@@ -14,7 +14,7 @@ PATH
     ddtrace (1.14.0)
       datadog-ci (~> 0.1.0)
       debase-ruby_core_source (= 3.2.2)
-      libdatadog (~> 4.0.0.1.0)
+      libdatadog (~> 5.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
 
@@ -121,8 +121,8 @@ GEM
     json (2.6.3)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (4.0.0.1.0-aarch64-linux)
-    libdatadog (4.0.0.1.0-x86_64-linux)
+    libdatadog (5.0.0.1.0-aarch64-linux)
+    libdatadog (5.0.0.1.0-x86_64-linux)
     libddwaf (1.14.0.0.0-aarch64-linux)
       ffi (~> 1.0)
     libddwaf (1.14.0.0.0-x86_64-linux)

--- a/gemfiles/ruby_3.0_redis_3.gemfile.lock
+++ b/gemfiles/ruby_3.0_redis_3.gemfile.lock
@@ -14,7 +14,7 @@ PATH
     ddtrace (1.14.0)
       datadog-ci (~> 0.1.0)
       debase-ruby_core_source (= 3.2.2)
-      libdatadog (~> 4.0.0.1.0)
+      libdatadog (~> 5.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
 
@@ -55,8 +55,8 @@ GEM
     json (2.6.3)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (4.0.0.1.0-aarch64-linux)
-    libdatadog (4.0.0.1.0-x86_64-linux)
+    libdatadog (5.0.0.1.0-aarch64-linux)
+    libdatadog (5.0.0.1.0-x86_64-linux)
     libddwaf (1.14.0.0.0-aarch64-linux)
       ffi (~> 1.0)
     libddwaf (1.14.0.0.0-x86_64-linux)

--- a/gemfiles/ruby_3.0_redis_4.gemfile.lock
+++ b/gemfiles/ruby_3.0_redis_4.gemfile.lock
@@ -14,7 +14,7 @@ PATH
     ddtrace (1.14.0)
       datadog-ci (~> 0.1.0)
       debase-ruby_core_source (= 3.2.2)
-      libdatadog (~> 4.0.0.1.0)
+      libdatadog (~> 5.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
 
@@ -55,8 +55,8 @@ GEM
     json (2.6.3)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (4.0.0.1.0-aarch64-linux)
-    libdatadog (4.0.0.1.0-x86_64-linux)
+    libdatadog (5.0.0.1.0-aarch64-linux)
+    libdatadog (5.0.0.1.0-x86_64-linux)
     libddwaf (1.14.0.0.0-aarch64-linux)
       ffi (~> 1.0)
     libddwaf (1.14.0.0.0-x86_64-linux)

--- a/gemfiles/ruby_3.0_redis_5.gemfile.lock
+++ b/gemfiles/ruby_3.0_redis_5.gemfile.lock
@@ -14,7 +14,7 @@ PATH
     ddtrace (1.14.0)
       datadog-ci (~> 0.1.0)
       debase-ruby_core_source (= 3.2.2)
-      libdatadog (~> 4.0.0.1.0)
+      libdatadog (~> 5.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
 
@@ -56,8 +56,8 @@ GEM
     json (2.6.3)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (4.0.0.1.0-aarch64-linux)
-    libdatadog (4.0.0.1.0-x86_64-linux)
+    libdatadog (5.0.0.1.0-aarch64-linux)
+    libdatadog (5.0.0.1.0-x86_64-linux)
     libddwaf (1.14.0.0.0-aarch64-linux)
       ffi (~> 1.0)
     libddwaf (1.14.0.0.0-x86_64-linux)

--- a/gemfiles/ruby_3.0_relational_db.gemfile.lock
+++ b/gemfiles/ruby_3.0_relational_db.gemfile.lock
@@ -14,7 +14,7 @@ PATH
     ddtrace (1.14.0)
       datadog-ci (~> 0.1.0)
       debase-ruby_core_source (= 3.2.2)
-      libdatadog (~> 4.0.0.1.0)
+      libdatadog (~> 5.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
 
@@ -72,8 +72,8 @@ GEM
     json (2.6.3)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (4.0.0.1.0-aarch64-linux)
-    libdatadog (4.0.0.1.0-x86_64-linux)
+    libdatadog (5.0.0.1.0-aarch64-linux)
+    libdatadog (5.0.0.1.0-x86_64-linux)
     libddwaf (1.14.0.0.0-aarch64-linux)
       ffi (~> 1.0)
     libddwaf (1.14.0.0.0-x86_64-linux)

--- a/gemfiles/ruby_3.0_resque2_redis3.gemfile.lock
+++ b/gemfiles/ruby_3.0_resque2_redis3.gemfile.lock
@@ -14,7 +14,7 @@ PATH
     ddtrace (1.14.0)
       datadog-ci (~> 0.1.0)
       debase-ruby_core_source (= 3.2.2)
-      libdatadog (~> 4.0.0.1.0)
+      libdatadog (~> 5.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
 
@@ -55,8 +55,8 @@ GEM
     json (2.6.3)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (4.0.0.1.0-aarch64-linux)
-    libdatadog (4.0.0.1.0-x86_64-linux)
+    libdatadog (5.0.0.1.0-aarch64-linux)
+    libdatadog (5.0.0.1.0-x86_64-linux)
     libddwaf (1.14.0.0.0-aarch64-linux)
       ffi (~> 1.0)
     libddwaf (1.14.0.0.0-x86_64-linux)

--- a/gemfiles/ruby_3.0_resque2_redis4.gemfile.lock
+++ b/gemfiles/ruby_3.0_resque2_redis4.gemfile.lock
@@ -14,7 +14,7 @@ PATH
     ddtrace (1.14.0)
       datadog-ci (~> 0.1.0)
       debase-ruby_core_source (= 3.2.2)
-      libdatadog (~> 4.0.0.1.0)
+      libdatadog (~> 5.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
 
@@ -56,8 +56,8 @@ GEM
     json (2.6.3)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (4.0.0.1.0-aarch64-linux)
-    libdatadog (4.0.0.1.0-x86_64-linux)
+    libdatadog (5.0.0.1.0-aarch64-linux)
+    libdatadog (5.0.0.1.0-x86_64-linux)
     libddwaf (1.14.0.0.0-aarch64-linux)
       ffi (~> 1.0)
     libddwaf (1.14.0.0.0-x86_64-linux)

--- a/gemfiles/ruby_3.0_sinatra.gemfile.lock
+++ b/gemfiles/ruby_3.0_sinatra.gemfile.lock
@@ -14,7 +14,7 @@ PATH
     ddtrace (1.14.0)
       datadog-ci (~> 0.1.0)
       debase-ruby_core_source (= 3.2.2)
-      libdatadog (~> 4.0.0.1.0)
+      libdatadog (~> 5.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
 
@@ -55,8 +55,8 @@ GEM
     json (2.6.3)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (4.0.0.1.0-aarch64-linux)
-    libdatadog (4.0.0.1.0-x86_64-linux)
+    libdatadog (5.0.0.1.0-aarch64-linux)
+    libdatadog (5.0.0.1.0-x86_64-linux)
     libddwaf (1.14.0.0.0-aarch64-linux)
       ffi (~> 1.0)
     libddwaf (1.14.0.0.0-x86_64-linux)

--- a/gemfiles/ruby_3.1_activesupport.gemfile.lock
+++ b/gemfiles/ruby_3.1_activesupport.gemfile.lock
@@ -14,7 +14,7 @@ PATH
     ddtrace (1.14.0)
       datadog-ci (~> 0.1.0)
       debase-ruby_core_source (= 3.2.2)
-      libdatadog (~> 4.0.0.1.0)
+      libdatadog (~> 5.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
 
@@ -111,8 +111,8 @@ GEM
       addressable (>= 2.4)
     jsonapi-renderer (0.2.2)
     king_konf (1.0.1)
-    libdatadog (4.0.0.1.0-aarch64-linux)
-    libdatadog (4.0.0.1.0-x86_64-linux)
+    libdatadog (5.0.0.1.0-aarch64-linux)
+    libdatadog (5.0.0.1.0-x86_64-linux)
     libddwaf (1.14.0.0.0-aarch64-linux)
       ffi (~> 1.0)
     libddwaf (1.14.0.0.0-x86_64-linux)

--- a/gemfiles/ruby_3.1_aws.gemfile.lock
+++ b/gemfiles/ruby_3.1_aws.gemfile.lock
@@ -14,7 +14,7 @@ PATH
     ddtrace (1.14.0)
       datadog-ci (~> 0.1.0)
       debase-ruby_core_source (= 3.2.2)
-      libdatadog (~> 4.0.0.1.0)
+      libdatadog (~> 5.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
 
@@ -1477,8 +1477,8 @@ GEM
     json (2.6.3)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (4.0.0.1.0-aarch64-linux)
-    libdatadog (4.0.0.1.0-x86_64-linux)
+    libdatadog (5.0.0.1.0-aarch64-linux)
+    libdatadog (5.0.0.1.0-x86_64-linux)
     libddwaf (1.14.0.0.0-aarch64-linux)
       ffi (~> 1.0)
     libddwaf (1.14.0.0.0-x86_64-linux)

--- a/gemfiles/ruby_3.1_contrib.gemfile.lock
+++ b/gemfiles/ruby_3.1_contrib.gemfile.lock
@@ -14,7 +14,7 @@ PATH
     ddtrace (1.14.0)
       datadog-ci (~> 0.1.0)
       debase-ruby_core_source (= 3.2.2)
-      libdatadog (~> 4.0.0.1.0)
+      libdatadog (~> 5.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
 
@@ -71,8 +71,8 @@ GEM
     json (2.6.3)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (4.0.0.1.0-aarch64-linux)
-    libdatadog (4.0.0.1.0-x86_64-linux)
+    libdatadog (5.0.0.1.0-aarch64-linux)
+    libdatadog (5.0.0.1.0-x86_64-linux)
     libddwaf (1.14.0.0.0-aarch64-linux)
       ffi (~> 1.0)
     libddwaf (1.14.0.0.0-x86_64-linux)

--- a/gemfiles/ruby_3.1_contrib_old.gemfile.lock
+++ b/gemfiles/ruby_3.1_contrib_old.gemfile.lock
@@ -14,7 +14,7 @@ PATH
     ddtrace (1.14.0)
       datadog-ci (~> 0.1.0)
       debase-ruby_core_source (= 3.2.2)
-      libdatadog (~> 4.0.0.1.0)
+      libdatadog (~> 5.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
 
@@ -75,8 +75,8 @@ GEM
     json (2.6.3)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (4.0.0.1.0-aarch64-linux)
-    libdatadog (4.0.0.1.0-x86_64-linux)
+    libdatadog (5.0.0.1.0-aarch64-linux)
+    libdatadog (5.0.0.1.0-x86_64-linux)
     libddwaf (1.14.0.0.0-aarch64-linux)
       ffi (~> 1.0)
     libddwaf (1.14.0.0.0-x86_64-linux)

--- a/gemfiles/ruby_3.1_core_old.gemfile.lock
+++ b/gemfiles/ruby_3.1_core_old.gemfile.lock
@@ -14,7 +14,7 @@ PATH
     ddtrace (1.14.0)
       datadog-ci (~> 0.1.0)
       debase-ruby_core_source (= 3.2.2)
-      libdatadog (~> 4.0.0.1.0)
+      libdatadog (~> 5.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
 
@@ -55,8 +55,8 @@ GEM
     json (2.6.3)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (4.0.0.1.0-aarch64-linux)
-    libdatadog (4.0.0.1.0-x86_64-linux)
+    libdatadog (5.0.0.1.0-aarch64-linux)
+    libdatadog (5.0.0.1.0-x86_64-linux)
     libddwaf (1.14.0.0.0-aarch64-linux)
       ffi (~> 1.0)
     libddwaf (1.14.0.0.0-x86_64-linux)

--- a/gemfiles/ruby_3.1_http.gemfile.lock
+++ b/gemfiles/ruby_3.1_http.gemfile.lock
@@ -14,7 +14,7 @@ PATH
     ddtrace (1.14.0)
       datadog-ci (~> 0.1.0)
       debase-ruby_core_source (= 3.2.2)
-      libdatadog (~> 4.0.0.1.0)
+      libdatadog (~> 5.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
 
@@ -85,8 +85,8 @@ GEM
     json (2.6.3)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (4.0.0.1.0-aarch64-linux)
-    libdatadog (4.0.0.1.0-x86_64-linux)
+    libdatadog (5.0.0.1.0-aarch64-linux)
+    libdatadog (5.0.0.1.0-x86_64-linux)
     libddwaf (1.14.0.0.0-aarch64-linux)
       ffi (~> 1.0)
     libddwaf (1.14.0.0.0-x86_64-linux)

--- a/gemfiles/ruby_3.1_opentelemetry.gemfile.lock
+++ b/gemfiles/ruby_3.1_opentelemetry.gemfile.lock
@@ -14,7 +14,7 @@ PATH
     ddtrace (1.14.0)
       datadog-ci (~> 0.1.0)
       debase-ruby_core_source (= 3.2.2)
-      libdatadog (~> 4.0.0.1.0)
+      libdatadog (~> 5.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
 
@@ -56,9 +56,9 @@ GEM
     json (2.6.3)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (4.0.0.1.0)
-    libdatadog (4.0.0.1.0-aarch64-linux)
-    libdatadog (4.0.0.1.0-x86_64-linux)
+    libdatadog (5.0.0.1.0)
+    libdatadog (5.0.0.1.0-aarch64-linux)
+    libdatadog (5.0.0.1.0-x86_64-linux)
     libddwaf (1.14.0.0.0-aarch64-linux)
       ffi (~> 1.0)
     libddwaf (1.14.0.0.0-x86_64-darwin)

--- a/gemfiles/ruby_3.1_opentracing.gemfile.lock
+++ b/gemfiles/ruby_3.1_opentracing.gemfile.lock
@@ -14,7 +14,7 @@ PATH
     ddtrace (1.14.0)
       datadog-ci (~> 0.1.0)
       debase-ruby_core_source (= 3.2.2)
-      libdatadog (~> 4.0.0.1.0)
+      libdatadog (~> 5.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
 
@@ -56,8 +56,8 @@ GEM
     json (2.6.3)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (4.0.0.1.0-aarch64-linux)
-    libdatadog (4.0.0.1.0-x86_64-linux)
+    libdatadog (5.0.0.1.0-aarch64-linux)
+    libdatadog (5.0.0.1.0-x86_64-linux)
     libddwaf (1.14.0.0.0-aarch64-linux)
       ffi (~> 1.0)
     libddwaf (1.14.0.0.0-x86_64-linux)

--- a/gemfiles/ruby_3.1_rack_1.gemfile.lock
+++ b/gemfiles/ruby_3.1_rack_1.gemfile.lock
@@ -14,7 +14,7 @@ PATH
     ddtrace (1.14.0)
       datadog-ci (~> 0.1.0)
       debase-ruby_core_source (= 3.2.2)
-      libdatadog (~> 4.0.0.1.0)
+      libdatadog (~> 5.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
 
@@ -55,8 +55,8 @@ GEM
     json (2.6.3)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (4.0.0.1.0-aarch64-linux)
-    libdatadog (4.0.0.1.0-x86_64-linux)
+    libdatadog (5.0.0.1.0-aarch64-linux)
+    libdatadog (5.0.0.1.0-x86_64-linux)
     libddwaf (1.14.0.0.0-aarch64-linux)
       ffi (~> 1.0)
     libddwaf (1.14.0.0.0-x86_64-linux)

--- a/gemfiles/ruby_3.1_rack_2.gemfile.lock
+++ b/gemfiles/ruby_3.1_rack_2.gemfile.lock
@@ -14,7 +14,7 @@ PATH
     ddtrace (1.14.0)
       datadog-ci (~> 0.1.0)
       debase-ruby_core_source (= 3.2.2)
-      libdatadog (~> 4.0.0.1.0)
+      libdatadog (~> 5.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
 
@@ -55,8 +55,8 @@ GEM
     json (2.6.3)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (4.0.0.1.0-aarch64-linux)
-    libdatadog (4.0.0.1.0-x86_64-linux)
+    libdatadog (5.0.0.1.0-aarch64-linux)
+    libdatadog (5.0.0.1.0-x86_64-linux)
     libddwaf (1.14.0.0.0-aarch64-linux)
       ffi (~> 1.0)
     libddwaf (1.14.0.0.0-x86_64-linux)

--- a/gemfiles/ruby_3.1_rack_3.gemfile.lock
+++ b/gemfiles/ruby_3.1_rack_3.gemfile.lock
@@ -14,7 +14,7 @@ PATH
     ddtrace (1.14.0)
       datadog-ci (~> 0.1.0)
       debase-ruby_core_source (= 3.2.2)
-      libdatadog (~> 4.0.0.1.0)
+      libdatadog (~> 5.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
 
@@ -55,8 +55,8 @@ GEM
     json (2.6.3)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (4.0.0.1.0-aarch64-linux)
-    libdatadog (4.0.0.1.0-x86_64-linux)
+    libdatadog (5.0.0.1.0-aarch64-linux)
+    libdatadog (5.0.0.1.0-x86_64-linux)
     libddwaf (1.14.0.0.0-aarch64-linux)
       ffi (~> 1.0)
     libddwaf (1.14.0.0.0-x86_64-linux)

--- a/gemfiles/ruby_3.1_rails61_mysql2.gemfile.lock
+++ b/gemfiles/ruby_3.1_rails61_mysql2.gemfile.lock
@@ -14,7 +14,7 @@ PATH
     ddtrace (1.14.0)
       datadog-ci (~> 0.1.0)
       debase-ruby_core_source (= 3.2.2)
-      libdatadog (~> 4.0.0.1.0)
+      libdatadog (~> 5.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
 
@@ -121,8 +121,8 @@ GEM
     json (2.6.3)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (4.0.0.1.0-aarch64-linux)
-    libdatadog (4.0.0.1.0-x86_64-linux)
+    libdatadog (5.0.0.1.0-aarch64-linux)
+    libdatadog (5.0.0.1.0-x86_64-linux)
     libddwaf (1.14.0.0.0-aarch64-linux)
       ffi (~> 1.0)
     libddwaf (1.14.0.0.0-x86_64-linux)

--- a/gemfiles/ruby_3.1_rails61_postgres.gemfile.lock
+++ b/gemfiles/ruby_3.1_rails61_postgres.gemfile.lock
@@ -14,7 +14,7 @@ PATH
     ddtrace (1.14.0)
       datadog-ci (~> 0.1.0)
       debase-ruby_core_source (= 3.2.2)
-      libdatadog (~> 4.0.0.1.0)
+      libdatadog (~> 5.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
 
@@ -121,8 +121,8 @@ GEM
     json (2.6.3)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (4.0.0.1.0-aarch64-linux)
-    libdatadog (4.0.0.1.0-x86_64-linux)
+    libdatadog (5.0.0.1.0-aarch64-linux)
+    libdatadog (5.0.0.1.0-x86_64-linux)
     libddwaf (1.14.0.0.0-aarch64-linux)
       ffi (~> 1.0)
     libddwaf (1.14.0.0.0-x86_64-linux)

--- a/gemfiles/ruby_3.1_rails61_postgres_redis.gemfile.lock
+++ b/gemfiles/ruby_3.1_rails61_postgres_redis.gemfile.lock
@@ -14,7 +14,7 @@ PATH
     ddtrace (1.14.0)
       datadog-ci (~> 0.1.0)
       debase-ruby_core_source (= 3.2.2)
-      libdatadog (~> 4.0.0.1.0)
+      libdatadog (~> 5.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
 
@@ -121,8 +121,8 @@ GEM
     json (2.6.3)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (4.0.0.1.0-aarch64-linux)
-    libdatadog (4.0.0.1.0-x86_64-linux)
+    libdatadog (5.0.0.1.0-aarch64-linux)
+    libdatadog (5.0.0.1.0-x86_64-linux)
     libddwaf (1.14.0.0.0-aarch64-linux)
       ffi (~> 1.0)
     libddwaf (1.14.0.0.0-x86_64-linux)

--- a/gemfiles/ruby_3.1_rails61_postgres_sidekiq.gemfile.lock
+++ b/gemfiles/ruby_3.1_rails61_postgres_sidekiq.gemfile.lock
@@ -14,7 +14,7 @@ PATH
     ddtrace (1.14.0)
       datadog-ci (~> 0.1.0)
       debase-ruby_core_source (= 3.2.2)
-      libdatadog (~> 4.0.0.1.0)
+      libdatadog (~> 5.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
 
@@ -122,8 +122,8 @@ GEM
     json (2.6.3)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (4.0.0.1.0-aarch64-linux)
-    libdatadog (4.0.0.1.0-x86_64-linux)
+    libdatadog (5.0.0.1.0-aarch64-linux)
+    libdatadog (5.0.0.1.0-x86_64-linux)
     libddwaf (1.14.0.0.0-aarch64-linux)
       ffi (~> 1.0)
     libddwaf (1.14.0.0.0-x86_64-linux)

--- a/gemfiles/ruby_3.1_rails61_semantic_logger.gemfile.lock
+++ b/gemfiles/ruby_3.1_rails61_semantic_logger.gemfile.lock
@@ -14,7 +14,7 @@ PATH
     ddtrace (1.14.0)
       datadog-ci (~> 0.1.0)
       debase-ruby_core_source (= 3.2.2)
-      libdatadog (~> 4.0.0.1.0)
+      libdatadog (~> 5.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
 
@@ -121,8 +121,8 @@ GEM
     json (2.6.3)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (4.0.0.1.0-aarch64-linux)
-    libdatadog (4.0.0.1.0-x86_64-linux)
+    libdatadog (5.0.0.1.0-aarch64-linux)
+    libdatadog (5.0.0.1.0-x86_64-linux)
     libddwaf (1.14.0.0.0-aarch64-linux)
       ffi (~> 1.0)
     libddwaf (1.14.0.0.0-x86_64-linux)

--- a/gemfiles/ruby_3.1_redis_3.gemfile.lock
+++ b/gemfiles/ruby_3.1_redis_3.gemfile.lock
@@ -14,7 +14,7 @@ PATH
     ddtrace (1.14.0)
       datadog-ci (~> 0.1.0)
       debase-ruby_core_source (= 3.2.2)
-      libdatadog (~> 4.0.0.1.0)
+      libdatadog (~> 5.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
 
@@ -55,8 +55,8 @@ GEM
     json (2.6.3)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (4.0.0.1.0-aarch64-linux)
-    libdatadog (4.0.0.1.0-x86_64-linux)
+    libdatadog (5.0.0.1.0-aarch64-linux)
+    libdatadog (5.0.0.1.0-x86_64-linux)
     libddwaf (1.14.0.0.0-aarch64-linux)
       ffi (~> 1.0)
     libddwaf (1.14.0.0.0-x86_64-linux)

--- a/gemfiles/ruby_3.1_redis_4.gemfile.lock
+++ b/gemfiles/ruby_3.1_redis_4.gemfile.lock
@@ -14,7 +14,7 @@ PATH
     ddtrace (1.14.0)
       datadog-ci (~> 0.1.0)
       debase-ruby_core_source (= 3.2.2)
-      libdatadog (~> 4.0.0.1.0)
+      libdatadog (~> 5.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
 
@@ -55,8 +55,8 @@ GEM
     json (2.6.3)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (4.0.0.1.0-aarch64-linux)
-    libdatadog (4.0.0.1.0-x86_64-linux)
+    libdatadog (5.0.0.1.0-aarch64-linux)
+    libdatadog (5.0.0.1.0-x86_64-linux)
     libddwaf (1.14.0.0.0-aarch64-linux)
       ffi (~> 1.0)
     libddwaf (1.14.0.0.0-x86_64-linux)

--- a/gemfiles/ruby_3.1_redis_5.gemfile.lock
+++ b/gemfiles/ruby_3.1_redis_5.gemfile.lock
@@ -14,7 +14,7 @@ PATH
     ddtrace (1.14.0)
       datadog-ci (~> 0.1.0)
       debase-ruby_core_source (= 3.2.2)
-      libdatadog (~> 4.0.0.1.0)
+      libdatadog (~> 5.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
 
@@ -56,8 +56,8 @@ GEM
     json (2.6.3)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (4.0.0.1.0-aarch64-linux)
-    libdatadog (4.0.0.1.0-x86_64-linux)
+    libdatadog (5.0.0.1.0-aarch64-linux)
+    libdatadog (5.0.0.1.0-x86_64-linux)
     libddwaf (1.14.0.0.0-aarch64-linux)
       ffi (~> 1.0)
     libddwaf (1.14.0.0.0-x86_64-linux)

--- a/gemfiles/ruby_3.1_relational_db.gemfile.lock
+++ b/gemfiles/ruby_3.1_relational_db.gemfile.lock
@@ -14,7 +14,7 @@ PATH
     ddtrace (1.14.0)
       datadog-ci (~> 0.1.0)
       debase-ruby_core_source (= 3.2.2)
-      libdatadog (~> 4.0.0.1.0)
+      libdatadog (~> 5.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
 
@@ -72,8 +72,8 @@ GEM
     json (2.6.3)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (4.0.0.1.0-aarch64-linux)
-    libdatadog (4.0.0.1.0-x86_64-linux)
+    libdatadog (5.0.0.1.0-aarch64-linux)
+    libdatadog (5.0.0.1.0-x86_64-linux)
     libddwaf (1.14.0.0.0-aarch64-linux)
       ffi (~> 1.0)
     libddwaf (1.14.0.0.0-x86_64-linux)

--- a/gemfiles/ruby_3.1_resque2_redis3.gemfile.lock
+++ b/gemfiles/ruby_3.1_resque2_redis3.gemfile.lock
@@ -14,7 +14,7 @@ PATH
     ddtrace (1.14.0)
       datadog-ci (~> 0.1.0)
       debase-ruby_core_source (= 3.2.2)
-      libdatadog (~> 4.0.0.1.0)
+      libdatadog (~> 5.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
 
@@ -55,8 +55,8 @@ GEM
     json (2.6.3)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (4.0.0.1.0-aarch64-linux)
-    libdatadog (4.0.0.1.0-x86_64-linux)
+    libdatadog (5.0.0.1.0-aarch64-linux)
+    libdatadog (5.0.0.1.0-x86_64-linux)
     libddwaf (1.14.0.0.0-aarch64-linux)
       ffi (~> 1.0)
     libddwaf (1.14.0.0.0-x86_64-linux)

--- a/gemfiles/ruby_3.1_resque2_redis4.gemfile.lock
+++ b/gemfiles/ruby_3.1_resque2_redis4.gemfile.lock
@@ -14,7 +14,7 @@ PATH
     ddtrace (1.14.0)
       datadog-ci (~> 0.1.0)
       debase-ruby_core_source (= 3.2.2)
-      libdatadog (~> 4.0.0.1.0)
+      libdatadog (~> 5.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
 
@@ -56,8 +56,8 @@ GEM
     json (2.6.3)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (4.0.0.1.0-aarch64-linux)
-    libdatadog (4.0.0.1.0-x86_64-linux)
+    libdatadog (5.0.0.1.0-aarch64-linux)
+    libdatadog (5.0.0.1.0-x86_64-linux)
     libddwaf (1.14.0.0.0-aarch64-linux)
       ffi (~> 1.0)
     libddwaf (1.14.0.0.0-x86_64-linux)

--- a/gemfiles/ruby_3.1_sinatra.gemfile.lock
+++ b/gemfiles/ruby_3.1_sinatra.gemfile.lock
@@ -14,7 +14,7 @@ PATH
     ddtrace (1.14.0)
       datadog-ci (~> 0.1.0)
       debase-ruby_core_source (= 3.2.2)
-      libdatadog (~> 4.0.0.1.0)
+      libdatadog (~> 5.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
 
@@ -55,8 +55,8 @@ GEM
     json (2.6.3)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (4.0.0.1.0-aarch64-linux)
-    libdatadog (4.0.0.1.0-x86_64-linux)
+    libdatadog (5.0.0.1.0-aarch64-linux)
+    libdatadog (5.0.0.1.0-x86_64-linux)
     libddwaf (1.14.0.0.0-aarch64-linux)
       ffi (~> 1.0)
     libddwaf (1.14.0.0.0-x86_64-linux)

--- a/gemfiles/ruby_3.2_activesupport.gemfile.lock
+++ b/gemfiles/ruby_3.2_activesupport.gemfile.lock
@@ -14,7 +14,7 @@ PATH
     ddtrace (1.14.0)
       datadog-ci (~> 0.1.0)
       debase-ruby_core_source (= 3.2.2)
-      libdatadog (~> 4.0.0.1.0)
+      libdatadog (~> 5.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
 
@@ -110,8 +110,8 @@ GEM
       addressable (>= 2.4)
     jsonapi-renderer (0.2.2)
     king_konf (1.0.1)
-    libdatadog (4.0.0.1.0-aarch64-linux)
-    libdatadog (4.0.0.1.0-x86_64-linux)
+    libdatadog (5.0.0.1.0-aarch64-linux)
+    libdatadog (5.0.0.1.0-x86_64-linux)
     libddwaf (1.14.0.0.0-aarch64-linux)
       ffi (~> 1.0)
     libddwaf (1.14.0.0.0-x86_64-linux)

--- a/gemfiles/ruby_3.2_aws.gemfile.lock
+++ b/gemfiles/ruby_3.2_aws.gemfile.lock
@@ -14,7 +14,7 @@ PATH
     ddtrace (1.14.0)
       datadog-ci (~> 0.1.0)
       debase-ruby_core_source (= 3.2.2)
-      libdatadog (~> 4.0.0.1.0)
+      libdatadog (~> 5.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
 
@@ -1476,8 +1476,8 @@ GEM
     json (2.6.3)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (4.0.0.1.0-aarch64-linux)
-    libdatadog (4.0.0.1.0-x86_64-linux)
+    libdatadog (5.0.0.1.0-aarch64-linux)
+    libdatadog (5.0.0.1.0-x86_64-linux)
     libddwaf (1.14.0.0.0-aarch64-linux)
       ffi (~> 1.0)
     libddwaf (1.14.0.0.0-x86_64-linux)

--- a/gemfiles/ruby_3.2_contrib.gemfile.lock
+++ b/gemfiles/ruby_3.2_contrib.gemfile.lock
@@ -14,7 +14,7 @@ PATH
     ddtrace (1.14.0)
       datadog-ci (~> 0.1.0)
       debase-ruby_core_source (= 3.2.2)
-      libdatadog (~> 4.0.0.1.0)
+      libdatadog (~> 5.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
 
@@ -70,8 +70,8 @@ GEM
     json (2.6.3)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (4.0.0.1.0-aarch64-linux)
-    libdatadog (4.0.0.1.0-x86_64-linux)
+    libdatadog (5.0.0.1.0-aarch64-linux)
+    libdatadog (5.0.0.1.0-x86_64-linux)
     libddwaf (1.14.0.0.0-aarch64-linux)
       ffi (~> 1.0)
     libddwaf (1.14.0.0.0-x86_64-linux)

--- a/gemfiles/ruby_3.2_contrib_old.gemfile.lock
+++ b/gemfiles/ruby_3.2_contrib_old.gemfile.lock
@@ -14,7 +14,7 @@ PATH
     ddtrace (1.14.0)
       datadog-ci (~> 0.1.0)
       debase-ruby_core_source (= 3.2.2)
-      libdatadog (~> 4.0.0.1.0)
+      libdatadog (~> 5.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
 
@@ -74,8 +74,8 @@ GEM
     json (2.6.3)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (4.0.0.1.0-aarch64-linux)
-    libdatadog (4.0.0.1.0-x86_64-linux)
+    libdatadog (5.0.0.1.0-aarch64-linux)
+    libdatadog (5.0.0.1.0-x86_64-linux)
     libddwaf (1.14.0.0.0-aarch64-linux)
       ffi (~> 1.0)
     libddwaf (1.14.0.0.0-x86_64-linux)

--- a/gemfiles/ruby_3.2_core_old.gemfile.lock
+++ b/gemfiles/ruby_3.2_core_old.gemfile.lock
@@ -14,7 +14,7 @@ PATH
     ddtrace (1.14.0)
       datadog-ci (~> 0.1.0)
       debase-ruby_core_source (= 3.2.2)
-      libdatadog (~> 4.0.0.1.0)
+      libdatadog (~> 5.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
 
@@ -54,8 +54,8 @@ GEM
     json (2.6.3)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (4.0.0.1.0-aarch64-linux)
-    libdatadog (4.0.0.1.0-x86_64-linux)
+    libdatadog (5.0.0.1.0-aarch64-linux)
+    libdatadog (5.0.0.1.0-x86_64-linux)
     libddwaf (1.14.0.0.0-aarch64-linux)
       ffi (~> 1.0)
     libddwaf (1.14.0.0.0-x86_64-linux)

--- a/gemfiles/ruby_3.2_http.gemfile.lock
+++ b/gemfiles/ruby_3.2_http.gemfile.lock
@@ -14,7 +14,7 @@ PATH
     ddtrace (1.14.0)
       datadog-ci (~> 0.1.0)
       debase-ruby_core_source (= 3.2.2)
-      libdatadog (~> 4.0.0.1.0)
+      libdatadog (~> 5.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
 
@@ -84,8 +84,8 @@ GEM
     json (2.6.3)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (4.0.0.1.0-aarch64-linux)
-    libdatadog (4.0.0.1.0-x86_64-linux)
+    libdatadog (5.0.0.1.0-aarch64-linux)
+    libdatadog (5.0.0.1.0-x86_64-linux)
     libddwaf (1.14.0.0.0-aarch64-linux)
       ffi (~> 1.0)
     libddwaf (1.14.0.0.0-x86_64-linux)

--- a/gemfiles/ruby_3.2_opentelemetry.gemfile.lock
+++ b/gemfiles/ruby_3.2_opentelemetry.gemfile.lock
@@ -14,7 +14,7 @@ PATH
     ddtrace (1.14.0)
       datadog-ci (~> 0.1.0)
       debase-ruby_core_source (= 3.2.2)
-      libdatadog (~> 4.0.0.1.0)
+      libdatadog (~> 5.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
 
@@ -54,8 +54,8 @@ GEM
     json (2.6.3)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (4.0.0.1.0-aarch64-linux)
-    libdatadog (4.0.0.1.0-x86_64-linux)
+    libdatadog (5.0.0.1.0-aarch64-linux)
+    libdatadog (5.0.0.1.0-x86_64-linux)
     libddwaf (1.14.0.0.0-aarch64-linux)
       ffi (~> 1.0)
     libddwaf (1.14.0.0.0-x86_64-linux)

--- a/gemfiles/ruby_3.2_opentracing.gemfile.lock
+++ b/gemfiles/ruby_3.2_opentracing.gemfile.lock
@@ -14,7 +14,7 @@ PATH
     ddtrace (1.14.0)
       datadog-ci (~> 0.1.0)
       debase-ruby_core_source (= 3.2.2)
-      libdatadog (~> 4.0.0.1.0)
+      libdatadog (~> 5.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
 
@@ -55,8 +55,8 @@ GEM
     json (2.6.3)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (4.0.0.1.0-aarch64-linux)
-    libdatadog (4.0.0.1.0-x86_64-linux)
+    libdatadog (5.0.0.1.0-aarch64-linux)
+    libdatadog (5.0.0.1.0-x86_64-linux)
     libddwaf (1.14.0.0.0-aarch64-linux)
       ffi (~> 1.0)
     libddwaf (1.14.0.0.0-x86_64-linux)

--- a/gemfiles/ruby_3.2_rack_1.gemfile.lock
+++ b/gemfiles/ruby_3.2_rack_1.gemfile.lock
@@ -14,7 +14,7 @@ PATH
     ddtrace (1.14.0)
       datadog-ci (~> 0.1.0)
       debase-ruby_core_source (= 3.2.2)
-      libdatadog (~> 4.0.0.1.0)
+      libdatadog (~> 5.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
 
@@ -54,8 +54,8 @@ GEM
     json (2.6.3)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (4.0.0.1.0-aarch64-linux)
-    libdatadog (4.0.0.1.0-x86_64-linux)
+    libdatadog (5.0.0.1.0-aarch64-linux)
+    libdatadog (5.0.0.1.0-x86_64-linux)
     libddwaf (1.14.0.0.0-aarch64-linux)
       ffi (~> 1.0)
     libddwaf (1.14.0.0.0-x86_64-linux)

--- a/gemfiles/ruby_3.2_rack_2.gemfile.lock
+++ b/gemfiles/ruby_3.2_rack_2.gemfile.lock
@@ -14,7 +14,7 @@ PATH
     ddtrace (1.14.0)
       datadog-ci (~> 0.1.0)
       debase-ruby_core_source (= 3.2.2)
-      libdatadog (~> 4.0.0.1.0)
+      libdatadog (~> 5.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
 
@@ -54,8 +54,8 @@ GEM
     json (2.6.3)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (4.0.0.1.0-aarch64-linux)
-    libdatadog (4.0.0.1.0-x86_64-linux)
+    libdatadog (5.0.0.1.0-aarch64-linux)
+    libdatadog (5.0.0.1.0-x86_64-linux)
     libddwaf (1.14.0.0.0-aarch64-linux)
       ffi (~> 1.0)
     libddwaf (1.14.0.0.0-x86_64-linux)

--- a/gemfiles/ruby_3.2_rack_3.gemfile.lock
+++ b/gemfiles/ruby_3.2_rack_3.gemfile.lock
@@ -14,7 +14,7 @@ PATH
     ddtrace (1.14.0)
       datadog-ci (~> 0.1.0)
       debase-ruby_core_source (= 3.2.2)
-      libdatadog (~> 4.0.0.1.0)
+      libdatadog (~> 5.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
 
@@ -54,8 +54,8 @@ GEM
     json (2.6.3)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (4.0.0.1.0-aarch64-linux)
-    libdatadog (4.0.0.1.0-x86_64-linux)
+    libdatadog (5.0.0.1.0-aarch64-linux)
+    libdatadog (5.0.0.1.0-x86_64-linux)
     libddwaf (1.14.0.0.0-aarch64-linux)
       ffi (~> 1.0)
     libddwaf (1.14.0.0.0-x86_64-linux)

--- a/gemfiles/ruby_3.2_rails61_mysql2.gemfile.lock
+++ b/gemfiles/ruby_3.2_rails61_mysql2.gemfile.lock
@@ -14,7 +14,7 @@ PATH
     ddtrace (1.14.0)
       datadog-ci (~> 0.1.0)
       debase-ruby_core_source (= 3.2.2)
-      libdatadog (~> 4.0.0.1.0)
+      libdatadog (~> 5.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
 
@@ -120,8 +120,8 @@ GEM
     json (2.6.3)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (4.0.0.1.0-aarch64-linux)
-    libdatadog (4.0.0.1.0-x86_64-linux)
+    libdatadog (5.0.0.1.0-aarch64-linux)
+    libdatadog (5.0.0.1.0-x86_64-linux)
     libddwaf (1.14.0.0.0-aarch64-linux)
       ffi (~> 1.0)
     libddwaf (1.14.0.0.0-x86_64-linux)

--- a/gemfiles/ruby_3.2_rails61_postgres.gemfile.lock
+++ b/gemfiles/ruby_3.2_rails61_postgres.gemfile.lock
@@ -14,7 +14,7 @@ PATH
     ddtrace (1.14.0)
       datadog-ci (~> 0.1.0)
       debase-ruby_core_source (= 3.2.2)
-      libdatadog (~> 4.0.0.1.0)
+      libdatadog (~> 5.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
 
@@ -120,8 +120,8 @@ GEM
     json (2.6.3)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (4.0.0.1.0-aarch64-linux)
-    libdatadog (4.0.0.1.0-x86_64-linux)
+    libdatadog (5.0.0.1.0-aarch64-linux)
+    libdatadog (5.0.0.1.0-x86_64-linux)
     libddwaf (1.14.0.0.0-aarch64-linux)
       ffi (~> 1.0)
     libddwaf (1.14.0.0.0-x86_64-linux)

--- a/gemfiles/ruby_3.2_rails61_postgres_redis.gemfile.lock
+++ b/gemfiles/ruby_3.2_rails61_postgres_redis.gemfile.lock
@@ -14,7 +14,7 @@ PATH
     ddtrace (1.14.0)
       datadog-ci (~> 0.1.0)
       debase-ruby_core_source (= 3.2.2)
-      libdatadog (~> 4.0.0.1.0)
+      libdatadog (~> 5.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
 
@@ -120,8 +120,8 @@ GEM
     json (2.6.3)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (4.0.0.1.0-aarch64-linux)
-    libdatadog (4.0.0.1.0-x86_64-linux)
+    libdatadog (5.0.0.1.0-aarch64-linux)
+    libdatadog (5.0.0.1.0-x86_64-linux)
     libddwaf (1.14.0.0.0-aarch64-linux)
       ffi (~> 1.0)
     libddwaf (1.14.0.0.0-x86_64-linux)

--- a/gemfiles/ruby_3.2_rails61_postgres_sidekiq.gemfile.lock
+++ b/gemfiles/ruby_3.2_rails61_postgres_sidekiq.gemfile.lock
@@ -14,7 +14,7 @@ PATH
     ddtrace (1.14.0)
       datadog-ci (~> 0.1.0)
       debase-ruby_core_source (= 3.2.2)
-      libdatadog (~> 4.0.0.1.0)
+      libdatadog (~> 5.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
 
@@ -121,8 +121,8 @@ GEM
     json (2.6.3)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (4.0.0.1.0-aarch64-linux)
-    libdatadog (4.0.0.1.0-x86_64-linux)
+    libdatadog (5.0.0.1.0-aarch64-linux)
+    libdatadog (5.0.0.1.0-x86_64-linux)
     libddwaf (1.14.0.0.0-aarch64-linux)
       ffi (~> 1.0)
     libddwaf (1.14.0.0.0-x86_64-linux)

--- a/gemfiles/ruby_3.2_rails61_semantic_logger.gemfile.lock
+++ b/gemfiles/ruby_3.2_rails61_semantic_logger.gemfile.lock
@@ -14,7 +14,7 @@ PATH
     ddtrace (1.14.0)
       datadog-ci (~> 0.1.0)
       debase-ruby_core_source (= 3.2.2)
-      libdatadog (~> 4.0.0.1.0)
+      libdatadog (~> 5.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
 
@@ -120,8 +120,8 @@ GEM
     json (2.6.3)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (4.0.0.1.0-aarch64-linux)
-    libdatadog (4.0.0.1.0-x86_64-linux)
+    libdatadog (5.0.0.1.0-aarch64-linux)
+    libdatadog (5.0.0.1.0-x86_64-linux)
     libddwaf (1.14.0.0.0-aarch64-linux)
       ffi (~> 1.0)
     libddwaf (1.14.0.0.0-x86_64-linux)

--- a/gemfiles/ruby_3.2_redis_3.gemfile.lock
+++ b/gemfiles/ruby_3.2_redis_3.gemfile.lock
@@ -14,7 +14,7 @@ PATH
     ddtrace (1.14.0)
       datadog-ci (~> 0.1.0)
       debase-ruby_core_source (= 3.2.2)
-      libdatadog (~> 4.0.0.1.0)
+      libdatadog (~> 5.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
 
@@ -54,8 +54,8 @@ GEM
     json (2.6.3)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (4.0.0.1.0-aarch64-linux)
-    libdatadog (4.0.0.1.0-x86_64-linux)
+    libdatadog (5.0.0.1.0-aarch64-linux)
+    libdatadog (5.0.0.1.0-x86_64-linux)
     libddwaf (1.14.0.0.0-aarch64-linux)
       ffi (~> 1.0)
     libddwaf (1.14.0.0.0-x86_64-linux)

--- a/gemfiles/ruby_3.2_redis_4.gemfile.lock
+++ b/gemfiles/ruby_3.2_redis_4.gemfile.lock
@@ -14,7 +14,7 @@ PATH
     ddtrace (1.14.0)
       datadog-ci (~> 0.1.0)
       debase-ruby_core_source (= 3.2.2)
-      libdatadog (~> 4.0.0.1.0)
+      libdatadog (~> 5.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
 
@@ -54,8 +54,8 @@ GEM
     json (2.6.3)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (4.0.0.1.0-aarch64-linux)
-    libdatadog (4.0.0.1.0-x86_64-linux)
+    libdatadog (5.0.0.1.0-aarch64-linux)
+    libdatadog (5.0.0.1.0-x86_64-linux)
     libddwaf (1.14.0.0.0-aarch64-linux)
       ffi (~> 1.0)
     libddwaf (1.14.0.0.0-x86_64-linux)

--- a/gemfiles/ruby_3.2_redis_5.gemfile.lock
+++ b/gemfiles/ruby_3.2_redis_5.gemfile.lock
@@ -14,7 +14,7 @@ PATH
     ddtrace (1.14.0)
       datadog-ci (~> 0.1.0)
       debase-ruby_core_source (= 3.2.2)
-      libdatadog (~> 4.0.0.1.0)
+      libdatadog (~> 5.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
 
@@ -55,8 +55,8 @@ GEM
     json (2.6.3)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (4.0.0.1.0-aarch64-linux)
-    libdatadog (4.0.0.1.0-x86_64-linux)
+    libdatadog (5.0.0.1.0-aarch64-linux)
+    libdatadog (5.0.0.1.0-x86_64-linux)
     libddwaf (1.14.0.0.0-aarch64-linux)
       ffi (~> 1.0)
     libddwaf (1.14.0.0.0-x86_64-linux)

--- a/gemfiles/ruby_3.2_relational_db.gemfile.lock
+++ b/gemfiles/ruby_3.2_relational_db.gemfile.lock
@@ -14,7 +14,7 @@ PATH
     ddtrace (1.14.0)
       datadog-ci (~> 0.1.0)
       debase-ruby_core_source (= 3.2.2)
-      libdatadog (~> 4.0.0.1.0)
+      libdatadog (~> 5.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
 
@@ -71,8 +71,8 @@ GEM
     json (2.6.3)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (4.0.0.1.0-aarch64-linux)
-    libdatadog (4.0.0.1.0-x86_64-linux)
+    libdatadog (5.0.0.1.0-aarch64-linux)
+    libdatadog (5.0.0.1.0-x86_64-linux)
     libddwaf (1.14.0.0.0-aarch64-linux)
       ffi (~> 1.0)
     libddwaf (1.14.0.0.0-x86_64-linux)

--- a/gemfiles/ruby_3.2_resque2_redis3.gemfile.lock
+++ b/gemfiles/ruby_3.2_resque2_redis3.gemfile.lock
@@ -14,7 +14,7 @@ PATH
     ddtrace (1.14.0)
       datadog-ci (~> 0.1.0)
       debase-ruby_core_source (= 3.2.2)
-      libdatadog (~> 4.0.0.1.0)
+      libdatadog (~> 5.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
 
@@ -54,8 +54,8 @@ GEM
     json (2.6.3)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (4.0.0.1.0-aarch64-linux)
-    libdatadog (4.0.0.1.0-x86_64-linux)
+    libdatadog (5.0.0.1.0-aarch64-linux)
+    libdatadog (5.0.0.1.0-x86_64-linux)
     libddwaf (1.14.0.0.0-aarch64-linux)
       ffi (~> 1.0)
     libddwaf (1.14.0.0.0-x86_64-linux)

--- a/gemfiles/ruby_3.2_resque2_redis4.gemfile.lock
+++ b/gemfiles/ruby_3.2_resque2_redis4.gemfile.lock
@@ -14,7 +14,7 @@ PATH
     ddtrace (1.14.0)
       datadog-ci (~> 0.1.0)
       debase-ruby_core_source (= 3.2.2)
-      libdatadog (~> 4.0.0.1.0)
+      libdatadog (~> 5.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
 
@@ -55,8 +55,8 @@ GEM
     json (2.6.3)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (4.0.0.1.0-aarch64-linux)
-    libdatadog (4.0.0.1.0-x86_64-linux)
+    libdatadog (5.0.0.1.0-aarch64-linux)
+    libdatadog (5.0.0.1.0-x86_64-linux)
     libddwaf (1.14.0.0.0-aarch64-linux)
       ffi (~> 1.0)
     libddwaf (1.14.0.0.0-x86_64-linux)

--- a/gemfiles/ruby_3.2_sinatra.gemfile.lock
+++ b/gemfiles/ruby_3.2_sinatra.gemfile.lock
@@ -14,7 +14,7 @@ PATH
     ddtrace (1.14.0)
       datadog-ci (~> 0.1.0)
       debase-ruby_core_source (= 3.2.2)
-      libdatadog (~> 4.0.0.1.0)
+      libdatadog (~> 5.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
 
@@ -54,8 +54,8 @@ GEM
     json (2.6.3)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (4.0.0.1.0-aarch64-linux)
-    libdatadog (4.0.0.1.0-x86_64-linux)
+    libdatadog (5.0.0.1.0-aarch64-linux)
+    libdatadog (5.0.0.1.0-x86_64-linux)
     libddwaf (1.14.0.0.0-aarch64-linux)
       ffi (~> 1.0)
     libddwaf (1.14.0.0.0-x86_64-linux)

--- a/gemfiles/ruby_3.3_activesupport.gemfile.lock
+++ b/gemfiles/ruby_3.3_activesupport.gemfile.lock
@@ -14,7 +14,7 @@ PATH
     ddtrace (1.14.0)
       datadog-ci (~> 0.1.0)
       debase-ruby_core_source (= 3.2.2)
-      libdatadog (~> 4.0.0.1.0)
+      libdatadog (~> 5.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
 
@@ -109,8 +109,8 @@ GEM
       addressable (>= 2.4)
     jsonapi-renderer (0.2.2)
     king_konf (1.0.1)
-    libdatadog (4.0.0.1.0-aarch64-linux)
-    libdatadog (4.0.0.1.0-x86_64-linux)
+    libdatadog (5.0.0.1.0-aarch64-linux)
+    libdatadog (5.0.0.1.0-x86_64-linux)
     libddwaf (1.14.0.0.0-aarch64-linux)
       ffi (~> 1.0)
     libddwaf (1.14.0.0.0-x86_64-linux)

--- a/gemfiles/ruby_3.3_aws.gemfile.lock
+++ b/gemfiles/ruby_3.3_aws.gemfile.lock
@@ -14,7 +14,7 @@ PATH
     ddtrace (1.14.0)
       datadog-ci (~> 0.1.0)
       debase-ruby_core_source (= 3.2.2)
-      libdatadog (~> 4.0.0.1.0)
+      libdatadog (~> 5.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
 
@@ -1475,8 +1475,8 @@ GEM
     json (2.6.3)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (4.0.0.1.0-aarch64-linux)
-    libdatadog (4.0.0.1.0-x86_64-linux)
+    libdatadog (5.0.0.1.0-aarch64-linux)
+    libdatadog (5.0.0.1.0-x86_64-linux)
     libddwaf (1.14.0.0.0-aarch64-linux)
       ffi (~> 1.0)
     libddwaf (1.14.0.0.0-x86_64-linux)

--- a/gemfiles/ruby_3.3_contrib.gemfile.lock
+++ b/gemfiles/ruby_3.3_contrib.gemfile.lock
@@ -14,7 +14,7 @@ PATH
     ddtrace (1.14.0)
       datadog-ci (~> 0.1.0)
       debase-ruby_core_source (= 3.2.2)
-      libdatadog (~> 4.0.0.1.0)
+      libdatadog (~> 5.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
 
@@ -66,8 +66,8 @@ GEM
     json (2.6.3)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (4.0.0.1.0-aarch64-linux)
-    libdatadog (4.0.0.1.0-x86_64-linux)
+    libdatadog (5.0.0.1.0-aarch64-linux)
+    libdatadog (5.0.0.1.0-x86_64-linux)
     libddwaf (1.14.0.0.0-aarch64-linux)
       ffi (~> 1.0)
     libddwaf (1.14.0.0.0-x86_64-linux)

--- a/gemfiles/ruby_3.3_contrib_old.gemfile.lock
+++ b/gemfiles/ruby_3.3_contrib_old.gemfile.lock
@@ -14,7 +14,7 @@ PATH
     ddtrace (1.14.0)
       datadog-ci (~> 0.1.0)
       debase-ruby_core_source (= 3.2.2)
-      libdatadog (~> 4.0.0.1.0)
+      libdatadog (~> 5.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
 
@@ -73,8 +73,8 @@ GEM
     json (2.6.3)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (4.0.0.1.0-aarch64-linux)
-    libdatadog (4.0.0.1.0-x86_64-linux)
+    libdatadog (5.0.0.1.0-aarch64-linux)
+    libdatadog (5.0.0.1.0-x86_64-linux)
     libddwaf (1.14.0.0.0-aarch64-linux)
       ffi (~> 1.0)
     libddwaf (1.14.0.0.0-x86_64-linux)

--- a/gemfiles/ruby_3.3_core_old.gemfile.lock
+++ b/gemfiles/ruby_3.3_core_old.gemfile.lock
@@ -14,7 +14,7 @@ PATH
     ddtrace (1.14.0)
       datadog-ci (~> 0.1.0)
       debase-ruby_core_source (= 3.2.2)
-      libdatadog (~> 4.0.0.1.0)
+      libdatadog (~> 5.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
 
@@ -53,8 +53,8 @@ GEM
     json (2.6.3)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (4.0.0.1.0-aarch64-linux)
-    libdatadog (4.0.0.1.0-x86_64-linux)
+    libdatadog (5.0.0.1.0-aarch64-linux)
+    libdatadog (5.0.0.1.0-x86_64-linux)
     libddwaf (1.14.0.0.0-aarch64-linux)
       ffi (~> 1.0)
     libddwaf (1.14.0.0.0-x86_64-linux)

--- a/gemfiles/ruby_3.3_http.gemfile.lock
+++ b/gemfiles/ruby_3.3_http.gemfile.lock
@@ -14,7 +14,7 @@ PATH
     ddtrace (1.14.0)
       datadog-ci (~> 0.1.0)
       debase-ruby_core_source (= 3.2.2)
-      libdatadog (~> 4.0.0.1.0)
+      libdatadog (~> 5.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
 
@@ -83,8 +83,8 @@ GEM
     json (2.6.3)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (4.0.0.1.0-aarch64-linux)
-    libdatadog (4.0.0.1.0-x86_64-linux)
+    libdatadog (5.0.0.1.0-aarch64-linux)
+    libdatadog (5.0.0.1.0-x86_64-linux)
     libddwaf (1.14.0.0.0-aarch64-linux)
       ffi (~> 1.0)
     libddwaf (1.14.0.0.0-x86_64-linux)

--- a/gemfiles/ruby_3.3_opentelemetry.gemfile.lock
+++ b/gemfiles/ruby_3.3_opentelemetry.gemfile.lock
@@ -14,7 +14,7 @@ PATH
     ddtrace (1.14.0)
       datadog-ci (~> 0.1.0)
       debase-ruby_core_source (= 3.2.2)
-      libdatadog (~> 4.0.0.1.0)
+      libdatadog (~> 5.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
 
@@ -53,8 +53,8 @@ GEM
     json (2.6.3)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (4.0.0.1.0-aarch64-linux)
-    libdatadog (4.0.0.1.0-x86_64-linux)
+    libdatadog (5.0.0.1.0-aarch64-linux)
+    libdatadog (5.0.0.1.0-x86_64-linux)
     libddwaf (1.14.0.0.0-aarch64-linux)
       ffi (~> 1.0)
     libddwaf (1.14.0.0.0-x86_64-linux)

--- a/gemfiles/ruby_3.3_opentracing.gemfile.lock
+++ b/gemfiles/ruby_3.3_opentracing.gemfile.lock
@@ -14,7 +14,7 @@ PATH
     ddtrace (1.14.0)
       datadog-ci (~> 0.1.0)
       debase-ruby_core_source (= 3.2.2)
-      libdatadog (~> 4.0.0.1.0)
+      libdatadog (~> 5.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
 
@@ -54,8 +54,8 @@ GEM
     json (2.6.3)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (4.0.0.1.0-aarch64-linux)
-    libdatadog (4.0.0.1.0-x86_64-linux)
+    libdatadog (5.0.0.1.0-aarch64-linux)
+    libdatadog (5.0.0.1.0-x86_64-linux)
     libddwaf (1.14.0.0.0-aarch64-linux)
       ffi (~> 1.0)
     libddwaf (1.14.0.0.0-x86_64-linux)

--- a/gemfiles/ruby_3.3_rack_1.gemfile.lock
+++ b/gemfiles/ruby_3.3_rack_1.gemfile.lock
@@ -14,7 +14,7 @@ PATH
     ddtrace (1.14.0)
       datadog-ci (~> 0.1.0)
       debase-ruby_core_source (= 3.2.2)
-      libdatadog (~> 4.0.0.1.0)
+      libdatadog (~> 5.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
 
@@ -53,8 +53,8 @@ GEM
     json (2.6.3)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (4.0.0.1.0-aarch64-linux)
-    libdatadog (4.0.0.1.0-x86_64-linux)
+    libdatadog (5.0.0.1.0-aarch64-linux)
+    libdatadog (5.0.0.1.0-x86_64-linux)
     libddwaf (1.14.0.0.0-aarch64-linux)
       ffi (~> 1.0)
     libddwaf (1.14.0.0.0-x86_64-linux)

--- a/gemfiles/ruby_3.3_rack_2.gemfile.lock
+++ b/gemfiles/ruby_3.3_rack_2.gemfile.lock
@@ -14,7 +14,7 @@ PATH
     ddtrace (1.14.0)
       datadog-ci (~> 0.1.0)
       debase-ruby_core_source (= 3.2.2)
-      libdatadog (~> 4.0.0.1.0)
+      libdatadog (~> 5.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
 
@@ -53,8 +53,8 @@ GEM
     json (2.6.3)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (4.0.0.1.0-aarch64-linux)
-    libdatadog (4.0.0.1.0-x86_64-linux)
+    libdatadog (5.0.0.1.0-aarch64-linux)
+    libdatadog (5.0.0.1.0-x86_64-linux)
     libddwaf (1.14.0.0.0-aarch64-linux)
       ffi (~> 1.0)
     libddwaf (1.14.0.0.0-x86_64-linux)

--- a/gemfiles/ruby_3.3_rack_3.gemfile.lock
+++ b/gemfiles/ruby_3.3_rack_3.gemfile.lock
@@ -14,7 +14,7 @@ PATH
     ddtrace (1.14.0)
       datadog-ci (~> 0.1.0)
       debase-ruby_core_source (= 3.2.2)
-      libdatadog (~> 4.0.0.1.0)
+      libdatadog (~> 5.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
 
@@ -53,8 +53,8 @@ GEM
     json (2.6.3)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (4.0.0.1.0-aarch64-linux)
-    libdatadog (4.0.0.1.0-x86_64-linux)
+    libdatadog (5.0.0.1.0-aarch64-linux)
+    libdatadog (5.0.0.1.0-x86_64-linux)
     libddwaf (1.14.0.0.0-aarch64-linux)
       ffi (~> 1.0)
     libddwaf (1.14.0.0.0-x86_64-linux)

--- a/gemfiles/ruby_3.3_rails61_mysql2.gemfile.lock
+++ b/gemfiles/ruby_3.3_rails61_mysql2.gemfile.lock
@@ -14,7 +14,7 @@ PATH
     ddtrace (1.14.0)
       datadog-ci (~> 0.1.0)
       debase-ruby_core_source (= 3.2.2)
-      libdatadog (~> 4.0.0.1.0)
+      libdatadog (~> 5.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
 
@@ -119,8 +119,8 @@ GEM
     json (2.6.3)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (4.0.0.1.0-aarch64-linux)
-    libdatadog (4.0.0.1.0-x86_64-linux)
+    libdatadog (5.0.0.1.0-aarch64-linux)
+    libdatadog (5.0.0.1.0-x86_64-linux)
     libddwaf (1.14.0.0.0-aarch64-linux)
       ffi (~> 1.0)
     libddwaf (1.14.0.0.0-x86_64-linux)

--- a/gemfiles/ruby_3.3_rails61_postgres.gemfile.lock
+++ b/gemfiles/ruby_3.3_rails61_postgres.gemfile.lock
@@ -14,7 +14,7 @@ PATH
     ddtrace (1.14.0)
       datadog-ci (~> 0.1.0)
       debase-ruby_core_source (= 3.2.2)
-      libdatadog (~> 4.0.0.1.0)
+      libdatadog (~> 5.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
 
@@ -119,8 +119,8 @@ GEM
     json (2.6.3)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (4.0.0.1.0-aarch64-linux)
-    libdatadog (4.0.0.1.0-x86_64-linux)
+    libdatadog (5.0.0.1.0-aarch64-linux)
+    libdatadog (5.0.0.1.0-x86_64-linux)
     libddwaf (1.14.0.0.0-aarch64-linux)
       ffi (~> 1.0)
     libddwaf (1.14.0.0.0-x86_64-linux)

--- a/gemfiles/ruby_3.3_rails61_postgres_redis.gemfile.lock
+++ b/gemfiles/ruby_3.3_rails61_postgres_redis.gemfile.lock
@@ -14,7 +14,7 @@ PATH
     ddtrace (1.14.0)
       datadog-ci (~> 0.1.0)
       debase-ruby_core_source (= 3.2.2)
-      libdatadog (~> 4.0.0.1.0)
+      libdatadog (~> 5.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
 
@@ -119,8 +119,8 @@ GEM
     json (2.6.3)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (4.0.0.1.0-aarch64-linux)
-    libdatadog (4.0.0.1.0-x86_64-linux)
+    libdatadog (5.0.0.1.0-aarch64-linux)
+    libdatadog (5.0.0.1.0-x86_64-linux)
     libddwaf (1.14.0.0.0-aarch64-linux)
       ffi (~> 1.0)
     libddwaf (1.14.0.0.0-x86_64-linux)

--- a/gemfiles/ruby_3.3_rails61_postgres_sidekiq.gemfile.lock
+++ b/gemfiles/ruby_3.3_rails61_postgres_sidekiq.gemfile.lock
@@ -14,7 +14,7 @@ PATH
     ddtrace (1.14.0)
       datadog-ci (~> 0.1.0)
       debase-ruby_core_source (= 3.2.2)
-      libdatadog (~> 4.0.0.1.0)
+      libdatadog (~> 5.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
 
@@ -120,8 +120,8 @@ GEM
     json (2.6.3)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (4.0.0.1.0-aarch64-linux)
-    libdatadog (4.0.0.1.0-x86_64-linux)
+    libdatadog (5.0.0.1.0-aarch64-linux)
+    libdatadog (5.0.0.1.0-x86_64-linux)
     libddwaf (1.14.0.0.0-aarch64-linux)
       ffi (~> 1.0)
     libddwaf (1.14.0.0.0-x86_64-linux)

--- a/gemfiles/ruby_3.3_rails61_semantic_logger.gemfile.lock
+++ b/gemfiles/ruby_3.3_rails61_semantic_logger.gemfile.lock
@@ -14,7 +14,7 @@ PATH
     ddtrace (1.14.0)
       datadog-ci (~> 0.1.0)
       debase-ruby_core_source (= 3.2.2)
-      libdatadog (~> 4.0.0.1.0)
+      libdatadog (~> 5.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
 
@@ -119,8 +119,8 @@ GEM
     json (2.6.3)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (4.0.0.1.0-aarch64-linux)
-    libdatadog (4.0.0.1.0-x86_64-linux)
+    libdatadog (5.0.0.1.0-aarch64-linux)
+    libdatadog (5.0.0.1.0-x86_64-linux)
     libddwaf (1.14.0.0.0-aarch64-linux)
       ffi (~> 1.0)
     libddwaf (1.14.0.0.0-x86_64-linux)

--- a/gemfiles/ruby_3.3_redis_3.gemfile.lock
+++ b/gemfiles/ruby_3.3_redis_3.gemfile.lock
@@ -14,7 +14,7 @@ PATH
     ddtrace (1.14.0)
       datadog-ci (~> 0.1.0)
       debase-ruby_core_source (= 3.2.2)
-      libdatadog (~> 4.0.0.1.0)
+      libdatadog (~> 5.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
 
@@ -53,8 +53,8 @@ GEM
     json (2.6.3)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (4.0.0.1.0-aarch64-linux)
-    libdatadog (4.0.0.1.0-x86_64-linux)
+    libdatadog (5.0.0.1.0-aarch64-linux)
+    libdatadog (5.0.0.1.0-x86_64-linux)
     libddwaf (1.14.0.0.0-aarch64-linux)
       ffi (~> 1.0)
     libddwaf (1.14.0.0.0-x86_64-linux)

--- a/gemfiles/ruby_3.3_redis_4.gemfile.lock
+++ b/gemfiles/ruby_3.3_redis_4.gemfile.lock
@@ -14,7 +14,7 @@ PATH
     ddtrace (1.14.0)
       datadog-ci (~> 0.1.0)
       debase-ruby_core_source (= 3.2.2)
-      libdatadog (~> 4.0.0.1.0)
+      libdatadog (~> 5.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
 
@@ -53,8 +53,8 @@ GEM
     json (2.6.3)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (4.0.0.1.0-aarch64-linux)
-    libdatadog (4.0.0.1.0-x86_64-linux)
+    libdatadog (5.0.0.1.0-aarch64-linux)
+    libdatadog (5.0.0.1.0-x86_64-linux)
     libddwaf (1.14.0.0.0-aarch64-linux)
       ffi (~> 1.0)
     libddwaf (1.14.0.0.0-x86_64-linux)

--- a/gemfiles/ruby_3.3_redis_5.gemfile.lock
+++ b/gemfiles/ruby_3.3_redis_5.gemfile.lock
@@ -14,7 +14,7 @@ PATH
     ddtrace (1.14.0)
       datadog-ci (~> 0.1.0)
       debase-ruby_core_source (= 3.2.2)
-      libdatadog (~> 4.0.0.1.0)
+      libdatadog (~> 5.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
 
@@ -54,8 +54,8 @@ GEM
     json (2.6.3)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (4.0.0.1.0-aarch64-linux)
-    libdatadog (4.0.0.1.0-x86_64-linux)
+    libdatadog (5.0.0.1.0-aarch64-linux)
+    libdatadog (5.0.0.1.0-x86_64-linux)
     libddwaf (1.14.0.0.0-aarch64-linux)
       ffi (~> 1.0)
     libddwaf (1.14.0.0.0-x86_64-linux)

--- a/gemfiles/ruby_3.3_relational_db.gemfile.lock
+++ b/gemfiles/ruby_3.3_relational_db.gemfile.lock
@@ -14,7 +14,7 @@ PATH
     ddtrace (1.14.0)
       datadog-ci (~> 0.1.0)
       debase-ruby_core_source (= 3.2.2)
-      libdatadog (~> 4.0.0.1.0)
+      libdatadog (~> 5.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
 
@@ -70,8 +70,8 @@ GEM
     json (2.6.3)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (4.0.0.1.0-aarch64-linux)
-    libdatadog (4.0.0.1.0-x86_64-linux)
+    libdatadog (5.0.0.1.0-aarch64-linux)
+    libdatadog (5.0.0.1.0-x86_64-linux)
     libddwaf (1.14.0.0.0-aarch64-linux)
       ffi (~> 1.0)
     libddwaf (1.14.0.0.0-x86_64-linux)

--- a/gemfiles/ruby_3.3_resque2_redis3.gemfile.lock
+++ b/gemfiles/ruby_3.3_resque2_redis3.gemfile.lock
@@ -14,7 +14,7 @@ PATH
     ddtrace (1.14.0)
       datadog-ci (~> 0.1.0)
       debase-ruby_core_source (= 3.2.2)
-      libdatadog (~> 4.0.0.1.0)
+      libdatadog (~> 5.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
 
@@ -53,8 +53,8 @@ GEM
     json (2.6.3)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (4.0.0.1.0-aarch64-linux)
-    libdatadog (4.0.0.1.0-x86_64-linux)
+    libdatadog (5.0.0.1.0-aarch64-linux)
+    libdatadog (5.0.0.1.0-x86_64-linux)
     libddwaf (1.14.0.0.0-aarch64-linux)
       ffi (~> 1.0)
     libddwaf (1.14.0.0.0-x86_64-linux)

--- a/gemfiles/ruby_3.3_resque2_redis4.gemfile.lock
+++ b/gemfiles/ruby_3.3_resque2_redis4.gemfile.lock
@@ -14,7 +14,7 @@ PATH
     ddtrace (1.14.0)
       datadog-ci (~> 0.1.0)
       debase-ruby_core_source (= 3.2.2)
-      libdatadog (~> 4.0.0.1.0)
+      libdatadog (~> 5.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
 
@@ -54,8 +54,8 @@ GEM
     json (2.6.3)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (4.0.0.1.0-aarch64-linux)
-    libdatadog (4.0.0.1.0-x86_64-linux)
+    libdatadog (5.0.0.1.0-aarch64-linux)
+    libdatadog (5.0.0.1.0-x86_64-linux)
     libddwaf (1.14.0.0.0-aarch64-linux)
       ffi (~> 1.0)
     libddwaf (1.14.0.0.0-x86_64-linux)

--- a/gemfiles/ruby_3.3_sinatra.gemfile.lock
+++ b/gemfiles/ruby_3.3_sinatra.gemfile.lock
@@ -14,7 +14,7 @@ PATH
     ddtrace (1.14.0)
       datadog-ci (~> 0.1.0)
       debase-ruby_core_source (= 3.2.2)
-      libdatadog (~> 4.0.0.1.0)
+      libdatadog (~> 5.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
 
@@ -53,8 +53,8 @@ GEM
     json (2.6.3)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (4.0.0.1.0-aarch64-linux)
-    libdatadog (4.0.0.1.0-x86_64-linux)
+    libdatadog (5.0.0.1.0-aarch64-linux)
+    libdatadog (5.0.0.1.0-x86_64-linux)
     libddwaf (1.14.0.0.0-aarch64-linux)
       ffi (~> 1.0)
     libddwaf (1.14.0.0.0-x86_64-linux)

--- a/spec/datadog/profiling/http_transport_spec.rb
+++ b/spec/datadog/profiling/http_transport_spec.rb
@@ -369,8 +369,10 @@ RSpec.describe Datadog::Profiling::HttpTransport do
         boundary = request['content-type'][%r{^multipart/form-data; boundary=(.+)}, 1]
         body = WEBrick::HTTPUtils.parse_form_data(StringIO.new(request.body), boundary)
 
-        expect(body.fetch(pprof_file_name)).to eq pprof_data # The pprof data is compressed in the datadog serializer, nothing to do
-        expect(LZ4.decode(body.fetch(code_provenance_file_name))).to eq code_provenance_data # This one needs to be compressed
+        # The pprof data is compressed in the datadog serializer, nothing to do
+        expect(body.fetch(pprof_file_name)).to eq pprof_data
+        # This one needs to be compressed
+        expect(LZ4.decode(body.fetch(code_provenance_file_name))).to eq code_provenance_data
       end
     end
 

--- a/spec/datadog/profiling/http_transport_spec.rb
+++ b/spec/datadog/profiling/http_transport_spec.rb
@@ -349,8 +349,8 @@ RSpec.describe Datadog::Profiling::HttpTransport do
         body = WEBrick::HTTPUtils.parse_form_data(StringIO.new(request.body), boundary)
         event_data = JSON.parse(body.fetch('event'))
 
-        expect(event_data).to eq(
-          'attachments' => [pprof_file_name, code_provenance_file_name],
+        expect(event_data).to match(
+          'attachments' => contain_exactly(pprof_file_name, code_provenance_file_name),
           'tags_profiler' => 'tag_a:value_a,tag_b:value_b',
           'start' => start_timestamp,
           'end' => end_timestamp,
@@ -369,10 +369,8 @@ RSpec.describe Datadog::Profiling::HttpTransport do
         boundary = request['content-type'][%r{^multipart/form-data; boundary=(.+)}, 1]
         body = WEBrick::HTTPUtils.parse_form_data(StringIO.new(request.body), boundary)
 
-        require 'extlz4' # Lazily required, to avoid trying to load it on JRuby
-
-        expect(LZ4.decode(body.fetch(pprof_file_name))).to eq pprof_data
-        expect(LZ4.decode(body.fetch(code_provenance_file_name))).to eq code_provenance_data
+        expect(body.fetch(pprof_file_name)).to eq pprof_data # The pprof data is compressed in the datadog serializer, nothing to do
+        expect(LZ4.decode(body.fetch(code_provenance_file_name))).to eq code_provenance_data # This one needs to be compressed
       end
     end
 

--- a/spec/datadog/profiling/stack_recorder_spec.rb
+++ b/spec/datadog/profiling/stack_recorder_spec.rb
@@ -50,7 +50,7 @@ RSpec.describe Datadog::Profiling::StackRecorder do
     let(:finish) { serialize[1] }
     let(:encoded_pprof) { serialize[2] }
 
-    let(:decoded_profile) { ::Perftools::Profiles::Profile.decode(encoded_pprof) }
+    let(:decoded_profile) { decode_profile(encoded_pprof) }
 
     it 'debug logs profile information' do
       message = nil


### PR DESCRIPTION
**What does this PR do?**

This PR upgrades dd-trace-rb to use libdatadog 5. This release includes BIG memory footprint improvements, but there were also a few breaking API changes, which needed adjustments in our code.

**Motivation:**

Use the latest libdatadog release.

**Additional Notes:**

I recommend reviewing this PR commit-by-commit, as it makes more sense for what changed why instead of the whole diff.

The backwards incompatible changes were the following:
* The value of the `end_timestamp_ns` label is now provided as a regular argument to `ddog_prof_Profile_add`
* The libdatadog 5 serializer outputs compressed pprof files:
  * A number of tests needed to be adjusted to take that into account
  * The `HttpTransport` needed to be adjusted to the new API that allows us to tell libdatadog which files to compress and which to assume are compressed when exporting
* The libdatadog 5 serializer now resets profiles as part of serializing them
* The `ddog_prof_Profile_new` now returns a result structure

~I'm opening this PR on top of https://github.com/DataDog/dd-trace-rb/pull/3162 because I'm making use of the `sample_labels` struct that was introduced in that PR. Otherwise the two PRs are independant.~

~Furthermore, I'm opening it as a draft since libdatadog 5 is not yet available on rubygems.org. Once a release is out, I'll mark this PR as non-draft.~

**How to test the change?**

Our existing test coverage also includes a lot of libdatadog integration testing.

**For Datadog employees:**
- [ ] If this PR touches code that signs or publishes builds or packages, or handles
credentials of any kind, I've requested a review from `@DataDog/security-design-and-guidance`.
- [x] This PR doesn't touch any of that.