### PR TITLE
Backport "Add interpreter vendor to trace headers" to master

### DIFF
--- a/lib/datadog/core/transport/ext.rb
+++ b/lib/datadog/core/transport/ext.rb
@@ -25,6 +25,8 @@ module Datadog
           HEADER_META_LANG = 'Datadog-Meta-Lang'
           HEADER_META_LANG_VERSION = 'Datadog-Meta-Lang-Version'
           HEADER_META_LANG_INTERPRETER = 'Datadog-Meta-Lang-Interpreter'
+          # Use for distinguishing between CRuby, JRuby, and TruffleRuby.
+          HEADER_META_LANG_INTERPRETER_VENDOR = 'Datadog-Meta-Lang-Interpreter-Vendor'
           HEADER_META_TRACER_VERSION = 'Datadog-Meta-Tracer-Version'
 
           # Header that prevents the Net::HTTP integration from tracing internal trace requests.

--- a/lib/datadog/tracing/transport/http.rb
+++ b/lib/datadog/tracing/transport/http.rb
@@ -71,6 +71,7 @@ module Datadog
             Datadog::Core::Transport::Ext::HTTP::HEADER_META_LANG_VERSION => Datadog::Core::Environment::Ext::LANG_VERSION,
             Datadog::Core::Transport::Ext::HTTP::HEADER_META_LANG_INTERPRETER =>
               Datadog::Core::Environment::Ext::LANG_INTERPRETER,
+            Datadog::Core::Transport::Ext::HTTP::HEADER_META_LANG_INTERPRETER_VENDOR => Core::Environment::Ext::LANG_ENGINE,
             Datadog::Core::Transport::Ext::HTTP::HEADER_META_TRACER_VERSION =>
               Datadog::Core::Environment::Ext::TRACER_VERSION
           }.tap do |headers|

--- a/sig/datadog/core/transport/ext.rbs
+++ b/sig/datadog/core/transport/ext.rbs
@@ -17,6 +17,8 @@ module Datadog
 
           HEADER_META_LANG: ::String
 
+          HEADER_META_LANG_INTERPRETER_VENDOR: ::String
+
           HEADER_META_LANG_VERSION: ::String
 
           HEADER_META_LANG_INTERPRETER: ::String

--- a/spec/datadog/tracing/transport/http_spec.rb
+++ b/spec/datadog/tracing/transport/http_spec.rb
@@ -172,6 +172,7 @@ RSpec.describe Datadog::Tracing::Transport::HTTP do
         Datadog::Core::Transport::Ext::HTTP::HEADER_META_LANG_VERSION => Datadog::Core::Environment::Ext::LANG_VERSION,
         Datadog::Core::Transport::Ext::HTTP::HEADER_META_LANG_INTERPRETER =>
           Datadog::Core::Environment::Ext::LANG_INTERPRETER,
+        'Datadog-Meta-Lang-Interpreter-Vendor' => RUBY_ENGINE,
         Datadog::Core::Transport::Ext::HTTP::HEADER_META_TRACER_VERSION => Datadog::Core::Environment::Ext::TRACER_VERSION
       )
     end


### PR DESCRIPTION
**What does this PR do?**

This PR backports https://github.com/DataDog/dd-trace-rb/pull/3451 "Add interpreter vendor to trace headers" from the 2.0 branch to master.

**Motivation:**

Having this metadata seems very relevant. Backporting it to master, means the last of the 1.x releases should have it, which will allows to measure how many customers staying on 1.x are on JRuby/other runtimes.

**Additional Notes:**

N/A

**How to test the change?**

This change includes test coverage. I also gave it a quick local check and can confirm I see the `"datadog-meta-lang-interpreter-vendor"=>["jruby"]` showing up.

**For Datadog employees:**
- [ ] If this PR touches code that signs or publishes builds or packages, or handles
credentials of any kind, I've requested a review from `@DataDog/security-design-and-guidance`.
- [x] This PR doesn't touch any of that.