### PR TITLE
Remove unused `_context` trace argument

### DIFF
--- a/lib/datadog/tracing.rb
+++ b/lib/datadog/tracing.rb
@@ -14,8 +14,29 @@ module Datadog
     class << self
       # (see Datadog::Tracing::Tracer#trace)
       # @public_api
-      def trace(name, continue_from: nil, **span_options, &block)
-        tracer.trace(name, continue_from: continue_from, **span_options, &block)
+      def trace(
+        name,
+        continue_from: nil,
+        on_error: nil,
+        resource: nil,
+        service: nil,
+        start_time: nil,
+        tags: nil,
+        type: nil,
+        &block
+      )
+
+        tracer.trace(
+          name,
+          continue_from: continue_from,
+          on_error: on_error,
+          resource: resource,
+          service: service,
+          start_time: start_time,
+          tags: tags,
+          type: type,
+          &block
+        )
       end
 
       # (see Datadog::Tracing::Tracer#continue_trace!)

--- a/lib/datadog/tracing/tracer.rb
+++ b/lib/datadog/tracing/tracer.rb
@@ -120,7 +120,6 @@ module Datadog
       # @yield Optional block where new newly created {Datadog::Tracing::SpanOperation} captures the execution.
       # @yieldparam [Datadog::Tracing::SpanOperation] span_op the newly created and active [Datadog::Tracing::SpanOperation]
       # @yieldparam [Datadog::Tracing::TraceOperation] trace_op the active [Datadog::Tracing::TraceOperation]
-      # rubocop:disable Lint/UnderscorePrefixedVariableName
       # rubocop:disable Metrics/MethodLength
       def trace(
         name,
@@ -131,16 +130,13 @@ module Datadog
         start_time: nil,
         tags: nil,
         type: nil,
-        _context: nil,
         &block
       )
         return skip_trace(name, &block) unless enabled
 
-        context, trace = nil
-
         # Resolve the trace
         begin
-          context = _context || call_context
+          context = call_context
           active_trace = context.active_trace
           trace = if continue_from || active_trace.nil?
                     start_trace(continue_from: continue_from)
@@ -186,7 +182,6 @@ module Datadog
           )
         end
       end
-      # rubocop:enable Lint/UnderscorePrefixedVariableName
       # rubocop:enable Metrics/MethodLength
 
       # Set the given key / value tag pair at the tracer level. These tags will be

--- a/spec/datadog/tracing/tracer_spec.rb
+++ b/spec/datadog/tracing/tracer_spec.rb
@@ -566,37 +566,6 @@ RSpec.describe Datadog::Tracing::Tracer do
         end
       end
 
-      context 'with _context: option' do
-        let(:options) { { _context: context_value } }
-
-        context 'as a context' do
-          let(:context) { Datadog::Tracing::Context.new }
-          let(:context_value) { context }
-
-          it 'creates an unmanaged trace' do
-            tracer.trace 'another' do
-              expect(trace).to be_root_span
-              # This context is one-off, and isn't stored in
-              # the tracer at all. We can only see the span
-              # isn't tracked by the tracer.
-              expect(trace).to_not be(tracer.active_span)
-            end
-          end
-        end
-      end
-
-      context 'without context: option' do
-        let(:options) { {} }
-
-        it 'creates span with current context' do
-          tracer.trace 'root' do |_root_span|
-            tracer.trace 'another' do |another_span|
-              expect(trace.send(:parent)).to eq another_span
-            end
-          end
-        end
-      end
-
       context 'with child finishing after parent' do
         it "allows child span to exceed parent's end time" do
           parent = tracer.trace('parent')

--- a/spec/datadog/tracing_spec.rb
+++ b/spec/datadog/tracing_spec.rb
@@ -59,15 +59,42 @@ RSpec.describe Datadog::Tracing do
   end
 
   describe '.trace' do
-    subject(:trace) { described_class.trace(name, continue_from: continue_from, **span_options, &block) }
+    subject(:trace) do
+      described_class.trace(
+        name,
+        continue_from: continue_from,
+        on_error: on_error,
+        resource: resource,
+        service: service,
+        start_time: start_time,
+        tags: tags,
+        type: type,
+        &block
+      )
+    end
+
     let(:name) { double('name') }
     let(:continue_from) { double('continue_from') }
-    let(:span_options) { { resource: double('option') } }
+    let(:on_error) { double('on_error') }
+    let(:resource) { double('resource') }
+    let(:service) { double('service') }
+    let(:start_time) { double('start_time') }
+    let(:tags) { double('tags') }
+    let(:type) { double('type') }
     let(:block) { -> {} }
 
     it 'delegates to the tracer' do
       expect(Datadog.send(:components).tracer).to receive(:trace)
-        .with(name, continue_from: continue_from, **span_options) { |&b| expect(b).to be(block) }
+        .with(
+          name,
+          continue_from: continue_from,
+          on_error: on_error,
+          resource: resource,
+          service: service,
+          start_time: start_time,
+          tags: tags,
+          type: type
+        ) { |&b| expect(b).to be(block) }
         .and_return(returned)
       expect(trace).to eq(returned)
     end


### PR DESCRIPTION
<!--
Check out the
https://github.com/DataDog/dd-trace-rb/blob/master/docs/DevelopmentGuide.md
for guidance on how to set up your development environment,
run the test suite, write new integrations, and more.
-->

**2.0 Upgrade Guide notes**

Remove undocumented argument `_context` from `Datadog::Tracing.trace(...)`.

<!--
(If this PR is for 1.x, please delete this section)
A public facing description that will go into the [upgrade guide](https://github.com/DataDog/dd-trace-rb/blob/master/docs/UpgradeGuide.md) for this change.
We already know what the PR does (from the PR title),
but users should know either:
* A migration path for this change. In other words, how to continue using their application without behavior changes
in 2.0 (e.g. environment variable 'X' renamed to 'Y').
* That there's no alternative; we completely dropped support for this feature.
-->

**Motivation:**
<!-- What inspired you to submit this pull request? -->

`_context` is unused in the `ddtrace` repository.

**Additional Notes:**
<!-- Anything else we should know when reviewing? -->

**How to test the change?**
<!--
Describe here how the change can be validated.
You are strongly encouraged to provide automated tests for this PR (unit or integration).
If this change cannot be feasibly tested, please explain why,
unless the change does not modify code (e.g. only modifies docs, comments).
-->

**For Datadog employees:**
- [ ] If this PR touches code that signs or publishes builds or packages, or handles
credentials of any kind, I've requested a review from `@DataDog/security-design-and-guidance`.
- [ ] This PR doesn't touch any of that.

Unsure? Have a question? Request a review!
