### PR TITLE
GitHub: Update Labeler bot with new products

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -43,3 +43,15 @@ dev/ci:
 # Version bump pull request
 release:
   - all: [ '{CHANGELOG.md,lib/datadog/version.rb}' ]
+
+# Changes to OpenTelemetry
+otel:
+  - any: [ 'lib/datadog/opentelemetry/**' ]
+
+# Changes to Single Step Instrumentation
+single-step:
+  - any: [ 'lib-injection/**' ]
+
+# Changes to Single Step Instrumentation
+debugging:
+  - any: [ 'lib/datadog/debugging/**' ]

--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -52,6 +52,6 @@ otel:
 single-step:
   - any: [ 'lib-injection/**' ]
 
-# Changes to Single Step Instrumentation
+# Changes to Debugging
 debugging:
   - any: [ 'lib/datadog/debugging/**' ]


### PR DESCRIPTION
This PR updates the [Labeler GitHub bot](https://github.com/DataDog/dd-trace-rb/blob/master/.github/workflows/pull-request-labeler.yml) to tag some new directories created by recent products.

Having the correct labels help us craft a rich changelog file.
