### PR TITLE
ASEC-131:Remove reference to SDG as the team no longer exists

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -33,9 +33,4 @@ If this change cannot be feasibly tested, please explain why,
 unless the change does not modify code (e.g. only modifies docs, comments).
 -->
 
-**For Datadog employees:**
-- [ ] If this PR touches code that signs or publishes builds or packages, or handles
-credentials of any kind, I've requested a review from `@DataDog/security-design-and-guidance`.
-- [ ] This PR doesn't touch any of that.
-
 Unsure? Have a question? Request a review!


### PR DESCRIPTION




**What does this PR do?**
<!-- A brief description of the change being made with this pull request. -->
Removing reference of Security Design and Guidance team in PR review template as the team no longer exists. We will work with the trace team to understand the requirements of review.

