### PR TITLE
bump datadog-ci dependency to 0.2

### DIFF
--- a/ddtrace.gemspec
+++ b/ddtrace.gemspec
@@ -69,7 +69,7 @@ Gem::Specification.new do |spec|
   spec.add_dependency 'libdatadog', '~> 5.0.0.1.0'
 
   # used for CI visibility product until the next major version
-  spec.add_dependency 'datadog-ci', '~> 0.1.0'
+  spec.add_dependency 'datadog-ci', '~> 0.2.0'
 
   spec.extensions = ['ext/ddtrace_profiling_native_extension/extconf.rb', 'ext/ddtrace_profiling_loader/extconf.rb']
 end

--- a/gemfiles/jruby_9.2.21.0_sinatra.gemfile.lock
+++ b/gemfiles/jruby_9.2.21.0_sinatra.gemfile.lock
@@ -12,7 +12,7 @@ PATH
   remote: ..
   specs:
     ddtrace (1.14.0)
-      datadog-ci (~> 0.1.0)
+      datadog-ci (~> 0.2.0)
       debase-ruby_core_source (= 3.2.2)
       libdatadog (~> 5.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
@@ -37,7 +37,7 @@ GEM
     crack (0.4.5)
       rexml
     cri (2.15.11)
-    datadog-ci (0.1.1)
+    datadog-ci (0.2.0)
     debase-ruby_core_source (3.2.2)
     diff-lcs (1.5.0)
     docile (1.4.0)

--- a/gemfiles/jruby_9.2_activesupport.gemfile.lock
+++ b/gemfiles/jruby_9.2_activesupport.gemfile.lock
@@ -12,7 +12,7 @@ PATH
   remote: ..
   specs:
     ddtrace (1.14.0)
-      datadog-ci (~> 0.1.0)
+      datadog-ci (~> 0.2.0)
       debase-ruby_core_source (= 3.2.2)
       libdatadog (~> 5.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
@@ -65,7 +65,7 @@ GEM
       rexml
     crass (1.0.6)
     cri (2.15.11)
-    datadog-ci (0.1.1)
+    datadog-ci (0.2.0)
     debase-ruby_core_source (3.2.2)
     diff-lcs (1.5.0)
     digest-crc (0.6.5)

--- a/gemfiles/jruby_9.2_aws.gemfile.lock
+++ b/gemfiles/jruby_9.2_aws.gemfile.lock
@@ -12,7 +12,7 @@ PATH
   remote: ..
   specs:
     ddtrace (1.14.0)
-      datadog-ci (~> 0.1.0)
+      datadog-ci (~> 0.2.0)
       debase-ruby_core_source (= 3.2.2)
       libdatadog (~> 5.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
@@ -1458,7 +1458,7 @@ GEM
     crack (0.4.5)
       rexml
     cri (2.15.11)
-    datadog-ci (0.1.1)
+    datadog-ci (0.2.0)
     debase-ruby_core_source (3.2.2)
     diff-lcs (1.5.0)
     docile (1.4.0)

--- a/gemfiles/jruby_9.2_contrib.gemfile.lock
+++ b/gemfiles/jruby_9.2_contrib.gemfile.lock
@@ -12,7 +12,7 @@ PATH
   remote: ..
   specs:
     ddtrace (1.14.0)
-      datadog-ci (~> 0.1.0)
+      datadog-ci (~> 0.2.0)
       debase-ruby_core_source (= 3.2.2)
       libdatadog (~> 5.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
@@ -44,7 +44,7 @@ GEM
       rexml
     cri (2.15.11)
     dalli (3.2.0)
-    datadog-ci (0.1.1)
+    datadog-ci (0.2.0)
     debase-ruby_core_source (3.2.2)
     diff-lcs (1.5.0)
     docile (1.4.0)

--- a/gemfiles/jruby_9.2_contrib_old.gemfile.lock
+++ b/gemfiles/jruby_9.2_contrib_old.gemfile.lock
@@ -12,7 +12,7 @@ PATH
   remote: ..
   specs:
     ddtrace (1.14.0)
-      datadog-ci (~> 0.1.0)
+      datadog-ci (~> 0.2.0)
       debase-ruby_core_source (= 3.2.2)
       libdatadog (~> 5.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
@@ -38,7 +38,7 @@ GEM
       rexml
     cri (2.15.11)
     dalli (2.7.11)
-    datadog-ci (0.1.1)
+    datadog-ci (0.2.0)
     debase-ruby_core_source (3.2.2)
     diff-lcs (1.5.0)
     docile (1.4.0)

--- a/gemfiles/jruby_9.2_core_old.gemfile.lock
+++ b/gemfiles/jruby_9.2_core_old.gemfile.lock
@@ -12,7 +12,7 @@ PATH
   remote: ..
   specs:
     ddtrace (1.14.0)
-      datadog-ci (~> 0.1.0)
+      datadog-ci (~> 0.2.0)
       debase-ruby_core_source (= 3.2.2)
       libdatadog (~> 5.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
@@ -37,7 +37,7 @@ GEM
     crack (0.4.5)
       rexml
     cri (2.15.11)
-    datadog-ci (0.1.1)
+    datadog-ci (0.2.0)
     debase-ruby_core_source (3.2.2)
     diff-lcs (1.5.0)
     docile (1.4.0)

--- a/gemfiles/jruby_9.2_hanami_1.gemfile.lock
+++ b/gemfiles/jruby_9.2_hanami_1.gemfile.lock
@@ -12,7 +12,7 @@ PATH
   remote: ..
   specs:
     ddtrace (1.14.0)
-      datadog-ci (~> 0.1.0)
+      datadog-ci (~> 0.2.0)
       debase-ruby_core_source (= 3.2.2)
       libdatadog (~> 5.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
@@ -37,7 +37,7 @@ GEM
     crack (0.4.5)
       rexml
     cri (2.15.11)
-    datadog-ci (0.1.1)
+    datadog-ci (0.2.0)
     debase-ruby_core_source (3.2.2)
     diff-lcs (1.5.0)
     digest (3.1.1-java)

--- a/gemfiles/jruby_9.2_http.gemfile.lock
+++ b/gemfiles/jruby_9.2_http.gemfile.lock
@@ -12,7 +12,7 @@ PATH
   remote: ..
   specs:
     ddtrace (1.14.0)
-      datadog-ci (~> 0.1.0)
+      datadog-ci (~> 0.2.0)
       debase-ruby_core_source (= 3.2.2)
       libdatadog (~> 5.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
@@ -37,7 +37,7 @@ GEM
     crack (0.4.5)
       rexml
     cri (2.15.11)
-    datadog-ci (0.1.1)
+    datadog-ci (0.2.0)
     debase-ruby_core_source (3.2.2)
     diff-lcs (1.5.0)
     docile (1.4.0)

--- a/gemfiles/jruby_9.2_opentracing.gemfile.lock
+++ b/gemfiles/jruby_9.2_opentracing.gemfile.lock
@@ -12,7 +12,7 @@ PATH
   remote: ..
   specs:
     ddtrace (1.14.0)
-      datadog-ci (~> 0.1.0)
+      datadog-ci (~> 0.2.0)
       debase-ruby_core_source (= 3.2.2)
       libdatadog (~> 5.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
@@ -38,7 +38,7 @@ GEM
     crack (0.4.5)
       rexml
     cri (2.15.11)
-    datadog-ci (0.1.1)
+    datadog-ci (0.2.0)
     debase-ruby_core_source (3.2.2)
     diff-lcs (1.5.0)
     docile (1.4.0)

--- a/gemfiles/jruby_9.2_rack_1.gemfile.lock
+++ b/gemfiles/jruby_9.2_rack_1.gemfile.lock
@@ -12,7 +12,7 @@ PATH
   remote: ..
   specs:
     ddtrace (1.14.0)
-      datadog-ci (~> 0.1.0)
+      datadog-ci (~> 0.2.0)
       debase-ruby_core_source (= 3.2.2)
       libdatadog (~> 5.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
@@ -37,7 +37,7 @@ GEM
     crack (0.4.5)
       rexml
     cri (2.15.11)
-    datadog-ci (0.1.1)
+    datadog-ci (0.2.0)
     debase-ruby_core_source (3.2.2)
     diff-lcs (1.5.0)
     docile (1.4.0)

--- a/gemfiles/jruby_9.2_rack_2.gemfile.lock
+++ b/gemfiles/jruby_9.2_rack_2.gemfile.lock
@@ -12,7 +12,7 @@ PATH
   remote: ..
   specs:
     ddtrace (1.14.0)
-      datadog-ci (~> 0.1.0)
+      datadog-ci (~> 0.2.0)
       debase-ruby_core_source (= 3.2.2)
       libdatadog (~> 5.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
@@ -37,7 +37,7 @@ GEM
     crack (0.4.5)
       rexml
     cri (2.15.11)
-    datadog-ci (0.1.1)
+    datadog-ci (0.2.0)
     debase-ruby_core_source (3.2.2)
     diff-lcs (1.5.0)
     docile (1.4.0)

--- a/gemfiles/jruby_9.2_rack_3.gemfile.lock
+++ b/gemfiles/jruby_9.2_rack_3.gemfile.lock
@@ -12,7 +12,7 @@ PATH
   remote: ..
   specs:
     ddtrace (1.14.0)
-      datadog-ci (~> 0.1.0)
+      datadog-ci (~> 0.2.0)
       debase-ruby_core_source (= 3.2.2)
       libdatadog (~> 5.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
@@ -37,7 +37,7 @@ GEM
     crack (0.4.5)
       rexml
     cri (2.15.11)
-    datadog-ci (0.1.1)
+    datadog-ci (0.2.0)
     debase-ruby_core_source (3.2.2)
     diff-lcs (1.5.0)
     docile (1.4.0)

--- a/gemfiles/jruby_9.2_rails5_mysql2.gemfile.lock
+++ b/gemfiles/jruby_9.2_rails5_mysql2.gemfile.lock
@@ -12,7 +12,7 @@ PATH
   remote: ..
   specs:
     ddtrace (1.14.0)
-      datadog-ci (~> 0.1.0)
+      datadog-ci (~> 0.2.0)
       debase-ruby_core_source (= 3.2.2)
       libdatadog (~> 5.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
@@ -85,7 +85,7 @@ GEM
       rexml
     crass (1.0.6)
     cri (2.15.11)
-    datadog-ci (0.1.1)
+    datadog-ci (0.2.0)
     debase-ruby_core_source (3.2.2)
     diff-lcs (1.5.0)
     docile (1.4.0)

--- a/gemfiles/jruby_9.2_rails5_postgres.gemfile.lock
+++ b/gemfiles/jruby_9.2_rails5_postgres.gemfile.lock
@@ -12,7 +12,7 @@ PATH
   remote: ..
   specs:
     ddtrace (1.14.0)
-      datadog-ci (~> 0.1.0)
+      datadog-ci (~> 0.2.0)
       debase-ruby_core_source (= 3.2.2)
       libdatadog (~> 5.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
@@ -85,7 +85,7 @@ GEM
       rexml
     crass (1.0.6)
     cri (2.15.11)
-    datadog-ci (0.1.1)
+    datadog-ci (0.2.0)
     debase-ruby_core_source (3.2.2)
     diff-lcs (1.5.0)
     digest (3.1.1-java)

--- a/gemfiles/jruby_9.2_rails5_postgres_redis.gemfile.lock
+++ b/gemfiles/jruby_9.2_rails5_postgres_redis.gemfile.lock
@@ -12,7 +12,7 @@ PATH
   remote: ..
   specs:
     ddtrace (1.14.0)
-      datadog-ci (~> 0.1.0)
+      datadog-ci (~> 0.2.0)
       debase-ruby_core_source (= 3.2.2)
       libdatadog (~> 5.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
@@ -86,7 +86,7 @@ GEM
       rexml
     crass (1.0.6)
     cri (2.15.11)
-    datadog-ci (0.1.1)
+    datadog-ci (0.2.0)
     debase-ruby_core_source (3.2.2)
     diff-lcs (1.5.0)
     digest (3.1.1-java)

--- a/gemfiles/jruby_9.2_rails5_postgres_redis_activesupport.gemfile.lock
+++ b/gemfiles/jruby_9.2_rails5_postgres_redis_activesupport.gemfile.lock
@@ -12,7 +12,7 @@ PATH
   remote: ..
   specs:
     ddtrace (1.14.0)
-      datadog-ci (~> 0.1.0)
+      datadog-ci (~> 0.2.0)
       debase-ruby_core_source (= 3.2.2)
       libdatadog (~> 5.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
@@ -85,7 +85,7 @@ GEM
       rexml
     crass (1.0.6)
     cri (2.15.11)
-    datadog-ci (0.1.1)
+    datadog-ci (0.2.0)
     debase-ruby_core_source (3.2.2)
     diff-lcs (1.5.0)
     digest (3.1.1-java)

--- a/gemfiles/jruby_9.2_rails5_postgres_sidekiq.gemfile.lock
+++ b/gemfiles/jruby_9.2_rails5_postgres_sidekiq.gemfile.lock
@@ -12,7 +12,7 @@ PATH
   remote: ..
   specs:
     ddtrace (1.14.0)
-      datadog-ci (~> 0.1.0)
+      datadog-ci (~> 0.2.0)
       debase-ruby_core_source (= 3.2.2)
       libdatadog (~> 5.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
@@ -86,7 +86,7 @@ GEM
       rexml
     crass (1.0.6)
     cri (2.15.11)
-    datadog-ci (0.1.1)
+    datadog-ci (0.2.0)
     debase-ruby_core_source (3.2.2)
     diff-lcs (1.5.0)
     digest (3.1.1-java)

--- a/gemfiles/jruby_9.2_rails5_semantic_logger.gemfile.lock
+++ b/gemfiles/jruby_9.2_rails5_semantic_logger.gemfile.lock
@@ -12,7 +12,7 @@ PATH
   remote: ..
   specs:
     ddtrace (1.14.0)
-      datadog-ci (~> 0.1.0)
+      datadog-ci (~> 0.2.0)
       debase-ruby_core_source (= 3.2.2)
       libdatadog (~> 5.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
@@ -85,7 +85,7 @@ GEM
       rexml
     crass (1.0.6)
     cri (2.15.11)
-    datadog-ci (0.1.1)
+    datadog-ci (0.2.0)
     debase-ruby_core_source (3.2.2)
     diff-lcs (1.5.0)
     digest (3.1.1-java)

--- a/gemfiles/jruby_9.2_rails61_mysql2.gemfile.lock
+++ b/gemfiles/jruby_9.2_rails61_mysql2.gemfile.lock
@@ -12,7 +12,7 @@ PATH
   remote: ..
   specs:
     ddtrace (1.14.0)
-      datadog-ci (~> 0.1.0)
+      datadog-ci (~> 0.2.0)
       debase-ruby_core_source (= 3.2.2)
       libdatadog (~> 5.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
@@ -102,7 +102,7 @@ GEM
       rexml
     crass (1.0.6)
     cri (2.15.11)
-    datadog-ci (0.1.1)
+    datadog-ci (0.2.0)
     debase-ruby_core_source (3.2.2)
     diff-lcs (1.5.0)
     docile (1.4.0)

--- a/gemfiles/jruby_9.2_rails61_postgres.gemfile.lock
+++ b/gemfiles/jruby_9.2_rails61_postgres.gemfile.lock
@@ -12,7 +12,7 @@ PATH
   remote: ..
   specs:
     ddtrace (1.14.0)
-      datadog-ci (~> 0.1.0)
+      datadog-ci (~> 0.2.0)
       debase-ruby_core_source (= 3.2.2)
       libdatadog (~> 5.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
@@ -102,7 +102,7 @@ GEM
       rexml
     crass (1.0.6)
     cri (2.15.11)
-    datadog-ci (0.1.1)
+    datadog-ci (0.2.0)
     debase-ruby_core_source (3.2.2)
     diff-lcs (1.5.0)
     digest (3.1.1-java)

--- a/gemfiles/jruby_9.2_rails61_postgres_redis.gemfile.lock
+++ b/gemfiles/jruby_9.2_rails61_postgres_redis.gemfile.lock
@@ -12,7 +12,7 @@ PATH
   remote: ..
   specs:
     ddtrace (1.14.0)
-      datadog-ci (~> 0.1.0)
+      datadog-ci (~> 0.2.0)
       debase-ruby_core_source (= 3.2.2)
       libdatadog (~> 5.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
@@ -103,7 +103,7 @@ GEM
       rexml
     crass (1.0.6)
     cri (2.15.11)
-    datadog-ci (0.1.1)
+    datadog-ci (0.2.0)
     debase-ruby_core_source (3.2.2)
     diff-lcs (1.5.0)
     digest (3.1.1-java)

--- a/gemfiles/jruby_9.2_rails61_postgres_sidekiq.gemfile.lock
+++ b/gemfiles/jruby_9.2_rails61_postgres_sidekiq.gemfile.lock
@@ -12,7 +12,7 @@ PATH
   remote: ..
   specs:
     ddtrace (1.14.0)
-      datadog-ci (~> 0.1.0)
+      datadog-ci (~> 0.2.0)
       debase-ruby_core_source (= 3.2.2)
       libdatadog (~> 5.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
@@ -103,7 +103,7 @@ GEM
       rexml
     crass (1.0.6)
     cri (2.15.11)
-    datadog-ci (0.1.1)
+    datadog-ci (0.2.0)
     debase-ruby_core_source (3.2.2)
     diff-lcs (1.5.0)
     digest (3.1.1-java)

--- a/gemfiles/jruby_9.2_rails61_semantic_logger.gemfile.lock
+++ b/gemfiles/jruby_9.2_rails61_semantic_logger.gemfile.lock
@@ -12,7 +12,7 @@ PATH
   remote: ..
   specs:
     ddtrace (1.14.0)
-      datadog-ci (~> 0.1.0)
+      datadog-ci (~> 0.2.0)
       debase-ruby_core_source (= 3.2.2)
       libdatadog (~> 5.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
@@ -102,7 +102,7 @@ GEM
       rexml
     crass (1.0.6)
     cri (2.15.11)
-    datadog-ci (0.1.1)
+    datadog-ci (0.2.0)
     debase-ruby_core_source (3.2.2)
     diff-lcs (1.5.0)
     digest (3.1.1-java)

--- a/gemfiles/jruby_9.2_rails6_mysql2.gemfile.lock
+++ b/gemfiles/jruby_9.2_rails6_mysql2.gemfile.lock
@@ -12,7 +12,7 @@ PATH
   remote: ..
   specs:
     ddtrace (1.14.0)
-      datadog-ci (~> 0.1.0)
+      datadog-ci (~> 0.2.0)
       debase-ruby_core_source (= 3.2.2)
       libdatadog (~> 5.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
@@ -98,7 +98,7 @@ GEM
       rexml
     crass (1.0.6)
     cri (2.15.11)
-    datadog-ci (0.1.1)
+    datadog-ci (0.2.0)
     debase-ruby_core_source (3.2.2)
     diff-lcs (1.5.0)
     docile (1.4.0)

--- a/gemfiles/jruby_9.2_rails6_postgres.gemfile.lock
+++ b/gemfiles/jruby_9.2_rails6_postgres.gemfile.lock
@@ -12,7 +12,7 @@ PATH
   remote: ..
   specs:
     ddtrace (1.14.0)
-      datadog-ci (~> 0.1.0)
+      datadog-ci (~> 0.2.0)
       debase-ruby_core_source (= 3.2.2)
       libdatadog (~> 5.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
@@ -98,7 +98,7 @@ GEM
       rexml
     crass (1.0.6)
     cri (2.15.11)
-    datadog-ci (0.1.1)
+    datadog-ci (0.2.0)
     debase-ruby_core_source (3.2.2)
     diff-lcs (1.5.0)
     digest (3.1.1-java)

--- a/gemfiles/jruby_9.2_rails6_postgres_redis.gemfile.lock
+++ b/gemfiles/jruby_9.2_rails6_postgres_redis.gemfile.lock
@@ -12,7 +12,7 @@ PATH
   remote: ..
   specs:
     ddtrace (1.14.0)
-      datadog-ci (~> 0.1.0)
+      datadog-ci (~> 0.2.0)
       debase-ruby_core_source (= 3.2.2)
       libdatadog (~> 5.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
@@ -99,7 +99,7 @@ GEM
       rexml
     crass (1.0.6)
     cri (2.15.11)
-    datadog-ci (0.1.1)
+    datadog-ci (0.2.0)
     debase-ruby_core_source (3.2.2)
     diff-lcs (1.5.0)
     digest (3.1.1-java)

--- a/gemfiles/jruby_9.2_rails6_postgres_redis_activesupport.gemfile.lock
+++ b/gemfiles/jruby_9.2_rails6_postgres_redis_activesupport.gemfile.lock
@@ -12,7 +12,7 @@ PATH
   remote: ..
   specs:
     ddtrace (1.14.0)
-      datadog-ci (~> 0.1.0)
+      datadog-ci (~> 0.2.0)
       debase-ruby_core_source (= 3.2.2)
       libdatadog (~> 5.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
@@ -98,7 +98,7 @@ GEM
       rexml
     crass (1.0.6)
     cri (2.15.11)
-    datadog-ci (0.1.1)
+    datadog-ci (0.2.0)
     debase-ruby_core_source (3.2.2)
     diff-lcs (1.5.0)
     digest (3.1.1-java)

--- a/gemfiles/jruby_9.2_rails6_postgres_sidekiq.gemfile.lock
+++ b/gemfiles/jruby_9.2_rails6_postgres_sidekiq.gemfile.lock
@@ -12,7 +12,7 @@ PATH
   remote: ..
   specs:
     ddtrace (1.14.0)
-      datadog-ci (~> 0.1.0)
+      datadog-ci (~> 0.2.0)
       debase-ruby_core_source (= 3.2.2)
       libdatadog (~> 5.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
@@ -99,7 +99,7 @@ GEM
       rexml
     crass (1.0.6)
     cri (2.15.11)
-    datadog-ci (0.1.1)
+    datadog-ci (0.2.0)
     debase-ruby_core_source (3.2.2)
     diff-lcs (1.5.0)
     digest (3.1.1-java)

--- a/gemfiles/jruby_9.2_rails6_semantic_logger.gemfile.lock
+++ b/gemfiles/jruby_9.2_rails6_semantic_logger.gemfile.lock
@@ -12,7 +12,7 @@ PATH
   remote: ..
   specs:
     ddtrace (1.14.0)
-      datadog-ci (~> 0.1.0)
+      datadog-ci (~> 0.2.0)
       debase-ruby_core_source (= 3.2.2)
       libdatadog (~> 5.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
@@ -98,7 +98,7 @@ GEM
       rexml
     crass (1.0.6)
     cri (2.15.11)
-    datadog-ci (0.1.1)
+    datadog-ci (0.2.0)
     debase-ruby_core_source (3.2.2)
     diff-lcs (1.5.0)
     digest (3.1.1-java)

--- a/gemfiles/jruby_9.2_redis_3.gemfile.lock
+++ b/gemfiles/jruby_9.2_redis_3.gemfile.lock
@@ -12,7 +12,7 @@ PATH
   remote: ..
   specs:
     ddtrace (1.14.0)
-      datadog-ci (~> 0.1.0)
+      datadog-ci (~> 0.2.0)
       debase-ruby_core_source (= 3.2.2)
       libdatadog (~> 5.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
@@ -37,7 +37,7 @@ GEM
     crack (0.4.5)
       rexml
     cri (2.15.11)
-    datadog-ci (0.1.1)
+    datadog-ci (0.2.0)
     debase-ruby_core_source (3.2.2)
     diff-lcs (1.5.0)
     docile (1.4.0)

--- a/gemfiles/jruby_9.2_redis_4.gemfile.lock
+++ b/gemfiles/jruby_9.2_redis_4.gemfile.lock
@@ -12,7 +12,7 @@ PATH
   remote: ..
   specs:
     ddtrace (1.14.0)
-      datadog-ci (~> 0.1.0)
+      datadog-ci (~> 0.2.0)
       debase-ruby_core_source (= 3.2.2)
       libdatadog (~> 5.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
@@ -37,7 +37,7 @@ GEM
     crack (0.4.5)
       rexml
     cri (2.15.11)
-    datadog-ci (0.1.1)
+    datadog-ci (0.2.0)
     debase-ruby_core_source (3.2.2)
     diff-lcs (1.5.0)
     docile (1.4.0)

--- a/gemfiles/jruby_9.2_redis_5.gemfile.lock
+++ b/gemfiles/jruby_9.2_redis_5.gemfile.lock
@@ -12,7 +12,7 @@ PATH
   remote: ..
   specs:
     ddtrace (1.14.0)
-      datadog-ci (~> 0.1.0)
+      datadog-ci (~> 0.2.0)
       debase-ruby_core_source (= 3.2.2)
       libdatadog (~> 5.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
@@ -38,7 +38,7 @@ GEM
     crack (0.4.5)
       rexml
     cri (2.15.11)
-    datadog-ci (0.1.1)
+    datadog-ci (0.2.0)
     debase-ruby_core_source (3.2.2)
     diff-lcs (1.5.0)
     docile (1.4.0)

--- a/gemfiles/jruby_9.2_relational_db.gemfile.lock
+++ b/gemfiles/jruby_9.2_relational_db.gemfile.lock
@@ -12,7 +12,7 @@ PATH
   remote: ..
   specs:
     ddtrace (1.14.0)
-      datadog-ci (~> 0.1.0)
+      datadog-ci (~> 0.2.0)
       debase-ruby_core_source (= 3.2.2)
       libdatadog (~> 5.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
@@ -60,7 +60,7 @@ GEM
     crack (0.4.5)
       rexml
     cri (2.15.11)
-    datadog-ci (0.1.1)
+    datadog-ci (0.2.0)
     debase-ruby_core_source (3.2.2)
     delayed_job (4.1.11)
       activesupport (>= 3.0, < 8.0)

--- a/gemfiles/jruby_9.2_resque2_redis3.gemfile.lock
+++ b/gemfiles/jruby_9.2_resque2_redis3.gemfile.lock
@@ -12,7 +12,7 @@ PATH
   remote: ..
   specs:
     ddtrace (1.14.0)
-      datadog-ci (~> 0.1.0)
+      datadog-ci (~> 0.2.0)
       debase-ruby_core_source (= 3.2.2)
       libdatadog (~> 5.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
@@ -37,7 +37,7 @@ GEM
     crack (0.4.5)
       rexml
     cri (2.15.11)
-    datadog-ci (0.1.1)
+    datadog-ci (0.2.0)
     debase-ruby_core_source (3.2.2)
     diff-lcs (1.5.0)
     docile (1.4.0)

--- a/gemfiles/jruby_9.2_resque2_redis4.gemfile.lock
+++ b/gemfiles/jruby_9.2_resque2_redis4.gemfile.lock
@@ -12,7 +12,7 @@ PATH
   remote: ..
   specs:
     ddtrace (1.14.0)
-      datadog-ci (~> 0.1.0)
+      datadog-ci (~> 0.2.0)
       debase-ruby_core_source (= 3.2.2)
       libdatadog (~> 5.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
@@ -38,7 +38,7 @@ GEM
     crack (0.4.5)
       rexml
     cri (2.15.11)
-    datadog-ci (0.1.1)
+    datadog-ci (0.2.0)
     debase-ruby_core_source (3.2.2)
     diff-lcs (1.5.0)
     docile (1.4.0)

--- a/gemfiles/jruby_9.2_sinatra.gemfile.lock
+++ b/gemfiles/jruby_9.2_sinatra.gemfile.lock
@@ -12,7 +12,7 @@ PATH
   remote: ..
   specs:
     ddtrace (1.14.0)
-      datadog-ci (~> 0.1.0)
+      datadog-ci (~> 0.2.0)
       debase-ruby_core_source (= 3.2.2)
       libdatadog (~> 5.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
@@ -37,7 +37,7 @@ GEM
     crack (0.4.5)
       rexml
     cri (2.15.11)
-    datadog-ci (0.1.1)
+    datadog-ci (0.2.0)
     debase-ruby_core_source (3.2.2)
     diff-lcs (1.5.0)
     docile (1.4.0)

--- a/gemfiles/jruby_9.3_activesupport.gemfile.lock
+++ b/gemfiles/jruby_9.3_activesupport.gemfile.lock
@@ -12,7 +12,7 @@ PATH
   remote: ..
   specs:
     ddtrace (1.14.0)
-      datadog-ci (~> 0.1.0)
+      datadog-ci (~> 0.2.0)
       debase-ruby_core_source (= 3.2.2)
       libdatadog (~> 5.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
@@ -67,7 +67,7 @@ GEM
       rexml
     crass (1.0.6)
     cri (2.15.11)
-    datadog-ci (0.1.1)
+    datadog-ci (0.2.0)
     debase-ruby_core_source (3.2.2)
     diff-lcs (1.5.0)
     digest-crc (0.6.5)

--- a/gemfiles/jruby_9.3_aws.gemfile.lock
+++ b/gemfiles/jruby_9.3_aws.gemfile.lock
@@ -12,7 +12,7 @@ PATH
   remote: ..
   specs:
     ddtrace (1.14.0)
-      datadog-ci (~> 0.1.0)
+      datadog-ci (~> 0.2.0)
       debase-ruby_core_source (= 3.2.2)
       libdatadog (~> 5.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
@@ -1459,7 +1459,7 @@ GEM
     crack (0.4.5)
       rexml
     cri (2.15.11)
-    datadog-ci (0.1.1)
+    datadog-ci (0.2.0)
     debase-ruby_core_source (3.2.2)
     diff-lcs (1.5.0)
     docile (1.4.0)

--- a/gemfiles/jruby_9.3_contrib.gemfile.lock
+++ b/gemfiles/jruby_9.3_contrib.gemfile.lock
@@ -12,7 +12,7 @@ PATH
   remote: ..
   specs:
     ddtrace (1.14.0)
-      datadog-ci (~> 0.1.0)
+      datadog-ci (~> 0.2.0)
       debase-ruby_core_source (= 3.2.2)
       libdatadog (~> 5.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
@@ -45,7 +45,7 @@ GEM
       rexml
     cri (2.15.11)
     dalli (3.2.3)
-    datadog-ci (0.1.1)
+    datadog-ci (0.2.0)
     debase-ruby_core_source (3.2.2)
     diff-lcs (1.5.0)
     docile (1.4.0)

--- a/gemfiles/jruby_9.3_contrib_old.gemfile.lock
+++ b/gemfiles/jruby_9.3_contrib_old.gemfile.lock
@@ -12,7 +12,7 @@ PATH
   remote: ..
   specs:
     ddtrace (1.14.0)
-      datadog-ci (~> 0.1.0)
+      datadog-ci (~> 0.2.0)
       debase-ruby_core_source (= 3.2.2)
       libdatadog (~> 5.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
@@ -39,7 +39,7 @@ GEM
       rexml
     cri (2.15.11)
     dalli (2.7.11)
-    datadog-ci (0.1.1)
+    datadog-ci (0.2.0)
     debase-ruby_core_source (3.2.2)
     diff-lcs (1.5.0)
     docile (1.4.0)

--- a/gemfiles/jruby_9.3_core_old.gemfile.lock
+++ b/gemfiles/jruby_9.3_core_old.gemfile.lock
@@ -12,7 +12,7 @@ PATH
   remote: ..
   specs:
     ddtrace (1.14.0)
-      datadog-ci (~> 0.1.0)
+      datadog-ci (~> 0.2.0)
       debase-ruby_core_source (= 3.2.2)
       libdatadog (~> 5.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
@@ -38,7 +38,7 @@ GEM
     crack (0.4.5)
       rexml
     cri (2.15.11)
-    datadog-ci (0.1.1)
+    datadog-ci (0.2.0)
     debase-ruby_core_source (3.2.2)
     diff-lcs (1.5.0)
     docile (1.4.0)

--- a/gemfiles/jruby_9.3_hanami_1.gemfile.lock
+++ b/gemfiles/jruby_9.3_hanami_1.gemfile.lock
@@ -12,7 +12,7 @@ PATH
   remote: ..
   specs:
     ddtrace (1.14.0)
-      datadog-ci (~> 0.1.0)
+      datadog-ci (~> 0.2.0)
       debase-ruby_core_source (= 3.2.2)
       libdatadog (~> 5.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
@@ -38,7 +38,7 @@ GEM
     crack (0.4.5)
       rexml
     cri (2.15.11)
-    datadog-ci (0.1.1)
+    datadog-ci (0.2.0)
     date (3.3.3-java)
     debase-ruby_core_source (3.2.2)
     diff-lcs (1.5.0)

--- a/gemfiles/jruby_9.3_http.gemfile.lock
+++ b/gemfiles/jruby_9.3_http.gemfile.lock
@@ -12,7 +12,7 @@ PATH
   remote: ..
   specs:
     ddtrace (1.14.0)
-      datadog-ci (~> 0.1.0)
+      datadog-ci (~> 0.2.0)
       debase-ruby_core_source (= 3.2.2)
       libdatadog (~> 5.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
@@ -38,7 +38,7 @@ GEM
     crack (0.4.5)
       rexml
     cri (2.15.11)
-    datadog-ci (0.1.1)
+    datadog-ci (0.2.0)
     debase-ruby_core_source (3.2.2)
     diff-lcs (1.5.0)
     docile (1.4.0)

--- a/gemfiles/jruby_9.3_opentracing.gemfile.lock
+++ b/gemfiles/jruby_9.3_opentracing.gemfile.lock
@@ -12,7 +12,7 @@ PATH
   remote: ..
   specs:
     ddtrace (1.14.0)
-      datadog-ci (~> 0.1.0)
+      datadog-ci (~> 0.2.0)
       debase-ruby_core_source (= 3.2.2)
       libdatadog (~> 5.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
@@ -39,7 +39,7 @@ GEM
     crack (0.4.5)
       rexml
     cri (2.15.11)
-    datadog-ci (0.1.1)
+    datadog-ci (0.2.0)
     debase-ruby_core_source (3.2.2)
     diff-lcs (1.5.0)
     docile (1.4.0)

--- a/gemfiles/jruby_9.3_rack_1.gemfile.lock
+++ b/gemfiles/jruby_9.3_rack_1.gemfile.lock
@@ -12,7 +12,7 @@ PATH
   remote: ..
   specs:
     ddtrace (1.14.0)
-      datadog-ci (~> 0.1.0)
+      datadog-ci (~> 0.2.0)
       debase-ruby_core_source (= 3.2.2)
       libdatadog (~> 5.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
@@ -38,7 +38,7 @@ GEM
     crack (0.4.5)
       rexml
     cri (2.15.11)
-    datadog-ci (0.1.1)
+    datadog-ci (0.2.0)
     debase-ruby_core_source (3.2.2)
     diff-lcs (1.5.0)
     docile (1.4.0)

--- a/gemfiles/jruby_9.3_rack_2.gemfile.lock
+++ b/gemfiles/jruby_9.3_rack_2.gemfile.lock
@@ -12,7 +12,7 @@ PATH
   remote: ..
   specs:
     ddtrace (1.14.0)
-      datadog-ci (~> 0.1.0)
+      datadog-ci (~> 0.2.0)
       debase-ruby_core_source (= 3.2.2)
       libdatadog (~> 5.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
@@ -38,7 +38,7 @@ GEM
     crack (0.4.5)
       rexml
     cri (2.15.11)
-    datadog-ci (0.1.1)
+    datadog-ci (0.2.0)
     debase-ruby_core_source (3.2.2)
     diff-lcs (1.5.0)
     docile (1.4.0)

--- a/gemfiles/jruby_9.3_rack_3.gemfile.lock
+++ b/gemfiles/jruby_9.3_rack_3.gemfile.lock
@@ -12,7 +12,7 @@ PATH
   remote: ..
   specs:
     ddtrace (1.14.0)
-      datadog-ci (~> 0.1.0)
+      datadog-ci (~> 0.2.0)
       debase-ruby_core_source (= 3.2.2)
       libdatadog (~> 5.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
@@ -38,7 +38,7 @@ GEM
     crack (0.4.5)
       rexml
     cri (2.15.11)
-    datadog-ci (0.1.1)
+    datadog-ci (0.2.0)
     debase-ruby_core_source (3.2.2)
     diff-lcs (1.5.0)
     docile (1.4.0)

--- a/gemfiles/jruby_9.3_rails5_mysql2.gemfile.lock
+++ b/gemfiles/jruby_9.3_rails5_mysql2.gemfile.lock
@@ -12,7 +12,7 @@ PATH
   remote: ..
   specs:
     ddtrace (1.14.0)
-      datadog-ci (~> 0.1.0)
+      datadog-ci (~> 0.2.0)
       debase-ruby_core_source (= 3.2.2)
       libdatadog (~> 5.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
@@ -86,7 +86,7 @@ GEM
       rexml
     crass (1.0.6)
     cri (2.15.11)
-    datadog-ci (0.1.1)
+    datadog-ci (0.2.0)
     date (3.3.3-java)
     debase-ruby_core_source (3.2.2)
     diff-lcs (1.5.0)

--- a/gemfiles/jruby_9.3_rails5_postgres.gemfile.lock
+++ b/gemfiles/jruby_9.3_rails5_postgres.gemfile.lock
@@ -12,7 +12,7 @@ PATH
   remote: ..
   specs:
     ddtrace (1.14.0)
-      datadog-ci (~> 0.1.0)
+      datadog-ci (~> 0.2.0)
       debase-ruby_core_source (= 3.2.2)
       libdatadog (~> 5.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
@@ -86,7 +86,7 @@ GEM
       rexml
     crass (1.0.6)
     cri (2.15.11)
-    datadog-ci (0.1.1)
+    datadog-ci (0.2.0)
     date (3.3.3-java)
     debase-ruby_core_source (3.2.2)
     diff-lcs (1.5.0)

--- a/gemfiles/jruby_9.3_rails5_postgres_redis.gemfile.lock
+++ b/gemfiles/jruby_9.3_rails5_postgres_redis.gemfile.lock
@@ -12,7 +12,7 @@ PATH
   remote: ..
   specs:
     ddtrace (1.14.0)
-      datadog-ci (~> 0.1.0)
+      datadog-ci (~> 0.2.0)
       debase-ruby_core_source (= 3.2.2)
       libdatadog (~> 5.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
@@ -86,7 +86,7 @@ GEM
       rexml
     crass (1.0.6)
     cri (2.15.11)
-    datadog-ci (0.1.1)
+    datadog-ci (0.2.0)
     date (3.3.3-java)
     debase-ruby_core_source (3.2.2)
     diff-lcs (1.5.0)

--- a/gemfiles/jruby_9.3_rails5_postgres_redis_activesupport.gemfile.lock
+++ b/gemfiles/jruby_9.3_rails5_postgres_redis_activesupport.gemfile.lock
@@ -12,7 +12,7 @@ PATH
   remote: ..
   specs:
     ddtrace (1.14.0)
-      datadog-ci (~> 0.1.0)
+      datadog-ci (~> 0.2.0)
       debase-ruby_core_source (= 3.2.2)
       libdatadog (~> 5.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
@@ -86,7 +86,7 @@ GEM
       rexml
     crass (1.0.6)
     cri (2.15.11)
-    datadog-ci (0.1.1)
+    datadog-ci (0.2.0)
     date (3.3.3-java)
     debase-ruby_core_source (3.2.2)
     diff-lcs (1.5.0)

--- a/gemfiles/jruby_9.3_rails5_postgres_sidekiq.gemfile.lock
+++ b/gemfiles/jruby_9.3_rails5_postgres_sidekiq.gemfile.lock
@@ -12,7 +12,7 @@ PATH
   remote: ..
   specs:
     ddtrace (1.14.0)
-      datadog-ci (~> 0.1.0)
+      datadog-ci (~> 0.2.0)
       debase-ruby_core_source (= 3.2.2)
       libdatadog (~> 5.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
@@ -87,7 +87,7 @@ GEM
       rexml
     crass (1.0.6)
     cri (2.15.11)
-    datadog-ci (0.1.1)
+    datadog-ci (0.2.0)
     date (3.3.3-java)
     debase-ruby_core_source (3.2.2)
     diff-lcs (1.5.0)

--- a/gemfiles/jruby_9.3_rails5_semantic_logger.gemfile.lock
+++ b/gemfiles/jruby_9.3_rails5_semantic_logger.gemfile.lock
@@ -12,7 +12,7 @@ PATH
   remote: ..
   specs:
     ddtrace (1.14.0)
-      datadog-ci (~> 0.1.0)
+      datadog-ci (~> 0.2.0)
       debase-ruby_core_source (= 3.2.2)
       libdatadog (~> 5.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
@@ -86,7 +86,7 @@ GEM
       rexml
     crass (1.0.6)
     cri (2.15.11)
-    datadog-ci (0.1.1)
+    datadog-ci (0.2.0)
     date (3.3.3-java)
     debase-ruby_core_source (3.2.2)
     diff-lcs (1.5.0)

--- a/gemfiles/jruby_9.3_rails61_mysql2.gemfile.lock
+++ b/gemfiles/jruby_9.3_rails61_mysql2.gemfile.lock
@@ -12,7 +12,7 @@ PATH
   remote: ..
   specs:
     ddtrace (1.14.0)
-      datadog-ci (~> 0.1.0)
+      datadog-ci (~> 0.2.0)
       debase-ruby_core_source (= 3.2.2)
       libdatadog (~> 5.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
@@ -103,7 +103,7 @@ GEM
       rexml
     crass (1.0.6)
     cri (2.15.11)
-    datadog-ci (0.1.1)
+    datadog-ci (0.2.0)
     date (3.3.3-java)
     debase-ruby_core_source (3.2.2)
     diff-lcs (1.5.0)

--- a/gemfiles/jruby_9.3_rails61_postgres.gemfile.lock
+++ b/gemfiles/jruby_9.3_rails61_postgres.gemfile.lock
@@ -12,7 +12,7 @@ PATH
   remote: ..
   specs:
     ddtrace (1.14.0)
-      datadog-ci (~> 0.1.0)
+      datadog-ci (~> 0.2.0)
       debase-ruby_core_source (= 3.2.2)
       libdatadog (~> 5.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
@@ -103,7 +103,7 @@ GEM
       rexml
     crass (1.0.6)
     cri (2.15.11)
-    datadog-ci (0.1.1)
+    datadog-ci (0.2.0)
     date (3.3.3-java)
     debase-ruby_core_source (3.2.2)
     diff-lcs (1.5.0)

--- a/gemfiles/jruby_9.3_rails61_postgres_redis.gemfile.lock
+++ b/gemfiles/jruby_9.3_rails61_postgres_redis.gemfile.lock
@@ -12,7 +12,7 @@ PATH
   remote: ..
   specs:
     ddtrace (1.14.0)
-      datadog-ci (~> 0.1.0)
+      datadog-ci (~> 0.2.0)
       debase-ruby_core_source (= 3.2.2)
       libdatadog (~> 5.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
@@ -103,7 +103,7 @@ GEM
       rexml
     crass (1.0.6)
     cri (2.15.11)
-    datadog-ci (0.1.1)
+    datadog-ci (0.2.0)
     date (3.3.3-java)
     debase-ruby_core_source (3.2.2)
     diff-lcs (1.5.0)

--- a/gemfiles/jruby_9.3_rails61_postgres_sidekiq.gemfile.lock
+++ b/gemfiles/jruby_9.3_rails61_postgres_sidekiq.gemfile.lock
@@ -12,7 +12,7 @@ PATH
   remote: ..
   specs:
     ddtrace (1.14.0)
-      datadog-ci (~> 0.1.0)
+      datadog-ci (~> 0.2.0)
       debase-ruby_core_source (= 3.2.2)
       libdatadog (~> 5.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
@@ -104,7 +104,7 @@ GEM
       rexml
     crass (1.0.6)
     cri (2.15.11)
-    datadog-ci (0.1.1)
+    datadog-ci (0.2.0)
     date (3.3.3-java)
     debase-ruby_core_source (3.2.2)
     diff-lcs (1.5.0)

--- a/gemfiles/jruby_9.3_rails61_semantic_logger.gemfile.lock
+++ b/gemfiles/jruby_9.3_rails61_semantic_logger.gemfile.lock
@@ -12,7 +12,7 @@ PATH
   remote: ..
   specs:
     ddtrace (1.14.0)
-      datadog-ci (~> 0.1.0)
+      datadog-ci (~> 0.2.0)
       debase-ruby_core_source (= 3.2.2)
       libdatadog (~> 5.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
@@ -103,7 +103,7 @@ GEM
       rexml
     crass (1.0.6)
     cri (2.15.11)
-    datadog-ci (0.1.1)
+    datadog-ci (0.2.0)
     date (3.3.3-java)
     debase-ruby_core_source (3.2.2)
     diff-lcs (1.5.0)

--- a/gemfiles/jruby_9.3_rails6_mysql2.gemfile.lock
+++ b/gemfiles/jruby_9.3_rails6_mysql2.gemfile.lock
@@ -12,7 +12,7 @@ PATH
   remote: ..
   specs:
     ddtrace (1.14.0)
-      datadog-ci (~> 0.1.0)
+      datadog-ci (~> 0.2.0)
       debase-ruby_core_source (= 3.2.2)
       libdatadog (~> 5.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
@@ -99,7 +99,7 @@ GEM
       rexml
     crass (1.0.6)
     cri (2.15.11)
-    datadog-ci (0.1.1)
+    datadog-ci (0.2.0)
     date (3.3.3-java)
     debase-ruby_core_source (3.2.2)
     diff-lcs (1.5.0)

--- a/gemfiles/jruby_9.3_rails6_postgres.gemfile.lock
+++ b/gemfiles/jruby_9.3_rails6_postgres.gemfile.lock
@@ -12,7 +12,7 @@ PATH
   remote: ..
   specs:
     ddtrace (1.14.0)
-      datadog-ci (~> 0.1.0)
+      datadog-ci (~> 0.2.0)
       debase-ruby_core_source (= 3.2.2)
       libdatadog (~> 5.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
@@ -99,7 +99,7 @@ GEM
       rexml
     crass (1.0.6)
     cri (2.15.11)
-    datadog-ci (0.1.1)
+    datadog-ci (0.2.0)
     date (3.3.3-java)
     debase-ruby_core_source (3.2.2)
     diff-lcs (1.5.0)

--- a/gemfiles/jruby_9.3_rails6_postgres_redis.gemfile.lock
+++ b/gemfiles/jruby_9.3_rails6_postgres_redis.gemfile.lock
@@ -12,7 +12,7 @@ PATH
   remote: ..
   specs:
     ddtrace (1.14.0)
-      datadog-ci (~> 0.1.0)
+      datadog-ci (~> 0.2.0)
       debase-ruby_core_source (= 3.2.2)
       libdatadog (~> 5.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
@@ -99,7 +99,7 @@ GEM
       rexml
     crass (1.0.6)
     cri (2.15.11)
-    datadog-ci (0.1.1)
+    datadog-ci (0.2.0)
     date (3.3.3-java)
     debase-ruby_core_source (3.2.2)
     diff-lcs (1.5.0)

--- a/gemfiles/jruby_9.3_rails6_postgres_redis_activesupport.gemfile.lock
+++ b/gemfiles/jruby_9.3_rails6_postgres_redis_activesupport.gemfile.lock
@@ -12,7 +12,7 @@ PATH
   remote: ..
   specs:
     ddtrace (1.14.0)
-      datadog-ci (~> 0.1.0)
+      datadog-ci (~> 0.2.0)
       debase-ruby_core_source (= 3.2.2)
       libdatadog (~> 5.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
@@ -99,7 +99,7 @@ GEM
       rexml
     crass (1.0.6)
     cri (2.15.11)
-    datadog-ci (0.1.1)
+    datadog-ci (0.2.0)
     date (3.3.3-java)
     debase-ruby_core_source (3.2.2)
     diff-lcs (1.5.0)

--- a/gemfiles/jruby_9.3_rails6_postgres_sidekiq.gemfile.lock
+++ b/gemfiles/jruby_9.3_rails6_postgres_sidekiq.gemfile.lock
@@ -12,7 +12,7 @@ PATH
   remote: ..
   specs:
     ddtrace (1.14.0)
-      datadog-ci (~> 0.1.0)
+      datadog-ci (~> 0.2.0)
       debase-ruby_core_source (= 3.2.2)
       libdatadog (~> 5.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
@@ -100,7 +100,7 @@ GEM
       rexml
     crass (1.0.6)
     cri (2.15.11)
-    datadog-ci (0.1.1)
+    datadog-ci (0.2.0)
     date (3.3.3-java)
     debase-ruby_core_source (3.2.2)
     diff-lcs (1.5.0)

--- a/gemfiles/jruby_9.3_rails6_semantic_logger.gemfile.lock
+++ b/gemfiles/jruby_9.3_rails6_semantic_logger.gemfile.lock
@@ -12,7 +12,7 @@ PATH
   remote: ..
   specs:
     ddtrace (1.14.0)
-      datadog-ci (~> 0.1.0)
+      datadog-ci (~> 0.2.0)
       debase-ruby_core_source (= 3.2.2)
       libdatadog (~> 5.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
@@ -99,7 +99,7 @@ GEM
       rexml
     crass (1.0.6)
     cri (2.15.11)
-    datadog-ci (0.1.1)
+    datadog-ci (0.2.0)
     date (3.3.3-java)
     debase-ruby_core_source (3.2.2)
     diff-lcs (1.5.0)

--- a/gemfiles/jruby_9.3_redis_3.gemfile.lock
+++ b/gemfiles/jruby_9.3_redis_3.gemfile.lock
@@ -12,7 +12,7 @@ PATH
   remote: ..
   specs:
     ddtrace (1.14.0)
-      datadog-ci (~> 0.1.0)
+      datadog-ci (~> 0.2.0)
       debase-ruby_core_source (= 3.2.2)
       libdatadog (~> 5.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
@@ -38,7 +38,7 @@ GEM
     crack (0.4.5)
       rexml
     cri (2.15.11)
-    datadog-ci (0.1.1)
+    datadog-ci (0.2.0)
     debase-ruby_core_source (3.2.2)
     diff-lcs (1.5.0)
     docile (1.4.0)

--- a/gemfiles/jruby_9.3_redis_4.gemfile.lock
+++ b/gemfiles/jruby_9.3_redis_4.gemfile.lock
@@ -12,7 +12,7 @@ PATH
   remote: ..
   specs:
     ddtrace (1.14.0)
-      datadog-ci (~> 0.1.0)
+      datadog-ci (~> 0.2.0)
       debase-ruby_core_source (= 3.2.2)
       libdatadog (~> 5.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
@@ -38,7 +38,7 @@ GEM
     crack (0.4.5)
       rexml
     cri (2.15.11)
-    datadog-ci (0.1.1)
+    datadog-ci (0.2.0)
     debase-ruby_core_source (3.2.2)
     diff-lcs (1.5.0)
     docile (1.4.0)

--- a/gemfiles/jruby_9.3_redis_5.gemfile.lock
+++ b/gemfiles/jruby_9.3_redis_5.gemfile.lock
@@ -12,7 +12,7 @@ PATH
   remote: ..
   specs:
     ddtrace (1.14.0)
-      datadog-ci (~> 0.1.0)
+      datadog-ci (~> 0.2.0)
       debase-ruby_core_source (= 3.2.2)
       libdatadog (~> 5.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
@@ -39,7 +39,7 @@ GEM
     crack (0.4.5)
       rexml
     cri (2.15.11)
-    datadog-ci (0.1.1)
+    datadog-ci (0.2.0)
     debase-ruby_core_source (3.2.2)
     diff-lcs (1.5.0)
     docile (1.4.0)

--- a/gemfiles/jruby_9.3_relational_db.gemfile.lock
+++ b/gemfiles/jruby_9.3_relational_db.gemfile.lock
@@ -12,7 +12,7 @@ PATH
   remote: ..
   specs:
     ddtrace (1.14.0)
-      datadog-ci (~> 0.1.0)
+      datadog-ci (~> 0.2.0)
       debase-ruby_core_source (= 3.2.2)
       libdatadog (~> 5.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
@@ -57,7 +57,7 @@ GEM
     crack (0.4.5)
       rexml
     cri (2.15.11)
-    datadog-ci (0.1.1)
+    datadog-ci (0.2.0)
     debase-ruby_core_source (3.2.2)
     delayed_job (4.1.11)
       activesupport (>= 3.0, < 8.0)

--- a/gemfiles/jruby_9.3_resque2_redis3.gemfile.lock
+++ b/gemfiles/jruby_9.3_resque2_redis3.gemfile.lock
@@ -12,7 +12,7 @@ PATH
   remote: ..
   specs:
     ddtrace (1.14.0)
-      datadog-ci (~> 0.1.0)
+      datadog-ci (~> 0.2.0)
       debase-ruby_core_source (= 3.2.2)
       libdatadog (~> 5.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
@@ -38,7 +38,7 @@ GEM
     crack (0.4.5)
       rexml
     cri (2.15.11)
-    datadog-ci (0.1.1)
+    datadog-ci (0.2.0)
     debase-ruby_core_source (3.2.2)
     diff-lcs (1.5.0)
     docile (1.4.0)

--- a/gemfiles/jruby_9.3_resque2_redis4.gemfile.lock
+++ b/gemfiles/jruby_9.3_resque2_redis4.gemfile.lock
@@ -12,7 +12,7 @@ PATH
   remote: ..
   specs:
     ddtrace (1.14.0)
-      datadog-ci (~> 0.1.0)
+      datadog-ci (~> 0.2.0)
       debase-ruby_core_source (= 3.2.2)
       libdatadog (~> 5.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
@@ -38,7 +38,7 @@ GEM
     crack (0.4.5)
       rexml
     cri (2.15.11)
-    datadog-ci (0.1.1)
+    datadog-ci (0.2.0)
     debase-ruby_core_source (3.2.2)
     diff-lcs (1.5.0)
     docile (1.4.0)

--- a/gemfiles/jruby_9.3_sinatra.gemfile.lock
+++ b/gemfiles/jruby_9.3_sinatra.gemfile.lock
@@ -12,7 +12,7 @@ PATH
   remote: ..
   specs:
     ddtrace (1.14.0)
-      datadog-ci (~> 0.1.0)
+      datadog-ci (~> 0.2.0)
       debase-ruby_core_source (= 3.2.2)
       libdatadog (~> 5.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
@@ -38,7 +38,7 @@ GEM
     crack (0.4.5)
       rexml
     cri (2.15.11)
-    datadog-ci (0.1.1)
+    datadog-ci (0.2.0)
     debase-ruby_core_source (3.2.2)
     diff-lcs (1.5.0)
     docile (1.4.0)

--- a/gemfiles/jruby_9.4_activesupport.gemfile.lock
+++ b/gemfiles/jruby_9.4_activesupport.gemfile.lock
@@ -12,7 +12,7 @@ PATH
   remote: ..
   specs:
     ddtrace (1.14.0)
-      datadog-ci (~> 0.1.0)
+      datadog-ci (~> 0.2.0)
       debase-ruby_core_source (= 3.2.2)
       libdatadog (~> 5.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
@@ -66,7 +66,7 @@ GEM
       rexml
     crass (1.0.6)
     cri (2.15.11)
-    datadog-ci (0.1.1)
+    datadog-ci (0.2.0)
     debase-ruby_core_source (3.2.2)
     diff-lcs (1.5.0)
     digest-crc (0.6.5)

--- a/gemfiles/jruby_9.4_aws.gemfile.lock
+++ b/gemfiles/jruby_9.4_aws.gemfile.lock
@@ -12,7 +12,7 @@ PATH
   remote: ..
   specs:
     ddtrace (1.14.0)
-      datadog-ci (~> 0.1.0)
+      datadog-ci (~> 0.2.0)
       debase-ruby_core_source (= 3.2.2)
       libdatadog (~> 5.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
@@ -1459,7 +1459,7 @@ GEM
     crack (0.4.5)
       rexml
     cri (2.15.11)
-    datadog-ci (0.1.1)
+    datadog-ci (0.2.0)
     debase-ruby_core_source (3.2.2)
     diff-lcs (1.5.0)
     docile (1.4.0)

--- a/gemfiles/jruby_9.4_contrib.gemfile.lock
+++ b/gemfiles/jruby_9.4_contrib.gemfile.lock
@@ -12,7 +12,7 @@ PATH
   remote: ..
   specs:
     ddtrace (1.14.0)
-      datadog-ci (~> 0.1.0)
+      datadog-ci (~> 0.2.0)
       debase-ruby_core_source (= 3.2.2)
       libdatadog (~> 5.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
@@ -45,7 +45,7 @@ GEM
       rexml
     cri (2.15.11)
     dalli (3.2.3)
-    datadog-ci (0.1.1)
+    datadog-ci (0.2.0)
     debase-ruby_core_source (3.2.2)
     diff-lcs (1.5.0)
     docile (1.4.0)

--- a/gemfiles/jruby_9.4_contrib_old.gemfile.lock
+++ b/gemfiles/jruby_9.4_contrib_old.gemfile.lock
@@ -12,7 +12,7 @@ PATH
   remote: ..
   specs:
     ddtrace (1.14.0)
-      datadog-ci (~> 0.1.0)
+      datadog-ci (~> 0.2.0)
       debase-ruby_core_source (= 3.2.2)
       libdatadog (~> 5.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
@@ -39,7 +39,7 @@ GEM
       rexml
     cri (2.15.11)
     dalli (2.7.11)
-    datadog-ci (0.1.1)
+    datadog-ci (0.2.0)
     debase-ruby_core_source (3.2.2)
     diff-lcs (1.5.0)
     docile (1.4.0)

--- a/gemfiles/jruby_9.4_core_old.gemfile.lock
+++ b/gemfiles/jruby_9.4_core_old.gemfile.lock
@@ -12,7 +12,7 @@ PATH
   remote: ..
   specs:
     ddtrace (1.14.0)
-      datadog-ci (~> 0.1.0)
+      datadog-ci (~> 0.2.0)
       debase-ruby_core_source (= 3.2.2)
       libdatadog (~> 5.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
@@ -38,7 +38,7 @@ GEM
     crack (0.4.5)
       rexml
     cri (2.15.11)
-    datadog-ci (0.1.1)
+    datadog-ci (0.2.0)
     debase-ruby_core_source (3.2.2)
     diff-lcs (1.5.0)
     docile (1.4.0)

--- a/gemfiles/jruby_9.4_http.gemfile.lock
+++ b/gemfiles/jruby_9.4_http.gemfile.lock
@@ -12,7 +12,7 @@ PATH
   remote: ..
   specs:
     ddtrace (1.14.0)
-      datadog-ci (~> 0.1.0)
+      datadog-ci (~> 0.2.0)
       debase-ruby_core_source (= 3.2.2)
       libdatadog (~> 5.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
@@ -38,7 +38,7 @@ GEM
     crack (0.4.5)
       rexml
     cri (2.15.11)
-    datadog-ci (0.1.1)
+    datadog-ci (0.2.0)
     debase-ruby_core_source (3.2.2)
     diff-lcs (1.5.0)
     docile (1.4.0)

--- a/gemfiles/jruby_9.4_opentracing.gemfile.lock
+++ b/gemfiles/jruby_9.4_opentracing.gemfile.lock
@@ -12,7 +12,7 @@ PATH
   remote: ..
   specs:
     ddtrace (1.14.0)
-      datadog-ci (~> 0.1.0)
+      datadog-ci (~> 0.2.0)
       debase-ruby_core_source (= 3.2.2)
       libdatadog (~> 5.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
@@ -39,7 +39,7 @@ GEM
     crack (0.4.5)
       rexml
     cri (2.15.11)
-    datadog-ci (0.1.1)
+    datadog-ci (0.2.0)
     debase-ruby_core_source (3.2.2)
     diff-lcs (1.5.0)
     docile (1.4.0)

--- a/gemfiles/jruby_9.4_rack_1.gemfile.lock
+++ b/gemfiles/jruby_9.4_rack_1.gemfile.lock
@@ -12,7 +12,7 @@ PATH
   remote: ..
   specs:
     ddtrace (1.14.0)
-      datadog-ci (~> 0.1.0)
+      datadog-ci (~> 0.2.0)
       debase-ruby_core_source (= 3.2.2)
       libdatadog (~> 5.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
@@ -38,7 +38,7 @@ GEM
     crack (0.4.5)
       rexml
     cri (2.15.11)
-    datadog-ci (0.1.1)
+    datadog-ci (0.2.0)
     debase-ruby_core_source (3.2.2)
     diff-lcs (1.5.0)
     docile (1.4.0)

--- a/gemfiles/jruby_9.4_rack_2.gemfile.lock
+++ b/gemfiles/jruby_9.4_rack_2.gemfile.lock
@@ -12,7 +12,7 @@ PATH
   remote: ..
   specs:
     ddtrace (1.14.0)
-      datadog-ci (~> 0.1.0)
+      datadog-ci (~> 0.2.0)
       debase-ruby_core_source (= 3.2.2)
       libdatadog (~> 5.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
@@ -38,7 +38,7 @@ GEM
     crack (0.4.5)
       rexml
     cri (2.15.11)
-    datadog-ci (0.1.1)
+    datadog-ci (0.2.0)
     debase-ruby_core_source (3.2.2)
     diff-lcs (1.5.0)
     docile (1.4.0)

--- a/gemfiles/jruby_9.4_rack_3.gemfile.lock
+++ b/gemfiles/jruby_9.4_rack_3.gemfile.lock
@@ -12,7 +12,7 @@ PATH
   remote: ..
   specs:
     ddtrace (1.14.0)
-      datadog-ci (~> 0.1.0)
+      datadog-ci (~> 0.2.0)
       debase-ruby_core_source (= 3.2.2)
       libdatadog (~> 5.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
@@ -38,7 +38,7 @@ GEM
     crack (0.4.5)
       rexml
     cri (2.15.11)
-    datadog-ci (0.1.1)
+    datadog-ci (0.2.0)
     debase-ruby_core_source (3.2.2)
     diff-lcs (1.5.0)
     docile (1.4.0)

--- a/gemfiles/jruby_9.4_rails61_mysql2.gemfile.lock
+++ b/gemfiles/jruby_9.4_rails61_mysql2.gemfile.lock
@@ -12,7 +12,7 @@ PATH
   remote: ..
   specs:
     ddtrace (1.14.0)
-      datadog-ci (~> 0.1.0)
+      datadog-ci (~> 0.2.0)
       debase-ruby_core_source (= 3.2.2)
       libdatadog (~> 5.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
@@ -103,7 +103,7 @@ GEM
       rexml
     crass (1.0.6)
     cri (2.15.11)
-    datadog-ci (0.1.1)
+    datadog-ci (0.2.0)
     date (3.3.3-java)
     debase-ruby_core_source (3.2.2)
     diff-lcs (1.5.0)

--- a/gemfiles/jruby_9.4_rails61_postgres.gemfile.lock
+++ b/gemfiles/jruby_9.4_rails61_postgres.gemfile.lock
@@ -12,7 +12,7 @@ PATH
   remote: ..
   specs:
     ddtrace (1.14.0)
-      datadog-ci (~> 0.1.0)
+      datadog-ci (~> 0.2.0)
       debase-ruby_core_source (= 3.2.2)
       libdatadog (~> 5.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
@@ -103,7 +103,7 @@ GEM
       rexml
     crass (1.0.6)
     cri (2.15.11)
-    datadog-ci (0.1.1)
+    datadog-ci (0.2.0)
     date (3.3.3-java)
     debase-ruby_core_source (3.2.2)
     diff-lcs (1.5.0)

--- a/gemfiles/jruby_9.4_rails61_postgres_redis.gemfile.lock
+++ b/gemfiles/jruby_9.4_rails61_postgres_redis.gemfile.lock
@@ -12,7 +12,7 @@ PATH
   remote: ..
   specs:
     ddtrace (1.14.0)
-      datadog-ci (~> 0.1.0)
+      datadog-ci (~> 0.2.0)
       debase-ruby_core_source (= 3.2.2)
       libdatadog (~> 5.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
@@ -103,7 +103,7 @@ GEM
       rexml
     crass (1.0.6)
     cri (2.15.11)
-    datadog-ci (0.1.1)
+    datadog-ci (0.2.0)
     date (3.3.3-java)
     debase-ruby_core_source (3.2.2)
     diff-lcs (1.5.0)

--- a/gemfiles/jruby_9.4_rails61_postgres_sidekiq.gemfile.lock
+++ b/gemfiles/jruby_9.4_rails61_postgres_sidekiq.gemfile.lock
@@ -12,7 +12,7 @@ PATH
   remote: ..
   specs:
     ddtrace (1.14.0)
-      datadog-ci (~> 0.1.0)
+      datadog-ci (~> 0.2.0)
       debase-ruby_core_source (= 3.2.2)
       libdatadog (~> 5.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
@@ -104,7 +104,7 @@ GEM
       rexml
     crass (1.0.6)
     cri (2.15.11)
-    datadog-ci (0.1.1)
+    datadog-ci (0.2.0)
     date (3.3.3-java)
     debase-ruby_core_source (3.2.2)
     diff-lcs (1.5.0)

--- a/gemfiles/jruby_9.4_rails61_semantic_logger.gemfile.lock
+++ b/gemfiles/jruby_9.4_rails61_semantic_logger.gemfile.lock
@@ -12,7 +12,7 @@ PATH
   remote: ..
   specs:
     ddtrace (1.14.0)
-      datadog-ci (~> 0.1.0)
+      datadog-ci (~> 0.2.0)
       debase-ruby_core_source (= 3.2.2)
       libdatadog (~> 5.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
@@ -103,7 +103,7 @@ GEM
       rexml
     crass (1.0.6)
     cri (2.15.11)
-    datadog-ci (0.1.1)
+    datadog-ci (0.2.0)
     date (3.3.3-java)
     debase-ruby_core_source (3.2.2)
     diff-lcs (1.5.0)

--- a/gemfiles/jruby_9.4_redis_3.gemfile.lock
+++ b/gemfiles/jruby_9.4_redis_3.gemfile.lock
@@ -12,7 +12,7 @@ PATH
   remote: ..
   specs:
     ddtrace (1.14.0)
-      datadog-ci (~> 0.1.0)
+      datadog-ci (~> 0.2.0)
       debase-ruby_core_source (= 3.2.2)
       libdatadog (~> 5.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
@@ -38,7 +38,7 @@ GEM
     crack (0.4.5)
       rexml
     cri (2.15.11)
-    datadog-ci (0.1.1)
+    datadog-ci (0.2.0)
     debase-ruby_core_source (3.2.2)
     diff-lcs (1.5.0)
     docile (1.4.0)

--- a/gemfiles/jruby_9.4_redis_4.gemfile.lock
+++ b/gemfiles/jruby_9.4_redis_4.gemfile.lock
@@ -12,7 +12,7 @@ PATH
   remote: ..
   specs:
     ddtrace (1.14.0)
-      datadog-ci (~> 0.1.0)
+      datadog-ci (~> 0.2.0)
       debase-ruby_core_source (= 3.2.2)
       libdatadog (~> 5.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
@@ -38,7 +38,7 @@ GEM
     crack (0.4.5)
       rexml
     cri (2.15.11)
-    datadog-ci (0.1.1)
+    datadog-ci (0.2.0)
     debase-ruby_core_source (3.2.2)
     diff-lcs (1.5.0)
     docile (1.4.0)

--- a/gemfiles/jruby_9.4_redis_5.gemfile.lock
+++ b/gemfiles/jruby_9.4_redis_5.gemfile.lock
@@ -12,7 +12,7 @@ PATH
   remote: ..
   specs:
     ddtrace (1.14.0)
-      datadog-ci (~> 0.1.0)
+      datadog-ci (~> 0.2.0)
       debase-ruby_core_source (= 3.2.2)
       libdatadog (~> 5.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
@@ -39,7 +39,7 @@ GEM
     crack (0.4.5)
       rexml
     cri (2.15.11)
-    datadog-ci (0.1.1)
+    datadog-ci (0.2.0)
     debase-ruby_core_source (3.2.2)
     diff-lcs (1.5.0)
     docile (1.4.0)

--- a/gemfiles/jruby_9.4_relational_db.gemfile.lock
+++ b/gemfiles/jruby_9.4_relational_db.gemfile.lock
@@ -12,7 +12,7 @@ PATH
   remote: ..
   specs:
     ddtrace (1.14.0)
-      datadog-ci (~> 0.1.0)
+      datadog-ci (~> 0.2.0)
       debase-ruby_core_source (= 3.2.2)
       libdatadog (~> 5.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
@@ -56,7 +56,7 @@ GEM
     crack (0.4.5)
       rexml
     cri (2.15.11)
-    datadog-ci (0.1.1)
+    datadog-ci (0.2.0)
     debase-ruby_core_source (3.2.2)
     delayed_job (4.1.11)
       activesupport (>= 3.0, < 8.0)

--- a/gemfiles/jruby_9.4_resque2_redis3.gemfile.lock
+++ b/gemfiles/jruby_9.4_resque2_redis3.gemfile.lock
@@ -12,7 +12,7 @@ PATH
   remote: ..
   specs:
     ddtrace (1.14.0)
-      datadog-ci (~> 0.1.0)
+      datadog-ci (~> 0.2.0)
       debase-ruby_core_source (= 3.2.2)
       libdatadog (~> 5.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
@@ -38,7 +38,7 @@ GEM
     crack (0.4.5)
       rexml
     cri (2.15.11)
-    datadog-ci (0.1.1)
+    datadog-ci (0.2.0)
     debase-ruby_core_source (3.2.2)
     diff-lcs (1.5.0)
     docile (1.4.0)

--- a/gemfiles/jruby_9.4_resque2_redis4.gemfile.lock
+++ b/gemfiles/jruby_9.4_resque2_redis4.gemfile.lock
@@ -12,7 +12,7 @@ PATH
   remote: ..
   specs:
     ddtrace (1.14.0)
-      datadog-ci (~> 0.1.0)
+      datadog-ci (~> 0.2.0)
       debase-ruby_core_source (= 3.2.2)
       libdatadog (~> 5.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
@@ -39,7 +39,7 @@ GEM
     crack (0.4.5)
       rexml
     cri (2.15.11)
-    datadog-ci (0.1.1)
+    datadog-ci (0.2.0)
     debase-ruby_core_source (3.2.2)
     diff-lcs (1.5.0)
     docile (1.4.0)

--- a/gemfiles/jruby_9.4_sinatra.gemfile.lock
+++ b/gemfiles/jruby_9.4_sinatra.gemfile.lock
@@ -12,7 +12,7 @@ PATH
   remote: ..
   specs:
     ddtrace (1.14.0)
-      datadog-ci (~> 0.1.0)
+      datadog-ci (~> 0.2.0)
       debase-ruby_core_source (= 3.2.2)
       libdatadog (~> 5.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
@@ -38,7 +38,7 @@ GEM
     crack (0.4.5)
       rexml
     cri (2.15.11)
-    datadog-ci (0.1.1)
+    datadog-ci (0.2.0)
     debase-ruby_core_source (3.2.2)
     diff-lcs (1.5.0)
     docile (1.4.0)

--- a/gemfiles/ruby_2.1_activesupport.gemfile.lock
+++ b/gemfiles/ruby_2.1_activesupport.gemfile.lock
@@ -2,7 +2,7 @@ PATH
   remote: ..
   specs:
     ddtrace (1.14.0)
-      datadog-ci (~> 0.1.0)
+      datadog-ci (~> 0.2.0)
       debase-ruby_core_source (= 3.2.2)
       libdatadog (~> 5.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
@@ -36,7 +36,7 @@ GEM
     concurrent-ruby (1.1.9)
     crack (0.4.5)
       rexml
-    datadog-ci (0.1.1)
+    datadog-ci (0.2.0)
     debase-ruby_core_source (3.2.2)
     diff-lcs (1.5.0)
     digest-crc (0.6.5)

--- a/gemfiles/ruby_2.1_aws.gemfile.lock
+++ b/gemfiles/ruby_2.1_aws.gemfile.lock
@@ -2,7 +2,7 @@ PATH
   remote: ..
   specs:
     ddtrace (1.14.0)
-      datadog-ci (~> 0.1.0)
+      datadog-ci (~> 0.2.0)
       debase-ruby_core_source (= 3.2.2)
       libdatadog (~> 5.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
@@ -35,7 +35,7 @@ GEM
     concurrent-ruby (1.1.9)
     crack (0.4.5)
       rexml
-    datadog-ci (0.1.1)
+    datadog-ci (0.2.0)
     debase-ruby_core_source (3.2.2)
     diff-lcs (1.5.0)
     docile (1.3.5)

--- a/gemfiles/ruby_2.1_contrib.gemfile.lock
+++ b/gemfiles/ruby_2.1_contrib.gemfile.lock
@@ -2,7 +2,7 @@ PATH
   remote: ..
   specs:
     ddtrace (1.14.0)
-      datadog-ci (~> 0.1.0)
+      datadog-ci (~> 0.2.0)
       debase-ruby_core_source (= 3.2.2)
       libdatadog (~> 5.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
@@ -45,7 +45,7 @@ GEM
     crack (0.4.5)
       rexml
     dalli (2.7.11)
-    datadog-ci (0.1.1)
+    datadog-ci (0.2.0)
     debase-ruby_core_source (3.2.2)
     diff-lcs (1.5.0)
     docile (1.3.5)

--- a/gemfiles/ruby_2.1_core_old.gemfile.lock
+++ b/gemfiles/ruby_2.1_core_old.gemfile.lock
@@ -2,7 +2,7 @@ PATH
   remote: ..
   specs:
     ddtrace (1.14.0)
-      datadog-ci (~> 0.1.0)
+      datadog-ci (~> 0.2.0)
       debase-ruby_core_source (= 3.2.2)
       libdatadog (~> 5.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
@@ -25,7 +25,7 @@ GEM
     concurrent-ruby (1.1.9)
     crack (0.4.5)
       rexml
-    datadog-ci (0.1.1)
+    datadog-ci (0.2.0)
     debase-ruby_core_source (3.2.2)
     diff-lcs (1.5.0)
     docile (1.3.5)

--- a/gemfiles/ruby_2.1_http.gemfile.lock
+++ b/gemfiles/ruby_2.1_http.gemfile.lock
@@ -2,7 +2,7 @@ PATH
   remote: ..
   specs:
     ddtrace (1.14.0)
-      datadog-ci (~> 0.1.0)
+      datadog-ci (~> 0.2.0)
       debase-ruby_core_source (= 3.2.2)
       libdatadog (~> 5.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
@@ -25,7 +25,7 @@ GEM
     concurrent-ruby (1.1.9)
     crack (0.4.5)
       rexml
-    datadog-ci (0.1.1)
+    datadog-ci (0.2.0)
     debase-ruby_core_source (3.2.2)
     diff-lcs (1.5.0)
     docile (1.3.5)

--- a/gemfiles/ruby_2.1_opentracing.gemfile.lock
+++ b/gemfiles/ruby_2.1_opentracing.gemfile.lock
@@ -2,7 +2,7 @@ PATH
   remote: ..
   specs:
     ddtrace (1.14.0)
-      datadog-ci (~> 0.1.0)
+      datadog-ci (~> 0.2.0)
       debase-ruby_core_source (= 3.2.2)
       libdatadog (~> 5.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
@@ -26,7 +26,7 @@ GEM
     concurrent-ruby (1.1.9)
     crack (0.4.5)
       rexml
-    datadog-ci (0.1.1)
+    datadog-ci (0.2.0)
     debase-ruby_core_source (3.2.2)
     diff-lcs (1.5.0)
     docile (1.3.5)

--- a/gemfiles/ruby_2.1_rack_1.gemfile.lock
+++ b/gemfiles/ruby_2.1_rack_1.gemfile.lock
@@ -2,7 +2,7 @@ PATH
   remote: ..
   specs:
     ddtrace (1.14.0)
-      datadog-ci (~> 0.1.0)
+      datadog-ci (~> 0.2.0)
       debase-ruby_core_source (= 3.2.2)
       libdatadog (~> 5.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
@@ -25,7 +25,7 @@ GEM
     concurrent-ruby (1.1.9)
     crack (0.4.5)
       rexml
-    datadog-ci (0.1.1)
+    datadog-ci (0.2.0)
     debase-ruby_core_source (3.2.2)
     diff-lcs (1.5.0)
     docile (1.3.5)

--- a/gemfiles/ruby_2.1_rails32_mysql2.gemfile.lock
+++ b/gemfiles/ruby_2.1_rails32_mysql2.gemfile.lock
@@ -2,7 +2,7 @@ PATH
   remote: ..
   specs:
     ddtrace (1.14.0)
-      datadog-ci (~> 0.1.0)
+      datadog-ci (~> 0.2.0)
       debase-ruby_core_source (= 3.2.2)
       libdatadog (~> 5.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
@@ -57,7 +57,7 @@ GEM
     concurrent-ruby (1.1.9)
     crack (0.4.5)
       rexml
-    datadog-ci (0.1.1)
+    datadog-ci (0.2.0)
     debase-ruby_core_source (3.2.2)
     diff-lcs (1.5.0)
     docile (1.3.5)

--- a/gemfiles/ruby_2.1_rails32_postgres.gemfile.lock
+++ b/gemfiles/ruby_2.1_rails32_postgres.gemfile.lock
@@ -2,7 +2,7 @@ PATH
   remote: ..
   specs:
     ddtrace (1.14.0)
-      datadog-ci (~> 0.1.0)
+      datadog-ci (~> 0.2.0)
       debase-ruby_core_source (= 3.2.2)
       libdatadog (~> 5.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
@@ -53,7 +53,7 @@ GEM
     concurrent-ruby (1.1.9)
     crack (0.4.5)
       rexml
-    datadog-ci (0.1.1)
+    datadog-ci (0.2.0)
     debase-ruby_core_source (3.2.2)
     diff-lcs (1.5.0)
     docile (1.3.5)

--- a/gemfiles/ruby_2.1_rails32_postgres_redis.gemfile.lock
+++ b/gemfiles/ruby_2.1_rails32_postgres_redis.gemfile.lock
@@ -2,7 +2,7 @@ PATH
   remote: ..
   specs:
     ddtrace (1.14.0)
-      datadog-ci (~> 0.1.0)
+      datadog-ci (~> 0.2.0)
       debase-ruby_core_source (= 3.2.2)
       libdatadog (~> 5.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
@@ -53,7 +53,7 @@ GEM
     concurrent-ruby (1.1.9)
     crack (0.4.5)
       rexml
-    datadog-ci (0.1.1)
+    datadog-ci (0.2.0)
     debase-ruby_core_source (3.2.2)
     diff-lcs (1.5.0)
     docile (1.3.5)

--- a/gemfiles/ruby_2.1_rails32_postgres_sidekiq.gemfile.lock
+++ b/gemfiles/ruby_2.1_rails32_postgres_sidekiq.gemfile.lock
@@ -2,7 +2,7 @@ PATH
   remote: ..
   specs:
     ddtrace (1.14.0)
-      datadog-ci (~> 0.1.0)
+      datadog-ci (~> 0.2.0)
       debase-ruby_core_source (= 3.2.2)
       libdatadog (~> 5.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
@@ -54,7 +54,7 @@ GEM
     connection_pool (2.2.3)
     crack (0.4.5)
       rexml
-    datadog-ci (0.1.1)
+    datadog-ci (0.2.0)
     debase-ruby_core_source (3.2.2)
     diff-lcs (1.5.0)
     docile (1.3.5)

--- a/gemfiles/ruby_2.1_rails4_mysql2.gemfile.lock
+++ b/gemfiles/ruby_2.1_rails4_mysql2.gemfile.lock
@@ -2,7 +2,7 @@ PATH
   remote: ..
   specs:
     ddtrace (1.14.0)
-      datadog-ci (~> 0.1.0)
+      datadog-ci (~> 0.2.0)
       debase-ruby_core_source (= 3.2.2)
       libdatadog (~> 5.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
@@ -61,7 +61,7 @@ GEM
     crack (0.4.5)
       rexml
     crass (1.0.6)
-    datadog-ci (0.1.1)
+    datadog-ci (0.2.0)
     debase-ruby_core_source (3.2.2)
     diff-lcs (1.5.0)
     docile (1.3.5)

--- a/gemfiles/ruby_2.1_rails4_postgres.gemfile.lock
+++ b/gemfiles/ruby_2.1_rails4_postgres.gemfile.lock
@@ -2,7 +2,7 @@ PATH
   remote: ..
   specs:
     ddtrace (1.14.0)
-      datadog-ci (~> 0.1.0)
+      datadog-ci (~> 0.2.0)
       debase-ruby_core_source (= 3.2.2)
       libdatadog (~> 5.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
@@ -61,7 +61,7 @@ GEM
     crack (0.4.5)
       rexml
     crass (1.0.6)
-    datadog-ci (0.1.1)
+    datadog-ci (0.2.0)
     debase-ruby_core_source (3.2.2)
     diff-lcs (1.5.0)
     docile (1.3.5)

--- a/gemfiles/ruby_2.1_rails4_postgres_redis.gemfile.lock
+++ b/gemfiles/ruby_2.1_rails4_postgres_redis.gemfile.lock
@@ -2,7 +2,7 @@ PATH
   remote: ..
   specs:
     ddtrace (1.14.0)
-      datadog-ci (~> 0.1.0)
+      datadog-ci (~> 0.2.0)
       debase-ruby_core_source (= 3.2.2)
       libdatadog (~> 5.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
@@ -61,7 +61,7 @@ GEM
     crack (0.4.5)
       rexml
     crass (1.0.6)
-    datadog-ci (0.1.1)
+    datadog-ci (0.2.0)
     debase-ruby_core_source (3.2.2)
     diff-lcs (1.5.0)
     docile (1.3.5)

--- a/gemfiles/ruby_2.1_rails4_semantic_logger.gemfile.lock
+++ b/gemfiles/ruby_2.1_rails4_semantic_logger.gemfile.lock
@@ -2,7 +2,7 @@ PATH
   remote: ..
   specs:
     ddtrace (1.14.0)
-      datadog-ci (~> 0.1.0)
+      datadog-ci (~> 0.2.0)
       debase-ruby_core_source (= 3.2.2)
       libdatadog (~> 5.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
@@ -61,7 +61,7 @@ GEM
     crack (0.4.5)
       rexml
     crass (1.0.6)
-    datadog-ci (0.1.1)
+    datadog-ci (0.2.0)
     debase-ruby_core_source (3.2.2)
     diff-lcs (1.5.0)
     docile (1.3.5)

--- a/gemfiles/ruby_2.1_redis_3.gemfile.lock
+++ b/gemfiles/ruby_2.1_redis_3.gemfile.lock
@@ -2,7 +2,7 @@ PATH
   remote: ..
   specs:
     ddtrace (1.14.0)
-      datadog-ci (~> 0.1.0)
+      datadog-ci (~> 0.2.0)
       debase-ruby_core_source (= 3.2.2)
       libdatadog (~> 5.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
@@ -25,7 +25,7 @@ GEM
     concurrent-ruby (1.1.9)
     crack (0.4.5)
       rexml
-    datadog-ci (0.1.1)
+    datadog-ci (0.2.0)
     debase-ruby_core_source (3.2.2)
     diff-lcs (1.5.0)
     docile (1.3.5)

--- a/gemfiles/ruby_2.1_relational_db.gemfile.lock
+++ b/gemfiles/ruby_2.1_relational_db.gemfile.lock
@@ -2,7 +2,7 @@ PATH
   remote: ..
   specs:
     ddtrace (1.14.0)
-      datadog-ci (~> 0.1.0)
+      datadog-ci (~> 0.2.0)
       debase-ruby_core_source (= 3.2.2)
       libdatadog (~> 5.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
@@ -41,7 +41,7 @@ GEM
     concurrent-ruby (1.1.9)
     crack (0.4.5)
       rexml
-    datadog-ci (0.1.1)
+    datadog-ci (0.2.0)
     debase-ruby_core_source (3.2.2)
     delayed_job (4.1.11)
       activesupport (>= 3.0, < 8.0)

--- a/gemfiles/ruby_2.1_sinatra.gemfile.lock
+++ b/gemfiles/ruby_2.1_sinatra.gemfile.lock
@@ -2,7 +2,7 @@ PATH
   remote: ..
   specs:
     ddtrace (1.14.0)
-      datadog-ci (~> 0.1.0)
+      datadog-ci (~> 0.2.0)
       debase-ruby_core_source (= 3.2.2)
       libdatadog (~> 5.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
@@ -25,7 +25,7 @@ GEM
     concurrent-ruby (1.1.9)
     crack (0.4.5)
       rexml
-    datadog-ci (0.1.1)
+    datadog-ci (0.2.0)
     debase-ruby_core_source (3.2.2)
     diff-lcs (1.5.0)
     docile (1.3.5)

--- a/gemfiles/ruby_2.2_activesupport.gemfile.lock
+++ b/gemfiles/ruby_2.2_activesupport.gemfile.lock
@@ -2,7 +2,7 @@ PATH
   remote: ..
   specs:
     ddtrace (1.14.0)
-      datadog-ci (~> 0.1.0)
+      datadog-ci (~> 0.2.0)
       debase-ruby_core_source (= 3.2.2)
       libdatadog (~> 5.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
@@ -60,7 +60,7 @@ GEM
     crack (0.4.5)
       rexml
     crass (1.0.6)
-    datadog-ci (0.1.1)
+    datadog-ci (0.2.0)
     debase-ruby_core_source (3.2.2)
     descendants_tracker (0.0.4)
       thread_safe (~> 0.3, >= 0.3.1)

--- a/gemfiles/ruby_2.2_aws.gemfile.lock
+++ b/gemfiles/ruby_2.2_aws.gemfile.lock
@@ -2,7 +2,7 @@ PATH
   remote: ..
   specs:
     ddtrace (1.14.0)
-      datadog-ci (~> 0.1.0)
+      datadog-ci (~> 0.2.0)
       debase-ruby_core_source (= 3.2.2)
       libdatadog (~> 5.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
@@ -1147,7 +1147,7 @@ GEM
     concurrent-ruby (1.1.10)
     crack (0.4.5)
       rexml
-    datadog-ci (0.1.1)
+    datadog-ci (0.2.0)
     debase-ruby_core_source (3.2.2)
     diff-lcs (1.5.0)
     docile (1.3.5)

--- a/gemfiles/ruby_2.2_contrib.gemfile.lock
+++ b/gemfiles/ruby_2.2_contrib.gemfile.lock
@@ -2,7 +2,7 @@ PATH
   remote: ..
   specs:
     ddtrace (1.14.0)
-      datadog-ci (~> 0.1.0)
+      datadog-ci (~> 0.2.0)
       debase-ruby_core_source (= 3.2.2)
       libdatadog (~> 5.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
@@ -31,7 +31,7 @@ GEM
     crack (0.4.5)
       rexml
     dalli (2.7.11)
-    datadog-ci (0.1.1)
+    datadog-ci (0.2.0)
     debase-ruby_core_source (3.2.2)
     diff-lcs (1.5.0)
     docile (1.3.5)

--- a/gemfiles/ruby_2.2_core_old.gemfile.lock
+++ b/gemfiles/ruby_2.2_core_old.gemfile.lock
@@ -2,7 +2,7 @@ PATH
   remote: ..
   specs:
     ddtrace (1.14.0)
-      datadog-ci (~> 0.1.0)
+      datadog-ci (~> 0.2.0)
       debase-ruby_core_source (= 3.2.2)
       libdatadog (~> 5.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
@@ -25,7 +25,7 @@ GEM
     concurrent-ruby (1.1.10)
     crack (0.4.5)
       rexml
-    datadog-ci (0.1.1)
+    datadog-ci (0.2.0)
     debase-ruby_core_source (3.2.2)
     diff-lcs (1.5.0)
     docile (1.3.5)

--- a/gemfiles/ruby_2.2_http.gemfile.lock
+++ b/gemfiles/ruby_2.2_http.gemfile.lock
@@ -2,7 +2,7 @@ PATH
   remote: ..
   specs:
     ddtrace (1.14.0)
-      datadog-ci (~> 0.1.0)
+      datadog-ci (~> 0.2.0)
       debase-ruby_core_source (= 3.2.2)
       libdatadog (~> 5.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
@@ -25,7 +25,7 @@ GEM
     concurrent-ruby (1.1.10)
     crack (0.4.5)
       rexml
-    datadog-ci (0.1.1)
+    datadog-ci (0.2.0)
     debase-ruby_core_source (3.2.2)
     diff-lcs (1.5.0)
     docile (1.3.5)

--- a/gemfiles/ruby_2.2_opentracing.gemfile.lock
+++ b/gemfiles/ruby_2.2_opentracing.gemfile.lock
@@ -2,7 +2,7 @@ PATH
   remote: ..
   specs:
     ddtrace (1.14.0)
-      datadog-ci (~> 0.1.0)
+      datadog-ci (~> 0.2.0)
       debase-ruby_core_source (= 3.2.2)
       libdatadog (~> 5.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
@@ -26,7 +26,7 @@ GEM
     concurrent-ruby (1.1.10)
     crack (0.4.5)
       rexml
-    datadog-ci (0.1.1)
+    datadog-ci (0.2.0)
     debase-ruby_core_source (3.2.2)
     diff-lcs (1.5.0)
     docile (1.3.5)

--- a/gemfiles/ruby_2.2_rack_1.gemfile.lock
+++ b/gemfiles/ruby_2.2_rack_1.gemfile.lock
@@ -2,7 +2,7 @@ PATH
   remote: ..
   specs:
     ddtrace (1.14.0)
-      datadog-ci (~> 0.1.0)
+      datadog-ci (~> 0.2.0)
       debase-ruby_core_source (= 3.2.2)
       libdatadog (~> 5.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
@@ -25,7 +25,7 @@ GEM
     concurrent-ruby (1.1.10)
     crack (0.4.5)
       rexml
-    datadog-ci (0.1.1)
+    datadog-ci (0.2.0)
     debase-ruby_core_source (3.2.2)
     diff-lcs (1.5.0)
     docile (1.3.5)

--- a/gemfiles/ruby_2.2_rails32_mysql2.gemfile.lock
+++ b/gemfiles/ruby_2.2_rails32_mysql2.gemfile.lock
@@ -2,7 +2,7 @@ PATH
   remote: ..
   specs:
     ddtrace (1.14.0)
-      datadog-ci (~> 0.1.0)
+      datadog-ci (~> 0.2.0)
       debase-ruby_core_source (= 3.2.2)
       libdatadog (~> 5.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
@@ -57,7 +57,7 @@ GEM
     concurrent-ruby (1.1.10)
     crack (0.4.5)
       rexml
-    datadog-ci (0.1.1)
+    datadog-ci (0.2.0)
     debase-ruby_core_source (3.2.2)
     diff-lcs (1.5.0)
     docile (1.3.5)

--- a/gemfiles/ruby_2.2_rails32_postgres.gemfile.lock
+++ b/gemfiles/ruby_2.2_rails32_postgres.gemfile.lock
@@ -2,7 +2,7 @@ PATH
   remote: ..
   specs:
     ddtrace (1.14.0)
-      datadog-ci (~> 0.1.0)
+      datadog-ci (~> 0.2.0)
       debase-ruby_core_source (= 3.2.2)
       libdatadog (~> 5.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
@@ -53,7 +53,7 @@ GEM
     concurrent-ruby (1.1.10)
     crack (0.4.5)
       rexml
-    datadog-ci (0.1.1)
+    datadog-ci (0.2.0)
     debase-ruby_core_source (3.2.2)
     diff-lcs (1.5.0)
     docile (1.3.5)

--- a/gemfiles/ruby_2.2_rails32_postgres_redis.gemfile.lock
+++ b/gemfiles/ruby_2.2_rails32_postgres_redis.gemfile.lock
@@ -2,7 +2,7 @@ PATH
   remote: ..
   specs:
     ddtrace (1.14.0)
-      datadog-ci (~> 0.1.0)
+      datadog-ci (~> 0.2.0)
       debase-ruby_core_source (= 3.2.2)
       libdatadog (~> 5.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
@@ -53,7 +53,7 @@ GEM
     concurrent-ruby (1.1.10)
     crack (0.4.5)
       rexml
-    datadog-ci (0.1.1)
+    datadog-ci (0.2.0)
     debase-ruby_core_source (3.2.2)
     diff-lcs (1.5.0)
     docile (1.3.5)

--- a/gemfiles/ruby_2.2_rails32_postgres_sidekiq.gemfile.lock
+++ b/gemfiles/ruby_2.2_rails32_postgres_sidekiq.gemfile.lock
@@ -2,7 +2,7 @@ PATH
   remote: ..
   specs:
     ddtrace (1.14.0)
-      datadog-ci (~> 0.1.0)
+      datadog-ci (~> 0.2.0)
       debase-ruby_core_source (= 3.2.2)
       libdatadog (~> 5.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
@@ -54,7 +54,7 @@ GEM
     connection_pool (2.2.3)
     crack (0.4.5)
       rexml
-    datadog-ci (0.1.1)
+    datadog-ci (0.2.0)
     debase-ruby_core_source (3.2.2)
     diff-lcs (1.5.0)
     docile (1.3.5)

--- a/gemfiles/ruby_2.2_rails4_mysql2.gemfile.lock
+++ b/gemfiles/ruby_2.2_rails4_mysql2.gemfile.lock
@@ -2,7 +2,7 @@ PATH
   remote: ..
   specs:
     ddtrace (1.14.0)
-      datadog-ci (~> 0.1.0)
+      datadog-ci (~> 0.2.0)
       debase-ruby_core_source (= 3.2.2)
       libdatadog (~> 5.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
@@ -61,7 +61,7 @@ GEM
     crack (0.4.5)
       rexml
     crass (1.0.6)
-    datadog-ci (0.1.1)
+    datadog-ci (0.2.0)
     debase-ruby_core_source (3.2.2)
     diff-lcs (1.5.0)
     docile (1.3.5)

--- a/gemfiles/ruby_2.2_rails4_postgres.gemfile.lock
+++ b/gemfiles/ruby_2.2_rails4_postgres.gemfile.lock
@@ -2,7 +2,7 @@ PATH
   remote: ..
   specs:
     ddtrace (1.14.0)
-      datadog-ci (~> 0.1.0)
+      datadog-ci (~> 0.2.0)
       debase-ruby_core_source (= 3.2.2)
       libdatadog (~> 5.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
@@ -61,7 +61,7 @@ GEM
     crack (0.4.5)
       rexml
     crass (1.0.6)
-    datadog-ci (0.1.1)
+    datadog-ci (0.2.0)
     debase-ruby_core_source (3.2.2)
     diff-lcs (1.5.0)
     docile (1.3.5)

--- a/gemfiles/ruby_2.2_rails4_postgres_redis.gemfile.lock
+++ b/gemfiles/ruby_2.2_rails4_postgres_redis.gemfile.lock
@@ -2,7 +2,7 @@ PATH
   remote: ..
   specs:
     ddtrace (1.14.0)
-      datadog-ci (~> 0.1.0)
+      datadog-ci (~> 0.2.0)
       debase-ruby_core_source (= 3.2.2)
       libdatadog (~> 5.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
@@ -61,7 +61,7 @@ GEM
     crack (0.4.5)
       rexml
     crass (1.0.6)
-    datadog-ci (0.1.1)
+    datadog-ci (0.2.0)
     debase-ruby_core_source (3.2.2)
     diff-lcs (1.5.0)
     docile (1.3.5)

--- a/gemfiles/ruby_2.2_rails4_postgres_sidekiq.gemfile.lock
+++ b/gemfiles/ruby_2.2_rails4_postgres_sidekiq.gemfile.lock
@@ -2,7 +2,7 @@ PATH
   remote: ..
   specs:
     ddtrace (1.14.0)
-      datadog-ci (~> 0.1.0)
+      datadog-ci (~> 0.2.0)
       debase-ruby_core_source (= 3.2.2)
       libdatadog (~> 5.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
@@ -62,7 +62,7 @@ GEM
     crack (0.4.5)
       rexml
     crass (1.0.6)
-    datadog-ci (0.1.1)
+    datadog-ci (0.2.0)
     debase-ruby_core_source (3.2.2)
     diff-lcs (1.5.0)
     docile (1.3.5)

--- a/gemfiles/ruby_2.2_rails4_semantic_logger.gemfile.lock
+++ b/gemfiles/ruby_2.2_rails4_semantic_logger.gemfile.lock
@@ -2,7 +2,7 @@ PATH
   remote: ..
   specs:
     ddtrace (1.14.0)
-      datadog-ci (~> 0.1.0)
+      datadog-ci (~> 0.2.0)
       debase-ruby_core_source (= 3.2.2)
       libdatadog (~> 5.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
@@ -61,7 +61,7 @@ GEM
     crack (0.4.5)
       rexml
     crass (1.0.6)
-    datadog-ci (0.1.1)
+    datadog-ci (0.2.0)
     debase-ruby_core_source (3.2.2)
     diff-lcs (1.5.0)
     docile (1.3.5)

--- a/gemfiles/ruby_2.2_rails5_mysql2.gemfile.lock
+++ b/gemfiles/ruby_2.2_rails5_mysql2.gemfile.lock
@@ -2,7 +2,7 @@ PATH
   remote: ..
   specs:
     ddtrace (1.14.0)
-      datadog-ci (~> 0.1.0)
+      datadog-ci (~> 0.2.0)
       debase-ruby_core_source (= 3.2.2)
       libdatadog (~> 5.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
@@ -68,7 +68,7 @@ GEM
     crack (0.4.5)
       rexml
     crass (1.0.6)
-    datadog-ci (0.1.1)
+    datadog-ci (0.2.0)
     debase-ruby_core_source (3.2.2)
     diff-lcs (1.5.0)
     docile (1.3.5)

--- a/gemfiles/ruby_2.2_rails5_postgres.gemfile.lock
+++ b/gemfiles/ruby_2.2_rails5_postgres.gemfile.lock
@@ -2,7 +2,7 @@ PATH
   remote: ..
   specs:
     ddtrace (1.14.0)
-      datadog-ci (~> 0.1.0)
+      datadog-ci (~> 0.2.0)
       debase-ruby_core_source (= 3.2.2)
       libdatadog (~> 5.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
@@ -68,7 +68,7 @@ GEM
     crack (0.4.5)
       rexml
     crass (1.0.6)
-    datadog-ci (0.1.1)
+    datadog-ci (0.2.0)
     debase-ruby_core_source (3.2.2)
     diff-lcs (1.5.0)
     docile (1.3.5)

--- a/gemfiles/ruby_2.2_rails5_postgres_redis.gemfile.lock
+++ b/gemfiles/ruby_2.2_rails5_postgres_redis.gemfile.lock
@@ -2,7 +2,7 @@ PATH
   remote: ..
   specs:
     ddtrace (1.14.0)
-      datadog-ci (~> 0.1.0)
+      datadog-ci (~> 0.2.0)
       debase-ruby_core_source (= 3.2.2)
       libdatadog (~> 5.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
@@ -68,7 +68,7 @@ GEM
     crack (0.4.5)
       rexml
     crass (1.0.6)
-    datadog-ci (0.1.1)
+    datadog-ci (0.2.0)
     debase-ruby_core_source (3.2.2)
     diff-lcs (1.5.0)
     docile (1.3.5)

--- a/gemfiles/ruby_2.2_rails5_postgres_redis_activesupport.gemfile.lock
+++ b/gemfiles/ruby_2.2_rails5_postgres_redis_activesupport.gemfile.lock
@@ -2,7 +2,7 @@ PATH
   remote: ..
   specs:
     ddtrace (1.14.0)
-      datadog-ci (~> 0.1.0)
+      datadog-ci (~> 0.2.0)
       debase-ruby_core_source (= 3.2.2)
       libdatadog (~> 5.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
@@ -68,7 +68,7 @@ GEM
     crack (0.4.5)
       rexml
     crass (1.0.6)
-    datadog-ci (0.1.1)
+    datadog-ci (0.2.0)
     debase-ruby_core_source (3.2.2)
     diff-lcs (1.5.0)
     docile (1.3.5)

--- a/gemfiles/ruby_2.2_rails5_postgres_sidekiq.gemfile.lock
+++ b/gemfiles/ruby_2.2_rails5_postgres_sidekiq.gemfile.lock
@@ -2,7 +2,7 @@ PATH
   remote: ..
   specs:
     ddtrace (1.14.0)
-      datadog-ci (~> 0.1.0)
+      datadog-ci (~> 0.2.0)
       debase-ruby_core_source (= 3.2.2)
       libdatadog (~> 5.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
@@ -69,7 +69,7 @@ GEM
     crack (0.4.5)
       rexml
     crass (1.0.6)
-    datadog-ci (0.1.1)
+    datadog-ci (0.2.0)
     debase-ruby_core_source (3.2.2)
     diff-lcs (1.5.0)
     docile (1.3.5)

--- a/gemfiles/ruby_2.2_rails5_semantic_logger.gemfile.lock
+++ b/gemfiles/ruby_2.2_rails5_semantic_logger.gemfile.lock
@@ -2,7 +2,7 @@ PATH
   remote: ..
   specs:
     ddtrace (1.14.0)
-      datadog-ci (~> 0.1.0)
+      datadog-ci (~> 0.2.0)
       debase-ruby_core_source (= 3.2.2)
       libdatadog (~> 5.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
@@ -68,7 +68,7 @@ GEM
     crack (0.4.5)
       rexml
     crass (1.0.6)
-    datadog-ci (0.1.1)
+    datadog-ci (0.2.0)
     debase-ruby_core_source (3.2.2)
     diff-lcs (1.5.0)
     docile (1.3.5)

--- a/gemfiles/ruby_2.2_redis_3.gemfile.lock
+++ b/gemfiles/ruby_2.2_redis_3.gemfile.lock
@@ -2,7 +2,7 @@ PATH
   remote: ..
   specs:
     ddtrace (1.14.0)
-      datadog-ci (~> 0.1.0)
+      datadog-ci (~> 0.2.0)
       debase-ruby_core_source (= 3.2.2)
       libdatadog (~> 5.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
@@ -25,7 +25,7 @@ GEM
     concurrent-ruby (1.1.10)
     crack (0.4.5)
       rexml
-    datadog-ci (0.1.1)
+    datadog-ci (0.2.0)
     debase-ruby_core_source (3.2.2)
     diff-lcs (1.5.0)
     docile (1.3.5)

--- a/gemfiles/ruby_2.2_relational_db.gemfile.lock
+++ b/gemfiles/ruby_2.2_relational_db.gemfile.lock
@@ -2,7 +2,7 @@ PATH
   remote: ..
   specs:
     ddtrace (1.14.0)
-      datadog-ci (~> 0.1.0)
+      datadog-ci (~> 0.2.0)
       debase-ruby_core_source (= 3.2.2)
       libdatadog (~> 5.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
@@ -37,7 +37,7 @@ GEM
     concurrent-ruby (1.1.10)
     crack (0.4.5)
       rexml
-    datadog-ci (0.1.1)
+    datadog-ci (0.2.0)
     debase-ruby_core_source (3.2.2)
     delayed_job (4.1.11)
       activesupport (>= 3.0, < 8.0)

--- a/gemfiles/ruby_2.2_sinatra.gemfile.lock
+++ b/gemfiles/ruby_2.2_sinatra.gemfile.lock
@@ -2,7 +2,7 @@ PATH
   remote: ..
   specs:
     ddtrace (1.14.0)
-      datadog-ci (~> 0.1.0)
+      datadog-ci (~> 0.2.0)
       debase-ruby_core_source (= 3.2.2)
       libdatadog (~> 5.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
@@ -25,7 +25,7 @@ GEM
     concurrent-ruby (1.1.10)
     crack (0.4.5)
       rexml
-    datadog-ci (0.1.1)
+    datadog-ci (0.2.0)
     debase-ruby_core_source (3.2.2)
     diff-lcs (1.5.0)
     docile (1.3.5)

--- a/gemfiles/ruby_2.3_activerecord_3.gemfile.lock
+++ b/gemfiles/ruby_2.3_activerecord_3.gemfile.lock
@@ -2,7 +2,7 @@ PATH
   remote: ..
   specs:
     ddtrace (1.14.0)
-      datadog-ci (~> 0.1.0)
+      datadog-ci (~> 0.2.0)
       debase-ruby_core_source (= 3.2.2)
       libdatadog (~> 5.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
@@ -41,7 +41,7 @@ GEM
     concurrent-ruby (1.2.2)
     crack (0.4.5)
       rexml
-    datadog-ci (0.1.1)
+    datadog-ci (0.2.0)
     debase-ruby_core_source (3.2.2)
     diff-lcs (1.5.0)
     docile (1.3.5)

--- a/gemfiles/ruby_2.3_activesupport.gemfile.lock
+++ b/gemfiles/ruby_2.3_activesupport.gemfile.lock
@@ -2,7 +2,7 @@ PATH
   remote: ..
   specs:
     ddtrace (1.14.0)
-      datadog-ci (~> 0.1.0)
+      datadog-ci (~> 0.2.0)
       debase-ruby_core_source (= 3.2.2)
       libdatadog (~> 5.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
@@ -60,7 +60,7 @@ GEM
     crack (0.4.5)
       rexml
     crass (1.0.6)
-    datadog-ci (0.1.1)
+    datadog-ci (0.2.0)
     debase-ruby_core_source (3.2.2)
     descendants_tracker (0.0.4)
       thread_safe (~> 0.3, >= 0.3.1)

--- a/gemfiles/ruby_2.3_aws.gemfile.lock
+++ b/gemfiles/ruby_2.3_aws.gemfile.lock
@@ -2,7 +2,7 @@ PATH
   remote: ..
   specs:
     ddtrace (1.14.0)
-      datadog-ci (~> 0.1.0)
+      datadog-ci (~> 0.2.0)
       debase-ruby_core_source (= 3.2.2)
       libdatadog (~> 5.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
@@ -1446,7 +1446,7 @@ GEM
     concurrent-ruby (1.2.2)
     crack (0.4.5)
       rexml
-    datadog-ci (0.1.1)
+    datadog-ci (0.2.0)
     debase-ruby_core_source (3.2.2)
     diff-lcs (1.5.0)
     docile (1.3.5)

--- a/gemfiles/ruby_2.3_contrib.gemfile.lock
+++ b/gemfiles/ruby_2.3_contrib.gemfile.lock
@@ -2,7 +2,7 @@ PATH
   remote: ..
   specs:
     ddtrace (1.14.0)
-      datadog-ci (~> 0.1.0)
+      datadog-ci (~> 0.2.0)
       debase-ruby_core_source (= 3.2.2)
       libdatadog (~> 5.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
@@ -32,7 +32,7 @@ GEM
     crack (0.4.5)
       rexml
     dalli (2.7.11)
-    datadog-ci (0.1.1)
+    datadog-ci (0.2.0)
     debase-ruby_core_source (3.2.2)
     diff-lcs (1.5.0)
     docile (1.3.5)

--- a/gemfiles/ruby_2.3_contrib_old.gemfile.lock
+++ b/gemfiles/ruby_2.3_contrib_old.gemfile.lock
@@ -2,7 +2,7 @@ PATH
   remote: ..
   specs:
     ddtrace (1.14.0)
-      datadog-ci (~> 0.1.0)
+      datadog-ci (~> 0.2.0)
       debase-ruby_core_source (= 3.2.2)
       libdatadog (~> 5.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
@@ -25,7 +25,7 @@ GEM
     concurrent-ruby (1.2.2)
     crack (0.4.5)
       rexml
-    datadog-ci (0.1.1)
+    datadog-ci (0.2.0)
     debase-ruby_core_source (3.2.2)
     diff-lcs (1.5.0)
     docile (1.3.5)

--- a/gemfiles/ruby_2.3_core_old.gemfile.lock
+++ b/gemfiles/ruby_2.3_core_old.gemfile.lock
@@ -2,7 +2,7 @@ PATH
   remote: ..
   specs:
     ddtrace (1.14.0)
-      datadog-ci (~> 0.1.0)
+      datadog-ci (~> 0.2.0)
       debase-ruby_core_source (= 3.2.2)
       libdatadog (~> 5.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
@@ -25,7 +25,7 @@ GEM
     concurrent-ruby (1.2.2)
     crack (0.4.5)
       rexml
-    datadog-ci (0.1.1)
+    datadog-ci (0.2.0)
     debase-ruby_core_source (3.2.2)
     diff-lcs (1.5.0)
     docile (1.3.5)

--- a/gemfiles/ruby_2.3_hanami_1.gemfile.lock
+++ b/gemfiles/ruby_2.3_hanami_1.gemfile.lock
@@ -2,7 +2,7 @@ PATH
   remote: ..
   specs:
     ddtrace (1.14.0)
-      datadog-ci (~> 0.1.0)
+      datadog-ci (~> 0.2.0)
       debase-ruby_core_source (= 3.2.2)
       libdatadog (~> 5.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
@@ -25,7 +25,7 @@ GEM
     concurrent-ruby (1.2.2)
     crack (0.4.5)
       rexml
-    datadog-ci (0.1.1)
+    datadog-ci (0.2.0)
     debase-ruby_core_source (3.2.2)
     diff-lcs (1.5.0)
     docile (1.3.5)

--- a/gemfiles/ruby_2.3_http.gemfile.lock
+++ b/gemfiles/ruby_2.3_http.gemfile.lock
@@ -2,7 +2,7 @@ PATH
   remote: ..
   specs:
     ddtrace (1.14.0)
-      datadog-ci (~> 0.1.0)
+      datadog-ci (~> 0.2.0)
       debase-ruby_core_source (= 3.2.2)
       libdatadog (~> 5.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
@@ -25,7 +25,7 @@ GEM
     concurrent-ruby (1.2.2)
     crack (0.4.5)
       rexml
-    datadog-ci (0.1.1)
+    datadog-ci (0.2.0)
     debase-ruby_core_source (3.2.2)
     diff-lcs (1.5.0)
     docile (1.3.5)

--- a/gemfiles/ruby_2.3_opentracing.gemfile.lock
+++ b/gemfiles/ruby_2.3_opentracing.gemfile.lock
@@ -2,7 +2,7 @@ PATH
   remote: ..
   specs:
     ddtrace (1.14.0)
-      datadog-ci (~> 0.1.0)
+      datadog-ci (~> 0.2.0)
       debase-ruby_core_source (= 3.2.2)
       libdatadog (~> 5.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
@@ -26,7 +26,7 @@ GEM
     concurrent-ruby (1.2.2)
     crack (0.4.5)
       rexml
-    datadog-ci (0.1.1)
+    datadog-ci (0.2.0)
     debase-ruby_core_source (3.2.2)
     diff-lcs (1.5.0)
     docile (1.3.5)

--- a/gemfiles/ruby_2.3_rack_1.gemfile.lock
+++ b/gemfiles/ruby_2.3_rack_1.gemfile.lock
@@ -2,7 +2,7 @@ PATH
   remote: ..
   specs:
     ddtrace (1.14.0)
-      datadog-ci (~> 0.1.0)
+      datadog-ci (~> 0.2.0)
       debase-ruby_core_source (= 3.2.2)
       libdatadog (~> 5.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
@@ -25,7 +25,7 @@ GEM
     concurrent-ruby (1.2.2)
     crack (0.4.5)
       rexml
-    datadog-ci (0.1.1)
+    datadog-ci (0.2.0)
     debase-ruby_core_source (3.2.2)
     diff-lcs (1.5.0)
     docile (1.3.5)

--- a/gemfiles/ruby_2.3_rack_2.gemfile.lock
+++ b/gemfiles/ruby_2.3_rack_2.gemfile.lock
@@ -2,7 +2,7 @@ PATH
   remote: ..
   specs:
     ddtrace (1.14.0)
-      datadog-ci (~> 0.1.0)
+      datadog-ci (~> 0.2.0)
       debase-ruby_core_source (= 3.2.2)
       libdatadog (~> 5.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
@@ -25,7 +25,7 @@ GEM
     concurrent-ruby (1.2.2)
     crack (0.4.5)
       rexml
-    datadog-ci (0.1.1)
+    datadog-ci (0.2.0)
     debase-ruby_core_source (3.2.2)
     diff-lcs (1.5.0)
     docile (1.3.5)

--- a/gemfiles/ruby_2.3_rails32_mysql2.gemfile.lock
+++ b/gemfiles/ruby_2.3_rails32_mysql2.gemfile.lock
@@ -2,7 +2,7 @@ PATH
   remote: ..
   specs:
     ddtrace (1.14.0)
-      datadog-ci (~> 0.1.0)
+      datadog-ci (~> 0.2.0)
       debase-ruby_core_source (= 3.2.2)
       libdatadog (~> 5.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
@@ -57,7 +57,7 @@ GEM
     concurrent-ruby (1.2.2)
     crack (0.4.5)
       rexml
-    datadog-ci (0.1.1)
+    datadog-ci (0.2.0)
     debase-ruby_core_source (3.2.2)
     diff-lcs (1.5.0)
     docile (1.3.5)

--- a/gemfiles/ruby_2.3_rails32_postgres.gemfile.lock
+++ b/gemfiles/ruby_2.3_rails32_postgres.gemfile.lock
@@ -2,7 +2,7 @@ PATH
   remote: ..
   specs:
     ddtrace (1.14.0)
-      datadog-ci (~> 0.1.0)
+      datadog-ci (~> 0.2.0)
       debase-ruby_core_source (= 3.2.2)
       libdatadog (~> 5.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
@@ -53,7 +53,7 @@ GEM
     concurrent-ruby (1.2.2)
     crack (0.4.5)
       rexml
-    datadog-ci (0.1.1)
+    datadog-ci (0.2.0)
     debase-ruby_core_source (3.2.2)
     diff-lcs (1.5.0)
     docile (1.3.5)

--- a/gemfiles/ruby_2.3_rails32_postgres_redis.gemfile.lock
+++ b/gemfiles/ruby_2.3_rails32_postgres_redis.gemfile.lock
@@ -2,7 +2,7 @@ PATH
   remote: ..
   specs:
     ddtrace (1.14.0)
-      datadog-ci (~> 0.1.0)
+      datadog-ci (~> 0.2.0)
       debase-ruby_core_source (= 3.2.2)
       libdatadog (~> 5.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
@@ -53,7 +53,7 @@ GEM
     concurrent-ruby (1.2.2)
     crack (0.4.5)
       rexml
-    datadog-ci (0.1.1)
+    datadog-ci (0.2.0)
     debase-ruby_core_source (3.2.2)
     diff-lcs (1.5.0)
     docile (1.3.5)

--- a/gemfiles/ruby_2.3_rails32_postgres_sidekiq.gemfile.lock
+++ b/gemfiles/ruby_2.3_rails32_postgres_sidekiq.gemfile.lock
@@ -2,7 +2,7 @@ PATH
   remote: ..
   specs:
     ddtrace (1.14.0)
-      datadog-ci (~> 0.1.0)
+      datadog-ci (~> 0.2.0)
       debase-ruby_core_source (= 3.2.2)
       libdatadog (~> 5.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
@@ -54,7 +54,7 @@ GEM
     connection_pool (2.2.5)
     crack (0.4.5)
       rexml
-    datadog-ci (0.1.1)
+    datadog-ci (0.2.0)
     debase-ruby_core_source (3.2.2)
     diff-lcs (1.5.0)
     docile (1.3.5)

--- a/gemfiles/ruby_2.3_rails4_mysql2.gemfile.lock
+++ b/gemfiles/ruby_2.3_rails4_mysql2.gemfile.lock
@@ -2,7 +2,7 @@ PATH
   remote: ..
   specs:
     ddtrace (1.14.0)
-      datadog-ci (~> 0.1.0)
+      datadog-ci (~> 0.2.0)
       debase-ruby_core_source (= 3.2.2)
       libdatadog (~> 5.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
@@ -61,7 +61,7 @@ GEM
     crack (0.4.5)
       rexml
     crass (1.0.6)
-    datadog-ci (0.1.1)
+    datadog-ci (0.2.0)
     debase-ruby_core_source (3.2.2)
     diff-lcs (1.5.0)
     docile (1.3.5)

--- a/gemfiles/ruby_2.3_rails4_postgres.gemfile.lock
+++ b/gemfiles/ruby_2.3_rails4_postgres.gemfile.lock
@@ -2,7 +2,7 @@ PATH
   remote: ..
   specs:
     ddtrace (1.14.0)
-      datadog-ci (~> 0.1.0)
+      datadog-ci (~> 0.2.0)
       debase-ruby_core_source (= 3.2.2)
       libdatadog (~> 5.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
@@ -61,7 +61,7 @@ GEM
     crack (0.4.5)
       rexml
     crass (1.0.6)
-    datadog-ci (0.1.1)
+    datadog-ci (0.2.0)
     debase-ruby_core_source (3.2.2)
     diff-lcs (1.5.0)
     docile (1.3.5)

--- a/gemfiles/ruby_2.3_rails4_postgres_redis.gemfile.lock
+++ b/gemfiles/ruby_2.3_rails4_postgres_redis.gemfile.lock
@@ -2,7 +2,7 @@ PATH
   remote: ..
   specs:
     ddtrace (1.14.0)
-      datadog-ci (~> 0.1.0)
+      datadog-ci (~> 0.2.0)
       debase-ruby_core_source (= 3.2.2)
       libdatadog (~> 5.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
@@ -61,7 +61,7 @@ GEM
     crack (0.4.5)
       rexml
     crass (1.0.6)
-    datadog-ci (0.1.1)
+    datadog-ci (0.2.0)
     debase-ruby_core_source (3.2.2)
     diff-lcs (1.5.0)
     docile (1.3.5)

--- a/gemfiles/ruby_2.3_rails4_postgres_sidekiq.gemfile.lock
+++ b/gemfiles/ruby_2.3_rails4_postgres_sidekiq.gemfile.lock
@@ -2,7 +2,7 @@ PATH
   remote: ..
   specs:
     ddtrace (1.14.0)
-      datadog-ci (~> 0.1.0)
+      datadog-ci (~> 0.2.0)
       debase-ruby_core_source (= 3.2.2)
       libdatadog (~> 5.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
@@ -62,7 +62,7 @@ GEM
     crack (0.4.5)
       rexml
     crass (1.0.6)
-    datadog-ci (0.1.1)
+    datadog-ci (0.2.0)
     debase-ruby_core_source (3.2.2)
     diff-lcs (1.5.0)
     docile (1.3.5)

--- a/gemfiles/ruby_2.3_rails4_semantic_logger.gemfile.lock
+++ b/gemfiles/ruby_2.3_rails4_semantic_logger.gemfile.lock
@@ -2,7 +2,7 @@ PATH
   remote: ..
   specs:
     ddtrace (1.14.0)
-      datadog-ci (~> 0.1.0)
+      datadog-ci (~> 0.2.0)
       debase-ruby_core_source (= 3.2.2)
       libdatadog (~> 5.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
@@ -61,7 +61,7 @@ GEM
     crack (0.4.5)
       rexml
     crass (1.0.6)
-    datadog-ci (0.1.1)
+    datadog-ci (0.2.0)
     debase-ruby_core_source (3.2.2)
     diff-lcs (1.5.0)
     docile (1.3.5)

--- a/gemfiles/ruby_2.3_rails5_mysql2.gemfile.lock
+++ b/gemfiles/ruby_2.3_rails5_mysql2.gemfile.lock
@@ -2,7 +2,7 @@ PATH
   remote: ..
   specs:
     ddtrace (1.14.0)
-      datadog-ci (~> 0.1.0)
+      datadog-ci (~> 0.2.0)
       debase-ruby_core_source (= 3.2.2)
       libdatadog (~> 5.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
@@ -68,7 +68,7 @@ GEM
     crack (0.4.5)
       rexml
     crass (1.0.6)
-    datadog-ci (0.1.1)
+    datadog-ci (0.2.0)
     debase-ruby_core_source (3.2.2)
     diff-lcs (1.5.0)
     docile (1.3.5)

--- a/gemfiles/ruby_2.3_rails5_postgres.gemfile.lock
+++ b/gemfiles/ruby_2.3_rails5_postgres.gemfile.lock
@@ -2,7 +2,7 @@ PATH
   remote: ..
   specs:
     ddtrace (1.14.0)
-      datadog-ci (~> 0.1.0)
+      datadog-ci (~> 0.2.0)
       debase-ruby_core_source (= 3.2.2)
       libdatadog (~> 5.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
@@ -68,7 +68,7 @@ GEM
     crack (0.4.5)
       rexml
     crass (1.0.6)
-    datadog-ci (0.1.1)
+    datadog-ci (0.2.0)
     debase-ruby_core_source (3.2.2)
     diff-lcs (1.5.0)
     docile (1.3.5)

--- a/gemfiles/ruby_2.3_rails5_postgres_redis.gemfile.lock
+++ b/gemfiles/ruby_2.3_rails5_postgres_redis.gemfile.lock
@@ -2,7 +2,7 @@ PATH
   remote: ..
   specs:
     ddtrace (1.14.0)
-      datadog-ci (~> 0.1.0)
+      datadog-ci (~> 0.2.0)
       debase-ruby_core_source (= 3.2.2)
       libdatadog (~> 5.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
@@ -68,7 +68,7 @@ GEM
     crack (0.4.5)
       rexml
     crass (1.0.6)
-    datadog-ci (0.1.1)
+    datadog-ci (0.2.0)
     debase-ruby_core_source (3.2.2)
     diff-lcs (1.5.0)
     docile (1.3.5)

--- a/gemfiles/ruby_2.3_rails5_postgres_redis_activesupport.gemfile.lock
+++ b/gemfiles/ruby_2.3_rails5_postgres_redis_activesupport.gemfile.lock
@@ -2,7 +2,7 @@ PATH
   remote: ..
   specs:
     ddtrace (1.14.0)
-      datadog-ci (~> 0.1.0)
+      datadog-ci (~> 0.2.0)
       debase-ruby_core_source (= 3.2.2)
       libdatadog (~> 5.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
@@ -68,7 +68,7 @@ GEM
     crack (0.4.5)
       rexml
     crass (1.0.6)
-    datadog-ci (0.1.1)
+    datadog-ci (0.2.0)
     debase-ruby_core_source (3.2.2)
     diff-lcs (1.5.0)
     docile (1.3.5)

--- a/gemfiles/ruby_2.3_rails5_postgres_sidekiq.gemfile.lock
+++ b/gemfiles/ruby_2.3_rails5_postgres_sidekiq.gemfile.lock
@@ -2,7 +2,7 @@ PATH
   remote: ..
   specs:
     ddtrace (1.14.0)
-      datadog-ci (~> 0.1.0)
+      datadog-ci (~> 0.2.0)
       debase-ruby_core_source (= 3.2.2)
       libdatadog (~> 5.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
@@ -69,7 +69,7 @@ GEM
     crack (0.4.5)
       rexml
     crass (1.0.6)
-    datadog-ci (0.1.1)
+    datadog-ci (0.2.0)
     debase-ruby_core_source (3.2.2)
     diff-lcs (1.5.0)
     docile (1.3.5)

--- a/gemfiles/ruby_2.3_rails5_semantic_logger.gemfile.lock
+++ b/gemfiles/ruby_2.3_rails5_semantic_logger.gemfile.lock
@@ -2,7 +2,7 @@ PATH
   remote: ..
   specs:
     ddtrace (1.14.0)
-      datadog-ci (~> 0.1.0)
+      datadog-ci (~> 0.2.0)
       debase-ruby_core_source (= 3.2.2)
       libdatadog (~> 5.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
@@ -68,7 +68,7 @@ GEM
     crack (0.4.5)
       rexml
     crass (1.0.6)
-    datadog-ci (0.1.1)
+    datadog-ci (0.2.0)
     debase-ruby_core_source (3.2.2)
     diff-lcs (1.5.0)
     docile (1.3.5)

--- a/gemfiles/ruby_2.3_redis_3.gemfile.lock
+++ b/gemfiles/ruby_2.3_redis_3.gemfile.lock
@@ -2,7 +2,7 @@ PATH
   remote: ..
   specs:
     ddtrace (1.14.0)
-      datadog-ci (~> 0.1.0)
+      datadog-ci (~> 0.2.0)
       debase-ruby_core_source (= 3.2.2)
       libdatadog (~> 5.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
@@ -25,7 +25,7 @@ GEM
     concurrent-ruby (1.2.2)
     crack (0.4.5)
       rexml
-    datadog-ci (0.1.1)
+    datadog-ci (0.2.0)
     debase-ruby_core_source (3.2.2)
     diff-lcs (1.5.0)
     docile (1.3.5)

--- a/gemfiles/ruby_2.3_relational_db.gemfile.lock
+++ b/gemfiles/ruby_2.3_relational_db.gemfile.lock
@@ -2,7 +2,7 @@ PATH
   remote: ..
   specs:
     ddtrace (1.14.0)
-      datadog-ci (~> 0.1.0)
+      datadog-ci (~> 0.2.0)
       debase-ruby_core_source (= 3.2.2)
       libdatadog (~> 5.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
@@ -37,7 +37,7 @@ GEM
     concurrent-ruby (1.2.2)
     crack (0.4.5)
       rexml
-    datadog-ci (0.1.1)
+    datadog-ci (0.2.0)
     debase-ruby_core_source (3.2.2)
     delayed_job (4.1.11)
       activesupport (>= 3.0, < 8.0)

--- a/gemfiles/ruby_2.3_resque2_redis3.gemfile.lock
+++ b/gemfiles/ruby_2.3_resque2_redis3.gemfile.lock
@@ -2,7 +2,7 @@ PATH
   remote: ..
   specs:
     ddtrace (1.14.0)
-      datadog-ci (~> 0.1.0)
+      datadog-ci (~> 0.2.0)
       debase-ruby_core_source (= 3.2.2)
       libdatadog (~> 5.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
@@ -25,7 +25,7 @@ GEM
     concurrent-ruby (1.2.2)
     crack (0.4.5)
       rexml
-    datadog-ci (0.1.1)
+    datadog-ci (0.2.0)
     debase-ruby_core_source (3.2.2)
     diff-lcs (1.5.0)
     docile (1.3.5)

--- a/gemfiles/ruby_2.3_resque2_redis4.gemfile.lock
+++ b/gemfiles/ruby_2.3_resque2_redis4.gemfile.lock
@@ -2,7 +2,7 @@ PATH
   remote: ..
   specs:
     ddtrace (1.14.0)
-      datadog-ci (~> 0.1.0)
+      datadog-ci (~> 0.2.0)
       debase-ruby_core_source (= 3.2.2)
       libdatadog (~> 5.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
@@ -25,7 +25,7 @@ GEM
     concurrent-ruby (1.2.2)
     crack (0.4.5)
       rexml
-    datadog-ci (0.1.1)
+    datadog-ci (0.2.0)
     debase-ruby_core_source (3.2.2)
     diff-lcs (1.5.0)
     docile (1.3.5)

--- a/gemfiles/ruby_2.3_sinatra.gemfile.lock
+++ b/gemfiles/ruby_2.3_sinatra.gemfile.lock
@@ -2,7 +2,7 @@ PATH
   remote: ..
   specs:
     ddtrace (1.14.0)
-      datadog-ci (~> 0.1.0)
+      datadog-ci (~> 0.2.0)
       debase-ruby_core_source (= 3.2.2)
       libdatadog (~> 5.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
@@ -25,7 +25,7 @@ GEM
     concurrent-ruby (1.2.2)
     crack (0.4.5)
       rexml
-    datadog-ci (0.1.1)
+    datadog-ci (0.2.0)
     debase-ruby_core_source (3.2.2)
     diff-lcs (1.5.0)
     docile (1.3.5)

--- a/gemfiles/ruby_2.4_activerecord_4.gemfile.lock
+++ b/gemfiles/ruby_2.4_activerecord_4.gemfile.lock
@@ -2,7 +2,7 @@ PATH
   remote: ..
   specs:
     ddtrace (1.14.0)
-      datadog-ci (~> 0.1.0)
+      datadog-ci (~> 0.2.0)
       debase-ruby_core_source (= 3.2.2)
       libdatadog (~> 5.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
@@ -40,7 +40,7 @@ GEM
     crack (0.4.5)
       rexml
     cri (2.15.10)
-    datadog-ci (0.1.1)
+    datadog-ci (0.2.0)
     debase-ruby_core_source (3.2.2)
     diff-lcs (1.5.0)
     docile (1.3.5)

--- a/gemfiles/ruby_2.4_activesupport.gemfile.lock
+++ b/gemfiles/ruby_2.4_activesupport.gemfile.lock
@@ -2,7 +2,7 @@ PATH
   remote: ..
   specs:
     ddtrace (1.14.0)
-      datadog-ci (~> 0.1.0)
+      datadog-ci (~> 0.2.0)
       debase-ruby_core_source (= 3.2.2)
       libdatadog (~> 5.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
@@ -55,7 +55,7 @@ GEM
       rexml
     crass (1.0.6)
     cri (2.15.10)
-    datadog-ci (0.1.1)
+    datadog-ci (0.2.0)
     debase-ruby_core_source (3.2.2)
     diff-lcs (1.5.0)
     digest-crc (0.6.5)

--- a/gemfiles/ruby_2.4_aws.gemfile.lock
+++ b/gemfiles/ruby_2.4_aws.gemfile.lock
@@ -2,7 +2,7 @@ PATH
   remote: ..
   specs:
     ddtrace (1.14.0)
-      datadog-ci (~> 0.1.0)
+      datadog-ci (~> 0.2.0)
       debase-ruby_core_source (= 3.2.2)
       libdatadog (~> 5.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
@@ -1448,7 +1448,7 @@ GEM
     crack (0.4.5)
       rexml
     cri (2.15.10)
-    datadog-ci (0.1.1)
+    datadog-ci (0.2.0)
     debase-ruby_core_source (3.2.2)
     diff-lcs (1.5.0)
     docile (1.3.5)

--- a/gemfiles/ruby_2.4_contrib.gemfile.lock
+++ b/gemfiles/ruby_2.4_contrib.gemfile.lock
@@ -2,7 +2,7 @@ PATH
   remote: ..
   specs:
     ddtrace (1.14.0)
-      datadog-ci (~> 0.1.0)
+      datadog-ci (~> 0.2.0)
       debase-ruby_core_source (= 3.2.2)
       libdatadog (~> 5.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
@@ -34,7 +34,7 @@ GEM
       rexml
     cri (2.15.10)
     dalli (2.7.11)
-    datadog-ci (0.1.1)
+    datadog-ci (0.2.0)
     debase-ruby_core_source (3.2.2)
     diff-lcs (1.3)
     docile (1.3.5)

--- a/gemfiles/ruby_2.4_contrib_old.gemfile.lock
+++ b/gemfiles/ruby_2.4_contrib_old.gemfile.lock
@@ -2,7 +2,7 @@ PATH
   remote: ..
   specs:
     ddtrace (1.14.0)
-      datadog-ci (~> 0.1.0)
+      datadog-ci (~> 0.2.0)
       debase-ruby_core_source (= 3.2.2)
       libdatadog (~> 5.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
@@ -27,7 +27,7 @@ GEM
     crack (0.4.5)
       rexml
     cri (2.15.10)
-    datadog-ci (0.1.1)
+    datadog-ci (0.2.0)
     debase-ruby_core_source (3.2.2)
     diff-lcs (1.5.0)
     docile (1.3.5)

--- a/gemfiles/ruby_2.4_core_old.gemfile.lock
+++ b/gemfiles/ruby_2.4_core_old.gemfile.lock
@@ -2,7 +2,7 @@ PATH
   remote: ..
   specs:
     ddtrace (1.14.0)
-      datadog-ci (~> 0.1.0)
+      datadog-ci (~> 0.2.0)
       debase-ruby_core_source (= 3.2.2)
       libdatadog (~> 5.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
@@ -27,7 +27,7 @@ GEM
     crack (0.4.5)
       rexml
     cri (2.15.10)
-    datadog-ci (0.1.1)
+    datadog-ci (0.2.0)
     debase-ruby_core_source (3.2.2)
     diff-lcs (1.5.0)
     docile (1.3.5)

--- a/gemfiles/ruby_2.4_hanami_1.gemfile.lock
+++ b/gemfiles/ruby_2.4_hanami_1.gemfile.lock
@@ -2,7 +2,7 @@ PATH
   remote: ..
   specs:
     ddtrace (1.14.0)
-      datadog-ci (~> 0.1.0)
+      datadog-ci (~> 0.2.0)
       debase-ruby_core_source (= 3.2.2)
       libdatadog (~> 5.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
@@ -27,7 +27,7 @@ GEM
     crack (0.4.5)
       rexml
     cri (2.15.10)
-    datadog-ci (0.1.1)
+    datadog-ci (0.2.0)
     debase-ruby_core_source (3.2.2)
     diff-lcs (1.5.0)
     docile (1.3.5)

--- a/gemfiles/ruby_2.4_http.gemfile.lock
+++ b/gemfiles/ruby_2.4_http.gemfile.lock
@@ -2,7 +2,7 @@ PATH
   remote: ..
   specs:
     ddtrace (1.14.0)
-      datadog-ci (~> 0.1.0)
+      datadog-ci (~> 0.2.0)
       debase-ruby_core_source (= 3.2.2)
       libdatadog (~> 5.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
@@ -27,7 +27,7 @@ GEM
     crack (0.4.5)
       rexml
     cri (2.15.10)
-    datadog-ci (0.1.1)
+    datadog-ci (0.2.0)
     debase-ruby_core_source (3.2.2)
     diff-lcs (1.5.0)
     docile (1.3.5)

--- a/gemfiles/ruby_2.4_opentracing.gemfile.lock
+++ b/gemfiles/ruby_2.4_opentracing.gemfile.lock
@@ -2,7 +2,7 @@ PATH
   remote: ..
   specs:
     ddtrace (1.14.0)
-      datadog-ci (~> 0.1.0)
+      datadog-ci (~> 0.2.0)
       debase-ruby_core_source (= 3.2.2)
       libdatadog (~> 5.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
@@ -28,7 +28,7 @@ GEM
     crack (0.4.5)
       rexml
     cri (2.15.10)
-    datadog-ci (0.1.1)
+    datadog-ci (0.2.0)
     debase-ruby_core_source (3.2.2)
     diff-lcs (1.5.0)
     docile (1.3.5)

--- a/gemfiles/ruby_2.4_rack_1.gemfile.lock
+++ b/gemfiles/ruby_2.4_rack_1.gemfile.lock
@@ -2,7 +2,7 @@ PATH
   remote: ..
   specs:
     ddtrace (1.14.0)
-      datadog-ci (~> 0.1.0)
+      datadog-ci (~> 0.2.0)
       debase-ruby_core_source (= 3.2.2)
       libdatadog (~> 5.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
@@ -27,7 +27,7 @@ GEM
     crack (0.4.5)
       rexml
     cri (2.15.10)
-    datadog-ci (0.1.1)
+    datadog-ci (0.2.0)
     debase-ruby_core_source (3.2.2)
     diff-lcs (1.5.0)
     docile (1.3.5)

--- a/gemfiles/ruby_2.4_rack_2.gemfile.lock
+++ b/gemfiles/ruby_2.4_rack_2.gemfile.lock
@@ -2,7 +2,7 @@ PATH
   remote: ..
   specs:
     ddtrace (1.14.0)
-      datadog-ci (~> 0.1.0)
+      datadog-ci (~> 0.2.0)
       debase-ruby_core_source (= 3.2.2)
       libdatadog (~> 5.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
@@ -27,7 +27,7 @@ GEM
     crack (0.4.5)
       rexml
     cri (2.15.10)
-    datadog-ci (0.1.1)
+    datadog-ci (0.2.0)
     debase-ruby_core_source (3.2.2)
     diff-lcs (1.5.0)
     docile (1.3.5)

--- a/gemfiles/ruby_2.4_rack_3.gemfile.lock
+++ b/gemfiles/ruby_2.4_rack_3.gemfile.lock
@@ -2,7 +2,7 @@ PATH
   remote: ..
   specs:
     ddtrace (1.14.0)
-      datadog-ci (~> 0.1.0)
+      datadog-ci (~> 0.2.0)
       debase-ruby_core_source (= 3.2.2)
       libdatadog (~> 5.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
@@ -27,7 +27,7 @@ GEM
     crack (0.4.5)
       rexml
     cri (2.15.10)
-    datadog-ci (0.1.1)
+    datadog-ci (0.2.0)
     debase-ruby_core_source (3.2.2)
     diff-lcs (1.5.0)
     docile (1.3.5)

--- a/gemfiles/ruby_2.4_rails5_mysql2.gemfile.lock
+++ b/gemfiles/ruby_2.4_rails5_mysql2.gemfile.lock
@@ -2,7 +2,7 @@ PATH
   remote: ..
   specs:
     ddtrace (1.14.0)
-      datadog-ci (~> 0.1.0)
+      datadog-ci (~> 0.2.0)
       debase-ruby_core_source (= 3.2.2)
       libdatadog (~> 5.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
@@ -70,7 +70,7 @@ GEM
       rexml
     crass (1.0.6)
     cri (2.15.10)
-    datadog-ci (0.1.1)
+    datadog-ci (0.2.0)
     debase-ruby_core_source (3.2.2)
     diff-lcs (1.5.0)
     docile (1.3.5)

--- a/gemfiles/ruby_2.4_rails5_postgres.gemfile.lock
+++ b/gemfiles/ruby_2.4_rails5_postgres.gemfile.lock
@@ -2,7 +2,7 @@ PATH
   remote: ..
   specs:
     ddtrace (1.14.0)
-      datadog-ci (~> 0.1.0)
+      datadog-ci (~> 0.2.0)
       debase-ruby_core_source (= 3.2.2)
       libdatadog (~> 5.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
@@ -70,7 +70,7 @@ GEM
       rexml
     crass (1.0.6)
     cri (2.15.10)
-    datadog-ci (0.1.1)
+    datadog-ci (0.2.0)
     debase-ruby_core_source (3.2.2)
     diff-lcs (1.5.0)
     docile (1.3.5)

--- a/gemfiles/ruby_2.4_rails5_postgres_redis.gemfile.lock
+++ b/gemfiles/ruby_2.4_rails5_postgres_redis.gemfile.lock
@@ -2,7 +2,7 @@ PATH
   remote: ..
   specs:
     ddtrace (1.14.0)
-      datadog-ci (~> 0.1.0)
+      datadog-ci (~> 0.2.0)
       debase-ruby_core_source (= 3.2.2)
       libdatadog (~> 5.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
@@ -70,7 +70,7 @@ GEM
       rexml
     crass (1.0.6)
     cri (2.15.10)
-    datadog-ci (0.1.1)
+    datadog-ci (0.2.0)
     debase-ruby_core_source (3.2.2)
     diff-lcs (1.5.0)
     docile (1.3.5)

--- a/gemfiles/ruby_2.4_rails5_postgres_redis_activesupport.gemfile.lock
+++ b/gemfiles/ruby_2.4_rails5_postgres_redis_activesupport.gemfile.lock
@@ -2,7 +2,7 @@ PATH
   remote: ..
   specs:
     ddtrace (1.14.0)
-      datadog-ci (~> 0.1.0)
+      datadog-ci (~> 0.2.0)
       debase-ruby_core_source (= 3.2.2)
       libdatadog (~> 5.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
@@ -70,7 +70,7 @@ GEM
       rexml
     crass (1.0.6)
     cri (2.15.10)
-    datadog-ci (0.1.1)
+    datadog-ci (0.2.0)
     debase-ruby_core_source (3.2.2)
     diff-lcs (1.5.0)
     docile (1.3.5)

--- a/gemfiles/ruby_2.4_rails5_postgres_sidekiq.gemfile.lock
+++ b/gemfiles/ruby_2.4_rails5_postgres_sidekiq.gemfile.lock
@@ -2,7 +2,7 @@ PATH
   remote: ..
   specs:
     ddtrace (1.14.0)
-      datadog-ci (~> 0.1.0)
+      datadog-ci (~> 0.2.0)
       debase-ruby_core_source (= 3.2.2)
       libdatadog (~> 5.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
@@ -71,7 +71,7 @@ GEM
       rexml
     crass (1.0.6)
     cri (2.15.10)
-    datadog-ci (0.1.1)
+    datadog-ci (0.2.0)
     debase-ruby_core_source (3.2.2)
     diff-lcs (1.5.0)
     docile (1.3.5)

--- a/gemfiles/ruby_2.4_rails5_semantic_logger.gemfile.lock
+++ b/gemfiles/ruby_2.4_rails5_semantic_logger.gemfile.lock
@@ -2,7 +2,7 @@ PATH
   remote: ..
   specs:
     ddtrace (1.14.0)
-      datadog-ci (~> 0.1.0)
+      datadog-ci (~> 0.2.0)
       debase-ruby_core_source (= 3.2.2)
       libdatadog (~> 5.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
@@ -70,7 +70,7 @@ GEM
       rexml
     crass (1.0.6)
     cri (2.15.10)
-    datadog-ci (0.1.1)
+    datadog-ci (0.2.0)
     debase-ruby_core_source (3.2.2)
     diff-lcs (1.5.0)
     docile (1.3.5)

--- a/gemfiles/ruby_2.4_redis_3.gemfile.lock
+++ b/gemfiles/ruby_2.4_redis_3.gemfile.lock
@@ -2,7 +2,7 @@ PATH
   remote: ..
   specs:
     ddtrace (1.14.0)
-      datadog-ci (~> 0.1.0)
+      datadog-ci (~> 0.2.0)
       debase-ruby_core_source (= 3.2.2)
       libdatadog (~> 5.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
@@ -27,7 +27,7 @@ GEM
     crack (0.4.5)
       rexml
     cri (2.15.10)
-    datadog-ci (0.1.1)
+    datadog-ci (0.2.0)
     debase-ruby_core_source (3.2.2)
     diff-lcs (1.5.0)
     docile (1.3.5)

--- a/gemfiles/ruby_2.4_redis_4.gemfile.lock
+++ b/gemfiles/ruby_2.4_redis_4.gemfile.lock
@@ -2,7 +2,7 @@ PATH
   remote: ..
   specs:
     ddtrace (1.14.0)
-      datadog-ci (~> 0.1.0)
+      datadog-ci (~> 0.2.0)
       debase-ruby_core_source (= 3.2.2)
       libdatadog (~> 5.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
@@ -27,7 +27,7 @@ GEM
     crack (0.4.5)
       rexml
     cri (2.15.10)
-    datadog-ci (0.1.1)
+    datadog-ci (0.2.0)
     debase-ruby_core_source (3.2.2)
     diff-lcs (1.5.0)
     docile (1.3.5)

--- a/gemfiles/ruby_2.4_relational_db.gemfile.lock
+++ b/gemfiles/ruby_2.4_relational_db.gemfile.lock
@@ -2,7 +2,7 @@ PATH
   remote: ..
   specs:
     ddtrace (1.14.0)
-      datadog-ci (~> 0.1.0)
+      datadog-ci (~> 0.2.0)
       debase-ruby_core_source (= 3.2.2)
       libdatadog (~> 5.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
@@ -39,7 +39,7 @@ GEM
     crack (0.4.5)
       rexml
     cri (2.15.10)
-    datadog-ci (0.1.1)
+    datadog-ci (0.2.0)
     debase-ruby_core_source (3.2.2)
     delayed_job (4.1.11)
       activesupport (>= 3.0, < 8.0)

--- a/gemfiles/ruby_2.4_resque2_redis3.gemfile.lock
+++ b/gemfiles/ruby_2.4_resque2_redis3.gemfile.lock
@@ -2,7 +2,7 @@ PATH
   remote: ..
   specs:
     ddtrace (1.14.0)
-      datadog-ci (~> 0.1.0)
+      datadog-ci (~> 0.2.0)
       debase-ruby_core_source (= 3.2.2)
       libdatadog (~> 5.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
@@ -27,7 +27,7 @@ GEM
     crack (0.4.5)
       rexml
     cri (2.15.10)
-    datadog-ci (0.1.1)
+    datadog-ci (0.2.0)
     debase-ruby_core_source (3.2.2)
     diff-lcs (1.5.0)
     docile (1.3.5)

--- a/gemfiles/ruby_2.4_resque2_redis4.gemfile.lock
+++ b/gemfiles/ruby_2.4_resque2_redis4.gemfile.lock
@@ -2,7 +2,7 @@ PATH
   remote: ..
   specs:
     ddtrace (1.14.0)
-      datadog-ci (~> 0.1.0)
+      datadog-ci (~> 0.2.0)
       debase-ruby_core_source (= 3.2.2)
       libdatadog (~> 5.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
@@ -27,7 +27,7 @@ GEM
     crack (0.4.5)
       rexml
     cri (2.15.10)
-    datadog-ci (0.1.1)
+    datadog-ci (0.2.0)
     debase-ruby_core_source (3.2.2)
     diff-lcs (1.5.0)
     docile (1.3.5)

--- a/gemfiles/ruby_2.4_sinatra.gemfile.lock
+++ b/gemfiles/ruby_2.4_sinatra.gemfile.lock
@@ -2,7 +2,7 @@ PATH
   remote: ..
   specs:
     ddtrace (1.14.0)
-      datadog-ci (~> 0.1.0)
+      datadog-ci (~> 0.2.0)
       debase-ruby_core_source (= 3.2.2)
       libdatadog (~> 5.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
@@ -27,7 +27,7 @@ GEM
     crack (0.4.5)
       rexml
     cri (2.15.10)
-    datadog-ci (0.1.1)
+    datadog-ci (0.2.0)
     debase-ruby_core_source (3.2.2)
     diff-lcs (1.5.0)
     docile (1.3.5)

--- a/gemfiles/ruby_2.5_activesupport.gemfile.lock
+++ b/gemfiles/ruby_2.5_activesupport.gemfile.lock
@@ -12,7 +12,7 @@ PATH
   remote: ..
   specs:
     ddtrace (1.14.0)
-      datadog-ci (~> 0.1.0)
+      datadog-ci (~> 0.2.0)
       debase-ruby_core_source (= 3.2.2)
       libdatadog (~> 5.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
@@ -67,7 +67,7 @@ GEM
       rexml
     crass (1.0.6)
     cri (2.15.11)
-    datadog-ci (0.1.1)
+    datadog-ci (0.2.0)
     debase-ruby_core_source (3.2.2)
     debug_inspector (1.1.0)
     diff-lcs (1.5.0)

--- a/gemfiles/ruby_2.5_aws.gemfile.lock
+++ b/gemfiles/ruby_2.5_aws.gemfile.lock
@@ -12,7 +12,7 @@ PATH
   remote: ..
   specs:
     ddtrace (1.14.0)
-      datadog-ci (~> 0.1.0)
+      datadog-ci (~> 0.2.0)
       debase-ruby_core_source (= 3.2.2)
       libdatadog (~> 5.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
@@ -1460,7 +1460,7 @@ GEM
     crack (0.4.5)
       rexml
     cri (2.15.11)
-    datadog-ci (0.1.1)
+    datadog-ci (0.2.0)
     debase-ruby_core_source (3.2.2)
     debug_inspector (1.1.0)
     diff-lcs (1.5.0)

--- a/gemfiles/ruby_2.5_contrib.gemfile.lock
+++ b/gemfiles/ruby_2.5_contrib.gemfile.lock
@@ -12,7 +12,7 @@ PATH
   remote: ..
   specs:
     ddtrace (1.14.0)
-      datadog-ci (~> 0.1.0)
+      datadog-ci (~> 0.2.0)
       debase-ruby_core_source (= 3.2.2)
       libdatadog (~> 5.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
@@ -46,7 +46,7 @@ GEM
       rexml
     cri (2.15.11)
     dalli (3.2.0)
-    datadog-ci (0.1.1)
+    datadog-ci (0.2.0)
     debase-ruby_core_source (3.2.2)
     debug_inspector (1.1.0)
     diff-lcs (1.5.0)

--- a/gemfiles/ruby_2.5_contrib_old.gemfile.lock
+++ b/gemfiles/ruby_2.5_contrib_old.gemfile.lock
@@ -12,7 +12,7 @@ PATH
   remote: ..
   specs:
     ddtrace (1.14.0)
-      datadog-ci (~> 0.1.0)
+      datadog-ci (~> 0.2.0)
       debase-ruby_core_source (= 3.2.2)
       libdatadog (~> 5.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
@@ -44,7 +44,7 @@ GEM
     cri (2.15.11)
     daemons (1.4.1)
     dalli (2.7.11)
-    datadog-ci (0.1.1)
+    datadog-ci (0.2.0)
     debase-ruby_core_source (3.2.2)
     debug_inspector (1.1.0)
     diff-lcs (1.5.0)

--- a/gemfiles/ruby_2.5_core_old.gemfile.lock
+++ b/gemfiles/ruby_2.5_core_old.gemfile.lock
@@ -12,7 +12,7 @@ PATH
   remote: ..
   specs:
     ddtrace (1.14.0)
-      datadog-ci (~> 0.1.0)
+      datadog-ci (~> 0.2.0)
       debase-ruby_core_source (= 3.2.2)
       libdatadog (~> 5.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
@@ -39,7 +39,7 @@ GEM
     crack (0.4.5)
       rexml
     cri (2.15.11)
-    datadog-ci (0.1.1)
+    datadog-ci (0.2.0)
     debase-ruby_core_source (3.2.2)
     debug_inspector (1.1.0)
     diff-lcs (1.5.0)

--- a/gemfiles/ruby_2.5_hanami_1.gemfile.lock
+++ b/gemfiles/ruby_2.5_hanami_1.gemfile.lock
@@ -12,7 +12,7 @@ PATH
   remote: ..
   specs:
     ddtrace (1.14.0)
-      datadog-ci (~> 0.1.0)
+      datadog-ci (~> 0.2.0)
       debase-ruby_core_source (= 3.2.2)
       libdatadog (~> 5.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
@@ -39,7 +39,7 @@ GEM
     crack (0.4.5)
       rexml
     cri (2.15.11)
-    datadog-ci (0.1.1)
+    datadog-ci (0.2.0)
     debase-ruby_core_source (3.2.2)
     debug_inspector (1.1.0)
     diff-lcs (1.5.0)

--- a/gemfiles/ruby_2.5_http.gemfile.lock
+++ b/gemfiles/ruby_2.5_http.gemfile.lock
@@ -12,7 +12,7 @@ PATH
   remote: ..
   specs:
     ddtrace (1.14.0)
-      datadog-ci (~> 0.1.0)
+      datadog-ci (~> 0.2.0)
       debase-ruby_core_source (= 3.2.2)
       libdatadog (~> 5.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
@@ -39,7 +39,7 @@ GEM
     crack (0.4.5)
       rexml
     cri (2.15.11)
-    datadog-ci (0.1.1)
+    datadog-ci (0.2.0)
     debase-ruby_core_source (3.2.2)
     debug_inspector (1.1.0)
     diff-lcs (1.5.0)

--- a/gemfiles/ruby_2.5_opentracing.gemfile.lock
+++ b/gemfiles/ruby_2.5_opentracing.gemfile.lock
@@ -12,7 +12,7 @@ PATH
   remote: ..
   specs:
     ddtrace (1.14.0)
-      datadog-ci (~> 0.1.0)
+      datadog-ci (~> 0.2.0)
       debase-ruby_core_source (= 3.2.2)
       libdatadog (~> 5.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
@@ -40,7 +40,7 @@ GEM
     crack (0.4.5)
       rexml
     cri (2.15.11)
-    datadog-ci (0.1.1)
+    datadog-ci (0.2.0)
     debase-ruby_core_source (3.2.2)
     debug_inspector (1.1.0)
     diff-lcs (1.5.0)

--- a/gemfiles/ruby_2.5_rack_1.gemfile.lock
+++ b/gemfiles/ruby_2.5_rack_1.gemfile.lock
@@ -12,7 +12,7 @@ PATH
   remote: ..
   specs:
     ddtrace (1.14.0)
-      datadog-ci (~> 0.1.0)
+      datadog-ci (~> 0.2.0)
       debase-ruby_core_source (= 3.2.2)
       libdatadog (~> 5.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
@@ -39,7 +39,7 @@ GEM
     crack (0.4.5)
       rexml
     cri (2.15.11)
-    datadog-ci (0.1.1)
+    datadog-ci (0.2.0)
     debase-ruby_core_source (3.2.2)
     debug_inspector (1.1.0)
     diff-lcs (1.5.0)

--- a/gemfiles/ruby_2.5_rack_2.gemfile.lock
+++ b/gemfiles/ruby_2.5_rack_2.gemfile.lock
@@ -12,7 +12,7 @@ PATH
   remote: ..
   specs:
     ddtrace (1.14.0)
-      datadog-ci (~> 0.1.0)
+      datadog-ci (~> 0.2.0)
       debase-ruby_core_source (= 3.2.2)
       libdatadog (~> 5.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
@@ -39,7 +39,7 @@ GEM
     crack (0.4.5)
       rexml
     cri (2.15.11)
-    datadog-ci (0.1.1)
+    datadog-ci (0.2.0)
     debase-ruby_core_source (3.2.2)
     debug_inspector (1.1.0)
     diff-lcs (1.5.0)

--- a/gemfiles/ruby_2.5_rack_3.gemfile.lock
+++ b/gemfiles/ruby_2.5_rack_3.gemfile.lock
@@ -12,7 +12,7 @@ PATH
   remote: ..
   specs:
     ddtrace (1.14.0)
-      datadog-ci (~> 0.1.0)
+      datadog-ci (~> 0.2.0)
       debase-ruby_core_source (= 3.2.2)
       libdatadog (~> 5.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
@@ -39,7 +39,7 @@ GEM
     crack (0.4.5)
       rexml
     cri (2.15.11)
-    datadog-ci (0.1.1)
+    datadog-ci (0.2.0)
     debase-ruby_core_source (3.2.2)
     debug_inspector (1.1.0)
     diff-lcs (1.5.0)

--- a/gemfiles/ruby_2.5_rails5_mysql2.gemfile.lock
+++ b/gemfiles/ruby_2.5_rails5_mysql2.gemfile.lock
@@ -12,7 +12,7 @@ PATH
   remote: ..
   specs:
     ddtrace (1.14.0)
-      datadog-ci (~> 0.1.0)
+      datadog-ci (~> 0.2.0)
       debase-ruby_core_source (= 3.2.2)
       libdatadog (~> 5.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
@@ -82,7 +82,7 @@ GEM
       rexml
     crass (1.0.6)
     cri (2.15.11)
-    datadog-ci (0.1.1)
+    datadog-ci (0.2.0)
     debase-ruby_core_source (3.2.2)
     debug_inspector (1.1.0)
     diff-lcs (1.5.0)

--- a/gemfiles/ruby_2.5_rails5_postgres.gemfile.lock
+++ b/gemfiles/ruby_2.5_rails5_postgres.gemfile.lock
@@ -12,7 +12,7 @@ PATH
   remote: ..
   specs:
     ddtrace (1.14.0)
-      datadog-ci (~> 0.1.0)
+      datadog-ci (~> 0.2.0)
       debase-ruby_core_source (= 3.2.2)
       libdatadog (~> 5.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
@@ -82,7 +82,7 @@ GEM
       rexml
     crass (1.0.6)
     cri (2.15.11)
-    datadog-ci (0.1.1)
+    datadog-ci (0.2.0)
     debase-ruby_core_source (3.2.2)
     debug_inspector (1.1.0)
     diff-lcs (1.5.0)

--- a/gemfiles/ruby_2.5_rails5_postgres_redis.gemfile.lock
+++ b/gemfiles/ruby_2.5_rails5_postgres_redis.gemfile.lock
@@ -12,7 +12,7 @@ PATH
   remote: ..
   specs:
     ddtrace (1.14.0)
-      datadog-ci (~> 0.1.0)
+      datadog-ci (~> 0.2.0)
       debase-ruby_core_source (= 3.2.2)
       libdatadog (~> 5.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
@@ -83,7 +83,7 @@ GEM
       rexml
     crass (1.0.6)
     cri (2.15.11)
-    datadog-ci (0.1.1)
+    datadog-ci (0.2.0)
     debase-ruby_core_source (3.2.2)
     debug_inspector (1.1.0)
     diff-lcs (1.5.0)

--- a/gemfiles/ruby_2.5_rails5_postgres_redis_activesupport.gemfile.lock
+++ b/gemfiles/ruby_2.5_rails5_postgres_redis_activesupport.gemfile.lock
@@ -12,7 +12,7 @@ PATH
   remote: ..
   specs:
     ddtrace (1.14.0)
-      datadog-ci (~> 0.1.0)
+      datadog-ci (~> 0.2.0)
       debase-ruby_core_source (= 3.2.2)
       libdatadog (~> 5.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
@@ -82,7 +82,7 @@ GEM
       rexml
     crass (1.0.6)
     cri (2.15.11)
-    datadog-ci (0.1.1)
+    datadog-ci (0.2.0)
     debase-ruby_core_source (3.2.2)
     debug_inspector (1.1.0)
     diff-lcs (1.5.0)

--- a/gemfiles/ruby_2.5_rails5_postgres_sidekiq.gemfile.lock
+++ b/gemfiles/ruby_2.5_rails5_postgres_sidekiq.gemfile.lock
@@ -12,7 +12,7 @@ PATH
   remote: ..
   specs:
     ddtrace (1.14.0)
-      datadog-ci (~> 0.1.0)
+      datadog-ci (~> 0.2.0)
       debase-ruby_core_source (= 3.2.2)
       libdatadog (~> 5.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
@@ -83,7 +83,7 @@ GEM
       rexml
     crass (1.0.6)
     cri (2.15.11)
-    datadog-ci (0.1.1)
+    datadog-ci (0.2.0)
     debase-ruby_core_source (3.2.2)
     debug_inspector (1.1.0)
     diff-lcs (1.5.0)

--- a/gemfiles/ruby_2.5_rails5_semantic_logger.gemfile.lock
+++ b/gemfiles/ruby_2.5_rails5_semantic_logger.gemfile.lock
@@ -12,7 +12,7 @@ PATH
   remote: ..
   specs:
     ddtrace (1.14.0)
-      datadog-ci (~> 0.1.0)
+      datadog-ci (~> 0.2.0)
       debase-ruby_core_source (= 3.2.2)
       libdatadog (~> 5.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
@@ -82,7 +82,7 @@ GEM
       rexml
     crass (1.0.6)
     cri (2.15.11)
-    datadog-ci (0.1.1)
+    datadog-ci (0.2.0)
     debase-ruby_core_source (3.2.2)
     debug_inspector (1.1.0)
     diff-lcs (1.5.0)

--- a/gemfiles/ruby_2.5_rails61_mysql2.gemfile.lock
+++ b/gemfiles/ruby_2.5_rails61_mysql2.gemfile.lock
@@ -12,7 +12,7 @@ PATH
   remote: ..
   specs:
     ddtrace (1.14.0)
-      datadog-ci (~> 0.1.0)
+      datadog-ci (~> 0.2.0)
       debase-ruby_core_source (= 3.2.2)
       libdatadog (~> 5.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
@@ -99,7 +99,7 @@ GEM
       rexml
     crass (1.0.6)
     cri (2.15.11)
-    datadog-ci (0.1.1)
+    datadog-ci (0.2.0)
     debase-ruby_core_source (3.2.2)
     debug_inspector (1.1.0)
     diff-lcs (1.5.0)

--- a/gemfiles/ruby_2.5_rails61_postgres.gemfile.lock
+++ b/gemfiles/ruby_2.5_rails61_postgres.gemfile.lock
@@ -12,7 +12,7 @@ PATH
   remote: ..
   specs:
     ddtrace (1.14.0)
-      datadog-ci (~> 0.1.0)
+      datadog-ci (~> 0.2.0)
       debase-ruby_core_source (= 3.2.2)
       libdatadog (~> 5.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
@@ -99,7 +99,7 @@ GEM
       rexml
     crass (1.0.6)
     cri (2.15.11)
-    datadog-ci (0.1.1)
+    datadog-ci (0.2.0)
     debase-ruby_core_source (3.2.2)
     debug_inspector (1.1.0)
     diff-lcs (1.5.0)

--- a/gemfiles/ruby_2.5_rails61_postgres_redis.gemfile.lock
+++ b/gemfiles/ruby_2.5_rails61_postgres_redis.gemfile.lock
@@ -12,7 +12,7 @@ PATH
   remote: ..
   specs:
     ddtrace (1.14.0)
-      datadog-ci (~> 0.1.0)
+      datadog-ci (~> 0.2.0)
       debase-ruby_core_source (= 3.2.2)
       libdatadog (~> 5.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
@@ -100,7 +100,7 @@ GEM
       rexml
     crass (1.0.6)
     cri (2.15.11)
-    datadog-ci (0.1.1)
+    datadog-ci (0.2.0)
     debase-ruby_core_source (3.2.2)
     debug_inspector (1.1.0)
     diff-lcs (1.5.0)

--- a/gemfiles/ruby_2.5_rails61_postgres_sidekiq.gemfile.lock
+++ b/gemfiles/ruby_2.5_rails61_postgres_sidekiq.gemfile.lock
@@ -12,7 +12,7 @@ PATH
   remote: ..
   specs:
     ddtrace (1.14.0)
-      datadog-ci (~> 0.1.0)
+      datadog-ci (~> 0.2.0)
       debase-ruby_core_source (= 3.2.2)
       libdatadog (~> 5.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
@@ -100,7 +100,7 @@ GEM
       rexml
     crass (1.0.6)
     cri (2.15.11)
-    datadog-ci (0.1.1)
+    datadog-ci (0.2.0)
     debase-ruby_core_source (3.2.2)
     debug_inspector (1.1.0)
     diff-lcs (1.5.0)

--- a/gemfiles/ruby_2.5_rails61_semantic_logger.gemfile.lock
+++ b/gemfiles/ruby_2.5_rails61_semantic_logger.gemfile.lock
@@ -12,7 +12,7 @@ PATH
   remote: ..
   specs:
     ddtrace (1.14.0)
-      datadog-ci (~> 0.1.0)
+      datadog-ci (~> 0.2.0)
       debase-ruby_core_source (= 3.2.2)
       libdatadog (~> 5.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
@@ -99,7 +99,7 @@ GEM
       rexml
     crass (1.0.6)
     cri (2.15.11)
-    datadog-ci (0.1.1)
+    datadog-ci (0.2.0)
     debase-ruby_core_source (3.2.2)
     debug_inspector (1.1.0)
     diff-lcs (1.5.0)

--- a/gemfiles/ruby_2.5_rails6_mysql2.gemfile.lock
+++ b/gemfiles/ruby_2.5_rails6_mysql2.gemfile.lock
@@ -12,7 +12,7 @@ PATH
   remote: ..
   specs:
     ddtrace (1.14.0)
-      datadog-ci (~> 0.1.0)
+      datadog-ci (~> 0.2.0)
       debase-ruby_core_source (= 3.2.2)
       libdatadog (~> 5.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
@@ -95,7 +95,7 @@ GEM
       rexml
     crass (1.0.6)
     cri (2.15.11)
-    datadog-ci (0.1.1)
+    datadog-ci (0.2.0)
     debase-ruby_core_source (3.2.2)
     debug_inspector (1.1.0)
     diff-lcs (1.5.0)

--- a/gemfiles/ruby_2.5_rails6_postgres.gemfile.lock
+++ b/gemfiles/ruby_2.5_rails6_postgres.gemfile.lock
@@ -12,7 +12,7 @@ PATH
   remote: ..
   specs:
     ddtrace (1.14.0)
-      datadog-ci (~> 0.1.0)
+      datadog-ci (~> 0.2.0)
       debase-ruby_core_source (= 3.2.2)
       libdatadog (~> 5.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
@@ -95,7 +95,7 @@ GEM
       rexml
     crass (1.0.6)
     cri (2.15.11)
-    datadog-ci (0.1.1)
+    datadog-ci (0.2.0)
     debase-ruby_core_source (3.2.2)
     debug_inspector (1.1.0)
     diff-lcs (1.5.0)

--- a/gemfiles/ruby_2.5_rails6_postgres_redis.gemfile.lock
+++ b/gemfiles/ruby_2.5_rails6_postgres_redis.gemfile.lock
@@ -12,7 +12,7 @@ PATH
   remote: ..
   specs:
     ddtrace (1.14.0)
-      datadog-ci (~> 0.1.0)
+      datadog-ci (~> 0.2.0)
       debase-ruby_core_source (= 3.2.2)
       libdatadog (~> 5.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
@@ -96,7 +96,7 @@ GEM
       rexml
     crass (1.0.6)
     cri (2.15.11)
-    datadog-ci (0.1.1)
+    datadog-ci (0.2.0)
     debase-ruby_core_source (3.2.2)
     debug_inspector (1.1.0)
     diff-lcs (1.5.0)

--- a/gemfiles/ruby_2.5_rails6_postgres_redis_activesupport.gemfile.lock
+++ b/gemfiles/ruby_2.5_rails6_postgres_redis_activesupport.gemfile.lock
@@ -12,7 +12,7 @@ PATH
   remote: ..
   specs:
     ddtrace (1.14.0)
-      datadog-ci (~> 0.1.0)
+      datadog-ci (~> 0.2.0)
       debase-ruby_core_source (= 3.2.2)
       libdatadog (~> 5.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
@@ -95,7 +95,7 @@ GEM
       rexml
     crass (1.0.6)
     cri (2.15.11)
-    datadog-ci (0.1.1)
+    datadog-ci (0.2.0)
     debase-ruby_core_source (3.2.2)
     debug_inspector (1.1.0)
     diff-lcs (1.5.0)

--- a/gemfiles/ruby_2.5_rails6_postgres_sidekiq.gemfile.lock
+++ b/gemfiles/ruby_2.5_rails6_postgres_sidekiq.gemfile.lock
@@ -12,7 +12,7 @@ PATH
   remote: ..
   specs:
     ddtrace (1.14.0)
-      datadog-ci (~> 0.1.0)
+      datadog-ci (~> 0.2.0)
       debase-ruby_core_source (= 3.2.2)
       libdatadog (~> 5.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
@@ -96,7 +96,7 @@ GEM
       rexml
     crass (1.0.6)
     cri (2.15.11)
-    datadog-ci (0.1.1)
+    datadog-ci (0.2.0)
     debase-ruby_core_source (3.2.2)
     debug_inspector (1.1.0)
     diff-lcs (1.5.0)

--- a/gemfiles/ruby_2.5_rails6_semantic_logger.gemfile.lock
+++ b/gemfiles/ruby_2.5_rails6_semantic_logger.gemfile.lock
@@ -12,7 +12,7 @@ PATH
   remote: ..
   specs:
     ddtrace (1.14.0)
-      datadog-ci (~> 0.1.0)
+      datadog-ci (~> 0.2.0)
       debase-ruby_core_source (= 3.2.2)
       libdatadog (~> 5.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
@@ -95,7 +95,7 @@ GEM
       rexml
     crass (1.0.6)
     cri (2.15.11)
-    datadog-ci (0.1.1)
+    datadog-ci (0.2.0)
     debase-ruby_core_source (3.2.2)
     debug_inspector (1.1.0)
     diff-lcs (1.5.0)

--- a/gemfiles/ruby_2.5_redis_3.gemfile.lock
+++ b/gemfiles/ruby_2.5_redis_3.gemfile.lock
@@ -12,7 +12,7 @@ PATH
   remote: ..
   specs:
     ddtrace (1.14.0)
-      datadog-ci (~> 0.1.0)
+      datadog-ci (~> 0.2.0)
       debase-ruby_core_source (= 3.2.2)
       libdatadog (~> 5.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
@@ -39,7 +39,7 @@ GEM
     crack (0.4.5)
       rexml
     cri (2.15.11)
-    datadog-ci (0.1.1)
+    datadog-ci (0.2.0)
     debase-ruby_core_source (3.2.2)
     debug_inspector (1.1.0)
     diff-lcs (1.5.0)

--- a/gemfiles/ruby_2.5_redis_4.gemfile.lock
+++ b/gemfiles/ruby_2.5_redis_4.gemfile.lock
@@ -12,7 +12,7 @@ PATH
   remote: ..
   specs:
     ddtrace (1.14.0)
-      datadog-ci (~> 0.1.0)
+      datadog-ci (~> 0.2.0)
       debase-ruby_core_source (= 3.2.2)
       libdatadog (~> 5.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
@@ -39,7 +39,7 @@ GEM
     crack (0.4.5)
       rexml
     cri (2.15.11)
-    datadog-ci (0.1.1)
+    datadog-ci (0.2.0)
     debase-ruby_core_source (3.2.2)
     debug_inspector (1.1.0)
     diff-lcs (1.5.0)

--- a/gemfiles/ruby_2.5_redis_5.gemfile.lock
+++ b/gemfiles/ruby_2.5_redis_5.gemfile.lock
@@ -12,7 +12,7 @@ PATH
   remote: ..
   specs:
     ddtrace (1.14.0)
-      datadog-ci (~> 0.1.0)
+      datadog-ci (~> 0.2.0)
       debase-ruby_core_source (= 3.2.2)
       libdatadog (~> 5.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
@@ -40,7 +40,7 @@ GEM
     crack (0.4.5)
       rexml
     cri (2.15.11)
-    datadog-ci (0.1.1)
+    datadog-ci (0.2.0)
     debase-ruby_core_source (3.2.2)
     debug_inspector (1.1.0)
     diff-lcs (1.5.0)

--- a/gemfiles/ruby_2.5_relational_db.gemfile.lock
+++ b/gemfiles/ruby_2.5_relational_db.gemfile.lock
@@ -12,7 +12,7 @@ PATH
   remote: ..
   specs:
     ddtrace (1.14.0)
-      datadog-ci (~> 0.1.0)
+      datadog-ci (~> 0.2.0)
       debase-ruby_core_source (= 3.2.2)
       libdatadog (~> 5.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
@@ -51,7 +51,7 @@ GEM
     crack (0.4.5)
       rexml
     cri (2.15.11)
-    datadog-ci (0.1.1)
+    datadog-ci (0.2.0)
     debase-ruby_core_source (3.2.2)
     debug_inspector (1.1.0)
     delayed_job (4.1.11)

--- a/gemfiles/ruby_2.5_resque2_redis3.gemfile.lock
+++ b/gemfiles/ruby_2.5_resque2_redis3.gemfile.lock
@@ -12,7 +12,7 @@ PATH
   remote: ..
   specs:
     ddtrace (1.14.0)
-      datadog-ci (~> 0.1.0)
+      datadog-ci (~> 0.2.0)
       debase-ruby_core_source (= 3.2.2)
       libdatadog (~> 5.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
@@ -39,7 +39,7 @@ GEM
     crack (0.4.5)
       rexml
     cri (2.15.11)
-    datadog-ci (0.1.1)
+    datadog-ci (0.2.0)
     debase-ruby_core_source (3.2.2)
     debug_inspector (1.1.0)
     diff-lcs (1.5.0)

--- a/gemfiles/ruby_2.5_resque2_redis4.gemfile.lock
+++ b/gemfiles/ruby_2.5_resque2_redis4.gemfile.lock
@@ -12,7 +12,7 @@ PATH
   remote: ..
   specs:
     ddtrace (1.14.0)
-      datadog-ci (~> 0.1.0)
+      datadog-ci (~> 0.2.0)
       debase-ruby_core_source (= 3.2.2)
       libdatadog (~> 5.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
@@ -40,7 +40,7 @@ GEM
     crack (0.4.5)
       rexml
     cri (2.15.11)
-    datadog-ci (0.1.1)
+    datadog-ci (0.2.0)
     debase-ruby_core_source (3.2.2)
     debug_inspector (1.1.0)
     diff-lcs (1.5.0)

--- a/gemfiles/ruby_2.5_sinatra.gemfile.lock
+++ b/gemfiles/ruby_2.5_sinatra.gemfile.lock
@@ -12,7 +12,7 @@ PATH
   remote: ..
   specs:
     ddtrace (1.14.0)
-      datadog-ci (~> 0.1.0)
+      datadog-ci (~> 0.2.0)
       debase-ruby_core_source (= 3.2.2)
       libdatadog (~> 5.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
@@ -39,7 +39,7 @@ GEM
     crack (0.4.5)
       rexml
     cri (2.15.11)
-    datadog-ci (0.1.1)
+    datadog-ci (0.2.0)
     debase-ruby_core_source (3.2.2)
     debug_inspector (1.1.0)
     diff-lcs (1.5.0)

--- a/gemfiles/ruby_2.6_activesupport.gemfile.lock
+++ b/gemfiles/ruby_2.6_activesupport.gemfile.lock
@@ -12,7 +12,7 @@ PATH
   remote: ..
   specs:
     ddtrace (1.14.0)
-      datadog-ci (~> 0.1.0)
+      datadog-ci (~> 0.2.0)
       debase-ruby_core_source (= 3.2.2)
       libdatadog (~> 5.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
@@ -70,7 +70,7 @@ GEM
       rexml
     crass (1.0.6)
     cri (2.15.11)
-    datadog-ci (0.1.1)
+    datadog-ci (0.2.0)
     debase-ruby_core_source (3.2.2)
     debug_inspector (1.1.0)
     diff-lcs (1.5.0)

--- a/gemfiles/ruby_2.6_aws.gemfile.lock
+++ b/gemfiles/ruby_2.6_aws.gemfile.lock
@@ -12,7 +12,7 @@ PATH
   remote: ..
   specs:
     ddtrace (1.14.0)
-      datadog-ci (~> 0.1.0)
+      datadog-ci (~> 0.2.0)
       debase-ruby_core_source (= 3.2.2)
       libdatadog (~> 5.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
@@ -1462,7 +1462,7 @@ GEM
     crack (0.4.5)
       rexml
     cri (2.15.11)
-    datadog-ci (0.1.1)
+    datadog-ci (0.2.0)
     debase-ruby_core_source (3.2.2)
     debug_inspector (1.1.0)
     diff-lcs (1.5.0)

--- a/gemfiles/ruby_2.6_contrib.gemfile.lock
+++ b/gemfiles/ruby_2.6_contrib.gemfile.lock
@@ -12,7 +12,7 @@ PATH
   remote: ..
   specs:
     ddtrace (1.14.0)
-      datadog-ci (~> 0.1.0)
+      datadog-ci (~> 0.2.0)
       debase-ruby_core_source (= 3.2.2)
       libdatadog (~> 5.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
@@ -48,7 +48,7 @@ GEM
       rexml
     cri (2.15.11)
     dalli (3.2.4)
-    datadog-ci (0.1.1)
+    datadog-ci (0.2.0)
     debase-ruby_core_source (3.2.2)
     debug_inspector (1.1.0)
     diff-lcs (1.5.0)

--- a/gemfiles/ruby_2.6_contrib_old.gemfile.lock
+++ b/gemfiles/ruby_2.6_contrib_old.gemfile.lock
@@ -12,7 +12,7 @@ PATH
   remote: ..
   specs:
     ddtrace (1.14.0)
-      datadog-ci (~> 0.1.0)
+      datadog-ci (~> 0.2.0)
       debase-ruby_core_source (= 3.2.2)
       libdatadog (~> 5.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
@@ -46,7 +46,7 @@ GEM
     cri (2.15.11)
     daemons (1.4.1)
     dalli (2.7.11)
-    datadog-ci (0.1.1)
+    datadog-ci (0.2.0)
     debase-ruby_core_source (3.2.2)
     debug_inspector (1.1.0)
     diff-lcs (1.5.0)

--- a/gemfiles/ruby_2.6_core_old.gemfile.lock
+++ b/gemfiles/ruby_2.6_core_old.gemfile.lock
@@ -12,7 +12,7 @@ PATH
   remote: ..
   specs:
     ddtrace (1.14.0)
-      datadog-ci (~> 0.1.0)
+      datadog-ci (~> 0.2.0)
       debase-ruby_core_source (= 3.2.2)
       libdatadog (~> 5.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
@@ -41,7 +41,7 @@ GEM
     crack (0.4.5)
       rexml
     cri (2.15.11)
-    datadog-ci (0.1.1)
+    datadog-ci (0.2.0)
     debase-ruby_core_source (3.2.2)
     debug_inspector (1.1.0)
     diff-lcs (1.5.0)

--- a/gemfiles/ruby_2.6_hanami_1.gemfile.lock
+++ b/gemfiles/ruby_2.6_hanami_1.gemfile.lock
@@ -12,7 +12,7 @@ PATH
   remote: ..
   specs:
     ddtrace (1.14.0)
-      datadog-ci (~> 0.1.0)
+      datadog-ci (~> 0.2.0)
       debase-ruby_core_source (= 3.2.2)
       libdatadog (~> 5.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
@@ -41,7 +41,7 @@ GEM
     crack (0.4.5)
       rexml
     cri (2.15.11)
-    datadog-ci (0.1.1)
+    datadog-ci (0.2.0)
     date (3.3.3)
     debase-ruby_core_source (3.2.2)
     debug_inspector (1.1.0)

--- a/gemfiles/ruby_2.6_http.gemfile.lock
+++ b/gemfiles/ruby_2.6_http.gemfile.lock
@@ -12,7 +12,7 @@ PATH
   remote: ..
   specs:
     ddtrace (1.14.0)
-      datadog-ci (~> 0.1.0)
+      datadog-ci (~> 0.2.0)
       debase-ruby_core_source (= 3.2.2)
       libdatadog (~> 5.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
@@ -41,7 +41,7 @@ GEM
     crack (0.4.5)
       rexml
     cri (2.15.11)
-    datadog-ci (0.1.1)
+    datadog-ci (0.2.0)
     debase-ruby_core_source (3.2.2)
     debug_inspector (1.1.0)
     diff-lcs (1.5.0)

--- a/gemfiles/ruby_2.6_opentelemetry.gemfile.lock
+++ b/gemfiles/ruby_2.6_opentelemetry.gemfile.lock
@@ -12,7 +12,7 @@ PATH
   remote: ..
   specs:
     ddtrace (1.14.0)
-      datadog-ci (~> 0.1.0)
+      datadog-ci (~> 0.2.0)
       debase-ruby_core_source (= 3.2.2)
       libdatadog (~> 5.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
@@ -41,7 +41,7 @@ GEM
     crack (0.4.5)
       rexml
     cri (2.15.11)
-    datadog-ci (0.1.1)
+    datadog-ci (0.2.0)
     debase-ruby_core_source (3.2.2)
     debug_inspector (1.1.0)
     diff-lcs (1.5.0)

--- a/gemfiles/ruby_2.6_opentracing.gemfile.lock
+++ b/gemfiles/ruby_2.6_opentracing.gemfile.lock
@@ -12,7 +12,7 @@ PATH
   remote: ..
   specs:
     ddtrace (1.14.0)
-      datadog-ci (~> 0.1.0)
+      datadog-ci (~> 0.2.0)
       debase-ruby_core_source (= 3.2.2)
       libdatadog (~> 5.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
@@ -42,7 +42,7 @@ GEM
     crack (0.4.5)
       rexml
     cri (2.15.11)
-    datadog-ci (0.1.1)
+    datadog-ci (0.2.0)
     debase-ruby_core_source (3.2.2)
     debug_inspector (1.1.0)
     diff-lcs (1.5.0)

--- a/gemfiles/ruby_2.6_rack_1.gemfile.lock
+++ b/gemfiles/ruby_2.6_rack_1.gemfile.lock
@@ -12,7 +12,7 @@ PATH
   remote: ..
   specs:
     ddtrace (1.14.0)
-      datadog-ci (~> 0.1.0)
+      datadog-ci (~> 0.2.0)
       debase-ruby_core_source (= 3.2.2)
       libdatadog (~> 5.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
@@ -41,7 +41,7 @@ GEM
     crack (0.4.5)
       rexml
     cri (2.15.11)
-    datadog-ci (0.1.1)
+    datadog-ci (0.2.0)
     debase-ruby_core_source (3.2.2)
     debug_inspector (1.1.0)
     diff-lcs (1.5.0)

--- a/gemfiles/ruby_2.6_rack_2.gemfile.lock
+++ b/gemfiles/ruby_2.6_rack_2.gemfile.lock
@@ -12,7 +12,7 @@ PATH
   remote: ..
   specs:
     ddtrace (1.14.0)
-      datadog-ci (~> 0.1.0)
+      datadog-ci (~> 0.2.0)
       debase-ruby_core_source (= 3.2.2)
       libdatadog (~> 5.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
@@ -41,7 +41,7 @@ GEM
     crack (0.4.5)
       rexml
     cri (2.15.11)
-    datadog-ci (0.1.1)
+    datadog-ci (0.2.0)
     debase-ruby_core_source (3.2.2)
     debug_inspector (1.1.0)
     diff-lcs (1.5.0)

--- a/gemfiles/ruby_2.6_rack_3.gemfile.lock
+++ b/gemfiles/ruby_2.6_rack_3.gemfile.lock
@@ -12,7 +12,7 @@ PATH
   remote: ..
   specs:
     ddtrace (1.14.0)
-      datadog-ci (~> 0.1.0)
+      datadog-ci (~> 0.2.0)
       debase-ruby_core_source (= 3.2.2)
       libdatadog (~> 5.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
@@ -41,7 +41,7 @@ GEM
     crack (0.4.5)
       rexml
     cri (2.15.11)
-    datadog-ci (0.1.1)
+    datadog-ci (0.2.0)
     debase-ruby_core_source (3.2.2)
     debug_inspector (1.1.0)
     diff-lcs (1.5.0)

--- a/gemfiles/ruby_2.6_rails5_mysql2.gemfile.lock
+++ b/gemfiles/ruby_2.6_rails5_mysql2.gemfile.lock
@@ -12,7 +12,7 @@ PATH
   remote: ..
   specs:
     ddtrace (1.14.0)
-      datadog-ci (~> 0.1.0)
+      datadog-ci (~> 0.2.0)
       debase-ruby_core_source (= 3.2.2)
       libdatadog (~> 5.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
@@ -84,7 +84,7 @@ GEM
       rexml
     crass (1.0.6)
     cri (2.15.11)
-    datadog-ci (0.1.1)
+    datadog-ci (0.2.0)
     date (3.3.3)
     debase-ruby_core_source (3.2.2)
     debug_inspector (1.1.0)

--- a/gemfiles/ruby_2.6_rails5_postgres.gemfile.lock
+++ b/gemfiles/ruby_2.6_rails5_postgres.gemfile.lock
@@ -12,7 +12,7 @@ PATH
   remote: ..
   specs:
     ddtrace (1.14.0)
-      datadog-ci (~> 0.1.0)
+      datadog-ci (~> 0.2.0)
       debase-ruby_core_source (= 3.2.2)
       libdatadog (~> 5.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
@@ -84,7 +84,7 @@ GEM
       rexml
     crass (1.0.6)
     cri (2.15.11)
-    datadog-ci (0.1.1)
+    datadog-ci (0.2.0)
     date (3.3.3)
     debase-ruby_core_source (3.2.2)
     debug_inspector (1.1.0)

--- a/gemfiles/ruby_2.6_rails5_postgres_redis.gemfile.lock
+++ b/gemfiles/ruby_2.6_rails5_postgres_redis.gemfile.lock
@@ -12,7 +12,7 @@ PATH
   remote: ..
   specs:
     ddtrace (1.14.0)
-      datadog-ci (~> 0.1.0)
+      datadog-ci (~> 0.2.0)
       debase-ruby_core_source (= 3.2.2)
       libdatadog (~> 5.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
@@ -84,7 +84,7 @@ GEM
       rexml
     crass (1.0.6)
     cri (2.15.11)
-    datadog-ci (0.1.1)
+    datadog-ci (0.2.0)
     date (3.3.3)
     debase-ruby_core_source (3.2.2)
     debug_inspector (1.1.0)

--- a/gemfiles/ruby_2.6_rails5_postgres_redis_activesupport.gemfile.lock
+++ b/gemfiles/ruby_2.6_rails5_postgres_redis_activesupport.gemfile.lock
@@ -12,7 +12,7 @@ PATH
   remote: ..
   specs:
     ddtrace (1.14.0)
-      datadog-ci (~> 0.1.0)
+      datadog-ci (~> 0.2.0)
       debase-ruby_core_source (= 3.2.2)
       libdatadog (~> 5.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
@@ -84,7 +84,7 @@ GEM
       rexml
     crass (1.0.6)
     cri (2.15.11)
-    datadog-ci (0.1.1)
+    datadog-ci (0.2.0)
     date (3.3.3)
     debase-ruby_core_source (3.2.2)
     debug_inspector (1.1.0)

--- a/gemfiles/ruby_2.6_rails5_postgres_sidekiq.gemfile.lock
+++ b/gemfiles/ruby_2.6_rails5_postgres_sidekiq.gemfile.lock
@@ -12,7 +12,7 @@ PATH
   remote: ..
   specs:
     ddtrace (1.14.0)
-      datadog-ci (~> 0.1.0)
+      datadog-ci (~> 0.2.0)
       debase-ruby_core_source (= 3.2.2)
       libdatadog (~> 5.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
@@ -85,7 +85,7 @@ GEM
       rexml
     crass (1.0.6)
     cri (2.15.11)
-    datadog-ci (0.1.1)
+    datadog-ci (0.2.0)
     date (3.3.3)
     debase-ruby_core_source (3.2.2)
     debug_inspector (1.1.0)

--- a/gemfiles/ruby_2.6_rails5_semantic_logger.gemfile.lock
+++ b/gemfiles/ruby_2.6_rails5_semantic_logger.gemfile.lock
@@ -12,7 +12,7 @@ PATH
   remote: ..
   specs:
     ddtrace (1.14.0)
-      datadog-ci (~> 0.1.0)
+      datadog-ci (~> 0.2.0)
       debase-ruby_core_source (= 3.2.2)
       libdatadog (~> 5.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
@@ -84,7 +84,7 @@ GEM
       rexml
     crass (1.0.6)
     cri (2.15.11)
-    datadog-ci (0.1.1)
+    datadog-ci (0.2.0)
     date (3.3.3)
     debase-ruby_core_source (3.2.2)
     debug_inspector (1.1.0)

--- a/gemfiles/ruby_2.6_rails61_mysql2.gemfile.lock
+++ b/gemfiles/ruby_2.6_rails61_mysql2.gemfile.lock
@@ -12,7 +12,7 @@ PATH
   remote: ..
   specs:
     ddtrace (1.14.0)
-      datadog-ci (~> 0.1.0)
+      datadog-ci (~> 0.2.0)
       debase-ruby_core_source (= 3.2.2)
       libdatadog (~> 5.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
@@ -101,7 +101,7 @@ GEM
       rexml
     crass (1.0.6)
     cri (2.15.11)
-    datadog-ci (0.1.1)
+    datadog-ci (0.2.0)
     date (3.3.3)
     debase-ruby_core_source (3.2.2)
     debug_inspector (1.1.0)

--- a/gemfiles/ruby_2.6_rails61_postgres.gemfile.lock
+++ b/gemfiles/ruby_2.6_rails61_postgres.gemfile.lock
@@ -12,7 +12,7 @@ PATH
   remote: ..
   specs:
     ddtrace (1.14.0)
-      datadog-ci (~> 0.1.0)
+      datadog-ci (~> 0.2.0)
       debase-ruby_core_source (= 3.2.2)
       libdatadog (~> 5.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
@@ -101,7 +101,7 @@ GEM
       rexml
     crass (1.0.6)
     cri (2.15.11)
-    datadog-ci (0.1.1)
+    datadog-ci (0.2.0)
     date (3.3.3)
     debase-ruby_core_source (3.2.2)
     debug_inspector (1.1.0)

--- a/gemfiles/ruby_2.6_rails61_postgres_redis.gemfile.lock
+++ b/gemfiles/ruby_2.6_rails61_postgres_redis.gemfile.lock
@@ -12,7 +12,7 @@ PATH
   remote: ..
   specs:
     ddtrace (1.14.0)
-      datadog-ci (~> 0.1.0)
+      datadog-ci (~> 0.2.0)
       debase-ruby_core_source (= 3.2.2)
       libdatadog (~> 5.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
@@ -101,7 +101,7 @@ GEM
       rexml
     crass (1.0.6)
     cri (2.15.11)
-    datadog-ci (0.1.1)
+    datadog-ci (0.2.0)
     date (3.3.3)
     debase-ruby_core_source (3.2.2)
     debug_inspector (1.1.0)

--- a/gemfiles/ruby_2.6_rails61_postgres_sidekiq.gemfile.lock
+++ b/gemfiles/ruby_2.6_rails61_postgres_sidekiq.gemfile.lock
@@ -12,7 +12,7 @@ PATH
   remote: ..
   specs:
     ddtrace (1.14.0)
-      datadog-ci (~> 0.1.0)
+      datadog-ci (~> 0.2.0)
       debase-ruby_core_source (= 3.2.2)
       libdatadog (~> 5.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
@@ -102,7 +102,7 @@ GEM
       rexml
     crass (1.0.6)
     cri (2.15.11)
-    datadog-ci (0.1.1)
+    datadog-ci (0.2.0)
     date (3.3.3)
     debase-ruby_core_source (3.2.2)
     debug_inspector (1.1.0)

--- a/gemfiles/ruby_2.6_rails61_semantic_logger.gemfile.lock
+++ b/gemfiles/ruby_2.6_rails61_semantic_logger.gemfile.lock
@@ -12,7 +12,7 @@ PATH
   remote: ..
   specs:
     ddtrace (1.14.0)
-      datadog-ci (~> 0.1.0)
+      datadog-ci (~> 0.2.0)
       debase-ruby_core_source (= 3.2.2)
       libdatadog (~> 5.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
@@ -101,7 +101,7 @@ GEM
       rexml
     crass (1.0.6)
     cri (2.15.11)
-    datadog-ci (0.1.1)
+    datadog-ci (0.2.0)
     date (3.3.3)
     debase-ruby_core_source (3.2.2)
     debug_inspector (1.1.0)

--- a/gemfiles/ruby_2.6_rails6_mysql2.gemfile.lock
+++ b/gemfiles/ruby_2.6_rails6_mysql2.gemfile.lock
@@ -12,7 +12,7 @@ PATH
   remote: ..
   specs:
     ddtrace (1.14.0)
-      datadog-ci (~> 0.1.0)
+      datadog-ci (~> 0.2.0)
       debase-ruby_core_source (= 3.2.2)
       libdatadog (~> 5.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
@@ -97,7 +97,7 @@ GEM
       rexml
     crass (1.0.6)
     cri (2.15.11)
-    datadog-ci (0.1.1)
+    datadog-ci (0.2.0)
     date (3.3.3)
     debase-ruby_core_source (3.2.2)
     debug_inspector (1.1.0)

--- a/gemfiles/ruby_2.6_rails6_postgres.gemfile.lock
+++ b/gemfiles/ruby_2.6_rails6_postgres.gemfile.lock
@@ -12,7 +12,7 @@ PATH
   remote: ..
   specs:
     ddtrace (1.14.0)
-      datadog-ci (~> 0.1.0)
+      datadog-ci (~> 0.2.0)
       debase-ruby_core_source (= 3.2.2)
       libdatadog (~> 5.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
@@ -97,7 +97,7 @@ GEM
       rexml
     crass (1.0.6)
     cri (2.15.11)
-    datadog-ci (0.1.1)
+    datadog-ci (0.2.0)
     date (3.3.3)
     debase-ruby_core_source (3.2.2)
     debug_inspector (1.1.0)

--- a/gemfiles/ruby_2.6_rails6_postgres_redis.gemfile.lock
+++ b/gemfiles/ruby_2.6_rails6_postgres_redis.gemfile.lock
@@ -12,7 +12,7 @@ PATH
   remote: ..
   specs:
     ddtrace (1.14.0)
-      datadog-ci (~> 0.1.0)
+      datadog-ci (~> 0.2.0)
       debase-ruby_core_source (= 3.2.2)
       libdatadog (~> 5.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
@@ -97,7 +97,7 @@ GEM
       rexml
     crass (1.0.6)
     cri (2.15.11)
-    datadog-ci (0.1.1)
+    datadog-ci (0.2.0)
     date (3.3.3)
     debase-ruby_core_source (3.2.2)
     debug_inspector (1.1.0)

--- a/gemfiles/ruby_2.6_rails6_postgres_redis_activesupport.gemfile.lock
+++ b/gemfiles/ruby_2.6_rails6_postgres_redis_activesupport.gemfile.lock
@@ -12,7 +12,7 @@ PATH
   remote: ..
   specs:
     ddtrace (1.14.0)
-      datadog-ci (~> 0.1.0)
+      datadog-ci (~> 0.2.0)
       debase-ruby_core_source (= 3.2.2)
       libdatadog (~> 5.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
@@ -97,7 +97,7 @@ GEM
       rexml
     crass (1.0.6)
     cri (2.15.11)
-    datadog-ci (0.1.1)
+    datadog-ci (0.2.0)
     date (3.3.3)
     debase-ruby_core_source (3.2.2)
     debug_inspector (1.1.0)

--- a/gemfiles/ruby_2.6_rails6_postgres_sidekiq.gemfile.lock
+++ b/gemfiles/ruby_2.6_rails6_postgres_sidekiq.gemfile.lock
@@ -12,7 +12,7 @@ PATH
   remote: ..
   specs:
     ddtrace (1.14.0)
-      datadog-ci (~> 0.1.0)
+      datadog-ci (~> 0.2.0)
       debase-ruby_core_source (= 3.2.2)
       libdatadog (~> 5.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
@@ -98,7 +98,7 @@ GEM
       rexml
     crass (1.0.6)
     cri (2.15.11)
-    datadog-ci (0.1.1)
+    datadog-ci (0.2.0)
     date (3.3.3)
     debase-ruby_core_source (3.2.2)
     debug_inspector (1.1.0)

--- a/gemfiles/ruby_2.6_rails6_semantic_logger.gemfile.lock
+++ b/gemfiles/ruby_2.6_rails6_semantic_logger.gemfile.lock
@@ -12,7 +12,7 @@ PATH
   remote: ..
   specs:
     ddtrace (1.14.0)
-      datadog-ci (~> 0.1.0)
+      datadog-ci (~> 0.2.0)
       debase-ruby_core_source (= 3.2.2)
       libdatadog (~> 5.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
@@ -97,7 +97,7 @@ GEM
       rexml
     crass (1.0.6)
     cri (2.15.11)
-    datadog-ci (0.1.1)
+    datadog-ci (0.2.0)
     date (3.3.3)
     debase-ruby_core_source (3.2.2)
     debug_inspector (1.1.0)

--- a/gemfiles/ruby_2.6_redis_3.gemfile.lock
+++ b/gemfiles/ruby_2.6_redis_3.gemfile.lock
@@ -12,7 +12,7 @@ PATH
   remote: ..
   specs:
     ddtrace (1.14.0)
-      datadog-ci (~> 0.1.0)
+      datadog-ci (~> 0.2.0)
       debase-ruby_core_source (= 3.2.2)
       libdatadog (~> 5.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
@@ -41,7 +41,7 @@ GEM
     crack (0.4.5)
       rexml
     cri (2.15.11)
-    datadog-ci (0.1.1)
+    datadog-ci (0.2.0)
     debase-ruby_core_source (3.2.2)
     debug_inspector (1.1.0)
     diff-lcs (1.5.0)

--- a/gemfiles/ruby_2.6_redis_4.gemfile.lock
+++ b/gemfiles/ruby_2.6_redis_4.gemfile.lock
@@ -12,7 +12,7 @@ PATH
   remote: ..
   specs:
     ddtrace (1.14.0)
-      datadog-ci (~> 0.1.0)
+      datadog-ci (~> 0.2.0)
       debase-ruby_core_source (= 3.2.2)
       libdatadog (~> 5.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
@@ -41,7 +41,7 @@ GEM
     crack (0.4.5)
       rexml
     cri (2.15.11)
-    datadog-ci (0.1.1)
+    datadog-ci (0.2.0)
     debase-ruby_core_source (3.2.2)
     debug_inspector (1.1.0)
     diff-lcs (1.5.0)

--- a/gemfiles/ruby_2.6_redis_5.gemfile.lock
+++ b/gemfiles/ruby_2.6_redis_5.gemfile.lock
@@ -12,7 +12,7 @@ PATH
   remote: ..
   specs:
     ddtrace (1.14.0)
-      datadog-ci (~> 0.1.0)
+      datadog-ci (~> 0.2.0)
       debase-ruby_core_source (= 3.2.2)
       libdatadog (~> 5.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
@@ -42,7 +42,7 @@ GEM
     crack (0.4.5)
       rexml
     cri (2.15.11)
-    datadog-ci (0.1.1)
+    datadog-ci (0.2.0)
     debase-ruby_core_source (3.2.2)
     debug_inspector (1.1.0)
     diff-lcs (1.5.0)

--- a/gemfiles/ruby_2.6_relational_db.gemfile.lock
+++ b/gemfiles/ruby_2.6_relational_db.gemfile.lock
@@ -12,7 +12,7 @@ PATH
   remote: ..
   specs:
     ddtrace (1.14.0)
-      datadog-ci (~> 0.1.0)
+      datadog-ci (~> 0.2.0)
       debase-ruby_core_source (= 3.2.2)
       libdatadog (~> 5.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
@@ -52,7 +52,7 @@ GEM
     crack (0.4.5)
       rexml
     cri (2.15.11)
-    datadog-ci (0.1.1)
+    datadog-ci (0.2.0)
     debase-ruby_core_source (3.2.2)
     debug_inspector (1.1.0)
     delayed_job (4.1.11)

--- a/gemfiles/ruby_2.6_resque2_redis3.gemfile.lock
+++ b/gemfiles/ruby_2.6_resque2_redis3.gemfile.lock
@@ -12,7 +12,7 @@ PATH
   remote: ..
   specs:
     ddtrace (1.14.0)
-      datadog-ci (~> 0.1.0)
+      datadog-ci (~> 0.2.0)
       debase-ruby_core_source (= 3.2.2)
       libdatadog (~> 5.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
@@ -41,7 +41,7 @@ GEM
     crack (0.4.5)
       rexml
     cri (2.15.11)
-    datadog-ci (0.1.1)
+    datadog-ci (0.2.0)
     debase-ruby_core_source (3.2.2)
     debug_inspector (1.1.0)
     diff-lcs (1.5.0)

--- a/gemfiles/ruby_2.6_resque2_redis4.gemfile.lock
+++ b/gemfiles/ruby_2.6_resque2_redis4.gemfile.lock
@@ -12,7 +12,7 @@ PATH
   remote: ..
   specs:
     ddtrace (1.14.0)
-      datadog-ci (~> 0.1.0)
+      datadog-ci (~> 0.2.0)
       debase-ruby_core_source (= 3.2.2)
       libdatadog (~> 5.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
@@ -41,7 +41,7 @@ GEM
     crack (0.4.5)
       rexml
     cri (2.15.11)
-    datadog-ci (0.1.1)
+    datadog-ci (0.2.0)
     debase-ruby_core_source (3.2.2)
     debug_inspector (1.1.0)
     diff-lcs (1.5.0)

--- a/gemfiles/ruby_2.6_sinatra.gemfile.lock
+++ b/gemfiles/ruby_2.6_sinatra.gemfile.lock
@@ -12,7 +12,7 @@ PATH
   remote: ..
   specs:
     ddtrace (1.14.0)
-      datadog-ci (~> 0.1.0)
+      datadog-ci (~> 0.2.0)
       debase-ruby_core_source (= 3.2.2)
       libdatadog (~> 5.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
@@ -41,7 +41,7 @@ GEM
     crack (0.4.5)
       rexml
     cri (2.15.11)
-    datadog-ci (0.1.1)
+    datadog-ci (0.2.0)
     debase-ruby_core_source (3.2.2)
     debug_inspector (1.1.0)
     diff-lcs (1.5.0)

--- a/gemfiles/ruby_2.7.6_sinatra.gemfile.lock
+++ b/gemfiles/ruby_2.7.6_sinatra.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   remote: ..
   specs:
     ddtrace (1.14.0)
-      datadog-ci (~> 0.1.0)
+      datadog-ci (~> 0.2.0)
       debase-ruby_core_source (= 3.2.2)
       libdatadog (~> 5.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
@@ -42,7 +42,7 @@ GEM
     crack (0.4.5)
       rexml
     cri (2.15.11)
-    datadog-ci (0.1.1)
+    datadog-ci (0.2.0)
     debase-ruby_core_source (3.2.2)
     debug_inspector (1.1.0)
     diff-lcs (1.5.0)

--- a/gemfiles/ruby_2.7_activesupport.gemfile.lock
+++ b/gemfiles/ruby_2.7_activesupport.gemfile.lock
@@ -12,7 +12,7 @@ PATH
   remote: ..
   specs:
     ddtrace (1.14.0)
-      datadog-ci (~> 0.1.0)
+      datadog-ci (~> 0.2.0)
       debase-ruby_core_source (= 3.2.2)
       libdatadog (~> 5.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
@@ -70,7 +70,7 @@ GEM
       rexml
     crass (1.0.6)
     cri (2.15.11)
-    datadog-ci (0.1.1)
+    datadog-ci (0.2.0)
     debase-ruby_core_source (3.2.2)
     debug_inspector (1.1.0)
     diff-lcs (1.5.0)

--- a/gemfiles/ruby_2.7_aws.gemfile.lock
+++ b/gemfiles/ruby_2.7_aws.gemfile.lock
@@ -12,7 +12,7 @@ PATH
   remote: ..
   specs:
     ddtrace (1.14.0)
-      datadog-ci (~> 0.1.0)
+      datadog-ci (~> 0.2.0)
       debase-ruby_core_source (= 3.2.2)
       libdatadog (~> 5.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
@@ -1462,7 +1462,7 @@ GEM
     crack (0.4.5)
       rexml
     cri (2.15.11)
-    datadog-ci (0.1.1)
+    datadog-ci (0.2.0)
     debase-ruby_core_source (3.2.2)
     debug_inspector (1.1.0)
     diff-lcs (1.5.0)

--- a/gemfiles/ruby_2.7_contrib.gemfile.lock
+++ b/gemfiles/ruby_2.7_contrib.gemfile.lock
@@ -12,7 +12,7 @@ PATH
   remote: ..
   specs:
     ddtrace (1.14.0)
-      datadog-ci (~> 0.1.0)
+      datadog-ci (~> 0.2.0)
       debase-ruby_core_source (= 3.2.2)
       libdatadog (~> 5.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
@@ -48,7 +48,7 @@ GEM
       rexml
     cri (2.15.11)
     dalli (3.2.4)
-    datadog-ci (0.1.1)
+    datadog-ci (0.2.0)
     debase-ruby_core_source (3.2.2)
     debug_inspector (1.1.0)
     diff-lcs (1.5.0)

--- a/gemfiles/ruby_2.7_contrib_old.gemfile.lock
+++ b/gemfiles/ruby_2.7_contrib_old.gemfile.lock
@@ -12,7 +12,7 @@ PATH
   remote: ..
   specs:
     ddtrace (1.14.0)
-      datadog-ci (~> 0.1.0)
+      datadog-ci (~> 0.2.0)
       debase-ruby_core_source (= 3.2.2)
       libdatadog (~> 5.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
@@ -46,7 +46,7 @@ GEM
     cri (2.15.11)
     daemons (1.4.1)
     dalli (2.7.11)
-    datadog-ci (0.1.1)
+    datadog-ci (0.2.0)
     debase-ruby_core_source (3.2.2)
     debug_inspector (1.1.0)
     diff-lcs (1.5.0)

--- a/gemfiles/ruby_2.7_core_old.gemfile.lock
+++ b/gemfiles/ruby_2.7_core_old.gemfile.lock
@@ -12,7 +12,7 @@ PATH
   remote: ..
   specs:
     ddtrace (1.14.0)
-      datadog-ci (~> 0.1.0)
+      datadog-ci (~> 0.2.0)
       debase-ruby_core_source (= 3.2.2)
       libdatadog (~> 5.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
@@ -41,7 +41,7 @@ GEM
     crack (0.4.5)
       rexml
     cri (2.15.11)
-    datadog-ci (0.1.1)
+    datadog-ci (0.2.0)
     debase-ruby_core_source (3.2.2)
     debug_inspector (1.1.0)
     diff-lcs (1.5.0)

--- a/gemfiles/ruby_2.7_hanami_1.gemfile.lock
+++ b/gemfiles/ruby_2.7_hanami_1.gemfile.lock
@@ -12,7 +12,7 @@ PATH
   remote: ..
   specs:
     ddtrace (1.14.0)
-      datadog-ci (~> 0.1.0)
+      datadog-ci (~> 0.2.0)
       debase-ruby_core_source (= 3.2.2)
       libdatadog (~> 5.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
@@ -41,7 +41,7 @@ GEM
     crack (0.4.5)
       rexml
     cri (2.15.11)
-    datadog-ci (0.1.1)
+    datadog-ci (0.2.0)
     date (3.3.3)
     debase-ruby_core_source (3.2.2)
     debug_inspector (1.1.0)

--- a/gemfiles/ruby_2.7_http.gemfile.lock
+++ b/gemfiles/ruby_2.7_http.gemfile.lock
@@ -12,7 +12,7 @@ PATH
   remote: ..
   specs:
     ddtrace (1.14.0)
-      datadog-ci (~> 0.1.0)
+      datadog-ci (~> 0.2.0)
       debase-ruby_core_source (= 3.2.2)
       libdatadog (~> 5.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
@@ -41,7 +41,7 @@ GEM
     crack (0.4.5)
       rexml
     cri (2.15.11)
-    datadog-ci (0.1.1)
+    datadog-ci (0.2.0)
     debase-ruby_core_source (3.2.2)
     debug_inspector (1.1.0)
     diff-lcs (1.5.0)

--- a/gemfiles/ruby_2.7_opentelemetry.gemfile.lock
+++ b/gemfiles/ruby_2.7_opentelemetry.gemfile.lock
@@ -12,7 +12,7 @@ PATH
   remote: ..
   specs:
     ddtrace (1.14.0)
-      datadog-ci (~> 0.1.0)
+      datadog-ci (~> 0.2.0)
       debase-ruby_core_source (= 3.2.2)
       libdatadog (~> 5.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
@@ -41,7 +41,7 @@ GEM
     crack (0.4.5)
       rexml
     cri (2.15.11)
-    datadog-ci (0.1.1)
+    datadog-ci (0.2.0)
     debase-ruby_core_source (3.2.2)
     debug_inspector (1.1.0)
     diff-lcs (1.5.0)

--- a/gemfiles/ruby_2.7_opentracing.gemfile.lock
+++ b/gemfiles/ruby_2.7_opentracing.gemfile.lock
@@ -12,7 +12,7 @@ PATH
   remote: ..
   specs:
     ddtrace (1.14.0)
-      datadog-ci (~> 0.1.0)
+      datadog-ci (~> 0.2.0)
       debase-ruby_core_source (= 3.2.2)
       libdatadog (~> 5.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
@@ -42,7 +42,7 @@ GEM
     crack (0.4.5)
       rexml
     cri (2.15.11)
-    datadog-ci (0.1.1)
+    datadog-ci (0.2.0)
     debase-ruby_core_source (3.2.2)
     debug_inspector (1.1.0)
     diff-lcs (1.5.0)

--- a/gemfiles/ruby_2.7_rack_1.gemfile.lock
+++ b/gemfiles/ruby_2.7_rack_1.gemfile.lock
@@ -12,7 +12,7 @@ PATH
   remote: ..
   specs:
     ddtrace (1.14.0)
-      datadog-ci (~> 0.1.0)
+      datadog-ci (~> 0.2.0)
       debase-ruby_core_source (= 3.2.2)
       libdatadog (~> 5.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
@@ -41,7 +41,7 @@ GEM
     crack (0.4.5)
       rexml
     cri (2.15.11)
-    datadog-ci (0.1.1)
+    datadog-ci (0.2.0)
     debase-ruby_core_source (3.2.2)
     debug_inspector (1.1.0)
     diff-lcs (1.5.0)

--- a/gemfiles/ruby_2.7_rack_2.gemfile.lock
+++ b/gemfiles/ruby_2.7_rack_2.gemfile.lock
@@ -12,7 +12,7 @@ PATH
   remote: ..
   specs:
     ddtrace (1.14.0)
-      datadog-ci (~> 0.1.0)
+      datadog-ci (~> 0.2.0)
       debase-ruby_core_source (= 3.2.2)
       libdatadog (~> 5.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
@@ -41,7 +41,7 @@ GEM
     crack (0.4.5)
       rexml
     cri (2.15.11)
-    datadog-ci (0.1.1)
+    datadog-ci (0.2.0)
     debase-ruby_core_source (3.2.2)
     debug_inspector (1.1.0)
     diff-lcs (1.5.0)

--- a/gemfiles/ruby_2.7_rack_3.gemfile.lock
+++ b/gemfiles/ruby_2.7_rack_3.gemfile.lock
@@ -12,7 +12,7 @@ PATH
   remote: ..
   specs:
     ddtrace (1.14.0)
-      datadog-ci (~> 0.1.0)
+      datadog-ci (~> 0.2.0)
       debase-ruby_core_source (= 3.2.2)
       libdatadog (~> 5.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
@@ -41,7 +41,7 @@ GEM
     crack (0.4.5)
       rexml
     cri (2.15.11)
-    datadog-ci (0.1.1)
+    datadog-ci (0.2.0)
     debase-ruby_core_source (3.2.2)
     debug_inspector (1.1.0)
     diff-lcs (1.5.0)

--- a/gemfiles/ruby_2.7_rails5_mysql2.gemfile.lock
+++ b/gemfiles/ruby_2.7_rails5_mysql2.gemfile.lock
@@ -12,7 +12,7 @@ PATH
   remote: ..
   specs:
     ddtrace (1.14.0)
-      datadog-ci (~> 0.1.0)
+      datadog-ci (~> 0.2.0)
       debase-ruby_core_source (= 3.2.2)
       libdatadog (~> 5.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
@@ -84,7 +84,7 @@ GEM
       rexml
     crass (1.0.6)
     cri (2.15.11)
-    datadog-ci (0.1.1)
+    datadog-ci (0.2.0)
     date (3.3.3)
     debase-ruby_core_source (3.2.2)
     debug_inspector (1.1.0)

--- a/gemfiles/ruby_2.7_rails5_postgres.gemfile.lock
+++ b/gemfiles/ruby_2.7_rails5_postgres.gemfile.lock
@@ -12,7 +12,7 @@ PATH
   remote: ..
   specs:
     ddtrace (1.14.0)
-      datadog-ci (~> 0.1.0)
+      datadog-ci (~> 0.2.0)
       debase-ruby_core_source (= 3.2.2)
       libdatadog (~> 5.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
@@ -84,7 +84,7 @@ GEM
       rexml
     crass (1.0.6)
     cri (2.15.11)
-    datadog-ci (0.1.1)
+    datadog-ci (0.2.0)
     date (3.3.3)
     debase-ruby_core_source (3.2.2)
     debug_inspector (1.1.0)

--- a/gemfiles/ruby_2.7_rails5_postgres_redis.gemfile.lock
+++ b/gemfiles/ruby_2.7_rails5_postgres_redis.gemfile.lock
@@ -12,7 +12,7 @@ PATH
   remote: ..
   specs:
     ddtrace (1.14.0)
-      datadog-ci (~> 0.1.0)
+      datadog-ci (~> 0.2.0)
       debase-ruby_core_source (= 3.2.2)
       libdatadog (~> 5.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
@@ -84,7 +84,7 @@ GEM
       rexml
     crass (1.0.6)
     cri (2.15.11)
-    datadog-ci (0.1.1)
+    datadog-ci (0.2.0)
     date (3.3.3)
     debase-ruby_core_source (3.2.2)
     debug_inspector (1.1.0)

--- a/gemfiles/ruby_2.7_rails5_postgres_redis_activesupport.gemfile.lock
+++ b/gemfiles/ruby_2.7_rails5_postgres_redis_activesupport.gemfile.lock
@@ -12,7 +12,7 @@ PATH
   remote: ..
   specs:
     ddtrace (1.14.0)
-      datadog-ci (~> 0.1.0)
+      datadog-ci (~> 0.2.0)
       debase-ruby_core_source (= 3.2.2)
       libdatadog (~> 5.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
@@ -84,7 +84,7 @@ GEM
       rexml
     crass (1.0.6)
     cri (2.15.11)
-    datadog-ci (0.1.1)
+    datadog-ci (0.2.0)
     date (3.3.3)
     debase-ruby_core_source (3.2.2)
     debug_inspector (1.1.0)

--- a/gemfiles/ruby_2.7_rails5_postgres_sidekiq.gemfile.lock
+++ b/gemfiles/ruby_2.7_rails5_postgres_sidekiq.gemfile.lock
@@ -12,7 +12,7 @@ PATH
   remote: ..
   specs:
     ddtrace (1.14.0)
-      datadog-ci (~> 0.1.0)
+      datadog-ci (~> 0.2.0)
       debase-ruby_core_source (= 3.2.2)
       libdatadog (~> 5.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
@@ -85,7 +85,7 @@ GEM
       rexml
     crass (1.0.6)
     cri (2.15.11)
-    datadog-ci (0.1.1)
+    datadog-ci (0.2.0)
     date (3.3.3)
     debase-ruby_core_source (3.2.2)
     debug_inspector (1.1.0)

--- a/gemfiles/ruby_2.7_rails5_semantic_logger.gemfile.lock
+++ b/gemfiles/ruby_2.7_rails5_semantic_logger.gemfile.lock
@@ -12,7 +12,7 @@ PATH
   remote: ..
   specs:
     ddtrace (1.14.0)
-      datadog-ci (~> 0.1.0)
+      datadog-ci (~> 0.2.0)
       debase-ruby_core_source (= 3.2.2)
       libdatadog (~> 5.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
@@ -84,7 +84,7 @@ GEM
       rexml
     crass (1.0.6)
     cri (2.15.11)
-    datadog-ci (0.1.1)
+    datadog-ci (0.2.0)
     date (3.3.3)
     debase-ruby_core_source (3.2.2)
     debug_inspector (1.1.0)

--- a/gemfiles/ruby_2.7_rails61_mysql2.gemfile.lock
+++ b/gemfiles/ruby_2.7_rails61_mysql2.gemfile.lock
@@ -12,7 +12,7 @@ PATH
   remote: ..
   specs:
     ddtrace (1.14.0)
-      datadog-ci (~> 0.1.0)
+      datadog-ci (~> 0.2.0)
       debase-ruby_core_source (= 3.2.2)
       libdatadog (~> 5.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
@@ -101,7 +101,7 @@ GEM
       rexml
     crass (1.0.6)
     cri (2.15.11)
-    datadog-ci (0.1.1)
+    datadog-ci (0.2.0)
     date (3.3.3)
     debase-ruby_core_source (3.2.2)
     debug_inspector (1.1.0)

--- a/gemfiles/ruby_2.7_rails61_postgres.gemfile.lock
+++ b/gemfiles/ruby_2.7_rails61_postgres.gemfile.lock
@@ -12,7 +12,7 @@ PATH
   remote: ..
   specs:
     ddtrace (1.14.0)
-      datadog-ci (~> 0.1.0)
+      datadog-ci (~> 0.2.0)
       debase-ruby_core_source (= 3.2.2)
       libdatadog (~> 5.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
@@ -101,7 +101,7 @@ GEM
       rexml
     crass (1.0.6)
     cri (2.15.11)
-    datadog-ci (0.1.1)
+    datadog-ci (0.2.0)
     date (3.3.3)
     debase-ruby_core_source (3.2.2)
     debug_inspector (1.1.0)

--- a/gemfiles/ruby_2.7_rails61_postgres_redis.gemfile.lock
+++ b/gemfiles/ruby_2.7_rails61_postgres_redis.gemfile.lock
@@ -12,7 +12,7 @@ PATH
   remote: ..
   specs:
     ddtrace (1.14.0)
-      datadog-ci (~> 0.1.0)
+      datadog-ci (~> 0.2.0)
       debase-ruby_core_source (= 3.2.2)
       libdatadog (~> 5.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
@@ -101,7 +101,7 @@ GEM
       rexml
     crass (1.0.6)
     cri (2.15.11)
-    datadog-ci (0.1.1)
+    datadog-ci (0.2.0)
     date (3.3.3)
     debase-ruby_core_source (3.2.2)
     debug_inspector (1.1.0)

--- a/gemfiles/ruby_2.7_rails61_postgres_sidekiq.gemfile.lock
+++ b/gemfiles/ruby_2.7_rails61_postgres_sidekiq.gemfile.lock
@@ -12,7 +12,7 @@ PATH
   remote: ..
   specs:
     ddtrace (1.14.0)
-      datadog-ci (~> 0.1.0)
+      datadog-ci (~> 0.2.0)
       debase-ruby_core_source (= 3.2.2)
       libdatadog (~> 5.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
@@ -102,7 +102,7 @@ GEM
       rexml
     crass (1.0.6)
     cri (2.15.11)
-    datadog-ci (0.1.1)
+    datadog-ci (0.2.0)
     date (3.3.3)
     debase-ruby_core_source (3.2.2)
     debug_inspector (1.1.0)

--- a/gemfiles/ruby_2.7_rails61_semantic_logger.gemfile.lock
+++ b/gemfiles/ruby_2.7_rails61_semantic_logger.gemfile.lock
@@ -12,7 +12,7 @@ PATH
   remote: ..
   specs:
     ddtrace (1.14.0)
-      datadog-ci (~> 0.1.0)
+      datadog-ci (~> 0.2.0)
       debase-ruby_core_source (= 3.2.2)
       libdatadog (~> 5.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
@@ -101,7 +101,7 @@ GEM
       rexml
     crass (1.0.6)
     cri (2.15.11)
-    datadog-ci (0.1.1)
+    datadog-ci (0.2.0)
     date (3.3.3)
     debase-ruby_core_source (3.2.2)
     debug_inspector (1.1.0)

--- a/gemfiles/ruby_2.7_rails6_mysql2.gemfile.lock
+++ b/gemfiles/ruby_2.7_rails6_mysql2.gemfile.lock
@@ -12,7 +12,7 @@ PATH
   remote: ..
   specs:
     ddtrace (1.14.0)
-      datadog-ci (~> 0.1.0)
+      datadog-ci (~> 0.2.0)
       debase-ruby_core_source (= 3.2.2)
       libdatadog (~> 5.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
@@ -97,7 +97,7 @@ GEM
       rexml
     crass (1.0.6)
     cri (2.15.11)
-    datadog-ci (0.1.1)
+    datadog-ci (0.2.0)
     date (3.3.3)
     debase-ruby_core_source (3.2.2)
     debug_inspector (1.1.0)

--- a/gemfiles/ruby_2.7_rails6_postgres.gemfile.lock
+++ b/gemfiles/ruby_2.7_rails6_postgres.gemfile.lock
@@ -12,7 +12,7 @@ PATH
   remote: ..
   specs:
     ddtrace (1.14.0)
-      datadog-ci (~> 0.1.0)
+      datadog-ci (~> 0.2.0)
       debase-ruby_core_source (= 3.2.2)
       libdatadog (~> 5.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
@@ -97,7 +97,7 @@ GEM
       rexml
     crass (1.0.6)
     cri (2.15.11)
-    datadog-ci (0.1.1)
+    datadog-ci (0.2.0)
     date (3.3.3)
     debase-ruby_core_source (3.2.2)
     debug_inspector (1.1.0)

--- a/gemfiles/ruby_2.7_rails6_postgres_redis.gemfile.lock
+++ b/gemfiles/ruby_2.7_rails6_postgres_redis.gemfile.lock
@@ -12,7 +12,7 @@ PATH
   remote: ..
   specs:
     ddtrace (1.14.0)
-      datadog-ci (~> 0.1.0)
+      datadog-ci (~> 0.2.0)
       debase-ruby_core_source (= 3.2.2)
       libdatadog (~> 5.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
@@ -97,7 +97,7 @@ GEM
       rexml
     crass (1.0.6)
     cri (2.15.11)
-    datadog-ci (0.1.1)
+    datadog-ci (0.2.0)
     date (3.3.3)
     debase-ruby_core_source (3.2.2)
     debug_inspector (1.1.0)

--- a/gemfiles/ruby_2.7_rails6_postgres_redis_activesupport.gemfile.lock
+++ b/gemfiles/ruby_2.7_rails6_postgres_redis_activesupport.gemfile.lock
@@ -12,7 +12,7 @@ PATH
   remote: ..
   specs:
     ddtrace (1.14.0)
-      datadog-ci (~> 0.1.0)
+      datadog-ci (~> 0.2.0)
       debase-ruby_core_source (= 3.2.2)
       libdatadog (~> 5.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
@@ -97,7 +97,7 @@ GEM
       rexml
     crass (1.0.6)
     cri (2.15.11)
-    datadog-ci (0.1.1)
+    datadog-ci (0.2.0)
     date (3.3.3)
     debase-ruby_core_source (3.2.2)
     debug_inspector (1.1.0)

--- a/gemfiles/ruby_2.7_rails6_postgres_sidekiq.gemfile.lock
+++ b/gemfiles/ruby_2.7_rails6_postgres_sidekiq.gemfile.lock
@@ -12,7 +12,7 @@ PATH
   remote: ..
   specs:
     ddtrace (1.14.0)
-      datadog-ci (~> 0.1.0)
+      datadog-ci (~> 0.2.0)
       debase-ruby_core_source (= 3.2.2)
       libdatadog (~> 5.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
@@ -98,7 +98,7 @@ GEM
       rexml
     crass (1.0.6)
     cri (2.15.11)
-    datadog-ci (0.1.1)
+    datadog-ci (0.2.0)
     date (3.3.3)
     debase-ruby_core_source (3.2.2)
     debug_inspector (1.1.0)

--- a/gemfiles/ruby_2.7_rails6_semantic_logger.gemfile.lock
+++ b/gemfiles/ruby_2.7_rails6_semantic_logger.gemfile.lock
@@ -12,7 +12,7 @@ PATH
   remote: ..
   specs:
     ddtrace (1.14.0)
-      datadog-ci (~> 0.1.0)
+      datadog-ci (~> 0.2.0)
       debase-ruby_core_source (= 3.2.2)
       libdatadog (~> 5.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
@@ -97,7 +97,7 @@ GEM
       rexml
     crass (1.0.6)
     cri (2.15.11)
-    datadog-ci (0.1.1)
+    datadog-ci (0.2.0)
     date (3.3.3)
     debase-ruby_core_source (3.2.2)
     debug_inspector (1.1.0)

--- a/gemfiles/ruby_2.7_redis_3.gemfile.lock
+++ b/gemfiles/ruby_2.7_redis_3.gemfile.lock
@@ -12,7 +12,7 @@ PATH
   remote: ..
   specs:
     ddtrace (1.14.0)
-      datadog-ci (~> 0.1.0)
+      datadog-ci (~> 0.2.0)
       debase-ruby_core_source (= 3.2.2)
       libdatadog (~> 5.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
@@ -41,7 +41,7 @@ GEM
     crack (0.4.5)
       rexml
     cri (2.15.11)
-    datadog-ci (0.1.1)
+    datadog-ci (0.2.0)
     debase-ruby_core_source (3.2.2)
     debug_inspector (1.1.0)
     diff-lcs (1.5.0)

--- a/gemfiles/ruby_2.7_redis_4.gemfile.lock
+++ b/gemfiles/ruby_2.7_redis_4.gemfile.lock
@@ -12,7 +12,7 @@ PATH
   remote: ..
   specs:
     ddtrace (1.14.0)
-      datadog-ci (~> 0.1.0)
+      datadog-ci (~> 0.2.0)
       debase-ruby_core_source (= 3.2.2)
       libdatadog (~> 5.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
@@ -41,7 +41,7 @@ GEM
     crack (0.4.5)
       rexml
     cri (2.15.11)
-    datadog-ci (0.1.1)
+    datadog-ci (0.2.0)
     debase-ruby_core_source (3.2.2)
     debug_inspector (1.1.0)
     diff-lcs (1.5.0)

--- a/gemfiles/ruby_2.7_redis_5.gemfile.lock
+++ b/gemfiles/ruby_2.7_redis_5.gemfile.lock
@@ -12,7 +12,7 @@ PATH
   remote: ..
   specs:
     ddtrace (1.14.0)
-      datadog-ci (~> 0.1.0)
+      datadog-ci (~> 0.2.0)
       debase-ruby_core_source (= 3.2.2)
       libdatadog (~> 5.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
@@ -42,7 +42,7 @@ GEM
     crack (0.4.5)
       rexml
     cri (2.15.11)
-    datadog-ci (0.1.1)
+    datadog-ci (0.2.0)
     debase-ruby_core_source (3.2.2)
     debug_inspector (1.1.0)
     diff-lcs (1.5.0)

--- a/gemfiles/ruby_2.7_relational_db.gemfile.lock
+++ b/gemfiles/ruby_2.7_relational_db.gemfile.lock
@@ -12,7 +12,7 @@ PATH
   remote: ..
   specs:
     ddtrace (1.14.0)
-      datadog-ci (~> 0.1.0)
+      datadog-ci (~> 0.2.0)
       debase-ruby_core_source (= 3.2.2)
       libdatadog (~> 5.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
@@ -52,7 +52,7 @@ GEM
     crack (0.4.5)
       rexml
     cri (2.15.11)
-    datadog-ci (0.1.1)
+    datadog-ci (0.2.0)
     debase-ruby_core_source (3.2.2)
     debug_inspector (1.1.0)
     delayed_job (4.1.11)

--- a/gemfiles/ruby_2.7_resque2_redis3.gemfile.lock
+++ b/gemfiles/ruby_2.7_resque2_redis3.gemfile.lock
@@ -12,7 +12,7 @@ PATH
   remote: ..
   specs:
     ddtrace (1.14.0)
-      datadog-ci (~> 0.1.0)
+      datadog-ci (~> 0.2.0)
       debase-ruby_core_source (= 3.2.2)
       libdatadog (~> 5.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
@@ -41,7 +41,7 @@ GEM
     crack (0.4.5)
       rexml
     cri (2.15.11)
-    datadog-ci (0.1.1)
+    datadog-ci (0.2.0)
     debase-ruby_core_source (3.2.2)
     debug_inspector (1.1.0)
     diff-lcs (1.5.0)

--- a/gemfiles/ruby_2.7_resque2_redis4.gemfile.lock
+++ b/gemfiles/ruby_2.7_resque2_redis4.gemfile.lock
@@ -12,7 +12,7 @@ PATH
   remote: ..
   specs:
     ddtrace (1.14.0)
-      datadog-ci (~> 0.1.0)
+      datadog-ci (~> 0.2.0)
       debase-ruby_core_source (= 3.2.2)
       libdatadog (~> 5.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
@@ -41,7 +41,7 @@ GEM
     crack (0.4.5)
       rexml
     cri (2.15.11)
-    datadog-ci (0.1.1)
+    datadog-ci (0.2.0)
     debase-ruby_core_source (3.2.2)
     debug_inspector (1.1.0)
     diff-lcs (1.5.0)

--- a/gemfiles/ruby_2.7_sinatra.gemfile.lock
+++ b/gemfiles/ruby_2.7_sinatra.gemfile.lock
@@ -12,7 +12,7 @@ PATH
   remote: ..
   specs:
     ddtrace (1.14.0)
-      datadog-ci (~> 0.1.0)
+      datadog-ci (~> 0.2.0)
       debase-ruby_core_source (= 3.2.2)
       libdatadog (~> 5.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
@@ -41,7 +41,7 @@ GEM
     crack (0.4.5)
       rexml
     cri (2.15.11)
-    datadog-ci (0.1.1)
+    datadog-ci (0.2.0)
     debase-ruby_core_source (3.2.2)
     debug_inspector (1.1.0)
     diff-lcs (1.5.0)

--- a/gemfiles/ruby_3.0_activesupport.gemfile.lock
+++ b/gemfiles/ruby_3.0_activesupport.gemfile.lock
@@ -12,7 +12,7 @@ PATH
   remote: ..
   specs:
     ddtrace (1.14.0)
-      datadog-ci (~> 0.1.0)
+      datadog-ci (~> 0.2.0)
       debase-ruby_core_source (= 3.2.2)
       libdatadog (~> 5.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
@@ -69,7 +69,7 @@ GEM
       rexml
     crass (1.0.6)
     cri (2.15.11)
-    datadog-ci (0.1.1)
+    datadog-ci (0.2.0)
     debase-ruby_core_source (3.2.2)
     debug_inspector (1.1.0)
     diff-lcs (1.5.0)

--- a/gemfiles/ruby_3.0_aws.gemfile.lock
+++ b/gemfiles/ruby_3.0_aws.gemfile.lock
@@ -12,7 +12,7 @@ PATH
   remote: ..
   specs:
     ddtrace (1.14.0)
-      datadog-ci (~> 0.1.0)
+      datadog-ci (~> 0.2.0)
       debase-ruby_core_source (= 3.2.2)
       libdatadog (~> 5.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
@@ -1462,7 +1462,7 @@ GEM
     crack (0.4.5)
       rexml
     cri (2.15.11)
-    datadog-ci (0.1.1)
+    datadog-ci (0.2.0)
     debase-ruby_core_source (3.2.2)
     debug_inspector (1.1.0)
     diff-lcs (1.5.0)

--- a/gemfiles/ruby_3.0_contrib.gemfile.lock
+++ b/gemfiles/ruby_3.0_contrib.gemfile.lock
@@ -12,7 +12,7 @@ PATH
   remote: ..
   specs:
     ddtrace (1.14.0)
-      datadog-ci (~> 0.1.0)
+      datadog-ci (~> 0.2.0)
       debase-ruby_core_source (= 3.2.2)
       libdatadog (~> 5.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
@@ -48,7 +48,7 @@ GEM
       rexml
     cri (2.15.11)
     dalli (3.2.4)
-    datadog-ci (0.1.1)
+    datadog-ci (0.2.0)
     debase-ruby_core_source (3.2.2)
     debug_inspector (1.1.0)
     diff-lcs (1.5.0)

--- a/gemfiles/ruby_3.0_contrib_old.gemfile.lock
+++ b/gemfiles/ruby_3.0_contrib_old.gemfile.lock
@@ -12,7 +12,7 @@ PATH
   remote: ..
   specs:
     ddtrace (1.14.0)
-      datadog-ci (~> 0.1.0)
+      datadog-ci (~> 0.2.0)
       debase-ruby_core_source (= 3.2.2)
       libdatadog (~> 5.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
@@ -46,7 +46,7 @@ GEM
     cri (2.15.11)
     daemons (1.4.1)
     dalli (2.7.11)
-    datadog-ci (0.1.1)
+    datadog-ci (0.2.0)
     debase-ruby_core_source (3.2.2)
     debug_inspector (1.1.0)
     diff-lcs (1.5.0)

--- a/gemfiles/ruby_3.0_core_old.gemfile.lock
+++ b/gemfiles/ruby_3.0_core_old.gemfile.lock
@@ -12,7 +12,7 @@ PATH
   remote: ..
   specs:
     ddtrace (1.14.0)
-      datadog-ci (~> 0.1.0)
+      datadog-ci (~> 0.2.0)
       debase-ruby_core_source (= 3.2.2)
       libdatadog (~> 5.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
@@ -41,7 +41,7 @@ GEM
     crack (0.4.5)
       rexml
     cri (2.15.11)
-    datadog-ci (0.1.1)
+    datadog-ci (0.2.0)
     debase-ruby_core_source (3.2.2)
     debug_inspector (1.1.0)
     diff-lcs (1.5.0)

--- a/gemfiles/ruby_3.0_http.gemfile.lock
+++ b/gemfiles/ruby_3.0_http.gemfile.lock
@@ -12,7 +12,7 @@ PATH
   remote: ..
   specs:
     ddtrace (1.14.0)
-      datadog-ci (~> 0.1.0)
+      datadog-ci (~> 0.2.0)
       debase-ruby_core_source (= 3.2.2)
       libdatadog (~> 5.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
@@ -41,7 +41,7 @@ GEM
     crack (0.4.5)
       rexml
     cri (2.15.11)
-    datadog-ci (0.1.1)
+    datadog-ci (0.2.0)
     debase-ruby_core_source (3.2.2)
     debug_inspector (1.1.0)
     diff-lcs (1.5.0)

--- a/gemfiles/ruby_3.0_opentelemetry.gemfile.lock
+++ b/gemfiles/ruby_3.0_opentelemetry.gemfile.lock
@@ -12,7 +12,7 @@ PATH
   remote: ..
   specs:
     ddtrace (1.14.0)
-      datadog-ci (~> 0.1.0)
+      datadog-ci (~> 0.2.0)
       debase-ruby_core_source (= 3.2.2)
       libdatadog (~> 5.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
@@ -41,7 +41,7 @@ GEM
     crack (0.4.5)
       rexml
     cri (2.15.11)
-    datadog-ci (0.1.1)
+    datadog-ci (0.2.0)
     debase-ruby_core_source (3.2.2)
     debug_inspector (1.1.0)
     diff-lcs (1.5.0)

--- a/gemfiles/ruby_3.0_opentracing.gemfile.lock
+++ b/gemfiles/ruby_3.0_opentracing.gemfile.lock
@@ -12,7 +12,7 @@ PATH
   remote: ..
   specs:
     ddtrace (1.14.0)
-      datadog-ci (~> 0.1.0)
+      datadog-ci (~> 0.2.0)
       debase-ruby_core_source (= 3.2.2)
       libdatadog (~> 5.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
@@ -42,7 +42,7 @@ GEM
     crack (0.4.5)
       rexml
     cri (2.15.11)
-    datadog-ci (0.1.1)
+    datadog-ci (0.2.0)
     debase-ruby_core_source (3.2.2)
     debug_inspector (1.1.0)
     diff-lcs (1.5.0)

--- a/gemfiles/ruby_3.0_rack_1.gemfile.lock
+++ b/gemfiles/ruby_3.0_rack_1.gemfile.lock
@@ -12,7 +12,7 @@ PATH
   remote: ..
   specs:
     ddtrace (1.14.0)
-      datadog-ci (~> 0.1.0)
+      datadog-ci (~> 0.2.0)
       debase-ruby_core_source (= 3.2.2)
       libdatadog (~> 5.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
@@ -41,7 +41,7 @@ GEM
     crack (0.4.5)
       rexml
     cri (2.15.11)
-    datadog-ci (0.1.1)
+    datadog-ci (0.2.0)
     debase-ruby_core_source (3.2.2)
     debug_inspector (1.1.0)
     diff-lcs (1.5.0)

--- a/gemfiles/ruby_3.0_rack_2.gemfile.lock
+++ b/gemfiles/ruby_3.0_rack_2.gemfile.lock
@@ -12,7 +12,7 @@ PATH
   remote: ..
   specs:
     ddtrace (1.14.0)
-      datadog-ci (~> 0.1.0)
+      datadog-ci (~> 0.2.0)
       debase-ruby_core_source (= 3.2.2)
       libdatadog (~> 5.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
@@ -41,7 +41,7 @@ GEM
     crack (0.4.5)
       rexml
     cri (2.15.11)
-    datadog-ci (0.1.1)
+    datadog-ci (0.2.0)
     debase-ruby_core_source (3.2.2)
     debug_inspector (1.1.0)
     diff-lcs (1.5.0)

--- a/gemfiles/ruby_3.0_rack_3.gemfile.lock
+++ b/gemfiles/ruby_3.0_rack_3.gemfile.lock
@@ -12,7 +12,7 @@ PATH
   remote: ..
   specs:
     ddtrace (1.14.0)
-      datadog-ci (~> 0.1.0)
+      datadog-ci (~> 0.2.0)
       debase-ruby_core_source (= 3.2.2)
       libdatadog (~> 5.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
@@ -41,7 +41,7 @@ GEM
     crack (0.4.5)
       rexml
     cri (2.15.11)
-    datadog-ci (0.1.1)
+    datadog-ci (0.2.0)
     debase-ruby_core_source (3.2.2)
     debug_inspector (1.1.0)
     diff-lcs (1.5.0)

--- a/gemfiles/ruby_3.0_rails61_mysql2.gemfile.lock
+++ b/gemfiles/ruby_3.0_rails61_mysql2.gemfile.lock
@@ -12,7 +12,7 @@ PATH
   remote: ..
   specs:
     ddtrace (1.14.0)
-      datadog-ci (~> 0.1.0)
+      datadog-ci (~> 0.2.0)
       debase-ruby_core_source (= 3.2.2)
       libdatadog (~> 5.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
@@ -101,7 +101,7 @@ GEM
       rexml
     crass (1.0.6)
     cri (2.15.11)
-    datadog-ci (0.1.1)
+    datadog-ci (0.2.0)
     date (3.3.3)
     debase-ruby_core_source (3.2.2)
     debug_inspector (1.1.0)

--- a/gemfiles/ruby_3.0_rails61_postgres.gemfile.lock
+++ b/gemfiles/ruby_3.0_rails61_postgres.gemfile.lock
@@ -12,7 +12,7 @@ PATH
   remote: ..
   specs:
     ddtrace (1.14.0)
-      datadog-ci (~> 0.1.0)
+      datadog-ci (~> 0.2.0)
       debase-ruby_core_source (= 3.2.2)
       libdatadog (~> 5.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
@@ -101,7 +101,7 @@ GEM
       rexml
     crass (1.0.6)
     cri (2.15.11)
-    datadog-ci (0.1.1)
+    datadog-ci (0.2.0)
     date (3.3.3)
     debase-ruby_core_source (3.2.2)
     debug_inspector (1.1.0)

--- a/gemfiles/ruby_3.0_rails61_postgres_redis.gemfile.lock
+++ b/gemfiles/ruby_3.0_rails61_postgres_redis.gemfile.lock
@@ -12,7 +12,7 @@ PATH
   remote: ..
   specs:
     ddtrace (1.14.0)
-      datadog-ci (~> 0.1.0)
+      datadog-ci (~> 0.2.0)
       debase-ruby_core_source (= 3.2.2)
       libdatadog (~> 5.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
@@ -101,7 +101,7 @@ GEM
       rexml
     crass (1.0.6)
     cri (2.15.11)
-    datadog-ci (0.1.1)
+    datadog-ci (0.2.0)
     date (3.3.3)
     debase-ruby_core_source (3.2.2)
     debug_inspector (1.1.0)

--- a/gemfiles/ruby_3.0_rails61_postgres_sidekiq.gemfile.lock
+++ b/gemfiles/ruby_3.0_rails61_postgres_sidekiq.gemfile.lock
@@ -12,7 +12,7 @@ PATH
   remote: ..
   specs:
     ddtrace (1.14.0)
-      datadog-ci (~> 0.1.0)
+      datadog-ci (~> 0.2.0)
       debase-ruby_core_source (= 3.2.2)
       libdatadog (~> 5.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
@@ -102,7 +102,7 @@ GEM
       rexml
     crass (1.0.6)
     cri (2.15.11)
-    datadog-ci (0.1.1)
+    datadog-ci (0.2.0)
     date (3.3.3)
     debase-ruby_core_source (3.2.2)
     debug_inspector (1.1.0)

--- a/gemfiles/ruby_3.0_rails61_semantic_logger.gemfile.lock
+++ b/gemfiles/ruby_3.0_rails61_semantic_logger.gemfile.lock
@@ -12,7 +12,7 @@ PATH
   remote: ..
   specs:
     ddtrace (1.14.0)
-      datadog-ci (~> 0.1.0)
+      datadog-ci (~> 0.2.0)
       debase-ruby_core_source (= 3.2.2)
       libdatadog (~> 5.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
@@ -101,7 +101,7 @@ GEM
       rexml
     crass (1.0.6)
     cri (2.15.11)
-    datadog-ci (0.1.1)
+    datadog-ci (0.2.0)
     date (3.3.3)
     debase-ruby_core_source (3.2.2)
     debug_inspector (1.1.0)

--- a/gemfiles/ruby_3.0_redis_3.gemfile.lock
+++ b/gemfiles/ruby_3.0_redis_3.gemfile.lock
@@ -12,7 +12,7 @@ PATH
   remote: ..
   specs:
     ddtrace (1.14.0)
-      datadog-ci (~> 0.1.0)
+      datadog-ci (~> 0.2.0)
       debase-ruby_core_source (= 3.2.2)
       libdatadog (~> 5.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
@@ -41,7 +41,7 @@ GEM
     crack (0.4.5)
       rexml
     cri (2.15.11)
-    datadog-ci (0.1.1)
+    datadog-ci (0.2.0)
     debase-ruby_core_source (3.2.2)
     debug_inspector (1.1.0)
     diff-lcs (1.5.0)

--- a/gemfiles/ruby_3.0_redis_4.gemfile.lock
+++ b/gemfiles/ruby_3.0_redis_4.gemfile.lock
@@ -12,7 +12,7 @@ PATH
   remote: ..
   specs:
     ddtrace (1.14.0)
-      datadog-ci (~> 0.1.0)
+      datadog-ci (~> 0.2.0)
       debase-ruby_core_source (= 3.2.2)
       libdatadog (~> 5.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
@@ -41,7 +41,7 @@ GEM
     crack (0.4.5)
       rexml
     cri (2.15.11)
-    datadog-ci (0.1.1)
+    datadog-ci (0.2.0)
     debase-ruby_core_source (3.2.2)
     debug_inspector (1.1.0)
     diff-lcs (1.5.0)

--- a/gemfiles/ruby_3.0_redis_5.gemfile.lock
+++ b/gemfiles/ruby_3.0_redis_5.gemfile.lock
@@ -12,7 +12,7 @@ PATH
   remote: ..
   specs:
     ddtrace (1.14.0)
-      datadog-ci (~> 0.1.0)
+      datadog-ci (~> 0.2.0)
       debase-ruby_core_source (= 3.2.2)
       libdatadog (~> 5.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
@@ -42,7 +42,7 @@ GEM
     crack (0.4.5)
       rexml
     cri (2.15.11)
-    datadog-ci (0.1.1)
+    datadog-ci (0.2.0)
     debase-ruby_core_source (3.2.2)
     debug_inspector (1.1.0)
     diff-lcs (1.5.0)

--- a/gemfiles/ruby_3.0_relational_db.gemfile.lock
+++ b/gemfiles/ruby_3.0_relational_db.gemfile.lock
@@ -12,7 +12,7 @@ PATH
   remote: ..
   specs:
     ddtrace (1.14.0)
-      datadog-ci (~> 0.1.0)
+      datadog-ci (~> 0.2.0)
       debase-ruby_core_source (= 3.2.2)
       libdatadog (~> 5.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
@@ -51,7 +51,7 @@ GEM
     crack (0.4.5)
       rexml
     cri (2.15.11)
-    datadog-ci (0.1.1)
+    datadog-ci (0.2.0)
     debase-ruby_core_source (3.2.2)
     debug_inspector (1.1.0)
     delayed_job (4.1.11)

--- a/gemfiles/ruby_3.0_resque2_redis3.gemfile.lock
+++ b/gemfiles/ruby_3.0_resque2_redis3.gemfile.lock
@@ -12,7 +12,7 @@ PATH
   remote: ..
   specs:
     ddtrace (1.14.0)
-      datadog-ci (~> 0.1.0)
+      datadog-ci (~> 0.2.0)
       debase-ruby_core_source (= 3.2.2)
       libdatadog (~> 5.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
@@ -41,7 +41,7 @@ GEM
     crack (0.4.5)
       rexml
     cri (2.15.11)
-    datadog-ci (0.1.1)
+    datadog-ci (0.2.0)
     debase-ruby_core_source (3.2.2)
     debug_inspector (1.1.0)
     diff-lcs (1.5.0)

--- a/gemfiles/ruby_3.0_resque2_redis4.gemfile.lock
+++ b/gemfiles/ruby_3.0_resque2_redis4.gemfile.lock
@@ -12,7 +12,7 @@ PATH
   remote: ..
   specs:
     ddtrace (1.14.0)
-      datadog-ci (~> 0.1.0)
+      datadog-ci (~> 0.2.0)
       debase-ruby_core_source (= 3.2.2)
       libdatadog (~> 5.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
@@ -42,7 +42,7 @@ GEM
     crack (0.4.5)
       rexml
     cri (2.15.11)
-    datadog-ci (0.1.1)
+    datadog-ci (0.2.0)
     debase-ruby_core_source (3.2.2)
     debug_inspector (1.1.0)
     diff-lcs (1.5.0)

--- a/gemfiles/ruby_3.0_sinatra.gemfile.lock
+++ b/gemfiles/ruby_3.0_sinatra.gemfile.lock
@@ -12,7 +12,7 @@ PATH
   remote: ..
   specs:
     ddtrace (1.14.0)
-      datadog-ci (~> 0.1.0)
+      datadog-ci (~> 0.2.0)
       debase-ruby_core_source (= 3.2.2)
       libdatadog (~> 5.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
@@ -41,7 +41,7 @@ GEM
     crack (0.4.5)
       rexml
     cri (2.15.11)
-    datadog-ci (0.1.1)
+    datadog-ci (0.2.0)
     debase-ruby_core_source (3.2.2)
     debug_inspector (1.1.0)
     diff-lcs (1.5.0)

--- a/gemfiles/ruby_3.1_activesupport.gemfile.lock
+++ b/gemfiles/ruby_3.1_activesupport.gemfile.lock
@@ -12,7 +12,7 @@ PATH
   remote: ..
   specs:
     ddtrace (1.14.0)
-      datadog-ci (~> 0.1.0)
+      datadog-ci (~> 0.2.0)
       debase-ruby_core_source (= 3.2.2)
       libdatadog (~> 5.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
@@ -69,7 +69,7 @@ GEM
       rexml
     crass (1.0.6)
     cri (2.15.11)
-    datadog-ci (0.1.1)
+    datadog-ci (0.2.0)
     debase-ruby_core_source (3.2.2)
     debug_inspector (1.1.0)
     diff-lcs (1.5.0)

--- a/gemfiles/ruby_3.1_aws.gemfile.lock
+++ b/gemfiles/ruby_3.1_aws.gemfile.lock
@@ -12,7 +12,7 @@ PATH
   remote: ..
   specs:
     ddtrace (1.14.0)
-      datadog-ci (~> 0.1.0)
+      datadog-ci (~> 0.2.0)
       debase-ruby_core_source (= 3.2.2)
       libdatadog (~> 5.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
@@ -1462,7 +1462,7 @@ GEM
     crack (0.4.5)
       rexml
     cri (2.15.11)
-    datadog-ci (0.1.1)
+    datadog-ci (0.2.0)
     debase-ruby_core_source (3.2.2)
     debug_inspector (1.1.0)
     diff-lcs (1.5.0)

--- a/gemfiles/ruby_3.1_contrib.gemfile.lock
+++ b/gemfiles/ruby_3.1_contrib.gemfile.lock
@@ -12,7 +12,7 @@ PATH
   remote: ..
   specs:
     ddtrace (1.14.0)
-      datadog-ci (~> 0.1.0)
+      datadog-ci (~> 0.2.0)
       debase-ruby_core_source (= 3.2.2)
       libdatadog (~> 5.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
@@ -48,7 +48,7 @@ GEM
       rexml
     cri (2.15.11)
     dalli (3.2.4)
-    datadog-ci (0.1.1)
+    datadog-ci (0.2.0)
     debase-ruby_core_source (3.2.2)
     debug_inspector (1.1.0)
     diff-lcs (1.5.0)

--- a/gemfiles/ruby_3.1_contrib_old.gemfile.lock
+++ b/gemfiles/ruby_3.1_contrib_old.gemfile.lock
@@ -12,7 +12,7 @@ PATH
   remote: ..
   specs:
     ddtrace (1.14.0)
-      datadog-ci (~> 0.1.0)
+      datadog-ci (~> 0.2.0)
       debase-ruby_core_source (= 3.2.2)
       libdatadog (~> 5.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
@@ -46,7 +46,7 @@ GEM
     cri (2.15.11)
     daemons (1.4.1)
     dalli (2.7.11)
-    datadog-ci (0.1.1)
+    datadog-ci (0.2.0)
     debase-ruby_core_source (3.2.2)
     debug_inspector (1.1.0)
     diff-lcs (1.5.0)

--- a/gemfiles/ruby_3.1_core_old.gemfile.lock
+++ b/gemfiles/ruby_3.1_core_old.gemfile.lock
@@ -12,7 +12,7 @@ PATH
   remote: ..
   specs:
     ddtrace (1.14.0)
-      datadog-ci (~> 0.1.0)
+      datadog-ci (~> 0.2.0)
       debase-ruby_core_source (= 3.2.2)
       libdatadog (~> 5.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
@@ -41,7 +41,7 @@ GEM
     crack (0.4.5)
       rexml
     cri (2.15.11)
-    datadog-ci (0.1.1)
+    datadog-ci (0.2.0)
     debase-ruby_core_source (3.2.2)
     debug_inspector (1.1.0)
     diff-lcs (1.5.0)

--- a/gemfiles/ruby_3.1_http.gemfile.lock
+++ b/gemfiles/ruby_3.1_http.gemfile.lock
@@ -12,7 +12,7 @@ PATH
   remote: ..
   specs:
     ddtrace (1.14.0)
-      datadog-ci (~> 0.1.0)
+      datadog-ci (~> 0.2.0)
       debase-ruby_core_source (= 3.2.2)
       libdatadog (~> 5.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
@@ -41,7 +41,7 @@ GEM
     crack (0.4.5)
       rexml
     cri (2.15.11)
-    datadog-ci (0.1.1)
+    datadog-ci (0.2.0)
     debase-ruby_core_source (3.2.2)
     debug_inspector (1.1.0)
     diff-lcs (1.5.0)

--- a/gemfiles/ruby_3.1_opentelemetry.gemfile.lock
+++ b/gemfiles/ruby_3.1_opentelemetry.gemfile.lock
@@ -12,7 +12,7 @@ PATH
   remote: ..
   specs:
     ddtrace (1.14.0)
-      datadog-ci (~> 0.1.0)
+      datadog-ci (~> 0.2.0)
       debase-ruby_core_source (= 3.2.2)
       libdatadog (~> 5.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
@@ -41,7 +41,7 @@ GEM
     crack (0.4.5)
       rexml
     cri (2.15.11)
-    datadog-ci (0.1.1)
+    datadog-ci (0.2.0)
     debase-ruby_core_source (3.2.2)
     debug_inspector (1.1.0)
     diff-lcs (1.5.0)

--- a/gemfiles/ruby_3.1_opentracing.gemfile.lock
+++ b/gemfiles/ruby_3.1_opentracing.gemfile.lock
@@ -12,7 +12,7 @@ PATH
   remote: ..
   specs:
     ddtrace (1.14.0)
-      datadog-ci (~> 0.1.0)
+      datadog-ci (~> 0.2.0)
       debase-ruby_core_source (= 3.2.2)
       libdatadog (~> 5.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
@@ -42,7 +42,7 @@ GEM
     crack (0.4.5)
       rexml
     cri (2.15.11)
-    datadog-ci (0.1.1)
+    datadog-ci (0.2.0)
     debase-ruby_core_source (3.2.2)
     debug_inspector (1.1.0)
     diff-lcs (1.5.0)

--- a/gemfiles/ruby_3.1_rack_1.gemfile.lock
+++ b/gemfiles/ruby_3.1_rack_1.gemfile.lock
@@ -12,7 +12,7 @@ PATH
   remote: ..
   specs:
     ddtrace (1.14.0)
-      datadog-ci (~> 0.1.0)
+      datadog-ci (~> 0.2.0)
       debase-ruby_core_source (= 3.2.2)
       libdatadog (~> 5.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
@@ -41,7 +41,7 @@ GEM
     crack (0.4.5)
       rexml
     cri (2.15.11)
-    datadog-ci (0.1.1)
+    datadog-ci (0.2.0)
     debase-ruby_core_source (3.2.2)
     debug_inspector (1.1.0)
     diff-lcs (1.5.0)

--- a/gemfiles/ruby_3.1_rack_2.gemfile.lock
+++ b/gemfiles/ruby_3.1_rack_2.gemfile.lock
@@ -12,7 +12,7 @@ PATH
   remote: ..
   specs:
     ddtrace (1.14.0)
-      datadog-ci (~> 0.1.0)
+      datadog-ci (~> 0.2.0)
       debase-ruby_core_source (= 3.2.2)
       libdatadog (~> 5.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
@@ -41,7 +41,7 @@ GEM
     crack (0.4.5)
       rexml
     cri (2.15.11)
-    datadog-ci (0.1.1)
+    datadog-ci (0.2.0)
     debase-ruby_core_source (3.2.2)
     debug_inspector (1.1.0)
     diff-lcs (1.5.0)

--- a/gemfiles/ruby_3.1_rack_3.gemfile.lock
+++ b/gemfiles/ruby_3.1_rack_3.gemfile.lock
@@ -12,7 +12,7 @@ PATH
   remote: ..
   specs:
     ddtrace (1.14.0)
-      datadog-ci (~> 0.1.0)
+      datadog-ci (~> 0.2.0)
       debase-ruby_core_source (= 3.2.2)
       libdatadog (~> 5.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
@@ -41,7 +41,7 @@ GEM
     crack (0.4.5)
       rexml
     cri (2.15.11)
-    datadog-ci (0.1.1)
+    datadog-ci (0.2.0)
     debase-ruby_core_source (3.2.2)
     debug_inspector (1.1.0)
     diff-lcs (1.5.0)

--- a/gemfiles/ruby_3.1_rails61_mysql2.gemfile.lock
+++ b/gemfiles/ruby_3.1_rails61_mysql2.gemfile.lock
@@ -12,7 +12,7 @@ PATH
   remote: ..
   specs:
     ddtrace (1.14.0)
-      datadog-ci (~> 0.1.0)
+      datadog-ci (~> 0.2.0)
       debase-ruby_core_source (= 3.2.2)
       libdatadog (~> 5.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
@@ -101,7 +101,7 @@ GEM
       rexml
     crass (1.0.6)
     cri (2.15.11)
-    datadog-ci (0.1.1)
+    datadog-ci (0.2.0)
     date (3.3.3)
     debase-ruby_core_source (3.2.2)
     debug_inspector (1.1.0)

--- a/gemfiles/ruby_3.1_rails61_postgres.gemfile.lock
+++ b/gemfiles/ruby_3.1_rails61_postgres.gemfile.lock
@@ -12,7 +12,7 @@ PATH
   remote: ..
   specs:
     ddtrace (1.14.0)
-      datadog-ci (~> 0.1.0)
+      datadog-ci (~> 0.2.0)
       debase-ruby_core_source (= 3.2.2)
       libdatadog (~> 5.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
@@ -101,7 +101,7 @@ GEM
       rexml
     crass (1.0.6)
     cri (2.15.11)
-    datadog-ci (0.1.1)
+    datadog-ci (0.2.0)
     date (3.3.3)
     debase-ruby_core_source (3.2.2)
     debug_inspector (1.1.0)

--- a/gemfiles/ruby_3.1_rails61_postgres_redis.gemfile.lock
+++ b/gemfiles/ruby_3.1_rails61_postgres_redis.gemfile.lock
@@ -12,7 +12,7 @@ PATH
   remote: ..
   specs:
     ddtrace (1.14.0)
-      datadog-ci (~> 0.1.0)
+      datadog-ci (~> 0.2.0)
       debase-ruby_core_source (= 3.2.2)
       libdatadog (~> 5.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
@@ -101,7 +101,7 @@ GEM
       rexml
     crass (1.0.6)
     cri (2.15.11)
-    datadog-ci (0.1.1)
+    datadog-ci (0.2.0)
     date (3.3.3)
     debase-ruby_core_source (3.2.2)
     debug_inspector (1.1.0)

--- a/gemfiles/ruby_3.1_rails61_postgres_sidekiq.gemfile.lock
+++ b/gemfiles/ruby_3.1_rails61_postgres_sidekiq.gemfile.lock
@@ -12,7 +12,7 @@ PATH
   remote: ..
   specs:
     ddtrace (1.14.0)
-      datadog-ci (~> 0.1.0)
+      datadog-ci (~> 0.2.0)
       debase-ruby_core_source (= 3.2.2)
       libdatadog (~> 5.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
@@ -102,7 +102,7 @@ GEM
       rexml
     crass (1.0.6)
     cri (2.15.11)
-    datadog-ci (0.1.1)
+    datadog-ci (0.2.0)
     date (3.3.3)
     debase-ruby_core_source (3.2.2)
     debug_inspector (1.1.0)

--- a/gemfiles/ruby_3.1_rails61_semantic_logger.gemfile.lock
+++ b/gemfiles/ruby_3.1_rails61_semantic_logger.gemfile.lock
@@ -12,7 +12,7 @@ PATH
   remote: ..
   specs:
     ddtrace (1.14.0)
-      datadog-ci (~> 0.1.0)
+      datadog-ci (~> 0.2.0)
       debase-ruby_core_source (= 3.2.2)
       libdatadog (~> 5.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
@@ -101,7 +101,7 @@ GEM
       rexml
     crass (1.0.6)
     cri (2.15.11)
-    datadog-ci (0.1.1)
+    datadog-ci (0.2.0)
     date (3.3.3)
     debase-ruby_core_source (3.2.2)
     debug_inspector (1.1.0)

--- a/gemfiles/ruby_3.1_redis_3.gemfile.lock
+++ b/gemfiles/ruby_3.1_redis_3.gemfile.lock
@@ -12,7 +12,7 @@ PATH
   remote: ..
   specs:
     ddtrace (1.14.0)
-      datadog-ci (~> 0.1.0)
+      datadog-ci (~> 0.2.0)
       debase-ruby_core_source (= 3.2.2)
       libdatadog (~> 5.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
@@ -41,7 +41,7 @@ GEM
     crack (0.4.5)
       rexml
     cri (2.15.11)
-    datadog-ci (0.1.1)
+    datadog-ci (0.2.0)
     debase-ruby_core_source (3.2.2)
     debug_inspector (1.1.0)
     diff-lcs (1.5.0)

--- a/gemfiles/ruby_3.1_redis_4.gemfile.lock
+++ b/gemfiles/ruby_3.1_redis_4.gemfile.lock
@@ -12,7 +12,7 @@ PATH
   remote: ..
   specs:
     ddtrace (1.14.0)
-      datadog-ci (~> 0.1.0)
+      datadog-ci (~> 0.2.0)
       debase-ruby_core_source (= 3.2.2)
       libdatadog (~> 5.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
@@ -41,7 +41,7 @@ GEM
     crack (0.4.5)
       rexml
     cri (2.15.11)
-    datadog-ci (0.1.1)
+    datadog-ci (0.2.0)
     debase-ruby_core_source (3.2.2)
     debug_inspector (1.1.0)
     diff-lcs (1.5.0)

--- a/gemfiles/ruby_3.1_redis_5.gemfile.lock
+++ b/gemfiles/ruby_3.1_redis_5.gemfile.lock
@@ -12,7 +12,7 @@ PATH
   remote: ..
   specs:
     ddtrace (1.14.0)
-      datadog-ci (~> 0.1.0)
+      datadog-ci (~> 0.2.0)
       debase-ruby_core_source (= 3.2.2)
       libdatadog (~> 5.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
@@ -42,7 +42,7 @@ GEM
     crack (0.4.5)
       rexml
     cri (2.15.11)
-    datadog-ci (0.1.1)
+    datadog-ci (0.2.0)
     debase-ruby_core_source (3.2.2)
     debug_inspector (1.1.0)
     diff-lcs (1.5.0)

--- a/gemfiles/ruby_3.1_relational_db.gemfile.lock
+++ b/gemfiles/ruby_3.1_relational_db.gemfile.lock
@@ -12,7 +12,7 @@ PATH
   remote: ..
   specs:
     ddtrace (1.14.0)
-      datadog-ci (~> 0.1.0)
+      datadog-ci (~> 0.2.0)
       debase-ruby_core_source (= 3.2.2)
       libdatadog (~> 5.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
@@ -51,7 +51,7 @@ GEM
     crack (0.4.5)
       rexml
     cri (2.15.11)
-    datadog-ci (0.1.1)
+    datadog-ci (0.2.0)
     debase-ruby_core_source (3.2.2)
     debug_inspector (1.1.0)
     delayed_job (4.1.11)

--- a/gemfiles/ruby_3.1_resque2_redis3.gemfile.lock
+++ b/gemfiles/ruby_3.1_resque2_redis3.gemfile.lock
@@ -12,7 +12,7 @@ PATH
   remote: ..
   specs:
     ddtrace (1.14.0)
-      datadog-ci (~> 0.1.0)
+      datadog-ci (~> 0.2.0)
       debase-ruby_core_source (= 3.2.2)
       libdatadog (~> 5.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
@@ -41,7 +41,7 @@ GEM
     crack (0.4.5)
       rexml
     cri (2.15.11)
-    datadog-ci (0.1.1)
+    datadog-ci (0.2.0)
     debase-ruby_core_source (3.2.2)
     debug_inspector (1.1.0)
     diff-lcs (1.5.0)

--- a/gemfiles/ruby_3.1_resque2_redis4.gemfile.lock
+++ b/gemfiles/ruby_3.1_resque2_redis4.gemfile.lock
@@ -12,7 +12,7 @@ PATH
   remote: ..
   specs:
     ddtrace (1.14.0)
-      datadog-ci (~> 0.1.0)
+      datadog-ci (~> 0.2.0)
       debase-ruby_core_source (= 3.2.2)
       libdatadog (~> 5.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
@@ -42,7 +42,7 @@ GEM
     crack (0.4.5)
       rexml
     cri (2.15.11)
-    datadog-ci (0.1.1)
+    datadog-ci (0.2.0)
     debase-ruby_core_source (3.2.2)
     debug_inspector (1.1.0)
     diff-lcs (1.5.0)

--- a/gemfiles/ruby_3.1_sinatra.gemfile.lock
+++ b/gemfiles/ruby_3.1_sinatra.gemfile.lock
@@ -12,7 +12,7 @@ PATH
   remote: ..
   specs:
     ddtrace (1.14.0)
-      datadog-ci (~> 0.1.0)
+      datadog-ci (~> 0.2.0)
       debase-ruby_core_source (= 3.2.2)
       libdatadog (~> 5.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
@@ -41,7 +41,7 @@ GEM
     crack (0.4.5)
       rexml
     cri (2.15.11)
-    datadog-ci (0.1.1)
+    datadog-ci (0.2.0)
     debase-ruby_core_source (3.2.2)
     debug_inspector (1.1.0)
     diff-lcs (1.5.0)

--- a/gemfiles/ruby_3.2_activesupport.gemfile.lock
+++ b/gemfiles/ruby_3.2_activesupport.gemfile.lock
@@ -12,7 +12,7 @@ PATH
   remote: ..
   specs:
     ddtrace (1.14.0)
-      datadog-ci (~> 0.1.0)
+      datadog-ci (~> 0.2.0)
       debase-ruby_core_source (= 3.2.2)
       libdatadog (~> 5.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
@@ -68,7 +68,7 @@ GEM
       rexml
     crass (1.0.6)
     cri (2.15.11)
-    datadog-ci (0.1.1)
+    datadog-ci (0.2.0)
     debase-ruby_core_source (3.2.2)
     debug_inspector (1.1.0)
     diff-lcs (1.5.0)

--- a/gemfiles/ruby_3.2_aws.gemfile.lock
+++ b/gemfiles/ruby_3.2_aws.gemfile.lock
@@ -12,7 +12,7 @@ PATH
   remote: ..
   specs:
     ddtrace (1.14.0)
-      datadog-ci (~> 0.1.0)
+      datadog-ci (~> 0.2.0)
       debase-ruby_core_source (= 3.2.2)
       libdatadog (~> 5.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
@@ -1461,7 +1461,7 @@ GEM
     crack (0.4.5)
       rexml
     cri (2.15.11)
-    datadog-ci (0.1.1)
+    datadog-ci (0.2.0)
     debase-ruby_core_source (3.2.2)
     debug_inspector (1.1.0)
     diff-lcs (1.5.0)

--- a/gemfiles/ruby_3.2_contrib.gemfile.lock
+++ b/gemfiles/ruby_3.2_contrib.gemfile.lock
@@ -12,7 +12,7 @@ PATH
   remote: ..
   specs:
     ddtrace (1.14.0)
-      datadog-ci (~> 0.1.0)
+      datadog-ci (~> 0.2.0)
       debase-ruby_core_source (= 3.2.2)
       libdatadog (~> 5.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
@@ -47,7 +47,7 @@ GEM
       rexml
     cri (2.15.11)
     dalli (3.2.4)
-    datadog-ci (0.1.1)
+    datadog-ci (0.2.0)
     debase-ruby_core_source (3.2.2)
     debug_inspector (1.1.0)
     diff-lcs (1.5.0)

--- a/gemfiles/ruby_3.2_contrib_old.gemfile.lock
+++ b/gemfiles/ruby_3.2_contrib_old.gemfile.lock
@@ -12,7 +12,7 @@ PATH
   remote: ..
   specs:
     ddtrace (1.14.0)
-      datadog-ci (~> 0.1.0)
+      datadog-ci (~> 0.2.0)
       debase-ruby_core_source (= 3.2.2)
       libdatadog (~> 5.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
@@ -45,7 +45,7 @@ GEM
     cri (2.15.11)
     daemons (1.4.1)
     dalli (2.7.11)
-    datadog-ci (0.1.1)
+    datadog-ci (0.2.0)
     debase-ruby_core_source (3.2.2)
     debug_inspector (1.1.0)
     diff-lcs (1.5.0)

--- a/gemfiles/ruby_3.2_core_old.gemfile.lock
+++ b/gemfiles/ruby_3.2_core_old.gemfile.lock
@@ -12,7 +12,7 @@ PATH
   remote: ..
   specs:
     ddtrace (1.14.0)
-      datadog-ci (~> 0.1.0)
+      datadog-ci (~> 0.2.0)
       debase-ruby_core_source (= 3.2.2)
       libdatadog (~> 5.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
@@ -40,7 +40,7 @@ GEM
     crack (0.4.5)
       rexml
     cri (2.15.11)
-    datadog-ci (0.1.1)
+    datadog-ci (0.2.0)
     debase-ruby_core_source (3.2.2)
     debug_inspector (1.1.0)
     diff-lcs (1.5.0)

--- a/gemfiles/ruby_3.2_http.gemfile.lock
+++ b/gemfiles/ruby_3.2_http.gemfile.lock
@@ -12,7 +12,7 @@ PATH
   remote: ..
   specs:
     ddtrace (1.14.0)
-      datadog-ci (~> 0.1.0)
+      datadog-ci (~> 0.2.0)
       debase-ruby_core_source (= 3.2.2)
       libdatadog (~> 5.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
@@ -40,7 +40,7 @@ GEM
     crack (0.4.5)
       rexml
     cri (2.15.11)
-    datadog-ci (0.1.1)
+    datadog-ci (0.2.0)
     debase-ruby_core_source (3.2.2)
     debug_inspector (1.1.0)
     diff-lcs (1.5.0)

--- a/gemfiles/ruby_3.2_opentelemetry.gemfile.lock
+++ b/gemfiles/ruby_3.2_opentelemetry.gemfile.lock
@@ -12,7 +12,7 @@ PATH
   remote: ..
   specs:
     ddtrace (1.14.0)
-      datadog-ci (~> 0.1.0)
+      datadog-ci (~> 0.2.0)
       debase-ruby_core_source (= 3.2.2)
       libdatadog (~> 5.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
@@ -40,7 +40,7 @@ GEM
     crack (0.4.5)
       rexml
     cri (2.15.11)
-    datadog-ci (0.1.1)
+    datadog-ci (0.2.0)
     debase-ruby_core_source (3.2.2)
     debug_inspector (1.1.0)
     diff-lcs (1.5.0)

--- a/gemfiles/ruby_3.2_opentracing.gemfile.lock
+++ b/gemfiles/ruby_3.2_opentracing.gemfile.lock
@@ -12,7 +12,7 @@ PATH
   remote: ..
   specs:
     ddtrace (1.14.0)
-      datadog-ci (~> 0.1.0)
+      datadog-ci (~> 0.2.0)
       debase-ruby_core_source (= 3.2.2)
       libdatadog (~> 5.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
@@ -41,7 +41,7 @@ GEM
     crack (0.4.5)
       rexml
     cri (2.15.11)
-    datadog-ci (0.1.1)
+    datadog-ci (0.2.0)
     debase-ruby_core_source (3.2.2)
     debug_inspector (1.1.0)
     diff-lcs (1.5.0)

--- a/gemfiles/ruby_3.2_rack_1.gemfile.lock
+++ b/gemfiles/ruby_3.2_rack_1.gemfile.lock
@@ -12,7 +12,7 @@ PATH
   remote: ..
   specs:
     ddtrace (1.14.0)
-      datadog-ci (~> 0.1.0)
+      datadog-ci (~> 0.2.0)
       debase-ruby_core_source (= 3.2.2)
       libdatadog (~> 5.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
@@ -40,7 +40,7 @@ GEM
     crack (0.4.5)
       rexml
     cri (2.15.11)
-    datadog-ci (0.1.1)
+    datadog-ci (0.2.0)
     debase-ruby_core_source (3.2.2)
     debug_inspector (1.1.0)
     diff-lcs (1.5.0)

--- a/gemfiles/ruby_3.2_rack_2.gemfile.lock
+++ b/gemfiles/ruby_3.2_rack_2.gemfile.lock
@@ -12,7 +12,7 @@ PATH
   remote: ..
   specs:
     ddtrace (1.14.0)
-      datadog-ci (~> 0.1.0)
+      datadog-ci (~> 0.2.0)
       debase-ruby_core_source (= 3.2.2)
       libdatadog (~> 5.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
@@ -40,7 +40,7 @@ GEM
     crack (0.4.5)
       rexml
     cri (2.15.11)
-    datadog-ci (0.1.1)
+    datadog-ci (0.2.0)
     debase-ruby_core_source (3.2.2)
     debug_inspector (1.1.0)
     diff-lcs (1.5.0)

--- a/gemfiles/ruby_3.2_rack_3.gemfile.lock
+++ b/gemfiles/ruby_3.2_rack_3.gemfile.lock
@@ -12,7 +12,7 @@ PATH
   remote: ..
   specs:
     ddtrace (1.14.0)
-      datadog-ci (~> 0.1.0)
+      datadog-ci (~> 0.2.0)
       debase-ruby_core_source (= 3.2.2)
       libdatadog (~> 5.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
@@ -40,7 +40,7 @@ GEM
     crack (0.4.5)
       rexml
     cri (2.15.11)
-    datadog-ci (0.1.1)
+    datadog-ci (0.2.0)
     debase-ruby_core_source (3.2.2)
     debug_inspector (1.1.0)
     diff-lcs (1.5.0)

--- a/gemfiles/ruby_3.2_rails61_mysql2.gemfile.lock
+++ b/gemfiles/ruby_3.2_rails61_mysql2.gemfile.lock
@@ -12,7 +12,7 @@ PATH
   remote: ..
   specs:
     ddtrace (1.14.0)
-      datadog-ci (~> 0.1.0)
+      datadog-ci (~> 0.2.0)
       debase-ruby_core_source (= 3.2.2)
       libdatadog (~> 5.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
@@ -100,7 +100,7 @@ GEM
       rexml
     crass (1.0.6)
     cri (2.15.11)
-    datadog-ci (0.1.1)
+    datadog-ci (0.2.0)
     date (3.3.3)
     debase-ruby_core_source (3.2.2)
     debug_inspector (1.1.0)

--- a/gemfiles/ruby_3.2_rails61_postgres.gemfile.lock
+++ b/gemfiles/ruby_3.2_rails61_postgres.gemfile.lock
@@ -12,7 +12,7 @@ PATH
   remote: ..
   specs:
     ddtrace (1.14.0)
-      datadog-ci (~> 0.1.0)
+      datadog-ci (~> 0.2.0)
       debase-ruby_core_source (= 3.2.2)
       libdatadog (~> 5.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
@@ -100,7 +100,7 @@ GEM
       rexml
     crass (1.0.6)
     cri (2.15.11)
-    datadog-ci (0.1.1)
+    datadog-ci (0.2.0)
     date (3.3.3)
     debase-ruby_core_source (3.2.2)
     debug_inspector (1.1.0)

--- a/gemfiles/ruby_3.2_rails61_postgres_redis.gemfile.lock
+++ b/gemfiles/ruby_3.2_rails61_postgres_redis.gemfile.lock
@@ -12,7 +12,7 @@ PATH
   remote: ..
   specs:
     ddtrace (1.14.0)
-      datadog-ci (~> 0.1.0)
+      datadog-ci (~> 0.2.0)
       debase-ruby_core_source (= 3.2.2)
       libdatadog (~> 5.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
@@ -100,7 +100,7 @@ GEM
       rexml
     crass (1.0.6)
     cri (2.15.11)
-    datadog-ci (0.1.1)
+    datadog-ci (0.2.0)
     date (3.3.3)
     debase-ruby_core_source (3.2.2)
     debug_inspector (1.1.0)

--- a/gemfiles/ruby_3.2_rails61_postgres_sidekiq.gemfile.lock
+++ b/gemfiles/ruby_3.2_rails61_postgres_sidekiq.gemfile.lock
@@ -12,7 +12,7 @@ PATH
   remote: ..
   specs:
     ddtrace (1.14.0)
-      datadog-ci (~> 0.1.0)
+      datadog-ci (~> 0.2.0)
       debase-ruby_core_source (= 3.2.2)
       libdatadog (~> 5.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
@@ -101,7 +101,7 @@ GEM
       rexml
     crass (1.0.6)
     cri (2.15.11)
-    datadog-ci (0.1.1)
+    datadog-ci (0.2.0)
     date (3.3.3)
     debase-ruby_core_source (3.2.2)
     debug_inspector (1.1.0)

--- a/gemfiles/ruby_3.2_rails61_semantic_logger.gemfile.lock
+++ b/gemfiles/ruby_3.2_rails61_semantic_logger.gemfile.lock
@@ -12,7 +12,7 @@ PATH
   remote: ..
   specs:
     ddtrace (1.14.0)
-      datadog-ci (~> 0.1.0)
+      datadog-ci (~> 0.2.0)
       debase-ruby_core_source (= 3.2.2)
       libdatadog (~> 5.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
@@ -100,7 +100,7 @@ GEM
       rexml
     crass (1.0.6)
     cri (2.15.11)
-    datadog-ci (0.1.1)
+    datadog-ci (0.2.0)
     date (3.3.3)
     debase-ruby_core_source (3.2.2)
     debug_inspector (1.1.0)

--- a/gemfiles/ruby_3.2_redis_3.gemfile.lock
+++ b/gemfiles/ruby_3.2_redis_3.gemfile.lock
@@ -12,7 +12,7 @@ PATH
   remote: ..
   specs:
     ddtrace (1.14.0)
-      datadog-ci (~> 0.1.0)
+      datadog-ci (~> 0.2.0)
       debase-ruby_core_source (= 3.2.2)
       libdatadog (~> 5.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
@@ -40,7 +40,7 @@ GEM
     crack (0.4.5)
       rexml
     cri (2.15.11)
-    datadog-ci (0.1.1)
+    datadog-ci (0.2.0)
     debase-ruby_core_source (3.2.2)
     debug_inspector (1.1.0)
     diff-lcs (1.5.0)

--- a/gemfiles/ruby_3.2_redis_4.gemfile.lock
+++ b/gemfiles/ruby_3.2_redis_4.gemfile.lock
@@ -12,7 +12,7 @@ PATH
   remote: ..
   specs:
     ddtrace (1.14.0)
-      datadog-ci (~> 0.1.0)
+      datadog-ci (~> 0.2.0)
       debase-ruby_core_source (= 3.2.2)
       libdatadog (~> 5.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
@@ -40,7 +40,7 @@ GEM
     crack (0.4.5)
       rexml
     cri (2.15.11)
-    datadog-ci (0.1.1)
+    datadog-ci (0.2.0)
     debase-ruby_core_source (3.2.2)
     debug_inspector (1.1.0)
     diff-lcs (1.5.0)

--- a/gemfiles/ruby_3.2_redis_5.gemfile.lock
+++ b/gemfiles/ruby_3.2_redis_5.gemfile.lock
@@ -12,7 +12,7 @@ PATH
   remote: ..
   specs:
     ddtrace (1.14.0)
-      datadog-ci (~> 0.1.0)
+      datadog-ci (~> 0.2.0)
       debase-ruby_core_source (= 3.2.2)
       libdatadog (~> 5.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
@@ -41,7 +41,7 @@ GEM
     crack (0.4.5)
       rexml
     cri (2.15.11)
-    datadog-ci (0.1.1)
+    datadog-ci (0.2.0)
     debase-ruby_core_source (3.2.2)
     debug_inspector (1.1.0)
     diff-lcs (1.5.0)

--- a/gemfiles/ruby_3.2_relational_db.gemfile.lock
+++ b/gemfiles/ruby_3.2_relational_db.gemfile.lock
@@ -12,7 +12,7 @@ PATH
   remote: ..
   specs:
     ddtrace (1.14.0)
-      datadog-ci (~> 0.1.0)
+      datadog-ci (~> 0.2.0)
       debase-ruby_core_source (= 3.2.2)
       libdatadog (~> 5.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
@@ -50,7 +50,7 @@ GEM
     crack (0.4.5)
       rexml
     cri (2.15.11)
-    datadog-ci (0.1.1)
+    datadog-ci (0.2.0)
     debase-ruby_core_source (3.2.2)
     debug_inspector (1.1.0)
     delayed_job (4.1.11)

--- a/gemfiles/ruby_3.2_resque2_redis3.gemfile.lock
+++ b/gemfiles/ruby_3.2_resque2_redis3.gemfile.lock
@@ -12,7 +12,7 @@ PATH
   remote: ..
   specs:
     ddtrace (1.14.0)
-      datadog-ci (~> 0.1.0)
+      datadog-ci (~> 0.2.0)
       debase-ruby_core_source (= 3.2.2)
       libdatadog (~> 5.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
@@ -40,7 +40,7 @@ GEM
     crack (0.4.5)
       rexml
     cri (2.15.11)
-    datadog-ci (0.1.1)
+    datadog-ci (0.2.0)
     debase-ruby_core_source (3.2.2)
     debug_inspector (1.1.0)
     diff-lcs (1.5.0)

--- a/gemfiles/ruby_3.2_resque2_redis4.gemfile.lock
+++ b/gemfiles/ruby_3.2_resque2_redis4.gemfile.lock
@@ -12,7 +12,7 @@ PATH
   remote: ..
   specs:
     ddtrace (1.14.0)
-      datadog-ci (~> 0.1.0)
+      datadog-ci (~> 0.2.0)
       debase-ruby_core_source (= 3.2.2)
       libdatadog (~> 5.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
@@ -41,7 +41,7 @@ GEM
     crack (0.4.5)
       rexml
     cri (2.15.11)
-    datadog-ci (0.1.1)
+    datadog-ci (0.2.0)
     debase-ruby_core_source (3.2.2)
     debug_inspector (1.1.0)
     diff-lcs (1.5.0)

--- a/gemfiles/ruby_3.2_sinatra.gemfile.lock
+++ b/gemfiles/ruby_3.2_sinatra.gemfile.lock
@@ -12,7 +12,7 @@ PATH
   remote: ..
   specs:
     ddtrace (1.14.0)
-      datadog-ci (~> 0.1.0)
+      datadog-ci (~> 0.2.0)
       debase-ruby_core_source (= 3.2.2)
       libdatadog (~> 5.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
@@ -40,7 +40,7 @@ GEM
     crack (0.4.5)
       rexml
     cri (2.15.11)
-    datadog-ci (0.1.1)
+    datadog-ci (0.2.0)
     debase-ruby_core_source (3.2.2)
     debug_inspector (1.1.0)
     diff-lcs (1.5.0)

--- a/gemfiles/ruby_3.3_activesupport.gemfile.lock
+++ b/gemfiles/ruby_3.3_activesupport.gemfile.lock
@@ -12,7 +12,7 @@ PATH
   remote: ..
   specs:
     ddtrace (1.14.0)
-      datadog-ci (~> 0.1.0)
+      datadog-ci (~> 0.2.0)
       debase-ruby_core_source (= 3.2.2)
       libdatadog (~> 5.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
@@ -68,7 +68,7 @@ GEM
       rexml
     crass (1.0.6)
     cri (2.15.11)
-    datadog-ci (0.1.1)
+    datadog-ci (0.2.0)
     debase-ruby_core_source (3.2.2)
     debug_inspector (1.1.0)
     diff-lcs (1.5.0)

--- a/gemfiles/ruby_3.3_aws.gemfile.lock
+++ b/gemfiles/ruby_3.3_aws.gemfile.lock
@@ -12,7 +12,7 @@ PATH
   remote: ..
   specs:
     ddtrace (1.14.0)
-      datadog-ci (~> 0.1.0)
+      datadog-ci (~> 0.2.0)
       debase-ruby_core_source (= 3.2.2)
       libdatadog (~> 5.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
@@ -1461,7 +1461,7 @@ GEM
     crack (0.4.5)
       rexml
     cri (2.15.11)
-    datadog-ci (0.1.1)
+    datadog-ci (0.2.0)
     debase-ruby_core_source (3.2.2)
     debug_inspector (1.1.0)
     diff-lcs (1.5.0)

--- a/gemfiles/ruby_3.3_contrib.gemfile.lock
+++ b/gemfiles/ruby_3.3_contrib.gemfile.lock
@@ -12,7 +12,7 @@ PATH
   remote: ..
   specs:
     ddtrace (1.14.0)
-      datadog-ci (~> 0.1.0)
+      datadog-ci (~> 0.2.0)
       debase-ruby_core_source (= 3.2.2)
       libdatadog (~> 5.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
@@ -47,7 +47,7 @@ GEM
       rexml
     cri (2.15.11)
     dalli (3.2.4)
-    datadog-ci (0.1.1)
+    datadog-ci (0.2.0)
     debase-ruby_core_source (3.2.2)
     debug_inspector (1.1.0)
     diff-lcs (1.5.0)

--- a/gemfiles/ruby_3.3_contrib_old.gemfile.lock
+++ b/gemfiles/ruby_3.3_contrib_old.gemfile.lock
@@ -12,7 +12,7 @@ PATH
   remote: ..
   specs:
     ddtrace (1.14.0)
-      datadog-ci (~> 0.1.0)
+      datadog-ci (~> 0.2.0)
       debase-ruby_core_source (= 3.2.2)
       libdatadog (~> 5.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
@@ -45,7 +45,7 @@ GEM
     cri (2.15.11)
     daemons (1.4.1)
     dalli (2.7.11)
-    datadog-ci (0.1.1)
+    datadog-ci (0.2.0)
     debase-ruby_core_source (3.2.2)
     debug_inspector (1.1.0)
     diff-lcs (1.5.0)

--- a/gemfiles/ruby_3.3_core_old.gemfile.lock
+++ b/gemfiles/ruby_3.3_core_old.gemfile.lock
@@ -12,7 +12,7 @@ PATH
   remote: ..
   specs:
     ddtrace (1.14.0)
-      datadog-ci (~> 0.1.0)
+      datadog-ci (~> 0.2.0)
       debase-ruby_core_source (= 3.2.2)
       libdatadog (~> 5.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
@@ -40,7 +40,7 @@ GEM
     crack (0.4.5)
       rexml
     cri (2.15.11)
-    datadog-ci (0.1.1)
+    datadog-ci (0.2.0)
     debase-ruby_core_source (3.2.2)
     debug_inspector (1.1.0)
     diff-lcs (1.5.0)

--- a/gemfiles/ruby_3.3_http.gemfile.lock
+++ b/gemfiles/ruby_3.3_http.gemfile.lock
@@ -12,7 +12,7 @@ PATH
   remote: ..
   specs:
     ddtrace (1.14.0)
-      datadog-ci (~> 0.1.0)
+      datadog-ci (~> 0.2.0)
       debase-ruby_core_source (= 3.2.2)
       libdatadog (~> 5.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
@@ -40,7 +40,7 @@ GEM
     crack (0.4.5)
       rexml
     cri (2.15.11)
-    datadog-ci (0.1.1)
+    datadog-ci (0.2.0)
     debase-ruby_core_source (3.2.2)
     debug_inspector (1.1.0)
     diff-lcs (1.5.0)

--- a/gemfiles/ruby_3.3_opentelemetry.gemfile.lock
+++ b/gemfiles/ruby_3.3_opentelemetry.gemfile.lock
@@ -12,7 +12,7 @@ PATH
   remote: ..
   specs:
     ddtrace (1.14.0)
-      datadog-ci (~> 0.1.0)
+      datadog-ci (~> 0.2.0)
       debase-ruby_core_source (= 3.2.2)
       libdatadog (~> 5.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
@@ -40,7 +40,7 @@ GEM
     crack (0.4.5)
       rexml
     cri (2.15.11)
-    datadog-ci (0.1.1)
+    datadog-ci (0.2.0)
     debase-ruby_core_source (3.2.2)
     debug_inspector (1.1.0)
     diff-lcs (1.5.0)

--- a/gemfiles/ruby_3.3_opentracing.gemfile.lock
+++ b/gemfiles/ruby_3.3_opentracing.gemfile.lock
@@ -12,7 +12,7 @@ PATH
   remote: ..
   specs:
     ddtrace (1.14.0)
-      datadog-ci (~> 0.1.0)
+      datadog-ci (~> 0.2.0)
       debase-ruby_core_source (= 3.2.2)
       libdatadog (~> 5.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
@@ -41,7 +41,7 @@ GEM
     crack (0.4.5)
       rexml
     cri (2.15.11)
-    datadog-ci (0.1.1)
+    datadog-ci (0.2.0)
     debase-ruby_core_source (3.2.2)
     debug_inspector (1.1.0)
     diff-lcs (1.5.0)

--- a/gemfiles/ruby_3.3_rack_1.gemfile.lock
+++ b/gemfiles/ruby_3.3_rack_1.gemfile.lock
@@ -12,7 +12,7 @@ PATH
   remote: ..
   specs:
     ddtrace (1.14.0)
-      datadog-ci (~> 0.1.0)
+      datadog-ci (~> 0.2.0)
       debase-ruby_core_source (= 3.2.2)
       libdatadog (~> 5.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
@@ -40,7 +40,7 @@ GEM
     crack (0.4.5)
       rexml
     cri (2.15.11)
-    datadog-ci (0.1.1)
+    datadog-ci (0.2.0)
     debase-ruby_core_source (3.2.2)
     debug_inspector (1.1.0)
     diff-lcs (1.5.0)

--- a/gemfiles/ruby_3.3_rack_2.gemfile.lock
+++ b/gemfiles/ruby_3.3_rack_2.gemfile.lock
@@ -12,7 +12,7 @@ PATH
   remote: ..
   specs:
     ddtrace (1.14.0)
-      datadog-ci (~> 0.1.0)
+      datadog-ci (~> 0.2.0)
       debase-ruby_core_source (= 3.2.2)
       libdatadog (~> 5.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
@@ -40,7 +40,7 @@ GEM
     crack (0.4.5)
       rexml
     cri (2.15.11)
-    datadog-ci (0.1.1)
+    datadog-ci (0.2.0)
     debase-ruby_core_source (3.2.2)
     debug_inspector (1.1.0)
     diff-lcs (1.5.0)

--- a/gemfiles/ruby_3.3_rack_3.gemfile.lock
+++ b/gemfiles/ruby_3.3_rack_3.gemfile.lock
@@ -12,7 +12,7 @@ PATH
   remote: ..
   specs:
     ddtrace (1.14.0)
-      datadog-ci (~> 0.1.0)
+      datadog-ci (~> 0.2.0)
       debase-ruby_core_source (= 3.2.2)
       libdatadog (~> 5.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
@@ -40,7 +40,7 @@ GEM
     crack (0.4.5)
       rexml
     cri (2.15.11)
-    datadog-ci (0.1.1)
+    datadog-ci (0.2.0)
     debase-ruby_core_source (3.2.2)
     debug_inspector (1.1.0)
     diff-lcs (1.5.0)

--- a/gemfiles/ruby_3.3_rails61_mysql2.gemfile.lock
+++ b/gemfiles/ruby_3.3_rails61_mysql2.gemfile.lock
@@ -12,7 +12,7 @@ PATH
   remote: ..
   specs:
     ddtrace (1.14.0)
-      datadog-ci (~> 0.1.0)
+      datadog-ci (~> 0.2.0)
       debase-ruby_core_source (= 3.2.2)
       libdatadog (~> 5.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
@@ -100,7 +100,7 @@ GEM
       rexml
     crass (1.0.6)
     cri (2.15.11)
-    datadog-ci (0.1.1)
+    datadog-ci (0.2.0)
     date (3.3.3)
     debase-ruby_core_source (3.2.2)
     debug_inspector (1.1.0)

--- a/gemfiles/ruby_3.3_rails61_postgres.gemfile.lock
+++ b/gemfiles/ruby_3.3_rails61_postgres.gemfile.lock
@@ -12,7 +12,7 @@ PATH
   remote: ..
   specs:
     ddtrace (1.14.0)
-      datadog-ci (~> 0.1.0)
+      datadog-ci (~> 0.2.0)
       debase-ruby_core_source (= 3.2.2)
       libdatadog (~> 5.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
@@ -100,7 +100,7 @@ GEM
       rexml
     crass (1.0.6)
     cri (2.15.11)
-    datadog-ci (0.1.1)
+    datadog-ci (0.2.0)
     date (3.3.3)
     debase-ruby_core_source (3.2.2)
     debug_inspector (1.1.0)

--- a/gemfiles/ruby_3.3_rails61_postgres_redis.gemfile.lock
+++ b/gemfiles/ruby_3.3_rails61_postgres_redis.gemfile.lock
@@ -12,7 +12,7 @@ PATH
   remote: ..
   specs:
     ddtrace (1.14.0)
-      datadog-ci (~> 0.1.0)
+      datadog-ci (~> 0.2.0)
       debase-ruby_core_source (= 3.2.2)
       libdatadog (~> 5.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
@@ -100,7 +100,7 @@ GEM
       rexml
     crass (1.0.6)
     cri (2.15.11)
-    datadog-ci (0.1.1)
+    datadog-ci (0.2.0)
     date (3.3.3)
     debase-ruby_core_source (3.2.2)
     debug_inspector (1.1.0)

--- a/gemfiles/ruby_3.3_rails61_postgres_sidekiq.gemfile.lock
+++ b/gemfiles/ruby_3.3_rails61_postgres_sidekiq.gemfile.lock
@@ -12,7 +12,7 @@ PATH
   remote: ..
   specs:
     ddtrace (1.14.0)
-      datadog-ci (~> 0.1.0)
+      datadog-ci (~> 0.2.0)
       debase-ruby_core_source (= 3.2.2)
       libdatadog (~> 5.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
@@ -101,7 +101,7 @@ GEM
       rexml
     crass (1.0.6)
     cri (2.15.11)
-    datadog-ci (0.1.1)
+    datadog-ci (0.2.0)
     date (3.3.3)
     debase-ruby_core_source (3.2.2)
     debug_inspector (1.1.0)

--- a/gemfiles/ruby_3.3_rails61_semantic_logger.gemfile.lock
+++ b/gemfiles/ruby_3.3_rails61_semantic_logger.gemfile.lock
@@ -12,7 +12,7 @@ PATH
   remote: ..
   specs:
     ddtrace (1.14.0)
-      datadog-ci (~> 0.1.0)
+      datadog-ci (~> 0.2.0)
       debase-ruby_core_source (= 3.2.2)
       libdatadog (~> 5.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
@@ -100,7 +100,7 @@ GEM
       rexml
     crass (1.0.6)
     cri (2.15.11)
-    datadog-ci (0.1.1)
+    datadog-ci (0.2.0)
     date (3.3.3)
     debase-ruby_core_source (3.2.2)
     debug_inspector (1.1.0)

--- a/gemfiles/ruby_3.3_redis_3.gemfile.lock
+++ b/gemfiles/ruby_3.3_redis_3.gemfile.lock
@@ -12,7 +12,7 @@ PATH
   remote: ..
   specs:
     ddtrace (1.14.0)
-      datadog-ci (~> 0.1.0)
+      datadog-ci (~> 0.2.0)
       debase-ruby_core_source (= 3.2.2)
       libdatadog (~> 5.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
@@ -40,7 +40,7 @@ GEM
     crack (0.4.5)
       rexml
     cri (2.15.11)
-    datadog-ci (0.1.1)
+    datadog-ci (0.2.0)
     debase-ruby_core_source (3.2.2)
     debug_inspector (1.1.0)
     diff-lcs (1.5.0)

--- a/gemfiles/ruby_3.3_redis_4.gemfile.lock
+++ b/gemfiles/ruby_3.3_redis_4.gemfile.lock
@@ -12,7 +12,7 @@ PATH
   remote: ..
   specs:
     ddtrace (1.14.0)
-      datadog-ci (~> 0.1.0)
+      datadog-ci (~> 0.2.0)
       debase-ruby_core_source (= 3.2.2)
       libdatadog (~> 5.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
@@ -40,7 +40,7 @@ GEM
     crack (0.4.5)
       rexml
     cri (2.15.11)
-    datadog-ci (0.1.1)
+    datadog-ci (0.2.0)
     debase-ruby_core_source (3.2.2)
     debug_inspector (1.1.0)
     diff-lcs (1.5.0)

--- a/gemfiles/ruby_3.3_redis_5.gemfile.lock
+++ b/gemfiles/ruby_3.3_redis_5.gemfile.lock
@@ -12,7 +12,7 @@ PATH
   remote: ..
   specs:
     ddtrace (1.14.0)
-      datadog-ci (~> 0.1.0)
+      datadog-ci (~> 0.2.0)
       debase-ruby_core_source (= 3.2.2)
       libdatadog (~> 5.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
@@ -41,7 +41,7 @@ GEM
     crack (0.4.5)
       rexml
     cri (2.15.11)
-    datadog-ci (0.1.1)
+    datadog-ci (0.2.0)
     debase-ruby_core_source (3.2.2)
     debug_inspector (1.1.0)
     diff-lcs (1.5.0)

--- a/gemfiles/ruby_3.3_relational_db.gemfile.lock
+++ b/gemfiles/ruby_3.3_relational_db.gemfile.lock
@@ -12,7 +12,7 @@ PATH
   remote: ..
   specs:
     ddtrace (1.14.0)
-      datadog-ci (~> 0.1.0)
+      datadog-ci (~> 0.2.0)
       debase-ruby_core_source (= 3.2.2)
       libdatadog (~> 5.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
@@ -50,7 +50,7 @@ GEM
     crack (0.4.5)
       rexml
     cri (2.15.11)
-    datadog-ci (0.1.1)
+    datadog-ci (0.2.0)
     debase-ruby_core_source (3.2.2)
     debug_inspector (1.1.0)
     delayed_job (4.1.11)

--- a/gemfiles/ruby_3.3_resque2_redis3.gemfile.lock
+++ b/gemfiles/ruby_3.3_resque2_redis3.gemfile.lock
@@ -12,7 +12,7 @@ PATH
   remote: ..
   specs:
     ddtrace (1.14.0)
-      datadog-ci (~> 0.1.0)
+      datadog-ci (~> 0.2.0)
       debase-ruby_core_source (= 3.2.2)
       libdatadog (~> 5.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
@@ -40,7 +40,7 @@ GEM
     crack (0.4.5)
       rexml
     cri (2.15.11)
-    datadog-ci (0.1.1)
+    datadog-ci (0.2.0)
     debase-ruby_core_source (3.2.2)
     debug_inspector (1.1.0)
     diff-lcs (1.5.0)

--- a/gemfiles/ruby_3.3_resque2_redis4.gemfile.lock
+++ b/gemfiles/ruby_3.3_resque2_redis4.gemfile.lock
@@ -12,7 +12,7 @@ PATH
   remote: ..
   specs:
     ddtrace (1.14.0)
-      datadog-ci (~> 0.1.0)
+      datadog-ci (~> 0.2.0)
       debase-ruby_core_source (= 3.2.2)
       libdatadog (~> 5.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
@@ -41,7 +41,7 @@ GEM
     crack (0.4.5)
       rexml
     cri (2.15.11)
-    datadog-ci (0.1.1)
+    datadog-ci (0.2.0)
     debase-ruby_core_source (3.2.2)
     debug_inspector (1.1.0)
     diff-lcs (1.5.0)

--- a/gemfiles/ruby_3.3_sinatra.gemfile.lock
+++ b/gemfiles/ruby_3.3_sinatra.gemfile.lock
@@ -12,7 +12,7 @@ PATH
   remote: ..
   specs:
     ddtrace (1.14.0)
-      datadog-ci (~> 0.1.0)
+      datadog-ci (~> 0.2.0)
       debase-ruby_core_source (= 3.2.2)
       libdatadog (~> 5.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
@@ -40,7 +40,7 @@ GEM
     crack (0.4.5)
       rexml
     cri (2.15.11)
-    datadog-ci (0.1.1)
+    datadog-ci (0.2.0)
     debase-ruby_core_source (3.2.2)
     debug_inspector (1.1.0)
     diff-lcs (1.5.0)


### PR DESCRIPTION
**What does this PR do?**
Bumps datadog-ci runtime dependency to 0.2

[Release notes](https://github.com/DataDog/datadog-ci-rb/releases/tag/v0.2.0):

Added
- Agentless mode

Fixed
- Fix an issue with emojis in commit message breaking LocalGit tags provider

**Motivation:**
Introducing agentless mode for CI visibility product

**How to test the change?**
```bash
git clone https://github.com/DataDog/test-environment

cd test-environment

yarn

cd dd-trace-rb/jekyll
bundle add ddtrace --git "https://github.com/DataDog/dd-trace-rb.git" --branch "anmarchenko/ci_vis_0.2" --skip-install
bundle install --path .bundle
cd ../..

yarn test dd-trace-rb/jekyll.test.js

cd dd-trace-rb/devdocs
bundle add ddtrace --git "https://github.com/DataDog/dd-trace-rb.git" --branch "anmarchenko/ci_vis_0.2" --skip-install
bundle install --path .bundle
cd ../..

yarn test dd-trace-rb/devdocs.test.js

```

**For Datadog employees:**
- [ ] If this PR touches code that signs or publishes builds or packages, or handles
credentials of any kind, I've requested a review from `@DataDog/security-design-and-guidance`.
- [x] This PR doesn't touch any of that.

