### PR TITLE
Pass the service name to instantiation spans

### DIFF
--- a/lib/datadog/tracing/contrib/active_record/events/instantiation.rb
+++ b/lib/datadog/tracing/contrib/active_record/events/instantiation.rb
@@ -30,6 +30,15 @@ module Datadog
             end
 
             def process(span, event, _id, payload)
+              config = Utils.connection_config(payload[:connection], payload[:connection_id])
+              settings = Datadog.configuration.tracing[:active_record, config]
+              adapter_name = Contrib::Utils::Database.normalize_vendor(config[:adapter])
+              service_name = if settings.service_name != Contrib::Utils::Database::VENDOR_DEFAULT
+                               settings.service_name
+                             else
+                               adapter_name
+                             end
+              span.service = service_name
               span.resource = payload.fetch(:class_name)
               span.span_type = Ext::SPAN_TYPE_INSTANTIATION
               span.set_tag(Tracing::Metadata::Ext::TAG_COMPONENT, Ext::TAG_COMPONENT)

--- a/spec/datadog/tracing/contrib/rails/database_spec.rb
+++ b/spec/datadog/tracing/contrib/rails/database_spec.rb
@@ -82,8 +82,7 @@ RSpec.describe 'Rails database' do
         span, = spans
         expect(span.name).to eq('active_record.instantiation')
         expect(span.span_type).to eq('custom')
-        # Because no parent, and doesn't belong to database service
-        expect(span.service).to eq(tracer.default_service)
+        expect(span.service).to eq(database_service)
         expect(span.resource).to eq('Article')
         expect(span.get_tag('active_record.instantiation.class_name')).to eq('Article')
         expect(span.get_tag('active_record.instantiation.record_count')).to eq(1)
@@ -110,7 +109,7 @@ RSpec.describe 'Rails database' do
 
           expect(instantiation_span.name).to eq('active_record.instantiation')
           expect(instantiation_span.span_type).to eq('custom')
-          expect(instantiation_span.service).to eq(tracer.default_service) # Because within parent
+          expect(instantiation_span.service).to eq(database_service)
           expect(instantiation_span.resource).to eq('Article')
           expect(instantiation_span.get_tag('active_record.instantiation.class_name')).to eq('Article')
           expect(instantiation_span.get_tag('active_record.instantiation.record_count')).to eq(1)


### PR DESCRIPTION
**What does this PR do?**

This PR fix https://github.com/DataDog/dd-trace-rb/issues/3359 

This is a draft because I think we need to have a discussion first on the issue.

**Motivation:**

Having the same service name for "instantiation spans" and "sql spans".

**Additional Notes:**

I don't know how this change can impact end user. 

**How to test the change?**

It has been tested in spec suite but should be tested E2E. 😄

**For Datadog employees:**
- [ ] If this PR touches code that signs or publishes builds or packages, or handles
credentials of any kind, I've requested a review from `@DataDog/security-design-and-guidance`.
- [ ] This PR doesn't touch any of that.

Unsure? Have a question? Request a review!
