### PR TITLE
Add ability to set sampling rules by resource

### DIFF
--- a/lib/datadog/tracing/configuration/settings.rb
+++ b/lib/datadog/tracing/configuration/settings.rb
@@ -318,10 +318,10 @@ module Datadog
                 # These rules control whether a trace is kept or dropped by the tracer.
                 #
                 # The `rules` format is a String with a JSON array of objects:
-                # Each object must have a `sample_rate`, and the `name` and `service` fields
+                # Each object must have a `sample_rate`, and the `name`, `service`, and `resource` fields
                 # are optional. The `sample_rate` value must be between 0.0 and 1.0 (inclusive).
-                # `name` and `service` are Strings that allow the `sample_rate` to be applied only
-                # to traces matching the `name` and `service`.
+                # `name`, `service`, and `resource` are Strings that allow the `sample_rate` to be applied only
+                # to traces matching the `name`, `service`, `resource`.
                 #
                 # @default `DD_TRACE_SAMPLING_RULES` environment variable. Otherwise `nil`.
                 # @return [String,nil]

--- a/lib/datadog/tracing/diagnostics/environment_logger.rb
+++ b/lib/datadog/tracing/diagnostics/environment_logger.rb
@@ -108,6 +108,7 @@ module Datadog
               {
                 name: rule.matcher.name,
                 service: rule.matcher.service,
+                resource: rule.matcher.resource,
                 sample_rate: rule.sampler.sample_rate(nil)
               }
             end.compact

--- a/lib/datadog/tracing/sampling/matcher.rb
+++ b/lib/datadog/tracing/sampling/matcher.rb
@@ -29,20 +29,23 @@ module Datadog
           end
         end.new
 
-        attr_reader :name, :service
+        attr_reader :name, :service, :resource
 
         # @param name [String,Regexp,Proc] Matcher for case equality (===) with the trace name,
         #             defaults to always match
         # @param service [String,Regexp,Proc] Matcher for case equality (===) with the service name,
         #                defaults to always match
-        def initialize(name: MATCH_ALL, service: MATCH_ALL)
+        # @param resource [String,Regexp,Proc] Matcher for case equality (===) with the resource name,
+        #                defaults to always match
+        def initialize(name: MATCH_ALL, service: MATCH_ALL, resource: MATCH_ALL)
           super()
           @name = name
           @service = service
+          @resource = resource
         end
 
         def match?(trace)
-          name === trace.name && service === trace.service
+          name === trace.name && service === trace.service && resource === trace.resource
         end
       end
 
@@ -60,7 +63,7 @@ module Datadog
         end
 
         def match?(trace)
-          block.call(trace.name, trace.service)
+          block.call(trace.name, trace.service, trace.resource)
         end
       end
     end

--- a/lib/datadog/tracing/sampling/rule.rb
+++ b/lib/datadog/tracing/sampling/rule.rb
@@ -44,15 +44,20 @@ module Datadog
       end
 
       # A {Datadog::Tracing::Sampling::Rule} that matches a trace based on
-      # trace name and/or service name and
+      # trace name and/or service name and/or resource name and
       # applies a fixed sampling to matching spans.
       # @public_api
       class SimpleRule < Rule
         # @param name [String,Regexp,Proc] Matcher for case equality (===) with the trace name, defaults to always match
         # @param service [String,Regexp,Proc] Matcher for case equality (===) with the service name,
         #                defaults to always match
+        # @param resource [String,Regexp,Proc] Matcher for case equality (===) with the resource name,
+        #                defaults to always match
         # @param sample_rate [Float] Sampling rate between +[0,1]+
-        def initialize(name: SimpleMatcher::MATCH_ALL, service: SimpleMatcher::MATCH_ALL, sample_rate: 1.0)
+        def initialize(
+          name: SimpleMatcher::MATCH_ALL, service: SimpleMatcher::MATCH_ALL,
+          resource: SimpleMatcher::MATCH_ALL, sample_rate: 1.0
+        )
           # We want to allow 0.0 to drop all traces, but {Datadog::Tracing::Sampling::RateSampler}
           # considers 0.0 an invalid rate and falls back to 100% sampling.
           #
@@ -64,7 +69,7 @@ module Datadog
           sampler = RateSampler.new
           sampler.sample_rate = sample_rate
 
-          super(SimpleMatcher.new(name: name, service: service), sampler)
+          super(SimpleMatcher.new(name: name, service: service, resource: resource), sampler)
         end
       end
     end

--- a/lib/datadog/tracing/sampling/rule_sampler.rb
+++ b/lib/datadog/tracing/sampling/rule_sampler.rb
@@ -61,6 +61,7 @@ module Datadog
             kwargs = {
               name: rule['name'],
               service: rule['service'],
+              resource: rule['resource'],
               sample_rate: sample_rate,
             }
 

--- a/lib/datadog/tracing/sampling/span/rule_parser.rb
+++ b/lib/datadog/tracing/sampling/span/rule_parser.rb
@@ -83,6 +83,10 @@ module Datadog
                 matcher_options[:service_pattern] = service_pattern
               end
 
+              if (resource_pattern = hash['resource'])
+                matcher_options[:resource_pattern] = resource_pattern
+              end
+
               matcher = Matcher.new(**matcher_options)
 
               rule_options = {}

--- a/spec/datadog/tracing/sampling/matcher_spec.rb
+++ b/spec/datadog/tracing/sampling/matcher_spec.rb
@@ -3,9 +3,10 @@ require 'spec_helper'
 require 'datadog/tracing/sampling/matcher'
 
 RSpec.describe Datadog::Tracing::Sampling::SimpleMatcher do
-  let(:span_op) { Datadog::Tracing::SpanOperation.new(span_name, service: span_service) }
+  let(:span_op) { Datadog::Tracing::SpanOperation.new(span_name, service: span_service, resource: span_resource) }
   let(:span_name) { 'operation.name' }
   let(:span_service) { nil }
+  let(:span_resource) { nil }
 
   describe '#match?' do
     subject(:match?) { rule.match?(span_op) }
@@ -112,6 +113,62 @@ RSpec.describe Datadog::Tracing::Sampling::SimpleMatcher do
       end
     end
 
+    context 'with a resource matcher' do
+      let(:rule) { described_class.new(resource: resource) }
+
+      context 'when span resource name is present' do
+        let(:span_resource) { 'resource-1' }
+
+        context 'with a regexp' do
+          context 'matching' do
+            let(:resource) { /.*/ }
+
+            it { is_expected.to eq(true) }
+          end
+
+          context 'not matching' do
+            let(:resource) { /^$/ }
+
+            it { is_expected.to eq(false) }
+          end
+        end
+
+        context 'with a string' do
+          context 'matching' do
+            let(:resource) { span_resource.to_s }
+
+            it { is_expected.to eq(true) }
+          end
+
+          context 'not matching' do
+            let(:resource) { '' }
+
+            it { is_expected.to eq(false) }
+          end
+        end
+
+        context 'with a proc' do
+          context 'matching' do
+            let(:resource) { ->(n) { n == span_resource } }
+
+            it { is_expected.to eq(true) }
+          end
+
+          context 'not matching' do
+            let(:resource) { ->(_n) { false } }
+
+            it { is_expected.to eq(false) }
+          end
+        end
+      end
+
+      context 'when span resource is not present' do
+        let(:resource) { /.*/ }
+
+        it { is_expected.to eq(false) }
+      end
+    end
+
     context 'with name and service matchers' do
       let(:rule) { described_class.new(name: name, service: service) }
 
@@ -128,13 +185,74 @@ RSpec.describe Datadog::Tracing::Sampling::SimpleMatcher do
         it { is_expected.to eq(false) }
       end
     end
+
+    context 'with name and resource matchers' do
+      let(:rule) { described_class.new(name: name, resource: resource) }
+
+      let(:name) { /.*/ }
+      let(:resource) { /.*/ }
+
+      context 'when span resource name is present' do
+        let(:span_resource) { 'resource-1' }
+
+        it { is_expected.to eq(true) }
+      end
+
+      context 'when span resource is not present' do
+        it { is_expected.to eq(false) }
+      end
+    end
+
+    context 'with service and resource matchers' do
+      let(:rule) { described_class.new(service: service, resource: resource) }
+
+      let(:service) { /.*/ }
+      let(:resource) { /.*/ }
+
+      context 'when span service and resource service are present' do
+        let(:span_service) { 'service-1' }
+        let(:span_resource) { 'resource-1' }
+
+        it { is_expected.to eq(true) }
+      end
+
+      context 'when span service is not present' do
+        let(:span_resource) { 'resource-1' }
+        it { is_expected.to eq(false) }
+      end
+
+      context 'when span resource is not present' do
+        let(:span_service) { 'service-1' }
+        it { is_expected.to eq(false) }
+      end
+
+      context 'when neither span service nor resource is present' do
+        it { is_expected.to eq(false) }
+      end
+    end
+
+    context 'with name, service, and resource matchers' do
+      let(:rule) { described_class.new(name: name, service: service, resource: resource) }
+
+      let(:name) { /.*/ }
+      let(:service) { /.*/ }
+      let(:resource) { /.*/ }
+
+      context 'when span service and resource service are present' do
+        let(:span_service) { 'service-1' }
+        let(:span_resource) { 'resource-1' }
+
+        it { is_expected.to eq(true) }
+      end
+    end
   end
 end
 
 RSpec.describe Datadog::Tracing::Sampling::ProcMatcher do
-  let(:span_op) { Datadog::Tracing::SpanOperation.new(span_name, service: span_service) }
+  let(:span_op) { Datadog::Tracing::SpanOperation.new(span_name, service: span_service, resource: span_resource) }
   let(:span_name) { 'operation.name' }
   let(:span_service) { nil }
+  let(:span_resource) { 'resource' }
 
   describe '#match?' do
     subject(:match?) { rule.match?(span_op) }
@@ -142,13 +260,17 @@ RSpec.describe Datadog::Tracing::Sampling::ProcMatcher do
     let(:rule) { described_class.new(&block) }
 
     context 'with matching block' do
-      let(:block) { ->(name, service) { name == span_name && service == span_service } }
+      let(:block) do
+        lambda do |name, service, resource|
+          name == span_name && service == span_service && resource == span_resource
+        end
+      end
 
       it { is_expected.to eq(true) }
     end
 
     context 'with mismatching block' do
-      let(:block) { ->(_name, _service) { false } }
+      let(:block) { ->(_name, _service, _resource) { false } }
 
       it { is_expected.to eq(false) }
     end

--- a/spec/datadog/tracing/sampling/rule_sampler_spec.rb
+++ b/spec/datadog/tracing/sampling/rule_sampler_spec.rb
@@ -26,6 +26,7 @@ RSpec.describe Datadog::Tracing::Sampling::RuleSampler do
     it do
       expect(rule.matcher.name).to eq(Datadog::Tracing::Sampling::SimpleMatcher::MATCH_ALL)
       expect(rule.matcher.service).to eq(Datadog::Tracing::Sampling::SimpleMatcher::MATCH_ALL)
+      expect(rule.matcher.resource).to eq(Datadog::Tracing::Sampling::SimpleMatcher::MATCH_ALL)
       expect(rule.sampler.sample_rate).to eq(options[:sample_rate])
     end
   end
@@ -100,6 +101,7 @@ RSpec.describe Datadog::Tracing::Sampling::RuleSampler do
       it 'parses as a match any' do
         expect(actual_rule.matcher.name).to eq(Datadog::Tracing::Sampling::SimpleMatcher::MATCH_ALL)
         expect(actual_rule.matcher.service).to eq(Datadog::Tracing::Sampling::SimpleMatcher::MATCH_ALL)
+        expect(actual_rule.matcher.resource).to eq(Datadog::Tracing::Sampling::SimpleMatcher::MATCH_ALL)
         expect(actual_rule.sampler.sample_rate).to eq(0.1)
       end
 
@@ -109,6 +111,7 @@ RSpec.describe Datadog::Tracing::Sampling::RuleSampler do
         it 'parses matching any service' do
           expect(actual_rule.matcher.name).to eq('test-name')
           expect(actual_rule.matcher.service).to eq(Datadog::Tracing::Sampling::SimpleMatcher::MATCH_ALL)
+          expect(actual_rule.matcher.resource).to eq(Datadog::Tracing::Sampling::SimpleMatcher::MATCH_ALL)
           expect(actual_rule.sampler.sample_rate).to eq(0.1)
         end
       end
@@ -119,6 +122,18 @@ RSpec.describe Datadog::Tracing::Sampling::RuleSampler do
         it 'parses matching any name' do
           expect(actual_rule.matcher.name).to eq(Datadog::Tracing::Sampling::SimpleMatcher::MATCH_ALL)
           expect(actual_rule.matcher.service).to eq('test-service')
+          expect(actual_rule.matcher.resource).to eq(Datadog::Tracing::Sampling::SimpleMatcher::MATCH_ALL)
+          expect(actual_rule.sampler.sample_rate).to eq(0.1)
+        end
+      end
+
+      context 'and resource' do
+        let(:rule) { { sample_rate: 0.1, resource: 'test-resource' } }
+
+        it 'parses matching any name' do
+          expect(actual_rule.matcher.name).to eq(Datadog::Tracing::Sampling::SimpleMatcher::MATCH_ALL)
+          expect(actual_rule.matcher.service).to eq(Datadog::Tracing::Sampling::SimpleMatcher::MATCH_ALL)
+          expect(actual_rule.matcher.resource).to eq('test-resource')
           expect(actual_rule.sampler.sample_rate).to eq(0.1)
         end
       end

--- a/spec/datadog/tracing/sampling/rule_spec.rb
+++ b/spec/datadog/tracing/sampling/rule_spec.rb
@@ -6,9 +6,10 @@ require 'datadog/tracing/sampling/rule'
 require 'datadog/tracing/span_operation'
 
 RSpec.describe Datadog::Tracing::Sampling::Rule do
-  let(:span_op) { Datadog::Tracing::SpanOperation.new(span_name, service: span_service) }
+  let(:span_op) { Datadog::Tracing::SpanOperation.new(span_name, service: span_service, resource: span_resource) }
   let(:span_name) { 'operation.name' }
   let(:span_service) { nil }
+  let(:span_resource) { nil }
 
   let(:rule) { described_class.new(matcher, sampler) }
   let(:matcher) { instance_double(Datadog::Tracing::Sampling::Matcher) }

--- a/spec/datadog/tracing/sampling/span/matcher_spec.rb
+++ b/spec/datadog/tracing/sampling/span/matcher_spec.rb
@@ -1,9 +1,10 @@
 require 'datadog/tracing/sampling/span/matcher'
 
 RSpec.describe Datadog::Tracing::Sampling::Span::Matcher do
-  let(:span_op) { Datadog::Tracing::SpanOperation.new(span_name, service: span_service) }
+  let(:span_op) { Datadog::Tracing::SpanOperation.new(span_name, service: span_service, resource: span_resource) }
   let(:span_name) { 'operation.name' }
   let(:span_service) { '' }
+  let(:span_resource) { '' }
 
   describe '#match?' do
     subject(:match?) { matcher.match?(span_op) }
@@ -77,11 +78,59 @@ RSpec.describe Datadog::Tracing::Sampling::Span::Matcher do
               end
             end
 
+            context 'matching on span resource' do
+              let(:matcher) { described_class.new(resource_pattern: pattern) }
+              let(:span_resource) { input }
+
+              it "does #{'not ' unless expected}match" do
+                is_expected.to eq(expected)
+              end
+            end
+
             context 'matching on span name and service' do
               context 'with the same matching scenario for both fields' do
                 let(:matcher) { described_class.new(name_pattern: pattern, service_pattern: pattern) }
                 let(:span_name) { input }
                 let(:span_service) { input }
+
+                it "does #{'not ' unless expected}match" do
+                  is_expected.to eq(expected)
+                end
+              end
+            end
+
+            context 'matching on span name and resource' do
+              context 'with the same matching scenario for both fields' do
+                let(:matcher) { described_class.new(name_pattern: pattern, resource_pattern: pattern) }
+                let(:span_name) { input }
+                let(:span_resource) { input }
+
+                it "does #{'not ' unless expected}match" do
+                  is_expected.to eq(expected)
+                end
+              end
+            end
+
+            context 'matching on span service and resource' do
+              context 'with the same matching scenario for both fields' do
+                let(:matcher) { described_class.new(service_pattern: pattern, resource_pattern: pattern) }
+                let(:span_service) { input }
+                let(:span_resource) { input }
+
+                it "does #{'not ' unless expected}match" do
+                  is_expected.to eq(expected)
+                end
+              end
+            end
+
+            context 'matching on span name, service, and resource' do
+              context 'with the same matching scenario for all fields' do
+                let(:matcher) do
+                  described_class.new(name_pattern: pattern, service_pattern: pattern, resource_pattern: pattern)
+                end
+                let(:span_name) { input }
+                let(:span_service) { input }
+                let(:span_resource) { input }
 
                 it "does #{'not ' unless expected}match" do
                   is_expected.to eq(expected)
@@ -94,13 +143,21 @@ RSpec.describe Datadog::Tracing::Sampling::Span::Matcher do
     end
 
     context 'matching on span name and service' do
-      let(:matcher) { described_class.new(name_pattern: name_pattern, service_pattern: service_pattern) }
+      let(:matcher) do
+        described_class.new(
+          name_pattern: name_pattern,
+          service_pattern: service_pattern,
+          resource_pattern: resource_pattern
+        )
+      end
 
       context 'when only name matches' do
         let(:span_name) { 'web.get' }
         let(:span_service) { 'server' }
+        let(:span_resource) { 'resource' }
         let(:name_pattern) { 'web.*' }
         let(:service_pattern) { 'server2' }
+        let(:resource_pattern) { 'resource2' }
 
         context 'does not match' do
           it { is_expected.to eq(false) }
@@ -110,8 +167,23 @@ RSpec.describe Datadog::Tracing::Sampling::Span::Matcher do
       context 'when only service matches' do
         let(:span_name) { 'web.get' }
         let(:span_service) { 'server' }
+        let(:span_resource) { 'resource' }
         let(:name_pattern) { 'web.post' }
         let(:service_pattern) { 'server' }
+        let(:resource_pattern) { 'resource2' }
+
+        context 'does not match' do
+          it { is_expected.to eq(false) }
+        end
+      end
+
+      context 'when only resource matches' do
+        let(:span_name) { 'web.get' }
+        let(:span_service) { 'server' }
+        let(:span_resource) { 'resource' }
+        let(:name_pattern) { 'web.post' }
+        let(:service_pattern) { 'server2' }
+        let(:resource_pattern) { 'resource' }
 
         context 'does not match' do
           it { is_expected.to eq(false) }

--- a/spec/datadog/tracing/sampling/span/rule_parser_spec.rb
+++ b/spec/datadog/tracing/sampling/span/rule_parser_spec.rb
@@ -54,6 +54,7 @@ RSpec.describe Datadog::Tracing::Sampling::Span::RuleParser do
             {
               name: name,
               service: service,
+              resource: resource,
               sample_rate: sample_rate,
               max_per_second: max_per_second,
             }
@@ -61,6 +62,7 @@ RSpec.describe Datadog::Tracing::Sampling::Span::RuleParser do
 
           let(:name) { nil }
           let(:service) { nil }
+          let(:resource) { nil }
           let(:sample_rate) { nil }
           let(:max_per_second) { nil }
 
@@ -109,6 +111,27 @@ RSpec.describe Datadog::Tracing::Sampling::Span::RuleParser do
 
               it 'warns and returns nil' do
                 expect(Datadog.logger).to receive(:warn).with(include(service.inspect) & include('Error'))
+                is_expected.to be_nil
+              end
+            end
+          end
+
+          context 'with resource' do
+            let(:resource) { 'resource' }
+
+            it 'sets the rule matcher resource' do
+              is_expected.to contain_exactly(
+                Datadog::Tracing::Sampling::Span::Rule.new(
+                  Datadog::Tracing::Sampling::Span::Matcher.new(resource_pattern: resource)
+                )
+              )
+            end
+
+            context 'with an invalid value' do
+              let(:resource) { { 'bad' => 'resource' } }
+
+              it 'warns and returns nil' do
+                expect(Datadog.logger).to receive(:warn).with(include(resource.inspect) & include('Error'))
                 is_expected.to be_nil
               end
             end

--- a/spec/datadog/tracing/sampling/span/rule_spec.rb
+++ b/spec/datadog/tracing/sampling/span/rule_spec.rb
@@ -7,9 +7,10 @@ RSpec.describe Datadog::Tracing::Sampling::Span::Rule do
   let(:sample_rate) { 0.0 }
   let(:rate_limit) { 0 }
 
-  let(:span_op) { Datadog::Tracing::SpanOperation.new(span_name, service: span_service) }
+  let(:span_op) { Datadog::Tracing::SpanOperation.new(span_name, service: span_service, resource: span_resource) }
   let(:span_name) { 'operation.name' }
   let(:span_service) { '' }
+  let(:span_resource) { '' }
 
   describe '#initialize' do
     subject(:rule) { described_class.new(matcher) }

--- a/spec/datadog/tracing/sampling/span/sampler_spec.rb
+++ b/spec/datadog/tracing/sampling/span/sampler_spec.rb
@@ -8,7 +8,7 @@ RSpec.describe Datadog::Tracing::Sampling::Span::Sampler do
   let(:rules) { [] }
 
   let(:trace_op) { Datadog::Tracing::TraceOperation.new }
-  let(:span_op) { Datadog::Tracing::SpanOperation.new('name', service: 'service') }
+  let(:span_op) { Datadog::Tracing::SpanOperation.new('name', service: 'service', resource: 'resource') }
 
   describe '#sample!' do
     subject(:sample!) { sampler.sample!(trace_op, span_op) }


### PR DESCRIPTION
<!--
Check out the
https://github.com/DataDog/dd-trace-rb/blob/master/docs/DevelopmentGuide.md
for guidance on how to set up your development environment,
run the test suite, write new integrations, and more.
-->

**What does this PR do?**
<!-- A brief description of the change being made with this pull request. -->
This PR adds support for sampling based on resources.  It does not change anything about when the rules / matchers / etc are evaluated.  It just compares against the existing `resource` value in addition to the `name` and `service` values.

Default behavior continues to be matching all resources

**Motivation:**
<!-- What inspired you to submit this pull request? -->
I was looking for a way to ensure that everything from a given resource within a service was sampled at a `1.0` rate.  I also noticed this feature existed in the python interface ([added here](https://github.com/DataDog/dd-trace-py/pull/6821)) so it seemed there would be no fundamental objection.

**Additional Notes:**
<!-- Anything else we should know when reviewing? -->

**How to test the change?**
<!--
Describe here how the change can be validated.
You are strongly encouraged to provide automated tests for this PR (unit or integration).
If this change cannot be feasibly tested, please explain why,
unless the change does not modify code (e.g. only modifies docs, comments).
-->
Mirrored the existing testing for `name` and `service`.  Additionally added in test cases for the combinations of `(name,service,resource)` patterns.

**For Datadog employees:**
- [ ] If this PR touches code that signs or publishes builds or packages, or handles
credentials of any kind, I've requested a review from `@DataDog/security-design-and-guidance`.
- [ ] This PR doesn't touch any of that.

Unsure? Have a question? Request a review!
