### PR TITLE
Remove obsolete 2.0 upgrade guide from PR template

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -5,17 +5,6 @@ for guidance on how to set up your development environment,
 run the test suite, write new integrations, and more.
 -->
 
-**2.0 Upgrade Guide notes**
-<!--
-(If this PR is for 1.x, please delete this section)
-If this PR introduces a breaking change, update the
-https://github.com/DataDog/dd-trace-rb/blob/2.0/docs/UpgradeGuide2.md
-in this PR with either:
-* A migration path for this change. In other words, how to continue using their application without behavior changes
-in 2.0 (e.g. environment variable 'X' renamed to 'Y').
-* That there's no alternative; we removed support for this feature.
--->
-
 **What does this PR do?**
 <!-- A brief description of the change being made with this pull request. -->
 


### PR DESCRIPTION
**What does this PR do?**

Remove 2.0 Upgrade guide section from PR template
