### PR TITLE
Add benchmark for distributed trace propagation

### DIFF
--- a/benchmarks/tracing_trace.rb
+++ b/benchmarks/tracing_trace.rb
@@ -98,6 +98,54 @@ class TracingTraceBenchmark
       end
     end
   end
+
+  def benchmark_propagation_datadog
+    Datadog.configure do |c|
+      c.tracing.propagation_style = ['datadog']
+    end
+
+    Datadog::Tracing.trace('op.name') do |span, trace|
+      injected_trace_digest = trace.to_digest
+      Benchmark.ips do |x|
+        benchmark_time = VALIDATE_BENCHMARK_MODE ? { time: 0.001, warmup: 0 } : { time: 10.5, warmup: 2 }
+        x.config(**benchmark_time)
+
+        x.report("Propagation - Datadog") do
+          env = {}
+          Datadog::Tracing::Contrib::HTTP.inject(injected_trace_digest, env)
+          extracted_trace_digest = Datadog::Tracing::Contrib::HTTP.extract(env)
+          raise unless extracted_trace_digest
+        end
+
+        x.save! "#{__FILE__}-results.json" unless VALIDATE_BENCHMARK_MODE
+        x.compare!
+      end
+    end
+  end
+
+  def benchmark_propagation_trace_context
+    Datadog.configure do |c|
+      c.tracing.propagation_style = ['tracecontext']
+    end
+
+    Datadog::Tracing.trace('op.name') do |span, trace|
+      injected_trace_digest = trace.to_digest
+      Benchmark.ips do |x|
+        benchmark_time = VALIDATE_BENCHMARK_MODE ? { time: 0.001, warmup: 0 } : { time: 10.5, warmup: 2 }
+        x.config(**benchmark_time)
+
+        x.report("Propagation - Trace Context") do
+          env = {}
+          Datadog::Tracing::Contrib::HTTP.inject(injected_trace_digest, env)
+          extracted_trace_digest = Datadog::Tracing::Contrib::HTTP.extract(env)
+          raise unless extracted_trace_digest
+        end
+
+        x.save! "#{__FILE__}-results.json" unless VALIDATE_BENCHMARK_MODE
+        x.compare!
+      end
+    end
+  end
 end
 
 puts "Current pid is #{Process.pid}"
@@ -115,4 +163,6 @@ TracingTraceBenchmark.new.instance_exec do
   run_benchmark { benchmark_no_network }
   run_benchmark { benchmark_to_digest }
   run_benchmark { benchmark_log_correlation }
+  run_benchmark { benchmark_propagation_datadog }
+  run_benchmark { benchmark_propagation_trace_context }
 end


### PR DESCRIPTION
<!--
Check out the
https://github.com/DataDog/dd-trace-rb/blob/master/docs/DevelopmentGuide.md
for guidance on how to set up your development environment,
run the test suite, write new integrations, and more.
-->

**What does this PR do?**

Add benchmarking for distributed trace propagation round-trip: extracting distributed headers from the active trace, then passing those headers back into a trace digest.

This PR has benchmarks for both the Datadog propagation style and W3C Trace Context style.

It also has a benchmark for a basic, digest generation and continuation.

**Motivation:**
This captures the complete overhead of distributed tracing.

**Additional Notes:**
<!-- Anything else we should know when reviewing? -->

**How to test the change?**
<!--
Describe here how the change can be validated.
You are strongly encouraged to provide automated tests for this PR (unit or integration).
If this change cannot be feasibly tested, please explain why,
unless the change does not modify code (e.g. only modifies docs, comments).
-->

**For Datadog employees:**
- [ ] If this PR touches code that signs or publishes builds or packages, or handles
credentials of any kind, I've requested a review from `@DataDog/security-design-and-guidance`.
- [ ] This PR doesn't touch any of that.

Unsure? Have a question? Request a review!
