### PR TITLE
[NO-TICKET] Remove deprecated profiler settings

### DIFF
--- a/docs/UpgradeGuide2.md
+++ b/docs/UpgradeGuide2.md
@@ -92,7 +92,7 @@ Datadog.configure do |c|
 end
 ```
 
-<h4 id="2.0-type-checking">Enforce type checking</h4>
+<h4 id="2.0-type-checking">Enforced type checking</h4>
 
 Configuration options are type checked. When validation fails, an `ArgumentError` is raised.
 
@@ -124,7 +124,7 @@ B3 propagation has been removed from the default propagation for distributed tra
 
 - Option `c.tracing.client_ip.enabled`: `ENV['DD_TRACE_CLIENT_IP_HEADER_DISABLED']` is removed. Use `ENV['DD_TRACE_CLIENT_IP_ENABLED']` instead.
 
-- The following programmatic configuration options have been changed. Their corresponding environment variables (if any) are unchanged:
+- The following configuration options have been changed. Changes to their corresponding environment variables (if any) are noted as well:
 
   | 1.x                                                      | 2.0                                   |
   | -------------------------------------------------------- | ------------------------------------- |
@@ -134,13 +134,15 @@ B3 propagation has been removed from the default propagation for distributed tra
   | `tracing.distributed_tracing.propagation_style`          | `tracing.propagation_style`           |
   | `diagnostics.health_metrics.enabled`                     | `health_metrics.enabled`              |
   | `diagnostics.health_metrics.statsd`                      | `health_metrics.statsd`               |
-  | `profiling.advanced.max_events`                          | Removed                               |
-  | `profiling.advanced.legacy_transport_enabled`            | Removed                               |
-  | `profiling.advanced.force_enable_new_profiler`           | Removed                               |
-  | `profiling.advanced.force_enable_legacy_profiler`        | Removed                               |
   | `profiling.advanced.allocation_counting_enabled`         | Removed                               |
+  | `profiling.advanced.experimental_allocation_enabled`     | `profiling.allocation_enabled` (`DD_PROFILING_ALLOCATION_ENABLED` environment variable)                          |
   | `profiling.advanced.experimental_allocation_sample_rate` | Removed                               |
-  | `profiling.advanced.experimental_timeline_enabled`       | `profiling.advanced.timeline_enabled` |
+  | `profiling.advanced.experimental_timeline_enabled`       | `profiling.advanced.timeline_enabled` (`DD_PROFILING_TIMELINE_ENABLED` environment variable, enabled by default) |
+  | `profiling.advanced.force_enable_gc_profiling`           | `profiling.advanced.gc_enabled` (`DD_PROFILING_GC_ENABLED` environment variable, enabled by default)             |
+  | `profiling.advanced.force_enable_legacy_profiler`        | Removed                               |
+  | `profiling.advanced.force_enable_new_profiler`           | Removed                               |
+  | `profiling.advanced.legacy_transport_enabled`            | Removed                               |
+  | `profiling.advanced.max_events`                          | Removed                               |
 
 <h2 id="2.0-advanced-usage">Advanced Usage</h2>
 

--- a/lib/datadog/core/configuration/settings.rb
+++ b/lib/datadog/core/configuration/settings.rb
@@ -276,24 +276,6 @@ module Datadog
               o.default true
             end
 
-            # Forces enabling of profiling of time/resources spent in Garbage Collection.
-            #
-            # Note that setting this to "false" (or not setting it) will not prevent the feature from being
-            # being automatically enabled in the future.
-            #
-            # GC profiling is now on by default and controlled by {:gc_enabled}.
-            option :force_enable_gc_profiling do |o|
-              o.after_set do |_, _, precedence|
-                unless precedence == Datadog::Core::Configuration::Option::Precedence::DEFAULT
-                  Datadog.logger.warn(
-                    'The profiling.advanced.force_enable_gc_profiling setting has been deprecated for removal and no ' \
-                    'longer does anything (the feature is now on by default). ' \
-                    'Please remove this setting from your Datadog.configure block.'
-                  )
-                end
-              end
-            end
-
             # Can be used to enable/disable garbage collection profiling.
             #
             # @warn To avoid https://bugs.ruby-lang.org/issues/18464 even when enabled, GC profiling is only started
@@ -308,36 +290,6 @@ module Datadog
               o.type :bool
               o.env 'DD_PROFILING_GC_ENABLED'
               o.default true
-            end
-
-            # Can be used to enable/disable the Datadog::Profiling.allocation_count feature.
-            #
-            # @deprecated Use {:allocation_enabled} (outside of advanced section) instead.
-            option :allocation_counting_enabled do |o|
-              o.after_set do |_, _, precedence|
-                unless precedence == Datadog::Core::Configuration::Option::Precedence::DEFAULT
-                  Datadog.logger.warn(
-                    'The profiling.advanced.allocation_counting_enabled setting has been deprecated for removal and no ' \
-                    'longer does anything. Please remove it from your Datadog.configure block. ' \
-                    'Allocation counting is now controlled by the profiling.allocation_enabled setting instead.'
-                  )
-                end
-              end
-            end
-
-            # @deprecated Use {:allocation_enabled} (outside of advanced section) instead.
-            option :experimental_allocation_enabled do |o|
-              o.type :bool
-              o.default false
-              o.after_set do |_, _, precedence|
-                unless precedence == Datadog::Core::Configuration::Option::Precedence::DEFAULT
-                  Datadog.logger.warn(
-                    'The profiling.advanced.experimental_allocation_enabled setting has been deprecated for removal and ' \
-                    'no longer does anything. Please remove it from your Datadog.configure block. ' \
-                    'Allocation profiling is now controlled by the profiling.allocation_enabled setting instead.'
-                  )
-                end
-              end
             end
 
             # Can be used to enable/disable the collection of heap profiles.
@@ -367,22 +319,6 @@ module Datadog
               o.default true # This gets ANDed with experimental_heap_enabled in the profiler component.
             end
 
-            # Can be used to configure the allocation sampling rate: a sample will be collected every x allocations.
-            #
-            # This feature is now controlled via {:overhead_target_percentage}
-            option :experimental_allocation_sample_rate do |o|
-              o.after_set do |_, _, precedence|
-                unless precedence == Datadog::Core::Configuration::Option::Precedence::DEFAULT
-                  Datadog.logger.warn(
-                    'The profiling.advanced.experimental_allocation_sample_rate setting has been deprecated for removal ' \
-                    'and no longer does anything. Please remove it from your Datadog.configure block. ' \
-                    'Allocation sample rate is now handled by a dynamic sampler which will adjust the sampling rate to ' \
-                    'keep to the configured `profiling.advanced.overhead_target_percentage`.'
-                  )
-                end
-              end
-            end
-
             # Can be used to configure the heap sampling rate: a heap sample will be collected for every x allocation
             # samples.
             #
@@ -408,21 +344,6 @@ module Datadog
               o.type :bool
               o.env 'DD_PROFILING_SKIP_MYSQL2_CHECK'
               o.default false
-            end
-
-            # Enables data collection for the timeline feature. This is still experimental and not recommended yet.
-            #
-            # @default `DD_PROFILING_EXPERIMENTAL_TIMELINE_ENABLED` environment variable as a boolean, otherwise `false`
-            option :experimental_timeline_enabled do |o|
-              o.after_set do |_, _, precedence|
-                unless precedence == Datadog::Core::Configuration::Option::Precedence::DEFAULT
-                  Datadog.logger.warn(
-                    'The profiling.advanced.experimental_timeline_enabled setting has been deprecated for removal ' \
-                    'and no longer does anything. Please remove it from your Datadog.configure block. ' \
-                    'The timeline feature counting is now controlled by the `timeline_enabled` setting instead.'
-                  )
-                end
-              end
             end
 
             # Controls data collection for the timeline feature.

--- a/spec/datadog/core/configuration/settings_spec.rb
+++ b/spec/datadog/core/configuration/settings_spec.rb
@@ -457,14 +457,6 @@ RSpec.describe Datadog::Core::Configuration::Settings do
         end
       end
 
-      describe '#force_enable_gc_profiling=' do
-        it 'logs a warning informing customers this no longer does anything' do
-          expect(Datadog.logger).to receive(:warn).with(/no longer does anything/)
-
-          settings.profiling.advanced.force_enable_gc_profiling = true
-        end
-      end
-
       describe '#gc_enabled' do
         subject(:gc_enabled) { settings.profiling.advanced.gc_enabled }
 
@@ -497,22 +489,6 @@ RSpec.describe Datadog::Core::Configuration::Settings do
             .to change { settings.profiling.advanced.gc_enabled }
             .from(true)
             .to(false)
-        end
-      end
-
-      describe '#allocation_counting_enabled=' do
-        it 'logs a warning informing customers this no longer does anything' do
-          expect(Datadog.logger).to receive(:warn).with(/no longer does anything/)
-
-          settings.profiling.advanced.allocation_counting_enabled = false
-        end
-      end
-
-      describe '#experimental_allocation_enabled=' do
-        it 'logs a warning informing customers this no longer does anything' do
-          expect(Datadog.logger).to receive(:warn).with(/no longer does anything/)
-
-          settings.profiling.advanced.experimental_allocation_enabled = true
         end
       end
 
@@ -583,14 +559,6 @@ RSpec.describe Datadog::Core::Configuration::Settings do
             .to change { settings.profiling.advanced.experimental_heap_size_enabled }
             .from(true)
             .to(false)
-        end
-      end
-
-      describe '#experimental_allocation_sample_rate=' do
-        it 'logs a warning informing customers this no longer does anything' do
-          expect(Datadog.logger).to receive(:warn).with(/no longer does anything/)
-
-          settings.profiling.advanced.experimental_allocation_sample_rate = 0
         end
       end
 
@@ -694,14 +662,6 @@ RSpec.describe Datadog::Core::Configuration::Settings do
             .to change { settings.profiling.advanced.no_signals_workaround_enabled }
             .from(:auto)
             .to(false)
-        end
-      end
-
-      describe '#experimental_timeline_enabled=' do
-        it 'logs a warning  that this no longer does anything' do
-          expect(Datadog.logger).to receive(:warn).with(/no longer does anything/)
-
-          settings.profiling.advanced.experimental_timeline_enabled = 0
         end
       end
 


### PR DESCRIPTION
**What does this PR do?**

This profiler removes a number of profiler settings that have been deprecated for a while.

**Motivation:**

On the 1.x series, we were keeping these settings around, even though they didn't do anything; for the 2.0 release, we're taking the opportunity to delete them, as, again, they don't do anything.

**Additional Notes:**

I've included the needed changes to the upgrade guide as well.

**How to test the change?**

These settings were already not in use, so the only change is really to delete any references to them.