### PR TITLE
[PROF-9370] Add microbenchmark coverage for GC profiling

### DIFF
--- a/benchmarks/dogstatsd_reporter.rb
+++ b/benchmarks/dogstatsd_reporter.rb
@@ -12,12 +12,14 @@ require 'securerandom'
 #   x.config(suite: report_to_dogstatsd_if_enabled_via_environment_variable(...settings...))
 # ```
 
+REPORTING_DISABLED_ONLY_ONCE = Datadog::Core::Utils::OnlyOnce.new
+
 def report_to_dogstatsd_if_enabled_via_environment_variable(**args)
   if ENV['REPORT_TO_DOGSTATSD'] == 'true'
     puts "DogStatsD reporting ✅ enabled"
     DogstatsdReporter.new(**args)
   else
-    puts "DogStatsD reporting ❌ disabled"
+    REPORTING_DISABLED_ONLY_ONCE.run { puts "DogStatsD reporting ❌ disabled" }
     nil
   end
 end

--- a/benchmarks/profiler_gc.rb
+++ b/benchmarks/profiler_gc.rb
@@ -1,0 +1,154 @@
+# Used to quickly run benchmark under RSpec as part of the usual test suite, to validate it didn't bitrot
+VALIDATE_BENCHMARK_MODE = ENV['VALIDATE_BENCHMARK'] == 'true'
+
+return unless __FILE__ == $PROGRAM_NAME || VALIDATE_BENCHMARK_MODE
+
+require 'benchmark/ips'
+require 'ddtrace'
+require 'pry'
+require_relative 'dogstatsd_reporter'
+
+# This benchmark measures the performance of GC profiling
+
+class ProfilerGcBenchmark
+  def create_profiler
+    @recorder = Datadog::Profiling::StackRecorder.new(
+      cpu_time_enabled: true,
+      alloc_samples_enabled: false,
+      heap_samples_enabled: false,
+      heap_size_enabled: false,
+      heap_sample_every: 1,
+      timeline_enabled: true,
+    )
+    @collector = Datadog::Profiling::Collectors::ThreadContext.new(
+      recorder: @recorder, max_frames: 400, tracer: nil, endpoint_collection_enabled: false, timeline_enabled: true
+    )
+
+    # We take a dummy sample so that the context for the main thread is created, as otherwise the GC profiling methods do
+    # not create it (because we don't want to do memory allocations in the middle of GC)
+    Datadog::Profiling::Collectors::ThreadContext::Testing._native_sample(@collector, Thread.current)
+  end
+
+  def run_benchmark
+    Benchmark.ips do |x|
+      benchmark_time = VALIDATE_BENCHMARK_MODE ? { time: 0.01, warmup: 0 } : { time: 10, warmup: 2 }
+      x.config(
+        **benchmark_time,
+        suite: report_to_dogstatsd_if_enabled_via_environment_variable(benchmark_name: 'profiler_gc')
+      )
+
+      # The idea of this benchmark is to test the overall cost of the Ruby VM calling these methods on every GC.
+      # We're going as fast as possible (not realistic), but this should give us an upper bound for expected performance.
+      x.report('profiler gc') do
+        Datadog::Profiling::Collectors::ThreadContext::Testing._native_on_gc_start(@collector)
+        Datadog::Profiling::Collectors::ThreadContext::Testing._native_on_gc_finish(@collector)
+        Datadog::Profiling::Collectors::ThreadContext::Testing._native_sample_after_gc(@collector)
+      end
+
+      x.save! 'profiler-gc-results.json' unless VALIDATE_BENCHMARK_MODE
+      x.compare!
+    end
+
+    Benchmark.ips do |x|
+      benchmark_time = VALIDATE_BENCHMARK_MODE ? { time: 0.01, warmup: 0 } : { time: 10, warmup: 2 }
+      x.config(
+        **benchmark_time,
+        suite: report_to_dogstatsd_if_enabled_via_environment_variable(benchmark_name: 'profiler_gc_minute')
+      )
+
+      # We cap the number of minor GC samples to not happen more often than TIME_BETWEEN_GC_EVENTS_NS (10)
+      minor_gc_per_second_upper_bound = 100
+      # ...but every major GC triggers a flush. Here we consider what would happen if we had 1000 major GCs per second
+      pessimistic_number_of_gcs_per_second = minor_gc_per_second_upper_bound * 10
+      estimated_gc_per_minute = pessimistic_number_of_gcs_per_second * 60
+
+      x.report("estimated profiler gc per minute (sample #{estimated_gc_per_minute} times + serialize result)") do
+        estimated_gc_per_minute.times do
+          Datadog::Profiling::Collectors::ThreadContext::Testing._native_on_gc_start(@collector)
+          Datadog::Profiling::Collectors::ThreadContext::Testing._native_on_gc_finish(@collector)
+          Datadog::Profiling::Collectors::ThreadContext::Testing._native_sample_after_gc(@collector)
+        end
+
+        @recorder.serialize
+      end
+
+      x.save! 'profiler-gc-minute-results.json' unless VALIDATE_BENCHMARK_MODE
+      x.compare!
+    end
+
+    Benchmark.ips do |x|
+      benchmark_time = VALIDATE_BENCHMARK_MODE ? { time: 0.01, warmup: 0 } : { time: 10, warmup: 2 }
+      x.config(
+        **benchmark_time,
+        suite: report_to_dogstatsd_if_enabled_via_environment_variable(benchmark_name: 'profiler_gc_integration')
+      )
+
+      x.report('Major GC runs (profiling disabled)', 'GC.start')
+
+      x.save! 'profiler-gc-integration-results.json' unless VALIDATE_BENCHMARK_MODE
+      x.compare!
+    end
+
+    Datadog.configure do |c|
+      c.profiling.enabled = true
+      c.profiling.allocation_enabled = false
+      c.profiling.advanced.force_enable_gc_profiling = true
+    end
+
+    Benchmark.ips do |x|
+      benchmark_time = VALIDATE_BENCHMARK_MODE ? { time: 0.01, warmup: 0 } : { time: 10, warmup: 2 }
+      x.config(
+        **benchmark_time,
+        suite: report_to_dogstatsd_if_enabled_via_environment_variable(benchmark_name: 'profiler_gc_integration')
+      )
+
+      x.report('Major GC runs (profiling enabled)', 'GC.start')
+
+      x.save! 'profiler-gc-integration-results.json' unless VALIDATE_BENCHMARK_MODE
+      x.compare!
+    end
+
+    Datadog.configure { |c| c.profiling.enabled = false }
+
+    Benchmark.ips do |x|
+      benchmark_time = VALIDATE_BENCHMARK_MODE ? { time: 0.01, warmup: 0 } : { time: 10, warmup: 2 }
+      x.config(
+        **benchmark_time,
+        suite: report_to_dogstatsd_if_enabled_via_environment_variable(benchmark_name: 'profiler_gc_integration_allocations')
+      )
+
+      x.report('Allocations (profiling disabled)', 'Object.new')
+
+      x.save! 'profiler-gc-integration-allocations-results.json' unless VALIDATE_BENCHMARK_MODE
+      x.compare!
+    end
+
+    Datadog.configure do |c|
+      c.profiling.enabled = true
+      c.profiling.allocation_enabled = false
+      c.profiling.advanced.force_enable_gc_profiling = true
+    end
+
+    Benchmark.ips do |x|
+      benchmark_time = VALIDATE_BENCHMARK_MODE ? { time: 0.01, warmup: 0 } : { time: 10, warmup: 2 }
+      x.config(
+        **benchmark_time,
+        suite: report_to_dogstatsd_if_enabled_via_environment_variable(benchmark_name: 'profiler_gc_integration_allocations')
+      )
+
+      x.report('Allocations (profiling enabled)', 'Object.new')
+
+      x.save! 'profiler-gc-integration-allocations-results.json' unless VALIDATE_BENCHMARK_MODE
+      x.compare!
+    end
+
+    @recorder.serialize
+  end
+end
+
+puts "Current pid is #{Process.pid}"
+
+ProfilerGcBenchmark.new.instance_exec do
+  create_profiler
+  run_benchmark
+end

--- a/ext/datadog_profiling_native_extension/collectors_thread_context.c
+++ b/ext/datadog_profiling_native_extension/collectors_thread_context.c
@@ -621,11 +621,14 @@ bool thread_context_collector_on_gc_finish(VALUE self_instance) {
   // Let the caller know if it should schedule a flush or not. Returning true every time would cause a lot of overhead
   // on the application (see GC tracking introduction at the top of the file), so instead we try to accumulate a few
   // samples first.
-  bool finished_major_gc = gc_profiling_has_major_gc_finished();
   bool over_flush_time_treshold =
     (wall_time_at_finish_ns - state->gc_tracking.wall_time_at_last_flushed_gc_event_ns) >= TIME_BETWEEN_GC_EVENTS_NS;
 
-  return finished_major_gc || over_flush_time_treshold;
+  if (over_flush_time_treshold) {
+    return true;
+  } else {
+    return gc_profiling_has_major_gc_finished();
+  }
 }
 
 // This function gets called after one or more GC work steps (calls to on_gc_start/on_gc_finish).

--- a/spec/datadog/profiling/validate_benchmarks_spec.rb
+++ b/spec/datadog/profiling/validate_benchmarks_spec.rb
@@ -9,19 +9,15 @@ RSpec.describe 'Profiling benchmarks', if: (RUBY_VERSION >= '2.4.0') do
     end
   end
 
-  describe 'profiler_sample_loop_v2' do
-    it('runs without raising errors') { expect_in_fork { load './benchmarks/profiler_sample_loop_v2.rb' } }
-  end
-
-  describe 'profiler_http_transport' do
-    it('runs without raising errors') { expect_in_fork { load './benchmarks/profiler_http_transport.rb' } }
-  end
-
-  describe 'profiler_sample_serialize' do
-    it('runs without raising errors') { expect_in_fork { load './benchmarks/profiler_sample_serialize.rb' } }
-  end
-
-  describe 'profiler_memory_sample_serialize' do
-    it('runs without raising errors') { expect_in_fork { load './benchmarks/profiler_memory_sample_serialize.rb' } }
+  [
+    'profiler_sample_loop_v2',
+    'profiler_http_transport',
+    'profiler_sample_serialize',
+    'profiler_memory_sample_serialize',
+    'profiler_gc'
+  ].each do |benchmark|
+    describe benchmark do
+      it('runs without raising errors') { expect_in_fork { load "./benchmarks/#{benchmark}.rb" } }
+    end
   end
 end


### PR DESCRIPTION
**What does this PR do?**

As part of validating the overhead of the GC profiling feature, I've created 4 sets of benchmarks to be able to characterize its performance:

* `profiler_gc`: Measures the cost, on the profiler side, of each GC iteration
* `profiler_gc_minute`: Measures the cost of sampling one minute of an app with a lot of GC activity
* `profiler_gc_integration`: Measures the overhead of GC profiling on major GC cycles
* `profiler_gc_integration_allocations`: Measures the overhead of GC profiling on minor GC cycles

I'm preparing a writeup with analysis of these results, which I'll share soon.

**Motivation:**
Validate overhead of GC profiling feature before we enable it by default.

**Additional Notes:**

I've also included a really really really small performance tweak in 24db6ef76248a6fc06b20345b005ceb3fb5f206e .

**How to test the change?**
Run the benchmarks!

**For Datadog employees:**
- [ ] If this PR touches code that signs or publishes builds or packages, or handles
credentials of any kind, I've requested a review from `@DataDog/security-design-and-guidance`.
- [x] This PR doesn't touch any of that.