### PR TITLE
[PROF-8632] Ruby heap size profiling PoC

### DIFF
--- a/ext/ddtrace_profiling_native_extension/heap_recorder.c
+++ b/ext/ddtrace_profiling_native_extension/heap_recorder.c
@@ -186,7 +186,7 @@ static int st_object_records_iterate(st_data_t key, st_data_t value, st_data_t e
 
   stack_iteration_data stack_data = {
     .inuse_objects = record->weight,
-    .inuse_size = rb_obj_memsize_of(obj),
+    .inuse_size = rb_obj_memsize_of(obj) * record->weight,
     .locations = reusableLocationsFromStack(iteration_data->heap_recorder, record->heap_record->stack),
   };
 

--- a/ext/ddtrace_profiling_native_extension/heap_recorder.h
+++ b/ext/ddtrace_profiling_native_extension/heap_recorder.h
@@ -9,9 +9,10 @@ typedef struct heap_recorder heap_recorder;
 typedef struct {
   ddog_prof_Slice_Location locations;
   uint64_t inuse_objects;
+  uint64_t inuse_size;
 } stack_iteration_data;
 
-heap_recorder* heap_recorder_init(void);
+heap_recorder* heap_recorder_init(bool enable_heap_size_profiling);
 void heap_recorder_free(heap_recorder *heap_recorder);
 void heap_recorder_iterate_stacks(heap_recorder *heap_recorder, void (*for_each_callback)(stack_iteration_data stack_data, void* extra_arg), void *for_each_callback_extra_arg);
 void start_heap_allocation_recording(heap_recorder *heap_recorder, VALUE new_obj, unsigned int weight, ddog_CharSlice *class_name);

--- a/ext/ddtrace_profiling_native_extension/stack_recorder.c
+++ b/ext/ddtrace_profiling_native_extension/stack_recorder.c
@@ -155,13 +155,15 @@ static VALUE stack_recorder_class = Qnil;
 #define ALLOC_SAMPLES_VALUE_ID 3
 #define HEAP_SAMPLES_VALUE     {.type_ = VALUE_STRING("heap-live-samples"),     .unit = VALUE_STRING("count")}
 #define HEAP_SAMPLES_VALUE_ID 4
+#define HEAP_SIZE_VALUE     {.type_ = VALUE_STRING("heap-live-size"),     .unit = VALUE_STRING("bytes")}
+#define HEAP_SIZE_VALUE_ID 5
 
-static const ddog_prof_ValueType all_value_types[] = {CPU_TIME_VALUE, CPU_SAMPLES_VALUE, WALL_TIME_VALUE, ALLOC_SAMPLES_VALUE, HEAP_SAMPLES_VALUE};
+static const ddog_prof_ValueType all_value_types[] = {CPU_TIME_VALUE, CPU_SAMPLES_VALUE, WALL_TIME_VALUE, ALLOC_SAMPLES_VALUE, HEAP_SAMPLES_VALUE, HEAP_SIZE_VALUE};
 
 // This array MUST be kept in sync with all_value_types above and is intended to act as a "hashmap" between VALUE_ID and the position it
 // occupies on the all_value_types array.
 // E.g. all_value_types_positions[CPU_TIME_VALUE_ID] => 0, means that CPU_TIME_VALUE was declared at position 0 of all_value_types.
-static const uint8_t all_value_types_positions[] = {CPU_TIME_VALUE_ID, CPU_SAMPLES_VALUE_ID, WALL_TIME_VALUE_ID, ALLOC_SAMPLES_VALUE_ID, HEAP_SAMPLES_VALUE_ID};
+static const uint8_t all_value_types_positions[] = {CPU_TIME_VALUE_ID, CPU_SAMPLES_VALUE_ID, WALL_TIME_VALUE_ID, ALLOC_SAMPLES_VALUE_ID, HEAP_SAMPLES_VALUE_ID, HEAP_SIZE_VALUE_ID};
 
 #define ALL_VALUE_TYPES_COUNT (sizeof(all_value_types) / sizeof(ddog_prof_ValueType))
 
@@ -205,7 +207,7 @@ static VALUE _native_new(VALUE klass);
 static void initialize_slot_concurrency_control(struct stack_recorder_state *state);
 static void initialize_profiles(struct stack_recorder_state *state, ddog_prof_Slice_ValueType sample_types);
 static void stack_recorder_typed_data_free(void *data);
-static VALUE _native_initialize(DDTRACE_UNUSED VALUE _self, VALUE recorder_instance, VALUE cpu_time_enabled, VALUE alloc_samples_enabled, VALUE heap_samples_enabled);
+static VALUE _native_initialize(DDTRACE_UNUSED VALUE _self, VALUE recorder_instance, VALUE cpu_time_enabled, VALUE alloc_samples_enabled, VALUE heap_samples_enabled, VALUE heap_size_enabled);
 static VALUE _native_serialize(VALUE self, VALUE recorder_instance);
 static VALUE ruby_time_from(ddog_Timespec ddprof_time);
 static void *call_serialize_without_gvl(void *call_args);
@@ -237,7 +239,7 @@ void stack_recorder_init(VALUE profiling_module) {
   // https://bugs.ruby-lang.org/issues/18007 for a discussion around this.
   rb_define_alloc_func(stack_recorder_class, _native_new);
 
-  rb_define_singleton_method(stack_recorder_class, "_native_initialize", _native_initialize, 4);
+  rb_define_singleton_method(stack_recorder_class, "_native_initialize", _native_initialize, 5);
   rb_define_singleton_method(stack_recorder_class, "_native_serialize",  _native_serialize, 1);
   rb_define_singleton_method(stack_recorder_class, "_native_reset_after_fork", _native_reset_after_fork, 1);
   rb_define_singleton_method(testing_module, "_native_active_slot", _native_active_slot, 1);
@@ -330,7 +332,7 @@ static void stack_recorder_typed_data_free(void *state_ptr) {
   ruby_xfree(state);
 }
 
-static VALUE _native_initialize(DDTRACE_UNUSED VALUE _self, VALUE recorder_instance, VALUE cpu_time_enabled, VALUE alloc_samples_enabled, VALUE heap_samples_enabled) {
+static VALUE _native_initialize(DDTRACE_UNUSED VALUE _self, VALUE recorder_instance, VALUE cpu_time_enabled, VALUE alloc_samples_enabled, VALUE heap_samples_enabled, VALUE heap_size_enabled) {
   ENFORCE_BOOLEAN(cpu_time_enabled);
   ENFORCE_BOOLEAN(alloc_samples_enabled);
   ENFORCE_BOOLEAN(heap_samples_enabled);
@@ -338,7 +340,7 @@ static VALUE _native_initialize(DDTRACE_UNUSED VALUE _self, VALUE recorder_insta
   struct stack_recorder_state *state;
   TypedData_Get_Struct(recorder_instance, struct stack_recorder_state, &stack_recorder_typed_data, state);
 
-  state->heap_recorder = heap_recorder_init();
+  state->heap_recorder = heap_recorder_init(heap_size_enabled == Qtrue);
 
   if (cpu_time_enabled == Qtrue && alloc_samples_enabled == Qtrue) return Qtrue; // Nothing to do, this is the default
 
@@ -380,6 +382,14 @@ static VALUE _native_initialize(DDTRACE_UNUSED VALUE _self, VALUE recorder_insta
   } else {
     state->position_for[HEAP_SAMPLES_VALUE_ID] = next_disabled_pos++;
   }
+
+  if (alloc_samples_enabled == Qtrue && heap_size_enabled == Qtrue) {
+    enabled_value_types[next_enabled_pos] = (ddog_prof_ValueType) HEAP_SIZE_VALUE;
+    state->position_for[HEAP_SIZE_VALUE_ID] = next_enabled_pos++;
+  } else {
+    state->position_for[HEAP_SIZE_VALUE_ID] = next_disabled_pos++;
+  }
+
 
   ddog_prof_Profile_drop(&state->slot_one_profile);
   ddog_prof_Profile_drop(&state->slot_two_profile);
@@ -523,6 +533,7 @@ static void add_heap_sample_to_active_profile(stack_iteration_data stack_data, v
   uint8_t *position_for = context->state->position_for;
 
   metric_values[position_for[HEAP_SAMPLES_VALUE_ID]] = stack_data.inuse_objects;
+  metric_values[position_for[HEAP_SIZE_VALUE_ID]] = stack_data.inuse_size;
 
   ddog_prof_Profile_Result result = ddog_prof_Profile_add(
     context->profile,

--- a/lib/datadog/profiling/component.rb
+++ b/lib/datadog/profiling/component.rb
@@ -46,7 +46,8 @@ module Datadog
           cpu_time_enabled: RUBY_PLATFORM.include?('linux'), # Only supported on Linux currently
           # FIXME: Don't hardcode this
           alloc_samples_enabled: true,
-          heap_samples_enabled: true
+          heap_samples_enabled: true,
+          heap_size_enabled: true,
         )
         thread_context_collector = Datadog::Profiling::Collectors::ThreadContext.new(
           recorder: recorder,

--- a/lib/datadog/profiling/stack_recorder.rb
+++ b/lib/datadog/profiling/stack_recorder.rb
@@ -4,7 +4,7 @@ module Datadog
     # Note that `record_sample` is only accessible from native code.
     # Methods prefixed with _native_ are implemented in `stack_recorder.c`
     class StackRecorder
-      def initialize(cpu_time_enabled:, alloc_samples_enabled:, heap_samples_enabled:)
+      def initialize(cpu_time_enabled:, alloc_samples_enabled:, heap_samples_enabled:, heap_size_enabled:)
         # This mutex works in addition to the fancy C-level mutexes we have in the native side (see the docs there).
         # It prevents multiple Ruby threads calling serialize at the same time -- something like
         # `10.times { Thread.new { stack_recorder.serialize } }`.
@@ -13,7 +13,13 @@ module Datadog
         # accidentally happening.
         @no_concurrent_synchronize_mutex = Mutex.new
 
-        self.class._native_initialize(self, cpu_time_enabled, alloc_samples_enabled, heap_samples_enabled)
+        self.class._native_initialize(
+          self,
+          cpu_time_enabled,
+          alloc_samples_enabled,
+          heap_samples_enabled,
+          heap_size_enabled
+        )
       end
 
       def serialize


### PR DESCRIPTION
<!--
Check out the
https://github.com/DataDog/dd-trace-rb/blob/master/docs/DevelopmentGuide.md
for guidance on how to set up your development environment,
run the test suite, write new integrations, and more.
-->

**What does this PR do?**
Build on top of https://github.com/DataDog/dd-trace-rb/pull/3246 by adding a new profile type capturing the weighted heap size of all live sampled objects in the heap.

<img width="1049" alt="image" src="https://github.com/DataDog/dd-trace-rb/assets/373323/50e795a3-750d-485b-ad41-a02d75584788">


**Motivation:**
Tracking the number of living objects alone does not give us an idea of resource (in this case, memory) utilisation. To understand how close we are to hitting limits and OOMing, we need to understand the cumulative size of things in heap.

**Additional Notes:**
<!-- Anything else we should know when reviewing? -->

**How to test the change?**
<!--
Describe here how the change can be validated.
You are strongly encouraged to provide automated tests for this PR (unit or integration).
If this change cannot be feasibly tested, please explain why,
unless the change does not modify code (e.g. only modifies docs, comments).
-->

**For Datadog employees:**
- [ ] If this PR touches code that signs or publishes builds or packages, or handles
credentials of any kind, I've requested a review from `@DataDog/security-design-and-guidance`.
- [ ] This PR doesn't touch any of that.

Unsure? Have a question? Request a review!
