### PR TITLE
Add Rails 7.1 to the system test matrix

### DIFF
--- a/.github/workflows/system-tests.yml
+++ b/.github/workflows/system-tests.yml
@@ -27,8 +27,9 @@ jobs:
           repository: 'DataDog/system-tests'
       - name: Pull released image
         run: |
-          docker pull ghcr.io/datadog/dd-trace-rb/system-tests/${{ matrix.image }}:latest
-          docker tag ghcr.io/datadog/dd-trace-rb/system-tests/${{ matrix.image }}:latest system_tests/${{ matrix.image }}:latest
+          if docker pull ghcr.io/datadog/dd-trace-rb/system-tests/${{ matrix.image }}:latest; then
+            docker tag ghcr.io/datadog/dd-trace-rb/system-tests/${{ matrix.image }}:latest system_tests/${{ matrix.image }}:latest
+          fi
       - name: Build image
         run: ./build.sh --images ${{ matrix.image }}
       - name: List images
@@ -87,10 +88,11 @@ jobs:
         uses: actions/checkout@v4
         with:
           path: 'binaries/dd-trace-rb'
-      # name: Pull released image
-      # run: |
-      #   docker pull ghcr.io/datadog/dd-trace-rb/system-tests/${{ matrix.image }}-${{ matrix.app }}:latest
-      #   docker tag ghcr.io/datadog/dd-trace-rb/system-tests/${{ matrix.image }}-${{ matrix.app }}:latest system_tests/${{ matrix.image }}:latest
+      - name: Pull released image
+        run: |
+          if docker pull ghcr.io/datadog/dd-trace-rb/system-tests/${{ matrix.image }}-${{ matrix.app }}:latest; then
+            docker tag ghcr.io/datadog/dd-trace-rb/system-tests/${{ matrix.image }}-${{ matrix.app }}:latest system_tests/${{ matrix.image }}:latest
+          fi
       - name: Log in to the Container registry
         run: |
           echo ${{ secrets.GITHUB_TOKEN }} | docker login ${{ env.REGISTRY }} -u ${{ github.actor }} --password-stdin

--- a/.github/workflows/system-tests.yml
+++ b/.github/workflows/system-tests.yml
@@ -75,6 +75,7 @@ jobs:
           - rails60
           - rails61
           - rails70
+          - rails71
     runs-on: ubuntu-latest
     name: Build (${{ matrix.app }})
     steps:

--- a/.github/workflows/system-tests.yml
+++ b/.github/workflows/system-tests.yml
@@ -87,10 +87,10 @@ jobs:
         uses: actions/checkout@v4
         with:
           path: 'binaries/dd-trace-rb'
-      - name: Pull released image
-        run: |
-          docker pull ghcr.io/datadog/dd-trace-rb/system-tests/${{ matrix.image }}-${{ matrix.app }}:latest
-          docker tag ghcr.io/datadog/dd-trace-rb/system-tests/${{ matrix.image }}-${{ matrix.app }}:latest system_tests/${{ matrix.image }}:latest
+      # name: Pull released image
+      # run: |
+      #   docker pull ghcr.io/datadog/dd-trace-rb/system-tests/${{ matrix.image }}-${{ matrix.app }}:latest
+      #   docker tag ghcr.io/datadog/dd-trace-rb/system-tests/${{ matrix.image }}-${{ matrix.app }}:latest system_tests/${{ matrix.image }}:latest
       - name: Log in to the Container registry
         run: |
           echo ${{ secrets.GITHUB_TOKEN }} | docker login ${{ env.REGISTRY }} -u ${{ github.actor }} --password-stdin


### PR DESCRIPTION
<!--
Check out the
https://github.com/DataDog/dd-trace-rb/blob/master/docs/DevelopmentGuide.md
for guidance on how to set up your development environment,
run the test suite, write new integrations, and more.
-->

**2.0 Upgrade Guide notes**
<!--
(If this PR is for 1.x, please delete this section)
If this PR introduces a breaking change, update the
https://github.com/DataDog/dd-trace-rb/blob/2.0/docs/UpgradeGuide2.md
in this PR with either:
* A migration path for this change. In other words, how to continue using their application without behavior changes
in 2.0 (e.g. environment variable 'X' renamed to 'Y').
* That there's no alternative; we removed support for this feature.
-->

**What does this PR do?**

Add Rails 7.1

**Motivation:**

missing coverage

**Additional Notes:**

- followup to https://github.com/DataDog/system-tests/pull/2242
- more to come with subsequent https://github.com/DataDog/system-tests/pull/2246

**How to test the change?**
<!--
Describe here how the change can be validated.
You are strongly encouraged to provide automated tests for this PR (unit or integration).
If this change cannot be feasibly tested, please explain why,
unless the change does not modify code (e.g. only modifies docs, comments).
-->

CI should pass

**For Datadog employees:**
- [ ] If this PR touches code that signs or publishes builds or packages, or handles
credentials of any kind, I've requested a review from `@DataDog/security-design-and-guidance`.
- [ ] This PR doesn't touch any of that.

Unsure? Have a question? Request a review!
