### PR TITLE
[NO-TICKET] Fix "no signals" workaround detection when mariadb is in use

### DIFF
--- a/sig/datadog/profiling/component.rbs
+++ b/sig/datadog/profiling/component.rbs
@@ -42,6 +42,7 @@ module Datadog
       def self.incompatible_passenger_version?: () -> bool
       def self.flush_interval: (untyped settings) -> ::Numeric
       def self.valid_overhead_target: (::Float overhead_target_percentage) -> ::Float
+      def self.looks_like_mariadb?: ({ header_version: ::String? }, ::Gem::Version) -> bool
     end
   end
 end

--- a/spec/datadog/profiling/component_spec.rb
+++ b/spec/datadog/profiling/component_spec.rb
@@ -620,6 +620,23 @@ RSpec.describe Datadog::Profiling::Component do
               end
             end
 
+            # See comments on looks_like_mariadb? for details on how this matching works
+            context "when mysql2 gem is linked to mariadb's version of libmysqlclient" do
+              before do
+                fake_client = double('Fake Mysql2::Client')
+                stub_const('Mysql2::Client', fake_client)
+                expect(fake_client).to receive(:info).and_return({ version: '4.9.99', header_version: '10.0.0' })
+              end
+
+              it { is_expected.to be false }
+
+              it 'does not log any warning message' do
+                expect(Datadog.logger).to_not receive(:warn)
+
+                no_signals_workaround_enabled?
+              end
+            end
+
             context 'when mysql2 gem is using a version of libmysqlclient < 8.0.0' do
               before do
                 fake_client = double('Fake Mysql2::Client')

--- a/vendor/rbs/mysql2/0/mysql2.rbs
+++ b/vendor/rbs/mysql2/0/mysql2.rbs
@@ -1,5 +1,5 @@
 module Mysql2
   class Client
-    def self.info: () -> { version: ::String }
+    def self.info: () -> { version: ::String, header_version: ::String? }
   end
 end


### PR DESCRIPTION
**What does this PR do?**

This PR fixes #3334 by tweaking the libmysqlclient detection code to not trigger when the mariadb version of libmysqlversion is in use.

The detection was triggering because the versioning schema used by mariadb is completely different from the libmysqlclient (e.g. latest releases report version 3.x, whereas mysql is 5.x or above).

**Motivation:**

For context, how we got here, is that legacy versions of the libmysqlclient library require the profiler "no signals" workaround to work without issues. To provide a seamless experience, we autodetect such versions and automatically apply the "no signals" workaround.

Unfortunately, this detection code incorrectly flagged the libmysqlclient version provided by mariadb as being incompatible.

In fact, that library has diverged a lot from the mysql version and we don't have any reports of issues that require the "no signals" workaround.

**Additional Notes:**

It's kinda fiddly to detect the mariadb version of libmysqlclient, see the added comments for more details.

**How to test the change?**

The change includes test coverage. To test it locally, I've additionally used the `dokken/centos-stream-9:latest` docker image, and then installed ruby + ruby-devel + gcc + make + MariaDB-devel from <https://mariadb.org/download/?t=repo-config&d=CentOS+Stream&v=11.2>.

**For Datadog employees:**
- [ ] If this PR touches code that signs or publishes builds or packages, or handles
credentials of any kind, I've requested a review from `@DataDog/security-design-and-guidance`.
- [x] This PR doesn't touch any of that.

Fixes #3334