### PR TITLE
Fix minitest detection spec

### DIFF
--- a/spec/datadog/core/environment/execution_spec.rb
+++ b/spec/datadog/core/environment/execution_spec.rb
@@ -90,7 +90,7 @@ RSpec.describe Datadog::Core::Environment::Execution do
 
             # MiniTest 5.22.1 requires a test to be defined, otherwise it will fail
             # https://github.com/minitest/minitest/blob/master/History.rdoc#label-5.22.1+-2F+2024-02-06
-            class DummyTest < Minitest::Test
+            Class.new(Minitest::Test) do
               def test_it_does_something_useful
                 assert true
               end

--- a/spec/datadog/core/environment/execution_spec.rb
+++ b/spec/datadog/core/environment/execution_spec.rb
@@ -88,6 +88,14 @@ RSpec.describe Datadog::Core::Environment::Execution do
 
             require 'minitest/autorun'
 
+            # MiniTest 5.22.1 requires a test to be defined, otherwise it will fail
+            # https://github.com/minitest/minitest/blob/master/History.rdoc#label-5.22.1+-2F+2024-02-06
+            class DummyTest < Minitest::Test
+              def test_it_does_something_useful
+                assert true
+              end
+            end
+
             is_expected.to eq(true)
           end
         end


### PR DESCRIPTION
**What does this PR do?**

Fix failing spec on MacOS and CircleCI, where `steep` is bundled. 

`steep` depends on  `activesupport`, which depends on `minitest`. So the test is activated on CI. 

With no version constraint on the version, Minitest release 5.22.1 on Feb 6
https://github.com/minitest/minitest/blob/master/History.rdoc#label-5.22.1+-2F+2024-02-06

Our test suite failed with such change. 

To fix it, add a dummy test case so the process status would be successful.

**Note**: This is something we should be working on continuing improving our environment.
