### PR TITLE
Add benchmark that only excludes network

### DIFF
--- a/benchmarks/tracing_trace.rb
+++ b/benchmarks/tracing_trace.rb
@@ -7,22 +7,53 @@ require 'benchmark/ips'
 require 'ddtrace'
 
 class TracingTraceBenchmark
-  module FauxWriter
+  module NoopWriter
     def write(trace)
       # no-op
     end
-
-    ::Datadog::Tracing::Writer.prepend(self)
   end
 
-  def run_benchmark
+  module NoopAdapter
+    Response = Struct.new(:code, :body)
+
+    def open
+      Response.new(200)
+    end
+  end
+
+  def benchmark_no_writer
+    ::Datadog::Tracing::Writer.prepend(NoopWriter)
+
     Benchmark.ips do |x|
       benchmark_time = VALIDATE_BENCHMARK_MODE ? { time: 0.001, warmup: 0 } : { time: 10.5, warmup: 2 }
       x.config(**benchmark_time)
 
       def trace(x, depth)
         x.report(
-          "#{depth} span trace",
+          "#{depth} span trace - no writer",
+          (depth.times.map { "Datadog::Tracing.trace('op.name') {" } + depth.times.map { "}" }).join
+        )
+      end
+
+      trace(x, 1)
+      trace(x, 10)
+      trace(x, 100)
+
+      x.save! "#{__FILE__}-results.json" unless VALIDATE_BENCHMARK_MODE
+      x.compare!
+    end
+  end
+
+  def benchmark_no_network
+    ::Datadog::Core::Transport::HTTP::Adapters::Net.prepend(NoopAdapter)
+
+    Benchmark.ips do |x|
+      benchmark_time = VALIDATE_BENCHMARK_MODE ? { time: 0.001, warmup: 0 } : { time: 10.5, warmup: 2 }
+      x.config(**benchmark_time)
+
+      def trace(x, depth)
+        x.report(
+          "#{depth} span trace - no network",
           (depth.times.map { "Datadog::Tracing.trace('op.name') {" } + depth.times.map { "}" }).join
         )
       end
@@ -39,6 +70,15 @@ end
 
 puts "Current pid is #{Process.pid}"
 
+def run_benchmark(&block)
+  # Forking to avoid monkey-patching leaking between benchmarks
+  pid = fork { block.call }
+  _, status = Process.wait2(pid)
+
+  raise "Benchmark failed with status #{status}" unless status.success?
+end
+
 TracingTraceBenchmark.new.instance_exec do
-  run_benchmark
+  run_benchmark { benchmark_no_writer }
+  run_benchmark { benchmark_no_network }
 end


### PR DESCRIPTION
<!--
Check out the
https://github.com/DataDog/dd-trace-rb/blob/master/docs/DevelopmentGuide.md
for guidance on how to set up your development environment,
run the test suite, write new integrations, and more.
-->

**What does this PR do?**

Adds a benchmark that stubs the network adapter, but includes everything else: writer, serialization, transport.

This new benchmark is in addition to the one testing to tracer critical path only, introduced in #3472.

**Motivation:**

There's quite a bit of work done by the library besides the main critical path work. This new benchmark captures that.


**How to test the change?**
<!--
Describe here how the change can be validated.
You are strongly encouraged to provide automated tests for this PR (unit or integration).
If this change cannot be feasibly tested, please explain why,
unless the change does not modify code (e.g. only modifies docs, comments).
-->

**For Datadog employees:**
- [ ] If this PR touches code that signs or publishes builds or packages, or handles
credentials of any kind, I've requested a review from `@DataDog/security-design-and-guidance`.
- [ ] This PR doesn't touch any of that.

Unsure? Have a question? Request a review!
