### PR TITLE
[PROF-9472] Add recorder_stats and profile_stats to internal metadata

### DIFF
--- a/ext/datadog_profiling_native_extension/collectors_cpu_and_wall_time_worker.c
+++ b/ext/datadog_profiling_native_extension/collectors_cpu_and_wall_time_worker.c
@@ -929,18 +929,6 @@ static VALUE _native_stats(DDTRACE_UNUSED VALUE self, VALUE instance) {
   struct cpu_and_wall_time_worker_state *state;
   TypedData_Get_Struct(instance, struct cpu_and_wall_time_worker_state, &cpu_and_wall_time_worker_typed_data, state);
 
-  VALUE pretty_cpu_sampling_time_ns_min = state->stats.cpu_sampling_time_ns_min == UINT64_MAX ? Qnil : ULL2NUM(state->stats.cpu_sampling_time_ns_min);
-  VALUE pretty_cpu_sampling_time_ns_max = state->stats.cpu_sampling_time_ns_max == 0 ? Qnil : ULL2NUM(state->stats.cpu_sampling_time_ns_max);
-  VALUE pretty_cpu_sampling_time_ns_total = state->stats.cpu_sampling_time_ns_total == 0 ? Qnil : ULL2NUM(state->stats.cpu_sampling_time_ns_total);
-  VALUE pretty_cpu_sampling_time_ns_avg =
-    state->stats.cpu_sampled == 0 ? Qnil : DBL2NUM(((double) state->stats.cpu_sampling_time_ns_total) / state->stats.cpu_sampled);
-
-  VALUE pretty_allocation_sampling_time_ns_min = state->stats.allocation_sampling_time_ns_min == UINT64_MAX ? Qnil : ULL2NUM(state->stats.allocation_sampling_time_ns_min);
-  VALUE pretty_allocation_sampling_time_ns_max = state->stats.allocation_sampling_time_ns_max == 0 ? Qnil : ULL2NUM(state->stats.allocation_sampling_time_ns_max);
-  VALUE pretty_allocation_sampling_time_ns_total = state->stats.allocation_sampling_time_ns_total == 0 ? Qnil : ULL2NUM(state->stats.allocation_sampling_time_ns_total);
-  VALUE pretty_allocation_sampling_time_ns_avg =
-    state->stats.allocation_sampled == 0 ? Qnil : DBL2NUM(((double) state->stats.allocation_sampling_time_ns_total) / state->stats.allocation_sampled);
-
   unsigned long total_cpu_samples_attempted = state->stats.cpu_sampled + state->stats.cpu_skipped;
   VALUE effective_cpu_sample_rate =
     total_cpu_samples_attempted == 0 ? Qnil : DBL2NUM(((double) state->stats.cpu_sampled) / total_cpu_samples_attempted);
@@ -968,19 +956,19 @@ static VALUE _native_stats(DDTRACE_UNUSED VALUE self, VALUE instance) {
     ID2SYM(rb_intern("cpu_sampled")),                /* => */ UINT2NUM(state->stats.cpu_sampled),
     ID2SYM(rb_intern("cpu_skipped")),                /* => */ UINT2NUM(state->stats.cpu_skipped),
     ID2SYM(rb_intern("cpu_effective_sample_rate")),  /* => */ effective_cpu_sample_rate,
-    ID2SYM(rb_intern("cpu_sampling_time_ns_min")),   /* => */ pretty_cpu_sampling_time_ns_min,
-    ID2SYM(rb_intern("cpu_sampling_time_ns_max")),   /* => */ pretty_cpu_sampling_time_ns_max,
-    ID2SYM(rb_intern("cpu_sampling_time_ns_total")), /* => */ pretty_cpu_sampling_time_ns_total,
-    ID2SYM(rb_intern("cpu_sampling_time_ns_avg")),   /* => */ pretty_cpu_sampling_time_ns_avg,
+    ID2SYM(rb_intern("cpu_sampling_time_ns_min")),   /* => */ RUBY_NUM_OR_NIL(state->stats.cpu_sampling_time_ns_min, != UINT64_MAX, ULL2NUM),
+    ID2SYM(rb_intern("cpu_sampling_time_ns_max")),   /* => */ RUBY_NUM_OR_NIL(state->stats.cpu_sampling_time_ns_max, > 0, ULL2NUM),
+    ID2SYM(rb_intern("cpu_sampling_time_ns_total")), /* => */ RUBY_NUM_OR_NIL(state->stats.cpu_sampling_time_ns_total, > 0, ULL2NUM),
+    ID2SYM(rb_intern("cpu_sampling_time_ns_avg")),   /* => */ RUBY_AVG_OR_NIL(state->stats.cpu_sampling_time_ns_total, state->stats.cpu_sampled),
 
     // Allocation stats
     ID2SYM(rb_intern("allocation_sampled")),                /* => */ state->allocation_profiling_enabled ? ULONG2NUM(state->stats.allocation_sampled) : Qnil,
     ID2SYM(rb_intern("allocation_skipped")),                /* => */ state->allocation_profiling_enabled ? ULONG2NUM(state->stats.allocation_skipped) : Qnil,
     ID2SYM(rb_intern("allocation_effective_sample_rate")),  /* => */ effective_allocation_sample_rate,
-    ID2SYM(rb_intern("allocation_sampling_time_ns_min")),   /* => */ pretty_allocation_sampling_time_ns_min,
-    ID2SYM(rb_intern("allocation_sampling_time_ns_max")),   /* => */ pretty_allocation_sampling_time_ns_max,
-    ID2SYM(rb_intern("allocation_sampling_time_ns_total")), /* => */ pretty_allocation_sampling_time_ns_total,
-    ID2SYM(rb_intern("allocation_sampling_time_ns_avg")),   /* => */ pretty_allocation_sampling_time_ns_avg,
+    ID2SYM(rb_intern("allocation_sampling_time_ns_min")),   /* => */ RUBY_NUM_OR_NIL(state->stats.allocation_sampling_time_ns_min, != UINT64_MAX, ULL2NUM),
+    ID2SYM(rb_intern("allocation_sampling_time_ns_max")),   /* => */ RUBY_NUM_OR_NIL(state->stats.allocation_sampling_time_ns_max, > 0, ULL2NUM),
+    ID2SYM(rb_intern("allocation_sampling_time_ns_total")), /* => */ RUBY_NUM_OR_NIL(state->stats.allocation_sampling_time_ns_total, > 0, ULL2NUM),
+    ID2SYM(rb_intern("allocation_sampling_time_ns_avg")),   /* => */ RUBY_AVG_OR_NIL(state->stats.allocation_sampling_time_ns_total, state->stats.allocation_sampled),
     ID2SYM(rb_intern("allocation_sampler_snapshot")),       /* => */ allocation_sampler_snapshot,
     ID2SYM(rb_intern("allocations_during_sample")),         /* => */ state->allocation_profiling_enabled ? UINT2NUM(state->stats.allocations_during_sample) : Qnil,
   };

--- a/ext/datadog_profiling_native_extension/heap_recorder.c
+++ b/ext/datadog_profiling_native_extension/heap_recorder.c
@@ -565,6 +565,7 @@ static int st_object_record_update(st_data_t key, st_data_t value, st_data_t ext
       RB_FL_SET(ref, RUBY_FL_SEEN_OBJ_ID);
 
       on_committed_object_record_cleanup(recorder, record);
+      recorder->stats_last_update.objects_dead++;
       return ST_DELETE;
     }
 

--- a/ext/datadog_profiling_native_extension/heap_recorder.h
+++ b/ext/datadog_profiling_native_extension/heap_recorder.h
@@ -150,7 +150,7 @@ bool heap_recorder_for_each_live_object(
     bool (*for_each_callback)(heap_recorder_iteration_data data, void* extra_arg),
     void *for_each_callback_extra_arg);
 
-// Return a Ruby hash containing a snapshot of this sampler's interesting state at calling time.
+// Return a Ruby hash containing a snapshot of this recorder's interesting state at calling time.
 // WARN: This allocates in the Ruby VM and therefore should not be called without the
 //       VM lock or during GC.
 VALUE heap_recorder_state_snapshot(heap_recorder *heap_recorder);

--- a/ext/datadog_profiling_native_extension/heap_recorder.h
+++ b/ext/datadog_profiling_native_extension/heap_recorder.h
@@ -150,6 +150,11 @@ bool heap_recorder_for_each_live_object(
     bool (*for_each_callback)(heap_recorder_iteration_data data, void* extra_arg),
     void *for_each_callback_extra_arg);
 
+// Return a Ruby hash containing a snapshot of this sampler's interesting state at calling time.
+// WARN: This allocates in the Ruby VM and therefore should not be called without the
+//       VM lock or during GC.
+VALUE heap_recorder_state_snapshot(heap_recorder *heap_recorder);
+
 // v--- TEST-ONLY APIs ---v
 
 // Assert internal hashing logic is valid for the provided locations and its

--- a/ext/datadog_profiling_native_extension/ruby_helpers.h
+++ b/ext/datadog_profiling_native_extension/ruby_helpers.h
@@ -82,6 +82,9 @@ NORETURN(
 #define ENFORCE_SUCCESS_HELPER(expression, have_gvl) \
   { int result_syserr_errno = expression; if (RB_UNLIKELY(result_syserr_errno)) raise_syserr(result_syserr_errno, have_gvl, ADD_QUOTES(expression), __FILE__, __LINE__, __func__); }
 
+#define RUBY_NUM_OR_NIL(val, condition, conv) ((val condition) ? conv(val) : Qnil)
+#define RUBY_AVG_OR_NIL(total, count) ((count == 0) ? Qnil : DBL2NUM(((double) total) / count))
+
 // Called by ENFORCE_SUCCESS_HELPER; should not be used directly
 NORETURN(void raise_syserr(
   int syserr_errno,

--- a/lib/datadog/profiling/exporter.rb
+++ b/lib/datadog/profiling/exporter.rb
@@ -52,7 +52,12 @@ module Datadog
 
       def flush
         worker_stats = @worker.stats_and_reset_not_thread_safe
-        start, finish, compressed_pprof = pprof_recorder.serialize
+        serialization_result = pprof_recorder.serialize
+        if serialization_result.nil?
+          Datadog.logger.debug('Skipped exporting profiling events due to failed serialization')
+          return
+        end
+        start, finish, compressed_pprof, profile_stats = serialization_result
         @last_flush_finish_at = finish
 
         return if compressed_pprof.nil? # We don't want to report empty profiles
@@ -75,6 +80,8 @@ module Datadog
           internal_metadata: internal_metadata.merge(
             {
               worker_stats: worker_stats,
+              profile_stats: profile_stats,
+              recorder_stats: pprof_recorder.stats,
               gc: GC.stat,
             }
           ),

--- a/lib/datadog/profiling/exporter.rb
+++ b/lib/datadog/profiling/exporter.rb
@@ -53,14 +53,10 @@ module Datadog
       def flush
         worker_stats = @worker.stats_and_reset_not_thread_safe
         serialization_result = pprof_recorder.serialize
-        if serialization_result.nil?
-          Datadog.logger.debug('Skipped exporting profiling events due to failed serialization')
-          return
-        end
+        return if serialization_result.nil?
+
         start, finish, compressed_pprof, profile_stats = serialization_result
         @last_flush_finish_at = finish
-
-        return if compressed_pprof.nil? # We don't want to report empty profiles
 
         if duration_below_threshold?(start, finish)
           Datadog.logger.debug('Skipped exporting profiling events as profile duration is below minimum')

--- a/lib/datadog/profiling/stack_recorder.rb
+++ b/lib/datadog/profiling/stack_recorder.rb
@@ -31,11 +31,11 @@ module Datadog
         status, result = @no_concurrent_synchronize_mutex.synchronize { self.class._native_serialize(self) }
 
         if status == :ok
-          start, finish, encoded_pprof = result
+          start, finish, encoded_pprof, profile_stats = result
 
           Datadog.logger.debug { "Encoded profile covering #{start.iso8601} to #{finish.iso8601}" }
 
-          [start, finish, encoded_pprof]
+          [start, finish, encoded_pprof, profile_stats]
         else
           error_message = result
 
@@ -61,6 +61,10 @@ module Datadog
 
       def reset_after_fork
         self.class._native_reset_after_fork(self)
+      end
+
+      def stats
+        self.class._native_stats(self)
       end
     end
   end

--- a/sig/datadog/profiling/stack_recorder.rbs
+++ b/sig/datadog/profiling/stack_recorder.rbs
@@ -22,9 +22,16 @@ module Datadog
         bool timeline_enabled,
       ) -> true
 
-      def serialize: () -> untyped
+      type serialized_profile_data = [
+        ::Time, # Start
+        ::Time, # Finish
+        String, # Serialized PProf
+        ::Hash[::Symbol, untyped], # Hash
+      ]
 
-      def self._native_serialize: (Datadog::Profiling::StackRecorder recorder_instance) -> [:ok | :error, untyped]
+      def serialize: () -> (serialized_profile_data | nil)
+
+      def self._native_serialize: (Datadog::Profiling::StackRecorder recorder_instance) -> ([:ok, serialized_profile_data] | [:error, ::String])
 
       def serialize!: () -> String
 
@@ -33,6 +40,9 @@ module Datadog
       def reset_after_fork: () -> true
 
       def self._native_reset_after_fork: (Datadog::Profiling::StackRecorder recorder_instance) -> true
+
+      def stats: () -> ::Hash[::Symbol, untyped]
+      def self._native_stats: (Datadog::Profiling::StackRecorder recorder_instance) -> ::Hash[::Symbol, untyped]
     end
   end
 end


### PR DESCRIPTION
**What does this PR do?**

Make use of the internal metadata mechanism to ship some statistics about the profile itself and the stack recorder. 

We first introduced this back in https://github.com/DataDog/dd-trace-rb/pull/3429 but that was scoped to worker stats which capture sampling-related statistics. This PR focuses on the serialization side of things + heap recorder if enabled.

**Motivation:**

Easier understanding of some of the internal ops that are otherwise hard/impossible to gather from the final pprof.

**Additional Notes:**
<!-- Anything else we should know when reviewing? -->

**How to test the change?**
Look at the `event.json` produced by any app being profiled with this PR and notice the extra fields in `internal`:

<img width="403" alt="image" src="https://github.com/DataDog/dd-trace-rb/assets/373323/18ec3724-cc01-4aba-be6a-c059bf226f7c">

Unsure? Have a question? Request a review!
