### PR TITLE
Action:Prevent Update Gemfiles running on merge target

### DIFF
--- a/.github/workflows/update-gemfiles.yml
+++ b/.github/workflows/update-gemfiles.yml
@@ -35,6 +35,8 @@ jobs:
       - name: Check if this branch is attached to a Pull Request
         uses: 8bitjonny/gh-get-current-pr@2215326c76d51bfa3f2af0a470f32677f6c0cae9 # v2.2.0
         id: pr
+        with:
+          filterOutClosed: true # Don't trigger on commits with closed PRs, including merges into `master`.
       - if: steps.pr.outputs.pr_found == 'true'
         uses: actions/checkout@v4
       # And also, only execute if files that can affect gemfiles are modified.


### PR DESCRIPTION
After merging #3149, the job ran on the `master` merge commit.
This was not intended, and happened because the GH Action was able to find a PR associated with the commit, making it think that `master` is a branch the user is currently working on.

This PR ensures that the Action does not run for commits that belong to a PR that is not longer active (e.g. merged or closed).