### PR TITLE
Test for active_record.instantiation events

### DIFF
--- a/docs/GettingStarted.md
+++ b/docs/GettingStarted.md
@@ -467,7 +467,7 @@ end
 
 | Key            | Description                                                                                                                                                                                       | Default                                    |
 |----------------|---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|--------------------------------------------|
-| `service_name` | **Deprecated:** override the service name for the SQL query instrumentation. ActiveRecord instantiation instrumentation always uses the application's configured service name. | Name of database adapter (e.g. `'mysql2'`) |
+| `service_name` | Override the service name for the SQL query instrumentation. ActiveRecord instantiation instrumentation always uses the application's configured service name. | Name of database adapter (e.g. `'mysql2'`) |
 
 **Configuring trace settings per database**
 

--- a/docs/GettingStarted.md
+++ b/docs/GettingStarted.md
@@ -467,7 +467,7 @@ end
 
 | Key            | Description                                                                                                                                                                                       | Default                                    |
 |----------------|---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|--------------------------------------------|
-| `service_name` | Name of application running the `active_record` instrumentation. May be overridden by `global_default_service_name`. [See *Additional Configuration* for more details](#additional-configuration) | Name of database adapter (e.g. `'mysql2'`) |
+| `service_name` | **Deprecated:** override the service name for the SQL query instrumentation. ActiveRecord instantiation instrumentation always uses the application's configured service name. | Name of database adapter (e.g. `'mysql2'`) |
 
 **Configuring trace settings per database**
 

--- a/lib/datadog/tracing/contrib/active_record/events/instantiation.rb
+++ b/lib/datadog/tracing/contrib/active_record/events/instantiation.rb
@@ -31,6 +31,7 @@ module Datadog
 
             def process(span, event, _id, payload)
               span.resource = payload.fetch(:class_name)
+              span.service = configuration[:service_name] if configuration[:service_name]
               span.span_type = Ext::SPAN_TYPE_INSTANTIATION
               span.set_tag(Tracing::Metadata::Ext::TAG_COMPONENT, Ext::TAG_COMPONENT)
               span.set_tag(Tracing::Metadata::Ext::TAG_OPERATION, Ext::TAG_OPERATION_INSTANTIATION)

--- a/lib/datadog/tracing/contrib/active_record/events/instantiation.rb
+++ b/lib/datadog/tracing/contrib/active_record/events/instantiation.rb
@@ -31,7 +31,6 @@ module Datadog
 
             def process(span, event, _id, payload)
               span.resource = payload.fetch(:class_name)
-              span.service = configuration[:service_name] if configuration[:service_name]
               span.span_type = Ext::SPAN_TYPE_INSTANTIATION
               span.set_tag(Tracing::Metadata::Ext::TAG_COMPONENT, Ext::TAG_COMPONENT)
               span.set_tag(Tracing::Metadata::Ext::TAG_OPERATION, Ext::TAG_OPERATION_INSTANTIATION)

--- a/spec/datadog/tracing/contrib/active_record/app.rb
+++ b/spec/datadog/tracing/contrib/active_record/app.rb
@@ -10,8 +10,12 @@ else
   if ActiveRecord::VERSION::MAJOR < 4
     require 'active_record/connection_adapters/mysql2_adapter'
 
-    class ActiveRecord::ConnectionAdapters::Mysql2Adapter
-      NATIVE_DATABASE_TYPES[:primary_key] = "int(11) auto_increment PRIMARY KEY"
+    module ActiveRecord
+      module ConnectionAdapters
+        class Mysql2Adapter
+          NATIVE_DATABASE_TYPES[:primary_key] = 'int(11) auto_increment PRIMARY KEY'
+        end
+      end
     end
   end
 end

--- a/spec/datadog/tracing/contrib/active_record/app.rb
+++ b/spec/datadog/tracing/contrib/active_record/app.rb
@@ -4,6 +4,16 @@ if PlatformHelpers.jruby?
   require 'activerecord-jdbc-adapter'
 else
   require 'mysql2'
+
+  # Fix for https://github.com/brianmario/mysql2/issues/784#issuecomment-414878642
+  # for Rails 3.2.
+  if ActiveRecord::VERSION::MAJOR < 4
+    require 'active_record/connection_adapters/mysql2_adapter'
+
+    class ActiveRecord::ConnectionAdapters::Mysql2Adapter
+      NATIVE_DATABASE_TYPES[:primary_key] = "int(11) auto_increment PRIMARY KEY"
+    end
+  end
 end
 
 logger = Logger.new($stdout)

--- a/spec/datadog/tracing/contrib/active_record/instantiation_spec.rb
+++ b/spec/datadog/tracing/contrib/active_record/instantiation_spec.rb
@@ -40,8 +40,6 @@ RSpec.describe 'ActiveRecord instantiation instrumentation' do
       let(:analytics_sample_rate_var) { Datadog::Tracing::Contrib::ActiveRecord::Ext::ENV_ANALYTICS_SAMPLE_RATE }
     end
 
-    it_behaves_like 'measured span for integration', true
-
     let(:span) do
       # First span is for SQL query, second span is for instantiation.
       expect(spans.length).to be(2)
@@ -49,6 +47,7 @@ RSpec.describe 'ActiveRecord instantiation instrumentation' do
       expect(spans.last.name).to match(/query/)
       spans.first
     end
+    it_behaves_like 'measured span for integration', true
 
     it 'calls the instrumentation when is used standalone' do
       aggregate_failures do
@@ -61,7 +60,7 @@ RSpec.describe 'ActiveRecord instantiation instrumentation' do
     end
 
     context 'and service_name' do
-      #it_behaves_like 'schema version span'
+      # it_behaves_like 'schema version span'
 
       context 'is not set' do
         it { expect(span.service).to eq(tracer.default_service) }

--- a/spec/datadog/tracing/contrib/active_record/instantiation_spec.rb
+++ b/spec/datadog/tracing/contrib/active_record/instantiation_spec.rb
@@ -1,0 +1,71 @@
+require 'datadog/tracing/contrib/support/spec_helper'
+require 'datadog/tracing/contrib/analytics_examples'
+require 'datadog/tracing/contrib/integration_examples'
+require 'datadog/tracing/contrib/span_attribute_schema_examples'
+require 'ddtrace'
+
+require 'spec/datadog/tracing/contrib/rails/support/deprecation'
+
+require_relative 'app'
+
+RSpec.describe 'ActiveRecord instantiation instrumentation' do
+  let(:configuration_options) { {} }
+  let(:artile) { Article.new(title: 'test') }
+
+  before do
+    # Prevent extra spans during tests
+    Article.count
+
+    # Reset options (that might linger from other tests)
+    Datadog.configuration.tracing[:active_record].reset!
+
+    Datadog.configure do |c|
+      c.tracing.instrument :active_record, configuration_options
+    end
+
+    raise_on_rails_deprecation!
+  end
+
+  around do |example|
+    # Reset before and after each example; don't allow global state to linger.
+    Datadog.registry[:active_record].reset_configuration!
+    example.run
+    Datadog.registry[:active_record].reset_configuration!
+  end
+
+  context 'when a model is instantiated' do
+    before { Article.count }
+
+    it_behaves_like 'analytics for integration' do
+      let(:analytics_enabled_var) { Datadog::Tracing::Contrib::ActiveRecord::Ext::ENV_ANALYTICS_ENABLED }
+      let(:analytics_sample_rate_var) { Datadog::Tracing::Contrib::ActiveRecord::Ext::ENV_ANALYTICS_SAMPLE_RATE }
+    end
+
+    it_behaves_like 'measured span for integration', false
+
+    it 'calls the instrumentation when is used standalone' do
+      aggregate_failures do
+        expect(span.service).to eq('fixme')
+        expect(span.name).to eq('active_record.instantiation')
+        expect(span.span_type).to eq('fixme')
+        expect(span.resource.strip).to eq('Article')
+        expect(span.get_tag(Datadog::Tracing::Metadata::Ext::TAG_COMPONENT)).to eq('active_record')
+      end
+    end
+
+    context 'and service_name' do
+      it_behaves_like 'schema version span'
+
+      context 'is not set' do
+        it { expect(span.service).to eq('fixme') }
+      end
+
+      context 'is set' do
+        let(:service_name) { 'test_active_record' }
+        let(:configuration_options) { super().merge(service_name: service_name) }
+
+        it { expect(span.service).to eq(service_name) }
+      end
+    end
+  end
+end

--- a/spec/datadog/tracing/contrib/active_record/instantiation_spec.rb
+++ b/spec/datadog/tracing/contrib/active_record/instantiation_spec.rb
@@ -65,18 +65,17 @@ RSpec.describe 'ActiveRecord instantiation instrumentation' do
       #it_behaves_like 'schema version span'
 
       context 'is not set' do
-        it { expect(span.service).to eq('rspec') }
+        it { expect(span.service).to eq(tracer.default_service) }
       end
 
       context 'is set' do
         let(:service_name) { 'test_active_record' }
         let(:configuration_options) { super().merge(service_name: service_name) }
 
-        #it { expect(span.service).to eq(service_name) }
-        #
-        # Currently the service name is not defined in the instantiation
-        # integration, therefore the root span's service name is used.
-        it { expect(span.service).to eq('rspec') }
+        # Service name override in AR tracing configuration applies only to
+        # the SQL query instrumentation, not to instantiation insturmentation.
+        # Instantiation events always use the application's service name.
+        it { expect(span.service).to eq(tracer.default_service) }
       end
     end
   end

--- a/spec/datadog/tracing/contrib/active_record/instantiation_spec.rb
+++ b/spec/datadog/tracing/contrib/active_record/instantiation_spec.rb
@@ -1,6 +1,5 @@
 require 'datadog/tracing/contrib/support/spec_helper'
 require 'datadog/tracing/contrib/analytics_examples'
-require 'datadog/tracing/contrib/integration_examples'
 require 'datadog/tracing/contrib/span_attribute_schema_examples'
 require 'ddtrace'
 

--- a/spec/datadog/tracing/contrib/active_record/instantiation_spec.rb
+++ b/spec/datadog/tracing/contrib/active_record/instantiation_spec.rb
@@ -12,6 +12,12 @@ RSpec.describe 'ActiveRecord instantiation instrumentation' do
   let(:article) { Article.first }
 
   before do
+    if Gem::Version.new(ActiveRecord::VERSION::STRING) < Gem::Version.new('4.2')
+      skip "ActiveRecord instantiation events were added in Rails 4.2"
+    end
+  end
+
+  before do
     # Create the article to be retrieved in the tests.
     Article.create!(title: 'test')
 

--- a/spec/datadog/tracing/contrib/active_record/instantiation_spec.rb
+++ b/spec/datadog/tracing/contrib/active_record/instantiation_spec.rb
@@ -13,8 +13,8 @@ RSpec.describe 'ActiveRecord instantiation instrumentation' do
   let(:artile) { Article.new(title: 'test') }
 
   before do
-    # Prevent extra spans during tests
-    Article.count
+    # # Prevent extra spans during tests
+    # Article.count
 
     # Reset options (that might linger from other tests)
     Datadog.configuration.tracing[:active_record].reset!
@@ -34,7 +34,7 @@ RSpec.describe 'ActiveRecord instantiation instrumentation' do
   end
 
   context 'when a model is instantiated' do
-    before { Article.count }
+    before { artile }
 
     it_behaves_like 'analytics for integration' do
       let(:analytics_enabled_var) { Datadog::Tracing::Contrib::ActiveRecord::Ext::ENV_ANALYTICS_ENABLED }

--- a/spec/datadog/tracing/contrib/active_record/instantiation_spec.rb
+++ b/spec/datadog/tracing/contrib/active_record/instantiation_spec.rb
@@ -13,12 +13,8 @@ RSpec.describe 'ActiveRecord instantiation instrumentation' do
 
   before do
     if Gem::Version.new(ActiveRecord::VERSION::STRING) < Gem::Version.new('4.2')
-      skip "ActiveRecord instantiation events were added in Rails 4.2"
+      skip 'ActiveRecord instantiation events were added in Rails 4.2'
     end
-  end
-
-  before do
-    # Create the article to be retrieved in the tests.
     Article.create!(title: 'test')
 
     # Reset options (that might linger from other tests)


### PR DESCRIPTION
<!--
Check out the
https://github.com/DataDog/dd-trace-rb/blob/master/docs/DevelopmentGuide.md
for guidance on how to set up your development environment,
run the test suite, write new integrations, and more.
-->

This is an extraction of tests from #3184.


**What does this PR do?**
<!-- A brief description of the change being made with this pull request. -->

This PR adds a test for ActiveRecord instantiation events. This is functionality already provided by the library but apparently untested.

**Motivation:**
<!-- What inspired you to submit this pull request? -->

**Additional Notes:**
<!-- Anything else we should know when reviewing? -->

**How to test the change?**
<!--
Describe here how the change can be validated.
You are strongly encouraged to provide automated tests for this PR (unit or integration).
If this change cannot be feasibly tested, please explain why,
unless the change does not modify code (e.g. only modifies docs, comments).
-->

The change is in test suite only.

**For Datadog employees:**
- [ ] If this PR touches code that signs or publishes builds or packages, or handles
credentials of any kind, I've requested a review from `@DataDog/security-design-and-guidance`.
- [ ] This PR doesn't touch any of that.

Unsure? Have a question? Request a review!
