### PR TITLE
[PROF-9370] Remove separate configuration for benchmarking GC profiling

### DIFF
--- a/.gitlab/benchmarks.yml
+++ b/.gitlab/benchmarks.yml
@@ -74,14 +74,6 @@ only-profiling:
     # better accuracy, mode.
     DD_PROFILING_NO_SIGNALS_WORKAROUND_ENABLED: "false"
 
-only-profiling-gc:
-  extends: .benchmarks
-  variables:
-    DD_BENCHMARKS_CONFIGURATION: only-profiling
-    DD_PROFILING_ENABLED: "true"
-    DD_PROFILING_NO_SIGNALS_WORKAROUND_ENABLED: "false"
-    DD_PROFILING_FORCE_ENABLE_GC: "true"
-
 only-profiling-alloc:
   extends: .benchmarks
   variables:


### PR DESCRIPTION
**What does this PR do?**

This PR removes the benchmarking configuration for testing GC profiling.

This is because in https://github.com/DataDog/dd-trace-rb/pull/3558 GC profiling was enabled by default and so the `only-profiling` configuration now includes GC profiling (and thus we don't need a separate one).

**Motivation:**

Remove benchmarking configurations that no longer make sense to have.

**Additional Notes:**

N/A

**How to test the change?**

Validate this configuration is no longer tested.

**For Datadog employees:**
- [ ] If this PR touches code that signs or publishes builds or packages, or handles
credentials of any kind, I've requested a review from `@DataDog/security-design-and-guidance`.
- [x] This PR doesn't touch any of that.