### PR TITLE
Fix OpenTelemetry internal loading

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -119,3 +119,7 @@ end
 gem 'docile', '~> 1.3.5' if RUBY_VERSION < '2.5'
 gem 'ffi', '~> 1.12.2' if RUBY_VERSION < '2.3'
 gem 'msgpack', '~> 1.3.3' if RUBY_VERSION < '2.4'
+
+gem "opentelemetry-sdk", "~> 1.2"
+gem "opentelemetry-exporter-otlp", "~> 0.24"
+gem "opentelemetry-instrumentation-all", "~> 0.39"

--- a/Gemfile
+++ b/Gemfile
@@ -119,7 +119,3 @@ end
 gem 'docile', '~> 1.3.5' if RUBY_VERSION < '2.5'
 gem 'ffi', '~> 1.12.2' if RUBY_VERSION < '2.3'
 gem 'msgpack', '~> 1.3.3' if RUBY_VERSION < '2.4'
-
-gem "opentelemetry-sdk", "~> 1.2"
-gem "opentelemetry-exporter-otlp", "~> 0.24"
-gem "opentelemetry-instrumentation-all", "~> 0.39"

--- a/lib/datadog/opentelemetry.rb
+++ b/lib/datadog/opentelemetry.rb
@@ -8,7 +8,10 @@
 # This file activates the integrations of all OpenTelemetry
 # components supported by Datadog.
 
+# Load Tracing
 require_relative 'tracing'
+require_relative 'tracing/contrib'
+
 require_relative 'opentelemetry/api/context'
 
 # DEV: Should this be a Contrib integration, that depends on the `opentelemetry-sdk`

--- a/lib/datadog/opentelemetry/sdk/propagator.rb
+++ b/lib/datadog/opentelemetry/sdk/propagator.rb
@@ -29,7 +29,8 @@ module Datadog
           carrier, context: ::OpenTelemetry::Context.current,
           getter: ::OpenTelemetry::Context::Propagation.text_map_getter
         )
-          unless getter == ::OpenTelemetry::Context::Propagation.text_map_getter
+          if getter != ::OpenTelemetry::Common::Propagation.text_map_getter &&
+            getter != ::OpenTelemetry::Common::Propagation.rack_env_getter
             Datadog.logger.error(
               "Custom getter #{getter} is not supported. Please inform the `ddtrace` team at " \
             ' https://github.com/DataDog/dd-trace-rb of your use case so we can best support you. Using the default ' \

--- a/lib/datadog/opentelemetry/sdk/propagator.rb
+++ b/lib/datadog/opentelemetry/sdk/propagator.rb
@@ -30,7 +30,7 @@ module Datadog
           getter: ::OpenTelemetry::Context::Propagation.text_map_getter
         )
           if getter != ::OpenTelemetry::Context::Propagation.text_map_getter &&
-            getter != ::OpenTelemetry::Common::Propagation.rack_env_getter
+              getter != ::OpenTelemetry::Common::Propagation.rack_env_getter
             Datadog.logger.error(
               "Custom getter #{getter} is not supported. Please inform the `ddtrace` team at " \
             ' https://github.com/DataDog/dd-trace-rb of your use case so we can best support you. Using the default ' \

--- a/lib/datadog/opentelemetry/sdk/propagator.rb
+++ b/lib/datadog/opentelemetry/sdk/propagator.rb
@@ -31,7 +31,7 @@ module Datadog
         )
           unless getter == ::OpenTelemetry::Context::Propagation.text_map_getter
             Datadog.logger.error(
-              'Custom getter is not supported. Please inform the `ddtrace` team at ' \
+              "Custom getter #{getter} is not supported. Please inform the `ddtrace` team at " \
             ' https://github.com/DataDog/dd-trace-rb of your use case so we can best support you. Using the default ' \
             'OpenTelemetry::Context::Propagation.text_map_getter as a fallback getter.'
             )

--- a/lib/datadog/opentelemetry/sdk/propagator.rb
+++ b/lib/datadog/opentelemetry/sdk/propagator.rb
@@ -29,7 +29,7 @@ module Datadog
           carrier, context: ::OpenTelemetry::Context.current,
           getter: ::OpenTelemetry::Context::Propagation.text_map_getter
         )
-          if getter != ::OpenTelemetry::Common::Propagation.text_map_getter &&
+          if getter != ::OpenTelemetry::Context::Propagation.text_map_getter &&
             getter != ::OpenTelemetry::Common::Propagation.rack_env_getter
             Datadog.logger.error(
               "Custom getter #{getter} is not supported. Please inform the `ddtrace` team at " \

--- a/lib/datadog/tracing/contrib/http/distributed/fetcher.rb
+++ b/lib/datadog/tracing/contrib/http/distributed/fetcher.rb
@@ -13,8 +13,8 @@ module Datadog
           #
           # In case both variants are present, the verbatim match will be used.
           class Fetcher < Tracing::Distributed::Fetcher
-            # DEV: Should we try to parse both verbatim an Rack-formatted headers,
-            # DEV: given Rack-formatted is the most common format in Ruby?
+            # @param [String] name the header name
+            # @return [String, nil] the header value or nil if not found
             def [](name)
               # Try to fetch with the plain key
               value = super(name)

--- a/sig/datadog/tracing/contrib/http/distributed/fetcher.rbs
+++ b/sig/datadog/tracing/contrib/http/distributed/fetcher.rbs
@@ -4,7 +4,7 @@ module Datadog
       module HTTP
         module Distributed
           class Fetcher < Tracing::Distributed::Fetcher
-            def []: (untyped name) -> untyped
+            def []: (String name) -> (String | nil)
           end
         end
       end


### PR DESCRIPTION
<!--
Check out the
https://github.com/DataDog/dd-trace-rb/blob/master/docs/DevelopmentGuide.md
for guidance on how to set up your development environment,
run the test suite, write new integrations, and more.
-->


This PR fixes two issues:
* When loading `datadog/opentelemetry` before `ddtrace`, `tracing/contrib` files are not loaded.
* There are two default OpenTelemetry propagation getters, `text_map_getter` and `rack_env_getter`, but we only supported `text_map_getter` before. All our propagation code works correctly with `rack_env_getter`, so we allow it during configuration.

<!--
(If this PR is for 1.x, please delete this section)
A public facing description that will go into the [upgrade guide](https://github.com/DataDog/dd-trace-rb/blob/master/docs/UpgradeGuide.md) for this change.
We already know what the PR does (from the PR title),
but users should know either:
* A migration path for this change. In other words, how to continue using their application without behavior changes
in 2.0 (e.g. environment variable 'X' renamed to 'Y').
* That there's no alternative; we completely dropped support for this feature.
-->

**Motivation:**

These two issues were found during the setup of https://github.com/DataDog/opentelemetry-demo/pull/42/files#diff-6f62dcc2d3fa2ec6fa2c3529d3d9357ae69c771fca911e87e2e982a45b50fa71

**Additional Notes:**
<!-- Anything else we should know when reviewing? -->

**How to test the change?**
<!--
Describe here how the change can be validated.
You are strongly encouraged to provide automated tests for this PR (unit or integration).
If this change cannot be feasibly tested, please explain why,
unless the change does not modify code (e.g. only modifies docs, comments).
-->

**For Datadog employees:**
- [ ] If this PR touches code that signs or publishes builds or packages, or handles
credentials of any kind, I've requested a review from `@DataDog/security-design-and-guidance`.
- [ ] This PR doesn't touch any of that.

Unsure? Have a question? Request a review!
