### PR TITLE
remove deprecated lazy method for option_definition

### DIFF
--- a/lib/datadog/core/configuration/option_definition.rb
+++ b/lib/datadog/core/configuration/option_definition.rb
@@ -95,16 +95,6 @@ module Datadog
             @helpers[name] = block
           end
 
-          def lazy(_value = true)
-            Datadog::Core.log_deprecation do
-              'Defining an option as lazy is deprecated for removal. Options now always behave as lazy. '\
-              "Please remove all references to the lazy setting.\n"\
-              'Non-lazy options that were previously stored as blocks are no longer supported. '\
-              'If you used this feature, please let us know by opening an issue on: '\
-              'https://github.com/datadog/dd-trace-rb/issues/new so we can better understand and support your use case.'
-            end
-          end
-
           def after_set(&block)
             @after_set = block
           end
@@ -133,7 +123,6 @@ module Datadog
             env(options[:env]) if options.key?(:env)
             deprecated_env(options[:deprecated_env]) if options.key?(:deprecated_env)
             env_parser(&options[:env_parser]) if options.key?(:env_parser)
-            lazy(options[:lazy]) if options.key?(:lazy)
             after_set(&options[:after_set]) if options.key?(:after_set)
             resetter(&options[:resetter]) if options.key?(:resetter)
             setter(&options[:setter]) if options.key?(:setter)

--- a/spec/datadog/core/configuration/option_definition_spec.rb
+++ b/spec/datadog/core/configuration/option_definition_spec.rb
@@ -263,13 +263,6 @@ RSpec.describe Datadog::Core::Configuration::OptionDefinition::Builder do
     end
   end
 
-  describe '#lazy' do
-    it 'logs deprecation warning' do
-      expect(Datadog::Core).to receive(:log_deprecation)
-      builder.lazy
-    end
-  end
-
   describe '#after_set' do
     subject(:after_set) { builder.after_set(&block) }
 


### PR DESCRIPTION
<!--
Check out the
https://github.com/DataDog/dd-trace-rb/blob/master/docs/DevelopmentGuide.md
for guidance on how to set up your development environment,
run the test suite, write new integrations, and more.
-->

**2.0 Upgrade Guide notes**
Configuration options can no longer be defined as `lazy`. All options are lazily evaluated, making this redundant. 

**What does this PR do?**
Removes a deprecated method on option_definition for defining a configuration option as lazy. 

**Motivation:**
<!-- What inspired you to submit this pull request? -->

**Additional Notes:**
<!-- Anything else we should know when reviewing? -->

**How to test the change?**
<!--
Describe here how the change can be validated.
You are strongly encouraged to provide automated tests for this PR (unit or integration).
If this change cannot be feasibly tested, please explain why,
unless the change does not modify code (e.g. only modifies docs, comments).
-->

**For Datadog employees:**
- [ ] If this PR touches code that signs or publishes builds or packages, or handles
credentials of any kind, I've requested a review from `@DataDog/security-design-and-guidance`.
- [x] This PR doesn't touch any of that.

Unsure? Have a question? Request a review!
