### PR TITLE
Patch Sinatra only once

### DIFF
--- a/lib/datadog/tracing/contrib/configurable.rb
+++ b/lib/datadog/tracing/contrib/configurable.rb
@@ -41,7 +41,7 @@ module Datadog
 
           # Create or update configuration associated with `matcher` with
           # the provided `options` and `&block`.
-          def configure(matcher = :default, options = {}, &block)
+          def configure(matcher = :default, options = {}, tracing = nil, &block)
             config = if matcher == :default
                        default_configuration
                      else
@@ -51,6 +51,12 @@ module Datadog
 
             # Apply the settings
             config.configure(options, &block)
+
+            # Configure dependents
+            if tracing && respond_to?(:subconfigure)
+              subconfigure(tracing, config)
+            end
+
             config
           end
 

--- a/lib/datadog/tracing/contrib/extensions.rb
+++ b/lib/datadog/tracing/contrib/extensions.rb
@@ -63,6 +63,10 @@ module Datadog
             # Reconfigure core settings
             super(&block)
 
+            # Configuration should be considered RO past this point:
+            # - Patcher's `patch` must not modify configuration.
+            # - use Integration's `subconfigure` instead
+
             # Activate integrations
             configuration = self.configuration.tracing
 
@@ -158,7 +162,7 @@ module Datadog
               unless integration.nil? || !integration.default_configuration.enabled
                 configuration_name = options[:describes] || :default
                 filtered_options = options.reject { |k, _v| k == :describes }
-                integration.configure(configuration_name, filtered_options, &block)
+                integration.configure(configuration_name, filtered_options, self, &block)
                 instrumented_integrations[integration_name] = integration
 
                 # Add to activation list

--- a/lib/datadog/tracing/contrib/sinatra/framework.rb
+++ b/lib/datadog/tracing/contrib/sinatra/framework.rb
@@ -7,27 +7,6 @@ module Datadog
         # - handle configuration entries which are specific to Datadog tracing
         # - instrument parts of the framework when needed
         module Framework
-          # Configure Rack from Sinatra, but only if Rack has not been configured manually beforehand
-          def self.setup
-            Datadog.configure do |datadog_config|
-              sinatra_config = config_with_defaults(datadog_config)
-              activate_rack!(datadog_config, sinatra_config)
-            end
-          end
-
-          def self.config_with_defaults(datadog_config)
-            datadog_config.tracing[:sinatra]
-          end
-
-          # Apply relevant configuration from Sinatra to Rack
-          def self.activate_rack!(datadog_config, sinatra_config)
-            datadog_config.tracing.instrument(
-              :rack,
-              service_name: sinatra_config[:service_name],
-              distributed_tracing: sinatra_config[:distributed_tracing],
-            )
-          end
-
           # Add Rack middleware at the top of the stack
           def self.add_middleware(middleware, builder, *args, &block)
             insert_middleware(builder, middleware, args, block) do |proc_, use|

--- a/lib/datadog/tracing/contrib/sinatra/integration.rb
+++ b/lib/datadog/tracing/contrib/sinatra/integration.rb
@@ -31,6 +31,14 @@ module Datadog
             Configuration::Settings.new
           end
 
+          def subconfigure(tracing, sinatra)
+            tracing.instrument(
+              :rack,
+              service_name: sinatra.service_name,
+              distributed_tracing: sinatra.distributed_tracing,
+            )
+          end
+
           def patcher
             Patcher
           end

--- a/lib/datadog/tracing/contrib/sinatra/patcher.rb
+++ b/lib/datadog/tracing/contrib/sinatra/patcher.rb
@@ -9,19 +9,6 @@ module Datadog
   module Tracing
     module Contrib
       module Sinatra
-        # Set tracer configuration at a late enough time
-        module TracerSetupPatch
-          ONLY_ONCE_PER_APP = Hash.new { |h, key| h[key] = Core::Utils::OnlyOnce.new }
-
-          def setup_middleware(*args, &block)
-            super.tap do
-              ONLY_ONCE_PER_APP[self].run do
-                Contrib::Sinatra::Framework.setup
-              end
-            end
-          end
-        end
-
         # Hook into builder before the middleware list gets frozen
         module DefaultMiddlewarePatch
           ONLY_ONCE_PER_APP = Hash.new { |h, key| h[key] = Core::Utils::OnlyOnce.new }
@@ -42,8 +29,6 @@ module Datadog
         module Patcher
           include Contrib::Patcher
 
-          PATCH_ONLY_ONCE = Core::Utils::OnlyOnce.new
-
           module_function
 
           def target_version
@@ -51,13 +36,10 @@ module Datadog
           end
 
           def patch
-            PATCH_ONLY_ONCE.run do
-              require_relative 'tracer'
-              register_tracer
+            require_relative 'tracer'
+            register_tracer
 
-              patch_default_middlewares
-              setup_tracer
-            end
+            patch_default_middlewares
           end
 
           def register_tracer


### PR DESCRIPTION
**What does this PR do?**

Sinatra needs to be patched once only.

**Motivation:**

Sinatra sets things up at first-request time, which may cause concurrent requests to call `configure` and break RC (thread leak).

**Additional Notes:**

The integration [hooks](https://github.com/DataDog/dd-trace-rb/blob/9e4a267ce0d93c3bd4603b02b3e39d40ae7c937b/lib/datadog/tracing/contrib/sinatra/patcher.rb#L68-L70) onto [`Sinatra::Base#setup_middleware`](https://github.com/DataDog/dd-trace-rb/blob/9e4a267ce0d93c3bd4603b02b3e39d40ae7c937b/lib/datadog/tracing/contrib/sinatra/patcher.rb#L26-L29), which then (much later, as `Sinatra::Base#setup_middleware` appears to be invoked at first request) calls our [`Contrib::Sinatra::Framework.setup`](https://github.com/DataDog/dd-trace-rb/blob/9e4a267ce0d93c3bd4603b02b3e39d40ae7c937b/lib/datadog/tracing/contrib/sinatra/framework.rb#L11-L16), which calls `Datadog.configure` and [`activate_rack!`](https://github.com/DataDog/dd-trace-rb/blob/9e4a267ce0d93c3bd4603b02b3e39d40ae7c937b/lib/datadog/tracing/contrib/sinatra/framework.rb#L23-L29) which invokes `config.tracing.instrument :rack`, which ultimately inserts the Rack middleware.

The trouble appears to be that this `Datadog.configure` call is not concurrency-protected enough, which leads to RC workers being started then mid-way the RC component being rebuilt with inconsistent access through `active_remote`.

**How to test the change?**

- CI
- test in a Sinatra app

**For Datadog employees:**
- [ ] If this PR touches code that signs or publishes builds or packages, or handles
credentials of any kind, I've requested a review from `@DataDog/security-design-and-guidance`.
- [x] This PR doesn't touch any of that.

Unsure? Have a question? Request a review!
