### PR TITLE
DEBUG-2334 Add Debugger component

### DIFF
--- a/lib/datadog.rb
+++ b/lib/datadog.rb
@@ -7,4 +7,5 @@ require_relative 'datadog/tracing/contrib'
 # Load other products (must follow tracing)
 require_relative 'datadog/profiling'
 require_relative 'datadog/appsec'
+require_relative 'datadog/debugger'
 require_relative 'datadog/kit'

--- a/lib/datadog/core/configuration/components.rb
+++ b/lib/datadog/core/configuration/components.rb
@@ -13,6 +13,7 @@ require_relative '../remote/component'
 require_relative '../../tracing/component'
 require_relative '../../profiling/component'
 require_relative '../../appsec/component'
+require_relative '../../debugger/component'
 
 module Datadog
   module Core
@@ -80,6 +81,7 @@ module Datadog
           :runtime_metrics,
           :telemetry,
           :tracer,
+          :debugger,
           :appsec
 
         def initialize(settings)
@@ -105,6 +107,7 @@ module Datadog
           @health_metrics = self.class.build_health_metrics(settings)
           @telemetry = self.class.build_telemetry(settings, agent_settings, logger)
           @appsec = Datadog::AppSec::Component.build_appsec_component(settings)
+          @debugger = Datadog::Debugger::Component.build(settings)
 
           self.class.configure_tracing(settings)
         end

--- a/lib/datadog/debugger.rb
+++ b/lib/datadog/debugger.rb
@@ -1,0 +1,19 @@
+# frozen_string_literal: true
+
+require_relative 'debugger/component'
+require_relative 'debugger/configuration'
+require_relative 'debugger/extensions'
+
+module Datadog
+  # Namespace for Datadog Debugger instrumentation
+  module Debugger
+    class << self
+      def enabled?
+        Datadog.configuration.debugger.enabled
+      end
+    end
+
+    # Expose Debugger to global shared objects
+    Extensions.activate!
+  end
+end

--- a/lib/datadog/debugger/component.rb
+++ b/lib/datadog/debugger/component.rb
@@ -12,8 +12,7 @@ module Datadog
         end
       end
 
-      def shutdown!(replacement = nil)
-      end
+      def shutdown!(replacement = nil); end
     end
   end
 end

--- a/lib/datadog/debugger/component.rb
+++ b/lib/datadog/debugger/component.rb
@@ -1,0 +1,19 @@
+# frozen_string_literal: true
+
+module Datadog
+  module Debugger
+    # Core-pluggable component for Debugger
+    class Component
+      class << self
+        def build(settings)
+          return unless settings.respond_to?(:debugger) && settings.debugger.enabled
+
+          new
+        end
+      end
+
+      def shutdown!(replacement = nil)
+      end
+    end
+  end
+end

--- a/lib/datadog/debugger/configuration.rb
+++ b/lib/datadog/debugger/configuration.rb
@@ -1,0 +1,11 @@
+# frozen_string_literal: true
+
+module Datadog
+  module Debugger
+    # Configuration for Debugger
+    module Configuration
+    end
+  end
+end
+
+require_relative 'configuration/settings'

--- a/lib/datadog/debugger/configuration/settings.rb
+++ b/lib/datadog/debugger/configuration/settings.rb
@@ -5,13 +5,11 @@ module Datadog
     module Configuration
       # Settings
       module Settings
-
         def self.extended(base)
           base = base.singleton_class unless base.is_a?(Class)
           add_settings!(base)
         end
 
-        # rubocop:disable Metrics/AbcSize,Metrics/MethodLength,Metrics/BlockLength,Metrics/CyclomaticComplexity,Metrics/PerceivedComplexity
         def self.add_settings!(base)
           base.class_eval do
             settings :debugger do
@@ -20,7 +18,6 @@ module Datadog
                 o.env 'DD_DYNAMIC_INSTRUMENTATION_ENABLED'
                 o.default false
               end
-
             end
           end
         end

--- a/lib/datadog/debugger/configuration/settings.rb
+++ b/lib/datadog/debugger/configuration/settings.rb
@@ -1,0 +1,30 @@
+# frozen_string_literal: true
+
+module Datadog
+  module Debugger
+    module Configuration
+      # Settings
+      module Settings
+
+        def self.extended(base)
+          base = base.singleton_class unless base.is_a?(Class)
+          add_settings!(base)
+        end
+
+        # rubocop:disable Metrics/AbcSize,Metrics/MethodLength,Metrics/BlockLength,Metrics/CyclomaticComplexity,Metrics/PerceivedComplexity
+        def self.add_settings!(base)
+          base.class_eval do
+            settings :debugger do
+              option :enabled do |o|
+                o.type :bool
+                o.env 'DD_DYNAMIC_INSTRUMENTATION_ENABLED'
+                o.default false
+              end
+
+            end
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/datadog/debugger/extensions.rb
+++ b/lib/datadog/debugger/extensions.rb
@@ -1,0 +1,15 @@
+# frozen_string_literal: true
+
+require_relative 'configuration'
+
+module Datadog
+  module Debugger
+    # Extends Datadog tracing with Debugger features
+    module Extensions
+      # Inject Debugger into global objects.
+      def self.activate!
+        Core::Configuration::Settings.extend(Configuration::Settings)
+      end
+    end
+  end
+end

--- a/sig/datadog/core/configuration/settings.rbs
+++ b/sig/datadog/core/configuration/settings.rbs
@@ -54,6 +54,12 @@ module Datadog
           def templates: () -> _TemplatesBlock
         end
 
+        interface _Debugger
+          def enabled: () -> bool
+
+          def enabled=: (bool) -> void
+        end
+
         interface _TemplatesBlock
           def html=: (::String) -> void
 
@@ -81,6 +87,8 @@ module Datadog
         def runtime_metrics: (?untyped? options) -> untyped
 
         def appsec: (?untyped? options) -> Datadog::Core::Configuration::Settings::_AppSec
+
+        def debugger: (?untyped? options) -> Datadog::Core::Configuration::Settings::_Debugger
 
         def remote: (?untyped? options) -> Datadog::Core::Configuration::Settings::_Remote
       end

--- a/sig/datadog/debugger.rbs
+++ b/sig/datadog/debugger.rbs
@@ -1,0 +1,5 @@
+module Datadog
+  module Debugger
+    def self.enabled?: () -> bool
+  end
+end

--- a/sig/datadog/debugger/component.rbs
+++ b/sig/datadog/debugger/component.rbs
@@ -1,0 +1,11 @@
+module Datadog
+  module Debugger
+    class Component
+      def self.build: (Datadog::Core::Configuration::Settings settings) -> Datadog::Debugger::Component?
+
+      private
+
+      def shutdown!: () -> untyped
+    end
+  end
+end

--- a/sig/datadog/debugger/configuration.rbs
+++ b/sig/datadog/debugger/configuration.rbs
@@ -1,0 +1,6 @@
+module Datadog
+  module Debugger
+    module Configuration
+    end
+  end
+end

--- a/sig/datadog/debugger/configuration/settings.rbs
+++ b/sig/datadog/debugger/configuration/settings.rbs
@@ -1,0 +1,19 @@
+module Datadog
+  module Debugger
+    module Configuration
+      # Settings
+      module Settings
+        extend Datadog::Core::Configuration::Base::ClassMethods
+        include Datadog::Core::Configuration::Base::InstanceMethods
+        extend Datadog::Core::Configuration::Options::ClassMethods
+        include Datadog::Core::Configuration::Options::InstanceMethods
+
+        def self.extended: (untyped base) -> untyped
+
+        def self.add_settings!: (untyped base) -> untyped
+
+        def self.enabled:  -> bool
+      end
+    end
+  end
+end

--- a/sig/datadog/debugger/extensions.rbs
+++ b/sig/datadog/debugger/extensions.rbs
@@ -1,0 +1,7 @@
+module Datadog
+  module Debugger
+    module Extensions
+      def self.activate!: () -> untyped
+    end
+  end
+end

--- a/spec/datadog/core/configuration/components_spec.rb
+++ b/spec/datadog/core/configuration/components_spec.rb
@@ -1085,6 +1085,7 @@ RSpec.describe Datadog::Core::Configuration::Components do
         expect(components.tracer).to receive(:shutdown!)
         expect(components.remote).to receive(:shutdown!) unless components.remote.nil?
         expect(components.profiler).to receive(:shutdown!) unless components.profiler.nil?
+        expect(components.debugger).to receive(:shutdown!) unless components.debugger.nil?
         expect(components.appsec).to receive(:shutdown!) unless components.appsec.nil?
         expect(components.runtime_metrics).to receive(:stop)
           .with(true, close_metrics: false)
@@ -1104,6 +1105,7 @@ RSpec.describe Datadog::Core::Configuration::Components do
         let(:profiler) { Datadog::Profiling.supported? ? instance_double(Datadog::Profiling::Profiler) : nil }
         let(:remote) { instance_double(Datadog::Core::Remote::Component) }
         let(:appsec) { instance_double(Datadog::AppSec::Component) }
+        let(:debugger) { instance_double(Datadog::Debugger::Component) }
         let(:runtime_metrics_worker) { instance_double(Datadog::Core::Workers::RuntimeMetrics, metrics: runtime_metrics) }
         let(:runtime_metrics) { instance_double(Datadog::Core::Runtime::Metrics, statsd: statsd) }
         let(:health_metrics) { instance_double(Datadog::Core::Diagnostics::Health::Metrics, statsd: statsd) }
@@ -1114,6 +1116,7 @@ RSpec.describe Datadog::Core::Configuration::Components do
           allow(replacement).to receive(:tracer).and_return(tracer)
           allow(replacement).to receive(:profiler).and_return(profiler)
           allow(replacement).to receive(:appsec).and_return(appsec)
+          allow(replacement).to receive(:debugger).and_return(debugger)
           allow(replacement).to receive(:remote).and_return(remote)
           allow(replacement).to receive(:runtime_metrics).and_return(runtime_metrics_worker)
           allow(replacement).to receive(:health_metrics).and_return(health_metrics)
@@ -1128,6 +1131,7 @@ RSpec.describe Datadog::Core::Configuration::Components do
           expect(components.tracer).to receive(:shutdown!)
           expect(components.profiler).to receive(:shutdown!) unless components.profiler.nil?
           expect(components.appsec).to receive(:shutdown!) unless components.appsec.nil?
+          expect(components.debugger).to receive(:shutdown!) unless components.debugger.nil?
           expect(components.runtime_metrics).to receive(:stop)
             .with(true, close_metrics: false)
           expect(components.runtime_metrics.metrics.statsd).to receive(:close)

--- a/spec/datadog/debugger/component_spec.rb
+++ b/spec/datadog/debugger/component_spec.rb
@@ -1,0 +1,29 @@
+require 'datadog/debugger/component'
+
+RSpec.describe Datadog::Debugger::Component do
+  describe '.build' do
+    let(:settings) do
+      settings = Datadog::Core::Configuration::Settings.new
+      settings.debugger.enabled = debugger_enabled
+      settings
+    end
+
+    context 'when debugger is enabled' do
+      let(:debugger_enabled) { true }
+
+      it 'returns a Datadog::Debugger::Component instance' do
+        component = described_class.build(settings)
+        expect(component).to be_a(described_class)
+      end
+    end
+
+    context 'when debugger is disabled' do
+      let(:debugger_enabled) { false }
+
+      it 'returns nil' do
+        component = described_class.build(settings)
+        expect(component).to be nil
+      end
+    end
+  end
+end

--- a/spec/datadog/debugger/configuration/settings_spec.rb
+++ b/spec/datadog/debugger/configuration/settings_spec.rb
@@ -1,0 +1,46 @@
+require 'spec_helper'
+
+RSpec.describe Datadog::Debugger::Configuration::Settings do
+  subject(:settings) { Datadog::Core::Configuration::Settings.new }
+
+  describe 'debugger' do
+    describe '#enabled' do
+      subject(:enabled) { settings.debugger.enabled }
+
+      context 'when DD_DYNAMIC_INSTRUMENTATION_ENABLED' do
+        around do |example|
+          ClimateControl.modify('DD_DYNAMIC_INSTRUMENTATION_ENABLED' => debugger_enabled) do
+            example.run
+          end
+        end
+
+        context 'is not defined' do
+          let(:debugger_enabled) { nil }
+
+          it { is_expected.to eq false }
+        end
+
+        context 'is defined' do
+          let(:debugger_enabled) { 'true' }
+
+          it { is_expected.to eq(true) }
+        end
+      end
+    end
+
+    describe '#enabled=' do
+      subject(:set_debugger_enabled) { settings.debugger.enabled = debugger_enabled }
+
+      [true, false].each do |value|
+        context "when given #{value}" do
+          let(:debugger_enabled) { value }
+
+          before { set_debugger_enabled }
+
+          it { expect(settings.debugger.enabled).to eq(value) }
+        end
+      end
+    end
+
+  end
+end

--- a/spec/datadog/debugger/configuration/settings_spec.rb
+++ b/spec/datadog/debugger/configuration/settings_spec.rb
@@ -41,6 +41,5 @@ RSpec.describe Datadog::Debugger::Configuration::Settings do
         end
       end
     end
-
   end
 end


### PR DESCRIPTION
This adds a component for Dynamic Instrumentation / Live Debugger using AppSec component as the model.

Included is a 'debugger' setting to turn the component on, and handling of DD_DYNAMIC_INSTRUMENTATION_ENABLED environment variable which is equivalent to the setting.

The component is not used by anything at this point and is/will remain off by default.

<!--
Check out the
https://github.com/DataDog/dd-trace-rb/blob/master/docs/DevelopmentGuide.md
for guidance on how to set up your development environment,
run the test suite, write new integrations, and more.
-->

**2.0 Upgrade Guide notes**
<!--
(If this PR is for 1.x, please delete this section)
If this PR introduces a breaking change, update the
https://github.com/DataDog/dd-trace-rb/blob/2.0/docs/UpgradeGuide2.md
in this PR with either:
* A migration path for this change. In other words, how to continue using their application without behavior changes
in 2.0 (e.g. environment variable 'X' renamed to 'Y').
* That there's no alternative; we removed support for this feature.
-->

**How to test the change?**
Unit tests only at this time.
<!--
Describe here how the change can be validated.
You are strongly encouraged to provide automated tests for this PR (unit or integration).
If this change cannot be feasibly tested, please explain why,
unless the change does not modify code (e.g. only modifies docs, comments).
-->

