### PR TITLE
Fix service used by dbm between `span.service` and `peer.service`

### DIFF
--- a/spec/datadog/tracing/contrib/propagation/sql_comment_spec.rb
+++ b/spec/datadog/tracing/contrib/propagation/sql_comment_spec.rb
@@ -93,7 +93,6 @@ RSpec.describe Datadog::Tracing::Contrib::Propagation::SqlComment do
           let(:span_op) do
             Datadog::Tracing::SpanOperation.new(
               'sample_span',
-              service: 'database_service',
               tags: { 'peer.service' => 'sample_peer_service' }
             )
           end
@@ -101,6 +100,38 @@ RSpec.describe Datadog::Tracing::Contrib::Propagation::SqlComment do
           it do
             is_expected.to eq(
               "/*dddbs='sample_peer_service',dde='production',ddps='Traders%27%20Joe',ddpv='1.0.0'*/ #{sql_statement}"
+            )
+          end
+        end
+
+        context 'when given a span operation tagged with peer.service and default service' do
+          let(:span_op) do
+            Datadog::Tracing::SpanOperation.new(
+              'sample_span',
+              service: Datadog.configuration.service,
+              tags: { 'peer.service' => 'sample_peer_service' }
+            )
+          end
+
+          it do
+            is_expected.to eq(
+              "/*dddbs='sample_peer_service',dde='production',ddps='Traders%27%20Joe',ddpv='1.0.0'*/ #{sql_statement}"
+            )
+          end
+        end
+
+        context 'when given a span operation tagged with peer.service and unique service' do
+          let(:span_op) do
+            Datadog::Tracing::SpanOperation.new(
+              'sample_span',
+              service: 'database_service',
+              tags: { 'peer.service' => 'sample_peer_service' }
+            )
+          end
+
+          it do
+            is_expected.to eq(
+              "/*dddbs='database_service',dde='production',ddps='Traders%27%20Joe',ddpv='1.0.0'*/ #{sql_statement}"
             )
           end
         end
@@ -125,7 +156,6 @@ RSpec.describe Datadog::Tracing::Contrib::Propagation::SqlComment do
           let(:span_op) do
             Datadog::Tracing::SpanOperation.new(
               'sample_span',
-              service: 'database_service',
               tags: { 'peer.service' => 'sample_peer_service' }
             )
           end
@@ -138,6 +168,48 @@ RSpec.describe Datadog::Tracing::Contrib::Propagation::SqlComment do
               "ddpv='1.0.0',"\
               "traceparent='#{traceparent}'*/ "\
               "#{sql_statement}"
+            )
+          }
+        end
+
+        context 'when given a span operation tagged with peer.service and default service' do
+          let(:span_op) do
+            Datadog::Tracing::SpanOperation.new(
+              'sample_span',
+              service: Datadog.configuration.service,
+              tags: { 'peer.service' => 'sample_peer_service' }
+            )
+          end
+
+          it {
+            is_expected.to eq(
+              "/*dddbs='sample_peer_service',"\
+                "dde='production',"\
+                "ddps='Traders%27%20Joe',"\
+                "ddpv='1.0.0',"\
+                "traceparent='#{traceparent}'*/ "\
+                "#{sql_statement}"
+            )
+          }
+        end
+
+        context 'when given a span operation tagged with peer.service and unique service' do
+          let(:span_op) do
+            Datadog::Tracing::SpanOperation.new(
+              'sample_span',
+              service: 'database_service',
+              tags: { 'peer.service' => 'sample_peer_service' }
+            )
+          end
+
+          it {
+            is_expected.to eq(
+              "/*dddbs='database_service',"\
+                "dde='production',"\
+                "ddps='Traders%27%20Joe',"\
+                "ddpv='1.0.0',"\
+                "traceparent='#{traceparent}'*/ "\
+                "#{sql_statement}"
             )
           }
         end


### PR DESCRIPTION
<!--
Check out the
https://github.com/DataDog/dd-trace-rb/blob/master/docs/DevelopmentGuide.md
for guidance on how to set up your development environment,
run the test suite, write new integrations, and more.
-->

**2.0 Upgrade Guide notes**
<!--
(If this PR is for 1.x, please delete this section)
A public facing description that will go into the [upgrade guide](https://github.com/DataDog/dd-trace-rb/blob/master/docs/UpgradeGuide.md) for this change.
We already know what the PR does (from the PR title),
but users should know either:
* A migration path for this change. In other words, how to continue using their application without behavior changes
in 2.0 (e.g. environment variable 'X' renamed to 'Y').
* That there's no alternative; we completely dropped support for this feature.
-->

**What does this PR do?**
Changes configuration to only use `peer.service` as the propagated dbm service if the service name for the span is nil or the global default value. 

This will only trigger when the user enables `DD_TRACE_REMOVE_INTEGRATION_SERVICE_NAMES_ENABLED` and intends to use `peer.service `as the distinguishing factor between spans instead of `span.service`.

**Motivation:**
<!-- What inspired you to submit this pull request? -->

**Additional Notes:**
<!-- Anything else we should know when reviewing? -->

**How to test the change?**
<!--
Describe here how the change can be validated.
You are strongly encouraged to provide automated tests for this PR (unit or integration).
If this change cannot be feasibly tested, please explain why,
unless the change does not modify code (e.g. only modifies docs, comments).
-->

**For Datadog employees:**
- [ ] If this PR touches code that signs or publishes builds or packages, or handles
credentials of any kind, I've requested a review from `@DataDog/security-design-and-guidance`.
- [x] This PR doesn't touch any of that.

Unsure? Have a question? Request a review!
