### PR TITLE
[PROF-8648] Add labels to heap samples

### DIFF
--- a/ext/ddtrace_profiling_native_extension/heap_recorder.h
+++ b/ext/ddtrace_profiling_native_extension/heap_recorder.h
@@ -7,9 +7,15 @@
 typedef struct heap_recorder heap_recorder;
 
 typedef struct {
+  char *alloc_class;
+  size_t alloc_generation;
+} object_metadata;
+
+typedef struct {
   ddog_prof_Slice_Location locations;
   uint64_t inuse_objects;
   uint64_t inuse_size;
+  object_metadata *metadata;
 } stack_iteration_data;
 
 heap_recorder* heap_recorder_init(bool enable_heap_size_profiling);

--- a/ext/ddtrace_profiling_native_extension/libdatadog_helpers.h
+++ b/ext/ddtrace_profiling_native_extension/libdatadog_helpers.h
@@ -9,6 +9,13 @@ inline static ddog_CharSlice char_slice_from_ruby_string(VALUE string) {
   return char_slice;
 }
 
+inline static ddog_CharSlice char_slice_from_c_string(char *string) {
+  return (ddog_CharSlice) {
+    .ptr = string,
+    .len = strlen(string),
+  };
+}
+
 inline static VALUE ruby_string_from_vec_u8(ddog_Vec_U8 string) {
   return rb_str_new((char *) string.ptr, string.len);
 }


### PR DESCRIPTION
<!--
Check out the
https://github.com/DataDog/dd-trace-rb/blob/master/docs/DevelopmentGuide.md
for guidance on how to set up your development environment,
run the test suite, write new integrations, and more.
-->

**What does this PR do?**
<!-- A brief description of the change being made with this pull request. -->

Builds on top of https://github.com/DataDog/dd-trace-rb/pull/3261 by tagging heap samples with `alloc class` and `gc gen age` labels that describe, respectively, what class a sample corresponds to and how many GCs has this sample survived for. The latter is especially useful to track memory leaks since anything that has a very recent age is susceptible to be cleared in a near-future GC whereas real leaks will tend to have very big ages.

<img width="1048" alt="image" src="https://github.com/DataDog/dd-trace-rb/assets/373323/0a1f2a85-1a54-4f6c-9668-1f5f9a774b15">


**Motivation:**
<!-- What inspired you to submit this pull request? -->

Add more context to heap profiling data.

**Additional Notes:**
<!-- Anything else we should know when reviewing? -->

**How to test the change?**
<!--
Describe here how the change can be validated.
You are strongly encouraged to provide automated tests for this PR (unit or integration).
If this change cannot be feasibly tested, please explain why,
unless the change does not modify code (e.g. only modifies docs, comments).
-->

**For Datadog employees:**
- [ ] If this PR touches code that signs or publishes builds or packages, or handles
credentials of any kind, I've requested a review from `@DataDog/security-design-and-guidance`.
- [ ] This PR doesn't touch any of that.

Unsure? Have a question? Request a review!
