### PR TITLE
Move publishing OCI image in deploy stage and needs onboarding_tests

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -188,8 +188,10 @@ oci-internal-publish:
     FLAVOR: datadog-apm-library-ruby
 
 oci-internal-test-ecr-publish:
-  stage: package
-  needs: [ oci-internal-publish ]
+  stage: deploy
+  needs:
+    - onboarding_tests
+    - oci-internal-publish
   rules:
     - when: on_success
   trigger:


### PR DESCRIPTION
**What does this PR do?**

This PR moves the `oci-internal-test-ecr-publish` job to `deploy` stage and needs `onboarding_tests` 
