### PR TITLE
Rack: Fix missing active trace

### DIFF
--- a/lib/datadog/tracing/contrib/rack/middlewares.rb
+++ b/lib/datadog/tracing/contrib/rack/middlewares.rb
@@ -91,7 +91,11 @@ module Datadog
             # we must ensure that the span `resource` is set later
             request_span = Tracing.trace(Ext::SPAN_REQUEST, **trace_options)
             request_span.resource = nil
-            request_trace = Tracing.active_trace
+
+            # When tracing and distributed tracing are both disabled, `.active_trace` will be `nil`,
+            # Return a null object to continue operation
+            request_trace = Tracing.active_trace || TraceOperation.new
+
             env[Ext::RACK_ENV_REQUEST_SPAN] = request_span
 
             # Copy the original env, before the rest of the stack executes.

--- a/spec/datadog/tracing/contrib/rack/disabled_spec.rb
+++ b/spec/datadog/tracing/contrib/rack/disabled_spec.rb
@@ -15,6 +15,7 @@ RSpec.describe 'Rack integration tests' do
   end
 
   after do
+    Datadog.registry[:rack].reset_configuration!
     Datadog.configuration.reset!
   end
 

--- a/spec/datadog/tracing/contrib/rack/disabled_spec.rb
+++ b/spec/datadog/tracing/contrib/rack/disabled_spec.rb
@@ -1,0 +1,43 @@
+require 'datadog/tracing/contrib/support/spec_helper'
+require 'rack/test'
+require 'rack'
+require 'ddtrace'
+require 'datadog/tracing/contrib/rack/middlewares'
+
+RSpec.describe 'Rack integration tests' do
+  include Rack::Test::Methods
+
+  before do
+    Datadog.configure do |c|
+      c.tracing.enabled = false
+      c.tracing.instrument :rack, distributed_tracing: false
+    end
+  end
+
+  after do
+    Datadog.configuration.reset!
+  end
+
+  context 'for an application' do
+    let(:app) do
+      Rack::Builder.new do
+        use Datadog::Tracing::Contrib::Rack::TraceMiddleware
+        map '/success/' do
+          run(proc { |_env| [200, { 'Content-Type' => 'text/html' }, ['OK']] })
+        end
+      end.to_app
+    end
+
+    context 'with a basic route' do
+      describe 'GET request' do
+        it do
+          response = get 'success'
+
+          expect(response).to be_ok
+
+          expect(spans).to have(0).items
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
**What does this PR do?**

closes #3389 

When `tracing` and `distributed_tracing` both disabled, The reference of `Datadog::Tracing.active_trace` in rack 
instrumentation returns `nil`. 

Causing
```
NoMethodError: undefined method `resource_override?' for nil:NilClass
```