### PR TITLE
Add missing Apache 2.0 license from gemspec

### DIFF
--- a/datadog.gemspec
+++ b/datadog.gemspec
@@ -25,7 +25,7 @@ Gem::Specification.new do |spec|
   DESC
 
   spec.homepage = 'https://github.com/DataDog/dd-trace-rb'
-  spec.license  = 'BSD-3-Clause'
+  spec.licenses = ['BSD-3-Clause', 'Apache-2.0']
 
   if spec.respond_to?(:metadata)
     spec.metadata['allowed_push_host'] = 'https://rubygems.org'

--- a/spec/datadog/release_gem_spec.rb
+++ b/spec/datadog/release_gem_spec.rb
@@ -100,5 +100,11 @@ RSpec.describe 'gem release process' do
         )
       end
     end
+
+    context 'licenses' do
+      it 'returns dual licenses (BSD-3-Clause and Apache-2)' do
+        expect(gemspec.licenses).to contain_exactly('BSD-3-Clause', 'Apache-2.0')
+      end
+    end
   end
 end


### PR DESCRIPTION
**What does this PR do?**

Add missing `Apache 2` license in gemspec