### PR TITLE
Allow profiler to run without "no signals" workaround on passenger 6.0.19+

### DIFF
--- a/lib/datadog/profiling/component.rb
+++ b/lib/datadog/profiling/component.rb
@@ -171,12 +171,11 @@ module Datadog
           return true
         end
 
-        if defined?(::PhusionPassenger)
+        if (defined?(::PhusionPassenger) || Gem.loaded_specs['passenger']) && incompatible_passenger_version?
           Datadog.logger.warn(
-            'Enabling the profiling "no signals" workaround because the passenger web server is in use. ' \
-            'This is needed because passenger is currently incompatible with the normal working mode ' \
-            'of the profiler, as detailed in <https://github.com/DataDog/dd-trace-rb/issues/2976>. ' \
-            'Profiling data will have lower quality.'
+            'Enabling the profiling "no signals" workaround because an incompatible version of the passenger gem is ' \
+            'installed. Profiling data will have lower quality.' \
+            'To fix this, upgrade the passenger gem to version 6.0.19 or above.'
           )
           return true
         end
@@ -234,6 +233,15 @@ module Datadog
             "Cause: #{e.class.name} #{e.message} Location: #{Array(e.backtrace).first}"
           )
 
+          true
+        end
+      end
+
+      # See https://github.com/datadog/dd-trace-rb/issues/2976 for details.
+      private_class_method def self.incompatible_passenger_version?
+        if Gem.loaded_specs['passenger']
+          Gem.loaded_specs['passenger'].version < Gem::Version.new('6.0.19')
+        else
           true
         end
       end

--- a/sig/datadog/profiling/component.rbs
+++ b/sig/datadog/profiling/component.rbs
@@ -23,6 +23,7 @@ module Datadog
       def self.no_signals_workaround_enabled?: (untyped settings) -> bool
 
       def self.incompatible_libmysqlclient_version?: (untyped settings) -> bool
+      def self.incompatible_passenger_version?: () -> bool
     end
   end
 end

--- a/spec/datadog/profiling/component_spec.rb
+++ b/spec/datadog/profiling/component_spec.rb
@@ -480,7 +480,9 @@ RSpec.describe Datadog::Profiling::Component do
           end
         end
 
-        context 'when running inside the passenger web server' do
+        context 'when running inside the passenger web server, even when gem is not available' do
+          include_context('loaded gems', passenger: nil, rugged: nil, mysql2: nil)
+
           before do
             stub_const('::PhusionPassenger', Module.new)
             allow(Datadog.logger).to receive(:warn)
@@ -495,8 +497,30 @@ RSpec.describe Datadog::Profiling::Component do
           end
         end
 
+        context 'when passenger gem is available' do
+          context 'on passenger >= 6.0.19' do
+            include_context('loaded gems', passenger: Gem::Version.new('6.0.19'), rugged: nil, mysql2: nil)
+
+            it { is_expected.to be false }
+          end
+
+          context 'on passenger < 6.0.19' do
+            include_context('loaded gems', passenger: Gem::Version.new('6.0.18'), rugged: nil, mysql2: nil)
+
+            before { allow(Datadog.logger).to receive(:warn) }
+
+            it { is_expected.to be true }
+
+            it 'logs a warning message mentioning that the no signals workaround is going to be used' do
+              expect(Datadog.logger).to receive(:warn).with(/Enabling the profiling "no signals" workaround/)
+
+              no_signals_workaround_enabled?
+            end
+          end
+        end
+
         context 'when mysql2 / rugged gems + passenger are not available' do
-          include_context('loaded gems', mysql2: nil, rugged: nil)
+          include_context('loaded gems', passenger: nil, mysql2: nil, rugged: nil)
 
           it { is_expected.to be false }
         end


### PR DESCRIPTION
**What does this PR do?**

This PR is the last step to fully fixing the issue reported in #2976.

In that issue, we discovered that he passenger web server had an incompatibility with the profiler. At the time, we added code to detect when passenger was in use and apply the "no signals" workaround to avoid this issue out-of-the-box.

Upstream passenger has since accepted our PR to fix the issue, allowing us in this PR to change our detection logic to:

a) Not enable the "no signals" workaround on passenger 6.0.19+
b) Provide an actionable error message to customers on older passenger versions to tell them that the best option is to upgrade

**Motivation:**

Improve the out-of-the-box experience of profiler users that use the passenger web server.

**Additional Notes:**

N/A

**How to test the change?**

I used the following `config.ru`:

```ruby
def self.fib(n)
  n <= 1 ? n : fib(n-1) + fib(n-2)
end

app = ->(env) {
  puts " ** Got request!"

  [200, {}, ["Hello, World! #{fib(30)}"]]
}
run app
```

and `Gemfile`:

```ruby
source 'https://rubygems.org'

gem 'ddtrace', path: 'path/to/local/repo'
 #gem 'passenger', '= 6.0.18'
gem 'passenger', '= 6.0.19'
gem 'puma'
```

to validate that the passenger versions are correctly detected + request processing is not impacted on either.

**For Datadog employees:**
- [ ] If this PR touches code that signs or publishes builds or packages, or handles
credentials of any kind, I've requested a review from `@DataDog/security-design-and-guidance`.
- [x] This PR doesn't touch any of that.

Fixes #2976