### PR TITLE
`Sidekiq` : Remove worker specific configuration

### DIFF
--- a/lib/datadog/tracing/contrib/sidekiq/server_tracer.rb
+++ b/lib/datadog/tracing/contrib/sidekiq/server_tracer.rb
@@ -18,22 +18,21 @@ module Datadog
           def initialize(options = {})
             @sidekiq_service = options[:service_name] || configuration[:service_name]
             @on_error = options[:on_error] || configuration[:on_error]
+            @distributed_tracing = options[:distributed_tracing] || configuration[:distributed_tracing]
+            @quantize = options[:quantize] || configuration[:quantize]
           end
 
           def call(worker, job, queue)
             resource = job_resource(job)
 
-            if configuration[:distributed_tracing]
+            if @distributed_tracing
               trace_digest = propagation.extract(job)
               Datadog::Tracing.continue_trace!(trace_digest)
             end
 
-            service = worker_config(resource, :service_name) || @sidekiq_service
-            quantize = worker_config(resource, :quantize) || configuration[:quantize]
-
             Datadog::Tracing.trace(
               Ext::SPAN_JOB,
-              service: service,
+              service: @sidekiq_service,
               type: Datadog::Tracing::Metadata::Ext::AppTypes::TYPE_WORKER,
               on_error: @on_error
             ) do |span|
@@ -65,7 +64,9 @@ module Datadog
               span.set_tag(Ext::TAG_JOB_DELAY, 1000.0 * (Time.now.utc.to_f - job['enqueued_at'].to_f))
 
               args = job['args']
-              span.set_tag(Ext::TAG_JOB_ARGS, quantize_args(quantize, args)) if args && !args.empty?
+              if args && !args.empty?
+                span.set_tag(Ext::TAG_JOB_ARGS, Contrib::Utils::Quantization::Hash.format(args, (@quantize[:args] || {})))
+              end
 
               yield
             end
@@ -77,28 +78,8 @@ module Datadog
             @propagation ||= Contrib::Sidekiq::Distributed::Propagation.new
           end
 
-          def quantize_args(quantize, args)
-            quantize_options = quantize && quantize[:args]
-            quantize_options ||= {}
-
-            Contrib::Utils::Quantization::Hash.format(args, quantize_options)
-          end
-
           def configuration
             Datadog.configuration.tracing[:sidekiq]
-          end
-
-          # DEV-2.0: Is this still being used? If not, we should remove it
-          # as this adds brittleness and complexity to this integration.
-          def worker_config(resource, key)
-            # Try to get the Ruby class from the resource name.
-            worker_klass = begin
-              Object.const_get(resource)
-            rescue NameError
-              nil
-            end
-
-            worker_klass.datadog_tracer_config[key] if worker_klass.respond_to?(:datadog_tracer_config)
           end
         end
       end

--- a/spec/datadog/tracing/contrib/sidekiq/server_tracer_spec.rb
+++ b/spec/datadog/tracing/contrib/sidekiq/server_tracer_spec.rb
@@ -12,7 +12,7 @@ RSpec.describe 'Server tracer' do
   before do
     Sidekiq::Testing.server_middleware.clear
     Sidekiq::Testing.server_middleware do |chain|
-      chain.add(Datadog::Tracing::Contrib::Sidekiq::ServerTracer)
+      chain.add(Datadog::Tracing::Contrib::Sidekiq::ServerTracer, sidekiq_options)
     end
   end
 
@@ -75,8 +75,6 @@ RSpec.describe 'Server tracer' do
 
   context 'with custom job' do
     before do
-      allow(Datadog.configuration.tracing).to receive(:[]).with(:sidekiq).and_return(sidekiq_options)
-
       stub_const(
         'CustomWorker',
         Class.new do


### PR DESCRIPTION
**2.0 Upgrade Guide notes**

🚨 Remove Sidekiq worker specific configuration

Defining `datadog_tracer_config` on Sidekiq worker is never documented and publicly supported. Hence removing the code.