### PR TITLE
Fix lib injection with outdated dependencies

### DIFF
--- a/.gitlab/install_datadog_deps.rb
+++ b/.gitlab/install_datadog_deps.rb
@@ -18,7 +18,9 @@ gemfile_file_path = versioned_path.join('Gemfile')
 
 File.open(gemfile_file_path, 'w') do |file|
   file.write("source 'https://rubygems.org'\n")
-  file.write("gem 'datadog', '#{ENV.fetch('RUBY_PACKAGE_VERSION')}', path: '#{current_path}'")
+  file.write("gem 'datadog', '#{ENV.fetch('RUBY_PACKAGE_VERSION')}', path: '#{current_path}'\n")
+  # Mimick outdated `msgpack` version, remove before merging
+  file.write("gem 'msgpack', '1.6.0'\n")
 end
 
 puts '=== Reading Gemfile ==='

--- a/lib-injection/host_inject.rb
+++ b/lib-injection/host_inject.rb
@@ -1,5 +1,4 @@
 # Keep in sync with auto_inject.rb
-
 return if ENV['DD_TRACE_SKIP_LIB_INJECTION'] == 'true'
 
 require 'rubygems'
@@ -9,17 +8,11 @@ ruby_api_version = RbConfig::CONFIG['ruby_version']
 
 dd_lib_injection_path = "/opt/datadog/apm/library/ruby/#{ruby_api_version}"
 
-# Look for pre-installed tracers
-Gem.paths = {
-  'GEM_PATH' => "#{dd_lib_injection_path}:#{ENV['GEM_PATH']}"
-}
-
-# Also apply to the environment variable, to guarantee any spawned processes will respected the modified `GEM_PATH`.
-ENV['GEM_PATH'] = Gem.path.join(':')
-
 def debug_log(msg)
   $stdout.puts msg if ENV['DD_TRACE_DEBUG'] == 'true'
 end
+
+debug_log "[datadog] Loading from #{dd_lib_injection_path}..."
 
 begin
   require 'open3'
@@ -92,7 +85,11 @@ begin
         ::FileUtils.cp lockfile, datadog_lockfile
 
         output, status = Open3.capture2e(
-          { 'DD_TRACE_SKIP_LIB_INJECTION' => 'true', 'BUNDLE_GEMFILE' => datadog_gemfile.to_s },
+          {
+            'BUNDLE_GEMFILE' => datadog_gemfile.to_s,
+            'DD_TRACE_SKIP_LIB_INJECTION' => 'true',
+            'GEM_PATH' => dd_lib_injection_path
+          },
           bundle_add_cmd
         )
 
@@ -113,6 +110,12 @@ begin
       end
     end
   end
+
+  # Look for pre-installed tracers
+  Gem.paths = { 'GEM_PATH' => "#{dd_lib_injection_path}:#{ENV['GEM_PATH']}" }
+
+  # Also apply to the environment variable, to guarantee any spawned processes will respected the modified `GEM_PATH`.
+  ENV['GEM_PATH'] = Gem.path.join(':')
 rescue Exception => e
   warn "[datadog] Injection failed: #{e.class.name} #{e.message}\nBacktrace: #{e.backtrace.join("\n")}\n#{support_message}"
   ENV['DD_TRACE_SKIP_LIB_INJECTION'] = 'true'


### PR DESCRIPTION
**Why**

Implementation in https://github.com/DataDog/dd-trace-rb/pull/3638 has caveats.

Edge case: When community releases a new version of dependency. The dependencies bundled together become outdated. Hence the Bundler's `Add` command would resolve with the latest version which the artifact does not include. 

This scenario can be mimicked by preparing an older version of dependency.

**What does this PR do?**

1. Fix PR reverts the implementation in https://github.com/DataDog/dd-trace-rb/pull/3638 
2. Run bundle cli commands with updated GEM_PATH to resolve correctly.
3. Delay in propagating ENV after successful injection.