### PR TITLE
Add tracing microbenchmarks

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -50,3 +50,6 @@ gemfiles/.bundle
 # Native extension binaries
 lib/*.bundle
 lib/*.so
+
+# Benchmark result files
+/benchmarks/*.json

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -4,6 +4,7 @@ stages:
   - deploy
   - macrobenchmarks
   - microbenchmarks
+  - benchmarks
 
 include:
   - remote: https://gitlab-templates.ddbuild.io/apm/packaging.yml

--- a/.gitlab/benchmarks.yml
+++ b/.gitlab/benchmarks.yml
@@ -169,6 +169,7 @@ benchmarks:
     - ./steps/run-benchmarks.sh
     - ./steps/analyze-results.sh
     - "./steps/upload-results-to-s3.sh || :"
+    - "./steps/upload-results-to-benchmarking-api.sh || :"
     - "./steps/post-pr-comment.sh || :"
   artifacts:
     name: "artifacts"

--- a/.gitlab/benchmarks.yml
+++ b/.gitlab/benchmarks.yml
@@ -5,6 +5,7 @@
 variables:
   GITLAB_BENCHMARKS_CI_IMAGE: 486234852809.dkr.ecr.us-east-1.amazonaws.com/ci/benchmarking-platform:ruby-gitlab
   GITLAB_DDPROF_BENCHMARK_CI_IMAGE: 486234852809.dkr.ecr.us-east-1.amazonaws.com/ci/benchmarking-platform:ruby-ddprof-benchmark
+  BASE_CI_IMAGE: 486234852809.dkr.ecr.us-east-1.amazonaws.com/ci/benchmarking-platform:dd-trace-rb
 
 .benchmarks:
   stage: macrobenchmarks
@@ -153,3 +154,32 @@ ddprof-benchmark:
     FF_USE_LEGACY_KUBERNETES_EXECUTION_STRATEGY: "true" # Important tweak for stability of benchmarks
     LATEST_COMMIT_ID: $CI_COMMIT_SHA
     KUBERNETES_SERVICE_ACCOUNT_OVERWRITE: dd-trace-rb
+benchmarks:
+  stage: benchmarks
+  when: on_success
+  tags: ["runner:apm-k8s-tweaked-metal"]
+  image: $BASE_CI_IMAGE
+  interruptible: true
+  timeout: 1h
+  script:
+    - export ARTIFACTS_DIR="$(pwd)/artifacts" && (mkdir "${ARTIFACTS_DIR}" || :)
+    - git config --global url."https://gitlab-ci-token:${CI_JOB_TOKEN}@gitlab.ddbuild.io/DataDog/".insteadOf "https://github.com/DataDog/"
+    - git clone --branch dd-trace-rb https://github.com/DataDog/benchmarking-platform platform && cd platform
+    - ./steps/capture-hardware-software-info.sh
+    - ./steps/run-benchmarks.sh
+    - ./steps/analyze-results.sh
+    - "./steps/upload-results-to-s3.sh || :"
+    - "./steps/post-pr-comment.sh || :"
+  artifacts:
+    name: "artifacts"
+    when: always
+    paths:
+      - artifacts/
+    expire_in: 3 months
+  variables:
+    KUBERNETES_SERVICE_ACCOUNT_OVERWRITE: dd-trace-rb
+    FF_USE_LEGACY_KUBERNETES_EXECUTION_STRATEGY: "true"
+    UPSTREAM_BRANCH: $CI_COMMIT_REF_NAME
+    UPSTREAM_PROJECT_ID: $CI_PROJECT_ID
+    UPSTREAM_PROJECT_NAME: $CI_PROJECT_NAME
+    UPSTREAM_COMMIT_SHA: $CI_COMMIT_SHA

--- a/benchmarks/Dockerfile
+++ b/benchmarks/Dockerfile
@@ -7,15 +7,15 @@ RUN echo 'APT::Get::Assume-Yes "true";' > /etc/apt/apt.conf.d/90circleci \
 ENV DEBIAN_FRONTEND=noninteractive
 
 # Install required packages
-RUN set -ex; \
-        apt-get update; \
-        mkdir -p /usr/share/man/man1; \
+RUN set -ex && \
+        apt-get update && \
+        mkdir -p /usr/share/man/man1 && \
         apt-get install -y --no-install-recommends \
             git mercurial xvfb \
             locales sudo openssh-client ca-certificates tar gzip parallel \
             net-tools netcat unzip zip bzip2 gnupg curl wget \
-            tzdata rsync vim less jq; \
-        rm -rf /var/lib/apt/lists/*;
+            tzdata rsync vim less jq && \
+        rm -rf /var/lib/apt/lists/*
 
 # Set timezone to UTC by default
 RUN ln -sf /usr/share/zoneinfo/Etc/UTC /etc/localtime

--- a/benchmarks/Dockerfile
+++ b/benchmarks/Dockerfile
@@ -29,8 +29,8 @@ ENV LANGUAGE en_US:en
 RUN mkdir -p "$GEM_HOME" && chmod -R 777 "$GEM_HOME"
 
 # Upgrade RubyGems and Bundler
-RUN gem update --system 3.3.26
-RUN gem install bundler -v '~> 2.3.26'
+RUN gem update --system 3.5.6
+RUN gem install bundler -v '~> 2.5.6'
 ENV BUNDLE_SILENCE_ROOT_WARNING 1
 
 # Reinstall a recent version of the trace to help Docker cache dependencies.

--- a/benchmarks/Dockerfile
+++ b/benchmarks/Dockerfile
@@ -1,0 +1,52 @@
+FROM ruby:3.3.0-bullseye
+
+# Make apt non-interactive
+RUN echo 'APT::Get::Assume-Yes "true";' > /etc/apt/apt.conf.d/90circleci \
+  && echo 'DPkg::Options "--force-confnew";' >> /etc/apt/apt.conf.d/90circleci
+
+ENV DEBIAN_FRONTEND=noninteractive
+
+# Install required packages
+RUN set -ex; \
+        apt-get update; \
+        mkdir -p /usr/share/man/man1; \
+        apt-get install -y --no-install-recommends \
+            git mercurial xvfb \
+            locales sudo openssh-client ca-certificates tar gzip parallel \
+            net-tools netcat unzip zip bzip2 gnupg curl wget \
+            tzdata rsync vim less jq; \
+        rm -rf /var/lib/apt/lists/*;
+
+# Set timezone to UTC by default
+RUN ln -sf /usr/share/zoneinfo/Etc/UTC /etc/localtime
+
+# Set language
+RUN locale-gen en_US.UTF-8
+ENV LANG en_US.UTF-8
+ENV LANGUAGE en_US:en
+
+# Install RubyGems
+RUN mkdir -p "$GEM_HOME" && chmod -R 777 "$GEM_HOME"
+
+# Upgrade RubyGems and Bundler
+RUN gem update --system 3.3.26
+RUN gem install bundler -v '~> 2.3.26'
+ENV BUNDLE_SILENCE_ROOT_WARNING 1
+
+# Reinstall a recent version of the trace to help Docker cache dependencies.
+# Bump this version periodically.
+RUN gem install ddtrace -v 1.20.0
+
+WORKDIR /app
+
+# Add base common files used by all scenarios
+COPY . /app/
+
+RUN bundle install
+
+# Conrfigure the benchmark to run
+ENV BENCHMARK=tracing_trace.rb
+
+ENTRYPOINT ["/bin/bash", "-c"]
+CMD bundle exec ruby "benchmarks/${BENCHMARK}"
+

--- a/benchmarks/tracing_trace.rb
+++ b/benchmarks/tracing_trace.rb
@@ -4,10 +4,6 @@ VALIDATE_BENCHMARK_MODE = ENV['VALIDATE_BENCHMARK'] == 'true'
 return unless __FILE__ == $PROGRAM_NAME || VALIDATE_BENCHMARK_MODE
 
 require 'benchmark/ips'
-
-# Load the local version of the gem
-lib = File.expand_path('lib', __dir__)
-$LOAD_PATH.unshift(lib) unless $LOAD_PATH.include?(lib)
 require 'ddtrace'
 
 class TracingTraceBenchmark

--- a/benchmarks/tracing_trace.rb
+++ b/benchmarks/tracing_trace.rb
@@ -1,0 +1,48 @@
+# Used to quickly run benchmark under RSpec as part of the usual test suite, to validate it didn't bitrot
+VALIDATE_BENCHMARK_MODE = ENV['VALIDATE_BENCHMARK'] == 'true'
+
+return unless __FILE__ == $PROGRAM_NAME || VALIDATE_BENCHMARK_MODE
+
+require 'benchmark/ips'
+
+# Load the local version of the gem
+lib = File.expand_path('lib', __dir__)
+$LOAD_PATH.unshift(lib) unless $LOAD_PATH.include?(lib)
+require 'ddtrace'
+
+class TracingTraceBenchmark
+  module FauxWriter
+    def write(trace)
+      # no-op
+    end
+
+    ::Datadog::Tracing::Writer.prepend(self)
+  end
+
+  def run_benchmark
+    Benchmark.ips do |x|
+      benchmark_time = VALIDATE_BENCHMARK_MODE ? { time: 0.001, warmup: 0 } : { time: 10.5, warmup: 2 }
+      x.config(**benchmark_time)
+
+      def trace(x, depth)
+        x.report(
+          "#{depth} span trace",
+          (depth.times.map { "Datadog::Tracing.trace('op.name') {" } + depth.times.map { "}" }).join
+        )
+      end
+
+      trace(x, 1)
+      trace(x, 10)
+      trace(x, 100)
+
+      x.save! "#{__FILE__}-results.json" unless VALIDATE_BENCHMARK_MODE
+      x.compare!
+    end
+  end
+end
+
+puts "Current pid is #{Process.pid}"
+
+TracingTraceBenchmark.new.instance_exec do
+  run_benchmark
+end

--- a/spec/datadog/profiling/validate_benchmarks_spec.rb
+++ b/spec/datadog/profiling/validate_benchmarks_spec.rb
@@ -20,4 +20,8 @@ RSpec.describe 'Profiling benchmarks', if: (RUBY_VERSION >= '2.4.0') do
   describe 'profiler_sample_serialize' do
     it('runs without raising errors') { expect_in_fork { load './benchmarks/profiler_sample_serialize.rb' } }
   end
+
+  describe 'tracing_trace' do
+    it('runs without raising errors') { expect_in_fork { load './benchmarks/tracing_trace.rb' } }
+  end
 end

--- a/spec/datadog/profiling/validate_benchmarks_spec.rb
+++ b/spec/datadog/profiling/validate_benchmarks_spec.rb
@@ -1,6 +1,6 @@
 require 'datadog/profiling/spec_helper'
 
-RSpec.describe 'Profiling benchmarks', if: (RUBY_VERSION >= '2.4.0') do
+RSpec.describe 'Profiling benchmarks' do
   before { skip_if_profiling_not_supported(self) }
 
   around do |example|
@@ -19,9 +19,5 @@ RSpec.describe 'Profiling benchmarks', if: (RUBY_VERSION >= '2.4.0') do
 
   describe 'profiler_sample_serialize' do
     it('runs without raising errors') { expect_in_fork { load './benchmarks/profiler_sample_serialize.rb' } }
-  end
-
-  describe 'tracing_trace' do
-    it('runs without raising errors') { expect_in_fork { load './benchmarks/tracing_trace.rb' } }
   end
 end

--- a/spec/datadog/tracing/validate_benchmarks_spec.rb
+++ b/spec/datadog/tracing/validate_benchmarks_spec.rb
@@ -1,8 +1,6 @@
-require 'datadog/profiling/spec_helper'
+require 'spec_helper'
 
-RSpec.describe 'Profiling benchmarks' do
-  before { skip_if_profiling_not_supported(self) }
-
+RSpec.describe 'Tracing benchmarks' do
   around do |example|
     ClimateControl.modify('VALIDATE_BENCHMARK' => 'true') do
       example.run

--- a/spec/datadog/tracing/validate_benchmarks_spec.rb
+++ b/spec/datadog/tracing/validate_benchmarks_spec.rb
@@ -1,0 +1,15 @@
+require 'datadog/profiling/spec_helper'
+
+RSpec.describe 'Profiling benchmarks' do
+  before { skip_if_profiling_not_supported(self) }
+
+  around do |example|
+    ClimateControl.modify('VALIDATE_BENCHMARK' => 'true') do
+      example.run
+    end
+  end
+
+  describe 'tracing_trace' do
+    it('runs without raising errors') { expect_in_fork { load './benchmarks/tracing_trace.rb' } }
+  end
+end

--- a/spec/datadog/tracing/validate_benchmarks_spec.rb
+++ b/spec/datadog/tracing/validate_benchmarks_spec.rb
@@ -1,6 +1,8 @@
 require 'spec_helper'
 
 RSpec.describe 'Tracing benchmarks' do
+  before { skip('Spec requires Ruby VM supporting fork') unless PlatformHelpers.supports_fork? }
+
   around do |example|
     ClimateControl.modify('VALIDATE_BENCHMARK' => 'true') do
       example.run


### PR DESCRIPTION
**What does this PR do?**
Adds a tracing microbenchmark that measures the total time the tracing takes to create a custom trace, until it reaches the writer. This does not measure the writer cost (it's stubbed out).

**Motivation:**

Microbenchmarks allows us to quickly compare the performance between two commits, making it feasible to run on every PR change. It also allows for quick iteration when performing performance improvements.

**How to test the change?**

You can see the [PR comment below](https://github.com/DataDog/dd-trace-rb/pull/3472#issuecomment-1958201602) with the results for this PR, which are uninteresting because it doesn't make Ruby prod changes.

When merged, the [2.0 PR](https://github.com/DataDog/dd-trace-rb/pull/3421) will continuously display the performance changes compared to master.

**For Datadog employees:**
- [ ] If this PR touches code that signs or publishes builds or packages, or handles
credentials of any kind, I've requested a review from `@DataDog/security-design-and-guidance`.
- [ ] This PR doesn't touch any of that.

Unsure? Have a question? Request a review!
