### PR TITLE
[profiling] Fix 3 flaky tests

### DIFF
--- a/spec/datadog/profiling/collectors/cpu_and_wall_time_worker_spec.rb
+++ b/spec/datadog/profiling/collectors/cpu_and_wall_time_worker_spec.rb
@@ -623,12 +623,18 @@ RSpec.describe 'Datadog::Profiling::Collectors::CpuAndWallTimeWorker' do
             (sample.values[:'heap-live-samples'] || 0) > 0
         }
 
-        relevant_sample = samples_from_pprof(recorder.serialize!)
-          .find(&test_struct_heap_sample)
+        # We can't just use find here because samples might have different gc age labels
+        # if a gc happens to run in the middle of this test. Thus, we'll have to sum up
+        # together the values of all matching samples.
+        relevant_samples = samples_from_pprof(recorder.serialize!)
+          .select(&test_struct_heap_sample)
 
-        expect(relevant_sample.values[:'heap-live-samples']).to eq test_num_allocated_object
+        total_samples = relevant_samples.map { |sample| sample.values[:'heap-live-samples'] || 0 }.reduce(:+)
+        total_size = relevant_samples.map { |sample| sample.values[:'heap-live-size'] || 0 }.reduce(:+)
+
+        expect(total_samples).to eq test_num_allocated_object
         # 40 is the size of a basic object and we have test_num_allocated_object of them
-        expect(relevant_sample.values[:'heap-live-size']).to eq test_num_allocated_object * 40
+        expect(total_size).to eq test_num_allocated_object * 40
       end
     end
 
@@ -926,17 +932,43 @@ RSpec.describe 'Datadog::Profiling::Collectors::CpuAndWallTimeWorker' do
           expect(described_class._native_allocation_count).to be >= 0
         end
 
-        it 'returns the number of allocations between two calls of the method' do
-          # To get the exact expected number of allocations, we run this once before so that Ruby can create and cache all
-          # it needs to
-          new_object = proc { Object.new }
-          1.times(&new_object)
+        it 'returns the exact number of allocations between two calls of the method' do
+          # In rare situations (once every few thousand runs) we've witnessed this test failing with
+          # more than 100 allocations being reported. With some extra debugging logs and callstack
+          # dumps we've tracked the extra allocations to the calling of finalizers with complex
+          # arguments (e.g. *rest args) which lead to the allocation of a temporary array.
+          #
+          # Finalizer usage isn't really a common thing in the Ruby stdlib. In fact, there are just
+          # two places where we see them being used:
+          # * Weakmaps - Not used by anything in this test suite and the actual finalizer function
+          #              looks simple enough, receiving a single objid.
+          # * Tempfiles - Used indirectly in some of tests in this suite through `expect_in_fork`.
+          #               The finalizer functions are declared as `run(*args)` which would trigger
+          #               the complex calling logic.
+          #
+          # Thus, in a test execution where those (or any other tests using Tempfiles) run first,
+          # there's a small chance that a GC gets triggered in between the two
+          # `_native_allocation_count` calls and contributes with unexpected Array allocations to
+          # the allocation count. To prevent this, we'll explicitly disable GC around these checks.
+          begin
+            GC.disable
+            # To get the exact expected number of allocations, we run through the ropes once so
+            # Ruby can create and cache all it needs to and hopefully flush any pending finalizer
+            # executions that could affect our expectations
+            described_class._native_allocation_count
+            new_object = proc { Object.new }
+            1.times(&new_object)
+            described_class._native_allocation_count
 
-          before_allocations = described_class._native_allocation_count
-          100.times(&new_object)
-          after_allocations = described_class._native_allocation_count
+            # Here we do the actual work we care about
+            before_allocations = described_class._native_allocation_count
+            100.times(&new_object)
+            after_allocations = described_class._native_allocation_count
 
-          expect(after_allocations - before_allocations).to be 100
+            expect(after_allocations - before_allocations).to be 100
+          ensure
+            GC.enable
+          end
         end
 
         it 'returns different numbers of allocations for different threads' do
@@ -993,7 +1025,12 @@ RSpec.describe 'Datadog::Profiling::Collectors::CpuAndWallTimeWorker' do
       wait_until_running
 
       try_wait_until do
+        # Wait until we get CPU/Wall time samples. Since we have allocation
+        # profiling enabled, not adding the extra reject could lead us to
+        # prematurely stop waiting as soon as we get an allocation sample
+        # which would result in us reaching our expectation with cpu_sampled = 0
         samples = samples_from_pprof_without_gc_and_overhead(recorder.serialize!)
+          .reject { |sample| sample.values[:'alloc-samples'] > 0 }
         samples if samples.any?
       end
 


### PR DESCRIPTION
**What does this PR do?**
Fix 3 flaky tests that have surfaced this week:

* `Datadog::Profiling::Collectors::CpuAndWallTimeWorker ._native_allocation_count when CpuAndWallTimeWorker has been started when allocation profiling is enabled returns the number of allocations between two calls of the method`
  * https://app.circleci.com/pipelines/github/DataDog/dd-trace-rb/14119/workflows/cbefa69c-c16e-41fd-a601-2e951a5264ab/jobs/525211
  * `expect(after_allocations - before_allocations).to be 100 | expected #<Integer:201> => 100 | got #<Integer:215> => 107`
  * TL;DR: Rare GC occurrence in the middle of the test would count extra array allocations due to execution of finalizer functions with complex arguments (`*rest`) which are expected to come from usage of `Tempfile` in previous tests in the run.
    <details>
    <summary>C backtrace of Array-typed allocation samples during allocation of 100 Objects</summary>
     
	```
	-- C level backtrace information -------------------------------------------
	/Users/alexandre.fonseca/.asdf/installs/ruby/3.3.0/lib/libruby.3.3.dylib(rb_vm_bugreport+0xb4c) [0x105013440]
	/Users/alexandre.fonseca/.asdf/installs/ruby/3.3.0/lib/libruby.3.3.dylib(rb_bug_without_die+0xfc) [0x104e561b8]
	/Users/alexandre.fonseca/.asdf/installs/ruby/3.3.0/lib/libruby.3.3.dylib(rb_bug+0x1c) [0x105108b90]
	/Users/alexandre.fonseca/go/src/github.com/DataDog/dd-trace-rb/lib/datadog_profiling_native_extension.3.3.0_arm64-darwin23.bundle(_sample_thread.cold.1+0x14) [0x12d3178a8]
	/Users/alexandre.fonseca/go/src/github.com/DataDog/dd-trace-rb/lib/datadog_profiling_native_extension.3.3.0_arm64-darwin23.bundle(sample_thread+0x604) [0x12d30f65c]
	/Users/alexandre.fonseca/go/src/github.com/DataDog/dd-trace-rb/lib/datadog_profiling_native_extension.3.3.0_arm64-darwin23.bundle(trigger_sample_for_thread+0x574) [0x12d310bbc]
	/Users/alexandre.fonseca/go/src/github.com/DataDog/dd-trace-rb/lib/datadog_profiling_native_extension.3.3.0_arm64-darwin23.bundle(thread_context_collector_sample_allocation+0x298) [0x12d3113d4]
	/Users/alexandre.fonseca/go/src/github.com/DataDog/dd-trace-rb/lib/datadog_profiling_native_extension.3.3.0_arm64-darwin23.bundle(rescued_sample_allocation+0x58) [0x12d30c81c]
	/Users/alexandre.fonseca/.asdf/installs/ruby/3.3.0/lib/libruby.3.3.dylib(rb_vrescue2+0xc8) [0x104e62910]
	/Users/alexandre.fonseca/.asdf/installs/ruby/3.3.0/lib/libruby.3.3.dylib(rb_rescue2+0x2c) [0x104e62820]
	/Users/alexandre.fonseca/go/src/github.com/DataDog/dd-trace-rb/lib/datadog_profiling_native_extension.3.3.0_arm64-darwin23.bundle(on_newobj_event+0xb8) [0x12d30c6ac]
	/Users/alexandre.fonseca/.asdf/installs/ruby/3.3.0/lib/libruby.3.3.dylib(exec_hooks_unprotected+0x54) [0x105014814]
	/Users/alexandre.fonseca/.asdf/installs/ruby/3.3.0/lib/libruby.3.3.dylib(rb_exec_event_hooks+0xc8) [0x105014764]
	/Users/alexandre.fonseca/.asdf/installs/ruby/3.3.0/lib/libruby.3.3.dylib(gc_event_hook_body+0x94) [0x104e83954]
	/Users/alexandre.fonseca/.asdf/installs/ruby/3.3.0/lib/libruby.3.3.dylib(newobj_slowpath_wb_protected+0x164) [0x104e804a0]
	/Users/alexandre.fonseca/.asdf/installs/ruby/3.3.0/lib/libruby.3.3.dylib(rb_wb_protected_newobj_of+0x90) [0x104e7243c]
	/Users/alexandre.fonseca/.asdf/installs/ruby/3.3.0/lib/libruby.3.3.dylib(ary_new+0x6c) [0x104dbb7c4]
	/Users/alexandre.fonseca/.asdf/installs/ruby/3.3.0/lib/libruby.3.3.dylib(rb_ary_new_from_values+0x28) [0x104dbba4c]
	/Users/alexandre.fonseca/.asdf/installs/ruby/3.3.0/lib/libruby.3.3.dylib(setup_parameters_complex+0xad8) [0x105003df8]
	/Users/alexandre.fonseca/.asdf/installs/ruby/3.3.0/lib/libruby.3.3.dylib(vm_call_iseq_setup+0x60) [0x1050014a0]
	/Users/alexandre.fonseca/.asdf/installs/ruby/3.3.0/lib/libruby.3.3.dylib(vm_call0_body+0x260) [0x10500b438]
	/Users/alexandre.fonseca/.asdf/installs/ruby/3.3.0/lib/libruby.3.3.dylib(rb_vm_call0+0xd8) [0x104ff5390]
	/Users/alexandre.fonseca/.asdf/installs/ruby/3.3.0/lib/libruby.3.3.dylib(run_finalizer+0x120) [0x104e74cf4]
	/Users/alexandre.fonseca/.asdf/installs/ruby/3.3.0/lib/libruby.3.3.dylib(finalize_deferred_heap_pages+0x88) [0x104e74e78]
	/Users/alexandre.fonseca/.asdf/installs/ruby/3.3.0/lib/libruby.3.3.dylib(gc_finalize_deferred+0x50) [0x104e71e6c]
	/Users/alexandre.fonseca/.asdf/installs/ruby/3.3.0/lib/libruby.3.3.dylib(rb_postponed_job_flush+0x170) [0x105018358]
	/Users/alexandre.fonseca/.asdf/installs/ruby/3.3.0/lib/libruby.3.3.dylib(rb_threadptr_execute_interrupts+0x118) [0x104fb5090]
	/Users/alexandre.fonseca/.asdf/installs/ruby/3.3.0/lib/libruby.3.3.dylib(vm_call0_body+0x9bc) [0x10500bb94]
	/Users/alexandre.fonseca/.asdf/installs/ruby/3.3.0/lib/libruby.3.3.dylib(rb_call0+0x3c8) [0x10500c7f4]
	/Users/alexandre.fonseca/.asdf/installs/ruby/3.3.0/lib/libruby.3.3.dylib(rb_class_new_instance_pass_kw+0x3c) [0x104ee9188]
	```
    </details>

* `Datadog::Profiling::Collectors::CpuAndWallTimeWorker #stats_reset_not_thread_safe returns accumulated stats and resets them back to 0`
  * https://app.circleci.com/pipelines/github/DataDog/dd-trace-rb/14155/workflows/c25e0bb6-b98a-477e-918f-f64a9bdc0a9a/jobs/526423
  * ```
     expect(stats).to match(
         hash_including(
           :cpu_sampled => be > 0,
           :allocation_sampled => be > 0,
           :cpu_sampling_time_ns_avg => be > 0,
           :allocation_sampling_time_ns_avg => be > 0,
         )
       )

      +:cpu_sampled => 0,
      +:cpu_sampling_time_ns_avg => nil,
    ```
  * TL;DR: An early allocation sample could lead us to short-circuit our waiting logic and lead us to reach expectations with no cpu samples having been made.

* `Datadog::Profiling::Collectors::CpuAndWallTimeWorker #start when heap profiling is enabled records live heap objects`
  * Not hit in CI but surfaced during the thousands of runs we had to run to reproduce the above 2.
  * `expect(relevant_sample.values[:'heap-live-samples']).to eq test_num_allocated_object | expected: 123 | got: 120`
  * TL;DR: An unlucky GC during the test execution could lead to some of the recorded objects having been allocated before the GC and others after, leading to different values of `gc gen age` and thus being aggregated in multiple samples rather than the expected individual one.

**Motivation:**
Less flakes!

**Additional Notes:**
<!-- Anything else we should know when reviewing? -->

**How to test the change?**
These bugs were reproduced and fixed through thousands of local executions of the `cpu_and_wall_time_worker_spec.rb`. We haven't hit failures after fixing them but you're welcome to give it a try!

**For Datadog employees:**
- [ ] If this PR touches code that signs or publishes builds or packages, or handles
credentials of any kind, I've requested a review from `@DataDog/security-design-and-guidance`.
- [ ] This PR doesn't touch any of that.

Unsure? Have a question? Request a review!
