### PR TITLE
Backport "List Ruby 3.3 as supported in the docs" to master branch

### DIFF
--- a/docs/Compatibility.md
+++ b/docs/Compatibility.md
@@ -6,7 +6,8 @@ The Ruby Datadog Trace library is open source. See the [dd-trace-rb][1] GitHub r
 
 | Type  | Documentation              | Version | Support type                         | Gem version support |
 | ----- | -------------------------- | -----   | ------------------------------------ | ------------------- |
-| MRI   | https://www.ruby-lang.org/ | 3.2     | Full                                 | Latest              |
+| MRI   | https://www.ruby-lang.org/ | 3.3     | Full                                 | Latest              |
+|       |                            | 3.2     | Full                                 | Latest              |
 |       |                            | 3.1     | Full                                 | Latest              |
 |       |                            | 3.0     | Full                                 | Latest              |
 |       |                            | 2.7     | Full                                 | Latest              |


### PR DESCRIPTION
**What does this PR do?**

This PR backports https://github.com/DataDog/dd-trace-rb/pull/3371 to the `master` branch. It updates our docs to mark that Ruby 3.3 is fully supported.

**Motivation:**

Because https://github.com/DataDog/dd-trace-rb/pull/3371 was merged to the `release` branch directly (so as to update the docs immediately), we need to copy it to master as otherwise it would be clobbered the next time we make a release of the gem.

**Additional Notes:**

Thanks @gdubicki for the original PR.

**How to test the change?**

Look at the markdown ;)

**For Datadog employees:**
- [ ] If this PR touches code that signs or publishes builds or packages, or handles
credentials of any kind, I've requested a review from `@DataDog/security-design-and-guidance`.
- [x] This PR doesn't touch any of that.