### PR TITLE
Mark ddtrace threads as fork-safe

### DIFF
--- a/lib/datadog/core/configuration.rb
+++ b/lib/datadog/core/configuration.rb
@@ -273,6 +273,10 @@ module Datadog
       def handle_interrupt_shutdown!
         logger = Datadog.logger
         shutdown_thread = Thread.new { shutdown! }
+        unless Gem::Version.new(RUBY_VERSION) < Gem::Version.new('2.3')
+          shutdown_thread.name = Datadog::Core::Configuration.name
+        end
+
         print_message_treshold_seconds = 0.2
 
         slow_shutdown = shutdown_thread.join(print_message_treshold_seconds).nil?

--- a/lib/datadog/core/remote/worker.rb
+++ b/lib/datadog/core/remote/worker.rb
@@ -30,6 +30,7 @@ module Datadog
 
           thread = Thread.new { poll(@interval) }
           thread.name = self.class.name unless Gem::Version.new(RUBY_VERSION) < Gem::Version.new('2.3')
+          thread.thread_variable_set(:fork_safe, true)
           @thr = thread
 
           @started = true

--- a/lib/datadog/core/workers/async.rb
+++ b/lib/datadog/core/workers/async.rb
@@ -147,6 +147,7 @@ module Datadog
               # rubocop:enable Lint/RescueException
             end
             @worker.name = self.class.name unless Gem::Version.new(RUBY_VERSION) < Gem::Version.new('2.3')
+            @worker.thread_variable_set(:fork_safe, true)
 
             nil
           end

--- a/lib/datadog/profiling/collectors/cpu_and_wall_time_worker.rb
+++ b/lib/datadog/profiling/collectors/cpu_and_wall_time_worker.rb
@@ -78,6 +78,7 @@ module Datadog
               end
             end
             @worker_thread.name = self.class.name # Repeated from above to make sure thread gets named asap
+            @worker_thread.thread_variable_set(:fork_safe, true)
           end
 
           true

--- a/lib/datadog/profiling/collectors/idle_sampling_helper.rb
+++ b/lib/datadog/profiling/collectors/idle_sampling_helper.rb
@@ -43,6 +43,7 @@ module Datadog
               end
             end
             @worker_thread.name = self.class.name # Repeated from above to make sure thread gets named asap
+            @worker_thread.thread_variable_set(:fork_safe, true)
           end
 
           true

--- a/lib/datadog/tracing/workers.rb
+++ b/lib/datadog/tracing/workers.rb
@@ -69,6 +69,7 @@ module Datadog
             Datadog.logger.debug { "Starting thread for: #{self}" }
             @worker = Thread.new { perform }
             @worker.name = self.class.name unless Gem::Version.new(RUBY_VERSION) < Gem::Version.new('2.3')
+            @worker.thread_variable_set(:fork_safe, true)
 
             nil
           end

--- a/spec/datadog/core/configuration_spec.rb
+++ b/spec/datadog/core/configuration_spec.rb
@@ -599,7 +599,13 @@ RSpec.describe Datadog::Core::Configuration do
     describe '#handle_interrupt_shutdown!' do
       subject(:handle_interrupt_shutdown!) { test_class.send(:handle_interrupt_shutdown!) }
 
-      let(:fake_thread) { instance_double(Thread, 'fake thread') }
+      let(:fake_thread) do
+        instance_double(Thread, 'fake thread').tap do |it|
+          if Gem::Version.new(RUBY_VERSION) >= Gem::Version.new('2.3')
+            expect(it).to(receive(:name=).with('Datadog::Core::Configuration'))
+          end
+        end
+      end
 
       it 'calls #shutdown! in a background thread' do
         allow(fake_thread).to receive(:join).and_return(fake_thread)

--- a/spec/datadog/core/remote/worker_spec.rb
+++ b/spec/datadog/core/remote/worker_spec.rb
@@ -61,6 +61,7 @@ RSpec.describe Datadog::Core::Remote::Worker do
       end
     end
 
+    # See https://github.com/puma/puma/blob/32e011ab9e029c757823efb068358ed255fb7ef4/lib/puma/cluster.rb#L353-L359
     it 'marks the worker thread as fork-safe (to avoid fork-safety warnings in webservers)' do
       worker.start
 

--- a/spec/datadog/core/remote/worker_spec.rb
+++ b/spec/datadog/core/remote/worker_spec.rb
@@ -60,6 +60,12 @@ RSpec.describe Datadog::Core::Remote::Worker do
         expect(Thread.list.map(&:name)).to include(described_class.to_s)
       end
     end
+
+    it 'marks the worker thread as fork-safe (to avoid fork-safety warnings in webservers)' do
+      worker.start
+
+      expect(worker.instance_variable_get(:@thr).thread_variable_get(:fork_safe)).to be true
+    end
   end
 
   describe '#stop' do

--- a/spec/datadog/core/workers/async_spec.rb
+++ b/spec/datadog/core/workers/async_spec.rb
@@ -489,6 +489,7 @@ RSpec.describe Datadog::Core::Workers::Async::Thread do
         end
       end
 
+      # See https://github.com/puma/puma/blob/32e011ab9e029c757823efb068358ed255fb7ef4/lib/puma/cluster.rb#L353-L359
       it 'marks the worker thread as fork-safe (to avoid fork-safety warnings in webservers)' do
         worker.perform
 

--- a/spec/datadog/core/workers/async_spec.rb
+++ b/spec/datadog/core/workers/async_spec.rb
@@ -451,7 +451,7 @@ RSpec.describe Datadog::Core::Workers::Async::Thread do
       end
     end
 
-    describe 'thread naming' do
+    describe 'thread naming and fork-safety marker' do
       after { worker.terminate }
 
       context 'on Ruby < 2.3' do
@@ -487,6 +487,12 @@ RSpec.describe Datadog::Core::Workers::Async::Thread do
 
           expect(worker.send(:worker).name).to eq worker_class.to_s
         end
+      end
+
+      it 'marks the worker thread as fork-safe (to avoid fork-safety warnings in webservers)' do
+        worker.perform
+
+        expect(worker.send(:worker).thread_variable_get(:fork_safe)).to be true
       end
     end
   end

--- a/spec/datadog/profiling/collectors/cpu_and_wall_time_worker_spec.rb
+++ b/spec/datadog/profiling/collectors/cpu_and_wall_time_worker_spec.rb
@@ -71,6 +71,7 @@ RSpec.describe 'Datadog::Profiling::Collectors::CpuAndWallTimeWorker' do
       expect(Thread.list.map(&:name)).to include(described_class.name)
     end
 
+    # See https://github.com/puma/puma/blob/32e011ab9e029c757823efb068358ed255fb7ef4/lib/puma/cluster.rb#L353-L359
     it 'marks the new thread as fork-safe' do
       start
 

--- a/spec/datadog/profiling/collectors/cpu_and_wall_time_worker_spec.rb
+++ b/spec/datadog/profiling/collectors/cpu_and_wall_time_worker_spec.rb
@@ -71,6 +71,12 @@ RSpec.describe 'Datadog::Profiling::Collectors::CpuAndWallTimeWorker' do
       expect(Thread.list.map(&:name)).to include(described_class.name)
     end
 
+    it 'marks the new thread as fork-safe' do
+      start
+
+      expect(cpu_and_wall_time_worker.instance_variable_get(:@worker_thread).thread_variable_get(:fork_safe)).to be true
+    end
+
     it 'does not create a second thread if start is called again' do
       start
 

--- a/spec/datadog/profiling/collectors/idle_sampling_helper_spec.rb
+++ b/spec/datadog/profiling/collectors/idle_sampling_helper_spec.rb
@@ -26,6 +26,7 @@ RSpec.describe Datadog::Profiling::Collectors::IdleSamplingHelper do
       start
     end
 
+    # See https://github.com/puma/puma/blob/32e011ab9e029c757823efb068358ed255fb7ef4/lib/puma/cluster.rb#L353-L359
     it 'marks the new thread as fork-safe' do
       start
 

--- a/spec/datadog/profiling/collectors/idle_sampling_helper_spec.rb
+++ b/spec/datadog/profiling/collectors/idle_sampling_helper_spec.rb
@@ -26,6 +26,12 @@ RSpec.describe Datadog::Profiling::Collectors::IdleSamplingHelper do
       start
     end
 
+    it 'marks the new thread as fork-safe' do
+      start
+
+      expect(idle_sampling_helper.instance_variable_get(:@worker_thread).thread_variable_get(:fork_safe)).to be true
+    end
+
     it 'does not create a second thread if start is called again' do
       start
 

--- a/spec/datadog/tracing/workers_spec.rb
+++ b/spec/datadog/tracing/workers_spec.rb
@@ -39,7 +39,7 @@ RSpec.describe Datadog::Tracing::Workers::AsyncTransport do
     end
   end
 
-  describe 'thread naming' do
+  describe 'thread naming and fork-safety marker' do
     context 'on Ruby < 2.3' do
       before do
         skip 'Only applies to old Rubies' if Gem::Version.new(RUBY_VERSION) >= Gem::Version.new('2.3')
@@ -64,6 +64,12 @@ RSpec.describe Datadog::Tracing::Workers::AsyncTransport do
 
         expect(worker.instance_variable_get(:@worker).name).to eq described_class.name
       end
+    end
+
+    it 'marks the worker thread as fork-safe (to avoid fork-safety warnings in webservers)' do
+      worker.start
+
+      expect(worker.instance_variable_get(:@worker).thread_variable_get(:fork_safe)).to be true
     end
   end
 

--- a/spec/datadog/tracing/workers_spec.rb
+++ b/spec/datadog/tracing/workers_spec.rb
@@ -66,6 +66,7 @@ RSpec.describe Datadog::Tracing::Workers::AsyncTransport do
       end
     end
 
+    # See https://github.com/puma/puma/blob/32e011ab9e029c757823efb068358ed255fb7ef4/lib/puma/cluster.rb#L353-L359
     it 'marks the worker thread as fork-safe (to avoid fork-safety warnings in webservers)' do
       worker.start
 


### PR DESCRIPTION
**What does this PR do?**

This PR applies to all relevant ddtrace threads a pattern pioneered by rails: set the `:fork_safe` thread variable to indicate that it's OK if ddtrace threads are started before a Ruby app calls fork.

**Motivation:**

This PR fixes the issue reported in #3203. The puma webserver in clustering mode has a check where it will warn when it detects that threads were started before the webserver has fork'd the child processes, see:

https://github.com/puma/puma/blob/32e011ab9e029c757823efb068358ed255fb7ef4/lib/puma/cluster.rb#L353-L359

This is not a problem for ddtrace (as discussed in #3203), but the warning is annoying.

While looking into the issue again today, I spotted that actually there's a way to tell puma that a thread is fine and is it's not a problem if it's started before the webserver has fork'd: puma checks if the thread has a `:fork_safe` thread-variable set to `true`.

**Additional Notes:**

We have a bunch of places in ddtrace where we create threads... I briefly played with the idea of creating a superclass of all ddtrace Threads, but decided to not get into a bigger refactoring for such a small issue. Maybe next time...?

**How to test the change?**

Test coverage included. Furthermore, you can try running a Ruby webapp in puma before/after the change to confirm the warning is gone.

**For Datadog employees:**
- [ ] If this PR touches code that signs or publishes builds or packages, or handles
credentials of any kind, I've requested a review from `@DataDog/security-design-and-guidance`.
- [x] This PR doesn't touch any of that.

Fixes #3203