### PR TITLE
[NO-TICKET] Do not reference `rb_gc_force_recycle` on Ruby 3.1+

### DIFF
--- a/ext/datadog_profiling_native_extension/stack_recorder.c
+++ b/ext/datadog_profiling_native_extension/stack_recorder.c
@@ -918,6 +918,7 @@ static VALUE _native_debug_heap_recorder(DDTRACE_UNUSED VALUE _self, VALUE recor
 #pragma GCC diagnostic push
 // rb_gc_force_recycle was deprecated in latest versions of Ruby and is a noop.
 #pragma GCC diagnostic ignored "-Wdeprecated-declarations"
+#pragma GCC diagnostic ignored "-Wunused-parameter"
 // This method exists only to enable testing Datadog::Profiling::StackRecorder behavior using RSpec.
 // It SHOULD NOT be used for other purposes.
 static VALUE _native_gc_force_recycle(DDTRACE_UNUSED VALUE _self, VALUE obj) {

--- a/ext/datadog_profiling_native_extension/stack_recorder.c
+++ b/ext/datadog_profiling_native_extension/stack_recorder.c
@@ -921,7 +921,9 @@ static VALUE _native_debug_heap_recorder(DDTRACE_UNUSED VALUE _self, VALUE recor
 // This method exists only to enable testing Datadog::Profiling::StackRecorder behavior using RSpec.
 // It SHOULD NOT be used for other purposes.
 static VALUE _native_gc_force_recycle(DDTRACE_UNUSED VALUE _self, VALUE obj) {
-  rb_gc_force_recycle(obj);
+  #ifdef HAVE_WORKING_RB_GC_FORCE_RECYCLE
+    rb_gc_force_recycle(obj);
+  #endif
   return Qnil;
 }
 #pragma GCC diagnostic pop


### PR DESCRIPTION
**What does this PR do?**

This PR avoids referencing `rb_gc_force_recycle` on Rubies where this method is a no-op.

**Motivation:**

This method will be removed in Ruby 3.4
( https://github.com/ruby/ruby/pull/10324 ) so we should stop referencing it.

**Additional Notes:**

N/A

**How to test the change?**

Validate that CI is still green.
