### PR TITLE
Update UpgradeGuide in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@
 
 ## Getting started
 
-**If you're upgrading from a 0.x version, check out our [upgrade guide](https://github.com/DataDog/dd-trace-rb/blob/master/docs/UpgradeGuide.md#from-0x-to-10).**
+**If you're upgrading from a 1.x version, check out the [upgrade guide](https://github.com/DataDog/dd-trace-rb/blob/release/docs/UpgradeGuide2.md).**
 
 For a product overview, installation, and configuration check out our [documentation][public docs].
 


### PR DESCRIPTION
Points to the 2.x guide instead of the 1.x guide.
