### PR TITLE
Fix potential crash by importing upstream `rb_profile_frames` fix

### DIFF
--- a/ext/ddtrace_profiling_native_extension/extconf.rb
+++ b/ext/ddtrace_profiling_native_extension/extconf.rb
@@ -158,6 +158,9 @@ $defs << '-DNO_PRIMITIVE_POP' if RUBY_VERSION < '3.2'
 # On older Rubies, there was no tid member in the internal thread structure
 $defs << '-DNO_THREAD_TID' if RUBY_VERSION < '3.1'
 
+# On older Rubies, there was no jit_return member on the rb_control_frame_t struct
+$defs << '-DNO_JIT_RETURN' if RUBY_VERSION < '3.1'
+
 # On older Rubies, we need to use a backported version of this function. See private_vm_api_access.h for details.
 $defs << '-DUSE_BACKPORTED_RB_PROFILE_FRAME_METHOD_NAME' if RUBY_VERSION < '3'
 


### PR DESCRIPTION
**What does this PR do?**

This PR imports the changes from upstream
https://github.com/ruby/ruby/pull/8415 into our copy of `rb_profile_frames`.

I'm not entirely sure if this crash could happen for ddtrace because unlike other Ruby profilers (like stackprof) we are not (yet?) sampling from the signal handler.

**Motivation:**

Make sure our `rb_profile_frames` matches upstream in terms of validation/safety.

**Additional Notes:**

N/A

**How to test the change?**

Good question -- I'll admit I don't quite know how to trigger the issue reported upstream. In any case, the change is quite small, so at most we'll report line 0 in a few cases where we previously weren't.

**For Datadog employees:**
- [ ] If this PR touches code that signs or publishes builds or packages, or handles
credentials of any kind, I've requested a review from `@DataDog/security-design-and-guidance`.
- [x] This PR doesn't touch any of that.