### PR TITLE
Revert "Revert "Support lib injection for ARM64 architecture""

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -24,7 +24,7 @@ variables:
 default:
   tags: [ "runner:main", "size:large" ]
 
-build-image:
+.build-image-base:
   stage: manual-images
   rules:
     - if: $CI_PIPELINE_SOURCE == "merge_request_event" || $CI_PIPELINE_SOURCE == "push"
@@ -32,7 +32,6 @@ build-image:
         - .gitlab/Dockerfile-*
       when: manual
       allow_failure: true
-  tags: [ "runner:docker" ]
   image: $DOCKER_REGISTRY/docker:20.10.13
   parallel:
     matrix:
@@ -41,10 +40,22 @@ build-image:
   script:
     - >
       docker build
-      --tag $RUBY_CUSTOM_IMAGE_BASE/$RUBY_VERSION:$CI_PIPELINE_ID
+      --tag $RUBY_CUSTOM_IMAGE_BASE/$RUBY_VERSION-$ARCHITECTURE:$CI_PIPELINE_ID
       --file .gitlab/Dockerfile-$RUBY_VERSION
       .
-    - docker push --all-tags $RUBY_CUSTOM_IMAGE_BASE/$RUBY_VERSION
+    - docker push --all-tags $RUBY_CUSTOM_IMAGE_BASE/$RUBY_VERSION-$ARCHITECTURE
+
+build-image-amd64:
+   extends: .build-image-base
+   tags: [ "runner:docker" ]
+   variables:
+     ARCHITECTURE: amd64
+
+build-image-arm64:
+   extends: .build-image-base
+   tags: [ "runner:docker-arm", "platform:arm64"]
+   variables:
+     ARCHITECTURE: arm64
 
 promote-image:
   stage: manual-images
@@ -55,13 +66,14 @@ promote-image:
     matrix:
       # ADD NEW RUBIES HERE
       - RUBY_VERSION: [ '3.2.2', '3.1.4', '3.0.6', '2.7.8' ]
+        ARCHITECTURE: [ 'amd64', 'arm64' ]
   script:
-    - docker pull $RUBY_CUSTOM_IMAGE_BASE/$RUBY_VERSION:$CI_PIPELINE_ID
-    - docker tag $RUBY_CUSTOM_IMAGE_BASE/$RUBY_VERSION:$CI_PIPELINE_ID $RUBY_CUSTOM_IMAGE_BASE/$RUBY_VERSION:current
-    - docker push $RUBY_CUSTOM_IMAGE_BASE/$RUBY_VERSION:current
+    - docker pull $RUBY_CUSTOM_IMAGE_BASE/$RUBY_VERSION-$ARCHITECTURE:$CI_PIPELINE_ID
+    - docker tag $RUBY_CUSTOM_IMAGE_BASE/$RUBY_VERSION-$ARCHITECTURE:$CI_PIPELINE_ID $RUBY_CUSTOM_IMAGE_BASE/$RUBY_VERSION-$ARCHITECTURE:current
+    - docker push $RUBY_CUSTOM_IMAGE_BASE/$RUBY_VERSION-$ARCHITECTURE:current
 
-install-base-ruby-gems:
-  image: $RUBY_CUSTOM_IMAGE_BASE/3.2.2:current
+.install-base-ruby-gems:
+  image: $RUBY_CUSTOM_IMAGE_BASE/3.2.2-$ARCHITECTURE:current
   needs:
     - check-gem-presence
   stage: package
@@ -78,8 +90,17 @@ install-base-ruby-gems:
     paths:
       - pkg
 
-install-version-dependant-gems:
-  image: $RUBY_CUSTOM_IMAGE_BASE/$RUBY_VERSION:current
+install-base-ruby-gems-amd64:
+  extends: .install-base-ruby-gems
+  image: $RUBY_CUSTOM_IMAGE_BASE/3.2.2-amd64:current
+  tags: [ "runner:main" ]
+
+install-base-ruby-gems-arm64:
+  extends: .install-base-ruby-gems
+  image: $RUBY_CUSTOM_IMAGE_BASE/3.2.2-arm64:current
+  tags: [ "arch:arm64" ]
+
+.install-version-dependant-gems:
   parallel:
     matrix:
       - RUBY_VERSION: ["2.7.8", "3.0.6", "3.1.4"]
@@ -89,17 +110,30 @@ install-version-dependant-gems:
     - if: '$CI_COMMIT_TAG =~ /^v.*/'
       when: on_success
   stage: package
-  needs:
-    - check-gem-presence
-    - install-base-ruby-gems
   script:
     - ruby pkg/install_ddtrace_deps.rb msgpack ffi ddtrace
   artifacts:
     paths:
       - pkg
 
+install-version-dependant-gems-amd64:
+  extends: .install-version-dependant-gems
+  image: $RUBY_CUSTOM_IMAGE_BASE/$RUBY_VERSION-amd64:current
+  tags: [ "runner:main" ]
+  needs:
+    - check-gem-presence
+    - install-base-ruby-gems-amd64
+
+install-version-dependant-gems-arm64:
+  extends: .install-version-dependant-gems
+  image: $RUBY_CUSTOM_IMAGE_BASE/$RUBY_VERSION-arm64:current
+  tags: [ "arch:arm64" ]
+  needs:
+    - check-gem-presence
+    - install-base-ruby-gems-arm64
+
 check-gem-presence:
-  image: $RUBY_CUSTOM_IMAGE_BASE/3.2.2:current
+  image: $RUBY_CUSTOM_IMAGE_BASE/3.2.2-amd64:current
   rules:
     - if: $RUBY_PACKAGE_VERSION
       when: on_success
@@ -113,8 +147,23 @@ package:
   extends: .package
   needs:
     - check-gem-presence
-    - install-version-dependant-gems
-    - install-base-ruby-gems
+    - install-version-dependant-gems-amd64
+    - install-base-ruby-gems-amd64
+  rules:
+    - if: $RUBY_PACKAGE_VERSION
+      when: on_success
+    - if: '$CI_COMMIT_TAG =~ /^v.*/'
+      when: on_success
+  script:
+    - ls ../pkg
+    - ../.gitlab/build-deb-rpm.sh
+
+package-arm:
+  extends: .package-arm
+  needs:
+    - check-gem-presence
+    - install-version-dependant-gems-arm64
+    - install-base-ruby-gems-arm64
   rules:
     - if: $RUBY_PACKAGE_VERSION
       when: on_success

--- a/.gitlab/Dockerfile-2.7.8
+++ b/.gitlab/Dockerfile-2.7.8
@@ -1,6 +1,6 @@
 # This is copied from official Docker image, but compile Ruby with `--disable-shared` instead.
 
-FROM buildpack-deps:buster
+FROM registry.ddbuild.io/images/mirror/buildpack-deps:buster
 
 # skip installing gem documentation
 RUN set -eux; \

--- a/.gitlab/Dockerfile-3.0.6
+++ b/.gitlab/Dockerfile-3.0.6
@@ -1,6 +1,6 @@
 # This is copied from official Docker image, but compile Ruby with `--disable-shared` instead.
 
-FROM buildpack-deps:buster
+FROM registry.ddbuild.io/images/mirror/buildpack-deps:buster
 
 # skip installing gem documentation
 RUN set -eux; \

--- a/.gitlab/Dockerfile-3.1.4
+++ b/.gitlab/Dockerfile-3.1.4
@@ -1,6 +1,6 @@
 # This is copied from official Docker image, but compile Ruby with `--disable-shared` instead.
 
-FROM buildpack-deps:buster
+FROM registry.ddbuild.io/images/mirror/buildpack-deps:buster
 
 # skip installing gem documentation
 RUN set -eux; \

--- a/.gitlab/Dockerfile-3.2.2
+++ b/.gitlab/Dockerfile-3.2.2
@@ -1,6 +1,6 @@
 # This is copied from official Docker image, but compile Ruby with `--disable-shared` instead.
 
-FROM buildpack-deps:buster
+FROM registry.ddbuild.io/images/mirror/buildpack-deps:buster
 
 # skip installing gem documentation
 RUN set -eux; \

--- a/lib-injection/README.md
+++ b/lib-injection/README.md
@@ -42,7 +42,7 @@ Currently, we support
 | Environment| version |
 |---|---|
 | Ruby  | `2.7`, `3.0`, `3.1`, `3.2`|
-| Arch  | `amd64` |
+| Arch  | `amd64`, `arm64` |
 | glibc |  2.28+ |
 
 In order to ship `ddtrace` and its dependencies as a pre-install package, we need a few tweaks in our build pipeline.


### PR DESCRIPTION
Reverts DataDog/dd-trace-rb#3272

This PR reverts the revert PR. Other teams from Datadog are prepared to support ARM64.