### PR TITLE
[NO-TICKET] Upgrade to libdatadog 8

### DIFF
--- a/ddtrace.gemspec
+++ b/ddtrace.gemspec
@@ -66,7 +66,7 @@ Gem::Specification.new do |spec|
 
   # Used by profiling (and possibly others in the future)
   # When updating the version here, please also update the version in `native_extension_helpers.rb` (and yes we have a test for it)
-  spec.add_dependency 'libdatadog', '~> 7.0.0.1.0'
+  spec.add_dependency 'libdatadog', '~> 8.0.0.1.0'
 
   # used for CI visibility product until the next major version
   spec.add_dependency 'datadog-ci', '~> 0.8.1'

--- a/ext/datadog_profiling_native_extension/native_extension_helpers.rb
+++ b/ext/datadog_profiling_native_extension/native_extension_helpers.rb
@@ -15,7 +15,7 @@ module Datadog
       # The MJIT header was introduced on 2.6 and removed on 3.3; for other Rubies we rely on debase-ruby_core_source
       CAN_USE_MJIT_HEADER = RUBY_VERSION.start_with?('2.6', '2.7', '3.0.', '3.1.', '3.2.')
 
-      LIBDATADOG_VERSION = '~> 7.0.0.1.0'
+      LIBDATADOG_VERSION = '~> 8.0.0.1.0'
 
       def self.fail_install_if_missing_extension?
         ENV[ENV_FAIL_INSTALL_IF_MISSING_EXTENSION].to_s.strip.downcase == 'true'

--- a/gemfiles/jruby_9.2.21.0_sinatra.gemfile.lock
+++ b/gemfiles/jruby_9.2.21.0_sinatra.gemfile.lock
@@ -14,7 +14,7 @@ PATH
     ddtrace (1.21.1)
       datadog-ci (~> 0.2.0)
       debase-ruby_core_source (= 3.3.1)
-      libdatadog (~> 7.0.0.1.0)
+      libdatadog (~> 8.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
 
@@ -46,7 +46,7 @@ GEM
     hashdiff (1.0.1)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (7.0.0.1.0)
+    libdatadog (8.0.0.1.0)
     libddwaf (1.14.0.0.0-java)
       ffi (~> 1.0)
     memory_profiler (0.9.14)

--- a/gemfiles/jruby_9.2_activesupport.gemfile.lock
+++ b/gemfiles/jruby_9.2_activesupport.gemfile.lock
@@ -14,7 +14,7 @@ PATH
     ddtrace (1.21.1)
       datadog-ci (~> 0.8.1)
       debase-ruby_core_source (= 3.3.1)
-      libdatadog (~> 7.0.0.1.0)
+      libdatadog (~> 8.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
 
@@ -107,7 +107,7 @@ GEM
       addressable (>= 2.4)
     jsonapi-renderer (0.2.2)
     king_konf (1.0.1)
-    libdatadog (7.0.0.1.0)
+    libdatadog (8.0.0.1.0)
     libddwaf (1.14.0.0.0-java)
       ffi (~> 1.0)
     lograge (0.13.0)

--- a/gemfiles/jruby_9.2_aws.gemfile.lock
+++ b/gemfiles/jruby_9.2_aws.gemfile.lock
@@ -14,7 +14,7 @@ PATH
     ddtrace (1.21.1)
       datadog-ci (~> 0.8.1)
       debase-ruby_core_source (= 3.3.1)
-      libdatadog (~> 7.0.0.1.0)
+      libdatadog (~> 8.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
 
@@ -1469,7 +1469,7 @@ GEM
     jmespath (1.6.2)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (7.0.0.1.0)
+    libdatadog (8.0.0.1.0)
     libddwaf (1.14.0.0.0-java)
       ffi (~> 1.0)
     memory_profiler (0.9.14)

--- a/gemfiles/jruby_9.2_contrib.gemfile.lock
+++ b/gemfiles/jruby_9.2_contrib.gemfile.lock
@@ -14,7 +14,7 @@ PATH
     ddtrace (1.21.1)
       datadog-ci (~> 0.8.1)
       debase-ruby_core_source (= 3.3.1)
-      libdatadog (~> 7.0.0.1.0)
+      libdatadog (~> 8.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
 
@@ -56,7 +56,7 @@ GEM
       concurrent-ruby (~> 1.0)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (7.0.0.1.0)
+    libdatadog (8.0.0.1.0)
     libddwaf (1.14.0.0.0-java)
       ffi (~> 1.0)
     memory_profiler (0.9.14)

--- a/gemfiles/jruby_9.2_contrib_old.gemfile.lock
+++ b/gemfiles/jruby_9.2_contrib_old.gemfile.lock
@@ -14,7 +14,7 @@ PATH
     ddtrace (1.21.1)
       datadog-ci (~> 0.8.1)
       debase-ruby_core_source (= 3.3.1)
-      libdatadog (~> 7.0.0.1.0)
+      libdatadog (~> 8.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
 
@@ -52,7 +52,7 @@ GEM
     hashdiff (1.0.1)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (7.0.0.1.0)
+    libdatadog (8.0.0.1.0)
     libddwaf (1.14.0.0.0-java)
       ffi (~> 1.0)
     memory_profiler (0.9.14)

--- a/gemfiles/jruby_9.2_core_old.gemfile.lock
+++ b/gemfiles/jruby_9.2_core_old.gemfile.lock
@@ -14,7 +14,7 @@ PATH
     ddtrace (1.21.1)
       datadog-ci (~> 0.8.1)
       debase-ruby_core_source (= 3.3.1)
-      libdatadog (~> 7.0.0.1.0)
+      libdatadog (~> 8.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
 
@@ -47,7 +47,7 @@ GEM
     hashdiff (1.0.1)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (7.0.0.1.0)
+    libdatadog (8.0.0.1.0)
     libddwaf (1.14.0.0.0-java)
       ffi (~> 1.0)
     memory_profiler (0.9.14)

--- a/gemfiles/jruby_9.2_elasticsearch_7.gemfile.lock
+++ b/gemfiles/jruby_9.2_elasticsearch_7.gemfile.lock
@@ -14,7 +14,7 @@ PATH
     ddtrace (1.21.1)
       datadog-ci (~> 0.8.1)
       debase-ruby_core_source (= 3.3.1)
-      libdatadog (~> 7.0.0.1.0)
+      libdatadog (~> 8.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
 
@@ -79,7 +79,7 @@ GEM
     hashdiff (1.0.1)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (7.0.0.1.0)
+    libdatadog (8.0.0.1.0)
     libddwaf (1.14.0.0.0-java)
       ffi (~> 1.0)
     memory_profiler (0.9.14)

--- a/gemfiles/jruby_9.2_elasticsearch_8.gemfile.lock
+++ b/gemfiles/jruby_9.2_elasticsearch_8.gemfile.lock
@@ -14,7 +14,7 @@ PATH
     ddtrace (1.21.1)
       datadog-ci (~> 0.8.1)
       debase-ruby_core_source (= 3.3.1)
-      libdatadog (~> 7.0.0.1.0)
+      libdatadog (~> 8.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
 
@@ -79,7 +79,7 @@ GEM
     hashdiff (1.0.1)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (7.0.0.1.0)
+    libdatadog (8.0.0.1.0)
     libddwaf (1.14.0.0.0-java)
       ffi (~> 1.0)
     memory_profiler (0.9.14)

--- a/gemfiles/jruby_9.2_graphql_1.12.gemfile.lock
+++ b/gemfiles/jruby_9.2_graphql_1.12.gemfile.lock
@@ -14,7 +14,7 @@ PATH
     ddtrace (1.21.1)
       datadog-ci (~> 0.8.1)
       debase-ruby_core_source (= 3.3.1)
-      libdatadog (~> 7.0.0.1.0)
+      libdatadog (~> 8.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
 
@@ -49,7 +49,7 @@ GEM
     hashdiff (1.1.0)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (7.0.0.1.0)
+    libdatadog (8.0.0.1.0)
     libddwaf (1.14.0.0.0-java)
       ffi (~> 1.0)
     memory_profiler (0.9.14)

--- a/gemfiles/jruby_9.2_graphql_1.13.gemfile.lock
+++ b/gemfiles/jruby_9.2_graphql_1.13.gemfile.lock
@@ -14,7 +14,7 @@ PATH
     ddtrace (1.21.1)
       datadog-ci (~> 0.8.1)
       debase-ruby_core_source (= 3.3.1)
-      libdatadog (~> 7.0.0.1.0)
+      libdatadog (~> 8.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
 
@@ -49,7 +49,7 @@ GEM
     hashdiff (1.1.0)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (7.0.0.1.0)
+    libdatadog (8.0.0.1.0)
     libddwaf (1.14.0.0.0-java)
       ffi (~> 1.0)
     memory_profiler (0.9.14)

--- a/gemfiles/jruby_9.2_graphql_2.0.gemfile.lock
+++ b/gemfiles/jruby_9.2_graphql_2.0.gemfile.lock
@@ -14,7 +14,7 @@ PATH
     ddtrace (1.21.1)
       datadog-ci (~> 0.8.1)
       debase-ruby_core_source (= 3.3.1)
-      libdatadog (~> 7.0.0.1.0)
+      libdatadog (~> 8.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
 
@@ -49,7 +49,7 @@ GEM
     hashdiff (1.1.0)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (7.0.0.1.0)
+    libdatadog (8.0.0.1.0)
     libddwaf (1.14.0.0.0-java)
       ffi (~> 1.0)
     memory_profiler (0.9.14)

--- a/gemfiles/jruby_9.2_hanami_1.gemfile.lock
+++ b/gemfiles/jruby_9.2_hanami_1.gemfile.lock
@@ -14,7 +14,7 @@ PATH
     ddtrace (1.21.1)
       datadog-ci (~> 0.8.1)
       debase-ruby_core_source (= 3.3.1)
-      libdatadog (~> 7.0.0.1.0)
+      libdatadog (~> 8.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
 
@@ -123,7 +123,7 @@ GEM
     io-wait (0.3.0-java)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (7.0.0.1.0)
+    libdatadog (8.0.0.1.0)
     libddwaf (1.14.0.0.0-java)
       ffi (~> 1.0)
     mail (2.8.0.1)

--- a/gemfiles/jruby_9.2_http.gemfile.lock
+++ b/gemfiles/jruby_9.2_http.gemfile.lock
@@ -14,7 +14,7 @@ PATH
     ddtrace (1.21.1)
       datadog-ci (~> 0.8.1)
       debase-ruby_core_source (= 3.3.1)
-      libdatadog (~> 7.0.0.1.0)
+      libdatadog (~> 8.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
 
@@ -90,7 +90,7 @@ GEM
     httpclient (2.8.3)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (7.0.0.1.0)
+    libdatadog (8.0.0.1.0)
     libddwaf (1.14.0.0.0-java)
       ffi (~> 1.0)
     memory_profiler (0.9.14)

--- a/gemfiles/jruby_9.2_multi_rack_app.gemfile.lock
+++ b/gemfiles/jruby_9.2_multi_rack_app.gemfile.lock
@@ -14,7 +14,7 @@ PATH
     ddtrace (1.21.1)
       datadog-ci (~> 0.8.1)
       debase-ruby_core_source (= 3.3.1)
-      libdatadog (~> 7.0.0.1.0)
+      libdatadog (~> 8.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
 
@@ -125,7 +125,7 @@ GEM
     io-wait (0.3.1-java)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (7.0.0.1.0)
+    libdatadog (8.0.0.1.0)
     libddwaf (1.14.0.0.0-java)
       ffi (~> 1.0)
     loofah (2.22.0)

--- a/gemfiles/jruby_9.2_opensearch_2.gemfile.lock
+++ b/gemfiles/jruby_9.2_opensearch_2.gemfile.lock
@@ -14,7 +14,7 @@ PATH
     ddtrace (1.21.1)
       datadog-ci (~> 0.8.1)
       debase-ruby_core_source (= 3.3.1)
-      libdatadog (~> 7.0.0.1.0)
+      libdatadog (~> 8.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
 
@@ -71,7 +71,7 @@ GEM
     hashdiff (1.0.1)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (7.0.0.1.0)
+    libdatadog (8.0.0.1.0)
     libddwaf (1.14.0.0.0-java)
       ffi (~> 1.0)
     memory_profiler (0.9.14)

--- a/gemfiles/jruby_9.2_opensearch_3.gemfile.lock
+++ b/gemfiles/jruby_9.2_opensearch_3.gemfile.lock
@@ -14,7 +14,7 @@ PATH
     ddtrace (1.21.1)
       datadog-ci (~> 0.8.1)
       debase-ruby_core_source (= 3.3.1)
-      libdatadog (~> 7.0.0.1.0)
+      libdatadog (~> 8.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
 
@@ -71,7 +71,7 @@ GEM
     hashdiff (1.0.1)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (7.0.0.1.0)
+    libdatadog (8.0.0.1.0)
     libddwaf (1.14.0.0.0-java)
       ffi (~> 1.0)
     memory_profiler (0.9.14)

--- a/gemfiles/jruby_9.2_opentracing.gemfile.lock
+++ b/gemfiles/jruby_9.2_opentracing.gemfile.lock
@@ -14,7 +14,7 @@ PATH
     ddtrace (1.21.1)
       datadog-ci (~> 0.8.1)
       debase-ruby_core_source (= 3.3.1)
-      libdatadog (~> 7.0.0.1.0)
+      libdatadog (~> 8.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
 
@@ -48,7 +48,7 @@ GEM
     hashdiff (1.0.1)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (7.0.0.1.0)
+    libdatadog (8.0.0.1.0)
     libddwaf (1.14.0.0.0-java)
       ffi (~> 1.0)
     memory_profiler (0.9.14)

--- a/gemfiles/jruby_9.2_rack_1.gemfile.lock
+++ b/gemfiles/jruby_9.2_rack_1.gemfile.lock
@@ -14,7 +14,7 @@ PATH
     ddtrace (1.21.1)
       datadog-ci (~> 0.8.1)
       debase-ruby_core_source (= 3.3.1)
-      libdatadog (~> 7.0.0.1.0)
+      libdatadog (~> 8.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
 
@@ -47,7 +47,7 @@ GEM
     hashdiff (1.0.1)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (7.0.0.1.0)
+    libdatadog (8.0.0.1.0)
     libddwaf (1.14.0.0.0-java)
       ffi (~> 1.0)
     memory_profiler (0.9.14)

--- a/gemfiles/jruby_9.2_rack_2.gemfile.lock
+++ b/gemfiles/jruby_9.2_rack_2.gemfile.lock
@@ -14,7 +14,7 @@ PATH
     ddtrace (1.21.1)
       datadog-ci (~> 0.8.1)
       debase-ruby_core_source (= 3.3.1)
-      libdatadog (~> 7.0.0.1.0)
+      libdatadog (~> 8.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
 
@@ -47,7 +47,7 @@ GEM
     hashdiff (1.0.1)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (7.0.0.1.0)
+    libdatadog (8.0.0.1.0)
     libddwaf (1.14.0.0.0-java)
       ffi (~> 1.0)
     memory_profiler (0.9.14)

--- a/gemfiles/jruby_9.2_rack_3.gemfile.lock
+++ b/gemfiles/jruby_9.2_rack_3.gemfile.lock
@@ -14,7 +14,7 @@ PATH
     ddtrace (1.21.1)
       datadog-ci (~> 0.8.1)
       debase-ruby_core_source (= 3.3.1)
-      libdatadog (~> 7.0.0.1.0)
+      libdatadog (~> 8.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
 
@@ -47,7 +47,7 @@ GEM
     hashdiff (1.0.1)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (7.0.0.1.0)
+    libdatadog (8.0.0.1.0)
     libddwaf (1.14.0.0.0-java)
       ffi (~> 1.0)
     memory_profiler (0.9.14)

--- a/gemfiles/jruby_9.2_rails5_mysql2.gemfile.lock
+++ b/gemfiles/jruby_9.2_rails5_mysql2.gemfile.lock
@@ -14,7 +14,7 @@ PATH
     ddtrace (1.21.1)
       datadog-ci (~> 0.8.1)
       debase-ruby_core_source (= 3.3.1)
-      libdatadog (~> 7.0.0.1.0)
+      libdatadog (~> 8.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
 
@@ -101,7 +101,7 @@ GEM
     jdbc-mysql (8.0.27)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (7.0.0.1.0)
+    libdatadog (8.0.0.1.0)
     libddwaf (1.14.0.0.0-java)
       ffi (~> 1.0)
     lograge (0.12.0)

--- a/gemfiles/jruby_9.2_rails5_postgres.gemfile.lock
+++ b/gemfiles/jruby_9.2_rails5_postgres.gemfile.lock
@@ -14,7 +14,7 @@ PATH
     ddtrace (1.21.1)
       datadog-ci (~> 0.8.1)
       debase-ruby_core_source (= 3.3.1)
-      libdatadog (~> 7.0.0.1.0)
+      libdatadog (~> 8.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
 
@@ -103,7 +103,7 @@ GEM
     jdbc-postgres (42.2.25)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (7.0.0.1.0)
+    libdatadog (8.0.0.1.0)
     libddwaf (1.14.0.0.0-java)
       ffi (~> 1.0)
     lograge (0.12.0)

--- a/gemfiles/jruby_9.2_rails5_postgres_redis.gemfile.lock
+++ b/gemfiles/jruby_9.2_rails5_postgres_redis.gemfile.lock
@@ -14,7 +14,7 @@ PATH
     ddtrace (1.21.1)
       datadog-ci (~> 0.8.1)
       debase-ruby_core_source (= 3.3.1)
-      libdatadog (~> 7.0.0.1.0)
+      libdatadog (~> 8.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
 
@@ -104,7 +104,7 @@ GEM
     jdbc-postgres (42.2.25)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (7.0.0.1.0)
+    libdatadog (8.0.0.1.0)
     libddwaf (1.14.0.0.0-java)
       ffi (~> 1.0)
     lograge (0.12.0)

--- a/gemfiles/jruby_9.2_rails5_postgres_redis_activesupport.gemfile.lock
+++ b/gemfiles/jruby_9.2_rails5_postgres_redis_activesupport.gemfile.lock
@@ -14,7 +14,7 @@ PATH
     ddtrace (1.21.1)
       datadog-ci (~> 0.8.1)
       debase-ruby_core_source (= 3.3.1)
-      libdatadog (~> 7.0.0.1.0)
+      libdatadog (~> 8.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
 
@@ -103,7 +103,7 @@ GEM
     jdbc-postgres (42.2.25)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (7.0.0.1.0)
+    libdatadog (8.0.0.1.0)
     libddwaf (1.14.0.0.0-java)
       ffi (~> 1.0)
     lograge (0.12.0)

--- a/gemfiles/jruby_9.2_rails5_postgres_sidekiq.gemfile.lock
+++ b/gemfiles/jruby_9.2_rails5_postgres_sidekiq.gemfile.lock
@@ -14,7 +14,7 @@ PATH
     ddtrace (1.21.1)
       datadog-ci (~> 0.8.1)
       debase-ruby_core_source (= 3.3.1)
-      libdatadog (~> 7.0.0.1.0)
+      libdatadog (~> 8.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
 
@@ -104,7 +104,7 @@ GEM
     jdbc-postgres (42.2.25)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (7.0.0.1.0)
+    libdatadog (8.0.0.1.0)
     libddwaf (1.14.0.0.0-java)
       ffi (~> 1.0)
     lograge (0.12.0)

--- a/gemfiles/jruby_9.2_rails5_semantic_logger.gemfile.lock
+++ b/gemfiles/jruby_9.2_rails5_semantic_logger.gemfile.lock
@@ -14,7 +14,7 @@ PATH
     ddtrace (1.21.1)
       datadog-ci (~> 0.8.1)
       debase-ruby_core_source (= 3.3.1)
-      libdatadog (~> 7.0.0.1.0)
+      libdatadog (~> 8.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
 
@@ -103,7 +103,7 @@ GEM
     jdbc-postgres (42.2.25)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (7.0.0.1.0)
+    libdatadog (8.0.0.1.0)
     libddwaf (1.14.0.0.0-java)
       ffi (~> 1.0)
     loofah (2.19.1)

--- a/gemfiles/jruby_9.2_rails61_mysql2.gemfile.lock
+++ b/gemfiles/jruby_9.2_rails61_mysql2.gemfile.lock
@@ -14,7 +14,7 @@ PATH
     ddtrace (1.21.1)
       datadog-ci (~> 0.8.1)
       debase-ruby_core_source (= 3.3.1)
-      libdatadog (~> 7.0.0.1.0)
+      libdatadog (~> 8.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
 
@@ -118,7 +118,7 @@ GEM
     jdbc-mysql (8.0.27)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (7.0.0.1.0)
+    libdatadog (8.0.0.1.0)
     libddwaf (1.14.0.0.0-java)
       ffi (~> 1.0)
     lograge (0.12.0)

--- a/gemfiles/jruby_9.2_rails61_postgres.gemfile.lock
+++ b/gemfiles/jruby_9.2_rails61_postgres.gemfile.lock
@@ -14,7 +14,7 @@ PATH
     ddtrace (1.21.1)
       datadog-ci (~> 0.8.1)
       debase-ruby_core_source (= 3.3.1)
-      libdatadog (~> 7.0.0.1.0)
+      libdatadog (~> 8.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
 
@@ -120,7 +120,7 @@ GEM
     jdbc-postgres (42.2.25)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (7.0.0.1.0)
+    libdatadog (8.0.0.1.0)
     libddwaf (1.14.0.0.0-java)
       ffi (~> 1.0)
     lograge (0.12.0)

--- a/gemfiles/jruby_9.2_rails61_postgres_redis.gemfile.lock
+++ b/gemfiles/jruby_9.2_rails61_postgres_redis.gemfile.lock
@@ -14,7 +14,7 @@ PATH
     ddtrace (1.21.1)
       datadog-ci (~> 0.8.1)
       debase-ruby_core_source (= 3.3.1)
-      libdatadog (~> 7.0.0.1.0)
+      libdatadog (~> 8.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
 
@@ -121,7 +121,7 @@ GEM
     jdbc-postgres (42.2.25)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (7.0.0.1.0)
+    libdatadog (8.0.0.1.0)
     libddwaf (1.14.0.0.0-java)
       ffi (~> 1.0)
     lograge (0.12.0)

--- a/gemfiles/jruby_9.2_rails61_postgres_sidekiq.gemfile.lock
+++ b/gemfiles/jruby_9.2_rails61_postgres_sidekiq.gemfile.lock
@@ -14,7 +14,7 @@ PATH
     ddtrace (1.21.1)
       datadog-ci (~> 0.8.1)
       debase-ruby_core_source (= 3.3.1)
-      libdatadog (~> 7.0.0.1.0)
+      libdatadog (~> 8.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
 
@@ -121,7 +121,7 @@ GEM
     jdbc-postgres (42.2.25)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (7.0.0.1.0)
+    libdatadog (8.0.0.1.0)
     libddwaf (1.14.0.0.0-java)
       ffi (~> 1.0)
     lograge (0.12.0)

--- a/gemfiles/jruby_9.2_rails61_semantic_logger.gemfile.lock
+++ b/gemfiles/jruby_9.2_rails61_semantic_logger.gemfile.lock
@@ -14,7 +14,7 @@ PATH
     ddtrace (1.21.1)
       datadog-ci (~> 0.8.1)
       debase-ruby_core_source (= 3.3.1)
-      libdatadog (~> 7.0.0.1.0)
+      libdatadog (~> 8.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
 
@@ -120,7 +120,7 @@ GEM
     jdbc-postgres (42.2.25)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (7.0.0.1.0)
+    libdatadog (8.0.0.1.0)
     libddwaf (1.14.0.0.0-java)
       ffi (~> 1.0)
     loofah (2.19.1)

--- a/gemfiles/jruby_9.2_rails6_mysql2.gemfile.lock
+++ b/gemfiles/jruby_9.2_rails6_mysql2.gemfile.lock
@@ -14,7 +14,7 @@ PATH
     ddtrace (1.21.1)
       datadog-ci (~> 0.8.1)
       debase-ruby_core_source (= 3.3.1)
-      libdatadog (~> 7.0.0.1.0)
+      libdatadog (~> 8.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
 
@@ -114,7 +114,7 @@ GEM
     jdbc-mysql (8.0.27)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (7.0.0.1.0)
+    libdatadog (8.0.0.1.0)
     libddwaf (1.14.0.0.0-java)
       ffi (~> 1.0)
     lograge (0.12.0)

--- a/gemfiles/jruby_9.2_rails6_postgres.gemfile.lock
+++ b/gemfiles/jruby_9.2_rails6_postgres.gemfile.lock
@@ -14,7 +14,7 @@ PATH
     ddtrace (1.21.1)
       datadog-ci (~> 0.8.1)
       debase-ruby_core_source (= 3.3.1)
-      libdatadog (~> 7.0.0.1.0)
+      libdatadog (~> 8.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
 
@@ -116,7 +116,7 @@ GEM
     jdbc-postgres (42.2.25)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (7.0.0.1.0)
+    libdatadog (8.0.0.1.0)
     libddwaf (1.14.0.0.0-java)
       ffi (~> 1.0)
     lograge (0.12.0)

--- a/gemfiles/jruby_9.2_rails6_postgres_redis.gemfile.lock
+++ b/gemfiles/jruby_9.2_rails6_postgres_redis.gemfile.lock
@@ -14,7 +14,7 @@ PATH
     ddtrace (1.21.1)
       datadog-ci (~> 0.8.1)
       debase-ruby_core_source (= 3.3.1)
-      libdatadog (~> 7.0.0.1.0)
+      libdatadog (~> 8.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
 
@@ -117,7 +117,7 @@ GEM
     jdbc-postgres (42.2.25)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (7.0.0.1.0)
+    libdatadog (8.0.0.1.0)
     libddwaf (1.14.0.0.0-java)
       ffi (~> 1.0)
     lograge (0.12.0)

--- a/gemfiles/jruby_9.2_rails6_postgres_redis_activesupport.gemfile.lock
+++ b/gemfiles/jruby_9.2_rails6_postgres_redis_activesupport.gemfile.lock
@@ -14,7 +14,7 @@ PATH
     ddtrace (1.21.1)
       datadog-ci (~> 0.8.1)
       debase-ruby_core_source (= 3.3.1)
-      libdatadog (~> 7.0.0.1.0)
+      libdatadog (~> 8.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
 
@@ -116,7 +116,7 @@ GEM
     jdbc-postgres (42.2.25)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (7.0.0.1.0)
+    libdatadog (8.0.0.1.0)
     libddwaf (1.14.0.0.0-java)
       ffi (~> 1.0)
     lograge (0.12.0)

--- a/gemfiles/jruby_9.2_rails6_postgres_sidekiq.gemfile.lock
+++ b/gemfiles/jruby_9.2_rails6_postgres_sidekiq.gemfile.lock
@@ -14,7 +14,7 @@ PATH
     ddtrace (1.21.1)
       datadog-ci (~> 0.8.1)
       debase-ruby_core_source (= 3.3.1)
-      libdatadog (~> 7.0.0.1.0)
+      libdatadog (~> 8.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
 
@@ -117,7 +117,7 @@ GEM
     jdbc-postgres (42.2.25)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (7.0.0.1.0)
+    libdatadog (8.0.0.1.0)
     libddwaf (1.14.0.0.0-java)
       ffi (~> 1.0)
     lograge (0.12.0)

--- a/gemfiles/jruby_9.2_rails6_semantic_logger.gemfile.lock
+++ b/gemfiles/jruby_9.2_rails6_semantic_logger.gemfile.lock
@@ -14,7 +14,7 @@ PATH
     ddtrace (1.21.1)
       datadog-ci (~> 0.8.1)
       debase-ruby_core_source (= 3.3.1)
-      libdatadog (~> 7.0.0.1.0)
+      libdatadog (~> 8.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
 
@@ -116,7 +116,7 @@ GEM
     jdbc-postgres (42.2.25)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (7.0.0.1.0)
+    libdatadog (8.0.0.1.0)
     libddwaf (1.14.0.0.0-java)
       ffi (~> 1.0)
     loofah (2.19.1)

--- a/gemfiles/jruby_9.2_redis_3.gemfile.lock
+++ b/gemfiles/jruby_9.2_redis_3.gemfile.lock
@@ -14,7 +14,7 @@ PATH
     ddtrace (1.21.1)
       datadog-ci (~> 0.8.1)
       debase-ruby_core_source (= 3.3.1)
-      libdatadog (~> 7.0.0.1.0)
+      libdatadog (~> 8.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
 
@@ -47,7 +47,7 @@ GEM
     hashdiff (1.0.1)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (7.0.0.1.0)
+    libdatadog (8.0.0.1.0)
     libddwaf (1.14.0.0.0-java)
       ffi (~> 1.0)
     memory_profiler (0.9.14)

--- a/gemfiles/jruby_9.2_redis_4.gemfile.lock
+++ b/gemfiles/jruby_9.2_redis_4.gemfile.lock
@@ -14,7 +14,7 @@ PATH
     ddtrace (1.21.1)
       datadog-ci (~> 0.8.1)
       debase-ruby_core_source (= 3.3.1)
-      libdatadog (~> 7.0.0.1.0)
+      libdatadog (~> 8.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
 
@@ -47,7 +47,7 @@ GEM
     hashdiff (1.0.1)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (7.0.0.1.0)
+    libdatadog (8.0.0.1.0)
     libddwaf (1.14.0.0.0-java)
       ffi (~> 1.0)
     memory_profiler (0.9.14)

--- a/gemfiles/jruby_9.2_redis_5.gemfile.lock
+++ b/gemfiles/jruby_9.2_redis_5.gemfile.lock
@@ -14,7 +14,7 @@ PATH
     ddtrace (1.21.1)
       datadog-ci (~> 0.8.1)
       debase-ruby_core_source (= 3.3.1)
-      libdatadog (~> 7.0.0.1.0)
+      libdatadog (~> 8.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
 
@@ -48,7 +48,7 @@ GEM
     hashdiff (1.0.1)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (7.0.0.1.0)
+    libdatadog (8.0.0.1.0)
     libddwaf (1.14.0.0.0-java)
       ffi (~> 1.0)
     memory_profiler (0.9.14)

--- a/gemfiles/jruby_9.2_relational_db.gemfile.lock
+++ b/gemfiles/jruby_9.2_relational_db.gemfile.lock
@@ -14,7 +14,7 @@ PATH
     ddtrace (1.21.1)
       datadog-ci (~> 0.8.1)
       debase-ruby_core_source (= 3.3.1)
-      libdatadog (~> 7.0.0.1.0)
+      libdatadog (~> 8.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
 
@@ -80,7 +80,7 @@ GEM
     jdbc-sqlite3 (3.28.0)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (7.0.0.1.0)
+    libdatadog (8.0.0.1.0)
     libddwaf (1.14.0.0.0-java)
       ffi (~> 1.0)
     makara (0.5.1)

--- a/gemfiles/jruby_9.2_resque2_redis3.gemfile.lock
+++ b/gemfiles/jruby_9.2_resque2_redis3.gemfile.lock
@@ -14,7 +14,7 @@ PATH
     ddtrace (1.21.1)
       datadog-ci (~> 0.8.1)
       debase-ruby_core_source (= 3.3.1)
-      libdatadog (~> 7.0.0.1.0)
+      libdatadog (~> 8.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
 
@@ -47,7 +47,7 @@ GEM
     hashdiff (1.0.1)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (7.0.0.1.0)
+    libdatadog (8.0.0.1.0)
     libddwaf (1.14.0.0.0-java)
       ffi (~> 1.0)
     memory_profiler (0.9.14)

--- a/gemfiles/jruby_9.2_resque2_redis4.gemfile.lock
+++ b/gemfiles/jruby_9.2_resque2_redis4.gemfile.lock
@@ -14,7 +14,7 @@ PATH
     ddtrace (1.21.1)
       datadog-ci (~> 0.8.1)
       debase-ruby_core_source (= 3.3.1)
-      libdatadog (~> 7.0.0.1.0)
+      libdatadog (~> 8.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
 
@@ -48,7 +48,7 @@ GEM
     hashdiff (1.0.1)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (7.0.0.1.0)
+    libdatadog (8.0.0.1.0)
     libddwaf (1.14.0.0.0-java)
       ffi (~> 1.0)
     memory_profiler (0.9.14)

--- a/gemfiles/jruby_9.2_sinatra.gemfile.lock
+++ b/gemfiles/jruby_9.2_sinatra.gemfile.lock
@@ -14,7 +14,7 @@ PATH
     ddtrace (1.21.1)
       datadog-ci (~> 0.8.1)
       debase-ruby_core_source (= 3.3.1)
-      libdatadog (~> 7.0.0.1.0)
+      libdatadog (~> 8.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
 
@@ -47,7 +47,7 @@ GEM
     hashdiff (1.0.1)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (7.0.0.1.0)
+    libdatadog (8.0.0.1.0)
     libddwaf (1.14.0.0.0-java)
       ffi (~> 1.0)
     memory_profiler (0.9.14)

--- a/gemfiles/jruby_9.3_activesupport.gemfile.lock
+++ b/gemfiles/jruby_9.3_activesupport.gemfile.lock
@@ -14,7 +14,7 @@ PATH
     ddtrace (1.21.1)
       datadog-ci (~> 0.8.1)
       debase-ruby_core_source (= 3.3.1)
-      libdatadog (~> 7.0.0.1.0)
+      libdatadog (~> 8.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
 
@@ -110,7 +110,7 @@ GEM
       addressable (>= 2.4)
     jsonapi-renderer (0.2.2)
     king_konf (1.0.1)
-    libdatadog (7.0.0.1.0)
+    libdatadog (8.0.0.1.0)
     libddwaf (1.14.0.0.0-java)
       ffi (~> 1.0)
     lograge (0.13.0)

--- a/gemfiles/jruby_9.3_aws.gemfile.lock
+++ b/gemfiles/jruby_9.3_aws.gemfile.lock
@@ -14,7 +14,7 @@ PATH
     ddtrace (1.21.1)
       datadog-ci (~> 0.8.1)
       debase-ruby_core_source (= 3.3.1)
-      libdatadog (~> 7.0.0.1.0)
+      libdatadog (~> 8.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
 
@@ -1471,7 +1471,7 @@ GEM
     json (2.6.3-java)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (7.0.0.1.0)
+    libdatadog (8.0.0.1.0)
     libddwaf (1.14.0.0.0-java)
       ffi (~> 1.0)
     memory_profiler (0.9.14)

--- a/gemfiles/jruby_9.3_contrib.gemfile.lock
+++ b/gemfiles/jruby_9.3_contrib.gemfile.lock
@@ -14,7 +14,7 @@ PATH
     ddtrace (1.21.1)
       datadog-ci (~> 0.8.1)
       debase-ruby_core_source (= 3.3.1)
-      libdatadog (~> 7.0.0.1.0)
+      libdatadog (~> 8.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
 
@@ -56,7 +56,7 @@ GEM
     json (2.6.3-java)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (7.0.0.1.0)
+    libdatadog (8.0.0.1.0)
     libddwaf (1.14.0.0.0-java)
       ffi (~> 1.0)
     memory_profiler (0.9.14)

--- a/gemfiles/jruby_9.3_contrib_old.gemfile.lock
+++ b/gemfiles/jruby_9.3_contrib_old.gemfile.lock
@@ -14,7 +14,7 @@ PATH
     ddtrace (1.21.1)
       datadog-ci (~> 0.8.1)
       debase-ruby_core_source (= 3.3.1)
-      libdatadog (~> 7.0.0.1.0)
+      libdatadog (~> 8.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
 
@@ -54,7 +54,7 @@ GEM
     json (2.6.3-java)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (7.0.0.1.0)
+    libdatadog (8.0.0.1.0)
     libddwaf (1.14.0.0.0-java)
       ffi (~> 1.0)
     memory_profiler (0.9.14)

--- a/gemfiles/jruby_9.3_core_old.gemfile.lock
+++ b/gemfiles/jruby_9.3_core_old.gemfile.lock
@@ -14,7 +14,7 @@ PATH
     ddtrace (1.21.1)
       datadog-ci (~> 0.8.1)
       debase-ruby_core_source (= 3.3.1)
-      libdatadog (~> 7.0.0.1.0)
+      libdatadog (~> 8.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
 
@@ -49,7 +49,7 @@ GEM
     json (2.6.3-java)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (7.0.0.1.0)
+    libdatadog (8.0.0.1.0)
     libddwaf (1.14.0.0.0-java)
       ffi (~> 1.0)
     memory_profiler (0.9.14)

--- a/gemfiles/jruby_9.3_elasticsearch_7.gemfile.lock
+++ b/gemfiles/jruby_9.3_elasticsearch_7.gemfile.lock
@@ -14,7 +14,7 @@ PATH
     ddtrace (1.21.1)
       datadog-ci (~> 0.8.1)
       debase-ruby_core_source (= 3.3.1)
-      libdatadog (~> 7.0.0.1.0)
+      libdatadog (~> 8.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
 
@@ -81,7 +81,7 @@ GEM
     json (2.6.3-java)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (7.0.0.1.0)
+    libdatadog (8.0.0.1.0)
     libddwaf (1.14.0.0.0-java)
       ffi (~> 1.0)
     memory_profiler (0.9.14)

--- a/gemfiles/jruby_9.3_elasticsearch_8.gemfile.lock
+++ b/gemfiles/jruby_9.3_elasticsearch_8.gemfile.lock
@@ -14,7 +14,7 @@ PATH
     ddtrace (1.21.1)
       datadog-ci (~> 0.8.1)
       debase-ruby_core_source (= 3.3.1)
-      libdatadog (~> 7.0.0.1.0)
+      libdatadog (~> 8.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
 
@@ -64,7 +64,7 @@ GEM
     json (2.6.3-java)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (7.0.0.1.0)
+    libdatadog (8.0.0.1.0)
     libddwaf (1.14.0.0.0-java)
       ffi (~> 1.0)
     memory_profiler (0.9.14)

--- a/gemfiles/jruby_9.3_graphql_1.12.gemfile.lock
+++ b/gemfiles/jruby_9.3_graphql_1.12.gemfile.lock
@@ -14,7 +14,7 @@ PATH
     ddtrace (1.21.1)
       datadog-ci (~> 0.8.1)
       debase-ruby_core_source (= 3.3.1)
-      libdatadog (~> 7.0.0.1.0)
+      libdatadog (~> 8.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
 
@@ -51,7 +51,7 @@ GEM
     json (2.7.1-java)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (7.0.0.1.0)
+    libdatadog (8.0.0.1.0)
     libddwaf (1.14.0.0.0-java)
       ffi (~> 1.0)
     memory_profiler (0.9.14)

--- a/gemfiles/jruby_9.3_graphql_1.13.gemfile.lock
+++ b/gemfiles/jruby_9.3_graphql_1.13.gemfile.lock
@@ -14,7 +14,7 @@ PATH
     ddtrace (1.21.1)
       datadog-ci (~> 0.8.1)
       debase-ruby_core_source (= 3.3.1)
-      libdatadog (~> 7.0.0.1.0)
+      libdatadog (~> 8.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
 
@@ -51,7 +51,7 @@ GEM
     json (2.7.1-java)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (7.0.0.1.0)
+    libdatadog (8.0.0.1.0)
     libddwaf (1.14.0.0.0-java)
       ffi (~> 1.0)
     memory_profiler (0.9.14)

--- a/gemfiles/jruby_9.3_graphql_2.0.gemfile.lock
+++ b/gemfiles/jruby_9.3_graphql_2.0.gemfile.lock
@@ -14,7 +14,7 @@ PATH
     ddtrace (1.21.1)
       datadog-ci (~> 0.8.1)
       debase-ruby_core_source (= 3.3.1)
-      libdatadog (~> 7.0.0.1.0)
+      libdatadog (~> 8.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
 
@@ -51,7 +51,7 @@ GEM
     json (2.7.1-java)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (7.0.0.1.0)
+    libdatadog (8.0.0.1.0)
     libddwaf (1.14.0.0.0-java)
       ffi (~> 1.0)
     memory_profiler (0.9.14)

--- a/gemfiles/jruby_9.3_hanami_1.gemfile.lock
+++ b/gemfiles/jruby_9.3_hanami_1.gemfile.lock
@@ -14,7 +14,7 @@ PATH
     ddtrace (1.21.1)
       datadog-ci (~> 0.8.1)
       debase-ruby_core_source (= 3.3.1)
-      libdatadog (~> 7.0.0.1.0)
+      libdatadog (~> 8.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
 
@@ -124,7 +124,7 @@ GEM
     json (2.6.3-java)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (7.0.0.1.0)
+    libdatadog (8.0.0.1.0)
     libddwaf (1.14.0.0.0-java)
       ffi (~> 1.0)
     mail (2.8.0.1)

--- a/gemfiles/jruby_9.3_http.gemfile.lock
+++ b/gemfiles/jruby_9.3_http.gemfile.lock
@@ -14,7 +14,7 @@ PATH
     ddtrace (1.21.1)
       datadog-ci (~> 0.8.1)
       debase-ruby_core_source (= 3.3.1)
-      libdatadog (~> 7.0.0.1.0)
+      libdatadog (~> 8.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
 
@@ -73,7 +73,7 @@ GEM
     json (2.6.3-java)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (7.0.0.1.0)
+    libdatadog (8.0.0.1.0)
     libddwaf (1.14.0.0.0-java)
       ffi (~> 1.0)
     memory_profiler (0.9.14)

--- a/gemfiles/jruby_9.3_multi_rack_app.gemfile.lock
+++ b/gemfiles/jruby_9.3_multi_rack_app.gemfile.lock
@@ -14,7 +14,7 @@ PATH
     ddtrace (1.21.1)
       datadog-ci (~> 0.8.1)
       debase-ruby_core_source (= 3.3.1)
-      libdatadog (~> 7.0.0.1.0)
+      libdatadog (~> 8.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
 
@@ -127,7 +127,7 @@ GEM
     json (2.7.1-java)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (7.0.0.1.0)
+    libdatadog (8.0.0.1.0)
     libddwaf (1.14.0.0.0-java)
       ffi (~> 1.0)
     loofah (2.22.0)

--- a/gemfiles/jruby_9.3_opensearch_2.gemfile.lock
+++ b/gemfiles/jruby_9.3_opensearch_2.gemfile.lock
@@ -14,7 +14,7 @@ PATH
     ddtrace (1.21.1)
       datadog-ci (~> 0.8.1)
       debase-ruby_core_source (= 3.3.1)
-      libdatadog (~> 7.0.0.1.0)
+      libdatadog (~> 8.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
 
@@ -56,7 +56,7 @@ GEM
     json (2.6.3-java)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (7.0.0.1.0)
+    libdatadog (8.0.0.1.0)
     libddwaf (1.14.0.0.0-java)
       ffi (~> 1.0)
     memory_profiler (0.9.14)

--- a/gemfiles/jruby_9.3_opensearch_3.gemfile.lock
+++ b/gemfiles/jruby_9.3_opensearch_3.gemfile.lock
@@ -14,7 +14,7 @@ PATH
     ddtrace (1.21.1)
       datadog-ci (~> 0.8.1)
       debase-ruby_core_source (= 3.3.1)
-      libdatadog (~> 7.0.0.1.0)
+      libdatadog (~> 8.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
 
@@ -56,7 +56,7 @@ GEM
     json (2.6.3-java)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (7.0.0.1.0)
+    libdatadog (8.0.0.1.0)
     libddwaf (1.14.0.0.0-java)
       ffi (~> 1.0)
     memory_profiler (0.9.14)

--- a/gemfiles/jruby_9.3_opentracing.gemfile.lock
+++ b/gemfiles/jruby_9.3_opentracing.gemfile.lock
@@ -14,7 +14,7 @@ PATH
     ddtrace (1.21.1)
       datadog-ci (~> 0.8.1)
       debase-ruby_core_source (= 3.3.1)
-      libdatadog (~> 7.0.0.1.0)
+      libdatadog (~> 8.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
 
@@ -50,7 +50,7 @@ GEM
     json (2.6.3-java)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (7.0.0.1.0)
+    libdatadog (8.0.0.1.0)
     libddwaf (1.14.0.0.0-java)
       ffi (~> 1.0)
     memory_profiler (0.9.14)

--- a/gemfiles/jruby_9.3_rack_1.gemfile.lock
+++ b/gemfiles/jruby_9.3_rack_1.gemfile.lock
@@ -14,7 +14,7 @@ PATH
     ddtrace (1.21.1)
       datadog-ci (~> 0.8.1)
       debase-ruby_core_source (= 3.3.1)
-      libdatadog (~> 7.0.0.1.0)
+      libdatadog (~> 8.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
 
@@ -49,7 +49,7 @@ GEM
     json (2.6.3-java)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (7.0.0.1.0)
+    libdatadog (8.0.0.1.0)
     libddwaf (1.14.0.0.0-java)
       ffi (~> 1.0)
     memory_profiler (0.9.14)

--- a/gemfiles/jruby_9.3_rack_2.gemfile.lock
+++ b/gemfiles/jruby_9.3_rack_2.gemfile.lock
@@ -14,7 +14,7 @@ PATH
     ddtrace (1.21.1)
       datadog-ci (~> 0.8.1)
       debase-ruby_core_source (= 3.3.1)
-      libdatadog (~> 7.0.0.1.0)
+      libdatadog (~> 8.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
 
@@ -49,7 +49,7 @@ GEM
     json (2.6.3-java)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (7.0.0.1.0)
+    libdatadog (8.0.0.1.0)
     libddwaf (1.14.0.0.0-java)
       ffi (~> 1.0)
     memory_profiler (0.9.14)

--- a/gemfiles/jruby_9.3_rack_3.gemfile.lock
+++ b/gemfiles/jruby_9.3_rack_3.gemfile.lock
@@ -14,7 +14,7 @@ PATH
     ddtrace (1.21.1)
       datadog-ci (~> 0.8.1)
       debase-ruby_core_source (= 3.3.1)
-      libdatadog (~> 7.0.0.1.0)
+      libdatadog (~> 8.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
 
@@ -49,7 +49,7 @@ GEM
     json (2.6.3-java)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (7.0.0.1.0)
+    libdatadog (8.0.0.1.0)
     libddwaf (1.14.0.0.0-java)
       ffi (~> 1.0)
     memory_profiler (0.9.14)

--- a/gemfiles/jruby_9.3_rails5_mysql2.gemfile.lock
+++ b/gemfiles/jruby_9.3_rails5_mysql2.gemfile.lock
@@ -14,7 +14,7 @@ PATH
     ddtrace (1.21.1)
       datadog-ci (~> 0.8.1)
       debase-ruby_core_source (= 3.3.1)
-      libdatadog (~> 7.0.0.1.0)
+      libdatadog (~> 8.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
 
@@ -104,7 +104,7 @@ GEM
     json (2.6.3-java)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (7.0.0.1.0)
+    libdatadog (8.0.0.1.0)
     libddwaf (1.14.0.0.0-java)
       ffi (~> 1.0)
     lograge (0.12.0)

--- a/gemfiles/jruby_9.3_rails5_postgres.gemfile.lock
+++ b/gemfiles/jruby_9.3_rails5_postgres.gemfile.lock
@@ -14,7 +14,7 @@ PATH
     ddtrace (1.21.1)
       datadog-ci (~> 0.8.1)
       debase-ruby_core_source (= 3.3.1)
-      libdatadog (~> 7.0.0.1.0)
+      libdatadog (~> 8.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
 
@@ -104,7 +104,7 @@ GEM
     json (2.6.3-java)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (7.0.0.1.0)
+    libdatadog (8.0.0.1.0)
     libddwaf (1.14.0.0.0-java)
       ffi (~> 1.0)
     lograge (0.12.0)

--- a/gemfiles/jruby_9.3_rails5_postgres_redis.gemfile.lock
+++ b/gemfiles/jruby_9.3_rails5_postgres_redis.gemfile.lock
@@ -14,7 +14,7 @@ PATH
     ddtrace (1.21.1)
       datadog-ci (~> 0.8.1)
       debase-ruby_core_source (= 3.3.1)
-      libdatadog (~> 7.0.0.1.0)
+      libdatadog (~> 8.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
 
@@ -104,7 +104,7 @@ GEM
     json (2.6.3-java)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (7.0.0.1.0)
+    libdatadog (8.0.0.1.0)
     libddwaf (1.14.0.0.0-java)
       ffi (~> 1.0)
     lograge (0.12.0)

--- a/gemfiles/jruby_9.3_rails5_postgres_redis_activesupport.gemfile.lock
+++ b/gemfiles/jruby_9.3_rails5_postgres_redis_activesupport.gemfile.lock
@@ -14,7 +14,7 @@ PATH
     ddtrace (1.21.1)
       datadog-ci (~> 0.8.1)
       debase-ruby_core_source (= 3.3.1)
-      libdatadog (~> 7.0.0.1.0)
+      libdatadog (~> 8.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
 
@@ -104,7 +104,7 @@ GEM
     json (2.6.3-java)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (7.0.0.1.0)
+    libdatadog (8.0.0.1.0)
     libddwaf (1.14.0.0.0-java)
       ffi (~> 1.0)
     lograge (0.12.0)

--- a/gemfiles/jruby_9.3_rails5_postgres_sidekiq.gemfile.lock
+++ b/gemfiles/jruby_9.3_rails5_postgres_sidekiq.gemfile.lock
@@ -14,7 +14,7 @@ PATH
     ddtrace (1.21.1)
       datadog-ci (~> 0.8.1)
       debase-ruby_core_source (= 3.3.1)
-      libdatadog (~> 7.0.0.1.0)
+      libdatadog (~> 8.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
 
@@ -105,7 +105,7 @@ GEM
     json (2.6.3-java)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (7.0.0.1.0)
+    libdatadog (8.0.0.1.0)
     libddwaf (1.14.0.0.0-java)
       ffi (~> 1.0)
     lograge (0.12.0)

--- a/gemfiles/jruby_9.3_rails5_semantic_logger.gemfile.lock
+++ b/gemfiles/jruby_9.3_rails5_semantic_logger.gemfile.lock
@@ -14,7 +14,7 @@ PATH
     ddtrace (1.21.1)
       datadog-ci (~> 0.8.1)
       debase-ruby_core_source (= 3.3.1)
-      libdatadog (~> 7.0.0.1.0)
+      libdatadog (~> 8.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
 
@@ -104,7 +104,7 @@ GEM
     json (2.6.3-java)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (7.0.0.1.0)
+    libdatadog (8.0.0.1.0)
     libddwaf (1.14.0.0.0-java)
       ffi (~> 1.0)
     loofah (2.21.3)

--- a/gemfiles/jruby_9.3_rails61_mysql2.gemfile.lock
+++ b/gemfiles/jruby_9.3_rails61_mysql2.gemfile.lock
@@ -14,7 +14,7 @@ PATH
     ddtrace (1.21.1)
       datadog-ci (~> 0.8.1)
       debase-ruby_core_source (= 3.3.1)
-      libdatadog (~> 7.0.0.1.0)
+      libdatadog (~> 8.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
 
@@ -121,7 +121,7 @@ GEM
     json (2.6.3-java)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (7.0.0.1.0)
+    libdatadog (8.0.0.1.0)
     libddwaf (1.14.0.0.0-java)
       ffi (~> 1.0)
     lograge (0.12.0)

--- a/gemfiles/jruby_9.3_rails61_postgres.gemfile.lock
+++ b/gemfiles/jruby_9.3_rails61_postgres.gemfile.lock
@@ -14,7 +14,7 @@ PATH
     ddtrace (1.21.1)
       datadog-ci (~> 0.8.1)
       debase-ruby_core_source (= 3.3.1)
-      libdatadog (~> 7.0.0.1.0)
+      libdatadog (~> 8.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
 
@@ -121,7 +121,7 @@ GEM
     json (2.6.3-java)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (7.0.0.1.0)
+    libdatadog (8.0.0.1.0)
     libddwaf (1.14.0.0.0-java)
       ffi (~> 1.0)
     lograge (0.12.0)

--- a/gemfiles/jruby_9.3_rails61_postgres_redis.gemfile.lock
+++ b/gemfiles/jruby_9.3_rails61_postgres_redis.gemfile.lock
@@ -14,7 +14,7 @@ PATH
     ddtrace (1.21.1)
       datadog-ci (~> 0.8.1)
       debase-ruby_core_source (= 3.3.1)
-      libdatadog (~> 7.0.0.1.0)
+      libdatadog (~> 8.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
 
@@ -121,7 +121,7 @@ GEM
     json (2.6.3-java)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (7.0.0.1.0)
+    libdatadog (8.0.0.1.0)
     libddwaf (1.14.0.0.0-java)
       ffi (~> 1.0)
     lograge (0.12.0)

--- a/gemfiles/jruby_9.3_rails61_postgres_sidekiq.gemfile.lock
+++ b/gemfiles/jruby_9.3_rails61_postgres_sidekiq.gemfile.lock
@@ -14,7 +14,7 @@ PATH
     ddtrace (1.21.1)
       datadog-ci (~> 0.8.1)
       debase-ruby_core_source (= 3.3.1)
-      libdatadog (~> 7.0.0.1.0)
+      libdatadog (~> 8.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
 
@@ -122,7 +122,7 @@ GEM
     json (2.6.3-java)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (7.0.0.1.0)
+    libdatadog (8.0.0.1.0)
     libddwaf (1.14.0.0.0-java)
       ffi (~> 1.0)
     lograge (0.12.0)

--- a/gemfiles/jruby_9.3_rails61_semantic_logger.gemfile.lock
+++ b/gemfiles/jruby_9.3_rails61_semantic_logger.gemfile.lock
@@ -14,7 +14,7 @@ PATH
     ddtrace (1.21.1)
       datadog-ci (~> 0.8.1)
       debase-ruby_core_source (= 3.3.1)
-      libdatadog (~> 7.0.0.1.0)
+      libdatadog (~> 8.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
 
@@ -121,7 +121,7 @@ GEM
     json (2.6.3-java)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (7.0.0.1.0)
+    libdatadog (8.0.0.1.0)
     libddwaf (1.14.0.0.0-java)
       ffi (~> 1.0)
     loofah (2.21.3)

--- a/gemfiles/jruby_9.3_rails6_mysql2.gemfile.lock
+++ b/gemfiles/jruby_9.3_rails6_mysql2.gemfile.lock
@@ -14,7 +14,7 @@ PATH
     ddtrace (1.21.1)
       datadog-ci (~> 0.8.1)
       debase-ruby_core_source (= 3.3.1)
-      libdatadog (~> 7.0.0.1.0)
+      libdatadog (~> 8.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
 
@@ -117,7 +117,7 @@ GEM
     json (2.6.3-java)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (7.0.0.1.0)
+    libdatadog (8.0.0.1.0)
     libddwaf (1.14.0.0.0-java)
       ffi (~> 1.0)
     lograge (0.12.0)

--- a/gemfiles/jruby_9.3_rails6_postgres.gemfile.lock
+++ b/gemfiles/jruby_9.3_rails6_postgres.gemfile.lock
@@ -14,7 +14,7 @@ PATH
     ddtrace (1.21.1)
       datadog-ci (~> 0.8.1)
       debase-ruby_core_source (= 3.3.1)
-      libdatadog (~> 7.0.0.1.0)
+      libdatadog (~> 8.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
 
@@ -117,7 +117,7 @@ GEM
     json (2.6.3-java)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (7.0.0.1.0)
+    libdatadog (8.0.0.1.0)
     libddwaf (1.14.0.0.0-java)
       ffi (~> 1.0)
     lograge (0.12.0)

--- a/gemfiles/jruby_9.3_rails6_postgres_redis.gemfile.lock
+++ b/gemfiles/jruby_9.3_rails6_postgres_redis.gemfile.lock
@@ -14,7 +14,7 @@ PATH
     ddtrace (1.21.1)
       datadog-ci (~> 0.8.1)
       debase-ruby_core_source (= 3.3.1)
-      libdatadog (~> 7.0.0.1.0)
+      libdatadog (~> 8.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
 
@@ -117,7 +117,7 @@ GEM
     json (2.6.3-java)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (7.0.0.1.0)
+    libdatadog (8.0.0.1.0)
     libddwaf (1.14.0.0.0-java)
       ffi (~> 1.0)
     lograge (0.12.0)

--- a/gemfiles/jruby_9.3_rails6_postgres_redis_activesupport.gemfile.lock
+++ b/gemfiles/jruby_9.3_rails6_postgres_redis_activesupport.gemfile.lock
@@ -14,7 +14,7 @@ PATH
     ddtrace (1.21.1)
       datadog-ci (~> 0.8.1)
       debase-ruby_core_source (= 3.3.1)
-      libdatadog (~> 7.0.0.1.0)
+      libdatadog (~> 8.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
 
@@ -117,7 +117,7 @@ GEM
     json (2.6.3-java)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (7.0.0.1.0)
+    libdatadog (8.0.0.1.0)
     libddwaf (1.14.0.0.0-java)
       ffi (~> 1.0)
     lograge (0.12.0)

--- a/gemfiles/jruby_9.3_rails6_postgres_sidekiq.gemfile.lock
+++ b/gemfiles/jruby_9.3_rails6_postgres_sidekiq.gemfile.lock
@@ -14,7 +14,7 @@ PATH
     ddtrace (1.21.1)
       datadog-ci (~> 0.8.1)
       debase-ruby_core_source (= 3.3.1)
-      libdatadog (~> 7.0.0.1.0)
+      libdatadog (~> 8.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
 
@@ -118,7 +118,7 @@ GEM
     json (2.6.3-java)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (7.0.0.1.0)
+    libdatadog (8.0.0.1.0)
     libddwaf (1.14.0.0.0-java)
       ffi (~> 1.0)
     lograge (0.12.0)

--- a/gemfiles/jruby_9.3_rails6_semantic_logger.gemfile.lock
+++ b/gemfiles/jruby_9.3_rails6_semantic_logger.gemfile.lock
@@ -14,7 +14,7 @@ PATH
     ddtrace (1.21.1)
       datadog-ci (~> 0.8.1)
       debase-ruby_core_source (= 3.3.1)
-      libdatadog (~> 7.0.0.1.0)
+      libdatadog (~> 8.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
 
@@ -117,7 +117,7 @@ GEM
     json (2.6.3-java)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (7.0.0.1.0)
+    libdatadog (8.0.0.1.0)
     libddwaf (1.14.0.0.0-java)
       ffi (~> 1.0)
     loofah (2.21.3)

--- a/gemfiles/jruby_9.3_redis_3.gemfile.lock
+++ b/gemfiles/jruby_9.3_redis_3.gemfile.lock
@@ -14,7 +14,7 @@ PATH
     ddtrace (1.21.1)
       datadog-ci (~> 0.8.1)
       debase-ruby_core_source (= 3.3.1)
-      libdatadog (~> 7.0.0.1.0)
+      libdatadog (~> 8.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
 
@@ -49,7 +49,7 @@ GEM
     json (2.6.3-java)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (7.0.0.1.0)
+    libdatadog (8.0.0.1.0)
     libddwaf (1.14.0.0.0-java)
       ffi (~> 1.0)
     memory_profiler (0.9.14)

--- a/gemfiles/jruby_9.3_redis_4.gemfile.lock
+++ b/gemfiles/jruby_9.3_redis_4.gemfile.lock
@@ -14,7 +14,7 @@ PATH
     ddtrace (1.21.1)
       datadog-ci (~> 0.8.1)
       debase-ruby_core_source (= 3.3.1)
-      libdatadog (~> 7.0.0.1.0)
+      libdatadog (~> 8.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
 
@@ -49,7 +49,7 @@ GEM
     json (2.6.3-java)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (7.0.0.1.0)
+    libdatadog (8.0.0.1.0)
     libddwaf (1.14.0.0.0-java)
       ffi (~> 1.0)
     memory_profiler (0.9.14)

--- a/gemfiles/jruby_9.3_redis_5.gemfile.lock
+++ b/gemfiles/jruby_9.3_redis_5.gemfile.lock
@@ -14,7 +14,7 @@ PATH
     ddtrace (1.21.1)
       datadog-ci (~> 0.8.1)
       debase-ruby_core_source (= 3.3.1)
-      libdatadog (~> 7.0.0.1.0)
+      libdatadog (~> 8.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
 
@@ -50,7 +50,7 @@ GEM
     json (2.6.3-java)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (7.0.0.1.0)
+    libdatadog (8.0.0.1.0)
     libddwaf (1.14.0.0.0-java)
       ffi (~> 1.0)
     memory_profiler (0.9.14)

--- a/gemfiles/jruby_9.3_relational_db.gemfile.lock
+++ b/gemfiles/jruby_9.3_relational_db.gemfile.lock
@@ -14,7 +14,7 @@ PATH
     ddtrace (1.21.1)
       datadog-ci (~> 0.8.1)
       debase-ruby_core_source (= 3.3.1)
-      libdatadog (~> 7.0.0.1.0)
+      libdatadog (~> 8.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
 
@@ -78,7 +78,7 @@ GEM
     json (2.6.3-java)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (7.0.0.1.0)
+    libdatadog (8.0.0.1.0)
     libddwaf (1.14.0.0.0-java)
       ffi (~> 1.0)
     makara (0.5.1)

--- a/gemfiles/jruby_9.3_resque2_redis3.gemfile.lock
+++ b/gemfiles/jruby_9.3_resque2_redis3.gemfile.lock
@@ -14,7 +14,7 @@ PATH
     ddtrace (1.21.1)
       datadog-ci (~> 0.8.1)
       debase-ruby_core_source (= 3.3.1)
-      libdatadog (~> 7.0.0.1.0)
+      libdatadog (~> 8.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
 
@@ -49,7 +49,7 @@ GEM
     json (2.6.3-java)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (7.0.0.1.0)
+    libdatadog (8.0.0.1.0)
     libddwaf (1.14.0.0.0-java)
       ffi (~> 1.0)
     memory_profiler (0.9.14)

--- a/gemfiles/jruby_9.3_resque2_redis4.gemfile.lock
+++ b/gemfiles/jruby_9.3_resque2_redis4.gemfile.lock
@@ -14,7 +14,7 @@ PATH
     ddtrace (1.21.1)
       datadog-ci (~> 0.8.1)
       debase-ruby_core_source (= 3.3.1)
-      libdatadog (~> 7.0.0.1.0)
+      libdatadog (~> 8.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
 
@@ -49,7 +49,7 @@ GEM
     json (2.6.3-java)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (7.0.0.1.0)
+    libdatadog (8.0.0.1.0)
     libddwaf (1.14.0.0.0-java)
       ffi (~> 1.0)
     memory_profiler (0.9.14)

--- a/gemfiles/jruby_9.3_sinatra.gemfile.lock
+++ b/gemfiles/jruby_9.3_sinatra.gemfile.lock
@@ -14,7 +14,7 @@ PATH
     ddtrace (1.21.1)
       datadog-ci (~> 0.8.1)
       debase-ruby_core_source (= 3.3.1)
-      libdatadog (~> 7.0.0.1.0)
+      libdatadog (~> 8.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
 
@@ -49,7 +49,7 @@ GEM
     json (2.6.3-java)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (7.0.0.1.0)
+    libdatadog (8.0.0.1.0)
     libddwaf (1.14.0.0.0-java)
       ffi (~> 1.0)
     memory_profiler (0.9.14)

--- a/gemfiles/jruby_9.4_activesupport.gemfile.lock
+++ b/gemfiles/jruby_9.4_activesupport.gemfile.lock
@@ -14,7 +14,7 @@ PATH
     ddtrace (1.21.1)
       datadog-ci (~> 0.8.1)
       debase-ruby_core_source (= 3.3.1)
-      libdatadog (~> 7.0.0.1.0)
+      libdatadog (~> 8.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
 
@@ -105,7 +105,7 @@ GEM
       addressable (>= 2.4)
     jsonapi-renderer (0.2.2)
     king_konf (1.0.1)
-    libdatadog (7.0.0.1.0)
+    libdatadog (8.0.0.1.0)
     libddwaf (1.14.0.0.0-java)
       ffi (~> 1.0)
     lograge (0.13.0)

--- a/gemfiles/jruby_9.4_aws.gemfile.lock
+++ b/gemfiles/jruby_9.4_aws.gemfile.lock
@@ -14,7 +14,7 @@ PATH
     ddtrace (1.21.1)
       datadog-ci (~> 0.8.1)
       debase-ruby_core_source (= 3.3.1)
-      libdatadog (~> 7.0.0.1.0)
+      libdatadog (~> 8.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
 
@@ -1471,7 +1471,7 @@ GEM
     json (2.6.3-java)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (7.0.0.1.0)
+    libdatadog (8.0.0.1.0)
     libddwaf (1.14.0.0.0-java)
       ffi (~> 1.0)
     memory_profiler (0.9.14)

--- a/gemfiles/jruby_9.4_contrib.gemfile.lock
+++ b/gemfiles/jruby_9.4_contrib.gemfile.lock
@@ -14,7 +14,7 @@ PATH
     ddtrace (1.21.1)
       datadog-ci (~> 0.8.1)
       debase-ruby_core_source (= 3.3.1)
-      libdatadog (~> 7.0.0.1.0)
+      libdatadog (~> 8.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
 
@@ -56,7 +56,7 @@ GEM
     json (2.6.3-java)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (7.0.0.1.0)
+    libdatadog (8.0.0.1.0)
     libddwaf (1.14.0.0.0-java)
       ffi (~> 1.0)
     memory_profiler (0.9.14)

--- a/gemfiles/jruby_9.4_contrib_old.gemfile.lock
+++ b/gemfiles/jruby_9.4_contrib_old.gemfile.lock
@@ -14,7 +14,7 @@ PATH
     ddtrace (1.21.1)
       datadog-ci (~> 0.8.1)
       debase-ruby_core_source (= 3.3.1)
-      libdatadog (~> 7.0.0.1.0)
+      libdatadog (~> 8.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
 
@@ -54,7 +54,7 @@ GEM
     json (2.6.3-java)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (7.0.0.1.0)
+    libdatadog (8.0.0.1.0)
     libddwaf (1.14.0.0.0-java)
       ffi (~> 1.0)
     memory_profiler (0.9.14)

--- a/gemfiles/jruby_9.4_core_old.gemfile.lock
+++ b/gemfiles/jruby_9.4_core_old.gemfile.lock
@@ -14,7 +14,7 @@ PATH
     ddtrace (1.21.1)
       datadog-ci (~> 0.8.1)
       debase-ruby_core_source (= 3.3.1)
-      libdatadog (~> 7.0.0.1.0)
+      libdatadog (~> 8.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
 
@@ -49,7 +49,7 @@ GEM
     json (2.6.3-java)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (7.0.0.1.0)
+    libdatadog (8.0.0.1.0)
     libddwaf (1.14.0.0.0-java)
       ffi (~> 1.0)
     memory_profiler (0.9.14)

--- a/gemfiles/jruby_9.4_elasticsearch_7.gemfile.lock
+++ b/gemfiles/jruby_9.4_elasticsearch_7.gemfile.lock
@@ -14,7 +14,7 @@ PATH
     ddtrace (1.21.1)
       datadog-ci (~> 0.8.1)
       debase-ruby_core_source (= 3.3.1)
-      libdatadog (~> 7.0.0.1.0)
+      libdatadog (~> 8.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
 
@@ -81,7 +81,7 @@ GEM
     json (2.6.3-java)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (7.0.0.1.0)
+    libdatadog (8.0.0.1.0)
     libddwaf (1.14.0.0.0-java)
       ffi (~> 1.0)
     memory_profiler (0.9.14)

--- a/gemfiles/jruby_9.4_elasticsearch_8.gemfile.lock
+++ b/gemfiles/jruby_9.4_elasticsearch_8.gemfile.lock
@@ -14,7 +14,7 @@ PATH
     ddtrace (1.21.1)
       datadog-ci (~> 0.8.1)
       debase-ruby_core_source (= 3.3.1)
-      libdatadog (~> 7.0.0.1.0)
+      libdatadog (~> 8.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
 
@@ -64,7 +64,7 @@ GEM
     json (2.6.3-java)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (7.0.0.1.0)
+    libdatadog (8.0.0.1.0)
     libddwaf (1.14.0.0.0-java)
       ffi (~> 1.0)
     memory_profiler (0.9.14)

--- a/gemfiles/jruby_9.4_graphql_1.12.gemfile.lock
+++ b/gemfiles/jruby_9.4_graphql_1.12.gemfile.lock
@@ -14,7 +14,7 @@ PATH
     ddtrace (1.21.1)
       datadog-ci (~> 0.8.1)
       debase-ruby_core_source (= 3.3.1)
-      libdatadog (~> 7.0.0.1.0)
+      libdatadog (~> 8.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
 
@@ -51,7 +51,7 @@ GEM
     json (2.7.1-java)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (7.0.0.1.0)
+    libdatadog (8.0.0.1.0)
     libddwaf (1.14.0.0.0-java)
       ffi (~> 1.0)
     memory_profiler (0.9.14)

--- a/gemfiles/jruby_9.4_graphql_1.13.gemfile.lock
+++ b/gemfiles/jruby_9.4_graphql_1.13.gemfile.lock
@@ -14,7 +14,7 @@ PATH
     ddtrace (1.21.1)
       datadog-ci (~> 0.8.1)
       debase-ruby_core_source (= 3.3.1)
-      libdatadog (~> 7.0.0.1.0)
+      libdatadog (~> 8.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
 
@@ -51,7 +51,7 @@ GEM
     json (2.7.1-java)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (7.0.0.1.0)
+    libdatadog (8.0.0.1.0)
     libddwaf (1.14.0.0.0-java)
       ffi (~> 1.0)
     memory_profiler (0.9.14)

--- a/gemfiles/jruby_9.4_graphql_2.0.gemfile.lock
+++ b/gemfiles/jruby_9.4_graphql_2.0.gemfile.lock
@@ -14,7 +14,7 @@ PATH
     ddtrace (1.21.1)
       datadog-ci (~> 0.8.1)
       debase-ruby_core_source (= 3.3.1)
-      libdatadog (~> 7.0.0.1.0)
+      libdatadog (~> 8.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
 
@@ -51,7 +51,7 @@ GEM
     json (2.7.1-java)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (7.0.0.1.0)
+    libdatadog (8.0.0.1.0)
     libddwaf (1.14.0.0.0-java)
       ffi (~> 1.0)
     memory_profiler (0.9.14)

--- a/gemfiles/jruby_9.4_graphql_2.1.gemfile.lock
+++ b/gemfiles/jruby_9.4_graphql_2.1.gemfile.lock
@@ -14,7 +14,7 @@ PATH
     ddtrace (1.21.1)
       datadog-ci (~> 0.8.1)
       debase-ruby_core_source (= 3.3.1)
-      libdatadog (~> 7.0.0.1.0)
+      libdatadog (~> 8.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
 
@@ -52,7 +52,7 @@ GEM
     json (2.7.1-java)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (7.0.0.1.0)
+    libdatadog (8.0.0.1.0)
     libddwaf (1.14.0.0.0-java)
       ffi (~> 1.0)
     memory_profiler (0.9.14)

--- a/gemfiles/jruby_9.4_graphql_2.2.gemfile.lock
+++ b/gemfiles/jruby_9.4_graphql_2.2.gemfile.lock
@@ -14,7 +14,7 @@ PATH
     ddtrace (1.21.1)
       datadog-ci (~> 0.8.1)
       debase-ruby_core_source (= 3.3.1)
-      libdatadog (~> 7.0.0.1.0)
+      libdatadog (~> 8.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
 
@@ -52,7 +52,7 @@ GEM
     json (2.7.1-java)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (7.0.0.1.0)
+    libdatadog (8.0.0.1.0)
     libddwaf (1.14.0.0.0-java)
       ffi (~> 1.0)
     memory_profiler (0.9.14)

--- a/gemfiles/jruby_9.4_http.gemfile.lock
+++ b/gemfiles/jruby_9.4_http.gemfile.lock
@@ -14,7 +14,7 @@ PATH
     ddtrace (1.21.1)
       datadog-ci (~> 0.8.1)
       debase-ruby_core_source (= 3.3.1)
-      libdatadog (~> 7.0.0.1.0)
+      libdatadog (~> 8.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
 
@@ -73,7 +73,7 @@ GEM
     json (2.6.3-java)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (7.0.0.1.0)
+    libdatadog (8.0.0.1.0)
     libddwaf (1.14.0.0.0-java)
       ffi (~> 1.0)
     memory_profiler (0.9.14)

--- a/gemfiles/jruby_9.4_multi_rack_app.gemfile.lock
+++ b/gemfiles/jruby_9.4_multi_rack_app.gemfile.lock
@@ -14,7 +14,7 @@ PATH
     ddtrace (1.21.1)
       datadog-ci (~> 0.8.1)
       debase-ruby_core_source (= 3.3.1)
-      libdatadog (~> 7.0.0.1.0)
+      libdatadog (~> 8.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
 
@@ -141,7 +141,7 @@ GEM
     json (2.7.1-java)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (7.0.0.1.0)
+    libdatadog (8.0.0.1.0)
     libddwaf (1.14.0.0.0-java)
       ffi (~> 1.0)
     loofah (2.22.0)

--- a/gemfiles/jruby_9.4_opensearch_2.gemfile.lock
+++ b/gemfiles/jruby_9.4_opensearch_2.gemfile.lock
@@ -14,7 +14,7 @@ PATH
     ddtrace (1.21.1)
       datadog-ci (~> 0.8.1)
       debase-ruby_core_source (= 3.3.1)
-      libdatadog (~> 7.0.0.1.0)
+      libdatadog (~> 8.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
 
@@ -56,7 +56,7 @@ GEM
     json (2.6.3-java)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (7.0.0.1.0)
+    libdatadog (8.0.0.1.0)
     libddwaf (1.14.0.0.0-java)
       ffi (~> 1.0)
     memory_profiler (0.9.14)

--- a/gemfiles/jruby_9.4_opensearch_3.gemfile.lock
+++ b/gemfiles/jruby_9.4_opensearch_3.gemfile.lock
@@ -14,7 +14,7 @@ PATH
     ddtrace (1.21.1)
       datadog-ci (~> 0.8.1)
       debase-ruby_core_source (= 3.3.1)
-      libdatadog (~> 7.0.0.1.0)
+      libdatadog (~> 8.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
 
@@ -56,7 +56,7 @@ GEM
     json (2.6.3-java)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (7.0.0.1.0)
+    libdatadog (8.0.0.1.0)
     libddwaf (1.14.0.0.0-java)
       ffi (~> 1.0)
     memory_profiler (0.9.14)

--- a/gemfiles/jruby_9.4_opentracing.gemfile.lock
+++ b/gemfiles/jruby_9.4_opentracing.gemfile.lock
@@ -14,7 +14,7 @@ PATH
     ddtrace (1.21.1)
       datadog-ci (~> 0.8.1)
       debase-ruby_core_source (= 3.3.1)
-      libdatadog (~> 7.0.0.1.0)
+      libdatadog (~> 8.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
 
@@ -50,7 +50,7 @@ GEM
     json (2.6.3-java)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (7.0.0.1.0)
+    libdatadog (8.0.0.1.0)
     libddwaf (1.14.0.0.0-java)
       ffi (~> 1.0)
     memory_profiler (0.9.14)

--- a/gemfiles/jruby_9.4_rack_1.gemfile.lock
+++ b/gemfiles/jruby_9.4_rack_1.gemfile.lock
@@ -14,7 +14,7 @@ PATH
     ddtrace (1.21.1)
       datadog-ci (~> 0.8.1)
       debase-ruby_core_source (= 3.3.1)
-      libdatadog (~> 7.0.0.1.0)
+      libdatadog (~> 8.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
 
@@ -49,7 +49,7 @@ GEM
     json (2.6.3-java)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (7.0.0.1.0)
+    libdatadog (8.0.0.1.0)
     libddwaf (1.14.0.0.0-java)
       ffi (~> 1.0)
     memory_profiler (0.9.14)

--- a/gemfiles/jruby_9.4_rack_2.gemfile.lock
+++ b/gemfiles/jruby_9.4_rack_2.gemfile.lock
@@ -14,7 +14,7 @@ PATH
     ddtrace (1.21.1)
       datadog-ci (~> 0.8.1)
       debase-ruby_core_source (= 3.3.1)
-      libdatadog (~> 7.0.0.1.0)
+      libdatadog (~> 8.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
 
@@ -49,7 +49,7 @@ GEM
     json (2.6.3-java)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (7.0.0.1.0)
+    libdatadog (8.0.0.1.0)
     libddwaf (1.14.0.0.0-java)
       ffi (~> 1.0)
     memory_profiler (0.9.14)

--- a/gemfiles/jruby_9.4_rack_3.gemfile.lock
+++ b/gemfiles/jruby_9.4_rack_3.gemfile.lock
@@ -14,7 +14,7 @@ PATH
     ddtrace (1.21.1)
       datadog-ci (~> 0.8.1)
       debase-ruby_core_source (= 3.3.1)
-      libdatadog (~> 7.0.0.1.0)
+      libdatadog (~> 8.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
 
@@ -49,7 +49,7 @@ GEM
     json (2.6.3-java)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (7.0.0.1.0)
+    libdatadog (8.0.0.1.0)
     libddwaf (1.14.0.0.0-java)
       ffi (~> 1.0)
     memory_profiler (0.9.14)

--- a/gemfiles/jruby_9.4_rails61_mysql2.gemfile.lock
+++ b/gemfiles/jruby_9.4_rails61_mysql2.gemfile.lock
@@ -14,7 +14,7 @@ PATH
     ddtrace (1.21.1)
       datadog-ci (~> 0.8.1)
       debase-ruby_core_source (= 3.3.1)
-      libdatadog (~> 7.0.0.1.0)
+      libdatadog (~> 8.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
 
@@ -121,7 +121,7 @@ GEM
     json (2.6.3-java)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (7.0.0.1.0)
+    libdatadog (8.0.0.1.0)
     libddwaf (1.14.0.0.0-java)
       ffi (~> 1.0)
     lograge (0.12.0)

--- a/gemfiles/jruby_9.4_rails61_postgres.gemfile.lock
+++ b/gemfiles/jruby_9.4_rails61_postgres.gemfile.lock
@@ -14,7 +14,7 @@ PATH
     ddtrace (1.21.1)
       datadog-ci (~> 0.8.1)
       debase-ruby_core_source (= 3.3.1)
-      libdatadog (~> 7.0.0.1.0)
+      libdatadog (~> 8.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
 
@@ -121,7 +121,7 @@ GEM
     json (2.6.3-java)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (7.0.0.1.0)
+    libdatadog (8.0.0.1.0)
     libddwaf (1.14.0.0.0-java)
       ffi (~> 1.0)
     lograge (0.12.0)

--- a/gemfiles/jruby_9.4_rails61_postgres_redis.gemfile.lock
+++ b/gemfiles/jruby_9.4_rails61_postgres_redis.gemfile.lock
@@ -14,7 +14,7 @@ PATH
     ddtrace (1.21.1)
       datadog-ci (~> 0.8.1)
       debase-ruby_core_source (= 3.3.1)
-      libdatadog (~> 7.0.0.1.0)
+      libdatadog (~> 8.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
 
@@ -121,7 +121,7 @@ GEM
     json (2.6.3-java)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (7.0.0.1.0)
+    libdatadog (8.0.0.1.0)
     libddwaf (1.14.0.0.0-java)
       ffi (~> 1.0)
     lograge (0.12.0)

--- a/gemfiles/jruby_9.4_rails61_postgres_sidekiq.gemfile.lock
+++ b/gemfiles/jruby_9.4_rails61_postgres_sidekiq.gemfile.lock
@@ -14,7 +14,7 @@ PATH
     ddtrace (1.21.1)
       datadog-ci (~> 0.8.1)
       debase-ruby_core_source (= 3.3.1)
-      libdatadog (~> 7.0.0.1.0)
+      libdatadog (~> 8.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
 
@@ -122,7 +122,7 @@ GEM
     json (2.6.3-java)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (7.0.0.1.0)
+    libdatadog (8.0.0.1.0)
     libddwaf (1.14.0.0.0-java)
       ffi (~> 1.0)
     lograge (0.12.0)

--- a/gemfiles/jruby_9.4_rails61_semantic_logger.gemfile.lock
+++ b/gemfiles/jruby_9.4_rails61_semantic_logger.gemfile.lock
@@ -14,7 +14,7 @@ PATH
     ddtrace (1.21.1)
       datadog-ci (~> 0.8.1)
       debase-ruby_core_source (= 3.3.1)
-      libdatadog (~> 7.0.0.1.0)
+      libdatadog (~> 8.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
 
@@ -121,7 +121,7 @@ GEM
     json (2.6.3-java)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (7.0.0.1.0)
+    libdatadog (8.0.0.1.0)
     libddwaf (1.14.0.0.0-java)
       ffi (~> 1.0)
     loofah (2.19.1)

--- a/gemfiles/jruby_9.4_redis_3.gemfile.lock
+++ b/gemfiles/jruby_9.4_redis_3.gemfile.lock
@@ -14,7 +14,7 @@ PATH
     ddtrace (1.21.1)
       datadog-ci (~> 0.8.1)
       debase-ruby_core_source (= 3.3.1)
-      libdatadog (~> 7.0.0.1.0)
+      libdatadog (~> 8.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
 
@@ -49,7 +49,7 @@ GEM
     json (2.6.3-java)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (7.0.0.1.0)
+    libdatadog (8.0.0.1.0)
     libddwaf (1.14.0.0.0-java)
       ffi (~> 1.0)
     memory_profiler (0.9.14)

--- a/gemfiles/jruby_9.4_redis_4.gemfile.lock
+++ b/gemfiles/jruby_9.4_redis_4.gemfile.lock
@@ -14,7 +14,7 @@ PATH
     ddtrace (1.21.1)
       datadog-ci (~> 0.8.1)
       debase-ruby_core_source (= 3.3.1)
-      libdatadog (~> 7.0.0.1.0)
+      libdatadog (~> 8.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
 
@@ -49,7 +49,7 @@ GEM
     json (2.6.3-java)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (7.0.0.1.0)
+    libdatadog (8.0.0.1.0)
     libddwaf (1.14.0.0.0-java)
       ffi (~> 1.0)
     memory_profiler (0.9.14)

--- a/gemfiles/jruby_9.4_redis_5.gemfile.lock
+++ b/gemfiles/jruby_9.4_redis_5.gemfile.lock
@@ -14,7 +14,7 @@ PATH
     ddtrace (1.21.1)
       datadog-ci (~> 0.8.1)
       debase-ruby_core_source (= 3.3.1)
-      libdatadog (~> 7.0.0.1.0)
+      libdatadog (~> 8.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
 
@@ -50,7 +50,7 @@ GEM
     json (2.6.3-java)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (7.0.0.1.0)
+    libdatadog (8.0.0.1.0)
     libddwaf (1.14.0.0.0-java)
       ffi (~> 1.0)
     memory_profiler (0.9.14)

--- a/gemfiles/jruby_9.4_relational_db.gemfile.lock
+++ b/gemfiles/jruby_9.4_relational_db.gemfile.lock
@@ -14,7 +14,7 @@ PATH
     ddtrace (1.21.1)
       datadog-ci (~> 0.8.1)
       debase-ruby_core_source (= 3.3.1)
-      libdatadog (~> 7.0.0.1.0)
+      libdatadog (~> 8.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
 
@@ -77,7 +77,7 @@ GEM
     json (2.6.3-java)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (7.0.0.1.0)
+    libdatadog (8.0.0.1.0)
     libddwaf (1.14.0.0.0-java)
       ffi (~> 1.0)
     makara (0.6.0.pre)

--- a/gemfiles/jruby_9.4_resque2_redis3.gemfile.lock
+++ b/gemfiles/jruby_9.4_resque2_redis3.gemfile.lock
@@ -14,7 +14,7 @@ PATH
     ddtrace (1.21.1)
       datadog-ci (~> 0.8.1)
       debase-ruby_core_source (= 3.3.1)
-      libdatadog (~> 7.0.0.1.0)
+      libdatadog (~> 8.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
 
@@ -49,7 +49,7 @@ GEM
     json (2.6.3-java)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (7.0.0.1.0)
+    libdatadog (8.0.0.1.0)
     libddwaf (1.14.0.0.0-java)
       ffi (~> 1.0)
     memory_profiler (0.9.14)

--- a/gemfiles/jruby_9.4_resque2_redis4.gemfile.lock
+++ b/gemfiles/jruby_9.4_resque2_redis4.gemfile.lock
@@ -14,7 +14,7 @@ PATH
     ddtrace (1.21.1)
       datadog-ci (~> 0.8.1)
       debase-ruby_core_source (= 3.3.1)
-      libdatadog (~> 7.0.0.1.0)
+      libdatadog (~> 8.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
 
@@ -50,7 +50,7 @@ GEM
     json (2.6.3-java)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (7.0.0.1.0)
+    libdatadog (8.0.0.1.0)
     libddwaf (1.14.0.0.0-java)
       ffi (~> 1.0)
     memory_profiler (0.9.14)

--- a/gemfiles/jruby_9.4_sinatra.gemfile.lock
+++ b/gemfiles/jruby_9.4_sinatra.gemfile.lock
@@ -14,7 +14,7 @@ PATH
     ddtrace (1.21.1)
       datadog-ci (~> 0.8.1)
       debase-ruby_core_source (= 3.3.1)
-      libdatadog (~> 7.0.0.1.0)
+      libdatadog (~> 8.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
 
@@ -49,7 +49,7 @@ GEM
     json (2.6.3-java)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (7.0.0.1.0)
+    libdatadog (8.0.0.1.0)
     libddwaf (1.14.0.0.0-java)
       ffi (~> 1.0)
     memory_profiler (0.9.14)

--- a/gemfiles/ruby_2.1_activesupport.gemfile.lock
+++ b/gemfiles/ruby_2.1_activesupport.gemfile.lock
@@ -4,7 +4,7 @@ PATH
     ddtrace (1.21.1)
       datadog-ci (~> 0.8.1)
       debase-ruby_core_source (= 3.3.1)
-      libdatadog (~> 7.0.0.1.0)
+      libdatadog (~> 8.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
 
@@ -54,7 +54,7 @@ GEM
     json (2.5.1)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (7.0.0.1.0)
+    libdatadog (8.0.0.1.0)
     libddwaf (1.14.0.0.0)
       ffi (~> 1.0)
     memory_profiler (0.9.12)

--- a/gemfiles/ruby_2.1_aws.gemfile.lock
+++ b/gemfiles/ruby_2.1_aws.gemfile.lock
@@ -4,7 +4,7 @@ PATH
     ddtrace (1.21.1)
       datadog-ci (~> 0.8.1)
       debase-ruby_core_source (= 3.3.1)
-      libdatadog (~> 7.0.0.1.0)
+      libdatadog (~> 8.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
 
@@ -50,7 +50,7 @@ GEM
     json (2.5.1)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (7.0.0.1.0)
+    libdatadog (8.0.0.1.0)
     libddwaf (1.14.0.0.0)
       ffi (~> 1.0)
     memory_profiler (0.9.12)

--- a/gemfiles/ruby_2.1_contrib.gemfile.lock
+++ b/gemfiles/ruby_2.1_contrib.gemfile.lock
@@ -4,7 +4,7 @@ PATH
     ddtrace (1.21.1)
       datadog-ci (~> 0.8.1)
       debase-ruby_core_source (= 3.3.1)
-      libdatadog (~> 7.0.0.1.0)
+      libdatadog (~> 8.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
 
@@ -64,7 +64,7 @@ GEM
     json (1.8.6)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (7.0.0.1.0)
+    libdatadog (8.0.0.1.0)
     libddwaf (1.14.0.0.0)
       ffi (~> 1.0)
     memory_profiler (0.9.12)

--- a/gemfiles/ruby_2.1_core_old.gemfile.lock
+++ b/gemfiles/ruby_2.1_core_old.gemfile.lock
@@ -4,7 +4,7 @@ PATH
     ddtrace (1.21.1)
       datadog-ci (~> 0.8.1)
       debase-ruby_core_source (= 3.3.1)
-      libdatadog (~> 7.0.0.1.0)
+      libdatadog (~> 8.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
 
@@ -39,7 +39,7 @@ GEM
     json (2.5.1)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (7.0.0.1.0)
+    libdatadog (8.0.0.1.0)
     libddwaf (1.14.0.0.0)
       ffi (~> 1.0)
     memory_profiler (0.9.12)

--- a/gemfiles/ruby_2.1_elasticsearch_7.gemfile.lock
+++ b/gemfiles/ruby_2.1_elasticsearch_7.gemfile.lock
@@ -4,7 +4,7 @@ PATH
     ddtrace (1.21.1)
       datadog-ci (~> 0.8.1)
       debase-ruby_core_source (= 3.3.1)
-      libdatadog (~> 7.0.0.1.0)
+      libdatadog (~> 8.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
 
@@ -50,7 +50,7 @@ GEM
     json (2.5.1)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (7.0.0.1.0)
+    libdatadog (8.0.0.1.0)
     libddwaf (1.14.0.0.0)
       ffi (~> 1.0)
     memory_profiler (0.9.12)

--- a/gemfiles/ruby_2.1_http.gemfile.lock
+++ b/gemfiles/ruby_2.1_http.gemfile.lock
@@ -4,7 +4,7 @@ PATH
     ddtrace (1.21.1)
       datadog-ci (~> 0.8.1)
       debase-ruby_core_source (= 3.3.1)
-      libdatadog (~> 7.0.0.1.0)
+      libdatadog (~> 8.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
 
@@ -57,7 +57,7 @@ GEM
     json (2.5.1)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (7.0.0.1.0)
+    libdatadog (8.0.0.1.0)
     libddwaf (1.14.0.0.0)
       ffi (~> 1.0)
     memory_profiler (0.9.12)

--- a/gemfiles/ruby_2.1_opentracing.gemfile.lock
+++ b/gemfiles/ruby_2.1_opentracing.gemfile.lock
@@ -4,7 +4,7 @@ PATH
     ddtrace (1.21.1)
       datadog-ci (~> 0.8.1)
       debase-ruby_core_source (= 3.3.1)
-      libdatadog (~> 7.0.0.1.0)
+      libdatadog (~> 8.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
 
@@ -40,7 +40,7 @@ GEM
     json (2.5.1)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (7.0.0.1.0)
+    libdatadog (8.0.0.1.0)
     libddwaf (1.14.0.0.0)
       ffi (~> 1.0)
     memory_profiler (0.9.12)

--- a/gemfiles/ruby_2.1_rack_1.gemfile.lock
+++ b/gemfiles/ruby_2.1_rack_1.gemfile.lock
@@ -4,7 +4,7 @@ PATH
     ddtrace (1.21.1)
       datadog-ci (~> 0.8.1)
       debase-ruby_core_source (= 3.3.1)
-      libdatadog (~> 7.0.0.1.0)
+      libdatadog (~> 8.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
 
@@ -39,7 +39,7 @@ GEM
     json (2.5.1)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (7.0.0.1.0)
+    libdatadog (8.0.0.1.0)
     libddwaf (1.14.0.0.0)
       ffi (~> 1.0)
     memory_profiler (0.9.12)

--- a/gemfiles/ruby_2.1_rails32_mysql2.gemfile.lock
+++ b/gemfiles/ruby_2.1_rails32_mysql2.gemfile.lock
@@ -4,7 +4,7 @@ PATH
     ddtrace (1.21.1)
       datadog-ci (~> 0.8.1)
       debase-ruby_core_source (= 3.3.1)
-      libdatadog (~> 7.0.0.1.0)
+      libdatadog (~> 8.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
 
@@ -76,7 +76,7 @@ GEM
     json (2.5.1)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (7.0.0.1.0)
+    libdatadog (8.0.0.1.0)
     libddwaf (1.14.0.0.0)
       ffi (~> 1.0)
     mail (2.5.5)

--- a/gemfiles/ruby_2.1_rails32_postgres.gemfile.lock
+++ b/gemfiles/ruby_2.1_rails32_postgres.gemfile.lock
@@ -4,7 +4,7 @@ PATH
     ddtrace (1.21.1)
       datadog-ci (~> 0.8.1)
       debase-ruby_core_source (= 3.3.1)
-      libdatadog (~> 7.0.0.1.0)
+      libdatadog (~> 8.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
 
@@ -72,7 +72,7 @@ GEM
     json (2.5.1)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (7.0.0.1.0)
+    libdatadog (8.0.0.1.0)
     libddwaf (1.14.0.0.0)
       ffi (~> 1.0)
     mail (2.5.5)

--- a/gemfiles/ruby_2.1_rails32_postgres_redis.gemfile.lock
+++ b/gemfiles/ruby_2.1_rails32_postgres_redis.gemfile.lock
@@ -4,7 +4,7 @@ PATH
     ddtrace (1.21.1)
       datadog-ci (~> 0.8.1)
       debase-ruby_core_source (= 3.3.1)
-      libdatadog (~> 7.0.0.1.0)
+      libdatadog (~> 8.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
 
@@ -72,7 +72,7 @@ GEM
     json (2.5.1)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (7.0.0.1.0)
+    libdatadog (8.0.0.1.0)
     libddwaf (1.14.0.0.0)
       ffi (~> 1.0)
     mail (2.5.5)

--- a/gemfiles/ruby_2.1_rails32_postgres_sidekiq.gemfile.lock
+++ b/gemfiles/ruby_2.1_rails32_postgres_sidekiq.gemfile.lock
@@ -4,7 +4,7 @@ PATH
     ddtrace (1.21.1)
       datadog-ci (~> 0.8.1)
       debase-ruby_core_source (= 3.3.1)
-      libdatadog (~> 7.0.0.1.0)
+      libdatadog (~> 8.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
 
@@ -73,7 +73,7 @@ GEM
     json (1.8.6)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (7.0.0.1.0)
+    libdatadog (8.0.0.1.0)
     libddwaf (1.14.0.0.0)
       ffi (~> 1.0)
     mail (2.5.5)

--- a/gemfiles/ruby_2.1_rails4_mysql2.gemfile.lock
+++ b/gemfiles/ruby_2.1_rails4_mysql2.gemfile.lock
@@ -4,7 +4,7 @@ PATH
     ddtrace (1.21.1)
       datadog-ci (~> 0.8.1)
       debase-ruby_core_source (= 3.3.1)
-      libdatadog (~> 7.0.0.1.0)
+      libdatadog (~> 8.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
 
@@ -80,7 +80,7 @@ GEM
     json (2.5.1)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (7.0.0.1.0)
+    libdatadog (8.0.0.1.0)
     libddwaf (1.14.0.0.0)
       ffi (~> 1.0)
     lograge (0.11.2)

--- a/gemfiles/ruby_2.1_rails4_postgres.gemfile.lock
+++ b/gemfiles/ruby_2.1_rails4_postgres.gemfile.lock
@@ -4,7 +4,7 @@ PATH
     ddtrace (1.21.1)
       datadog-ci (~> 0.8.1)
       debase-ruby_core_source (= 3.3.1)
-      libdatadog (~> 7.0.0.1.0)
+      libdatadog (~> 8.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
 
@@ -80,7 +80,7 @@ GEM
     json (2.5.1)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (7.0.0.1.0)
+    libdatadog (8.0.0.1.0)
     libddwaf (1.14.0.0.0)
       ffi (~> 1.0)
     lograge (0.11.2)

--- a/gemfiles/ruby_2.1_rails4_postgres_redis.gemfile.lock
+++ b/gemfiles/ruby_2.1_rails4_postgres_redis.gemfile.lock
@@ -4,7 +4,7 @@ PATH
     ddtrace (1.21.1)
       datadog-ci (~> 0.8.1)
       debase-ruby_core_source (= 3.3.1)
-      libdatadog (~> 7.0.0.1.0)
+      libdatadog (~> 8.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
 
@@ -80,7 +80,7 @@ GEM
     json (2.5.1)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (7.0.0.1.0)
+    libdatadog (8.0.0.1.0)
     libddwaf (1.14.0.0.0)
       ffi (~> 1.0)
     lograge (0.11.2)

--- a/gemfiles/ruby_2.1_rails4_semantic_logger.gemfile.lock
+++ b/gemfiles/ruby_2.1_rails4_semantic_logger.gemfile.lock
@@ -4,7 +4,7 @@ PATH
     ddtrace (1.21.1)
       datadog-ci (~> 0.8.1)
       debase-ruby_core_source (= 3.3.1)
-      libdatadog (~> 7.0.0.1.0)
+      libdatadog (~> 8.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
 
@@ -80,7 +80,7 @@ GEM
     json (2.5.1)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (7.0.0.1.0)
+    libdatadog (8.0.0.1.0)
     libddwaf (1.14.0.0.0)
       ffi (~> 1.0)
     loofah (2.19.1)

--- a/gemfiles/ruby_2.1_redis_3.gemfile.lock
+++ b/gemfiles/ruby_2.1_redis_3.gemfile.lock
@@ -4,7 +4,7 @@ PATH
     ddtrace (1.21.1)
       datadog-ci (~> 0.8.1)
       debase-ruby_core_source (= 3.3.1)
-      libdatadog (~> 7.0.0.1.0)
+      libdatadog (~> 8.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
 
@@ -39,7 +39,7 @@ GEM
     json (2.5.1)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (7.0.0.1.0)
+    libdatadog (8.0.0.1.0)
     libddwaf (1.14.0.0.0)
       ffi (~> 1.0)
     memory_profiler (0.9.12)

--- a/gemfiles/ruby_2.1_relational_db.gemfile.lock
+++ b/gemfiles/ruby_2.1_relational_db.gemfile.lock
@@ -4,7 +4,7 @@ PATH
     ddtrace (1.21.1)
       datadog-ci (~> 0.8.1)
       debase-ruby_core_source (= 3.3.1)
-      libdatadog (~> 7.0.0.1.0)
+      libdatadog (~> 8.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
 
@@ -62,7 +62,7 @@ GEM
     json (2.5.1)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (7.0.0.1.0)
+    libdatadog (8.0.0.1.0)
     libddwaf (1.14.0.0.0)
       ffi (~> 1.0)
     makara (0.4.1)

--- a/gemfiles/ruby_2.1_sinatra.gemfile.lock
+++ b/gemfiles/ruby_2.1_sinatra.gemfile.lock
@@ -4,7 +4,7 @@ PATH
     ddtrace (1.21.1)
       datadog-ci (~> 0.8.1)
       debase-ruby_core_source (= 3.3.1)
-      libdatadog (~> 7.0.0.1.0)
+      libdatadog (~> 8.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
 
@@ -39,7 +39,7 @@ GEM
     json (2.5.1)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (7.0.0.1.0)
+    libdatadog (8.0.0.1.0)
     libddwaf (1.14.0.0.0)
       ffi (~> 1.0)
     memory_profiler (0.9.12)

--- a/gemfiles/ruby_2.2_activesupport.gemfile.lock
+++ b/gemfiles/ruby_2.2_activesupport.gemfile.lock
@@ -4,7 +4,7 @@ PATH
     ddtrace (1.21.1)
       datadog-ci (~> 0.8.1)
       debase-ruby_core_source (= 3.3.1)
-      libdatadog (~> 7.0.0.1.0)
+      libdatadog (~> 8.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
 
@@ -91,7 +91,7 @@ GEM
       addressable (>= 2.4)
     jsonapi-renderer (0.2.2)
     king_konf (1.0.1)
-    libdatadog (7.0.0.1.0)
+    libdatadog (8.0.0.1.0)
     libddwaf (1.14.0.0.0)
       ffi (~> 1.0)
     lograge (0.11.2)

--- a/gemfiles/ruby_2.2_aws.gemfile.lock
+++ b/gemfiles/ruby_2.2_aws.gemfile.lock
@@ -4,7 +4,7 @@ PATH
     ddtrace (1.21.1)
       datadog-ci (~> 0.8.1)
       debase-ruby_core_source (= 3.3.1)
-      libdatadog (~> 7.0.0.1.0)
+      libdatadog (~> 8.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
 
@@ -1162,7 +1162,7 @@ GEM
     json (2.5.1)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (7.0.0.1.0)
+    libdatadog (8.0.0.1.0)
     libddwaf (1.14.0.0.0)
       ffi (~> 1.0)
     memory_profiler (0.9.12)

--- a/gemfiles/ruby_2.2_contrib.gemfile.lock
+++ b/gemfiles/ruby_2.2_contrib.gemfile.lock
@@ -4,7 +4,7 @@ PATH
     ddtrace (1.21.1)
       datadog-ci (~> 0.8.1)
       debase-ruby_core_source (= 3.3.1)
-      libdatadog (~> 7.0.0.1.0)
+      libdatadog (~> 8.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
 
@@ -57,7 +57,7 @@ GEM
     json (2.5.1)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (7.0.0.1.0)
+    libdatadog (8.0.0.1.0)
     libddwaf (1.14.0.0.0)
       ffi (~> 1.0)
     memory_profiler (0.9.12)

--- a/gemfiles/ruby_2.2_core_old.gemfile.lock
+++ b/gemfiles/ruby_2.2_core_old.gemfile.lock
@@ -4,7 +4,7 @@ PATH
     ddtrace (1.21.1)
       datadog-ci (~> 0.8.1)
       debase-ruby_core_source (= 3.3.1)
-      libdatadog (~> 7.0.0.1.0)
+      libdatadog (~> 8.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
 
@@ -39,7 +39,7 @@ GEM
     json (2.5.1)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (7.0.0.1.0)
+    libdatadog (8.0.0.1.0)
     libddwaf (1.14.0.0.0)
       ffi (~> 1.0)
     memory_profiler (0.9.12)

--- a/gemfiles/ruby_2.2_elasticsearch_7.gemfile.lock
+++ b/gemfiles/ruby_2.2_elasticsearch_7.gemfile.lock
@@ -4,7 +4,7 @@ PATH
     ddtrace (1.21.1)
       datadog-ci (~> 0.8.1)
       debase-ruby_core_source (= 3.3.1)
-      libdatadog (~> 7.0.0.1.0)
+      libdatadog (~> 8.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
 
@@ -50,7 +50,7 @@ GEM
     json (2.5.1)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (7.0.0.1.0)
+    libdatadog (8.0.0.1.0)
     libddwaf (1.14.0.0.0)
       ffi (~> 1.0)
     memory_profiler (0.9.12)

--- a/gemfiles/ruby_2.2_graphql_1.12.gemfile.lock
+++ b/gemfiles/ruby_2.2_graphql_1.12.gemfile.lock
@@ -4,7 +4,7 @@ PATH
     ddtrace (1.21.1)
       datadog-ci (~> 0.8.1)
       debase-ruby_core_source (= 3.3.1)
-      libdatadog (~> 7.0.0.1.0)
+      libdatadog (~> 8.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
 
@@ -41,7 +41,7 @@ GEM
     json (2.5.1)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (7.0.0.1.0)
+    libdatadog (8.0.0.1.0)
     libddwaf (1.14.0.0.0)
       ffi (~> 1.0)
     memory_profiler (0.9.12)

--- a/gemfiles/ruby_2.2_http.gemfile.lock
+++ b/gemfiles/ruby_2.2_http.gemfile.lock
@@ -4,7 +4,7 @@ PATH
     ddtrace (1.21.1)
       datadog-ci (~> 0.8.1)
       debase-ruby_core_source (= 3.3.1)
-      libdatadog (~> 7.0.0.1.0)
+      libdatadog (~> 8.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
 
@@ -57,7 +57,7 @@ GEM
     json (2.5.1)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (7.0.0.1.0)
+    libdatadog (8.0.0.1.0)
     libddwaf (1.14.0.0.0)
       ffi (~> 1.0)
     memory_profiler (0.9.12)

--- a/gemfiles/ruby_2.2_opentracing.gemfile.lock
+++ b/gemfiles/ruby_2.2_opentracing.gemfile.lock
@@ -4,7 +4,7 @@ PATH
     ddtrace (1.21.1)
       datadog-ci (~> 0.8.1)
       debase-ruby_core_source (= 3.3.1)
-      libdatadog (~> 7.0.0.1.0)
+      libdatadog (~> 8.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
 
@@ -40,7 +40,7 @@ GEM
     json (2.5.1)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (7.0.0.1.0)
+    libdatadog (8.0.0.1.0)
     libddwaf (1.14.0.0.0)
       ffi (~> 1.0)
     memory_profiler (0.9.12)

--- a/gemfiles/ruby_2.2_rack_1.gemfile.lock
+++ b/gemfiles/ruby_2.2_rack_1.gemfile.lock
@@ -4,7 +4,7 @@ PATH
     ddtrace (1.21.1)
       datadog-ci (~> 0.8.1)
       debase-ruby_core_source (= 3.3.1)
-      libdatadog (~> 7.0.0.1.0)
+      libdatadog (~> 8.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
 
@@ -39,7 +39,7 @@ GEM
     json (2.5.1)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (7.0.0.1.0)
+    libdatadog (8.0.0.1.0)
     libddwaf (1.14.0.0.0)
       ffi (~> 1.0)
     memory_profiler (0.9.12)

--- a/gemfiles/ruby_2.2_rails32_mysql2.gemfile.lock
+++ b/gemfiles/ruby_2.2_rails32_mysql2.gemfile.lock
@@ -4,7 +4,7 @@ PATH
     ddtrace (1.21.1)
       datadog-ci (~> 0.8.1)
       debase-ruby_core_source (= 3.3.1)
-      libdatadog (~> 7.0.0.1.0)
+      libdatadog (~> 8.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
 
@@ -76,7 +76,7 @@ GEM
     json (2.5.1)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (7.0.0.1.0)
+    libdatadog (8.0.0.1.0)
     libddwaf (1.14.0.0.0)
       ffi (~> 1.0)
     mail (2.5.5)

--- a/gemfiles/ruby_2.2_rails32_postgres.gemfile.lock
+++ b/gemfiles/ruby_2.2_rails32_postgres.gemfile.lock
@@ -4,7 +4,7 @@ PATH
     ddtrace (1.21.1)
       datadog-ci (~> 0.8.1)
       debase-ruby_core_source (= 3.3.1)
-      libdatadog (~> 7.0.0.1.0)
+      libdatadog (~> 8.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
 
@@ -72,7 +72,7 @@ GEM
     json (2.5.1)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (7.0.0.1.0)
+    libdatadog (8.0.0.1.0)
     libddwaf (1.14.0.0.0)
       ffi (~> 1.0)
     mail (2.5.5)

--- a/gemfiles/ruby_2.2_rails32_postgres_redis.gemfile.lock
+++ b/gemfiles/ruby_2.2_rails32_postgres_redis.gemfile.lock
@@ -4,7 +4,7 @@ PATH
     ddtrace (1.21.1)
       datadog-ci (~> 0.8.1)
       debase-ruby_core_source (= 3.3.1)
-      libdatadog (~> 7.0.0.1.0)
+      libdatadog (~> 8.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
 
@@ -72,7 +72,7 @@ GEM
     json (2.5.1)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (7.0.0.1.0)
+    libdatadog (8.0.0.1.0)
     libddwaf (1.14.0.0.0)
       ffi (~> 1.0)
     mail (2.5.5)

--- a/gemfiles/ruby_2.2_rails32_postgres_sidekiq.gemfile.lock
+++ b/gemfiles/ruby_2.2_rails32_postgres_sidekiq.gemfile.lock
@@ -4,7 +4,7 @@ PATH
     ddtrace (1.21.1)
       datadog-ci (~> 0.8.1)
       debase-ruby_core_source (= 3.3.1)
-      libdatadog (~> 7.0.0.1.0)
+      libdatadog (~> 8.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
 
@@ -73,7 +73,7 @@ GEM
     json (1.8.6)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (7.0.0.1.0)
+    libdatadog (8.0.0.1.0)
     libddwaf (1.14.0.0.0)
       ffi (~> 1.0)
     mail (2.5.5)

--- a/gemfiles/ruby_2.2_rails4_mysql2.gemfile.lock
+++ b/gemfiles/ruby_2.2_rails4_mysql2.gemfile.lock
@@ -4,7 +4,7 @@ PATH
     ddtrace (1.21.1)
       datadog-ci (~> 0.8.1)
       debase-ruby_core_source (= 3.3.1)
-      libdatadog (~> 7.0.0.1.0)
+      libdatadog (~> 8.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
 
@@ -80,7 +80,7 @@ GEM
     json (2.5.1)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (7.0.0.1.0)
+    libdatadog (8.0.0.1.0)
     libddwaf (1.14.0.0.0)
       ffi (~> 1.0)
     lograge (0.11.2)

--- a/gemfiles/ruby_2.2_rails4_postgres.gemfile.lock
+++ b/gemfiles/ruby_2.2_rails4_postgres.gemfile.lock
@@ -4,7 +4,7 @@ PATH
     ddtrace (1.21.1)
       datadog-ci (~> 0.8.1)
       debase-ruby_core_source (= 3.3.1)
-      libdatadog (~> 7.0.0.1.0)
+      libdatadog (~> 8.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
 
@@ -80,7 +80,7 @@ GEM
     json (2.5.1)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (7.0.0.1.0)
+    libdatadog (8.0.0.1.0)
     libddwaf (1.14.0.0.0)
       ffi (~> 1.0)
     lograge (0.11.2)

--- a/gemfiles/ruby_2.2_rails4_postgres_redis.gemfile.lock
+++ b/gemfiles/ruby_2.2_rails4_postgres_redis.gemfile.lock
@@ -4,7 +4,7 @@ PATH
     ddtrace (1.21.1)
       datadog-ci (~> 0.8.1)
       debase-ruby_core_source (= 3.3.1)
-      libdatadog (~> 7.0.0.1.0)
+      libdatadog (~> 8.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
 
@@ -80,7 +80,7 @@ GEM
     json (2.5.1)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (7.0.0.1.0)
+    libdatadog (8.0.0.1.0)
     libddwaf (1.14.0.0.0)
       ffi (~> 1.0)
     lograge (0.11.2)

--- a/gemfiles/ruby_2.2_rails4_postgres_sidekiq.gemfile.lock
+++ b/gemfiles/ruby_2.2_rails4_postgres_sidekiq.gemfile.lock
@@ -4,7 +4,7 @@ PATH
     ddtrace (1.21.1)
       datadog-ci (~> 0.8.1)
       debase-ruby_core_source (= 3.3.1)
-      libdatadog (~> 7.0.0.1.0)
+      libdatadog (~> 8.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
 
@@ -81,7 +81,7 @@ GEM
     json (2.5.1)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (7.0.0.1.0)
+    libdatadog (8.0.0.1.0)
     libddwaf (1.14.0.0.0)
       ffi (~> 1.0)
     lograge (0.11.2)

--- a/gemfiles/ruby_2.2_rails4_semantic_logger.gemfile.lock
+++ b/gemfiles/ruby_2.2_rails4_semantic_logger.gemfile.lock
@@ -4,7 +4,7 @@ PATH
     ddtrace (1.21.1)
       datadog-ci (~> 0.8.1)
       debase-ruby_core_source (= 3.3.1)
-      libdatadog (~> 7.0.0.1.0)
+      libdatadog (~> 8.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
 
@@ -80,7 +80,7 @@ GEM
     json (2.5.1)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (7.0.0.1.0)
+    libdatadog (8.0.0.1.0)
     libddwaf (1.14.0.0.0)
       ffi (~> 1.0)
     loofah (2.19.1)

--- a/gemfiles/ruby_2.2_rails5_mysql2.gemfile.lock
+++ b/gemfiles/ruby_2.2_rails5_mysql2.gemfile.lock
@@ -4,7 +4,7 @@ PATH
     ddtrace (1.21.1)
       datadog-ci (~> 0.8.1)
       debase-ruby_core_source (= 3.3.1)
-      libdatadog (~> 7.0.0.1.0)
+      libdatadog (~> 8.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
 
@@ -87,7 +87,7 @@ GEM
     json (2.5.1)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (7.0.0.1.0)
+    libdatadog (8.0.0.1.0)
     libddwaf (1.14.0.0.0)
       ffi (~> 1.0)
     lograge (0.11.2)

--- a/gemfiles/ruby_2.2_rails5_postgres.gemfile.lock
+++ b/gemfiles/ruby_2.2_rails5_postgres.gemfile.lock
@@ -4,7 +4,7 @@ PATH
     ddtrace (1.21.1)
       datadog-ci (~> 0.8.1)
       debase-ruby_core_source (= 3.3.1)
-      libdatadog (~> 7.0.0.1.0)
+      libdatadog (~> 8.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
 
@@ -87,7 +87,7 @@ GEM
     json (2.5.1)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (7.0.0.1.0)
+    libdatadog (8.0.0.1.0)
     libddwaf (1.14.0.0.0)
       ffi (~> 1.0)
     lograge (0.11.2)

--- a/gemfiles/ruby_2.2_rails5_postgres_redis.gemfile.lock
+++ b/gemfiles/ruby_2.2_rails5_postgres_redis.gemfile.lock
@@ -4,7 +4,7 @@ PATH
     ddtrace (1.21.1)
       datadog-ci (~> 0.8.1)
       debase-ruby_core_source (= 3.3.1)
-      libdatadog (~> 7.0.0.1.0)
+      libdatadog (~> 8.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
 
@@ -87,7 +87,7 @@ GEM
     json (2.5.1)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (7.0.0.1.0)
+    libdatadog (8.0.0.1.0)
     libddwaf (1.14.0.0.0)
       ffi (~> 1.0)
     lograge (0.11.2)

--- a/gemfiles/ruby_2.2_rails5_postgres_redis_activesupport.gemfile.lock
+++ b/gemfiles/ruby_2.2_rails5_postgres_redis_activesupport.gemfile.lock
@@ -4,7 +4,7 @@ PATH
     ddtrace (1.21.1)
       datadog-ci (~> 0.8.1)
       debase-ruby_core_source (= 3.3.1)
-      libdatadog (~> 7.0.0.1.0)
+      libdatadog (~> 8.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
 
@@ -87,7 +87,7 @@ GEM
     json (2.5.1)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (7.0.0.1.0)
+    libdatadog (8.0.0.1.0)
     libddwaf (1.14.0.0.0)
       ffi (~> 1.0)
     lograge (0.11.2)

--- a/gemfiles/ruby_2.2_rails5_postgres_sidekiq.gemfile.lock
+++ b/gemfiles/ruby_2.2_rails5_postgres_sidekiq.gemfile.lock
@@ -4,7 +4,7 @@ PATH
     ddtrace (1.21.1)
       datadog-ci (~> 0.8.1)
       debase-ruby_core_source (= 3.3.1)
-      libdatadog (~> 7.0.0.1.0)
+      libdatadog (~> 8.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
 
@@ -88,7 +88,7 @@ GEM
     json (2.5.1)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (7.0.0.1.0)
+    libdatadog (8.0.0.1.0)
     libddwaf (1.14.0.0.0)
       ffi (~> 1.0)
     lograge (0.11.2)

--- a/gemfiles/ruby_2.2_rails5_semantic_logger.gemfile.lock
+++ b/gemfiles/ruby_2.2_rails5_semantic_logger.gemfile.lock
@@ -4,7 +4,7 @@ PATH
     ddtrace (1.21.1)
       datadog-ci (~> 0.8.1)
       debase-ruby_core_source (= 3.3.1)
-      libdatadog (~> 7.0.0.1.0)
+      libdatadog (~> 8.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
 
@@ -87,7 +87,7 @@ GEM
     json (2.5.1)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (7.0.0.1.0)
+    libdatadog (8.0.0.1.0)
     libddwaf (1.14.0.0.0)
       ffi (~> 1.0)
     loofah (2.19.1)

--- a/gemfiles/ruby_2.2_redis_3.gemfile.lock
+++ b/gemfiles/ruby_2.2_redis_3.gemfile.lock
@@ -4,7 +4,7 @@ PATH
     ddtrace (1.21.1)
       datadog-ci (~> 0.8.1)
       debase-ruby_core_source (= 3.3.1)
-      libdatadog (~> 7.0.0.1.0)
+      libdatadog (~> 8.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
 
@@ -39,7 +39,7 @@ GEM
     json (2.5.1)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (7.0.0.1.0)
+    libdatadog (8.0.0.1.0)
     libddwaf (1.14.0.0.0)
       ffi (~> 1.0)
     memory_profiler (0.9.12)

--- a/gemfiles/ruby_2.2_relational_db.gemfile.lock
+++ b/gemfiles/ruby_2.2_relational_db.gemfile.lock
@@ -4,7 +4,7 @@ PATH
     ddtrace (1.21.1)
       datadog-ci (~> 0.8.1)
       debase-ruby_core_source (= 3.3.1)
-      libdatadog (~> 7.0.0.1.0)
+      libdatadog (~> 8.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
 
@@ -58,7 +58,7 @@ GEM
     json (2.5.1)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (7.0.0.1.0)
+    libdatadog (8.0.0.1.0)
     libddwaf (1.14.0.0.0)
       ffi (~> 1.0)
     makara (0.4.1)

--- a/gemfiles/ruby_2.2_sinatra.gemfile.lock
+++ b/gemfiles/ruby_2.2_sinatra.gemfile.lock
@@ -4,7 +4,7 @@ PATH
     ddtrace (1.21.1)
       datadog-ci (~> 0.8.1)
       debase-ruby_core_source (= 3.3.1)
-      libdatadog (~> 7.0.0.1.0)
+      libdatadog (~> 8.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
 
@@ -39,7 +39,7 @@ GEM
     json (2.5.1)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (7.0.0.1.0)
+    libdatadog (8.0.0.1.0)
     libddwaf (1.14.0.0.0)
       ffi (~> 1.0)
     memory_profiler (0.9.12)

--- a/gemfiles/ruby_2.3_activerecord_3.gemfile.lock
+++ b/gemfiles/ruby_2.3_activerecord_3.gemfile.lock
@@ -4,7 +4,7 @@ PATH
     ddtrace (1.21.1)
       datadog-ci (~> 0.8.1)
       debase-ruby_core_source (= 3.3.1)
-      libdatadog (~> 7.0.0.1.0)
+      libdatadog (~> 8.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
 
@@ -57,7 +57,7 @@ GEM
     json (2.6.3)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (7.0.0.1.0)
+    libdatadog (8.0.0.1.0)
     libddwaf (1.14.0.0.0)
       ffi (~> 1.0)
     makara (0.3.10)

--- a/gemfiles/ruby_2.3_activesupport.gemfile.lock
+++ b/gemfiles/ruby_2.3_activesupport.gemfile.lock
@@ -4,7 +4,7 @@ PATH
     ddtrace (1.21.1)
       datadog-ci (~> 0.8.1)
       debase-ruby_core_source (= 3.3.1)
-      libdatadog (~> 7.0.0.1.0)
+      libdatadog (~> 8.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
 
@@ -91,7 +91,7 @@ GEM
       addressable (>= 2.4)
     jsonapi-renderer (0.2.2)
     king_konf (1.0.1)
-    libdatadog (7.0.0.1.0)
+    libdatadog (8.0.0.1.0)
     libddwaf (1.14.0.0.0)
       ffi (~> 1.0)
     lograge (0.11.2)

--- a/gemfiles/ruby_2.3_aws.gemfile.lock
+++ b/gemfiles/ruby_2.3_aws.gemfile.lock
@@ -4,7 +4,7 @@ PATH
     ddtrace (1.21.1)
       datadog-ci (~> 0.8.1)
       debase-ruby_core_source (= 3.3.1)
-      libdatadog (~> 7.0.0.1.0)
+      libdatadog (~> 8.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
 
@@ -1461,7 +1461,7 @@ GEM
     json (2.6.3)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (7.0.0.1.0)
+    libdatadog (8.0.0.1.0)
     libddwaf (1.14.0.0.0)
       ffi (~> 1.0)
     memory_profiler (0.9.14)

--- a/gemfiles/ruby_2.3_contrib.gemfile.lock
+++ b/gemfiles/ruby_2.3_contrib.gemfile.lock
@@ -4,7 +4,7 @@ PATH
     ddtrace (1.21.1)
       datadog-ci (~> 0.8.1)
       debase-ruby_core_source (= 3.3.1)
-      libdatadog (~> 7.0.0.1.0)
+      libdatadog (~> 8.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
 
@@ -54,7 +54,7 @@ GEM
     json (2.6.3)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (7.0.0.1.0)
+    libdatadog (8.0.0.1.0)
     libddwaf (1.14.0.0.0)
       ffi (~> 1.0)
     memory_profiler (0.9.14)

--- a/gemfiles/ruby_2.3_contrib_old.gemfile.lock
+++ b/gemfiles/ruby_2.3_contrib_old.gemfile.lock
@@ -4,7 +4,7 @@ PATH
     ddtrace (1.21.1)
       datadog-ci (~> 0.8.1)
       debase-ruby_core_source (= 3.3.1)
-      libdatadog (~> 7.0.0.1.0)
+      libdatadog (~> 8.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
 
@@ -43,7 +43,7 @@ GEM
     json (2.6.3)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (7.0.0.1.0)
+    libdatadog (8.0.0.1.0)
     libddwaf (1.14.0.0.0)
       ffi (~> 1.0)
     memory_profiler (0.9.14)

--- a/gemfiles/ruby_2.3_core_old.gemfile.lock
+++ b/gemfiles/ruby_2.3_core_old.gemfile.lock
@@ -4,7 +4,7 @@ PATH
     ddtrace (1.21.1)
       datadog-ci (~> 0.8.1)
       debase-ruby_core_source (= 3.3.1)
-      libdatadog (~> 7.0.0.1.0)
+      libdatadog (~> 8.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
 
@@ -39,7 +39,7 @@ GEM
     json (2.6.3)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (7.0.0.1.0)
+    libdatadog (8.0.0.1.0)
     libddwaf (1.14.0.0.0)
       ffi (~> 1.0)
     memory_profiler (0.9.14)

--- a/gemfiles/ruby_2.3_elasticsearch_7.gemfile.lock
+++ b/gemfiles/ruby_2.3_elasticsearch_7.gemfile.lock
@@ -4,7 +4,7 @@ PATH
     ddtrace (1.21.1)
       datadog-ci (~> 0.8.1)
       debase-ruby_core_source (= 3.3.1)
-      libdatadog (~> 7.0.0.1.0)
+      libdatadog (~> 8.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
 
@@ -50,7 +50,7 @@ GEM
     json (2.6.3)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (7.0.0.1.0)
+    libdatadog (8.0.0.1.0)
     libddwaf (1.14.0.0.0)
       ffi (~> 1.0)
     memory_profiler (0.9.14)

--- a/gemfiles/ruby_2.3_graphql_1.12.gemfile.lock
+++ b/gemfiles/ruby_2.3_graphql_1.12.gemfile.lock
@@ -4,7 +4,7 @@ PATH
     ddtrace (1.21.1)
       datadog-ci (~> 0.8.1)
       debase-ruby_core_source (= 3.3.1)
-      libdatadog (~> 7.0.0.1.0)
+      libdatadog (~> 8.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
 
@@ -41,7 +41,7 @@ GEM
     json (2.7.1)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (7.0.0.1.0)
+    libdatadog (8.0.0.1.0)
     libddwaf (1.14.0.0.0)
       ffi (~> 1.0)
     memory_profiler (0.9.14)

--- a/gemfiles/ruby_2.3_hanami_1.gemfile.lock
+++ b/gemfiles/ruby_2.3_hanami_1.gemfile.lock
@@ -4,7 +4,7 @@ PATH
     ddtrace (1.21.1)
       datadog-ci (~> 0.8.1)
       debase-ruby_core_source (= 3.3.1)
-      libdatadog (~> 7.0.0.1.0)
+      libdatadog (~> 8.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
 
@@ -114,7 +114,7 @@ GEM
     json (2.6.3)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (7.0.0.1.0)
+    libdatadog (8.0.0.1.0)
     libddwaf (1.14.0.0.0)
       ffi (~> 1.0)
     mail (2.7.1)

--- a/gemfiles/ruby_2.3_http.gemfile.lock
+++ b/gemfiles/ruby_2.3_http.gemfile.lock
@@ -4,7 +4,7 @@ PATH
     ddtrace (1.21.1)
       datadog-ci (~> 0.8.1)
       debase-ruby_core_source (= 3.3.1)
-      libdatadog (~> 7.0.0.1.0)
+      libdatadog (~> 8.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
 
@@ -61,7 +61,7 @@ GEM
     json (2.6.3)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (7.0.0.1.0)
+    libdatadog (8.0.0.1.0)
     libddwaf (1.14.0.0.0)
       ffi (~> 1.0)
     memory_profiler (0.9.14)

--- a/gemfiles/ruby_2.3_opentracing.gemfile.lock
+++ b/gemfiles/ruby_2.3_opentracing.gemfile.lock
@@ -4,7 +4,7 @@ PATH
     ddtrace (1.21.1)
       datadog-ci (~> 0.8.1)
       debase-ruby_core_source (= 3.3.1)
-      libdatadog (~> 7.0.0.1.0)
+      libdatadog (~> 8.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
 
@@ -40,7 +40,7 @@ GEM
     json (2.6.3)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (7.0.0.1.0)
+    libdatadog (8.0.0.1.0)
     libddwaf (1.14.0.0.0)
       ffi (~> 1.0)
     memory_profiler (0.9.14)

--- a/gemfiles/ruby_2.3_rack_1.gemfile.lock
+++ b/gemfiles/ruby_2.3_rack_1.gemfile.lock
@@ -4,7 +4,7 @@ PATH
     ddtrace (1.21.1)
       datadog-ci (~> 0.8.1)
       debase-ruby_core_source (= 3.3.1)
-      libdatadog (~> 7.0.0.1.0)
+      libdatadog (~> 8.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
 
@@ -39,7 +39,7 @@ GEM
     json (2.6.3)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (7.0.0.1.0)
+    libdatadog (8.0.0.1.0)
     libddwaf (1.14.0.0.0)
       ffi (~> 1.0)
     memory_profiler (0.9.14)

--- a/gemfiles/ruby_2.3_rack_2.gemfile.lock
+++ b/gemfiles/ruby_2.3_rack_2.gemfile.lock
@@ -4,7 +4,7 @@ PATH
     ddtrace (1.21.1)
       datadog-ci (~> 0.8.1)
       debase-ruby_core_source (= 3.3.1)
-      libdatadog (~> 7.0.0.1.0)
+      libdatadog (~> 8.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
 
@@ -39,7 +39,7 @@ GEM
     json (2.6.3)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (7.0.0.1.0)
+    libdatadog (8.0.0.1.0)
     libddwaf (1.14.0.0.0)
       ffi (~> 1.0)
     memory_profiler (0.9.14)

--- a/gemfiles/ruby_2.3_rails32_mysql2.gemfile.lock
+++ b/gemfiles/ruby_2.3_rails32_mysql2.gemfile.lock
@@ -4,7 +4,7 @@ PATH
     ddtrace (1.21.1)
       datadog-ci (~> 0.8.1)
       debase-ruby_core_source (= 3.3.1)
-      libdatadog (~> 7.0.0.1.0)
+      libdatadog (~> 8.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
 
@@ -76,7 +76,7 @@ GEM
     json (2.6.3)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (7.0.0.1.0)
+    libdatadog (8.0.0.1.0)
     libddwaf (1.14.0.0.0)
       ffi (~> 1.0)
     mail (2.5.5)

--- a/gemfiles/ruby_2.3_rails32_postgres.gemfile.lock
+++ b/gemfiles/ruby_2.3_rails32_postgres.gemfile.lock
@@ -4,7 +4,7 @@ PATH
     ddtrace (1.21.1)
       datadog-ci (~> 0.8.1)
       debase-ruby_core_source (= 3.3.1)
-      libdatadog (~> 7.0.0.1.0)
+      libdatadog (~> 8.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
 
@@ -72,7 +72,7 @@ GEM
     json (2.6.3)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (7.0.0.1.0)
+    libdatadog (8.0.0.1.0)
     libddwaf (1.14.0.0.0)
       ffi (~> 1.0)
     mail (2.5.5)

--- a/gemfiles/ruby_2.3_rails32_postgres_redis.gemfile.lock
+++ b/gemfiles/ruby_2.3_rails32_postgres_redis.gemfile.lock
@@ -4,7 +4,7 @@ PATH
     ddtrace (1.21.1)
       datadog-ci (~> 0.8.1)
       debase-ruby_core_source (= 3.3.1)
-      libdatadog (~> 7.0.0.1.0)
+      libdatadog (~> 8.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
 
@@ -72,7 +72,7 @@ GEM
     json (2.6.3)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (7.0.0.1.0)
+    libdatadog (8.0.0.1.0)
     libddwaf (1.14.0.0.0)
       ffi (~> 1.0)
     mail (2.5.5)

--- a/gemfiles/ruby_2.3_rails32_postgres_sidekiq.gemfile.lock
+++ b/gemfiles/ruby_2.3_rails32_postgres_sidekiq.gemfile.lock
@@ -4,7 +4,7 @@ PATH
     ddtrace (1.21.1)
       datadog-ci (~> 0.8.1)
       debase-ruby_core_source (= 3.3.1)
-      libdatadog (~> 7.0.0.1.0)
+      libdatadog (~> 8.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
 
@@ -73,7 +73,7 @@ GEM
     json (1.8.6)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (7.0.0.1.0)
+    libdatadog (8.0.0.1.0)
     libddwaf (1.14.0.0.0)
       ffi (~> 1.0)
     mail (2.5.5)

--- a/gemfiles/ruby_2.3_rails4_mysql2.gemfile.lock
+++ b/gemfiles/ruby_2.3_rails4_mysql2.gemfile.lock
@@ -4,7 +4,7 @@ PATH
     ddtrace (1.21.1)
       datadog-ci (~> 0.8.1)
       debase-ruby_core_source (= 3.3.1)
-      libdatadog (~> 7.0.0.1.0)
+      libdatadog (~> 8.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
 
@@ -80,7 +80,7 @@ GEM
     json (2.6.3)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (7.0.0.1.0)
+    libdatadog (8.0.0.1.0)
     libddwaf (1.14.0.0.0)
       ffi (~> 1.0)
     lograge (0.11.2)

--- a/gemfiles/ruby_2.3_rails4_postgres.gemfile.lock
+++ b/gemfiles/ruby_2.3_rails4_postgres.gemfile.lock
@@ -4,7 +4,7 @@ PATH
     ddtrace (1.21.1)
       datadog-ci (~> 0.8.1)
       debase-ruby_core_source (= 3.3.1)
-      libdatadog (~> 7.0.0.1.0)
+      libdatadog (~> 8.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
 
@@ -80,7 +80,7 @@ GEM
     json (2.6.3)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (7.0.0.1.0)
+    libdatadog (8.0.0.1.0)
     libddwaf (1.14.0.0.0)
       ffi (~> 1.0)
     lograge (0.11.2)

--- a/gemfiles/ruby_2.3_rails4_postgres_redis.gemfile.lock
+++ b/gemfiles/ruby_2.3_rails4_postgres_redis.gemfile.lock
@@ -4,7 +4,7 @@ PATH
     ddtrace (1.21.1)
       datadog-ci (~> 0.8.1)
       debase-ruby_core_source (= 3.3.1)
-      libdatadog (~> 7.0.0.1.0)
+      libdatadog (~> 8.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
 
@@ -80,7 +80,7 @@ GEM
     json (2.6.3)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (7.0.0.1.0)
+    libdatadog (8.0.0.1.0)
     libddwaf (1.14.0.0.0)
       ffi (~> 1.0)
     lograge (0.11.2)

--- a/gemfiles/ruby_2.3_rails4_postgres_sidekiq.gemfile.lock
+++ b/gemfiles/ruby_2.3_rails4_postgres_sidekiq.gemfile.lock
@@ -4,7 +4,7 @@ PATH
     ddtrace (1.21.1)
       datadog-ci (~> 0.8.1)
       debase-ruby_core_source (= 3.3.1)
-      libdatadog (~> 7.0.0.1.0)
+      libdatadog (~> 8.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
 
@@ -81,7 +81,7 @@ GEM
     json (2.6.3)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (7.0.0.1.0)
+    libdatadog (8.0.0.1.0)
     libddwaf (1.14.0.0.0)
       ffi (~> 1.0)
     lograge (0.11.2)

--- a/gemfiles/ruby_2.3_rails4_semantic_logger.gemfile.lock
+++ b/gemfiles/ruby_2.3_rails4_semantic_logger.gemfile.lock
@@ -4,7 +4,7 @@ PATH
     ddtrace (1.21.1)
       datadog-ci (~> 0.8.1)
       debase-ruby_core_source (= 3.3.1)
-      libdatadog (~> 7.0.0.1.0)
+      libdatadog (~> 8.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
 
@@ -80,7 +80,7 @@ GEM
     json (2.6.3)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (7.0.0.1.0)
+    libdatadog (8.0.0.1.0)
     libddwaf (1.14.0.0.0)
       ffi (~> 1.0)
     loofah (2.19.1)

--- a/gemfiles/ruby_2.3_rails5_mysql2.gemfile.lock
+++ b/gemfiles/ruby_2.3_rails5_mysql2.gemfile.lock
@@ -4,7 +4,7 @@ PATH
     ddtrace (1.21.1)
       datadog-ci (~> 0.8.1)
       debase-ruby_core_source (= 3.3.1)
-      libdatadog (~> 7.0.0.1.0)
+      libdatadog (~> 8.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
 
@@ -87,7 +87,7 @@ GEM
     json (2.6.3)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (7.0.0.1.0)
+    libdatadog (8.0.0.1.0)
     libddwaf (1.14.0.0.0)
       ffi (~> 1.0)
     lograge (0.11.2)

--- a/gemfiles/ruby_2.3_rails5_postgres.gemfile.lock
+++ b/gemfiles/ruby_2.3_rails5_postgres.gemfile.lock
@@ -4,7 +4,7 @@ PATH
     ddtrace (1.21.1)
       datadog-ci (~> 0.8.1)
       debase-ruby_core_source (= 3.3.1)
-      libdatadog (~> 7.0.0.1.0)
+      libdatadog (~> 8.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
 
@@ -87,7 +87,7 @@ GEM
     json (2.6.3)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (7.0.0.1.0)
+    libdatadog (8.0.0.1.0)
     libddwaf (1.14.0.0.0)
       ffi (~> 1.0)
     lograge (0.11.2)

--- a/gemfiles/ruby_2.3_rails5_postgres_redis.gemfile.lock
+++ b/gemfiles/ruby_2.3_rails5_postgres_redis.gemfile.lock
@@ -4,7 +4,7 @@ PATH
     ddtrace (1.21.1)
       datadog-ci (~> 0.8.1)
       debase-ruby_core_source (= 3.3.1)
-      libdatadog (~> 7.0.0.1.0)
+      libdatadog (~> 8.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
 
@@ -87,7 +87,7 @@ GEM
     json (2.6.3)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (7.0.0.1.0)
+    libdatadog (8.0.0.1.0)
     libddwaf (1.14.0.0.0)
       ffi (~> 1.0)
     lograge (0.11.2)

--- a/gemfiles/ruby_2.3_rails5_postgres_redis_activesupport.gemfile.lock
+++ b/gemfiles/ruby_2.3_rails5_postgres_redis_activesupport.gemfile.lock
@@ -4,7 +4,7 @@ PATH
     ddtrace (1.21.1)
       datadog-ci (~> 0.8.1)
       debase-ruby_core_source (= 3.3.1)
-      libdatadog (~> 7.0.0.1.0)
+      libdatadog (~> 8.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
 
@@ -87,7 +87,7 @@ GEM
     json (2.6.3)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (7.0.0.1.0)
+    libdatadog (8.0.0.1.0)
     libddwaf (1.14.0.0.0)
       ffi (~> 1.0)
     lograge (0.11.2)

--- a/gemfiles/ruby_2.3_rails5_postgres_sidekiq.gemfile.lock
+++ b/gemfiles/ruby_2.3_rails5_postgres_sidekiq.gemfile.lock
@@ -4,7 +4,7 @@ PATH
     ddtrace (1.21.1)
       datadog-ci (~> 0.8.1)
       debase-ruby_core_source (= 3.3.1)
-      libdatadog (~> 7.0.0.1.0)
+      libdatadog (~> 8.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
 
@@ -88,7 +88,7 @@ GEM
     json (2.6.3)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (7.0.0.1.0)
+    libdatadog (8.0.0.1.0)
     libddwaf (1.14.0.0.0)
       ffi (~> 1.0)
     lograge (0.11.2)

--- a/gemfiles/ruby_2.3_rails5_semantic_logger.gemfile.lock
+++ b/gemfiles/ruby_2.3_rails5_semantic_logger.gemfile.lock
@@ -4,7 +4,7 @@ PATH
     ddtrace (1.21.1)
       datadog-ci (~> 0.8.1)
       debase-ruby_core_source (= 3.3.1)
-      libdatadog (~> 7.0.0.1.0)
+      libdatadog (~> 8.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
 
@@ -87,7 +87,7 @@ GEM
     json (2.6.3)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (7.0.0.1.0)
+    libdatadog (8.0.0.1.0)
     libddwaf (1.14.0.0.0)
       ffi (~> 1.0)
     loofah (2.19.1)

--- a/gemfiles/ruby_2.3_redis_3.gemfile.lock
+++ b/gemfiles/ruby_2.3_redis_3.gemfile.lock
@@ -4,7 +4,7 @@ PATH
     ddtrace (1.21.1)
       datadog-ci (~> 0.8.1)
       debase-ruby_core_source (= 3.3.1)
-      libdatadog (~> 7.0.0.1.0)
+      libdatadog (~> 8.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
 
@@ -39,7 +39,7 @@ GEM
     json (2.6.3)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (7.0.0.1.0)
+    libdatadog (8.0.0.1.0)
     libddwaf (1.14.0.0.0)
       ffi (~> 1.0)
     memory_profiler (0.9.14)

--- a/gemfiles/ruby_2.3_relational_db.gemfile.lock
+++ b/gemfiles/ruby_2.3_relational_db.gemfile.lock
@@ -4,7 +4,7 @@ PATH
     ddtrace (1.21.1)
       datadog-ci (~> 0.8.1)
       debase-ruby_core_source (= 3.3.1)
-      libdatadog (~> 7.0.0.1.0)
+      libdatadog (~> 8.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
 
@@ -58,7 +58,7 @@ GEM
     json (2.6.3)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (7.0.0.1.0)
+    libdatadog (8.0.0.1.0)
     libddwaf (1.14.0.0.0)
       ffi (~> 1.0)
     makara (0.5.0)

--- a/gemfiles/ruby_2.3_resque2_redis3.gemfile.lock
+++ b/gemfiles/ruby_2.3_resque2_redis3.gemfile.lock
@@ -4,7 +4,7 @@ PATH
     ddtrace (1.21.1)
       datadog-ci (~> 0.8.1)
       debase-ruby_core_source (= 3.3.1)
-      libdatadog (~> 7.0.0.1.0)
+      libdatadog (~> 8.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
 
@@ -39,7 +39,7 @@ GEM
     json (2.6.3)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (7.0.0.1.0)
+    libdatadog (8.0.0.1.0)
     libddwaf (1.14.0.0.0)
       ffi (~> 1.0)
     memory_profiler (0.9.14)

--- a/gemfiles/ruby_2.3_resque2_redis4.gemfile.lock
+++ b/gemfiles/ruby_2.3_resque2_redis4.gemfile.lock
@@ -4,7 +4,7 @@ PATH
     ddtrace (1.21.1)
       datadog-ci (~> 0.8.1)
       debase-ruby_core_source (= 3.3.1)
-      libdatadog (~> 7.0.0.1.0)
+      libdatadog (~> 8.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
 
@@ -39,7 +39,7 @@ GEM
     json (2.6.3)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (7.0.0.1.0)
+    libdatadog (8.0.0.1.0)
     libddwaf (1.14.0.0.0)
       ffi (~> 1.0)
     memory_profiler (0.9.14)

--- a/gemfiles/ruby_2.3_sinatra.gemfile.lock
+++ b/gemfiles/ruby_2.3_sinatra.gemfile.lock
@@ -4,7 +4,7 @@ PATH
     ddtrace (1.21.1)
       datadog-ci (~> 0.8.1)
       debase-ruby_core_source (= 3.3.1)
-      libdatadog (~> 7.0.0.1.0)
+      libdatadog (~> 8.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
 
@@ -39,7 +39,7 @@ GEM
     json (2.6.3)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (7.0.0.1.0)
+    libdatadog (8.0.0.1.0)
     libddwaf (1.14.0.0.0)
       ffi (~> 1.0)
     memory_profiler (0.9.14)

--- a/gemfiles/ruby_2.4_activerecord_4.gemfile.lock
+++ b/gemfiles/ruby_2.4_activerecord_4.gemfile.lock
@@ -4,7 +4,7 @@ PATH
     ddtrace (1.21.1)
       datadog-ci (~> 0.8.1)
       debase-ruby_core_source (= 3.3.1)
-      libdatadog (~> 7.0.0.1.0)
+      libdatadog (~> 8.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
 
@@ -55,8 +55,8 @@ GEM
       concurrent-ruby (~> 1.0)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (7.0.0.1.0-aarch64-linux)
-    libdatadog (7.0.0.1.0-x86_64-linux)
+    libdatadog (8.0.0.1.0-aarch64-linux)
+    libdatadog (8.0.0.1.0-x86_64-linux)
     libddwaf (1.14.0.0.0-aarch64-linux)
       ffi (~> 1.0)
     libddwaf (1.14.0.0.0-x86_64-linux)

--- a/gemfiles/ruby_2.4_activesupport.gemfile.lock
+++ b/gemfiles/ruby_2.4_activesupport.gemfile.lock
@@ -4,7 +4,7 @@ PATH
     ddtrace (1.21.1)
       datadog-ci (~> 0.8.1)
       debase-ruby_core_source (= 3.3.1)
-      libdatadog (~> 7.0.0.1.0)
+      libdatadog (~> 8.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
 
@@ -104,8 +104,8 @@ GEM
       addressable (>= 2.4)
     jsonapi-renderer (0.2.2)
     king_konf (1.0.1)
-    libdatadog (7.0.0.1.0-aarch64-linux)
-    libdatadog (7.0.0.1.0-x86_64-linux)
+    libdatadog (8.0.0.1.0-aarch64-linux)
+    libdatadog (8.0.0.1.0-x86_64-linux)
     libddwaf (1.14.0.0.0-aarch64-linux)
       ffi (~> 1.0)
     libddwaf (1.14.0.0.0-x86_64-linux)

--- a/gemfiles/ruby_2.4_aws.gemfile.lock
+++ b/gemfiles/ruby_2.4_aws.gemfile.lock
@@ -4,7 +4,7 @@ PATH
     ddtrace (1.21.1)
       datadog-ci (~> 0.8.1)
       debase-ruby_core_source (= 3.3.1)
-      libdatadog (~> 7.0.0.1.0)
+      libdatadog (~> 8.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
 
@@ -1462,8 +1462,8 @@ GEM
     jmespath (1.6.2)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (7.0.0.1.0-aarch64-linux)
-    libdatadog (7.0.0.1.0-x86_64-linux)
+    libdatadog (8.0.0.1.0-aarch64-linux)
+    libdatadog (8.0.0.1.0-x86_64-linux)
     libddwaf (1.14.0.0.0-aarch64-linux)
       ffi (~> 1.0)
     libddwaf (1.14.0.0.0-x86_64-linux)

--- a/gemfiles/ruby_2.4_contrib.gemfile.lock
+++ b/gemfiles/ruby_2.4_contrib.gemfile.lock
@@ -4,7 +4,7 @@ PATH
     ddtrace (1.21.1)
       datadog-ci (~> 0.8.1)
       debase-ruby_core_source (= 3.3.1)
-      libdatadog (~> 7.0.0.1.0)
+      libdatadog (~> 8.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
 
@@ -55,8 +55,8 @@ GEM
     hashdiff (1.0.1)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (7.0.0.1.0-aarch64-linux)
-    libdatadog (7.0.0.1.0-x86_64-linux)
+    libdatadog (8.0.0.1.0-aarch64-linux)
+    libdatadog (8.0.0.1.0-x86_64-linux)
     libddwaf (1.14.0.0.0-aarch64-linux)
       ffi (~> 1.0)
     libddwaf (1.14.0.0.0-x86_64-linux)

--- a/gemfiles/ruby_2.4_contrib_old.gemfile.lock
+++ b/gemfiles/ruby_2.4_contrib_old.gemfile.lock
@@ -4,7 +4,7 @@ PATH
     ddtrace (1.21.1)
       datadog-ci (~> 0.8.1)
       debase-ruby_core_source (= 3.3.1)
-      libdatadog (~> 7.0.0.1.0)
+      libdatadog (~> 8.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
 
@@ -44,8 +44,8 @@ GEM
     hashdiff (1.0.1)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (7.0.0.1.0-aarch64-linux)
-    libdatadog (7.0.0.1.0-x86_64-linux)
+    libdatadog (8.0.0.1.0-aarch64-linux)
+    libdatadog (8.0.0.1.0-x86_64-linux)
     libddwaf (1.14.0.0.0-aarch64-linux)
       ffi (~> 1.0)
     libddwaf (1.14.0.0.0-x86_64-linux)

--- a/gemfiles/ruby_2.4_core_old.gemfile.lock
+++ b/gemfiles/ruby_2.4_core_old.gemfile.lock
@@ -4,7 +4,7 @@ PATH
     ddtrace (1.21.1)
       datadog-ci (~> 0.8.1)
       debase-ruby_core_source (= 3.3.1)
-      libdatadog (~> 7.0.0.1.0)
+      libdatadog (~> 8.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
 
@@ -40,8 +40,8 @@ GEM
     hashdiff (1.0.1)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (7.0.0.1.0-aarch64-linux)
-    libdatadog (7.0.0.1.0-x86_64-linux)
+    libdatadog (8.0.0.1.0-aarch64-linux)
+    libdatadog (8.0.0.1.0-x86_64-linux)
     libddwaf (1.14.0.0.0-aarch64-linux)
       ffi (~> 1.0)
     libddwaf (1.14.0.0.0-x86_64-linux)

--- a/gemfiles/ruby_2.4_elasticsearch_7.gemfile.lock
+++ b/gemfiles/ruby_2.4_elasticsearch_7.gemfile.lock
@@ -4,7 +4,7 @@ PATH
     ddtrace (1.21.1)
       datadog-ci (~> 0.8.1)
       debase-ruby_core_source (= 3.3.1)
-      libdatadog (~> 7.0.0.1.0)
+      libdatadog (~> 8.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
 
@@ -72,8 +72,8 @@ GEM
     hashdiff (1.0.1)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (7.0.0.1.0-aarch64-linux)
-    libdatadog (7.0.0.1.0-x86_64-linux)
+    libdatadog (8.0.0.1.0-aarch64-linux)
+    libdatadog (8.0.0.1.0-x86_64-linux)
     libddwaf (1.14.0.0.0-aarch64-linux)
       ffi (~> 1.0)
     libddwaf (1.14.0.0.0-x86_64-linux)

--- a/gemfiles/ruby_2.4_graphql_1.12.gemfile.lock
+++ b/gemfiles/ruby_2.4_graphql_1.12.gemfile.lock
@@ -4,7 +4,7 @@ PATH
     ddtrace (1.21.1)
       datadog-ci (~> 0.8.1)
       debase-ruby_core_source (= 3.3.1)
-      libdatadog (~> 7.0.0.1.0)
+      libdatadog (~> 8.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
 
@@ -42,8 +42,8 @@ GEM
     hashdiff (1.1.0)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (7.0.0.1.0-aarch64-linux)
-    libdatadog (7.0.0.1.0-x86_64-linux)
+    libdatadog (8.0.0.1.0-aarch64-linux)
+    libdatadog (8.0.0.1.0-x86_64-linux)
     libddwaf (1.14.0.0.0-aarch64-linux)
       ffi (~> 1.0)
     libddwaf (1.14.0.0.0-x86_64-linux)

--- a/gemfiles/ruby_2.4_graphql_1.13.gemfile.lock
+++ b/gemfiles/ruby_2.4_graphql_1.13.gemfile.lock
@@ -4,7 +4,7 @@ PATH
     ddtrace (1.21.1)
       datadog-ci (~> 0.8.1)
       debase-ruby_core_source (= 3.3.1)
-      libdatadog (~> 7.0.0.1.0)
+      libdatadog (~> 8.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
 
@@ -42,8 +42,8 @@ GEM
     hashdiff (1.1.0)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (7.0.0.1.0-aarch64-linux)
-    libdatadog (7.0.0.1.0-x86_64-linux)
+    libdatadog (8.0.0.1.0-aarch64-linux)
+    libdatadog (8.0.0.1.0-x86_64-linux)
     libddwaf (1.14.0.0.0-aarch64-linux)
       ffi (~> 1.0)
     libddwaf (1.14.0.0.0-x86_64-linux)

--- a/gemfiles/ruby_2.4_graphql_2.0.gemfile.lock
+++ b/gemfiles/ruby_2.4_graphql_2.0.gemfile.lock
@@ -4,7 +4,7 @@ PATH
     ddtrace (1.21.1)
       datadog-ci (~> 0.8.1)
       debase-ruby_core_source (= 3.3.1)
-      libdatadog (~> 7.0.0.1.0)
+      libdatadog (~> 8.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
 
@@ -42,8 +42,8 @@ GEM
     hashdiff (1.1.0)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (7.0.0.1.0-aarch64-linux)
-    libdatadog (7.0.0.1.0-x86_64-linux)
+    libdatadog (8.0.0.1.0-aarch64-linux)
+    libdatadog (8.0.0.1.0-x86_64-linux)
     libddwaf (1.14.0.0.0-aarch64-linux)
       ffi (~> 1.0)
     libddwaf (1.14.0.0.0-x86_64-linux)

--- a/gemfiles/ruby_2.4_hanami_1.gemfile.lock
+++ b/gemfiles/ruby_2.4_hanami_1.gemfile.lock
@@ -4,7 +4,7 @@ PATH
     ddtrace (1.21.1)
       datadog-ci (~> 0.8.1)
       debase-ruby_core_source (= 3.3.1)
-      libdatadog (~> 7.0.0.1.0)
+      libdatadog (~> 8.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
 
@@ -115,8 +115,8 @@ GEM
     inflecto (0.0.2)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (7.0.0.1.0-aarch64-linux)
-    libdatadog (7.0.0.1.0-x86_64-linux)
+    libdatadog (8.0.0.1.0-aarch64-linux)
+    libdatadog (8.0.0.1.0-x86_64-linux)
     libddwaf (1.14.0.0.0-aarch64-linux)
       ffi (~> 1.0)
     libddwaf (1.14.0.0.0-x86_64-linux)

--- a/gemfiles/ruby_2.4_http.gemfile.lock
+++ b/gemfiles/ruby_2.4_http.gemfile.lock
@@ -4,7 +4,7 @@ PATH
     ddtrace (1.21.1)
       datadog-ci (~> 0.8.1)
       debase-ruby_core_source (= 3.3.1)
-      libdatadog (~> 7.0.0.1.0)
+      libdatadog (~> 8.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
 
@@ -83,8 +83,8 @@ GEM
     httpclient (2.8.3)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (7.0.0.1.0-aarch64-linux)
-    libdatadog (7.0.0.1.0-x86_64-linux)
+    libdatadog (8.0.0.1.0-aarch64-linux)
+    libdatadog (8.0.0.1.0-x86_64-linux)
     libddwaf (1.14.0.0.0-aarch64-linux)
       ffi (~> 1.0)
     libddwaf (1.14.0.0.0-x86_64-linux)

--- a/gemfiles/ruby_2.4_opensearch_2.gemfile.lock
+++ b/gemfiles/ruby_2.4_opensearch_2.gemfile.lock
@@ -4,7 +4,7 @@ PATH
     ddtrace (1.21.1)
       datadog-ci (~> 0.8.1)
       debase-ruby_core_source (= 3.3.1)
-      libdatadog (~> 7.0.0.1.0)
+      libdatadog (~> 8.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
 
@@ -64,8 +64,8 @@ GEM
     hashdiff (1.0.1)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (7.0.0.1.0-aarch64-linux)
-    libdatadog (7.0.0.1.0-x86_64-linux)
+    libdatadog (8.0.0.1.0-aarch64-linux)
+    libdatadog (8.0.0.1.0-x86_64-linux)
     libddwaf (1.14.0.0.0-aarch64-linux)
       ffi (~> 1.0)
     libddwaf (1.14.0.0.0-x86_64-linux)

--- a/gemfiles/ruby_2.4_opentracing.gemfile.lock
+++ b/gemfiles/ruby_2.4_opentracing.gemfile.lock
@@ -4,7 +4,7 @@ PATH
     ddtrace (1.21.1)
       datadog-ci (~> 0.8.1)
       debase-ruby_core_source (= 3.3.1)
-      libdatadog (~> 7.0.0.1.0)
+      libdatadog (~> 8.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
 
@@ -41,8 +41,8 @@ GEM
     hashdiff (1.0.1)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (7.0.0.1.0-aarch64-linux)
-    libdatadog (7.0.0.1.0-x86_64-linux)
+    libdatadog (8.0.0.1.0-aarch64-linux)
+    libdatadog (8.0.0.1.0-x86_64-linux)
     libddwaf (1.14.0.0.0-aarch64-linux)
       ffi (~> 1.0)
     libddwaf (1.14.0.0.0-x86_64-linux)

--- a/gemfiles/ruby_2.4_rack_1.gemfile.lock
+++ b/gemfiles/ruby_2.4_rack_1.gemfile.lock
@@ -4,7 +4,7 @@ PATH
     ddtrace (1.21.1)
       datadog-ci (~> 0.8.1)
       debase-ruby_core_source (= 3.3.1)
-      libdatadog (~> 7.0.0.1.0)
+      libdatadog (~> 8.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
 
@@ -40,8 +40,8 @@ GEM
     hashdiff (1.0.1)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (7.0.0.1.0-aarch64-linux)
-    libdatadog (7.0.0.1.0-x86_64-linux)
+    libdatadog (8.0.0.1.0-aarch64-linux)
+    libdatadog (8.0.0.1.0-x86_64-linux)
     libddwaf (1.14.0.0.0-aarch64-linux)
       ffi (~> 1.0)
     libddwaf (1.14.0.0.0-x86_64-linux)

--- a/gemfiles/ruby_2.4_rack_2.gemfile.lock
+++ b/gemfiles/ruby_2.4_rack_2.gemfile.lock
@@ -4,7 +4,7 @@ PATH
     ddtrace (1.21.1)
       datadog-ci (~> 0.8.1)
       debase-ruby_core_source (= 3.3.1)
-      libdatadog (~> 7.0.0.1.0)
+      libdatadog (~> 8.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
 
@@ -40,8 +40,8 @@ GEM
     hashdiff (1.0.1)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (7.0.0.1.0-aarch64-linux)
-    libdatadog (7.0.0.1.0-x86_64-linux)
+    libdatadog (8.0.0.1.0-aarch64-linux)
+    libdatadog (8.0.0.1.0-x86_64-linux)
     libddwaf (1.14.0.0.0-aarch64-linux)
       ffi (~> 1.0)
     libddwaf (1.14.0.0.0-x86_64-linux)

--- a/gemfiles/ruby_2.4_rack_3.gemfile.lock
+++ b/gemfiles/ruby_2.4_rack_3.gemfile.lock
@@ -4,7 +4,7 @@ PATH
     ddtrace (1.21.1)
       datadog-ci (~> 0.8.1)
       debase-ruby_core_source (= 3.3.1)
-      libdatadog (~> 7.0.0.1.0)
+      libdatadog (~> 8.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
 
@@ -40,8 +40,8 @@ GEM
     hashdiff (1.0.1)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (7.0.0.1.0-aarch64-linux)
-    libdatadog (7.0.0.1.0-x86_64-linux)
+    libdatadog (8.0.0.1.0-aarch64-linux)
+    libdatadog (8.0.0.1.0-x86_64-linux)
     libddwaf (1.14.0.0.0-aarch64-linux)
       ffi (~> 1.0)
     libddwaf (1.14.0.0.0-x86_64-linux)

--- a/gemfiles/ruby_2.4_rails5_mysql2.gemfile.lock
+++ b/gemfiles/ruby_2.4_rails5_mysql2.gemfile.lock
@@ -4,7 +4,7 @@ PATH
     ddtrace (1.21.1)
       datadog-ci (~> 0.8.1)
       debase-ruby_core_source (= 3.3.1)
-      libdatadog (~> 7.0.0.1.0)
+      libdatadog (~> 8.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
 
@@ -88,8 +88,8 @@ GEM
       concurrent-ruby (~> 1.0)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (7.0.0.1.0-aarch64-linux)
-    libdatadog (7.0.0.1.0-x86_64-linux)
+    libdatadog (8.0.0.1.0-aarch64-linux)
+    libdatadog (8.0.0.1.0-x86_64-linux)
     libddwaf (1.14.0.0.0-aarch64-linux)
       ffi (~> 1.0)
     libddwaf (1.14.0.0.0-x86_64-linux)

--- a/gemfiles/ruby_2.4_rails5_postgres.gemfile.lock
+++ b/gemfiles/ruby_2.4_rails5_postgres.gemfile.lock
@@ -4,7 +4,7 @@ PATH
     ddtrace (1.21.1)
       datadog-ci (~> 0.8.1)
       debase-ruby_core_source (= 3.3.1)
-      libdatadog (~> 7.0.0.1.0)
+      libdatadog (~> 8.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
 
@@ -88,8 +88,8 @@ GEM
       concurrent-ruby (~> 1.0)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (7.0.0.1.0-aarch64-linux)
-    libdatadog (7.0.0.1.0-x86_64-linux)
+    libdatadog (8.0.0.1.0-aarch64-linux)
+    libdatadog (8.0.0.1.0-x86_64-linux)
     libddwaf (1.14.0.0.0-aarch64-linux)
       ffi (~> 1.0)
     libddwaf (1.14.0.0.0-x86_64-linux)

--- a/gemfiles/ruby_2.4_rails5_postgres_redis.gemfile.lock
+++ b/gemfiles/ruby_2.4_rails5_postgres_redis.gemfile.lock
@@ -4,7 +4,7 @@ PATH
     ddtrace (1.21.1)
       datadog-ci (~> 0.8.1)
       debase-ruby_core_source (= 3.3.1)
-      libdatadog (~> 7.0.0.1.0)
+      libdatadog (~> 8.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
 
@@ -88,8 +88,8 @@ GEM
       concurrent-ruby (~> 1.0)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (7.0.0.1.0-aarch64-linux)
-    libdatadog (7.0.0.1.0-x86_64-linux)
+    libdatadog (8.0.0.1.0-aarch64-linux)
+    libdatadog (8.0.0.1.0-x86_64-linux)
     libddwaf (1.14.0.0.0-aarch64-linux)
       ffi (~> 1.0)
     libddwaf (1.14.0.0.0-x86_64-linux)

--- a/gemfiles/ruby_2.4_rails5_postgres_redis_activesupport.gemfile.lock
+++ b/gemfiles/ruby_2.4_rails5_postgres_redis_activesupport.gemfile.lock
@@ -4,7 +4,7 @@ PATH
     ddtrace (1.21.1)
       datadog-ci (~> 0.8.1)
       debase-ruby_core_source (= 3.3.1)
-      libdatadog (~> 7.0.0.1.0)
+      libdatadog (~> 8.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
 
@@ -88,8 +88,8 @@ GEM
       concurrent-ruby (~> 1.0)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (7.0.0.1.0-aarch64-linux)
-    libdatadog (7.0.0.1.0-x86_64-linux)
+    libdatadog (8.0.0.1.0-aarch64-linux)
+    libdatadog (8.0.0.1.0-x86_64-linux)
     libddwaf (1.14.0.0.0-aarch64-linux)
       ffi (~> 1.0)
     libddwaf (1.14.0.0.0-x86_64-linux)

--- a/gemfiles/ruby_2.4_rails5_postgres_sidekiq.gemfile.lock
+++ b/gemfiles/ruby_2.4_rails5_postgres_sidekiq.gemfile.lock
@@ -4,7 +4,7 @@ PATH
     ddtrace (1.21.1)
       datadog-ci (~> 0.8.1)
       debase-ruby_core_source (= 3.3.1)
-      libdatadog (~> 7.0.0.1.0)
+      libdatadog (~> 8.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
 
@@ -89,8 +89,8 @@ GEM
       concurrent-ruby (~> 1.0)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (7.0.0.1.0-aarch64-linux)
-    libdatadog (7.0.0.1.0-x86_64-linux)
+    libdatadog (8.0.0.1.0-aarch64-linux)
+    libdatadog (8.0.0.1.0-x86_64-linux)
     libddwaf (1.14.0.0.0-aarch64-linux)
       ffi (~> 1.0)
     libddwaf (1.14.0.0.0-x86_64-linux)

--- a/gemfiles/ruby_2.4_rails5_semantic_logger.gemfile.lock
+++ b/gemfiles/ruby_2.4_rails5_semantic_logger.gemfile.lock
@@ -4,7 +4,7 @@ PATH
     ddtrace (1.21.1)
       datadog-ci (~> 0.8.1)
       debase-ruby_core_source (= 3.3.1)
-      libdatadog (~> 7.0.0.1.0)
+      libdatadog (~> 8.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
 
@@ -88,8 +88,8 @@ GEM
       concurrent-ruby (~> 1.0)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (7.0.0.1.0-aarch64-linux)
-    libdatadog (7.0.0.1.0-x86_64-linux)
+    libdatadog (8.0.0.1.0-aarch64-linux)
+    libdatadog (8.0.0.1.0-x86_64-linux)
     libddwaf (1.14.0.0.0-aarch64-linux)
       ffi (~> 1.0)
     libddwaf (1.14.0.0.0-x86_64-linux)

--- a/gemfiles/ruby_2.4_redis_3.gemfile.lock
+++ b/gemfiles/ruby_2.4_redis_3.gemfile.lock
@@ -4,7 +4,7 @@ PATH
     ddtrace (1.21.1)
       datadog-ci (~> 0.8.1)
       debase-ruby_core_source (= 3.3.1)
-      libdatadog (~> 7.0.0.1.0)
+      libdatadog (~> 8.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
 
@@ -40,8 +40,8 @@ GEM
     hashdiff (1.0.1)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (7.0.0.1.0-aarch64-linux)
-    libdatadog (7.0.0.1.0-x86_64-linux)
+    libdatadog (8.0.0.1.0-aarch64-linux)
+    libdatadog (8.0.0.1.0-x86_64-linux)
     libddwaf (1.14.0.0.0-aarch64-linux)
       ffi (~> 1.0)
     libddwaf (1.14.0.0.0-x86_64-linux)

--- a/gemfiles/ruby_2.4_redis_4.gemfile.lock
+++ b/gemfiles/ruby_2.4_redis_4.gemfile.lock
@@ -4,7 +4,7 @@ PATH
     ddtrace (1.21.1)
       datadog-ci (~> 0.8.1)
       debase-ruby_core_source (= 3.3.1)
-      libdatadog (~> 7.0.0.1.0)
+      libdatadog (~> 8.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
 
@@ -40,8 +40,8 @@ GEM
     hashdiff (1.0.1)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (7.0.0.1.0-aarch64-linux)
-    libdatadog (7.0.0.1.0-x86_64-linux)
+    libdatadog (8.0.0.1.0-aarch64-linux)
+    libdatadog (8.0.0.1.0-x86_64-linux)
     libddwaf (1.14.0.0.0-aarch64-linux)
       ffi (~> 1.0)
     libddwaf (1.14.0.0.0-x86_64-linux)

--- a/gemfiles/ruby_2.4_relational_db.gemfile.lock
+++ b/gemfiles/ruby_2.4_relational_db.gemfile.lock
@@ -4,7 +4,7 @@ PATH
     ddtrace (1.21.1)
       datadog-ci (~> 0.8.1)
       debase-ruby_core_source (= 3.3.1)
-      libdatadog (~> 7.0.0.1.0)
+      libdatadog (~> 8.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
 
@@ -59,8 +59,8 @@ GEM
       concurrent-ruby (~> 1.0)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (7.0.0.1.0-aarch64-linux)
-    libdatadog (7.0.0.1.0-x86_64-linux)
+    libdatadog (8.0.0.1.0-aarch64-linux)
+    libdatadog (8.0.0.1.0-x86_64-linux)
     libddwaf (1.14.0.0.0-aarch64-linux)
       ffi (~> 1.0)
     libddwaf (1.14.0.0.0-x86_64-linux)

--- a/gemfiles/ruby_2.4_resque2_redis3.gemfile.lock
+++ b/gemfiles/ruby_2.4_resque2_redis3.gemfile.lock
@@ -4,7 +4,7 @@ PATH
     ddtrace (1.21.1)
       datadog-ci (~> 0.8.1)
       debase-ruby_core_source (= 3.3.1)
-      libdatadog (~> 7.0.0.1.0)
+      libdatadog (~> 8.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
 
@@ -40,8 +40,8 @@ GEM
     hashdiff (1.0.1)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (7.0.0.1.0-aarch64-linux)
-    libdatadog (7.0.0.1.0-x86_64-linux)
+    libdatadog (8.0.0.1.0-aarch64-linux)
+    libdatadog (8.0.0.1.0-x86_64-linux)
     libddwaf (1.14.0.0.0-aarch64-linux)
       ffi (~> 1.0)
     libddwaf (1.14.0.0.0-x86_64-linux)

--- a/gemfiles/ruby_2.4_resque2_redis4.gemfile.lock
+++ b/gemfiles/ruby_2.4_resque2_redis4.gemfile.lock
@@ -4,7 +4,7 @@ PATH
     ddtrace (1.21.1)
       datadog-ci (~> 0.8.1)
       debase-ruby_core_source (= 3.3.1)
-      libdatadog (~> 7.0.0.1.0)
+      libdatadog (~> 8.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
 
@@ -40,8 +40,8 @@ GEM
     hashdiff (1.0.1)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (7.0.0.1.0-aarch64-linux)
-    libdatadog (7.0.0.1.0-x86_64-linux)
+    libdatadog (8.0.0.1.0-aarch64-linux)
+    libdatadog (8.0.0.1.0-x86_64-linux)
     libddwaf (1.14.0.0.0-aarch64-linux)
       ffi (~> 1.0)
     libddwaf (1.14.0.0.0-x86_64-linux)

--- a/gemfiles/ruby_2.4_sinatra.gemfile.lock
+++ b/gemfiles/ruby_2.4_sinatra.gemfile.lock
@@ -4,7 +4,7 @@ PATH
     ddtrace (1.21.1)
       datadog-ci (~> 0.8.1)
       debase-ruby_core_source (= 3.3.1)
-      libdatadog (~> 7.0.0.1.0)
+      libdatadog (~> 8.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
 
@@ -40,8 +40,8 @@ GEM
     hashdiff (1.0.1)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (7.0.0.1.0-aarch64-linux)
-    libdatadog (7.0.0.1.0-x86_64-linux)
+    libdatadog (8.0.0.1.0-aarch64-linux)
+    libdatadog (8.0.0.1.0-x86_64-linux)
     libddwaf (1.14.0.0.0-aarch64-linux)
       ffi (~> 1.0)
     libddwaf (1.14.0.0.0-x86_64-linux)

--- a/gemfiles/ruby_2.5_activesupport.gemfile.lock
+++ b/gemfiles/ruby_2.5_activesupport.gemfile.lock
@@ -14,7 +14,7 @@ PATH
     ddtrace (1.21.1)
       datadog-ci (~> 0.8.1)
       debase-ruby_core_source (= 3.3.1)
-      libdatadog (~> 7.0.0.1.0)
+      libdatadog (~> 8.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
 
@@ -113,8 +113,8 @@ GEM
       addressable (>= 2.4)
     jsonapi-renderer (0.2.2)
     king_konf (1.0.1)
-    libdatadog (7.0.0.1.0-aarch64-linux)
-    libdatadog (7.0.0.1.0-x86_64-linux)
+    libdatadog (8.0.0.1.0-aarch64-linux)
+    libdatadog (8.0.0.1.0-x86_64-linux)
     libddwaf (1.14.0.0.0-aarch64-linux)
       ffi (~> 1.0)
     libddwaf (1.14.0.0.0-x86_64-linux)

--- a/gemfiles/ruby_2.5_aws.gemfile.lock
+++ b/gemfiles/ruby_2.5_aws.gemfile.lock
@@ -14,7 +14,7 @@ PATH
     ddtrace (1.21.1)
       datadog-ci (~> 0.8.1)
       debase-ruby_core_source (= 3.3.1)
-      libdatadog (~> 7.0.0.1.0)
+      libdatadog (~> 8.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
 
@@ -1475,8 +1475,8 @@ GEM
     jmespath (1.6.2)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (7.0.0.1.0-aarch64-linux)
-    libdatadog (7.0.0.1.0-x86_64-linux)
+    libdatadog (8.0.0.1.0-aarch64-linux)
+    libdatadog (8.0.0.1.0-x86_64-linux)
     libddwaf (1.14.0.0.0-aarch64-linux)
       ffi (~> 1.0)
     libddwaf (1.14.0.0.0-x86_64-linux)

--- a/gemfiles/ruby_2.5_contrib.gemfile.lock
+++ b/gemfiles/ruby_2.5_contrib.gemfile.lock
@@ -14,7 +14,7 @@ PATH
     ddtrace (1.21.1)
       datadog-ci (~> 0.8.1)
       debase-ruby_core_source (= 3.3.1)
-      libdatadog (~> 7.0.0.1.0)
+      libdatadog (~> 8.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
 
@@ -68,8 +68,8 @@ GEM
     hashdiff (1.0.1)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (7.0.0.1.0-aarch64-linux)
-    libdatadog (7.0.0.1.0-x86_64-linux)
+    libdatadog (8.0.0.1.0-aarch64-linux)
+    libdatadog (8.0.0.1.0-x86_64-linux)
     libddwaf (1.14.0.0.0-aarch64-linux)
       ffi (~> 1.0)
     libddwaf (1.14.0.0.0-x86_64-linux)

--- a/gemfiles/ruby_2.5_contrib_old.gemfile.lock
+++ b/gemfiles/ruby_2.5_contrib_old.gemfile.lock
@@ -14,7 +14,7 @@ PATH
     ddtrace (1.21.1)
       datadog-ci (~> 0.8.1)
       debase-ruby_core_source (= 3.3.1)
-      libdatadog (~> 7.0.0.1.0)
+      libdatadog (~> 8.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
 
@@ -64,8 +64,8 @@ GEM
     hitimes (1.3.1)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (7.0.0.1.0-aarch64-linux)
-    libdatadog (7.0.0.1.0-x86_64-linux)
+    libdatadog (8.0.0.1.0-aarch64-linux)
+    libdatadog (8.0.0.1.0-x86_64-linux)
     libddwaf (1.14.0.0.0-aarch64-linux)
       ffi (~> 1.0)
     libddwaf (1.14.0.0.0-x86_64-linux)

--- a/gemfiles/ruby_2.5_core_old.gemfile.lock
+++ b/gemfiles/ruby_2.5_core_old.gemfile.lock
@@ -14,7 +14,7 @@ PATH
     ddtrace (1.21.1)
       datadog-ci (~> 0.8.1)
       debase-ruby_core_source (= 3.3.1)
-      libdatadog (~> 7.0.0.1.0)
+      libdatadog (~> 8.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
 
@@ -53,8 +53,8 @@ GEM
     hashdiff (1.0.1)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (7.0.0.1.0-aarch64-linux)
-    libdatadog (7.0.0.1.0-x86_64-linux)
+    libdatadog (8.0.0.1.0-aarch64-linux)
+    libdatadog (8.0.0.1.0-x86_64-linux)
     libddwaf (1.14.0.0.0-aarch64-linux)
       ffi (~> 1.0)
     libddwaf (1.14.0.0.0-x86_64-linux)

--- a/gemfiles/ruby_2.5_elasticsearch_7.gemfile.lock
+++ b/gemfiles/ruby_2.5_elasticsearch_7.gemfile.lock
@@ -14,7 +14,7 @@ PATH
     ddtrace (1.21.1)
       datadog-ci (~> 0.8.1)
       debase-ruby_core_source (= 3.3.1)
-      libdatadog (~> 7.0.0.1.0)
+      libdatadog (~> 8.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
 
@@ -85,8 +85,8 @@ GEM
     hashdiff (1.0.1)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (7.0.0.1.0-aarch64-linux)
-    libdatadog (7.0.0.1.0-x86_64-linux)
+    libdatadog (8.0.0.1.0-aarch64-linux)
+    libdatadog (8.0.0.1.0-x86_64-linux)
     libddwaf (1.14.0.0.0-aarch64-linux)
       ffi (~> 1.0)
     libddwaf (1.14.0.0.0-x86_64-linux)

--- a/gemfiles/ruby_2.5_elasticsearch_8.gemfile.lock
+++ b/gemfiles/ruby_2.5_elasticsearch_8.gemfile.lock
@@ -14,7 +14,7 @@ PATH
     ddtrace (1.21.1)
       datadog-ci (~> 0.8.1)
       debase-ruby_core_source (= 3.3.1)
-      libdatadog (~> 7.0.0.1.0)
+      libdatadog (~> 8.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
 
@@ -85,8 +85,8 @@ GEM
     hashdiff (1.0.1)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (7.0.0.1.0-aarch64-linux)
-    libdatadog (7.0.0.1.0-x86_64-linux)
+    libdatadog (8.0.0.1.0-aarch64-linux)
+    libdatadog (8.0.0.1.0-x86_64-linux)
     libddwaf (1.14.0.0.0-aarch64-linux)
       ffi (~> 1.0)
     libddwaf (1.14.0.0.0-x86_64-linux)

--- a/gemfiles/ruby_2.5_graphql_1.12.gemfile.lock
+++ b/gemfiles/ruby_2.5_graphql_1.12.gemfile.lock
@@ -14,7 +14,7 @@ PATH
     ddtrace (1.21.1)
       datadog-ci (~> 0.8.1)
       debase-ruby_core_source (= 3.3.1)
-      libdatadog (~> 7.0.0.1.0)
+      libdatadog (~> 8.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
 
@@ -55,8 +55,8 @@ GEM
     hashdiff (1.1.0)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (7.0.0.1.0-aarch64-linux)
-    libdatadog (7.0.0.1.0-x86_64-linux)
+    libdatadog (8.0.0.1.0-aarch64-linux)
+    libdatadog (8.0.0.1.0-x86_64-linux)
     libddwaf (1.14.0.0.0-aarch64-linux)
       ffi (~> 1.0)
     libddwaf (1.14.0.0.0-x86_64-linux)

--- a/gemfiles/ruby_2.5_graphql_1.13.gemfile.lock
+++ b/gemfiles/ruby_2.5_graphql_1.13.gemfile.lock
@@ -14,7 +14,7 @@ PATH
     ddtrace (1.21.1)
       datadog-ci (~> 0.8.1)
       debase-ruby_core_source (= 3.3.1)
-      libdatadog (~> 7.0.0.1.0)
+      libdatadog (~> 8.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
 
@@ -55,8 +55,8 @@ GEM
     hashdiff (1.1.0)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (7.0.0.1.0-aarch64-linux)
-    libdatadog (7.0.0.1.0-x86_64-linux)
+    libdatadog (8.0.0.1.0-aarch64-linux)
+    libdatadog (8.0.0.1.0-x86_64-linux)
     libddwaf (1.14.0.0.0-aarch64-linux)
       ffi (~> 1.0)
     libddwaf (1.14.0.0.0-x86_64-linux)

--- a/gemfiles/ruby_2.5_graphql_2.0.gemfile.lock
+++ b/gemfiles/ruby_2.5_graphql_2.0.gemfile.lock
@@ -14,7 +14,7 @@ PATH
     ddtrace (1.21.1)
       datadog-ci (~> 0.8.1)
       debase-ruby_core_source (= 3.3.1)
-      libdatadog (~> 7.0.0.1.0)
+      libdatadog (~> 8.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
 
@@ -55,8 +55,8 @@ GEM
     hashdiff (1.1.0)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (7.0.0.1.0-aarch64-linux)
-    libdatadog (7.0.0.1.0-x86_64-linux)
+    libdatadog (8.0.0.1.0-aarch64-linux)
+    libdatadog (8.0.0.1.0-x86_64-linux)
     libddwaf (1.14.0.0.0-aarch64-linux)
       ffi (~> 1.0)
     libddwaf (1.14.0.0.0-x86_64-linux)

--- a/gemfiles/ruby_2.5_hanami_1.gemfile.lock
+++ b/gemfiles/ruby_2.5_hanami_1.gemfile.lock
@@ -14,7 +14,7 @@ PATH
     ddtrace (1.21.1)
       datadog-ci (~> 0.8.1)
       debase-ruby_core_source (= 3.3.1)
-      libdatadog (~> 7.0.0.1.0)
+      libdatadog (~> 8.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
 
@@ -129,8 +129,8 @@ GEM
     io-wait (0.3.0)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (7.0.0.1.0-aarch64-linux)
-    libdatadog (7.0.0.1.0-x86_64-linux)
+    libdatadog (8.0.0.1.0-aarch64-linux)
+    libdatadog (8.0.0.1.0-x86_64-linux)
     libddwaf (1.14.0.0.0-aarch64-linux)
       ffi (~> 1.0)
     libddwaf (1.14.0.0.0-x86_64-linux)

--- a/gemfiles/ruby_2.5_http.gemfile.lock
+++ b/gemfiles/ruby_2.5_http.gemfile.lock
@@ -14,7 +14,7 @@ PATH
     ddtrace (1.21.1)
       datadog-ci (~> 0.8.1)
       debase-ruby_core_source (= 3.3.1)
-      libdatadog (~> 7.0.0.1.0)
+      libdatadog (~> 8.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
 
@@ -94,8 +94,8 @@ GEM
     httpclient (2.8.3)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (7.0.0.1.0-aarch64-linux)
-    libdatadog (7.0.0.1.0-x86_64-linux)
+    libdatadog (8.0.0.1.0-aarch64-linux)
+    libdatadog (8.0.0.1.0-x86_64-linux)
     libddwaf (1.14.0.0.0-aarch64-linux)
       ffi (~> 1.0)
     libddwaf (1.14.0.0.0-x86_64-linux)

--- a/gemfiles/ruby_2.5_multi_rack_app.gemfile.lock
+++ b/gemfiles/ruby_2.5_multi_rack_app.gemfile.lock
@@ -14,7 +14,7 @@ PATH
     ddtrace (1.21.1)
       datadog-ci (~> 0.8.1)
       debase-ruby_core_source (= 3.3.1)
-      libdatadog (~> 7.0.0.1.0)
+      libdatadog (~> 8.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
 
@@ -131,8 +131,8 @@ GEM
     io-wait (0.3.1)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (7.0.0.1.0-aarch64-linux)
-    libdatadog (7.0.0.1.0-x86_64-linux)
+    libdatadog (8.0.0.1.0-aarch64-linux)
+    libdatadog (8.0.0.1.0-x86_64-linux)
     libddwaf (1.14.0.0.0-aarch64-linux)
       ffi (~> 1.0)
     libddwaf (1.14.0.0.0-x86_64-linux)

--- a/gemfiles/ruby_2.5_opensearch_2.gemfile.lock
+++ b/gemfiles/ruby_2.5_opensearch_2.gemfile.lock
@@ -14,7 +14,7 @@ PATH
     ddtrace (1.21.1)
       datadog-ci (~> 0.8.1)
       debase-ruby_core_source (= 3.3.1)
-      libdatadog (~> 7.0.0.1.0)
+      libdatadog (~> 8.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
 
@@ -77,8 +77,8 @@ GEM
     hashdiff (1.0.1)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (7.0.0.1.0-aarch64-linux)
-    libdatadog (7.0.0.1.0-x86_64-linux)
+    libdatadog (8.0.0.1.0-aarch64-linux)
+    libdatadog (8.0.0.1.0-x86_64-linux)
     libddwaf (1.14.0.0.0-aarch64-linux)
       ffi (~> 1.0)
     libddwaf (1.14.0.0.0-x86_64-linux)

--- a/gemfiles/ruby_2.5_opensearch_3.gemfile.lock
+++ b/gemfiles/ruby_2.5_opensearch_3.gemfile.lock
@@ -14,7 +14,7 @@ PATH
     ddtrace (1.21.1)
       datadog-ci (~> 0.8.1)
       debase-ruby_core_source (= 3.3.1)
-      libdatadog (~> 7.0.0.1.0)
+      libdatadog (~> 8.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
 
@@ -77,8 +77,8 @@ GEM
     hashdiff (1.0.1)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (7.0.0.1.0-aarch64-linux)
-    libdatadog (7.0.0.1.0-x86_64-linux)
+    libdatadog (8.0.0.1.0-aarch64-linux)
+    libdatadog (8.0.0.1.0-x86_64-linux)
     libddwaf (1.14.0.0.0-aarch64-linux)
       ffi (~> 1.0)
     libddwaf (1.14.0.0.0-x86_64-linux)

--- a/gemfiles/ruby_2.5_opentracing.gemfile.lock
+++ b/gemfiles/ruby_2.5_opentracing.gemfile.lock
@@ -14,7 +14,7 @@ PATH
     ddtrace (1.21.1)
       datadog-ci (~> 0.8.1)
       debase-ruby_core_source (= 3.3.1)
-      libdatadog (~> 7.0.0.1.0)
+      libdatadog (~> 8.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
 
@@ -54,8 +54,8 @@ GEM
     hashdiff (1.0.1)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (7.0.0.1.0-aarch64-linux)
-    libdatadog (7.0.0.1.0-x86_64-linux)
+    libdatadog (8.0.0.1.0-aarch64-linux)
+    libdatadog (8.0.0.1.0-x86_64-linux)
     libddwaf (1.14.0.0.0-aarch64-linux)
       ffi (~> 1.0)
     libddwaf (1.14.0.0.0-x86_64-linux)

--- a/gemfiles/ruby_2.5_rack_1.gemfile.lock
+++ b/gemfiles/ruby_2.5_rack_1.gemfile.lock
@@ -14,7 +14,7 @@ PATH
     ddtrace (1.21.1)
       datadog-ci (~> 0.8.1)
       debase-ruby_core_source (= 3.3.1)
-      libdatadog (~> 7.0.0.1.0)
+      libdatadog (~> 8.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
 
@@ -53,8 +53,8 @@ GEM
     hashdiff (1.0.1)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (7.0.0.1.0-aarch64-linux)
-    libdatadog (7.0.0.1.0-x86_64-linux)
+    libdatadog (8.0.0.1.0-aarch64-linux)
+    libdatadog (8.0.0.1.0-x86_64-linux)
     libddwaf (1.14.0.0.0-aarch64-linux)
       ffi (~> 1.0)
     libddwaf (1.14.0.0.0-x86_64-linux)

--- a/gemfiles/ruby_2.5_rack_2.gemfile.lock
+++ b/gemfiles/ruby_2.5_rack_2.gemfile.lock
@@ -14,7 +14,7 @@ PATH
     ddtrace (1.21.1)
       datadog-ci (~> 0.8.1)
       debase-ruby_core_source (= 3.3.1)
-      libdatadog (~> 7.0.0.1.0)
+      libdatadog (~> 8.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
 
@@ -53,8 +53,8 @@ GEM
     hashdiff (1.0.1)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (7.0.0.1.0-aarch64-linux)
-    libdatadog (7.0.0.1.0-x86_64-linux)
+    libdatadog (8.0.0.1.0-aarch64-linux)
+    libdatadog (8.0.0.1.0-x86_64-linux)
     libddwaf (1.14.0.0.0-aarch64-linux)
       ffi (~> 1.0)
     libddwaf (1.14.0.0.0-x86_64-linux)

--- a/gemfiles/ruby_2.5_rack_3.gemfile.lock
+++ b/gemfiles/ruby_2.5_rack_3.gemfile.lock
@@ -14,7 +14,7 @@ PATH
     ddtrace (1.21.1)
       datadog-ci (~> 0.8.1)
       debase-ruby_core_source (= 3.3.1)
-      libdatadog (~> 7.0.0.1.0)
+      libdatadog (~> 8.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
 
@@ -53,8 +53,8 @@ GEM
     hashdiff (1.0.1)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (7.0.0.1.0-aarch64-linux)
-    libdatadog (7.0.0.1.0-x86_64-linux)
+    libdatadog (8.0.0.1.0-aarch64-linux)
+    libdatadog (8.0.0.1.0-x86_64-linux)
     libddwaf (1.14.0.0.0-aarch64-linux)
       ffi (~> 1.0)
     libddwaf (1.14.0.0.0-x86_64-linux)

--- a/gemfiles/ruby_2.5_rails5_mysql2.gemfile.lock
+++ b/gemfiles/ruby_2.5_rails5_mysql2.gemfile.lock
@@ -14,7 +14,7 @@ PATH
     ddtrace (1.21.1)
       datadog-ci (~> 0.8.1)
       debase-ruby_core_source (= 3.3.1)
-      libdatadog (~> 7.0.0.1.0)
+      libdatadog (~> 8.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
 
@@ -101,8 +101,8 @@ GEM
       concurrent-ruby (~> 1.0)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (7.0.0.1.0-aarch64-linux)
-    libdatadog (7.0.0.1.0-x86_64-linux)
+    libdatadog (8.0.0.1.0-aarch64-linux)
+    libdatadog (8.0.0.1.0-x86_64-linux)
     libddwaf (1.14.0.0.0-aarch64-linux)
       ffi (~> 1.0)
     libddwaf (1.14.0.0.0-x86_64-linux)

--- a/gemfiles/ruby_2.5_rails5_postgres.gemfile.lock
+++ b/gemfiles/ruby_2.5_rails5_postgres.gemfile.lock
@@ -14,7 +14,7 @@ PATH
     ddtrace (1.21.1)
       datadog-ci (~> 0.8.1)
       debase-ruby_core_source (= 3.3.1)
-      libdatadog (~> 7.0.0.1.0)
+      libdatadog (~> 8.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
 
@@ -103,8 +103,8 @@ GEM
     io-wait (0.3.0)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (7.0.0.1.0-aarch64-linux)
-    libdatadog (7.0.0.1.0-x86_64-linux)
+    libdatadog (8.0.0.1.0-aarch64-linux)
+    libdatadog (8.0.0.1.0-x86_64-linux)
     libddwaf (1.14.0.0.0-aarch64-linux)
       ffi (~> 1.0)
     libddwaf (1.14.0.0.0-x86_64-linux)

--- a/gemfiles/ruby_2.5_rails5_postgres_redis.gemfile.lock
+++ b/gemfiles/ruby_2.5_rails5_postgres_redis.gemfile.lock
@@ -14,7 +14,7 @@ PATH
     ddtrace (1.21.1)
       datadog-ci (~> 0.8.1)
       debase-ruby_core_source (= 3.3.1)
-      libdatadog (~> 7.0.0.1.0)
+      libdatadog (~> 8.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
 
@@ -104,8 +104,8 @@ GEM
     io-wait (0.3.0)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (7.0.0.1.0-aarch64-linux)
-    libdatadog (7.0.0.1.0-x86_64-linux)
+    libdatadog (8.0.0.1.0-aarch64-linux)
+    libdatadog (8.0.0.1.0-x86_64-linux)
     libddwaf (1.14.0.0.0-aarch64-linux)
       ffi (~> 1.0)
     libddwaf (1.14.0.0.0-x86_64-linux)

--- a/gemfiles/ruby_2.5_rails5_postgres_redis_activesupport.gemfile.lock
+++ b/gemfiles/ruby_2.5_rails5_postgres_redis_activesupport.gemfile.lock
@@ -14,7 +14,7 @@ PATH
     ddtrace (1.21.1)
       datadog-ci (~> 0.8.1)
       debase-ruby_core_source (= 3.3.1)
-      libdatadog (~> 7.0.0.1.0)
+      libdatadog (~> 8.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
 
@@ -103,8 +103,8 @@ GEM
     io-wait (0.3.0)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (7.0.0.1.0-aarch64-linux)
-    libdatadog (7.0.0.1.0-x86_64-linux)
+    libdatadog (8.0.0.1.0-aarch64-linux)
+    libdatadog (8.0.0.1.0-x86_64-linux)
     libddwaf (1.14.0.0.0-aarch64-linux)
       ffi (~> 1.0)
     libddwaf (1.14.0.0.0-x86_64-linux)

--- a/gemfiles/ruby_2.5_rails5_postgres_sidekiq.gemfile.lock
+++ b/gemfiles/ruby_2.5_rails5_postgres_sidekiq.gemfile.lock
@@ -14,7 +14,7 @@ PATH
     ddtrace (1.21.1)
       datadog-ci (~> 0.8.1)
       debase-ruby_core_source (= 3.3.1)
-      libdatadog (~> 7.0.0.1.0)
+      libdatadog (~> 8.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
 
@@ -104,8 +104,8 @@ GEM
     io-wait (0.3.0)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (7.0.0.1.0-aarch64-linux)
-    libdatadog (7.0.0.1.0-x86_64-linux)
+    libdatadog (8.0.0.1.0-aarch64-linux)
+    libdatadog (8.0.0.1.0-x86_64-linux)
     libddwaf (1.14.0.0.0-aarch64-linux)
       ffi (~> 1.0)
     libddwaf (1.14.0.0.0-x86_64-linux)

--- a/gemfiles/ruby_2.5_rails5_semantic_logger.gemfile.lock
+++ b/gemfiles/ruby_2.5_rails5_semantic_logger.gemfile.lock
@@ -14,7 +14,7 @@ PATH
     ddtrace (1.21.1)
       datadog-ci (~> 0.8.1)
       debase-ruby_core_source (= 3.3.1)
-      libdatadog (~> 7.0.0.1.0)
+      libdatadog (~> 8.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
 
@@ -103,8 +103,8 @@ GEM
     io-wait (0.3.0)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (7.0.0.1.0-aarch64-linux)
-    libdatadog (7.0.0.1.0-x86_64-linux)
+    libdatadog (8.0.0.1.0-aarch64-linux)
+    libdatadog (8.0.0.1.0-x86_64-linux)
     libddwaf (1.14.0.0.0-aarch64-linux)
       ffi (~> 1.0)
     libddwaf (1.14.0.0.0-x86_64-linux)

--- a/gemfiles/ruby_2.5_rails61_mysql2.gemfile.lock
+++ b/gemfiles/ruby_2.5_rails61_mysql2.gemfile.lock
@@ -14,7 +14,7 @@ PATH
     ddtrace (1.21.1)
       datadog-ci (~> 0.8.1)
       debase-ruby_core_source (= 3.3.1)
-      libdatadog (~> 7.0.0.1.0)
+      libdatadog (~> 8.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
 
@@ -118,8 +118,8 @@ GEM
       concurrent-ruby (~> 1.0)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (7.0.0.1.0-aarch64-linux)
-    libdatadog (7.0.0.1.0-x86_64-linux)
+    libdatadog (8.0.0.1.0-aarch64-linux)
+    libdatadog (8.0.0.1.0-x86_64-linux)
     libddwaf (1.14.0.0.0-aarch64-linux)
       ffi (~> 1.0)
     libddwaf (1.14.0.0.0-x86_64-linux)

--- a/gemfiles/ruby_2.5_rails61_postgres.gemfile.lock
+++ b/gemfiles/ruby_2.5_rails61_postgres.gemfile.lock
@@ -14,7 +14,7 @@ PATH
     ddtrace (1.21.1)
       datadog-ci (~> 0.8.1)
       debase-ruby_core_source (= 3.3.1)
-      libdatadog (~> 7.0.0.1.0)
+      libdatadog (~> 8.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
 
@@ -120,8 +120,8 @@ GEM
     io-wait (0.3.0)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (7.0.0.1.0-aarch64-linux)
-    libdatadog (7.0.0.1.0-x86_64-linux)
+    libdatadog (8.0.0.1.0-aarch64-linux)
+    libdatadog (8.0.0.1.0-x86_64-linux)
     libddwaf (1.14.0.0.0-aarch64-linux)
       ffi (~> 1.0)
     libddwaf (1.14.0.0.0-x86_64-linux)

--- a/gemfiles/ruby_2.5_rails61_postgres_redis.gemfile.lock
+++ b/gemfiles/ruby_2.5_rails61_postgres_redis.gemfile.lock
@@ -14,7 +14,7 @@ PATH
     ddtrace (1.21.1)
       datadog-ci (~> 0.8.1)
       debase-ruby_core_source (= 3.3.1)
-      libdatadog (~> 7.0.0.1.0)
+      libdatadog (~> 8.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
 
@@ -121,8 +121,8 @@ GEM
     io-wait (0.3.0)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (7.0.0.1.0-aarch64-linux)
-    libdatadog (7.0.0.1.0-x86_64-linux)
+    libdatadog (8.0.0.1.0-aarch64-linux)
+    libdatadog (8.0.0.1.0-x86_64-linux)
     libddwaf (1.14.0.0.0-aarch64-linux)
       ffi (~> 1.0)
     libddwaf (1.14.0.0.0-x86_64-linux)

--- a/gemfiles/ruby_2.5_rails61_postgres_sidekiq.gemfile.lock
+++ b/gemfiles/ruby_2.5_rails61_postgres_sidekiq.gemfile.lock
@@ -14,7 +14,7 @@ PATH
     ddtrace (1.21.1)
       datadog-ci (~> 0.8.1)
       debase-ruby_core_source (= 3.3.1)
-      libdatadog (~> 7.0.0.1.0)
+      libdatadog (~> 8.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
 
@@ -121,8 +121,8 @@ GEM
     io-wait (0.3.0)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (7.0.0.1.0-aarch64-linux)
-    libdatadog (7.0.0.1.0-x86_64-linux)
+    libdatadog (8.0.0.1.0-aarch64-linux)
+    libdatadog (8.0.0.1.0-x86_64-linux)
     libddwaf (1.14.0.0.0-aarch64-linux)
       ffi (~> 1.0)
     libddwaf (1.14.0.0.0-x86_64-linux)

--- a/gemfiles/ruby_2.5_rails61_semantic_logger.gemfile.lock
+++ b/gemfiles/ruby_2.5_rails61_semantic_logger.gemfile.lock
@@ -14,7 +14,7 @@ PATH
     ddtrace (1.21.1)
       datadog-ci (~> 0.8.1)
       debase-ruby_core_source (= 3.3.1)
-      libdatadog (~> 7.0.0.1.0)
+      libdatadog (~> 8.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
 
@@ -120,8 +120,8 @@ GEM
     io-wait (0.3.0)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (7.0.0.1.0-aarch64-linux)
-    libdatadog (7.0.0.1.0-x86_64-linux)
+    libdatadog (8.0.0.1.0-aarch64-linux)
+    libdatadog (8.0.0.1.0-x86_64-linux)
     libddwaf (1.14.0.0.0-aarch64-linux)
       ffi (~> 1.0)
     libddwaf (1.14.0.0.0-x86_64-linux)

--- a/gemfiles/ruby_2.5_rails6_mysql2.gemfile.lock
+++ b/gemfiles/ruby_2.5_rails6_mysql2.gemfile.lock
@@ -14,7 +14,7 @@ PATH
     ddtrace (1.21.1)
       datadog-ci (~> 0.8.1)
       debase-ruby_core_source (= 3.3.1)
-      libdatadog (~> 7.0.0.1.0)
+      libdatadog (~> 8.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
 
@@ -114,8 +114,8 @@ GEM
       concurrent-ruby (~> 1.0)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (7.0.0.1.0-aarch64-linux)
-    libdatadog (7.0.0.1.0-x86_64-linux)
+    libdatadog (8.0.0.1.0-aarch64-linux)
+    libdatadog (8.0.0.1.0-x86_64-linux)
     libddwaf (1.14.0.0.0-aarch64-linux)
       ffi (~> 1.0)
     libddwaf (1.14.0.0.0-x86_64-linux)

--- a/gemfiles/ruby_2.5_rails6_postgres.gemfile.lock
+++ b/gemfiles/ruby_2.5_rails6_postgres.gemfile.lock
@@ -14,7 +14,7 @@ PATH
     ddtrace (1.21.1)
       datadog-ci (~> 0.8.1)
       debase-ruby_core_source (= 3.3.1)
-      libdatadog (~> 7.0.0.1.0)
+      libdatadog (~> 8.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
 
@@ -116,8 +116,8 @@ GEM
     io-wait (0.3.0)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (7.0.0.1.0-aarch64-linux)
-    libdatadog (7.0.0.1.0-x86_64-linux)
+    libdatadog (8.0.0.1.0-aarch64-linux)
+    libdatadog (8.0.0.1.0-x86_64-linux)
     libddwaf (1.14.0.0.0-aarch64-linux)
       ffi (~> 1.0)
     libddwaf (1.14.0.0.0-x86_64-linux)

--- a/gemfiles/ruby_2.5_rails6_postgres_redis.gemfile.lock
+++ b/gemfiles/ruby_2.5_rails6_postgres_redis.gemfile.lock
@@ -14,7 +14,7 @@ PATH
     ddtrace (1.21.1)
       datadog-ci (~> 0.8.1)
       debase-ruby_core_source (= 3.3.1)
-      libdatadog (~> 7.0.0.1.0)
+      libdatadog (~> 8.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
 
@@ -117,8 +117,8 @@ GEM
     io-wait (0.3.0)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (7.0.0.1.0-aarch64-linux)
-    libdatadog (7.0.0.1.0-x86_64-linux)
+    libdatadog (8.0.0.1.0-aarch64-linux)
+    libdatadog (8.0.0.1.0-x86_64-linux)
     libddwaf (1.14.0.0.0-aarch64-linux)
       ffi (~> 1.0)
     libddwaf (1.14.0.0.0-x86_64-linux)

--- a/gemfiles/ruby_2.5_rails6_postgres_redis_activesupport.gemfile.lock
+++ b/gemfiles/ruby_2.5_rails6_postgres_redis_activesupport.gemfile.lock
@@ -14,7 +14,7 @@ PATH
     ddtrace (1.21.1)
       datadog-ci (~> 0.8.1)
       debase-ruby_core_source (= 3.3.1)
-      libdatadog (~> 7.0.0.1.0)
+      libdatadog (~> 8.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
 
@@ -116,8 +116,8 @@ GEM
     io-wait (0.3.0)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (7.0.0.1.0-aarch64-linux)
-    libdatadog (7.0.0.1.0-x86_64-linux)
+    libdatadog (8.0.0.1.0-aarch64-linux)
+    libdatadog (8.0.0.1.0-x86_64-linux)
     libddwaf (1.14.0.0.0-aarch64-linux)
       ffi (~> 1.0)
     libddwaf (1.14.0.0.0-x86_64-linux)

--- a/gemfiles/ruby_2.5_rails6_postgres_sidekiq.gemfile.lock
+++ b/gemfiles/ruby_2.5_rails6_postgres_sidekiq.gemfile.lock
@@ -14,7 +14,7 @@ PATH
     ddtrace (1.21.1)
       datadog-ci (~> 0.8.1)
       debase-ruby_core_source (= 3.3.1)
-      libdatadog (~> 7.0.0.1.0)
+      libdatadog (~> 8.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
 
@@ -117,8 +117,8 @@ GEM
     io-wait (0.3.0)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (7.0.0.1.0-aarch64-linux)
-    libdatadog (7.0.0.1.0-x86_64-linux)
+    libdatadog (8.0.0.1.0-aarch64-linux)
+    libdatadog (8.0.0.1.0-x86_64-linux)
     libddwaf (1.14.0.0.0-aarch64-linux)
       ffi (~> 1.0)
     libddwaf (1.14.0.0.0-x86_64-linux)

--- a/gemfiles/ruby_2.5_rails6_semantic_logger.gemfile.lock
+++ b/gemfiles/ruby_2.5_rails6_semantic_logger.gemfile.lock
@@ -14,7 +14,7 @@ PATH
     ddtrace (1.21.1)
       datadog-ci (~> 0.8.1)
       debase-ruby_core_source (= 3.3.1)
-      libdatadog (~> 7.0.0.1.0)
+      libdatadog (~> 8.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
 
@@ -116,8 +116,8 @@ GEM
     io-wait (0.3.0)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (7.0.0.1.0-aarch64-linux)
-    libdatadog (7.0.0.1.0-x86_64-linux)
+    libdatadog (8.0.0.1.0-aarch64-linux)
+    libdatadog (8.0.0.1.0-x86_64-linux)
     libddwaf (1.14.0.0.0-aarch64-linux)
       ffi (~> 1.0)
     libddwaf (1.14.0.0.0-x86_64-linux)

--- a/gemfiles/ruby_2.5_redis_3.gemfile.lock
+++ b/gemfiles/ruby_2.5_redis_3.gemfile.lock
@@ -14,7 +14,7 @@ PATH
     ddtrace (1.21.1)
       datadog-ci (~> 0.8.1)
       debase-ruby_core_source (= 3.3.1)
-      libdatadog (~> 7.0.0.1.0)
+      libdatadog (~> 8.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
 
@@ -53,8 +53,8 @@ GEM
     hashdiff (1.0.1)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (7.0.0.1.0-aarch64-linux)
-    libdatadog (7.0.0.1.0-x86_64-linux)
+    libdatadog (8.0.0.1.0-aarch64-linux)
+    libdatadog (8.0.0.1.0-x86_64-linux)
     libddwaf (1.14.0.0.0-aarch64-linux)
       ffi (~> 1.0)
     libddwaf (1.14.0.0.0-x86_64-linux)

--- a/gemfiles/ruby_2.5_redis_4.gemfile.lock
+++ b/gemfiles/ruby_2.5_redis_4.gemfile.lock
@@ -14,7 +14,7 @@ PATH
     ddtrace (1.21.1)
       datadog-ci (~> 0.8.1)
       debase-ruby_core_source (= 3.3.1)
-      libdatadog (~> 7.0.0.1.0)
+      libdatadog (~> 8.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
 
@@ -53,8 +53,8 @@ GEM
     hashdiff (1.0.1)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (7.0.0.1.0-aarch64-linux)
-    libdatadog (7.0.0.1.0-x86_64-linux)
+    libdatadog (8.0.0.1.0-aarch64-linux)
+    libdatadog (8.0.0.1.0-x86_64-linux)
     libddwaf (1.14.0.0.0-aarch64-linux)
       ffi (~> 1.0)
     libddwaf (1.14.0.0.0-x86_64-linux)

--- a/gemfiles/ruby_2.5_redis_5.gemfile.lock
+++ b/gemfiles/ruby_2.5_redis_5.gemfile.lock
@@ -14,7 +14,7 @@ PATH
     ddtrace (1.21.1)
       datadog-ci (~> 0.8.1)
       debase-ruby_core_source (= 3.3.1)
-      libdatadog (~> 7.0.0.1.0)
+      libdatadog (~> 8.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
 
@@ -54,8 +54,8 @@ GEM
     hashdiff (1.0.1)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (7.0.0.1.0-aarch64-linux)
-    libdatadog (7.0.0.1.0-x86_64-linux)
+    libdatadog (8.0.0.1.0-aarch64-linux)
+    libdatadog (8.0.0.1.0-x86_64-linux)
     libddwaf (1.14.0.0.0-aarch64-linux)
       ffi (~> 1.0)
     libddwaf (1.14.0.0.0-x86_64-linux)

--- a/gemfiles/ruby_2.5_relational_db.gemfile.lock
+++ b/gemfiles/ruby_2.5_relational_db.gemfile.lock
@@ -14,7 +14,7 @@ PATH
     ddtrace (1.21.1)
       datadog-ci (~> 0.8.1)
       debase-ruby_core_source (= 3.3.1)
-      libdatadog (~> 7.0.0.1.0)
+      libdatadog (~> 8.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
 
@@ -72,8 +72,8 @@ GEM
       concurrent-ruby (~> 1.0)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (7.0.0.1.0-aarch64-linux)
-    libdatadog (7.0.0.1.0-x86_64-linux)
+    libdatadog (8.0.0.1.0-aarch64-linux)
+    libdatadog (8.0.0.1.0-x86_64-linux)
     libddwaf (1.14.0.0.0-aarch64-linux)
       ffi (~> 1.0)
     libddwaf (1.14.0.0.0-x86_64-linux)

--- a/gemfiles/ruby_2.5_resque2_redis3.gemfile.lock
+++ b/gemfiles/ruby_2.5_resque2_redis3.gemfile.lock
@@ -14,7 +14,7 @@ PATH
     ddtrace (1.21.1)
       datadog-ci (~> 0.8.1)
       debase-ruby_core_source (= 3.3.1)
-      libdatadog (~> 7.0.0.1.0)
+      libdatadog (~> 8.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
 
@@ -53,8 +53,8 @@ GEM
     hashdiff (1.0.1)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (7.0.0.1.0-aarch64-linux)
-    libdatadog (7.0.0.1.0-x86_64-linux)
+    libdatadog (8.0.0.1.0-aarch64-linux)
+    libdatadog (8.0.0.1.0-x86_64-linux)
     libddwaf (1.14.0.0.0-aarch64-linux)
       ffi (~> 1.0)
     libddwaf (1.14.0.0.0-x86_64-linux)

--- a/gemfiles/ruby_2.5_resque2_redis4.gemfile.lock
+++ b/gemfiles/ruby_2.5_resque2_redis4.gemfile.lock
@@ -14,7 +14,7 @@ PATH
     ddtrace (1.21.1)
       datadog-ci (~> 0.8.1)
       debase-ruby_core_source (= 3.3.1)
-      libdatadog (~> 7.0.0.1.0)
+      libdatadog (~> 8.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
 
@@ -54,8 +54,8 @@ GEM
     hashdiff (1.0.1)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (7.0.0.1.0-aarch64-linux)
-    libdatadog (7.0.0.1.0-x86_64-linux)
+    libdatadog (8.0.0.1.0-aarch64-linux)
+    libdatadog (8.0.0.1.0-x86_64-linux)
     libddwaf (1.14.0.0.0-aarch64-linux)
       ffi (~> 1.0)
     libddwaf (1.14.0.0.0-x86_64-linux)

--- a/gemfiles/ruby_2.5_sinatra.gemfile.lock
+++ b/gemfiles/ruby_2.5_sinatra.gemfile.lock
@@ -14,7 +14,7 @@ PATH
     ddtrace (1.21.1)
       datadog-ci (~> 0.8.1)
       debase-ruby_core_source (= 3.3.1)
-      libdatadog (~> 7.0.0.1.0)
+      libdatadog (~> 8.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
 
@@ -53,8 +53,8 @@ GEM
     hashdiff (1.0.1)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (7.0.0.1.0-aarch64-linux)
-    libdatadog (7.0.0.1.0-x86_64-linux)
+    libdatadog (8.0.0.1.0-aarch64-linux)
+    libdatadog (8.0.0.1.0-x86_64-linux)
     libddwaf (1.14.0.0.0-aarch64-linux)
       ffi (~> 1.0)
     libddwaf (1.14.0.0.0-x86_64-linux)

--- a/gemfiles/ruby_2.6_activesupport.gemfile.lock
+++ b/gemfiles/ruby_2.6_activesupport.gemfile.lock
@@ -14,7 +14,7 @@ PATH
     ddtrace (1.21.1)
       datadog-ci (~> 0.8.1)
       debase-ruby_core_source (= 3.3.1)
-      libdatadog (~> 7.0.0.1.0)
+      libdatadog (~> 8.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
 
@@ -117,8 +117,8 @@ GEM
       addressable (>= 2.4)
     jsonapi-renderer (0.2.2)
     king_konf (1.0.1)
-    libdatadog (7.0.0.1.0-aarch64-linux)
-    libdatadog (7.0.0.1.0-x86_64-linux)
+    libdatadog (8.0.0.1.0-aarch64-linux)
+    libdatadog (8.0.0.1.0-x86_64-linux)
     libddwaf (1.14.0.0.0-aarch64-linux)
       ffi (~> 1.0)
     libddwaf (1.14.0.0.0-x86_64-linux)

--- a/gemfiles/ruby_2.6_aws.gemfile.lock
+++ b/gemfiles/ruby_2.6_aws.gemfile.lock
@@ -14,7 +14,7 @@ PATH
     ddtrace (1.21.1)
       datadog-ci (~> 0.8.1)
       debase-ruby_core_source (= 3.3.1)
-      libdatadog (~> 7.0.0.1.0)
+      libdatadog (~> 8.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
 
@@ -1478,8 +1478,8 @@ GEM
     json (2.6.3)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (7.0.0.1.0-aarch64-linux)
-    libdatadog (7.0.0.1.0-x86_64-linux)
+    libdatadog (8.0.0.1.0-aarch64-linux)
+    libdatadog (8.0.0.1.0-x86_64-linux)
     libddwaf (1.14.0.0.0-aarch64-linux)
       ffi (~> 1.0)
     libddwaf (1.14.0.0.0-x86_64-linux)

--- a/gemfiles/ruby_2.6_contrib.gemfile.lock
+++ b/gemfiles/ruby_2.6_contrib.gemfile.lock
@@ -14,7 +14,7 @@ PATH
     ddtrace (1.21.1)
       datadog-ci (~> 0.8.1)
       debase-ruby_core_source (= 3.3.1)
-      libdatadog (~> 7.0.0.1.0)
+      libdatadog (~> 8.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
 
@@ -71,8 +71,8 @@ GEM
     json (2.6.3)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (7.0.0.1.0-aarch64-linux)
-    libdatadog (7.0.0.1.0-x86_64-linux)
+    libdatadog (8.0.0.1.0-aarch64-linux)
+    libdatadog (8.0.0.1.0-x86_64-linux)
     libddwaf (1.14.0.0.0-aarch64-linux)
       ffi (~> 1.0)
     libddwaf (1.14.0.0.0-x86_64-linux)

--- a/gemfiles/ruby_2.6_contrib_old.gemfile.lock
+++ b/gemfiles/ruby_2.6_contrib_old.gemfile.lock
@@ -14,7 +14,7 @@ PATH
     ddtrace (1.21.1)
       datadog-ci (~> 0.8.1)
       debase-ruby_core_source (= 3.3.1)
-      libdatadog (~> 7.0.0.1.0)
+      libdatadog (~> 8.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
 
@@ -67,8 +67,8 @@ GEM
     json (2.6.3)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (7.0.0.1.0-aarch64-linux)
-    libdatadog (7.0.0.1.0-x86_64-linux)
+    libdatadog (8.0.0.1.0-aarch64-linux)
+    libdatadog (8.0.0.1.0-x86_64-linux)
     libddwaf (1.14.0.0.0-aarch64-linux)
       ffi (~> 1.0)
     libddwaf (1.14.0.0.0-x86_64-linux)

--- a/gemfiles/ruby_2.6_core_old.gemfile.lock
+++ b/gemfiles/ruby_2.6_core_old.gemfile.lock
@@ -14,7 +14,7 @@ PATH
     ddtrace (1.21.1)
       datadog-ci (~> 0.8.1)
       debase-ruby_core_source (= 3.3.1)
-      libdatadog (~> 7.0.0.1.0)
+      libdatadog (~> 8.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
 
@@ -56,8 +56,8 @@ GEM
     json (2.6.3)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (7.0.0.1.0-aarch64-linux)
-    libdatadog (7.0.0.1.0-x86_64-linux)
+    libdatadog (8.0.0.1.0-aarch64-linux)
+    libdatadog (8.0.0.1.0-x86_64-linux)
     libddwaf (1.14.0.0.0-aarch64-linux)
       ffi (~> 1.0)
     libddwaf (1.14.0.0.0-x86_64-linux)

--- a/gemfiles/ruby_2.6_elasticsearch_7.gemfile.lock
+++ b/gemfiles/ruby_2.6_elasticsearch_7.gemfile.lock
@@ -14,7 +14,7 @@ PATH
     ddtrace (1.21.1)
       datadog-ci (~> 0.8.1)
       debase-ruby_core_source (= 3.3.1)
-      libdatadog (~> 7.0.0.1.0)
+      libdatadog (~> 8.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
 
@@ -88,8 +88,8 @@ GEM
     json (2.6.3)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (7.0.0.1.0-aarch64-linux)
-    libdatadog (7.0.0.1.0-x86_64-linux)
+    libdatadog (8.0.0.1.0-aarch64-linux)
+    libdatadog (8.0.0.1.0-x86_64-linux)
     libddwaf (1.14.0.0.0-aarch64-linux)
       ffi (~> 1.0)
     libddwaf (1.14.0.0.0-x86_64-linux)

--- a/gemfiles/ruby_2.6_elasticsearch_8.gemfile.lock
+++ b/gemfiles/ruby_2.6_elasticsearch_8.gemfile.lock
@@ -14,7 +14,7 @@ PATH
     ddtrace (1.21.1)
       datadog-ci (~> 0.8.1)
       debase-ruby_core_source (= 3.3.1)
-      libdatadog (~> 7.0.0.1.0)
+      libdatadog (~> 8.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
 
@@ -71,8 +71,8 @@ GEM
     json (2.6.3)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (7.0.0.1.0-aarch64-linux)
-    libdatadog (7.0.0.1.0-x86_64-linux)
+    libdatadog (8.0.0.1.0-aarch64-linux)
+    libdatadog (8.0.0.1.0-x86_64-linux)
     libddwaf (1.14.0.0.0-aarch64-linux)
       ffi (~> 1.0)
     libddwaf (1.14.0.0.0-x86_64-linux)

--- a/gemfiles/ruby_2.6_graphql_1.12.gemfile.lock
+++ b/gemfiles/ruby_2.6_graphql_1.12.gemfile.lock
@@ -14,7 +14,7 @@ PATH
     ddtrace (1.21.1)
       datadog-ci (~> 0.8.1)
       debase-ruby_core_source (= 3.3.1)
-      libdatadog (~> 7.0.0.1.0)
+      libdatadog (~> 8.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
 
@@ -58,8 +58,8 @@ GEM
     json (2.7.1)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (7.0.0.1.0-aarch64-linux)
-    libdatadog (7.0.0.1.0-x86_64-linux)
+    libdatadog (8.0.0.1.0-aarch64-linux)
+    libdatadog (8.0.0.1.0-x86_64-linux)
     libddwaf (1.14.0.0.0-aarch64-linux)
       ffi (~> 1.0)
     libddwaf (1.14.0.0.0-x86_64-linux)

--- a/gemfiles/ruby_2.6_graphql_1.13.gemfile.lock
+++ b/gemfiles/ruby_2.6_graphql_1.13.gemfile.lock
@@ -14,7 +14,7 @@ PATH
     ddtrace (1.21.1)
       datadog-ci (~> 0.8.1)
       debase-ruby_core_source (= 3.3.1)
-      libdatadog (~> 7.0.0.1.0)
+      libdatadog (~> 8.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
 
@@ -58,8 +58,8 @@ GEM
     json (2.7.1)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (7.0.0.1.0-aarch64-linux)
-    libdatadog (7.0.0.1.0-x86_64-linux)
+    libdatadog (8.0.0.1.0-aarch64-linux)
+    libdatadog (8.0.0.1.0-x86_64-linux)
     libddwaf (1.14.0.0.0-aarch64-linux)
       ffi (~> 1.0)
     libddwaf (1.14.0.0.0-x86_64-linux)

--- a/gemfiles/ruby_2.6_graphql_2.0.gemfile.lock
+++ b/gemfiles/ruby_2.6_graphql_2.0.gemfile.lock
@@ -14,7 +14,7 @@ PATH
     ddtrace (1.21.1)
       datadog-ci (~> 0.8.1)
       debase-ruby_core_source (= 3.3.1)
-      libdatadog (~> 7.0.0.1.0)
+      libdatadog (~> 8.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
 
@@ -58,8 +58,8 @@ GEM
     json (2.7.1)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (7.0.0.1.0-aarch64-linux)
-    libdatadog (7.0.0.1.0-x86_64-linux)
+    libdatadog (8.0.0.1.0-aarch64-linux)
+    libdatadog (8.0.0.1.0-x86_64-linux)
     libddwaf (1.14.0.0.0-aarch64-linux)
       ffi (~> 1.0)
     libddwaf (1.14.0.0.0-x86_64-linux)

--- a/gemfiles/ruby_2.6_hanami_1.gemfile.lock
+++ b/gemfiles/ruby_2.6_hanami_1.gemfile.lock
@@ -14,7 +14,7 @@ PATH
     ddtrace (1.21.1)
       datadog-ci (~> 0.8.1)
       debase-ruby_core_source (= 3.3.1)
-      libdatadog (~> 7.0.0.1.0)
+      libdatadog (~> 8.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
 
@@ -131,8 +131,8 @@ GEM
     json (2.6.3)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (7.0.0.1.0-aarch64-linux)
-    libdatadog (7.0.0.1.0-x86_64-linux)
+    libdatadog (8.0.0.1.0-aarch64-linux)
+    libdatadog (8.0.0.1.0-x86_64-linux)
     libddwaf (1.14.0.0.0-aarch64-linux)
       ffi (~> 1.0)
     libddwaf (1.14.0.0.0-x86_64-linux)

--- a/gemfiles/ruby_2.6_http.gemfile.lock
+++ b/gemfiles/ruby_2.6_http.gemfile.lock
@@ -14,7 +14,7 @@ PATH
     ddtrace (1.21.1)
       datadog-ci (~> 0.8.1)
       debase-ruby_core_source (= 3.3.1)
-      libdatadog (~> 7.0.0.1.0)
+      libdatadog (~> 8.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
 
@@ -78,8 +78,8 @@ GEM
     json (2.6.3)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (7.0.0.1.0-aarch64-linux)
-    libdatadog (7.0.0.1.0-x86_64-linux)
+    libdatadog (8.0.0.1.0-aarch64-linux)
+    libdatadog (8.0.0.1.0-x86_64-linux)
     libddwaf (1.14.0.0.0-aarch64-linux)
       ffi (~> 1.0)
     libddwaf (1.14.0.0.0-x86_64-linux)

--- a/gemfiles/ruby_2.6_multi_rack_app.gemfile.lock
+++ b/gemfiles/ruby_2.6_multi_rack_app.gemfile.lock
@@ -14,7 +14,7 @@ PATH
     ddtrace (1.21.1)
       datadog-ci (~> 0.8.1)
       debase-ruby_core_source (= 3.3.1)
-      libdatadog (~> 7.0.0.1.0)
+      libdatadog (~> 8.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
 
@@ -134,8 +134,8 @@ GEM
     json (2.7.1)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (7.0.0.1.0-aarch64-linux)
-    libdatadog (7.0.0.1.0-x86_64-linux)
+    libdatadog (8.0.0.1.0-aarch64-linux)
+    libdatadog (8.0.0.1.0-x86_64-linux)
     libddwaf (1.14.0.0.0-aarch64-linux)
       ffi (~> 1.0)
     libddwaf (1.14.0.0.0-x86_64-linux)

--- a/gemfiles/ruby_2.6_opensearch_2.gemfile.lock
+++ b/gemfiles/ruby_2.6_opensearch_2.gemfile.lock
@@ -14,7 +14,7 @@ PATH
     ddtrace (1.21.1)
       datadog-ci (~> 0.8.1)
       debase-ruby_core_source (= 3.3.1)
-      libdatadog (~> 7.0.0.1.0)
+      libdatadog (~> 8.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
 
@@ -63,8 +63,8 @@ GEM
     json (2.6.3)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (7.0.0.1.0-aarch64-linux)
-    libdatadog (7.0.0.1.0-x86_64-linux)
+    libdatadog (8.0.0.1.0-aarch64-linux)
+    libdatadog (8.0.0.1.0-x86_64-linux)
     libddwaf (1.14.0.0.0-aarch64-linux)
       ffi (~> 1.0)
     libddwaf (1.14.0.0.0-x86_64-linux)

--- a/gemfiles/ruby_2.6_opensearch_3.gemfile.lock
+++ b/gemfiles/ruby_2.6_opensearch_3.gemfile.lock
@@ -14,7 +14,7 @@ PATH
     ddtrace (1.21.1)
       datadog-ci (~> 0.8.1)
       debase-ruby_core_source (= 3.3.1)
-      libdatadog (~> 7.0.0.1.0)
+      libdatadog (~> 8.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
 
@@ -63,8 +63,8 @@ GEM
     json (2.6.3)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (7.0.0.1.0-aarch64-linux)
-    libdatadog (7.0.0.1.0-x86_64-linux)
+    libdatadog (8.0.0.1.0-aarch64-linux)
+    libdatadog (8.0.0.1.0-x86_64-linux)
     libddwaf (1.14.0.0.0-aarch64-linux)
       ffi (~> 1.0)
     libddwaf (1.14.0.0.0-x86_64-linux)

--- a/gemfiles/ruby_2.6_opentelemetry.gemfile.lock
+++ b/gemfiles/ruby_2.6_opentelemetry.gemfile.lock
@@ -14,7 +14,7 @@ PATH
     ddtrace (1.21.1)
       datadog-ci (~> 0.8.1)
       debase-ruby_core_source (= 3.3.1)
-      libdatadog (~> 7.0.0.1.0)
+      libdatadog (~> 8.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
 
@@ -56,8 +56,8 @@ GEM
     json (2.6.3)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (7.0.0.1.0-aarch64-linux)
-    libdatadog (7.0.0.1.0-x86_64-linux)
+    libdatadog (8.0.0.1.0-aarch64-linux)
+    libdatadog (8.0.0.1.0-x86_64-linux)
     libddwaf (1.14.0.0.0-aarch64-linux)
       ffi (~> 1.0)
     libddwaf (1.14.0.0.0-x86_64-linux)

--- a/gemfiles/ruby_2.6_opentracing.gemfile.lock
+++ b/gemfiles/ruby_2.6_opentracing.gemfile.lock
@@ -14,7 +14,7 @@ PATH
     ddtrace (1.21.1)
       datadog-ci (~> 0.8.1)
       debase-ruby_core_source (= 3.3.1)
-      libdatadog (~> 7.0.0.1.0)
+      libdatadog (~> 8.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
 
@@ -57,8 +57,8 @@ GEM
     json (2.6.3)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (7.0.0.1.0-aarch64-linux)
-    libdatadog (7.0.0.1.0-x86_64-linux)
+    libdatadog (8.0.0.1.0-aarch64-linux)
+    libdatadog (8.0.0.1.0-x86_64-linux)
     libddwaf (1.14.0.0.0-aarch64-linux)
       ffi (~> 1.0)
     libddwaf (1.14.0.0.0-x86_64-linux)

--- a/gemfiles/ruby_2.6_rack_1.gemfile.lock
+++ b/gemfiles/ruby_2.6_rack_1.gemfile.lock
@@ -14,7 +14,7 @@ PATH
     ddtrace (1.21.1)
       datadog-ci (~> 0.8.1)
       debase-ruby_core_source (= 3.3.1)
-      libdatadog (~> 7.0.0.1.0)
+      libdatadog (~> 8.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
 
@@ -56,8 +56,8 @@ GEM
     json (2.6.3)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (7.0.0.1.0-aarch64-linux)
-    libdatadog (7.0.0.1.0-x86_64-linux)
+    libdatadog (8.0.0.1.0-aarch64-linux)
+    libdatadog (8.0.0.1.0-x86_64-linux)
     libddwaf (1.14.0.0.0-aarch64-linux)
       ffi (~> 1.0)
     libddwaf (1.14.0.0.0-x86_64-linux)

--- a/gemfiles/ruby_2.6_rack_2.gemfile.lock
+++ b/gemfiles/ruby_2.6_rack_2.gemfile.lock
@@ -14,7 +14,7 @@ PATH
     ddtrace (1.21.1)
       datadog-ci (~> 0.8.1)
       debase-ruby_core_source (= 3.3.1)
-      libdatadog (~> 7.0.0.1.0)
+      libdatadog (~> 8.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
 
@@ -56,8 +56,8 @@ GEM
     json (2.6.3)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (7.0.0.1.0-aarch64-linux)
-    libdatadog (7.0.0.1.0-x86_64-linux)
+    libdatadog (8.0.0.1.0-aarch64-linux)
+    libdatadog (8.0.0.1.0-x86_64-linux)
     libddwaf (1.14.0.0.0-aarch64-linux)
       ffi (~> 1.0)
     libddwaf (1.14.0.0.0-x86_64-linux)

--- a/gemfiles/ruby_2.6_rack_3.gemfile.lock
+++ b/gemfiles/ruby_2.6_rack_3.gemfile.lock
@@ -14,7 +14,7 @@ PATH
     ddtrace (1.21.1)
       datadog-ci (~> 0.8.1)
       debase-ruby_core_source (= 3.3.1)
-      libdatadog (~> 7.0.0.1.0)
+      libdatadog (~> 8.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
 
@@ -56,8 +56,8 @@ GEM
     json (2.6.3)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (7.0.0.1.0-aarch64-linux)
-    libdatadog (7.0.0.1.0-x86_64-linux)
+    libdatadog (8.0.0.1.0-aarch64-linux)
+    libdatadog (8.0.0.1.0-x86_64-linux)
     libddwaf (1.14.0.0.0-aarch64-linux)
       ffi (~> 1.0)
     libddwaf (1.14.0.0.0-x86_64-linux)

--- a/gemfiles/ruby_2.6_rails5_mysql2.gemfile.lock
+++ b/gemfiles/ruby_2.6_rails5_mysql2.gemfile.lock
@@ -14,7 +14,7 @@ PATH
     ddtrace (1.21.1)
       datadog-ci (~> 0.8.1)
       debase-ruby_core_source (= 3.3.1)
-      libdatadog (~> 7.0.0.1.0)
+      libdatadog (~> 8.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
 
@@ -105,8 +105,8 @@ GEM
     json (2.6.3)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (7.0.0.1.0-aarch64-linux)
-    libdatadog (7.0.0.1.0-x86_64-linux)
+    libdatadog (8.0.0.1.0-aarch64-linux)
+    libdatadog (8.0.0.1.0-x86_64-linux)
     libddwaf (1.14.0.0.0-aarch64-linux)
       ffi (~> 1.0)
     libddwaf (1.14.0.0.0-x86_64-linux)

--- a/gemfiles/ruby_2.6_rails5_postgres.gemfile.lock
+++ b/gemfiles/ruby_2.6_rails5_postgres.gemfile.lock
@@ -14,7 +14,7 @@ PATH
     ddtrace (1.21.1)
       datadog-ci (~> 0.8.1)
       debase-ruby_core_source (= 3.3.1)
-      libdatadog (~> 7.0.0.1.0)
+      libdatadog (~> 8.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
 
@@ -105,8 +105,8 @@ GEM
     json (2.6.3)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (7.0.0.1.0-aarch64-linux)
-    libdatadog (7.0.0.1.0-x86_64-linux)
+    libdatadog (8.0.0.1.0-aarch64-linux)
+    libdatadog (8.0.0.1.0-x86_64-linux)
     libddwaf (1.14.0.0.0-aarch64-linux)
       ffi (~> 1.0)
     libddwaf (1.14.0.0.0-x86_64-linux)

--- a/gemfiles/ruby_2.6_rails5_postgres_redis.gemfile.lock
+++ b/gemfiles/ruby_2.6_rails5_postgres_redis.gemfile.lock
@@ -14,7 +14,7 @@ PATH
     ddtrace (1.21.1)
       datadog-ci (~> 0.8.1)
       debase-ruby_core_source (= 3.3.1)
-      libdatadog (~> 7.0.0.1.0)
+      libdatadog (~> 8.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
 
@@ -105,8 +105,8 @@ GEM
     json (2.6.3)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (7.0.0.1.0-aarch64-linux)
-    libdatadog (7.0.0.1.0-x86_64-linux)
+    libdatadog (8.0.0.1.0-aarch64-linux)
+    libdatadog (8.0.0.1.0-x86_64-linux)
     libddwaf (1.14.0.0.0-aarch64-linux)
       ffi (~> 1.0)
     libddwaf (1.14.0.0.0-x86_64-linux)

--- a/gemfiles/ruby_2.6_rails5_postgres_redis_activesupport.gemfile.lock
+++ b/gemfiles/ruby_2.6_rails5_postgres_redis_activesupport.gemfile.lock
@@ -14,7 +14,7 @@ PATH
     ddtrace (1.21.1)
       datadog-ci (~> 0.8.1)
       debase-ruby_core_source (= 3.3.1)
-      libdatadog (~> 7.0.0.1.0)
+      libdatadog (~> 8.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
 
@@ -105,8 +105,8 @@ GEM
     json (2.6.3)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (7.0.0.1.0-aarch64-linux)
-    libdatadog (7.0.0.1.0-x86_64-linux)
+    libdatadog (8.0.0.1.0-aarch64-linux)
+    libdatadog (8.0.0.1.0-x86_64-linux)
     libddwaf (1.14.0.0.0-aarch64-linux)
       ffi (~> 1.0)
     libddwaf (1.14.0.0.0-x86_64-linux)

--- a/gemfiles/ruby_2.6_rails5_postgres_sidekiq.gemfile.lock
+++ b/gemfiles/ruby_2.6_rails5_postgres_sidekiq.gemfile.lock
@@ -14,7 +14,7 @@ PATH
     ddtrace (1.21.1)
       datadog-ci (~> 0.8.1)
       debase-ruby_core_source (= 3.3.1)
-      libdatadog (~> 7.0.0.1.0)
+      libdatadog (~> 8.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
 
@@ -106,8 +106,8 @@ GEM
     json (2.6.3)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (7.0.0.1.0-aarch64-linux)
-    libdatadog (7.0.0.1.0-x86_64-linux)
+    libdatadog (8.0.0.1.0-aarch64-linux)
+    libdatadog (8.0.0.1.0-x86_64-linux)
     libddwaf (1.14.0.0.0-aarch64-linux)
       ffi (~> 1.0)
     libddwaf (1.14.0.0.0-x86_64-linux)

--- a/gemfiles/ruby_2.6_rails5_semantic_logger.gemfile.lock
+++ b/gemfiles/ruby_2.6_rails5_semantic_logger.gemfile.lock
@@ -14,7 +14,7 @@ PATH
     ddtrace (1.21.1)
       datadog-ci (~> 0.8.1)
       debase-ruby_core_source (= 3.3.1)
-      libdatadog (~> 7.0.0.1.0)
+      libdatadog (~> 8.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
 
@@ -105,8 +105,8 @@ GEM
     json (2.6.3)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (7.0.0.1.0-aarch64-linux)
-    libdatadog (7.0.0.1.0-x86_64-linux)
+    libdatadog (8.0.0.1.0-aarch64-linux)
+    libdatadog (8.0.0.1.0-x86_64-linux)
     libddwaf (1.14.0.0.0-aarch64-linux)
       ffi (~> 1.0)
     libddwaf (1.14.0.0.0-x86_64-linux)

--- a/gemfiles/ruby_2.6_rails61_mysql2.gemfile.lock
+++ b/gemfiles/ruby_2.6_rails61_mysql2.gemfile.lock
@@ -14,7 +14,7 @@ PATH
     ddtrace (1.21.1)
       datadog-ci (~> 0.8.1)
       debase-ruby_core_source (= 3.3.1)
-      libdatadog (~> 7.0.0.1.0)
+      libdatadog (~> 8.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
 
@@ -122,8 +122,8 @@ GEM
     json (2.6.3)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (7.0.0.1.0-aarch64-linux)
-    libdatadog (7.0.0.1.0-x86_64-linux)
+    libdatadog (8.0.0.1.0-aarch64-linux)
+    libdatadog (8.0.0.1.0-x86_64-linux)
     libddwaf (1.14.0.0.0-aarch64-linux)
       ffi (~> 1.0)
     libddwaf (1.14.0.0.0-x86_64-linux)

--- a/gemfiles/ruby_2.6_rails61_postgres.gemfile.lock
+++ b/gemfiles/ruby_2.6_rails61_postgres.gemfile.lock
@@ -14,7 +14,7 @@ PATH
     ddtrace (1.21.1)
       datadog-ci (~> 0.8.1)
       debase-ruby_core_source (= 3.3.1)
-      libdatadog (~> 7.0.0.1.0)
+      libdatadog (~> 8.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
 
@@ -122,8 +122,8 @@ GEM
     json (2.6.3)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (7.0.0.1.0-aarch64-linux)
-    libdatadog (7.0.0.1.0-x86_64-linux)
+    libdatadog (8.0.0.1.0-aarch64-linux)
+    libdatadog (8.0.0.1.0-x86_64-linux)
     libddwaf (1.14.0.0.0-aarch64-linux)
       ffi (~> 1.0)
     libddwaf (1.14.0.0.0-x86_64-linux)

--- a/gemfiles/ruby_2.6_rails61_postgres_redis.gemfile.lock
+++ b/gemfiles/ruby_2.6_rails61_postgres_redis.gemfile.lock
@@ -14,7 +14,7 @@ PATH
     ddtrace (1.21.1)
       datadog-ci (~> 0.8.1)
       debase-ruby_core_source (= 3.3.1)
-      libdatadog (~> 7.0.0.1.0)
+      libdatadog (~> 8.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
 
@@ -122,8 +122,8 @@ GEM
     json (2.6.3)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (7.0.0.1.0-aarch64-linux)
-    libdatadog (7.0.0.1.0-x86_64-linux)
+    libdatadog (8.0.0.1.0-aarch64-linux)
+    libdatadog (8.0.0.1.0-x86_64-linux)
     libddwaf (1.14.0.0.0-aarch64-linux)
       ffi (~> 1.0)
     libddwaf (1.14.0.0.0-x86_64-linux)

--- a/gemfiles/ruby_2.6_rails61_postgres_sidekiq.gemfile.lock
+++ b/gemfiles/ruby_2.6_rails61_postgres_sidekiq.gemfile.lock
@@ -14,7 +14,7 @@ PATH
     ddtrace (1.21.1)
       datadog-ci (~> 0.8.1)
       debase-ruby_core_source (= 3.3.1)
-      libdatadog (~> 7.0.0.1.0)
+      libdatadog (~> 8.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
 
@@ -123,8 +123,8 @@ GEM
     json (2.6.3)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (7.0.0.1.0-aarch64-linux)
-    libdatadog (7.0.0.1.0-x86_64-linux)
+    libdatadog (8.0.0.1.0-aarch64-linux)
+    libdatadog (8.0.0.1.0-x86_64-linux)
     libddwaf (1.14.0.0.0-aarch64-linux)
       ffi (~> 1.0)
     libddwaf (1.14.0.0.0-x86_64-linux)

--- a/gemfiles/ruby_2.6_rails61_semantic_logger.gemfile.lock
+++ b/gemfiles/ruby_2.6_rails61_semantic_logger.gemfile.lock
@@ -14,7 +14,7 @@ PATH
     ddtrace (1.21.1)
       datadog-ci (~> 0.8.1)
       debase-ruby_core_source (= 3.3.1)
-      libdatadog (~> 7.0.0.1.0)
+      libdatadog (~> 8.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
 
@@ -122,8 +122,8 @@ GEM
     json (2.6.3)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (7.0.0.1.0-aarch64-linux)
-    libdatadog (7.0.0.1.0-x86_64-linux)
+    libdatadog (8.0.0.1.0-aarch64-linux)
+    libdatadog (8.0.0.1.0-x86_64-linux)
     libddwaf (1.14.0.0.0-aarch64-linux)
       ffi (~> 1.0)
     libddwaf (1.14.0.0.0-x86_64-linux)

--- a/gemfiles/ruby_2.6_rails6_mysql2.gemfile.lock
+++ b/gemfiles/ruby_2.6_rails6_mysql2.gemfile.lock
@@ -14,7 +14,7 @@ PATH
     ddtrace (1.21.1)
       datadog-ci (~> 0.8.1)
       debase-ruby_core_source (= 3.3.1)
-      libdatadog (~> 7.0.0.1.0)
+      libdatadog (~> 8.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
 
@@ -118,8 +118,8 @@ GEM
     json (2.6.3)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (7.0.0.1.0-aarch64-linux)
-    libdatadog (7.0.0.1.0-x86_64-linux)
+    libdatadog (8.0.0.1.0-aarch64-linux)
+    libdatadog (8.0.0.1.0-x86_64-linux)
     libddwaf (1.14.0.0.0-aarch64-linux)
       ffi (~> 1.0)
     libddwaf (1.14.0.0.0-x86_64-linux)

--- a/gemfiles/ruby_2.6_rails6_postgres.gemfile.lock
+++ b/gemfiles/ruby_2.6_rails6_postgres.gemfile.lock
@@ -14,7 +14,7 @@ PATH
     ddtrace (1.21.1)
       datadog-ci (~> 0.8.1)
       debase-ruby_core_source (= 3.3.1)
-      libdatadog (~> 7.0.0.1.0)
+      libdatadog (~> 8.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
 
@@ -118,8 +118,8 @@ GEM
     json (2.6.3)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (7.0.0.1.0-aarch64-linux)
-    libdatadog (7.0.0.1.0-x86_64-linux)
+    libdatadog (8.0.0.1.0-aarch64-linux)
+    libdatadog (8.0.0.1.0-x86_64-linux)
     libddwaf (1.14.0.0.0-aarch64-linux)
       ffi (~> 1.0)
     libddwaf (1.14.0.0.0-x86_64-linux)

--- a/gemfiles/ruby_2.6_rails6_postgres_redis.gemfile.lock
+++ b/gemfiles/ruby_2.6_rails6_postgres_redis.gemfile.lock
@@ -14,7 +14,7 @@ PATH
     ddtrace (1.21.1)
       datadog-ci (~> 0.8.1)
       debase-ruby_core_source (= 3.3.1)
-      libdatadog (~> 7.0.0.1.0)
+      libdatadog (~> 8.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
 
@@ -118,8 +118,8 @@ GEM
     json (2.6.3)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (7.0.0.1.0-aarch64-linux)
-    libdatadog (7.0.0.1.0-x86_64-linux)
+    libdatadog (8.0.0.1.0-aarch64-linux)
+    libdatadog (8.0.0.1.0-x86_64-linux)
     libddwaf (1.14.0.0.0-aarch64-linux)
       ffi (~> 1.0)
     libddwaf (1.14.0.0.0-x86_64-linux)

--- a/gemfiles/ruby_2.6_rails6_postgres_redis_activesupport.gemfile.lock
+++ b/gemfiles/ruby_2.6_rails6_postgres_redis_activesupport.gemfile.lock
@@ -14,7 +14,7 @@ PATH
     ddtrace (1.21.1)
       datadog-ci (~> 0.8.1)
       debase-ruby_core_source (= 3.3.1)
-      libdatadog (~> 7.0.0.1.0)
+      libdatadog (~> 8.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
 
@@ -118,8 +118,8 @@ GEM
     json (2.6.3)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (7.0.0.1.0-aarch64-linux)
-    libdatadog (7.0.0.1.0-x86_64-linux)
+    libdatadog (8.0.0.1.0-aarch64-linux)
+    libdatadog (8.0.0.1.0-x86_64-linux)
     libddwaf (1.14.0.0.0-aarch64-linux)
       ffi (~> 1.0)
     libddwaf (1.14.0.0.0-x86_64-linux)

--- a/gemfiles/ruby_2.6_rails6_postgres_sidekiq.gemfile.lock
+++ b/gemfiles/ruby_2.6_rails6_postgres_sidekiq.gemfile.lock
@@ -14,7 +14,7 @@ PATH
     ddtrace (1.21.1)
       datadog-ci (~> 0.8.1)
       debase-ruby_core_source (= 3.3.1)
-      libdatadog (~> 7.0.0.1.0)
+      libdatadog (~> 8.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
 
@@ -119,8 +119,8 @@ GEM
     json (2.6.3)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (7.0.0.1.0-aarch64-linux)
-    libdatadog (7.0.0.1.0-x86_64-linux)
+    libdatadog (8.0.0.1.0-aarch64-linux)
+    libdatadog (8.0.0.1.0-x86_64-linux)
     libddwaf (1.14.0.0.0-aarch64-linux)
       ffi (~> 1.0)
     libddwaf (1.14.0.0.0-x86_64-linux)

--- a/gemfiles/ruby_2.6_rails6_semantic_logger.gemfile.lock
+++ b/gemfiles/ruby_2.6_rails6_semantic_logger.gemfile.lock
@@ -14,7 +14,7 @@ PATH
     ddtrace (1.21.1)
       datadog-ci (~> 0.8.1)
       debase-ruby_core_source (= 3.3.1)
-      libdatadog (~> 7.0.0.1.0)
+      libdatadog (~> 8.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
 
@@ -118,8 +118,8 @@ GEM
     json (2.6.3)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (7.0.0.1.0-aarch64-linux)
-    libdatadog (7.0.0.1.0-x86_64-linux)
+    libdatadog (8.0.0.1.0-aarch64-linux)
+    libdatadog (8.0.0.1.0-x86_64-linux)
     libddwaf (1.14.0.0.0-aarch64-linux)
       ffi (~> 1.0)
     libddwaf (1.14.0.0.0-x86_64-linux)

--- a/gemfiles/ruby_2.6_redis_3.gemfile.lock
+++ b/gemfiles/ruby_2.6_redis_3.gemfile.lock
@@ -14,7 +14,7 @@ PATH
     ddtrace (1.21.1)
       datadog-ci (~> 0.8.1)
       debase-ruby_core_source (= 3.3.1)
-      libdatadog (~> 7.0.0.1.0)
+      libdatadog (~> 8.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
 
@@ -56,8 +56,8 @@ GEM
     json (2.6.3)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (7.0.0.1.0-aarch64-linux)
-    libdatadog (7.0.0.1.0-x86_64-linux)
+    libdatadog (8.0.0.1.0-aarch64-linux)
+    libdatadog (8.0.0.1.0-x86_64-linux)
     libddwaf (1.14.0.0.0-aarch64-linux)
       ffi (~> 1.0)
     libddwaf (1.14.0.0.0-x86_64-linux)

--- a/gemfiles/ruby_2.6_redis_4.gemfile.lock
+++ b/gemfiles/ruby_2.6_redis_4.gemfile.lock
@@ -14,7 +14,7 @@ PATH
     ddtrace (1.21.1)
       datadog-ci (~> 0.8.1)
       debase-ruby_core_source (= 3.3.1)
-      libdatadog (~> 7.0.0.1.0)
+      libdatadog (~> 8.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
 
@@ -56,8 +56,8 @@ GEM
     json (2.6.3)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (7.0.0.1.0-aarch64-linux)
-    libdatadog (7.0.0.1.0-x86_64-linux)
+    libdatadog (8.0.0.1.0-aarch64-linux)
+    libdatadog (8.0.0.1.0-x86_64-linux)
     libddwaf (1.14.0.0.0-aarch64-linux)
       ffi (~> 1.0)
     libddwaf (1.14.0.0.0-x86_64-linux)

--- a/gemfiles/ruby_2.6_redis_5.gemfile.lock
+++ b/gemfiles/ruby_2.6_redis_5.gemfile.lock
@@ -14,7 +14,7 @@ PATH
     ddtrace (1.21.1)
       datadog-ci (~> 0.8.1)
       debase-ruby_core_source (= 3.3.1)
-      libdatadog (~> 7.0.0.1.0)
+      libdatadog (~> 8.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
 
@@ -57,8 +57,8 @@ GEM
     json (2.6.3)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (7.0.0.1.0-aarch64-linux)
-    libdatadog (7.0.0.1.0-x86_64-linux)
+    libdatadog (8.0.0.1.0-aarch64-linux)
+    libdatadog (8.0.0.1.0-x86_64-linux)
     libddwaf (1.14.0.0.0-aarch64-linux)
       ffi (~> 1.0)
     libddwaf (1.14.0.0.0-x86_64-linux)

--- a/gemfiles/ruby_2.6_relational_db.gemfile.lock
+++ b/gemfiles/ruby_2.6_relational_db.gemfile.lock
@@ -14,7 +14,7 @@ PATH
     ddtrace (1.21.1)
       datadog-ci (~> 0.8.1)
       debase-ruby_core_source (= 3.3.1)
-      libdatadog (~> 7.0.0.1.0)
+      libdatadog (~> 8.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
 
@@ -74,8 +74,8 @@ GEM
     json (2.6.3)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (7.0.0.1.0-aarch64-linux)
-    libdatadog (7.0.0.1.0-x86_64-linux)
+    libdatadog (8.0.0.1.0-aarch64-linux)
+    libdatadog (8.0.0.1.0-x86_64-linux)
     libddwaf (1.14.0.0.0-aarch64-linux)
       ffi (~> 1.0)
     libddwaf (1.14.0.0.0-x86_64-linux)

--- a/gemfiles/ruby_2.6_resque2_redis3.gemfile.lock
+++ b/gemfiles/ruby_2.6_resque2_redis3.gemfile.lock
@@ -14,7 +14,7 @@ PATH
     ddtrace (1.21.1)
       datadog-ci (~> 0.8.1)
       debase-ruby_core_source (= 3.3.1)
-      libdatadog (~> 7.0.0.1.0)
+      libdatadog (~> 8.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
 
@@ -56,8 +56,8 @@ GEM
     json (2.6.3)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (7.0.0.1.0-aarch64-linux)
-    libdatadog (7.0.0.1.0-x86_64-linux)
+    libdatadog (8.0.0.1.0-aarch64-linux)
+    libdatadog (8.0.0.1.0-x86_64-linux)
     libddwaf (1.14.0.0.0-aarch64-linux)
       ffi (~> 1.0)
     libddwaf (1.14.0.0.0-x86_64-linux)

--- a/gemfiles/ruby_2.6_resque2_redis4.gemfile.lock
+++ b/gemfiles/ruby_2.6_resque2_redis4.gemfile.lock
@@ -14,7 +14,7 @@ PATH
     ddtrace (1.21.1)
       datadog-ci (~> 0.8.1)
       debase-ruby_core_source (= 3.3.1)
-      libdatadog (~> 7.0.0.1.0)
+      libdatadog (~> 8.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
 
@@ -56,8 +56,8 @@ GEM
     json (2.6.3)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (7.0.0.1.0-aarch64-linux)
-    libdatadog (7.0.0.1.0-x86_64-linux)
+    libdatadog (8.0.0.1.0-aarch64-linux)
+    libdatadog (8.0.0.1.0-x86_64-linux)
     libddwaf (1.14.0.0.0-aarch64-linux)
       ffi (~> 1.0)
     libddwaf (1.14.0.0.0-x86_64-linux)

--- a/gemfiles/ruby_2.6_sinatra.gemfile.lock
+++ b/gemfiles/ruby_2.6_sinatra.gemfile.lock
@@ -14,7 +14,7 @@ PATH
     ddtrace (1.21.1)
       datadog-ci (~> 0.8.1)
       debase-ruby_core_source (= 3.3.1)
-      libdatadog (~> 7.0.0.1.0)
+      libdatadog (~> 8.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
 
@@ -56,8 +56,8 @@ GEM
     json (2.6.3)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (7.0.0.1.0-aarch64-linux)
-    libdatadog (7.0.0.1.0-x86_64-linux)
+    libdatadog (8.0.0.1.0-aarch64-linux)
+    libdatadog (8.0.0.1.0-x86_64-linux)
     libddwaf (1.14.0.0.0-aarch64-linux)
       ffi (~> 1.0)
     libddwaf (1.14.0.0.0-x86_64-linux)

--- a/gemfiles/ruby_2.7.6_sinatra.gemfile.lock
+++ b/gemfiles/ruby_2.7.6_sinatra.gemfile.lock
@@ -15,7 +15,7 @@ PATH
     ddtrace (1.21.1)
       datadog-ci (~> 0.2.0)
       debase-ruby_core_source (= 3.3.1)
-      libdatadog (~> 7.0.0.1.0)
+      libdatadog (~> 8.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
 
@@ -56,8 +56,8 @@ GEM
     json (2.6.3)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (7.0.0.1.0-aarch64-linux)
-    libdatadog (7.0.0.1.0-x86_64-linux)
+    libdatadog (8.0.0.1.0-aarch64-linux)
+    libdatadog (8.0.0.1.0-x86_64-linux)
     libddwaf (1.14.0.0.0-aarch64-linux)
       ffi (~> 1.0)
     libddwaf (1.14.0.0.0-x86_64-linux)

--- a/gemfiles/ruby_2.7_activesupport.gemfile.lock
+++ b/gemfiles/ruby_2.7_activesupport.gemfile.lock
@@ -14,7 +14,7 @@ PATH
     ddtrace (1.21.1)
       datadog-ci (~> 0.8.1)
       debase-ruby_core_source (= 3.3.1)
-      libdatadog (~> 7.0.0.1.0)
+      libdatadog (~> 8.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
 
@@ -113,8 +113,8 @@ GEM
       addressable (>= 2.4)
     jsonapi-renderer (0.2.2)
     king_konf (1.0.1)
-    libdatadog (7.0.0.1.0-aarch64-linux)
-    libdatadog (7.0.0.1.0-x86_64-linux)
+    libdatadog (8.0.0.1.0-aarch64-linux)
+    libdatadog (8.0.0.1.0-x86_64-linux)
     libddwaf (1.14.0.0.0-aarch64-linux)
       ffi (~> 1.0)
     libddwaf (1.14.0.0.0-x86_64-linux)

--- a/gemfiles/ruby_2.7_aws.gemfile.lock
+++ b/gemfiles/ruby_2.7_aws.gemfile.lock
@@ -14,7 +14,7 @@ PATH
     ddtrace (1.21.1)
       datadog-ci (~> 0.8.1)
       debase-ruby_core_source (= 3.3.1)
-      libdatadog (~> 7.0.0.1.0)
+      libdatadog (~> 8.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
 
@@ -1478,8 +1478,8 @@ GEM
     json (2.6.3)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (7.0.0.1.0-aarch64-linux)
-    libdatadog (7.0.0.1.0-x86_64-linux)
+    libdatadog (8.0.0.1.0-aarch64-linux)
+    libdatadog (8.0.0.1.0-x86_64-linux)
     libddwaf (1.14.0.0.0-aarch64-linux)
       ffi (~> 1.0)
     libddwaf (1.14.0.0.0-x86_64-linux)

--- a/gemfiles/ruby_2.7_contrib.gemfile.lock
+++ b/gemfiles/ruby_2.7_contrib.gemfile.lock
@@ -14,7 +14,7 @@ PATH
     ddtrace (1.21.1)
       datadog-ci (~> 0.8.1)
       debase-ruby_core_source (= 3.3.1)
-      libdatadog (~> 7.0.0.1.0)
+      libdatadog (~> 8.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
 
@@ -71,8 +71,8 @@ GEM
     json (2.6.3)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (7.0.0.1.0-aarch64-linux)
-    libdatadog (7.0.0.1.0-x86_64-linux)
+    libdatadog (8.0.0.1.0-aarch64-linux)
+    libdatadog (8.0.0.1.0-x86_64-linux)
     libddwaf (1.14.0.0.0-aarch64-linux)
       ffi (~> 1.0)
     libddwaf (1.14.0.0.0-x86_64-linux)

--- a/gemfiles/ruby_2.7_contrib_old.gemfile.lock
+++ b/gemfiles/ruby_2.7_contrib_old.gemfile.lock
@@ -14,7 +14,7 @@ PATH
     ddtrace (1.21.1)
       datadog-ci (~> 0.8.1)
       debase-ruby_core_source (= 3.3.1)
-      libdatadog (~> 7.0.0.1.0)
+      libdatadog (~> 8.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
 
@@ -67,8 +67,8 @@ GEM
     json (2.6.3)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (7.0.0.1.0-aarch64-linux)
-    libdatadog (7.0.0.1.0-x86_64-linux)
+    libdatadog (8.0.0.1.0-aarch64-linux)
+    libdatadog (8.0.0.1.0-x86_64-linux)
     libddwaf (1.14.0.0.0-aarch64-linux)
       ffi (~> 1.0)
     libddwaf (1.14.0.0.0-x86_64-linux)

--- a/gemfiles/ruby_2.7_core_old.gemfile.lock
+++ b/gemfiles/ruby_2.7_core_old.gemfile.lock
@@ -14,7 +14,7 @@ PATH
     ddtrace (1.21.1)
       datadog-ci (~> 0.8.1)
       debase-ruby_core_source (= 3.3.1)
-      libdatadog (~> 7.0.0.1.0)
+      libdatadog (~> 8.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
 
@@ -56,8 +56,8 @@ GEM
     json (2.6.3)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (7.0.0.1.0-aarch64-linux)
-    libdatadog (7.0.0.1.0-x86_64-linux)
+    libdatadog (8.0.0.1.0-aarch64-linux)
+    libdatadog (8.0.0.1.0-x86_64-linux)
     libddwaf (1.14.0.0.0-aarch64-linux)
       ffi (~> 1.0)
     libddwaf (1.14.0.0.0-x86_64-linux)

--- a/gemfiles/ruby_2.7_elasticsearch_7.gemfile.lock
+++ b/gemfiles/ruby_2.7_elasticsearch_7.gemfile.lock
@@ -14,7 +14,7 @@ PATH
     ddtrace (1.21.1)
       datadog-ci (~> 0.8.1)
       debase-ruby_core_source (= 3.3.1)
-      libdatadog (~> 7.0.0.1.0)
+      libdatadog (~> 8.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
 
@@ -88,8 +88,8 @@ GEM
     json (2.6.3)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (7.0.0.1.0-aarch64-linux)
-    libdatadog (7.0.0.1.0-x86_64-linux)
+    libdatadog (8.0.0.1.0-aarch64-linux)
+    libdatadog (8.0.0.1.0-x86_64-linux)
     libddwaf (1.14.0.0.0-aarch64-linux)
       ffi (~> 1.0)
     libddwaf (1.14.0.0.0-x86_64-linux)

--- a/gemfiles/ruby_2.7_elasticsearch_8.gemfile.lock
+++ b/gemfiles/ruby_2.7_elasticsearch_8.gemfile.lock
@@ -14,7 +14,7 @@ PATH
     ddtrace (1.21.1)
       datadog-ci (~> 0.8.1)
       debase-ruby_core_source (= 3.3.1)
-      libdatadog (~> 7.0.0.1.0)
+      libdatadog (~> 8.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
 
@@ -71,8 +71,8 @@ GEM
     json (2.6.3)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (7.0.0.1.0-aarch64-linux)
-    libdatadog (7.0.0.1.0-x86_64-linux)
+    libdatadog (8.0.0.1.0-aarch64-linux)
+    libdatadog (8.0.0.1.0-x86_64-linux)
     libddwaf (1.14.0.0.0-aarch64-linux)
       ffi (~> 1.0)
     libddwaf (1.14.0.0.0-x86_64-linux)

--- a/gemfiles/ruby_2.7_graphql_1.12.gemfile.lock
+++ b/gemfiles/ruby_2.7_graphql_1.12.gemfile.lock
@@ -14,7 +14,7 @@ PATH
     ddtrace (1.21.1)
       datadog-ci (~> 0.8.1)
       debase-ruby_core_source (= 3.3.1)
-      libdatadog (~> 7.0.0.1.0)
+      libdatadog (~> 8.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
 
@@ -58,8 +58,8 @@ GEM
     json (2.7.1)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (7.0.0.1.0-aarch64-linux)
-    libdatadog (7.0.0.1.0-x86_64-linux)
+    libdatadog (8.0.0.1.0-aarch64-linux)
+    libdatadog (8.0.0.1.0-x86_64-linux)
     libddwaf (1.14.0.0.0-aarch64-linux)
       ffi (~> 1.0)
     libddwaf (1.14.0.0.0-x86_64-linux)

--- a/gemfiles/ruby_2.7_graphql_1.13.gemfile.lock
+++ b/gemfiles/ruby_2.7_graphql_1.13.gemfile.lock
@@ -14,7 +14,7 @@ PATH
     ddtrace (1.21.1)
       datadog-ci (~> 0.8.1)
       debase-ruby_core_source (= 3.3.1)
-      libdatadog (~> 7.0.0.1.0)
+      libdatadog (~> 8.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
 
@@ -58,8 +58,8 @@ GEM
     json (2.7.1)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (7.0.0.1.0-aarch64-linux)
-    libdatadog (7.0.0.1.0-x86_64-linux)
+    libdatadog (8.0.0.1.0-aarch64-linux)
+    libdatadog (8.0.0.1.0-x86_64-linux)
     libddwaf (1.14.0.0.0-aarch64-linux)
       ffi (~> 1.0)
     libddwaf (1.14.0.0.0-x86_64-linux)

--- a/gemfiles/ruby_2.7_graphql_2.0.gemfile.lock
+++ b/gemfiles/ruby_2.7_graphql_2.0.gemfile.lock
@@ -14,7 +14,7 @@ PATH
     ddtrace (1.21.1)
       datadog-ci (~> 0.8.1)
       debase-ruby_core_source (= 3.3.1)
-      libdatadog (~> 7.0.0.1.0)
+      libdatadog (~> 8.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
 
@@ -58,8 +58,8 @@ GEM
     json (2.7.1)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (7.0.0.1.0-aarch64-linux)
-    libdatadog (7.0.0.1.0-x86_64-linux)
+    libdatadog (8.0.0.1.0-aarch64-linux)
+    libdatadog (8.0.0.1.0-x86_64-linux)
     libddwaf (1.14.0.0.0-aarch64-linux)
       ffi (~> 1.0)
     libddwaf (1.14.0.0.0-x86_64-linux)

--- a/gemfiles/ruby_2.7_graphql_2.1.gemfile.lock
+++ b/gemfiles/ruby_2.7_graphql_2.1.gemfile.lock
@@ -14,7 +14,7 @@ PATH
     ddtrace (1.21.1)
       datadog-ci (~> 0.8.1)
       debase-ruby_core_source (= 3.3.1)
-      libdatadog (~> 7.0.0.1.0)
+      libdatadog (~> 8.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
 
@@ -59,8 +59,8 @@ GEM
     json (2.7.1)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (7.0.0.1.0-aarch64-linux)
-    libdatadog (7.0.0.1.0-x86_64-linux)
+    libdatadog (8.0.0.1.0-aarch64-linux)
+    libdatadog (8.0.0.1.0-x86_64-linux)
     libddwaf (1.14.0.0.0-aarch64-linux)
       ffi (~> 1.0)
     libddwaf (1.14.0.0.0-x86_64-linux)

--- a/gemfiles/ruby_2.7_graphql_2.2.gemfile.lock
+++ b/gemfiles/ruby_2.7_graphql_2.2.gemfile.lock
@@ -14,7 +14,7 @@ PATH
     ddtrace (1.21.1)
       datadog-ci (~> 0.8.1)
       debase-ruby_core_source (= 3.3.1)
-      libdatadog (~> 7.0.0.1.0)
+      libdatadog (~> 8.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
 
@@ -59,8 +59,8 @@ GEM
     json (2.7.1)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (7.0.0.1.0-aarch64-linux)
-    libdatadog (7.0.0.1.0-x86_64-linux)
+    libdatadog (8.0.0.1.0-aarch64-linux)
+    libdatadog (8.0.0.1.0-x86_64-linux)
     libddwaf (1.14.0.0.0-aarch64-linux)
       ffi (~> 1.0)
     libddwaf (1.14.0.0.0-x86_64-linux)

--- a/gemfiles/ruby_2.7_hanami_1.gemfile.lock
+++ b/gemfiles/ruby_2.7_hanami_1.gemfile.lock
@@ -14,7 +14,7 @@ PATH
     ddtrace (1.21.1)
       datadog-ci (~> 0.8.1)
       debase-ruby_core_source (= 3.3.1)
-      libdatadog (~> 7.0.0.1.0)
+      libdatadog (~> 8.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
 
@@ -132,8 +132,8 @@ GEM
     json (2.6.3)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (7.0.0.1.0-aarch64-linux)
-    libdatadog (7.0.0.1.0-x86_64-linux)
+    libdatadog (8.0.0.1.0-aarch64-linux)
+    libdatadog (8.0.0.1.0-x86_64-linux)
     libddwaf (1.14.0.0.0-aarch64-linux)
       ffi (~> 1.0)
     libddwaf (1.14.0.0.0-x86_64-linux)

--- a/gemfiles/ruby_2.7_http.gemfile.lock
+++ b/gemfiles/ruby_2.7_http.gemfile.lock
@@ -14,7 +14,7 @@ PATH
     ddtrace (1.21.1)
       datadog-ci (~> 0.8.1)
       debase-ruby_core_source (= 3.3.1)
-      libdatadog (~> 7.0.0.1.0)
+      libdatadog (~> 8.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
 
@@ -78,8 +78,8 @@ GEM
     json (2.6.3)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (7.0.0.1.0-aarch64-linux)
-    libdatadog (7.0.0.1.0-x86_64-linux)
+    libdatadog (8.0.0.1.0-aarch64-linux)
+    libdatadog (8.0.0.1.0-x86_64-linux)
     libddwaf (1.14.0.0.0-aarch64-linux)
       ffi (~> 1.0)
     libddwaf (1.14.0.0.0-x86_64-linux)

--- a/gemfiles/ruby_2.7_multi_rack_app.gemfile.lock
+++ b/gemfiles/ruby_2.7_multi_rack_app.gemfile.lock
@@ -14,7 +14,7 @@ PATH
     ddtrace (1.21.1)
       datadog-ci (~> 0.8.1)
       debase-ruby_core_source (= 3.3.1)
-      libdatadog (~> 7.0.0.1.0)
+      libdatadog (~> 8.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
 
@@ -130,8 +130,8 @@ GEM
     json (2.7.1)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (7.0.0.1.0-aarch64-linux)
-    libdatadog (7.0.0.1.0-x86_64-linux)
+    libdatadog (8.0.0.1.0-aarch64-linux)
+    libdatadog (8.0.0.1.0-x86_64-linux)
     libddwaf (1.14.0.0.0-aarch64-linux)
       ffi (~> 1.0)
     libddwaf (1.14.0.0.0-x86_64-linux)

--- a/gemfiles/ruby_2.7_opensearch_2.gemfile.lock
+++ b/gemfiles/ruby_2.7_opensearch_2.gemfile.lock
@@ -14,7 +14,7 @@ PATH
     ddtrace (1.21.1)
       datadog-ci (~> 0.8.1)
       debase-ruby_core_source (= 3.3.1)
-      libdatadog (~> 7.0.0.1.0)
+      libdatadog (~> 8.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
 
@@ -63,8 +63,8 @@ GEM
     json (2.6.3)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (7.0.0.1.0-aarch64-linux)
-    libdatadog (7.0.0.1.0-x86_64-linux)
+    libdatadog (8.0.0.1.0-aarch64-linux)
+    libdatadog (8.0.0.1.0-x86_64-linux)
     libddwaf (1.14.0.0.0-aarch64-linux)
       ffi (~> 1.0)
     libddwaf (1.14.0.0.0-x86_64-linux)

--- a/gemfiles/ruby_2.7_opensearch_3.gemfile.lock
+++ b/gemfiles/ruby_2.7_opensearch_3.gemfile.lock
@@ -14,7 +14,7 @@ PATH
     ddtrace (1.21.1)
       datadog-ci (~> 0.8.1)
       debase-ruby_core_source (= 3.3.1)
-      libdatadog (~> 7.0.0.1.0)
+      libdatadog (~> 8.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
 
@@ -63,8 +63,8 @@ GEM
     json (2.6.3)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (7.0.0.1.0-aarch64-linux)
-    libdatadog (7.0.0.1.0-x86_64-linux)
+    libdatadog (8.0.0.1.0-aarch64-linux)
+    libdatadog (8.0.0.1.0-x86_64-linux)
     libddwaf (1.14.0.0.0-aarch64-linux)
       ffi (~> 1.0)
     libddwaf (1.14.0.0.0-x86_64-linux)

--- a/gemfiles/ruby_2.7_opentelemetry.gemfile.lock
+++ b/gemfiles/ruby_2.7_opentelemetry.gemfile.lock
@@ -14,7 +14,7 @@ PATH
     ddtrace (1.21.1)
       datadog-ci (~> 0.8.1)
       debase-ruby_core_source (= 3.3.1)
-      libdatadog (~> 7.0.0.1.0)
+      libdatadog (~> 8.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
 
@@ -56,8 +56,8 @@ GEM
     json (2.6.3)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (7.0.0.1.0-aarch64-linux)
-    libdatadog (7.0.0.1.0-x86_64-linux)
+    libdatadog (8.0.0.1.0-aarch64-linux)
+    libdatadog (8.0.0.1.0-x86_64-linux)
     libddwaf (1.14.0.0.0-aarch64-linux)
       ffi (~> 1.0)
     libddwaf (1.14.0.0.0-x86_64-linux)

--- a/gemfiles/ruby_2.7_opentracing.gemfile.lock
+++ b/gemfiles/ruby_2.7_opentracing.gemfile.lock
@@ -14,7 +14,7 @@ PATH
     ddtrace (1.21.1)
       datadog-ci (~> 0.8.1)
       debase-ruby_core_source (= 3.3.1)
-      libdatadog (~> 7.0.0.1.0)
+      libdatadog (~> 8.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
 
@@ -57,8 +57,8 @@ GEM
     json (2.6.3)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (7.0.0.1.0-aarch64-linux)
-    libdatadog (7.0.0.1.0-x86_64-linux)
+    libdatadog (8.0.0.1.0-aarch64-linux)
+    libdatadog (8.0.0.1.0-x86_64-linux)
     libddwaf (1.14.0.0.0-aarch64-linux)
       ffi (~> 1.0)
     libddwaf (1.14.0.0.0-x86_64-linux)

--- a/gemfiles/ruby_2.7_rack_1.gemfile.lock
+++ b/gemfiles/ruby_2.7_rack_1.gemfile.lock
@@ -14,7 +14,7 @@ PATH
     ddtrace (1.21.1)
       datadog-ci (~> 0.8.1)
       debase-ruby_core_source (= 3.3.1)
-      libdatadog (~> 7.0.0.1.0)
+      libdatadog (~> 8.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
 
@@ -56,8 +56,8 @@ GEM
     json (2.6.3)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (7.0.0.1.0-aarch64-linux)
-    libdatadog (7.0.0.1.0-x86_64-linux)
+    libdatadog (8.0.0.1.0-aarch64-linux)
+    libdatadog (8.0.0.1.0-x86_64-linux)
     libddwaf (1.14.0.0.0-aarch64-linux)
       ffi (~> 1.0)
     libddwaf (1.14.0.0.0-x86_64-linux)

--- a/gemfiles/ruby_2.7_rack_2.gemfile.lock
+++ b/gemfiles/ruby_2.7_rack_2.gemfile.lock
@@ -14,7 +14,7 @@ PATH
     ddtrace (1.21.1)
       datadog-ci (~> 0.8.1)
       debase-ruby_core_source (= 3.3.1)
-      libdatadog (~> 7.0.0.1.0)
+      libdatadog (~> 8.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
 
@@ -56,8 +56,8 @@ GEM
     json (2.6.3)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (7.0.0.1.0-aarch64-linux)
-    libdatadog (7.0.0.1.0-x86_64-linux)
+    libdatadog (8.0.0.1.0-aarch64-linux)
+    libdatadog (8.0.0.1.0-x86_64-linux)
     libddwaf (1.14.0.0.0-aarch64-linux)
       ffi (~> 1.0)
     libddwaf (1.14.0.0.0-x86_64-linux)

--- a/gemfiles/ruby_2.7_rack_3.gemfile.lock
+++ b/gemfiles/ruby_2.7_rack_3.gemfile.lock
@@ -14,7 +14,7 @@ PATH
     ddtrace (1.21.1)
       datadog-ci (~> 0.8.1)
       debase-ruby_core_source (= 3.3.1)
-      libdatadog (~> 7.0.0.1.0)
+      libdatadog (~> 8.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
 
@@ -56,8 +56,8 @@ GEM
     json (2.6.3)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (7.0.0.1.0-aarch64-linux)
-    libdatadog (7.0.0.1.0-x86_64-linux)
+    libdatadog (8.0.0.1.0-aarch64-linux)
+    libdatadog (8.0.0.1.0-x86_64-linux)
     libddwaf (1.14.0.0.0-aarch64-linux)
       ffi (~> 1.0)
     libddwaf (1.14.0.0.0-x86_64-linux)

--- a/gemfiles/ruby_2.7_rails5_mysql2.gemfile.lock
+++ b/gemfiles/ruby_2.7_rails5_mysql2.gemfile.lock
@@ -14,7 +14,7 @@ PATH
     ddtrace (1.21.1)
       datadog-ci (~> 0.8.1)
       debase-ruby_core_source (= 3.3.1)
-      libdatadog (~> 7.0.0.1.0)
+      libdatadog (~> 8.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
 
@@ -105,8 +105,8 @@ GEM
     json (2.6.3)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (7.0.0.1.0-aarch64-linux)
-    libdatadog (7.0.0.1.0-x86_64-linux)
+    libdatadog (8.0.0.1.0-aarch64-linux)
+    libdatadog (8.0.0.1.0-x86_64-linux)
     libddwaf (1.14.0.0.0-aarch64-linux)
       ffi (~> 1.0)
     libddwaf (1.14.0.0.0-x86_64-linux)

--- a/gemfiles/ruby_2.7_rails5_postgres.gemfile.lock
+++ b/gemfiles/ruby_2.7_rails5_postgres.gemfile.lock
@@ -14,7 +14,7 @@ PATH
     ddtrace (1.21.1)
       datadog-ci (~> 0.8.1)
       debase-ruby_core_source (= 3.3.1)
-      libdatadog (~> 7.0.0.1.0)
+      libdatadog (~> 8.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
 
@@ -105,8 +105,8 @@ GEM
     json (2.6.3)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (7.0.0.1.0-aarch64-linux)
-    libdatadog (7.0.0.1.0-x86_64-linux)
+    libdatadog (8.0.0.1.0-aarch64-linux)
+    libdatadog (8.0.0.1.0-x86_64-linux)
     libddwaf (1.14.0.0.0-aarch64-linux)
       ffi (~> 1.0)
     libddwaf (1.14.0.0.0-x86_64-linux)

--- a/gemfiles/ruby_2.7_rails5_postgres_redis.gemfile.lock
+++ b/gemfiles/ruby_2.7_rails5_postgres_redis.gemfile.lock
@@ -14,7 +14,7 @@ PATH
     ddtrace (1.21.1)
       datadog-ci (~> 0.8.1)
       debase-ruby_core_source (= 3.3.1)
-      libdatadog (~> 7.0.0.1.0)
+      libdatadog (~> 8.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
 
@@ -105,8 +105,8 @@ GEM
     json (2.6.3)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (7.0.0.1.0-aarch64-linux)
-    libdatadog (7.0.0.1.0-x86_64-linux)
+    libdatadog (8.0.0.1.0-aarch64-linux)
+    libdatadog (8.0.0.1.0-x86_64-linux)
     libddwaf (1.14.0.0.0-aarch64-linux)
       ffi (~> 1.0)
     libddwaf (1.14.0.0.0-x86_64-linux)

--- a/gemfiles/ruby_2.7_rails5_postgres_redis_activesupport.gemfile.lock
+++ b/gemfiles/ruby_2.7_rails5_postgres_redis_activesupport.gemfile.lock
@@ -14,7 +14,7 @@ PATH
     ddtrace (1.21.1)
       datadog-ci (~> 0.8.1)
       debase-ruby_core_source (= 3.3.1)
-      libdatadog (~> 7.0.0.1.0)
+      libdatadog (~> 8.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
 
@@ -105,8 +105,8 @@ GEM
     json (2.6.3)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (7.0.0.1.0-aarch64-linux)
-    libdatadog (7.0.0.1.0-x86_64-linux)
+    libdatadog (8.0.0.1.0-aarch64-linux)
+    libdatadog (8.0.0.1.0-x86_64-linux)
     libddwaf (1.14.0.0.0-aarch64-linux)
       ffi (~> 1.0)
     libddwaf (1.14.0.0.0-x86_64-linux)

--- a/gemfiles/ruby_2.7_rails5_postgres_sidekiq.gemfile.lock
+++ b/gemfiles/ruby_2.7_rails5_postgres_sidekiq.gemfile.lock
@@ -14,7 +14,7 @@ PATH
     ddtrace (1.21.1)
       datadog-ci (~> 0.8.1)
       debase-ruby_core_source (= 3.3.1)
-      libdatadog (~> 7.0.0.1.0)
+      libdatadog (~> 8.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
 
@@ -106,8 +106,8 @@ GEM
     json (2.6.3)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (7.0.0.1.0-aarch64-linux)
-    libdatadog (7.0.0.1.0-x86_64-linux)
+    libdatadog (8.0.0.1.0-aarch64-linux)
+    libdatadog (8.0.0.1.0-x86_64-linux)
     libddwaf (1.14.0.0.0-aarch64-linux)
       ffi (~> 1.0)
     libddwaf (1.14.0.0.0-x86_64-linux)

--- a/gemfiles/ruby_2.7_rails5_semantic_logger.gemfile.lock
+++ b/gemfiles/ruby_2.7_rails5_semantic_logger.gemfile.lock
@@ -14,7 +14,7 @@ PATH
     ddtrace (1.21.1)
       datadog-ci (~> 0.8.1)
       debase-ruby_core_source (= 3.3.1)
-      libdatadog (~> 7.0.0.1.0)
+      libdatadog (~> 8.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
 
@@ -105,8 +105,8 @@ GEM
     json (2.6.3)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (7.0.0.1.0-aarch64-linux)
-    libdatadog (7.0.0.1.0-x86_64-linux)
+    libdatadog (8.0.0.1.0-aarch64-linux)
+    libdatadog (8.0.0.1.0-x86_64-linux)
     libddwaf (1.14.0.0.0-aarch64-linux)
       ffi (~> 1.0)
     libddwaf (1.14.0.0.0-x86_64-linux)

--- a/gemfiles/ruby_2.7_rails61_mysql2.gemfile.lock
+++ b/gemfiles/ruby_2.7_rails61_mysql2.gemfile.lock
@@ -14,7 +14,7 @@ PATH
     ddtrace (1.21.1)
       datadog-ci (~> 0.8.1)
       debase-ruby_core_source (= 3.3.1)
-      libdatadog (~> 7.0.0.1.0)
+      libdatadog (~> 8.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
 
@@ -122,8 +122,8 @@ GEM
     json (2.6.3)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (7.0.0.1.0-aarch64-linux)
-    libdatadog (7.0.0.1.0-x86_64-linux)
+    libdatadog (8.0.0.1.0-aarch64-linux)
+    libdatadog (8.0.0.1.0-x86_64-linux)
     libddwaf (1.14.0.0.0-aarch64-linux)
       ffi (~> 1.0)
     libddwaf (1.14.0.0.0-x86_64-linux)

--- a/gemfiles/ruby_2.7_rails61_postgres.gemfile.lock
+++ b/gemfiles/ruby_2.7_rails61_postgres.gemfile.lock
@@ -14,7 +14,7 @@ PATH
     ddtrace (1.21.1)
       datadog-ci (~> 0.8.1)
       debase-ruby_core_source (= 3.3.1)
-      libdatadog (~> 7.0.0.1.0)
+      libdatadog (~> 8.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
 
@@ -122,8 +122,8 @@ GEM
     json (2.6.3)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (7.0.0.1.0-aarch64-linux)
-    libdatadog (7.0.0.1.0-x86_64-linux)
+    libdatadog (8.0.0.1.0-aarch64-linux)
+    libdatadog (8.0.0.1.0-x86_64-linux)
     libddwaf (1.14.0.0.0-aarch64-linux)
       ffi (~> 1.0)
     libddwaf (1.14.0.0.0-x86_64-linux)

--- a/gemfiles/ruby_2.7_rails61_postgres_redis.gemfile.lock
+++ b/gemfiles/ruby_2.7_rails61_postgres_redis.gemfile.lock
@@ -14,7 +14,7 @@ PATH
     ddtrace (1.21.1)
       datadog-ci (~> 0.8.1)
       debase-ruby_core_source (= 3.3.1)
-      libdatadog (~> 7.0.0.1.0)
+      libdatadog (~> 8.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
 
@@ -122,8 +122,8 @@ GEM
     json (2.6.3)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (7.0.0.1.0-aarch64-linux)
-    libdatadog (7.0.0.1.0-x86_64-linux)
+    libdatadog (8.0.0.1.0-aarch64-linux)
+    libdatadog (8.0.0.1.0-x86_64-linux)
     libddwaf (1.14.0.0.0-aarch64-linux)
       ffi (~> 1.0)
     libddwaf (1.14.0.0.0-x86_64-linux)

--- a/gemfiles/ruby_2.7_rails61_postgres_sidekiq.gemfile.lock
+++ b/gemfiles/ruby_2.7_rails61_postgres_sidekiq.gemfile.lock
@@ -14,7 +14,7 @@ PATH
     ddtrace (1.21.1)
       datadog-ci (~> 0.8.1)
       debase-ruby_core_source (= 3.3.1)
-      libdatadog (~> 7.0.0.1.0)
+      libdatadog (~> 8.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
 
@@ -123,8 +123,8 @@ GEM
     json (2.6.3)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (7.0.0.1.0-aarch64-linux)
-    libdatadog (7.0.0.1.0-x86_64-linux)
+    libdatadog (8.0.0.1.0-aarch64-linux)
+    libdatadog (8.0.0.1.0-x86_64-linux)
     libddwaf (1.14.0.0.0-aarch64-linux)
       ffi (~> 1.0)
     libddwaf (1.14.0.0.0-x86_64-linux)

--- a/gemfiles/ruby_2.7_rails61_semantic_logger.gemfile.lock
+++ b/gemfiles/ruby_2.7_rails61_semantic_logger.gemfile.lock
@@ -14,7 +14,7 @@ PATH
     ddtrace (1.21.1)
       datadog-ci (~> 0.8.1)
       debase-ruby_core_source (= 3.3.1)
-      libdatadog (~> 7.0.0.1.0)
+      libdatadog (~> 8.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
 
@@ -122,8 +122,8 @@ GEM
     json (2.6.3)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (7.0.0.1.0-aarch64-linux)
-    libdatadog (7.0.0.1.0-x86_64-linux)
+    libdatadog (8.0.0.1.0-aarch64-linux)
+    libdatadog (8.0.0.1.0-x86_64-linux)
     libddwaf (1.14.0.0.0-aarch64-linux)
       ffi (~> 1.0)
     libddwaf (1.14.0.0.0-x86_64-linux)

--- a/gemfiles/ruby_2.7_rails6_mysql2.gemfile.lock
+++ b/gemfiles/ruby_2.7_rails6_mysql2.gemfile.lock
@@ -14,7 +14,7 @@ PATH
     ddtrace (1.21.1)
       datadog-ci (~> 0.8.1)
       debase-ruby_core_source (= 3.3.1)
-      libdatadog (~> 7.0.0.1.0)
+      libdatadog (~> 8.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
 
@@ -118,8 +118,8 @@ GEM
     json (2.6.3)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (7.0.0.1.0-aarch64-linux)
-    libdatadog (7.0.0.1.0-x86_64-linux)
+    libdatadog (8.0.0.1.0-aarch64-linux)
+    libdatadog (8.0.0.1.0-x86_64-linux)
     libddwaf (1.14.0.0.0-aarch64-linux)
       ffi (~> 1.0)
     libddwaf (1.14.0.0.0-x86_64-linux)

--- a/gemfiles/ruby_2.7_rails6_postgres.gemfile.lock
+++ b/gemfiles/ruby_2.7_rails6_postgres.gemfile.lock
@@ -14,7 +14,7 @@ PATH
     ddtrace (1.21.1)
       datadog-ci (~> 0.8.1)
       debase-ruby_core_source (= 3.3.1)
-      libdatadog (~> 7.0.0.1.0)
+      libdatadog (~> 8.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
 
@@ -118,8 +118,8 @@ GEM
     json (2.6.3)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (7.0.0.1.0-aarch64-linux)
-    libdatadog (7.0.0.1.0-x86_64-linux)
+    libdatadog (8.0.0.1.0-aarch64-linux)
+    libdatadog (8.0.0.1.0-x86_64-linux)
     libddwaf (1.14.0.0.0-aarch64-linux)
       ffi (~> 1.0)
     libddwaf (1.14.0.0.0-x86_64-linux)

--- a/gemfiles/ruby_2.7_rails6_postgres_redis.gemfile.lock
+++ b/gemfiles/ruby_2.7_rails6_postgres_redis.gemfile.lock
@@ -14,7 +14,7 @@ PATH
     ddtrace (1.21.1)
       datadog-ci (~> 0.8.1)
       debase-ruby_core_source (= 3.3.1)
-      libdatadog (~> 7.0.0.1.0)
+      libdatadog (~> 8.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
 
@@ -118,8 +118,8 @@ GEM
     json (2.6.3)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (7.0.0.1.0-aarch64-linux)
-    libdatadog (7.0.0.1.0-x86_64-linux)
+    libdatadog (8.0.0.1.0-aarch64-linux)
+    libdatadog (8.0.0.1.0-x86_64-linux)
     libddwaf (1.14.0.0.0-aarch64-linux)
       ffi (~> 1.0)
     libddwaf (1.14.0.0.0-x86_64-linux)

--- a/gemfiles/ruby_2.7_rails6_postgres_redis_activesupport.gemfile.lock
+++ b/gemfiles/ruby_2.7_rails6_postgres_redis_activesupport.gemfile.lock
@@ -14,7 +14,7 @@ PATH
     ddtrace (1.21.1)
       datadog-ci (~> 0.8.1)
       debase-ruby_core_source (= 3.3.1)
-      libdatadog (~> 7.0.0.1.0)
+      libdatadog (~> 8.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
 
@@ -118,8 +118,8 @@ GEM
     json (2.6.3)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (7.0.0.1.0-aarch64-linux)
-    libdatadog (7.0.0.1.0-x86_64-linux)
+    libdatadog (8.0.0.1.0-aarch64-linux)
+    libdatadog (8.0.0.1.0-x86_64-linux)
     libddwaf (1.14.0.0.0-aarch64-linux)
       ffi (~> 1.0)
     libddwaf (1.14.0.0.0-x86_64-linux)

--- a/gemfiles/ruby_2.7_rails6_postgres_sidekiq.gemfile.lock
+++ b/gemfiles/ruby_2.7_rails6_postgres_sidekiq.gemfile.lock
@@ -14,7 +14,7 @@ PATH
     ddtrace (1.21.1)
       datadog-ci (~> 0.8.1)
       debase-ruby_core_source (= 3.3.1)
-      libdatadog (~> 7.0.0.1.0)
+      libdatadog (~> 8.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
 
@@ -119,8 +119,8 @@ GEM
     json (2.6.3)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (7.0.0.1.0-aarch64-linux)
-    libdatadog (7.0.0.1.0-x86_64-linux)
+    libdatadog (8.0.0.1.0-aarch64-linux)
+    libdatadog (8.0.0.1.0-x86_64-linux)
     libddwaf (1.14.0.0.0-aarch64-linux)
       ffi (~> 1.0)
     libddwaf (1.14.0.0.0-x86_64-linux)

--- a/gemfiles/ruby_2.7_rails6_semantic_logger.gemfile.lock
+++ b/gemfiles/ruby_2.7_rails6_semantic_logger.gemfile.lock
@@ -14,7 +14,7 @@ PATH
     ddtrace (1.21.1)
       datadog-ci (~> 0.8.1)
       debase-ruby_core_source (= 3.3.1)
-      libdatadog (~> 7.0.0.1.0)
+      libdatadog (~> 8.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
 
@@ -118,8 +118,8 @@ GEM
     json (2.6.3)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (7.0.0.1.0-aarch64-linux)
-    libdatadog (7.0.0.1.0-x86_64-linux)
+    libdatadog (8.0.0.1.0-aarch64-linux)
+    libdatadog (8.0.0.1.0-x86_64-linux)
     libddwaf (1.14.0.0.0-aarch64-linux)
       ffi (~> 1.0)
     libddwaf (1.14.0.0.0-x86_64-linux)

--- a/gemfiles/ruby_2.7_redis_3.gemfile.lock
+++ b/gemfiles/ruby_2.7_redis_3.gemfile.lock
@@ -14,7 +14,7 @@ PATH
     ddtrace (1.21.1)
       datadog-ci (~> 0.8.1)
       debase-ruby_core_source (= 3.3.1)
-      libdatadog (~> 7.0.0.1.0)
+      libdatadog (~> 8.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
 
@@ -56,8 +56,8 @@ GEM
     json (2.6.3)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (7.0.0.1.0-aarch64-linux)
-    libdatadog (7.0.0.1.0-x86_64-linux)
+    libdatadog (8.0.0.1.0-aarch64-linux)
+    libdatadog (8.0.0.1.0-x86_64-linux)
     libddwaf (1.14.0.0.0-aarch64-linux)
       ffi (~> 1.0)
     libddwaf (1.14.0.0.0-x86_64-linux)

--- a/gemfiles/ruby_2.7_redis_4.gemfile.lock
+++ b/gemfiles/ruby_2.7_redis_4.gemfile.lock
@@ -14,7 +14,7 @@ PATH
     ddtrace (1.21.1)
       datadog-ci (~> 0.8.1)
       debase-ruby_core_source (= 3.3.1)
-      libdatadog (~> 7.0.0.1.0)
+      libdatadog (~> 8.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
 
@@ -56,8 +56,8 @@ GEM
     json (2.6.3)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (7.0.0.1.0-aarch64-linux)
-    libdatadog (7.0.0.1.0-x86_64-linux)
+    libdatadog (8.0.0.1.0-aarch64-linux)
+    libdatadog (8.0.0.1.0-x86_64-linux)
     libddwaf (1.14.0.0.0-aarch64-linux)
       ffi (~> 1.0)
     libddwaf (1.14.0.0.0-x86_64-linux)

--- a/gemfiles/ruby_2.7_redis_5.gemfile.lock
+++ b/gemfiles/ruby_2.7_redis_5.gemfile.lock
@@ -14,7 +14,7 @@ PATH
     ddtrace (1.21.1)
       datadog-ci (~> 0.8.1)
       debase-ruby_core_source (= 3.3.1)
-      libdatadog (~> 7.0.0.1.0)
+      libdatadog (~> 8.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
 
@@ -57,8 +57,8 @@ GEM
     json (2.6.3)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (7.0.0.1.0-aarch64-linux)
-    libdatadog (7.0.0.1.0-x86_64-linux)
+    libdatadog (8.0.0.1.0-aarch64-linux)
+    libdatadog (8.0.0.1.0-x86_64-linux)
     libddwaf (1.14.0.0.0-aarch64-linux)
       ffi (~> 1.0)
     libddwaf (1.14.0.0.0-x86_64-linux)

--- a/gemfiles/ruby_2.7_relational_db.gemfile.lock
+++ b/gemfiles/ruby_2.7_relational_db.gemfile.lock
@@ -14,7 +14,7 @@ PATH
     ddtrace (1.21.1)
       datadog-ci (~> 0.8.1)
       debase-ruby_core_source (= 3.3.1)
-      libdatadog (~> 7.0.0.1.0)
+      libdatadog (~> 8.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
 
@@ -74,8 +74,8 @@ GEM
     json (2.6.3)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (7.0.0.1.0-aarch64-linux)
-    libdatadog (7.0.0.1.0-x86_64-linux)
+    libdatadog (8.0.0.1.0-aarch64-linux)
+    libdatadog (8.0.0.1.0-x86_64-linux)
     libddwaf (1.14.0.0.0-aarch64-linux)
       ffi (~> 1.0)
     libddwaf (1.14.0.0.0-x86_64-linux)

--- a/gemfiles/ruby_2.7_resque2_redis3.gemfile.lock
+++ b/gemfiles/ruby_2.7_resque2_redis3.gemfile.lock
@@ -14,7 +14,7 @@ PATH
     ddtrace (1.21.1)
       datadog-ci (~> 0.8.1)
       debase-ruby_core_source (= 3.3.1)
-      libdatadog (~> 7.0.0.1.0)
+      libdatadog (~> 8.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
 
@@ -56,8 +56,8 @@ GEM
     json (2.6.3)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (7.0.0.1.0-aarch64-linux)
-    libdatadog (7.0.0.1.0-x86_64-linux)
+    libdatadog (8.0.0.1.0-aarch64-linux)
+    libdatadog (8.0.0.1.0-x86_64-linux)
     libddwaf (1.14.0.0.0-aarch64-linux)
       ffi (~> 1.0)
     libddwaf (1.14.0.0.0-x86_64-linux)

--- a/gemfiles/ruby_2.7_resque2_redis4.gemfile.lock
+++ b/gemfiles/ruby_2.7_resque2_redis4.gemfile.lock
@@ -14,7 +14,7 @@ PATH
     ddtrace (1.21.1)
       datadog-ci (~> 0.8.1)
       debase-ruby_core_source (= 3.3.1)
-      libdatadog (~> 7.0.0.1.0)
+      libdatadog (~> 8.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
 
@@ -56,8 +56,8 @@ GEM
     json (2.6.3)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (7.0.0.1.0-aarch64-linux)
-    libdatadog (7.0.0.1.0-x86_64-linux)
+    libdatadog (8.0.0.1.0-aarch64-linux)
+    libdatadog (8.0.0.1.0-x86_64-linux)
     libddwaf (1.14.0.0.0-aarch64-linux)
       ffi (~> 1.0)
     libddwaf (1.14.0.0.0-x86_64-linux)

--- a/gemfiles/ruby_2.7_sinatra.gemfile.lock
+++ b/gemfiles/ruby_2.7_sinatra.gemfile.lock
@@ -14,7 +14,7 @@ PATH
     ddtrace (1.21.1)
       datadog-ci (~> 0.8.1)
       debase-ruby_core_source (= 3.3.1)
-      libdatadog (~> 7.0.0.1.0)
+      libdatadog (~> 8.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
 
@@ -56,8 +56,8 @@ GEM
     json (2.6.3)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (7.0.0.1.0-aarch64-linux)
-    libdatadog (7.0.0.1.0-x86_64-linux)
+    libdatadog (8.0.0.1.0-aarch64-linux)
+    libdatadog (8.0.0.1.0-x86_64-linux)
     libddwaf (1.14.0.0.0-aarch64-linux)
       ffi (~> 1.0)
     libddwaf (1.14.0.0.0-x86_64-linux)

--- a/gemfiles/ruby_3.0_activesupport.gemfile.lock
+++ b/gemfiles/ruby_3.0_activesupport.gemfile.lock
@@ -14,7 +14,7 @@ PATH
     ddtrace (1.21.1)
       datadog-ci (~> 0.8.1)
       debase-ruby_core_source (= 3.3.1)
-      libdatadog (~> 7.0.0.1.0)
+      libdatadog (~> 8.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
 
@@ -112,8 +112,8 @@ GEM
       addressable (>= 2.4)
     jsonapi-renderer (0.2.2)
     king_konf (1.0.1)
-    libdatadog (7.0.0.1.0-aarch64-linux)
-    libdatadog (7.0.0.1.0-x86_64-linux)
+    libdatadog (8.0.0.1.0-aarch64-linux)
+    libdatadog (8.0.0.1.0-x86_64-linux)
     libddwaf (1.14.0.0.0-aarch64-linux)
       ffi (~> 1.0)
     libddwaf (1.14.0.0.0-x86_64-linux)

--- a/gemfiles/ruby_3.0_aws.gemfile.lock
+++ b/gemfiles/ruby_3.0_aws.gemfile.lock
@@ -14,7 +14,7 @@ PATH
     ddtrace (1.21.1)
       datadog-ci (~> 0.8.1)
       debase-ruby_core_source (= 3.3.1)
-      libdatadog (~> 7.0.0.1.0)
+      libdatadog (~> 8.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
 
@@ -1478,8 +1478,8 @@ GEM
     json (2.6.3)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (7.0.0.1.0-aarch64-linux)
-    libdatadog (7.0.0.1.0-x86_64-linux)
+    libdatadog (8.0.0.1.0-aarch64-linux)
+    libdatadog (8.0.0.1.0-x86_64-linux)
     libddwaf (1.14.0.0.0-aarch64-linux)
       ffi (~> 1.0)
     libddwaf (1.14.0.0.0-x86_64-linux)

--- a/gemfiles/ruby_3.0_contrib.gemfile.lock
+++ b/gemfiles/ruby_3.0_contrib.gemfile.lock
@@ -14,7 +14,7 @@ PATH
     ddtrace (1.21.1)
       datadog-ci (~> 0.8.1)
       debase-ruby_core_source (= 3.3.1)
-      libdatadog (~> 7.0.0.1.0)
+      libdatadog (~> 8.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
 
@@ -71,8 +71,8 @@ GEM
     json (2.6.3)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (7.0.0.1.0-aarch64-linux)
-    libdatadog (7.0.0.1.0-x86_64-linux)
+    libdatadog (8.0.0.1.0-aarch64-linux)
+    libdatadog (8.0.0.1.0-x86_64-linux)
     libddwaf (1.14.0.0.0-aarch64-linux)
       ffi (~> 1.0)
     libddwaf (1.14.0.0.0-x86_64-linux)

--- a/gemfiles/ruby_3.0_contrib_old.gemfile.lock
+++ b/gemfiles/ruby_3.0_contrib_old.gemfile.lock
@@ -14,7 +14,7 @@ PATH
     ddtrace (1.21.1)
       datadog-ci (~> 0.8.1)
       debase-ruby_core_source (= 3.3.1)
-      libdatadog (~> 7.0.0.1.0)
+      libdatadog (~> 8.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
 
@@ -67,8 +67,8 @@ GEM
     json (2.6.3)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (7.0.0.1.0-aarch64-linux)
-    libdatadog (7.0.0.1.0-x86_64-linux)
+    libdatadog (8.0.0.1.0-aarch64-linux)
+    libdatadog (8.0.0.1.0-x86_64-linux)
     libddwaf (1.14.0.0.0-aarch64-linux)
       ffi (~> 1.0)
     libddwaf (1.14.0.0.0-x86_64-linux)

--- a/gemfiles/ruby_3.0_core_old.gemfile.lock
+++ b/gemfiles/ruby_3.0_core_old.gemfile.lock
@@ -14,7 +14,7 @@ PATH
     ddtrace (1.21.1)
       datadog-ci (~> 0.8.1)
       debase-ruby_core_source (= 3.3.1)
-      libdatadog (~> 7.0.0.1.0)
+      libdatadog (~> 8.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
 
@@ -56,8 +56,8 @@ GEM
     json (2.6.3)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (7.0.0.1.0-aarch64-linux)
-    libdatadog (7.0.0.1.0-x86_64-linux)
+    libdatadog (8.0.0.1.0-aarch64-linux)
+    libdatadog (8.0.0.1.0-x86_64-linux)
     libddwaf (1.14.0.0.0-aarch64-linux)
       ffi (~> 1.0)
     libddwaf (1.14.0.0.0-x86_64-linux)

--- a/gemfiles/ruby_3.0_elasticsearch_7.gemfile.lock
+++ b/gemfiles/ruby_3.0_elasticsearch_7.gemfile.lock
@@ -14,7 +14,7 @@ PATH
     ddtrace (1.21.1)
       datadog-ci (~> 0.8.1)
       debase-ruby_core_source (= 3.3.1)
-      libdatadog (~> 7.0.0.1.0)
+      libdatadog (~> 8.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
 
@@ -88,8 +88,8 @@ GEM
     json (2.6.3)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (7.0.0.1.0-aarch64-linux)
-    libdatadog (7.0.0.1.0-x86_64-linux)
+    libdatadog (8.0.0.1.0-aarch64-linux)
+    libdatadog (8.0.0.1.0-x86_64-linux)
     libddwaf (1.14.0.0.0-aarch64-linux)
       ffi (~> 1.0)
     libddwaf (1.14.0.0.0-x86_64-linux)

--- a/gemfiles/ruby_3.0_elasticsearch_8.gemfile.lock
+++ b/gemfiles/ruby_3.0_elasticsearch_8.gemfile.lock
@@ -14,7 +14,7 @@ PATH
     ddtrace (1.21.1)
       datadog-ci (~> 0.8.1)
       debase-ruby_core_source (= 3.3.1)
-      libdatadog (~> 7.0.0.1.0)
+      libdatadog (~> 8.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
 
@@ -71,8 +71,8 @@ GEM
     json (2.6.3)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (7.0.0.1.0-aarch64-linux)
-    libdatadog (7.0.0.1.0-x86_64-linux)
+    libdatadog (8.0.0.1.0-aarch64-linux)
+    libdatadog (8.0.0.1.0-x86_64-linux)
     libddwaf (1.14.0.0.0-aarch64-linux)
       ffi (~> 1.0)
     libddwaf (1.14.0.0.0-x86_64-linux)

--- a/gemfiles/ruby_3.0_graphql_1.12.gemfile.lock
+++ b/gemfiles/ruby_3.0_graphql_1.12.gemfile.lock
@@ -14,7 +14,7 @@ PATH
     ddtrace (1.21.1)
       datadog-ci (~> 0.8.1)
       debase-ruby_core_source (= 3.3.1)
-      libdatadog (~> 7.0.0.1.0)
+      libdatadog (~> 8.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
 
@@ -58,8 +58,8 @@ GEM
     json (2.7.1)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (7.0.0.1.0-aarch64-linux)
-    libdatadog (7.0.0.1.0-x86_64-linux)
+    libdatadog (8.0.0.1.0-aarch64-linux)
+    libdatadog (8.0.0.1.0-x86_64-linux)
     libddwaf (1.14.0.0.0-aarch64-linux)
       ffi (~> 1.0)
     libddwaf (1.14.0.0.0-x86_64-linux)

--- a/gemfiles/ruby_3.0_graphql_1.13.gemfile.lock
+++ b/gemfiles/ruby_3.0_graphql_1.13.gemfile.lock
@@ -14,7 +14,7 @@ PATH
     ddtrace (1.21.1)
       datadog-ci (~> 0.8.1)
       debase-ruby_core_source (= 3.3.1)
-      libdatadog (~> 7.0.0.1.0)
+      libdatadog (~> 8.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
 
@@ -58,8 +58,8 @@ GEM
     json (2.7.1)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (7.0.0.1.0-aarch64-linux)
-    libdatadog (7.0.0.1.0-x86_64-linux)
+    libdatadog (8.0.0.1.0-aarch64-linux)
+    libdatadog (8.0.0.1.0-x86_64-linux)
     libddwaf (1.14.0.0.0-aarch64-linux)
       ffi (~> 1.0)
     libddwaf (1.14.0.0.0-x86_64-linux)

--- a/gemfiles/ruby_3.0_graphql_2.0.gemfile.lock
+++ b/gemfiles/ruby_3.0_graphql_2.0.gemfile.lock
@@ -14,7 +14,7 @@ PATH
     ddtrace (1.21.1)
       datadog-ci (~> 0.8.1)
       debase-ruby_core_source (= 3.3.1)
-      libdatadog (~> 7.0.0.1.0)
+      libdatadog (~> 8.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
 
@@ -58,8 +58,8 @@ GEM
     json (2.7.1)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (7.0.0.1.0-aarch64-linux)
-    libdatadog (7.0.0.1.0-x86_64-linux)
+    libdatadog (8.0.0.1.0-aarch64-linux)
+    libdatadog (8.0.0.1.0-x86_64-linux)
     libddwaf (1.14.0.0.0-aarch64-linux)
       ffi (~> 1.0)
     libddwaf (1.14.0.0.0-x86_64-linux)

--- a/gemfiles/ruby_3.0_graphql_2.1.gemfile.lock
+++ b/gemfiles/ruby_3.0_graphql_2.1.gemfile.lock
@@ -14,7 +14,7 @@ PATH
     ddtrace (1.21.1)
       datadog-ci (~> 0.8.1)
       debase-ruby_core_source (= 3.3.1)
-      libdatadog (~> 7.0.0.1.0)
+      libdatadog (~> 8.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
 
@@ -59,8 +59,8 @@ GEM
     json (2.7.1)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (7.0.0.1.0-aarch64-linux)
-    libdatadog (7.0.0.1.0-x86_64-linux)
+    libdatadog (8.0.0.1.0-aarch64-linux)
+    libdatadog (8.0.0.1.0-x86_64-linux)
     libddwaf (1.14.0.0.0-aarch64-linux)
       ffi (~> 1.0)
     libddwaf (1.14.0.0.0-x86_64-linux)

--- a/gemfiles/ruby_3.0_graphql_2.2.gemfile.lock
+++ b/gemfiles/ruby_3.0_graphql_2.2.gemfile.lock
@@ -14,7 +14,7 @@ PATH
     ddtrace (1.21.1)
       datadog-ci (~> 0.8.1)
       debase-ruby_core_source (= 3.3.1)
-      libdatadog (~> 7.0.0.1.0)
+      libdatadog (~> 8.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
 
@@ -59,8 +59,8 @@ GEM
     json (2.7.1)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (7.0.0.1.0-aarch64-linux)
-    libdatadog (7.0.0.1.0-x86_64-linux)
+    libdatadog (8.0.0.1.0-aarch64-linux)
+    libdatadog (8.0.0.1.0-x86_64-linux)
     libddwaf (1.14.0.0.0-aarch64-linux)
       ffi (~> 1.0)
     libddwaf (1.14.0.0.0-x86_64-linux)

--- a/gemfiles/ruby_3.0_http.gemfile.lock
+++ b/gemfiles/ruby_3.0_http.gemfile.lock
@@ -14,7 +14,7 @@ PATH
     ddtrace (1.21.1)
       datadog-ci (~> 0.8.1)
       debase-ruby_core_source (= 3.3.1)
-      libdatadog (~> 7.0.0.1.0)
+      libdatadog (~> 8.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
 
@@ -78,8 +78,8 @@ GEM
     json (2.6.3)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (7.0.0.1.0-aarch64-linux)
-    libdatadog (7.0.0.1.0-x86_64-linux)
+    libdatadog (8.0.0.1.0-aarch64-linux)
+    libdatadog (8.0.0.1.0-x86_64-linux)
     libddwaf (1.14.0.0.0-aarch64-linux)
       ffi (~> 1.0)
     libddwaf (1.14.0.0.0-x86_64-linux)

--- a/gemfiles/ruby_3.0_multi_rack_app.gemfile.lock
+++ b/gemfiles/ruby_3.0_multi_rack_app.gemfile.lock
@@ -14,7 +14,7 @@ PATH
     ddtrace (1.21.1)
       datadog-ci (~> 0.8.1)
       debase-ruby_core_source (= 3.3.1)
-      libdatadog (~> 7.0.0.1.0)
+      libdatadog (~> 8.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
 
@@ -148,8 +148,8 @@ GEM
     json (2.7.1)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (7.0.0.1.0-aarch64-linux)
-    libdatadog (7.0.0.1.0-x86_64-linux)
+    libdatadog (8.0.0.1.0-aarch64-linux)
+    libdatadog (8.0.0.1.0-x86_64-linux)
     libddwaf (1.14.0.0.0-aarch64-linux)
       ffi (~> 1.0)
     libddwaf (1.14.0.0.0-x86_64-linux)

--- a/gemfiles/ruby_3.0_opensearch_2.gemfile.lock
+++ b/gemfiles/ruby_3.0_opensearch_2.gemfile.lock
@@ -14,7 +14,7 @@ PATH
     ddtrace (1.21.1)
       datadog-ci (~> 0.8.1)
       debase-ruby_core_source (= 3.3.1)
-      libdatadog (~> 7.0.0.1.0)
+      libdatadog (~> 8.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
 
@@ -63,8 +63,8 @@ GEM
     json (2.6.3)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (7.0.0.1.0-aarch64-linux)
-    libdatadog (7.0.0.1.0-x86_64-linux)
+    libdatadog (8.0.0.1.0-aarch64-linux)
+    libdatadog (8.0.0.1.0-x86_64-linux)
     libddwaf (1.14.0.0.0-aarch64-linux)
       ffi (~> 1.0)
     libddwaf (1.14.0.0.0-x86_64-linux)

--- a/gemfiles/ruby_3.0_opensearch_3.gemfile.lock
+++ b/gemfiles/ruby_3.0_opensearch_3.gemfile.lock
@@ -14,7 +14,7 @@ PATH
     ddtrace (1.21.1)
       datadog-ci (~> 0.8.1)
       debase-ruby_core_source (= 3.3.1)
-      libdatadog (~> 7.0.0.1.0)
+      libdatadog (~> 8.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
 
@@ -63,8 +63,8 @@ GEM
     json (2.6.3)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (7.0.0.1.0-aarch64-linux)
-    libdatadog (7.0.0.1.0-x86_64-linux)
+    libdatadog (8.0.0.1.0-aarch64-linux)
+    libdatadog (8.0.0.1.0-x86_64-linux)
     libddwaf (1.14.0.0.0-aarch64-linux)
       ffi (~> 1.0)
     libddwaf (1.14.0.0.0-x86_64-linux)

--- a/gemfiles/ruby_3.0_opentelemetry.gemfile.lock
+++ b/gemfiles/ruby_3.0_opentelemetry.gemfile.lock
@@ -14,7 +14,7 @@ PATH
     ddtrace (1.21.1)
       datadog-ci (~> 0.8.1)
       debase-ruby_core_source (= 3.3.1)
-      libdatadog (~> 7.0.0.1.0)
+      libdatadog (~> 8.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
 
@@ -56,8 +56,8 @@ GEM
     json (2.6.3)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (7.0.0.1.0-aarch64-linux)
-    libdatadog (7.0.0.1.0-x86_64-linux)
+    libdatadog (8.0.0.1.0-aarch64-linux)
+    libdatadog (8.0.0.1.0-x86_64-linux)
     libddwaf (1.14.0.0.0-aarch64-linux)
       ffi (~> 1.0)
     libddwaf (1.14.0.0.0-x86_64-linux)

--- a/gemfiles/ruby_3.0_opentracing.gemfile.lock
+++ b/gemfiles/ruby_3.0_opentracing.gemfile.lock
@@ -14,7 +14,7 @@ PATH
     ddtrace (1.21.1)
       datadog-ci (~> 0.8.1)
       debase-ruby_core_source (= 3.3.1)
-      libdatadog (~> 7.0.0.1.0)
+      libdatadog (~> 8.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
 
@@ -57,8 +57,8 @@ GEM
     json (2.6.3)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (7.0.0.1.0-aarch64-linux)
-    libdatadog (7.0.0.1.0-x86_64-linux)
+    libdatadog (8.0.0.1.0-aarch64-linux)
+    libdatadog (8.0.0.1.0-x86_64-linux)
     libddwaf (1.14.0.0.0-aarch64-linux)
       ffi (~> 1.0)
     libddwaf (1.14.0.0.0-x86_64-linux)

--- a/gemfiles/ruby_3.0_rack_1.gemfile.lock
+++ b/gemfiles/ruby_3.0_rack_1.gemfile.lock
@@ -14,7 +14,7 @@ PATH
     ddtrace (1.21.1)
       datadog-ci (~> 0.8.1)
       debase-ruby_core_source (= 3.3.1)
-      libdatadog (~> 7.0.0.1.0)
+      libdatadog (~> 8.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
 
@@ -56,8 +56,8 @@ GEM
     json (2.6.3)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (7.0.0.1.0-aarch64-linux)
-    libdatadog (7.0.0.1.0-x86_64-linux)
+    libdatadog (8.0.0.1.0-aarch64-linux)
+    libdatadog (8.0.0.1.0-x86_64-linux)
     libddwaf (1.14.0.0.0-aarch64-linux)
       ffi (~> 1.0)
     libddwaf (1.14.0.0.0-x86_64-linux)

--- a/gemfiles/ruby_3.0_rack_2.gemfile.lock
+++ b/gemfiles/ruby_3.0_rack_2.gemfile.lock
@@ -14,7 +14,7 @@ PATH
     ddtrace (1.21.1)
       datadog-ci (~> 0.8.1)
       debase-ruby_core_source (= 3.3.1)
-      libdatadog (~> 7.0.0.1.0)
+      libdatadog (~> 8.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
 
@@ -56,8 +56,8 @@ GEM
     json (2.6.3)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (7.0.0.1.0-aarch64-linux)
-    libdatadog (7.0.0.1.0-x86_64-linux)
+    libdatadog (8.0.0.1.0-aarch64-linux)
+    libdatadog (8.0.0.1.0-x86_64-linux)
     libddwaf (1.14.0.0.0-aarch64-linux)
       ffi (~> 1.0)
     libddwaf (1.14.0.0.0-x86_64-linux)

--- a/gemfiles/ruby_3.0_rack_3.gemfile.lock
+++ b/gemfiles/ruby_3.0_rack_3.gemfile.lock
@@ -14,7 +14,7 @@ PATH
     ddtrace (1.21.1)
       datadog-ci (~> 0.8.1)
       debase-ruby_core_source (= 3.3.1)
-      libdatadog (~> 7.0.0.1.0)
+      libdatadog (~> 8.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
 
@@ -56,8 +56,8 @@ GEM
     json (2.6.3)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (7.0.0.1.0-aarch64-linux)
-    libdatadog (7.0.0.1.0-x86_64-linux)
+    libdatadog (8.0.0.1.0-aarch64-linux)
+    libdatadog (8.0.0.1.0-x86_64-linux)
     libddwaf (1.14.0.0.0-aarch64-linux)
       ffi (~> 1.0)
     libddwaf (1.14.0.0.0-x86_64-linux)

--- a/gemfiles/ruby_3.0_rails61_mysql2.gemfile.lock
+++ b/gemfiles/ruby_3.0_rails61_mysql2.gemfile.lock
@@ -14,7 +14,7 @@ PATH
     ddtrace (1.21.1)
       datadog-ci (~> 0.8.1)
       debase-ruby_core_source (= 3.3.1)
-      libdatadog (~> 7.0.0.1.0)
+      libdatadog (~> 8.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
 
@@ -122,8 +122,8 @@ GEM
     json (2.6.3)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (7.0.0.1.0-aarch64-linux)
-    libdatadog (7.0.0.1.0-x86_64-linux)
+    libdatadog (8.0.0.1.0-aarch64-linux)
+    libdatadog (8.0.0.1.0-x86_64-linux)
     libddwaf (1.14.0.0.0-aarch64-linux)
       ffi (~> 1.0)
     libddwaf (1.14.0.0.0-x86_64-linux)

--- a/gemfiles/ruby_3.0_rails61_postgres.gemfile.lock
+++ b/gemfiles/ruby_3.0_rails61_postgres.gemfile.lock
@@ -14,7 +14,7 @@ PATH
     ddtrace (1.21.1)
       datadog-ci (~> 0.8.1)
       debase-ruby_core_source (= 3.3.1)
-      libdatadog (~> 7.0.0.1.0)
+      libdatadog (~> 8.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
 
@@ -122,8 +122,8 @@ GEM
     json (2.6.3)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (7.0.0.1.0-aarch64-linux)
-    libdatadog (7.0.0.1.0-x86_64-linux)
+    libdatadog (8.0.0.1.0-aarch64-linux)
+    libdatadog (8.0.0.1.0-x86_64-linux)
     libddwaf (1.14.0.0.0-aarch64-linux)
       ffi (~> 1.0)
     libddwaf (1.14.0.0.0-x86_64-linux)

--- a/gemfiles/ruby_3.0_rails61_postgres_redis.gemfile.lock
+++ b/gemfiles/ruby_3.0_rails61_postgres_redis.gemfile.lock
@@ -14,7 +14,7 @@ PATH
     ddtrace (1.21.1)
       datadog-ci (~> 0.8.1)
       debase-ruby_core_source (= 3.3.1)
-      libdatadog (~> 7.0.0.1.0)
+      libdatadog (~> 8.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
 
@@ -122,8 +122,8 @@ GEM
     json (2.6.3)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (7.0.0.1.0-aarch64-linux)
-    libdatadog (7.0.0.1.0-x86_64-linux)
+    libdatadog (8.0.0.1.0-aarch64-linux)
+    libdatadog (8.0.0.1.0-x86_64-linux)
     libddwaf (1.14.0.0.0-aarch64-linux)
       ffi (~> 1.0)
     libddwaf (1.14.0.0.0-x86_64-linux)

--- a/gemfiles/ruby_3.0_rails61_postgres_sidekiq.gemfile.lock
+++ b/gemfiles/ruby_3.0_rails61_postgres_sidekiq.gemfile.lock
@@ -14,7 +14,7 @@ PATH
     ddtrace (1.21.1)
       datadog-ci (~> 0.8.1)
       debase-ruby_core_source (= 3.3.1)
-      libdatadog (~> 7.0.0.1.0)
+      libdatadog (~> 8.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
 
@@ -123,8 +123,8 @@ GEM
     json (2.6.3)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (7.0.0.1.0-aarch64-linux)
-    libdatadog (7.0.0.1.0-x86_64-linux)
+    libdatadog (8.0.0.1.0-aarch64-linux)
+    libdatadog (8.0.0.1.0-x86_64-linux)
     libddwaf (1.14.0.0.0-aarch64-linux)
       ffi (~> 1.0)
     libddwaf (1.14.0.0.0-x86_64-linux)

--- a/gemfiles/ruby_3.0_rails61_semantic_logger.gemfile.lock
+++ b/gemfiles/ruby_3.0_rails61_semantic_logger.gemfile.lock
@@ -14,7 +14,7 @@ PATH
     ddtrace (1.21.1)
       datadog-ci (~> 0.8.1)
       debase-ruby_core_source (= 3.3.1)
-      libdatadog (~> 7.0.0.1.0)
+      libdatadog (~> 8.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
 
@@ -122,8 +122,8 @@ GEM
     json (2.6.3)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (7.0.0.1.0-aarch64-linux)
-    libdatadog (7.0.0.1.0-x86_64-linux)
+    libdatadog (8.0.0.1.0-aarch64-linux)
+    libdatadog (8.0.0.1.0-x86_64-linux)
     libddwaf (1.14.0.0.0-aarch64-linux)
       ffi (~> 1.0)
     libddwaf (1.14.0.0.0-x86_64-linux)

--- a/gemfiles/ruby_3.0_rails61_trilogy.gemfile.lock
+++ b/gemfiles/ruby_3.0_rails61_trilogy.gemfile.lock
@@ -14,7 +14,7 @@ PATH
     ddtrace (1.21.1)
       datadog-ci (~> 0.8.1)
       debase-ruby_core_source (= 3.3.1)
-      libdatadog (~> 7.0.0.1.0)
+      libdatadog (~> 8.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
 
@@ -126,8 +126,8 @@ GEM
     json (2.6.3)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (7.0.0.1.0-aarch64-linux)
-    libdatadog (7.0.0.1.0-x86_64-linux)
+    libdatadog (8.0.0.1.0-aarch64-linux)
+    libdatadog (8.0.0.1.0-x86_64-linux)
     libddwaf (1.14.0.0.0-aarch64-linux)
       ffi (~> 1.0)
     libddwaf (1.14.0.0.0-x86_64-linux)

--- a/gemfiles/ruby_3.0_redis_3.gemfile.lock
+++ b/gemfiles/ruby_3.0_redis_3.gemfile.lock
@@ -14,7 +14,7 @@ PATH
     ddtrace (1.21.1)
       datadog-ci (~> 0.8.1)
       debase-ruby_core_source (= 3.3.1)
-      libdatadog (~> 7.0.0.1.0)
+      libdatadog (~> 8.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
 
@@ -56,8 +56,8 @@ GEM
     json (2.6.3)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (7.0.0.1.0-aarch64-linux)
-    libdatadog (7.0.0.1.0-x86_64-linux)
+    libdatadog (8.0.0.1.0-aarch64-linux)
+    libdatadog (8.0.0.1.0-x86_64-linux)
     libddwaf (1.14.0.0.0-aarch64-linux)
       ffi (~> 1.0)
     libddwaf (1.14.0.0.0-x86_64-linux)

--- a/gemfiles/ruby_3.0_redis_4.gemfile.lock
+++ b/gemfiles/ruby_3.0_redis_4.gemfile.lock
@@ -14,7 +14,7 @@ PATH
     ddtrace (1.21.1)
       datadog-ci (~> 0.8.1)
       debase-ruby_core_source (= 3.3.1)
-      libdatadog (~> 7.0.0.1.0)
+      libdatadog (~> 8.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
 
@@ -56,8 +56,8 @@ GEM
     json (2.6.3)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (7.0.0.1.0-aarch64-linux)
-    libdatadog (7.0.0.1.0-x86_64-linux)
+    libdatadog (8.0.0.1.0-aarch64-linux)
+    libdatadog (8.0.0.1.0-x86_64-linux)
     libddwaf (1.14.0.0.0-aarch64-linux)
       ffi (~> 1.0)
     libddwaf (1.14.0.0.0-x86_64-linux)

--- a/gemfiles/ruby_3.0_redis_5.gemfile.lock
+++ b/gemfiles/ruby_3.0_redis_5.gemfile.lock
@@ -14,7 +14,7 @@ PATH
     ddtrace (1.21.1)
       datadog-ci (~> 0.8.1)
       debase-ruby_core_source (= 3.3.1)
-      libdatadog (~> 7.0.0.1.0)
+      libdatadog (~> 8.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
 
@@ -57,8 +57,8 @@ GEM
     json (2.6.3)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (7.0.0.1.0-aarch64-linux)
-    libdatadog (7.0.0.1.0-x86_64-linux)
+    libdatadog (8.0.0.1.0-aarch64-linux)
+    libdatadog (8.0.0.1.0-x86_64-linux)
     libddwaf (1.14.0.0.0-aarch64-linux)
       ffi (~> 1.0)
     libddwaf (1.14.0.0.0-x86_64-linux)

--- a/gemfiles/ruby_3.0_relational_db.gemfile.lock
+++ b/gemfiles/ruby_3.0_relational_db.gemfile.lock
@@ -14,7 +14,7 @@ PATH
     ddtrace (1.21.1)
       datadog-ci (~> 0.8.1)
       debase-ruby_core_source (= 3.3.1)
-      libdatadog (~> 7.0.0.1.0)
+      libdatadog (~> 8.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
 
@@ -73,8 +73,8 @@ GEM
     json (2.6.3)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (7.0.0.1.0-aarch64-linux)
-    libdatadog (7.0.0.1.0-x86_64-linux)
+    libdatadog (8.0.0.1.0-aarch64-linux)
+    libdatadog (8.0.0.1.0-x86_64-linux)
     libddwaf (1.14.0.0.0-aarch64-linux)
       ffi (~> 1.0)
     libddwaf (1.14.0.0.0-x86_64-linux)

--- a/gemfiles/ruby_3.0_resque2_redis3.gemfile.lock
+++ b/gemfiles/ruby_3.0_resque2_redis3.gemfile.lock
@@ -14,7 +14,7 @@ PATH
     ddtrace (1.21.1)
       datadog-ci (~> 0.8.1)
       debase-ruby_core_source (= 3.3.1)
-      libdatadog (~> 7.0.0.1.0)
+      libdatadog (~> 8.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
 
@@ -56,8 +56,8 @@ GEM
     json (2.6.3)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (7.0.0.1.0-aarch64-linux)
-    libdatadog (7.0.0.1.0-x86_64-linux)
+    libdatadog (8.0.0.1.0-aarch64-linux)
+    libdatadog (8.0.0.1.0-x86_64-linux)
     libddwaf (1.14.0.0.0-aarch64-linux)
       ffi (~> 1.0)
     libddwaf (1.14.0.0.0-x86_64-linux)

--- a/gemfiles/ruby_3.0_resque2_redis4.gemfile.lock
+++ b/gemfiles/ruby_3.0_resque2_redis4.gemfile.lock
@@ -14,7 +14,7 @@ PATH
     ddtrace (1.21.1)
       datadog-ci (~> 0.8.1)
       debase-ruby_core_source (= 3.3.1)
-      libdatadog (~> 7.0.0.1.0)
+      libdatadog (~> 8.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
 
@@ -57,8 +57,8 @@ GEM
     json (2.6.3)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (7.0.0.1.0-aarch64-linux)
-    libdatadog (7.0.0.1.0-x86_64-linux)
+    libdatadog (8.0.0.1.0-aarch64-linux)
+    libdatadog (8.0.0.1.0-x86_64-linux)
     libddwaf (1.14.0.0.0-aarch64-linux)
       ffi (~> 1.0)
     libddwaf (1.14.0.0.0-x86_64-linux)

--- a/gemfiles/ruby_3.0_sinatra.gemfile.lock
+++ b/gemfiles/ruby_3.0_sinatra.gemfile.lock
@@ -14,7 +14,7 @@ PATH
     ddtrace (1.21.1)
       datadog-ci (~> 0.8.1)
       debase-ruby_core_source (= 3.3.1)
-      libdatadog (~> 7.0.0.1.0)
+      libdatadog (~> 8.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
 
@@ -56,8 +56,8 @@ GEM
     json (2.6.3)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (7.0.0.1.0-aarch64-linux)
-    libdatadog (7.0.0.1.0-x86_64-linux)
+    libdatadog (8.0.0.1.0-aarch64-linux)
+    libdatadog (8.0.0.1.0-x86_64-linux)
     libddwaf (1.14.0.0.0-aarch64-linux)
       ffi (~> 1.0)
     libddwaf (1.14.0.0.0-x86_64-linux)

--- a/gemfiles/ruby_3.1_activesupport.gemfile.lock
+++ b/gemfiles/ruby_3.1_activesupport.gemfile.lock
@@ -14,7 +14,7 @@ PATH
     ddtrace (1.21.1)
       datadog-ci (~> 0.8.1)
       debase-ruby_core_source (= 3.3.1)
-      libdatadog (~> 7.0.0.1.0)
+      libdatadog (~> 8.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
 
@@ -112,8 +112,8 @@ GEM
       addressable (>= 2.4)
     jsonapi-renderer (0.2.2)
     king_konf (1.0.1)
-    libdatadog (7.0.0.1.0-aarch64-linux)
-    libdatadog (7.0.0.1.0-x86_64-linux)
+    libdatadog (8.0.0.1.0-aarch64-linux)
+    libdatadog (8.0.0.1.0-x86_64-linux)
     libddwaf (1.14.0.0.0-aarch64-linux)
       ffi (~> 1.0)
     libddwaf (1.14.0.0.0-x86_64-linux)

--- a/gemfiles/ruby_3.1_aws.gemfile.lock
+++ b/gemfiles/ruby_3.1_aws.gemfile.lock
@@ -14,7 +14,7 @@ PATH
     ddtrace (1.21.1)
       datadog-ci (~> 0.8.1)
       debase-ruby_core_source (= 3.3.1)
-      libdatadog (~> 7.0.0.1.0)
+      libdatadog (~> 8.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
 
@@ -1478,8 +1478,8 @@ GEM
     json (2.6.3)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (7.0.0.1.0-aarch64-linux)
-    libdatadog (7.0.0.1.0-x86_64-linux)
+    libdatadog (8.0.0.1.0-aarch64-linux)
+    libdatadog (8.0.0.1.0-x86_64-linux)
     libddwaf (1.14.0.0.0-aarch64-linux)
       ffi (~> 1.0)
     libddwaf (1.14.0.0.0-x86_64-linux)

--- a/gemfiles/ruby_3.1_contrib.gemfile.lock
+++ b/gemfiles/ruby_3.1_contrib.gemfile.lock
@@ -14,7 +14,7 @@ PATH
     ddtrace (1.21.1)
       datadog-ci (~> 0.8.1)
       debase-ruby_core_source (= 3.3.1)
-      libdatadog (~> 7.0.0.1.0)
+      libdatadog (~> 8.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
 
@@ -71,8 +71,8 @@ GEM
     json (2.6.3)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (7.0.0.1.0-aarch64-linux)
-    libdatadog (7.0.0.1.0-x86_64-linux)
+    libdatadog (8.0.0.1.0-aarch64-linux)
+    libdatadog (8.0.0.1.0-x86_64-linux)
     libddwaf (1.14.0.0.0-aarch64-linux)
       ffi (~> 1.0)
     libddwaf (1.14.0.0.0-x86_64-linux)

--- a/gemfiles/ruby_3.1_contrib_old.gemfile.lock
+++ b/gemfiles/ruby_3.1_contrib_old.gemfile.lock
@@ -14,7 +14,7 @@ PATH
     ddtrace (1.21.1)
       datadog-ci (~> 0.8.1)
       debase-ruby_core_source (= 3.3.1)
-      libdatadog (~> 7.0.0.1.0)
+      libdatadog (~> 8.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
 
@@ -67,8 +67,8 @@ GEM
     json (2.6.3)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (7.0.0.1.0-aarch64-linux)
-    libdatadog (7.0.0.1.0-x86_64-linux)
+    libdatadog (8.0.0.1.0-aarch64-linux)
+    libdatadog (8.0.0.1.0-x86_64-linux)
     libddwaf (1.14.0.0.0-aarch64-linux)
       ffi (~> 1.0)
     libddwaf (1.14.0.0.0-x86_64-linux)

--- a/gemfiles/ruby_3.1_core_old.gemfile.lock
+++ b/gemfiles/ruby_3.1_core_old.gemfile.lock
@@ -14,7 +14,7 @@ PATH
     ddtrace (1.21.1)
       datadog-ci (~> 0.8.1)
       debase-ruby_core_source (= 3.3.1)
-      libdatadog (~> 7.0.0.1.0)
+      libdatadog (~> 8.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
 
@@ -56,8 +56,8 @@ GEM
     json (2.6.3)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (7.0.0.1.0-aarch64-linux)
-    libdatadog (7.0.0.1.0-x86_64-linux)
+    libdatadog (8.0.0.1.0-aarch64-linux)
+    libdatadog (8.0.0.1.0-x86_64-linux)
     libddwaf (1.14.0.0.0-aarch64-linux)
       ffi (~> 1.0)
     libddwaf (1.14.0.0.0-x86_64-linux)

--- a/gemfiles/ruby_3.1_elasticsearch_7.gemfile.lock
+++ b/gemfiles/ruby_3.1_elasticsearch_7.gemfile.lock
@@ -14,7 +14,7 @@ PATH
     ddtrace (1.21.1)
       datadog-ci (~> 0.8.1)
       debase-ruby_core_source (= 3.3.1)
-      libdatadog (~> 7.0.0.1.0)
+      libdatadog (~> 8.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
 
@@ -88,8 +88,8 @@ GEM
     json (2.6.3)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (7.0.0.1.0-aarch64-linux)
-    libdatadog (7.0.0.1.0-x86_64-linux)
+    libdatadog (8.0.0.1.0-aarch64-linux)
+    libdatadog (8.0.0.1.0-x86_64-linux)
     libddwaf (1.14.0.0.0-aarch64-linux)
       ffi (~> 1.0)
     libddwaf (1.14.0.0.0-x86_64-linux)

--- a/gemfiles/ruby_3.1_elasticsearch_8.gemfile.lock
+++ b/gemfiles/ruby_3.1_elasticsearch_8.gemfile.lock
@@ -14,7 +14,7 @@ PATH
     ddtrace (1.21.1)
       datadog-ci (~> 0.8.1)
       debase-ruby_core_source (= 3.3.1)
-      libdatadog (~> 7.0.0.1.0)
+      libdatadog (~> 8.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
 
@@ -71,8 +71,8 @@ GEM
     json (2.6.3)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (7.0.0.1.0-aarch64-linux)
-    libdatadog (7.0.0.1.0-x86_64-linux)
+    libdatadog (8.0.0.1.0-aarch64-linux)
+    libdatadog (8.0.0.1.0-x86_64-linux)
     libddwaf (1.14.0.0.0-aarch64-linux)
       ffi (~> 1.0)
     libddwaf (1.14.0.0.0-x86_64-linux)

--- a/gemfiles/ruby_3.1_graphql_1.12.gemfile.lock
+++ b/gemfiles/ruby_3.1_graphql_1.12.gemfile.lock
@@ -14,7 +14,7 @@ PATH
     ddtrace (1.21.1)
       datadog-ci (~> 0.8.1)
       debase-ruby_core_source (= 3.3.1)
-      libdatadog (~> 7.0.0.1.0)
+      libdatadog (~> 8.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
 
@@ -58,8 +58,8 @@ GEM
     json (2.7.1)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (7.0.0.1.0-aarch64-linux)
-    libdatadog (7.0.0.1.0-x86_64-linux)
+    libdatadog (8.0.0.1.0-aarch64-linux)
+    libdatadog (8.0.0.1.0-x86_64-linux)
     libddwaf (1.14.0.0.0-aarch64-linux)
       ffi (~> 1.0)
     libddwaf (1.14.0.0.0-x86_64-linux)

--- a/gemfiles/ruby_3.1_graphql_1.13.gemfile.lock
+++ b/gemfiles/ruby_3.1_graphql_1.13.gemfile.lock
@@ -14,7 +14,7 @@ PATH
     ddtrace (1.21.1)
       datadog-ci (~> 0.8.1)
       debase-ruby_core_source (= 3.3.1)
-      libdatadog (~> 7.0.0.1.0)
+      libdatadog (~> 8.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
 
@@ -58,8 +58,8 @@ GEM
     json (2.7.1)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (7.0.0.1.0-aarch64-linux)
-    libdatadog (7.0.0.1.0-x86_64-linux)
+    libdatadog (8.0.0.1.0-aarch64-linux)
+    libdatadog (8.0.0.1.0-x86_64-linux)
     libddwaf (1.14.0.0.0-aarch64-linux)
       ffi (~> 1.0)
     libddwaf (1.14.0.0.0-x86_64-linux)

--- a/gemfiles/ruby_3.1_graphql_2.0.gemfile.lock
+++ b/gemfiles/ruby_3.1_graphql_2.0.gemfile.lock
@@ -14,7 +14,7 @@ PATH
     ddtrace (1.21.1)
       datadog-ci (~> 0.8.1)
       debase-ruby_core_source (= 3.3.1)
-      libdatadog (~> 7.0.0.1.0)
+      libdatadog (~> 8.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
 
@@ -58,8 +58,8 @@ GEM
     json (2.7.1)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (7.0.0.1.0-aarch64-linux)
-    libdatadog (7.0.0.1.0-x86_64-linux)
+    libdatadog (8.0.0.1.0-aarch64-linux)
+    libdatadog (8.0.0.1.0-x86_64-linux)
     libddwaf (1.14.0.0.0-aarch64-linux)
       ffi (~> 1.0)
     libddwaf (1.14.0.0.0-x86_64-linux)

--- a/gemfiles/ruby_3.1_graphql_2.1.gemfile.lock
+++ b/gemfiles/ruby_3.1_graphql_2.1.gemfile.lock
@@ -14,7 +14,7 @@ PATH
     ddtrace (1.21.1)
       datadog-ci (~> 0.8.1)
       debase-ruby_core_source (= 3.3.1)
-      libdatadog (~> 7.0.0.1.0)
+      libdatadog (~> 8.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
 
@@ -59,8 +59,8 @@ GEM
     json (2.7.1)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (7.0.0.1.0-aarch64-linux)
-    libdatadog (7.0.0.1.0-x86_64-linux)
+    libdatadog (8.0.0.1.0-aarch64-linux)
+    libdatadog (8.0.0.1.0-x86_64-linux)
     libddwaf (1.14.0.0.0-aarch64-linux)
       ffi (~> 1.0)
     libddwaf (1.14.0.0.0-x86_64-linux)

--- a/gemfiles/ruby_3.1_graphql_2.2.gemfile.lock
+++ b/gemfiles/ruby_3.1_graphql_2.2.gemfile.lock
@@ -14,7 +14,7 @@ PATH
     ddtrace (1.21.1)
       datadog-ci (~> 0.8.1)
       debase-ruby_core_source (= 3.3.1)
-      libdatadog (~> 7.0.0.1.0)
+      libdatadog (~> 8.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
 
@@ -59,8 +59,8 @@ GEM
     json (2.7.1)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (7.0.0.1.0-aarch64-linux)
-    libdatadog (7.0.0.1.0-x86_64-linux)
+    libdatadog (8.0.0.1.0-aarch64-linux)
+    libdatadog (8.0.0.1.0-x86_64-linux)
     libddwaf (1.14.0.0.0-aarch64-linux)
       ffi (~> 1.0)
     libddwaf (1.14.0.0.0-x86_64-linux)

--- a/gemfiles/ruby_3.1_http.gemfile.lock
+++ b/gemfiles/ruby_3.1_http.gemfile.lock
@@ -14,7 +14,7 @@ PATH
     ddtrace (1.21.1)
       datadog-ci (~> 0.8.1)
       debase-ruby_core_source (= 3.3.1)
-      libdatadog (~> 7.0.0.1.0)
+      libdatadog (~> 8.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
 
@@ -78,8 +78,8 @@ GEM
     json (2.6.3)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (7.0.0.1.0-aarch64-linux)
-    libdatadog (7.0.0.1.0-x86_64-linux)
+    libdatadog (8.0.0.1.0-aarch64-linux)
+    libdatadog (8.0.0.1.0-x86_64-linux)
     libddwaf (1.14.0.0.0-aarch64-linux)
       ffi (~> 1.0)
     libddwaf (1.14.0.0.0-x86_64-linux)

--- a/gemfiles/ruby_3.1_opensearch_2.gemfile.lock
+++ b/gemfiles/ruby_3.1_opensearch_2.gemfile.lock
@@ -14,7 +14,7 @@ PATH
     ddtrace (1.21.1)
       datadog-ci (~> 0.8.1)
       debase-ruby_core_source (= 3.3.1)
-      libdatadog (~> 7.0.0.1.0)
+      libdatadog (~> 8.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
 
@@ -63,8 +63,8 @@ GEM
     json (2.6.3)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (7.0.0.1.0-aarch64-linux)
-    libdatadog (7.0.0.1.0-x86_64-linux)
+    libdatadog (8.0.0.1.0-aarch64-linux)
+    libdatadog (8.0.0.1.0-x86_64-linux)
     libddwaf (1.14.0.0.0-aarch64-linux)
       ffi (~> 1.0)
     libddwaf (1.14.0.0.0-x86_64-linux)

--- a/gemfiles/ruby_3.1_opensearch_3.gemfile.lock
+++ b/gemfiles/ruby_3.1_opensearch_3.gemfile.lock
@@ -14,7 +14,7 @@ PATH
     ddtrace (1.21.1)
       datadog-ci (~> 0.8.1)
       debase-ruby_core_source (= 3.3.1)
-      libdatadog (~> 7.0.0.1.0)
+      libdatadog (~> 8.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
 
@@ -63,8 +63,8 @@ GEM
     json (2.6.3)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (7.0.0.1.0-aarch64-linux)
-    libdatadog (7.0.0.1.0-x86_64-linux)
+    libdatadog (8.0.0.1.0-aarch64-linux)
+    libdatadog (8.0.0.1.0-x86_64-linux)
     libddwaf (1.14.0.0.0-aarch64-linux)
       ffi (~> 1.0)
     libddwaf (1.14.0.0.0-x86_64-linux)

--- a/gemfiles/ruby_3.1_opentelemetry.gemfile.lock
+++ b/gemfiles/ruby_3.1_opentelemetry.gemfile.lock
@@ -14,7 +14,7 @@ PATH
     ddtrace (1.21.1)
       datadog-ci (~> 0.8.1)
       debase-ruby_core_source (= 3.3.1)
-      libdatadog (~> 7.0.0.1.0)
+      libdatadog (~> 8.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
 
@@ -57,9 +57,9 @@ GEM
     json (2.6.3)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (7.0.0.1.0)
-    libdatadog (7.0.0.1.0-aarch64-linux)
-    libdatadog (7.0.0.1.0-x86_64-linux)
+    libdatadog (8.0.0.1.0)
+    libdatadog (8.0.0.1.0-aarch64-linux)
+    libdatadog (8.0.0.1.0-x86_64-linux)
     libddwaf (1.14.0.0.0-aarch64-linux)
       ffi (~> 1.0)
     libddwaf (1.14.0.0.0-x86_64-darwin)

--- a/gemfiles/ruby_3.1_opentracing.gemfile.lock
+++ b/gemfiles/ruby_3.1_opentracing.gemfile.lock
@@ -14,7 +14,7 @@ PATH
     ddtrace (1.21.1)
       datadog-ci (~> 0.8.1)
       debase-ruby_core_source (= 3.3.1)
-      libdatadog (~> 7.0.0.1.0)
+      libdatadog (~> 8.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
 
@@ -57,8 +57,8 @@ GEM
     json (2.6.3)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (7.0.0.1.0-aarch64-linux)
-    libdatadog (7.0.0.1.0-x86_64-linux)
+    libdatadog (8.0.0.1.0-aarch64-linux)
+    libdatadog (8.0.0.1.0-x86_64-linux)
     libddwaf (1.14.0.0.0-aarch64-linux)
       ffi (~> 1.0)
     libddwaf (1.14.0.0.0-x86_64-linux)

--- a/gemfiles/ruby_3.1_rack_1.gemfile.lock
+++ b/gemfiles/ruby_3.1_rack_1.gemfile.lock
@@ -14,7 +14,7 @@ PATH
     ddtrace (1.21.1)
       datadog-ci (~> 0.8.1)
       debase-ruby_core_source (= 3.3.1)
-      libdatadog (~> 7.0.0.1.0)
+      libdatadog (~> 8.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
 
@@ -56,8 +56,8 @@ GEM
     json (2.6.3)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (7.0.0.1.0-aarch64-linux)
-    libdatadog (7.0.0.1.0-x86_64-linux)
+    libdatadog (8.0.0.1.0-aarch64-linux)
+    libdatadog (8.0.0.1.0-x86_64-linux)
     libddwaf (1.14.0.0.0-aarch64-linux)
       ffi (~> 1.0)
     libddwaf (1.14.0.0.0-x86_64-linux)

--- a/gemfiles/ruby_3.1_rack_2.gemfile.lock
+++ b/gemfiles/ruby_3.1_rack_2.gemfile.lock
@@ -14,7 +14,7 @@ PATH
     ddtrace (1.21.1)
       datadog-ci (~> 0.8.1)
       debase-ruby_core_source (= 3.3.1)
-      libdatadog (~> 7.0.0.1.0)
+      libdatadog (~> 8.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
 
@@ -56,8 +56,8 @@ GEM
     json (2.6.3)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (7.0.0.1.0-aarch64-linux)
-    libdatadog (7.0.0.1.0-x86_64-linux)
+    libdatadog (8.0.0.1.0-aarch64-linux)
+    libdatadog (8.0.0.1.0-x86_64-linux)
     libddwaf (1.14.0.0.0-aarch64-linux)
       ffi (~> 1.0)
     libddwaf (1.14.0.0.0-x86_64-linux)

--- a/gemfiles/ruby_3.1_rack_3.gemfile.lock
+++ b/gemfiles/ruby_3.1_rack_3.gemfile.lock
@@ -14,7 +14,7 @@ PATH
     ddtrace (1.21.1)
       datadog-ci (~> 0.8.1)
       debase-ruby_core_source (= 3.3.1)
-      libdatadog (~> 7.0.0.1.0)
+      libdatadog (~> 8.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
 
@@ -56,8 +56,8 @@ GEM
     json (2.6.3)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (7.0.0.1.0-aarch64-linux)
-    libdatadog (7.0.0.1.0-x86_64-linux)
+    libdatadog (8.0.0.1.0-aarch64-linux)
+    libdatadog (8.0.0.1.0-x86_64-linux)
     libddwaf (1.14.0.0.0-aarch64-linux)
       ffi (~> 1.0)
     libddwaf (1.14.0.0.0-x86_64-linux)

--- a/gemfiles/ruby_3.1_rails61_mysql2.gemfile.lock
+++ b/gemfiles/ruby_3.1_rails61_mysql2.gemfile.lock
@@ -14,7 +14,7 @@ PATH
     ddtrace (1.21.1)
       datadog-ci (~> 0.8.1)
       debase-ruby_core_source (= 3.3.1)
-      libdatadog (~> 7.0.0.1.0)
+      libdatadog (~> 8.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
 
@@ -122,8 +122,8 @@ GEM
     json (2.6.3)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (7.0.0.1.0-aarch64-linux)
-    libdatadog (7.0.0.1.0-x86_64-linux)
+    libdatadog (8.0.0.1.0-aarch64-linux)
+    libdatadog (8.0.0.1.0-x86_64-linux)
     libddwaf (1.14.0.0.0-aarch64-linux)
       ffi (~> 1.0)
     libddwaf (1.14.0.0.0-x86_64-linux)

--- a/gemfiles/ruby_3.1_rails61_postgres.gemfile.lock
+++ b/gemfiles/ruby_3.1_rails61_postgres.gemfile.lock
@@ -14,7 +14,7 @@ PATH
     ddtrace (1.21.1)
       datadog-ci (~> 0.8.1)
       debase-ruby_core_source (= 3.3.1)
-      libdatadog (~> 7.0.0.1.0)
+      libdatadog (~> 8.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
 
@@ -122,8 +122,8 @@ GEM
     json (2.6.3)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (7.0.0.1.0-aarch64-linux)
-    libdatadog (7.0.0.1.0-x86_64-linux)
+    libdatadog (8.0.0.1.0-aarch64-linux)
+    libdatadog (8.0.0.1.0-x86_64-linux)
     libddwaf (1.14.0.0.0-aarch64-linux)
       ffi (~> 1.0)
     libddwaf (1.14.0.0.0-x86_64-linux)

--- a/gemfiles/ruby_3.1_rails61_postgres_redis.gemfile.lock
+++ b/gemfiles/ruby_3.1_rails61_postgres_redis.gemfile.lock
@@ -14,7 +14,7 @@ PATH
     ddtrace (1.21.1)
       datadog-ci (~> 0.8.1)
       debase-ruby_core_source (= 3.3.1)
-      libdatadog (~> 7.0.0.1.0)
+      libdatadog (~> 8.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
 
@@ -122,8 +122,8 @@ GEM
     json (2.6.3)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (7.0.0.1.0-aarch64-linux)
-    libdatadog (7.0.0.1.0-x86_64-linux)
+    libdatadog (8.0.0.1.0-aarch64-linux)
+    libdatadog (8.0.0.1.0-x86_64-linux)
     libddwaf (1.14.0.0.0-aarch64-linux)
       ffi (~> 1.0)
     libddwaf (1.14.0.0.0-x86_64-linux)

--- a/gemfiles/ruby_3.1_rails61_postgres_sidekiq.gemfile.lock
+++ b/gemfiles/ruby_3.1_rails61_postgres_sidekiq.gemfile.lock
@@ -14,7 +14,7 @@ PATH
     ddtrace (1.21.1)
       datadog-ci (~> 0.8.1)
       debase-ruby_core_source (= 3.3.1)
-      libdatadog (~> 7.0.0.1.0)
+      libdatadog (~> 8.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
 
@@ -123,8 +123,8 @@ GEM
     json (2.6.3)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (7.0.0.1.0-aarch64-linux)
-    libdatadog (7.0.0.1.0-x86_64-linux)
+    libdatadog (8.0.0.1.0-aarch64-linux)
+    libdatadog (8.0.0.1.0-x86_64-linux)
     libddwaf (1.14.0.0.0-aarch64-linux)
       ffi (~> 1.0)
     libddwaf (1.14.0.0.0-x86_64-linux)

--- a/gemfiles/ruby_3.1_rails61_semantic_logger.gemfile.lock
+++ b/gemfiles/ruby_3.1_rails61_semantic_logger.gemfile.lock
@@ -14,7 +14,7 @@ PATH
     ddtrace (1.21.1)
       datadog-ci (~> 0.8.1)
       debase-ruby_core_source (= 3.3.1)
-      libdatadog (~> 7.0.0.1.0)
+      libdatadog (~> 8.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
 
@@ -122,8 +122,8 @@ GEM
     json (2.6.3)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (7.0.0.1.0-aarch64-linux)
-    libdatadog (7.0.0.1.0-x86_64-linux)
+    libdatadog (8.0.0.1.0-aarch64-linux)
+    libdatadog (8.0.0.1.0-x86_64-linux)
     libddwaf (1.14.0.0.0-aarch64-linux)
       ffi (~> 1.0)
     libddwaf (1.14.0.0.0-x86_64-linux)

--- a/gemfiles/ruby_3.1_rails61_trilogy.gemfile.lock
+++ b/gemfiles/ruby_3.1_rails61_trilogy.gemfile.lock
@@ -14,7 +14,7 @@ PATH
     ddtrace (1.21.1)
       datadog-ci (~> 0.8.1)
       debase-ruby_core_source (= 3.3.1)
-      libdatadog (~> 7.0.0.1.0)
+      libdatadog (~> 8.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
 
@@ -126,8 +126,8 @@ GEM
     json (2.6.3)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (7.0.0.1.0-aarch64-linux)
-    libdatadog (7.0.0.1.0-x86_64-linux)
+    libdatadog (8.0.0.1.0-aarch64-linux)
+    libdatadog (8.0.0.1.0-x86_64-linux)
     libddwaf (1.14.0.0.0-aarch64-linux)
       ffi (~> 1.0)
     libddwaf (1.14.0.0.0-x86_64-linux)

--- a/gemfiles/ruby_3.1_redis_3.gemfile.lock
+++ b/gemfiles/ruby_3.1_redis_3.gemfile.lock
@@ -14,7 +14,7 @@ PATH
     ddtrace (1.21.1)
       datadog-ci (~> 0.8.1)
       debase-ruby_core_source (= 3.3.1)
-      libdatadog (~> 7.0.0.1.0)
+      libdatadog (~> 8.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
 
@@ -56,8 +56,8 @@ GEM
     json (2.6.3)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (7.0.0.1.0-aarch64-linux)
-    libdatadog (7.0.0.1.0-x86_64-linux)
+    libdatadog (8.0.0.1.0-aarch64-linux)
+    libdatadog (8.0.0.1.0-x86_64-linux)
     libddwaf (1.14.0.0.0-aarch64-linux)
       ffi (~> 1.0)
     libddwaf (1.14.0.0.0-x86_64-linux)

--- a/gemfiles/ruby_3.1_redis_4.gemfile.lock
+++ b/gemfiles/ruby_3.1_redis_4.gemfile.lock
@@ -14,7 +14,7 @@ PATH
     ddtrace (1.21.1)
       datadog-ci (~> 0.8.1)
       debase-ruby_core_source (= 3.3.1)
-      libdatadog (~> 7.0.0.1.0)
+      libdatadog (~> 8.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
 
@@ -56,8 +56,8 @@ GEM
     json (2.6.3)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (7.0.0.1.0-aarch64-linux)
-    libdatadog (7.0.0.1.0-x86_64-linux)
+    libdatadog (8.0.0.1.0-aarch64-linux)
+    libdatadog (8.0.0.1.0-x86_64-linux)
     libddwaf (1.14.0.0.0-aarch64-linux)
       ffi (~> 1.0)
     libddwaf (1.14.0.0.0-x86_64-linux)

--- a/gemfiles/ruby_3.1_redis_5.gemfile.lock
+++ b/gemfiles/ruby_3.1_redis_5.gemfile.lock
@@ -14,7 +14,7 @@ PATH
     ddtrace (1.21.1)
       datadog-ci (~> 0.8.1)
       debase-ruby_core_source (= 3.3.1)
-      libdatadog (~> 7.0.0.1.0)
+      libdatadog (~> 8.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
 
@@ -57,8 +57,8 @@ GEM
     json (2.6.3)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (7.0.0.1.0-aarch64-linux)
-    libdatadog (7.0.0.1.0-x86_64-linux)
+    libdatadog (8.0.0.1.0-aarch64-linux)
+    libdatadog (8.0.0.1.0-x86_64-linux)
     libddwaf (1.14.0.0.0-aarch64-linux)
       ffi (~> 1.0)
     libddwaf (1.14.0.0.0-x86_64-linux)

--- a/gemfiles/ruby_3.1_relational_db.gemfile.lock
+++ b/gemfiles/ruby_3.1_relational_db.gemfile.lock
@@ -14,7 +14,7 @@ PATH
     ddtrace (1.21.1)
       datadog-ci (~> 0.8.1)
       debase-ruby_core_source (= 3.3.1)
-      libdatadog (~> 7.0.0.1.0)
+      libdatadog (~> 8.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
 
@@ -73,8 +73,8 @@ GEM
     json (2.6.3)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (7.0.0.1.0-aarch64-linux)
-    libdatadog (7.0.0.1.0-x86_64-linux)
+    libdatadog (8.0.0.1.0-aarch64-linux)
+    libdatadog (8.0.0.1.0-x86_64-linux)
     libddwaf (1.14.0.0.0-aarch64-linux)
       ffi (~> 1.0)
     libddwaf (1.14.0.0.0-x86_64-linux)

--- a/gemfiles/ruby_3.1_resque2_redis3.gemfile.lock
+++ b/gemfiles/ruby_3.1_resque2_redis3.gemfile.lock
@@ -14,7 +14,7 @@ PATH
     ddtrace (1.21.1)
       datadog-ci (~> 0.8.1)
       debase-ruby_core_source (= 3.3.1)
-      libdatadog (~> 7.0.0.1.0)
+      libdatadog (~> 8.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
 
@@ -56,8 +56,8 @@ GEM
     json (2.6.3)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (7.0.0.1.0-aarch64-linux)
-    libdatadog (7.0.0.1.0-x86_64-linux)
+    libdatadog (8.0.0.1.0-aarch64-linux)
+    libdatadog (8.0.0.1.0-x86_64-linux)
     libddwaf (1.14.0.0.0-aarch64-linux)
       ffi (~> 1.0)
     libddwaf (1.14.0.0.0-x86_64-linux)

--- a/gemfiles/ruby_3.1_resque2_redis4.gemfile.lock
+++ b/gemfiles/ruby_3.1_resque2_redis4.gemfile.lock
@@ -14,7 +14,7 @@ PATH
     ddtrace (1.21.1)
       datadog-ci (~> 0.8.1)
       debase-ruby_core_source (= 3.3.1)
-      libdatadog (~> 7.0.0.1.0)
+      libdatadog (~> 8.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
 
@@ -57,8 +57,8 @@ GEM
     json (2.6.3)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (7.0.0.1.0-aarch64-linux)
-    libdatadog (7.0.0.1.0-x86_64-linux)
+    libdatadog (8.0.0.1.0-aarch64-linux)
+    libdatadog (8.0.0.1.0-x86_64-linux)
     libddwaf (1.14.0.0.0-aarch64-linux)
       ffi (~> 1.0)
     libddwaf (1.14.0.0.0-x86_64-linux)

--- a/gemfiles/ruby_3.1_sinatra.gemfile.lock
+++ b/gemfiles/ruby_3.1_sinatra.gemfile.lock
@@ -14,7 +14,7 @@ PATH
     ddtrace (1.21.1)
       datadog-ci (~> 0.8.1)
       debase-ruby_core_source (= 3.3.1)
-      libdatadog (~> 7.0.0.1.0)
+      libdatadog (~> 8.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
 
@@ -56,8 +56,8 @@ GEM
     json (2.6.3)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (7.0.0.1.0-aarch64-linux)
-    libdatadog (7.0.0.1.0-x86_64-linux)
+    libdatadog (8.0.0.1.0-aarch64-linux)
+    libdatadog (8.0.0.1.0-x86_64-linux)
     libddwaf (1.14.0.0.0-aarch64-linux)
       ffi (~> 1.0)
     libddwaf (1.14.0.0.0-x86_64-linux)

--- a/gemfiles/ruby_3.2_activesupport.gemfile.lock
+++ b/gemfiles/ruby_3.2_activesupport.gemfile.lock
@@ -14,7 +14,7 @@ PATH
     ddtrace (1.21.1)
       datadog-ci (~> 0.8.1)
       debase-ruby_core_source (= 3.3.1)
-      libdatadog (~> 7.0.0.1.0)
+      libdatadog (~> 8.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
 
@@ -111,8 +111,8 @@ GEM
       addressable (>= 2.4)
     jsonapi-renderer (0.2.2)
     king_konf (1.0.1)
-    libdatadog (7.0.0.1.0-aarch64-linux)
-    libdatadog (7.0.0.1.0-x86_64-linux)
+    libdatadog (8.0.0.1.0-aarch64-linux)
+    libdatadog (8.0.0.1.0-x86_64-linux)
     libddwaf (1.14.0.0.0-aarch64-linux)
       ffi (~> 1.0)
     libddwaf (1.14.0.0.0-x86_64-linux)

--- a/gemfiles/ruby_3.2_aws.gemfile.lock
+++ b/gemfiles/ruby_3.2_aws.gemfile.lock
@@ -14,7 +14,7 @@ PATH
     ddtrace (1.21.1)
       datadog-ci (~> 0.8.1)
       debase-ruby_core_source (= 3.3.1)
-      libdatadog (~> 7.0.0.1.0)
+      libdatadog (~> 8.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
 
@@ -1477,8 +1477,8 @@ GEM
     json (2.6.3)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (7.0.0.1.0-aarch64-linux)
-    libdatadog (7.0.0.1.0-x86_64-linux)
+    libdatadog (8.0.0.1.0-aarch64-linux)
+    libdatadog (8.0.0.1.0-x86_64-linux)
     libddwaf (1.14.0.0.0-aarch64-linux)
       ffi (~> 1.0)
     libddwaf (1.14.0.0.0-x86_64-linux)

--- a/gemfiles/ruby_3.2_contrib.gemfile.lock
+++ b/gemfiles/ruby_3.2_contrib.gemfile.lock
@@ -14,7 +14,7 @@ PATH
     ddtrace (1.21.1)
       datadog-ci (~> 0.8.1)
       debase-ruby_core_source (= 3.3.1)
-      libdatadog (~> 7.0.0.1.0)
+      libdatadog (~> 8.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
 
@@ -70,8 +70,8 @@ GEM
     json (2.6.3)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (7.0.0.1.0-aarch64-linux)
-    libdatadog (7.0.0.1.0-x86_64-linux)
+    libdatadog (8.0.0.1.0-aarch64-linux)
+    libdatadog (8.0.0.1.0-x86_64-linux)
     libddwaf (1.14.0.0.0-aarch64-linux)
       ffi (~> 1.0)
     libddwaf (1.14.0.0.0-x86_64-linux)

--- a/gemfiles/ruby_3.2_contrib_old.gemfile.lock
+++ b/gemfiles/ruby_3.2_contrib_old.gemfile.lock
@@ -14,7 +14,7 @@ PATH
     ddtrace (1.21.1)
       datadog-ci (~> 0.8.1)
       debase-ruby_core_source (= 3.3.1)
-      libdatadog (~> 7.0.0.1.0)
+      libdatadog (~> 8.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
 
@@ -66,8 +66,8 @@ GEM
     json (2.6.3)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (7.0.0.1.0-aarch64-linux)
-    libdatadog (7.0.0.1.0-x86_64-linux)
+    libdatadog (8.0.0.1.0-aarch64-linux)
+    libdatadog (8.0.0.1.0-x86_64-linux)
     libddwaf (1.14.0.0.0-aarch64-linux)
       ffi (~> 1.0)
     libddwaf (1.14.0.0.0-x86_64-linux)

--- a/gemfiles/ruby_3.2_core_old.gemfile.lock
+++ b/gemfiles/ruby_3.2_core_old.gemfile.lock
@@ -14,7 +14,7 @@ PATH
     ddtrace (1.21.1)
       datadog-ci (~> 0.8.1)
       debase-ruby_core_source (= 3.3.1)
-      libdatadog (~> 7.0.0.1.0)
+      libdatadog (~> 8.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
 
@@ -55,8 +55,8 @@ GEM
     json (2.6.3)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (7.0.0.1.0-aarch64-linux)
-    libdatadog (7.0.0.1.0-x86_64-linux)
+    libdatadog (8.0.0.1.0-aarch64-linux)
+    libdatadog (8.0.0.1.0-x86_64-linux)
     libddwaf (1.14.0.0.0-aarch64-linux)
       ffi (~> 1.0)
     libddwaf (1.14.0.0.0-x86_64-linux)

--- a/gemfiles/ruby_3.2_elasticsearch_7.gemfile.lock
+++ b/gemfiles/ruby_3.2_elasticsearch_7.gemfile.lock
@@ -14,7 +14,7 @@ PATH
     ddtrace (1.21.1)
       datadog-ci (~> 0.8.1)
       debase-ruby_core_source (= 3.3.1)
-      libdatadog (~> 7.0.0.1.0)
+      libdatadog (~> 8.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
 
@@ -87,8 +87,8 @@ GEM
     json (2.6.3)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (7.0.0.1.0-aarch64-linux)
-    libdatadog (7.0.0.1.0-x86_64-linux)
+    libdatadog (8.0.0.1.0-aarch64-linux)
+    libdatadog (8.0.0.1.0-x86_64-linux)
     libddwaf (1.14.0.0.0-aarch64-linux)
       ffi (~> 1.0)
     libddwaf (1.14.0.0.0-x86_64-linux)

--- a/gemfiles/ruby_3.2_elasticsearch_8.gemfile.lock
+++ b/gemfiles/ruby_3.2_elasticsearch_8.gemfile.lock
@@ -14,7 +14,7 @@ PATH
     ddtrace (1.21.1)
       datadog-ci (~> 0.8.1)
       debase-ruby_core_source (= 3.3.1)
-      libdatadog (~> 7.0.0.1.0)
+      libdatadog (~> 8.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
 
@@ -70,8 +70,8 @@ GEM
     json (2.6.3)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (7.0.0.1.0-aarch64-linux)
-    libdatadog (7.0.0.1.0-x86_64-linux)
+    libdatadog (8.0.0.1.0-aarch64-linux)
+    libdatadog (8.0.0.1.0-x86_64-linux)
     libddwaf (1.14.0.0.0-aarch64-linux)
       ffi (~> 1.0)
     libddwaf (1.14.0.0.0-x86_64-linux)

--- a/gemfiles/ruby_3.2_graphql_1.12.gemfile.lock
+++ b/gemfiles/ruby_3.2_graphql_1.12.gemfile.lock
@@ -14,7 +14,7 @@ PATH
     ddtrace (1.21.1)
       datadog-ci (~> 0.8.1)
       debase-ruby_core_source (= 3.3.1)
-      libdatadog (~> 7.0.0.1.0)
+      libdatadog (~> 8.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
 
@@ -57,8 +57,8 @@ GEM
     json (2.7.1)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (7.0.0.1.0-aarch64-linux)
-    libdatadog (7.0.0.1.0-x86_64-linux)
+    libdatadog (8.0.0.1.0-aarch64-linux)
+    libdatadog (8.0.0.1.0-x86_64-linux)
     libddwaf (1.14.0.0.0-aarch64-linux)
       ffi (~> 1.0)
     libddwaf (1.14.0.0.0-x86_64-linux)

--- a/gemfiles/ruby_3.2_graphql_1.13.gemfile.lock
+++ b/gemfiles/ruby_3.2_graphql_1.13.gemfile.lock
@@ -14,7 +14,7 @@ PATH
     ddtrace (1.21.1)
       datadog-ci (~> 0.8.1)
       debase-ruby_core_source (= 3.3.1)
-      libdatadog (~> 7.0.0.1.0)
+      libdatadog (~> 8.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
 
@@ -57,8 +57,8 @@ GEM
     json (2.7.1)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (7.0.0.1.0-aarch64-linux)
-    libdatadog (7.0.0.1.0-x86_64-linux)
+    libdatadog (8.0.0.1.0-aarch64-linux)
+    libdatadog (8.0.0.1.0-x86_64-linux)
     libddwaf (1.14.0.0.0-aarch64-linux)
       ffi (~> 1.0)
     libddwaf (1.14.0.0.0-x86_64-linux)

--- a/gemfiles/ruby_3.2_graphql_2.0.gemfile.lock
+++ b/gemfiles/ruby_3.2_graphql_2.0.gemfile.lock
@@ -14,7 +14,7 @@ PATH
     ddtrace (1.21.1)
       datadog-ci (~> 0.8.1)
       debase-ruby_core_source (= 3.3.1)
-      libdatadog (~> 7.0.0.1.0)
+      libdatadog (~> 8.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
 
@@ -57,8 +57,8 @@ GEM
     json (2.7.1)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (7.0.0.1.0-aarch64-linux)
-    libdatadog (7.0.0.1.0-x86_64-linux)
+    libdatadog (8.0.0.1.0-aarch64-linux)
+    libdatadog (8.0.0.1.0-x86_64-linux)
     libddwaf (1.14.0.0.0-aarch64-linux)
       ffi (~> 1.0)
     libddwaf (1.14.0.0.0-x86_64-linux)

--- a/gemfiles/ruby_3.2_graphql_2.1.gemfile.lock
+++ b/gemfiles/ruby_3.2_graphql_2.1.gemfile.lock
@@ -14,7 +14,7 @@ PATH
     ddtrace (1.21.1)
       datadog-ci (~> 0.8.1)
       debase-ruby_core_source (= 3.3.1)
-      libdatadog (~> 7.0.0.1.0)
+      libdatadog (~> 8.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
 
@@ -58,8 +58,8 @@ GEM
     json (2.7.1)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (7.0.0.1.0-aarch64-linux)
-    libdatadog (7.0.0.1.0-x86_64-linux)
+    libdatadog (8.0.0.1.0-aarch64-linux)
+    libdatadog (8.0.0.1.0-x86_64-linux)
     libddwaf (1.14.0.0.0-aarch64-linux)
       ffi (~> 1.0)
     libddwaf (1.14.0.0.0-x86_64-linux)

--- a/gemfiles/ruby_3.2_graphql_2.2.gemfile.lock
+++ b/gemfiles/ruby_3.2_graphql_2.2.gemfile.lock
@@ -14,7 +14,7 @@ PATH
     ddtrace (1.21.1)
       datadog-ci (~> 0.8.1)
       debase-ruby_core_source (= 3.3.1)
-      libdatadog (~> 7.0.0.1.0)
+      libdatadog (~> 8.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
 
@@ -58,8 +58,8 @@ GEM
     json (2.7.1)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (7.0.0.1.0-aarch64-linux)
-    libdatadog (7.0.0.1.0-x86_64-linux)
+    libdatadog (8.0.0.1.0-aarch64-linux)
+    libdatadog (8.0.0.1.0-x86_64-linux)
     libddwaf (1.14.0.0.0-aarch64-linux)
       ffi (~> 1.0)
     libddwaf (1.14.0.0.0-x86_64-linux)

--- a/gemfiles/ruby_3.2_http.gemfile.lock
+++ b/gemfiles/ruby_3.2_http.gemfile.lock
@@ -14,7 +14,7 @@ PATH
     ddtrace (1.21.1)
       datadog-ci (~> 0.8.1)
       debase-ruby_core_source (= 3.3.1)
-      libdatadog (~> 7.0.0.1.0)
+      libdatadog (~> 8.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
 
@@ -77,8 +77,8 @@ GEM
     json (2.6.3)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (7.0.0.1.0-aarch64-linux)
-    libdatadog (7.0.0.1.0-x86_64-linux)
+    libdatadog (8.0.0.1.0-aarch64-linux)
+    libdatadog (8.0.0.1.0-x86_64-linux)
     libddwaf (1.14.0.0.0-aarch64-linux)
       ffi (~> 1.0)
     libddwaf (1.14.0.0.0-x86_64-linux)

--- a/gemfiles/ruby_3.2_multi_rack_app.gemfile.lock
+++ b/gemfiles/ruby_3.2_multi_rack_app.gemfile.lock
@@ -14,7 +14,7 @@ PATH
     ddtrace (1.21.1)
       datadog-ci (~> 0.8.1)
       debase-ruby_core_source (= 3.3.1)
-      libdatadog (~> 7.0.0.1.0)
+      libdatadog (~> 8.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
 
@@ -147,8 +147,8 @@ GEM
     json (2.7.1)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (7.0.0.1.0-aarch64-linux)
-    libdatadog (7.0.0.1.0-x86_64-linux)
+    libdatadog (8.0.0.1.0-aarch64-linux)
+    libdatadog (8.0.0.1.0-x86_64-linux)
     libddwaf (1.14.0.0.0-aarch64-linux)
       ffi (~> 1.0)
     libddwaf (1.14.0.0.0-x86_64-linux)

--- a/gemfiles/ruby_3.2_opensearch_2.gemfile.lock
+++ b/gemfiles/ruby_3.2_opensearch_2.gemfile.lock
@@ -14,7 +14,7 @@ PATH
     ddtrace (1.21.1)
       datadog-ci (~> 0.8.1)
       debase-ruby_core_source (= 3.3.1)
-      libdatadog (~> 7.0.0.1.0)
+      libdatadog (~> 8.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
 
@@ -62,8 +62,8 @@ GEM
     json (2.6.3)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (7.0.0.1.0-aarch64-linux)
-    libdatadog (7.0.0.1.0-x86_64-linux)
+    libdatadog (8.0.0.1.0-aarch64-linux)
+    libdatadog (8.0.0.1.0-x86_64-linux)
     libddwaf (1.14.0.0.0-aarch64-linux)
       ffi (~> 1.0)
     libddwaf (1.14.0.0.0-x86_64-linux)

--- a/gemfiles/ruby_3.2_opensearch_3.gemfile.lock
+++ b/gemfiles/ruby_3.2_opensearch_3.gemfile.lock
@@ -14,7 +14,7 @@ PATH
     ddtrace (1.21.1)
       datadog-ci (~> 0.8.1)
       debase-ruby_core_source (= 3.3.1)
-      libdatadog (~> 7.0.0.1.0)
+      libdatadog (~> 8.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
 
@@ -62,8 +62,8 @@ GEM
     json (2.6.3)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (7.0.0.1.0-aarch64-linux)
-    libdatadog (7.0.0.1.0-x86_64-linux)
+    libdatadog (8.0.0.1.0-aarch64-linux)
+    libdatadog (8.0.0.1.0-x86_64-linux)
     libddwaf (1.14.0.0.0-aarch64-linux)
       ffi (~> 1.0)
     libddwaf (1.14.0.0.0-x86_64-linux)

--- a/gemfiles/ruby_3.2_opentelemetry.gemfile.lock
+++ b/gemfiles/ruby_3.2_opentelemetry.gemfile.lock
@@ -14,7 +14,7 @@ PATH
     ddtrace (1.21.1)
       datadog-ci (~> 0.8.1)
       debase-ruby_core_source (= 3.3.1)
-      libdatadog (~> 7.0.0.1.0)
+      libdatadog (~> 8.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
 
@@ -55,8 +55,8 @@ GEM
     json (2.6.3)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (7.0.0.1.0-aarch64-linux)
-    libdatadog (7.0.0.1.0-x86_64-linux)
+    libdatadog (8.0.0.1.0-aarch64-linux)
+    libdatadog (8.0.0.1.0-x86_64-linux)
     libddwaf (1.14.0.0.0-aarch64-linux)
       ffi (~> 1.0)
     libddwaf (1.14.0.0.0-x86_64-linux)

--- a/gemfiles/ruby_3.2_opentracing.gemfile.lock
+++ b/gemfiles/ruby_3.2_opentracing.gemfile.lock
@@ -14,7 +14,7 @@ PATH
     ddtrace (1.21.1)
       datadog-ci (~> 0.8.1)
       debase-ruby_core_source (= 3.3.1)
-      libdatadog (~> 7.0.0.1.0)
+      libdatadog (~> 8.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
 
@@ -56,8 +56,8 @@ GEM
     json (2.6.3)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (7.0.0.1.0-aarch64-linux)
-    libdatadog (7.0.0.1.0-x86_64-linux)
+    libdatadog (8.0.0.1.0-aarch64-linux)
+    libdatadog (8.0.0.1.0-x86_64-linux)
     libddwaf (1.14.0.0.0-aarch64-linux)
       ffi (~> 1.0)
     libddwaf (1.14.0.0.0-x86_64-linux)

--- a/gemfiles/ruby_3.2_rack_1.gemfile.lock
+++ b/gemfiles/ruby_3.2_rack_1.gemfile.lock
@@ -14,7 +14,7 @@ PATH
     ddtrace (1.21.1)
       datadog-ci (~> 0.8.1)
       debase-ruby_core_source (= 3.3.1)
-      libdatadog (~> 7.0.0.1.0)
+      libdatadog (~> 8.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
 
@@ -55,8 +55,8 @@ GEM
     json (2.6.3)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (7.0.0.1.0-aarch64-linux)
-    libdatadog (7.0.0.1.0-x86_64-linux)
+    libdatadog (8.0.0.1.0-aarch64-linux)
+    libdatadog (8.0.0.1.0-x86_64-linux)
     libddwaf (1.14.0.0.0-aarch64-linux)
       ffi (~> 1.0)
     libddwaf (1.14.0.0.0-x86_64-linux)

--- a/gemfiles/ruby_3.2_rack_2.gemfile.lock
+++ b/gemfiles/ruby_3.2_rack_2.gemfile.lock
@@ -14,7 +14,7 @@ PATH
     ddtrace (1.21.1)
       datadog-ci (~> 0.8.1)
       debase-ruby_core_source (= 3.3.1)
-      libdatadog (~> 7.0.0.1.0)
+      libdatadog (~> 8.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
 
@@ -55,8 +55,8 @@ GEM
     json (2.6.3)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (7.0.0.1.0-aarch64-linux)
-    libdatadog (7.0.0.1.0-x86_64-linux)
+    libdatadog (8.0.0.1.0-aarch64-linux)
+    libdatadog (8.0.0.1.0-x86_64-linux)
     libddwaf (1.14.0.0.0-aarch64-linux)
       ffi (~> 1.0)
     libddwaf (1.14.0.0.0-x86_64-linux)

--- a/gemfiles/ruby_3.2_rack_3.gemfile.lock
+++ b/gemfiles/ruby_3.2_rack_3.gemfile.lock
@@ -14,7 +14,7 @@ PATH
     ddtrace (1.21.1)
       datadog-ci (~> 0.8.1)
       debase-ruby_core_source (= 3.3.1)
-      libdatadog (~> 7.0.0.1.0)
+      libdatadog (~> 8.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
 
@@ -55,8 +55,8 @@ GEM
     json (2.6.3)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (7.0.0.1.0-aarch64-linux)
-    libdatadog (7.0.0.1.0-x86_64-linux)
+    libdatadog (8.0.0.1.0-aarch64-linux)
+    libdatadog (8.0.0.1.0-x86_64-linux)
     libddwaf (1.14.0.0.0-aarch64-linux)
       ffi (~> 1.0)
     libddwaf (1.14.0.0.0-x86_64-linux)

--- a/gemfiles/ruby_3.2_rails61_mysql2.gemfile.lock
+++ b/gemfiles/ruby_3.2_rails61_mysql2.gemfile.lock
@@ -14,7 +14,7 @@ PATH
     ddtrace (1.21.1)
       datadog-ci (~> 0.8.1)
       debase-ruby_core_source (= 3.3.1)
-      libdatadog (~> 7.0.0.1.0)
+      libdatadog (~> 8.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
 
@@ -121,8 +121,8 @@ GEM
     json (2.6.3)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (7.0.0.1.0-aarch64-linux)
-    libdatadog (7.0.0.1.0-x86_64-linux)
+    libdatadog (8.0.0.1.0-aarch64-linux)
+    libdatadog (8.0.0.1.0-x86_64-linux)
     libddwaf (1.14.0.0.0-aarch64-linux)
       ffi (~> 1.0)
     libddwaf (1.14.0.0.0-x86_64-linux)

--- a/gemfiles/ruby_3.2_rails61_postgres.gemfile.lock
+++ b/gemfiles/ruby_3.2_rails61_postgres.gemfile.lock
@@ -14,7 +14,7 @@ PATH
     ddtrace (1.21.1)
       datadog-ci (~> 0.8.1)
       debase-ruby_core_source (= 3.3.1)
-      libdatadog (~> 7.0.0.1.0)
+      libdatadog (~> 8.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
 
@@ -121,8 +121,8 @@ GEM
     json (2.6.3)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (7.0.0.1.0-aarch64-linux)
-    libdatadog (7.0.0.1.0-x86_64-linux)
+    libdatadog (8.0.0.1.0-aarch64-linux)
+    libdatadog (8.0.0.1.0-x86_64-linux)
     libddwaf (1.14.0.0.0-aarch64-linux)
       ffi (~> 1.0)
     libddwaf (1.14.0.0.0-x86_64-linux)

--- a/gemfiles/ruby_3.2_rails61_postgres_redis.gemfile.lock
+++ b/gemfiles/ruby_3.2_rails61_postgres_redis.gemfile.lock
@@ -14,7 +14,7 @@ PATH
     ddtrace (1.21.1)
       datadog-ci (~> 0.8.1)
       debase-ruby_core_source (= 3.3.1)
-      libdatadog (~> 7.0.0.1.0)
+      libdatadog (~> 8.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
 
@@ -121,8 +121,8 @@ GEM
     json (2.6.3)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (7.0.0.1.0-aarch64-linux)
-    libdatadog (7.0.0.1.0-x86_64-linux)
+    libdatadog (8.0.0.1.0-aarch64-linux)
+    libdatadog (8.0.0.1.0-x86_64-linux)
     libddwaf (1.14.0.0.0-aarch64-linux)
       ffi (~> 1.0)
     libddwaf (1.14.0.0.0-x86_64-linux)

--- a/gemfiles/ruby_3.2_rails61_postgres_sidekiq.gemfile.lock
+++ b/gemfiles/ruby_3.2_rails61_postgres_sidekiq.gemfile.lock
@@ -14,7 +14,7 @@ PATH
     ddtrace (1.21.1)
       datadog-ci (~> 0.8.1)
       debase-ruby_core_source (= 3.3.1)
-      libdatadog (~> 7.0.0.1.0)
+      libdatadog (~> 8.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
 
@@ -122,8 +122,8 @@ GEM
     json (2.6.3)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (7.0.0.1.0-aarch64-linux)
-    libdatadog (7.0.0.1.0-x86_64-linux)
+    libdatadog (8.0.0.1.0-aarch64-linux)
+    libdatadog (8.0.0.1.0-x86_64-linux)
     libddwaf (1.14.0.0.0-aarch64-linux)
       ffi (~> 1.0)
     libddwaf (1.14.0.0.0-x86_64-linux)

--- a/gemfiles/ruby_3.2_rails61_semantic_logger.gemfile.lock
+++ b/gemfiles/ruby_3.2_rails61_semantic_logger.gemfile.lock
@@ -14,7 +14,7 @@ PATH
     ddtrace (1.21.1)
       datadog-ci (~> 0.8.1)
       debase-ruby_core_source (= 3.3.1)
-      libdatadog (~> 7.0.0.1.0)
+      libdatadog (~> 8.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
 
@@ -121,8 +121,8 @@ GEM
     json (2.6.3)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (7.0.0.1.0-aarch64-linux)
-    libdatadog (7.0.0.1.0-x86_64-linux)
+    libdatadog (8.0.0.1.0-aarch64-linux)
+    libdatadog (8.0.0.1.0-x86_64-linux)
     libddwaf (1.14.0.0.0-aarch64-linux)
       ffi (~> 1.0)
     libddwaf (1.14.0.0.0-x86_64-linux)

--- a/gemfiles/ruby_3.2_rails61_trilogy.gemfile.lock
+++ b/gemfiles/ruby_3.2_rails61_trilogy.gemfile.lock
@@ -14,7 +14,7 @@ PATH
     ddtrace (1.21.1)
       datadog-ci (~> 0.8.1)
       debase-ruby_core_source (= 3.3.1)
-      libdatadog (~> 7.0.0.1.0)
+      libdatadog (~> 8.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
 
@@ -125,8 +125,8 @@ GEM
     json (2.6.3)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (7.0.0.1.0-aarch64-linux)
-    libdatadog (7.0.0.1.0-x86_64-linux)
+    libdatadog (8.0.0.1.0-aarch64-linux)
+    libdatadog (8.0.0.1.0-x86_64-linux)
     libddwaf (1.14.0.0.0-aarch64-linux)
       ffi (~> 1.0)
     libddwaf (1.14.0.0.0-x86_64-linux)

--- a/gemfiles/ruby_3.2_redis_3.gemfile.lock
+++ b/gemfiles/ruby_3.2_redis_3.gemfile.lock
@@ -14,7 +14,7 @@ PATH
     ddtrace (1.21.1)
       datadog-ci (~> 0.8.1)
       debase-ruby_core_source (= 3.3.1)
-      libdatadog (~> 7.0.0.1.0)
+      libdatadog (~> 8.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
 
@@ -55,8 +55,8 @@ GEM
     json (2.6.3)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (7.0.0.1.0-aarch64-linux)
-    libdatadog (7.0.0.1.0-x86_64-linux)
+    libdatadog (8.0.0.1.0-aarch64-linux)
+    libdatadog (8.0.0.1.0-x86_64-linux)
     libddwaf (1.14.0.0.0-aarch64-linux)
       ffi (~> 1.0)
     libddwaf (1.14.0.0.0-x86_64-linux)

--- a/gemfiles/ruby_3.2_redis_4.gemfile.lock
+++ b/gemfiles/ruby_3.2_redis_4.gemfile.lock
@@ -14,7 +14,7 @@ PATH
     ddtrace (1.21.1)
       datadog-ci (~> 0.8.1)
       debase-ruby_core_source (= 3.3.1)
-      libdatadog (~> 7.0.0.1.0)
+      libdatadog (~> 8.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
 
@@ -55,8 +55,8 @@ GEM
     json (2.6.3)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (7.0.0.1.0-aarch64-linux)
-    libdatadog (7.0.0.1.0-x86_64-linux)
+    libdatadog (8.0.0.1.0-aarch64-linux)
+    libdatadog (8.0.0.1.0-x86_64-linux)
     libddwaf (1.14.0.0.0-aarch64-linux)
       ffi (~> 1.0)
     libddwaf (1.14.0.0.0-x86_64-linux)

--- a/gemfiles/ruby_3.2_redis_5.gemfile.lock
+++ b/gemfiles/ruby_3.2_redis_5.gemfile.lock
@@ -14,7 +14,7 @@ PATH
     ddtrace (1.21.1)
       datadog-ci (~> 0.8.1)
       debase-ruby_core_source (= 3.3.1)
-      libdatadog (~> 7.0.0.1.0)
+      libdatadog (~> 8.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
 
@@ -56,8 +56,8 @@ GEM
     json (2.6.3)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (7.0.0.1.0-aarch64-linux)
-    libdatadog (7.0.0.1.0-x86_64-linux)
+    libdatadog (8.0.0.1.0-aarch64-linux)
+    libdatadog (8.0.0.1.0-x86_64-linux)
     libddwaf (1.14.0.0.0-aarch64-linux)
       ffi (~> 1.0)
     libddwaf (1.14.0.0.0-x86_64-linux)

--- a/gemfiles/ruby_3.2_relational_db.gemfile.lock
+++ b/gemfiles/ruby_3.2_relational_db.gemfile.lock
@@ -14,7 +14,7 @@ PATH
     ddtrace (1.21.1)
       datadog-ci (~> 0.8.1)
       debase-ruby_core_source (= 3.3.1)
-      libdatadog (~> 7.0.0.1.0)
+      libdatadog (~> 8.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
 
@@ -72,8 +72,8 @@ GEM
     json (2.6.3)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (7.0.0.1.0-aarch64-linux)
-    libdatadog (7.0.0.1.0-x86_64-linux)
+    libdatadog (8.0.0.1.0-aarch64-linux)
+    libdatadog (8.0.0.1.0-x86_64-linux)
     libddwaf (1.14.0.0.0-aarch64-linux)
       ffi (~> 1.0)
     libddwaf (1.14.0.0.0-x86_64-linux)

--- a/gemfiles/ruby_3.2_resque2_redis3.gemfile.lock
+++ b/gemfiles/ruby_3.2_resque2_redis3.gemfile.lock
@@ -14,7 +14,7 @@ PATH
     ddtrace (1.21.1)
       datadog-ci (~> 0.8.1)
       debase-ruby_core_source (= 3.3.1)
-      libdatadog (~> 7.0.0.1.0)
+      libdatadog (~> 8.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
 
@@ -55,8 +55,8 @@ GEM
     json (2.6.3)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (7.0.0.1.0-aarch64-linux)
-    libdatadog (7.0.0.1.0-x86_64-linux)
+    libdatadog (8.0.0.1.0-aarch64-linux)
+    libdatadog (8.0.0.1.0-x86_64-linux)
     libddwaf (1.14.0.0.0-aarch64-linux)
       ffi (~> 1.0)
     libddwaf (1.14.0.0.0-x86_64-linux)

--- a/gemfiles/ruby_3.2_resque2_redis4.gemfile.lock
+++ b/gemfiles/ruby_3.2_resque2_redis4.gemfile.lock
@@ -14,7 +14,7 @@ PATH
     ddtrace (1.21.1)
       datadog-ci (~> 0.8.1)
       debase-ruby_core_source (= 3.3.1)
-      libdatadog (~> 7.0.0.1.0)
+      libdatadog (~> 8.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
 
@@ -56,8 +56,8 @@ GEM
     json (2.6.3)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (7.0.0.1.0-aarch64-linux)
-    libdatadog (7.0.0.1.0-x86_64-linux)
+    libdatadog (8.0.0.1.0-aarch64-linux)
+    libdatadog (8.0.0.1.0-x86_64-linux)
     libddwaf (1.14.0.0.0-aarch64-linux)
       ffi (~> 1.0)
     libddwaf (1.14.0.0.0-x86_64-linux)

--- a/gemfiles/ruby_3.2_sinatra.gemfile.lock
+++ b/gemfiles/ruby_3.2_sinatra.gemfile.lock
@@ -14,7 +14,7 @@ PATH
     ddtrace (1.21.1)
       datadog-ci (~> 0.8.1)
       debase-ruby_core_source (= 3.3.1)
-      libdatadog (~> 7.0.0.1.0)
+      libdatadog (~> 8.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
 
@@ -55,8 +55,8 @@ GEM
     json (2.6.3)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (7.0.0.1.0-aarch64-linux)
-    libdatadog (7.0.0.1.0-x86_64-linux)
+    libdatadog (8.0.0.1.0-aarch64-linux)
+    libdatadog (8.0.0.1.0-x86_64-linux)
     libddwaf (1.14.0.0.0-aarch64-linux)
       ffi (~> 1.0)
     libddwaf (1.14.0.0.0-x86_64-linux)

--- a/gemfiles/ruby_3.3_activesupport.gemfile.lock
+++ b/gemfiles/ruby_3.3_activesupport.gemfile.lock
@@ -14,7 +14,7 @@ PATH
     ddtrace (1.21.1)
       datadog-ci (~> 0.8.1)
       debase-ruby_core_source (= 3.3.1)
-      libdatadog (~> 7.0.0.1.0)
+      libdatadog (~> 8.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
 
@@ -110,8 +110,8 @@ GEM
       addressable (>= 2.4)
     jsonapi-renderer (0.2.2)
     king_konf (1.0.1)
-    libdatadog (7.0.0.1.0-aarch64-linux)
-    libdatadog (7.0.0.1.0-x86_64-linux)
+    libdatadog (8.0.0.1.0-aarch64-linux)
+    libdatadog (8.0.0.1.0-x86_64-linux)
     libddwaf (1.14.0.0.0-aarch64-linux)
       ffi (~> 1.0)
     libddwaf (1.14.0.0.0-x86_64-linux)

--- a/gemfiles/ruby_3.3_aws.gemfile.lock
+++ b/gemfiles/ruby_3.3_aws.gemfile.lock
@@ -14,7 +14,7 @@ PATH
     ddtrace (1.21.1)
       datadog-ci (~> 0.8.1)
       debase-ruby_core_source (= 3.3.1)
-      libdatadog (~> 7.0.0.1.0)
+      libdatadog (~> 8.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
 
@@ -1476,8 +1476,8 @@ GEM
     json (2.6.3)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (7.0.0.1.0-aarch64-linux)
-    libdatadog (7.0.0.1.0-x86_64-linux)
+    libdatadog (8.0.0.1.0-aarch64-linux)
+    libdatadog (8.0.0.1.0-x86_64-linux)
     libddwaf (1.14.0.0.0-aarch64-linux)
       ffi (~> 1.0)
     libddwaf (1.14.0.0.0-x86_64-linux)

--- a/gemfiles/ruby_3.3_contrib.gemfile.lock
+++ b/gemfiles/ruby_3.3_contrib.gemfile.lock
@@ -14,7 +14,7 @@ PATH
     ddtrace (1.21.1)
       datadog-ci (~> 0.8.1)
       debase-ruby_core_source (= 3.3.1)
-      libdatadog (~> 7.0.0.1.0)
+      libdatadog (~> 8.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
 
@@ -66,8 +66,8 @@ GEM
     json (2.6.3)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (7.0.0.1.0-aarch64-linux)
-    libdatadog (7.0.0.1.0-x86_64-linux)
+    libdatadog (8.0.0.1.0-aarch64-linux)
+    libdatadog (8.0.0.1.0-x86_64-linux)
     libddwaf (1.14.0.0.0-aarch64-linux)
       ffi (~> 1.0)
     libddwaf (1.14.0.0.0-x86_64-linux)

--- a/gemfiles/ruby_3.3_contrib_old.gemfile.lock
+++ b/gemfiles/ruby_3.3_contrib_old.gemfile.lock
@@ -14,7 +14,7 @@ PATH
     ddtrace (1.21.1)
       datadog-ci (~> 0.8.1)
       debase-ruby_core_source (= 3.3.1)
-      libdatadog (~> 7.0.0.1.0)
+      libdatadog (~> 8.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
 
@@ -65,8 +65,8 @@ GEM
     json (2.6.3)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (7.0.0.1.0-aarch64-linux)
-    libdatadog (7.0.0.1.0-x86_64-linux)
+    libdatadog (8.0.0.1.0-aarch64-linux)
+    libdatadog (8.0.0.1.0-x86_64-linux)
     libddwaf (1.14.0.0.0-aarch64-linux)
       ffi (~> 1.0)
     libddwaf (1.14.0.0.0-x86_64-linux)

--- a/gemfiles/ruby_3.3_core_old.gemfile.lock
+++ b/gemfiles/ruby_3.3_core_old.gemfile.lock
@@ -14,7 +14,7 @@ PATH
     ddtrace (1.21.1)
       datadog-ci (~> 0.8.1)
       debase-ruby_core_source (= 3.3.1)
-      libdatadog (~> 7.0.0.1.0)
+      libdatadog (~> 8.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
 
@@ -54,8 +54,8 @@ GEM
     json (2.6.3)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (7.0.0.1.0-aarch64-linux)
-    libdatadog (7.0.0.1.0-x86_64-linux)
+    libdatadog (8.0.0.1.0-aarch64-linux)
+    libdatadog (8.0.0.1.0-x86_64-linux)
     libddwaf (1.14.0.0.0-aarch64-linux)
       ffi (~> 1.0)
     libddwaf (1.14.0.0.0-x86_64-linux)

--- a/gemfiles/ruby_3.3_elasticsearch_7.gemfile.lock
+++ b/gemfiles/ruby_3.3_elasticsearch_7.gemfile.lock
@@ -14,7 +14,7 @@ PATH
     ddtrace (1.21.1)
       datadog-ci (~> 0.8.1)
       debase-ruby_core_source (= 3.3.1)
-      libdatadog (~> 7.0.0.1.0)
+      libdatadog (~> 8.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
 
@@ -86,8 +86,8 @@ GEM
     json (2.6.3)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (7.0.0.1.0-aarch64-linux)
-    libdatadog (7.0.0.1.0-x86_64-linux)
+    libdatadog (8.0.0.1.0-aarch64-linux)
+    libdatadog (8.0.0.1.0-x86_64-linux)
     libddwaf (1.14.0.0.0-aarch64-linux)
       ffi (~> 1.0)
     libddwaf (1.14.0.0.0-x86_64-linux)

--- a/gemfiles/ruby_3.3_elasticsearch_8.gemfile.lock
+++ b/gemfiles/ruby_3.3_elasticsearch_8.gemfile.lock
@@ -14,7 +14,7 @@ PATH
     ddtrace (1.21.1)
       datadog-ci (~> 0.8.1)
       debase-ruby_core_source (= 3.3.1)
-      libdatadog (~> 7.0.0.1.0)
+      libdatadog (~> 8.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
 
@@ -69,8 +69,8 @@ GEM
     json (2.6.3)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (7.0.0.1.0-aarch64-linux)
-    libdatadog (7.0.0.1.0-x86_64-linux)
+    libdatadog (8.0.0.1.0-aarch64-linux)
+    libdatadog (8.0.0.1.0-x86_64-linux)
     libddwaf (1.14.0.0.0-aarch64-linux)
       ffi (~> 1.0)
     libddwaf (1.14.0.0.0-x86_64-linux)

--- a/gemfiles/ruby_3.3_graphql_1.12.gemfile.lock
+++ b/gemfiles/ruby_3.3_graphql_1.12.gemfile.lock
@@ -14,7 +14,7 @@ PATH
     ddtrace (1.21.1)
       datadog-ci (~> 0.8.1)
       debase-ruby_core_source (= 3.3.1)
-      libdatadog (~> 7.0.0.1.0)
+      libdatadog (~> 8.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
 
@@ -56,8 +56,8 @@ GEM
     json (2.7.1)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (7.0.0.1.0-aarch64-linux)
-    libdatadog (7.0.0.1.0-x86_64-linux)
+    libdatadog (8.0.0.1.0-aarch64-linux)
+    libdatadog (8.0.0.1.0-x86_64-linux)
     libddwaf (1.14.0.0.0-aarch64-linux)
       ffi (~> 1.0)
     libddwaf (1.14.0.0.0-x86_64-linux)

--- a/gemfiles/ruby_3.3_graphql_1.13.gemfile.lock
+++ b/gemfiles/ruby_3.3_graphql_1.13.gemfile.lock
@@ -14,7 +14,7 @@ PATH
     ddtrace (1.21.1)
       datadog-ci (~> 0.8.1)
       debase-ruby_core_source (= 3.3.1)
-      libdatadog (~> 7.0.0.1.0)
+      libdatadog (~> 8.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
 
@@ -56,8 +56,8 @@ GEM
     json (2.7.1)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (7.0.0.1.0-aarch64-linux)
-    libdatadog (7.0.0.1.0-x86_64-linux)
+    libdatadog (8.0.0.1.0-aarch64-linux)
+    libdatadog (8.0.0.1.0-x86_64-linux)
     libddwaf (1.14.0.0.0-aarch64-linux)
       ffi (~> 1.0)
     libddwaf (1.14.0.0.0-x86_64-linux)

--- a/gemfiles/ruby_3.3_graphql_2.0.gemfile.lock
+++ b/gemfiles/ruby_3.3_graphql_2.0.gemfile.lock
@@ -14,7 +14,7 @@ PATH
     ddtrace (1.21.1)
       datadog-ci (~> 0.8.1)
       debase-ruby_core_source (= 3.3.1)
-      libdatadog (~> 7.0.0.1.0)
+      libdatadog (~> 8.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
 
@@ -56,8 +56,8 @@ GEM
     json (2.7.1)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (7.0.0.1.0-aarch64-linux)
-    libdatadog (7.0.0.1.0-x86_64-linux)
+    libdatadog (8.0.0.1.0-aarch64-linux)
+    libdatadog (8.0.0.1.0-x86_64-linux)
     libddwaf (1.14.0.0.0-aarch64-linux)
       ffi (~> 1.0)
     libddwaf (1.14.0.0.0-x86_64-linux)

--- a/gemfiles/ruby_3.3_graphql_2.1.gemfile.lock
+++ b/gemfiles/ruby_3.3_graphql_2.1.gemfile.lock
@@ -14,7 +14,7 @@ PATH
     ddtrace (1.21.1)
       datadog-ci (~> 0.8.1)
       debase-ruby_core_source (= 3.3.1)
-      libdatadog (~> 7.0.0.1.0)
+      libdatadog (~> 8.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
 
@@ -57,8 +57,8 @@ GEM
     json (2.7.1)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (7.0.0.1.0-aarch64-linux)
-    libdatadog (7.0.0.1.0-x86_64-linux)
+    libdatadog (8.0.0.1.0-aarch64-linux)
+    libdatadog (8.0.0.1.0-x86_64-linux)
     libddwaf (1.14.0.0.0-aarch64-linux)
       ffi (~> 1.0)
     libddwaf (1.14.0.0.0-x86_64-linux)

--- a/gemfiles/ruby_3.3_graphql_2.2.gemfile.lock
+++ b/gemfiles/ruby_3.3_graphql_2.2.gemfile.lock
@@ -14,7 +14,7 @@ PATH
     ddtrace (1.21.1)
       datadog-ci (~> 0.8.1)
       debase-ruby_core_source (= 3.3.1)
-      libdatadog (~> 7.0.0.1.0)
+      libdatadog (~> 8.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
 
@@ -57,8 +57,8 @@ GEM
     json (2.7.1)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (7.0.0.1.0-aarch64-linux)
-    libdatadog (7.0.0.1.0-x86_64-linux)
+    libdatadog (8.0.0.1.0-aarch64-linux)
+    libdatadog (8.0.0.1.0-x86_64-linux)
     libddwaf (1.14.0.0.0-aarch64-linux)
       ffi (~> 1.0)
     libddwaf (1.14.0.0.0-x86_64-linux)

--- a/gemfiles/ruby_3.3_http.gemfile.lock
+++ b/gemfiles/ruby_3.3_http.gemfile.lock
@@ -14,7 +14,7 @@ PATH
     ddtrace (1.21.1)
       datadog-ci (~> 0.8.1)
       debase-ruby_core_source (= 3.3.1)
-      libdatadog (~> 7.0.0.1.0)
+      libdatadog (~> 8.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
 
@@ -76,8 +76,8 @@ GEM
     json (2.6.3)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (7.0.0.1.0-aarch64-linux)
-    libdatadog (7.0.0.1.0-x86_64-linux)
+    libdatadog (8.0.0.1.0-aarch64-linux)
+    libdatadog (8.0.0.1.0-x86_64-linux)
     libddwaf (1.14.0.0.0-aarch64-linux)
       ffi (~> 1.0)
     libddwaf (1.14.0.0.0-x86_64-linux)

--- a/gemfiles/ruby_3.3_multi_rack_app.gemfile.lock
+++ b/gemfiles/ruby_3.3_multi_rack_app.gemfile.lock
@@ -14,7 +14,7 @@ PATH
     ddtrace (1.21.1)
       datadog-ci (~> 0.8.1)
       debase-ruby_core_source (= 3.3.1)
-      libdatadog (~> 7.0.0.1.0)
+      libdatadog (~> 8.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
 
@@ -146,8 +146,8 @@ GEM
     json (2.7.1)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (7.0.0.1.0-aarch64-linux)
-    libdatadog (7.0.0.1.0-x86_64-linux)
+    libdatadog (8.0.0.1.0-aarch64-linux)
+    libdatadog (8.0.0.1.0-x86_64-linux)
     libddwaf (1.14.0.0.0-aarch64-linux)
       ffi (~> 1.0)
     libddwaf (1.14.0.0.0-x86_64-linux)

--- a/gemfiles/ruby_3.3_opensearch_2.gemfile.lock
+++ b/gemfiles/ruby_3.3_opensearch_2.gemfile.lock
@@ -14,7 +14,7 @@ PATH
     ddtrace (1.21.1)
       datadog-ci (~> 0.8.1)
       debase-ruby_core_source (= 3.3.1)
-      libdatadog (~> 7.0.0.1.0)
+      libdatadog (~> 8.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
 
@@ -61,8 +61,8 @@ GEM
     json (2.6.3)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (7.0.0.1.0-aarch64-linux)
-    libdatadog (7.0.0.1.0-x86_64-linux)
+    libdatadog (8.0.0.1.0-aarch64-linux)
+    libdatadog (8.0.0.1.0-x86_64-linux)
     libddwaf (1.14.0.0.0-aarch64-linux)
       ffi (~> 1.0)
     libddwaf (1.14.0.0.0-x86_64-linux)

--- a/gemfiles/ruby_3.3_opensearch_3.gemfile.lock
+++ b/gemfiles/ruby_3.3_opensearch_3.gemfile.lock
@@ -14,7 +14,7 @@ PATH
     ddtrace (1.21.1)
       datadog-ci (~> 0.8.1)
       debase-ruby_core_source (= 3.3.1)
-      libdatadog (~> 7.0.0.1.0)
+      libdatadog (~> 8.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
 
@@ -61,8 +61,8 @@ GEM
     json (2.6.3)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (7.0.0.1.0-aarch64-linux)
-    libdatadog (7.0.0.1.0-x86_64-linux)
+    libdatadog (8.0.0.1.0-aarch64-linux)
+    libdatadog (8.0.0.1.0-x86_64-linux)
     libddwaf (1.14.0.0.0-aarch64-linux)
       ffi (~> 1.0)
     libddwaf (1.14.0.0.0-x86_64-linux)

--- a/gemfiles/ruby_3.3_opentelemetry.gemfile.lock
+++ b/gemfiles/ruby_3.3_opentelemetry.gemfile.lock
@@ -14,7 +14,7 @@ PATH
     ddtrace (1.21.1)
       datadog-ci (~> 0.8.1)
       debase-ruby_core_source (= 3.3.1)
-      libdatadog (~> 7.0.0.1.0)
+      libdatadog (~> 8.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
 
@@ -54,8 +54,8 @@ GEM
     json (2.6.3)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (7.0.0.1.0-aarch64-linux)
-    libdatadog (7.0.0.1.0-x86_64-linux)
+    libdatadog (8.0.0.1.0-aarch64-linux)
+    libdatadog (8.0.0.1.0-x86_64-linux)
     libddwaf (1.14.0.0.0-aarch64-linux)
       ffi (~> 1.0)
     libddwaf (1.14.0.0.0-x86_64-linux)

--- a/gemfiles/ruby_3.3_opentracing.gemfile.lock
+++ b/gemfiles/ruby_3.3_opentracing.gemfile.lock
@@ -14,7 +14,7 @@ PATH
     ddtrace (1.21.1)
       datadog-ci (~> 0.8.1)
       debase-ruby_core_source (= 3.3.1)
-      libdatadog (~> 7.0.0.1.0)
+      libdatadog (~> 8.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
 
@@ -55,8 +55,8 @@ GEM
     json (2.6.3)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (7.0.0.1.0-aarch64-linux)
-    libdatadog (7.0.0.1.0-x86_64-linux)
+    libdatadog (8.0.0.1.0-aarch64-linux)
+    libdatadog (8.0.0.1.0-x86_64-linux)
     libddwaf (1.14.0.0.0-aarch64-linux)
       ffi (~> 1.0)
     libddwaf (1.14.0.0.0-x86_64-linux)

--- a/gemfiles/ruby_3.3_rack_1.gemfile.lock
+++ b/gemfiles/ruby_3.3_rack_1.gemfile.lock
@@ -14,7 +14,7 @@ PATH
     ddtrace (1.21.1)
       datadog-ci (~> 0.8.1)
       debase-ruby_core_source (= 3.3.1)
-      libdatadog (~> 7.0.0.1.0)
+      libdatadog (~> 8.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
 
@@ -54,8 +54,8 @@ GEM
     json (2.6.3)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (7.0.0.1.0-aarch64-linux)
-    libdatadog (7.0.0.1.0-x86_64-linux)
+    libdatadog (8.0.0.1.0-aarch64-linux)
+    libdatadog (8.0.0.1.0-x86_64-linux)
     libddwaf (1.14.0.0.0-aarch64-linux)
       ffi (~> 1.0)
     libddwaf (1.14.0.0.0-x86_64-linux)

--- a/gemfiles/ruby_3.3_rack_2.gemfile.lock
+++ b/gemfiles/ruby_3.3_rack_2.gemfile.lock
@@ -14,7 +14,7 @@ PATH
     ddtrace (1.21.1)
       datadog-ci (~> 0.8.1)
       debase-ruby_core_source (= 3.3.1)
-      libdatadog (~> 7.0.0.1.0)
+      libdatadog (~> 8.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
 
@@ -54,8 +54,8 @@ GEM
     json (2.6.3)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (7.0.0.1.0-aarch64-linux)
-    libdatadog (7.0.0.1.0-x86_64-linux)
+    libdatadog (8.0.0.1.0-aarch64-linux)
+    libdatadog (8.0.0.1.0-x86_64-linux)
     libddwaf (1.14.0.0.0-aarch64-linux)
       ffi (~> 1.0)
     libddwaf (1.14.0.0.0-x86_64-linux)

--- a/gemfiles/ruby_3.3_rack_3.gemfile.lock
+++ b/gemfiles/ruby_3.3_rack_3.gemfile.lock
@@ -14,7 +14,7 @@ PATH
     ddtrace (1.21.1)
       datadog-ci (~> 0.8.1)
       debase-ruby_core_source (= 3.3.1)
-      libdatadog (~> 7.0.0.1.0)
+      libdatadog (~> 8.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
 
@@ -54,8 +54,8 @@ GEM
     json (2.6.3)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (7.0.0.1.0-aarch64-linux)
-    libdatadog (7.0.0.1.0-x86_64-linux)
+    libdatadog (8.0.0.1.0-aarch64-linux)
+    libdatadog (8.0.0.1.0-x86_64-linux)
     libddwaf (1.14.0.0.0-aarch64-linux)
       ffi (~> 1.0)
     libddwaf (1.14.0.0.0-x86_64-linux)

--- a/gemfiles/ruby_3.3_rails61_mysql2.gemfile.lock
+++ b/gemfiles/ruby_3.3_rails61_mysql2.gemfile.lock
@@ -14,7 +14,7 @@ PATH
     ddtrace (1.21.1)
       datadog-ci (~> 0.8.1)
       debase-ruby_core_source (= 3.3.1)
-      libdatadog (~> 7.0.0.1.0)
+      libdatadog (~> 8.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
 
@@ -120,8 +120,8 @@ GEM
     json (2.6.3)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (7.0.0.1.0-aarch64-linux)
-    libdatadog (7.0.0.1.0-x86_64-linux)
+    libdatadog (8.0.0.1.0-aarch64-linux)
+    libdatadog (8.0.0.1.0-x86_64-linux)
     libddwaf (1.14.0.0.0-aarch64-linux)
       ffi (~> 1.0)
     libddwaf (1.14.0.0.0-x86_64-linux)

--- a/gemfiles/ruby_3.3_rails61_postgres.gemfile.lock
+++ b/gemfiles/ruby_3.3_rails61_postgres.gemfile.lock
@@ -14,7 +14,7 @@ PATH
     ddtrace (1.21.1)
       datadog-ci (~> 0.8.1)
       debase-ruby_core_source (= 3.3.1)
-      libdatadog (~> 7.0.0.1.0)
+      libdatadog (~> 8.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
 
@@ -120,8 +120,8 @@ GEM
     json (2.6.3)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (7.0.0.1.0-aarch64-linux)
-    libdatadog (7.0.0.1.0-x86_64-linux)
+    libdatadog (8.0.0.1.0-aarch64-linux)
+    libdatadog (8.0.0.1.0-x86_64-linux)
     libddwaf (1.14.0.0.0-aarch64-linux)
       ffi (~> 1.0)
     libddwaf (1.14.0.0.0-x86_64-linux)

--- a/gemfiles/ruby_3.3_rails61_postgres_redis.gemfile.lock
+++ b/gemfiles/ruby_3.3_rails61_postgres_redis.gemfile.lock
@@ -14,7 +14,7 @@ PATH
     ddtrace (1.21.1)
       datadog-ci (~> 0.8.1)
       debase-ruby_core_source (= 3.3.1)
-      libdatadog (~> 7.0.0.1.0)
+      libdatadog (~> 8.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
 
@@ -120,8 +120,8 @@ GEM
     json (2.6.3)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (7.0.0.1.0-aarch64-linux)
-    libdatadog (7.0.0.1.0-x86_64-linux)
+    libdatadog (8.0.0.1.0-aarch64-linux)
+    libdatadog (8.0.0.1.0-x86_64-linux)
     libddwaf (1.14.0.0.0-aarch64-linux)
       ffi (~> 1.0)
     libddwaf (1.14.0.0.0-x86_64-linux)

--- a/gemfiles/ruby_3.3_rails61_postgres_sidekiq.gemfile.lock
+++ b/gemfiles/ruby_3.3_rails61_postgres_sidekiq.gemfile.lock
@@ -14,7 +14,7 @@ PATH
     ddtrace (1.21.1)
       datadog-ci (~> 0.8.1)
       debase-ruby_core_source (= 3.3.1)
-      libdatadog (~> 7.0.0.1.0)
+      libdatadog (~> 8.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
 
@@ -121,8 +121,8 @@ GEM
     json (2.6.3)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (7.0.0.1.0-aarch64-linux)
-    libdatadog (7.0.0.1.0-x86_64-linux)
+    libdatadog (8.0.0.1.0-aarch64-linux)
+    libdatadog (8.0.0.1.0-x86_64-linux)
     libddwaf (1.14.0.0.0-aarch64-linux)
       ffi (~> 1.0)
     libddwaf (1.14.0.0.0-x86_64-linux)

--- a/gemfiles/ruby_3.3_rails61_semantic_logger.gemfile.lock
+++ b/gemfiles/ruby_3.3_rails61_semantic_logger.gemfile.lock
@@ -14,7 +14,7 @@ PATH
     ddtrace (1.21.1)
       datadog-ci (~> 0.8.1)
       debase-ruby_core_source (= 3.3.1)
-      libdatadog (~> 7.0.0.1.0)
+      libdatadog (~> 8.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
 
@@ -120,8 +120,8 @@ GEM
     json (2.6.3)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (7.0.0.1.0-aarch64-linux)
-    libdatadog (7.0.0.1.0-x86_64-linux)
+    libdatadog (8.0.0.1.0-aarch64-linux)
+    libdatadog (8.0.0.1.0-x86_64-linux)
     libddwaf (1.14.0.0.0-aarch64-linux)
       ffi (~> 1.0)
     libddwaf (1.14.0.0.0-x86_64-linux)

--- a/gemfiles/ruby_3.3_rails61_trilogy.gemfile.lock
+++ b/gemfiles/ruby_3.3_rails61_trilogy.gemfile.lock
@@ -14,7 +14,7 @@ PATH
     ddtrace (1.21.1)
       datadog-ci (~> 0.8.1)
       debase-ruby_core_source (= 3.3.1)
-      libdatadog (~> 7.0.0.1.0)
+      libdatadog (~> 8.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
 
@@ -124,8 +124,8 @@ GEM
     json (2.6.3)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (7.0.0.1.0-aarch64-linux)
-    libdatadog (7.0.0.1.0-x86_64-linux)
+    libdatadog (8.0.0.1.0-aarch64-linux)
+    libdatadog (8.0.0.1.0-x86_64-linux)
     libddwaf (1.14.0.0.0-aarch64-linux)
       ffi (~> 1.0)
     libddwaf (1.14.0.0.0-x86_64-linux)

--- a/gemfiles/ruby_3.3_redis_3.gemfile.lock
+++ b/gemfiles/ruby_3.3_redis_3.gemfile.lock
@@ -14,7 +14,7 @@ PATH
     ddtrace (1.21.1)
       datadog-ci (~> 0.8.1)
       debase-ruby_core_source (= 3.3.1)
-      libdatadog (~> 7.0.0.1.0)
+      libdatadog (~> 8.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
 
@@ -54,8 +54,8 @@ GEM
     json (2.6.3)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (7.0.0.1.0-aarch64-linux)
-    libdatadog (7.0.0.1.0-x86_64-linux)
+    libdatadog (8.0.0.1.0-aarch64-linux)
+    libdatadog (8.0.0.1.0-x86_64-linux)
     libddwaf (1.14.0.0.0-aarch64-linux)
       ffi (~> 1.0)
     libddwaf (1.14.0.0.0-x86_64-linux)

--- a/gemfiles/ruby_3.3_redis_4.gemfile.lock
+++ b/gemfiles/ruby_3.3_redis_4.gemfile.lock
@@ -14,7 +14,7 @@ PATH
     ddtrace (1.21.1)
       datadog-ci (~> 0.8.1)
       debase-ruby_core_source (= 3.3.1)
-      libdatadog (~> 7.0.0.1.0)
+      libdatadog (~> 8.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
 
@@ -54,8 +54,8 @@ GEM
     json (2.6.3)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (7.0.0.1.0-aarch64-linux)
-    libdatadog (7.0.0.1.0-x86_64-linux)
+    libdatadog (8.0.0.1.0-aarch64-linux)
+    libdatadog (8.0.0.1.0-x86_64-linux)
     libddwaf (1.14.0.0.0-aarch64-linux)
       ffi (~> 1.0)
     libddwaf (1.14.0.0.0-x86_64-linux)

--- a/gemfiles/ruby_3.3_redis_5.gemfile.lock
+++ b/gemfiles/ruby_3.3_redis_5.gemfile.lock
@@ -14,7 +14,7 @@ PATH
     ddtrace (1.21.1)
       datadog-ci (~> 0.8.1)
       debase-ruby_core_source (= 3.3.1)
-      libdatadog (~> 7.0.0.1.0)
+      libdatadog (~> 8.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
 
@@ -55,8 +55,8 @@ GEM
     json (2.6.3)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (7.0.0.1.0-aarch64-linux)
-    libdatadog (7.0.0.1.0-x86_64-linux)
+    libdatadog (8.0.0.1.0-aarch64-linux)
+    libdatadog (8.0.0.1.0-x86_64-linux)
     libddwaf (1.14.0.0.0-aarch64-linux)
       ffi (~> 1.0)
     libddwaf (1.14.0.0.0-x86_64-linux)

--- a/gemfiles/ruby_3.3_relational_db.gemfile.lock
+++ b/gemfiles/ruby_3.3_relational_db.gemfile.lock
@@ -14,7 +14,7 @@ PATH
     ddtrace (1.21.1)
       datadog-ci (~> 0.8.1)
       debase-ruby_core_source (= 3.3.1)
-      libdatadog (~> 7.0.0.1.0)
+      libdatadog (~> 8.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
 
@@ -71,8 +71,8 @@ GEM
     json (2.6.3)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (7.0.0.1.0-aarch64-linux)
-    libdatadog (7.0.0.1.0-x86_64-linux)
+    libdatadog (8.0.0.1.0-aarch64-linux)
+    libdatadog (8.0.0.1.0-x86_64-linux)
     libddwaf (1.14.0.0.0-aarch64-linux)
       ffi (~> 1.0)
     libddwaf (1.14.0.0.0-x86_64-linux)

--- a/gemfiles/ruby_3.3_resque2_redis3.gemfile.lock
+++ b/gemfiles/ruby_3.3_resque2_redis3.gemfile.lock
@@ -14,7 +14,7 @@ PATH
     ddtrace (1.21.1)
       datadog-ci (~> 0.8.1)
       debase-ruby_core_source (= 3.3.1)
-      libdatadog (~> 7.0.0.1.0)
+      libdatadog (~> 8.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
 
@@ -54,8 +54,8 @@ GEM
     json (2.6.3)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (7.0.0.1.0-aarch64-linux)
-    libdatadog (7.0.0.1.0-x86_64-linux)
+    libdatadog (8.0.0.1.0-aarch64-linux)
+    libdatadog (8.0.0.1.0-x86_64-linux)
     libddwaf (1.14.0.0.0-aarch64-linux)
       ffi (~> 1.0)
     libddwaf (1.14.0.0.0-x86_64-linux)

--- a/gemfiles/ruby_3.3_resque2_redis4.gemfile.lock
+++ b/gemfiles/ruby_3.3_resque2_redis4.gemfile.lock
@@ -14,7 +14,7 @@ PATH
     ddtrace (1.21.1)
       datadog-ci (~> 0.8.1)
       debase-ruby_core_source (= 3.3.1)
-      libdatadog (~> 7.0.0.1.0)
+      libdatadog (~> 8.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
 
@@ -55,8 +55,8 @@ GEM
     json (2.6.3)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (7.0.0.1.0-aarch64-linux)
-    libdatadog (7.0.0.1.0-x86_64-linux)
+    libdatadog (8.0.0.1.0-aarch64-linux)
+    libdatadog (8.0.0.1.0-x86_64-linux)
     libddwaf (1.14.0.0.0-aarch64-linux)
       ffi (~> 1.0)
     libddwaf (1.14.0.0.0-x86_64-linux)

--- a/gemfiles/ruby_3.3_sinatra.gemfile.lock
+++ b/gemfiles/ruby_3.3_sinatra.gemfile.lock
@@ -14,7 +14,7 @@ PATH
     ddtrace (1.21.1)
       datadog-ci (~> 0.8.1)
       debase-ruby_core_source (= 3.3.1)
-      libdatadog (~> 7.0.0.1.0)
+      libdatadog (~> 8.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
 
@@ -54,8 +54,8 @@ GEM
     json (2.6.3)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (7.0.0.1.0-aarch64-linux)
-    libdatadog (7.0.0.1.0-x86_64-linux)
+    libdatadog (8.0.0.1.0-aarch64-linux)
+    libdatadog (8.0.0.1.0-x86_64-linux)
     libddwaf (1.14.0.0.0-aarch64-linux)
       ffi (~> 1.0)
     libddwaf (1.14.0.0.0-x86_64-linux)


### PR DESCRIPTION
**What does this PR do?**

This PR upgrades dd-trace-rb to use libdatadog 8.

Even though there were a few breaking API changes, none of those APIs were being used in the Ruby profiler, so it's a very minor bump for us.

**Motivation:**

This version includes a number of fixes and tweaks that will finally enable us to land the crash tracker feature (https://github.com/DataDog/dd-trace-rb/pull/3384).

**Additional Notes:**

I'm opening this PR as a draft as libdatadog 8 is not yet available on rubygems.org, and I'll come back to re-trigger CI and mark this as non-draft once it is.

**How to test the change?**

Our existing test coverage includes libdatadog testing, so a green CI is good here :)