### PR TITLE
Fix: Guard PG result with `nil` check

### DIFF
--- a/lib/datadog/tracing/contrib/pg/instrumentation.rb
+++ b/lib/datadog/tracing/contrib/pg/instrumentation.rb
@@ -125,15 +125,21 @@ module Datadog
                 end
 
                 # Read metadata from PG::Result
+                #
+                # It is unclear how result can be `nil` instead of a `PG::Result`
+                # Maybe a bug in the PG gem or ActiveRecord ??
+                # see: https://github.com/DataDog/dd-trace-rb/issues/3507
+                #
+                # Mitigate by guarding with `nil` check
                 if block
                   yield(propagated_sql_statement, proc do |result|
                     ret = block.call(result)
-                    annotate_span_with_result!(span, result)
+                    annotate_span_with_result!(span, result) if result
                     ret
                   end)
                 else
                   result = yield(propagated_sql_statement)
-                  annotate_span_with_result!(span, result)
+                  annotate_span_with_result!(span, result) if result
                   result
                 end
               end


### PR DESCRIPTION
closes #3507 

**What does this PR do?**

It is unclear how `PG` is yielding or returning `nil` instead of `PG::Result`. 

I cannot reproduce the issue and here's a list what I have tried: 

1. I tried sending non-SELECT query (`DELETE FROM...`), `PG::Result` is returned
2. I tried closing the connection object in the block, it raises exception
3. I tried assigning the result object in the block and accessing it afterward, the `PG::Result` has a `cleared` status.

