### PR TITLE
Fix flakiness of gc_force_recycle tests

### DIFF
--- a/spec/datadog/profiling/stack_recorder_spec.rb
+++ b/spec/datadog/profiling/stack_recorder_spec.rb
@@ -613,6 +613,7 @@ RSpec.describe Datadog::Profiling::StackRecorder do
                 end
               end
             end
+            raise 'could not allocate an object in a recycled slot'
           end
 
           it 'enforces seen id flag on objects on recycled slots that get sampled' do

--- a/spec/datadog/profiling/stack_recorder_spec.rb
+++ b/spec/datadog/profiling/stack_recorder_spec.rb
@@ -554,6 +554,26 @@ RSpec.describe Datadog::Profiling::StackRecorder do
             described_class::Testing._native_has_seen_id_flag(obj)
           end
 
+          # This method attempts to allocate an object on a recycled heap slot.
+          #
+          # Heap slot recycling was a troublesome feature that has been removed from Rubies >= 3.1
+          # in which an object could be freed through a fast-path that bypassed a lot of runtime
+          # machinery such as finalizers or object id tracking and thus introduced a fair amount
+          # of buggy behaviour. Some of this buggy behaviour manifests when a recycled slot gets
+          # re-used by a new live object: the new live object id will be the same as the id of
+          # the object that was recycled, violating a core constraint of Ruby objects: object ids
+          # are unique and non-repeatable.
+          #
+          # Recycling an object slot is easy (accomplished by a rb_gc_force_recycle native method call).
+          # More difficult is allocating an object on a recycled slot. Ruby gives us no control on
+          # where to allocate an object so we have to play a probability game. This method attempts to
+          # maximize our chances of quickly getting an object in a recycled slot by:
+          # 1. Force recycling 1000 objects.
+          # 2. Repeatedly allocating 1000 objects and keeping references to them, thus preventing GC
+          #    from reclaiming their slots.
+          # 3. Checking if any of the ids of the 1000 recycled objects now map to a live object. If
+          #    that happens, then we know that live object was allocated on a recycled slot and we
+          #    can return it.
           def create_obj_in_recycled_slot(should_sample_original: false)
             # Force-recycle 1000 objects.
             # NOTE: In theory, a single force recycle would suffice but the more recycled slots
@@ -581,7 +601,10 @@ RSpec.describe Datadog::Profiling::StackRecorder do
               # NOTE: We keep the object references around to prevent GCs from constantly
               #       freeing up slots from the previous iteration. Thus each consecutive
               #       iteration should get one step closer to re-using one of the recycled
-              #       slots.
+              #       slots. This should not lead to OOMs since we know there are 1000
+              #       free recycled slots available (we recycled them above). At the very
+              #       limit we'd expect the Ruby VM to prefer to re-use those slots rather
+              #       than expand heap pages and when that happens we'd stop iterating.
               1000.times { objs << Object.new }
               recycled_obj_ids.each do |obj_id|
                 begin

--- a/spec/datadog/profiling/stack_recorder_spec.rb
+++ b/spec/datadog/profiling/stack_recorder_spec.rb
@@ -594,7 +594,7 @@ RSpec.describe Datadog::Profiling::StackRecorder do
             # Repeatedly allocate objects until we find one that resolves to the id of one of
             # the force recycled objects
             objs = []
-            loop do
+            100.times do
               # Instead of doing this one at a time which would be slow given id2ref will
               # raise on failure, allocate a ton of objects each time, increasing the
               # probability of getting a hit on each iteration


### PR DESCRIPTION
**What does this PR do?**
Increases the probability to re-use a recycled object slot.

**Motivation:**
Reduce flakiness seen in gc_force_recycle tests.

**Additional Notes:**
<!-- Anything else we should know when reviewing? -->

**How to test the change?**
<!--
Describe here how the change can be validated.
You are strongly encouraged to provide automated tests for this PR (unit or integration).
If this change cannot be feasibly tested, please explain why,
unless the change does not modify code (e.g. only modifies docs, comments).
-->

**For Datadog employees:**
- [ ] If this PR touches code that signs or publishes builds or packages, or handles
credentials of any kind, I've requested a review from `@DataDog/security-design-and-guidance`.
- [ ] This PR doesn't touch any of that.

Unsure? Have a question? Request a review!
