### PR TITLE
Profiling: Include specific kind of VM-internal T_IMEMO object in allocation info

### DIFF
--- a/ext/ddtrace_profiling_native_extension/collectors_thread_context.c
+++ b/ext/ddtrace_profiling_native_extension/collectors_thread_context.c
@@ -1197,7 +1197,14 @@ void thread_context_collector_sample_allocation(VALUE self_instance, unsigned in
         class_name = ruby_value_type_to_class_name(type);
       }
     } else if (type == RUBY_T_IMEMO) {
-      class_name = DDOG_CHARSLICE_C("(VM Internal, T_IMEMO)");
+      const char *imemo_string = imemo_kind(new_object);
+      if (imemo_string != NULL) {
+        char imemo_type[100];
+        snprintf(imemo_type, 100, "(VM Internal, T_IMEMO, %s)", imemo_string);
+        class_name = (ddog_CharSlice) {.ptr = imemo_type, .len = strlen(imemo_type)};
+      } else { // Ruby < 3
+        class_name = DDOG_CHARSLICE_C("(VM Internal, T_IMEMO)");
+      }
     } else {
       class_name = ruby_vm_type; // For other weird internal things we just use the VM type
     }

--- a/ext/ddtrace_profiling_native_extension/collectors_thread_context.c
+++ b/ext/ddtrace_profiling_native_extension/collectors_thread_context.c
@@ -1150,6 +1150,7 @@ void thread_context_collector_sample_allocation(VALUE self_instance, unsigned in
   // Since this is stack allocated, be careful about moving it
   ddog_CharSlice class_name;
   ddog_CharSlice *optional_class_name = NULL;
+  char imemo_type[100];
 
   if (state->allocation_type_enabled) {
     optional_class_name = &class_name;
@@ -1199,7 +1200,6 @@ void thread_context_collector_sample_allocation(VALUE self_instance, unsigned in
     } else if (type == RUBY_T_IMEMO) {
       const char *imemo_string = imemo_kind(new_object);
       if (imemo_string != NULL) {
-        char imemo_type[100];
         snprintf(imemo_type, 100, "(VM Internal, T_IMEMO, %s)", imemo_string);
         class_name = (ddog_CharSlice) {.ptr = imemo_type, .len = strlen(imemo_type)};
       } else { // Ruby < 3

--- a/ext/ddtrace_profiling_native_extension/extconf.rb
+++ b/ext/ddtrace_profiling_native_extension/extconf.rb
@@ -164,6 +164,9 @@ $defs << '-DUSE_BACKPORTED_RB_PROFILE_FRAME_METHOD_NAME' if RUBY_VERSION < '3'
 # On older Rubies, there are no Ractors
 $defs << '-DNO_RACTORS' if RUBY_VERSION < '3'
 
+# On older Rubies, rb_imemo_name did not exist
+$defs << '-DNO_IMEMO_NAME' if RUBY_VERSION < '3'
+
 # On older Rubies, objects would not move
 $defs << '-DNO_T_MOVED' if RUBY_VERSION < '2.7'
 

--- a/ext/ddtrace_profiling_native_extension/private_vm_api_access.h
+++ b/ext/ddtrace_profiling_native_extension/private_vm_api_access.h
@@ -52,3 +52,6 @@ VALUE invoke_location_for(VALUE thread, int *line_location);
 
 // Check if RUBY_MN_THREADS is enabled (aka main Ractor is not doing 1:1 threads)
 void self_test_mn_enabled(void);
+
+// Provides more specific information on what kind an imemo is
+const char *imemo_kind(VALUE imemo);


### PR DESCRIPTION
**What does this PR do?**

This PR extends the code that generates a description for an object during allocation to include the specific kind of `T_IMEMO` object.

On Ruby < 3, the `rb_imemo_name` function we're relying on does not exist, so I chose to just not gather this information for legacy Rubies. (It's posssible to still get it, but I didn't want to spend more time).

**Motivation:**

During discussion of #3282 the question of what a `T_IMEMO` is came up, and since it turns out it can represent different kinds of things in the Ruby VM, I decided to see if there was a way of spelling those out, and it turns out there is.

Is this going to be useful for most customers? Probably not, but even for our internal debugging/learning, it may come in handy, so it was a bit of a "why not" kinda thing.

**Additional Notes:**

N/A

**How to test the change?**

I hesitated in terms of testing this, since these objects are internally created by the VM so we could only run a bit of code and kinda hope to trigger their creation.

Since this was a kind-of small thing I... decided to just leave it as-is without a specific test.

In the future, we may add some testing, if we think this feature is useful enough.

I did test it locally -- on Ruby 3.x I got from this trivial script `DD_PROFILING_ENABLED=true bundle exec ddtracerb exec ruby -e "def foo; end; foo; sleep(1)"` (output from `go pprof tool`):

```
allocation class:[(VM Internal, T_IMEMO, callcache)] ruby vm type:[T_IMEMO] thread id:[649074 (2660)] thread name:[main]
allocation class:[(VM Internal, T_IMEMO, constcache)] ruby vm type:[T_IMEMO] thread id:[649074 (2660)] thread name:[main]
allocation class:[(VM Internal, T_IMEMO, ment)] ruby vm type:[T_IMEMO] thread id:[649074 (2660)] thread name:[main]
```

whereas on Ruby 2.x, I got the `(VM Internal, T_IMEMO)` only.

**For Datadog employees:**
- [ ] If this PR touches code that signs or publishes builds or packages, or handles
credentials of any kind, I've requested a review from `@DataDog/security-design-and-guidance`.
- [x] This PR doesn't touch any of that.