### PR TITLE
[PROF-7440] Add workaround for incorrect invoke location when logging gem is in use

### DIFF
--- a/ext/ddtrace_profiling_native_extension/collectors_thread_context.c
+++ b/ext/ddtrace_profiling_native_extension/collectors_thread_context.c
@@ -819,6 +819,13 @@ static struct per_thread_context *get_context_for(VALUE thread, struct thread_co
 
 // The `logging` gem monkey patches thread creation, which makes the `invoke_location_for` useless, since every thread
 // will point to the `logging` gem. When that happens, we avoid using the invoke location.
+//
+// TODO: This approach is a bit brittle, since it matches on the specific gem path, and only works for the `logging`
+// gem.
+// In the future we should probably explore a more generic fix (e.g. using Thread.method(:new).source_location or
+// something like that to detect redefinition of the `Thread` methods). One difficulty of doing it is that we need
+// to either run Ruby code during sampling (not great), or otherwise use some of the VM private APIs to detect this.
+//
 static bool is_logging_gem_monkey_patch(VALUE invoke_file_location) {
   int logging_gem_path_len = strlen(LOGGING_GEM_PATH);
   char *invoke_file = StringValueCStr(invoke_file_location);

--- a/spec/datadog/profiling/collectors/helper/lib/logging/diagnostic_context.rb
+++ b/spec/datadog/profiling/collectors/helper/lib/logging/diagnostic_context.rb
@@ -1,0 +1,12 @@
+# This file is used by the `thread_context_spec.rb`. It's used to simulate the file from the `logging` gem on the same
+# partial path. See that file for more details.
+
+# rubocop:disable Style/GlobalVars
+
+$simulated_logging_gem_monkey_patched_thread_ready_queue = Queue.new
+$simulated_logging_gem_monkey_patched_thread = Thread.start do
+  $simulated_logging_gem_monkey_patched_thread_ready_queue << true
+  sleep
+end
+
+# rubocop:enable Style/GlobalVars


### PR DESCRIPTION
**What does this PR do?**

In #2950, we added a fallback for nameless threads: we use their "invoke location", as shown by Ruby in the default `Thread#to_s`. The invoke location is the file and line of the first method of the thread.

This fallback has an issue: when thread creation is monkey patched. One common source of this is the `logging` gem. When the `logging` gem monkey patches thread creation, every thread will have the same invoke location, which will point to the `logging` gem.

This made the fallback invoke location worse than not having anything.

To work around this, this PR changes the profiler so that when the invoke location belongs to the `logging` gem, it's not used, and a simpler `(Unnamed thread)` placeholder is used instead.

**Motivation:**

This issue came up when testing the timeline feature with some of the internal Ruby apps.

**Additional Notes:**

In the future we could probably explore a more generic fix (e.g. using `Thread.method(:new).source_location` or something like that to detect redefinition) but doing that from the profiler native code is a bit more work so I decided to go with a simpler approach.

**How to test the change?**

Change includes test coverage. You can also see the thread name difference on an app by creating a simple thread before/after loading the `logging` gem and see the fallback name for the thread.

**For Datadog employees:**
- [ ] If this PR touches code that signs or publishes builds or packages, or handles
credentials of any kind, I've requested a review from `@DataDog/security-design-and-guidance`.
- [x] This PR doesn't touch any of that.