### PR TITLE
Allow suppresing error logs for Core::Remote::Negotiation

### DIFF
--- a/lib/datadog/core/remote/negotiation.rb
+++ b/lib/datadog/core/remote/negotiation.rb
@@ -7,12 +7,12 @@ module Datadog
     module Remote
       # Endpoint negotiation
       class Negotiation
-        def initialize(_settings, agent_settings)
+        def initialize(_settings, agent_settings, suppress_logging: {})
           transport_options = {}
           transport_options[:agent_settings] = agent_settings if agent_settings
 
           @transport_root = Datadog::Core::Remote::Transport::HTTP.root(**transport_options.dup)
-          @logged = {}
+          @logged = suppress_logging
         end
 
         def endpoint?(path)

--- a/sig/datadog/core/remote/negotiation.rbs
+++ b/sig/datadog/core/remote/negotiation.rbs
@@ -5,7 +5,7 @@ module Datadog
         @transport_root: Datadog::Core::Remote::Transport::Negotiation::Transport
         @logged: ::Hash[::Symbol, bool]
 
-        def initialize: (Datadog::Core::Configuration::Settings _settings, Datadog::Core::Configuration::AgentSettingsResolver::AgentSettings agent_settings) -> void
+        def initialize: (Datadog::Core::Configuration::Settings _settings, Datadog::Core::Configuration::AgentSettingsResolver::AgentSettings agent_settings, ?suppress_logging: ::Hash[::Symbol, bool]) -> void
 
         def endpoint?: (::String path) -> bool
 

--- a/spec/datadog/core/remote/negotiation_spec.rb
+++ b/spec/datadog/core/remote/negotiation_spec.rb
@@ -35,7 +35,8 @@ RSpec.describe Datadog::Core::Remote::Negotiation do
     include_context 'HTTP connection stub'
 
     subject(:endpoint?) { negotiation.endpoint?('/foo') }
-    let(:negotiation) { described_class.new(settings, agent_settings) }
+    let(:suppress_logging) { {} }
+    let(:negotiation) { described_class.new(settings, agent_settings, suppress_logging: suppress_logging) }
 
     context 'when /info exists' do
       let(:response_code) { 200 }
@@ -58,6 +59,16 @@ RSpec.describe Datadog::Core::Remote::Negotiation do
         expect(Datadog.logger).to receive(:error).and_return(nil)
 
         expect(negotiation.endpoint?('/bar')).to be false
+      end
+
+      context 'when logging for :no_config_endpoint is suppressed' do
+        let(:suppress_logging) { { no_config_endpoint: true } }
+
+        it 'does not log an error' do
+          expect(Datadog.logger).to_not receive(:error)
+
+          expect(negotiation.endpoint?('/bar')).to be false
+        end
       end
     end
 


### PR DESCRIPTION
**What does this PR do?**
Adds `suppress_logging` keyword argument that makes it possible to skip logging error messages for selected error cases.

Usage: 

```ruby
negotiation = Datadog::Core::Remote::Negotiation.new(
  settings, 
  agent_settings, 
  suppress_logging: { no_config_endpoint: true }
)

# no error logged
negotiation.endpoint?("/evp_proxy/v4/") # => false
```

**Motivation:**
`datadog-ci` gem uses `Datadog::Core::Remote::Negotiation` to check if agent has certain endpoints available(`/evp_proxy/v4` and `/evp_proxy/v2/`) to configure the correct transport for citestcycle events. We do not treat the absence of any of these endpoints as error, just an information for us to choose the correct way to send events. 

Currently, this class treats this situation as an error and logs error message thus creating unnecessary noise for the user. This PR aims to fix it by allowing us to skip certain logs.


**How to test the change?**
Covered by unit tests; default behaviour didn't change.

**For Datadog employees:**
- [ ] If this PR touches code that signs or publishes builds or packages, or handles
credentials of any kind, I've requested a review from `@DataDog/security-design-and-guidance`.
- [x] This PR doesn't touch any of that.

