### PR TITLE
Enable docker mode for system tests

### DIFF
--- a/.github/workflows/system-tests.yml
+++ b/.github/workflows/system-tests.yml
@@ -18,11 +18,11 @@ jobs:
       matrix:
         image:
           - name: runner
-            version: runner
+            internal: system_tests/runner
           - name: agent
-            version: agent
+            internal: system_tests/agent
           - name: proxy
-            version: proxy-v1
+            internal: system-tests/proxy-v1
     runs-on: ubuntu-latest
     name: Build (${{ matrix.image }})
     steps:
@@ -33,7 +33,7 @@ jobs:
       - name: Pull released image
         run: |
           if docker pull ghcr.io/datadog/dd-trace-rb/system-tests/${{ matrix.image.name }}:latest; then
-            docker tag ghcr.io/datadog/dd-trace-rb/system-tests/${{ matrix.image.name }}:latest system_tests/${{ matrix.image.version }}:latest
+            docker tag ghcr.io/datadog/dd-trace-rb/system-tests/${{ matrix.image.name }}:latest ${{ matrix.image.internal }}:latest
           fi
       - name: Build image
         run: ./build.sh --images ${{ matrix.image.name }} --docker
@@ -45,14 +45,14 @@ jobs:
           echo ${{ secrets.GITHUB_TOKEN }} | docker login ${{ env.REGISTRY }} -u ${{ github.actor }} --password-stdin
       - name: Tag image for CI run
         run:
-          docker tag system_tests/${{ matrix.image.version }}:latest ghcr.io/datadog/dd-trace-rb/system-tests/${{ matrix.image.name }}:gha${{ github.run_id }}-g${{ github.sha }}
+          docker tag ${{ matrix.image.internal }}:latest ghcr.io/datadog/dd-trace-rb/system-tests/${{ matrix.image.name }}:gha${{ github.run_id }}-g${{ github.sha }}
       - name: Push image for CI run
         run: |
           docker push ghcr.io/datadog/dd-trace-rb/system-tests/${{ matrix.image.name }}:gha${{ github.run_id }}-g${{ github.sha }}
       - name: Tag image for release
         if: ${{ github.ref == 'refs/heads/master' }}
         run:
-          docker tag system_tests/${{ matrix.image.version }}:latest ghcr.io/datadog/dd-trace-rb/system-tests/${{ matrix.image.name }}:latest
+          docker tag ${{ matrix.image.internal }}:latest ghcr.io/datadog/dd-trace-rb/system-tests/${{ matrix.image.name }}:latest
       - name: Push image for release
         if: ${{ github.ref == 'refs/heads/master' }}
         run: |
@@ -223,7 +223,7 @@ jobs:
       - name: Pull proxy image
         run: |
           docker pull ghcr.io/datadog/dd-trace-rb/system-tests/proxy:gha${{ github.run_id }}-g${{ github.sha }}
-          docker tag ghcr.io/datadog/dd-trace-rb/system-tests/proxy:gha${{ github.run_id }}-g${{ github.sha }} system_tests/proxy-v1:latest
+          docker tag ghcr.io/datadog/dd-trace-rb/system-tests/proxy:gha${{ github.run_id }}-g${{ github.sha }} system-tests/proxy-v1:latest
       - name: Pull agent image
         run: |
           docker pull ghcr.io/datadog/dd-trace-rb/system-tests/agent:gha${{ github.run_id }}-g${{ github.sha }}

--- a/.github/workflows/system-tests.yml
+++ b/.github/workflows/system-tests.yml
@@ -10,6 +10,7 @@ on:
 
 env:
   REGISTRY: ghcr.io
+  REPO: ghcr.io/datadog/dd-trace-rb
 
 jobs:
   build-harness:
@@ -30,10 +31,11 @@ jobs:
         uses: actions/checkout@v4
         with:
           repository: 'DataDog/system-tests'
+          ref: fix-docker-mode
       - name: Pull released image
         run: |
-          if docker pull ghcr.io/datadog/dd-trace-rb/system-tests/${{ matrix.image.name }}:latest; then
-            docker tag ghcr.io/datadog/dd-trace-rb/system-tests/${{ matrix.image.name }}:latest ${{ matrix.image.internal }}
+          if docker pull ${{ env.REPO }}/system-tests/${{ matrix.image.name }}:latest; then
+            docker tag ${{ env.REPO }}/system-tests/${{ matrix.image.name }}:latest ${{ matrix.image.internal }}
           fi
       - name: Build image
         run: ./build.sh --images ${{ matrix.image.name }} --docker --extra-docker-args '--cache-from ${{ matrix.image.internal }}'
@@ -45,18 +47,18 @@ jobs:
           echo ${{ secrets.GITHUB_TOKEN }} | docker login ${{ env.REGISTRY }} -u ${{ github.actor }} --password-stdin
       - name: Tag image for CI run
         run:
-          docker tag ${{ matrix.image.internal }} ghcr.io/datadog/dd-trace-rb/system-tests/${{ matrix.image.name }}:gha${{ github.run_id }}-g${{ github.sha }}
+          docker tag ${{ matrix.image.internal }} ${{ env.REPO }}/system-tests/${{ matrix.image.name }}:gha${{ github.run_id }}-g${{ github.sha }}
       - name: Push image for CI run
         run: |
-          docker push ghcr.io/datadog/dd-trace-rb/system-tests/${{ matrix.image.name }}:gha${{ github.run_id }}-g${{ github.sha }}
+          docker push ${{ env.REPO }}/system-tests/${{ matrix.image.name }}:gha${{ github.run_id }}-g${{ github.sha }}
       - name: Tag image for release
         if: ${{ github.ref == 'refs/heads/master' }}
         run:
-          docker tag ${{ matrix.image.internal }} ghcr.io/datadog/dd-trace-rb/system-tests/${{ matrix.image.name }}:latest
+          docker tag ${{ matrix.image.internal }} ${{ env.REPO }}/system-tests/${{ matrix.image.name }}:latest
       - name: Push image for release
         if: ${{ github.ref == 'refs/heads/master' }}
         run: |
-          docker push ghcr.io/datadog/dd-trace-rb/system-tests/${{ matrix.image.name }}:latest
+          docker push ${{ env.REPO }}/system-tests/${{ matrix.image.name }}:latest
 
   build-apps:
     strategy:
@@ -65,7 +67,9 @@ jobs:
         image:
           - weblog
         library:
-          - ruby
+          - name: ruby
+            repository: DataDog/dd-trace-rb
+            path: dd-trace-rb
         app:
           - rack
           - sinatra14
@@ -89,34 +93,36 @@ jobs:
         uses: actions/checkout@v4
         with:
           repository: 'DataDog/system-tests'
-      - name: Checkout dd-trace-rb
+          ref: fix-docker-mode
+      - name: Checkout ${{ matrix.library.repository }}
         uses: actions/checkout@v4
         with:
-          path: 'binaries/dd-trace-rb'
+          repository: '${{ matrix.library.repository }}'
+          path: 'binaries/${{ matrix.library.path }}'
       - name: Pull released image
         run: |
-          if docker pull ghcr.io/datadog/dd-trace-rb/system-tests/${{ matrix.image }}-${{ matrix.app }}:latest; then
-            docker tag ghcr.io/datadog/dd-trace-rb/system-tests/${{ matrix.image }}-${{ matrix.app }}:latest system_tests/${{ matrix.image }}:latest
+          if docker pull ${{ env.REPO }}/system-tests/${{ matrix.library.name }}/${{ matrix.image }}-${{ matrix.app }}:latest; then
+            docker tag ${{ env.REPO }}/system-tests/${{ matrix.library.name }}/${{ matrix.image }}-${{ matrix.app }}:latest system_tests/${{ matrix.image }}:latest
           fi
       - name: Log in to the Container registry
         run: |
           echo ${{ secrets.GITHUB_TOKEN }} | docker login ${{ env.REGISTRY }} -u ${{ github.actor }} --password-stdin
       - name: Build
-        run: ./build.sh --library ${{ matrix.library }} --weblog-variant ${{ matrix.app }} --images ${{ matrix.image }} --extra-docker-args '--cache-from system_tests/${{ matrix.image }}:latest'
+        run: ./build.sh --library ${{ matrix.library.name }} --weblog-variant ${{ matrix.app }} --images ${{ matrix.image }} --extra-docker-args '--cache-from system_tests/${{ matrix.image }}:latest'
       - name: Tag image for CI run
         run:
-          docker tag system_tests/${{ matrix.image }}:latest ghcr.io/datadog/dd-trace-rb/system-tests/${{ matrix.image }}-${{ matrix.app }}:gha${{ github.run_id }}-g${{ github.sha }}
+          docker tag system_tests/${{ matrix.image }}:latest ${{ env.REPO }}/system-tests/${{ matrix.library.name }}/${{ matrix.image }}-${{ matrix.app }}:gha${{ github.run_id }}-g${{ github.sha }}
       - name: Push image for CI run
         run: |
-          docker push ghcr.io/datadog/dd-trace-rb/system-tests/${{ matrix.image }}-${{ matrix.app }}:gha${{ github.run_id }}-g${{ github.sha }}
+          docker push ${{ env.REPO }}/system-tests/${{ matrix.library.name }}/${{ matrix.image }}-${{ matrix.app }}:gha${{ github.run_id }}-g${{ github.sha }}
       - name: Tag image for release
         if: ${{ github.ref == 'refs/heads/master' }}
         run:
-          docker tag system_tests/${{ matrix.image }}:latest ghcr.io/datadog/dd-trace-rb/system-tests/${{ matrix.image }}-${{ matrix.app }}:latest
+          docker tag system_tests/${{ matrix.image }}:latest ${{ env.REPO }}/system-tests/${{ matrix.library.name }}/${{ matrix.image }}-${{ matrix.app }}:latest
       - name: Push image for release
         if: ${{ github.ref == 'refs/heads/master' }}
         run: |
-          docker push ghcr.io/datadog/dd-trace-rb/system-tests/${{ matrix.image }}-${{ matrix.app }}:latest
+          docker push ${{ env.REPO }}/system-tests/${{ matrix.library.name }}/${{ matrix.image }}-${{ matrix.app }}:latest
 
   test:
     strategy:
@@ -139,6 +145,7 @@ jobs:
           - rails60
           - rails61
           - rails70
+          - rails71
         scenario:
           - DEFAULT
           - APPSEC_DISABLED
@@ -208,30 +215,27 @@ jobs:
       - build-apps
     name: Test (${{ matrix.app }}, ${{ matrix.scenario }})
     steps:
-      - name: Setup python 3.9
-        uses: actions/setup-python@v4
-        with:
-          python-version: '3.9'
       - name: Checkout
         uses: actions/checkout@v4
         with:
           repository: 'DataDog/system-tests'
+          ref: fix-docker-mode
       - name: Pull runner image
         run: |
-          docker pull ghcr.io/datadog/dd-trace-rb/system-tests/runner:gha${{ github.run_id }}-g${{ github.sha }}
-          docker tag ghcr.io/datadog/dd-trace-rb/system-tests/runner:gha${{ github.run_id }}-g${{ github.sha }} system_tests/runner:latest
+          docker pull ${{ env.REPO }}/system-tests/runner:gha${{ github.run_id }}-g${{ github.sha }}
+          docker tag ${{ env.REPO }}/system-tests/runner:gha${{ github.run_id }}-g${{ github.sha }} system_tests/runner:latest
       - name: Pull proxy image
         run: |
-          docker pull ghcr.io/datadog/dd-trace-rb/system-tests/proxy:gha${{ github.run_id }}-g${{ github.sha }}
-          docker tag ghcr.io/datadog/dd-trace-rb/system-tests/proxy:gha${{ github.run_id }}-g${{ github.sha }} datadog/system-tests:proxy-v1
+          docker pull ${{ env.REPO }}/system-tests/proxy:gha${{ github.run_id }}-g${{ github.sha }}
+          docker tag ${{ env.REPO }}/system-tests/proxy:gha${{ github.run_id }}-g${{ github.sha }} datadog/system-tests:proxy-v1
       - name: Pull agent image
         run: |
-          docker pull ghcr.io/datadog/dd-trace-rb/system-tests/agent:gha${{ github.run_id }}-g${{ github.sha }}
-          docker tag ghcr.io/datadog/dd-trace-rb/system-tests/agent:gha${{ github.run_id }}-g${{ github.sha }} system_tests/agent:latest
+          docker pull ${{ env.REPO }}/system-tests/agent:gha${{ github.run_id }}-g${{ github.sha }}
+          docker tag ${{ env.REPO }}/system-tests/agent:gha${{ github.run_id }}-g${{ github.sha }} system_tests/agent:latest
       - name: Pull app image
         run: |
-          docker pull ghcr.io/datadog/dd-trace-rb/system-tests/weblog-${{ matrix.app }}:gha${{ github.run_id }}-g${{ github.sha }}
-          docker tag ghcr.io/datadog/dd-trace-rb/system-tests/weblog-${{ matrix.app }}:gha${{ github.run_id }}-g${{ github.sha }} system_tests/weblog:latest
+          docker pull ${{ env.REPO }}/system-tests/${{ matrix.library }}/weblog-${{ matrix.app }}:gha${{ github.run_id }}-g${{ github.sha }}
+          docker tag ${{ env.REPO }}/system-tests/${{ matrix.library }}/weblog-${{ matrix.app }}:gha${{ github.run_id }}-g${{ github.sha }} system_tests/weblog:latest
       - name: List images
         run: |
           docker image list
@@ -239,27 +243,12 @@ jobs:
         run: ./run.sh ++docker ${{ matrix.scenario }}
         env:
           DD_API_KEY: ${{ secrets.DD_APPSEC_SYSTEM_TESTS_API_KEY }}
-      - name: Archive logs (per scenario)
-        uses: actions/upload-artifact@v3
+      - name: Archive logs
+        uses: actions/upload-artifact@v4
         if: ${{ always() }}
         with:
           name: system-tests-${{ matrix.library }}-${{ matrix.app }}-${{ matrix.scenario }}-logs-gha${{ github.run_id }}-g${{ github.sha }}
           path: logs*
-      - name: Archive logs (aggregated)
-        uses: actions/upload-artifact@v3
-        if: ${{ always() }}
-        with:
-          name: system-tests-${{ matrix.library }}-${{ matrix.app }}-logs-gha${{ github.run_id }}-g${{ github.sha }}
-          path: logs*
-
-  all_test_successful:
-    name: System tests successful
-    runs-on: ubuntu-latest
-    needs:
-      - test
-    steps:
-      - name: System tests successful
-        run: echo "Done"
 
   aggregate:
     strategy:
@@ -282,6 +271,7 @@ jobs:
           - rails60
           - rails61
           - rails70
+          - rails71
     runs-on: ubuntu-latest
     needs:
       - test
@@ -289,56 +279,21 @@ jobs:
     name: Aggregate (${{ matrix.app }})
     steps:
       - name: Setup python 3.9
-        uses: actions/setup-python@v4
+        uses: actions/setup-python@v5
         with:
           python-version: '3.9'
       - name: Checkout
         uses: actions/checkout@v4
         with:
           repository: 'DataDog/system-tests'
+          ref: fix-docker-mode
       - name: Retrieve logs
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         with:
-          name: system-tests-${{ matrix.library }}-${{ matrix.app }}-logs-gha${{ github.run_id }}-g${{ github.sha }}
+          pattern: system-tests-${{ matrix.library }}-${{ matrix.app }}-*-logs-gha${{ github.run_id }}-g${{ github.sha }}
+          merge-multiple: true
           path: .
       - name: Print fancy log report
         run: |
           find logs*
           python utils/scripts/markdown_logs.py >> $GITHUB_STEP_SUMMARY
-
-  cleanup:
-    strategy:
-      fail-fast: false
-      matrix:
-        image:
-          - runner
-          - agent
-          - weblog-rack
-          - weblog-sinatra14
-          - weblog-sinatra20
-          - weblog-sinatra21
-          - weblog-rails32
-          - weblog-rails40
-          - weblog-rails41
-          - weblog-rails42
-          - weblog-rails50
-          - weblog-rails51
-          - weblog-rails52
-          - weblog-rails60
-          - weblog-rails61
-          - weblog-rails70
-    runs-on: ubuntu-latest
-    needs:
-      - test
-    if: ${{ always() }}
-    name: Cleanup (${{ matrix.image }})
-    steps:
-      - name: Log in to the Container registry
-        run: |
-          echo ${{ secrets.GITHUB_TOKEN }} | docker login ${{ env.REGISTRY }} -u ${{ github.actor }} --password-stdin
-      - uses: actions/delete-package-versions@v4
-        with:
-          package-version-ids: 'gha${{ github.run_id }}-g${{ github.sha }}'
-          package-name: 'system-tests/${{ matrix.image }}'
-          package-type: 'container'
-        continue-on-error: true

--- a/.github/workflows/system-tests.yml
+++ b/.github/workflows/system-tests.yml
@@ -19,7 +19,7 @@ jobs:
         image:
           - runner
           - agent
-          - proxy
+          - proxy-v1
     runs-on: ubuntu-latest
     name: Build (${{ matrix.image }})
     steps:
@@ -220,7 +220,7 @@ jobs:
       - name: Pull proxy image
         run: |
           docker pull ghcr.io/datadog/dd-trace-rb/system-tests/agent:gha${{ github.run_id }}-g${{ github.sha }}
-          docker tag ghcr.io/datadog/dd-trace-rb/system-tests/agent:gha${{ github.run_id }}-g${{ github.sha }} system_tests/proxy:latest
+          docker tag ghcr.io/datadog/dd-trace-rb/system-tests/agent:gha${{ github.run_id }}-g${{ github.sha }} system_tests/proxy-v1:latest
       - name: Pull agent image
         run: |
           docker pull ghcr.io/datadog/dd-trace-rb/system-tests/agent:gha${{ github.run_id }}-g${{ github.sha }}

--- a/.github/workflows/system-tests.yml
+++ b/.github/workflows/system-tests.yml
@@ -24,7 +24,7 @@ jobs:
           - name: proxy
             internal: system-tests/proxy-v1
     runs-on: ubuntu-latest
-    name: Build (${{ matrix.image }})
+    name: Build (${{ matrix.image.name }})
     steps:
       - name: Checkout
         uses: actions/checkout@v4

--- a/.github/workflows/system-tests.yml
+++ b/.github/workflows/system-tests.yml
@@ -18,11 +18,11 @@ jobs:
       matrix:
         image:
           - name: runner
-            internal: system_tests/runner
+            internal: system_tests/runner:latest
           - name: agent
-            internal: system_tests/agent
+            internal: system_tests/agent:latest
           - name: proxy
-            internal: system-tests/proxy-v1
+            internal: datadog/system-tests:proxy-v1
     runs-on: ubuntu-latest
     name: Build (${{ matrix.image.name }})
     steps:
@@ -33,7 +33,7 @@ jobs:
       - name: Pull released image
         run: |
           if docker pull ghcr.io/datadog/dd-trace-rb/system-tests/${{ matrix.image.name }}:latest; then
-            docker tag ghcr.io/datadog/dd-trace-rb/system-tests/${{ matrix.image.name }}:latest ${{ matrix.image.internal }}:latest
+            docker tag ghcr.io/datadog/dd-trace-rb/system-tests/${{ matrix.image.name }}:latest ${{ matrix.image.internal }}
           fi
       - name: Build image
         run: ./build.sh --images ${{ matrix.image.name }} --docker
@@ -45,14 +45,14 @@ jobs:
           echo ${{ secrets.GITHUB_TOKEN }} | docker login ${{ env.REGISTRY }} -u ${{ github.actor }} --password-stdin
       - name: Tag image for CI run
         run:
-          docker tag ${{ matrix.image.internal }}:latest ghcr.io/datadog/dd-trace-rb/system-tests/${{ matrix.image.name }}:gha${{ github.run_id }}-g${{ github.sha }}
+          docker tag ${{ matrix.image.internal }} ghcr.io/datadog/dd-trace-rb/system-tests/${{ matrix.image.name }}:gha${{ github.run_id }}-g${{ github.sha }}
       - name: Push image for CI run
         run: |
           docker push ghcr.io/datadog/dd-trace-rb/system-tests/${{ matrix.image.name }}:gha${{ github.run_id }}-g${{ github.sha }}
       - name: Tag image for release
         if: ${{ github.ref == 'refs/heads/master' }}
         run:
-          docker tag ${{ matrix.image.internal }}:latest ghcr.io/datadog/dd-trace-rb/system-tests/${{ matrix.image.name }}:latest
+          docker tag ${{ matrix.image.internal }} ghcr.io/datadog/dd-trace-rb/system-tests/${{ matrix.image.name }}:latest
       - name: Push image for release
         if: ${{ github.ref == 'refs/heads/master' }}
         run: |
@@ -223,7 +223,7 @@ jobs:
       - name: Pull proxy image
         run: |
           docker pull ghcr.io/datadog/dd-trace-rb/system-tests/proxy:gha${{ github.run_id }}-g${{ github.sha }}
-          docker tag ghcr.io/datadog/dd-trace-rb/system-tests/proxy:gha${{ github.run_id }}-g${{ github.sha }} system-tests/proxy-v1:latest
+          docker tag ghcr.io/datadog/dd-trace-rb/system-tests/proxy:gha${{ github.run_id }}-g${{ github.sha }} datadog/system-tests:proxy-v1
       - name: Pull agent image
         run: |
           docker pull ghcr.io/datadog/dd-trace-rb/system-tests/agent:gha${{ github.run_id }}-g${{ github.sha }}

--- a/.github/workflows/system-tests.yml
+++ b/.github/workflows/system-tests.yml
@@ -17,9 +17,12 @@ jobs:
       fail-fast: false
       matrix:
         image:
-          - runner
-          - agent
-          - proxy-v1
+          - name: runner
+            version: runner
+          - name: agent
+            version: agent
+          - name: proxy
+            version: proxy-v1
     runs-on: ubuntu-latest
     name: Build (${{ matrix.image }})
     steps:
@@ -29,11 +32,11 @@ jobs:
           repository: 'DataDog/system-tests'
       - name: Pull released image
         run: |
-          if docker pull ghcr.io/datadog/dd-trace-rb/system-tests/${{ matrix.image }}:latest; then
-            docker tag ghcr.io/datadog/dd-trace-rb/system-tests/${{ matrix.image }}:latest system_tests/${{ matrix.image }}:latest
+          if docker pull ghcr.io/datadog/dd-trace-rb/system-tests/${{ matrix.image.name }}:latest; then
+            docker tag ghcr.io/datadog/dd-trace-rb/system-tests/${{ matrix.image.name }}:latest system_tests/${{ matrix.image.version }}:latest
           fi
       - name: Build image
-        run: ./build.sh --images ${{ matrix.image }} --docker
+        run: ./build.sh --images ${{ matrix.image.name }} --docker
       - name: List images
         run: |
           docker image list
@@ -42,18 +45,18 @@ jobs:
           echo ${{ secrets.GITHUB_TOKEN }} | docker login ${{ env.REGISTRY }} -u ${{ github.actor }} --password-stdin
       - name: Tag image for CI run
         run:
-          docker tag system_tests/${{ matrix.image }}:latest ghcr.io/datadog/dd-trace-rb/system-tests/${{ matrix.image }}:gha${{ github.run_id }}-g${{ github.sha }}
+          docker tag system_tests/${{ matrix.image.version }}:latest ghcr.io/datadog/dd-trace-rb/system-tests/${{ matrix.image.name }}:gha${{ github.run_id }}-g${{ github.sha }}
       - name: Push image for CI run
         run: |
-          docker push ghcr.io/datadog/dd-trace-rb/system-tests/${{ matrix.image }}:gha${{ github.run_id }}-g${{ github.sha }}
+          docker push ghcr.io/datadog/dd-trace-rb/system-tests/${{ matrix.image.name }}:gha${{ github.run_id }}-g${{ github.sha }}
       - name: Tag image for release
         if: ${{ github.ref == 'refs/heads/master' }}
         run:
-          docker tag system_tests/${{ matrix.image }}:latest ghcr.io/datadog/dd-trace-rb/system-tests/${{ matrix.image }}:latest
+          docker tag system_tests/${{ matrix.image.version }}:latest ghcr.io/datadog/dd-trace-rb/system-tests/${{ matrix.image.name }}:latest
       - name: Push image for release
         if: ${{ github.ref == 'refs/heads/master' }}
         run: |
-          docker push ghcr.io/datadog/dd-trace-rb/system-tests/${{ matrix.image }}:latest
+          docker push ghcr.io/datadog/dd-trace-rb/system-tests/${{ matrix.image.name }}:latest
 
   build-apps:
     strategy:
@@ -215,12 +218,12 @@ jobs:
           repository: 'DataDog/system-tests'
       - name: Pull runner image
         run: |
-          docker pull ghcr.io/datadog/dd-trace-rb/system-tests/agent:gha${{ github.run_id }}-g${{ github.sha }}
-          docker tag ghcr.io/datadog/dd-trace-rb/system-tests/agent:gha${{ github.run_id }}-g${{ github.sha }} system_tests/runner:latest
+          docker pull ghcr.io/datadog/dd-trace-rb/system-tests/runner:gha${{ github.run_id }}-g${{ github.sha }}
+          docker tag ghcr.io/datadog/dd-trace-rb/system-tests/runner:gha${{ github.run_id }}-g${{ github.sha }} system_tests/runner:latest
       - name: Pull proxy image
         run: |
-          docker pull ghcr.io/datadog/dd-trace-rb/system-tests/agent:gha${{ github.run_id }}-g${{ github.sha }}
-          docker tag ghcr.io/datadog/dd-trace-rb/system-tests/agent:gha${{ github.run_id }}-g${{ github.sha }} system_tests/proxy-v1:latest
+          docker pull ghcr.io/datadog/dd-trace-rb/system-tests/proxy:gha${{ github.run_id }}-g${{ github.sha }}
+          docker tag ghcr.io/datadog/dd-trace-rb/system-tests/proxy:gha${{ github.run_id }}-g${{ github.sha }} system_tests/proxy-v1:latest
       - name: Pull agent image
         run: |
           docker pull ghcr.io/datadog/dd-trace-rb/system-tests/agent:gha${{ github.run_id }}-g${{ github.sha }}

--- a/.github/workflows/system-tests.yml
+++ b/.github/workflows/system-tests.yml
@@ -40,8 +40,8 @@ jobs:
       - name: Build image
         run: |
           cache_from=()
-          for sha in $(git rev-list --parents -n 1 ${{ github.sha }} | sed 's/${{ github.sha }}//'); do
-            cache_from+=(--cache-from '${{ env.REPO }}/system-tests/${{ matrix.image.name }}:g${sha}')
+          for tag in latest; do
+            cache_from+=(--cache-from "${{ env.REPO }}/system-tests/${{ matrix.image.name }}:${tag}")
           done
           echo "cache args: ${cache_from[*]}"
           ./build.sh --images ${{ matrix.image.name }} --docker --extra-docker-args "${cache_from[*]}"
@@ -111,6 +111,7 @@ jobs:
         with:
           repository: '${{ matrix.library.repository }}'
           path: 'binaries/${{ matrix.library.path }}'
+          fetch-depth: 2
       - name: Pull released image
         run: |
           if docker pull ${{ env.REPO }}/system-tests/${{ matrix.library.name }}/${{ matrix.image }}-${{ matrix.app }}:latest; then
@@ -122,8 +123,12 @@ jobs:
       - name: Build
         run: |
           cache_from=()
-          for sha in $(git rev-list --parents -n 1 ${{ github.sha }} | sed 's/${{ github.sha }}//'); do
-            cache_from+=(--cache-from '${{ env.REPO }}/system-tests/${{ matrix.library.name }}/${{ matrix.image }}-${{ matrix.app }}:g${sha}')
+          for tag in latest; do
+            cache_from+=(--cache-from "${{ env.REPO }}/system-tests/${{ matrix.library.name }}/${{ matrix.image }}-${{ matrix.app }}:${tag}")
+          done
+          parents="$(cd 'binaries/${{ matrix.library.path }}' && git rev-list --parents -n 1 ${{ github.sha }})"
+          for sha in $parents; do
+            cache_from+=(--cache-from type=registry,ref="${{ env.REPO }}/system-tests/${{ matrix.library.name }}/${{ matrix.image }}-${{ matrix.app }}:g${sha}")
           done
           echo "cache args: ${cache_from[*]}"
           ./build.sh --library ${{ matrix.library.name }} --weblog-variant ${{ matrix.app }} --images ${{ matrix.image }} --extra-docker-args "${cache_from[*]}"

--- a/.github/workflows/system-tests.yml
+++ b/.github/workflows/system-tests.yml
@@ -38,7 +38,13 @@ jobs:
             docker tag ${{ env.REPO }}/system-tests/${{ matrix.image.name }}:latest ${{ matrix.image.internal }}
           fi
       - name: Build image
-        run: ./build.sh --images ${{ matrix.image.name }} --docker --extra-docker-args '--cache-from ${{ matrix.image.internal }}'
+        run: |
+          cache_from=()
+          for sha in $(git rev-list --parents -n 1 ${{ github.sha }} | sed 's/${{ github.sha }}//'); do
+            cache_from+=(--cache-from '${{ env.REPO }}/system-tests/${{ matrix.image.name }}:${sha}')
+          done
+          echo "cache args: ${cache_from[*]}"
+          ./build.sh --images ${{ matrix.image.name }} --docker --extra-docker-args "${cache_from[*]}"
       - name: List images
         run: |
           docker image list
@@ -51,6 +57,12 @@ jobs:
       - name: Push image for CI run
         run: |
           docker push ${{ env.REPO }}/system-tests/${{ matrix.image.name }}:gha${{ github.run_id }}-g${{ github.sha }}
+      - name: Tag image for commit
+        run:
+          docker tag ${{ matrix.image.internal }} ${{ env.REPO }}/system-tests/${{ matrix.image.name }}:g${{ github.sha }}
+      - name: Push image for commit
+        run: |
+          docker push ${{ env.REPO }}/system-tests/${{ matrix.image.name }}:g${{ github.sha }}
       - name: Tag image for release
         if: ${{ github.ref == 'refs/heads/master' }}
         run:
@@ -108,13 +120,25 @@ jobs:
         run: |
           echo ${{ secrets.GITHUB_TOKEN }} | docker login ${{ env.REGISTRY }} -u ${{ github.actor }} --password-stdin
       - name: Build
-        run: ./build.sh --library ${{ matrix.library.name }} --weblog-variant ${{ matrix.app }} --images ${{ matrix.image }} --extra-docker-args '--cache-from system_tests/${{ matrix.image }}:latest'
+        run: |
+          cache_from=()
+          for sha in $(git rev-list --parents -n 1 ${{ github.sha }} | sed 's/${{ github.sha }}//'); do
+            cache_from+=(--cache-from '${{ env.REPO }}/system-tests/${{ matrix.library.name }}/${{ matrix.image }}-${{ matrix.app }}:${sha}')
+          done
+          echo "cache args: ${cache_from[*]}"
+          ./build.sh --library ${{ matrix.library.name }} --weblog-variant ${{ matrix.app }} --images ${{ matrix.image }} --extra-docker-args "${cache_from[*]}"
       - name: Tag image for CI run
         run:
           docker tag system_tests/${{ matrix.image }}:latest ${{ env.REPO }}/system-tests/${{ matrix.library.name }}/${{ matrix.image }}-${{ matrix.app }}:gha${{ github.run_id }}-g${{ github.sha }}
       - name: Push image for CI run
         run: |
           docker push ${{ env.REPO }}/system-tests/${{ matrix.library.name }}/${{ matrix.image }}-${{ matrix.app }}:gha${{ github.run_id }}-g${{ github.sha }}
+      - name: Tag image for commit
+        run:
+          docker tag system_tests/${{ matrix.image }}:latest ${{ env.REPO }}/system-tests/${{ matrix.library.name }}/${{ matrix.image }}-${{ matrix.app }}:g${{ github.sha }}
+      - name: Push image for commit
+        run: |
+          docker push ${{ env.REPO }}/system-tests/${{ matrix.library.name }}/${{ matrix.image }}-${{ matrix.app }}:g${{ github.sha }}
       - name: Tag image for release
         if: ${{ github.ref == 'refs/heads/master' }}
         run:

--- a/.github/workflows/system-tests.yml
+++ b/.github/workflows/system-tests.yml
@@ -102,7 +102,7 @@ jobs:
         run: |
           echo ${{ secrets.GITHUB_TOKEN }} | docker login ${{ env.REGISTRY }} -u ${{ github.actor }} --password-stdin
       - name: Build
-        run: ./build.sh --library ${{ matrix.library }} --weblog-variant ${{ matrix.app }} --images ${{ matrix.image }} --extra-docker-args '--cache-from ${{ matrix.image }}:latest'
+        run: ./build.sh --library ${{ matrix.library }} --weblog-variant ${{ matrix.app }} --images ${{ matrix.image }} --extra-docker-args '--cache-from system_tests/${{ matrix.image }}:latest'
       - name: Tag image for CI run
         run:
           docker tag system_tests/${{ matrix.image }}:latest ghcr.io/datadog/dd-trace-rb/system-tests/${{ matrix.image }}-${{ matrix.app }}:gha${{ github.run_id }}-g${{ github.sha }}

--- a/.github/workflows/system-tests.yml
+++ b/.github/workflows/system-tests.yml
@@ -17,7 +17,9 @@ jobs:
       fail-fast: false
       matrix:
         image:
+          - runner
           - agent
+          - proxy
     runs-on: ubuntu-latest
     name: Build (${{ matrix.image }})
     steps:
@@ -31,7 +33,7 @@ jobs:
             docker tag ghcr.io/datadog/dd-trace-rb/system-tests/${{ matrix.image }}:latest system_tests/${{ matrix.image }}:latest
           fi
       - name: Build image
-        run: ./build.sh --images ${{ matrix.image }}
+        run: ./build.sh --images ${{ matrix.image }} --docker
       - name: List images
         run: |
           docker image list
@@ -211,6 +213,14 @@ jobs:
         uses: actions/checkout@v4
         with:
           repository: 'DataDog/system-tests'
+      - name: Pull runner image
+        run: |
+          docker pull ghcr.io/datadog/dd-trace-rb/system-tests/agent:gha${{ github.run_id }}-g${{ github.sha }}
+          docker tag ghcr.io/datadog/dd-trace-rb/system-tests/agent:gha${{ github.run_id }}-g${{ github.sha }} system_tests/runner:latest
+      - name: Pull proxy image
+        run: |
+          docker pull ghcr.io/datadog/dd-trace-rb/system-tests/agent:gha${{ github.run_id }}-g${{ github.sha }}
+          docker tag ghcr.io/datadog/dd-trace-rb/system-tests/agent:gha${{ github.run_id }}-g${{ github.sha }} system_tests/proxy:latest
       - name: Pull agent image
         run: |
           docker pull ghcr.io/datadog/dd-trace-rb/system-tests/agent:gha${{ github.run_id }}-g${{ github.sha }}
@@ -223,7 +233,7 @@ jobs:
         run: |
           docker image list
       - name: Run scenario
-        run: ./build.sh --images runner && ./run.sh ${{ matrix.scenario }}
+        run: ./run.sh ++docker ${{ matrix.scenario }}
         env:
           DD_API_KEY: ${{ secrets.DD_APPSEC_SYSTEM_TESTS_API_KEY }}
       - name: Archive logs (per scenario)

--- a/.github/workflows/system-tests.yml
+++ b/.github/workflows/system-tests.yml
@@ -36,7 +36,7 @@ jobs:
             docker tag ghcr.io/datadog/dd-trace-rb/system-tests/${{ matrix.image.name }}:latest ${{ matrix.image.internal }}
           fi
       - name: Build image
-        run: ./build.sh --images ${{ matrix.image.name }} --docker
+        run: ./build.sh --images ${{ matrix.image.name }} --docker --extra-docker-args '--cache-from ${{ matrix.image.internal }}'
       - name: List images
         run: |
           docker image list
@@ -102,7 +102,7 @@ jobs:
         run: |
           echo ${{ secrets.GITHUB_TOKEN }} | docker login ${{ env.REGISTRY }} -u ${{ github.actor }} --password-stdin
       - name: Build
-        run: ./build.sh --library ${{ matrix.library }} --weblog-variant ${{ matrix.app }} --images ${{ matrix.image }}
+        run: ./build.sh --library ${{ matrix.library }} --weblog-variant ${{ matrix.app }} --images ${{ matrix.image }} --extra-docker-args '--cache-from ${{ matrix.image }}:latest'
       - name: Tag image for CI run
         run:
           docker tag system_tests/${{ matrix.image }}:latest ghcr.io/datadog/dd-trace-rb/system-tests/${{ matrix.image }}-${{ matrix.app }}:gha${{ github.run_id }}-g${{ github.sha }}

--- a/.github/workflows/system-tests.yml
+++ b/.github/workflows/system-tests.yml
@@ -41,7 +41,7 @@ jobs:
         run: |
           cache_from=()
           for sha in $(git rev-list --parents -n 1 ${{ github.sha }} | sed 's/${{ github.sha }}//'); do
-            cache_from+=(--cache-from '${{ env.REPO }}/system-tests/${{ matrix.image.name }}:${sha}')
+            cache_from+=(--cache-from '${{ env.REPO }}/system-tests/${{ matrix.image.name }}:g${sha}')
           done
           echo "cache args: ${cache_from[*]}"
           ./build.sh --images ${{ matrix.image.name }} --docker --extra-docker-args "${cache_from[*]}"
@@ -123,7 +123,7 @@ jobs:
         run: |
           cache_from=()
           for sha in $(git rev-list --parents -n 1 ${{ github.sha }} | sed 's/${{ github.sha }}//'); do
-            cache_from+=(--cache-from '${{ env.REPO }}/system-tests/${{ matrix.library.name }}/${{ matrix.image }}-${{ matrix.app }}:${sha}')
+            cache_from+=(--cache-from '${{ env.REPO }}/system-tests/${{ matrix.library.name }}/${{ matrix.image }}-${{ matrix.app }}:g${sha}')
           done
           echo "cache args: ${cache_from[*]}"
           ./build.sh --library ${{ matrix.library.name }} --weblog-variant ${{ matrix.app }} --images ${{ matrix.image }} --extra-docker-args "${cache_from[*]}"

--- a/.github/workflows/system-tests.yml
+++ b/.github/workflows/system-tests.yml
@@ -31,7 +31,6 @@ jobs:
         uses: actions/checkout@v4
         with:
           repository: 'DataDog/system-tests'
-          ref: fix-docker-mode
       - name: Pull released image
         run: |
           if docker pull ${{ env.REPO }}/system-tests/${{ matrix.image.name }}:latest; then
@@ -105,7 +104,6 @@ jobs:
         uses: actions/checkout@v4
         with:
           repository: 'DataDog/system-tests'
-          ref: fix-docker-mode
       - name: Checkout ${{ matrix.library.repository }}
         uses: actions/checkout@v4
         with:
@@ -252,7 +250,6 @@ jobs:
         uses: actions/checkout@v4
         with:
           repository: 'DataDog/system-tests'
-          ref: fix-docker-mode
       - name: Pull runner image
         run: |
           docker pull ${{ env.REPO }}/system-tests/runner:gha${{ github.run_id }}-g${{ github.sha }}
@@ -319,7 +316,6 @@ jobs:
         uses: actions/checkout@v4
         with:
           repository: 'DataDog/system-tests'
-          ref: fix-docker-mode
       - name: Retrieve logs
         uses: actions/download-artifact@v4
         with:

--- a/.github/workflows/system-tests.yml
+++ b/.github/workflows/system-tests.yml
@@ -117,6 +117,10 @@ jobs:
           if docker pull ${{ env.REPO }}/system-tests/${{ matrix.library.name }}/${{ matrix.image }}-${{ matrix.app }}:latest; then
             docker tag ${{ env.REPO }}/system-tests/${{ matrix.library.name }}/${{ matrix.image }}-${{ matrix.app }}:latest system_tests/${{ matrix.image }}:latest
           fi
+          parents="$(cd 'binaries/${{ matrix.library.path }}' && git rev-list --parents -n 1 ${{ github.sha }})"
+          for sha in $parents; do
+            docker pull "${{ env.REPO }}/system-tests/${{ matrix.library.name }}/${{ matrix.image }}-${{ matrix.app }}:g${sha}" || true
+          done
       - name: Log in to the Container registry
         run: |
           echo ${{ secrets.GITHUB_TOKEN }} | docker login ${{ env.REGISTRY }} -u ${{ github.actor }} --password-stdin
@@ -128,7 +132,7 @@ jobs:
           done
           parents="$(cd 'binaries/${{ matrix.library.path }}' && git rev-list --parents -n 1 ${{ github.sha }})"
           for sha in $parents; do
-            cache_from+=(--cache-from type=registry,ref="${{ env.REPO }}/system-tests/${{ matrix.library.name }}/${{ matrix.image }}-${{ matrix.app }}:g${sha}")
+            cache_from+=(--cache-from ${{ env.REPO }}/system-tests/${{ matrix.library.name }}/${{ matrix.image }}-${{ matrix.app }}:g${sha})
           done
           echo "cache args: ${cache_from[*]}"
           ./build.sh --library ${{ matrix.library.name }} --weblog-variant ${{ matrix.app }} --images ${{ matrix.image }} --extra-docker-args "${cache_from[*]}"


### PR DESCRIPTION
<!--
Check out the
https://github.com/DataDog/dd-trace-rb/blob/master/docs/DevelopmentGuide.md
for guidance on how to set up your development environment,
run the test suite, write new integrations, and more.
-->

**2.0 Upgrade Guide notes**
<!--
(If this PR is for 1.x, please delete this section)
If this PR introduces a breaking change, update the
https://github.com/DataDog/dd-trace-rb/blob/2.0/docs/UpgradeGuide2.md
in this PR with either:
* A migration path for this change. In other words, how to continue using their application without behavior changes
in 2.0 (e.g. environment variable 'X' renamed to 'Y').
* That there's no alternative; we removed support for this feature.
-->

**What does this PR do?**

Enable docker mode for system tests

**Motivation:**

This allows hoisting runner build out of the test run job

**Additional Notes:**

~Tentative. May or may not work.~ It works now.

**How to test the change?**

CI should pass system tests.

**For Datadog employees:**
- [ ] If this PR touches code that signs or publishes builds or packages, or handles
credentials of any kind, I've requested a review from `@DataDog/security-design-and-guidance`.
- [x] This PR doesn't touch any of that.

Unsure? Have a question? Request a review!
