### PR TITLE
Case-insensitive propagation style configuration

### DIFF
--- a/lib/datadog/tracing/configuration/ext.rb
+++ b/lib/datadog/tracing/configuration/ext.rb
@@ -32,7 +32,7 @@ module Datadog
         # @public_api
         module Distributed
           # Custom Datadog format
-          PROPAGATION_STYLE_DATADOG = 'Datadog'
+          PROPAGATION_STYLE_DATADOG = 'datadog'
 
           PROPAGATION_STYLE_B3_MULTI_HEADER = 'b3multi'
           PROPAGATION_STYLE_B3_SINGLE_HEADER = 'b3'

--- a/lib/datadog/tracing/configuration/settings.rb
+++ b/lib/datadog/tracing/configuration/settings.rb
@@ -42,14 +42,14 @@ module Datadog
               #
               # @public_api
               settings :distributed_tracing do
-                # An ordered list of what data propagation styles the tracer will use to extract distributed tracing propagation
+                # An ordered, case-insensitive list of what data propagation styles the tracer will use to extract distributed tracing propagation
                 # data from incoming requests and messages.
                 #
                 # The tracer will try to find distributed headers in the order they are present in the list provided to this option.
                 # The first format to have valid data present will be used.
                 #
                 # @default `DD_TRACE_PROPAGATION_STYLE_EXTRACT` environment variable (comma-separated list),
-                #   otherwise `['Datadog','b3multi','b3']`.
+                #   otherwise `['datadog','b3multi','b3']`.
                 # @return [Array<String>]
                 option :propagation_extract_style do |o|
                   o.type :array
@@ -60,14 +60,18 @@ module Datadog
                       Tracing::Configuration::Ext::Distributed::PROPAGATION_STYLE_TRACE_CONTEXT,
                     ]
                   )
+                  o.after_set do |styles|
+                    # Make values case-insensitive
+                    styles.map!(&:downcase)
+                  end
                 end
 
-                # The data propagation styles the tracer will use to inject distributed tracing propagation
+                # The case-insensitive list of the data propagation styles the tracer will use to inject distributed tracing propagation
                 # data into outgoing requests and messages.
                 #
                 # The tracer will inject data from all styles specified in this option.
                 #
-                # @default `DD_TRACE_PROPAGATION_STYLE_INJECT` environment variable (comma-separated list), otherwise `['Datadog']`.
+                # @default `DD_TRACE_PROPAGATION_STYLE_INJECT` environment variable (comma-separated list), otherwise `['datadog','tracecontext']`.
                 # @return [Array<String>]
                 option :propagation_inject_style do |o|
                   o.type :array
@@ -76,9 +80,13 @@ module Datadog
                     Tracing::Configuration::Ext::Distributed::PROPAGATION_STYLE_DATADOG,
                     Tracing::Configuration::Ext::Distributed::PROPAGATION_STYLE_TRACE_CONTEXT,
                   ]
+                  o.after_set do |styles|
+                    # Make values case-insensitive
+                    styles.map!(&:downcase)
+                  end
                 end
 
-                # An ordered list of what data propagation styles the tracer will use to extract distributed tracing propagation
+                # An ordered, case-insensitive list of what data propagation styles the tracer will use to extract distributed tracing propagation
                 # data from incoming requests and inject into outgoing requests.
                 #
                 # This configuration is the equivalent of configuring both {propagation_extract_style}
@@ -92,6 +100,9 @@ module Datadog
                   o.default []
                   o.after_set do |styles|
                     next if styles.empty?
+
+                    # Make values case-insensitive
+                    styles.map!(&:downcase)
 
                     set_option(:propagation_extract_style, styles)
                     set_option(:propagation_inject_style, styles)

--- a/spec/datadog/opentelemetry_spec.rb
+++ b/spec/datadog/opentelemetry_spec.rb
@@ -16,7 +16,7 @@ RSpec.describe Datadog::OpenTelemetry do
       Datadog.configure do |c|
         c.tracing.writer = writer_
         c.tracing.partial_flush.min_spans_threshold = 1 # Ensure tests flush spans quickly
-        c.tracing.distributed_tracing.propagation_style = ['Datadog'] # Ensure test has consistent propagation configuration
+        c.tracing.distributed_tracing.propagation_style = ['datadog'] # Ensure test has consistent propagation configuration
       end
 
       ::OpenTelemetry::SDK.configure do |c|
@@ -732,7 +732,7 @@ RSpec.describe Datadog::OpenTelemetry do
 
           before do
             Datadog.configure do |c|
-              c.tracing.distributed_tracing.propagation_extract_style = ['Datadog', 'tracecontext']
+              c.tracing.distributed_tracing.propagation_extract_style = ['datadog', 'tracecontext']
             end
           end
 

--- a/spec/datadog/opentracer/rack_propagator_spec.rb
+++ b/spec/datadog/opentracer/rack_propagator_spec.rb
@@ -24,7 +24,7 @@ RSpec.describe Datadog::OpenTracer::RackPropagator do
 
     before do
       Datadog.configure do |c|
-        c.tracing.distributed_tracing.propagation_style = ['Datadog']
+        c.tracing.distributed_tracing.propagation_style = ['datadog']
       end
 
       # Expect carrier to be set with Datadog trace properties

--- a/spec/datadog/tracing/configuration/settings_spec.rb
+++ b/spec/datadog/tracing/configuration/settings_spec.rb
@@ -92,6 +92,19 @@ RSpec.describe Datadog::Tracing::Configuration::Settings do
                 ]
               )
             end
+
+            context 'with a mixed case value' do
+              let(:var_value) { 'B3Multi,B3' }
+
+              it 'parses in a case-insensitive manner' do
+                is_expected.to eq(
+                  [
+                    Datadog::Tracing::Configuration::Ext::Distributed::PROPAGATION_STYLE_B3_MULTI_HEADER,
+                    Datadog::Tracing::Configuration::Ext::Distributed::PROPAGATION_STYLE_B3_SINGLE_HEADER
+                  ]
+                )
+              end
+            end
           end
         end
       end
@@ -114,7 +127,7 @@ RSpec.describe Datadog::Tracing::Configuration::Settings do
           end
 
           context 'is defined' do
-            let(:var_value) { 'Datadog,b3' }
+            let(:var_value) { 'datadog,b3' }
 
             it do
               is_expected.to eq(
@@ -123,6 +136,19 @@ RSpec.describe Datadog::Tracing::Configuration::Settings do
                   Datadog::Tracing::Configuration::Ext::Distributed::PROPAGATION_STYLE_B3_SINGLE_HEADER
                 ]
               )
+            end
+
+            context 'with a mixed case value' do
+              let(:var_value) { 'Datadog,B3' }
+
+              it 'parses in a case-insensitive manner' do
+                is_expected.to eq(
+                  [
+                    Datadog::Tracing::Configuration::Ext::Distributed::PROPAGATION_STYLE_DATADOG,
+                    Datadog::Tracing::Configuration::Ext::Distributed::PROPAGATION_STYLE_B3_SINGLE_HEADER
+                  ]
+                )
+              end
             end
           end
         end
@@ -148,11 +174,11 @@ RSpec.describe Datadog::Tracing::Configuration::Settings do
             it { is_expected.to eq [] }
 
             it 'does not change propagation_extract_style' do
-              expect { propagation_style }.to_not change { propagation_extract_style }.from(%w[Datadog tracecontext])
+              expect { propagation_style }.to_not change { propagation_extract_style }.from(%w[datadog tracecontext])
             end
 
             it 'does not change propagation_inject_style' do
-              expect { propagation_style }.to_not change { propagation_inject_style }.from(%w[Datadog tracecontext])
+              expect { propagation_style }.to_not change { propagation_inject_style }.from(%w[datadog tracecontext])
             end
           end
 
@@ -167,6 +193,14 @@ RSpec.describe Datadog::Tracing::Configuration::Settings do
 
             it 'sets propagation_inject_style' do
               expect { propagation_style }.to change { propagation_inject_style }.to(%w[b3multi b3])
+            end
+
+            context 'with a mixed case value' do
+              let(:var_value) { 'b3MULTI' }
+
+              it 'parses in a case-insensitive manner' do
+                expect { propagation_style }.to change { propagation_extract_style }.to(%w[b3multi])
+              end
             end
           end
         end

--- a/spec/datadog/tracing/contrib/grpc/distributed/propagation_spec.rb
+++ b/spec/datadog/tracing/contrib/grpc/distributed/propagation_spec.rb
@@ -54,7 +54,7 @@ RSpec.describe Datadog::Tracing::Contrib::GRPC::Distributed::Propagation do
 
   context 'for Datadog' do
     it_behaves_like 'Datadog distributed format' do
-      before { Datadog.configure { |c| c.tracing.distributed_tracing.propagation_style = ['Datadog'] } }
+      before { Datadog.configure { |c| c.tracing.distributed_tracing.propagation_style = ['datadog'] } }
       let(:datadog) { propagation }
     end
   end

--- a/spec/datadog/tracing/contrib/http/distributed/propagation_spec.rb
+++ b/spec/datadog/tracing/contrib/http/distributed/propagation_spec.rb
@@ -39,7 +39,7 @@ RSpec.describe Datadog::Tracing::Contrib::HTTP::Distributed::Propagation do
 
   context 'for Datadog' do
     it_behaves_like 'Datadog distributed format' do
-      before { Datadog.configure { |c| c.tracing.distributed_tracing.propagation_style = ['Datadog'] } }
+      before { Datadog.configure { |c| c.tracing.distributed_tracing.propagation_style = ['datadog'] } }
       let(:datadog) { propagation }
     end
   end

--- a/spec/datadog/tracing/distributed/propagation_spec.rb
+++ b/spec/datadog/tracing/distributed/propagation_spec.rb
@@ -7,7 +7,7 @@ RSpec.shared_examples 'Distributed tracing propagator' do
 
   let(:propagation_styles) do
     {
-      'Datadog' => Datadog::Tracing::Distributed::Datadog.new(fetcher: fetcher_class),
+      'datadog' => Datadog::Tracing::Distributed::Datadog.new(fetcher: fetcher_class),
       'tracecontext' => Datadog::Tracing::Distributed::TraceContext.new(fetcher: fetcher_class),
     }
   end


### PR DESCRIPTION
<!--
Check out the
https://github.com/DataDog/dd-trace-rb/blob/master/docs/DevelopmentGuide.md
for guidance on how to set up your development environment,
run the test suite, write new integrations, and more.
-->

**2.0 Upgrade Guide notes**
The the values for the environment variables `DD_TRACE_PROPAGATION_STYLE`, `DD_TRACE_PROPAGATION_STYLE_INJECT`, and `DD_TRACE_PROPAGATION_STYLE_EXTRACT` are now considered case-insensitive.
The major impact of this change is that, previously, `B3` would configure Tracing with the [B3 Multiple Headers](https://github.com/openzipkin/b3-propagation/tree/7c6e9f14d6627832bd80baa87ac7dabee7be23cf#multiple-headers) propagator. Now `B3` will configure it with the [B3 Single Header](https://github.com/open-telemetry/opentelemetry-specification/blob/62effed618589a0bec416a87e559c0a9d96289bb/specification/configuration/sdk-environment-variables.md?plain=1#L102) propagator.

<!--
(If this PR is for 1.x, please delete this section)
A public facing description that will go into the [upgrade guide](https://github.com/DataDog/dd-trace-rb/blob/master/docs/UpgradeGuide.md) for this change.
We already know what the PR does (from the PR title),
but users should know either:
* A migration path for this change. In other words, how to continue using their application without behavior changes
in 2.0 (e.g. environment variable 'X' renamed to 'Y').
* That there's no alternative; we completely dropped support for this feature.
-->

**Motivation:**
<!-- What inspired you to submit this pull request? -->

This change aligns the Ruby tracer with all other Datadog Tracers.

**Additional Notes:**
<!-- Anything else we should know when reviewing? -->

**How to test the change?**
<!--
Describe here how the change can be validated.
You are strongly encouraged to provide automated tests for this PR (unit or integration).
If this change cannot be feasibly tested, please explain why,
unless the change does not modify code (e.g. only modifies docs, comments).
-->

**For Datadog employees:**
- [ ] If this PR touches code that signs or publishes builds or packages, or handles
credentials of any kind, I've requested a review from `@DataDog/security-design-and-guidance`.
- [ ] This PR doesn't touch any of that.

Unsure? Have a question? Request a review!
