### PR TITLE
Disable Ruby 3.3 integration due to protobuf compilation error (#3211)

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -626,11 +626,12 @@ workflows:
           integration_apps: 'rack rails-six rails-seven sinatra2-classic sinatra2-modular'
           ruby_version: '3.2'
           <<: *filters_all_branches_and_tags
-      - orb/build_and_test_integration:
-          name: build_and_test_integration-3.3
-          integration_apps: 'rack rails-six rails-seven sinatra2-classic sinatra2-modular'
-          ruby_version: '3.3'
-          <<: *filters_all_branches_and_tags
+#      # Disabled until https://github.com/protocolbuffers/protobuf/issues/14509 is fixed.
+#      - orb/build_and_test_integration:
+#          name: build_and_test_integration-3.3
+#          integration_apps: 'rack rails-six rails-seven sinatra2-classic sinatra2-modular'
+#          ruby_version: '3.3'
+#          <<: *filters_all_branches_and_tags
       # ⬆️ **Note**: If add/remove test apps above, remember to also copy-paste the changes to the "edge" workflow further down the file.
       #
       # ADD NEW RUBIES HERE


### PR DESCRIPTION
<!--
Check out the
https://github.com/DataDog/dd-trace-rb/blob/master/docs/DevelopmentGuide.md
for guidance on how to set up your development environment,
run the test suite, write new integrations, and more.
-->

**What does this PR do?**
Backports #3211: Disable integration test for Ruby 3.3. that cannot install its gemfiles until https://github.com/protocolbuffers/protobuf/issues/14509 is addressed.

**Motivation:**
CI is breaking for 1.x-stable

**Additional Notes:**
<!-- Anything else we should know when reviewing? -->

**How to test the change?**
<!--
Describe here how the change can be validated.
You are strongly encouraged to provide automated tests for this PR (unit or integration).
If this change cannot be feasibly tested, please explain why,
unless the change does not modify code (e.g. only modifies docs, comments).
-->

**For Datadog employees:**
- [ ] If this PR touches code that signs or publishes builds or packages, or handles
credentials of any kind, I've requested a review from `@DataDog/security-design-and-guidance`.
- [x] This PR doesn't touch any of that.

Unsure? Have a question? Request a review!
