### PR TITLE
ASM make sure to append content type and length information

### DIFF
--- a/lib/datadog/appsec/contrib/rack/gateway/request.rb
+++ b/lib/datadog/appsec/contrib/rack/gateway/request.rb
@@ -40,9 +40,13 @@ module Datadog
             end
 
             def headers
-              request.env.each_with_object({}) do |(k, v), h|
-                h[k.gsub(/^HTTP_/, '').downcase.tr('_', '-')] = v if k =~ /^HTTP_/
+              result = request.env.each_with_object({}) do |(k, v), h|
+                h[k.gsub(/^HTTP_/, '').downcase!.tr('_', '-')] = v if k =~ /^HTTP_/
               end
+
+              result['content-type'] = request.content_type if request.content_type
+              result['content-length'] = request.content_length if request.content_length
+              result
             end
 
             def body

--- a/spec/datadog/appsec/contrib/rack/gateway/request_spec.rb
+++ b/spec/datadog/appsec/contrib/rack/gateway/request_spec.rb
@@ -10,7 +10,7 @@ RSpec.describe Datadog::AppSec::Contrib::Rack::Gateway::Request do
       Rack::MockRequest.env_for(
         'http://example.com:8080/?a=foo&a=bar&b=baz',
         {
-          'REQUEST_METHOD' => 'GET', 'REMOTE_ADDR' => '10.10.10.10', 'HTTP_CONTENT_TYPE' => 'text/html',
+          'REQUEST_METHOD' => 'GET', 'REMOTE_ADDR' => '10.10.10.10', 'CONTENT_TYPE' => 'text/html',
           'HTTP_COOKIE' => 'foo=bar', 'HTTP_USER_AGENT' => 'WebKit'
         }
       )
@@ -24,8 +24,13 @@ RSpec.describe Datadog::AppSec::Contrib::Rack::Gateway::Request do
   end
 
   describe '#headers' do
-    it 'returns the header information and strip the HTTP_ prefix' do
-      expected_headers = { 'content-type' => 'text/html', 'cookie' => 'foo=bar', 'user-agent' => 'WebKit' }
+    it 'returns the header information. Strip the HTTP_ prefix and append content-type and content-length information' do
+      expected_headers = {
+        'content-type' => 'text/html',
+        'cookie' => 'foo=bar',
+        'user-agent' => 'WebKit',
+        'content-length' => '0'
+      }
       expect(request.headers).to eq(expected_headers)
     end
   end

--- a/spec/datadog/appsec/contrib/rack/reactive/request_spec.rb
+++ b/spec/datadog/appsec/contrib/rack/reactive/request_spec.rb
@@ -12,19 +12,34 @@ RSpec.describe Datadog::AppSec::Contrib::Rack::Reactive::Request do
     Datadog::AppSec::Contrib::Rack::Gateway::Request.new(
       Rack::MockRequest.env_for(
         'http://example.com:8080/?a=foo',
-        { 'REQUEST_METHOD' => 'GET', 'REMOTE_ADDR' => '10.10.10.10', 'HTTP_CONTENT_TYPE' => 'text/html' }
+        {
+          'REQUEST_METHOD' => 'GET',
+          'REMOTE_ADDR' => '10.10.10.10',
+          'CONTENT_TYPE' => 'text/html',
+          'HTTP_USER_AGENT' => 'foo',
+          'HTTP_COOKIE' => 'foo=bar'
+        }
       )
     )
+  end
+
+  let(:expected_headers_with_cookies) do
+    { 'content-length' => '0', 'content-type' => 'text/html', 'user-agent' => 'foo', 'cookie' => 'foo=bar' }
+  end
+
+  let(:expected_headers_without_cookies) do
+    { 'content-length' => '0', 'content-type' => 'text/html', 'user-agent' => 'foo' }
   end
 
   describe '.publish' do
     it 'propagates request attributes to the operation' do
       expect(operation).to receive(:publish).with('server.request.method', 'GET')
       expect(operation).to receive(:publish).with('request.query', { 'a' => ['foo'] })
-      expect(operation).to receive(:publish).with('request.headers', { 'content-type' => 'text/html' })
+      expect(operation).to receive(:publish).with('request.headers', expected_headers_with_cookies)
       expect(operation).to receive(:publish).with('request.uri.raw', '/?a=foo')
-      expect(operation).to receive(:publish).with('request.cookies', {})
+      expect(operation).to receive(:publish).with('request.cookies', { 'foo' => 'bar' })
       expect(operation).to receive(:publish).with('request.client_ip', '10.10.10.10')
+
       described_class.publish(operation, request)
     end
   end
@@ -52,11 +67,11 @@ RSpec.describe Datadog::AppSec::Contrib::Rack::Reactive::Request do
         expect(operation).to receive(:subscribe).and_call_original
 
         expected_waf_arguments = {
-          'server.request.cookies' => {},
+          'server.request.cookies' => { 'foo' => 'bar' },
           'server.request.query' => { 'a' => ['foo'] },
           'server.request.uri.raw' => '/?a=foo',
-          'server.request.headers' => { 'content-type' => 'text/html' },
-          'server.request.headers.no_cookies' => { 'content-type' => 'text/html' },
+          'server.request.headers' => expected_headers_with_cookies,
+          'server.request.headers.no_cookies' => expected_headers_without_cookies,
           'http.client_ip' => '10.10.10.10',
           'server.request.method' => 'GET',
         }

--- a/spec/datadog/appsec/event_spec.rb
+++ b/spec/datadog/appsec/event_spec.rb
@@ -2,217 +2,311 @@ require 'datadog/appsec/spec_helper'
 require 'datadog/appsec/event'
 
 RSpec.describe Datadog::AppSec::Event do
-  context 'self' do
-    describe '#record' do
-      before do
-        # prevent rate limiter to bias tests
-        Datadog::AppSec::RateLimiter.reset!(:traces)
-      end
-
-      let(:options) { {} }
-      let(:trace_op) { Datadog::Tracing::TraceOperation.new(**options) }
-      let(:trace) { trace_op.flush! }
-
-      let(:rack_request) do
-        dbl = double
-
-        allow(dbl).to receive(:host).and_return('example.com')
-        allow(dbl).to receive(:user_agent).and_return('Ruby/0.0')
-        allow(dbl).to receive(:remote_addr).and_return('127.0.0.1')
-
-        allow(dbl).to receive(:headers).and_return [
-          ['user-agent', 'Ruby/0.0'],
-          ['SERVER_NAME', 'example.com'],
-          ['REMOTE_ADDR', '127.0.0.1']
+  context 'ALLOWED_REQUEST_HEADERS' do
+    it 'store the correct values' do
+      expect(described_class::ALLOWED_REQUEST_HEADERS).to eq(
+        [
+          'x-forwarded-for',
+          'x-client-ip',
+          'x-real-ip',
+          'x-forwarded',
+          'x-cluster-client-ip',
+          'forwarded-for',
+          'forwarded',
+          'via',
+          'true-client-ip',
+          'content-length',
+          'content-type',
+          'content-encoding',
+          'content-language',
+          'host',
+          'user-agent',
+          'accept',
+          'accept-encoding',
+          'accept-language'
         ]
+      )
+    end
+  end
 
-        dbl
+  context 'ALLOWED_RESPONSE_HEADERS' do
+    it 'store the correct values' do
+      expect(described_class::ALLOWED_RESPONSE_HEADERS).to eq(
+        [
+          'content-length',
+          'content-type',
+          'content-encoding',
+          'content-language'
+        ]
+      )
+    end
+  end
+
+  describe '.record' do
+    before do
+      # prevent rate limiter to bias tests
+      Datadog::AppSec::RateLimiter.reset!(:traces)
+    end
+
+    let(:options) { {} }
+    let(:trace_op) { Datadog::Tracing::TraceOperation.new(**options) }
+    let(:trace) { trace_op.flush! }
+
+    let(:rack_request_headers) do
+      {
+        'user-agent' => 'Ruby/0.0',
+        'SERVER_NAME' => 'example.com',
+        'REMOTE_ADDR' => '127.0.0.1',
+      }
+    end
+
+    let(:rack_response_headers) do
+      {
+        'content-type' => 'text/html'
+      }
+    end
+
+    let(:rack_request) do
+      dbl = double
+
+      allow(dbl).to receive(:host).and_return('example.com')
+      allow(dbl).to receive(:user_agent).and_return('Ruby/0.0')
+      allow(dbl).to receive(:remote_addr).and_return('127.0.0.1')
+
+      allow(dbl).to receive(:headers).and_return(rack_request_headers)
+
+      dbl
+    end
+
+    let(:rack_response) do
+      dbl = double
+
+      allow(dbl).to receive(:headers).and_return(rack_response_headers)
+
+      dbl
+    end
+
+    let(:waf_events) do
+      [1, { a: :b }]
+    end
+
+    let(:waf_result) do
+      dbl = double
+
+      allow(dbl).to receive(:events).and_return(waf_events)
+      allow(dbl).to receive(:derivatives).and_return(derivatives)
+
+      dbl
+    end
+
+    let(:event_count) { 1 }
+    let(:derivatives) { {} }
+
+    let(:events) do
+      Array.new(event_count) do
+        {
+          trace: trace_op,
+          span: nil, # backfilled later
+          request: rack_request,
+          response: rack_response,
+          waf_result: waf_result,
+        }
       end
+    end
 
-      let(:rack_response) do
-        dbl = double
+    context 'with one event' do
+      let(:trace) do
+        trace_op.measure('request') do |span|
+          events.each { |e| e[:span] = span }
 
-        allow(dbl).to receive(:headers).and_return([])
-
-        dbl
-      end
-
-      let(:waf_result) do
-        dbl = double
-
-        allow(dbl).to receive(:events).and_return([])
-        allow(dbl).to receive(:derivatives).and_return(derivatives)
-
-        dbl
-      end
-
-      let(:event_count) { 1 }
-      let(:derivatives) { {} }
-
-      let(:events) do
-        Array.new(event_count) do
-          {
-            trace: trace_op,
-            span: nil, # backfilled later
-            request: rack_request,
-            response: rack_response,
-            waf_result: waf_result,
-          }
-        end
-      end
-
-      context 'with one event' do
-        let(:trace) do
-          trace_op.measure('request') do |span|
-            events.each { |e| e[:span] = span }
-
-            10.times do |i|
-              trace_op.measure("span #{i}") {}
-            end
-
-            described_class.record(span, *events)
+          10.times do |i|
+            trace_op.measure("span #{i}") {}
           end
 
-          trace_op.flush!
+          described_class.record(span, *events)
         end
 
-        let(:top_level_span) do
-          trace.spans.find { |s| s.metrics['_dd.top_level'] && s.metrics['_dd.top_level'] > 0.0 }
-        end
+        trace_op.flush!
+      end
 
-        let(:other_spans) do
-          trace.spans - [top_level_span]
-        end
+      let(:top_level_span) do
+        trace.spans.find { |s| s.metrics['_dd.top_level'] && s.metrics['_dd.top_level'] > 0.0 }
+      end
 
-        it 'records an event on the top level span' do
-          expect(top_level_span.meta).to eq(
-            '_dd.appsec.json' => '{"triggers":[]}',
-            'http.host' => 'example.com',
-            'http.useragent' => 'Ruby/0.0',
-            'http.request.headers.user-agent' => 'Ruby/0.0',
-            'network.client.ip' => '127.0.0.1',
-            '_dd.origin' => 'appsec',
-          )
-        end
+      let(:other_spans) do
+        trace.spans - [top_level_span]
+      end
 
-        it 'records nothing on other spans' do
-          other_spans.each do |other_span|
-            expect(other_span.meta).to be_empty
+      context 'request headers' do
+        context 'allowed headers' do
+          it 'records allowed headers' do
+            expect(top_level_span.meta).to include('http.request.headers.user-agent' => 'Ruby/0.0')
           end
         end
 
-        it 'marks the trace to be kept' do
-          expect(trace.sampling_priority).to eq Datadog::Tracing::Sampling::Ext::Priority::USER_KEEP
-        end
-
-        context 'waf_result derivatives' do
-          let(:derivatives) do
+        context 'discard not allowed headers' do
+          let(:rack_request_headers) do
             {
-              '_dd.appsec.s.req.headers' => [{ 'host' => [8], 'version' => [8] }]
+              'not-supported-header' => 'foo',
             }
           end
 
-          context 'JSON payload' do
-            it 'uses JSON string when do not exceeds MIN_SCHEMA_SIZE_FOR_COMPRESSION' do
-              stub_const('Datadog::AppSec::Event::MIN_SCHEMA_SIZE_FOR_COMPRESSION', 3000)
-              meta = top_level_span.meta
-
-              expect(meta['_dd.appsec.s.req.headers']).to eq('[{"host":[8],"version":[8]}]')
-            end
-          end
-
-          context 'Compressed payload' do
-            it 'uses compressed value when JSON string is bigger than MIN_SCHEMA_SIZE_FOR_COMPRESSION' do
-              result = "H4sIAOYoHGUAA4aphwAAAA=\n"
-              stub_const('Datadog::AppSec::Event::MIN_SCHEMA_SIZE_FOR_COMPRESSION', 1)
-              expect(described_class).to receive(:compressed_and_base64_encoded).and_return(result)
-
-              meta = top_level_span.meta
-
-              expect(meta['_dd.appsec.s.req.headers']).to eq(result)
-            end
-          end
-
-          context 'derivative values exceed Event::MAX_ENCODED_SCHEMA_SIZE value' do
-            it 'do not add derivative key to meta' do
-              stub_const('Datadog::AppSec::Event::MAX_ENCODED_SCHEMA_SIZE', 1)
-              meta = top_level_span.meta
-
-              expect(meta['_dd.appsec.s.req.headers']).to be_nil
-            end
+          it 'does not records allowed headers' do
+            expect(top_level_span.meta).to_not include('http.request.headers.not-supported-header')
           end
         end
       end
 
-      context 'with no event' do
-        let(:event_count) { 0 }
+      context 'response headers' do
+        context 'allowed headers' do
+          it 'records allowed headers' do
+            expect(top_level_span.meta).to include('http.response.headers.content-type' => 'text/html')
+          end
+        end
 
-        let(:trace) do
+        context 'discard not allowed headers' do
+          let(:rack_response_headers) do
+            {
+              'not-supported-header' => 'foo',
+            }
+          end
+
+          it 'does not records allowed headers' do
+            expect(top_level_span.meta).to_not include('http.response.headers.not-supported-header')
+          end
+        end
+      end
+
+      context 'http information' do
+        it 'records http information' do
+          expect(top_level_span.meta).to include('http.host' => 'example.com')
+          expect(top_level_span.meta).to include('http.useragent' => 'Ruby/0.0')
+          expect(top_level_span.meta).to include('network.client.ip' => '127.0.0.1')
+        end
+      end
+
+      it 'records an event on the top level span' do
+        expect(top_level_span.meta).to include('_dd.appsec.json' => '{"triggers":[1,{"a":"b"}]}')
+        expect(top_level_span.meta).to include('_dd.origin' => 'appsec')
+      end
+
+      it 'records nothing on other spans' do
+        other_spans.each do |other_span|
+          expect(other_span.meta).to be_empty
+        end
+      end
+
+      it 'marks the trace to be kept' do
+        expect(trace.sampling_priority).to eq Datadog::Tracing::Sampling::Ext::Priority::USER_KEEP
+      end
+
+      context 'waf_result derivatives' do
+        let(:derivatives) do
+          {
+            '_dd.appsec.s.req.headers' => [{ 'host' => [8], 'version' => [8] }]
+          }
+        end
+
+        context 'JSON payload' do
+          it 'uses JSON string when do not exceeds MIN_SCHEMA_SIZE_FOR_COMPRESSION' do
+            stub_const('Datadog::AppSec::Event::MIN_SCHEMA_SIZE_FOR_COMPRESSION', 3000)
+            meta = top_level_span.meta
+
+            expect(meta['_dd.appsec.s.req.headers']).to eq('[{"host":[8],"version":[8]}]')
+          end
+        end
+
+        context 'Compressed payload' do
+          it 'uses compressed value when JSON string is bigger than MIN_SCHEMA_SIZE_FOR_COMPRESSION' do
+            result = "H4sIAOYoHGUAA4aphwAAAA=\n"
+            stub_const('Datadog::AppSec::Event::MIN_SCHEMA_SIZE_FOR_COMPRESSION', 1)
+            expect(described_class).to receive(:compressed_and_base64_encoded).and_return(result)
+
+            meta = top_level_span.meta
+
+            expect(meta['_dd.appsec.s.req.headers']).to eq(result)
+          end
+        end
+
+        context 'derivative values exceed Event::MAX_ENCODED_SCHEMA_SIZE value' do
+          it 'do not add derivative key to meta' do
+            stub_const('Datadog::AppSec::Event::MAX_ENCODED_SCHEMA_SIZE', 1)
+            meta = top_level_span.meta
+
+            expect(meta['_dd.appsec.s.req.headers']).to be_nil
+          end
+        end
+      end
+    end
+
+    context 'with no event' do
+      let(:event_count) { 0 }
+
+      let(:trace) do
+        trace_op.measure('request') do |span|
+          events.each { |e| e[:span] = span }
+
+          described_class.record(span, *events)
+        end
+
+        trace_op.flush!
+      end
+
+      it 'does not mark the trace to be kept' do
+        expect(trace.sampling_priority).to eq nil
+      end
+
+      it 'does not attempt to record in the trace' do
+        expect(described_class).to_not receive(:record_via_span)
+
+        expect(trace).to_not be nil
+      end
+
+      it 'does not call the rate limiter' do
+        expect(Datadog::AppSec::RateLimiter).to_not receive(:limit)
+
+        expect(trace).to_not be nil
+      end
+    end
+
+    context 'with no span' do
+      let(:event_count) { 1 }
+
+      it 'does not attempt to record in the trace' do
+        expect(described_class).to_not receive(:record_via_span)
+
+        described_class.record(nil, events)
+      end
+
+      it 'does not call the rate limiter' do
+        expect(Datadog::AppSec::RateLimiter).to_not receive(:limit)
+
+        described_class.record(nil, events)
+      end
+    end
+
+    context 'with many traces' do
+      let(:rate_limit) { 100 }
+      let(:trace_count) { rate_limit * 2 }
+
+      let(:traces) do
+        Array.new(trace_count) do
+          trace_op = Datadog::Tracing::TraceOperation.new(**options)
+
           trace_op.measure('request') do |span|
             events.each { |e| e[:span] = span }
 
             described_class.record(span, *events)
           end
 
-          trace_op.flush!
-        end
-
-        it 'does not mark the trace to be kept' do
-          expect(trace.sampling_priority).to eq nil
-        end
-
-        it 'does not attempt to record in the trace' do
-          expect(described_class).to_not receive(:record_via_span)
-
-          expect(trace).to_not be nil
-        end
-
-        it 'does not call the rate limiter' do
-          expect(Datadog::AppSec::RateLimiter).to_not receive(:limit)
-
-          expect(trace).to_not be nil
+          trace_op.keep!
         end
       end
 
-      context 'with no span' do
-        let(:event_count) { 1 }
+      it 'rate limits event recording' do
+        expect(described_class).to receive(:record_via_span).exactly(rate_limit).times.and_call_original
 
-        it 'does not attempt to record in the trace' do
-          expect(described_class).to_not receive(:record_via_span)
-
-          described_class.record(nil, events)
-        end
-
-        it 'does not call the rate limiter' do
-          expect(Datadog::AppSec::RateLimiter).to_not receive(:limit)
-
-          described_class.record(nil, events)
-        end
-      end
-
-      context 'with many traces' do
-        let(:rate_limit) { 100 }
-        let(:trace_count) { rate_limit * 2 }
-
-        let(:traces) do
-          Array.new(trace_count) do
-            trace_op = Datadog::Tracing::TraceOperation.new(**options)
-
-            trace_op.measure('request') do |span|
-              events.each { |e| e[:span] = span }
-
-              described_class.record(span, *events)
-            end
-
-            trace_op.keep!
-          end
-        end
-
-        it 'rate limits event recording' do
-          expect(described_class).to receive(:record_via_span).exactly(rate_limit).times.and_call_original
-
-          expect(traces).to have_attributes(count: trace_count)
-        end
+        expect(traces).to have_attributes(count: trace_count)
       end
     end
   end


### PR DESCRIPTION
<!--
Check out the
https://github.com/DataDog/dd-trace-rb/blob/master/docs/DevelopmentGuide.md
for guidance on how to set up your development environment,
run the test suite, write new integrations, and more.
-->

**What does this PR do?**
<!-- A brief description of the change being made with this pull request. -->

On ASM, append HTTP request information as part of the top-level span. 

The code that collects the request header assumes we are interested in all header requests starting with `HTTP_`.  Those headers are set by the client following the [RFC3875 section 4.1.18](https://tools.ietf.org/html/rfc3875#section-4.1.18) 

Unfortunately, that is not the case for specific headers that are specified by the server. For example, `Content-Type` and `Content-Length` are not prefixed with `HTTP_`  

The variables are called CGI server variables. [Here is the list](https://www6.uniovi.es/~antonio/ncsa_httpd/cgi/env.html)

This PR appends the content type and content length information and improves our specs.

**Motivation:**
<!-- What inspired you to submit this pull request? -->

**Additional Notes:**
<!-- Anything else we should know when reviewing? -->

**How to test the change?**
<!--
Describe here how the change can be validated.
You are strongly encouraged to provide automated tests for this PR (unit or integration).
If this change cannot be feasibly tested, please explain why,
unless the change does not modify code (e.g. only modifies docs, comments).
-->

**For Datadog employees:**
- [ ] If this PR touches code that signs or publishes builds or packages, or handles
credentials of any kind, I've requested a review from `@DataDog/security-design-and-guidance`.
- [ ] This PR doesn't touch any of that.

Unsure? Have a question? Request a review!
