### PR TITLE
Fix `Datadog::Tracing.reject!` with correct metrics

### DIFF
--- a/lib/datadog/tracing/trace_operation.rb
+++ b/lib/datadog/tracing/trace_operation.rb
@@ -137,13 +137,12 @@ module Datadog
       end
 
       def keep!
-        self.sampled = true
         self.sampling_priority = Sampling::Ext::Priority::USER_KEEP
         set_tag(Tracing::Metadata::Ext::Distributed::TAG_DECISION_MAKER, Tracing::Sampling::Ext::Decision::MANUAL)
+        self.sampled = true # Just in case the in-app sampler had decided to drop this span, we revert that decision.
       end
 
       def reject!
-        self.sampled = false
         self.sampling_priority = Sampling::Ext::Priority::USER_REJECT
         set_tag(Tracing::Metadata::Ext::Distributed::TAG_DECISION_MAKER, Tracing::Sampling::Ext::Decision::MANUAL)
       end

--- a/spec/datadog/tracing/integration_spec.rb
+++ b/spec/datadog/tracing/integration_spec.rb
@@ -775,7 +775,10 @@ RSpec.describe 'Tracer integration tests' do
       it 'drops trace at application side' do
         expect(tracer.writer).to_not receive(:write)
 
-        tracer.trace('span') { |_, trace| trace.reject! }
+        tracer.trace('span') do |_, trace|
+          trace.reject!
+          trace.sampled = false
+        end
       end
     end
 

--- a/spec/datadog/tracing/trace_operation_spec.rb
+++ b/spec/datadog/tracing/trace_operation_spec.rb
@@ -871,18 +871,17 @@ RSpec.describe Datadog::Tracing::TraceOperation do
 
     it 'does not modify sampled?' do
       expect { reject! }
-        .to change { trace_op.sampled? }
-        .from(true).to(false)
+        .to_not change { trace_op.sampled? }
+        .from(true)
     end
 
     context 'when #sampled was true' do
       before { trace_op.sampled = true }
 
-      it 'sets sampled? to false' do
+      it 'does not change sampled?' do
         expect { reject! }
-          .to change { trace_op.sampled? }
+          .to_not change { trace_op.sampled? }
           .from(true)
-          .to(false)
       end
     end
 


### PR DESCRIPTION
**What does this PR do?**

`Datadog::Tracing.reject!` now only changes the priority sampling, as documented, instead of preventing the trace from reaching the Datadog Agent. Now, rejected traces will correctly count towards [trace metrics](https://docs.datadoghq.com/tracing/metrics/#trace-metrics).

This was always the intended behavior, but was incorrectly implemented.