### PR TITLE
[NO-TICKET] Fix sinatra integration apps broken by missing `rackup`

### DIFF
--- a/integration/apps/sinatra2-classic/Gemfile
+++ b/integration/apps/sinatra2-classic/Gemfile
@@ -35,3 +35,4 @@ gem 'pry-byebug'
 gem 'rspec'
 gem 'rspec-wait'
 gem 'webrick' if RUBY_VERSION >= '2.3' # Older Rubies can just use the built-in version of webrick
+gem 'rackup'

--- a/integration/apps/sinatra2-classic/Gemfile
+++ b/integration/apps/sinatra2-classic/Gemfile
@@ -4,7 +4,7 @@ source "https://rubygems.org"
 
 gem 'puma'
 gem 'unicorn'
-gem 'sinatra'
+gem 'sinatra', '>= 3.0'
 
 gem 'dogstatsd-ruby'
 # Choose correct specs for 'ddtrace' demo environment

--- a/integration/apps/sinatra2-modular/Gemfile
+++ b/integration/apps/sinatra2-modular/Gemfile
@@ -36,3 +36,4 @@ gem 'pry-byebug'
 gem 'rspec'
 gem 'rspec-wait'
 gem 'webrick' if RUBY_VERSION >= '2.3' # Older Rubies can just use the built-in version of webrick
+gem 'rackup'

--- a/integration/apps/sinatra2-modular/Gemfile
+++ b/integration/apps/sinatra2-modular/Gemfile
@@ -4,8 +4,8 @@ source "https://rubygems.org"
 
 gem 'puma'
 gem 'unicorn'
-gem 'sinatra'
-gem 'sinatra-router'
+gem 'sinatra', '>= 3.0'
+gem 'sinatra-router', '>= 0.3.0'
 
 gem 'dogstatsd-ruby'
 # Choose correct specs for 'ddtrace' demo environment


### PR DESCRIPTION
**What does this PR do?**

This PR adds the `rackup` as a dependency of the sinatra integration apps.

This fixes our sinatra-based integration apps being broken in CI for master.

The `rackup` command is no longer included in modern versions of `rack`, and has

**Motivation:**

The `rackup` command is no longer included in modern versions of `rack`, and has been extracted into a separate gem.

The release of `sinatra` 4 moved to one such modern version of `rack`, which broke our integration apps.

**Additional Notes:**

Sigh, this is the second "CI-broken-in-master" in 7 days :(

**How to test the change?**

Validate that CI is green!

**For Datadog employees:**
- [ ] If this PR touches code that signs or publishes builds or packages, or handles
credentials of any kind, I've requested a review from `@DataDog/security-design-and-guidance`.
- [x] This PR doesn't touch any of that.