### PR TITLE
OpenTelemetry:Fix attribute merge with Datadog tags

### DIFF
--- a/lib/datadog/opentelemetry/sdk/span_processor.rb
+++ b/lib/datadog/opentelemetry/sdk/span_processor.rb
@@ -136,7 +136,7 @@ module Datadog
           end
           attributes.flatten!(1)
 
-          kwargs[:tags] = attributes
+          kwargs[:tags] = attributes.to_h
 
           [name, kwargs]
         end


### PR DESCRIPTION
**What does this PR do?**
This PR fixes an issue with the tracing OpenTelemetry integration where OpenTelemetry span `attributes` were processed and converted to Datadog span tags, but not correctly converted back into a Hash object; they were left as an Array of key/value pairs.
Because an Array of key/value pairs is not what `Tracing.trace(tags:)` expects, this should have failed much earlier. But it actually has a chance of successfully setting span tags in the scenario that:
1. There are no global `DD_TAGS`. In this case, we don't need to merge the existing tag array with the provided Array of key/value pairs. https://github.com/DataDog/dd-trace-rb/blob/7ca30420a6315323343f9f1d9a895f53078c6ca3/lib/datadog/tracing/tracer.rb#L423
2. `set_tags` iterates over the provided tags in a way that works for both Hashes and Arrays of key/value pairs: https://github.com/DataDog/dd-trace-rb/blob/7ca30420a6315323343f9f1d9a895f53078c6ca3/lib/datadog/tracing/metadata/tagging.rb#L65

This means that unless`DD_TAGS` (or the equivalent `c.tags = ...`) was set, everything worked as expected.

**Motivation:**
To fix this error:
```ruby
lib/datadog/tracing/tracer.rb:429:in `merge': no implicit conversion of Array into Hash (TypeError)	
lib/datadog/tracing/tracer.rb:429:in `resolve_tags'	
lib/datadog/tracing/tracer.rb:404:in `start_span'	
lib/datadog/tracing/tracer.rb:176:in `trace'	
lib/datadog/tracing.rb:18:in `trace'	
lib/datadog/opentelemetry/sdk/span_processor.rb:85:in `start_datadog_span'
```

**How to test the change?**
We have unit tests for this change.

Unsure? Have a question? Request a review!
