### PR TITLE
Backport #3207 to 1.x-stable: Name `Datadog::Core::Remote::Worker` thread

### DIFF
--- a/lib/datadog/core/remote/worker.rb
+++ b/lib/datadog/core/remote/worker.rb
@@ -29,6 +29,7 @@ module Datadog
           @starting = true
 
           @thr = Thread.new { poll(@interval) }
+          @thr.name = self.class.name unless Gem::Version.new(RUBY_VERSION) < Gem::Version.new('2.3')
 
           @started = true
           @starting = false

--- a/lib/datadog/core/remote/worker.rb
+++ b/lib/datadog/core/remote/worker.rb
@@ -28,8 +28,9 @@ module Datadog
 
           @starting = true
 
-          @thr = Thread.new { poll(@interval) }
-          @thr.name = self.class.name unless Gem::Version.new(RUBY_VERSION) < Gem::Version.new('2.3')
+          thread = Thread.new { poll(@interval) }
+          thread.name = self.class.name unless Gem::Version.new(RUBY_VERSION) < Gem::Version.new('2.3')
+          @thr = thread
 
           @started = true
           @starting = false

--- a/spec/datadog/core/remote/worker_spec.rb
+++ b/spec/datadog/core/remote/worker_spec.rb
@@ -48,6 +48,12 @@ RSpec.describe Datadog::Core::Remote::Worker do
         expect(result).to eq([1])
       end
     end
+
+    it 'names the worker thread' do
+      worker.start
+
+      expect(Thread.list.map(&:name)).to include(described_class.to_s)
+    end
   end
 
   describe '#stop' do

--- a/spec/datadog/core/remote/worker_spec.rb
+++ b/spec/datadog/core/remote/worker_spec.rb
@@ -49,10 +49,16 @@ RSpec.describe Datadog::Core::Remote::Worker do
       end
     end
 
-    it 'names the worker thread' do
-      worker.start
+    context 'on Ruby >= 2.3' do
+      before do
+        skip 'Not supported on old Rubies' if Gem::Version.new(RUBY_VERSION) < Gem::Version.new('2.3')
+      end
 
-      expect(Thread.list.map(&:name)).to include(described_class.to_s)
+      it 'names the worker thread' do
+        worker.start
+
+        expect(Thread.list.map(&:name)).to include(described_class.to_s)
+      end
     end
   end
 


### PR DESCRIPTION
This is a backport of https://github.com/DataDog/dd-trace-rb/pull/3207 to the 1.x-stable branch.

I merely rebased the commits on top of the other branch, with no other changes.