### PR TITLE
[NO-TICKET] Improve testing coverage for profiler sampling via signals

### DIFF
--- a/ext/datadog_profiling_native_extension/collectors_cpu_and_wall_time_worker.c
+++ b/ext/datadog_profiling_native_extension/collectors_cpu_and_wall_time_worker.c
@@ -96,6 +96,7 @@ struct cpu_and_wall_time_worker_state {
   bool no_signals_workaround_enabled;
   bool dynamic_sampling_rate_enabled;
   bool allocation_profiling_enabled;
+  bool skip_idle_samples_for_testing;
   VALUE self_instance;
   VALUE thread_context_collector_instance;
   VALUE idle_sampling_helper_instance;
@@ -132,6 +133,8 @@ struct cpu_and_wall_time_worker_state {
     unsigned int signal_handler_enqueued_sample;
     // How many times the signal handler was called from the wrong thread
     unsigned int signal_handler_wrong_thread;
+    // How many times we actually tried to interrupt a thread for sampling
+    unsigned int interrupt_thread_attempts;
 
     // # Stats for the results of calling rb_postponed_job_register_one
     // The same function was already waiting to be executed
@@ -177,7 +180,8 @@ static VALUE _native_initialize(
   VALUE no_signals_workaround_enabled,
   VALUE dynamic_sampling_rate_enabled,
   VALUE dynamic_sampling_rate_overhead_target_percentage,
-  VALUE allocation_profiling_enabled
+  VALUE allocation_profiling_enabled,
+  VALUE skip_idle_samples_for_testing
 );
 static void cpu_and_wall_time_worker_typed_data_mark(void *state_ptr);
 static VALUE _native_sampling_loop(VALUE self, VALUE instance);
@@ -272,7 +276,7 @@ void collectors_cpu_and_wall_time_worker_init(VALUE profiling_module) {
   // https://bugs.ruby-lang.org/issues/18007 for a discussion around this.
   rb_define_alloc_func(collectors_cpu_and_wall_time_worker_class, _native_new);
 
-  rb_define_singleton_method(collectors_cpu_and_wall_time_worker_class, "_native_initialize", _native_initialize, 8);
+  rb_define_singleton_method(collectors_cpu_and_wall_time_worker_class, "_native_initialize", _native_initialize, 9);
   rb_define_singleton_method(collectors_cpu_and_wall_time_worker_class, "_native_sampling_loop", _native_sampling_loop, 1);
   rb_define_singleton_method(collectors_cpu_and_wall_time_worker_class, "_native_stop", _native_stop, 2);
   rb_define_singleton_method(collectors_cpu_and_wall_time_worker_class, "_native_reset_after_fork", _native_reset_after_fork, 1);
@@ -317,6 +321,7 @@ static VALUE _native_new(VALUE klass) {
   state->no_signals_workaround_enabled = false;
   state->dynamic_sampling_rate_enabled = true;
   state->allocation_profiling_enabled = false;
+  state->skip_idle_samples_for_testing = false;
   state->thread_context_collector_instance = Qnil;
   state->idle_sampling_helper_instance = Qnil;
   state->owner_thread = Qnil;
@@ -352,13 +357,15 @@ static VALUE _native_initialize(
   VALUE no_signals_workaround_enabled,
   VALUE dynamic_sampling_rate_enabled,
   VALUE dynamic_sampling_rate_overhead_target_percentage,
-  VALUE allocation_profiling_enabled
+  VALUE allocation_profiling_enabled,
+  VALUE skip_idle_samples_for_testing
 ) {
   ENFORCE_BOOLEAN(gc_profiling_enabled);
   ENFORCE_BOOLEAN(no_signals_workaround_enabled);
   ENFORCE_BOOLEAN(dynamic_sampling_rate_enabled);
   ENFORCE_TYPE(dynamic_sampling_rate_overhead_target_percentage, T_FLOAT);
   ENFORCE_BOOLEAN(allocation_profiling_enabled);
+  ENFORCE_BOOLEAN(skip_idle_samples_for_testing)
 
   struct cpu_and_wall_time_worker_state *state;
   TypedData_Get_Struct(self_instance, struct cpu_and_wall_time_worker_state, &cpu_and_wall_time_worker_typed_data, state);
@@ -367,6 +374,7 @@ static VALUE _native_initialize(
   state->no_signals_workaround_enabled = (no_signals_workaround_enabled == Qtrue);
   state->dynamic_sampling_rate_enabled = (dynamic_sampling_rate_enabled == Qtrue);
   state->allocation_profiling_enabled = (allocation_profiling_enabled == Qtrue);
+  state->skip_idle_samples_for_testing = (skip_idle_samples_for_testing == Qtrue);
 
   double total_overhead_target_percentage = NUM2DBL(dynamic_sampling_rate_overhead_target_percentage);
   if (!state->allocation_profiling_enabled) {
@@ -618,17 +626,23 @@ static void *run_sampling_trigger_loop(void *state_ptr) {
         // Note that reading the GVL owner and sending them a signal is a race -- the Ruby VM keeps on executing while
         // we're doing this, so we may still not signal the correct thread from time to time, but our signal handler
         // includes a check to see if it got called in the right thread
+        state->stats.interrupt_thread_attempts++;
         pthread_kill(owner.owner, SIGPROF);
       } else {
-        // If no thread owns the Global VM Lock, the application is probably idle at the moment. We still want to sample
-        // so we "ask a friend" (the IdleSamplingHelper component) to grab the GVL and simulate getting a SIGPROF.
-        //
-        // In a previous version of the code, we called `grab_gvl_and_sample` directly BUT this was problematic because
-        // Ruby may concurrently get busy and so the CpuAndWallTimeWorker would be blocked in line to acquire the GVL
-        // for an uncontrolled amount of time. (This can still happen to the IdleSamplingHelper, but the
-        // CpuAndWallTimeWorker will still be free to interrupt the Ruby VM and keep sampling for the entire blocking period).
-        state->stats.trigger_simulated_signal_delivery_attempts++;
-        idle_sampling_helper_request_action(state->idle_sampling_helper_instance, grab_gvl_and_sample);
+        if (state->skip_idle_samples_for_testing) {
+          // This was added to make sure our tests don't accidentally pass due to idle samples. Specifically, if we
+          // comment out the thread interruption code inside `if (owner.valid)` above, our tests should not pass!
+        } else {
+          // If no thread owns the Global VM Lock, the application is probably idle at the moment. We still want to sample
+          // so we "ask a friend" (the IdleSamplingHelper component) to grab the GVL and simulate getting a SIGPROF.
+          //
+          // In a previous version of the code, we called `grab_gvl_and_sample` directly BUT this was problematic because
+          // Ruby may concurrently get busy and so the CpuAndWallTimeWorker would be blocked in line to acquire the GVL
+          // for an uncontrolled amount of time. (This can still happen to the IdleSamplingHelper, but the
+          // CpuAndWallTimeWorker will still be free to interrupt the Ruby VM and keep sampling for the entire blocking period).
+          state->stats.trigger_simulated_signal_delivery_attempts++;
+          idle_sampling_helper_request_action(state->idle_sampling_helper_instance, grab_gvl_and_sample);
+        }
       }
     }
 
@@ -948,6 +962,7 @@ static VALUE _native_stats(DDTRACE_UNUSED VALUE self, VALUE instance) {
     ID2SYM(rb_intern("postponed_job_success")),                      /* => */ UINT2NUM(state->stats.postponed_job_success),
     ID2SYM(rb_intern("postponed_job_full")),                         /* => */ UINT2NUM(state->stats.postponed_job_full),
     ID2SYM(rb_intern("postponed_job_unknown_result")),               /* => */ UINT2NUM(state->stats.postponed_job_unknown_result),
+    ID2SYM(rb_intern("interrupt_thread_attempts")),                  /* => */ UINT2NUM(state->stats.interrupt_thread_attempts),
 
     // CPU Stats
     ID2SYM(rb_intern("cpu_sampled")),                /* => */ UINT2NUM(state->stats.cpu_sampled),

--- a/lib/datadog/profiling/collectors/cpu_and_wall_time_worker.rb
+++ b/lib/datadog/profiling/collectors/cpu_and_wall_time_worker.rb
@@ -22,6 +22,7 @@ module Datadog
           # **NOTE**: This should only be used for testing; disabling the dynamic sampling rate will increase the
           # profiler overhead!
           dynamic_sampling_rate_enabled: true,
+          skip_idle_samples_for_testing: false,
           idle_sampling_helper: IdleSamplingHelper.new
         )
           unless dynamic_sampling_rate_enabled
@@ -39,6 +40,7 @@ module Datadog
             dynamic_sampling_rate_enabled,
             dynamic_sampling_rate_overhead_target_percentage,
             allocation_profiling_enabled,
+            skip_idle_samples_for_testing,
           )
           @worker_thread = nil
           @failure_exception = nil

--- a/sig/datadog/profiling/collectors/cpu_and_wall_time_worker.rbs
+++ b/sig/datadog/profiling/collectors/cpu_and_wall_time_worker.rbs
@@ -15,6 +15,7 @@ module Datadog
           ?idle_sampling_helper: Datadog::Profiling::Collectors::IdleSamplingHelper,
           ?dynamic_sampling_rate_enabled: bool,
           allocation_profiling_enabled: bool,
+          ?skip_idle_samples_for_testing: false,
         ) -> void
 
         def self._native_initialize: (
@@ -26,6 +27,7 @@ module Datadog
           bool dynamic_sampling_rate_enabled,
           Float dynamic_sampling_rate_overhead_target_percentage,
           bool allocation_profiling_enabled,
+          bool skip_idle_samples_for_testing,
         ) -> true
 
         def start: (?on_failure_proc: ::Proc?) -> bool?

--- a/spec/datadog/profiling/collectors/cpu_and_wall_time_worker_spec.rb
+++ b/spec/datadog/profiling/collectors/cpu_and_wall_time_worker_spec.rb
@@ -163,40 +163,48 @@ RSpec.describe 'Datadog::Profiling::Collectors::CpuAndWallTimeWorker' do
       end
     end
 
-    it 'triggers sampling and records the results' do
-      start
+    context 'sampling of active threads' do
+      # This option makes sure our samples are taken via thread interruptions (and not via idle sampling).
+      # See native bits for more details.
+      let(:options) { { **super(), skip_idle_samples_for_testing: true } }
 
-      all_samples = try_wait_until do
-        samples = samples_from_pprof_without_gc_and_overhead(recorder.serialize!)
-        samples if samples.any?
+      it 'triggers sampling and records the results' do
+        start
+
+        all_samples = loop_until do
+          samples = samples_from_pprof_without_gc_and_overhead(recorder.serialize!)
+          samples if samples.any?
+        end
+
+        expect(samples_for_thread(all_samples, Thread.current)).to_not be_empty
       end
 
-      expect(samples_for_thread(all_samples, Thread.current)).to_not be_empty
-    end
+      it(
+        'keeps statistics on how many samples were triggered by the background thread, ' \
+        'as well as how many samples were requested from the VM',
+      ) do
+        start
 
-    it(
-      'keeps statistics on how many samples were triggered by the background thread, ' \
-      'as well as how many samples were requested from the VM'
-    ) do
-      start
+        all_samples = loop_until do
+          samples = samples_from_pprof_without_gc_and_overhead(recorder.serialize!)
+          samples if samples.any?
+        end
 
-      all_samples = try_wait_until do
-        samples = samples_from_pprof_without_gc_and_overhead(recorder.serialize!)
-        samples if samples.any?
+        cpu_and_wall_time_worker.stop
+
+        sample_count =
+          samples_for_thread(all_samples, Thread.current)
+            .map { |it| it.values.fetch(:'cpu-samples') }
+            .reduce(:+)
+
+        stats = cpu_and_wall_time_worker.stats
+
+        expect(sample_count).to be > 0
+        expect(stats.fetch(:signal_handler_enqueued_sample)).to be >= sample_count
+        expect(stats.fetch(:trigger_sample_attempts)).to be >= stats.fetch(:signal_handler_enqueued_sample)
+        # Validate that we actually tried to sample via thread interruption, and not other means
+        expect(stats.fetch(:interrupt_thread_attempts)).to be > 0
       end
-
-      cpu_and_wall_time_worker.stop
-
-      sample_count =
-        samples_for_thread(all_samples, Thread.current)
-          .map { |it| it.values.fetch(:'cpu-samples') }
-          .reduce(:+)
-
-      stats = cpu_and_wall_time_worker.stats
-
-      expect(sample_count).to be > 0
-      expect(stats.fetch(:signal_handler_enqueued_sample)).to be >= sample_count
-      expect(stats.fetch(:trigger_sample_attempts)).to be >= stats.fetch(:signal_handler_enqueued_sample)
     end
 
     it 'keeps statistics on how long sampling is taking' do
@@ -912,6 +920,7 @@ RSpec.describe 'Datadog::Profiling::Collectors::CpuAndWallTimeWorker' do
           postponed_job_success: 0,
           postponed_job_full: 0,
           postponed_job_unknown_result: 0,
+          interrupt_thread_attempts: 0,
           cpu_sampled: 0,
           cpu_skipped: 0,
           cpu_effective_sample_rate: nil,
@@ -1191,5 +1200,16 @@ RSpec.describe 'Datadog::Profiling::Collectors::CpuAndWallTimeWorker' do
       endpoint_collection_enabled: endpoint_collection_enabled,
       timeline_enabled: timeline_enabled,
     )
+  end
+
+  def loop_until(timeout_seconds: 5)
+    deadline = Time.now + timeout_seconds
+
+    while Time.now < deadline
+      result = yield
+      return result if result
+    end
+
+    raise('Wait time exhausted!')
   end
 end


### PR DESCRIPTION
**What does this PR do?**

This PR improves the test coverage we have around taking samples in the profiler using signals.

While prototyping something yesterday I was surprised by the discovery that if I commented out triggering profiler samples via a signal:

```c
pthread_kill(owner.owner, SIGPROF);
```

that actually only one test of the test suite failed! (Yay, at least one!)

This is because our tests were *waiting* on a loop, and because most of the time they were waiting, sampling was happening via the idle sampling code path, not via the signal sending code path.

But this is a dangerous state to be in -- we don't want accidental changes to such core logic to not be caught clearly in tests.

Thus, this PR tightens out testing around sampling, to make sure we check for the existence of samples that were taken via the thread interruption code paths.

**Motivation:**

Improve test coverage for the profiler.

**Additional Notes:**

There's quite a few whitespace-only changes in this PR/commit, so I recommend looking at the diff while hiding whitespace.

**How to test the change?**

Comment out `pthread_kill`, and observe how tests now fail by having no samples.
