### PR TITLE
New k8s lib injection tests

### DIFF
--- a/.github/workflows/lib-injection.yml
+++ b/.github/workflows/lib-injection.yml
@@ -32,7 +32,6 @@ jobs:
           platforms: 'linux/amd64,linux/arm64/v8'
           build-args: DDTRACE_RUBY_SHA=${{ github.sha }}
           context: ./lib-injection
-
   test:
     needs:
       - build-and-publish-test-image
@@ -40,10 +39,9 @@ jobs:
     permissions:
       contents: read
       packages: write
+
     strategy:
       matrix:
-        lib-injection-connection: ['network']
-        lib-injection-use-admission-controller: ['', 'use-admission-controller']
         weblog-variant:
           - dd-lib-ruby-init-test-rails
           - dd-lib-ruby-init-test-rails-explicit
@@ -52,21 +50,32 @@ jobs:
     env:
       TEST_LIBRARY: ruby
       WEBLOG_VARIANT: ${{ matrix.weblog-variant }}
-      LIBRARY_INJECTION_CONNECTION: ${{ matrix.lib-injection-connection }}
-      LIBRARY_INJECTION_ADMISSION_CONTROLLER: ${{ matrix.lib-injection-use-admission-controller }}
       DOCKER_REGISTRY_IMAGES_PATH: ghcr.io/datadog
       DOCKER_IMAGE_TAG: ${{ github.sha }}
       BUILDX_PLATFORMS: linux/amd64,linux/arm64/v8
-      MODE: manual
     steps:
-      - name: lib-injection test runner
-        id: lib-injection-test-runner
-        uses: DataDog/system-tests/lib-injection/runner@main
-        with:
-          docker-registry: ghcr.io
-          docker-registry-username: ${{ github.repository_owner }}
-          docker-registry-password: ${{ secrets.GITHUB_TOKEN }}
-          test-script: ./lib-injection/run-manual-lib-injection.sh
+    - name: Checkout system tests
+      uses: actions/checkout@v4
+      with:
+          repository: 'DataDog/system-tests'
+
+    - name: Install runner
+      uses: ./.github/actions/install_runner 
+
+    - name: Run K8s Lib Injection Tests
+      run: ./run.sh K8S_LIB_INJECTION_BASIC
+
+    - name: Compress logs
+      id: compress_logs
+      if: always()
+      run: tar -czvf artifact.tar.gz $(ls | grep logs)
+
+    - name: Upload artifact
+      if: always()
+      uses: actions/upload-artifact@v3
+      with:
+        name: logs_k8s_lib_injection
+        path: artifact.tar.gz
 
   test-negative:
     runs-on: ubuntu-latest


### PR DESCRIPTION
We are migrating the lib injection tests in order to use Kubernetes Python Client instead of bash script. With this change we integrate the new lib injection tests into system-tests lifecycle. For example, we can push the test results to FPD.
<!--
Check out the
https://github.com/DataDog/dd-trace-rb/blob/master/docs/DevelopmentGuide.md
for guidance on how to set up your development environment,
run the test suite, write new integrations, and more.
-->

**2.0 Upgrade Guide notes**
<!--
(If this PR is for 1.x, please delete this section)
If this PR introduces a breaking change, update the
https://github.com/DataDog/dd-trace-rb/blob/2.0/docs/UpgradeGuide2.md
in this PR with either:
* A migration path for this change. In other words, how to continue using their application without behavior changes
in 2.0 (e.g. environment variable 'X' renamed to 'Y').
* That there's no alternative; we removed support for this feature.
-->

**What does this PR do?**
<!-- A brief description of the change being made with this pull request. -->

**Motivation:**
<!-- What inspired you to submit this pull request? -->

**Additional Notes:**
<!-- Anything else we should know when reviewing? -->

**How to test the change?**
<!--
Describe here how the change can be validated.
You are strongly encouraged to provide automated tests for this PR (unit or integration).
If this change cannot be feasibly tested, please explain why,
unless the change does not modify code (e.g. only modifies docs, comments).
-->

**For Datadog employees:**
- [ ] If this PR touches code that signs or publishes builds or packages, or handles
credentials of any kind, I've requested a review from `@DataDog/security-design-and-guidance`.
- [ ] This PR doesn't touch any of that.

Unsure? Have a question? Request a review!
