### PR TITLE
[PROF-9180] Benchmarks for allocation profiling

### DIFF
--- a/.gitlab/benchmarks.yml
+++ b/.gitlab/benchmarks.yml
@@ -82,6 +82,14 @@ only-profiling-gc:
     DD_PROFILING_NO_SIGNALS_WORKAROUND_ENABLED: "false"
     DD_PROFILING_FORCE_ENABLE_GC: "true"
 
+only-profiling-alloc:
+  extends: .benchmarks
+  variables:
+    DD_BENCHMARKS_CONFIGURATION: only-profiling
+    DD_PROFILING_ENABLED: "true"
+    DD_PROFILING_NO_SIGNALS_WORKAROUND_ENABLED: "false"
+    DD_PROFILING_EXPERIMENTAL_ALLOCATION_ENABLED: "true"
+
 profiling-and-tracing:
   extends: .benchmarks
   variables:

--- a/benchmarks/profiler_memory_sample_serialize.rb
+++ b/benchmarks/profiler_memory_sample_serialize.rb
@@ -1,0 +1,102 @@
+# Used to quickly run benchmark under RSpec as part of the usual test suite, to validate it didn't bitrot
+VALIDATE_BENCHMARK_MODE = ENV['VALIDATE_BENCHMARK'] == 'true'
+
+return unless __FILE__ == $PROGRAM_NAME || VALIDATE_BENCHMARK_MODE
+
+require 'benchmark/ips'
+require 'ddtrace'
+require 'pry'
+require_relative 'dogstatsd_reporter'
+
+require 'libdatadog'
+
+puts "Libdatadog from: #{Libdatadog.pkgconfig_folder}"
+
+# This benchmark measures the performance of sampling + serializing memory profiles. It enables us to evaluate changes to
+# the profiler and/or libdatadog that may impact both individual samples, as well as samples over time.
+#
+METRIC_VALUES = { 'cpu-time' => 0, 'cpu-samples' => 0, 'wall-time' => 0, 'alloc-samples' => 1, 'timeline' => 0 }.freeze
+OBJECT_CLASS = 'object'.freeze
+
+def sample_object(recorder, depth = 0)
+  if depth <= 0
+    Datadog::Profiling::StackRecorder::Testing._native_track_object(
+      recorder,
+      Object.new,
+      1,
+      OBJECT_CLASS,
+    )
+    Datadog::Profiling::Collectors::Stack::Testing._native_sample(
+      Thread.current,
+      recorder,
+      METRIC_VALUES,
+      [],
+      [],
+      400,
+      false
+    )
+  else
+    sample_object(recorder, depth - 1)
+  end
+end
+
+class ProfilerMemorySampleSerializeBenchmark
+  def create_profiler
+    @recorder = Datadog::Profiling::StackRecorder.new(
+      cpu_time_enabled: false,
+      alloc_samples_enabled: true,
+      heap_samples_enabled: false,
+      heap_size_enabled: false,
+      heap_sample_every: 1,
+      timeline_enabled: false,
+    )
+  end
+
+  def run_benchmark
+    Benchmark.ips do |x|
+      benchmark_time = VALIDATE_BENCHMARK_MODE ? { time: 0.01, warmup: 0 } : { time: 10, warmup: 2 }
+      x.config(
+        **benchmark_time,
+        suite: report_to_dogstatsd_if_enabled_via_environment_variable(benchmark_name: 'profiler_memory_sample_serialize')
+      )
+
+      x.report("sample+serialize #{ENV['CONFIG']}") do
+        samples_per_second = 100
+        simulate_seconds = 60
+
+        (samples_per_second * simulate_seconds).times do |i|
+          sample_object(@recorder, i % 400)
+        end
+
+        @recorder.serialize
+        nil
+      end
+
+      x.save! 'profiler_memory_sample_serialize-results.json' unless VALIDATE_BENCHMARK_MODE
+      x.compare!
+    end
+
+    @recorder.serialize
+  end
+
+  def run_forever
+    loop do
+      1000.times do
+        Datadog::Profiling::Collectors::ThreadContext::Testing._native_sample(@collector, PROFILER_OVERHEAD_STACK_THREAD)
+      end
+      @recorder.serialize
+      print '.'
+    end
+  end
+end
+
+puts "Current pid is #{Process.pid}"
+
+ProfilerMemorySampleSerializeBenchmark.new.instance_exec do
+  create_profiler
+  if ARGV.include?('--forever')
+    run_forever
+  else
+    run_benchmark
+  end
+end

--- a/benchmarks/profiler_memory_sample_serialize.rb
+++ b/benchmarks/profiler_memory_sample_serialize.rb
@@ -81,8 +81,8 @@ class ProfilerMemorySampleSerializeBenchmark
 
   def run_forever
     loop do
-      1000.times do
-        Datadog::Profiling::Collectors::ThreadContext::Testing._native_sample(@collector, PROFILER_OVERHEAD_STACK_THREAD)
+      1000.times do |i|
+        sample_object(@recorder, i % 400)
       end
       @recorder.serialize
       print '.'

--- a/spec/datadog/profiling/validate_benchmarks_spec.rb
+++ b/spec/datadog/profiling/validate_benchmarks_spec.rb
@@ -21,7 +21,7 @@ RSpec.describe 'Profiling benchmarks', if: (RUBY_VERSION >= '2.4.0') do
     it('runs without raising errors') { expect_in_fork { load './benchmarks/profiler_sample_serialize.rb' } }
   end
 
-  describe 'profiler_memory sample_serialize' do
+  describe 'profiler_memory_sample_serialize' do
     it('runs without raising errors') { expect_in_fork { load './benchmarks/profiler_memory_sample_serialize.rb' } }
   end
 end

--- a/spec/datadog/profiling/validate_benchmarks_spec.rb
+++ b/spec/datadog/profiling/validate_benchmarks_spec.rb
@@ -20,4 +20,8 @@ RSpec.describe 'Profiling benchmarks', if: (RUBY_VERSION >= '2.4.0') do
   describe 'profiler_sample_serialize' do
     it('runs without raising errors') { expect_in_fork { load './benchmarks/profiler_sample_serialize.rb' } }
   end
+
+  describe 'profiler_memory sample_serialize' do
+    it('runs without raising errors') { expect_in_fork { load './benchmarks/profiler_memory_sample_serialize.rb' } }
+  end
 end


### PR DESCRIPTION
**What does this PR do?**
Adds sample+serialize ruby microbenchmark and a benchmarking platform configuration focused on allocation profiling.

**Motivation:**
Understand overheads of allocation profiling.

**How to test the change?**

## Microbenchmark
```
❯ bundle exec ruby benchmarks/profiler_memory_sample_serialize.rb
Libdatadog from: /Users/alexandre.fonseca/Projects/DataDog/libdatadog/build/arm64-darwin-23/lib/pkgconfig
Current pid is 48717
DogStatsD reporting ❌ disabled
Warming up --------------------------------------
sample+serialize 
                         1.000  i/100ms
Calculating -------------------------------------
sample+serialize 
                          4.526  (± 0.0%) i/s -     46.000  in  10.164368s
```

## Benchmarking platform
<img width="851" alt="image" src="https://github.com/DataDog/dd-trace-rb/assets/373323/036429c5-2b31-4321-80e2-75fa83dfda52">


**For Datadog employees:**
- [ ] If this PR touches code that signs or publishes builds or packages, or handles
credentials of any kind, I've requested a review from `@DataDog/security-design-and-guidance`.
- [ ] This PR doesn't touch any of that.

Unsure? Have a question? Request a review!
