### PR TITLE
HTTP adapter renamed to :http

### DIFF
--- a/lib/datadog/core/configuration/ext.rb
+++ b/lib/datadog/core/configuration/ext.rb
@@ -30,7 +30,7 @@ module Datadog
           ENV_DEFAULT_TIMEOUT_SECONDS = 'DD_TRACE_AGENT_TIMEOUT_SECONDS'
 
           module HTTP
-            ADAPTER = :net_http # DEV: Rename to simply `:http`, as Net::HTTP is an implementation detail.
+            ADAPTER = :http
             DEFAULT_HOST = '127.0.0.1'
             DEFAULT_PORT = 8126
             DEFAULT_USE_SSL = false

--- a/sig/datadog/core/transport/ext.rbs
+++ b/sig/datadog/core/transport/ext.rbs
@@ -3,7 +3,7 @@ module Datadog
     module Transport
       module Ext
         module HTTP
-          ADAPTER: :net_http
+          ADAPTER: :http
 
           DEFAULT_HOST: "127.0.0.1"
 

--- a/spec/datadog/core/configuration/agent_settings_resolver_spec.rb
+++ b/spec/datadog/core/configuration/agent_settings_resolver_spec.rb
@@ -27,7 +27,7 @@ RSpec.describe Datadog::Core::Configuration::AgentSettingsResolver do
     }
   end
 
-  let(:adapter) { :net_http }
+  let(:adapter) { :http }
   let(:hostname) { '127.0.0.1' }
   let(:port) { 8126 }
   let(:uds_path) { nil }
@@ -171,7 +171,7 @@ RSpec.describe Datadog::Core::Configuration::AgentSettingsResolver do
           let(:with_agent_host) { 'custom-hostname' }
 
           it 'prioritizes the http configuration' do
-            expect(resolver).to have_attributes(hostname: 'custom-hostname', adapter: :net_http)
+            expect(resolver).to have_attributes(hostname: 'custom-hostname', adapter: :http)
           end
 
           it 'logs a warning including the uds path' do
@@ -187,7 +187,7 @@ RSpec.describe Datadog::Core::Configuration::AgentSettingsResolver do
 
           context 'when there is no port specified' do
             it 'prioritizes the http configuration and uses the default port' do
-              expect(resolver).to have_attributes(port: 8126, hostname: 'custom-hostname', adapter: :net_http)
+              expect(resolver).to have_attributes(port: 8126, hostname: 'custom-hostname', adapter: :http)
             end
 
             it 'logs a warning including the hostname and default port' do
@@ -205,7 +205,7 @@ RSpec.describe Datadog::Core::Configuration::AgentSettingsResolver do
             let(:with_agent_port) { 1234 }
 
             it 'prioritizes the http configuration and uses the specified port' do
-              expect(resolver).to have_attributes(port: 1234, hostname: 'custom-hostname', adapter: :net_http)
+              expect(resolver).to have_attributes(port: 1234, hostname: 'custom-hostname', adapter: :http)
             end
 
             it 'logs a warning including the hostname and port' do
@@ -224,7 +224,7 @@ RSpec.describe Datadog::Core::Configuration::AgentSettingsResolver do
           let(:with_agent_port) { 5678 }
 
           it 'prioritizes the http configuration' do
-            expect(resolver).to have_attributes(port: 5678, adapter: :net_http)
+            expect(resolver).to have_attributes(port: 5678, adapter: :http)
           end
 
           it 'logs a warning including the uds path' do
@@ -240,7 +240,7 @@ RSpec.describe Datadog::Core::Configuration::AgentSettingsResolver do
 
           context 'when there is no hostname specified' do
             it 'prioritizes the http configuration and uses the default hostname' do
-              expect(resolver).to have_attributes(port: 5678, hostname: '127.0.0.1', adapter: :net_http)
+              expect(resolver).to have_attributes(port: 5678, hostname: '127.0.0.1', adapter: :http)
             end
 
             it 'logs a warning including the default hostname and port' do
@@ -258,7 +258,7 @@ RSpec.describe Datadog::Core::Configuration::AgentSettingsResolver do
             let(:with_agent_host) { 'custom-hostname' }
 
             it 'prioritizes the http configuration and uses the specified hostname' do
-              expect(resolver).to have_attributes(port: 5678, hostname: 'custom-hostname', adapter: :net_http)
+              expect(resolver).to have_attributes(port: 5678, hostname: 'custom-hostname', adapter: :http)
             end
 
             it 'logs a warning including the hostname and port' do

--- a/spec/datadog/tracing/contrib/elasticsearch/patcher_spec.rb
+++ b/spec/datadog/tracing/contrib/elasticsearch/patcher_spec.rb
@@ -14,7 +14,7 @@ require 'datadog/tracing/contrib/elasticsearch/support/client'
 RSpec.describe Datadog::Tracing::Contrib::Elasticsearch::Patcher do
   include_context 'Elasticsearch client'
 
-  let(:client) { Elasticsearch::Client.new(url: server, adapter: :net_http) }
+  let(:client) { Elasticsearch::Client.new(url: server, adapter: :http) }
   let(:configuration_options) { {} }
 
   before do

--- a/spec/datadog/tracing/contrib/elasticsearch/transport_spec.rb
+++ b/spec/datadog/tracing/contrib/elasticsearch/transport_spec.rb
@@ -29,7 +29,7 @@ RSpec.describe 'Elasticsearch::Transport::Client tracing' do
   let(:port) { ENV.fetch('TEST_ELASTICSEARCH_PORT', '1234').to_i }
   let(:server) { "http://#{host}:#{port}" }
 
-  let(:client) { Elasticsearch::Client.new(url: server, adapter: :net_http) }
+  let(:client) { Elasticsearch::Client.new(url: server, adapter: :http) }
   let(:configuration_options) { {} }
 
   before do

--- a/spec/datadog/tracing/contrib/support/tracer_helpers.rb
+++ b/spec/datadog/tracing/contrib/support/tracer_helpers.rb
@@ -104,7 +104,7 @@ module Contrib
           if tracer.respond_to?(:writer) && tracer.writer.transport.client.api.adapter.respond_to?(:hostname) && # rubocop:disable Style/SoleNestedConditional
               tracer.writer.transport.client.api.adapter.hostname == agent_host
             transport_options = {
-              adapter: :net_http,
+              adapter: :http,
               hostname: agent_host,
               port: agent_port,
               timeout: 30

--- a/spec/datadog/tracing/transport/http/benchmark_spec.rb
+++ b/spec/datadog/tracing/transport/http/benchmark_spec.rb
@@ -11,7 +11,7 @@ RSpec.describe 'Transport::HTTP benchmarks' do
 
   describe '#send' do
     let!(:default_transport) { Datadog::Tracing::Transport::HTTP.default }
-    let!(:net_transport) { Datadog::Tracing::Transport::HTTP.default { |t| t.adapter :net_http } }
+    let!(:net_transport) { Datadog::Tracing::Transport::HTTP.default { |t| t.adapter :http } }
     let!(:unix_transport) { Datadog::Tracing::Transport::HTTP.default { |t| t.adapter :unix } }
     let!(:test_transport) { Datadog::Tracing::Transport::HTTP.default { |t| t.adapter :test } }
 

--- a/spec/datadog/tracing/transport/http_spec.rb
+++ b/spec/datadog/tracing/transport/http_spec.rb
@@ -53,7 +53,7 @@ RSpec.describe Datadog::Tracing::Transport::HTTP do
         expect(api.headers).to include(described_class.default_headers)
 
         case env_agent_settings.adapter
-        when :net_http
+        when :http
           expect(api.adapter).to be_a_kind_of(Datadog::Core::Transport::HTTP::Adapters::Net)
           expect(api.adapter.hostname).to eq(env_agent_settings.hostname)
           expect(api.adapter.port).to eq(env_agent_settings.port)
@@ -72,7 +72,7 @@ RSpec.describe Datadog::Tracing::Transport::HTTP do
 
       let(:options) { {} }
 
-      let(:adapter) { :net_http }
+      let(:adapter) { :http }
       let(:ssl) { nil }
       let(:hostname) { nil }
       let(:port) { nil }
@@ -183,6 +183,6 @@ RSpec.describe Datadog::Tracing::Transport::HTTP do
   describe '.default_adapter' do
     subject(:default_adapter) { described_class.default_adapter }
 
-    it { is_expected.to be(:net_http) }
+    it { is_expected.to be(:http) }
   end
 end


### PR DESCRIPTION
<!--
Check out the
https://github.com/DataDog/dd-trace-rb/blob/master/docs/DevelopmentGuide.md
for guidance on how to set up your development environment,
run the test suite, write new integrations, and more.
-->

**2.0 Upgrade Guide notes**

In 1.x:
```ruby
c.tracing.transport_options = proc do |t|
  t.adapter :net_http
end
```

In 2.0:
```ruby
c.tracing.transport_options = proc do |t|
  t.adapter :http
end
```
<!--
(If this PR is for 1.x, please delete this section)
A public facing description that will go into the [upgrade guide](https://github.com/DataDog/dd-trace-rb/blob/master/docs/UpgradeGuide.md) for this change.
We already know what the PR does (from the PR title),
but users should know either:
* A migration path for this change. In other words, how to continue using their application without behavior changes
in 2.0 (e.g. environment variable 'X' renamed to 'Y').
* That there's no alternative; we completely dropped support for this feature.
-->


**Motivation:**

The fact that the HTTP transport currently uses `Net::HTTP` is an implementation detail.

**Additional Notes:**
<!-- Anything else we should know when reviewing? -->

**How to test the change?**
<!--
Describe here how the change can be validated.
You are strongly encouraged to provide automated tests for this PR (unit or integration).
If this change cannot be feasibly tested, please explain why,
unless the change does not modify code (e.g. only modifies docs, comments).
-->

**For Datadog employees:**
- [ ] If this PR touches code that signs or publishes builds or packages, or handles
credentials of any kind, I've requested a review from `@DataDog/security-design-and-guidance`.
- [ ] This PR doesn't touch any of that.

Unsure? Have a question? Request a review!
