### PR TITLE
Remove configuration for priority_sampling

### DIFF
--- a/lib/datadog/core/telemetry/collector.rb
+++ b/lib/datadog/core/telemetry/collector.rb
@@ -123,7 +123,6 @@ module Datadog
           'tracing.log_injection',
           'tracing.partial_flush.enabled',
           'tracing.partial_flush.min_spans_threshold',
-          'tracing.priority_sampling',
           'tracing.report_hostname',
           'tracing.sampling.default_rate',
           'tracing.sampling.rate_limit'

--- a/lib/datadog/tracing/component.rb
+++ b/lib/datadog/tracing/component.rb
@@ -70,63 +70,32 @@ module Datadog
         end
       end
 
-      # TODO: Sampler should be a top-level component.
-      # It is currently part of the Tracer initialization
-      # process, but can take a variety of options (including
-      # a fully custom instance) that makes the Tracer
-      # initialization process complex.
       def build_sampler(settings)
+        # A custom sampler is provided
         if (sampler = settings.tracing.sampler)
-          if settings.tracing.priority_sampling == false
-            sampler
-          else
-            ensure_priority_sampling(sampler, settings)
-          end
-        elsif (rules = settings.tracing.sampling.rules)
+          return sampler
+        end
+
+        # Sampling rules are provided
+        if (rules = settings.tracing.sampling.rules)
           post_sampler = Tracing::Sampling::RuleSampler.parse(
             rules,
             settings.tracing.sampling.rate_limit,
             settings.tracing.sampling.default_rate
           )
-
-          post_sampler ||= # Fallback RuleSampler in case `rules` parsing fails
-            Tracing::Sampling::RuleSampler.new(
-              rate_limit: settings.tracing.sampling.rate_limit,
-              default_sample_rate: settings.tracing.sampling.default_rate
-            )
-
-          Tracing::Sampling::PrioritySampler.new(
-            base_sampler: Tracing::Sampling::AllSampler.new,
-            post_sampler: post_sampler
-          )
-        elsif settings.tracing.priority_sampling == false
-          Tracing::Sampling::RuleSampler.new(
-            rate_limit: settings.tracing.sampling.rate_limit,
-            default_sample_rate: settings.tracing.sampling.default_rate
-          )
-        else
-          Tracing::Sampling::PrioritySampler.new(
-            base_sampler: Tracing::Sampling::AllSampler.new,
-            post_sampler: Tracing::Sampling::RuleSampler.new(
-              rate_limit: settings.tracing.sampling.rate_limit,
-              default_sample_rate: settings.tracing.sampling.default_rate
-            )
-          )
         end
-      end
 
-      def ensure_priority_sampling(sampler, settings)
-        if sampler.is_a?(Tracing::Sampling::PrioritySampler)
-          sampler
-        else
-          Tracing::Sampling::PrioritySampler.new(
-            base_sampler: sampler,
-            post_sampler: Tracing::Sampling::RuleSampler.new(
-              rate_limit: settings.tracing.sampling.rate_limit,
-              default_sample_rate: settings.tracing.sampling.default_rate
-            )
-          )
-        end
+        # The default sampler.
+        # Used if no custom sampler is provided, or if sampling rule parsing fails.
+        post_sampler ||= Tracing::Sampling::RuleSampler.new(
+          rate_limit: settings.tracing.sampling.rate_limit,
+          default_sample_rate: settings.tracing.sampling.default_rate
+        )
+
+        Tracing::Sampling::PrioritySampler.new(
+          base_sampler: Tracing::Sampling::AllSampler.new,
+          post_sampler: post_sampler
+        )
       end
 
       # TODO: Writer should be a top-level component.

--- a/lib/datadog/tracing/configuration/settings.rb
+++ b/lib/datadog/tracing/configuration/settings.rb
@@ -227,12 +227,6 @@ module Datadog
                 option :min_spans_threshold, default: 500, type: :int
               end
 
-              # Enables {https://docs.datadoghq.com/tracing/trace_retention_and_ingestion/#datadog-intelligent-retention-filter
-              # Datadog intelligent retention filter}.
-              # @default `true`
-              # @return [Boolean,nil]
-              option :priority_sampling
-
               option :report_hostname do |o|
                 o.env Tracing::Configuration::Ext::NET::ENV_REPORT_HOSTNAME
                 o.default false

--- a/lib/datadog/tracing/diagnostics/environment_logger.rb
+++ b/lib/datadog/tracing/diagnostics/environment_logger.rb
@@ -40,7 +40,6 @@ module Datadog
               sampling_rules: sampling_rules,
               integrations_loaded: integrations_loaded,
               partial_flushing_enabled: partial_flushing_enabled,
-              priority_sampling_enabled: priority_sampling_enabled,
               **instrumented_integrations_settings
             }
           end
@@ -127,11 +126,6 @@ module Datadog
           # @return [Boolean, nil] partial flushing enabled in configuration
           def partial_flushing_enabled
             !!Datadog.configuration.tracing.partial_flush.enabled
-          end
-
-          # @return [Boolean, nil] priority sampling enabled in configuration
-          def priority_sampling_enabled
-            !!Datadog.configuration.tracing.priority_sampling
           end
 
           private

--- a/sig/datadog/core/telemetry/collector.rbs
+++ b/sig/datadog/core/telemetry/collector.rbs
@@ -14,7 +14,7 @@ module Datadog
 
         private
 
-        TARGET_OPTIONS: ::Array["ci.enabled" | "logger.level" | "profiling.advanced.code_provenance_enabled" | "profiling.advanced.endpoint.collection.enabled" | "profiling.enabled" | "runtime_metrics.enabled" | "tracing.analytics.enabled" | "tracing.distributed_tracing.propagation_inject_style" | "tracing.distributed_tracing.propagation_extract_style" | "tracing.enabled" | "tracing.log_injection" | "tracing.partial_flush.enabled" | "tracing.partial_flush.min_spans_threshold" | "tracing.priority_sampling" | "tracing.report_hostname" | "tracing.sampling.default_rate" | "tracing.sampling.rate_limit"]
+        TARGET_OPTIONS: ::Array[::String]
 
         def additional_payload_variables: () -> untyped
 

--- a/spec/datadog/core/configuration/components_spec.rb
+++ b/spec/datadog/core/configuration/components_spec.rb
@@ -572,74 +572,18 @@ RSpec.describe Datadog::Core::Configuration::Components do
         end
       end
 
-      context 'with :priority_sampling' do
+      context 'with :sampler' do
         before do
           allow(settings.tracing)
-            .to receive(:priority_sampling)
-            .and_return(priority_sampling)
+            .to receive(:sampler)
+            .and_return(sampler)
         end
 
-        context 'enabled' do
-          let(:priority_sampling) { true }
+        let(:sampler) { double('sampler') }
 
-          it_behaves_like 'new tracer'
-
-          context 'with :sampler' do
-            before do
-              allow(settings.tracing)
-                .to receive(:sampler)
-                .and_return(sampler)
-            end
-
-            context 'that is a priority sampler' do
-              let(:sampler) { Datadog::Tracing::Sampling::PrioritySampler.new }
-
-              it_behaves_like 'new tracer' do
-                let(:options) { { sampler: sampler } }
-                it_behaves_like 'event publishing writer and priority sampler'
-              end
-            end
-
-            context 'that is not a priority sampler' do
-              let(:sampler) { double('sampler') }
-
-              context 'wraps sampler in a priority sampler' do
-                it_behaves_like 'new tracer' do
-                  let(:options) do
-                    { sampler: be_a(Datadog::Tracing::Sampling::PrioritySampler) & have_attributes(
-                      pre_sampler: sampler,
-                      priority_sampler: be_a(Datadog::Tracing::Sampling::RuleSampler)
-                    ) }
-                  end
-
-                  it_behaves_like 'event publishing writer and priority sampler'
-                end
-              end
-            end
-          end
-        end
-
-        context 'disabled' do
-          let(:priority_sampling) { false }
-
-          it_behaves_like 'new tracer' do
-            let(:options) { { sampler: be_a(Datadog::Tracing::Sampling::RuleSampler) } }
-          end
-
-          context 'with :sampler' do
-            before do
-              allow(settings.tracing)
-                .to receive(:sampler)
-                .and_return(sampler)
-            end
-
-            let(:sampler) { double('sampler') }
-
-            it_behaves_like 'new tracer' do
-              let(:options) { { sampler: sampler } }
-              it_behaves_like 'event publishing writer and priority sampler'
-            end
-          end
+        it_behaves_like 'new tracer' do
+          let(:options) { { sampler: sampler } }
+          it_behaves_like 'event publishing writer and priority sampler'
         end
       end
 

--- a/spec/datadog/tracing/configuration/settings_spec.rb
+++ b/spec/datadog/tracing/configuration/settings_spec.rb
@@ -404,21 +404,6 @@ RSpec.describe Datadog::Tracing::Configuration::Settings do
       end
     end
 
-    describe '#priority_sampling' do
-      subject(:priority_sampling) { settings.tracing.priority_sampling }
-
-      it { is_expected.to be nil }
-    end
-
-    describe '#priority_sampling=' do
-      it 'updates the #priority_sampling setting' do
-        expect { settings.tracing.priority_sampling = true }
-          .to change { settings.tracing.priority_sampling }
-          .from(nil)
-          .to(true)
-      end
-    end
-
     describe '#report_hostname' do
       subject(:report_hostname) { settings.tracing.report_hostname }
 
@@ -668,7 +653,7 @@ RSpec.describe Datadog::Tracing::Configuration::Settings do
       end
 
       describe '#writer_options=' do
-        let(:options) { { priority_sampling: true } }
+        let(:options) { { anything: double } }
 
         it 'updates the #writer_options setting' do
           expect { settings.tracing.test_mode.writer_options = options }
@@ -728,7 +713,7 @@ RSpec.describe Datadog::Tracing::Configuration::Settings do
     end
 
     describe '#writer_options=' do
-      let(:options) { { priority_sampling: true } }
+      let(:options) { { anything: double } }
 
       it 'updates the #writer_options setting' do
         expect { settings.tracing.writer_options = options }

--- a/spec/datadog/tracing/diagnostics/environment_logger_spec.rb
+++ b/spec/datadog/tracing/diagnostics/environment_logger_spec.rb
@@ -45,7 +45,6 @@ RSpec.describe Datadog::Tracing::Diagnostics::EnvironmentLogger do
           'sampling_rules' => nil,
           'integrations_loaded' => nil,
           'partial_flushing_enabled' => false,
-          'priority_sampling_enabled' => false,
         )
       end
     end
@@ -140,7 +139,6 @@ RSpec.describe Datadog::Tracing::Diagnostics::EnvironmentLogger do
           sampling_rules: nil,
           integrations_loaded: nil,
           partial_flushing_enabled: false,
-          priority_sampling_enabled: false,
         )
       end
 
@@ -215,12 +213,6 @@ RSpec.describe Datadog::Tracing::Diagnostics::EnvironmentLogger do
           before { expect(Datadog.configuration.tracing.partial_flush).to receive(:enabled).and_return(true) }
 
           it { is_expected.to include partial_flushing_enabled: true }
-        end
-
-        context 'with priority sampling enabled' do
-          before { expect(Datadog.configuration.tracing).to receive(:priority_sampling).and_return(true) }
-
-          it { is_expected.to include priority_sampling_enabled: true }
         end
       end
     end


### PR DESCRIPTION
<!--
Check out the
https://github.com/DataDog/dd-trace-rb/blob/master/docs/DevelopmentGuide.md
for guidance on how to set up your development environment,
run the test suite, write new integrations, and more.
-->

**2.0 Upgrade Guide notes**

The configuration setting `c.tracing.priority_sampling` has been removed. This option was used to disable priority sampling, which was enabled by default.
To disable priority sampling, you now have to create a custom sampler.
<!--
(If this PR is for 1.x, please delete this section)
A public facing description that will go into the [upgrade guide](https://github.com/DataDog/dd-trace-rb/blob/master/docs/UpgradeGuide.md) for this change.
We already know what the PR does (from the PR title),
but users should know either:
* A migration path for this change. In other words, how to continue using their application without behavior changes
in 2.0 (e.g. environment variable 'X' renamed to 'Y').
* That there's no alternative; we completely dropped support for this feature.
-->

**Motivation:**

Priority sampling is the preferable way to store a sampling decision at Datadog.
Disabling it also disables features in the Datadog Agent and creates subpart reporting in the [Ingestion Control](https://docs.datadoghq.com/tracing/guide/ingestion_sampling_use_cases/) page.


**How to test the change?**
There are unit and integration tests for all changes.

**For Datadog employees:**
- [ ] If this PR touches code that signs or publishes builds or packages, or handles
credentials of any kind, I've requested a review from `@DataDog/security-design-and-guidance`.
- [ ] This PR doesn't touch any of that.

Unsure? Have a question? Request a review!
