### PR TITLE
DEBUG-2334 Change Dispatcher constructor to directly accept receivers

### DIFF
--- a/lib/datadog/core/remote/client.rb
+++ b/lib/datadog/core/remote/client.rb
@@ -20,12 +20,8 @@ module Datadog
 
           @repository = repository
           @id = SecureRandom.uuid
-          @dispatcher = Dispatcher.new
           @capabilities = capabilities
-
-          @capabilities.receivers.each do |receiver|
-            dispatcher.receivers << receiver
-          end
+          @dispatcher = Dispatcher.new(@capabilities.receivers)
         end
 
         # rubocop:disable Metrics/AbcSize,Metrics/PerceivedComplexity,Metrics/MethodLength,Metrics/CyclomaticComplexity

--- a/lib/datadog/core/remote/dispatcher.rb
+++ b/lib/datadog/core/remote/dispatcher.rb
@@ -7,8 +7,8 @@ module Datadog
       class Dispatcher
         attr_reader :receivers
 
-        def initialize
-          @receivers = []
+        def initialize(receivers)
+          @receivers = receivers
         end
 
         def dispatch(changes, repository)

--- a/sig/datadog/core/remote/dispatcher.rbs
+++ b/sig/datadog/core/remote/dispatcher.rbs
@@ -4,7 +4,7 @@ module Datadog
       class Dispatcher
         attr_reader receivers: Array[Receiver]
 
-        def initialize: () -> void
+        def initialize: (::Array[Receiver]) -> void
 
         def dispatch: (Remote::Configuration::Repository::ChangeSet changes, Remote::Configuration::Repository repository) -> untyped
 

--- a/spec/datadog/core/remote/dispatcher_spec.rb
+++ b/spec/datadog/core/remote/dispatcher_spec.rb
@@ -105,9 +105,7 @@ RSpec.describe Datadog::Core::Remote::Dispatcher do
   end
 
   subject(:dispatcher) do
-    d = described_class.new
-    d.receivers << receiver
-    d
+    described_class.new([receiver])
   end
 
   describe '#dispatch' do


### PR DESCRIPTION

<!--
Check out the
https://github.com/DataDog/dd-trace-rb/blob/master/docs/DevelopmentGuide.md
for guidance on how to set up your development environment,
run the test suite, write new integrations, and more.
-->

**What does this PR do?**
<!-- A brief description of the change being made with this pull request. -->
There is only one call site of Dispatcher and the caller immediately copies the receivers into the newly created dispatcher.

Instead pass the dispatchers directly into the constructor to make it clear that dispatchers are part of initialization.

**Motivation:**
<!-- What inspired you to submit this pull request? -->
- More clearly convey what is needed to initialize dispatcher
- Encapsulate data better (no more mutating receivers)

**How to test the change?**
Unit tests
<!--
Describe here how the change can be validated.
You are strongly encouraged to provide automated tests for this PR (unit or integration).
If this change cannot be feasibly tested, please explain why,
unless the change does not modify code (e.g. only modifies docs, comments).
-->
