### PR TITLE
Add helper method to (efficiently) format trace_id

### DIFF
--- a/lib/datadog/tracing/correlation.rb
+++ b/lib/datadog/tracing/correlation.rb
@@ -92,12 +92,7 @@ module Datadog
 
         # DEV-2.0: This public method was returning an Integer, but with 128 bit trace id it would return a String.
         def trace_id
-          if Datadog.configuration.tracing.trace_id_128_bit_logging_enabled &&
-              !Tracing::Utils::TraceId.to_high_order(@trace_id).zero?
-            Kernel.format('%032x', @trace_id)
-          else
-            Tracing::Utils::TraceId.to_low_order(@trace_id)
-          end
+          Tracing::Utils::TraceId.format(@trace_id)
         end
       end
 

--- a/lib/datadog/tracing/utils.rb
+++ b/lib/datadog/tracing/utils.rb
@@ -77,6 +77,15 @@ module Datadog
         def concatenate(high_order, low_order)
           high_order << 64 | low_order
         end
+
+        def format(trace_id)
+          if Datadog.configuration.tracing.trace_id_128_bit_logging_enabled &&
+              !to_high_order(trace_id).zero?
+            Kernel.format('%032x', trace_id)
+          else
+            to_low_order(trace_id)
+          end
+        end
       end
     end
   end

--- a/spec/datadog/tracing/utils_spec.rb
+++ b/spec/datadog/tracing/utils_spec.rb
@@ -103,4 +103,34 @@ RSpec.describe Datadog::Tracing::Utils::TraceId do
       end
     end
   end
+
+  describe '.format' do
+    context 'with 64-bit logging' do
+      before do
+        allow(Datadog.configuration.tracing).to receive(:trace_id_128_bit_logging_enabled).and_return(false)
+      end
+
+      it 'can format a 128-bit trace id' do
+        expect(described_class.format(0xaaaaaaaaaaaaaaaaffffffffffffffff)).to eq(18446744073709551615)
+      end
+
+      it 'can format a 64-bit trace id' do
+        expect(described_class.format(0xaaaaaaaa)).to eq(2863311530)
+      end
+    end
+
+    context 'with 128-bit logging' do
+      before do
+        allow(Datadog.configuration.tracing).to receive(:trace_id_128_bit_logging_enabled).and_return(true)
+      end
+
+      it 'can format a 128-bit trace id' do
+        expect(described_class.format(0xaaaaaaaaaaaaaaaaffffffffffffffff)).to eq('aaaaaaaaaaaaaaaaffffffffffffffff')
+      end
+
+      it 'can format a 64-bit trace id' do
+        expect(described_class.format(0xaaaaaaaa)).to eq(2863311530)
+      end
+    end
+  end
 end


### PR DESCRIPTION
**What does this PR do?**

It provides a helper method to format a trace_id, suitable for the wire protocol (mainly log correlation in my case). I don't have a strong opinion about the method name.

**Motivation:**

I don't want to create a `Correlation` object every time I log something.

Specifically, this code was previously working fine: https://github.com/socketry/console-output-datadog/blob/main/lib/console/output/datadog/wrapper.rb#L39-L54

But it appears to break with 128-bit trace IDs. I want to use the method introduced in this PR to correctly format the trace ID.

**Additional Notes:**

Should it always return a string, i.e. the format should be opaque to the user? If we agree to this, some changes to the Correlation class/related code might be required.

I wonder if, for the sake of compatibility, 128-bit integer trace ids should be accepted for the purpose of log correlation. As this code (`console-output-datadog`) worked previously but now appears broken. Actually, I believe this would cause problems, because it would be hard to differentiate 128-bit integer (decimal) from 16-byte hex (OpenTelemetry format).

Another option, or in addition to this, would be to consider supporting something like `trace.correlation_id`/`trace.formatted_id`/`trace.id_string` or something similar, OR if you really wanted to improve compatibility, have `trace.id.to_s` behave similarly, e.g. `trace.id` can return an opaque object that has `#to_s` that behaves similarly to the method in this PR.