### PR TITLE
Add spec for dependencies

### DIFF
--- a/spec/ddtrace/release_gem_spec.rb
+++ b/spec/ddtrace/release_gem_spec.rb
@@ -1,8 +1,8 @@
 RSpec.describe 'gem release process' do
   context 'ddtrace.gemspec' do
-    context 'files' do
-      subject(:files) { Gem::Specification.load('ddtrace.gemspec').files }
+    subject(:gemspec) { Gem::Specification.load('ddtrace.gemspec') }
 
+    context 'files' do
       # It's easy to forget to ship new files, especially when a new paradigm is
       # introduced (e.g. introducing native files requires the inclusion `ext/`)
       it 'includes all important files' do
@@ -57,13 +57,48 @@ RSpec.describe 'gem release process' do
           )/
         }x
 
-        expect(files)
+        expect(gemspec.files)
           .to match_array(
             `git ls-files -z`
               .split("\x0")
               .reject { |f| f.match(directories_excluded) }
               .reject { |f| f.match(single_files_excluded) }
           )
+      end
+    end
+
+    context 'lib injection dependencies' do
+      it do
+        file = Tempfile.new('Gemfile')
+
+        begin
+          file.write "source 'https://rubygems.org'\n"
+          file.write "gem '#{gemspec.name}', path: '#{FileUtils.pwd}'\n"
+          file.rewind
+
+          gemfile = Bundler::Dsl.evaluate(file.path, nil, {})
+          lock_file_parser = Bundler::LockfileParser.new(gemfile.to_lock)
+
+          gem_version_mapping = lock_file_parser.specs.each_with_object({}) do |spec, hash|
+            hash[spec.name] = spec.version.to_s
+          end
+        ensure
+          file.close
+          file.unlink
+        end
+
+        # Lib injection package pipeline should be updated to include the following gems
+        expect(gem_version_mapping.keys).to contain_exactly(
+          # This list MUST NOT derive from the `gemspec.dependencies`,
+          # since it is used to alarm when dependencies  modified.
+          'datadog-ci',
+          'ddtrace',
+          'debase-ruby_core_source',
+          'ffi',
+          'libdatadog',
+          'libddwaf',
+          'msgpack',
+        )
       end
     end
   end


### PR DESCRIPTION
**What does this PR do?**

Add a test to identify if where is a change for dependencies, which might leads to a broken pipeline for lib injection artifacts

**Motivation:**

When building lib injection artifacts, we need to include all the dependencies. Dependencies  changes in gemspec could leads to a broken pipeline.