### PR TITLE
Backport adding `latest_major` and `latest_minor` tags

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -194,7 +194,7 @@ deploy_to_reliability_env:
 prepare_image_destinations:
   stage: deploy
   tags: ["arch:amd64"]
-  image: registry.ddbuild.io/ci/auto_inject/gitlab:current
+  image: $DOCKER_REGISTRY/images/mirror/ruby:3.2.2
   rules:
     - if: '$POPULATE_CACHE'
       when: never
@@ -203,6 +203,9 @@ prepare_image_destinations:
     - when: manual
       allow_failure: true
   script:
+    - ruby -v
+    - gem -v
+    - bundle -v
     - ./.gitlab/check_gem_presence.rb $CI_COMMIT_TAG
     - echo "IMG_DESTINATIONS=$(./.gitlab/prepare_image_destinations.rb dd-lib-ruby-init $CI_COMMIT_TAG)" >> build.env
   artifacts:

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -207,7 +207,12 @@ prepare_image_destinations:
     - gem -v
     - bundle -v
     - ./.gitlab/check_gem_presence.rb $CI_COMMIT_TAG
-    - echo "IMG_DESTINATIONS=$(./.gitlab/prepare_image_destinations.rb dd-lib-ruby-init $CI_COMMIT_TAG)" >> build.env
+    - |
+      IMG_DESTINATIONS=$(./.gitlab/prepare_image_destinations.rb dd-lib-ruby-init $CI_COMMIT_TAG) || {
+        echo "Failed to prepare image destinations: $CI_COMMIT_TAG"
+        exit 1
+      }
+      echo "IMG_DESTINATIONS=$IMG_DESTINATIONS" > build.env
   artifacts:
     reports:
       dotenv: build.env

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -191,40 +191,33 @@ deploy_to_reliability_env:
     UPSTREAM_PROJECT_NAME: $CI_PROJECT_NAME
     UPSTREAM_COMMIT_SHA: $CI_COMMIT_SHA
 
+prepare_image_destinations:
+  stage: deploy
+  tags: ["arch:amd64"]
+  image: registry.ddbuild.io/ci/auto_inject/gitlab:current
+  rules:
+    - if: '$POPULATE_CACHE'
+      when: never
+    - if:  $CI_COMMIT_TAG =~ /^v(\d+)\.(\d+)\.(\d+)$/ # Exclude prerelease
+      when: always
+    - when: manual
+      allow_failure: true
+  script:
+    - echo "IMG_DESTINATIONS=$(./.gitlab/prepare_image_destinations.rb dd-lib-ruby-init $CI_COMMIT_TAG)" >> build.env
+  artifacts:
+    reports:
+      dotenv: build.env
+
 deploy_to_docker_registries:
   stage: deploy
-  rules:
-    - if: "$POPULATE_CACHE"
-      when: never
-    - if: $CI_COMMIT_TAG =~ /^v(\d+)\.(\d+)\.(\d+)$/ # Exclude prerelease
-      when: delayed
-      start_in: 1 day
-    - when: manual
-      allow_failure: true
+  needs:
+    - job: prepare_image_destinations
+      artifacts: true
   trigger:
     project: DataDog/public-images
     branch: main
     strategy: depend
   variables:
     IMG_SOURCES: ghcr.io/datadog/dd-trace-rb/dd-lib-ruby-init:$CI_COMMIT_TAG
-    IMG_DESTINATIONS: dd-lib-ruby-init:$CI_COMMIT_TAG
-    IMG_SIGNING: "false"
-
-deploy_latest_tag_to_docker_registries:
-  stage: deploy
-  rules:
-    - if: "$POPULATE_CACHE"
-      when: never
-    - if: $CI_COMMIT_TAG =~ /^v(\d+)\.(\d+)\.(\d+)$/ && $CI_COMMIT_BRANCH == 'master' # Exclude prerelease and only for master branch
-      when: delayed
-      start_in: 1 day
-    - when: manual
-      allow_failure: true
-  trigger:
-    project: DataDog/public-images
-    branch: main
-    strategy: depend
-  variables:
-    IMG_SOURCES: ghcr.io/datadog/dd-trace-rb/dd-lib-ruby-init:$CI_COMMIT_TAG
-    IMG_DESTINATIONS: dd-lib-ruby-init:latest
+    IMG_DESTINATIONS: $IMG_DESTINATIONS
     IMG_SIGNING: "false"

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -203,6 +203,7 @@ prepare_image_destinations:
     - when: manual
       allow_failure: true
   script:
+    - ./.gitlab/check_gem_presence.rb $CI_COMMIT_TAG
     - echo "IMG_DESTINATIONS=$(./.gitlab/prepare_image_destinations.rb dd-lib-ruby-init $CI_COMMIT_TAG)" >> build.env
   artifacts:
     reports:

--- a/.gitlab/check_gem_presence.rb
+++ b/.gitlab/check_gem_presence.rb
@@ -1,0 +1,37 @@
+#!/usr/bin/env ruby
+
+require 'bundler/inline'
+
+gemfile { gem 'gems', source: 'https://rubygems.org' }
+
+require 'rubygems'
+require 'gems'
+
+version = ARGV[0].chomp
+version = version.delete_prefix('v') if version.start_with?('v')
+
+candidate = Gem::Version.new(version)
+
+retry_count = 0
+max_retries = 60
+interval = 60
+
+loop do
+  versions = Gems.versions('ddtrace').map { |h| Gem::Version.new(h['number']) }
+
+  if versions.include?(candidate)
+    puts "Gem version #{candidate} found!"
+    exit 0
+  else
+    retry_count += 1
+    puts "Attempt(#{retry_count}):  Gem 'ddtrace' version '#{candidate}' not found."
+
+    if retry_count >= max_retries
+      puts "Max retries(#{max_retries}) reached, stopping..."
+      exit 1
+    else
+      puts "Retrying in #{interval} seconds..."
+      sleep interval
+    end
+  end
+end

--- a/.gitlab/prepare_image_destinations.rb
+++ b/.gitlab/prepare_image_destinations.rb
@@ -1,0 +1,38 @@
+#!/usr/bin/env ruby
+
+require 'bundler/inline'
+
+gemfile { gem 'gems', source: 'https://rubygems.org' }
+
+require 'rubygems'
+require 'gems'
+
+image_name = ARGV[0].chomp
+version = ARGV[1].chomp
+version = version.delete_prefix('v') if version.start_with?('v')
+
+candidate = Gem::Version.new(version)
+
+if candidate.prerelease?
+  warn 'No tags for pre-releases'
+  exit 1
+end
+
+major, minor, = candidate.to_s.split('.')
+
+latest_major_tag = "v#{major}"          # contains major
+latest_minor_tag = "v#{major}.#{minor}" # contains major, minor
+
+tags = []
+
+gem_name = 'datadog'
+
+# Check if the candidate is larger than public latest version
+tags << 'latest' if candidate > Gem::Version.new(Gems.latest_version(gem_name).fetch('version'))
+tags << latest_major_tag
+tags << latest_minor_tag
+tags << "v#{candidate}"
+
+destinations = tags.map { |tag| "#{image_name}:#{tag}" }
+
+$stdout.puts destinations.join(',')

--- a/.gitlab/prepare_image_destinations.rb
+++ b/.gitlab/prepare_image_destinations.rb
@@ -1,11 +1,6 @@
 #!/usr/bin/env ruby
 
-require 'bundler/inline'
-
-gemfile { gem 'gems', source: 'https://rubygems.org' }
-
 require 'rubygems'
-require 'gems'
 
 image_name = ARGV[0].chomp
 version = ARGV[1].chomp
@@ -25,10 +20,9 @@ latest_minor_tag = "v#{major}.#{minor}" # contains major, minor
 
 tags = []
 
-gem_name = 'datadog'
-
-# Check if the candidate is larger than public latest version
-tags << 'latest' if candidate > Gem::Version.new(Gems.latest_version(gem_name).fetch('version'))
+# `ddtrace` is the gem name on 1.x-stable branch, releasing from this branch means it won't be tagged with `latest`
+#
+# `latest` tag will be carried over by 2.x version of the gem named `datadog` on `master` branch
 tags << latest_major_tag
 tags << latest_minor_tag
 tags << "v#{candidate}"


### PR DESCRIPTION
This PR backports https://github.com/DataDog/dd-trace-rb/pull/3643 to `1.x-stable` 

In addition, it does not tagged `latest` on this branch
