### PR TITLE
Backport #3197 to 1.x-stable: Shut down profiler if any components failed

### DIFF
--- a/lib/datadog/profiling/collectors/cpu_and_wall_time_worker.rb
+++ b/lib/datadog/profiling/collectors/cpu_and_wall_time_worker.rb
@@ -53,7 +53,7 @@ module Datadog
           @idle_sampling_helper = idle_sampling_helper
         end
 
-        def start
+        def start(on_failure_proc: nil)
           @start_stop_mutex.synchronize do
             return if @worker_thread && @worker_thread.alive?
 
@@ -74,6 +74,7 @@ module Datadog
                   'CpuAndWallTimeWorker thread error. ' \
                   "Cause: #{e.class.name} #{e.message} Location: #{Array(e.backtrace).first}"
                 )
+                on_failure_proc&.call
               end
             end
             @worker_thread.name = self.class.name # Repeated from above to make sure thread gets named asap

--- a/lib/datadog/profiling/profiler.rb
+++ b/lib/datadog/profiling/profiler.rb
@@ -21,17 +21,41 @@ module Datadog
           scheduler.reset_after_fork
         end
 
-        worker.start
-        scheduler.start
+        worker.start(on_failure_proc: proc { component_failed(:worker) })
+        scheduler.start(on_failure_proc: proc { component_failed(:scheduler) })
       end
 
       def shutdown!
         Datadog.logger.debug('Shutting down profiler')
 
-        worker.stop
+        stop_worker
+        stop_scheduler
+      end
 
+      private
+
+      def stop_worker
+        worker.stop
+      end
+
+      def stop_scheduler
         scheduler.enabled = false
         scheduler.stop(true)
+      end
+
+      def component_failed(failed_component)
+        Datadog.logger.warn(
+          "Detected issue with profiler (#{failed_component} component), stopping profiling. " \
+          'See previous log messages for details.'
+        )
+
+        if failed_component == :worker
+          stop_scheduler
+        elsif failed_component == :scheduler
+          stop_worker
+        else
+          raise ArgumentError, "Unexpected failed_component: #{failed_component.inspect}"
+        end
       end
     end
   end

--- a/lib/datadog/profiling/scheduler.rb
+++ b/lib/datadog/profiling/scheduler.rb
@@ -45,22 +45,31 @@ module Datadog
         self.enabled = enabled
       end
 
-      def start
-        perform
+      def start(on_failure_proc: nil)
+        perform(on_failure_proc)
       end
 
-      def perform
-        # A profiling flush may be called while the VM is shutting down, to report the last profile. When we do so,
-        # we impose a strict timeout. This means this last profile may or may not be sent, depending on if the flush can
-        # successfully finish in the strict timeout.
-        # This can be somewhat confusing (why did it not get reported?), so let's at least log what happened.
-        interrupted = true
-
+      def perform(on_failure_proc)
         begin
-          flush_and_wait
-          interrupted = false
-        ensure
-          Datadog.logger.debug('#flush was interrupted or failed before it could complete') if interrupted
+          # A profiling flush may be called while the VM is shutting down, to report the last profile. When we do so,
+          # we impose a strict timeout. This means this last profile may or may not be sent, depending on if the flush can
+          # successfully finish in the strict timeout.
+          # This can be somewhat confusing (why did it not get reported?), so let's at least log what happened.
+          interrupted = true
+
+          begin
+            flush_and_wait
+            interrupted = false
+          ensure
+            Datadog.logger.debug('#flush was interrupted or failed before it could complete') if interrupted
+          end
+        rescue Exception => e # rubocop:disable Lint/RescueException
+          Datadog.logger.warn(
+            'Profiling::Scheduler thread error. ' \
+            "Cause: #{e.class.name} #{e.message} Location: #{Array(e.backtrace).first}"
+          )
+          on_failure_proc&.call
+          raise
         end
       end
 

--- a/lib/datadog/profiling/scheduler.rb
+++ b/lib/datadog/profiling/scheduler.rb
@@ -57,12 +57,8 @@ module Datadog
           # This can be somewhat confusing (why did it not get reported?), so let's at least log what happened.
           interrupted = true
 
-          begin
-            flush_and_wait
-            interrupted = false
-          ensure
-            Datadog.logger.debug('#flush was interrupted or failed before it could complete') if interrupted
-          end
+          flush_and_wait
+          interrupted = false
         rescue Exception => e # rubocop:disable Lint/RescueException
           Datadog.logger.warn(
             'Profiling::Scheduler thread error. ' \
@@ -70,6 +66,8 @@ module Datadog
           )
           on_failure_proc&.call
           raise
+        ensure
+          Datadog.logger.debug('#flush was interrupted or failed before it could complete') if interrupted
         end
       end
 

--- a/sig/datadog/profiling/collectors/cpu_and_wall_time_worker.rbs
+++ b/sig/datadog/profiling/collectors/cpu_and_wall_time_worker.rbs
@@ -28,7 +28,7 @@ module Datadog
           ::Integer allocation_sample_every,
         ) -> true
 
-        def start: () -> bool?
+        def start: (?on_failure_proc: ::Proc?) -> bool?
 
         def stop: () -> void
         def self._native_stop: (CpuAndWallTimeWorker self_instance, ::Thread worker_thread) -> true

--- a/sig/datadog/profiling/profiler.rbs
+++ b/sig/datadog/profiling/profiler.rbs
@@ -18,6 +18,12 @@ module Datadog
       def start: () -> void
 
       def shutdown!: () -> void
+
+      private
+
+      def stop_worker: () -> void
+      def stop_scheduler: () -> void
+      def component_failed: (:worker | :scheduler failed_component) -> void
     end
   end
 end

--- a/sig/datadog/profiling/scheduler.rbs
+++ b/sig/datadog/profiling/scheduler.rbs
@@ -11,7 +11,7 @@ module Datadog
         ?enabled: bool,
       ) -> void
 
-      def start: () -> void
+      def start: (?on_failure_proc: ::Proc?) -> void
 
       def reset_after_fork: () -> void
     end

--- a/spec/datadog/profiling/collectors/cpu_and_wall_time_worker_spec.rb
+++ b/spec/datadog/profiling/collectors/cpu_and_wall_time_worker_spec.rb
@@ -526,6 +526,19 @@ RSpec.describe Datadog::Profiling::Collectors::CpuAndWallTimeWorker do
         process_waiter_thread.join
       end
     end
+
+    context 'when the _native_sampling_loop terminates with an exception' do
+      it 'calls the on_failure_proc' do
+        expect(described_class).to receive(:_native_sampling_loop).and_raise(StandardError.new('Simulated error'))
+        expect(Datadog.logger).to receive(:warn)
+
+        proc_called = Queue.new
+
+        cpu_and_wall_time_worker.start(on_failure_proc: proc { proc_called << true })
+
+        proc_called.pop
+      end
+    end
   end
 
   describe 'Ractor safety' do

--- a/spec/datadog/profiling/collectors/cpu_and_wall_time_worker_spec.rb
+++ b/spec/datadog/profiling/collectors/cpu_and_wall_time_worker_spec.rb
@@ -1,8 +1,11 @@
 require 'datadog/profiling/spec_helper'
-require 'datadog/profiling/collectors/cpu_and_wall_time_worker'
 
-RSpec.describe Datadog::Profiling::Collectors::CpuAndWallTimeWorker do
+RSpec.describe 'Datadog::Profiling::Collectors::CpuAndWallTimeWorker' do
   before { skip_if_profiling_not_supported(self) }
+
+  # This is needed because this class uses syntax that doesn't work on Ruby 2.1/2.2; we can undo this once dd-trace-rb
+  # drops support for these Rubies globally
+  let(:described_class) { Datadog::Profiling::Collectors::CpuAndWallTimeWorker }
 
   let(:recorder) { build_stack_recorder }
   let(:endpoint_collection_enabled) { true }

--- a/spec/datadog/profiling/scheduler_spec.rb
+++ b/spec/datadog/profiling/scheduler_spec.rb
@@ -1,15 +1,16 @@
-require 'spec_helper'
+require 'datadog/profiling/spec_helper'
 
-require 'datadog/profiling/http_transport'
-require 'datadog/profiling/exporter'
-require 'datadog/profiling/scheduler'
+RSpec.describe 'Datadog::Profiling::Scheduler' do
+  before { skip_if_profiling_not_supported(self) }
 
-RSpec.describe Datadog::Profiling::Scheduler do
-  subject(:scheduler) { described_class.new(exporter: exporter, transport: transport, **options) }
-
+  # This is needed because this class uses syntax that doesn't work on Ruby 2.1/2.2; we can undo this once dd-trace-rb
+  # drops support for these Rubies globally
+  let(:described_class) { Datadog::Profiling::Scheduler }
   let(:exporter) { instance_double(Datadog::Profiling::Exporter) }
   let(:transport) { instance_double(Datadog::Profiling::HttpTransport) }
   let(:options) { {} }
+
+  subject(:scheduler) { described_class.new(exporter: exporter, transport: transport, **options) }
 
   describe '.new' do
     describe 'default settings' do
@@ -129,7 +130,7 @@ RSpec.describe Datadog::Profiling::Scheduler do
       let(:options) { { **super(), interval: 0.01 } }
 
       # Assert that the interval isn't set below the min interval
-      it "floors the wait interval to #{described_class.const_get(:MINIMUM_INTERVAL_SECONDS)}" do
+      it 'floors the wait interval to MINIMUM_INTERVAL_SECONDS' do
         expect(scheduler).to receive(:loop_wait_time=)
           .with(described_class.const_get(:MINIMUM_INTERVAL_SECONDS))
 

--- a/spec/datadog/profiling/scheduler_spec.rb
+++ b/spec/datadog/profiling/scheduler_spec.rb
@@ -84,6 +84,9 @@ RSpec.describe 'Datadog::Profiling::Scheduler' do
       end
 
       context 'when perform fails' do
+        before { Thread.report_on_exception = false if Thread.respond_to?(:report_on_exception=) }
+        after  { Thread.report_on_exception = true  if Thread.respond_to?(:report_on_exception=) }
+
         it 'calls the on_failure_proc and logs the error' do
           expect(scheduler).to receive(:flush_and_wait).and_raise(StandardError.new('Simulated error'))
 


### PR DESCRIPTION
This is a backport of https://github.com/DataDog/dd-trace-rb/pull/3197 to the 1.x-stable branch.

I merely rebased the commits on top of the other branch, with no other changes.