### PR TITLE
Bump to version 1.21.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,18 @@
 
 ## [Unreleased]
 
+## [1.21.1] - 2024-03-20
+
+### Added
+
+* Backports auto instrument shim with `datadog/auto_instrument` ([#3535][])
+
+### Fixed
+
+* Fix ActiveRecord resolving invalid string ([#3523][])
+* Revert `http.route` tagging to fix instrumentation failure for Rails 7.1 apps ([#3539][])
+* Fix wrong permissions on released gem files ([#3531][])
+
 ## [1.21.0] - 2024-03-14
 
 ### Highlights
@@ -2764,7 +2776,8 @@ Release notes: https://github.com/DataDog/dd-trace-rb/releases/tag/v0.3.1
 Git diff: https://github.com/DataDog/dd-trace-rb/compare/v0.3.0...v0.3.1
 
 
-[Unreleased]: https://github.com/DataDog/dd-trace-rb/compare/v1.21.0...master
+[Unreleased]: https://github.com/DataDog/dd-trace-rb/compare/v1.21.1...master
+[1.21.1]: https://github.com/DataDog/dd-trace-rb/compare/v1.21.0...v1.21.1
 [1.21.0]: https://github.com/DataDog/dd-trace-rb/compare/v1.20.0...v1.21.0
 [1.20.0]: https://github.com/DataDog/dd-trace-rb/compare/v1.19.0...v1.20.0
 [1.19.0]: https://github.com/DataDog/dd-trace-rb/compare/v1.18.0...v1.19.0
@@ -4056,6 +4069,10 @@ Git diff: https://github.com/DataDog/dd-trace-rb/compare/v0.3.0...v0.3.1
 [#3518]: https://github.com/DataDog/dd-trace-rb/issues/3518
 [#3519]: https://github.com/DataDog/dd-trace-rb/issues/3519
 [#3520]: https://github.com/DataDog/dd-trace-rb/issues/3520
+[#3523]: https://github.com/DataDog/dd-trace-rb/issues/3523
+[#3531]: https://github.com/DataDog/dd-trace-rb/issues/3531
+[#3535]: https://github.com/DataDog/dd-trace-rb/issues/3535
+[#3539]: https://github.com/DataDog/dd-trace-rb/issues/3539
 [@AdrianLC]: https://github.com/AdrianLC
 [@Azure7111]: https://github.com/Azure7111
 [@BabyGroot]: https://github.com/BabyGroot

--- a/gemfiles/jruby_9.2.21.0_sinatra.gemfile.lock
+++ b/gemfiles/jruby_9.2.21.0_sinatra.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    ddtrace (1.21.0)
+    ddtrace (1.21.1)
       datadog-ci (~> 0.2.0)
       debase-ruby_core_source (= 3.3.1)
       libdatadog (~> 6.0.0.2.0)

--- a/gemfiles/jruby_9.2_activesupport.gemfile.lock
+++ b/gemfiles/jruby_9.2_activesupport.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    ddtrace (1.21.0)
+    ddtrace (1.21.1)
       datadog-ci (~> 0.8.1)
       debase-ruby_core_source (= 3.3.1)
       libdatadog (~> 6.0.0.2.0)

--- a/gemfiles/jruby_9.2_aws.gemfile.lock
+++ b/gemfiles/jruby_9.2_aws.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    ddtrace (1.21.0)
+    ddtrace (1.21.1)
       datadog-ci (~> 0.8.1)
       debase-ruby_core_source (= 3.3.1)
       libdatadog (~> 6.0.0.2.0)

--- a/gemfiles/jruby_9.2_contrib.gemfile.lock
+++ b/gemfiles/jruby_9.2_contrib.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    ddtrace (1.21.0)
+    ddtrace (1.21.1)
       datadog-ci (~> 0.8.1)
       debase-ruby_core_source (= 3.3.1)
       libdatadog (~> 6.0.0.2.0)

--- a/gemfiles/jruby_9.2_contrib_old.gemfile.lock
+++ b/gemfiles/jruby_9.2_contrib_old.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    ddtrace (1.21.0)
+    ddtrace (1.21.1)
       datadog-ci (~> 0.8.1)
       debase-ruby_core_source (= 3.3.1)
       libdatadog (~> 6.0.0.2.0)

--- a/gemfiles/jruby_9.2_core_old.gemfile.lock
+++ b/gemfiles/jruby_9.2_core_old.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    ddtrace (1.21.0)
+    ddtrace (1.21.1)
       datadog-ci (~> 0.8.1)
       debase-ruby_core_source (= 3.3.1)
       libdatadog (~> 6.0.0.2.0)

--- a/gemfiles/jruby_9.2_elasticsearch_7.gemfile.lock
+++ b/gemfiles/jruby_9.2_elasticsearch_7.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    ddtrace (1.21.0)
+    ddtrace (1.21.1)
       datadog-ci (~> 0.8.1)
       debase-ruby_core_source (= 3.3.1)
       libdatadog (~> 6.0.0.2.0)

--- a/gemfiles/jruby_9.2_elasticsearch_8.gemfile.lock
+++ b/gemfiles/jruby_9.2_elasticsearch_8.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    ddtrace (1.21.0)
+    ddtrace (1.21.1)
       datadog-ci (~> 0.8.1)
       debase-ruby_core_source (= 3.3.1)
       libdatadog (~> 6.0.0.2.0)

--- a/gemfiles/jruby_9.2_graphql_1.12.gemfile.lock
+++ b/gemfiles/jruby_9.2_graphql_1.12.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    ddtrace (1.21.0)
+    ddtrace (1.21.1)
       datadog-ci (~> 0.8.1)
       debase-ruby_core_source (= 3.3.1)
       libdatadog (~> 6.0.0.2.0)

--- a/gemfiles/jruby_9.2_graphql_1.13.gemfile.lock
+++ b/gemfiles/jruby_9.2_graphql_1.13.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    ddtrace (1.21.0)
+    ddtrace (1.21.1)
       datadog-ci (~> 0.8.1)
       debase-ruby_core_source (= 3.3.1)
       libdatadog (~> 6.0.0.2.0)

--- a/gemfiles/jruby_9.2_graphql_2.0.gemfile.lock
+++ b/gemfiles/jruby_9.2_graphql_2.0.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    ddtrace (1.21.0)
+    ddtrace (1.21.1)
       datadog-ci (~> 0.8.1)
       debase-ruby_core_source (= 3.3.1)
       libdatadog (~> 6.0.0.2.0)

--- a/gemfiles/jruby_9.2_hanami_1.gemfile.lock
+++ b/gemfiles/jruby_9.2_hanami_1.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    ddtrace (1.21.0)
+    ddtrace (1.21.1)
       datadog-ci (~> 0.8.1)
       debase-ruby_core_source (= 3.3.1)
       libdatadog (~> 6.0.0.2.0)

--- a/gemfiles/jruby_9.2_http.gemfile.lock
+++ b/gemfiles/jruby_9.2_http.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    ddtrace (1.21.0)
+    ddtrace (1.21.1)
       datadog-ci (~> 0.8.1)
       debase-ruby_core_source (= 3.3.1)
       libdatadog (~> 6.0.0.2.0)

--- a/gemfiles/jruby_9.2_multi_rack_app.gemfile.lock
+++ b/gemfiles/jruby_9.2_multi_rack_app.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    ddtrace (1.21.0)
+    ddtrace (1.21.1)
       datadog-ci (~> 0.8.1)
       debase-ruby_core_source (= 3.3.1)
       libdatadog (~> 6.0.0.2.0)

--- a/gemfiles/jruby_9.2_opensearch_2.gemfile.lock
+++ b/gemfiles/jruby_9.2_opensearch_2.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    ddtrace (1.21.0)
+    ddtrace (1.21.1)
       datadog-ci (~> 0.8.1)
       debase-ruby_core_source (= 3.3.1)
       libdatadog (~> 6.0.0.2.0)

--- a/gemfiles/jruby_9.2_opensearch_3.gemfile.lock
+++ b/gemfiles/jruby_9.2_opensearch_3.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    ddtrace (1.21.0)
+    ddtrace (1.21.1)
       datadog-ci (~> 0.8.1)
       debase-ruby_core_source (= 3.3.1)
       libdatadog (~> 6.0.0.2.0)

--- a/gemfiles/jruby_9.2_opentracing.gemfile.lock
+++ b/gemfiles/jruby_9.2_opentracing.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    ddtrace (1.21.0)
+    ddtrace (1.21.1)
       datadog-ci (~> 0.8.1)
       debase-ruby_core_source (= 3.3.1)
       libdatadog (~> 6.0.0.2.0)

--- a/gemfiles/jruby_9.2_rack_1.gemfile.lock
+++ b/gemfiles/jruby_9.2_rack_1.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    ddtrace (1.21.0)
+    ddtrace (1.21.1)
       datadog-ci (~> 0.8.1)
       debase-ruby_core_source (= 3.3.1)
       libdatadog (~> 6.0.0.2.0)

--- a/gemfiles/jruby_9.2_rack_2.gemfile.lock
+++ b/gemfiles/jruby_9.2_rack_2.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    ddtrace (1.21.0)
+    ddtrace (1.21.1)
       datadog-ci (~> 0.8.1)
       debase-ruby_core_source (= 3.3.1)
       libdatadog (~> 6.0.0.2.0)

--- a/gemfiles/jruby_9.2_rack_3.gemfile.lock
+++ b/gemfiles/jruby_9.2_rack_3.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    ddtrace (1.21.0)
+    ddtrace (1.21.1)
       datadog-ci (~> 0.8.1)
       debase-ruby_core_source (= 3.3.1)
       libdatadog (~> 6.0.0.2.0)

--- a/gemfiles/jruby_9.2_rails5_mysql2.gemfile.lock
+++ b/gemfiles/jruby_9.2_rails5_mysql2.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    ddtrace (1.21.0)
+    ddtrace (1.21.1)
       datadog-ci (~> 0.8.1)
       debase-ruby_core_source (= 3.3.1)
       libdatadog (~> 6.0.0.2.0)

--- a/gemfiles/jruby_9.2_rails5_postgres.gemfile.lock
+++ b/gemfiles/jruby_9.2_rails5_postgres.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    ddtrace (1.21.0)
+    ddtrace (1.21.1)
       datadog-ci (~> 0.8.1)
       debase-ruby_core_source (= 3.3.1)
       libdatadog (~> 6.0.0.2.0)

--- a/gemfiles/jruby_9.2_rails5_postgres_redis.gemfile.lock
+++ b/gemfiles/jruby_9.2_rails5_postgres_redis.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    ddtrace (1.21.0)
+    ddtrace (1.21.1)
       datadog-ci (~> 0.8.1)
       debase-ruby_core_source (= 3.3.1)
       libdatadog (~> 6.0.0.2.0)

--- a/gemfiles/jruby_9.2_rails5_postgres_redis_activesupport.gemfile.lock
+++ b/gemfiles/jruby_9.2_rails5_postgres_redis_activesupport.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    ddtrace (1.21.0)
+    ddtrace (1.21.1)
       datadog-ci (~> 0.8.1)
       debase-ruby_core_source (= 3.3.1)
       libdatadog (~> 6.0.0.2.0)

--- a/gemfiles/jruby_9.2_rails5_postgres_sidekiq.gemfile.lock
+++ b/gemfiles/jruby_9.2_rails5_postgres_sidekiq.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    ddtrace (1.21.0)
+    ddtrace (1.21.1)
       datadog-ci (~> 0.8.1)
       debase-ruby_core_source (= 3.3.1)
       libdatadog (~> 6.0.0.2.0)

--- a/gemfiles/jruby_9.2_rails5_semantic_logger.gemfile.lock
+++ b/gemfiles/jruby_9.2_rails5_semantic_logger.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    ddtrace (1.21.0)
+    ddtrace (1.21.1)
       datadog-ci (~> 0.8.1)
       debase-ruby_core_source (= 3.3.1)
       libdatadog (~> 6.0.0.2.0)

--- a/gemfiles/jruby_9.2_rails61_mysql2.gemfile.lock
+++ b/gemfiles/jruby_9.2_rails61_mysql2.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    ddtrace (1.21.0)
+    ddtrace (1.21.1)
       datadog-ci (~> 0.8.1)
       debase-ruby_core_source (= 3.3.1)
       libdatadog (~> 6.0.0.2.0)

--- a/gemfiles/jruby_9.2_rails61_postgres.gemfile.lock
+++ b/gemfiles/jruby_9.2_rails61_postgres.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    ddtrace (1.21.0)
+    ddtrace (1.21.1)
       datadog-ci (~> 0.8.1)
       debase-ruby_core_source (= 3.3.1)
       libdatadog (~> 6.0.0.2.0)

--- a/gemfiles/jruby_9.2_rails61_postgres_redis.gemfile.lock
+++ b/gemfiles/jruby_9.2_rails61_postgres_redis.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    ddtrace (1.21.0)
+    ddtrace (1.21.1)
       datadog-ci (~> 0.8.1)
       debase-ruby_core_source (= 3.3.1)
       libdatadog (~> 6.0.0.2.0)

--- a/gemfiles/jruby_9.2_rails61_postgres_sidekiq.gemfile.lock
+++ b/gemfiles/jruby_9.2_rails61_postgres_sidekiq.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    ddtrace (1.21.0)
+    ddtrace (1.21.1)
       datadog-ci (~> 0.8.1)
       debase-ruby_core_source (= 3.3.1)
       libdatadog (~> 6.0.0.2.0)

--- a/gemfiles/jruby_9.2_rails61_semantic_logger.gemfile.lock
+++ b/gemfiles/jruby_9.2_rails61_semantic_logger.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    ddtrace (1.21.0)
+    ddtrace (1.21.1)
       datadog-ci (~> 0.8.1)
       debase-ruby_core_source (= 3.3.1)
       libdatadog (~> 6.0.0.2.0)

--- a/gemfiles/jruby_9.2_rails6_mysql2.gemfile.lock
+++ b/gemfiles/jruby_9.2_rails6_mysql2.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    ddtrace (1.21.0)
+    ddtrace (1.21.1)
       datadog-ci (~> 0.8.1)
       debase-ruby_core_source (= 3.3.1)
       libdatadog (~> 6.0.0.2.0)

--- a/gemfiles/jruby_9.2_rails6_postgres.gemfile.lock
+++ b/gemfiles/jruby_9.2_rails6_postgres.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    ddtrace (1.21.0)
+    ddtrace (1.21.1)
       datadog-ci (~> 0.8.1)
       debase-ruby_core_source (= 3.3.1)
       libdatadog (~> 6.0.0.2.0)

--- a/gemfiles/jruby_9.2_rails6_postgres_redis.gemfile.lock
+++ b/gemfiles/jruby_9.2_rails6_postgres_redis.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    ddtrace (1.21.0)
+    ddtrace (1.21.1)
       datadog-ci (~> 0.8.1)
       debase-ruby_core_source (= 3.3.1)
       libdatadog (~> 6.0.0.2.0)

--- a/gemfiles/jruby_9.2_rails6_postgres_redis_activesupport.gemfile.lock
+++ b/gemfiles/jruby_9.2_rails6_postgres_redis_activesupport.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    ddtrace (1.21.0)
+    ddtrace (1.21.1)
       datadog-ci (~> 0.8.1)
       debase-ruby_core_source (= 3.3.1)
       libdatadog (~> 6.0.0.2.0)

--- a/gemfiles/jruby_9.2_rails6_postgres_sidekiq.gemfile.lock
+++ b/gemfiles/jruby_9.2_rails6_postgres_sidekiq.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    ddtrace (1.21.0)
+    ddtrace (1.21.1)
       datadog-ci (~> 0.8.1)
       debase-ruby_core_source (= 3.3.1)
       libdatadog (~> 6.0.0.2.0)

--- a/gemfiles/jruby_9.2_rails6_semantic_logger.gemfile.lock
+++ b/gemfiles/jruby_9.2_rails6_semantic_logger.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    ddtrace (1.21.0)
+    ddtrace (1.21.1)
       datadog-ci (~> 0.8.1)
       debase-ruby_core_source (= 3.3.1)
       libdatadog (~> 6.0.0.2.0)

--- a/gemfiles/jruby_9.2_redis_3.gemfile.lock
+++ b/gemfiles/jruby_9.2_redis_3.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    ddtrace (1.21.0)
+    ddtrace (1.21.1)
       datadog-ci (~> 0.8.1)
       debase-ruby_core_source (= 3.3.1)
       libdatadog (~> 6.0.0.2.0)

--- a/gemfiles/jruby_9.2_redis_4.gemfile.lock
+++ b/gemfiles/jruby_9.2_redis_4.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    ddtrace (1.21.0)
+    ddtrace (1.21.1)
       datadog-ci (~> 0.8.1)
       debase-ruby_core_source (= 3.3.1)
       libdatadog (~> 6.0.0.2.0)

--- a/gemfiles/jruby_9.2_redis_5.gemfile.lock
+++ b/gemfiles/jruby_9.2_redis_5.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    ddtrace (1.21.0)
+    ddtrace (1.21.1)
       datadog-ci (~> 0.8.1)
       debase-ruby_core_source (= 3.3.1)
       libdatadog (~> 6.0.0.2.0)

--- a/gemfiles/jruby_9.2_relational_db.gemfile.lock
+++ b/gemfiles/jruby_9.2_relational_db.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    ddtrace (1.21.0)
+    ddtrace (1.21.1)
       datadog-ci (~> 0.8.1)
       debase-ruby_core_source (= 3.3.1)
       libdatadog (~> 6.0.0.2.0)

--- a/gemfiles/jruby_9.2_resque2_redis3.gemfile.lock
+++ b/gemfiles/jruby_9.2_resque2_redis3.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    ddtrace (1.21.0)
+    ddtrace (1.21.1)
       datadog-ci (~> 0.8.1)
       debase-ruby_core_source (= 3.3.1)
       libdatadog (~> 6.0.0.2.0)

--- a/gemfiles/jruby_9.2_resque2_redis4.gemfile.lock
+++ b/gemfiles/jruby_9.2_resque2_redis4.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    ddtrace (1.21.0)
+    ddtrace (1.21.1)
       datadog-ci (~> 0.8.1)
       debase-ruby_core_source (= 3.3.1)
       libdatadog (~> 6.0.0.2.0)

--- a/gemfiles/jruby_9.2_sinatra.gemfile.lock
+++ b/gemfiles/jruby_9.2_sinatra.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    ddtrace (1.21.0)
+    ddtrace (1.21.1)
       datadog-ci (~> 0.8.1)
       debase-ruby_core_source (= 3.3.1)
       libdatadog (~> 6.0.0.2.0)

--- a/gemfiles/jruby_9.3_activesupport.gemfile.lock
+++ b/gemfiles/jruby_9.3_activesupport.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    ddtrace (1.21.0)
+    ddtrace (1.21.1)
       datadog-ci (~> 0.8.1)
       debase-ruby_core_source (= 3.3.1)
       libdatadog (~> 6.0.0.2.0)

--- a/gemfiles/jruby_9.3_aws.gemfile.lock
+++ b/gemfiles/jruby_9.3_aws.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    ddtrace (1.21.0)
+    ddtrace (1.21.1)
       datadog-ci (~> 0.8.1)
       debase-ruby_core_source (= 3.3.1)
       libdatadog (~> 6.0.0.2.0)

--- a/gemfiles/jruby_9.3_contrib.gemfile.lock
+++ b/gemfiles/jruby_9.3_contrib.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    ddtrace (1.21.0)
+    ddtrace (1.21.1)
       datadog-ci (~> 0.8.1)
       debase-ruby_core_source (= 3.3.1)
       libdatadog (~> 6.0.0.2.0)

--- a/gemfiles/jruby_9.3_contrib_old.gemfile.lock
+++ b/gemfiles/jruby_9.3_contrib_old.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    ddtrace (1.21.0)
+    ddtrace (1.21.1)
       datadog-ci (~> 0.8.1)
       debase-ruby_core_source (= 3.3.1)
       libdatadog (~> 6.0.0.2.0)

--- a/gemfiles/jruby_9.3_core_old.gemfile.lock
+++ b/gemfiles/jruby_9.3_core_old.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    ddtrace (1.21.0)
+    ddtrace (1.21.1)
       datadog-ci (~> 0.8.1)
       debase-ruby_core_source (= 3.3.1)
       libdatadog (~> 6.0.0.2.0)

--- a/gemfiles/jruby_9.3_elasticsearch_7.gemfile.lock
+++ b/gemfiles/jruby_9.3_elasticsearch_7.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    ddtrace (1.21.0)
+    ddtrace (1.21.1)
       datadog-ci (~> 0.8.1)
       debase-ruby_core_source (= 3.3.1)
       libdatadog (~> 6.0.0.2.0)

--- a/gemfiles/jruby_9.3_elasticsearch_8.gemfile.lock
+++ b/gemfiles/jruby_9.3_elasticsearch_8.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    ddtrace (1.21.0)
+    ddtrace (1.21.1)
       datadog-ci (~> 0.8.1)
       debase-ruby_core_source (= 3.3.1)
       libdatadog (~> 6.0.0.2.0)

--- a/gemfiles/jruby_9.3_graphql_1.12.gemfile.lock
+++ b/gemfiles/jruby_9.3_graphql_1.12.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    ddtrace (1.21.0)
+    ddtrace (1.21.1)
       datadog-ci (~> 0.8.1)
       debase-ruby_core_source (= 3.3.1)
       libdatadog (~> 6.0.0.2.0)

--- a/gemfiles/jruby_9.3_graphql_1.13.gemfile.lock
+++ b/gemfiles/jruby_9.3_graphql_1.13.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    ddtrace (1.21.0)
+    ddtrace (1.21.1)
       datadog-ci (~> 0.8.1)
       debase-ruby_core_source (= 3.3.1)
       libdatadog (~> 6.0.0.2.0)

--- a/gemfiles/jruby_9.3_graphql_2.0.gemfile.lock
+++ b/gemfiles/jruby_9.3_graphql_2.0.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    ddtrace (1.21.0)
+    ddtrace (1.21.1)
       datadog-ci (~> 0.8.1)
       debase-ruby_core_source (= 3.3.1)
       libdatadog (~> 6.0.0.2.0)

--- a/gemfiles/jruby_9.3_hanami_1.gemfile.lock
+++ b/gemfiles/jruby_9.3_hanami_1.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    ddtrace (1.21.0)
+    ddtrace (1.21.1)
       datadog-ci (~> 0.8.1)
       debase-ruby_core_source (= 3.3.1)
       libdatadog (~> 6.0.0.2.0)

--- a/gemfiles/jruby_9.3_http.gemfile.lock
+++ b/gemfiles/jruby_9.3_http.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    ddtrace (1.21.0)
+    ddtrace (1.21.1)
       datadog-ci (~> 0.8.1)
       debase-ruby_core_source (= 3.3.1)
       libdatadog (~> 6.0.0.2.0)

--- a/gemfiles/jruby_9.3_multi_rack_app.gemfile.lock
+++ b/gemfiles/jruby_9.3_multi_rack_app.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    ddtrace (1.21.0)
+    ddtrace (1.21.1)
       datadog-ci (~> 0.8.1)
       debase-ruby_core_source (= 3.3.1)
       libdatadog (~> 6.0.0.2.0)

--- a/gemfiles/jruby_9.3_opensearch_2.gemfile.lock
+++ b/gemfiles/jruby_9.3_opensearch_2.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    ddtrace (1.21.0)
+    ddtrace (1.21.1)
       datadog-ci (~> 0.8.1)
       debase-ruby_core_source (= 3.3.1)
       libdatadog (~> 6.0.0.2.0)

--- a/gemfiles/jruby_9.3_opensearch_3.gemfile.lock
+++ b/gemfiles/jruby_9.3_opensearch_3.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    ddtrace (1.21.0)
+    ddtrace (1.21.1)
       datadog-ci (~> 0.8.1)
       debase-ruby_core_source (= 3.3.1)
       libdatadog (~> 6.0.0.2.0)

--- a/gemfiles/jruby_9.3_opentracing.gemfile.lock
+++ b/gemfiles/jruby_9.3_opentracing.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    ddtrace (1.21.0)
+    ddtrace (1.21.1)
       datadog-ci (~> 0.8.1)
       debase-ruby_core_source (= 3.3.1)
       libdatadog (~> 6.0.0.2.0)

--- a/gemfiles/jruby_9.3_rack_1.gemfile.lock
+++ b/gemfiles/jruby_9.3_rack_1.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    ddtrace (1.21.0)
+    ddtrace (1.21.1)
       datadog-ci (~> 0.8.1)
       debase-ruby_core_source (= 3.3.1)
       libdatadog (~> 6.0.0.2.0)

--- a/gemfiles/jruby_9.3_rack_2.gemfile.lock
+++ b/gemfiles/jruby_9.3_rack_2.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    ddtrace (1.21.0)
+    ddtrace (1.21.1)
       datadog-ci (~> 0.8.1)
       debase-ruby_core_source (= 3.3.1)
       libdatadog (~> 6.0.0.2.0)

--- a/gemfiles/jruby_9.3_rack_3.gemfile.lock
+++ b/gemfiles/jruby_9.3_rack_3.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    ddtrace (1.21.0)
+    ddtrace (1.21.1)
       datadog-ci (~> 0.8.1)
       debase-ruby_core_source (= 3.3.1)
       libdatadog (~> 6.0.0.2.0)

--- a/gemfiles/jruby_9.3_rails5_mysql2.gemfile.lock
+++ b/gemfiles/jruby_9.3_rails5_mysql2.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    ddtrace (1.21.0)
+    ddtrace (1.21.1)
       datadog-ci (~> 0.8.1)
       debase-ruby_core_source (= 3.3.1)
       libdatadog (~> 6.0.0.2.0)

--- a/gemfiles/jruby_9.3_rails5_postgres.gemfile.lock
+++ b/gemfiles/jruby_9.3_rails5_postgres.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    ddtrace (1.21.0)
+    ddtrace (1.21.1)
       datadog-ci (~> 0.8.1)
       debase-ruby_core_source (= 3.3.1)
       libdatadog (~> 6.0.0.2.0)

--- a/gemfiles/jruby_9.3_rails5_postgres_redis.gemfile.lock
+++ b/gemfiles/jruby_9.3_rails5_postgres_redis.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    ddtrace (1.21.0)
+    ddtrace (1.21.1)
       datadog-ci (~> 0.8.1)
       debase-ruby_core_source (= 3.3.1)
       libdatadog (~> 6.0.0.2.0)

--- a/gemfiles/jruby_9.3_rails5_postgres_redis_activesupport.gemfile.lock
+++ b/gemfiles/jruby_9.3_rails5_postgres_redis_activesupport.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    ddtrace (1.21.0)
+    ddtrace (1.21.1)
       datadog-ci (~> 0.8.1)
       debase-ruby_core_source (= 3.3.1)
       libdatadog (~> 6.0.0.2.0)

--- a/gemfiles/jruby_9.3_rails5_postgres_sidekiq.gemfile.lock
+++ b/gemfiles/jruby_9.3_rails5_postgres_sidekiq.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    ddtrace (1.21.0)
+    ddtrace (1.21.1)
       datadog-ci (~> 0.8.1)
       debase-ruby_core_source (= 3.3.1)
       libdatadog (~> 6.0.0.2.0)

--- a/gemfiles/jruby_9.3_rails5_semantic_logger.gemfile.lock
+++ b/gemfiles/jruby_9.3_rails5_semantic_logger.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    ddtrace (1.21.0)
+    ddtrace (1.21.1)
       datadog-ci (~> 0.8.1)
       debase-ruby_core_source (= 3.3.1)
       libdatadog (~> 6.0.0.2.0)

--- a/gemfiles/jruby_9.3_rails61_mysql2.gemfile.lock
+++ b/gemfiles/jruby_9.3_rails61_mysql2.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    ddtrace (1.21.0)
+    ddtrace (1.21.1)
       datadog-ci (~> 0.8.1)
       debase-ruby_core_source (= 3.3.1)
       libdatadog (~> 6.0.0.2.0)

--- a/gemfiles/jruby_9.3_rails61_postgres.gemfile.lock
+++ b/gemfiles/jruby_9.3_rails61_postgres.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    ddtrace (1.21.0)
+    ddtrace (1.21.1)
       datadog-ci (~> 0.8.1)
       debase-ruby_core_source (= 3.3.1)
       libdatadog (~> 6.0.0.2.0)

--- a/gemfiles/jruby_9.3_rails61_postgres_redis.gemfile.lock
+++ b/gemfiles/jruby_9.3_rails61_postgres_redis.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    ddtrace (1.21.0)
+    ddtrace (1.21.1)
       datadog-ci (~> 0.8.1)
       debase-ruby_core_source (= 3.3.1)
       libdatadog (~> 6.0.0.2.0)

--- a/gemfiles/jruby_9.3_rails61_postgres_sidekiq.gemfile.lock
+++ b/gemfiles/jruby_9.3_rails61_postgres_sidekiq.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    ddtrace (1.21.0)
+    ddtrace (1.21.1)
       datadog-ci (~> 0.8.1)
       debase-ruby_core_source (= 3.3.1)
       libdatadog (~> 6.0.0.2.0)

--- a/gemfiles/jruby_9.3_rails61_semantic_logger.gemfile.lock
+++ b/gemfiles/jruby_9.3_rails61_semantic_logger.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    ddtrace (1.21.0)
+    ddtrace (1.21.1)
       datadog-ci (~> 0.8.1)
       debase-ruby_core_source (= 3.3.1)
       libdatadog (~> 6.0.0.2.0)

--- a/gemfiles/jruby_9.3_rails6_mysql2.gemfile.lock
+++ b/gemfiles/jruby_9.3_rails6_mysql2.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    ddtrace (1.21.0)
+    ddtrace (1.21.1)
       datadog-ci (~> 0.8.1)
       debase-ruby_core_source (= 3.3.1)
       libdatadog (~> 6.0.0.2.0)

--- a/gemfiles/jruby_9.3_rails6_postgres.gemfile.lock
+++ b/gemfiles/jruby_9.3_rails6_postgres.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    ddtrace (1.21.0)
+    ddtrace (1.21.1)
       datadog-ci (~> 0.8.1)
       debase-ruby_core_source (= 3.3.1)
       libdatadog (~> 6.0.0.2.0)

--- a/gemfiles/jruby_9.3_rails6_postgres_redis.gemfile.lock
+++ b/gemfiles/jruby_9.3_rails6_postgres_redis.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    ddtrace (1.21.0)
+    ddtrace (1.21.1)
       datadog-ci (~> 0.8.1)
       debase-ruby_core_source (= 3.3.1)
       libdatadog (~> 6.0.0.2.0)

--- a/gemfiles/jruby_9.3_rails6_postgres_redis_activesupport.gemfile.lock
+++ b/gemfiles/jruby_9.3_rails6_postgres_redis_activesupport.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    ddtrace (1.21.0)
+    ddtrace (1.21.1)
       datadog-ci (~> 0.8.1)
       debase-ruby_core_source (= 3.3.1)
       libdatadog (~> 6.0.0.2.0)

--- a/gemfiles/jruby_9.3_rails6_postgres_sidekiq.gemfile.lock
+++ b/gemfiles/jruby_9.3_rails6_postgres_sidekiq.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    ddtrace (1.21.0)
+    ddtrace (1.21.1)
       datadog-ci (~> 0.8.1)
       debase-ruby_core_source (= 3.3.1)
       libdatadog (~> 6.0.0.2.0)

--- a/gemfiles/jruby_9.3_rails6_semantic_logger.gemfile.lock
+++ b/gemfiles/jruby_9.3_rails6_semantic_logger.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    ddtrace (1.21.0)
+    ddtrace (1.21.1)
       datadog-ci (~> 0.8.1)
       debase-ruby_core_source (= 3.3.1)
       libdatadog (~> 6.0.0.2.0)

--- a/gemfiles/jruby_9.3_redis_3.gemfile.lock
+++ b/gemfiles/jruby_9.3_redis_3.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    ddtrace (1.21.0)
+    ddtrace (1.21.1)
       datadog-ci (~> 0.8.1)
       debase-ruby_core_source (= 3.3.1)
       libdatadog (~> 6.0.0.2.0)

--- a/gemfiles/jruby_9.3_redis_4.gemfile.lock
+++ b/gemfiles/jruby_9.3_redis_4.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    ddtrace (1.21.0)
+    ddtrace (1.21.1)
       datadog-ci (~> 0.8.1)
       debase-ruby_core_source (= 3.3.1)
       libdatadog (~> 6.0.0.2.0)

--- a/gemfiles/jruby_9.3_redis_5.gemfile.lock
+++ b/gemfiles/jruby_9.3_redis_5.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    ddtrace (1.21.0)
+    ddtrace (1.21.1)
       datadog-ci (~> 0.8.1)
       debase-ruby_core_source (= 3.3.1)
       libdatadog (~> 6.0.0.2.0)

--- a/gemfiles/jruby_9.3_relational_db.gemfile.lock
+++ b/gemfiles/jruby_9.3_relational_db.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    ddtrace (1.21.0)
+    ddtrace (1.21.1)
       datadog-ci (~> 0.8.1)
       debase-ruby_core_source (= 3.3.1)
       libdatadog (~> 6.0.0.2.0)

--- a/gemfiles/jruby_9.3_resque2_redis3.gemfile.lock
+++ b/gemfiles/jruby_9.3_resque2_redis3.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    ddtrace (1.21.0)
+    ddtrace (1.21.1)
       datadog-ci (~> 0.8.1)
       debase-ruby_core_source (= 3.3.1)
       libdatadog (~> 6.0.0.2.0)

--- a/gemfiles/jruby_9.3_resque2_redis4.gemfile.lock
+++ b/gemfiles/jruby_9.3_resque2_redis4.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    ddtrace (1.21.0)
+    ddtrace (1.21.1)
       datadog-ci (~> 0.8.1)
       debase-ruby_core_source (= 3.3.1)
       libdatadog (~> 6.0.0.2.0)

--- a/gemfiles/jruby_9.3_sinatra.gemfile.lock
+++ b/gemfiles/jruby_9.3_sinatra.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    ddtrace (1.21.0)
+    ddtrace (1.21.1)
       datadog-ci (~> 0.8.1)
       debase-ruby_core_source (= 3.3.1)
       libdatadog (~> 6.0.0.2.0)

--- a/gemfiles/jruby_9.4_activesupport.gemfile.lock
+++ b/gemfiles/jruby_9.4_activesupport.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    ddtrace (1.21.0)
+    ddtrace (1.21.1)
       datadog-ci (~> 0.8.1)
       debase-ruby_core_source (= 3.3.1)
       libdatadog (~> 6.0.0.2.0)

--- a/gemfiles/jruby_9.4_aws.gemfile.lock
+++ b/gemfiles/jruby_9.4_aws.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    ddtrace (1.21.0)
+    ddtrace (1.21.1)
       datadog-ci (~> 0.8.1)
       debase-ruby_core_source (= 3.3.1)
       libdatadog (~> 6.0.0.2.0)

--- a/gemfiles/jruby_9.4_contrib.gemfile.lock
+++ b/gemfiles/jruby_9.4_contrib.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    ddtrace (1.21.0)
+    ddtrace (1.21.1)
       datadog-ci (~> 0.8.1)
       debase-ruby_core_source (= 3.3.1)
       libdatadog (~> 6.0.0.2.0)

--- a/gemfiles/jruby_9.4_contrib_old.gemfile.lock
+++ b/gemfiles/jruby_9.4_contrib_old.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    ddtrace (1.21.0)
+    ddtrace (1.21.1)
       datadog-ci (~> 0.8.1)
       debase-ruby_core_source (= 3.3.1)
       libdatadog (~> 6.0.0.2.0)

--- a/gemfiles/jruby_9.4_core_old.gemfile.lock
+++ b/gemfiles/jruby_9.4_core_old.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    ddtrace (1.21.0)
+    ddtrace (1.21.1)
       datadog-ci (~> 0.8.1)
       debase-ruby_core_source (= 3.3.1)
       libdatadog (~> 6.0.0.2.0)

--- a/gemfiles/jruby_9.4_elasticsearch_7.gemfile.lock
+++ b/gemfiles/jruby_9.4_elasticsearch_7.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    ddtrace (1.21.0)
+    ddtrace (1.21.1)
       datadog-ci (~> 0.8.1)
       debase-ruby_core_source (= 3.3.1)
       libdatadog (~> 6.0.0.2.0)

--- a/gemfiles/jruby_9.4_elasticsearch_8.gemfile.lock
+++ b/gemfiles/jruby_9.4_elasticsearch_8.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    ddtrace (1.21.0)
+    ddtrace (1.21.1)
       datadog-ci (~> 0.8.1)
       debase-ruby_core_source (= 3.3.1)
       libdatadog (~> 6.0.0.2.0)

--- a/gemfiles/jruby_9.4_graphql_1.12.gemfile.lock
+++ b/gemfiles/jruby_9.4_graphql_1.12.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    ddtrace (1.21.0)
+    ddtrace (1.21.1)
       datadog-ci (~> 0.8.1)
       debase-ruby_core_source (= 3.3.1)
       libdatadog (~> 6.0.0.2.0)

--- a/gemfiles/jruby_9.4_graphql_1.13.gemfile.lock
+++ b/gemfiles/jruby_9.4_graphql_1.13.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    ddtrace (1.21.0)
+    ddtrace (1.21.1)
       datadog-ci (~> 0.8.1)
       debase-ruby_core_source (= 3.3.1)
       libdatadog (~> 6.0.0.2.0)

--- a/gemfiles/jruby_9.4_graphql_2.0.gemfile.lock
+++ b/gemfiles/jruby_9.4_graphql_2.0.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    ddtrace (1.21.0)
+    ddtrace (1.21.1)
       datadog-ci (~> 0.8.1)
       debase-ruby_core_source (= 3.3.1)
       libdatadog (~> 6.0.0.2.0)

--- a/gemfiles/jruby_9.4_graphql_2.1.gemfile.lock
+++ b/gemfiles/jruby_9.4_graphql_2.1.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    ddtrace (1.21.0)
+    ddtrace (1.21.1)
       datadog-ci (~> 0.8.1)
       debase-ruby_core_source (= 3.3.1)
       libdatadog (~> 6.0.0.2.0)

--- a/gemfiles/jruby_9.4_graphql_2.2.gemfile.lock
+++ b/gemfiles/jruby_9.4_graphql_2.2.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    ddtrace (1.21.0)
+    ddtrace (1.21.1)
       datadog-ci (~> 0.8.1)
       debase-ruby_core_source (= 3.3.1)
       libdatadog (~> 6.0.0.2.0)

--- a/gemfiles/jruby_9.4_http.gemfile.lock
+++ b/gemfiles/jruby_9.4_http.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    ddtrace (1.21.0)
+    ddtrace (1.21.1)
       datadog-ci (~> 0.8.1)
       debase-ruby_core_source (= 3.3.1)
       libdatadog (~> 6.0.0.2.0)

--- a/gemfiles/jruby_9.4_multi_rack_app.gemfile.lock
+++ b/gemfiles/jruby_9.4_multi_rack_app.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    ddtrace (1.21.0)
+    ddtrace (1.21.1)
       datadog-ci (~> 0.8.1)
       debase-ruby_core_source (= 3.3.1)
       libdatadog (~> 6.0.0.2.0)

--- a/gemfiles/jruby_9.4_opensearch_2.gemfile.lock
+++ b/gemfiles/jruby_9.4_opensearch_2.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    ddtrace (1.21.0)
+    ddtrace (1.21.1)
       datadog-ci (~> 0.8.1)
       debase-ruby_core_source (= 3.3.1)
       libdatadog (~> 6.0.0.2.0)

--- a/gemfiles/jruby_9.4_opensearch_3.gemfile.lock
+++ b/gemfiles/jruby_9.4_opensearch_3.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    ddtrace (1.21.0)
+    ddtrace (1.21.1)
       datadog-ci (~> 0.8.1)
       debase-ruby_core_source (= 3.3.1)
       libdatadog (~> 6.0.0.2.0)

--- a/gemfiles/jruby_9.4_opentracing.gemfile.lock
+++ b/gemfiles/jruby_9.4_opentracing.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    ddtrace (1.21.0)
+    ddtrace (1.21.1)
       datadog-ci (~> 0.8.1)
       debase-ruby_core_source (= 3.3.1)
       libdatadog (~> 6.0.0.2.0)

--- a/gemfiles/jruby_9.4_rack_1.gemfile.lock
+++ b/gemfiles/jruby_9.4_rack_1.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    ddtrace (1.21.0)
+    ddtrace (1.21.1)
       datadog-ci (~> 0.8.1)
       debase-ruby_core_source (= 3.3.1)
       libdatadog (~> 6.0.0.2.0)

--- a/gemfiles/jruby_9.4_rack_2.gemfile.lock
+++ b/gemfiles/jruby_9.4_rack_2.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    ddtrace (1.21.0)
+    ddtrace (1.21.1)
       datadog-ci (~> 0.8.1)
       debase-ruby_core_source (= 3.3.1)
       libdatadog (~> 6.0.0.2.0)

--- a/gemfiles/jruby_9.4_rack_3.gemfile.lock
+++ b/gemfiles/jruby_9.4_rack_3.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    ddtrace (1.21.0)
+    ddtrace (1.21.1)
       datadog-ci (~> 0.8.1)
       debase-ruby_core_source (= 3.3.1)
       libdatadog (~> 6.0.0.2.0)

--- a/gemfiles/jruby_9.4_rails61_mysql2.gemfile.lock
+++ b/gemfiles/jruby_9.4_rails61_mysql2.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    ddtrace (1.21.0)
+    ddtrace (1.21.1)
       datadog-ci (~> 0.8.1)
       debase-ruby_core_source (= 3.3.1)
       libdatadog (~> 6.0.0.2.0)

--- a/gemfiles/jruby_9.4_rails61_postgres.gemfile.lock
+++ b/gemfiles/jruby_9.4_rails61_postgres.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    ddtrace (1.21.0)
+    ddtrace (1.21.1)
       datadog-ci (~> 0.8.1)
       debase-ruby_core_source (= 3.3.1)
       libdatadog (~> 6.0.0.2.0)

--- a/gemfiles/jruby_9.4_rails61_postgres_redis.gemfile.lock
+++ b/gemfiles/jruby_9.4_rails61_postgres_redis.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    ddtrace (1.21.0)
+    ddtrace (1.21.1)
       datadog-ci (~> 0.8.1)
       debase-ruby_core_source (= 3.3.1)
       libdatadog (~> 6.0.0.2.0)

--- a/gemfiles/jruby_9.4_rails61_postgres_sidekiq.gemfile.lock
+++ b/gemfiles/jruby_9.4_rails61_postgres_sidekiq.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    ddtrace (1.21.0)
+    ddtrace (1.21.1)
       datadog-ci (~> 0.8.1)
       debase-ruby_core_source (= 3.3.1)
       libdatadog (~> 6.0.0.2.0)

--- a/gemfiles/jruby_9.4_rails61_semantic_logger.gemfile.lock
+++ b/gemfiles/jruby_9.4_rails61_semantic_logger.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    ddtrace (1.21.0)
+    ddtrace (1.21.1)
       datadog-ci (~> 0.8.1)
       debase-ruby_core_source (= 3.3.1)
       libdatadog (~> 6.0.0.2.0)

--- a/gemfiles/jruby_9.4_redis_3.gemfile.lock
+++ b/gemfiles/jruby_9.4_redis_3.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    ddtrace (1.21.0)
+    ddtrace (1.21.1)
       datadog-ci (~> 0.8.1)
       debase-ruby_core_source (= 3.3.1)
       libdatadog (~> 6.0.0.2.0)

--- a/gemfiles/jruby_9.4_redis_4.gemfile.lock
+++ b/gemfiles/jruby_9.4_redis_4.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    ddtrace (1.21.0)
+    ddtrace (1.21.1)
       datadog-ci (~> 0.8.1)
       debase-ruby_core_source (= 3.3.1)
       libdatadog (~> 6.0.0.2.0)

--- a/gemfiles/jruby_9.4_redis_5.gemfile.lock
+++ b/gemfiles/jruby_9.4_redis_5.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    ddtrace (1.21.0)
+    ddtrace (1.21.1)
       datadog-ci (~> 0.8.1)
       debase-ruby_core_source (= 3.3.1)
       libdatadog (~> 6.0.0.2.0)

--- a/gemfiles/jruby_9.4_relational_db.gemfile.lock
+++ b/gemfiles/jruby_9.4_relational_db.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    ddtrace (1.21.0)
+    ddtrace (1.21.1)
       datadog-ci (~> 0.8.1)
       debase-ruby_core_source (= 3.3.1)
       libdatadog (~> 6.0.0.2.0)

--- a/gemfiles/jruby_9.4_resque2_redis3.gemfile.lock
+++ b/gemfiles/jruby_9.4_resque2_redis3.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    ddtrace (1.21.0)
+    ddtrace (1.21.1)
       datadog-ci (~> 0.8.1)
       debase-ruby_core_source (= 3.3.1)
       libdatadog (~> 6.0.0.2.0)

--- a/gemfiles/jruby_9.4_resque2_redis4.gemfile.lock
+++ b/gemfiles/jruby_9.4_resque2_redis4.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    ddtrace (1.21.0)
+    ddtrace (1.21.1)
       datadog-ci (~> 0.8.1)
       debase-ruby_core_source (= 3.3.1)
       libdatadog (~> 6.0.0.2.0)

--- a/gemfiles/jruby_9.4_sinatra.gemfile.lock
+++ b/gemfiles/jruby_9.4_sinatra.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    ddtrace (1.21.0)
+    ddtrace (1.21.1)
       datadog-ci (~> 0.8.1)
       debase-ruby_core_source (= 3.3.1)
       libdatadog (~> 6.0.0.2.0)

--- a/gemfiles/ruby_2.1_activesupport.gemfile.lock
+++ b/gemfiles/ruby_2.1_activesupport.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    ddtrace (1.21.0)
+    ddtrace (1.21.1)
       datadog-ci (~> 0.8.1)
       debase-ruby_core_source (= 3.3.1)
       libdatadog (~> 6.0.0.2.0)

--- a/gemfiles/ruby_2.1_aws.gemfile.lock
+++ b/gemfiles/ruby_2.1_aws.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    ddtrace (1.21.0)
+    ddtrace (1.21.1)
       datadog-ci (~> 0.8.1)
       debase-ruby_core_source (= 3.3.1)
       libdatadog (~> 6.0.0.2.0)

--- a/gemfiles/ruby_2.1_contrib.gemfile.lock
+++ b/gemfiles/ruby_2.1_contrib.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    ddtrace (1.21.0)
+    ddtrace (1.21.1)
       datadog-ci (~> 0.8.1)
       debase-ruby_core_source (= 3.3.1)
       libdatadog (~> 6.0.0.2.0)

--- a/gemfiles/ruby_2.1_core_old.gemfile.lock
+++ b/gemfiles/ruby_2.1_core_old.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    ddtrace (1.21.0)
+    ddtrace (1.21.1)
       datadog-ci (~> 0.8.1)
       debase-ruby_core_source (= 3.3.1)
       libdatadog (~> 6.0.0.2.0)

--- a/gemfiles/ruby_2.1_elasticsearch_7.gemfile.lock
+++ b/gemfiles/ruby_2.1_elasticsearch_7.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    ddtrace (1.21.0)
+    ddtrace (1.21.1)
       datadog-ci (~> 0.8.1)
       debase-ruby_core_source (= 3.3.1)
       libdatadog (~> 6.0.0.2.0)

--- a/gemfiles/ruby_2.1_http.gemfile.lock
+++ b/gemfiles/ruby_2.1_http.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    ddtrace (1.21.0)
+    ddtrace (1.21.1)
       datadog-ci (~> 0.8.1)
       debase-ruby_core_source (= 3.3.1)
       libdatadog (~> 6.0.0.2.0)

--- a/gemfiles/ruby_2.1_opentracing.gemfile.lock
+++ b/gemfiles/ruby_2.1_opentracing.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    ddtrace (1.21.0)
+    ddtrace (1.21.1)
       datadog-ci (~> 0.8.1)
       debase-ruby_core_source (= 3.3.1)
       libdatadog (~> 6.0.0.2.0)

--- a/gemfiles/ruby_2.1_rack_1.gemfile.lock
+++ b/gemfiles/ruby_2.1_rack_1.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    ddtrace (1.21.0)
+    ddtrace (1.21.1)
       datadog-ci (~> 0.8.1)
       debase-ruby_core_source (= 3.3.1)
       libdatadog (~> 6.0.0.2.0)

--- a/gemfiles/ruby_2.1_rails32_mysql2.gemfile.lock
+++ b/gemfiles/ruby_2.1_rails32_mysql2.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    ddtrace (1.21.0)
+    ddtrace (1.21.1)
       datadog-ci (~> 0.8.1)
       debase-ruby_core_source (= 3.3.1)
       libdatadog (~> 6.0.0.2.0)

--- a/gemfiles/ruby_2.1_rails32_postgres.gemfile.lock
+++ b/gemfiles/ruby_2.1_rails32_postgres.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    ddtrace (1.21.0)
+    ddtrace (1.21.1)
       datadog-ci (~> 0.8.1)
       debase-ruby_core_source (= 3.3.1)
       libdatadog (~> 6.0.0.2.0)

--- a/gemfiles/ruby_2.1_rails32_postgres_redis.gemfile.lock
+++ b/gemfiles/ruby_2.1_rails32_postgres_redis.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    ddtrace (1.21.0)
+    ddtrace (1.21.1)
       datadog-ci (~> 0.8.1)
       debase-ruby_core_source (= 3.3.1)
       libdatadog (~> 6.0.0.2.0)

--- a/gemfiles/ruby_2.1_rails32_postgres_sidekiq.gemfile.lock
+++ b/gemfiles/ruby_2.1_rails32_postgres_sidekiq.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    ddtrace (1.21.0)
+    ddtrace (1.21.1)
       datadog-ci (~> 0.8.1)
       debase-ruby_core_source (= 3.3.1)
       libdatadog (~> 6.0.0.2.0)

--- a/gemfiles/ruby_2.1_rails4_mysql2.gemfile.lock
+++ b/gemfiles/ruby_2.1_rails4_mysql2.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    ddtrace (1.21.0)
+    ddtrace (1.21.1)
       datadog-ci (~> 0.8.1)
       debase-ruby_core_source (= 3.3.1)
       libdatadog (~> 6.0.0.2.0)

--- a/gemfiles/ruby_2.1_rails4_postgres.gemfile.lock
+++ b/gemfiles/ruby_2.1_rails4_postgres.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    ddtrace (1.21.0)
+    ddtrace (1.21.1)
       datadog-ci (~> 0.8.1)
       debase-ruby_core_source (= 3.3.1)
       libdatadog (~> 6.0.0.2.0)

--- a/gemfiles/ruby_2.1_rails4_postgres_redis.gemfile.lock
+++ b/gemfiles/ruby_2.1_rails4_postgres_redis.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    ddtrace (1.21.0)
+    ddtrace (1.21.1)
       datadog-ci (~> 0.8.1)
       debase-ruby_core_source (= 3.3.1)
       libdatadog (~> 6.0.0.2.0)

--- a/gemfiles/ruby_2.1_rails4_semantic_logger.gemfile.lock
+++ b/gemfiles/ruby_2.1_rails4_semantic_logger.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    ddtrace (1.21.0)
+    ddtrace (1.21.1)
       datadog-ci (~> 0.8.1)
       debase-ruby_core_source (= 3.3.1)
       libdatadog (~> 6.0.0.2.0)

--- a/gemfiles/ruby_2.1_redis_3.gemfile.lock
+++ b/gemfiles/ruby_2.1_redis_3.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    ddtrace (1.21.0)
+    ddtrace (1.21.1)
       datadog-ci (~> 0.8.1)
       debase-ruby_core_source (= 3.3.1)
       libdatadog (~> 6.0.0.2.0)

--- a/gemfiles/ruby_2.1_relational_db.gemfile.lock
+++ b/gemfiles/ruby_2.1_relational_db.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    ddtrace (1.21.0)
+    ddtrace (1.21.1)
       datadog-ci (~> 0.8.1)
       debase-ruby_core_source (= 3.3.1)
       libdatadog (~> 6.0.0.2.0)

--- a/gemfiles/ruby_2.1_sinatra.gemfile.lock
+++ b/gemfiles/ruby_2.1_sinatra.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    ddtrace (1.21.0)
+    ddtrace (1.21.1)
       datadog-ci (~> 0.8.1)
       debase-ruby_core_source (= 3.3.1)
       libdatadog (~> 6.0.0.2.0)

--- a/gemfiles/ruby_2.2_activesupport.gemfile.lock
+++ b/gemfiles/ruby_2.2_activesupport.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    ddtrace (1.21.0)
+    ddtrace (1.21.1)
       datadog-ci (~> 0.8.1)
       debase-ruby_core_source (= 3.3.1)
       libdatadog (~> 6.0.0.2.0)

--- a/gemfiles/ruby_2.2_aws.gemfile.lock
+++ b/gemfiles/ruby_2.2_aws.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    ddtrace (1.21.0)
+    ddtrace (1.21.1)
       datadog-ci (~> 0.8.1)
       debase-ruby_core_source (= 3.3.1)
       libdatadog (~> 6.0.0.2.0)

--- a/gemfiles/ruby_2.2_contrib.gemfile.lock
+++ b/gemfiles/ruby_2.2_contrib.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    ddtrace (1.21.0)
+    ddtrace (1.21.1)
       datadog-ci (~> 0.8.1)
       debase-ruby_core_source (= 3.3.1)
       libdatadog (~> 6.0.0.2.0)

--- a/gemfiles/ruby_2.2_core_old.gemfile.lock
+++ b/gemfiles/ruby_2.2_core_old.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    ddtrace (1.21.0)
+    ddtrace (1.21.1)
       datadog-ci (~> 0.8.1)
       debase-ruby_core_source (= 3.3.1)
       libdatadog (~> 6.0.0.2.0)

--- a/gemfiles/ruby_2.2_elasticsearch_7.gemfile.lock
+++ b/gemfiles/ruby_2.2_elasticsearch_7.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    ddtrace (1.21.0)
+    ddtrace (1.21.1)
       datadog-ci (~> 0.8.1)
       debase-ruby_core_source (= 3.3.1)
       libdatadog (~> 6.0.0.2.0)

--- a/gemfiles/ruby_2.2_graphql_1.12.gemfile.lock
+++ b/gemfiles/ruby_2.2_graphql_1.12.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    ddtrace (1.21.0)
+    ddtrace (1.21.1)
       datadog-ci (~> 0.8.1)
       debase-ruby_core_source (= 3.3.1)
       libdatadog (~> 6.0.0.2.0)

--- a/gemfiles/ruby_2.2_http.gemfile.lock
+++ b/gemfiles/ruby_2.2_http.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    ddtrace (1.21.0)
+    ddtrace (1.21.1)
       datadog-ci (~> 0.8.1)
       debase-ruby_core_source (= 3.3.1)
       libdatadog (~> 6.0.0.2.0)

--- a/gemfiles/ruby_2.2_opentracing.gemfile.lock
+++ b/gemfiles/ruby_2.2_opentracing.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    ddtrace (1.21.0)
+    ddtrace (1.21.1)
       datadog-ci (~> 0.8.1)
       debase-ruby_core_source (= 3.3.1)
       libdatadog (~> 6.0.0.2.0)

--- a/gemfiles/ruby_2.2_rack_1.gemfile.lock
+++ b/gemfiles/ruby_2.2_rack_1.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    ddtrace (1.21.0)
+    ddtrace (1.21.1)
       datadog-ci (~> 0.8.1)
       debase-ruby_core_source (= 3.3.1)
       libdatadog (~> 6.0.0.2.0)

--- a/gemfiles/ruby_2.2_rails32_mysql2.gemfile.lock
+++ b/gemfiles/ruby_2.2_rails32_mysql2.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    ddtrace (1.21.0)
+    ddtrace (1.21.1)
       datadog-ci (~> 0.8.1)
       debase-ruby_core_source (= 3.3.1)
       libdatadog (~> 6.0.0.2.0)

--- a/gemfiles/ruby_2.2_rails32_postgres.gemfile.lock
+++ b/gemfiles/ruby_2.2_rails32_postgres.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    ddtrace (1.21.0)
+    ddtrace (1.21.1)
       datadog-ci (~> 0.8.1)
       debase-ruby_core_source (= 3.3.1)
       libdatadog (~> 6.0.0.2.0)

--- a/gemfiles/ruby_2.2_rails32_postgres_redis.gemfile.lock
+++ b/gemfiles/ruby_2.2_rails32_postgres_redis.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    ddtrace (1.21.0)
+    ddtrace (1.21.1)
       datadog-ci (~> 0.8.1)
       debase-ruby_core_source (= 3.3.1)
       libdatadog (~> 6.0.0.2.0)

--- a/gemfiles/ruby_2.2_rails32_postgres_sidekiq.gemfile.lock
+++ b/gemfiles/ruby_2.2_rails32_postgres_sidekiq.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    ddtrace (1.21.0)
+    ddtrace (1.21.1)
       datadog-ci (~> 0.8.1)
       debase-ruby_core_source (= 3.3.1)
       libdatadog (~> 6.0.0.2.0)

--- a/gemfiles/ruby_2.2_rails4_mysql2.gemfile.lock
+++ b/gemfiles/ruby_2.2_rails4_mysql2.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    ddtrace (1.21.0)
+    ddtrace (1.21.1)
       datadog-ci (~> 0.8.1)
       debase-ruby_core_source (= 3.3.1)
       libdatadog (~> 6.0.0.2.0)

--- a/gemfiles/ruby_2.2_rails4_postgres.gemfile.lock
+++ b/gemfiles/ruby_2.2_rails4_postgres.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    ddtrace (1.21.0)
+    ddtrace (1.21.1)
       datadog-ci (~> 0.8.1)
       debase-ruby_core_source (= 3.3.1)
       libdatadog (~> 6.0.0.2.0)

--- a/gemfiles/ruby_2.2_rails4_postgres_redis.gemfile.lock
+++ b/gemfiles/ruby_2.2_rails4_postgres_redis.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    ddtrace (1.21.0)
+    ddtrace (1.21.1)
       datadog-ci (~> 0.8.1)
       debase-ruby_core_source (= 3.3.1)
       libdatadog (~> 6.0.0.2.0)

--- a/gemfiles/ruby_2.2_rails4_postgres_sidekiq.gemfile.lock
+++ b/gemfiles/ruby_2.2_rails4_postgres_sidekiq.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    ddtrace (1.21.0)
+    ddtrace (1.21.1)
       datadog-ci (~> 0.8.1)
       debase-ruby_core_source (= 3.3.1)
       libdatadog (~> 6.0.0.2.0)

--- a/gemfiles/ruby_2.2_rails4_semantic_logger.gemfile.lock
+++ b/gemfiles/ruby_2.2_rails4_semantic_logger.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    ddtrace (1.21.0)
+    ddtrace (1.21.1)
       datadog-ci (~> 0.8.1)
       debase-ruby_core_source (= 3.3.1)
       libdatadog (~> 6.0.0.2.0)

--- a/gemfiles/ruby_2.2_rails5_mysql2.gemfile.lock
+++ b/gemfiles/ruby_2.2_rails5_mysql2.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    ddtrace (1.21.0)
+    ddtrace (1.21.1)
       datadog-ci (~> 0.8.1)
       debase-ruby_core_source (= 3.3.1)
       libdatadog (~> 6.0.0.2.0)

--- a/gemfiles/ruby_2.2_rails5_postgres.gemfile.lock
+++ b/gemfiles/ruby_2.2_rails5_postgres.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    ddtrace (1.21.0)
+    ddtrace (1.21.1)
       datadog-ci (~> 0.8.1)
       debase-ruby_core_source (= 3.3.1)
       libdatadog (~> 6.0.0.2.0)

--- a/gemfiles/ruby_2.2_rails5_postgres_redis.gemfile.lock
+++ b/gemfiles/ruby_2.2_rails5_postgres_redis.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    ddtrace (1.21.0)
+    ddtrace (1.21.1)
       datadog-ci (~> 0.8.1)
       debase-ruby_core_source (= 3.3.1)
       libdatadog (~> 6.0.0.2.0)

--- a/gemfiles/ruby_2.2_rails5_postgres_redis_activesupport.gemfile.lock
+++ b/gemfiles/ruby_2.2_rails5_postgres_redis_activesupport.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    ddtrace (1.21.0)
+    ddtrace (1.21.1)
       datadog-ci (~> 0.8.1)
       debase-ruby_core_source (= 3.3.1)
       libdatadog (~> 6.0.0.2.0)

--- a/gemfiles/ruby_2.2_rails5_postgres_sidekiq.gemfile.lock
+++ b/gemfiles/ruby_2.2_rails5_postgres_sidekiq.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    ddtrace (1.21.0)
+    ddtrace (1.21.1)
       datadog-ci (~> 0.8.1)
       debase-ruby_core_source (= 3.3.1)
       libdatadog (~> 6.0.0.2.0)

--- a/gemfiles/ruby_2.2_rails5_semantic_logger.gemfile.lock
+++ b/gemfiles/ruby_2.2_rails5_semantic_logger.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    ddtrace (1.21.0)
+    ddtrace (1.21.1)
       datadog-ci (~> 0.8.1)
       debase-ruby_core_source (= 3.3.1)
       libdatadog (~> 6.0.0.2.0)

--- a/gemfiles/ruby_2.2_redis_3.gemfile.lock
+++ b/gemfiles/ruby_2.2_redis_3.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    ddtrace (1.21.0)
+    ddtrace (1.21.1)
       datadog-ci (~> 0.8.1)
       debase-ruby_core_source (= 3.3.1)
       libdatadog (~> 6.0.0.2.0)

--- a/gemfiles/ruby_2.2_relational_db.gemfile.lock
+++ b/gemfiles/ruby_2.2_relational_db.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    ddtrace (1.21.0)
+    ddtrace (1.21.1)
       datadog-ci (~> 0.8.1)
       debase-ruby_core_source (= 3.3.1)
       libdatadog (~> 6.0.0.2.0)

--- a/gemfiles/ruby_2.2_sinatra.gemfile.lock
+++ b/gemfiles/ruby_2.2_sinatra.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    ddtrace (1.21.0)
+    ddtrace (1.21.1)
       datadog-ci (~> 0.8.1)
       debase-ruby_core_source (= 3.3.1)
       libdatadog (~> 6.0.0.2.0)

--- a/gemfiles/ruby_2.3_activerecord_3.gemfile.lock
+++ b/gemfiles/ruby_2.3_activerecord_3.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    ddtrace (1.21.0)
+    ddtrace (1.21.1)
       datadog-ci (~> 0.8.1)
       debase-ruby_core_source (= 3.3.1)
       libdatadog (~> 6.0.0.2.0)

--- a/gemfiles/ruby_2.3_activesupport.gemfile.lock
+++ b/gemfiles/ruby_2.3_activesupport.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    ddtrace (1.21.0)
+    ddtrace (1.21.1)
       datadog-ci (~> 0.8.1)
       debase-ruby_core_source (= 3.3.1)
       libdatadog (~> 6.0.0.2.0)

--- a/gemfiles/ruby_2.3_aws.gemfile.lock
+++ b/gemfiles/ruby_2.3_aws.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    ddtrace (1.21.0)
+    ddtrace (1.21.1)
       datadog-ci (~> 0.8.1)
       debase-ruby_core_source (= 3.3.1)
       libdatadog (~> 6.0.0.2.0)

--- a/gemfiles/ruby_2.3_contrib.gemfile.lock
+++ b/gemfiles/ruby_2.3_contrib.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    ddtrace (1.21.0)
+    ddtrace (1.21.1)
       datadog-ci (~> 0.8.1)
       debase-ruby_core_source (= 3.3.1)
       libdatadog (~> 6.0.0.2.0)

--- a/gemfiles/ruby_2.3_contrib_old.gemfile.lock
+++ b/gemfiles/ruby_2.3_contrib_old.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    ddtrace (1.21.0)
+    ddtrace (1.21.1)
       datadog-ci (~> 0.8.1)
       debase-ruby_core_source (= 3.3.1)
       libdatadog (~> 6.0.0.2.0)

--- a/gemfiles/ruby_2.3_core_old.gemfile.lock
+++ b/gemfiles/ruby_2.3_core_old.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    ddtrace (1.21.0)
+    ddtrace (1.21.1)
       datadog-ci (~> 0.8.1)
       debase-ruby_core_source (= 3.3.1)
       libdatadog (~> 6.0.0.2.0)

--- a/gemfiles/ruby_2.3_elasticsearch_7.gemfile.lock
+++ b/gemfiles/ruby_2.3_elasticsearch_7.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    ddtrace (1.21.0)
+    ddtrace (1.21.1)
       datadog-ci (~> 0.8.1)
       debase-ruby_core_source (= 3.3.1)
       libdatadog (~> 6.0.0.2.0)

--- a/gemfiles/ruby_2.3_graphql_1.12.gemfile.lock
+++ b/gemfiles/ruby_2.3_graphql_1.12.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    ddtrace (1.21.0)
+    ddtrace (1.21.1)
       datadog-ci (~> 0.8.1)
       debase-ruby_core_source (= 3.3.1)
       libdatadog (~> 6.0.0.2.0)

--- a/gemfiles/ruby_2.3_hanami_1.gemfile.lock
+++ b/gemfiles/ruby_2.3_hanami_1.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    ddtrace (1.21.0)
+    ddtrace (1.21.1)
       datadog-ci (~> 0.8.1)
       debase-ruby_core_source (= 3.3.1)
       libdatadog (~> 6.0.0.2.0)

--- a/gemfiles/ruby_2.3_http.gemfile.lock
+++ b/gemfiles/ruby_2.3_http.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    ddtrace (1.21.0)
+    ddtrace (1.21.1)
       datadog-ci (~> 0.8.1)
       debase-ruby_core_source (= 3.3.1)
       libdatadog (~> 6.0.0.2.0)

--- a/gemfiles/ruby_2.3_opentracing.gemfile.lock
+++ b/gemfiles/ruby_2.3_opentracing.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    ddtrace (1.21.0)
+    ddtrace (1.21.1)
       datadog-ci (~> 0.8.1)
       debase-ruby_core_source (= 3.3.1)
       libdatadog (~> 6.0.0.2.0)

--- a/gemfiles/ruby_2.3_rack_1.gemfile.lock
+++ b/gemfiles/ruby_2.3_rack_1.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    ddtrace (1.21.0)
+    ddtrace (1.21.1)
       datadog-ci (~> 0.8.1)
       debase-ruby_core_source (= 3.3.1)
       libdatadog (~> 6.0.0.2.0)

--- a/gemfiles/ruby_2.3_rack_2.gemfile.lock
+++ b/gemfiles/ruby_2.3_rack_2.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    ddtrace (1.21.0)
+    ddtrace (1.21.1)
       datadog-ci (~> 0.8.1)
       debase-ruby_core_source (= 3.3.1)
       libdatadog (~> 6.0.0.2.0)

--- a/gemfiles/ruby_2.3_rails32_mysql2.gemfile.lock
+++ b/gemfiles/ruby_2.3_rails32_mysql2.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    ddtrace (1.21.0)
+    ddtrace (1.21.1)
       datadog-ci (~> 0.8.1)
       debase-ruby_core_source (= 3.3.1)
       libdatadog (~> 6.0.0.2.0)

--- a/gemfiles/ruby_2.3_rails32_postgres.gemfile.lock
+++ b/gemfiles/ruby_2.3_rails32_postgres.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    ddtrace (1.21.0)
+    ddtrace (1.21.1)
       datadog-ci (~> 0.8.1)
       debase-ruby_core_source (= 3.3.1)
       libdatadog (~> 6.0.0.2.0)

--- a/gemfiles/ruby_2.3_rails32_postgres_redis.gemfile.lock
+++ b/gemfiles/ruby_2.3_rails32_postgres_redis.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    ddtrace (1.21.0)
+    ddtrace (1.21.1)
       datadog-ci (~> 0.8.1)
       debase-ruby_core_source (= 3.3.1)
       libdatadog (~> 6.0.0.2.0)

--- a/gemfiles/ruby_2.3_rails32_postgres_sidekiq.gemfile.lock
+++ b/gemfiles/ruby_2.3_rails32_postgres_sidekiq.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    ddtrace (1.21.0)
+    ddtrace (1.21.1)
       datadog-ci (~> 0.8.1)
       debase-ruby_core_source (= 3.3.1)
       libdatadog (~> 6.0.0.2.0)

--- a/gemfiles/ruby_2.3_rails4_mysql2.gemfile.lock
+++ b/gemfiles/ruby_2.3_rails4_mysql2.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    ddtrace (1.21.0)
+    ddtrace (1.21.1)
       datadog-ci (~> 0.8.1)
       debase-ruby_core_source (= 3.3.1)
       libdatadog (~> 6.0.0.2.0)

--- a/gemfiles/ruby_2.3_rails4_postgres.gemfile.lock
+++ b/gemfiles/ruby_2.3_rails4_postgres.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    ddtrace (1.21.0)
+    ddtrace (1.21.1)
       datadog-ci (~> 0.8.1)
       debase-ruby_core_source (= 3.3.1)
       libdatadog (~> 6.0.0.2.0)

--- a/gemfiles/ruby_2.3_rails4_postgres_redis.gemfile.lock
+++ b/gemfiles/ruby_2.3_rails4_postgres_redis.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    ddtrace (1.21.0)
+    ddtrace (1.21.1)
       datadog-ci (~> 0.8.1)
       debase-ruby_core_source (= 3.3.1)
       libdatadog (~> 6.0.0.2.0)

--- a/gemfiles/ruby_2.3_rails4_postgres_sidekiq.gemfile.lock
+++ b/gemfiles/ruby_2.3_rails4_postgres_sidekiq.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    ddtrace (1.21.0)
+    ddtrace (1.21.1)
       datadog-ci (~> 0.8.1)
       debase-ruby_core_source (= 3.3.1)
       libdatadog (~> 6.0.0.2.0)

--- a/gemfiles/ruby_2.3_rails4_semantic_logger.gemfile.lock
+++ b/gemfiles/ruby_2.3_rails4_semantic_logger.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    ddtrace (1.21.0)
+    ddtrace (1.21.1)
       datadog-ci (~> 0.8.1)
       debase-ruby_core_source (= 3.3.1)
       libdatadog (~> 6.0.0.2.0)

--- a/gemfiles/ruby_2.3_rails5_mysql2.gemfile.lock
+++ b/gemfiles/ruby_2.3_rails5_mysql2.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    ddtrace (1.21.0)
+    ddtrace (1.21.1)
       datadog-ci (~> 0.8.1)
       debase-ruby_core_source (= 3.3.1)
       libdatadog (~> 6.0.0.2.0)

--- a/gemfiles/ruby_2.3_rails5_postgres.gemfile.lock
+++ b/gemfiles/ruby_2.3_rails5_postgres.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    ddtrace (1.21.0)
+    ddtrace (1.21.1)
       datadog-ci (~> 0.8.1)
       debase-ruby_core_source (= 3.3.1)
       libdatadog (~> 6.0.0.2.0)

--- a/gemfiles/ruby_2.3_rails5_postgres_redis.gemfile.lock
+++ b/gemfiles/ruby_2.3_rails5_postgres_redis.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    ddtrace (1.21.0)
+    ddtrace (1.21.1)
       datadog-ci (~> 0.8.1)
       debase-ruby_core_source (= 3.3.1)
       libdatadog (~> 6.0.0.2.0)

--- a/gemfiles/ruby_2.3_rails5_postgres_redis_activesupport.gemfile.lock
+++ b/gemfiles/ruby_2.3_rails5_postgres_redis_activesupport.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    ddtrace (1.21.0)
+    ddtrace (1.21.1)
       datadog-ci (~> 0.8.1)
       debase-ruby_core_source (= 3.3.1)
       libdatadog (~> 6.0.0.2.0)

--- a/gemfiles/ruby_2.3_rails5_postgres_sidekiq.gemfile.lock
+++ b/gemfiles/ruby_2.3_rails5_postgres_sidekiq.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    ddtrace (1.21.0)
+    ddtrace (1.21.1)
       datadog-ci (~> 0.8.1)
       debase-ruby_core_source (= 3.3.1)
       libdatadog (~> 6.0.0.2.0)

--- a/gemfiles/ruby_2.3_rails5_semantic_logger.gemfile.lock
+++ b/gemfiles/ruby_2.3_rails5_semantic_logger.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    ddtrace (1.21.0)
+    ddtrace (1.21.1)
       datadog-ci (~> 0.8.1)
       debase-ruby_core_source (= 3.3.1)
       libdatadog (~> 6.0.0.2.0)

--- a/gemfiles/ruby_2.3_redis_3.gemfile.lock
+++ b/gemfiles/ruby_2.3_redis_3.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    ddtrace (1.21.0)
+    ddtrace (1.21.1)
       datadog-ci (~> 0.8.1)
       debase-ruby_core_source (= 3.3.1)
       libdatadog (~> 6.0.0.2.0)

--- a/gemfiles/ruby_2.3_relational_db.gemfile.lock
+++ b/gemfiles/ruby_2.3_relational_db.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    ddtrace (1.21.0)
+    ddtrace (1.21.1)
       datadog-ci (~> 0.8.1)
       debase-ruby_core_source (= 3.3.1)
       libdatadog (~> 6.0.0.2.0)

--- a/gemfiles/ruby_2.3_resque2_redis3.gemfile.lock
+++ b/gemfiles/ruby_2.3_resque2_redis3.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    ddtrace (1.21.0)
+    ddtrace (1.21.1)
       datadog-ci (~> 0.8.1)
       debase-ruby_core_source (= 3.3.1)
       libdatadog (~> 6.0.0.2.0)

--- a/gemfiles/ruby_2.3_resque2_redis4.gemfile.lock
+++ b/gemfiles/ruby_2.3_resque2_redis4.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    ddtrace (1.21.0)
+    ddtrace (1.21.1)
       datadog-ci (~> 0.8.1)
       debase-ruby_core_source (= 3.3.1)
       libdatadog (~> 6.0.0.2.0)

--- a/gemfiles/ruby_2.3_sinatra.gemfile.lock
+++ b/gemfiles/ruby_2.3_sinatra.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    ddtrace (1.21.0)
+    ddtrace (1.21.1)
       datadog-ci (~> 0.8.1)
       debase-ruby_core_source (= 3.3.1)
       libdatadog (~> 6.0.0.2.0)

--- a/gemfiles/ruby_2.4_activerecord_4.gemfile.lock
+++ b/gemfiles/ruby_2.4_activerecord_4.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    ddtrace (1.21.0)
+    ddtrace (1.21.1)
       datadog-ci (~> 0.8.1)
       debase-ruby_core_source (= 3.3.1)
       libdatadog (~> 6.0.0.2.0)

--- a/gemfiles/ruby_2.4_activesupport.gemfile.lock
+++ b/gemfiles/ruby_2.4_activesupport.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    ddtrace (1.21.0)
+    ddtrace (1.21.1)
       datadog-ci (~> 0.8.1)
       debase-ruby_core_source (= 3.3.1)
       libdatadog (~> 6.0.0.2.0)

--- a/gemfiles/ruby_2.4_aws.gemfile.lock
+++ b/gemfiles/ruby_2.4_aws.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    ddtrace (1.21.0)
+    ddtrace (1.21.1)
       datadog-ci (~> 0.8.1)
       debase-ruby_core_source (= 3.3.1)
       libdatadog (~> 6.0.0.2.0)

--- a/gemfiles/ruby_2.4_contrib.gemfile.lock
+++ b/gemfiles/ruby_2.4_contrib.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    ddtrace (1.21.0)
+    ddtrace (1.21.1)
       datadog-ci (~> 0.8.1)
       debase-ruby_core_source (= 3.3.1)
       libdatadog (~> 6.0.0.2.0)

--- a/gemfiles/ruby_2.4_contrib_old.gemfile.lock
+++ b/gemfiles/ruby_2.4_contrib_old.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    ddtrace (1.21.0)
+    ddtrace (1.21.1)
       datadog-ci (~> 0.8.1)
       debase-ruby_core_source (= 3.3.1)
       libdatadog (~> 6.0.0.2.0)

--- a/gemfiles/ruby_2.4_core_old.gemfile.lock
+++ b/gemfiles/ruby_2.4_core_old.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    ddtrace (1.21.0)
+    ddtrace (1.21.1)
       datadog-ci (~> 0.8.1)
       debase-ruby_core_source (= 3.3.1)
       libdatadog (~> 6.0.0.2.0)

--- a/gemfiles/ruby_2.4_elasticsearch_7.gemfile.lock
+++ b/gemfiles/ruby_2.4_elasticsearch_7.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    ddtrace (1.21.0)
+    ddtrace (1.21.1)
       datadog-ci (~> 0.8.1)
       debase-ruby_core_source (= 3.3.1)
       libdatadog (~> 6.0.0.2.0)

--- a/gemfiles/ruby_2.4_graphql_1.12.gemfile.lock
+++ b/gemfiles/ruby_2.4_graphql_1.12.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    ddtrace (1.21.0)
+    ddtrace (1.21.1)
       datadog-ci (~> 0.8.1)
       debase-ruby_core_source (= 3.3.1)
       libdatadog (~> 6.0.0.2.0)

--- a/gemfiles/ruby_2.4_graphql_1.13.gemfile.lock
+++ b/gemfiles/ruby_2.4_graphql_1.13.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    ddtrace (1.21.0)
+    ddtrace (1.21.1)
       datadog-ci (~> 0.8.1)
       debase-ruby_core_source (= 3.3.1)
       libdatadog (~> 6.0.0.2.0)

--- a/gemfiles/ruby_2.4_graphql_2.0.gemfile.lock
+++ b/gemfiles/ruby_2.4_graphql_2.0.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    ddtrace (1.21.0)
+    ddtrace (1.21.1)
       datadog-ci (~> 0.8.1)
       debase-ruby_core_source (= 3.3.1)
       libdatadog (~> 6.0.0.2.0)

--- a/gemfiles/ruby_2.4_hanami_1.gemfile.lock
+++ b/gemfiles/ruby_2.4_hanami_1.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    ddtrace (1.21.0)
+    ddtrace (1.21.1)
       datadog-ci (~> 0.8.1)
       debase-ruby_core_source (= 3.3.1)
       libdatadog (~> 6.0.0.2.0)

--- a/gemfiles/ruby_2.4_http.gemfile.lock
+++ b/gemfiles/ruby_2.4_http.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    ddtrace (1.21.0)
+    ddtrace (1.21.1)
       datadog-ci (~> 0.8.1)
       debase-ruby_core_source (= 3.3.1)
       libdatadog (~> 6.0.0.2.0)

--- a/gemfiles/ruby_2.4_opensearch_2.gemfile.lock
+++ b/gemfiles/ruby_2.4_opensearch_2.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    ddtrace (1.21.0)
+    ddtrace (1.21.1)
       datadog-ci (~> 0.8.1)
       debase-ruby_core_source (= 3.3.1)
       libdatadog (~> 6.0.0.2.0)

--- a/gemfiles/ruby_2.4_opentracing.gemfile.lock
+++ b/gemfiles/ruby_2.4_opentracing.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    ddtrace (1.21.0)
+    ddtrace (1.21.1)
       datadog-ci (~> 0.8.1)
       debase-ruby_core_source (= 3.3.1)
       libdatadog (~> 6.0.0.2.0)

--- a/gemfiles/ruby_2.4_rack_1.gemfile.lock
+++ b/gemfiles/ruby_2.4_rack_1.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    ddtrace (1.21.0)
+    ddtrace (1.21.1)
       datadog-ci (~> 0.8.1)
       debase-ruby_core_source (= 3.3.1)
       libdatadog (~> 6.0.0.2.0)

--- a/gemfiles/ruby_2.4_rack_2.gemfile.lock
+++ b/gemfiles/ruby_2.4_rack_2.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    ddtrace (1.21.0)
+    ddtrace (1.21.1)
       datadog-ci (~> 0.8.1)
       debase-ruby_core_source (= 3.3.1)
       libdatadog (~> 6.0.0.2.0)

--- a/gemfiles/ruby_2.4_rack_3.gemfile.lock
+++ b/gemfiles/ruby_2.4_rack_3.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    ddtrace (1.21.0)
+    ddtrace (1.21.1)
       datadog-ci (~> 0.8.1)
       debase-ruby_core_source (= 3.3.1)
       libdatadog (~> 6.0.0.2.0)

--- a/gemfiles/ruby_2.4_rails5_mysql2.gemfile.lock
+++ b/gemfiles/ruby_2.4_rails5_mysql2.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    ddtrace (1.21.0)
+    ddtrace (1.21.1)
       datadog-ci (~> 0.8.1)
       debase-ruby_core_source (= 3.3.1)
       libdatadog (~> 6.0.0.2.0)

--- a/gemfiles/ruby_2.4_rails5_postgres.gemfile.lock
+++ b/gemfiles/ruby_2.4_rails5_postgres.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    ddtrace (1.21.0)
+    ddtrace (1.21.1)
       datadog-ci (~> 0.8.1)
       debase-ruby_core_source (= 3.3.1)
       libdatadog (~> 6.0.0.2.0)

--- a/gemfiles/ruby_2.4_rails5_postgres_redis.gemfile.lock
+++ b/gemfiles/ruby_2.4_rails5_postgres_redis.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    ddtrace (1.21.0)
+    ddtrace (1.21.1)
       datadog-ci (~> 0.8.1)
       debase-ruby_core_source (= 3.3.1)
       libdatadog (~> 6.0.0.2.0)

--- a/gemfiles/ruby_2.4_rails5_postgres_redis_activesupport.gemfile.lock
+++ b/gemfiles/ruby_2.4_rails5_postgres_redis_activesupport.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    ddtrace (1.21.0)
+    ddtrace (1.21.1)
       datadog-ci (~> 0.8.1)
       debase-ruby_core_source (= 3.3.1)
       libdatadog (~> 6.0.0.2.0)

--- a/gemfiles/ruby_2.4_rails5_postgres_sidekiq.gemfile.lock
+++ b/gemfiles/ruby_2.4_rails5_postgres_sidekiq.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    ddtrace (1.21.0)
+    ddtrace (1.21.1)
       datadog-ci (~> 0.8.1)
       debase-ruby_core_source (= 3.3.1)
       libdatadog (~> 6.0.0.2.0)

--- a/gemfiles/ruby_2.4_rails5_semantic_logger.gemfile.lock
+++ b/gemfiles/ruby_2.4_rails5_semantic_logger.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    ddtrace (1.21.0)
+    ddtrace (1.21.1)
       datadog-ci (~> 0.8.1)
       debase-ruby_core_source (= 3.3.1)
       libdatadog (~> 6.0.0.2.0)

--- a/gemfiles/ruby_2.4_redis_3.gemfile.lock
+++ b/gemfiles/ruby_2.4_redis_3.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    ddtrace (1.21.0)
+    ddtrace (1.21.1)
       datadog-ci (~> 0.8.1)
       debase-ruby_core_source (= 3.3.1)
       libdatadog (~> 6.0.0.2.0)

--- a/gemfiles/ruby_2.4_redis_4.gemfile.lock
+++ b/gemfiles/ruby_2.4_redis_4.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    ddtrace (1.21.0)
+    ddtrace (1.21.1)
       datadog-ci (~> 0.8.1)
       debase-ruby_core_source (= 3.3.1)
       libdatadog (~> 6.0.0.2.0)

--- a/gemfiles/ruby_2.4_relational_db.gemfile.lock
+++ b/gemfiles/ruby_2.4_relational_db.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    ddtrace (1.21.0)
+    ddtrace (1.21.1)
       datadog-ci (~> 0.8.1)
       debase-ruby_core_source (= 3.3.1)
       libdatadog (~> 6.0.0.2.0)

--- a/gemfiles/ruby_2.4_resque2_redis3.gemfile.lock
+++ b/gemfiles/ruby_2.4_resque2_redis3.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    ddtrace (1.21.0)
+    ddtrace (1.21.1)
       datadog-ci (~> 0.8.1)
       debase-ruby_core_source (= 3.3.1)
       libdatadog (~> 6.0.0.2.0)

--- a/gemfiles/ruby_2.4_resque2_redis4.gemfile.lock
+++ b/gemfiles/ruby_2.4_resque2_redis4.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    ddtrace (1.21.0)
+    ddtrace (1.21.1)
       datadog-ci (~> 0.8.1)
       debase-ruby_core_source (= 3.3.1)
       libdatadog (~> 6.0.0.2.0)

--- a/gemfiles/ruby_2.4_sinatra.gemfile.lock
+++ b/gemfiles/ruby_2.4_sinatra.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    ddtrace (1.21.0)
+    ddtrace (1.21.1)
       datadog-ci (~> 0.8.1)
       debase-ruby_core_source (= 3.3.1)
       libdatadog (~> 6.0.0.2.0)

--- a/gemfiles/ruby_2.5_activesupport.gemfile.lock
+++ b/gemfiles/ruby_2.5_activesupport.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    ddtrace (1.21.0)
+    ddtrace (1.21.1)
       datadog-ci (~> 0.8.1)
       debase-ruby_core_source (= 3.3.1)
       libdatadog (~> 6.0.0.2.0)

--- a/gemfiles/ruby_2.5_aws.gemfile.lock
+++ b/gemfiles/ruby_2.5_aws.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    ddtrace (1.21.0)
+    ddtrace (1.21.1)
       datadog-ci (~> 0.8.1)
       debase-ruby_core_source (= 3.3.1)
       libdatadog (~> 6.0.0.2.0)

--- a/gemfiles/ruby_2.5_contrib.gemfile.lock
+++ b/gemfiles/ruby_2.5_contrib.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    ddtrace (1.21.0)
+    ddtrace (1.21.1)
       datadog-ci (~> 0.8.1)
       debase-ruby_core_source (= 3.3.1)
       libdatadog (~> 6.0.0.2.0)

--- a/gemfiles/ruby_2.5_contrib_old.gemfile.lock
+++ b/gemfiles/ruby_2.5_contrib_old.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    ddtrace (1.21.0)
+    ddtrace (1.21.1)
       datadog-ci (~> 0.8.1)
       debase-ruby_core_source (= 3.3.1)
       libdatadog (~> 6.0.0.2.0)

--- a/gemfiles/ruby_2.5_core_old.gemfile.lock
+++ b/gemfiles/ruby_2.5_core_old.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    ddtrace (1.21.0)
+    ddtrace (1.21.1)
       datadog-ci (~> 0.8.1)
       debase-ruby_core_source (= 3.3.1)
       libdatadog (~> 6.0.0.2.0)

--- a/gemfiles/ruby_2.5_elasticsearch_7.gemfile.lock
+++ b/gemfiles/ruby_2.5_elasticsearch_7.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    ddtrace (1.21.0)
+    ddtrace (1.21.1)
       datadog-ci (~> 0.8.1)
       debase-ruby_core_source (= 3.3.1)
       libdatadog (~> 6.0.0.2.0)

--- a/gemfiles/ruby_2.5_elasticsearch_8.gemfile.lock
+++ b/gemfiles/ruby_2.5_elasticsearch_8.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    ddtrace (1.21.0)
+    ddtrace (1.21.1)
       datadog-ci (~> 0.8.1)
       debase-ruby_core_source (= 3.3.1)
       libdatadog (~> 6.0.0.2.0)

--- a/gemfiles/ruby_2.5_graphql_1.12.gemfile.lock
+++ b/gemfiles/ruby_2.5_graphql_1.12.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    ddtrace (1.21.0)
+    ddtrace (1.21.1)
       datadog-ci (~> 0.8.1)
       debase-ruby_core_source (= 3.3.1)
       libdatadog (~> 6.0.0.2.0)

--- a/gemfiles/ruby_2.5_graphql_1.13.gemfile.lock
+++ b/gemfiles/ruby_2.5_graphql_1.13.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    ddtrace (1.21.0)
+    ddtrace (1.21.1)
       datadog-ci (~> 0.8.1)
       debase-ruby_core_source (= 3.3.1)
       libdatadog (~> 6.0.0.2.0)

--- a/gemfiles/ruby_2.5_graphql_2.0.gemfile.lock
+++ b/gemfiles/ruby_2.5_graphql_2.0.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    ddtrace (1.21.0)
+    ddtrace (1.21.1)
       datadog-ci (~> 0.8.1)
       debase-ruby_core_source (= 3.3.1)
       libdatadog (~> 6.0.0.2.0)

--- a/gemfiles/ruby_2.5_hanami_1.gemfile.lock
+++ b/gemfiles/ruby_2.5_hanami_1.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    ddtrace (1.21.0)
+    ddtrace (1.21.1)
       datadog-ci (~> 0.8.1)
       debase-ruby_core_source (= 3.3.1)
       libdatadog (~> 6.0.0.2.0)

--- a/gemfiles/ruby_2.5_http.gemfile.lock
+++ b/gemfiles/ruby_2.5_http.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    ddtrace (1.21.0)
+    ddtrace (1.21.1)
       datadog-ci (~> 0.8.1)
       debase-ruby_core_source (= 3.3.1)
       libdatadog (~> 6.0.0.2.0)

--- a/gemfiles/ruby_2.5_multi_rack_app.gemfile.lock
+++ b/gemfiles/ruby_2.5_multi_rack_app.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    ddtrace (1.21.0)
+    ddtrace (1.21.1)
       datadog-ci (~> 0.8.1)
       debase-ruby_core_source (= 3.3.1)
       libdatadog (~> 6.0.0.2.0)

--- a/gemfiles/ruby_2.5_opensearch_2.gemfile.lock
+++ b/gemfiles/ruby_2.5_opensearch_2.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    ddtrace (1.21.0)
+    ddtrace (1.21.1)
       datadog-ci (~> 0.8.1)
       debase-ruby_core_source (= 3.3.1)
       libdatadog (~> 6.0.0.2.0)

--- a/gemfiles/ruby_2.5_opensearch_3.gemfile.lock
+++ b/gemfiles/ruby_2.5_opensearch_3.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    ddtrace (1.21.0)
+    ddtrace (1.21.1)
       datadog-ci (~> 0.8.1)
       debase-ruby_core_source (= 3.3.1)
       libdatadog (~> 6.0.0.2.0)

--- a/gemfiles/ruby_2.5_opentracing.gemfile.lock
+++ b/gemfiles/ruby_2.5_opentracing.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    ddtrace (1.21.0)
+    ddtrace (1.21.1)
       datadog-ci (~> 0.8.1)
       debase-ruby_core_source (= 3.3.1)
       libdatadog (~> 6.0.0.2.0)

--- a/gemfiles/ruby_2.5_rack_1.gemfile.lock
+++ b/gemfiles/ruby_2.5_rack_1.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    ddtrace (1.21.0)
+    ddtrace (1.21.1)
       datadog-ci (~> 0.8.1)
       debase-ruby_core_source (= 3.3.1)
       libdatadog (~> 6.0.0.2.0)

--- a/gemfiles/ruby_2.5_rack_2.gemfile.lock
+++ b/gemfiles/ruby_2.5_rack_2.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    ddtrace (1.21.0)
+    ddtrace (1.21.1)
       datadog-ci (~> 0.8.1)
       debase-ruby_core_source (= 3.3.1)
       libdatadog (~> 6.0.0.2.0)

--- a/gemfiles/ruby_2.5_rack_3.gemfile.lock
+++ b/gemfiles/ruby_2.5_rack_3.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    ddtrace (1.21.0)
+    ddtrace (1.21.1)
       datadog-ci (~> 0.8.1)
       debase-ruby_core_source (= 3.3.1)
       libdatadog (~> 6.0.0.2.0)

--- a/gemfiles/ruby_2.5_rails5_mysql2.gemfile.lock
+++ b/gemfiles/ruby_2.5_rails5_mysql2.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    ddtrace (1.21.0)
+    ddtrace (1.21.1)
       datadog-ci (~> 0.8.1)
       debase-ruby_core_source (= 3.3.1)
       libdatadog (~> 6.0.0.2.0)

--- a/gemfiles/ruby_2.5_rails5_postgres.gemfile.lock
+++ b/gemfiles/ruby_2.5_rails5_postgres.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    ddtrace (1.21.0)
+    ddtrace (1.21.1)
       datadog-ci (~> 0.8.1)
       debase-ruby_core_source (= 3.3.1)
       libdatadog (~> 6.0.0.2.0)

--- a/gemfiles/ruby_2.5_rails5_postgres_redis.gemfile.lock
+++ b/gemfiles/ruby_2.5_rails5_postgres_redis.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    ddtrace (1.21.0)
+    ddtrace (1.21.1)
       datadog-ci (~> 0.8.1)
       debase-ruby_core_source (= 3.3.1)
       libdatadog (~> 6.0.0.2.0)

--- a/gemfiles/ruby_2.5_rails5_postgres_redis_activesupport.gemfile.lock
+++ b/gemfiles/ruby_2.5_rails5_postgres_redis_activesupport.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    ddtrace (1.21.0)
+    ddtrace (1.21.1)
       datadog-ci (~> 0.8.1)
       debase-ruby_core_source (= 3.3.1)
       libdatadog (~> 6.0.0.2.0)

--- a/gemfiles/ruby_2.5_rails5_postgres_sidekiq.gemfile.lock
+++ b/gemfiles/ruby_2.5_rails5_postgres_sidekiq.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    ddtrace (1.21.0)
+    ddtrace (1.21.1)
       datadog-ci (~> 0.8.1)
       debase-ruby_core_source (= 3.3.1)
       libdatadog (~> 6.0.0.2.0)

--- a/gemfiles/ruby_2.5_rails5_semantic_logger.gemfile.lock
+++ b/gemfiles/ruby_2.5_rails5_semantic_logger.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    ddtrace (1.21.0)
+    ddtrace (1.21.1)
       datadog-ci (~> 0.8.1)
       debase-ruby_core_source (= 3.3.1)
       libdatadog (~> 6.0.0.2.0)

--- a/gemfiles/ruby_2.5_rails61_mysql2.gemfile.lock
+++ b/gemfiles/ruby_2.5_rails61_mysql2.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    ddtrace (1.21.0)
+    ddtrace (1.21.1)
       datadog-ci (~> 0.8.1)
       debase-ruby_core_source (= 3.3.1)
       libdatadog (~> 6.0.0.2.0)

--- a/gemfiles/ruby_2.5_rails61_postgres.gemfile.lock
+++ b/gemfiles/ruby_2.5_rails61_postgres.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    ddtrace (1.21.0)
+    ddtrace (1.21.1)
       datadog-ci (~> 0.8.1)
       debase-ruby_core_source (= 3.3.1)
       libdatadog (~> 6.0.0.2.0)

--- a/gemfiles/ruby_2.5_rails61_postgres_redis.gemfile.lock
+++ b/gemfiles/ruby_2.5_rails61_postgres_redis.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    ddtrace (1.21.0)
+    ddtrace (1.21.1)
       datadog-ci (~> 0.8.1)
       debase-ruby_core_source (= 3.3.1)
       libdatadog (~> 6.0.0.2.0)

--- a/gemfiles/ruby_2.5_rails61_postgres_sidekiq.gemfile.lock
+++ b/gemfiles/ruby_2.5_rails61_postgres_sidekiq.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    ddtrace (1.21.0)
+    ddtrace (1.21.1)
       datadog-ci (~> 0.8.1)
       debase-ruby_core_source (= 3.3.1)
       libdatadog (~> 6.0.0.2.0)

--- a/gemfiles/ruby_2.5_rails61_semantic_logger.gemfile.lock
+++ b/gemfiles/ruby_2.5_rails61_semantic_logger.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    ddtrace (1.21.0)
+    ddtrace (1.21.1)
       datadog-ci (~> 0.8.1)
       debase-ruby_core_source (= 3.3.1)
       libdatadog (~> 6.0.0.2.0)

--- a/gemfiles/ruby_2.5_rails6_mysql2.gemfile.lock
+++ b/gemfiles/ruby_2.5_rails6_mysql2.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    ddtrace (1.21.0)
+    ddtrace (1.21.1)
       datadog-ci (~> 0.8.1)
       debase-ruby_core_source (= 3.3.1)
       libdatadog (~> 6.0.0.2.0)

--- a/gemfiles/ruby_2.5_rails6_postgres.gemfile.lock
+++ b/gemfiles/ruby_2.5_rails6_postgres.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    ddtrace (1.21.0)
+    ddtrace (1.21.1)
       datadog-ci (~> 0.8.1)
       debase-ruby_core_source (= 3.3.1)
       libdatadog (~> 6.0.0.2.0)

--- a/gemfiles/ruby_2.5_rails6_postgres_redis.gemfile.lock
+++ b/gemfiles/ruby_2.5_rails6_postgres_redis.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    ddtrace (1.21.0)
+    ddtrace (1.21.1)
       datadog-ci (~> 0.8.1)
       debase-ruby_core_source (= 3.3.1)
       libdatadog (~> 6.0.0.2.0)

--- a/gemfiles/ruby_2.5_rails6_postgres_redis_activesupport.gemfile.lock
+++ b/gemfiles/ruby_2.5_rails6_postgres_redis_activesupport.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    ddtrace (1.21.0)
+    ddtrace (1.21.1)
       datadog-ci (~> 0.8.1)
       debase-ruby_core_source (= 3.3.1)
       libdatadog (~> 6.0.0.2.0)

--- a/gemfiles/ruby_2.5_rails6_postgres_sidekiq.gemfile.lock
+++ b/gemfiles/ruby_2.5_rails6_postgres_sidekiq.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    ddtrace (1.21.0)
+    ddtrace (1.21.1)
       datadog-ci (~> 0.8.1)
       debase-ruby_core_source (= 3.3.1)
       libdatadog (~> 6.0.0.2.0)

--- a/gemfiles/ruby_2.5_rails6_semantic_logger.gemfile.lock
+++ b/gemfiles/ruby_2.5_rails6_semantic_logger.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    ddtrace (1.21.0)
+    ddtrace (1.21.1)
       datadog-ci (~> 0.8.1)
       debase-ruby_core_source (= 3.3.1)
       libdatadog (~> 6.0.0.2.0)

--- a/gemfiles/ruby_2.5_redis_3.gemfile.lock
+++ b/gemfiles/ruby_2.5_redis_3.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    ddtrace (1.21.0)
+    ddtrace (1.21.1)
       datadog-ci (~> 0.8.1)
       debase-ruby_core_source (= 3.3.1)
       libdatadog (~> 6.0.0.2.0)

--- a/gemfiles/ruby_2.5_redis_4.gemfile.lock
+++ b/gemfiles/ruby_2.5_redis_4.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    ddtrace (1.21.0)
+    ddtrace (1.21.1)
       datadog-ci (~> 0.8.1)
       debase-ruby_core_source (= 3.3.1)
       libdatadog (~> 6.0.0.2.0)

--- a/gemfiles/ruby_2.5_redis_5.gemfile.lock
+++ b/gemfiles/ruby_2.5_redis_5.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    ddtrace (1.21.0)
+    ddtrace (1.21.1)
       datadog-ci (~> 0.8.1)
       debase-ruby_core_source (= 3.3.1)
       libdatadog (~> 6.0.0.2.0)

--- a/gemfiles/ruby_2.5_relational_db.gemfile.lock
+++ b/gemfiles/ruby_2.5_relational_db.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    ddtrace (1.21.0)
+    ddtrace (1.21.1)
       datadog-ci (~> 0.8.1)
       debase-ruby_core_source (= 3.3.1)
       libdatadog (~> 6.0.0.2.0)

--- a/gemfiles/ruby_2.5_resque2_redis3.gemfile.lock
+++ b/gemfiles/ruby_2.5_resque2_redis3.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    ddtrace (1.21.0)
+    ddtrace (1.21.1)
       datadog-ci (~> 0.8.1)
       debase-ruby_core_source (= 3.3.1)
       libdatadog (~> 6.0.0.2.0)

--- a/gemfiles/ruby_2.5_resque2_redis4.gemfile.lock
+++ b/gemfiles/ruby_2.5_resque2_redis4.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    ddtrace (1.21.0)
+    ddtrace (1.21.1)
       datadog-ci (~> 0.8.1)
       debase-ruby_core_source (= 3.3.1)
       libdatadog (~> 6.0.0.2.0)

--- a/gemfiles/ruby_2.5_sinatra.gemfile.lock
+++ b/gemfiles/ruby_2.5_sinatra.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    ddtrace (1.21.0)
+    ddtrace (1.21.1)
       datadog-ci (~> 0.8.1)
       debase-ruby_core_source (= 3.3.1)
       libdatadog (~> 6.0.0.2.0)

--- a/gemfiles/ruby_2.6_activesupport.gemfile.lock
+++ b/gemfiles/ruby_2.6_activesupport.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    ddtrace (1.21.0)
+    ddtrace (1.21.1)
       datadog-ci (~> 0.8.1)
       debase-ruby_core_source (= 3.3.1)
       libdatadog (~> 6.0.0.2.0)

--- a/gemfiles/ruby_2.6_aws.gemfile.lock
+++ b/gemfiles/ruby_2.6_aws.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    ddtrace (1.21.0)
+    ddtrace (1.21.1)
       datadog-ci (~> 0.8.1)
       debase-ruby_core_source (= 3.3.1)
       libdatadog (~> 6.0.0.2.0)

--- a/gemfiles/ruby_2.6_contrib.gemfile.lock
+++ b/gemfiles/ruby_2.6_contrib.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    ddtrace (1.21.0)
+    ddtrace (1.21.1)
       datadog-ci (~> 0.8.1)
       debase-ruby_core_source (= 3.3.1)
       libdatadog (~> 6.0.0.2.0)

--- a/gemfiles/ruby_2.6_contrib_old.gemfile.lock
+++ b/gemfiles/ruby_2.6_contrib_old.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    ddtrace (1.21.0)
+    ddtrace (1.21.1)
       datadog-ci (~> 0.8.1)
       debase-ruby_core_source (= 3.3.1)
       libdatadog (~> 6.0.0.2.0)

--- a/gemfiles/ruby_2.6_core_old.gemfile.lock
+++ b/gemfiles/ruby_2.6_core_old.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    ddtrace (1.21.0)
+    ddtrace (1.21.1)
       datadog-ci (~> 0.8.1)
       debase-ruby_core_source (= 3.3.1)
       libdatadog (~> 6.0.0.2.0)

--- a/gemfiles/ruby_2.6_elasticsearch_7.gemfile.lock
+++ b/gemfiles/ruby_2.6_elasticsearch_7.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    ddtrace (1.21.0)
+    ddtrace (1.21.1)
       datadog-ci (~> 0.8.1)
       debase-ruby_core_source (= 3.3.1)
       libdatadog (~> 6.0.0.2.0)

--- a/gemfiles/ruby_2.6_elasticsearch_8.gemfile.lock
+++ b/gemfiles/ruby_2.6_elasticsearch_8.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    ddtrace (1.21.0)
+    ddtrace (1.21.1)
       datadog-ci (~> 0.8.1)
       debase-ruby_core_source (= 3.3.1)
       libdatadog (~> 6.0.0.2.0)

--- a/gemfiles/ruby_2.6_graphql_1.12.gemfile.lock
+++ b/gemfiles/ruby_2.6_graphql_1.12.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    ddtrace (1.21.0)
+    ddtrace (1.21.1)
       datadog-ci (~> 0.8.1)
       debase-ruby_core_source (= 3.3.1)
       libdatadog (~> 6.0.0.2.0)

--- a/gemfiles/ruby_2.6_graphql_1.13.gemfile.lock
+++ b/gemfiles/ruby_2.6_graphql_1.13.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    ddtrace (1.21.0)
+    ddtrace (1.21.1)
       datadog-ci (~> 0.8.1)
       debase-ruby_core_source (= 3.3.1)
       libdatadog (~> 6.0.0.2.0)

--- a/gemfiles/ruby_2.6_graphql_2.0.gemfile.lock
+++ b/gemfiles/ruby_2.6_graphql_2.0.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    ddtrace (1.21.0)
+    ddtrace (1.21.1)
       datadog-ci (~> 0.8.1)
       debase-ruby_core_source (= 3.3.1)
       libdatadog (~> 6.0.0.2.0)

--- a/gemfiles/ruby_2.6_hanami_1.gemfile.lock
+++ b/gemfiles/ruby_2.6_hanami_1.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    ddtrace (1.21.0)
+    ddtrace (1.21.1)
       datadog-ci (~> 0.8.1)
       debase-ruby_core_source (= 3.3.1)
       libdatadog (~> 6.0.0.2.0)

--- a/gemfiles/ruby_2.6_http.gemfile.lock
+++ b/gemfiles/ruby_2.6_http.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    ddtrace (1.21.0)
+    ddtrace (1.21.1)
       datadog-ci (~> 0.8.1)
       debase-ruby_core_source (= 3.3.1)
       libdatadog (~> 6.0.0.2.0)

--- a/gemfiles/ruby_2.6_multi_rack_app.gemfile.lock
+++ b/gemfiles/ruby_2.6_multi_rack_app.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    ddtrace (1.21.0)
+    ddtrace (1.21.1)
       datadog-ci (~> 0.8.1)
       debase-ruby_core_source (= 3.3.1)
       libdatadog (~> 6.0.0.2.0)

--- a/gemfiles/ruby_2.6_opensearch_2.gemfile.lock
+++ b/gemfiles/ruby_2.6_opensearch_2.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    ddtrace (1.21.0)
+    ddtrace (1.21.1)
       datadog-ci (~> 0.8.1)
       debase-ruby_core_source (= 3.3.1)
       libdatadog (~> 6.0.0.2.0)

--- a/gemfiles/ruby_2.6_opensearch_3.gemfile.lock
+++ b/gemfiles/ruby_2.6_opensearch_3.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    ddtrace (1.21.0)
+    ddtrace (1.21.1)
       datadog-ci (~> 0.8.1)
       debase-ruby_core_source (= 3.3.1)
       libdatadog (~> 6.0.0.2.0)

--- a/gemfiles/ruby_2.6_opentelemetry.gemfile.lock
+++ b/gemfiles/ruby_2.6_opentelemetry.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    ddtrace (1.21.0)
+    ddtrace (1.21.1)
       datadog-ci (~> 0.8.1)
       debase-ruby_core_source (= 3.3.1)
       libdatadog (~> 6.0.0.2.0)

--- a/gemfiles/ruby_2.6_opentracing.gemfile.lock
+++ b/gemfiles/ruby_2.6_opentracing.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    ddtrace (1.21.0)
+    ddtrace (1.21.1)
       datadog-ci (~> 0.8.1)
       debase-ruby_core_source (= 3.3.1)
       libdatadog (~> 6.0.0.2.0)

--- a/gemfiles/ruby_2.6_rack_1.gemfile.lock
+++ b/gemfiles/ruby_2.6_rack_1.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    ddtrace (1.21.0)
+    ddtrace (1.21.1)
       datadog-ci (~> 0.8.1)
       debase-ruby_core_source (= 3.3.1)
       libdatadog (~> 6.0.0.2.0)

--- a/gemfiles/ruby_2.6_rack_2.gemfile.lock
+++ b/gemfiles/ruby_2.6_rack_2.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    ddtrace (1.21.0)
+    ddtrace (1.21.1)
       datadog-ci (~> 0.8.1)
       debase-ruby_core_source (= 3.3.1)
       libdatadog (~> 6.0.0.2.0)

--- a/gemfiles/ruby_2.6_rack_3.gemfile.lock
+++ b/gemfiles/ruby_2.6_rack_3.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    ddtrace (1.21.0)
+    ddtrace (1.21.1)
       datadog-ci (~> 0.8.1)
       debase-ruby_core_source (= 3.3.1)
       libdatadog (~> 6.0.0.2.0)

--- a/gemfiles/ruby_2.6_rails5_mysql2.gemfile.lock
+++ b/gemfiles/ruby_2.6_rails5_mysql2.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    ddtrace (1.21.0)
+    ddtrace (1.21.1)
       datadog-ci (~> 0.8.1)
       debase-ruby_core_source (= 3.3.1)
       libdatadog (~> 6.0.0.2.0)

--- a/gemfiles/ruby_2.6_rails5_postgres.gemfile.lock
+++ b/gemfiles/ruby_2.6_rails5_postgres.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    ddtrace (1.21.0)
+    ddtrace (1.21.1)
       datadog-ci (~> 0.8.1)
       debase-ruby_core_source (= 3.3.1)
       libdatadog (~> 6.0.0.2.0)

--- a/gemfiles/ruby_2.6_rails5_postgres_redis.gemfile.lock
+++ b/gemfiles/ruby_2.6_rails5_postgres_redis.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    ddtrace (1.21.0)
+    ddtrace (1.21.1)
       datadog-ci (~> 0.8.1)
       debase-ruby_core_source (= 3.3.1)
       libdatadog (~> 6.0.0.2.0)

--- a/gemfiles/ruby_2.6_rails5_postgres_redis_activesupport.gemfile.lock
+++ b/gemfiles/ruby_2.6_rails5_postgres_redis_activesupport.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    ddtrace (1.21.0)
+    ddtrace (1.21.1)
       datadog-ci (~> 0.8.1)
       debase-ruby_core_source (= 3.3.1)
       libdatadog (~> 6.0.0.2.0)

--- a/gemfiles/ruby_2.6_rails5_postgres_sidekiq.gemfile.lock
+++ b/gemfiles/ruby_2.6_rails5_postgres_sidekiq.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    ddtrace (1.21.0)
+    ddtrace (1.21.1)
       datadog-ci (~> 0.8.1)
       debase-ruby_core_source (= 3.3.1)
       libdatadog (~> 6.0.0.2.0)

--- a/gemfiles/ruby_2.6_rails5_semantic_logger.gemfile.lock
+++ b/gemfiles/ruby_2.6_rails5_semantic_logger.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    ddtrace (1.21.0)
+    ddtrace (1.21.1)
       datadog-ci (~> 0.8.1)
       debase-ruby_core_source (= 3.3.1)
       libdatadog (~> 6.0.0.2.0)

--- a/gemfiles/ruby_2.6_rails61_mysql2.gemfile.lock
+++ b/gemfiles/ruby_2.6_rails61_mysql2.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    ddtrace (1.21.0)
+    ddtrace (1.21.1)
       datadog-ci (~> 0.8.1)
       debase-ruby_core_source (= 3.3.1)
       libdatadog (~> 6.0.0.2.0)

--- a/gemfiles/ruby_2.6_rails61_postgres.gemfile.lock
+++ b/gemfiles/ruby_2.6_rails61_postgres.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    ddtrace (1.21.0)
+    ddtrace (1.21.1)
       datadog-ci (~> 0.8.1)
       debase-ruby_core_source (= 3.3.1)
       libdatadog (~> 6.0.0.2.0)

--- a/gemfiles/ruby_2.6_rails61_postgres_redis.gemfile.lock
+++ b/gemfiles/ruby_2.6_rails61_postgres_redis.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    ddtrace (1.21.0)
+    ddtrace (1.21.1)
       datadog-ci (~> 0.8.1)
       debase-ruby_core_source (= 3.3.1)
       libdatadog (~> 6.0.0.2.0)

--- a/gemfiles/ruby_2.6_rails61_postgres_sidekiq.gemfile.lock
+++ b/gemfiles/ruby_2.6_rails61_postgres_sidekiq.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    ddtrace (1.21.0)
+    ddtrace (1.21.1)
       datadog-ci (~> 0.8.1)
       debase-ruby_core_source (= 3.3.1)
       libdatadog (~> 6.0.0.2.0)

--- a/gemfiles/ruby_2.6_rails61_semantic_logger.gemfile.lock
+++ b/gemfiles/ruby_2.6_rails61_semantic_logger.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    ddtrace (1.21.0)
+    ddtrace (1.21.1)
       datadog-ci (~> 0.8.1)
       debase-ruby_core_source (= 3.3.1)
       libdatadog (~> 6.0.0.2.0)

--- a/gemfiles/ruby_2.6_rails6_mysql2.gemfile.lock
+++ b/gemfiles/ruby_2.6_rails6_mysql2.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    ddtrace (1.21.0)
+    ddtrace (1.21.1)
       datadog-ci (~> 0.8.1)
       debase-ruby_core_source (= 3.3.1)
       libdatadog (~> 6.0.0.2.0)

--- a/gemfiles/ruby_2.6_rails6_postgres.gemfile.lock
+++ b/gemfiles/ruby_2.6_rails6_postgres.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    ddtrace (1.21.0)
+    ddtrace (1.21.1)
       datadog-ci (~> 0.8.1)
       debase-ruby_core_source (= 3.3.1)
       libdatadog (~> 6.0.0.2.0)

--- a/gemfiles/ruby_2.6_rails6_postgres_redis.gemfile.lock
+++ b/gemfiles/ruby_2.6_rails6_postgres_redis.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    ddtrace (1.21.0)
+    ddtrace (1.21.1)
       datadog-ci (~> 0.8.1)
       debase-ruby_core_source (= 3.3.1)
       libdatadog (~> 6.0.0.2.0)

--- a/gemfiles/ruby_2.6_rails6_postgres_redis_activesupport.gemfile.lock
+++ b/gemfiles/ruby_2.6_rails6_postgres_redis_activesupport.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    ddtrace (1.21.0)
+    ddtrace (1.21.1)
       datadog-ci (~> 0.8.1)
       debase-ruby_core_source (= 3.3.1)
       libdatadog (~> 6.0.0.2.0)

--- a/gemfiles/ruby_2.6_rails6_postgres_sidekiq.gemfile.lock
+++ b/gemfiles/ruby_2.6_rails6_postgres_sidekiq.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    ddtrace (1.21.0)
+    ddtrace (1.21.1)
       datadog-ci (~> 0.8.1)
       debase-ruby_core_source (= 3.3.1)
       libdatadog (~> 6.0.0.2.0)

--- a/gemfiles/ruby_2.6_rails6_semantic_logger.gemfile.lock
+++ b/gemfiles/ruby_2.6_rails6_semantic_logger.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    ddtrace (1.21.0)
+    ddtrace (1.21.1)
       datadog-ci (~> 0.8.1)
       debase-ruby_core_source (= 3.3.1)
       libdatadog (~> 6.0.0.2.0)

--- a/gemfiles/ruby_2.6_redis_3.gemfile.lock
+++ b/gemfiles/ruby_2.6_redis_3.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    ddtrace (1.21.0)
+    ddtrace (1.21.1)
       datadog-ci (~> 0.8.1)
       debase-ruby_core_source (= 3.3.1)
       libdatadog (~> 6.0.0.2.0)

--- a/gemfiles/ruby_2.6_redis_4.gemfile.lock
+++ b/gemfiles/ruby_2.6_redis_4.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    ddtrace (1.21.0)
+    ddtrace (1.21.1)
       datadog-ci (~> 0.8.1)
       debase-ruby_core_source (= 3.3.1)
       libdatadog (~> 6.0.0.2.0)

--- a/gemfiles/ruby_2.6_redis_5.gemfile.lock
+++ b/gemfiles/ruby_2.6_redis_5.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    ddtrace (1.21.0)
+    ddtrace (1.21.1)
       datadog-ci (~> 0.8.1)
       debase-ruby_core_source (= 3.3.1)
       libdatadog (~> 6.0.0.2.0)

--- a/gemfiles/ruby_2.6_relational_db.gemfile.lock
+++ b/gemfiles/ruby_2.6_relational_db.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    ddtrace (1.21.0)
+    ddtrace (1.21.1)
       datadog-ci (~> 0.8.1)
       debase-ruby_core_source (= 3.3.1)
       libdatadog (~> 6.0.0.2.0)

--- a/gemfiles/ruby_2.6_resque2_redis3.gemfile.lock
+++ b/gemfiles/ruby_2.6_resque2_redis3.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    ddtrace (1.21.0)
+    ddtrace (1.21.1)
       datadog-ci (~> 0.8.1)
       debase-ruby_core_source (= 3.3.1)
       libdatadog (~> 6.0.0.2.0)

--- a/gemfiles/ruby_2.6_resque2_redis4.gemfile.lock
+++ b/gemfiles/ruby_2.6_resque2_redis4.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    ddtrace (1.21.0)
+    ddtrace (1.21.1)
       datadog-ci (~> 0.8.1)
       debase-ruby_core_source (= 3.3.1)
       libdatadog (~> 6.0.0.2.0)

--- a/gemfiles/ruby_2.6_sinatra.gemfile.lock
+++ b/gemfiles/ruby_2.6_sinatra.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    ddtrace (1.21.0)
+    ddtrace (1.21.1)
       datadog-ci (~> 0.8.1)
       debase-ruby_core_source (= 3.3.1)
       libdatadog (~> 6.0.0.2.0)

--- a/gemfiles/ruby_2.7.6_sinatra.gemfile.lock
+++ b/gemfiles/ruby_2.7.6_sinatra.gemfile.lock
@@ -12,7 +12,7 @@ GIT
 PATH
   remote: ..
   specs:
-    ddtrace (1.21.0)
+    ddtrace (1.21.1)
       datadog-ci (~> 0.2.0)
       debase-ruby_core_source (= 3.3.1)
       libdatadog (~> 6.0.0.2.0)

--- a/gemfiles/ruby_2.7_activesupport.gemfile.lock
+++ b/gemfiles/ruby_2.7_activesupport.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    ddtrace (1.21.0)
+    ddtrace (1.21.1)
       datadog-ci (~> 0.8.1)
       debase-ruby_core_source (= 3.3.1)
       libdatadog (~> 6.0.0.2.0)

--- a/gemfiles/ruby_2.7_aws.gemfile.lock
+++ b/gemfiles/ruby_2.7_aws.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    ddtrace (1.21.0)
+    ddtrace (1.21.1)
       datadog-ci (~> 0.8.1)
       debase-ruby_core_source (= 3.3.1)
       libdatadog (~> 6.0.0.2.0)

--- a/gemfiles/ruby_2.7_contrib.gemfile.lock
+++ b/gemfiles/ruby_2.7_contrib.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    ddtrace (1.21.0)
+    ddtrace (1.21.1)
       datadog-ci (~> 0.8.1)
       debase-ruby_core_source (= 3.3.1)
       libdatadog (~> 6.0.0.2.0)

--- a/gemfiles/ruby_2.7_contrib_old.gemfile.lock
+++ b/gemfiles/ruby_2.7_contrib_old.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    ddtrace (1.21.0)
+    ddtrace (1.21.1)
       datadog-ci (~> 0.8.1)
       debase-ruby_core_source (= 3.3.1)
       libdatadog (~> 6.0.0.2.0)

--- a/gemfiles/ruby_2.7_core_old.gemfile.lock
+++ b/gemfiles/ruby_2.7_core_old.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    ddtrace (1.21.0)
+    ddtrace (1.21.1)
       datadog-ci (~> 0.8.1)
       debase-ruby_core_source (= 3.3.1)
       libdatadog (~> 6.0.0.2.0)

--- a/gemfiles/ruby_2.7_elasticsearch_7.gemfile.lock
+++ b/gemfiles/ruby_2.7_elasticsearch_7.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    ddtrace (1.21.0)
+    ddtrace (1.21.1)
       datadog-ci (~> 0.8.1)
       debase-ruby_core_source (= 3.3.1)
       libdatadog (~> 6.0.0.2.0)

--- a/gemfiles/ruby_2.7_elasticsearch_8.gemfile.lock
+++ b/gemfiles/ruby_2.7_elasticsearch_8.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    ddtrace (1.21.0)
+    ddtrace (1.21.1)
       datadog-ci (~> 0.8.1)
       debase-ruby_core_source (= 3.3.1)
       libdatadog (~> 6.0.0.2.0)

--- a/gemfiles/ruby_2.7_graphql_1.12.gemfile.lock
+++ b/gemfiles/ruby_2.7_graphql_1.12.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    ddtrace (1.21.0)
+    ddtrace (1.21.1)
       datadog-ci (~> 0.8.1)
       debase-ruby_core_source (= 3.3.1)
       libdatadog (~> 6.0.0.2.0)

--- a/gemfiles/ruby_2.7_graphql_1.13.gemfile.lock
+++ b/gemfiles/ruby_2.7_graphql_1.13.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    ddtrace (1.21.0)
+    ddtrace (1.21.1)
       datadog-ci (~> 0.8.1)
       debase-ruby_core_source (= 3.3.1)
       libdatadog (~> 6.0.0.2.0)

--- a/gemfiles/ruby_2.7_graphql_2.0.gemfile.lock
+++ b/gemfiles/ruby_2.7_graphql_2.0.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    ddtrace (1.21.0)
+    ddtrace (1.21.1)
       datadog-ci (~> 0.8.1)
       debase-ruby_core_source (= 3.3.1)
       libdatadog (~> 6.0.0.2.0)

--- a/gemfiles/ruby_2.7_graphql_2.1.gemfile.lock
+++ b/gemfiles/ruby_2.7_graphql_2.1.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    ddtrace (1.21.0)
+    ddtrace (1.21.1)
       datadog-ci (~> 0.8.1)
       debase-ruby_core_source (= 3.3.1)
       libdatadog (~> 6.0.0.2.0)

--- a/gemfiles/ruby_2.7_graphql_2.2.gemfile.lock
+++ b/gemfiles/ruby_2.7_graphql_2.2.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    ddtrace (1.21.0)
+    ddtrace (1.21.1)
       datadog-ci (~> 0.8.1)
       debase-ruby_core_source (= 3.3.1)
       libdatadog (~> 6.0.0.2.0)

--- a/gemfiles/ruby_2.7_hanami_1.gemfile.lock
+++ b/gemfiles/ruby_2.7_hanami_1.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    ddtrace (1.21.0)
+    ddtrace (1.21.1)
       datadog-ci (~> 0.8.1)
       debase-ruby_core_source (= 3.3.1)
       libdatadog (~> 6.0.0.2.0)

--- a/gemfiles/ruby_2.7_http.gemfile.lock
+++ b/gemfiles/ruby_2.7_http.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    ddtrace (1.21.0)
+    ddtrace (1.21.1)
       datadog-ci (~> 0.8.1)
       debase-ruby_core_source (= 3.3.1)
       libdatadog (~> 6.0.0.2.0)

--- a/gemfiles/ruby_2.7_multi_rack_app.gemfile.lock
+++ b/gemfiles/ruby_2.7_multi_rack_app.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    ddtrace (1.21.0)
+    ddtrace (1.21.1)
       datadog-ci (~> 0.8.1)
       debase-ruby_core_source (= 3.3.1)
       libdatadog (~> 6.0.0.2.0)

--- a/gemfiles/ruby_2.7_opensearch_2.gemfile.lock
+++ b/gemfiles/ruby_2.7_opensearch_2.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    ddtrace (1.21.0)
+    ddtrace (1.21.1)
       datadog-ci (~> 0.8.1)
       debase-ruby_core_source (= 3.3.1)
       libdatadog (~> 6.0.0.2.0)

--- a/gemfiles/ruby_2.7_opensearch_3.gemfile.lock
+++ b/gemfiles/ruby_2.7_opensearch_3.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    ddtrace (1.21.0)
+    ddtrace (1.21.1)
       datadog-ci (~> 0.8.1)
       debase-ruby_core_source (= 3.3.1)
       libdatadog (~> 6.0.0.2.0)

--- a/gemfiles/ruby_2.7_opentelemetry.gemfile.lock
+++ b/gemfiles/ruby_2.7_opentelemetry.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    ddtrace (1.21.0)
+    ddtrace (1.21.1)
       datadog-ci (~> 0.8.1)
       debase-ruby_core_source (= 3.3.1)
       libdatadog (~> 6.0.0.2.0)

--- a/gemfiles/ruby_2.7_opentracing.gemfile.lock
+++ b/gemfiles/ruby_2.7_opentracing.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    ddtrace (1.21.0)
+    ddtrace (1.21.1)
       datadog-ci (~> 0.8.1)
       debase-ruby_core_source (= 3.3.1)
       libdatadog (~> 6.0.0.2.0)

--- a/gemfiles/ruby_2.7_rack_1.gemfile.lock
+++ b/gemfiles/ruby_2.7_rack_1.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    ddtrace (1.21.0)
+    ddtrace (1.21.1)
       datadog-ci (~> 0.8.1)
       debase-ruby_core_source (= 3.3.1)
       libdatadog (~> 6.0.0.2.0)

--- a/gemfiles/ruby_2.7_rack_2.gemfile.lock
+++ b/gemfiles/ruby_2.7_rack_2.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    ddtrace (1.21.0)
+    ddtrace (1.21.1)
       datadog-ci (~> 0.8.1)
       debase-ruby_core_source (= 3.3.1)
       libdatadog (~> 6.0.0.2.0)

--- a/gemfiles/ruby_2.7_rack_3.gemfile.lock
+++ b/gemfiles/ruby_2.7_rack_3.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    ddtrace (1.21.0)
+    ddtrace (1.21.1)
       datadog-ci (~> 0.8.1)
       debase-ruby_core_source (= 3.3.1)
       libdatadog (~> 6.0.0.2.0)

--- a/gemfiles/ruby_2.7_rails5_mysql2.gemfile.lock
+++ b/gemfiles/ruby_2.7_rails5_mysql2.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    ddtrace (1.21.0)
+    ddtrace (1.21.1)
       datadog-ci (~> 0.8.1)
       debase-ruby_core_source (= 3.3.1)
       libdatadog (~> 6.0.0.2.0)

--- a/gemfiles/ruby_2.7_rails5_postgres.gemfile.lock
+++ b/gemfiles/ruby_2.7_rails5_postgres.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    ddtrace (1.21.0)
+    ddtrace (1.21.1)
       datadog-ci (~> 0.8.1)
       debase-ruby_core_source (= 3.3.1)
       libdatadog (~> 6.0.0.2.0)

--- a/gemfiles/ruby_2.7_rails5_postgres_redis.gemfile.lock
+++ b/gemfiles/ruby_2.7_rails5_postgres_redis.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    ddtrace (1.21.0)
+    ddtrace (1.21.1)
       datadog-ci (~> 0.8.1)
       debase-ruby_core_source (= 3.3.1)
       libdatadog (~> 6.0.0.2.0)

--- a/gemfiles/ruby_2.7_rails5_postgres_redis_activesupport.gemfile.lock
+++ b/gemfiles/ruby_2.7_rails5_postgres_redis_activesupport.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    ddtrace (1.21.0)
+    ddtrace (1.21.1)
       datadog-ci (~> 0.8.1)
       debase-ruby_core_source (= 3.3.1)
       libdatadog (~> 6.0.0.2.0)

--- a/gemfiles/ruby_2.7_rails5_postgres_sidekiq.gemfile.lock
+++ b/gemfiles/ruby_2.7_rails5_postgres_sidekiq.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    ddtrace (1.21.0)
+    ddtrace (1.21.1)
       datadog-ci (~> 0.8.1)
       debase-ruby_core_source (= 3.3.1)
       libdatadog (~> 6.0.0.2.0)

--- a/gemfiles/ruby_2.7_rails5_semantic_logger.gemfile.lock
+++ b/gemfiles/ruby_2.7_rails5_semantic_logger.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    ddtrace (1.21.0)
+    ddtrace (1.21.1)
       datadog-ci (~> 0.8.1)
       debase-ruby_core_source (= 3.3.1)
       libdatadog (~> 6.0.0.2.0)

--- a/gemfiles/ruby_2.7_rails61_mysql2.gemfile.lock
+++ b/gemfiles/ruby_2.7_rails61_mysql2.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    ddtrace (1.21.0)
+    ddtrace (1.21.1)
       datadog-ci (~> 0.8.1)
       debase-ruby_core_source (= 3.3.1)
       libdatadog (~> 6.0.0.2.0)

--- a/gemfiles/ruby_2.7_rails61_postgres.gemfile.lock
+++ b/gemfiles/ruby_2.7_rails61_postgres.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    ddtrace (1.21.0)
+    ddtrace (1.21.1)
       datadog-ci (~> 0.8.1)
       debase-ruby_core_source (= 3.3.1)
       libdatadog (~> 6.0.0.2.0)

--- a/gemfiles/ruby_2.7_rails61_postgres_redis.gemfile.lock
+++ b/gemfiles/ruby_2.7_rails61_postgres_redis.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    ddtrace (1.21.0)
+    ddtrace (1.21.1)
       datadog-ci (~> 0.8.1)
       debase-ruby_core_source (= 3.3.1)
       libdatadog (~> 6.0.0.2.0)

--- a/gemfiles/ruby_2.7_rails61_postgres_sidekiq.gemfile.lock
+++ b/gemfiles/ruby_2.7_rails61_postgres_sidekiq.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    ddtrace (1.21.0)
+    ddtrace (1.21.1)
       datadog-ci (~> 0.8.1)
       debase-ruby_core_source (= 3.3.1)
       libdatadog (~> 6.0.0.2.0)

--- a/gemfiles/ruby_2.7_rails61_semantic_logger.gemfile.lock
+++ b/gemfiles/ruby_2.7_rails61_semantic_logger.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    ddtrace (1.21.0)
+    ddtrace (1.21.1)
       datadog-ci (~> 0.8.1)
       debase-ruby_core_source (= 3.3.1)
       libdatadog (~> 6.0.0.2.0)

--- a/gemfiles/ruby_2.7_rails6_mysql2.gemfile.lock
+++ b/gemfiles/ruby_2.7_rails6_mysql2.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    ddtrace (1.21.0)
+    ddtrace (1.21.1)
       datadog-ci (~> 0.8.1)
       debase-ruby_core_source (= 3.3.1)
       libdatadog (~> 6.0.0.2.0)

--- a/gemfiles/ruby_2.7_rails6_postgres.gemfile.lock
+++ b/gemfiles/ruby_2.7_rails6_postgres.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    ddtrace (1.21.0)
+    ddtrace (1.21.1)
       datadog-ci (~> 0.8.1)
       debase-ruby_core_source (= 3.3.1)
       libdatadog (~> 6.0.0.2.0)

--- a/gemfiles/ruby_2.7_rails6_postgres_redis.gemfile.lock
+++ b/gemfiles/ruby_2.7_rails6_postgres_redis.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    ddtrace (1.21.0)
+    ddtrace (1.21.1)
       datadog-ci (~> 0.8.1)
       debase-ruby_core_source (= 3.3.1)
       libdatadog (~> 6.0.0.2.0)

--- a/gemfiles/ruby_2.7_rails6_postgres_redis_activesupport.gemfile.lock
+++ b/gemfiles/ruby_2.7_rails6_postgres_redis_activesupport.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    ddtrace (1.21.0)
+    ddtrace (1.21.1)
       datadog-ci (~> 0.8.1)
       debase-ruby_core_source (= 3.3.1)
       libdatadog (~> 6.0.0.2.0)

--- a/gemfiles/ruby_2.7_rails6_postgres_sidekiq.gemfile.lock
+++ b/gemfiles/ruby_2.7_rails6_postgres_sidekiq.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    ddtrace (1.21.0)
+    ddtrace (1.21.1)
       datadog-ci (~> 0.8.1)
       debase-ruby_core_source (= 3.3.1)
       libdatadog (~> 6.0.0.2.0)

--- a/gemfiles/ruby_2.7_rails6_semantic_logger.gemfile.lock
+++ b/gemfiles/ruby_2.7_rails6_semantic_logger.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    ddtrace (1.21.0)
+    ddtrace (1.21.1)
       datadog-ci (~> 0.8.1)
       debase-ruby_core_source (= 3.3.1)
       libdatadog (~> 6.0.0.2.0)

--- a/gemfiles/ruby_2.7_redis_3.gemfile.lock
+++ b/gemfiles/ruby_2.7_redis_3.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    ddtrace (1.21.0)
+    ddtrace (1.21.1)
       datadog-ci (~> 0.8.1)
       debase-ruby_core_source (= 3.3.1)
       libdatadog (~> 6.0.0.2.0)

--- a/gemfiles/ruby_2.7_redis_4.gemfile.lock
+++ b/gemfiles/ruby_2.7_redis_4.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    ddtrace (1.21.0)
+    ddtrace (1.21.1)
       datadog-ci (~> 0.8.1)
       debase-ruby_core_source (= 3.3.1)
       libdatadog (~> 6.0.0.2.0)

--- a/gemfiles/ruby_2.7_redis_5.gemfile.lock
+++ b/gemfiles/ruby_2.7_redis_5.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    ddtrace (1.21.0)
+    ddtrace (1.21.1)
       datadog-ci (~> 0.8.1)
       debase-ruby_core_source (= 3.3.1)
       libdatadog (~> 6.0.0.2.0)

--- a/gemfiles/ruby_2.7_relational_db.gemfile.lock
+++ b/gemfiles/ruby_2.7_relational_db.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    ddtrace (1.21.0)
+    ddtrace (1.21.1)
       datadog-ci (~> 0.8.1)
       debase-ruby_core_source (= 3.3.1)
       libdatadog (~> 6.0.0.2.0)

--- a/gemfiles/ruby_2.7_resque2_redis3.gemfile.lock
+++ b/gemfiles/ruby_2.7_resque2_redis3.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    ddtrace (1.21.0)
+    ddtrace (1.21.1)
       datadog-ci (~> 0.8.1)
       debase-ruby_core_source (= 3.3.1)
       libdatadog (~> 6.0.0.2.0)

--- a/gemfiles/ruby_2.7_resque2_redis4.gemfile.lock
+++ b/gemfiles/ruby_2.7_resque2_redis4.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    ddtrace (1.21.0)
+    ddtrace (1.21.1)
       datadog-ci (~> 0.8.1)
       debase-ruby_core_source (= 3.3.1)
       libdatadog (~> 6.0.0.2.0)

--- a/gemfiles/ruby_2.7_sinatra.gemfile.lock
+++ b/gemfiles/ruby_2.7_sinatra.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    ddtrace (1.21.0)
+    ddtrace (1.21.1)
       datadog-ci (~> 0.8.1)
       debase-ruby_core_source (= 3.3.1)
       libdatadog (~> 6.0.0.2.0)

--- a/gemfiles/ruby_3.0_activesupport.gemfile.lock
+++ b/gemfiles/ruby_3.0_activesupport.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    ddtrace (1.21.0)
+    ddtrace (1.21.1)
       datadog-ci (~> 0.8.1)
       debase-ruby_core_source (= 3.3.1)
       libdatadog (~> 6.0.0.2.0)

--- a/gemfiles/ruby_3.0_aws.gemfile.lock
+++ b/gemfiles/ruby_3.0_aws.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    ddtrace (1.21.0)
+    ddtrace (1.21.1)
       datadog-ci (~> 0.8.1)
       debase-ruby_core_source (= 3.3.1)
       libdatadog (~> 6.0.0.2.0)

--- a/gemfiles/ruby_3.0_contrib.gemfile.lock
+++ b/gemfiles/ruby_3.0_contrib.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    ddtrace (1.21.0)
+    ddtrace (1.21.1)
       datadog-ci (~> 0.8.1)
       debase-ruby_core_source (= 3.3.1)
       libdatadog (~> 6.0.0.2.0)

--- a/gemfiles/ruby_3.0_contrib_old.gemfile.lock
+++ b/gemfiles/ruby_3.0_contrib_old.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    ddtrace (1.21.0)
+    ddtrace (1.21.1)
       datadog-ci (~> 0.8.1)
       debase-ruby_core_source (= 3.3.1)
       libdatadog (~> 6.0.0.2.0)

--- a/gemfiles/ruby_3.0_core_old.gemfile.lock
+++ b/gemfiles/ruby_3.0_core_old.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    ddtrace (1.21.0)
+    ddtrace (1.21.1)
       datadog-ci (~> 0.8.1)
       debase-ruby_core_source (= 3.3.1)
       libdatadog (~> 6.0.0.2.0)

--- a/gemfiles/ruby_3.0_elasticsearch_7.gemfile.lock
+++ b/gemfiles/ruby_3.0_elasticsearch_7.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    ddtrace (1.21.0)
+    ddtrace (1.21.1)
       datadog-ci (~> 0.8.1)
       debase-ruby_core_source (= 3.3.1)
       libdatadog (~> 6.0.0.2.0)

--- a/gemfiles/ruby_3.0_elasticsearch_8.gemfile.lock
+++ b/gemfiles/ruby_3.0_elasticsearch_8.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    ddtrace (1.21.0)
+    ddtrace (1.21.1)
       datadog-ci (~> 0.8.1)
       debase-ruby_core_source (= 3.3.1)
       libdatadog (~> 6.0.0.2.0)

--- a/gemfiles/ruby_3.0_graphql_1.12.gemfile.lock
+++ b/gemfiles/ruby_3.0_graphql_1.12.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    ddtrace (1.21.0)
+    ddtrace (1.21.1)
       datadog-ci (~> 0.8.1)
       debase-ruby_core_source (= 3.3.1)
       libdatadog (~> 6.0.0.2.0)

--- a/gemfiles/ruby_3.0_graphql_1.13.gemfile.lock
+++ b/gemfiles/ruby_3.0_graphql_1.13.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    ddtrace (1.21.0)
+    ddtrace (1.21.1)
       datadog-ci (~> 0.8.1)
       debase-ruby_core_source (= 3.3.1)
       libdatadog (~> 6.0.0.2.0)

--- a/gemfiles/ruby_3.0_graphql_2.0.gemfile.lock
+++ b/gemfiles/ruby_3.0_graphql_2.0.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    ddtrace (1.21.0)
+    ddtrace (1.21.1)
       datadog-ci (~> 0.8.1)
       debase-ruby_core_source (= 3.3.1)
       libdatadog (~> 6.0.0.2.0)

--- a/gemfiles/ruby_3.0_graphql_2.1.gemfile.lock
+++ b/gemfiles/ruby_3.0_graphql_2.1.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    ddtrace (1.21.0)
+    ddtrace (1.21.1)
       datadog-ci (~> 0.8.1)
       debase-ruby_core_source (= 3.3.1)
       libdatadog (~> 6.0.0.2.0)

--- a/gemfiles/ruby_3.0_graphql_2.2.gemfile.lock
+++ b/gemfiles/ruby_3.0_graphql_2.2.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    ddtrace (1.21.0)
+    ddtrace (1.21.1)
       datadog-ci (~> 0.8.1)
       debase-ruby_core_source (= 3.3.1)
       libdatadog (~> 6.0.0.2.0)

--- a/gemfiles/ruby_3.0_http.gemfile.lock
+++ b/gemfiles/ruby_3.0_http.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    ddtrace (1.21.0)
+    ddtrace (1.21.1)
       datadog-ci (~> 0.8.1)
       debase-ruby_core_source (= 3.3.1)
       libdatadog (~> 6.0.0.2.0)

--- a/gemfiles/ruby_3.0_multi_rack_app.gemfile.lock
+++ b/gemfiles/ruby_3.0_multi_rack_app.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    ddtrace (1.21.0)
+    ddtrace (1.21.1)
       datadog-ci (~> 0.8.1)
       debase-ruby_core_source (= 3.3.1)
       libdatadog (~> 6.0.0.2.0)

--- a/gemfiles/ruby_3.0_opensearch_2.gemfile.lock
+++ b/gemfiles/ruby_3.0_opensearch_2.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    ddtrace (1.21.0)
+    ddtrace (1.21.1)
       datadog-ci (~> 0.8.1)
       debase-ruby_core_source (= 3.3.1)
       libdatadog (~> 6.0.0.2.0)

--- a/gemfiles/ruby_3.0_opensearch_3.gemfile.lock
+++ b/gemfiles/ruby_3.0_opensearch_3.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    ddtrace (1.21.0)
+    ddtrace (1.21.1)
       datadog-ci (~> 0.8.1)
       debase-ruby_core_source (= 3.3.1)
       libdatadog (~> 6.0.0.2.0)

--- a/gemfiles/ruby_3.0_opentelemetry.gemfile.lock
+++ b/gemfiles/ruby_3.0_opentelemetry.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    ddtrace (1.21.0)
+    ddtrace (1.21.1)
       datadog-ci (~> 0.8.1)
       debase-ruby_core_source (= 3.3.1)
       libdatadog (~> 6.0.0.2.0)

--- a/gemfiles/ruby_3.0_opentracing.gemfile.lock
+++ b/gemfiles/ruby_3.0_opentracing.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    ddtrace (1.21.0)
+    ddtrace (1.21.1)
       datadog-ci (~> 0.8.1)
       debase-ruby_core_source (= 3.3.1)
       libdatadog (~> 6.0.0.2.0)

--- a/gemfiles/ruby_3.0_rack_1.gemfile.lock
+++ b/gemfiles/ruby_3.0_rack_1.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    ddtrace (1.21.0)
+    ddtrace (1.21.1)
       datadog-ci (~> 0.8.1)
       debase-ruby_core_source (= 3.3.1)
       libdatadog (~> 6.0.0.2.0)

--- a/gemfiles/ruby_3.0_rack_2.gemfile.lock
+++ b/gemfiles/ruby_3.0_rack_2.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    ddtrace (1.21.0)
+    ddtrace (1.21.1)
       datadog-ci (~> 0.8.1)
       debase-ruby_core_source (= 3.3.1)
       libdatadog (~> 6.0.0.2.0)

--- a/gemfiles/ruby_3.0_rack_3.gemfile.lock
+++ b/gemfiles/ruby_3.0_rack_3.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    ddtrace (1.21.0)
+    ddtrace (1.21.1)
       datadog-ci (~> 0.8.1)
       debase-ruby_core_source (= 3.3.1)
       libdatadog (~> 6.0.0.2.0)

--- a/gemfiles/ruby_3.0_rails61_mysql2.gemfile.lock
+++ b/gemfiles/ruby_3.0_rails61_mysql2.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    ddtrace (1.21.0)
+    ddtrace (1.21.1)
       datadog-ci (~> 0.8.1)
       debase-ruby_core_source (= 3.3.1)
       libdatadog (~> 6.0.0.2.0)

--- a/gemfiles/ruby_3.0_rails61_postgres.gemfile.lock
+++ b/gemfiles/ruby_3.0_rails61_postgres.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    ddtrace (1.21.0)
+    ddtrace (1.21.1)
       datadog-ci (~> 0.8.1)
       debase-ruby_core_source (= 3.3.1)
       libdatadog (~> 6.0.0.2.0)

--- a/gemfiles/ruby_3.0_rails61_postgres_redis.gemfile.lock
+++ b/gemfiles/ruby_3.0_rails61_postgres_redis.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    ddtrace (1.21.0)
+    ddtrace (1.21.1)
       datadog-ci (~> 0.8.1)
       debase-ruby_core_source (= 3.3.1)
       libdatadog (~> 6.0.0.2.0)

--- a/gemfiles/ruby_3.0_rails61_postgres_sidekiq.gemfile.lock
+++ b/gemfiles/ruby_3.0_rails61_postgres_sidekiq.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    ddtrace (1.21.0)
+    ddtrace (1.21.1)
       datadog-ci (~> 0.8.1)
       debase-ruby_core_source (= 3.3.1)
       libdatadog (~> 6.0.0.2.0)

--- a/gemfiles/ruby_3.0_rails61_semantic_logger.gemfile.lock
+++ b/gemfiles/ruby_3.0_rails61_semantic_logger.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    ddtrace (1.21.0)
+    ddtrace (1.21.1)
       datadog-ci (~> 0.8.1)
       debase-ruby_core_source (= 3.3.1)
       libdatadog (~> 6.0.0.2.0)

--- a/gemfiles/ruby_3.0_rails61_trilogy.gemfile.lock
+++ b/gemfiles/ruby_3.0_rails61_trilogy.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    ddtrace (1.21.0)
+    ddtrace (1.21.1)
       datadog-ci (~> 0.8.1)
       debase-ruby_core_source (= 3.3.1)
       libdatadog (~> 6.0.0.2.0)

--- a/gemfiles/ruby_3.0_redis_3.gemfile.lock
+++ b/gemfiles/ruby_3.0_redis_3.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    ddtrace (1.21.0)
+    ddtrace (1.21.1)
       datadog-ci (~> 0.8.1)
       debase-ruby_core_source (= 3.3.1)
       libdatadog (~> 6.0.0.2.0)

--- a/gemfiles/ruby_3.0_redis_4.gemfile.lock
+++ b/gemfiles/ruby_3.0_redis_4.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    ddtrace (1.21.0)
+    ddtrace (1.21.1)
       datadog-ci (~> 0.8.1)
       debase-ruby_core_source (= 3.3.1)
       libdatadog (~> 6.0.0.2.0)

--- a/gemfiles/ruby_3.0_redis_5.gemfile.lock
+++ b/gemfiles/ruby_3.0_redis_5.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    ddtrace (1.21.0)
+    ddtrace (1.21.1)
       datadog-ci (~> 0.8.1)
       debase-ruby_core_source (= 3.3.1)
       libdatadog (~> 6.0.0.2.0)

--- a/gemfiles/ruby_3.0_relational_db.gemfile.lock
+++ b/gemfiles/ruby_3.0_relational_db.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    ddtrace (1.21.0)
+    ddtrace (1.21.1)
       datadog-ci (~> 0.8.1)
       debase-ruby_core_source (= 3.3.1)
       libdatadog (~> 6.0.0.2.0)

--- a/gemfiles/ruby_3.0_resque2_redis3.gemfile.lock
+++ b/gemfiles/ruby_3.0_resque2_redis3.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    ddtrace (1.21.0)
+    ddtrace (1.21.1)
       datadog-ci (~> 0.8.1)
       debase-ruby_core_source (= 3.3.1)
       libdatadog (~> 6.0.0.2.0)

--- a/gemfiles/ruby_3.0_resque2_redis4.gemfile.lock
+++ b/gemfiles/ruby_3.0_resque2_redis4.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    ddtrace (1.21.0)
+    ddtrace (1.21.1)
       datadog-ci (~> 0.8.1)
       debase-ruby_core_source (= 3.3.1)
       libdatadog (~> 6.0.0.2.0)

--- a/gemfiles/ruby_3.0_sinatra.gemfile.lock
+++ b/gemfiles/ruby_3.0_sinatra.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    ddtrace (1.21.0)
+    ddtrace (1.21.1)
       datadog-ci (~> 0.8.1)
       debase-ruby_core_source (= 3.3.1)
       libdatadog (~> 6.0.0.2.0)

--- a/gemfiles/ruby_3.1_activesupport.gemfile.lock
+++ b/gemfiles/ruby_3.1_activesupport.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    ddtrace (1.21.0)
+    ddtrace (1.21.1)
       datadog-ci (~> 0.8.1)
       debase-ruby_core_source (= 3.3.1)
       libdatadog (~> 6.0.0.2.0)

--- a/gemfiles/ruby_3.1_aws.gemfile.lock
+++ b/gemfiles/ruby_3.1_aws.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    ddtrace (1.21.0)
+    ddtrace (1.21.1)
       datadog-ci (~> 0.8.1)
       debase-ruby_core_source (= 3.3.1)
       libdatadog (~> 6.0.0.2.0)

--- a/gemfiles/ruby_3.1_contrib.gemfile.lock
+++ b/gemfiles/ruby_3.1_contrib.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    ddtrace (1.21.0)
+    ddtrace (1.21.1)
       datadog-ci (~> 0.8.1)
       debase-ruby_core_source (= 3.3.1)
       libdatadog (~> 6.0.0.2.0)

--- a/gemfiles/ruby_3.1_contrib_old.gemfile.lock
+++ b/gemfiles/ruby_3.1_contrib_old.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    ddtrace (1.21.0)
+    ddtrace (1.21.1)
       datadog-ci (~> 0.8.1)
       debase-ruby_core_source (= 3.3.1)
       libdatadog (~> 6.0.0.2.0)

--- a/gemfiles/ruby_3.1_core_old.gemfile.lock
+++ b/gemfiles/ruby_3.1_core_old.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    ddtrace (1.21.0)
+    ddtrace (1.21.1)
       datadog-ci (~> 0.8.1)
       debase-ruby_core_source (= 3.3.1)
       libdatadog (~> 6.0.0.2.0)

--- a/gemfiles/ruby_3.1_elasticsearch_7.gemfile.lock
+++ b/gemfiles/ruby_3.1_elasticsearch_7.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    ddtrace (1.21.0)
+    ddtrace (1.21.1)
       datadog-ci (~> 0.8.1)
       debase-ruby_core_source (= 3.3.1)
       libdatadog (~> 6.0.0.2.0)

--- a/gemfiles/ruby_3.1_elasticsearch_8.gemfile.lock
+++ b/gemfiles/ruby_3.1_elasticsearch_8.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    ddtrace (1.21.0)
+    ddtrace (1.21.1)
       datadog-ci (~> 0.8.1)
       debase-ruby_core_source (= 3.3.1)
       libdatadog (~> 6.0.0.2.0)

--- a/gemfiles/ruby_3.1_graphql_1.12.gemfile.lock
+++ b/gemfiles/ruby_3.1_graphql_1.12.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    ddtrace (1.21.0)
+    ddtrace (1.21.1)
       datadog-ci (~> 0.8.1)
       debase-ruby_core_source (= 3.3.1)
       libdatadog (~> 6.0.0.2.0)

--- a/gemfiles/ruby_3.1_graphql_1.13.gemfile.lock
+++ b/gemfiles/ruby_3.1_graphql_1.13.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    ddtrace (1.21.0)
+    ddtrace (1.21.1)
       datadog-ci (~> 0.8.1)
       debase-ruby_core_source (= 3.3.1)
       libdatadog (~> 6.0.0.2.0)

--- a/gemfiles/ruby_3.1_graphql_2.0.gemfile.lock
+++ b/gemfiles/ruby_3.1_graphql_2.0.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    ddtrace (1.21.0)
+    ddtrace (1.21.1)
       datadog-ci (~> 0.8.1)
       debase-ruby_core_source (= 3.3.1)
       libdatadog (~> 6.0.0.2.0)

--- a/gemfiles/ruby_3.1_graphql_2.1.gemfile.lock
+++ b/gemfiles/ruby_3.1_graphql_2.1.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    ddtrace (1.21.0)
+    ddtrace (1.21.1)
       datadog-ci (~> 0.8.1)
       debase-ruby_core_source (= 3.3.1)
       libdatadog (~> 6.0.0.2.0)

--- a/gemfiles/ruby_3.1_graphql_2.2.gemfile.lock
+++ b/gemfiles/ruby_3.1_graphql_2.2.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    ddtrace (1.21.0)
+    ddtrace (1.21.1)
       datadog-ci (~> 0.8.1)
       debase-ruby_core_source (= 3.3.1)
       libdatadog (~> 6.0.0.2.0)

--- a/gemfiles/ruby_3.1_http.gemfile.lock
+++ b/gemfiles/ruby_3.1_http.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    ddtrace (1.21.0)
+    ddtrace (1.21.1)
       datadog-ci (~> 0.8.1)
       debase-ruby_core_source (= 3.3.1)
       libdatadog (~> 6.0.0.2.0)

--- a/gemfiles/ruby_3.1_opensearch_2.gemfile.lock
+++ b/gemfiles/ruby_3.1_opensearch_2.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    ddtrace (1.21.0)
+    ddtrace (1.21.1)
       datadog-ci (~> 0.8.1)
       debase-ruby_core_source (= 3.3.1)
       libdatadog (~> 6.0.0.2.0)

--- a/gemfiles/ruby_3.1_opensearch_3.gemfile.lock
+++ b/gemfiles/ruby_3.1_opensearch_3.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    ddtrace (1.21.0)
+    ddtrace (1.21.1)
       datadog-ci (~> 0.8.1)
       debase-ruby_core_source (= 3.3.1)
       libdatadog (~> 6.0.0.2.0)

--- a/gemfiles/ruby_3.1_opentelemetry.gemfile.lock
+++ b/gemfiles/ruby_3.1_opentelemetry.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    ddtrace (1.21.0)
+    ddtrace (1.21.1)
       datadog-ci (~> 0.8.1)
       debase-ruby_core_source (= 3.3.1)
       libdatadog (~> 6.0.0.2.0)

--- a/gemfiles/ruby_3.1_opentracing.gemfile.lock
+++ b/gemfiles/ruby_3.1_opentracing.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    ddtrace (1.21.0)
+    ddtrace (1.21.1)
       datadog-ci (~> 0.8.1)
       debase-ruby_core_source (= 3.3.1)
       libdatadog (~> 6.0.0.2.0)

--- a/gemfiles/ruby_3.1_rack_1.gemfile.lock
+++ b/gemfiles/ruby_3.1_rack_1.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    ddtrace (1.21.0)
+    ddtrace (1.21.1)
       datadog-ci (~> 0.8.1)
       debase-ruby_core_source (= 3.3.1)
       libdatadog (~> 6.0.0.2.0)

--- a/gemfiles/ruby_3.1_rack_2.gemfile.lock
+++ b/gemfiles/ruby_3.1_rack_2.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    ddtrace (1.21.0)
+    ddtrace (1.21.1)
       datadog-ci (~> 0.8.1)
       debase-ruby_core_source (= 3.3.1)
       libdatadog (~> 6.0.0.2.0)

--- a/gemfiles/ruby_3.1_rack_3.gemfile.lock
+++ b/gemfiles/ruby_3.1_rack_3.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    ddtrace (1.21.0)
+    ddtrace (1.21.1)
       datadog-ci (~> 0.8.1)
       debase-ruby_core_source (= 3.3.1)
       libdatadog (~> 6.0.0.2.0)

--- a/gemfiles/ruby_3.1_rails61_mysql2.gemfile.lock
+++ b/gemfiles/ruby_3.1_rails61_mysql2.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    ddtrace (1.21.0)
+    ddtrace (1.21.1)
       datadog-ci (~> 0.8.1)
       debase-ruby_core_source (= 3.3.1)
       libdatadog (~> 6.0.0.2.0)

--- a/gemfiles/ruby_3.1_rails61_postgres.gemfile.lock
+++ b/gemfiles/ruby_3.1_rails61_postgres.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    ddtrace (1.21.0)
+    ddtrace (1.21.1)
       datadog-ci (~> 0.8.1)
       debase-ruby_core_source (= 3.3.1)
       libdatadog (~> 6.0.0.2.0)

--- a/gemfiles/ruby_3.1_rails61_postgres_redis.gemfile.lock
+++ b/gemfiles/ruby_3.1_rails61_postgres_redis.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    ddtrace (1.21.0)
+    ddtrace (1.21.1)
       datadog-ci (~> 0.8.1)
       debase-ruby_core_source (= 3.3.1)
       libdatadog (~> 6.0.0.2.0)

--- a/gemfiles/ruby_3.1_rails61_postgres_sidekiq.gemfile.lock
+++ b/gemfiles/ruby_3.1_rails61_postgres_sidekiq.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    ddtrace (1.21.0)
+    ddtrace (1.21.1)
       datadog-ci (~> 0.8.1)
       debase-ruby_core_source (= 3.3.1)
       libdatadog (~> 6.0.0.2.0)

--- a/gemfiles/ruby_3.1_rails61_semantic_logger.gemfile.lock
+++ b/gemfiles/ruby_3.1_rails61_semantic_logger.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    ddtrace (1.21.0)
+    ddtrace (1.21.1)
       datadog-ci (~> 0.8.1)
       debase-ruby_core_source (= 3.3.1)
       libdatadog (~> 6.0.0.2.0)

--- a/gemfiles/ruby_3.1_rails61_trilogy.gemfile.lock
+++ b/gemfiles/ruby_3.1_rails61_trilogy.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    ddtrace (1.21.0)
+    ddtrace (1.21.1)
       datadog-ci (~> 0.8.1)
       debase-ruby_core_source (= 3.3.1)
       libdatadog (~> 6.0.0.2.0)

--- a/gemfiles/ruby_3.1_redis_3.gemfile.lock
+++ b/gemfiles/ruby_3.1_redis_3.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    ddtrace (1.21.0)
+    ddtrace (1.21.1)
       datadog-ci (~> 0.8.1)
       debase-ruby_core_source (= 3.3.1)
       libdatadog (~> 6.0.0.2.0)

--- a/gemfiles/ruby_3.1_redis_4.gemfile.lock
+++ b/gemfiles/ruby_3.1_redis_4.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    ddtrace (1.21.0)
+    ddtrace (1.21.1)
       datadog-ci (~> 0.8.1)
       debase-ruby_core_source (= 3.3.1)
       libdatadog (~> 6.0.0.2.0)

--- a/gemfiles/ruby_3.1_redis_5.gemfile.lock
+++ b/gemfiles/ruby_3.1_redis_5.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    ddtrace (1.21.0)
+    ddtrace (1.21.1)
       datadog-ci (~> 0.8.1)
       debase-ruby_core_source (= 3.3.1)
       libdatadog (~> 6.0.0.2.0)

--- a/gemfiles/ruby_3.1_relational_db.gemfile.lock
+++ b/gemfiles/ruby_3.1_relational_db.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    ddtrace (1.21.0)
+    ddtrace (1.21.1)
       datadog-ci (~> 0.8.1)
       debase-ruby_core_source (= 3.3.1)
       libdatadog (~> 6.0.0.2.0)

--- a/gemfiles/ruby_3.1_resque2_redis3.gemfile.lock
+++ b/gemfiles/ruby_3.1_resque2_redis3.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    ddtrace (1.21.0)
+    ddtrace (1.21.1)
       datadog-ci (~> 0.8.1)
       debase-ruby_core_source (= 3.3.1)
       libdatadog (~> 6.0.0.2.0)

--- a/gemfiles/ruby_3.1_resque2_redis4.gemfile.lock
+++ b/gemfiles/ruby_3.1_resque2_redis4.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    ddtrace (1.21.0)
+    ddtrace (1.21.1)
       datadog-ci (~> 0.8.1)
       debase-ruby_core_source (= 3.3.1)
       libdatadog (~> 6.0.0.2.0)

--- a/gemfiles/ruby_3.1_sinatra.gemfile.lock
+++ b/gemfiles/ruby_3.1_sinatra.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    ddtrace (1.21.0)
+    ddtrace (1.21.1)
       datadog-ci (~> 0.8.1)
       debase-ruby_core_source (= 3.3.1)
       libdatadog (~> 6.0.0.2.0)

--- a/gemfiles/ruby_3.2_activesupport.gemfile.lock
+++ b/gemfiles/ruby_3.2_activesupport.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    ddtrace (1.21.0)
+    ddtrace (1.21.1)
       datadog-ci (~> 0.8.1)
       debase-ruby_core_source (= 3.3.1)
       libdatadog (~> 6.0.0.2.0)

--- a/gemfiles/ruby_3.2_aws.gemfile.lock
+++ b/gemfiles/ruby_3.2_aws.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    ddtrace (1.21.0)
+    ddtrace (1.21.1)
       datadog-ci (~> 0.8.1)
       debase-ruby_core_source (= 3.3.1)
       libdatadog (~> 6.0.0.2.0)

--- a/gemfiles/ruby_3.2_contrib.gemfile.lock
+++ b/gemfiles/ruby_3.2_contrib.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    ddtrace (1.21.0)
+    ddtrace (1.21.1)
       datadog-ci (~> 0.8.1)
       debase-ruby_core_source (= 3.3.1)
       libdatadog (~> 6.0.0.2.0)

--- a/gemfiles/ruby_3.2_contrib_old.gemfile.lock
+++ b/gemfiles/ruby_3.2_contrib_old.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    ddtrace (1.21.0)
+    ddtrace (1.21.1)
       datadog-ci (~> 0.8.1)
       debase-ruby_core_source (= 3.3.1)
       libdatadog (~> 6.0.0.2.0)

--- a/gemfiles/ruby_3.2_core_old.gemfile.lock
+++ b/gemfiles/ruby_3.2_core_old.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    ddtrace (1.21.0)
+    ddtrace (1.21.1)
       datadog-ci (~> 0.8.1)
       debase-ruby_core_source (= 3.3.1)
       libdatadog (~> 6.0.0.2.0)

--- a/gemfiles/ruby_3.2_elasticsearch_7.gemfile.lock
+++ b/gemfiles/ruby_3.2_elasticsearch_7.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    ddtrace (1.21.0)
+    ddtrace (1.21.1)
       datadog-ci (~> 0.8.1)
       debase-ruby_core_source (= 3.3.1)
       libdatadog (~> 6.0.0.2.0)

--- a/gemfiles/ruby_3.2_elasticsearch_8.gemfile.lock
+++ b/gemfiles/ruby_3.2_elasticsearch_8.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    ddtrace (1.21.0)
+    ddtrace (1.21.1)
       datadog-ci (~> 0.8.1)
       debase-ruby_core_source (= 3.3.1)
       libdatadog (~> 6.0.0.2.0)

--- a/gemfiles/ruby_3.2_graphql_1.12.gemfile.lock
+++ b/gemfiles/ruby_3.2_graphql_1.12.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    ddtrace (1.21.0)
+    ddtrace (1.21.1)
       datadog-ci (~> 0.8.1)
       debase-ruby_core_source (= 3.3.1)
       libdatadog (~> 6.0.0.2.0)

--- a/gemfiles/ruby_3.2_graphql_1.13.gemfile.lock
+++ b/gemfiles/ruby_3.2_graphql_1.13.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    ddtrace (1.21.0)
+    ddtrace (1.21.1)
       datadog-ci (~> 0.8.1)
       debase-ruby_core_source (= 3.3.1)
       libdatadog (~> 6.0.0.2.0)

--- a/gemfiles/ruby_3.2_graphql_2.0.gemfile.lock
+++ b/gemfiles/ruby_3.2_graphql_2.0.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    ddtrace (1.21.0)
+    ddtrace (1.21.1)
       datadog-ci (~> 0.8.1)
       debase-ruby_core_source (= 3.3.1)
       libdatadog (~> 6.0.0.2.0)

--- a/gemfiles/ruby_3.2_graphql_2.1.gemfile.lock
+++ b/gemfiles/ruby_3.2_graphql_2.1.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    ddtrace (1.21.0)
+    ddtrace (1.21.1)
       datadog-ci (~> 0.8.1)
       debase-ruby_core_source (= 3.3.1)
       libdatadog (~> 6.0.0.2.0)

--- a/gemfiles/ruby_3.2_graphql_2.2.gemfile.lock
+++ b/gemfiles/ruby_3.2_graphql_2.2.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    ddtrace (1.21.0)
+    ddtrace (1.21.1)
       datadog-ci (~> 0.8.1)
       debase-ruby_core_source (= 3.3.1)
       libdatadog (~> 6.0.0.2.0)

--- a/gemfiles/ruby_3.2_http.gemfile.lock
+++ b/gemfiles/ruby_3.2_http.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    ddtrace (1.21.0)
+    ddtrace (1.21.1)
       datadog-ci (~> 0.8.1)
       debase-ruby_core_source (= 3.3.1)
       libdatadog (~> 6.0.0.2.0)

--- a/gemfiles/ruby_3.2_multi_rack_app.gemfile.lock
+++ b/gemfiles/ruby_3.2_multi_rack_app.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    ddtrace (1.21.0)
+    ddtrace (1.21.1)
       datadog-ci (~> 0.8.1)
       debase-ruby_core_source (= 3.3.1)
       libdatadog (~> 6.0.0.2.0)

--- a/gemfiles/ruby_3.2_opensearch_2.gemfile.lock
+++ b/gemfiles/ruby_3.2_opensearch_2.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    ddtrace (1.21.0)
+    ddtrace (1.21.1)
       datadog-ci (~> 0.8.1)
       debase-ruby_core_source (= 3.3.1)
       libdatadog (~> 6.0.0.2.0)

--- a/gemfiles/ruby_3.2_opensearch_3.gemfile.lock
+++ b/gemfiles/ruby_3.2_opensearch_3.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    ddtrace (1.21.0)
+    ddtrace (1.21.1)
       datadog-ci (~> 0.8.1)
       debase-ruby_core_source (= 3.3.1)
       libdatadog (~> 6.0.0.2.0)

--- a/gemfiles/ruby_3.2_opentelemetry.gemfile.lock
+++ b/gemfiles/ruby_3.2_opentelemetry.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    ddtrace (1.21.0)
+    ddtrace (1.21.1)
       datadog-ci (~> 0.8.1)
       debase-ruby_core_source (= 3.3.1)
       libdatadog (~> 6.0.0.2.0)

--- a/gemfiles/ruby_3.2_opentracing.gemfile.lock
+++ b/gemfiles/ruby_3.2_opentracing.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    ddtrace (1.21.0)
+    ddtrace (1.21.1)
       datadog-ci (~> 0.8.1)
       debase-ruby_core_source (= 3.3.1)
       libdatadog (~> 6.0.0.2.0)

--- a/gemfiles/ruby_3.2_rack_1.gemfile.lock
+++ b/gemfiles/ruby_3.2_rack_1.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    ddtrace (1.21.0)
+    ddtrace (1.21.1)
       datadog-ci (~> 0.8.1)
       debase-ruby_core_source (= 3.3.1)
       libdatadog (~> 6.0.0.2.0)

--- a/gemfiles/ruby_3.2_rack_2.gemfile.lock
+++ b/gemfiles/ruby_3.2_rack_2.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    ddtrace (1.21.0)
+    ddtrace (1.21.1)
       datadog-ci (~> 0.8.1)
       debase-ruby_core_source (= 3.3.1)
       libdatadog (~> 6.0.0.2.0)

--- a/gemfiles/ruby_3.2_rack_3.gemfile.lock
+++ b/gemfiles/ruby_3.2_rack_3.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    ddtrace (1.21.0)
+    ddtrace (1.21.1)
       datadog-ci (~> 0.8.1)
       debase-ruby_core_source (= 3.3.1)
       libdatadog (~> 6.0.0.2.0)

--- a/gemfiles/ruby_3.2_rails61_mysql2.gemfile.lock
+++ b/gemfiles/ruby_3.2_rails61_mysql2.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    ddtrace (1.21.0)
+    ddtrace (1.21.1)
       datadog-ci (~> 0.8.1)
       debase-ruby_core_source (= 3.3.1)
       libdatadog (~> 6.0.0.2.0)

--- a/gemfiles/ruby_3.2_rails61_postgres.gemfile.lock
+++ b/gemfiles/ruby_3.2_rails61_postgres.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    ddtrace (1.21.0)
+    ddtrace (1.21.1)
       datadog-ci (~> 0.8.1)
       debase-ruby_core_source (= 3.3.1)
       libdatadog (~> 6.0.0.2.0)

--- a/gemfiles/ruby_3.2_rails61_postgres_redis.gemfile.lock
+++ b/gemfiles/ruby_3.2_rails61_postgres_redis.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    ddtrace (1.21.0)
+    ddtrace (1.21.1)
       datadog-ci (~> 0.8.1)
       debase-ruby_core_source (= 3.3.1)
       libdatadog (~> 6.0.0.2.0)

--- a/gemfiles/ruby_3.2_rails61_postgres_sidekiq.gemfile.lock
+++ b/gemfiles/ruby_3.2_rails61_postgres_sidekiq.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    ddtrace (1.21.0)
+    ddtrace (1.21.1)
       datadog-ci (~> 0.8.1)
       debase-ruby_core_source (= 3.3.1)
       libdatadog (~> 6.0.0.2.0)

--- a/gemfiles/ruby_3.2_rails61_semantic_logger.gemfile.lock
+++ b/gemfiles/ruby_3.2_rails61_semantic_logger.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    ddtrace (1.21.0)
+    ddtrace (1.21.1)
       datadog-ci (~> 0.8.1)
       debase-ruby_core_source (= 3.3.1)
       libdatadog (~> 6.0.0.2.0)

--- a/gemfiles/ruby_3.2_rails61_trilogy.gemfile.lock
+++ b/gemfiles/ruby_3.2_rails61_trilogy.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    ddtrace (1.21.0)
+    ddtrace (1.21.1)
       datadog-ci (~> 0.8.1)
       debase-ruby_core_source (= 3.3.1)
       libdatadog (~> 6.0.0.2.0)

--- a/gemfiles/ruby_3.2_redis_3.gemfile.lock
+++ b/gemfiles/ruby_3.2_redis_3.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    ddtrace (1.21.0)
+    ddtrace (1.21.1)
       datadog-ci (~> 0.8.1)
       debase-ruby_core_source (= 3.3.1)
       libdatadog (~> 6.0.0.2.0)

--- a/gemfiles/ruby_3.2_redis_4.gemfile.lock
+++ b/gemfiles/ruby_3.2_redis_4.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    ddtrace (1.21.0)
+    ddtrace (1.21.1)
       datadog-ci (~> 0.8.1)
       debase-ruby_core_source (= 3.3.1)
       libdatadog (~> 6.0.0.2.0)

--- a/gemfiles/ruby_3.2_redis_5.gemfile.lock
+++ b/gemfiles/ruby_3.2_redis_5.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    ddtrace (1.21.0)
+    ddtrace (1.21.1)
       datadog-ci (~> 0.8.1)
       debase-ruby_core_source (= 3.3.1)
       libdatadog (~> 6.0.0.2.0)

--- a/gemfiles/ruby_3.2_relational_db.gemfile.lock
+++ b/gemfiles/ruby_3.2_relational_db.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    ddtrace (1.21.0)
+    ddtrace (1.21.1)
       datadog-ci (~> 0.8.1)
       debase-ruby_core_source (= 3.3.1)
       libdatadog (~> 6.0.0.2.0)

--- a/gemfiles/ruby_3.2_resque2_redis3.gemfile.lock
+++ b/gemfiles/ruby_3.2_resque2_redis3.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    ddtrace (1.21.0)
+    ddtrace (1.21.1)
       datadog-ci (~> 0.8.1)
       debase-ruby_core_source (= 3.3.1)
       libdatadog (~> 6.0.0.2.0)

--- a/gemfiles/ruby_3.2_resque2_redis4.gemfile.lock
+++ b/gemfiles/ruby_3.2_resque2_redis4.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    ddtrace (1.21.0)
+    ddtrace (1.21.1)
       datadog-ci (~> 0.8.1)
       debase-ruby_core_source (= 3.3.1)
       libdatadog (~> 6.0.0.2.0)

--- a/gemfiles/ruby_3.2_sinatra.gemfile.lock
+++ b/gemfiles/ruby_3.2_sinatra.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    ddtrace (1.21.0)
+    ddtrace (1.21.1)
       datadog-ci (~> 0.8.1)
       debase-ruby_core_source (= 3.3.1)
       libdatadog (~> 6.0.0.2.0)

--- a/gemfiles/ruby_3.3_activesupport.gemfile.lock
+++ b/gemfiles/ruby_3.3_activesupport.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    ddtrace (1.21.0)
+    ddtrace (1.21.1)
       datadog-ci (~> 0.8.1)
       debase-ruby_core_source (= 3.3.1)
       libdatadog (~> 6.0.0.2.0)

--- a/gemfiles/ruby_3.3_aws.gemfile.lock
+++ b/gemfiles/ruby_3.3_aws.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    ddtrace (1.21.0)
+    ddtrace (1.21.1)
       datadog-ci (~> 0.8.1)
       debase-ruby_core_source (= 3.3.1)
       libdatadog (~> 6.0.0.2.0)

--- a/gemfiles/ruby_3.3_contrib.gemfile.lock
+++ b/gemfiles/ruby_3.3_contrib.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    ddtrace (1.21.0)
+    ddtrace (1.21.1)
       datadog-ci (~> 0.8.1)
       debase-ruby_core_source (= 3.3.1)
       libdatadog (~> 6.0.0.2.0)

--- a/gemfiles/ruby_3.3_contrib_old.gemfile.lock
+++ b/gemfiles/ruby_3.3_contrib_old.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    ddtrace (1.21.0)
+    ddtrace (1.21.1)
       datadog-ci (~> 0.8.1)
       debase-ruby_core_source (= 3.3.1)
       libdatadog (~> 6.0.0.2.0)

--- a/gemfiles/ruby_3.3_core_old.gemfile.lock
+++ b/gemfiles/ruby_3.3_core_old.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    ddtrace (1.21.0)
+    ddtrace (1.21.1)
       datadog-ci (~> 0.8.1)
       debase-ruby_core_source (= 3.3.1)
       libdatadog (~> 6.0.0.2.0)

--- a/gemfiles/ruby_3.3_elasticsearch_7.gemfile.lock
+++ b/gemfiles/ruby_3.3_elasticsearch_7.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    ddtrace (1.21.0)
+    ddtrace (1.21.1)
       datadog-ci (~> 0.8.1)
       debase-ruby_core_source (= 3.3.1)
       libdatadog (~> 6.0.0.2.0)

--- a/gemfiles/ruby_3.3_elasticsearch_8.gemfile.lock
+++ b/gemfiles/ruby_3.3_elasticsearch_8.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    ddtrace (1.21.0)
+    ddtrace (1.21.1)
       datadog-ci (~> 0.8.1)
       debase-ruby_core_source (= 3.3.1)
       libdatadog (~> 6.0.0.2.0)

--- a/gemfiles/ruby_3.3_graphql_1.12.gemfile.lock
+++ b/gemfiles/ruby_3.3_graphql_1.12.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    ddtrace (1.21.0)
+    ddtrace (1.21.1)
       datadog-ci (~> 0.8.1)
       debase-ruby_core_source (= 3.3.1)
       libdatadog (~> 6.0.0.2.0)

--- a/gemfiles/ruby_3.3_graphql_1.13.gemfile.lock
+++ b/gemfiles/ruby_3.3_graphql_1.13.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    ddtrace (1.21.0)
+    ddtrace (1.21.1)
       datadog-ci (~> 0.8.1)
       debase-ruby_core_source (= 3.3.1)
       libdatadog (~> 6.0.0.2.0)

--- a/gemfiles/ruby_3.3_graphql_2.0.gemfile.lock
+++ b/gemfiles/ruby_3.3_graphql_2.0.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    ddtrace (1.21.0)
+    ddtrace (1.21.1)
       datadog-ci (~> 0.8.1)
       debase-ruby_core_source (= 3.3.1)
       libdatadog (~> 6.0.0.2.0)

--- a/gemfiles/ruby_3.3_graphql_2.1.gemfile.lock
+++ b/gemfiles/ruby_3.3_graphql_2.1.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    ddtrace (1.21.0)
+    ddtrace (1.21.1)
       datadog-ci (~> 0.8.1)
       debase-ruby_core_source (= 3.3.1)
       libdatadog (~> 6.0.0.2.0)

--- a/gemfiles/ruby_3.3_graphql_2.2.gemfile.lock
+++ b/gemfiles/ruby_3.3_graphql_2.2.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    ddtrace (1.21.0)
+    ddtrace (1.21.1)
       datadog-ci (~> 0.8.1)
       debase-ruby_core_source (= 3.3.1)
       libdatadog (~> 6.0.0.2.0)

--- a/gemfiles/ruby_3.3_http.gemfile.lock
+++ b/gemfiles/ruby_3.3_http.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    ddtrace (1.21.0)
+    ddtrace (1.21.1)
       datadog-ci (~> 0.8.1)
       debase-ruby_core_source (= 3.3.1)
       libdatadog (~> 6.0.0.2.0)

--- a/gemfiles/ruby_3.3_multi_rack_app.gemfile.lock
+++ b/gemfiles/ruby_3.3_multi_rack_app.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    ddtrace (1.21.0)
+    ddtrace (1.21.1)
       datadog-ci (~> 0.8.1)
       debase-ruby_core_source (= 3.3.1)
       libdatadog (~> 6.0.0.2.0)

--- a/gemfiles/ruby_3.3_opensearch_2.gemfile.lock
+++ b/gemfiles/ruby_3.3_opensearch_2.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    ddtrace (1.21.0)
+    ddtrace (1.21.1)
       datadog-ci (~> 0.8.1)
       debase-ruby_core_source (= 3.3.1)
       libdatadog (~> 6.0.0.2.0)

--- a/gemfiles/ruby_3.3_opensearch_3.gemfile.lock
+++ b/gemfiles/ruby_3.3_opensearch_3.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    ddtrace (1.21.0)
+    ddtrace (1.21.1)
       datadog-ci (~> 0.8.1)
       debase-ruby_core_source (= 3.3.1)
       libdatadog (~> 6.0.0.2.0)

--- a/gemfiles/ruby_3.3_opentelemetry.gemfile.lock
+++ b/gemfiles/ruby_3.3_opentelemetry.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    ddtrace (1.21.0)
+    ddtrace (1.21.1)
       datadog-ci (~> 0.8.1)
       debase-ruby_core_source (= 3.3.1)
       libdatadog (~> 6.0.0.2.0)

--- a/gemfiles/ruby_3.3_opentracing.gemfile.lock
+++ b/gemfiles/ruby_3.3_opentracing.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    ddtrace (1.21.0)
+    ddtrace (1.21.1)
       datadog-ci (~> 0.8.1)
       debase-ruby_core_source (= 3.3.1)
       libdatadog (~> 6.0.0.2.0)

--- a/gemfiles/ruby_3.3_rack_1.gemfile.lock
+++ b/gemfiles/ruby_3.3_rack_1.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    ddtrace (1.21.0)
+    ddtrace (1.21.1)
       datadog-ci (~> 0.8.1)
       debase-ruby_core_source (= 3.3.1)
       libdatadog (~> 6.0.0.2.0)

--- a/gemfiles/ruby_3.3_rack_2.gemfile.lock
+++ b/gemfiles/ruby_3.3_rack_2.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    ddtrace (1.21.0)
+    ddtrace (1.21.1)
       datadog-ci (~> 0.8.1)
       debase-ruby_core_source (= 3.3.1)
       libdatadog (~> 6.0.0.2.0)

--- a/gemfiles/ruby_3.3_rack_3.gemfile.lock
+++ b/gemfiles/ruby_3.3_rack_3.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    ddtrace (1.21.0)
+    ddtrace (1.21.1)
       datadog-ci (~> 0.8.1)
       debase-ruby_core_source (= 3.3.1)
       libdatadog (~> 6.0.0.2.0)

--- a/gemfiles/ruby_3.3_rails61_mysql2.gemfile.lock
+++ b/gemfiles/ruby_3.3_rails61_mysql2.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    ddtrace (1.21.0)
+    ddtrace (1.21.1)
       datadog-ci (~> 0.8.1)
       debase-ruby_core_source (= 3.3.1)
       libdatadog (~> 6.0.0.2.0)

--- a/gemfiles/ruby_3.3_rails61_postgres.gemfile.lock
+++ b/gemfiles/ruby_3.3_rails61_postgres.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    ddtrace (1.21.0)
+    ddtrace (1.21.1)
       datadog-ci (~> 0.8.1)
       debase-ruby_core_source (= 3.3.1)
       libdatadog (~> 6.0.0.2.0)

--- a/gemfiles/ruby_3.3_rails61_postgres_redis.gemfile.lock
+++ b/gemfiles/ruby_3.3_rails61_postgres_redis.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    ddtrace (1.21.0)
+    ddtrace (1.21.1)
       datadog-ci (~> 0.8.1)
       debase-ruby_core_source (= 3.3.1)
       libdatadog (~> 6.0.0.2.0)

--- a/gemfiles/ruby_3.3_rails61_postgres_sidekiq.gemfile.lock
+++ b/gemfiles/ruby_3.3_rails61_postgres_sidekiq.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    ddtrace (1.21.0)
+    ddtrace (1.21.1)
       datadog-ci (~> 0.8.1)
       debase-ruby_core_source (= 3.3.1)
       libdatadog (~> 6.0.0.2.0)

--- a/gemfiles/ruby_3.3_rails61_semantic_logger.gemfile.lock
+++ b/gemfiles/ruby_3.3_rails61_semantic_logger.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    ddtrace (1.21.0)
+    ddtrace (1.21.1)
       datadog-ci (~> 0.8.1)
       debase-ruby_core_source (= 3.3.1)
       libdatadog (~> 6.0.0.2.0)

--- a/gemfiles/ruby_3.3_rails61_trilogy.gemfile.lock
+++ b/gemfiles/ruby_3.3_rails61_trilogy.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    ddtrace (1.21.0)
+    ddtrace (1.21.1)
       datadog-ci (~> 0.8.1)
       debase-ruby_core_source (= 3.3.1)
       libdatadog (~> 6.0.0.2.0)

--- a/gemfiles/ruby_3.3_redis_3.gemfile.lock
+++ b/gemfiles/ruby_3.3_redis_3.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    ddtrace (1.21.0)
+    ddtrace (1.21.1)
       datadog-ci (~> 0.8.1)
       debase-ruby_core_source (= 3.3.1)
       libdatadog (~> 6.0.0.2.0)

--- a/gemfiles/ruby_3.3_redis_4.gemfile.lock
+++ b/gemfiles/ruby_3.3_redis_4.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    ddtrace (1.21.0)
+    ddtrace (1.21.1)
       datadog-ci (~> 0.8.1)
       debase-ruby_core_source (= 3.3.1)
       libdatadog (~> 6.0.0.2.0)

--- a/gemfiles/ruby_3.3_redis_5.gemfile.lock
+++ b/gemfiles/ruby_3.3_redis_5.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    ddtrace (1.21.0)
+    ddtrace (1.21.1)
       datadog-ci (~> 0.8.1)
       debase-ruby_core_source (= 3.3.1)
       libdatadog (~> 6.0.0.2.0)

--- a/gemfiles/ruby_3.3_relational_db.gemfile.lock
+++ b/gemfiles/ruby_3.3_relational_db.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    ddtrace (1.21.0)
+    ddtrace (1.21.1)
       datadog-ci (~> 0.8.1)
       debase-ruby_core_source (= 3.3.1)
       libdatadog (~> 6.0.0.2.0)

--- a/gemfiles/ruby_3.3_resque2_redis3.gemfile.lock
+++ b/gemfiles/ruby_3.3_resque2_redis3.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    ddtrace (1.21.0)
+    ddtrace (1.21.1)
       datadog-ci (~> 0.8.1)
       debase-ruby_core_source (= 3.3.1)
       libdatadog (~> 6.0.0.2.0)

--- a/gemfiles/ruby_3.3_resque2_redis4.gemfile.lock
+++ b/gemfiles/ruby_3.3_resque2_redis4.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    ddtrace (1.21.0)
+    ddtrace (1.21.1)
       datadog-ci (~> 0.8.1)
       debase-ruby_core_source (= 3.3.1)
       libdatadog (~> 6.0.0.2.0)

--- a/gemfiles/ruby_3.3_sinatra.gemfile.lock
+++ b/gemfiles/ruby_3.3_sinatra.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    ddtrace (1.21.0)
+    ddtrace (1.21.1)
       datadog-ci (~> 0.8.1)
       debase-ruby_core_source (= 3.3.1)
       libdatadog (~> 6.0.0.2.0)

--- a/lib/ddtrace/version.rb
+++ b/lib/ddtrace/version.rb
@@ -4,7 +4,7 @@ module DDTrace
   module VERSION
     MAJOR = 1
     MINOR = 21
-    PATCH = 0
+    PATCH = 1
     PRE = nil
     BUILD = nil
     # PRE and BUILD above are modified for dev gems during gem build GHA workflow


### PR DESCRIPTION
### Added

* Backports auto instrument shim with `datadog/auto_instrument` (#3535)

### Fixed

* Fix ActiveRecord resolving invalid string (#3523)
* Revert `http.route` tagging to fix instrumentation failure for Rails 7.1 apps (#3539)
* Fix wrong permissions on released gem files (#3531)