### PR TITLE
Add parametric system-tests workflow

### DIFF
--- a/.github/workflows/parametric-system-tests.yml
+++ b/.github/workflows/parametric-system-tests.yml
@@ -1,0 +1,74 @@
+name: Parametric System Tests
+
+on:
+  push:
+    branches:
+      - "**"
+  workflow_dispatch: {}
+  schedule:
+    - cron:  '00 04 * * 2-6'
+
+env:
+  REGISTRY: ghcr.io
+  REPO: ghcr.io/datadog/dd-trace-rb
+  ST_REF: main
+  FORCE_TESTS:
+
+jobs:
+  build-runner:
+    strategy:
+      fail-fast: false
+      matrix:
+        library:
+          - name: ruby
+            repository: DataDog/dd-trace-rb
+            path: dd-trace-rb
+    runs-on: ubuntu-latest
+    name: Run parametric system tests
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          repository: 'DataDog/system-tests'
+          ref: ${{ env.ST_REF }}
+      - name: Install python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.9"
+      - name: Install dependencies
+        uses: actions/cache@v4
+        id: runner_cache
+        with:
+          path: venv
+          key: runner_venv-${{ runner.os }}-${{ env.pythonLocation }}-${{ hashFiles('requirements.txt') }}
+      - name: Build runner
+        shell: bash
+        if: steps.runner_cache.outputs.cache-hit != 'true'
+        run: ./build.sh -i runner
+      - name: Print versions
+        shell: bash
+        run: |
+          source venv/bin/activate
+          python --version
+          pip freeze
+      - name: Checkout dd-trace-rb
+        uses: actions/checkout@v4
+        with:
+          repository: '${{ matrix.library.repository }}'
+          path: 'binaries/${{ matrix.library.path }}'
+          fetch-depth: 2
+      - name: Run parametric system tests
+        run: TEST_LIBRARY=ruby ./run.sh PARAMETRIC ${{ env.FORCE_TESTS }}
+      - name: Compress logs
+        id: compress_logs
+        if: always()
+        run: tar -czvf artifact.tar.gz $(ls | grep logs)
+      - name: Upload artifact
+        if: always() && steps.compress_logs.outcome == 'success'
+        uses: actions/upload-artifact@v4
+        with:
+          name: logs_parametric_${{ matrix.library}}_parametric_dev
+          path: artifact.tar.gz
+      - name: Print fancy log report
+        if: ${{ always() }}
+        run: python utils/scripts/markdown_logs.py >> $GITHUB_STEP_SUMMARY


### PR DESCRIPTION
**What does this PR do?**
<!-- A brief description of the change being made with this pull request. -->
This PR adds a GitHub workflow for parametrics system-tests

**Motivation:**
<!-- What inspired you to submit this pull request? -->
The SCA Env Var system-tests is run as a parametric test, and I wanted to test it on the CI.

**Additional Notes:**
<!-- Anything else we should know when reviewing? -->
The FORCE_TESTS env var does not work as the -F option on system-tests only work for the DEFAULT scenario right now.
There are currently 4 tests that needs to be fixed:

- [ ] tests/parametric/test_dynamic_configuration.py::TestDynamicConfigSamplingRules::test_trace_sampling_rules_with_tags
- [ ] tests/parametric/test_otel_span_methods.py::Test_Otel_Span_Methods::test_otel_span_started_with_link_from_datadog_headers
- [ ] tests/parametric/test_otel_span_methods.py::Test_Otel_Span_Methods::test_otel_span_started_with_link_from_w3c_headers
- [ ] tests/parametric/test_otel_span_methods.py::Test_Otel_Span_Methods::test_otel_span_started_with_link_from_other_spans
