### PR TITLE
[PROF-9370] Enable Garbage Collection profiling by default

### DIFF
--- a/benchmarks/profiler_gc.rb
+++ b/benchmarks/profiler_gc.rb
@@ -92,7 +92,7 @@ class ProfilerGcBenchmark
     Datadog.configure do |c|
       c.profiling.enabled = true
       c.profiling.allocation_enabled = false
-      c.profiling.advanced.force_enable_gc_profiling = true
+      c.profiling.advanced.gc_enabled = true
     end
     Datadog::Profiling.wait_until_running
 
@@ -127,7 +127,7 @@ class ProfilerGcBenchmark
     Datadog.configure do |c|
       c.profiling.enabled = true
       c.profiling.allocation_enabled = false
-      c.profiling.advanced.force_enable_gc_profiling = true
+      c.profiling.advanced.gc_enabled = true
     end
     Datadog::Profiling.wait_until_running
 

--- a/lib/datadog/core/configuration/settings.rb
+++ b/lib/datadog/core/configuration/settings.rb
@@ -266,7 +266,10 @@ module Datadog
 
             # Can be used to disable the gathering of names and versions of gems in use by the service, used to power
             # grouping and categorization of stack traces.
-            option :code_provenance_enabled, default: true
+            option :code_provenance_enabled do |o|
+              o.type :bool
+              o.default true
+            end
 
             # @deprecated No longer does anything, and will be removed on dd-trace-rb 2.0.
             #
@@ -313,27 +316,35 @@ module Datadog
               end
             end
 
-            # Forces enabling of profiling of time/resources spent in Garbage Collection.
+            # @deprecated No longer does anything, and will be removed on dd-trace-rb 2.0.
             #
-            # Note that setting this to "false" (or not setting it) will not prevent the feature from being
-            # being automatically enabled in the future.
-            #
-            # This feature defaults to off for two reasons:
-            # 1. Currently this feature can add a lot of overhead for GC-heavy workloads.
-            # 2. Although this feature is safe on Ruby 2.x, on Ruby 3.x it can break in applications that make use of
-            #    Ractors due to two Ruby VM bugs:
-            #    https://bugs.ruby-lang.org/issues/19112 AND https://bugs.ruby-lang.org/issues/18464.
-            #    If you use Ruby 3.x and your application does not use Ractors (or if your Ruby has been patched), the
-            #    feature is fully safe to enable and this toggle can be used to do so.
-            #
-            # We expect the once the above issues are overcome, we'll automatically enable the feature on fixed Ruby
-            # versions.
-            #
-            # @default `DD_PROFILING_FORCE_ENABLE_GC` environment variable, otherwise `false`
+            # GC profiling is now on by default and controlled by {:gc_enabled}.
             option :force_enable_gc_profiling do |o|
-              o.env 'DD_PROFILING_FORCE_ENABLE_GC'
+              o.after_set do |_, _, precedence|
+                unless precedence == Datadog::Core::Configuration::Option::Precedence::DEFAULT
+                  Datadog.logger.warn(
+                    'The profiling.advanced.force_enable_gc_profiling setting has been deprecated for removal and no ' \
+                    'longer does anything (the feature is now on by default). ' \
+                    'Please remove this setting from your Datadog.configure block.'
+                  )
+                end
+              end
+            end
+
+            # Can be used to enable/disable garbage collection profiling.
+            #
+            # @warn To avoid https://bugs.ruby-lang.org/issues/18464 even when enabled, GC profiling is only started
+            #       for Ruby versions 2.x, 3.1.4+, 3.2.3+ and 3.3.0+
+            #       (more details in {Datadog::Profiling::Component.enable_gc_profiling?})
+            #
+            # @warn Due to a VM bug in the Ractor implementation (https://bugs.ruby-lang.org/issues/19112) this feature
+            #       stops working when Ractors get garbage collected.
+            #
+            # @default `DD_PROFILING_GC_ENABLED` environment variable, otherwise `true`
+            option :gc_enabled do |o|
               o.type :bool
-              o.default false
+              o.env 'DD_PROFILING_GC_ENABLED'
+              o.default true
             end
 
             # Can be used to enable/disable the Datadog::Profiling.allocation_count feature.

--- a/lib/datadog/profiling/component.rb
+++ b/lib/datadog/profiling/component.rb
@@ -111,19 +111,30 @@ module Datadog
       end
 
       private_class_method def self.enable_gc_profiling?(settings)
-        # See comments on the setting definition for more context on why it exists.
-        if settings.profiling.advanced.force_enable_gc_profiling
-          if Gem::Version.new(RUBY_VERSION) >= Gem::Version.new('3')
-            Datadog.logger.debug(
-              'Profiling time/resources spent in Garbage Collection force enabled. Do not use Ractors in combination ' \
-              'with this option as profiles will be incomplete.'
-            )
-          end
+        return false unless settings.profiling.advanced.gc_enabled
 
-          true
-        else
-          false
+        # SEVERE - Only with Ractors
+        # On Ruby versions 3.0 (all), 3.1.0 to 3.1.3, and 3.2.0 to 3.2.2 gc profiling can trigger a VM bug
+        # that causes a segmentation fault during garbage collection of Ractors
+        # (https://bugs.ruby-lang.org/issues/18464). We don't allow enabling gc profiling on such Rubies.
+        # This bug is fixed on Ruby versions 3.1.4, 3.2.3 and 3.3.0.
+        if RUBY_VERSION.start_with?('3.0.') ||
+            (RUBY_VERSION.start_with?('3.1.') && RUBY_VERSION < '3.1.4') ||
+            (RUBY_VERSION.start_with?('3.2.') && RUBY_VERSION < '3.2.3')
+          Datadog.logger.warn(
+            "Current Ruby version (#{RUBY_VERSION}) has a VM bug where enabling GC profiling would cause "\
+            'crashes (https://bugs.ruby-lang.org/issues/18464). GC profiling has been disabled.'
+          )
+          return false
+        elsif RUBY_VERSION.start_with?('3.')
+          Datadog.logger.debug(
+            'In all known versions of Ruby 3.x, using Ractors may result in GC profiling unexpectedly ' \
+            'stopping (https://bugs.ruby-lang.org/issues/19112). Note that this stop has no impact in your ' \
+            'application stability or performance. This does not happen if Ractors are not used.'
+          )
         end
+
+        true
       end
 
       private_class_method def self.get_heap_sample_every(settings)
@@ -135,10 +146,7 @@ module Datadog
       end
 
       private_class_method def self.enable_allocation_profiling?(settings)
-        unless settings.profiling.allocation_enabled
-          # Allocation profiling disabled, short-circuit out
-          return false
-        end
+        return false unless settings.profiling.allocation_enabled
 
         # Allocation sampling is safe and supported on Ruby 2.x, but has a few caveats on Ruby 3.x.
 

--- a/spec/datadog/core/configuration/settings_spec.rb
+++ b/spec/datadog/core/configuration/settings_spec.rb
@@ -521,12 +521,20 @@ RSpec.describe Datadog::Core::Configuration::Settings do
         end
       end
 
-      describe '#force_enable_gc_profiling' do
-        subject(:force_enable_gc_profiling) { settings.profiling.advanced.force_enable_gc_profiling }
+      describe '#force_enable_gc_profiling=' do
+        it 'logs a warning informing customers this no longer does anything' do
+          expect(Datadog.logger).to receive(:warn).with(/no longer does anything/)
 
-        context 'when DD_PROFILING_FORCE_ENABLE_GC' do
+          settings.profiling.advanced.force_enable_gc_profiling = true
+        end
+      end
+
+      describe '#gc_enabled' do
+        subject(:gc_enabled) { settings.profiling.advanced.gc_enabled }
+
+        context 'when DD_PROFILING_GC_ENABLED' do
           around do |example|
-            ClimateControl.modify('DD_PROFILING_FORCE_ENABLE_GC' => environment) do
+            ClimateControl.modify('DD_PROFILING_GC_ENABLED' => environment) do
               example.run
             end
           end
@@ -534,7 +542,7 @@ RSpec.describe Datadog::Core::Configuration::Settings do
           context 'is not defined' do
             let(:environment) { nil }
 
-            it { is_expected.to be false }
+            it { is_expected.to be true }
           end
 
           [true, false].each do |value|
@@ -547,12 +555,12 @@ RSpec.describe Datadog::Core::Configuration::Settings do
         end
       end
 
-      describe '#force_enable_gc_profiling=' do
-        it 'updates the #force_enable_gc_profiling setting' do
-          expect { settings.profiling.advanced.force_enable_gc_profiling = true }
-            .to change { settings.profiling.advanced.force_enable_gc_profiling }
-            .from(false)
-            .to(true)
+      describe '#gc_enabled=' do
+        it 'updates the #gc_enabled setting' do
+          expect { settings.profiling.advanced.gc_enabled = false }
+            .to change { settings.profiling.advanced.gc_enabled }
+            .from(true)
+            .to(false)
         end
       end
 


### PR DESCRIPTION
**What does this PR do?**

This PR turns the Garbage Collection profiling feature on by default.

Specifically it:

1. Introduces a new `c.profiling.advanced.gc_enabled` setting, which defaults to `true` (can also be toggled using the `DD_PROFILING_GC_ENABLED` env var)

2. Deprecates the previous `c.profiling.advanced.force_enable_gc_profiling` setting. This setting only served to turn the feature on, not turn it off, so it no longer makes sense to exist.

3. Does not turn on GC profiling on Rubies affected by https://bugs.ruby-lang.org/issues/18464 . Specifically, GC profiling can now only be turned on in Ruby versions 2.x, 3.1.4+, 3.2.3+ and 3.3+ . This avoids impacting known-buggy Rubies.

**Motivation:**

We've done through validation that this feature is working nicely and with low overhead, and it works great with the timeline view.

**Additional Notes:**

Regarding the impact of Ruby issue 18464, I explicitly chose to no longer allow GC profiling to be enabled on affected Rubies.

I did this so as to simplify the implementation of the settings.

Because we wanted to enable this feature by default, having a way to still enable it on these Rubies would mean either having another option (e.g. keep `force_enable_gc_profiling` around?), somehow introducing a tri-state value for the setting (like we do for the `no_signals_workaround_enabled`), or fiddling with precedences to distinguish the default value from a user-set one.

In the end, I decided to simplify and not do any of the above. We can still change our minds later and introduce it based on user feedback and needs, but unless a user really needs to be on 3.0.x for which there is no bug fix release, we really really really really instead recomend moving to the latest patch release of the 3.1.x or 3.2.x series.

**How to test the change?**

The change includes test coverage. You can also profile a simple script and observe that GC profiling is included by default, without any extra option having to be set.

**For Datadog employees:**
- [ ] If this PR touches code that signs or publishes builds or packages, or handles
credentials of any kind, I've requested a review from `@DataDog/security-design-and-guidance`.
- [x] This PR doesn't touch any of that.