### PR TITLE
[NO-TICKET] Add validation for gem file permissions

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -353,7 +353,7 @@ namespace :spec do
   RSpec::Core::RakeTask.new(:main) do |t, args|
     t.pattern = 'spec/**/*_spec.rb'
     t.exclude_pattern = 'spec/**/{contrib,benchmark,redis,opentracer,auto_instrument,opentelemetry,profiling}/**/*_spec.rb,'\
-                        ' spec/**/{auto_instrument,opentelemetry}_spec.rb'
+                        ' spec/**/{auto_instrument,opentelemetry}_spec.rb, spec/ddtrace/gem_packaging_spec.rb'
     t.rspec_opts = args.to_a.join(' ')
   end
 

--- a/spec/ddtrace/gem_packaging_spec.rb
+++ b/spec/ddtrace/gem_packaging_spec.rb
@@ -1,0 +1,30 @@
+require 'rubygems'
+require 'rubygems/package'
+require 'rubygems/package/tar_reader'
+
+RSpec.describe 'gem release process (after packaging)' do
+  # TODO: This will need to be updated for the 2.0 branch
+  let(:gem_name) { 'ddtrace' }
+  let(:gem_version) { DDTrace::VERSION::STRING }
+  let(:packaged_gem_file) { "pkg/#{gem_name}-#{gem_version}.gem" }
+  let(:executable_permissions) { ['bin/ddprofrb', 'bin/ddtracerb'] }
+
+  it 'sets the right permissions on the gem files' do
+    Gem::Package::TarReader.new(File.open(packaged_gem_file)) do |tar|
+      data = tar.find { |entry| entry.header.name == 'data.tar.gz' }
+
+      Gem::Package::TarReader.new(Zlib::GzipReader.new(StringIO.new(data.read))) do |data_tar|
+        data_tar.each do |entry|
+          filename = entry.header.name
+          octal_permissions = entry.header.mode.to_s(8)[-3..-1]
+
+          expected_permissions = executable_permissions.include?(filename) ? '755' : '644'
+
+          expect(octal_permissions).to eq(expected_permissions),
+            "Unexpected permissions for #{filename} inside #{packaged_gem_file} (got #{octal_permissions}, " \
+            "expected #{expected_permissions})"
+        end
+      end
+    end
+  end
+end

--- a/tasks/release_gem.rake
+++ b/tasks/release_gem.rake
@@ -1,9 +1,22 @@
 Rake::Task["build"].enhance(["build:pre_check"])
+Rake::Task["build"].enhance do
+  # This syntax makes this task run after build -- see https://dev.to/molly/rake-task-enhance-method-explained-3bo0
+  Rake::Task["build:after_check"].execute
+end
 
 desc 'Checks executed before gem is built'
 task :'build:pre_check' do
   require 'rspec'
+  RSpec.world.reset # If any other tests ran before, flushes them
   ret = RSpec::Core::Runner.run(['spec/ddtrace/release_gem_spec.rb'])
+  raise "Release tests failed! See error output above." if ret != 0
+end
+
+desc 'Checks executed after gem is built'
+task :'build:after_check' do
+  require 'rspec'
+  RSpec.world.reset # If any other tests ran before, flushes them
+  ret = RSpec::Core::Runner.run(['spec/ddtrace/gem_packaging_spec.rb'])
   raise "Release tests failed! See error output above." if ret != 0
 end
 


### PR DESCRIPTION
**What does this PR do?**

This PR adds validation so we catch the issue from #3529 before the incorrect packages are published on rubygems.org.

Specifically, it checks that every file in packaged `.gem` file has the expected permissions.

**Motivation:**

Avoid #3529 happening again.

**Additional Notes:**

N/A

**How to test the change?**

You can run `bundle exec rake build` to trigger this validation. Try setting incorrect permissions on one of the files and running, and you should see the validation failing.

**For Datadog employees:**
- [ ] If this PR touches code that signs or publishes builds or packages, or handles
credentials of any kind, I've requested a review from `@DataDog/security-design-and-guidance`.
- [x] This PR doesn't touch any of that.