### PR TITLE
Add more logging to profiling flaky to thread state categorization spec

### DIFF
--- a/spec/datadog/profiling/collectors/stack_spec.rb
+++ b/spec/datadog/profiling/collectors/stack_spec.rb
@@ -314,7 +314,12 @@ RSpec.describe Datadog::Profiling::Collectors::Stack do
         end
 
         it do
-          expect(sample_and_decode(background_thread, :labels)).to include(state: 'blocked')
+          sample = sample_and_decode(background_thread, :itself)
+          expect(sample.labels).to(
+            include(state: 'blocked'),
+            "**If you see this test flaking, please report it to @ivoanjo!**\n\n" \
+            "sample: #{sample}",
+          )
         end
       end
 


### PR DESCRIPTION
**What does this PR do?**

The spec

> Datadog::Profiling::Collectors::Stack in a background thread
> approximate thread state categorization based on current stack when
> sampling a thread blocked on Thread#join is expected
> to include {:state => "blocked"}

proved to be flaky in
https://app.circleci.com/pipelines/github/DataDog/dd-trace-rb/12189/workflows/78612cd5-3173-4faf-a034-5cb172ed4549/jobs/458502

```
     Failure/Error: expect(sample_and_decode(background_thread, :labels)).to include(state: 'blocked')

       expected {:label_a => "value_a", :label_b => "value_b", :state => "unknown"} to include {:state => "blocked"}
       Diff:
       @@ -1,3 +1,5 @@
       -:state => "blocked",
       +:label_a => "value_a",
       +:label_b => "value_b",
       +:state => "unknown",
```

I'm not entirely sure what happened here -- if the thread we were inspecting did not have the expected stack (but what stack would it have?) or something else.

I tried reproducing the failure using `rspec_n` on this file, and re-running the entire suite and could not replicate the issue.

Thus, I'm updating the test to add more debugging info, so I can investigate further. If this happens again, hopefully we'll be able to track it down, or decide to redo/disable the spec to avoid annoying everyone.

**Motivation:**

Make sure there are zero profiling flaky specs.

**Additional Notes:**

N/A

**How to test the change?**

Change affects only the test suite.

**For Datadog employees:**
- [ ] If this PR touches code that signs or publishes builds or packages, or handles
credentials of any kind, I've requested a review from `@DataDog/security-design-and-guidance`.
- [x] This PR doesn't touch any of that.