### PR TITLE
Name `Datadog::Core::Remote::Worker` thread

### DIFF
--- a/lib/datadog/core/remote/worker.rb
+++ b/lib/datadog/core/remote/worker.rb
@@ -29,6 +29,7 @@ module Datadog
           @starting = true
 
           @thr = Thread.new { poll(@interval) }
+          @thr.name = self.class.name unless Gem::Version.new(RUBY_VERSION) < Gem::Version.new('2.3')
 
           @started = true
           @starting = false

--- a/lib/datadog/core/remote/worker.rb
+++ b/lib/datadog/core/remote/worker.rb
@@ -28,8 +28,9 @@ module Datadog
 
           @starting = true
 
-          @thr = Thread.new { poll(@interval) }
-          @thr.name = self.class.name unless Gem::Version.new(RUBY_VERSION) < Gem::Version.new('2.3')
+          thread = Thread.new { poll(@interval) }
+          thread.name = self.class.name unless Gem::Version.new(RUBY_VERSION) < Gem::Version.new('2.3')
+          @thr = thread
 
           @started = true
           @starting = false

--- a/spec/datadog/core/remote/worker_spec.rb
+++ b/spec/datadog/core/remote/worker_spec.rb
@@ -48,6 +48,12 @@ RSpec.describe Datadog::Core::Remote::Worker do
         expect(result).to eq([1])
       end
     end
+
+    it 'names the worker thread' do
+      worker.start
+
+      expect(Thread.list.map(&:name)).to include(described_class.to_s)
+    end
   end
 
   describe '#stop' do

--- a/spec/datadog/core/remote/worker_spec.rb
+++ b/spec/datadog/core/remote/worker_spec.rb
@@ -49,10 +49,16 @@ RSpec.describe Datadog::Core::Remote::Worker do
       end
     end
 
-    it 'names the worker thread' do
-      worker.start
+    context 'on Ruby >= 2.3' do
+      before do
+        skip 'Not supported on old Rubies' if Gem::Version.new(RUBY_VERSION) < Gem::Version.new('2.3')
+      end
 
-      expect(Thread.list.map(&:name)).to include(described_class.to_s)
+      it 'names the worker thread' do
+        worker.start
+
+        expect(Thread.list.map(&:name)).to include(described_class.to_s)
+      end
     end
   end
 


### PR DESCRIPTION
**What does this PR do?**

This PR sets the name of the thread started by the `Datadog::Core::Remote::Worker` class (to be the name of the class).

This follows the same pattern we use for other dd-trace-rb internal threads.

**Motivation:**

The profiler shows thread names in multiple places, and nameless threads make it harder to see the data in several cases, so as much as possible we want to avoid them.

One particular case is that for the timeline feature, we collapse all dd-trace-rb threads by default, but that collapsing feature relies on thread names, and so the remote worker thread was not being properly collapsed (which is how I spotted it).

**Additional Notes:**

I've chosen to still include the Ruby 2.2/2.1 support because I plan to backport this to the 1.x branch.

**How to test the change?**

This change includes test coverage. You can also enable the profiler and check that when looking at thread names (right sidebar in single and aggregated profiles; left side for timeline) you will see the thread for this class properly named.

**For Datadog employees:**
- [ ] If this PR touches code that signs or publishes builds or packages, or handles
credentials of any kind, I've requested a review from `@DataDog/security-design-and-guidance`.
- [x] This PR doesn't touch any of that.
