### PR TITLE
Respect service_name in active_record.instantiation events

### DIFF
--- a/lib/datadog/tracing/contrib/active_record/events/instantiation.rb
+++ b/lib/datadog/tracing/contrib/active_record/events/instantiation.rb
@@ -31,6 +31,7 @@ module Datadog
 
             def process(span, event, _id, payload)
               span.resource = payload.fetch(:class_name)
+              span.service = configuration[:service_name] if configuration[:service_name]
               span.span_type = Ext::SPAN_TYPE_INSTANTIATION
               span.set_tag(Tracing::Metadata::Ext::TAG_COMPONENT, Ext::TAG_COMPONENT)
               span.set_tag(Tracing::Metadata::Ext::TAG_OPERATION, Ext::TAG_OPERATION_INSTANTIATION)

--- a/spec/datadog/tracing/contrib/active_record/instantiation_spec.rb
+++ b/spec/datadog/tracing/contrib/active_record/instantiation_spec.rb
@@ -1,0 +1,71 @@
+require 'datadog/tracing/contrib/support/spec_helper'
+require 'datadog/tracing/contrib/analytics_examples'
+require 'datadog/tracing/contrib/integration_examples'
+require 'datadog/tracing/contrib/span_attribute_schema_examples'
+require 'ddtrace'
+
+require 'spec/datadog/tracing/contrib/rails/support/deprecation'
+
+require_relative 'app'
+
+RSpec.describe 'ActiveRecord instantiation instrumentation' do
+  let(:configuration_options) { {} }
+  let(:artile) { Article.new(title: 'test') }
+
+  before do
+    # Prevent extra spans during tests
+    Article.count
+
+    # Reset options (that might linger from other tests)
+    Datadog.configuration.tracing[:active_record].reset!
+
+    Datadog.configure do |c|
+      c.tracing.instrument :active_record, configuration_options
+    end
+
+    raise_on_rails_deprecation!
+  end
+
+  around do |example|
+    # Reset before and after each example; don't allow global state to linger.
+    Datadog.registry[:active_record].reset_configuration!
+    example.run
+    Datadog.registry[:active_record].reset_configuration!
+  end
+
+  context 'when a model is instantiated' do
+    before { Article.count }
+
+    it_behaves_like 'analytics for integration' do
+      let(:analytics_enabled_var) { Datadog::Tracing::Contrib::ActiveRecord::Ext::ENV_ANALYTICS_ENABLED }
+      let(:analytics_sample_rate_var) { Datadog::Tracing::Contrib::ActiveRecord::Ext::ENV_ANALYTICS_SAMPLE_RATE }
+    end
+
+    it_behaves_like 'measured span for integration', false
+
+    it 'calls the instrumentation when is used standalone' do
+      aggregate_failures do
+        expect(span.service).to eq('fixme')
+        expect(span.name).to eq('active_record.instantiation')
+        expect(span.span_type).to eq('fixme')
+        expect(span.resource.strip).to eq('Article')
+        expect(span.get_tag(Datadog::Tracing::Metadata::Ext::TAG_COMPONENT)).to eq('active_record')
+      end
+    end
+
+    context 'and service_name' do
+      it_behaves_like 'schema version span'
+
+      context 'is not set' do
+        it { expect(span.service).to eq('fixme') }
+      end
+
+      context 'is set' do
+        let(:service_name) { 'test_active_record' }
+        let(:configuration_options) { super().merge(service_name: service_name) }
+
+        it { expect(span.service).to eq(service_name) }
+      end
+    end
+  end
+end

--- a/spec/datadog/tracing/contrib/active_record/instantiation_spec.rb
+++ b/spec/datadog/tracing/contrib/active_record/instantiation_spec.rb
@@ -13,8 +13,8 @@ RSpec.describe 'ActiveRecord instantiation instrumentation' do
   let(:artile) { Article.new(title: 'test') }
 
   before do
-    # Prevent extra spans during tests
-    Article.count
+    # # Prevent extra spans during tests
+    # Article.count
 
     # Reset options (that might linger from other tests)
     Datadog.configuration.tracing[:active_record].reset!
@@ -34,7 +34,7 @@ RSpec.describe 'ActiveRecord instantiation instrumentation' do
   end
 
   context 'when a model is instantiated' do
-    before { Article.count }
+    before { artile }
 
     it_behaves_like 'analytics for integration' do
       let(:analytics_enabled_var) { Datadog::Tracing::Contrib::ActiveRecord::Ext::ENV_ANALYTICS_ENABLED }


### PR DESCRIPTION
<!--
Check out the
https://github.com/DataDog/dd-trace-rb/blob/master/docs/DevelopmentGuide.md
for guidance on how to set up your development environment,
run the test suite, write new integrations, and more.
-->

**What does this PR do?**
<!-- A brief description of the change being made with this pull request. -->

Use the configured value of `service_name` for `active_record.instantiation` instrumentation

**Motivation:**
<!-- What inspired you to submit this pull request? -->

In our application, we configure the service name. This is being respected by all operations under rails and active_record, including `mysql.query` (active_record), but also `rack.request`, `active_job.perform`, `rails.render_template`, and so on, but not `active_record.instantiation`, which ends up in a separate, unique service. This is confusing and makes it harder to reason about our APM page.

**Additional Notes:**
<!-- Anything else we should know when reviewing? -->

We are configuring our application similarly to

```rb
  Datadog.configure do |c|
    # ...
    c.tracing.instrument :rails, service_name: "foo"
    c.tracing.instrument :active_record, service_name: "foo"  
    # ...
  end
```

And we are currently working around this limitation with a monkey patch to `Datadog::Tracing::Contrib::ActiveRecord::Events`:

```rb
        def process(span, event, _id, payload)
          span.service = "foo"
          super
        end
```

**How to test the change?**
<!--
Describe here how the change can be validated.
You are strongly encouraged to provide automated tests for this PR (unit or integration).
If this change cannot be feasibly tested, please explain why,
unless the change does not modify code (e.g. only modifies docs, comments).
-->

There wasn't a spec for `active_record.instantiation` that I could see, so I added one. (Still trying to work out some local docker issues, so also trying to use this PR for CI)

**For Datadog employees:**
- [ ] If this PR touches code that signs or publishes builds or packages, or handles
credentials of any kind, I've requested a review from `@DataDog/security-design-and-guidance`.
- [ ] This PR doesn't touch any of that.

Unsure? Have a question? Request a review!
