### PR TITLE
`Sinatra` :Remove deprecated constants

### DIFF
--- a/lib/datadog/tracing/contrib/sinatra/ext.rb
+++ b/lib/datadog/tracing/contrib/sinatra/ext.rb
@@ -23,12 +23,6 @@ module Datadog
           TAG_SCRIPT_NAME = 'sinatra.script_name'
           TAG_TEMPLATE_ENGINE = 'sinatra.template_engine'
           TAG_TEMPLATE_NAME = 'sinatra.template_name'
-
-          # === Deprecated: To be removed ===
-          RACK_ENV_REQUEST_SPAN = 'datadog.sinatra_request_span'
-          RACK_ENV_MIDDLEWARE_START_TIME = 'datadog.sinatra_middleware_start_time'
-          RACK_ENV_MIDDLEWARE_TRACED = 'datadog.sinatra_middleware_traced'
-          # === Deprecated: To be removed ===
         end
       end
     end

--- a/sig/datadog/tracing/contrib/sinatra/ext.rbs
+++ b/sig/datadog/tracing/contrib/sinatra/ext.rbs
@@ -34,11 +34,6 @@ module Datadog
           TAG_TEMPLATE_ENGINE: "sinatra.template_engine"
 
           TAG_TEMPLATE_NAME: "sinatra.template_name"
-          RACK_ENV_REQUEST_SPAN: "datadog.sinatra_request_span"
-
-          RACK_ENV_MIDDLEWARE_START_TIME: "datadog.sinatra_middleware_start_time"
-
-          RACK_ENV_MIDDLEWARE_TRACED: "datadog.sinatra_middleware_traced"
         end
       end
     end


### PR DESCRIPTION

**2.0 Upgrade Guide notes**

🚨 Remove following constants

```ruby
Datadog::Tracing::Contrib::Sinatra::Ext::RACK_ENV_REQUEST_SPAN
Datadog::Tracing::Contrib::Sinatra::Ext::RACK_ENV_MIDDLEWARE_START_TIME
Datadog::Tracing::Contrib::Sinatra::Ext::RACK_ENV_MIDDLEWARE_TRACED
```