### PR TITLE
Stricter validation for integer and float configuration

### DIFF
--- a/lib/datadog/core/configuration/option.rb
+++ b/lib/datadog/core/configuration/option.rb
@@ -196,7 +196,7 @@ module Datadog
 
         def coerce_env_var_int(value)
           # Strict integer parsing
-          Integer(value)
+          Integer(value, 10)
         rescue ArgumentError => e
           # Try also parsing as a whole floating point numbers
           begin

--- a/lib/datadog/core/configuration/option.rb
+++ b/lib/datadog/core/configuration/option.rb
@@ -168,11 +168,9 @@ module Datadog
               hash[pair[0]] = pair[1]
             end
           when :int
-            # DEV-2.0: Change to a more strict coercion method. Integer(value).
-            value.to_i
+            coerce_env_var_int(value)
           when :float
-            # DEV-2.0: Change to a more strict coercion method. Float(value).
-            value.to_f
+            Float(value)
           when :array
             values = value.split(',')
 
@@ -191,9 +189,31 @@ module Datadog
           when :string, NilClass
             value
           else
-            raise ArgumentError,
+            raise InvalidDefinitionError,
               "The option #{@definition.name} is using an unsupported type option for env coercion `#{@definition.type}`"
           end
+        end
+
+        def coerce_env_var_int(value)
+          # Strict integer parsing
+          Integer(value)
+        rescue ArgumentError => e
+          # Try also parsing as a whole floating point numbers
+          begin
+            f = Float(value)
+
+            # Check for whole numbers
+            raise ArgumentError, "#{value} is not a whole number" unless f.truncate == f
+
+            f
+          rescue ArgumentError
+            # It's neither an integer nor a whole float
+            raise e
+          end
+        end
+
+        # For errors caused by illegal option declarations
+        class InvalidDefinitionError < StandardError
         end
 
         def validate_type(value)
@@ -235,8 +255,10 @@ module Datadog
           case type
           when :string
             value.is_a?(String)
-          when :int, :float
-            value.is_a?(Numeric)
+          when :int
+            value.is_a?(Integer) || (value.is_a?(Float) && (value.truncate == value))
+          when :float
+            value.is_a?(Float) || value.is_a?(Integer) || value.is_a?(Rational)
           when :array
             value.is_a?(Array)
           when :hash
@@ -279,13 +301,16 @@ module Datadog
         def set_value_from_env_or_default
           value = nil
           precedence = nil
+          effective_env = nil
 
           if definition.env && ENV[definition.env]
+            effective_env = definition.env
             value = coerce_env_variable(ENV[definition.env])
             precedence = Precedence::PROGRAMMATIC
           end
 
           if value.nil? && definition.deprecated_env && ENV[definition.deprecated_env]
+            effective_env = definition.deprecated_env
             value = coerce_env_variable(ENV[definition.deprecated_env])
             precedence = Precedence::PROGRAMMATIC
 
@@ -297,6 +322,10 @@ module Datadog
           option_value = value.nil? ? default_value : value
 
           set(option_value, precedence: precedence || Precedence::DEFAULT)
+        rescue ArgumentError
+          raise ArgumentError,
+            "Expected environment variable #{effective_env} to be a #{@definition.type}, " \
+                              "but '#{ENV[effective_env]}' was provided"
         end
 
         def skip_validation?

--- a/lib/datadog/core/configuration/option.rb
+++ b/lib/datadog/core/configuration/option.rb
@@ -235,7 +235,7 @@ module Datadog
           when :int
             value.is_a?(Integer)
           when :float
-            value.is_a?(Float) || value.is_a?(Rational)
+            value.is_a?(Float) || value.is_a?(Integer) || value.is_a?(Rational)
           when :array
             value.is_a?(Array)
           when :hash

--- a/spec/datadog/appsec/contrib/support/integration/shared_examples.rb
+++ b/spec/datadog/appsec/contrib/support/integration/shared_examples.rb
@@ -123,7 +123,7 @@ end
 RSpec.shared_examples 'a trace with AppSec api security tags' do
   context 'with api security enabled' do
     let(:api_security_enabled) { true }
-    let(:api_security_sample) { 1 }
+    let(:api_security_sample) { 1.0 }
 
     it do
       api_security_tags = service_span.send(:meta).select { |key, _value| key.include?('_dd.appsec.s') }

--- a/spec/datadog/core/configuration/option_spec.rb
+++ b/spec/datadog/core/configuration/option_spec.rb
@@ -287,7 +287,7 @@ RSpec.describe Datadog::Core::Configuration::Option do
               expect { set }.not_to raise_exception
             end
 
-            context 'allow floats too' do
+            context 'that is a whole float' do
               let(:value) { 10.0 }
 
               it 'does not raise exception' do
@@ -302,6 +302,14 @@ RSpec.describe Datadog::Core::Configuration::Option do
             it 'raise exception' do
               expect { set }.to raise_exception(ArgumentError)
             end
+
+            context 'that is a decimal float' do
+              let(:value) { 10.1 }
+
+              it 'raises exception' do
+                expect { set }.to raise_exception(ArgumentError)
+              end
+            end
           end
         end
 
@@ -315,8 +323,16 @@ RSpec.describe Datadog::Core::Configuration::Option do
               expect { set }.not_to raise_exception
             end
 
-            context 'allow integers too' do
+            context 'that is an integer' do
               let(:value) { 10 }
+
+              it 'does not raise exception' do
+                expect { set }.not_to raise_exception
+              end
+            end
+
+            context 'that is a rational' do
+              let(:value) { 1/3r }
 
               it 'does not raise exception' do
                 expect { set }.not_to raise_exception
@@ -631,6 +647,27 @@ RSpec.describe Datadog::Core::Configuration::Option do
           it 'coerce value' do
             expect(option.get).to eq 1234
           end
+
+          context 'with a whole float' do
+            let(:env_value) { '10.0' }
+            it 'coerce value' do
+              expect(option.get).to eq 10
+            end
+          end
+
+          context 'with a decimal float' do
+            let(:env_value) { '10.1' }
+            it 'errors' do
+              expect { option.get }.to raise_exception(ArgumentError)
+            end
+          end
+
+          context 'with not a number' do
+            let(:env_value) { 'not a number' }
+            it 'errors' do
+              expect { option.get }.to raise_exception(ArgumentError)
+            end
+          end
         end
 
         context ':float' do
@@ -639,6 +676,13 @@ RSpec.describe Datadog::Core::Configuration::Option do
 
           it 'coerce value' do
             expect(option.get).to eq 12.34
+          end
+
+          context 'with not a number' do
+            let(:env_value) { 'not a number' }
+            it 'errors' do
+              expect { option.get }.to raise_exception(ArgumentError)
+            end
           end
         end
 
@@ -695,7 +739,7 @@ RSpec.describe Datadog::Core::Configuration::Option do
           let(:env_value) { '1' }
 
           it 'raise exception' do
-            expect { option.get }.to raise_exception(ArgumentError)
+            expect { option.get }.to raise_exception(Datadog::Core::Configuration::Option::InvalidDefinitionError)
           end
         end
       end

--- a/spec/datadog/core/configuration/option_spec.rb
+++ b/spec/datadog/core/configuration/option_spec.rb
@@ -255,26 +255,6 @@ RSpec.describe Datadog::Core::Configuration::Option do
           it 'raise exception' do
             expect { set }.to raise_exception(ArgumentError)
           end
-
-          context 'set DD_EXPERIMENTAL_SKIP_CONFIGURATION_VALIDATION' do
-            ['1', 'true'].each do |value|
-              context "with #{value}" do
-                it 'does not raise exception' do
-                  ClimateControl.modify('DD_EXPERIMENTAL_SKIP_CONFIGURATION_VALIDATION' => '1') do
-                    expect { set }.to_not raise_exception
-                  end
-                end
-              end
-            end
-
-            context 'with something else' do
-              it 'does not raise exception' do
-                ClimateControl.modify('DD_EXPERIMENTAL_SKIP_CONFIGURATION_VALIDATION' => 'esle') do
-                  expect { set }.to raise_exception(ArgumentError)
-                end
-              end
-            end
-          end
         end
 
         context 'Integer' do
@@ -286,14 +266,6 @@ RSpec.describe Datadog::Core::Configuration::Option do
             it 'does not raise exception' do
               expect { set }.not_to raise_exception
             end
-
-            context 'that is a whole float' do
-              let(:value) { 10.0 }
-
-              it 'does not raise exception' do
-                expect { set }.not_to raise_exception
-              end
-            end
           end
 
           context 'invalid value' do
@@ -303,7 +275,7 @@ RSpec.describe Datadog::Core::Configuration::Option do
               expect { set }.to raise_exception(ArgumentError)
             end
 
-            context 'that is a decimal float' do
+            context 'that is a float' do
               let(:value) { 10.1 }
 
               it 'raises exception' do
@@ -323,14 +295,6 @@ RSpec.describe Datadog::Core::Configuration::Option do
               expect { set }.not_to raise_exception
             end
 
-            context 'that is an integer' do
-              let(:value) { 10 }
-
-              it 'does not raise exception' do
-                expect { set }.not_to raise_exception
-              end
-            end
-
             context 'that is a rational' do
               let(:value) { 1/3r }
 
@@ -345,6 +309,14 @@ RSpec.describe Datadog::Core::Configuration::Option do
 
             it 'raise exception' do
               expect { set }.to raise_exception(ArgumentError)
+            end
+
+            context 'that is an integer' do
+              let(:value) { 10 }
+
+              it 'raise exception' do
+                expect { set }.to raise_exception(ArgumentError)
+              end
             end
           end
         end
@@ -655,14 +627,7 @@ RSpec.describe Datadog::Core::Configuration::Option do
             end
           end
 
-          context 'with a whole float' do
-            let(:env_value) { '10.0' }
-            it 'coerce value' do
-              expect(option.get).to eq 10
-            end
-          end
-
-          context 'with a decimal float' do
+          context 'with a float' do
             let(:env_value) { '10.1' }
             it 'errors' do
               expect { option.get }.to raise_exception(ArgumentError)

--- a/spec/datadog/core/configuration/option_spec.rb
+++ b/spec/datadog/core/configuration/option_spec.rb
@@ -648,6 +648,13 @@ RSpec.describe Datadog::Core::Configuration::Option do
             expect(option.get).to eq 1234
           end
 
+          context 'with an octal number' do
+            let(:env_value) { '010' }
+            it 'parses in base 10' do
+              expect(option.get).to eq 10
+            end
+          end
+
           context 'with a whole float' do
             let(:env_value) { '10.0' }
             it 'coerce value' do

--- a/spec/datadog/core/configuration/option_spec.rb
+++ b/spec/datadog/core/configuration/option_spec.rb
@@ -295,6 +295,14 @@ RSpec.describe Datadog::Core::Configuration::Option do
               expect { set }.not_to raise_exception
             end
 
+            context 'that is an integer' do
+              let(:value) { 10 }
+
+              it 'does not raise exception' do
+                expect { set }.not_to raise_exception
+              end
+            end
+
             context 'that is a rational' do
               let(:value) { 1/3r }
 
@@ -309,14 +317,6 @@ RSpec.describe Datadog::Core::Configuration::Option do
 
             it 'raise exception' do
               expect { set }.to raise_exception(ArgumentError)
-            end
-
-            context 'that is an integer' do
-              let(:value) { 10 }
-
-              it 'raise exception' do
-                expect { set }.to raise_exception(ArgumentError)
-              end
             end
           end
         end

--- a/spec/datadog/core/configuration/settings_spec.rb
+++ b/spec/datadog/core/configuration/settings_spec.rb
@@ -586,12 +586,10 @@ RSpec.describe Datadog::Core::Configuration::Settings do
             it { is_expected.to be 50 }
           end
 
-          [100, 30.5].each do |value|
-            context "is defined as #{value}" do
-              let(:environment) { value.to_s }
+          context 'is defined as 100' do
+            let(:environment) { '100' }
 
-              it { is_expected.to be value.to_i }
-            end
+            it { is_expected.to eq(100) }
           end
         end
       end
@@ -621,12 +619,10 @@ RSpec.describe Datadog::Core::Configuration::Settings do
             it { is_expected.to be 10 }
           end
 
-          [100, 30.5].each do |value|
-            context "is defined as #{value}" do
-              let(:environment) { value.to_s }
+          context 'is defined as 100' do
+            let(:environment) { '100' }
 
-              it { is_expected.to be value.to_i }
-            end
+            it { is_expected.to eq(100) }
           end
         end
       end

--- a/spec/datadog/tracing/configuration/settings_spec.rb
+++ b/spec/datadog/tracing/configuration/settings_spec.rb
@@ -464,12 +464,12 @@ RSpec.describe Datadog::Tracing::Configuration::Settings do
 
         context 'when ENV is provided' do
           around do |example|
-            ClimateControl.modify(Datadog::Tracing::Configuration::Ext::Sampling::ENV_RATE_LIMIT => '20.0') do
+            ClimateControl.modify(Datadog::Tracing::Configuration::Ext::Sampling::ENV_RATE_LIMIT => '20') do
               example.run
             end
           end
 
-          it { is_expected.to eq(20.0) }
+          it { is_expected.to eq(20) }
         end
       end
 

--- a/spec/datadog/tracing/contrib/shared_settings_examples.rb
+++ b/spec/datadog/tracing/contrib/shared_settings_examples.rb
@@ -15,16 +15,6 @@ RSpec.shared_examples_for 'with on_error setting' do
     subject { described_class.new(on_error: 1) }
 
     it { expect { subject }.to raise_error(ArgumentError) }
-
-    context 'when skip configuration validation' do
-      around do |example|
-        ClimateControl.modify('DD_EXPERIMENTAL_SKIP_CONFIGURATION_VALIDATION' => 'true') do
-          example.run
-        end
-      end
-
-      it { expect { subject }.not_to raise_error }
-    end
   end
 end
 


### PR DESCRIPTION
<!--
Check out the
https://github.com/DataDog/dd-trace-rb/blob/master/docs/DevelopmentGuide.md
for guidance on how to set up your development environment,
run the test suite, write new integrations, and more.
-->

**2.0 Upgrade Guide notes**
Configuration options of types ':int' and ':float' now have stricter type validation:
* Fractional numbers are no longer considered valid for ':int' options.
* Empty values (nil or empty string) are no longer considered valid for ':int' or ':float' options.

This applies to both environment variable and programmatic configuration.
Here's the list of all affected options:
[Insert all :int and :float options at release time!!!]

The environment variable `DD_EXPERIMENTAL_SKIP_CONFIGURATION_VALIDATION` has been removed.

<!--
(If this PR is for 1.x, please delete this section)
A public facing description that will go into the [upgrade guide](https://github.com/DataDog/dd-trace-rb/blob/master/docs/UpgradeGuide.md) for this change.
We already know what the PR does (from the PR title),
but users should know either:
* A migration path for this change. In other words, how to continue using their application without behavior changes
in 2.0 (e.g. environment variable 'X' renamed to 'Y').
* That there's no alternative; we completely dropped support for this feature.
-->

**Motivation:**
It was possible to configure options with empty values (e.g. `DD_TRACE_SAMPLE_RATE=`) and end up with a sampling rate of `0.0`, because of the logic `value.to_f`. The same applies to integer options (`value.to_i`).
Non-numeric values would also be converted to zero.
This means users do not know what their effective configuration will be, and are not given feedback on how to address configuration issues.


**How to test the change?**
There are unit tests for all the changes.

**For Datadog employees:**
- [ ] If this PR touches code that signs or publishes builds or packages, or handles
credentials of any kind, I've requested a review from `@DataDog/security-design-and-guidance`.
- [x] This PR doesn't touch any of that.

Unsure? Have a question? Request a review!
