### PR TITLE
[NO-TICKET] Remove unused parameter warning workaround for Ruby 3.3

### DIFF
--- a/ext/ddtrace_profiling_native_extension/extconf.rb
+++ b/ext/ddtrace_profiling_native_extension/extconf.rb
@@ -99,15 +99,6 @@ add_compiler_flag '-Wno-declaration-after-statement'
 # cause a segfault later. Let's ensure that never happens.
 add_compiler_flag '-Werror-implicit-function-declaration'
 
-# Warn on unused parameters to functions. Use `DDTRACE_UNUSED` to mark things as known-to-not-be-used.
-#
-# @ivoanjo TODO: 3.3.0 development releases are causing issues because:
-# 1. We're enabling unused parameter warnings
-# 2. The VM headers trigger unused parameter warnings
-# 3. When we call `have_header` below, mkmf compiles the target code with `-Werror`, turning warnings into errors
-# For now, I've chosen to disable this warning for Ruby 3.3; we can revisit at a later 3.3 release.
-add_compiler_flag '-Wunused-parameter' unless RUBY_VERSION.start_with?('3.3.')
-
 # The native extension is not intended to expose any symbols/functions for other native libraries to use;
 # the sole exception being `Init_ddtrace_profiling_native_extension` which needs to be visible for Ruby to call it when
 # it `dlopen`s the library.
@@ -247,6 +238,10 @@ if Datadog::Profiling::NativeExtensionHelpers::CAN_USE_MJIT_HEADER
   # NOTE: This needs to come after all changes to $defs
   create_header
 
+  # Warn on unused parameters to functions. Use `DDTRACE_UNUSED` to mark things as known-to-not-be-used.
+  # See the comment on the same flag below for why this is done last.
+  add_compiler_flag '-Wunused-parameter'
+
   create_makefile EXTENSION_NAME
 else
   # The MJIT header was introduced on 2.6 and removed on 3.3; for other Rubies we rely on
@@ -262,9 +257,20 @@ else
   Debase::RubyCoreSource
     .create_makefile_with_core(
       proc do
-        have_header('vm_core.h') &&
-        have_header('iseq.h') &&
-        (RUBY_VERSION < '3.3' || have_header('ractor_core.h'))
+        headers_available =
+          have_header('vm_core.h') &&
+          have_header('iseq.h') &&
+          (RUBY_VERSION < '3.3' || have_header('ractor_core.h'))
+
+        if headers_available
+          # Warn on unused parameters to functions. Use `DDTRACE_UNUSED` to mark things as known-to-not-be-used.
+          # This is added as late as possible because in some Rubies we support (e.g. 3.3), adding this flag before checking if
+          # internal VM headers are available causes those checks to fail because of this warning (and not because the headers
+          # are not available.)
+          add_compiler_flag '-Wunused-parameter'
+        end
+
+        headers_available
       end,
       EXTENSION_NAME,
     )

--- a/ext/ddtrace_profiling_native_extension/extconf.rb
+++ b/ext/ddtrace_profiling_native_extension/extconf.rb
@@ -264,9 +264,9 @@ else
 
         if headers_available
           # Warn on unused parameters to functions. Use `DDTRACE_UNUSED` to mark things as known-to-not-be-used.
-          # This is added as late as possible because in some Rubies we support (e.g. 3.3), adding this flag before checking if
-          # internal VM headers are available causes those checks to fail because of this warning (and not because the headers
-          # are not available.)
+          # This is added as late as possible because in some Rubies we support (e.g. 3.3), adding this flag before
+          # checking if internal VM headers are available causes those checks to fail because of this warning (and not
+          # because the headers are not available.)
           add_compiler_flag '-Wunused-parameter'
         end
 


### PR DESCRIPTION
**What does this PR do?**

This PR removes the workaround we add to not use the `-Wunused-parameter` warning on Ruby 3.3.

This means we'll have those warnings when compiling the profiler native extension on that Ruby version.

The issue was that some of the internal Ruby headers in Ruby 3.3 have unused parameters. If we applied the warning before checking these internal headers, the header detection check (`have_header`) would fail not because the headers were missing, but because they have warnings.

(Why do they fail due to warnings? Because by default `have_header` tries to compile a tiny app that includes the header AND tries to compile that app with `-Werror`, turning any warning into an error -- thus making the combination fail)

To fix this issue, we need to enable these warnings after all the other checks have passed, and after nothing else will be checked with `-Werror`.

**Motivation:**

This fix enables us to have this useful warning enabled when compiling the profiler for Ruby 3.3 (and probably for future versions of Ruby).

**Additional Notes:**

This "internal headers with warnings cause us not to be able to use -Wunused-parameter" also happens with some older Ruby versions, on some of the public headers.

On those versions `add_compiler_flag '-Wunused-parameter'` will try to add the flag and fail (same reason as my note above: headers have warnings + check uses `-Werror`).

This PR was born out of an attempt of fixing that problem as well, but I didn't like the fix, because while I can fix `extconf.rb` (`try_cflags` can recieve an option to disable `-Werror`), the next problem is thatt when compiling our own files, a torrent of warnings shows up from those internal headers. And... getting rid of those warnings so we can see anything else is... too ugly. So for now I've extracted only the relevant part of my fix.

**How to test the change?**

This whole thing only really affects development, so if CI is still green, things are still fine.

Additionally, you can remove a `DDTRACE_UNUSED` qualifier in some of the functions and observe that we now get warnings for unused parameters on the Ruby 3.3 image we use for CI.

**For Datadog employees:**
- [ ] If this PR touches code that signs or publishes builds or packages, or handles
credentials of any kind, I've requested a review from `@DataDog/security-design-and-guidance`.
- [x] This PR doesn't touch any of that.