### PR TITLE
Fix version range for required_ruby_version

### DIFF
--- a/ddtrace.gemspec
+++ b/ddtrace.gemspec
@@ -7,8 +7,8 @@ require 'ddtrace/version'
 Gem::Specification.new do |spec|
   spec.name                  = 'ddtrace'
   spec.version               = DDTrace::VERSION::STRING
-  spec.required_ruby_version = [">= #{DDTrace::VERSION::MINIMUM_RUBY_VERSION}",
-                                "< #{DDTrace::VERSION::MAXIMUM_RUBY_VERSION}"]
+  # required_ruby_version should be in a single line due to test-head workflow `sed` to unlock the version
+  spec.required_ruby_version = [">= #{DDTrace::VERSION::MINIMUM_RUBY_VERSION}", "< #{DDTrace::VERSION::MAXIMUM_RUBY_VERSION}"]
   spec.required_rubygems_version = '>= 2.0.0'
   spec.authors               = ['Datadog, Inc.']
   spec.email                 = ['dev@datadoghq.com']


### PR DESCRIPTION
<!--
Check out the
https://github.com/DataDog/dd-trace-rb/blob/master/docs/DevelopmentGuide.md
for guidance on how to set up your development environment,
run the test suite, write new integrations, and more.
-->

**2.0 Upgrade Guide notes**
<!--
(If this PR is for 1.x, please delete this section)
If this PR introduces a breaking change, update the
https://github.com/DataDog/dd-trace-rb/blob/2.0/docs/UpgradeGuide2.md
in this PR with either:
* A migration path for this change. In other words, how to continue using their application without behavior changes
in 2.0 (e.g. environment variable 'X' renamed to 'Y').
* That there's no alternative; we removed support for this feature.
-->

**What does this PR do?**
This PR fixes the workflow `test-head`.

**Motivation:**
While looking into Ruby 3.4 issue, I found the `test-head` workflow that tries to use the latest ruby version. Upon inspecting further, I noticed that the [builds were not successful due to gemspec parse error](https://github.com/DataDog/dd-trace-rb/actions/runs/8615489955/job/23611138121).

```bash
[!] There was an error parsing `Gemfile`: 
[!] There was an error while loading `ddtrace.gemspec`: syntax error, unexpected ']', expecting 'end' or dummy end - ...ERSION::MAXIMUM_RUBY_VERSION}"]
...                              ^
. Bundler cannot continue.

 #  from /home/runner/work/dd-trace-rb/dd-trace-rb/ddtrace.gemspec:10
 #  -------------------------------------------
 #    spec.version               = DDTrace::VERSION::STRING
 >                                  "< #{DDTrace::VERSION::MAXIMUM_RUBY_VERSION}"]
 #    spec.required_rubygems_version = '>= 2.0.0'
 #  -------------------------------------------
. Bundler cannot continue.
```

This is because the workflow assumes the version string to be in a single line (it runs `ed -i~ -e '/spec\.required_ruby_version/d' ddtrace.gemspec`)

**Additional Notes:**
Even after addressing it, some of the tests continue to fail. Further, the failures are not reported as failures. But it's unclear how much this matters.

**How to test the change?**
See [Test unstable workflow](https://github.com/DataDog/dd-trace-rb/actions/workflows/test-head.yaml)

Unsure? Have a question? Request a review!
