### PR TITLE
Remove datadog-gemfile and datadog-lockfile forcefully

### DIFF
--- a/lib-injection/auto_inject.rb
+++ b/lib-injection/auto_inject.rb
@@ -82,8 +82,8 @@ begin
     end
   ensure
     # Remove the copies
-    FileUtils.rm datadog_gemfile
-    FileUtils.rm datadog_lockfile
+    FileUtils.rm(datadog_gemfile, force: true)
+    FileUtils.rm(datadog_lockfile, force: true)
   end
 rescue Exception => e
   warn "[datadog] Injection failed: #{e.class.name} #{e.message}\nBacktrace: #{e.backtrace.join("\n")}\n#{support_message}"


### PR DESCRIPTION
<!--
Check out the
https://github.com/DataDog/dd-trace-rb/blob/master/docs/DevelopmentGuide.md
for guidance on how to set up your development environment,
run the test suite, write new integrations, and more.
-->

**2.0 Upgrade Guide notes**
<!--
(If this PR is for 1.x, please delete this section)
If this PR introduces a breaking change, update the
https://github.com/DataDog/dd-trace-rb/blob/2.0/docs/UpgradeGuide2.md
in this PR with either:
* A migration path for this change. In other words, how to continue using their application without behavior changes
in 2.0 (e.g. environment variable 'X' renamed to 'Y').
* That there's no alternative; we removed support for this feature.
-->

**What does this PR do?**
<!-- A brief description of the change being made with this pull request. -->

Remove datadog-gemfile and datadog-lockfile forcefully.

**Motivation:**
<!-- What inspired you to submit this pull request? -->

To ignore this error occasionally. See https://docs.ruby-lang.org/en/3.3/FileUtils.html#method-c-rm.

```
[ddtrace] Injection failed: Errno::ENOENT No such file or directory @ apply2files - /path/to/datadog-Gemfile
Backtrace: /usr/local/bundle/gems/fileutils-1.7.2/lib/fileutils.rb:2330:in `unlink'
/usr/local/bundle/gems/fileutils-1.7.2/lib/fileutils.rb:2330:in `block in remove_file'
/usr/local/bundle/gems/fileutils-1.7.2/lib/fileutils.rb:2335:in `platform_support'
/usr/local/bundle/gems/fileutils-1.7.2/lib/fileutils.rb:2329:in `remove_file'
/usr/local/bundle/gems/fileutils-1.7.2/lib/fileutils.rb:1474:in `remove_file'
/usr/local/bundle/gems/fileutils-1.7.2/lib/fileutils.rb:1222:in `block in rm'
/usr/local/bundle/gems/fileutils-1.7.2/lib/fileutils.rb:1221:in `each'
/usr/local/bundle/gems/fileutils-1.7.2/lib/fileutils.rb:1221:in `rm'
/datadog-lib/auto_inject.rb:85:in `ensure in <top (required)>'
/datadog-lib/auto_inject.rb:86:in `<top (required)>'
<internal:/usr/local/lib/ruby/site_ruby/3.2.0/rubygems/core_ext/kernel_require.rb>:136:in `require'
<internal:/usr/local/lib/ruby/site_ruby/3.2.0/rubygems/core_ext/kernel_require.rb>:136:in `require'
For help solving this issue, please contact Datadog support at https://docs.datadoghq.com/help/.
```

**Additional Notes:**
<!-- Anything else we should know when reviewing? -->

APMS-12026

**How to test the change?**
<!--
Describe here how the change can be validated.
You are strongly encouraged to provide automated tests for this PR (unit or integration).
If this change cannot be feasibly tested, please explain why,
unless the change does not modify code (e.g. only modifies docs, comments).
-->

Unsure? Have a question? Request a review!
