### PR TITLE
[PROF-9469] Skip heap samples with age 0

### DIFF
--- a/benchmarks/profiler_memory_sample_serialize.rb
+++ b/benchmarks/profiler_memory_sample_serialize.rb
@@ -48,6 +48,7 @@ class ProfilerMemorySampleSerializeBenchmark
     @heap_size_enabled = ENV['HEAP_SIZE'] == 'true'
     @heap_sample_every = (ENV['HEAP_SAMPLE_EVERY'] || '1').to_i
     @retain_every = (ENV['RETAIN_EVERY'] || '10').to_i
+    @skip_end_gc = ENV['SKIP_END_GC'] == 'true'
     @recorder_factory = proc {
       Datadog::Profiling::StackRecorder.new(
         cpu_time_enabled: false,
@@ -68,7 +69,7 @@ class ProfilerMemorySampleSerializeBenchmark
         suite: report_to_dogstatsd_if_enabled_via_environment_variable(benchmark_name: 'profiler_memory_sample_serialize')
       )
 
-      x.report("sample+serialize #{ENV['CONFIG']} retain_every=#{@retain_every} heap_samples=#{@heap_samples_enabled} heap_size=#{@heap_size_enabled} heap_sample_every=#{@heap_sample_every}") do
+      x.report("sample+serialize #{ENV['CONFIG']} retain_every=#{@retain_every} heap_samples=#{@heap_samples_enabled} heap_size=#{@heap_size_enabled} heap_sample_every=#{@heap_sample_every} skip_end_gc=#{@skip_end_gc}") do
         recorder = @recorder_factory.call
         samples_per_second = 100
         simulate_seconds = 60
@@ -79,7 +80,7 @@ class ProfilerMemorySampleSerializeBenchmark
           retained_objs << obj if (i % @retain_every).zero?
         end
 
-        GC.start
+        GC.start unless @skip_end_gc
 
         recorder.serialize
       end

--- a/ext/datadog_profiling_native_extension/heap_recorder.c
+++ b/ext/datadog_profiling_native_extension/heap_recorder.c
@@ -488,8 +488,7 @@ static int st_object_record_update(st_data_t key, st_data_t value, st_data_t ext
   size_t iteration_gen = recorder->iteration_gen;
   size_t alloc_gen = record->object_data.alloc_gen;
   // Guard against potential overflows given unsigned types here.
-  size_t age = alloc_gen < iteration_gen ? iteration_gen - alloc_gen : 0;
-  record->object_data.gen_age = age;
+  record->object_data.gen_age = alloc_gen < iteration_gen ? iteration_gen - alloc_gen : 0;
 
   if (NOT_INCLUDED_IN_ITERATION(record)) {
     // If an object won't be included in the current iteration, there's

--- a/ext/datadog_profiling_native_extension/heap_recorder.h
+++ b/ext/datadog_profiling_native_extension/heap_recorder.h
@@ -27,7 +27,9 @@ typedef struct live_object_data {
   //          could be seen as being representative of 50 objects.
   unsigned int weight;
 
-  // Size of this object on last flush/update.
+  // Size of this object in memory.
+  // NOTE: This only gets updated during heap_recorder_prepare_iteration and only
+  //       for those objects that meet the minimum iteration age requirements.
   size_t size;
 
   // The class of the object that we're tracking.
@@ -38,6 +40,10 @@ typedef struct live_object_data {
   //
   // This enables us to calculate the age of this object in terms of GC executions.
   size_t alloc_gen;
+
+  // The age of this object in terms of GC generations.
+  // NOTE: This only gets updated during heap_recorder_prepare_iteration
+  size_t gen_age;
 
   // Whether this object was previously seen as being frozen. If this is the case,
   // we'll skip any further size updates since frozen objects are supposed to be
@@ -50,9 +56,6 @@ typedef struct live_object_data {
 typedef struct {
   ddog_prof_Slice_Location locations;
   live_object_data object_data;
-  // Age (in terms of GC generations) of this live object as snapshotted during iteration
-  // preparation.
-  size_t gen_age;
 } heap_recorder_iteration_data;
 
 // Initialize a new heap recorder.
@@ -116,16 +119,8 @@ void end_heap_allocation_recording(heap_recorder *heap_recorder, ddog_prof_Slice
 // Update the heap recorder to reflect the latest state of the VM and prepare internal structures
 // for efficient iteration.
 //
-// @param min_gc_age
-//   Minimum age (in GC epochs/generations) of objects we want to iterate over. Any objects whose
-//   age is below this value will not be seen by the next heap_recorder_for_each_live_object
-//   calls and thus, for efficiency, we'll also skip their updating (size and liveness checks).
-// @return gc_count() at which the iteration started being prepared. Note that preparation is
-//   not atomic and thus a GC could have executed in the middle so our notion of age can be off
-//   by a bit (hopefully at most just 1 generation/epoch).
-//
 // WARN: This must be called strictly before iteration. Failing to do so will result in exceptions.
-size_t heap_recorder_prepare_iteration(heap_recorder *heap_recorder, size_t min_gc_age);
+void heap_recorder_prepare_iteration(heap_recorder *heap_recorder);
 
 // Optimize the heap recorder by cleaning up any data that might have been prepared specifically
 // for the purpose of iterating over the heap recorder data.

--- a/spec/datadog/profiling/collectors/cpu_and_wall_time_worker_spec.rb
+++ b/spec/datadog/profiling/collectors/cpu_and_wall_time_worker_spec.rb
@@ -637,6 +637,10 @@ RSpec.describe 'Datadog::Profiling::Collectors::CpuAndWallTimeWorker' do
         test_num_allocated_object.times { |i| live_objects[i] = CpuAndWallTimeWorkerSpec::TestStruct.new }
         allocation_line = __LINE__ - 1
 
+        # Force a GC to happen here to ensure all the live_objects have age > 0.
+        # Otherwise they wouldn't show up in the serialized pprof below
+        GC.start
+
         cpu_and_wall_time_worker.stop
 
         test_struct_heap_sample = lambda { |sample|

--- a/spec/datadog/profiling/stack_recorder_spec.rb
+++ b/spec/datadog/profiling/stack_recorder_spec.rb
@@ -548,6 +548,8 @@ RSpec.describe Datadog::Profiling::StackRecorder do
 
           described_class::Testing._native_end_fake_slow_heap_serialization(stack_recorder)
 
+          GC.start # Force a GC so the live_objects above have age > 0 and show up in heap samples
+
           relevant_sample = heap_samples.find { |s| s.has_location?(path: __FILE__, line: sample_line) }
           expect(relevant_sample).not_to be nil
           expect(relevant_sample.values[:'heap-live-samples']).to eq test_num_allocated_object * sample_rate
@@ -664,6 +666,8 @@ RSpec.describe Datadog::Profiling::StackRecorder do
 
             sample_allocation(recycled_obj)
             sample_line = __LINE__ - 1
+
+            GC.start # Ensure recycled sample has age > 0 so it shows up in serialized profile
 
             recycled_sample = heap_samples.find { |s| s.has_location?(path: __FILE__, line: sample_line) }
             expect(recycled_sample).not_to be nil


### PR DESCRIPTION
**What does this PR do?**

Skip updating and serialization of heap samples for objects that were allocated in the current GC epoch/generation. The fact that these objects are still alive is usually just a happy accident from the fact that GC hasn't run yet and thus just add noise when you want to understand long-term heap usage and, more specifically, memory leaks.

In fact, allocation profiles alone can give you a rather accurate description of what the population of age == 0 should look like at any-one time. If no GCs ever ran, allocation profiles would be === to heap profiles as all objects would be technically alive.

**Motivation:**
* Objects with age == 0 tend to be mostly noise when investigating heap usage.
* Unless GCs occur at intervals <1 minute or you have big memory leaks, objects with age == 0 will naturally be much more common than objects with age > 0 and so end up being major contributors to sampling and serialization overhead. Skipping them can result in significant savings.

**Additional Notes:**

Some micro-benchmark results:

```
Comparison:
sample+serialize min_age_1 retain_every=10 heap_samples=true heap_size=true heap_sample_every=10 skip_end_gc=true:        5.7 i/s
sample+serialize min_age_0 retain_every=10 heap_samples=true heap_size=true heap_sample_every=10 skip_end_gc=true:        5.5 i/s - 1.02x  slower
sample+serialize min_age_1 retain_every=10 heap_samples=true heap_size=true heap_sample_every=1 skip_end_gc=true:        4.3 i/s - 1.33x  slower
sample+serialize min_age_0 retain_every=10 heap_samples=true heap_size=true heap_sample_every=1 skip_end_gc=true:        3.1 i/s - 1.85x  slower
```

**How to test the change?**
<!--
Describe here how the change can be validated.
You are strongly encouraged to provide automated tests for this PR (unit or integration).
If this change cannot be feasibly tested, please explain why,
unless the change does not modify code (e.g. only modifies docs, comments).
-->

Unsure? Have a question? Request a review!
