### PR TITLE
chore(lib-injection): update base image to alpine 3.20

### DIFF
--- a/lib-injection/Dockerfile
+++ b/lib-injection/Dockerfile
@@ -1,6 +1,6 @@
 # This image provides the files needed to install the dd-trace-rb
 # and auto instrument Ruby applications in containerized environments.
-FROM alpine:3.18.6
+FROM alpine:3.20
 
 # Set high UID to prevent possible conflict with existing users: http://www.linfo.org/uid.html
 ARG UID=10000


### PR DESCRIPTION
3.18.3 has a known vulnerability, CVE-2023-5363 that can trigger warnings even though this image is not used to run any applications.

**What does this PR do?**
<!-- A brief description of the change being made with this pull request. -->

**Motivation:**
<!-- What inspired you to submit this pull request? -->

**Additional Notes:**
<!-- Anything else we should know when reviewing? -->

**How to test the change?**
<!--
Describe here how the change can be validated.
You are strongly encouraged to provide automated tests for this PR (unit or integration).
If this change cannot be feasibly tested, please explain why,
unless the change does not modify code (e.g. only modifies docs, comments).
-->

Unsure? Have a question? Request a review!
