### PR TITLE
Revert "update version to 2.0.0.alpha1 on master"

### DIFF
--- a/lib/ddtrace/version.rb
+++ b/lib/ddtrace/version.rb
@@ -2,10 +2,10 @@
 
 module DDTrace
   module VERSION
-    MAJOR = 2
-    MINOR = 0
+    MAJOR = 1
+    MINOR = 15
     PATCH = 0
-    PRE = 'alpha1'
+    PRE = nil
     BUILD = nil
     # PRE and BUILD above are modified for dev gems during gem build GHA workflow
 

--- a/spec/datadog/profiling/tag_builder_spec.rb
+++ b/spec/datadog/profiling/tag_builder_spec.rb
@@ -11,7 +11,7 @@ RSpec.describe Datadog::Profiling::TagBuilder do
         'host' => Datadog::Core::Environment::Socket.hostname,
         'language' => 'ruby',
         'process_id' => Process.pid.to_s,
-        'profiler_version' => start_with('2.'),
+        'profiler_version' => start_with('1.'),
         'runtime' => 'ruby',
         'runtime_engine' => RUBY_ENGINE,
         'runtime-id' => Datadog::Core::Environment::Identity.id,


### PR DESCRIPTION
Reverts DataDog/dd-trace-rb#3201

Let's go back to master being 1.x until we have a more concrete timeline for the release of 2.x changes.

## Motivation

We've seen very frequent backporting (pretty much all changes so far) because current development is still intended for 1.x.
Until the first 2.x prerelease has a concrete timeline, we'll keep master as 1.x.