### PR TITLE
k8s-lib-injection: Generate latest_snapshot lib init image

### DIFF
--- a/.github/workflows/lib-injection.yml
+++ b/.github/workflows/lib-injection.yml
@@ -15,6 +15,15 @@ jobs:
         uses: docker/setup-buildx-action@v2
       - name: Login to Docker
         run: docker login -u publisher -p ${{ secrets.GITHUB_TOKEN }} ghcr.io
+      - name: Docker latest snapshot build
+        #if: github.ref == 'refs/heads/master'
+        uses: docker/build-push-action@v3
+        with:
+          push: true
+          tags: ghcr.io/datadog/dd-trace-rb/dd-lib-ruby-init:latest_snapshot
+          platforms: 'linux/amd64,linux/arm64/v8'
+          build-args: DDTRACE_RUBY_SHA=${{ github.sha }}
+          context: ./lib-injection
       - name: Docker Build
         uses: docker/build-push-action@v3
         with:

--- a/.github/workflows/lib-injection.yml
+++ b/.github/workflows/lib-injection.yml
@@ -16,7 +16,7 @@ jobs:
       - name: Login to Docker
         run: docker login -u publisher -p ${{ secrets.GITHUB_TOKEN }} ghcr.io
       - name: Docker latest snapshot build
-        #if: github.ref == 'refs/heads/master'
+        if: github.ref == 'refs/heads/master'
         uses: docker/build-push-action@v3
         with:
           push: true


### PR DESCRIPTION
**What does this PR do?**

We generate the latest snapshot of lib init image in order to be tested from other pipelines (system-tests nightly build)