### PR TITLE
Fix OpenTelemetry doc headings

### DIFF
--- a/docs/OpenTelemetry.md
+++ b/docs/OpenTelemetry.md
@@ -1,3 +1,5 @@
+# OpenTelemetry
+
 **ATTENTION**:
 
 ***OpenTelemetry support is currently "experimental". It may be subject to breaking changes between minor versions, and is not yet recommended for use in production or other sensitive environments.***
@@ -10,7 +12,7 @@ If you are interested in using this feature experimentally, please contact the d
 | ------------- | ---------------------------------------------------- | --------------- | ------------------- |
 | OpenTelemetry | https://github.com/open-telemetry/opentelemetry-ruby | 1.9.0+          | >= 1.1.0            |
 
-#### Configuring OpenTelemetry
+## Configuring OpenTelemetry
 
 1. Add the `ddtrace` gem to your Gemfile:
 
@@ -48,7 +50,7 @@ If you are interested in using this feature experimentally, please contact the d
 
    [Integration instrumentations](#integration-instrumentation) and OpenTelemetry [Automatic instrumentations](https://opentelemetry.io/docs/instrumentation/ruby/automatic/) are also supported.
 
-##### Limitations
+## Limitations
 
 There are a few limitations to OpenTelemetry Tracing when the APM integration is activated:
 
@@ -60,7 +62,7 @@ There are a few limitations to OpenTelemetry Tracing when the APM integration is
 | `OpenTelemetry.logger`                                                                                     | Special     | `OpenTelemetry.logger` is set to the same object as `Datadog.logger`.             | Configure through [Custom logging](#custom-logging). |   |
 | Trace/span [ID generators](https://opentelemetry.io/docs/reference/specification/trace/sdk/#id-generators) | Special     | ID generation is performed by `ddtrace`.                                          | N/A                                                  |   |
 
-##### Exporting OpenTelemetry-only traces
+## Exporting OpenTelemetry-only traces
 
 You can send OpenTelemetry traces directly to the Datadog agent (without `ddtrace`) by using [OTLP](https://open-telemetry.github.io/opentelemetry-ruby/opentelemetry-exporter-otlp/latest).
 Check out our documentation on [OTLP ingest in the Datadog Agent](https://docs.datadoghq.com/tracing/setup_overview/open_standards/#otlp-ingest-in-datadog-agent) for details.


### PR DESCRIPTION
<!--
Check out the
https://github.com/DataDog/dd-trace-rb/blob/master/docs/DevelopmentGuide.md
for guidance on how to set up your development environment,
run the test suite, write new integrations, and more.
-->

**What does this PR do?**
<!-- A brief description of the change being made with this pull request. -->

This PR fixes headings in the OpenTelemetry doc page.

**Motivation:**
<!-- What inspired you to submit this pull request? -->
I was looking through documentation and the headings on pages aren't always written consistently. This issue affects other pages also, this PR only tackles OpenTelemetry where I think the change is straightforward.


**How to test the change?**
<!--
Describe here how the change can be validated.
You are strongly encouraged to provide automated tests for this PR (unit or integration).
If this change cannot be feasibly tested, please explain why,
unless the change does not modify code (e.g. only modifies docs, comments).
-->
Render the markdown page to HTML and look at the headings' appearance.

**For Datadog employees:**
- [ ] If this PR touches code that signs or publishes builds or packages, or handles
credentials of any kind, I've requested a review from `@DataDog/security-design-and-guidance`.
- [x] This PR doesn't touch any of that.

Unsure? Have a question? Request a review!
