### PR TITLE
Remove dependency on base64 gem

### DIFF
--- a/Steepfile
+++ b/Steepfile
@@ -588,7 +588,6 @@ target :datadog do
   library 'ipaddr'
   library 'net-http'
   library 'securerandom'
-  library 'base64'
   library 'digest'
   library 'zlib'
   library 'time'

--- a/datadog.gemspec
+++ b/datadog.gemspec
@@ -60,9 +60,6 @@ Gem::Specification.new do |spec|
   # rubies, see #1739 and #1336 for an extended discussion about this
   spec.add_dependency 'msgpack'
 
-  # Requiring base64 from stdlib is deprecated in Ruby v3.3 and will be removed in v3.4
-  spec.add_dependency 'base64'
-
   # Used by the profiler native extension to support Ruby < 2.6 and > 3.2
   #
   # We decided to pin it at the latest available version and will manually bump the dependency as needed.

--- a/lib/datadog/appsec/event.rb
+++ b/lib/datadog/appsec/event.rb
@@ -2,9 +2,9 @@
 
 require 'json'
 require 'zlib'
-require 'base64'
 
 require_relative 'rate_limiter'
+require_relative '../core/utils/base64'
 
 module Datadog
   module AppSec
@@ -140,7 +140,7 @@ module Datadog
         private
 
         def compressed_and_base64_encoded(value)
-          Base64.encode64(gzip(value))
+          Datadog::Core::Utils::Base64.encode64(gzip(value))
         rescue TypeError => e
           Datadog.logger.debug do
             "Failed to compress and encode value when populating AppSec::Event. Error: #{e.message}"

--- a/lib/datadog/core/remote/client/capabilities.rb
+++ b/lib/datadog/core/remote/client/capabilities.rb
@@ -1,5 +1,6 @@
 # frozen_string_literal: true
 
+require_relative '../../utils/base64'
 require_relative '../../../appsec/remote'
 require_relative '../../../tracing/remote'
 
@@ -53,7 +54,7 @@ module Datadog
             cap_to_hexs = capabilities.reduce(:|).to_s(16).tap { |s| s.size.odd? && s.prepend('0') }.scan(/\h\h/)
             binary = cap_to_hexs.each_with_object([]) { |hex, acc| acc << hex }.map { |e| e.to_i(16) }.pack('C*')
 
-            Base64.encode64(binary).chomp
+            Datadog::Core::Utils::Base64.encode64(binary).chomp
           end
         end
       end

--- a/lib/datadog/core/remote/transport/http/config.rb
+++ b/lib/datadog/core/remote/transport/http/config.rb
@@ -1,10 +1,10 @@
 # frozen_string_literal: true
 
 require 'json'
-require 'base64'
 
 require_relative '../config'
 require_relative 'client'
+require_relative '../../../utils/base64'
 require_relative '../../../transport/http/response'
 require_relative '../../../transport/http/api/endpoint'
 
@@ -51,7 +51,7 @@ module Datadog
 
                 # TODO: these fallbacks should be improved
                 roots = payload[:roots] || []
-                targets = payload[:targets] || Base64.encode64('{}').chomp
+                targets = payload[:targets] || Datadog::Core::Utils::Base64.encode64('{}').chomp
                 target_files = payload[:target_files] || []
                 client_configs = payload[:client_configs] || []
 
@@ -61,7 +61,7 @@ module Datadog
                   raise TypeError.new(String, root) unless root.is_a?(String)
 
                   decoded = begin
-                    Base64.strict_decode64(root) # TODO: unprocessed, don't symbolize_names
+                    Datadog::Core::Utils::Base64.strict_decode64(root) # TODO: unprocessed, don't symbolize_names
                   rescue ArgumentError
                     raise DecodeError.new(:roots, root)
                   end
@@ -81,7 +81,7 @@ module Datadog
 
                 @targets = begin
                   decoded = begin
-                    Base64.strict_decode64(targets)
+                    Datadog::Core::Utils::Base64.strict_decode64(targets)
                   rescue ArgumentError
                     raise DecodeError.new(:targets, targets)
                   end
@@ -109,7 +109,7 @@ module Datadog
                   raise TypeError.new(String, raw) unless raw.is_a?(String)
 
                   content = begin
-                    Base64.strict_decode64(raw)
+                    Datadog::Core::Utils::Base64.strict_decode64(raw)
                   rescue ArgumentError
                     raise DecodeError.new(:target_files, raw)
                   end

--- a/lib/datadog/core/utils/base64.rb
+++ b/lib/datadog/core/utils/base64.rb
@@ -1,0 +1,22 @@
+# frozen_string_literal: true
+
+module Datadog
+  module Core
+    module Utils
+      # Helper methods for encoding and decoding base64
+      module Base64
+        def self.encode64(bin)
+          [bin].pack('m')
+        end
+
+        def self.strict_encode64(bin)
+          [bin].pack('m0')
+        end
+
+        def self.strict_decode64(str)
+          str.unpack1('m0')
+        end
+      end
+    end
+  end
+end

--- a/sig/datadog/core/utils/base64.rbs
+++ b/sig/datadog/core/utils/base64.rbs
@@ -1,0 +1,14 @@
+module Datadog
+  module Core
+    module Utils
+      # Helper methods for encoding and decoding base64
+      module Base64
+        def self.encode64: (String bin) -> String
+
+        def self.strict_encode64: (String bin) -> String
+
+        def self.strict_decode64: (String str) -> untyped
+      end
+    end
+  end
+end

--- a/spec/datadog/core/remote/client_spec.rb
+++ b/spec/datadog/core/remote/client_spec.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 require 'spec_helper'
+require 'datadog/core/utils/base64'
 require 'datadog/core/remote/transport/http'
 require 'datadog/core/remote/client'
 
@@ -204,21 +205,21 @@ RSpec.describe Datadog::Core::Remote::Client do
   let(:rules_data_response) do
     {
       'path' => 'datadog/603646/ASM_DD/latest/config',
-      'raw' => Base64.strict_encode64(rules_data).chomp
+      'raw' => Datadog::Core::Utils::Base64.strict_encode64(rules_data).chomp
     }
   end
 
   let(:blocked_ips_data_response) do
     {
       'path' => 'datadog/603646/ASM_DATA/blocked_ips/config',
-      'raw' => Base64.strict_encode64(blocked_ips).chomp
+      'raw' => Datadog::Core::Utils::Base64.strict_encode64(blocked_ips).chomp
     }
   end
 
   let(:exclusion_data_response) do
     {
       'path' => 'datadog/603646/ASM/exclusion_filters/config',
-      'raw' => Base64.strict_encode64(exclusions).chomp
+      'raw' => Datadog::Core::Utils::Base64.strict_encode64(exclusions).chomp
     }
   end
 
@@ -228,8 +229,8 @@ RSpec.describe Datadog::Core::Remote::Client do
 
   let(:response_body) do
     {
-      'roots' => roots.map { |r| Base64.strict_encode64(r.to_json).chomp },
-      'targets' => Base64.strict_encode64(targets.to_json).chomp,
+      'roots' => roots.map { |r| Datadog::Core::Utils::Base64.strict_encode64(r.to_json).chomp },
+      'targets' => Datadog::Core::Utils::Base64.strict_encode64(targets.to_json).chomp,
       'target_files' => target_files,
       'client_configs' => client_configs,
     }.to_json
@@ -380,12 +381,12 @@ RSpec.describe Datadog::Core::Remote::Client do
       context 'invalid response body' do
         let(:response_body) do
           {
-            'roots' => roots.map { |r| Base64.strict_encode64(r.to_json).chomp },
-            'targets' => Base64.strict_encode64(targets.to_json).chomp,
+            'roots' => roots.map { |r| Datadog::Core::Utils::Base64.strict_encode64(r.to_json).chomp },
+            'targets' => Datadog::Core::Utils::Base64.strict_encode64(targets.to_json).chomp,
             'target_files' => [
               {
                 'path' => 'datadog/603646/ASM/exclusion_filters/config',
-                'raw' => Base64.strict_encode64(exclusions).chomp
+                'raw' => Datadog::Core::Utils::Base64.strict_encode64(exclusions).chomp
               }
             ],
             'client_configs' => [

--- a/spec/datadog/core/remote/transport/http_spec.rb
+++ b/spec/datadog/core/remote/transport/http_spec.rb
@@ -2,6 +2,7 @@
 
 require 'spec_helper'
 
+require 'datadog/core/utils/base64'
 require 'datadog/core/remote/transport/http'
 require 'datadog/core/remote/transport/http/negotiation'
 require 'datadog/core/remote/transport/negotiation'
@@ -133,7 +134,7 @@ RSpec.describe Datadog::Core::Remote::Transport::HTTP do
               env: Datadog.configuration.env,
               tags: [],
             },
-            capabilities: Base64.encode64(capabilities_binary).chomp,
+            capabilities: Datadog::Core::Utils::Base64.encode64(capabilities_binary).chomp,
           },
           cached_target_files: [],
         }
@@ -144,11 +145,11 @@ RSpec.describe Datadog::Core::Remote::Transport::HTTP do
       let(:response_code) { 200 }
       let(:response_body) do
         encode = proc do |obj|
-          Base64.strict_encode64(obj).chomp
+          Datadog::Core::Utils::Base64.strict_encode64(obj).chomp
         end
 
         jencode = proc do |obj|
-          Base64.strict_encode64(JSON.dump(obj)).chomp
+          Datadog::Core::Utils::Base64.strict_encode64(JSON.dump(obj)).chomp
         end
 
         JSON.dump(

--- a/spec/datadog/core/remote/transport/integration_spec.rb
+++ b/spec/datadog/core/remote/transport/integration_spec.rb
@@ -2,6 +2,7 @@
 
 require 'spec_helper'
 
+require 'datadog/core/utils/base64'
 require 'datadog/core/remote/transport/http'
 require 'datadog/core/remote/transport/http/negotiation'
 require 'datadog/core/remote/transport/negotiation'
@@ -89,7 +90,7 @@ RSpec.describe Datadog::Core::Remote::Transport::HTTP do
               env: Datadog.configuration.env,
               tags: [],
             },
-            capabilities: Base64.encode64(capabilities_binary).chomp,
+            capabilities: Datadog::Core::Utils::Base64.encode64(capabilities_binary).chomp,
           },
           cached_target_files: [],
         }

--- a/spec/datadog/tracing/contrib/suite/integration_spec.rb
+++ b/spec/datadog/tracing/contrib/suite/integration_spec.rb
@@ -1,3 +1,4 @@
+require 'datadog/core/utils/base64'
 require 'datadog/tracing/contrib/support/spec_helper'
 
 require 'datadog'
@@ -72,7 +73,7 @@ RSpec.describe 'contrib integration testing', :integration do
 
         target_files << {
           'path' => target,
-          'raw' => Base64.strict_encode64(raw),
+          'raw' => Datadog::Core::Utils::Base64.strict_encode64(raw),
         }
 
         targets_targets[target] = {
@@ -85,7 +86,7 @@ RSpec.describe 'contrib integration testing', :integration do
 
       {
         'target_files' => target_files,
-        'targets' => Base64.strict_encode64(targets.to_json),
+        'targets' => Datadog::Core::Utils::Base64.strict_encode64(targets.to_json),
         'client_configs' => client_configs,
       }.to_json
     end


### PR DESCRIPTION
<!--
Check out the
https://github.com/DataDog/dd-trace-rb/blob/master/docs/DevelopmentGuide.md
for guidance on how to set up your development environment,
run the test suite, write new integrations, and more.
-->

**2.0 Upgrade Guide notes**
<!--
(If this PR is for 1.x, please delete this section)
If this PR introduces a breaking change, update the
https://github.com/DataDog/dd-trace-rb/blob/2.0/docs/UpgradeGuide2.md
in this PR with either:
* A migration path for this change. In other words, how to continue using their application without behavior changes
in 2.0 (e.g. environment variable 'X' renamed to 'Y').
* That there's no alternative; we removed support for this feature.
-->

**What does this PR do?**
<!-- A brief description of the change being made with this pull request. -->

Remove the runtime dependency on the base64 gem.

**Motivation:**
#3364 added a dependency on the base64 gem to silence warnings on Ruby >= 3.4

The used portions of the base64 gem are just wrappers around the pack/unpack methods ([see here](https://github.com/ruby/base64/blob/9669a7d3b0e3b9a739969404daf58f912c58c6b3/lib/base64.rb)). These can be added to a module to keep their descriptive names and allow the gem to drop a dependency.

I've done something quite similar for the newrelic agent [here](https://github.com/newrelic/newrelic-ruby-agent/pull/2378), and other gems did something like that as well:

* https://github.com/rack/rack/pull/2110
* https://github.com/rubocop/rubocop/pull/12313
* https://github.com/lostisland/faraday/pull/1541
* https://github.com/bblimke/webmock/pull/1046
* etc.

**Additional Notes:**
<!-- Anything else we should know when reviewing? -->

I think I'm not supposed to touch the gemfiles/lockfiles? I believe I github action will take care of that.

**How to test the change?**
<!--
Describe here how the change can be validated.
You are strongly encouraged to provide automated tests for this PR (unit or integration).
If this change cannot be feasibly tested, please explain why,
unless the change does not modify code (e.g. only modifies docs, comments).
-->

Current tests are fine.

**For Datadog employees:**
- [ ] If this PR touches code that signs or publishes builds or packages, or handles
credentials of any kind, I've requested a review from `@DataDog/security-design-and-guidance`.
- [ ] This PR doesn't touch any of that.

Unsure? Have a question? Request a review!
