### PR TITLE
Fix host injection error handling 

### DIFF
--- a/lib-injection/host_inject.rb
+++ b/lib-injection/host_inject.rb
@@ -113,5 +113,5 @@ begin
     end
   end
 rescue Exception => e
-  warn "[ddtrace] #{failure_prefix} #{e.class.name} #{e.message}\nBacktrace: #{e.backtrace.join("\n")}\n#{support_message}"
+  warn "[ddtrace] Injection failed: #{e.class.name} #{e.message}\nBacktrace: #{e.backtrace.join("\n")}\n#{support_message}"
 end


### PR DESCRIPTION
**What does this PR do?**

Variable `failure_prefix` is obsolete and causing error when handling exception. 
Remove an obsolete variable from host inject script .