### PR TITLE
Injection guard rails

### DIFF
--- a/lib-injection/host_inject.rb
+++ b/lib-injection/host_inject.rb
@@ -116,6 +116,7 @@ begin
 
   # Also apply to the environment variable, to guarantee any spawned processes will respected the modified `GEM_PATH`.
   ENV['GEM_PATH'] = Gem.path.join(':')
+  ENV['DD_INJECTION_ENABLED'] = 'true'
 rescue Exception => e
   warn "[datadog] Injection failed: #{e.class.name} #{e.message}\nBacktrace: #{e.backtrace.join("\n")}\n#{support_message}"
   ENV['DD_TRACE_SKIP_LIB_INJECTION'] = 'true'

--- a/lib-injection/host_inject.rb
+++ b/lib-injection/host_inject.rb
@@ -90,10 +90,12 @@ begin
     return # Skip injection
   end
 
-  _, status = Open3.capture2e({ 'DD_TRACE_SKIP_LIB_INJECTION' => 'true' }, 'bundle show datadog')
-  if status.success?
-    dd_debug_log 'Skip injection: already installed'
-    return
+  ['ddtrace', 'datadog'].each do |gem|
+    show_output, status = Open3.capture2e({ 'DD_TRACE_SKIP_LIB_INJECTION' => 'true' }, "bundle show #{gem}")
+    if status.success? && !show_output.include?("- exit -")
+      dd_debug_log 'Skip injection: already installed'
+      return
+    end
   end
 
   if Bundler.frozen_bundle?
@@ -139,9 +141,9 @@ begin
     'libddwaf',
     'datadog'
   ].each do |gem|
-    _show_output, show_status = Open3.capture2e({ 'DD_TRACE_SKIP_LIB_INJECTION' => 'true' }, "bundle show #{gem}")
+    show_output, show_status = Open3.capture2e({ 'DD_TRACE_SKIP_LIB_INJECTION' => 'true' }, "bundle show #{gem}")
 
-    if show_status.success?
+    if show_status.success? && !show_output.include?("- exit -")
       dd_debug_log "#{gem} already installed... skipping..."
       next
     end

--- a/lib-injection/host_inject.rb
+++ b/lib-injection/host_inject.rb
@@ -1,14 +1,4 @@
-# Keep in sync with auto_inject.rb
 return if ENV['DD_TRACE_SKIP_LIB_INJECTION'] == 'true'
-
-def debug_log(msg)
-  $stdout.puts msg if ENV['DD_TRACE_DEBUG'] == 'true'
-end
-
-def datadog_skip_injection
-  ENV['DD_TRACE_SKIP_LIB_INJECTION'] = 'true'
-  # Do something when skipping injection
-end
 
 begin
   require 'rubygems'
@@ -17,61 +7,107 @@ begin
   require 'bundler/cli'
   require 'shellwords'
   require 'fileutils'
+  require 'json'
+
+  def dd_debug_log(msg)
+    $stdout.puts "[datadog] #{msg}" if ENV['DD_TRACE_DEBUG'] == 'true'
+  end
+
+  def dd_error_log(msg)
+    warn "[datadog] #{msg}"
+  end
+
+  def dd_skip_injection!
+    ENV['DD_TRACE_SKIP_LIB_INJECTION'] = 'true'
+  end
+
+  def dd_send_telemetry(events)
+    pid = Process.respond_to?(:pid) ? Process.pid : 0 # Not available on all platforms
+
+    tracer_version = if File.exist?('/opt/datadog/apm/library/ruby/version.txt')
+                       File.read('/opt/datadog/apm/library/ruby/version.txt').chomp
+                     else
+                       'unknown'
+                     end
+
+    payload = {
+      metadata: {
+        language_name: 'ruby',
+        language_version: RUBY_VERSION,
+        runtime_name: RUBY_ENGINE,
+        runtime_version: RUBY_VERSION,
+        tracer_version: tracer_version,
+        pid: pid
+      },
+      points: Array(events)
+    }.to_json
+
+    output, = Open3.capture2e(ENV.fetch('DD_TELEMETRY_FORWARDER_PATH', 'cat'), stdin_data: payload)
+    dd_debug_log output
+  end
+
+  unless Bundler::SharedHelpers.in_bundle?
+    dd_debug_log 'Not in bundle... skipping injection'
+    return
+  end
 
   major, minor, = RUBY_VERSION.split('.')
   ruby_api_version = "#{major}.#{minor}.0"
   dd_lib_injection_path = "/opt/datadog/apm/library/ruby/#{ruby_api_version}"
-  debug_log "[datadog] Loading from #{dd_lib_injection_path}..."
-
-  if RUBY_ENGINE != 'ruby'
-    # Handle unsupported RUBY_ENGINE (Only supports `ruby`, not `jruby` or `truffleruby`)
-    return
-  end
+  dd_debug_log "Loading from #{dd_lib_injection_path}..."
 
   supported_ruby_api_versions = ['2.7.0', '3.0.0', '3.1.0', '3.2.0'].freeze
-  if supported_ruby_api_versions.none? { |v| ruby_api_version == v }
-    # Handle unsupported ruby api versions (Only supports `2.7.0`, `3.0.0`, `3.1.0`, and `3.2.0`)
-    return
+
+  # Handle unsupported runtimes
+  # - RUBY_ENGINE (Only supports `ruby`, not `jruby` or `truffleruby`)
+  # - ruby api versions (Only supports `2.7.0`, `3.0.0`, `3.1.0`, and `3.2.0`)
+  if RUBY_ENGINE != 'ruby' || supported_ruby_api_versions.none? { |v| ruby_api_version == v }
+    dd_send_telemetry(
+      [
+        { name: 'library_entrypoint.abort', tags: ['reason:incompatible_runtime}'] },
+        { name: 'library_entrypoint.abort.runtime' }
+      ]
+    )
+    dd_skip_injection!
+    return # Skip injection
   end
 
-  supported_architectures = ['x86_64', 'aarch64'].freeze
-  if supported_architectures.none? { |v| Gem::Platform.local.cpu == v }
-    # Handle unsupported architectures (Only supports `amd64` and `arm64`)
-    return
-  end
+  local_platform = Gem::Platform.local
+  platform_support_matrix = {
+    cpu: ['x86_64', 'aarch64'].freeze,
+    os: ['linux'].freeze,
+    version: ['gnu', nil].freeze # nil is equivalent to `gnu` for local platform
+  }
 
-  supported_oses = ['linux'].freeze
-  if supported_oses.none? { |v| Gem::Platform.local.os == v }
-    # Handle unsupported oses (Only supports `linux`)
-    return
-  end
+  if platform_support_matrix.fetch(:cpu).none? { |v| local_platform.cpu == v } ||
+      platform_support_matrix.fetch(:os).none? { |v| local_platform.os == v } ||
+      platform_support_matrix.fetch(:version).none? { |v| local_platform.version == v }
 
-  supported_versions = ['gnu', nil].freeze # nil is equivalent to `gnu` for local platform
-  if supported_versions.none? { |v| Gem::Platform.local.version == v }
-    # Handle unsupported libc version (Only supports `glibc`)
-    return
-  end
-
-  unless Bundler::SharedHelpers.in_bundle?
-    debug_log '[datadog] Not in bundle... skipping injection'
-    return
+    dd_debug_log "Platform check failed: #{local_platform}"
+    dd_send_telemetry({ name: 'library_entrypoint.abort', tags: ['reason:incompatible_platform}'] })
+    dd_skip_injection!
+    return # Skip injection
   end
 
   _, status = Open3.capture2e({ 'DD_TRACE_SKIP_LIB_INJECTION' => 'true' }, 'bundle show datadog')
   if status.success?
-    debug_log '[datadog] datadog already installed... skipping injection'
+    dd_debug_log 'Skip injection: already installed'
     return
   end
 
   if Bundler.frozen_bundle?
-    warn '[datadog] Injection failed: Unable to inject into a frozen Gemfile '\
-    '(Bundler is configured with `deployment` or `frozen`)'
+    dd_error_log "Skip injection: bundler is configured with 'deployment' or 'frozen'"
+
+    dd_send_telemetry({ name: 'library_entrypoint.abort', tags: ['reason:bundler'] })
+    dd_skip_injection!
     return
   end
 
   unless Bundler::CLI.commands['add'] && Bundler::CLI.commands['add'].options.key?('require')
-    warn "[datadog] Injection failed: Bundler version #{Bundler::VERSION} is not supported. "\
-      'Upgrade to Bundler >= 2.3 to enable injection.'
+    dd_error_log "Skip injection: bundler version #{Bundler::VERSION} is not supported, please upgrade to >= 2.3."
+
+    dd_send_telemetry({ name: 'library_entrypoint.abort', tags: ['reason:bundler_version'] })
+    dd_skip_injection!
     return
   end
 
@@ -93,14 +129,14 @@ begin
     _, status = Open3.capture2e({ 'DD_TRACE_SKIP_LIB_INJECTION' => 'true' }, "bundle show #{gem}")
 
     if status.success?
-      debug_log "[datadog] #{gem} already installed... skipping..."
+      dd_debug_log "#{gem} already installed... skipping..."
       next
     else
       bundle_add_cmd = "bundle add #{gem} --skip-install --version #{gem_version_mapping[gem]} "
 
       bundle_add_cmd << '--require datadog/auto_instrument' if gem == 'datadog'
 
-      debug_log "[datadog] Injection with `#{bundle_add_cmd}`"
+      dd_debug_log "Injection with `#{bundle_add_cmd}`"
 
       gemfile = Bundler::SharedHelpers.default_gemfile
       lockfile = Bundler::SharedHelpers.default_lockfile
@@ -113,24 +149,19 @@ begin
         ::FileUtils.cp gemfile, datadog_gemfile
         ::FileUtils.cp lockfile, datadog_lockfile
 
-        output, status = Open3.capture2e(
-          {
-            'BUNDLE_GEMFILE' => datadog_gemfile.to_s,
-            'DD_TRACE_SKIP_LIB_INJECTION' => 'true',
-            'GEM_PATH' => dd_lib_injection_path
-          },
-          bundle_add_cmd
-        )
+        env = { 'BUNDLE_GEMFILE' => datadog_gemfile.to_s,
+                'DD_TRACE_SKIP_LIB_INJECTION' => 'true',
+                'GEM_PATH' => dd_lib_injection_path }
+        output, status = Open3.capture2e(env, bundle_add_cmd)
 
         if status.success?
-          $stdout.puts "[datadog] Successfully injected #{gem} into the application."
+          dd_debug_log "Successfully injected #{gem} into the application."
 
           ::FileUtils.cp datadog_gemfile, gemfile
           ::FileUtils.cp datadog_lockfile, lockfile
         else
-          warn "[datadog] Injection failed: Unable to add datadog. Error output:\n#{output.split("\n").map do |l|
-            "[datadog] #{l}"
-          end.join("\n")}"
+          dd_error_log "Injection failed: Unable to add datadog. Error output: #{output}"
+          dd_send_telemetry({ name: 'library_entrypoint.error', tags: ['error_type:injection_failure'] })
         end
       ensure
         # Remove the copies
@@ -142,11 +173,19 @@ begin
 
   # Look for pre-installed tracers
   Gem.paths = { 'GEM_PATH' => "#{dd_lib_injection_path}:#{ENV['GEM_PATH']}" }
-
   # Also apply to the environment variable, to guarantee any spawned processes will respected the modified `GEM_PATH`.
   ENV['GEM_PATH'] = Gem.path.join(':')
-  ENV['DD_INJECTION_ENABLED'] = 'true'
+
+  dd_send_telemetry({ name: 'library_entrypoint.complete', tags: ['injection_forced:false'] })
 rescue Exception => e
+  if respond_to?(:dd_send_telemetry)
+    dd_send_telemetry(
+      { name: 'library_entrypoint.error',
+        tags: ["error_type:#{e.class.name}"] }
+    )
+  end
   warn "[datadog] Injection failed: #{e.class.name} #{e.message}\nBacktrace: #{e.backtrace.join("\n")}"
+
+  # Skip injection if the environment variable is set
   ENV['DD_TRACE_SKIP_LIB_INJECTION'] = 'true'
 end

--- a/lib-injection/host_inject.rb
+++ b/lib-injection/host_inject.rb
@@ -42,8 +42,7 @@ begin
       points: events
     }.to_json
 
-    output, = Open3.capture2e("#{ENV.fetch('DD_TELEMETRY_FORWARDER_PATH', 'echo')} library_entrypoint", stdin_data: payload)
-    dd_debug_log output
+    Open3.capture2e("#{ENV.fetch('DD_TELEMETRY_FORWARDER_PATH', 'echo')} library_entrypoint", stdin_data: payload)
   end
 
   unless Bundler::SharedHelpers.in_bundle?

--- a/lib-injection/host_inject.rb
+++ b/lib-injection/host_inject.rb
@@ -10,9 +10,7 @@ begin
   require 'json'
 
   def dd_debug_log(msg)
-    if ENV['DD_TRACE_DEBUG'] == 'true'
-      $stdout.puts "[datadog] #{msg}"
-    end
+    $stdout.puts "[datadog] #{msg}" if ENV['DD_TRACE_DEBUG'] == 'true'
   end
 
   def dd_error_log(msg)
@@ -91,8 +89,7 @@ begin
   end
 
   ['ddtrace', 'datadog'].each do |gem|
-    show_output, status = Open3.capture2e({ 'DD_TRACE_SKIP_LIB_INJECTION' => 'true' }, "bundle show #{gem}")
-    if status.success? && !show_output.include?("- exit -")
+    if (Bundler::CLI::Common.select_spec(gem) rescue false)
       dd_debug_log 'Skip injection: already installed'
       return
     end
@@ -141,9 +138,7 @@ begin
     'libddwaf',
     'datadog'
   ].each do |gem|
-    show_output, show_status = Open3.capture2e({ 'DD_TRACE_SKIP_LIB_INJECTION' => 'true' }, "bundle show #{gem}")
-
-    if show_status.success? && !show_output.include?("- exit -")
+    if (Bundler::CLI::Common.select_spec(gem) rescue false)
       dd_debug_log "#{gem} already installed... skipping..."
       next
     end

--- a/lib-injection/host_inject.rb
+++ b/lib-injection/host_inject.rb
@@ -42,7 +42,7 @@ begin
       points: events
     }.to_json
 
-    output, = Open3.capture2e(ENV.fetch('DD_TELEMETRY_FORWARDER_PATH', 'cat'), stdin_data: payload)
+    output, = Open3.capture2e("#{ENV.fetch('DD_TELEMETRY_FORWARDER_PATH', 'echo')} library_entrypoint", stdin_data: payload)
     dd_debug_log output
   end
 


### PR DESCRIPTION
**What does this PR do?**

This PR adds some guard rails for host injection

1. Checking  Ruby runtime
2. Checking Ruby platform
3. Send telemetry with the provided executable from `ENV['DD_TELEMETRY_FORWARDER_PATH']`

In additionally, 

1. Fix false positive result while checking whether the dependency exists in the bundle
2. Write to another Gemfile instead of the existing Gemfile and swap the bundled Gemfile in order to make lib injection transactional to prevent corrupted file. 