### PR TITLE
[PROF-9036] Include profiling worker and GC stats in profiles

### DIFF
--- a/ext/ddtrace_profiling_native_extension/collectors_cpu_and_wall_time_worker.c
+++ b/ext/ddtrace_profiling_native_extension/collectors_cpu_and_wall_time_worker.c
@@ -119,6 +119,7 @@ struct cpu_and_wall_time_worker_state {
   bool during_sample;
 
   struct stats {
+    // # Generic stats
     // How many times we tried to trigger a sample
     unsigned int trigger_sample_attempts;
     // How many times we tried to simulate signal delivery
@@ -129,11 +130,6 @@ struct cpu_and_wall_time_worker_state {
     unsigned int signal_handler_enqueued_sample;
     // How many times the signal handler was called from the wrong thread
     unsigned int signal_handler_wrong_thread;
-    // How many times we actually sampled (except GC samples)
-    unsigned int sampled;
-    // How many times we skipped a sample because of the dynamic sampling rate mechanism
-    unsigned int skipped_sample_because_of_dynamic_sampling_rate;
-
     // Stats for the results of calling rb_postponed_job_register_one
       // The same function was already waiting to be executed
     unsigned int postponed_job_skipped_already_existed;
@@ -144,10 +140,25 @@ struct cpu_and_wall_time_worker_state {
       // The function returned an unknown result code
     unsigned int postponed_job_unknown_result;
 
-    // Min/max/total wall-time spent sampling (except GC samples)
-    uint64_t sampling_time_ns_min;
-    uint64_t sampling_time_ns_max;
-    uint64_t sampling_time_ns_total;
+    // # CPU/Walltime sampling stats
+    // How many times we actually CPU/wall sampled
+    unsigned int cpu_sampled;
+    // How many times we skipped a CPU/wall sample because of the dynamic sampling rate mechanism
+    unsigned int cpu_skipped;
+    // Min/max/total wall-time spent on CPU/wall sampling
+    uint64_t cpu_sampling_time_ns_min;
+    uint64_t cpu_sampling_time_ns_max;
+    uint64_t cpu_sampling_time_ns_total;
+
+    // # Allocation sampling stats
+    // How many times we actually allocation sampled
+    uint64_t allocation_sampled;
+    // How many times we skipped an allocation sample because of the dynamic sampling rate mechanism
+    uint64_t allocation_skipped;
+    // Min/max/total wall-time spent on allocation sampling
+    uint64_t allocation_sampling_time_ns_min;
+    uint64_t allocation_sampling_time_ns_max;
+    uint64_t allocation_sampling_time_ns_total;
     // How many times we saw allocations being done inside a sample
     unsigned int allocations_during_sample;
   } stats;
@@ -191,6 +202,7 @@ static VALUE _native_simulate_sample_from_postponed_job(DDTRACE_UNUSED VALUE sel
 static VALUE _native_reset_after_fork(DDTRACE_UNUSED VALUE self, VALUE instance);
 static VALUE _native_is_sigprof_blocked_in_current_thread(DDTRACE_UNUSED VALUE self);
 static VALUE _native_stats(DDTRACE_UNUSED VALUE self, VALUE instance);
+static VALUE _native_stats_reset(DDTRACE_UNUSED VALUE self, VALUE instance);
 void *simulate_sampling_signal_delivery(DDTRACE_UNUSED void *_unused);
 static void grab_gvl_and_sample(void);
 static void reset_stats(struct cpu_and_wall_time_worker_state *state);
@@ -252,6 +264,7 @@ void collectors_cpu_and_wall_time_worker_init(VALUE profiling_module) {
   rb_define_singleton_method(collectors_cpu_and_wall_time_worker_class, "_native_stop", _native_stop, 2);
   rb_define_singleton_method(collectors_cpu_and_wall_time_worker_class, "_native_reset_after_fork", _native_reset_after_fork, 1);
   rb_define_singleton_method(collectors_cpu_and_wall_time_worker_class, "_native_stats", _native_stats, 1);
+  rb_define_singleton_method(collectors_cpu_and_wall_time_worker_class, "_native_stats_reset", _native_stats_reset, 1);
   rb_define_singleton_method(collectors_cpu_and_wall_time_worker_class, "_native_allocation_count", _native_allocation_count, 0);
   rb_define_singleton_method(testing_module, "_native_current_sigprof_signal_handler", _native_current_sigprof_signal_handler, 0);
   rb_define_singleton_method(testing_module, "_native_is_running?", _native_is_running, 1);
@@ -607,11 +620,11 @@ static VALUE rescued_sample_from_postponed_job(VALUE self_instance) {
   long wall_time_ns_before_sample = monotonic_wall_time_now_ns(RAISE_ON_FAILURE);
 
   if (state->dynamic_sampling_rate_enabled && !dynamic_sampling_rate_should_sample(&state->cpu_dynamic_sampling_rate, wall_time_ns_before_sample)) {
-    state->stats.skipped_sample_because_of_dynamic_sampling_rate++;
+    state->stats.cpu_skipped++;
     return Qnil;
   }
 
-  state->stats.sampled++;
+  state->stats.cpu_sampled++;
 
   VALUE profiler_overhead_stack_thread = state->owner_thread; // Used to attribute profiler overhead to a different stack
   thread_context_collector_sample(state->thread_context_collector_instance, wall_time_ns_before_sample, profiler_overhead_stack_thread);
@@ -622,9 +635,9 @@ static VALUE rescued_sample_from_postponed_job(VALUE self_instance) {
   // Guard against wall-time going backwards, see https://github.com/DataDog/dd-trace-rb/pull/2336 for discussion.
   uint64_t sampling_time_ns = delta_ns < 0 ? 0 : delta_ns;
 
-  state->stats.sampling_time_ns_min = uint64_min_of(sampling_time_ns, state->stats.sampling_time_ns_min);
-  state->stats.sampling_time_ns_max = uint64_max_of(sampling_time_ns, state->stats.sampling_time_ns_max);
-  state->stats.sampling_time_ns_total += sampling_time_ns;
+  state->stats.cpu_sampling_time_ns_min = uint64_min_of(sampling_time_ns, state->stats.cpu_sampling_time_ns_min);
+  state->stats.cpu_sampling_time_ns_max = uint64_max_of(sampling_time_ns, state->stats.cpu_sampling_time_ns_max);
+  state->stats.cpu_sampling_time_ns_total += sampling_time_ns;
 
   dynamic_sampling_rate_after_sample(&state->cpu_dynamic_sampling_rate, wall_time_ns_after_sample, sampling_time_ns);
 
@@ -839,11 +852,24 @@ static VALUE _native_stats(DDTRACE_UNUSED VALUE self, VALUE instance) {
   struct cpu_and_wall_time_worker_state *state;
   TypedData_Get_Struct(instance, struct cpu_and_wall_time_worker_state, &cpu_and_wall_time_worker_typed_data, state);
 
-  VALUE pretty_sampling_time_ns_min = state->stats.sampling_time_ns_min == UINT64_MAX ? Qnil : ULL2NUM(state->stats.sampling_time_ns_min);
-  VALUE pretty_sampling_time_ns_max = state->stats.sampling_time_ns_max == 0 ? Qnil : ULL2NUM(state->stats.sampling_time_ns_max);
-  VALUE pretty_sampling_time_ns_total = state->stats.sampling_time_ns_total == 0 ? Qnil : ULL2NUM(state->stats.sampling_time_ns_total);
-  VALUE pretty_sampling_time_ns_avg =
-    state->stats.sampled == 0 ? Qnil : DBL2NUM(((double) state->stats.sampling_time_ns_total) / state->stats.sampled);
+  VALUE pretty_cpu_sampling_time_ns_min = state->stats.cpu_sampling_time_ns_min == UINT64_MAX ? Qnil : ULL2NUM(state->stats.cpu_sampling_time_ns_min);
+  VALUE pretty_cpu_sampling_time_ns_max = state->stats.cpu_sampling_time_ns_max == 0 ? Qnil : ULL2NUM(state->stats.cpu_sampling_time_ns_max);
+  VALUE pretty_cpu_sampling_time_ns_total = state->stats.cpu_sampling_time_ns_total == 0 ? Qnil : ULL2NUM(state->stats.cpu_sampling_time_ns_total);
+  VALUE pretty_cpu_sampling_time_ns_avg =
+    state->stats.cpu_sampled == 0 ? Qnil : DBL2NUM(((double) state->stats.cpu_sampling_time_ns_total) / state->stats.cpu_sampled);
+
+  VALUE pretty_allocation_sampling_time_ns_min = state->stats.allocation_sampling_time_ns_min == UINT64_MAX ? Qnil : ULL2NUM(state->stats.allocation_sampling_time_ns_min);
+  VALUE pretty_allocation_sampling_time_ns_max = state->stats.allocation_sampling_time_ns_max == 0 ? Qnil : ULL2NUM(state->stats.allocation_sampling_time_ns_max);
+  VALUE pretty_allocation_sampling_time_ns_total = state->stats.allocation_sampling_time_ns_total == 0 ? Qnil : ULL2NUM(state->stats.allocation_sampling_time_ns_total);
+  VALUE pretty_allocation_sampling_time_ns_avg =
+    state->stats.allocation_sampled == 0 ? Qnil : DBL2NUM(((double) state->stats.allocation_sampling_time_ns_total) / state->stats.allocation_sampled);
+
+  unsigned long total_cpu_samples_attempted = state->stats.cpu_sampled + state->stats.cpu_skipped;
+  VALUE effective_cpu_sample_rate =
+    total_cpu_samples_attempted == 0 ? Qnil : DBL2NUM(((double) state->stats.cpu_sampled) / total_cpu_samples_attempted);
+  unsigned long total_allocation_samples_attempted = state->stats.allocation_sampled + state->stats.allocation_skipped;
+  VALUE effective_allocation_sample_rate =
+    total_allocation_samples_attempted == 0 ? Qnil : DBL2NUM(((double) state->stats.allocation_sampled) / total_allocation_samples_attempted);
 
   VALUE stats_as_hash = rb_hash_new();
   VALUE arguments[] = {
@@ -852,20 +878,40 @@ static VALUE _native_stats(DDTRACE_UNUSED VALUE self, VALUE instance) {
     ID2SYM(rb_intern("simulated_signal_delivery")),                  /* => */ UINT2NUM(state->stats.simulated_signal_delivery),
     ID2SYM(rb_intern("signal_handler_enqueued_sample")),             /* => */ UINT2NUM(state->stats.signal_handler_enqueued_sample),
     ID2SYM(rb_intern("signal_handler_wrong_thread")),                /* => */ UINT2NUM(state->stats.signal_handler_wrong_thread),
-    ID2SYM(rb_intern("sampled")),                                    /* => */ UINT2NUM(state->stats.sampled),
-    ID2SYM(rb_intern("skipped_sample_because_of_dynamic_sampling_rate")), /* => */ UINT2NUM(state->stats.skipped_sample_because_of_dynamic_sampling_rate),
     ID2SYM(rb_intern("postponed_job_skipped_already_existed")),      /* => */ UINT2NUM(state->stats.postponed_job_skipped_already_existed),
     ID2SYM(rb_intern("postponed_job_success")),                      /* => */ UINT2NUM(state->stats.postponed_job_success),
     ID2SYM(rb_intern("postponed_job_full")),                         /* => */ UINT2NUM(state->stats.postponed_job_full),
     ID2SYM(rb_intern("postponed_job_unknown_result")),               /* => */ UINT2NUM(state->stats.postponed_job_unknown_result),
-    ID2SYM(rb_intern("sampling_time_ns_min")),                       /* => */ pretty_sampling_time_ns_min,
-    ID2SYM(rb_intern("sampling_time_ns_max")),                       /* => */ pretty_sampling_time_ns_max,
-    ID2SYM(rb_intern("sampling_time_ns_total")),                     /* => */ pretty_sampling_time_ns_total,
-    ID2SYM(rb_intern("sampling_time_ns_avg")),                       /* => */ pretty_sampling_time_ns_avg,
-    ID2SYM(rb_intern("allocations_during_sample")),                  /* => */ UINT2NUM(state->stats.allocations_during_sample),
+
+    // CPU Stats
+    ID2SYM(rb_intern("cpu_sampled")),                /* => */ UINT2NUM(state->stats.cpu_sampled),
+    ID2SYM(rb_intern("cpu_skipped")),                /* => */ UINT2NUM(state->stats.cpu_skipped),
+    ID2SYM(rb_intern("cpu_effective_sample_rate")),  /* => */ effective_cpu_sample_rate,
+    ID2SYM(rb_intern("cpu_sampling_time_ns_min")),   /* => */ pretty_cpu_sampling_time_ns_min,
+    ID2SYM(rb_intern("cpu_sampling_time_ns_max")),   /* => */ pretty_cpu_sampling_time_ns_max,
+    ID2SYM(rb_intern("cpu_sampling_time_ns_total")), /* => */ pretty_cpu_sampling_time_ns_total,
+    ID2SYM(rb_intern("cpu_sampling_time_ns_avg")),   /* => */ pretty_cpu_sampling_time_ns_avg,
+
+    // Allocation stats
+    ID2SYM(rb_intern("allocation_sampled")),                /* => */ ULONG2NUM(state->stats.allocation_sampled),
+    ID2SYM(rb_intern("allocation_skipped")),                /* => */ ULONG2NUM(state->stats.allocation_skipped),
+    ID2SYM(rb_intern("allocation_effective_sample_rate")),  /* => */ effective_allocation_sample_rate,
+    ID2SYM(rb_intern("allocation_sampling_time_ns_min")),   /* => */ pretty_allocation_sampling_time_ns_min,
+    ID2SYM(rb_intern("allocation_sampling_time_ns_max")),   /* => */ pretty_allocation_sampling_time_ns_max,
+    ID2SYM(rb_intern("allocation_sampling_time_ns_total")), /* => */ pretty_allocation_sampling_time_ns_total,
+    ID2SYM(rb_intern("allocation_sampling_time_ns_avg")),   /* => */ pretty_allocation_sampling_time_ns_avg,
+    ID2SYM(rb_intern("allocation_sampler_snapshot")),       /* => */ discrete_dynamic_sampler_state_snapshot(&state->allocation_sampler),
+    ID2SYM(rb_intern("allocations_during_sample")),         /* => */ UINT2NUM(state->stats.allocations_during_sample),
   };
   for (long unsigned int i = 0; i < VALUE_COUNT(arguments); i += 2) rb_hash_aset(stats_as_hash, arguments[i], arguments[i+1]);
   return stats_as_hash;
+}
+
+static VALUE _native_stats_reset(DDTRACE_UNUSED VALUE self, VALUE instance) {
+  struct cpu_and_wall_time_worker_state *state;
+  TypedData_Get_Struct(instance, struct cpu_and_wall_time_worker_state, &cpu_and_wall_time_worker_typed_data, state);
+  reset_stats(state);
+  return Qnil;
 }
 
 void *simulate_sampling_signal_delivery(DDTRACE_UNUSED void *_unused) {
@@ -886,8 +932,16 @@ void *simulate_sampling_signal_delivery(DDTRACE_UNUSED void *_unused) {
 static void grab_gvl_and_sample(void) { rb_thread_call_with_gvl(simulate_sampling_signal_delivery, NULL); }
 
 static void reset_stats(struct cpu_and_wall_time_worker_state *state) {
-  state->stats = (struct stats) {}; // Resets all stats back to zero
-  state->stats.sampling_time_ns_min = UINT64_MAX; // Since we always take the min between existing and latest sample
+  // NOTE: This is not really thread safe so ongoing sampling operations that are concurrent with a reset can have their stats:
+  //       * Lost (writes after stats retrieval but before reset).
+  //       * Included in the previous stats window (writes before stats retrieval and reset).
+  //       * Included in the following stats window (writes after stats retrieval and reset).
+  //       Given the expected infrequency of resetting (~once per 60s profile) and the auxiliary/non-critical nature of these stats
+  //       this momentary loss of accuracy is deemed acceptable to keep overhead to a minimum.
+  state->stats = (struct stats) {
+    .cpu_sampling_time_ns_min = UINT64_MAX, // Since we always take the min between existing and latest sample
+    .allocation_sampling_time_ns_min = UINT64_MAX, // Since we always take the min between existing and latest sample
+  };
 }
 
 static void sleep_for(uint64_t time_ns) {
@@ -938,6 +992,7 @@ static void on_newobj_event(VALUE tracepoint_data, DDTRACE_UNUSED void *unused) 
   }
 
   if (state->dynamic_sampling_rate_enabled && !discrete_dynamic_sampler_should_sample(&state->allocation_sampler)) {
+    state->stats.cpu_skipped++;
     return;
   }
 
@@ -950,7 +1005,11 @@ static void on_newobj_event(VALUE tracepoint_data, DDTRACE_UNUSED void *unused) 
   // Rescue against any exceptions that happen during sampling
   safely_call(rescued_sample_allocation, tracepoint_data, state->self_instance);
 
-  discrete_dynamic_sampler_after_sample(&state->allocation_sampler);
+  uint64_t sampling_time_ns = discrete_dynamic_sampler_after_sample(&state->allocation_sampler);
+  state->stats.allocation_sampling_time_ns_min = uint64_min_of(sampling_time_ns, state->stats.allocation_sampling_time_ns_min);
+  state->stats.allocation_sampling_time_ns_max = uint64_max_of(sampling_time_ns, state->stats.allocation_sampling_time_ns_max);
+  state->stats.allocation_sampling_time_ns_total += sampling_time_ns;
+  state->stats.allocation_sampled++;
 
   state->during_sample = false;
 }

--- a/ext/ddtrace_profiling_native_extension/collectors_cpu_and_wall_time_worker.c
+++ b/ext/ddtrace_profiling_native_extension/collectors_cpu_and_wall_time_worker.c
@@ -992,7 +992,7 @@ static void on_newobj_event(VALUE tracepoint_data, DDTRACE_UNUSED void *unused) 
   }
 
   if (state->dynamic_sampling_rate_enabled && !discrete_dynamic_sampler_should_sample(&state->allocation_sampler)) {
-    state->stats.cpu_skipped++;
+    state->stats.allocation_skipped++;
     return;
   }
 

--- a/ext/ddtrace_profiling_native_extension/collectors_cpu_and_wall_time_worker.c
+++ b/ext/ddtrace_profiling_native_extension/collectors_cpu_and_wall_time_worker.c
@@ -130,14 +130,15 @@ struct cpu_and_wall_time_worker_state {
     unsigned int signal_handler_enqueued_sample;
     // How many times the signal handler was called from the wrong thread
     unsigned int signal_handler_wrong_thread;
-    // Stats for the results of calling rb_postponed_job_register_one
-      // The same function was already waiting to be executed
+
+    // # Stats for the results of calling rb_postponed_job_register_one
+    // The same function was already waiting to be executed
     unsigned int postponed_job_skipped_already_existed;
-      // The function was added to the queue successfully
+    // The function was added to the queue successfully
     unsigned int postponed_job_success;
-      // The queue was full
+    // The queue was full
     unsigned int postponed_job_full;
-      // The function returned an unknown result code
+    // The function returned an unknown result code
     unsigned int postponed_job_unknown_result;
 
     // # CPU/Walltime sampling stats
@@ -202,10 +203,10 @@ static VALUE _native_simulate_sample_from_postponed_job(DDTRACE_UNUSED VALUE sel
 static VALUE _native_reset_after_fork(DDTRACE_UNUSED VALUE self, VALUE instance);
 static VALUE _native_is_sigprof_blocked_in_current_thread(DDTRACE_UNUSED VALUE self);
 static VALUE _native_stats(DDTRACE_UNUSED VALUE self, VALUE instance);
-static VALUE _native_stats_reset(DDTRACE_UNUSED VALUE self, VALUE instance);
+static VALUE _native_stats_reset_not_thread_safe(DDTRACE_UNUSED VALUE self, VALUE instance);
 void *simulate_sampling_signal_delivery(DDTRACE_UNUSED void *_unused);
 static void grab_gvl_and_sample(void);
-static void reset_stats(struct cpu_and_wall_time_worker_state *state);
+static void reset_stats_not_thread_safe(struct cpu_and_wall_time_worker_state *state);
 static void sleep_for(uint64_t time_ns);
 static VALUE _native_allocation_count(DDTRACE_UNUSED VALUE self);
 static void on_newobj_event(VALUE tracepoint_data, DDTRACE_UNUSED void *unused);
@@ -264,7 +265,7 @@ void collectors_cpu_and_wall_time_worker_init(VALUE profiling_module) {
   rb_define_singleton_method(collectors_cpu_and_wall_time_worker_class, "_native_stop", _native_stop, 2);
   rb_define_singleton_method(collectors_cpu_and_wall_time_worker_class, "_native_reset_after_fork", _native_reset_after_fork, 1);
   rb_define_singleton_method(collectors_cpu_and_wall_time_worker_class, "_native_stats", _native_stats, 1);
-  rb_define_singleton_method(collectors_cpu_and_wall_time_worker_class, "_native_stats_reset", _native_stats_reset, 1);
+  rb_define_singleton_method(collectors_cpu_and_wall_time_worker_class, "_native_stats_reset_not_thread_safe", _native_stats_reset_not_thread_safe, 1);
   rb_define_singleton_method(collectors_cpu_and_wall_time_worker_class, "_native_allocation_count", _native_allocation_count, 0);
   rb_define_singleton_method(testing_module, "_native_current_sigprof_signal_handler", _native_current_sigprof_signal_handler, 0);
   rb_define_singleton_method(testing_module, "_native_is_running?", _native_is_running, 1);
@@ -315,7 +316,7 @@ static VALUE _native_new(VALUE klass) {
 
   state->during_sample = false;
 
-  reset_stats(state);
+  reset_stats_not_thread_safe(state);
 
   return state->self_instance = TypedData_Wrap_Struct(klass, &cpu_and_wall_time_worker_typed_data, state);
 }
@@ -836,7 +837,7 @@ static VALUE _native_reset_after_fork(DDTRACE_UNUSED VALUE self, VALUE instance)
   // Disable all tracepoints, so that there are no more attempts to mutate the profile
   disable_tracepoints(state);
 
-  reset_stats(state);
+  reset_stats_not_thread_safe(state);
 
   // Remove all state from the `Collectors::ThreadState` and connected downstream components
   rb_funcall(state->thread_context_collector_instance, rb_intern("reset_after_fork"), 0);
@@ -871,6 +872,9 @@ static VALUE _native_stats(DDTRACE_UNUSED VALUE self, VALUE instance) {
   VALUE effective_allocation_sample_rate =
     total_allocation_samples_attempted == 0 ? Qnil : DBL2NUM(((double) state->stats.allocation_sampled) / total_allocation_samples_attempted);
 
+  VALUE allocation_sampler_snapshot = state->allocation_profiling_enabled && state->dynamic_sampling_rate_enabled ?
+    discrete_dynamic_sampler_state_snapshot(&state->allocation_sampler) : Qnil;
+
   VALUE stats_as_hash = rb_hash_new();
   VALUE arguments[] = {
     ID2SYM(rb_intern("trigger_sample_attempts")),                    /* => */ UINT2NUM(state->stats.trigger_sample_attempts),
@@ -893,24 +897,24 @@ static VALUE _native_stats(DDTRACE_UNUSED VALUE self, VALUE instance) {
     ID2SYM(rb_intern("cpu_sampling_time_ns_avg")),   /* => */ pretty_cpu_sampling_time_ns_avg,
 
     // Allocation stats
-    ID2SYM(rb_intern("allocation_sampled")),                /* => */ ULONG2NUM(state->stats.allocation_sampled),
-    ID2SYM(rb_intern("allocation_skipped")),                /* => */ ULONG2NUM(state->stats.allocation_skipped),
+    ID2SYM(rb_intern("allocation_sampled")),                /* => */ state->allocation_profiling_enabled ? ULONG2NUM(state->stats.allocation_sampled) : Qnil,
+    ID2SYM(rb_intern("allocation_skipped")),                /* => */ state->allocation_profiling_enabled ? ULONG2NUM(state->stats.allocation_skipped) : Qnil,
     ID2SYM(rb_intern("allocation_effective_sample_rate")),  /* => */ effective_allocation_sample_rate,
     ID2SYM(rb_intern("allocation_sampling_time_ns_min")),   /* => */ pretty_allocation_sampling_time_ns_min,
     ID2SYM(rb_intern("allocation_sampling_time_ns_max")),   /* => */ pretty_allocation_sampling_time_ns_max,
     ID2SYM(rb_intern("allocation_sampling_time_ns_total")), /* => */ pretty_allocation_sampling_time_ns_total,
     ID2SYM(rb_intern("allocation_sampling_time_ns_avg")),   /* => */ pretty_allocation_sampling_time_ns_avg,
-    ID2SYM(rb_intern("allocation_sampler_snapshot")),       /* => */ discrete_dynamic_sampler_state_snapshot(&state->allocation_sampler),
-    ID2SYM(rb_intern("allocations_during_sample")),         /* => */ UINT2NUM(state->stats.allocations_during_sample),
+    ID2SYM(rb_intern("allocation_sampler_snapshot")),       /* => */ allocation_sampler_snapshot,
+    ID2SYM(rb_intern("allocations_during_sample")),         /* => */ state->allocation_profiling_enabled ? UINT2NUM(state->stats.allocations_during_sample) : Qnil,
   };
   for (long unsigned int i = 0; i < VALUE_COUNT(arguments); i += 2) rb_hash_aset(stats_as_hash, arguments[i], arguments[i+1]);
   return stats_as_hash;
 }
 
-static VALUE _native_stats_reset(DDTRACE_UNUSED VALUE self, VALUE instance) {
+static VALUE _native_stats_reset_not_thread_safe(DDTRACE_UNUSED VALUE self, VALUE instance) {
   struct cpu_and_wall_time_worker_state *state;
   TypedData_Get_Struct(instance, struct cpu_and_wall_time_worker_state, &cpu_and_wall_time_worker_typed_data, state);
-  reset_stats(state);
+  reset_stats_not_thread_safe(state);
   return Qnil;
 }
 
@@ -931,7 +935,7 @@ void *simulate_sampling_signal_delivery(DDTRACE_UNUSED void *_unused) {
 
 static void grab_gvl_and_sample(void) { rb_thread_call_with_gvl(simulate_sampling_signal_delivery, NULL); }
 
-static void reset_stats(struct cpu_and_wall_time_worker_state *state) {
+static void reset_stats_not_thread_safe(struct cpu_and_wall_time_worker_state *state) {
   // NOTE: This is not really thread safe so ongoing sampling operations that are concurrent with a reset can have their stats:
   //       * Lost (writes after stats retrieval but before reset).
   //       * Included in the previous stats window (writes before stats retrieval and reset).
@@ -1005,10 +1009,14 @@ static void on_newobj_event(VALUE tracepoint_data, DDTRACE_UNUSED void *unused) 
   // Rescue against any exceptions that happen during sampling
   safely_call(rescued_sample_allocation, tracepoint_data, state->self_instance);
 
-  uint64_t sampling_time_ns = discrete_dynamic_sampler_after_sample(&state->allocation_sampler);
-  state->stats.allocation_sampling_time_ns_min = uint64_min_of(sampling_time_ns, state->stats.allocation_sampling_time_ns_min);
-  state->stats.allocation_sampling_time_ns_max = uint64_max_of(sampling_time_ns, state->stats.allocation_sampling_time_ns_max);
-  state->stats.allocation_sampling_time_ns_total += sampling_time_ns;
+  if (state->dynamic_sampling_rate_enabled) {
+    // NOTE: To keep things lean when dynamic sampling rate is disabled we skip clock interactions.
+    uint64_t sampling_time_ns = discrete_dynamic_sampler_after_sample(&state->allocation_sampler);
+    state->stats.allocation_sampling_time_ns_min = uint64_min_of(sampling_time_ns, state->stats.allocation_sampling_time_ns_min);
+    state->stats.allocation_sampling_time_ns_max = uint64_max_of(sampling_time_ns, state->stats.allocation_sampling_time_ns_max);
+    state->stats.allocation_sampling_time_ns_total += sampling_time_ns;
+  }
+
   state->stats.allocation_sampled++;
 
   state->during_sample = false;

--- a/ext/ddtrace_profiling_native_extension/collectors_discrete_dynamic_sampler.c
+++ b/ext/ddtrace_profiling_native_extension/collectors_discrete_dynamic_sampler.c
@@ -255,6 +255,23 @@ static void maybe_readjust(discrete_dynamic_sampler *sampler, long now) {
   sampler->has_completed_full_adjustment_window = true;
 }
 
+VALUE discrete_dynamic_sampler_state_snapshot(discrete_dynamic_sampler *sampler) {
+  VALUE arguments[] = {
+    ID2SYM(rb_intern("target_overhead")),                 /* => */ DBL2NUM(sampler->target_overhead),
+    ID2SYM(rb_intern("target_overhead_adjustment")),      /* => */ DBL2NUM(sampler->target_overhead_adjustment),
+    ID2SYM(rb_intern("events_per_sec")),                  /* => */ DBL2NUM(sampler->events_per_ns / 1e9),
+    ID2SYM(rb_intern("sampling_time_ns")),                /* => */ LONG2NUM(sampler->sampling_time_ns),
+    ID2SYM(rb_intern("sampling_interval")),               /* => */ ULONG2NUM(sampler->sampling_interval),
+    ID2SYM(rb_intern("sampling_probability")),            /* => */ DBL2NUM(sampler->sampling_probability),
+    ID2SYM(rb_intern("events_since_last_readjustment")),  /* => */ ULONG2NUM(sampler->events_since_last_readjustment),
+    ID2SYM(rb_intern("samples_since_last_readjustment")), /* => */ ULONG2NUM(sampler->samples_since_last_readjustment),
+  };
+  size_t entries = VALUE_COUNT(arguments) / 2;
+  VALUE hash = rb_hash_new_capa(entries);
+  rb_hash_bulk_insert(entries * 2, arguments, hash);
+  return hash;
+}
+
 // ---
 // Below here is boilerplate to expose the above code to Ruby so that we can test it with RSpec as usual.
 

--- a/ext/ddtrace_profiling_native_extension/collectors_discrete_dynamic_sampler.c
+++ b/ext/ddtrace_profiling_native_extension/collectors_discrete_dynamic_sampler.c
@@ -259,7 +259,7 @@ VALUE discrete_dynamic_sampler_state_snapshot(discrete_dynamic_sampler *sampler)
   VALUE arguments[] = {
     ID2SYM(rb_intern("target_overhead")),                 /* => */ DBL2NUM(sampler->target_overhead),
     ID2SYM(rb_intern("target_overhead_adjustment")),      /* => */ DBL2NUM(sampler->target_overhead_adjustment),
-    ID2SYM(rb_intern("events_per_sec")),                  /* => */ DBL2NUM(sampler->events_per_ns / 1e9),
+    ID2SYM(rb_intern("events_per_sec")),                  /* => */ DBL2NUM(sampler->events_per_ns * 1e9),
     ID2SYM(rb_intern("sampling_time_ns")),                /* => */ LONG2NUM(sampler->sampling_time_ns),
     ID2SYM(rb_intern("sampling_interval")),               /* => */ ULONG2NUM(sampler->sampling_interval),
     ID2SYM(rb_intern("sampling_probability")),            /* => */ DBL2NUM(sampler->sampling_probability),

--- a/ext/ddtrace_profiling_native_extension/collectors_discrete_dynamic_sampler.c
+++ b/ext/ddtrace_profiling_native_extension/collectors_discrete_dynamic_sampler.c
@@ -266,9 +266,8 @@ VALUE discrete_dynamic_sampler_state_snapshot(discrete_dynamic_sampler *sampler)
     ID2SYM(rb_intern("events_since_last_readjustment")),  /* => */ ULONG2NUM(sampler->events_since_last_readjustment),
     ID2SYM(rb_intern("samples_since_last_readjustment")), /* => */ ULONG2NUM(sampler->samples_since_last_readjustment),
   };
-  size_t entries = VALUE_COUNT(arguments) / 2;
-  VALUE hash = rb_hash_new_capa(entries);
-  rb_hash_bulk_insert(entries * 2, arguments, hash);
+  VALUE hash = rb_hash_new();
+  for (long unsigned int i = 0; i < VALUE_COUNT(arguments); i += 2) rb_hash_aset(hash, arguments[i], arguments[i+1]);
   return hash;
 }
 

--- a/ext/ddtrace_profiling_native_extension/collectors_discrete_dynamic_sampler.c
+++ b/ext/ddtrace_profiling_native_extension/collectors_discrete_dynamic_sampler.c
@@ -262,7 +262,7 @@ VALUE discrete_dynamic_sampler_state_snapshot(discrete_dynamic_sampler *sampler)
     ID2SYM(rb_intern("events_per_sec")),                  /* => */ DBL2NUM(sampler->events_per_ns * 1e9),
     ID2SYM(rb_intern("sampling_time_ns")),                /* => */ LONG2NUM(sampler->sampling_time_ns),
     ID2SYM(rb_intern("sampling_interval")),               /* => */ ULONG2NUM(sampler->sampling_interval),
-    ID2SYM(rb_intern("sampling_probability")),            /* => */ DBL2NUM(sampler->sampling_probability),
+    ID2SYM(rb_intern("sampling_probability")),            /* => */ DBL2NUM(sampler->sampling_probability * 100),
     ID2SYM(rb_intern("events_since_last_readjustment")),  /* => */ ULONG2NUM(sampler->events_since_last_readjustment),
     ID2SYM(rb_intern("samples_since_last_readjustment")), /* => */ ULONG2NUM(sampler->samples_since_last_readjustment),
   };

--- a/ext/ddtrace_profiling_native_extension/collectors_discrete_dynamic_sampler.h
+++ b/ext/ddtrace_profiling_native_extension/collectors_discrete_dynamic_sampler.h
@@ -3,6 +3,8 @@
 #include <stdbool.h>
 #include <stddef.h>
 
+#include <ruby.h>
+
 // A sampler that will sample discrete events based on the overhead of their
 // sampling.
 //
@@ -87,3 +89,8 @@ double discrete_dynamic_sampler_probability(discrete_dynamic_sampler *sampler);
 
 // Retrieve the current number of events seen since last sample.
 unsigned long discrete_dynamic_sampler_events_since_last_sample(discrete_dynamic_sampler *sampler);
+
+// Return a Ruby hash containing a snapshot of this sampler's interesting state at calling time.
+// WARN: This allocates in the Ruby VM and therefore should not be called without the
+//       VM lock or during GC.
+VALUE discrete_dynamic_sampler_state_snapshot(discrete_dynamic_sampler *sampler);

--- a/lib/datadog/profiling/collectors/cpu_and_wall_time_worker.rb
+++ b/lib/datadog/profiling/collectors/cpu_and_wall_time_worker.rb
@@ -101,9 +101,9 @@ module Datadog
           self.class._native_stats(self)
         end
 
-        def stats_and_reset
+        def stats_and_reset_not_thread_safe
           stats = self.stats
-          self.class._native_stats_reset(self)
+          self.class._native_stats_reset_not_thread_safe(self)
           stats
         end
       end

--- a/lib/datadog/profiling/collectors/cpu_and_wall_time_worker.rb
+++ b/lib/datadog/profiling/collectors/cpu_and_wall_time_worker.rb
@@ -100,6 +100,12 @@ module Datadog
         def stats
           self.class._native_stats(self)
         end
+
+        def stats_and_reset
+          stats = self.stats
+          self.class._native_stats_reset(self)
+          stats
+        end
       end
     end
   end

--- a/lib/datadog/profiling/component.rb
+++ b/lib/datadog/profiling/component.rb
@@ -72,7 +72,7 @@ module Datadog
           heap_sample_every: heap_sample_every,
         }.freeze
 
-        exporter = build_profiler_exporter(settings, recorder, internal_metadata: internal_metadata)
+        exporter = build_profiler_exporter(settings, recorder, worker, internal_metadata: internal_metadata)
         transport = build_profiler_transport(settings, agent_settings)
         scheduler = Profiling::Scheduler.new(exporter: exporter, transport: transport, interval: upload_period_seconds)
 
@@ -89,12 +89,13 @@ module Datadog
         )
       end
 
-      private_class_method def self.build_profiler_exporter(settings, recorder, internal_metadata:)
+      private_class_method def self.build_profiler_exporter(settings, recorder, worker, internal_metadata:)
         code_provenance_collector =
           (Profiling::Collectors::CodeProvenance.new if settings.profiling.advanced.code_provenance_enabled)
 
         Profiling::Exporter.new(
           pprof_recorder: recorder,
+          worker: worker,
           code_provenance_collector: code_provenance_collector,
           internal_metadata: internal_metadata,
         )

--- a/lib/datadog/profiling/exporter.rb
+++ b/lib/datadog/profiling/exporter.rb
@@ -46,7 +46,7 @@ module Datadog
       end
 
       def flush
-        worker_stats = @worker.stats_and_reset
+        worker_stats = @worker.stats_and_reset_not_thread_safe
         start, finish, uncompressed_pprof = pprof_recorder.serialize
         @last_flush_finish_at = finish
 

--- a/lib/datadog/profiling/exporter.rb
+++ b/lib/datadog/profiling/exporter.rb
@@ -29,12 +29,14 @@ module Datadog
 
       def initialize(
         pprof_recorder:,
+        worker:,
         code_provenance_collector:,
         internal_metadata:,
         minimum_duration_seconds: PROFILE_DURATION_THRESHOLD_SECONDS,
         time_provider: Time
       )
         @pprof_recorder = pprof_recorder
+        @worker = worker
         @code_provenance_collector = code_provenance_collector
         @minimum_duration_seconds = minimum_duration_seconds
         @time_provider = time_provider
@@ -44,6 +46,7 @@ module Datadog
       end
 
       def flush
+        worker_stats = @worker.stats_and_reset
         start, finish, uncompressed_pprof = pprof_recorder.serialize
         @last_flush_finish_at = finish
 
@@ -64,7 +67,12 @@ module Datadog
           code_provenance_file_name: Datadog::Profiling::Ext::Transport::HTTP::CODE_PROVENANCE_FILENAME,
           code_provenance_data: uncompressed_code_provenance,
           tags_as_array: Datadog::Profiling::TagBuilder.call(settings: Datadog.configuration).to_a,
-          internal_metadata: internal_metadata,
+          internal_metadata: internal_metadata.merge(
+            {
+              worker_stats: worker_stats,
+              gc: GC.stat,
+            }
+          ),
         )
       end
 

--- a/lib/datadog/profiling/flush.rb
+++ b/lib/datadog/profiling/flush.rb
@@ -33,7 +33,7 @@ module Datadog
         @code_provenance_file_name = code_provenance_file_name
         @code_provenance_data = code_provenance_data
         @tags_as_array = tags_as_array
-        @internal_metadata_json = JSON.fast_generate(internal_metadata.map { |k, v| [k, v.to_s] }.to_h)
+        @internal_metadata_json = JSON.fast_generate(internal_metadata)
       end
     end
   end

--- a/sig/datadog/profiling/collectors/cpu_and_wall_time_worker.rbs
+++ b/sig/datadog/profiling/collectors/cpu_and_wall_time_worker.rbs
@@ -38,6 +38,7 @@ module Datadog
 
         def stats: () -> ::Hash[::Symbol, untyped]
         def self._native_stats: (CpuAndWallTimeWorker self_instance) -> ::Hash[::Symbol, untyped]
+        def self._native_stats_reset: (CpuAndWallTimeWorker self_instance) -> void
 
         def self._native_allocation_count: () -> ::Integer?
         def self._native_sampling_loop: (CpuAndWallTimeWorker self_instance) -> void

--- a/sig/datadog/profiling/collectors/cpu_and_wall_time_worker.rbs
+++ b/sig/datadog/profiling/collectors/cpu_and_wall_time_worker.rbs
@@ -38,7 +38,7 @@ module Datadog
 
         def stats: () -> ::Hash[::Symbol, untyped]
         def self._native_stats: (CpuAndWallTimeWorker self_instance) -> ::Hash[::Symbol, untyped]
-        def self._native_stats_reset: (CpuAndWallTimeWorker self_instance) -> void
+        def self._native_stats_reset_not_thread_safe: (CpuAndWallTimeWorker self_instance) -> void
 
         def self._native_allocation_count: () -> ::Integer?
         def self._native_sampling_loop: (CpuAndWallTimeWorker self_instance) -> void

--- a/sig/datadog/profiling/component.rbs
+++ b/sig/datadog/profiling/component.rbs
@@ -17,6 +17,7 @@ module Datadog
       def self.build_profiler_exporter: (
         untyped settings,
         Datadog::Profiling::StackRecorder recorder,
+        Datadog::Profiling::Collectors::CpuAndWallTimeWorker worker,
         internal_metadata: ::Hash[::Symbol, ::String | bool | ::Numeric],
       ) -> Datadog::Profiling::Exporter
 

--- a/sig/datadog/profiling/exporter.rbs
+++ b/sig/datadog/profiling/exporter.rbs
@@ -11,14 +11,15 @@ module Datadog
       attr_reader time_provider: untyped
       attr_reader last_flush_finish_at: ::Time?
       attr_reader created_at: ::Time
-      attr_reader internal_metadata: ::Hash[::Symbol, ::String | bool | ::Numeric]
+      attr_reader internal_metadata: ::Hash[::Symbol, untyped]
 
       public
 
       def initialize: (
         pprof_recorder: Datadog::Profiling::StackRecorder,
+        worker: Datadog::Profiling::Collectors::CpuAndWallTimeWorker,
         code_provenance_collector: Datadog::Profiling::Collectors::CodeProvenance?,
-        internal_metadata: ::Hash[::Symbol, ::String | bool | ::Numeric],
+        internal_metadata: ::Hash[::Symbol, untyped],
         ?minimum_duration_seconds: ::Integer,
         ?time_provider: untyped
       ) -> void

--- a/spec/datadog/profiling/collectors/cpu_and_wall_time_worker_spec.rb
+++ b/spec/datadog/profiling/collectors/cpu_and_wall_time_worker_spec.rb
@@ -211,10 +211,10 @@ RSpec.describe 'Datadog::Profiling::Collectors::CpuAndWallTimeWorker' do
 
       stats = cpu_and_wall_time_worker.stats
 
-      sampling_time_ns_min = stats.fetch(:sampling_time_ns_min)
-      sampling_time_ns_max = stats.fetch(:sampling_time_ns_max)
-      sampling_time_ns_total = stats.fetch(:sampling_time_ns_total)
-      sampling_time_ns_avg = stats.fetch(:sampling_time_ns_avg)
+      sampling_time_ns_min = stats.fetch(:cpu_sampling_time_ns_min)
+      sampling_time_ns_max = stats.fetch(:cpu_sampling_time_ns_max)
+      sampling_time_ns_total = stats.fetch(:cpu_sampling_time_ns_total)
+      sampling_time_ns_avg = stats.fetch(:cpu_sampling_time_ns_avg)
 
       expect(sampling_time_ns_min).to be <= sampling_time_ns_max
       expect(sampling_time_ns_max).to be <= sampling_time_ns_total
@@ -832,23 +832,34 @@ RSpec.describe 'Datadog::Profiling::Collectors::CpuAndWallTimeWorker' do
 
       reset_after_fork
 
-      expect(cpu_and_wall_time_worker.stats).to eq(
-        trigger_sample_attempts: 0,
-        trigger_simulated_signal_delivery_attempts: 0,
-        simulated_signal_delivery: 0,
-        signal_handler_enqueued_sample: 0,
-        signal_handler_wrong_thread: 0,
-        sampled: 0,
-        skipped_sample_because_of_dynamic_sampling_rate: 0,
-        postponed_job_skipped_already_existed: 0,
-        postponed_job_success: 0,
-        postponed_job_full: 0,
-        postponed_job_unknown_result: 0,
-        sampling_time_ns_min: nil,
-        sampling_time_ns_max: nil,
-        sampling_time_ns_total: nil,
-        sampling_time_ns_avg: nil,
-        allocations_during_sample: 0,
+      expect(cpu_and_wall_time_worker.stats).to match(
+        {
+          trigger_sample_attempts: 0,
+          trigger_simulated_signal_delivery_attempts: 0,
+          simulated_signal_delivery: 0,
+          signal_handler_enqueued_sample: 0,
+          signal_handler_wrong_thread: 0,
+          postponed_job_skipped_already_existed: 0,
+          postponed_job_success: 0,
+          postponed_job_full: 0,
+          postponed_job_unknown_result: 0,
+          cpu_sampled: 0,
+          cpu_skipped: 0,
+          cpu_effective_sample_rate: nil,
+          cpu_sampling_time_ns_min: nil,
+          cpu_sampling_time_ns_max: nil,
+          cpu_sampling_time_ns_total: nil,
+          cpu_sampling_time_ns_avg: nil,
+          allocation_sampled: 0,
+          allocation_skipped: 0,
+          allocation_effective_sample_rate: nil,
+          allocation_sampling_time_ns_min: nil,
+          allocation_sampling_time_ns_max: nil,
+          allocation_sampling_time_ns_total: nil,
+          allocation_sampling_time_ns_avg: nil,
+          allocation_sampler_snapshot: hash_including(:sampling_probability => be > 0),
+          allocations_during_sample: 0,
+        }
       )
     end
   end

--- a/spec/datadog/profiling/collectors/cpu_and_wall_time_worker_spec.rb
+++ b/spec/datadog/profiling/collectors/cpu_and_wall_time_worker_spec.rb
@@ -223,23 +223,28 @@ RSpec.describe 'Datadog::Profiling::Collectors::CpuAndWallTimeWorker' do
       expect(sampling_time_ns_max).to be < one_second_in_ns, "A single sample should not take longer than 1s, #{stats}"
     end
 
-    it 'does not allocate Ruby objects during the regular operation of sampling' do
-      # The intention of this test is to warn us if we accidentally trigger object allocations during "happy path"
-      # sampling.
-      # Note that when something does go wrong during sampling, we do allocate exceptions (and then raise them).
+    context 'with allocation profiling enabled' do
+      # We need this otherwise allocations_during_sample will never change
+      let(:allocation_profiling_enabled) { true }
 
-      start
+      it 'does not allocate Ruby objects during the regular operation of sampling' do
+        # The intention of this test is to warn us if we accidentally trigger object allocations during "happy path"
+        # sampling.
+        # Note that when something does go wrong during sampling, we do allocate exceptions (and then raise them).
 
-      try_wait_until do
-        samples = samples_from_pprof_without_gc_and_overhead(recorder.serialize!)
-        samples if samples.any?
+        start
+
+        try_wait_until do
+          samples = samples_from_pprof_without_gc_and_overhead(recorder.serialize!)
+          samples if samples.any?
+        end
+
+        cpu_and_wall_time_worker.stop
+
+        stats = cpu_and_wall_time_worker.stats
+
+        expect(stats).to include(allocations_during_sample: 0)
       end
-
-      cpu_and_wall_time_worker.stop
-
-      stats = cpu_and_wall_time_worker.stats
-
-      expect(stats).to include(allocations_during_sample: 0)
     end
 
     it 'records garbage collection cycles' do
@@ -448,7 +453,7 @@ RSpec.describe 'Datadog::Profiling::Collectors::CpuAndWallTimeWorker' do
 
       before do
         allow(Datadog.logger).to receive(:warn)
-        expect(Datadog.logger).to receive(:warn).with(/dynamic sampling rate disabled/)
+        allow(Datadog.logger).to receive(:warn).with(/dynamic sampling rate disabled/)
       end
 
       it 'records allocated objects' do
@@ -467,6 +472,39 @@ RSpec.describe 'Datadog::Profiling::Collectors::CpuAndWallTimeWorker' do
 
         expect(allocation_sample.values).to include(:'alloc-samples' => test_num_allocated_object)
         expect(allocation_sample.locations.first.lineno).to eq allocation_line
+      end
+
+      context 'with dynamic_sampling_rate_enabled' do
+        let(:options) { { dynamic_sampling_rate_enabled: true } }
+        it 'keeps statistics on how allocation sampling is doing' do
+          stub_const('CpuAndWallTimeWorkerSpec::TestStruct', Struct.new(:foo))
+
+          start
+
+          test_num_allocated_object.times { CpuAndWallTimeWorkerSpec::TestStruct.new }
+
+          cpu_and_wall_time_worker.stop
+
+          stats = cpu_and_wall_time_worker.stats
+
+          sampled = stats.fetch(:allocation_sampled)
+          skipped = stats.fetch(:allocation_skipped)
+          effective_rate = stats.fetch(:allocation_effective_sample_rate)
+          sampling_time_ns_min = stats.fetch(:allocation_sampling_time_ns_min)
+          sampling_time_ns_max = stats.fetch(:allocation_sampling_time_ns_max)
+          sampling_time_ns_total = stats.fetch(:allocation_sampling_time_ns_total)
+          sampling_time_ns_avg = stats.fetch(:allocation_sampling_time_ns_avg)
+
+          expect(sampled).to be > 0
+          expect(skipped).to be > 0
+          expect(effective_rate).to be > 0
+          expect(effective_rate).to be < 1
+          expect(sampling_time_ns_min).to be <= sampling_time_ns_max
+          expect(sampling_time_ns_max).to be <= sampling_time_ns_total
+          expect(sampling_time_ns_avg).to be >= sampling_time_ns_min
+          one_second_in_ns = 1_000_000_000
+          expect(sampling_time_ns_max).to be < one_second_in_ns, "A single sample should not take longer than 1s, #{stats}"
+        end
       end
 
       context 'when sampling optimized Ruby strings' do
@@ -850,15 +888,15 @@ RSpec.describe 'Datadog::Profiling::Collectors::CpuAndWallTimeWorker' do
           cpu_sampling_time_ns_max: nil,
           cpu_sampling_time_ns_total: nil,
           cpu_sampling_time_ns_avg: nil,
-          allocation_sampled: 0,
-          allocation_skipped: 0,
+          allocation_sampled: nil,
+          allocation_skipped: nil,
           allocation_effective_sample_rate: nil,
           allocation_sampling_time_ns_min: nil,
           allocation_sampling_time_ns_max: nil,
           allocation_sampling_time_ns_total: nil,
           allocation_sampling_time_ns_avg: nil,
-          allocation_sampler_snapshot: hash_including(:sampling_probability => be > 0),
-          allocations_during_sample: 0,
+          allocation_sampler_snapshot: nil,
+          allocations_during_sample: nil,
         }
       )
     end
@@ -944,6 +982,47 @@ RSpec.describe 'Datadog::Profiling::Collectors::CpuAndWallTimeWorker' do
           expect(described_class._native_allocation_count).to be nil
         end
       end
+    end
+  end
+
+  describe '#stats_reset_not_thread_safe' do
+    let(:allocation_profiling_enabled) { true }
+
+    it 'returns accumulated stats and resets them back to 0' do
+      cpu_and_wall_time_worker.start
+      wait_until_running
+
+      try_wait_until do
+        samples = samples_from_pprof_without_gc_and_overhead(recorder.serialize!)
+        samples if samples.any?
+      end
+
+      stub_const('CpuAndWallTimeWorkerSpec::TestStruct', Struct.new(:foo))
+      1000.times { CpuAndWallTimeWorkerSpec::TestStruct.new }
+
+      cpu_and_wall_time_worker.stop
+
+      stats = cpu_and_wall_time_worker.stats_and_reset_not_thread_safe
+
+      expect(stats).to match(
+        hash_including(
+          :cpu_sampled => be > 0,
+          :allocation_sampled => be > 0,
+          :cpu_sampling_time_ns_avg => be > 0,
+          :allocation_sampling_time_ns_avg => be > 0,
+        )
+      )
+
+      stats = cpu_and_wall_time_worker.stats
+
+      expect(stats).to match(
+        hash_including(
+          :cpu_sampled => 0,
+          :allocation_sampled => 0,
+          :cpu_sampling_time_ns_avg => nil,
+          :allocation_sampling_time_ns_avg => nil,
+        )
+      )
     end
   end
 

--- a/spec/datadog/profiling/exporter_spec.rb
+++ b/spec/datadog/profiling/exporter_spec.rb
@@ -54,7 +54,7 @@ RSpec.describe Datadog::Profiling::Exporter do
         {
           no_signals_workaround_enabled: no_signals_workaround_enabled,
           worker_stats: stats,
-          gc: hash_including(:count, :time),
+          gc: hash_including(:count, :total_freed_objects),
         }
       )
     end

--- a/spec/datadog/profiling/exporter_spec.rb
+++ b/spec/datadog/profiling/exporter_spec.rb
@@ -1,11 +1,13 @@
 require 'datadog/profiling/exporter'
 require 'datadog/profiling/collectors/code_provenance'
+require 'datadog/profiling/collectors/cpu_and_wall_time_worker'
 require 'datadog/core/logger'
 
 RSpec.describe Datadog::Profiling::Exporter do
   subject(:exporter) do
     described_class.new(
       pprof_recorder: pprof_recorder,
+      worker: worker,
       code_provenance_collector: code_provenance_collector,
       internal_metadata: internal_metadata,
       **options
@@ -18,6 +20,7 @@ RSpec.describe Datadog::Profiling::Exporter do
   let(:code_provenance_data) { 'dummy code provenance data' }
   let(:pprof_recorder_serialize) { [start, finish, pprof_data] }
   let(:pprof_recorder) { instance_double(Datadog::Profiling::StackRecorder, serialize: pprof_recorder_serialize) }
+  let(:worker) { instance_double(Datadog::Profiling::Collectors::CpuAndWallTimeWorker, stats_and_reset: stats) }
   let(:code_provenance_collector) do
     collector = instance_double(Datadog::Profiling::Collectors::CodeProvenance, generate_json: code_provenance_data)
     allow(collector).to receive(:refresh).and_return(collector)
@@ -27,6 +30,12 @@ RSpec.describe Datadog::Profiling::Exporter do
   let(:no_signals_workaround_enabled) { false }
   let(:logger) { Datadog.logger }
   let(:options) { {} }
+  let(:stats) do
+    {
+      statA: 123,
+      statB: 456,
+    }
+  end
 
   describe '#flush' do
     subject(:flush) { exporter.flush }
@@ -41,6 +50,13 @@ RSpec.describe Datadog::Profiling::Exporter do
       )
       expect(flush.pprof_data).to eq pprof_data
       expect(flush.code_provenance_data).to eq code_provenance_data
+      expect(JSON.parse(flush.internal_metadata_json, { symbolize_names: true })).to match(
+        {
+          no_signals_workaround_enabled: no_signals_workaround_enabled,
+          worker_stats: stats,
+          gc: hash_including(:count, :time),
+        }
+      )
     end
 
     context 'when pprof recorder has no data' do
@@ -79,12 +95,16 @@ RSpec.describe Datadog::Profiling::Exporter do
 
     context 'when no_signals_workaround_enabled is true' do
       let(:no_signals_workaround_enabled) { true }
-      it { is_expected.to have_attributes(internal_metadata_json: '{"no_signals_workaround_enabled":"true"}') }
+      it {
+        is_expected.to have_attributes(internal_metadata_json: a_string_matching('"no_signals_workaround_enabled":true'))
+      }
     end
 
     context 'when no_signals_workaround_enabled is false' do
       let(:no_signals_workaround_enabled) { false }
-      it { is_expected.to have_attributes(internal_metadata_json: '{"no_signals_workaround_enabled":"false"}') }
+      it {
+        is_expected.to have_attributes(internal_metadata_json: a_string_matching('"no_signals_workaround_enabled":false'))
+      }
     end
   end
 

--- a/spec/datadog/profiling/exporter_spec.rb
+++ b/spec/datadog/profiling/exporter_spec.rb
@@ -53,7 +53,8 @@ RSpec.describe Datadog::Profiling::Exporter do
         {
           no_signals_workaround_enabled: no_signals_workaround_enabled,
           worker_stats: stats,
-          gc: hash_including(:count, :total_freed_objects),
+          # GC stats are slightly different between ruby and jruby
+          gc: hash_including(:count, RUBY_PLATFORM != 'java' ? :total_freed_objects : :"PS MarkSweep"),
         }
       )
     end

--- a/spec/datadog/profiling/exporter_spec.rb
+++ b/spec/datadog/profiling/exporter_spec.rb
@@ -1,6 +1,5 @@
 require 'datadog/profiling/exporter'
 require 'datadog/profiling/collectors/code_provenance'
-require 'datadog/profiling/collectors/cpu_and_wall_time_worker'
 require 'datadog/core/logger'
 
 RSpec.describe Datadog::Profiling::Exporter do
@@ -20,7 +19,7 @@ RSpec.describe Datadog::Profiling::Exporter do
   let(:code_provenance_data) { 'dummy code provenance data' }
   let(:pprof_recorder_serialize) { [start, finish, pprof_data] }
   let(:pprof_recorder) { instance_double(Datadog::Profiling::StackRecorder, serialize: pprof_recorder_serialize) }
-  let(:worker) { instance_double(Datadog::Profiling::Collectors::CpuAndWallTimeWorker, stats_and_reset: stats) }
+  let(:worker) { instance_double('Datadog::Profiling::Collectors::CpuAndWallTimeWorker', stats_and_reset: stats) }
   let(:code_provenance_collector) do
     collector = instance_double(Datadog::Profiling::Collectors::CodeProvenance, generate_json: code_provenance_data)
     allow(collector).to receive(:refresh).and_return(collector)

--- a/spec/datadog/profiling/exporter_spec.rb
+++ b/spec/datadog/profiling/exporter_spec.rb
@@ -1,8 +1,12 @@
+require 'datadog/profiling/spec_helper'
+
 require 'datadog/profiling/exporter'
 require 'datadog/profiling/collectors/code_provenance'
 require 'datadog/core/logger'
 
 RSpec.describe Datadog::Profiling::Exporter do
+  before { skip_if_profiling_not_supported(self) }
+
   subject(:exporter) do
     described_class.new(
       pprof_recorder: pprof_recorder,
@@ -19,7 +23,11 @@ RSpec.describe Datadog::Profiling::Exporter do
   let(:code_provenance_data) { 'dummy code provenance data' }
   let(:pprof_recorder_serialize) { [start, finish, pprof_data] }
   let(:pprof_recorder) { instance_double(Datadog::Profiling::StackRecorder, serialize: pprof_recorder_serialize) }
-  let(:worker) { instance_double('Datadog::Profiling::Collectors::CpuAndWallTimeWorker', stats_and_reset: stats) }
+  let(:worker) do
+    # TODO: Change this to a direct reference when we drop support for old Rubies which currently error if we try
+    #       to `require 'profiling/collectors/cpu_and_wall_time_worker'`
+    instance_double('Datadog::Profiling::Collectors::CpuAndWallTimeWorker', stats_and_reset_not_thread_safe: stats)
+  end
   let(:code_provenance_collector) do
     collector = instance_double(Datadog::Profiling::Collectors::CodeProvenance, generate_json: code_provenance_data)
     allow(collector).to receive(:refresh).and_return(collector)
@@ -49,14 +57,12 @@ RSpec.describe Datadog::Profiling::Exporter do
       )
       expect(flush.pprof_data).to eq pprof_data
       expect(flush.code_provenance_data).to eq code_provenance_data
-      expect(JSON.parse(flush.internal_metadata_json, { symbolize_names: true })).to match(
+      expect(JSON.parse(flush.internal_metadata_json, symbolize_names: true)).to match(
         {
           no_signals_workaround_enabled: no_signals_workaround_enabled,
           worker_stats: stats,
-          # GC stats are slightly different between ruby versions and jrubies. Count is always
-          # there but it's hard to find commonality across others so we'll be very lenient in
-          # our matching
-          gc: hash_including(:count),
+          # GC stats are slightly different between ruby versions.
+          gc: hash_including(:count, :total_freed_objects),
         }
       )
     end

--- a/spec/datadog/profiling/exporter_spec.rb
+++ b/spec/datadog/profiling/exporter_spec.rb
@@ -53,8 +53,10 @@ RSpec.describe Datadog::Profiling::Exporter do
         {
           no_signals_workaround_enabled: no_signals_workaround_enabled,
           worker_stats: stats,
-          # GC stats are slightly different between ruby and jruby
-          gc: hash_including(:count, RUBY_PLATFORM != 'java' ? :total_freed_objects : :"PS MarkSweep"),
+          # GC stats are slightly different between ruby versions and jrubies. Count is always
+          # there but it's hard to find commonality across others so we'll be very lenient in
+          # our matching
+          gc: hash_including(:count),
         }
       )
     end

--- a/spec/datadog/profiling/flush_spec.rb
+++ b/spec/datadog/profiling/flush_spec.rb
@@ -33,7 +33,7 @@ RSpec.describe Datadog::Profiling::Flush do
         code_provenance_file_name: code_provenance_file_name,
         code_provenance_data: code_provenance_data,
         tags_as_array: tags_as_array,
-        internal_metadata_json: '{"no_signals_workaround_enabled":"false"}',
+        internal_metadata_json: '{"no_signals_workaround_enabled":false}',
       )
     end
   end

--- a/spec/datadog/profiling/http_transport_spec.rb
+++ b/spec/datadog/profiling/http_transport_spec.rb
@@ -187,7 +187,7 @@ RSpec.describe Datadog::Profiling::HttpTransport do
       finish_timespec_seconds = 1699718400
       finish_timespec_nanoseconds = 123456789
 
-      internal_metadata_json = '{"no_signals_workaround_enabled":"true"}'
+      internal_metadata_json = '{"no_signals_workaround_enabled":true}'
 
       expect(described_class).to receive(:_native_do_export).with(
         kind_of(Array), # exporter_configuration
@@ -357,7 +357,7 @@ RSpec.describe Datadog::Profiling::HttpTransport do
           'family' => 'ruby',
           'version' => '4',
           'endpoint_counts' => nil,
-          'internal' => { 'no_signals_workaround_enabled' => 'true' },
+          'internal' => { 'no_signals_workaround_enabled' => true },
         )
       end
 
@@ -405,7 +405,7 @@ RSpec.describe Datadog::Profiling::HttpTransport do
           'family' => 'ruby',
           'version' => '4',
           'endpoint_counts' => nil,
-          'internal' => { 'no_signals_workaround_enabled' => 'true' },
+          'internal' => { 'no_signals_workaround_enabled' => true },
         )
 
         expect(body[code_provenance_file_name]).to be nil


### PR DESCRIPTION
**What does this PR do?**
Ship extra information about the profile that is helpful for developers to understand the workings of certain internal processes such as allocation sampling statistics and state in a non-impactful manner.

**Motivation:**
Having information such as sampling statistics accompanying uploaded profiles enables a multitude of things:
* Extra data to facilitate troubleshooting/debugging of weird edge cases or as data-sources for profiling insights.
* Creation of anonymised wide-range telemetry for studying systems operating in practice (e.g. "what is the min/max/avg/pxx allocation sampling probability/allocated samples per profile").

**Additional Notes:**
<!-- Anything else we should know when reviewing? -->

**How to test the change?**
Profiles uploaded with this change will have extra fields in their metadata, looking like:

```
"internal": {
  "heap_sample_every": 10,
    "no_signals_workaround_enabled": false,
    "timeline_enabled": false,
    "gc": {
      "heap_final_slots": 0,
      "oldmalloc_increase_bytes": 48241936,
      "heap_tomb_pages": 0,
      "heap_marked_slots": 2209030,
      "heap_allocatable_pages": 0,
      "heap_allocated_pages": 6999,
      "heap_eden_pages": 6999,
      "total_allocated_objects": 24354462,
      "total_allocated_pages": 6999,
      "remembered_wb_unprotected_objects": 35473,
      "heap_sorted_length": 6999,
      "minor_gc_count": 84,
      "malloc_increase_bytes_limit": 33554432,
      "oldmalloc_increase_bytes_limit": 76868783,
      "old_objects_limit": 4025702,
      "heap_live_slots": 2723623,
      "total_freed_objects": 21630839,
      "heap_available_slots": 2852772,
      "count": 105,
      "malloc_increase_bytes": 19969352,
      "total_freed_pages": 0,
      "old_objects": 2098657,
      "heap_free_slots": 129149,
      "major_gc_count": 21,
      "remembered_wb_unprotected_objects_limit": 67952,
      "compact_count": 0
    },
    "worker_stats": {
      "cpu_sampling_time_ns_max": 126372,
      "postponed_job_full": 0,
      "cpu_sampling_time_ns_total": 288278789,
      "signal_handler_enqueued_sample": 5955,
      "cpu_effective_sample_rate": 1,
      "cpu_sampling_time_ns_min": 33723,
      "allocation_sampled": 8100,
      "allocation_sampling_time_ns_avg": 7897.086430423509,
      "allocation_sampling_time_ns_min": 2248,
      "cpu_sampling_time_ns_avg": 48409.53635600336,
      "postponed_job_skipped_already_existed": 0,
      "allocation_sampler_snapshot": {
        "sampling_probability": 100,
        "target_overhead": 1,
        "target_overhead_adjustment": -0.0020571595751800896,
        "events_per_sec": 194.9349927333729,
        "events_since_last_readjustment": 99,
        "samples_since_last_readjustment": 99,
        "sampling_interval": 1,
        "sampling_time_ns": 8855
      },
      "allocation_sampling_time_ns_total": 63958503,
      "allocations_during_sample": 0,
      "postponed_job_success": 5955,
      "allocation_sampling_time_ns_max": 539569,
      "signal_handler_wrong_thread": 0,
      "trigger_sample_attempts": 5955,
      "allocation_effective_sample_rate": 1,
      "postponed_job_unknown_result": 0,
      "cpu_skipped": 0,
      "simulated_signal_delivery": 5946,
      "allocation_skipped": 0,
      "cpu_sampled": 5955,
      "trigger_simulated_signal_delivery_attempts": 5946
    }
}
```

**For Datadog employees:**
- [ ] If this PR touches code that signs or publishes builds or packages, or handles
credentials of any kind, I've requested a review from `@DataDog/security-design-and-guidance`.
- [x] This PR doesn't touch any of that.

Unsure? Have a question? Request a review!
