### PR TITLE
Fix disabling pg instrumentation configuration

### DIFF
--- a/lib/datadog/tracing/contrib/pg/instrumentation.rb
+++ b/lib/datadog/tracing/contrib/pg/instrumentation.rb
@@ -21,18 +21,24 @@ module Datadog
           # PG::Connection patch methods
           module InstanceMethods
             def exec(sql, *args, &block)
+              return super unless enabled?
+
               trace(Ext::SPAN_EXEC, sql: sql, block: block) do |sql_statement, wrapped_block|
                 super(sql_statement, *args, &wrapped_block)
               end
             end
 
             def exec_params(sql, params, *args, &block)
+              return super unless enabled?
+
               trace(Ext::SPAN_EXEC_PARAMS, sql: sql, block: block) do |sql_statement, wrapped_block|
                 super(sql_statement, params, *args, &wrapped_block)
               end
             end
 
             def exec_prepared(statement_name, params, *args, &block)
+              return super unless enabled?
+
               trace(Ext::SPAN_EXEC_PREPARED, statement_name: statement_name, block: block) do |_, wrapped_block|
                 super(statement_name, params, *args, &wrapped_block)
               end
@@ -40,6 +46,8 @@ module Datadog
 
             # async_exec is an alias to exec
             def async_exec(sql, *args, &block)
+              return super unless enabled?
+
               trace(Ext::SPAN_ASYNC_EXEC, sql: sql, block: block) do |sql_statement, wrapped_block|
                 super(sql_statement, *args, &wrapped_block)
               end
@@ -47,6 +55,8 @@ module Datadog
 
             # async_exec_params is an alias to exec_params
             def async_exec_params(sql, params, *args, &block)
+              return super unless enabled?
+
               trace(Ext::SPAN_ASYNC_EXEC_PARAMS, sql: sql, block: block) do |sql_statement, wrapped_block|
                 super(sql_statement, params, *args, &wrapped_block)
               end
@@ -54,24 +64,32 @@ module Datadog
 
             # async_exec_prepared is an alias to exec_prepared
             def async_exec_prepared(statement_name, params, *args, &block)
+              return super unless enabled?
+
               trace(Ext::SPAN_ASYNC_EXEC_PREPARED, statement_name: statement_name, block: block) do |_, wrapped_block|
                 super(statement_name, params, *args, &wrapped_block)
               end
             end
 
             def sync_exec(sql, *args, &block)
+              return super unless enabled?
+
               trace(Ext::SPAN_SYNC_EXEC, sql: sql, block: block) do |sql_statement, wrapped_block|
                 super(sql_statement, *args, &wrapped_block)
               end
             end
 
             def sync_exec_params(sql, params, *args, &block)
+              return super unless enabled?
+
               trace(Ext::SPAN_SYNC_EXEC_PARAMS, sql: sql, block: block) do |sql_statement, wrapped_block|
                 super(sql_statement, params, *args, &wrapped_block)
               end
             end
 
             def sync_exec_prepared(statement_name, params, *args, &block)
+              return super unless enabled?
+
               trace(Ext::SPAN_SYNC_EXEC_PREPARED, statement_name: statement_name, block: block) do |_, wrapped_block|
                 super(statement_name, params, *args, &wrapped_block)
               end
@@ -171,6 +189,10 @@ module Datadog
 
             def comment_propagation
               datadog_configuration[:comment_propagation]
+            end
+
+            def enabled?
+              datadog_configuration[:enabled]
             end
           end
         end

--- a/spec/datadog/tracing/contrib/pg/patcher_spec.rb
+++ b/spec/datadog/tracing/contrib/pg/patcher_spec.rb
@@ -71,7 +71,7 @@ RSpec.describe 'PG::Connection patcher' do
           it 'does not generate spans' do
             result = exec
 
-            expect(result.values).to eq([["1"]])
+            expect(result.values).to eq([['1']])
             expect(spans).to be_empty
           end
         end
@@ -322,7 +322,7 @@ RSpec.describe 'PG::Connection patcher' do
           it 'does not generate spans' do
             result = exec_params
 
-            expect(result.values).to eq([["1"]])
+            expect(result.values).to eq([['1']])
             expect(spans).to be_empty
           end
         end
@@ -580,7 +580,7 @@ RSpec.describe 'PG::Connection patcher' do
           it 'does not generate spans' do
             result = exec_prepared
 
-            expect(result.values).to eq([["1"]])
+            expect(result.values).to eq([['1']])
             expect(spans).to be_empty
           end
         end
@@ -824,7 +824,7 @@ RSpec.describe 'PG::Connection patcher' do
           it 'does not generate spans' do
             result = async_exec
 
-            expect(result.values).to eq([["1"]])
+            expect(result.values).to eq([['1']])
             expect(spans).to be_empty
           end
         end
@@ -1085,7 +1085,7 @@ RSpec.describe 'PG::Connection patcher' do
           it 'does not generate spans' do
             result = async_exec_params
 
-            expect(result.values).to eq([["1"]])
+            expect(result.values).to eq([['1']])
             expect(spans).to be_empty
           end
         end
@@ -1342,7 +1342,7 @@ RSpec.describe 'PG::Connection patcher' do
           it 'does not generate spans' do
             result = async_exec_prepared
 
-            expect(result.values).to eq([["1"]])
+            expect(result.values).to eq([['1']])
             expect(spans).to be_empty
           end
         end
@@ -1593,7 +1593,7 @@ RSpec.describe 'PG::Connection patcher' do
           it 'does not generate spans' do
             result = sync_exec
 
-            expect(result.values).to eq([["1"]])
+            expect(result.values).to eq([['1']])
             expect(spans).to be_empty
           end
         end
@@ -1845,7 +1845,7 @@ RSpec.describe 'PG::Connection patcher' do
           it 'does not generate spans' do
             result = sync_exec_params
 
-            expect(result.values).to eq([["1"]])
+            expect(result.values).to eq([['1']])
             expect(spans).to be_empty
           end
         end
@@ -2098,7 +2098,7 @@ RSpec.describe 'PG::Connection patcher' do
           it 'does not generate spans' do
             result = sync_exec_prepared
 
-            expect(result.values).to eq([["1"]])
+            expect(result.values).to eq([['1']])
             expect(spans).to be_empty
           end
         end

--- a/spec/datadog/tracing/contrib/pg/patcher_spec.rb
+++ b/spec/datadog/tracing/contrib/pg/patcher_spec.rb
@@ -65,6 +65,17 @@ RSpec.describe 'PG::Connection patcher' do
           end
         end
 
+        context 'when instrumentation is disabled' do
+          let(:configuration_options) { { enabled: false } }
+
+          it 'does not generate spans' do
+            result = exec
+
+            expect(result.values).to eq([["1"]])
+            expect(spans).to be_empty
+          end
+        end
+
         context 'when the tracer is configured directly' do
           let(:service_name) { 'pg-override' }
 
@@ -174,6 +185,16 @@ RSpec.describe 'PG::Connection patcher' do
           before { tracer.enabled = false }
 
           it 'does not write spans' do
+            exec
+
+            expect(spans).to be_empty
+          end
+        end
+
+        context 'when instrumentation is disabled' do
+          let(:configuration_options) { { enabled: false } }
+
+          it 'does not generate spans' do
             exec
 
             expect(spans).to be_empty
@@ -295,6 +316,17 @@ RSpec.describe 'PG::Connection patcher' do
           end
         end
 
+        context 'when instrumentation is disabled' do
+          let(:configuration_options) { { enabled: false } }
+
+          it 'does not generate spans' do
+            result = exec_params
+
+            expect(result.values).to eq([["1"]])
+            expect(spans).to be_empty
+          end
+        end
+
         context 'when the tracer is configured directly' do
           let(:service_name) { 'pg-override' }
 
@@ -406,6 +438,16 @@ RSpec.describe 'PG::Connection patcher' do
           before { tracer.enabled = false }
 
           it 'does not write spans' do
+            exec_params
+
+            expect(spans).to be_empty
+          end
+        end
+
+        context 'when instrumentation is disabled' do
+          let(:configuration_options) { { enabled: false } }
+
+          it 'does not generate spans' do
             exec_params
 
             expect(spans).to be_empty
@@ -532,6 +574,17 @@ RSpec.describe 'PG::Connection patcher' do
           end
         end
 
+        context 'when instrumentation is disabled' do
+          let(:configuration_options) { { enabled: false } }
+
+          it 'does not generate spans' do
+            result = exec_prepared
+
+            expect(result.values).to eq([["1"]])
+            expect(spans).to be_empty
+          end
+        end
+
         context 'when the tracer is configured directly' do
           let(:service_override) { 'pg-override' }
 
@@ -637,6 +690,16 @@ RSpec.describe 'PG::Connection patcher' do
 
           it 'does not write spans' do
             exec_prepared
+            expect(spans).to be_empty
+          end
+        end
+
+        context 'when instrumentation is disabled' do
+          let(:configuration_options) { { enabled: false } }
+
+          it 'does not generate spans' do
+            exec_prepared
+
             expect(spans).to be_empty
           end
         end
@@ -755,6 +818,17 @@ RSpec.describe 'PG::Connection patcher' do
           end
         end
 
+        context 'when instrumentation is disabled' do
+          let(:configuration_options) { { enabled: false } }
+
+          it 'does not generate spans' do
+            result = async_exec
+
+            expect(result.values).to eq([["1"]])
+            expect(spans).to be_empty
+          end
+        end
+
         context 'when the tracer is configured directly' do
           let(:service_name) { 'pg-override' }
 
@@ -865,6 +939,16 @@ RSpec.describe 'PG::Connection patcher' do
           before { tracer.enabled = false }
 
           it 'does not write spans' do
+            async_exec
+
+            expect(spans).to be_empty
+          end
+        end
+
+        context 'when instrumentation is disabled' do
+          let(:configuration_options) { { enabled: false } }
+
+          it 'does not generate spans' do
             async_exec
 
             expect(spans).to be_empty
@@ -995,6 +1079,17 @@ RSpec.describe 'PG::Connection patcher' do
           end
         end
 
+        context 'when instrumentation is disabled' do
+          let(:configuration_options) { { enabled: false } }
+
+          it 'does not generate spans' do
+            result = async_exec_params
+
+            expect(result.values).to eq([["1"]])
+            expect(spans).to be_empty
+          end
+        end
+
         context 'when the tracer is configured directly' do
           let(:service_name) { 'pg-override' }
 
@@ -1111,6 +1206,16 @@ RSpec.describe 'PG::Connection patcher' do
           end
         end
 
+        context 'when instrumentation is disabled' do
+          let(:configuration_options) { { enabled: false } }
+
+          it 'does not generate spans' do
+            async_exec_params
+
+            expect(spans).to be_empty
+          end
+        end
+
         context 'when the tracer is configured directly' do
           let(:service_name) { 'pg-override' }
 
@@ -1221,11 +1326,23 @@ RSpec.describe 'PG::Connection patcher' do
 
       context 'when without given block' do
         subject(:async_exec_prepared) { conn.async_exec_prepared('prepared select 1', [1]) }
+
         context 'when the tracer is disabled' do
           before { tracer.enabled = false }
 
           it 'does not write spans' do
             async_exec_prepared
+            expect(spans).to be_empty
+          end
+        end
+
+        context 'when instrumentation is disabled' do
+          let(:configuration_options) { { enabled: false } }
+
+          it 'does not generate spans' do
+            result = async_exec_prepared
+
+            expect(result.values).to eq([["1"]])
             expect(spans).to be_empty
           end
         end
@@ -1335,6 +1452,17 @@ RSpec.describe 'PG::Connection patcher' do
 
           it 'does not write spans' do
             async_exec_prepared
+
+            expect(spans).to be_empty
+          end
+        end
+
+        context 'when instrumentation is disabled' do
+          let(:configuration_options) { { enabled: false } }
+
+          it 'does not generate spans' do
+            async_exec_prepared
+
             expect(spans).to be_empty
           end
         end
@@ -1459,6 +1587,17 @@ RSpec.describe 'PG::Connection patcher' do
           end
         end
 
+        context 'when instrumentation is disabled' do
+          let(:configuration_options) { { enabled: false } }
+
+          it 'does not generate spans' do
+            result = sync_exec
+
+            expect(result.values).to eq([["1"]])
+            expect(spans).to be_empty
+          end
+        end
+
         context 'when the tracer is configured directly' do
           let(:service_name) { 'pg-override' }
 
@@ -1567,6 +1706,16 @@ RSpec.describe 'PG::Connection patcher' do
           before { tracer.enabled = false }
 
           it 'does not write spans' do
+            sync_exec
+
+            expect(spans).to be_empty
+          end
+        end
+
+        context 'when instrumentation is disabled' do
+          let(:configuration_options) { { enabled: false } }
+
+          it 'does not generate spans' do
             sync_exec
 
             expect(spans).to be_empty
@@ -1690,6 +1839,17 @@ RSpec.describe 'PG::Connection patcher' do
           end
         end
 
+        context 'when instrumentation is disabled' do
+          let(:configuration_options) { { enabled: false } }
+
+          it 'does not generate spans' do
+            result = sync_exec_params
+
+            expect(result.values).to eq([["1"]])
+            expect(spans).to be_empty
+          end
+        end
+
         context 'when the tracer is configured directly' do
           let(:service_name) { 'pg-override' }
 
@@ -1801,6 +1961,16 @@ RSpec.describe 'PG::Connection patcher' do
 
           it 'does not write spans' do
             sync_exec_params
+            expect(spans).to be_empty
+          end
+        end
+
+        context 'when instrumentation is disabled' do
+          let(:configuration_options) { { enabled: false } }
+
+          it 'does not generate spans' do
+            sync_exec_params
+
             expect(spans).to be_empty
           end
         end
@@ -1922,6 +2092,17 @@ RSpec.describe 'PG::Connection patcher' do
           end
         end
 
+        context 'when instrumentation is disabled' do
+          let(:configuration_options) { { enabled: false } }
+
+          it 'does not generate spans' do
+            result = sync_exec_prepared
+
+            expect(result.values).to eq([["1"]])
+            expect(spans).to be_empty
+          end
+        end
+
         context 'when the tracer is configured directly' do
           let(:service_override) { 'pg-override' }
 
@@ -2026,6 +2207,16 @@ RSpec.describe 'PG::Connection patcher' do
 
           it 'does not write spans' do
             sync_exec_prepared
+            expect(spans).to be_empty
+          end
+        end
+
+        context 'when instrumentation is disabled' do
+          let(:configuration_options) { { enabled: false } }
+
+          it 'does not generate spans' do
+            sync_exec_prepared
+
             expect(spans).to be_empty
           end
         end


### PR DESCRIPTION
**What does this PR do?**

This PR fixes the pg instrumentation to respect the `enable` option from configuration settings. 

**For Datadog employees:**
- [ ] If this PR touches code that signs or publishes builds or packages, or handles
credentials of any kind, I've requested a review from `@DataDog/security-design-and-guidance`.
- [x] This PR doesn't touch any of that.

Unsure? Have a question? Request a review!
