### PR TITLE
Fix ActiveRecord resolve function

### DIFF
--- a/lib/datadog/tracing/contrib/active_record/configuration/resolver.rb
+++ b/lib/datadog/tracing/contrib/active_record/configuration/resolver.rb
@@ -65,9 +65,14 @@ module Datadog
 
               config
             rescue => e
+              # Resolving a valid database configuration should not raise an exception,
+              # but if it does, it can be due to adding a broken pattern match prior to this call.
+              #
+              # `db_config` input may contain sensitive information such as passwords,
+              # hence provide a succinct summary for the error logging.
               Datadog.logger.error(
-                "Failed to resolve ActiveRecord configuration key #{db_config.inspect}. " \
-                "Cause: #{e.class.name} #{e.message} Source: #{Array(e.backtrace).first}"
+                'Failed to resolve ActiveRecord database configuration. '\
+                "Cause: #{e.class.name} Source: #{Array(e.backtrace).first}"
               )
 
               nil
@@ -85,9 +90,11 @@ module Datadog
               normalized
             rescue => e
               Datadog.logger.error(
-                "Failed to resolve ActiveRecord configuration key #{matcher.inspect}. " \
-                "Cause: #{e.class.name} #{e.message} Source: #{Array(e.backtrace).first}"
+                "Failed to resolve key #{matcher.inspect}. " \
+                "Cause: #{e.class.name} Source: #{Array(e.backtrace).first}"
               )
+
+              nil
             end
 
             #

--- a/lib/datadog/tracing/contrib/configurable.rb
+++ b/lib/datadog/tracing/contrib/configurable.rb
@@ -50,7 +50,7 @@ module Datadog
                      end
 
             # Apply the settings
-            config.configure(options, &block)
+            config.configure(options, &block) if config
             config
           end
 

--- a/spec/datadog/tracing/contrib/active_record/configuration/resolver_spec.rb
+++ b/spec/datadog/tracing/contrib/active_record/configuration/resolver_spec.rb
@@ -96,6 +96,16 @@ RSpec.describe Datadog::Tracing::Contrib::ActiveRecord::Configuration::Resolver 
         expect(resolver.configurations).to include(db_config => config)
       end
     end
+
+    context 'with an invalid string' do
+      let(:matcher) { 'bala boom!' }
+
+      it 'does not resolves' do
+        add
+
+        expect(resolver.configurations).to be_empty
+      end
+    end
   end
 
   describe '#resolve' do
@@ -295,6 +305,25 @@ RSpec.describe Datadog::Tracing::Contrib::ActiveRecord::Configuration::Resolver 
             is_expected.to be(second_matcher)
           end
         end
+      end
+    end
+
+    context 'with an invalid string' do
+      let(:matchers) do
+        []
+      end
+
+      let(:actual) do
+        'activerecord database configuration may contain password'
+      end
+
+      it do
+        expect(Datadog.logger).to receive(:error) do |message|
+          expect(message).to match(/failed to resolve/i)
+          expect(message).not_to match(/password/i)
+        end
+
+        is_expected.to be_nil
       end
     end
   end

--- a/spec/datadog/tracing/contrib/active_record/multi_db_spec.rb
+++ b/spec/datadog/tracing/contrib/active_record/multi_db_spec.rb
@@ -213,6 +213,24 @@ RSpec.describe 'ActiveRecord multi-database implementation' do
           expect(widget_span.service).to eq(widget_db_service_name)
         end
       end
+
+      context 'an invalid value' do
+        context 'for a typical server' do
+          before do
+            Datadog.configure do |c|
+              c.tracing.instrument :active_record, describes: 'some invalid string' do |gadget_db|
+                gadget_db.service_name = gadget_db_service_name
+              end
+            end
+          end
+
+          it 'fails to configure' do
+            count
+
+            expect(gadget_span.service).to eq(default_db_service_name)
+          end
+        end
+      end
     end
 
     context 'a Hash that describes a connection' do


### PR DESCRIPTION
closes #3522 

**What does this PR do?**

When an invalid string is provided for multiplexing configuration, although it logs an error, it still add the matcher `true` to the configuration. Later during resolving, an exception will be raised.

In this PR, the mitigation is to skip adding the matcher if the input is invalid, also reduce the log message.


