### PR TITLE
Bump to version 2.1.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,16 @@
 
 ## [Unreleased]
 
+## [2.1.0] - 2024-06-10
+
+### Added
+
+* Tracing: Configuration by OpenTelemetry environment variables ([#3657][])
+
+### Fixed
+
+* Tracing: Improved compatibility with W3C Trace Context propagation ([#3631][])
+
 ## [2.0.0] - 2024-06-06
 
 ### Added
@@ -2894,7 +2904,8 @@ Release notes: https://github.com/DataDog/dd-trace-rb/releases/tag/v0.3.1
 Git diff: https://github.com/DataDog/dd-trace-rb/compare/v0.3.0...v0.3.1
 
 
-[Unreleased]: https://github.com/DataDog/dd-trace-rb/compare/v2.0.0...master
+[Unreleased]: https://github.com/DataDog/dd-trace-rb/compare/v2.1.0...master
+[2.1.0]: https://github.com/DataDog/dd-trace-rb/compare/v2.0.0...v2.1.0
 [2.0.0]: https://github.com/DataDog/dd-trace-rb/compare/v2.0.0.rc1...v2.0.0
 [2.0.0.rc1]: https://github.com/DataDog/dd-trace-rb/compare/v2.0.0.beta2...v2.0.0.rc1
 [1.23.0]: https://github.com/DataDog/dd-trace-rb/compare/v1.22.0...v1.23.0
@@ -4267,8 +4278,10 @@ Git diff: https://github.com/DataDog/dd-trace-rb/compare/v0.3.0...v0.3.1
 [#3624]: https://github.com/DataDog/dd-trace-rb/issues/3624
 [#3627]: https://github.com/DataDog/dd-trace-rb/issues/3627
 [#3630]: https://github.com/DataDog/dd-trace-rb/issues/3630
+[#3631]: https://github.com/DataDog/dd-trace-rb/issues/3631
 [#3645]: https://github.com/DataDog/dd-trace-rb/issues/3645
 [#3651]: https://github.com/DataDog/dd-trace-rb/issues/3651
+[#3657]: https://github.com/DataDog/dd-trace-rb/issues/3657
 [#3664]: https://github.com/DataDog/dd-trace-rb/issues/3664
 [@AdrianLC]: https://github.com/AdrianLC
 [@Azure7111]: https://github.com/Azure7111

--- a/gemfiles/jruby_9.2_activesupport.gemfile.lock
+++ b/gemfiles/jruby_9.2_activesupport.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    datadog (2.0.0)
+    datadog (2.1.0)
       debase-ruby_core_source (= 3.3.1)
       libdatadog (~> 9.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)

--- a/gemfiles/jruby_9.2_aws.gemfile.lock
+++ b/gemfiles/jruby_9.2_aws.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    datadog (2.0.0)
+    datadog (2.1.0)
       debase-ruby_core_source (= 3.3.1)
       libdatadog (~> 9.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)

--- a/gemfiles/jruby_9.2_contrib.gemfile.lock
+++ b/gemfiles/jruby_9.2_contrib.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    datadog (2.0.0)
+    datadog (2.1.0)
       debase-ruby_core_source (= 3.3.1)
       libdatadog (~> 9.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)

--- a/gemfiles/jruby_9.2_contrib_old.gemfile.lock
+++ b/gemfiles/jruby_9.2_contrib_old.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    datadog (2.0.0)
+    datadog (2.1.0)
       debase-ruby_core_source (= 3.3.1)
       libdatadog (~> 9.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)

--- a/gemfiles/jruby_9.2_core_old.gemfile.lock
+++ b/gemfiles/jruby_9.2_core_old.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    datadog (2.0.0)
+    datadog (2.1.0)
       debase-ruby_core_source (= 3.3.1)
       libdatadog (~> 9.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)

--- a/gemfiles/jruby_9.2_elasticsearch_7.gemfile.lock
+++ b/gemfiles/jruby_9.2_elasticsearch_7.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    datadog (2.0.0)
+    datadog (2.1.0)
       debase-ruby_core_source (= 3.3.1)
       libdatadog (~> 9.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)

--- a/gemfiles/jruby_9.2_elasticsearch_8.gemfile.lock
+++ b/gemfiles/jruby_9.2_elasticsearch_8.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    datadog (2.0.0)
+    datadog (2.1.0)
       debase-ruby_core_source (= 3.3.1)
       libdatadog (~> 9.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)

--- a/gemfiles/jruby_9.2_graphql_2.0.gemfile.lock
+++ b/gemfiles/jruby_9.2_graphql_2.0.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    datadog (2.0.0)
+    datadog (2.1.0)
       debase-ruby_core_source (= 3.3.1)
       libdatadog (~> 9.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)

--- a/gemfiles/jruby_9.2_http.gemfile.lock
+++ b/gemfiles/jruby_9.2_http.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    datadog (2.0.0)
+    datadog (2.1.0)
       debase-ruby_core_source (= 3.3.1)
       libdatadog (~> 9.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)

--- a/gemfiles/jruby_9.2_opensearch_2.gemfile.lock
+++ b/gemfiles/jruby_9.2_opensearch_2.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    datadog (2.0.0)
+    datadog (2.1.0)
       debase-ruby_core_source (= 3.3.1)
       libdatadog (~> 9.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)

--- a/gemfiles/jruby_9.2_opensearch_3.gemfile.lock
+++ b/gemfiles/jruby_9.2_opensearch_3.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    datadog (2.0.0)
+    datadog (2.1.0)
       debase-ruby_core_source (= 3.3.1)
       libdatadog (~> 9.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)

--- a/gemfiles/jruby_9.2_rack_1.gemfile.lock
+++ b/gemfiles/jruby_9.2_rack_1.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    datadog (2.0.0)
+    datadog (2.1.0)
       debase-ruby_core_source (= 3.3.1)
       libdatadog (~> 9.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)

--- a/gemfiles/jruby_9.2_rack_2.gemfile.lock
+++ b/gemfiles/jruby_9.2_rack_2.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    datadog (2.0.0)
+    datadog (2.1.0)
       debase-ruby_core_source (= 3.3.1)
       libdatadog (~> 9.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)

--- a/gemfiles/jruby_9.2_rack_3.gemfile.lock
+++ b/gemfiles/jruby_9.2_rack_3.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    datadog (2.0.0)
+    datadog (2.1.0)
       debase-ruby_core_source (= 3.3.1)
       libdatadog (~> 9.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)

--- a/gemfiles/jruby_9.2_rails5_mysql2.gemfile.lock
+++ b/gemfiles/jruby_9.2_rails5_mysql2.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    datadog (2.0.0)
+    datadog (2.1.0)
       debase-ruby_core_source (= 3.3.1)
       libdatadog (~> 9.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)

--- a/gemfiles/jruby_9.2_rails5_postgres.gemfile.lock
+++ b/gemfiles/jruby_9.2_rails5_postgres.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    datadog (2.0.0)
+    datadog (2.1.0)
       debase-ruby_core_source (= 3.3.1)
       libdatadog (~> 9.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)

--- a/gemfiles/jruby_9.2_rails5_postgres_redis.gemfile.lock
+++ b/gemfiles/jruby_9.2_rails5_postgres_redis.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    datadog (2.0.0)
+    datadog (2.1.0)
       debase-ruby_core_source (= 3.3.1)
       libdatadog (~> 9.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)

--- a/gemfiles/jruby_9.2_rails5_postgres_redis_activesupport.gemfile.lock
+++ b/gemfiles/jruby_9.2_rails5_postgres_redis_activesupport.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    datadog (2.0.0)
+    datadog (2.1.0)
       debase-ruby_core_source (= 3.3.1)
       libdatadog (~> 9.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)

--- a/gemfiles/jruby_9.2_rails5_postgres_sidekiq.gemfile.lock
+++ b/gemfiles/jruby_9.2_rails5_postgres_sidekiq.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    datadog (2.0.0)
+    datadog (2.1.0)
       debase-ruby_core_source (= 3.3.1)
       libdatadog (~> 9.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)

--- a/gemfiles/jruby_9.2_rails5_semantic_logger.gemfile.lock
+++ b/gemfiles/jruby_9.2_rails5_semantic_logger.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    datadog (2.0.0)
+    datadog (2.1.0)
       debase-ruby_core_source (= 3.3.1)
       libdatadog (~> 9.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)

--- a/gemfiles/jruby_9.2_rails61_mysql2.gemfile.lock
+++ b/gemfiles/jruby_9.2_rails61_mysql2.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    datadog (2.0.0)
+    datadog (2.1.0)
       debase-ruby_core_source (= 3.3.1)
       libdatadog (~> 9.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)

--- a/gemfiles/jruby_9.2_rails61_postgres.gemfile.lock
+++ b/gemfiles/jruby_9.2_rails61_postgres.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    datadog (2.0.0)
+    datadog (2.1.0)
       debase-ruby_core_source (= 3.3.1)
       libdatadog (~> 9.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)

--- a/gemfiles/jruby_9.2_rails61_postgres_redis.gemfile.lock
+++ b/gemfiles/jruby_9.2_rails61_postgres_redis.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    datadog (2.0.0)
+    datadog (2.1.0)
       debase-ruby_core_source (= 3.3.1)
       libdatadog (~> 9.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)

--- a/gemfiles/jruby_9.2_rails61_postgres_sidekiq.gemfile.lock
+++ b/gemfiles/jruby_9.2_rails61_postgres_sidekiq.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    datadog (2.0.0)
+    datadog (2.1.0)
       debase-ruby_core_source (= 3.3.1)
       libdatadog (~> 9.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)

--- a/gemfiles/jruby_9.2_rails61_semantic_logger.gemfile.lock
+++ b/gemfiles/jruby_9.2_rails61_semantic_logger.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    datadog (2.0.0)
+    datadog (2.1.0)
       debase-ruby_core_source (= 3.3.1)
       libdatadog (~> 9.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)

--- a/gemfiles/jruby_9.2_rails6_mysql2.gemfile.lock
+++ b/gemfiles/jruby_9.2_rails6_mysql2.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    datadog (2.0.0)
+    datadog (2.1.0)
       debase-ruby_core_source (= 3.3.1)
       libdatadog (~> 9.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)

--- a/gemfiles/jruby_9.2_rails6_postgres.gemfile.lock
+++ b/gemfiles/jruby_9.2_rails6_postgres.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    datadog (2.0.0)
+    datadog (2.1.0)
       debase-ruby_core_source (= 3.3.1)
       libdatadog (~> 9.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)

--- a/gemfiles/jruby_9.2_rails6_postgres_redis.gemfile.lock
+++ b/gemfiles/jruby_9.2_rails6_postgres_redis.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    datadog (2.0.0)
+    datadog (2.1.0)
       debase-ruby_core_source (= 3.3.1)
       libdatadog (~> 9.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)

--- a/gemfiles/jruby_9.2_rails6_postgres_redis_activesupport.gemfile.lock
+++ b/gemfiles/jruby_9.2_rails6_postgres_redis_activesupport.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    datadog (2.0.0)
+    datadog (2.1.0)
       debase-ruby_core_source (= 3.3.1)
       libdatadog (~> 9.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)

--- a/gemfiles/jruby_9.2_rails6_postgres_sidekiq.gemfile.lock
+++ b/gemfiles/jruby_9.2_rails6_postgres_sidekiq.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    datadog (2.0.0)
+    datadog (2.1.0)
       debase-ruby_core_source (= 3.3.1)
       libdatadog (~> 9.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)

--- a/gemfiles/jruby_9.2_rails6_semantic_logger.gemfile.lock
+++ b/gemfiles/jruby_9.2_rails6_semantic_logger.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    datadog (2.0.0)
+    datadog (2.1.0)
       debase-ruby_core_source (= 3.3.1)
       libdatadog (~> 9.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)

--- a/gemfiles/jruby_9.2_redis_3.gemfile.lock
+++ b/gemfiles/jruby_9.2_redis_3.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    datadog (2.0.0)
+    datadog (2.1.0)
       debase-ruby_core_source (= 3.3.1)
       libdatadog (~> 9.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)

--- a/gemfiles/jruby_9.2_redis_4.gemfile.lock
+++ b/gemfiles/jruby_9.2_redis_4.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    datadog (2.0.0)
+    datadog (2.1.0)
       debase-ruby_core_source (= 3.3.1)
       libdatadog (~> 9.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)

--- a/gemfiles/jruby_9.2_redis_5.gemfile.lock
+++ b/gemfiles/jruby_9.2_redis_5.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    datadog (2.0.0)
+    datadog (2.1.0)
       debase-ruby_core_source (= 3.3.1)
       libdatadog (~> 9.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)

--- a/gemfiles/jruby_9.2_relational_db.gemfile.lock
+++ b/gemfiles/jruby_9.2_relational_db.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    datadog (2.0.0)
+    datadog (2.1.0)
       debase-ruby_core_source (= 3.3.1)
       libdatadog (~> 9.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)

--- a/gemfiles/jruby_9.2_resque2_redis3.gemfile.lock
+++ b/gemfiles/jruby_9.2_resque2_redis3.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    datadog (2.0.0)
+    datadog (2.1.0)
       debase-ruby_core_source (= 3.3.1)
       libdatadog (~> 9.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)

--- a/gemfiles/jruby_9.2_resque2_redis4.gemfile.lock
+++ b/gemfiles/jruby_9.2_resque2_redis4.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    datadog (2.0.0)
+    datadog (2.1.0)
       debase-ruby_core_source (= 3.3.1)
       libdatadog (~> 9.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)

--- a/gemfiles/jruby_9.2_sinatra_2.gemfile.lock
+++ b/gemfiles/jruby_9.2_sinatra_2.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    datadog (2.0.0)
+    datadog (2.1.0)
       debase-ruby_core_source (= 3.3.1)
       libdatadog (~> 9.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)

--- a/gemfiles/jruby_9.3_activesupport.gemfile.lock
+++ b/gemfiles/jruby_9.3_activesupport.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    datadog (2.0.0)
+    datadog (2.1.0)
       debase-ruby_core_source (= 3.3.1)
       libdatadog (~> 9.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)

--- a/gemfiles/jruby_9.3_aws.gemfile.lock
+++ b/gemfiles/jruby_9.3_aws.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    datadog (2.0.0)
+    datadog (2.1.0)
       debase-ruby_core_source (= 3.3.1)
       libdatadog (~> 9.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)

--- a/gemfiles/jruby_9.3_contrib.gemfile.lock
+++ b/gemfiles/jruby_9.3_contrib.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    datadog (2.0.0)
+    datadog (2.1.0)
       debase-ruby_core_source (= 3.3.1)
       libdatadog (~> 9.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)

--- a/gemfiles/jruby_9.3_contrib_old.gemfile.lock
+++ b/gemfiles/jruby_9.3_contrib_old.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    datadog (2.0.0)
+    datadog (2.1.0)
       debase-ruby_core_source (= 3.3.1)
       libdatadog (~> 9.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)

--- a/gemfiles/jruby_9.3_core_old.gemfile.lock
+++ b/gemfiles/jruby_9.3_core_old.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    datadog (2.0.0)
+    datadog (2.1.0)
       debase-ruby_core_source (= 3.3.1)
       libdatadog (~> 9.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)

--- a/gemfiles/jruby_9.3_elasticsearch_7.gemfile.lock
+++ b/gemfiles/jruby_9.3_elasticsearch_7.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    datadog (2.0.0)
+    datadog (2.1.0)
       debase-ruby_core_source (= 3.3.1)
       libdatadog (~> 9.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)

--- a/gemfiles/jruby_9.3_elasticsearch_8.gemfile.lock
+++ b/gemfiles/jruby_9.3_elasticsearch_8.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    datadog (2.0.0)
+    datadog (2.1.0)
       debase-ruby_core_source (= 3.3.1)
       libdatadog (~> 9.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)

--- a/gemfiles/jruby_9.3_graphql_1.13.gemfile.lock
+++ b/gemfiles/jruby_9.3_graphql_1.13.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    datadog (2.0.0)
+    datadog (2.1.0)
       debase-ruby_core_source (= 3.3.1)
       libdatadog (~> 9.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)

--- a/gemfiles/jruby_9.3_graphql_2.0.gemfile.lock
+++ b/gemfiles/jruby_9.3_graphql_2.0.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    datadog (2.0.0)
+    datadog (2.1.0)
       debase-ruby_core_source (= 3.3.1)
       libdatadog (~> 9.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)

--- a/gemfiles/jruby_9.3_http.gemfile.lock
+++ b/gemfiles/jruby_9.3_http.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    datadog (2.0.0)
+    datadog (2.1.0)
       debase-ruby_core_source (= 3.3.1)
       libdatadog (~> 9.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)

--- a/gemfiles/jruby_9.3_opensearch_2.gemfile.lock
+++ b/gemfiles/jruby_9.3_opensearch_2.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    datadog (2.0.0)
+    datadog (2.1.0)
       debase-ruby_core_source (= 3.3.1)
       libdatadog (~> 9.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)

--- a/gemfiles/jruby_9.3_opensearch_3.gemfile.lock
+++ b/gemfiles/jruby_9.3_opensearch_3.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    datadog (2.0.0)
+    datadog (2.1.0)
       debase-ruby_core_source (= 3.3.1)
       libdatadog (~> 9.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)

--- a/gemfiles/jruby_9.3_rack_1.gemfile.lock
+++ b/gemfiles/jruby_9.3_rack_1.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    datadog (2.0.0)
+    datadog (2.1.0)
       debase-ruby_core_source (= 3.3.1)
       libdatadog (~> 9.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)

--- a/gemfiles/jruby_9.3_rack_2.gemfile.lock
+++ b/gemfiles/jruby_9.3_rack_2.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    datadog (2.0.0)
+    datadog (2.1.0)
       debase-ruby_core_source (= 3.3.1)
       libdatadog (~> 9.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)

--- a/gemfiles/jruby_9.3_rack_3.gemfile.lock
+++ b/gemfiles/jruby_9.3_rack_3.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    datadog (2.0.0)
+    datadog (2.1.0)
       debase-ruby_core_source (= 3.3.1)
       libdatadog (~> 9.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)

--- a/gemfiles/jruby_9.3_rails5_mysql2.gemfile.lock
+++ b/gemfiles/jruby_9.3_rails5_mysql2.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    datadog (2.0.0)
+    datadog (2.1.0)
       debase-ruby_core_source (= 3.3.1)
       libdatadog (~> 9.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)

--- a/gemfiles/jruby_9.3_rails5_postgres.gemfile.lock
+++ b/gemfiles/jruby_9.3_rails5_postgres.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    datadog (2.0.0)
+    datadog (2.1.0)
       debase-ruby_core_source (= 3.3.1)
       libdatadog (~> 9.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)

--- a/gemfiles/jruby_9.3_rails5_postgres_redis.gemfile.lock
+++ b/gemfiles/jruby_9.3_rails5_postgres_redis.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    datadog (2.0.0)
+    datadog (2.1.0)
       debase-ruby_core_source (= 3.3.1)
       libdatadog (~> 9.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)

--- a/gemfiles/jruby_9.3_rails5_postgres_redis_activesupport.gemfile.lock
+++ b/gemfiles/jruby_9.3_rails5_postgres_redis_activesupport.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    datadog (2.0.0)
+    datadog (2.1.0)
       debase-ruby_core_source (= 3.3.1)
       libdatadog (~> 9.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)

--- a/gemfiles/jruby_9.3_rails5_postgres_sidekiq.gemfile.lock
+++ b/gemfiles/jruby_9.3_rails5_postgres_sidekiq.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    datadog (2.0.0)
+    datadog (2.1.0)
       debase-ruby_core_source (= 3.3.1)
       libdatadog (~> 9.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)

--- a/gemfiles/jruby_9.3_rails5_semantic_logger.gemfile.lock
+++ b/gemfiles/jruby_9.3_rails5_semantic_logger.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    datadog (2.0.0)
+    datadog (2.1.0)
       debase-ruby_core_source (= 3.3.1)
       libdatadog (~> 9.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)

--- a/gemfiles/jruby_9.3_rails61_mysql2.gemfile.lock
+++ b/gemfiles/jruby_9.3_rails61_mysql2.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    datadog (2.0.0)
+    datadog (2.1.0)
       debase-ruby_core_source (= 3.3.1)
       libdatadog (~> 9.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)

--- a/gemfiles/jruby_9.3_rails61_postgres.gemfile.lock
+++ b/gemfiles/jruby_9.3_rails61_postgres.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    datadog (2.0.0)
+    datadog (2.1.0)
       debase-ruby_core_source (= 3.3.1)
       libdatadog (~> 9.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)

--- a/gemfiles/jruby_9.3_rails61_postgres_redis.gemfile.lock
+++ b/gemfiles/jruby_9.3_rails61_postgres_redis.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    datadog (2.0.0)
+    datadog (2.1.0)
       debase-ruby_core_source (= 3.3.1)
       libdatadog (~> 9.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)

--- a/gemfiles/jruby_9.3_rails61_postgres_sidekiq.gemfile.lock
+++ b/gemfiles/jruby_9.3_rails61_postgres_sidekiq.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    datadog (2.0.0)
+    datadog (2.1.0)
       debase-ruby_core_source (= 3.3.1)
       libdatadog (~> 9.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)

--- a/gemfiles/jruby_9.3_rails61_semantic_logger.gemfile.lock
+++ b/gemfiles/jruby_9.3_rails61_semantic_logger.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    datadog (2.0.0)
+    datadog (2.1.0)
       debase-ruby_core_source (= 3.3.1)
       libdatadog (~> 9.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)

--- a/gemfiles/jruby_9.3_rails6_mysql2.gemfile.lock
+++ b/gemfiles/jruby_9.3_rails6_mysql2.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    datadog (2.0.0)
+    datadog (2.1.0)
       debase-ruby_core_source (= 3.3.1)
       libdatadog (~> 9.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)

--- a/gemfiles/jruby_9.3_rails6_postgres.gemfile.lock
+++ b/gemfiles/jruby_9.3_rails6_postgres.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    datadog (2.0.0)
+    datadog (2.1.0)
       debase-ruby_core_source (= 3.3.1)
       libdatadog (~> 9.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)

--- a/gemfiles/jruby_9.3_rails6_postgres_redis.gemfile.lock
+++ b/gemfiles/jruby_9.3_rails6_postgres_redis.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    datadog (2.0.0)
+    datadog (2.1.0)
       debase-ruby_core_source (= 3.3.1)
       libdatadog (~> 9.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)

--- a/gemfiles/jruby_9.3_rails6_postgres_redis_activesupport.gemfile.lock
+++ b/gemfiles/jruby_9.3_rails6_postgres_redis_activesupport.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    datadog (2.0.0)
+    datadog (2.1.0)
       debase-ruby_core_source (= 3.3.1)
       libdatadog (~> 9.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)

--- a/gemfiles/jruby_9.3_rails6_postgres_sidekiq.gemfile.lock
+++ b/gemfiles/jruby_9.3_rails6_postgres_sidekiq.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    datadog (2.0.0)
+    datadog (2.1.0)
       debase-ruby_core_source (= 3.3.1)
       libdatadog (~> 9.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)

--- a/gemfiles/jruby_9.3_rails6_semantic_logger.gemfile.lock
+++ b/gemfiles/jruby_9.3_rails6_semantic_logger.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    datadog (2.0.0)
+    datadog (2.1.0)
       debase-ruby_core_source (= 3.3.1)
       libdatadog (~> 9.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)

--- a/gemfiles/jruby_9.3_redis_3.gemfile.lock
+++ b/gemfiles/jruby_9.3_redis_3.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    datadog (2.0.0)
+    datadog (2.1.0)
       debase-ruby_core_source (= 3.3.1)
       libdatadog (~> 9.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)

--- a/gemfiles/jruby_9.3_redis_4.gemfile.lock
+++ b/gemfiles/jruby_9.3_redis_4.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    datadog (2.0.0)
+    datadog (2.1.0)
       debase-ruby_core_source (= 3.3.1)
       libdatadog (~> 9.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)

--- a/gemfiles/jruby_9.3_redis_5.gemfile.lock
+++ b/gemfiles/jruby_9.3_redis_5.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    datadog (2.0.0)
+    datadog (2.1.0)
       debase-ruby_core_source (= 3.3.1)
       libdatadog (~> 9.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)

--- a/gemfiles/jruby_9.3_relational_db.gemfile.lock
+++ b/gemfiles/jruby_9.3_relational_db.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    datadog (2.0.0)
+    datadog (2.1.0)
       debase-ruby_core_source (= 3.3.1)
       libdatadog (~> 9.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)

--- a/gemfiles/jruby_9.3_resque2_redis3.gemfile.lock
+++ b/gemfiles/jruby_9.3_resque2_redis3.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    datadog (2.0.0)
+    datadog (2.1.0)
       debase-ruby_core_source (= 3.3.1)
       libdatadog (~> 9.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)

--- a/gemfiles/jruby_9.3_resque2_redis4.gemfile.lock
+++ b/gemfiles/jruby_9.3_resque2_redis4.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    datadog (2.0.0)
+    datadog (2.1.0)
       debase-ruby_core_source (= 3.3.1)
       libdatadog (~> 9.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)

--- a/gemfiles/jruby_9.3_sinatra_2.gemfile.lock
+++ b/gemfiles/jruby_9.3_sinatra_2.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    datadog (2.0.0)
+    datadog (2.1.0)
       debase-ruby_core_source (= 3.3.1)
       libdatadog (~> 9.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)

--- a/gemfiles/jruby_9.3_sinatra_3.gemfile.lock
+++ b/gemfiles/jruby_9.3_sinatra_3.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    datadog (2.0.0)
+    datadog (2.1.0)
       debase-ruby_core_source (= 3.3.1)
       libdatadog (~> 9.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)

--- a/gemfiles/jruby_9.4_activesupport.gemfile.lock
+++ b/gemfiles/jruby_9.4_activesupport.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    datadog (2.0.0)
+    datadog (2.1.0)
       debase-ruby_core_source (= 3.3.1)
       libdatadog (~> 9.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)

--- a/gemfiles/jruby_9.4_aws.gemfile.lock
+++ b/gemfiles/jruby_9.4_aws.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    datadog (2.0.0)
+    datadog (2.1.0)
       debase-ruby_core_source (= 3.3.1)
       libdatadog (~> 9.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)

--- a/gemfiles/jruby_9.4_contrib.gemfile.lock
+++ b/gemfiles/jruby_9.4_contrib.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    datadog (2.0.0)
+    datadog (2.1.0)
       debase-ruby_core_source (= 3.3.1)
       libdatadog (~> 9.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)

--- a/gemfiles/jruby_9.4_contrib_old.gemfile.lock
+++ b/gemfiles/jruby_9.4_contrib_old.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    datadog (2.0.0)
+    datadog (2.1.0)
       debase-ruby_core_source (= 3.3.1)
       libdatadog (~> 9.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)

--- a/gemfiles/jruby_9.4_core_old.gemfile.lock
+++ b/gemfiles/jruby_9.4_core_old.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    datadog (2.0.0)
+    datadog (2.1.0)
       debase-ruby_core_source (= 3.3.1)
       libdatadog (~> 9.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)

--- a/gemfiles/jruby_9.4_elasticsearch_7.gemfile.lock
+++ b/gemfiles/jruby_9.4_elasticsearch_7.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    datadog (2.0.0)
+    datadog (2.1.0)
       debase-ruby_core_source (= 3.3.1)
       libdatadog (~> 9.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)

--- a/gemfiles/jruby_9.4_elasticsearch_8.gemfile.lock
+++ b/gemfiles/jruby_9.4_elasticsearch_8.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    datadog (2.0.0)
+    datadog (2.1.0)
       debase-ruby_core_source (= 3.3.1)
       libdatadog (~> 9.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)

--- a/gemfiles/jruby_9.4_graphql_1.13.gemfile.lock
+++ b/gemfiles/jruby_9.4_graphql_1.13.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    datadog (2.0.0)
+    datadog (2.1.0)
       debase-ruby_core_source (= 3.3.1)
       libdatadog (~> 9.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)

--- a/gemfiles/jruby_9.4_graphql_2.0.gemfile.lock
+++ b/gemfiles/jruby_9.4_graphql_2.0.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    datadog (2.0.0)
+    datadog (2.1.0)
       debase-ruby_core_source (= 3.3.1)
       libdatadog (~> 9.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)

--- a/gemfiles/jruby_9.4_graphql_2.1.gemfile.lock
+++ b/gemfiles/jruby_9.4_graphql_2.1.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    datadog (2.0.0)
+    datadog (2.1.0)
       debase-ruby_core_source (= 3.3.1)
       libdatadog (~> 9.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)

--- a/gemfiles/jruby_9.4_graphql_2.2.gemfile.lock
+++ b/gemfiles/jruby_9.4_graphql_2.2.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    datadog (2.0.0)
+    datadog (2.1.0)
       debase-ruby_core_source (= 3.3.1)
       libdatadog (~> 9.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)

--- a/gemfiles/jruby_9.4_http.gemfile.lock
+++ b/gemfiles/jruby_9.4_http.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    datadog (2.0.0)
+    datadog (2.1.0)
       debase-ruby_core_source (= 3.3.1)
       libdatadog (~> 9.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)

--- a/gemfiles/jruby_9.4_opensearch_2.gemfile.lock
+++ b/gemfiles/jruby_9.4_opensearch_2.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    datadog (2.0.0)
+    datadog (2.1.0)
       debase-ruby_core_source (= 3.3.1)
       libdatadog (~> 9.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)

--- a/gemfiles/jruby_9.4_opensearch_3.gemfile.lock
+++ b/gemfiles/jruby_9.4_opensearch_3.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    datadog (2.0.0)
+    datadog (2.1.0)
       debase-ruby_core_source (= 3.3.1)
       libdatadog (~> 9.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)

--- a/gemfiles/jruby_9.4_rack_1.gemfile.lock
+++ b/gemfiles/jruby_9.4_rack_1.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    datadog (2.0.0)
+    datadog (2.1.0)
       debase-ruby_core_source (= 3.3.1)
       libdatadog (~> 9.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)

--- a/gemfiles/jruby_9.4_rack_2.gemfile.lock
+++ b/gemfiles/jruby_9.4_rack_2.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    datadog (2.0.0)
+    datadog (2.1.0)
       debase-ruby_core_source (= 3.3.1)
       libdatadog (~> 9.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)

--- a/gemfiles/jruby_9.4_rack_3.gemfile.lock
+++ b/gemfiles/jruby_9.4_rack_3.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    datadog (2.0.0)
+    datadog (2.1.0)
       debase-ruby_core_source (= 3.3.1)
       libdatadog (~> 9.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)

--- a/gemfiles/jruby_9.4_rails61_mysql2.gemfile.lock
+++ b/gemfiles/jruby_9.4_rails61_mysql2.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    datadog (2.0.0)
+    datadog (2.1.0)
       debase-ruby_core_source (= 3.3.1)
       libdatadog (~> 9.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)

--- a/gemfiles/jruby_9.4_rails61_postgres.gemfile.lock
+++ b/gemfiles/jruby_9.4_rails61_postgres.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    datadog (2.0.0)
+    datadog (2.1.0)
       debase-ruby_core_source (= 3.3.1)
       libdatadog (~> 9.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)

--- a/gemfiles/jruby_9.4_rails61_postgres_redis.gemfile.lock
+++ b/gemfiles/jruby_9.4_rails61_postgres_redis.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    datadog (2.0.0)
+    datadog (2.1.0)
       debase-ruby_core_source (= 3.3.1)
       libdatadog (~> 9.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)

--- a/gemfiles/jruby_9.4_rails61_postgres_sidekiq.gemfile.lock
+++ b/gemfiles/jruby_9.4_rails61_postgres_sidekiq.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    datadog (2.0.0)
+    datadog (2.1.0)
       debase-ruby_core_source (= 3.3.1)
       libdatadog (~> 9.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)

--- a/gemfiles/jruby_9.4_rails61_semantic_logger.gemfile.lock
+++ b/gemfiles/jruby_9.4_rails61_semantic_logger.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    datadog (2.0.0)
+    datadog (2.1.0)
       debase-ruby_core_source (= 3.3.1)
       libdatadog (~> 9.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)

--- a/gemfiles/jruby_9.4_redis_3.gemfile.lock
+++ b/gemfiles/jruby_9.4_redis_3.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    datadog (2.0.0)
+    datadog (2.1.0)
       debase-ruby_core_source (= 3.3.1)
       libdatadog (~> 9.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)

--- a/gemfiles/jruby_9.4_redis_4.gemfile.lock
+++ b/gemfiles/jruby_9.4_redis_4.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    datadog (2.0.0)
+    datadog (2.1.0)
       debase-ruby_core_source (= 3.3.1)
       libdatadog (~> 9.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)

--- a/gemfiles/jruby_9.4_redis_5.gemfile.lock
+++ b/gemfiles/jruby_9.4_redis_5.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    datadog (2.0.0)
+    datadog (2.1.0)
       debase-ruby_core_source (= 3.3.1)
       libdatadog (~> 9.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)

--- a/gemfiles/jruby_9.4_relational_db.gemfile.lock
+++ b/gemfiles/jruby_9.4_relational_db.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    datadog (2.0.0)
+    datadog (2.1.0)
       debase-ruby_core_source (= 3.3.1)
       libdatadog (~> 9.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)

--- a/gemfiles/jruby_9.4_resque2_redis3.gemfile.lock
+++ b/gemfiles/jruby_9.4_resque2_redis3.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    datadog (2.0.0)
+    datadog (2.1.0)
       debase-ruby_core_source (= 3.3.1)
       libdatadog (~> 9.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)

--- a/gemfiles/jruby_9.4_resque2_redis4.gemfile.lock
+++ b/gemfiles/jruby_9.4_resque2_redis4.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    datadog (2.0.0)
+    datadog (2.1.0)
       debase-ruby_core_source (= 3.3.1)
       libdatadog (~> 9.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)

--- a/gemfiles/jruby_9.4_sinatra_2.gemfile.lock
+++ b/gemfiles/jruby_9.4_sinatra_2.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    datadog (2.0.0)
+    datadog (2.1.0)
       debase-ruby_core_source (= 3.3.1)
       libdatadog (~> 9.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)

--- a/gemfiles/jruby_9.4_sinatra_3.gemfile.lock
+++ b/gemfiles/jruby_9.4_sinatra_3.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    datadog (2.0.0)
+    datadog (2.1.0)
       debase-ruby_core_source (= 3.3.1)
       libdatadog (~> 9.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)

--- a/gemfiles/jruby_9.4_sinatra_4.gemfile.lock
+++ b/gemfiles/jruby_9.4_sinatra_4.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    datadog (2.0.0)
+    datadog (2.1.0)
       debase-ruby_core_source (= 3.3.1)
       libdatadog (~> 9.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)

--- a/gemfiles/ruby_2.5_activesupport.gemfile.lock
+++ b/gemfiles/ruby_2.5_activesupport.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    datadog (2.0.0)
+    datadog (2.1.0)
       debase-ruby_core_source (= 3.3.1)
       libdatadog (~> 9.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)

--- a/gemfiles/ruby_2.5_aws.gemfile.lock
+++ b/gemfiles/ruby_2.5_aws.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    datadog (2.0.0)
+    datadog (2.1.0)
       debase-ruby_core_source (= 3.3.1)
       libdatadog (~> 9.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)

--- a/gemfiles/ruby_2.5_contrib.gemfile.lock
+++ b/gemfiles/ruby_2.5_contrib.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    datadog (2.0.0)
+    datadog (2.1.0)
       debase-ruby_core_source (= 3.3.1)
       libdatadog (~> 9.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)

--- a/gemfiles/ruby_2.5_contrib_old.gemfile.lock
+++ b/gemfiles/ruby_2.5_contrib_old.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    datadog (2.0.0)
+    datadog (2.1.0)
       debase-ruby_core_source (= 3.3.1)
       libdatadog (~> 9.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)

--- a/gemfiles/ruby_2.5_core_old.gemfile.lock
+++ b/gemfiles/ruby_2.5_core_old.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    datadog (2.0.0)
+    datadog (2.1.0)
       debase-ruby_core_source (= 3.3.1)
       libdatadog (~> 9.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)

--- a/gemfiles/ruby_2.5_elasticsearch_7.gemfile.lock
+++ b/gemfiles/ruby_2.5_elasticsearch_7.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    datadog (2.0.0)
+    datadog (2.1.0)
       debase-ruby_core_source (= 3.3.1)
       libdatadog (~> 9.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)

--- a/gemfiles/ruby_2.5_elasticsearch_8.gemfile.lock
+++ b/gemfiles/ruby_2.5_elasticsearch_8.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    datadog (2.0.0)
+    datadog (2.1.0)
       debase-ruby_core_source (= 3.3.1)
       libdatadog (~> 9.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)

--- a/gemfiles/ruby_2.5_graphql_2.0.gemfile.lock
+++ b/gemfiles/ruby_2.5_graphql_2.0.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    datadog (2.0.0)
+    datadog (2.1.0)
       debase-ruby_core_source (= 3.3.1)
       libdatadog (~> 9.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)

--- a/gemfiles/ruby_2.5_hanami_1.gemfile.lock
+++ b/gemfiles/ruby_2.5_hanami_1.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    datadog (2.0.0)
+    datadog (2.1.0)
       debase-ruby_core_source (= 3.3.1)
       libdatadog (~> 9.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)

--- a/gemfiles/ruby_2.5_http.gemfile.lock
+++ b/gemfiles/ruby_2.5_http.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    datadog (2.0.0)
+    datadog (2.1.0)
       debase-ruby_core_source (= 3.3.1)
       libdatadog (~> 9.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)

--- a/gemfiles/ruby_2.5_opensearch_2.gemfile.lock
+++ b/gemfiles/ruby_2.5_opensearch_2.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    datadog (2.0.0)
+    datadog (2.1.0)
       debase-ruby_core_source (= 3.3.1)
       libdatadog (~> 9.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)

--- a/gemfiles/ruby_2.5_opensearch_3.gemfile.lock
+++ b/gemfiles/ruby_2.5_opensearch_3.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    datadog (2.0.0)
+    datadog (2.1.0)
       debase-ruby_core_source (= 3.3.1)
       libdatadog (~> 9.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)

--- a/gemfiles/ruby_2.5_rack_1.gemfile.lock
+++ b/gemfiles/ruby_2.5_rack_1.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    datadog (2.0.0)
+    datadog (2.1.0)
       debase-ruby_core_source (= 3.3.1)
       libdatadog (~> 9.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)

--- a/gemfiles/ruby_2.5_rack_2.gemfile.lock
+++ b/gemfiles/ruby_2.5_rack_2.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    datadog (2.0.0)
+    datadog (2.1.0)
       debase-ruby_core_source (= 3.3.1)
       libdatadog (~> 9.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)

--- a/gemfiles/ruby_2.5_rack_3.gemfile.lock
+++ b/gemfiles/ruby_2.5_rack_3.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    datadog (2.0.0)
+    datadog (2.1.0)
       debase-ruby_core_source (= 3.3.1)
       libdatadog (~> 9.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)

--- a/gemfiles/ruby_2.5_rails4_mysql2.gemfile.lock
+++ b/gemfiles/ruby_2.5_rails4_mysql2.gemfile.lock
@@ -67,7 +67,7 @@ GIT
 PATH
   remote: ..
   specs:
-    datadog (2.0.0)
+    datadog (2.1.0)
       debase-ruby_core_source (= 3.3.1)
       libdatadog (~> 9.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)

--- a/gemfiles/ruby_2.5_rails4_postgres.gemfile.lock
+++ b/gemfiles/ruby_2.5_rails4_postgres.gemfile.lock
@@ -67,7 +67,7 @@ GIT
 PATH
   remote: ..
   specs:
-    datadog (2.0.0)
+    datadog (2.1.0)
       debase-ruby_core_source (= 3.3.1)
       libdatadog (~> 9.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)

--- a/gemfiles/ruby_2.5_rails4_postgres_redis.gemfile.lock
+++ b/gemfiles/ruby_2.5_rails4_postgres_redis.gemfile.lock
@@ -67,7 +67,7 @@ GIT
 PATH
   remote: ..
   specs:
-    datadog (2.0.0)
+    datadog (2.1.0)
       debase-ruby_core_source (= 3.3.1)
       libdatadog (~> 9.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)

--- a/gemfiles/ruby_2.5_rails4_postgres_sidekiq.gemfile.lock
+++ b/gemfiles/ruby_2.5_rails4_postgres_sidekiq.gemfile.lock
@@ -64,7 +64,7 @@ GIT
 PATH
   remote: ..
   specs:
-    datadog (2.0.0)
+    datadog (2.1.0)
       debase-ruby_core_source (= 3.3.1)
       libdatadog (~> 9.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)

--- a/gemfiles/ruby_2.5_rails4_semantic_logger.gemfile.lock
+++ b/gemfiles/ruby_2.5_rails4_semantic_logger.gemfile.lock
@@ -67,7 +67,7 @@ GIT
 PATH
   remote: ..
   specs:
-    datadog (2.0.0)
+    datadog (2.1.0)
       debase-ruby_core_source (= 3.3.1)
       libdatadog (~> 9.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)

--- a/gemfiles/ruby_2.5_rails5_mysql2.gemfile.lock
+++ b/gemfiles/ruby_2.5_rails5_mysql2.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    datadog (2.0.0)
+    datadog (2.1.0)
       debase-ruby_core_source (= 3.3.1)
       libdatadog (~> 9.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)

--- a/gemfiles/ruby_2.5_rails5_postgres.gemfile.lock
+++ b/gemfiles/ruby_2.5_rails5_postgres.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    datadog (2.0.0)
+    datadog (2.1.0)
       debase-ruby_core_source (= 3.3.1)
       libdatadog (~> 9.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)

--- a/gemfiles/ruby_2.5_rails5_postgres_redis.gemfile.lock
+++ b/gemfiles/ruby_2.5_rails5_postgres_redis.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    datadog (2.0.0)
+    datadog (2.1.0)
       debase-ruby_core_source (= 3.3.1)
       libdatadog (~> 9.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)

--- a/gemfiles/ruby_2.5_rails5_postgres_redis_activesupport.gemfile.lock
+++ b/gemfiles/ruby_2.5_rails5_postgres_redis_activesupport.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    datadog (2.0.0)
+    datadog (2.1.0)
       debase-ruby_core_source (= 3.3.1)
       libdatadog (~> 9.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)

--- a/gemfiles/ruby_2.5_rails5_postgres_sidekiq.gemfile.lock
+++ b/gemfiles/ruby_2.5_rails5_postgres_sidekiq.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    datadog (2.0.0)
+    datadog (2.1.0)
       debase-ruby_core_source (= 3.3.1)
       libdatadog (~> 9.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)

--- a/gemfiles/ruby_2.5_rails5_semantic_logger.gemfile.lock
+++ b/gemfiles/ruby_2.5_rails5_semantic_logger.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    datadog (2.0.0)
+    datadog (2.1.0)
       debase-ruby_core_source (= 3.3.1)
       libdatadog (~> 9.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)

--- a/gemfiles/ruby_2.5_rails61_mysql2.gemfile.lock
+++ b/gemfiles/ruby_2.5_rails61_mysql2.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    datadog (2.0.0)
+    datadog (2.1.0)
       debase-ruby_core_source (= 3.3.1)
       libdatadog (~> 9.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)

--- a/gemfiles/ruby_2.5_rails61_postgres.gemfile.lock
+++ b/gemfiles/ruby_2.5_rails61_postgres.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    datadog (2.0.0)
+    datadog (2.1.0)
       debase-ruby_core_source (= 3.3.1)
       libdatadog (~> 9.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)

--- a/gemfiles/ruby_2.5_rails61_postgres_redis.gemfile.lock
+++ b/gemfiles/ruby_2.5_rails61_postgres_redis.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    datadog (2.0.0)
+    datadog (2.1.0)
       debase-ruby_core_source (= 3.3.1)
       libdatadog (~> 9.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)

--- a/gemfiles/ruby_2.5_rails61_postgres_sidekiq.gemfile.lock
+++ b/gemfiles/ruby_2.5_rails61_postgres_sidekiq.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    datadog (2.0.0)
+    datadog (2.1.0)
       debase-ruby_core_source (= 3.3.1)
       libdatadog (~> 9.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)

--- a/gemfiles/ruby_2.5_rails61_semantic_logger.gemfile.lock
+++ b/gemfiles/ruby_2.5_rails61_semantic_logger.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    datadog (2.0.0)
+    datadog (2.1.0)
       debase-ruby_core_source (= 3.3.1)
       libdatadog (~> 9.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)

--- a/gemfiles/ruby_2.5_rails6_mysql2.gemfile.lock
+++ b/gemfiles/ruby_2.5_rails6_mysql2.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    datadog (2.0.0)
+    datadog (2.1.0)
       debase-ruby_core_source (= 3.3.1)
       libdatadog (~> 9.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)

--- a/gemfiles/ruby_2.5_rails6_postgres.gemfile.lock
+++ b/gemfiles/ruby_2.5_rails6_postgres.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    datadog (2.0.0)
+    datadog (2.1.0)
       debase-ruby_core_source (= 3.3.1)
       libdatadog (~> 9.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)

--- a/gemfiles/ruby_2.5_rails6_postgres_redis.gemfile.lock
+++ b/gemfiles/ruby_2.5_rails6_postgres_redis.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    datadog (2.0.0)
+    datadog (2.1.0)
       debase-ruby_core_source (= 3.3.1)
       libdatadog (~> 9.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)

--- a/gemfiles/ruby_2.5_rails6_postgres_redis_activesupport.gemfile.lock
+++ b/gemfiles/ruby_2.5_rails6_postgres_redis_activesupport.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    datadog (2.0.0)
+    datadog (2.1.0)
       debase-ruby_core_source (= 3.3.1)
       libdatadog (~> 9.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)

--- a/gemfiles/ruby_2.5_rails6_postgres_sidekiq.gemfile.lock
+++ b/gemfiles/ruby_2.5_rails6_postgres_sidekiq.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    datadog (2.0.0)
+    datadog (2.1.0)
       debase-ruby_core_source (= 3.3.1)
       libdatadog (~> 9.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)

--- a/gemfiles/ruby_2.5_rails6_semantic_logger.gemfile.lock
+++ b/gemfiles/ruby_2.5_rails6_semantic_logger.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    datadog (2.0.0)
+    datadog (2.1.0)
       debase-ruby_core_source (= 3.3.1)
       libdatadog (~> 9.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)

--- a/gemfiles/ruby_2.5_redis_3.gemfile.lock
+++ b/gemfiles/ruby_2.5_redis_3.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    datadog (2.0.0)
+    datadog (2.1.0)
       debase-ruby_core_source (= 3.3.1)
       libdatadog (~> 9.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)

--- a/gemfiles/ruby_2.5_redis_4.gemfile.lock
+++ b/gemfiles/ruby_2.5_redis_4.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    datadog (2.0.0)
+    datadog (2.1.0)
       debase-ruby_core_source (= 3.3.1)
       libdatadog (~> 9.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)

--- a/gemfiles/ruby_2.5_redis_5.gemfile.lock
+++ b/gemfiles/ruby_2.5_redis_5.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    datadog (2.0.0)
+    datadog (2.1.0)
       debase-ruby_core_source (= 3.3.1)
       libdatadog (~> 9.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)

--- a/gemfiles/ruby_2.5_relational_db.gemfile.lock
+++ b/gemfiles/ruby_2.5_relational_db.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    datadog (2.0.0)
+    datadog (2.1.0)
       debase-ruby_core_source (= 3.3.1)
       libdatadog (~> 9.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)

--- a/gemfiles/ruby_2.5_resque2_redis3.gemfile.lock
+++ b/gemfiles/ruby_2.5_resque2_redis3.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    datadog (2.0.0)
+    datadog (2.1.0)
       debase-ruby_core_source (= 3.3.1)
       libdatadog (~> 9.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)

--- a/gemfiles/ruby_2.5_resque2_redis4.gemfile.lock
+++ b/gemfiles/ruby_2.5_resque2_redis4.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    datadog (2.0.0)
+    datadog (2.1.0)
       debase-ruby_core_source (= 3.3.1)
       libdatadog (~> 9.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)

--- a/gemfiles/ruby_2.5_sinatra_2.gemfile.lock
+++ b/gemfiles/ruby_2.5_sinatra_2.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    datadog (2.0.0)
+    datadog (2.1.0)
       debase-ruby_core_source (= 3.3.1)
       libdatadog (~> 9.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)

--- a/gemfiles/ruby_2.6_activesupport.gemfile.lock
+++ b/gemfiles/ruby_2.6_activesupport.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    datadog (2.0.0)
+    datadog (2.1.0)
       debase-ruby_core_source (= 3.3.1)
       libdatadog (~> 9.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)

--- a/gemfiles/ruby_2.6_aws.gemfile.lock
+++ b/gemfiles/ruby_2.6_aws.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    datadog (2.0.0)
+    datadog (2.1.0)
       debase-ruby_core_source (= 3.3.1)
       libdatadog (~> 9.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)

--- a/gemfiles/ruby_2.6_contrib.gemfile.lock
+++ b/gemfiles/ruby_2.6_contrib.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    datadog (2.0.0)
+    datadog (2.1.0)
       debase-ruby_core_source (= 3.3.1)
       libdatadog (~> 9.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)

--- a/gemfiles/ruby_2.6_contrib_old.gemfile.lock
+++ b/gemfiles/ruby_2.6_contrib_old.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    datadog (2.0.0)
+    datadog (2.1.0)
       debase-ruby_core_source (= 3.3.1)
       libdatadog (~> 9.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)

--- a/gemfiles/ruby_2.6_core_old.gemfile.lock
+++ b/gemfiles/ruby_2.6_core_old.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    datadog (2.0.0)
+    datadog (2.1.0)
       debase-ruby_core_source (= 3.3.1)
       libdatadog (~> 9.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)

--- a/gemfiles/ruby_2.6_elasticsearch_7.gemfile.lock
+++ b/gemfiles/ruby_2.6_elasticsearch_7.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    datadog (2.0.0)
+    datadog (2.1.0)
       debase-ruby_core_source (= 3.3.1)
       libdatadog (~> 9.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)

--- a/gemfiles/ruby_2.6_elasticsearch_8.gemfile.lock
+++ b/gemfiles/ruby_2.6_elasticsearch_8.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    datadog (2.0.0)
+    datadog (2.1.0)
       debase-ruby_core_source (= 3.3.1)
       libdatadog (~> 9.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)

--- a/gemfiles/ruby_2.6_graphql_1.13.gemfile.lock
+++ b/gemfiles/ruby_2.6_graphql_1.13.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    datadog (2.0.0)
+    datadog (2.1.0)
       debase-ruby_core_source (= 3.3.1)
       libdatadog (~> 9.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)

--- a/gemfiles/ruby_2.6_graphql_2.0.gemfile.lock
+++ b/gemfiles/ruby_2.6_graphql_2.0.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    datadog (2.0.0)
+    datadog (2.1.0)
       debase-ruby_core_source (= 3.3.1)
       libdatadog (~> 9.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)

--- a/gemfiles/ruby_2.6_hanami_1.gemfile.lock
+++ b/gemfiles/ruby_2.6_hanami_1.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    datadog (2.0.0)
+    datadog (2.1.0)
       debase-ruby_core_source (= 3.3.1)
       libdatadog (~> 9.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)

--- a/gemfiles/ruby_2.6_http.gemfile.lock
+++ b/gemfiles/ruby_2.6_http.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    datadog (2.0.0)
+    datadog (2.1.0)
       debase-ruby_core_source (= 3.3.1)
       libdatadog (~> 9.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)

--- a/gemfiles/ruby_2.6_opensearch_2.gemfile.lock
+++ b/gemfiles/ruby_2.6_opensearch_2.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    datadog (2.0.0)
+    datadog (2.1.0)
       debase-ruby_core_source (= 3.3.1)
       libdatadog (~> 9.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)

--- a/gemfiles/ruby_2.6_opensearch_3.gemfile.lock
+++ b/gemfiles/ruby_2.6_opensearch_3.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    datadog (2.0.0)
+    datadog (2.1.0)
       debase-ruby_core_source (= 3.3.1)
       libdatadog (~> 9.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)

--- a/gemfiles/ruby_2.6_opentelemetry.gemfile.lock
+++ b/gemfiles/ruby_2.6_opentelemetry.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    datadog (2.0.0)
+    datadog (2.1.0)
       debase-ruby_core_source (= 3.3.1)
       libdatadog (~> 9.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)

--- a/gemfiles/ruby_2.6_rack_1.gemfile.lock
+++ b/gemfiles/ruby_2.6_rack_1.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    datadog (2.0.0)
+    datadog (2.1.0)
       debase-ruby_core_source (= 3.3.1)
       libdatadog (~> 9.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)

--- a/gemfiles/ruby_2.6_rack_2.gemfile.lock
+++ b/gemfiles/ruby_2.6_rack_2.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    datadog (2.0.0)
+    datadog (2.1.0)
       debase-ruby_core_source (= 3.3.1)
       libdatadog (~> 9.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)

--- a/gemfiles/ruby_2.6_rack_3.gemfile.lock
+++ b/gemfiles/ruby_2.6_rack_3.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    datadog (2.0.0)
+    datadog (2.1.0)
       debase-ruby_core_source (= 3.3.1)
       libdatadog (~> 9.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)

--- a/gemfiles/ruby_2.6_rails5_mysql2.gemfile.lock
+++ b/gemfiles/ruby_2.6_rails5_mysql2.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    datadog (2.0.0)
+    datadog (2.1.0)
       debase-ruby_core_source (= 3.3.1)
       libdatadog (~> 9.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)

--- a/gemfiles/ruby_2.6_rails5_postgres.gemfile.lock
+++ b/gemfiles/ruby_2.6_rails5_postgres.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    datadog (2.0.0)
+    datadog (2.1.0)
       debase-ruby_core_source (= 3.3.1)
       libdatadog (~> 9.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)

--- a/gemfiles/ruby_2.6_rails5_postgres_redis.gemfile.lock
+++ b/gemfiles/ruby_2.6_rails5_postgres_redis.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    datadog (2.0.0)
+    datadog (2.1.0)
       debase-ruby_core_source (= 3.3.1)
       libdatadog (~> 9.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)

--- a/gemfiles/ruby_2.6_rails5_postgres_redis_activesupport.gemfile.lock
+++ b/gemfiles/ruby_2.6_rails5_postgres_redis_activesupport.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    datadog (2.0.0)
+    datadog (2.1.0)
       debase-ruby_core_source (= 3.3.1)
       libdatadog (~> 9.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)

--- a/gemfiles/ruby_2.6_rails5_postgres_sidekiq.gemfile.lock
+++ b/gemfiles/ruby_2.6_rails5_postgres_sidekiq.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    datadog (2.0.0)
+    datadog (2.1.0)
       debase-ruby_core_source (= 3.3.1)
       libdatadog (~> 9.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)

--- a/gemfiles/ruby_2.6_rails5_semantic_logger.gemfile.lock
+++ b/gemfiles/ruby_2.6_rails5_semantic_logger.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    datadog (2.0.0)
+    datadog (2.1.0)
       debase-ruby_core_source (= 3.3.1)
       libdatadog (~> 9.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)

--- a/gemfiles/ruby_2.6_rails61_mysql2.gemfile.lock
+++ b/gemfiles/ruby_2.6_rails61_mysql2.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    datadog (2.0.0)
+    datadog (2.1.0)
       debase-ruby_core_source (= 3.3.1)
       libdatadog (~> 9.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)

--- a/gemfiles/ruby_2.6_rails61_postgres.gemfile.lock
+++ b/gemfiles/ruby_2.6_rails61_postgres.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    datadog (2.0.0)
+    datadog (2.1.0)
       debase-ruby_core_source (= 3.3.1)
       libdatadog (~> 9.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)

--- a/gemfiles/ruby_2.6_rails61_postgres_redis.gemfile.lock
+++ b/gemfiles/ruby_2.6_rails61_postgres_redis.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    datadog (2.0.0)
+    datadog (2.1.0)
       debase-ruby_core_source (= 3.3.1)
       libdatadog (~> 9.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)

--- a/gemfiles/ruby_2.6_rails61_postgres_sidekiq.gemfile.lock
+++ b/gemfiles/ruby_2.6_rails61_postgres_sidekiq.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    datadog (2.0.0)
+    datadog (2.1.0)
       debase-ruby_core_source (= 3.3.1)
       libdatadog (~> 9.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)

--- a/gemfiles/ruby_2.6_rails61_semantic_logger.gemfile.lock
+++ b/gemfiles/ruby_2.6_rails61_semantic_logger.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    datadog (2.0.0)
+    datadog (2.1.0)
       debase-ruby_core_source (= 3.3.1)
       libdatadog (~> 9.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)

--- a/gemfiles/ruby_2.6_rails6_mysql2.gemfile.lock
+++ b/gemfiles/ruby_2.6_rails6_mysql2.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    datadog (2.0.0)
+    datadog (2.1.0)
       debase-ruby_core_source (= 3.3.1)
       libdatadog (~> 9.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)

--- a/gemfiles/ruby_2.6_rails6_postgres.gemfile.lock
+++ b/gemfiles/ruby_2.6_rails6_postgres.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    datadog (2.0.0)
+    datadog (2.1.0)
       debase-ruby_core_source (= 3.3.1)
       libdatadog (~> 9.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)

--- a/gemfiles/ruby_2.6_rails6_postgres_redis.gemfile.lock
+++ b/gemfiles/ruby_2.6_rails6_postgres_redis.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    datadog (2.0.0)
+    datadog (2.1.0)
       debase-ruby_core_source (= 3.3.1)
       libdatadog (~> 9.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)

--- a/gemfiles/ruby_2.6_rails6_postgres_redis_activesupport.gemfile.lock
+++ b/gemfiles/ruby_2.6_rails6_postgres_redis_activesupport.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    datadog (2.0.0)
+    datadog (2.1.0)
       debase-ruby_core_source (= 3.3.1)
       libdatadog (~> 9.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)

--- a/gemfiles/ruby_2.6_rails6_postgres_sidekiq.gemfile.lock
+++ b/gemfiles/ruby_2.6_rails6_postgres_sidekiq.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    datadog (2.0.0)
+    datadog (2.1.0)
       debase-ruby_core_source (= 3.3.1)
       libdatadog (~> 9.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)

--- a/gemfiles/ruby_2.6_rails6_semantic_logger.gemfile.lock
+++ b/gemfiles/ruby_2.6_rails6_semantic_logger.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    datadog (2.0.0)
+    datadog (2.1.0)
       debase-ruby_core_source (= 3.3.1)
       libdatadog (~> 9.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)

--- a/gemfiles/ruby_2.6_redis_3.gemfile.lock
+++ b/gemfiles/ruby_2.6_redis_3.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    datadog (2.0.0)
+    datadog (2.1.0)
       debase-ruby_core_source (= 3.3.1)
       libdatadog (~> 9.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)

--- a/gemfiles/ruby_2.6_redis_4.gemfile.lock
+++ b/gemfiles/ruby_2.6_redis_4.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    datadog (2.0.0)
+    datadog (2.1.0)
       debase-ruby_core_source (= 3.3.1)
       libdatadog (~> 9.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)

--- a/gemfiles/ruby_2.6_redis_5.gemfile.lock
+++ b/gemfiles/ruby_2.6_redis_5.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    datadog (2.0.0)
+    datadog (2.1.0)
       debase-ruby_core_source (= 3.3.1)
       libdatadog (~> 9.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)

--- a/gemfiles/ruby_2.6_relational_db.gemfile.lock
+++ b/gemfiles/ruby_2.6_relational_db.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    datadog (2.0.0)
+    datadog (2.1.0)
       debase-ruby_core_source (= 3.3.1)
       libdatadog (~> 9.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)

--- a/gemfiles/ruby_2.6_resque2_redis3.gemfile.lock
+++ b/gemfiles/ruby_2.6_resque2_redis3.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    datadog (2.0.0)
+    datadog (2.1.0)
       debase-ruby_core_source (= 3.3.1)
       libdatadog (~> 9.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)

--- a/gemfiles/ruby_2.6_resque2_redis4.gemfile.lock
+++ b/gemfiles/ruby_2.6_resque2_redis4.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    datadog (2.0.0)
+    datadog (2.1.0)
       debase-ruby_core_source (= 3.3.1)
       libdatadog (~> 9.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)

--- a/gemfiles/ruby_2.6_sinatra_2.gemfile.lock
+++ b/gemfiles/ruby_2.6_sinatra_2.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    datadog (2.0.0)
+    datadog (2.1.0)
       debase-ruby_core_source (= 3.3.1)
       libdatadog (~> 9.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)

--- a/gemfiles/ruby_2.6_sinatra_3.gemfile.lock
+++ b/gemfiles/ruby_2.6_sinatra_3.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    datadog (2.0.0)
+    datadog (2.1.0)
       debase-ruby_core_source (= 3.3.1)
       libdatadog (~> 9.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)

--- a/gemfiles/ruby_2.7_activesupport.gemfile.lock
+++ b/gemfiles/ruby_2.7_activesupport.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    datadog (2.0.0)
+    datadog (2.1.0)
       debase-ruby_core_source (= 3.3.1)
       libdatadog (~> 9.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)

--- a/gemfiles/ruby_2.7_aws.gemfile.lock
+++ b/gemfiles/ruby_2.7_aws.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    datadog (2.0.0)
+    datadog (2.1.0)
       debase-ruby_core_source (= 3.3.1)
       libdatadog (~> 9.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)

--- a/gemfiles/ruby_2.7_contrib.gemfile.lock
+++ b/gemfiles/ruby_2.7_contrib.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    datadog (2.0.0)
+    datadog (2.1.0)
       debase-ruby_core_source (= 3.3.1)
       libdatadog (~> 9.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)

--- a/gemfiles/ruby_2.7_contrib_old.gemfile.lock
+++ b/gemfiles/ruby_2.7_contrib_old.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    datadog (2.0.0)
+    datadog (2.1.0)
       debase-ruby_core_source (= 3.3.1)
       libdatadog (~> 9.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)

--- a/gemfiles/ruby_2.7_core_old.gemfile.lock
+++ b/gemfiles/ruby_2.7_core_old.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    datadog (2.0.0)
+    datadog (2.1.0)
       debase-ruby_core_source (= 3.3.1)
       libdatadog (~> 9.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)

--- a/gemfiles/ruby_2.7_elasticsearch_7.gemfile.lock
+++ b/gemfiles/ruby_2.7_elasticsearch_7.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    datadog (2.0.0)
+    datadog (2.1.0)
       debase-ruby_core_source (= 3.3.1)
       libdatadog (~> 9.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)

--- a/gemfiles/ruby_2.7_elasticsearch_8.gemfile.lock
+++ b/gemfiles/ruby_2.7_elasticsearch_8.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    datadog (2.0.0)
+    datadog (2.1.0)
       debase-ruby_core_source (= 3.3.1)
       libdatadog (~> 9.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)

--- a/gemfiles/ruby_2.7_graphql_1.13.gemfile.lock
+++ b/gemfiles/ruby_2.7_graphql_1.13.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    datadog (2.0.0)
+    datadog (2.1.0)
       debase-ruby_core_source (= 3.3.1)
       libdatadog (~> 9.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)

--- a/gemfiles/ruby_2.7_graphql_2.0.gemfile.lock
+++ b/gemfiles/ruby_2.7_graphql_2.0.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    datadog (2.0.0)
+    datadog (2.1.0)
       debase-ruby_core_source (= 3.3.1)
       libdatadog (~> 9.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)

--- a/gemfiles/ruby_2.7_graphql_2.1.gemfile.lock
+++ b/gemfiles/ruby_2.7_graphql_2.1.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    datadog (2.0.0)
+    datadog (2.1.0)
       debase-ruby_core_source (= 3.3.1)
       libdatadog (~> 9.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)

--- a/gemfiles/ruby_2.7_graphql_2.2.gemfile.lock
+++ b/gemfiles/ruby_2.7_graphql_2.2.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    datadog (2.0.0)
+    datadog (2.1.0)
       debase-ruby_core_source (= 3.3.1)
       libdatadog (~> 9.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)

--- a/gemfiles/ruby_2.7_hanami_1.gemfile.lock
+++ b/gemfiles/ruby_2.7_hanami_1.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    datadog (2.0.0)
+    datadog (2.1.0)
       debase-ruby_core_source (= 3.3.1)
       libdatadog (~> 9.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)

--- a/gemfiles/ruby_2.7_http.gemfile.lock
+++ b/gemfiles/ruby_2.7_http.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    datadog (2.0.0)
+    datadog (2.1.0)
       debase-ruby_core_source (= 3.3.1)
       libdatadog (~> 9.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)

--- a/gemfiles/ruby_2.7_opensearch_2.gemfile.lock
+++ b/gemfiles/ruby_2.7_opensearch_2.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    datadog (2.0.0)
+    datadog (2.1.0)
       debase-ruby_core_source (= 3.3.1)
       libdatadog (~> 9.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)

--- a/gemfiles/ruby_2.7_opensearch_3.gemfile.lock
+++ b/gemfiles/ruby_2.7_opensearch_3.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    datadog (2.0.0)
+    datadog (2.1.0)
       debase-ruby_core_source (= 3.3.1)
       libdatadog (~> 9.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)

--- a/gemfiles/ruby_2.7_opentelemetry.gemfile.lock
+++ b/gemfiles/ruby_2.7_opentelemetry.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    datadog (2.0.0)
+    datadog (2.1.0)
       debase-ruby_core_source (= 3.3.1)
       libdatadog (~> 9.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)

--- a/gemfiles/ruby_2.7_rack_1.gemfile.lock
+++ b/gemfiles/ruby_2.7_rack_1.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    datadog (2.0.0)
+    datadog (2.1.0)
       debase-ruby_core_source (= 3.3.1)
       libdatadog (~> 9.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)

--- a/gemfiles/ruby_2.7_rack_2.gemfile.lock
+++ b/gemfiles/ruby_2.7_rack_2.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    datadog (2.0.0)
+    datadog (2.1.0)
       debase-ruby_core_source (= 3.3.1)
       libdatadog (~> 9.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)

--- a/gemfiles/ruby_2.7_rack_3.gemfile.lock
+++ b/gemfiles/ruby_2.7_rack_3.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    datadog (2.0.0)
+    datadog (2.1.0)
       debase-ruby_core_source (= 3.3.1)
       libdatadog (~> 9.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)

--- a/gemfiles/ruby_2.7_rails5_mysql2.gemfile.lock
+++ b/gemfiles/ruby_2.7_rails5_mysql2.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    datadog (2.0.0)
+    datadog (2.1.0)
       debase-ruby_core_source (= 3.3.1)
       libdatadog (~> 9.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)

--- a/gemfiles/ruby_2.7_rails5_postgres.gemfile.lock
+++ b/gemfiles/ruby_2.7_rails5_postgres.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    datadog (2.0.0)
+    datadog (2.1.0)
       debase-ruby_core_source (= 3.3.1)
       libdatadog (~> 9.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)

--- a/gemfiles/ruby_2.7_rails5_postgres_redis.gemfile.lock
+++ b/gemfiles/ruby_2.7_rails5_postgres_redis.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    datadog (2.0.0)
+    datadog (2.1.0)
       debase-ruby_core_source (= 3.3.1)
       libdatadog (~> 9.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)

--- a/gemfiles/ruby_2.7_rails5_postgres_redis_activesupport.gemfile.lock
+++ b/gemfiles/ruby_2.7_rails5_postgres_redis_activesupport.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    datadog (2.0.0)
+    datadog (2.1.0)
       debase-ruby_core_source (= 3.3.1)
       libdatadog (~> 9.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)

--- a/gemfiles/ruby_2.7_rails5_postgres_sidekiq.gemfile.lock
+++ b/gemfiles/ruby_2.7_rails5_postgres_sidekiq.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    datadog (2.0.0)
+    datadog (2.1.0)
       debase-ruby_core_source (= 3.3.1)
       libdatadog (~> 9.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)

--- a/gemfiles/ruby_2.7_rails5_semantic_logger.gemfile.lock
+++ b/gemfiles/ruby_2.7_rails5_semantic_logger.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    datadog (2.0.0)
+    datadog (2.1.0)
       debase-ruby_core_source (= 3.3.1)
       libdatadog (~> 9.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)

--- a/gemfiles/ruby_2.7_rails61_mysql2.gemfile.lock
+++ b/gemfiles/ruby_2.7_rails61_mysql2.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    datadog (2.0.0)
+    datadog (2.1.0)
       debase-ruby_core_source (= 3.3.1)
       libdatadog (~> 9.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)

--- a/gemfiles/ruby_2.7_rails61_postgres.gemfile.lock
+++ b/gemfiles/ruby_2.7_rails61_postgres.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    datadog (2.0.0)
+    datadog (2.1.0)
       debase-ruby_core_source (= 3.3.1)
       libdatadog (~> 9.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)

--- a/gemfiles/ruby_2.7_rails61_postgres_redis.gemfile.lock
+++ b/gemfiles/ruby_2.7_rails61_postgres_redis.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    datadog (2.0.0)
+    datadog (2.1.0)
       debase-ruby_core_source (= 3.3.1)
       libdatadog (~> 9.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)

--- a/gemfiles/ruby_2.7_rails61_postgres_sidekiq.gemfile.lock
+++ b/gemfiles/ruby_2.7_rails61_postgres_sidekiq.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    datadog (2.0.0)
+    datadog (2.1.0)
       debase-ruby_core_source (= 3.3.1)
       libdatadog (~> 9.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)

--- a/gemfiles/ruby_2.7_rails61_semantic_logger.gemfile.lock
+++ b/gemfiles/ruby_2.7_rails61_semantic_logger.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    datadog (2.0.0)
+    datadog (2.1.0)
       debase-ruby_core_source (= 3.3.1)
       libdatadog (~> 9.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)

--- a/gemfiles/ruby_2.7_rails6_mysql2.gemfile.lock
+++ b/gemfiles/ruby_2.7_rails6_mysql2.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    datadog (2.0.0)
+    datadog (2.1.0)
       debase-ruby_core_source (= 3.3.1)
       libdatadog (~> 9.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)

--- a/gemfiles/ruby_2.7_rails6_postgres.gemfile.lock
+++ b/gemfiles/ruby_2.7_rails6_postgres.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    datadog (2.0.0)
+    datadog (2.1.0)
       debase-ruby_core_source (= 3.3.1)
       libdatadog (~> 9.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)

--- a/gemfiles/ruby_2.7_rails6_postgres_redis.gemfile.lock
+++ b/gemfiles/ruby_2.7_rails6_postgres_redis.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    datadog (2.0.0)
+    datadog (2.1.0)
       debase-ruby_core_source (= 3.3.1)
       libdatadog (~> 9.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)

--- a/gemfiles/ruby_2.7_rails6_postgres_redis_activesupport.gemfile.lock
+++ b/gemfiles/ruby_2.7_rails6_postgres_redis_activesupport.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    datadog (2.0.0)
+    datadog (2.1.0)
       debase-ruby_core_source (= 3.3.1)
       libdatadog (~> 9.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)

--- a/gemfiles/ruby_2.7_rails6_postgres_sidekiq.gemfile.lock
+++ b/gemfiles/ruby_2.7_rails6_postgres_sidekiq.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    datadog (2.0.0)
+    datadog (2.1.0)
       debase-ruby_core_source (= 3.3.1)
       libdatadog (~> 9.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)

--- a/gemfiles/ruby_2.7_rails6_semantic_logger.gemfile.lock
+++ b/gemfiles/ruby_2.7_rails6_semantic_logger.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    datadog (2.0.0)
+    datadog (2.1.0)
       debase-ruby_core_source (= 3.3.1)
       libdatadog (~> 9.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)

--- a/gemfiles/ruby_2.7_redis_3.gemfile.lock
+++ b/gemfiles/ruby_2.7_redis_3.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    datadog (2.0.0)
+    datadog (2.1.0)
       debase-ruby_core_source (= 3.3.1)
       libdatadog (~> 9.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)

--- a/gemfiles/ruby_2.7_redis_4.gemfile.lock
+++ b/gemfiles/ruby_2.7_redis_4.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    datadog (2.0.0)
+    datadog (2.1.0)
       debase-ruby_core_source (= 3.3.1)
       libdatadog (~> 9.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)

--- a/gemfiles/ruby_2.7_redis_5.gemfile.lock
+++ b/gemfiles/ruby_2.7_redis_5.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    datadog (2.0.0)
+    datadog (2.1.0)
       debase-ruby_core_source (= 3.3.1)
       libdatadog (~> 9.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)

--- a/gemfiles/ruby_2.7_relational_db.gemfile.lock
+++ b/gemfiles/ruby_2.7_relational_db.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    datadog (2.0.0)
+    datadog (2.1.0)
       debase-ruby_core_source (= 3.3.1)
       libdatadog (~> 9.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)

--- a/gemfiles/ruby_2.7_resque2_redis3.gemfile.lock
+++ b/gemfiles/ruby_2.7_resque2_redis3.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    datadog (2.0.0)
+    datadog (2.1.0)
       debase-ruby_core_source (= 3.3.1)
       libdatadog (~> 9.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)

--- a/gemfiles/ruby_2.7_resque2_redis4.gemfile.lock
+++ b/gemfiles/ruby_2.7_resque2_redis4.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    datadog (2.0.0)
+    datadog (2.1.0)
       debase-ruby_core_source (= 3.3.1)
       libdatadog (~> 9.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)

--- a/gemfiles/ruby_2.7_sinatra_2.gemfile.lock
+++ b/gemfiles/ruby_2.7_sinatra_2.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    datadog (2.0.0)
+    datadog (2.1.0)
       debase-ruby_core_source (= 3.3.1)
       libdatadog (~> 9.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)

--- a/gemfiles/ruby_2.7_sinatra_3.gemfile.lock
+++ b/gemfiles/ruby_2.7_sinatra_3.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    datadog (2.0.0)
+    datadog (2.1.0)
       debase-ruby_core_source (= 3.3.1)
       libdatadog (~> 9.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)

--- a/gemfiles/ruby_3.0_activesupport.gemfile.lock
+++ b/gemfiles/ruby_3.0_activesupport.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    datadog (2.0.0)
+    datadog (2.1.0)
       debase-ruby_core_source (= 3.3.1)
       libdatadog (~> 9.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)

--- a/gemfiles/ruby_3.0_aws.gemfile.lock
+++ b/gemfiles/ruby_3.0_aws.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    datadog (2.0.0)
+    datadog (2.1.0)
       debase-ruby_core_source (= 3.3.1)
       libdatadog (~> 9.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)

--- a/gemfiles/ruby_3.0_contrib.gemfile.lock
+++ b/gemfiles/ruby_3.0_contrib.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    datadog (2.0.0)
+    datadog (2.1.0)
       debase-ruby_core_source (= 3.3.1)
       libdatadog (~> 9.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)

--- a/gemfiles/ruby_3.0_contrib_old.gemfile.lock
+++ b/gemfiles/ruby_3.0_contrib_old.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    datadog (2.0.0)
+    datadog (2.1.0)
       debase-ruby_core_source (= 3.3.1)
       libdatadog (~> 9.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)

--- a/gemfiles/ruby_3.0_core_old.gemfile.lock
+++ b/gemfiles/ruby_3.0_core_old.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    datadog (2.0.0)
+    datadog (2.1.0)
       debase-ruby_core_source (= 3.3.1)
       libdatadog (~> 9.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)

--- a/gemfiles/ruby_3.0_elasticsearch_7.gemfile.lock
+++ b/gemfiles/ruby_3.0_elasticsearch_7.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    datadog (2.0.0)
+    datadog (2.1.0)
       debase-ruby_core_source (= 3.3.1)
       libdatadog (~> 9.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)

--- a/gemfiles/ruby_3.0_elasticsearch_8.gemfile.lock
+++ b/gemfiles/ruby_3.0_elasticsearch_8.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    datadog (2.0.0)
+    datadog (2.1.0)
       debase-ruby_core_source (= 3.3.1)
       libdatadog (~> 9.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)

--- a/gemfiles/ruby_3.0_graphql_1.13.gemfile.lock
+++ b/gemfiles/ruby_3.0_graphql_1.13.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    datadog (2.0.0)
+    datadog (2.1.0)
       debase-ruby_core_source (= 3.3.1)
       libdatadog (~> 9.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)

--- a/gemfiles/ruby_3.0_graphql_2.0.gemfile.lock
+++ b/gemfiles/ruby_3.0_graphql_2.0.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    datadog (2.0.0)
+    datadog (2.1.0)
       debase-ruby_core_source (= 3.3.1)
       libdatadog (~> 9.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)

--- a/gemfiles/ruby_3.0_graphql_2.1.gemfile.lock
+++ b/gemfiles/ruby_3.0_graphql_2.1.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    datadog (2.0.0)
+    datadog (2.1.0)
       debase-ruby_core_source (= 3.3.1)
       libdatadog (~> 9.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)

--- a/gemfiles/ruby_3.0_graphql_2.2.gemfile.lock
+++ b/gemfiles/ruby_3.0_graphql_2.2.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    datadog (2.0.0)
+    datadog (2.1.0)
       debase-ruby_core_source (= 3.3.1)
       libdatadog (~> 9.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)

--- a/gemfiles/ruby_3.0_http.gemfile.lock
+++ b/gemfiles/ruby_3.0_http.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    datadog (2.0.0)
+    datadog (2.1.0)
       debase-ruby_core_source (= 3.3.1)
       libdatadog (~> 9.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)

--- a/gemfiles/ruby_3.0_opensearch_2.gemfile.lock
+++ b/gemfiles/ruby_3.0_opensearch_2.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    datadog (2.0.0)
+    datadog (2.1.0)
       debase-ruby_core_source (= 3.3.1)
       libdatadog (~> 9.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)

--- a/gemfiles/ruby_3.0_opensearch_3.gemfile.lock
+++ b/gemfiles/ruby_3.0_opensearch_3.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    datadog (2.0.0)
+    datadog (2.1.0)
       debase-ruby_core_source (= 3.3.1)
       libdatadog (~> 9.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)

--- a/gemfiles/ruby_3.0_opentelemetry.gemfile.lock
+++ b/gemfiles/ruby_3.0_opentelemetry.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    datadog (2.0.0)
+    datadog (2.1.0)
       debase-ruby_core_source (= 3.3.1)
       libdatadog (~> 9.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)

--- a/gemfiles/ruby_3.0_rack_1.gemfile.lock
+++ b/gemfiles/ruby_3.0_rack_1.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    datadog (2.0.0)
+    datadog (2.1.0)
       debase-ruby_core_source (= 3.3.1)
       libdatadog (~> 9.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)

--- a/gemfiles/ruby_3.0_rack_2.gemfile.lock
+++ b/gemfiles/ruby_3.0_rack_2.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    datadog (2.0.0)
+    datadog (2.1.0)
       debase-ruby_core_source (= 3.3.1)
       libdatadog (~> 9.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)

--- a/gemfiles/ruby_3.0_rack_3.gemfile.lock
+++ b/gemfiles/ruby_3.0_rack_3.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    datadog (2.0.0)
+    datadog (2.1.0)
       debase-ruby_core_source (= 3.3.1)
       libdatadog (~> 9.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)

--- a/gemfiles/ruby_3.0_rails61_mysql2.gemfile.lock
+++ b/gemfiles/ruby_3.0_rails61_mysql2.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    datadog (2.0.0)
+    datadog (2.1.0)
       debase-ruby_core_source (= 3.3.1)
       libdatadog (~> 9.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)

--- a/gemfiles/ruby_3.0_rails61_postgres.gemfile.lock
+++ b/gemfiles/ruby_3.0_rails61_postgres.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    datadog (2.0.0)
+    datadog (2.1.0)
       debase-ruby_core_source (= 3.3.1)
       libdatadog (~> 9.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)

--- a/gemfiles/ruby_3.0_rails61_postgres_redis.gemfile.lock
+++ b/gemfiles/ruby_3.0_rails61_postgres_redis.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    datadog (2.0.0)
+    datadog (2.1.0)
       debase-ruby_core_source (= 3.3.1)
       libdatadog (~> 9.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)

--- a/gemfiles/ruby_3.0_rails61_postgres_sidekiq.gemfile.lock
+++ b/gemfiles/ruby_3.0_rails61_postgres_sidekiq.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    datadog (2.0.0)
+    datadog (2.1.0)
       debase-ruby_core_source (= 3.3.1)
       libdatadog (~> 9.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)

--- a/gemfiles/ruby_3.0_rails61_semantic_logger.gemfile.lock
+++ b/gemfiles/ruby_3.0_rails61_semantic_logger.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    datadog (2.0.0)
+    datadog (2.1.0)
       debase-ruby_core_source (= 3.3.1)
       libdatadog (~> 9.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)

--- a/gemfiles/ruby_3.0_rails61_trilogy.gemfile.lock
+++ b/gemfiles/ruby_3.0_rails61_trilogy.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    datadog (2.0.0)
+    datadog (2.1.0)
       debase-ruby_core_source (= 3.3.1)
       libdatadog (~> 9.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)

--- a/gemfiles/ruby_3.0_redis_3.gemfile.lock
+++ b/gemfiles/ruby_3.0_redis_3.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    datadog (2.0.0)
+    datadog (2.1.0)
       debase-ruby_core_source (= 3.3.1)
       libdatadog (~> 9.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)

--- a/gemfiles/ruby_3.0_redis_4.gemfile.lock
+++ b/gemfiles/ruby_3.0_redis_4.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    datadog (2.0.0)
+    datadog (2.1.0)
       debase-ruby_core_source (= 3.3.1)
       libdatadog (~> 9.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)

--- a/gemfiles/ruby_3.0_redis_5.gemfile.lock
+++ b/gemfiles/ruby_3.0_redis_5.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    datadog (2.0.0)
+    datadog (2.1.0)
       debase-ruby_core_source (= 3.3.1)
       libdatadog (~> 9.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)

--- a/gemfiles/ruby_3.0_relational_db.gemfile.lock
+++ b/gemfiles/ruby_3.0_relational_db.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    datadog (2.0.0)
+    datadog (2.1.0)
       debase-ruby_core_source (= 3.3.1)
       libdatadog (~> 9.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)

--- a/gemfiles/ruby_3.0_resque2_redis3.gemfile.lock
+++ b/gemfiles/ruby_3.0_resque2_redis3.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    datadog (2.0.0)
+    datadog (2.1.0)
       debase-ruby_core_source (= 3.3.1)
       libdatadog (~> 9.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)

--- a/gemfiles/ruby_3.0_resque2_redis4.gemfile.lock
+++ b/gemfiles/ruby_3.0_resque2_redis4.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    datadog (2.0.0)
+    datadog (2.1.0)
       debase-ruby_core_source (= 3.3.1)
       libdatadog (~> 9.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)

--- a/gemfiles/ruby_3.0_sinatra_2.gemfile.lock
+++ b/gemfiles/ruby_3.0_sinatra_2.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    datadog (2.0.0)
+    datadog (2.1.0)
       debase-ruby_core_source (= 3.3.1)
       libdatadog (~> 9.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)

--- a/gemfiles/ruby_3.0_sinatra_3.gemfile.lock
+++ b/gemfiles/ruby_3.0_sinatra_3.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    datadog (2.0.0)
+    datadog (2.1.0)
       debase-ruby_core_source (= 3.3.1)
       libdatadog (~> 9.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)

--- a/gemfiles/ruby_3.0_sinatra_4.gemfile.lock
+++ b/gemfiles/ruby_3.0_sinatra_4.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    datadog (2.0.0)
+    datadog (2.1.0)
       debase-ruby_core_source (= 3.3.1)
       libdatadog (~> 9.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)

--- a/gemfiles/ruby_3.1_activesupport.gemfile.lock
+++ b/gemfiles/ruby_3.1_activesupport.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    datadog (2.0.0)
+    datadog (2.1.0)
       debase-ruby_core_source (= 3.3.1)
       libdatadog (~> 9.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)

--- a/gemfiles/ruby_3.1_aws.gemfile.lock
+++ b/gemfiles/ruby_3.1_aws.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    datadog (2.0.0)
+    datadog (2.1.0)
       debase-ruby_core_source (= 3.3.1)
       libdatadog (~> 9.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)

--- a/gemfiles/ruby_3.1_contrib.gemfile.lock
+++ b/gemfiles/ruby_3.1_contrib.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    datadog (2.0.0)
+    datadog (2.1.0)
       debase-ruby_core_source (= 3.3.1)
       libdatadog (~> 9.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)

--- a/gemfiles/ruby_3.1_contrib_old.gemfile.lock
+++ b/gemfiles/ruby_3.1_contrib_old.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    datadog (2.0.0)
+    datadog (2.1.0)
       debase-ruby_core_source (= 3.3.1)
       libdatadog (~> 9.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)

--- a/gemfiles/ruby_3.1_core_old.gemfile.lock
+++ b/gemfiles/ruby_3.1_core_old.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    datadog (2.0.0)
+    datadog (2.1.0)
       debase-ruby_core_source (= 3.3.1)
       libdatadog (~> 9.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)

--- a/gemfiles/ruby_3.1_elasticsearch_7.gemfile.lock
+++ b/gemfiles/ruby_3.1_elasticsearch_7.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    datadog (2.0.0)
+    datadog (2.1.0)
       debase-ruby_core_source (= 3.3.1)
       libdatadog (~> 9.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)

--- a/gemfiles/ruby_3.1_elasticsearch_8.gemfile.lock
+++ b/gemfiles/ruby_3.1_elasticsearch_8.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    datadog (2.0.0)
+    datadog (2.1.0)
       debase-ruby_core_source (= 3.3.1)
       libdatadog (~> 9.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)

--- a/gemfiles/ruby_3.1_graphql_1.13.gemfile.lock
+++ b/gemfiles/ruby_3.1_graphql_1.13.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    datadog (2.0.0)
+    datadog (2.1.0)
       debase-ruby_core_source (= 3.3.1)
       libdatadog (~> 9.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)

--- a/gemfiles/ruby_3.1_graphql_2.0.gemfile.lock
+++ b/gemfiles/ruby_3.1_graphql_2.0.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    datadog (2.0.0)
+    datadog (2.1.0)
       debase-ruby_core_source (= 3.3.1)
       libdatadog (~> 9.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)

--- a/gemfiles/ruby_3.1_graphql_2.1.gemfile.lock
+++ b/gemfiles/ruby_3.1_graphql_2.1.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    datadog (2.0.0)
+    datadog (2.1.0)
       debase-ruby_core_source (= 3.3.1)
       libdatadog (~> 9.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)

--- a/gemfiles/ruby_3.1_graphql_2.2.gemfile.lock
+++ b/gemfiles/ruby_3.1_graphql_2.2.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    datadog (2.0.0)
+    datadog (2.1.0)
       debase-ruby_core_source (= 3.3.1)
       libdatadog (~> 9.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)

--- a/gemfiles/ruby_3.1_http.gemfile.lock
+++ b/gemfiles/ruby_3.1_http.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    datadog (2.0.0)
+    datadog (2.1.0)
       debase-ruby_core_source (= 3.3.1)
       libdatadog (~> 9.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)

--- a/gemfiles/ruby_3.1_opensearch_2.gemfile.lock
+++ b/gemfiles/ruby_3.1_opensearch_2.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    datadog (2.0.0)
+    datadog (2.1.0)
       debase-ruby_core_source (= 3.3.1)
       libdatadog (~> 9.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)

--- a/gemfiles/ruby_3.1_opensearch_3.gemfile.lock
+++ b/gemfiles/ruby_3.1_opensearch_3.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    datadog (2.0.0)
+    datadog (2.1.0)
       debase-ruby_core_source (= 3.3.1)
       libdatadog (~> 9.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)

--- a/gemfiles/ruby_3.1_opentelemetry.gemfile.lock
+++ b/gemfiles/ruby_3.1_opentelemetry.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    datadog (2.0.0)
+    datadog (2.1.0)
       debase-ruby_core_source (= 3.3.1)
       libdatadog (~> 9.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)

--- a/gemfiles/ruby_3.1_rack_1.gemfile.lock
+++ b/gemfiles/ruby_3.1_rack_1.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    datadog (2.0.0)
+    datadog (2.1.0)
       debase-ruby_core_source (= 3.3.1)
       libdatadog (~> 9.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)

--- a/gemfiles/ruby_3.1_rack_2.gemfile.lock
+++ b/gemfiles/ruby_3.1_rack_2.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    datadog (2.0.0)
+    datadog (2.1.0)
       debase-ruby_core_source (= 3.3.1)
       libdatadog (~> 9.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)

--- a/gemfiles/ruby_3.1_rack_3.gemfile.lock
+++ b/gemfiles/ruby_3.1_rack_3.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    datadog (2.0.0)
+    datadog (2.1.0)
       debase-ruby_core_source (= 3.3.1)
       libdatadog (~> 9.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)

--- a/gemfiles/ruby_3.1_rails61_mysql2.gemfile.lock
+++ b/gemfiles/ruby_3.1_rails61_mysql2.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    datadog (2.0.0)
+    datadog (2.1.0)
       debase-ruby_core_source (= 3.3.1)
       libdatadog (~> 9.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)

--- a/gemfiles/ruby_3.1_rails61_postgres.gemfile.lock
+++ b/gemfiles/ruby_3.1_rails61_postgres.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    datadog (2.0.0)
+    datadog (2.1.0)
       debase-ruby_core_source (= 3.3.1)
       libdatadog (~> 9.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)

--- a/gemfiles/ruby_3.1_rails61_postgres_redis.gemfile.lock
+++ b/gemfiles/ruby_3.1_rails61_postgres_redis.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    datadog (2.0.0)
+    datadog (2.1.0)
       debase-ruby_core_source (= 3.3.1)
       libdatadog (~> 9.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)

--- a/gemfiles/ruby_3.1_rails61_postgres_sidekiq.gemfile.lock
+++ b/gemfiles/ruby_3.1_rails61_postgres_sidekiq.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    datadog (2.0.0)
+    datadog (2.1.0)
       debase-ruby_core_source (= 3.3.1)
       libdatadog (~> 9.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)

--- a/gemfiles/ruby_3.1_rails61_semantic_logger.gemfile.lock
+++ b/gemfiles/ruby_3.1_rails61_semantic_logger.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    datadog (2.0.0)
+    datadog (2.1.0)
       debase-ruby_core_source (= 3.3.1)
       libdatadog (~> 9.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)

--- a/gemfiles/ruby_3.1_rails61_trilogy.gemfile.lock
+++ b/gemfiles/ruby_3.1_rails61_trilogy.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    datadog (2.0.0)
+    datadog (2.1.0)
       debase-ruby_core_source (= 3.3.1)
       libdatadog (~> 9.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)

--- a/gemfiles/ruby_3.1_redis_3.gemfile.lock
+++ b/gemfiles/ruby_3.1_redis_3.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    datadog (2.0.0)
+    datadog (2.1.0)
       debase-ruby_core_source (= 3.3.1)
       libdatadog (~> 9.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)

--- a/gemfiles/ruby_3.1_redis_4.gemfile.lock
+++ b/gemfiles/ruby_3.1_redis_4.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    datadog (2.0.0)
+    datadog (2.1.0)
       debase-ruby_core_source (= 3.3.1)
       libdatadog (~> 9.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)

--- a/gemfiles/ruby_3.1_redis_5.gemfile.lock
+++ b/gemfiles/ruby_3.1_redis_5.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    datadog (2.0.0)
+    datadog (2.1.0)
       debase-ruby_core_source (= 3.3.1)
       libdatadog (~> 9.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)

--- a/gemfiles/ruby_3.1_relational_db.gemfile.lock
+++ b/gemfiles/ruby_3.1_relational_db.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    datadog (2.0.0)
+    datadog (2.1.0)
       debase-ruby_core_source (= 3.3.1)
       libdatadog (~> 9.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)

--- a/gemfiles/ruby_3.1_resque2_redis3.gemfile.lock
+++ b/gemfiles/ruby_3.1_resque2_redis3.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    datadog (2.0.0)
+    datadog (2.1.0)
       debase-ruby_core_source (= 3.3.1)
       libdatadog (~> 9.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)

--- a/gemfiles/ruby_3.1_resque2_redis4.gemfile.lock
+++ b/gemfiles/ruby_3.1_resque2_redis4.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    datadog (2.0.0)
+    datadog (2.1.0)
       debase-ruby_core_source (= 3.3.1)
       libdatadog (~> 9.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)

--- a/gemfiles/ruby_3.1_sinatra_2.gemfile.lock
+++ b/gemfiles/ruby_3.1_sinatra_2.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    datadog (2.0.0)
+    datadog (2.1.0)
       debase-ruby_core_source (= 3.3.1)
       libdatadog (~> 9.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)

--- a/gemfiles/ruby_3.1_sinatra_3.gemfile.lock
+++ b/gemfiles/ruby_3.1_sinatra_3.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    datadog (2.0.0)
+    datadog (2.1.0)
       debase-ruby_core_source (= 3.3.1)
       libdatadog (~> 9.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)

--- a/gemfiles/ruby_3.1_sinatra_4.gemfile.lock
+++ b/gemfiles/ruby_3.1_sinatra_4.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    datadog (2.0.0)
+    datadog (2.1.0)
       debase-ruby_core_source (= 3.3.1)
       libdatadog (~> 9.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)

--- a/gemfiles/ruby_3.2_activesupport.gemfile.lock
+++ b/gemfiles/ruby_3.2_activesupport.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    datadog (2.0.0)
+    datadog (2.1.0)
       debase-ruby_core_source (= 3.3.1)
       libdatadog (~> 9.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)

--- a/gemfiles/ruby_3.2_aws.gemfile.lock
+++ b/gemfiles/ruby_3.2_aws.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    datadog (2.0.0)
+    datadog (2.1.0)
       debase-ruby_core_source (= 3.3.1)
       libdatadog (~> 9.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)

--- a/gemfiles/ruby_3.2_contrib.gemfile.lock
+++ b/gemfiles/ruby_3.2_contrib.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    datadog (2.0.0)
+    datadog (2.1.0)
       debase-ruby_core_source (= 3.3.1)
       libdatadog (~> 9.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)

--- a/gemfiles/ruby_3.2_contrib_old.gemfile.lock
+++ b/gemfiles/ruby_3.2_contrib_old.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    datadog (2.0.0)
+    datadog (2.1.0)
       debase-ruby_core_source (= 3.3.1)
       libdatadog (~> 9.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)

--- a/gemfiles/ruby_3.2_core_old.gemfile.lock
+++ b/gemfiles/ruby_3.2_core_old.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    datadog (2.0.0)
+    datadog (2.1.0)
       debase-ruby_core_source (= 3.3.1)
       libdatadog (~> 9.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)

--- a/gemfiles/ruby_3.2_elasticsearch_7.gemfile.lock
+++ b/gemfiles/ruby_3.2_elasticsearch_7.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    datadog (2.0.0)
+    datadog (2.1.0)
       debase-ruby_core_source (= 3.3.1)
       libdatadog (~> 9.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)

--- a/gemfiles/ruby_3.2_elasticsearch_8.gemfile.lock
+++ b/gemfiles/ruby_3.2_elasticsearch_8.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    datadog (2.0.0)
+    datadog (2.1.0)
       debase-ruby_core_source (= 3.3.1)
       libdatadog (~> 9.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)

--- a/gemfiles/ruby_3.2_graphql_1.13.gemfile.lock
+++ b/gemfiles/ruby_3.2_graphql_1.13.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    datadog (2.0.0)
+    datadog (2.1.0)
       debase-ruby_core_source (= 3.3.1)
       libdatadog (~> 9.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)

--- a/gemfiles/ruby_3.2_graphql_2.0.gemfile.lock
+++ b/gemfiles/ruby_3.2_graphql_2.0.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    datadog (2.0.0)
+    datadog (2.1.0)
       debase-ruby_core_source (= 3.3.1)
       libdatadog (~> 9.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)

--- a/gemfiles/ruby_3.2_graphql_2.1.gemfile.lock
+++ b/gemfiles/ruby_3.2_graphql_2.1.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    datadog (2.0.0)
+    datadog (2.1.0)
       debase-ruby_core_source (= 3.3.1)
       libdatadog (~> 9.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)

--- a/gemfiles/ruby_3.2_graphql_2.2.gemfile.lock
+++ b/gemfiles/ruby_3.2_graphql_2.2.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    datadog (2.0.0)
+    datadog (2.1.0)
       debase-ruby_core_source (= 3.3.1)
       libdatadog (~> 9.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)

--- a/gemfiles/ruby_3.2_http.gemfile.lock
+++ b/gemfiles/ruby_3.2_http.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    datadog (2.0.0)
+    datadog (2.1.0)
       debase-ruby_core_source (= 3.3.1)
       libdatadog (~> 9.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)

--- a/gemfiles/ruby_3.2_opensearch_2.gemfile.lock
+++ b/gemfiles/ruby_3.2_opensearch_2.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    datadog (2.0.0)
+    datadog (2.1.0)
       debase-ruby_core_source (= 3.3.1)
       libdatadog (~> 9.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)

--- a/gemfiles/ruby_3.2_opensearch_3.gemfile.lock
+++ b/gemfiles/ruby_3.2_opensearch_3.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    datadog (2.0.0)
+    datadog (2.1.0)
       debase-ruby_core_source (= 3.3.1)
       libdatadog (~> 9.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)

--- a/gemfiles/ruby_3.2_opentelemetry.gemfile.lock
+++ b/gemfiles/ruby_3.2_opentelemetry.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    datadog (2.0.0)
+    datadog (2.1.0)
       debase-ruby_core_source (= 3.3.1)
       libdatadog (~> 9.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)

--- a/gemfiles/ruby_3.2_rack_1.gemfile.lock
+++ b/gemfiles/ruby_3.2_rack_1.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    datadog (2.0.0)
+    datadog (2.1.0)
       debase-ruby_core_source (= 3.3.1)
       libdatadog (~> 9.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)

--- a/gemfiles/ruby_3.2_rack_2.gemfile.lock
+++ b/gemfiles/ruby_3.2_rack_2.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    datadog (2.0.0)
+    datadog (2.1.0)
       debase-ruby_core_source (= 3.3.1)
       libdatadog (~> 9.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)

--- a/gemfiles/ruby_3.2_rack_3.gemfile.lock
+++ b/gemfiles/ruby_3.2_rack_3.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    datadog (2.0.0)
+    datadog (2.1.0)
       debase-ruby_core_source (= 3.3.1)
       libdatadog (~> 9.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)

--- a/gemfiles/ruby_3.2_rails61_mysql2.gemfile.lock
+++ b/gemfiles/ruby_3.2_rails61_mysql2.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    datadog (2.0.0)
+    datadog (2.1.0)
       debase-ruby_core_source (= 3.3.1)
       libdatadog (~> 9.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)

--- a/gemfiles/ruby_3.2_rails61_postgres.gemfile.lock
+++ b/gemfiles/ruby_3.2_rails61_postgres.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    datadog (2.0.0)
+    datadog (2.1.0)
       debase-ruby_core_source (= 3.3.1)
       libdatadog (~> 9.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)

--- a/gemfiles/ruby_3.2_rails61_postgres_redis.gemfile.lock
+++ b/gemfiles/ruby_3.2_rails61_postgres_redis.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    datadog (2.0.0)
+    datadog (2.1.0)
       debase-ruby_core_source (= 3.3.1)
       libdatadog (~> 9.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)

--- a/gemfiles/ruby_3.2_rails61_postgres_sidekiq.gemfile.lock
+++ b/gemfiles/ruby_3.2_rails61_postgres_sidekiq.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    datadog (2.0.0)
+    datadog (2.1.0)
       debase-ruby_core_source (= 3.3.1)
       libdatadog (~> 9.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)

--- a/gemfiles/ruby_3.2_rails61_semantic_logger.gemfile.lock
+++ b/gemfiles/ruby_3.2_rails61_semantic_logger.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    datadog (2.0.0)
+    datadog (2.1.0)
       debase-ruby_core_source (= 3.3.1)
       libdatadog (~> 9.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)

--- a/gemfiles/ruby_3.2_rails61_trilogy.gemfile.lock
+++ b/gemfiles/ruby_3.2_rails61_trilogy.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    datadog (2.0.0)
+    datadog (2.1.0)
       debase-ruby_core_source (= 3.3.1)
       libdatadog (~> 9.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)

--- a/gemfiles/ruby_3.2_redis_3.gemfile.lock
+++ b/gemfiles/ruby_3.2_redis_3.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    datadog (2.0.0)
+    datadog (2.1.0)
       debase-ruby_core_source (= 3.3.1)
       libdatadog (~> 9.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)

--- a/gemfiles/ruby_3.2_redis_4.gemfile.lock
+++ b/gemfiles/ruby_3.2_redis_4.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    datadog (2.0.0)
+    datadog (2.1.0)
       debase-ruby_core_source (= 3.3.1)
       libdatadog (~> 9.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)

--- a/gemfiles/ruby_3.2_redis_5.gemfile.lock
+++ b/gemfiles/ruby_3.2_redis_5.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    datadog (2.0.0)
+    datadog (2.1.0)
       debase-ruby_core_source (= 3.3.1)
       libdatadog (~> 9.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)

--- a/gemfiles/ruby_3.2_relational_db.gemfile.lock
+++ b/gemfiles/ruby_3.2_relational_db.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    datadog (2.0.0)
+    datadog (2.1.0)
       debase-ruby_core_source (= 3.3.1)
       libdatadog (~> 9.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)

--- a/gemfiles/ruby_3.2_resque2_redis3.gemfile.lock
+++ b/gemfiles/ruby_3.2_resque2_redis3.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    datadog (2.0.0)
+    datadog (2.1.0)
       debase-ruby_core_source (= 3.3.1)
       libdatadog (~> 9.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)

--- a/gemfiles/ruby_3.2_resque2_redis4.gemfile.lock
+++ b/gemfiles/ruby_3.2_resque2_redis4.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    datadog (2.0.0)
+    datadog (2.1.0)
       debase-ruby_core_source (= 3.3.1)
       libdatadog (~> 9.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)

--- a/gemfiles/ruby_3.2_sinatra_2.gemfile.lock
+++ b/gemfiles/ruby_3.2_sinatra_2.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    datadog (2.0.0)
+    datadog (2.1.0)
       debase-ruby_core_source (= 3.3.1)
       libdatadog (~> 9.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)

--- a/gemfiles/ruby_3.2_sinatra_3.gemfile.lock
+++ b/gemfiles/ruby_3.2_sinatra_3.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    datadog (2.0.0)
+    datadog (2.1.0)
       debase-ruby_core_source (= 3.3.1)
       libdatadog (~> 9.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)

--- a/gemfiles/ruby_3.2_sinatra_4.gemfile.lock
+++ b/gemfiles/ruby_3.2_sinatra_4.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    datadog (2.0.0)
+    datadog (2.1.0)
       debase-ruby_core_source (= 3.3.1)
       libdatadog (~> 9.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)

--- a/gemfiles/ruby_3.3_activesupport.gemfile.lock
+++ b/gemfiles/ruby_3.3_activesupport.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    datadog (2.0.0)
+    datadog (2.1.0)
       debase-ruby_core_source (= 3.3.1)
       libdatadog (~> 9.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)

--- a/gemfiles/ruby_3.3_aws.gemfile.lock
+++ b/gemfiles/ruby_3.3_aws.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    datadog (2.0.0)
+    datadog (2.1.0)
       debase-ruby_core_source (= 3.3.1)
       libdatadog (~> 9.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)

--- a/gemfiles/ruby_3.3_contrib.gemfile.lock
+++ b/gemfiles/ruby_3.3_contrib.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    datadog (2.0.0)
+    datadog (2.1.0)
       debase-ruby_core_source (= 3.3.1)
       libdatadog (~> 9.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)

--- a/gemfiles/ruby_3.3_contrib_old.gemfile.lock
+++ b/gemfiles/ruby_3.3_contrib_old.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    datadog (2.0.0)
+    datadog (2.1.0)
       debase-ruby_core_source (= 3.3.1)
       libdatadog (~> 9.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)

--- a/gemfiles/ruby_3.3_core_old.gemfile.lock
+++ b/gemfiles/ruby_3.3_core_old.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    datadog (2.0.0)
+    datadog (2.1.0)
       debase-ruby_core_source (= 3.3.1)
       libdatadog (~> 9.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)

--- a/gemfiles/ruby_3.3_elasticsearch_7.gemfile.lock
+++ b/gemfiles/ruby_3.3_elasticsearch_7.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    datadog (2.0.0)
+    datadog (2.1.0)
       debase-ruby_core_source (= 3.3.1)
       libdatadog (~> 9.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)

--- a/gemfiles/ruby_3.3_elasticsearch_8.gemfile.lock
+++ b/gemfiles/ruby_3.3_elasticsearch_8.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    datadog (2.0.0)
+    datadog (2.1.0)
       debase-ruby_core_source (= 3.3.1)
       libdatadog (~> 9.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)

--- a/gemfiles/ruby_3.3_graphql_1.13.gemfile.lock
+++ b/gemfiles/ruby_3.3_graphql_1.13.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    datadog (2.0.0)
+    datadog (2.1.0)
       debase-ruby_core_source (= 3.3.1)
       libdatadog (~> 9.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)

--- a/gemfiles/ruby_3.3_graphql_2.0.gemfile.lock
+++ b/gemfiles/ruby_3.3_graphql_2.0.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    datadog (2.0.0)
+    datadog (2.1.0)
       debase-ruby_core_source (= 3.3.1)
       libdatadog (~> 9.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)

--- a/gemfiles/ruby_3.3_graphql_2.1.gemfile.lock
+++ b/gemfiles/ruby_3.3_graphql_2.1.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    datadog (2.0.0)
+    datadog (2.1.0)
       debase-ruby_core_source (= 3.3.1)
       libdatadog (~> 9.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)

--- a/gemfiles/ruby_3.3_graphql_2.2.gemfile.lock
+++ b/gemfiles/ruby_3.3_graphql_2.2.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    datadog (2.0.0)
+    datadog (2.1.0)
       debase-ruby_core_source (= 3.3.1)
       libdatadog (~> 9.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)

--- a/gemfiles/ruby_3.3_http.gemfile.lock
+++ b/gemfiles/ruby_3.3_http.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    datadog (2.0.0)
+    datadog (2.1.0)
       debase-ruby_core_source (= 3.3.1)
       libdatadog (~> 9.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)

--- a/gemfiles/ruby_3.3_opensearch_2.gemfile.lock
+++ b/gemfiles/ruby_3.3_opensearch_2.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    datadog (2.0.0)
+    datadog (2.1.0)
       debase-ruby_core_source (= 3.3.1)
       libdatadog (~> 9.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)

--- a/gemfiles/ruby_3.3_opensearch_3.gemfile.lock
+++ b/gemfiles/ruby_3.3_opensearch_3.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    datadog (2.0.0)
+    datadog (2.1.0)
       debase-ruby_core_source (= 3.3.1)
       libdatadog (~> 9.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)

--- a/gemfiles/ruby_3.3_opentelemetry.gemfile.lock
+++ b/gemfiles/ruby_3.3_opentelemetry.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    datadog (2.0.0)
+    datadog (2.1.0)
       debase-ruby_core_source (= 3.3.1)
       libdatadog (~> 9.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)

--- a/gemfiles/ruby_3.3_rack_2.gemfile.lock
+++ b/gemfiles/ruby_3.3_rack_2.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    datadog (2.0.0)
+    datadog (2.1.0)
       debase-ruby_core_source (= 3.3.1)
       libdatadog (~> 9.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)

--- a/gemfiles/ruby_3.3_rack_3.gemfile.lock
+++ b/gemfiles/ruby_3.3_rack_3.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    datadog (2.0.0)
+    datadog (2.1.0)
       debase-ruby_core_source (= 3.3.1)
       libdatadog (~> 9.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)

--- a/gemfiles/ruby_3.3_rails61_mysql2.gemfile.lock
+++ b/gemfiles/ruby_3.3_rails61_mysql2.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    datadog (2.0.0)
+    datadog (2.1.0)
       debase-ruby_core_source (= 3.3.1)
       libdatadog (~> 9.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)

--- a/gemfiles/ruby_3.3_rails61_postgres.gemfile.lock
+++ b/gemfiles/ruby_3.3_rails61_postgres.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    datadog (2.0.0)
+    datadog (2.1.0)
       debase-ruby_core_source (= 3.3.1)
       libdatadog (~> 9.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)

--- a/gemfiles/ruby_3.3_rails61_postgres_redis.gemfile.lock
+++ b/gemfiles/ruby_3.3_rails61_postgres_redis.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    datadog (2.0.0)
+    datadog (2.1.0)
       debase-ruby_core_source (= 3.3.1)
       libdatadog (~> 9.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)

--- a/gemfiles/ruby_3.3_rails61_postgres_sidekiq.gemfile.lock
+++ b/gemfiles/ruby_3.3_rails61_postgres_sidekiq.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    datadog (2.0.0)
+    datadog (2.1.0)
       debase-ruby_core_source (= 3.3.1)
       libdatadog (~> 9.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)

--- a/gemfiles/ruby_3.3_rails61_semantic_logger.gemfile.lock
+++ b/gemfiles/ruby_3.3_rails61_semantic_logger.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    datadog (2.0.0)
+    datadog (2.1.0)
       debase-ruby_core_source (= 3.3.1)
       libdatadog (~> 9.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)

--- a/gemfiles/ruby_3.3_rails61_trilogy.gemfile.lock
+++ b/gemfiles/ruby_3.3_rails61_trilogy.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    datadog (2.0.0)
+    datadog (2.1.0)
       debase-ruby_core_source (= 3.3.1)
       libdatadog (~> 9.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)

--- a/gemfiles/ruby_3.3_redis_3.gemfile.lock
+++ b/gemfiles/ruby_3.3_redis_3.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    datadog (2.0.0)
+    datadog (2.1.0)
       debase-ruby_core_source (= 3.3.1)
       libdatadog (~> 9.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)

--- a/gemfiles/ruby_3.3_redis_4.gemfile.lock
+++ b/gemfiles/ruby_3.3_redis_4.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    datadog (2.0.0)
+    datadog (2.1.0)
       debase-ruby_core_source (= 3.3.1)
       libdatadog (~> 9.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)

--- a/gemfiles/ruby_3.3_redis_5.gemfile.lock
+++ b/gemfiles/ruby_3.3_redis_5.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    datadog (2.0.0)
+    datadog (2.1.0)
       debase-ruby_core_source (= 3.3.1)
       libdatadog (~> 9.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)

--- a/gemfiles/ruby_3.3_relational_db.gemfile.lock
+++ b/gemfiles/ruby_3.3_relational_db.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    datadog (2.0.0)
+    datadog (2.1.0)
       debase-ruby_core_source (= 3.3.1)
       libdatadog (~> 9.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)

--- a/gemfiles/ruby_3.3_resque2_redis3.gemfile.lock
+++ b/gemfiles/ruby_3.3_resque2_redis3.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    datadog (2.0.0)
+    datadog (2.1.0)
       debase-ruby_core_source (= 3.3.1)
       libdatadog (~> 9.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)

--- a/gemfiles/ruby_3.3_resque2_redis4.gemfile.lock
+++ b/gemfiles/ruby_3.3_resque2_redis4.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    datadog (2.0.0)
+    datadog (2.1.0)
       debase-ruby_core_source (= 3.3.1)
       libdatadog (~> 9.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)

--- a/gemfiles/ruby_3.3_sinatra_2.gemfile.lock
+++ b/gemfiles/ruby_3.3_sinatra_2.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    datadog (2.0.0)
+    datadog (2.1.0)
       debase-ruby_core_source (= 3.3.1)
       libdatadog (~> 9.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)

--- a/gemfiles/ruby_3.3_sinatra_3.gemfile.lock
+++ b/gemfiles/ruby_3.3_sinatra_3.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    datadog (2.0.0)
+    datadog (2.1.0)
       debase-ruby_core_source (= 3.3.1)
       libdatadog (~> 9.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)

--- a/gemfiles/ruby_3.3_sinatra_4.gemfile.lock
+++ b/gemfiles/ruby_3.3_sinatra_4.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    datadog (2.0.0)
+    datadog (2.1.0)
       debase-ruby_core_source (= 3.3.1)
       libdatadog (~> 9.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)

--- a/lib/datadog/version.rb
+++ b/lib/datadog/version.rb
@@ -3,7 +3,7 @@
 module Datadog
   module VERSION
     MAJOR = 2
-    MINOR = 0
+    MINOR = 1
     PATCH = 0
     PRE = nil
     BUILD = nil


### PR DESCRIPTION
### Added

* Tracing: Configuration by OpenTelemetry environment variables (#3657)

### Fixed

* Tracing: Improved compatibility with W3C Trace Context propagation (#3631)
