### PR TITLE
Add apm-idm-ruby as CODEOWNERS to contrib

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -8,7 +8,7 @@
 /lib/datadog/appsec/ @DataDog/asm-ruby
 /lib/datadog/appsec.rb @DataDog/asm-ruby
 /lib/datadog/tracing/ @DataDog/tracing-ruby
-/lib/datadog/tracing/contrib @DataDog/apm-idm-ruby
+/lib/datadog/tracing/contrib/ @DataDog/apm-idm-ruby
 /lib/datadog/tracing.rb @DataDog/tracing-ruby
 /lib/datadog/opentelemetry/ @DataDog/tracing-ruby
 /lib/datadog/opentelemetry.rb @DataDog/tracing-ruby
@@ -21,7 +21,7 @@
 /sig/datadog/appsec/ @DataDog/asm-ruby
 /sig/datadog/appsec.rbs @DataDog/asm-ruby
 /sig/datadog/tracing/ @DataDog/tracing-ruby
-/sig/datadog/tracing/contrib @DataDog/apm-idm-ruby
+/sig/datadog/tracing/contrib/ @DataDog/apm-idm-ruby
 /sig/datadog/tracing.rbs @DataDog/tracing-ruby
 /sig/datadog/opentelemetry/ @DataDog/tracing-ruby
 /sig/datadog/opentelemetry.rbs @DataDog/tracing-ruby
@@ -31,7 +31,7 @@
 # Specs
 /spec/datadog/appsec/ @DataDog/asm-ruby
 /spec/datadog/tracing/ @DataDog/tracing-ruby
-/spec/datadog/tracing/contrib @DataDog/apm-idm-ruby
+/spec/datadog/tracing/contrib/ @DataDog/apm-idm-ruby
 /spec/datadog/tracing_spec.rb @DataDog/tracing-ruby
 /spec/datadog/opentelemetry/ @DataDog/tracing-ruby
 /spec/datadog/opentelemetry_spec.rb @DataDog/tracing-ruby

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -8,6 +8,7 @@
 /lib/datadog/appsec/ @DataDog/asm-ruby
 /lib/datadog/appsec.rb @DataDog/asm-ruby
 /lib/datadog/tracing/ @DataDog/tracing-ruby
+/lib/datadog/tracing/contrib @DataDog/apm-idm-ruby
 /lib/datadog/tracing.rb @DataDog/tracing-ruby
 /lib/datadog/opentelemetry/ @DataDog/tracing-ruby
 /lib/datadog/opentelemetry.rb @DataDog/tracing-ruby
@@ -20,6 +21,7 @@
 /sig/datadog/appsec/ @DataDog/asm-ruby
 /sig/datadog/appsec.rbs @DataDog/asm-ruby
 /sig/datadog/tracing/ @DataDog/tracing-ruby
+/sig/datadog/tracing/contrib @DataDog/apm-idm-ruby
 /sig/datadog/tracing.rbs @DataDog/tracing-ruby
 /sig/datadog/opentelemetry/ @DataDog/tracing-ruby
 /sig/datadog/opentelemetry.rbs @DataDog/tracing-ruby
@@ -29,6 +31,7 @@
 # Specs
 /spec/datadog/appsec/ @DataDog/asm-ruby
 /spec/datadog/tracing/ @DataDog/tracing-ruby
+/spec/datadog/tracing/contrib @DataDog/apm-idm-ruby
 /spec/datadog/tracing_spec.rb @DataDog/tracing-ruby
 /spec/datadog/opentelemetry/ @DataDog/tracing-ruby
 /spec/datadog/opentelemetry_spec.rb @DataDog/tracing-ruby


### PR DESCRIPTION
**Motivation:**
The IDM team would like to have a clean notification inbox when it comes to code reviews in `dd-trace-rb`. This is being done across all languages.

**How to test the change?**
<!--
Describe here how the change can be validated.
You are strongly encouraged to provide automated tests for this PR (unit or integration).
If this change cannot be feasibly tested, please explain why,
unless the change does not modify code (e.g. only modifies docs, comments).
-->

Unsure? Have a question? Request a review!
