### PR TITLE
add sigs to gem package

### DIFF
--- a/ddtrace.gemspec
+++ b/ddtrace.gemspec
@@ -39,6 +39,7 @@ Gem::Specification.new do |spec|
       bin/**/*
       ext/**/*
       lib/**/*
+      sig/**/*
     ]]
       .select { |fn| File.file?(fn) } # We don't want directories, only files
       .reject { |fn| fn.end_with?('.so', '.bundle') } # Exclude local profiler binary artifacts


### PR DESCRIPTION
application code can't reuse ddtrace type sigs otherwise.
