### PR TITLE
Add telemetry for opentracing

### DIFF
--- a/lib/datadog/core/telemetry/collector.rb
+++ b/lib/datadog/core/telemetry/collector.rb
@@ -146,6 +146,7 @@ module Datadog
           options['logger.instance'] = configuration.logger.instance.class.to_s
           options['appsec.enabled'] = configuration.dig('appsec', 'enabled') if configuration.respond_to?('appsec')
           options['tracing.opentelemetry.enabled'] = !defined?(Datadog::OpenTelemetry::LOADED).nil?
+          options['tracing.opentracing.enabled'] = !defined?(Datadog::OpenTracer::LOADED).nil?
           options.compact!
           options
         end

--- a/lib/datadog/opentracer.rb
+++ b/lib/datadog/opentracer.rb
@@ -22,3 +22,12 @@ require_relative 'opentracer/global_tracer'
 
 # Modify the OpenTracing module functions
 ::OpenTracing.singleton_class.prepend(Datadog::OpenTracer::GlobalTracer)
+
+module Datadog
+  # Datadog OpenTracing integration.
+  # DEV: This module should be named `Datadog::OpenTracing` to match the gem (`opentracing`).
+  module OpenTracer
+    # Used by Telemetry to decide if OpenTracing instrumentation is enabled
+    LOADED = true
+  end
+end

--- a/spec/datadog/core/telemetry/collector_spec.rb
+++ b/spec/datadog/core/telemetry/collector_spec.rb
@@ -293,6 +293,14 @@ RSpec.describe Datadog::Core::Telemetry::Collector do
 
       it { is_expected.to include('tracing.opentelemetry.enabled' => true) }
     end
+
+    context 'when OpenTracing is enabled' do
+      before do
+        stub_const('Datadog::OpenTracer::LOADED', true)
+      end
+
+      it { is_expected.to include('tracing.opentracing.enabled' => true) }
+    end
   end
 
   describe '#dependencies' do


### PR DESCRIPTION
<!--
Check out the
https://github.com/DataDog/dd-trace-rb/blob/master/docs/DevelopmentGuide.md
for guidance on how to set up your development environment,
run the test suite, write new integrations, and more.
-->

**What does this PR do?**
<!-- A brief description of the change being made with this pull request. -->

Adds telemetry to measure usage of the OpenTracing integration.

**Motivation:**
<!-- What inspired you to submit this pull request? -->

[OpenTracing has been superseded by OpenTelemetry.](https://www.cncf.io/blog/2022/01/31/cncf-archives-the-opentracing-project/)
We want to measure its usage going forward to make decisions regarding how support for OpenTracing.

**Additional Notes:**
<!-- Anything else we should know when reviewing? -->

**How to test the change?**
<!--
Describe here how the change can be validated.
You are strongly encouraged to provide automated tests for this PR (unit or integration).
If this change cannot be feasibly tested, please explain why,
unless the change does not modify code (e.g. only modifies docs, comments).
-->

**For Datadog employees:**
- [ ] If this PR touches code that signs or publishes builds or packages, or handles
credentials of any kind, I've requested a review from `@DataDog/security-design-and-guidance`.
- [ ] This PR doesn't touch any of that.

Unsure? Have a question? Request a review!
