### PR TITLE
Attempt to remove flaky test for checking that tracer threads are correctly shutdown

### DIFF
--- a/spec/datadog/integration_spec.rb
+++ b/spec/datadog/integration_spec.rb
@@ -22,12 +22,12 @@ RSpec.describe 'Datadog integration' do
     end
 
     context 'for threads' do
-      let(:original_threads) { Thread.list }
+      let!(:original_threads) { Thread.list }
       let(:start_tracer) do
         Datadog::Tracing.trace('test.op') {}
 
         new_threads = Thread.list - original_threads
-        tracer_threads.concat(new_threads.map(&:object_id))
+        tracer_threads.concat(new_threads)
       end
       let(:tracer_threads) { [] }
 
@@ -43,10 +43,10 @@ RSpec.describe 'Datadog integration' do
 
         shutdown
 
-        post_shutdown_threads = Thread.list.map(&:object_id)
+        post_shutdown_threads = Thread.list
 
         expect(post_shutdown_threads & tracer_threads).to be_empty,
-          "Tracer threads not terminated: #{inspect_threads(Thread.list)}"
+          "Tracer threads not terminated: #{inspect_threads(post_shutdown_threads)}"
       end
     end
 

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -280,3 +280,11 @@ end
 
 # Helper matchers
 RSpec::Matchers.define_negated_matcher :not_be, :be
+
+# The Ruby Timeout class uses a long-lived class-level thread that is never terminated.
+# Creating it early here ensures tests that tests that check for leaking threads are not
+# triggered by the creation of this thread.
+#
+# This has to be one once for the lifetime of this process, and was introduced in Ruby 3.1.
+# Before 3.1, a thread was created and destroyed on every Timeout#timeout call.
+Timeout.ensure_timeout_thread_created if Timeout.respond_to?(:ensure_timeout_thread_created)


### PR DESCRIPTION
<!--
Check out the
https://github.com/DataDog/dd-trace-rb/blob/master/docs/DevelopmentGuide.md
for guidance on how to set up your development environment,
run the test suite, write new integrations, and more.
-->

**What does this PR do?**
~~Instead of checking number of threads before and after tracer is started and shutdown, we grab the object IDs for the threads the tracer creates and check that they are no longer present after the tracer shuts down. This test has been flaky for some time.~~

Add back `Timeout.ensure_timeout_thread_created if Timeout.respond_to?(:ensure_timeout_thread_created)` to spec_helper.rb that was removed in https://github.com/DataDog/dd-trace-rb/pull/2991. The Timeout thread can lead to flaky tests where we are checking what threads are present before and after actions as it could be created during a test. This ensures the thread is always there before a test starts for consistent observation.

Also, improve the existing test for tracing thread shutdown by checking the thread objects themselves and not just the size of `Threads.list` and make the error output clearer. 

**Motivation:**
Flaky tests make people sad. This PR addresses #3212 

**Additional Notes:**
<!-- Anything else we should know when reviewing? -->

**How to test the change?**
I ran the rspec test several times and didn't observe any false failures. The previous test would fail at least 1 in every 10 times locally. 

**For Datadog employees:**
- [ ] If this PR touches code that signs or publishes builds or packages, or handles
credentials of any kind, I've requested a review from `@DataDog/security-design-and-guidance`.
- [x] This PR doesn't touch any of that.

Unsure? Have a question? Request a review!
