### PR TITLE
Allows deployment without prerequisites

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -176,6 +176,7 @@ onboarding_tests:
 
 deploy_to_reliability_env:
   stage: deploy
+  needs: [] # This allows the job to run without prerequisites
   rules:
     - if: $CI_PIPELINE_SOURCE == "schedule"
       when: on_success


### PR DESCRIPTION
**What does this PR do?**

I want to validate Relenv deployment without waiting on prerequisites during development. 