### PR TITLE
Skip publishing lib injection artifacts for prereleases

### DIFF
--- a/.github/workflows/release-lib-injection.yml
+++ b/.github/workflows/release-lib-injection.yml
@@ -4,6 +4,7 @@ on:
   push:
     tags:
       - 'v*.*.*'
+      - '!v*.*.*.*' # Exclude prerelease tags
 
 jobs:
   build-and-publish-release-image:

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -215,7 +215,7 @@ deploy_latest_tag_to_docker_registries:
   rules:
     - if: "$POPULATE_CACHE"
       when: never
-    - if: $CI_COMMIT_TAG =~ /^v(\d+)\.(\d+)\.(\d+)$/ # Exclude prerelease
+    - if: $CI_COMMIT_TAG =~ /^v(\d+)\.(\d+)\.(\d+)$/ && $CI_COMMIT_BRANCH == 'master' # Exclude prerelease and only for master branch
       when: delayed
       start_in: 1 day
     - when: manual

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -196,7 +196,7 @@ deploy_to_docker_registries:
   rules:
     - if: "$POPULATE_CACHE"
       when: never
-    - if: "$CI_COMMIT_TAG =~ /^v.*/"
+    - if: $CI_COMMIT_TAG =~ /^v(\d+)\.(\d+)\.(\d+)$/ # Exclude prerelease
       when: delayed
       start_in: 1 day
     - when: manual
@@ -215,7 +215,7 @@ deploy_latest_tag_to_docker_registries:
   rules:
     - if: "$POPULATE_CACHE"
       when: never
-    - if: "$CI_COMMIT_TAG =~ /^v.*/"
+    - if: $CI_COMMIT_TAG =~ /^v(\d+)\.(\d+)\.(\d+)$/ # Exclude prerelease
       when: delayed
       start_in: 1 day
     - when: manual


### PR DESCRIPTION
**What does this PR do?**

1. Skip publishing lib injection artifacts for prereleases
2. Tag `latest` from `master` 