### PR TITLE
[CIVIS-7720] instrumented_integrations returns empty hash if tracing config is not extended by Tracing::Contrib::Extensions

### DIFF
--- a/lib/datadog/tracing/diagnostics/environment_logger.rb
+++ b/lib/datadog/tracing/diagnostics/environment_logger.rb
@@ -137,8 +137,10 @@ module Datadog
           private
 
           def instrumented_integrations
-            # `instrumented_integrations` method is added only if tracing contrib extensions are required
-            # If tracing is used in manual mode without integrations enabled this method does not exist
+            # `instrumented_integrations` method is added only if tracing contrib extensions are required.
+            # If tracing is used in manual mode without integrations enabled this method does not exist.
+            # CI visibility gem datadog-ci uses Datadog::Tracer without requiring datadog/tracing/contrib folder
+            # nor enabling any integrations by default which causes EnvironmentCollector to fail.
             return {} unless Datadog.configuration.tracing.respond_to?(:instrumented_integrations)
 
             Datadog.configuration.tracing.instrumented_integrations

--- a/lib/datadog/tracing/diagnostics/environment_logger.rb
+++ b/lib/datadog/tracing/diagnostics/environment_logger.rb
@@ -137,6 +137,10 @@ module Datadog
           private
 
           def instrumented_integrations
+            # `instrumented_integrations` method is added only if tracing contrib extensions are required
+            # If tracing is used in manual mode without integrations enabled this method does not exist
+            return {} unless Datadog.configuration.tracing.respond_to?(:instrumented_integrations)
+
             Datadog.configuration.tracing.instrumented_integrations
           end
 


### PR DESCRIPTION
**What does this PR do?**
`Datadog::Tracing::Diagnostics::EnvironmentLogger::EnvironmentCollector.instrumented_integrations` check if tracing config responds to `instrumented_integrations` method and returns an empty hash otherwise.

**Motivation:**
When using Tracer manually without tracing integrations in CI mode, the following error is getting spammed to logs:

```
WARN -- ddtrace: [ddtrace] Failed to collect tracing environment information: undefined method `instrumented_integrations' for #<#Class:0x00000001034942e8:0x0000000103798a48 @options={:enabled=>#<Datadog::Core::Configuration::Option:0x000000010388b4a0 @definition=#<Datadog::Core::Configuration::OptionDefinition:0x00000001034924e8 @default=true, @default_proc=nil, @env="DD_TRACE_ENABLED", @deprecated_env=nil, @env_parser=nil, @name=:"tracing.enabled", @after_set=nil, @resetter=nil, @setter=#<Proc:0x0000000103472788 /Users/andrey.marchenko/.rbenv/versions/3.2.2/lib/rub
```

**Additional Notes:**
Other possible way to fix it:
- require `contrib/extensions` from tracer.rb file
- makes EnvironmentLogger configurable to be able to turn it off for CI

**How to test the change?**
Tested by running tests instrumented by CI visibility locally to confirm that error does not happen.

It is not feasible to add a unit test for this as in specs contrib settings are already required.

**For Datadog employees:**
- [ ] If this PR touches code that signs or publishes builds or packages, or handles
credentials of any kind, I've requested a review from `@DataDog/security-design-and-guidance`.
- [x] This PR doesn't touch any of that.

