### PR TITLE
Action:Fix PR milestone action

### DIFF
--- a/.github/workflows/add-milestone-to-pull-requests.yml
+++ b/.github/workflows/add-milestone-to-pull-requests.yml
@@ -8,6 +8,8 @@ on:
 jobs:
   add_milestone_to_merged:
     permissions:
+      # These two permissions are needed to modify milestone, even though only one should be enough
+      issues: write
       pull-requests: write
 
     if: github.event.pull_request.merged && github.event.pull_request.milestone == null
@@ -18,11 +20,11 @@ jobs:
     steps:
       - name: Get project milestones
         id: milestones
-        uses: actions/github-script@0.9.0
+        uses: actions/github-script@v6
         with:
           github-token: ${{secrets.GITHUB_TOKEN}}
           script: |
-            const list = await github.issues.listMilestonesForRepo({
+            const list = await github.rest.issues.listMilestones({
               owner: context.repo.owner,
               repo: context.repo.repo,
               state: 'open'
@@ -34,12 +36,12 @@ jobs:
             return milestones.length == 0 ? null : milestones[0].number
       - name: Update Pull Request
         if: steps.milestones.outputs.result != null
-        uses: actions/github-script@0.9.0
+        uses: actions/github-script@v6
         with:
           github-token: ${{secrets.GITHUB_TOKEN}}
           script: |
             // Confusingly, the issues api is used because pull requests are issues
-            await github.issues.update({
+            await github.rest.issues.update({
               owner: context.repo.owner,
               repo: context.repo.repo,
               issue_number: ${{ github.event.pull_request.number }},


### PR DESCRIPTION
This PR fixes the permission for the `.github/workflows/add-milestone-to-pull-requests.yml` workflow, which attaches milestones to PRs.

I think there's something weird going on here because the octokit calls from the workflow returned 200, but did not modify the milestone AND the listed permission required for updating a pull request do not seem to coincide with reality: I think it's a GH bug.

### Other comments 

It also upgrades the GitHub actions used in the workflow as it was using a very very old version, which used node12 and GitHub has been complaining that node12 is deprecated:
```
The following actions uses node12 which is deprecated and will be forced to run on node16: actions/github-script@0.9.0. For more info: https://github.blog/changelog/2023-06-13-github-actions-all-actions-will-run-on-node16-instead-of-node12-by-default/
```