### PR TITLE
Fix check workflow branches

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -1,10 +1,10 @@
 name: Check
 on:
   push:
-    branches: [ master ]
+    branches: [ '**' ]
   pull_request:
     # The branches below must be a subset of the branches above
-    branches: [ master ]
+    branches: [ '**' ]
 jobs:
   check:
     name: Check types

--- a/sig/datadog/core/configuration/ext.rbs
+++ b/sig/datadog/core/configuration/ext.rbs
@@ -17,6 +17,26 @@ module Datadog
         module Transport
           ENV_DEFAULT_HOST: "DD_AGENT_HOST"
         end
+
+        module Agent
+          ENV_DEFAULT_PORT: 'DD_TRACE_AGENT_PORT'
+          ENV_DEFAULT_URL: 'DD_TRACE_AGENT_URL'
+          ENV_DEFAULT_TIMEOUT_SECONDS: 'DD_TRACE_AGENT_TIMEOUT_SECONDS'
+
+          module HTTP
+            ADAPTER: :net_http
+            DEFAULT_HOST: '127.0.0.1'
+            DEFAULT_PORT: 8126
+            DEFAULT_USE_SSL: false
+            DEFAULT_TIMEOUT_SECONDS: 30
+          end
+
+          module UnixSocket
+            ADAPTER: :unix
+            DEFAULT_PATH: '/var/run/datadog/apm.socket'
+            DEFAULT_TIMEOUT_SECONDS: 1
+          end
+        end
       end
     end
   end


### PR DESCRIPTION
<!--
Check out the
https://github.com/DataDog/dd-trace-rb/blob/master/docs/DevelopmentGuide.md
for guidance on how to set up your development environment,
run the test suite, write new integrations, and more.
-->

**2.0 Upgrade Guide notes**
<!--
(If this PR is for 1.x, please delete this section)
A public facing description that will go into the [upgrade guide](https://github.com/DataDog/dd-trace-rb/blob/master/docs/UpgradeGuide.md) for this change.
We already know what the PR does (from the PR title),
but users should know either:
* A migration path for this change. In other words, how to continue using their application without behavior changes
in 2.0 (e.g. environment variable 'X' renamed to 'Y').
* That there's no alternative; we completely dropped support for this feature.
-->

**What does this PR do?**

Always run checks.

**Motivation:**

The workflow fails to run for PRs targeting 2.0, and x.y-stable branches. It should always run instead.

**Additional Notes:**

They're cheap enough. "Always" sounds like a good plan.

Forward-port of https://github.com/DataDog/dd-trace-rb/pull/3415

**How to test the change?**
<!--
Describe here how the change can be validated.
You are strongly encouraged to provide automated tests for this PR (unit or integration).
If this change cannot be feasibly tested, please explain why,
unless the change does not modify code (e.g. only modifies docs, comments).
-->

**For Datadog employees:**
- [ ] If this PR touches code that signs or publishes builds or packages, or handles
credentials of any kind, I've requested a review from `@DataDog/security-design-and-guidance`.
- [x] This PR doesn't touch any of that.

Unsure? Have a question? Request a review!
