### PR TITLE
skip passing waf addresses when the value is empty

### DIFF
--- a/lib/datadog/appsec/processor.rb
+++ b/lib/datadog/appsec/processor.rb
@@ -22,9 +22,16 @@ module Datadog
 
           start_ns = Core::Utils::Time.get_time(:nanosecond)
 
-          cleaned_input = remove_empty_entries(input)
+          input.reject! do |_, v|
+            case v
+            when TrueClass, FalseClass
+              false
+            else
+              v.nil? ? true : v.empty?
+            end
+          end
 
-          _code, res = @context.run(cleaned_input, timeout)
+          _code, res = @context.run(input, timeout)
 
           stop_ns = Core::Utils::Time.get_time(:nanosecond)
 
@@ -61,18 +68,6 @@ module Datadog
         def extract_schema?
           Datadog.configuration.appsec.api_security.enabled &&
             Datadog.configuration.appsec.api_security.sample_rate.sample?
-        end
-
-        def remove_empty_entries(entries)
-          entries.each_with_object({}) do |(k, v), acc|
-            acc[k] = v unless empty_value?(v)
-          end
-        end
-
-        def empty_value?(v)
-          return true unless v
-
-          v.empty?
         end
       end
 

--- a/lib/datadog/appsec/processor.rb
+++ b/lib/datadog/appsec/processor.rb
@@ -22,7 +22,9 @@ module Datadog
 
           start_ns = Core::Utils::Time.get_time(:nanosecond)
 
-          _code, res = @context.run(input, timeout)
+          cleaned_input = remove_empty_entries(input)
+
+          _code, res = @context.run(cleaned_input, timeout)
 
           stop_ns = Core::Utils::Time.get_time(:nanosecond)
 
@@ -59,6 +61,18 @@ module Datadog
         def extract_schema?
           Datadog.configuration.appsec.api_security.enabled &&
             Datadog.configuration.appsec.api_security.sample_rate.sample?
+        end
+
+        def remove_empty_entries(entries)
+          entries.each_with_object({}) do |(k, v), acc|
+            acc[k] = v unless empty_value?(v)
+          end
+        end
+
+        def empty_value?(v)
+          return true unless v
+
+          v.empty?
         end
       end
 

--- a/sig/datadog/appsec/processor.rbs
+++ b/sig/datadog/appsec/processor.rbs
@@ -15,14 +15,12 @@ module Datadog
         @run_mutex: ::Thread::Mutex
 
         def initialize: (Processor processor) -> void
-        def run: (data input, ?::Integer timeout) -> WAF::Result
+        def run: (Hash[untyped, untyped] input, ?::Integer timeout) -> WAF::Result
         def extract_schema: () -> WAF::Result?
         def finalize: () -> void
 
         private
         def extract_schema?: () -> bool
-        def remove_empty_entries: (untyped entries) -> data
-        def empty_value?: (untyped v) -> bool
       end
 
       def self.active_context: () -> Context

--- a/sig/datadog/appsec/processor.rbs
+++ b/sig/datadog/appsec/processor.rbs
@@ -21,6 +21,8 @@ module Datadog
 
         private
         def extract_schema?: () -> bool
+        def remove_empty_entries: (untyped entries) -> data
+        def empty_value?: (untyped v) -> bool
       end
 
       def self.active_context: () -> Context

--- a/spec/datadog/appsec/processor_spec.rb
+++ b/spec/datadog/appsec/processor_spec.rb
@@ -233,6 +233,18 @@ RSpec.describe Datadog::AppSec::Processor::Context do
         context.run(input, timeout)
       end
 
+      it 'do not removes boolean values' do
+        input = {
+          'false_value' => false,
+          'true_value' => true
+        }
+        expect(context.instance_variable_get(:@context)).to receive(:run).with(
+          input, timeout
+        ).and_call_original
+
+        context.run(input, timeout)
+      end
+
       it 'removes empty string values' do
         input = {
           'empty_string_value' => '',

--- a/spec/datadog/appsec/processor_spec.rb
+++ b/spec/datadog/appsec/processor_spec.rb
@@ -217,6 +217,68 @@ RSpec.describe Datadog::AppSec::Processor::Context do
       matches.map(&:actions)
     end
 
+    context 'clear key with empty values' do
+      it 'removes nil values' do
+        input = {
+          'nil_value' => nil,
+          'string_value' => 'hello'
+        }
+        expect(context.instance_variable_get(:@context)).to receive(:run).with(
+          {
+            'string_value' => 'hello'
+          },
+          timeout
+        ).and_call_original
+
+        context.run(input, timeout)
+      end
+
+      it 'removes empty string values' do
+        input = {
+          'empty_string_value' => '',
+          'string_value' => 'hello'
+        }
+        expect(context.instance_variable_get(:@context)).to receive(:run).with(
+          {
+            'string_value' => 'hello'
+          },
+          timeout
+        ).and_call_original
+
+        context.run(input, timeout)
+      end
+
+      it 'removes empty arrays values' do
+        input = {
+          'empty_array' => [],
+          'non_empty_array_value' => [1, 2],
+        }
+        expect(context.instance_variable_get(:@context)).to receive(:run).with(
+          {
+            'non_empty_array_value' => [1, 2]
+          },
+          timeout
+        ).and_call_original
+
+        context.run(input, timeout)
+      end
+
+      it 'removes empty hash values' do
+        input = {
+          'empty_hash' => {},
+          'non_empty_hash_value' => { 'hello' => 'world' },
+        }
+        expect(context.instance_variable_get(:@context)).to receive(:run).with(
+          {
+            'non_empty_hash_value' => { 'hello' => 'world' }
+          },
+          timeout
+        ).and_call_original
+
+        context.run(input, timeout)
+      end
+    end
+
     context 'no attack' do
       let(:input) { input_safe }
 


### PR DESCRIPTION
<!--
Check out the
https://github.com/DataDog/dd-trace-rb/blob/master/docs/DevelopmentGuide.md
for guidance on how to set up your development environment,
run the test suite, write new integrations, and more.
-->

**What does this PR do?**
<!-- A brief description of the change being made with this pull request. -->

We remove empty and nil WAF Addresses before sending it to the WAF to be processed.

**Motivation:**
<!-- What inspired you to submit this pull request? -->

**Additional Notes:**
<!-- Anything else we should know when reviewing? -->

**How to test the change?**
<!--
Describe here how the change can be validated.
You are strongly encouraged to provide automated tests for this PR (unit or integration).
If this change cannot be feasibly tested, please explain why,
unless the change does not modify code (e.g. only modifies docs, comments).
-->

**For Datadog employees:**
- [ ] If this PR touches code that signs or publishes builds or packages, or handles
credentials of any kind, I've requested a review from `@DataDog/security-design-and-guidance`.
- [ ] This PR doesn't touch any of that.

Unsure? Have a question? Request a review!
