### PR TITLE
 Rails: Remove circular require 

### DIFF
--- a/lib/datadog/tracing/contrib/action_pack/integration.rb
+++ b/lib/datadog/tracing/contrib/action_pack/integration.rb
@@ -3,7 +3,7 @@
 require_relative 'configuration/settings'
 require_relative 'patcher'
 require_relative '../integration'
-require_relative '../rails/integration'
+require_relative '../rails/ext'
 require_relative '../rails/utils'
 
 module Datadog

--- a/lib/datadog/tracing/contrib/action_view/integration.rb
+++ b/lib/datadog/tracing/contrib/action_view/integration.rb
@@ -3,7 +3,7 @@
 require_relative 'configuration/settings'
 require_relative 'patcher'
 require_relative '../integration'
-require_relative '../rails/integration'
+require_relative '../rails/ext'
 require_relative '../rails/utils'
 
 module Datadog

--- a/lib/datadog/tracing/contrib/active_record/integration.rb
+++ b/lib/datadog/tracing/contrib/active_record/integration.rb
@@ -5,7 +5,7 @@ require_relative 'configuration/settings'
 require_relative 'events'
 require_relative 'patcher'
 require_relative '../integration'
-require_relative '../rails/integration'
+require_relative '../rails/ext'
 require_relative '../rails/utils'
 
 module Datadog

--- a/lib/datadog/tracing/contrib/active_support/integration.rb
+++ b/lib/datadog/tracing/contrib/active_support/integration.rb
@@ -4,7 +4,7 @@ require_relative '../integration'
 require_relative 'configuration/settings'
 require_relative 'patcher'
 require_relative 'cache/redis'
-require_relative '../rails/integration'
+require_relative '../rails/ext'
 require_relative '../rails/utils'
 
 module Datadog


### PR DESCRIPTION
**What does this PR do?**

This PR removes a few circular `require`s in the Rails integrations, like the following example:
```
from ddtrace/lib/datadog.rb:5:in  `<top (required)>'
  from ddtrace/lib/datadog.rb:5:in  `require_relative'
  from ddtrace/lib/datadog/tracing/contrib.rb:35:in  `<top (required)>'
from ddtrace/lib/datadog/tracing/contrib.rb:35:in  `require_relative'
  from ddtrace/lib/datadog/tracing/contrib/action_pack/integration.rb:6:in  `<top (required)>'
  from ddtrace/lib/datadog/tracing/contrib/action_pack/integration.rb:6:in  `require_relative'
from ddtrace/lib/datadog/tracing/contrib/rails/integration.rb:7:in  `<top (required)>'
  from ddtrace/lib/datadog/tracing/contrib/rails/integration.rb:7:in  `require_relative'
  from ddtrace/lib/datadog/tracing/contrib/rails/patcher.rb:5:in  `<top (required)>'
from ddtrace/lib/datadog/tracing/contrib/rails/patcher.rb:5:in  `require_relative'
  from ddtrace/lib/datadog/tracing/contrib/rails/framework.rb:8:in  `<top (required)>'
  from ddtrace/lib/datadog/tracing/contrib/rails/framework.rb:8:in  `require_relative'
from ddtrace/lib/datadog/tracing/contrib/active_support/integration.rb:7:in  `<top (required)>'
  from ddtrace/lib/datadog/tracing/contrib/active_support/integration.rb:7:in  `require_relative'
```

**How to test the change?**

There should be no change in behaviour as long as integration tests pass in CI.

**For Datadog employees:**
- [ ] If this PR touches code that signs or publishes builds or packages, or handles
credentials of any kind, I've requested a review from `@DataDog/security-design-and-guidance`.
- [ ] This PR doesn't touch any of that.

Unsure? Have a question? Request a review!
