### PR TITLE
[NO-TICKET] Remove profiler support for Ruby 2.3 and 2.4

### DIFF
--- a/ext/datadog_profiling_native_extension/NativeExtensionDesign.md
+++ b/ext/datadog_profiling_native_extension/NativeExtensionDesign.md
@@ -28,7 +28,7 @@ documentation.**
 The profiling native extension is (and must always be) designed to **not cause failures** during gem installation, even
 if some features, Ruby versions, or operating systems are not supported.
 
-E.g. the extension must not break installation on Ruby 2.1 (or the oldest Ruby version we support at the time) on 64-bit ARM macOS,
+E.g. the extension must not break installation on Ruby 2.5 (or the oldest Ruby version we support at the time) on 64-bit ARM macOS,
 even if at run time it will effectively do nothing for such a setup.
 
 We have a CI setup to help validate this, but this is really important to keep in mind when adding to or changing the

--- a/ext/datadog_profiling_native_extension/extconf.rb
+++ b/ext/datadog_profiling_native_extension/extconf.rb
@@ -126,7 +126,7 @@ if RUBY_PLATFORM.include?('linux')
   # have_library 'pthread'
   # have_func 'pthread_getcpuclockid'
   # ```
-  # but a) it broke the build on Windows, b) on older Ruby versions (2.2 and below) and c) It's slower to build
+  # but it's slower to build
   # so instead we just assume that we have the function we need on Linux, and nowhere else
   $defs << '-DHAVE_PTHREAD_GETCPUCLOCKID'
 end
@@ -163,6 +163,11 @@ $defs << '-DNO_THREAD_TID' if RUBY_VERSION < '3.1'
 # On older Rubies, there was no jit_return member on the rb_control_frame_t struct
 $defs << '-DNO_JIT_RETURN' if RUBY_VERSION < '3.1'
 
+# On older Rubies, rb_gc_force_recycle allowed to free objects in a way that
+# would be invisible to free tracepoints, finalizers and without cleaning
+# obj_to_id_tbl mappings.
+$defs << '-DHAVE_WORKING_RB_GC_FORCE_RECYCLE' if RUBY_VERSION < '3.1'
+
 # On older Rubies, we need to use a backported version of this function. See private_vm_api_access.h for details.
 $defs << '-DUSE_BACKPORTED_RB_PROFILE_FRAME_METHOD_NAME' if RUBY_VERSION < '3'
 
@@ -175,33 +180,14 @@ $defs << '-DNO_IMEMO_NAME' if RUBY_VERSION < '3'
 # On older Rubies, objects would not move
 $defs << '-DNO_T_MOVED' if RUBY_VERSION < '2.7'
 
+# On older Rubies, there was no RUBY_SEEN_OBJ_ID flag
+$defs << '-DNO_SEEN_OBJ_ID_FLAG' if RUBY_VERSION < '2.7'
+
 # On older Rubies, rb_global_vm_lock_struct did not include the owner field
 $defs << '-DNO_GVL_OWNER' if RUBY_VERSION < '2.6'
 
 # On older Rubies, there was no thread->invoke_arg
 $defs << '-DNO_THREAD_INVOKE_ARG' if RUBY_VERSION < '2.6'
-
-# On older Rubies, we need to use rb_thread_t instead of rb_execution_context_t
-$defs << '-DUSE_THREAD_INSTEAD_OF_EXECUTION_CONTEXT' if RUBY_VERSION < '2.5'
-
-# On older Rubies, extensions can't use GET_VM()
-$defs << '-DNO_GET_VM' if RUBY_VERSION < '2.5'
-
-# On older Rubies...
-if RUBY_VERSION < '2.4'
-  # ...we need to use RUBY_VM_NORMAL_ISEQ_P instead of VM_FRAME_RUBYFRAME_P
-  $defs << '-DUSE_ISEQ_P_INSTEAD_OF_RUBYFRAME_P'
-  # ...we use a legacy copy of rb_vm_frame_method_entry
-  $defs << '-DUSE_LEGACY_RB_VM_FRAME_METHOD_ENTRY'
-end
-
-# On older Rubies, rb_gc_force_recycle allowed to free objects in a way that
-# would be invisible to free tracepoints, finalizers and without cleaning
-# obj_to_id_tbl mappings.
-$defs << '-DHAVE_WORKING_RB_GC_FORCE_RECYCLE' if RUBY_VERSION < '3.1'
-
-# On older Rubies, there was no RUBY_SEEN_OBJ_ID flag
-$defs << '-DNO_SEEN_OBJ_ID_FLAG' if RUBY_VERSION < '2.7'
 
 # If we got here, libdatadog is available and loaded
 ENV['PKG_CONFIG_PATH'] = "#{ENV['PKG_CONFIG_PATH']}:#{Libdatadog.pkgconfig_folder}"

--- a/ext/datadog_profiling_native_extension/native_extension_helpers.rb
+++ b/ext/datadog_profiling_native_extension/native_extension_helpers.rb
@@ -86,7 +86,6 @@ module Datadog
             on_macos? ||
             on_unknown_os? ||
             on_unsupported_cpu_arch? ||
-            on_unsupported_ruby_version? ||
             expected_to_use_mjit_but_mjit_is_disabled? ||
             libdatadog_not_available? ||
             libdatadog_not_usable?
@@ -258,15 +257,6 @@ module Datadog
           )
 
           architecture_not_supported unless RUBY_PLATFORM.start_with?('x86_64', 'aarch64', 'arm64')
-        end
-
-        private_class_method def self.on_unsupported_ruby_version?
-          ruby_version_not_supported = explain_issue(
-            'the profiler only supports Ruby 2.3 or newer.',
-            suggested: UPGRADE_RUBY,
-          )
-
-          ruby_version_not_supported if RUBY_VERSION.start_with?('2.1.', '2.2.')
         end
 
         # On some Rubies, we require the mjit header to be present. If Ruby was installed without MJIT support, we also skip

--- a/ext/datadog_profiling_native_extension/ruby_helpers.h
+++ b/ext/datadog_profiling_native_extension/ruby_helpers.h
@@ -16,11 +16,6 @@ static inline VALUE process_pending_interruptions(DDTRACE_UNUSED VALUE _) {
   return Qnil;
 }
 
-// RB_UNLIKELY is not supported on Ruby 2.3
-#ifndef RB_UNLIKELY
-  #define RB_UNLIKELY(x) x
-#endif
-
 // Calls process_pending_interruptions BUT "rescues" any exceptions to be raised, returning them instead as
 // a non-zero `pending_exception`.
 //

--- a/integration/apps/rack/app/acme.rb
+++ b/integration/apps/rack/app/acme.rb
@@ -90,8 +90,7 @@ module Acme
         [200, { 'content-type' => 'application/json'}, [JSON.pretty_generate(
           webserver_process: $PROGRAM_NAME,
           profiler_available: Datadog::Profiling.start_if_enabled,
-          # NOTE: Threads can't be named on Ruby 2.1 and 2.2
-          profiler_threads: ((Thread.list.map(&:name).select { |it| it && it.include?('Profiling') }) unless RUBY_VERSION < '2.3')
+          profiler_threads: Thread.list.map(&:name).select { |it| it && it.include?('Profiling') },
         )], "\n"]
       end
     end

--- a/integration/apps/rack/app/resque_background_job.rb
+++ b/integration/apps/rack/app/resque_background_job.rb
@@ -29,8 +29,7 @@ class ResqueBackgroundJob
       value: value,
       resque_process: $PROGRAM_NAME,
       profiler_available: Datadog::Profiling.start_if_enabled,
-      # NOTE: Threads can't be named on Ruby 2.1 and 2.2
-      profiler_threads: ((Thread.list.map(&:name).select { |it| it && it.include?('Profiling') }) unless RUBY_VERSION < '2.3')
+      profiler_threads: Thread.list.map(&:name).select { |it| it && it.include?('Profiling') },
     ))
   end
 end

--- a/integration/apps/rack/app/sidekiq_background_job.rb
+++ b/integration/apps/rack/app/sidekiq_background_job.rb
@@ -27,8 +27,7 @@ class SidekiqBackgroundJob
       value: value,
       sidekiq_process: $PROGRAM_NAME,
       profiler_available: Datadog::Profiling.start_if_enabled,
-      # NOTE: Threads can't be named on Ruby 2.1 and 2.2
-      profiler_threads: ((Thread.list.map(&:name).select { |it| it && it.include?('Profiling') }) unless RUBY_VERSION < '2.3')
+      profiler_threads: Thread.list.map(&:name).select { |it| it && it.include?('Profiling') },
     ))
   end
 end

--- a/integration/apps/rack/spec/integration/basic_spec.rb
+++ b/integration/apps/rack/spec/integration/basic_spec.rb
@@ -11,7 +11,7 @@ RSpec.describe 'Basic scenarios' do
     it { is_expected.to be_a_kind_of(Net::HTTPOK) }
   end
 
-  let(:expected_profiler_available) { RUBY_VERSION >= '2.3' }
+  let(:expected_profiler_available) { true }
 
   let(:expected_profiler_threads) do
     expected_profiler_available ? contain_exactly(

--- a/integration/apps/rails-five/config/initializers/resque.rb
+++ b/integration/apps/rails-five/config/initializers/resque.rb
@@ -1,4 +1,3 @@
 require 'resque'
 
 Resque.redis = ENV['REDIS_URL']
-# Resque.redis = 'redis:6379' # Ruby 2.2 compatibility

--- a/integration/apps/rails-seven/config/initializers/resque.rb
+++ b/integration/apps/rails-seven/config/initializers/resque.rb
@@ -1,4 +1,3 @@
 require 'resque'
 
 Resque.redis = ENV['REDIS_URL']
-# Resque.redis = 'redis:6379' # Ruby 2.2 compatibility

--- a/integration/apps/rails-seven/spec/integration/basic_spec.rb
+++ b/integration/apps/rails-seven/spec/integration/basic_spec.rb
@@ -14,7 +14,7 @@ RSpec.describe 'Basic scenarios' do
 
     let(:json_result) { JSON.parse(subject.body, symbolize_names: true) }
 
-    let(:expected_profiler_available) { RUBY_VERSION >= '2.3' }
+    let(:expected_profiler_available) { true }
 
     let(:expected_profiler_threads) do
       expected_profiler_available ? contain_exactly(

--- a/integration/apps/rails-six/config/initializers/resque.rb
+++ b/integration/apps/rails-six/config/initializers/resque.rb
@@ -1,4 +1,3 @@
 require 'resque'
 
 Resque.redis = ENV['REDIS_URL']
-# Resque.redis = 'redis:6379' # Ruby 2.2 compatibility

--- a/integration/apps/rails-six/spec/integration/basic_spec.rb
+++ b/integration/apps/rails-six/spec/integration/basic_spec.rb
@@ -14,7 +14,7 @@ RSpec.describe 'Basic scenarios' do
 
     let(:json_result) { JSON.parse(subject.body, symbolize_names: true) }
 
-    let(:expected_profiler_available) { RUBY_VERSION >= '2.3' }
+    let(:expected_profiler_available) { true }
 
     let(:expected_profiler_threads) do
       expected_profiler_available ? contain_exactly(

--- a/integration/apps/sinatra2-classic/Gemfile
+++ b/integration/apps/sinatra2-classic/Gemfile
@@ -17,5 +17,5 @@ gem 'pry-byebug'
 # gem 'ruby-prof'
 gem 'rspec'
 gem 'rspec-wait'
-gem 'webrick' if RUBY_VERSION >= '2.3' # Older Rubies can just use the built-in version of webrick
+gem 'webrick'
 gem 'rackup'

--- a/integration/apps/sinatra2-classic/app/acme.rb
+++ b/integration/apps/sinatra2-classic/app/acme.rb
@@ -37,12 +37,7 @@ get '/health/detailed' do
     JSON.generate(
       webserver_process: $PROGRAM_NAME,
       profiler_available: Datadog::Profiling.start_if_enabled,
-      # NOTE: Threads can't be named on Ruby 2.1 and 2.2
-      profiler_threads: (unless RUBY_VERSION < '2.3'
-                           (Thread.list.map(&:name).select do |it|
-                              it && it.include?('Profiling')
-                            end)
-                         end)
+      profiler_threads: Thread.list.map(&:name).select { |it| it && it.include?('Profiling') },
     )
   ]
 end

--- a/integration/apps/sinatra2-classic/spec/integration/basic_spec.rb
+++ b/integration/apps/sinatra2-classic/spec/integration/basic_spec.rb
@@ -11,7 +11,7 @@ RSpec.describe 'Basic scenarios' do
     it { is_expected.to be_a_kind_of(Net::HTTPOK) }
   end
 
-  let(:expected_profiler_available) { RUBY_VERSION >= '2.3' }
+  let(:expected_profiler_available) { true }
 
   let(:expected_profiler_threads) do
     expected_profiler_available ? contain_exactly(

--- a/integration/apps/sinatra2-modular/Gemfile
+++ b/integration/apps/sinatra2-modular/Gemfile
@@ -13,10 +13,7 @@ gem 'datadog', *Datadog::DemoEnv.gem_spec('datadog')
 
 # Development
 gem 'pry-byebug'
-# gem 'pry-stack_explorer', platform: :ruby
-# gem 'rbtrace'
-# gem 'ruby-prof'
 gem 'rspec'
 gem 'rspec-wait'
-gem 'webrick' if RUBY_VERSION >= '2.3' # Older Rubies can just use the built-in version of webrick
+gem 'webrick'
 gem 'rackup'

--- a/integration/apps/sinatra2-modular/app/health.rb
+++ b/integration/apps/sinatra2-modular/app/health.rb
@@ -15,12 +15,7 @@ class Health < Sinatra::Base
       JSON.generate(
         webserver_process: $PROGRAM_NAME,
         profiler_available: Datadog::Profiling.start_if_enabled,
-        # NOTE: Threads can't be named on Ruby 2.1 and 2.2
-        profiler_threads: (unless RUBY_VERSION < '2.3'
-                             (Thread.list.map(&:name).select do |it|
-                                it && it.include?('Profiling')
-                              end)
-                           end)
+        profiler_threads: Thread.list.map(&:name).select { |it| it && it.include?('Profiling') },
       )
     ]
   end

--- a/integration/apps/sinatra2-modular/spec/integration/basic_spec.rb
+++ b/integration/apps/sinatra2-modular/spec/integration/basic_spec.rb
@@ -11,7 +11,7 @@ RSpec.describe 'Basic scenarios' do
     it { is_expected.to be_a_kind_of(Net::HTTPOK) }
   end
 
-  let(:expected_profiler_available) { RUBY_VERSION >= '2.3' }
+  let(:expected_profiler_available) { true }
 
   let(:expected_profiler_threads) do
     expected_profiler_available ? contain_exactly(

--- a/integration/images/include/build_datadog_profiling_native_extension.rb
+++ b/integration/images/include/build_datadog_profiling_native_extension.rb
@@ -1,14 +1,10 @@
 #!/usr/bin/env ruby
 
 if local_gem_path = ENV['DD_DEMO_ENV_GEM_LOCAL_DATADOG']
-  if RUBY_VERSION.start_with?('2.1.', '2.2.')
-    puts "\n== Skipping build of profiler native extension on Ruby 2.1/2.2 =="
-  else
-    puts "\n== Building profiler native extension =="
-    success =
-      system("export BUNDLE_GEMFILE=#{local_gem_path}/Gemfile && cd #{local_gem_path} && bundle install && bundle exec rake clean compile")
-    raise 'Failure to compile profiler native extension' unless success
-  end
+  puts "\n== Building profiler native extension =="
+  success =
+    system("export BUNDLE_GEMFILE=#{local_gem_path}/Gemfile && cd #{local_gem_path} && bundle install && bundle exec rake clean compile")
+  raise 'Failure to compile profiler native extension' unless success
 else
   puts "\n== Skipping build of profiler native extension, no DD_DEMO_ENV_GEM_LOCAL_DATADOG set =="
 end

--- a/lib/datadog/profiling/component.rb
+++ b/lib/datadog/profiling/component.rb
@@ -243,7 +243,7 @@ module Datadog
 
       private_class_method def self.no_signals_workaround_enabled?(settings) # rubocop:disable Metrics/MethodLength
         setting_value = settings.profiling.advanced.no_signals_workaround_enabled
-        legacy_ruby_that_should_use_workaround = RUBY_VERSION.start_with?('2.3.', '2.4.', '2.5.')
+        legacy_ruby_that_should_use_workaround = RUBY_VERSION.start_with?('2.5.')
 
         unless [true, false, :auto].include?(setting_value)
           Datadog.logger.error(

--- a/spec/datadog/profiling/collectors/cpu_and_wall_time_worker_spec.rb
+++ b/spec/datadog/profiling/collectors/cpu_and_wall_time_worker_spec.rb
@@ -1,5 +1,7 @@
 require 'datadog/profiling/spec_helper'
 
+require 'datadog/profiling/collectors/cpu_and_wall_time_worker'
+
 RSpec.describe Datadog::Profiling::Collectors::CpuAndWallTimeWorker do
   before { skip_if_profiling_not_supported(self) }
 

--- a/spec/datadog/profiling/collectors/cpu_and_wall_time_worker_spec.rb
+++ b/spec/datadog/profiling/collectors/cpu_and_wall_time_worker_spec.rb
@@ -1,11 +1,7 @@
 require 'datadog/profiling/spec_helper'
 
-RSpec.describe 'Datadog::Profiling::Collectors::CpuAndWallTimeWorker' do
+RSpec.describe Datadog::Profiling::Collectors::CpuAndWallTimeWorker do
   before { skip_if_profiling_not_supported(self) }
-
-  # This is needed because this class uses syntax that doesn't work on Ruby 2.1/2.2; we can undo this once dd-trace-rb
-  # drops support for these Rubies globally
-  let(:described_class) { Datadog::Profiling::Collectors::CpuAndWallTimeWorker }
 
   let(:endpoint_collection_enabled) { true }
   let(:gc_profiling_enabled) { true }

--- a/spec/datadog/profiling/collectors/stack_spec.rb
+++ b/spec/datadog/profiling/collectors/stack_spec.rb
@@ -363,7 +363,7 @@ RSpec.describe Datadog::Profiling::Collectors::Stack do
       context 'when sampling a thread blocked on Monitor#synchronize' do
         let(:expected_method_name) do
           # On older Rubies Monitor is implemented using Mutex instead of natively
-          if RUBY_VERSION.start_with?('2.3', '2.4', '2.5', '2.6')
+          if RUBY_VERSION.start_with?('2.5', '2.6')
             'lock'
           else
             'synchronize'

--- a/spec/datadog/profiling/collectors/thread_context_spec.rb
+++ b/spec/datadog/profiling/collectors/thread_context_spec.rb
@@ -1110,7 +1110,7 @@ RSpec.describe Datadog::Profiling::Collectors::ThreadContext do
       { expected_type: :T_REGEXP, object: /Hello/, klass: 'Regexp' },
       { expected_type: :T_ARRAY, object: [], klass: 'Array' },
       { expected_type: :T_HASH, object: {}, klass: 'Hash' },
-      { expected_type: :T_BIGNUM, object: 2**256, klass: RUBY_VERSION < '2.4' ? 'Bignum' : 'Integer' },
+      { expected_type: :T_BIGNUM, object: 2**256, klass: 'Integer' },
       # ThreadContext is a T_DATA; we create here a dummy instance just as an example
       { expected_type: :T_DATA, object: described_class.allocate, klass: 'Datadog::Profiling::Collectors::ThreadContext' },
       { expected_type: :T_MATCH, object: 'a'.match(Regexp.new('a')), klass: 'MatchData' },
@@ -1120,7 +1120,7 @@ RSpec.describe Datadog::Profiling::Collectors::ThreadContext do
       { expected_type: :T_TRUE, object: true, klass: 'TrueClass' },
       { expected_type: :T_FALSE, object: false, klass: 'FalseClass' },
       { expected_type: :T_SYMBOL, object: :hello, klass: 'Symbol' },
-      { expected_type: :T_FIXNUM, object: 1, klass: RUBY_VERSION < '2.4' ? 'Fixnum' : 'Integer' },
+      { expected_type: :T_FIXNUM, object: 1, klass: 'Integer' },
     ].each do |type|
       expected_type = type.fetch(:expected_type)
       object = type.fetch(:object)

--- a/spec/datadog/profiling/component_spec.rb
+++ b/spec/datadog/profiling/component_spec.rb
@@ -165,7 +165,7 @@ RSpec.describe Datadog::Profiling::Component do
           end
 
           context 'on Ruby 2.x' do
-            let(:testing_version) { '2.3.0 ' }
+            let(:testing_version) { '2.5.0' }
 
             it 'initializes CpuAndWallTimeWorker and StackRecorder with allocation sampling support' do
               expect(Datadog::Profiling::Collectors::CpuAndWallTimeWorker).to receive(:new).with hash_including(

--- a/spec/datadog/profiling/native_extension_helpers_spec.rb
+++ b/spec/datadog/profiling/native_extension_helpers_spec.rb
@@ -15,12 +15,7 @@ RSpec.describe Datadog::Profiling::NativeExtensionHelpers do
       it 'returns a relative path to libdatadog folder from the gem lib folder' do
         relative_path = described_class.libdatadog_folder_relative_to_native_lib_folder
 
-        # RbConfig::CONFIG['SOEXT'] was only introduced in Ruby 2.5, so we have a fallback for older Rubies...
-        libdatadog_extension =
-          RbConfig::CONFIG['SOEXT'] ||
-          ('so' if PlatformHelpers.linux?) ||
-          ('dylib' if PlatformHelpers.mac?) ||
-          raise('Missing SOEXT for current platform')
+        libdatadog_extension = RbConfig::CONFIG['SOEXT'] || raise('Missing SOEXT for current platform')
 
         gem_lib_folder = "#{Gem.loaded_specs['datadog'].gem_dir}/lib"
         full_libdatadog_path = "#{gem_lib_folder}/#{relative_path}/libdatadog_profiling.#{libdatadog_extension}"
@@ -127,75 +122,61 @@ RSpec.describe Datadog::Profiling::NativeExtensionHelpers::Supported do
         end
 
         shared_examples 'supported ruby validation' do
-          context 'when not on Ruby 2.1 or 2.2' do
-            before { stub_const('RUBY_VERSION', '2.3.0') }
+          before { stub_const('RUBY_VERSION', '2.5.0') }
 
-            shared_examples 'libdatadog available' do
-              context 'when libdatadog fails to activate' do
-                before do
-                  expect(described_class)
-                    .to receive(:gem).with('libdatadog', Datadog::Profiling::NativeExtensionHelpers::LIBDATADOG_VERSION)
-                    .and_raise(LoadError.new('Simulated error activating gem'))
-                end
-
-                it { is_expected.to include 'exception during loading' }
+          shared_examples 'libdatadog available' do
+            context 'when libdatadog fails to activate' do
+              before do
+                expect(described_class)
+                  .to receive(:gem).with('libdatadog', Datadog::Profiling::NativeExtensionHelpers::LIBDATADOG_VERSION)
+                  .and_raise(LoadError.new('Simulated error activating gem'))
               end
 
-              context 'when libdatadog successfully activates' do
-                include_examples 'libdatadog usable'
-              end
+              it { is_expected.to include 'exception during loading' }
             end
 
-            shared_examples 'libdatadog usable' do
-              context 'when libdatadog DOES NOT HAVE binaries for the current platform' do
-                before do
-                  expect(Libdatadog).to receive(:pkgconfig_folder).and_return(nil)
-                  expect(Libdatadog).to receive(:available_binaries).and_return(%w[fooarch-linux bararch-linux-musl])
-                end
+            context 'when libdatadog successfully activates' do
+              include_examples 'libdatadog usable'
+            end
+          end
 
-                it { is_expected.to include 'platform variant' }
+          shared_examples 'libdatadog usable' do
+            context 'when libdatadog DOES NOT HAVE binaries for the current platform' do
+              before do
+                expect(Libdatadog).to receive(:pkgconfig_folder).and_return(nil)
+                expect(Libdatadog).to receive(:available_binaries).and_return(%w[fooarch-linux bararch-linux-musl])
               end
 
-              context 'when libdatadog HAS BINARIES for the current platform' do
-                before { expect(Libdatadog).to receive(:pkgconfig_folder).and_return('/simulated/pkgconfig_folder') }
-
-                it('marks the native extension as supported') { is_expected.to be nil }
-              end
+              it { is_expected.to include 'platform variant' }
             end
 
-            context 'on a Ruby version where we CAN NOT use the MJIT header' do
-              before { stub_const('Datadog::Profiling::NativeExtensionHelpers::CAN_USE_MJIT_HEADER', false) }
+            context 'when libdatadog HAS BINARIES for the current platform' do
+              before { expect(Libdatadog).to receive(:pkgconfig_folder).and_return('/simulated/pkgconfig_folder') }
+
+              it('marks the native extension as supported') { is_expected.to be nil }
+            end
+          end
+
+          context 'on a Ruby version where we CAN NOT use the MJIT header' do
+            before { stub_const('Datadog::Profiling::NativeExtensionHelpers::CAN_USE_MJIT_HEADER', false) }
+
+            include_examples 'libdatadog available'
+          end
+
+          context 'on a Ruby version where we CAN use the MJIT header' do
+            before { stub_const('Datadog::Profiling::NativeExtensionHelpers::CAN_USE_MJIT_HEADER', true) }
+
+            context 'but DOES NOT have MJIT support' do
+              before { expect(RbConfig::CONFIG).to receive(:[]).with('MJIT_SUPPORT').and_return('no') }
+
+              it { is_expected.to include 'without JIT' }
+            end
+
+            context 'and DOES have MJIT support' do
+              before { expect(RbConfig::CONFIG).to receive(:[]).with('MJIT_SUPPORT').and_return('yes') }
 
               include_examples 'libdatadog available'
             end
-
-            context 'on a Ruby version where we CAN use the MJIT header' do
-              before { stub_const('Datadog::Profiling::NativeExtensionHelpers::CAN_USE_MJIT_HEADER', true) }
-
-              context 'but DOES NOT have MJIT support' do
-                before { expect(RbConfig::CONFIG).to receive(:[]).with('MJIT_SUPPORT').and_return('no') }
-
-                it { is_expected.to include 'without JIT' }
-              end
-
-              context 'and DOES have MJIT support' do
-                before { expect(RbConfig::CONFIG).to receive(:[]).with('MJIT_SUPPORT').and_return('yes') }
-
-                include_examples 'libdatadog available'
-              end
-            end
-          end
-
-          context 'when on Ruby 2.1' do
-            before { stub_const('RUBY_VERSION', '2.1.10') }
-
-            it { is_expected.to include 'profiler only supports Ruby 2.3 or newer' }
-          end
-
-          context 'when on Ruby 2.2' do
-            before { stub_const('RUBY_VERSION', '2.2.10') }
-
-            it { is_expected.to include 'profiler only supports Ruby 2.3 or newer' }
           end
         end
 

--- a/spec/datadog/profiling/scheduler_spec.rb
+++ b/spec/datadog/profiling/scheduler_spec.rb
@@ -1,5 +1,7 @@
 require 'datadog/profiling/spec_helper'
 
+require 'datadog/profiling/scheduler'
+
 RSpec.describe Datadog::Profiling::Scheduler do
   before { skip_if_profiling_not_supported(self) }
 

--- a/spec/datadog/profiling/scheduler_spec.rb
+++ b/spec/datadog/profiling/scheduler_spec.rb
@@ -1,11 +1,8 @@
 require 'datadog/profiling/spec_helper'
 
-RSpec.describe 'Datadog::Profiling::Scheduler' do
+RSpec.describe Datadog::Profiling::Scheduler do
   before { skip_if_profiling_not_supported(self) }
 
-  # This is needed because this class uses syntax that doesn't work on Ruby 2.1/2.2; we can undo this once dd-trace-rb
-  # drops support for these Rubies globally
-  let(:described_class) { Datadog::Profiling::Scheduler }
   let(:exporter) { instance_double(Datadog::Profiling::Exporter) }
   let(:transport) { instance_double(Datadog::Profiling::HttpTransport) }
   let(:interval) { 60 } # seconds

--- a/spec/datadog/profiling/spec_helper.rb
+++ b/spec/datadog/profiling/spec_helper.rb
@@ -21,7 +21,6 @@ module ProfileHelpers
   def skip_if_profiling_not_supported(testcase)
     testcase.skip('Profiling is not supported on JRuby') if PlatformHelpers.jruby?
     testcase.skip('Profiling is not supported on TruffleRuby') if PlatformHelpers.truffleruby?
-    testcase.skip('Profiling is not supported on Ruby 2.1/2.2') if RUBY_VERSION.start_with?('2.1.', '2.2.')
 
     # Profiling is not officially supported on macOS due to missing libdatadog binaries,
     # but it's still useful to allow it to be enabled for development.


### PR DESCRIPTION
**What does this PR do?**

This PR removes the code for supporting Ruby 2.3 and 2.4 from the profiler.

This matches the minimum version for the datadog gem which is now Ruby 2.5 (e.g. this was dead code -- you couldn't actually use it anymore).

**Motivation:**

We opted not to do this earlier on in the 2.x release cycle, but as we are getting close to the final release, and given that the diff is not that big, I decided to go ahead and do it now.

**Additional Notes:**

In some cases, because a conditional was removed, indentation was adjusted. I suggest reviewing this diff with "Hide whitespace" turned on (or `-w` in the git cli).

In ddtrace 1.x, the gem supported Ruby 2.1+ whereas the profiler was supporting 2.3+. We still had some awkward support code to deal with this difference, which I also went ahead and removed.

It's cool in particular to see `private_vm_api_access.c` shrinking. I'm looking forward to this trend continuing, and maybe one day we'll even be able to remove it completely :)

**How to test the change?**

Validate that CI is still green on supported Rubies.