### PR TITLE
Fix ffi version 1.16.3 in lib injection artifacts 

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -108,6 +108,9 @@ build-gem:
   script:
     - export RUBY_PACKAGE_VERSION=$(cat tmp/version.txt)
     - export DATADOG_GEM_LOCATION=$(readlink -f pkg/datadog-*.gem)
+    - ruby -v
+    - gem -v
+    - bundler -v
     - ruby .gitlab/install_datadog_deps.rb
   artifacts:
     paths:

--- a/.gitlab/Dockerfile-2.7.8
+++ b/.gitlab/Dockerfile-2.7.8
@@ -1,4 +1,5 @@
-# This is copied from official Docker image, but compile Ruby with `--disable-shared` instead.
+# This is copied from official Docker image
+# but compile Ruby with `--disable-shared` and update gem version
 
 FROM registry.ddbuild.io/images/mirror/buildpack-deps:buster
 
@@ -75,6 +76,9 @@ RUN set -eux; \
 # verify we have no "ruby" packages installed
 	if dpkg -l | grep -i ruby; then exit 1; fi; \
 	[ "$(command -v ruby)" = '/usr/local/bin/ruby' ]; \
+
+RUN gem update --system 3.3.27
+
 # rough smoke test
 	ruby --version; \
 	gem --version; \

--- a/.gitlab/Dockerfile-2.7.8
+++ b/.gitlab/Dockerfile-2.7.8
@@ -76,9 +76,8 @@ RUN set -eux; \
 # verify we have no "ruby" packages installed
 	if dpkg -l | grep -i ruby; then exit 1; fi; \
 	[ "$(command -v ruby)" = '/usr/local/bin/ruby' ]; \
-
-RUN gem update --system 3.3.27
-
+# update gem version
+	gem update --system 3.3.27;\
 # rough smoke test
 	ruby --version; \
 	gem --version; \

--- a/.gitlab/Dockerfile-3.0.6
+++ b/.gitlab/Dockerfile-3.0.6
@@ -76,9 +76,8 @@ RUN set -eux; \
 # verify we have no "ruby" packages installed
 	if dpkg -l | grep -i ruby; then exit 1; fi; \
 	[ "$(command -v ruby)" = '/usr/local/bin/ruby' ]; \
-
-RUN gem update --system
-
+# update gem version
+	gem update --system;\
 # rough smoke test
 	ruby --version; \
 	gem --version; \

--- a/.gitlab/Dockerfile-3.0.6
+++ b/.gitlab/Dockerfile-3.0.6
@@ -1,4 +1,5 @@
-# This is copied from official Docker image, but compile Ruby with `--disable-shared` instead.
+# This is copied from official Docker image
+# but compile Ruby with `--disable-shared` and update gem version
 
 FROM registry.ddbuild.io/images/mirror/buildpack-deps:buster
 
@@ -75,6 +76,9 @@ RUN set -eux; \
 # verify we have no "ruby" packages installed
 	if dpkg -l | grep -i ruby; then exit 1; fi; \
 	[ "$(command -v ruby)" = '/usr/local/bin/ruby' ]; \
+
+RUN gem update --system
+
 # rough smoke test
 	ruby --version; \
 	gem --version; \

--- a/.gitlab/Dockerfile-3.1.4
+++ b/.gitlab/Dockerfile-3.1.4
@@ -76,9 +76,8 @@ RUN set -eux; \
 # verify we have no "ruby" packages installed
 	if dpkg -l | grep -i ruby; then exit 1; fi; \
 	[ "$(command -v ruby)" = '/usr/local/bin/ruby' ]; \
-
-RUN gem update --system
-
+# update gem version
+	gem update --system;\
 # rough smoke test
 	ruby --version; \
 	gem --version; \

--- a/.gitlab/Dockerfile-3.1.4
+++ b/.gitlab/Dockerfile-3.1.4
@@ -1,4 +1,5 @@
-# This is copied from official Docker image, but compile Ruby with `--disable-shared` instead.
+# This is copied from official Docker image
+# but compile Ruby with `--disable-shared` and update gem version
 
 FROM registry.ddbuild.io/images/mirror/buildpack-deps:buster
 
@@ -75,6 +76,9 @@ RUN set -eux; \
 # verify we have no "ruby" packages installed
 	if dpkg -l | grep -i ruby; then exit 1; fi; \
 	[ "$(command -v ruby)" = '/usr/local/bin/ruby' ]; \
+
+RUN gem update --system
+
 # rough smoke test
 	ruby --version; \
 	gem --version; \

--- a/.gitlab/Dockerfile-3.2.2
+++ b/.gitlab/Dockerfile-3.2.2
@@ -1,4 +1,5 @@
-# This is copied from official Docker image, but compile Ruby with `--disable-shared` instead.
+# This is copied from official Docker image, but
+# compile Ruby with `--disable-shared` and update gem version
 
 FROM registry.ddbuild.io/images/mirror/buildpack-deps:buster
 
@@ -99,6 +100,9 @@ RUN set -eux; \
 # verify we have no "ruby" packages installed
 	if dpkg -l | grep -i ruby; then exit 1; fi; \
 	[ "$(command -v ruby)" = '/usr/local/bin/ruby' ]; \
+
+RUN gem update --system
+
 # rough smoke test
 	ruby --version; \
 	gem --version; \

--- a/.gitlab/Dockerfile-3.2.2
+++ b/.gitlab/Dockerfile-3.2.2
@@ -100,9 +100,8 @@ RUN set -eux; \
 # verify we have no "ruby" packages installed
 	if dpkg -l | grep -i ruby; then exit 1; fi; \
 	[ "$(command -v ruby)" = '/usr/local/bin/ruby' ]; \
-
-RUN gem update --system
-
+# update gem version
+	gem update --system;\
 # rough smoke test
 	ruby --version; \
 	gem --version; \

--- a/.gitlab/install_datadog_deps.rb
+++ b/.gitlab/install_datadog_deps.rb
@@ -33,6 +33,7 @@ gemfile_file_path = versioned_path.join('Gemfile')
 File.open(gemfile_file_path, 'w') do |file|
   file.write("source 'https://rubygems.org'\n")
   file.write("gem 'datadog', '#{ENV.fetch('RUBY_PACKAGE_VERSION')}', path: '#{current_path}'\n")
+  file.write("gem 'ffi', '1.16.3'\n")
   # Mimick outdated `msgpack` version, uncomment below line to test
   # file.write("gem 'msgpack', '1.6.0'\n")
 end
@@ -73,7 +74,6 @@ gem_version_mapping.each do |gem, version|
   case gem
   when 'ffi'
     gem_install_cmd << "--install-dir #{versioned_path} "
-    gem_install_cmd << "--platform ruby "
     # Install `ffi` gem with its built-in `libffi` native extension instead of using system's `libffi`
     gem_install_cmd << '-- --disable-system-libffi '
   when 'datadog'

--- a/.gitlab/install_datadog_deps.rb
+++ b/.gitlab/install_datadog_deps.rb
@@ -4,7 +4,21 @@ require 'bundler'
 require 'fileutils'
 require 'pathname'
 
+puts '=== RUBY_VERSION ==='
+puts RUBY_VERSION
+puts '=== RUBY_ENGINE ==='
+puts RUBY_ENGINE
+puts '=== RUBY_ENGINE_VERSION ==='
+puts RUBY_ENGINE_VERSION
+puts '=== RUBY_PLATFORM ==='
+puts RUBY_PLATFORM
+puts '=== GEM PLATFORM ==='
+puts Gem::Platform.local
+
 ruby_api_version = Gem.ruby_api_version
+
+puts '=== RUBY API VERISON ==='
+puts ruby_api_version
 
 current_path = Pathname.new(FileUtils.pwd)
 

--- a/.gitlab/install_datadog_deps.rb
+++ b/.gitlab/install_datadog_deps.rb
@@ -73,6 +73,7 @@ gem_version_mapping.each do |gem, version|
   case gem
   when 'ffi'
     gem_install_cmd << "--install-dir #{versioned_path} "
+    gem_install_cmd << "--platform ruby "
     # Install `ffi` gem with its built-in `libffi` native extension instead of using system's `libffi`
     gem_install_cmd << '-- --disable-system-libffi '
   when 'datadog'

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,5 @@
+{
+  "files.associations": {
+    "Dockerfile*": "dockerfile"
+  }
+}

--- a/spec/datadog/release_gem_spec.rb
+++ b/spec/datadog/release_gem_spec.rb
@@ -46,6 +46,7 @@ RSpec.describe 'gem release process' do
             |\.circleci
             |\.github
             |\.gitlab
+            |\.vscode
             |lib-injection
             |appraisal
             |benchmarks


### PR DESCRIPTION
**Motivation:**

`ffi` 1.17.0 ships binary gems for many platforms, which breaks our lib injection artifact pipeline.

https://github.com/ffi/ffi/blob/master/CHANGELOG.md#1170rc1--2024-04-08

The error was first discovered with 

```
ffi-1.17.0-x86_64-linux-musl requires rubygems version >= 3.3.22, which is
incompatible with the current version, 3.1.6
```

**What does this PR do?**

After updating the gem version in our images. Lib injection artifacts can be built but the injection won't work with error 

```
Jun 04 12:19:47 ip-172-29-134-46 bash[26468]: /var/lib/gems/3.0.0/gems/bundler-2.3.26/lib/bundler/definition.rb:507:in `materialize': Could not find ffi-1.17.0 in locally installed gems (Bundler::GemNotFound)
```

To mitigate this: lock `ffi` version with `1.16.3` for now