### PR TITLE
Minor: Fix incorrect comment

### DIFF
--- a/lib/datadog/core/configuration/settings.rb
+++ b/lib/datadog/core/configuration/settings.rb
@@ -330,7 +330,7 @@ module Datadog
             # Caveat 3 (severe):
             # Ruby 3.2.0 to 3.2.2 have a bug in the newobj tracepoint (https://bugs.ruby-lang.org/issues/19482,
             # https://github.com/ruby/ruby/pull/7464) so that's an extra reason why it's not safe on those Rubies.
-            # This bug is fixed on Ruby versions 3.2.2 and 3.3.0.
+            # This bug is fixed on Ruby versions 3.2.3 and 3.3.0.
             #
             # @default `true` on Ruby 2.x and 3.1.4+, 3.2.3+ and 3.3.0+; `false` for Ruby 3.0 and unpatched Rubies.
             option :allocation_counting_enabled do |o|


### PR DESCRIPTION
**What does this PR do?**

Fixes an incorrect comment; the bug being discussed is going to be fixed in the upcoming Ruby 3.2.3 release; not on 3.2.2.

**Motivation:**

Fix incorrect information.

**Additional Notes:**

N/A

**How to test the change?**

N/A

**For Datadog employees:**
- [ ] If this PR touches code that signs or publishes builds or packages, or handles
credentials of any kind, I've requested a review from `@DataDog/security-design-and-guidance`.
- [x] This PR doesn't touch any of that.