### PR TITLE
Added WAF vendors headers in traces tags

### DIFF
--- a/lib/datadog/appsec/contrib/rack/request_middleware.rb
+++ b/lib/datadog/appsec/contrib/rack/request_middleware.rb
@@ -23,18 +23,18 @@ module Datadog
           X-SigSci-RequestID
           X-SigSci-Tags
           Akamai-User-Risk
-      ].map(&:downcase).freeze
-        
+        ].map(&:downcase).freeze
+
         # .map { |s| [s.downcase, Datadog::Tracing::Contrib::Rack::Header.to_rack_header(s)] }.to_h
 
         # Topmost Rack middleware for AppSec
         # This should be inserted just below Datadog::Tracing::Contrib::Rack::TraceMiddleware
         class RequestMiddleware
-          @@rack_headers = {}
           def initialize(app, opt = {})
             @app = app
 
             @oneshot_tags_sent = false
+            @rack_headers = {}
           end
 
           # rubocop:disable Metrics/AbcSize,Metrics/PerceivedComplexity,Metrics/CyclomaticComplexity,Metrics/MethodLength
@@ -217,7 +217,7 @@ module Datadog
           end
 
           def to_rack_header(header)
-            @@rack_headers[header] ||= Datadog::Tracing::Contrib::Rack::Header::to_rack_header(header)
+            @rack_headers[header] ||= Datadog::Tracing::Contrib::Rack::Header.to_rack_header(header)
           end
         end
       end

--- a/lib/datadog/appsec/contrib/rack/request_middleware.rb
+++ b/lib/datadog/appsec/contrib/rack/request_middleware.rb
@@ -151,6 +151,11 @@ module Datadog
             span.set_tag('_dd.runtime_family', 'ruby')
             span.set_tag('_dd.appsec.waf.version', Datadog::AppSec::WAF::VERSION::BASE_STRING)
 
+            # Always add WAF vendors headers
+            WAF_VENDORS_HEADERS.each do |lowercase_header, rack_header|
+              span.set_tag("http.request.headers.#{lowercase_header}", env[rack_header]) if env[rack_header]
+            end
+
             if span && span.get_tag(Tracing::Metadata::Ext::HTTP::TAG_CLIENT_IP).nil?
               request_header_collection = Datadog::Tracing::Contrib::Rack::Header::RequestHeaderCollection.new(env)
 
@@ -160,11 +165,6 @@ module Datadog
                 headers: request_header_collection,
                 remote_ip: env['REMOTE_ADDR']
               )
-            end
-
-            # Always add WAF vendors headers
-            WAF_VENDORS_HEADERS.each do |lowercase_header, rack_header|
-              span.set_tag("http.request.headers.#{lowercase_header}", env[rack_header]) if env[rack_header]
             end
 
             if processor.diagnostics

--- a/lib/datadog/appsec/contrib/rack/request_middleware.rb
+++ b/lib/datadog/appsec/contrib/rack/request_middleware.rb
@@ -67,7 +67,7 @@ module Datadog
             gateway_request = Gateway::Request.new(env)
 
             add_appsec_tags(processor, scope)
-            add_http_headers_tags(scope, env)
+            add_request_tags(scope, env)
 
             request_return, request_response = catch(::Datadog::AppSec::Ext::INTERRUPT) do
               Instrumentation.gateway.push('rack.request', gateway_request) do
@@ -177,7 +177,7 @@ module Datadog
             end
           end
 
-          def add_http_headers_tags(scope, env)
+          def add_request_tags(scope, env)
             span = scope.service_entry_span
 
             return unless span

--- a/lib/datadog/appsec/contrib/rack/request_middleware.rb
+++ b/lib/datadog/appsec/contrib/rack/request_middleware.rb
@@ -25,8 +25,6 @@ module Datadog
           Akamai-User-Risk
         ].map(&:downcase).freeze
 
-        # .map { |s| [s.downcase, Datadog::Tracing::Contrib::Rack::Header.to_rack_header(s)] }.to_h
-
         # Topmost Rack middleware for AppSec
         # This should be inserted just below Datadog::Tracing::Contrib::Rack::TraceMiddleware
         class RequestMiddleware

--- a/spec/datadog/appsec/contrib/rack/integration_test_spec.rb
+++ b/spec/datadog/appsec/contrib/rack/integration_test_spec.rb
@@ -129,22 +129,6 @@ RSpec.describe 'Rack integration tests' do
     }
   end
 
-  let(:waf_vendors_headers) do
-    {
-      'x-amzn-trace-id' => 'Root=1-63441c4a-abcdef012345678912345678',
-      'cloudfront-viewer-ja3-fingerprint' => 'e7d705a3286e19ea42f587b344ee6865',
-      'cf-ray' => '230b030023ae2822-SJC',
-      'x-cloud-trace-context' => '105445aa7843bc8bf206b12000100000/1;o=1',
-      'x-appgw-trace-id' => 'ac882cd65a2712a0fe1289ec2bb6aee7',
-      'akamai-user-risk' => 'uuid=12345678-1234-1234-1234-123456789012;request-id=12345678;status=0;score=61;'\
-                            'risk=udfp:1234567890abcdefghijklmnopqrstuvwxyz1234/Hlunp=20057/H;trust=ugp:us;'\
-                            'general=di=1234567890abcdefghijklmnopqrstuvwxyz1234|do=Mac iOS 14|db=iOS Safari 14|aci=0;'\
-                            'allow=0;action=none',
-      'x-sigsci-requestid' => '55c24b96ca84c02201000001',
-      'x-sigsci-tags' => 'SITE-FLAGGED-IP,IMPOSTOR'
-    }
-  end
-
   before do
     unless remote_enabled
       Datadog.configure do |c|
@@ -629,16 +613,74 @@ RSpec.describe 'Rack integration tests' do
           it_behaves_like 'a trace with AppSec api security tags'
         end
 
-        context 'with WAF vendors headers' do
+        context 'with WAF vendor headers' do
+          let(:trace_tag_headers) do
+            {
+              'http.request.headers.x-amzn-trace-id' =>
+                'Root=1-63441c4a-abcdef012345678912345678',
+
+              'http.request.headers.cloudfront-viewer-ja3-fingerprint' =>
+                'e7d705a3286e19ea42f587b344ee6865',
+
+              'http.request.headers.cf-ray' =>
+                '230b030023ae2822-SJC',
+
+              'http.request.headers.x-cloud-trace-context' =>
+                '105445aa7843bc8bf206b12000100000/1;o=1',
+
+              'http.request.headers.x-appgw-trace-id' =>
+                'ac882cd65a2712a0fe1289ec2bb6aee7',
+
+              'http.request.headers.akamai-user-risk' =>
+                'uuid=12345678-1234-1234-1234-123456789012;request-id=12345678;status=0;score=61;'\
+                'risk=udfp:1234567890abcdefghijklmnopqrstuvwxyz1234/Hlunp=20057/H;trust=ugp:us;'\
+                'general=di=1234567890abcdefghijklmnopqrstuvwxyz1234|do=Mac iOS 14|db=iOS Safari 14|aci=0;'\
+                'allow=0;action=none',
+
+              'http.request.headers.x-sigsci-requestid' =>
+                '55c24b96ca84c02201000001',
+
+              'http.request.headers.x-sigsci-tags' =>
+                'SITE-FLAGGED-IP,IMPOSTOR'
+            }
+          end
+
           let(:headers) do
-            waf_vendors_headers.map { |h, v| [Datadog::Tracing::Contrib::Rack::Header.to_rack_header(h), v] }.to_h
+            {
+              'HTTP_X_AMZN_TRACE_ID' =>
+                'Root=1-63441c4a-abcdef012345678912345678',
+
+              'HTTP_CLOUDFRONT_VIEWER_JA3_FINGERPRINT' =>
+                'e7d705a3286e19ea42f587b344ee6865',
+
+              'HTTP_CF_RAY' =>
+                '230b030023ae2822-SJC',
+
+              'HTTP_X_CLOUD_TRACE_CONTEXT' =>
+                '105445aa7843bc8bf206b12000100000/1;o=1',
+
+              'HTTP_X_APPGW_TRACE_ID' =>
+                'ac882cd65a2712a0fe1289ec2bb6aee7',
+
+              'HTTP_AKAMAI_USER_RISK' =>
+                'uuid=12345678-1234-1234-1234-123456789012;request-id=12345678;status=0;score=61;'\
+                'risk=udfp:1234567890abcdefghijklmnopqrstuvwxyz1234/Hlunp=20057/H;trust=ugp:us;'\
+                'general=di=1234567890abcdefghijklmnopqrstuvwxyz1234|do=Mac iOS 14|db=iOS Safari 14|aci=0;'\
+                'allow=0;action=none',
+
+              'HTTP_X_SIGSCI_REQUESTID' =>
+                '55c24b96ca84c02201000001',
+
+              'HTTP_X_SIGSCI_TAGS' =>
+                'SITE-FLAGGED-IP,IMPOSTOR'
+            }
           end
 
           it { is_expected.to be_ok }
 
           it do
-            waf_vendors_headers.each do |header, value|
-              expect(span.get_tag("http.request.headers.#{header}")).to eq(value)
+            trace_tag_headers.each do |header, value|
+              expect(span.get_tag(header)).to eq(value)
             end
           end
 


### PR DESCRIPTION
<!--
Check out the
https://github.com/DataDog/dd-trace-rb/blob/master/docs/DevelopmentGuide.md
for guidance on how to set up your development environment,
run the test suite, write new integrations, and more.
-->

**What does this PR do?**
Add WAF vendors headers in traces tags according to this [RFC](https://docs.google.com/document/d/1xf-s6PtSr6heZxmO_QLUtcFzY_X_rT94lRXNq6-Ghws)

**Motivation:**
This will enable the ASM Respond team to parse the value of these headers and check that they are in the correct format

**Additional Notes:**
I used a hash to access traces-formatted headers and rack-formatted headers at the same time, and this hash is created from a list of string, corresponding to the HTTP-formatted header. Maybe these operations can add overhead time, and manually creating the hash would be faster

**How to test the change?**
<!--
Describe here how the change can be validated.
You are strongly encouraged to provide automated tests for this PR (unit or integration).
If this change cannot be feasibly tested, please explain why,
unless the change does not modify code (e.g. only modifies docs, comments).
-->
1. Use Rspec (`-e 'with WAF vendor headers'`)
2. Use [system-tests](https://github.com/DataDog/system-tests)
	- Enable Test_ExternalWafRequestsIdentification in ruby manifest
	- `run.sh tests/appsec/test_traces.py::Test_ExternalWafRequestsIdentification::test_external_wafs_header_collection`
	- Check on datad0g staging that the trace contains WAF headers tags

**For Datadog employees:**
- [ ] If this PR touches code that signs or publishes builds or packages, or handles
credentials of any kind, I've requested a review from `@DataDog/security-design-and-guidance`.
- [x] This PR doesn't touch any of that.

**JIRA**
- [APPSEC-52081](https://datadoghq.atlassian.net/browse/APPSEC-52081)
- [APPSEC-52097](https://datadoghq.atlassian.net/browse/APPSEC-52097)


[APPSEC-52081]: https://datadoghq.atlassian.net/browse/APPSEC-52081?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ