### PR TITLE
rename ENV var for ASM API Security response body parsing and enable by default

### DIFF
--- a/.gitlab/benchmarks.yml
+++ b/.gitlab/benchmarks.yml
@@ -127,6 +127,7 @@ candidate-tracer-appsec-with-api-security:
     DD_APPSEC_ENABLED: "true"
     DD_EXPERIMENTAL_API_SECURITY_ENABLED: "true"
     DD_API_SECURITY_REQUEST_SAMPLE_RATE: "1.0"
+    DD_API_SECURITY_PARSE_RESPONSE_BODY: "false"
 
 candidate-tracer-appsec-with-api-security-and-parse-response-body:
   extends: .benchmarks
@@ -136,7 +137,6 @@ candidate-tracer-appsec-with-api-security-and-parse-response-body:
     DD_APPSEC_ENABLED: "true"
     DD_EXPERIMENTAL_API_SECURITY_ENABLED: "true"
     DD_API_SECURITY_REQUEST_SAMPLE_RATE: "1.0"
-    DD_API_SECURITY_PARSE_RESPONSE_BODY: "true"
 
 # -----------------------------------------------------
 # Microbenchmarks that report to statsd

--- a/.gitlab/benchmarks.yml
+++ b/.gitlab/benchmarks.yml
@@ -127,16 +127,16 @@ candidate-tracer-appsec-with-api-security:
     DD_APPSEC_ENABLED: "true"
     DD_EXPERIMENTAL_API_SECURITY_ENABLED: "true"
     DD_API_SECURITY_REQUEST_SAMPLE_RATE: "1.0"
-    DD_API_SECURITY_PARSE_RESPONSE_BODY: "false"
 
-candidate-tracer-appsec-with-api-security-and-parse-response-body:
+candidate-tracer-appsec-with-api-security-without-response-body:
   extends: .benchmarks
   variables:
-    DD_BENCHMARKS_CONFIGURATION: "tracing-and-appsec-with-api-security-and-parsed-body"
+    DD_BENCHMARKS_CONFIGURATION: "tracing-and-appsec-with-api-security-without-response-body"
     DD_PROFILING_ENABLED: "false"
     DD_APPSEC_ENABLED: "true"
     DD_EXPERIMENTAL_API_SECURITY_ENABLED: "true"
     DD_API_SECURITY_REQUEST_SAMPLE_RATE: "1.0"
+    DD_API_SECURITY_PARSE_RESPONSE_BODY: "false"
 
 # -----------------------------------------------------
 # Microbenchmarks that report to statsd

--- a/.gitlab/benchmarks.yml
+++ b/.gitlab/benchmarks.yml
@@ -136,7 +136,7 @@ candidate-tracer-appsec-with-api-security-and-parse-response-body:
     DD_APPSEC_ENABLED: "true"
     DD_EXPERIMENTAL_API_SECURITY_ENABLED: "true"
     DD_API_SECURITY_REQUEST_SAMPLE_RATE: "1.0"
-    DD_EXPERIMENTAL_API_SECURITY_PARSE_RESPONSE_BODY: "true"
+    DD_API_SECURITY_PARSE_RESPONSE_BODY: "true"
 
 # -----------------------------------------------------
 # Microbenchmarks that report to statsd

--- a/lib/datadog/appsec/configuration/settings.rb
+++ b/lib/datadog/appsec/configuration/settings.rb
@@ -192,7 +192,7 @@ module Datadog
               option :parse_response_body do |o|
                 o.type :bool
                 o.env 'DD_API_SECURITY_PARSE_RESPONSE_BODY'
-                o.default false
+                o.default true
               end
             end
           end

--- a/lib/datadog/appsec/configuration/settings.rb
+++ b/lib/datadog/appsec/configuration/settings.rb
@@ -191,7 +191,7 @@ module Datadog
 
               option :parse_response_body do |o|
                 o.type :bool
-                o.env 'DD_EXPERIMENTAL_API_SECURITY_PARSE_RESPONSE_BODY'
+                o.env 'DD_API_SECURITY_PARSE_RESPONSE_BODY'
                 o.default false
               end
             end

--- a/spec/datadog/appsec/configuration/settings_spec.rb
+++ b/spec/datadog/appsec/configuration/settings_spec.rb
@@ -725,7 +725,7 @@ RSpec.describe Datadog::AppSec::Configuration::Settings do
         context 'is not defined' do
           let(:api_security_parse_response_body) { nil }
 
-          it { is_expected.to eq false }
+          it { is_expected.to eq true }
         end
 
         context 'is defined' do

--- a/spec/datadog/appsec/configuration/settings_spec.rb
+++ b/spec/datadog/appsec/configuration/settings_spec.rb
@@ -715,9 +715,9 @@ RSpec.describe Datadog::AppSec::Configuration::Settings do
     describe 'parse_response_body' do
       subject(:enabled) { settings.appsec.parse_response_body }
 
-      context 'when DD_EXPERIMENTAL_API_SECURITY_PARSE_RESPONSE_BODY' do
+      context 'when DD_API_SECURITY_PARSE_RESPONSE_BODY' do
         around do |example|
-          ClimateControl.modify('DD_EXPERIMENTAL_API_SECURITY_PARSE_RESPONSE_BODY' => api_security_parse_response_body) do
+          ClimateControl.modify('DD_API_SECURITY_PARSE_RESPONSE_BODY' => api_security_parse_response_body) do
             example.run
           end
         end

--- a/spec/datadog/appsec/contrib/rack/gateway/response_spec.rb
+++ b/spec/datadog/appsec/contrib/rack/gateway/response_spec.rb
@@ -54,7 +54,7 @@ RSpec.describe Datadog::AppSec::Contrib::Rack::Gateway::Response do
 
       context 'when parse_response_body is enabled' do
         around do |example|
-          ClimateControl.modify('DD_EXPERIMENTAL_API_SECURITY_PARSE_RESPONSE_BODY' => 'true') do
+          ClimateControl.modify('DD_API_SECURITY_PARSE_RESPONSE_BODY' => 'true') do
             example.run
           end
         end

--- a/spec/datadog/appsec/contrib/rack/gateway/response_spec.rb
+++ b/spec/datadog/appsec/contrib/rack/gateway/response_spec.rb
@@ -47,18 +47,18 @@ RSpec.describe Datadog::AppSec::Contrib::Rack::Gateway::Response do
       let(:content_type) { 'application/json' }
 
       context 'when parse_response_body is disable' do
+        around do |example|
+          ClimateControl.modify('DD_API_SECURITY_PARSE_RESPONSE_BODY' => 'false') do
+            example.run
+          end
+        end
+
         it 'returns a nil' do
           expect(response.parsed_body).to be_nil
         end
       end
 
       context 'when parse_response_body is enabled' do
-        around do |example|
-          ClimateControl.modify('DD_API_SECURITY_PARSE_RESPONSE_BODY' => 'true') do
-            example.run
-          end
-        end
-
         context 'all body parts are strings' do
           let(:body) { ['{ "f', 'oo":', ' "ba', 'r" }'] }
 

--- a/spec/datadog/appsec/contrib/rack/reactive/response_spec.rb
+++ b/spec/datadog/appsec/contrib/rack/reactive/response_spec.rb
@@ -43,7 +43,7 @@ RSpec.describe Datadog::AppSec::Contrib::Rack::Reactive::Response do
 
       context 'when parsed_response_body is enabled' do
         around do |example|
-          ClimateControl.modify('DD_EXPERIMENTAL_API_SECURITY_PARSE_RESPONSE_BODY' => 'true') do
+          ClimateControl.modify('DD_API_SECURITY_PARSE_RESPONSE_BODY' => 'true') do
             example.run
           end
         end
@@ -132,7 +132,7 @@ RSpec.describe Datadog::AppSec::Contrib::Rack::Reactive::Response do
 
         context 'when parsed_response_body is enabled' do
           around do |example|
-            ClimateControl.modify('DD_EXPERIMENTAL_API_SECURITY_PARSE_RESPONSE_BODY' => 'true') do
+            ClimateControl.modify('DD_API_SECURITY_PARSE_RESPONSE_BODY' => 'true') do
               example.run
             end
           end

--- a/spec/datadog/appsec/contrib/rack/reactive/response_spec.rb
+++ b/spec/datadog/appsec/contrib/rack/reactive/response_spec.rb
@@ -42,12 +42,6 @@ RSpec.describe Datadog::AppSec::Contrib::Rack::Reactive::Response do
       let(:body) { ['{"a":"b"}'] }
 
       context 'when parsed_response_body is enabled' do
-        around do |example|
-          ClimateControl.modify('DD_API_SECURITY_PARSE_RESPONSE_BODY' => 'true') do
-            example.run
-          end
-        end
-
         it 'propagates response attributes to the operation' do
           expect(operation).to receive(:publish).with('response.status', 200)
           expect(operation).to receive(:publish).with(
@@ -64,6 +58,12 @@ RSpec.describe Datadog::AppSec::Contrib::Rack::Reactive::Response do
       end
 
       context 'when parsed_response_body is disabled' do
+        around do |example|
+          ClimateControl.modify('DD_API_SECURITY_PARSE_RESPONSE_BODY' => 'false') do
+            example.run
+          end
+        end
+
         it 'propagates response attributes to the operation' do
           expect(operation).to receive(:publish).with('response.status', 200)
           expect(operation).to receive(:publish).with(
@@ -131,12 +131,6 @@ RSpec.describe Datadog::AppSec::Contrib::Rack::Reactive::Response do
         let(:body) { ['{"a":"b"}'] }
 
         context 'when parsed_response_body is enabled' do
-          around do |example|
-            ClimateControl.modify('DD_API_SECURITY_PARSE_RESPONSE_BODY' => 'true') do
-              example.run
-            end
-          end
-
           context 'all addresses have been published' do
             let(:expected_waf_arguments) do
               {
@@ -195,6 +189,12 @@ RSpec.describe Datadog::AppSec::Contrib::Rack::Reactive::Response do
         end
 
         context 'when parsed_response_body is disabled' do
+          around do |example|
+            ClimateControl.modify('DD_API_SECURITY_PARSE_RESPONSE_BODY' => 'false') do
+              example.run
+            end
+          end
+
           let(:expected_waf_arguments) do
             {
               'server.response.status' => '200',


### PR DESCRIPTION
<!--
Check out the
https://github.com/DataDog/dd-trace-rb/blob/master/docs/DevelopmentGuide.md
for guidance on how to set up your development environment,
run the test suite, write new integrations, and more.
-->

**What does this PR do?**
<!-- A brief description of the change being made with this pull request. -->

After discussing with the team, we decided to remove the `EXPERIMENTAL` qualifier for the ASM api security response body parsing configuration 

**Motivation:**
<!-- What inspired you to submit this pull request? -->

**Additional Notes:**
<!-- Anything else we should know when reviewing? -->

**How to test the change?**
<!--
Describe here how the change can be validated.
You are strongly encouraged to provide automated tests for this PR (unit or integration).
If this change cannot be feasibly tested, please explain why,
unless the change does not modify code (e.g. only modifies docs, comments).
-->

**For Datadog employees:**
- [ ] If this PR touches code that signs or publishes builds or packages, or handles
credentials of any kind, I've requested a review from `@DataDog/security-design-and-guidance`.
- [ ] This PR doesn't touch any of that.

Unsure? Have a question? Request a review!
