### PR TITLE
Remove `Datadog::Tracing::Contrib::HTTP::Instrumentation.after_request`

### DIFF
--- a/lib/datadog/tracing/contrib/http/instrumentation.rb
+++ b/lib/datadog/tracing/contrib/http/instrumentation.rb
@@ -15,17 +15,6 @@ module Datadog
             base.prepend(InstanceMethods)
           end
 
-          # Span hook invoked after request is completed.
-          def self.after_request(&block)
-            if block
-              # Set hook
-              @after_request = block
-            else
-              # Get hook
-              @after_request ||= nil
-            end
-          end
-
           # InstanceMethods - implementing instrumentation
           module InstanceMethods
             include Contrib::HttpAnnotationHelper
@@ -58,11 +47,6 @@ module Datadog
 
                 # Add additional response specific tags to the span.
                 annotate_span_with_response!(span, response, request_options)
-
-                # Invoke hook, if set.
-                unless Contrib::HTTP::Instrumentation.after_request.nil?
-                  Contrib::HTTP::Instrumentation.after_request.call(span, self, req, response)
-                end
 
                 response
               end

--- a/sig/datadog/tracing/contrib/http/instrumentation.rbs
+++ b/sig/datadog/tracing/contrib/http/instrumentation.rbs
@@ -4,7 +4,6 @@ module Datadog
       module HTTP
         module Instrumentation
           def self.included: (untyped base) -> untyped
-          def self.after_request: () ?{ () -> untyped } -> untyped
           module InstanceMethods
             include Contrib::HttpAnnotationHelper
             def request: (untyped req, ?untyped? body) ?{ () -> untyped } -> untyped


### PR DESCRIPTION
<!--
Check out the
https://github.com/DataDog/dd-trace-rb/blob/master/docs/DevelopmentGuide.md
for guidance on how to set up your development environment,
run the test suite, write new integrations, and more.
-->

**2.0 Upgrade Guide notes**

The undocumented HTTP hook `Datadog::Tracing::Contrib::HTTP::Instrumentation.after_request` has been removed. This hook was intrusive, only restricted to the `net/http` client, and was not generalizable to other HTTP client gems.

If you require this hook, please [open a "Feature request"](https://github.com/DataDog/dd-trace-rb/issues/new/choose) stating your use case so we can asses how to best support it.

<!--
(If this PR is for 1.x, please delete this section)
A public facing description that will go into the [upgrade guide](https://github.com/DataDog/dd-trace-rb/blob/master/docs/UpgradeGuide.md) for this change.
We already know what the PR does (from the PR title),
but users should know either:
* A migration path for this change. In other words, how to continue using their application without behavior changes
in 2.0 (e.g. environment variable 'X' renamed to 'Y').
* That there's no alternative; we completely dropped support for this feature.
-->

**Additional Notes:**

We are open to adding similar capabilities in the future, but we should asses the concrete user needs for such hook.

**How to test the change?**

All changes are covered by unit testing. In this case, the tests are removed due to the removal of the feature.

**For Datadog employees:**
- [ ] If this PR touches code that signs or publishes builds or packages, or handles
credentials of any kind, I've requested a review from `@DataDog/security-design-and-guidance`.
- [x] This PR doesn't touch any of that.

Unsure? Have a question? Request a review!
