### PR TITLE
Add interpreter vendor to trace headers

### DIFF
--- a/lib/datadog/core/transport/ext.rb
+++ b/lib/datadog/core/transport/ext.rb
@@ -21,6 +21,8 @@ module Datadog
           HEADER_META_LANG = 'Datadog-Meta-Lang'
           HEADER_META_LANG_VERSION = 'Datadog-Meta-Lang-Version'
           HEADER_META_LANG_INTERPRETER = 'Datadog-Meta-Lang-Interpreter'
+          # Use for distinguishing between CRuby, JRuby, and TruffleRuby.
+          HEADER_META_LANG_INTERPRETER_VENDOR = 'Datadog-Meta-Lang-Interpreter-Vendor'
           HEADER_META_TRACER_VERSION = 'Datadog-Meta-Tracer-Version'
 
           # Header that prevents the Net::HTTP integration from tracing internal trace requests.

--- a/lib/datadog/tracing/transport/http.rb
+++ b/lib/datadog/tracing/transport/http.rb
@@ -67,6 +67,7 @@ module Datadog
             Datadog::Core::Transport::Ext::HTTP::HEADER_META_LANG_VERSION => Datadog::Core::Environment::Ext::LANG_VERSION,
             Datadog::Core::Transport::Ext::HTTP::HEADER_META_LANG_INTERPRETER =>
               Datadog::Core::Environment::Ext::LANG_INTERPRETER,
+            Datadog::Core::Transport::Ext::HTTP::HEADER_META_LANG_INTERPRETER_VENDOR => Core::Environment::Ext::LANG_ENGINE,
             Datadog::Core::Transport::Ext::HTTP::HEADER_META_TRACER_VERSION =>
               Datadog::Core::Environment::Ext::TRACER_VERSION
           }.tap do |headers|

--- a/sig/datadog/core/transport/ext.rbs
+++ b/sig/datadog/core/transport/ext.rbs
@@ -17,6 +17,8 @@ module Datadog
 
           HEADER_META_LANG: ::String
 
+          HEADER_META_LANG_INTERPRETER_VENDOR: ::String
+
           HEADER_META_LANG_VERSION: ::String
 
           HEADER_META_LANG_INTERPRETER: ::String

--- a/spec/datadog/tracing/transport/http_spec.rb
+++ b/spec/datadog/tracing/transport/http_spec.rb
@@ -159,6 +159,7 @@ RSpec.describe Datadog::Tracing::Transport::HTTP do
         Datadog::Core::Transport::Ext::HTTP::HEADER_META_LANG_VERSION => Datadog::Core::Environment::Ext::LANG_VERSION,
         Datadog::Core::Transport::Ext::HTTP::HEADER_META_LANG_INTERPRETER =>
           Datadog::Core::Environment::Ext::LANG_INTERPRETER,
+        'Datadog-Meta-Lang-Interpreter-Vendor' => RUBY_ENGINE,
         Datadog::Core::Transport::Ext::HTTP::HEADER_META_TRACER_VERSION => Datadog::Core::Environment::Ext::TRACER_VERSION
       )
     end


### PR DESCRIPTION
<!--
Check out the
https://github.com/DataDog/dd-trace-rb/blob/master/docs/DevelopmentGuide.md
for guidance on how to set up your development environment,
run the test suite, write new integrations, and more.
-->

**What does this PR do?**
Add the required field to allow us to differentiate between the different Ruby interpreters in internal reporting.

**Motivation:**
We currently have to distinguish between CRuby and JRuby in our reporting by trying to guess which one is which from the Ruby language version number they support.
But because JRuby and CRuby version numbers overlap, it is not possible to make a conclusive decision on such data.

**Additional Notes:**
<!-- Anything else we should know when reviewing? -->

**How to test the change?**
<!--
Describe here how the change can be validated.
You are strongly encouraged to provide automated tests for this PR (unit or integration).
If this change cannot be feasibly tested, please explain why,
unless the change does not modify code (e.g. only modifies docs, comments).
-->

**For Datadog employees:**
- [ ] If this PR touches code that signs or publishes builds or packages, or handles
credentials of any kind, I've requested a review from `@DataDog/security-design-and-guidance`.
- [ ] This PR doesn't touch any of that.

Unsure? Have a question? Request a review!
