### PR TITLE
Reduce permissions to Action for creating next milestone

### DIFF
--- a/.github/workflows/create-next-milestone.yml
+++ b/.github/workflows/create-next-milestone.yml
@@ -5,6 +5,9 @@ on:
 
 jobs:
   create_next_milestone:
+    permissions:
+      issues: write
+
     runs-on: ubuntu-latest
     steps:
       - name: Get next minor version


### PR DESCRIPTION
Similar to #3193, this PR reduces the permission to the `create-next-milestone` GitHub Action.

This action does not carry the same concern as #3193 because it does not execute based on external pull requests, but this is a step towards changing our default GitHub Actions token to read only.