### PR TITLE
[NO-TICKET] Replace `profiling.advanced.experimental_allocation_enabled` with `profiling.allocation_enabled` and remove experimental warning

### DIFF
--- a/lib/datadog/core/configuration/settings.rb
+++ b/lib/datadog/core/configuration/settings.rb
@@ -205,6 +205,22 @@ module Datadog
             option :transport
           end
 
+          # Can be used to enable/disable collection of allocation profiles.
+          #
+          # This feature is disabled by default
+          #
+          # @warn Due to bugs in Ruby we only recommend enabling this feature in
+          #       Ruby versions 2.x, 3.1.4+, 3.2.3+ and 3.3.0+
+          #       (more details in {Datadog::Profiling::Component.enable_allocation_profiling?})
+          #
+          # @default `DD_PROFILING_ALLOCATION_ENABLED` environment variable as a boolean, otherwise `false`
+          option :allocation_enabled do |o|
+            o.type :bool
+            o.deprecated_env 'DD_PROFILING_EXPERIMENTAL_ALLOCATION_ENABLED' # TODO: Remove this for dd-trace-rb 2.0
+            o.env 'DD_PROFILING_ALLOCATION_ENABLED'
+            o.default false
+          end
+
           # @public_api
           settings :advanced do
             # @deprecated No longer does anything, and will be removed on dd-trace-rb 2.0.
@@ -322,32 +338,32 @@ module Datadog
 
             # Can be used to enable/disable the Datadog::Profiling.allocation_count feature.
             #
-            # This feature is now controlled via {:experimental_allocation_enabled}
+            # @deprecated Use {:allocation_enabled} (outside of advanced section) instead.
             option :allocation_counting_enabled do |o|
               o.after_set do |_, _, precedence|
                 unless precedence == Datadog::Core::Configuration::Option::Precedence::DEFAULT
                   Datadog.logger.warn(
                     'The profiling.advanced.allocation_counting_enabled setting has been deprecated for removal and no ' \
                     'longer does anything. Please remove it from your Datadog.configure block. ' \
-                    'Allocation counting is now controlled by the `experimental_allocation_enabled` setting instead.'
+                    'Allocation counting is now controlled by the profiling.allocation_enabled setting instead.'
                   )
                 end
               end
             end
 
-            # Can be used to enable/disable collection of allocation profiles.
-            #
-            # This feature is alpha and disabled by default
-            #
-            # @warn This feature is not supported/safe in all Rubies. Details in {Datadog::Profiling::Component} but
-            #       in summary, this should be supported on Ruby 2.x, 3.1.4+, 3.2.3+ and 3.3.0+. Enabling it on
-            #       unsupported Rubies may result in unexpected behaviour, including crashes.
-            #
-            # @default `DD_PROFILING_EXPERIMENTAL_ALLOCATION_ENABLED` environment variable as a boolean, otherwise `false`
+            # @deprecated Use {:allocation_enabled} (outside of advanced section) instead.
             option :experimental_allocation_enabled do |o|
               o.type :bool
-              o.env 'DD_PROFILING_EXPERIMENTAL_ALLOCATION_ENABLED'
               o.default false
+              o.after_set do |_, _, precedence|
+                unless precedence == Datadog::Core::Configuration::Option::Precedence::DEFAULT
+                  Datadog.logger.warn(
+                    'The profiling.advanced.experimental_allocation_enabled setting has been deprecated for removal and ' \
+                    'no longer does anything. Please remove it from your Datadog.configure block. ' \
+                    'Allocation profiling is now controlled by the profiling.allocation_enabled setting instead.'
+                  )
+                end
+              end
             end
 
             # Can be used to enable/disable the collection of heap profiles.

--- a/lib/datadog/profiling/component.rb
+++ b/lib/datadog/profiling/component.rb
@@ -135,7 +135,7 @@ module Datadog
       end
 
       private_class_method def self.enable_allocation_profiling?(settings)
-        unless settings.profiling.advanced.experimental_allocation_enabled
+        unless settings.profiling.allocation_enabled
           # Allocation profiling disabled, short-circuit out
           return false
         end

--- a/lib/datadog/profiling/component.rb
+++ b/lib/datadog/profiling/component.rb
@@ -179,9 +179,7 @@ module Datadog
           )
         end
 
-        Datadog.logger.warn(
-          'Enabled experimental allocation profiling. This is experimental, not recommended, and will increase overhead!'
-        )
+        Datadog.logger.debug('Enabled allocation profiling')
 
         true
       end

--- a/spec/datadog/core/configuration/settings_spec.rb
+++ b/spec/datadog/core/configuration/settings_spec.rb
@@ -342,6 +342,65 @@ RSpec.describe Datadog::Core::Configuration::Settings do
       end
     end
 
+    describe '#allocation_enabled' do
+      subject(:allocation_enabled) { settings.profiling.allocation_enabled }
+
+      context 'when DD_PROFILING_EXPERIMENTAL_ALLOCATION_ENABLED' do
+        around do |example|
+          ClimateControl.modify('DD_PROFILING_EXPERIMENTAL_ALLOCATION_ENABLED' => environment) do
+            example.run
+          end
+        end
+
+        context 'is not defined' do
+          let(:environment) { nil }
+
+          it { is_expected.to be false }
+        end
+
+        [true, false].each do |value|
+          context "is defined as #{value}" do
+            let(:environment) { value.to_s }
+
+            before { expect(Datadog::Core).to receive(:log_deprecation) }
+
+            it { is_expected.to be value }
+          end
+        end
+      end
+
+      context 'when DD_PROFILING_ALLOCATION_ENABLED' do
+        around do |example|
+          ClimateControl.modify('DD_PROFILING_ALLOCATION_ENABLED' => environment) do
+            example.run
+          end
+        end
+
+        context 'is not defined' do
+          let(:environment) { nil }
+
+          it { is_expected.to be false }
+        end
+
+        [true, false].each do |value|
+          context "is defined as #{value}" do
+            let(:environment) { value.to_s }
+
+            it { is_expected.to be value }
+          end
+        end
+      end
+    end
+
+    describe '#allocation_enabled=' do
+      it 'updates the #allocation_enabled setting' do
+        expect { settings.profiling.allocation_enabled = true }
+          .to change { settings.profiling.allocation_enabled }
+          .from(false)
+          .to(true)
+      end
+    end
+
     describe '#advanced' do
       describe '#max_events=' do
         it 'logs a warning informing customers this no longer does anything' do
@@ -505,38 +564,11 @@ RSpec.describe Datadog::Core::Configuration::Settings do
         end
       end
 
-      describe '#experimental_allocation_enabled' do
-        subject(:experimental_allocation_enabled) { settings.profiling.advanced.experimental_allocation_enabled }
-
-        context 'when DD_PROFILING_EXPERIMENTAL_ALLOCATION_ENABLED' do
-          around do |example|
-            ClimateControl.modify('DD_PROFILING_EXPERIMENTAL_ALLOCATION_ENABLED' => environment) do
-              example.run
-            end
-          end
-
-          context 'is not defined' do
-            let(:environment) { nil }
-
-            it { is_expected.to be false }
-          end
-
-          [true, false].each do |value|
-            context "is defined as #{value}" do
-              let(:environment) { value.to_s }
-
-              it { is_expected.to be value }
-            end
-          end
-        end
-      end
-
       describe '#experimental_allocation_enabled=' do
-        it 'updates the #experimental_allocation_enabled setting' do
-          expect { settings.profiling.advanced.experimental_allocation_enabled = true }
-            .to change { settings.profiling.advanced.experimental_allocation_enabled }
-            .from(false)
-            .to(true)
+        it 'logs a warning informing customers this no longer does anything' do
+          expect(Datadog.logger).to receive(:warn).with(/no longer does anything/)
+
+          settings.profiling.advanced.experimental_allocation_enabled = true
         end
       end
 

--- a/spec/datadog/profiling/collectors/info_spec.rb
+++ b/spec/datadog/profiling/collectors/info_spec.rb
@@ -44,7 +44,6 @@ RSpec.describe Datadog::Profiling::Collectors::Info do
       expect(info[:profiler][:settings][:advanced]).to match(
         a_hash_including(
           max_frames: 600,
-          experimental_allocation_enabled: false,
           experimental_heap_enabled: true,
         )
       )

--- a/spec/datadog/profiling/component_spec.rb
+++ b/spec/datadog/profiling/component_spec.rb
@@ -138,7 +138,7 @@ RSpec.describe Datadog::Profiling::Component do
           context 'on Ruby 2.x' do
             let(:testing_version) { '2.3.0 ' }
 
-            it 'initializes CpuAndWallTimeWorker and StackRecorder with allocation sampling support and warns' do
+            it 'initializes CpuAndWallTimeWorker and StackRecorder with allocation sampling support' do
               expect(Datadog::Profiling::Collectors::CpuAndWallTimeWorker).to receive(:new).with hash_including(
                 allocation_profiling_enabled: true,
               )
@@ -146,8 +146,8 @@ RSpec.describe Datadog::Profiling::Component do
                 .with(hash_including(alloc_samples_enabled: true))
                 .and_call_original
 
-              expect(Datadog.logger).to receive(:warn).with(/experimental allocation profiling/)
-              expect(Datadog.logger).to_not receive(:warn).with(/Ractor/)
+              expect(Datadog.logger).to receive(:debug).with(/Enabled allocation profiling/)
+              expect(Datadog.logger).to_not receive(:warn)
 
               build_profiler_component
             end
@@ -167,7 +167,6 @@ RSpec.describe Datadog::Profiling::Component do
 
                 expect(Datadog.logger).to receive(:warn).with(/forcibly disabled/)
                 expect(Datadog.logger).to_not receive(:warn).with(/Ractor/)
-                expect(Datadog.logger).to_not receive(:warn).with(/experimental allocation profiling/)
 
                 build_profiler_component
               end
@@ -187,7 +186,7 @@ RSpec.describe Datadog::Profiling::Component do
                   .and_call_original
 
                 expect(Datadog.logger).to receive(:warn).with(/Ractors.+crashes/)
-                expect(Datadog.logger).to receive(:warn).with(/experimental allocation profiling/)
+                expect(Datadog.logger).to receive(:debug).with(/Enabled allocation profiling/)
 
                 build_profiler_component
               end
@@ -206,7 +205,7 @@ RSpec.describe Datadog::Profiling::Component do
                   .and_call_original
 
                 expect(Datadog.logger).to receive(:warn).with(/Ractors.+stopping/)
-                expect(Datadog.logger).to receive(:warn).with(/experimental allocation profiling/)
+                expect(Datadog.logger).to receive(:debug).with(/Enabled allocation profiling/)
 
                 build_profiler_component
               end
@@ -275,7 +274,7 @@ RSpec.describe Datadog::Profiling::Component do
                 .and_call_original
 
               expect(Datadog.logger).to receive(:warn).with(/Ractors.+stopping/)
-              expect(Datadog.logger).to receive(:warn).with(/experimental allocation profiling/)
+              expect(Datadog.logger).to receive(:debug).with(/Enabled allocation profiling/)
               expect(Datadog.logger).to receive(:warn).with(/experimental heap profiling/)
               expect(Datadog.logger).to receive(:warn).with(/experimental heap size profiling/)
 
@@ -292,7 +291,7 @@ RSpec.describe Datadog::Profiling::Component do
                   .with(hash_including(heap_samples_enabled: true, heap_size_enabled: false))
                   .and_call_original
 
-                expect(Datadog.logger).to receive(:warn).with(/experimental allocation profiling/)
+                expect(Datadog.logger).to receive(:debug).with(/Enabled allocation profiling/)
                 expect(Datadog.logger).to receive(:warn).with(/experimental heap profiling/)
                 expect(Datadog.logger).not_to receive(:warn).with(/experimental heap size profiling/)
 
@@ -308,7 +307,7 @@ RSpec.describe Datadog::Profiling::Component do
                   .with(hash_including(heap_samples_enabled: true))
                   .and_call_original
 
-                expect(Datadog.logger).to receive(:warn).with(/experimental allocation profiling/)
+                expect(Datadog.logger).to receive(:debug).with(/Enabled allocation profiling/)
                 expect(Datadog.logger).to receive(:warn).with(/experimental heap profiling/)
                 expect(Datadog.logger).to receive(:warn).with(/experimental heap size profiling/)
                 expect(Datadog.logger).to receive(:debug).with(/forced object recycling.+upgrading to Ruby >= 3.1/)

--- a/spec/datadog/profiling/component_spec.rb
+++ b/spec/datadog/profiling/component_spec.rb
@@ -131,7 +131,7 @@ RSpec.describe Datadog::Profiling::Component do
 
         context 'when allocation profiling is enabled' do
           before do
-            settings.profiling.advanced.experimental_allocation_enabled = true
+            settings.profiling.allocation_enabled = true
             stub_const('RUBY_VERSION', testing_version)
           end
 
@@ -216,7 +216,7 @@ RSpec.describe Datadog::Profiling::Component do
 
         context 'when allocation profiling is disabled' do
           before do
-            settings.profiling.advanced.experimental_allocation_enabled = false
+            settings.profiling.allocation_enabled = false
           end
 
           it 'initializes CpuAndWallTimeWorker and StackRecorder without allocation sampling support' do
@@ -256,7 +256,7 @@ RSpec.describe Datadog::Profiling::Component do
 
           context 'and allocation profiling disabled' do
             before do
-              settings.profiling.advanced.experimental_allocation_enabled = false
+              settings.profiling.allocation_enabled = false
             end
 
             it 'raises an ArgumentError during component initialization' do
@@ -266,7 +266,7 @@ RSpec.describe Datadog::Profiling::Component do
 
           context 'and allocation profiling enabled and supported' do
             before do
-              settings.profiling.advanced.experimental_allocation_enabled = true
+              settings.profiling.allocation_enabled = true
             end
 
             it 'initializes StackRecorder with heap sampling support and warns' do


### PR DESCRIPTION
**What does this PR do?**

In the next dd-trace-rb release, allocation profiling is no longer experimental. To reflect this, this PR includes two changes:

* It replaces the `profiling.advanced.experimental_allocation_enabled` with the new `profiling.allocation_enabled` option
* It turns the previous warning when turning on allocation profiling into a debug log message

**Motivation:**

Update code to match non-experimental status of feature.


**Additional Notes:**

I've decided to move the new setting outside the `advanced` configuration group, as enabling allocation profiling is not considered an "advanced" option.

To allow for smooth upgrades, I've left `profiling.advanced.experimental_allocation_enabled` in place with a deprecation warning, but unfortunately I was not able to find a nice way to automatically set the new `profiling.allocation_enabled` when the old one was set.

This means that users that had previously-enabled allocation profiling via code will need to update their configuration after upgrading, otherwise they won't get allocation profiling.

On the bright side, I was still able to support the old environment variable, so any customers that enabled the feature previously using that path will still get allocation profiling, plus a deprecation warning suggesting moving to the new environment variable.

**How to test the change?**

Change includes test coverage.

**For Datadog employees:**
- [ ] If this PR touches code that signs or publishes builds or packages, or handles
credentials of any kind, I've requested a review from `@DataDog/security-design-and-guidance`.
- [x] This PR doesn't touch any of that.