### PR TITLE
[PROF-8942] Remove separate benchmarking configurations for profiling timeline

### DIFF
--- a/.gitlab/benchmarks.yml
+++ b/.gitlab/benchmarks.yml
@@ -74,7 +74,7 @@ only-profiling:
     # better accuracy, mode.
     DD_PROFILING_NO_SIGNALS_WORKAROUND_ENABLED: "false"
 
-only-profiling-timeline-gc:
+only-profiling-gc:
   extends: .benchmarks
   variables:
     DD_BENCHMARKS_CONFIGURATION: only-profiling

--- a/.gitlab/benchmarks.yml
+++ b/.gitlab/benchmarks.yml
@@ -74,21 +74,12 @@ only-profiling:
     # better accuracy, mode.
     DD_PROFILING_NO_SIGNALS_WORKAROUND_ENABLED: "false"
 
-only-profiling-timeline:
-  extends: .benchmarks
-  variables:
-    DD_BENCHMARKS_CONFIGURATION: only-profiling
-    DD_PROFILING_ENABLED: "true"
-    DD_PROFILING_NO_SIGNALS_WORKAROUND_ENABLED: "false"
-    DD_PROFILING_EXPERIMENTAL_TIMELINE_ENABLED: "true"
-
 only-profiling-timeline-gc:
   extends: .benchmarks
   variables:
     DD_BENCHMARKS_CONFIGURATION: only-profiling
     DD_PROFILING_ENABLED: "true"
     DD_PROFILING_NO_SIGNALS_WORKAROUND_ENABLED: "false"
-    DD_PROFILING_EXPERIMENTAL_TIMELINE_ENABLED: "true"
     DD_PROFILING_FORCE_ENABLE_GC: "true"
 
 profiling-and-tracing:
@@ -118,15 +109,6 @@ profiling-and-tracing-and-appsec:
     DD_APPSEC_ENABLED: "true"
     DD_PROFILING_ENABLED: "true"
     DD_PROFILING_NO_SIGNALS_WORKAROUND_ENABLED: "false"
-
-profiling-and-tracing-and-appsec-timeline:
-  extends: .benchmarks
-  variables:
-    DD_BENCHMARKS_CONFIGURATION: profiling-and-tracing-and-appsec
-    DD_APPSEC_ENABLED: "true"
-    DD_PROFILING_ENABLED: "true"
-    DD_PROFILING_NO_SIGNALS_WORKAROUND_ENABLED: "false"
-    DD_PROFILING_EXPERIMENTAL_TIMELINE_ENABLED: "true"
 
 candidate-tracer-appsec-with-api-security:
   extends: .benchmarks


### PR DESCRIPTION
**What does this PR do?**

As soon as we merge https://github.com/datadog/dd-trace-rb/pull/3428 the profiler will default to timeline being enabled.

This means that the "profiler" configurations will all have timeline, so having separate configurations for timeline does not make any sense.

**Motivation:**

Remove timeline testing configurations that no longer make sense.

**Additional Notes:**

For the configuration with GC profiling, I've removed the `DD_PROFILING_EXPERIMENTAL_TIMELINE_ENABLED` environment variable, since, again, timeline is on by default.

We could potentially keep a configuration without timeline around, but we already have a lot of configurations, so for now I've chosen not to do so.

**How to test the change?**

This can be tested by manually triggering a deploy to the benchmarking platform.

**For Datadog employees:**
- [ ] If this PR touches code that signs or publishes builds or packages, or handles
credentials of any kind, I've requested a review from `@DataDog/security-design-and-guidance`.
- [x] This PR doesn't touch any of that.