### PR TITLE
Cache ActiveRecord configuration resolver

### DIFF
--- a/lib/datadog/tracing/contrib/active_record/configuration/resolver.rb
+++ b/lib/datadog/tracing/contrib/active_record/configuration/resolver.rb
@@ -32,7 +32,7 @@ module Datadog
           # based on addition order (`#add`).
           class Resolver < Contrib::Configuration::Resolver
             prepend MakaraResolver
-            prepend Contrib::Configuration::CachedResolver
+            prepend Contrib::Configuration::CachingResolver
 
             def initialize(active_record_configuration = nil)
               super()

--- a/lib/datadog/tracing/contrib/active_record/configuration/resolver.rb
+++ b/lib/datadog/tracing/contrib/active_record/configuration/resolver.rb
@@ -32,6 +32,7 @@ module Datadog
           # based on addition order (`#add`).
           class Resolver < Contrib::Configuration::Resolver
             prepend MakaraResolver
+            prepend Contrib::Configuration::CachedResolver
 
             def initialize(active_record_configuration = nil)
               super()

--- a/lib/datadog/tracing/contrib/active_record/integration.rb
+++ b/lib/datadog/tracing/contrib/active_record/integration.rb
@@ -4,6 +4,7 @@ require_relative 'configuration/resolver'
 require_relative 'configuration/settings'
 require_relative 'events'
 require_relative 'patcher'
+require_relative '../component'
 require_relative '../integration'
 require_relative '../rails/ext'
 require_relative '../rails/utils'
@@ -49,6 +50,15 @@ module Datadog
 
           def resolver
             @resolver ||= Configuration::Resolver.new
+          end
+
+          def reset_resolver_cache
+            @resolver&.reset_cache
+          end
+
+          Contrib::Component.register('activerecord') do |_config|
+            # Ensure resolver cache is reset on configuration change
+            Datadog.configuration.tracing.fetch_integration(:active_record).reset_resolver_cache
           end
         end
       end

--- a/lib/datadog/tracing/contrib/configuration/resolver.rb
+++ b/lib/datadog/tracing/contrib/configuration/resolver.rb
@@ -80,16 +80,16 @@ module Datadog
           end
         end
 
-        # The {CachedResolver} is a mixin that provides caching functionality to the {Resolver} class.
+        # The {CachingResolver} is a mixin that provides caching functionality to the {Resolver} class.
         # This is useful when {Resolver#resolve} values that are expensive to compute.
         # This is a size-limited, FIFO cache.
         #
         # @example
         #   class MyResolver < Datadog::Tracing::Contrib::Configuration::Resolver
-        #     prepend Datadog::Tracing::Contrib::Configuration::CachedResolver
+        #     prepend Datadog::Tracing::Contrib::Configuration::CachingResolver
         #     # ...
         #   end
-        module CachedResolver
+        module CachingResolver
           # @param [Integer] cache_limit maximum number of entries to cache
           def initialize(*args, cache_limit: 200)
             super(*args)

--- a/spec/datadog/tracing/contrib/active_record/configuration/resolver_spec.rb
+++ b/spec/datadog/tracing/contrib/active_record/configuration/resolver_spec.rb
@@ -8,7 +8,12 @@ RSpec.describe Datadog::Tracing::Contrib::ActiveRecord::Configuration::Resolver 
     if ::ActiveRecord.respond_to?(:version) && ::ActiveRecord.version >= Gem::Version.new('6')
       # ::ActiveRecord::DatabaseConfigurations` was introduced from 6+
       require 'active_record/database_configurations'
-      described_class.new(::ActiveRecord::DatabaseConfigurations.new(configuration))
+      # A keyword argument is passed as the last argument to avoid old Rubies considering the
+      # `::ActiveRecord::DatabaseConfigurations.new(configuration)` a keyword argument Hash, and
+      # erroneously calling `to_hash` on it. `ruby2_keywords` didn't work for this case.
+      # Neither did adding a `**` splat operator here, or explicitly declaring the keyword argument in
+      # the initializer.
+      described_class.new(::ActiveRecord::DatabaseConfigurations.new(configuration), cache_limit: 200)
     else
       described_class.new(configuration)
     end

--- a/spec/datadog/tracing/contrib/configuration/resolver_spec.rb
+++ b/spec/datadog/tracing/contrib/configuration/resolver_spec.rb
@@ -82,7 +82,7 @@ RSpec.describe Datadog::Tracing::Contrib::Configuration::Resolver do
   end
 end
 
-RSpec.describe Datadog::Tracing::Contrib::Configuration::CachedResolver do
+RSpec.describe Datadog::Tracing::Contrib::Configuration::CachingResolver do
   subject(:resolver) { resolver_class.new(cache_limit: cache_limit) }
 
   let(:cache_limit) { 2 }
@@ -90,7 +90,7 @@ RSpec.describe Datadog::Tracing::Contrib::Configuration::CachedResolver do
 
   let(:resolver_class) do
     Class.new(Datadog::Tracing::Contrib::Configuration::Resolver) do
-      prepend Datadog::Tracing::Contrib::Configuration::CachedResolver
+      prepend Datadog::Tracing::Contrib::Configuration::CachingResolver
 
       def resolve(key)
         @invoked ||= 0

--- a/spec/datadog/tracing/contrib/configuration/resolver_spec.rb
+++ b/spec/datadog/tracing/contrib/configuration/resolver_spec.rb
@@ -81,3 +81,90 @@ RSpec.describe Datadog::Tracing::Contrib::Configuration::Resolver do
     end
   end
 end
+
+RSpec.describe Datadog::Tracing::Contrib::Configuration::CachedResolver do
+  subject(:resolver) { resolver_class.new(cache_limit: cache_limit) }
+
+  let(:cache_limit) { 2 }
+  let(:value) { double('value') }
+
+  let(:resolver_class) do
+    Class.new(Datadog::Tracing::Contrib::Configuration::Resolver) do
+      prepend Datadog::Tracing::Contrib::Configuration::CachedResolver
+
+      def resolve(key)
+        @invoked ||= 0
+        @invoked += 1
+        super
+      end
+
+      def invocations
+        @invoked ||= 0
+      end
+    end
+  end
+
+  describe '#resolve' do
+    subject(:resolve) { resolver.resolve(key) }
+
+    let(:key) { 'key' }
+
+    before { resolver.add(key, value) }
+
+    it 'returns the correct value' do
+      expect(resolve).to eq(value)
+    end
+
+    it 'calls the original resolver once' do
+      resolver.resolve(key)
+      resolver.resolve(key)
+
+      expect(resolver.invocations).to eq(1)
+    end
+
+    context 'when a matcher key is added' do
+      let(:new_key) { 'new_key' }
+
+      it 'busts the cache' do
+        expect(resolver.resolve(key)).to eq(value)
+
+        resolver.add(new_key, value)
+
+        expect(resolver.resolve(key)).to eq(value)
+
+        expect(resolver.invocations).to eq(2)
+      end
+    end
+
+    context 'when the cache is reset' do
+      let(:new_key) { 'new_key' }
+
+      it 'busts the cache' do
+        expect(resolver.resolve(key)).to eq(value)
+
+        resolver.reset_cache
+
+        expect(resolver.resolve(key)).to eq(value)
+
+        expect(resolver.invocations).to eq(2)
+      end
+    end
+
+    context 'when the cache size limit is reached' do
+      before do
+        resolver.resolve('first_key')
+        resolver.resolve('second_key')
+      end
+
+      it 'removes the oldest entry from the cache' do
+        expect { resolver.resolve('third_key') }.to(change { resolver.invocations }.by(1)) # Removes `first_key` from cache
+        expect { resolver.resolve('second_key') }.to_not(change { resolver.invocations }) # `second_key` is still cached
+
+        expect { resolver.resolve('first_key') }.to(change { resolver.invocations }.by(1)) # Removes `second_key` from cache
+        expect { resolver.resolve('third_key') }.to_not(change { resolver.invocations }) # `third_key` is still cached
+
+        expect { resolver.resolve('second_key') }.to(change { resolver.invocations }.by(1)) # Removes `third_key` from cache
+      end
+    end
+  end
+end


### PR DESCRIPTION
<!--
Check out the
https://github.com/DataDog/dd-trace-rb/blob/master/docs/DevelopmentGuide.md
for guidance on how to set up your development environment,
run the test suite, write new integrations, and more.
-->

**What does this PR do?**
This PR adds caching to the ActiveRecord configuration resolver, resulting in only the first request with a specific ActiveRecord configuration performing the Rails resolution lookup.

This virtually eliminates the for ActiveRecord configuration resolution. This will improve the performance on every ActiveRecord span.

I can provide better performance numbers when this change has had a chance to run in our internal testing environment.

**Motivation:**
#3581

**How to test the change?**
All changes are covered by testing.

Unsure? Have a question? Request a review!
