### PR TITLE
chore(lib-injection): update base image to alpine 3.20

### DIFF
--- a/lib-injection/Dockerfile
+++ b/lib-injection/Dockerfile
@@ -1,6 +1,6 @@
 # This image provides the files needed to install the dd-trace-rb
 # and auto instrument Ruby applications in containerized environments.
-FROM alpine:3.18.3
+FROM alpine:3.20
 
 # Set high UID to prevent possible conflict with existing users: http://www.linfo.org/uid.html
 ARG UID=10000


### PR DESCRIPTION
Backport https://github.com/DataDog/dd-trace-rb/pull/3665 to address https://github.com/advisories/GHSA-xw78-pcr6-wrg8.