### PR TITLE
Consistent option naming for health metrics

### DIFF
--- a/lib/datadog/core/configuration/components.rb
+++ b/lib/datadog/core/configuration/components.rb
@@ -21,7 +21,7 @@ module Datadog
           include Datadog::Tracing::Component
 
           def build_health_metrics(settings)
-            settings = settings.diagnostics.health_metrics
+            settings = settings.health_metrics
             options = { enabled: settings.enabled }
             options[:statsd] = settings.statsd unless settings.statsd.nil?
 

--- a/lib/datadog/core/configuration/settings.rb
+++ b/lib/datadog/core/configuration/settings.rb
@@ -109,29 +109,6 @@ module Datadog
               require 'pp' if enabled
             end
           end
-          # Internal {Datadog::Statsd} metrics collection.
-          #
-          # @public_api
-          settings :health_metrics do
-            # Enable health metrics collection.
-            #
-            # @default `DD_HEALTH_METRICS_ENABLED` environment variable, otherwise `false`
-            # @return [Boolean]
-            option :enabled do |o|
-              o.env Datadog::Core::Configuration::Ext::Diagnostics::ENV_HEALTH_METRICS_ENABLED
-              o.default false
-              o.type :bool
-            end
-
-            # {Datadog::Statsd} instance to collect health metrics.
-            #
-            # If `nil`, health metrics creates a new {Datadog::Statsd} client with default agent configuration.
-            #
-            # @default `nil`
-            # @return [Datadog::Statsd,nil] a custom {Datadog::Statsd} instance
-            # @return [nil] an instance with default agent configuration will be lazily created
-            option :statsd
-          end
 
           # Tracer startup debug log statement configuration.
           # @public_api
@@ -159,6 +136,30 @@ module Datadog
           o.type :string, nilable: true
           # NOTE: env also gets set as a side effect of tags. See the WORKAROUND note in #initialize for details.
           o.env Core::Environment::Ext::ENV_ENVIRONMENT
+        end
+
+        # Internal {Datadog::Statsd} metrics collection.
+        #
+        # @public_api
+        settings :health_metrics do
+          # Enable health metrics collection.
+          #
+          # @default `DD_HEALTH_METRICS_ENABLED` environment variable, otherwise `false`
+          # @return [Boolean]
+          option :enabled do |o|
+            o.env Datadog::Core::Configuration::Ext::Diagnostics::ENV_HEALTH_METRICS_ENABLED
+            o.default false
+            o.type :bool
+          end
+
+          # {Datadog::Statsd} instance to collect health metrics.
+          #
+          # If `nil`, health metrics creates a new {Datadog::Statsd} client with default agent configuration.
+          #
+          # @default `nil`
+          # @return [Datadog::Statsd,nil] a custom {Datadog::Statsd} instance
+          # @return [nil] an instance with default agent configuration will be lazily created
+          option :statsd
         end
 
         # Internal `Datadog.logger` configuration.

--- a/lib/datadog/core/diagnostics/environment_logger.rb
+++ b/lib/datadog/core/diagnostics/environment_logger.rb
@@ -166,7 +166,7 @@ module Datadog
 
           # @return [Boolean, nil] health metrics enabled in configuration
           def health_metrics_enabled
-            !!Datadog.configuration.diagnostics.health_metrics.enabled
+            !!Datadog.configuration.health_metrics.enabled
           end
 
           private

--- a/spec/datadog/core/configuration/components_spec.rb
+++ b/spec/datadog/core/configuration/components_spec.rb
@@ -96,7 +96,7 @@ RSpec.describe Datadog::Core::Configuration::Components do
     context 'given settings' do
       shared_examples_for 'new health metrics' do
         let(:health_metrics) { instance_double(Datadog::Core::Diagnostics::Health::Metrics) }
-        let(:default_options) { { enabled: settings.diagnostics.health_metrics.enabled } }
+        let(:default_options) { { enabled: settings.health_metrics.enabled } }
         let(:options) { {} }
 
         before do
@@ -116,7 +116,7 @@ RSpec.describe Datadog::Core::Configuration::Components do
         let(:enabled) { double('enabled') }
 
         before do
-          allow(settings.diagnostics.health_metrics)
+          allow(settings.health_metrics)
             .to receive(:enabled)
             .and_return(enabled)
         end
@@ -130,7 +130,7 @@ RSpec.describe Datadog::Core::Configuration::Components do
         let(:statsd) { instance_double(Datadog::Statsd) }
 
         before do
-          allow(settings.diagnostics.health_metrics)
+          allow(settings.health_metrics)
             .to receive(:statsd)
             .and_return(statsd)
         end

--- a/spec/datadog/core/configuration/settings_spec.rb
+++ b/spec/datadog/core/configuration/settings_spec.rb
@@ -112,60 +112,6 @@ RSpec.describe Datadog::Core::Configuration::Settings do
         end
       end
     end
-
-    describe '#health_metrics' do
-      describe '#enabled' do
-        subject(:enabled) { settings.diagnostics.health_metrics.enabled }
-
-        context "when #{Datadog::Core::Configuration::Ext::Diagnostics::ENV_HEALTH_METRICS_ENABLED}" do
-          around do |example|
-            ClimateControl.modify(
-              Datadog::Core::Configuration::Ext::Diagnostics::ENV_HEALTH_METRICS_ENABLED => environment
-            ) do
-              example.run
-            end
-          end
-
-          context 'is not defined' do
-            let(:environment) { nil }
-
-            it { is_expected.to be false }
-          end
-
-          context 'is defined' do
-            let(:environment) { 'true' }
-
-            it { is_expected.to be true }
-          end
-        end
-      end
-
-      describe '#enabled=' do
-        it 'changes the #enabled setting' do
-          expect { settings.diagnostics.health_metrics.enabled = true }
-            .to change { settings.diagnostics.health_metrics.enabled }
-            .from(false)
-            .to(true)
-        end
-      end
-
-      describe '#statsd' do
-        subject(:statsd) { settings.diagnostics.health_metrics.statsd }
-
-        it { is_expected.to be nil }
-      end
-
-      describe '#statsd=' do
-        let(:statsd) { double('statsd') }
-
-        it 'changes the #statsd setting' do
-          expect { settings.diagnostics.health_metrics.statsd = statsd }
-            .to change { settings.diagnostics.health_metrics.statsd }
-            .from(nil)
-            .to(statsd)
-        end
-      end
-    end
   end
 
   describe '#env' do
@@ -233,6 +179,60 @@ RSpec.describe Datadog::Core::Configuration::Settings do
       before { set_env }
 
       it { expect(settings.env).to be_nil }
+    end
+  end
+
+  describe '#health_metrics' do
+    describe '#enabled' do
+      subject(:enabled) { settings.health_metrics.enabled }
+
+      context "when #{Datadog::Core::Configuration::Ext::Diagnostics::ENV_HEALTH_METRICS_ENABLED}" do
+        around do |example|
+          ClimateControl.modify(
+            Datadog::Core::Configuration::Ext::Diagnostics::ENV_HEALTH_METRICS_ENABLED => environment
+          ) do
+            example.run
+          end
+        end
+
+        context 'is not defined' do
+          let(:environment) { nil }
+
+          it { is_expected.to be false }
+        end
+
+        context 'is defined' do
+          let(:environment) { 'true' }
+
+          it { is_expected.to be true }
+        end
+      end
+    end
+
+    describe '#enabled=' do
+      it 'changes the #enabled setting' do
+        expect { settings.health_metrics.enabled = true }
+          .to change { settings.health_metrics.enabled }
+          .from(false)
+          .to(true)
+      end
+    end
+
+    describe '#statsd' do
+      subject(:statsd) { settings.health_metrics.statsd }
+
+      it { is_expected.to be nil }
+    end
+
+    describe '#statsd=' do
+      let(:statsd) { double('statsd') }
+
+      it 'changes the #statsd setting' do
+        expect { settings.health_metrics.statsd = statsd }
+          .to change { settings.health_metrics.statsd }
+          .from(nil)
+          .to(statsd)
+      end
     end
   end
 

--- a/spec/datadog/core/configuration_spec.rb
+++ b/spec/datadog/core/configuration_spec.rb
@@ -187,12 +187,12 @@ RSpec.describe Datadog::Core::Configuration do
 
             test_class.configure do |c|
               c.runtime_metrics.statsd = old_statsd
-              c.diagnostics.health_metrics.statsd = old_statsd
+              c.health_metrics.statsd = old_statsd
             end
 
             test_class.configure do |c|
               c.runtime_metrics.statsd = new_statsd
-              c.diagnostics.health_metrics.statsd = new_statsd
+              c.health_metrics.statsd = new_statsd
             end
           end
 
@@ -212,7 +212,7 @@ RSpec.describe Datadog::Core::Configuration do
 
             test_class.configure do |c|
               c.runtime_metrics.statsd = old_statsd
-              c.diagnostics.health_metrics.statsd = old_statsd
+              c.health_metrics.statsd = old_statsd
             end
 
             test_class.configure do |c|
@@ -234,12 +234,12 @@ RSpec.describe Datadog::Core::Configuration do
 
             test_class.configure do |c|
               c.runtime_metrics.statsd = statsd
-              c.diagnostics.health_metrics.statsd = statsd
+              c.health_metrics.statsd = statsd
             end
 
             test_class.configure do |c|
               c.runtime_metrics.statsd = statsd
-              c.diagnostics.health_metrics.statsd = statsd
+              c.health_metrics.statsd = statsd
             end
           end
 
@@ -256,7 +256,7 @@ RSpec.describe Datadog::Core::Configuration do
 
             test_class.configure do |c|
               c.runtime_metrics.statsd = statsd
-              c.diagnostics.health_metrics.statsd = statsd
+              c.health_metrics.statsd = statsd
             end
 
             test_class.configure { |_c| }

--- a/spec/datadog/core/diagnostics/environment_logger_spec.rb
+++ b/spec/datadog/core/diagnostics/environment_logger_spec.rb
@@ -194,7 +194,7 @@ RSpec.describe Datadog::Core::Diagnostics::EnvironmentLogger do
       end
 
       context 'with health metrics enabled' do
-        before { expect(Datadog.configuration.diagnostics.health_metrics).to receive(:enabled).and_return(true) }
+        before { expect(Datadog.configuration.health_metrics).to receive(:enabled).and_return(true) }
 
         it { is_expected.to include health_metrics_enabled: true }
       end

--- a/spec/datadog/integration_spec.rb
+++ b/spec/datadog/integration_spec.rb
@@ -86,14 +86,14 @@ RSpec.describe 'Datadog integration' do
 
     before do
       Datadog.configure do |c|
-        c.diagnostics.health_metrics.enabled = true
+        c.health_metrics.enabled = true
       end
 
       shutdown!
     end
 
     after do
-      Datadog.configuration.diagnostics.health_metrics.reset!
+      Datadog.configuration.health_metrics.reset!
       Datadog.shutdown!
     end
 


### PR DESCRIPTION
<!--
Check out the
https://github.com/DataDog/dd-trace-rb/blob/master/docs/DevelopmentGuide.md
for guidance on how to set up your development environment,
run the test suite, write new integrations, and more.
-->

**2.0 Upgrade Guide notes**


Programmatic configuration options have been made more consistent with their respective environment variables:

| Previous | New | Environment Variable (unchanged) |
|-|-|-|
| `diagnostics.health_metrics.enabled` | `health_metrics.enabled` | `DD_HEALTH_METRICS_ENABLED` |
| `diagnostics.health_metrics.statsd` | `health_metrics.statsd` | (none) |

<!--
(If this PR is for 1.x, please delete this section)
A public facing description that will go into the [upgrade guide](https://github.com/DataDog/dd-trace-rb/blob/master/docs/UpgradeGuide.md) for this change.
We already know what the PR does (from the PR title),
but users should know either:
* A migration path for this change. In other words, how to continue using their application without behavior changes
in 2.0 (e.g. environment variable 'X' renamed to 'Y').
* That there's no alternative; we completely dropped support for this feature.
-->

**What does this PR do?**
<!-- A brief description of the change being made with this pull request. -->

**Motivation:**

Environment variable naming is standard across all Datadog languages.
Our programmatic configuration API is an extra avenue for configuration for Ruby clients, and reflects the same options as the ones provided by environment variables.
The naming between the programmatic variant and the environment variable variant of the same option should be as close as possible.

**Additional Notes:**
<!-- Anything else we should know when reviewing? -->

**How to test the change?**
<!--
Describe here how the change can be validated.
You are strongly encouraged to provide automated tests for this PR (unit or integration).
If this change cannot be feasibly tested, please explain why,
unless the change does not modify code (e.g. only modifies docs, comments).
-->

**For Datadog employees:**
- [ ] If this PR touches code that signs or publishes builds or packages, or handles
credentials of any kind, I've requested a review from `@DataDog/security-design-and-guidance`.
- [ ] This PR doesn't touch any of that.

Unsure? Have a question? Request a review!
