### PR TITLE
[NO-TICKET] Pin sinatra integration apps to sinatra 2

### DIFF
--- a/integration/apps/sinatra2-classic/Gemfile
+++ b/integration/apps/sinatra2-classic/Gemfile
@@ -4,7 +4,7 @@ source "https://rubygems.org"
 
 gem 'puma'
 gem 'unicorn'
-gem 'sinatra'
+gem 'sinatra', '>= 2.2.4', '< 3'
 
 gem 'dogstatsd-ruby'
 # Choose correct specs for 'ddtrace' demo environment
@@ -35,3 +35,4 @@ gem 'pry-byebug'
 gem 'rspec'
 gem 'rspec-wait'
 gem 'webrick' if RUBY_VERSION >= '2.3' # Older Rubies can just use the built-in version of webrick
+gem 'rackup'

--- a/integration/apps/sinatra2-modular/Gemfile
+++ b/integration/apps/sinatra2-modular/Gemfile
@@ -4,8 +4,8 @@ source "https://rubygems.org"
 
 gem 'puma'
 gem 'unicorn'
-gem 'sinatra'
-gem 'sinatra-router'
+gem 'sinatra', '>= 2.2.4', '< 3'
+gem 'sinatra-router', '>= 0.3.0'
 
 gem 'dogstatsd-ruby'
 # Choose correct specs for 'ddtrace' demo environment
@@ -36,3 +36,4 @@ gem 'pry-byebug'
 gem 'rspec'
 gem 'rspec-wait'
 gem 'webrick' if RUBY_VERSION >= '2.3' # Older Rubies can just use the built-in version of webrick
+gem 'rackup'


### PR DESCRIPTION
**What does this PR do?**

This PR pins our sinatra integration apps to make sure they use sinatra 2. They were otherwise picking up sinatra 3 and 4.

It also tweaks a few of the gems to avoid future troubles when trying to run this app with newer sinatra/rack versions.

**Motivation:**

This PR is an alternative to #3390. Our sinatra apps are broken in CI as they picked up sinatra 4 and started breaking due to a minor incompatibility (`rack` 3 no longer includes `rackup` by default).

We could've opted to use newer sinatra versions for these apps, but our current pattern with rails is to have a different app for different versions, so for now let's keep with it.

**Additional Notes:**

N/A

**How to test the change?**

Validate that CI is green.

**For Datadog employees:**
- [ ] If this PR touches code that signs or publishes builds or packages, or handles
credentials of any kind, I've requested a review from `@DataDog/security-design-and-guidance`.
- [x] This PR doesn't touch any of that.