### PR TITLE
Include forked tests in coverage report

### DIFF
--- a/spec/datadog/profiling/ext/forking_spec.rb
+++ b/spec/datadog/profiling/ext/forking_spec.rb
@@ -38,9 +38,9 @@ RSpec.describe Datadog::Profiling::Ext::Forking do
         # Can't assert this because top level can't be reverted; can't guarantee pristine state.
         # expect(toplevel_receiver.class.ancestors.include?(described_class::Kernel)).to be false
 
-        expect(::Process.method(:fork).source_location).to be nil
-        expect(::Kernel.method(:fork).source_location).to be nil
-        expect(::Process.method(:daemon).source_location).to be nil
+        expect(::Process.method(:fork).source_location&.first).to_not match(%r{.*datadog/profiling/ext/forking.rb})
+        expect(::Kernel.method(:fork).source_location&.first).to_not match(%r{.*datadog/profiling/ext/forking.rb})
+        expect(::Process.method(:daemon).source_location&.first).to_not match(%r{.*datadog/profiling/ext/forking.rb})
         # Can't assert this because top level can't be reverted; can't guarantee pristine state.
         # expect(toplevel_receiver.method(:fork).source_location).to be nil
       end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -17,6 +17,7 @@ if (ENV['SKIP_SIMPLECOV'] != '1') && !RSpec.configuration.files_to_run.all? { |p
   require 'simplecov'
   SimpleCov.start do
     formatter SimpleCov::Formatter::SimpleFormatter
+    enable_for_subprocesses true # Ensure tests that fork count towards code coverage
   end
 end
 


### PR DESCRIPTION
(I'm trying to see if code coverage for Sidekiq fork tests like https://app.codecov.io/gh/DataDog/dd-trace-rb/blob/master/spec%2Fdatadog%2Ftracing%2Fcontrib%2Fsidekiq%2Fserver_internal_tracer%2Fjob_fetch_spec.rb#L26 start being collected)