### PR TITLE
Minimize sampling API

### DIFF
--- a/lib/datadog/tracing/sampling/all_sampler.rb
+++ b/lib/datadog/tracing/sampling/all_sampler.rb
@@ -6,7 +6,6 @@ module Datadog
   module Tracing
     module Sampling
       # {Datadog::Tracing::Sampling::AllSampler} samples all the traces.
-      # @public_api
       class AllSampler < Sampler
         def sample?(_trace)
           true

--- a/lib/datadog/tracing/sampling/matcher.rb
+++ b/lib/datadog/tracing/sampling/matcher.rb
@@ -5,7 +5,6 @@ module Datadog
     module Sampling
       # Checks if a trace conforms to a matching criteria.
       # @abstract
-      # @public_api
       class Matcher
         # Returns `true` if the trace should conforms to this rule, `false` otherwise
         #
@@ -18,7 +17,6 @@ module Datadog
 
       # A {Datadog::Sampling::Matcher} that supports matching a trace by
       # trace name and/or service name.
-      # @public_api
       class SimpleMatcher < Matcher
         # Returns `true` for case equality (===) with any object
         MATCH_ALL = Class.new do
@@ -48,7 +46,6 @@ module Datadog
 
       # A {Datadog::Tracing::Sampling::Matcher} that allows for arbitrary trace matching
       # based on the return value of a provided block.
-      # @public_api
       class ProcMatcher < Matcher
         attr_reader :block
 

--- a/lib/datadog/tracing/sampling/priority_sampler.rb
+++ b/lib/datadog/tracing/sampling/priority_sampler.rb
@@ -9,7 +9,6 @@ module Datadog
   module Tracing
     module Sampling
       # {Datadog::Tracing::Sampling::PrioritySampler}
-      # @public_api
       class PrioritySampler
         # NOTE: We do not advise using a pre-sampler. It can save resources,
         # but pre-sampling at rates < 100% may result in partial traces, unless
@@ -22,10 +21,6 @@ module Datadog
         def initialize(opts = {})
           @pre_sampler = opts[:base_sampler] || AllSampler.new
           @priority_sampler = opts[:post_sampler] || RateByServiceSampler.new(decision: Sampling::Ext::Decision::AGENT_RATE)
-        end
-
-        def sample?(trace)
-          @pre_sampler.sample?(trace)
         end
 
         # DEV-2.0:We should get rid of this complicated interaction between @pre_sampler and @priority_sampler.

--- a/lib/datadog/tracing/sampling/rate_by_key_sampler.rb
+++ b/lib/datadog/tracing/sampling/rate_by_key_sampler.rb
@@ -5,7 +5,6 @@ module Datadog
   module Tracing
     module Sampling
       # Samples at different rates by key.
-      # @public_api
       class RateByKeySampler < Sampler
         attr_reader \
           :default_key
@@ -29,14 +28,6 @@ module Datadog
 
         def default_sampler
           @samplers[default_key]
-        end
-
-        def sample?(trace)
-          key = resolve(trace)
-
-          @mutex.synchronize do
-            @samplers.fetch(key, default_sampler).sample?(trace)
-          end
         end
 
         def sample!(trace)

--- a/lib/datadog/tracing/sampling/rate_by_service_sampler.rb
+++ b/lib/datadog/tracing/sampling/rate_by_service_sampler.rb
@@ -4,7 +4,6 @@ module Datadog
   module Tracing
     module Sampling
       # {Datadog::Tracing::Sampling::RateByServiceSampler} samples different services at different rates
-      # @public_api
       class RateByServiceSampler < RateByKeySampler
         DEFAULT_KEY = 'service:,env:'.freeze
 

--- a/lib/datadog/tracing/sampling/rate_limiter.rb
+++ b/lib/datadog/tracing/sampling/rate_limiter.rb
@@ -4,7 +4,6 @@ module Datadog
   module Tracing
     module Sampling
       # Checks for rate limiting on a resource.
-      # @public_api
       class RateLimiter
         # Checks if resource of specified size can be
         # conforms with the current limit.
@@ -26,7 +25,6 @@ module Datadog
       # for rate limiting.
       #
       # @see https://en.wikipedia.org/wiki/Token_bucket Token bucket
-      # @public_api
       class TokenBucket < RateLimiter
         attr_reader :rate, :max_tokens
 
@@ -169,7 +167,6 @@ module Datadog
 
       # {Datadog::Tracing::Sampling::RateLimiter} that accepts all resources,
       # with no limits.
-      # @public_api
       class UnlimitedLimiter < RateLimiter
         # @return [Boolean] always +true+
         def allow?(_)

--- a/lib/datadog/tracing/sampling/rate_sampler.rb
+++ b/lib/datadog/tracing/sampling/rate_sampler.rb
@@ -5,7 +5,6 @@ module Datadog
   module Tracing
     module Sampling
       # {Datadog::Tracing::Sampling::RateSampler} is based on a sample rate.
-      # @public_api
       class RateSampler < Sampler
         KNUTH_FACTOR = 1111111111111111111
 
@@ -42,7 +41,7 @@ module Datadog
         end
 
         def sample!(trace)
-          sampled = trace.sampled = sample?(trace)
+          sampled = sample?(trace)
 
           return false unless sampled
 

--- a/lib/datadog/tracing/sampling/rule.rb
+++ b/lib/datadog/tracing/sampling/rule.rb
@@ -7,7 +7,6 @@ module Datadog
       # Sampling rule that dictates if a trace matches
       # a specific criteria and what sampling strategy to
       # apply in case of a positive match.
-      # @public_api
       class Rule
         attr_reader :matcher, :sampler
 
@@ -32,9 +31,9 @@ module Datadog
           nil
         end
 
-        # (see Datadog::Tracing::Sampling::Sampler#sample?)
-        def sample?(trace)
-          @sampler.sample?(trace)
+        # (see Datadog::Tracing::Sampling::Sampler#sample!)
+        def sample!(trace)
+          @sampler.sample!(trace)
         end
 
         # (see Datadog::Tracing::Sampling::Sampler#sample_rate)
@@ -46,7 +45,6 @@ module Datadog
       # A {Datadog::Tracing::Sampling::Rule} that matches a trace based on
       # trace name and/or service name and
       # applies a fixed sampling to matching spans.
-      # @public_api
       class SimpleRule < Rule
         # @param name [String,Regexp,Proc] Matcher for case equality (===) with the trace name, defaults to always match
         # @param service [String,Regexp,Proc] Matcher for case equality (===) with the service name,

--- a/lib/datadog/tracing/sampling/rule_sampler.rb
+++ b/lib/datadog/tracing/sampling/rule_sampler.rb
@@ -10,7 +10,6 @@ module Datadog
       #
       # If a trace does not conform to any rules, a default
       # sampling strategy is applied.
-      # @public_api
       class RuleSampler
         attr_reader :rules, :rate_limiter, :default_sampler
 
@@ -77,16 +76,6 @@ module Datadog
           nil
         end
 
-        # /RuleSampler's components (it's rate limiter, for example) are
-        # not be guaranteed to be size-effect free.
-        # It is not possible to guarantee that a call to {#sample?} will
-        # return the same result as a successive call to {#sample!} with the same trace.
-        #
-        # Use {#sample!} instead
-        def sample?(_trace)
-          raise 'RuleSampler cannot be evaluated without side-effects'
-        end
-
         def sample!(trace)
           sampled = sample_trace(trace) do |t|
             @default_sampler.sample!(t).tap do
@@ -114,7 +103,7 @@ module Datadog
 
           return yield(trace) if rule.nil?
 
-          sampled = rule.sample?(trace)
+          sampled = rule.sample!(trace)
           sample_rate = rule.sample_rate(trace)
 
           set_priority(trace, sampled)

--- a/lib/datadog/tracing/sampling/sampler.rb
+++ b/lib/datadog/tracing/sampling/sampler.rb
@@ -3,19 +3,7 @@ module Datadog
     module Sampling
       # Interface for client-side trace sampling.
       # @abstract
-      # @public_api
       class Sampler
-        # Returns `true` if the provided trace should be kept.
-        # Otherwise, `false`.
-        #
-        # This method *must not* modify the `trace`.
-        #
-        # @param [Datadog::Tracing::TraceOperation] trace
-        # @return [Boolean] should this trace be kept?
-        def sample?(trace)
-          raise NotImplementedError, 'Samplers must implement the #sample? method'
-        end
-
         # Returns `true` if the provided trace should be kept.
         # Otherwise, `false`.
         #

--- a/lib/datadog/tracing/sampling/span/rule.rb
+++ b/lib/datadog/tracing/sampling/span/rule.rb
@@ -47,13 +47,14 @@ module Datadog
           #
           # This method modifies the `span` if it matches the provided matcher.
           #
+          # @param [Datadog::Tracing::TraceOperation] trace_op trace for the span to be sampled
           # @param [Datadog::Tracing::SpanOperation] span_op span to be sampled
           # @return [:kept,:rejected] should this span be sampled?
           # @return [:not_matched] span did not satisfy the matcher, no changes are made to the span
-          def sample!(span_op)
+          def sample!(trace_op, span_op)
             return :not_matched unless @matcher.match?(span_op)
 
-            if @sampler.sample?(span_op) && @rate_limiter.allow?(1)
+            if @rate_limiter.allow?(1) && @sampler.sample!(trace_op)
               span_op.set_metric(Span::Ext::TAG_MECHANISM, Sampling::Ext::Mechanism::SPAN_SAMPLING_RATE)
               span_op.set_metric(Span::Ext::TAG_RULE_RATE, @sample_rate)
               span_op.set_metric(Span::Ext::TAG_MAX_PER_SECOND, @rate_limit)

--- a/lib/datadog/tracing/sampling/span/sampler.rb
+++ b/lib/datadog/tracing/sampling/span/sampler.rb
@@ -54,7 +54,7 @@ module Datadog
 
             # Applies the first matching rule
             @rules.each do |rule|
-              decision = rule.sample!(span_op)
+              decision = rule.sample!(trace_op, span_op)
 
               next if decision == :not_matched # Iterate until we find a matching decision
 

--- a/spec/datadog/tracing/integration_spec.rb
+++ b/spec/datadog/tracing/integration_spec.rb
@@ -503,44 +503,6 @@ RSpec.describe 'Tracer integration tests' do
         end
       end
 
-      context 'by direct sampling' do
-        let(:custom_sampler) { no_sampler }
-
-        let(:no_sampler) do
-          Class.new do
-            def sample!(trace)
-              trace.reject!
-              trace.sampled = false
-            end
-          end.new
-        end
-
-        context 'with rule matching' do
-          context 'with a dropped span' do
-            let(:wait_for_flush) {} # No spans will be flushed with direct sampling drops
-
-            context 'by sampling rate' do
-              let(:rules) { [{ name: 'single.sampled_span', sample_rate: 0.0 }] }
-
-              it_behaves_like 'flushed no trace'
-            end
-
-            context 'by rate limiting' do
-              let(:rules) { [{ name: 'single.sampled_span', sample_rate: 1.0, max_per_second: 0 }] }
-
-              it_behaves_like 'flushed no trace'
-            end
-          end
-
-          context 'with a kept span' do
-            let(:rules) { [{ name: 'single.sampled_span', sample_rate: 1.0 }] }
-
-            it_behaves_like 'flushed complete trace', expected_span_count: 1
-            it_behaves_like 'set single span sampling tags'
-          end
-        end
-      end
-
       context 'ensures correct stats calculation in the agent' do
         it 'sets the Datadog-Client-Computed-Top-Level header to a non-empty value' do
           expect(WebMock)
@@ -786,7 +748,7 @@ RSpec.describe 'Tracer integration tests' do
       end
 
       let(:custom_sampler) do
-        instance_double(Datadog::Tracing::Sampling::Sampler, sample?: double, sample!: double, sample_rate: double)
+        instance_double(Datadog::Tracing::Sampling::Sampler, sample!: double, sample_rate: double)
       end
 
       context 'that accepts a span' do

--- a/spec/datadog/tracing/sampling/rate_sampler_spec.rb
+++ b/spec/datadog/tracing/sampling/rate_sampler_spec.rb
@@ -64,12 +64,13 @@ RSpec.describe Datadog::Tracing::Sampling::RateSampler do
       let(:expected_num_of_sampled_traces) { trace_count * sample_rate }
 
       it 'samples an appropriate proportion of span operations' do
-        traces.each do |trace|
+        sample = traces.map do |trace|
           sampled = sampler.sample!(trace)
           expect(trace.sample_rate).to eq(sample_rate) if sampled
+          sampled
         end
 
-        expect(traces.count(&:sampled?)).to be_within(expected_num_of_sampled_traces * 0.1)
+        expect(sample.count(&:itself)).to be_within(expected_num_of_sampled_traces * 0.1)
           .of(expected_num_of_sampled_traces)
       end
     end

--- a/spec/datadog/tracing/sampling/rule_sampler_spec.rb
+++ b/spec/datadog/tracing/sampling/rule_sampler_spec.rb
@@ -17,7 +17,6 @@ RSpec.describe Datadog::Tracing::Sampling::RuleSampler do
   let(:trace) { Datadog::Tracing::TraceOperation.new }
 
   before do
-    allow(default_sampler).to receive(:sample?).with(trace).and_return(nil)
     allow(rate_limiter).to receive(:effective_rate).and_return(effective_rate)
     allow(rate_limiter).to receive(:allow?).with(1).and_return(allow?)
   end
@@ -178,7 +177,7 @@ RSpec.describe Datadog::Tracing::Sampling::RuleSampler do
 
     before do
       allow(rule).to receive(:match?).with(trace).and_return(true)
-      allow(rule).to receive(:sample?).with(trace).and_return(sampled)
+      allow(rule).to receive(:sample!).with(trace).and_return(sampled)
       allow(rule).to receive(:sample_rate).with(trace).and_return(sample_rate)
     end
   end
@@ -285,12 +284,6 @@ RSpec.describe Datadog::Tracing::Sampling::RuleSampler do
         end
       end
     end
-  end
-
-  describe '#sample?' do
-    subject(:sample?) { rule_sampler.sample?(trace) }
-
-    it { expect { sample? }.to raise_error(StandardError, 'RuleSampler cannot be evaluated without side-effects') }
   end
 
   describe '#update' do

--- a/spec/datadog/tracing/sampling/rule_spec.rb
+++ b/spec/datadog/tracing/sampling/rule_spec.rb
@@ -49,13 +49,13 @@ RSpec.describe Datadog::Tracing::Sampling::Rule do
     end
   end
 
-  describe '#sample?' do
-    subject(:sample?) { rule.sample?(span_op) }
+  describe '#sample!' do
+    subject(:sample!) { rule.sample!(span_op) }
 
     let(:sample) { double }
 
     before do
-      allow(sampler).to receive(:sample?).with(span_op).and_return(sample)
+      allow(sampler).to receive(:sample!).with(span_op).and_return(sample)
     end
 
     it { is_expected.to be(sample) }

--- a/spec/datadog/tracing/sampling/span/rule_spec.rb
+++ b/spec/datadog/tracing/sampling/span/rule_spec.rb
@@ -8,6 +8,7 @@ RSpec.describe Datadog::Tracing::Sampling::Span::Rule do
   let(:rate_limit) { 0 }
 
   let(:span_op) { Datadog::Tracing::SpanOperation.new(span_name, service: span_service) }
+  let(:trace_op) { Datadog::Tracing::TraceOperation.new }
   let(:span_name) { 'operation.name' }
   let(:span_service) { '' }
 
@@ -25,7 +26,7 @@ RSpec.describe Datadog::Tracing::Sampling::Span::Rule do
   end
 
   describe '#sample!' do
-    subject(:sample!) { rule.sample!(span_op) }
+    subject(:sample!) { rule.sample!(trace_op, span_op) }
 
     shared_examples 'does not modify span' do
       it { expect { sample! }.to_not(change { span_op.send(:build_span).to_hash }) }


### PR DESCRIPTION
<!--
Check out the
https://github.com/DataDog/dd-trace-rb/blob/master/docs/DevelopmentGuide.md
for guidance on how to set up your development environment,
run the test suite, write new integrations, and more.
-->

**2.0 Upgrade Guide notes**

The following sampling classes have been removed from the public API:

```ruby
Datadog::Tracing::Sampling::AllSampler
Datadog::Tracing::Sampling::Matcher
Datadog::Tracing::Sampling::SimpleMatcher
Datadog::Tracing::Sampling::ProcMatcher
Datadog::Tracing::Sampling::PrioritySampler
Datadog::Tracing::Sampling::RateByKeySampler
Datadog::Tracing::Sampling::RateByServiceSampler
Datadog::Tracing::Sampling::RateLimiter
Datadog::Tracing::Sampling::TokenBucket
Datadog::Tracing::Sampling::UnlimitedLimiter
Datadog::Tracing::Sampling::RateSampler
Datadog::Tracing::Sampling::Rule
Datadog::Tracing::Sampling::SimpleRule
Datadog::Tracing::Sampling::RuleSampler
Datadog::Tracing::Sampling::Sampler
```

Most custom sampling can be accomplished with a combination of [Ingestion Controls](https://docs.datadoghq.com/tracing/trace_pipeline/ingestion_controls/) and [user-defined rules](https://docs.datadoghq.com/tracing/trace_pipeline/ingestion_mechanisms/?tab=ruby&code-lang=ruby#in-tracing-libraries-user-defined-rules). This is the preferred option, as it is more maintainable and auditable than custom sampling.

If you still need a custom sampler, its API has been simplified in 2.0. See https://github.com/DataDog/dd-trace-rb/blob/2.0/docs/GettingStarted.md#custom-sampling for the new detailed requirements of a custom sampler.



<!--
(If this PR is for 1.x, please delete this section)
A public facing description that will go into the [upgrade guide](https://github.com/DataDog/dd-trace-rb/blob/master/docs/UpgradeGuide.md) for this change.
We already know what the PR does (from the PR title),
but users should know either:
* A migration path for this change. In other words, how to continue using their application without behavior changes
in 2.0 (e.g. environment variable 'X' renamed to 'Y').
* That there's no alternative; we completely dropped support for this feature.
-->

<!-- A brief description of the change being made with this pull request. -->

**Motivation:**

We have made large improvements to sampling since 1.0.0 and plan to introduce new features and improvements in the near future.
The sampling changes introduced since 1.0.0 were hard to implement because almost all of the sampling classes are part of the public API. Moreover, large technical debt was introduced in order to keep the API stable while implementing such improvements. Thus, recent changes to the sampling logic have been very hard to implement correctly.

Since 1.0.0, we have introduced new ways to configure rule sampling, as well as post-ingestion sampling, which give users more maintainable options than using our custom sampling classes.

**How to test the change?**
There is no change in behaviour for `ddtrace`.
Changes to custom samplers are documented in our public docs.

**For Datadog employees:**
- [ ] If this PR touches code that signs or publishes builds or packages, or handles
credentials of any kind, I've requested a review from `@DataDog/security-design-and-guidance`.
- [x] This PR doesn't touch any of that.

Unsure? Have a question? Request a review!
