### PR TITLE
[prof-heap] Misc improvements/fixes

### DIFF
--- a/ext/ddtrace_profiling_native_extension/heap_recorder.c
+++ b/ext/ddtrace_profiling_native_extension/heap_recorder.c
@@ -92,6 +92,7 @@ typedef struct {
 } object_record;
 static object_record* object_record_new(long, heap_record*, live_object_data);
 static void object_record_free(object_record*);
+static VALUE object_record_inspect(object_record*);
 
 struct heap_recorder {
   // Config
@@ -438,22 +439,7 @@ static int st_object_records_debug(DDTRACE_UNUSED st_data_t key, st_data_t value
 
   object_record *record = (object_record*) value;
 
-  heap_frame top_frame = record->heap_record->stack->frames[0];
-  rb_str_catf(debug_str, "obj_id=%ld weight=%d size=%zu location=%s:%d alloc_gen=%zu ", record->obj_id, record->object_data.weight, record->object_data.size, top_frame.filename, (int) top_frame.line, record->object_data.alloc_gen);
-
-  const char *class = record->object_data.class;
-  if (class != NULL) {
-    rb_str_catf(debug_str, "class=%s ", class);
-  }
-
-  VALUE ref;
-  if (!ruby_ref_from_id(LONG2NUM(record->obj_id), &ref)) {
-    rb_str_catf(debug_str, "object=<invalid>");
-  } else {
-    rb_str_catf(debug_str, "object=%+"PRIsVALUE, ref);
-  }
-
-  rb_str_catf(debug_str, "\n");
+  rb_str_catf(debug_str, "%"PRIsVALUE"\n", object_record_inspect(record));
 
   return ST_CONTINUE;
 }
@@ -471,7 +457,11 @@ typedef struct {
 static int update_object_record_entry(DDTRACE_UNUSED st_data_t *key, st_data_t *value, st_data_t data, int existing) {
   object_record_update_data *update_data = (object_record_update_data*) data;
   if (existing) {
-    rb_raise(rb_eRuntimeError, "Object ids are supposed to be unique. We got 2 allocation recordings with the same id");
+    object_record *existing_record = (object_record*) (*value);
+    VALUE existing_inspect = object_record_inspect(existing_record);
+    VALUE new_inspect = object_record_inspect(update_data->new_object_record);
+    rb_raise(rb_eRuntimeError, "Object ids are supposed to be unique. We got 2 allocation recordings with "
+        "the same id.\nprevious=%"PRIsVALUE"\nnew=%"PRIsVALUE"\n", existing_inspect, new_inspect);
   }
   // Always carry on with the update, we want the new record to be there at the end
   (*value) = (st_data_t) update_data->new_object_record;
@@ -598,6 +588,32 @@ void object_record_free(object_record *record) {
     ruby_xfree(record->object_data.class);
   }
   ruby_xfree(record);
+}
+
+VALUE object_record_inspect(object_record *record) {
+  heap_frame top_frame = record->heap_record->stack->frames[0];
+  VALUE inspect = rb_sprintf("obj_id=%ld weight=%d size=%zu location=%s:%d alloc_gen=%zu ",
+      record->obj_id, record->object_data.weight, record->object_data.size, top_frame.filename,
+      (int) top_frame.line, record->object_data.alloc_gen);
+
+  const char *class = record->object_data.class;
+  if (class != NULL) {
+    rb_str_catf(inspect, "class=%s ", class);
+  }
+
+  VALUE ref;
+  if (!ruby_ref_from_id(LONG2NUM(record->obj_id), &ref)) {
+    rb_str_catf(inspect, "object=<invalid>");
+  } else {
+    VALUE ruby_inspect = ruby_safe_inspect(ref);
+    if (ruby_inspect != Qnil) {
+      rb_str_catf(inspect, "object=%"PRIsVALUE, ruby_inspect);
+    } else {
+      rb_str_catf(inspect, "object=%s", ruby_value_type_to_string(rb_type(ref)));
+    }
+  }
+
+  return inspect;
 }
 
 // ==============

--- a/ext/ddtrace_profiling_native_extension/heap_recorder.c
+++ b/ext/ddtrace_profiling_native_extension/heap_recorder.c
@@ -93,11 +93,13 @@ typedef struct {
 static object_record* object_record_new(long, heap_record*, live_object_data);
 static void object_record_free(object_record*);
 static VALUE object_record_inspect(object_record*);
+static object_record SKIPPED_RECORD = {0};
 
 struct heap_recorder {
   // Config
   // Whether the recorder should try to determine approximate sizes for tracked objects.
   bool size_enabled;
+  uint sample_rate;
 
   // Map[key: heap_record_key*, record: heap_record*]
   // NOTE: We always use heap_record_key.type == HEAP_STACK for storage but support lookups
@@ -126,6 +128,9 @@ struct heap_recorder {
 
   // Reusable location array, implementing a flyweight pattern for things like iteration.
   ddog_prof_Location *reusable_locations;
+
+  // Sampling state
+  uint num_recordings_skipped;
 };
 static heap_record* get_or_create_heap_record(heap_recorder*, ddog_prof_Slice_Location);
 static void cleanup_heap_record_if_unused(heap_recorder*, heap_record*);
@@ -155,6 +160,7 @@ heap_recorder* heap_recorder_new(void) {
   recorder->reusable_locations = ruby_xcalloc(MAX_FRAMES_LIMIT, sizeof(ddog_prof_Location));
   recorder->partial_object_record = NULL;
   recorder->size_enabled = true;
+  recorder->sample_rate = 1; // By default do no sampling
 
   return recorder;
 }
@@ -189,7 +195,24 @@ void heap_recorder_free(heap_recorder *heap_recorder) {
 }
 
 void heap_recorder_set_size_enabled(heap_recorder *heap_recorder, bool size_enabled) {
+  if (heap_recorder == NULL) {
+    return;
+  }
+
   heap_recorder->size_enabled = size_enabled;
+}
+
+void heap_recorder_set_sample_rate(heap_recorder *heap_recorder, int sample_rate) {
+  if (heap_recorder == NULL) {
+    return;
+  }
+
+  if (sample_rate < 0) {
+    rb_raise(rb_eArgError, "Heap sample rate must be a positive integer value but was %d", sample_rate);
+  }
+
+  heap_recorder->sample_rate = sample_rate;
+  heap_recorder->num_recordings_skipped = 0;
 }
 
 // WARN: Assumes this gets called before profiler is reinitialized on the fork
@@ -222,6 +245,14 @@ void start_heap_allocation_recording(heap_recorder *heap_recorder, VALUE new_obj
     return;
   }
 
+  if (heap_recorder->num_recordings_skipped + 1 < heap_recorder->sample_rate) {
+    heap_recorder->partial_object_record = &SKIPPED_RECORD;
+    heap_recorder->num_recordings_skipped++;
+    return;
+  }
+
+  heap_recorder->num_recordings_skipped = 0;
+
   VALUE ruby_obj_id = rb_obj_id(new_obj);
   if (!FIXNUM_P(ruby_obj_id)) {
     rb_raise(rb_eRuntimeError, "Detected a bignum object id. These are not supported by heap profiling.");
@@ -232,7 +263,7 @@ void start_heap_allocation_recording(heap_recorder *heap_recorder, VALUE new_obj
   }
 
   heap_recorder->partial_object_record = object_record_new(FIX2LONG(ruby_obj_id), NULL, (live_object_data) {
-    .weight =  weight,
+    .weight =  weight * heap_recorder->sample_rate,
     .class = alloc_class != NULL ? string_from_char_slice(*alloc_class) : NULL,
     .alloc_gen = rb_gc_count(),
   });
@@ -249,10 +280,14 @@ void end_heap_allocation_recording(struct heap_recorder *heap_recorder, ddog_pro
     // Recording ended without having been started?
     rb_raise(rb_eRuntimeError, "Ended a heap recording that was not started");
   }
-
   // From now on, mark active recording as invalid so we can short-circuit at any point and
   // not end up with a still active recording. partial_object_record still holds the object for this recording
   heap_recorder->partial_object_record = NULL;
+
+  if (partial_object_record == &SKIPPED_RECORD) {
+    // special marker when we decided to skip due to sampling
+    return;
+  }
 
   heap_record *heap_record = get_or_create_heap_record(heap_recorder, locations);
 

--- a/ext/ddtrace_profiling_native_extension/heap_recorder.c
+++ b/ext/ddtrace_profiling_native_extension/heap_recorder.c
@@ -160,7 +160,7 @@ heap_recorder* heap_recorder_new(void) {
   recorder->reusable_locations = ruby_xcalloc(MAX_FRAMES_LIMIT, sizeof(ddog_prof_Location));
   recorder->partial_object_record = NULL;
   recorder->size_enabled = true;
-  recorder->sample_rate = 1; // By default do no sampling
+  recorder->sample_rate = 1; // By default do no sampling on top of what allocation profiling already does
 
   return recorder;
 }
@@ -207,7 +207,7 @@ void heap_recorder_set_sample_rate(heap_recorder *heap_recorder, int sample_rate
     return;
   }
 
-  if (sample_rate < 0) {
+  if (sample_rate <= 0) {
     rb_raise(rb_eArgError, "Heap sample rate must be a positive integer value but was %d", sample_rate);
   }
 
@@ -635,8 +635,8 @@ VALUE object_record_inspect(object_record *record) {
   if (class != NULL) {
     rb_str_catf(inspect, "class=%s ", class);
   }
-
   VALUE ref;
+
   if (!ruby_ref_from_id(LONG2NUM(record->obj_id), &ref)) {
     rb_str_catf(inspect, "object=<invalid>");
   } else {

--- a/ext/ddtrace_profiling_native_extension/heap_recorder.c
+++ b/ext/ddtrace_profiling_native_extension/heap_recorder.c
@@ -496,7 +496,7 @@ static int update_object_record_entry(DDTRACE_UNUSED st_data_t *key, st_data_t *
     VALUE existing_inspect = object_record_inspect(existing_record);
     VALUE new_inspect = object_record_inspect(update_data->new_object_record);
     rb_raise(rb_eRuntimeError, "Object ids are supposed to be unique. We got 2 allocation recordings with "
-        "the same id.\nprevious=%"PRIsVALUE"\nnew=%"PRIsVALUE"\n", existing_inspect, new_inspect);
+        "the same id. previous=%"PRIsVALUE" new=%"PRIsVALUE, existing_inspect, new_inspect);
   }
   // Always carry on with the update, we want the new record to be there at the end
   (*value) = (st_data_t) update_data->new_object_record;

--- a/ext/ddtrace_profiling_native_extension/heap_recorder.h
+++ b/ext/ddtrace_profiling_native_extension/heap_recorder.h
@@ -69,6 +69,21 @@ void heap_recorder_free(heap_recorder *heap_recorder);
 // objects.
 void heap_recorder_set_size_enabled(heap_recorder *heap_recorder, bool size_enabled);
 
+// Set sample rate used by this heap recorder.
+//
+// Controls how many recordings will be ignored before committing a heap allocation and
+// the weight of the committed heap allocation.
+//
+// A value of 1 will effectively track all objects that are passed through
+// start/end_heap_allocation_recording pairs. A value of 10 will only track every 10th
+// object passed through such calls and its effective weight for the purposes of heap
+// profiling will be multiplied by 10.
+//
+// NOTE: Default is 1, i.e., track all heap allocation recordings.
+//
+// WARN: Non-positive values will lead to an exception being thrown.
+void heap_recorder_set_sample_rate(heap_recorder *heap_recorder, int sample_rate);
+
 // Do any cleanup needed after forking.
 // WARN: Assumes this gets called before profiler is reinitialized on the fork
 void heap_recorder_after_fork(heap_recorder *heap_recorder);

--- a/ext/ddtrace_profiling_native_extension/ruby_helpers.c
+++ b/ext/ddtrace_profiling_native_extension/ruby_helpers.c
@@ -244,7 +244,7 @@ static bool ruby_is_obj_with_class(VALUE obj) {
 
 VALUE ruby_safe_inspect(VALUE obj) {
   if (!ruby_is_obj_with_class(obj)) {
-    return Qnil;
+    return rb_str_new_cstr("(Not an object)");
   }
 
   if (rb_respond_to(obj, inspect_id)) {
@@ -252,6 +252,6 @@ VALUE ruby_safe_inspect(VALUE obj) {
   } else if (rb_respond_to(obj, to_s_id)) {
     return rb_sprintf("%"PRIsVALUE, obj);
   } else {
-    return Qnil;
+    return rb_str_new_cstr("(Not inspectable)");
   }
 }

--- a/ext/ddtrace_profiling_native_extension/ruby_helpers.h
+++ b/ext/ddtrace_profiling_native_extension/ruby_helpers.h
@@ -111,3 +111,7 @@ bool ruby_ref_from_id(size_t id, VALUE *value);
 // object.
 size_t ruby_obj_memsize_of(VALUE obj);
 
+// Safely inspect any ruby object. If the object responds to 'inspect',
+// return a string with the result of that call. Elsif the object responds to
+// 'to_s', return a string with the result of that call. Otherwise, return Qnil.
+VALUE ruby_safe_inspect(VALUE obj);

--- a/ext/ddtrace_profiling_native_extension/stack_recorder.c
+++ b/ext/ddtrace_profiling_native_extension/stack_recorder.c
@@ -217,6 +217,7 @@ static VALUE _native_initialize(
   VALUE alloc_samples_enabled,
   VALUE heap_samples_enabled,
   VALUE heap_size_enabled,
+  VALUE heap_sample_every,
   VALUE timeline_enabled
 );
 static VALUE _native_serialize(VALUE self, VALUE recorder_instance);
@@ -256,7 +257,7 @@ void stack_recorder_init(VALUE profiling_module) {
   // https://bugs.ruby-lang.org/issues/18007 for a discussion around this.
   rb_define_alloc_func(stack_recorder_class, _native_new);
 
-  rb_define_singleton_method(stack_recorder_class, "_native_initialize", _native_initialize, 6);
+  rb_define_singleton_method(stack_recorder_class, "_native_initialize", _native_initialize, 7);
   rb_define_singleton_method(stack_recorder_class, "_native_serialize",  _native_serialize, 1);
   rb_define_singleton_method(stack_recorder_class, "_native_reset_after_fork", _native_reset_after_fork, 1);
   rb_define_singleton_method(testing_module, "_native_active_slot", _native_active_slot, 1);
@@ -371,16 +372,20 @@ static VALUE _native_initialize(
   VALUE alloc_samples_enabled,
   VALUE heap_samples_enabled,
   VALUE heap_size_enabled,
+  VALUE heap_sample_every,
   VALUE timeline_enabled
 ) {
   ENFORCE_BOOLEAN(cpu_time_enabled);
   ENFORCE_BOOLEAN(alloc_samples_enabled);
   ENFORCE_BOOLEAN(heap_samples_enabled);
   ENFORCE_BOOLEAN(heap_size_enabled);
+  ENFORCE_TYPE(heap_sample_every, T_FIXNUM);
   ENFORCE_BOOLEAN(timeline_enabled);
 
   struct stack_recorder_state *state;
   TypedData_Get_Struct(recorder_instance, struct stack_recorder_state, &stack_recorder_typed_data, state);
+
+  heap_recorder_set_sample_rate(state->heap_recorder, NUM2INT(heap_sample_every));
 
   uint8_t requested_values_count = ALL_VALUE_TYPES_COUNT -
     (cpu_time_enabled == Qtrue ? 0 : 1) -

--- a/lib/datadog/core/configuration/settings.rb
+++ b/lib/datadog/core/configuration/settings.rb
@@ -356,6 +356,21 @@ module Datadog
               o.default false
             end
 
+            # Can be used to enable/disable the collection of heap size profiles.
+            #
+            # This feature is alpha and enabled by default when heap profiling is enabled.
+            #
+            # @warn To enable heap size profiling you are required to also enable allocation and heap profiling.
+            # @note Heap profiles are not yet GA in the Datadog UI, get in touch if you want to help us test it.
+            #
+            # @default `DD_PROFILING_EXPERIMENTAL_HEAP_SIZE_ENABLED` environment variable as a boolean, otherwise
+            # whatever the value of DD_PROFILING_EXPERIMENTAL_HEAP_ENABLED is.
+            option :experimental_heap_size_enabled do |o|
+              o.type :bool
+              o.env 'DD_PROFILING_EXPERIMENTAL_HEAP_SIZE_ENABLED'
+              o.default true # This gets ANDed with experimental_heap_enabled in the profiler component.
+            end
+
             # Can be used to configure the allocation sampling rate: a sample will be collected every x allocations.
             #
             # The lower the value, the more accuracy in allocation and heap tracking but the bigger the overhead. In
@@ -366,6 +381,22 @@ module Datadog
               o.type :int
               o.env 'DD_PROFILING_EXPERIMENTAL_ALLOCATION_SAMPLE_RATE'
               o.default 50
+            end
+
+            # Can be used to configure the heap sampling rate: a heap sample will be collected for every x allocation
+            # samples.
+            #
+            # The lower the value, the more accuracy in heap tracking but the bigger the overhead. In particular, a
+            # value of 1 will track ALL allocations samples for heap profiles.
+            #
+            # The effective heap sampling rate in terms of allocations (not allocation samples) can be calculated via
+            # effective_heap_sample_rate = allocation_sample_rate * heap_sample_rate.
+            #
+            # @default `DD_PROFILING_EXPERIMENTAL_HEAP_SAMPLE_RATE` environment variable, otherwise `10`.
+            option :experimental_heap_sample_rate do |o|
+              o.type :int
+              o.env 'DD_PROFILING_EXPERIMENTAL_HEAP_SAMPLE_RATE'
+              o.default 10
             end
 
             # Can be used to disable checking which version of `libmysqlclient` is being used by the `mysql2` gem.

--- a/lib/datadog/core/configuration/settings.rb
+++ b/lib/datadog/core/configuration/settings.rb
@@ -333,8 +333,6 @@ module Datadog
             #       in summary, this should be supported on Ruby 2.x, 3.1.4+, 3.2.3+ and 3.3.0+. Enabling it on
             #       unsupported Rubies may result in unexpected behaviour, including crashes.
             #
-            # @note Allocation profiles are not yet GA in the Datadog UI, get in touch if you want to help us test it.
-            #
             # @default `DD_PROFILING_EXPERIMENTAL_ALLOCATION_ENABLED` environment variable as a boolean, otherwise `false`
             option :experimental_allocation_enabled do |o|
               o.type :bool
@@ -347,7 +345,6 @@ module Datadog
             # This feature is alpha and disabled by default
             #
             # @warn To enable heap profiling you are required to also enable allocation profiling.
-            # @note Heap profiles are not yet GA in the Datadog UI, get in touch if you want to help us test it.
             #
             # @default `DD_PROFILING_EXPERIMENTAL_HEAP_ENABLED` environment variable as a boolean, otherwise `false`
             option :experimental_heap_enabled do |o|
@@ -361,7 +358,6 @@ module Datadog
             # This feature is alpha and enabled by default when heap profiling is enabled.
             #
             # @warn To enable heap size profiling you are required to also enable allocation and heap profiling.
-            # @note Heap profiles are not yet GA in the Datadog UI, get in touch if you want to help us test it.
             #
             # @default `DD_PROFILING_EXPERIMENTAL_HEAP_SIZE_ENABLED` environment variable as a boolean, otherwise
             # whatever the value of DD_PROFILING_EXPERIMENTAL_HEAP_ENABLED is.

--- a/lib/datadog/profiling/component.rb
+++ b/lib/datadog/profiling/component.rb
@@ -7,7 +7,7 @@ module Datadog
       # Passing in a `nil` tracer is supported and will disable the following profiling features:
       # * Code Hotspots panel in the trace viewer, as well as scoping a profile down to a span
       # * Endpoint aggregation in the profiler UX, including normalization (resource per endpoint call)
-      def self.build_profiler_component(settings:, agent_settings:, optional_tracer:)
+      def self.build_profiler_component(settings:, agent_settings:, optional_tracer:) # rubocop:disable Metrics/MethodLength
         require_relative '../profiling/diagnostics/environment_logger'
 
         Profiling::Diagnostics::EnvironmentLogger.collect_and_log!
@@ -43,7 +43,9 @@ module Datadog
         timeline_enabled = settings.profiling.advanced.experimental_timeline_enabled
         allocation_sample_every = get_allocation_sample_every(settings)
         allocation_profiling_enabled = enable_allocation_profiling?(settings, allocation_sample_every)
-        heap_profiling_enabled = enable_heap_profiling?(settings, allocation_profiling_enabled)
+        heap_sample_every = get_heap_sample_every(settings)
+        heap_profiling_enabled = enable_heap_profiling?(settings, allocation_profiling_enabled, heap_sample_every)
+        heap_size_profiling_enabled = enable_heap_size_profiling?(settings, heap_profiling_enabled)
 
         overhead_target_percentage = valid_overhead_target(settings.profiling.advanced.overhead_target_percentage)
         upload_period_seconds = [60, settings.profiling.advanced.upload_period_seconds].max
@@ -51,6 +53,8 @@ module Datadog
         recorder = build_recorder(
           allocation_profiling_enabled: allocation_profiling_enabled,
           heap_profiling_enabled: heap_profiling_enabled,
+          heap_size_profiling_enabled: heap_size_profiling_enabled,
+          heap_sample_every: heap_sample_every,
           timeline_enabled: timeline_enabled,
         )
         thread_context_collector = build_thread_context_collector(settings, recorder, optional_tracer, timeline_enabled)
@@ -67,6 +71,7 @@ module Datadog
           no_signals_workaround_enabled: no_signals_workaround_enabled,
           timeline_enabled: timeline_enabled,
           allocation_sample_every: allocation_sample_every,
+          heap_sample_every: heap_sample_every,
         }.freeze
 
         exporter = build_profiler_exporter(settings, recorder, internal_metadata: internal_metadata)
@@ -79,13 +84,16 @@ module Datadog
       private_class_method def self.build_recorder(
         allocation_profiling_enabled:,
         heap_profiling_enabled:,
+        heap_size_profiling_enabled:,
+        heap_sample_every:,
         timeline_enabled:
       )
         Datadog::Profiling::StackRecorder.new(
           cpu_time_enabled: RUBY_PLATFORM.include?('linux'), # Only supported on Linux currently
           alloc_samples_enabled: allocation_profiling_enabled,
           heap_samples_enabled: heap_profiling_enabled,
-          heap_size_enabled: heap_profiling_enabled,
+          heap_size_enabled: heap_size_profiling_enabled,
+          heap_sample_every: heap_sample_every,
           timeline_enabled: timeline_enabled,
         )
       end
@@ -147,6 +155,14 @@ module Datadog
         allocation_sample_rate
       end
 
+      private_class_method def self.get_heap_sample_every(settings)
+        heap_sample_rate = settings.profiling.advanced.experimental_heap_sample_rate
+
+        raise ArgumentError, "Heap sample rate must be a positive integer. Was #{heap_sample_rate}" if heap_sample_rate <= 0
+
+        heap_sample_rate
+      end
+
       private_class_method def self.enable_allocation_profiling?(settings, allocation_sample_every)
         unless settings.profiling.advanced.experimental_allocation_enabled
           # Allocation profiling disabled, short-circuit out
@@ -200,7 +216,7 @@ module Datadog
         true
       end
 
-      private_class_method def self.enable_heap_profiling?(settings, allocation_profiling_enabled)
+      private_class_method def self.enable_heap_profiling?(settings, allocation_profiling_enabled, heap_sample_rate)
         heap_profiling_enabled = settings.profiling.advanced.experimental_heap_enabled
 
         return false unless heap_profiling_enabled
@@ -219,7 +235,20 @@ module Datadog
         end
 
         Datadog.logger.warn(
-          'Enabled experimental heap profiling. This is experimental, not recommended, and will increase overhead!'
+          "Enabled experimental heap profiling: heap_sample_rate=#{heap_sample_rate}. This is experimental, not " \
+          'recommended, and will increase overhead!'
+        )
+
+        true
+      end
+
+      private_class_method def self.enable_heap_size_profiling?(settings, heap_profiling_enabled)
+        heap_size_profiling_enabled = settings.profiling.advanced.experimental_heap_size_enabled
+
+        return false unless heap_profiling_enabled && heap_size_profiling_enabled
+
+        Datadog.logger.warn(
+          'Enabled experimental heap size profiling. This is experimental, not recommended, and will increase overhead!'
         )
 
         true

--- a/lib/datadog/profiling/component.rb
+++ b/lib/datadog/profiling/component.rb
@@ -50,10 +50,11 @@ module Datadog
         overhead_target_percentage = valid_overhead_target(settings.profiling.advanced.overhead_target_percentage)
         upload_period_seconds = [60, settings.profiling.advanced.upload_period_seconds].max
 
-        recorder = build_recorder(
-          allocation_profiling_enabled: allocation_profiling_enabled,
-          heap_profiling_enabled: heap_profiling_enabled,
-          heap_size_profiling_enabled: heap_size_profiling_enabled,
+        recorder = Datadog::Profiling::StackRecorder.new(
+          cpu_time_enabled: RUBY_PLATFORM.include?('linux'), # Only supported on Linux currently
+          alloc_samples_enabled: allocation_profiling_enabled,
+          heap_samples_enabled: heap_profiling_enabled,
+          heap_size_enabled: heap_size_profiling_enabled,
           heap_sample_every: heap_sample_every,
           timeline_enabled: timeline_enabled,
         )
@@ -79,23 +80,6 @@ module Datadog
         scheduler = Profiling::Scheduler.new(exporter: exporter, transport: transport, interval: upload_period_seconds)
 
         Profiling::Profiler.new(worker: worker, scheduler: scheduler)
-      end
-
-      private_class_method def self.build_recorder(
-        allocation_profiling_enabled:,
-        heap_profiling_enabled:,
-        heap_size_profiling_enabled:,
-        heap_sample_every:,
-        timeline_enabled:
-      )
-        Datadog::Profiling::StackRecorder.new(
-          cpu_time_enabled: RUBY_PLATFORM.include?('linux'), # Only supported on Linux currently
-          alloc_samples_enabled: allocation_profiling_enabled,
-          heap_samples_enabled: heap_profiling_enabled,
-          heap_size_enabled: heap_size_profiling_enabled,
-          heap_sample_every: heap_sample_every,
-          timeline_enabled: timeline_enabled,
-        )
       end
 
       private_class_method def self.build_thread_context_collector(settings, recorder, optional_tracer, timeline_enabled)

--- a/lib/datadog/profiling/stack_recorder.rb
+++ b/lib/datadog/profiling/stack_recorder.rb
@@ -6,7 +6,7 @@ module Datadog
     class StackRecorder
       def initialize(
         cpu_time_enabled:, alloc_samples_enabled:, heap_samples_enabled:, heap_size_enabled:,
-        timeline_enabled:
+        heap_sample_every:, timeline_enabled:
       )
         # This mutex works in addition to the fancy C-level mutexes we have in the native side (see the docs there).
         # It prevents multiple Ruby threads calling serialize at the same time -- something like
@@ -22,6 +22,7 @@ module Datadog
           alloc_samples_enabled,
           heap_samples_enabled,
           heap_size_enabled,
+          heap_sample_every,
           timeline_enabled,
         )
       end

--- a/sig/datadog/profiling/component.rbs
+++ b/sig/datadog/profiling/component.rbs
@@ -7,14 +7,6 @@ module Datadog
         optional_tracer: Datadog::Tracing::Tracer?,
       ) -> Datadog::Profiling::Profiler?
 
-      def self.build_recorder: (
-        allocation_profiling_enabled: bool,
-        heap_profiling_enabled: bool,
-        heap_size_profiling_enabled: bool,
-        heap_sample_every: ::Integer,
-        timeline_enabled: bool,
-      ) -> Datadog::Profiling::StackRecorder
-
       def self.build_thread_context_collector: (
         untyped settings,
         Datadog::Profiling::StackRecorder recorder,

--- a/sig/datadog/profiling/component.rbs
+++ b/sig/datadog/profiling/component.rbs
@@ -10,6 +10,8 @@ module Datadog
       def self.build_recorder: (
         allocation_profiling_enabled: bool,
         heap_profiling_enabled: bool,
+        heap_size_profiling_enabled: bool,
+        heap_sample_every: ::Integer,
         timeline_enabled: bool,
       ) -> Datadog::Profiling::StackRecorder
 
@@ -34,7 +36,9 @@ module Datadog
       def self.enable_gc_profiling?: (untyped settings) -> bool
       def self.get_allocation_sample_every: (untyped settings) -> ::Integer
       def self.enable_allocation_profiling?: (untyped settings, ::Integer allocation_sample_every) -> bool
-      def self.enable_heap_profiling?: (untyped settings, bool allocation_profiling_enabled) -> bool
+      def self.get_heap_sample_every: (untyped settings) -> ::Integer
+      def self.enable_heap_profiling?: (untyped settings, bool allocation_profiling_enabled, ::Integer heap_sample_every) -> bool
+      def self.enable_heap_size_profiling?: (untyped settings, bool heap_profiling_enabled) -> bool
 
       def self.no_signals_workaround_enabled?: (untyped settings) -> bool
 

--- a/sig/datadog/profiling/stack_recorder.rbs
+++ b/sig/datadog/profiling/stack_recorder.rbs
@@ -8,6 +8,7 @@ module Datadog
         alloc_samples_enabled: bool,
         heap_samples_enabled: bool,
         heap_size_enabled: bool,
+        heap_sample_every: Integer,
         timeline_enabled: bool,
       ) -> void
 
@@ -17,6 +18,7 @@ module Datadog
         bool alloc_samples_enabled,
         bool heap_samples_enabled,
         bool heap_size_enabled,
+        Integer heap_sample_every,
         bool timeline_enabled,
       ) -> true
 

--- a/spec/datadog/core/configuration/settings_spec.rb
+++ b/spec/datadog/core/configuration/settings_spec.rb
@@ -575,6 +575,41 @@ RSpec.describe Datadog::Core::Configuration::Settings do
         end
       end
 
+      describe '#experimental_heap_size_enabled' do
+        subject(:experimental_heap_size_enabled) { settings.profiling.advanced.experimental_heap_size_enabled }
+
+        context 'when DD_PROFILING_EXPERIMENTAL_HEAP_SIZE_ENABLED' do
+          around do |example|
+            ClimateControl.modify('DD_PROFILING_EXPERIMENTAL_HEAP_SIZE_ENABLED' => environment) do
+              example.run
+            end
+          end
+
+          context 'is not defined' do
+            let(:environment) { nil }
+
+            it { is_expected.to be true }
+          end
+
+          [true, false].each do |value|
+            context "is defined as #{value}" do
+              let(:environment) { value.to_s }
+
+              it { is_expected.to be value }
+            end
+          end
+        end
+      end
+
+      describe '#experimental_heap_size_enabled=' do
+        it 'updates the #experimental_heap_size_enabled setting' do
+          expect { settings.profiling.advanced.experimental_heap_size_enabled = false }
+            .to change { settings.profiling.advanced.experimental_heap_size_enabled }
+            .from(true)
+            .to(false)
+        end
+      end
+
       describe '#experimental_allocation_sample_rate' do
         subject(:experimental_allocation_sample_rate) { settings.profiling.advanced.experimental_allocation_sample_rate }
 
@@ -606,6 +641,41 @@ RSpec.describe Datadog::Core::Configuration::Settings do
           expect { settings.profiling.advanced.experimental_allocation_sample_rate = 100 }
             .to change { settings.profiling.advanced.experimental_allocation_sample_rate }
             .from(50)
+            .to(100)
+        end
+      end
+
+      describe '#experimental_heap_sample_rate' do
+        subject(:experimental_heap_sample_rate) { settings.profiling.advanced.experimental_heap_sample_rate }
+
+        context 'when DD_PROFILING_EXPERIMENTAL_HEAP_SAMPLE_RATE' do
+          around do |example|
+            ClimateControl.modify('DD_PROFILING_EXPERIMENTAL_HEAP_SAMPLE_RATE' => environment) do
+              example.run
+            end
+          end
+
+          context 'is not defined' do
+            let(:environment) { nil }
+
+            it { is_expected.to be 10 }
+          end
+
+          [100, 30.5].each do |value|
+            context "is defined as #{value}" do
+              let(:environment) { value.to_s }
+
+              it { is_expected.to be value.to_i }
+            end
+          end
+        end
+      end
+
+      describe '#experimental_heap_sample_rate=' do
+        it 'updates the #experimental_heap_sample_rate setting' do
+          expect { settings.profiling.advanced.experimental_heap_sample_rate = 100 }
+            .to change { settings.profiling.advanced.experimental_heap_sample_rate }
+            .from(10)
             .to(100)
         end
       end

--- a/spec/datadog/profiling/spec_helper.rb
+++ b/spec/datadog/profiling/spec_helper.rb
@@ -81,12 +81,16 @@ module ProfileHelpers
 
   # We disable heap_sample collection by default in tests since it requires some extra mocking/
   # setup for it to properly work.
-  def build_stack_recorder(heap_samples_enabled: false, heap_size_enabled: false, timeline_enabled: false)
+  def build_stack_recorder(
+    heap_samples_enabled: false, heap_size_enabled: false, heap_sample_every: 1,
+    timeline_enabled: false
+  )
     Datadog::Profiling::StackRecorder.new(
       cpu_time_enabled: true,
       alloc_samples_enabled: true,
       heap_samples_enabled: heap_samples_enabled,
       heap_size_enabled: heap_size_enabled,
+      heap_sample_every: heap_sample_every,
       timeline_enabled: timeline_enabled,
     )
   end

--- a/spec/datadog/profiling/stack_recorder_spec.rb
+++ b/spec/datadog/profiling/stack_recorder_spec.rb
@@ -11,6 +11,7 @@ RSpec.describe Datadog::Profiling::StackRecorder do
   # Enabling this is tested in a particular context below.
   let(:heap_samples_enabled) { false }
   let(:heap_size_enabled) { false }
+  let(:heap_sample_every) { 1 }
   let(:timeline_enabled) { true }
 
   subject(:stack_recorder) do
@@ -19,6 +20,7 @@ RSpec.describe Datadog::Profiling::StackRecorder do
       alloc_samples_enabled: alloc_samples_enabled,
       heap_samples_enabled: heap_samples_enabled,
       heap_size_enabled: heap_size_enabled,
+      heap_sample_every: heap_sample_every,
       timeline_enabled: timeline_enabled,
     )
   end
@@ -528,6 +530,20 @@ RSpec.describe Datadog::Profiling::StackRecorder do
           relevant_sample = heap_samples.find(&heap_samples_in_test_matcher)
           expect(relevant_sample).not_to be nil
           expect(relevant_sample.values[:'heap-live-samples']).to eq test_num_allocated_object * sample_rate
+        end
+
+        context 'with custom heap sample rate configuration' do
+          let(:heap_sample_every) { 2 }
+
+          it 'only keeps track of some allocations' do
+            # By only sampling every 2nd allocation we only track the odd objects which means our array
+            # should be the only heap sample captured (string is index 0, array is index 1, hash is 4)
+            expect(heap_samples.size).to eq(1)
+
+            heap_sample = heap_samples.first
+            expect(heap_sample.labels[:'allocation class']).to eq('Array')
+            expect(heap_sample.values[:'heap-live-samples']).to eq(sample_rate * heap_sample_every)
+          end
         end
       end
     end


### PR DESCRIPTION
**What does this PR do?**
* When an object id conflict is not allowed, raise with a more informative error message.
* Allow configuration of heap size collection (`DD_PROFILING_EXPERIMENTAL_HEAP_SIZE_ENABLED`) and heap sample rate (`DD_PROFILING_EXPERIMENTAL_HEAP_SAMPLE_RATE`).

**Motivation:**
* Debugging profiler shutdown on Ruby 2.7 workloads due to obj id conflicts.
* More knobs to enable different benchmarking flavours.

**Additional Notes:**
<!-- Anything else we should know when reviewing? -->

**How to test the change?**
<!--
Describe here how the change can be validated.
You are strongly encouraged to provide automated tests for this PR (unit or integration).
If this change cannot be feasibly tested, please explain why,
unless the change does not modify code (e.g. only modifies docs, comments).
-->

**For Datadog employees:**
- [ ] If this PR touches code that signs or publishes builds or packages, or handles
credentials of any kind, I've requested a review from `@DataDog/security-design-and-guidance`.
- [ ] This PR doesn't touch any of that.

Unsure? Have a question? Request a review!
