### PR TITLE
[NO-TICKET] Minor: Re-enable gc profiling spec on Ruby 3

### DIFF
--- a/spec/datadog/profiling/collectors/cpu_and_wall_time_worker_spec.rb
+++ b/spec/datadog/profiling/collectors/cpu_and_wall_time_worker_spec.rb
@@ -245,15 +245,6 @@ RSpec.describe 'Datadog::Profiling::Collectors::CpuAndWallTimeWorker' do
     end
 
     it 'records garbage collection cycles' do
-      if RUBY_VERSION.start_with?('3.')
-        skip(
-          'This test (and feature...) is broken on Ruby 3 if any Ractors get used due to a bug in the VM during ' \
-          'Ractor GC, see https://bugs.ruby-lang.org/issues/19112 for details. ' \
-          'For that reason, we disable this feature on Ruby 3 by default by passing `gc_profiling_enabled: false` during ' \
-          'profiler initialization.'
-        )
-      end
-
       start
 
       described_class::Testing._native_trigger_sample


### PR DESCRIPTION
**What does this PR do?**

This PR re-enables a garbage collection profiling spec in the `CpuAndWallTimeWorker` that was disabled on Ruby 3.

This test was disabled in #2354 as this caused flaky tests due to a Ruby VM bug related to Ractor GC.

Recently, this "flaky when combined with Ractors" behavior started showing up in other places and @AlexJF came up with a better solution in #3320 of separating out the Ractor tests.

Thus, we can now run this spec on Ruby 3.

**Motivation**:

Recently, while working on #3356, I noticed that if I commented out the calls to `rb_postponed_job_[trigger|register_one]` in `on_gc_event`, no specs failed.

This was pretty surprising to me -- as it was weird that we didn't have test coverage for it.

After looking into it, I realized we did have specs for it -- but we weren't running them on Ruby 3, which I was using for local development.

The re-enabled spec correctly covers that situation.

**Additional Notes:**

N/A

**How to test the change?**

Validate that test now runs on Ruby 3 and test suite is still green.

**For Datadog employees:**
- [ ] If this PR touches code that signs or publishes builds or packages, or handles
credentials of any kind, I've requested a review from `@DataDog/security-design-and-guidance`.
- [x] This PR doesn't touch any of that.