### PR TITLE
return empty hash if tracing config is not extended by Tracing::Contrib::Extensions

### DIFF
--- a/lib/datadog/tracing/diagnostics/environment_logger.rb
+++ b/lib/datadog/tracing/diagnostics/environment_logger.rb
@@ -137,6 +137,12 @@ module Datadog
           private
 
           def instrumented_integrations
+            # `instrumented_integrations` method is added only if tracing contrib extensions are required.
+            # If tracing is used in manual mode without integrations enabled this method does not exist.
+            # CI visibility gem datadog-ci uses Datadog::Tracer without requiring datadog/tracing/contrib folder
+            # nor enabling any integrations by default which causes EnvironmentCollector to fail.
+            return {} unless Datadog.configuration.tracing.respond_to?(:instrumented_integrations)
+
             Datadog.configuration.tracing.instrumented_integrations
           end
 


### PR DESCRIPTION
**What does this PR do?**
Backport changes from https://github.com/DataDog/dd-trace-rb/pull/3209

**Motivation:**
Release this fix in the next 1.x release

**For Datadog employees:**
- [ ] If this PR touches code that signs or publishes builds or packages, or handles
credentials of any kind, I've requested a review from `@DataDog/security-design-and-guidance`.
- [x] This PR doesn't touch any of that.

Unsure? Have a question? Request a review!
