### PR TITLE
RFC: Remove tracer threads integration test

### DIFF
--- a/spec/datadog/integration_spec.rb
+++ b/spec/datadog/integration_spec.rb
@@ -21,27 +21,6 @@ RSpec.describe 'Datadog integration' do
       try_wait_until { Datadog::Tracing.send(:tracer).writer.transport.stats.success > 0 }
     end
 
-    context 'for threads' do
-      let(:original_threads) { Thread.list }
-      let!(:original_threads_inspect) { inspect_threads(original_threads) } # Store result as stack trace will change
-      let(:threads) { Thread.list }
-
-      def inspect_threads(threads)
-        threads.map.with_index { |t, idx| "#{idx}=#{t.backtrace}" }.join(';')
-      end
-
-      it 'closes tracer threads' do
-        start_tracer
-        wait_for_tracer_sent
-
-        shutdown
-
-        expect(threads.size).to eq(original_threads.size),
-          "Expected #{original_threads.size} threads (#{original_threads_inspect}), "\
-                  "got #{threads.size} threads (#{inspect_threads(threads)})"
-      end
-    end
-
     context 'for file descriptors' do
       def open_file_descriptors
         # Unix-specific way to get the current process' open file descriptors and the files (if any) they correspond to


### PR DESCRIPTION
**What does this PR do?**

As discussed during last week's meeting, I'm opening this PR to discuss the removal of this long-standing flaky test.

See
<https://app.circleci.com/pipelines/github/DataDog/dd-trace-rb/12281/workflows/f4763f8c-d024-405b-bc00-cae3c5cecc0c/jobs/462118> for a recent example of it failing.

**Motivation:**

Avoid CI flakiness by either fixing or disabling/removing flaky tests.

**Additional Notes:**

N/A

**How to test the change?**

Observe that CI is green :)

**For Datadog employees:**
- [ ] If this PR touches code that signs or publishes builds or packages, or handles
credentials of any kind, I've requested a review from `@DataDog/security-design-and-guidance`.
- [x] This PR doesn't touch any of that.