### PR TITLE
Remove `binding.pry` comment

### DIFF
--- a/lib/datadog/tracing/contrib/sinatra/tracer.rb
+++ b/lib/datadog/tracing/contrib/sinatra/tracer.rb
@@ -76,7 +76,6 @@ module Datadog
                 _, path = env['sinatra.route'].split(' ', 2)
                 trace.set_tag(Tracing::Metadata::Ext::HTTP::TAG_ROUTE, path)
                 trace.set_tag(Tracing::Metadata::Ext::HTTP::TAG_ROUTE_PATH, env['SCRIPT_NAME'])
-                # binding.pry
                 super
               end
             end


### PR DESCRIPTION
Removes comment of `binding.pry` that was mistakenly merged in #3345 