### PR TITLE
[NO-TICKET] Minor: Print core dump status info even when already enabled

### DIFF
--- a/lib/datadog/kit/enable_core_dumps.rb
+++ b/lib/datadog/kit/enable_core_dumps.rb
@@ -16,11 +16,13 @@ module Datadog
             '(Could not open /proc/sys/kernel/core_pattern)'
           end
 
+        enabled_status = "Maximum size: #{maximum_size} Output pattern: '#{core_pattern}'"
+
         if maximum_size <= 0
           Kernel.warn("[ddtrace] Could not enable core dumps on crash, maximum size is #{maximum_size} (disabled).")
           return
         elsif maximum_size == current_size
-          Kernel.warn('[ddtrace] Core dumps already enabled, nothing to do!')
+          Kernel.warn("[ddtrace] Core dumps already enabled, nothing to do. #{enabled_status}")
           return
         end
 
@@ -35,12 +37,9 @@ module Datadog
         end
 
         if current_size == 0
-          Kernel.warn("[ddtrace] Enabled core dumps. Maximum size: #{maximum_size} Output pattern: '#{core_pattern}'")
+          Kernel.warn("[ddtrace] Enabled core dumps. #{enabled_status}")
         else
-          Kernel.warn(
-            "[ddtrace] Raised core dump limit. Old size: #{current_size} " \
-            "Maximum size: #{maximum_size} Output pattern: '#{core_pattern}'"
-          )
+          Kernel.warn("[ddtrace] Raised core dump limit. Old size: #{current_size} #{enabled_status}")
         end
       end
     end


### PR DESCRIPTION
**What does this PR do?**

This PR tweaks the `enable_core_dumps` helper to also print the code dump status (maximum size and output pattern) even when core dumps are already enabled. This will allow us to know where to find the core dump files in such situations.

**Motivation:**

Simplify diagnostics when using this helper.

**Additional Notes:**

N/A

**How to test the change?**

This class already has test coverage. To quickly test it manually, running `load '.../enable_core_dumps.rb'` more than once will trigger the multiple messages.

**For Datadog employees:**
- [ ] If this PR touches code that signs or publishes builds or packages, or handles
credentials of any kind, I've requested a review from `@DataDog/security-design-and-guidance`.
- [x] This PR doesn't touch any of that.