### PR TITLE
[PROF-8942] Enable Ruby timeline by default

### DIFF
--- a/lib/datadog/core/configuration/settings.rb
+++ b/lib/datadog/core/configuration/settings.rb
@@ -424,9 +424,28 @@ module Datadog
             #
             # @default `DD_PROFILING_EXPERIMENTAL_TIMELINE_ENABLED` environment variable as a boolean, otherwise `false`
             option :experimental_timeline_enabled do |o|
+              o.after_set do
+                # FIXME: TODO: This needs to be updated to match up with https://github.com/DataDog/dd-trace-rb/pull/3357
+                Datadog.logger.warn(
+                  'The profiling.advanced.experimental_timeline_enabled setting has been deprecated for removal ' \
+                  'and no longer does anything. Please remove it from your Datadog.configure block. ' \
+                  'The timeline feature counting is now controlled by the `timeline_enabled` setting instead.'
+                )
+              end
+            end
+
+            # Controls data collection for the timeline feature.
+            #
+            # If you needed to disable this, please tell us why on <https://github.com/DataDog/dd-trace-rb/issues/new>,
+            # so we can fix it!
+            #
+            # TODO: In the future this setting may be deprecated and the timeline may no longer be optional.
+            #
+            # @default `DD_PROFILING_TIMELINE_ENABLED` environment variable as a boolean, otherwise `true`
+            option :timeline_enabled do |o|
               o.type :bool
-              o.env 'DD_PROFILING_EXPERIMENTAL_TIMELINE_ENABLED'
-              o.default false
+              o.env 'DD_PROFILING_TIMELINE_ENABLED'
+              o.default true
             end
 
             # The profiler gathers data by sending `SIGPROF` unix signals to Ruby application threads.

--- a/lib/datadog/core/configuration/settings.rb
+++ b/lib/datadog/core/configuration/settings.rb
@@ -440,8 +440,6 @@ module Datadog
             # If you needed to disable this, please tell us why on <https://github.com/DataDog/dd-trace-rb/issues/new>,
             # so we can fix it!
             #
-            # TODO: In the future this setting may be deprecated and the timeline may no longer be optional.
-            #
             # @default `DD_PROFILING_TIMELINE_ENABLED` environment variable as a boolean, otherwise `true`
             option :timeline_enabled do |o|
               o.type :bool

--- a/lib/datadog/core/configuration/settings.rb
+++ b/lib/datadog/core/configuration/settings.rb
@@ -424,13 +424,14 @@ module Datadog
             #
             # @default `DD_PROFILING_EXPERIMENTAL_TIMELINE_ENABLED` environment variable as a boolean, otherwise `false`
             option :experimental_timeline_enabled do |o|
-              o.after_set do
-                # FIXME: TODO: This needs to be updated to match up with https://github.com/DataDog/dd-trace-rb/pull/3357
-                Datadog.logger.warn(
-                  'The profiling.advanced.experimental_timeline_enabled setting has been deprecated for removal ' \
-                  'and no longer does anything. Please remove it from your Datadog.configure block. ' \
-                  'The timeline feature counting is now controlled by the `timeline_enabled` setting instead.'
-                )
+              o.after_set do |_, _, precedence|
+                unless precedence == Datadog::Core::Configuration::Option::Precedence::DEFAULT
+                  Datadog.logger.warn(
+                    'The profiling.advanced.experimental_timeline_enabled setting has been deprecated for removal ' \
+                    'and no longer does anything. Please remove it from your Datadog.configure block. ' \
+                    'The timeline feature counting is now controlled by the `timeline_enabled` setting instead.'
+                  )
+                end
               end
             end
 

--- a/lib/datadog/profiling/component.rb
+++ b/lib/datadog/profiling/component.rb
@@ -40,7 +40,7 @@ module Datadog
         # NOTE: Please update the Initialization section of ProfilingDevelopment.md with any changes to this method
 
         no_signals_workaround_enabled = no_signals_workaround_enabled?(settings)
-        timeline_enabled = settings.profiling.advanced.experimental_timeline_enabled
+        timeline_enabled = settings.profiling.advanced.timeline_enabled
         allocation_profiling_enabled = enable_allocation_profiling?(settings)
         heap_sample_every = get_heap_sample_every(settings)
         heap_profiling_enabled = enable_heap_profiling?(settings, allocation_profiling_enabled, heap_sample_every)

--- a/spec/datadog/core/configuration/settings_spec.rb
+++ b/spec/datadog/core/configuration/settings_spec.rb
@@ -723,12 +723,20 @@ RSpec.describe Datadog::Core::Configuration::Settings do
         end
       end
 
-      describe '#experimental_timeline_enabled' do
-        subject(:experimental_timeline_enabled) { settings.profiling.advanced.experimental_timeline_enabled }
+      describe '#experimental_timeline_enabled=' do
+        it 'logs a warning  that this no longer does anything' do
+          expect(Datadog.logger).to receive(:warn).with(/no longer does anything/)
 
-        context 'when DD_PROFILING_EXPERIMENTAL_TIMELINE_ENABLED' do
+          settings.profiling.advanced.experimental_timeline_enabled = 0
+        end
+      end
+
+      describe '#timeline_enabled' do
+        subject(:timeline_enabled) { settings.profiling.advanced.timeline_enabled }
+
+        context 'when DD_PROFILING_TIMELINE_ENABLED' do
           around do |example|
-            ClimateControl.modify('DD_PROFILING_EXPERIMENTAL_TIMELINE_ENABLED' => environment) do
+            ClimateControl.modify('DD_PROFILING_TIMELINE_ENABLED' => environment) do
               example.run
             end
           end
@@ -736,7 +744,7 @@ RSpec.describe Datadog::Core::Configuration::Settings do
           context 'is not defined' do
             let(:environment) { nil }
 
-            it { is_expected.to be false }
+            it { is_expected.to be true }
           end
 
           [true, false].each do |value|
@@ -749,12 +757,12 @@ RSpec.describe Datadog::Core::Configuration::Settings do
         end
       end
 
-      describe '#experimental_timeline_enabled=' do
-        it 'updates the #experimental_timeline_enabled setting' do
-          expect { settings.profiling.advanced.experimental_timeline_enabled = true }
-            .to change { settings.profiling.advanced.experimental_timeline_enabled }
-            .from(false)
-            .to(true)
+      describe '#timeline_enabled=' do
+        it 'updates the #timeline_enabled setting from its default of true' do
+          expect { settings.profiling.advanced.timeline_enabled = false }
+            .to change { settings.profiling.advanced.timeline_enabled }
+            .from(true)
+            .to(false)
         end
       end
 

--- a/spec/datadog/profiling/component_spec.rb
+++ b/spec/datadog/profiling/component_spec.rb
@@ -58,7 +58,7 @@ RSpec.describe Datadog::Profiling::Component do
 
           expect(settings.profiling.advanced).to receive(:max_frames).and_return(:max_frames_config)
           expect(settings.profiling.advanced)
-            .to receive(:experimental_timeline_enabled).and_return(:experimental_timeline_enabled_config)
+            .to receive(:timeline_enabled).and_return(:timeline_enabled_config)
           expect(settings.profiling.advanced.endpoint.collection)
             .to receive(:enabled).and_return(:endpoint_collection_enabled_config)
 
@@ -67,7 +67,7 @@ RSpec.describe Datadog::Profiling::Component do
             max_frames: :max_frames_config,
             tracer: tracer,
             endpoint_collection_enabled: :endpoint_collection_enabled_config,
-            timeline_enabled: :experimental_timeline_enabled_config,
+            timeline_enabled: :timeline_enabled_config,
           )
 
           build_profiler_component
@@ -330,7 +330,7 @@ RSpec.describe Datadog::Profiling::Component do
         end
 
         context 'when timeline is enabled' do
-          before { settings.profiling.advanced.experimental_timeline_enabled = true }
+          before { settings.profiling.advanced.timeline_enabled = true }
 
           it 'sets up the StackRecorder with timeline_enabled: true' do
             expect(Datadog::Profiling::StackRecorder)
@@ -341,7 +341,7 @@ RSpec.describe Datadog::Profiling::Component do
         end
 
         context 'when timeline is disabled' do
-          before { settings.profiling.advanced.experimental_timeline_enabled = false }
+          before { settings.profiling.advanced.timeline_enabled = false }
 
           it 'sets up the StackRecorder with timeline_enabled: false' do
             expect(Datadog::Profiling::StackRecorder)
@@ -373,7 +373,7 @@ RSpec.describe Datadog::Profiling::Component do
           allow(Datadog::Profiling::StackRecorder).to receive(:new)
 
           expect(described_class).to receive(:no_signals_workaround_enabled?).and_return(:no_signals_result)
-          expect(settings.profiling.advanced).to receive(:experimental_timeline_enabled).and_return(:timeline_result)
+          expect(settings.profiling.advanced).to receive(:timeline_enabled).and_return(:timeline_result)
           expect(settings.profiling.advanced).to receive(:experimental_heap_sample_rate).and_return(456)
           expect(Datadog::Profiling::Exporter).to receive(:new).with(
             hash_including(


### PR DESCRIPTION
**What does this PR do?**

This PR enables the timeline feature for the Continuous Profiler by default.

It introduces a new setting, `timeline_enabled`, which can also be controlled by setting the `DD_PROFILING_TIMELINE_ENABLED` environment variable.

It also deprecates the old `experimental_timeline_enabled` + it's environment variable counterpart.

**Motivation:**

With the latest round of improvements to libdatadog, we're confident about enabling this feature by default.

**Additional Notes:**

~~I'm opening this PR as a draft as it still depends on https://github.com/DataDog/libdatadog/pull/293 being released + a few more rounds of internal validation.~~ ✅ Fixed

~~This PR also will need to be updated with the changes from https://github.com/DataDog/dd-trace-rb/pull/3357 OR the reverse will need to happen -- whichever one is merged first.~~ ✅ Fixed

**How to test the change?**

Try to profile any application, validate that you get timeline data without further configuration.

**For Datadog employees:**
- [ ] If this PR touches code that signs or publishes builds or packages, or handles
credentials of any kind, I've requested a review from `@DataDog/security-design-and-guidance`.
- [x] This PR doesn't touch any of that.
