### PR TITLE
Remove `use` alias for `instrument`

### DIFF
--- a/gemfiles/ruby_2.5_graphql_1.12.gemfile.lock
+++ b/gemfiles/ruby_2.5_graphql_1.12.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    ddtrace (1.19.0)
+    ddtrace (1.20.0)
       base64
       debase-ruby_core_source (= 3.3.1)
       libdatadog (~> 5.0.0.1.0)

--- a/gemfiles/ruby_2.6_graphql_1.12.gemfile.lock
+++ b/gemfiles/ruby_2.6_graphql_1.12.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    ddtrace (1.19.0)
+    ddtrace (1.20.0)
       base64
       debase-ruby_core_source (= 3.3.1)
       libdatadog (~> 5.0.0.1.0)

--- a/gemfiles/ruby_2.7_graphql_1.12.gemfile.lock
+++ b/gemfiles/ruby_2.7_graphql_1.12.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    ddtrace (1.19.0)
+    ddtrace (1.20.0)
       base64
       debase-ruby_core_source (= 3.3.1)
       libdatadog (~> 5.0.0.1.0)

--- a/gemfiles/ruby_3.0_graphql_1.12.gemfile.lock
+++ b/gemfiles/ruby_3.0_graphql_1.12.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    ddtrace (1.19.0)
+    ddtrace (1.20.0)
       base64
       debase-ruby_core_source (= 3.3.1)
       libdatadog (~> 5.0.0.1.0)

--- a/gemfiles/ruby_3.0_rails61_trilogy.gemfile.lock
+++ b/gemfiles/ruby_3.0_rails61_trilogy.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    ddtrace (1.19.0)
+    ddtrace (1.20.0)
       base64
       debase-ruby_core_source (= 3.3.1)
       libdatadog (~> 5.0.0.1.0)

--- a/gemfiles/ruby_3.1_graphql_1.12.gemfile.lock
+++ b/gemfiles/ruby_3.1_graphql_1.12.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    ddtrace (1.19.0)
+    ddtrace (1.20.0)
       base64
       debase-ruby_core_source (= 3.3.1)
       libdatadog (~> 5.0.0.1.0)

--- a/gemfiles/ruby_3.1_rails61_trilogy.gemfile.lock
+++ b/gemfiles/ruby_3.1_rails61_trilogy.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    ddtrace (1.19.0)
+    ddtrace (1.20.0)
       base64
       debase-ruby_core_source (= 3.3.1)
       libdatadog (~> 5.0.0.1.0)

--- a/gemfiles/ruby_3.2_graphql_1.12.gemfile.lock
+++ b/gemfiles/ruby_3.2_graphql_1.12.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    ddtrace (1.19.0)
+    ddtrace (1.20.0)
       base64
       debase-ruby_core_source (= 3.3.1)
       libdatadog (~> 5.0.0.1.0)

--- a/gemfiles/ruby_3.2_rails61_trilogy.gemfile.lock
+++ b/gemfiles/ruby_3.2_rails61_trilogy.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    ddtrace (1.19.0)
+    ddtrace (1.20.0)
       base64
       debase-ruby_core_source (= 3.3.1)
       libdatadog (~> 5.0.0.1.0)

--- a/lib/datadog/tracing/contrib/extensions.rb
+++ b/lib/datadog/tracing/contrib/extensions.rb
@@ -170,9 +170,6 @@ module Datadog
               integration
             end
 
-            # TODO: Deprecate in the next major version, as `instrument` better describes this method's purpose
-            alias_method :use, :instrument
-
             # For the provided `integration_name`, resolves a matching configuration
             # for the provided integration from an integration-specific `key`.
             #


### PR DESCRIPTION
**2.0 Upgrade Guide notes**

🚨 Breaking change: Remove `use` method for configuration, replace with `instrument`. 

For example

```ruby
Datadog.configure do |c|
  c.tracing.use :mysql2
end
```
to
```ruby
Datadog.configure do |c|
  c.tracing.instrument :mysql2
end
```