### PR TITLE
Improve log correlation performance

### DIFF
--- a/gemfiles/ruby_2.5_rails4_mysql2.gemfile.lock
+++ b/gemfiles/ruby_2.5_rails4_mysql2.gemfile.lock
@@ -69,7 +69,7 @@ PATH
   specs:
     datadog (2.0.0.beta1)
       debase-ruby_core_source (= 3.3.1)
-      libdatadog (~> 6.0.0.2.0)
+      libdatadog (~> 7.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
 
@@ -116,8 +116,8 @@ GEM
     io-wait (0.3.1)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (6.0.0.2.0-aarch64-linux)
-    libdatadog (6.0.0.2.0-x86_64-linux)
+    libdatadog (7.0.0.1.0-aarch64-linux)
+    libdatadog (7.0.0.1.0-x86_64-linux)
     libddwaf (1.14.0.0.0-aarch64-linux)
       ffi (~> 1.0)
     libddwaf (1.14.0.0.0-x86_64-linux)

--- a/gemfiles/ruby_2.5_rails4_postgres.gemfile.lock
+++ b/gemfiles/ruby_2.5_rails4_postgres.gemfile.lock
@@ -69,7 +69,7 @@ PATH
   specs:
     datadog (2.0.0.beta1)
       debase-ruby_core_source (= 3.3.1)
-      libdatadog (~> 6.0.0.2.0)
+      libdatadog (~> 7.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
 
@@ -116,8 +116,8 @@ GEM
     io-wait (0.3.1)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (6.0.0.2.0-aarch64-linux)
-    libdatadog (6.0.0.2.0-x86_64-linux)
+    libdatadog (7.0.0.1.0-aarch64-linux)
+    libdatadog (7.0.0.1.0-x86_64-linux)
     libddwaf (1.14.0.0.0-aarch64-linux)
       ffi (~> 1.0)
     libddwaf (1.14.0.0.0-x86_64-linux)

--- a/gemfiles/ruby_2.5_rails4_postgres_redis.gemfile.lock
+++ b/gemfiles/ruby_2.5_rails4_postgres_redis.gemfile.lock
@@ -69,7 +69,7 @@ PATH
   specs:
     datadog (2.0.0.beta1)
       debase-ruby_core_source (= 3.3.1)
-      libdatadog (~> 6.0.0.2.0)
+      libdatadog (~> 7.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
 
@@ -116,8 +116,8 @@ GEM
     io-wait (0.3.1)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (6.0.0.2.0-aarch64-linux)
-    libdatadog (6.0.0.2.0-x86_64-linux)
+    libdatadog (7.0.0.1.0-aarch64-linux)
+    libdatadog (7.0.0.1.0-x86_64-linux)
     libddwaf (1.14.0.0.0-aarch64-linux)
       ffi (~> 1.0)
     libddwaf (1.14.0.0.0-x86_64-linux)

--- a/gemfiles/ruby_2.5_rails4_postgres_sidekiq.gemfile.lock
+++ b/gemfiles/ruby_2.5_rails4_postgres_sidekiq.gemfile.lock
@@ -66,7 +66,7 @@ PATH
   specs:
     datadog (2.0.0.beta1)
       debase-ruby_core_source (= 3.3.1)
-      libdatadog (~> 6.0.0.2.0)
+      libdatadog (~> 7.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
 
@@ -117,8 +117,8 @@ GEM
     io-wait (0.3.1)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (6.0.0.2.0-aarch64-linux)
-    libdatadog (6.0.0.2.0-x86_64-linux)
+    libdatadog (7.0.0.1.0-aarch64-linux)
+    libdatadog (7.0.0.1.0-x86_64-linux)
     libddwaf (1.14.0.0.0-aarch64-linux)
       ffi (~> 1.0)
     libddwaf (1.14.0.0.0-x86_64-linux)

--- a/gemfiles/ruby_2.5_rails4_semantic_logger.gemfile.lock
+++ b/gemfiles/ruby_2.5_rails4_semantic_logger.gemfile.lock
@@ -69,7 +69,7 @@ PATH
   specs:
     datadog (2.0.0.beta1)
       debase-ruby_core_source (= 3.3.1)
-      libdatadog (~> 6.0.0.2.0)
+      libdatadog (~> 7.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
 
@@ -116,8 +116,8 @@ GEM
     io-wait (0.3.1)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (6.0.0.2.0-aarch64-linux)
-    libdatadog (6.0.0.2.0-x86_64-linux)
+    libdatadog (7.0.0.1.0-aarch64-linux)
+    libdatadog (7.0.0.1.0-x86_64-linux)
     libddwaf (1.14.0.0.0-aarch64-linux)
       ffi (~> 1.0)
     libddwaf (1.14.0.0.0-x86_64-linux)

--- a/gemfiles/ruby_3.1_multi_rack_app.gemfile.lock
+++ b/gemfiles/ruby_3.1_multi_rack_app.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     datadog (2.0.0.beta1)
       debase-ruby_core_source (= 3.3.1)
-      libdatadog (~> 6.0.0.2.0)
+      libdatadog (~> 7.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
 
@@ -145,8 +145,8 @@ GEM
     json (2.7.1)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (6.0.0.2.0-aarch64-linux)
-    libdatadog (6.0.0.2.0-x86_64-linux)
+    libdatadog (7.0.0.1.0-aarch64-linux)
+    libdatadog (7.0.0.1.0-x86_64-linux)
     libddwaf (1.14.0.0.0-aarch64-linux)
       ffi (~> 1.0)
     libddwaf (1.14.0.0.0-x86_64-linux)

--- a/lib/datadog/tracing/correlation.rb
+++ b/lib/datadog/tracing/correlation.rb
@@ -1,7 +1,6 @@
 # frozen_string_literal: true
 
 require_relative 'utils'
-require_relative 'metadata/ext'
 require_relative '../core/logging/ext'
 
 module Datadog
@@ -36,11 +35,11 @@ module Datadog
           version: nil
         )
           # Dup and freeze strings so they aren't modified by reference.
-          @env = Core::Utils::SafeDup.frozen_dup(env || Datadog.configuration.env)
-          @service = Core::Utils::SafeDup.frozen_dup(service || Datadog.configuration.service)
+          @env = env || Datadog.configuration.env
+          @service = service || Datadog.configuration.service
           @span_id = (span_id || 0).to_s
           @trace_id = trace_id || 0
-          @version = Core::Utils::SafeDup.frozen_dup(version || Datadog.configuration.version)
+          @version = version || Datadog.configuration.version
         end
 
         def to_h

--- a/lib/datadog/tracing/trace_operation.rb
+++ b/lib/datadog/tracing/trace_operation.rb
@@ -8,6 +8,7 @@ require_relative 'metadata/tagging'
 require_relative 'sampling/ext'
 require_relative 'span_operation'
 require_relative 'trace_digest'
+require_relative 'correlation'
 require_relative 'trace_segment'
 require_relative 'utils'
 
@@ -304,6 +305,17 @@ module Datadog
           trace_state_unknown_fields: @trace_state_unknown_fields,
           span_remote: (@remote_parent && @active_span.nil?),
         ).freeze
+      end
+
+      def to_correlation
+        # Resolve current span ID
+        span_id = @active_span && @active_span.id
+        span_id ||= @parent_span_id unless finished?
+
+        Correlation::Identifier.new(
+          trace_id: @id,
+          span_id: span_id
+        )
       end
 
       # Returns a copy of this trace suitable for forks (w/o spans.)

--- a/lib/datadog/tracing/tracer.rb
+++ b/lib/datadog/tracing/tracer.rb
@@ -224,9 +224,10 @@ module Datadog
       # @return [Datadog::Tracing::Correlation::Identifier] correlation object
       def active_correlation(key = nil)
         trace = active_trace(key)
-        Correlation.identifier_from_digest(
-          trace && trace.to_digest
-        )
+
+        return Datadog::Tracing::Correlation::Identifier.new unless trace
+
+        trace.to_correlation
       end
 
       # Setup a new trace to continue from where another

--- a/spec/datadog/tracing/correlation_spec.rb
+++ b/spec/datadog/tracing/correlation_spec.rb
@@ -22,14 +22,7 @@ RSpec.describe Datadog::Tracing::Correlation do
     let(:env) { 'dev' }
     let(:service) { 'acme-api' }
     let(:span_id) { Datadog::Tracing::Utils.next_id }
-    let(:span_name) { 'active_record.sql' }
-    let(:span_resource) { 'SELECT * FROM users;' }
-    let(:span_service) { 'acme-mysql' }
-    let(:span_type) { 'db' }
     let(:trace_id) { Datadog::Tracing::Utils::TraceId.next_id }
-    let(:trace_name) { 'rack.request' }
-    let(:trace_resource) { 'GET /users' }
-    let(:trace_service) { 'acme-api' }
     let(:version) { '0.1' }
   end
 
@@ -52,10 +45,10 @@ RSpec.describe Datadog::Tracing::Correlation do
         )
       end
 
-      it 'has frozen copies of strings' do
-        expect(identifier.env).to be_a_frozen_copy_of(default_env)
-        expect(identifier.service).to be_a_frozen_copy_of(default_service)
-        expect(identifier.version).to be_a_frozen_copy_of(default_version)
+      it 'has strings' do
+        expect(identifier.env).to eq(default_env)
+        expect(identifier.service).to eq(default_service)
+        expect(identifier.version).to eq(default_version)
       end
     end
 
@@ -66,14 +59,7 @@ RSpec.describe Datadog::Tracing::Correlation do
         instance_double(
           Datadog::Tracing::TraceDigest,
           span_id: span_id,
-          span_name: span_name,
-          span_resource: span_resource,
-          span_service: span_service,
-          span_type: span_type,
           trace_id: trace_id,
-          trace_name: trace_name,
-          trace_resource: trace_resource,
-          trace_service: trace_service
         )
       end
 
@@ -87,10 +73,10 @@ RSpec.describe Datadog::Tracing::Correlation do
         )
       end
 
-      it 'has frozen copies of strings' do
-        expect(identifier.env).to be_a_frozen_copy_of(default_env)
-        expect(identifier.service).to be_a_frozen_copy_of(default_service)
-        expect(identifier.version).to be_a_frozen_copy_of(default_version)
+      it 'has strings' do
+        expect(identifier.env).to eq(default_env)
+        expect(identifier.service).to eq(default_service)
+        expect(identifier.version).to eq(default_version)
       end
     end
   end
@@ -110,10 +96,10 @@ RSpec.describe Datadog::Tracing::Correlation do
           )
         end
 
-        it 'has frozen copies of strings' do
-          expect(identifier.env).to be_a_frozen_copy_of(default_env)
-          expect(identifier.service).to be_a_frozen_copy_of(default_service)
-          expect(identifier.version).to be_a_frozen_copy_of(default_version)
+        it 'has strings' do
+          expect(identifier.env).to eq(default_env)
+          expect(identifier.service).to eq(default_service)
+          expect(identifier.version).to eq(default_version)
         end
       end
 
@@ -140,10 +126,10 @@ RSpec.describe Datadog::Tracing::Correlation do
           )
         end
 
-        it 'has frozen copies of strings' do
-          expect(identifier.env).to be_a_frozen_copy_of(env)
-          expect(identifier.service).to be_a_frozen_copy_of(service)
-          expect(identifier.version).to be_a_frozen_copy_of(version)
+        it 'has strings' do
+          expect(identifier.env).to eq(env)
+          expect(identifier.service).to eq(service)
+          expect(identifier.version).to eq(version)
         end
       end
     end


### PR DESCRIPTION
Inspired by https://github.com/DataDog/dd-trace-rb/pull/3447

**What does this PR do?**

This is a performance improvement for correlation object. 

1. Creating correlation object from trace operation (skipping TraceDigest)
2. Improve `version`, `env` and `service` without duplicate in memory

