### PR TITLE
Backport "[PROF-9650] Enable endpoint profiling for Sidekiq and similar background job processors" to 1.x-stable

### DIFF
--- a/ext/datadog_profiling_native_extension/collectors_thread_context.c
+++ b/ext/datadog_profiling_native_extension/collectors_thread_context.c
@@ -217,7 +217,7 @@ static long thread_id_for(VALUE thread);
 static VALUE _native_stats(VALUE self, VALUE collector_instance);
 static VALUE _native_gc_tracking(VALUE self, VALUE collector_instance);
 static void trace_identifiers_for(struct thread_context_collector_state *state, VALUE thread, struct trace_identifiers *trace_identifiers_result);
-static bool should_collect_resource(VALUE root_span_type);
+static bool should_collect_resource(VALUE root_span);
 static VALUE _native_reset_after_fork(DDTRACE_UNUSED VALUE self, VALUE collector_instance);
 static VALUE thread_list(struct thread_context_collector_state *state);
 static VALUE _native_sample_allocation(DDTRACE_UNUSED VALUE self, VALUE collector_instance, VALUE sample_weight, VALUE new_object);
@@ -1146,10 +1146,7 @@ static void trace_identifiers_for(struct thread_context_collector_state *state, 
 
   trace_identifiers_result->valid = true;
 
-  if (!state->endpoint_collection_enabled) return;
-
-  VALUE root_span_type = rb_ivar_get(root_span, at_type_id /* @type */);
-  if (root_span_type == Qnil || !should_collect_resource(root_span_type)) return;
+  if (!state->endpoint_collection_enabled || !should_collect_resource(root_span)) return;
 
   VALUE trace_resource = rb_ivar_get(active_trace, at_resource_id /* @resource */);
   if (RB_TYPE_P(trace_resource, T_STRING)) {
@@ -1167,7 +1164,9 @@ static void trace_identifiers_for(struct thread_context_collector_state *state, 
 // NOTE: Currently we're only interested in HTTP service endpoints. Over time, this list may be expanded.
 // Resources MUST NOT include personal identifiable information (PII); this should not be the case with
 // ddtrace integrations, but worth mentioning just in case :)
-static bool should_collect_resource(VALUE root_span_type) {
+static bool should_collect_resource(VALUE root_span) {
+  VALUE root_span_type = rb_ivar_get(root_span, at_type_id /* @type */);
+  if (root_span_type == Qnil) return false;
   ENFORCE_TYPE(root_span_type, T_STRING);
 
   int root_span_type_length = RSTRING_LEN(root_span_type);

--- a/spec/datadog/profiling/collectors/thread_context_spec.rb
+++ b/spec/datadog/profiling/collectors/thread_context_spec.rb
@@ -522,6 +522,12 @@ RSpec.describe Datadog::Profiling::Collectors::ThreadContext do
             it_behaves_like 'samples with code hotspots information'
           end
 
+          context 'when local root span type is worker' do
+            let(:root_span_type) { 'worker' }
+
+            it_behaves_like 'samples with code hotspots information'
+          end
+
           def self.otel_sdk_available?
             begin
               require 'opentelemetry/sdk'


### PR DESCRIPTION
**What does this PR do?**

This PR backports https://github.com/DataDog/dd-trace-rb/pull/3610 to the 1.x-stable branch. See original PR for more details.

**Motivation:**

We want to release this profiling feature in the 1.x-stable series as well.

**Additional Notes:**

I cherry-picked the upstream commits with no other changes.

**How to test the change?**

See original PR for details.
