### PR TITLE
Include `source_code_uri` in gemspec, version `changelog_uri`

### DIFF
--- a/datadog.gemspec
+++ b/datadog.gemspec
@@ -29,7 +29,8 @@ Gem::Specification.new do |spec|
 
   if spec.respond_to?(:metadata)
     spec.metadata['allowed_push_host'] = 'https://rubygems.org'
-    spec.metadata['changelog_uri'] = 'https://github.com/DataDog/dd-trace-rb/blob/master/CHANGELOG.md'
+    spec.metadata['changelog_uri'] = "https://github.com/DataDog/dd-trace-rb/blob/v#{spec.version}/CHANGELOG.md"
+    spec.metadata['source_code_uri'] = "https://github.com/DataDog/dd-trace-rb/tree/v#{spec.version}"
   else
     raise 'RubyGems 2.0 or newer is required to protect against public gem pushes.'
   end

--- a/spec/datadog/release_gem_spec.rb
+++ b/spec/datadog/release_gem_spec.rb
@@ -107,5 +107,17 @@ RSpec.describe 'gem release process' do
         expect(gemspec.licenses).to contain_exactly('BSD-3-Clause', 'Apache-2.0')
       end
     end
+
+    describe '#metadata' do
+      it do
+        {
+          'allowed_push_host' => 'https://rubygems.org',
+          'changelog_uri' => "https://github.com/DataDog/dd-trace-rb/blob/v#{gemspec.version}/CHANGELOG.md",
+          'source_code_uri' => "https://github.com/DataDog/dd-trace-rb/tree/v#{gemspec.version}"
+        }.each do |key, value|
+          expect(gemspec.metadata[key]).to eq(value)
+        end
+      end
+    end
   end
 end

--- a/spec/datadog/release_gem_spec.rb
+++ b/spec/datadog/release_gem_spec.rb
@@ -111,11 +111,22 @@ RSpec.describe 'gem release process' do
     describe '#metadata' do
       it do
         {
-          'allowed_push_host' => 'https://rubygems.org',
           'changelog_uri' => "https://github.com/DataDog/dd-trace-rb/blob/v#{gemspec.version}/CHANGELOG.md",
           'source_code_uri' => "https://github.com/DataDog/dd-trace-rb/tree/v#{gemspec.version}"
         }.each do |key, value|
           expect(gemspec.metadata[key]).to eq(value)
+        end
+      end
+
+      # `allowed_push_host` is overwritten by automated scripts
+      # in order to publish to another destination repository.
+      context 'allowed_push_host' do
+        it { expect(gemspec.metadata).to have_key('allowed_push_host') }
+
+        it do
+          expect(gemspec.metadata['allowed_push_host'])
+            .to eq('https://rubygems.org')
+            .or eq('https://rubygems.pkg.github.com/DataDog')
         end
       end
     end


### PR DESCRIPTION
See #3684

If you compare https://rubygems.org/gems/datadog and https://rubygems.org/gems/ddtrace you will notice that `datadog` is missing the GitHub star count, and the "Source Code" link. Right now you can only go to source through the "Changelog" link. This should fix that, though the GitHub badge may depend on `spec.homepage`, not entirely sure. Either way, a bit better than now.