### PR TITLE
Update Nix shell to use today's latest 23.05 + updated compilers

### DIFF
--- a/shell.nix
+++ b/shell.nix
@@ -3,17 +3,17 @@
   pkgs ? import <nixpkgs> {},
 
   # use a pinned package state
-  pinned ? import(fetchTarball("https://github.com/NixOS/nixpkgs/archive/14d9b465c71.tar.gz")) {},
+  pinned ? import(fetchTarball("https://github.com/NixOS/nixpkgs/archive/31b322916ae1.tar.gz")) {},
 }:
 let
   # specify ruby version to use
-  ruby = pinned.ruby_3_1;
+  ruby = pinned.ruby_3_2;
 
   # control llvm/clang version (e.g for packages built from source)
-  llvm = pinned.llvmPackages_12;
+  llvm = pinned.llvmPackages_16;
 
   # control gcc version (e.g for packages built from source)
-  gcc = pinned.gcc12;
+  gcc = pinned.gcc13;
 in llvm.stdenv.mkDerivation {
   # unique project name for this environment derivation
   name = "dd-trace-rb.devshell";


### PR DESCRIPTION
<!--
Check out the
https://github.com/DataDog/dd-trace-rb/blob/master/docs/DevelopmentGuide.md
for guidance on how to set up your development environment,
run the test suite, write new integrations, and more.
-->

**What does this PR do?**

Update Nix shell to use today's latest 23.05 + updated compilers

**Motivation:**

Keeping things up to date

**Additional Notes:**

Backport of #3219 to 1.x

**How to test the change?**
<!--
Describe here how the change can be validated.
You are strongly encouraged to provide automated tests for this PR (unit or integration).
If this change cannot be feasibly tested, please explain why,
unless the change does not modify code (e.g. only modifies docs, comments).
-->
- If not done already, install nixpkgs (Linux, macOS):

  ```
  $ sh <(curl -L https://nixos.org/nix/install) --daemon
  ```

  This quickly installs basic nix commands out of the way in `/nix` and does not conflict with anything (incl. Homebrew)

- Enter Nix shell:

  ```
  $ cd /path/to/dd-trace/clone
  $ nix-shell
  ```

- Try the usual Ruby stuff:

  ```
  nix-shell$ bundle install
  nix-shell$ bundle exec rake test:main
  ```

**For Datadog employees:**
- [ ] If this PR touches code that signs or publishes builds or packages, or handles
credentials of any kind, I've requested a review from `@DataDog/security-design-and-guidance`.
- [x] This PR doesn't touch any of that.

Unsure? Have a question? Request a review!
