### PR TITLE
[PROF-8667] Heap Profiling - Part 2 - Heap Recorder

### DIFF
--- a/ext/ddtrace_profiling_native_extension/collectors_stack.c
+++ b/ext/ddtrace_profiling_native_extension/collectors_stack.c
@@ -11,9 +11,6 @@
 // Gathers stack traces from running threads, storing them in a StackRecorder instance
 // This file implements the native bits of the Datadog::Profiling::Collectors::Stack class
 
-#define MAX_FRAMES_LIMIT            10000
-#define MAX_FRAMES_LIMIT_AS_STRING "10000"
-
 static VALUE missing_string = Qnil;
 
 // Used as scratch space during sampling

--- a/ext/ddtrace_profiling_native_extension/collectors_stack.h
+++ b/ext/ddtrace_profiling_native_extension/collectors_stack.h
@@ -4,6 +4,9 @@
 
 #include "stack_recorder.h"
 
+#define MAX_FRAMES_LIMIT            10000
+#define MAX_FRAMES_LIMIT_AS_STRING "10000"
+
 typedef struct sampling_buffer sampling_buffer;
 
 typedef enum { SAMPLE_REGULAR, SAMPLE_IN_GC } sample_type;

--- a/ext/ddtrace_profiling_native_extension/heap_recorder.c
+++ b/ext/ddtrace_profiling_native_extension/heap_recorder.c
@@ -1,23 +1,129 @@
 #include "heap_recorder.h"
 #include <pthread.h>
 #include "ruby/st.h"
-#include "ruby/util.h"
 #include "ruby_helpers.h"
 #include <errno.h>
+
+#define MAX_FRAMES_LIMIT 10000
+
+// A compact representation of a stacktrace frame for a heap allocation.
+typedef struct {
+  char *name;
+  char *filename;
+  int64_t line;
+} heap_frame;
+static st_index_t heap_frame_hash(heap_frame*, st_index_t seed);
+
+// A compact representation of a stacktrace for a heap allocation.
+//
+// We could use a ddog_prof_Slice_Location instead but it has a lot of
+// unused fields. Because we have to keep these stacks around for at
+// least the lifetime of the objects allocated therein, we would be
+// incurring a non-negligible memory overhead for little purpose.
+typedef struct {
+  uint64_t frames_len;
+  heap_frame frames[];
+} heap_stack;
+static heap_stack* heap_stack_new(ddog_prof_Slice_Location);
+static void heap_stack_free(heap_stack*);
+static st_index_t heap_stack_hash(heap_stack*, st_index_t);
+
+enum heap_record_key_type {
+  HEAP_STACK,
+  LOCATION_SLICE
+};
+// This struct allows us to use two different types of stacks when
+// interacting with a heap_record hash.
+//
+// The idea is that we'll always want to use heap_stack-keys when
+// adding new entries to the hash since that's the compact stack
+// representation we rely on internally.
+//
+// However, when querying for an existing heap record, we'd save a
+// lot of allocations if we could query with the
+// ddog_prof_Slice_Location we receive in our external API.
+//
+// To allow this interchange, we need a union and need to ensure
+// that whatever shape of the union, the heap_record_key_cmp_st
+// and heap_record_hash_st functions return the same results for
+// equivalent stacktraces.
+typedef struct {
+  enum heap_record_key_type type;
+  union {
+    // key never owns this if set
+    heap_stack *heap_stack;
+    // key never owns this if set
+    ddog_prof_Slice_Location *location_slice;
+  };
+} heap_record_key;
+static heap_record_key* heap_record_key_new(heap_stack*);
+static void heap_record_key_free(heap_record_key*);
+static int heap_record_key_cmp_st(st_data_t, st_data_t);
+static st_index_t heap_record_key_hash_st(st_data_t);
+static const struct st_hash_type st_hash_type_heap_record_key = {
+    heap_record_key_cmp_st,
+    heap_record_key_hash_st,
+};
+
+// Need to implement these functions to support the location-slice based keys
+static st_index_t ddog_location_hash(ddog_prof_Location, st_index_t seed);
+static st_index_t ddog_location_slice_hash(ddog_prof_Slice_Location, st_index_t seed);
+
+// A heap record is used for deduping heap allocation stacktraces across multiple
+// objects sharing the same allocation location.
+typedef struct {
+  // How many objects are currently tracked by the heap recorder for this heap record.
+  uint64_t num_tracked_objects;
+  // stack is owned by the associated record and gets cleaned up alongside it
+  heap_stack *stack;
+} heap_record;
+static heap_record* heap_record_new(heap_stack*);
+static void heap_record_free(heap_record*);
+
+// An object record is used for storing data about currently tracked live objects
+typedef struct {
+  long obj_id;
+  heap_record *heap_record;
+  live_object_data object_data;
+} object_record;
+static object_record* object_record_new(long, heap_record*, live_object_data);
+static void object_record_free(object_record*);
 
 // Allows storing data passed to ::start_heap_allocation_recording to make it accessible to
 // ::end_heap_allocation_recording.
 //
-// obj != Qnil flags this struct as holding a valid partial heap recording.
+// obj_id != 0 flags this struct as holding a valid partial heap recording.
 typedef struct {
-  VALUE obj;
+  long obj_id;
   live_object_data object_data;
 } partial_heap_recording;
 
 struct heap_recorder {
+  // Map[key: heap_record_key*, record: heap_record*]
+  // NOTE: We always use heap_record_key.type == HEAP_STACK for storage but support lookups
+  // via heap_record_key.type == LOCATION_SLICE to allow for allocation-free fast-paths.
+  st_table *heap_records;
+
+  // Map[obj_id: long, record: object_record*]
+  st_table *object_records;
+
+  // Lock protecting writes to above record tables
+  pthread_mutex_t records_mutex;
+
   // Data for a heap recording that was started but not yet ended
   partial_heap_recording active_recording;
+
+  // Reusable location array, implementing a flyweight pattern for things like iteration.
+  ddog_prof_Location *reusable_locations;
 };
+static heap_record* get_or_create_heap_record(heap_recorder*, ddog_prof_Slice_Location);
+static void cleanup_heap_record_if_unused(heap_recorder*, heap_record*);
+static int st_heap_record_entry_free(st_data_t, st_data_t, st_data_t);
+static int st_object_record_entry_free(st_data_t, st_data_t, st_data_t);
+static int st_object_record_entry_free_if_invalid(st_data_t, st_data_t, st_data_t);
+static int st_object_records_iterate(st_data_t, st_data_t, st_data_t);
+static int update_object_record_entry(st_data_t*, st_data_t*, st_data_t, int);
+static void commit_allocation(heap_recorder*, heap_record*, long, live_object_data);
 
 // ==========================
 // Heap Recorder External API
@@ -29,34 +135,66 @@ struct heap_recorder {
 //
 // ==========================
 heap_recorder* heap_recorder_new(void) {
-  heap_recorder* recorder = ruby_xmalloc(sizeof(heap_recorder));
+  heap_recorder *recorder = ruby_xcalloc(1, sizeof(heap_recorder));
 
+  recorder->records_mutex = (pthread_mutex_t) PTHREAD_MUTEX_INITIALIZER;
+  recorder->heap_records = st_init_table(&st_hash_type_heap_record_key);
+  recorder->object_records = st_init_numtable();
+  recorder->reusable_locations = ruby_xcalloc(MAX_FRAMES_LIMIT, sizeof(ddog_prof_Location));
   recorder->active_recording = (partial_heap_recording) {
-    .obj = Qnil,
+    .obj_id = 0, // 0 is actually the obj_id of false, but we'll never track that one in heap so we use
+                 // it as invalid/unset value.
     .object_data = {0},
   };
 
   return recorder;
 }
 
-void heap_recorder_free(struct heap_recorder* recorder) {
-  if (recorder == NULL) {
+void heap_recorder_free(heap_recorder *heap_recorder) {
+  if (heap_recorder == NULL) {
     return;
   }
 
-  ruby_xfree(recorder);
+  st_foreach(heap_recorder->object_records, st_object_record_entry_free, 0);
+  st_free_table(heap_recorder->object_records);
+
+  st_foreach(heap_recorder->heap_records, st_heap_record_entry_free, 0);
+  st_free_table(heap_recorder->heap_records);
+
+  pthread_mutex_destroy(&heap_recorder->records_mutex);
+
+  ruby_xfree(heap_recorder->reusable_locations);
+
+  ruby_xfree(heap_recorder);
 }
 
-// TODO: Remove when things get implemented
-#pragma GCC diagnostic push
-#pragma GCC diagnostic ignored "-Wunused-parameter"
-
+// WARN: Assumes this gets called before profiler is reinitialized on the fork
 void heap_recorder_after_fork(heap_recorder *heap_recorder) {
   if (heap_recorder == NULL) {
     return;
   }
 
-  // TODO: Implement
+  // When forking, the child process gets a copy of the entire state of the parent process, minus
+  // threads.
+  //
+  // This means anything the heap recorder is tracking will still be alive after the fork and
+  // should thus be kept. Because this heap recorder implementation does not rely on free
+  // tracepoints to track liveness, any frees that happen until we fully reinitialize, will
+  // simply be noticed on next heap_recorder_flush.
+  //
+  // There is one small caveat though: fork only preserves one thread and in a Ruby app, that
+  // will be the thread holding on to the GVL. Since we support iteration on the heap recorder
+  // outside of the GVL (which implies acquiring the records_mutex lock), this means the child
+  // process may be in this weird state of having a records_mutex lock stuck in a locked
+  // state and that state having been caused by a thread that no longer exists.
+  //
+  // We can't blindly unlock records_mutex from the thread calling heap_recorder_after_fork
+  // as unlocking mutexes a thread doesn't own is undefined behaviour. What we can do is
+  // create a new lock and start using it from now on-forward. This is fine because at this
+  // point in the fork-handling logic, all tracepoints are disabled and no-one should be
+  // iterating on the recorder state so there are no writers/readers that may race with
+  // this reinitialization.
+  heap_recorder->records_mutex = (pthread_mutex_t) PTHREAD_MUTEX_INITIALIZER;
 }
 
 void start_heap_allocation_recording(heap_recorder *heap_recorder, VALUE new_obj, unsigned int weight) {
@@ -64,8 +202,13 @@ void start_heap_allocation_recording(heap_recorder *heap_recorder, VALUE new_obj
     return;
   }
 
+  VALUE ruby_obj_id = rb_obj_id(new_obj);
+  if (!FIXNUM_P(ruby_obj_id)) {
+    rb_raise(rb_eRuntimeError, "Detected a bignum object id. These are not supported by heap profiling.");
+  }
+
   heap_recorder->active_recording = (partial_heap_recording) {
-    .obj = new_obj,
+    .obj_id = FIX2LONG(ruby_obj_id),
     .object_data = (live_object_data) {
       .weight = weight,
     },
@@ -79,17 +222,34 @@ void end_heap_allocation_recording(struct heap_recorder *heap_recorder, ddog_pro
 
   partial_heap_recording *active_recording = &heap_recorder->active_recording;
 
-  VALUE new_obj = active_recording->obj;
-  if (new_obj == Qnil) {
+  long obj_id = active_recording->obj_id;
+  if (obj_id == 0) {
     // Recording ended without having been started?
     rb_raise(rb_eRuntimeError, "Ended a heap recording that was not started");
   }
 
   // From now on, mark active recording as invalid so we can short-circuit at any point and
   // not end up with a still active recording. new_obj still holds the object for this recording
-  active_recording->obj = Qnil;
+  active_recording->obj_id = 0;
 
-  // TODO: Implement
+  // NOTE: This is the only path where we lookup/mutate the heap_records hash. Since this
+  //       runs under the GVL, we can afford to interact with heap_records without getting
+  //       the lock below.
+  heap_record *heap_record = get_or_create_heap_record(heap_recorder, locations);
+
+  int error = pthread_mutex_trylock(&heap_recorder->records_mutex);
+  if (error == EBUSY) {
+    // We weren't able to get a lock
+    // TODO: Add some queuing system so we can do something other than drop this data.
+    cleanup_heap_record_if_unused(heap_recorder, heap_record);
+    return;
+  }
+  if (error) ENFORCE_SUCCESS_GVL(error);
+
+  // And then commit the new allocation.
+  commit_allocation(heap_recorder, heap_record, obj_id, active_recording->object_data);
+
+  ENFORCE_SUCCESS_GVL(pthread_mutex_unlock(&heap_recorder->records_mutex));
 }
 
 void heap_recorder_flush(heap_recorder *heap_recorder) {
@@ -97,8 +257,18 @@ void heap_recorder_flush(heap_recorder *heap_recorder) {
     return;
   }
 
-  // TODO: Implement
+  st_foreach(heap_recorder->object_records, st_object_record_entry_free_if_invalid, (st_data_t) heap_recorder);
 }
+
+// Internal data we need while performing iteration over live objects.
+typedef struct {
+  // The callback we need to call for each object.
+  bool (*for_each_callback)(heap_recorder_iteration_data stack_data, void *extra_arg);
+  // The extra arg to pass as the second parameter to the callback.
+  void *for_each_callback_extra_arg;
+  // A reference to the heap recorder so we can access extra stuff like reusable_locations.
+  heap_recorder *heap_recorder;
+} iteration_context;
 
 // WARN: If with_gvl = False, NO HEAP ALLOCATIONS, EXCEPTIONS or RUBY CALLS ARE ALLOWED.
 void heap_recorder_for_each_live_object(
@@ -110,8 +280,426 @@ void heap_recorder_for_each_live_object(
     return;
   }
 
-  // TODO: Implement
+  ENFORCE_SUCCESS_HELPER(pthread_mutex_lock(&heap_recorder->records_mutex), with_gvl);
+  iteration_context context;
+  context.for_each_callback = for_each_callback;
+  context.for_each_callback_extra_arg = for_each_callback_extra_arg;
+  context.heap_recorder = heap_recorder;
+  st_foreach(heap_recorder->object_records, st_object_records_iterate, (st_data_t) &context);
+  ENFORCE_SUCCESS_HELPER(pthread_mutex_unlock(&heap_recorder->records_mutex), with_gvl);
 }
 
-// TODO: Remove when things get implemented
-#pragma GCC diagnostic pop
+// ==========================
+// Heap Recorder Internal API
+// ==========================
+static int st_heap_record_entry_free(st_data_t key, st_data_t value, DDTRACE_UNUSED st_data_t extra_arg) {
+  heap_record_key *record_key = (heap_record_key*) key;
+  heap_record_key_free(record_key);
+  heap_record_free((heap_record *) value);
+  return ST_DELETE;
+}
+
+static int st_object_record_entry_free(DDTRACE_UNUSED st_data_t key, st_data_t value, DDTRACE_UNUSED st_data_t extra_arg) {
+  object_record_free((object_record *) value);
+  return ST_DELETE;
+}
+
+static int st_object_record_entry_free_if_invalid(st_data_t key, st_data_t value, st_data_t extra_arg) {
+  long obj_id = (long) key;
+  object_record *record = (object_record*) value;
+  heap_recorder *recorder = (heap_recorder*) extra_arg;
+
+  if (!ruby_ref_from_id(LONG2NUM(obj_id), NULL)) {
+    // Id no longer associated with a valid ref. Need to clean things up!
+
+    // Starting with the associated heap record. There will now be one less tracked object pointing to it
+    heap_record *heap_record = record->heap_record;
+    heap_record->num_tracked_objects--;
+
+    // One less object using this heap record, it may have become unused...
+    cleanup_heap_record_if_unused(recorder, heap_record);
+
+    object_record_free(record);
+    return ST_DELETE;
+  }
+
+  return ST_CONTINUE;
+}
+
+// WARN: This can get called outside the GVL. NO HEAP ALLOCATIONS OR EXCEPTIONS ARE ALLOWED.
+static int st_object_records_iterate(DDTRACE_UNUSED st_data_t key, st_data_t value, st_data_t extra) {
+  object_record *record = (object_record*) value;
+  const heap_stack *stack = record->heap_record->stack;
+  iteration_context *context = (iteration_context*) extra;
+
+  ddog_prof_Location *locations = context->heap_recorder->reusable_locations;
+
+  for (uint64_t i = 0; i < stack->frames_len; i++) {
+    const heap_frame *frame = &stack->frames[i];
+    ddog_prof_Location *location = &locations[i];
+    location->function.name.ptr = frame->name;
+    location->function.name.len = strlen(frame->name);
+    location->function.filename.ptr = frame->filename;
+    location->function.filename.len = strlen(frame->filename);
+    location->line = frame->line;
+  }
+
+  heap_recorder_iteration_data iteration_data;
+  iteration_data.object_data = record->object_data;
+  iteration_data.locations = (ddog_prof_Slice_Location) {.ptr = locations, .len = stack->frames_len};
+
+  if (!context->for_each_callback(iteration_data, context->for_each_callback_extra_arg)) {
+    return ST_STOP;
+  }
+
+  return ST_CONTINUE;
+}
+
+// Struct holding data required for an update operation on heap_records
+typedef struct {
+  // [in] The new object record we want to add.
+  // NOTE: Transfer of ownership is assumed, do not re-use it after call to ::update_object_record_entry
+  object_record *new_object_record;
+
+  // [in] The heap recorder where the update is happening.
+  heap_recorder *heap_recorder;
+} object_record_update_data;
+
+static int update_object_record_entry(DDTRACE_UNUSED st_data_t *key, st_data_t *value, st_data_t data, int existing) {
+  object_record_update_data *update_data = (object_record_update_data*) data;
+  if (existing) {
+    rb_raise(rb_eRuntimeError, "Object ids are supposed to be unique. We got 2 allocation recordings with the same id");
+  }
+  // Always carry on with the update, we want the new record to be there at the end
+  (*value) = (st_data_t) update_data->new_object_record;
+  return ST_CONTINUE;
+}
+
+// WARN: Expects records_mutex to be held
+static void commit_allocation(heap_recorder *heap_recorder, heap_record *heap_record, long obj_id, live_object_data object_data) {
+  // Update object_records
+  object_record_update_data update_data = (object_record_update_data) {
+    .heap_recorder = heap_recorder,
+    .new_object_record = object_record_new(obj_id, heap_record, object_data),
+  };
+  if (!st_update(heap_recorder->object_records, obj_id, update_object_record_entry, (st_data_t) &update_data)) {
+    // We are sure there was no previous record for this id so let the heap record know there now is one
+    // extra record associated with this stack.
+    heap_record->num_tracked_objects++;
+  };
+}
+
+// Struct holding data required for an update operation on heap_records
+typedef struct {
+  // [in] The locations we did this update with
+  ddog_prof_Slice_Location locations;
+  // [out] Pointer that will be updated to the updated heap record to prevent having to do
+  // another lookup to access the updated heap record.
+  heap_record **record;
+} heap_record_update_data;
+
+// This function assumes ownership of stack_data is passed on to it so it'll either transfer ownership or clean-up.
+static int update_heap_record_entry_with_new_allocation(st_data_t *key, st_data_t *value, st_data_t data, int existing) {
+  heap_record_update_data *update_data = (heap_record_update_data*) data;
+
+  if (!existing) {
+    // there was no matching heap record so lets create a new one...
+    // we need to initialize a heap_record_key with a new stack and use that for the key storage. We can't use the
+    // locations-based key we used for the update call because we don't own its lifecycle. So we create a new
+    // heap stack and will pass ownership of it to the heap_record.
+    heap_stack *stack = heap_stack_new(update_data->locations);
+    (*key) = (st_data_t) heap_record_key_new(stack);
+    (*value) = (st_data_t) heap_record_new(stack);
+  }
+
+  heap_record *record = (heap_record*) (*value);
+  (*update_data->record) = record;
+
+  return ST_CONTINUE;
+}
+
+static heap_record* get_or_create_heap_record(heap_recorder *heap_recorder, ddog_prof_Slice_Location locations) {
+  // For performance reasons we use a stack-allocated location-slice based key. This allows us
+  // to do allocation-free lookups and reuse of a matching existing heap record.
+  // NOTE: If we end up creating a new record, we'll create a heap-allocated key we own and use that for storage
+  //       instead of this one.
+  heap_record_key lookup_key = (heap_record_key) {
+    .type = LOCATION_SLICE,
+    .location_slice = &locations,
+  };
+
+  heap_record *heap_record = NULL;
+  heap_record_update_data update_data = (heap_record_update_data) {
+    .locations = locations,
+    .record = &heap_record,
+  };
+  st_update(heap_recorder->heap_records, (st_data_t) &lookup_key, update_heap_record_entry_with_new_allocation, (st_data_t) &update_data);
+
+  return heap_record;
+}
+
+static void cleanup_heap_record_if_unused(heap_recorder *heap_recorder, heap_record *heap_record) {
+  if (heap_record->num_tracked_objects > 0) {
+    // still being used! do nothing...
+    return;
+  }
+
+  heap_record_key heap_key = (heap_record_key) {
+    .type = HEAP_STACK,
+    .heap_stack = heap_record->stack,
+  };
+  // We need to access the deleted key to free it since we gave ownership of the keys to the hash.
+  // st_delete will change this pointer to point to the removed key if one is found.
+  heap_record_key *deleted_key = &heap_key;
+  if (!st_delete(heap_recorder->heap_records, (st_data_t*) &deleted_key, NULL)) {
+    rb_raise(rb_eRuntimeError, "Attempted to cleanup an untracked heap_record");
+  };
+  heap_record_key_free(deleted_key);
+  heap_record_free(heap_record);
+}
+
+// ===============
+// Heap Record API
+// ===============
+heap_record* heap_record_new(heap_stack *stack) {
+  heap_record *record = ruby_xcalloc(1, sizeof(heap_record));
+  record->num_tracked_objects = 0;
+  record->stack = stack;
+  return record;
+}
+
+void heap_record_free(heap_record *record) {
+  heap_stack_free(record->stack);
+  ruby_xfree(record);
+}
+
+
+// =================
+// Object Record API
+// =================
+object_record* object_record_new(long obj_id, heap_record *heap_record, live_object_data object_data) {
+  object_record *record = ruby_xcalloc(1, sizeof(object_record));
+  record->obj_id = obj_id;
+  record->heap_record = heap_record;
+  record->object_data = object_data;
+  return record;
+}
+
+void object_record_free(object_record *record) {
+  ruby_xfree(record);
+}
+
+// ==============
+// Heap Frame API
+// ==============
+int heap_frame_cmp(heap_frame *f1, heap_frame *f2) {
+  int line_diff = (int) (f1->line - f2->line);
+  if (line_diff != 0) {
+    return line_diff;
+  }
+  int cmp = strcmp(f1->name, f2->name);
+  if (cmp != 0) {
+    return cmp;
+  }
+  return strcmp(f1->filename, f2->filename);
+}
+
+// WARN: Must be kept in-sync with ::char_slice_hash
+st_index_t string_hash(char *str, st_index_t seed) {
+  return st_hash(str, strlen(str), seed);
+}
+
+// WARN: Must be kept in-sync with ::ddog_location_hash
+st_index_t heap_frame_hash(heap_frame *frame, st_index_t seed) {
+  st_index_t hash = string_hash(frame->name, seed);
+  hash = string_hash(frame->filename, hash);
+  hash = st_hash(&frame->line, sizeof(frame->line), hash);
+  return hash;
+}
+
+// WARN: Must be kept in-sync with ::string_hash
+st_index_t char_slice_hash(ddog_CharSlice char_slice, st_index_t seed) {
+  return st_hash(char_slice.ptr, char_slice.len, seed);
+}
+
+// WARN: Must be kept in-sync with ::heap_frame_hash
+st_index_t ddog_location_hash(ddog_prof_Location location, st_index_t seed) {
+  st_index_t hash = char_slice_hash(location.function.name, seed);
+  hash = char_slice_hash(location.function.filename, hash);
+  hash = st_hash(&location.line, sizeof(location.line), hash);
+  return hash;
+}
+
+
+// ==============
+// Heap Stack API
+// ==============
+heap_stack* heap_stack_new(ddog_prof_Slice_Location locations) {
+  heap_stack *stack = ruby_xcalloc(1, sizeof(heap_stack) + locations.len * sizeof(heap_frame));
+  stack->frames_len = locations.len;
+  for (uint64_t i = 0; i < locations.len; i++) {
+    const ddog_prof_Location *location = &locations.ptr[i];
+    stack->frames[i] = (heap_frame) {
+      .name = ruby_strndup(location->function.name.ptr, location->function.name.len),
+      .filename = ruby_strndup(location->function.filename.ptr, location->function.filename.len),
+      .line = location->line,
+    };
+  }
+  return stack;
+}
+
+void heap_stack_free(heap_stack *stack) {
+  for (uint64_t i = 0; i < stack->frames_len; i++) {
+    heap_frame *frame = &stack->frames[i];
+    ruby_xfree(frame->name);
+    ruby_xfree(frame->filename);
+  }
+  ruby_xfree(stack);
+}
+
+int heap_stack_cmp(heap_stack *st1, heap_stack *st2) {
+  if (st1->frames_len != st2->frames_len) {
+    return (int) (st1->frames_len - st2->frames_len);
+  }
+  for (uint64_t i = 0; i < st1->frames_len; i++) {
+    int cmp = heap_frame_cmp(&st1->frames[i], &st2->frames[i]);
+    if (cmp != 0) {
+      return cmp;
+    }
+  }
+  return 0;
+}
+
+// WARN: Must be kept in-sync with ::ddog_location_slice_hash
+st_index_t heap_stack_hash(heap_stack *stack, st_index_t seed) {
+  st_index_t hash = seed;
+  for (uint64_t i = 0; i < stack->frames_len; i++) {
+    hash = heap_frame_hash(&stack->frames[i], hash);
+  }
+  return hash;
+}
+
+// WARN: Must be kept in-sync with ::heap_stack_hash
+st_index_t ddog_location_slice_hash(ddog_prof_Slice_Location locations, st_index_t seed) {
+  st_index_t hash = seed;
+  for (uint64_t i = 0; i < locations.len; i++) {
+    hash = ddog_location_hash(locations.ptr[i], hash);
+  }
+  return hash;
+}
+
+// ===================
+// Heap Record Key API
+// ===================
+heap_record_key* heap_record_key_new(heap_stack *stack) {
+  heap_record_key *key = ruby_xmalloc(sizeof(heap_record_key));
+  key->type = HEAP_STACK;
+  key->heap_stack = stack;
+  return key;
+}
+
+void heap_record_key_free(heap_record_key *key) {
+  ruby_xfree(key);
+}
+
+static inline size_t heap_record_key_len(heap_record_key *key) {
+  if (key->type == HEAP_STACK) {
+    return key->heap_stack->frames_len;
+  } else {
+    return key->location_slice->len;
+  }
+}
+
+static inline int64_t heap_record_key_entry_line(heap_record_key *key, size_t entry_i) {
+  if (key->type == HEAP_STACK) {
+    return key->heap_stack->frames[entry_i].line;
+  } else {
+    return key->location_slice->ptr[entry_i].line;
+  }
+}
+
+static inline size_t heap_record_key_entry_name(heap_record_key *key, size_t entry_i, const char **name_ptr) {
+  if (key->type == HEAP_STACK) {
+    char *name = key->heap_stack->frames[entry_i].name;
+    (*name_ptr) = name;
+    return strlen(name);
+  } else {
+    ddog_CharSlice name = key->location_slice->ptr[entry_i].function.name;
+    (*name_ptr) = name.ptr;
+    return name.len;
+  }
+}
+
+static inline size_t heap_record_key_entry_filename(heap_record_key *key, size_t entry_i, const char **filename_ptr) {
+  if (key->type == HEAP_STACK) {
+    char *filename = key->heap_stack->frames[entry_i].filename;
+    (*filename_ptr) = filename;
+    return strlen(filename);
+  } else {
+    ddog_CharSlice filename = key->location_slice->ptr[entry_i].function.filename;
+    (*filename_ptr) = filename.ptr;
+    return filename.len;
+  }
+}
+
+int heap_record_key_cmp_st(st_data_t key1, st_data_t key2) {
+  heap_record_key *key_record1 = (heap_record_key*) key1;
+  heap_record_key *key_record2 = (heap_record_key*) key2;
+
+  // Fast path, check if lengths differ
+  size_t key_record1_len = heap_record_key_len(key_record1);
+  size_t key_record2_len = heap_record_key_len(key_record2);
+
+  if (key_record1_len != key_record2_len) {
+    return ((int) key_record1_len) - ((int) key_record2_len);
+  }
+
+  // If we got this far, we have same lengths so need to check item-by-item
+  for (size_t i = 0; i < key_record1_len; i++) {
+    // Lines are faster to compare, lets do that first
+    size_t line1 = heap_record_key_entry_line(key_record1, i);
+    size_t line2 = heap_record_key_entry_line(key_record2, i);
+    if (line1 != line2) {
+      return ((int) line1) - ((int)line2);
+    }
+
+    // Then come names, they are usually smaller than filenames
+    const char *name1, *name2;
+    size_t name1_len = heap_record_key_entry_name(key_record1, i, &name1);
+    size_t name2_len = heap_record_key_entry_name(key_record2, i, &name2);
+    if (name1_len != name2_len) {
+      return ((int) name1_len) - ((int) name2_len);
+    }
+    int name_cmp_result = strncmp(name1, name2, name1_len);
+    if (name_cmp_result != 0) {
+      return name_cmp_result;
+    }
+
+    // Then come filenames
+    const char *filename1, *filename2;
+    int64_t filename1_len = heap_record_key_entry_filename(key_record1, i, &filename1);
+    int64_t filename2_len = heap_record_key_entry_filename(key_record2, i, &filename2);
+    if (filename1_len != filename2_len) {
+      return ((int) filename1_len) - ((int) filename2_len);
+    }
+    int filename_cmp_result = strncmp(filename1, filename2, filename1_len);
+    if (filename_cmp_result != 0) {
+      return filename_cmp_result;
+    }
+  }
+
+  // If we survived the above for, then everything matched
+  return 0;
+}
+
+// Initial seed for hash functions
+#define FNV1_32A_INIT 0x811c9dc5
+
+st_index_t heap_record_key_hash_st(st_data_t key) {
+  heap_record_key *record_key = (heap_record_key*) key;
+  if (record_key->type == HEAP_STACK) {
+    return heap_stack_hash(record_key->heap_stack, FNV1_32A_INIT);
+  } else {
+    return ddog_location_slice_hash(*record_key->location_slice, FNV1_32A_INIT);
+  }
+}

--- a/ext/ddtrace_profiling_native_extension/heap_recorder.c
+++ b/ext/ddtrace_profiling_native_extension/heap_recorder.c
@@ -105,12 +105,16 @@ struct heap_recorder {
   // Map[key: heap_record_key*, record: heap_record*]
   // NOTE: We always use heap_record_key.type == HEAP_STACK for storage but support lookups
   // via heap_record_key.type == LOCATION_SLICE to allow for allocation-free fast-paths.
+  // NOTE: This table is currently only protected by the GVL since we never iterate on it
+  // outside the GVL.
   st_table *heap_records;
 
   // Map[obj_id: long, record: object_record*]
   st_table *object_records;
 
-  // Lock protecting writes to above record tables
+  // Lock protecting writes to object_records.
+  // NOTE: heap_records is currently not protected by this one since we do not iterate on
+  // heap records outside the GVL.
   pthread_mutex_t records_mutex;
 
   // Data for a heap recording that was started but not yet ended

--- a/ext/ddtrace_profiling_native_extension/heap_recorder.c
+++ b/ext/ddtrace_profiling_native_extension/heap_recorder.c
@@ -560,7 +560,10 @@ st_index_t char_slice_hash(ddog_CharSlice char_slice, st_index_t seed) {
 st_index_t ddog_location_hash(ddog_prof_Location location, st_index_t seed) {
   st_index_t hash = char_slice_hash(location.function.name, seed);
   hash = char_slice_hash(location.function.filename, hash);
-  hash = st_hash(&location.line, sizeof(location.line), hash);
+  // Convert ddog_prof line type to the same type we use for our heap_frames to
+  // ensure we have compatible hashes
+  int32_t line_as_int32 = (int32_t) location.line;
+  hash = st_hash(&line_as_int32, sizeof(line_as_int32), hash);
   return hash;
 }
 

--- a/ext/ddtrace_profiling_native_extension/heap_recorder.h
+++ b/ext/ddtrace_profiling_native_extension/heap_recorder.h
@@ -42,6 +42,7 @@ heap_recorder* heap_recorder_new(void);
 void heap_recorder_free(heap_recorder *heap_recorder);
 
 // Do any cleanup needed after forking.
+// WARN: Assumes this gets called before profiler is reinitialized on the fork
 void heap_recorder_after_fork(heap_recorder *heap_recorder);
 
 // Start a heap allocation recording on the heap recorder for a new object.
@@ -66,7 +67,8 @@ void start_heap_allocation_recording(heap_recorder *heap_recorder, VALUE new_obj
 // WARN: It is illegal to call this without previously having called ::start_heap_allocation_recording.
 void end_heap_allocation_recording(heap_recorder *heap_recorder, ddog_prof_Slice_Location locations);
 
-// Flush any intermediate state that might be queued inside the heap recorder.
+// Flush any intermediate state that might be queued inside the heap recorder or updates certain
+// state to reflect the latest state of the VM.
 //
 // NOTE: This should usually be called before iteration to ensure data is as little stale as possible.
 void heap_recorder_flush(heap_recorder *heap_recorder);

--- a/ext/ddtrace_profiling_native_extension/heap_recorder.h
+++ b/ext/ddtrace_profiling_native_extension/heap_recorder.h
@@ -91,3 +91,7 @@ void heap_recorder_for_each_live_object(
     bool (*for_each_callback)(heap_recorder_iteration_data data, void* extra_arg),
     void *for_each_callback_extra_arg,
     bool with_gvl);
+
+// v--- TEST-ONLY APIs ---v
+
+void heap_recorder_testonly_assert_hash_matches(ddog_prof_Slice_Location locations);

--- a/ext/ddtrace_profiling_native_extension/profiling.c
+++ b/ext/ddtrace_profiling_native_extension/profiling.c
@@ -41,6 +41,7 @@ void DDTRACE_EXPORT Init_ddtrace_profiling_native_extension(void) {
   rb_define_singleton_method(native_extension_module, "native_working?", native_working_p, 0);
   rb_funcall(native_extension_module, rb_intern("private_class_method"), 1, ID2SYM(rb_intern("native_working?")));
 
+  ruby_helpers_init();
   collectors_cpu_and_wall_time_worker_init(profiling_module);
   collectors_dynamic_sampling_rate_init(profiling_module);
   collectors_idle_sampling_helper_init(profiling_module);

--- a/ext/ddtrace_profiling_native_extension/ruby_helpers.c
+++ b/ext/ddtrace_profiling_native_extension/ruby_helpers.c
@@ -11,7 +11,6 @@ static ID _id2ref_id = Qnil;
 
 void ruby_helpers_init(void) {
   rb_global_variable(&module_object_space);
-  rb_global_variable(&_id2ref_id);
 
   module_object_space = rb_const_get(rb_cObject, rb_intern("ObjectSpace"));
   _id2ref_id = rb_intern("_id2ref");

--- a/ext/ddtrace_profiling_native_extension/ruby_helpers.c
+++ b/ext/ddtrace_profiling_native_extension/ruby_helpers.c
@@ -108,3 +108,61 @@ void raise_syserr(
     grab_gvl_and_raise_syserr(syserr_errno, "Failure returned by '%s' at %s:%d:in `%s'", expression, file, line, function_name);
   }
 }
+
+char* ruby_strndup(const char *str, size_t size) {
+  char *dup;
+
+  dup = xmalloc(size + 1);
+  memcpy(dup, str, size);
+  dup[size] = '\0';
+
+  return dup;
+}
+
+// Note on sampler global state safety:
+//
+// `module_object_space` is **GLOBAL** state. Be careful when accessing or modifying it.
+// In particular, it's important to only mutate them while holding the global VM lock, to ensure correctness.
+//
+// This global state is needed to memoize the ObjectSpace module so we can skip definition/lookup on each call
+// to _id2ref.
+static VALUE module_object_space = Qnil;
+
+VALUE _id2ref(VALUE obj_id) {
+  if (module_object_space == Qnil) {
+    module_object_space = rb_define_module("ObjectSpace");
+  }
+
+  // Call ::ObjectSpace._id2ref natively. It will raise if the id is no longer valid
+  return rb_funcall(module_object_space, rb_intern("_id2ref"), 1, obj_id);
+}
+
+VALUE _id2ref_failure(DDTRACE_UNUSED VALUE _unused1, DDTRACE_UNUSED VALUE _unused2) {
+  return Qfalse;
+}
+
+// Native wrapper to get an object ref from an id. Returns true on success and
+// writes the ref to the value pointer parameter if !NULL. False if id doesn't
+// reference a valid object (in which case value is not changed).
+bool ruby_ref_from_id(VALUE obj_id, VALUE *value) {
+  // Call ::ObjectSpace._id2ref natively. It will raise if the id is no longer valid
+  // so we need to call it via rb_erscue2
+  VALUE result = rb_rescue2(
+    _id2ref,
+    obj_id,
+    _id2ref_failure,
+    Qnil,
+    rb_eRangeError, // rb_eRangeError is the erorr used to flag invalid ids
+    0 // Required by API to be the last argument
+  );
+
+  if (result == Qfalse) {
+    return false;
+  }
+
+  if (value != NULL) {
+    (*value) = result;
+  }
+
+  return true;
+}

--- a/ext/ddtrace_profiling_native_extension/ruby_helpers.h
+++ b/ext/ddtrace_profiling_native_extension/ruby_helpers.h
@@ -5,6 +5,10 @@
 
 #include "helpers.h"
 
+// Initialize internal data needed by some ruby helpers. Should be called during start, before any actual
+// usage of ruby helpers.
+void ruby_helpers_init(void);
+
 // Processes any pending interruptions, including exceptions to be raised.
 // If there's an exception to be raised, it raises it. In that case, this function does not return.
 static inline VALUE process_pending_interruptions(DDTRACE_UNUSED VALUE _) {

--- a/ext/ddtrace_profiling_native_extension/ruby_helpers.h
+++ b/ext/ddtrace_profiling_native_extension/ruby_helpers.h
@@ -87,3 +87,18 @@ NORETURN(void raise_syserr(
   int line,
   const char *function_name
 ));
+
+// Alternative to ruby_strdup that takes a size argument.
+// Similar to C's strndup but slightly less smart as size is expected to
+// be smaller or equal to the real size of str (minus null termination if it
+// exists).
+// A new string will be returned with size+1 bytes and last byte set to '\0'.
+// The returned string must be freed explicitly.
+//
+// WARN: Cannot be used during GC or outside the GVL.
+char* ruby_strndup(const char *str, size_t size);
+
+// Native wrapper to get an object ref from an id. Returns true on success and
+// writes the ref to the value pointer parameter if !NULL. False if id doesn't
+// reference a valid object (in which case value is not changed).
+bool ruby_ref_from_id(size_t id, VALUE *value);

--- a/ext/ddtrace_profiling_native_extension/stack_recorder.c
+++ b/ext/ddtrace_profiling_native_extension/stack_recorder.c
@@ -744,7 +744,7 @@ static VALUE _native_track_object(DDTRACE_UNUSED VALUE _self, VALUE recorder_ins
 static VALUE _native_check_heap_hashes(DDTRACE_UNUSED VALUE _self, VALUE locations) {
   ENFORCE_TYPE(locations, T_ARRAY);
   size_t locations_len = rb_array_len(locations);
-  ddog_prof_Location *locations_arr = ruby_xcalloc(locations_len, sizeof(ddog_prof_Location));
+  ddog_prof_Location locations_arr[locations_len];
   for (size_t i = 0; i < locations_len; i++) {
     VALUE location = rb_ary_entry(locations, i);
     ENFORCE_TYPE(location, T_ARRAY);

--- a/lib/datadog/profiling/component.rb
+++ b/lib/datadog/profiling/component.rb
@@ -193,17 +193,26 @@ module Datadog
       private_class_method def self.enable_heap_profiling?(settings, allocation_profiling_enabled)
         heap_profiling_enabled = settings.profiling.advanced.experimental_heap_enabled
 
-        if heap_profiling_enabled && !allocation_profiling_enabled
-          raise ArgumentError, 'Heap profiling requires allocation profiling to be enabled'
-        end
+        return false unless heap_profiling_enabled
 
-        if heap_profiling_enabled
+        if RUBY_VERSION.start_with?('2.') && RUBY_VERSION < '2.7'
           Datadog.logger.warn(
-            'Enabled experimental heap profiling. This is experimental, not recommended, and will increase overhead!'
+            'Heap profiling currently relies on features introduced in Ruby 2.7 and will be forcibly disabled. '\
+            'Please upgrade to Ruby >= 2.7 in order to use this feature.'
           )
+          return false
         end
 
-        heap_profiling_enabled
+        unless allocation_profiling_enabled
+          raise ArgumentError,
+            'Heap profiling requires allocation profiling to be enabled'
+        end
+
+        Datadog.logger.warn(
+          'Enabled experimental heap profiling. This is experimental, not recommended, and will increase overhead!'
+        )
+
+        true
       end
 
       private_class_method def self.no_signals_workaround_enabled?(settings) # rubocop:disable Metrics/MethodLength

--- a/spec/datadog/profiling/collectors/cpu_and_wall_time_worker_spec.rb
+++ b/spec/datadog/profiling/collectors/cpu_and_wall_time_worker_spec.rb
@@ -570,21 +570,31 @@ RSpec.describe 'Datadog::Profiling::Collectors::CpuAndWallTimeWorker' do
       end
 
       it 'records live heap objects' do
-        pending "heap profiling isn't actually implemented just yet"
-
         stub_const('CpuAndWallTimeWorkerSpec::TestStruct', Struct.new(:foo))
+
+        # Warm this up to remove VM-related allocations
+        # TODO: Remove this when we can match on allocation class
+        CpuAndWallTimeWorkerSpec::TestStruct.new
 
         start
 
-        test_num_allocated_object.times { CpuAndWallTimeWorkerSpec::TestStruct.new }
+        live_objects = Array.new(test_num_allocated_object)
+
+        test_num_allocated_object.times { |i| live_objects[i] = CpuAndWallTimeWorkerSpec::TestStruct.new }
         allocation_line = __LINE__ - 1
 
         cpu_and_wall_time_worker.stop
 
-        relevant_sample = samples_for_thread(samples_from_pprof(recorder.serialize!), Thread.current)
-          .find { |s| s.locations.first.lineno == allocation_line && s.locations.first.path == __FILE__ }
+        test_struct_heap_sample = lambda { |sample|
+          first_frame = sample.locations.first
+          first_frame.lineno == allocation_line && first_frame.path == __FILE__ && first_frame.base_label == 'new' &&
+            (sample.values[:'heap-live-samples'] || 0) > 0
+        }
 
-        expect(relevant_sample.values[':heap-live-samples']).to eq test_num_allocated_object
+        relevant_sample = samples_from_pprof(recorder.serialize!)
+          .find(&test_struct_heap_sample)
+
+        expect(relevant_sample.values[:'heap-live-samples']).to eq test_num_allocated_object
       end
     end
 

--- a/spec/datadog/profiling/component_spec.rb
+++ b/spec/datadog/profiling/component_spec.rb
@@ -227,11 +227,26 @@ RSpec.describe Datadog::Profiling::Component do
         end
 
         context 'when heap profiling is enabled' do
+          # Universally supported ruby version for allocation profiling by default
+          let(:testing_version) { '2.7.2' }
+
           before do
             settings.profiling.advanced.experimental_heap_enabled = true
-            # Universally supported ruby version for allocation profiling, we don't want to test those
-            # edge cases here
-            stub_const('RUBY_VERSION', '2.7.2')
+            stub_const('RUBY_VERSION', testing_version)
+          end
+
+          context 'on a Ruby older than 2.7' do
+            let(:testing_version) { '2.6' }
+
+            it 'initializes StackRecorder without heap sampling support and warns' do
+              expect(Datadog::Profiling::StackRecorder).to receive(:new)
+                .with(hash_including(heap_samples_enabled: false))
+                .and_call_original
+
+              expect(Datadog.logger).to receive(:warn).with(/upgrade to Ruby >= 2.7/)
+
+              build_profiler_component
+            end
           end
 
           context 'and allocation profiling disabled' do

--- a/spec/datadog/profiling/spec_helper.rb
+++ b/spec/datadog/profiling/spec_helper.rb
@@ -70,7 +70,7 @@ module ProfileHelpers
 
   def samples_for_thread(samples, thread)
     samples.select do |sample|
-      thread_id = sample.labels.fetch(:'thread id', nil)
+      thread_id = sample.labels[:'thread id']
       thread_id && object_id_from(thread_id) == thread.object_id
     end
   end

--- a/spec/datadog/profiling/spec_helper.rb
+++ b/spec/datadog/profiling/spec_helper.rb
@@ -69,7 +69,10 @@ module ProfileHelpers
   end
 
   def samples_for_thread(samples, thread)
-    samples.select { |sample| object_id_from(sample.labels.fetch(:'thread id')) == thread.object_id }
+    samples.select do |sample|
+      thread_id = sample.labels.fetch(:'thread id', nil)
+      thread_id && object_id_from(thread_id) == thread.object_id
+    end
   end
 
   # We disable heap_sample collection by default in tests since it requires some extra mocking/

--- a/spec/datadog/profiling/stack_recorder_spec.rb
+++ b/spec/datadog/profiling/stack_recorder_spec.rb
@@ -551,4 +551,69 @@ RSpec.describe Datadog::Profiling::StackRecorder do
       expect(stack_recorder.serialize.first).to be >= now
     end
   end
+
+  describe '#heap_recorder' do
+    context 'stack/location hashing' do
+      it 'works for empty stacks' do
+        described_class::Testing._native_check_heap_hashes([])
+      end
+
+      it 'works for single-frame stacks' do
+        described_class::Testing._native_check_heap_hashes(
+          [
+            ['a name', 'a filename', 123]
+          ]
+        )
+      end
+
+      it 'works for multi-frame stacks' do
+        described_class::Testing._native_check_heap_hashes(
+          [
+            ['a name', 'a filename', 123],
+            ['another name', 'anoter filename', 456],
+          ]
+        )
+      end
+
+      it 'works with empty names' do
+        described_class::Testing._native_check_heap_hashes(
+          [
+            ['', 'a filename', 123],
+          ]
+        )
+      end
+
+      it 'works with empty filenames' do
+        described_class::Testing._native_check_heap_hashes(
+          [
+            ['a name', '', 123],
+          ]
+        )
+      end
+
+      it 'works with zero lines' do
+        described_class::Testing._native_check_heap_hashes(
+          [
+            ['a name', 'a filename', 0]
+          ]
+        )
+      end
+
+      it 'works with negative lines' do
+        described_class::Testing._native_check_heap_hashes(
+          [
+            ['a name', 'a filename', -123]
+          ]
+        )
+      end
+
+      it 'works with biiiiiiig lines' do
+        described_class::Testing._native_check_heap_hashes(
+          [
+            ['a name', 'a filename', 4_000_000]
+          ]
+        )
+      end
+    end
+  end
 end

--- a/spec/datadog/profiling/stack_recorder_spec.rb
+++ b/spec/datadog/profiling/stack_recorder_spec.rb
@@ -552,13 +552,13 @@ RSpec.describe Datadog::Profiling::StackRecorder do
     end
   end
 
-  describe '#heap_recorder' do
-    context 'stack/location hashing' do
-      it 'works for empty stacks' do
+  describe 'Heap_recorder' do
+    context 'produces the same hash code for stack-based and location-based keys' do
+      it 'with empty stacks' do
         described_class::Testing._native_check_heap_hashes([])
       end
 
-      it 'works for single-frame stacks' do
+      it 'with single-frame stacks' do
         described_class::Testing._native_check_heap_hashes(
           [
             ['a name', 'a filename', 123]
@@ -566,7 +566,7 @@ RSpec.describe Datadog::Profiling::StackRecorder do
         )
       end
 
-      it 'works for multi-frame stacks' do
+      it 'with multi-frame stacks' do
         described_class::Testing._native_check_heap_hashes(
           [
             ['a name', 'a filename', 123],
@@ -575,7 +575,7 @@ RSpec.describe Datadog::Profiling::StackRecorder do
         )
       end
 
-      it 'works with empty names' do
+      it 'with empty names' do
         described_class::Testing._native_check_heap_hashes(
           [
             ['', 'a filename', 123],
@@ -583,7 +583,7 @@ RSpec.describe Datadog::Profiling::StackRecorder do
         )
       end
 
-      it 'works with empty filenames' do
+      it 'with empty filenames' do
         described_class::Testing._native_check_heap_hashes(
           [
             ['a name', '', 123],
@@ -591,7 +591,7 @@ RSpec.describe Datadog::Profiling::StackRecorder do
         )
       end
 
-      it 'works with zero lines' do
+      it 'with zero lines' do
         described_class::Testing._native_check_heap_hashes(
           [
             ['a name', 'a filename', 0]
@@ -599,7 +599,7 @@ RSpec.describe Datadog::Profiling::StackRecorder do
         )
       end
 
-      it 'works with negative lines' do
+      it 'with negative lines' do
         described_class::Testing._native_check_heap_hashes(
           [
             ['a name', 'a filename', -123]
@@ -607,7 +607,7 @@ RSpec.describe Datadog::Profiling::StackRecorder do
         )
       end
 
-      it 'works with biiiiiiig lines' do
+      it 'with biiiiiiig lines' do
         described_class::Testing._native_check_heap_hashes(
           [
             ['a name', 'a filename', 4_000_000]

--- a/spec/datadog/profiling/stack_recorder_spec.rb
+++ b/spec/datadog/profiling/stack_recorder_spec.rb
@@ -391,8 +391,6 @@ RSpec.describe Datadog::Profiling::StackRecorder do
         end
 
         it 'include the stack and sample counts for the objects still left alive' do
-          pending 'heap_recorder implementation is currently missing'
-
           # We sample from 2 distinct locations
           expect(heap_samples.size).to eq(2)
 

--- a/spec/datadog/profiling/stack_recorder_spec.rb
+++ b/spec/datadog/profiling/stack_recorder_spec.rb
@@ -342,13 +342,13 @@ RSpec.describe Datadog::Profiling::StackRecorder do
       let(:labels) { { 'label_a' => 'value_a', 'label_b' => 'value_b', 'state' => 'unknown' }.to_a }
 
       let(:a_string) { 'a beautiful string' }
-      let(:an_array) { [1..10] }
+      let(:an_array) { (1..10).to_a }
       let(:a_hash) { { 'a' => 1, 'b' => '2', 'c' => true } }
 
       let(:samples) { samples_from_pprof(encoded_pprof) }
 
       before do
-        allocations = [a_string, an_array, 'a fearsome string', [-10..-1], a_hash, { 'z' => -1, 'y' => '-2', 'x' => false }]
+        allocations = [a_string, an_array, "a fearsome interpolated string: #{sample_rate}", (-10..-1).to_a, a_hash, { 'z' => -1, 'y' => '-2', 'x' => false }]
         @num_allocations = 0
         allocations.each_with_index do |obj, i|
           # Heap sampling currently requires this 2-step process to first pass data about the allocated object...

--- a/spec/datadog/profiling/stack_recorder_spec.rb
+++ b/spec/datadog/profiling/stack_recorder_spec.rb
@@ -348,7 +348,8 @@ RSpec.describe Datadog::Profiling::StackRecorder do
       let(:samples) { samples_from_pprof(encoded_pprof) }
 
       before do
-        allocations = [a_string, an_array, "a fearsome interpolated string: #{sample_rate}", (-10..-1).to_a, a_hash, { 'z' => -1, 'y' => '-2', 'x' => false }]
+        allocations = [a_string, an_array, "a fearsome interpolated string: #{sample_rate}", (-10..-1).to_a, a_hash,
+                       { 'z' => -1, 'y' => '-2', 'x' => false }]
         @num_allocations = 0
         allocations.each_with_index do |obj, i|
           # Heap sampling currently requires this 2-step process to first pass data about the allocated object...


### PR DESCRIPTION
**What does this PR do?**

This PR follows https://github.com/DataDog/dd-trace-rb/pull/3281 by actually implementing the heap recorder native module to support tracking the number (not size yet) of live heap objects.

**How does it work?**

The heap recorder essentially plugs into the allocation sampling mechanism and will record the object ids (via `Object::object_id`) and allocation stacktraces of all objects whose allocation we sampled.

At profile serialization time, we flush/update the heap recorder, at which point we make use of [`ObjectSpace::_id2ref`](https://github.com/ruby/ruby/blob/57748ef2a26cbdfe075347c6f7064eb419b4949a/gc.c#L4683) to try to obtain an object reference from our stored ids. This will fail only in these cases:
1. The id isn't valid (shouldn't happen since we record the id directly by calling `Object::object_id`.
2. The object the id refers to is no longer alive -> This leads us to clean up the associated recorded live object record and acts as a more robust alternative to listening to free tracepoints (which are easy to miss).
3. The VM is operating in multi-ractor mode and the object we sampled is not shareable between ractors -> We consciously choose not to support ractors initially for this feature so we'll also handle these as free.

For all ids for which we were still able to retrieve a valid object reference, we'll iterate through them and generate corresponding libdatadog samples with `heap-live-samples` values (properly scaled according to allocation sampling rate).

**NOTE**: This implementation relies on the new object id mechanism introduced in Ruby >= 2.7 which guarantees uniqueness (i.e. never re-used) and stickiness across eventual memory compaction. Prior to Ruby 2.7 object ids were related to memory locations and it'd thus be very easy to "miss" frees if the memory location got re-used for a different object. If that happened, we'd keep on reporting the original object as alive when it really wasn't.

**Motivation:**
Actually implement basic heap profiling (count only, no size yet).

**Additional Notes:**
<!-- Anything else we should know when reviewing? -->

**How to test the change?**
Non-zero `heap-live-samples` values should now be included in the resulting Ruby profiles when an app is executed with:

```
DD_PROFILING_EXPERIMENTAL_ALLOCATION_ENABLEd=true DD_PROFILING_EXPERIMENTAL_HEAP_ENABLED=true ddtracerb exec ...
```

**For Datadog employees:**
- [ ] If this PR touches code that signs or publishes builds or packages, or handles
credentials of any kind, I've requested a review from `@DataDog/security-design-and-guidance`.
- [x] This PR doesn't touch any of that.

Unsure? Have a question? Request a review!
