### PR TITLE
Use strict base64 encoding (no newline)

### DIFF
--- a/lib/datadog/appsec/event.rb
+++ b/lib/datadog/appsec/event.rb
@@ -138,7 +138,7 @@ module Datadog
         private
 
         def compressed_and_base64_encoded(value)
-          Base64.encode64(gzip(value))
+          Base64.strict_encode64(gzip(value))
         rescue TypeError => e
           Datadog.logger.debug do
             "Failed to compress and encode value when populating AppSec::Event. Error: #{e.message}"

--- a/lib/datadog/core/remote/client/capabilities.rb
+++ b/lib/datadog/core/remote/client/capabilities.rb
@@ -53,7 +53,7 @@ module Datadog
             cap_to_hexs = capabilities.reduce(:|).to_s(16).tap { |s| s.size.odd? && s.prepend('0') }.scan(/\h\h/)
             binary = cap_to_hexs.each_with_object([]) { |hex, acc| acc << hex }.map { |e| e.to_i(16) }.pack('C*')
 
-            Base64.encode64(binary).chomp
+            Base64.strict_encode64(binary)
           end
         end
       end

--- a/lib/datadog/core/remote/transport/http/config.rb
+++ b/lib/datadog/core/remote/transport/http/config.rb
@@ -51,7 +51,7 @@ module Datadog
 
                 # TODO: these fallbacks should be improved
                 roots = payload[:roots] || []
-                targets = payload[:targets] || Base64.encode64('{}').chomp
+                targets = payload[:targets] || Base64.strict_encode64('{}')
                 target_files = payload[:target_files] || []
                 client_configs = payload[:client_configs] || []
 

--- a/spec/datadog/appsec/event_spec.rb
+++ b/spec/datadog/appsec/event_spec.rb
@@ -218,13 +218,59 @@ RSpec.describe Datadog::AppSec::Event do
 
         context 'Compressed payload' do
           it 'uses compressed value when JSON string is bigger than MIN_SCHEMA_SIZE_FOR_COMPRESSION' do
-            result = "H4sIAOYoHGUAA4aphwAAAA=\n"
+            result = 'H4sIAOYoHGUAA4aphwAAAA='
             stub_const('Datadog::AppSec::Event::MIN_SCHEMA_SIZE_FOR_COMPRESSION', 1)
             expect(described_class).to receive(:compressed_and_base64_encoded).and_return(result)
 
             meta = top_level_span.meta
 
             expect(meta['_dd.appsec.s.req.headers']).to eq(result)
+          end
+
+          context 'with big derivatives' do
+            let(:derivatives) do
+              {
+                '_dd.appsec.s.req.headers' => [
+                  {
+                    'host' => [8],
+                    'version' => [8],
+                    'foo' => [8],
+                    'bar' => [8],
+                    'baz' => [8],
+                    'qux' => [8],
+                    'quux' => [8],
+                    'quuux' => [8],
+                    'quuuux' => [8],
+                    'quuuuux' => [8],
+                    'quuuuuux' => [8],
+                    'quuuuuuux' => [8],
+                    'quuuuuuuux' => [8],
+                    'quuuuuuuuux' => [8],
+                    'quuuuuuuuuux' => [8],
+                    'quuuuuuuuuuux' => [8],
+                    'quuuuuuuuuuuux' => [8],
+                    'quuuuuuuuuuuuux' => [8],
+                    'quuuuuuuuuuuuuux' => [8],
+                    'quuuuuuuuuuuuuuux' => [8],
+                    'quuuuuuuuuuuuuuuux' => [8],
+                    'quuuuuuuuuuuuuuuuux' => [8],
+                    'quuuuuuuuuuuuuuuuuux' => [8],
+                    'quuuuuuuuuuuuuuuuuuux' => [8],
+                    'quuuuuuuuuuuuuuuuuuuux' => [8],
+                    'quuuuuuuuuuuuuuuuuuuuux' => [8],
+                    'quuuuuuuuuuuuuuuuuuuuuux' => [8],
+                    'quuuuuuuuuuuuuuuuuuuuuuux' => [8],
+                    'quuuuuuuuuuuuuuuuuuuuuuuux' => [8],
+                  }
+                ]
+              }
+            end
+
+            it 'has no newlines when encoded' do
+              meta = top_level_span.meta
+
+              expect(meta['_dd.appsec.s.req.headers']).to_not match(/\n/)
+            end
           end
         end
 


### PR DESCRIPTION
<!--
Check out the
https://github.com/DataDog/dd-trace-rb/blob/master/docs/DevelopmentGuide.md
for guidance on how to set up your development environment,
run the test suite, write new integrations, and more.
-->

**2.0 Upgrade Guide notes**
<!--
(If this PR is for 1.x, please delete this section)
If this PR introduces a breaking change, update the
https://github.com/DataDog/dd-trace-rb/blob/2.0/docs/UpgradeGuide2.md
in this PR with either:
* A migration path for this change. In other words, how to continue using their application without behavior changes
in 2.0 (e.g. environment variable 'X' renamed to 'Y').
* That there's no alternative; we removed support for this feature.
-->

**What does this PR do?**

Use strict base64 encoding. 

**Motivation:**

MIME-style newlines in the middle of base64 makes for some unhappy results.

**Additional Notes:**

Reported case was with compressed data on appsec derivative results (e.g schema), introduced in https://github.com/DataDog/dd-trace-rb/commit/8c52213e047cde29a773714fc304135635d8dedd

This also applies to a few areas like RC capabilities, although the contents was smaller thus not affected (a trailing newline was handled with a `chomp`.

**How to test the change?**
<!--
Describe here how the change can be validated.
You are strongly encouraged to provide automated tests for this PR (unit or integration).
If this change cannot be feasibly tested, please explain why,
unless the change does not modify code (e.g. only modifies docs, comments).
-->

CI covers it (added a non-regression test)

**For Datadog employees:**
- [ ] If this PR touches code that signs or publishes builds or packages, or handles
credentials of any kind, I've requested a review from `@DataDog/security-design-and-guidance`.
- [x] This PR doesn't touch any of that.

Unsure? Have a question? Request a review!
