### PR TITLE
Call Devise RegistrationsController block

### DIFF
--- a/lib/datadog/appsec/contrib/devise/patcher/registration_controller_patch.rb
+++ b/lib/datadog/appsec/contrib/devise/patcher/registration_controller_patch.rb
@@ -42,6 +42,8 @@ module Datadog
                     **event_information.to_h
                   )
                 end
+
+                yield resource if block_given?
               end
             end
           end

--- a/spec/datadog/appsec/contrib/devise/patcher/registration_controller_patch_spec.rb
+++ b/spec/datadog/appsec/contrib/devise/patcher/registration_controller_patch_spec.rb
@@ -66,6 +66,17 @@ RSpec.describe Datadog::AppSec::Contrib::Devise::Patcher::RegistrationController
       expect(Datadog::AppSec::Contrib::Devise::Tracking).to_not receive(:track_signup)
       expect(controller.create).to eq(true)
     end
+
+    context 'and a block is given' do
+      let(:canary) { proc { |resource| } }
+      let(:block) { proc { |resource| canary.call(resource) } }
+
+      it 'do not tracks event' do
+        expect(Datadog::AppSec::Contrib::Devise::Tracking).to_not receive(:track_signup)
+        expect(canary).to receive(:call).with(resource)
+        expect(controller.create(&block)).to eq(true)
+      end
+    end
   end
 
   context 'Automated user tracking is disabled' do
@@ -76,6 +87,17 @@ RSpec.describe Datadog::AppSec::Contrib::Devise::Patcher::RegistrationController
     it 'do not tracks event' do
       expect(Datadog::AppSec::Contrib::Devise::Tracking).to_not receive(:track_signup)
       expect(controller.create).to eq(true)
+    end
+
+    context 'and a block is given' do
+      let(:canary) { proc { |resource| } }
+      let(:block) { proc { |resource| canary.call(resource) } }
+
+      it 'do not tracks event' do
+        expect(Datadog::AppSec::Contrib::Devise::Tracking).to_not receive(:track_signup)
+        expect(canary).to receive(:call).with(resource)
+        expect(controller.create(&block)).to eq(true)
+      end
     end
   end
 
@@ -89,6 +111,17 @@ RSpec.describe Datadog::AppSec::Contrib::Devise::Patcher::RegistrationController
       expect(Datadog::AppSec::Contrib::Devise::Tracking).to_not receive(:track_signup)
       expect(controller.create).to eq(true)
     end
+
+    context 'and a block is given' do
+      let(:canary) { proc { |resource| } }
+      let(:block) { proc { |resource| canary.call(resource) } }
+
+      it 'do not tracks event' do
+        expect(Datadog::AppSec::Contrib::Devise::Tracking).to_not receive(:track_signup)
+        expect(canary).to receive(:call).with(resource)
+        expect(controller.create(&block)).to eq(true)
+      end
+    end
   end
 
   context 'with persisted resource' do
@@ -98,6 +131,41 @@ RSpec.describe Datadog::AppSec::Contrib::Devise::Patcher::RegistrationController
 
     context 'with resource ID' do
       let(:resource) { persited_resource }
+
+      context 'and a block is given' do
+        let(:canary) { proc { |resource| } }
+        let(:block) { proc { |resource| canary.call(resource) } }
+
+        context 'safe mode' do
+          let(:mode) { 'safe' }
+
+          it 'tracks event' do
+            expect(Datadog::AppSec::Contrib::Devise::Tracking).to receive(:track_signup).with(
+              appsec_scope.trace,
+              appsec_scope.service_entry_span,
+              user_id: resource.id,
+              **{}
+            )
+            expect(canary).to receive(:call).with(resource)
+            expect(controller.create(&block)).to eq(true)
+          end
+        end
+
+        context 'extended mode' do
+          let(:mode) { 'extended' }
+
+          it 'tracks event' do
+            expect(Datadog::AppSec::Contrib::Devise::Tracking).to receive(:track_signup).with(
+              appsec_scope.trace,
+              appsec_scope.service_entry_span,
+              user_id: resource.id,
+              **{ email: 'hello@gmail.com', username: 'John' }
+            )
+            expect(canary).to receive(:call).with(resource)
+            expect(controller.create(&block)).to eq(true)
+          end
+        end
+      end
 
       context 'safe mode' do
         let(:mode) { 'safe' }
@@ -130,6 +198,41 @@ RSpec.describe Datadog::AppSec::Contrib::Devise::Patcher::RegistrationController
 
     context 'without resource ID' do
       let(:resource) { mock_resource.new(nil, 'hello@gmail.com', 'John', true) }
+
+      context 'and a block is given' do
+        let(:canary) { proc { |resource| } }
+        let(:block) { proc { |resource| canary.call(resource) } }
+
+        context 'safe mode' do
+          let(:mode) { 'safe' }
+
+          it 'tracks event' do
+            expect(Datadog::AppSec::Contrib::Devise::Tracking).to receive(:track_signup).with(
+              appsec_scope.trace,
+              appsec_scope.service_entry_span,
+              user_id: nil,
+              **{}
+            )
+            expect(canary).to receive(:call).with(resource)
+            expect(controller.create(&block)).to eq(true)
+          end
+        end
+
+        context 'extended mode' do
+          let(:mode) { 'extended' }
+
+          it 'tracks event' do
+            expect(Datadog::AppSec::Contrib::Devise::Tracking).to receive(:track_signup).with(
+              appsec_scope.trace,
+              appsec_scope.service_entry_span,
+              user_id: nil,
+              **{ email: 'hello@gmail.com', username: 'John' }
+            )
+            expect(canary).to receive(:call).with(resource)
+            expect(controller.create(&block)).to eq(true)
+          end
+        end
+      end
 
       context 'safe mode' do
         let(:mode) { 'safe' }
@@ -174,6 +277,17 @@ RSpec.describe Datadog::AppSec::Contrib::Devise::Patcher::RegistrationController
         expect(Datadog::AppSec::Contrib::Devise::Tracking).to_not receive(:track_signup)
         expect(controller.create).to eq(true)
       end
+
+      context 'and a block is given' do
+        let(:canary) { proc { |resource| } }
+        let(:block) { proc { |resource| canary.call(resource) } }
+
+        it 'do not tracks event' do
+          expect(Datadog::AppSec::Contrib::Devise::Tracking).to_not receive(:track_signup)
+          expect(canary).to receive(:call).with(resource)
+          expect(controller.create(&block)).to eq(true)
+        end
+      end
     end
 
     context 'extended mode' do
@@ -182,6 +296,17 @@ RSpec.describe Datadog::AppSec::Contrib::Devise::Patcher::RegistrationController
       it 'tracks event' do
         expect(Datadog::AppSec::Contrib::Devise::Tracking).to_not receive(:track_signup)
         expect(controller.create).to eq(true)
+      end
+
+      context 'and a block is given' do
+        let(:canary) { proc { |resource| } }
+        let(:block) { proc { |resource| canary.call(resource) } }
+
+        it 'do not tracks event' do
+          expect(Datadog::AppSec::Contrib::Devise::Tracking).to_not receive(:track_signup)
+          expect(canary).to receive(:call).with(resource)
+          expect(controller.create(&block)).to eq(true)
+        end
       end
     end
   end


### PR DESCRIPTION
**What does this PR do?**
<!-- A brief description of the change being made with this pull request. -->

When a Devise user calls create with a block, that block was swallowed by the block we use to perform our resource information extraction for registration events.

Ensure the original block is called. We call it after our analysis in the event we should block for some reason, thus protecting the additional user code in their block.

<!--
Check out the
https://github.com/DataDog/dd-trace-rb/blob/master/docs/DevelopmentGuide.md
for guidance on how to set up your development environment,
run the test suite, write new integrations, and more.
-->


**Motivation:**

User-reported issue.

**Additional Notes:**

JIRA:
- [SCRS-704](https://datadoghq.atlassian.net/browse/SCRS-704)
- [APPSEC-12115](https://datadoghq.atlassian.net/browse/APPSEC-12115)
- [APPSEC-12770](https://datadoghq.atlassian.net/browse/APPSEC-12770)

**How to test the change?**

Specs

**For Datadog employees:**
- [ ] If this PR touches code that signs or publishes builds or packages, or handles
credentials of any kind, I've requested a review from `@DataDog/security-design-and-guidance`.
- [ ] This PR doesn't touch any of that.

Unsure? Have a question? Request a review!
