### PR TITLE
Bump to version 2.0.0.beta2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,53 @@
 
 ## [Unreleased]
 
+## [2.0.0.beta2] - 2024-04-18
+
+### Added
+
+* Add Agent configuration option: `timeout_seconds`, `uds_path`, and `use_ssl` ([#3350][])
+* Tracing: Add lightweight log correlation generation ([#3486][])
+* Tracing: Add span links ([#3546][])
+* Tracing: Add `span_remote` field to `TraceDigest` ([#3516][])
+* Tracing: Add `_dd.parent_id` to `tracestate` ([#3488][])
+* Tracing: Allow `RateSampler` with zero sampling rate ([#3295][])
+* Grape: Add `on_error` settings ([#3370][])
+
+### Changed
+
+* Rename gem from `ddtrace` to `datadog` ([#3490][])
+* Require Ruby `>= 2.5` ([#3291][])
+* Frozen string literals ([#3392][])
+* Startup logs emit when reconfigures ([#3441][])
+* Enhance validation for configuration ([#3332][], [#3326][])
+* Tracing: Propagation style configuration becomes case-insensitive ([#3299][])
+* Tracing: Return string for `#trace_id` and `#span_id` from `Correlation::Identifier` ([#3322][])
+* `Elasticsearch`: Replace instance configuration from `client` to `transport` instance ([#3399][])
+* `Grape`: Change `error_statuses` settings to `error_status_codes` ([#3370][])
+* `GraphQL`: Instrument with `GraphQL::Tracing::DataDogTrace` and more ([#3409][], [#3417][], [#3388][])
+* `Rack`: Change http proxy span pattern ([#3369][])
+* `Sidekiq`: Remove `tag_args` option and worker specific configuration ([#3396][], [#3402][])
+* Integrations: Rename `error_handler` settings to `on_error` ([#3341][])
+*
+### Fixed
+
+* Tracing: Fix `error_status_codes` options ([#3344][])
+
+### Removed
+
+* Profiling: Remove `bin/ddtracerb` ([#3506][])
+* Ci-app: Remove `datadog-ci` gem dependency ([#3288][])
+* Tracing: Remove `SpanOperation` aliases ([#3330][])
+* Tracing: Remove `b3` style from default propagation ([#3293][])
+* Tracing: Minimize sampling API ([#3423][])
+* Tracing: Remove `client_ip` disabled env ([#3404][])
+* Tracing: Remove `use` alias for `instrument` ([#3403][])
+* Tracing: `OpenTracing`, `qless` removed ([#3398][], [#3443][])
+* `Net/Http`: Remove `Datadog::Tracing::Contrib::HTTP::Instrumentation.after_request` ([#3367][])
+* `Rails`: Drop support for Rails 3 ([#3324][])
+* `Rails`: Remove `exception_controller` option ([#3243][])
+* Remove constants, methods and more ([#3401][], [#3336][], [#3454][], [#3338][], [#3335][], [#3298][], [#3297][], [#3309][], [#3294][], [#3325][], [#3300][])
+
 ## [1.22.0] - 2024-04-16
 
 ### Added
@@ -2804,6 +2851,7 @@ Git diff: https://github.com/DataDog/dd-trace-rb/compare/v0.3.0...v0.3.1
 
 
 [Unreleased]: https://github.com/DataDog/dd-trace-rb/compare/v1.22.0...master
+[2.0.0.beta2]: https://github.com/DataDog/dd-trace-rb/compare/v2.0.0.beta1...v2.0.0.beta2
 [1.22.0]: https://github.com/DataDog/dd-trace-rb/compare/v1.21.1...v1.22.0
 [2.0.0.beta1]: https://github.com/DataDog/dd-trace-rb/compare/v1.21.1...v2.0.0.beta1
 [1.21.1]: https://github.com/DataDog/dd-trace-rb/compare/v1.21.0...v1.21.1
@@ -4027,6 +4075,7 @@ Git diff: https://github.com/DataDog/dd-trace-rb/compare/v0.3.0...v0.3.1
 [#3235]: https://github.com/DataDog/dd-trace-rb/issues/3235
 [#3240]: https://github.com/DataDog/dd-trace-rb/issues/3240
 [#3242]: https://github.com/DataDog/dd-trace-rb/issues/3242
+[#3243]: https://github.com/DataDog/dd-trace-rb/issues/3243
 [#3248]: https://github.com/DataDog/dd-trace-rb/issues/3248
 [#3252]: https://github.com/DataDog/dd-trace-rb/issues/3252
 [#3255]: https://github.com/DataDog/dd-trace-rb/issues/3255
@@ -4045,21 +4094,43 @@ Git diff: https://github.com/DataDog/dd-trace-rb/compare/v0.3.0...v0.3.1
 [#3284]: https://github.com/DataDog/dd-trace-rb/issues/3284
 [#3286]: https://github.com/DataDog/dd-trace-rb/issues/3286
 [#3287]: https://github.com/DataDog/dd-trace-rb/issues/3287
+[#3288]: https://github.com/DataDog/dd-trace-rb/issues/3288
 [#3289]: https://github.com/DataDog/dd-trace-rb/issues/3289
+[#3291]: https://github.com/DataDog/dd-trace-rb/issues/3291
+[#3293]: https://github.com/DataDog/dd-trace-rb/issues/3293
+[#3294]: https://github.com/DataDog/dd-trace-rb/issues/3294
+[#3295]: https://github.com/DataDog/dd-trace-rb/issues/3295
+[#3297]: https://github.com/DataDog/dd-trace-rb/issues/3297
+[#3298]: https://github.com/DataDog/dd-trace-rb/issues/3298
+[#3299]: https://github.com/DataDog/dd-trace-rb/issues/3299
+[#3300]: https://github.com/DataDog/dd-trace-rb/issues/3300
 [#3303]: https://github.com/DataDog/dd-trace-rb/issues/3303
 [#3307]: https://github.com/DataDog/dd-trace-rb/issues/3307
 [#3308]: https://github.com/DataDog/dd-trace-rb/issues/3308
+[#3309]: https://github.com/DataDog/dd-trace-rb/issues/3309
 [#3310]: https://github.com/DataDog/dd-trace-rb/issues/3310
 [#3313]: https://github.com/DataDog/dd-trace-rb/issues/3313
 [#3315]: https://github.com/DataDog/dd-trace-rb/issues/3315
 [#3316]: https://github.com/DataDog/dd-trace-rb/issues/3316
 [#3317]: https://github.com/DataDog/dd-trace-rb/issues/3317
 [#3320]: https://github.com/DataDog/dd-trace-rb/issues/3320
+[#3322]: https://github.com/DataDog/dd-trace-rb/issues/3322
+[#3324]: https://github.com/DataDog/dd-trace-rb/issues/3324
+[#3325]: https://github.com/DataDog/dd-trace-rb/issues/3325
+[#3326]: https://github.com/DataDog/dd-trace-rb/issues/3326
 [#3328]: https://github.com/DataDog/dd-trace-rb/issues/3328
 [#3329]: https://github.com/DataDog/dd-trace-rb/issues/3329
+[#3330]: https://github.com/DataDog/dd-trace-rb/issues/3330
+[#3332]: https://github.com/DataDog/dd-trace-rb/issues/3332
 [#3333]: https://github.com/DataDog/dd-trace-rb/issues/3333
+[#3335]: https://github.com/DataDog/dd-trace-rb/issues/3335
+[#3336]: https://github.com/DataDog/dd-trace-rb/issues/3336
+[#3338]: https://github.com/DataDog/dd-trace-rb/issues/3338
+[#3341]: https://github.com/DataDog/dd-trace-rb/issues/3341
+[#3344]: https://github.com/DataDog/dd-trace-rb/issues/3344
 [#3345]: https://github.com/DataDog/dd-trace-rb/issues/3345
 [#3349]: https://github.com/DataDog/dd-trace-rb/issues/3349
+[#3350]: https://github.com/DataDog/dd-trace-rb/issues/3350
 [#3352]: https://github.com/DataDog/dd-trace-rb/issues/3352
 [#3354]: https://github.com/DataDog/dd-trace-rb/issues/3354
 [#3356]: https://github.com/DataDog/dd-trace-rb/issues/3356
@@ -4069,13 +4140,28 @@ Git diff: https://github.com/DataDog/dd-trace-rb/compare/v0.3.0...v0.3.1
 [#3362]: https://github.com/DataDog/dd-trace-rb/issues/3362
 [#3365]: https://github.com/DataDog/dd-trace-rb/issues/3365
 [#3366]: https://github.com/DataDog/dd-trace-rb/issues/3366
+[#3367]: https://github.com/DataDog/dd-trace-rb/issues/3367
+[#3369]: https://github.com/DataDog/dd-trace-rb/issues/3369
+[#3370]: https://github.com/DataDog/dd-trace-rb/issues/3370
 [#3373]: https://github.com/DataDog/dd-trace-rb/issues/3373
 [#3374]: https://github.com/DataDog/dd-trace-rb/issues/3374
 [#3386]: https://github.com/DataDog/dd-trace-rb/issues/3386
+[#3388]: https://github.com/DataDog/dd-trace-rb/issues/3388
+[#3392]: https://github.com/DataDog/dd-trace-rb/issues/3392
 [#3395]: https://github.com/DataDog/dd-trace-rb/issues/3395
+[#3396]: https://github.com/DataDog/dd-trace-rb/issues/3396
+[#3398]: https://github.com/DataDog/dd-trace-rb/issues/3398
+[#3399]: https://github.com/DataDog/dd-trace-rb/issues/3399
 [#3400]: https://github.com/DataDog/dd-trace-rb/issues/3400
+[#3401]: https://github.com/DataDog/dd-trace-rb/issues/3401
+[#3402]: https://github.com/DataDog/dd-trace-rb/issues/3402
+[#3403]: https://github.com/DataDog/dd-trace-rb/issues/3403
+[#3404]: https://github.com/DataDog/dd-trace-rb/issues/3404
 [#3408]: https://github.com/DataDog/dd-trace-rb/issues/3408
+[#3409]: https://github.com/DataDog/dd-trace-rb/issues/3409
+[#3417]: https://github.com/DataDog/dd-trace-rb/issues/3417
 [#3420]: https://github.com/DataDog/dd-trace-rb/issues/3420
+[#3423]: https://github.com/DataDog/dd-trace-rb/issues/3423
 [#3426]: https://github.com/DataDog/dd-trace-rb/issues/3426
 [#3427]: https://github.com/DataDog/dd-trace-rb/issues/3427
 [#3428]: https://github.com/DataDog/dd-trace-rb/issues/3428
@@ -4084,17 +4170,25 @@ Git diff: https://github.com/DataDog/dd-trace-rb/compare/v0.3.0...v0.3.1
 [#3438]: https://github.com/DataDog/dd-trace-rb/issues/3438
 [#3439]: https://github.com/DataDog/dd-trace-rb/issues/3439
 [#3440]: https://github.com/DataDog/dd-trace-rb/issues/3440
+[#3441]: https://github.com/DataDog/dd-trace-rb/issues/3441
+[#3443]: https://github.com/DataDog/dd-trace-rb/issues/3443
+[#3454]: https://github.com/DataDog/dd-trace-rb/issues/3454
 [#3455]: https://github.com/DataDog/dd-trace-rb/issues/3455
 [#3463]: https://github.com/DataDog/dd-trace-rb/issues/3463
 [#3466]: https://github.com/DataDog/dd-trace-rb/issues/3466
 [#3468]: https://github.com/DataDog/dd-trace-rb/issues/3468
 [#3473]: https://github.com/DataDog/dd-trace-rb/issues/3473
+[#3486]: https://github.com/DataDog/dd-trace-rb/issues/3486
+[#3488]: https://github.com/DataDog/dd-trace-rb/issues/3488
+[#3490]: https://github.com/DataDog/dd-trace-rb/issues/3490
 [#3491]: https://github.com/DataDog/dd-trace-rb/issues/3491
 [#3495]: https://github.com/DataDog/dd-trace-rb/issues/3495
 [#3501]: https://github.com/DataDog/dd-trace-rb/issues/3501
 [#3502]: https://github.com/DataDog/dd-trace-rb/issues/3502
 [#3503]: https://github.com/DataDog/dd-trace-rb/issues/3503
+[#3506]: https://github.com/DataDog/dd-trace-rb/issues/3506
 [#3511]: https://github.com/DataDog/dd-trace-rb/issues/3511
+[#3516]: https://github.com/DataDog/dd-trace-rb/issues/3516
 [#3518]: https://github.com/DataDog/dd-trace-rb/issues/3518
 [#3519]: https://github.com/DataDog/dd-trace-rb/issues/3519
 [#3520]: https://github.com/DataDog/dd-trace-rb/issues/3520
@@ -4104,6 +4198,7 @@ Git diff: https://github.com/DataDog/dd-trace-rb/compare/v0.3.0...v0.3.1
 [#3535]: https://github.com/DataDog/dd-trace-rb/issues/3535
 [#3536]: https://github.com/DataDog/dd-trace-rb/issues/3536
 [#3539]: https://github.com/DataDog/dd-trace-rb/issues/3539
+[#3546]: https://github.com/DataDog/dd-trace-rb/issues/3546
 [#3551]: https://github.com/DataDog/dd-trace-rb/issues/3551
 [#3558]: https://github.com/DataDog/dd-trace-rb/issues/3558
 [#3565]: https://github.com/DataDog/dd-trace-rb/issues/3565

--- a/gemfiles/jruby_9.2_activesupport.gemfile.lock
+++ b/gemfiles/jruby_9.2_activesupport.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    datadog (2.0.0.beta1)
+    datadog (2.0.0.beta2)
       debase-ruby_core_source (= 3.3.1)
       libdatadog (~> 7.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)

--- a/gemfiles/jruby_9.2_aws.gemfile.lock
+++ b/gemfiles/jruby_9.2_aws.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    datadog (2.0.0.beta1)
+    datadog (2.0.0.beta2)
       debase-ruby_core_source (= 3.3.1)
       libdatadog (~> 7.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)

--- a/gemfiles/jruby_9.2_contrib.gemfile.lock
+++ b/gemfiles/jruby_9.2_contrib.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    datadog (2.0.0.beta1)
+    datadog (2.0.0.beta2)
       debase-ruby_core_source (= 3.3.1)
       libdatadog (~> 7.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)

--- a/gemfiles/jruby_9.2_contrib_old.gemfile.lock
+++ b/gemfiles/jruby_9.2_contrib_old.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    datadog (2.0.0.beta1)
+    datadog (2.0.0.beta2)
       debase-ruby_core_source (= 3.3.1)
       libdatadog (~> 7.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)

--- a/gemfiles/jruby_9.2_core_old.gemfile.lock
+++ b/gemfiles/jruby_9.2_core_old.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    datadog (2.0.0.beta1)
+    datadog (2.0.0.beta2)
       debase-ruby_core_source (= 3.3.1)
       libdatadog (~> 7.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)

--- a/gemfiles/jruby_9.2_elasticsearch_7.gemfile.lock
+++ b/gemfiles/jruby_9.2_elasticsearch_7.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    datadog (2.0.0.beta1)
+    datadog (2.0.0.beta2)
       debase-ruby_core_source (= 3.3.1)
       libdatadog (~> 7.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)

--- a/gemfiles/jruby_9.2_elasticsearch_8.gemfile.lock
+++ b/gemfiles/jruby_9.2_elasticsearch_8.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    datadog (2.0.0.beta1)
+    datadog (2.0.0.beta2)
       debase-ruby_core_source (= 3.3.1)
       libdatadog (~> 7.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)

--- a/gemfiles/jruby_9.2_graphql_1.13.gemfile.lock
+++ b/gemfiles/jruby_9.2_graphql_1.13.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    datadog (2.0.0.beta1)
+    datadog (2.0.0.beta2)
       debase-ruby_core_source (= 3.3.1)
       libdatadog (~> 7.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)

--- a/gemfiles/jruby_9.2_graphql_2.0.gemfile.lock
+++ b/gemfiles/jruby_9.2_graphql_2.0.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    datadog (2.0.0.beta1)
+    datadog (2.0.0.beta2)
       debase-ruby_core_source (= 3.3.1)
       libdatadog (~> 7.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)

--- a/gemfiles/jruby_9.2_hanami_1.gemfile.lock
+++ b/gemfiles/jruby_9.2_hanami_1.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    datadog (2.0.0.beta1)
+    datadog (2.0.0.beta2)
       debase-ruby_core_source (= 3.3.1)
       libdatadog (~> 7.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)

--- a/gemfiles/jruby_9.2_http.gemfile.lock
+++ b/gemfiles/jruby_9.2_http.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    datadog (2.0.0.beta1)
+    datadog (2.0.0.beta2)
       debase-ruby_core_source (= 3.3.1)
       libdatadog (~> 7.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)

--- a/gemfiles/jruby_9.2_multi_rack_app.gemfile.lock
+++ b/gemfiles/jruby_9.2_multi_rack_app.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    datadog (2.0.0.dev)
+    datadog (2.0.0.beta2)
       base64
       debase-ruby_core_source (= 3.3.1)
       libdatadog (~> 7.0.0.1.0)

--- a/gemfiles/jruby_9.2_opensearch_2.gemfile.lock
+++ b/gemfiles/jruby_9.2_opensearch_2.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    datadog (2.0.0.beta1)
+    datadog (2.0.0.beta2)
       debase-ruby_core_source (= 3.3.1)
       libdatadog (~> 7.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)

--- a/gemfiles/jruby_9.2_opensearch_3.gemfile.lock
+++ b/gemfiles/jruby_9.2_opensearch_3.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    datadog (2.0.0.beta1)
+    datadog (2.0.0.beta2)
       debase-ruby_core_source (= 3.3.1)
       libdatadog (~> 7.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)

--- a/gemfiles/jruby_9.2_opentracing.gemfile.lock
+++ b/gemfiles/jruby_9.2_opentracing.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    datadog (2.0.0.beta1)
+    datadog (2.0.0.beta2)
       debase-ruby_core_source (= 3.3.1)
       libdatadog (~> 7.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)

--- a/gemfiles/jruby_9.2_rack_1.gemfile.lock
+++ b/gemfiles/jruby_9.2_rack_1.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    datadog (2.0.0.beta1)
+    datadog (2.0.0.beta2)
       debase-ruby_core_source (= 3.3.1)
       libdatadog (~> 7.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)

--- a/gemfiles/jruby_9.2_rack_2.gemfile.lock
+++ b/gemfiles/jruby_9.2_rack_2.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    datadog (2.0.0.beta1)
+    datadog (2.0.0.beta2)
       debase-ruby_core_source (= 3.3.1)
       libdatadog (~> 7.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)

--- a/gemfiles/jruby_9.2_rack_3.gemfile.lock
+++ b/gemfiles/jruby_9.2_rack_3.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    datadog (2.0.0.beta1)
+    datadog (2.0.0.beta2)
       debase-ruby_core_source (= 3.3.1)
       libdatadog (~> 7.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)

--- a/gemfiles/jruby_9.2_rails5_mysql2.gemfile.lock
+++ b/gemfiles/jruby_9.2_rails5_mysql2.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    datadog (2.0.0.beta1)
+    datadog (2.0.0.beta2)
       debase-ruby_core_source (= 3.3.1)
       libdatadog (~> 7.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)

--- a/gemfiles/jruby_9.2_rails5_postgres.gemfile.lock
+++ b/gemfiles/jruby_9.2_rails5_postgres.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    datadog (2.0.0.beta1)
+    datadog (2.0.0.beta2)
       debase-ruby_core_source (= 3.3.1)
       libdatadog (~> 7.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)

--- a/gemfiles/jruby_9.2_rails5_postgres_redis.gemfile.lock
+++ b/gemfiles/jruby_9.2_rails5_postgres_redis.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    datadog (2.0.0.beta1)
+    datadog (2.0.0.beta2)
       debase-ruby_core_source (= 3.3.1)
       libdatadog (~> 7.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)

--- a/gemfiles/jruby_9.2_rails5_postgres_redis_activesupport.gemfile.lock
+++ b/gemfiles/jruby_9.2_rails5_postgres_redis_activesupport.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    datadog (2.0.0.beta1)
+    datadog (2.0.0.beta2)
       debase-ruby_core_source (= 3.3.1)
       libdatadog (~> 7.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)

--- a/gemfiles/jruby_9.2_rails5_postgres_sidekiq.gemfile.lock
+++ b/gemfiles/jruby_9.2_rails5_postgres_sidekiq.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    datadog (2.0.0.beta1)
+    datadog (2.0.0.beta2)
       debase-ruby_core_source (= 3.3.1)
       libdatadog (~> 7.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)

--- a/gemfiles/jruby_9.2_rails5_semantic_logger.gemfile.lock
+++ b/gemfiles/jruby_9.2_rails5_semantic_logger.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    datadog (2.0.0.beta1)
+    datadog (2.0.0.beta2)
       debase-ruby_core_source (= 3.3.1)
       libdatadog (~> 7.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)

--- a/gemfiles/jruby_9.2_rails61_mysql2.gemfile.lock
+++ b/gemfiles/jruby_9.2_rails61_mysql2.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    datadog (2.0.0.beta1)
+    datadog (2.0.0.beta2)
       debase-ruby_core_source (= 3.3.1)
       libdatadog (~> 7.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)

--- a/gemfiles/jruby_9.2_rails61_postgres.gemfile.lock
+++ b/gemfiles/jruby_9.2_rails61_postgres.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    datadog (2.0.0.beta1)
+    datadog (2.0.0.beta2)
       debase-ruby_core_source (= 3.3.1)
       libdatadog (~> 7.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)

--- a/gemfiles/jruby_9.2_rails61_postgres_redis.gemfile.lock
+++ b/gemfiles/jruby_9.2_rails61_postgres_redis.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    datadog (2.0.0.beta1)
+    datadog (2.0.0.beta2)
       debase-ruby_core_source (= 3.3.1)
       libdatadog (~> 7.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)

--- a/gemfiles/jruby_9.2_rails61_postgres_sidekiq.gemfile.lock
+++ b/gemfiles/jruby_9.2_rails61_postgres_sidekiq.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    datadog (2.0.0.beta1)
+    datadog (2.0.0.beta2)
       debase-ruby_core_source (= 3.3.1)
       libdatadog (~> 7.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)

--- a/gemfiles/jruby_9.2_rails61_semantic_logger.gemfile.lock
+++ b/gemfiles/jruby_9.2_rails61_semantic_logger.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    datadog (2.0.0.beta1)
+    datadog (2.0.0.beta2)
       debase-ruby_core_source (= 3.3.1)
       libdatadog (~> 7.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)

--- a/gemfiles/jruby_9.2_rails6_mysql2.gemfile.lock
+++ b/gemfiles/jruby_9.2_rails6_mysql2.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    datadog (2.0.0.beta1)
+    datadog (2.0.0.beta2)
       debase-ruby_core_source (= 3.3.1)
       libdatadog (~> 7.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)

--- a/gemfiles/jruby_9.2_rails6_postgres.gemfile.lock
+++ b/gemfiles/jruby_9.2_rails6_postgres.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    datadog (2.0.0.beta1)
+    datadog (2.0.0.beta2)
       debase-ruby_core_source (= 3.3.1)
       libdatadog (~> 7.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)

--- a/gemfiles/jruby_9.2_rails6_postgres_redis.gemfile.lock
+++ b/gemfiles/jruby_9.2_rails6_postgres_redis.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    datadog (2.0.0.beta1)
+    datadog (2.0.0.beta2)
       debase-ruby_core_source (= 3.3.1)
       libdatadog (~> 7.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)

--- a/gemfiles/jruby_9.2_rails6_postgres_redis_activesupport.gemfile.lock
+++ b/gemfiles/jruby_9.2_rails6_postgres_redis_activesupport.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    datadog (2.0.0.beta1)
+    datadog (2.0.0.beta2)
       debase-ruby_core_source (= 3.3.1)
       libdatadog (~> 7.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)

--- a/gemfiles/jruby_9.2_rails6_postgres_sidekiq.gemfile.lock
+++ b/gemfiles/jruby_9.2_rails6_postgres_sidekiq.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    datadog (2.0.0.beta1)
+    datadog (2.0.0.beta2)
       debase-ruby_core_source (= 3.3.1)
       libdatadog (~> 7.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)

--- a/gemfiles/jruby_9.2_rails6_semantic_logger.gemfile.lock
+++ b/gemfiles/jruby_9.2_rails6_semantic_logger.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    datadog (2.0.0.beta1)
+    datadog (2.0.0.beta2)
       debase-ruby_core_source (= 3.3.1)
       libdatadog (~> 7.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)

--- a/gemfiles/jruby_9.2_redis_3.gemfile.lock
+++ b/gemfiles/jruby_9.2_redis_3.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    datadog (2.0.0.beta1)
+    datadog (2.0.0.beta2)
       debase-ruby_core_source (= 3.3.1)
       libdatadog (~> 7.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)

--- a/gemfiles/jruby_9.2_redis_4.gemfile.lock
+++ b/gemfiles/jruby_9.2_redis_4.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    datadog (2.0.0.beta1)
+    datadog (2.0.0.beta2)
       debase-ruby_core_source (= 3.3.1)
       libdatadog (~> 7.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)

--- a/gemfiles/jruby_9.2_redis_5.gemfile.lock
+++ b/gemfiles/jruby_9.2_redis_5.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    datadog (2.0.0.beta1)
+    datadog (2.0.0.beta2)
       debase-ruby_core_source (= 3.3.1)
       libdatadog (~> 7.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)

--- a/gemfiles/jruby_9.2_relational_db.gemfile.lock
+++ b/gemfiles/jruby_9.2_relational_db.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    datadog (2.0.0.beta1)
+    datadog (2.0.0.beta2)
       debase-ruby_core_source (= 3.3.1)
       libdatadog (~> 7.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)

--- a/gemfiles/jruby_9.2_resque2_redis3.gemfile.lock
+++ b/gemfiles/jruby_9.2_resque2_redis3.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    datadog (2.0.0.beta1)
+    datadog (2.0.0.beta2)
       debase-ruby_core_source (= 3.3.1)
       libdatadog (~> 7.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)

--- a/gemfiles/jruby_9.2_resque2_redis4.gemfile.lock
+++ b/gemfiles/jruby_9.2_resque2_redis4.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    datadog (2.0.0.beta1)
+    datadog (2.0.0.beta2)
       debase-ruby_core_source (= 3.3.1)
       libdatadog (~> 7.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)

--- a/gemfiles/jruby_9.2_sinatra.gemfile.lock
+++ b/gemfiles/jruby_9.2_sinatra.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    datadog (2.0.0.beta1)
+    datadog (2.0.0.beta2)
       debase-ruby_core_source (= 3.3.1)
       libdatadog (~> 7.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)

--- a/gemfiles/jruby_9.3_activesupport.gemfile.lock
+++ b/gemfiles/jruby_9.3_activesupport.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    datadog (2.0.0.beta1)
+    datadog (2.0.0.beta2)
       debase-ruby_core_source (= 3.3.1)
       libdatadog (~> 7.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)

--- a/gemfiles/jruby_9.3_aws.gemfile.lock
+++ b/gemfiles/jruby_9.3_aws.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    datadog (2.0.0.beta1)
+    datadog (2.0.0.beta2)
       debase-ruby_core_source (= 3.3.1)
       libdatadog (~> 7.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)

--- a/gemfiles/jruby_9.3_contrib.gemfile.lock
+++ b/gemfiles/jruby_9.3_contrib.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    datadog (2.0.0.beta1)
+    datadog (2.0.0.beta2)
       debase-ruby_core_source (= 3.3.1)
       libdatadog (~> 7.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)

--- a/gemfiles/jruby_9.3_contrib_old.gemfile.lock
+++ b/gemfiles/jruby_9.3_contrib_old.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    datadog (2.0.0.beta1)
+    datadog (2.0.0.beta2)
       debase-ruby_core_source (= 3.3.1)
       libdatadog (~> 7.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)

--- a/gemfiles/jruby_9.3_core_old.gemfile.lock
+++ b/gemfiles/jruby_9.3_core_old.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    datadog (2.0.0.beta1)
+    datadog (2.0.0.beta2)
       debase-ruby_core_source (= 3.3.1)
       libdatadog (~> 7.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)

--- a/gemfiles/jruby_9.3_elasticsearch_7.gemfile.lock
+++ b/gemfiles/jruby_9.3_elasticsearch_7.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    datadog (2.0.0.beta1)
+    datadog (2.0.0.beta2)
       debase-ruby_core_source (= 3.3.1)
       libdatadog (~> 7.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)

--- a/gemfiles/jruby_9.3_elasticsearch_8.gemfile.lock
+++ b/gemfiles/jruby_9.3_elasticsearch_8.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    datadog (2.0.0.beta1)
+    datadog (2.0.0.beta2)
       debase-ruby_core_source (= 3.3.1)
       libdatadog (~> 7.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)

--- a/gemfiles/jruby_9.3_graphql_1.13.gemfile.lock
+++ b/gemfiles/jruby_9.3_graphql_1.13.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    datadog (2.0.0.beta1)
+    datadog (2.0.0.beta2)
       debase-ruby_core_source (= 3.3.1)
       libdatadog (~> 7.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)

--- a/gemfiles/jruby_9.3_graphql_2.0.gemfile.lock
+++ b/gemfiles/jruby_9.3_graphql_2.0.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    datadog (2.0.0.beta1)
+    datadog (2.0.0.beta2)
       debase-ruby_core_source (= 3.3.1)
       libdatadog (~> 7.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)

--- a/gemfiles/jruby_9.3_hanami_1.gemfile.lock
+++ b/gemfiles/jruby_9.3_hanami_1.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    datadog (2.0.0.beta1)
+    datadog (2.0.0.beta2)
       debase-ruby_core_source (= 3.3.1)
       libdatadog (~> 7.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)

--- a/gemfiles/jruby_9.3_http.gemfile.lock
+++ b/gemfiles/jruby_9.3_http.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    datadog (2.0.0.beta1)
+    datadog (2.0.0.beta2)
       debase-ruby_core_source (= 3.3.1)
       libdatadog (~> 7.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)

--- a/gemfiles/jruby_9.3_multi_rack_app.gemfile.lock
+++ b/gemfiles/jruby_9.3_multi_rack_app.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    datadog (2.0.0.dev)
+    datadog (2.0.0.beta2)
       base64
       debase-ruby_core_source (= 3.3.1)
       libdatadog (~> 7.0.0.1.0)

--- a/gemfiles/jruby_9.3_opensearch_2.gemfile.lock
+++ b/gemfiles/jruby_9.3_opensearch_2.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    datadog (2.0.0.beta1)
+    datadog (2.0.0.beta2)
       debase-ruby_core_source (= 3.3.1)
       libdatadog (~> 7.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)

--- a/gemfiles/jruby_9.3_opensearch_3.gemfile.lock
+++ b/gemfiles/jruby_9.3_opensearch_3.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    datadog (2.0.0.beta1)
+    datadog (2.0.0.beta2)
       debase-ruby_core_source (= 3.3.1)
       libdatadog (~> 7.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)

--- a/gemfiles/jruby_9.3_opentracing.gemfile.lock
+++ b/gemfiles/jruby_9.3_opentracing.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    datadog (2.0.0.beta1)
+    datadog (2.0.0.beta2)
       debase-ruby_core_source (= 3.3.1)
       libdatadog (~> 7.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)

--- a/gemfiles/jruby_9.3_rack_1.gemfile.lock
+++ b/gemfiles/jruby_9.3_rack_1.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    datadog (2.0.0.beta1)
+    datadog (2.0.0.beta2)
       debase-ruby_core_source (= 3.3.1)
       libdatadog (~> 7.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)

--- a/gemfiles/jruby_9.3_rack_2.gemfile.lock
+++ b/gemfiles/jruby_9.3_rack_2.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    datadog (2.0.0.beta1)
+    datadog (2.0.0.beta2)
       debase-ruby_core_source (= 3.3.1)
       libdatadog (~> 7.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)

--- a/gemfiles/jruby_9.3_rack_3.gemfile.lock
+++ b/gemfiles/jruby_9.3_rack_3.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    datadog (2.0.0.beta1)
+    datadog (2.0.0.beta2)
       debase-ruby_core_source (= 3.3.1)
       libdatadog (~> 7.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)

--- a/gemfiles/jruby_9.3_rails5_mysql2.gemfile.lock
+++ b/gemfiles/jruby_9.3_rails5_mysql2.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    datadog (2.0.0.beta1)
+    datadog (2.0.0.beta2)
       debase-ruby_core_source (= 3.3.1)
       libdatadog (~> 7.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)

--- a/gemfiles/jruby_9.3_rails5_postgres.gemfile.lock
+++ b/gemfiles/jruby_9.3_rails5_postgres.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    datadog (2.0.0.beta1)
+    datadog (2.0.0.beta2)
       debase-ruby_core_source (= 3.3.1)
       libdatadog (~> 7.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)

--- a/gemfiles/jruby_9.3_rails5_postgres_redis.gemfile.lock
+++ b/gemfiles/jruby_9.3_rails5_postgres_redis.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    datadog (2.0.0.beta1)
+    datadog (2.0.0.beta2)
       debase-ruby_core_source (= 3.3.1)
       libdatadog (~> 7.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)

--- a/gemfiles/jruby_9.3_rails5_postgres_redis_activesupport.gemfile.lock
+++ b/gemfiles/jruby_9.3_rails5_postgres_redis_activesupport.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    datadog (2.0.0.beta1)
+    datadog (2.0.0.beta2)
       debase-ruby_core_source (= 3.3.1)
       libdatadog (~> 7.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)

--- a/gemfiles/jruby_9.3_rails5_postgres_sidekiq.gemfile.lock
+++ b/gemfiles/jruby_9.3_rails5_postgres_sidekiq.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    datadog (2.0.0.beta1)
+    datadog (2.0.0.beta2)
       debase-ruby_core_source (= 3.3.1)
       libdatadog (~> 7.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)

--- a/gemfiles/jruby_9.3_rails5_semantic_logger.gemfile.lock
+++ b/gemfiles/jruby_9.3_rails5_semantic_logger.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    datadog (2.0.0.beta1)
+    datadog (2.0.0.beta2)
       debase-ruby_core_source (= 3.3.1)
       libdatadog (~> 7.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)

--- a/gemfiles/jruby_9.3_rails61_mysql2.gemfile.lock
+++ b/gemfiles/jruby_9.3_rails61_mysql2.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    datadog (2.0.0.beta1)
+    datadog (2.0.0.beta2)
       debase-ruby_core_source (= 3.3.1)
       libdatadog (~> 7.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)

--- a/gemfiles/jruby_9.3_rails61_postgres.gemfile.lock
+++ b/gemfiles/jruby_9.3_rails61_postgres.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    datadog (2.0.0.beta1)
+    datadog (2.0.0.beta2)
       debase-ruby_core_source (= 3.3.1)
       libdatadog (~> 7.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)

--- a/gemfiles/jruby_9.3_rails61_postgres_redis.gemfile.lock
+++ b/gemfiles/jruby_9.3_rails61_postgres_redis.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    datadog (2.0.0.beta1)
+    datadog (2.0.0.beta2)
       debase-ruby_core_source (= 3.3.1)
       libdatadog (~> 7.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)

--- a/gemfiles/jruby_9.3_rails61_postgres_sidekiq.gemfile.lock
+++ b/gemfiles/jruby_9.3_rails61_postgres_sidekiq.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    datadog (2.0.0.beta1)
+    datadog (2.0.0.beta2)
       debase-ruby_core_source (= 3.3.1)
       libdatadog (~> 7.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)

--- a/gemfiles/jruby_9.3_rails61_semantic_logger.gemfile.lock
+++ b/gemfiles/jruby_9.3_rails61_semantic_logger.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    datadog (2.0.0.beta1)
+    datadog (2.0.0.beta2)
       debase-ruby_core_source (= 3.3.1)
       libdatadog (~> 7.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)

--- a/gemfiles/jruby_9.3_rails6_mysql2.gemfile.lock
+++ b/gemfiles/jruby_9.3_rails6_mysql2.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    datadog (2.0.0.beta1)
+    datadog (2.0.0.beta2)
       debase-ruby_core_source (= 3.3.1)
       libdatadog (~> 7.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)

--- a/gemfiles/jruby_9.3_rails6_postgres.gemfile.lock
+++ b/gemfiles/jruby_9.3_rails6_postgres.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    datadog (2.0.0.beta1)
+    datadog (2.0.0.beta2)
       debase-ruby_core_source (= 3.3.1)
       libdatadog (~> 7.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)

--- a/gemfiles/jruby_9.3_rails6_postgres_redis.gemfile.lock
+++ b/gemfiles/jruby_9.3_rails6_postgres_redis.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    datadog (2.0.0.beta1)
+    datadog (2.0.0.beta2)
       debase-ruby_core_source (= 3.3.1)
       libdatadog (~> 7.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)

--- a/gemfiles/jruby_9.3_rails6_postgres_redis_activesupport.gemfile.lock
+++ b/gemfiles/jruby_9.3_rails6_postgres_redis_activesupport.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    datadog (2.0.0.beta1)
+    datadog (2.0.0.beta2)
       debase-ruby_core_source (= 3.3.1)
       libdatadog (~> 7.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)

--- a/gemfiles/jruby_9.3_rails6_postgres_sidekiq.gemfile.lock
+++ b/gemfiles/jruby_9.3_rails6_postgres_sidekiq.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    datadog (2.0.0.beta1)
+    datadog (2.0.0.beta2)
       debase-ruby_core_source (= 3.3.1)
       libdatadog (~> 7.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)

--- a/gemfiles/jruby_9.3_rails6_semantic_logger.gemfile.lock
+++ b/gemfiles/jruby_9.3_rails6_semantic_logger.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    datadog (2.0.0.beta1)
+    datadog (2.0.0.beta2)
       debase-ruby_core_source (= 3.3.1)
       libdatadog (~> 7.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)

--- a/gemfiles/jruby_9.3_redis_3.gemfile.lock
+++ b/gemfiles/jruby_9.3_redis_3.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    datadog (2.0.0.beta1)
+    datadog (2.0.0.beta2)
       debase-ruby_core_source (= 3.3.1)
       libdatadog (~> 7.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)

--- a/gemfiles/jruby_9.3_redis_4.gemfile.lock
+++ b/gemfiles/jruby_9.3_redis_4.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    datadog (2.0.0.beta1)
+    datadog (2.0.0.beta2)
       debase-ruby_core_source (= 3.3.1)
       libdatadog (~> 7.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)

--- a/gemfiles/jruby_9.3_redis_5.gemfile.lock
+++ b/gemfiles/jruby_9.3_redis_5.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    datadog (2.0.0.beta1)
+    datadog (2.0.0.beta2)
       debase-ruby_core_source (= 3.3.1)
       libdatadog (~> 7.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)

--- a/gemfiles/jruby_9.3_relational_db.gemfile.lock
+++ b/gemfiles/jruby_9.3_relational_db.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    datadog (2.0.0.beta1)
+    datadog (2.0.0.beta2)
       debase-ruby_core_source (= 3.3.1)
       libdatadog (~> 7.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)

--- a/gemfiles/jruby_9.3_resque2_redis3.gemfile.lock
+++ b/gemfiles/jruby_9.3_resque2_redis3.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    datadog (2.0.0.beta1)
+    datadog (2.0.0.beta2)
       debase-ruby_core_source (= 3.3.1)
       libdatadog (~> 7.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)

--- a/gemfiles/jruby_9.3_resque2_redis4.gemfile.lock
+++ b/gemfiles/jruby_9.3_resque2_redis4.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    datadog (2.0.0.beta1)
+    datadog (2.0.0.beta2)
       debase-ruby_core_source (= 3.3.1)
       libdatadog (~> 7.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)

--- a/gemfiles/jruby_9.3_sinatra.gemfile.lock
+++ b/gemfiles/jruby_9.3_sinatra.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    datadog (2.0.0.beta1)
+    datadog (2.0.0.beta2)
       debase-ruby_core_source (= 3.3.1)
       libdatadog (~> 7.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)

--- a/gemfiles/jruby_9.4_activesupport.gemfile.lock
+++ b/gemfiles/jruby_9.4_activesupport.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    datadog (2.0.0.beta1)
+    datadog (2.0.0.beta2)
       debase-ruby_core_source (= 3.3.1)
       libdatadog (~> 7.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)

--- a/gemfiles/jruby_9.4_aws.gemfile.lock
+++ b/gemfiles/jruby_9.4_aws.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    datadog (2.0.0.beta1)
+    datadog (2.0.0.beta2)
       debase-ruby_core_source (= 3.3.1)
       libdatadog (~> 7.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)

--- a/gemfiles/jruby_9.4_contrib.gemfile.lock
+++ b/gemfiles/jruby_9.4_contrib.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    datadog (2.0.0.beta1)
+    datadog (2.0.0.beta2)
       debase-ruby_core_source (= 3.3.1)
       libdatadog (~> 7.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)

--- a/gemfiles/jruby_9.4_contrib_old.gemfile.lock
+++ b/gemfiles/jruby_9.4_contrib_old.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    datadog (2.0.0.beta1)
+    datadog (2.0.0.beta2)
       debase-ruby_core_source (= 3.3.1)
       libdatadog (~> 7.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)

--- a/gemfiles/jruby_9.4_core_old.gemfile.lock
+++ b/gemfiles/jruby_9.4_core_old.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    datadog (2.0.0.beta1)
+    datadog (2.0.0.beta2)
       debase-ruby_core_source (= 3.3.1)
       libdatadog (~> 7.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)

--- a/gemfiles/jruby_9.4_elasticsearch_7.gemfile.lock
+++ b/gemfiles/jruby_9.4_elasticsearch_7.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    datadog (2.0.0.beta1)
+    datadog (2.0.0.beta2)
       debase-ruby_core_source (= 3.3.1)
       libdatadog (~> 7.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)

--- a/gemfiles/jruby_9.4_elasticsearch_8.gemfile.lock
+++ b/gemfiles/jruby_9.4_elasticsearch_8.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    datadog (2.0.0.beta1)
+    datadog (2.0.0.beta2)
       debase-ruby_core_source (= 3.3.1)
       libdatadog (~> 7.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)

--- a/gemfiles/jruby_9.4_graphql_1.13.gemfile.lock
+++ b/gemfiles/jruby_9.4_graphql_1.13.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    datadog (2.0.0.beta1)
+    datadog (2.0.0.beta2)
       debase-ruby_core_source (= 3.3.1)
       libdatadog (~> 7.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)

--- a/gemfiles/jruby_9.4_graphql_2.0.gemfile.lock
+++ b/gemfiles/jruby_9.4_graphql_2.0.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    datadog (2.0.0.beta1)
+    datadog (2.0.0.beta2)
       debase-ruby_core_source (= 3.3.1)
       libdatadog (~> 7.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)

--- a/gemfiles/jruby_9.4_graphql_2.1.gemfile.lock
+++ b/gemfiles/jruby_9.4_graphql_2.1.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    datadog (2.0.0.beta1)
+    datadog (2.0.0.beta2)
       debase-ruby_core_source (= 3.3.1)
       libdatadog (~> 7.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)

--- a/gemfiles/jruby_9.4_graphql_2.2.gemfile.lock
+++ b/gemfiles/jruby_9.4_graphql_2.2.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    datadog (2.0.0.beta1)
+    datadog (2.0.0.beta2)
       debase-ruby_core_source (= 3.3.1)
       libdatadog (~> 7.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)

--- a/gemfiles/jruby_9.4_http.gemfile.lock
+++ b/gemfiles/jruby_9.4_http.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    datadog (2.0.0.beta1)
+    datadog (2.0.0.beta2)
       debase-ruby_core_source (= 3.3.1)
       libdatadog (~> 7.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)

--- a/gemfiles/jruby_9.4_multi_rack_app.gemfile.lock
+++ b/gemfiles/jruby_9.4_multi_rack_app.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    datadog (2.0.0.dev)
+    datadog (2.0.0.beta2)
       base64
       debase-ruby_core_source (= 3.3.1)
       libdatadog (~> 7.0.0.1.0)

--- a/gemfiles/jruby_9.4_opensearch_2.gemfile.lock
+++ b/gemfiles/jruby_9.4_opensearch_2.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    datadog (2.0.0.beta1)
+    datadog (2.0.0.beta2)
       debase-ruby_core_source (= 3.3.1)
       libdatadog (~> 7.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)

--- a/gemfiles/jruby_9.4_opensearch_3.gemfile.lock
+++ b/gemfiles/jruby_9.4_opensearch_3.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    datadog (2.0.0.beta1)
+    datadog (2.0.0.beta2)
       debase-ruby_core_source (= 3.3.1)
       libdatadog (~> 7.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)

--- a/gemfiles/jruby_9.4_opentracing.gemfile.lock
+++ b/gemfiles/jruby_9.4_opentracing.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    datadog (2.0.0.beta1)
+    datadog (2.0.0.beta2)
       debase-ruby_core_source (= 3.3.1)
       libdatadog (~> 7.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)

--- a/gemfiles/jruby_9.4_rack_1.gemfile.lock
+++ b/gemfiles/jruby_9.4_rack_1.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    datadog (2.0.0.beta1)
+    datadog (2.0.0.beta2)
       debase-ruby_core_source (= 3.3.1)
       libdatadog (~> 7.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)

--- a/gemfiles/jruby_9.4_rack_2.gemfile.lock
+++ b/gemfiles/jruby_9.4_rack_2.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    datadog (2.0.0.beta1)
+    datadog (2.0.0.beta2)
       debase-ruby_core_source (= 3.3.1)
       libdatadog (~> 7.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)

--- a/gemfiles/jruby_9.4_rack_3.gemfile.lock
+++ b/gemfiles/jruby_9.4_rack_3.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    datadog (2.0.0.beta1)
+    datadog (2.0.0.beta2)
       debase-ruby_core_source (= 3.3.1)
       libdatadog (~> 7.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)

--- a/gemfiles/jruby_9.4_rails61_mysql2.gemfile.lock
+++ b/gemfiles/jruby_9.4_rails61_mysql2.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    datadog (2.0.0.beta1)
+    datadog (2.0.0.beta2)
       debase-ruby_core_source (= 3.3.1)
       libdatadog (~> 7.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)

--- a/gemfiles/jruby_9.4_rails61_postgres.gemfile.lock
+++ b/gemfiles/jruby_9.4_rails61_postgres.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    datadog (2.0.0.beta1)
+    datadog (2.0.0.beta2)
       debase-ruby_core_source (= 3.3.1)
       libdatadog (~> 7.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)

--- a/gemfiles/jruby_9.4_rails61_postgres_redis.gemfile.lock
+++ b/gemfiles/jruby_9.4_rails61_postgres_redis.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    datadog (2.0.0.beta1)
+    datadog (2.0.0.beta2)
       debase-ruby_core_source (= 3.3.1)
       libdatadog (~> 7.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)

--- a/gemfiles/jruby_9.4_rails61_postgres_sidekiq.gemfile.lock
+++ b/gemfiles/jruby_9.4_rails61_postgres_sidekiq.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    datadog (2.0.0.beta1)
+    datadog (2.0.0.beta2)
       debase-ruby_core_source (= 3.3.1)
       libdatadog (~> 7.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)

--- a/gemfiles/jruby_9.4_rails61_semantic_logger.gemfile.lock
+++ b/gemfiles/jruby_9.4_rails61_semantic_logger.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    datadog (2.0.0.beta1)
+    datadog (2.0.0.beta2)
       debase-ruby_core_source (= 3.3.1)
       libdatadog (~> 7.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)

--- a/gemfiles/jruby_9.4_redis_3.gemfile.lock
+++ b/gemfiles/jruby_9.4_redis_3.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    datadog (2.0.0.beta1)
+    datadog (2.0.0.beta2)
       debase-ruby_core_source (= 3.3.1)
       libdatadog (~> 7.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)

--- a/gemfiles/jruby_9.4_redis_4.gemfile.lock
+++ b/gemfiles/jruby_9.4_redis_4.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    datadog (2.0.0.beta1)
+    datadog (2.0.0.beta2)
       debase-ruby_core_source (= 3.3.1)
       libdatadog (~> 7.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)

--- a/gemfiles/jruby_9.4_redis_5.gemfile.lock
+++ b/gemfiles/jruby_9.4_redis_5.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    datadog (2.0.0.beta1)
+    datadog (2.0.0.beta2)
       debase-ruby_core_source (= 3.3.1)
       libdatadog (~> 7.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)

--- a/gemfiles/jruby_9.4_relational_db.gemfile.lock
+++ b/gemfiles/jruby_9.4_relational_db.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    datadog (2.0.0.beta1)
+    datadog (2.0.0.beta2)
       debase-ruby_core_source (= 3.3.1)
       libdatadog (~> 7.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)

--- a/gemfiles/jruby_9.4_resque2_redis3.gemfile.lock
+++ b/gemfiles/jruby_9.4_resque2_redis3.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    datadog (2.0.0.beta1)
+    datadog (2.0.0.beta2)
       debase-ruby_core_source (= 3.3.1)
       libdatadog (~> 7.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)

--- a/gemfiles/jruby_9.4_resque2_redis4.gemfile.lock
+++ b/gemfiles/jruby_9.4_resque2_redis4.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    datadog (2.0.0.beta1)
+    datadog (2.0.0.beta2)
       debase-ruby_core_source (= 3.3.1)
       libdatadog (~> 7.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)

--- a/gemfiles/jruby_9.4_sinatra.gemfile.lock
+++ b/gemfiles/jruby_9.4_sinatra.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    datadog (2.0.0.beta1)
+    datadog (2.0.0.beta2)
       debase-ruby_core_source (= 3.3.1)
       libdatadog (~> 7.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)

--- a/gemfiles/ruby_2.5_activesupport.gemfile.lock
+++ b/gemfiles/ruby_2.5_activesupport.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    datadog (2.0.0.beta1)
+    datadog (2.0.0.beta2)
       debase-ruby_core_source (= 3.3.1)
       libdatadog (~> 7.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)

--- a/gemfiles/ruby_2.5_aws.gemfile.lock
+++ b/gemfiles/ruby_2.5_aws.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    datadog (2.0.0.beta1)
+    datadog (2.0.0.beta2)
       debase-ruby_core_source (= 3.3.1)
       libdatadog (~> 7.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)

--- a/gemfiles/ruby_2.5_contrib.gemfile.lock
+++ b/gemfiles/ruby_2.5_contrib.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    datadog (2.0.0.beta1)
+    datadog (2.0.0.beta2)
       debase-ruby_core_source (= 3.3.1)
       libdatadog (~> 7.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)

--- a/gemfiles/ruby_2.5_contrib_old.gemfile.lock
+++ b/gemfiles/ruby_2.5_contrib_old.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    datadog (2.0.0.beta1)
+    datadog (2.0.0.beta2)
       debase-ruby_core_source (= 3.3.1)
       libdatadog (~> 7.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)

--- a/gemfiles/ruby_2.5_core_old.gemfile.lock
+++ b/gemfiles/ruby_2.5_core_old.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    datadog (2.0.0.beta1)
+    datadog (2.0.0.beta2)
       debase-ruby_core_source (= 3.3.1)
       libdatadog (~> 7.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)

--- a/gemfiles/ruby_2.5_elasticsearch_7.gemfile.lock
+++ b/gemfiles/ruby_2.5_elasticsearch_7.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    datadog (2.0.0.beta1)
+    datadog (2.0.0.beta2)
       debase-ruby_core_source (= 3.3.1)
       libdatadog (~> 7.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)

--- a/gemfiles/ruby_2.5_elasticsearch_8.gemfile.lock
+++ b/gemfiles/ruby_2.5_elasticsearch_8.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    datadog (2.0.0.beta1)
+    datadog (2.0.0.beta2)
       debase-ruby_core_source (= 3.3.1)
       libdatadog (~> 7.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)

--- a/gemfiles/ruby_2.5_graphql_1.12.gemfile.lock
+++ b/gemfiles/ruby_2.5_graphql_1.12.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    datadog (2.0.0.beta1)
+    datadog (2.0.0.beta2)
       debase-ruby_core_source (= 3.3.1)
       libdatadog (~> 7.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)

--- a/gemfiles/ruby_2.5_graphql_1.13.gemfile.lock
+++ b/gemfiles/ruby_2.5_graphql_1.13.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    datadog (2.0.0.beta1)
+    datadog (2.0.0.beta2)
       debase-ruby_core_source (= 3.3.1)
       libdatadog (~> 7.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)

--- a/gemfiles/ruby_2.5_graphql_2.0.gemfile.lock
+++ b/gemfiles/ruby_2.5_graphql_2.0.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    datadog (2.0.0.beta1)
+    datadog (2.0.0.beta2)
       debase-ruby_core_source (= 3.3.1)
       libdatadog (~> 7.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)

--- a/gemfiles/ruby_2.5_hanami_1.gemfile.lock
+++ b/gemfiles/ruby_2.5_hanami_1.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    datadog (2.0.0.beta1)
+    datadog (2.0.0.beta2)
       debase-ruby_core_source (= 3.3.1)
       libdatadog (~> 7.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)

--- a/gemfiles/ruby_2.5_http.gemfile.lock
+++ b/gemfiles/ruby_2.5_http.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    datadog (2.0.0.beta1)
+    datadog (2.0.0.beta2)
       debase-ruby_core_source (= 3.3.1)
       libdatadog (~> 7.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)

--- a/gemfiles/ruby_2.5_multi_rack_app.gemfile.lock
+++ b/gemfiles/ruby_2.5_multi_rack_app.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    datadog (2.0.0.beta1)
+    datadog (2.0.0.beta2)
       debase-ruby_core_source (= 3.3.1)
       libdatadog (~> 7.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)

--- a/gemfiles/ruby_2.5_opensearch_2.gemfile.lock
+++ b/gemfiles/ruby_2.5_opensearch_2.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    datadog (2.0.0.beta1)
+    datadog (2.0.0.beta2)
       debase-ruby_core_source (= 3.3.1)
       libdatadog (~> 7.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)

--- a/gemfiles/ruby_2.5_opensearch_3.gemfile.lock
+++ b/gemfiles/ruby_2.5_opensearch_3.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    datadog (2.0.0.beta1)
+    datadog (2.0.0.beta2)
       debase-ruby_core_source (= 3.3.1)
       libdatadog (~> 7.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)

--- a/gemfiles/ruby_2.5_opentracing.gemfile.lock
+++ b/gemfiles/ruby_2.5_opentracing.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    datadog (2.0.0.beta1)
+    datadog (2.0.0.beta2)
       debase-ruby_core_source (= 3.3.1)
       libdatadog (~> 7.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)

--- a/gemfiles/ruby_2.5_rack_1.gemfile.lock
+++ b/gemfiles/ruby_2.5_rack_1.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    datadog (2.0.0.beta1)
+    datadog (2.0.0.beta2)
       debase-ruby_core_source (= 3.3.1)
       libdatadog (~> 7.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)

--- a/gemfiles/ruby_2.5_rack_2.gemfile.lock
+++ b/gemfiles/ruby_2.5_rack_2.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    datadog (2.0.0.beta1)
+    datadog (2.0.0.beta2)
       debase-ruby_core_source (= 3.3.1)
       libdatadog (~> 7.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)

--- a/gemfiles/ruby_2.5_rack_3.gemfile.lock
+++ b/gemfiles/ruby_2.5_rack_3.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    datadog (2.0.0.beta1)
+    datadog (2.0.0.beta2)
       debase-ruby_core_source (= 3.3.1)
       libdatadog (~> 7.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)

--- a/gemfiles/ruby_2.5_rails4_mysql2.gemfile.lock
+++ b/gemfiles/ruby_2.5_rails4_mysql2.gemfile.lock
@@ -67,7 +67,7 @@ GIT
 PATH
   remote: ..
   specs:
-    datadog (2.0.0.beta1)
+    datadog (2.0.0.beta2)
       debase-ruby_core_source (= 3.3.1)
       libdatadog (~> 7.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)

--- a/gemfiles/ruby_2.5_rails4_postgres.gemfile.lock
+++ b/gemfiles/ruby_2.5_rails4_postgres.gemfile.lock
@@ -67,7 +67,7 @@ GIT
 PATH
   remote: ..
   specs:
-    datadog (2.0.0.beta1)
+    datadog (2.0.0.beta2)
       debase-ruby_core_source (= 3.3.1)
       libdatadog (~> 7.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)

--- a/gemfiles/ruby_2.5_rails4_postgres_redis.gemfile.lock
+++ b/gemfiles/ruby_2.5_rails4_postgres_redis.gemfile.lock
@@ -67,7 +67,7 @@ GIT
 PATH
   remote: ..
   specs:
-    datadog (2.0.0.beta1)
+    datadog (2.0.0.beta2)
       debase-ruby_core_source (= 3.3.1)
       libdatadog (~> 7.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)

--- a/gemfiles/ruby_2.5_rails4_postgres_sidekiq.gemfile.lock
+++ b/gemfiles/ruby_2.5_rails4_postgres_sidekiq.gemfile.lock
@@ -64,7 +64,7 @@ GIT
 PATH
   remote: ..
   specs:
-    datadog (2.0.0.beta1)
+    datadog (2.0.0.beta2)
       debase-ruby_core_source (= 3.3.1)
       libdatadog (~> 7.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)

--- a/gemfiles/ruby_2.5_rails4_semantic_logger.gemfile.lock
+++ b/gemfiles/ruby_2.5_rails4_semantic_logger.gemfile.lock
@@ -67,7 +67,7 @@ GIT
 PATH
   remote: ..
   specs:
-    datadog (2.0.0.beta1)
+    datadog (2.0.0.beta2)
       debase-ruby_core_source (= 3.3.1)
       libdatadog (~> 7.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)

--- a/gemfiles/ruby_2.5_rails5_mysql2.gemfile.lock
+++ b/gemfiles/ruby_2.5_rails5_mysql2.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    datadog (2.0.0.beta1)
+    datadog (2.0.0.beta2)
       debase-ruby_core_source (= 3.3.1)
       libdatadog (~> 7.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)

--- a/gemfiles/ruby_2.5_rails5_postgres.gemfile.lock
+++ b/gemfiles/ruby_2.5_rails5_postgres.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    datadog (2.0.0.beta1)
+    datadog (2.0.0.beta2)
       debase-ruby_core_source (= 3.3.1)
       libdatadog (~> 7.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)

--- a/gemfiles/ruby_2.5_rails5_postgres_redis.gemfile.lock
+++ b/gemfiles/ruby_2.5_rails5_postgres_redis.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    datadog (2.0.0.beta1)
+    datadog (2.0.0.beta2)
       debase-ruby_core_source (= 3.3.1)
       libdatadog (~> 7.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)

--- a/gemfiles/ruby_2.5_rails5_postgres_redis_activesupport.gemfile.lock
+++ b/gemfiles/ruby_2.5_rails5_postgres_redis_activesupport.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    datadog (2.0.0.beta1)
+    datadog (2.0.0.beta2)
       debase-ruby_core_source (= 3.3.1)
       libdatadog (~> 7.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)

--- a/gemfiles/ruby_2.5_rails5_postgres_sidekiq.gemfile.lock
+++ b/gemfiles/ruby_2.5_rails5_postgres_sidekiq.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    datadog (2.0.0.beta1)
+    datadog (2.0.0.beta2)
       debase-ruby_core_source (= 3.3.1)
       libdatadog (~> 7.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)

--- a/gemfiles/ruby_2.5_rails5_semantic_logger.gemfile.lock
+++ b/gemfiles/ruby_2.5_rails5_semantic_logger.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    datadog (2.0.0.beta1)
+    datadog (2.0.0.beta2)
       debase-ruby_core_source (= 3.3.1)
       libdatadog (~> 7.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)

--- a/gemfiles/ruby_2.5_rails61_mysql2.gemfile.lock
+++ b/gemfiles/ruby_2.5_rails61_mysql2.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    datadog (2.0.0.beta1)
+    datadog (2.0.0.beta2)
       debase-ruby_core_source (= 3.3.1)
       libdatadog (~> 7.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)

--- a/gemfiles/ruby_2.5_rails61_postgres.gemfile.lock
+++ b/gemfiles/ruby_2.5_rails61_postgres.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    datadog (2.0.0.beta1)
+    datadog (2.0.0.beta2)
       debase-ruby_core_source (= 3.3.1)
       libdatadog (~> 7.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)

--- a/gemfiles/ruby_2.5_rails61_postgres_redis.gemfile.lock
+++ b/gemfiles/ruby_2.5_rails61_postgres_redis.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    datadog (2.0.0.beta1)
+    datadog (2.0.0.beta2)
       debase-ruby_core_source (= 3.3.1)
       libdatadog (~> 7.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)

--- a/gemfiles/ruby_2.5_rails61_postgres_sidekiq.gemfile.lock
+++ b/gemfiles/ruby_2.5_rails61_postgres_sidekiq.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    datadog (2.0.0.beta1)
+    datadog (2.0.0.beta2)
       debase-ruby_core_source (= 3.3.1)
       libdatadog (~> 7.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)

--- a/gemfiles/ruby_2.5_rails61_semantic_logger.gemfile.lock
+++ b/gemfiles/ruby_2.5_rails61_semantic_logger.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    datadog (2.0.0.beta1)
+    datadog (2.0.0.beta2)
       debase-ruby_core_source (= 3.3.1)
       libdatadog (~> 7.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)

--- a/gemfiles/ruby_2.5_rails6_mysql2.gemfile.lock
+++ b/gemfiles/ruby_2.5_rails6_mysql2.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    datadog (2.0.0.beta1)
+    datadog (2.0.0.beta2)
       debase-ruby_core_source (= 3.3.1)
       libdatadog (~> 7.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)

--- a/gemfiles/ruby_2.5_rails6_postgres.gemfile.lock
+++ b/gemfiles/ruby_2.5_rails6_postgres.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    datadog (2.0.0.beta1)
+    datadog (2.0.0.beta2)
       debase-ruby_core_source (= 3.3.1)
       libdatadog (~> 7.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)

--- a/gemfiles/ruby_2.5_rails6_postgres_redis.gemfile.lock
+++ b/gemfiles/ruby_2.5_rails6_postgres_redis.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    datadog (2.0.0.beta1)
+    datadog (2.0.0.beta2)
       debase-ruby_core_source (= 3.3.1)
       libdatadog (~> 7.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)

--- a/gemfiles/ruby_2.5_rails6_postgres_redis_activesupport.gemfile.lock
+++ b/gemfiles/ruby_2.5_rails6_postgres_redis_activesupport.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    datadog (2.0.0.beta1)
+    datadog (2.0.0.beta2)
       debase-ruby_core_source (= 3.3.1)
       libdatadog (~> 7.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)

--- a/gemfiles/ruby_2.5_rails6_postgres_sidekiq.gemfile.lock
+++ b/gemfiles/ruby_2.5_rails6_postgres_sidekiq.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    datadog (2.0.0.beta1)
+    datadog (2.0.0.beta2)
       debase-ruby_core_source (= 3.3.1)
       libdatadog (~> 7.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)

--- a/gemfiles/ruby_2.5_rails6_semantic_logger.gemfile.lock
+++ b/gemfiles/ruby_2.5_rails6_semantic_logger.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    datadog (2.0.0.beta1)
+    datadog (2.0.0.beta2)
       debase-ruby_core_source (= 3.3.1)
       libdatadog (~> 7.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)

--- a/gemfiles/ruby_2.5_redis_3.gemfile.lock
+++ b/gemfiles/ruby_2.5_redis_3.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    datadog (2.0.0.beta1)
+    datadog (2.0.0.beta2)
       debase-ruby_core_source (= 3.3.1)
       libdatadog (~> 7.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)

--- a/gemfiles/ruby_2.5_redis_4.gemfile.lock
+++ b/gemfiles/ruby_2.5_redis_4.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    datadog (2.0.0.beta1)
+    datadog (2.0.0.beta2)
       debase-ruby_core_source (= 3.3.1)
       libdatadog (~> 7.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)

--- a/gemfiles/ruby_2.5_redis_5.gemfile.lock
+++ b/gemfiles/ruby_2.5_redis_5.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    datadog (2.0.0.beta1)
+    datadog (2.0.0.beta2)
       debase-ruby_core_source (= 3.3.1)
       libdatadog (~> 7.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)

--- a/gemfiles/ruby_2.5_relational_db.gemfile.lock
+++ b/gemfiles/ruby_2.5_relational_db.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    datadog (2.0.0.beta1)
+    datadog (2.0.0.beta2)
       debase-ruby_core_source (= 3.3.1)
       libdatadog (~> 7.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)

--- a/gemfiles/ruby_2.5_resque2_redis3.gemfile.lock
+++ b/gemfiles/ruby_2.5_resque2_redis3.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    datadog (2.0.0.beta1)
+    datadog (2.0.0.beta2)
       debase-ruby_core_source (= 3.3.1)
       libdatadog (~> 7.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)

--- a/gemfiles/ruby_2.5_resque2_redis4.gemfile.lock
+++ b/gemfiles/ruby_2.5_resque2_redis4.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    datadog (2.0.0.beta1)
+    datadog (2.0.0.beta2)
       debase-ruby_core_source (= 3.3.1)
       libdatadog (~> 7.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)

--- a/gemfiles/ruby_2.5_sinatra.gemfile.lock
+++ b/gemfiles/ruby_2.5_sinatra.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    datadog (2.0.0.beta1)
+    datadog (2.0.0.beta2)
       debase-ruby_core_source (= 3.3.1)
       libdatadog (~> 7.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)

--- a/gemfiles/ruby_2.6_activesupport.gemfile.lock
+++ b/gemfiles/ruby_2.6_activesupport.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    datadog (2.0.0.beta1)
+    datadog (2.0.0.beta2)
       debase-ruby_core_source (= 3.3.1)
       libdatadog (~> 7.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)

--- a/gemfiles/ruby_2.6_aws.gemfile.lock
+++ b/gemfiles/ruby_2.6_aws.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    datadog (2.0.0.beta1)
+    datadog (2.0.0.beta2)
       debase-ruby_core_source (= 3.3.1)
       libdatadog (~> 7.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)

--- a/gemfiles/ruby_2.6_contrib.gemfile.lock
+++ b/gemfiles/ruby_2.6_contrib.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    datadog (2.0.0.beta1)
+    datadog (2.0.0.beta2)
       debase-ruby_core_source (= 3.3.1)
       libdatadog (~> 7.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)

--- a/gemfiles/ruby_2.6_contrib_old.gemfile.lock
+++ b/gemfiles/ruby_2.6_contrib_old.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    datadog (2.0.0.beta1)
+    datadog (2.0.0.beta2)
       debase-ruby_core_source (= 3.3.1)
       libdatadog (~> 7.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)

--- a/gemfiles/ruby_2.6_core_old.gemfile.lock
+++ b/gemfiles/ruby_2.6_core_old.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    datadog (2.0.0.beta1)
+    datadog (2.0.0.beta2)
       debase-ruby_core_source (= 3.3.1)
       libdatadog (~> 7.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)

--- a/gemfiles/ruby_2.6_elasticsearch_7.gemfile.lock
+++ b/gemfiles/ruby_2.6_elasticsearch_7.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    datadog (2.0.0.beta1)
+    datadog (2.0.0.beta2)
       debase-ruby_core_source (= 3.3.1)
       libdatadog (~> 7.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)

--- a/gemfiles/ruby_2.6_elasticsearch_8.gemfile.lock
+++ b/gemfiles/ruby_2.6_elasticsearch_8.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    datadog (2.0.0.beta1)
+    datadog (2.0.0.beta2)
       debase-ruby_core_source (= 3.3.1)
       libdatadog (~> 7.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)

--- a/gemfiles/ruby_2.6_graphql_1.12.gemfile.lock
+++ b/gemfiles/ruby_2.6_graphql_1.12.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    datadog (2.0.0.beta1)
+    datadog (2.0.0.beta2)
       debase-ruby_core_source (= 3.3.1)
       libdatadog (~> 7.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)

--- a/gemfiles/ruby_2.6_graphql_1.13.gemfile.lock
+++ b/gemfiles/ruby_2.6_graphql_1.13.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    datadog (2.0.0.beta1)
+    datadog (2.0.0.beta2)
       debase-ruby_core_source (= 3.3.1)
       libdatadog (~> 7.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)

--- a/gemfiles/ruby_2.6_graphql_2.0.gemfile.lock
+++ b/gemfiles/ruby_2.6_graphql_2.0.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    datadog (2.0.0.beta1)
+    datadog (2.0.0.beta2)
       debase-ruby_core_source (= 3.3.1)
       libdatadog (~> 7.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)

--- a/gemfiles/ruby_2.6_hanami_1.gemfile.lock
+++ b/gemfiles/ruby_2.6_hanami_1.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    datadog (2.0.0.beta1)
+    datadog (2.0.0.beta2)
       debase-ruby_core_source (= 3.3.1)
       libdatadog (~> 7.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)

--- a/gemfiles/ruby_2.6_http.gemfile.lock
+++ b/gemfiles/ruby_2.6_http.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    datadog (2.0.0.beta1)
+    datadog (2.0.0.beta2)
       debase-ruby_core_source (= 3.3.1)
       libdatadog (~> 7.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)

--- a/gemfiles/ruby_2.6_multi_rack_app.gemfile.lock
+++ b/gemfiles/ruby_2.6_multi_rack_app.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    datadog (2.0.0.beta1)
+    datadog (2.0.0.beta2)
       debase-ruby_core_source (= 3.3.1)
       libdatadog (~> 7.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)

--- a/gemfiles/ruby_2.6_opensearch_2.gemfile.lock
+++ b/gemfiles/ruby_2.6_opensearch_2.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    datadog (2.0.0.beta1)
+    datadog (2.0.0.beta2)
       debase-ruby_core_source (= 3.3.1)
       libdatadog (~> 7.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)

--- a/gemfiles/ruby_2.6_opensearch_3.gemfile.lock
+++ b/gemfiles/ruby_2.6_opensearch_3.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    datadog (2.0.0.beta1)
+    datadog (2.0.0.beta2)
       debase-ruby_core_source (= 3.3.1)
       libdatadog (~> 7.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)

--- a/gemfiles/ruby_2.6_opentelemetry.gemfile.lock
+++ b/gemfiles/ruby_2.6_opentelemetry.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    datadog (2.0.0.beta1)
+    datadog (2.0.0.beta2)
       debase-ruby_core_source (= 3.3.1)
       libdatadog (~> 7.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)

--- a/gemfiles/ruby_2.6_opentracing.gemfile.lock
+++ b/gemfiles/ruby_2.6_opentracing.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    datadog (2.0.0.beta1)
+    datadog (2.0.0.beta2)
       debase-ruby_core_source (= 3.3.1)
       libdatadog (~> 7.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)

--- a/gemfiles/ruby_2.6_rack_1.gemfile.lock
+++ b/gemfiles/ruby_2.6_rack_1.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    datadog (2.0.0.beta1)
+    datadog (2.0.0.beta2)
       debase-ruby_core_source (= 3.3.1)
       libdatadog (~> 7.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)

--- a/gemfiles/ruby_2.6_rack_2.gemfile.lock
+++ b/gemfiles/ruby_2.6_rack_2.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    datadog (2.0.0.beta1)
+    datadog (2.0.0.beta2)
       debase-ruby_core_source (= 3.3.1)
       libdatadog (~> 7.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)

--- a/gemfiles/ruby_2.6_rack_3.gemfile.lock
+++ b/gemfiles/ruby_2.6_rack_3.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    datadog (2.0.0.beta1)
+    datadog (2.0.0.beta2)
       debase-ruby_core_source (= 3.3.1)
       libdatadog (~> 7.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)

--- a/gemfiles/ruby_2.6_rails5_mysql2.gemfile.lock
+++ b/gemfiles/ruby_2.6_rails5_mysql2.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    datadog (2.0.0.beta1)
+    datadog (2.0.0.beta2)
       debase-ruby_core_source (= 3.3.1)
       libdatadog (~> 7.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)

--- a/gemfiles/ruby_2.6_rails5_postgres.gemfile.lock
+++ b/gemfiles/ruby_2.6_rails5_postgres.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    datadog (2.0.0.beta1)
+    datadog (2.0.0.beta2)
       debase-ruby_core_source (= 3.3.1)
       libdatadog (~> 7.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)

--- a/gemfiles/ruby_2.6_rails5_postgres_redis.gemfile.lock
+++ b/gemfiles/ruby_2.6_rails5_postgres_redis.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    datadog (2.0.0.beta1)
+    datadog (2.0.0.beta2)
       debase-ruby_core_source (= 3.3.1)
       libdatadog (~> 7.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)

--- a/gemfiles/ruby_2.6_rails5_postgres_redis_activesupport.gemfile.lock
+++ b/gemfiles/ruby_2.6_rails5_postgres_redis_activesupport.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    datadog (2.0.0.beta1)
+    datadog (2.0.0.beta2)
       debase-ruby_core_source (= 3.3.1)
       libdatadog (~> 7.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)

--- a/gemfiles/ruby_2.6_rails5_postgres_sidekiq.gemfile.lock
+++ b/gemfiles/ruby_2.6_rails5_postgres_sidekiq.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    datadog (2.0.0.beta1)
+    datadog (2.0.0.beta2)
       debase-ruby_core_source (= 3.3.1)
       libdatadog (~> 7.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)

--- a/gemfiles/ruby_2.6_rails5_semantic_logger.gemfile.lock
+++ b/gemfiles/ruby_2.6_rails5_semantic_logger.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    datadog (2.0.0.beta1)
+    datadog (2.0.0.beta2)
       debase-ruby_core_source (= 3.3.1)
       libdatadog (~> 7.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)

--- a/gemfiles/ruby_2.6_rails61_mysql2.gemfile.lock
+++ b/gemfiles/ruby_2.6_rails61_mysql2.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    datadog (2.0.0.beta1)
+    datadog (2.0.0.beta2)
       debase-ruby_core_source (= 3.3.1)
       libdatadog (~> 7.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)

--- a/gemfiles/ruby_2.6_rails61_postgres.gemfile.lock
+++ b/gemfiles/ruby_2.6_rails61_postgres.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    datadog (2.0.0.beta1)
+    datadog (2.0.0.beta2)
       debase-ruby_core_source (= 3.3.1)
       libdatadog (~> 7.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)

--- a/gemfiles/ruby_2.6_rails61_postgres_redis.gemfile.lock
+++ b/gemfiles/ruby_2.6_rails61_postgres_redis.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    datadog (2.0.0.beta1)
+    datadog (2.0.0.beta2)
       debase-ruby_core_source (= 3.3.1)
       libdatadog (~> 7.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)

--- a/gemfiles/ruby_2.6_rails61_postgres_sidekiq.gemfile.lock
+++ b/gemfiles/ruby_2.6_rails61_postgres_sidekiq.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    datadog (2.0.0.beta1)
+    datadog (2.0.0.beta2)
       debase-ruby_core_source (= 3.3.1)
       libdatadog (~> 7.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)

--- a/gemfiles/ruby_2.6_rails61_semantic_logger.gemfile.lock
+++ b/gemfiles/ruby_2.6_rails61_semantic_logger.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    datadog (2.0.0.beta1)
+    datadog (2.0.0.beta2)
       debase-ruby_core_source (= 3.3.1)
       libdatadog (~> 7.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)

--- a/gemfiles/ruby_2.6_rails6_mysql2.gemfile.lock
+++ b/gemfiles/ruby_2.6_rails6_mysql2.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    datadog (2.0.0.beta1)
+    datadog (2.0.0.beta2)
       debase-ruby_core_source (= 3.3.1)
       libdatadog (~> 7.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)

--- a/gemfiles/ruby_2.6_rails6_postgres.gemfile.lock
+++ b/gemfiles/ruby_2.6_rails6_postgres.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    datadog (2.0.0.beta1)
+    datadog (2.0.0.beta2)
       debase-ruby_core_source (= 3.3.1)
       libdatadog (~> 7.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)

--- a/gemfiles/ruby_2.6_rails6_postgres_redis.gemfile.lock
+++ b/gemfiles/ruby_2.6_rails6_postgres_redis.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    datadog (2.0.0.beta1)
+    datadog (2.0.0.beta2)
       debase-ruby_core_source (= 3.3.1)
       libdatadog (~> 7.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)

--- a/gemfiles/ruby_2.6_rails6_postgres_redis_activesupport.gemfile.lock
+++ b/gemfiles/ruby_2.6_rails6_postgres_redis_activesupport.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    datadog (2.0.0.beta1)
+    datadog (2.0.0.beta2)
       debase-ruby_core_source (= 3.3.1)
       libdatadog (~> 7.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)

--- a/gemfiles/ruby_2.6_rails6_postgres_sidekiq.gemfile.lock
+++ b/gemfiles/ruby_2.6_rails6_postgres_sidekiq.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    datadog (2.0.0.beta1)
+    datadog (2.0.0.beta2)
       debase-ruby_core_source (= 3.3.1)
       libdatadog (~> 7.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)

--- a/gemfiles/ruby_2.6_rails6_semantic_logger.gemfile.lock
+++ b/gemfiles/ruby_2.6_rails6_semantic_logger.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    datadog (2.0.0.beta1)
+    datadog (2.0.0.beta2)
       debase-ruby_core_source (= 3.3.1)
       libdatadog (~> 7.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)

--- a/gemfiles/ruby_2.6_redis_3.gemfile.lock
+++ b/gemfiles/ruby_2.6_redis_3.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    datadog (2.0.0.beta1)
+    datadog (2.0.0.beta2)
       debase-ruby_core_source (= 3.3.1)
       libdatadog (~> 7.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)

--- a/gemfiles/ruby_2.6_redis_4.gemfile.lock
+++ b/gemfiles/ruby_2.6_redis_4.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    datadog (2.0.0.beta1)
+    datadog (2.0.0.beta2)
       debase-ruby_core_source (= 3.3.1)
       libdatadog (~> 7.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)

--- a/gemfiles/ruby_2.6_redis_5.gemfile.lock
+++ b/gemfiles/ruby_2.6_redis_5.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    datadog (2.0.0.beta1)
+    datadog (2.0.0.beta2)
       debase-ruby_core_source (= 3.3.1)
       libdatadog (~> 7.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)

--- a/gemfiles/ruby_2.6_relational_db.gemfile.lock
+++ b/gemfiles/ruby_2.6_relational_db.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    datadog (2.0.0.beta1)
+    datadog (2.0.0.beta2)
       debase-ruby_core_source (= 3.3.1)
       libdatadog (~> 7.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)

--- a/gemfiles/ruby_2.6_resque2_redis3.gemfile.lock
+++ b/gemfiles/ruby_2.6_resque2_redis3.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    datadog (2.0.0.beta1)
+    datadog (2.0.0.beta2)
       debase-ruby_core_source (= 3.3.1)
       libdatadog (~> 7.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)

--- a/gemfiles/ruby_2.6_resque2_redis4.gemfile.lock
+++ b/gemfiles/ruby_2.6_resque2_redis4.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    datadog (2.0.0.beta1)
+    datadog (2.0.0.beta2)
       debase-ruby_core_source (= 3.3.1)
       libdatadog (~> 7.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)

--- a/gemfiles/ruby_2.6_sinatra.gemfile.lock
+++ b/gemfiles/ruby_2.6_sinatra.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    datadog (2.0.0.beta1)
+    datadog (2.0.0.beta2)
       debase-ruby_core_source (= 3.3.1)
       libdatadog (~> 7.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)

--- a/gemfiles/ruby_2.7_activesupport.gemfile.lock
+++ b/gemfiles/ruby_2.7_activesupport.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    datadog (2.0.0.beta1)
+    datadog (2.0.0.beta2)
       debase-ruby_core_source (= 3.3.1)
       libdatadog (~> 7.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)

--- a/gemfiles/ruby_2.7_aws.gemfile.lock
+++ b/gemfiles/ruby_2.7_aws.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    datadog (2.0.0.beta1)
+    datadog (2.0.0.beta2)
       debase-ruby_core_source (= 3.3.1)
       libdatadog (~> 7.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)

--- a/gemfiles/ruby_2.7_contrib.gemfile.lock
+++ b/gemfiles/ruby_2.7_contrib.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    datadog (2.0.0.beta1)
+    datadog (2.0.0.beta2)
       debase-ruby_core_source (= 3.3.1)
       libdatadog (~> 7.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)

--- a/gemfiles/ruby_2.7_contrib_old.gemfile.lock
+++ b/gemfiles/ruby_2.7_contrib_old.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    datadog (2.0.0.beta1)
+    datadog (2.0.0.beta2)
       debase-ruby_core_source (= 3.3.1)
       libdatadog (~> 7.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)

--- a/gemfiles/ruby_2.7_core_old.gemfile.lock
+++ b/gemfiles/ruby_2.7_core_old.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    datadog (2.0.0.beta1)
+    datadog (2.0.0.beta2)
       debase-ruby_core_source (= 3.3.1)
       libdatadog (~> 7.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)

--- a/gemfiles/ruby_2.7_elasticsearch_7.gemfile.lock
+++ b/gemfiles/ruby_2.7_elasticsearch_7.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    datadog (2.0.0.beta1)
+    datadog (2.0.0.beta2)
       debase-ruby_core_source (= 3.3.1)
       libdatadog (~> 7.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)

--- a/gemfiles/ruby_2.7_elasticsearch_8.gemfile.lock
+++ b/gemfiles/ruby_2.7_elasticsearch_8.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    datadog (2.0.0.beta1)
+    datadog (2.0.0.beta2)
       debase-ruby_core_source (= 3.3.1)
       libdatadog (~> 7.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)

--- a/gemfiles/ruby_2.7_graphql_1.12.gemfile.lock
+++ b/gemfiles/ruby_2.7_graphql_1.12.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    datadog (2.0.0.beta1)
+    datadog (2.0.0.beta2)
       debase-ruby_core_source (= 3.3.1)
       libdatadog (~> 7.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)

--- a/gemfiles/ruby_2.7_graphql_1.13.gemfile.lock
+++ b/gemfiles/ruby_2.7_graphql_1.13.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    datadog (2.0.0.beta1)
+    datadog (2.0.0.beta2)
       debase-ruby_core_source (= 3.3.1)
       libdatadog (~> 7.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)

--- a/gemfiles/ruby_2.7_graphql_2.0.gemfile.lock
+++ b/gemfiles/ruby_2.7_graphql_2.0.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    datadog (2.0.0.beta1)
+    datadog (2.0.0.beta2)
       debase-ruby_core_source (= 3.3.1)
       libdatadog (~> 7.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)

--- a/gemfiles/ruby_2.7_graphql_2.1.gemfile.lock
+++ b/gemfiles/ruby_2.7_graphql_2.1.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    datadog (2.0.0.beta1)
+    datadog (2.0.0.beta2)
       debase-ruby_core_source (= 3.3.1)
       libdatadog (~> 7.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)

--- a/gemfiles/ruby_2.7_graphql_2.2.gemfile.lock
+++ b/gemfiles/ruby_2.7_graphql_2.2.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    datadog (2.0.0.beta1)
+    datadog (2.0.0.beta2)
       debase-ruby_core_source (= 3.3.1)
       libdatadog (~> 7.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)

--- a/gemfiles/ruby_2.7_hanami_1.gemfile.lock
+++ b/gemfiles/ruby_2.7_hanami_1.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    datadog (2.0.0.beta1)
+    datadog (2.0.0.beta2)
       debase-ruby_core_source (= 3.3.1)
       libdatadog (~> 7.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)

--- a/gemfiles/ruby_2.7_http.gemfile.lock
+++ b/gemfiles/ruby_2.7_http.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    datadog (2.0.0.beta1)
+    datadog (2.0.0.beta2)
       debase-ruby_core_source (= 3.3.1)
       libdatadog (~> 7.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)

--- a/gemfiles/ruby_2.7_multi_rack_app.gemfile.lock
+++ b/gemfiles/ruby_2.7_multi_rack_app.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    datadog (2.0.0.beta1)
+    datadog (2.0.0.beta2)
       debase-ruby_core_source (= 3.3.1)
       libdatadog (~> 7.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)

--- a/gemfiles/ruby_2.7_opensearch_2.gemfile.lock
+++ b/gemfiles/ruby_2.7_opensearch_2.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    datadog (2.0.0.beta1)
+    datadog (2.0.0.beta2)
       debase-ruby_core_source (= 3.3.1)
       libdatadog (~> 7.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)

--- a/gemfiles/ruby_2.7_opensearch_3.gemfile.lock
+++ b/gemfiles/ruby_2.7_opensearch_3.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    datadog (2.0.0.beta1)
+    datadog (2.0.0.beta2)
       debase-ruby_core_source (= 3.3.1)
       libdatadog (~> 7.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)

--- a/gemfiles/ruby_2.7_opentelemetry.gemfile.lock
+++ b/gemfiles/ruby_2.7_opentelemetry.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    datadog (2.0.0.beta1)
+    datadog (2.0.0.beta2)
       debase-ruby_core_source (= 3.3.1)
       libdatadog (~> 7.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)

--- a/gemfiles/ruby_2.7_opentracing.gemfile.lock
+++ b/gemfiles/ruby_2.7_opentracing.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    datadog (2.0.0.beta1)
+    datadog (2.0.0.beta2)
       debase-ruby_core_source (= 3.3.1)
       libdatadog (~> 7.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)

--- a/gemfiles/ruby_2.7_rack_1.gemfile.lock
+++ b/gemfiles/ruby_2.7_rack_1.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    datadog (2.0.0.beta1)
+    datadog (2.0.0.beta2)
       debase-ruby_core_source (= 3.3.1)
       libdatadog (~> 7.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)

--- a/gemfiles/ruby_2.7_rack_2.gemfile.lock
+++ b/gemfiles/ruby_2.7_rack_2.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    datadog (2.0.0.beta1)
+    datadog (2.0.0.beta2)
       debase-ruby_core_source (= 3.3.1)
       libdatadog (~> 7.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)

--- a/gemfiles/ruby_2.7_rack_3.gemfile.lock
+++ b/gemfiles/ruby_2.7_rack_3.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    datadog (2.0.0.beta1)
+    datadog (2.0.0.beta2)
       debase-ruby_core_source (= 3.3.1)
       libdatadog (~> 7.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)

--- a/gemfiles/ruby_2.7_rails5_mysql2.gemfile.lock
+++ b/gemfiles/ruby_2.7_rails5_mysql2.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    datadog (2.0.0.beta1)
+    datadog (2.0.0.beta2)
       debase-ruby_core_source (= 3.3.1)
       libdatadog (~> 7.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)

--- a/gemfiles/ruby_2.7_rails5_postgres.gemfile.lock
+++ b/gemfiles/ruby_2.7_rails5_postgres.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    datadog (2.0.0.beta1)
+    datadog (2.0.0.beta2)
       debase-ruby_core_source (= 3.3.1)
       libdatadog (~> 7.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)

--- a/gemfiles/ruby_2.7_rails5_postgres_redis.gemfile.lock
+++ b/gemfiles/ruby_2.7_rails5_postgres_redis.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    datadog (2.0.0.beta1)
+    datadog (2.0.0.beta2)
       debase-ruby_core_source (= 3.3.1)
       libdatadog (~> 7.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)

--- a/gemfiles/ruby_2.7_rails5_postgres_redis_activesupport.gemfile.lock
+++ b/gemfiles/ruby_2.7_rails5_postgres_redis_activesupport.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    datadog (2.0.0.beta1)
+    datadog (2.0.0.beta2)
       debase-ruby_core_source (= 3.3.1)
       libdatadog (~> 7.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)

--- a/gemfiles/ruby_2.7_rails5_postgres_sidekiq.gemfile.lock
+++ b/gemfiles/ruby_2.7_rails5_postgres_sidekiq.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    datadog (2.0.0.beta1)
+    datadog (2.0.0.beta2)
       debase-ruby_core_source (= 3.3.1)
       libdatadog (~> 7.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)

--- a/gemfiles/ruby_2.7_rails5_semantic_logger.gemfile.lock
+++ b/gemfiles/ruby_2.7_rails5_semantic_logger.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    datadog (2.0.0.beta1)
+    datadog (2.0.0.beta2)
       debase-ruby_core_source (= 3.3.1)
       libdatadog (~> 7.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)

--- a/gemfiles/ruby_2.7_rails61_mysql2.gemfile.lock
+++ b/gemfiles/ruby_2.7_rails61_mysql2.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    datadog (2.0.0.beta1)
+    datadog (2.0.0.beta2)
       debase-ruby_core_source (= 3.3.1)
       libdatadog (~> 7.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)

--- a/gemfiles/ruby_2.7_rails61_postgres.gemfile.lock
+++ b/gemfiles/ruby_2.7_rails61_postgres.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    datadog (2.0.0.beta1)
+    datadog (2.0.0.beta2)
       debase-ruby_core_source (= 3.3.1)
       libdatadog (~> 7.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)

--- a/gemfiles/ruby_2.7_rails61_postgres_redis.gemfile.lock
+++ b/gemfiles/ruby_2.7_rails61_postgres_redis.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    datadog (2.0.0.beta1)
+    datadog (2.0.0.beta2)
       debase-ruby_core_source (= 3.3.1)
       libdatadog (~> 7.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)

--- a/gemfiles/ruby_2.7_rails61_postgres_sidekiq.gemfile.lock
+++ b/gemfiles/ruby_2.7_rails61_postgres_sidekiq.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    datadog (2.0.0.beta1)
+    datadog (2.0.0.beta2)
       debase-ruby_core_source (= 3.3.1)
       libdatadog (~> 7.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)

--- a/gemfiles/ruby_2.7_rails61_semantic_logger.gemfile.lock
+++ b/gemfiles/ruby_2.7_rails61_semantic_logger.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    datadog (2.0.0.beta1)
+    datadog (2.0.0.beta2)
       debase-ruby_core_source (= 3.3.1)
       libdatadog (~> 7.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)

--- a/gemfiles/ruby_2.7_rails6_mysql2.gemfile.lock
+++ b/gemfiles/ruby_2.7_rails6_mysql2.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    datadog (2.0.0.beta1)
+    datadog (2.0.0.beta2)
       debase-ruby_core_source (= 3.3.1)
       libdatadog (~> 7.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)

--- a/gemfiles/ruby_2.7_rails6_postgres.gemfile.lock
+++ b/gemfiles/ruby_2.7_rails6_postgres.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    datadog (2.0.0.beta1)
+    datadog (2.0.0.beta2)
       debase-ruby_core_source (= 3.3.1)
       libdatadog (~> 7.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)

--- a/gemfiles/ruby_2.7_rails6_postgres_redis.gemfile.lock
+++ b/gemfiles/ruby_2.7_rails6_postgres_redis.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    datadog (2.0.0.beta1)
+    datadog (2.0.0.beta2)
       debase-ruby_core_source (= 3.3.1)
       libdatadog (~> 7.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)

--- a/gemfiles/ruby_2.7_rails6_postgres_redis_activesupport.gemfile.lock
+++ b/gemfiles/ruby_2.7_rails6_postgres_redis_activesupport.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    datadog (2.0.0.beta1)
+    datadog (2.0.0.beta2)
       debase-ruby_core_source (= 3.3.1)
       libdatadog (~> 7.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)

--- a/gemfiles/ruby_2.7_rails6_postgres_sidekiq.gemfile.lock
+++ b/gemfiles/ruby_2.7_rails6_postgres_sidekiq.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    datadog (2.0.0.beta1)
+    datadog (2.0.0.beta2)
       debase-ruby_core_source (= 3.3.1)
       libdatadog (~> 7.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)

--- a/gemfiles/ruby_2.7_rails6_semantic_logger.gemfile.lock
+++ b/gemfiles/ruby_2.7_rails6_semantic_logger.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    datadog (2.0.0.beta1)
+    datadog (2.0.0.beta2)
       debase-ruby_core_source (= 3.3.1)
       libdatadog (~> 7.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)

--- a/gemfiles/ruby_2.7_redis_3.gemfile.lock
+++ b/gemfiles/ruby_2.7_redis_3.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    datadog (2.0.0.beta1)
+    datadog (2.0.0.beta2)
       debase-ruby_core_source (= 3.3.1)
       libdatadog (~> 7.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)

--- a/gemfiles/ruby_2.7_redis_4.gemfile.lock
+++ b/gemfiles/ruby_2.7_redis_4.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    datadog (2.0.0.beta1)
+    datadog (2.0.0.beta2)
       debase-ruby_core_source (= 3.3.1)
       libdatadog (~> 7.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)

--- a/gemfiles/ruby_2.7_redis_5.gemfile.lock
+++ b/gemfiles/ruby_2.7_redis_5.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    datadog (2.0.0.beta1)
+    datadog (2.0.0.beta2)
       debase-ruby_core_source (= 3.3.1)
       libdatadog (~> 7.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)

--- a/gemfiles/ruby_2.7_relational_db.gemfile.lock
+++ b/gemfiles/ruby_2.7_relational_db.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    datadog (2.0.0.beta1)
+    datadog (2.0.0.beta2)
       debase-ruby_core_source (= 3.3.1)
       libdatadog (~> 7.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)

--- a/gemfiles/ruby_2.7_resque2_redis3.gemfile.lock
+++ b/gemfiles/ruby_2.7_resque2_redis3.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    datadog (2.0.0.beta1)
+    datadog (2.0.0.beta2)
       debase-ruby_core_source (= 3.3.1)
       libdatadog (~> 7.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)

--- a/gemfiles/ruby_2.7_resque2_redis4.gemfile.lock
+++ b/gemfiles/ruby_2.7_resque2_redis4.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    datadog (2.0.0.beta1)
+    datadog (2.0.0.beta2)
       debase-ruby_core_source (= 3.3.1)
       libdatadog (~> 7.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)

--- a/gemfiles/ruby_2.7_sinatra.gemfile.lock
+++ b/gemfiles/ruby_2.7_sinatra.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    datadog (2.0.0.beta1)
+    datadog (2.0.0.beta2)
       debase-ruby_core_source (= 3.3.1)
       libdatadog (~> 7.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)

--- a/gemfiles/ruby_3.0_activesupport.gemfile.lock
+++ b/gemfiles/ruby_3.0_activesupport.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    datadog (2.0.0.beta1)
+    datadog (2.0.0.beta2)
       debase-ruby_core_source (= 3.3.1)
       libdatadog (~> 7.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)

--- a/gemfiles/ruby_3.0_aws.gemfile.lock
+++ b/gemfiles/ruby_3.0_aws.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    datadog (2.0.0.beta1)
+    datadog (2.0.0.beta2)
       debase-ruby_core_source (= 3.3.1)
       libdatadog (~> 7.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)

--- a/gemfiles/ruby_3.0_contrib.gemfile.lock
+++ b/gemfiles/ruby_3.0_contrib.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    datadog (2.0.0.beta1)
+    datadog (2.0.0.beta2)
       debase-ruby_core_source (= 3.3.1)
       libdatadog (~> 7.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)

--- a/gemfiles/ruby_3.0_contrib_old.gemfile.lock
+++ b/gemfiles/ruby_3.0_contrib_old.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    datadog (2.0.0.beta1)
+    datadog (2.0.0.beta2)
       debase-ruby_core_source (= 3.3.1)
       libdatadog (~> 7.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)

--- a/gemfiles/ruby_3.0_core_old.gemfile.lock
+++ b/gemfiles/ruby_3.0_core_old.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    datadog (2.0.0.beta1)
+    datadog (2.0.0.beta2)
       debase-ruby_core_source (= 3.3.1)
       libdatadog (~> 7.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)

--- a/gemfiles/ruby_3.0_elasticsearch_7.gemfile.lock
+++ b/gemfiles/ruby_3.0_elasticsearch_7.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    datadog (2.0.0.beta1)
+    datadog (2.0.0.beta2)
       debase-ruby_core_source (= 3.3.1)
       libdatadog (~> 7.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)

--- a/gemfiles/ruby_3.0_elasticsearch_8.gemfile.lock
+++ b/gemfiles/ruby_3.0_elasticsearch_8.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    datadog (2.0.0.beta1)
+    datadog (2.0.0.beta2)
       debase-ruby_core_source (= 3.3.1)
       libdatadog (~> 7.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)

--- a/gemfiles/ruby_3.0_graphql_1.12.gemfile.lock
+++ b/gemfiles/ruby_3.0_graphql_1.12.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    datadog (2.0.0.beta1)
+    datadog (2.0.0.beta2)
       debase-ruby_core_source (= 3.3.1)
       libdatadog (~> 7.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)

--- a/gemfiles/ruby_3.0_graphql_1.13.gemfile.lock
+++ b/gemfiles/ruby_3.0_graphql_1.13.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    datadog (2.0.0.beta1)
+    datadog (2.0.0.beta2)
       debase-ruby_core_source (= 3.3.1)
       libdatadog (~> 7.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)

--- a/gemfiles/ruby_3.0_graphql_2.0.gemfile.lock
+++ b/gemfiles/ruby_3.0_graphql_2.0.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    datadog (2.0.0.beta1)
+    datadog (2.0.0.beta2)
       debase-ruby_core_source (= 3.3.1)
       libdatadog (~> 7.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)

--- a/gemfiles/ruby_3.0_graphql_2.1.gemfile.lock
+++ b/gemfiles/ruby_3.0_graphql_2.1.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    datadog (2.0.0.beta1)
+    datadog (2.0.0.beta2)
       debase-ruby_core_source (= 3.3.1)
       libdatadog (~> 7.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)

--- a/gemfiles/ruby_3.0_graphql_2.2.gemfile.lock
+++ b/gemfiles/ruby_3.0_graphql_2.2.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    datadog (2.0.0.beta1)
+    datadog (2.0.0.beta2)
       debase-ruby_core_source (= 3.3.1)
       libdatadog (~> 7.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)

--- a/gemfiles/ruby_3.0_http.gemfile.lock
+++ b/gemfiles/ruby_3.0_http.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    datadog (2.0.0.beta1)
+    datadog (2.0.0.beta2)
       debase-ruby_core_source (= 3.3.1)
       libdatadog (~> 7.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)

--- a/gemfiles/ruby_3.0_multi_rack_app.gemfile.lock
+++ b/gemfiles/ruby_3.0_multi_rack_app.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    datadog (2.0.0.beta1)
+    datadog (2.0.0.beta2)
       debase-ruby_core_source (= 3.3.1)
       libdatadog (~> 7.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)

--- a/gemfiles/ruby_3.0_opensearch_2.gemfile.lock
+++ b/gemfiles/ruby_3.0_opensearch_2.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    datadog (2.0.0.beta1)
+    datadog (2.0.0.beta2)
       debase-ruby_core_source (= 3.3.1)
       libdatadog (~> 7.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)

--- a/gemfiles/ruby_3.0_opensearch_3.gemfile.lock
+++ b/gemfiles/ruby_3.0_opensearch_3.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    datadog (2.0.0.beta1)
+    datadog (2.0.0.beta2)
       debase-ruby_core_source (= 3.3.1)
       libdatadog (~> 7.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)

--- a/gemfiles/ruby_3.0_opentelemetry.gemfile.lock
+++ b/gemfiles/ruby_3.0_opentelemetry.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    datadog (2.0.0.beta1)
+    datadog (2.0.0.beta2)
       debase-ruby_core_source (= 3.3.1)
       libdatadog (~> 7.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)

--- a/gemfiles/ruby_3.0_opentracing.gemfile.lock
+++ b/gemfiles/ruby_3.0_opentracing.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    datadog (2.0.0.beta1)
+    datadog (2.0.0.beta2)
       debase-ruby_core_source (= 3.3.1)
       libdatadog (~> 7.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)

--- a/gemfiles/ruby_3.0_rack_1.gemfile.lock
+++ b/gemfiles/ruby_3.0_rack_1.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    datadog (2.0.0.beta1)
+    datadog (2.0.0.beta2)
       debase-ruby_core_source (= 3.3.1)
       libdatadog (~> 7.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)

--- a/gemfiles/ruby_3.0_rack_2.gemfile.lock
+++ b/gemfiles/ruby_3.0_rack_2.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    datadog (2.0.0.beta1)
+    datadog (2.0.0.beta2)
       debase-ruby_core_source (= 3.3.1)
       libdatadog (~> 7.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)

--- a/gemfiles/ruby_3.0_rack_3.gemfile.lock
+++ b/gemfiles/ruby_3.0_rack_3.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    datadog (2.0.0.beta1)
+    datadog (2.0.0.beta2)
       debase-ruby_core_source (= 3.3.1)
       libdatadog (~> 7.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)

--- a/gemfiles/ruby_3.0_rails61_mysql2.gemfile.lock
+++ b/gemfiles/ruby_3.0_rails61_mysql2.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    datadog (2.0.0.beta1)
+    datadog (2.0.0.beta2)
       debase-ruby_core_source (= 3.3.1)
       libdatadog (~> 7.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)

--- a/gemfiles/ruby_3.0_rails61_postgres.gemfile.lock
+++ b/gemfiles/ruby_3.0_rails61_postgres.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    datadog (2.0.0.beta1)
+    datadog (2.0.0.beta2)
       debase-ruby_core_source (= 3.3.1)
       libdatadog (~> 7.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)

--- a/gemfiles/ruby_3.0_rails61_postgres_redis.gemfile.lock
+++ b/gemfiles/ruby_3.0_rails61_postgres_redis.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    datadog (2.0.0.beta1)
+    datadog (2.0.0.beta2)
       debase-ruby_core_source (= 3.3.1)
       libdatadog (~> 7.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)

--- a/gemfiles/ruby_3.0_rails61_postgres_sidekiq.gemfile.lock
+++ b/gemfiles/ruby_3.0_rails61_postgres_sidekiq.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    datadog (2.0.0.beta1)
+    datadog (2.0.0.beta2)
       debase-ruby_core_source (= 3.3.1)
       libdatadog (~> 7.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)

--- a/gemfiles/ruby_3.0_rails61_semantic_logger.gemfile.lock
+++ b/gemfiles/ruby_3.0_rails61_semantic_logger.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    datadog (2.0.0.beta1)
+    datadog (2.0.0.beta2)
       debase-ruby_core_source (= 3.3.1)
       libdatadog (~> 7.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)

--- a/gemfiles/ruby_3.0_rails61_trilogy.gemfile.lock
+++ b/gemfiles/ruby_3.0_rails61_trilogy.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    datadog (2.0.0.beta1)
+    datadog (2.0.0.beta2)
       debase-ruby_core_source (= 3.3.1)
       libdatadog (~> 7.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)

--- a/gemfiles/ruby_3.0_redis_3.gemfile.lock
+++ b/gemfiles/ruby_3.0_redis_3.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    datadog (2.0.0.beta1)
+    datadog (2.0.0.beta2)
       debase-ruby_core_source (= 3.3.1)
       libdatadog (~> 7.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)

--- a/gemfiles/ruby_3.0_redis_4.gemfile.lock
+++ b/gemfiles/ruby_3.0_redis_4.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    datadog (2.0.0.beta1)
+    datadog (2.0.0.beta2)
       debase-ruby_core_source (= 3.3.1)
       libdatadog (~> 7.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)

--- a/gemfiles/ruby_3.0_redis_5.gemfile.lock
+++ b/gemfiles/ruby_3.0_redis_5.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    datadog (2.0.0.beta1)
+    datadog (2.0.0.beta2)
       debase-ruby_core_source (= 3.3.1)
       libdatadog (~> 7.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)

--- a/gemfiles/ruby_3.0_relational_db.gemfile.lock
+++ b/gemfiles/ruby_3.0_relational_db.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    datadog (2.0.0.beta1)
+    datadog (2.0.0.beta2)
       debase-ruby_core_source (= 3.3.1)
       libdatadog (~> 7.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)

--- a/gemfiles/ruby_3.0_resque2_redis3.gemfile.lock
+++ b/gemfiles/ruby_3.0_resque2_redis3.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    datadog (2.0.0.beta1)
+    datadog (2.0.0.beta2)
       debase-ruby_core_source (= 3.3.1)
       libdatadog (~> 7.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)

--- a/gemfiles/ruby_3.0_resque2_redis4.gemfile.lock
+++ b/gemfiles/ruby_3.0_resque2_redis4.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    datadog (2.0.0.beta1)
+    datadog (2.0.0.beta2)
       debase-ruby_core_source (= 3.3.1)
       libdatadog (~> 7.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)

--- a/gemfiles/ruby_3.0_sinatra.gemfile.lock
+++ b/gemfiles/ruby_3.0_sinatra.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    datadog (2.0.0.beta1)
+    datadog (2.0.0.beta2)
       debase-ruby_core_source (= 3.3.1)
       libdatadog (~> 7.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)

--- a/gemfiles/ruby_3.1_activesupport.gemfile.lock
+++ b/gemfiles/ruby_3.1_activesupport.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    datadog (2.0.0.beta1)
+    datadog (2.0.0.beta2)
       debase-ruby_core_source (= 3.3.1)
       libdatadog (~> 7.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)

--- a/gemfiles/ruby_3.1_aws.gemfile.lock
+++ b/gemfiles/ruby_3.1_aws.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    datadog (2.0.0.beta1)
+    datadog (2.0.0.beta2)
       debase-ruby_core_source (= 3.3.1)
       libdatadog (~> 7.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)

--- a/gemfiles/ruby_3.1_contrib.gemfile.lock
+++ b/gemfiles/ruby_3.1_contrib.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    datadog (2.0.0.beta1)
+    datadog (2.0.0.beta2)
       debase-ruby_core_source (= 3.3.1)
       libdatadog (~> 7.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)

--- a/gemfiles/ruby_3.1_contrib_old.gemfile.lock
+++ b/gemfiles/ruby_3.1_contrib_old.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    datadog (2.0.0.beta1)
+    datadog (2.0.0.beta2)
       debase-ruby_core_source (= 3.3.1)
       libdatadog (~> 7.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)

--- a/gemfiles/ruby_3.1_core_old.gemfile.lock
+++ b/gemfiles/ruby_3.1_core_old.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    datadog (2.0.0.beta1)
+    datadog (2.0.0.beta2)
       debase-ruby_core_source (= 3.3.1)
       libdatadog (~> 7.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)

--- a/gemfiles/ruby_3.1_elasticsearch_7.gemfile.lock
+++ b/gemfiles/ruby_3.1_elasticsearch_7.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    datadog (2.0.0.beta1)
+    datadog (2.0.0.beta2)
       debase-ruby_core_source (= 3.3.1)
       libdatadog (~> 7.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)

--- a/gemfiles/ruby_3.1_elasticsearch_8.gemfile.lock
+++ b/gemfiles/ruby_3.1_elasticsearch_8.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    datadog (2.0.0.beta1)
+    datadog (2.0.0.beta2)
       debase-ruby_core_source (= 3.3.1)
       libdatadog (~> 7.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)

--- a/gemfiles/ruby_3.1_graphql_1.12.gemfile.lock
+++ b/gemfiles/ruby_3.1_graphql_1.12.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    datadog (2.0.0.beta1)
+    datadog (2.0.0.beta2)
       debase-ruby_core_source (= 3.3.1)
       libdatadog (~> 7.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)

--- a/gemfiles/ruby_3.1_graphql_1.13.gemfile.lock
+++ b/gemfiles/ruby_3.1_graphql_1.13.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    datadog (2.0.0.beta1)
+    datadog (2.0.0.beta2)
       debase-ruby_core_source (= 3.3.1)
       libdatadog (~> 7.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)

--- a/gemfiles/ruby_3.1_graphql_2.0.gemfile.lock
+++ b/gemfiles/ruby_3.1_graphql_2.0.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    datadog (2.0.0.beta1)
+    datadog (2.0.0.beta2)
       debase-ruby_core_source (= 3.3.1)
       libdatadog (~> 7.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)

--- a/gemfiles/ruby_3.1_graphql_2.1.gemfile.lock
+++ b/gemfiles/ruby_3.1_graphql_2.1.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    datadog (2.0.0.beta1)
+    datadog (2.0.0.beta2)
       debase-ruby_core_source (= 3.3.1)
       libdatadog (~> 7.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)

--- a/gemfiles/ruby_3.1_graphql_2.2.gemfile.lock
+++ b/gemfiles/ruby_3.1_graphql_2.2.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    datadog (2.0.0.beta1)
+    datadog (2.0.0.beta2)
       debase-ruby_core_source (= 3.3.1)
       libdatadog (~> 7.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)

--- a/gemfiles/ruby_3.1_http.gemfile.lock
+++ b/gemfiles/ruby_3.1_http.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    datadog (2.0.0.beta1)
+    datadog (2.0.0.beta2)
       debase-ruby_core_source (= 3.3.1)
       libdatadog (~> 7.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)

--- a/gemfiles/ruby_3.1_multi_rack_app.gemfile.lock
+++ b/gemfiles/ruby_3.1_multi_rack_app.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    datadog (2.0.0.beta1)
+    datadog (2.0.0.beta2)
       debase-ruby_core_source (= 3.3.1)
       libdatadog (~> 7.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)

--- a/gemfiles/ruby_3.1_opensearch_2.gemfile.lock
+++ b/gemfiles/ruby_3.1_opensearch_2.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    datadog (2.0.0.beta1)
+    datadog (2.0.0.beta2)
       debase-ruby_core_source (= 3.3.1)
       libdatadog (~> 7.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)

--- a/gemfiles/ruby_3.1_opensearch_3.gemfile.lock
+++ b/gemfiles/ruby_3.1_opensearch_3.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    datadog (2.0.0.beta1)
+    datadog (2.0.0.beta2)
       debase-ruby_core_source (= 3.3.1)
       libdatadog (~> 7.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)

--- a/gemfiles/ruby_3.1_opentelemetry.gemfile.lock
+++ b/gemfiles/ruby_3.1_opentelemetry.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    datadog (2.0.0.beta1)
+    datadog (2.0.0.beta2)
       debase-ruby_core_source (= 3.3.1)
       libdatadog (~> 7.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)

--- a/gemfiles/ruby_3.1_opentracing.gemfile.lock
+++ b/gemfiles/ruby_3.1_opentracing.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    datadog (2.0.0.beta1)
+    datadog (2.0.0.beta2)
       debase-ruby_core_source (= 3.3.1)
       libdatadog (~> 7.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)

--- a/gemfiles/ruby_3.1_rack_1.gemfile.lock
+++ b/gemfiles/ruby_3.1_rack_1.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    datadog (2.0.0.beta1)
+    datadog (2.0.0.beta2)
       debase-ruby_core_source (= 3.3.1)
       libdatadog (~> 7.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)

--- a/gemfiles/ruby_3.1_rack_2.gemfile.lock
+++ b/gemfiles/ruby_3.1_rack_2.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    datadog (2.0.0.beta1)
+    datadog (2.0.0.beta2)
       debase-ruby_core_source (= 3.3.1)
       libdatadog (~> 7.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)

--- a/gemfiles/ruby_3.1_rack_3.gemfile.lock
+++ b/gemfiles/ruby_3.1_rack_3.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    datadog (2.0.0.beta1)
+    datadog (2.0.0.beta2)
       debase-ruby_core_source (= 3.3.1)
       libdatadog (~> 7.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)

--- a/gemfiles/ruby_3.1_rails61_mysql2.gemfile.lock
+++ b/gemfiles/ruby_3.1_rails61_mysql2.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    datadog (2.0.0.beta1)
+    datadog (2.0.0.beta2)
       debase-ruby_core_source (= 3.3.1)
       libdatadog (~> 7.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)

--- a/gemfiles/ruby_3.1_rails61_postgres.gemfile.lock
+++ b/gemfiles/ruby_3.1_rails61_postgres.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    datadog (2.0.0.beta1)
+    datadog (2.0.0.beta2)
       debase-ruby_core_source (= 3.3.1)
       libdatadog (~> 7.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)

--- a/gemfiles/ruby_3.1_rails61_postgres_redis.gemfile.lock
+++ b/gemfiles/ruby_3.1_rails61_postgres_redis.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    datadog (2.0.0.beta1)
+    datadog (2.0.0.beta2)
       debase-ruby_core_source (= 3.3.1)
       libdatadog (~> 7.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)

--- a/gemfiles/ruby_3.1_rails61_postgres_sidekiq.gemfile.lock
+++ b/gemfiles/ruby_3.1_rails61_postgres_sidekiq.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    datadog (2.0.0.beta1)
+    datadog (2.0.0.beta2)
       debase-ruby_core_source (= 3.3.1)
       libdatadog (~> 7.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)

--- a/gemfiles/ruby_3.1_rails61_semantic_logger.gemfile.lock
+++ b/gemfiles/ruby_3.1_rails61_semantic_logger.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    datadog (2.0.0.beta1)
+    datadog (2.0.0.beta2)
       debase-ruby_core_source (= 3.3.1)
       libdatadog (~> 7.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)

--- a/gemfiles/ruby_3.1_rails61_trilogy.gemfile.lock
+++ b/gemfiles/ruby_3.1_rails61_trilogy.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    datadog (2.0.0.beta1)
+    datadog (2.0.0.beta2)
       debase-ruby_core_source (= 3.3.1)
       libdatadog (~> 7.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)

--- a/gemfiles/ruby_3.1_redis_3.gemfile.lock
+++ b/gemfiles/ruby_3.1_redis_3.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    datadog (2.0.0.beta1)
+    datadog (2.0.0.beta2)
       debase-ruby_core_source (= 3.3.1)
       libdatadog (~> 7.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)

--- a/gemfiles/ruby_3.1_redis_4.gemfile.lock
+++ b/gemfiles/ruby_3.1_redis_4.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    datadog (2.0.0.beta1)
+    datadog (2.0.0.beta2)
       debase-ruby_core_source (= 3.3.1)
       libdatadog (~> 7.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)

--- a/gemfiles/ruby_3.1_redis_5.gemfile.lock
+++ b/gemfiles/ruby_3.1_redis_5.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    datadog (2.0.0.beta1)
+    datadog (2.0.0.beta2)
       debase-ruby_core_source (= 3.3.1)
       libdatadog (~> 7.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)

--- a/gemfiles/ruby_3.1_relational_db.gemfile.lock
+++ b/gemfiles/ruby_3.1_relational_db.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    datadog (2.0.0.beta1)
+    datadog (2.0.0.beta2)
       debase-ruby_core_source (= 3.3.1)
       libdatadog (~> 7.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)

--- a/gemfiles/ruby_3.1_resque2_redis3.gemfile.lock
+++ b/gemfiles/ruby_3.1_resque2_redis3.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    datadog (2.0.0.beta1)
+    datadog (2.0.0.beta2)
       debase-ruby_core_source (= 3.3.1)
       libdatadog (~> 7.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)

--- a/gemfiles/ruby_3.1_resque2_redis4.gemfile.lock
+++ b/gemfiles/ruby_3.1_resque2_redis4.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    datadog (2.0.0.beta1)
+    datadog (2.0.0.beta2)
       debase-ruby_core_source (= 3.3.1)
       libdatadog (~> 7.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)

--- a/gemfiles/ruby_3.1_sinatra.gemfile.lock
+++ b/gemfiles/ruby_3.1_sinatra.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    datadog (2.0.0.beta1)
+    datadog (2.0.0.beta2)
       debase-ruby_core_source (= 3.3.1)
       libdatadog (~> 7.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)

--- a/gemfiles/ruby_3.2_activesupport.gemfile.lock
+++ b/gemfiles/ruby_3.2_activesupport.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    datadog (2.0.0.beta1)
+    datadog (2.0.0.beta2)
       debase-ruby_core_source (= 3.3.1)
       libdatadog (~> 7.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)

--- a/gemfiles/ruby_3.2_aws.gemfile.lock
+++ b/gemfiles/ruby_3.2_aws.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    datadog (2.0.0.beta1)
+    datadog (2.0.0.beta2)
       debase-ruby_core_source (= 3.3.1)
       libdatadog (~> 7.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)

--- a/gemfiles/ruby_3.2_contrib.gemfile.lock
+++ b/gemfiles/ruby_3.2_contrib.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    datadog (2.0.0.beta1)
+    datadog (2.0.0.beta2)
       debase-ruby_core_source (= 3.3.1)
       libdatadog (~> 7.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)

--- a/gemfiles/ruby_3.2_contrib_old.gemfile.lock
+++ b/gemfiles/ruby_3.2_contrib_old.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    datadog (2.0.0.beta1)
+    datadog (2.0.0.beta2)
       debase-ruby_core_source (= 3.3.1)
       libdatadog (~> 7.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)

--- a/gemfiles/ruby_3.2_core_old.gemfile.lock
+++ b/gemfiles/ruby_3.2_core_old.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    datadog (2.0.0.beta1)
+    datadog (2.0.0.beta2)
       debase-ruby_core_source (= 3.3.1)
       libdatadog (~> 7.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)

--- a/gemfiles/ruby_3.2_elasticsearch_7.gemfile.lock
+++ b/gemfiles/ruby_3.2_elasticsearch_7.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    datadog (2.0.0.beta1)
+    datadog (2.0.0.beta2)
       debase-ruby_core_source (= 3.3.1)
       libdatadog (~> 7.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)

--- a/gemfiles/ruby_3.2_elasticsearch_8.gemfile.lock
+++ b/gemfiles/ruby_3.2_elasticsearch_8.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    datadog (2.0.0.beta1)
+    datadog (2.0.0.beta2)
       debase-ruby_core_source (= 3.3.1)
       libdatadog (~> 7.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)

--- a/gemfiles/ruby_3.2_graphql_1.12.gemfile.lock
+++ b/gemfiles/ruby_3.2_graphql_1.12.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    datadog (2.0.0.beta1)
+    datadog (2.0.0.beta2)
       debase-ruby_core_source (= 3.3.1)
       libdatadog (~> 7.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)

--- a/gemfiles/ruby_3.2_graphql_1.13.gemfile.lock
+++ b/gemfiles/ruby_3.2_graphql_1.13.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    datadog (2.0.0.beta1)
+    datadog (2.0.0.beta2)
       debase-ruby_core_source (= 3.3.1)
       libdatadog (~> 7.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)

--- a/gemfiles/ruby_3.2_graphql_2.0.gemfile.lock
+++ b/gemfiles/ruby_3.2_graphql_2.0.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    datadog (2.0.0.beta1)
+    datadog (2.0.0.beta2)
       debase-ruby_core_source (= 3.3.1)
       libdatadog (~> 7.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)

--- a/gemfiles/ruby_3.2_graphql_2.1.gemfile.lock
+++ b/gemfiles/ruby_3.2_graphql_2.1.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    datadog (2.0.0.beta1)
+    datadog (2.0.0.beta2)
       debase-ruby_core_source (= 3.3.1)
       libdatadog (~> 7.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)

--- a/gemfiles/ruby_3.2_graphql_2.2.gemfile.lock
+++ b/gemfiles/ruby_3.2_graphql_2.2.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    datadog (2.0.0.beta1)
+    datadog (2.0.0.beta2)
       debase-ruby_core_source (= 3.3.1)
       libdatadog (~> 7.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)

--- a/gemfiles/ruby_3.2_http.gemfile.lock
+++ b/gemfiles/ruby_3.2_http.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    datadog (2.0.0.beta1)
+    datadog (2.0.0.beta2)
       debase-ruby_core_source (= 3.3.1)
       libdatadog (~> 7.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)

--- a/gemfiles/ruby_3.2_multi_rack_app.gemfile.lock
+++ b/gemfiles/ruby_3.2_multi_rack_app.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    datadog (2.0.0.beta1)
+    datadog (2.0.0.beta2)
       debase-ruby_core_source (= 3.3.1)
       libdatadog (~> 7.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)

--- a/gemfiles/ruby_3.2_opensearch_2.gemfile.lock
+++ b/gemfiles/ruby_3.2_opensearch_2.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    datadog (2.0.0.beta1)
+    datadog (2.0.0.beta2)
       debase-ruby_core_source (= 3.3.1)
       libdatadog (~> 7.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)

--- a/gemfiles/ruby_3.2_opensearch_3.gemfile.lock
+++ b/gemfiles/ruby_3.2_opensearch_3.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    datadog (2.0.0.beta1)
+    datadog (2.0.0.beta2)
       debase-ruby_core_source (= 3.3.1)
       libdatadog (~> 7.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)

--- a/gemfiles/ruby_3.2_opentelemetry.gemfile.lock
+++ b/gemfiles/ruby_3.2_opentelemetry.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    datadog (2.0.0.beta1)
+    datadog (2.0.0.beta2)
       debase-ruby_core_source (= 3.3.1)
       libdatadog (~> 7.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)

--- a/gemfiles/ruby_3.2_opentracing.gemfile.lock
+++ b/gemfiles/ruby_3.2_opentracing.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    datadog (2.0.0.beta1)
+    datadog (2.0.0.beta2)
       debase-ruby_core_source (= 3.3.1)
       libdatadog (~> 7.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)

--- a/gemfiles/ruby_3.2_rack_1.gemfile.lock
+++ b/gemfiles/ruby_3.2_rack_1.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    datadog (2.0.0.beta1)
+    datadog (2.0.0.beta2)
       debase-ruby_core_source (= 3.3.1)
       libdatadog (~> 7.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)

--- a/gemfiles/ruby_3.2_rack_2.gemfile.lock
+++ b/gemfiles/ruby_3.2_rack_2.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    datadog (2.0.0.beta1)
+    datadog (2.0.0.beta2)
       debase-ruby_core_source (= 3.3.1)
       libdatadog (~> 7.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)

--- a/gemfiles/ruby_3.2_rack_3.gemfile.lock
+++ b/gemfiles/ruby_3.2_rack_3.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    datadog (2.0.0.beta1)
+    datadog (2.0.0.beta2)
       debase-ruby_core_source (= 3.3.1)
       libdatadog (~> 7.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)

--- a/gemfiles/ruby_3.2_rails61_mysql2.gemfile.lock
+++ b/gemfiles/ruby_3.2_rails61_mysql2.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    datadog (2.0.0.beta1)
+    datadog (2.0.0.beta2)
       debase-ruby_core_source (= 3.3.1)
       libdatadog (~> 7.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)

--- a/gemfiles/ruby_3.2_rails61_postgres.gemfile.lock
+++ b/gemfiles/ruby_3.2_rails61_postgres.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    datadog (2.0.0.beta1)
+    datadog (2.0.0.beta2)
       debase-ruby_core_source (= 3.3.1)
       libdatadog (~> 7.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)

--- a/gemfiles/ruby_3.2_rails61_postgres_redis.gemfile.lock
+++ b/gemfiles/ruby_3.2_rails61_postgres_redis.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    datadog (2.0.0.beta1)
+    datadog (2.0.0.beta2)
       debase-ruby_core_source (= 3.3.1)
       libdatadog (~> 7.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)

--- a/gemfiles/ruby_3.2_rails61_postgres_sidekiq.gemfile.lock
+++ b/gemfiles/ruby_3.2_rails61_postgres_sidekiq.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    datadog (2.0.0.beta1)
+    datadog (2.0.0.beta2)
       debase-ruby_core_source (= 3.3.1)
       libdatadog (~> 7.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)

--- a/gemfiles/ruby_3.2_rails61_semantic_logger.gemfile.lock
+++ b/gemfiles/ruby_3.2_rails61_semantic_logger.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    datadog (2.0.0.beta1)
+    datadog (2.0.0.beta2)
       debase-ruby_core_source (= 3.3.1)
       libdatadog (~> 7.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)

--- a/gemfiles/ruby_3.2_rails61_trilogy.gemfile.lock
+++ b/gemfiles/ruby_3.2_rails61_trilogy.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    datadog (2.0.0.beta1)
+    datadog (2.0.0.beta2)
       debase-ruby_core_source (= 3.3.1)
       libdatadog (~> 7.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)

--- a/gemfiles/ruby_3.2_redis_3.gemfile.lock
+++ b/gemfiles/ruby_3.2_redis_3.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    datadog (2.0.0.beta1)
+    datadog (2.0.0.beta2)
       debase-ruby_core_source (= 3.3.1)
       libdatadog (~> 7.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)

--- a/gemfiles/ruby_3.2_redis_4.gemfile.lock
+++ b/gemfiles/ruby_3.2_redis_4.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    datadog (2.0.0.beta1)
+    datadog (2.0.0.beta2)
       debase-ruby_core_source (= 3.3.1)
       libdatadog (~> 7.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)

--- a/gemfiles/ruby_3.2_redis_5.gemfile.lock
+++ b/gemfiles/ruby_3.2_redis_5.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    datadog (2.0.0.beta1)
+    datadog (2.0.0.beta2)
       debase-ruby_core_source (= 3.3.1)
       libdatadog (~> 7.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)

--- a/gemfiles/ruby_3.2_relational_db.gemfile.lock
+++ b/gemfiles/ruby_3.2_relational_db.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    datadog (2.0.0.beta1)
+    datadog (2.0.0.beta2)
       debase-ruby_core_source (= 3.3.1)
       libdatadog (~> 7.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)

--- a/gemfiles/ruby_3.2_resque2_redis3.gemfile.lock
+++ b/gemfiles/ruby_3.2_resque2_redis3.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    datadog (2.0.0.beta1)
+    datadog (2.0.0.beta2)
       debase-ruby_core_source (= 3.3.1)
       libdatadog (~> 7.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)

--- a/gemfiles/ruby_3.2_resque2_redis4.gemfile.lock
+++ b/gemfiles/ruby_3.2_resque2_redis4.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    datadog (2.0.0.beta1)
+    datadog (2.0.0.beta2)
       debase-ruby_core_source (= 3.3.1)
       libdatadog (~> 7.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)

--- a/gemfiles/ruby_3.2_sinatra.gemfile.lock
+++ b/gemfiles/ruby_3.2_sinatra.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    datadog (2.0.0.beta1)
+    datadog (2.0.0.beta2)
       debase-ruby_core_source (= 3.3.1)
       libdatadog (~> 7.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)

--- a/gemfiles/ruby_3.3_activesupport.gemfile.lock
+++ b/gemfiles/ruby_3.3_activesupport.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    datadog (2.0.0.beta1)
+    datadog (2.0.0.beta2)
       debase-ruby_core_source (= 3.3.1)
       libdatadog (~> 7.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)

--- a/gemfiles/ruby_3.3_aws.gemfile.lock
+++ b/gemfiles/ruby_3.3_aws.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    datadog (2.0.0.beta1)
+    datadog (2.0.0.beta2)
       debase-ruby_core_source (= 3.3.1)
       libdatadog (~> 7.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)

--- a/gemfiles/ruby_3.3_contrib.gemfile.lock
+++ b/gemfiles/ruby_3.3_contrib.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    datadog (2.0.0.beta1)
+    datadog (2.0.0.beta2)
       debase-ruby_core_source (= 3.3.1)
       libdatadog (~> 7.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)

--- a/gemfiles/ruby_3.3_contrib_old.gemfile.lock
+++ b/gemfiles/ruby_3.3_contrib_old.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    datadog (2.0.0.beta1)
+    datadog (2.0.0.beta2)
       debase-ruby_core_source (= 3.3.1)
       libdatadog (~> 7.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)

--- a/gemfiles/ruby_3.3_core_old.gemfile.lock
+++ b/gemfiles/ruby_3.3_core_old.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    datadog (2.0.0.beta1)
+    datadog (2.0.0.beta2)
       debase-ruby_core_source (= 3.3.1)
       libdatadog (~> 7.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)

--- a/gemfiles/ruby_3.3_elasticsearch_7.gemfile.lock
+++ b/gemfiles/ruby_3.3_elasticsearch_7.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    datadog (2.0.0.beta1)
+    datadog (2.0.0.beta2)
       debase-ruby_core_source (= 3.3.1)
       libdatadog (~> 7.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)

--- a/gemfiles/ruby_3.3_elasticsearch_8.gemfile.lock
+++ b/gemfiles/ruby_3.3_elasticsearch_8.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    datadog (2.0.0.beta1)
+    datadog (2.0.0.beta2)
       debase-ruby_core_source (= 3.3.1)
       libdatadog (~> 7.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)

--- a/gemfiles/ruby_3.3_graphql_1.12.gemfile.lock
+++ b/gemfiles/ruby_3.3_graphql_1.12.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    datadog (2.0.0.beta1)
+    datadog (2.0.0.beta2)
       debase-ruby_core_source (= 3.3.1)
       libdatadog (~> 7.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)

--- a/gemfiles/ruby_3.3_graphql_1.13.gemfile.lock
+++ b/gemfiles/ruby_3.3_graphql_1.13.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    datadog (2.0.0.beta1)
+    datadog (2.0.0.beta2)
       debase-ruby_core_source (= 3.3.1)
       libdatadog (~> 7.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)

--- a/gemfiles/ruby_3.3_graphql_2.0.gemfile.lock
+++ b/gemfiles/ruby_3.3_graphql_2.0.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    datadog (2.0.0.beta1)
+    datadog (2.0.0.beta2)
       debase-ruby_core_source (= 3.3.1)
       libdatadog (~> 7.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)

--- a/gemfiles/ruby_3.3_graphql_2.1.gemfile.lock
+++ b/gemfiles/ruby_3.3_graphql_2.1.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    datadog (2.0.0.beta1)
+    datadog (2.0.0.beta2)
       debase-ruby_core_source (= 3.3.1)
       libdatadog (~> 7.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)

--- a/gemfiles/ruby_3.3_graphql_2.2.gemfile.lock
+++ b/gemfiles/ruby_3.3_graphql_2.2.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    datadog (2.0.0.beta1)
+    datadog (2.0.0.beta2)
       debase-ruby_core_source (= 3.3.1)
       libdatadog (~> 7.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)

--- a/gemfiles/ruby_3.3_http.gemfile.lock
+++ b/gemfiles/ruby_3.3_http.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    datadog (2.0.0.beta1)
+    datadog (2.0.0.beta2)
       debase-ruby_core_source (= 3.3.1)
       libdatadog (~> 7.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)

--- a/gemfiles/ruby_3.3_multi_rack_app.gemfile.lock
+++ b/gemfiles/ruby_3.3_multi_rack_app.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    datadog (2.0.0.beta1)
+    datadog (2.0.0.beta2)
       debase-ruby_core_source (= 3.3.1)
       libdatadog (~> 7.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)

--- a/gemfiles/ruby_3.3_opensearch_2.gemfile.lock
+++ b/gemfiles/ruby_3.3_opensearch_2.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    datadog (2.0.0.beta1)
+    datadog (2.0.0.beta2)
       debase-ruby_core_source (= 3.3.1)
       libdatadog (~> 7.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)

--- a/gemfiles/ruby_3.3_opensearch_3.gemfile.lock
+++ b/gemfiles/ruby_3.3_opensearch_3.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    datadog (2.0.0.beta1)
+    datadog (2.0.0.beta2)
       debase-ruby_core_source (= 3.3.1)
       libdatadog (~> 7.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)

--- a/gemfiles/ruby_3.3_opentelemetry.gemfile.lock
+++ b/gemfiles/ruby_3.3_opentelemetry.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    datadog (2.0.0.beta1)
+    datadog (2.0.0.beta2)
       debase-ruby_core_source (= 3.3.1)
       libdatadog (~> 7.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)

--- a/gemfiles/ruby_3.3_opentracing.gemfile.lock
+++ b/gemfiles/ruby_3.3_opentracing.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    datadog (2.0.0.beta1)
+    datadog (2.0.0.beta2)
       debase-ruby_core_source (= 3.3.1)
       libdatadog (~> 7.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)

--- a/gemfiles/ruby_3.3_rack_1.gemfile.lock
+++ b/gemfiles/ruby_3.3_rack_1.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    datadog (2.0.0.beta1)
+    datadog (2.0.0.beta2)
       debase-ruby_core_source (= 3.3.1)
       libdatadog (~> 7.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)

--- a/gemfiles/ruby_3.3_rack_2.gemfile.lock
+++ b/gemfiles/ruby_3.3_rack_2.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    datadog (2.0.0.beta1)
+    datadog (2.0.0.beta2)
       debase-ruby_core_source (= 3.3.1)
       libdatadog (~> 7.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)

--- a/gemfiles/ruby_3.3_rack_3.gemfile.lock
+++ b/gemfiles/ruby_3.3_rack_3.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    datadog (2.0.0.beta1)
+    datadog (2.0.0.beta2)
       debase-ruby_core_source (= 3.3.1)
       libdatadog (~> 7.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)

--- a/gemfiles/ruby_3.3_rails61_mysql2.gemfile.lock
+++ b/gemfiles/ruby_3.3_rails61_mysql2.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    datadog (2.0.0.beta1)
+    datadog (2.0.0.beta2)
       debase-ruby_core_source (= 3.3.1)
       libdatadog (~> 7.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)

--- a/gemfiles/ruby_3.3_rails61_postgres.gemfile.lock
+++ b/gemfiles/ruby_3.3_rails61_postgres.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    datadog (2.0.0.beta1)
+    datadog (2.0.0.beta2)
       debase-ruby_core_source (= 3.3.1)
       libdatadog (~> 7.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)

--- a/gemfiles/ruby_3.3_rails61_postgres_redis.gemfile.lock
+++ b/gemfiles/ruby_3.3_rails61_postgres_redis.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    datadog (2.0.0.beta1)
+    datadog (2.0.0.beta2)
       debase-ruby_core_source (= 3.3.1)
       libdatadog (~> 7.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)

--- a/gemfiles/ruby_3.3_rails61_postgres_sidekiq.gemfile.lock
+++ b/gemfiles/ruby_3.3_rails61_postgres_sidekiq.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    datadog (2.0.0.beta1)
+    datadog (2.0.0.beta2)
       debase-ruby_core_source (= 3.3.1)
       libdatadog (~> 7.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)

--- a/gemfiles/ruby_3.3_rails61_semantic_logger.gemfile.lock
+++ b/gemfiles/ruby_3.3_rails61_semantic_logger.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    datadog (2.0.0.beta1)
+    datadog (2.0.0.beta2)
       debase-ruby_core_source (= 3.3.1)
       libdatadog (~> 7.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)

--- a/gemfiles/ruby_3.3_rails61_trilogy.gemfile.lock
+++ b/gemfiles/ruby_3.3_rails61_trilogy.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    datadog (2.0.0.beta1)
+    datadog (2.0.0.beta2)
       debase-ruby_core_source (= 3.3.1)
       libdatadog (~> 7.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)

--- a/gemfiles/ruby_3.3_redis_3.gemfile.lock
+++ b/gemfiles/ruby_3.3_redis_3.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    datadog (2.0.0.beta1)
+    datadog (2.0.0.beta2)
       debase-ruby_core_source (= 3.3.1)
       libdatadog (~> 7.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)

--- a/gemfiles/ruby_3.3_redis_4.gemfile.lock
+++ b/gemfiles/ruby_3.3_redis_4.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    datadog (2.0.0.beta1)
+    datadog (2.0.0.beta2)
       debase-ruby_core_source (= 3.3.1)
       libdatadog (~> 7.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)

--- a/gemfiles/ruby_3.3_redis_5.gemfile.lock
+++ b/gemfiles/ruby_3.3_redis_5.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    datadog (2.0.0.beta1)
+    datadog (2.0.0.beta2)
       debase-ruby_core_source (= 3.3.1)
       libdatadog (~> 7.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)

--- a/gemfiles/ruby_3.3_relational_db.gemfile.lock
+++ b/gemfiles/ruby_3.3_relational_db.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    datadog (2.0.0.beta1)
+    datadog (2.0.0.beta2)
       debase-ruby_core_source (= 3.3.1)
       libdatadog (~> 7.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)

--- a/gemfiles/ruby_3.3_resque2_redis3.gemfile.lock
+++ b/gemfiles/ruby_3.3_resque2_redis3.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    datadog (2.0.0.beta1)
+    datadog (2.0.0.beta2)
       debase-ruby_core_source (= 3.3.1)
       libdatadog (~> 7.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)

--- a/gemfiles/ruby_3.3_resque2_redis4.gemfile.lock
+++ b/gemfiles/ruby_3.3_resque2_redis4.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    datadog (2.0.0.beta1)
+    datadog (2.0.0.beta2)
       debase-ruby_core_source (= 3.3.1)
       libdatadog (~> 7.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)

--- a/gemfiles/ruby_3.3_sinatra.gemfile.lock
+++ b/gemfiles/ruby_3.3_sinatra.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    datadog (2.0.0.beta1)
+    datadog (2.0.0.beta2)
       debase-ruby_core_source (= 3.3.1)
       libdatadog (~> 7.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)

--- a/lib/datadog/version.rb
+++ b/lib/datadog/version.rb
@@ -5,7 +5,7 @@ module Datadog
     MAJOR = 2
     MINOR = 0
     PATCH = 0
-    PRE = 'beta1'
+    PRE = 'beta2'
     BUILD = nil
     # PRE and BUILD above are modified for dev gems during gem build GHA workflow
 


### PR DESCRIPTION
### Added

* Add Agent configuration option: `timeout_seconds`, `uds_path`, and `use_ssl` (#3350)
* Tracing: Add lightweight log correlation generation (#3486)
* Tracing: Add span links (#3546)
* Tracing: Add `span_remote` field to `TraceDigest` (#3516)
* Tracing: Add `_dd.parent_id` to `tracestate` (#3488)
* Tracing: Allow `RateSampler` with zero sampling rate (#3295)
* Grape: Add `on_error` settings (#3370)

### Changed

* Rename gem from `ddtrace` to `datadog` (#3490)
* Require Ruby `>= 2.5` (#3291)
* Frozen string literals (#3392)
* Startup logs emit when reconfigures (#3441)
* Enhance validation for configuration (#3332, #3326)
* Tracing: Propagation style configuration becomes case-insensitive (#3299)
* Tracing: Return string for `#trace_id` and `#span_id` from `Correlation::Identifier` (#3322)
* `Elasticsearch`: Replace instance configuration from `client` to `transport` instance (#3399)
* `Grape`: Change `error_statuses` settings to `error_status_codes` (#3370)
* `GraphQL`: Instrument with `GraphQL::Tracing::DataDogTrace` and more (#3409, #3417, #3388)
* `Rack`: Change http proxy span pattern (#3369)
* `Sidekiq`: Remove `tag_args` option and worker specific configuration (#3396, #3402)
* Integrations: Rename `error_handler` settings to `on_error` (#3341)
*
### Fixed

* Tracing: Fix `error_status_codes` options (#3344)

### Removed

* Profiling: Remove `bin/ddtracerb` (#3506)
* Ci-app: Remove `datadog-ci` gem dependency (#3288)
* Tracing: Remove `SpanOperation` aliases (#3330)
* Tracing: Remove `b3` style from default propagation (#3293)
* Tracing: Minimize sampling API (#3423)
* Tracing: Remove `client_ip` disabled env (#3404)
* Tracing: Remove `use` alias for `instrument` (#3403)
* Tracing: `OpenTracing`, `qless` removed (#3398, #3443)
* `Net/Http`: Remove `Datadog::Tracing::Contrib::HTTP::Instrumentation.after_request` (#3367)
* `Rails`: Drop support for Rails 3 (#3324)
* `Rails`: Remove `exception_controller` option (#3243)
* Remove constants, methods and more (#3401, #3336, #3454, #3338, #3335, #3298, #3297, #3309, #3294, #3325, #3300)


