### PR TITLE
[NO-TICKET] Fix Ruby 2.3 system tests by using Debian 11 bullseye as a base

### DIFF
--- a/.circleci/images/primary/Dockerfile-2.3.8
+++ b/.circleci/images/primary/Dockerfile-2.3.8
@@ -1,7 +1,12 @@
 # Note: See the "Publishing updates to images" note in ./README.md for how to publish new builds of this container image
 
-# taken from https://hub.docker.com/layers/library/ruby/2.3.8-jessie/images/sha256-cff37ff7e88348a8dd630f9b2d1c679fe9e7b597cfb51a30c42bf2c2afb2eca2?context=explore
-FROM buildpack-deps:bookworm AS ruby-2.3.8-bookworm
+# Based on https://hub.docker.com/layers/library/ruby/2.3.8-jessie/images/sha256-cff37ff7e88348a8dd630f9b2d1c679fe9e7b597cfb51a30c42bf2c2afb2eca2?context=explore
+#
+# Important note: In https://github.com/DataDog/dd-trace-rb/pull/3534 we actually tried to use debian 12 (bookworm) here
+# but ran into issues because one of the test apps we use in system-tests uses a version of nokogiri that fails to
+# build on that debian version. If you change the base image, make sure that `gem install nokogiri -v '= 1.10.10'`
+# successfully installs.
+FROM buildpack-deps:bullseye AS ruby-2.3.8-bullseye
 
 # skip installing gem documentation
 RUN mkdir -p /usr/local/etc \
@@ -86,7 +91,7 @@ RUN mkdir -p "$GEM_HOME" "$BUNDLE_BIN" \
 
 CMD [ "irb" ]
 
-FROM ruby-2.3.8-bookworm
+FROM ruby-2.3.8-bullseye
 
 # Make apt non-interactive
 RUN echo 'APT::Get::Assume-Yes "true";' > /etc/apt/apt.conf.d/90circleci \
@@ -116,11 +121,11 @@ ENV LANGUAGE en_US:en
 # Install Docker and Docker Compose
 RUN set -ex \
   && ARCH=$(dpkg --print-architecture) \
-  && wget https://download.docker.com/linux/debian/dists/bookworm/pool/stable/${ARCH}/containerd.io_1.6.28-2_${ARCH}.deb \
-  && wget https://download.docker.com/linux/debian/dists/bookworm/pool/stable/${ARCH}/docker-ce_25.0.4-1~debian.12~bookworm_${ARCH}.deb \
-  && wget https://download.docker.com/linux/debian/dists/bookworm/pool/stable/${ARCH}/docker-ce-cli_25.0.4-1~debian.12~bookworm_${ARCH}.deb \
-  && wget https://download.docker.com/linux/debian/dists/bookworm/pool/stable/${ARCH}/docker-buildx-plugin_0.13.0-1~debian.12~bookworm_${ARCH}.deb \
-  && wget https://download.docker.com/linux/debian/dists/bookworm/pool/stable/${ARCH}/docker-compose-plugin_2.24.7-1~debian.12~bookworm_${ARCH}.deb \
+  && wget https://download.docker.com/linux/debian/dists/bullseye/pool/stable/${ARCH}/containerd.io_1.6.28-2_${ARCH}.deb \
+  && wget https://download.docker.com/linux/debian/dists/bullseye/pool/stable/${ARCH}/docker-ce_25.0.4-1~debian.11~bullseye_${ARCH}.deb \
+  && wget https://download.docker.com/linux/debian/dists/bullseye/pool/stable/${ARCH}/docker-ce-cli_25.0.4-1~debian.11~bullseye_${ARCH}.deb \
+  && wget https://download.docker.com/linux/debian/dists/bullseye/pool/stable/${ARCH}/docker-buildx-plugin_0.13.0-1~debian.11~bullseye_${ARCH}.deb \
+  && wget https://download.docker.com/linux/debian/dists/bullseye/pool/stable/${ARCH}/docker-compose-plugin_2.24.7-1~debian.11~bullseye_${ARCH}.deb \
   && dpkg -i *.deb \
   && rm -rf *.deb
 


### PR DESCRIPTION
**What does this PR do?**

This PR changes our Ruby 2.3 docker image to use Debian 11 "bullseye" as a base instead of Debian 12 "buster".

In https://github.com/DataDog/dd-trace-rb/pull/3534 we updated this image but this broke system-tests
(https://github.com/DataDog/dd-trace-rb/actions/runs/8346827939/job/22845592152) because they use an old nokogiri version that fails to build on modern systems (https://github.com/sparklemotion/nokogiri/issues/2105):

```
$ gem install nokogiri -v '= 1.10.10'

xml_document.c:495:14: error: conflicting types for 'canonicalize'; have 'VALUE(int,  VALUE *, VALUE)' {aka 'long unsigned int(int,  long unsigned int *, long unsigned int)'}
  495 | static VALUE canonicalize(int argc, VALUE* argv, VALUE self)
      |              ^~~~~~~~~~~~
In file included from /usr/include/features.h:489,
                 from /usr/include/x86_64-linux-gnu/bits/libc-header-start.h:33,
                 from /usr/include/stdlib.h:26,
                 from ./nokogiri.h:4,
                 from ./xml_document.h:4,
                 from xml_document.c:1:
/usr/include/x86_64-linux-gnu/bits/mathcalls.h:370:1: note: previous declaration of 'canonicalize' with type 'int(double *, const double *)'
  370 | __MATHDECL_1 (int, canonicalize,, (_Mdouble_ *__cx, const _Mdouble_ *__x));
      | ^~~~~~~~~~~~
make: *** [Makefile:240: xml_document.o] Error 1

make failed, exit code 2

Gem files will remain installed in /usr/local/bundle/gems/nokogiri-1.10.10 for inspection.
Results logged to /usr/local/bundle/extensions/x86_64-linux/2.3.0/nokogiri-1.10.10/gem_make.out
```

Rather than fighting nokogiri or the system-tests app, let's instead gently step back from Debian 12 to 11, which should still buy us plenty of time until we deprecate Ruby 2.3.

**Motivation:**

Fix CI/system-tests for Ruby 2.3.

**Additional Notes:**

N/A

**How to test the change?**

I've locally built the image with

```bash
$ docker build . -f Dockerfile-2.3.8 -t some-testing-name
```

and confirmed that nokogiri successfully installs.

**For Datadog employees:**
- [ ] If this PR touches code that signs or publishes builds or packages, or handles
credentials of any kind, I've requested a review from `@DataDog/security-design-and-guidance`.
- [x] This PR doesn't touch any of that.