### PR TITLE
[PROF-9147] Add workaround for Ruby VM bug causing crash in gc_finalize_deferred

### DIFF
--- a/ext/ddtrace_profiling_native_extension/collectors_cpu_and_wall_time_worker.c
+++ b/ext/ddtrace_profiling_native_extension/collectors_cpu_and_wall_time_worker.c
@@ -225,6 +225,11 @@ static VALUE rescued_sample_allocation(VALUE tracepoint_data);
 static VALUE active_sampler_instance = Qnil;
 static struct cpu_and_wall_time_worker_state *active_sampler_instance_state = NULL;
 
+// See handle_sampling_signal for details on what this does
+#ifdef NO_POSTPONED_TRIGGER
+  static void *gc_finalize_deferred_workaround;
+#endif
+
 // Used to implement CpuAndWallTimeWorker._native_allocation_count . To be able to use cheap thread-local variables
 // (here with `__thread`, see https://gcc.gnu.org/onlinedocs/gcc/Thread-Local.html), this needs to be global.
 //
@@ -243,6 +248,8 @@ void collectors_cpu_and_wall_time_worker_init(VALUE profiling_module) {
     if (sample_from_postponed_job_handle == POSTPONED_JOB_HANDLE_INVALID || after_gc_from_postponed_job_handle == POSTPONED_JOB_HANDLE_INVALID) {
       rb_raise(rb_eRuntimeError, "Failed to register profiler postponed jobs (got POSTPONED_JOB_HANDLE_INVALID)");
     }
+  #else
+    gc_finalize_deferred_workaround = objspace_ptr_for_gc_finalize_deferred_workaround();
   #endif
 
   VALUE collectors_module = rb_define_module_under(profiling_module, "Collectors");
@@ -517,7 +524,32 @@ static void handle_sampling_signal(DDTRACE_UNUSED int _signal, DDTRACE_UNUSED si
     rb_postponed_job_trigger(sample_from_postponed_job_handle);
     state->stats.postponed_job_success++; // Always succeeds
   #else
-    int result = rb_postponed_job_register_one(0, sample_from_postponed_job, NULL);
+
+    // This is a workaround for https://bugs.ruby-lang.org/issues/19991 (for Ruby < 3.3)
+    //
+    // TL;DR the `rb_postponed_job_register_one` API is not atomic (which is why it got replaced by `rb_postponed_job_trigger`)
+    // and in rare cases can cause VM crashes.
+    //
+    // Specifically, if we're interrupting `rb_postponed_job_flush` (the function that processes postponed jobs), the way
+    // that this function reads the jobs is not atomic, and can cause our call to
+    // `rb_postponed_job_register(function, arg)` to clobber an existing job that is getting dequeued.
+    // Clobbering an existing job is somewhat annoying, but the worst part is that it can happen that we clobber only
+    // the existing job's arguments.
+    // As surveyed in https://github.com/ruby/ruby/pull/8949#issuecomment-1821441370 clobbering the arguments turns out
+    // to not matter in many cases as usually `rb_postponed_job_register` calls in the VM and ecosystem ignore the argument.
+    //
+    // https://bugs.ruby-lang.org/issues/19991 is the exception: inside Ruby's `gc.c`, when dealing with object
+    // finalizers, Ruby calls `gc_finalize_deferred_register` which internally calls
+    // `rb_postponed_job_register_one(gc_finalize_deferred, objspace)`.
+    // Clobbering this call means that `gc_finalize_deferred` would get called with `NULL`, causing a segmentation fault.
+    //
+    // Note that this is quite rare: our signal needs to land at exactly the point where the VM has read the function
+    // to execute, but has yet to read the arguments. @ivoanjo: I could only reproduce it by manually changing the VM
+    // code to simulate this happening.
+    //
+    // Thus, our workaround is simple: we pass in objspace as our argument, just in case the clobbering happens.
+    // In the happy path, we never use this argument so it makes no difference. In the buggy path, we avoid crashing the VM.
+    int result = rb_postponed_job_register(0, sample_from_postponed_job, gc_finalize_deferred_workaround /* instead of NULL */);
 
     // Officially, the result of rb_postponed_job_register_one is documented as being opaque, but in practice it does not
     // seem to have changed between Ruby 2.3 and 3.2, and so we track it as a debugging mechanism

--- a/ext/ddtrace_profiling_native_extension/private_vm_api_access.c
+++ b/ext/ddtrace_profiling_native_extension/private_vm_api_access.c
@@ -876,3 +876,17 @@ static inline int ddtrace_imemo_type(VALUE imemo) {
     return NULL;
   }
 #endif
+
+// This is used to workaround a VM bug. See "handle_sampling_signal" in "collectors_cpu_and_wall_time_worker" for details.
+#ifdef NO_POSTPONED_TRIGGER
+  void *objspace_ptr_for_gc_finalize_deferred_workaround(void) {
+    rb_vm_t *vm =
+      #ifndef NO_GET_VM // TODO: Inline GET_VM below once we drop support in dd-trace-rb 2.x for < Ruby 2.5
+        GET_VM();
+      #else
+        thread_struct_from_object(rb_thread_current())->vm;
+      #endif
+
+    return vm->objspace;
+  }
+#endif

--- a/ext/ddtrace_profiling_native_extension/private_vm_api_access.h
+++ b/ext/ddtrace_profiling_native_extension/private_vm_api_access.h
@@ -55,3 +55,7 @@ void self_test_mn_enabled(void);
 
 // Provides more specific information on what kind an imemo is
 const char *imemo_kind(VALUE imemo);
+
+#ifdef NO_POSTPONED_TRIGGER
+  void *objspace_ptr_for_gc_finalize_deferred_workaround(void);
+#endif


### PR DESCRIPTION
**What does this PR do?**

This PR adds a workaround for a VM bug (https://bugs.ruby-lang.org/issues/19991) that has affected at least two customers (the other being https://github.com/DataDog/dd-trace-rb/issues/3430).

The workaround is... not very pretty... but I believe will get the job done, for the reasons explained in the big comment I added.

**Motivation:**

The good thing about this crash is that it seems extremely rare.

The bad thing is that without this workaround, only moving to Ruby 3.3+ is the fix, and we still have a lot of customers on older Ruby versions.

We've documented in https://docs.datadoghq.com/profiler/profiler_troubleshooting/ruby/#segmentation-faults-in-gc_finalize_deferred-in-ruby-versions-26-to-32 that the no signals workaround can be used to work around the issue but:

a. Enabling it for everyone on < 3.3 is really crappy, as it yields biased samples and the crash only happens in the presence of specific types of Ruby objects (e.g. objects with finalizers) that not all apps will run into.

b. For folks that are affected by this issue, it may take quite a while for them to connect the bug to the profiler, since their crash log will point at `gc_finalize_deferred` and won't mention datadog at all.

**Additional Notes:**

N/A

**How to test the change?**

This is the million dollar question. I am unable to reproduce the issue locally just by running the profiler.

I was able to simulate it by changing Ruby's `vm_trace.c` as follows:

```diff
@@ -1748,6 +1748,8 @@ rb_workqueue_register(unsigned flags, rb_postponed_job_func_t func, void *data)
     return TRUE;
 }

+static void dummy_method(void *_unused) { }
+
 void
 rb_postponed_job_flush(rb_vm_t *vm)
 {
@@ -1775,7 +1777,11 @@ rb_postponed_job_flush(rb_vm_t *vm)
             while ((index = vm->postponed_job_index) > 0) {
                 if (ATOMIC_CAS(vm->postponed_job_index, index, index-1) == index) {
                     rb_postponed_job_t *pjob = &vm->postponed_job_buffer[index-1];
-                    (*pjob->func)(pjob->data);
+                    rb_postponed_job_func_t the_func = (*pjob->func);
+                    if (the_func != dummy_method) rb_postponed_job_register_one(0, dummy_method, NULL);
+                    //if (the_func != dummy_method) rb_postponed_job_register_one(0, dummy_method, GET_VM()->objspace);
+                    (the_func)(pjob->data);
                 }
```

The idea being that it's equivalent to the profiler SIGPROF interruption landing right between reading `pjob->func` and `pjob->data`.

I then ran the following Ruby snippet (which triggers `gc_finalize_deferred`):

```ruby
class UsesFinalizer
  DUMMY_FINALIZER = proc { }
  def initialize = ObjectSpace.define_finalizer(self, DUMMY_FINALIZER)
end
UsesFinalizer.new while true
```

...and this gets me a crash that matches the ones linked in
* https://bugs.ruby-lang.org/issues/19991
* https://github.com/DataDog/dd-trace-rb/issues/3430

If instead of passing `NULL`, we uncommend the second option that passes in `GET_VM()->objspace`, the crash goes away.

Thus I believe that my fix works and is equivalent to what the experiment above does.

I plan to reach out to both customers that saw this issue and see if they'd be up for testing the fix.

**For Datadog employees:**
- [ ] If this PR touches code that signs or publishes builds or packages, or handles
credentials of any kind, I've requested a review from `@DataDog/security-design-and-guidance`.
- [x] This PR doesn't touch any of that.