### PR TITLE
Remove obsolete rake tasks slated for removal in 2.0

### DIFF
--- a/tasks/appraisal.rake
+++ b/tasks/appraisal.rake
@@ -179,15 +179,3 @@ FORCE_BUNDLER_VERSION = {
   '3.1' => '2.3.26',
   '3.2' => '2.3.26',
 }.freeze
-
-# TODO: remove with 2.0
-task :install_appraisal_gemfiles do
-  warn 'This task has been removed, please use rake appraisal:install instead'
-  exit 1
-end
-
-# TODO: remove with 2.0
-task :update_appraisal_gemfiles do
-  warn 'This task has been removed, please use rake appraisal:update instead'
-  exit 1
-end


### PR DESCRIPTION
<!--
Check out the
https://github.com/DataDog/dd-trace-rb/blob/master/docs/DevelopmentGuide.md
for guidance on how to set up your development environment,
run the test suite, write new integrations, and more.
-->

**2.0 Upgrade Guide notes**
<!--
(If this PR is for 1.x, please delete this section)
A public facing description that will go into the [upgrade guide](https://github.com/DataDog/dd-trace-rb/blob/master/docs/UpgradeGuide.md) for this change.
We already know what the PR does (from the PR title),
but users should know either:
* A migration path for this change. In other words, how to continue using their application without behavior changes
in 2.0 (e.g. environment variable 'X' renamed to 'Y').
* That there's no alternative; we completely dropped support for this feature.
-->
The deprecated `:install_appraisal_gemfiles` and `:update_appraisal_gemfiles` are now removed.

**What does this PR do?**
This PR removes rake tasks that were marked to be removed in 2.0.
<!-- A brief description of the change being made with this pull request. -->

**Motivation:**
Just came across this looking at docker-compose configuration.
<!-- What inspired you to submit this pull request? -->

**Additional Notes:**
<!-- Anything else we should know when reviewing? -->

**How to test the change?**
<!--
Describe here how the change can be validated.
You are strongly encouraged to provide automated tests for this PR (unit or integration).
If this change cannot be feasibly tested, please explain why,
unless the change does not modify code (e.g. only modifies docs, comments).
-->

**For Datadog employees:**
- [ ] If this PR touches code that signs or publishes builds or packages, or handles
credentials of any kind, I've requested a review from `@DataDog/security-design-and-guidance`.
- [ ] This PR doesn't touch any of that.

Unsure? Have a question? Request a review!
