### PR TITLE
Use 128 bits trace id in test

### DIFF
--- a/spec/datadog/tracing/contrib/lograge/instrumentation_spec.rb
+++ b/spec/datadog/tracing/contrib/lograge/instrumentation_spec.rb
@@ -20,7 +20,7 @@ RSpec.describe Datadog::Tracing::Contrib::Lograge::Instrumentation do
         version: version,
       )
     end
-    let(:trace_id) { Datadog::Tracing::Utils.next_id }
+    let(:trace_id) { Datadog::Tracing::Utils::TraceId.next_id }
     let(:span_id) { Datadog::Tracing::Utils.next_id }
     let(:env) { 'env' }
     let(:service) { 'service' }
@@ -50,7 +50,7 @@ RSpec.describe Datadog::Tracing::Contrib::Lograge::Instrumentation do
               env: 'env',
               service: 'service',
               span_id: span_id.to_s,
-              trace_id: trace_id.to_s,
+              trace_id: low_order_trace_id(trace_id).to_s,
               version: 'version'
             },
             ddsource: 'ruby' }

--- a/spec/datadog/tracing/contrib/semantic_logger/instrumentation_spec.rb
+++ b/spec/datadog/tracing/contrib/semantic_logger/instrumentation_spec.rb
@@ -45,7 +45,7 @@ RSpec.describe Datadog::Tracing::Contrib::SemanticLogger::Instrumentation do
       end
     end
 
-    let(:trace_id) { Datadog::Tracing::Utils.next_id }
+    let(:trace_id) { Datadog::Tracing::Utils::TraceId.next_id }
     let(:span_id) { Datadog::Tracing::Utils.next_id }
 
     let(:correlation) do
@@ -71,7 +71,7 @@ RSpec.describe Datadog::Tracing::Contrib::SemanticLogger::Instrumentation do
         expect(log_entry).to include 'Mamamia!'
         expect(log_entry).to include 'original: tag'
 
-        expect(log_entry).to include trace_id.to_s
+        expect(log_entry).to include low_order_trace_id(trace_id).to_s
         expect(log_entry).to include span_id.to_s
         expect(log_entry).to include 'production'
         expect(log_entry).to include 'MyService'
@@ -91,7 +91,7 @@ RSpec.describe Datadog::Tracing::Contrib::SemanticLogger::Instrumentation do
         expect(log_entry).to include 'Mamamia!'
         expect(log_entry).to include 'original: tag'
 
-        expect(log_entry).not_to include trace_id.to_s
+        expect(log_entry).not_to include low_order_trace_id(trace_id).to_s
         expect(log_entry).not_to include span_id.to_s
         expect(log_entry).not_to include 'production'
         expect(log_entry).not_to include 'MyService'
@@ -111,7 +111,7 @@ RSpec.describe Datadog::Tracing::Contrib::SemanticLogger::Instrumentation do
         expect(log_entry).to include 'Mamamia!'
         expect(log_entry).to include 'original: tag'
 
-        expect(log_entry).not_to include trace_id.to_s
+        expect(log_entry).not_to include low_order_trace_id(trace_id).to_s
         expect(log_entry).not_to include span_id.to_s
         expect(log_entry).not_to include 'production'
         expect(log_entry).not_to include 'MyService'
@@ -137,7 +137,7 @@ RSpec.describe Datadog::Tracing::Contrib::SemanticLogger::Instrumentation do
         expect(log_entry).to include 'Mamamia!'
         expect(log_entry).not_to include 'original: tag'
 
-        expect(log_entry).to include trace_id.to_s
+        expect(log_entry).to include low_order_trace_id(trace_id).to_s
         expect(log_entry).to include span_id.to_s
         expect(log_entry).to include 'production'
         expect(log_entry).to include 'MyService'

--- a/spec/datadog/tracing/contrib/sidekiq/distributed_tracing_spec.rb
+++ b/spec/datadog/tracing/contrib/sidekiq/distributed_tracing_spec.rb
@@ -66,7 +66,7 @@ RSpec.describe 'Sidekiq distributed tracing' do
     end
 
     context 'when receiving' do
-      let(:trace_id) { Datadog::Tracing::Utils.next_id }
+      let(:trace_id) { Datadog::Tracing::Utils::TraceId.next_id }
       let(:span_id) { Datadog::Tracing::Utils.next_id }
       let(:jid) { '123abc' }
 
@@ -78,10 +78,10 @@ RSpec.describe 'Sidekiq distributed tracing' do
             'args' => [],
             'class' => EmptyWorker.to_s,
             'jid' => jid,
-            'x-datadog-trace-id' => trace_id.to_s,
+            'x-datadog-trace-id' => low_order_trace_id(trace_id).to_s,
             'x-datadog-parent-id' => span_id.to_s,
             'x-datadog-sampling-priority' => '2',
-            'x-datadog-tags' => '_dd.p.dm=-99',
+            'x-datadog-tags' => "_dd.p.dm=-99,_dd.p.tid=#{high_order_hex_trace_id(trace_id)}",
             'x-datadog-origin' => 'my-origin'
           )
         )
@@ -153,7 +153,7 @@ RSpec.describe 'Sidekiq distributed tracing' do
     end
 
     context 'when receiving' do
-      let(:trace_id) { Datadog::Tracing::Utils.next_id }
+      let(:trace_id) { Datadog::Tracing::Utils::TraceId.next_id }
       let(:span_id) { Datadog::Tracing::Utils.next_id }
       let(:jid) { '123abc' }
 

--- a/spec/datadog/tracing/correlation_spec.rb
+++ b/spec/datadog/tracing/correlation_spec.rb
@@ -26,7 +26,7 @@ RSpec.describe Datadog::Tracing::Correlation do
     let(:span_resource) { 'SELECT * FROM users;' }
     let(:span_service) { 'acme-mysql' }
     let(:span_type) { 'db' }
-    let(:trace_id) { Datadog::Tracing::Utils.next_id }
+    let(:trace_id) { Datadog::Tracing::Utils::TraceId.next_id }
     let(:trace_name) { 'rack.request' }
     let(:trace_resource) { 'GET /users' }
     let(:trace_service) { 'acme-api' }
@@ -93,7 +93,7 @@ RSpec.describe Datadog::Tracing::Correlation do
           span_resource: span_resource,
           span_service: span_service,
           span_type: span_type,
-          trace_id: trace_id,
+          trace_id: low_order_trace_id(trace_id),
           trace_name: trace_name,
           trace_resource: trace_resource,
           trace_service: trace_service,
@@ -174,7 +174,7 @@ RSpec.describe Datadog::Tracing::Correlation do
             span_resource: span_resource,
             span_service: span_service,
             span_type: span_type,
-            trace_id: trace_id,
+            trace_id: low_order_trace_id(trace_id),
             trace_name: trace_name,
             trace_resource: trace_resource,
             trace_service: trace_service,
@@ -199,7 +199,7 @@ RSpec.describe Datadog::Tracing::Correlation do
 
     describe '#to_h' do
       context 'when given values' do
-        let(:trace_id) { Datadog::Tracing::Utils.next_id }
+        let(:trace_id) { Datadog::Tracing::Utils::TraceId.next_id }
         let(:span_id) { Datadog::Tracing::Utils.next_id }
 
         it 'returns a formatted hash' do
@@ -217,7 +217,7 @@ RSpec.describe Datadog::Tracing::Correlation do
                 env: 'dev',
                 service: 'acme-api',
                 version: '1.0',
-                trace_id: trace_id.to_s,
+                trace_id: low_order_trace_id(trace_id).to_s,
                 span_id: span_id.to_s
               },
               ddsource: 'ruby'
@@ -266,7 +266,7 @@ RSpec.describe Datadog::Tracing::Correlation do
           )
         end
 
-        let(:trace_id) { Datadog::Tracing::Utils.next_id }
+        let(:trace_id) { Datadog::Tracing::Utils::TraceId.next_id }
         let(:span_id) { Datadog::Tracing::Utils.next_id }
         let(:env) { 'dev' }
         let(:service) { 'acme-api' }

--- a/spec/datadog/tracing/span_operation_spec.rb
+++ b/spec/datadog/tracing/span_operation_spec.rb
@@ -359,7 +359,7 @@ RSpec.describe Datadog::Tracing::SpanOperation do
         end
 
         context 'that is an Integer' do
-          let(:trace_id) { Datadog::Tracing::Utils.next_id }
+          let(:trace_id) { Datadog::Tracing::Utils::TraceId.next_id }
           it { is_expected.to have_attributes(trace_id: trace_id) }
         end
       end

--- a/spec/datadog/tracing/trace_digest_spec.rb
+++ b/spec/datadog/tracing/trace_digest_spec.rb
@@ -92,7 +92,7 @@ RSpec.describe Datadog::Tracing::TraceDigest do
 
       context ':trace_id' do
         let(:options) { { trace_id: trace_id } }
-        let(:trace_id) { Datadog::Tracing::Utils.next_id }
+        let(:trace_id) { Datadog::Tracing::Utils::TraceId.next_id }
 
         it { is_expected.to have_attributes(trace_id: trace_id) }
       end


### PR DESCRIPTION
**What does this PR do?**

Replace random 64 bits trace ID with 128 bits generation in our test suite. 

This better simulates the reality with our default.


**For Datadog employees:**
- [ ] If this PR touches code that signs or publishes builds or packages, or handles
credentials of any kind, I've requested a review from `@DataDog/security-design-and-guidance`.
- [x] This PR doesn't touch any of that.