### PR TITLE
Make sure function that checks content-type header value accepts nil content-type header value

### DIFF
--- a/.github/workflows/system-tests.yml
+++ b/.github/workflows/system-tests.yml
@@ -171,6 +171,9 @@ jobs:
             app: rails70
             scenario: APPSEC_AUTO_EVENTS_EXTENDED
           - library: ruby
+            app: rails70
+            scenario: APPSEC_API_SECURITY
+          - library: ruby
             app: rack
             scenario: APPSEC_RULES_MONITORING_WITH_ERRORS
           - library: ruby

--- a/lib/datadog/appsec/contrib/rack/gateway/response.rb
+++ b/lib/datadog/appsec/contrib/rack/gateway/response.rb
@@ -66,7 +66,7 @@ module Datadog
 
             def json_content_type?
               content_type = headers['content-type']
-              VALID_JSON_TYPES.any? { |valid_type| content_type.include?(valid_type) }
+              VALID_JSON_TYPES.include?(content_type)
             end
           end
         end

--- a/spec/datadog/appsec/contrib/rack/gateway/response_spec.rb
+++ b/spec/datadog/appsec/contrib/rack/gateway/response_spec.rb
@@ -8,12 +8,13 @@ require 'rack'
 RSpec.describe Datadog::AppSec::Contrib::Rack::Gateway::Response do
   let(:body) { ['Ok'] }
   let(:content_type) { 'text/html' }
+  let(:headers) { { 'Content-Type' => content_type } }
 
   let(:response) do
     described_class.new(
       body,
       200,
-      { 'Content-Type' => content_type },
+      headers,
       scope: instance_double(Datadog::AppSec::Scope)
     )
   end
@@ -87,6 +88,14 @@ RSpec.describe Datadog::AppSec::Contrib::Rack::Gateway::Response do
 
       context 'non supported response type' do
         let(:content_type) { 'text/xml' }
+
+        it 'returns nil' do
+          expect(response.parsed_body).to be_nil
+        end
+      end
+
+      context 'without content-type header' do
+        let(:headers) { {} }
 
         it 'returns nil' do
           expect(response.parsed_body).to be_nil


### PR DESCRIPTION
<!--
Check out the
https://github.com/DataDog/dd-trace-rb/blob/master/docs/DevelopmentGuide.md
for guidance on how to set up your development environment,
run the test suite, write new integrations, and more.
-->

**What does this PR do?**
<!-- A brief description of the change being made with this pull request. -->

Fix regression introduce in https://github.com/DataDog/dd-trace-rb/pull/3153/commits/b1952740df7b27ffcbb1d4547caf03cab92c4546

Make sure that the function that checks if the content-type header
is valid for parsing the response body
and supports when there is no content-type header information.

**Motivation:**
<!-- What inspired you to submit this pull request? -->

**Additional Notes:**
<!-- Anything else we should know when reviewing? -->

**How to test the change?**
<!--
Describe here how the change can be validated.
You are strongly encouraged to provide automated tests for this PR (unit or integration).
If this change cannot be feasibly tested, please explain why,
unless the change does not modify code (e.g. only modifies docs, comments).
-->

**For Datadog employees:**
- [ ] If this PR touches code that signs or publishes builds or packages, or handles
credentials of any kind, I've requested a review from `@DataDog/security-design-and-guidance`.
- [ ] This PR doesn't touch any of that.

Unsure? Have a question? Request a review!
