### PR TITLE
[PROF-8669] Benchmarks for heap profiling

### DIFF
--- a/.gitlab/benchmarks.yml
+++ b/.gitlab/benchmarks.yml
@@ -88,7 +88,26 @@ only-profiling-alloc:
     DD_BENCHMARKS_CONFIGURATION: only-profiling
     DD_PROFILING_ENABLED: "true"
     DD_PROFILING_NO_SIGNALS_WORKAROUND_ENABLED: "false"
-    DD_PROFILING_EXPERIMENTAL_ALLOCATION_ENABLED: "true"
+    DD_PROFILING_ALLOCATION_ENABLED: "true"
+
+only-profiling-heap:
+  extends: .benchmarks
+  variables:
+    DD_BENCHMARKS_CONFIGURATION: only-profiling
+    DD_PROFILING_ENABLED: "true"
+    DD_PROFILING_NO_SIGNALS_WORKAROUND_ENABLED: "false"
+    DD_PROFILING_ALLOCATION_ENABLED: "true"
+    DD_PROFILING_EXPERIMENTAL_HEAP_ENABLED: "true"
+
+only-profiling-heap-size:
+  extends: .benchmarks
+  variables:
+    DD_BENCHMARKS_CONFIGURATION: only-profiling
+    DD_PROFILING_ENABLED: "true"
+    DD_PROFILING_NO_SIGNALS_WORKAROUND_ENABLED: "false"
+    DD_PROFILING_ALLOCATION_ENABLED: "true"
+    DD_PROFILING_EXPERIMENTAL_HEAP_ENABLED: "true"
+    DD_PROFILING_EXPERIMENTAL_HEAP_SIZE_ENABLED: "true"
 
 profiling-and-tracing:
   extends: .benchmarks

--- a/.gitlab/benchmarks.yml
+++ b/.gitlab/benchmarks.yml
@@ -109,6 +109,17 @@ only-profiling-heap-size:
     DD_PROFILING_EXPERIMENTAL_HEAP_ENABLED: "true"
     DD_PROFILING_EXPERIMENTAL_HEAP_SIZE_ENABLED: "true"
 
+only-profiling-heap-size-sample-rate-1:
+  extends: .benchmarks
+  variables:
+    DD_BENCHMARKS_CONFIGURATION: only-profiling
+    DD_PROFILING_ENABLED: "true"
+    DD_PROFILING_NO_SIGNALS_WORKAROUND_ENABLED: "false"
+    DD_PROFILING_ALLOCATION_ENABLED: "true"
+    DD_PROFILING_EXPERIMENTAL_HEAP_ENABLED: "true"
+    DD_PROFILING_EXPERIMENTAL_HEAP_SIZE_ENABLED: "true"
+    DD_PROFILING_EXPERIMENTAL_HEAP_SAMPLE_RATE: "1"
+
 profiling-and-tracing:
   extends: .benchmarks
   variables:

--- a/benchmarks/profiler_memory_sample_serialize.rb
+++ b/benchmarks/profiler_memory_sample_serialize.rb
@@ -20,9 +20,10 @@ OBJECT_CLASS = 'object'.freeze
 
 def sample_object(recorder, depth = 0)
   if depth <= 0
+    obj = Object.new
     Datadog::Profiling::StackRecorder::Testing._native_track_object(
       recorder,
-      Object.new,
+      obj,
       1,
       OBJECT_CLASS,
     )
@@ -35,56 +36,66 @@ def sample_object(recorder, depth = 0)
       400,
       false
     )
+    obj
   else
     sample_object(recorder, depth - 1)
   end
 end
 
 class ProfilerMemorySampleSerializeBenchmark
-  def create_profiler
-    @recorder = Datadog::Profiling::StackRecorder.new(
-      cpu_time_enabled: false,
-      alloc_samples_enabled: true,
-      heap_samples_enabled: false,
-      heap_size_enabled: false,
-      heap_sample_every: 1,
-      timeline_enabled: false,
-    )
+  def setup
+    @heap_samples_enabled = ENV['HEAP_SAMPLES'] == 'true'
+    @heap_size_enabled = ENV['HEAP_SIZE'] == 'true'
+    @heap_sample_every = (ENV['HEAP_SAMPLE_EVERY'] || '1').to_i
+    @retain_every = (ENV['RETAIN_EVERY'] || '10').to_i
+    @recorder_factory = proc {
+      Datadog::Profiling::StackRecorder.new(
+        cpu_time_enabled: false,
+        alloc_samples_enabled: true,
+        heap_samples_enabled: @heap_samples_enabled,
+        heap_size_enabled: @heap_size_enabled,
+        heap_sample_every: @heap_sample_every,
+        timeline_enabled: false,
+      )
+    }
   end
 
   def run_benchmark
     Benchmark.ips do |x|
-      benchmark_time = VALIDATE_BENCHMARK_MODE ? { time: 0.01, warmup: 0 } : { time: 10, warmup: 2 }
+      benchmark_time = VALIDATE_BENCHMARK_MODE ? { time: 0.01, warmup: 0 } : { time: 30, warmup: 2 }
       x.config(
         **benchmark_time,
         suite: report_to_dogstatsd_if_enabled_via_environment_variable(benchmark_name: 'profiler_memory_sample_serialize')
       )
 
-      x.report("sample+serialize #{ENV['CONFIG']}") do
+      x.report("sample+serialize #{ENV['CONFIG']} retain_every=#{@retain_every} heap_samples=#{@heap_samples_enabled} heap_size=#{@heap_size_enabled} heap_sample_every=#{@heap_sample_every}") do
+        recorder = @recorder_factory.call
         samples_per_second = 100
         simulate_seconds = 60
+        retained_objs = []
 
         (samples_per_second * simulate_seconds).times do |i|
-          sample_object(@recorder, i % 400)
+          obj = sample_object(recorder, i % 400)
+          retained_objs << obj if (i % @retain_every).zero?
         end
 
-        @recorder.serialize
-        nil
+        GC.start
+
+        recorder.serialize
       end
 
       x.save! 'profiler_memory_sample_serialize-results.json' unless VALIDATE_BENCHMARK_MODE
       x.compare!
     end
-
-    @recorder.serialize
   end
 
   def run_forever
     loop do
+      recorder = @recorder_factory.call
       1000.times do |i|
-        sample_object(@recorder, i % 400)
+        sample_object(recorder, i % 400)
       end
-      @recorder.serialize
+      recorder.serialize
       print '.'
     end
   end
@@ -93,7 +104,7 @@ end
 puts "Current pid is #{Process.pid}"
 
 ProfilerMemorySampleSerializeBenchmark.new.instance_exec do
-  create_profiler
+  setup
   if ARGV.include?('--forever')
     run_forever
   else


### PR DESCRIPTION
**What does this PR do?**
Adds knobs to existing memory profile benchmark to allow benchmarks of different heap profiler configurations.

Because heap profiling is stateful, I've had to tweak the benchmark a bit to ensure each run uses an independent profiler. I bumped the benchmark time to try and compensate for any noise this might add.

**Motivation:**
Understand overheads of heap profiling against allocation alone.

**How to test the change?**
## Microbenchmarks

Commands:
```
bundle exec ruby benchmarks/profiler_memory_sample_serialize.rb
HEAP_SAMPLES=true bundle exec ruby benchmarks/profiler_memory_sample_serialize.rb
HEAP_SAMPLES=true HEAP_SIZE=true bundle exec ruby benchmarks/profiler_memory_sample_serialize.rb
RETAIN_EVERY=1 HEAP_SAMPLES=true HEAP_SIZE=true bundle exec ruby benchmarks/profiler_memory_sample_serialize.rb
RETAIN_EVERY=100 HEAP_SAMPLES=true HEAP_SIZE=true bundle exec ruby benchmarks/profiler_memory_sample_serialize.rb
RETAIN_EVERY=1000 HEAP_SAMPLES=true HEAP_SIZE=true bundle exec ruby benchmarks/profiler_memory_sample_serialize.rb
RETAIN_EVERY=10 HEAP_SAMPLE_EVERY=10 HEAP_SAMPLES=true HEAP_SIZE=true bundle exec ruby benchmarks/profiler_memory_sample_serialize.rb
RETAIN_EVERY=100 HEAP_SAMPLE_EVERY=10 HEAP_SAMPLES=true HEAP_SIZE=true bundle exec ruby benchmarks/profiler_memory_sample_serialize.rb
```

Results:
```
Comparison:
sample+serialize  retain_every=10 heap_samples=false heap_size=false heap_sample_every=1:        5.9 i/s
sample+serialize  retain_every=100 heap_samples=true heap_size=true heap_sample_every=10:        5.6 i/s - 1.06x  slower
sample+serialize  retain_every=10 heap_samples=true heap_size=true heap_sample_every=10:        5.5 i/s - 1.07x  slower
sample+serialize  retain_every=1000 heap_samples=true heap_size=true heap_sample_every=1:        3.9 i/s - 1.51x  slower
sample+serialize  retain_every=100 heap_samples=true heap_size=true heap_sample_every=1:        3.9 i/s - 1.51x  slower
sample+serialize  retain_every=10 heap_samples=true heap_size=true heap_sample_every=1:        3.8 i/s - 1.56x  slower
sample+serialize  retain_every=10 heap_samples=true heap_size=false heap_sample_every=1:        3.7 i/s - 1.57x  slower
sample+serialize  retain_every=1 heap_samples=true heap_size=true heap_sample_every=1:        2.9 i/s - 2.05x  slower
```

## Benchmarking platform

https://benchmarking.us1.prod.dog/benchmarks?projectId=5&page=1&ciJobDateStart=1711360069479&ciJobDateEnd=1711964869479&benchmarkGroupPipelineId=30914579&benchmarkGroupSha=44fc55b34b23ec7722658c66b85a8493f85846a5&benchmarkId=3045890

https://docs.google.com/document/d/1-ntPzqDxbNOANJAw7wWmjSHLoYeLgk1yS7iwRkIe2ng

**For Datadog employees:**
- [ ] If this PR touches code that signs or publishes builds or packages, or handles
credentials of any kind, I've requested a review from `@DataDog/security-design-and-guidance`.
- [ ] This PR doesn't touch any of that.

Unsure? Have a question? Request a review!
