### PR TITLE
Ensure traces reach the agent

### DIFF
--- a/lib/datadog/tracing/trace_operation.rb
+++ b/lib/datadog/tracing/trace_operation.rb
@@ -137,13 +137,12 @@ module Datadog
       end
 
       def keep!
-        self.sampled = true
         self.sampling_priority = Sampling::Ext::Priority::USER_KEEP
         set_tag(Tracing::Metadata::Ext::Distributed::TAG_DECISION_MAKER, Tracing::Sampling::Ext::Decision::MANUAL)
+        self.sampled = true # Just in case the in-app sampler had decided to drop this span, we revert that decision.
       end
 
       def reject!
-        self.sampled = false
         self.sampling_priority = Sampling::Ext::Priority::USER_REJECT
         set_tag(Tracing::Metadata::Ext::Distributed::TAG_DECISION_MAKER, Tracing::Sampling::Ext::Decision::MANUAL)
       end

--- a/spec/datadog/tracing/integration_spec.rb
+++ b/spec/datadog/tracing/integration_spec.rb
@@ -775,7 +775,10 @@ RSpec.describe 'Tracer integration tests' do
       it 'drops trace at application side' do
         expect(tracer.writer).to_not receive(:write)
 
-        tracer.trace('span') { |_, trace| trace.reject! }
+        tracer.trace('span') do |_, trace|
+          trace.reject!
+          trace.sampled = false
+        end
       end
     end
 

--- a/spec/datadog/tracing/trace_operation_spec.rb
+++ b/spec/datadog/tracing/trace_operation_spec.rb
@@ -871,18 +871,17 @@ RSpec.describe Datadog::Tracing::TraceOperation do
 
     it 'does not modify sampled?' do
       expect { reject! }
-        .to change { trace_op.sampled? }
-        .from(true).to(false)
+        .to_not change { trace_op.sampled? }
+        .from(true)
     end
 
     context 'when #sampled was true' do
       before { trace_op.sampled = true }
 
-      it 'sets sampled? to false' do
+      it 'does not change sampled?' do
         expect { reject! }
-          .to change { trace_op.sampled? }
+          .to_not change { trace_op.sampled? }
           .from(true)
-          .to(false)
       end
     end
 


### PR DESCRIPTION
<!--
Check out the
https://github.com/DataDog/dd-trace-rb/blob/master/docs/DevelopmentGuide.md
for guidance on how to set up your development environment,
run the test suite, write new integrations, and more.
-->

**2.0 Upgrade Guide notes**

`Datadog::Tracing.reject!` now only changes the priority sampling, as documented, instead of preventing the trace from reaching the Datadog Agent. Now, rejected traces will correctly count towards [trace metrics](https://docs.datadoghq.com/tracing/metrics/#trace-metrics).

<!--
(If this PR is for 1.x, please delete this section)
A public facing description that will go into the [upgrade guide](https://github.com/DataDog/dd-trace-rb/blob/master/docs/UpgradeGuide.md) for this change.
We already know what the PR does (from the PR title),
but users should know either:
* A migration path for this change. In other words, how to continue using their application without behavior changes
in 2.0 (e.g. environment variable 'X' renamed to 'Y').
* That there's no alternative; we completely dropped support for this feature.
-->

**Motivation:**

This was always the intended behavior, but was incorrectly implemented.

**Additional Notes:**
<!-- Anything else we should know when reviewing? -->

**How to test the change?**
<!--
Describe here how the change can be validated.
You are strongly encouraged to provide automated tests for this PR (unit or integration).
If this change cannot be feasibly tested, please explain why,
unless the change does not modify code (e.g. only modifies docs, comments).
-->

**For Datadog employees:**
- [ ] If this PR touches code that signs or publishes builds or packages, or handles
credentials of any kind, I've requested a review from `@DataDog/security-design-and-guidance`.
- [ ] This PR doesn't touch any of that.

Unsure? Have a question? Request a review!
