### PR TITLE
Remove possibly inaccurate comment

### DIFF
--- a/lib/datadog/core/configuration/ext.rb
+++ b/lib/datadog/core/configuration/ext.rb
@@ -30,7 +30,7 @@ module Datadog
           ENV_DEFAULT_TIMEOUT_SECONDS = 'DD_TRACE_AGENT_TIMEOUT_SECONDS'
 
           module HTTP
-            ADAPTER = :net_http # DEV: Rename to simply `:http`, as Net::HTTP is an implementation detail.
+            ADAPTER = :net_http
             DEFAULT_HOST = '127.0.0.1'
             DEFAULT_PORT = 8126
             DEFAULT_USE_SSL = false


### PR DESCRIPTION
I don't have confidence that this comment I wrote in the past has an accurate recommendation anymore, so I'm removing it to avoid possibly inaccurate advice coming from it. 