### PR TITLE
[NO-TICKET] Check extension dir as well when loading profiler

### DIFF
--- a/lib/datadog/profiling/load_native_extension.rb
+++ b/lib/datadog/profiling/load_native_extension.rb
@@ -18,7 +18,20 @@ rescue LoadError => e
 end
 
 extension_name = "datadog_profiling_native_extension.#{RUBY_VERSION}_#{RUBY_PLATFORM}"
-full_file_path = "#{__dir__}/../../#{extension_name}.#{RbConfig::CONFIG['DLEXT']}"
+file_name = "#{extension_name}.#{RbConfig::CONFIG['DLEXT']}"
+full_file_path = "#{__dir__}/../../#{file_name}"
+
+unless File.exist?(full_file_path)
+  extension_dir = Gem.loaded_specs['ddtrace'].extension_dir
+  candidate_path = "#{extension_dir}/#{file_name}"
+  if File.exist?(candidate_path)
+    full_file_path = candidate_path
+  else # rubocop:disable Style/EmptyElse
+    # We found none of the files. This is unexpected. Let's go ahead anyway, the error is going to be reported further
+    # down anyway.
+  end
+end
+
 init_function_name = "Init_#{extension_name.split('.').first}"
 
 status, result = Datadog::Profiling::Loader._native_load(full_file_path, init_function_name)

--- a/spec/datadog/profiling/load_native_extension_spec.rb
+++ b/spec/datadog/profiling/load_native_extension_spec.rb
@@ -1,0 +1,73 @@
+require 'spec_helper'
+require 'datadog/profiling/spec_helper'
+
+RSpec.describe 'Datadog::Profiling load_native_extension' do
+  before { skip_if_profiling_not_supported(self) }
+
+  subject(:load_native_extension) do
+    load "#{__dir__}/../../../lib/datadog/profiling/load_native_extension.rb"
+  end
+
+  context 'when native extension can be found inside lib' do
+    it 'loads the native extension from lib/' do
+      expect(Datadog::Profiling::Loader).to receive(:_native_load) do |full_file_path|
+        absolute_path = File.absolute_path(full_file_path)
+        expect(absolute_path).to include('lib/datadog_profiling_native_extension')
+      end
+
+      load_native_extension
+    end
+  end
+
+  context 'when native extension cannot be found inside lib' do
+    let(:extension_dir) { Gem.loaded_specs['ddtrace'].extension_dir }
+
+    before do
+      expect(File).to receive(:exist?) do |full_file_path|
+        absolute_path = File.absolute_path(full_file_path)
+
+        if absolute_path.include?('lib/datadog_profiling_native_extension')
+          false
+        elsif absolute_path.include?(extension_dir)
+          true
+        else
+          raise "Unexpected path in mock: #{full_file_path}"
+        end
+      end.twice
+    end
+
+    it 'loads the native extension from the extension dir' do
+      expect(Datadog::Profiling::Loader).to receive(:_native_load) do |full_file_path|
+        absolute_path = File.absolute_path(full_file_path)
+        expect(absolute_path).to include(extension_dir)
+      end
+
+      load_native_extension
+    end
+  end
+
+  context 'when native extension cannot be found on either directory' do
+    before do
+      expect(File).to receive(:exist?).twice.and_return(false)
+    end
+
+    it 'tries to load the native extension from lib/' do
+      expect(Datadog::Profiling::Loader).to receive(:_native_load) do |full_file_path|
+        absolute_path = File.absolute_path(full_file_path)
+        expect(absolute_path).to include('lib/datadog_profiling_native_extension')
+      end
+
+      load_native_extension
+    end
+  end
+
+  context 'when the loader reports an error' do
+    it 'raises an exception' do
+      expect(Datadog::Profiling::Loader).to receive(:_native_load).and_return([:error, 'some error'])
+
+      expect do
+        load_native_extension
+      end.to raise_error(/Failure to load datadog_profiling_native_extension.*due to some error/)
+    end
+  end
+end

--- a/vendor/rbs/gem/0/gem.rbs
+++ b/vendor/rbs/gem/0/gem.rbs
@@ -14,4 +14,5 @@ class Gem::BasicSpecification
   def version: () -> String
   def name: () -> String
   def gem_dir: () -> String
+  def extension_dir: () -> String
 end


### PR DESCRIPTION
**What does this PR do?**

This PR tweaks our existing logic for loading the profiling native extension to try to find the file in two directories:

1. The lib/ directory
2. The Ruby extensions directory

Previously we would only check 1.

**Motivation:**

I'll admit I don't 100% understand when one or the other folder gets used.

For instance, on a fresh install of `ddtrace` on my machine I get

```
$ bundle exec gem contents ddtrace | grep so$
.rvm/gems/ruby-3.1.4/gems/ddtrace-1.21.1/lib/datadog_profiling_loader.3.1.4_x86_64-linux.so
.rvm/gems/ruby-3.1.4/gems/ddtrace-1.21.1/lib/datadog_profiling_native_extension.3.1.4_x86_64-linux.so
```

(this is 1., above)

but also...

```
$ find `bundle exec ruby -e "require 'ddtrace'; puts Gem::loaded_specs['ddtrace'].extension_dir"` | grep so$
.rvm/gems/ruby-3.1.4/extensions/x86_64-linux/3.1.0/ddtrace-1.21.1/datadog_profiling_native_extension.3.1.4_x86_64-linux.so
.rvm/gems/ruby-3.1.4/extensions/x86_64-linux/3.1.0/ddtrace-1.21.1/datadog_profiling_loader.3.1.4_x86_64-linux.so
```

(this is 2., above)

(Aside: These are not leftovers -- if I uninstall the gem, the files get removed, and get recreated when I install them.)

So, on my machine, the files get installed to two different folders.

And for most of our customers, I'm pretty sure they get installed into 1. because otherwise the profiler won't work.

But one customer reported the following error:

> `Profiling was requested but is not supported, profiling disabled: There was an error loading the profiling native extension due to 'RuntimeError Failure to load ddtrace_profiling_native_extension.3.2.2_x86_64-linux due to /var/app/current/vendor/bundle/ruby/3.2.0/gems/ddtrace-1.20.0/lib/datadog/profiling/../../ddtrace_profiling_native_extension.3.2.2_x86_64-linux.so: cannot open shared object file: No such file or directory' at '/var/app/current/vendor/bundle/ruby/3.2.0/gems/ddtrace-1.20.0/lib/datadog/profiling/load_native_extension.rb:26:in `<top (required)>''`

Now my first intuition was to suspect -- something is wrong, the native extension didn't get built. But, actually, that's not the case, and here's a very important detail that took me a while to fully understand: the error message says that the
**ddtrace_profiling_native_extension.3.2.2_x86_64-linux.so** was not found, not the **datadog_profiling_loader.3.2.2_x86_64-linux.so**.

This distinction is important, because it's the loader that attempts to load the extension. So if the loader didn't fail first, it means the loader **was found**; but the extension **wasn't**.

With a bit more input from the customer, and some testing on my side, it looks like Ruby puts both folders above (1. and 2.) in the `$LOAD_PATH`, so when using `require` to load a file, both get checked.

And for this one customer, the extension only existed in folder 2., not 1. (even after reinstalling the gem).

Since we use a regular `require` to load the loader, it was still found, regardless of where it was. BUT because for the extension we try to load by using a specific path, and that path only checked lib (1.), then the extension failed to load.

This is why the customer saw an error message that pointed to the loader working, but the extension not being found.

Now because our previous logic of only checking folder 1. worked for all other customers we have, I'm not really sure why this one customer had the extension only in folder 2., but not in 1. . But regardless, having either folder in use is something that Ruby does, so I think it's reasonable for us to emulate that logic.

**Additional Notes:**

If you're curious why we are reimplementing Ruby logic for loading extensions, check the comments on `datadog_profiling_loader.c`.

TL;DR is, we want to load the library with specific system flags, and Ruby doesn't provide a way to do so, so we need to basically duplicate a bunch of Ruby's library loading logic ourselves to be able to emulate Ruby's behavior but change the system flags.

**How to test the change?**

I was able to reproduce the issue locally by installing ddtrace, and then manually deleting the files in 1., leaving them only in 2.

Without this change, I saw exactly the same error message as the customer did; with this change, profiling works.

On top of the added specs, I manually tested this fix on Ruby versions 2.3, 3.1 and 3.3.
