### PR TITLE
[PROF-9650] Enable endpoint profiling for Sidekiq and similar background job processors

### DIFF
--- a/ext/datadog_profiling_native_extension/collectors_thread_context.c
+++ b/ext/datadog_profiling_native_extension/collectors_thread_context.c
@@ -217,7 +217,7 @@ static long thread_id_for(VALUE thread);
 static VALUE _native_stats(VALUE self, VALUE collector_instance);
 static VALUE _native_gc_tracking(VALUE self, VALUE collector_instance);
 static void trace_identifiers_for(struct thread_context_collector_state *state, VALUE thread, struct trace_identifiers *trace_identifiers_result);
-static bool should_collect_resource(VALUE root_span_type);
+static bool should_collect_resource(VALUE root_span);
 static VALUE _native_reset_after_fork(DDTRACE_UNUSED VALUE self, VALUE collector_instance);
 static VALUE thread_list(struct thread_context_collector_state *state);
 static VALUE _native_sample_allocation(DDTRACE_UNUSED VALUE self, VALUE collector_instance, VALUE sample_weight, VALUE new_object);
@@ -1146,10 +1146,7 @@ static void trace_identifiers_for(struct thread_context_collector_state *state, 
 
   trace_identifiers_result->valid = true;
 
-  if (!state->endpoint_collection_enabled) return;
-
-  VALUE root_span_type = rb_ivar_get(root_span, at_type_id /* @type */);
-  if (root_span_type == Qnil || !should_collect_resource(root_span_type)) return;
+  if (!state->endpoint_collection_enabled || !should_collect_resource(root_span)) return;
 
   VALUE trace_resource = rb_ivar_get(active_trace, at_resource_id /* @resource */);
   if (RB_TYPE_P(trace_resource, T_STRING)) {
@@ -1167,7 +1164,9 @@ static void trace_identifiers_for(struct thread_context_collector_state *state, 
 // NOTE: Currently we're only interested in HTTP service endpoints. Over time, this list may be expanded.
 // Resources MUST NOT include personal identifiable information (PII); this should not be the case with
 // ddtrace integrations, but worth mentioning just in case :)
-static bool should_collect_resource(VALUE root_span_type) {
+static bool should_collect_resource(VALUE root_span) {
+  VALUE root_span_type = rb_ivar_get(root_span, at_type_id /* @type */);
+  if (root_span_type == Qnil) return false;
   ENFORCE_TYPE(root_span_type, T_STRING);
 
   int root_span_type_length = RSTRING_LEN(root_span_type);

--- a/spec/datadog/profiling/collectors/thread_context_spec.rb
+++ b/spec/datadog/profiling/collectors/thread_context_spec.rb
@@ -522,6 +522,12 @@ RSpec.describe Datadog::Profiling::Collectors::ThreadContext do
             it_behaves_like 'samples with code hotspots information'
           end
 
+          context 'when local root span type is worker' do
+            let(:root_span_type) { 'worker' }
+
+            it_behaves_like 'samples with code hotspots information'
+          end
+
           def self.otel_sdk_available?
             begin
               require 'opentelemetry/sdk'


### PR DESCRIPTION
**What does this PR do?**

We have an opt-in list for which kinds of traces we collect the resource from; this PR extends that list with the `worker` type used by background consumers such as Sidekiq.

![image](https://github.com/DataDog/dd-trace-rb/assets/2785847/f928e104-24a1-4815-9367-2fd67e5d08dd)

**Motivation:**

Enable profiling for Sidekiq and similar background job processors.

**Additional Notes:**

We also collect a few Sidekiq internal things (such as `sidekiq.job_fetch`, `sidekiq.scheduled_poller_wait`, `sidekiq.scheduled_push`, `sidekiq.stop` and `sidekiq.heartbeat`).

We discussed if it would make sense to hide them or not, but for now we decided to still show them.

**How to test the change?**

This change includes test coverage; I also booted up sidekiq and tested manually using the following script:

```ruby
 # Running redis:
 # * `docker-compose up redis`
 # Running server:
 # * `DD_SERVICE=sidekiq-testing DD_ENV=staging DD_PROFILING_ENABLED=true bundle exec sidekiq -r ./sidekiq.rb`
 # Running client:
 # * `DD_TRACE_ENABLED=false DD_TRACING_ENABLED=false be ddprofrb exec irb -r ./sidekiq.rb`
 # * `ThisIsASidekiqJob.perform_async("hello", 10)`

require "sidekiq"
require 'datadog'

Datadog.configure { |c| c.tracing.instrument :sidekiq }

class ThisIsASidekiqJob
  include Sidekiq::Job

  def perform(some_arg = "potato", how_long = 1)
    puts "Start of job!"
    sleep how_long
    puts "End of job!"
  end
end
```
