### PR TITLE
Temp disable publishing lib injection artifacts

### DIFF
--- a/.github/workflows/release-lib-injection.yml
+++ b/.github/workflows/release-lib-injection.yml
@@ -1,33 +1,32 @@
+# name: "Release Library Injection"
+# on:
+#   push:
+#     tags:
+#       - 'v*.*.*'
 
-name: "Release Library Injection"
-on:
-  push:
-    tags:
-      - 'v*.*.*'
-
-jobs:
-  build-and-publish-release-image:
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v4
-      - name: Set version
-        id: version
-        run: echo "version=${GITHUB_REF#refs/*/}" >> $GITHUB_OUTPUT
-      - name: Get version
-        run: echo "The selected version is ${{ steps.version.outputs.version }}"
-      - name: Set up QEMU
-        uses: docker/setup-qemu-action@v2
-      - name: Set up Docker Buildx
-        id: buildx
-        uses: docker/setup-buildx-action@v2
-      - name: Login to Docker
-        run: docker login -u publisher -p ${{ secrets.GITHUB_TOKEN }} ghcr.io
-      - name: Docker Build
-        uses: docker/build-push-action@v3
-        with:
-          push: true
-          tags: ghcr.io/datadog/dd-trace-rb/dd-lib-ruby-init:${{ steps.version.outputs.version }}
-          platforms: 'linux/amd64,linux/arm64/v8'
-          build-args: DATADOG_RUBY_GEM_VERSION=${{ steps.version.outputs.version }}
-          context: ./lib-injection
+# jobs:
+#   build-and-publish-release-image:
+#     runs-on: ubuntu-latest
+#     steps:
+#       - uses: actions/checkout@v4
+#       - name: Set version
+#         id: version
+#         run: echo "version=${GITHUB_REF#refs/*/}" >> $GITHUB_OUTPUT
+#       - name: Get version
+#         run: echo "The selected version is ${{ steps.version.outputs.version }}"
+#       - name: Set up QEMU
+#         uses: docker/setup-qemu-action@v2
+#       - name: Set up Docker Buildx
+#         id: buildx
+#         uses: docker/setup-buildx-action@v2
+#       - name: Login to Docker
+#         run: docker login -u publisher -p ${{ secrets.GITHUB_TOKEN }} ghcr.io
+#       - name: Docker Build
+#         uses: docker/build-push-action@v3
+#         with:
+#           push: true
+#           tags: ghcr.io/datadog/dd-trace-rb/dd-lib-ruby-init:${{ steps.version.outputs.version }}
+#           platforms: 'linux/amd64,linux/arm64/v8'
+#           build-args: DATADOG_RUBY_GEM_VERSION=${{ steps.version.outputs.version }}
+#           context: ./lib-injection
 

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -192,40 +192,40 @@ deploy_to_reliability_env:
     UPSTREAM_PROJECT_NAME: $CI_PROJECT_NAME
     UPSTREAM_COMMIT_SHA: $CI_COMMIT_SHA
 
-deploy_to_docker_registries:
-  stage: deploy
-  rules:
-    - if: "$POPULATE_CACHE"
-      when: never
-    - if: "$CI_COMMIT_TAG =~ /^v.*/"
-      when: delayed
-      start_in: 1 day
-    - when: manual
-      allow_failure: true
-  trigger:
-    project: DataDog/public-images
-    branch: main
-    strategy: depend
-  variables:
-    IMG_SOURCES: ghcr.io/datadog/dd-trace-rb/dd-lib-ruby-init:$CI_COMMIT_TAG
-    IMG_DESTINATIONS: dd-lib-ruby-init:$CI_COMMIT_TAG
-    IMG_SIGNING: "false"
+# deploy_to_docker_registries:
+#   stage: deploy
+#   rules:
+#     - if: "$POPULATE_CACHE"
+#       when: never
+#     - if: "$CI_COMMIT_TAG =~ /^v.*/"
+#       when: delayed
+#       start_in: 1 day
+#     - when: manual
+#       allow_failure: true
+#   trigger:
+#     project: DataDog/public-images
+#     branch: main
+#     strategy: depend
+#   variables:
+#     IMG_SOURCES: ghcr.io/datadog/dd-trace-rb/dd-lib-ruby-init:$CI_COMMIT_TAG
+#     IMG_DESTINATIONS: dd-lib-ruby-init:$CI_COMMIT_TAG
+#     IMG_SIGNING: "false"
 
-deploy_latest_tag_to_docker_registries:
-  stage: deploy
-  rules:
-    - if: "$POPULATE_CACHE"
-      when: never
-    - if: "$CI_COMMIT_TAG =~ /^v.*/"
-      when: delayed
-      start_in: 1 day
-    - when: manual
-      allow_failure: true
-  trigger:
-    project: DataDog/public-images
-    branch: main
-    strategy: depend
-  variables:
-    IMG_SOURCES: ghcr.io/datadog/dd-trace-rb/dd-lib-ruby-init:$CI_COMMIT_TAG
-    IMG_DESTINATIONS: dd-lib-ruby-init:latest
-    IMG_SIGNING: "false"
+# deploy_latest_tag_to_docker_registries:
+#   stage: deploy
+#   rules:
+#     - if: "$POPULATE_CACHE"
+#       when: never
+#     - if: "$CI_COMMIT_TAG =~ /^v.*/"
+#       when: delayed
+#       start_in: 1 day
+#     - when: manual
+#       allow_failure: true
+#   trigger:
+#     project: DataDog/public-images
+#     branch: main
+#     strategy: depend
+#   variables:
+#     IMG_SOURCES: ghcr.io/datadog/dd-trace-rb/dd-lib-ruby-init:$CI_COMMIT_TAG
+#     IMG_DESTINATIONS: dd-lib-ruby-init:latest
+#     IMG_SIGNING: "false"


### PR DESCRIPTION
**What does this PR do?**

On the verge of releasing `2.0.0.beta1`, disable publishing lib injection artifacts since they are not safe to be publicly available.