### PR TITLE
[NO-TICKET] Fix nightly test build deploys

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -73,7 +73,7 @@ build-gem:
   stage: package
   rules:
     - if: $CI_PIPELINE_SOURCE == "schedule"
-      when: never
+      when: on_success
     - if: $CI_COMMIT_TAG
       when: on_success
     - if: $CI_COMMIT_BRANCH == 'master'


### PR DESCRIPTION
**What does this PR do?**

This PR fixes the following error in our nightly deploys of test builds:

```
Unable to create pipeline
'install-dependencies-amd64: [2.7.8]' job needs 'build-gem' job, but 'build-gem' is not in any previous stage
'install-dependencies-amd64: [3.0.6]' job needs 'build-gem' job, but 'build-gem' is not in any previous stage
'install-dependencies-amd64: [3.1.4]' job needs 'build-gem' job, but 'build-gem' is not in any previous stage
'install-dependencies-amd64: [3.2.2]' job needs 'build-gem' job, but 'build-gem' is not in any previous stage
'install-dependencies-arm64: [2.7.8]' job needs 'build-gem' job, but 'build-gem' is not in any previous stage
'install-dependencies-arm64: [3.0.6]' job needs 'build-gem' job, but 'build-gem' is not in any previous stage
'install-dependencies-arm64: [3.1.4]' job needs 'build-gem' job, but 'build-gem' is not in any previous stage
'install-dependencies-arm64: [3.2.2]' job needs 'build-gem' job, but 'build-gem' is not in any previous stage
'package-amd64: [deb-x64]' job needs 'build-gem' job, but 'build-gem' is not in any previous stage
'package-amd64: [rpm-x64]' job needs 'build-gem' job, but 'build-gem' is not in any previous stage
'package-arm64: [deb-arm64]' job needs 'build-gem' job, but 'build-gem' is not in any previous stage
'package-arm64: [rpm-arm64]' job needs 'build-gem' job, but 'build-gem' is not in any previous stage
```

@alexjf figured out correctly that because we excluded the `build-gem` step entirely, this made GitLab CI really unhappy.

We discussed a bit if we should still build the gem or not in the nightly build, but ultimately decided to still let it build (at least as a simplification to move forward on this issue).

**Motivation:**

Without this our nighly deploys are failing.

**Additional Notes:**

N/A

**How to test the change?**

We'll test a schedule run from this branch to see if it works fine.

**For Datadog employees:**
- [ ] If this PR touches code that signs or publishes builds or packages, or handles
credentials of any kind, I've requested a review from `@DataDog/security-design-and-guidance`.
- [x] This PR doesn't touch any of that.