### PR TITLE
[PROF-8669] Benchmarks for core heap profiling phases

### DIFF
--- a/benchmarks/profiler_heap_sampling.rb
+++ b/benchmarks/profiler_heap_sampling.rb
@@ -1,0 +1,183 @@
+# Used to quickly run benchmark under RSpec as part of the usual test suite, to validate it didn't bitrot
+VALIDATE_BENCHMARK_MODE = ENV['VALIDATE_BENCHMARK'] == 'true'
+
+return unless __FILE__ == $PROGRAM_NAME || VALIDATE_BENCHMARK_MODE
+
+require 'benchmark/ips'
+require 'ddtrace'
+require 'pry'
+require_relative 'dogstatsd_reporter'
+
+METRIC_VALUES = { 'cpu-time' => 0, 'cpu-samples' => 0, 'wall-time' => 0, 'alloc-samples' => 1, 'timeline' => 0 }.freeze
+OBJECT_CLASS = 'object'.freeze
+
+def sample_object(recorder, depth = 0)
+  if depth <= 0
+    Datadog::Profiling::StackRecorder::Testing._native_track_object(
+      recorder,
+      Object.new,
+      1,
+      OBJECT_CLASS,
+    )
+    Datadog::Profiling::Collectors::Stack::Testing._native_sample(
+      Thread.current,
+      recorder,
+      METRIC_VALUES,
+      [],
+      [],
+      400,
+      false
+    )
+  else
+    sample_object(recorder, depth - 1)
+  end
+end
+
+# This benchmark measures the performance of the sampling operations with different flavours of heap profiling
+# with single stacks
+Benchmark.ips do |x|
+  benchmark_time = VALIDATE_BENCHMARK_MODE ? { time: 0.01, warmup: 0 } : { time: 10, warmup: 2 }
+  x.config(
+    **benchmark_time,
+    suite: report_to_dogstatsd_if_enabled_via_environment_variable(benchmark_name: 'profiler_heap_sampling')
+  )
+
+  recorder_without_heap = Datadog::Profiling::StackRecorder.new(
+    cpu_time_enabled: false,
+    alloc_samples_enabled: false,
+    heap_samples_enabled: false,
+    heap_size_enabled: false,
+    heap_sample_every: 1,
+    timeline_enabled: false,
+  )
+
+  recorder_with_heap = Datadog::Profiling::StackRecorder.new(
+    cpu_time_enabled: false,
+    alloc_samples_enabled: true,
+    heap_samples_enabled: true,
+    heap_size_enabled: true,
+    heap_sample_every: 1,
+    timeline_enabled: false,
+  )
+
+  x.report('no heap - single stack') do
+    sample_object(recorder_without_heap)
+  end
+
+  x.report('heap - single stack') do
+    sample_object(recorder_with_heap)
+  end
+
+  x.save! 'profiler-heap-sampling-results-single-stack.json' unless VALIDATE_BENCHMARK_MODE
+  x.compare!
+end
+
+# This benchmark measures the performance of the sampling operations with different flavours of heap profiling
+# with many stacks
+Benchmark.ips do |x|
+  benchmark_time = VALIDATE_BENCHMARK_MODE ? { time: 0.01, warmup: 0 } : { time: 10, warmup: 2 }
+  x.config(
+    **benchmark_time,
+    suite: report_to_dogstatsd_if_enabled_via_environment_variable(benchmark_name: 'profiler_heap_sampling_many_stacks')
+  )
+
+  recorder_without_heap = Datadog::Profiling::StackRecorder.new(
+    cpu_time_enabled: false,
+    alloc_samples_enabled: false,
+    heap_samples_enabled: false,
+    heap_size_enabled: false,
+    heap_sample_every: 1,
+    timeline_enabled: false,
+  )
+
+  recorder_with_heap = Datadog::Profiling::StackRecorder.new(
+    cpu_time_enabled: false,
+    alloc_samples_enabled: true,
+    heap_samples_enabled: true,
+    heap_size_enabled: true,
+    heap_sample_every: 1,
+    timeline_enabled: false,
+  )
+
+  x.report('no heap - many stacks') do |times|
+    i = 0
+    while i < times
+      sample_object(recorder_without_heap, i % 400)
+      i += 1
+    end
+  end
+
+  x.report('heap - many stacks') do |times|
+    i = 0
+    while i < times
+      sample_object(recorder_with_heap, i % 400)
+      i += 1
+    end
+  end
+
+  x.save! 'profiler-heap-sampling-many-stacks-results.json' unless VALIDATE_BENCHMARK_MODE
+  x.compare!
+end
+
+# This benchmark measures the performance of the sampling operations with different heap profiling sampling levels
+Benchmark.ips do |x|
+  benchmark_time = VALIDATE_BENCHMARK_MODE ? { time: 0.01, warmup: 0 } : { time: 10, warmup: 2 }
+  x.config(
+    **benchmark_time,
+    suite: report_to_dogstatsd_if_enabled_via_environment_variable(benchmark_name: 'profiler_heap_sampling_rates')
+  )
+
+  recorder_heap_sampling_1 = Datadog::Profiling::StackRecorder.new(
+    cpu_time_enabled: false,
+    alloc_samples_enabled: false,
+    heap_samples_enabled: true,
+    heap_size_enabled: true,
+    heap_sample_every: 1,
+    timeline_enabled: false,
+  )
+
+  recorder_heap_sampling_10 = Datadog::Profiling::StackRecorder.new(
+    cpu_time_enabled: false,
+    alloc_samples_enabled: true,
+    heap_samples_enabled: true,
+    heap_size_enabled: true,
+    heap_sample_every: 10,
+    timeline_enabled: false,
+  )
+
+  recorder_heap_sampling_100 = Datadog::Profiling::StackRecorder.new(
+    cpu_time_enabled: false,
+    alloc_samples_enabled: true,
+    heap_samples_enabled: true,
+    heap_size_enabled: true,
+    heap_sample_every: 100,
+    timeline_enabled: false,
+  )
+
+  x.report('heap profiling - sample_rate=1') do |times|
+    i = 0
+    while i < times
+      sample_object(recorder_heap_sampling_1, i % 400)
+      i += 1
+    end
+  end
+
+  x.report('heap profiling - sample_rate=10') do |times|
+    i = 0
+    while i < times
+      sample_object(recorder_heap_sampling_10, i % 400)
+      i += 1
+    end
+  end
+
+  x.report('heap profiling - sample_rate=100') do |times|
+    i = 0
+    while i < times
+      sample_object(recorder_heap_sampling_100, i % 400)
+      i += 1
+    end
+  end
+
+  x.save! 'profiler-heap-sampling-rates-results.json' unless VALIDATE_BENCHMARK_MODE
+  x.compare!
+end

--- a/benchmarks/profiler_heap_serialization.rb
+++ b/benchmarks/profiler_heap_serialization.rb
@@ -1,0 +1,249 @@
+# Used to quickly run benchmark under RSpec as part of the usual test suite, to validate it didn't bitrot
+VALIDATE_BENCHMARK_MODE = ENV['VALIDATE_BENCHMARK'] == 'true'
+
+return unless __FILE__ == $PROGRAM_NAME || VALIDATE_BENCHMARK_MODE
+
+require 'benchmark/ips'
+require 'ddtrace'
+require 'pry'
+require_relative 'dogstatsd_reporter'
+
+RANDOM = Random.new
+METRIC_VALUES = { 'cpu-time' => 0, 'cpu-samples' => 0, 'wall-time' => 0, 'alloc-samples' => 1, 'timeline' => 0 }.freeze
+
+def sample_object(recorder, obj, depth = 0)
+  if depth <= 0
+    Datadog::Profiling::StackRecorder::Testing._native_track_object(
+      recorder,
+      obj,
+      1,
+      obj.class.name,
+    )
+    Datadog::Profiling::Collectors::Stack::Testing._native_sample(
+      Thread.current,
+      recorder,
+      METRIC_VALUES,
+      [],
+      [],
+      400,
+      false
+    )
+  else
+    sample_object(recorder, obj, depth - 1)
+  end
+end
+
+def random_value(depth = 0)
+  case [:array, :hash, :string, :number, :object].sample
+  when :array
+    random_array(depth)
+  when :hash
+    random_hash(depth)
+  when :string
+    RANDOM.bytes(rand(0..50))
+  when :number
+    rand(-1_000_000_000_000..1_000_000_000_000)
+  when :object
+    BenchmarkObject.new(depth)
+  end
+end
+
+def create_benchmark_live_objects(num_objects: 1_000_000)
+  live_objects = []
+
+  num_objects.times { live_objects << random_object }
+end
+
+def random_array(depth)
+  num_entries = rand(0..(100 / (10**depth)))
+  Array.new(num_entries) { random_value(depth + 1) }
+end
+
+def random_hash(depth)
+  num_entries = rand(0..(100 / (10**depth)))
+  Array.new(num_entries) { [random_value(depth + 1).freeze, random_value(depth + 1)] }.to_h
+end
+
+class BenchmarkObject < Object
+  def initialize(depth)
+    num_fields = rand(0..(100 / (10**depth)))
+    obj = self
+
+    num_fields.times { |i| obj.instance_variable_set("@field#{i}".to_sym, random_value(depth + 1)) }
+  end
+end
+
+# This benchmark measures the performance of different flavours of heap profiling
+Benchmark.ips do |x|
+  benchmark_time = VALIDATE_BENCHMARK_MODE ? { time: 0.01, warmup: 0 } : { time: 10, warmup: 2 }
+  x.config(
+    **benchmark_time,
+    suite: report_to_dogstatsd_if_enabled_via_environment_variable(benchmark_name: 'profiler_heap_serialization')
+  )
+
+  recorder_without_heap = Datadog::Profiling::StackRecorder.new(
+    cpu_time_enabled: false,
+    alloc_samples_enabled: false,
+    heap_samples_enabled: false,
+    heap_size_enabled: false,
+    heap_sample_every: 1,
+    timeline_enabled: false,
+  )
+
+  recorder_with_heap_samples_only = Datadog::Profiling::StackRecorder.new(
+    cpu_time_enabled: false,
+    alloc_samples_enabled: true,
+    heap_samples_enabled: true,
+    heap_size_enabled: false,
+    heap_sample_every: 1,
+    timeline_enabled: false,
+  )
+
+  recorder_with_full_heap = Datadog::Profiling::StackRecorder.new(
+    cpu_time_enabled: false,
+    alloc_samples_enabled: true,
+    heap_samples_enabled: true,
+    heap_size_enabled: true,
+    heap_sample_every: 1,
+    timeline_enabled: false,
+  )
+
+  live_objects = Array.new(VALIDATE_BENCHMARK_MODE ? 100 : 10_000) { BenchmarkObject.new(0) }
+
+  live_objects.each_with_index do |obj, _i|
+    sample_object(recorder_without_heap, obj)
+    sample_object(recorder_with_heap_samples_only, obj)
+    sample_object(recorder_with_full_heap, obj)
+  end
+
+  x.report('full serialization without heap profiling') do
+    recorder_without_heap.serialize!
+  end
+
+  x.report('heap sampling serialization preparation - samples') do
+    Datadog::Profiling::StackRecorder::Testing._native_prepare_heap_serialization(recorder_with_heap_samples_only)
+    Datadog::Profiling::StackRecorder::Testing._native_finish_heap_serialization(recorder_with_heap_samples_only)
+  end
+
+  x.report('heap sampling serialization preparation - samples+size') do
+    Datadog::Profiling::StackRecorder::Testing._native_prepare_heap_serialization(recorder_with_full_heap)
+    Datadog::Profiling::StackRecorder::Testing._native_finish_heap_serialization(recorder_with_full_heap)
+  end
+
+  x.report('full serialization with heap profiling - samples') do
+    recorder_with_heap_samples_only.serialize!
+  end
+
+  x.report('full serialization with heap profiling - samples+size') do
+    recorder_with_full_heap.serialize!
+  end
+
+  x.save! 'profiler-heap-serialization-results.json' unless VALIDATE_BENCHMARK_MODE
+  x.compare!
+end
+
+# This benchmark measures the effect of stack variety on heap serialization.
+Benchmark.ips do |x|
+  benchmark_time = VALIDATE_BENCHMARK_MODE ? { time: 0.01, warmup: 0 } : { time: 10, warmup: 2 }
+  x.config(
+    **benchmark_time,
+    suite: report_to_dogstatsd_if_enabled_via_environment_variable(benchmark_name: 'profiler_heap_serialization_stacks')
+  )
+
+  recorder_single_stack = Datadog::Profiling::StackRecorder.new(
+    cpu_time_enabled: false,
+    alloc_samples_enabled: true,
+    heap_samples_enabled: true,
+    heap_size_enabled: true,
+    heap_sample_every: 1,
+    timeline_enabled: false,
+  )
+
+  recorder_many_stacks = Datadog::Profiling::StackRecorder.new(
+    cpu_time_enabled: false,
+    alloc_samples_enabled: true,
+    heap_samples_enabled: true,
+    heap_size_enabled: true,
+    heap_sample_every: 1,
+    timeline_enabled: false,
+  )
+
+  live_objects = Array.new(VALIDATE_BENCHMARK_MODE ? 100 : 10_000) { BenchmarkObject.new(0) }
+
+  live_objects.each_with_index do |obj, i|
+    sample_object(recorder_single_stack, obj)
+    depth = i % 400
+    sample_object(recorder_many_stacks, obj, depth)
+  end
+
+  x.report('heap profiling serialization - single stack') do
+    recorder_single_stack.serialize!
+  end
+
+  x.report('heap profiling serialization - many stacks') do
+    recorder_many_stacks.serialize!
+  end
+
+  x.save! 'profiler-heap-serialization-stacks-results.json' unless VALIDATE_BENCHMARK_MODE
+  x.compare!
+end
+
+# This benchmark measures the effect of heap sampling on heap serialization.
+Benchmark.ips do |x|
+  benchmark_time = VALIDATE_BENCHMARK_MODE ? { time: 0.01, warmup: 0 } : { time: 10, warmup: 2 }
+  x.config(
+    **benchmark_time,
+    suite: report_to_dogstatsd_if_enabled_via_environment_variable(benchmark_name: 'profiler_heap_serialization_sampling')
+  )
+
+  recorder_with_full_heap_and_sampling_1 = Datadog::Profiling::StackRecorder.new(
+    cpu_time_enabled: false,
+    alloc_samples_enabled: true,
+    heap_samples_enabled: true,
+    heap_size_enabled: true,
+    heap_sample_every: 1,
+    timeline_enabled: false,
+  )
+
+  recorder_with_full_heap_and_sampling_10 = Datadog::Profiling::StackRecorder.new(
+    cpu_time_enabled: false,
+    alloc_samples_enabled: true,
+    heap_samples_enabled: true,
+    heap_size_enabled: true,
+    heap_sample_every: 10,
+    timeline_enabled: false,
+  )
+
+  recorder_with_full_heap_and_sampling_100 = Datadog::Profiling::StackRecorder.new(
+    cpu_time_enabled: false,
+    alloc_samples_enabled: true,
+    heap_samples_enabled: true,
+    heap_size_enabled: true,
+    heap_sample_every: 100,
+    timeline_enabled: false,
+  )
+
+  live_objects = Array.new(VALIDATE_BENCHMARK_MODE ? 100 : 10_000) { BenchmarkObject.new(0) }
+
+  live_objects.each_with_index do |obj, i|
+    depth = i % 400
+    sample_object(recorder_with_full_heap_and_sampling_1, obj, depth)
+    sample_object(recorder_with_full_heap_and_sampling_10, obj, depth)
+    sample_object(recorder_with_full_heap_and_sampling_100, obj, depth)
+  end
+
+  x.report('heap profiling serialization with sampling rate of 1') do
+    recorder_with_full_heap_and_sampling_1.serialize!
+  end
+
+  x.report('heap profiling serialization with sampling rate of 10') do
+    recorder_with_full_heap_and_sampling_10.serialize!
+  end
+
+  x.report('heap profiling serialization with sampling rate of 100') do
+    recorder_with_full_heap_and_sampling_100.serialize!
+  end
+
+  x.save! 'profiler-heap-serialization-sampling-results.json' unless VALIDATE_BENCHMARK_MODE
+  x.compare!
+end

--- a/benchmarks/profiler_sample_loop_v2.rb
+++ b/benchmarks/profiler_sample_loop_v2.rb
@@ -20,6 +20,7 @@ class ProfilerSampleLoopBenchmark
       cpu_time_enabled: true,
       alloc_samples_enabled: false,
       heap_samples_enabled: false,
+      heap_size_enabled: false,
       timeline_enabled: false,
     )
     @collector = Datadog::Profiling::Collectors::ThreadContext.new(

--- a/ext/ddtrace_profiling_native_extension/extconf.rb
+++ b/ext/ddtrace_profiling_native_extension/extconf.rb
@@ -192,6 +192,12 @@ if RUBY_VERSION < '2.4'
   $defs << '-DUSE_LEGACY_RB_VM_FRAME_METHOD_ENTRY'
 end
 
+# On older Rubies, rb_gc_force_recycle allowed to free objects in a way that
+# would be invisible to free tracepoints, finalizers and without cleaning
+# obj_to_id_tbl mappings. This leads to potential invisible object re-use
+# to our heap profiler.
+$defs << '-DHAVE_WORKING_RB_GC_FORCE_RECYCLE' if RUBY_VERSION < '3.1'
+
 # If we got here, libdatadog is available and loaded
 ENV['PKG_CONFIG_PATH'] = "#{ENV['PKG_CONFIG_PATH']}:#{Libdatadog.pkgconfig_folder}"
 Logging.message("[ddtrace] PKG_CONFIG_PATH set to #{ENV['PKG_CONFIG_PATH'].inspect}\n")

--- a/ext/ddtrace_profiling_native_extension/heap_recorder.c
+++ b/ext/ddtrace_profiling_native_extension/heap_recorder.c
@@ -92,6 +92,7 @@ typedef struct {
 } object_record;
 static object_record* object_record_new(long, heap_record*, live_object_data);
 static void object_record_free(object_record*);
+static VALUE object_record_inspect(object_record*);
 
 struct heap_recorder {
   // Map[key: heap_record_key*, record: heap_record*]
@@ -438,22 +439,7 @@ static int st_object_records_debug(DDTRACE_UNUSED st_data_t key, st_data_t value
 
   object_record *record = (object_record*) value;
 
-  heap_frame top_frame = record->heap_record->stack->frames[0];
-  rb_str_catf(debug_str, "obj_id=%ld weight=%d size=%zu location=%s:%d alloc_gen=%zu ", record->obj_id, record->object_data.weight, record->object_data.size, top_frame.filename, (int) top_frame.line, record->object_data.alloc_gen);
-
-  const char *class = record->object_data.class;
-  if (class != NULL) {
-    rb_str_catf(debug_str, "class=%s ", class);
-  }
-
-  VALUE ref;
-  if (!ruby_ref_from_id(LONG2NUM(record->obj_id), &ref)) {
-    rb_str_catf(debug_str, "object=<invalid>");
-  } else {
-    rb_str_catf(debug_str, "object=%+"PRIsVALUE, ref);
-  }
-
-  rb_str_catf(debug_str, "\n");
+  rb_str_catf(debug_str, "%"PRIsVALUE"\n", object_record_inspect(record));
 
   return ST_CONTINUE;
 }
@@ -471,7 +457,11 @@ typedef struct {
 static int update_object_record_entry(DDTRACE_UNUSED st_data_t *key, st_data_t *value, st_data_t data, int existing) {
   object_record_update_data *update_data = (object_record_update_data*) data;
   if (existing) {
-    rb_raise(rb_eRuntimeError, "Object ids are supposed to be unique. We got 2 allocation recordings with the same id");
+    object_record *existing_record = (object_record*) (*value);
+    VALUE existing_inspect = object_record_inspect(existing_record);
+    VALUE new_inspect = object_record_inspect(update_data->new_object_record);
+    rb_raise(rb_eRuntimeError, "Object ids are supposed to be unique. We got 2 allocation recordings with "
+        "the same id.\nprevious=%"PRIsVALUE"\nnew=%"PRIsVALUE"\n", existing_inspect, new_inspect);
   }
   // Always carry on with the update, we want the new record to be there at the end
   (*value) = (st_data_t) update_data->new_object_record;
@@ -598,6 +588,32 @@ void object_record_free(object_record *record) {
     ruby_xfree(record->object_data.class);
   }
   ruby_xfree(record);
+}
+
+VALUE object_record_inspect(object_record *record) {
+  heap_frame top_frame = record->heap_record->stack->frames[0];
+  VALUE inspect = rb_sprintf("obj_id=%ld weight=%d size=%zu location=%s:%d alloc_gen=%zu ",
+      record->obj_id, record->object_data.weight, record->object_data.size, top_frame.filename,
+      (int) top_frame.line, record->object_data.alloc_gen);
+
+  const char *class = record->object_data.class;
+  if (class != NULL) {
+    rb_str_catf(inspect, "class=%s ", class);
+  }
+
+  VALUE ref;
+  if (!ruby_ref_from_id(LONG2NUM(record->obj_id), &ref)) {
+    rb_str_catf(inspect, "object=<invalid>");
+  } else {
+    VALUE ruby_inspect = ruby_safe_inspect(ref);
+    if (ruby_inspect != Qnil) {
+      rb_str_catf(inspect, "object=%"PRIsVALUE, ruby_inspect);
+    } else {
+      rb_str_catf(inspect, "object=%s", ruby_value_type_to_string(rb_type(ref)));
+    }
+  }
+
+  return inspect;
 }
 
 // ==============

--- a/ext/ddtrace_profiling_native_extension/heap_recorder.c
+++ b/ext/ddtrace_profiling_native_extension/heap_recorder.c
@@ -126,7 +126,7 @@ static heap_record* get_or_create_heap_record(heap_recorder*, ddog_prof_Slice_Lo
 static void cleanup_heap_record_if_unused(heap_recorder*, heap_record*);
 static int st_heap_record_entry_free(st_data_t, st_data_t, st_data_t);
 static int st_object_record_entry_free(st_data_t, st_data_t, st_data_t);
-static int st_object_record_entry_free_if_invalid(st_data_t, st_data_t, st_data_t);
+static int st_object_record_update(st_data_t, st_data_t, st_data_t);
 static int st_object_records_iterate(st_data_t, st_data_t, st_data_t);
 static int st_object_records_debug(st_data_t key, st_data_t value, st_data_t extra);
 static int update_object_record_entry(st_data_t*, st_data_t*, st_data_t, int);
@@ -260,7 +260,7 @@ void heap_recorder_prepare_iteration(heap_recorder *heap_recorder) {
     rb_raise(rb_eRuntimeError, "New heap recorder iteration prepared without the previous one having been finished.");
   }
 
-  st_foreach(heap_recorder->object_records, st_object_record_entry_free_if_invalid, (st_data_t) heap_recorder);
+  st_foreach(heap_recorder->object_records, st_object_record_update, (st_data_t) heap_recorder);
 
   heap_recorder->object_records_snapshot = st_copy(heap_recorder->object_records);
   if (heap_recorder->object_records_snapshot == NULL) {
@@ -361,13 +361,15 @@ static int st_object_record_entry_free(DDTRACE_UNUSED st_data_t key, st_data_t v
   return ST_DELETE;
 }
 
-static int st_object_record_entry_free_if_invalid(st_data_t key, st_data_t value, st_data_t extra_arg) {
+static int st_object_record_update(st_data_t key, st_data_t value, st_data_t extra_arg) {
   long obj_id = (long) key;
   object_record *record = (object_record*) value;
   heap_recorder *recorder = (heap_recorder*) extra_arg;
 
-  if (!ruby_ref_from_id(LONG2NUM(obj_id), NULL)) {
-    // Id no longer associated with a valid ref. Need to clean things up!
+  VALUE ref;
+
+  if (!ruby_ref_from_id(LONG2NUM(obj_id), &ref)) {
+    // Id no longer associated with a valid ref. Need to delete this object record!
 
     // Starting with the associated heap record. There will now be one less tracked object pointing to it
     heap_record *heap_record = record->heap_record;
@@ -379,6 +381,9 @@ static int st_object_record_entry_free_if_invalid(st_data_t key, st_data_t value
     object_record_free(record);
     return ST_DELETE;
   }
+
+  // If we got this far, entry is still valid so lets update its size
+  record->object_data.size = ruby_obj_memsize_of(ref);
 
   return ST_CONTINUE;
 }
@@ -418,7 +423,7 @@ static int st_object_records_debug(DDTRACE_UNUSED st_data_t key, st_data_t value
   object_record *record = (object_record*) value;
 
   heap_frame top_frame = record->heap_record->stack->frames[0];
-  rb_str_catf(debug_str, "obj_id=%ld weight=%d location=%s:%d alloc_gen=%zu ", record->obj_id, record->object_data.weight, top_frame.filename, (int) top_frame.line, record->object_data.alloc_gen);
+  rb_str_catf(debug_str, "obj_id=%ld weight=%d size=%zu location=%s:%d alloc_gen=%zu ", record->obj_id, record->object_data.weight, record->object_data.size, top_frame.filename, (int) top_frame.line, record->object_data.alloc_gen);
 
   const char *class = record->object_data.class;
   if (class != NULL) {

--- a/ext/ddtrace_profiling_native_extension/heap_recorder.c
+++ b/ext/ddtrace_profiling_native_extension/heap_recorder.c
@@ -93,6 +93,7 @@ typedef struct {
 static object_record* object_record_new(long, heap_record*, live_object_data);
 static void object_record_free(object_record*);
 static VALUE object_record_inspect(object_record*);
+static object_record SKIPPED_RECORD = {0};
 
 struct heap_recorder {
   // Map[key: heap_record_key*, record: heap_record*]
@@ -122,6 +123,10 @@ struct heap_recorder {
 
   // Reusable location array, implementing a flyweight pattern for things like iteration.
   ddog_prof_Location *reusable_locations;
+
+  // Sampling controls
+  uint sample_rate;
+  uint num_recordings_skipped;
 };
 static heap_record* get_or_create_heap_record(heap_recorder*, ddog_prof_Slice_Location);
 static void cleanup_heap_record_if_unused(heap_recorder*, heap_record*);
@@ -151,6 +156,7 @@ heap_recorder* heap_recorder_new(void) {
   recorder->object_records_snapshot = NULL;
   recorder->reusable_locations = ruby_xcalloc(MAX_FRAMES_LIMIT, sizeof(ddog_prof_Location));
   recorder->partial_object_record = NULL;
+  recorder->sample_rate = 1; // By default do no sampling
 
   return recorder;
 }
@@ -184,6 +190,19 @@ void heap_recorder_free(heap_recorder *heap_recorder) {
   ruby_xfree(heap_recorder);
 }
 
+void heap_recorder_set_sample_rate(heap_recorder *heap_recorder, int sample_rate) {
+  if (heap_recorder == NULL) {
+    return;
+  }
+
+  if (sample_rate < 0) {
+    rb_raise(rb_eArgError, "Heap sample rate must be a positive integer value but was %d", sample_rate);
+  }
+
+  heap_recorder->sample_rate = sample_rate;
+  heap_recorder->num_recordings_skipped = 0;
+}
+
 // WARN: Assumes this gets called before profiler is reinitialized on the fork
 void heap_recorder_after_fork(heap_recorder *heap_recorder) {
   if (heap_recorder == NULL) {
@@ -214,6 +233,14 @@ void start_heap_allocation_recording(heap_recorder *heap_recorder, VALUE new_obj
     return;
   }
 
+  if (heap_recorder->num_recordings_skipped + 1 < heap_recorder->sample_rate) {
+    heap_recorder->partial_object_record = &SKIPPED_RECORD;
+    heap_recorder->num_recordings_skipped++;
+    return;
+  }
+
+  heap_recorder->num_recordings_skipped = 0;
+
   VALUE ruby_obj_id = rb_obj_id(new_obj);
   if (!FIXNUM_P(ruby_obj_id)) {
     rb_raise(rb_eRuntimeError, "Detected a bignum object id. These are not supported by heap profiling.");
@@ -224,7 +251,7 @@ void start_heap_allocation_recording(heap_recorder *heap_recorder, VALUE new_obj
   }
 
   heap_recorder->partial_object_record = object_record_new(FIX2LONG(ruby_obj_id), NULL, (live_object_data) {
-    .weight =  weight,
+    .weight =  weight * heap_recorder->sample_rate,
     .class = alloc_class != NULL ? string_from_char_slice(*alloc_class) : NULL,
     .alloc_gen = rb_gc_count(),
   });
@@ -241,10 +268,14 @@ void end_heap_allocation_recording(struct heap_recorder *heap_recorder, ddog_pro
     // Recording ended without having been started?
     rb_raise(rb_eRuntimeError, "Ended a heap recording that was not started");
   }
-
   // From now on, mark active recording as invalid so we can short-circuit at any point and
   // not end up with a still active recording. partial_object_record still holds the object for this recording
   heap_recorder->partial_object_record = NULL;
+
+  if (partial_object_record == &SKIPPED_RECORD) {
+    // special marker when we decided to skip due to sampling
+    return;
+  }
 
   heap_record *heap_record = get_or_create_heap_record(heap_recorder, locations);
 

--- a/ext/ddtrace_profiling_native_extension/heap_recorder.c
+++ b/ext/ddtrace_profiling_native_extension/heap_recorder.c
@@ -250,7 +250,15 @@ void end_heap_allocation_recording(struct heap_recorder *heap_recorder, ddog_pro
   commit_allocation(heap_recorder, heap_record, partial_object_record);
 }
 
-void heap_recorder_prepare_iteration(heap_recorder *heap_recorder) {
+typedef struct {
+  // A reference to the heap recorder so we can access extra stuff to cleanup unused records.
+  heap_recorder *heap_recorder;
+
+  // Whether we should update object sizes as part of the update iteration or not.
+  bool update_sizes;
+} prepare_iteration_context;
+
+void heap_recorder_prepare_iteration(heap_recorder *heap_recorder, bool update_sizes) {
   if (heap_recorder == NULL) {
     return;
   }
@@ -260,7 +268,11 @@ void heap_recorder_prepare_iteration(heap_recorder *heap_recorder) {
     rb_raise(rb_eRuntimeError, "New heap recorder iteration prepared without the previous one having been finished.");
   }
 
-  st_foreach(heap_recorder->object_records, st_object_record_update, (st_data_t) heap_recorder);
+  prepare_iteration_context context = (prepare_iteration_context) {
+    .heap_recorder = heap_recorder,
+    .update_sizes = update_sizes,
+  };
+  st_foreach(heap_recorder->object_records, st_object_record_update, (st_data_t) &context);
 
   heap_recorder->object_records_snapshot = st_copy(heap_recorder->object_records);
   if (heap_recorder->object_records_snapshot == NULL) {
@@ -364,7 +376,7 @@ static int st_object_record_entry_free(DDTRACE_UNUSED st_data_t key, st_data_t v
 static int st_object_record_update(st_data_t key, st_data_t value, st_data_t extra_arg) {
   long obj_id = (long) key;
   object_record *record = (object_record*) value;
-  heap_recorder *recorder = (heap_recorder*) extra_arg;
+  prepare_iteration_context *context = (prepare_iteration_context*) extra_arg;
 
   VALUE ref;
 
@@ -376,14 +388,18 @@ static int st_object_record_update(st_data_t key, st_data_t value, st_data_t ext
     heap_record->num_tracked_objects--;
 
     // One less object using this heap record, it may have become unused...
-    cleanup_heap_record_if_unused(recorder, heap_record);
+    cleanup_heap_record_if_unused(context->heap_recorder, heap_record);
 
     object_record_free(record);
     return ST_DELETE;
   }
 
-  // If we got this far, entry is still valid so lets update its size
-  record->object_data.size = ruby_obj_memsize_of(ref);
+  // If we got this far, entry is still valid
+
+  if (context->update_sizes) {
+    // if we were asked to update sizes, do so...
+    record->object_data.size = ruby_obj_memsize_of(ref);
+  }
 
   return ST_CONTINUE;
 }

--- a/ext/ddtrace_profiling_native_extension/heap_recorder.h
+++ b/ext/ddtrace_profiling_native_extension/heap_recorder.h
@@ -53,6 +53,21 @@ heap_recorder* heap_recorder_new(void);
 // Free a previously initialized heap recorder.
 void heap_recorder_free(heap_recorder *heap_recorder);
 
+// Set sample rate used by this heap recorder.
+//
+// Controls how many recordings will be ignored before committing a heap allocation and
+// the weight of the committed heap allocation.
+//
+// A value of 1 will effectively track all objects that are passed through
+// start/end_heap_allocation_recording pairs. A value of 10 will only track every 10th
+// object passed through such calls and its effective weight for the purposes of heap
+// profiling will be multiplied by 10.
+//
+// NOTE: Default is 1, i.e., track all heap allocation recordings.
+//
+// WARN: Non-positive values will lead to an exception being thrown.
+void heap_recorder_set_sample_rate(heap_recorder *heap_recorder, int sample_rate);
+
 // Do any cleanup needed after forking.
 // WARN: Assumes this gets called before profiler is reinitialized on the fork
 void heap_recorder_after_fork(heap_recorder *heap_recorder);

--- a/ext/ddtrace_profiling_native_extension/heap_recorder.h
+++ b/ext/ddtrace_profiling_native_extension/heap_recorder.h
@@ -27,6 +27,9 @@ typedef struct live_object_data {
   //          could be seen as being representative of 50 objects.
   unsigned int weight;
 
+  // Size of this object on last flush/update.
+  size_t size;
+
   // The class of the object that we're tracking.
   // NOTE: This is optional and will be set to NULL if not set.
   char* class;

--- a/ext/ddtrace_profiling_native_extension/heap_recorder.h
+++ b/ext/ddtrace_profiling_native_extension/heap_recorder.h
@@ -82,8 +82,12 @@ void end_heap_allocation_recording(heap_recorder *heap_recorder, ddog_prof_Slice
 // Update the heap recorder to reflect the latest state of the VM and prepare internal structures
 // for efficient iteration.
 //
+// @param update_sizes
+//   True if we should re-calculate live object sizes ahead of the next iteration. If false,
+//   the previous sizes will be used (or 0 if we never updated them before).
+//
 // WARN: This must be called strictly before iteration. Failing to do so will result in exceptions.
-void heap_recorder_prepare_iteration(heap_recorder *heap_recorder);
+void heap_recorder_prepare_iteration(heap_recorder *heap_recorder, bool update_sizes);
 
 // Optimize the heap recorder by cleaning up any data that might have been prepared specifically
 // for the purpose of iterating over the heap recorder data.

--- a/ext/ddtrace_profiling_native_extension/ruby_helpers.c
+++ b/ext/ddtrace_profiling_native_extension/ruby_helpers.c
@@ -166,3 +166,39 @@ bool ruby_ref_from_id(VALUE obj_id, VALUE *value) {
 
   return true;
 }
+
+// Not part of public headers but is externed from Ruby
+size_t rb_obj_memsize_of(VALUE obj);
+
+// Wrapper around rb_obj_memsize_of to avoid hitting crashing paths.
+size_t ruby_obj_memsize_of(VALUE obj) {
+  switch (BUILTIN_TYPE(obj)) {
+    case T_OBJECT:
+    case T_MODULE:
+    case T_CLASS:
+    case T_ICLASS:
+    case T_STRING:
+    case T_ARRAY:
+    case T_HASH:
+    case T_REGEXP:
+    case T_DATA:
+    case T_MATCH:
+    case T_FILE:
+    case T_RATIONAL:
+    case T_COMPLEX:
+    case T_IMEMO:
+    case T_FLOAT:
+    case T_SYMBOL:
+    case T_BIGNUM:
+    // case T_NODE: -> Throws exception in rb_obj_memsize_of
+    case T_STRUCT:
+    case T_ZOMBIE:
+    #ifndef NO_T_MOVED
+    case T_MOVED:
+    #endif
+      return rb_obj_memsize_of(obj);
+    default:
+      // Unsupported, return 0 instead of erroring like rb_obj_memsize_of likes doing
+      return 0;
+  }
+}

--- a/ext/ddtrace_profiling_native_extension/ruby_helpers.c
+++ b/ext/ddtrace_profiling_native_extension/ruby_helpers.c
@@ -172,7 +172,7 @@ size_t rb_obj_memsize_of(VALUE obj);
 
 // Wrapper around rb_obj_memsize_of to avoid hitting crashing paths.
 size_t ruby_obj_memsize_of(VALUE obj) {
-  switch (BUILTIN_TYPE(obj)) {
+  switch (rb_type(obj)) {
     case T_OBJECT:
     case T_MODULE:
     case T_CLASS:

--- a/ext/ddtrace_profiling_native_extension/ruby_helpers.c
+++ b/ext/ddtrace_profiling_native_extension/ruby_helpers.c
@@ -8,12 +8,16 @@
 // They are not expected to be mutated outside of init.
 static VALUE module_object_space = Qnil;
 static ID _id2ref_id = Qnil;
+static ID _inspect_id = Qnil;
+static ID _to_s_id = Qnil;
 
 void ruby_helpers_init(void) {
   rb_global_variable(&module_object_space);
 
   module_object_space = rb_const_get(rb_cObject, rb_intern("ObjectSpace"));
   _id2ref_id = rb_intern("_id2ref");
+  _inspect_id = rb_intern("inspect");
+  _to_s_id = rb_intern("to_s");
 }
 
 void raise_unexpected_type(
@@ -200,5 +204,31 @@ size_t ruby_obj_memsize_of(VALUE obj) {
     default:
       // Unsupported, return 0 instead of erroring like rb_obj_memsize_of likes doing
       return 0;
+  }
+}
+
+VALUE ruby_safe_inspect(VALUE obj) {
+  switch(rb_type(obj)) {
+    case T_DATA:
+    case T_IMEMO:
+    #ifndef NO_T_MOVED
+    case T_MOVED:
+    #endif
+    case T_NIL:
+    case T_NODE:
+    case T_NONE:
+    case T_UNDEF:
+    case T_ZOMBIE:
+      return Qnil;
+    default:
+      break;
+  }
+
+  if (rb_respond_to(obj, _inspect_id)) {
+    return rb_sprintf("%+"PRIsVALUE, obj);
+  } else if (rb_respond_to(obj, _to_s_id)) {
+    return rb_sprintf("%"PRIsVALUE, obj);
+  } else {
+    return Qnil;
   }
 }

--- a/ext/ddtrace_profiling_native_extension/ruby_helpers.h
+++ b/ext/ddtrace_profiling_native_extension/ruby_helpers.h
@@ -111,3 +111,7 @@ bool ruby_ref_from_id(size_t id, VALUE *value);
 // object.
 size_t ruby_obj_memsize_of(VALUE obj);
 
+// Safely inspect any ruby object. If the object responds to 'inspect',
+// return a string with the result of that call. Elsif the object responds to
+// 'to_s', return a string with the result of that call. Otherwise, return Qnil.
+VALUE ruby_safe_inspect(VALUE obj);

--- a/ext/ddtrace_profiling_native_extension/ruby_helpers.h
+++ b/ext/ddtrace_profiling_native_extension/ruby_helpers.h
@@ -106,3 +106,8 @@ char* ruby_strndup(const char *str, size_t size);
 // writes the ref to the value pointer parameter if !NULL. False if id doesn't
 // reference a valid object (in which case value is not changed).
 bool ruby_ref_from_id(size_t id, VALUE *value);
+
+// Native wrapper to get the approximate/estimated current size of the passed
+// object.
+size_t ruby_obj_memsize_of(VALUE obj);
+

--- a/ext/ddtrace_profiling_native_extension/stack_recorder.c
+++ b/ext/ddtrace_profiling_native_extension/stack_recorder.c
@@ -238,8 +238,8 @@ static VALUE _native_record_endpoint(DDTRACE_UNUSED VALUE _self, VALUE recorder_
 static void reset_profile(ddog_prof_Profile *profile, ddog_Timespec *start_time /* Can be null */);
 static VALUE _native_track_object(DDTRACE_UNUSED VALUE _self, VALUE recorder_instance, VALUE new_obj, VALUE weight, VALUE alloc_class);
 static VALUE _native_check_heap_hashes(DDTRACE_UNUSED VALUE _self, VALUE locations);
-static VALUE _native_start_fake_slow_heap_serialization(DDTRACE_UNUSED VALUE _self, VALUE recorder_instance);
-static VALUE _native_end_fake_slow_heap_serialization(DDTRACE_UNUSED VALUE _self, VALUE recorder_instance);
+static VALUE _native_prepare_heap_serialization(DDTRACE_UNUSED VALUE _self, VALUE recorder_instance);
+static VALUE _native_finish_heap_serialization(DDTRACE_UNUSED VALUE _self, VALUE recorder_instance);
 static VALUE _native_debug_heap_recorder(DDTRACE_UNUSED VALUE _self, VALUE recorder_instance);
 
 
@@ -267,10 +267,10 @@ void stack_recorder_init(VALUE profiling_module) {
   rb_define_singleton_method(testing_module, "_native_record_endpoint", _native_record_endpoint, 3);
   rb_define_singleton_method(testing_module, "_native_track_object", _native_track_object, 4);
   rb_define_singleton_method(testing_module, "_native_check_heap_hashes", _native_check_heap_hashes, 1);
-  rb_define_singleton_method(testing_module, "_native_start_fake_slow_heap_serialization",
-      _native_start_fake_slow_heap_serialization, 1);
-  rb_define_singleton_method(testing_module, "_native_end_fake_slow_heap_serialization",
-      _native_end_fake_slow_heap_serialization, 1);
+  rb_define_singleton_method(testing_module, "_native_prepare_heap_serialization",
+      _native_prepare_heap_serialization, 1);
+  rb_define_singleton_method(testing_module, "_native_finish_heap_serialization",
+      _native_finish_heap_serialization, 1);
   rb_define_singleton_method(testing_module, "_native_debug_heap_recorder",
       _native_debug_heap_recorder, 1);
 
@@ -883,7 +883,7 @@ static void reset_profile(ddog_prof_Profile *profile, ddog_Timespec *start_time 
 
 // This method exists only to enable testing Datadog::Profiling::StackRecorder behavior using RSpec.
 // It SHOULD NOT be used for other purposes.
-static VALUE _native_start_fake_slow_heap_serialization(DDTRACE_UNUSED VALUE _self, VALUE recorder_instance) {
+static VALUE _native_prepare_heap_serialization(DDTRACE_UNUSED VALUE _self, VALUE recorder_instance) {
   struct stack_recorder_state *state;
   TypedData_Get_Struct(recorder_instance, struct stack_recorder_state, &stack_recorder_typed_data, state);
 
@@ -894,7 +894,7 @@ static VALUE _native_start_fake_slow_heap_serialization(DDTRACE_UNUSED VALUE _se
 
 // This method exists only to enable testing Datadog::Profiling::StackRecorder behavior using RSpec.
 // It SHOULD NOT be used for other purposes.
-static VALUE _native_end_fake_slow_heap_serialization(DDTRACE_UNUSED VALUE _self, VALUE recorder_instance) {
+static VALUE _native_finish_heap_serialization(DDTRACE_UNUSED VALUE _self, VALUE recorder_instance) {
   struct stack_recorder_state *state;
   TypedData_Get_Struct(recorder_instance, struct stack_recorder_state, &stack_recorder_typed_data, state);
 

--- a/ext/ddtrace_profiling_native_extension/stack_recorder.c
+++ b/ext/ddtrace_profiling_native_extension/stack_recorder.c
@@ -184,6 +184,7 @@ struct stack_recorder_state {
 
   uint8_t position_for[ALL_VALUE_TYPES_COUNT];
   uint8_t enabled_values_count;
+  bool heap_size_enabled;
 };
 
 // Used to return a pair of values from sampler_lock_active_profile()
@@ -216,6 +217,7 @@ static VALUE _native_initialize(
   VALUE cpu_time_enabled,
   VALUE alloc_samples_enabled,
   VALUE heap_samples_enabled,
+  VALUE heap_sizes_enabled,
   VALUE timeline_enabled
 );
 static VALUE _native_serialize(VALUE self, VALUE recorder_instance);
@@ -255,7 +257,7 @@ void stack_recorder_init(VALUE profiling_module) {
   // https://bugs.ruby-lang.org/issues/18007 for a discussion around this.
   rb_define_alloc_func(stack_recorder_class, _native_new);
 
-  rb_define_singleton_method(stack_recorder_class, "_native_initialize", _native_initialize, 5);
+  rb_define_singleton_method(stack_recorder_class, "_native_initialize", _native_initialize, 6);
   rb_define_singleton_method(stack_recorder_class, "_native_serialize",  _native_serialize, 1);
   rb_define_singleton_method(stack_recorder_class, "_native_reset_after_fork", _native_reset_after_fork, 1);
   rb_define_singleton_method(testing_module, "_native_active_slot", _native_active_slot, 1);
@@ -309,6 +311,7 @@ static VALUE _native_new(VALUE klass) {
   //       heap samples, we will free and reset heap_recorder to NULL, effectively disabling all behaviour specific
   //       to heap profiling (all calls to heap_recorder_* with a NULL heap recorder are noops).
   state->heap_recorder = heap_recorder_new();
+  state->heap_size_enabled = true;
 
   // Note: Don't raise exceptions after this point, since it'll lead to libdatadog memory leaking!
 
@@ -369,11 +372,13 @@ static VALUE _native_initialize(
   VALUE cpu_time_enabled,
   VALUE alloc_samples_enabled,
   VALUE heap_samples_enabled,
+  VALUE heap_size_enabled,
   VALUE timeline_enabled
 ) {
   ENFORCE_BOOLEAN(cpu_time_enabled);
   ENFORCE_BOOLEAN(alloc_samples_enabled);
   ENFORCE_BOOLEAN(heap_samples_enabled);
+  ENFORCE_BOOLEAN(heap_size_enabled);
   ENFORCE_BOOLEAN(timeline_enabled);
 
   struct stack_recorder_state *state;
@@ -382,7 +387,8 @@ static VALUE _native_initialize(
   uint8_t requested_values_count = ALL_VALUE_TYPES_COUNT -
     (cpu_time_enabled == Qtrue ? 0 : 1) -
     (alloc_samples_enabled == Qtrue? 0 : 1) -
-    (heap_samples_enabled == Qtrue ? 0 : 2) -
+    (heap_samples_enabled == Qtrue ? 0 : 1) -
+    (heap_size_enabled == Qtrue ? 0 : 1) -
     (timeline_enabled == Qtrue ? 0 : 1);
 
   if (requested_values_count == ALL_VALUE_TYPES_COUNT) return Qtrue; // Nothing to do, this is the default
@@ -422,12 +428,20 @@ static VALUE _native_initialize(
   if (heap_samples_enabled == Qtrue) {
     enabled_value_types[next_enabled_pos] = (ddog_prof_ValueType) HEAP_SAMPLES_VALUE;
     state->position_for[HEAP_SAMPLES_VALUE_ID] = next_enabled_pos++;
-    enabled_value_types[next_enabled_pos] = (ddog_prof_ValueType) HEAP_SIZE_VALUE;
-    state->position_for[HEAP_SIZE_VALUE_ID] = next_enabled_pos++;
   } else {
     state->position_for[HEAP_SAMPLES_VALUE_ID] = next_disabled_pos++;
-    state->position_for[HEAP_SIZE_VALUE_ID] = next_disabled_pos++;
+  }
 
+  if (heap_size_enabled == Qtrue) {
+    enabled_value_types[next_enabled_pos] = (ddog_prof_ValueType) HEAP_SIZE_VALUE;
+    state->position_for[HEAP_SIZE_VALUE_ID] = next_enabled_pos++;
+    state->heap_size_enabled = true;
+  } else {
+    state->position_for[HEAP_SIZE_VALUE_ID] = next_disabled_pos++;
+    state->heap_size_enabled = false;
+  }
+
+  if (heap_samples_enabled == Qfalse && heap_size_enabled == Qfalse) {
     // Turns out heap sampling is disabled but we initialized everything in _native_new
     // assuming all samples were enabled. We need to deinitialize the heap recorder.
     heap_recorder_free(state->heap_recorder);
@@ -460,7 +474,7 @@ static VALUE _native_serialize(DDTRACE_UNUSED VALUE _self, VALUE recorder_instan
 
   // Prepare the iteration on heap recorder we'll be doing outside the GVL. The preparation needs to
   // happen while holding on to the GVL.
-  heap_recorder_prepare_iteration(state->heap_recorder);
+  heap_recorder_prepare_iteration(state->heap_recorder, state->heap_size_enabled);
 
   // We'll release the Global VM Lock while we're calling serialize, so that the Ruby VM can continue to work while this
   // is pending
@@ -868,7 +882,7 @@ static VALUE _native_start_fake_slow_heap_serialization(DDTRACE_UNUSED VALUE _se
   struct stack_recorder_state *state;
   TypedData_Get_Struct(recorder_instance, struct stack_recorder_state, &stack_recorder_typed_data, state);
 
-  heap_recorder_prepare_iteration(state->heap_recorder);
+  heap_recorder_prepare_iteration(state->heap_recorder, false);
 
   return Qnil;
 }

--- a/ext/ddtrace_profiling_native_extension/stack_recorder.c
+++ b/ext/ddtrace_profiling_native_extension/stack_recorder.c
@@ -153,17 +153,19 @@ static VALUE error_symbol = Qnil; // :error in Ruby
 #define ALLOC_SAMPLES_VALUE_ID 3
 #define HEAP_SAMPLES_VALUE      {.type_ = VALUE_STRING("heap-live-samples"), .unit = VALUE_STRING("count")}
 #define HEAP_SAMPLES_VALUE_ID 4
+#define HEAP_SIZE_VALUE         {.type_ = VALUE_STRING("heap-live-size"),    .unit = VALUE_STRING("bytes")}
+#define HEAP_SIZE_VALUE_ID 5
 #define TIMELINE_VALUE          {.type_ = VALUE_STRING("timeline"),          .unit = VALUE_STRING("nanoseconds")}
-#define TIMELINE_VALUE_ID 5
+#define TIMELINE_VALUE_ID 6
 
 static const ddog_prof_ValueType all_value_types[] =
-  {CPU_TIME_VALUE, CPU_SAMPLES_VALUE, WALL_TIME_VALUE, ALLOC_SAMPLES_VALUE, HEAP_SAMPLES_VALUE, TIMELINE_VALUE};
+  {CPU_TIME_VALUE, CPU_SAMPLES_VALUE, WALL_TIME_VALUE, ALLOC_SAMPLES_VALUE, HEAP_SAMPLES_VALUE, HEAP_SIZE_VALUE, TIMELINE_VALUE};
 
 // This array MUST be kept in sync with all_value_types above and is intended to act as a "hashmap" between VALUE_ID and the position it
 // occupies on the all_value_types array.
 // E.g. all_value_types_positions[CPU_TIME_VALUE_ID] => 0, means that CPU_TIME_VALUE was declared at position 0 of all_value_types.
 static const uint8_t all_value_types_positions[] =
-  {CPU_TIME_VALUE_ID, CPU_SAMPLES_VALUE_ID, WALL_TIME_VALUE_ID, ALLOC_SAMPLES_VALUE_ID, HEAP_SAMPLES_VALUE_ID, TIMELINE_VALUE_ID};
+  {CPU_TIME_VALUE_ID, CPU_SAMPLES_VALUE_ID, WALL_TIME_VALUE_ID, ALLOC_SAMPLES_VALUE_ID, HEAP_SAMPLES_VALUE_ID, HEAP_SIZE_VALUE_ID, TIMELINE_VALUE_ID};
 
 #define ALL_VALUE_TYPES_COUNT (sizeof(all_value_types) / sizeof(ddog_prof_ValueType))
 
@@ -380,7 +382,7 @@ static VALUE _native_initialize(
   uint8_t requested_values_count = ALL_VALUE_TYPES_COUNT -
     (cpu_time_enabled == Qtrue ? 0 : 1) -
     (alloc_samples_enabled == Qtrue? 0 : 1) -
-    (heap_samples_enabled == Qtrue ? 0 : 1) -
+    (heap_samples_enabled == Qtrue ? 0 : 2) -
     (timeline_enabled == Qtrue ? 0 : 1);
 
   if (requested_values_count == ALL_VALUE_TYPES_COUNT) return Qtrue; // Nothing to do, this is the default
@@ -420,8 +422,11 @@ static VALUE _native_initialize(
   if (heap_samples_enabled == Qtrue) {
     enabled_value_types[next_enabled_pos] = (ddog_prof_ValueType) HEAP_SAMPLES_VALUE;
     state->position_for[HEAP_SAMPLES_VALUE_ID] = next_enabled_pos++;
+    enabled_value_types[next_enabled_pos] = (ddog_prof_ValueType) HEAP_SIZE_VALUE;
+    state->position_for[HEAP_SIZE_VALUE_ID] = next_enabled_pos++;
   } else {
     state->position_for[HEAP_SAMPLES_VALUE_ID] = next_disabled_pos++;
+    state->position_for[HEAP_SIZE_VALUE_ID] = next_disabled_pos++;
 
     // Turns out heap sampling is disabled but we initialized everything in _native_new
     // assuming all samples were enabled. We need to deinitialize the heap recorder.
@@ -599,6 +604,7 @@ static bool add_heap_sample_to_active_profile_without_gvl(heap_recorder_iteratio
   uint8_t *position_for = context->state->position_for;
 
   metric_values[position_for[HEAP_SAMPLES_VALUE_ID]] = object_data->weight;
+  metric_values[position_for[HEAP_SIZE_VALUE_ID]] = object_data->size * object_data->weight;
 
   ddog_prof_Label labels[2];
   size_t label_offset = 0;

--- a/lib/datadog/core/configuration/settings.rb
+++ b/lib/datadog/core/configuration/settings.rb
@@ -356,6 +356,21 @@ module Datadog
               o.default false
             end
 
+            # Can be used to enable/disable the collection of heap size profiles.
+            #
+            # This feature is alpha and enabled by default when heap profiling is enabled.
+            #
+            # @warn To enable heap size profiling you are required to also enable allocation and heap profiling.
+            # @note Heap profiles are not yet GA in the Datadog UI, get in touch if you want to help us test it.
+            #
+            # @default `DD_PROFILING_EXPERIMENTAL_HEAP_SIZE_ENABLED` environment variable as a boolean, otherwise
+            # whatever the value of DD_PROFILING_EXPERIMENTAL_HEAP_ENABLED is.
+            option :experimental_heap_size_enabled do |o|
+              o.type :bool
+              o.env 'DD_PROFILING_EXPERIMENTAL_HEAP_SIZE_ENABLED'
+              o.default true # This gets ANDed with experimental_heap_enabled in the profiler component.
+            end
+
             # Can be used to configure the allocation sampling rate: a sample will be collected every x allocations.
             #
             # The lower the value, the more accuracy in allocation and heap tracking but the bigger the overhead. In
@@ -366,6 +381,22 @@ module Datadog
               o.type :int
               o.env 'DD_PROFILING_EXPERIMENTAL_ALLOCATION_SAMPLE_RATE'
               o.default 50
+            end
+
+            # Can be used to configure the heap sampling rate: a heap sample will be collected for every x allocation
+            # samples.
+            #
+            # The lower the value, the more accuracy in heap tracking but the bigger the overhead. In particular, a
+            # value of 1 will track ALL allocations samples for heap profiles.
+            #
+            # The effective heap sampling rate in terms of allocations (not allocation samples) can be calculated via
+            # effective_heap_sample_rate = allocation_sample_rate * heap_sample_rate.
+            #
+            # @default `DD_PROFILING_EXPERIMENTAL_HEAP_SAMPLE_RATE` environment variable, otherwise `10`.
+            option :experimental_heap_sample_rate do |o|
+              o.type :int
+              o.env 'DD_PROFILING_EXPERIMENTAL_HEAP_SAMPLE_RATE'
+              o.default 10
             end
 
             # Can be used to disable checking which version of `libmysqlclient` is being used by the `mysql2` gem.

--- a/lib/datadog/profiling/component.rb
+++ b/lib/datadog/profiling/component.rb
@@ -85,6 +85,7 @@ module Datadog
           cpu_time_enabled: RUBY_PLATFORM.include?('linux'), # Only supported on Linux currently
           alloc_samples_enabled: allocation_profiling_enabled,
           heap_samples_enabled: heap_profiling_enabled,
+          heap_size_enabled: heap_profiling_enabled,
           timeline_enabled: timeline_enabled,
         )
       end

--- a/lib/datadog/profiling/component.rb
+++ b/lib/datadog/profiling/component.rb
@@ -213,6 +213,14 @@ module Datadog
           return false
         end
 
+        if RUBY_VERSION.start_with?('3.') && RUBY_VERSION < '3.1'
+          Datadog.logger.warn(
+            "Current Ruby version (#{RUBY_VERSION}) supports forced object recycling which may affect the "\
+            'accuracy of heap profiling data. Please update to Ruby >= 3.1 where this feature was removed '\
+            '(https://bugs.ruby-lang.org/issues/18290) to improve heap profiling quality.'
+          )
+        end
+
         unless allocation_profiling_enabled
           raise ArgumentError,
             'Heap profiling requires allocation profiling to be enabled'

--- a/lib/datadog/profiling/stack_recorder.rb
+++ b/lib/datadog/profiling/stack_recorder.rb
@@ -4,7 +4,10 @@ module Datadog
     # Note that `record_sample` is only accessible from native code.
     # Methods prefixed with _native_ are implemented in `stack_recorder.c`
     class StackRecorder
-      def initialize(cpu_time_enabled:, alloc_samples_enabled:, heap_samples_enabled:, timeline_enabled:)
+      def initialize(
+        cpu_time_enabled:, alloc_samples_enabled:, heap_samples_enabled:, heap_size_enabled:,
+        timeline_enabled:
+      )
         # This mutex works in addition to the fancy C-level mutexes we have in the native side (see the docs there).
         # It prevents multiple Ruby threads calling serialize at the same time -- something like
         # `10.times { Thread.new { stack_recorder.serialize } }`.
@@ -18,6 +21,7 @@ module Datadog
           cpu_time_enabled,
           alloc_samples_enabled,
           heap_samples_enabled,
+          heap_size_enabled,
           timeline_enabled,
         )
       end

--- a/lib/datadog/profiling/stack_recorder.rb
+++ b/lib/datadog/profiling/stack_recorder.rb
@@ -6,7 +6,7 @@ module Datadog
     class StackRecorder
       def initialize(
         cpu_time_enabled:, alloc_samples_enabled:, heap_samples_enabled:, heap_size_enabled:,
-        timeline_enabled:
+        heap_sample_every:, timeline_enabled:
       )
         # This mutex works in addition to the fancy C-level mutexes we have in the native side (see the docs there).
         # It prevents multiple Ruby threads calling serialize at the same time -- something like
@@ -22,6 +22,7 @@ module Datadog
           alloc_samples_enabled,
           heap_samples_enabled,
           heap_size_enabled,
+          heap_sample_every,
           timeline_enabled,
         )
       end

--- a/sig/datadog/profiling/stack_recorder.rbs
+++ b/sig/datadog/profiling/stack_recorder.rbs
@@ -3,13 +3,20 @@ module Datadog
     class StackRecorder
       @no_concurrent_synchronize_mutex: ::Thread::Mutex
 
-      def initialize: (cpu_time_enabled: bool, alloc_samples_enabled: bool, heap_samples_enabled: bool, timeline_enabled: bool) -> void
+      def initialize: (
+        cpu_time_enabled: bool,
+        alloc_samples_enabled: bool,
+        heap_samples_enabled: bool,
+        heap_size_enabled: bool,
+        timeline_enabled: bool,
+      ) -> void
 
       def self._native_initialize: (
         Datadog::Profiling::StackRecorder recorder_instance,
         bool cpu_time_enabled,
         bool alloc_samples_enabled,
         bool heap_samples_enabled,
+        bool heap_size_enabled,
         bool timeline_enabled,
       ) -> true
 

--- a/spec/datadog/core/configuration/settings_spec.rb
+++ b/spec/datadog/core/configuration/settings_spec.rb
@@ -575,6 +575,41 @@ RSpec.describe Datadog::Core::Configuration::Settings do
         end
       end
 
+      describe '#experimental_heap_size_enabled' do
+        subject(:experimental_heap_size_enabled) { settings.profiling.advanced.experimental_heap_size_enabled }
+
+        context 'when DD_PROFILING_EXPERIMENTAL_HEAP_SIZE_ENABLED' do
+          around do |example|
+            ClimateControl.modify('DD_PROFILING_EXPERIMENTAL_HEAP_SIZE_ENABLED' => environment) do
+              example.run
+            end
+          end
+
+          context 'is not defined' do
+            let(:environment) { nil }
+
+            it { is_expected.to be true }
+          end
+
+          [true, false].each do |value|
+            context "is defined as #{value}" do
+              let(:environment) { value.to_s }
+
+              it { is_expected.to be value }
+            end
+          end
+        end
+      end
+
+      describe '#experimental_heap_size_enabled=' do
+        it 'updates the #experimental_heap_size_enabled setting' do
+          expect { settings.profiling.advanced.experimental_heap_size_enabled = false }
+            .to change { settings.profiling.advanced.experimental_heap_size_enabled }
+            .from(true)
+            .to(false)
+        end
+      end
+
       describe '#experimental_allocation_sample_rate' do
         subject(:experimental_allocation_sample_rate) { settings.profiling.advanced.experimental_allocation_sample_rate }
 
@@ -606,6 +641,41 @@ RSpec.describe Datadog::Core::Configuration::Settings do
           expect { settings.profiling.advanced.experimental_allocation_sample_rate = 100 }
             .to change { settings.profiling.advanced.experimental_allocation_sample_rate }
             .from(50)
+            .to(100)
+        end
+      end
+
+      describe '#experimental_heap_sample_rate' do
+        subject(:experimental_heap_sample_rate) { settings.profiling.advanced.experimental_heap_sample_rate }
+
+        context 'when DD_PROFILING_EXPERIMENTAL_HEAP_SAMPLE_RATE' do
+          around do |example|
+            ClimateControl.modify('DD_PROFILING_EXPERIMENTAL_HEAP_SAMPLE_RATE' => environment) do
+              example.run
+            end
+          end
+
+          context 'is not defined' do
+            let(:environment) { nil }
+
+            it { is_expected.to be 10 }
+          end
+
+          [100, 30.5].each do |value|
+            context "is defined as #{value}" do
+              let(:environment) { value.to_s }
+
+              it { is_expected.to be value.to_i }
+            end
+          end
+        end
+      end
+
+      describe '#experimental_heap_sample_rate=' do
+        it 'updates the #experimental_heap_sample_rate setting' do
+          expect { settings.profiling.advanced.experimental_heap_sample_rate = 100 }
+            .to change { settings.profiling.advanced.experimental_heap_sample_rate }
+            .from(10)
             .to(100)
         end
       end

--- a/spec/datadog/profiling/collectors/cpu_and_wall_time_worker_spec.rb
+++ b/spec/datadog/profiling/collectors/cpu_and_wall_time_worker_spec.rb
@@ -12,7 +12,9 @@ RSpec.describe 'Datadog::Profiling::Collectors::CpuAndWallTimeWorker' do
   let(:allocation_sample_every) { 50 }
   let(:allocation_profiling_enabled) { false }
   let(:heap_profiling_enabled) { false }
-  let(:recorder) { build_stack_recorder(heap_samples_enabled: heap_profiling_enabled) }
+  let(:recorder) do
+    build_stack_recorder(heap_samples_enabled: heap_profiling_enabled, heap_size_enabled: heap_profiling_enabled)
+  end
   let(:no_signals_workaround_enabled) { false }
   let(:timeline_enabled) { false }
   let(:options) { {} }

--- a/spec/datadog/profiling/collectors/cpu_and_wall_time_worker_spec.rb
+++ b/spec/datadog/profiling/collectors/cpu_and_wall_time_worker_spec.rb
@@ -594,6 +594,8 @@ RSpec.describe 'Datadog::Profiling::Collectors::CpuAndWallTimeWorker' do
           .find(&test_struct_heap_sample)
 
         expect(relevant_sample.values[:'heap-live-samples']).to eq test_num_allocated_object
+        # 40 is the size of a basic object and we have test_num_allocated_object of them
+        expect(relevant_sample.values[:'heap-live-size']).to eq test_num_allocated_object * 40
       end
     end
 

--- a/spec/datadog/profiling/spec_helper.rb
+++ b/spec/datadog/profiling/spec_helper.rb
@@ -81,12 +81,16 @@ module ProfileHelpers
 
   # We disable heap_sample collection by default in tests since it requires some extra mocking/
   # setup for it to properly work.
-  def build_stack_recorder(heap_samples_enabled: false, heap_size_enabled: false, timeline_enabled: false)
+  def build_stack_recorder(
+    heap_samples_enabled: false, heap_size_enabled: false, heap_sample_every: 1,
+    timeline_enabled: false
+  )
     Datadog::Profiling::StackRecorder.new(
       cpu_time_enabled: true,
       alloc_samples_enabled: true,
       heap_samples_enabled: heap_samples_enabled,
       heap_size_enabled: heap_size_enabled,
+      heap_sample_every: heap_sample_every,
       timeline_enabled: timeline_enabled,
     )
   end

--- a/spec/datadog/profiling/spec_helper.rb
+++ b/spec/datadog/profiling/spec_helper.rb
@@ -81,11 +81,12 @@ module ProfileHelpers
 
   # We disable heap_sample collection by default in tests since it requires some extra mocking/
   # setup for it to properly work.
-  def build_stack_recorder(heap_samples_enabled: false, timeline_enabled: false)
+  def build_stack_recorder(heap_samples_enabled: false, heap_size_enabled: false, timeline_enabled: false)
     Datadog::Profiling::StackRecorder.new(
       cpu_time_enabled: true,
       alloc_samples_enabled: true,
       heap_samples_enabled: heap_samples_enabled,
+      heap_size_enabled: heap_size_enabled,
       timeline_enabled: timeline_enabled,
     )
   end

--- a/spec/datadog/profiling/stack_recorder_spec.rb
+++ b/spec/datadog/profiling/stack_recorder_spec.rb
@@ -522,7 +522,7 @@ RSpec.describe Datadog::Profiling::StackRecorder do
         end
 
         it "aren't lost when they happen concurrently with a long serialization" do
-          described_class::Testing._native_start_fake_slow_heap_serialization(stack_recorder)
+          described_class::Testing._native_prepare_heap_serialization(stack_recorder)
 
           test_num_allocated_object = 123
           live_objects = Array.new(test_num_allocated_object)
@@ -534,7 +534,7 @@ RSpec.describe Datadog::Profiling::StackRecorder do
 
           allocation_line = __LINE__ - 3
 
-          described_class::Testing._native_end_fake_slow_heap_serialization(stack_recorder)
+          described_class::Testing._native_finish_heap_serialization(stack_recorder)
 
           heap_samples_in_test_matcher = lambda { |sample|
             (sample.values[:'heap-live-samples'] || 0) > 0 && sample.locations.any? do |location|

--- a/spec/datadog/profiling/stack_recorder_spec.rb
+++ b/spec/datadog/profiling/stack_recorder_spec.rb
@@ -10,6 +10,7 @@ RSpec.describe Datadog::Profiling::StackRecorder do
   # Disabling these by default since they require some extra setup and produce separate samples.
   # Enabling this is tested in a particular context below.
   let(:heap_samples_enabled) { false }
+  let(:heap_size_enabled) { false }
   let(:timeline_enabled) { true }
 
   subject(:stack_recorder) do
@@ -17,6 +18,7 @@ RSpec.describe Datadog::Profiling::StackRecorder do
       cpu_time_enabled: cpu_time_enabled,
       alloc_samples_enabled: alloc_samples_enabled,
       heap_samples_enabled: heap_samples_enabled,
+      heap_size_enabled: heap_size_enabled,
       timeline_enabled: timeline_enabled,
     )
   end
@@ -124,6 +126,7 @@ RSpec.describe Datadog::Profiling::StackRecorder do
         let(:cpu_time_enabled) { true }
         let(:alloc_samples_enabled) { true }
         let(:heap_samples_enabled) { true }
+        let(:heap_size_enabled) { true }
         let(:timeline_enabled) { true }
         let(:all_profile_types) do
           {
@@ -137,8 +140,8 @@ RSpec.describe Datadog::Profiling::StackRecorder do
           }
         end
 
-        def profile_types_without(*types)
-          all_profile_types.dup.tap { |it| it.delete_if { |k| types.include?(k) } }
+        def profile_types_without(type)
+          all_profile_types.dup.tap { |it| it.delete(type) { raise 'Missing key' } }
         end
 
         context 'when all profile types are enabled' do
@@ -167,7 +170,15 @@ RSpec.describe Datadog::Profiling::StackRecorder do
           let(:heap_samples_enabled) { false }
 
           it 'returns a pprof without the heap-live-samples type' do
-            expect(sample_types_from(decoded_profile)).to eq(profile_types_without('heap-live-samples', 'heap-live-size'))
+            expect(sample_types_from(decoded_profile)).to eq(profile_types_without('heap-live-samples'))
+          end
+        end
+
+        context 'when heap-live-size is disabled' do
+          let(:heap_size_enabled) { false }
+
+          it 'returns a pprof without the heap-live-size type' do
+            expect(sample_types_from(decoded_profile)).to eq(profile_types_without('heap-live-size'))
           end
         end
 
@@ -183,6 +194,7 @@ RSpec.describe Datadog::Profiling::StackRecorder do
           let(:cpu_time_enabled) { false }
           let(:alloc_samples_enabled) { false }
           let(:heap_samples_enabled) { false }
+          let(:heap_size_enabled) { false }
           let(:timeline_enabled) { false }
 
           it 'returns a pprof without the optional types' do
@@ -341,7 +353,7 @@ RSpec.describe Datadog::Profiling::StackRecorder do
       end
     end
 
-    describe 'heap samples' do
+    describe 'heap samples and sizes' do
       let(:sample_rate) { 50 }
       let(:metric_values) do
         { 'cpu-time' => 101, 'cpu-samples' => 1, 'wall-time' => 789, 'alloc-samples' => sample_rate, 'timeline' => 42 }
@@ -405,6 +417,7 @@ RSpec.describe Datadog::Profiling::StackRecorder do
 
       context 'when disabled' do
         let(:heap_samples_enabled) { false }
+        let(:heap_size_enabled) { false }
 
         it 'are ommitted from the profile' do
           # We sample from 2 distinct locations
@@ -416,6 +429,7 @@ RSpec.describe Datadog::Profiling::StackRecorder do
 
       context 'when enabled' do
         let(:heap_samples_enabled) { true }
+        let(:heap_size_enabled) { true }
 
         let(:heap_samples) do
           samples.select { |s| s.values[:'heap-live-samples'] > 0 }

--- a/spec/datadog/profiling/validate_benchmarks_spec.rb
+++ b/spec/datadog/profiling/validate_benchmarks_spec.rb
@@ -16,4 +16,12 @@ RSpec.describe 'Profiling benchmarks', if: (RUBY_VERSION >= '2.4.0') do
   describe 'profiler_http_transport' do
     it('runs without raising errors') { expect_in_fork { load './benchmarks/profiler_http_transport.rb' } }
   end
+
+  describe 'profiler_heap_sampling' do
+    it('runs without raising errors') { expect_in_fork { load './benchmarks/profiler_heap_sampling.rb' } }
+  end
+
+  describe 'profiler_heap_serialization' do
+    it('runs without raising errors') { expect_in_fork { load './benchmarks/profiler_heap_serialization.rb' } }
+  end
 end


### PR DESCRIPTION
**What does this PR do?**
Add a couple of benchmarks focusing on the core phases of heap profiling:
* What's the impact on the sampling side.
* What's the impact on serialization side (both within GVL - preparation - and outside the GVL - full serialization).

The benchmarks are currently running through the normal flow (i.e. involving stack recorder and such) which means they also capture some extra work unrelated to heap profiling like stack walking, generation of non-heap samples or ddprof serialization. I think this is valuable to get a feeling of overall overhead in normal operation and not focus too much on local optimizations that may have a very small impact in total runtime.

**Motivation:**
* Get a feeling for heap profiling overheads.
* Do some extra stress testing of the heap recorder mechanisms.

**Additional Notes:**
<!-- Anything else we should know when reviewing? -->

**How to test the change?**

#### Sampling

```
❯ bundle exec ruby benchmarks/profiler_heap_sampling.rb     
DogStatsD reporting ❌ disabled
Warming up --------------------------------------
no heap - single stack
                        37.125k i/100ms
 heap - single stack    27.479k i/100ms
Calculating -------------------------------------
no heap - single stack
                        361.009k (± 6.2%) i/s -      3.601M in  10.014774s
 heap - single stack    280.275k (± 3.3%) i/s -      2.803M in  10.013193s

Comparison:
no heap - single stack:   361008.9 i/s
 heap - single stack:   280274.7 i/s - 1.29x  slower

DogStatsD reporting ❌ disabled
Warming up --------------------------------------
no heap - many stacks
                         4.243k i/100ms
  heap - many stacks     3.048k i/100ms
Calculating -------------------------------------
no heap - many stacks
                         43.056k (± 0.8%) i/s -    432.786k in  10.052483s
  heap - many stacks     29.916k (± 3.6%) i/s -    301.752k in  10.099722s

Comparison:
no heap - many stacks:    43055.6 i/s
  heap - many stacks:    29916.3 i/s - 1.44x  slower

DogStatsD reporting ❌ disabled
Warming up --------------------------------------
heap profiling - sample_rate=1
                         2.834k i/100ms
heap profiling - sample_rate=10
                         4.034k i/100ms
heap profiling - sample_rate=100
                         3.906k i/100ms
Calculating -------------------------------------
heap profiling - sample_rate=1
                         29.322k (± 3.8%) i/s -    294.736k in  10.066480s
heap profiling - sample_rate=10
                         39.827k (± 3.4%) i/s -    399.366k in  10.039527s
heap profiling - sample_rate=100
                         41.736k (± 2.6%) i/s -    417.942k in  10.020877s

Comparison:
heap profiling - sample_rate=100:    41736.3 i/s
heap profiling - sample_rate=10:    39827.3 i/s - same-ish: difference falls within error
heap profiling - sample_rate=1:    29321.7 i/s - 1.42x  slower
```

#### Serialization

```
❯ bundle exec ruby benchmarks/profiler_heap_serialization.rb
DogStatsD reporting ❌ disabled
Warming up --------------------------------------
full serialization without heap profiling
                        30.506k i/100ms
heap sampling serialization preparation - samples
                       214.000  i/100ms
heap sampling serialization preparation - samples+size
                       223.000  i/100ms
full serialization with heap profiling - samples
                        11.000  i/100ms
full serialization with heap profiling - samples+size
                        11.000  i/100ms
Calculating -------------------------------------
full serialization without heap profiling
                        299.932k (± 2.6%) i/s -      3.020M in  10.076043s
heap sampling serialization preparation - samples
                          2.162k (± 4.7%) i/s -     21.614k in  10.023727s
heap sampling serialization preparation - samples+size
                          2.163k (± 3.6%) i/s -     21.631k in  10.015366s
full serialization with heap profiling - samples
                        109.297  (± 1.8%) i/s -      1.100k in  10.067532s
full serialization with heap profiling - samples+size
                        107.649  (± 0.9%) i/s -      1.078k in  10.015311s

Comparison:
full serialization without heap profiling:   299932.4 i/s
heap sampling serialization preparation - samples+size:     2162.9 i/s - 138.67x  slower
heap sampling serialization preparation - samples:     2161.7 i/s - 138.75x  slower
full serialization with heap profiling - samples:      109.3 i/s - 2744.21x  slower
full serialization with heap profiling - samples+size:      107.6 i/s - 2786.20x  slower

DogStatsD reporting ❌ disabled
Warming up --------------------------------------
heap profiling serialization - single stack
                        10.000  i/100ms
heap profiling serialization - many stacks
                         1.000  i/100ms
Calculating -------------------------------------
heap profiling serialization - single stack
                        105.570  (± 1.9%) i/s -      1.060k in  10.044343s
heap profiling serialization - many stacks
                          6.222  (± 0.0%) i/s -     63.000  in  10.126989s

Comparison:
heap profiling serialization - single stack:      105.6 i/s
heap profiling serialization - many stacks:        6.2 i/s - 16.97x  slower

DogStatsD reporting ❌ disabled
Warming up --------------------------------------
heap profiling serialization with sampling rate of 1
                         1.000  i/100ms
heap profiling serialization with sampling rate of 10
                         5.000  i/100ms
heap profiling serialization with sampling rate of 100
                        50.000  i/100ms
Calculating -------------------------------------
heap profiling serialization with sampling rate of 1
                          6.173  (± 0.0%) i/s -     62.000  in  10.044963s
heap profiling serialization with sampling rate of 10
                         60.810  (± 1.6%) i/s -    610.000  in  10.034120s
heap profiling serialization with sampling rate of 100
                        513.250  (± 1.8%) i/s -      5.150k in  10.037699s

Comparison:
heap profiling serialization with sampling rate of 100:      513.3 i/s
heap profiling serialization with sampling rate of 10:       60.8 i/s - 8.44x  slower
heap profiling serialization with sampling rate of 1:        6.2 i/s - 83.14x  slower
```

**For Datadog employees:**
- [x] If this PR touches code that signs or publishes builds or packages, or handles
credentials of any kind, I've requested a review from `@DataDog/security-design-and-guidance`.
- [ ] This PR doesn't touch any of that.

Unsure? Have a question? Request a review!
