### PR TITLE
Disable schedule rule for BP and reenable nightly deploy to RelEnv

### DIFF
--- a/.gitlab/benchmarks.yml
+++ b/.gitlab/benchmarks.yml
@@ -13,8 +13,6 @@ variables:
   rules:
     - if: $CI_COMMIT_REF_NAME == "master"
       when: always
-    - if: $CI_PIPELINE_SOURCE == "schedule"
-      when: always
     - when: manual
   # If you have a problem with Gitlab cache, see Troubleshooting section in Benchmarking Platform docs
   image: $GITLAB_BENCHMARKS_CI_IMAGE


### PR DESCRIPTION
<!--
Check out the
https://github.com/DataDog/dd-trace-rb/blob/master/docs/DevelopmentGuide.md
for guidance on how to set up your development environment,
run the test suite, write new integrations, and more.
-->

**What does this PR do?**

Reenable nightly deploy to RelEnv without changing logic of BP pipelines.

**Motivation:**

Bug fix for CI/CD pipeline.

**How to test the change?**

The newest commit should be deployed to RelEnv nightly. BP should not run nightly.
