### PR TITLE
[NO-TICKET] Remove leftover helper file for profiling 0.x to 1.x migration

### DIFF
--- a/lib/ddtrace/profiling/preload.rb
+++ b/lib/ddtrace/profiling/preload.rb
@@ -1,2 +1,0 @@
-# TODO: Warns users after 1.0 upgrade. Remove this file in 2.0.
-raise LoadError, 'This file has been moved to `datadog/profiling/preload` in 1.0.0'


### PR DESCRIPTION
**What does this PR do?**

This PR removes the `ddtrace/profiling/preload` file. As the comment attached to it said, this file was used to direct users to the correct new file in the 0.x to 1.x migration.

Let's remove it for 2.0.

**Motivation:**

Empty out the `lib/ddtrace` folder.

**Additional Notes:**

N/A

**How to test the change?**

Validate that `ddtrace/profiling/preload` no longer exists? ;)

**For Datadog employees:**
- [ ] If this PR touches code that signs or publishes builds or packages, or handles
credentials of any kind, I've requested a review from `@DataDog/security-design-and-guidance`.
- [x] This PR doesn't touch any of that.