### PR TITLE
Use GraphQL::Tracing::DataDogTrace when it's available

### DIFF
--- a/docs/GettingStarted.md
+++ b/docs/GettingStarted.md
@@ -902,18 +902,8 @@ If you prefer to individually configure the tracer settings for a schema (e.g. y
 ```ruby
 # Class-based schema
 class YourSchema < GraphQL::Schema
-  use(
-    GraphQL::Tracing::DataDogTracing,
-    service: 'graphql'
-  )
-end
-```
-
-```ruby
-# .define-style schema
-YourSchema = GraphQL::Schema.define do
-  use(
-    GraphQL::Tracing::DataDogTracing,
+  trace_with(
+    GraphQL::Tracing::DatadogTrace,
     service: 'graphql'
   )
 end
@@ -923,20 +913,10 @@ Or you can modify an already defined schema:
 
 ```ruby
 # Class-based schema
-YourSchema.use(
-    GraphQL::Tracing::DataDogTracing,
-    service: 'graphql'
+YourSchema.trace_with(
+  GraphQL::Tracing::DatadogTrace,
+  service: 'graphql'
 )
-```
-
-```ruby
-# .define-style schema
-YourSchema.define do
-  use(
-    GraphQL::Tracing::DataDogTracing,
-    service: 'graphql'
-  )
-end
 ```
 
 Do *NOT* `instrument :graphql` in `Datadog.configure` if you choose to configure manually, as to avoid double tracing. These two means of configuring GraphQL tracing are considered mutually exclusive.

--- a/lib/datadog/tracing/contrib/graphql/patcher.rb
+++ b/lib/datadog/tracing/contrib/graphql/patcher.rb
@@ -28,7 +28,17 @@ module Datadog
             analytics_enabled = Contrib::Analytics.enabled?(get_option(:analytics_enabled))
             analytics_sample_rate = get_option(:analytics_sample_rate)
 
-            if schema.respond_to?(:use)
+            if schema.respond_to?(:trace_with)
+              schema.trace_with(
+                ::GraphQL::Tracing::DataDogTrace,
+                # By default, Tracing::DataDogTrace holds a reference to a tracer.
+                # If we provide a tracer argument here it will be eagerly cached,
+                # and Tracing::DataDogTracing will send traces to a stale tracer instance.
+                service: service_name,
+                analytics_enabled: analytics_enabled,
+                analytics_sample_rate: analytics_sample_rate
+              )
+            elsif schema.respond_to?(:use)
               schema.use(
                 ::GraphQL::Tracing::DataDogTracing,
                 # By default, Tracing::DataDogTracing holds a reference to a tracer.

--- a/spec/datadog/tracing/contrib/graphql/integration_spec.rb
+++ b/spec/datadog/tracing/contrib/graphql/integration_spec.rb
@@ -22,10 +22,11 @@ RSpec.describe Datadog::Tracing::Contrib::GraphQL::Integration do
   describe '.loaded?' do
     subject(:loaded?) { described_class.loaded? }
 
-    context 'when neither GraphQL or GraphQL::Tracing::DataDogTracing are defined' do
+    context 'when neither GraphQL, GraphQL::Tracing::DataDogTracing, nor GraphQL::Tracing::DataDogTrace are defined' do
       before do
         hide_const('GraphQL')
         hide_const('GraphQL::Tracing::DataDogTracing')
+        hide_const('GraphQL::Tracing::DataDogTrace')
       end
 
       it { is_expected.to be false }
@@ -35,6 +36,7 @@ RSpec.describe Datadog::Tracing::Contrib::GraphQL::Integration do
       before do
         stub_const('GraphQL', Class.new)
         hide_const('GraphQL::Tracing::DataDogTracing')
+        hide_const('GraphQL::Tracing::DataDogTrace')
       end
 
       it { is_expected.to be false }
@@ -44,6 +46,18 @@ RSpec.describe Datadog::Tracing::Contrib::GraphQL::Integration do
       before { stub_const('GraphQL::Tracing::DataDogTracing', Class.new) }
 
       it { is_expected.to be true }
+    end
+
+    context 'when GraphQL::Tracing::DataDogTrace is defined' do
+      context 'when only GraphQL is defined' do
+        before do
+          stub_const('GraphQL', Class.new)
+          hide_const('GraphQL::Tracing::DataDogTracing')
+          stub_const('GraphQL::Tracing::DataDogTrace', Class.new)
+        end
+
+        it { is_expected.to be true }
+      end
     end
   end
 


### PR DESCRIPTION

**What does this PR do?**
<!-- A brief description of the change being made with this pull request. -->

Uses the new GraphQL-Ruby `trace_with` API _directly_, instead of via `use ...`., to avoid a deprecation warning. 

**Motivation:**
<!-- What inspired you to submit this pull request? -->

Someone reported the deprecation warning to me 

**Additional Notes:**
<!-- Anything else we should know when reviewing? -->

Although this changes how the module is applied, it doesn't actually change behavior on recent GraphQL-Ruby versions, because GraphQL-Ruby was applying this new module even when the old one was attached: https://github.com/rmosolgo/graphql-ruby/blob/1a0b0dea2f9134c63f20228001c785f9cbaea3d9/lib/graphql/tracing/platform_tracing.rb#L82-L85

So, I think users have already been using the new code. 

**How to test the change?**

Unit tests 

**For Datadog employees:**
- [ ] If this PR touches code that signs or publishes builds or packages, or handles
credentials of any kind, I've requested a review from `@DataDog/security-design-and-guidance`.
- [ ] This PR doesn't touch any of that.

Unsure? Have a question? Request a review!
