### PR TITLE
[CIVIS-8604] APM source code integration

### DIFF
--- a/lib/datadog/core/environment/git.rb
+++ b/lib/datadog/core/environment/git.rb
@@ -8,15 +8,13 @@ module Datadog
     module Environment
       # Retrieves git repository information from environment variables
       module Git
-        module_function
-
-        def git_repository_url
+        def self.git_repository_url
           return @git_repository_url if defined?(@git_repository_url)
 
           @git_repository_url = Utils::Url.filter_basic_auth(ENV[Datadog::Core::Git::Ext::ENV_REPOSITORY_URL])
         end
 
-        def git_commit_sha
+        def self.git_commit_sha
           return @git_commit_sha if defined?(@git_commit_sha)
 
           @git_commit_sha = ENV[Datadog::Core::Git::Ext::ENV_COMMIT_SHA]

--- a/lib/datadog/core/environment/git.rb
+++ b/lib/datadog/core/environment/git.rb
@@ -1,0 +1,27 @@
+# frozen_string_literal: true
+
+require_relative '../git/ext'
+require_relative '../utils/url'
+
+module Datadog
+  module Core
+    module Environment
+      # Retrieves garbage collection statistics
+      module Git
+        module_function
+
+        def git_repository_url
+          return @git_repository_url if defined?(@git_repository_url)
+
+          @git_repository_url = Utils::Url.filter_sensitive_info(ENV[Datadog::Core::Git::Ext::ENV_REPOSITORY_URL])
+        end
+
+        def git_commit_sha
+          return @git_commit_sha if defined?(@git_commit_sha)
+
+          @git_commit_sha = ENV[Datadog::Core::Git::Ext::ENV_COMMIT_SHA]
+        end
+      end
+    end
+  end
+end

--- a/lib/datadog/core/environment/git.rb
+++ b/lib/datadog/core/environment/git.rb
@@ -6,14 +6,14 @@ require_relative '../utils/url'
 module Datadog
   module Core
     module Environment
-      # Retrieves garbage collection statistics
+      # Retrieves git repository information from environment variables
       module Git
         module_function
 
         def git_repository_url
           return @git_repository_url if defined?(@git_repository_url)
 
-          @git_repository_url = Utils::Url.filter_sensitive_info(ENV[Datadog::Core::Git::Ext::ENV_REPOSITORY_URL])
+          @git_repository_url = Utils::Url.filter_basic_auth(ENV[Datadog::Core::Git::Ext::ENV_REPOSITORY_URL])
         end
 
         def git_commit_sha

--- a/lib/datadog/core/git/ext.rb
+++ b/lib/datadog/core/git/ext.rb
@@ -5,32 +5,11 @@ module Datadog
     module Git
       # Defines constants for Git tags
       module Ext
-        GIT_SHA_LENGTH = 40
-
-        TAG_BRANCH = 'git.branch'
-        TAG_REPOSITORY_URL = 'git.repository_url'
-        TAG_TAG = 'git.tag'
-
-        TAG_COMMIT_AUTHOR_DATE = 'git.commit.author.date'
-        TAG_COMMIT_AUTHOR_EMAIL = 'git.commit.author.email'
-        TAG_COMMIT_AUTHOR_NAME = 'git.commit.author.name'
-        TAG_COMMIT_COMMITTER_DATE = 'git.commit.committer.date'
-        TAG_COMMIT_COMMITTER_EMAIL = 'git.commit.committer.email'
-        TAG_COMMIT_COMMITTER_NAME = 'git.commit.committer.name'
-        TAG_COMMIT_MESSAGE = 'git.commit.message'
-        TAG_COMMIT_SHA = 'git.commit.sha'
+        TAG_REPOSITORY_URL = '_dd.git.repository_url'
+        TAG_COMMIT_SHA = '_dd.git.commit.sha'
 
         ENV_REPOSITORY_URL = 'DD_GIT_REPOSITORY_URL'
         ENV_COMMIT_SHA = 'DD_GIT_COMMIT_SHA'
-        ENV_BRANCH = 'DD_GIT_BRANCH'
-        ENV_TAG = 'DD_GIT_TAG'
-        ENV_COMMIT_MESSAGE = 'DD_GIT_COMMIT_MESSAGE'
-        ENV_COMMIT_AUTHOR_NAME = 'DD_GIT_COMMIT_AUTHOR_NAME'
-        ENV_COMMIT_AUTHOR_EMAIL = 'DD_GIT_COMMIT_AUTHOR_EMAIL'
-        ENV_COMMIT_AUTHOR_DATE = 'DD_GIT_COMMIT_AUTHOR_DATE'
-        ENV_COMMIT_COMMITTER_NAME = 'DD_GIT_COMMIT_COMMITTER_NAME'
-        ENV_COMMIT_COMMITTER_EMAIL = 'DD_GIT_COMMIT_COMMITTER_EMAIL'
-        ENV_COMMIT_COMMITTER_DATE = 'DD_GIT_COMMIT_COMMITTER_DATE'
       end
     end
   end

--- a/lib/datadog/core/utils/url.rb
+++ b/lib/datadog/core/utils/url.rb
@@ -1,0 +1,17 @@
+# frozen_string_literal: true
+
+module Datadog
+  module Core
+    module Utils
+      # Helpers class that provides methods to proces URLs
+      # such as filtering sensitive information.
+      module Url
+        def self.filter_sensitive_info(url)
+          return nil if url.nil?
+
+          url.gsub(%r{((https?|ssh)://)[^/]*@}, '\1')
+        end
+      end
+    end
+  end
+end

--- a/lib/datadog/core/utils/url.rb
+++ b/lib/datadog/core/utils/url.rb
@@ -1,15 +1,23 @@
 # frozen_string_literal: true
 
+require 'uri'
+
 module Datadog
   module Core
     module Utils
-      # Helpers class that provides methods to proces URLs
+      # Helpers class that provides methods to process URLs
       # such as filtering sensitive information.
       module Url
-        def self.filter_sensitive_info(url)
+        def self.filter_basic_auth(url)
           return nil if url.nil?
 
-          url.gsub(%r{((https?|ssh)://)[^/]*@}, '\1')
+          URI(url).tap do |u|
+            u.user = nil
+            u.password = nil
+          end.to_s
+        # Git scheme: git@github.com:DataDog/dd-trace-rb.git
+        rescue URI::InvalidURIError
+          url
         end
       end
     end

--- a/lib/datadog/profiling/ext.rb
+++ b/lib/datadog/profiling/ext.rb
@@ -23,6 +23,8 @@ module Datadog
           FORM_FIELD_TAG_RUNTIME_VERSION = 'runtime_version'
           FORM_FIELD_TAG_SERVICE = 'service'
           FORM_FIELD_TAG_VERSION = 'version'
+          FORM_FIELD_TAG_GIT_REPOSITORY_URL = 'git.repository_url'
+          FORM_FIELD_TAG_GIT_COMMIT_SHA = 'git.commit.sha'
 
           PPROF_DEFAULT_FILENAME = 'rubyprofile.pprof'
           CODE_PROVENANCE_FILENAME = 'code-provenance.json'

--- a/lib/datadog/profiling/ext.rb
+++ b/lib/datadog/profiling/ext.rb
@@ -23,8 +23,8 @@ module Datadog
           FORM_FIELD_TAG_RUNTIME_VERSION = 'runtime_version'
           FORM_FIELD_TAG_SERVICE = 'service'
           FORM_FIELD_TAG_VERSION = 'version'
-          FORM_FIELD_TAG_GIT_REPOSITORY_URL = 'git.repository_url'
-          FORM_FIELD_TAG_GIT_COMMIT_SHA = 'git.commit.sha'
+          TAG_GIT_REPOSITORY_URL = 'git.repository_url'
+          TAG_GIT_COMMIT_SHA = 'git.commit.sha'
 
           PPROF_DEFAULT_FILENAME = 'rubyprofile.pprof'
           CODE_PROVENANCE_FILENAME = 'code-provenance.json'

--- a/lib/datadog/profiling/tag_builder.rb
+++ b/lib/datadog/profiling/tag_builder.rb
@@ -2,14 +2,12 @@
 
 require_relative '../core/utils'
 require_relative '../core/environment/git'
-require_relative '../core/git/ext'
 
 module Datadog
   module Profiling
     # Builds a hash of default plus user tags to be included in a profile
     module TagBuilder
       include Datadog::Profiling::Ext::Transport::HTTP # Tag name constants
-      include Datadog::Core::Git::Ext # Git tags constants
 
       def self.call(
         settings:,
@@ -47,8 +45,8 @@ module Datadog
         tags[FORM_FIELD_TAG_ENV] = env if env
         tags[FORM_FIELD_TAG_SERVICE] = service if service
         tags[FORM_FIELD_TAG_VERSION] = version if version
-        tags[TAG_REPOSITORY_URL] = git_repository_url if git_repository_url
-        tags[TAG_COMMIT_SHA] = git_commit_sha if git_commit_sha
+        tags[FORM_FIELD_TAG_GIT_REPOSITORY_URL] = git_repository_url if git_repository_url
+        tags[FORM_FIELD_TAG_GIT_COMMIT_SHA] = git_commit_sha if git_commit_sha
 
         # Make sure everything is an utf-8 string, to avoid encoding issues in native code/libddprof/further downstream
         user_tags.merge(tags).map do |key, value|

--- a/lib/datadog/profiling/tag_builder.rb
+++ b/lib/datadog/profiling/tag_builder.rb
@@ -1,12 +1,15 @@
 # frozen_string_literal: true
 
 require_relative '../core/utils'
+require_relative '../core/environment/git'
+require_relative '../core/git/ext'
 
 module Datadog
   module Profiling
     # Builds a hash of default plus user tags to be included in a profile
     module TagBuilder
       include Datadog::Profiling::Ext::Transport::HTTP # Tag name constants
+      include Datadog::Core::Git::Ext # Git tags constants
 
       def self.call(
         settings:,
@@ -23,6 +26,8 @@ module Datadog
         runtime_id: Core::Environment::Identity.id,
         runtime_platform: Core::Environment::Identity.lang_platform,
         runtime_version: Core::Environment::Identity.lang_version,
+        git_repository_url: Core::Environment::Git.git_repository_url,
+        git_commit_sha: Core::Environment::Git.git_commit_sha,
         # User-provided tags
         user_tags: settings.tags
       )
@@ -42,6 +47,8 @@ module Datadog
         tags[FORM_FIELD_TAG_ENV] = env if env
         tags[FORM_FIELD_TAG_SERVICE] = service if service
         tags[FORM_FIELD_TAG_VERSION] = version if version
+        tags[TAG_REPOSITORY_URL] = git_repository_url if git_repository_url
+        tags[TAG_COMMIT_SHA] = git_commit_sha if git_commit_sha
 
         # Make sure everything is an utf-8 string, to avoid encoding issues in native code/libddprof/further downstream
         user_tags.merge(tags).map do |key, value|

--- a/lib/datadog/profiling/tag_builder.rb
+++ b/lib/datadog/profiling/tag_builder.rb
@@ -45,8 +45,8 @@ module Datadog
         tags[FORM_FIELD_TAG_ENV] = env if env
         tags[FORM_FIELD_TAG_SERVICE] = service if service
         tags[FORM_FIELD_TAG_VERSION] = version if version
-        tags[FORM_FIELD_TAG_GIT_REPOSITORY_URL] = git_repository_url if git_repository_url
-        tags[FORM_FIELD_TAG_GIT_COMMIT_SHA] = git_commit_sha if git_commit_sha
+        tags[TAG_GIT_REPOSITORY_URL] = git_repository_url if git_repository_url
+        tags[TAG_GIT_COMMIT_SHA] = git_commit_sha if git_commit_sha
 
         # Make sure everything is an utf-8 string, to avoid encoding issues in native code/libddprof/further downstream
         user_tags.merge(tags).map do |key, value|

--- a/lib/datadog/tracing/transport/trace_formatter.rb
+++ b/lib/datadog/tracing/transport/trace_formatter.rb
@@ -60,10 +60,10 @@ module Datadog
           tag_sampling_priority!
           tag_profiling_enabled!
 
-          return trace unless first_span
-
-          tag_git_repository_url!
-          tag_git_commit_sha!
+          if first_span
+            tag_git_repository_url!
+            tag_git_commit_sha!
+          end
 
           trace
         end

--- a/sig/datadog/core/environment/git.rbs
+++ b/sig/datadog/core/environment/git.rbs
@@ -1,0 +1,15 @@
+module Datadog
+  module Core
+    module Environment
+      module Git
+        @git_repository_url: String?
+
+        @git_commit_sha: String?
+
+        def self?.git_repository_url: () -> String?
+
+        def self?.git_commit_sha: () -> String?
+      end
+    end
+  end
+end

--- a/sig/datadog/core/git/ext.rbs
+++ b/sig/datadog/core/git/ext.rbs
@@ -2,51 +2,13 @@ module Datadog
   module Core
     module Git
       module Ext
-        GIT_SHA_LENGTH: ::Regexp
+        TAG_REPOSITORY_URL: "_dd.git.repository_url"
 
-        TAG_BRANCH: "git.branch"
-
-        TAG_REPOSITORY_URL: "git.repository_url"
-
-        TAG_TAG: "git.tag"
-
-        TAG_COMMIT_AUTHOR_DATE: "git.commit.author.date"
-
-        TAG_COMMIT_AUTHOR_EMAIL: "git.commit.author.email"
-
-        TAG_COMMIT_AUTHOR_NAME: "git.commit.author.name"
-
-        TAG_COMMIT_COMMITTER_DATE: "git.commit.committer.date"
-
-        TAG_COMMIT_COMMITTER_EMAIL: "git.commit.committer.email"
-
-        TAG_COMMIT_COMMITTER_NAME: "git.commit.committer.name"
-
-        TAG_COMMIT_MESSAGE: "git.commit.message"
-
-        TAG_COMMIT_SHA: "git.commit.sha"
+        TAG_COMMIT_SHA: "_dd.git.commit.sha"
 
         ENV_REPOSITORY_URL: "DD_GIT_REPOSITORY_URL"
 
         ENV_COMMIT_SHA: "DD_GIT_COMMIT_SHA"
-
-        ENV_BRANCH: "DD_GIT_BRANCH"
-
-        ENV_TAG: "DD_GIT_TAG"
-
-        ENV_COMMIT_MESSAGE: "DD_GIT_COMMIT_MESSAGE"
-
-        ENV_COMMIT_AUTHOR_NAME: "DD_GIT_COMMIT_AUTHOR_NAME"
-
-        ENV_COMMIT_AUTHOR_EMAIL: "DD_GIT_COMMIT_AUTHOR_EMAIL"
-
-        ENV_COMMIT_AUTHOR_DATE: "DD_GIT_COMMIT_AUTHOR_DATE"
-
-        ENV_COMMIT_COMMITTER_NAME: "DD_GIT_COMMIT_COMMITTER_NAME"
-
-        ENV_COMMIT_COMMITTER_EMAIL: "DD_GIT_COMMIT_COMMITTER_EMAIL"
-
-        ENV_COMMIT_COMMITTER_DATE: "DD_GIT_COMMIT_COMMITTER_DATE"
       end
     end
   end

--- a/sig/datadog/core/utils/url.rbs
+++ b/sig/datadog/core/utils/url.rbs
@@ -1,0 +1,9 @@
+module Datadog
+  module Core
+    module Utils
+      module Url
+        def self?.filter_sensitive_info: (::String? url) -> ::String?
+      end
+    end
+  end
+end

--- a/sig/datadog/core/utils/url.rbs
+++ b/sig/datadog/core/utils/url.rbs
@@ -2,7 +2,7 @@ module Datadog
   module Core
     module Utils
       module Url
-        def self?.filter_sensitive_info: (::String? url) -> ::String?
+        def self?.filter_basic_auth: (::String? url) -> ::String?
       end
     end
   end

--- a/sig/datadog/profiling/ext.rbs
+++ b/sig/datadog/profiling/ext.rbs
@@ -23,8 +23,8 @@ module Datadog
           FORM_FIELD_TAG_RUNTIME_VERSION: "runtime_version"
           FORM_FIELD_TAG_SERVICE: "service"
           FORM_FIELD_TAG_VERSION: "version"
-          FORM_FIELD_TAG_GIT_REPOSITORY_URL: 'git.repository_url'
-          FORM_FIELD_TAG_GIT_COMMIT_SHA: 'git.commit.sha'
+          TAG_GIT_REPOSITORY_URL: "git.repository_url"
+          TAG_GIT_COMMIT_SHA: "git.commit.sha"
           PPROF_DEFAULT_FILENAME: "rubyprofile.pprof"
           CODE_PROVENANCE_FILENAME: "code-provenance.json"
         end

--- a/sig/datadog/profiling/ext.rbs
+++ b/sig/datadog/profiling/ext.rbs
@@ -23,6 +23,8 @@ module Datadog
           FORM_FIELD_TAG_RUNTIME_VERSION: "runtime_version"
           FORM_FIELD_TAG_SERVICE: "service"
           FORM_FIELD_TAG_VERSION: "version"
+          FORM_FIELD_TAG_GIT_REPOSITORY_URL: 'git.repository_url'
+          FORM_FIELD_TAG_GIT_COMMIT_SHA: 'git.commit.sha'
           PPROF_DEFAULT_FILENAME: "rubyprofile.pprof"
           CODE_PROVENANCE_FILENAME: "code-provenance.json"
         end

--- a/sig/datadog/tracing/transport/trace_formatter.rbs
+++ b/sig/datadog/tracing/transport/trace_formatter.rbs
@@ -4,6 +4,8 @@ module Datadog
       class TraceFormatter
         attr_reader root_span: untyped
 
+        attr_reader first_span: untyped
+
         attr_reader trace: untyped
 
         def self.format!: (untyped trace) -> untyped
@@ -40,11 +42,19 @@ module Datadog
 
         def tag_high_order_trace_id!: () -> (nil | untyped)
 
+        def tag_git_repository_url!: () -> (nil | untyped)
+
+        def tag_git_commit_sha!: () -> (nil | untyped)
+
         private
 
         def partial?: () -> untyped
 
         def find_root_span: (untyped trace) -> untyped
+
+        def git_repository_url: () -> (nil | untyped)
+
+        def git_commit_sha: () -> (nil | untyped)
       end
     end
   end

--- a/spec/datadog/core/environment/git_spec.rb
+++ b/spec/datadog/core/environment/git_spec.rb
@@ -1,0 +1,29 @@
+require 'spec_helper'
+
+require 'datadog/core/environment/git'
+
+RSpec.describe Datadog::Core::Environment::Git do
+  around do |example|
+    ClimateControl.modify(env_key => env_value) do
+      example.run
+    end
+  end
+
+  describe '.git_repository_url' do
+    subject { described_class.git_repository_url }
+
+    let(:env_key) { Datadog::Core::Git::Ext::ENV_REPOSITORY_URL }
+    let(:env_value) { 'https://gitlab-ci-token:AAA_bbb@gitlab.com/DataDog/systems-test.git' }
+
+    it { is_expected.to eq('https://gitlab.com/DataDog/systems-test.git') }
+  end
+
+  describe '.git_commit_sha' do
+    subject { described_class.git_commit_sha }
+
+    let(:env_key) { Datadog::Core::Git::Ext::ENV_COMMIT_SHA }
+    let(:env_value) { '1234567890abcdef' }
+
+    it { is_expected.to eq('1234567890abcdef') }
+  end
+end

--- a/spec/datadog/core/environment/git_spec.rb
+++ b/spec/datadog/core/environment/git_spec.rb
@@ -3,10 +3,28 @@ require 'spec_helper'
 require 'datadog/core/environment/git'
 
 RSpec.describe Datadog::Core::Environment::Git do
+  def remove_cached_variables
+    if described_class.instance_variable_defined?(:@git_repository_url)
+      described_class.remove_instance_variable(:@git_repository_url)
+    end
+
+    if described_class.instance_variable_defined?(:@git_commit_sha)
+      described_class.remove_instance_variable(:@git_commit_sha)
+    end
+  end
+
   around do |example|
     ClimateControl.modify(env_key => env_value) do
       example.run
     end
+  end
+
+  before do
+    remove_cached_variables
+  end
+
+  after do
+    remove_cached_variables
   end
 
   describe '.git_repository_url' do

--- a/spec/datadog/core/utils/url_spec.rb
+++ b/spec/datadog/core/utils/url_spec.rb
@@ -1,0 +1,69 @@
+require 'spec_helper'
+
+require 'datadog/core/utils/url'
+
+RSpec.describe Datadog::Core::Utils::Url do
+  describe '.filter_sensitive_info' do
+    subject(:filtered_url) { described_class.filter_sensitive_info(url) }
+
+    context 'with https' do
+      context 'with username and password' do
+        let(:url) { 'https://gitlab-ci-token:AAA_bbb@gitlab.com/DataDog/systems-test.git' }
+
+        it { is_expected.to eq('https://gitlab.com/DataDog/systems-test.git') }
+      end
+
+      context 'with username' do
+        let(:url) { 'https://token@gitlab.com/user/project.git' }
+
+        it { is_expected.to eq('https://gitlab.com/user/project.git') }
+      end
+
+      context 'without credentials' do
+        let(:url) { 'https://gitlab.com/DataDog/systems-test.git' }
+
+        it { is_expected.to eq('https://gitlab.com/DataDog/systems-test.git') }
+      end
+    end
+
+    context 'with ssh' do
+      context 'with username and password' do
+        let(:url) { 'ssh://gitlab-ci-token:AAA_bbb@gitlab.com/DataDog/systems-test.git' }
+
+        it { is_expected.to eq('ssh://gitlab.com/DataDog/systems-test.git') }
+      end
+
+      context 'with username' do
+        let(:url) { 'ssh://token@gitlab.com/user/project.git' }
+
+        it { is_expected.to eq('ssh://gitlab.com/user/project.git') }
+      end
+
+      context 'without credentials' do
+        let(:url) { 'ssh://gitlab.com/DataDog/systems-test.git' }
+
+        it { is_expected.to eq('ssh://gitlab.com/DataDog/systems-test.git') }
+      end
+    end
+
+    context 'without protocol' do
+      context 'without credentials' do
+        let(:url) { 'gitlab.com/DataDog/systems-test.git' }
+
+        it { is_expected.to eq('gitlab.com/DataDog/systems-test.git') }
+      end
+
+      context 'with credentials' do
+        let(:url) { 'git@github.com:user/project.git' }
+
+        it { is_expected.to eq('git@github.com:user/project.git') }
+      end
+    end
+
+    context 'with nil' do
+      let(:url) { nil }
+
+      it { is_expected.to be_nil }
+    end
+  end
+end

--- a/spec/datadog/core/utils/url_spec.rb
+++ b/spec/datadog/core/utils/url_spec.rb
@@ -3,8 +3,8 @@ require 'spec_helper'
 require 'datadog/core/utils/url'
 
 RSpec.describe Datadog::Core::Utils::Url do
-  describe '.filter_sensitive_info' do
-    subject(:filtered_url) { described_class.filter_sensitive_info(url) }
+  describe '.filter_basic_auth' do
+    subject(:filtered_url) { described_class.filter_basic_auth(url) }
 
     context 'with https' do
       context 'with username and password' do

--- a/spec/datadog/profiling/tag_builder_spec.rb
+++ b/spec/datadog/profiling/tag_builder_spec.rb
@@ -90,7 +90,7 @@ RSpec.describe Datadog::Profiling::TagBuilder do
 
         it 'includes the git repository URL and commit SHA' do
           expect(call).to include(
-            '_dd.git.repository_url' => 'git_repository_url', '_dd.git.commit.sha' => 'git_commit_sha'
+            'git.repository_url' => 'git_repository_url', 'git.commit.sha' => 'git_commit_sha'
           )
         end
       end
@@ -102,7 +102,7 @@ RSpec.describe Datadog::Profiling::TagBuilder do
         end
 
         it 'includes the git repository URL and commit SHA' do
-          expect(call).to_not include('_dd.git.repository_url', '_dd.git.commit.sha')
+          expect(call).to_not include('git.repository_url', 'git.commit.sha')
         end
       end
     end

--- a/spec/datadog/profiling/tag_builder_spec.rb
+++ b/spec/datadog/profiling/tag_builder_spec.rb
@@ -78,5 +78,33 @@ RSpec.describe Datadog::Profiling::TagBuilder do
         expect(result).to include('ascii-key' => 'ascii-value')
       end
     end
+
+    describe 'source code integration' do
+      context 'when git environment is available' do
+        before do
+          allow(Datadog::Core::Environment::Git).to receive(:git_repository_url).and_return(
+            'git_repository_url'
+          )
+          allow(Datadog::Core::Environment::Git).to receive(:git_commit_sha).and_return('git_commit_sha')
+        end
+
+        it 'includes the git repository URL and commit SHA' do
+          expect(call).to include(
+            '_dd.git.repository_url' => 'git_repository_url', '_dd.git.commit.sha' => 'git_commit_sha'
+          )
+        end
+      end
+
+      context 'when git environment is not available' do
+        before do
+          allow(Datadog::Core::Environment::Git).to receive(:git_repository_url).and_return(nil)
+          allow(Datadog::Core::Environment::Git).to receive(:git_commit_sha).and_return(nil)
+        end
+
+        it 'includes the git repository URL and commit SHA' do
+          expect(call).to_not include('_dd.git.repository_url', '_dd.git.commit.sha')
+        end
+      end
+    end
   end
 end

--- a/spec/datadog/tracing/transport/trace_formatter_spec.rb
+++ b/spec/datadog/tracing/transport/trace_formatter_spec.rb
@@ -120,8 +120,7 @@ RSpec.describe Datadog::Tracing::Transport::TraceFormatter do
         it do
           is_expected.to have_attributes(
             trace: trace,
-            root_span: root_span,
-            first_span: first_span
+            root_span: root_span
           )
         end
       end

--- a/spec/datadog/tracing/transport/trace_formatter_spec.rb
+++ b/spec/datadog/tracing/transport/trace_formatter_spec.rb
@@ -66,10 +66,32 @@ RSpec.describe Datadog::Tracing::Transport::TraceFormatter do
     end
   end
 
+  shared_context 'git environment stub' do
+    before do
+      allow(Datadog::Core::Environment::Git).to receive(:git_repository_url).and_return(git_repository_url)
+      allow(Datadog::Core::Environment::Git).to receive(:git_commit_sha).and_return(git_commit_sha)
+    end
+  end
+
+  shared_context 'git metadata' do
+    let(:git_repository_url) { 'git_repository_url' }
+    let(:git_commit_sha) { 'git_commit_sha' }
+
+    include_context 'git environment stub'
+  end
+
+  shared_context 'no git metadata' do
+    let(:git_repository_url) { nil }
+    let(:git_commit_sha) { nil }
+
+    include_context 'git environment stub'
+  end
+
   shared_context 'no root span' do
     let(:trace) { Datadog::Tracing::TraceSegment.new(spans, **trace_options) }
     let(:spans) { Array.new(3) { Datadog::Tracing::Span.new('my.job') } }
     let(:root_span) { spans.last }
+    let(:first_span) { spans.first }
   end
 
   shared_context 'missing root span' do
@@ -82,12 +104,14 @@ RSpec.describe Datadog::Tracing::Transport::TraceFormatter do
     end
     let(:spans) { Array.new(3) { Datadog::Tracing::Span.new('my.job') } }
     let(:root_span) { spans.last }
+    let(:first_span) { spans.first }
   end
 
   shared_context 'available root span' do
     let(:trace) { Datadog::Tracing::TraceSegment.new(spans, root_span_id: root_span.id, **trace_options) }
     let(:spans) { Array.new(3) { Datadog::Tracing::Span.new('my.job') } }
     let(:root_span) { spans[1] }
+    let(:first_span) { spans.first }
   end
 
   describe '::new' do
@@ -96,7 +120,8 @@ RSpec.describe Datadog::Tracing::Transport::TraceFormatter do
         it do
           is_expected.to have_attributes(
             trace: trace,
-            root_span: root_span
+            root_span: root_span,
+            first_span: first_span
           )
         end
       end
@@ -194,6 +219,25 @@ RSpec.describe Datadog::Tracing::Transport::TraceFormatter do
         end
       end
 
+      shared_examples 'first span with no git metadata' do
+        it do
+          format!
+          expect(first_span.meta).to_not include('_dd.git.repository_url', '_dd.git.commit.sha')
+        end
+      end
+
+      shared_examples 'first span with git metadata' do
+        it do
+          format!
+          expect(first_span.meta).to include(
+            {
+              '_dd.git.repository_url' => git_repository_url,
+              '_dd.git.commit.sha' => git_commit_sha
+            }
+          )
+        end
+      end
+
       context 'with no root span' do
         include_context 'no root span'
 
@@ -230,6 +274,16 @@ RSpec.describe Datadog::Tracing::Transport::TraceFormatter do
 
           it_behaves_like 'root span with tags'
           it_behaves_like 'root span without generic tags'
+        end
+
+        context 'with git metadata' do
+          include_context 'git metadata'
+          it_behaves_like 'first span with git metadata'
+        end
+
+        context 'without git metadata' do
+          include_context 'no git metadata'
+          it_behaves_like 'first span with no git metadata'
         end
       end
 
@@ -269,6 +323,16 @@ RSpec.describe Datadog::Tracing::Transport::TraceFormatter do
 
           it_behaves_like 'root span with tags'
           it_behaves_like 'root span without generic tags'
+        end
+
+        context 'with git metadata' do
+          include_context 'git metadata'
+          it_behaves_like 'first span with git metadata'
+        end
+
+        context 'without git metadata' do
+          include_context 'no git metadata'
+          it_behaves_like 'first span with no git metadata'
         end
       end
 
@@ -310,6 +374,16 @@ RSpec.describe Datadog::Tracing::Transport::TraceFormatter do
 
           it_behaves_like 'root span with tags'
           it_behaves_like 'root span with generic tags'
+        end
+
+        context 'with git metadata' do
+          include_context 'git metadata'
+          it_behaves_like 'first span with git metadata'
+        end
+
+        context 'without git metadata' do
+          include_context 'no git metadata'
+          it_behaves_like 'first span with no git metadata'
         end
       end
     end


### PR DESCRIPTION
**2.0 Upgrade Guide notes**
In order to use the new source code integration feature set the following environment variables:
- DD_GIT_REPOSITORY_URL
- DD_GIT_COMMIT_SHA 

**What does this PR do?**
Adds source code integration tags to APM traces according to the following requirements:
- if DD_GIT_REPOSITORY_URL env var is defined, its value should be sanitized by removing possible URL credentials (user/password information if it can be successfully parsed into an URL) and set in the _dd.git.repository_url of the first span of every trace chunk
- if DD_GIT_COMMIT_SHA env var is defined, its value should be set in _dd.git.commit.sha of the first span of every trace chunk

**Additional Notes:**
Why are we not using trace_operation.set_tags?

Trace-level tags are being set in the **root span** of the trace, not the **first span** as defined by the requirements. Moreover, if flush is partial then these tags are not set at all:

```ruby
    def set_trace_tags!
      # If the root span wasn't specified, don't set this. We don't want to
      # misset or overwrite the tags of a span that is in the middle of the
      # trace.
      return if partial?

      root_span.set_tags(trace.send(:meta))
      root_span.set_tags(trace.send(:metrics))
    end
```

In order to provide 100% compatibility with Datadog APM backend without edge cases I decided to implement additional logic in `Datadog::Tracing::Transport::TraceFormatter` to set git tags for the first span of trace that is being serialized.

**How to test the change?**
Tested using system-tests locally
From junit report:

```xml
<testcase classname="tests.parametric.test_tracer.Test_TracerSCITagging" name="tests.parametric.test_tracer.Test_TracerSCITagging.test_tracer_repository_url_environment_variable[library_env0]" time="0.048">
<properties>
<property name="dd_tags[systest.case.outcome]" value="passed" />
<property name="dd_tags[systest.case.skip_reason]" value="" />
</properties>
</testcase>
```

**For Datadog employees:**
- [ ] If this PR touches code that signs or publishes builds or packages, or handles
credentials of any kind, I've requested a review from `@DataDog/security-design-and-guidance`.
- [x] This PR doesn't touch any of that.
