### PR TITLE
fix(span_links): ensures trace_flags is consistent with the sampling priority

### DIFF
--- a/lib/datadog/tracing/span_link.rb
+++ b/lib/datadog/tracing/span_link.rb
@@ -46,7 +46,13 @@ module Datadog
       )
         @span_id = digest&.span_id
         @trace_id = digest&.trace_id
-        @trace_flags = digest&.trace_flags
+        @trace_flags = if digest.nil? || digest.trace_sampling_priority.nil?
+                         nil
+                       elsif digest.trace_sampling_priority > 0
+                         1
+                       else
+                         0
+                       end
         @trace_state = digest&.trace_state && digest&.trace_state.dup
         @dropped_attributes = 0
         @attributes = (attributes && attributes.dup) || {}

--- a/lib/datadog/tracing/span_link.rb
+++ b/lib/datadog/tracing/span_link.rb
@@ -41,19 +41,19 @@ module Datadog
       attr_reader :dropped_attributes
 
       def initialize(
-        attributes: nil,
-        digest: nil
+        digest,
+        attributes: nil
       )
-        @span_id = digest&.span_id
-        @trace_id = digest&.trace_id
-        @trace_flags = if digest.nil? || digest.trace_sampling_priority.nil?
+        @span_id = digest.span_id
+        @trace_id = digest.trace_id
+        @trace_flags = if digest.trace_sampling_priority.nil?
                          nil
                        elsif digest.trace_sampling_priority > 0
                          1
                        else
                          0
                        end
-        @trace_state = digest&.trace_state && digest&.trace_state.dup
+        @trace_state = digest.trace_state && digest.trace_state.dup
         @dropped_attributes = 0
         @attributes = (attributes && attributes.dup) || {}
       end

--- a/sig/datadog/tracing/span_link.rbs
+++ b/sig/datadog/tracing/span_link.rbs
@@ -50,7 +50,7 @@ module Datadog
       #   @return [Integer]
       attr_reader dropped_attributes: untyped
 
-      def initialize: (?attributes: untyped?, ?digest: untyped?) -> void
+      def initialize: (untyped digest, ?attributes: untyped?) -> void
 
       def to_hash: () -> untyped
     end

--- a/spec/datadog/tracing/span_link_spec.rb
+++ b/spec/datadog/tracing/span_link_spec.rb
@@ -5,7 +5,7 @@ require 'datadog/tracing/span_link'
 require 'datadog/tracing/trace_digest'
 
 RSpec.describe Datadog::Tracing::SpanLink do
-  subject(:span_link) { described_class.new(attributes: attributes, digest: digest) }
+  subject(:span_link) { described_class.new(digest, attributes: attributes) }
 
   let(:attributes) { nil }
   let(:digest) do
@@ -23,7 +23,7 @@ RSpec.describe Datadog::Tracing::SpanLink do
 
   describe '::new' do
     context 'by default' do
-      let(:digest) { nil }
+      let(:digest) { Datadog::Tracing::TraceDigest.new }
       let(:attributes) { nil }
 
       it do

--- a/spec/datadog/tracing/span_link_spec.rb
+++ b/spec/datadog/tracing/span_link_spec.rb
@@ -12,7 +12,7 @@ RSpec.describe Datadog::Tracing::SpanLink do
     Datadog::Tracing::TraceDigest.new(
       span_id: span_id,
       trace_id: trace_id,
-      trace_flags: trace_flags,
+      trace_sampling_priority: trace_flags,
       trace_state: trace_state,
     )
   end

--- a/spec/datadog/tracing/transport/serializable_trace_spec.rb
+++ b/spec/datadog/tracing/transport/serializable_trace_spec.rb
@@ -84,7 +84,7 @@ RSpec.describe Datadog::Tracing::Transport::SerializableTrace do
                   trace_id: 0xaaaaaaaaaaaaaaaaffffffffffffffff,
                   span_id: 0x1,
                   trace_state: 'vendor1=value,v2=v,dd=s:1',
-                  trace_flags: 0x1,
+                  trace_sampling_priority: 0x1,
                 ),
                 attributes: { 'link.name' => 'test_link' }
               ),

--- a/spec/datadog/tracing/transport/serializable_trace_spec.rb
+++ b/spec/datadog/tracing/transport/serializable_trace_spec.rb
@@ -80,7 +80,7 @@ RSpec.describe Datadog::Tracing::Transport::SerializableTrace do
             'dummy',
             links: [
               Datadog::Tracing::SpanLink.new(
-                digest: Datadog::Tracing::TraceDigest.new(
+                Datadog::Tracing::TraceDigest.new(
                   trace_id: 0xaaaaaaaaaaaaaaaaffffffffffffffff,
                   span_id: 0x1,
                   trace_state: 'vendor1=value,v2=v,dd=s:1',
@@ -89,13 +89,13 @@ RSpec.describe Datadog::Tracing::Transport::SerializableTrace do
                 attributes: { 'link.name' => 'test_link' }
               ),
               Datadog::Tracing::SpanLink.new(
-                digest: Datadog::Tracing::TraceDigest.new(
+                Datadog::Tracing::TraceDigest.new(
                   trace_id: 0xa0123456789abcdef,
                   span_id: 0x2,
                 ),
               ),
               Datadog::Tracing::SpanLink.new(
-                digest: Datadog::Tracing::TraceDigest.new,
+                Datadog::Tracing::TraceDigest.new,
               )
             ],
           )


### PR DESCRIPTION

**What does this PR do?**

Currently the `SpanLink.trace_flags`  is set using `TraceDigest.trace_flags`. The `trace_flag` field in a trace_digest store sampling decisions propagated by tracecontext distributed headers. Therefore for non-remote spans and spans generated via datadog/b3 distributed tracing headers will have a `trace_flag` of `nil` even when a sampling decision exists. 

`SpanLink.trace_flag` must have one of the following values:
  - `nil` If there is NO sampling decision on the linked span
  -  `1` If the linked span is sampled
  - `0` If the linked span is NOT sampled (span will be dropped by the agent)

Since trace_flag is ONLY a function of sampling priority, we can ignore `TraceDigest.trace_flags` and always use sampling_priority to compute the valid when a span link is generated.