### PR TITLE
Ensure micro benchmarks always run

### DIFF
--- a/.gitlab/benchmarks.yml
+++ b/.gitlab/benchmarks.yml
@@ -145,7 +145,7 @@ ddprof-benchmark:
     KUBERNETES_SERVICE_ACCOUNT_OVERWRITE: dd-trace-rb
 benchmarks:
   stage: benchmarks
-  when: on_success
+  when: always
   tags: ["runner:apm-k8s-tweaked-metal"]
   image: $BASE_CI_IMAGE
   interruptible: true


### PR DESCRIPTION
**What does this PR do?**
Micro benchmarks haven't been running recently because their GitLab job is set to `when: on_success`, which depends on every proceeding GitLab job to succeeded.

This is problematic when there are optional GitLab jobs that can fail.
