### PR TITLE
Add new profiler benchmark and `malloc_stats` helper

### DIFF
--- a/benchmarks/profiler_sample_serialize.rb
+++ b/benchmarks/profiler_sample_serialize.rb
@@ -1,0 +1,86 @@
+# Used to quickly run benchmark under RSpec as part of the usual test suite, to validate it didn't bitrot
+VALIDATE_BENCHMARK_MODE = ENV['VALIDATE_BENCHMARK'] == 'true'
+
+return unless __FILE__ == $PROGRAM_NAME || VALIDATE_BENCHMARK_MODE
+
+require 'benchmark/ips'
+require 'ddtrace'
+require 'pry'
+require_relative 'dogstatsd_reporter'
+
+require 'libdatadog'
+
+puts "Libdatadog from: #{Libdatadog.pkgconfig_folder}"
+
+# This benchmark measures the performance of sampling + serializing profiles. It enables us to evaluate changes to
+# the profiler and/or libdatadog that may impact both individual samples, as well as samples over time (e.g. timeline).
+
+class ProfilerSampleSerializeBenchmark
+  # This is needed because we're directly invoking the collector through a testing interface; in normal
+  # use a profiler thread is automatically used.
+  PROFILER_OVERHEAD_STACK_THREAD = Thread.new { sleep }
+
+  def create_profiler
+    timeline_enabled = ENV['TIMELINE'] == 'true'
+    @recorder = Datadog::Profiling::StackRecorder.new(
+      cpu_time_enabled: true,
+      alloc_samples_enabled: false,
+      heap_samples_enabled: false,
+      heap_size_enabled: false,
+      heap_sample_every: 1,
+      timeline_enabled: timeline_enabled,
+    )
+    @collector = Datadog::Profiling::Collectors::ThreadContext.new(
+      recorder: @recorder, max_frames: 400, tracer: nil, endpoint_collection_enabled: false, timeline_enabled: timeline_enabled
+    )
+  end
+
+  def run_benchmark
+    Benchmark.ips do |x|
+      benchmark_time = VALIDATE_BENCHMARK_MODE ? { time: 0.01, warmup: 0 } : { time: 10, warmup: 2 }
+      x.config(
+        **benchmark_time,
+        suite: report_to_dogstatsd_if_enabled_via_environment_variable(benchmark_name: 'profiler_sample_serialize')
+      )
+
+      x.report("sample #{ENV['CONFIG']} timeline=#{ENV['TIMELINE'] == 'true'}") do
+        samples_per_second = 100
+        simulate_seconds = 60
+
+        (samples_per_second * simulate_seconds).times do
+          Datadog::Profiling::Collectors::ThreadContext::Testing._native_sample(@collector, PROFILER_OVERHEAD_STACK_THREAD)
+        end
+
+        @recorder.serialize
+        nil
+      end
+
+      x.save! 'profiler_sample_serialize-results.json' unless VALIDATE_BENCHMARK_MODE
+      x.compare!
+    end
+
+    @recorder.serialize
+  end
+
+  def run_forever
+    while true
+      1000.times do
+        Datadog::Profiling::Collectors::ThreadContext::Testing._native_sample(@collector, PROFILER_OVERHEAD_STACK_THREAD)
+      end
+      @recorder.serialize
+      print '.'
+    end
+  end
+end
+
+puts "Current pid is #{Process.pid}"
+
+ProfilerSampleSerializeBenchmark.new.instance_exec do
+  create_profiler
+  10.times { Thread.new { sleep } }
+  if ARGV.include?('--forever')
+    run_forever
+  else
+    run_benchmark
+  end
+end

--- a/ext/ddtrace_profiling_native_extension/extconf.rb
+++ b/ext/ddtrace_profiling_native_extension/extconf.rb
@@ -130,6 +130,8 @@ if RUBY_PLATFORM.include?('linux')
   $defs << '-DHAVE_PTHREAD_GETCPUCLOCKID'
 end
 
+have_func 'malloc_stats'
+
 # On older Rubies, rb_postponed_job_preregister/rb_postponed_job_trigger did not exist
 $defs << '-DNO_POSTPONED_TRIGGER' if RUBY_VERSION < '3.3'
 

--- a/ext/ddtrace_profiling_native_extension/profiling.c
+++ b/ext/ddtrace_profiling_native_extension/profiling.c
@@ -1,6 +1,7 @@
 #include <ruby.h>
 #include <ruby/thread.h>
 #include <errno.h>
+#include <malloc.h>
 
 #include "clock_id.h"
 #include "helpers.h"
@@ -32,6 +33,7 @@ static void holding_the_gvl_signal_handler(DDTRACE_UNUSED int _signal, DDTRACE_U
 static VALUE _native_trigger_holding_the_gvl_signal_handler_on(DDTRACE_UNUSED VALUE _self, VALUE background_thread);
 static VALUE _native_enforce_success(DDTRACE_UNUSED VALUE _self, VALUE syserr_errno, VALUE with_gvl);
 static void *trigger_enforce_success(void *trigger_args);
+static VALUE _native_malloc_stats(DDTRACE_UNUSED VALUE _self);
 
 void DDTRACE_EXPORT Init_ddtrace_profiling_native_extension(void) {
   VALUE datadog_module = rb_define_module("Datadog");
@@ -65,6 +67,7 @@ void DDTRACE_EXPORT Init_ddtrace_profiling_native_extension(void) {
   rb_define_singleton_method(testing_module, "_native_install_holding_the_gvl_signal_handler", _native_install_holding_the_gvl_signal_handler, 0);
   rb_define_singleton_method(testing_module, "_native_trigger_holding_the_gvl_signal_handler_on", _native_trigger_holding_the_gvl_signal_handler_on, 1);
   rb_define_singleton_method(testing_module, "_native_enforce_success", _native_enforce_success, 2);
+  rb_define_singleton_method(testing_module, "_native_malloc_stats", _native_malloc_stats, 0);
 }
 
 static VALUE native_working_p(DDTRACE_UNUSED VALUE _self) {
@@ -248,4 +251,11 @@ static void *trigger_enforce_success(void *trigger_args) {
   intptr_t syserr_errno = (intptr_t) trigger_args;
   ENFORCE_SUCCESS_NO_GVL(syserr_errno);
   return NULL;
+}
+
+static VALUE _native_malloc_stats(DDTRACE_UNUSED VALUE _self) {
+  #ifdef HAVE_MALLOC_STATS
+    malloc_stats();
+  #endif
+  return Qnil;
 }

--- a/spec/datadog/profiling/validate_benchmarks_spec.rb
+++ b/spec/datadog/profiling/validate_benchmarks_spec.rb
@@ -16,4 +16,8 @@ RSpec.describe 'Profiling benchmarks', if: (RUBY_VERSION >= '2.4.0') do
   describe 'profiler_http_transport' do
     it('runs without raising errors') { expect_in_fork { load './benchmarks/profiler_http_transport.rb' } }
   end
+
+  describe 'profiler_sample_serialize' do
+    it('runs without raising errors') { expect_in_fork { load './benchmarks/profiler_sample_serialize.rb' } }
+  end
 end


### PR DESCRIPTION
**What does this PR do?**

This PR includes two changes I've extracted from my ongoing work to improve timeline memory usage and overhead:
* Add helper to print malloc_stats()
* Add `profiler_sample_serialize` benchmark

**Motivation:**

I think both of these are useful to keep in-tree, so in the future we can use them for future investigations.

**Additional Notes:**

Since `malloc_stats` is Linux-specific, I needed to add a check for it in `extconf.rb`.

**How to test the change?**

Both can be seen working easily from the command-line:

```
$ bundle exec ruby -e "require 'ddtrace'; Datadog::Profiling::NativeExtension::Testing._native_malloc_stats"
Arena 0:
system bytes     =   21139456
in use bytes     =   20927216
Total (incl. mmap):
system bytes     =   23773184
in use bytes     =   23560944
max mmap regions =          3
max mmap bytes   =    2633728
```

and

```
$ bundle exec ruby benchmarks/profiler_sample_serialize.rb 
Libdatadog from: ruby-3.1.4/gems/libdatadog-5.0.0.1.0-x86_64-linux/vendor/libdatadog-5.0.0/x86_64-linux/libdatadog-x86_64-unknown-linux-gnu/lib/pkgconfig
Current pid is 589982
DogStatsD reporting ❌ disabled
ruby 3.1.4p223 (2023-03-30 revision 957bb7cb81) [x86_64-linux]
Warming up --------------------------------------
sample  timeline=false
                         1.000 i/100ms
Calculating -------------------------------------
sample  timeline=false
                         13.830 (± 0.0%) i/s -    139.000 in  10.063133s

Comparison:
sample  timeline=false:       13.8 i/s
sample  timeline=true:       10.8 i/s - 1.27x  slower
```

**For Datadog employees:**
- [ ] If this PR touches code that signs or publishes builds or packages, or handles
credentials of any kind, I've requested a review from `@DataDog/security-design-and-guidance`.
- [x] This PR doesn't touch any of that.