### PR TITLE
Backport "[NO-TICKET] Fix error during telemetry debug logging attempt" to 1.x-stable

### DIFF
--- a/lib/datadog/core/telemetry/emitter.rb
+++ b/lib/datadog/core/telemetry/emitter.rb
@@ -24,7 +24,7 @@ module Datadog
             seq_id = self.class.sequence.next
             payload = Request.build_payload(event, seq_id)
             res = @http_transport.request(request_type: event.type, payload: payload.to_json)
-            Datadog.logger.debug { "Telemetry sent for event `#{event.type}` (status code: #{res.code})" }
+            Datadog.logger.debug { "Telemetry sent for event `#{event.type}` (code: #{res.code.inspect})" }
             res
           rescue => e
             Datadog.logger.debug("Unable to send telemetry request for event `#{event.type rescue 'unknown'}`: #{e}")

--- a/lib/datadog/core/telemetry/http/response.rb
+++ b/lib/datadog/core/telemetry/http/response.rb
@@ -32,6 +32,10 @@ module Datadog
             nil
           end
 
+          def code
+            nil
+          end
+
           def inspect
             "#{self.class} ok?:#{ok?} unsupported?:#{unsupported?}, " \
             "not_found?:#{not_found?}, client_error?:#{client_error?}, " \

--- a/spec/datadog/core/telemetry/emitter_spec.rb
+++ b/spec/datadog/core/telemetry/emitter_spec.rb
@@ -74,6 +74,21 @@ RSpec.describe Datadog::Core::Telemetry::Emitter do
             expect(emitter.class.sequence.instance_variable_get(:@current)).to be(original_seq_id + 1)
           end
         end
+
+        context 'when call is not successful and debug logging is enabled' do
+          let(:response) do
+            Datadog::Core::Telemetry::Http::InternalErrorResponse.new(StandardError.new('Failed call'))
+          end
+
+          it 'logs the request correctly' do
+            log_message = nil
+            expect(Datadog.logger).to receive(:debug) { |&message| log_message = message.call }
+
+            request
+
+            expect(log_message).to match('Telemetry sent for event')
+          end
+        end
       end
     end
 


### PR DESCRIPTION
**What does this PR do?**

This PR backports https://github.com/DataDog/dd-trace-rb/pull/3617 to the 1.x-stable branch. See original PR for more details.

**Motivation:**

This fix also makes sense to apply on the 1.x-stable series.

**Additional Notes:**

I cherry-picked the upstream commit with no other changes.

**How to test the change?**

See original PR for details.
