### PR TITLE
Add Concurrent::Async instrumentation

### DIFF
--- a/docs/GettingStarted.md
+++ b/docs/GettingStarted.md
@@ -584,8 +584,7 @@ Aws::S3::Client.new.list_buckets
 
 ### Concurrent Ruby
 
-The Concurrent Ruby integration adds support for context propagation when using `::Concurrent::Future` and `Concurrent::Async`,
-making sure that code traced within the `Future#execute` and `Concurrent::Async#async` will have correct parent set.
+The Concurrent Ruby integration adds support for context propagation when using `::Concurrent::Future` and `Concurrent::Async`, and ensures that code traced within the `Future#execute` and `Concurrent::Async#async` will have the correct parent set.
 
 To activate your integration, use the `Datadog.configure` method:
 

--- a/docs/GettingStarted.md
+++ b/docs/GettingStarted.md
@@ -584,8 +584,8 @@ Aws::S3::Client.new.list_buckets
 
 ### Concurrent Ruby
 
-The Concurrent Ruby integration adds support for context propagation when using `::Concurrent::Future`.
-Making sure that code traced within the `Future#execute` will have correct parent set.
+The Concurrent Ruby integration adds support for context propagation when using `::Concurrent::Future` and `Concurrent::Async`,
+making sure that code traced within the `Future#execute` and `Concurrent::Async#async` will have correct parent set.
 
 To activate your integration, use the `Datadog.configure` method:
 
@@ -599,6 +599,19 @@ end
 # Pass context into code executed within Concurrent::Future
 Datadog::Tracing.trace('outer') do
   Concurrent::Future.execute { Datadog::Tracing.trace('inner') { } }.wait
+end
+
+# Pass context into code executed within Concurrent::Async
+class MyClass
+  include ConcurrentAsync
+
+  def foo
+    Datadog::Tracing.trace('inner') { }
+  end
+end
+
+Datadog::Tracing.trace('outer') do
+  MyClass.new.async.foo
 end
 ```
 

--- a/lib/datadog/tracing/contrib/concurrent_ruby/async_patch.rb
+++ b/lib/datadog/tracing/contrib/concurrent_ruby/async_patch.rb
@@ -1,0 +1,20 @@
+# frozen_string_literal: true
+
+require_relative 'context_composite_executor_service'
+
+module Datadog
+  module Tracing
+    module Contrib
+      module ConcurrentRuby
+        # This patches the Async - to wrap executor service using ContextCompositeExecutorService
+        module AsyncPatch
+          def initialize(delegate)
+            super(delegate)
+
+            @executor = ContextCompositeExecutorService.new(@executor)
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/datadog/tracing/contrib/concurrent_ruby/patcher.rb
+++ b/lib/datadog/tracing/contrib/concurrent_ruby/patcher.rb
@@ -6,7 +6,7 @@ module Datadog
   module Tracing
     module Contrib
       module ConcurrentRuby
-        # Patcher enables patching of 'Future' class.
+        # Patcher enables patching of 'Future' and 'Async' classes.
         module Patcher
           include Contrib::Patcher
 
@@ -21,6 +21,16 @@ module Datadog
             patch_future
             require_relative 'promises_future_patch'
             patch_promises_future
+            require_relative 'async_patch'
+            async_patch
+          end
+
+          # Propagate tracing context in Concurrent::Async
+          def async_patch
+            if defined?(::Concurrent::Async)
+              # NOTE: AsyncDelegator is a private constant
+              ::Concurrent::Async.const_get(:AsyncDelegator).prepend(AsyncPatch)
+            end
           end
 
           # Propagate tracing context in Concurrent::Future

--- a/sig/datadog/tracing/contrib/concurrent_ruby/async_patch.rbs
+++ b/sig/datadog/tracing/contrib/concurrent_ruby/async_patch.rbs
@@ -1,0 +1,13 @@
+module Datadog
+  module Tracing
+    module Contrib
+      module ConcurrentRuby
+        module AsyncPatch
+          @executor: untyped
+
+          def initialize: (untyped delegate) -> void
+        end
+      end
+    end
+  end
+end

--- a/spec/datadog/tracing/contrib/concurrent_ruby/integration_test_spec.rb
+++ b/spec/datadog/tracing/contrib/concurrent_ruby/integration_test_spec.rb
@@ -11,6 +11,7 @@ RSpec.describe 'ConcurrentRuby integration tests' do
 
   before do
     # stub inheritance chain for instrumentation rollback
+    stub_const('Concurrent::Async::AsyncDelegator', ::Concurrent::Async.const_get(:AsyncDelegator).dup)
     stub_const('Concurrent::Promises', ::Concurrent::Promises.dup)
     stub_const('Concurrent::Future', ::Concurrent::Future.dup)
   end
@@ -207,6 +208,132 @@ RSpec.describe 'ConcurrentRuby integration tests' do
       it 'inner span parent should be included in outer span' do
         deferred_execution
         expect(inner_span.parent_id).to eq(outer_span.span_id)
+      end
+    end
+  end
+
+  context 'Concurrent::Async' do
+    before(:context) do
+      # Execute an async future to force the eager creation of internal
+      # global threads that are never closed.
+      #
+      # This allows us to separate internal concurrent-ruby threads
+      # from ddtrace threads for leak detection. We need to create the maximum
+      # number of threads that will be created concurrently in a test, which in
+      # this case is 2.
+      ThreadHelpers.with_leaky_thread_creation(:concurrent_ruby) do
+        klass = Class.new do
+          include Concurrent::Async
+          def echo
+            yield if block_given?
+          end
+        end
+        klass.new.async.echo { klass.new.async.echo.value }.value
+      end
+    end
+
+    let(:async_klass) do
+      Class.new do
+        include Concurrent::Async
+        def echo
+          yield if block_given?
+        end
+      end
+    end
+
+    subject(:deferred_execution) do
+      outer_span = tracer.trace('outer_span')
+
+      ivar = async_klass.new.async.echo do
+        tracer.trace('inner_span') {}
+      end
+      ivar.value
+
+      outer_span.finish
+    end
+
+    describe 'patching' do
+      subject(:patch) do
+        Datadog.configure do |c|
+          c.tracing.instrument :concurrent_ruby
+        end
+      end
+
+      it 'adds PromisesFuturePatch to Promises ancestors' do
+        expect { patch }.to change { ::Concurrent::Promises.singleton_class.ancestors.map(&:to_s) }
+          .to include('Datadog::Tracing::Contrib::ConcurrentRuby::PromisesFuturePatch')
+      end
+    end
+
+    context 'when context propagation is disabled' do
+      it_behaves_like 'deferred execution'
+
+      it 'inner span should not have parent' do
+        deferred_execution
+        expect(inner_span).to be_root_span
+      end
+    end
+
+    context 'when context propagation is enabled' do
+      before do
+        Datadog.configure do |c|
+          c.tracing.instrument :concurrent_ruby
+        end
+      end
+
+      it_behaves_like 'deferred execution'
+
+      it 'inner span parent should be included in outer span' do
+        deferred_execution
+        expect(inner_span.parent_id).to eq(outer_span.span_id)
+      end
+
+      context 'when there are multiple asyncs with inner spans that have the same parent' do
+        let(:second_inner_span) { spans.find { |s| s.name == 'second_inner_span' } }
+
+        subject(:multiple_deferred_executions) do
+          # use a barrier to ensure both threads are created before continuing
+          barrier = Concurrent::CyclicBarrier.new(2)
+
+          outer_span = tracer.trace('outer_span')
+
+          ivar_1 = async_klass.new.async.echo do
+            barrier.wait
+            tracer.trace('inner_span') do
+              barrier.wait
+            end
+          end
+
+          ivar_2 = async_klass.new.async.echo do
+            barrier.wait
+            tracer.trace('second_inner_span') do
+              barrier.wait
+            end
+          end
+
+          ivar_1.wait
+          ivar_2.wait
+          outer_span.finish
+        end
+
+        describe 'it correctly associates to the parent span' do
+          it 'both inner span parents should be included in same outer span' do
+            multiple_deferred_executions
+
+            expect(inner_span.parent_id).to eq(outer_span.span_id)
+            expect(second_inner_span.parent_id).to eq(outer_span.span_id)
+          end
+        end
+      end
+
+      context 'when propagates without an active trace' do
+        it 'creates a root span' do
+          async_klass.new.async.echo do
+            tracer.trace('inner_span') {}
+          end.value
+
+          expect(inner_span).to be_root_span
+        end
       end
     end
   end


### PR DESCRIPTION
**What does this PR do?**
Add [Concurrent::Async](https://ruby-concurrency.github.io/concurrent-ruby/1.2.3/Concurrent/Async.html) instrumentation. 

**Motivation:**
Looking at the existing implementation for `Concurrent::Future`, it wasn't hard to replicate it to `Concurrent::Async` as well (which I use in a project) 😄 

**Additional Notes:**
None.

**How to test the change?**
Added some tests and documentation to the README.

**For Datadog employees:**
- [ ] If this PR touches code that signs or publishes builds or packages, or handles
credentials of any kind, I've requested a review from `@DataDog/security-design-and-guidance`.
- [ ] This PR doesn't touch any of that.

Unsure? Have a question? Request a review!
