### PR TITLE
Change prerelease gem version pattern

### DIFF
--- a/.github/workflows/build-gem.yml
+++ b/.github/workflows/build-gem.yml
@@ -36,52 +36,16 @@ jobs:
         if: ${{ matrix.type != 'final' }}
         run: |
           # Obtain context information
-          git_ref='${{ github.ref }}'
-          git_branch="$(echo "${git_ref}" | sed -e 's#^refs/heads/##')"
-          git_sha='${{ github.sha }}'
           gha_run_id='${{ github.run_id }}'
+          git_ref='${{ github.ref }}'
+          git_sha='${{ github.sha }}'
 
           # Output info for CI debug
-          echo git_ref="${git_ref}"
-          echo git_branch="${git_branch}"
-          echo git_sha="${git_sha}"
           echo gha_run_id="${gha_run_id}"
+          echo git_ref="${git_ref}"
+          echo git_sha="${git_sha}"
 
-          # Sanitize for ruby version usage
-          git_branch_sha="$(echo "$git_branch" | ruby -rdigest -n -e 'print Digest::SHA256.hexdigest($_.chomp)[0, 6]')"
-          echo git_branch_sha="${git_branch_sha}"
-
-          # Shorten commit sha
-          git_sha_short="${git_sha:0:8}"
-          echo git_sha_short="${git_sha_short}"
-
-          # Set component values:
-          # - PRE is `dev` to denote being a development version and
-          #   act as a categorizer.
-          # - BUILD starts with git branch sha for grouping, prefixed by `b`.
-          # - BUILD has CI run id for traceability, prefixed by `gha`
-          #   for identification.
-          # - BUILD has commit next for traceability, prefixed git-describe
-          #   style by `g` for identification.
-          # - BUILD has branch name last since it has to be separated
-          #   by dots and thus has variable version segment size and
-          #   unpredictable ordering; it can thus be reliably extracted
-          #   and does not impair readability in lists
-          PRE='${{ matrix.type }}'
-          BUILD="b${git_branch_sha}.gha${gha_run_id}.g${git_sha_short}"
-
-          # Output info for CI debug
-          echo PRE="${PRE}"
-          echo BUILD="${BUILD}"
-
-          # Patch in components
-          sed lib/ddtrace/version.rb -i -e "s/^\([\t ]*PRE\) *= */\1 = \'${PRE}\' # /"
-          sed lib/ddtrace/version.rb -i -e "s/^\([\t ]*BUILD\) *= */\1 = \'${BUILD}\' # /"
-
-          # Test result
-          cat lib/ddtrace/version.rb | grep -e PRE -e BUILD
-          ruby -Ilib -rddtrace/version -e 'puts DDTrace::VERSION::STRING'
-          ruby -Ilib -rddtrace/version -e 'puts Gem::Version.new(DDTrace::VERSION::STRING).to_s'
+          .gitlab/patch_gem_version.sh gha $gha_run_id $git_ref $git_sha;
       - name: Patch gem host
         if: ${{ matrix.type != 'final' }}
         run: |

--- a/.github/workflows/build-gem.yml
+++ b/.github/workflows/build-gem.yml
@@ -48,17 +48,17 @@ jobs:
           echo gha_run_id="${gha_run_id}"
 
           # Sanitize for ruby version usage
-          git_branch_sanitized="$(echo "$git_branch" | sed -e 's/[^a-zA-Z0-9+]\{1,\}/./g')"
-          echo git_branch_sanitized="${git_branch_sanitized}"
+          git_branch_sha="$(echo "$git_branch" | ruby -rdigest -n -e 'print Digest::SHA256.hexdigest($_.chomp)[0, 6]')"
+          echo git_branch_sha="${git_branch_sha}"
 
           # Shorten commit sha
-          git_sha_short="${git_sha:0:12}"
+          git_sha_short="${git_sha:0:8}"
           echo git_sha_short="${git_sha_short}"
 
           # Set component values:
           # - PRE is `dev` to denote being a development version and
           #   act as a categorizer.
-          # - BUILD starts with CI run id for ordering.
+          # - BUILD starts with git branch sha for grouping, prefixed by `b`.
           # - BUILD has CI run id for traceability, prefixed by `gha`
           #   for identification.
           # - BUILD has commit next for traceability, prefixed git-describe
@@ -68,7 +68,7 @@ jobs:
           #   unpredictable ordering; it can thus be reliably extracted
           #   and does not impair readability in lists
           PRE='${{ matrix.type }}'
-          BUILD="gha${gha_run_id}.g${git_sha_short}.${git_branch_sanitized}"
+          BUILD="b${git_branch_sha}.gha${gha_run_id}.g${git_sha_short}"
 
           # Output info for CI debug
           echo PRE="${PRE}"

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -79,7 +79,14 @@ build-gem:
     - when: manual
       allow_failure: true
   script:
-    - if [ -z "$CI_COMMIT_TAG"]; then .gitlab/patch_gem_version.sh; fi # if not release, patch the version
+    - |
+      if [ -z "$CI_COMMIT_TAG" ]; then
+        echo CI_JOB_ID=$CI_JOB_ID
+        echo CI_COMMIT_REF_NAME=$CI_COMMIT_REF_NAME
+        echo CI_COMMIT_SHA=$CI_COMMIT_SHA
+
+        .gitlab/patch_gem_version.sh glci $CI_JOB_ID $CI_COMMIT_REF_NAME $CI_COMMIT_SHA
+      fi
     - bundle install && bundle exec rake build
     - mkdir -p tmp && ruby -Ilib -rddtrace/version -e 'puts Gem::Version.new(DDTrace::VERSION::STRING).to_s' >> tmp/version.txt
   artifacts:

--- a/.gitlab/patch_gem_version.sh
+++ b/.gitlab/patch_gem_version.sh
@@ -2,7 +2,10 @@
 
 echo CI_JOB_ID="${CI_JOB_ID}"
 
-git_branch_hash=$(git rev-parse --abbrev-ref HEAD |ruby -rdigest -n -e 'print Digest::SHA256.hexdigest($_.chomp)[0, 6]')
+git_branch=$(git rev-parse --abbrev-ref HEAD)
+echo git_branch="${git_branch}"
+
+git_branch_hash=$(echo "$git_branch" |ruby -rdigest -n -e 'print Digest::SHA256.hexdigest($_.chomp)[0, 6]')
 echo git_branch_hash="${git_branch_hash}"
 
 git_sha=$(git rev-parse --short=8 HEAD)

--- a/.gitlab/patch_gem_version.sh
+++ b/.gitlab/patch_gem_version.sh
@@ -1,16 +1,17 @@
 #!/bin/bash
 
-# Obtain context information
-git_sha=$(git rev-parse --short HEAD)
+echo CI_JOB_ID="${CI_JOB_ID}"
 
-# Output info for CI debug
+git_branch_hash=$(git rev-parse --abbrev-ref HEAD |ruby -rdigest -n -e 'print Digest::SHA256.hexdigest($_.chomp)[0, 6]')
+echo git_branch_hash="${git_branch_hash}"
+
+git_sha=$(git rev-parse --short=8 HEAD)
 echo git_sha="${git_sha}"
 
 PRE='dev'
-BUILD="${git_sha}"
-
-# Output info for CI debug
 echo PRE="${PRE}"
+
+BUILD="b${git_branch_hash}.glci${CI_JOB_ID}.g${git_sha}"
 echo BUILD="${BUILD}"
 
 # Patch in components

--- a/.gitlab/patch_gem_version.sh
+++ b/.gitlab/patch_gem_version.sh
@@ -1,23 +1,32 @@
 #!/bin/bash
+set -e
 
-echo CI_JOB_ID="${CI_JOB_ID}"
+echo CI=$1
+echo MONOTONIC_ID=$2
+echo GIT_REF=$3
+echo GIT_COMMIT_SHA=$4
 
-git_ref="${CI_COMMIT_REF_NAME}"
-echo git_ref="${git_ref}"
-
-git_branch="$(echo "${git_ref}" | sed -e 's#^refs/heads/##')"
+git_branch="${3#refs/heads/}"
 echo git_branch="${git_branch}"
 
 git_branch_hash=$(echo "$git_branch" | ruby -rdigest -n -e 'print Digest::SHA256.hexdigest($_.chomp)[0, 6]')
 echo git_branch_hash="${git_branch_hash}"
 
-git_sha=$(git rev-parse --short=8 HEAD)
-echo git_sha="${git_sha}"
+git_short_sha=${4:0:8}
+echo git_short_sha=$git_short_sha
 
-PRE='dev'
+PRE=dev
 echo PRE="${PRE}"
 
-BUILD="b${git_branch_hash}.glci${CI_JOB_ID}.g${git_sha}"
+# Set component values:
+# - PRE is `dev` to denote being a development version and
+#   act as a categorizer.
+# - BUILD starts with git branch sha for grouping, prefixed by `b`.
+# - BUILD has CI run id for traceability, prefixed by `gha` or `glci`
+#   for identification.
+# - BUILD has commit next for traceability, prefixed git-describe
+#   style by `g` for identification.
+BUILD="b${git_branch_hash}.${1}${2}.g${git_short_sha}"
 echo BUILD="${BUILD}"
 
 # Patch in components

--- a/.gitlab/patch_gem_version.sh
+++ b/.gitlab/patch_gem_version.sh
@@ -2,10 +2,13 @@
 
 echo CI_JOB_ID="${CI_JOB_ID}"
 
-git_branch=$(git rev-parse --abbrev-ref HEAD)
+git_ref="${CI_COMMIT_REF_NAME}"
+echo git_ref="${git_ref}"
+
+git_branch="$(echo "${git_ref}" | sed -e 's#^refs/heads/##')"
 echo git_branch="${git_branch}"
 
-git_branch_hash=$(echo "$git_branch" |ruby -rdigest -n -e 'print Digest::SHA256.hexdigest($_.chomp)[0, 6]')
+git_branch_hash=$(echo "$git_branch" | ruby -rdigest -n -e 'print Digest::SHA256.hexdigest($_.chomp)[0, 6]')
 echo git_branch_hash="${git_branch_hash}"
 
 git_sha=$(git rev-parse --short=8 HEAD)

--- a/lib/datadog/core/environment/identity.rb
+++ b/lib/datadog/core/environment/identity.rb
@@ -76,7 +76,7 @@ module Datadog
             end
           end
 
-          semver << pre << build
+          semver + pre + build
         end
       end
     end

--- a/spec/datadog/core/environment/identity_spec.rb
+++ b/spec/datadog/core/environment/identity_spec.rb
@@ -91,18 +91,18 @@ RSpec.describe Datadog::Core::Environment::Identity do
 
     context 'when development' do
       before do
-        expect(described_class).to receive(:tracer_version).and_return('10.20.30.gha12345.ga1b2c3d4.a.branch.name')
+        expect(described_class).to receive(:tracer_version).and_return('10.20.30.b3fe268.gha12345.ga1b2c3d4')
       end
 
-      it { is_expected.to eq('10.20.30+gha12345.ga1b2c3d4.a-branch-name') }
+      it { is_expected.to eq('10.20.30+b3fe268.gha12345.ga1b2c3d4') }
     end
 
     context 'when prerelease and development' do
       before do
-        expect(described_class).to receive(:tracer_version).and_return('10.20.30.beta40.gha12345.ga1b2c3d4.a.branch.name')
+        expect(described_class).to receive(:tracer_version).and_return('10.20.30.beta40.b3fe268.gha12345.ga1b2c3d4')
       end
 
-      it { is_expected.to eq('10.20.30-beta40+gha12345.ga1b2c3d4.a-branch-name') }
+      it { is_expected.to eq('10.20.30-beta40+b3fe268.gha12345.ga1b2c3d4') }
     end
   end
 end

--- a/spec/datadog/core/environment/identity_spec.rb
+++ b/spec/datadog/core/environment/identity_spec.rb
@@ -75,7 +75,7 @@ RSpec.describe Datadog::Core::Environment::Identity do
 
     context 'when not prerelease' do
       before do
-        expect(described_class).to receive(:tracer_version).and_return('10.20.30')
+        expect(described_class).to receive(:tracer_version).and_return('10.20.30'.freeze)
       end
 
       it { is_expected.to eq('10.20.30') }
@@ -83,7 +83,7 @@ RSpec.describe Datadog::Core::Environment::Identity do
 
     context 'when prerelease' do
       before do
-        expect(described_class).to receive(:tracer_version).and_return('10.20.30.beta40')
+        expect(described_class).to receive(:tracer_version).and_return('10.20.30.beta40'.freeze)
       end
 
       it { is_expected.to eq('10.20.30-beta40') }
@@ -91,7 +91,7 @@ RSpec.describe Datadog::Core::Environment::Identity do
 
     context 'when development' do
       before do
-        expect(described_class).to receive(:tracer_version).and_return('10.20.30.b3fe268.gha12345.ga1b2c3d4')
+        expect(described_class).to receive(:tracer_version).and_return('10.20.30.b3fe268.gha12345.ga1b2c3d4'.freeze)
       end
 
       it { is_expected.to eq('10.20.30+b3fe268.gha12345.ga1b2c3d4') }
@@ -99,7 +99,7 @@ RSpec.describe Datadog::Core::Environment::Identity do
 
     context 'when prerelease and development' do
       before do
-        expect(described_class).to receive(:tracer_version).and_return('10.20.30.beta40.b3fe268.gha12345.ga1b2c3d4')
+        expect(described_class).to receive(:tracer_version).and_return('10.20.30.beta40.b3fe268.gha12345.ga1b2c3d4'.freeze)
       end
 
       it { is_expected.to eq('10.20.30-beta40+b3fe268.gha12345.ga1b2c3d4') }


### PR DESCRIPTION
**What does this PR do?**

This PR changes the gem version for our test/prerelease gem. 

The build metadata starts with a git branch hash which can be helpful to group artifacts per branch.
