### PR TITLE
fix: ensure the correct ids are serialized and propagated

### DIFF
--- a/lib/datadog/opentelemetry/sdk/propagator.rb
+++ b/lib/datadog/opentelemetry/sdk/propagator.rb
@@ -41,9 +41,9 @@ module Datadog
           digest = @datadog_propagator.extract(carrier)
           return context unless digest
 
-          # Converts the {Numeric} Datadog id object to OpenTelemetry's byte array format.
-          trace_id = [format('%032x', digest.trace_id)].pack('H32')
-          span_id = [format('%016x', digest.span_id)].pack('H16')
+          # Converts the {Numeric} Datadog id object to OpenTelemetry's byte array format.  
+          trace_id = [digest.trace_id >> 64, digest.trace_id & 0xFFFFFFFFFFFFFFFF].pack('Q>Q>') # 128-bit unsigned, big-endian integer  
+          span_id = [digest.span_id].pack('Q>') # 64-bit unsigned, big-endian integer 
 
           if digest.trace_state || digest.trace_flags
             trace_flags = ::OpenTelemetry::Trace::TraceFlags.from_byte(digest.trace_flags)

--- a/lib/datadog/opentelemetry/sdk/propagator.rb
+++ b/lib/datadog/opentelemetry/sdk/propagator.rb
@@ -41,9 +41,11 @@ module Datadog
           digest = @datadog_propagator.extract(carrier)
           return context unless digest
 
-          # Converts the {Numeric} Datadog id object to OpenTelemetry's byte array format.  
-          trace_id = [digest.trace_id >> 64, digest.trace_id & 0xFFFFFFFFFFFFFFFF].pack('Q>Q>') # 128-bit unsigned, big-endian integer  
-          span_id = [digest.span_id].pack('Q>') # 64-bit unsigned, big-endian integer 
+          # Converts the {Numeric} Datadog id object to OpenTelemetry's byte array format.
+          # 128-bit unsigned, big-endian integer
+          trace_id = [digest.trace_id >> 64, digest.trace_id & 0xFFFFFFFFFFFFFFFF].pack('Q>Q>')
+          # 64-bit unsigned, big-endian integer
+          span_id = [digest.span_id].pack('Q>')
 
           if digest.trace_state || digest.trace_flags
             trace_flags = ::OpenTelemetry::Trace::TraceFlags.from_byte(digest.trace_flags)

--- a/lib/datadog/opentelemetry/sdk/span_processor.rb
+++ b/lib/datadog/opentelemetry/sdk/span_processor.rb
@@ -85,11 +85,6 @@ module Datadog
           name, kwargs = span_arguments(span, attributes)
 
           datadog_span = Tracing.trace(name, **kwargs)
-          # The Datadog span must have the same ID as the OpenTelemetry span
-          # DEV: We need to set the span ID after the span is created
-          datadog_span.id = span.context.hex_span_id.to_i(16)
-          datadog_span.trace_id = span.context.hex_trace_id.to_i(16)
-
           datadog_span.set_error([nil, span.status.description]) unless span.status.ok?
           datadog_span.set_tags(span.attributes)
 
@@ -146,6 +141,9 @@ module Datadog
           attributes.flatten!(1)
 
           kwargs[:tags] = attributes.to_h
+
+          # DEV: The datadog span must have the same ID as the OpenTelemetry span
+          kwargs[:id] = span.context.hex_span_id.to_i(16)
 
           [name, kwargs]
         end

--- a/lib/datadog/opentelemetry/sdk/span_processor.rb
+++ b/lib/datadog/opentelemetry/sdk/span_processor.rb
@@ -70,7 +70,8 @@ module Datadog
           if parent_context.trace
             Tracing.send(:tracer).send(:call_context).activate!(parent_context.ensure_trace)
           else
-            Tracing.continue_trace!(nil)
+            otel_trace_id = span.context.hex_trace_id.to_i(16)
+            Tracing.continue_trace!(Datadog::Tracing::TraceDigest.new(trace_id: otel_trace_id, span_remote: false))
           end
 
           datadog_span = start_datadog_span(span)

--- a/lib/datadog/opentelemetry/sdk/span_processor.rb
+++ b/lib/datadog/opentelemetry/sdk/span_processor.rb
@@ -85,6 +85,10 @@ module Datadog
           name, kwargs = span_arguments(span, attributes)
 
           datadog_span = Tracing.trace(name, **kwargs)
+          # The Datadog span must have the same ID as the OpenTelemetry span
+          # DEV: We need to set the span ID after the span is created
+          datadog_span.id = span.context.hex_span_id.to_i(16)
+          datadog_span.trace_id = span.context.hex_trace_id.to_i(16)
 
           datadog_span.set_error([nil, span.status.description]) unless span.status.ok?
           datadog_span.set_tags(span.attributes)

--- a/lib/datadog/tracing.rb
+++ b/lib/datadog/tracing.rb
@@ -23,6 +23,7 @@ module Datadog
         start_time: nil,
         tags: nil,
         type: nil,
+        id: nil,
         &block
       )
 
@@ -35,6 +36,7 @@ module Datadog
           start_time: start_time,
           tags: tags,
           type: type,
+          id: id,
           &block
         )
       end

--- a/lib/datadog/tracing/span_operation.rb
+++ b/lib/datadog/tracing/span_operation.rb
@@ -40,7 +40,8 @@ module Datadog
         tags: nil,
         trace_id: nil,
         type: nil,
-        links: nil
+        links: nil,
+        id: nil
       )
         # Ensure dynamically created strings are UTF-8 encoded.
         #
@@ -52,7 +53,7 @@ module Datadog
         self.type = type
         self.resource = resource
 
-        @id = Tracing::Utils.next_id
+        @id = id.nil? ? Tracing::Utils.next_id : id
         @parent_id = parent_id || 0
         @trace_id = trace_id || Tracing::Utils::TraceId.next_id
 

--- a/lib/datadog/tracing/span_operation.rb
+++ b/lib/datadog/tracing/span_operation.rb
@@ -25,16 +25,8 @@ module Datadog
 
       # Span attributes
       # NOTE: In the future, we should drop the me
-      attr_reader \
-        :end_time,
-        :id,
-        :name,
-        :parent_id,
-        :resource,
-        :service,
-        :start_time,
-        :trace_id,
-        :type
+      attr_accessor :id, :trace_id
+      attr_reader :end_time, :name, :parent_id, :resource, :service, :start_time, :type
       attr_accessor :links, :status
 
       def initialize(

--- a/lib/datadog/tracing/span_operation.rb
+++ b/lib/datadog/tracing/span_operation.rb
@@ -25,8 +25,16 @@ module Datadog
 
       # Span attributes
       # NOTE: In the future, we should drop the me
-      attr_accessor :id, :trace_id
-      attr_reader :end_time, :name, :parent_id, :resource, :service, :start_time, :type
+      attr_reader \
+        :end_time,
+        :id,
+        :name,
+        :parent_id,
+        :resource,
+        :service,
+        :start_time,
+        :trace_id,
+        :type
       attr_accessor :links, :status
 
       def initialize(

--- a/lib/datadog/tracing/trace_operation.rb
+++ b/lib/datadog/tracing/trace_operation.rb
@@ -181,6 +181,7 @@ module Datadog
         start_time: nil,
         tags: nil,
         type: nil,
+        id: nil,
         &block
       )
         # Don't allow more span measurements if the
@@ -197,7 +198,8 @@ module Datadog
           service: service,
           start_time: start_time,
           tags: tags,
-          type: type
+          type: type,
+          id: id
         )
 
         # Start span measurement
@@ -212,7 +214,8 @@ module Datadog
         service: nil,
         start_time: nil,
         tags: nil,
-        type: nil
+        type: nil,
+        id: nil
       )
         begin
           # Resolve span options:
@@ -249,7 +252,8 @@ module Datadog
             start_time: start_time,
             tags: tags,
             trace_id: trace_id,
-            type: type
+            type: type,
+            id: id
           )
         rescue StandardError => e
           Datadog.logger.debug { "Failed to build new span: #{e}" }

--- a/lib/datadog/tracing/tracer.rb
+++ b/lib/datadog/tracing/tracer.rb
@@ -113,6 +113,7 @@ module Datadog
       # @param [String] service the service name for this span.
       # @param [Time] start_time time which the span should have started.
       # @param [Hash<String,String>] tags extra tags which should be added to the span.
+      # @param [String] type the type of the span. See {Datadog::Tracing::Metadata::Ext::AppTypes}.
       # @param [Integer] the id of the new span.
       # @return [Object] If a block is provided, returns the result of the block execution.
       # @return [Datadog::Tracing::SpanOperation] If no block is provided, returns the active,

--- a/lib/datadog/tracing/tracer.rb
+++ b/lib/datadog/tracing/tracer.rb
@@ -113,7 +113,7 @@ module Datadog
       # @param [String] service the service name for this span.
       # @param [Time] start_time time which the span should have started.
       # @param [Hash<String,String>] tags extra tags which should be added to the span.
-      # @param [String] type the type of the span. See {Datadog::Tracing::Metadata::Ext::AppTypes}.
+      # @param [Integer] the id of the new span.
       # @return [Object] If a block is provided, returns the result of the block execution.
       # @return [Datadog::Tracing::SpanOperation] If no block is provided, returns the active,
       #         unfinished {Datadog::Tracing::SpanOperation}.
@@ -130,6 +130,7 @@ module Datadog
         start_time: nil,
         tags: nil,
         type: nil,
+        id: nil,
         &block
       )
         return skip_trace(name, &block) unless enabled
@@ -162,6 +163,7 @@ module Datadog
               tags: tags,
               type: type,
               _trace: trace,
+              id: id,
               &block
             )
           end
@@ -178,7 +180,8 @@ module Datadog
             start_time: start_time,
             tags: tags,
             type: type,
-            _trace: trace
+            _trace: trace,
+            id: id
           )
         end
       end
@@ -375,6 +378,7 @@ module Datadog
         tags: nil,
         type: nil,
         _trace: nil,
+        id: nil,
         &block
       )
         trace = _trace || start_trace(continue_from: continue_from)
@@ -391,6 +395,7 @@ module Datadog
             service: service,
             tags: resolve_tags(tags),
             type: type,
+            id: id,
             &block
           )
         else
@@ -403,7 +408,8 @@ module Datadog
             service: service,
             start_time: start_time,
             tags: resolve_tags(tags),
-            type: type
+            type: type,
+            id: id
           )
 
           span.start(start_time)

--- a/spec/datadog/opentelemetry_spec.rb
+++ b/spec/datadog/opentelemetry_spec.rb
@@ -333,11 +333,7 @@ RSpec.describe Datadog::OpenTelemetry do
           it 'the underlying datadog spans has the same span_id as the otel spans' do
             existing_span.finish
             start_span.finish
-            # parent otel span generates a Datadog span with the same ids
-            expect(existing_span.context.hex_trace_id.to_i(16)).to eq(parent.trace_id)
             expect(existing_span.context.hex_span_id.to_i(16)).to eq(parent.id)
-            # child otel span generates a Datadog span with the same ids
-            expect(start_span.context.hex_trace_id.to_i(16)).to eq(child.trace_id)
             expect(start_span.context.hex_span_id.to_i(16)).to eq(child.id)
           end
         end

--- a/spec/datadog/opentelemetry_spec.rb
+++ b/spec/datadog/opentelemetry_spec.rb
@@ -329,6 +329,17 @@ RSpec.describe Datadog::OpenTelemetry do
             expect(parent).to be_root_span
             expect(child.parent_id).to eq(parent.id)
           end
+
+          it 'the underlying datadog spans has the same span_id as the otel spans' do
+            existing_span.finish
+            start_span.finish
+            # parent otel span generates a Datadog span with the same ids
+            expect(existing_span.context.hex_trace_id.to_i(16)).to eq(parent.trace_id)
+            expect(existing_span.context.hex_span_id.to_i(16)).to eq(parent.id)
+            # child otel span generates a Datadog span with the same ids
+            expect(start_span.context.hex_trace_id.to_i(16)).to eq(child.trace_id)
+            expect(start_span.context.hex_span_id.to_i(16)).to eq(child.id)
+          end
         end
       end
 
@@ -802,7 +813,7 @@ RSpec.describe Datadog::OpenTelemetry do
         context 'with TraceContext headers' do
           let(:carrier) do
             {
-              'traceparent' => '00-00000000000000001111111111111111-2222222222222222-01'
+              'traceparent' => '00-11111111111111111111111111111111-2222222222222222-01'
             }
           end
 
@@ -817,7 +828,7 @@ RSpec.describe Datadog::OpenTelemetry do
               otel_tracer.in_span('otel') {}
             end
 
-            expect(span.trace_id).to eq(0x00000000000000001111111111111111)
+            expect(span.trace_id).to eq(0x11111111111111111111111111111111)
             expect(span.parent_id).to eq(0x2222222222222222)
           end
         end

--- a/spec/datadog/profiling/collectors/thread_context_spec.rb
+++ b/spec/datadog/profiling/collectors/thread_context_spec.rb
@@ -547,9 +547,9 @@ RSpec.describe Datadog::Profiling::Collectors::ThreadContext do
 
             let(:t1) do
               Thread.new(ready_queue, otel_tracer) do |ready_queue, otel_tracer|
-                otel_tracer.in_span('profiler.test') do |span|
-                  @t1_span_id = span.context.hex_span_id.to_i(16)
-                  @t1_local_root_span_id = span.context.hex_span_id.to_i(16)
+                otel_tracer.in_span('profiler.test') do
+                  @t1_span_id = Datadog::Tracing.correlation.span_id
+                  @t1_local_root_span_id = Datadog::Tracing.correlation.span_id
                   ready_queue << true
                   sleep
                 end
@@ -574,12 +574,12 @@ RSpec.describe Datadog::Profiling::Collectors::ThreadContext do
             context 'when there are multiple otel spans nested' do
               let(:t1) do
                 Thread.new(ready_queue, otel_tracer) do |ready_queue, otel_tracer|
-                  otel_tracer.in_span('profiler.test') do |root|
-                    @t1_local_root_span_id = root.context.hex_span_id.to_i(16)
+                  otel_tracer.in_span('profiler.test') do
+                    @t1_local_root_span_id = Datadog::Tracing.correlation.span_id
                     otel_tracer.in_span('profiler.test.nested.1') do
                       otel_tracer.in_span('profiler.test.nested.2') do
-                        otel_tracer.in_span('profiler.test.nested.3') do |leaf|
-                          @t1_span_id = leaf.context.hex_span_id.to_i(16)
+                        otel_tracer.in_span('profiler.test.nested.3') do
+                          @t1_span_id = Datadog::Tracing.correlation.span_id
                           ready_queue << true
                           sleep
                         end
@@ -641,8 +641,8 @@ RSpec.describe Datadog::Profiling::Collectors::ThreadContext do
               context 'when top-level span is started from otel' do
                 let(:t1) do
                   Thread.new(ready_queue, otel_tracer) do |ready_queue, otel_tracer|
-                    otel_tracer.in_span('profiler.test') do |root|
-                      @t1_local_root_span_id = root.context.hex_span_id.to_i(16)
+                    otel_tracer.in_span('profiler.test') do
+                      @t1_local_root_span_id = Datadog::Tracing.correlation.span_id
                       otel_tracer.in_span('profiler.test.nested.1') do
                         Datadog::Tracing.trace('profiler.test.nested.2') do
                           otel_tracer.in_span('profiler.test.nested.3') do

--- a/spec/datadog/tracing/span_operation_spec.rb
+++ b/spec/datadog/tracing/span_operation_spec.rb
@@ -224,6 +224,20 @@ RSpec.describe Datadog::Tracing::SpanOperation do
         end
       end
 
+      describe ':id' do
+        let(:options) { { id: id } }
+
+        context 'that is nil' do
+          let(:id) { nil }
+          it { is_expected.to have_attributes(id: kind_of(Integer)) }
+        end
+
+        context 'that is an Integer' do
+          let(:id) { instance_double(Integer) }
+          it { is_expected.to have_attributes(id: id) }
+        end
+      end
+
       describe ':resource' do
         it_behaves_like 'a string property' do
           let(:property) { :resource }
@@ -316,24 +330,6 @@ RSpec.describe Datadog::Tracing::SpanOperation do
       let(:resource) { 'legacy'.encode(Encoding::ASCII) }
       it { expect(span_op.resource).to eq(resource) }
       it { expect(span_op.resource.encoding).to eq(Encoding::UTF_8) }
-    end
-  end
-
-  describe '#id=' do
-    subject!(:id=) { span_op.id = id }
-
-    context 'with a valid 64 bit integer' do
-      let(:id) { 2 ^ 64 - 1 }
-      it { expect(span_op.id).to eq(id) }
-    end
-  end
-
-  describe '#trace_id=' do
-    subject!(:trace_id=) { span_op.trace_id = trace_id }
-
-    context 'with a valid 128 bit integer' do
-      let(:trace_id) { 2 ^ 128 - 1 }
-      it { expect(span_op.trace_id).to eq(trace_id) }
     end
   end
 

--- a/spec/datadog/tracing/span_operation_spec.rb
+++ b/spec/datadog/tracing/span_operation_spec.rb
@@ -319,6 +319,24 @@ RSpec.describe Datadog::Tracing::SpanOperation do
     end
   end
 
+  describe '#id=' do
+    subject!(:id=) { span_op.id = id }
+
+    context 'with a valid 64 bit integer' do
+      let(:id) { 2 ^ 64 - 1 }
+      it { expect(span_op.id).to eq(id) }
+    end
+  end
+
+  describe '#trace_id=' do
+    subject!(:trace_id=) { span_op.trace_id = trace_id }
+
+    context 'with a valid 128 bit integer' do
+      let(:trace_id) { 2 ^ 128 - 1 }
+      it { expect(span_op.trace_id).to eq(trace_id) }
+    end
+  end
+
   describe '#measure' do
     subject(:measure) { span_op.measure(&block) }
 

--- a/spec/datadog/tracing_spec.rb
+++ b/spec/datadog/tracing_spec.rb
@@ -69,6 +69,7 @@ RSpec.describe Datadog::Tracing do
         start_time: start_time,
         tags: tags,
         type: type,
+        id: id,
         &block
       )
     end
@@ -81,6 +82,7 @@ RSpec.describe Datadog::Tracing do
     let(:start_time) { double('start_time') }
     let(:tags) { double('tags') }
     let(:type) { double('type') }
+    let(:id) { double(1) }
     let(:block) { -> {} }
 
     it 'delegates to the tracer' do
@@ -93,7 +95,8 @@ RSpec.describe Datadog::Tracing do
           service: service,
           start_time: start_time,
           tags: tags,
-          type: type
+          type: type,
+          id: id
         ) { |&b| expect(b).to be(block) }
         .and_return(returned)
       expect(trace).to eq(returned)


### PR DESCRIPTION
**What does this PR do?**

- Ensures span_ids and trace_ids are encoded/decoded (integer <-> bytes) in a manner that is [consistent with the OpenTelemetry API](https://github.com/open-telemetry/opentelemetry-ruby/blob/5b2cc8ffe7614c27fd69f0b40d34368f0c06ff53/api/lib/opentelemetry/trace/span_context.rb#L41-L50)
  - Ensures 128bit trace_ids are not truncated to 64bits in the OpenTelemetry propagator
  - Ensures OpenTelemetry spans generate a corresponding Datadog span with the same Span ID and TraceID. This ensures OtelSpan.context returns the expected value. Regression test: https://github.com/DataDog/system-tests/pull/2548

**Motivation:**
<!-- What inspired you to submit this pull request? -->

**Additional Notes:**
<!-- Anything else we should know when reviewing? -->

**How to test the change?**
<!--
Describe here how the change can be validated.
You are strongly encouraged to provide automated tests for this PR (unit or integration).
If this change cannot be feasibly tested, please explain why,
unless the change does not modify code (e.g. only modifies docs, comments).
-->

Unsure? Have a question? Request a review!
