### PR TITLE
Fix unstable benchmarks and comparison with 1.x

### DIFF
--- a/benchmarks/tracing_trace.rb
+++ b/benchmarks/tracing_trace.rb
@@ -25,7 +25,7 @@ class TracingTraceBenchmark
 
   # @param [Integer] time in seconds. The default is 12 seconds because having over 105 samples allows the
   #   benchmarking platform to calculate helpful aggregate stats. Because benchmark-ips tries to run one iteration
-  #   pre 100 ms, this means we'll have around 120 samples (give or take a small margin of error).
+  #   per 100ms, this means we'll have around 120 samples (give or take a small margin of error).
   # @param [Integer] warmup in seconds. The default is 2 seconds.
   def benchmark_time(time: 12, warmup: 2)
     VALIDATE_BENCHMARK_MODE ? { time: 0.001, warmup: 0 } : { time: time, warmup: warmup }


### PR DESCRIPTION
<!--
Check out the
https://github.com/DataDog/dd-trace-rb/blob/master/docs/DevelopmentGuide.md
for guidance on how to set up your development environment,
run the test suite, write new integrations, and more.
-->


**What does this PR do?**


This PR documents why the benchmark that includes the writer yields unstable results.

This PR also fixes test comparisons with `master` branch running `1.x`. This is only needed because the benchmarks are run against both `1.X` and `2.X`. If benchmarks already existed `1.x` this wouldn't be an issue, but because they were recently introduced, they do not exist in master branch. We can revert this fix when `2.x` is merged to `master` but we need minor changes to ensure immediately compatibility.

**Motivation:**
<!-- What inspired you to submit this pull request? -->

**Additional Notes:**
<!-- Anything else we should know when reviewing? -->

**How to test the change?**
<!--
Describe here how the change can be validated.
You are strongly encouraged to provide automated tests for this PR (unit or integration).
If this change cannot be feasibly tested, please explain why,
unless the change does not modify code (e.g. only modifies docs, comments).
-->

**For Datadog employees:**
- [ ] If this PR touches code that signs or publishes builds or packages, or handles
credentials of any kind, I've requested a review from `@DataDog/security-design-and-guidance`.
- [ ] This PR doesn't touch any of that.

Unsure? Have a question? Request a review!
