### PR TITLE
Fix deadlock when logger tries to use correlation

### DIFF
--- a/lib/datadog/tracing.rb
+++ b/lib/datadog/tracing.rb
@@ -73,8 +73,14 @@ module Datadog
       # (see Datadog::Tracing::Tracer#active_correlation)
       # @public_api
       def correlation
-        current_tracer = tracer
-        return unless current_tracer
+        # We access this in this way as:
+        # * If the components have not been initialized, it doesn't make sense to initialize ddtrace just to say
+        #   'nil' here
+        # * It prevents recursive initialization attempts, see https://github.com/DataDog/dd-trace-rb/issues/3385
+        components = Datadog.send(:components, allow_initialization: false)
+        current_tracer = components.tracer if components
+
+        return Datadog::Tracing::Correlation::Identifier.new unless current_tracer
 
         current_tracer.active_correlation
       end

--- a/spec/datadog/tracing_spec.rb
+++ b/spec/datadog/tracing_spec.rb
@@ -128,9 +128,21 @@ RSpec.describe Datadog::Tracing do
 
   describe '.correlation' do
     subject(:correlation) { described_class.correlation }
+
     it 'delegates to the tracer' do
       expect(described_class.send(:tracer)).to receive(:active_correlation).and_return(returned)
       expect(correlation).to eq(returned)
+    end
+
+    context 'when dd-trace-rb is not initialized' do
+      before do
+        expect(Datadog.send(:components, allow_initialization: false)).to be nil
+      end
+
+      it 'does not cause components to be initialized' do
+        expect(correlation.span_id).to be 0
+        expect(Datadog.send(:components, allow_initialization: false)).to be nil
+      end
     end
   end
 


### PR DESCRIPTION
**What does this PR do?**

This PR fixes #3385 by preventing components initialization when calling the `Datadog::Tracing.correlation` API.

Instead, we use the `allow_initialization: false` option, which was added exactly to help break these kinds of initialization cycles.

**Motivation:**

This fixes a deadlock issue such as:

```
lib/datadog/core/configuration.rb:228:in `synchronize': deadlock; recursive locking (ThreadError)
  from lib/datadog/core/configuration.rb:228:in `safely_synchronize'
  from lib/datadog/core/configuration.rb:195:in `components'
  from lib/datadog/tracing.rb:134:in `components'
  from lib/datadog/tracing.rb:138:in `tracer'
  from lib/datadog/tracing.rb:76:in `correlation'
  from repro.rb:5:in `add'
  from logger-1.6.0/lib/logger.rb:691:in `debug'
  from lib/datadog/core/remote/component.rb:29:in `initialize'
  from lib/datadog/core/remote/component.rb:156:in `new'
  from lib/datadog/core/remote/component.rb:156:in `build'
  from lib/datadog/core/configuration/components.rb:90:in `initialize'
  from datadog-ci-0.7.0/lib/datadog/ci/configuration/components.rb:31:in `initialize'
  from lib/datadog/core/configuration.rb:248:in `new'
  from lib/datadog/core/configuration.rb:248:in `build_components'
  from lib/datadog/core/configuration.rb:89:in `block in configure'
  from lib/datadog/core/configuration.rb:230:in `block in safely_synchronize'
  from lib/datadog/core/configuration.rb:228:in `synchronize'
  from lib/datadog/core/configuration.rb:228:in `safely_synchronize'
  from lib/datadog/core/configuration.rb:84:in `configure'
  from lib/datadog/tracing/contrib/extensions.rb:64:in `configure'
  from repro.rb:9:in `<main>'
```

that happens when a logger is configured to also print correlation

**Additional Notes:**

While it may seem that I've changed the API semantics by returning an `Identifier` when there is no tracer, the previous code was actually misleading.

There is actually no way (that I know of) for `tracer` to be `nil` on dd-trace-rb currently. It can be disabled, but an instance will still exist.

The disabled instance, when called, returns an empty `Identifier`, so here I'm replicating that behavior, without needing the components to be initialized.

I guess this is open for debate? We could return `nil` instead in the future.

**How to test the change?**

This tiny snippet can be used to simulate the exact logger issue reported by the customer:

```ruby
require 'ddtrace'

class TestLogger < Datadog::Core::Logger
  def add(severity, message = nil, progname = nil, &block)
    puts Datadog::Tracing.correlation
  end
end

Datadog.configure do |c|
  c.logger.instance = TestLogger.new(STDOUT)
end
```

**For Datadog employees:**
- [ ] If this PR touches code that signs or publishes builds or packages, or handles
credentials of any kind, I've requested a review from `@DataDog/security-design-and-guidance`.
- [x] This PR doesn't touch any of that.

Fixes #3385