### PR TITLE
chore(tracing): Adds trace_remote field to TraceDigest

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -8,12 +8,12 @@ run the test suite, write new integrations, and more.
 **2.0 Upgrade Guide notes**
 <!--
 (If this PR is for 1.x, please delete this section)
-If this PR introduces a breaking change, update the
-https://github.com/DataDog/dd-trace-rb/blob/2.0/docs/UpgradeGuide2.md
-in this PR with either:
+A public facing description that will go into the [upgrade guide](https://github.com/DataDog/dd-trace-rb/blob/master/docs/UpgradeGuide.md) for this change.
+We already know what the PR does (from the PR title),
+but users should know either:
 * A migration path for this change. In other words, how to continue using their application without behavior changes
 in 2.0 (e.g. environment variable 'X' renamed to 'Y').
-* That there's no alternative; we removed support for this feature.
+* That there's no alternative; we completely dropped support for this feature.
 -->
 
 **What does this PR do?**

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -8,12 +8,12 @@ run the test suite, write new integrations, and more.
 **2.0 Upgrade Guide notes**
 <!--
 (If this PR is for 1.x, please delete this section)
-A public facing description that will go into the [upgrade guide](https://github.com/DataDog/dd-trace-rb/blob/master/docs/UpgradeGuide.md) for this change.
-We already know what the PR does (from the PR title),
-but users should know either:
+If this PR introduces a breaking change, update the
+https://github.com/DataDog/dd-trace-rb/blob/2.0/docs/UpgradeGuide2.md
+with either:
 * A migration path for this change. In other words, how to continue using their application without behavior changes
 in 2.0 (e.g. environment variable 'X' renamed to 'Y').
-* That there's no alternative; we completely dropped support for this feature.
+* That there's no alternative; we removed support for this feature.
 -->
 
 **What does this PR do?**

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -10,7 +10,7 @@ run the test suite, write new integrations, and more.
 (If this PR is for 1.x, please delete this section)
 If this PR introduces a breaking change, update the
 https://github.com/DataDog/dd-trace-rb/blob/2.0/docs/UpgradeGuide2.md
-with either:
+in this PR with either:
 * A migration path for this change. In other words, how to continue using their application without behavior changes
 in 2.0 (e.g. environment variable 'X' renamed to 'Y').
 * That there's no alternative; we removed support for this feature.

--- a/lib/datadog/opentelemetry/trace.rb
+++ b/lib/datadog/opentelemetry/trace.rb
@@ -50,7 +50,7 @@ module Datadog
             trace_service: digest.trace_service,
             trace_state: digest.trace_state,
             trace_state_unknown_fields: digest.trace_state_unknown_fields,
-            is_remote: digest.is_remote,
+            trace_remote: digest.trace_remote,
           ).freeze
         end
       end

--- a/lib/datadog/opentelemetry/trace.rb
+++ b/lib/datadog/opentelemetry/trace.rb
@@ -50,6 +50,7 @@ module Datadog
             trace_service: digest.trace_service,
             trace_state: digest.trace_state,
             trace_state_unknown_fields: digest.trace_state_unknown_fields,
+            is_remote: digest.is_remote,
           ).freeze
         end
       end

--- a/lib/datadog/opentelemetry/trace.rb
+++ b/lib/datadog/opentelemetry/trace.rb
@@ -50,7 +50,7 @@ module Datadog
             trace_service: digest.trace_service,
             trace_state: digest.trace_state,
             trace_state_unknown_fields: digest.trace_state_unknown_fields,
-            trace_remote: digest.trace_remote,
+            span_remote: digest.span_remote,
           ).freeze
         end
       end

--- a/lib/datadog/tracing/distributed/b3_multi.rb
+++ b/lib/datadog/tracing/distributed/b3_multi.rb
@@ -64,7 +64,7 @@ module Datadog
             trace_id: trace_id,
             span_id: span_id,
             trace_sampling_priority: sampling_priority,
-            is_remote: true,
+            trace_remote: true,
           )
         end
       end

--- a/lib/datadog/tracing/distributed/b3_multi.rb
+++ b/lib/datadog/tracing/distributed/b3_multi.rb
@@ -64,7 +64,7 @@ module Datadog
             trace_id: trace_id,
             span_id: span_id,
             trace_sampling_priority: sampling_priority,
-            trace_remote: true,
+            span_remote: true,
           )
         end
       end

--- a/lib/datadog/tracing/distributed/b3_multi.rb
+++ b/lib/datadog/tracing/distributed/b3_multi.rb
@@ -63,7 +63,8 @@ module Datadog
           TraceDigest.new(
             trace_id: trace_id,
             span_id: span_id,
-            trace_sampling_priority: sampling_priority
+            trace_sampling_priority: sampling_priority,
+            is_remote: true,
           )
         end
       end

--- a/lib/datadog/tracing/distributed/b3_single.rb
+++ b/lib/datadog/tracing/distributed/b3_single.rb
@@ -59,7 +59,8 @@ module Datadog
           TraceDigest.new(
             span_id: span_id,
             trace_id: trace_id,
-            trace_sampling_priority: sampling_priority
+            trace_sampling_priority: sampling_priority,
+            is_remote: true,
           )
         end
       end

--- a/lib/datadog/tracing/distributed/b3_single.rb
+++ b/lib/datadog/tracing/distributed/b3_single.rb
@@ -60,7 +60,7 @@ module Datadog
             span_id: span_id,
             trace_id: trace_id,
             trace_sampling_priority: sampling_priority,
-            is_remote: true,
+            trace_remote: true,
           )
         end
       end

--- a/lib/datadog/tracing/distributed/b3_single.rb
+++ b/lib/datadog/tracing/distributed/b3_single.rb
@@ -60,7 +60,7 @@ module Datadog
             span_id: span_id,
             trace_id: trace_id,
             trace_sampling_priority: sampling_priority,
-            trace_remote: true,
+            span_remote: true,
           )
         end
       end

--- a/lib/datadog/tracing/distributed/datadog.rb
+++ b/lib/datadog/tracing/distributed/datadog.rb
@@ -79,6 +79,7 @@ module Datadog
             trace_origin: origin,
             trace_sampling_priority: sampling_priority,
             trace_distributed_tags: trace_distributed_tags,
+            is_remote: true,
           )
         end
 

--- a/lib/datadog/tracing/distributed/datadog.rb
+++ b/lib/datadog/tracing/distributed/datadog.rb
@@ -79,7 +79,7 @@ module Datadog
             trace_origin: origin,
             trace_sampling_priority: sampling_priority,
             trace_distributed_tags: trace_distributed_tags,
-            trace_remote: true,
+            span_remote: true,
           )
         end
 

--- a/lib/datadog/tracing/distributed/datadog.rb
+++ b/lib/datadog/tracing/distributed/datadog.rb
@@ -79,7 +79,7 @@ module Datadog
             trace_origin: origin,
             trace_sampling_priority: sampling_priority,
             trace_distributed_tags: trace_distributed_tags,
-            is_remote: true,
+            trace_remote: true,
           )
         end
 

--- a/lib/datadog/tracing/distributed/trace_context.rb
+++ b/lib/datadog/tracing/distributed/trace_context.rb
@@ -63,7 +63,7 @@ module Datadog
             trace_flags: trace_flags,
             trace_state: tracestate,
             trace_state_unknown_fields: unknown_fields,
-            is_remote: true,
+            trace_remote: true,
           )
         end
 

--- a/lib/datadog/tracing/distributed/trace_context.rb
+++ b/lib/datadog/tracing/distributed/trace_context.rb
@@ -63,6 +63,7 @@ module Datadog
             trace_flags: trace_flags,
             trace_state: tracestate,
             trace_state_unknown_fields: unknown_fields,
+            is_remote: true,
           )
         end
 

--- a/lib/datadog/tracing/distributed/trace_context.rb
+++ b/lib/datadog/tracing/distributed/trace_context.rb
@@ -63,7 +63,7 @@ module Datadog
             trace_flags: trace_flags,
             trace_state: tracestate,
             trace_state_unknown_fields: unknown_fields,
-            trace_remote: true,
+            span_remote: true,
           )
         end
 

--- a/lib/datadog/tracing/trace_digest.rb
+++ b/lib/datadog/tracing/trace_digest.rb
@@ -52,7 +52,7 @@ module Datadog
       # @!attribute [r] trace_service
       #   The service of the currently active trace.
       #   @return [String]
-      # @!attribute [r] is_remote
+      # @!attribute [r] trace_remote
       #   Represents whether a TraceDigest was propagated from a remote parent or created locally.
       #   @see https://opentelemetry.io/docs/specs/otel/trace/api/#isremote
       #   @return [Boolean]
@@ -101,7 +101,7 @@ module Datadog
         :trace_flags,
         :trace_state,
         :trace_state_unknown_fields,
-        :is_remote
+        :trace_remote
 
       def initialize(
         span_id: nil,
@@ -123,7 +123,7 @@ module Datadog
         trace_flags: nil,
         trace_state: nil,
         trace_state_unknown_fields: nil,
-        is_remote: true
+        trace_remote: true
       )
         @span_id = span_id
         @span_name = span_name && span_name.dup.freeze
@@ -144,7 +144,7 @@ module Datadog
         @trace_flags = trace_flags
         @trace_state = trace_state && trace_state.dup.freeze
         @trace_state_unknown_fields = trace_state_unknown_fields && trace_state_unknown_fields.dup.freeze
-        @is_remote = is_remote
+        @trace_remote = trace_remote
         freeze
       end
 
@@ -175,7 +175,7 @@ module Datadog
             trace_flags: trace_flags,
             trace_state: trace_state,
             trace_state_unknown_fields: trace_state_unknown_fields,
-            is_remote: is_remote,
+            trace_remote: trace_remote,
           }.merge!(field_value_pairs)
         )
       end

--- a/lib/datadog/tracing/trace_digest.rb
+++ b/lib/datadog/tracing/trace_digest.rb
@@ -52,7 +52,7 @@ module Datadog
       # @!attribute [r] trace_service
       #   The service of the currently active trace.
       #   @return [String]
-      # @!attribute [r] trace_remote
+      # @!attribute [r] span_remote
       #   Represents whether a TraceDigest was propagated from a remote parent or created locally.
       #   @see https://opentelemetry.io/docs/specs/otel/trace/api/#isremote
       #   @return [Boolean]
@@ -101,7 +101,7 @@ module Datadog
         :trace_flags,
         :trace_state,
         :trace_state_unknown_fields,
-        :trace_remote
+        :span_remote
 
       def initialize(
         span_id: nil,
@@ -123,7 +123,7 @@ module Datadog
         trace_flags: nil,
         trace_state: nil,
         trace_state_unknown_fields: nil,
-        trace_remote: true
+        span_remote: true
       )
         @span_id = span_id
         @span_name = span_name && span_name.dup.freeze
@@ -144,7 +144,7 @@ module Datadog
         @trace_flags = trace_flags
         @trace_state = trace_state && trace_state.dup.freeze
         @trace_state_unknown_fields = trace_state_unknown_fields && trace_state_unknown_fields.dup.freeze
-        @trace_remote = trace_remote
+        @span_remote = span_remote
         freeze
       end
 
@@ -175,7 +175,7 @@ module Datadog
             trace_flags: trace_flags,
             trace_state: trace_state,
             trace_state_unknown_fields: trace_state_unknown_fields,
-            trace_remote: trace_remote,
+            span_remote: span_remote,
           }.merge!(field_value_pairs)
         )
       end

--- a/lib/datadog/tracing/trace_digest.rb
+++ b/lib/datadog/tracing/trace_digest.rb
@@ -4,6 +4,7 @@ module Datadog
   module Tracing
     # Trace digest that represents the important parts of an active trace.
     # Used to propagate context and continue traces across execution boundaries.
+    # TODO: Update all references from span to parent (ex: span_id -> parent_id) 
     # @public_api
     class TraceDigest
       # @!attribute [r] span_id

--- a/lib/datadog/tracing/trace_digest.rb
+++ b/lib/datadog/tracing/trace_digest.rb
@@ -52,6 +52,10 @@ module Datadog
       # @!attribute [r] trace_service
       #   The service of the currently active trace.
       #   @return [String]
+      # @!attribute [r] is_remote
+      #   Represents whether a TraceDigest was propagated from a remote parent or created locally.
+      #   @see https://opentelemetry.io/docs/specs/otel/trace/api/#isremote
+      #   @return [Boolean]
       # @!attribute [r] trace_distributed_id
       #   The trace id extracted from a distributed context, if different from `trace_id`.
       #
@@ -96,7 +100,8 @@ module Datadog
         :trace_distributed_id,
         :trace_flags,
         :trace_state,
-        :trace_state_unknown_fields
+        :trace_state_unknown_fields,
+        :is_remote
 
       def initialize(
         span_id: nil,
@@ -117,7 +122,8 @@ module Datadog
         trace_distributed_id: nil,
         trace_flags: nil,
         trace_state: nil,
-        trace_state_unknown_fields: nil
+        trace_state_unknown_fields: nil,
+        is_remote: true
       )
         @span_id = span_id
         @span_name = span_name && span_name.dup.freeze
@@ -138,7 +144,7 @@ module Datadog
         @trace_flags = trace_flags
         @trace_state = trace_state && trace_state.dup.freeze
         @trace_state_unknown_fields = trace_state_unknown_fields && trace_state_unknown_fields.dup.freeze
-
+        @is_remote = is_remote
         freeze
       end
 
@@ -169,6 +175,7 @@ module Datadog
             trace_flags: trace_flags,
             trace_state: trace_state,
             trace_state_unknown_fields: trace_state_unknown_fields,
+            is_remote: is_remote,
           }.merge!(field_value_pairs)
         )
       end

--- a/lib/datadog/tracing/trace_operation.rb
+++ b/lib/datadog/tracing/trace_operation.rb
@@ -299,6 +299,7 @@ module Datadog
           trace_service: service,
           trace_state: @trace_state,
           trace_state_unknown_fields: @trace_state_unknown_fields,
+          is_remote: false,
         ).freeze
       end
 

--- a/lib/datadog/tracing/trace_operation.rb
+++ b/lib/datadog/tracing/trace_operation.rb
@@ -302,7 +302,7 @@ module Datadog
           trace_service: service,
           trace_state: @trace_state,
           trace_state_unknown_fields: @trace_state_unknown_fields,
-          trace_remote: (@remote_parent && @active_span.nil?),
+          span_remote: (@remote_parent && @active_span.nil?),
         ).freeze
       end
 

--- a/lib/datadog/tracing/trace_operation.rb
+++ b/lib/datadog/tracing/trace_operation.rb
@@ -36,7 +36,7 @@ module Datadog
         :rule_sample_rate,
         :sample_rate,
         :sampling_priority,
-        :is_remote
+        :has_remote_parent
 
       attr_reader \
         :active_span_count,
@@ -74,14 +74,14 @@ module Datadog
         metrics: nil,
         trace_state: nil,
         trace_state_unknown_fields: nil,
-        is_remote: false
+        has_remote_parent: false
       )
         # Attributes
         @id = id || Tracing::Utils::TraceId.next_id
         @max_length = max_length || DEFAULT_MAX_LENGTH
         @parent_span_id = parent_span_id
         @sampled = sampled.nil? ? true : sampled
-        @is_remote = is_remote
+        @has_remote_parent = has_remote_parent
 
         # Tags
         @agent_sample_rate = agent_sample_rate
@@ -302,7 +302,7 @@ module Datadog
           trace_service: service,
           trace_state: @trace_state,
           trace_state_unknown_fields: @trace_state_unknown_fields,
-          is_remote: (@is_remote && @active_span.nil?),
+          is_remote: (@has_remote_parent && @active_span.nil?),
         ).freeze
       end
 
@@ -329,7 +329,7 @@ module Datadog
           trace_state_unknown_fields: (@trace_state_unknown_fields && @trace_state_unknown_fields.dup),
           tags: meta.dup,
           metrics: metrics.dup,
-          is_remote: @is_remote
+          has_remote_parent: @has_remote_parent
         )
       end
 

--- a/lib/datadog/tracing/trace_operation.rb
+++ b/lib/datadog/tracing/trace_operation.rb
@@ -36,7 +36,7 @@ module Datadog
         :rule_sample_rate,
         :sample_rate,
         :sampling_priority,
-        :has_remote_parent
+        :remote_parent
 
       attr_reader \
         :active_span_count,
@@ -74,14 +74,14 @@ module Datadog
         metrics: nil,
         trace_state: nil,
         trace_state_unknown_fields: nil,
-        has_remote_parent: false
+        remote_parent: false
       )
         # Attributes
         @id = id || Tracing::Utils::TraceId.next_id
         @max_length = max_length || DEFAULT_MAX_LENGTH
         @parent_span_id = parent_span_id
         @sampled = sampled.nil? ? true : sampled
-        @has_remote_parent = has_remote_parent
+        @remote_parent = remote_parent
 
         # Tags
         @agent_sample_rate = agent_sample_rate
@@ -302,7 +302,7 @@ module Datadog
           trace_service: service,
           trace_state: @trace_state,
           trace_state_unknown_fields: @trace_state_unknown_fields,
-          is_remote: (@has_remote_parent && @active_span.nil?),
+          trace_remote: (@remote_parent && @active_span.nil?),
         ).freeze
       end
 
@@ -329,7 +329,7 @@ module Datadog
           trace_state_unknown_fields: (@trace_state_unknown_fields && @trace_state_unknown_fields.dup),
           tags: meta.dup,
           metrics: metrics.dup,
-          has_remote_parent: @has_remote_parent
+          remote_parent: @remote_parent
         )
       end
 

--- a/lib/datadog/tracing/trace_operation.rb
+++ b/lib/datadog/tracing/trace_operation.rb
@@ -35,7 +35,8 @@ module Datadog
         :rate_limiter_rate,
         :rule_sample_rate,
         :sample_rate,
-        :sampling_priority
+        :sampling_priority,
+        :is_remote
 
       attr_reader \
         :active_span_count,
@@ -72,13 +73,15 @@ module Datadog
         tags: nil,
         metrics: nil,
         trace_state: nil,
-        trace_state_unknown_fields: nil
+        trace_state_unknown_fields: nil,
+        is_remote: nil
       )
         # Attributes
         @id = id || Tracing::Utils::TraceId.next_id
         @max_length = max_length || DEFAULT_MAX_LENGTH
         @parent_span_id = parent_span_id
         @sampled = sampled.nil? ? true : sampled
+        @is_remote = is_remote.nil? ? false : is_remote
 
         # Tags
         @agent_sample_rate = agent_sample_rate
@@ -299,7 +302,7 @@ module Datadog
           trace_service: service,
           trace_state: @trace_state,
           trace_state_unknown_fields: @trace_state_unknown_fields,
-          is_remote: false,
+          is_remote: (@is_remote && @active_span.nil?),
         ).freeze
       end
 
@@ -325,7 +328,8 @@ module Datadog
           trace_state: (@trace_state && @trace_state.dup),
           trace_state_unknown_fields: (@trace_state_unknown_fields && @trace_state_unknown_fields.dup),
           tags: meta.dup,
-          metrics: metrics.dup
+          metrics: metrics.dup,
+          is_remote: @is_remote
         )
       end
 

--- a/lib/datadog/tracing/trace_operation.rb
+++ b/lib/datadog/tracing/trace_operation.rb
@@ -74,14 +74,14 @@ module Datadog
         metrics: nil,
         trace_state: nil,
         trace_state_unknown_fields: nil,
-        is_remote: nil
+        is_remote: false
       )
         # Attributes
         @id = id || Tracing::Utils::TraceId.next_id
         @max_length = max_length || DEFAULT_MAX_LENGTH
         @parent_span_id = parent_span_id
         @sampled = sampled.nil? ? true : sampled
-        @is_remote = is_remote.nil? ? false : is_remote
+        @is_remote = is_remote
 
         # Tags
         @agent_sample_rate = agent_sample_rate

--- a/lib/datadog/tracing/tracer.rb
+++ b/lib/datadog/tracing/tracer.rb
@@ -325,7 +325,7 @@ module Datadog
             tags: digest.trace_distributed_tags,
             trace_state: digest.trace_state,
             trace_state_unknown_fields: digest.trace_state_unknown_fields,
-            remote_parent: digest.trace_remote,
+            remote_parent: digest.span_remote,
           )
         else
           TraceOperation.new(

--- a/lib/datadog/tracing/tracer.rb
+++ b/lib/datadog/tracing/tracer.rb
@@ -325,11 +325,13 @@ module Datadog
             tags: digest.trace_distributed_tags,
             trace_state: digest.trace_state,
             trace_state_unknown_fields: digest.trace_state_unknown_fields,
+            is_remote: digest.is_remote,
           )
         else
           TraceOperation.new(
             hostname: hostname,
             profiling_enabled: profiling_enabled,
+            is_remote: false,
           )
         end
       end

--- a/lib/datadog/tracing/tracer.rb
+++ b/lib/datadog/tracing/tracer.rb
@@ -325,13 +325,13 @@ module Datadog
             tags: digest.trace_distributed_tags,
             trace_state: digest.trace_state,
             trace_state_unknown_fields: digest.trace_state_unknown_fields,
-            is_remote: digest.is_remote,
+            has_remote_parent: digest.is_remote,
           )
         else
           TraceOperation.new(
             hostname: hostname,
             profiling_enabled: profiling_enabled,
-            is_remote: false,
+            has_remote_parent: false,
           )
         end
       end

--- a/lib/datadog/tracing/tracer.rb
+++ b/lib/datadog/tracing/tracer.rb
@@ -325,13 +325,13 @@ module Datadog
             tags: digest.trace_distributed_tags,
             trace_state: digest.trace_state,
             trace_state_unknown_fields: digest.trace_state_unknown_fields,
-            has_remote_parent: digest.is_remote,
+            remote_parent: digest.trace_remote,
           )
         else
           TraceOperation.new(
             hostname: hostname,
             profiling_enabled: profiling_enabled,
-            has_remote_parent: false,
+            remote_parent: false,
           )
         end
       end

--- a/sig/datadog/tracing/trace_digest.rbs
+++ b/sig/datadog/tracing/trace_digest.rbs
@@ -20,9 +20,9 @@ module Datadog
       attr_reader trace_flags: untyped
       attr_reader trace_state: untyped
       attr_reader trace_state_unknown_fields: untyped
-      attr_reader trace_remote: untyped
+      attr_reader span_remote: untyped
 
-      def initialize: (?span_id: untyped?, ?span_name: untyped?, ?span_resource: untyped?, ?span_service: untyped?, ?span_type: untyped?, ?trace_distributed_tags: untyped?, ?trace_hostname: untyped?, ?trace_id: untyped?, ?trace_name: untyped?, ?trace_origin: untyped?, ?trace_process_id: untyped?, ?trace_resource: untyped?, ?trace_runtime_id: untyped?, ?trace_sampling_priority: untyped?, ?trace_service: untyped?, ?trace_distributed_id: untyped?, ?trace_flags: untyped?, ?trace_state: untyped?, ?trace_state_unknown_fields: untyped?, ?trace_remote: untyped?) -> void
+      def initialize: (?span_id: untyped?, ?span_name: untyped?, ?span_resource: untyped?, ?span_service: untyped?, ?span_type: untyped?, ?trace_distributed_tags: untyped?, ?trace_hostname: untyped?, ?trace_id: untyped?, ?trace_name: untyped?, ?trace_origin: untyped?, ?trace_process_id: untyped?, ?trace_resource: untyped?, ?trace_runtime_id: untyped?, ?trace_sampling_priority: untyped?, ?trace_service: untyped?, ?trace_distributed_id: untyped?, ?trace_flags: untyped?, ?trace_state: untyped?, ?trace_state_unknown_fields: untyped?, ?span_remote: untyped?) -> void
     end
   end
 end

--- a/sig/datadog/tracing/trace_digest.rbs
+++ b/sig/datadog/tracing/trace_digest.rbs
@@ -20,8 +20,9 @@ module Datadog
       attr_reader trace_flags: untyped
       attr_reader trace_state: untyped
       attr_reader trace_state_unknown_fields: untyped
+      attr_reader is_remote: untyped
 
-      def initialize: (?span_id: untyped?, ?span_name: untyped?, ?span_resource: untyped?, ?span_service: untyped?, ?span_type: untyped?, ?trace_distributed_tags: untyped?, ?trace_hostname: untyped?, ?trace_id: untyped?, ?trace_name: untyped?, ?trace_origin: untyped?, ?trace_process_id: untyped?, ?trace_resource: untyped?, ?trace_runtime_id: untyped?, ?trace_sampling_priority: untyped?, ?trace_service: untyped?, ?trace_distributed_id: untyped?, ?trace_flags: untyped?, ?trace_state: untyped?, ?trace_state_unknown_fields: untyped?) -> void
+      def initialize: (?span_id: untyped?, ?span_name: untyped?, ?span_resource: untyped?, ?span_service: untyped?, ?span_type: untyped?, ?trace_distributed_tags: untyped?, ?trace_hostname: untyped?, ?trace_id: untyped?, ?trace_name: untyped?, ?trace_origin: untyped?, ?trace_process_id: untyped?, ?trace_resource: untyped?, ?trace_runtime_id: untyped?, ?trace_sampling_priority: untyped?, ?trace_service: untyped?, ?trace_distributed_id: untyped?, ?trace_flags: untyped?, ?trace_state: untyped?, ?trace_state_unknown_fields: untyped?, ?is_remote: untyped?) -> void
     end
   end
 end

--- a/sig/datadog/tracing/trace_digest.rbs
+++ b/sig/datadog/tracing/trace_digest.rbs
@@ -20,9 +20,9 @@ module Datadog
       attr_reader trace_flags: untyped
       attr_reader trace_state: untyped
       attr_reader trace_state_unknown_fields: untyped
-      attr_reader is_remote: untyped
+      attr_reader trace_remote: untyped
 
-      def initialize: (?span_id: untyped?, ?span_name: untyped?, ?span_resource: untyped?, ?span_service: untyped?, ?span_type: untyped?, ?trace_distributed_tags: untyped?, ?trace_hostname: untyped?, ?trace_id: untyped?, ?trace_name: untyped?, ?trace_origin: untyped?, ?trace_process_id: untyped?, ?trace_resource: untyped?, ?trace_runtime_id: untyped?, ?trace_sampling_priority: untyped?, ?trace_service: untyped?, ?trace_distributed_id: untyped?, ?trace_flags: untyped?, ?trace_state: untyped?, ?trace_state_unknown_fields: untyped?, ?is_remote: untyped?) -> void
+      def initialize: (?span_id: untyped?, ?span_name: untyped?, ?span_resource: untyped?, ?span_service: untyped?, ?span_type: untyped?, ?trace_distributed_tags: untyped?, ?trace_hostname: untyped?, ?trace_id: untyped?, ?trace_name: untyped?, ?trace_origin: untyped?, ?trace_process_id: untyped?, ?trace_resource: untyped?, ?trace_runtime_id: untyped?, ?trace_sampling_priority: untyped?, ?trace_service: untyped?, ?trace_distributed_id: untyped?, ?trace_flags: untyped?, ?trace_state: untyped?, ?trace_state_unknown_fields: untyped?, ?trace_remote: untyped?) -> void
     end
   end
 end

--- a/sig/datadog/tracing/trace_operation.rbs
+++ b/sig/datadog/tracing/trace_operation.rbs
@@ -11,6 +11,7 @@ module Datadog
       attr_accessor rate_limiter_rate: untyped
       attr_accessor rule_sample_rate: untyped
       attr_accessor sample_rate: untyped
+      attr_accessor is_remote: untyped
       attr_accessor sampling_priority: untyped
       attr_reader active_span_count: untyped
       attr_reader active_span: untyped
@@ -22,7 +23,7 @@ module Datadog
       attr_writer sampled: untyped
       attr_writer service: untyped
 
-      def initialize: (?agent_sample_rate: untyped?, ?events: untyped?, ?hostname: untyped?, ?id: untyped?, ?max_length: untyped, ?name: untyped?, ?origin: untyped?, ?parent_span_id: untyped?, ?rate_limiter_rate: untyped?, ?resource: untyped?, ?rule_sample_rate: untyped?, ?sample_rate: untyped?, ?sampled: untyped?, ?sampling_priority: untyped?, ?service: untyped?, ?tags: untyped?, ?metrics: untyped?) -> void
+      def initialize: (?agent_sample_rate: untyped?, ?events: untyped?, ?hostname: untyped?, ?id: untyped?, ?max_length: untyped, ?name: untyped?, ?origin: untyped?, ?parent_span_id: untyped?, ?rate_limiter_rate: untyped?, ?resource: untyped?, ?rule_sample_rate: untyped?, ?sample_rate: untyped?, ?sampled: untyped?, ?sampling_priority: untyped?, ?service: untyped?, ?tags: untyped?, ?metrics: untyped?, ?is_remote: untyped?) -> void
       def full?: () -> untyped
       def finished_span_count: () -> untyped
       def finished?: () -> untyped

--- a/sig/datadog/tracing/trace_operation.rbs
+++ b/sig/datadog/tracing/trace_operation.rbs
@@ -11,7 +11,7 @@ module Datadog
       attr_accessor rate_limiter_rate: untyped
       attr_accessor rule_sample_rate: untyped
       attr_accessor sample_rate: untyped
-      attr_accessor is_remote: untyped
+      attr_accessor has_remote_parent: untyped
       attr_accessor sampling_priority: untyped
       attr_reader active_span_count: untyped
       attr_reader active_span: untyped
@@ -23,7 +23,7 @@ module Datadog
       attr_writer sampled: untyped
       attr_writer service: untyped
 
-      def initialize: (?agent_sample_rate: untyped?, ?events: untyped?, ?hostname: untyped?, ?id: untyped?, ?max_length: untyped, ?name: untyped?, ?origin: untyped?, ?parent_span_id: untyped?, ?rate_limiter_rate: untyped?, ?resource: untyped?, ?rule_sample_rate: untyped?, ?sample_rate: untyped?, ?sampled: untyped?, ?sampling_priority: untyped?, ?service: untyped?, ?tags: untyped?, ?metrics: untyped?, ?is_remote: untyped?) -> void
+      def initialize: (?agent_sample_rate: untyped?, ?events: untyped?, ?hostname: untyped?, ?id: untyped?, ?max_length: untyped, ?name: untyped?, ?origin: untyped?, ?parent_span_id: untyped?, ?rate_limiter_rate: untyped?, ?resource: untyped?, ?rule_sample_rate: untyped?, ?sample_rate: untyped?, ?sampled: untyped?, ?sampling_priority: untyped?, ?service: untyped?, ?tags: untyped?, ?metrics: untyped?, ?has_remote_parent: untyped?) -> void
       def full?: () -> untyped
       def finished_span_count: () -> untyped
       def finished?: () -> untyped

--- a/sig/datadog/tracing/trace_operation.rbs
+++ b/sig/datadog/tracing/trace_operation.rbs
@@ -11,7 +11,7 @@ module Datadog
       attr_accessor rate_limiter_rate: untyped
       attr_accessor rule_sample_rate: untyped
       attr_accessor sample_rate: untyped
-      attr_accessor has_remote_parent: untyped
+      attr_accessor remote_parent: untyped
       attr_accessor sampling_priority: untyped
       attr_reader active_span_count: untyped
       attr_reader active_span: untyped
@@ -23,7 +23,7 @@ module Datadog
       attr_writer sampled: untyped
       attr_writer service: untyped
 
-      def initialize: (?agent_sample_rate: untyped?, ?events: untyped?, ?hostname: untyped?, ?id: untyped?, ?max_length: untyped, ?name: untyped?, ?origin: untyped?, ?parent_span_id: untyped?, ?rate_limiter_rate: untyped?, ?resource: untyped?, ?rule_sample_rate: untyped?, ?sample_rate: untyped?, ?sampled: untyped?, ?sampling_priority: untyped?, ?service: untyped?, ?tags: untyped?, ?metrics: untyped?, ?has_remote_parent: untyped?) -> void
+      def initialize: (?agent_sample_rate: untyped?, ?events: untyped?, ?hostname: untyped?, ?id: untyped?, ?max_length: untyped, ?name: untyped?, ?origin: untyped?, ?parent_span_id: untyped?, ?rate_limiter_rate: untyped?, ?resource: untyped?, ?rule_sample_rate: untyped?, ?sample_rate: untyped?, ?sampled: untyped?, ?sampling_priority: untyped?, ?service: untyped?, ?tags: untyped?, ?metrics: untyped?, ?remote_parent: untyped?) -> void
       def full?: () -> untyped
       def finished_span_count: () -> untyped
       def finished?: () -> untyped

--- a/spec/datadog/tracing/distributed/b3_multi_spec.rb
+++ b/spec/datadog/tracing/distributed/b3_multi_spec.rb
@@ -115,7 +115,7 @@ RSpec.shared_examples 'B3 Multi distributed format' do
       it { expect(digest.trace_id).to eq(10000) }
       it { expect(digest.trace_origin).to be nil }
       it { expect(digest.trace_sampling_priority).to be nil }
-      it { expect(digest.trace_remote).to be true }
+      it { expect(digest.span_remote).to be true }
 
       context 'with sampling priority' do
         let(:data) do

--- a/spec/datadog/tracing/distributed/b3_multi_spec.rb
+++ b/spec/datadog/tracing/distributed/b3_multi_spec.rb
@@ -115,6 +115,7 @@ RSpec.shared_examples 'B3 Multi distributed format' do
       it { expect(digest.trace_id).to eq(10000) }
       it { expect(digest.trace_origin).to be nil }
       it { expect(digest.trace_sampling_priority).to be nil }
+      it { expect(digest.is_remote).to be true }
 
       context 'with sampling priority' do
         let(:data) do

--- a/spec/datadog/tracing/distributed/b3_multi_spec.rb
+++ b/spec/datadog/tracing/distributed/b3_multi_spec.rb
@@ -115,7 +115,7 @@ RSpec.shared_examples 'B3 Multi distributed format' do
       it { expect(digest.trace_id).to eq(10000) }
       it { expect(digest.trace_origin).to be nil }
       it { expect(digest.trace_sampling_priority).to be nil }
-      it { expect(digest.is_remote).to be true }
+      it { expect(digest.trace_remote).to be true }
 
       context 'with sampling priority' do
         let(:data) do

--- a/spec/datadog/tracing/distributed/b3_single_spec.rb
+++ b/spec/datadog/tracing/distributed/b3_single_spec.rb
@@ -95,7 +95,7 @@ RSpec.shared_examples 'B3 Single distributed format' do
       it { expect(digest.span_id).to eq(0xfedcba) }
       it { expect(digest.trace_origin).to be nil }
       it { expect(digest.trace_sampling_priority).to be nil }
-      it { expect(digest.is_remote).to be true }
+      it { expect(digest.trace_remote).to be true }
 
       context 'with sampling priority' do
         let(:data) { { prepare_key[b3_single_header] => 'abcdef-fedcba-1' } }

--- a/spec/datadog/tracing/distributed/b3_single_spec.rb
+++ b/spec/datadog/tracing/distributed/b3_single_spec.rb
@@ -95,7 +95,7 @@ RSpec.shared_examples 'B3 Single distributed format' do
       it { expect(digest.span_id).to eq(0xfedcba) }
       it { expect(digest.trace_origin).to be nil }
       it { expect(digest.trace_sampling_priority).to be nil }
-      it { expect(digest.trace_remote).to be true }
+      it { expect(digest.span_remote).to be true }
 
       context 'with sampling priority' do
         let(:data) { { prepare_key[b3_single_header] => 'abcdef-fedcba-1' } }

--- a/spec/datadog/tracing/distributed/b3_single_spec.rb
+++ b/spec/datadog/tracing/distributed/b3_single_spec.rb
@@ -95,6 +95,7 @@ RSpec.shared_examples 'B3 Single distributed format' do
       it { expect(digest.span_id).to eq(0xfedcba) }
       it { expect(digest.trace_origin).to be nil }
       it { expect(digest.trace_sampling_priority).to be nil }
+      it { expect(digest.is_remote).to be true }
 
       context 'with sampling priority' do
         let(:data) { { prepare_key[b3_single_header] => 'abcdef-fedcba-1' } }

--- a/spec/datadog/tracing/distributed/datadog_spec.rb
+++ b/spec/datadog/tracing/distributed/datadog_spec.rb
@@ -265,7 +265,7 @@ RSpec.shared_examples 'Datadog distributed format' do
       it { expect(digest.trace_id).to eq(10000) }
       it { expect(digest.trace_origin).to be nil }
       it { expect(digest.trace_sampling_priority).to be nil }
-      it { expect(digest.is_remote).to be true }
+      it { expect(digest.trace_remote).to be true }
 
       context 'with sampling priority' do
         let(:data) do

--- a/spec/datadog/tracing/distributed/datadog_spec.rb
+++ b/spec/datadog/tracing/distributed/datadog_spec.rb
@@ -265,6 +265,7 @@ RSpec.shared_examples 'Datadog distributed format' do
       it { expect(digest.trace_id).to eq(10000) }
       it { expect(digest.trace_origin).to be nil }
       it { expect(digest.trace_sampling_priority).to be nil }
+      it { expect(digest.is_remote).to be true }
 
       context 'with sampling priority' do
         let(:data) do

--- a/spec/datadog/tracing/distributed/datadog_spec.rb
+++ b/spec/datadog/tracing/distributed/datadog_spec.rb
@@ -265,7 +265,7 @@ RSpec.shared_examples 'Datadog distributed format' do
       it { expect(digest.trace_id).to eq(10000) }
       it { expect(digest.trace_origin).to be nil }
       it { expect(digest.trace_sampling_priority).to be nil }
-      it { expect(digest.trace_remote).to be true }
+      it { expect(digest.span_remote).to be true }
 
       context 'with sampling priority' do
         let(:data) do

--- a/spec/datadog/tracing/distributed/propagation_spec.rb
+++ b/spec/datadog/tracing/distributed/propagation_spec.rb
@@ -164,6 +164,7 @@ RSpec.shared_examples 'Distributed tracing propagator' do
           expect(trace_digest.trace_id).to eq(123)
           expect(trace_digest.trace_origin).to be_nil
           expect(trace_digest.trace_sampling_priority).to be nil
+          expect(trace_digest.is_remote).to be true
         end
 
         context 'and sampling priority' do

--- a/spec/datadog/tracing/distributed/propagation_spec.rb
+++ b/spec/datadog/tracing/distributed/propagation_spec.rb
@@ -164,7 +164,7 @@ RSpec.shared_examples 'Distributed tracing propagator' do
           expect(trace_digest.trace_id).to eq(123)
           expect(trace_digest.trace_origin).to be_nil
           expect(trace_digest.trace_sampling_priority).to be nil
-          expect(trace_digest.trace_remote).to be true
+          expect(trace_digest.span_remote).to be true
         end
 
         context 'and sampling priority' do

--- a/spec/datadog/tracing/distributed/propagation_spec.rb
+++ b/spec/datadog/tracing/distributed/propagation_spec.rb
@@ -164,7 +164,7 @@ RSpec.shared_examples 'Distributed tracing propagator' do
           expect(trace_digest.trace_id).to eq(123)
           expect(trace_digest.trace_origin).to be_nil
           expect(trace_digest.trace_sampling_priority).to be nil
-          expect(trace_digest.is_remote).to be true
+          expect(trace_digest.trace_remote).to be true
         end
 
         context 'and sampling priority' do

--- a/spec/datadog/tracing/distributed/trace_context_spec.rb
+++ b/spec/datadog/tracing/distributed/trace_context_spec.rb
@@ -381,6 +381,7 @@ RSpec.shared_examples 'Trace Context distributed format' do
       it { expect(digest.span_id).to eq(0xBEE) }
       it { expect(digest.trace_origin).to be nil }
       it { expect(digest.trace_sampling_priority).to eq(0) }
+      it { expect(digest.is_remote).to be true }
 
       context 'and trace_id larger than 64 bits' do
         let(:trace_id) { 'ace00000000000000000000000c0ffee' }

--- a/spec/datadog/tracing/distributed/trace_context_spec.rb
+++ b/spec/datadog/tracing/distributed/trace_context_spec.rb
@@ -381,7 +381,7 @@ RSpec.shared_examples 'Trace Context distributed format' do
       it { expect(digest.span_id).to eq(0xBEE) }
       it { expect(digest.trace_origin).to be nil }
       it { expect(digest.trace_sampling_priority).to eq(0) }
-      it { expect(digest.trace_remote).to be true }
+      it { expect(digest.span_remote).to be true }
 
       context 'and trace_id larger than 64 bits' do
         let(:trace_id) { 'ace00000000000000000000000c0ffee' }

--- a/spec/datadog/tracing/distributed/trace_context_spec.rb
+++ b/spec/datadog/tracing/distributed/trace_context_spec.rb
@@ -381,7 +381,7 @@ RSpec.shared_examples 'Trace Context distributed format' do
       it { expect(digest.span_id).to eq(0xBEE) }
       it { expect(digest.trace_origin).to be nil }
       it { expect(digest.trace_sampling_priority).to eq(0) }
-      it { expect(digest.is_remote).to be true }
+      it { expect(digest.trace_remote).to be true }
 
       context 'and trace_id larger than 64 bits' do
         let(:trace_id) { 'ace00000000000000000000000c0ffee' }

--- a/spec/datadog/tracing/trace_operation_spec.rb
+++ b/spec/datadog/tracing/trace_operation_spec.rb
@@ -1825,10 +1825,9 @@ RSpec.describe Datadog::Tracing::TraceOperation do
               trace_process_id: Datadog::Core::Environment::Identity.pid,
               trace_resource: nil,
               trace_runtime_id: Datadog::Core::Environment::Identity.id,
-
               trace_sampling_priority: nil,
               trace_service: nil,
-              is_digest: false,
+              is_remote: false,
             )
           end
         end
@@ -2017,7 +2016,7 @@ RSpec.describe Datadog::Tracing::TraceOperation do
 
               trace_sampling_priority: nil,
               trace_service: 'foo',
-              is_remote: true
+              is_remote: false
             )
           end
         end
@@ -2060,7 +2059,7 @@ RSpec.describe Datadog::Tracing::TraceOperation do
 
             trace_sampling_priority: nil,
             trace_service: 'boo',
-            is_remote: true
+            is_remote: false,
           )
         end
 
@@ -2099,7 +2098,7 @@ RSpec.describe Datadog::Tracing::TraceOperation do
               sample_rate: sample_rate,
               sampled?: sampled,
               sampling_priority: sampling_priority,
-              service: be_a_copy_of(service)
+              service: be_a_copy_of(service),
               is_remote: true,
             )
           end

--- a/spec/datadog/tracing/trace_operation_spec.rb
+++ b/spec/datadog/tracing/trace_operation_spec.rb
@@ -37,7 +37,7 @@ RSpec.describe Datadog::Tracing::TraceOperation do
         metrics: metrics,
         trace_state: trace_state,
         trace_state_unknown_fields: trace_state_unknown_fields,
-        is_remote: is_remote,
+        has_remote_parent: has_remote_parent,
       }
     end
 
@@ -60,7 +60,7 @@ RSpec.describe Datadog::Tracing::TraceOperation do
     let(:trace_state_unknown_fields) { 'any;field;really' }
 
     let(:distributed_tags) { { '_dd.p.test' => 'value' } }
-    let(:is_remote) { true }
+    let(:has_remote_parent) { true }
   end
 
   shared_examples 'a span with default events' do
@@ -88,7 +88,7 @@ RSpec.describe Datadog::Tracing::TraceOperation do
           service: nil,
           trace_state: nil,
           trace_state_unknown_fields: nil,
-          is_remote: false,
+          has_remote_parent: false,
         )
       end
 
@@ -185,11 +185,11 @@ RSpec.describe Datadog::Tracing::TraceOperation do
         it { expect(trace_op.parent_span_id).to eq(parent_span_id) }
       end
 
-      context ':is_remote' do
-        subject(:options) { { is_remote: true } }
-        let(:is_remote) { true }
+      context ':has_remote_parent' do
+        subject(:options) { { has_remote_parent: true } }
+        let(:has_remote_parent) { true }
 
-        it { expect(trace_op.is_remote).to eq(is_remote) }
+        it { expect(trace_op.has_remote_parent).to eq(has_remote_parent) }
       end
 
       context ':rate_limiter_rate' do
@@ -1857,11 +1857,11 @@ RSpec.describe Datadog::Tracing::TraceOperation do
           end
         end
 
-        context 'and :is_remote is set to false' do
-          let(:options) { { is_remote: is_remote } }
-          let(:is_remote) { false }
+        context 'and :has_remote_parent is set to false' do
+          let(:options) { { has_remote_parent: has_remote_parent } }
+          let(:has_remote_parent) { false }
 
-          it { expect(digest.is_remote).to eq(is_remote) }
+          it { expect(digest.is_remote).to eq(false) }
         end
 
         context 'but :parent_span_id has been defined' do
@@ -2106,7 +2106,7 @@ RSpec.describe Datadog::Tracing::TraceOperation do
               sampled?: sampled,
               sampling_priority: sampling_priority,
               service: be_a_copy_of(service),
-              is_remote: true,
+              has_remote_parent: true,
             )
           end
 

--- a/spec/datadog/tracing/trace_operation_spec.rb
+++ b/spec/datadog/tracing/trace_operation_spec.rb
@@ -1857,6 +1857,13 @@ RSpec.describe Datadog::Tracing::TraceOperation do
           end
         end
 
+        context 'and :is_remote is set to false' do
+          let(:options) { { is_remote: is_remote } }
+          let(:is_remote) { false }
+
+          it { expect(digest.is_remote).to eq(is_remote) }
+        end
+
         context 'but :parent_span_id has been defined' do
           let(:options) { { parent_span_id: parent_span_id } }
           let(:parent_span_id) { Datadog::Tracing::Utils.next_id }

--- a/spec/datadog/tracing/trace_operation_spec.rb
+++ b/spec/datadog/tracing/trace_operation_spec.rb
@@ -37,7 +37,7 @@ RSpec.describe Datadog::Tracing::TraceOperation do
         metrics: metrics,
         trace_state: trace_state,
         trace_state_unknown_fields: trace_state_unknown_fields,
-        has_remote_parent: has_remote_parent,
+        remote_parent: remote_parent,
       }
     end
 
@@ -60,7 +60,7 @@ RSpec.describe Datadog::Tracing::TraceOperation do
     let(:trace_state_unknown_fields) { 'any;field;really' }
 
     let(:distributed_tags) { { '_dd.p.test' => 'value' } }
-    let(:has_remote_parent) { true }
+    let(:remote_parent) { true }
   end
 
   shared_examples 'a span with default events' do
@@ -88,7 +88,7 @@ RSpec.describe Datadog::Tracing::TraceOperation do
           service: nil,
           trace_state: nil,
           trace_state_unknown_fields: nil,
-          has_remote_parent: false,
+          remote_parent: false,
         )
       end
 
@@ -185,11 +185,11 @@ RSpec.describe Datadog::Tracing::TraceOperation do
         it { expect(trace_op.parent_span_id).to eq(parent_span_id) }
       end
 
-      context ':has_remote_parent' do
-        subject(:options) { { has_remote_parent: true } }
-        let(:has_remote_parent) { true }
+      context ':remote_parent' do
+        subject(:options) { { remote_parent: true } }
+        let(:remote_parent) { true }
 
-        it { expect(trace_op.has_remote_parent).to eq(has_remote_parent) }
+        it { expect(trace_op.remote_parent).to eq(remote_parent) }
       end
 
       context ':rate_limiter_rate' do
@@ -1827,7 +1827,7 @@ RSpec.describe Datadog::Tracing::TraceOperation do
               trace_runtime_id: Datadog::Core::Environment::Identity.id,
               trace_sampling_priority: nil,
               trace_service: nil,
-              is_remote: false,
+              trace_remote: false,
             )
           end
         end
@@ -1852,16 +1852,16 @@ RSpec.describe Datadog::Tracing::TraceOperation do
               trace_runtime_id: Datadog::Core::Environment::Identity.id,
               trace_sampling_priority: sampling_priority,
               trace_service: be_a_frozen_copy_of(service),
-              is_remote: true
+              trace_remote: true
             )
           end
         end
 
-        context 'and :has_remote_parent is set to false' do
-          let(:options) { { has_remote_parent: has_remote_parent } }
-          let(:has_remote_parent) { false }
+        context 'and :remote_parent is set to false' do
+          let(:options) { { remote_parent: remote_parent } }
+          let(:remote_parent) { false }
 
-          it { expect(digest.is_remote).to eq(false) }
+          it { expect(digest.trace_remote).to eq(false) }
         end
 
         context 'but :parent_span_id has been defined' do
@@ -1953,7 +1953,7 @@ RSpec.describe Datadog::Tracing::TraceOperation do
 
               trace_sampling_priority: nil,
               trace_service: nil,
-              is_remote: false
+              trace_remote: false
             )
           end
         end
@@ -1988,7 +1988,7 @@ RSpec.describe Datadog::Tracing::TraceOperation do
 
               trace_sampling_priority: nil,
               trace_service: 'foo',
-              is_remote: false
+              trace_remote: false
             )
           end
         end
@@ -2023,7 +2023,7 @@ RSpec.describe Datadog::Tracing::TraceOperation do
 
               trace_sampling_priority: nil,
               trace_service: 'foo',
-              is_remote: false
+              trace_remote: false
             )
           end
         end
@@ -2066,7 +2066,7 @@ RSpec.describe Datadog::Tracing::TraceOperation do
 
             trace_sampling_priority: nil,
             trace_service: 'boo',
-            is_remote: false,
+            trace_remote: false,
           )
         end
 
@@ -2106,7 +2106,7 @@ RSpec.describe Datadog::Tracing::TraceOperation do
               sampled?: sampled,
               sampling_priority: sampling_priority,
               service: be_a_copy_of(service),
-              has_remote_parent: true,
+              remote_parent: true,
             )
           end
 

--- a/spec/datadog/tracing/trace_operation_spec.rb
+++ b/spec/datadog/tracing/trace_operation_spec.rb
@@ -1827,7 +1827,7 @@ RSpec.describe Datadog::Tracing::TraceOperation do
               trace_runtime_id: Datadog::Core::Environment::Identity.id,
               trace_sampling_priority: nil,
               trace_service: nil,
-              trace_remote: false,
+              span_remote: false,
             )
           end
         end
@@ -1852,7 +1852,7 @@ RSpec.describe Datadog::Tracing::TraceOperation do
               trace_runtime_id: Datadog::Core::Environment::Identity.id,
               trace_sampling_priority: sampling_priority,
               trace_service: be_a_frozen_copy_of(service),
-              trace_remote: true
+              span_remote: true
             )
           end
         end
@@ -1861,7 +1861,7 @@ RSpec.describe Datadog::Tracing::TraceOperation do
           let(:options) { { remote_parent: remote_parent } }
           let(:remote_parent) { false }
 
-          it { expect(digest.trace_remote).to eq(false) }
+          it { expect(digest.span_remote).to eq(false) }
         end
 
         context 'but :parent_span_id has been defined' do
@@ -1953,7 +1953,7 @@ RSpec.describe Datadog::Tracing::TraceOperation do
 
               trace_sampling_priority: nil,
               trace_service: nil,
-              trace_remote: false
+              span_remote: false
             )
           end
         end
@@ -1988,7 +1988,7 @@ RSpec.describe Datadog::Tracing::TraceOperation do
 
               trace_sampling_priority: nil,
               trace_service: 'foo',
-              trace_remote: false
+              span_remote: false
             )
           end
         end
@@ -2023,7 +2023,7 @@ RSpec.describe Datadog::Tracing::TraceOperation do
 
               trace_sampling_priority: nil,
               trace_service: 'foo',
-              trace_remote: false
+              span_remote: false
             )
           end
         end
@@ -2066,7 +2066,7 @@ RSpec.describe Datadog::Tracing::TraceOperation do
 
             trace_sampling_priority: nil,
             trace_service: 'boo',
-            trace_remote: false,
+            span_remote: false,
           )
         end
 

--- a/spec/datadog/tracing/trace_operation_spec.rb
+++ b/spec/datadog/tracing/trace_operation_spec.rb
@@ -37,6 +37,7 @@ RSpec.describe Datadog::Tracing::TraceOperation do
         metrics: metrics,
         trace_state: trace_state,
         trace_state_unknown_fields: trace_state_unknown_fields,
+        is_remote: is_remote,
       }
     end
 
@@ -59,6 +60,7 @@ RSpec.describe Datadog::Tracing::TraceOperation do
     let(:trace_state_unknown_fields) { 'any;field;really' }
 
     let(:distributed_tags) { { '_dd.p.test' => 'value' } }
+    let(:is_remote) { true }
   end
 
   shared_examples 'a span with default events' do
@@ -86,6 +88,7 @@ RSpec.describe Datadog::Tracing::TraceOperation do
           service: nil,
           trace_state: nil,
           trace_state_unknown_fields: nil,
+          is_remote: false,
         )
       end
 
@@ -180,6 +183,13 @@ RSpec.describe Datadog::Tracing::TraceOperation do
         let(:parent_span_id) { Datadog::Tracing::Utils.next_id }
 
         it { expect(trace_op.parent_span_id).to eq(parent_span_id) }
+      end
+
+      context ':is_remote' do
+        subject(:options) { { is_remote: true } }
+        let(:is_remote) { true }
+
+        it { expect(trace_op.is_remote).to eq(is_remote) }
       end
 
       context ':rate_limiter_rate' do
@@ -1817,7 +1827,8 @@ RSpec.describe Datadog::Tracing::TraceOperation do
               trace_runtime_id: Datadog::Core::Environment::Identity.id,
 
               trace_sampling_priority: nil,
-              trace_service: nil
+              trace_service: nil,
+              is_digest: false,
             )
           end
         end
@@ -1841,7 +1852,8 @@ RSpec.describe Datadog::Tracing::TraceOperation do
               trace_resource: be_a_frozen_copy_of(resource),
               trace_runtime_id: Datadog::Core::Environment::Identity.id,
               trace_sampling_priority: sampling_priority,
-              trace_service: be_a_frozen_copy_of(service)
+              trace_service: be_a_frozen_copy_of(service),
+              is_remote: true
             )
           end
         end
@@ -1934,7 +1946,8 @@ RSpec.describe Datadog::Tracing::TraceOperation do
               trace_runtime_id: Datadog::Core::Environment::Identity.id,
 
               trace_sampling_priority: nil,
-              trace_service: nil
+              trace_service: nil,
+              is_remote: false
             )
           end
         end
@@ -1968,7 +1981,8 @@ RSpec.describe Datadog::Tracing::TraceOperation do
               trace_runtime_id: Datadog::Core::Environment::Identity.id,
 
               trace_sampling_priority: nil,
-              trace_service: 'foo'
+              trace_service: 'foo',
+              is_remote: false
             )
           end
         end
@@ -2002,7 +2016,8 @@ RSpec.describe Datadog::Tracing::TraceOperation do
               trace_runtime_id: Datadog::Core::Environment::Identity.id,
 
               trace_sampling_priority: nil,
-              trace_service: 'foo'
+              trace_service: 'foo',
+              is_remote: true
             )
           end
         end
@@ -2044,7 +2059,8 @@ RSpec.describe Datadog::Tracing::TraceOperation do
             trace_runtime_id: Datadog::Core::Environment::Identity.id,
 
             trace_sampling_priority: nil,
-            trace_service: 'boo'
+            trace_service: 'boo',
+            is_remote: true
           )
         end
 
@@ -2084,6 +2100,7 @@ RSpec.describe Datadog::Tracing::TraceOperation do
               sampled?: sampled,
               sampling_priority: sampling_priority,
               service: be_a_copy_of(service)
+              is_remote: true,
             )
           end
 

--- a/spec/datadog/tracing/tracer_spec.rb
+++ b/spec/datadog/tracing/tracer_spec.rb
@@ -850,8 +850,8 @@ RSpec.describe Datadog::Tracing::Tracer do
             trace_state: 'my-state',
             trace_state_unknown_fields: 'any;field',
           )
-          expect(digest.trace_remote).to be true
-          expect(trace.to_digest.trace_remote).to be false
+          expect(digest.span_remote).to be true
+          expect(trace.to_digest.span_remote).to be false
 
           expect(trace.send(:distributed_tags)).to eq('_dd.p.test' => 'value')
 

--- a/spec/datadog/tracing/tracer_spec.rb
+++ b/spec/datadog/tracing/tracer_spec.rb
@@ -851,7 +851,7 @@ RSpec.describe Datadog::Tracing::Tracer do
             trace_state_unknown_fields: 'any;field',
           )
           expect(digest.is_remote).to be true
-          expect(trace.to_digest.is_remote).to be false 
+          expect(trace.to_digest.is_remote).to be false
 
           expect(trace.send(:distributed_tags)).to eq('_dd.p.test' => 'value')
 

--- a/spec/datadog/tracing/tracer_spec.rb
+++ b/spec/datadog/tracing/tracer_spec.rb
@@ -850,6 +850,8 @@ RSpec.describe Datadog::Tracing::Tracer do
             trace_state: 'my-state',
             trace_state_unknown_fields: 'any;field',
           )
+          expect(digest.is_remote).to be true
+          expect(trace.to_digest.is_remote).to be false 
 
           expect(trace.send(:distributed_tags)).to eq('_dd.p.test' => 'value')
 

--- a/spec/datadog/tracing/tracer_spec.rb
+++ b/spec/datadog/tracing/tracer_spec.rb
@@ -850,8 +850,8 @@ RSpec.describe Datadog::Tracing::Tracer do
             trace_state: 'my-state',
             trace_state_unknown_fields: 'any;field',
           )
-          expect(digest.is_remote).to be true
-          expect(trace.to_digest.is_remote).to be false
+          expect(digest.trace_remote).to be true
+          expect(trace.to_digest.trace_remote).to be false
 
           expect(trace.send(:distributed_tags)).to eq('_dd.p.test' => 'value')
 


### PR DESCRIPTION
**What does this PR do?**

Adds a mechanism to track whether a TraceDigest represents a remote span or if it is local to a host. This change is analogous to a change made in NodeJS: https://github.com/DataDog/dd-trace-js/pull/4153.

`is_remote` or `trace_remote` is an opentelemetry concept and is defined here: https://opentelemetry.io/docs/specs/otel/trace/api/#isremote.

**Motivation:**

This new field will be used to propagate the last datadog parent id in w3c tracecontext headers. This change blocks: https://github.com/DataDog/dd-trace-rb/pull/3488 

**Additional Notes:**
<!-- Anything else we should know when reviewing? -->

**How to test the change?**
<!--
Describe here how the change can be validated.
You are strongly encouraged to provide automated tests for this PR (unit or integration).
If this change cannot be feasibly tested, please explain why,
unless the change does not modify code (e.g. only modifies docs, comments).
-->

**For Datadog employees:**
- [ ] If this PR touches code that signs or publishes builds or packages, or handles
credentials of any kind, I've requested a review from `@DataDog/security-design-and-guidance`.
- [ ] This PR doesn't touch any of that.

Unsure? Have a question? Request a review!
