### PR TITLE
[NO-TICKET] Add Ruby profiler benchmark with GC profiling

### DIFF
--- a/.gitlab/benchmarks.yml
+++ b/.gitlab/benchmarks.yml
@@ -82,6 +82,15 @@ only-profiling-timeline:
     DD_PROFILING_NO_SIGNALS_WORKAROUND_ENABLED: "false"
     DD_PROFILING_EXPERIMENTAL_TIMELINE_ENABLED: "true"
 
+only-profiling-timeline-gc:
+  extends: .benchmarks
+  variables:
+    DD_BENCHMARKS_CONFIGURATION: only-profiling
+    DD_PROFILING_ENABLED: "true"
+    DD_PROFILING_NO_SIGNALS_WORKAROUND_ENABLED: "false"
+    DD_PROFILING_EXPERIMENTAL_TIMELINE_ENABLED: "true"
+    DD_PROFILING_FORCE_ENABLE_GC: "true"
+
 profiling-and-tracing:
   extends: .benchmarks
   variables:


### PR DESCRIPTION
**What does this PR do?**

This PR adds a new configuration to for testing in the benchmarking platform.

This configuration enables the "GC profiling" (on top of timeline), and will be used to validate when we're good to enable this feature by default.

**Motivation:**

Validate performance impact of "GC profiling" feature, especially when used together with timeline.

**Additional Notes:**

I'm preparing a similar PR to add this configuration also to the reliability environment configurations.

**How to test the change?**

Validate that benchmarking platform profiling runs now include a variant where GC information shows up in the flamegraph, as well as in the timeline visualization.

**For Datadog employees:**
- [ ] If this PR touches code that signs or publishes builds or packages, or handles
credentials of any kind, I've requested a review from `@DataDog/security-design-and-guidance`.
- [x] This PR doesn't touch any of that.