### PR TITLE
[NO-TICKET] Bump debase-ruby_core_source dependency to 3.3.0

### DIFF
--- a/ddtrace.gemspec
+++ b/ddtrace.gemspec
@@ -59,7 +59,7 @@ Gem::Specification.new do |spec|
   # Used by the profiler native extension to support Ruby < 2.6 and > 3.2
   #
   # We decided to pin it at the latest available version and will manually bump the dependency as needed.
-  spec.add_dependency 'debase-ruby_core_source', '= 3.2.3'
+  spec.add_dependency 'debase-ruby_core_source', '= 3.3.0'
 
   # Used by appsec
   spec.add_dependency 'libddwaf', '~> 1.14.0.0.0'

--- a/gemfiles/jruby_9.2.21.0_sinatra.gemfile.lock
+++ b/gemfiles/jruby_9.2.21.0_sinatra.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.18.0)
       datadog-ci (~> 0.2.0)
-      debase-ruby_core_source (= 3.2.3)
+      debase-ruby_core_source (= 3.3.0)
       libdatadog (~> 5.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
@@ -38,7 +38,7 @@ GEM
       rexml
     cri (2.15.11)
     datadog-ci (0.2.0)
-    debase-ruby_core_source (3.2.3)
+    debase-ruby_core_source (3.3.0)
     diff-lcs (1.5.0)
     docile (1.4.0)
     dogstatsd-ruby (5.5.0)

--- a/gemfiles/jruby_9.2_activesupport.gemfile.lock
+++ b/gemfiles/jruby_9.2_activesupport.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.18.0)
       datadog-ci (~> 0.5.0)
-      debase-ruby_core_source (= 3.2.3)
+      debase-ruby_core_source (= 3.3.0)
       libdatadog (~> 5.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
@@ -67,7 +67,7 @@ GEM
     cri (2.15.11)
     datadog-ci (0.5.0)
       msgpack
-    debase-ruby_core_source (3.2.3)
+    debase-ruby_core_source (3.3.0)
     diff-lcs (1.5.0)
     digest-crc (0.6.5)
       rake (>= 12.0.0, < 14.0.0)

--- a/gemfiles/jruby_9.2_aws.gemfile.lock
+++ b/gemfiles/jruby_9.2_aws.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.18.0)
       datadog-ci (~> 0.5.0)
-      debase-ruby_core_source (= 3.2.3)
+      debase-ruby_core_source (= 3.3.0)
       libdatadog (~> 5.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
@@ -1460,7 +1460,7 @@ GEM
     cri (2.15.11)
     datadog-ci (0.5.0)
       msgpack
-    debase-ruby_core_source (3.2.3)
+    debase-ruby_core_source (3.3.0)
     diff-lcs (1.5.0)
     docile (1.4.0)
     dogstatsd-ruby (5.6.0)

--- a/gemfiles/jruby_9.2_contrib.gemfile.lock
+++ b/gemfiles/jruby_9.2_contrib.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.18.0)
       datadog-ci (~> 0.5.0)
-      debase-ruby_core_source (= 3.2.3)
+      debase-ruby_core_source (= 3.3.0)
       libdatadog (~> 5.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
@@ -46,7 +46,7 @@ GEM
     dalli (3.2.0)
     datadog-ci (0.5.0)
       msgpack
-    debase-ruby_core_source (3.2.3)
+    debase-ruby_core_source (3.3.0)
     diff-lcs (1.5.0)
     docile (1.4.0)
     dogstatsd-ruby (5.6.0)

--- a/gemfiles/jruby_9.2_contrib_old.gemfile.lock
+++ b/gemfiles/jruby_9.2_contrib_old.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.18.0)
       datadog-ci (~> 0.5.0)
-      debase-ruby_core_source (= 3.2.3)
+      debase-ruby_core_source (= 3.3.0)
       libdatadog (~> 5.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
@@ -40,7 +40,7 @@ GEM
     dalli (2.7.11)
     datadog-ci (0.5.0)
       msgpack
-    debase-ruby_core_source (3.2.3)
+    debase-ruby_core_source (3.3.0)
     diff-lcs (1.5.0)
     docile (1.4.0)
     dogstatsd-ruby (5.5.0)

--- a/gemfiles/jruby_9.2_core_old.gemfile.lock
+++ b/gemfiles/jruby_9.2_core_old.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.18.0)
       datadog-ci (~> 0.5.0)
-      debase-ruby_core_source (= 3.2.3)
+      debase-ruby_core_source (= 3.3.0)
       libdatadog (~> 5.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
@@ -39,7 +39,7 @@ GEM
     cri (2.15.11)
     datadog-ci (0.5.0)
       msgpack
-    debase-ruby_core_source (3.2.3)
+    debase-ruby_core_source (3.3.0)
     diff-lcs (1.5.0)
     docile (1.4.0)
     dogstatsd-ruby (4.8.3)

--- a/gemfiles/jruby_9.2_elasticsearch_7.gemfile.lock
+++ b/gemfiles/jruby_9.2_elasticsearch_7.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.18.0)
       datadog-ci (~> 0.5.0)
-      debase-ruby_core_source (= 3.2.3)
+      debase-ruby_core_source (= 3.3.0)
       libdatadog (~> 5.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
@@ -40,7 +40,7 @@ GEM
     cri (2.15.11)
     datadog-ci (0.5.0)
       msgpack
-    debase-ruby_core_source (3.2.3)
+    debase-ruby_core_source (3.3.0)
     diff-lcs (1.5.0)
     docile (1.4.0)
     dogstatsd-ruby (5.6.1)

--- a/gemfiles/jruby_9.2_elasticsearch_8.gemfile.lock
+++ b/gemfiles/jruby_9.2_elasticsearch_8.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.18.0)
       datadog-ci (~> 0.5.0)
-      debase-ruby_core_source (= 3.2.3)
+      debase-ruby_core_source (= 3.3.0)
       libdatadog (~> 5.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
@@ -40,7 +40,7 @@ GEM
     cri (2.15.11)
     datadog-ci (0.5.0)
       msgpack
-    debase-ruby_core_source (3.2.3)
+    debase-ruby_core_source (3.3.0)
     diff-lcs (1.5.0)
     docile (1.4.0)
     dogstatsd-ruby (5.6.1)

--- a/gemfiles/jruby_9.2_hanami_1.gemfile.lock
+++ b/gemfiles/jruby_9.2_hanami_1.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.18.0)
       datadog-ci (~> 0.5.0)
-      debase-ruby_core_source (= 3.2.3)
+      debase-ruby_core_source (= 3.3.0)
       libdatadog (~> 5.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
@@ -39,7 +39,7 @@ GEM
     cri (2.15.11)
     datadog-ci (0.5.0)
       msgpack
-    debase-ruby_core_source (3.2.3)
+    debase-ruby_core_source (3.3.0)
     diff-lcs (1.5.0)
     digest (3.1.1-java)
     docile (1.4.0)

--- a/gemfiles/jruby_9.2_http.gemfile.lock
+++ b/gemfiles/jruby_9.2_http.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.18.0)
       datadog-ci (~> 0.5.0)
-      debase-ruby_core_source (= 3.2.3)
+      debase-ruby_core_source (= 3.3.0)
       libdatadog (~> 5.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
@@ -39,7 +39,7 @@ GEM
     cri (2.15.11)
     datadog-ci (0.5.0)
       msgpack
-    debase-ruby_core_source (3.2.3)
+    debase-ruby_core_source (3.3.0)
     diff-lcs (1.5.0)
     docile (1.4.0)
     dogstatsd-ruby (5.6.1)

--- a/gemfiles/jruby_9.2_opensearch_2.gemfile.lock
+++ b/gemfiles/jruby_9.2_opensearch_2.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.18.0)
       datadog-ci (~> 0.5.0)
-      debase-ruby_core_source (= 3.2.3)
+      debase-ruby_core_source (= 3.3.0)
       libdatadog (~> 5.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
@@ -40,7 +40,7 @@ GEM
     cri (2.15.11)
     datadog-ci (0.5.0)
       msgpack
-    debase-ruby_core_source (3.2.3)
+    debase-ruby_core_source (3.3.0)
     diff-lcs (1.5.0)
     docile (1.4.0)
     dogstatsd-ruby (5.6.1)

--- a/gemfiles/jruby_9.2_opensearch_3.gemfile.lock
+++ b/gemfiles/jruby_9.2_opensearch_3.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.18.0)
       datadog-ci (~> 0.5.0)
-      debase-ruby_core_source (= 3.2.3)
+      debase-ruby_core_source (= 3.3.0)
       libdatadog (~> 5.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
@@ -40,7 +40,7 @@ GEM
     cri (2.15.11)
     datadog-ci (0.5.0)
       msgpack
-    debase-ruby_core_source (3.2.3)
+    debase-ruby_core_source (3.3.0)
     diff-lcs (1.5.0)
     docile (1.4.0)
     dogstatsd-ruby (5.6.1)

--- a/gemfiles/jruby_9.2_opentracing.gemfile.lock
+++ b/gemfiles/jruby_9.2_opentracing.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.18.0)
       datadog-ci (~> 0.5.0)
-      debase-ruby_core_source (= 3.2.3)
+      debase-ruby_core_source (= 3.3.0)
       libdatadog (~> 5.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
@@ -40,7 +40,7 @@ GEM
     cri (2.15.11)
     datadog-ci (0.5.0)
       msgpack
-    debase-ruby_core_source (3.2.3)
+    debase-ruby_core_source (3.3.0)
     diff-lcs (1.5.0)
     docile (1.4.0)
     dogstatsd-ruby (5.6.1)

--- a/gemfiles/jruby_9.2_rack_1.gemfile.lock
+++ b/gemfiles/jruby_9.2_rack_1.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.18.0)
       datadog-ci (~> 0.5.0)
-      debase-ruby_core_source (= 3.2.3)
+      debase-ruby_core_source (= 3.3.0)
       libdatadog (~> 5.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
@@ -39,7 +39,7 @@ GEM
     cri (2.15.11)
     datadog-ci (0.5.0)
       msgpack
-    debase-ruby_core_source (3.2.3)
+    debase-ruby_core_source (3.3.0)
     diff-lcs (1.5.0)
     docile (1.4.0)
     dogstatsd-ruby (5.6.1)

--- a/gemfiles/jruby_9.2_rack_2.gemfile.lock
+++ b/gemfiles/jruby_9.2_rack_2.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.18.0)
       datadog-ci (~> 0.5.0)
-      debase-ruby_core_source (= 3.2.3)
+      debase-ruby_core_source (= 3.3.0)
       libdatadog (~> 5.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
@@ -39,7 +39,7 @@ GEM
     cri (2.15.11)
     datadog-ci (0.5.0)
       msgpack
-    debase-ruby_core_source (3.2.3)
+    debase-ruby_core_source (3.3.0)
     diff-lcs (1.5.0)
     docile (1.4.0)
     dogstatsd-ruby (5.6.1)

--- a/gemfiles/jruby_9.2_rack_3.gemfile.lock
+++ b/gemfiles/jruby_9.2_rack_3.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.18.0)
       datadog-ci (~> 0.5.0)
-      debase-ruby_core_source (= 3.2.3)
+      debase-ruby_core_source (= 3.3.0)
       libdatadog (~> 5.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
@@ -39,7 +39,7 @@ GEM
     cri (2.15.11)
     datadog-ci (0.5.0)
       msgpack
-    debase-ruby_core_source (3.2.3)
+    debase-ruby_core_source (3.3.0)
     diff-lcs (1.5.0)
     docile (1.4.0)
     dogstatsd-ruby (5.6.1)

--- a/gemfiles/jruby_9.2_rails5_mysql2.gemfile.lock
+++ b/gemfiles/jruby_9.2_rails5_mysql2.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.18.0)
       datadog-ci (~> 0.5.0)
-      debase-ruby_core_source (= 3.2.3)
+      debase-ruby_core_source (= 3.3.0)
       libdatadog (~> 5.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
@@ -87,7 +87,7 @@ GEM
     cri (2.15.11)
     datadog-ci (0.5.0)
       msgpack
-    debase-ruby_core_source (3.2.3)
+    debase-ruby_core_source (3.3.0)
     diff-lcs (1.5.0)
     docile (1.4.0)
     dogstatsd-ruby (5.5.0)

--- a/gemfiles/jruby_9.2_rails5_postgres.gemfile.lock
+++ b/gemfiles/jruby_9.2_rails5_postgres.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.18.0)
       datadog-ci (~> 0.5.0)
-      debase-ruby_core_source (= 3.2.3)
+      debase-ruby_core_source (= 3.3.0)
       libdatadog (~> 5.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
@@ -87,7 +87,7 @@ GEM
     cri (2.15.11)
     datadog-ci (0.5.0)
       msgpack
-    debase-ruby_core_source (3.2.3)
+    debase-ruby_core_source (3.3.0)
     diff-lcs (1.5.0)
     digest (3.1.1-java)
     docile (1.4.0)

--- a/gemfiles/jruby_9.2_rails5_postgres_redis.gemfile.lock
+++ b/gemfiles/jruby_9.2_rails5_postgres_redis.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.18.0)
       datadog-ci (~> 0.5.0)
-      debase-ruby_core_source (= 3.2.3)
+      debase-ruby_core_source (= 3.3.0)
       libdatadog (~> 5.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
@@ -88,7 +88,7 @@ GEM
     cri (2.15.11)
     datadog-ci (0.5.0)
       msgpack
-    debase-ruby_core_source (3.2.3)
+    debase-ruby_core_source (3.3.0)
     diff-lcs (1.5.0)
     digest (3.1.1-java)
     docile (1.4.0)

--- a/gemfiles/jruby_9.2_rails5_postgres_redis_activesupport.gemfile.lock
+++ b/gemfiles/jruby_9.2_rails5_postgres_redis_activesupport.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.18.0)
       datadog-ci (~> 0.5.0)
-      debase-ruby_core_source (= 3.2.3)
+      debase-ruby_core_source (= 3.3.0)
       libdatadog (~> 5.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
@@ -87,7 +87,7 @@ GEM
     cri (2.15.11)
     datadog-ci (0.5.0)
       msgpack
-    debase-ruby_core_source (3.2.3)
+    debase-ruby_core_source (3.3.0)
     diff-lcs (1.5.0)
     digest (3.1.1-java)
     docile (1.4.0)

--- a/gemfiles/jruby_9.2_rails5_postgres_sidekiq.gemfile.lock
+++ b/gemfiles/jruby_9.2_rails5_postgres_sidekiq.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.18.0)
       datadog-ci (~> 0.5.0)
-      debase-ruby_core_source (= 3.2.3)
+      debase-ruby_core_source (= 3.3.0)
       libdatadog (~> 5.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
@@ -88,7 +88,7 @@ GEM
     cri (2.15.11)
     datadog-ci (0.5.0)
       msgpack
-    debase-ruby_core_source (3.2.3)
+    debase-ruby_core_source (3.3.0)
     diff-lcs (1.5.0)
     digest (3.1.1-java)
     docile (1.4.0)

--- a/gemfiles/jruby_9.2_rails5_semantic_logger.gemfile.lock
+++ b/gemfiles/jruby_9.2_rails5_semantic_logger.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.18.0)
       datadog-ci (~> 0.5.0)
-      debase-ruby_core_source (= 3.2.3)
+      debase-ruby_core_source (= 3.3.0)
       libdatadog (~> 5.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
@@ -87,7 +87,7 @@ GEM
     cri (2.15.11)
     datadog-ci (0.5.0)
       msgpack
-    debase-ruby_core_source (3.2.3)
+    debase-ruby_core_source (3.3.0)
     diff-lcs (1.5.0)
     digest (3.1.1-java)
     docile (1.4.0)

--- a/gemfiles/jruby_9.2_rails61_mysql2.gemfile.lock
+++ b/gemfiles/jruby_9.2_rails61_mysql2.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.18.0)
       datadog-ci (~> 0.5.0)
-      debase-ruby_core_source (= 3.2.3)
+      debase-ruby_core_source (= 3.3.0)
       libdatadog (~> 5.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
@@ -104,7 +104,7 @@ GEM
     cri (2.15.11)
     datadog-ci (0.5.0)
       msgpack
-    debase-ruby_core_source (3.2.3)
+    debase-ruby_core_source (3.3.0)
     diff-lcs (1.5.0)
     docile (1.4.0)
     dogstatsd-ruby (5.5.0)

--- a/gemfiles/jruby_9.2_rails61_postgres.gemfile.lock
+++ b/gemfiles/jruby_9.2_rails61_postgres.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.18.0)
       datadog-ci (~> 0.5.0)
-      debase-ruby_core_source (= 3.2.3)
+      debase-ruby_core_source (= 3.3.0)
       libdatadog (~> 5.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
@@ -104,7 +104,7 @@ GEM
     cri (2.15.11)
     datadog-ci (0.5.0)
       msgpack
-    debase-ruby_core_source (3.2.3)
+    debase-ruby_core_source (3.3.0)
     diff-lcs (1.5.0)
     digest (3.1.1-java)
     docile (1.4.0)

--- a/gemfiles/jruby_9.2_rails61_postgres_redis.gemfile.lock
+++ b/gemfiles/jruby_9.2_rails61_postgres_redis.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.18.0)
       datadog-ci (~> 0.5.0)
-      debase-ruby_core_source (= 3.2.3)
+      debase-ruby_core_source (= 3.3.0)
       libdatadog (~> 5.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
@@ -105,7 +105,7 @@ GEM
     cri (2.15.11)
     datadog-ci (0.5.0)
       msgpack
-    debase-ruby_core_source (3.2.3)
+    debase-ruby_core_source (3.3.0)
     diff-lcs (1.5.0)
     digest (3.1.1-java)
     docile (1.4.0)

--- a/gemfiles/jruby_9.2_rails61_postgres_sidekiq.gemfile.lock
+++ b/gemfiles/jruby_9.2_rails61_postgres_sidekiq.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.18.0)
       datadog-ci (~> 0.5.0)
-      debase-ruby_core_source (= 3.2.3)
+      debase-ruby_core_source (= 3.3.0)
       libdatadog (~> 5.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
@@ -105,7 +105,7 @@ GEM
     cri (2.15.11)
     datadog-ci (0.5.0)
       msgpack
-    debase-ruby_core_source (3.2.3)
+    debase-ruby_core_source (3.3.0)
     diff-lcs (1.5.0)
     digest (3.1.1-java)
     docile (1.4.0)

--- a/gemfiles/jruby_9.2_rails61_semantic_logger.gemfile.lock
+++ b/gemfiles/jruby_9.2_rails61_semantic_logger.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.18.0)
       datadog-ci (~> 0.5.0)
-      debase-ruby_core_source (= 3.2.3)
+      debase-ruby_core_source (= 3.3.0)
       libdatadog (~> 5.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
@@ -104,7 +104,7 @@ GEM
     cri (2.15.11)
     datadog-ci (0.5.0)
       msgpack
-    debase-ruby_core_source (3.2.3)
+    debase-ruby_core_source (3.3.0)
     diff-lcs (1.5.0)
     digest (3.1.1-java)
     docile (1.4.0)

--- a/gemfiles/jruby_9.2_rails6_mysql2.gemfile.lock
+++ b/gemfiles/jruby_9.2_rails6_mysql2.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.18.0)
       datadog-ci (~> 0.5.0)
-      debase-ruby_core_source (= 3.2.3)
+      debase-ruby_core_source (= 3.3.0)
       libdatadog (~> 5.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
@@ -100,7 +100,7 @@ GEM
     cri (2.15.11)
     datadog-ci (0.5.0)
       msgpack
-    debase-ruby_core_source (3.2.3)
+    debase-ruby_core_source (3.3.0)
     diff-lcs (1.5.0)
     docile (1.4.0)
     dogstatsd-ruby (5.5.0)

--- a/gemfiles/jruby_9.2_rails6_postgres.gemfile.lock
+++ b/gemfiles/jruby_9.2_rails6_postgres.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.18.0)
       datadog-ci (~> 0.5.0)
-      debase-ruby_core_source (= 3.2.3)
+      debase-ruby_core_source (= 3.3.0)
       libdatadog (~> 5.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
@@ -100,7 +100,7 @@ GEM
     cri (2.15.11)
     datadog-ci (0.5.0)
       msgpack
-    debase-ruby_core_source (3.2.3)
+    debase-ruby_core_source (3.3.0)
     diff-lcs (1.5.0)
     digest (3.1.1-java)
     docile (1.4.0)

--- a/gemfiles/jruby_9.2_rails6_postgres_redis.gemfile.lock
+++ b/gemfiles/jruby_9.2_rails6_postgres_redis.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.18.0)
       datadog-ci (~> 0.5.0)
-      debase-ruby_core_source (= 3.2.3)
+      debase-ruby_core_source (= 3.3.0)
       libdatadog (~> 5.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
@@ -101,7 +101,7 @@ GEM
     cri (2.15.11)
     datadog-ci (0.5.0)
       msgpack
-    debase-ruby_core_source (3.2.3)
+    debase-ruby_core_source (3.3.0)
     diff-lcs (1.5.0)
     digest (3.1.1-java)
     docile (1.4.0)

--- a/gemfiles/jruby_9.2_rails6_postgres_redis_activesupport.gemfile.lock
+++ b/gemfiles/jruby_9.2_rails6_postgres_redis_activesupport.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.18.0)
       datadog-ci (~> 0.5.0)
-      debase-ruby_core_source (= 3.2.3)
+      debase-ruby_core_source (= 3.3.0)
       libdatadog (~> 5.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
@@ -100,7 +100,7 @@ GEM
     cri (2.15.11)
     datadog-ci (0.5.0)
       msgpack
-    debase-ruby_core_source (3.2.3)
+    debase-ruby_core_source (3.3.0)
     diff-lcs (1.5.0)
     digest (3.1.1-java)
     docile (1.4.0)

--- a/gemfiles/jruby_9.2_rails6_postgres_sidekiq.gemfile.lock
+++ b/gemfiles/jruby_9.2_rails6_postgres_sidekiq.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.18.0)
       datadog-ci (~> 0.5.0)
-      debase-ruby_core_source (= 3.2.3)
+      debase-ruby_core_source (= 3.3.0)
       libdatadog (~> 5.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
@@ -101,7 +101,7 @@ GEM
     cri (2.15.11)
     datadog-ci (0.5.0)
       msgpack
-    debase-ruby_core_source (3.2.3)
+    debase-ruby_core_source (3.3.0)
     diff-lcs (1.5.0)
     digest (3.1.1-java)
     docile (1.4.0)

--- a/gemfiles/jruby_9.2_rails6_semantic_logger.gemfile.lock
+++ b/gemfiles/jruby_9.2_rails6_semantic_logger.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.18.0)
       datadog-ci (~> 0.5.0)
-      debase-ruby_core_source (= 3.2.3)
+      debase-ruby_core_source (= 3.3.0)
       libdatadog (~> 5.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
@@ -100,7 +100,7 @@ GEM
     cri (2.15.11)
     datadog-ci (0.5.0)
       msgpack
-    debase-ruby_core_source (3.2.3)
+    debase-ruby_core_source (3.3.0)
     diff-lcs (1.5.0)
     digest (3.1.1-java)
     docile (1.4.0)

--- a/gemfiles/jruby_9.2_redis_3.gemfile.lock
+++ b/gemfiles/jruby_9.2_redis_3.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.18.0)
       datadog-ci (~> 0.5.0)
-      debase-ruby_core_source (= 3.2.3)
+      debase-ruby_core_source (= 3.3.0)
       libdatadog (~> 5.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
@@ -39,7 +39,7 @@ GEM
     cri (2.15.11)
     datadog-ci (0.5.0)
       msgpack
-    debase-ruby_core_source (3.2.3)
+    debase-ruby_core_source (3.3.0)
     diff-lcs (1.5.0)
     docile (1.4.0)
     dogstatsd-ruby (5.5.0)

--- a/gemfiles/jruby_9.2_redis_4.gemfile.lock
+++ b/gemfiles/jruby_9.2_redis_4.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.18.0)
       datadog-ci (~> 0.5.0)
-      debase-ruby_core_source (= 3.2.3)
+      debase-ruby_core_source (= 3.3.0)
       libdatadog (~> 5.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
@@ -39,7 +39,7 @@ GEM
     cri (2.15.11)
     datadog-ci (0.5.0)
       msgpack
-    debase-ruby_core_source (3.2.3)
+    debase-ruby_core_source (3.3.0)
     diff-lcs (1.5.0)
     docile (1.4.0)
     dogstatsd-ruby (5.5.0)

--- a/gemfiles/jruby_9.2_redis_5.gemfile.lock
+++ b/gemfiles/jruby_9.2_redis_5.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.18.0)
       datadog-ci (~> 0.5.0)
-      debase-ruby_core_source (= 3.2.3)
+      debase-ruby_core_source (= 3.3.0)
       libdatadog (~> 5.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
@@ -40,7 +40,7 @@ GEM
     cri (2.15.11)
     datadog-ci (0.5.0)
       msgpack
-    debase-ruby_core_source (3.2.3)
+    debase-ruby_core_source (3.3.0)
     diff-lcs (1.5.0)
     docile (1.4.0)
     dogstatsd-ruby (5.5.0)

--- a/gemfiles/jruby_9.2_relational_db.gemfile.lock
+++ b/gemfiles/jruby_9.2_relational_db.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.18.0)
       datadog-ci (~> 0.5.0)
-      debase-ruby_core_source (= 3.2.3)
+      debase-ruby_core_source (= 3.3.0)
       libdatadog (~> 5.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
@@ -62,7 +62,7 @@ GEM
     cri (2.15.11)
     datadog-ci (0.5.0)
       msgpack
-    debase-ruby_core_source (3.2.3)
+    debase-ruby_core_source (3.3.0)
     delayed_job (4.1.11)
       activesupport (>= 3.0, < 8.0)
     delayed_job_active_record (4.1.7)

--- a/gemfiles/jruby_9.2_resque2_redis3.gemfile.lock
+++ b/gemfiles/jruby_9.2_resque2_redis3.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.18.0)
       datadog-ci (~> 0.5.0)
-      debase-ruby_core_source (= 3.2.3)
+      debase-ruby_core_source (= 3.3.0)
       libdatadog (~> 5.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
@@ -39,7 +39,7 @@ GEM
     cri (2.15.11)
     datadog-ci (0.5.0)
       msgpack
-    debase-ruby_core_source (3.2.3)
+    debase-ruby_core_source (3.3.0)
     diff-lcs (1.5.0)
     docile (1.4.0)
     dogstatsd-ruby (5.5.0)

--- a/gemfiles/jruby_9.2_resque2_redis4.gemfile.lock
+++ b/gemfiles/jruby_9.2_resque2_redis4.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.18.0)
       datadog-ci (~> 0.5.0)
-      debase-ruby_core_source (= 3.2.3)
+      debase-ruby_core_source (= 3.3.0)
       libdatadog (~> 5.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
@@ -40,7 +40,7 @@ GEM
     cri (2.15.11)
     datadog-ci (0.5.0)
       msgpack
-    debase-ruby_core_source (3.2.3)
+    debase-ruby_core_source (3.3.0)
     diff-lcs (1.5.0)
     docile (1.4.0)
     dogstatsd-ruby (5.5.0)

--- a/gemfiles/jruby_9.2_sinatra.gemfile.lock
+++ b/gemfiles/jruby_9.2_sinatra.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.18.0)
       datadog-ci (~> 0.5.0)
-      debase-ruby_core_source (= 3.2.3)
+      debase-ruby_core_source (= 3.3.0)
       libdatadog (~> 5.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
@@ -39,7 +39,7 @@ GEM
     cri (2.15.11)
     datadog-ci (0.5.0)
       msgpack
-    debase-ruby_core_source (3.2.3)
+    debase-ruby_core_source (3.3.0)
     diff-lcs (1.5.0)
     docile (1.4.0)
     dogstatsd-ruby (5.5.0)

--- a/gemfiles/jruby_9.3_activesupport.gemfile.lock
+++ b/gemfiles/jruby_9.3_activesupport.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.18.0)
       datadog-ci (~> 0.5.0)
-      debase-ruby_core_source (= 3.2.3)
+      debase-ruby_core_source (= 3.3.0)
       libdatadog (~> 5.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
@@ -69,7 +69,7 @@ GEM
     cri (2.15.11)
     datadog-ci (0.5.0)
       msgpack
-    debase-ruby_core_source (3.2.3)
+    debase-ruby_core_source (3.3.0)
     diff-lcs (1.5.0)
     digest-crc (0.6.5)
       rake (>= 12.0.0, < 14.0.0)

--- a/gemfiles/jruby_9.3_aws.gemfile.lock
+++ b/gemfiles/jruby_9.3_aws.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.18.0)
       datadog-ci (~> 0.5.0)
-      debase-ruby_core_source (= 3.2.3)
+      debase-ruby_core_source (= 3.3.0)
       libdatadog (~> 5.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
@@ -1461,7 +1461,7 @@ GEM
     cri (2.15.11)
     datadog-ci (0.5.0)
       msgpack
-    debase-ruby_core_source (3.2.3)
+    debase-ruby_core_source (3.3.0)
     diff-lcs (1.5.0)
     docile (1.4.0)
     dogstatsd-ruby (5.6.0)

--- a/gemfiles/jruby_9.3_contrib.gemfile.lock
+++ b/gemfiles/jruby_9.3_contrib.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.18.0)
       datadog-ci (~> 0.5.0)
-      debase-ruby_core_source (= 3.2.3)
+      debase-ruby_core_source (= 3.3.0)
       libdatadog (~> 5.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
@@ -47,7 +47,7 @@ GEM
     dalli (3.2.3)
     datadog-ci (0.5.0)
       msgpack
-    debase-ruby_core_source (3.2.3)
+    debase-ruby_core_source (3.3.0)
     diff-lcs (1.5.0)
     docile (1.4.0)
     dogstatsd-ruby (5.6.1)

--- a/gemfiles/jruby_9.3_contrib_old.gemfile.lock
+++ b/gemfiles/jruby_9.3_contrib_old.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.18.0)
       datadog-ci (~> 0.5.0)
-      debase-ruby_core_source (= 3.2.3)
+      debase-ruby_core_source (= 3.3.0)
       libdatadog (~> 5.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
@@ -41,7 +41,7 @@ GEM
     dalli (2.7.11)
     datadog-ci (0.5.0)
       msgpack
-    debase-ruby_core_source (3.2.3)
+    debase-ruby_core_source (3.3.0)
     diff-lcs (1.5.0)
     docile (1.4.0)
     dogstatsd-ruby (5.6.1)

--- a/gemfiles/jruby_9.3_core_old.gemfile.lock
+++ b/gemfiles/jruby_9.3_core_old.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.18.0)
       datadog-ci (~> 0.5.0)
-      debase-ruby_core_source (= 3.2.3)
+      debase-ruby_core_source (= 3.3.0)
       libdatadog (~> 5.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
@@ -40,7 +40,7 @@ GEM
     cri (2.15.11)
     datadog-ci (0.5.0)
       msgpack
-    debase-ruby_core_source (3.2.3)
+    debase-ruby_core_source (3.3.0)
     diff-lcs (1.5.0)
     docile (1.4.0)
     dogstatsd-ruby (4.8.3)

--- a/gemfiles/jruby_9.3_elasticsearch_7.gemfile.lock
+++ b/gemfiles/jruby_9.3_elasticsearch_7.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.18.0)
       datadog-ci (~> 0.5.0)
-      debase-ruby_core_source (= 3.2.3)
+      debase-ruby_core_source (= 3.3.0)
       libdatadog (~> 5.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
@@ -41,7 +41,7 @@ GEM
     cri (2.15.11)
     datadog-ci (0.5.0)
       msgpack
-    debase-ruby_core_source (3.2.3)
+    debase-ruby_core_source (3.3.0)
     diff-lcs (1.5.0)
     docile (1.4.0)
     dogstatsd-ruby (5.6.1)

--- a/gemfiles/jruby_9.3_elasticsearch_8.gemfile.lock
+++ b/gemfiles/jruby_9.3_elasticsearch_8.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.18.0)
       datadog-ci (~> 0.5.0)
-      debase-ruby_core_source (= 3.2.3)
+      debase-ruby_core_source (= 3.3.0)
       libdatadog (~> 5.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
@@ -42,7 +42,7 @@ GEM
     cri (2.15.11)
     datadog-ci (0.5.0)
       msgpack
-    debase-ruby_core_source (3.2.3)
+    debase-ruby_core_source (3.3.0)
     diff-lcs (1.5.0)
     docile (1.4.0)
     dogstatsd-ruby (5.6.1)

--- a/gemfiles/jruby_9.3_hanami_1.gemfile.lock
+++ b/gemfiles/jruby_9.3_hanami_1.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.18.0)
       datadog-ci (~> 0.5.0)
-      debase-ruby_core_source (= 3.2.3)
+      debase-ruby_core_source (= 3.3.0)
       libdatadog (~> 5.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
@@ -41,7 +41,7 @@ GEM
     datadog-ci (0.5.0)
       msgpack
     date (3.3.3-java)
-    debase-ruby_core_source (3.2.3)
+    debase-ruby_core_source (3.3.0)
     diff-lcs (1.5.0)
     docile (1.4.0)
     dogstatsd-ruby (5.6.1)

--- a/gemfiles/jruby_9.3_http.gemfile.lock
+++ b/gemfiles/jruby_9.3_http.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.18.0)
       datadog-ci (~> 0.5.0)
-      debase-ruby_core_source (= 3.2.3)
+      debase-ruby_core_source (= 3.3.0)
       libdatadog (~> 5.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
@@ -40,7 +40,7 @@ GEM
     cri (2.15.11)
     datadog-ci (0.5.0)
       msgpack
-    debase-ruby_core_source (3.2.3)
+    debase-ruby_core_source (3.3.0)
     diff-lcs (1.5.0)
     docile (1.4.0)
     dogstatsd-ruby (5.6.1)

--- a/gemfiles/jruby_9.3_opensearch_2.gemfile.lock
+++ b/gemfiles/jruby_9.3_opensearch_2.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.18.0)
       datadog-ci (~> 0.5.0)
-      debase-ruby_core_source (= 3.2.3)
+      debase-ruby_core_source (= 3.3.0)
       libdatadog (~> 5.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
@@ -42,7 +42,7 @@ GEM
     cri (2.15.11)
     datadog-ci (0.5.0)
       msgpack
-    debase-ruby_core_source (3.2.3)
+    debase-ruby_core_source (3.3.0)
     diff-lcs (1.5.0)
     docile (1.4.0)
     dogstatsd-ruby (5.6.1)

--- a/gemfiles/jruby_9.3_opensearch_3.gemfile.lock
+++ b/gemfiles/jruby_9.3_opensearch_3.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.18.0)
       datadog-ci (~> 0.5.0)
-      debase-ruby_core_source (= 3.2.3)
+      debase-ruby_core_source (= 3.3.0)
       libdatadog (~> 5.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
@@ -42,7 +42,7 @@ GEM
     cri (2.15.11)
     datadog-ci (0.5.0)
       msgpack
-    debase-ruby_core_source (3.2.3)
+    debase-ruby_core_source (3.3.0)
     diff-lcs (1.5.0)
     docile (1.4.0)
     dogstatsd-ruby (5.6.1)

--- a/gemfiles/jruby_9.3_opentracing.gemfile.lock
+++ b/gemfiles/jruby_9.3_opentracing.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.18.0)
       datadog-ci (~> 0.5.0)
-      debase-ruby_core_source (= 3.2.3)
+      debase-ruby_core_source (= 3.3.0)
       libdatadog (~> 5.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
@@ -41,7 +41,7 @@ GEM
     cri (2.15.11)
     datadog-ci (0.5.0)
       msgpack
-    debase-ruby_core_source (3.2.3)
+    debase-ruby_core_source (3.3.0)
     diff-lcs (1.5.0)
     docile (1.4.0)
     dogstatsd-ruby (5.6.1)

--- a/gemfiles/jruby_9.3_rack_1.gemfile.lock
+++ b/gemfiles/jruby_9.3_rack_1.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.18.0)
       datadog-ci (~> 0.5.0)
-      debase-ruby_core_source (= 3.2.3)
+      debase-ruby_core_source (= 3.3.0)
       libdatadog (~> 5.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
@@ -40,7 +40,7 @@ GEM
     cri (2.15.11)
     datadog-ci (0.5.0)
       msgpack
-    debase-ruby_core_source (3.2.3)
+    debase-ruby_core_source (3.3.0)
     diff-lcs (1.5.0)
     docile (1.4.0)
     dogstatsd-ruby (5.6.1)

--- a/gemfiles/jruby_9.3_rack_2.gemfile.lock
+++ b/gemfiles/jruby_9.3_rack_2.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.18.0)
       datadog-ci (~> 0.5.0)
-      debase-ruby_core_source (= 3.2.3)
+      debase-ruby_core_source (= 3.3.0)
       libdatadog (~> 5.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
@@ -40,7 +40,7 @@ GEM
     cri (2.15.11)
     datadog-ci (0.5.0)
       msgpack
-    debase-ruby_core_source (3.2.3)
+    debase-ruby_core_source (3.3.0)
     diff-lcs (1.5.0)
     docile (1.4.0)
     dogstatsd-ruby (5.6.1)

--- a/gemfiles/jruby_9.3_rack_3.gemfile.lock
+++ b/gemfiles/jruby_9.3_rack_3.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.18.0)
       datadog-ci (~> 0.5.0)
-      debase-ruby_core_source (= 3.2.3)
+      debase-ruby_core_source (= 3.3.0)
       libdatadog (~> 5.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
@@ -40,7 +40,7 @@ GEM
     cri (2.15.11)
     datadog-ci (0.5.0)
       msgpack
-    debase-ruby_core_source (3.2.3)
+    debase-ruby_core_source (3.3.0)
     diff-lcs (1.5.0)
     docile (1.4.0)
     dogstatsd-ruby (5.6.1)

--- a/gemfiles/jruby_9.3_rails5_mysql2.gemfile.lock
+++ b/gemfiles/jruby_9.3_rails5_mysql2.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.18.0)
       datadog-ci (~> 0.5.0)
-      debase-ruby_core_source (= 3.2.3)
+      debase-ruby_core_source (= 3.3.0)
       libdatadog (~> 5.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
@@ -89,7 +89,7 @@ GEM
     datadog-ci (0.5.0)
       msgpack
     date (3.3.3-java)
-    debase-ruby_core_source (3.2.3)
+    debase-ruby_core_source (3.3.0)
     diff-lcs (1.5.0)
     docile (1.4.0)
     dogstatsd-ruby (5.6.1)

--- a/gemfiles/jruby_9.3_rails5_postgres.gemfile.lock
+++ b/gemfiles/jruby_9.3_rails5_postgres.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.18.0)
       datadog-ci (~> 0.5.0)
-      debase-ruby_core_source (= 3.2.3)
+      debase-ruby_core_source (= 3.3.0)
       libdatadog (~> 5.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
@@ -89,7 +89,7 @@ GEM
     datadog-ci (0.5.0)
       msgpack
     date (3.3.3-java)
-    debase-ruby_core_source (3.2.3)
+    debase-ruby_core_source (3.3.0)
     diff-lcs (1.5.0)
     docile (1.4.0)
     dogstatsd-ruby (5.6.1)

--- a/gemfiles/jruby_9.3_rails5_postgres_redis.gemfile.lock
+++ b/gemfiles/jruby_9.3_rails5_postgres_redis.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.18.0)
       datadog-ci (~> 0.5.0)
-      debase-ruby_core_source (= 3.2.3)
+      debase-ruby_core_source (= 3.3.0)
       libdatadog (~> 5.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
@@ -89,7 +89,7 @@ GEM
     datadog-ci (0.5.0)
       msgpack
     date (3.3.3-java)
-    debase-ruby_core_source (3.2.3)
+    debase-ruby_core_source (3.3.0)
     diff-lcs (1.5.0)
     docile (1.4.0)
     dogstatsd-ruby (5.6.1)

--- a/gemfiles/jruby_9.3_rails5_postgres_redis_activesupport.gemfile.lock
+++ b/gemfiles/jruby_9.3_rails5_postgres_redis_activesupport.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.18.0)
       datadog-ci (~> 0.5.0)
-      debase-ruby_core_source (= 3.2.3)
+      debase-ruby_core_source (= 3.3.0)
       libdatadog (~> 5.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
@@ -89,7 +89,7 @@ GEM
     datadog-ci (0.5.0)
       msgpack
     date (3.3.3-java)
-    debase-ruby_core_source (3.2.3)
+    debase-ruby_core_source (3.3.0)
     diff-lcs (1.5.0)
     docile (1.4.0)
     dogstatsd-ruby (5.6.1)

--- a/gemfiles/jruby_9.3_rails5_postgres_sidekiq.gemfile.lock
+++ b/gemfiles/jruby_9.3_rails5_postgres_sidekiq.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.18.0)
       datadog-ci (~> 0.5.0)
-      debase-ruby_core_source (= 3.2.3)
+      debase-ruby_core_source (= 3.3.0)
       libdatadog (~> 5.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
@@ -90,7 +90,7 @@ GEM
     datadog-ci (0.5.0)
       msgpack
     date (3.3.3-java)
-    debase-ruby_core_source (3.2.3)
+    debase-ruby_core_source (3.3.0)
     diff-lcs (1.5.0)
     docile (1.4.0)
     dogstatsd-ruby (5.6.1)

--- a/gemfiles/jruby_9.3_rails5_semantic_logger.gemfile.lock
+++ b/gemfiles/jruby_9.3_rails5_semantic_logger.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.18.0)
       datadog-ci (~> 0.5.0)
-      debase-ruby_core_source (= 3.2.3)
+      debase-ruby_core_source (= 3.3.0)
       libdatadog (~> 5.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
@@ -89,7 +89,7 @@ GEM
     datadog-ci (0.5.0)
       msgpack
     date (3.3.3-java)
-    debase-ruby_core_source (3.2.3)
+    debase-ruby_core_source (3.3.0)
     diff-lcs (1.5.0)
     docile (1.4.0)
     dogstatsd-ruby (5.6.1)

--- a/gemfiles/jruby_9.3_rails61_mysql2.gemfile.lock
+++ b/gemfiles/jruby_9.3_rails61_mysql2.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.18.0)
       datadog-ci (~> 0.5.0)
-      debase-ruby_core_source (= 3.2.3)
+      debase-ruby_core_source (= 3.3.0)
       libdatadog (~> 5.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
@@ -106,7 +106,7 @@ GEM
     datadog-ci (0.5.0)
       msgpack
     date (3.3.3-java)
-    debase-ruby_core_source (3.2.3)
+    debase-ruby_core_source (3.3.0)
     diff-lcs (1.5.0)
     docile (1.4.0)
     dogstatsd-ruby (5.6.1)

--- a/gemfiles/jruby_9.3_rails61_postgres.gemfile.lock
+++ b/gemfiles/jruby_9.3_rails61_postgres.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.18.0)
       datadog-ci (~> 0.5.0)
-      debase-ruby_core_source (= 3.2.3)
+      debase-ruby_core_source (= 3.3.0)
       libdatadog (~> 5.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
@@ -106,7 +106,7 @@ GEM
     datadog-ci (0.5.0)
       msgpack
     date (3.3.3-java)
-    debase-ruby_core_source (3.2.3)
+    debase-ruby_core_source (3.3.0)
     diff-lcs (1.5.0)
     docile (1.4.0)
     dogstatsd-ruby (5.6.1)

--- a/gemfiles/jruby_9.3_rails61_postgres_redis.gemfile.lock
+++ b/gemfiles/jruby_9.3_rails61_postgres_redis.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.18.0)
       datadog-ci (~> 0.5.0)
-      debase-ruby_core_source (= 3.2.3)
+      debase-ruby_core_source (= 3.3.0)
       libdatadog (~> 5.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
@@ -106,7 +106,7 @@ GEM
     datadog-ci (0.5.0)
       msgpack
     date (3.3.3-java)
-    debase-ruby_core_source (3.2.3)
+    debase-ruby_core_source (3.3.0)
     diff-lcs (1.5.0)
     docile (1.4.0)
     dogstatsd-ruby (5.6.1)

--- a/gemfiles/jruby_9.3_rails61_postgres_sidekiq.gemfile.lock
+++ b/gemfiles/jruby_9.3_rails61_postgres_sidekiq.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.18.0)
       datadog-ci (~> 0.5.0)
-      debase-ruby_core_source (= 3.2.3)
+      debase-ruby_core_source (= 3.3.0)
       libdatadog (~> 5.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
@@ -107,7 +107,7 @@ GEM
     datadog-ci (0.5.0)
       msgpack
     date (3.3.3-java)
-    debase-ruby_core_source (3.2.3)
+    debase-ruby_core_source (3.3.0)
     diff-lcs (1.5.0)
     docile (1.4.0)
     dogstatsd-ruby (5.6.1)

--- a/gemfiles/jruby_9.3_rails61_semantic_logger.gemfile.lock
+++ b/gemfiles/jruby_9.3_rails61_semantic_logger.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.18.0)
       datadog-ci (~> 0.5.0)
-      debase-ruby_core_source (= 3.2.3)
+      debase-ruby_core_source (= 3.3.0)
       libdatadog (~> 5.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
@@ -106,7 +106,7 @@ GEM
     datadog-ci (0.5.0)
       msgpack
     date (3.3.3-java)
-    debase-ruby_core_source (3.2.3)
+    debase-ruby_core_source (3.3.0)
     diff-lcs (1.5.0)
     docile (1.4.0)
     dogstatsd-ruby (5.6.1)

--- a/gemfiles/jruby_9.3_rails6_mysql2.gemfile.lock
+++ b/gemfiles/jruby_9.3_rails6_mysql2.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.18.0)
       datadog-ci (~> 0.5.0)
-      debase-ruby_core_source (= 3.2.3)
+      debase-ruby_core_source (= 3.3.0)
       libdatadog (~> 5.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
@@ -102,7 +102,7 @@ GEM
     datadog-ci (0.5.0)
       msgpack
     date (3.3.3-java)
-    debase-ruby_core_source (3.2.3)
+    debase-ruby_core_source (3.3.0)
     diff-lcs (1.5.0)
     docile (1.4.0)
     dogstatsd-ruby (5.6.1)

--- a/gemfiles/jruby_9.3_rails6_postgres.gemfile.lock
+++ b/gemfiles/jruby_9.3_rails6_postgres.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.18.0)
       datadog-ci (~> 0.5.0)
-      debase-ruby_core_source (= 3.2.3)
+      debase-ruby_core_source (= 3.3.0)
       libdatadog (~> 5.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
@@ -102,7 +102,7 @@ GEM
     datadog-ci (0.5.0)
       msgpack
     date (3.3.3-java)
-    debase-ruby_core_source (3.2.3)
+    debase-ruby_core_source (3.3.0)
     diff-lcs (1.5.0)
     docile (1.4.0)
     dogstatsd-ruby (5.6.1)

--- a/gemfiles/jruby_9.3_rails6_postgres_redis.gemfile.lock
+++ b/gemfiles/jruby_9.3_rails6_postgres_redis.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.18.0)
       datadog-ci (~> 0.5.0)
-      debase-ruby_core_source (= 3.2.3)
+      debase-ruby_core_source (= 3.3.0)
       libdatadog (~> 5.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
@@ -102,7 +102,7 @@ GEM
     datadog-ci (0.5.0)
       msgpack
     date (3.3.3-java)
-    debase-ruby_core_source (3.2.3)
+    debase-ruby_core_source (3.3.0)
     diff-lcs (1.5.0)
     docile (1.4.0)
     dogstatsd-ruby (5.6.1)

--- a/gemfiles/jruby_9.3_rails6_postgres_redis_activesupport.gemfile.lock
+++ b/gemfiles/jruby_9.3_rails6_postgres_redis_activesupport.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.18.0)
       datadog-ci (~> 0.5.0)
-      debase-ruby_core_source (= 3.2.3)
+      debase-ruby_core_source (= 3.3.0)
       libdatadog (~> 5.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
@@ -102,7 +102,7 @@ GEM
     datadog-ci (0.5.0)
       msgpack
     date (3.3.3-java)
-    debase-ruby_core_source (3.2.3)
+    debase-ruby_core_source (3.3.0)
     diff-lcs (1.5.0)
     docile (1.4.0)
     dogstatsd-ruby (5.6.1)

--- a/gemfiles/jruby_9.3_rails6_postgres_sidekiq.gemfile.lock
+++ b/gemfiles/jruby_9.3_rails6_postgres_sidekiq.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.18.0)
       datadog-ci (~> 0.5.0)
-      debase-ruby_core_source (= 3.2.3)
+      debase-ruby_core_source (= 3.3.0)
       libdatadog (~> 5.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
@@ -103,7 +103,7 @@ GEM
     datadog-ci (0.5.0)
       msgpack
     date (3.3.3-java)
-    debase-ruby_core_source (3.2.3)
+    debase-ruby_core_source (3.3.0)
     diff-lcs (1.5.0)
     docile (1.4.0)
     dogstatsd-ruby (5.6.1)

--- a/gemfiles/jruby_9.3_rails6_semantic_logger.gemfile.lock
+++ b/gemfiles/jruby_9.3_rails6_semantic_logger.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.18.0)
       datadog-ci (~> 0.5.0)
-      debase-ruby_core_source (= 3.2.3)
+      debase-ruby_core_source (= 3.3.0)
       libdatadog (~> 5.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
@@ -102,7 +102,7 @@ GEM
     datadog-ci (0.5.0)
       msgpack
     date (3.3.3-java)
-    debase-ruby_core_source (3.2.3)
+    debase-ruby_core_source (3.3.0)
     diff-lcs (1.5.0)
     docile (1.4.0)
     dogstatsd-ruby (5.6.1)

--- a/gemfiles/jruby_9.3_redis_3.gemfile.lock
+++ b/gemfiles/jruby_9.3_redis_3.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.18.0)
       datadog-ci (~> 0.5.0)
-      debase-ruby_core_source (= 3.2.3)
+      debase-ruby_core_source (= 3.3.0)
       libdatadog (~> 5.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
@@ -40,7 +40,7 @@ GEM
     cri (2.15.11)
     datadog-ci (0.5.0)
       msgpack
-    debase-ruby_core_source (3.2.3)
+    debase-ruby_core_source (3.3.0)
     diff-lcs (1.5.0)
     docile (1.4.0)
     dogstatsd-ruby (5.6.1)

--- a/gemfiles/jruby_9.3_redis_4.gemfile.lock
+++ b/gemfiles/jruby_9.3_redis_4.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.18.0)
       datadog-ci (~> 0.5.0)
-      debase-ruby_core_source (= 3.2.3)
+      debase-ruby_core_source (= 3.3.0)
       libdatadog (~> 5.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
@@ -40,7 +40,7 @@ GEM
     cri (2.15.11)
     datadog-ci (0.5.0)
       msgpack
-    debase-ruby_core_source (3.2.3)
+    debase-ruby_core_source (3.3.0)
     diff-lcs (1.5.0)
     docile (1.4.0)
     dogstatsd-ruby (5.6.1)

--- a/gemfiles/jruby_9.3_redis_5.gemfile.lock
+++ b/gemfiles/jruby_9.3_redis_5.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.18.0)
       datadog-ci (~> 0.5.0)
-      debase-ruby_core_source (= 3.2.3)
+      debase-ruby_core_source (= 3.3.0)
       libdatadog (~> 5.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
@@ -41,7 +41,7 @@ GEM
     cri (2.15.11)
     datadog-ci (0.5.0)
       msgpack
-    debase-ruby_core_source (3.2.3)
+    debase-ruby_core_source (3.3.0)
     diff-lcs (1.5.0)
     docile (1.4.0)
     dogstatsd-ruby (5.6.1)

--- a/gemfiles/jruby_9.3_relational_db.gemfile.lock
+++ b/gemfiles/jruby_9.3_relational_db.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.18.0)
       datadog-ci (~> 0.5.0)
-      debase-ruby_core_source (= 3.2.3)
+      debase-ruby_core_source (= 3.3.0)
       libdatadog (~> 5.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
@@ -59,7 +59,7 @@ GEM
     cri (2.15.11)
     datadog-ci (0.5.0)
       msgpack
-    debase-ruby_core_source (3.2.3)
+    debase-ruby_core_source (3.3.0)
     delayed_job (4.1.11)
       activesupport (>= 3.0, < 8.0)
     delayed_job_active_record (4.1.7)

--- a/gemfiles/jruby_9.3_resque2_redis3.gemfile.lock
+++ b/gemfiles/jruby_9.3_resque2_redis3.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.18.0)
       datadog-ci (~> 0.5.0)
-      debase-ruby_core_source (= 3.2.3)
+      debase-ruby_core_source (= 3.3.0)
       libdatadog (~> 5.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
@@ -40,7 +40,7 @@ GEM
     cri (2.15.11)
     datadog-ci (0.5.0)
       msgpack
-    debase-ruby_core_source (3.2.3)
+    debase-ruby_core_source (3.3.0)
     diff-lcs (1.5.0)
     docile (1.4.0)
     dogstatsd-ruby (5.6.1)

--- a/gemfiles/jruby_9.3_resque2_redis4.gemfile.lock
+++ b/gemfiles/jruby_9.3_resque2_redis4.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.18.0)
       datadog-ci (~> 0.5.0)
-      debase-ruby_core_source (= 3.2.3)
+      debase-ruby_core_source (= 3.3.0)
       libdatadog (~> 5.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
@@ -40,7 +40,7 @@ GEM
     cri (2.15.11)
     datadog-ci (0.5.0)
       msgpack
-    debase-ruby_core_source (3.2.3)
+    debase-ruby_core_source (3.3.0)
     diff-lcs (1.5.0)
     docile (1.4.0)
     dogstatsd-ruby (5.6.1)

--- a/gemfiles/jruby_9.3_sinatra.gemfile.lock
+++ b/gemfiles/jruby_9.3_sinatra.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.18.0)
       datadog-ci (~> 0.5.0)
-      debase-ruby_core_source (= 3.2.3)
+      debase-ruby_core_source (= 3.3.0)
       libdatadog (~> 5.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
@@ -40,7 +40,7 @@ GEM
     cri (2.15.11)
     datadog-ci (0.5.0)
       msgpack
-    debase-ruby_core_source (3.2.3)
+    debase-ruby_core_source (3.3.0)
     diff-lcs (1.5.0)
     docile (1.4.0)
     dogstatsd-ruby (5.6.1)

--- a/gemfiles/jruby_9.4_activesupport.gemfile.lock
+++ b/gemfiles/jruby_9.4_activesupport.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.18.0)
       datadog-ci (~> 0.5.0)
-      debase-ruby_core_source (= 3.2.3)
+      debase-ruby_core_source (= 3.3.0)
       libdatadog (~> 5.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
@@ -68,7 +68,7 @@ GEM
     cri (2.15.11)
     datadog-ci (0.5.0)
       msgpack
-    debase-ruby_core_source (3.2.3)
+    debase-ruby_core_source (3.3.0)
     diff-lcs (1.5.0)
     digest-crc (0.6.5)
       rake (>= 12.0.0, < 14.0.0)

--- a/gemfiles/jruby_9.4_aws.gemfile.lock
+++ b/gemfiles/jruby_9.4_aws.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.18.0)
       datadog-ci (~> 0.5.0)
-      debase-ruby_core_source (= 3.2.3)
+      debase-ruby_core_source (= 3.3.0)
       libdatadog (~> 5.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
@@ -1461,7 +1461,7 @@ GEM
     cri (2.15.11)
     datadog-ci (0.5.0)
       msgpack
-    debase-ruby_core_source (3.2.3)
+    debase-ruby_core_source (3.3.0)
     diff-lcs (1.5.0)
     docile (1.4.0)
     dogstatsd-ruby (5.6.0)

--- a/gemfiles/jruby_9.4_contrib.gemfile.lock
+++ b/gemfiles/jruby_9.4_contrib.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.18.0)
       datadog-ci (~> 0.5.0)
-      debase-ruby_core_source (= 3.2.3)
+      debase-ruby_core_source (= 3.3.0)
       libdatadog (~> 5.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
@@ -47,7 +47,7 @@ GEM
     dalli (3.2.3)
     datadog-ci (0.5.0)
       msgpack
-    debase-ruby_core_source (3.2.3)
+    debase-ruby_core_source (3.3.0)
     diff-lcs (1.5.0)
     docile (1.4.0)
     dogstatsd-ruby (5.5.0)

--- a/gemfiles/jruby_9.4_contrib_old.gemfile.lock
+++ b/gemfiles/jruby_9.4_contrib_old.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.18.0)
       datadog-ci (~> 0.5.0)
-      debase-ruby_core_source (= 3.2.3)
+      debase-ruby_core_source (= 3.3.0)
       libdatadog (~> 5.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
@@ -41,7 +41,7 @@ GEM
     dalli (2.7.11)
     datadog-ci (0.5.0)
       msgpack
-    debase-ruby_core_source (3.2.3)
+    debase-ruby_core_source (3.3.0)
     diff-lcs (1.5.0)
     docile (1.4.0)
     dogstatsd-ruby (5.5.0)

--- a/gemfiles/jruby_9.4_core_old.gemfile.lock
+++ b/gemfiles/jruby_9.4_core_old.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.18.0)
       datadog-ci (~> 0.5.0)
-      debase-ruby_core_source (= 3.2.3)
+      debase-ruby_core_source (= 3.3.0)
       libdatadog (~> 5.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
@@ -40,7 +40,7 @@ GEM
     cri (2.15.11)
     datadog-ci (0.5.0)
       msgpack
-    debase-ruby_core_source (3.2.3)
+    debase-ruby_core_source (3.3.0)
     diff-lcs (1.5.0)
     docile (1.4.0)
     dogstatsd-ruby (4.8.3)

--- a/gemfiles/jruby_9.4_elasticsearch_7.gemfile.lock
+++ b/gemfiles/jruby_9.4_elasticsearch_7.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.18.0)
       datadog-ci (~> 0.5.0)
-      debase-ruby_core_source (= 3.2.3)
+      debase-ruby_core_source (= 3.3.0)
       libdatadog (~> 5.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
@@ -41,7 +41,7 @@ GEM
     cri (2.15.11)
     datadog-ci (0.5.0)
       msgpack
-    debase-ruby_core_source (3.2.3)
+    debase-ruby_core_source (3.3.0)
     diff-lcs (1.5.0)
     docile (1.4.0)
     dogstatsd-ruby (5.6.1)

--- a/gemfiles/jruby_9.4_elasticsearch_8.gemfile.lock
+++ b/gemfiles/jruby_9.4_elasticsearch_8.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.18.0)
       datadog-ci (~> 0.5.0)
-      debase-ruby_core_source (= 3.2.3)
+      debase-ruby_core_source (= 3.3.0)
       libdatadog (~> 5.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
@@ -42,7 +42,7 @@ GEM
     cri (2.15.11)
     datadog-ci (0.5.0)
       msgpack
-    debase-ruby_core_source (3.2.3)
+    debase-ruby_core_source (3.3.0)
     diff-lcs (1.5.0)
     docile (1.4.0)
     dogstatsd-ruby (5.6.1)

--- a/gemfiles/jruby_9.4_http.gemfile.lock
+++ b/gemfiles/jruby_9.4_http.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.18.0)
       datadog-ci (~> 0.5.0)
-      debase-ruby_core_source (= 3.2.3)
+      debase-ruby_core_source (= 3.3.0)
       libdatadog (~> 5.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
@@ -40,7 +40,7 @@ GEM
     cri (2.15.11)
     datadog-ci (0.5.0)
       msgpack
-    debase-ruby_core_source (3.2.3)
+    debase-ruby_core_source (3.3.0)
     diff-lcs (1.5.0)
     docile (1.4.0)
     dogstatsd-ruby (5.6.1)

--- a/gemfiles/jruby_9.4_opensearch_2.gemfile.lock
+++ b/gemfiles/jruby_9.4_opensearch_2.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.18.0)
       datadog-ci (~> 0.5.0)
-      debase-ruby_core_source (= 3.2.3)
+      debase-ruby_core_source (= 3.3.0)
       libdatadog (~> 5.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
@@ -42,7 +42,7 @@ GEM
     cri (2.15.11)
     datadog-ci (0.5.0)
       msgpack
-    debase-ruby_core_source (3.2.3)
+    debase-ruby_core_source (3.3.0)
     diff-lcs (1.5.0)
     docile (1.4.0)
     dogstatsd-ruby (5.6.1)

--- a/gemfiles/jruby_9.4_opensearch_3.gemfile.lock
+++ b/gemfiles/jruby_9.4_opensearch_3.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.18.0)
       datadog-ci (~> 0.5.0)
-      debase-ruby_core_source (= 3.2.3)
+      debase-ruby_core_source (= 3.3.0)
       libdatadog (~> 5.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
@@ -42,7 +42,7 @@ GEM
     cri (2.15.11)
     datadog-ci (0.5.0)
       msgpack
-    debase-ruby_core_source (3.2.3)
+    debase-ruby_core_source (3.3.0)
     diff-lcs (1.5.0)
     docile (1.4.0)
     dogstatsd-ruby (5.6.1)

--- a/gemfiles/jruby_9.4_opentracing.gemfile.lock
+++ b/gemfiles/jruby_9.4_opentracing.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.18.0)
       datadog-ci (~> 0.5.0)
-      debase-ruby_core_source (= 3.2.3)
+      debase-ruby_core_source (= 3.3.0)
       libdatadog (~> 5.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
@@ -41,7 +41,7 @@ GEM
     cri (2.15.11)
     datadog-ci (0.5.0)
       msgpack
-    debase-ruby_core_source (3.2.3)
+    debase-ruby_core_source (3.3.0)
     diff-lcs (1.5.0)
     docile (1.4.0)
     dogstatsd-ruby (5.6.1)

--- a/gemfiles/jruby_9.4_rack_1.gemfile.lock
+++ b/gemfiles/jruby_9.4_rack_1.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.18.0)
       datadog-ci (~> 0.5.0)
-      debase-ruby_core_source (= 3.2.3)
+      debase-ruby_core_source (= 3.3.0)
       libdatadog (~> 5.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
@@ -40,7 +40,7 @@ GEM
     cri (2.15.11)
     datadog-ci (0.5.0)
       msgpack
-    debase-ruby_core_source (3.2.3)
+    debase-ruby_core_source (3.3.0)
     diff-lcs (1.5.0)
     docile (1.4.0)
     dogstatsd-ruby (5.6.1)

--- a/gemfiles/jruby_9.4_rack_2.gemfile.lock
+++ b/gemfiles/jruby_9.4_rack_2.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.18.0)
       datadog-ci (~> 0.5.0)
-      debase-ruby_core_source (= 3.2.3)
+      debase-ruby_core_source (= 3.3.0)
       libdatadog (~> 5.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
@@ -40,7 +40,7 @@ GEM
     cri (2.15.11)
     datadog-ci (0.5.0)
       msgpack
-    debase-ruby_core_source (3.2.3)
+    debase-ruby_core_source (3.3.0)
     diff-lcs (1.5.0)
     docile (1.4.0)
     dogstatsd-ruby (5.6.1)

--- a/gemfiles/jruby_9.4_rack_3.gemfile.lock
+++ b/gemfiles/jruby_9.4_rack_3.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.18.0)
       datadog-ci (~> 0.5.0)
-      debase-ruby_core_source (= 3.2.3)
+      debase-ruby_core_source (= 3.3.0)
       libdatadog (~> 5.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
@@ -40,7 +40,7 @@ GEM
     cri (2.15.11)
     datadog-ci (0.5.0)
       msgpack
-    debase-ruby_core_source (3.2.3)
+    debase-ruby_core_source (3.3.0)
     diff-lcs (1.5.0)
     docile (1.4.0)
     dogstatsd-ruby (5.6.1)

--- a/gemfiles/jruby_9.4_rails61_mysql2.gemfile.lock
+++ b/gemfiles/jruby_9.4_rails61_mysql2.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.18.0)
       datadog-ci (~> 0.5.0)
-      debase-ruby_core_source (= 3.2.3)
+      debase-ruby_core_source (= 3.3.0)
       libdatadog (~> 5.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
@@ -106,7 +106,7 @@ GEM
     datadog-ci (0.5.0)
       msgpack
     date (3.3.3-java)
-    debase-ruby_core_source (3.2.3)
+    debase-ruby_core_source (3.3.0)
     diff-lcs (1.5.0)
     docile (1.4.0)
     dogstatsd-ruby (5.5.0)

--- a/gemfiles/jruby_9.4_rails61_postgres.gemfile.lock
+++ b/gemfiles/jruby_9.4_rails61_postgres.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.18.0)
       datadog-ci (~> 0.5.0)
-      debase-ruby_core_source (= 3.2.3)
+      debase-ruby_core_source (= 3.3.0)
       libdatadog (~> 5.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
@@ -106,7 +106,7 @@ GEM
     datadog-ci (0.5.0)
       msgpack
     date (3.3.3-java)
-    debase-ruby_core_source (3.2.3)
+    debase-ruby_core_source (3.3.0)
     diff-lcs (1.5.0)
     docile (1.4.0)
     dogstatsd-ruby (5.5.0)

--- a/gemfiles/jruby_9.4_rails61_postgres_redis.gemfile.lock
+++ b/gemfiles/jruby_9.4_rails61_postgres_redis.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.18.0)
       datadog-ci (~> 0.5.0)
-      debase-ruby_core_source (= 3.2.3)
+      debase-ruby_core_source (= 3.3.0)
       libdatadog (~> 5.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
@@ -106,7 +106,7 @@ GEM
     datadog-ci (0.5.0)
       msgpack
     date (3.3.3-java)
-    debase-ruby_core_source (3.2.3)
+    debase-ruby_core_source (3.3.0)
     diff-lcs (1.5.0)
     docile (1.4.0)
     dogstatsd-ruby (5.5.0)

--- a/gemfiles/jruby_9.4_rails61_postgres_sidekiq.gemfile.lock
+++ b/gemfiles/jruby_9.4_rails61_postgres_sidekiq.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.18.0)
       datadog-ci (~> 0.5.0)
-      debase-ruby_core_source (= 3.2.3)
+      debase-ruby_core_source (= 3.3.0)
       libdatadog (~> 5.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
@@ -107,7 +107,7 @@ GEM
     datadog-ci (0.5.0)
       msgpack
     date (3.3.3-java)
-    debase-ruby_core_source (3.2.3)
+    debase-ruby_core_source (3.3.0)
     diff-lcs (1.5.0)
     docile (1.4.0)
     dogstatsd-ruby (5.5.0)

--- a/gemfiles/jruby_9.4_rails61_semantic_logger.gemfile.lock
+++ b/gemfiles/jruby_9.4_rails61_semantic_logger.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.18.0)
       datadog-ci (~> 0.5.0)
-      debase-ruby_core_source (= 3.2.3)
+      debase-ruby_core_source (= 3.3.0)
       libdatadog (~> 5.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
@@ -106,7 +106,7 @@ GEM
     datadog-ci (0.5.0)
       msgpack
     date (3.3.3-java)
-    debase-ruby_core_source (3.2.3)
+    debase-ruby_core_source (3.3.0)
     diff-lcs (1.5.0)
     docile (1.4.0)
     dogstatsd-ruby (5.5.0)

--- a/gemfiles/jruby_9.4_redis_3.gemfile.lock
+++ b/gemfiles/jruby_9.4_redis_3.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.18.0)
       datadog-ci (~> 0.5.0)
-      debase-ruby_core_source (= 3.2.3)
+      debase-ruby_core_source (= 3.3.0)
       libdatadog (~> 5.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
@@ -40,7 +40,7 @@ GEM
     cri (2.15.11)
     datadog-ci (0.5.0)
       msgpack
-    debase-ruby_core_source (3.2.3)
+    debase-ruby_core_source (3.3.0)
     diff-lcs (1.5.0)
     docile (1.4.0)
     dogstatsd-ruby (5.5.0)

--- a/gemfiles/jruby_9.4_redis_4.gemfile.lock
+++ b/gemfiles/jruby_9.4_redis_4.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.18.0)
       datadog-ci (~> 0.5.0)
-      debase-ruby_core_source (= 3.2.3)
+      debase-ruby_core_source (= 3.3.0)
       libdatadog (~> 5.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
@@ -40,7 +40,7 @@ GEM
     cri (2.15.11)
     datadog-ci (0.5.0)
       msgpack
-    debase-ruby_core_source (3.2.3)
+    debase-ruby_core_source (3.3.0)
     diff-lcs (1.5.0)
     docile (1.4.0)
     dogstatsd-ruby (5.5.0)

--- a/gemfiles/jruby_9.4_redis_5.gemfile.lock
+++ b/gemfiles/jruby_9.4_redis_5.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.18.0)
       datadog-ci (~> 0.5.0)
-      debase-ruby_core_source (= 3.2.3)
+      debase-ruby_core_source (= 3.3.0)
       libdatadog (~> 5.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
@@ -41,7 +41,7 @@ GEM
     cri (2.15.11)
     datadog-ci (0.5.0)
       msgpack
-    debase-ruby_core_source (3.2.3)
+    debase-ruby_core_source (3.3.0)
     diff-lcs (1.5.0)
     docile (1.4.0)
     dogstatsd-ruby (5.5.0)

--- a/gemfiles/jruby_9.4_relational_db.gemfile.lock
+++ b/gemfiles/jruby_9.4_relational_db.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.18.0)
       datadog-ci (~> 0.5.0)
-      debase-ruby_core_source (= 3.2.3)
+      debase-ruby_core_source (= 3.3.0)
       libdatadog (~> 5.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
@@ -58,7 +58,7 @@ GEM
     cri (2.15.11)
     datadog-ci (0.5.0)
       msgpack
-    debase-ruby_core_source (3.2.3)
+    debase-ruby_core_source (3.3.0)
     delayed_job (4.1.11)
       activesupport (>= 3.0, < 8.0)
     delayed_job_active_record (4.1.7)

--- a/gemfiles/jruby_9.4_resque2_redis3.gemfile.lock
+++ b/gemfiles/jruby_9.4_resque2_redis3.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.18.0)
       datadog-ci (~> 0.5.0)
-      debase-ruby_core_source (= 3.2.3)
+      debase-ruby_core_source (= 3.3.0)
       libdatadog (~> 5.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
@@ -40,7 +40,7 @@ GEM
     cri (2.15.11)
     datadog-ci (0.5.0)
       msgpack
-    debase-ruby_core_source (3.2.3)
+    debase-ruby_core_source (3.3.0)
     diff-lcs (1.5.0)
     docile (1.4.0)
     dogstatsd-ruby (5.5.0)

--- a/gemfiles/jruby_9.4_resque2_redis4.gemfile.lock
+++ b/gemfiles/jruby_9.4_resque2_redis4.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.18.0)
       datadog-ci (~> 0.5.0)
-      debase-ruby_core_source (= 3.2.3)
+      debase-ruby_core_source (= 3.3.0)
       libdatadog (~> 5.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
@@ -41,7 +41,7 @@ GEM
     cri (2.15.11)
     datadog-ci (0.5.0)
       msgpack
-    debase-ruby_core_source (3.2.3)
+    debase-ruby_core_source (3.3.0)
     diff-lcs (1.5.0)
     docile (1.4.0)
     dogstatsd-ruby (5.5.0)

--- a/gemfiles/jruby_9.4_sinatra.gemfile.lock
+++ b/gemfiles/jruby_9.4_sinatra.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.18.0)
       datadog-ci (~> 0.5.0)
-      debase-ruby_core_source (= 3.2.3)
+      debase-ruby_core_source (= 3.3.0)
       libdatadog (~> 5.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
@@ -40,7 +40,7 @@ GEM
     cri (2.15.11)
     datadog-ci (0.5.0)
       msgpack
-    debase-ruby_core_source (3.2.3)
+    debase-ruby_core_source (3.3.0)
     diff-lcs (1.5.0)
     docile (1.4.0)
     dogstatsd-ruby (5.5.0)

--- a/gemfiles/ruby_2.1_activesupport.gemfile.lock
+++ b/gemfiles/ruby_2.1_activesupport.gemfile.lock
@@ -3,7 +3,7 @@ PATH
   specs:
     ddtrace (1.18.0)
       datadog-ci (~> 0.5.0)
-      debase-ruby_core_source (= 3.2.3)
+      debase-ruby_core_source (= 3.3.0)
       libdatadog (~> 5.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
@@ -38,7 +38,7 @@ GEM
       rexml
     datadog-ci (0.5.0)
       msgpack
-    debase-ruby_core_source (3.2.3)
+    debase-ruby_core_source (3.3.0)
     diff-lcs (1.5.0)
     digest-crc (0.6.5)
       rake (>= 12.0.0, < 14.0.0)

--- a/gemfiles/ruby_2.1_aws.gemfile.lock
+++ b/gemfiles/ruby_2.1_aws.gemfile.lock
@@ -3,7 +3,7 @@ PATH
   specs:
     ddtrace (1.18.0)
       datadog-ci (~> 0.5.0)
-      debase-ruby_core_source (= 3.2.3)
+      debase-ruby_core_source (= 3.3.0)
       libdatadog (~> 5.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
@@ -37,7 +37,7 @@ GEM
       rexml
     datadog-ci (0.5.0)
       msgpack
-    debase-ruby_core_source (3.2.3)
+    debase-ruby_core_source (3.3.0)
     diff-lcs (1.5.0)
     docile (1.3.5)
     dogstatsd-ruby (5.6.0)

--- a/gemfiles/ruby_2.1_contrib.gemfile.lock
+++ b/gemfiles/ruby_2.1_contrib.gemfile.lock
@@ -3,7 +3,7 @@ PATH
   specs:
     ddtrace (1.18.0)
       datadog-ci (~> 0.5.0)
-      debase-ruby_core_source (= 3.2.3)
+      debase-ruby_core_source (= 3.3.0)
       libdatadog (~> 5.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
@@ -47,7 +47,7 @@ GEM
     dalli (2.7.11)
     datadog-ci (0.5.0)
       msgpack
-    debase-ruby_core_source (3.2.3)
+    debase-ruby_core_source (3.3.0)
     diff-lcs (1.5.0)
     docile (1.3.5)
     dogstatsd-ruby (5.5.0)

--- a/gemfiles/ruby_2.1_core_old.gemfile.lock
+++ b/gemfiles/ruby_2.1_core_old.gemfile.lock
@@ -3,7 +3,7 @@ PATH
   specs:
     ddtrace (1.18.0)
       datadog-ci (~> 0.5.0)
-      debase-ruby_core_source (= 3.2.3)
+      debase-ruby_core_source (= 3.3.0)
       libdatadog (~> 5.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
@@ -27,7 +27,7 @@ GEM
       rexml
     datadog-ci (0.5.0)
       msgpack
-    debase-ruby_core_source (3.2.3)
+    debase-ruby_core_source (3.3.0)
     diff-lcs (1.5.0)
     docile (1.3.5)
     dogstatsd-ruby (4.8.3)

--- a/gemfiles/ruby_2.1_elasticsearch_7.gemfile.lock
+++ b/gemfiles/ruby_2.1_elasticsearch_7.gemfile.lock
@@ -3,7 +3,7 @@ PATH
   specs:
     ddtrace (1.18.0)
       datadog-ci (~> 0.5.0)
-      debase-ruby_core_source (= 3.2.3)
+      debase-ruby_core_source (= 3.3.0)
       libdatadog (~> 5.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
@@ -28,7 +28,7 @@ GEM
       rexml
     datadog-ci (0.5.0)
       msgpack
-    debase-ruby_core_source (3.2.3)
+    debase-ruby_core_source (3.3.0)
     diff-lcs (1.5.0)
     docile (1.3.5)
     dogstatsd-ruby (5.6.1)

--- a/gemfiles/ruby_2.1_http.gemfile.lock
+++ b/gemfiles/ruby_2.1_http.gemfile.lock
@@ -3,7 +3,7 @@ PATH
   specs:
     ddtrace (1.18.0)
       datadog-ci (~> 0.5.0)
-      debase-ruby_core_source (= 3.2.3)
+      debase-ruby_core_source (= 3.3.0)
       libdatadog (~> 5.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
@@ -27,7 +27,7 @@ GEM
       rexml
     datadog-ci (0.5.0)
       msgpack
-    debase-ruby_core_source (3.2.3)
+    debase-ruby_core_source (3.3.0)
     diff-lcs (1.5.0)
     docile (1.3.5)
     dogstatsd-ruby (5.6.1)

--- a/gemfiles/ruby_2.1_opentracing.gemfile.lock
+++ b/gemfiles/ruby_2.1_opentracing.gemfile.lock
@@ -3,7 +3,7 @@ PATH
   specs:
     ddtrace (1.18.0)
       datadog-ci (~> 0.5.0)
-      debase-ruby_core_source (= 3.2.3)
+      debase-ruby_core_source (= 3.3.0)
       libdatadog (~> 5.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
@@ -28,7 +28,7 @@ GEM
       rexml
     datadog-ci (0.5.0)
       msgpack
-    debase-ruby_core_source (3.2.3)
+    debase-ruby_core_source (3.3.0)
     diff-lcs (1.5.0)
     docile (1.3.5)
     dogstatsd-ruby (5.6.1)

--- a/gemfiles/ruby_2.1_rack_1.gemfile.lock
+++ b/gemfiles/ruby_2.1_rack_1.gemfile.lock
@@ -3,7 +3,7 @@ PATH
   specs:
     ddtrace (1.18.0)
       datadog-ci (~> 0.5.0)
-      debase-ruby_core_source (= 3.2.3)
+      debase-ruby_core_source (= 3.3.0)
       libdatadog (~> 5.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
@@ -27,7 +27,7 @@ GEM
       rexml
     datadog-ci (0.5.0)
       msgpack
-    debase-ruby_core_source (3.2.3)
+    debase-ruby_core_source (3.3.0)
     diff-lcs (1.5.0)
     docile (1.3.5)
     dogstatsd-ruby (5.6.1)

--- a/gemfiles/ruby_2.1_rails32_mysql2.gemfile.lock
+++ b/gemfiles/ruby_2.1_rails32_mysql2.gemfile.lock
@@ -3,7 +3,7 @@ PATH
   specs:
     ddtrace (1.18.0)
       datadog-ci (~> 0.5.0)
-      debase-ruby_core_source (= 3.2.3)
+      debase-ruby_core_source (= 3.3.0)
       libdatadog (~> 5.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
@@ -59,7 +59,7 @@ GEM
       rexml
     datadog-ci (0.5.0)
       msgpack
-    debase-ruby_core_source (3.2.3)
+    debase-ruby_core_source (3.3.0)
     diff-lcs (1.5.0)
     docile (1.3.5)
     dogstatsd-ruby (5.5.0)

--- a/gemfiles/ruby_2.1_rails32_postgres.gemfile.lock
+++ b/gemfiles/ruby_2.1_rails32_postgres.gemfile.lock
@@ -3,7 +3,7 @@ PATH
   specs:
     ddtrace (1.18.0)
       datadog-ci (~> 0.5.0)
-      debase-ruby_core_source (= 3.2.3)
+      debase-ruby_core_source (= 3.3.0)
       libdatadog (~> 5.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
@@ -55,7 +55,7 @@ GEM
       rexml
     datadog-ci (0.5.0)
       msgpack
-    debase-ruby_core_source (3.2.3)
+    debase-ruby_core_source (3.3.0)
     diff-lcs (1.5.0)
     docile (1.3.5)
     dogstatsd-ruby (5.5.0)

--- a/gemfiles/ruby_2.1_rails32_postgres_redis.gemfile.lock
+++ b/gemfiles/ruby_2.1_rails32_postgres_redis.gemfile.lock
@@ -3,7 +3,7 @@ PATH
   specs:
     ddtrace (1.18.0)
       datadog-ci (~> 0.5.0)
-      debase-ruby_core_source (= 3.2.3)
+      debase-ruby_core_source (= 3.3.0)
       libdatadog (~> 5.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
@@ -55,7 +55,7 @@ GEM
       rexml
     datadog-ci (0.5.0)
       msgpack
-    debase-ruby_core_source (3.2.3)
+    debase-ruby_core_source (3.3.0)
     diff-lcs (1.5.0)
     docile (1.3.5)
     dogstatsd-ruby (5.5.0)

--- a/gemfiles/ruby_2.1_rails32_postgres_sidekiq.gemfile.lock
+++ b/gemfiles/ruby_2.1_rails32_postgres_sidekiq.gemfile.lock
@@ -3,7 +3,7 @@ PATH
   specs:
     ddtrace (1.18.0)
       datadog-ci (~> 0.5.0)
-      debase-ruby_core_source (= 3.2.3)
+      debase-ruby_core_source (= 3.3.0)
       libdatadog (~> 5.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
@@ -56,7 +56,7 @@ GEM
       rexml
     datadog-ci (0.5.0)
       msgpack
-    debase-ruby_core_source (3.2.3)
+    debase-ruby_core_source (3.3.0)
     diff-lcs (1.5.0)
     docile (1.3.5)
     dogstatsd-ruby (5.5.0)

--- a/gemfiles/ruby_2.1_rails4_mysql2.gemfile.lock
+++ b/gemfiles/ruby_2.1_rails4_mysql2.gemfile.lock
@@ -3,7 +3,7 @@ PATH
   specs:
     ddtrace (1.18.0)
       datadog-ci (~> 0.5.0)
-      debase-ruby_core_source (= 3.2.3)
+      debase-ruby_core_source (= 3.3.0)
       libdatadog (~> 5.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
@@ -63,7 +63,7 @@ GEM
     crass (1.0.6)
     datadog-ci (0.5.0)
       msgpack
-    debase-ruby_core_source (3.2.3)
+    debase-ruby_core_source (3.3.0)
     diff-lcs (1.5.0)
     docile (1.3.5)
     dogstatsd-ruby (5.5.0)

--- a/gemfiles/ruby_2.1_rails4_postgres.gemfile.lock
+++ b/gemfiles/ruby_2.1_rails4_postgres.gemfile.lock
@@ -3,7 +3,7 @@ PATH
   specs:
     ddtrace (1.18.0)
       datadog-ci (~> 0.5.0)
-      debase-ruby_core_source (= 3.2.3)
+      debase-ruby_core_source (= 3.3.0)
       libdatadog (~> 5.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
@@ -63,7 +63,7 @@ GEM
     crass (1.0.6)
     datadog-ci (0.5.0)
       msgpack
-    debase-ruby_core_source (3.2.3)
+    debase-ruby_core_source (3.3.0)
     diff-lcs (1.5.0)
     docile (1.3.5)
     dogstatsd-ruby (5.5.0)

--- a/gemfiles/ruby_2.1_rails4_postgres_redis.gemfile.lock
+++ b/gemfiles/ruby_2.1_rails4_postgres_redis.gemfile.lock
@@ -3,7 +3,7 @@ PATH
   specs:
     ddtrace (1.18.0)
       datadog-ci (~> 0.5.0)
-      debase-ruby_core_source (= 3.2.3)
+      debase-ruby_core_source (= 3.3.0)
       libdatadog (~> 5.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
@@ -63,7 +63,7 @@ GEM
     crass (1.0.6)
     datadog-ci (0.5.0)
       msgpack
-    debase-ruby_core_source (3.2.3)
+    debase-ruby_core_source (3.3.0)
     diff-lcs (1.5.0)
     docile (1.3.5)
     dogstatsd-ruby (5.5.0)

--- a/gemfiles/ruby_2.1_rails4_semantic_logger.gemfile.lock
+++ b/gemfiles/ruby_2.1_rails4_semantic_logger.gemfile.lock
@@ -3,7 +3,7 @@ PATH
   specs:
     ddtrace (1.18.0)
       datadog-ci (~> 0.5.0)
-      debase-ruby_core_source (= 3.2.3)
+      debase-ruby_core_source (= 3.3.0)
       libdatadog (~> 5.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
@@ -63,7 +63,7 @@ GEM
     crass (1.0.6)
     datadog-ci (0.5.0)
       msgpack
-    debase-ruby_core_source (3.2.3)
+    debase-ruby_core_source (3.3.0)
     diff-lcs (1.5.0)
     docile (1.3.5)
     dogstatsd-ruby (5.5.0)

--- a/gemfiles/ruby_2.1_redis_3.gemfile.lock
+++ b/gemfiles/ruby_2.1_redis_3.gemfile.lock
@@ -3,7 +3,7 @@ PATH
   specs:
     ddtrace (1.18.0)
       datadog-ci (~> 0.5.0)
-      debase-ruby_core_source (= 3.2.3)
+      debase-ruby_core_source (= 3.3.0)
       libdatadog (~> 5.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
@@ -27,7 +27,7 @@ GEM
       rexml
     datadog-ci (0.5.0)
       msgpack
-    debase-ruby_core_source (3.2.3)
+    debase-ruby_core_source (3.3.0)
     diff-lcs (1.5.0)
     docile (1.3.5)
     dogstatsd-ruby (5.5.0)

--- a/gemfiles/ruby_2.1_relational_db.gemfile.lock
+++ b/gemfiles/ruby_2.1_relational_db.gemfile.lock
@@ -3,7 +3,7 @@ PATH
   specs:
     ddtrace (1.18.0)
       datadog-ci (~> 0.5.0)
-      debase-ruby_core_source (= 3.2.3)
+      debase-ruby_core_source (= 3.3.0)
       libdatadog (~> 5.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
@@ -43,7 +43,7 @@ GEM
       rexml
     datadog-ci (0.5.0)
       msgpack
-    debase-ruby_core_source (3.2.3)
+    debase-ruby_core_source (3.3.0)
     delayed_job (4.1.11)
       activesupport (>= 3.0, < 8.0)
     delayed_job_active_record (4.1.7)

--- a/gemfiles/ruby_2.1_sinatra.gemfile.lock
+++ b/gemfiles/ruby_2.1_sinatra.gemfile.lock
@@ -3,7 +3,7 @@ PATH
   specs:
     ddtrace (1.18.0)
       datadog-ci (~> 0.5.0)
-      debase-ruby_core_source (= 3.2.3)
+      debase-ruby_core_source (= 3.3.0)
       libdatadog (~> 5.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
@@ -27,7 +27,7 @@ GEM
       rexml
     datadog-ci (0.5.0)
       msgpack
-    debase-ruby_core_source (3.2.3)
+    debase-ruby_core_source (3.3.0)
     diff-lcs (1.5.0)
     docile (1.3.5)
     dogstatsd-ruby (5.5.0)

--- a/gemfiles/ruby_2.2_activesupport.gemfile.lock
+++ b/gemfiles/ruby_2.2_activesupport.gemfile.lock
@@ -3,7 +3,7 @@ PATH
   specs:
     ddtrace (1.18.0)
       datadog-ci (~> 0.5.0)
-      debase-ruby_core_source (= 3.2.3)
+      debase-ruby_core_source (= 3.3.0)
       libdatadog (~> 5.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
@@ -62,7 +62,7 @@ GEM
     crass (1.0.6)
     datadog-ci (0.5.0)
       msgpack
-    debase-ruby_core_source (3.2.3)
+    debase-ruby_core_source (3.3.0)
     descendants_tracker (0.0.4)
       thread_safe (~> 0.3, >= 0.3.1)
     diff-lcs (1.5.0)

--- a/gemfiles/ruby_2.2_aws.gemfile.lock
+++ b/gemfiles/ruby_2.2_aws.gemfile.lock
@@ -3,7 +3,7 @@ PATH
   specs:
     ddtrace (1.18.0)
       datadog-ci (~> 0.5.0)
-      debase-ruby_core_source (= 3.2.3)
+      debase-ruby_core_source (= 3.3.0)
       libdatadog (~> 5.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
@@ -1149,7 +1149,7 @@ GEM
       rexml
     datadog-ci (0.5.0)
       msgpack
-    debase-ruby_core_source (3.2.3)
+    debase-ruby_core_source (3.3.0)
     diff-lcs (1.5.0)
     docile (1.3.5)
     dogstatsd-ruby (5.6.0)

--- a/gemfiles/ruby_2.2_contrib.gemfile.lock
+++ b/gemfiles/ruby_2.2_contrib.gemfile.lock
@@ -3,7 +3,7 @@ PATH
   specs:
     ddtrace (1.18.0)
       datadog-ci (~> 0.5.0)
-      debase-ruby_core_source (= 3.2.3)
+      debase-ruby_core_source (= 3.3.0)
       libdatadog (~> 5.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
@@ -33,7 +33,7 @@ GEM
     dalli (2.7.11)
     datadog-ci (0.5.0)
       msgpack
-    debase-ruby_core_source (3.2.3)
+    debase-ruby_core_source (3.3.0)
     diff-lcs (1.5.0)
     docile (1.3.5)
     dogstatsd-ruby (5.5.0)

--- a/gemfiles/ruby_2.2_core_old.gemfile.lock
+++ b/gemfiles/ruby_2.2_core_old.gemfile.lock
@@ -3,7 +3,7 @@ PATH
   specs:
     ddtrace (1.18.0)
       datadog-ci (~> 0.5.0)
-      debase-ruby_core_source (= 3.2.3)
+      debase-ruby_core_source (= 3.3.0)
       libdatadog (~> 5.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
@@ -27,7 +27,7 @@ GEM
       rexml
     datadog-ci (0.5.0)
       msgpack
-    debase-ruby_core_source (3.2.3)
+    debase-ruby_core_source (3.3.0)
     diff-lcs (1.5.0)
     docile (1.3.5)
     dogstatsd-ruby (4.8.3)

--- a/gemfiles/ruby_2.2_elasticsearch_7.gemfile.lock
+++ b/gemfiles/ruby_2.2_elasticsearch_7.gemfile.lock
@@ -3,7 +3,7 @@ PATH
   specs:
     ddtrace (1.18.0)
       datadog-ci (~> 0.5.0)
-      debase-ruby_core_source (= 3.2.3)
+      debase-ruby_core_source (= 3.3.0)
       libdatadog (~> 5.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
@@ -28,7 +28,7 @@ GEM
       rexml
     datadog-ci (0.5.0)
       msgpack
-    debase-ruby_core_source (3.2.3)
+    debase-ruby_core_source (3.3.0)
     diff-lcs (1.5.0)
     docile (1.3.5)
     dogstatsd-ruby (5.6.1)

--- a/gemfiles/ruby_2.2_http.gemfile.lock
+++ b/gemfiles/ruby_2.2_http.gemfile.lock
@@ -3,7 +3,7 @@ PATH
   specs:
     ddtrace (1.18.0)
       datadog-ci (~> 0.5.0)
-      debase-ruby_core_source (= 3.2.3)
+      debase-ruby_core_source (= 3.3.0)
       libdatadog (~> 5.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
@@ -27,7 +27,7 @@ GEM
       rexml
     datadog-ci (0.5.0)
       msgpack
-    debase-ruby_core_source (3.2.3)
+    debase-ruby_core_source (3.3.0)
     diff-lcs (1.5.0)
     docile (1.3.5)
     dogstatsd-ruby (5.6.1)

--- a/gemfiles/ruby_2.2_opentracing.gemfile.lock
+++ b/gemfiles/ruby_2.2_opentracing.gemfile.lock
@@ -3,7 +3,7 @@ PATH
   specs:
     ddtrace (1.18.0)
       datadog-ci (~> 0.5.0)
-      debase-ruby_core_source (= 3.2.3)
+      debase-ruby_core_source (= 3.3.0)
       libdatadog (~> 5.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
@@ -28,7 +28,7 @@ GEM
       rexml
     datadog-ci (0.5.0)
       msgpack
-    debase-ruby_core_source (3.2.3)
+    debase-ruby_core_source (3.3.0)
     diff-lcs (1.5.0)
     docile (1.3.5)
     dogstatsd-ruby (5.6.1)

--- a/gemfiles/ruby_2.2_rack_1.gemfile.lock
+++ b/gemfiles/ruby_2.2_rack_1.gemfile.lock
@@ -3,7 +3,7 @@ PATH
   specs:
     ddtrace (1.18.0)
       datadog-ci (~> 0.5.0)
-      debase-ruby_core_source (= 3.2.3)
+      debase-ruby_core_source (= 3.3.0)
       libdatadog (~> 5.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
@@ -27,7 +27,7 @@ GEM
       rexml
     datadog-ci (0.5.0)
       msgpack
-    debase-ruby_core_source (3.2.3)
+    debase-ruby_core_source (3.3.0)
     diff-lcs (1.5.0)
     docile (1.3.5)
     dogstatsd-ruby (5.6.1)

--- a/gemfiles/ruby_2.2_rails32_mysql2.gemfile.lock
+++ b/gemfiles/ruby_2.2_rails32_mysql2.gemfile.lock
@@ -3,7 +3,7 @@ PATH
   specs:
     ddtrace (1.18.0)
       datadog-ci (~> 0.5.0)
-      debase-ruby_core_source (= 3.2.3)
+      debase-ruby_core_source (= 3.3.0)
       libdatadog (~> 5.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
@@ -59,7 +59,7 @@ GEM
       rexml
     datadog-ci (0.5.0)
       msgpack
-    debase-ruby_core_source (3.2.3)
+    debase-ruby_core_source (3.3.0)
     diff-lcs (1.5.0)
     docile (1.3.5)
     dogstatsd-ruby (5.5.0)

--- a/gemfiles/ruby_2.2_rails32_postgres.gemfile.lock
+++ b/gemfiles/ruby_2.2_rails32_postgres.gemfile.lock
@@ -3,7 +3,7 @@ PATH
   specs:
     ddtrace (1.18.0)
       datadog-ci (~> 0.5.0)
-      debase-ruby_core_source (= 3.2.3)
+      debase-ruby_core_source (= 3.3.0)
       libdatadog (~> 5.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
@@ -55,7 +55,7 @@ GEM
       rexml
     datadog-ci (0.5.0)
       msgpack
-    debase-ruby_core_source (3.2.3)
+    debase-ruby_core_source (3.3.0)
     diff-lcs (1.5.0)
     docile (1.3.5)
     dogstatsd-ruby (5.5.0)

--- a/gemfiles/ruby_2.2_rails32_postgres_redis.gemfile.lock
+++ b/gemfiles/ruby_2.2_rails32_postgres_redis.gemfile.lock
@@ -3,7 +3,7 @@ PATH
   specs:
     ddtrace (1.18.0)
       datadog-ci (~> 0.5.0)
-      debase-ruby_core_source (= 3.2.3)
+      debase-ruby_core_source (= 3.3.0)
       libdatadog (~> 5.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
@@ -55,7 +55,7 @@ GEM
       rexml
     datadog-ci (0.5.0)
       msgpack
-    debase-ruby_core_source (3.2.3)
+    debase-ruby_core_source (3.3.0)
     diff-lcs (1.5.0)
     docile (1.3.5)
     dogstatsd-ruby (5.5.0)

--- a/gemfiles/ruby_2.2_rails32_postgres_sidekiq.gemfile.lock
+++ b/gemfiles/ruby_2.2_rails32_postgres_sidekiq.gemfile.lock
@@ -3,7 +3,7 @@ PATH
   specs:
     ddtrace (1.18.0)
       datadog-ci (~> 0.5.0)
-      debase-ruby_core_source (= 3.2.3)
+      debase-ruby_core_source (= 3.3.0)
       libdatadog (~> 5.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
@@ -56,7 +56,7 @@ GEM
       rexml
     datadog-ci (0.5.0)
       msgpack
-    debase-ruby_core_source (3.2.3)
+    debase-ruby_core_source (3.3.0)
     diff-lcs (1.5.0)
     docile (1.3.5)
     dogstatsd-ruby (5.5.0)

--- a/gemfiles/ruby_2.2_rails4_mysql2.gemfile.lock
+++ b/gemfiles/ruby_2.2_rails4_mysql2.gemfile.lock
@@ -3,7 +3,7 @@ PATH
   specs:
     ddtrace (1.18.0)
       datadog-ci (~> 0.5.0)
-      debase-ruby_core_source (= 3.2.3)
+      debase-ruby_core_source (= 3.3.0)
       libdatadog (~> 5.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
@@ -63,7 +63,7 @@ GEM
     crass (1.0.6)
     datadog-ci (0.5.0)
       msgpack
-    debase-ruby_core_source (3.2.3)
+    debase-ruby_core_source (3.3.0)
     diff-lcs (1.5.0)
     docile (1.3.5)
     dogstatsd-ruby (5.5.0)

--- a/gemfiles/ruby_2.2_rails4_postgres.gemfile.lock
+++ b/gemfiles/ruby_2.2_rails4_postgres.gemfile.lock
@@ -3,7 +3,7 @@ PATH
   specs:
     ddtrace (1.18.0)
       datadog-ci (~> 0.5.0)
-      debase-ruby_core_source (= 3.2.3)
+      debase-ruby_core_source (= 3.3.0)
       libdatadog (~> 5.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
@@ -63,7 +63,7 @@ GEM
     crass (1.0.6)
     datadog-ci (0.5.0)
       msgpack
-    debase-ruby_core_source (3.2.3)
+    debase-ruby_core_source (3.3.0)
     diff-lcs (1.5.0)
     docile (1.3.5)
     dogstatsd-ruby (5.5.0)

--- a/gemfiles/ruby_2.2_rails4_postgres_redis.gemfile.lock
+++ b/gemfiles/ruby_2.2_rails4_postgres_redis.gemfile.lock
@@ -3,7 +3,7 @@ PATH
   specs:
     ddtrace (1.18.0)
       datadog-ci (~> 0.5.0)
-      debase-ruby_core_source (= 3.2.3)
+      debase-ruby_core_source (= 3.3.0)
       libdatadog (~> 5.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
@@ -63,7 +63,7 @@ GEM
     crass (1.0.6)
     datadog-ci (0.5.0)
       msgpack
-    debase-ruby_core_source (3.2.3)
+    debase-ruby_core_source (3.3.0)
     diff-lcs (1.5.0)
     docile (1.3.5)
     dogstatsd-ruby (5.5.0)

--- a/gemfiles/ruby_2.2_rails4_postgres_sidekiq.gemfile.lock
+++ b/gemfiles/ruby_2.2_rails4_postgres_sidekiq.gemfile.lock
@@ -3,7 +3,7 @@ PATH
   specs:
     ddtrace (1.18.0)
       datadog-ci (~> 0.5.0)
-      debase-ruby_core_source (= 3.2.3)
+      debase-ruby_core_source (= 3.3.0)
       libdatadog (~> 5.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
@@ -64,7 +64,7 @@ GEM
     crass (1.0.6)
     datadog-ci (0.5.0)
       msgpack
-    debase-ruby_core_source (3.2.3)
+    debase-ruby_core_source (3.3.0)
     diff-lcs (1.5.0)
     docile (1.3.5)
     dogstatsd-ruby (5.5.0)

--- a/gemfiles/ruby_2.2_rails4_semantic_logger.gemfile.lock
+++ b/gemfiles/ruby_2.2_rails4_semantic_logger.gemfile.lock
@@ -3,7 +3,7 @@ PATH
   specs:
     ddtrace (1.18.0)
       datadog-ci (~> 0.5.0)
-      debase-ruby_core_source (= 3.2.3)
+      debase-ruby_core_source (= 3.3.0)
       libdatadog (~> 5.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
@@ -63,7 +63,7 @@ GEM
     crass (1.0.6)
     datadog-ci (0.5.0)
       msgpack
-    debase-ruby_core_source (3.2.3)
+    debase-ruby_core_source (3.3.0)
     diff-lcs (1.5.0)
     docile (1.3.5)
     dogstatsd-ruby (5.5.0)

--- a/gemfiles/ruby_2.2_rails5_mysql2.gemfile.lock
+++ b/gemfiles/ruby_2.2_rails5_mysql2.gemfile.lock
@@ -3,7 +3,7 @@ PATH
   specs:
     ddtrace (1.18.0)
       datadog-ci (~> 0.5.0)
-      debase-ruby_core_source (= 3.2.3)
+      debase-ruby_core_source (= 3.3.0)
       libdatadog (~> 5.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
@@ -70,7 +70,7 @@ GEM
     crass (1.0.6)
     datadog-ci (0.5.0)
       msgpack
-    debase-ruby_core_source (3.2.3)
+    debase-ruby_core_source (3.3.0)
     diff-lcs (1.5.0)
     docile (1.3.5)
     dogstatsd-ruby (5.5.0)

--- a/gemfiles/ruby_2.2_rails5_postgres.gemfile.lock
+++ b/gemfiles/ruby_2.2_rails5_postgres.gemfile.lock
@@ -3,7 +3,7 @@ PATH
   specs:
     ddtrace (1.18.0)
       datadog-ci (~> 0.5.0)
-      debase-ruby_core_source (= 3.2.3)
+      debase-ruby_core_source (= 3.3.0)
       libdatadog (~> 5.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
@@ -70,7 +70,7 @@ GEM
     crass (1.0.6)
     datadog-ci (0.5.0)
       msgpack
-    debase-ruby_core_source (3.2.3)
+    debase-ruby_core_source (3.3.0)
     diff-lcs (1.5.0)
     docile (1.3.5)
     dogstatsd-ruby (5.5.0)

--- a/gemfiles/ruby_2.2_rails5_postgres_redis.gemfile.lock
+++ b/gemfiles/ruby_2.2_rails5_postgres_redis.gemfile.lock
@@ -3,7 +3,7 @@ PATH
   specs:
     ddtrace (1.18.0)
       datadog-ci (~> 0.5.0)
-      debase-ruby_core_source (= 3.2.3)
+      debase-ruby_core_source (= 3.3.0)
       libdatadog (~> 5.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
@@ -70,7 +70,7 @@ GEM
     crass (1.0.6)
     datadog-ci (0.5.0)
       msgpack
-    debase-ruby_core_source (3.2.3)
+    debase-ruby_core_source (3.3.0)
     diff-lcs (1.5.0)
     docile (1.3.5)
     dogstatsd-ruby (5.5.0)

--- a/gemfiles/ruby_2.2_rails5_postgres_redis_activesupport.gemfile.lock
+++ b/gemfiles/ruby_2.2_rails5_postgres_redis_activesupport.gemfile.lock
@@ -3,7 +3,7 @@ PATH
   specs:
     ddtrace (1.18.0)
       datadog-ci (~> 0.5.0)
-      debase-ruby_core_source (= 3.2.3)
+      debase-ruby_core_source (= 3.3.0)
       libdatadog (~> 5.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
@@ -70,7 +70,7 @@ GEM
     crass (1.0.6)
     datadog-ci (0.5.0)
       msgpack
-    debase-ruby_core_source (3.2.3)
+    debase-ruby_core_source (3.3.0)
     diff-lcs (1.5.0)
     docile (1.3.5)
     dogstatsd-ruby (5.5.0)

--- a/gemfiles/ruby_2.2_rails5_postgres_sidekiq.gemfile.lock
+++ b/gemfiles/ruby_2.2_rails5_postgres_sidekiq.gemfile.lock
@@ -3,7 +3,7 @@ PATH
   specs:
     ddtrace (1.18.0)
       datadog-ci (~> 0.5.0)
-      debase-ruby_core_source (= 3.2.3)
+      debase-ruby_core_source (= 3.3.0)
       libdatadog (~> 5.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
@@ -71,7 +71,7 @@ GEM
     crass (1.0.6)
     datadog-ci (0.5.0)
       msgpack
-    debase-ruby_core_source (3.2.3)
+    debase-ruby_core_source (3.3.0)
     diff-lcs (1.5.0)
     docile (1.3.5)
     dogstatsd-ruby (5.5.0)

--- a/gemfiles/ruby_2.2_rails5_semantic_logger.gemfile.lock
+++ b/gemfiles/ruby_2.2_rails5_semantic_logger.gemfile.lock
@@ -3,7 +3,7 @@ PATH
   specs:
     ddtrace (1.18.0)
       datadog-ci (~> 0.5.0)
-      debase-ruby_core_source (= 3.2.3)
+      debase-ruby_core_source (= 3.3.0)
       libdatadog (~> 5.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
@@ -70,7 +70,7 @@ GEM
     crass (1.0.6)
     datadog-ci (0.5.0)
       msgpack
-    debase-ruby_core_source (3.2.3)
+    debase-ruby_core_source (3.3.0)
     diff-lcs (1.5.0)
     docile (1.3.5)
     dogstatsd-ruby (5.5.0)

--- a/gemfiles/ruby_2.2_redis_3.gemfile.lock
+++ b/gemfiles/ruby_2.2_redis_3.gemfile.lock
@@ -3,7 +3,7 @@ PATH
   specs:
     ddtrace (1.18.0)
       datadog-ci (~> 0.5.0)
-      debase-ruby_core_source (= 3.2.3)
+      debase-ruby_core_source (= 3.3.0)
       libdatadog (~> 5.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
@@ -27,7 +27,7 @@ GEM
       rexml
     datadog-ci (0.5.0)
       msgpack
-    debase-ruby_core_source (3.2.3)
+    debase-ruby_core_source (3.3.0)
     diff-lcs (1.5.0)
     docile (1.3.5)
     dogstatsd-ruby (5.5.0)

--- a/gemfiles/ruby_2.2_relational_db.gemfile.lock
+++ b/gemfiles/ruby_2.2_relational_db.gemfile.lock
@@ -3,7 +3,7 @@ PATH
   specs:
     ddtrace (1.18.0)
       datadog-ci (~> 0.5.0)
-      debase-ruby_core_source (= 3.2.3)
+      debase-ruby_core_source (= 3.3.0)
       libdatadog (~> 5.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
@@ -39,7 +39,7 @@ GEM
       rexml
     datadog-ci (0.5.0)
       msgpack
-    debase-ruby_core_source (3.2.3)
+    debase-ruby_core_source (3.3.0)
     delayed_job (4.1.11)
       activesupport (>= 3.0, < 8.0)
     delayed_job_active_record (4.1.7)

--- a/gemfiles/ruby_2.2_sinatra.gemfile.lock
+++ b/gemfiles/ruby_2.2_sinatra.gemfile.lock
@@ -3,7 +3,7 @@ PATH
   specs:
     ddtrace (1.18.0)
       datadog-ci (~> 0.5.0)
-      debase-ruby_core_source (= 3.2.3)
+      debase-ruby_core_source (= 3.3.0)
       libdatadog (~> 5.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
@@ -27,7 +27,7 @@ GEM
       rexml
     datadog-ci (0.5.0)
       msgpack
-    debase-ruby_core_source (3.2.3)
+    debase-ruby_core_source (3.3.0)
     diff-lcs (1.5.0)
     docile (1.3.5)
     dogstatsd-ruby (5.5.0)

--- a/gemfiles/ruby_2.3_activerecord_3.gemfile.lock
+++ b/gemfiles/ruby_2.3_activerecord_3.gemfile.lock
@@ -3,7 +3,7 @@ PATH
   specs:
     ddtrace (1.18.0)
       datadog-ci (~> 0.5.0)
-      debase-ruby_core_source (= 3.2.3)
+      debase-ruby_core_source (= 3.3.0)
       libdatadog (~> 5.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
@@ -43,7 +43,7 @@ GEM
       rexml
     datadog-ci (0.5.0)
       msgpack
-    debase-ruby_core_source (3.2.3)
+    debase-ruby_core_source (3.3.0)
     diff-lcs (1.5.0)
     docile (1.3.5)
     dogstatsd-ruby (5.6.0)

--- a/gemfiles/ruby_2.3_activesupport.gemfile.lock
+++ b/gemfiles/ruby_2.3_activesupport.gemfile.lock
@@ -3,7 +3,7 @@ PATH
   specs:
     ddtrace (1.18.0)
       datadog-ci (~> 0.5.0)
-      debase-ruby_core_source (= 3.2.3)
+      debase-ruby_core_source (= 3.3.0)
       libdatadog (~> 5.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
@@ -62,7 +62,7 @@ GEM
     crass (1.0.6)
     datadog-ci (0.5.0)
       msgpack
-    debase-ruby_core_source (3.2.3)
+    debase-ruby_core_source (3.3.0)
     descendants_tracker (0.0.4)
       thread_safe (~> 0.3, >= 0.3.1)
     diff-lcs (1.5.0)

--- a/gemfiles/ruby_2.3_aws.gemfile.lock
+++ b/gemfiles/ruby_2.3_aws.gemfile.lock
@@ -3,7 +3,7 @@ PATH
   specs:
     ddtrace (1.18.0)
       datadog-ci (~> 0.5.0)
-      debase-ruby_core_source (= 3.2.3)
+      debase-ruby_core_source (= 3.3.0)
       libdatadog (~> 5.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
@@ -1448,7 +1448,7 @@ GEM
       rexml
     datadog-ci (0.5.0)
       msgpack
-    debase-ruby_core_source (3.2.3)
+    debase-ruby_core_source (3.3.0)
     diff-lcs (1.5.0)
     docile (1.3.5)
     dogstatsd-ruby (5.6.0)

--- a/gemfiles/ruby_2.3_contrib.gemfile.lock
+++ b/gemfiles/ruby_2.3_contrib.gemfile.lock
@@ -3,7 +3,7 @@ PATH
   specs:
     ddtrace (1.18.0)
       datadog-ci (~> 0.5.0)
-      debase-ruby_core_source (= 3.2.3)
+      debase-ruby_core_source (= 3.3.0)
       libdatadog (~> 5.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
@@ -34,7 +34,7 @@ GEM
     dalli (2.7.11)
     datadog-ci (0.5.0)
       msgpack
-    debase-ruby_core_source (3.2.3)
+    debase-ruby_core_source (3.3.0)
     diff-lcs (1.5.0)
     docile (1.3.5)
     dogstatsd-ruby (5.5.0)

--- a/gemfiles/ruby_2.3_contrib_old.gemfile.lock
+++ b/gemfiles/ruby_2.3_contrib_old.gemfile.lock
@@ -3,7 +3,7 @@ PATH
   specs:
     ddtrace (1.18.0)
       datadog-ci (~> 0.5.0)
-      debase-ruby_core_source (= 3.2.3)
+      debase-ruby_core_source (= 3.3.0)
       libdatadog (~> 5.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
@@ -27,7 +27,7 @@ GEM
       rexml
     datadog-ci (0.5.0)
       msgpack
-    debase-ruby_core_source (3.2.3)
+    debase-ruby_core_source (3.3.0)
     diff-lcs (1.5.0)
     docile (1.3.5)
     dogstatsd-ruby (5.5.0)

--- a/gemfiles/ruby_2.3_core_old.gemfile.lock
+++ b/gemfiles/ruby_2.3_core_old.gemfile.lock
@@ -3,7 +3,7 @@ PATH
   specs:
     ddtrace (1.18.0)
       datadog-ci (~> 0.5.0)
-      debase-ruby_core_source (= 3.2.3)
+      debase-ruby_core_source (= 3.3.0)
       libdatadog (~> 5.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
@@ -27,7 +27,7 @@ GEM
       rexml
     datadog-ci (0.5.0)
       msgpack
-    debase-ruby_core_source (3.2.3)
+    debase-ruby_core_source (3.3.0)
     diff-lcs (1.5.0)
     docile (1.3.5)
     dogstatsd-ruby (4.8.3)

--- a/gemfiles/ruby_2.3_elasticsearch_7.gemfile.lock
+++ b/gemfiles/ruby_2.3_elasticsearch_7.gemfile.lock
@@ -3,7 +3,7 @@ PATH
   specs:
     ddtrace (1.18.0)
       datadog-ci (~> 0.5.0)
-      debase-ruby_core_source (= 3.2.3)
+      debase-ruby_core_source (= 3.3.0)
       libdatadog (~> 5.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
@@ -28,7 +28,7 @@ GEM
       rexml
     datadog-ci (0.5.0)
       msgpack
-    debase-ruby_core_source (3.2.3)
+    debase-ruby_core_source (3.3.0)
     diff-lcs (1.5.0)
     docile (1.3.5)
     dogstatsd-ruby (5.6.1)

--- a/gemfiles/ruby_2.3_hanami_1.gemfile.lock
+++ b/gemfiles/ruby_2.3_hanami_1.gemfile.lock
@@ -3,7 +3,7 @@ PATH
   specs:
     ddtrace (1.18.0)
       datadog-ci (~> 0.5.0)
-      debase-ruby_core_source (= 3.2.3)
+      debase-ruby_core_source (= 3.3.0)
       libdatadog (~> 5.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
@@ -27,7 +27,7 @@ GEM
       rexml
     datadog-ci (0.5.0)
       msgpack
-    debase-ruby_core_source (3.2.3)
+    debase-ruby_core_source (3.3.0)
     diff-lcs (1.5.0)
     docile (1.3.5)
     dogstatsd-ruby (5.5.0)

--- a/gemfiles/ruby_2.3_http.gemfile.lock
+++ b/gemfiles/ruby_2.3_http.gemfile.lock
@@ -3,7 +3,7 @@ PATH
   specs:
     ddtrace (1.18.0)
       datadog-ci (~> 0.5.0)
-      debase-ruby_core_source (= 3.2.3)
+      debase-ruby_core_source (= 3.3.0)
       libdatadog (~> 5.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
@@ -27,7 +27,7 @@ GEM
       rexml
     datadog-ci (0.5.0)
       msgpack
-    debase-ruby_core_source (3.2.3)
+    debase-ruby_core_source (3.3.0)
     diff-lcs (1.5.0)
     docile (1.3.5)
     dogstatsd-ruby (5.6.1)

--- a/gemfiles/ruby_2.3_opentracing.gemfile.lock
+++ b/gemfiles/ruby_2.3_opentracing.gemfile.lock
@@ -3,7 +3,7 @@ PATH
   specs:
     ddtrace (1.18.0)
       datadog-ci (~> 0.5.0)
-      debase-ruby_core_source (= 3.2.3)
+      debase-ruby_core_source (= 3.3.0)
       libdatadog (~> 5.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
@@ -28,7 +28,7 @@ GEM
       rexml
     datadog-ci (0.5.0)
       msgpack
-    debase-ruby_core_source (3.2.3)
+    debase-ruby_core_source (3.3.0)
     diff-lcs (1.5.0)
     docile (1.3.5)
     dogstatsd-ruby (5.6.1)

--- a/gemfiles/ruby_2.3_rack_1.gemfile.lock
+++ b/gemfiles/ruby_2.3_rack_1.gemfile.lock
@@ -3,7 +3,7 @@ PATH
   specs:
     ddtrace (1.18.0)
       datadog-ci (~> 0.5.0)
-      debase-ruby_core_source (= 3.2.3)
+      debase-ruby_core_source (= 3.3.0)
       libdatadog (~> 5.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
@@ -27,7 +27,7 @@ GEM
       rexml
     datadog-ci (0.5.0)
       msgpack
-    debase-ruby_core_source (3.2.3)
+    debase-ruby_core_source (3.3.0)
     diff-lcs (1.5.0)
     docile (1.3.5)
     dogstatsd-ruby (5.6.1)

--- a/gemfiles/ruby_2.3_rack_2.gemfile.lock
+++ b/gemfiles/ruby_2.3_rack_2.gemfile.lock
@@ -3,7 +3,7 @@ PATH
   specs:
     ddtrace (1.18.0)
       datadog-ci (~> 0.5.0)
-      debase-ruby_core_source (= 3.2.3)
+      debase-ruby_core_source (= 3.3.0)
       libdatadog (~> 5.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
@@ -27,7 +27,7 @@ GEM
       rexml
     datadog-ci (0.5.0)
       msgpack
-    debase-ruby_core_source (3.2.3)
+    debase-ruby_core_source (3.3.0)
     diff-lcs (1.5.0)
     docile (1.3.5)
     dogstatsd-ruby (5.6.1)

--- a/gemfiles/ruby_2.3_rails32_mysql2.gemfile.lock
+++ b/gemfiles/ruby_2.3_rails32_mysql2.gemfile.lock
@@ -3,7 +3,7 @@ PATH
   specs:
     ddtrace (1.18.0)
       datadog-ci (~> 0.5.0)
-      debase-ruby_core_source (= 3.2.3)
+      debase-ruby_core_source (= 3.3.0)
       libdatadog (~> 5.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
@@ -59,7 +59,7 @@ GEM
       rexml
     datadog-ci (0.5.0)
       msgpack
-    debase-ruby_core_source (3.2.3)
+    debase-ruby_core_source (3.3.0)
     diff-lcs (1.5.0)
     docile (1.3.5)
     dogstatsd-ruby (5.5.0)

--- a/gemfiles/ruby_2.3_rails32_postgres.gemfile.lock
+++ b/gemfiles/ruby_2.3_rails32_postgres.gemfile.lock
@@ -3,7 +3,7 @@ PATH
   specs:
     ddtrace (1.18.0)
       datadog-ci (~> 0.5.0)
-      debase-ruby_core_source (= 3.2.3)
+      debase-ruby_core_source (= 3.3.0)
       libdatadog (~> 5.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
@@ -55,7 +55,7 @@ GEM
       rexml
     datadog-ci (0.5.0)
       msgpack
-    debase-ruby_core_source (3.2.3)
+    debase-ruby_core_source (3.3.0)
     diff-lcs (1.5.0)
     docile (1.3.5)
     dogstatsd-ruby (5.5.0)

--- a/gemfiles/ruby_2.3_rails32_postgres_redis.gemfile.lock
+++ b/gemfiles/ruby_2.3_rails32_postgres_redis.gemfile.lock
@@ -3,7 +3,7 @@ PATH
   specs:
     ddtrace (1.18.0)
       datadog-ci (~> 0.5.0)
-      debase-ruby_core_source (= 3.2.3)
+      debase-ruby_core_source (= 3.3.0)
       libdatadog (~> 5.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
@@ -55,7 +55,7 @@ GEM
       rexml
     datadog-ci (0.5.0)
       msgpack
-    debase-ruby_core_source (3.2.3)
+    debase-ruby_core_source (3.3.0)
     diff-lcs (1.5.0)
     docile (1.3.5)
     dogstatsd-ruby (5.5.0)

--- a/gemfiles/ruby_2.3_rails32_postgres_sidekiq.gemfile.lock
+++ b/gemfiles/ruby_2.3_rails32_postgres_sidekiq.gemfile.lock
@@ -3,7 +3,7 @@ PATH
   specs:
     ddtrace (1.18.0)
       datadog-ci (~> 0.5.0)
-      debase-ruby_core_source (= 3.2.3)
+      debase-ruby_core_source (= 3.3.0)
       libdatadog (~> 5.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
@@ -56,7 +56,7 @@ GEM
       rexml
     datadog-ci (0.5.0)
       msgpack
-    debase-ruby_core_source (3.2.3)
+    debase-ruby_core_source (3.3.0)
     diff-lcs (1.5.0)
     docile (1.3.5)
     dogstatsd-ruby (5.5.0)

--- a/gemfiles/ruby_2.3_rails4_mysql2.gemfile.lock
+++ b/gemfiles/ruby_2.3_rails4_mysql2.gemfile.lock
@@ -3,7 +3,7 @@ PATH
   specs:
     ddtrace (1.18.0)
       datadog-ci (~> 0.5.0)
-      debase-ruby_core_source (= 3.2.3)
+      debase-ruby_core_source (= 3.3.0)
       libdatadog (~> 5.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
@@ -63,7 +63,7 @@ GEM
     crass (1.0.6)
     datadog-ci (0.5.0)
       msgpack
-    debase-ruby_core_source (3.2.3)
+    debase-ruby_core_source (3.3.0)
     diff-lcs (1.5.0)
     docile (1.3.5)
     dogstatsd-ruby (5.5.0)

--- a/gemfiles/ruby_2.3_rails4_postgres.gemfile.lock
+++ b/gemfiles/ruby_2.3_rails4_postgres.gemfile.lock
@@ -3,7 +3,7 @@ PATH
   specs:
     ddtrace (1.18.0)
       datadog-ci (~> 0.5.0)
-      debase-ruby_core_source (= 3.2.3)
+      debase-ruby_core_source (= 3.3.0)
       libdatadog (~> 5.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
@@ -63,7 +63,7 @@ GEM
     crass (1.0.6)
     datadog-ci (0.5.0)
       msgpack
-    debase-ruby_core_source (3.2.3)
+    debase-ruby_core_source (3.3.0)
     diff-lcs (1.5.0)
     docile (1.3.5)
     dogstatsd-ruby (5.5.0)

--- a/gemfiles/ruby_2.3_rails4_postgres_redis.gemfile.lock
+++ b/gemfiles/ruby_2.3_rails4_postgres_redis.gemfile.lock
@@ -3,7 +3,7 @@ PATH
   specs:
     ddtrace (1.18.0)
       datadog-ci (~> 0.5.0)
-      debase-ruby_core_source (= 3.2.3)
+      debase-ruby_core_source (= 3.3.0)
       libdatadog (~> 5.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
@@ -63,7 +63,7 @@ GEM
     crass (1.0.6)
     datadog-ci (0.5.0)
       msgpack
-    debase-ruby_core_source (3.2.3)
+    debase-ruby_core_source (3.3.0)
     diff-lcs (1.5.0)
     docile (1.3.5)
     dogstatsd-ruby (5.5.0)

--- a/gemfiles/ruby_2.3_rails4_postgres_sidekiq.gemfile.lock
+++ b/gemfiles/ruby_2.3_rails4_postgres_sidekiq.gemfile.lock
@@ -3,7 +3,7 @@ PATH
   specs:
     ddtrace (1.18.0)
       datadog-ci (~> 0.5.0)
-      debase-ruby_core_source (= 3.2.3)
+      debase-ruby_core_source (= 3.3.0)
       libdatadog (~> 5.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
@@ -64,7 +64,7 @@ GEM
     crass (1.0.6)
     datadog-ci (0.5.0)
       msgpack
-    debase-ruby_core_source (3.2.3)
+    debase-ruby_core_source (3.3.0)
     diff-lcs (1.5.0)
     docile (1.3.5)
     dogstatsd-ruby (5.5.0)

--- a/gemfiles/ruby_2.3_rails4_semantic_logger.gemfile.lock
+++ b/gemfiles/ruby_2.3_rails4_semantic_logger.gemfile.lock
@@ -3,7 +3,7 @@ PATH
   specs:
     ddtrace (1.18.0)
       datadog-ci (~> 0.5.0)
-      debase-ruby_core_source (= 3.2.3)
+      debase-ruby_core_source (= 3.3.0)
       libdatadog (~> 5.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
@@ -63,7 +63,7 @@ GEM
     crass (1.0.6)
     datadog-ci (0.5.0)
       msgpack
-    debase-ruby_core_source (3.2.3)
+    debase-ruby_core_source (3.3.0)
     diff-lcs (1.5.0)
     docile (1.3.5)
     dogstatsd-ruby (5.5.0)

--- a/gemfiles/ruby_2.3_rails5_mysql2.gemfile.lock
+++ b/gemfiles/ruby_2.3_rails5_mysql2.gemfile.lock
@@ -3,7 +3,7 @@ PATH
   specs:
     ddtrace (1.18.0)
       datadog-ci (~> 0.5.0)
-      debase-ruby_core_source (= 3.2.3)
+      debase-ruby_core_source (= 3.3.0)
       libdatadog (~> 5.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
@@ -70,7 +70,7 @@ GEM
     crass (1.0.6)
     datadog-ci (0.5.0)
       msgpack
-    debase-ruby_core_source (3.2.3)
+    debase-ruby_core_source (3.3.0)
     diff-lcs (1.5.0)
     docile (1.3.5)
     dogstatsd-ruby (5.5.0)

--- a/gemfiles/ruby_2.3_rails5_postgres.gemfile.lock
+++ b/gemfiles/ruby_2.3_rails5_postgres.gemfile.lock
@@ -3,7 +3,7 @@ PATH
   specs:
     ddtrace (1.18.0)
       datadog-ci (~> 0.5.0)
-      debase-ruby_core_source (= 3.2.3)
+      debase-ruby_core_source (= 3.3.0)
       libdatadog (~> 5.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
@@ -70,7 +70,7 @@ GEM
     crass (1.0.6)
     datadog-ci (0.5.0)
       msgpack
-    debase-ruby_core_source (3.2.3)
+    debase-ruby_core_source (3.3.0)
     diff-lcs (1.5.0)
     docile (1.3.5)
     dogstatsd-ruby (5.5.0)

--- a/gemfiles/ruby_2.3_rails5_postgres_redis.gemfile.lock
+++ b/gemfiles/ruby_2.3_rails5_postgres_redis.gemfile.lock
@@ -3,7 +3,7 @@ PATH
   specs:
     ddtrace (1.18.0)
       datadog-ci (~> 0.5.0)
-      debase-ruby_core_source (= 3.2.3)
+      debase-ruby_core_source (= 3.3.0)
       libdatadog (~> 5.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
@@ -70,7 +70,7 @@ GEM
     crass (1.0.6)
     datadog-ci (0.5.0)
       msgpack
-    debase-ruby_core_source (3.2.3)
+    debase-ruby_core_source (3.3.0)
     diff-lcs (1.5.0)
     docile (1.3.5)
     dogstatsd-ruby (5.5.0)

--- a/gemfiles/ruby_2.3_rails5_postgres_redis_activesupport.gemfile.lock
+++ b/gemfiles/ruby_2.3_rails5_postgres_redis_activesupport.gemfile.lock
@@ -3,7 +3,7 @@ PATH
   specs:
     ddtrace (1.18.0)
       datadog-ci (~> 0.5.0)
-      debase-ruby_core_source (= 3.2.3)
+      debase-ruby_core_source (= 3.3.0)
       libdatadog (~> 5.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
@@ -70,7 +70,7 @@ GEM
     crass (1.0.6)
     datadog-ci (0.5.0)
       msgpack
-    debase-ruby_core_source (3.2.3)
+    debase-ruby_core_source (3.3.0)
     diff-lcs (1.5.0)
     docile (1.3.5)
     dogstatsd-ruby (5.5.0)

--- a/gemfiles/ruby_2.3_rails5_postgres_sidekiq.gemfile.lock
+++ b/gemfiles/ruby_2.3_rails5_postgres_sidekiq.gemfile.lock
@@ -3,7 +3,7 @@ PATH
   specs:
     ddtrace (1.18.0)
       datadog-ci (~> 0.5.0)
-      debase-ruby_core_source (= 3.2.3)
+      debase-ruby_core_source (= 3.3.0)
       libdatadog (~> 5.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
@@ -71,7 +71,7 @@ GEM
     crass (1.0.6)
     datadog-ci (0.5.0)
       msgpack
-    debase-ruby_core_source (3.2.3)
+    debase-ruby_core_source (3.3.0)
     diff-lcs (1.5.0)
     docile (1.3.5)
     dogstatsd-ruby (5.5.0)

--- a/gemfiles/ruby_2.3_rails5_semantic_logger.gemfile.lock
+++ b/gemfiles/ruby_2.3_rails5_semantic_logger.gemfile.lock
@@ -3,7 +3,7 @@ PATH
   specs:
     ddtrace (1.18.0)
       datadog-ci (~> 0.5.0)
-      debase-ruby_core_source (= 3.2.3)
+      debase-ruby_core_source (= 3.3.0)
       libdatadog (~> 5.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
@@ -70,7 +70,7 @@ GEM
     crass (1.0.6)
     datadog-ci (0.5.0)
       msgpack
-    debase-ruby_core_source (3.2.3)
+    debase-ruby_core_source (3.3.0)
     diff-lcs (1.5.0)
     docile (1.3.5)
     dogstatsd-ruby (5.5.0)

--- a/gemfiles/ruby_2.3_redis_3.gemfile.lock
+++ b/gemfiles/ruby_2.3_redis_3.gemfile.lock
@@ -3,7 +3,7 @@ PATH
   specs:
     ddtrace (1.18.0)
       datadog-ci (~> 0.5.0)
-      debase-ruby_core_source (= 3.2.3)
+      debase-ruby_core_source (= 3.3.0)
       libdatadog (~> 5.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
@@ -27,7 +27,7 @@ GEM
       rexml
     datadog-ci (0.5.0)
       msgpack
-    debase-ruby_core_source (3.2.3)
+    debase-ruby_core_source (3.3.0)
     diff-lcs (1.5.0)
     docile (1.3.5)
     dogstatsd-ruby (5.5.0)

--- a/gemfiles/ruby_2.3_relational_db.gemfile.lock
+++ b/gemfiles/ruby_2.3_relational_db.gemfile.lock
@@ -3,7 +3,7 @@ PATH
   specs:
     ddtrace (1.18.0)
       datadog-ci (~> 0.5.0)
-      debase-ruby_core_source (= 3.2.3)
+      debase-ruby_core_source (= 3.3.0)
       libdatadog (~> 5.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
@@ -39,7 +39,7 @@ GEM
       rexml
     datadog-ci (0.5.0)
       msgpack
-    debase-ruby_core_source (3.2.3)
+    debase-ruby_core_source (3.3.0)
     delayed_job (4.1.11)
       activesupport (>= 3.0, < 8.0)
     delayed_job_active_record (4.1.7)

--- a/gemfiles/ruby_2.3_resque2_redis3.gemfile.lock
+++ b/gemfiles/ruby_2.3_resque2_redis3.gemfile.lock
@@ -3,7 +3,7 @@ PATH
   specs:
     ddtrace (1.18.0)
       datadog-ci (~> 0.5.0)
-      debase-ruby_core_source (= 3.2.3)
+      debase-ruby_core_source (= 3.3.0)
       libdatadog (~> 5.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
@@ -27,7 +27,7 @@ GEM
       rexml
     datadog-ci (0.5.0)
       msgpack
-    debase-ruby_core_source (3.2.3)
+    debase-ruby_core_source (3.3.0)
     diff-lcs (1.5.0)
     docile (1.3.5)
     dogstatsd-ruby (5.5.0)

--- a/gemfiles/ruby_2.3_resque2_redis4.gemfile.lock
+++ b/gemfiles/ruby_2.3_resque2_redis4.gemfile.lock
@@ -3,7 +3,7 @@ PATH
   specs:
     ddtrace (1.18.0)
       datadog-ci (~> 0.5.0)
-      debase-ruby_core_source (= 3.2.3)
+      debase-ruby_core_source (= 3.3.0)
       libdatadog (~> 5.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
@@ -27,7 +27,7 @@ GEM
       rexml
     datadog-ci (0.5.0)
       msgpack
-    debase-ruby_core_source (3.2.3)
+    debase-ruby_core_source (3.3.0)
     diff-lcs (1.5.0)
     docile (1.3.5)
     dogstatsd-ruby (5.5.0)

--- a/gemfiles/ruby_2.3_sinatra.gemfile.lock
+++ b/gemfiles/ruby_2.3_sinatra.gemfile.lock
@@ -3,7 +3,7 @@ PATH
   specs:
     ddtrace (1.18.0)
       datadog-ci (~> 0.5.0)
-      debase-ruby_core_source (= 3.2.3)
+      debase-ruby_core_source (= 3.3.0)
       libdatadog (~> 5.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
@@ -27,7 +27,7 @@ GEM
       rexml
     datadog-ci (0.5.0)
       msgpack
-    debase-ruby_core_source (3.2.3)
+    debase-ruby_core_source (3.3.0)
     diff-lcs (1.5.0)
     docile (1.3.5)
     dogstatsd-ruby (5.5.0)

--- a/gemfiles/ruby_2.4_activerecord_4.gemfile.lock
+++ b/gemfiles/ruby_2.4_activerecord_4.gemfile.lock
@@ -3,7 +3,7 @@ PATH
   specs:
     ddtrace (1.18.0)
       datadog-ci (~> 0.5.0)
-      debase-ruby_core_source (= 3.2.3)
+      debase-ruby_core_source (= 3.3.0)
       libdatadog (~> 5.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
@@ -42,7 +42,7 @@ GEM
     cri (2.15.10)
     datadog-ci (0.5.0)
       msgpack
-    debase-ruby_core_source (3.2.3)
+    debase-ruby_core_source (3.3.0)
     diff-lcs (1.5.0)
     docile (1.3.5)
     dogstatsd-ruby (5.6.0)

--- a/gemfiles/ruby_2.4_activesupport.gemfile.lock
+++ b/gemfiles/ruby_2.4_activesupport.gemfile.lock
@@ -3,7 +3,7 @@ PATH
   specs:
     ddtrace (1.18.0)
       datadog-ci (~> 0.5.0)
-      debase-ruby_core_source (= 3.2.3)
+      debase-ruby_core_source (= 3.3.0)
       libdatadog (~> 5.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
@@ -57,7 +57,7 @@ GEM
     cri (2.15.10)
     datadog-ci (0.5.0)
       msgpack
-    debase-ruby_core_source (3.2.3)
+    debase-ruby_core_source (3.3.0)
     diff-lcs (1.5.0)
     digest-crc (0.6.5)
       rake (>= 12.0.0, < 14.0.0)

--- a/gemfiles/ruby_2.4_aws.gemfile.lock
+++ b/gemfiles/ruby_2.4_aws.gemfile.lock
@@ -3,7 +3,7 @@ PATH
   specs:
     ddtrace (1.18.0)
       datadog-ci (~> 0.5.0)
-      debase-ruby_core_source (= 3.2.3)
+      debase-ruby_core_source (= 3.3.0)
       libdatadog (~> 5.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
@@ -1450,7 +1450,7 @@ GEM
     cri (2.15.10)
     datadog-ci (0.5.0)
       msgpack
-    debase-ruby_core_source (3.2.3)
+    debase-ruby_core_source (3.3.0)
     diff-lcs (1.5.0)
     docile (1.3.5)
     dogstatsd-ruby (5.6.0)

--- a/gemfiles/ruby_2.4_contrib.gemfile.lock
+++ b/gemfiles/ruby_2.4_contrib.gemfile.lock
@@ -3,7 +3,7 @@ PATH
   specs:
     ddtrace (1.18.0)
       datadog-ci (~> 0.5.0)
-      debase-ruby_core_source (= 3.2.3)
+      debase-ruby_core_source (= 3.3.0)
       libdatadog (~> 5.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
@@ -36,7 +36,7 @@ GEM
     dalli (2.7.11)
     datadog-ci (0.5.0)
       msgpack
-    debase-ruby_core_source (3.2.3)
+    debase-ruby_core_source (3.3.0)
     diff-lcs (1.3)
     docile (1.3.5)
     dogstatsd-ruby (5.5.0)

--- a/gemfiles/ruby_2.4_contrib_old.gemfile.lock
+++ b/gemfiles/ruby_2.4_contrib_old.gemfile.lock
@@ -3,7 +3,7 @@ PATH
   specs:
     ddtrace (1.18.0)
       datadog-ci (~> 0.5.0)
-      debase-ruby_core_source (= 3.2.3)
+      debase-ruby_core_source (= 3.3.0)
       libdatadog (~> 5.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
@@ -29,7 +29,7 @@ GEM
     cri (2.15.10)
     datadog-ci (0.5.0)
       msgpack
-    debase-ruby_core_source (3.2.3)
+    debase-ruby_core_source (3.3.0)
     diff-lcs (1.5.0)
     docile (1.3.5)
     dogstatsd-ruby (5.5.0)

--- a/gemfiles/ruby_2.4_core_old.gemfile.lock
+++ b/gemfiles/ruby_2.4_core_old.gemfile.lock
@@ -3,7 +3,7 @@ PATH
   specs:
     ddtrace (1.18.0)
       datadog-ci (~> 0.5.0)
-      debase-ruby_core_source (= 3.2.3)
+      debase-ruby_core_source (= 3.3.0)
       libdatadog (~> 5.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
@@ -29,7 +29,7 @@ GEM
     cri (2.15.10)
     datadog-ci (0.5.0)
       msgpack
-    debase-ruby_core_source (3.2.3)
+    debase-ruby_core_source (3.3.0)
     diff-lcs (1.5.0)
     docile (1.3.5)
     dogstatsd-ruby (4.8.3)

--- a/gemfiles/ruby_2.4_elasticsearch_7.gemfile.lock
+++ b/gemfiles/ruby_2.4_elasticsearch_7.gemfile.lock
@@ -3,7 +3,7 @@ PATH
   specs:
     ddtrace (1.18.0)
       datadog-ci (~> 0.5.0)
-      debase-ruby_core_source (= 3.2.3)
+      debase-ruby_core_source (= 3.3.0)
       libdatadog (~> 5.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
@@ -30,7 +30,7 @@ GEM
     cri (2.15.10)
     datadog-ci (0.5.0)
       msgpack
-    debase-ruby_core_source (3.2.3)
+    debase-ruby_core_source (3.3.0)
     diff-lcs (1.5.0)
     docile (1.3.5)
     dogstatsd-ruby (5.6.1)

--- a/gemfiles/ruby_2.4_hanami_1.gemfile.lock
+++ b/gemfiles/ruby_2.4_hanami_1.gemfile.lock
@@ -3,7 +3,7 @@ PATH
   specs:
     ddtrace (1.18.0)
       datadog-ci (~> 0.5.0)
-      debase-ruby_core_source (= 3.2.3)
+      debase-ruby_core_source (= 3.3.0)
       libdatadog (~> 5.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
@@ -29,7 +29,7 @@ GEM
     cri (2.15.10)
     datadog-ci (0.5.0)
       msgpack
-    debase-ruby_core_source (3.2.3)
+    debase-ruby_core_source (3.3.0)
     diff-lcs (1.5.0)
     docile (1.3.5)
     dogstatsd-ruby (5.5.0)

--- a/gemfiles/ruby_2.4_http.gemfile.lock
+++ b/gemfiles/ruby_2.4_http.gemfile.lock
@@ -3,7 +3,7 @@ PATH
   specs:
     ddtrace (1.18.0)
       datadog-ci (~> 0.5.0)
-      debase-ruby_core_source (= 3.2.3)
+      debase-ruby_core_source (= 3.3.0)
       libdatadog (~> 5.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
@@ -29,7 +29,7 @@ GEM
     cri (2.15.10)
     datadog-ci (0.5.0)
       msgpack
-    debase-ruby_core_source (3.2.3)
+    debase-ruby_core_source (3.3.0)
     diff-lcs (1.5.0)
     docile (1.3.5)
     dogstatsd-ruby (5.6.1)

--- a/gemfiles/ruby_2.4_opensearch_2.gemfile.lock
+++ b/gemfiles/ruby_2.4_opensearch_2.gemfile.lock
@@ -3,7 +3,7 @@ PATH
   specs:
     ddtrace (1.18.0)
       datadog-ci (~> 0.5.0)
-      debase-ruby_core_source (= 3.2.3)
+      debase-ruby_core_source (= 3.3.0)
       libdatadog (~> 5.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
@@ -30,7 +30,7 @@ GEM
     cri (2.15.10)
     datadog-ci (0.5.0)
       msgpack
-    debase-ruby_core_source (3.2.3)
+    debase-ruby_core_source (3.3.0)
     diff-lcs (1.5.0)
     docile (1.3.5)
     dogstatsd-ruby (5.6.1)

--- a/gemfiles/ruby_2.4_opentracing.gemfile.lock
+++ b/gemfiles/ruby_2.4_opentracing.gemfile.lock
@@ -3,7 +3,7 @@ PATH
   specs:
     ddtrace (1.18.0)
       datadog-ci (~> 0.5.0)
-      debase-ruby_core_source (= 3.2.3)
+      debase-ruby_core_source (= 3.3.0)
       libdatadog (~> 5.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
@@ -30,7 +30,7 @@ GEM
     cri (2.15.10)
     datadog-ci (0.5.0)
       msgpack
-    debase-ruby_core_source (3.2.3)
+    debase-ruby_core_source (3.3.0)
     diff-lcs (1.5.0)
     docile (1.3.5)
     dogstatsd-ruby (5.6.1)

--- a/gemfiles/ruby_2.4_rack_1.gemfile.lock
+++ b/gemfiles/ruby_2.4_rack_1.gemfile.lock
@@ -3,7 +3,7 @@ PATH
   specs:
     ddtrace (1.18.0)
       datadog-ci (~> 0.5.0)
-      debase-ruby_core_source (= 3.2.3)
+      debase-ruby_core_source (= 3.3.0)
       libdatadog (~> 5.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
@@ -29,7 +29,7 @@ GEM
     cri (2.15.10)
     datadog-ci (0.5.0)
       msgpack
-    debase-ruby_core_source (3.2.3)
+    debase-ruby_core_source (3.3.0)
     diff-lcs (1.5.0)
     docile (1.3.5)
     dogstatsd-ruby (5.6.1)

--- a/gemfiles/ruby_2.4_rack_2.gemfile.lock
+++ b/gemfiles/ruby_2.4_rack_2.gemfile.lock
@@ -3,7 +3,7 @@ PATH
   specs:
     ddtrace (1.18.0)
       datadog-ci (~> 0.5.0)
-      debase-ruby_core_source (= 3.2.3)
+      debase-ruby_core_source (= 3.3.0)
       libdatadog (~> 5.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
@@ -29,7 +29,7 @@ GEM
     cri (2.15.10)
     datadog-ci (0.5.0)
       msgpack
-    debase-ruby_core_source (3.2.3)
+    debase-ruby_core_source (3.3.0)
     diff-lcs (1.5.0)
     docile (1.3.5)
     dogstatsd-ruby (5.6.1)

--- a/gemfiles/ruby_2.4_rack_3.gemfile.lock
+++ b/gemfiles/ruby_2.4_rack_3.gemfile.lock
@@ -3,7 +3,7 @@ PATH
   specs:
     ddtrace (1.18.0)
       datadog-ci (~> 0.5.0)
-      debase-ruby_core_source (= 3.2.3)
+      debase-ruby_core_source (= 3.3.0)
       libdatadog (~> 5.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
@@ -29,7 +29,7 @@ GEM
     cri (2.15.10)
     datadog-ci (0.5.0)
       msgpack
-    debase-ruby_core_source (3.2.3)
+    debase-ruby_core_source (3.3.0)
     diff-lcs (1.5.0)
     docile (1.3.5)
     dogstatsd-ruby (5.6.1)

--- a/gemfiles/ruby_2.4_rails5_mysql2.gemfile.lock
+++ b/gemfiles/ruby_2.4_rails5_mysql2.gemfile.lock
@@ -3,7 +3,7 @@ PATH
   specs:
     ddtrace (1.18.0)
       datadog-ci (~> 0.5.0)
-      debase-ruby_core_source (= 3.2.3)
+      debase-ruby_core_source (= 3.3.0)
       libdatadog (~> 5.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
@@ -72,7 +72,7 @@ GEM
     cri (2.15.10)
     datadog-ci (0.5.0)
       msgpack
-    debase-ruby_core_source (3.2.3)
+    debase-ruby_core_source (3.3.0)
     diff-lcs (1.5.0)
     docile (1.3.5)
     dogstatsd-ruby (5.5.0)

--- a/gemfiles/ruby_2.4_rails5_postgres.gemfile.lock
+++ b/gemfiles/ruby_2.4_rails5_postgres.gemfile.lock
@@ -3,7 +3,7 @@ PATH
   specs:
     ddtrace (1.18.0)
       datadog-ci (~> 0.5.0)
-      debase-ruby_core_source (= 3.2.3)
+      debase-ruby_core_source (= 3.3.0)
       libdatadog (~> 5.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
@@ -72,7 +72,7 @@ GEM
     cri (2.15.10)
     datadog-ci (0.5.0)
       msgpack
-    debase-ruby_core_source (3.2.3)
+    debase-ruby_core_source (3.3.0)
     diff-lcs (1.5.0)
     docile (1.3.5)
     dogstatsd-ruby (5.5.0)

--- a/gemfiles/ruby_2.4_rails5_postgres_redis.gemfile.lock
+++ b/gemfiles/ruby_2.4_rails5_postgres_redis.gemfile.lock
@@ -3,7 +3,7 @@ PATH
   specs:
     ddtrace (1.18.0)
       datadog-ci (~> 0.5.0)
-      debase-ruby_core_source (= 3.2.3)
+      debase-ruby_core_source (= 3.3.0)
       libdatadog (~> 5.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
@@ -72,7 +72,7 @@ GEM
     cri (2.15.10)
     datadog-ci (0.5.0)
       msgpack
-    debase-ruby_core_source (3.2.3)
+    debase-ruby_core_source (3.3.0)
     diff-lcs (1.5.0)
     docile (1.3.5)
     dogstatsd-ruby (5.5.0)

--- a/gemfiles/ruby_2.4_rails5_postgres_redis_activesupport.gemfile.lock
+++ b/gemfiles/ruby_2.4_rails5_postgres_redis_activesupport.gemfile.lock
@@ -3,7 +3,7 @@ PATH
   specs:
     ddtrace (1.18.0)
       datadog-ci (~> 0.5.0)
-      debase-ruby_core_source (= 3.2.3)
+      debase-ruby_core_source (= 3.3.0)
       libdatadog (~> 5.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
@@ -72,7 +72,7 @@ GEM
     cri (2.15.10)
     datadog-ci (0.5.0)
       msgpack
-    debase-ruby_core_source (3.2.3)
+    debase-ruby_core_source (3.3.0)
     diff-lcs (1.5.0)
     docile (1.3.5)
     dogstatsd-ruby (5.5.0)

--- a/gemfiles/ruby_2.4_rails5_postgres_sidekiq.gemfile.lock
+++ b/gemfiles/ruby_2.4_rails5_postgres_sidekiq.gemfile.lock
@@ -3,7 +3,7 @@ PATH
   specs:
     ddtrace (1.18.0)
       datadog-ci (~> 0.5.0)
-      debase-ruby_core_source (= 3.2.3)
+      debase-ruby_core_source (= 3.3.0)
       libdatadog (~> 5.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
@@ -73,7 +73,7 @@ GEM
     cri (2.15.10)
     datadog-ci (0.5.0)
       msgpack
-    debase-ruby_core_source (3.2.3)
+    debase-ruby_core_source (3.3.0)
     diff-lcs (1.5.0)
     docile (1.3.5)
     dogstatsd-ruby (5.5.0)

--- a/gemfiles/ruby_2.4_rails5_semantic_logger.gemfile.lock
+++ b/gemfiles/ruby_2.4_rails5_semantic_logger.gemfile.lock
@@ -3,7 +3,7 @@ PATH
   specs:
     ddtrace (1.18.0)
       datadog-ci (~> 0.5.0)
-      debase-ruby_core_source (= 3.2.3)
+      debase-ruby_core_source (= 3.3.0)
       libdatadog (~> 5.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
@@ -72,7 +72,7 @@ GEM
     cri (2.15.10)
     datadog-ci (0.5.0)
       msgpack
-    debase-ruby_core_source (3.2.3)
+    debase-ruby_core_source (3.3.0)
     diff-lcs (1.5.0)
     docile (1.3.5)
     dogstatsd-ruby (5.5.0)

--- a/gemfiles/ruby_2.4_redis_3.gemfile.lock
+++ b/gemfiles/ruby_2.4_redis_3.gemfile.lock
@@ -3,7 +3,7 @@ PATH
   specs:
     ddtrace (1.18.0)
       datadog-ci (~> 0.5.0)
-      debase-ruby_core_source (= 3.2.3)
+      debase-ruby_core_source (= 3.3.0)
       libdatadog (~> 5.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
@@ -29,7 +29,7 @@ GEM
     cri (2.15.10)
     datadog-ci (0.5.0)
       msgpack
-    debase-ruby_core_source (3.2.3)
+    debase-ruby_core_source (3.3.0)
     diff-lcs (1.5.0)
     docile (1.3.5)
     dogstatsd-ruby (5.5.0)

--- a/gemfiles/ruby_2.4_redis_4.gemfile.lock
+++ b/gemfiles/ruby_2.4_redis_4.gemfile.lock
@@ -3,7 +3,7 @@ PATH
   specs:
     ddtrace (1.18.0)
       datadog-ci (~> 0.5.0)
-      debase-ruby_core_source (= 3.2.3)
+      debase-ruby_core_source (= 3.3.0)
       libdatadog (~> 5.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
@@ -29,7 +29,7 @@ GEM
     cri (2.15.10)
     datadog-ci (0.5.0)
       msgpack
-    debase-ruby_core_source (3.2.3)
+    debase-ruby_core_source (3.3.0)
     diff-lcs (1.5.0)
     docile (1.3.5)
     dogstatsd-ruby (5.5.0)

--- a/gemfiles/ruby_2.4_relational_db.gemfile.lock
+++ b/gemfiles/ruby_2.4_relational_db.gemfile.lock
@@ -3,7 +3,7 @@ PATH
   specs:
     ddtrace (1.18.0)
       datadog-ci (~> 0.5.0)
-      debase-ruby_core_source (= 3.2.3)
+      debase-ruby_core_source (= 3.3.0)
       libdatadog (~> 5.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
@@ -41,7 +41,7 @@ GEM
     cri (2.15.10)
     datadog-ci (0.5.0)
       msgpack
-    debase-ruby_core_source (3.2.3)
+    debase-ruby_core_source (3.3.0)
     delayed_job (4.1.11)
       activesupport (>= 3.0, < 8.0)
     delayed_job_active_record (4.1.7)

--- a/gemfiles/ruby_2.4_resque2_redis3.gemfile.lock
+++ b/gemfiles/ruby_2.4_resque2_redis3.gemfile.lock
@@ -3,7 +3,7 @@ PATH
   specs:
     ddtrace (1.18.0)
       datadog-ci (~> 0.5.0)
-      debase-ruby_core_source (= 3.2.3)
+      debase-ruby_core_source (= 3.3.0)
       libdatadog (~> 5.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
@@ -29,7 +29,7 @@ GEM
     cri (2.15.10)
     datadog-ci (0.5.0)
       msgpack
-    debase-ruby_core_source (3.2.3)
+    debase-ruby_core_source (3.3.0)
     diff-lcs (1.5.0)
     docile (1.3.5)
     dogstatsd-ruby (5.5.0)

--- a/gemfiles/ruby_2.4_resque2_redis4.gemfile.lock
+++ b/gemfiles/ruby_2.4_resque2_redis4.gemfile.lock
@@ -3,7 +3,7 @@ PATH
   specs:
     ddtrace (1.18.0)
       datadog-ci (~> 0.5.0)
-      debase-ruby_core_source (= 3.2.3)
+      debase-ruby_core_source (= 3.3.0)
       libdatadog (~> 5.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
@@ -29,7 +29,7 @@ GEM
     cri (2.15.10)
     datadog-ci (0.5.0)
       msgpack
-    debase-ruby_core_source (3.2.3)
+    debase-ruby_core_source (3.3.0)
     diff-lcs (1.5.0)
     docile (1.3.5)
     dogstatsd-ruby (5.5.0)

--- a/gemfiles/ruby_2.4_sinatra.gemfile.lock
+++ b/gemfiles/ruby_2.4_sinatra.gemfile.lock
@@ -3,7 +3,7 @@ PATH
   specs:
     ddtrace (1.18.0)
       datadog-ci (~> 0.5.0)
-      debase-ruby_core_source (= 3.2.3)
+      debase-ruby_core_source (= 3.3.0)
       libdatadog (~> 5.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
@@ -29,7 +29,7 @@ GEM
     cri (2.15.10)
     datadog-ci (0.5.0)
       msgpack
-    debase-ruby_core_source (3.2.3)
+    debase-ruby_core_source (3.3.0)
     diff-lcs (1.5.0)
     docile (1.3.5)
     dogstatsd-ruby (5.5.0)

--- a/gemfiles/ruby_2.5_activesupport.gemfile.lock
+++ b/gemfiles/ruby_2.5_activesupport.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.18.0)
       datadog-ci (~> 0.5.0)
-      debase-ruby_core_source (= 3.2.3)
+      debase-ruby_core_source (= 3.3.0)
       libdatadog (~> 5.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
@@ -69,7 +69,7 @@ GEM
     cri (2.15.11)
     datadog-ci (0.5.0)
       msgpack
-    debase-ruby_core_source (3.2.3)
+    debase-ruby_core_source (3.3.0)
     debug_inspector (1.1.0)
     diff-lcs (1.5.0)
     digest-crc (0.6.5)

--- a/gemfiles/ruby_2.5_aws.gemfile.lock
+++ b/gemfiles/ruby_2.5_aws.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.18.0)
       datadog-ci (~> 0.5.0)
-      debase-ruby_core_source (= 3.2.3)
+      debase-ruby_core_source (= 3.3.0)
       libdatadog (~> 5.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
@@ -1462,7 +1462,7 @@ GEM
     cri (2.15.11)
     datadog-ci (0.5.0)
       msgpack
-    debase-ruby_core_source (3.2.3)
+    debase-ruby_core_source (3.3.0)
     debug_inspector (1.1.0)
     diff-lcs (1.5.0)
     docile (1.4.0)

--- a/gemfiles/ruby_2.5_contrib.gemfile.lock
+++ b/gemfiles/ruby_2.5_contrib.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.18.0)
       datadog-ci (~> 0.5.0)
-      debase-ruby_core_source (= 3.2.3)
+      debase-ruby_core_source (= 3.3.0)
       libdatadog (~> 5.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
@@ -48,7 +48,7 @@ GEM
     dalli (3.2.0)
     datadog-ci (0.5.0)
       msgpack
-    debase-ruby_core_source (3.2.3)
+    debase-ruby_core_source (3.3.0)
     debug_inspector (1.1.0)
     diff-lcs (1.5.0)
     docile (1.4.0)

--- a/gemfiles/ruby_2.5_contrib_old.gemfile.lock
+++ b/gemfiles/ruby_2.5_contrib_old.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.18.0)
       datadog-ci (~> 0.5.0)
-      debase-ruby_core_source (= 3.2.3)
+      debase-ruby_core_source (= 3.3.0)
       libdatadog (~> 5.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
@@ -46,7 +46,7 @@ GEM
     dalli (2.7.11)
     datadog-ci (0.5.0)
       msgpack
-    debase-ruby_core_source (3.2.3)
+    debase-ruby_core_source (3.3.0)
     debug_inspector (1.1.0)
     diff-lcs (1.5.0)
     docile (1.4.0)

--- a/gemfiles/ruby_2.5_core_old.gemfile.lock
+++ b/gemfiles/ruby_2.5_core_old.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.18.0)
       datadog-ci (~> 0.5.0)
-      debase-ruby_core_source (= 3.2.3)
+      debase-ruby_core_source (= 3.3.0)
       libdatadog (~> 5.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
@@ -41,7 +41,7 @@ GEM
     cri (2.15.11)
     datadog-ci (0.5.0)
       msgpack
-    debase-ruby_core_source (3.2.3)
+    debase-ruby_core_source (3.3.0)
     debug_inspector (1.1.0)
     diff-lcs (1.5.0)
     docile (1.4.0)

--- a/gemfiles/ruby_2.5_elasticsearch_7.gemfile.lock
+++ b/gemfiles/ruby_2.5_elasticsearch_7.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.18.0)
       datadog-ci (~> 0.5.0)
-      debase-ruby_core_source (= 3.2.3)
+      debase-ruby_core_source (= 3.3.0)
       libdatadog (~> 5.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
@@ -42,7 +42,7 @@ GEM
     cri (2.15.11)
     datadog-ci (0.5.0)
       msgpack
-    debase-ruby_core_source (3.2.3)
+    debase-ruby_core_source (3.3.0)
     debug_inspector (1.1.0)
     diff-lcs (1.5.0)
     docile (1.4.0)

--- a/gemfiles/ruby_2.5_elasticsearch_8.gemfile.lock
+++ b/gemfiles/ruby_2.5_elasticsearch_8.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.18.0)
       datadog-ci (~> 0.5.0)
-      debase-ruby_core_source (= 3.2.3)
+      debase-ruby_core_source (= 3.3.0)
       libdatadog (~> 5.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
@@ -42,7 +42,7 @@ GEM
     cri (2.15.11)
     datadog-ci (0.5.0)
       msgpack
-    debase-ruby_core_source (3.2.3)
+    debase-ruby_core_source (3.3.0)
     debug_inspector (1.1.0)
     diff-lcs (1.5.0)
     docile (1.4.0)

--- a/gemfiles/ruby_2.5_hanami_1.gemfile.lock
+++ b/gemfiles/ruby_2.5_hanami_1.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.18.0)
       datadog-ci (~> 0.5.0)
-      debase-ruby_core_source (= 3.2.3)
+      debase-ruby_core_source (= 3.3.0)
       libdatadog (~> 5.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
@@ -41,7 +41,7 @@ GEM
     cri (2.15.11)
     datadog-ci (0.5.0)
       msgpack
-    debase-ruby_core_source (3.2.3)
+    debase-ruby_core_source (3.3.0)
     debug_inspector (1.1.0)
     diff-lcs (1.5.0)
     digest (3.1.1)

--- a/gemfiles/ruby_2.5_http.gemfile.lock
+++ b/gemfiles/ruby_2.5_http.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.18.0)
       datadog-ci (~> 0.5.0)
-      debase-ruby_core_source (= 3.2.3)
+      debase-ruby_core_source (= 3.3.0)
       libdatadog (~> 5.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
@@ -41,7 +41,7 @@ GEM
     cri (2.15.11)
     datadog-ci (0.5.0)
       msgpack
-    debase-ruby_core_source (3.2.3)
+    debase-ruby_core_source (3.3.0)
     debug_inspector (1.1.0)
     diff-lcs (1.5.0)
     docile (1.4.0)

--- a/gemfiles/ruby_2.5_opensearch_2.gemfile.lock
+++ b/gemfiles/ruby_2.5_opensearch_2.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.18.0)
       datadog-ci (~> 0.5.0)
-      debase-ruby_core_source (= 3.2.3)
+      debase-ruby_core_source (= 3.3.0)
       libdatadog (~> 5.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
@@ -42,7 +42,7 @@ GEM
     cri (2.15.11)
     datadog-ci (0.5.0)
       msgpack
-    debase-ruby_core_source (3.2.3)
+    debase-ruby_core_source (3.3.0)
     debug_inspector (1.1.0)
     diff-lcs (1.5.0)
     docile (1.4.0)

--- a/gemfiles/ruby_2.5_opensearch_3.gemfile.lock
+++ b/gemfiles/ruby_2.5_opensearch_3.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.18.0)
       datadog-ci (~> 0.5.0)
-      debase-ruby_core_source (= 3.2.3)
+      debase-ruby_core_source (= 3.3.0)
       libdatadog (~> 5.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
@@ -42,7 +42,7 @@ GEM
     cri (2.15.11)
     datadog-ci (0.5.0)
       msgpack
-    debase-ruby_core_source (3.2.3)
+    debase-ruby_core_source (3.3.0)
     debug_inspector (1.1.0)
     diff-lcs (1.5.0)
     docile (1.4.0)

--- a/gemfiles/ruby_2.5_opentracing.gemfile.lock
+++ b/gemfiles/ruby_2.5_opentracing.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.18.0)
       datadog-ci (~> 0.5.0)
-      debase-ruby_core_source (= 3.2.3)
+      debase-ruby_core_source (= 3.3.0)
       libdatadog (~> 5.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
@@ -42,7 +42,7 @@ GEM
     cri (2.15.11)
     datadog-ci (0.5.0)
       msgpack
-    debase-ruby_core_source (3.2.3)
+    debase-ruby_core_source (3.3.0)
     debug_inspector (1.1.0)
     diff-lcs (1.5.0)
     docile (1.4.0)

--- a/gemfiles/ruby_2.5_rack_1.gemfile.lock
+++ b/gemfiles/ruby_2.5_rack_1.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.18.0)
       datadog-ci (~> 0.5.0)
-      debase-ruby_core_source (= 3.2.3)
+      debase-ruby_core_source (= 3.3.0)
       libdatadog (~> 5.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
@@ -41,7 +41,7 @@ GEM
     cri (2.15.11)
     datadog-ci (0.5.0)
       msgpack
-    debase-ruby_core_source (3.2.3)
+    debase-ruby_core_source (3.3.0)
     debug_inspector (1.1.0)
     diff-lcs (1.5.0)
     docile (1.4.0)

--- a/gemfiles/ruby_2.5_rack_2.gemfile.lock
+++ b/gemfiles/ruby_2.5_rack_2.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.18.0)
       datadog-ci (~> 0.5.0)
-      debase-ruby_core_source (= 3.2.3)
+      debase-ruby_core_source (= 3.3.0)
       libdatadog (~> 5.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
@@ -41,7 +41,7 @@ GEM
     cri (2.15.11)
     datadog-ci (0.5.0)
       msgpack
-    debase-ruby_core_source (3.2.3)
+    debase-ruby_core_source (3.3.0)
     debug_inspector (1.1.0)
     diff-lcs (1.5.0)
     docile (1.4.0)

--- a/gemfiles/ruby_2.5_rack_3.gemfile.lock
+++ b/gemfiles/ruby_2.5_rack_3.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.18.0)
       datadog-ci (~> 0.5.0)
-      debase-ruby_core_source (= 3.2.3)
+      debase-ruby_core_source (= 3.3.0)
       libdatadog (~> 5.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
@@ -41,7 +41,7 @@ GEM
     cri (2.15.11)
     datadog-ci (0.5.0)
       msgpack
-    debase-ruby_core_source (3.2.3)
+    debase-ruby_core_source (3.3.0)
     debug_inspector (1.1.0)
     diff-lcs (1.5.0)
     docile (1.4.0)

--- a/gemfiles/ruby_2.5_rails5_mysql2.gemfile.lock
+++ b/gemfiles/ruby_2.5_rails5_mysql2.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.18.0)
       datadog-ci (~> 0.5.0)
-      debase-ruby_core_source (= 3.2.3)
+      debase-ruby_core_source (= 3.3.0)
       libdatadog (~> 5.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
@@ -84,7 +84,7 @@ GEM
     cri (2.15.11)
     datadog-ci (0.5.0)
       msgpack
-    debase-ruby_core_source (3.2.3)
+    debase-ruby_core_source (3.3.0)
     debug_inspector (1.1.0)
     diff-lcs (1.5.0)
     docile (1.4.0)

--- a/gemfiles/ruby_2.5_rails5_postgres.gemfile.lock
+++ b/gemfiles/ruby_2.5_rails5_postgres.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.18.0)
       datadog-ci (~> 0.5.0)
-      debase-ruby_core_source (= 3.2.3)
+      debase-ruby_core_source (= 3.3.0)
       libdatadog (~> 5.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
@@ -84,7 +84,7 @@ GEM
     cri (2.15.11)
     datadog-ci (0.5.0)
       msgpack
-    debase-ruby_core_source (3.2.3)
+    debase-ruby_core_source (3.3.0)
     debug_inspector (1.1.0)
     diff-lcs (1.5.0)
     digest (3.1.1)

--- a/gemfiles/ruby_2.5_rails5_postgres_redis.gemfile.lock
+++ b/gemfiles/ruby_2.5_rails5_postgres_redis.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.18.0)
       datadog-ci (~> 0.5.0)
-      debase-ruby_core_source (= 3.2.3)
+      debase-ruby_core_source (= 3.3.0)
       libdatadog (~> 5.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
@@ -85,7 +85,7 @@ GEM
     cri (2.15.11)
     datadog-ci (0.5.0)
       msgpack
-    debase-ruby_core_source (3.2.3)
+    debase-ruby_core_source (3.3.0)
     debug_inspector (1.1.0)
     diff-lcs (1.5.0)
     digest (3.1.1)

--- a/gemfiles/ruby_2.5_rails5_postgres_redis_activesupport.gemfile.lock
+++ b/gemfiles/ruby_2.5_rails5_postgres_redis_activesupport.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.18.0)
       datadog-ci (~> 0.5.0)
-      debase-ruby_core_source (= 3.2.3)
+      debase-ruby_core_source (= 3.3.0)
       libdatadog (~> 5.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
@@ -84,7 +84,7 @@ GEM
     cri (2.15.11)
     datadog-ci (0.5.0)
       msgpack
-    debase-ruby_core_source (3.2.3)
+    debase-ruby_core_source (3.3.0)
     debug_inspector (1.1.0)
     diff-lcs (1.5.0)
     digest (3.1.1)

--- a/gemfiles/ruby_2.5_rails5_postgres_sidekiq.gemfile.lock
+++ b/gemfiles/ruby_2.5_rails5_postgres_sidekiq.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.18.0)
       datadog-ci (~> 0.5.0)
-      debase-ruby_core_source (= 3.2.3)
+      debase-ruby_core_source (= 3.3.0)
       libdatadog (~> 5.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
@@ -85,7 +85,7 @@ GEM
     cri (2.15.11)
     datadog-ci (0.5.0)
       msgpack
-    debase-ruby_core_source (3.2.3)
+    debase-ruby_core_source (3.3.0)
     debug_inspector (1.1.0)
     diff-lcs (1.5.0)
     digest (3.1.1)

--- a/gemfiles/ruby_2.5_rails5_semantic_logger.gemfile.lock
+++ b/gemfiles/ruby_2.5_rails5_semantic_logger.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.18.0)
       datadog-ci (~> 0.5.0)
-      debase-ruby_core_source (= 3.2.3)
+      debase-ruby_core_source (= 3.3.0)
       libdatadog (~> 5.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
@@ -84,7 +84,7 @@ GEM
     cri (2.15.11)
     datadog-ci (0.5.0)
       msgpack
-    debase-ruby_core_source (3.2.3)
+    debase-ruby_core_source (3.3.0)
     debug_inspector (1.1.0)
     diff-lcs (1.5.0)
     digest (3.1.1)

--- a/gemfiles/ruby_2.5_rails61_mysql2.gemfile.lock
+++ b/gemfiles/ruby_2.5_rails61_mysql2.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.18.0)
       datadog-ci (~> 0.5.0)
-      debase-ruby_core_source (= 3.2.3)
+      debase-ruby_core_source (= 3.3.0)
       libdatadog (~> 5.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
@@ -101,7 +101,7 @@ GEM
     cri (2.15.11)
     datadog-ci (0.5.0)
       msgpack
-    debase-ruby_core_source (3.2.3)
+    debase-ruby_core_source (3.3.0)
     debug_inspector (1.1.0)
     diff-lcs (1.5.0)
     docile (1.4.0)

--- a/gemfiles/ruby_2.5_rails61_postgres.gemfile.lock
+++ b/gemfiles/ruby_2.5_rails61_postgres.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.18.0)
       datadog-ci (~> 0.5.0)
-      debase-ruby_core_source (= 3.2.3)
+      debase-ruby_core_source (= 3.3.0)
       libdatadog (~> 5.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
@@ -101,7 +101,7 @@ GEM
     cri (2.15.11)
     datadog-ci (0.5.0)
       msgpack
-    debase-ruby_core_source (3.2.3)
+    debase-ruby_core_source (3.3.0)
     debug_inspector (1.1.0)
     diff-lcs (1.5.0)
     digest (3.1.1)

--- a/gemfiles/ruby_2.5_rails61_postgres_redis.gemfile.lock
+++ b/gemfiles/ruby_2.5_rails61_postgres_redis.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.18.0)
       datadog-ci (~> 0.5.0)
-      debase-ruby_core_source (= 3.2.3)
+      debase-ruby_core_source (= 3.3.0)
       libdatadog (~> 5.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
@@ -102,7 +102,7 @@ GEM
     cri (2.15.11)
     datadog-ci (0.5.0)
       msgpack
-    debase-ruby_core_source (3.2.3)
+    debase-ruby_core_source (3.3.0)
     debug_inspector (1.1.0)
     diff-lcs (1.5.0)
     digest (3.1.1)

--- a/gemfiles/ruby_2.5_rails61_postgres_sidekiq.gemfile.lock
+++ b/gemfiles/ruby_2.5_rails61_postgres_sidekiq.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.18.0)
       datadog-ci (~> 0.5.0)
-      debase-ruby_core_source (= 3.2.3)
+      debase-ruby_core_source (= 3.3.0)
       libdatadog (~> 5.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
@@ -102,7 +102,7 @@ GEM
     cri (2.15.11)
     datadog-ci (0.5.0)
       msgpack
-    debase-ruby_core_source (3.2.3)
+    debase-ruby_core_source (3.3.0)
     debug_inspector (1.1.0)
     diff-lcs (1.5.0)
     digest (3.1.1)

--- a/gemfiles/ruby_2.5_rails61_semantic_logger.gemfile.lock
+++ b/gemfiles/ruby_2.5_rails61_semantic_logger.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.18.0)
       datadog-ci (~> 0.5.0)
-      debase-ruby_core_source (= 3.2.3)
+      debase-ruby_core_source (= 3.3.0)
       libdatadog (~> 5.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
@@ -101,7 +101,7 @@ GEM
     cri (2.15.11)
     datadog-ci (0.5.0)
       msgpack
-    debase-ruby_core_source (3.2.3)
+    debase-ruby_core_source (3.3.0)
     debug_inspector (1.1.0)
     diff-lcs (1.5.0)
     digest (3.1.1)

--- a/gemfiles/ruby_2.5_rails6_mysql2.gemfile.lock
+++ b/gemfiles/ruby_2.5_rails6_mysql2.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.18.0)
       datadog-ci (~> 0.5.0)
-      debase-ruby_core_source (= 3.2.3)
+      debase-ruby_core_source (= 3.3.0)
       libdatadog (~> 5.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
@@ -97,7 +97,7 @@ GEM
     cri (2.15.11)
     datadog-ci (0.5.0)
       msgpack
-    debase-ruby_core_source (3.2.3)
+    debase-ruby_core_source (3.3.0)
     debug_inspector (1.1.0)
     diff-lcs (1.5.0)
     docile (1.4.0)

--- a/gemfiles/ruby_2.5_rails6_postgres.gemfile.lock
+++ b/gemfiles/ruby_2.5_rails6_postgres.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.18.0)
       datadog-ci (~> 0.5.0)
-      debase-ruby_core_source (= 3.2.3)
+      debase-ruby_core_source (= 3.3.0)
       libdatadog (~> 5.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
@@ -97,7 +97,7 @@ GEM
     cri (2.15.11)
     datadog-ci (0.5.0)
       msgpack
-    debase-ruby_core_source (3.2.3)
+    debase-ruby_core_source (3.3.0)
     debug_inspector (1.1.0)
     diff-lcs (1.5.0)
     digest (3.1.1)

--- a/gemfiles/ruby_2.5_rails6_postgres_redis.gemfile.lock
+++ b/gemfiles/ruby_2.5_rails6_postgres_redis.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.18.0)
       datadog-ci (~> 0.5.0)
-      debase-ruby_core_source (= 3.2.3)
+      debase-ruby_core_source (= 3.3.0)
       libdatadog (~> 5.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
@@ -98,7 +98,7 @@ GEM
     cri (2.15.11)
     datadog-ci (0.5.0)
       msgpack
-    debase-ruby_core_source (3.2.3)
+    debase-ruby_core_source (3.3.0)
     debug_inspector (1.1.0)
     diff-lcs (1.5.0)
     digest (3.1.1)

--- a/gemfiles/ruby_2.5_rails6_postgres_redis_activesupport.gemfile.lock
+++ b/gemfiles/ruby_2.5_rails6_postgres_redis_activesupport.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.18.0)
       datadog-ci (~> 0.5.0)
-      debase-ruby_core_source (= 3.2.3)
+      debase-ruby_core_source (= 3.3.0)
       libdatadog (~> 5.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
@@ -97,7 +97,7 @@ GEM
     cri (2.15.11)
     datadog-ci (0.5.0)
       msgpack
-    debase-ruby_core_source (3.2.3)
+    debase-ruby_core_source (3.3.0)
     debug_inspector (1.1.0)
     diff-lcs (1.5.0)
     digest (3.1.1)

--- a/gemfiles/ruby_2.5_rails6_postgres_sidekiq.gemfile.lock
+++ b/gemfiles/ruby_2.5_rails6_postgres_sidekiq.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.18.0)
       datadog-ci (~> 0.5.0)
-      debase-ruby_core_source (= 3.2.3)
+      debase-ruby_core_source (= 3.3.0)
       libdatadog (~> 5.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
@@ -98,7 +98,7 @@ GEM
     cri (2.15.11)
     datadog-ci (0.5.0)
       msgpack
-    debase-ruby_core_source (3.2.3)
+    debase-ruby_core_source (3.3.0)
     debug_inspector (1.1.0)
     diff-lcs (1.5.0)
     digest (3.1.1)

--- a/gemfiles/ruby_2.5_rails6_semantic_logger.gemfile.lock
+++ b/gemfiles/ruby_2.5_rails6_semantic_logger.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.18.0)
       datadog-ci (~> 0.5.0)
-      debase-ruby_core_source (= 3.2.3)
+      debase-ruby_core_source (= 3.3.0)
       libdatadog (~> 5.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
@@ -97,7 +97,7 @@ GEM
     cri (2.15.11)
     datadog-ci (0.5.0)
       msgpack
-    debase-ruby_core_source (3.2.3)
+    debase-ruby_core_source (3.3.0)
     debug_inspector (1.1.0)
     diff-lcs (1.5.0)
     digest (3.1.1)

--- a/gemfiles/ruby_2.5_redis_3.gemfile.lock
+++ b/gemfiles/ruby_2.5_redis_3.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.18.0)
       datadog-ci (~> 0.5.0)
-      debase-ruby_core_source (= 3.2.3)
+      debase-ruby_core_source (= 3.3.0)
       libdatadog (~> 5.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
@@ -41,7 +41,7 @@ GEM
     cri (2.15.11)
     datadog-ci (0.5.0)
       msgpack
-    debase-ruby_core_source (3.2.3)
+    debase-ruby_core_source (3.3.0)
     debug_inspector (1.1.0)
     diff-lcs (1.5.0)
     docile (1.4.0)

--- a/gemfiles/ruby_2.5_redis_4.gemfile.lock
+++ b/gemfiles/ruby_2.5_redis_4.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.18.0)
       datadog-ci (~> 0.5.0)
-      debase-ruby_core_source (= 3.2.3)
+      debase-ruby_core_source (= 3.3.0)
       libdatadog (~> 5.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
@@ -41,7 +41,7 @@ GEM
     cri (2.15.11)
     datadog-ci (0.5.0)
       msgpack
-    debase-ruby_core_source (3.2.3)
+    debase-ruby_core_source (3.3.0)
     debug_inspector (1.1.0)
     diff-lcs (1.5.0)
     docile (1.4.0)

--- a/gemfiles/ruby_2.5_redis_5.gemfile.lock
+++ b/gemfiles/ruby_2.5_redis_5.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.18.0)
       datadog-ci (~> 0.5.0)
-      debase-ruby_core_source (= 3.2.3)
+      debase-ruby_core_source (= 3.3.0)
       libdatadog (~> 5.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
@@ -42,7 +42,7 @@ GEM
     cri (2.15.11)
     datadog-ci (0.5.0)
       msgpack
-    debase-ruby_core_source (3.2.3)
+    debase-ruby_core_source (3.3.0)
     debug_inspector (1.1.0)
     diff-lcs (1.5.0)
     docile (1.4.0)

--- a/gemfiles/ruby_2.5_relational_db.gemfile.lock
+++ b/gemfiles/ruby_2.5_relational_db.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.18.0)
       datadog-ci (~> 0.5.0)
-      debase-ruby_core_source (= 3.2.3)
+      debase-ruby_core_source (= 3.3.0)
       libdatadog (~> 5.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
@@ -53,7 +53,7 @@ GEM
     cri (2.15.11)
     datadog-ci (0.5.0)
       msgpack
-    debase-ruby_core_source (3.2.3)
+    debase-ruby_core_source (3.3.0)
     debug_inspector (1.1.0)
     delayed_job (4.1.11)
       activesupport (>= 3.0, < 8.0)

--- a/gemfiles/ruby_2.5_resque2_redis3.gemfile.lock
+++ b/gemfiles/ruby_2.5_resque2_redis3.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.18.0)
       datadog-ci (~> 0.5.0)
-      debase-ruby_core_source (= 3.2.3)
+      debase-ruby_core_source (= 3.3.0)
       libdatadog (~> 5.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
@@ -41,7 +41,7 @@ GEM
     cri (2.15.11)
     datadog-ci (0.5.0)
       msgpack
-    debase-ruby_core_source (3.2.3)
+    debase-ruby_core_source (3.3.0)
     debug_inspector (1.1.0)
     diff-lcs (1.5.0)
     docile (1.4.0)

--- a/gemfiles/ruby_2.5_resque2_redis4.gemfile.lock
+++ b/gemfiles/ruby_2.5_resque2_redis4.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.18.0)
       datadog-ci (~> 0.5.0)
-      debase-ruby_core_source (= 3.2.3)
+      debase-ruby_core_source (= 3.3.0)
       libdatadog (~> 5.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
@@ -42,7 +42,7 @@ GEM
     cri (2.15.11)
     datadog-ci (0.5.0)
       msgpack
-    debase-ruby_core_source (3.2.3)
+    debase-ruby_core_source (3.3.0)
     debug_inspector (1.1.0)
     diff-lcs (1.5.0)
     docile (1.4.0)

--- a/gemfiles/ruby_2.5_sinatra.gemfile.lock
+++ b/gemfiles/ruby_2.5_sinatra.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.18.0)
       datadog-ci (~> 0.5.0)
-      debase-ruby_core_source (= 3.2.3)
+      debase-ruby_core_source (= 3.3.0)
       libdatadog (~> 5.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
@@ -41,7 +41,7 @@ GEM
     cri (2.15.11)
     datadog-ci (0.5.0)
       msgpack
-    debase-ruby_core_source (3.2.3)
+    debase-ruby_core_source (3.3.0)
     debug_inspector (1.1.0)
     diff-lcs (1.5.0)
     docile (1.4.0)

--- a/gemfiles/ruby_2.6_activesupport.gemfile.lock
+++ b/gemfiles/ruby_2.6_activesupport.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.18.0)
       datadog-ci (~> 0.5.0)
-      debase-ruby_core_source (= 3.2.3)
+      debase-ruby_core_source (= 3.3.0)
       libdatadog (~> 5.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
@@ -72,7 +72,7 @@ GEM
     cri (2.15.11)
     datadog-ci (0.5.0)
       msgpack
-    debase-ruby_core_source (3.2.3)
+    debase-ruby_core_source (3.3.0)
     debug_inspector (1.1.0)
     diff-lcs (1.5.0)
     digest-crc (0.6.5)

--- a/gemfiles/ruby_2.6_aws.gemfile.lock
+++ b/gemfiles/ruby_2.6_aws.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.18.0)
       datadog-ci (~> 0.5.0)
-      debase-ruby_core_source (= 3.2.3)
+      debase-ruby_core_source (= 3.3.0)
       libdatadog (~> 5.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
@@ -1464,7 +1464,7 @@ GEM
     cri (2.15.11)
     datadog-ci (0.5.0)
       msgpack
-    debase-ruby_core_source (3.2.3)
+    debase-ruby_core_source (3.3.0)
     debug_inspector (1.1.0)
     diff-lcs (1.5.0)
     docile (1.4.0)

--- a/gemfiles/ruby_2.6_contrib.gemfile.lock
+++ b/gemfiles/ruby_2.6_contrib.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.18.0)
       datadog-ci (~> 0.5.0)
-      debase-ruby_core_source (= 3.2.3)
+      debase-ruby_core_source (= 3.3.0)
       libdatadog (~> 5.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
@@ -50,7 +50,7 @@ GEM
     dalli (3.2.4)
     datadog-ci (0.5.0)
       msgpack
-    debase-ruby_core_source (3.2.3)
+    debase-ruby_core_source (3.3.0)
     debug_inspector (1.1.0)
     diff-lcs (1.5.0)
     docile (1.4.0)

--- a/gemfiles/ruby_2.6_contrib_old.gemfile.lock
+++ b/gemfiles/ruby_2.6_contrib_old.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.18.0)
       datadog-ci (~> 0.5.0)
-      debase-ruby_core_source (= 3.2.3)
+      debase-ruby_core_source (= 3.3.0)
       libdatadog (~> 5.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
@@ -48,7 +48,7 @@ GEM
     dalli (2.7.11)
     datadog-ci (0.5.0)
       msgpack
-    debase-ruby_core_source (3.2.3)
+    debase-ruby_core_source (3.3.0)
     debug_inspector (1.1.0)
     diff-lcs (1.5.0)
     docile (1.4.0)

--- a/gemfiles/ruby_2.6_core_old.gemfile.lock
+++ b/gemfiles/ruby_2.6_core_old.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.18.0)
       datadog-ci (~> 0.5.0)
-      debase-ruby_core_source (= 3.2.3)
+      debase-ruby_core_source (= 3.3.0)
       libdatadog (~> 5.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
@@ -43,7 +43,7 @@ GEM
     cri (2.15.11)
     datadog-ci (0.5.0)
       msgpack
-    debase-ruby_core_source (3.2.3)
+    debase-ruby_core_source (3.3.0)
     debug_inspector (1.1.0)
     diff-lcs (1.5.0)
     docile (1.4.0)

--- a/gemfiles/ruby_2.6_elasticsearch_7.gemfile.lock
+++ b/gemfiles/ruby_2.6_elasticsearch_7.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.18.0)
       datadog-ci (~> 0.5.0)
-      debase-ruby_core_source (= 3.2.3)
+      debase-ruby_core_source (= 3.3.0)
       libdatadog (~> 5.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
@@ -44,7 +44,7 @@ GEM
     cri (2.15.11)
     datadog-ci (0.5.0)
       msgpack
-    debase-ruby_core_source (3.2.3)
+    debase-ruby_core_source (3.3.0)
     debug_inspector (1.1.0)
     diff-lcs (1.5.0)
     docile (1.4.0)

--- a/gemfiles/ruby_2.6_elasticsearch_8.gemfile.lock
+++ b/gemfiles/ruby_2.6_elasticsearch_8.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.18.0)
       datadog-ci (~> 0.5.0)
-      debase-ruby_core_source (= 3.2.3)
+      debase-ruby_core_source (= 3.3.0)
       libdatadog (~> 5.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
@@ -45,7 +45,7 @@ GEM
     cri (2.15.11)
     datadog-ci (0.5.0)
       msgpack
-    debase-ruby_core_source (3.2.3)
+    debase-ruby_core_source (3.3.0)
     debug_inspector (1.1.0)
     diff-lcs (1.5.0)
     docile (1.4.0)

--- a/gemfiles/ruby_2.6_hanami_1.gemfile.lock
+++ b/gemfiles/ruby_2.6_hanami_1.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.18.0)
       datadog-ci (~> 0.5.0)
-      debase-ruby_core_source (= 3.2.3)
+      debase-ruby_core_source (= 3.3.0)
       libdatadog (~> 5.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
@@ -44,7 +44,7 @@ GEM
     datadog-ci (0.5.0)
       msgpack
     date (3.3.3)
-    debase-ruby_core_source (3.2.3)
+    debase-ruby_core_source (3.3.0)
     debug_inspector (1.1.0)
     diff-lcs (1.5.0)
     docile (1.4.0)

--- a/gemfiles/ruby_2.6_http.gemfile.lock
+++ b/gemfiles/ruby_2.6_http.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.18.0)
       datadog-ci (~> 0.5.0)
-      debase-ruby_core_source (= 3.2.3)
+      debase-ruby_core_source (= 3.3.0)
       libdatadog (~> 5.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
@@ -43,7 +43,7 @@ GEM
     cri (2.15.11)
     datadog-ci (0.5.0)
       msgpack
-    debase-ruby_core_source (3.2.3)
+    debase-ruby_core_source (3.3.0)
     debug_inspector (1.1.0)
     diff-lcs (1.5.0)
     docile (1.4.0)

--- a/gemfiles/ruby_2.6_opensearch_2.gemfile.lock
+++ b/gemfiles/ruby_2.6_opensearch_2.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.18.0)
       datadog-ci (~> 0.5.0)
-      debase-ruby_core_source (= 3.2.3)
+      debase-ruby_core_source (= 3.3.0)
       libdatadog (~> 5.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
@@ -45,7 +45,7 @@ GEM
     cri (2.15.11)
     datadog-ci (0.5.0)
       msgpack
-    debase-ruby_core_source (3.2.3)
+    debase-ruby_core_source (3.3.0)
     debug_inspector (1.1.0)
     diff-lcs (1.5.0)
     docile (1.4.0)

--- a/gemfiles/ruby_2.6_opensearch_3.gemfile.lock
+++ b/gemfiles/ruby_2.6_opensearch_3.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.18.0)
       datadog-ci (~> 0.5.0)
-      debase-ruby_core_source (= 3.2.3)
+      debase-ruby_core_source (= 3.3.0)
       libdatadog (~> 5.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
@@ -45,7 +45,7 @@ GEM
     cri (2.15.11)
     datadog-ci (0.5.0)
       msgpack
-    debase-ruby_core_source (3.2.3)
+    debase-ruby_core_source (3.3.0)
     debug_inspector (1.1.0)
     diff-lcs (1.5.0)
     docile (1.4.0)

--- a/gemfiles/ruby_2.6_opentelemetry.gemfile.lock
+++ b/gemfiles/ruby_2.6_opentelemetry.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.18.0)
       datadog-ci (~> 0.5.0)
-      debase-ruby_core_source (= 3.2.3)
+      debase-ruby_core_source (= 3.3.0)
       libdatadog (~> 5.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
@@ -43,7 +43,7 @@ GEM
     cri (2.15.11)
     datadog-ci (0.5.0)
       msgpack
-    debase-ruby_core_source (3.2.3)
+    debase-ruby_core_source (3.3.0)
     debug_inspector (1.1.0)
     diff-lcs (1.5.0)
     docile (1.4.0)

--- a/gemfiles/ruby_2.6_opentracing.gemfile.lock
+++ b/gemfiles/ruby_2.6_opentracing.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.18.0)
       datadog-ci (~> 0.5.0)
-      debase-ruby_core_source (= 3.2.3)
+      debase-ruby_core_source (= 3.3.0)
       libdatadog (~> 5.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
@@ -44,7 +44,7 @@ GEM
     cri (2.15.11)
     datadog-ci (0.5.0)
       msgpack
-    debase-ruby_core_source (3.2.3)
+    debase-ruby_core_source (3.3.0)
     debug_inspector (1.1.0)
     diff-lcs (1.5.0)
     docile (1.4.0)

--- a/gemfiles/ruby_2.6_rack_1.gemfile.lock
+++ b/gemfiles/ruby_2.6_rack_1.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.18.0)
       datadog-ci (~> 0.5.0)
-      debase-ruby_core_source (= 3.2.3)
+      debase-ruby_core_source (= 3.3.0)
       libdatadog (~> 5.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
@@ -43,7 +43,7 @@ GEM
     cri (2.15.11)
     datadog-ci (0.5.0)
       msgpack
-    debase-ruby_core_source (3.2.3)
+    debase-ruby_core_source (3.3.0)
     debug_inspector (1.1.0)
     diff-lcs (1.5.0)
     docile (1.4.0)

--- a/gemfiles/ruby_2.6_rack_2.gemfile.lock
+++ b/gemfiles/ruby_2.6_rack_2.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.18.0)
       datadog-ci (~> 0.5.0)
-      debase-ruby_core_source (= 3.2.3)
+      debase-ruby_core_source (= 3.3.0)
       libdatadog (~> 5.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
@@ -43,7 +43,7 @@ GEM
     cri (2.15.11)
     datadog-ci (0.5.0)
       msgpack
-    debase-ruby_core_source (3.2.3)
+    debase-ruby_core_source (3.3.0)
     debug_inspector (1.1.0)
     diff-lcs (1.5.0)
     docile (1.4.0)

--- a/gemfiles/ruby_2.6_rack_3.gemfile.lock
+++ b/gemfiles/ruby_2.6_rack_3.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.18.0)
       datadog-ci (~> 0.5.0)
-      debase-ruby_core_source (= 3.2.3)
+      debase-ruby_core_source (= 3.3.0)
       libdatadog (~> 5.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
@@ -43,7 +43,7 @@ GEM
     cri (2.15.11)
     datadog-ci (0.5.0)
       msgpack
-    debase-ruby_core_source (3.2.3)
+    debase-ruby_core_source (3.3.0)
     debug_inspector (1.1.0)
     diff-lcs (1.5.0)
     docile (1.4.0)

--- a/gemfiles/ruby_2.6_rails5_mysql2.gemfile.lock
+++ b/gemfiles/ruby_2.6_rails5_mysql2.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.18.0)
       datadog-ci (~> 0.5.0)
-      debase-ruby_core_source (= 3.2.3)
+      debase-ruby_core_source (= 3.3.0)
       libdatadog (~> 5.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
@@ -87,7 +87,7 @@ GEM
     datadog-ci (0.5.0)
       msgpack
     date (3.3.3)
-    debase-ruby_core_source (3.2.3)
+    debase-ruby_core_source (3.3.0)
     debug_inspector (1.1.0)
     diff-lcs (1.5.0)
     docile (1.4.0)

--- a/gemfiles/ruby_2.6_rails5_postgres.gemfile.lock
+++ b/gemfiles/ruby_2.6_rails5_postgres.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.18.0)
       datadog-ci (~> 0.5.0)
-      debase-ruby_core_source (= 3.2.3)
+      debase-ruby_core_source (= 3.3.0)
       libdatadog (~> 5.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
@@ -87,7 +87,7 @@ GEM
     datadog-ci (0.5.0)
       msgpack
     date (3.3.3)
-    debase-ruby_core_source (3.2.3)
+    debase-ruby_core_source (3.3.0)
     debug_inspector (1.1.0)
     diff-lcs (1.5.0)
     docile (1.4.0)

--- a/gemfiles/ruby_2.6_rails5_postgres_redis.gemfile.lock
+++ b/gemfiles/ruby_2.6_rails5_postgres_redis.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.18.0)
       datadog-ci (~> 0.5.0)
-      debase-ruby_core_source (= 3.2.3)
+      debase-ruby_core_source (= 3.3.0)
       libdatadog (~> 5.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
@@ -87,7 +87,7 @@ GEM
     datadog-ci (0.5.0)
       msgpack
     date (3.3.3)
-    debase-ruby_core_source (3.2.3)
+    debase-ruby_core_source (3.3.0)
     debug_inspector (1.1.0)
     diff-lcs (1.5.0)
     docile (1.4.0)

--- a/gemfiles/ruby_2.6_rails5_postgres_redis_activesupport.gemfile.lock
+++ b/gemfiles/ruby_2.6_rails5_postgres_redis_activesupport.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.18.0)
       datadog-ci (~> 0.5.0)
-      debase-ruby_core_source (= 3.2.3)
+      debase-ruby_core_source (= 3.3.0)
       libdatadog (~> 5.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
@@ -87,7 +87,7 @@ GEM
     datadog-ci (0.5.0)
       msgpack
     date (3.3.3)
-    debase-ruby_core_source (3.2.3)
+    debase-ruby_core_source (3.3.0)
     debug_inspector (1.1.0)
     diff-lcs (1.5.0)
     docile (1.4.0)

--- a/gemfiles/ruby_2.6_rails5_postgres_sidekiq.gemfile.lock
+++ b/gemfiles/ruby_2.6_rails5_postgres_sidekiq.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.18.0)
       datadog-ci (~> 0.5.0)
-      debase-ruby_core_source (= 3.2.3)
+      debase-ruby_core_source (= 3.3.0)
       libdatadog (~> 5.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
@@ -88,7 +88,7 @@ GEM
     datadog-ci (0.5.0)
       msgpack
     date (3.3.3)
-    debase-ruby_core_source (3.2.3)
+    debase-ruby_core_source (3.3.0)
     debug_inspector (1.1.0)
     diff-lcs (1.5.0)
     docile (1.4.0)

--- a/gemfiles/ruby_2.6_rails5_semantic_logger.gemfile.lock
+++ b/gemfiles/ruby_2.6_rails5_semantic_logger.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.18.0)
       datadog-ci (~> 0.5.0)
-      debase-ruby_core_source (= 3.2.3)
+      debase-ruby_core_source (= 3.3.0)
       libdatadog (~> 5.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
@@ -87,7 +87,7 @@ GEM
     datadog-ci (0.5.0)
       msgpack
     date (3.3.3)
-    debase-ruby_core_source (3.2.3)
+    debase-ruby_core_source (3.3.0)
     debug_inspector (1.1.0)
     diff-lcs (1.5.0)
     docile (1.4.0)

--- a/gemfiles/ruby_2.6_rails61_mysql2.gemfile.lock
+++ b/gemfiles/ruby_2.6_rails61_mysql2.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.18.0)
       datadog-ci (~> 0.5.0)
-      debase-ruby_core_source (= 3.2.3)
+      debase-ruby_core_source (= 3.3.0)
       libdatadog (~> 5.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
@@ -104,7 +104,7 @@ GEM
     datadog-ci (0.5.0)
       msgpack
     date (3.3.3)
-    debase-ruby_core_source (3.2.3)
+    debase-ruby_core_source (3.3.0)
     debug_inspector (1.1.0)
     diff-lcs (1.5.0)
     docile (1.4.0)

--- a/gemfiles/ruby_2.6_rails61_postgres.gemfile.lock
+++ b/gemfiles/ruby_2.6_rails61_postgres.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.18.0)
       datadog-ci (~> 0.5.0)
-      debase-ruby_core_source (= 3.2.3)
+      debase-ruby_core_source (= 3.3.0)
       libdatadog (~> 5.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
@@ -104,7 +104,7 @@ GEM
     datadog-ci (0.5.0)
       msgpack
     date (3.3.3)
-    debase-ruby_core_source (3.2.3)
+    debase-ruby_core_source (3.3.0)
     debug_inspector (1.1.0)
     diff-lcs (1.5.0)
     docile (1.4.0)

--- a/gemfiles/ruby_2.6_rails61_postgres_redis.gemfile.lock
+++ b/gemfiles/ruby_2.6_rails61_postgres_redis.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.18.0)
       datadog-ci (~> 0.5.0)
-      debase-ruby_core_source (= 3.2.3)
+      debase-ruby_core_source (= 3.3.0)
       libdatadog (~> 5.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
@@ -104,7 +104,7 @@ GEM
     datadog-ci (0.5.0)
       msgpack
     date (3.3.3)
-    debase-ruby_core_source (3.2.3)
+    debase-ruby_core_source (3.3.0)
     debug_inspector (1.1.0)
     diff-lcs (1.5.0)
     docile (1.4.0)

--- a/gemfiles/ruby_2.6_rails61_postgres_sidekiq.gemfile.lock
+++ b/gemfiles/ruby_2.6_rails61_postgres_sidekiq.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.18.0)
       datadog-ci (~> 0.5.0)
-      debase-ruby_core_source (= 3.2.3)
+      debase-ruby_core_source (= 3.3.0)
       libdatadog (~> 5.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
@@ -105,7 +105,7 @@ GEM
     datadog-ci (0.5.0)
       msgpack
     date (3.3.3)
-    debase-ruby_core_source (3.2.3)
+    debase-ruby_core_source (3.3.0)
     debug_inspector (1.1.0)
     diff-lcs (1.5.0)
     docile (1.4.0)

--- a/gemfiles/ruby_2.6_rails61_semantic_logger.gemfile.lock
+++ b/gemfiles/ruby_2.6_rails61_semantic_logger.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.18.0)
       datadog-ci (~> 0.5.0)
-      debase-ruby_core_source (= 3.2.3)
+      debase-ruby_core_source (= 3.3.0)
       libdatadog (~> 5.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
@@ -104,7 +104,7 @@ GEM
     datadog-ci (0.5.0)
       msgpack
     date (3.3.3)
-    debase-ruby_core_source (3.2.3)
+    debase-ruby_core_source (3.3.0)
     debug_inspector (1.1.0)
     diff-lcs (1.5.0)
     docile (1.4.0)

--- a/gemfiles/ruby_2.6_rails6_mysql2.gemfile.lock
+++ b/gemfiles/ruby_2.6_rails6_mysql2.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.18.0)
       datadog-ci (~> 0.5.0)
-      debase-ruby_core_source (= 3.2.3)
+      debase-ruby_core_source (= 3.3.0)
       libdatadog (~> 5.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
@@ -100,7 +100,7 @@ GEM
     datadog-ci (0.5.0)
       msgpack
     date (3.3.3)
-    debase-ruby_core_source (3.2.3)
+    debase-ruby_core_source (3.3.0)
     debug_inspector (1.1.0)
     diff-lcs (1.5.0)
     docile (1.4.0)

--- a/gemfiles/ruby_2.6_rails6_postgres.gemfile.lock
+++ b/gemfiles/ruby_2.6_rails6_postgres.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.18.0)
       datadog-ci (~> 0.5.0)
-      debase-ruby_core_source (= 3.2.3)
+      debase-ruby_core_source (= 3.3.0)
       libdatadog (~> 5.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
@@ -100,7 +100,7 @@ GEM
     datadog-ci (0.5.0)
       msgpack
     date (3.3.3)
-    debase-ruby_core_source (3.2.3)
+    debase-ruby_core_source (3.3.0)
     debug_inspector (1.1.0)
     diff-lcs (1.5.0)
     docile (1.4.0)

--- a/gemfiles/ruby_2.6_rails6_postgres_redis.gemfile.lock
+++ b/gemfiles/ruby_2.6_rails6_postgres_redis.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.18.0)
       datadog-ci (~> 0.5.0)
-      debase-ruby_core_source (= 3.2.3)
+      debase-ruby_core_source (= 3.3.0)
       libdatadog (~> 5.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
@@ -100,7 +100,7 @@ GEM
     datadog-ci (0.5.0)
       msgpack
     date (3.3.3)
-    debase-ruby_core_source (3.2.3)
+    debase-ruby_core_source (3.3.0)
     debug_inspector (1.1.0)
     diff-lcs (1.5.0)
     docile (1.4.0)

--- a/gemfiles/ruby_2.6_rails6_postgres_redis_activesupport.gemfile.lock
+++ b/gemfiles/ruby_2.6_rails6_postgres_redis_activesupport.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.18.0)
       datadog-ci (~> 0.5.0)
-      debase-ruby_core_source (= 3.2.3)
+      debase-ruby_core_source (= 3.3.0)
       libdatadog (~> 5.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
@@ -100,7 +100,7 @@ GEM
     datadog-ci (0.5.0)
       msgpack
     date (3.3.3)
-    debase-ruby_core_source (3.2.3)
+    debase-ruby_core_source (3.3.0)
     debug_inspector (1.1.0)
     diff-lcs (1.5.0)
     docile (1.4.0)

--- a/gemfiles/ruby_2.6_rails6_postgres_sidekiq.gemfile.lock
+++ b/gemfiles/ruby_2.6_rails6_postgres_sidekiq.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.18.0)
       datadog-ci (~> 0.5.0)
-      debase-ruby_core_source (= 3.2.3)
+      debase-ruby_core_source (= 3.3.0)
       libdatadog (~> 5.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
@@ -101,7 +101,7 @@ GEM
     datadog-ci (0.5.0)
       msgpack
     date (3.3.3)
-    debase-ruby_core_source (3.2.3)
+    debase-ruby_core_source (3.3.0)
     debug_inspector (1.1.0)
     diff-lcs (1.5.0)
     docile (1.4.0)

--- a/gemfiles/ruby_2.6_rails6_semantic_logger.gemfile.lock
+++ b/gemfiles/ruby_2.6_rails6_semantic_logger.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.18.0)
       datadog-ci (~> 0.5.0)
-      debase-ruby_core_source (= 3.2.3)
+      debase-ruby_core_source (= 3.3.0)
       libdatadog (~> 5.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
@@ -100,7 +100,7 @@ GEM
     datadog-ci (0.5.0)
       msgpack
     date (3.3.3)
-    debase-ruby_core_source (3.2.3)
+    debase-ruby_core_source (3.3.0)
     debug_inspector (1.1.0)
     diff-lcs (1.5.0)
     docile (1.4.0)

--- a/gemfiles/ruby_2.6_redis_3.gemfile.lock
+++ b/gemfiles/ruby_2.6_redis_3.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.18.0)
       datadog-ci (~> 0.5.0)
-      debase-ruby_core_source (= 3.2.3)
+      debase-ruby_core_source (= 3.3.0)
       libdatadog (~> 5.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
@@ -43,7 +43,7 @@ GEM
     cri (2.15.11)
     datadog-ci (0.5.0)
       msgpack
-    debase-ruby_core_source (3.2.3)
+    debase-ruby_core_source (3.3.0)
     debug_inspector (1.1.0)
     diff-lcs (1.5.0)
     docile (1.4.0)

--- a/gemfiles/ruby_2.6_redis_4.gemfile.lock
+++ b/gemfiles/ruby_2.6_redis_4.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.18.0)
       datadog-ci (~> 0.5.0)
-      debase-ruby_core_source (= 3.2.3)
+      debase-ruby_core_source (= 3.3.0)
       libdatadog (~> 5.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
@@ -43,7 +43,7 @@ GEM
     cri (2.15.11)
     datadog-ci (0.5.0)
       msgpack
-    debase-ruby_core_source (3.2.3)
+    debase-ruby_core_source (3.3.0)
     debug_inspector (1.1.0)
     diff-lcs (1.5.0)
     docile (1.4.0)

--- a/gemfiles/ruby_2.6_redis_5.gemfile.lock
+++ b/gemfiles/ruby_2.6_redis_5.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.18.0)
       datadog-ci (~> 0.5.0)
-      debase-ruby_core_source (= 3.2.3)
+      debase-ruby_core_source (= 3.3.0)
       libdatadog (~> 5.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
@@ -44,7 +44,7 @@ GEM
     cri (2.15.11)
     datadog-ci (0.5.0)
       msgpack
-    debase-ruby_core_source (3.2.3)
+    debase-ruby_core_source (3.3.0)
     debug_inspector (1.1.0)
     diff-lcs (1.5.0)
     docile (1.4.0)

--- a/gemfiles/ruby_2.6_relational_db.gemfile.lock
+++ b/gemfiles/ruby_2.6_relational_db.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.18.0)
       datadog-ci (~> 0.5.0)
-      debase-ruby_core_source (= 3.2.3)
+      debase-ruby_core_source (= 3.3.0)
       libdatadog (~> 5.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
@@ -54,7 +54,7 @@ GEM
     cri (2.15.11)
     datadog-ci (0.5.0)
       msgpack
-    debase-ruby_core_source (3.2.3)
+    debase-ruby_core_source (3.3.0)
     debug_inspector (1.1.0)
     delayed_job (4.1.11)
       activesupport (>= 3.0, < 8.0)

--- a/gemfiles/ruby_2.6_resque2_redis3.gemfile.lock
+++ b/gemfiles/ruby_2.6_resque2_redis3.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.18.0)
       datadog-ci (~> 0.5.0)
-      debase-ruby_core_source (= 3.2.3)
+      debase-ruby_core_source (= 3.3.0)
       libdatadog (~> 5.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
@@ -43,7 +43,7 @@ GEM
     cri (2.15.11)
     datadog-ci (0.5.0)
       msgpack
-    debase-ruby_core_source (3.2.3)
+    debase-ruby_core_source (3.3.0)
     debug_inspector (1.1.0)
     diff-lcs (1.5.0)
     docile (1.4.0)

--- a/gemfiles/ruby_2.6_resque2_redis4.gemfile.lock
+++ b/gemfiles/ruby_2.6_resque2_redis4.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.18.0)
       datadog-ci (~> 0.5.0)
-      debase-ruby_core_source (= 3.2.3)
+      debase-ruby_core_source (= 3.3.0)
       libdatadog (~> 5.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
@@ -43,7 +43,7 @@ GEM
     cri (2.15.11)
     datadog-ci (0.5.0)
       msgpack
-    debase-ruby_core_source (3.2.3)
+    debase-ruby_core_source (3.3.0)
     debug_inspector (1.1.0)
     diff-lcs (1.5.0)
     docile (1.4.0)

--- a/gemfiles/ruby_2.6_sinatra.gemfile.lock
+++ b/gemfiles/ruby_2.6_sinatra.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.18.0)
       datadog-ci (~> 0.5.0)
-      debase-ruby_core_source (= 3.2.3)
+      debase-ruby_core_source (= 3.3.0)
       libdatadog (~> 5.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
@@ -43,7 +43,7 @@ GEM
     cri (2.15.11)
     datadog-ci (0.5.0)
       msgpack
-    debase-ruby_core_source (3.2.3)
+    debase-ruby_core_source (3.3.0)
     debug_inspector (1.1.0)
     diff-lcs (1.5.0)
     docile (1.4.0)

--- a/gemfiles/ruby_2.7.6_sinatra.gemfile.lock
+++ b/gemfiles/ruby_2.7.6_sinatra.gemfile.lock
@@ -14,7 +14,7 @@ PATH
   specs:
     ddtrace (1.18.0)
       datadog-ci (~> 0.2.0)
-      debase-ruby_core_source (= 3.2.3)
+      debase-ruby_core_source (= 3.3.0)
       libdatadog (~> 5.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
@@ -43,7 +43,7 @@ GEM
       rexml
     cri (2.15.11)
     datadog-ci (0.2.0)
-    debase-ruby_core_source (3.2.3)
+    debase-ruby_core_source (3.3.0)
     debug_inspector (1.1.0)
     diff-lcs (1.5.0)
     docile (1.4.0)

--- a/gemfiles/ruby_2.7_activesupport.gemfile.lock
+++ b/gemfiles/ruby_2.7_activesupport.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.18.0)
       datadog-ci (~> 0.5.0)
-      debase-ruby_core_source (= 3.2.3)
+      debase-ruby_core_source (= 3.3.0)
       libdatadog (~> 5.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
@@ -72,7 +72,7 @@ GEM
     cri (2.15.11)
     datadog-ci (0.5.0)
       msgpack
-    debase-ruby_core_source (3.2.3)
+    debase-ruby_core_source (3.3.0)
     debug_inspector (1.1.0)
     diff-lcs (1.5.0)
     digest-crc (0.6.5)

--- a/gemfiles/ruby_2.7_aws.gemfile.lock
+++ b/gemfiles/ruby_2.7_aws.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.18.0)
       datadog-ci (~> 0.5.0)
-      debase-ruby_core_source (= 3.2.3)
+      debase-ruby_core_source (= 3.3.0)
       libdatadog (~> 5.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
@@ -1464,7 +1464,7 @@ GEM
     cri (2.15.11)
     datadog-ci (0.5.0)
       msgpack
-    debase-ruby_core_source (3.2.3)
+    debase-ruby_core_source (3.3.0)
     debug_inspector (1.1.0)
     diff-lcs (1.5.0)
     docile (1.4.0)

--- a/gemfiles/ruby_2.7_contrib.gemfile.lock
+++ b/gemfiles/ruby_2.7_contrib.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.18.0)
       datadog-ci (~> 0.5.0)
-      debase-ruby_core_source (= 3.2.3)
+      debase-ruby_core_source (= 3.3.0)
       libdatadog (~> 5.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
@@ -50,7 +50,7 @@ GEM
     dalli (3.2.4)
     datadog-ci (0.5.0)
       msgpack
-    debase-ruby_core_source (3.2.3)
+    debase-ruby_core_source (3.3.0)
     debug_inspector (1.1.0)
     diff-lcs (1.5.0)
     docile (1.4.0)

--- a/gemfiles/ruby_2.7_contrib_old.gemfile.lock
+++ b/gemfiles/ruby_2.7_contrib_old.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.18.0)
       datadog-ci (~> 0.5.0)
-      debase-ruby_core_source (= 3.2.3)
+      debase-ruby_core_source (= 3.3.0)
       libdatadog (~> 5.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
@@ -48,7 +48,7 @@ GEM
     dalli (2.7.11)
     datadog-ci (0.5.0)
       msgpack
-    debase-ruby_core_source (3.2.3)
+    debase-ruby_core_source (3.3.0)
     debug_inspector (1.1.0)
     diff-lcs (1.5.0)
     docile (1.4.0)

--- a/gemfiles/ruby_2.7_core_old.gemfile.lock
+++ b/gemfiles/ruby_2.7_core_old.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.18.0)
       datadog-ci (~> 0.5.0)
-      debase-ruby_core_source (= 3.2.3)
+      debase-ruby_core_source (= 3.3.0)
       libdatadog (~> 5.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
@@ -43,7 +43,7 @@ GEM
     cri (2.15.11)
     datadog-ci (0.5.0)
       msgpack
-    debase-ruby_core_source (3.2.3)
+    debase-ruby_core_source (3.3.0)
     debug_inspector (1.1.0)
     diff-lcs (1.5.0)
     docile (1.4.0)

--- a/gemfiles/ruby_2.7_elasticsearch_7.gemfile.lock
+++ b/gemfiles/ruby_2.7_elasticsearch_7.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.18.0)
       datadog-ci (~> 0.5.0)
-      debase-ruby_core_source (= 3.2.3)
+      debase-ruby_core_source (= 3.3.0)
       libdatadog (~> 5.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
@@ -44,7 +44,7 @@ GEM
     cri (2.15.11)
     datadog-ci (0.5.0)
       msgpack
-    debase-ruby_core_source (3.2.3)
+    debase-ruby_core_source (3.3.0)
     debug_inspector (1.1.0)
     diff-lcs (1.5.0)
     docile (1.4.0)

--- a/gemfiles/ruby_2.7_elasticsearch_8.gemfile.lock
+++ b/gemfiles/ruby_2.7_elasticsearch_8.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.18.0)
       datadog-ci (~> 0.5.0)
-      debase-ruby_core_source (= 3.2.3)
+      debase-ruby_core_source (= 3.3.0)
       libdatadog (~> 5.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
@@ -45,7 +45,7 @@ GEM
     cri (2.15.11)
     datadog-ci (0.5.0)
       msgpack
-    debase-ruby_core_source (3.2.3)
+    debase-ruby_core_source (3.3.0)
     debug_inspector (1.1.0)
     diff-lcs (1.5.0)
     docile (1.4.0)

--- a/gemfiles/ruby_2.7_hanami_1.gemfile.lock
+++ b/gemfiles/ruby_2.7_hanami_1.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.18.0)
       datadog-ci (~> 0.5.0)
-      debase-ruby_core_source (= 3.2.3)
+      debase-ruby_core_source (= 3.3.0)
       libdatadog (~> 5.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
@@ -44,7 +44,7 @@ GEM
     datadog-ci (0.5.0)
       msgpack
     date (3.3.3)
-    debase-ruby_core_source (3.2.3)
+    debase-ruby_core_source (3.3.0)
     debug_inspector (1.1.0)
     diff-lcs (1.5.0)
     docile (1.4.0)

--- a/gemfiles/ruby_2.7_http.gemfile.lock
+++ b/gemfiles/ruby_2.7_http.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.18.0)
       datadog-ci (~> 0.5.0)
-      debase-ruby_core_source (= 3.2.3)
+      debase-ruby_core_source (= 3.3.0)
       libdatadog (~> 5.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
@@ -43,7 +43,7 @@ GEM
     cri (2.15.11)
     datadog-ci (0.5.0)
       msgpack
-    debase-ruby_core_source (3.2.3)
+    debase-ruby_core_source (3.3.0)
     debug_inspector (1.1.0)
     diff-lcs (1.5.0)
     docile (1.4.0)

--- a/gemfiles/ruby_2.7_opensearch_2.gemfile.lock
+++ b/gemfiles/ruby_2.7_opensearch_2.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.18.0)
       datadog-ci (~> 0.5.0)
-      debase-ruby_core_source (= 3.2.3)
+      debase-ruby_core_source (= 3.3.0)
       libdatadog (~> 5.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
@@ -45,7 +45,7 @@ GEM
     cri (2.15.11)
     datadog-ci (0.5.0)
       msgpack
-    debase-ruby_core_source (3.2.3)
+    debase-ruby_core_source (3.3.0)
     debug_inspector (1.1.0)
     diff-lcs (1.5.0)
     docile (1.4.0)

--- a/gemfiles/ruby_2.7_opensearch_3.gemfile.lock
+++ b/gemfiles/ruby_2.7_opensearch_3.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.18.0)
       datadog-ci (~> 0.5.0)
-      debase-ruby_core_source (= 3.2.3)
+      debase-ruby_core_source (= 3.3.0)
       libdatadog (~> 5.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
@@ -45,7 +45,7 @@ GEM
     cri (2.15.11)
     datadog-ci (0.5.0)
       msgpack
-    debase-ruby_core_source (3.2.3)
+    debase-ruby_core_source (3.3.0)
     debug_inspector (1.1.0)
     diff-lcs (1.5.0)
     docile (1.4.0)

--- a/gemfiles/ruby_2.7_opentelemetry.gemfile.lock
+++ b/gemfiles/ruby_2.7_opentelemetry.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.18.0)
       datadog-ci (~> 0.5.0)
-      debase-ruby_core_source (= 3.2.3)
+      debase-ruby_core_source (= 3.3.0)
       libdatadog (~> 5.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
@@ -43,7 +43,7 @@ GEM
     cri (2.15.11)
     datadog-ci (0.5.0)
       msgpack
-    debase-ruby_core_source (3.2.3)
+    debase-ruby_core_source (3.3.0)
     debug_inspector (1.1.0)
     diff-lcs (1.5.0)
     docile (1.4.0)

--- a/gemfiles/ruby_2.7_opentracing.gemfile.lock
+++ b/gemfiles/ruby_2.7_opentracing.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.18.0)
       datadog-ci (~> 0.5.0)
-      debase-ruby_core_source (= 3.2.3)
+      debase-ruby_core_source (= 3.3.0)
       libdatadog (~> 5.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
@@ -44,7 +44,7 @@ GEM
     cri (2.15.11)
     datadog-ci (0.5.0)
       msgpack
-    debase-ruby_core_source (3.2.3)
+    debase-ruby_core_source (3.3.0)
     debug_inspector (1.1.0)
     diff-lcs (1.5.0)
     docile (1.4.0)

--- a/gemfiles/ruby_2.7_rack_1.gemfile.lock
+++ b/gemfiles/ruby_2.7_rack_1.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.18.0)
       datadog-ci (~> 0.5.0)
-      debase-ruby_core_source (= 3.2.3)
+      debase-ruby_core_source (= 3.3.0)
       libdatadog (~> 5.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
@@ -43,7 +43,7 @@ GEM
     cri (2.15.11)
     datadog-ci (0.5.0)
       msgpack
-    debase-ruby_core_source (3.2.3)
+    debase-ruby_core_source (3.3.0)
     debug_inspector (1.1.0)
     diff-lcs (1.5.0)
     docile (1.4.0)

--- a/gemfiles/ruby_2.7_rack_2.gemfile.lock
+++ b/gemfiles/ruby_2.7_rack_2.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.18.0)
       datadog-ci (~> 0.5.0)
-      debase-ruby_core_source (= 3.2.3)
+      debase-ruby_core_source (= 3.3.0)
       libdatadog (~> 5.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
@@ -43,7 +43,7 @@ GEM
     cri (2.15.11)
     datadog-ci (0.5.0)
       msgpack
-    debase-ruby_core_source (3.2.3)
+    debase-ruby_core_source (3.3.0)
     debug_inspector (1.1.0)
     diff-lcs (1.5.0)
     docile (1.4.0)

--- a/gemfiles/ruby_2.7_rack_3.gemfile.lock
+++ b/gemfiles/ruby_2.7_rack_3.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.18.0)
       datadog-ci (~> 0.5.0)
-      debase-ruby_core_source (= 3.2.3)
+      debase-ruby_core_source (= 3.3.0)
       libdatadog (~> 5.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
@@ -43,7 +43,7 @@ GEM
     cri (2.15.11)
     datadog-ci (0.5.0)
       msgpack
-    debase-ruby_core_source (3.2.3)
+    debase-ruby_core_source (3.3.0)
     debug_inspector (1.1.0)
     diff-lcs (1.5.0)
     docile (1.4.0)

--- a/gemfiles/ruby_2.7_rails5_mysql2.gemfile.lock
+++ b/gemfiles/ruby_2.7_rails5_mysql2.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.18.0)
       datadog-ci (~> 0.5.0)
-      debase-ruby_core_source (= 3.2.3)
+      debase-ruby_core_source (= 3.3.0)
       libdatadog (~> 5.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
@@ -87,7 +87,7 @@ GEM
     datadog-ci (0.5.0)
       msgpack
     date (3.3.3)
-    debase-ruby_core_source (3.2.3)
+    debase-ruby_core_source (3.3.0)
     debug_inspector (1.1.0)
     diff-lcs (1.5.0)
     docile (1.4.0)

--- a/gemfiles/ruby_2.7_rails5_postgres.gemfile.lock
+++ b/gemfiles/ruby_2.7_rails5_postgres.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.18.0)
       datadog-ci (~> 0.5.0)
-      debase-ruby_core_source (= 3.2.3)
+      debase-ruby_core_source (= 3.3.0)
       libdatadog (~> 5.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
@@ -87,7 +87,7 @@ GEM
     datadog-ci (0.5.0)
       msgpack
     date (3.3.3)
-    debase-ruby_core_source (3.2.3)
+    debase-ruby_core_source (3.3.0)
     debug_inspector (1.1.0)
     diff-lcs (1.5.0)
     docile (1.4.0)

--- a/gemfiles/ruby_2.7_rails5_postgres_redis.gemfile.lock
+++ b/gemfiles/ruby_2.7_rails5_postgres_redis.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.18.0)
       datadog-ci (~> 0.5.0)
-      debase-ruby_core_source (= 3.2.3)
+      debase-ruby_core_source (= 3.3.0)
       libdatadog (~> 5.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
@@ -87,7 +87,7 @@ GEM
     datadog-ci (0.5.0)
       msgpack
     date (3.3.3)
-    debase-ruby_core_source (3.2.3)
+    debase-ruby_core_source (3.3.0)
     debug_inspector (1.1.0)
     diff-lcs (1.5.0)
     docile (1.4.0)

--- a/gemfiles/ruby_2.7_rails5_postgres_redis_activesupport.gemfile.lock
+++ b/gemfiles/ruby_2.7_rails5_postgres_redis_activesupport.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.18.0)
       datadog-ci (~> 0.5.0)
-      debase-ruby_core_source (= 3.2.3)
+      debase-ruby_core_source (= 3.3.0)
       libdatadog (~> 5.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
@@ -87,7 +87,7 @@ GEM
     datadog-ci (0.5.0)
       msgpack
     date (3.3.3)
-    debase-ruby_core_source (3.2.3)
+    debase-ruby_core_source (3.3.0)
     debug_inspector (1.1.0)
     diff-lcs (1.5.0)
     docile (1.4.0)

--- a/gemfiles/ruby_2.7_rails5_postgres_sidekiq.gemfile.lock
+++ b/gemfiles/ruby_2.7_rails5_postgres_sidekiq.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.18.0)
       datadog-ci (~> 0.5.0)
-      debase-ruby_core_source (= 3.2.3)
+      debase-ruby_core_source (= 3.3.0)
       libdatadog (~> 5.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
@@ -88,7 +88,7 @@ GEM
     datadog-ci (0.5.0)
       msgpack
     date (3.3.3)
-    debase-ruby_core_source (3.2.3)
+    debase-ruby_core_source (3.3.0)
     debug_inspector (1.1.0)
     diff-lcs (1.5.0)
     docile (1.4.0)

--- a/gemfiles/ruby_2.7_rails5_semantic_logger.gemfile.lock
+++ b/gemfiles/ruby_2.7_rails5_semantic_logger.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.18.0)
       datadog-ci (~> 0.5.0)
-      debase-ruby_core_source (= 3.2.3)
+      debase-ruby_core_source (= 3.3.0)
       libdatadog (~> 5.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
@@ -87,7 +87,7 @@ GEM
     datadog-ci (0.5.0)
       msgpack
     date (3.3.3)
-    debase-ruby_core_source (3.2.3)
+    debase-ruby_core_source (3.3.0)
     debug_inspector (1.1.0)
     diff-lcs (1.5.0)
     docile (1.4.0)

--- a/gemfiles/ruby_2.7_rails61_mysql2.gemfile.lock
+++ b/gemfiles/ruby_2.7_rails61_mysql2.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.18.0)
       datadog-ci (~> 0.5.0)
-      debase-ruby_core_source (= 3.2.3)
+      debase-ruby_core_source (= 3.3.0)
       libdatadog (~> 5.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
@@ -104,7 +104,7 @@ GEM
     datadog-ci (0.5.0)
       msgpack
     date (3.3.3)
-    debase-ruby_core_source (3.2.3)
+    debase-ruby_core_source (3.3.0)
     debug_inspector (1.1.0)
     diff-lcs (1.5.0)
     docile (1.4.0)

--- a/gemfiles/ruby_2.7_rails61_postgres.gemfile.lock
+++ b/gemfiles/ruby_2.7_rails61_postgres.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.18.0)
       datadog-ci (~> 0.5.0)
-      debase-ruby_core_source (= 3.2.3)
+      debase-ruby_core_source (= 3.3.0)
       libdatadog (~> 5.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
@@ -104,7 +104,7 @@ GEM
     datadog-ci (0.5.0)
       msgpack
     date (3.3.3)
-    debase-ruby_core_source (3.2.3)
+    debase-ruby_core_source (3.3.0)
     debug_inspector (1.1.0)
     diff-lcs (1.5.0)
     docile (1.4.0)

--- a/gemfiles/ruby_2.7_rails61_postgres_redis.gemfile.lock
+++ b/gemfiles/ruby_2.7_rails61_postgres_redis.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.18.0)
       datadog-ci (~> 0.5.0)
-      debase-ruby_core_source (= 3.2.3)
+      debase-ruby_core_source (= 3.3.0)
       libdatadog (~> 5.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
@@ -104,7 +104,7 @@ GEM
     datadog-ci (0.5.0)
       msgpack
     date (3.3.3)
-    debase-ruby_core_source (3.2.3)
+    debase-ruby_core_source (3.3.0)
     debug_inspector (1.1.0)
     diff-lcs (1.5.0)
     docile (1.4.0)

--- a/gemfiles/ruby_2.7_rails61_postgres_sidekiq.gemfile.lock
+++ b/gemfiles/ruby_2.7_rails61_postgres_sidekiq.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.18.0)
       datadog-ci (~> 0.5.0)
-      debase-ruby_core_source (= 3.2.3)
+      debase-ruby_core_source (= 3.3.0)
       libdatadog (~> 5.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
@@ -105,7 +105,7 @@ GEM
     datadog-ci (0.5.0)
       msgpack
     date (3.3.3)
-    debase-ruby_core_source (3.2.3)
+    debase-ruby_core_source (3.3.0)
     debug_inspector (1.1.0)
     diff-lcs (1.5.0)
     docile (1.4.0)

--- a/gemfiles/ruby_2.7_rails61_semantic_logger.gemfile.lock
+++ b/gemfiles/ruby_2.7_rails61_semantic_logger.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.18.0)
       datadog-ci (~> 0.5.0)
-      debase-ruby_core_source (= 3.2.3)
+      debase-ruby_core_source (= 3.3.0)
       libdatadog (~> 5.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
@@ -104,7 +104,7 @@ GEM
     datadog-ci (0.5.0)
       msgpack
     date (3.3.3)
-    debase-ruby_core_source (3.2.3)
+    debase-ruby_core_source (3.3.0)
     debug_inspector (1.1.0)
     diff-lcs (1.5.0)
     docile (1.4.0)

--- a/gemfiles/ruby_2.7_rails6_mysql2.gemfile.lock
+++ b/gemfiles/ruby_2.7_rails6_mysql2.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.18.0)
       datadog-ci (~> 0.5.0)
-      debase-ruby_core_source (= 3.2.3)
+      debase-ruby_core_source (= 3.3.0)
       libdatadog (~> 5.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
@@ -100,7 +100,7 @@ GEM
     datadog-ci (0.5.0)
       msgpack
     date (3.3.3)
-    debase-ruby_core_source (3.2.3)
+    debase-ruby_core_source (3.3.0)
     debug_inspector (1.1.0)
     diff-lcs (1.5.0)
     docile (1.4.0)

--- a/gemfiles/ruby_2.7_rails6_postgres.gemfile.lock
+++ b/gemfiles/ruby_2.7_rails6_postgres.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.18.0)
       datadog-ci (~> 0.5.0)
-      debase-ruby_core_source (= 3.2.3)
+      debase-ruby_core_source (= 3.3.0)
       libdatadog (~> 5.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
@@ -100,7 +100,7 @@ GEM
     datadog-ci (0.5.0)
       msgpack
     date (3.3.3)
-    debase-ruby_core_source (3.2.3)
+    debase-ruby_core_source (3.3.0)
     debug_inspector (1.1.0)
     diff-lcs (1.5.0)
     docile (1.4.0)

--- a/gemfiles/ruby_2.7_rails6_postgres_redis.gemfile.lock
+++ b/gemfiles/ruby_2.7_rails6_postgres_redis.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.18.0)
       datadog-ci (~> 0.5.0)
-      debase-ruby_core_source (= 3.2.3)
+      debase-ruby_core_source (= 3.3.0)
       libdatadog (~> 5.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
@@ -100,7 +100,7 @@ GEM
     datadog-ci (0.5.0)
       msgpack
     date (3.3.3)
-    debase-ruby_core_source (3.2.3)
+    debase-ruby_core_source (3.3.0)
     debug_inspector (1.1.0)
     diff-lcs (1.5.0)
     docile (1.4.0)

--- a/gemfiles/ruby_2.7_rails6_postgres_redis_activesupport.gemfile.lock
+++ b/gemfiles/ruby_2.7_rails6_postgres_redis_activesupport.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.18.0)
       datadog-ci (~> 0.5.0)
-      debase-ruby_core_source (= 3.2.3)
+      debase-ruby_core_source (= 3.3.0)
       libdatadog (~> 5.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
@@ -100,7 +100,7 @@ GEM
     datadog-ci (0.5.0)
       msgpack
     date (3.3.3)
-    debase-ruby_core_source (3.2.3)
+    debase-ruby_core_source (3.3.0)
     debug_inspector (1.1.0)
     diff-lcs (1.5.0)
     docile (1.4.0)

--- a/gemfiles/ruby_2.7_rails6_postgres_sidekiq.gemfile.lock
+++ b/gemfiles/ruby_2.7_rails6_postgres_sidekiq.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.18.0)
       datadog-ci (~> 0.5.0)
-      debase-ruby_core_source (= 3.2.3)
+      debase-ruby_core_source (= 3.3.0)
       libdatadog (~> 5.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
@@ -101,7 +101,7 @@ GEM
     datadog-ci (0.5.0)
       msgpack
     date (3.3.3)
-    debase-ruby_core_source (3.2.3)
+    debase-ruby_core_source (3.3.0)
     debug_inspector (1.1.0)
     diff-lcs (1.5.0)
     docile (1.4.0)

--- a/gemfiles/ruby_2.7_rails6_semantic_logger.gemfile.lock
+++ b/gemfiles/ruby_2.7_rails6_semantic_logger.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.18.0)
       datadog-ci (~> 0.5.0)
-      debase-ruby_core_source (= 3.2.3)
+      debase-ruby_core_source (= 3.3.0)
       libdatadog (~> 5.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
@@ -100,7 +100,7 @@ GEM
     datadog-ci (0.5.0)
       msgpack
     date (3.3.3)
-    debase-ruby_core_source (3.2.3)
+    debase-ruby_core_source (3.3.0)
     debug_inspector (1.1.0)
     diff-lcs (1.5.0)
     docile (1.4.0)

--- a/gemfiles/ruby_2.7_redis_3.gemfile.lock
+++ b/gemfiles/ruby_2.7_redis_3.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.18.0)
       datadog-ci (~> 0.5.0)
-      debase-ruby_core_source (= 3.2.3)
+      debase-ruby_core_source (= 3.3.0)
       libdatadog (~> 5.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
@@ -43,7 +43,7 @@ GEM
     cri (2.15.11)
     datadog-ci (0.5.0)
       msgpack
-    debase-ruby_core_source (3.2.3)
+    debase-ruby_core_source (3.3.0)
     debug_inspector (1.1.0)
     diff-lcs (1.5.0)
     docile (1.4.0)

--- a/gemfiles/ruby_2.7_redis_4.gemfile.lock
+++ b/gemfiles/ruby_2.7_redis_4.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.18.0)
       datadog-ci (~> 0.5.0)
-      debase-ruby_core_source (= 3.2.3)
+      debase-ruby_core_source (= 3.3.0)
       libdatadog (~> 5.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
@@ -43,7 +43,7 @@ GEM
     cri (2.15.11)
     datadog-ci (0.5.0)
       msgpack
-    debase-ruby_core_source (3.2.3)
+    debase-ruby_core_source (3.3.0)
     debug_inspector (1.1.0)
     diff-lcs (1.5.0)
     docile (1.4.0)

--- a/gemfiles/ruby_2.7_redis_5.gemfile.lock
+++ b/gemfiles/ruby_2.7_redis_5.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.18.0)
       datadog-ci (~> 0.5.0)
-      debase-ruby_core_source (= 3.2.3)
+      debase-ruby_core_source (= 3.3.0)
       libdatadog (~> 5.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
@@ -44,7 +44,7 @@ GEM
     cri (2.15.11)
     datadog-ci (0.5.0)
       msgpack
-    debase-ruby_core_source (3.2.3)
+    debase-ruby_core_source (3.3.0)
     debug_inspector (1.1.0)
     diff-lcs (1.5.0)
     docile (1.4.0)

--- a/gemfiles/ruby_2.7_relational_db.gemfile.lock
+++ b/gemfiles/ruby_2.7_relational_db.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.18.0)
       datadog-ci (~> 0.5.0)
-      debase-ruby_core_source (= 3.2.3)
+      debase-ruby_core_source (= 3.3.0)
       libdatadog (~> 5.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
@@ -54,7 +54,7 @@ GEM
     cri (2.15.11)
     datadog-ci (0.5.0)
       msgpack
-    debase-ruby_core_source (3.2.3)
+    debase-ruby_core_source (3.3.0)
     debug_inspector (1.1.0)
     delayed_job (4.1.11)
       activesupport (>= 3.0, < 8.0)

--- a/gemfiles/ruby_2.7_resque2_redis3.gemfile.lock
+++ b/gemfiles/ruby_2.7_resque2_redis3.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.18.0)
       datadog-ci (~> 0.5.0)
-      debase-ruby_core_source (= 3.2.3)
+      debase-ruby_core_source (= 3.3.0)
       libdatadog (~> 5.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
@@ -43,7 +43,7 @@ GEM
     cri (2.15.11)
     datadog-ci (0.5.0)
       msgpack
-    debase-ruby_core_source (3.2.3)
+    debase-ruby_core_source (3.3.0)
     debug_inspector (1.1.0)
     diff-lcs (1.5.0)
     docile (1.4.0)

--- a/gemfiles/ruby_2.7_resque2_redis4.gemfile.lock
+++ b/gemfiles/ruby_2.7_resque2_redis4.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.18.0)
       datadog-ci (~> 0.5.0)
-      debase-ruby_core_source (= 3.2.3)
+      debase-ruby_core_source (= 3.3.0)
       libdatadog (~> 5.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
@@ -43,7 +43,7 @@ GEM
     cri (2.15.11)
     datadog-ci (0.5.0)
       msgpack
-    debase-ruby_core_source (3.2.3)
+    debase-ruby_core_source (3.3.0)
     debug_inspector (1.1.0)
     diff-lcs (1.5.0)
     docile (1.4.0)

--- a/gemfiles/ruby_2.7_sinatra.gemfile.lock
+++ b/gemfiles/ruby_2.7_sinatra.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.18.0)
       datadog-ci (~> 0.5.0)
-      debase-ruby_core_source (= 3.2.3)
+      debase-ruby_core_source (= 3.3.0)
       libdatadog (~> 5.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
@@ -43,7 +43,7 @@ GEM
     cri (2.15.11)
     datadog-ci (0.5.0)
       msgpack
-    debase-ruby_core_source (3.2.3)
+    debase-ruby_core_source (3.3.0)
     debug_inspector (1.1.0)
     diff-lcs (1.5.0)
     docile (1.4.0)

--- a/gemfiles/ruby_3.0_activesupport.gemfile.lock
+++ b/gemfiles/ruby_3.0_activesupport.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.18.0)
       datadog-ci (~> 0.5.0)
-      debase-ruby_core_source (= 3.2.3)
+      debase-ruby_core_source (= 3.3.0)
       libdatadog (~> 5.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
@@ -71,7 +71,7 @@ GEM
     cri (2.15.11)
     datadog-ci (0.5.0)
       msgpack
-    debase-ruby_core_source (3.2.3)
+    debase-ruby_core_source (3.3.0)
     debug_inspector (1.1.0)
     diff-lcs (1.5.0)
     digest-crc (0.6.5)

--- a/gemfiles/ruby_3.0_aws.gemfile.lock
+++ b/gemfiles/ruby_3.0_aws.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.18.0)
       datadog-ci (~> 0.5.0)
-      debase-ruby_core_source (= 3.2.3)
+      debase-ruby_core_source (= 3.3.0)
       libdatadog (~> 5.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
@@ -1464,7 +1464,7 @@ GEM
     cri (2.15.11)
     datadog-ci (0.5.0)
       msgpack
-    debase-ruby_core_source (3.2.3)
+    debase-ruby_core_source (3.3.0)
     debug_inspector (1.1.0)
     diff-lcs (1.5.0)
     docile (1.4.0)

--- a/gemfiles/ruby_3.0_contrib.gemfile.lock
+++ b/gemfiles/ruby_3.0_contrib.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.18.0)
       datadog-ci (~> 0.5.0)
-      debase-ruby_core_source (= 3.2.3)
+      debase-ruby_core_source (= 3.3.0)
       libdatadog (~> 5.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
@@ -50,7 +50,7 @@ GEM
     dalli (3.2.4)
     datadog-ci (0.5.0)
       msgpack
-    debase-ruby_core_source (3.2.3)
+    debase-ruby_core_source (3.3.0)
     debug_inspector (1.1.0)
     diff-lcs (1.5.0)
     docile (1.4.0)

--- a/gemfiles/ruby_3.0_contrib_old.gemfile.lock
+++ b/gemfiles/ruby_3.0_contrib_old.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.18.0)
       datadog-ci (~> 0.5.0)
-      debase-ruby_core_source (= 3.2.3)
+      debase-ruby_core_source (= 3.3.0)
       libdatadog (~> 5.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
@@ -48,7 +48,7 @@ GEM
     dalli (2.7.11)
     datadog-ci (0.5.0)
       msgpack
-    debase-ruby_core_source (3.2.3)
+    debase-ruby_core_source (3.3.0)
     debug_inspector (1.1.0)
     diff-lcs (1.5.0)
     docile (1.4.0)

--- a/gemfiles/ruby_3.0_core_old.gemfile.lock
+++ b/gemfiles/ruby_3.0_core_old.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.18.0)
       datadog-ci (~> 0.5.0)
-      debase-ruby_core_source (= 3.2.3)
+      debase-ruby_core_source (= 3.3.0)
       libdatadog (~> 5.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
@@ -43,7 +43,7 @@ GEM
     cri (2.15.11)
     datadog-ci (0.5.0)
       msgpack
-    debase-ruby_core_source (3.2.3)
+    debase-ruby_core_source (3.3.0)
     debug_inspector (1.1.0)
     diff-lcs (1.5.0)
     docile (1.4.0)

--- a/gemfiles/ruby_3.0_elasticsearch_7.gemfile.lock
+++ b/gemfiles/ruby_3.0_elasticsearch_7.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.18.0)
       datadog-ci (~> 0.5.0)
-      debase-ruby_core_source (= 3.2.3)
+      debase-ruby_core_source (= 3.3.0)
       libdatadog (~> 5.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
@@ -44,7 +44,7 @@ GEM
     cri (2.15.11)
     datadog-ci (0.5.0)
       msgpack
-    debase-ruby_core_source (3.2.3)
+    debase-ruby_core_source (3.3.0)
     debug_inspector (1.1.0)
     diff-lcs (1.5.0)
     docile (1.4.0)

--- a/gemfiles/ruby_3.0_elasticsearch_8.gemfile.lock
+++ b/gemfiles/ruby_3.0_elasticsearch_8.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.18.0)
       datadog-ci (~> 0.5.0)
-      debase-ruby_core_source (= 3.2.3)
+      debase-ruby_core_source (= 3.3.0)
       libdatadog (~> 5.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
@@ -45,7 +45,7 @@ GEM
     cri (2.15.11)
     datadog-ci (0.5.0)
       msgpack
-    debase-ruby_core_source (3.2.3)
+    debase-ruby_core_source (3.3.0)
     debug_inspector (1.1.0)
     diff-lcs (1.5.0)
     docile (1.4.0)

--- a/gemfiles/ruby_3.0_http.gemfile.lock
+++ b/gemfiles/ruby_3.0_http.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.18.0)
       datadog-ci (~> 0.5.0)
-      debase-ruby_core_source (= 3.2.3)
+      debase-ruby_core_source (= 3.3.0)
       libdatadog (~> 5.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
@@ -43,7 +43,7 @@ GEM
     cri (2.15.11)
     datadog-ci (0.5.0)
       msgpack
-    debase-ruby_core_source (3.2.3)
+    debase-ruby_core_source (3.3.0)
     debug_inspector (1.1.0)
     diff-lcs (1.5.0)
     docile (1.4.0)

--- a/gemfiles/ruby_3.0_opensearch_2.gemfile.lock
+++ b/gemfiles/ruby_3.0_opensearch_2.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.18.0)
       datadog-ci (~> 0.5.0)
-      debase-ruby_core_source (= 3.2.3)
+      debase-ruby_core_source (= 3.3.0)
       libdatadog (~> 5.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
@@ -45,7 +45,7 @@ GEM
     cri (2.15.11)
     datadog-ci (0.5.0)
       msgpack
-    debase-ruby_core_source (3.2.3)
+    debase-ruby_core_source (3.3.0)
     debug_inspector (1.1.0)
     diff-lcs (1.5.0)
     docile (1.4.0)

--- a/gemfiles/ruby_3.0_opensearch_3.gemfile.lock
+++ b/gemfiles/ruby_3.0_opensearch_3.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.18.0)
       datadog-ci (~> 0.5.0)
-      debase-ruby_core_source (= 3.2.3)
+      debase-ruby_core_source (= 3.3.0)
       libdatadog (~> 5.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
@@ -45,7 +45,7 @@ GEM
     cri (2.15.11)
     datadog-ci (0.5.0)
       msgpack
-    debase-ruby_core_source (3.2.3)
+    debase-ruby_core_source (3.3.0)
     debug_inspector (1.1.0)
     diff-lcs (1.5.0)
     docile (1.4.0)

--- a/gemfiles/ruby_3.0_opentelemetry.gemfile.lock
+++ b/gemfiles/ruby_3.0_opentelemetry.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.18.0)
       datadog-ci (~> 0.5.0)
-      debase-ruby_core_source (= 3.2.3)
+      debase-ruby_core_source (= 3.3.0)
       libdatadog (~> 5.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
@@ -43,7 +43,7 @@ GEM
     cri (2.15.11)
     datadog-ci (0.5.0)
       msgpack
-    debase-ruby_core_source (3.2.3)
+    debase-ruby_core_source (3.3.0)
     debug_inspector (1.1.0)
     diff-lcs (1.5.0)
     docile (1.4.0)

--- a/gemfiles/ruby_3.0_opentracing.gemfile.lock
+++ b/gemfiles/ruby_3.0_opentracing.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.18.0)
       datadog-ci (~> 0.5.0)
-      debase-ruby_core_source (= 3.2.3)
+      debase-ruby_core_source (= 3.3.0)
       libdatadog (~> 5.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
@@ -44,7 +44,7 @@ GEM
     cri (2.15.11)
     datadog-ci (0.5.0)
       msgpack
-    debase-ruby_core_source (3.2.3)
+    debase-ruby_core_source (3.3.0)
     debug_inspector (1.1.0)
     diff-lcs (1.5.0)
     docile (1.4.0)

--- a/gemfiles/ruby_3.0_rack_1.gemfile.lock
+++ b/gemfiles/ruby_3.0_rack_1.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.18.0)
       datadog-ci (~> 0.5.0)
-      debase-ruby_core_source (= 3.2.3)
+      debase-ruby_core_source (= 3.3.0)
       libdatadog (~> 5.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
@@ -43,7 +43,7 @@ GEM
     cri (2.15.11)
     datadog-ci (0.5.0)
       msgpack
-    debase-ruby_core_source (3.2.3)
+    debase-ruby_core_source (3.3.0)
     debug_inspector (1.1.0)
     diff-lcs (1.5.0)
     docile (1.4.0)

--- a/gemfiles/ruby_3.0_rack_2.gemfile.lock
+++ b/gemfiles/ruby_3.0_rack_2.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.18.0)
       datadog-ci (~> 0.5.0)
-      debase-ruby_core_source (= 3.2.3)
+      debase-ruby_core_source (= 3.3.0)
       libdatadog (~> 5.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
@@ -43,7 +43,7 @@ GEM
     cri (2.15.11)
     datadog-ci (0.5.0)
       msgpack
-    debase-ruby_core_source (3.2.3)
+    debase-ruby_core_source (3.3.0)
     debug_inspector (1.1.0)
     diff-lcs (1.5.0)
     docile (1.4.0)

--- a/gemfiles/ruby_3.0_rack_3.gemfile.lock
+++ b/gemfiles/ruby_3.0_rack_3.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.18.0)
       datadog-ci (~> 0.5.0)
-      debase-ruby_core_source (= 3.2.3)
+      debase-ruby_core_source (= 3.3.0)
       libdatadog (~> 5.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
@@ -43,7 +43,7 @@ GEM
     cri (2.15.11)
     datadog-ci (0.5.0)
       msgpack
-    debase-ruby_core_source (3.2.3)
+    debase-ruby_core_source (3.3.0)
     debug_inspector (1.1.0)
     diff-lcs (1.5.0)
     docile (1.4.0)

--- a/gemfiles/ruby_3.0_rails61_mysql2.gemfile.lock
+++ b/gemfiles/ruby_3.0_rails61_mysql2.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.18.0)
       datadog-ci (~> 0.5.0)
-      debase-ruby_core_source (= 3.2.3)
+      debase-ruby_core_source (= 3.3.0)
       libdatadog (~> 5.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
@@ -104,7 +104,7 @@ GEM
     datadog-ci (0.5.0)
       msgpack
     date (3.3.3)
-    debase-ruby_core_source (3.2.3)
+    debase-ruby_core_source (3.3.0)
     debug_inspector (1.1.0)
     diff-lcs (1.5.0)
     docile (1.4.0)

--- a/gemfiles/ruby_3.0_rails61_postgres.gemfile.lock
+++ b/gemfiles/ruby_3.0_rails61_postgres.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.18.0)
       datadog-ci (~> 0.5.0)
-      debase-ruby_core_source (= 3.2.3)
+      debase-ruby_core_source (= 3.3.0)
       libdatadog (~> 5.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
@@ -104,7 +104,7 @@ GEM
     datadog-ci (0.5.0)
       msgpack
     date (3.3.3)
-    debase-ruby_core_source (3.2.3)
+    debase-ruby_core_source (3.3.0)
     debug_inspector (1.1.0)
     diff-lcs (1.5.0)
     docile (1.4.0)

--- a/gemfiles/ruby_3.0_rails61_postgres_redis.gemfile.lock
+++ b/gemfiles/ruby_3.0_rails61_postgres_redis.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.18.0)
       datadog-ci (~> 0.5.0)
-      debase-ruby_core_source (= 3.2.3)
+      debase-ruby_core_source (= 3.3.0)
       libdatadog (~> 5.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
@@ -104,7 +104,7 @@ GEM
     datadog-ci (0.5.0)
       msgpack
     date (3.3.3)
-    debase-ruby_core_source (3.2.3)
+    debase-ruby_core_source (3.3.0)
     debug_inspector (1.1.0)
     diff-lcs (1.5.0)
     docile (1.4.0)

--- a/gemfiles/ruby_3.0_rails61_postgres_sidekiq.gemfile.lock
+++ b/gemfiles/ruby_3.0_rails61_postgres_sidekiq.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.18.0)
       datadog-ci (~> 0.5.0)
-      debase-ruby_core_source (= 3.2.3)
+      debase-ruby_core_source (= 3.3.0)
       libdatadog (~> 5.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
@@ -105,7 +105,7 @@ GEM
     datadog-ci (0.5.0)
       msgpack
     date (3.3.3)
-    debase-ruby_core_source (3.2.3)
+    debase-ruby_core_source (3.3.0)
     debug_inspector (1.1.0)
     diff-lcs (1.5.0)
     docile (1.4.0)

--- a/gemfiles/ruby_3.0_rails61_semantic_logger.gemfile.lock
+++ b/gemfiles/ruby_3.0_rails61_semantic_logger.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.18.0)
       datadog-ci (~> 0.5.0)
-      debase-ruby_core_source (= 3.2.3)
+      debase-ruby_core_source (= 3.3.0)
       libdatadog (~> 5.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
@@ -104,7 +104,7 @@ GEM
     datadog-ci (0.5.0)
       msgpack
     date (3.3.3)
-    debase-ruby_core_source (3.2.3)
+    debase-ruby_core_source (3.3.0)
     debug_inspector (1.1.0)
     diff-lcs (1.5.0)
     docile (1.4.0)

--- a/gemfiles/ruby_3.0_redis_3.gemfile.lock
+++ b/gemfiles/ruby_3.0_redis_3.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.18.0)
       datadog-ci (~> 0.5.0)
-      debase-ruby_core_source (= 3.2.3)
+      debase-ruby_core_source (= 3.3.0)
       libdatadog (~> 5.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
@@ -43,7 +43,7 @@ GEM
     cri (2.15.11)
     datadog-ci (0.5.0)
       msgpack
-    debase-ruby_core_source (3.2.3)
+    debase-ruby_core_source (3.3.0)
     debug_inspector (1.1.0)
     diff-lcs (1.5.0)
     docile (1.4.0)

--- a/gemfiles/ruby_3.0_redis_4.gemfile.lock
+++ b/gemfiles/ruby_3.0_redis_4.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.18.0)
       datadog-ci (~> 0.5.0)
-      debase-ruby_core_source (= 3.2.3)
+      debase-ruby_core_source (= 3.3.0)
       libdatadog (~> 5.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
@@ -43,7 +43,7 @@ GEM
     cri (2.15.11)
     datadog-ci (0.5.0)
       msgpack
-    debase-ruby_core_source (3.2.3)
+    debase-ruby_core_source (3.3.0)
     debug_inspector (1.1.0)
     diff-lcs (1.5.0)
     docile (1.4.0)

--- a/gemfiles/ruby_3.0_redis_5.gemfile.lock
+++ b/gemfiles/ruby_3.0_redis_5.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.18.0)
       datadog-ci (~> 0.5.0)
-      debase-ruby_core_source (= 3.2.3)
+      debase-ruby_core_source (= 3.3.0)
       libdatadog (~> 5.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
@@ -44,7 +44,7 @@ GEM
     cri (2.15.11)
     datadog-ci (0.5.0)
       msgpack
-    debase-ruby_core_source (3.2.3)
+    debase-ruby_core_source (3.3.0)
     debug_inspector (1.1.0)
     diff-lcs (1.5.0)
     docile (1.4.0)

--- a/gemfiles/ruby_3.0_relational_db.gemfile.lock
+++ b/gemfiles/ruby_3.0_relational_db.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.18.0)
       datadog-ci (~> 0.5.0)
-      debase-ruby_core_source (= 3.2.3)
+      debase-ruby_core_source (= 3.3.0)
       libdatadog (~> 5.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
@@ -53,7 +53,7 @@ GEM
     cri (2.15.11)
     datadog-ci (0.5.0)
       msgpack
-    debase-ruby_core_source (3.2.3)
+    debase-ruby_core_source (3.3.0)
     debug_inspector (1.1.0)
     delayed_job (4.1.11)
       activesupport (>= 3.0, < 8.0)

--- a/gemfiles/ruby_3.0_resque2_redis3.gemfile.lock
+++ b/gemfiles/ruby_3.0_resque2_redis3.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.18.0)
       datadog-ci (~> 0.5.0)
-      debase-ruby_core_source (= 3.2.3)
+      debase-ruby_core_source (= 3.3.0)
       libdatadog (~> 5.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
@@ -43,7 +43,7 @@ GEM
     cri (2.15.11)
     datadog-ci (0.5.0)
       msgpack
-    debase-ruby_core_source (3.2.3)
+    debase-ruby_core_source (3.3.0)
     debug_inspector (1.1.0)
     diff-lcs (1.5.0)
     docile (1.4.0)

--- a/gemfiles/ruby_3.0_resque2_redis4.gemfile.lock
+++ b/gemfiles/ruby_3.0_resque2_redis4.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.18.0)
       datadog-ci (~> 0.5.0)
-      debase-ruby_core_source (= 3.2.3)
+      debase-ruby_core_source (= 3.3.0)
       libdatadog (~> 5.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
@@ -44,7 +44,7 @@ GEM
     cri (2.15.11)
     datadog-ci (0.5.0)
       msgpack
-    debase-ruby_core_source (3.2.3)
+    debase-ruby_core_source (3.3.0)
     debug_inspector (1.1.0)
     diff-lcs (1.5.0)
     docile (1.4.0)

--- a/gemfiles/ruby_3.0_sinatra.gemfile.lock
+++ b/gemfiles/ruby_3.0_sinatra.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.18.0)
       datadog-ci (~> 0.5.0)
-      debase-ruby_core_source (= 3.2.3)
+      debase-ruby_core_source (= 3.3.0)
       libdatadog (~> 5.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
@@ -43,7 +43,7 @@ GEM
     cri (2.15.11)
     datadog-ci (0.5.0)
       msgpack
-    debase-ruby_core_source (3.2.3)
+    debase-ruby_core_source (3.3.0)
     debug_inspector (1.1.0)
     diff-lcs (1.5.0)
     docile (1.4.0)

--- a/gemfiles/ruby_3.1_activesupport.gemfile.lock
+++ b/gemfiles/ruby_3.1_activesupport.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.18.0)
       datadog-ci (~> 0.5.0)
-      debase-ruby_core_source (= 3.2.3)
+      debase-ruby_core_source (= 3.3.0)
       libdatadog (~> 5.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
@@ -71,7 +71,7 @@ GEM
     cri (2.15.11)
     datadog-ci (0.5.0)
       msgpack
-    debase-ruby_core_source (3.2.3)
+    debase-ruby_core_source (3.3.0)
     debug_inspector (1.1.0)
     diff-lcs (1.5.0)
     digest-crc (0.6.5)

--- a/gemfiles/ruby_3.1_aws.gemfile.lock
+++ b/gemfiles/ruby_3.1_aws.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.18.0)
       datadog-ci (~> 0.5.0)
-      debase-ruby_core_source (= 3.2.3)
+      debase-ruby_core_source (= 3.3.0)
       libdatadog (~> 5.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
@@ -1464,7 +1464,7 @@ GEM
     cri (2.15.11)
     datadog-ci (0.5.0)
       msgpack
-    debase-ruby_core_source (3.2.3)
+    debase-ruby_core_source (3.3.0)
     debug_inspector (1.1.0)
     diff-lcs (1.5.0)
     docile (1.4.0)

--- a/gemfiles/ruby_3.1_contrib.gemfile.lock
+++ b/gemfiles/ruby_3.1_contrib.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.18.0)
       datadog-ci (~> 0.5.0)
-      debase-ruby_core_source (= 3.2.3)
+      debase-ruby_core_source (= 3.3.0)
       libdatadog (~> 5.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
@@ -50,7 +50,7 @@ GEM
     dalli (3.2.4)
     datadog-ci (0.5.0)
       msgpack
-    debase-ruby_core_source (3.2.3)
+    debase-ruby_core_source (3.3.0)
     debug_inspector (1.1.0)
     diff-lcs (1.5.0)
     docile (1.4.0)

--- a/gemfiles/ruby_3.1_contrib_old.gemfile.lock
+++ b/gemfiles/ruby_3.1_contrib_old.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.18.0)
       datadog-ci (~> 0.5.0)
-      debase-ruby_core_source (= 3.2.3)
+      debase-ruby_core_source (= 3.3.0)
       libdatadog (~> 5.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
@@ -48,7 +48,7 @@ GEM
     dalli (2.7.11)
     datadog-ci (0.5.0)
       msgpack
-    debase-ruby_core_source (3.2.3)
+    debase-ruby_core_source (3.3.0)
     debug_inspector (1.1.0)
     diff-lcs (1.5.0)
     docile (1.4.0)

--- a/gemfiles/ruby_3.1_core_old.gemfile.lock
+++ b/gemfiles/ruby_3.1_core_old.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.18.0)
       datadog-ci (~> 0.5.0)
-      debase-ruby_core_source (= 3.2.3)
+      debase-ruby_core_source (= 3.3.0)
       libdatadog (~> 5.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
@@ -43,7 +43,7 @@ GEM
     cri (2.15.11)
     datadog-ci (0.5.0)
       msgpack
-    debase-ruby_core_source (3.2.3)
+    debase-ruby_core_source (3.3.0)
     debug_inspector (1.1.0)
     diff-lcs (1.5.0)
     docile (1.4.0)

--- a/gemfiles/ruby_3.1_elasticsearch_7.gemfile.lock
+++ b/gemfiles/ruby_3.1_elasticsearch_7.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.18.0)
       datadog-ci (~> 0.5.0)
-      debase-ruby_core_source (= 3.2.3)
+      debase-ruby_core_source (= 3.3.0)
       libdatadog (~> 5.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
@@ -44,7 +44,7 @@ GEM
     cri (2.15.11)
     datadog-ci (0.5.0)
       msgpack
-    debase-ruby_core_source (3.2.3)
+    debase-ruby_core_source (3.3.0)
     debug_inspector (1.1.0)
     diff-lcs (1.5.0)
     docile (1.4.0)

--- a/gemfiles/ruby_3.1_elasticsearch_8.gemfile.lock
+++ b/gemfiles/ruby_3.1_elasticsearch_8.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.18.0)
       datadog-ci (~> 0.5.0)
-      debase-ruby_core_source (= 3.2.3)
+      debase-ruby_core_source (= 3.3.0)
       libdatadog (~> 5.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
@@ -45,7 +45,7 @@ GEM
     cri (2.15.11)
     datadog-ci (0.5.0)
       msgpack
-    debase-ruby_core_source (3.2.3)
+    debase-ruby_core_source (3.3.0)
     debug_inspector (1.1.0)
     diff-lcs (1.5.0)
     docile (1.4.0)

--- a/gemfiles/ruby_3.1_http.gemfile.lock
+++ b/gemfiles/ruby_3.1_http.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.18.0)
       datadog-ci (~> 0.5.0)
-      debase-ruby_core_source (= 3.2.3)
+      debase-ruby_core_source (= 3.3.0)
       libdatadog (~> 5.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
@@ -43,7 +43,7 @@ GEM
     cri (2.15.11)
     datadog-ci (0.5.0)
       msgpack
-    debase-ruby_core_source (3.2.3)
+    debase-ruby_core_source (3.3.0)
     debug_inspector (1.1.0)
     diff-lcs (1.5.0)
     docile (1.4.0)

--- a/gemfiles/ruby_3.1_opensearch_2.gemfile.lock
+++ b/gemfiles/ruby_3.1_opensearch_2.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.18.0)
       datadog-ci (~> 0.5.0)
-      debase-ruby_core_source (= 3.2.3)
+      debase-ruby_core_source (= 3.3.0)
       libdatadog (~> 5.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
@@ -45,7 +45,7 @@ GEM
     cri (2.15.11)
     datadog-ci (0.5.0)
       msgpack
-    debase-ruby_core_source (3.2.3)
+    debase-ruby_core_source (3.3.0)
     debug_inspector (1.1.0)
     diff-lcs (1.5.0)
     docile (1.4.0)

--- a/gemfiles/ruby_3.1_opensearch_3.gemfile.lock
+++ b/gemfiles/ruby_3.1_opensearch_3.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.18.0)
       datadog-ci (~> 0.5.0)
-      debase-ruby_core_source (= 3.2.3)
+      debase-ruby_core_source (= 3.3.0)
       libdatadog (~> 5.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
@@ -45,7 +45,7 @@ GEM
     cri (2.15.11)
     datadog-ci (0.5.0)
       msgpack
-    debase-ruby_core_source (3.2.3)
+    debase-ruby_core_source (3.3.0)
     debug_inspector (1.1.0)
     diff-lcs (1.5.0)
     docile (1.4.0)

--- a/gemfiles/ruby_3.1_opentelemetry.gemfile.lock
+++ b/gemfiles/ruby_3.1_opentelemetry.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.18.0)
       datadog-ci (~> 0.5.0)
-      debase-ruby_core_source (= 3.2.3)
+      debase-ruby_core_source (= 3.3.0)
       libdatadog (~> 5.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
@@ -43,7 +43,7 @@ GEM
     cri (2.15.11)
     datadog-ci (0.5.0)
       msgpack
-    debase-ruby_core_source (3.2.3)
+    debase-ruby_core_source (3.3.0)
     debug_inspector (1.1.0)
     diff-lcs (1.5.0)
     docile (1.4.0)

--- a/gemfiles/ruby_3.1_opentracing.gemfile.lock
+++ b/gemfiles/ruby_3.1_opentracing.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.18.0)
       datadog-ci (~> 0.5.0)
-      debase-ruby_core_source (= 3.2.3)
+      debase-ruby_core_source (= 3.3.0)
       libdatadog (~> 5.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
@@ -44,7 +44,7 @@ GEM
     cri (2.15.11)
     datadog-ci (0.5.0)
       msgpack
-    debase-ruby_core_source (3.2.3)
+    debase-ruby_core_source (3.3.0)
     debug_inspector (1.1.0)
     diff-lcs (1.5.0)
     docile (1.4.0)

--- a/gemfiles/ruby_3.1_rack_1.gemfile.lock
+++ b/gemfiles/ruby_3.1_rack_1.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.18.0)
       datadog-ci (~> 0.5.0)
-      debase-ruby_core_source (= 3.2.3)
+      debase-ruby_core_source (= 3.3.0)
       libdatadog (~> 5.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
@@ -43,7 +43,7 @@ GEM
     cri (2.15.11)
     datadog-ci (0.5.0)
       msgpack
-    debase-ruby_core_source (3.2.3)
+    debase-ruby_core_source (3.3.0)
     debug_inspector (1.1.0)
     diff-lcs (1.5.0)
     docile (1.4.0)

--- a/gemfiles/ruby_3.1_rack_2.gemfile.lock
+++ b/gemfiles/ruby_3.1_rack_2.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.18.0)
       datadog-ci (~> 0.5.0)
-      debase-ruby_core_source (= 3.2.3)
+      debase-ruby_core_source (= 3.3.0)
       libdatadog (~> 5.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
@@ -43,7 +43,7 @@ GEM
     cri (2.15.11)
     datadog-ci (0.5.0)
       msgpack
-    debase-ruby_core_source (3.2.3)
+    debase-ruby_core_source (3.3.0)
     debug_inspector (1.1.0)
     diff-lcs (1.5.0)
     docile (1.4.0)

--- a/gemfiles/ruby_3.1_rack_3.gemfile.lock
+++ b/gemfiles/ruby_3.1_rack_3.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.18.0)
       datadog-ci (~> 0.5.0)
-      debase-ruby_core_source (= 3.2.3)
+      debase-ruby_core_source (= 3.3.0)
       libdatadog (~> 5.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
@@ -43,7 +43,7 @@ GEM
     cri (2.15.11)
     datadog-ci (0.5.0)
       msgpack
-    debase-ruby_core_source (3.2.3)
+    debase-ruby_core_source (3.3.0)
     debug_inspector (1.1.0)
     diff-lcs (1.5.0)
     docile (1.4.0)

--- a/gemfiles/ruby_3.1_rails61_mysql2.gemfile.lock
+++ b/gemfiles/ruby_3.1_rails61_mysql2.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.18.0)
       datadog-ci (~> 0.5.0)
-      debase-ruby_core_source (= 3.2.3)
+      debase-ruby_core_source (= 3.3.0)
       libdatadog (~> 5.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
@@ -104,7 +104,7 @@ GEM
     datadog-ci (0.5.0)
       msgpack
     date (3.3.3)
-    debase-ruby_core_source (3.2.3)
+    debase-ruby_core_source (3.3.0)
     debug_inspector (1.1.0)
     diff-lcs (1.5.0)
     docile (1.4.0)

--- a/gemfiles/ruby_3.1_rails61_postgres.gemfile.lock
+++ b/gemfiles/ruby_3.1_rails61_postgres.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.18.0)
       datadog-ci (~> 0.5.0)
-      debase-ruby_core_source (= 3.2.3)
+      debase-ruby_core_source (= 3.3.0)
       libdatadog (~> 5.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
@@ -104,7 +104,7 @@ GEM
     datadog-ci (0.5.0)
       msgpack
     date (3.3.3)
-    debase-ruby_core_source (3.2.3)
+    debase-ruby_core_source (3.3.0)
     debug_inspector (1.1.0)
     diff-lcs (1.5.0)
     docile (1.4.0)

--- a/gemfiles/ruby_3.1_rails61_postgres_redis.gemfile.lock
+++ b/gemfiles/ruby_3.1_rails61_postgres_redis.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.18.0)
       datadog-ci (~> 0.5.0)
-      debase-ruby_core_source (= 3.2.3)
+      debase-ruby_core_source (= 3.3.0)
       libdatadog (~> 5.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
@@ -104,7 +104,7 @@ GEM
     datadog-ci (0.5.0)
       msgpack
     date (3.3.3)
-    debase-ruby_core_source (3.2.3)
+    debase-ruby_core_source (3.3.0)
     debug_inspector (1.1.0)
     diff-lcs (1.5.0)
     docile (1.4.0)

--- a/gemfiles/ruby_3.1_rails61_postgres_sidekiq.gemfile.lock
+++ b/gemfiles/ruby_3.1_rails61_postgres_sidekiq.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.18.0)
       datadog-ci (~> 0.5.0)
-      debase-ruby_core_source (= 3.2.3)
+      debase-ruby_core_source (= 3.3.0)
       libdatadog (~> 5.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
@@ -105,7 +105,7 @@ GEM
     datadog-ci (0.5.0)
       msgpack
     date (3.3.3)
-    debase-ruby_core_source (3.2.3)
+    debase-ruby_core_source (3.3.0)
     debug_inspector (1.1.0)
     diff-lcs (1.5.0)
     docile (1.4.0)

--- a/gemfiles/ruby_3.1_rails61_semantic_logger.gemfile.lock
+++ b/gemfiles/ruby_3.1_rails61_semantic_logger.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.18.0)
       datadog-ci (~> 0.5.0)
-      debase-ruby_core_source (= 3.2.3)
+      debase-ruby_core_source (= 3.3.0)
       libdatadog (~> 5.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
@@ -104,7 +104,7 @@ GEM
     datadog-ci (0.5.0)
       msgpack
     date (3.3.3)
-    debase-ruby_core_source (3.2.3)
+    debase-ruby_core_source (3.3.0)
     debug_inspector (1.1.0)
     diff-lcs (1.5.0)
     docile (1.4.0)

--- a/gemfiles/ruby_3.1_redis_3.gemfile.lock
+++ b/gemfiles/ruby_3.1_redis_3.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.18.0)
       datadog-ci (~> 0.5.0)
-      debase-ruby_core_source (= 3.2.3)
+      debase-ruby_core_source (= 3.3.0)
       libdatadog (~> 5.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
@@ -43,7 +43,7 @@ GEM
     cri (2.15.11)
     datadog-ci (0.5.0)
       msgpack
-    debase-ruby_core_source (3.2.3)
+    debase-ruby_core_source (3.3.0)
     debug_inspector (1.1.0)
     diff-lcs (1.5.0)
     docile (1.4.0)

--- a/gemfiles/ruby_3.1_redis_4.gemfile.lock
+++ b/gemfiles/ruby_3.1_redis_4.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.18.0)
       datadog-ci (~> 0.5.0)
-      debase-ruby_core_source (= 3.2.3)
+      debase-ruby_core_source (= 3.3.0)
       libdatadog (~> 5.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
@@ -43,7 +43,7 @@ GEM
     cri (2.15.11)
     datadog-ci (0.5.0)
       msgpack
-    debase-ruby_core_source (3.2.3)
+    debase-ruby_core_source (3.3.0)
     debug_inspector (1.1.0)
     diff-lcs (1.5.0)
     docile (1.4.0)

--- a/gemfiles/ruby_3.1_redis_5.gemfile.lock
+++ b/gemfiles/ruby_3.1_redis_5.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.18.0)
       datadog-ci (~> 0.5.0)
-      debase-ruby_core_source (= 3.2.3)
+      debase-ruby_core_source (= 3.3.0)
       libdatadog (~> 5.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
@@ -44,7 +44,7 @@ GEM
     cri (2.15.11)
     datadog-ci (0.5.0)
       msgpack
-    debase-ruby_core_source (3.2.3)
+    debase-ruby_core_source (3.3.0)
     debug_inspector (1.1.0)
     diff-lcs (1.5.0)
     docile (1.4.0)

--- a/gemfiles/ruby_3.1_relational_db.gemfile.lock
+++ b/gemfiles/ruby_3.1_relational_db.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.18.0)
       datadog-ci (~> 0.5.0)
-      debase-ruby_core_source (= 3.2.3)
+      debase-ruby_core_source (= 3.3.0)
       libdatadog (~> 5.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
@@ -53,7 +53,7 @@ GEM
     cri (2.15.11)
     datadog-ci (0.5.0)
       msgpack
-    debase-ruby_core_source (3.2.3)
+    debase-ruby_core_source (3.3.0)
     debug_inspector (1.1.0)
     delayed_job (4.1.11)
       activesupport (>= 3.0, < 8.0)

--- a/gemfiles/ruby_3.1_resque2_redis3.gemfile.lock
+++ b/gemfiles/ruby_3.1_resque2_redis3.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.18.0)
       datadog-ci (~> 0.5.0)
-      debase-ruby_core_source (= 3.2.3)
+      debase-ruby_core_source (= 3.3.0)
       libdatadog (~> 5.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
@@ -43,7 +43,7 @@ GEM
     cri (2.15.11)
     datadog-ci (0.5.0)
       msgpack
-    debase-ruby_core_source (3.2.3)
+    debase-ruby_core_source (3.3.0)
     debug_inspector (1.1.0)
     diff-lcs (1.5.0)
     docile (1.4.0)

--- a/gemfiles/ruby_3.1_resque2_redis4.gemfile.lock
+++ b/gemfiles/ruby_3.1_resque2_redis4.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.18.0)
       datadog-ci (~> 0.5.0)
-      debase-ruby_core_source (= 3.2.3)
+      debase-ruby_core_source (= 3.3.0)
       libdatadog (~> 5.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
@@ -44,7 +44,7 @@ GEM
     cri (2.15.11)
     datadog-ci (0.5.0)
       msgpack
-    debase-ruby_core_source (3.2.3)
+    debase-ruby_core_source (3.3.0)
     debug_inspector (1.1.0)
     diff-lcs (1.5.0)
     docile (1.4.0)

--- a/gemfiles/ruby_3.1_sinatra.gemfile.lock
+++ b/gemfiles/ruby_3.1_sinatra.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.18.0)
       datadog-ci (~> 0.5.0)
-      debase-ruby_core_source (= 3.2.3)
+      debase-ruby_core_source (= 3.3.0)
       libdatadog (~> 5.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
@@ -43,7 +43,7 @@ GEM
     cri (2.15.11)
     datadog-ci (0.5.0)
       msgpack
-    debase-ruby_core_source (3.2.3)
+    debase-ruby_core_source (3.3.0)
     debug_inspector (1.1.0)
     diff-lcs (1.5.0)
     docile (1.4.0)

--- a/gemfiles/ruby_3.2_activesupport.gemfile.lock
+++ b/gemfiles/ruby_3.2_activesupport.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.18.0)
       datadog-ci (~> 0.5.0)
-      debase-ruby_core_source (= 3.2.3)
+      debase-ruby_core_source (= 3.3.0)
       libdatadog (~> 5.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
@@ -70,7 +70,7 @@ GEM
     cri (2.15.11)
     datadog-ci (0.5.0)
       msgpack
-    debase-ruby_core_source (3.2.3)
+    debase-ruby_core_source (3.3.0)
     debug_inspector (1.1.0)
     diff-lcs (1.5.0)
     digest-crc (0.6.5)

--- a/gemfiles/ruby_3.2_aws.gemfile.lock
+++ b/gemfiles/ruby_3.2_aws.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.18.0)
       datadog-ci (~> 0.5.0)
-      debase-ruby_core_source (= 3.2.3)
+      debase-ruby_core_source (= 3.3.0)
       libdatadog (~> 5.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
@@ -1463,7 +1463,7 @@ GEM
     cri (2.15.11)
     datadog-ci (0.5.0)
       msgpack
-    debase-ruby_core_source (3.2.3)
+    debase-ruby_core_source (3.3.0)
     debug_inspector (1.1.0)
     diff-lcs (1.5.0)
     docile (1.4.0)

--- a/gemfiles/ruby_3.2_contrib.gemfile.lock
+++ b/gemfiles/ruby_3.2_contrib.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.18.0)
       datadog-ci (~> 0.5.0)
-      debase-ruby_core_source (= 3.2.3)
+      debase-ruby_core_source (= 3.3.0)
       libdatadog (~> 5.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
@@ -49,7 +49,7 @@ GEM
     dalli (3.2.4)
     datadog-ci (0.5.0)
       msgpack
-    debase-ruby_core_source (3.2.3)
+    debase-ruby_core_source (3.3.0)
     debug_inspector (1.1.0)
     diff-lcs (1.5.0)
     docile (1.4.0)

--- a/gemfiles/ruby_3.2_contrib_old.gemfile.lock
+++ b/gemfiles/ruby_3.2_contrib_old.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.18.0)
       datadog-ci (~> 0.5.0)
-      debase-ruby_core_source (= 3.2.3)
+      debase-ruby_core_source (= 3.3.0)
       libdatadog (~> 5.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
@@ -47,7 +47,7 @@ GEM
     dalli (2.7.11)
     datadog-ci (0.5.0)
       msgpack
-    debase-ruby_core_source (3.2.3)
+    debase-ruby_core_source (3.3.0)
     debug_inspector (1.1.0)
     diff-lcs (1.5.0)
     docile (1.4.0)

--- a/gemfiles/ruby_3.2_core_old.gemfile.lock
+++ b/gemfiles/ruby_3.2_core_old.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.18.0)
       datadog-ci (~> 0.5.0)
-      debase-ruby_core_source (= 3.2.3)
+      debase-ruby_core_source (= 3.3.0)
       libdatadog (~> 5.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
@@ -42,7 +42,7 @@ GEM
     cri (2.15.11)
     datadog-ci (0.5.0)
       msgpack
-    debase-ruby_core_source (3.2.3)
+    debase-ruby_core_source (3.3.0)
     debug_inspector (1.1.0)
     diff-lcs (1.5.0)
     docile (1.4.0)

--- a/gemfiles/ruby_3.2_elasticsearch_7.gemfile.lock
+++ b/gemfiles/ruby_3.2_elasticsearch_7.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.18.0)
       datadog-ci (~> 0.5.0)
-      debase-ruby_core_source (= 3.2.3)
+      debase-ruby_core_source (= 3.3.0)
       libdatadog (~> 5.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
@@ -43,7 +43,7 @@ GEM
     cri (2.15.11)
     datadog-ci (0.5.0)
       msgpack
-    debase-ruby_core_source (3.2.3)
+    debase-ruby_core_source (3.3.0)
     debug_inspector (1.1.0)
     diff-lcs (1.5.0)
     docile (1.4.0)

--- a/gemfiles/ruby_3.2_elasticsearch_8.gemfile.lock
+++ b/gemfiles/ruby_3.2_elasticsearch_8.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.18.0)
       datadog-ci (~> 0.5.0)
-      debase-ruby_core_source (= 3.2.3)
+      debase-ruby_core_source (= 3.3.0)
       libdatadog (~> 5.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
@@ -44,7 +44,7 @@ GEM
     cri (2.15.11)
     datadog-ci (0.5.0)
       msgpack
-    debase-ruby_core_source (3.2.3)
+    debase-ruby_core_source (3.3.0)
     debug_inspector (1.1.0)
     diff-lcs (1.5.0)
     docile (1.4.0)

--- a/gemfiles/ruby_3.2_http.gemfile.lock
+++ b/gemfiles/ruby_3.2_http.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.18.0)
       datadog-ci (~> 0.5.0)
-      debase-ruby_core_source (= 3.2.3)
+      debase-ruby_core_source (= 3.3.0)
       libdatadog (~> 5.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
@@ -42,7 +42,7 @@ GEM
     cri (2.15.11)
     datadog-ci (0.5.0)
       msgpack
-    debase-ruby_core_source (3.2.3)
+    debase-ruby_core_source (3.3.0)
     debug_inspector (1.1.0)
     diff-lcs (1.5.0)
     docile (1.4.0)

--- a/gemfiles/ruby_3.2_opensearch_2.gemfile.lock
+++ b/gemfiles/ruby_3.2_opensearch_2.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.18.0)
       datadog-ci (~> 0.5.0)
-      debase-ruby_core_source (= 3.2.3)
+      debase-ruby_core_source (= 3.3.0)
       libdatadog (~> 5.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
@@ -44,7 +44,7 @@ GEM
     cri (2.15.11)
     datadog-ci (0.5.0)
       msgpack
-    debase-ruby_core_source (3.2.3)
+    debase-ruby_core_source (3.3.0)
     debug_inspector (1.1.0)
     diff-lcs (1.5.0)
     docile (1.4.0)

--- a/gemfiles/ruby_3.2_opensearch_3.gemfile.lock
+++ b/gemfiles/ruby_3.2_opensearch_3.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.18.0)
       datadog-ci (~> 0.5.0)
-      debase-ruby_core_source (= 3.2.3)
+      debase-ruby_core_source (= 3.3.0)
       libdatadog (~> 5.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
@@ -44,7 +44,7 @@ GEM
     cri (2.15.11)
     datadog-ci (0.5.0)
       msgpack
-    debase-ruby_core_source (3.2.3)
+    debase-ruby_core_source (3.3.0)
     debug_inspector (1.1.0)
     diff-lcs (1.5.0)
     docile (1.4.0)

--- a/gemfiles/ruby_3.2_opentelemetry.gemfile.lock
+++ b/gemfiles/ruby_3.2_opentelemetry.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.18.0)
       datadog-ci (~> 0.5.0)
-      debase-ruby_core_source (= 3.2.3)
+      debase-ruby_core_source (= 3.3.0)
       libdatadog (~> 5.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
@@ -42,7 +42,7 @@ GEM
     cri (2.15.11)
     datadog-ci (0.5.0)
       msgpack
-    debase-ruby_core_source (3.2.3)
+    debase-ruby_core_source (3.3.0)
     debug_inspector (1.1.0)
     diff-lcs (1.5.0)
     docile (1.4.0)

--- a/gemfiles/ruby_3.2_opentracing.gemfile.lock
+++ b/gemfiles/ruby_3.2_opentracing.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.18.0)
       datadog-ci (~> 0.5.0)
-      debase-ruby_core_source (= 3.2.3)
+      debase-ruby_core_source (= 3.3.0)
       libdatadog (~> 5.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
@@ -43,7 +43,7 @@ GEM
     cri (2.15.11)
     datadog-ci (0.5.0)
       msgpack
-    debase-ruby_core_source (3.2.3)
+    debase-ruby_core_source (3.3.0)
     debug_inspector (1.1.0)
     diff-lcs (1.5.0)
     docile (1.4.0)

--- a/gemfiles/ruby_3.2_rack_1.gemfile.lock
+++ b/gemfiles/ruby_3.2_rack_1.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.18.0)
       datadog-ci (~> 0.5.0)
-      debase-ruby_core_source (= 3.2.3)
+      debase-ruby_core_source (= 3.3.0)
       libdatadog (~> 5.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
@@ -42,7 +42,7 @@ GEM
     cri (2.15.11)
     datadog-ci (0.5.0)
       msgpack
-    debase-ruby_core_source (3.2.3)
+    debase-ruby_core_source (3.3.0)
     debug_inspector (1.1.0)
     diff-lcs (1.5.0)
     docile (1.4.0)

--- a/gemfiles/ruby_3.2_rack_2.gemfile.lock
+++ b/gemfiles/ruby_3.2_rack_2.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.18.0)
       datadog-ci (~> 0.5.0)
-      debase-ruby_core_source (= 3.2.3)
+      debase-ruby_core_source (= 3.3.0)
       libdatadog (~> 5.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
@@ -42,7 +42,7 @@ GEM
     cri (2.15.11)
     datadog-ci (0.5.0)
       msgpack
-    debase-ruby_core_source (3.2.3)
+    debase-ruby_core_source (3.3.0)
     debug_inspector (1.1.0)
     diff-lcs (1.5.0)
     docile (1.4.0)

--- a/gemfiles/ruby_3.2_rack_3.gemfile.lock
+++ b/gemfiles/ruby_3.2_rack_3.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.18.0)
       datadog-ci (~> 0.5.0)
-      debase-ruby_core_source (= 3.2.3)
+      debase-ruby_core_source (= 3.3.0)
       libdatadog (~> 5.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
@@ -42,7 +42,7 @@ GEM
     cri (2.15.11)
     datadog-ci (0.5.0)
       msgpack
-    debase-ruby_core_source (3.2.3)
+    debase-ruby_core_source (3.3.0)
     debug_inspector (1.1.0)
     diff-lcs (1.5.0)
     docile (1.4.0)

--- a/gemfiles/ruby_3.2_rails61_mysql2.gemfile.lock
+++ b/gemfiles/ruby_3.2_rails61_mysql2.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.18.0)
       datadog-ci (~> 0.5.0)
-      debase-ruby_core_source (= 3.2.3)
+      debase-ruby_core_source (= 3.3.0)
       libdatadog (~> 5.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
@@ -103,7 +103,7 @@ GEM
     datadog-ci (0.5.0)
       msgpack
     date (3.3.3)
-    debase-ruby_core_source (3.2.3)
+    debase-ruby_core_source (3.3.0)
     debug_inspector (1.1.0)
     diff-lcs (1.5.0)
     docile (1.4.0)

--- a/gemfiles/ruby_3.2_rails61_postgres.gemfile.lock
+++ b/gemfiles/ruby_3.2_rails61_postgres.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.18.0)
       datadog-ci (~> 0.5.0)
-      debase-ruby_core_source (= 3.2.3)
+      debase-ruby_core_source (= 3.3.0)
       libdatadog (~> 5.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
@@ -103,7 +103,7 @@ GEM
     datadog-ci (0.5.0)
       msgpack
     date (3.3.3)
-    debase-ruby_core_source (3.2.3)
+    debase-ruby_core_source (3.3.0)
     debug_inspector (1.1.0)
     diff-lcs (1.5.0)
     docile (1.4.0)

--- a/gemfiles/ruby_3.2_rails61_postgres_redis.gemfile.lock
+++ b/gemfiles/ruby_3.2_rails61_postgres_redis.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.18.0)
       datadog-ci (~> 0.5.0)
-      debase-ruby_core_source (= 3.2.3)
+      debase-ruby_core_source (= 3.3.0)
       libdatadog (~> 5.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
@@ -103,7 +103,7 @@ GEM
     datadog-ci (0.5.0)
       msgpack
     date (3.3.3)
-    debase-ruby_core_source (3.2.3)
+    debase-ruby_core_source (3.3.0)
     debug_inspector (1.1.0)
     diff-lcs (1.5.0)
     docile (1.4.0)

--- a/gemfiles/ruby_3.2_rails61_postgres_sidekiq.gemfile.lock
+++ b/gemfiles/ruby_3.2_rails61_postgres_sidekiq.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.18.0)
       datadog-ci (~> 0.5.0)
-      debase-ruby_core_source (= 3.2.3)
+      debase-ruby_core_source (= 3.3.0)
       libdatadog (~> 5.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
@@ -104,7 +104,7 @@ GEM
     datadog-ci (0.5.0)
       msgpack
     date (3.3.3)
-    debase-ruby_core_source (3.2.3)
+    debase-ruby_core_source (3.3.0)
     debug_inspector (1.1.0)
     diff-lcs (1.5.0)
     docile (1.4.0)

--- a/gemfiles/ruby_3.2_rails61_semantic_logger.gemfile.lock
+++ b/gemfiles/ruby_3.2_rails61_semantic_logger.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.18.0)
       datadog-ci (~> 0.5.0)
-      debase-ruby_core_source (= 3.2.3)
+      debase-ruby_core_source (= 3.3.0)
       libdatadog (~> 5.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
@@ -103,7 +103,7 @@ GEM
     datadog-ci (0.5.0)
       msgpack
     date (3.3.3)
-    debase-ruby_core_source (3.2.3)
+    debase-ruby_core_source (3.3.0)
     debug_inspector (1.1.0)
     diff-lcs (1.5.0)
     docile (1.4.0)

--- a/gemfiles/ruby_3.2_redis_3.gemfile.lock
+++ b/gemfiles/ruby_3.2_redis_3.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.18.0)
       datadog-ci (~> 0.5.0)
-      debase-ruby_core_source (= 3.2.3)
+      debase-ruby_core_source (= 3.3.0)
       libdatadog (~> 5.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
@@ -42,7 +42,7 @@ GEM
     cri (2.15.11)
     datadog-ci (0.5.0)
       msgpack
-    debase-ruby_core_source (3.2.3)
+    debase-ruby_core_source (3.3.0)
     debug_inspector (1.1.0)
     diff-lcs (1.5.0)
     docile (1.4.0)

--- a/gemfiles/ruby_3.2_redis_4.gemfile.lock
+++ b/gemfiles/ruby_3.2_redis_4.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.18.0)
       datadog-ci (~> 0.5.0)
-      debase-ruby_core_source (= 3.2.3)
+      debase-ruby_core_source (= 3.3.0)
       libdatadog (~> 5.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
@@ -42,7 +42,7 @@ GEM
     cri (2.15.11)
     datadog-ci (0.5.0)
       msgpack
-    debase-ruby_core_source (3.2.3)
+    debase-ruby_core_source (3.3.0)
     debug_inspector (1.1.0)
     diff-lcs (1.5.0)
     docile (1.4.0)

--- a/gemfiles/ruby_3.2_redis_5.gemfile.lock
+++ b/gemfiles/ruby_3.2_redis_5.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.18.0)
       datadog-ci (~> 0.5.0)
-      debase-ruby_core_source (= 3.2.3)
+      debase-ruby_core_source (= 3.3.0)
       libdatadog (~> 5.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
@@ -43,7 +43,7 @@ GEM
     cri (2.15.11)
     datadog-ci (0.5.0)
       msgpack
-    debase-ruby_core_source (3.2.3)
+    debase-ruby_core_source (3.3.0)
     debug_inspector (1.1.0)
     diff-lcs (1.5.0)
     docile (1.4.0)

--- a/gemfiles/ruby_3.2_relational_db.gemfile.lock
+++ b/gemfiles/ruby_3.2_relational_db.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.18.0)
       datadog-ci (~> 0.5.0)
-      debase-ruby_core_source (= 3.2.3)
+      debase-ruby_core_source (= 3.3.0)
       libdatadog (~> 5.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
@@ -52,7 +52,7 @@ GEM
     cri (2.15.11)
     datadog-ci (0.5.0)
       msgpack
-    debase-ruby_core_source (3.2.3)
+    debase-ruby_core_source (3.3.0)
     debug_inspector (1.1.0)
     delayed_job (4.1.11)
       activesupport (>= 3.0, < 8.0)

--- a/gemfiles/ruby_3.2_resque2_redis3.gemfile.lock
+++ b/gemfiles/ruby_3.2_resque2_redis3.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.18.0)
       datadog-ci (~> 0.5.0)
-      debase-ruby_core_source (= 3.2.3)
+      debase-ruby_core_source (= 3.3.0)
       libdatadog (~> 5.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
@@ -42,7 +42,7 @@ GEM
     cri (2.15.11)
     datadog-ci (0.5.0)
       msgpack
-    debase-ruby_core_source (3.2.3)
+    debase-ruby_core_source (3.3.0)
     debug_inspector (1.1.0)
     diff-lcs (1.5.0)
     docile (1.4.0)

--- a/gemfiles/ruby_3.2_resque2_redis4.gemfile.lock
+++ b/gemfiles/ruby_3.2_resque2_redis4.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.18.0)
       datadog-ci (~> 0.5.0)
-      debase-ruby_core_source (= 3.2.3)
+      debase-ruby_core_source (= 3.3.0)
       libdatadog (~> 5.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
@@ -43,7 +43,7 @@ GEM
     cri (2.15.11)
     datadog-ci (0.5.0)
       msgpack
-    debase-ruby_core_source (3.2.3)
+    debase-ruby_core_source (3.3.0)
     debug_inspector (1.1.0)
     diff-lcs (1.5.0)
     docile (1.4.0)

--- a/gemfiles/ruby_3.2_sinatra.gemfile.lock
+++ b/gemfiles/ruby_3.2_sinatra.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.18.0)
       datadog-ci (~> 0.5.0)
-      debase-ruby_core_source (= 3.2.3)
+      debase-ruby_core_source (= 3.3.0)
       libdatadog (~> 5.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
@@ -42,7 +42,7 @@ GEM
     cri (2.15.11)
     datadog-ci (0.5.0)
       msgpack
-    debase-ruby_core_source (3.2.3)
+    debase-ruby_core_source (3.3.0)
     debug_inspector (1.1.0)
     diff-lcs (1.5.0)
     docile (1.4.0)

--- a/gemfiles/ruby_3.3_activesupport.gemfile.lock
+++ b/gemfiles/ruby_3.3_activesupport.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.18.0)
       datadog-ci (~> 0.5.0)
-      debase-ruby_core_source (= 3.2.3)
+      debase-ruby_core_source (= 3.3.0)
       libdatadog (~> 5.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
@@ -70,7 +70,7 @@ GEM
     cri (2.15.11)
     datadog-ci (0.5.0)
       msgpack
-    debase-ruby_core_source (3.2.3)
+    debase-ruby_core_source (3.3.0)
     debug_inspector (1.1.0)
     diff-lcs (1.5.0)
     digest-crc (0.6.5)

--- a/gemfiles/ruby_3.3_aws.gemfile.lock
+++ b/gemfiles/ruby_3.3_aws.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.18.0)
       datadog-ci (~> 0.5.0)
-      debase-ruby_core_source (= 3.2.3)
+      debase-ruby_core_source (= 3.3.0)
       libdatadog (~> 5.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
@@ -1463,7 +1463,7 @@ GEM
     cri (2.15.11)
     datadog-ci (0.5.0)
       msgpack
-    debase-ruby_core_source (3.2.3)
+    debase-ruby_core_source (3.3.0)
     debug_inspector (1.1.0)
     diff-lcs (1.5.0)
     docile (1.4.0)

--- a/gemfiles/ruby_3.3_contrib.gemfile.lock
+++ b/gemfiles/ruby_3.3_contrib.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.18.0)
       datadog-ci (~> 0.5.0)
-      debase-ruby_core_source (= 3.2.3)
+      debase-ruby_core_source (= 3.3.0)
       libdatadog (~> 5.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
@@ -49,7 +49,7 @@ GEM
     dalli (3.2.4)
     datadog-ci (0.5.0)
       msgpack
-    debase-ruby_core_source (3.2.3)
+    debase-ruby_core_source (3.3.0)
     debug_inspector (1.1.0)
     diff-lcs (1.5.0)
     docile (1.4.0)

--- a/gemfiles/ruby_3.3_contrib_old.gemfile.lock
+++ b/gemfiles/ruby_3.3_contrib_old.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.18.0)
       datadog-ci (~> 0.5.0)
-      debase-ruby_core_source (= 3.2.3)
+      debase-ruby_core_source (= 3.3.0)
       libdatadog (~> 5.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
@@ -47,7 +47,7 @@ GEM
     dalli (2.7.11)
     datadog-ci (0.5.0)
       msgpack
-    debase-ruby_core_source (3.2.3)
+    debase-ruby_core_source (3.3.0)
     debug_inspector (1.1.0)
     diff-lcs (1.5.0)
     docile (1.4.0)

--- a/gemfiles/ruby_3.3_core_old.gemfile.lock
+++ b/gemfiles/ruby_3.3_core_old.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.18.0)
       datadog-ci (~> 0.5.0)
-      debase-ruby_core_source (= 3.2.3)
+      debase-ruby_core_source (= 3.3.0)
       libdatadog (~> 5.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
@@ -42,7 +42,7 @@ GEM
     cri (2.15.11)
     datadog-ci (0.5.0)
       msgpack
-    debase-ruby_core_source (3.2.3)
+    debase-ruby_core_source (3.3.0)
     debug_inspector (1.1.0)
     diff-lcs (1.5.0)
     docile (1.4.0)

--- a/gemfiles/ruby_3.3_elasticsearch_7.gemfile.lock
+++ b/gemfiles/ruby_3.3_elasticsearch_7.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.18.0)
       datadog-ci (~> 0.5.0)
-      debase-ruby_core_source (= 3.2.3)
+      debase-ruby_core_source (= 3.3.0)
       libdatadog (~> 5.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
@@ -43,7 +43,7 @@ GEM
     cri (2.15.11)
     datadog-ci (0.5.0)
       msgpack
-    debase-ruby_core_source (3.2.3)
+    debase-ruby_core_source (3.3.0)
     debug_inspector (1.1.0)
     diff-lcs (1.5.0)
     docile (1.4.0)

--- a/gemfiles/ruby_3.3_elasticsearch_8.gemfile.lock
+++ b/gemfiles/ruby_3.3_elasticsearch_8.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.18.0)
       datadog-ci (~> 0.5.0)
-      debase-ruby_core_source (= 3.2.3)
+      debase-ruby_core_source (= 3.3.0)
       libdatadog (~> 5.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
@@ -44,7 +44,7 @@ GEM
     cri (2.15.11)
     datadog-ci (0.5.0)
       msgpack
-    debase-ruby_core_source (3.2.3)
+    debase-ruby_core_source (3.3.0)
     debug_inspector (1.1.0)
     diff-lcs (1.5.0)
     docile (1.4.0)

--- a/gemfiles/ruby_3.3_http.gemfile.lock
+++ b/gemfiles/ruby_3.3_http.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.18.0)
       datadog-ci (~> 0.5.0)
-      debase-ruby_core_source (= 3.2.3)
+      debase-ruby_core_source (= 3.3.0)
       libdatadog (~> 5.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
@@ -42,7 +42,7 @@ GEM
     cri (2.15.11)
     datadog-ci (0.5.0)
       msgpack
-    debase-ruby_core_source (3.2.3)
+    debase-ruby_core_source (3.3.0)
     debug_inspector (1.1.0)
     diff-lcs (1.5.0)
     docile (1.4.0)

--- a/gemfiles/ruby_3.3_opensearch_2.gemfile.lock
+++ b/gemfiles/ruby_3.3_opensearch_2.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.18.0)
       datadog-ci (~> 0.5.0)
-      debase-ruby_core_source (= 3.2.3)
+      debase-ruby_core_source (= 3.3.0)
       libdatadog (~> 5.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
@@ -44,7 +44,7 @@ GEM
     cri (2.15.11)
     datadog-ci (0.5.0)
       msgpack
-    debase-ruby_core_source (3.2.3)
+    debase-ruby_core_source (3.3.0)
     debug_inspector (1.1.0)
     diff-lcs (1.5.0)
     docile (1.4.0)

--- a/gemfiles/ruby_3.3_opensearch_3.gemfile.lock
+++ b/gemfiles/ruby_3.3_opensearch_3.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.18.0)
       datadog-ci (~> 0.5.0)
-      debase-ruby_core_source (= 3.2.3)
+      debase-ruby_core_source (= 3.3.0)
       libdatadog (~> 5.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
@@ -44,7 +44,7 @@ GEM
     cri (2.15.11)
     datadog-ci (0.5.0)
       msgpack
-    debase-ruby_core_source (3.2.3)
+    debase-ruby_core_source (3.3.0)
     debug_inspector (1.1.0)
     diff-lcs (1.5.0)
     docile (1.4.0)

--- a/gemfiles/ruby_3.3_opentelemetry.gemfile.lock
+++ b/gemfiles/ruby_3.3_opentelemetry.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.18.0)
       datadog-ci (~> 0.5.0)
-      debase-ruby_core_source (= 3.2.3)
+      debase-ruby_core_source (= 3.3.0)
       libdatadog (~> 5.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
@@ -42,7 +42,7 @@ GEM
     cri (2.15.11)
     datadog-ci (0.5.0)
       msgpack
-    debase-ruby_core_source (3.2.3)
+    debase-ruby_core_source (3.3.0)
     debug_inspector (1.1.0)
     diff-lcs (1.5.0)
     docile (1.4.0)

--- a/gemfiles/ruby_3.3_opentracing.gemfile.lock
+++ b/gemfiles/ruby_3.3_opentracing.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.18.0)
       datadog-ci (~> 0.5.0)
-      debase-ruby_core_source (= 3.2.3)
+      debase-ruby_core_source (= 3.3.0)
       libdatadog (~> 5.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
@@ -43,7 +43,7 @@ GEM
     cri (2.15.11)
     datadog-ci (0.5.0)
       msgpack
-    debase-ruby_core_source (3.2.3)
+    debase-ruby_core_source (3.3.0)
     debug_inspector (1.1.0)
     diff-lcs (1.5.0)
     docile (1.4.0)

--- a/gemfiles/ruby_3.3_rack_1.gemfile.lock
+++ b/gemfiles/ruby_3.3_rack_1.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.18.0)
       datadog-ci (~> 0.5.0)
-      debase-ruby_core_source (= 3.2.3)
+      debase-ruby_core_source (= 3.3.0)
       libdatadog (~> 5.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
@@ -42,7 +42,7 @@ GEM
     cri (2.15.11)
     datadog-ci (0.5.0)
       msgpack
-    debase-ruby_core_source (3.2.3)
+    debase-ruby_core_source (3.3.0)
     debug_inspector (1.1.0)
     diff-lcs (1.5.0)
     docile (1.4.0)

--- a/gemfiles/ruby_3.3_rack_2.gemfile.lock
+++ b/gemfiles/ruby_3.3_rack_2.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.18.0)
       datadog-ci (~> 0.5.0)
-      debase-ruby_core_source (= 3.2.3)
+      debase-ruby_core_source (= 3.3.0)
       libdatadog (~> 5.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
@@ -42,7 +42,7 @@ GEM
     cri (2.15.11)
     datadog-ci (0.5.0)
       msgpack
-    debase-ruby_core_source (3.2.3)
+    debase-ruby_core_source (3.3.0)
     debug_inspector (1.1.0)
     diff-lcs (1.5.0)
     docile (1.4.0)

--- a/gemfiles/ruby_3.3_rack_3.gemfile.lock
+++ b/gemfiles/ruby_3.3_rack_3.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.18.0)
       datadog-ci (~> 0.5.0)
-      debase-ruby_core_source (= 3.2.3)
+      debase-ruby_core_source (= 3.3.0)
       libdatadog (~> 5.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
@@ -42,7 +42,7 @@ GEM
     cri (2.15.11)
     datadog-ci (0.5.0)
       msgpack
-    debase-ruby_core_source (3.2.3)
+    debase-ruby_core_source (3.3.0)
     debug_inspector (1.1.0)
     diff-lcs (1.5.0)
     docile (1.4.0)

--- a/gemfiles/ruby_3.3_rails61_mysql2.gemfile.lock
+++ b/gemfiles/ruby_3.3_rails61_mysql2.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.18.0)
       datadog-ci (~> 0.5.0)
-      debase-ruby_core_source (= 3.2.3)
+      debase-ruby_core_source (= 3.3.0)
       libdatadog (~> 5.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
@@ -103,7 +103,7 @@ GEM
     datadog-ci (0.5.0)
       msgpack
     date (3.3.3)
-    debase-ruby_core_source (3.2.3)
+    debase-ruby_core_source (3.3.0)
     debug_inspector (1.1.0)
     diff-lcs (1.5.0)
     docile (1.4.0)

--- a/gemfiles/ruby_3.3_rails61_postgres.gemfile.lock
+++ b/gemfiles/ruby_3.3_rails61_postgres.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.18.0)
       datadog-ci (~> 0.5.0)
-      debase-ruby_core_source (= 3.2.3)
+      debase-ruby_core_source (= 3.3.0)
       libdatadog (~> 5.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
@@ -103,7 +103,7 @@ GEM
     datadog-ci (0.5.0)
       msgpack
     date (3.3.3)
-    debase-ruby_core_source (3.2.3)
+    debase-ruby_core_source (3.3.0)
     debug_inspector (1.1.0)
     diff-lcs (1.5.0)
     docile (1.4.0)

--- a/gemfiles/ruby_3.3_rails61_postgres_redis.gemfile.lock
+++ b/gemfiles/ruby_3.3_rails61_postgres_redis.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.18.0)
       datadog-ci (~> 0.5.0)
-      debase-ruby_core_source (= 3.2.3)
+      debase-ruby_core_source (= 3.3.0)
       libdatadog (~> 5.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
@@ -103,7 +103,7 @@ GEM
     datadog-ci (0.5.0)
       msgpack
     date (3.3.3)
-    debase-ruby_core_source (3.2.3)
+    debase-ruby_core_source (3.3.0)
     debug_inspector (1.1.0)
     diff-lcs (1.5.0)
     docile (1.4.0)

--- a/gemfiles/ruby_3.3_rails61_postgres_sidekiq.gemfile.lock
+++ b/gemfiles/ruby_3.3_rails61_postgres_sidekiq.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.18.0)
       datadog-ci (~> 0.5.0)
-      debase-ruby_core_source (= 3.2.3)
+      debase-ruby_core_source (= 3.3.0)
       libdatadog (~> 5.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
@@ -104,7 +104,7 @@ GEM
     datadog-ci (0.5.0)
       msgpack
     date (3.3.3)
-    debase-ruby_core_source (3.2.3)
+    debase-ruby_core_source (3.3.0)
     debug_inspector (1.1.0)
     diff-lcs (1.5.0)
     docile (1.4.0)

--- a/gemfiles/ruby_3.3_rails61_semantic_logger.gemfile.lock
+++ b/gemfiles/ruby_3.3_rails61_semantic_logger.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.18.0)
       datadog-ci (~> 0.5.0)
-      debase-ruby_core_source (= 3.2.3)
+      debase-ruby_core_source (= 3.3.0)
       libdatadog (~> 5.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
@@ -103,7 +103,7 @@ GEM
     datadog-ci (0.5.0)
       msgpack
     date (3.3.3)
-    debase-ruby_core_source (3.2.3)
+    debase-ruby_core_source (3.3.0)
     debug_inspector (1.1.0)
     diff-lcs (1.5.0)
     docile (1.4.0)

--- a/gemfiles/ruby_3.3_redis_3.gemfile.lock
+++ b/gemfiles/ruby_3.3_redis_3.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.18.0)
       datadog-ci (~> 0.5.0)
-      debase-ruby_core_source (= 3.2.3)
+      debase-ruby_core_source (= 3.3.0)
       libdatadog (~> 5.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
@@ -42,7 +42,7 @@ GEM
     cri (2.15.11)
     datadog-ci (0.5.0)
       msgpack
-    debase-ruby_core_source (3.2.3)
+    debase-ruby_core_source (3.3.0)
     debug_inspector (1.1.0)
     diff-lcs (1.5.0)
     docile (1.4.0)

--- a/gemfiles/ruby_3.3_redis_4.gemfile.lock
+++ b/gemfiles/ruby_3.3_redis_4.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.18.0)
       datadog-ci (~> 0.5.0)
-      debase-ruby_core_source (= 3.2.3)
+      debase-ruby_core_source (= 3.3.0)
       libdatadog (~> 5.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
@@ -42,7 +42,7 @@ GEM
     cri (2.15.11)
     datadog-ci (0.5.0)
       msgpack
-    debase-ruby_core_source (3.2.3)
+    debase-ruby_core_source (3.3.0)
     debug_inspector (1.1.0)
     diff-lcs (1.5.0)
     docile (1.4.0)

--- a/gemfiles/ruby_3.3_redis_5.gemfile.lock
+++ b/gemfiles/ruby_3.3_redis_5.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.18.0)
       datadog-ci (~> 0.5.0)
-      debase-ruby_core_source (= 3.2.3)
+      debase-ruby_core_source (= 3.3.0)
       libdatadog (~> 5.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
@@ -43,7 +43,7 @@ GEM
     cri (2.15.11)
     datadog-ci (0.5.0)
       msgpack
-    debase-ruby_core_source (3.2.3)
+    debase-ruby_core_source (3.3.0)
     debug_inspector (1.1.0)
     diff-lcs (1.5.0)
     docile (1.4.0)

--- a/gemfiles/ruby_3.3_relational_db.gemfile.lock
+++ b/gemfiles/ruby_3.3_relational_db.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.18.0)
       datadog-ci (~> 0.5.0)
-      debase-ruby_core_source (= 3.2.3)
+      debase-ruby_core_source (= 3.3.0)
       libdatadog (~> 5.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
@@ -52,7 +52,7 @@ GEM
     cri (2.15.11)
     datadog-ci (0.5.0)
       msgpack
-    debase-ruby_core_source (3.2.3)
+    debase-ruby_core_source (3.3.0)
     debug_inspector (1.1.0)
     delayed_job (4.1.11)
       activesupport (>= 3.0, < 8.0)

--- a/gemfiles/ruby_3.3_resque2_redis3.gemfile.lock
+++ b/gemfiles/ruby_3.3_resque2_redis3.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.18.0)
       datadog-ci (~> 0.5.0)
-      debase-ruby_core_source (= 3.2.3)
+      debase-ruby_core_source (= 3.3.0)
       libdatadog (~> 5.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
@@ -42,7 +42,7 @@ GEM
     cri (2.15.11)
     datadog-ci (0.5.0)
       msgpack
-    debase-ruby_core_source (3.2.3)
+    debase-ruby_core_source (3.3.0)
     debug_inspector (1.1.0)
     diff-lcs (1.5.0)
     docile (1.4.0)

--- a/gemfiles/ruby_3.3_resque2_redis4.gemfile.lock
+++ b/gemfiles/ruby_3.3_resque2_redis4.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.18.0)
       datadog-ci (~> 0.5.0)
-      debase-ruby_core_source (= 3.2.3)
+      debase-ruby_core_source (= 3.3.0)
       libdatadog (~> 5.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
@@ -43,7 +43,7 @@ GEM
     cri (2.15.11)
     datadog-ci (0.5.0)
       msgpack
-    debase-ruby_core_source (3.2.3)
+    debase-ruby_core_source (3.3.0)
     debug_inspector (1.1.0)
     diff-lcs (1.5.0)
     docile (1.4.0)

--- a/gemfiles/ruby_3.3_sinatra.gemfile.lock
+++ b/gemfiles/ruby_3.3_sinatra.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.18.0)
       datadog-ci (~> 0.5.0)
-      debase-ruby_core_source (= 3.2.3)
+      debase-ruby_core_source (= 3.3.0)
       libdatadog (~> 5.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
@@ -42,7 +42,7 @@ GEM
     cri (2.15.11)
     datadog-ci (0.5.0)
       msgpack
-    debase-ruby_core_source (3.2.3)
+    debase-ruby_core_source (3.3.0)
     debug_inspector (1.1.0)
     diff-lcs (1.5.0)
     docile (1.4.0)


### PR DESCRIPTION
**What does this PR do?**

This PR bumps our dependency on `debase-ruby_core_source` to version 3.3.0. This version includes the headers for the recently-released Ruby 3.3.0; up until now we were supporting that Ruby version using a copy of the headers from the preview release.

**Motivation:**

Use up-to-date headers for profiling on Ruby 3.3.0.

**Additional Notes:**

I've updated the appraisal gemfiles as well.

**How to test the change?**

Validate that CI is green.

**For Datadog employees:**
- [ ] If this PR touches code that signs or publishes builds or packages, or handles
credentials of any kind, I've requested a review from `@DataDog/security-design-and-guidance`.
- [x] This PR doesn't touch any of that.
