### PR TITLE
Bump version to 2.0.0.dev

### DIFF
--- a/lib/ddtrace/version.rb
+++ b/lib/ddtrace/version.rb
@@ -5,7 +5,7 @@ module DDTrace
     MAJOR = 2
     MINOR = 0
     PATCH = 0
-    PRE = 'rc1'
+    PRE = 'dev'
     BUILD = nil
     # PRE and BUILD above are modified for dev gems during gem build GHA workflow
 

--- a/lib/ddtrace/version.rb
+++ b/lib/ddtrace/version.rb
@@ -2,10 +2,10 @@
 
 module DDTrace
   module VERSION
-    MAJOR = 1
-    MINOR = 20
+    MAJOR = 2
+    MINOR = 0
     PATCH = 0
-    PRE = nil
+    PRE = 'rc1'
     BUILD = nil
     # PRE and BUILD above are modified for dev gems during gem build GHA workflow
 

--- a/spec/datadog/profiling/tag_builder_spec.rb
+++ b/spec/datadog/profiling/tag_builder_spec.rb
@@ -11,7 +11,7 @@ RSpec.describe Datadog::Profiling::TagBuilder do
         'host' => Datadog::Core::Environment::Socket.hostname,
         'language' => 'ruby',
         'process_id' => Process.pid.to_s,
-        'profiler_version' => start_with('1.'),
+        'profiler_version' => start_with('2.'),
         'runtime' => 'ruby',
         'runtime_engine' => RUBY_ENGINE,
         'runtime-id' => Datadog::Core::Environment::Identity.id,


### PR DESCRIPTION
<!--
Check out the
https://github.com/DataDog/dd-trace-rb/blob/master/docs/DevelopmentGuide.md
for guidance on how to set up your development environment,
run the test suite, write new integrations, and more.
-->

**What does this PR do?**

This PR changes the version of the library to 2.0.0.rc1.

This is needed as we have started deploying 2.x to our internal environments, and we've started to see traces produced by 2.x being ingested. Without this version bump, it's impossible to tell if the trace was produced by `ddtrace` 1.x or 2.x.

**Additional Notes:**
<!-- Anything else we should know when reviewing? -->

**How to test the change?**
<!--
Describe here how the change can be validated.
You are strongly encouraged to provide automated tests for this PR (unit or integration).
If this change cannot be feasibly tested, please explain why,
unless the change does not modify code (e.g. only modifies docs, comments).
-->

**For Datadog employees:**
- [ ] If this PR touches code that signs or publishes builds or packages, or handles
credentials of any kind, I've requested a review from `@DataDog/security-design-and-guidance`.
- [ ] This PR doesn't touch any of that.

Unsure? Have a question? Request a review!
