### PR TITLE
[PROF-8667] Split profiling tests into ractor and non-ractor suites.

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -17,6 +17,12 @@ TEST_METADATA = {
   'appsec:main' => {
     '' => '✅ 2.1 / ✅ 2.2 / ✅ 2.3 / ✅ 2.4 / ✅ 2.5 / ✅ 2.6 / ✅ 2.7 / ✅ 3.0 / ✅ 3.1 / ✅ 3.2 / ✅ 3.3 / ✅ jruby'
   },
+  'profiling:main' => {
+    '' => '✅ 2.1 / ✅ 2.2 / ✅ 2.3 / ✅ 2.4 / ✅ 2.5 / ✅ 2.6 / ✅ 2.7 / ✅ 3.0 / ✅ 3.1 / ✅ 3.2 / ✅ 3.3 / ✅ jruby'
+  },
+  'profiling:ractors' => {
+    '' => '❌ 2.1 / ❌ 2.2 / ❌ 2.3 / ❌ 2.4 / ❌ 2.5 / ❌ 2.6 / ❌ 2.7 / ✅ 3.0 / ✅ 3.1 / ✅ 3.2 / ✅ 3.3 / ✅ jruby'
+  },
   'contrib' => {
     '' => '✅ 2.1 / ✅ 2.2 / ✅ 2.3 / ✅ 2.4 / ✅ 2.5 / ✅ 2.6 / ✅ 2.7 / ✅ 3.0 / ✅ 3.1 / ✅ 3.2 / ✅ 3.3 / ✅ jruby'
   },
@@ -323,19 +329,15 @@ desc 'Run RSpec'
 namespace :spec do
   task all: [:main, :benchmark,
              :rails, :railsredis, :railsredis_activesupport, :railsactivejob,
-             :elasticsearch, :http, :redis, :sidekiq, :sinatra, :hanami, :hanami_autoinstrument]
+             :elasticsearch, :http, :redis, :sidekiq, :sinatra, :hanami, :hanami_autoinstrument,
+             :profiling]
 
   desc '' # "Explicitly hiding from `rake -T`"
   RSpec::Core::RakeTask.new(:main) do |t, args|
     t.pattern = 'spec/**/*_spec.rb'
-    t.exclude_pattern = 'spec/**/{contrib,benchmark,redis,opentracer,auto_instrument,opentelemetry}/**/*_spec.rb,'\
+    t.exclude_pattern = 'spec/**/{contrib,benchmark,redis,opentracer,auto_instrument,opentelemetry,profiling}/**/*_spec.rb,'\
                         ' spec/**/{auto_instrument,opentelemetry}_spec.rb'
     t.rspec_opts = args.to_a.join(' ')
-  end
-  if RUBY_ENGINE == 'ruby' && OS.linux? && Gem::Version.new(RUBY_VERSION) >= Gem::Version.new('2.3.0')
-    # "bundle exec rake compile" currently only works on MRI Ruby on Linux
-    Rake::Task[:main].enhance([:clean])
-    Rake::Task[:main].enhance([:compile])
   end
 
   RSpec::Core::RakeTask.new(:benchmark) do |t, args|
@@ -535,6 +537,39 @@ namespace :spec do
   end
 
   task appsec: [:'appsec:all']
+
+  namespace :profiling do
+    task all: [:main, :ractors]
+
+    task :setup do
+      # "bundle exec rake compile" currently only works on MRI Ruby on Linux
+      if RUBY_ENGINE == 'ruby' && OS.linux? && Gem::Version.new(RUBY_VERSION) >= Gem::Version.new('2.3.0')
+        Rake::Task[:clean].invoke
+        Rake::Task[:compile].invoke
+      end
+    end
+
+    # Datadog Profiling main specs without Ractor creation
+    # NOTE: Ractor creation will transition the entire Ruby VM into multi-ractor mode. This cannot be undone
+    #       and, as such, may introduce side-effects between tests and make them flaky depending on order of
+    #       execution. By splitting in two separate suites, the side-effect impact should be mitigated as
+    #       the non-ractor VM will never trigger the transition into multi-ractor mode.
+    desc '' # "Explicitly hiding from `rake -T`"
+    RSpec::Core::RakeTask.new(:main) do |t, args|
+      t.pattern = 'spec/datadog/profiling/**/*_spec.rb'
+      t.rspec_opts = [*args.to_a, '-t ~ractors'].join(' ')
+    end
+    Rake::Task[:main].enhance([:setup])
+
+    desc '' # "Explicitly hiding from `rake -T`"
+    RSpec::Core::RakeTask.new(:ractors) do |t, args|
+      t.pattern = 'spec/datadog/profiling/**/*_spec.rb'
+      t.rspec_opts = [*args.to_a, '-t ractors'].join(' ')
+    end
+    Rake::Task[:ractors].enhance([:setup])
+  end
+
+  task profiling: [:'profiling:all']
 end
 
 if defined?(RuboCop::RakeTask)

--- a/Rakefile
+++ b/Rakefile
@@ -556,7 +556,7 @@ namespace :spec do
     #       the non-ractor VM will never trigger the transition into multi-ractor mode.
     desc '' # "Explicitly hiding from `rake -T`"
     RSpec::Core::RakeTask.new(:main) do |t, args|
-      t.pattern = 'spec/datadog/profiling/**/*_spec.rb'
+      t.pattern = 'spec/datadog/profiling/**/*_spec.rb,spec/datadog/profiling_spec.rb'
       t.rspec_opts = [*args.to_a, '-t ~ractors'].join(' ')
     end
 

--- a/Rakefile
+++ b/Rakefile
@@ -332,6 +332,14 @@ namespace :spec do
              :elasticsearch, :http, :redis, :sidekiq, :sinatra, :hanami, :hanami_autoinstrument,
              :profiling]
 
+  task :compile_native_extensions do
+    # "bundle exec rake compile" currently only works on MRI Ruby on Linux
+    if RUBY_ENGINE == 'ruby' && OS.linux? && Gem::Version.new(RUBY_VERSION) >= Gem::Version.new('2.3.0')
+      Rake::Task[:clean].invoke
+      Rake::Task[:compile].invoke
+    end
+  end
+
   desc '' # "Explicitly hiding from `rake -T`"
   RSpec::Core::RakeTask.new(:main) do |t, args|
     t.pattern = 'spec/**/*_spec.rb'
@@ -339,6 +347,8 @@ namespace :spec do
                         ' spec/**/{auto_instrument,opentelemetry}_spec.rb'
     t.rspec_opts = args.to_a.join(' ')
   end
+  # Some of the profiling-related core config tests require native extensions to be built
+  Rake::Task[:main].enhance([:compile_native_extensions])
 
   RSpec::Core::RakeTask.new(:benchmark) do |t, args|
     t.pattern = 'spec/ddtrace/benchmark/**/*_spec.rb'
@@ -541,14 +551,6 @@ namespace :spec do
   namespace :profiling do
     task all: [:main, :ractors]
 
-    task :setup do
-      # "bundle exec rake compile" currently only works on MRI Ruby on Linux
-      if RUBY_ENGINE == 'ruby' && OS.linux? && Gem::Version.new(RUBY_VERSION) >= Gem::Version.new('2.3.0')
-        Rake::Task[:clean].invoke
-        Rake::Task[:compile].invoke
-      end
-    end
-
     # Datadog Profiling main specs without Ractor creation
     # NOTE: Ractor creation will transition the entire Ruby VM into multi-ractor mode. This cannot be undone
     #       and, as such, may introduce side-effects between tests and make them flaky depending on order of
@@ -559,14 +561,14 @@ namespace :spec do
       t.pattern = 'spec/datadog/profiling/**/*_spec.rb'
       t.rspec_opts = [*args.to_a, '-t ~ractors'].join(' ')
     end
-    Rake::Task[:main].enhance([:setup])
 
     desc '' # "Explicitly hiding from `rake -T`"
     RSpec::Core::RakeTask.new(:ractors) do |t, args|
       t.pattern = 'spec/datadog/profiling/**/*_spec.rb'
       t.rspec_opts = [*args.to_a, '-t ractors'].join(' ')
     end
-    Rake::Task[:ractors].enhance([:setup])
+
+    Rake::Task[:all].prerequisite_tasks.each { |t| t.enhance([:compile_native_extensions]) }
   end
 
   task profiling: [:'profiling:all']

--- a/spec/datadog/core/configuration/components_spec.rb
+++ b/spec/datadog/core/configuration/components_spec.rb
@@ -1070,18 +1070,24 @@ RSpec.describe Datadog::Core::Configuration::Components do
       end
 
       context 'is enabled' do
-        before do
-          skip 'Profiling not supported.' unless Datadog::Profiling.supported?
+        # Using a generic double rather than instance_double since if profiling is not supported by the
+        # current CI runner we won't even load the Datadog::Profiling::Profiler class.
+        let(:profiler) { double }
 
+        before do
           allow(settings.profiling)
             .to receive(:enabled)
             .and_return(true)
           allow(profiler_setup_task).to receive(:run)
+          expect(Datadog::Profiling::Component).to receive(:build_profiler_component).with(
+            settings: settings,
+            agent_settings: agent_settings,
+            optional_tracer: anything,
+          ).and_return(profiler)
         end
 
         it do
-          expect(components.profiler)
-            .to receive(:start)
+          expect(profiler).to receive(:start)
 
           startup!
         end

--- a/spec/datadog/core/configuration/components_spec.rb
+++ b/spec/datadog/core/configuration/components_spec.rb
@@ -1078,7 +1078,6 @@ RSpec.describe Datadog::Core::Configuration::Components do
           allow(settings.profiling)
             .to receive(:enabled)
             .and_return(true)
-          allow(profiler_setup_task).to receive(:run)
           expect(Datadog::Profiling::Component).to receive(:build_profiler_component).with(
             settings: settings,
             agent_settings: agent_settings,

--- a/spec/datadog/core/configuration/components_spec.rb
+++ b/spec/datadog/core/configuration/components_spec.rb
@@ -1072,7 +1072,7 @@ RSpec.describe Datadog::Core::Configuration::Components do
       context 'is enabled' do
         # Using a generic double rather than instance_double since if profiling is not supported by the
         # current CI runner we won't even load the Datadog::Profiling::Profiler class.
-        let(:profiler) { double }
+        let(:profiler) { instance_double('Datadog::Profiling::Profiler') }
 
         before do
           allow(settings.profiling)

--- a/spec/datadog/core/configuration_spec.rb
+++ b/spec/datadog/core/configuration_spec.rb
@@ -316,30 +316,6 @@ RSpec.describe Datadog::Core::Configuration do
         end
       end
 
-      context 'when the profiler' do
-        context 'is not changed' do
-          before { skip_if_profiling_not_supported(self) }
-
-          context 'and profiling is enabled' do
-            before do
-              allow(test_class.configuration.profiling)
-                .to receive(:enabled)
-                .and_return(true)
-
-              allow_any_instance_of(Datadog::Profiling::Profiler)
-                .to receive(:start)
-              allow_any_instance_of(Datadog::Profiling::Tasks::Setup)
-                .to receive(:run)
-            end
-
-            it 'starts the profiler' do
-              configure
-              expect(test_class.send(:components).profiler).to have_received(:start)
-            end
-          end
-        end
-      end
-
       context 'when reconfigured multiple times' do
         context 'with runtime metrics active' do
           before do

--- a/spec/datadog/profiling/collectors/cpu_and_wall_time_worker_spec.rb
+++ b/spec/datadog/profiling/collectors/cpu_and_wall_time_worker_spec.rb
@@ -676,7 +676,7 @@ RSpec.describe 'Datadog::Profiling::Collectors::CpuAndWallTimeWorker' do
       end
     end
 
-    context 'when called from a background ractor' do
+    context 'when called from a background ractor', :ractors => true do
       # Even though we're not testing it explicitly, the GC profiling hooks can sometimes be called when running these
       # specs. Unfortunately, there's a VM crash in that case as well -- https://bugs.ruby-lang.org/issues/18464 --
       # so this must be disabled when interacting with Ractors.

--- a/spec/datadog/profiling/native_extension_spec.rb
+++ b/spec/datadog/profiling/native_extension_spec.rb
@@ -82,7 +82,7 @@ RSpec.describe Datadog::Profiling::NativeExtension do
         it { is_expected.to be true }
       end
 
-      context 'on a background Ractor' do
+      context 'on a background Ractor', :ractors => true do
         # @ivoanjo: When we initially added this test, our test suite kept deadlocking in CI in a later test (not on
         # this one).
         #


### PR DESCRIPTION
**What does this PR do?**

* Separate the profiling test suite from main to allow for profiling-specific customizations.
* Tag all tests that use `Ractor.new` with `ractors => true` tag.
* Introduce two spec tasks for profiling:
  * `profiling:main` - Run all tests EXCLUDING `ractors` tagged tests.
  * `profiling:ractors` - Run all `ractors` tagged tests.

**Motivation:**

As soon as you execute `Ractor.new`, the VM [transitions to a multi-ractor state](https://github.com/ruby/ruby/blob/b9f2c67106ac8277b0e83a5701a43d016d829131/ractor.c#L1877-L1892). This transition cannot be reversed and will change the behaviour of the VM. For example, [`ObjectSpace::_id2ref` will start to raise errors on unshareable objects](https://github.com/ruby/ruby/blob/b9f2c67106ac8277b0e83a5701a43d016d829131/gc.c#L4746C1-L4747). 

This essentially introduces an unavoidable cross-test side-effect that may make tests flaky depending on execution order. By containing tests that create actors to their own rspec run, we scope this side-effect to those tests that would always trigger it anyway.

**Additional Notes:**
<!-- Anything else we should know when reviewing? -->

**How to test the change?**

* `bundle exec rake spec:profiling`
* `bundle exec rake spec:profiling:main`
* `bundle exec rake spec:profiling:ractors`
* CI: 
  * `spec:profiling:main`: https://app.circleci.com/pipelines/github/DataDog/dd-trace-rb/12856/workflows/933470cd-2e63-4891-babb-9aca834e0660/jobs/483058/parallel-runs/4?filterBy=ALL
    <img width="1224" alt="image" src="https://github.com/DataDog/dd-trace-rb/assets/373323/4922e975-c698-484c-a9f2-2203bd3bb732">
  * `spec:profiling:ractors`: https://app.circleci.com/pipelines/github/DataDog/dd-trace-rb/12856/workflows/933470cd-2e63-4891-babb-9aca834e0660/jobs/483058/parallel-runs/5?filterBy=ALL
    <img width="1217" alt="image" src="https://github.com/DataDog/dd-trace-rb/assets/373323/6d3e084c-0c66-4afd-861b-084656373066">



**For Datadog employees:**
- [ ] If this PR touches code that signs or publishes builds or packages, or handles
credentials of any kind, I've requested a review from `@DataDog/security-design-and-guidance`.
- [ ] This PR doesn't touch any of that.

Unsure? Have a question? Request a review!
