### PR TITLE
Add benchmark for TraceDigest generation

### DIFF
--- a/benchmarks/tracing_trace.rb
+++ b/benchmarks/tracing_trace.rb
@@ -76,10 +76,10 @@ class TracingTraceBenchmark
         x.report("trace.to_digest") do
           trace.to_digest
         end
-      end
 
-      x.save! "#{__FILE__}-results.json" unless VALIDATE_BENCHMARK_MODE
-      x.compare!
+        x.save! "#{__FILE__}-results.json" unless VALIDATE_BENCHMARK_MODE
+        x.compare!
+      end
     end
   end
 end

--- a/benchmarks/tracing_trace.rb
+++ b/benchmarks/tracing_trace.rb
@@ -68,11 +68,11 @@ class TracingTraceBenchmark
   end
 
   def benchmark_to_digest
-    Benchmark.ips do |x|
-      benchmark_time = VALIDATE_BENCHMARK_MODE ? { time: 0.001, warmup: 0 } : { time: 10.5, warmup: 2 }
-      x.config(**benchmark_time)
+    Datadog::Tracing.trace('op.name') do |span, trace|
+      Benchmark.ips do |x|
+        benchmark_time = VALIDATE_BENCHMARK_MODE ? { time: 0.001, warmup: 0 } : { time: 10.5, warmup: 2 }
+        x.config(**benchmark_time)
 
-      Datadog::Tracing.trace('op.name') do |span, trace|
         x.report("trace.to_digest") do
           trace.to_digest
         end

--- a/benchmarks/tracing_trace.rb
+++ b/benchmarks/tracing_trace.rb
@@ -66,6 +66,22 @@ class TracingTraceBenchmark
       x.compare!
     end
   end
+
+  def benchmark_to_digest
+    Benchmark.ips do |x|
+      benchmark_time = VALIDATE_BENCHMARK_MODE ? { time: 0.001, warmup: 0 } : { time: 10.5, warmup: 2 }
+      x.config(**benchmark_time)
+
+      Datadog::Tracing.trace('op.name') do |span, trace|
+        x.report("trace.to_digest") do
+          trace.to_digest
+        end
+      end
+
+      x.save! "#{__FILE__}-results.json" unless VALIDATE_BENCHMARK_MODE
+      x.compare!
+    end
+  end
 end
 
 puts "Current pid is #{Process.pid}"
@@ -81,4 +97,5 @@ end
 TracingTraceBenchmark.new.instance_exec do
   run_benchmark { benchmark_no_writer }
   run_benchmark { benchmark_no_network }
+  run_benchmark { benchmark_to_digest }
 end


### PR DESCRIPTION
<!--
Check out the
https://github.com/DataDog/dd-trace-rb/blob/master/docs/DevelopmentGuide.md
for guidance on how to set up your development environment,
run the test suite, write new integrations, and more.
-->

Follow up to #3474

**What does this PR do?**

Adds a benchmark that measures the process of generating a `TraceDigest` from an active trace.
This happens whenever distributed tracing propagation happens.

**Additional Notes:**
<!-- Anything else we should know when reviewing? -->

**How to test the change?**
<!--
Describe here how the change can be validated.
You are strongly encouraged to provide automated tests for this PR (unit or integration).
If this change cannot be feasibly tested, please explain why,
unless the change does not modify code (e.g. only modifies docs, comments).
-->

**For Datadog employees:**
- [ ] If this PR touches code that signs or publishes builds or packages, or handles
credentials of any kind, I've requested a review from `@DataDog/security-design-and-guidance`.
- [ ] This PR doesn't touch any of that.

Unsure? Have a question? Request a review!
