### PR TITLE
[PROF-7307] Enable allocation counting feature by default for some Ruby 3 versions

### DIFF
--- a/spec/datadog/core/configuration/settings_spec.rb
+++ b/spec/datadog/core/configuration/settings_spec.rb
@@ -500,16 +500,25 @@ RSpec.describe Datadog::Core::Configuration::Settings do
       describe '#allocation_counting_enabled' do
         subject(:allocation_counting_enabled) { settings.profiling.advanced.allocation_counting_enabled }
 
-        context 'on Ruby 2.x' do
-          before { skip("Spec doesn't run on Ruby 3.x") unless RUBY_VERSION.start_with?('2.') }
+        before { stub_const('RUBY_VERSION', testing_version) }
 
+        context 'on Ruby 2.x' do
+          let(:testing_version) { '2.3.0 ' }
           it { is_expected.to be true }
         end
 
-        context 'on Ruby 3.x' do
-          before { skip("Spec doesn't run on Ruby 2.x") if RUBY_VERSION.start_with?('2.') }
+        ['3.0.0', '3.1.0', '3.1.3', '3.2.0', '3.2.2'].each do |broken_ruby|
+          context "on a Ruby 3 version affected by https://bugs.ruby-lang.org/issues/18464 (#{broken_ruby})" do
+            let(:testing_version) { broken_ruby }
+            it { is_expected.to be false }
+          end
+        end
 
-          it { is_expected.to be false }
+        ['3.1.4', '3.2.3', '3.3.0'].each do |fixed_ruby|
+          context "on a Ruby 3 version where https://bugs.ruby-lang.org/issues/18464 is fixed (#{fixed_ruby})" do
+            let(:testing_version) { fixed_ruby }
+            it { is_expected.to be true }
+          end
         end
       end
 


### PR DESCRIPTION
**What does this PR do?**

This PR enables the Profiler's `allocation_counting_enabled` feature by default for some Ruby 3 versions.

(This feature depends on the profiler itself being enabled).

TL;DR we were already enabling this feature by default on Ruby 2, but did not do it on Ruby 3 because of a VM bug
( https://bugs.ruby-lang.org/issues/18464 ).

Now that this VM bug has been fixed for some Ruby versions (3.1.4, 3.2.3, 3.3.0), we can enable it by default again.

**Motivation:**

The allocation counting feature is required to enable other features in the future (including allocation profiling) and thus we want to allow as many customers as possible to have it.

**Additional Notes:**

There's a second annoying VM bug that can also break `allocation_counting_enabled` (https://bugs.ruby-lang.org/issues/19112) but since that bug doesn't cause a VM crash and only makes it so that data collection stops for this feature, I think we can live with it for now.

I'm also reaching out through some contacts to see if we can get the other bug fixed soon (and possibly backported).

**How to test the change?**

Change includes test coverage.

**For Datadog employees:**
- [ ] If this PR touches code that signs or publishes builds or packages, or handles
credentials of any kind, I've requested a review from `@DataDog/security-design-and-guidance`.
- [x] This PR doesn't touch any of that.