### PR TITLE
Fix environment logger repeated entries

### DIFF
--- a/lib/datadog/tracing/component.rb
+++ b/lib/datadog/tracing/component.rb
@@ -124,8 +124,12 @@ module Datadog
       end
 
       WRITER_RECORD_ENVIRONMENT_INFORMATION_CALLBACK = lambda do |_, responses|
-        Tracing::Diagnostics::EnvironmentLogger.collect_and_log!(responses: responses)
+        WRITER_RECORD_ENVIRONMENT_INFORMATION_ONLY_ONCE.run do
+          Tracing::Diagnostics::EnvironmentLogger.collect_and_log!(responses: responses)
+        end
       end
+
+      WRITER_RECORD_ENVIRONMENT_INFORMATION_ONLY_ONCE = Core::Utils::OnlyOnce.new
 
       # Create new lambda for writer callback,
       # capture the current sampler in the callback closure.

--- a/sig/datadog/tracing/component.rbs
+++ b/sig/datadog/tracing/component.rbs
@@ -1,6 +1,8 @@
 module Datadog
   module Tracing
     module Component
+      WRITER_RECORD_ENVIRONMENT_INFORMATION_ONLY_ONCE: Core::Utils::OnlyOnce
+
       def build_tracer: (untyped settings, untyped agent_settings) -> untyped
 
       def build_trace_flush: (untyped settings) -> untyped

--- a/spec/datadog/tracing/component_spec.rb
+++ b/spec/datadog/tracing/component_spec.rb
@@ -9,9 +9,20 @@ RSpec.describe Datadog::Tracing::Component do
       let(:writer) { double('writer') }
       let(:responses) { [double('response')] }
 
+      before do
+        Datadog::Tracing::Component::WRITER_RECORD_ENVIRONMENT_INFORMATION_ONLY_ONCE.send(:reset_ran_once_state_for_tests)
+      end
+
       it 'invokes the environment logger with responses' do
         expect(Datadog::Tracing::Diagnostics::EnvironmentLogger).to receive(:collect_and_log!).with(responses: responses)
         call
+      end
+
+      it 'invokes the environment logger only once' do
+        expect(Datadog::Tracing::Diagnostics::EnvironmentLogger).to receive(:collect_and_log!).once
+
+        described_class.call(writer, responses)
+        described_class.call(writer, responses)
       end
     end
   end


### PR DESCRIPTION
**What does this PR do?**

This PR fixes that repeated log entries for `DATADOG CONFIGURATION - TRACING` they were introduced in 2.0.

**Additional Notes:**
<!-- Anything else we should know when reviewing? -->

**How to test the change?**
Running the following command before and after this change we will allow to see that the repeated log entries are gone:
```console
DD_TRACE_AGENT_TIMEOUT_SECONDS=1 bundle exec ruby -e "require 'datadog'; Datadog::Tracing.trace('a'){}; sleep 2; Datadog::Tracing.trace('a'){}; sleep 2"
```

Unsure? Have a question? Request a review!
