### PR TITLE
Remove bundler cache in for `setup-ruby` 

### DIFF
--- a/.github/workflows/test-macos.yaml
+++ b/.github/workflows/test-macos.yaml
@@ -38,7 +38,7 @@ jobs:
       - uses: ruby/setup-ruby@v1
         with:
           ruby-version: ${{ matrix.ruby }}
-          bundler-cache: true # runs 'bundle install' and caches installed gems automatically
-          bundler: latest # needed to fix issue with steep on Ruby 3.0/3.1
-          cache-version: v2 # bump this to invalidate cache
+          rubygems: 3.3.26
+          bundler: 2.3.26 # needed to fix issue with steep on Ruby 3.0/3.1
+      - run: bundle install
       - run: bundle exec rake spec:main


### PR DESCRIPTION
**What?**

MacOS test is failing due to dependencies

```
/Users/runner/hostedtoolcache/Ruby/2.7.8/x64/lib/ruby/gems/2.7.0/gems/bundler-2.3.26/lib/bundler/runtime.rb:308:in `check_for_activated_spec!': You have already activated strscan 1.0.3, but your Gemfile requires strscan 3.1.0. Since strscan is a default gem, you can either remove your dependency on it or try updating to a newer version of bundler that supports strscan as a default gem. (Gem::LoadError)
	from /Users/runner/hostedtoolcache/Ruby/2.7.8/x64/lib/ruby/gems/2.7.0/gems/bundler-2.3.26/lib/bundler/runtime.rb:25:in `block in setup'
	from /Users/runner/hostedtoolcache/Ruby/2.7.8/x64/lib/ruby/gems/2.7.0/gems/bundler-2.3.26/lib/bundler/spec_set.rb:155:in `each'
	from /Users/runner/hostedtoolcache/Ruby/2.7.8/x64/lib/ruby/gems/2.7.0/gems/bundler-2.3.26/lib/bundler/spec_set.rb:155:in `each'
	from /Users/runner/hostedtoolcache/Ruby/2.7.8/x64/lib/ruby/gems/2.7.0/gems/bundler-2.3.26/lib/bundler/runtime.rb:24:in `map'
	from /Users/runner/hostedtoolcache/Ruby/2.7.8/x64/lib/ruby/gems/2.7.0/gems/bundler-2.3.26/lib/bundler/runtime.rb:24:in `setup'
	from /Users/runner/hostedtoolcache/Ruby/2.7.8/x64/lib/ruby/gems/2.7.0/gems/bundler-2.3.26/lib/bundler/inline.rb:66:in `block in gemfile'
	from /Users/runner/hostedtoolcache/Ruby/2.7.8/x64/lib/ruby/gems/2.7.0/gems/bundler-2.3.26/lib/bundler/settings.rb:131:in `temporary'
	from /Users/runner/hostedtoolcache/Ruby/2.7.8/x64/lib/ruby/gems/2.7.0/gems/bundler-2.3.26/lib/bundler/inline.rb:50:in `gemfile'
	from -:3:in `<main>'
```

The GHA runner does not picked `strscan` bundled and the cache invalidation does not function as expected:
See: https://github.com/DataDog/dd-trace-rb/actions/runs/9173116481/job/25221083640

**How** 

1. Remove bundler cache
2. Pin rubygem and bundler version in MacOS test