### PR TITLE
Allow RateSampler with a sampling rate of zero

### DIFF
--- a/lib/datadog/tracing/sampling/rate_sampler.rb
+++ b/lib/datadog/tracing/sampling/rate_sampler.rb
@@ -13,24 +13,13 @@ module Datadog
         # This sampler keeps a random subset of the traces. Its main purpose is to
         # reduce the instrumentation footprint.
         #
-        # * +sample_rate+: the sample rate as a {Float} between 0.0 and 1.0. 0.0
-        #   means that no trace will be sampled; 1.0 means that all traces will be
-        #   sampled.
-        #
-        # DEV-2.0: Allow for `sample_rate` zero (drop all) to be allowed. This eases
-        # DEV-2.0: usage for all internal users of the {RateSampler} class: both
-        # DEV-2.0: RuleSampler and Single Span Sampling leverage the RateSampler, but want
-        # DEV-2.0: `sample_rate` zero to mean "drop all". They work around this by hard-
-        # DEV-2.0: setting the `sample_rate` to zero like so:
-        # DEV-2.0: ```
-        # DEV-2.0: sampler = RateSampler.new
-        # DEV-2.0: sampler.sample_rate = sample_rate
-        # DEV-2.0: ```
+        # @param sample_rate [Numeric] the sample rate between 0.0 and 1.0, inclusive.
+        #   0.0 means that no trace will be sampled; 1.0 means that all traces will be  sampled.
         def initialize(sample_rate = 1.0, decision: nil)
           super()
 
-          unless sample_rate > 0.0 && sample_rate <= 1.0
-            Datadog.logger.error('sample rate is not between 0 and 1, disabling the sampler')
+          unless sample_rate >= 0.0 && sample_rate <= 1.0
+            Datadog.logger.error('sample rate is not between 0 and 1, falling back to 1')
             sample_rate = 1.0
           end
 

--- a/lib/datadog/tracing/sampling/rule.rb
+++ b/lib/datadog/tracing/sampling/rule.rb
@@ -53,18 +53,7 @@ module Datadog
         #                defaults to always match
         # @param sample_rate [Float] Sampling rate between +[0,1]+
         def initialize(name: SimpleMatcher::MATCH_ALL, service: SimpleMatcher::MATCH_ALL, sample_rate: 1.0)
-          # We want to allow 0.0 to drop all traces, but {Datadog::Tracing::Sampling::RateSampler}
-          # considers 0.0 an invalid rate and falls back to 100% sampling.
-          #
-          # We address that here by not setting the rate in the constructor,
-          # but using the setter method.
-          #
-          # We don't want to make this change directly to {Datadog::Tracing::Sampling::RateSampler}
-          # because it breaks its current contract to existing users.
-          sampler = RateSampler.new
-          sampler.sample_rate = sample_rate
-
-          super(SimpleMatcher.new(name: name, service: service), sampler)
+          super(SimpleMatcher.new(name: name, service: service), RateSampler.new(sample_rate))
         end
       end
     end

--- a/lib/datadog/tracing/sampling/span/rule.rb
+++ b/lib/datadog/tracing/sampling/span/rule.rb
@@ -29,12 +29,7 @@ module Datadog
             @sample_rate = sample_rate
             @rate_limit = rate_limit
 
-            @sampler = Sampling::RateSampler.new
-            # Set the sample_rate outside of the initializer to allow for
-            # zero to be a "drop all".
-            # The RateSampler initializer enforces non-zero, falling back to 100% sampling
-            # if zero is provided.
-            @sampler.sample_rate = sample_rate
+            @sampler = Sampling::RateSampler.new(sample_rate)
             @rate_limiter = Sampling::TokenBucket.new(rate_limit)
           end
 

--- a/spec/datadog/tracing/sampling/rate_sampler_spec.rb
+++ b/spec/datadog/tracing/sampling/rate_sampler_spec.rb
@@ -27,6 +27,12 @@ RSpec.describe Datadog::Tracing::Sampling::RateSampler do
       context 'that is 0' do
         let(:sample_rate) { 0.0 }
 
+        it_behaves_like 'sampler with sample rate', 0.0
+      end
+
+      context 'that is 1' do
+        let(:sample_rate) { 1.0 }
+
         it_behaves_like 'sampler with sample rate', 1.0
       end
 


### PR DESCRIPTION
<!--
Check out the
https://github.com/DataDog/dd-trace-rb/blob/master/docs/DevelopmentGuide.md
for guidance on how to set up your development environment,
run the test suite, write new integrations, and more.
-->

**2.0 Upgrade Guide notes**

The custom sampler class `Datadog::Tracing::Sampling::RateSampler` now accepts a `sample_rate` of zero. This will drop all spans. Before 2.0, the `RateSampler` would fall back to a sample rate of `1.0` when provided with a `sample_rate` of zero.

<!--
(If this PR is for 1.x, please delete this section)
A public facing description that will go into the [upgrade guide](https://github.com/DataDog/dd-trace-rb/blob/master/docs/UpgradeGuide.md) for this change.
We already know what the PR does (from the PR title),
but users should know either:
* A migration path for this change. In other words, how to continue using their application without behavior changes
in 2.0 (e.g. environment variable 'X' renamed to 'Y').
* That there's no alternative; we completely dropped support for this feature.
-->

**Motivation:**
<!-- What inspired you to submit this pull request? -->

This PR creates consistency across all sampling configurations: they all allowed a zero sampling rate, only `RateSampler` was the exception.

**Additional Notes:**
<!-- Anything else we should know when reviewing? -->

**How to test the change?**
<!--
Describe here how the change can be validated.
You are strongly encouraged to provide automated tests for this PR (unit or integration).
If this change cannot be feasibly tested, please explain why,
unless the change does not modify code (e.g. only modifies docs, comments).
-->

**For Datadog employees:**
- [ ] If this PR touches code that signs or publishes builds or packages, or handles
credentials of any kind, I've requested a review from `@DataDog/security-design-and-guidance`.
- [ ] This PR doesn't touch any of that.

Unsure? Have a question? Request a review!
