### PR TITLE
Remove `client_ip` disabled env

### DIFF
--- a/lib/datadog/tracing/configuration/ext.rb
+++ b/lib/datadog/tracing/configuration/ext.rb
@@ -91,7 +91,6 @@ module Datadog
         # @public_api
         module ClientIp
           ENV_ENABLED = 'DD_TRACE_CLIENT_IP_ENABLED'
-          ENV_DISABLED = 'DD_TRACE_CLIENT_IP_HEADER_DISABLED' # TODO: deprecated, remove later
           ENV_HEADER_NAME = 'DD_TRACE_CLIENT_IP_HEADER'
         end
       end

--- a/lib/datadog/tracing/configuration/settings.rb
+++ b/lib/datadog/tracing/configuration/settings.rb
@@ -383,30 +383,14 @@ module Datadog
                 # Whether client IP collection is enabled. When enabled client IPs from HTTP requests will
                 #   be reported in traces.
                 #
-                # Usage of the DD_TRACE_CLIENT_IP_HEADER_DISABLED environment variable is deprecated.
-                #
                 # @see https://docs.datadoghq.com/tracing/configure_data_security#configuring-a-client-ip-header
                 #
                 # @default `DD_TRACE_CLIENT_IP_ENABLED` environment variable, otherwise `false`.
                 # @return [Boolean]
                 option :enabled do |o|
                   o.type :bool
-                  o.default do
-                    disabled = Core::Environment::VariableHelpers.env_to_bool(Tracing::Configuration::Ext::ClientIp::ENV_DISABLED)
-
-                    enabled = if disabled.nil?
-                                false
-                              else
-                                Datadog::Core.log_deprecation do
-                                  "#{Tracing::Configuration::Ext::ClientIp::ENV_DISABLED} environment variable is deprecated, use #{Tracing::Configuration::Ext::ClientIp::ENV_ENABLED} instead."
-                                end
-
-                                !disabled
-                              end
-
-                    # ENABLED env var takes precedence over deprecated DISABLED
-                    Core::Environment::VariableHelpers.env_to_bool(Tracing::Configuration::Ext::ClientIp::ENV_ENABLED, enabled)
-                  end
+                  o.env Tracing::Configuration::Ext::ClientIp::ENV_ENABLED
+                  o.default false
                 end
 
                 # An optional name of a custom header to resolve the client IP from.

--- a/spec/datadog/tracing/configuration/settings_spec.rb
+++ b/spec/datadog/tracing/configuration/settings_spec.rb
@@ -824,5 +824,31 @@ RSpec.describe Datadog::Tracing::Configuration::Settings do
           .to(true)
       end
     end
+
+    describe '#client_ip.enabled' do
+      context 'default' do
+        it do
+          expect(settings.tracing.client_ip.enabled).to eq(false)
+        end
+      end
+
+      {
+        'true' => true,
+        '1' => true,
+        'false' => false
+      }.each do |env, value|
+        context "when ENV['DD_TRACE_CLIENT_IP_ENABLED'] is '#{env}'" do
+          around do |example|
+            ClimateControl.modify('DD_TRACE_CLIENT_IP_ENABLED' => env) do
+              example.run
+            end
+          end
+
+          it do
+            expect(settings.tracing.client_ip.enabled).to eq(value)
+          end
+        end
+      end
+    end
   end
 end


### PR DESCRIPTION
**2.0 Upgrade Guide notes**

🚨 Breaking change: Configuration with `ENV['DD_TRACE_CLIENT_IP_HEADER_DISABLED']` is removed, use `ENV['DD_TRACE_CLIENT_IP_ENABLED']` instead. 

