### PR TITLE
Make appsec work without tracing

### DIFF
--- a/lib/datadog/appsec/contrib/devise/tracking.rb
+++ b/lib/datadog/appsec/contrib/devise/tracking.rb
@@ -13,12 +13,16 @@ module Datadog
           SIGNUP_EVENT = 'users.signup'
 
           def self.track_login_success(trace, span, user_id:, **others)
+            return if trace.nil? || span.nil?
+
             track(LOGIN_SUCCESS_EVENT, trace, span, **others)
 
             Kit::Identity.set_user(trace, span, id: user_id.to_s, **others) if user_id
           end
 
           def self.track_login_failure(trace, span, user_id:, user_exists:, **others)
+            return if trace.nil? || span.nil?
+
             track(LOGIN_FAILURE_EVENT, trace, span, **others)
 
             span.set_tag('appsec.events.users.login.failure.usr.id', user_id) if user_id
@@ -26,11 +30,15 @@ module Datadog
           end
 
           def self.track_signup(trace, span, user_id:, **others)
+            return if trace.nil? || span.nil?
+
             track(SIGNUP_EVENT, trace, span, **others)
             Kit::Identity.set_user(trace, id: user_id.to_s, **others) if user_id
           end
 
           def self.track(event, trace, span, **others)
+            return if trace.nil? || span.nil?
+
             span.set_tag("appsec.events.#{event}.track", 'true')
             span.set_tag("_dd.appsec.events.#{event}.auto.mode", Datadog.configuration.appsec.track_user_events.mode)
 

--- a/shell.nix
+++ b/shell.nix
@@ -3,11 +3,11 @@
   pkgs ? import <nixpkgs> {},
 
   # use a pinned package state
-  pinned ? import(fetchTarball("https://github.com/NixOS/nixpkgs/archive/31b322916ae1.tar.gz")) {},
+  pinned ? import(fetchTarball("https://github.com/NixOS/nixpkgs/archive/25865a40d14b.tar.gz")) {},
 }:
 let
   # specify ruby version to use
-  ruby = pinned.ruby_3_2;
+  ruby = pinned.ruby_3_3;
 
   # control llvm/clang version (e.g for packages built from source)
   llvm = pinned.llvmPackages_16;


### PR DESCRIPTION
<!--
Check out the
https://github.com/DataDog/dd-trace-rb/blob/master/docs/DevelopmentGuide.md
for guidance on how to set up your development environment,
run the test suite, write new integrations, and more.
-->

**2.0 Upgrade Guide notes**
<!--
(If this PR is for 1.x, please delete this section)
If this PR introduces a breaking change, update the
https://github.com/DataDog/dd-trace-rb/blob/2.0/docs/UpgradeGuide2.md
in this PR with either:
* A migration path for this change. In other words, how to continue using their application without behavior changes
in 2.0 (e.g. environment variable 'X' renamed to 'Y').
* That there's no alternative; we removed support for this feature.
-->

**What does this PR do?**

Make appsec work without tracing

**Motivation:**

Fixes https://github.com/DataDog/dd-trace-rb/issues/3564

**Additional Notes:**
<!-- Anything else we should know when reviewing? -->

Probably will need to be backported.

**How to test the change?**
<!--
Describe here how the change can be validated.
You are strongly encouraged to provide automated tests for this PR (unit or integration).
If this change cannot be feasibly tested, please explain why,
unless the change does not modify code (e.g. only modifies docs, comments).
-->

Unsure? Have a question? Request a review!
