### PR TITLE
Add Ruby 3.3 to matrix target in test-yjit

### DIFF
--- a/.github/workflows/test-yjit.yaml
+++ b/.github/workflows/test-yjit.yaml
@@ -9,6 +9,7 @@ jobs:
           - ubuntu-latest
         ruby:
           - '3.2'
+          - '3.3'
           # ADD NEW RUBIES HERE
     name: Test (${{ matrix.os }}, ${{ matrix.ruby }})
     runs-on: ${{ matrix.os }}


### PR DESCRIPTION
Ruby 3.3 has already been released last year and has mayn improvement changes on yjit.
Thus, I added Ruby 3.3 to matrix test target in test-yjit.

https://github.com/ruby/ruby/blob/029d92b8988d26955d0622f0cbb8ef3213200749/doc/NEWS/NEWS-3.3.0.md?plain=1#L401