### PR TITLE
Fix  `error_status_codes` options

### DIFF
--- a/lib/datadog/tracing/contrib/faraday/configuration/settings.rb
+++ b/lib/datadog/tracing/contrib/faraday/configuration/settings.rb
@@ -1,6 +1,8 @@
 # frozen_string_literal: true
 
 require_relative '../../configuration/settings'
+require_relative '../../status_range_matcher'
+require_relative '../../status_range_env_parser'
 require_relative '../ext'
 
 module Datadog
@@ -42,20 +44,11 @@ module Datadog
             option :error_status_codes do |o|
               o.env Ext::ENV_ERROR_STATUS_CODES
               o.default 400...600
-              o.env_parser do |value|
-                values = if value.include?(',')
-                           value.split(',')
-                         else
-                           value.split
-                         end
-                values.map! do |v|
-                  v.gsub!(/\A[\s,]*|[\s,]*\Z/, '')
-
-                  v.empty? ? nil : v
-                end
-
-                values.compact!
-                values
+              o.setter do |v|
+                Tracing::Contrib::StatusRangeMatcher.new(v) if v
+              end
+              o.env_parser do |v|
+                Tracing::Contrib::StatusRangeEnvParser.call(v) if v
               end
             end
 

--- a/lib/datadog/tracing/contrib/http/configuration/settings.rb
+++ b/lib/datadog/tracing/contrib/http/configuration/settings.rb
@@ -1,6 +1,8 @@
 # frozen_string_literal: true
 
 require_relative '../../configuration/settings'
+require_relative '../../status_range_matcher'
+require_relative '../../status_range_env_parser'
 require_relative '../ext'
 
 module Datadog
@@ -43,20 +45,11 @@ module Datadog
             option :error_status_codes do |o|
               o.env Ext::ENV_ERROR_STATUS_CODES
               o.default 400...600
-              o.env_parser do |value|
-                values = if value.include?(',')
-                           value.split(',')
-                         else
-                           value.split
-                         end
-                values.map! do |v|
-                  v.gsub!(/\A[\s,]*|[\s,]*\Z/, '')
-
-                  v.empty? ? nil : v
-                end
-
-                values.compact!
-                values
+              o.setter do |v|
+                Tracing::Contrib::StatusRangeMatcher.new(v) if v
+              end
+              o.env_parser do |v|
+                Tracing::Contrib::StatusRangeEnvParser.call(v) if v
               end
             end
 

--- a/lib/datadog/tracing/contrib/httpclient/configuration/settings.rb
+++ b/lib/datadog/tracing/contrib/httpclient/configuration/settings.rb
@@ -1,6 +1,8 @@
 # frozen_string_literal: true
 
 require_relative '../../configuration/settings'
+require_relative '../../status_range_matcher'
+require_relative '../../status_range_env_parser'
 require_relative '../ext'
 
 module Datadog
@@ -43,20 +45,11 @@ module Datadog
             option :error_status_codes do |o|
               o.env Ext::ENV_ERROR_STATUS_CODES
               o.default 400...600
-              o.env_parser do |value|
-                values = if value.include?(',')
-                           value.split(',')
-                         else
-                           value.split
-                         end
-                values.map! do |v|
-                  v.gsub!(/\A[\s,]*|[\s,]*\Z/, '')
-
-                  v.empty? ? nil : v
-                end
-
-                values.compact!
-                values
+              o.setter do |v|
+                Tracing::Contrib::StatusRangeMatcher.new(v) if v
+              end
+              o.env_parser do |v|
+                Tracing::Contrib::StatusRangeEnvParser.call(v) if v
               end
             end
 

--- a/lib/datadog/tracing/contrib/httprb/configuration/settings.rb
+++ b/lib/datadog/tracing/contrib/httprb/configuration/settings.rb
@@ -1,6 +1,8 @@
 # frozen_string_literal: true
 
 require_relative '../../configuration/settings'
+require_relative '../../status_range_matcher'
+require_relative '../../status_range_env_parser'
 require_relative '../ext'
 
 module Datadog
@@ -43,20 +45,11 @@ module Datadog
             option :error_status_codes do |o|
               o.env Ext::ENV_ERROR_STATUS_CODES
               o.default 400...600
-              o.env_parser do |value|
-                values = if value.include?(',')
-                           value.split(',')
-                         else
-                           value.split
-                         end
-                values.map! do |v|
-                  v.gsub!(/\A[\s,]*|[\s,]*\Z/, '')
-
-                  v.empty? ? nil : v
-                end
-
-                values.compact!
-                values
+              o.setter do |v|
+                Tracing::Contrib::StatusRangeMatcher.new(v) if v
+              end
+              o.env_parser do |v|
+                Tracing::Contrib::StatusRangeEnvParser.call(v) if v
               end
             end
 

--- a/lib/datadog/tracing/contrib/status_range_env_parser.rb
+++ b/lib/datadog/tracing/contrib/status_range_env_parser.rb
@@ -1,0 +1,33 @@
+# frozen_string_literal: true
+
+module Datadog
+  module Tracing
+    module Contrib
+      # Parsing status range from environment variable
+      class StatusRangeEnvParser
+        class << self
+          def call(value)
+            [].tap do |array|
+              value.split(',').each do |e|
+                next unless e
+
+                v = e.split('-')
+
+                case v.length
+                when 0 then next
+                when 1 then array << Integer(v.first)
+                when 2 then array << (Integer(v.first)..Integer(v.last))
+                else
+                  Datadog.logger.debug(
+                    "Invalid error_status_codes configuration: Unable to parse #{value}, containing #{v}."
+                  )
+                  next
+                end
+              end
+            end
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/datadog/tracing/contrib/status_range_matcher.rb
+++ b/lib/datadog/tracing/contrib/status_range_matcher.rb
@@ -1,0 +1,25 @@
+# frozen_string_literal: true
+
+module Datadog
+  module Tracing
+    module Contrib
+      # Useful checking whether the defined range covers status code
+      class StatusRangeMatcher
+        def initialize(ranges)
+          @ranges = Array(ranges)
+        end
+
+        def include?(status)
+          @ranges.any? do |e|
+            case e
+            when Range
+              e.include? status
+            when Integer
+              e == status
+            end
+          end
+        end
+      end
+    end
+  end
+end

--- a/spec/datadog/tracing/contrib/excon/instrumentation_spec.rb
+++ b/spec/datadog/tracing/contrib/excon/instrumentation_spec.rb
@@ -187,6 +187,20 @@ RSpec.describe Datadog::Tracing::Contrib::Excon::Middleware do
         expect(request_span).not_to have_error
       end
     end
+
+    context 'when configured from env' do
+      around do |example|
+        ClimateControl.modify('DD_TRACE_EXCON_ERROR_STATUS_CODES' => '500-600') do
+          example.run
+        end
+      end
+
+      it do
+        connection.get(path: '/not_found')
+
+        expect(span).not_to have_error
+      end
+    end
   end
 
   context 'when the request times out' do

--- a/spec/datadog/tracing/contrib/faraday/middleware_spec.rb
+++ b/spec/datadog/tracing/contrib/faraday/middleware_spec.rb
@@ -320,6 +320,20 @@ RSpec.describe 'Faraday middleware' do
         expect(span).not_to have_error
       end
     end
+
+    context 'when configured from env' do
+      around do |example|
+        ClimateControl.modify('DD_TRACE_FARADAY_ERROR_STATUS_CODES' => '500-600') do
+          example.run
+        end
+      end
+
+      it do
+        client.get('not_found')
+
+        expect(span).not_to have_error
+      end
+    end
   end
 
   context 'when split by domain' do

--- a/spec/datadog/tracing/contrib/http/request_spec.rb
+++ b/spec/datadog/tracing/contrib/http/request_spec.rb
@@ -43,7 +43,7 @@ RSpec.describe 'net/http requests' do
     subject(:response) { client.get(path) }
     before { stub_request(:any, "#{uri}#{path}").to_return(status: status_code, body: '{}') }
 
-    include_examples 'with error status code configuration'
+    include_examples 'with error status code configuration', env: 'DD_TRACE_HTTP_ERROR_STATUS_CODES'
   end
 
   describe '#get' do

--- a/spec/datadog/tracing/contrib/http_examples.rb
+++ b/spec/datadog/tracing/contrib/http_examples.rb
@@ -1,9 +1,33 @@
-RSpec.shared_examples 'with error status code configuration' do
+RSpec.shared_examples 'with error status code configuration' do |env:|
   before { subject }
 
   context 'with a custom range' do
     context 'with an Range object' do
       let(:configuration_options) { { error_status_codes: 500..502 } }
+
+      context 'with a status code within the range' do
+        let(:status_code) { 501 }
+
+        it 'marks the span as an error' do
+          expect(span).to have_error
+        end
+      end
+
+      context 'with a status code outside of the range' do
+        let(:status_code) { 503 }
+
+        it 'does not mark the span as an error' do
+          expect(span).to_not have_error
+        end
+      end
+    end
+
+    context 'when custom range from env' do
+      around do |example|
+        ClimateControl.modify(env => '500-502') do
+          example.run
+        end
+      end
 
       context 'with a status code within the range' do
         let(:status_code) { 501 }

--- a/spec/datadog/tracing/contrib/httpclient/instrumentation_spec.rb
+++ b/spec/datadog/tracing/contrib/httpclient/instrumentation_spec.rb
@@ -319,7 +319,7 @@ RSpec.describe Datadog::Tracing::Contrib::Httpclient::Instrumentation do
       let(:code) { status_code }
       before { response }
 
-      include_examples 'with error status code configuration'
+      include_examples 'with error status code configuration', env: 'DD_TRACE_HTTPCLIENT_ERROR_STATUS_CODES'
     end
 
     it_behaves_like 'instrumented request'

--- a/spec/datadog/tracing/contrib/httprb/instrumentation_spec.rb
+++ b/spec/datadog/tracing/contrib/httprb/instrumentation_spec.rb
@@ -322,7 +322,7 @@ RSpec.describe Datadog::Tracing::Contrib::Httprb::Instrumentation do
       let(:code) { status_code }
       before { response }
 
-      include_examples 'with error status code configuration'
+      include_examples 'with error status code configuration', env: 'DD_TRACE_HTTPRB_ERROR_STATUS_CODES'
     end
 
     it_behaves_like 'instrumented request'

--- a/spec/datadog/tracing/contrib/shared_settings_examples.rb
+++ b/spec/datadog/tracing/contrib/shared_settings_examples.rb
@@ -79,6 +79,7 @@ RSpec.shared_examples_for 'with error_status_codes setting' do |env:|
       it { expect(subject.error_status_codes).to include 599 }
       it { expect(subject.error_status_codes).to include 600 }
     end
+  end
 
   context 'when configured with environment variable' do
     subject { described_class.new }

--- a/spec/datadog/tracing/contrib/shared_settings_examples.rb
+++ b/spec/datadog/tracing/contrib/shared_settings_examples.rb
@@ -39,6 +39,47 @@ RSpec.shared_examples_for 'with error_status_codes setting' do |env:|
     it { expect(subject.error_status_codes).not_to include 600 }
   end
 
+  context 'when given error_status_codes' do
+    context 'when given a single value' do
+      subject { described_class.new(error_status_codes: 500) }
+
+      it { expect(subject.error_status_codes).not_to include 400 }
+      it { expect(subject.error_status_codes).not_to include 499 }
+      it { expect(subject.error_status_codes).to include 500 }
+      it { expect(subject.error_status_codes).not_to include 599 }
+      it { expect(subject.error_status_codes).not_to include 600 }
+    end
+
+    context 'when given an array of integers' do
+      subject { described_class.new(error_status_codes: [400, 500]) }
+
+      it { expect(subject.error_status_codes).to include 400 }
+      it { expect(subject.error_status_codes).not_to include 499 }
+      it { expect(subject.error_status_codes).to include 500 }
+      it { expect(subject.error_status_codes).not_to include 599 }
+      it { expect(subject.error_status_codes).not_to include 600 }
+    end
+
+    context 'when given a range' do
+      subject { described_class.new(error_status_codes: 500..600) }
+
+      it { expect(subject.error_status_codes).not_to include 400 }
+      it { expect(subject.error_status_codes).not_to include 499 }
+      it { expect(subject.error_status_codes).to include 500 }
+      it { expect(subject.error_status_codes).to include 599 }
+      it { expect(subject.error_status_codes).to include 600 }
+    end
+
+    context 'when given an array of integer and range' do
+      subject { described_class.new(error_status_codes: [400, 500..600]) }
+
+      it { expect(subject.error_status_codes).to include 400 }
+      it { expect(subject.error_status_codes).not_to include 499 }
+      it { expect(subject.error_status_codes).to include 500 }
+      it { expect(subject.error_status_codes).to include 599 }
+      it { expect(subject.error_status_codes).to include 600 }
+    end
+
   context 'when configured with environment variable' do
     subject { described_class.new }
 
@@ -82,6 +123,20 @@ RSpec.shared_examples_for 'with error_status_codes setting' do |env:|
       it { expect(subject.error_status_codes).to include 500 }
       it { expect(subject.error_status_codes).not_to include 599 }
       it { expect(subject.error_status_codes).not_to include 600 }
+    end
+
+    context 'when given a comma separated list with range' do
+      around do |example|
+        ClimateControl.modify(env => '400,500-600') do
+          example.run
+        end
+      end
+
+      it { expect(subject.error_status_codes).to include 400 }
+      it { expect(subject.error_status_codes).not_to include 499 }
+      it { expect(subject.error_status_codes).to include 500 }
+      it { expect(subject.error_status_codes).to include 599 }
+      it { expect(subject.error_status_codes).to include 600 }
     end
   end
 end

--- a/spec/datadog/tracing/contrib/shared_settings_examples.rb
+++ b/spec/datadog/tracing/contrib/shared_settings_examples.rb
@@ -32,7 +32,11 @@ RSpec.shared_examples_for 'with error_status_codes setting' do |env:|
   context 'default without settings' do
     subject { described_class.new }
 
-    it { expect(subject.error_status_codes).to eq(400...600) }
+    it { expect(subject.error_status_codes).to include 400 }
+    it { expect(subject.error_status_codes).to include 499 }
+    it { expect(subject.error_status_codes).to include 500 }
+    it { expect(subject.error_status_codes).to include 599 }
+    it { expect(subject.error_status_codes).not_to include 600 }
   end
 
   context 'when configured with environment variable' do
@@ -45,7 +49,11 @@ RSpec.shared_examples_for 'with error_status_codes setting' do |env:|
         end
       end
 
-      it { expect(subject.error_status_codes).to eq(['500']) }
+      it { expect(subject.error_status_codes).not_to include 400 }
+      it { expect(subject.error_status_codes).not_to include 499 }
+      it { expect(subject.error_status_codes).to include 500 }
+      it { expect(subject.error_status_codes).not_to include 599 }
+      it { expect(subject.error_status_codes).not_to include 600 }
     end
 
     context 'when given a comma separated list' do
@@ -55,7 +63,11 @@ RSpec.shared_examples_for 'with error_status_codes setting' do |env:|
         end
       end
 
-      it { expect(subject.error_status_codes).to eq(['400', '500']) }
+      it { expect(subject.error_status_codes).to include 400 }
+      it { expect(subject.error_status_codes).not_to include 499 }
+      it { expect(subject.error_status_codes).to include 500 }
+      it { expect(subject.error_status_codes).not_to include 599 }
+      it { expect(subject.error_status_codes).not_to include 600 }
     end
 
     context 'when given a comma separated list with space' do
@@ -65,7 +77,11 @@ RSpec.shared_examples_for 'with error_status_codes setting' do |env:|
         end
       end
 
-      it { expect(subject.error_status_codes).to eq(['400', '500']) }
+      it { expect(subject.error_status_codes).to include 400 }
+      it { expect(subject.error_status_codes).not_to include 499 }
+      it { expect(subject.error_status_codes).to include 500 }
+      it { expect(subject.error_status_codes).not_to include 599 }
+      it { expect(subject.error_status_codes).not_to include 600 }
     end
   end
 end

--- a/spec/datadog/tracing/contrib/status_code_matcher_spec.rb
+++ b/spec/datadog/tracing/contrib/status_code_matcher_spec.rb
@@ -1,0 +1,40 @@
+require 'datadog/tracing/contrib/status_code_matcher'
+
+RSpec.describe Datadog::Tracing::Contrib::StatusCodeMatcher do
+  describe '#include?' do
+    context 'when given a string to parse' do
+      it do
+        matcher = described_class.new('400')
+
+        expect(matcher).to include 400
+      end
+
+      it do
+        matcher = described_class.new('400,500')
+
+        expect(matcher).to include 400
+        expect(matcher).not_to include 499
+        expect(matcher).to include 500
+        expect(matcher).not_to include 599
+      end
+
+      it do
+        matcher = described_class.new('400-500')
+
+        expect(matcher).to include 400
+        expect(matcher).to include 499
+        expect(matcher).to include 500
+        expect(matcher).not_to include 599
+      end
+
+      it do
+        matcher = described_class.new('400-404,500')
+
+        expect(matcher).to include 400
+        expect(matcher).not_to include 499
+        expect(matcher).to include 500
+        expect(matcher).not_to include 599
+      end
+    end
+  end
+end

--- a/spec/datadog/tracing/contrib/status_range_env_parser_spec.rb
+++ b/spec/datadog/tracing/contrib/status_range_env_parser_spec.rb
@@ -1,0 +1,18 @@
+require 'datadog/tracing/contrib/status_range_env_parser'
+
+RSpec.describe Datadog::Tracing::Contrib::StatusRangeEnvParser do
+  describe '.call' do
+    [
+      ['400', [400]],
+      ['400,500', [400, 500]],
+      ['400,,500', [400, 500]],
+      [',400,500', [400, 500]],
+      ['400,500,', [400, 500]],
+      ['400-404,500', [400..404, 500]],
+      ['400-404,500-504', [400..404, 500..504]],
+      ['400-404,444,500-504', [400..404, 444, 500..504]],
+    ].each do |input, result|
+      it { expect(described_class.call(input)).to eq(result) }
+    end
+  end
+end

--- a/spec/datadog/tracing/contrib/status_range_matcher_spec.rb
+++ b/spec/datadog/tracing/contrib/status_range_matcher_spec.rb
@@ -1,0 +1,58 @@
+require 'datadog/tracing/contrib/status_range_matcher'
+
+RSpec.describe Datadog::Tracing::Contrib::StatusRangeMatcher do
+  describe '#include?' do
+    it do
+      matcher = described_class.new(400)
+
+      expect(matcher).to include 400
+      expect(matcher).not_to include 401
+      expect(matcher).not_to include 499
+      expect(matcher).not_to include 500
+      expect(matcher).not_to include 501
+      expect(matcher).not_to include 599
+    end
+
+    it do
+      matcher = described_class.new(400..500)
+
+      expect(matcher).to include 400
+      expect(matcher).to include 401
+      expect(matcher).to include 499
+      expect(matcher).to include 500
+      expect(matcher).not_to include 501
+      expect(matcher).not_to include 599
+    end
+
+    it do
+      matcher = described_class.new([400..500])
+
+      expect(matcher).to include 400
+      expect(matcher).to include 401
+      expect(matcher).to include 499
+      expect(matcher).to include 500
+      expect(matcher).not_to include 501
+      expect(matcher).not_to include 599
+    end
+
+    it do
+      matcher = described_class.new([400..401, 500])
+
+      expect(matcher).to include 400
+      expect(matcher).to include 401
+      expect(matcher).not_to include 499
+      expect(matcher).to include 500
+      expect(matcher).not_to include 599
+    end
+
+    it do
+      matcher = described_class.new([400..401, 500..600])
+
+      expect(matcher).to include 400
+      expect(matcher).to include 401
+      expect(matcher).not_to include 499
+      expect(matcher).to include 500
+      expect(matcher).to include 599
+    end
+  end
+end


### PR DESCRIPTION
**2.0 Upgrade Guide notes**

**What does this PR do?**

Fix and standardize the way to configure an array of ranges for `error_status_codes` from environment variables. 
