### PR TITLE
[PROF-9926] Fix rpath for linking to libdatadog when loading from extension dir (cherry-pick from 1.x-stable)

### DIFF
--- a/ext/datadog_profiling_native_extension/extconf.rb
+++ b/ext/datadog_profiling_native_extension/extconf.rb
@@ -211,12 +211,14 @@ unless have_type('atomic_int', ['stdatomic.h'])
   skip_building_extension!(Datadog::Profiling::NativeExtensionHelpers::Supported::COMPILER_ATOMIC_MISSING)
 end
 
-# See comments on the helper method being used for why we need to additionally set this.
+# See comments on the helper methods being used for why we need to additionally set this.
 # The extremely excessive escaping around ORIGIN below seems to be correct and was determined after a lot of
 # experimentation. We need to get these special characters across a lot of tools untouched...
-$LDFLAGS += \
-  ' -Wl,-rpath,$$$\\\\{ORIGIN\\}/' \
-  "#{Datadog::Profiling::NativeExtensionHelpers.libdatadog_folder_relative_to_native_lib_folder}"
+extra_relative_rpaths = [
+  Datadog::Profiling::NativeExtensionHelpers.libdatadog_folder_relative_to_native_lib_folder,
+  *Datadog::Profiling::NativeExtensionHelpers.libdatadog_folder_relative_to_ruby_extensions_folders,
+]
+extra_relative_rpaths.each { |folder| $LDFLAGS += " -Wl,-rpath,$$$\\\\{ORIGIN\\}/#{folder.to_str}" }
 Logging.message("[datadog] After pkg-config $LDFLAGS were set to: #{$LDFLAGS.inspect}\n")
 
 # Tag the native extension library with the Ruby version and Ruby platform.

--- a/spec/datadog/profiling/native_extension_helpers_spec.rb
+++ b/spec/datadog/profiling/native_extension_helpers_spec.rb
@@ -33,6 +33,46 @@ RSpec.describe Datadog::Profiling::NativeExtensionHelpers do
     end
   end
 
+  describe '.libdatadog_folder_relative_to_ruby_extensions_folders' do
+    context 'when libdatadog is available' do
+      before do
+        skip_if_profiling_not_supported(self)
+        if PlatformHelpers.mac? && Libdatadog.pkgconfig_folder.nil? && ENV['LIBDATADOG_VENDOR_OVERRIDE'].nil?
+          raise 'You have a libdatadog setup without macOS support. Did you forget to set LIBDATADOG_VENDOR_OVERRIDE?'
+        end
+      end
+
+      it 'returns a relative path to libdatadog folder from the ruby extensions folders' do
+        extensions_relative, bundler_extensions_relative =
+          described_class.libdatadog_folder_relative_to_ruby_extensions_folders
+
+        libdatadog_extension = RbConfig::CONFIG['SOEXT'] || raise('Missing SOEXT for current platform')
+        libdatadog = "libdatadog_profiling.#{libdatadog_extension}"
+
+        expect(extensions_relative).to start_with('../')
+        expect(bundler_extensions_relative).to start_with('../')
+
+        extensions_full =
+          "#{Gem.dir}/extensions/platform/extension_api_version/datadog_version/#{extensions_relative}/#{libdatadog}"
+        bundler_extensions_full =
+          "#{Gem.dir}/bundler/gems/extensions/platform/extension_api_version/datadog_version/" \
+          "#{bundler_extensions_relative}/#{libdatadog}"
+
+        expect(File.exist?(Pathname.new(extensions_full).cleanpath.to_s))
+          .to be(true), "Libdatadog not available in expected path: #{extensions_full.inspect}"
+        expect(File.exist?(Pathname.new(bundler_extensions_full).cleanpath.to_s))
+          .to be(true), "Libdatadog not available in expected path: #{bundler_extensions_full.inspect}"
+      end
+    end
+
+    context 'when libdatadog is unsupported' do
+      it do
+        expect(described_class.libdatadog_folder_relative_to_ruby_extensions_folders(libdatadog_pkgconfig_folder: nil)).to be nil
+      end
+    end
+  end
+
+
   describe '::LIBDATADOG_VERSION' do
     it 'must match the version restriction set on the gemspec' do
       # This test is expected to break when the libdatadog version on the .gemspec is updated but we forget to update

--- a/spec/datadog/profiling/native_extension_helpers_spec.rb
+++ b/spec/datadog/profiling/native_extension_helpers_spec.rb
@@ -67,11 +67,12 @@ RSpec.describe Datadog::Profiling::NativeExtensionHelpers do
 
     context 'when libdatadog is unsupported' do
       it do
-        expect(described_class.libdatadog_folder_relative_to_ruby_extensions_folders(libdatadog_pkgconfig_folder: nil)).to be nil
+        expect(
+          described_class.libdatadog_folder_relative_to_ruby_extensions_folders(libdatadog_pkgconfig_folder: nil)
+        ).to be nil
       end
     end
   end
-
 
   describe '::LIBDATADOG_VERSION' do
     it 'must match the version restriction set on the gemspec' do


### PR DESCRIPTION
**What does this PR do?**

This is a cherry-pick of #3683 which was first applied to the 1.x-stable branch. See that PR for details.

The diff is slightly different in the spec file since 1.x-stable needed a few tweaks to support older Rubies, which 2.x doesn't need. Everything else is the same.

**Motivation:**

Fix the rpath issue.

**Additional Notes:**

N/A

**How to test the change?**

See #3683 && and additional integration test for this was added on https://github.com/DataDog/prof-correctness/pull/39 .
