### PR TITLE
Revert "peer.service adjustment for sql propagation with DBM"

### DIFF
--- a/lib/datadog/tracing/contrib/mysql2/instrumentation.rb
+++ b/lib/datadog/tracing/contrib/mysql2/instrumentation.rb
@@ -54,17 +54,12 @@ module Datadog
                 span.set_tag(Tracing::Metadata::Ext::NET::TAG_TARGET_HOST, query_options[:host])
                 span.set_tag(Tracing::Metadata::Ext::NET::TAG_TARGET_PORT, query_options[:port])
 
-                Contrib::SpanAttributeSchema.set_peer_service!(span, Ext::PEER_SERVICE_SOURCES)
-
                 propagation_mode = Contrib::Propagation::SqlComment::Mode.new(comment_propagation)
 
                 Contrib::Propagation::SqlComment.annotate!(span, propagation_mode)
-                sql = Contrib::Propagation::SqlComment.prepend_comment(
-                  sql,
-                  span,
-                  trace_op,
-                  propagation_mode
-                )
+                sql = Contrib::Propagation::SqlComment.prepend_comment(sql, span, trace_op, propagation_mode)
+
+                Contrib::SpanAttributeSchema.set_peer_service!(span, Ext::PEER_SERVICE_SOURCES)
 
                 super(sql, options)
               end

--- a/lib/datadog/tracing/contrib/propagation/sql_comment.rb
+++ b/lib/datadog/tracing/contrib/propagation/sql_comment.rb
@@ -21,7 +21,7 @@ module Datadog
             return sql unless mode.enabled?
 
             tags = {
-              Ext::KEY_DATABASE_SERVICE => span_op.get_tag(Tracing::Metadata::Ext::TAG_PEER_SERVICE) || span_op.service,
+              Ext::KEY_DATABASE_SERVICE => span_op.service,
               Ext::KEY_ENVIRONMENT => datadog_configuration.env,
               Ext::KEY_PARENT_SERVICE => datadog_configuration.service,
               Ext::KEY_VERSION => datadog_configuration.version

--- a/spec/datadog/tracing/contrib/propagation/sql_comment_spec.rb
+++ b/spec/datadog/tracing/contrib/propagation/sql_comment_spec.rb
@@ -56,12 +56,7 @@ RSpec.describe Datadog::Tracing::Contrib::Propagation::SqlComment do
         end
       end
 
-      let(:span_op) do
-        Datadog::Tracing::SpanOperation.new(
-          'sample_span',
-          service: 'database_service'
-        )
-      end
+      let(:span_op) { double(service: 'database_service') }
       let(:trace_op) do
         double(
           to_digest: Datadog::Tracing::TraceDigest.new(
@@ -88,22 +83,6 @@ RSpec.describe Datadog::Tracing::Contrib::Propagation::SqlComment do
             "/*dddbs='database_service',dde='production',ddps='Traders%27%20Joe',ddpv='1.0.0'*/ #{sql_statement}"
           )
         end
-
-        context 'when given a span operation tagged with peer.service' do
-          let(:span_op) do
-            Datadog::Tracing::SpanOperation.new(
-              'sample_span',
-              service: 'database_service',
-              tags: { 'peer.service' => 'sample_peer_service' }
-            )
-          end
-
-          it do
-            is_expected.to eq(
-              "/*dddbs='sample_peer_service',dde='production',ddps='Traders%27%20Joe',ddpv='1.0.0'*/ #{sql_statement}"
-            )
-          end
-        end
       end
 
       context 'when `full` mode' do
@@ -120,27 +99,6 @@ RSpec.describe Datadog::Tracing::Contrib::Propagation::SqlComment do
             "#{sql_statement}"
           )
         }
-
-        context 'when given a span operation tagged with peer.service' do
-          let(:span_op) do
-            Datadog::Tracing::SpanOperation.new(
-              'sample_span',
-              service: 'database_service',
-              tags: { 'peer.service' => 'sample_peer_service' }
-            )
-          end
-
-          it {
-            is_expected.to eq(
-              "/*dddbs='sample_peer_service',"\
-              "dde='production',"\
-              "ddps='Traders%27%20Joe',"\
-              "ddpv='1.0.0',"\
-              "traceparent='#{traceparent}'*/ "\
-              "#{sql_statement}"
-            )
-          }
-        end
       end
     end
 


### PR DESCRIPTION
Reverts DataDog/dd-trace-rb#3127

`peer.service` is not a meaningful attribute for DBM as the data model is evolving to rely on `peer.db.name` and `peer.hostname` instead. The original PR is causing issues that we can avoid by reverting back to the old behavior. 