### PR TITLE
Fix telemetry app-started event on auto instrument

### DIFF
--- a/lib/datadog/core/configuration.rb
+++ b/lib/datadog/core/configuration.rb
@@ -81,21 +81,22 @@ module Datadog
         configuration = self.configuration
         yield(configuration)
 
-        start_telemetry = false
+        built_components = false
 
-        safely_synchronize do |write_components|
+        components = safely_synchronize do |write_components|
           write_components.call(
             if components?
               replace_components!(configuration, @components)
             else
               components = build_components(configuration)
-              start_telemetry = true
+              built_components = true
               components
             end
           )
         end
 
-        components.telemetry.started! if start_telemetry
+        # Should only be called the first time components are built
+        components.telemetry.started! if built_components
 
         configuration
       end
@@ -196,9 +197,20 @@ module Datadog
         current_components = COMPONENTS_READ_LOCK.synchronize { defined?(@components) && @components }
         return current_components if current_components || !allow_initialization
 
-        safely_synchronize do |write_components|
-          (defined?(@components) && @components) || write_components.call(build_components(configuration))
+        built_components = false
+
+        components = safely_synchronize do |write_components|
+          if defined?(@components) && @components
+            @components
+          else
+            built_components = true
+            write_components.call(build_components(configuration))
+          end
         end
+
+        # Should only be called the first time components are built
+        components.telemetry.started! if built_components && components && components.telemetry
+        components
       end
 
       private

--- a/spec/datadog/core/configuration_spec.rb
+++ b/spec/datadog/core/configuration_spec.rb
@@ -41,6 +41,10 @@ RSpec.describe Datadog::Core::Configuration do
           end
 
           it do
+            # We cannot mix `expect().to_not` with `expect().to(...).ordered`.
+            # One way around that is to force the method to raise an error if it's ever called.
+            allow(telemetry_client).to receive(:started!).and_raise('Should not be called')
+
             # Components should have changed
             expect { configure }
               .to change { test_class.send(:components) }
@@ -497,6 +501,8 @@ RSpec.describe Datadog::Core::Configuration do
     describe '#components' do
       context 'when components are not initialized' do
         it 'initializes the components' do
+          expect(telemetry_client).to receive(:started!)
+
           test_class.send(:components)
 
           expect(test_class.send(:components?)).to be true
@@ -504,6 +510,8 @@ RSpec.describe Datadog::Core::Configuration do
 
         context 'when allow_initialization is false' do
           it 'does not initialize the components' do
+            expect(telemetry_client).to_not receive(:started!)
+
             test_class.send(:components, allow_initialization: false)
 
             expect(test_class.send(:components?)).to be false
@@ -519,6 +527,7 @@ RSpec.describe Datadog::Core::Configuration do
         it 'returns the components without touching the COMPONENTS_WRITE_LOCK' do
           described_class.const_get(:COMPONENTS_WRITE_LOCK).lock
 
+          expect(telemetry_client).to_not receive(:started!)
           expect(test_class.send(:components)).to_not be_nil
         end
       end


### PR DESCRIPTION
Fixes system test failure `Test_Telemetry.test_app_started_is_first_message` for Rails applications that use auto-instrument: https://github.com/DataDog/dd-trace-rb/actions/runs/8703916892/job/23871310217?pr=3591