### PR TITLE
Revert "Disable Ruby 3.3 integration due to protobuf compilation error"

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -606,12 +606,11 @@ workflows:
           integration_apps: 'rack rails-six rails-seven sinatra2-classic sinatra2-modular'
           ruby_version: '3.2'
           <<: *filters_all_branches_and_tags
-#      # Disabled until https://github.com/protocolbuffers/protobuf/issues/14509 is fixed.
-#      - orb/build_and_test_integration:
-#          name: build_and_test_integration-3.3
-#          integration_apps: 'rack rails-six rails-seven sinatra2-classic sinatra2-modular'
-#          ruby_version: '3.3'
-#          <<: *filters_all_branches_and_tags
+      - orb/build_and_test_integration:
+          name: build_and_test_integration-3.3
+          integration_apps: 'rack rails-six rails-seven sinatra2-classic sinatra2-modular'
+          ruby_version: '3.3'
+          <<: *filters_all_branches_and_tags
       # ⬆️ **Note**: If add/remove test apps above, remember to also copy-paste the changes to the "edge" workflow further down the file.
       #
       # ADD NEW RUBIES HERE


### PR DESCRIPTION
**What does this PR do?**

This reverts commit f9ebce90b92fbb0fec14f0865504610b31b51a04.

**Motivation:**

In #3211 we disabled our CI integration testing on Ruby 3.3 because one of the dependencies (protobuf) had an incompatibility at the time (see protocolbuffers/protobuf#14509 for details).

Upstream has since fixed the issue, so we're good to go.

**Additional Notes:**

N/A

**How to test the change?**

Check that CircleCI is now also running the `build_and_test_integration-3.3` test.

**For Datadog employees:**
- [ ] If this PR touches code that signs or publishes builds or packages, or handles
credentials of any kind, I've requested a review from `@DataDog/security-design-and-guidance`.
- [x] This PR doesn't touch any of that.