### PR TITLE
Upgrade steep typechecker to latest version 1.5.3

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -113,7 +113,7 @@ end
 group :check do
   if RUBY_VERSION >= '3.0.0' && RUBY_PLATFORM != 'java'
     gem 'rbs', '~> 3.2.0', require: false
-    gem 'steep', '~> 1.4.0', require: false
+    gem 'steep', '~> 1.5.3', require: false
   end
 end
 

--- a/Steepfile
+++ b/Steepfile
@@ -32,6 +32,7 @@ target :ddtrace do
   ignore 'lib/datadog/appsec/contrib/sinatra/request_middleware.rb'
   ignore 'lib/datadog/appsec/monitor/gateway/watcher.rb'
   ignore 'lib/datadog/appsec/monitor/reactive/set_user.rb'
+  ignore 'lib/datadog/appsec/processor/rule_merger.rb'
   ignore 'lib/datadog/ci.rb'
   ignore 'lib/datadog/ci/configuration/components.rb'
   ignore 'lib/datadog/ci/configuration/settings.rb'

--- a/Steepfile
+++ b/Steepfile
@@ -32,7 +32,6 @@ target :ddtrace do
   ignore 'lib/datadog/appsec/contrib/sinatra/request_middleware.rb'
   ignore 'lib/datadog/appsec/monitor/gateway/watcher.rb'
   ignore 'lib/datadog/appsec/monitor/reactive/set_user.rb'
-  ignore 'lib/datadog/appsec/processor/rule_merger.rb'
   ignore 'lib/datadog/ci.rb'
   ignore 'lib/datadog/ci/configuration/components.rb'
   ignore 'lib/datadog/ci/configuration/settings.rb'

--- a/sig/datadog/appsec/processor/rule_merger.rbs
+++ b/sig/datadog/appsec/processor/rule_merger.rbs
@@ -8,16 +8,16 @@ module Datadog
 
         type rules = ::Hash[::String, untyped]
         type data = ::Array[::Hash[::String, untyped]]
-        type overrides = ::Array[::Hash[::String, untyped]]
-        type exclusions = ::Array[::Hash[::String, untyped]]
-        type custom_rules = ::Array[::Hash[::String, untyped]]
+        type overrides = ::Array[::Array[::Hash[::String, untyped]]]
+        type exclusions = ::Array[::Array[::Hash[::String, untyped]]]
+        type custom_rules = ::Array[::Array[::Hash[::String, untyped]]]
         type processors = ::Array[::Hash[::String, untyped]]
         type scanners = ::Array[::Hash[::String, untyped]]
 
         DEFAULT_WAF_PROCESSORS: processors
         DEFAULT_WAF_SCANNERS: processors
 
-        def self.merge: (rules: ::Array[rules], ?data: ::Array[data], ?overrides: ::Array[overrides], ?exclusions: ::Array[exclusions], ?custom_rules: ::Array[custom_rules], ?processors: processors, ?scanners: scanners) -> rules
+        def self.merge: (rules: ::Array[rules], ?data: ::Array[data], ?overrides: overrides, ?exclusions: exclusions, ?custom_rules: custom_rules, ?processors: processors, ?scanners: scanners) -> rules
 
         private
 
@@ -25,13 +25,13 @@ module Datadog
 
         def self.combine_data: (::Array[data] data) -> data?
 
-        def self.merge_data_base_on_expiration: (data data1, data data2) -> ::Array[data]
+        def self.merge_data_base_on_expiration: (data data1, data data2) -> data
 
-        def self.combine_overrides: (::Array[overrides] overrides) -> ::Array[overrides]?
+        def self.combine_overrides: (overrides overrides) -> overrides?
 
-        def self.combine_exclusions: (::Array[exclusions] exclusions) -> ::Array[exclusions]?
+        def self.combine_exclusions: (exclusions exclusions) -> exclusions?
 
-        def self.combine_custom_rules: (::Array[custom_rules] custom_rules) -> ::Array[custom_rules]?
+        def self.combine_custom_rules: (custom_rules custom_rules) -> custom_rules?
       end
     end
   end


### PR DESCRIPTION
**What does this PR do?**

This PR upgrades the steep typechecker to the latest version available, 1.5.3.

It also disables type-checking one of the appsec files that started failing typechecking with this version.

**Motivation:**

Use latest version of typechecker.

**Additional Notes:**

~Here's the full error message for the failing appsec file:~

The issue with the ASM file has been fix with https://github.com/DataDog/dd-trace-rb/pull/3198/commits/7f147ecc2736a14b40b31f00675387e42782f8a8

**How to test the change?**

Observe that typecheck still passes in CI.

**For Datadog employees:**
- [ ] If this PR touches code that signs or publishes builds or packages, or handles
credentials of any kind, I've requested a review from `@DataDog/security-design-and-guidance`.
- [x] This PR doesn't touch any of that.