### PR TITLE
Add auto instrument shim

### DIFF
--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -43,6 +43,7 @@ Metrics/BlockNesting:
 Naming/FileName:
   Exclude:
     - 'lib/datadog/appsec/autoload.rb'
+    - 'lib/datadog/auto_instrument.rb'
     - 'lib/datadog/core/backport.rb'
     - 'lib/datadog/opentelemetry/api/trace/span.rb'
     - 'lib/datadog/opentelemetry/sdk/trace/span.rb'

--- a/lib/datadog/auto_instrument.rb
+++ b/lib/datadog/auto_instrument.rb
@@ -1,0 +1,3 @@
+# frozen_string_literal: true
+
+require_relative '../ddtrace/auto_instrument'


### PR DESCRIPTION
**What does this PR do?**

Add an auto instrument shim

In Gemfile

```ruby
gem 'ddtrace', require: 'ddtrace/auto_instrument'
# Is the same 
gem 'ddtrace', require: 'datadog/auto_instrument'
```

**Motivation:**

Smoother upgrade for 2.0