### PR TITLE
Fix concurrent ruby future propagation without `active_trace`

### DIFF
--- a/lib/datadog/tracing/contrib/concurrent_ruby/context_composite_executor_service.rb
+++ b/lib/datadog/tracing/contrib/concurrent_ruby/context_composite_executor_service.rb
@@ -19,7 +19,7 @@ module Datadog
           # post method runs the task within composited executor - in a different thread. The original arguments are
           # captured to be propagated to the composited executor post method
           def post(*args, &task)
-            digest = Tracing.active_trace.to_digest
+            digest = Tracing.active_trace && Tracing.active_trace.to_digest
             executor = @composited_executor.is_a?(Symbol) ? Concurrent.executor(@composited_executor) : @composited_executor
 
             # Pass the original arguments to the composited executor, which

--- a/spec/datadog/tracing/contrib/concurrent_ruby/integration_test_spec.rb
+++ b/spec/datadog/tracing/contrib/concurrent_ruby/integration_test_spec.rb
@@ -135,6 +135,18 @@ RSpec.describe 'ConcurrentRuby integration tests' do
           end
         end
       end
+
+      context 'when propagates without an active trace' do
+        it 'creates a root span' do
+          future = Concurrent::Promises.future do
+            tracer.trace('inner_span') {}
+          end
+
+          future.wait
+
+          expect(inner_span).to be_root_span
+        end
+      end
     end
   end
 


### PR DESCRIPTION
**What does this PR do?**

Concurrent ruby propagation breaks with `NoMethodError` when there is no `active_trace` to propagates. 

Fix with conditionals. 

