### PR TITLE
Fix lib injection artifact file permission

### DIFF
--- a/.gitlab/build-deb-rpm.sh
+++ b/.gitlab/build-deb-rpm.sh
@@ -5,7 +5,7 @@ echo -n "$RUBY_PACKAGE_VERSION" > auto_inject-ruby.version
 
 source common_build_functions.sh
 
-chmod a+r -R ../tmp/*
+chmod -R a+r,go-w ../tmp/*
 
 fpm_wrapper "datadog-apm-library-ruby" "$RUBY_PACKAGE_VERSION" \
  --input-type dir \

--- a/.gitlab/build-deb-rpm.sh
+++ b/.gitlab/build-deb-rpm.sh
@@ -5,6 +5,10 @@ echo -n "$RUBY_PACKAGE_VERSION" > auto_inject-ruby.version
 
 source common_build_functions.sh
 
+# The normal settings for /tmp are 1777, which ls shows as drwxrwxrwt. That is wide open.
+#
+# This gives all users read access, and removes write access for group and others,
+# to all files and directories in the tmp directory.
 chmod -R a+r,go-w ../tmp/*
 
 fpm_wrapper "datadog-apm-library-ruby" "$RUBY_PACKAGE_VERSION" \


### PR DESCRIPTION
**What does this PR do?**

The change moved the packaging into /tmp the file permissions there [default to being wide open](https://unix.stackexchange.com/questions/71622/what-are-correct-permissions-for-tmp-i-unintentionally-set-it-all-public-recu). This PR changes the permission to `drwxr-xr-x`