### PR TITLE
`Sidekiq`: Remove `tag_args` option 

### DIFF
--- a/docs/GettingStarted.md
+++ b/docs/GettingStarted.md
@@ -1806,7 +1806,6 @@ end
 | Key | Description | Default |
 | --- | ----------- | ------- |
 | `distributed_tracing` | Enabling [distributed tracing](#distributed-tracing) creates a parent-child relationship between the `sidekiq.push` span and the `sidekiq.job` span. <br /><br />**Important**: *Enabling distributed_tracing for asynchronous processing can result in drastic changes in your trace graph. Such cases include long running jobs, retried jobs, and jobs scheduled in the far future. Make sure to inspect your traces after enabling this feature.* | `false` |
-| `tag_args` | Enable tagging of job arguments. `true` for on, `false` for off. | `false` |
 | `on_error` | Custom error handler invoked when a job raises an error. Provided `span` and `error` as arguments. Sets error on the span by default. Useful for ignoring transient errors. | `proc { \|span, error\| span.set_error(error) unless span.nil? }` |
 | `quantize` | Hash containing options for quantization of job arguments. | `{}` |
 

--- a/lib/datadog/tracing/contrib/sidekiq/configuration/settings.rb
+++ b/lib/datadog/tracing/contrib/sidekiq/configuration/settings.rb
@@ -29,12 +29,6 @@ module Datadog
               o.default 1.0
             end
 
-            option :tag_args do |o|
-              o.type :bool
-              o.env Ext::ENV_TAG_JOB_ARGS
-              o.default false
-            end
-
             option :service_name
             option :client_service_name
 

--- a/lib/datadog/tracing/contrib/sidekiq/ext.rb
+++ b/lib/datadog/tracing/contrib/sidekiq/ext.rb
@@ -11,7 +11,6 @@ module Datadog
           ENV_ENABLED = 'DD_TRACE_SIDEKIQ_ENABLED'
           ENV_ANALYTICS_ENABLED = 'DD_TRACE_SIDEKIQ_ANALYTICS_ENABLED'
           ENV_ANALYTICS_SAMPLE_RATE = 'DD_TRACE_SIDEKIQ_ANALYTICS_SAMPLE_RATE'
-          ENV_TAG_JOB_ARGS = 'DD_SIDEKIQ_TAG_JOB_ARGS'
           SERVICE_NAME = 'sidekiq'
           SPAN_PUSH = 'sidekiq.push'
           SPAN_JOB = 'sidekiq.job'

--- a/lib/datadog/tracing/contrib/sidekiq/server_tracer.rb
+++ b/lib/datadog/tracing/contrib/sidekiq/server_tracer.rb
@@ -15,8 +15,6 @@ module Datadog
         class ServerTracer
           include Utils
 
-          QUANTIZE_SHOW_ALL = { args: { show: :all } }.freeze
-
           def initialize(options = {})
             @sidekiq_service = options[:service_name] || configuration[:service_name]
             @on_error = options[:on_error] || configuration[:on_error]
@@ -33,8 +31,6 @@ module Datadog
             end
 
             service = worker_config(resource, :service_name) || @sidekiq_service
-            # DEV-2.0: Remove `tag_args`, as `quantize` can fulfill the same contract
-            tag_args = worker_config(resource, :tag_args) || configuration[:tag_args]
             quantize = worker_config(resource, :quantize) || configuration[:quantize]
 
             Datadog::Tracing.trace(
@@ -72,7 +68,6 @@ module Datadog
 
               args = job['args']
               if args && !args.empty?
-                quantize = tag_args ? QUANTIZE_SHOW_ALL : quantize
                 span.set_tag(Ext::TAG_JOB_ARGS, quantize_args(quantize, args))
               end
 

--- a/lib/datadog/tracing/contrib/sidekiq/server_tracer.rb
+++ b/lib/datadog/tracing/contrib/sidekiq/server_tracer.rb
@@ -20,8 +20,6 @@ module Datadog
             @on_error = options[:on_error] || configuration[:on_error]
           end
 
-          # rubocop:disable Metrics/MethodLength
-          # rubocop:disable Metrics/AbcSize
           def call(worker, job, queue)
             resource = job_resource(job)
 
@@ -67,14 +65,10 @@ module Datadog
               span.set_tag(Ext::TAG_JOB_DELAY, 1000.0 * (Time.now.utc.to_f - job['enqueued_at'].to_f))
 
               args = job['args']
-              if args && !args.empty?
-                span.set_tag(Ext::TAG_JOB_ARGS, quantize_args(quantize, args))
-              end
+              span.set_tag(Ext::TAG_JOB_ARGS, quantize_args(quantize, args)) if args && !args.empty?
 
               yield
             end
-            # rubocop:enable Metrics/MethodLength
-            # rubocop:enable Metrics/AbcSize
           end
 
           private

--- a/sig/datadog/tracing/contrib/sidekiq/ext.rbs
+++ b/sig/datadog/tracing/contrib/sidekiq/ext.rbs
@@ -11,8 +11,6 @@ module Datadog
 
           ENV_ANALYTICS_SAMPLE_RATE: "DD_TRACE_SIDEKIQ_ANALYTICS_SAMPLE_RATE"
 
-          ENV_TAG_JOB_ARGS: "DD_SIDEKIQ_TAG_JOB_ARGS"
-
           SERVICE_NAME: "sidekiq"
 
           SPAN_PUSH: "sidekiq.push"

--- a/spec/datadog/tracing/contrib/sidekiq/server_tracer_spec.rb
+++ b/spec/datadog/tracing/contrib/sidekiq/server_tracer_spec.rb
@@ -115,21 +115,6 @@ RSpec.describe 'Server tracer' do
       expect(custom.get_tag('messaging.system')).to eq('sidekiq')
     end
 
-    context 'with tag_args' do
-      let(:sidekiq_options) { { service_name: 'sidekiq-slow', tag_args: true } }
-
-      it 'records tag values' do
-        perform_async
-        CustomWorker.perform_async('random_id')
-
-        expect(spans).to have(4).items
-
-        custom, _empty, _push, _push = spans
-
-        expect(custom.get_tag('sidekiq.job.args')).to eq(['random_id'].to_s)
-      end
-    end
-
     context 'with default quantization' do
       let(:sidekiq_options) { { service_name: 'sidekiq-slow', quantize: {} } }
 


### PR DESCRIPTION
**2.0 Upgrade Guide notes**

🚨 Sidekiq: `tag_args` option is removed, use `quantize` instead

If you were setting this option with true, change your code from 
```
    Datadog.configure do |c|
      c.tracing.instrument :sidekiq, tag_args: true
    end
```
to
```
    Datadog.configure do |c|
      c.tracing.instrument :sidekiq, quantize: { args: { show: :all } }
    end
```