### PR TITLE
Faraday: Add `on_error` option

### DIFF
--- a/docs/GettingStarted.md
+++ b/docs/GettingStarted.md
@@ -838,7 +838,7 @@ connection.get('/foo')
 | `distributed_tracing` |                                 | Enables [distributed tracing](#distributed-tracing)                                                                                                                                         | `true`    |
 | `split_by_domain`     |                                 | Uses the request domain as the service name when set to `true`.                                                                                                                             | `false`   |
 | `error_handler`       |                                 | A `Proc` that accepts a `response` parameter. If it evaluates to a *truthy* value, the trace span is marked as an error. By default only sets 5XX responses as errors.                      | `nil`     |
-| `on_error` | Custom error handler invoked when a request raises an error. Provided `span` and `error` as arguments. Sets error on the span by deault. | `proc { \|span, error\| span.set_error(error) unless span.nil? }` |
+| `on_error` | Custom error handler invoked when a request raises an error. Provided `span` and `error` as arguments. Sets an error on the span by default. | `proc { \|span, error\| span.set_error(error) unless span.nil? }` |
 
 ### Grape
 

--- a/docs/GettingStarted.md
+++ b/docs/GettingStarted.md
@@ -838,7 +838,7 @@ connection.get('/foo')
 | `distributed_tracing` |                                 | Enables [distributed tracing](#distributed-tracing)                                                                                                                                         | `true`    |
 | `split_by_domain`     |                                 | Uses the request domain as the service name when set to `true`.                                                                                                                             | `false`   |
 | `error_handler`       |                                 | A `Proc` that accepts a `response` parameter. If it evaluates to a *truthy* value, the trace span is marked as an error. By default only sets 5XX responses as errors.                      | `nil`     |
-
+| `on_error` | Custom error handler invoked when a request raises an error. Provided `span` and `error` as arguments. Sets error on the span by deault. | `proc { \|span, error\| span.set_error(error) unless span.nil? }` |
 
 ### Grape
 

--- a/lib/datadog/tracing/contrib/faraday/configuration/settings.rb
+++ b/lib/datadog/tracing/contrib/faraday/configuration/settings.rb
@@ -35,10 +35,16 @@ module Datadog
             end
 
             option :distributed_tracing, default: true, type: :bool
+
             option :error_handler do |o|
               o.type :proc
               o.default_proc(&DEFAULT_ERROR_HANDLER)
             end
+
+            option :on_error do |o|
+              o.type :proc, nilable: true
+            end
+
             option :split_by_domain, default: false, type: :bool
 
             option :service_name do |o|

--- a/lib/datadog/tracing/contrib/faraday/middleware.rb
+++ b/lib/datadog/tracing/contrib/faraday/middleware.rb
@@ -24,7 +24,7 @@ module Datadog
             # Do this once to reduce expensive regex calls.
             request_options = build_request_options!(env)
 
-            Tracing.trace(Ext::SPAN_REQUEST) do |span, trace|
+            Tracing.trace(Ext::SPAN_REQUEST, on_error: request_options[:on_error]) do |span, trace|
               annotate!(span, env, request_options)
               propagate!(trace, span, env) if request_options[:distributed_tracing] && Tracing.enabled?
               app.call(env).on_complete { |resp| handle_response(span, resp, request_options) }

--- a/spec/datadog/tracing/contrib/faraday/middleware_spec.rb
+++ b/spec/datadog/tracing/contrib/faraday/middleware_spec.rb
@@ -279,6 +279,17 @@ RSpec.describe 'Faraday middleware' do
       expect(span.get_tag('span.kind')).to eq('client')
     end
 
+    context 'when given `on_error`' do
+      let(:configuration_options) { { on_error: proc { @error_handler_called = true } } }
+
+      it do
+        expect { response }.to raise_error(Faraday::ConnectionFailed)
+
+        expect(span).not_to have_error
+        expect(@error_handler_called).to be_truthy
+      end
+    end
+
     it_behaves_like 'a peer service span' do
       let(:peer_service_val) { 'example.com' }
       let(:peer_service_source) { 'peer.hostname' }


### PR DESCRIPTION
**What does this PR do?**

From a closed PR: https://github.com/DataDog/dd-trace-rb/pull/3306

Backport the changes for `Faraday` with `on_error` option