### PR TITLE
backport(OCI): Backport OCI build (#3662) in 1.x-stable

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -149,10 +149,59 @@ package-arm64:
     - export RUBY_PACKAGE_VERSION=$(cat ../tmp/version.txt)
     - ../.gitlab/build-deb-rpm.sh
 
+package-oci-amd64:
+  extends: .package-oci
+  stage: package
+  needs:
+    - build-gem
+    - install-dependencies-amd64
+  variables:
+    ARCH: amd64
+  script:
+    - cp ../lib-injection/host_inject.rb ../tmp
+    - export RUBY_PACKAGE_VERSION=$(cat ../tmp/version.txt)
+    - ../.gitlab/build-oci-package.sh
+
+package-oci-arm64:
+  extends: .package-oci
+  stage: package
+  needs:
+    - build-gem
+    - install-dependencies-arm64
+  variables:
+    ARCH: arm64
+  script:
+    - cp ../lib-injection/host_inject.rb ../tmp
+    - export RUBY_PACKAGE_VERSION=$(cat ../tmp/version.txt)
+    - ../.gitlab/build-oci-package.sh
+
+oci-internal-publish:
+  extends: .oci-internal-publish
+  stage: package
+  needs: [ package-oci-arm64, package-oci-amd64 ]
+  rules:
+    - when: on_success
+  variables:
+    FLAVOR: datadog-apm-library-ruby
+
+oci-internal-test-ecr-publish:
+  stage: package
+  needs: [ oci-internal-publish ]
+  rules:
+    - when: on_success
+  trigger:
+    project: DataDog/public-images
+    branch: main
+    strategy: depend
+  variables:
+    IMG_SOURCES: registry.ddbuild.io/ci/remote-updates/datadog-apm-library-ruby:pipeline-${CI_PIPELINE_ID}-1
+    IMG_DESTINATIONS: apm-library-ruby-package:pipeline-${CI_PIPELINE_ID}
+    IMG_REGISTRIES: agent-qa
+
 onboarding_tests:
   extends: .base_job_onboarding_tests
   stage: integration-tests
-  needs: [ package-amd64, package-arm64]
+  needs: [ package-amd64, package-arm64, oci-internal-test-ecr-publish]
   allow_failure: false
   variables:
     TEST_LIBRARY: ruby
@@ -163,10 +212,13 @@ onboarding_tests:
           SCENARIO: [SIMPLE_HOST_AUTO_INJECTION]
         - ONBOARDING_FILTER_WEBLOG: [test-app-ruby-container]
           SCENARIO: [SIMPLE_CONTAINER_AUTO_INJECTION]
+        - ONBOARDING_FILTER_WEBLOG: [test-app-ruby,test-app-ruby-container]
+          SCENARIO: [INSTALLER_AUTO_INJECTION]
   script:
     - git clone https://git@github.com/DataDog/system-tests.git system-tests
     - cp packaging/*.rpm system-tests/binaries
     - cp packaging/*.deb system-tests/binaries
+    - export DD_INSTALLER_LIBRARY_VERSION="pipeline-${CI_PIPELINE_ID}"
     - ls system-tests/binaries
     - cd system-tests
     - ./build.sh -i runner

--- a/.gitlab/build-oci-package.sh
+++ b/.gitlab/build-oci-package.sh
@@ -1,0 +1,19 @@
+#!/bin/bash
+
+set -e
+
+mkdir sources
+
+cp -r ../tmp/* sources
+sed -i "s#/opt/datadog/apm/library/ruby/#/opt/datadog-packages/datadog-apm-library-ruby/$RUBY_PACKAGE_VERSION/#g" sources/host_inject.rb
+
+echo -n "$RUBY_PACKAGE_VERSION" > sources/version
+
+datadog-package create \
+  --version="$RUBY_PACKAGE_VERSION" \
+  --package="datadog-apm-library-ruby" \
+  --archive=true \
+  --archive-path="datadog-apm-library-ruby-$RUBY_PACKAGE_VERSION-$ARCH.tar" \
+  --arch "$ARCH" \
+  --os "linux" \
+  ./sources

--- a/.gitlab/onboarding_tests.yml
+++ b/.gitlab/onboarding_tests.yml
@@ -10,6 +10,7 @@
     - export DD_APP_KEY_ONBOARDING=$(aws ssm get-parameter --region us-east-1 --name ci.dd-trace-rb.dd-app-key-onboarding --with-decryption --query "Parameter.Value" --out text)
     - export ONBOARDING_AWS_INFRA_SUBNET_ID=$(aws ssm get-parameter --region us-east-1 --name ci.dd-trace-rb.aws-infra-subnet-id --with-decryption --query "Parameter.Value" --out text)
     - export ONBOARDING_AWS_INFRA_SECURITY_GROUPS_ID=$(aws ssm get-parameter --region us-east-1 --name ci.dd-trace-rb.aws-infra-securiy-groups-id --with-decryption --query "Parameter.Value" --out text)
+    - export ONBOARDING_AWS_INFRA_IAM_INSTANCE_PROFILE=ec2InstanceRole
     - export PULUMI_CONFIG_PASSPHRASE=$(aws ssm get-parameter --region us-east-1 --name ci.dd-trace-rb.pulumi-config-passphrase --with-decryption --query "Parameter.Value" --out text) 
     #Install plugins for PULUMI you need connect to gh. Sometimes this problem arises: GitHub rate limit exceeded
     - export GITHUB_TOKEN=$(aws ssm get-parameter --region us-east-1 --name ci.dd-trace-rb.gh-token --with-decryption --query "Parameter.Value" --out text) 


### PR DESCRIPTION
**What does this PR do?**
Backports #3662 so we can have OCI builds for 1.X

**Motivation:**
Make sure CI setup in 1.x-stable stays in good shape.

**Additional Notes:**
N/A

**How to test the change?**
If Gitlab CI is green then we are good