### PR TITLE
Reduce permission for milestone GitHub Action

### DIFF
--- a/.github/workflows/add-milestone-to-pull-requests.yml
+++ b/.github/workflows/add-milestone-to-pull-requests.yml
@@ -7,9 +7,14 @@ on:
 
 jobs:
   add_milestone_to_merged:
+    permissions:
+      pull-requests: write
+
     if: github.event.pull_request.merged && github.event.pull_request.milestone == null
+
     name: Add milestone to merged pull requests
     runs-on: ubuntu-latest
+
     steps:
       - name: Get project milestones
         id: milestones


### PR DESCRIPTION
This PR reduces the permission of the `add-milestone-to-pull-requests` GitHub Action to the minimum possible.

This is specially important on GitHub Actions that use the `pull_request_target` trigger, because it can run on pull requests by external contributors (which is what we want for this tagger action). More details about the dangers of `pull_request_target` here: https://securitylab.github.com/research/github-actions-preventing-pwn-requests/
Despite these concerns, `pull_request_target` is the trigger we want because we do want external pull requests to trigger this Action and have permission to edit the milestone of a pull request (a write permission).

## Notes

The only other action using, the `pull-request-labeler`, already has minimum permissions declared, thanks to well-documented default permissions by the Action author: https://github.com/DataDog/dd-trace-rb/blob/5e27525874aeeaae9205b6bdbd9a1c29ad8d4b8f/.github/workflows/pull-request-labeler.yml#L7-L9
