### PR TITLE
remove deprecated profiler config options

### DIFF
--- a/lib/datadog/core/configuration/settings.rb
+++ b/lib/datadog/core/configuration/settings.rb
@@ -207,19 +207,6 @@ module Datadog
 
           # @public_api
           settings :advanced do
-            # @deprecated No longer does anything, and will be removed on dd-trace-rb 2.0.
-            #
-            # This was used prior to the GA of the new CPU Profiling 2.0 profiler. The CPU Profiling 2.0 profiler does not
-            # use or need this setting and thus it doesn't do anything.
-            option :max_events do |o|
-              o.after_set do
-                Datadog.logger.warn(
-                  'The profiling.advanced.max_events setting has been deprecated for removal and no ' \
-                  'longer does anything. Please remove it from your Datadog.configure block.'
-                )
-              end
-            end
-
             # Controls the maximum number of frames for each thread sampled. Can be tuned to avoid omitted frames in the
             # produced profiles. Increasing this may increase the overhead of profiling.
             #
@@ -249,45 +236,6 @@ module Datadog
             # Can be used to disable the gathering of names and versions of gems in use by the service, used to power
             # grouping and categorization of stack traces.
             option :code_provenance_enabled, default: true
-
-            # @deprecated No longer does anything, and will be removed on dd-trace-rb 2.0.
-            #
-            # This was added as a temporary support option in case of issues with the new `Profiling::HttpTransport` class
-            # but we're now confident it's working nicely so we've removed the old code path.
-            option :legacy_transport_enabled do |o|
-              o.after_set do
-                Datadog.logger.warn(
-                  'The profiling.advanced.legacy_transport_enabled setting has been deprecated for removal and no ' \
-                  'longer does anything. Please remove it from your Datadog.configure block.'
-                )
-              end
-            end
-
-            # @deprecated No longer does anything, and will be removed on dd-trace-rb 2.0.
-            #
-            # This was used prior to the GA of the new CPU Profiling 2.0 profiler. Using CPU Profiling 2.0 is now the
-            # default and this doesn't do anything.
-            option :force_enable_new_profiler do |o|
-              o.after_set do
-                Datadog.logger.warn(
-                  'The profiling.advanced.force_enable_new_profiler setting has been deprecated for removal and no ' \
-                  'longer does anything. Please remove it from your Datadog.configure block.'
-                )
-              end
-            end
-
-            # @deprecated No longer does anything, and will be removed on dd-trace-rb 2.0.
-            #
-            # This was used prior to the GA of the new CPU Profiling 2.0 profiler. Using CPU Profiling 2.0 is now the
-            # default and this doesn't do anything.
-            option :force_enable_legacy_profiler do |o|
-              o.after_set do
-                Datadog.logger.warn(
-                  'The profiling.advanced.force_enable_legacy_profiler setting has been deprecated for removal and no ' \
-                  'longer does anything. Please remove it from your Datadog.configure block.'
-                )
-              end
-            end
 
             # Forces enabling of profiling of time/resources spent in Garbage Collection.
             #

--- a/spec/datadog/core/configuration/settings_spec.rb
+++ b/spec/datadog/core/configuration/settings_spec.rb
@@ -343,14 +343,6 @@ RSpec.describe Datadog::Core::Configuration::Settings do
     end
 
     describe '#advanced' do
-      describe '#max_events=' do
-        it 'logs a warning informing customers this no longer does anything' do
-          expect(Datadog.logger).to receive(:warn).with(/no longer does anything/)
-
-          settings.profiling.advanced.max_events = 1234
-        end
-      end
-
       describe '#max_frames' do
         subject(:max_frames) { settings.profiling.advanced.max_frames }
 
@@ -435,30 +427,6 @@ RSpec.describe Datadog::Core::Configuration::Settings do
             .to change { settings.profiling.advanced.code_provenance_enabled }
             .from(true)
             .to(false)
-        end
-      end
-
-      describe '#force_enable_new_profiler=' do
-        it 'logs a warning informing customers this no longer does anything' do
-          expect(Datadog.logger).to receive(:warn).with(/no longer does anything/)
-
-          settings.profiling.advanced.force_enable_new_profiler = true
-        end
-      end
-
-      describe '#legacy_transport_enabled=' do
-        it 'logs a warning informing customers this no longer does anything' do
-          expect(Datadog.logger).to receive(:warn).with(/no longer does anything/)
-
-          settings.profiling.advanced.legacy_transport_enabled = true
-        end
-      end
-
-      describe '#force_enable_legacy_profiler=' do
-        it 'logs a warning informing customers this no longer does anything' do
-          expect(Datadog.logger).to receive(:warn).with(/no longer does anything/)
-
-          settings.profiling.advanced.force_enable_legacy_profiler = true
         end
       end
 


### PR DESCRIPTION
<!--
Check out the
https://github.com/DataDog/dd-trace-rb/blob/master/docs/DevelopmentGuide.md
for guidance on how to set up your development environment,
run the test suite, write new integrations, and more.
-->

**2.0 Upgrade Guide notes**
The following profiler configuration options have been removed: `max_events`, `legacy_transport_enabled`, `force_enable_new_profiler` and `force_enable_legacy_profiler`. Users should remove these from their configuration blocks. These options have not been functional since the GA release of CPU profiler 2.0.

**What does this PR do?**
Removes four configuration options for the profiler that have been deprecated and non-functional since GA of the 2.0 profiler. 

**Motivation:**
Non-functional, deprecated options.

**Additional Notes:**
<!-- Anything else we should know when reviewing? -->

**How to test the change?**
<!--
Describe here how the change can be validated.
You are strongly encouraged to provide automated tests for this PR (unit or integration).
If this change cannot be feasibly tested, please explain why,
unless the change does not modify code (e.g. only modifies docs, comments).
-->

**For Datadog employees:**
- [ ] If this PR touches code that signs or publishes builds or packages, or handles
credentials of any kind, I've requested a review from `@DataDog/security-design-and-guidance`.
- [ ] This PR doesn't touch any of that.

Unsure? Have a question? Request a review!
