### PR TITLE
do not restrict startup logs to emit only once

### DIFF
--- a/lib/datadog/core/diagnostics/environment_logger.rb
+++ b/lib/datadog/core/diagnostics/environment_logger.rb
@@ -23,16 +23,6 @@ module Datadog
           Datadog.logger
         end
 
-        # If logger should log and hasn't logged already, then output environment configuration and possible errors.
-        def log_once!
-          # Check if already been executed
-          return false if (defined?(@executed) && @executed) || !log?
-
-          yield if block_given?
-
-          @executed = true
-        end
-
         # Are we logging the environment data?
         def log?
           startup_logs_enabled = Datadog.configuration.diagnostics.startup_logs.enabled
@@ -59,7 +49,7 @@ module Datadog
         extend EnvironmentLogging
 
         def self.collect_and_log!
-          log_once! do
+          if log?
             data = EnvironmentCollector.collect_config!
             log_configuration!('CORE', data.to_json)
           end

--- a/lib/datadog/profiling/diagnostics/environment_logger.rb
+++ b/lib/datadog/profiling/diagnostics/environment_logger.rb
@@ -13,7 +13,7 @@ module Datadog
         extend Core::Diagnostics::EnvironmentLogging
 
         def self.collect_and_log!
-          log_once! do
+          if log?
             data = EnvironmentCollector.collect_config!
             log_configuration!('PROFILING', data.to_json)
           end

--- a/lib/datadog/tracing/diagnostics/environment_logger.rb
+++ b/lib/datadog/tracing/diagnostics/environment_logger.rb
@@ -13,7 +13,7 @@ module Datadog
         extend Core::Diagnostics::EnvironmentLogging
 
         def self.collect_and_log!(responses: nil)
-          log_once! do
+          if log?
             env_data = EnvironmentCollector.collect_config!
             log_configuration!('TRACING', env_data.to_json)
 

--- a/sig/datadog/core/diagnostics/environment_logger.rbs
+++ b/sig/datadog/core/diagnostics/environment_logger.rbs
@@ -7,7 +7,6 @@ module Datadog
         def log_error!: (untyped prefix, untyped type, untyped error) -> untyped
 
         def logger: () -> untyped
-        def log_once!: () ?{ () -> untyped } -> (false | untyped)
         def log?: () -> untyped
 
         REPL_PROGRAM_NAMES: ::Array["irb" | "pry"]

--- a/spec/datadog/core/diagnostics/environment_logger_spec.rb
+++ b/spec/datadog/core/diagnostics/environment_logger_spec.rb
@@ -54,11 +54,11 @@ RSpec.describe Datadog::Core::Diagnostics::EnvironmentLogger do
     end
 
     context 'with multiple invocations' do
-      it 'executes only once' do
+      it 'executes twice' do
         env_logger.collect_and_log!
         env_logger.collect_and_log!
 
-        expect(logger).to have_received(:info).once
+        expect(logger).to have_received(:info).twice
       end
     end
 

--- a/spec/datadog/core/diagnostics/environment_logger_spec.rb
+++ b/spec/datadog/core/diagnostics/environment_logger_spec.rb
@@ -53,15 +53,6 @@ RSpec.describe Datadog::Core::Diagnostics::EnvironmentLogger do
       end
     end
 
-    context 'with multiple invocations' do
-      it 'executes twice' do
-        env_logger.collect_and_log!
-        env_logger.collect_and_log!
-
-        expect(logger).to have_received(:info).twice
-      end
-    end
-
     context 'under a REPL' do
       around do |example|
         begin

--- a/spec/datadog/profiling/diagnostics/environment_logger_spec.rb
+++ b/spec/datadog/profiling/diagnostics/environment_logger_spec.rb
@@ -38,11 +38,11 @@ RSpec.describe Datadog::Profiling::Diagnostics::EnvironmentLogger do
     end
 
     context 'with multiple invocations' do
-      it 'executes only once' do
+      it 'executes multiple times' do
         env_logger.collect_and_log!
         env_logger.collect_and_log!
 
-        expect(logger).to have_received(:info).once
+        expect(logger).to have_received(:info).twice
       end
     end
 

--- a/spec/datadog/profiling/diagnostics/environment_logger_spec.rb
+++ b/spec/datadog/profiling/diagnostics/environment_logger_spec.rb
@@ -37,15 +37,6 @@ RSpec.describe Datadog::Profiling::Diagnostics::EnvironmentLogger do
       end
     end
 
-    context 'with multiple invocations' do
-      it 'executes multiple times' do
-        env_logger.collect_and_log!
-        env_logger.collect_and_log!
-
-        expect(logger).to have_received(:info).twice
-      end
-    end
-
     context 'under a REPL' do
       around do |example|
         begin

--- a/spec/datadog/tracing/diagnostics/environment_logger_spec.rb
+++ b/spec/datadog/tracing/diagnostics/environment_logger_spec.rb
@@ -53,15 +53,6 @@ RSpec.describe Datadog::Tracing::Diagnostics::EnvironmentLogger do
       end
     end
 
-    context 'with multiple invocations' do
-      it 'executes multiple times' do
-        env_logger.collect_and_log!
-        env_logger.collect_and_log!
-
-        expect(logger).to have_received(:info).twice
-      end
-    end
-
     context 'with agent error' do
       subject(:collect_and_log!) { env_logger.collect_and_log!(responses: [response]) }
 

--- a/spec/datadog/tracing/diagnostics/environment_logger_spec.rb
+++ b/spec/datadog/tracing/diagnostics/environment_logger_spec.rb
@@ -54,11 +54,11 @@ RSpec.describe Datadog::Tracing::Diagnostics::EnvironmentLogger do
     end
 
     context 'with multiple invocations' do
-      it 'executes only once' do
+      it 'executes multiple times' do
         env_logger.collect_and_log!
         env_logger.collect_and_log!
 
-        expect(logger).to have_received(:info).once
+        expect(logger).to have_received(:info).twice
       end
     end
 


### PR DESCRIPTION
<!--
Check out the
https://github.com/DataDog/dd-trace-rb/blob/master/docs/DevelopmentGuide.md
for guidance on how to set up your development environment,
run the test suite, write new integrations, and more.
-->

**2.0 Upgrade Guide notes**
In 1.x startup logs would emit only once during initial configuration of the library. In 2.0 these logs will now emit whenever the library reconfigures itself, which may occur multiple times during startup. The increased verbosity in logging better represents the configuration state of the library at the time the logs are generated. 

The default setting has not changed for startup logs. It remains `nil`, which generates startup logs for non-dev environments. To turn off startup logs completely you can set:

```ruby
Datadog.configure { |c| c.diagnostics.startup_logs.enabled = false }
  ```

**What does this PR do?**
Remove the `log_once` restriction on startup logs.

**Motivation:**
<!-- What inspired you to submit this pull request? -->

**Additional Notes:**
<!-- Anything else we should know when reviewing? -->

**How to test the change?**
<!--
Describe here how the change can be validated.
You are strongly encouraged to provide automated tests for this PR (unit or integration).
If this change cannot be feasibly tested, please explain why,
unless the change does not modify code (e.g. only modifies docs, comments).
-->

**For Datadog employees:**
- [ ] If this PR touches code that signs or publishes builds or packages, or handles
credentials of any kind, I've requested a review from `@DataDog/security-design-and-guidance`.
- [x] This PR doesn't touch any of that.

Unsure? Have a question? Request a review!
