### PR TITLE
[NO-TICKET] Use Ruby 3.3 stable for CI testing

### DIFF
--- a/.circleci/images/primary/Dockerfile-3.3.0
+++ b/.circleci/images/primary/Dockerfile-3.3.0
@@ -1,6 +1,6 @@
 # Note: See the "Publishing updates to images" note in ./README.md for how to publish new builds of this container image
 
-FROM ruby:3.3-rc-bullseye
+FROM ruby:3.3.0-bullseye
 
 # Make apt non-interactive
 RUN echo 'APT::Get::Assume-Yes "true";' > /etc/apt/apt.conf.d/90circleci \

--- a/integration/images/ruby/3.3/Dockerfile
+++ b/integration/images/ruby/3.3/Dockerfile
@@ -1,4 +1,4 @@
-FROM ruby:3.3-rc
+FROM ruby:3.3
 
 ENV DEBIAN_FRONTEND=noninteractive
 


### PR DESCRIPTION
**What does this PR do?**

This PR updates our dockerfiles so that the Ruby 3.3 stable release (currently 3.3.0) gets used for CI testing, replacing the RC releases.

**Motivation:**

Make sure dd-trace-rb is working correctly on 3.3 .

**Additional Notes:**

The docker image under `.circleci` doesn't get automatically picked up by CI.

I'll make sure to manually run the "Build Ruby" workflow (https://github.com/DataDog/dd-trace-rb/actions/workflows/build-ruby.yml) with the "Push images" option after this PR gets merged.

**How to test the change?**

Validate that the following CI steps still pass:

* Ruby 3.3 integration (will pick up the new Ruby)
* Build Ruby (will be able to build the new Ruby)

**For Datadog employees:**
- [ ] If this PR touches code that signs or publishes builds or packages, or handles
credentials of any kind, I've requested a review from `@DataDog/security-design-and-guidance`.
- [x] This PR doesn't touch any of that.