### PR TITLE
[NO-TICKET] Import upstream `rb_profile_frames` fix

### DIFF
--- a/ext/ddtrace_profiling_native_extension/private_vm_api_access.c
+++ b/ext/ddtrace_profiling_native_extension/private_vm_api_access.c
@@ -471,6 +471,11 @@ int ddtrace_rb_profile_frames(VALUE thread, int start, int limit, VALUE *buff, i
     // it from https://github.com/ruby/ruby/pull/7116 in a "just in case" kind of mindset.
     if (cfp == NULL) return 0;
 
+    // As of this writing, we don't support profiling with MN enabled, and this only happens in that mode, but as we
+    // probably want to experiment with it in the future, I've decided to import https://github.com/ruby/ruby/pull/9310
+    // here.
+    if (ec == NULL) return 0;
+
     // Fix: Skip dummy frame that shows up in main thread.
     //
     // According to a comment in `backtrace_each` (`vm_backtrace.c`), there's two dummy frames that we should ignore


### PR DESCRIPTION
**What does this PR do?**

This PR imports an upstream fix to `rb_profile_frames` from https://github.com/ruby/ruby/pull/9310 into our own custom copy of that function.

**Motivation:**

As explained in the comment, the situation being handled does not yet happen with dd-trace-rb in practice since we don't support profiling with MN threads enabled, but since we want to try supporting it at some point, I've gone ahead and imported the fix.

**Additional Notes:**

N/A

**How to test the change?**

This is a bit awkward to test, so didn't add any coverage.

**For Datadog employees:**
- [ ] If this PR touches code that signs or publishes builds or packages, or handles
credentials of any kind, I've requested a review from `@DataDog/security-design-and-guidance`.
- [x] This PR doesn't touch any of that.
