### PR TITLE
ekump/backport fix instrumentation of custom cache stores

### DIFF
--- a/lib/datadog/tracing/contrib/active_support/cache/instrumentation.rb
+++ b/lib/datadog/tracing/contrib/active_support/cache/instrumentation.rb
@@ -101,7 +101,9 @@ module Datadog
 
                 # DEV: String#underscore is available through ActiveSupport, and is
                 # DEV: the exact reverse operation to `#camelize`.
-                @store_name = self.class.name.underscore.match(%r{active_support/cache/(.*)})[1]
+                # DEV: String#demodulize is available through ActiveSupport, and is
+                # DEV: used to remove the module ('*::') part of a constant name.
+                @store_name = self.class.name.demodulize.underscore
               end
             end
 

--- a/spec/datadog/tracing/contrib/rails/cache_spec.rb
+++ b/spec/datadog/tracing/contrib/rails/cache_spec.rb
@@ -61,6 +61,26 @@ RSpec.describe 'Rails cache' do
       end
     end
 
+    context 'with a cache not in the ActiveSupport::Cache:: namespace' do
+      let(:cache_class) { stub_const('My::CustomCache', Class.new(ActiveSupport::Cache::MemoryStore)) }
+      let(:cache) { cache_class.new }
+
+      it 'returns the matching backend type' do
+        subject
+        expect(spans[0].get_tag('rails.cache.backend')).to eq('custom_cache')
+      end
+    end
+
+    context 'with an unnamespaced cache class' do
+      let(:cache_class) { stub_const('CustomCache', Class.new(ActiveSupport::Cache::MemoryStore)) }
+      let(:cache) { cache_class.new }
+
+      it 'returns the matching backend type' do
+        subject
+        expect(spans[0].get_tag('rails.cache.backend')).to eq('custom_cache')
+      end
+    end
+
     it_behaves_like 'measured span for integration', false do
       before { subject }
       let(:span) { spans[0] }


### PR DESCRIPTION
<!--
Check out the
https://github.com/DataDog/dd-trace-rb/blob/master/docs/DevelopmentGuide.md
for guidance on how to set up your development environment,
run the test suite, write new integrations, and more.
-->

**What does this PR do?**
backports https://github.com/DataDog/dd-trace-rb/pull/3206 - fixes instrumentation of custom cache stores

**Motivation:**
Want to include in 1.16 release

**Additional Notes:**
<!-- Anything else we should know when reviewing? -->

**How to test the change?**
<!--
Describe here how the change can be validated.
You are strongly encouraged to provide automated tests for this PR (unit or integration).
If this change cannot be feasibly tested, please explain why,
unless the change does not modify code (e.g. only modifies docs, comments).
-->

**For Datadog employees:**
- [ ] If this PR touches code that signs or publishes builds or packages, or handles
credentials of any kind, I've requested a review from `@DataDog/security-design-and-guidance`.
- [x] This PR doesn't touch any of that.

Unsure? Have a question? Request a review!
