### PR TITLE
Use ghrc.io/datadog/images-rb as base

### DIFF
--- a/.circleci/images/primary/Dockerfile-2.5.9
+++ b/.circleci/images/primary/Dockerfile-2.5.9
@@ -1,12 +1,6 @@
 # Note: See the "Publishing updates to images" note in ./README.md for how to publish new builds of this container image
 
-FROM ruby:2.5.9-buster
-
-# Make apt non-interactive
-RUN echo 'APT::Get::Assume-Yes "true";' > /etc/apt/apt.conf.d/90circleci \
-  && echo 'DPkg::Options "--force-confnew";' >> /etc/apt/apt.conf.d/90circleci
-
-ENV DEBIAN_FRONTEND=noninteractive
+FROM ghcr.io/datadog/images-rb/engines/ruby:2.5
 
 # Install required packages
 RUN set -ex; \
@@ -18,14 +12,6 @@ RUN set -ex; \
             net-tools netcat unzip zip bzip2 gnupg curl wget \
             tzdata rsync vim less jq; \
         rm -rf /var/lib/apt/lists/*;
-
-# Set timezone to UTC by default
-RUN ln -sf /usr/share/zoneinfo/Etc/UTC /etc/localtime
-
-# Set language
-RUN locale-gen en_US.UTF-8
-ENV LANG en_US.UTF-8
-ENV LANGUAGE en_US:en
 
 # Install Docker
 RUN set -ex \
@@ -53,14 +39,6 @@ RUN DOCKERIZE_URL="https://github.com/powerman/dockerize/releases/download/v0.17
   && curl --silent --show-error --location --fail --retry 3 --output /usr/local/bin/dockerize $DOCKERIZE_URL \
   && chmod +x /usr/local/bin/dockerize \
   && dockerize --version
-
-# Install RubyGems
-RUN mkdir -p "$GEM_HOME" && chmod -R 777 "$GEM_HOME"
-
-# Install RubyGems and Bundler
-RUN gem update --system 3.3.26
-RUN gem install bundler -v '~> 2.3.26'
-ENV BUNDLE_SILENCE_ROOT_WARNING 1
 
 RUN mkdir /app
 WORKDIR /app

--- a/.circleci/images/primary/Dockerfile-2.6.10
+++ b/.circleci/images/primary/Dockerfile-2.6.10
@@ -1,12 +1,6 @@
 # Note: See the "Publishing updates to images" note in ./README.md for how to publish new builds of this container image
 
-FROM ruby:2.6.10-bullseye
-
-# Make apt non-interactive
-RUN echo 'APT::Get::Assume-Yes "true";' > /etc/apt/apt.conf.d/90circleci \
-  && echo 'DPkg::Options "--force-confnew";' >> /etc/apt/apt.conf.d/90circleci
-
-ENV DEBIAN_FRONTEND=noninteractive
+FROM ghcr.io/datadog/images-rb/engines/ruby:2.6
 
 # Install required packages
 RUN set -ex; \
@@ -18,14 +12,6 @@ RUN set -ex; \
             net-tools netcat unzip zip bzip2 gnupg curl wget \
             tzdata rsync vim less jq; \
         rm -rf /var/lib/apt/lists/*;
-
-# Set timezone to UTC by default
-RUN ln -sf /usr/share/zoneinfo/Etc/UTC /etc/localtime
-
-# Set language
-RUN locale-gen en_US.UTF-8
-ENV LANG en_US.UTF-8
-ENV LANGUAGE en_US:en
 
 # Install Docker
 RUN set -ex \
@@ -53,14 +39,6 @@ RUN DOCKERIZE_URL="https://github.com/powerman/dockerize/releases/download/v0.17
   && curl --silent --show-error --location --fail --retry 3 --output /usr/local/bin/dockerize $DOCKERIZE_URL \
   && chmod +x /usr/local/bin/dockerize \
   && dockerize --version
-
-# Install RubyGems
-RUN mkdir -p "$GEM_HOME" && chmod -R 777 "$GEM_HOME"
-
-# Install RubyGems
-RUN gem update --system 3.3.26
-RUN gem install bundler -v '~> 2.3.26'
-ENV BUNDLE_SILENCE_ROOT_WARNING 1
 
 RUN mkdir /app
 WORKDIR /app

--- a/.circleci/images/primary/Dockerfile-2.7.8
+++ b/.circleci/images/primary/Dockerfile-2.7.8
@@ -1,12 +1,6 @@
 # Note: See the "Publishing updates to images" note in ./README.md for how to publish new builds of this container image
 
-FROM ruby:2.7.8-bullseye
-
-# Make apt non-interactive
-RUN echo 'APT::Get::Assume-Yes "true";' > /etc/apt/apt.conf.d/90circleci \
-  && echo 'DPkg::Options "--force-confnew";' >> /etc/apt/apt.conf.d/90circleci
-
-ENV DEBIAN_FRONTEND=noninteractive
+FROM ghcr.io/datadog/images-rb/engines/ruby:2.7
 
 # Install required packages
 RUN set -ex; \
@@ -18,14 +12,6 @@ RUN set -ex; \
             net-tools netcat unzip zip bzip2 gnupg curl wget \
             tzdata rsync vim less jq; \
         rm -rf /var/lib/apt/lists/*;
-
-# Set timezone to UTC by default
-RUN ln -sf /usr/share/zoneinfo/Etc/UTC /etc/localtime
-
-# Set language
-RUN locale-gen en_US.UTF-8
-ENV LANG en_US.UTF-8
-ENV LANGUAGE en_US:en
 
 # Install Docker
 RUN set -ex \
@@ -53,14 +39,6 @@ RUN DOCKERIZE_URL="https://github.com/powerman/dockerize/releases/download/v0.17
   && curl --silent --show-error --location --fail --retry 3 --output /usr/local/bin/dockerize $DOCKERIZE_URL \
   && chmod +x /usr/local/bin/dockerize \
   && dockerize --version
-
-# Install RubyGems
-RUN mkdir -p "$GEM_HOME" && chmod -R 777 "$GEM_HOME"
-
-# Upgrade RubyGems and Bundler # Upgrading disabled until https://github.com/thoughtbot/appraisal/issues/162 is fixed
-RUN gem update --system 3.3.26
-RUN gem install bundler -v '~> 2.3.26'
-ENV BUNDLE_SILENCE_ROOT_WARNING 1
 
 RUN mkdir /app
 WORKDIR /app

--- a/.circleci/images/primary/Dockerfile-3.0.7
+++ b/.circleci/images/primary/Dockerfile-3.0.7
@@ -1,12 +1,6 @@
 # Note: See the "Publishing updates to images" note in ./README.md for how to publish new builds of this container image
 
-FROM ruby:3.0.7-bullseye
-
-# Make apt non-interactive
-RUN echo 'APT::Get::Assume-Yes "true";' > /etc/apt/apt.conf.d/90circleci \
-  && echo 'DPkg::Options "--force-confnew";' >> /etc/apt/apt.conf.d/90circleci
-
-ENV DEBIAN_FRONTEND=noninteractive
+FROM ghcr.io/datadog/images-rb/engines/ruby:3.0
 
 # Install required packages
 RUN set -ex; \
@@ -18,14 +12,6 @@ RUN set -ex; \
             net-tools netcat unzip zip bzip2 gnupg curl wget \
             tzdata rsync vim less jq; \
         rm -rf /var/lib/apt/lists/*;
-
-# Set timezone to UTC by default
-RUN ln -sf /usr/share/zoneinfo/Etc/UTC /etc/localtime
-
-# Set language
-RUN locale-gen en_US.UTF-8
-ENV LANG en_US.UTF-8
-ENV LANGUAGE en_US:en
 
 # Install Docker
 RUN set -ex \
@@ -53,14 +39,6 @@ RUN DOCKERIZE_URL="https://github.com/powerman/dockerize/releases/download/v0.17
   && curl --silent --show-error --location --fail --retry 3 --output /usr/local/bin/dockerize $DOCKERIZE_URL \
   && chmod +x /usr/local/bin/dockerize \
   && dockerize --version
-
-# Install RubyGems
-RUN mkdir -p "$GEM_HOME" && chmod -R 777 "$GEM_HOME"
-
-# Upgrade RubyGems and Bundler
-RUN gem update --system 3.3.26
-RUN gem install bundler -v '~> 2.3.26'
-ENV BUNDLE_SILENCE_ROOT_WARNING 1
 
 RUN mkdir /app
 WORKDIR /app

--- a/.circleci/images/primary/Dockerfile-3.1.6
+++ b/.circleci/images/primary/Dockerfile-3.1.6
@@ -1,12 +1,6 @@
 # Note: See the "Publishing updates to images" note in ./README.md for how to publish new builds of this container image
 
-FROM ruby:3.1.6-bookworm
-
-# Make apt non-interactive
-RUN echo 'APT::Get::Assume-Yes "true";' > /etc/apt/apt.conf.d/90circleci \
-  && echo 'DPkg::Options "--force-confnew";' >> /etc/apt/apt.conf.d/90circleci
-
-ENV DEBIAN_FRONTEND=noninteractive
+FROM ghcr.io/datadog/images-rb/engines/ruby:3.1
 
 # Install required packages
 RUN set -ex; \
@@ -18,14 +12,6 @@ RUN set -ex; \
             net-tools netcat-openbsd unzip zip bzip2 gnupg curl wget \
             tzdata rsync vim less jq; \
         rm -rf /var/lib/apt/lists/*;
-
-# Set timezone to UTC by default
-RUN ln -sf /usr/share/zoneinfo/Etc/UTC /etc/localtime
-
-# Set language
-RUN locale-gen en_US.UTF-8
-ENV LANG en_US.UTF-8
-ENV LANGUAGE en_US:en
 
 # Install Docker
 RUN set -ex \
@@ -53,14 +39,6 @@ RUN DOCKERIZE_URL="https://github.com/powerman/dockerize/releases/download/v0.17
   && curl --silent --show-error --location --fail --retry 3 --output /usr/local/bin/dockerize $DOCKERIZE_URL \
   && chmod +x /usr/local/bin/dockerize \
   && dockerize --version
-
-# Install RubyGems
-RUN mkdir -p "$GEM_HOME" && chmod -R 777 "$GEM_HOME"
-
-# Upgrade RubyGems and Bundler
-RUN gem update --system 3.3.26
-RUN gem install bundler -v '~> 2.3.26'
-ENV BUNDLE_SILENCE_ROOT_WARNING 1
 
 RUN mkdir /app
 WORKDIR /app

--- a/.circleci/images/primary/Dockerfile-3.2.4
+++ b/.circleci/images/primary/Dockerfile-3.2.4
@@ -1,12 +1,6 @@
 # Note: See the "Publishing updates to images" note in ./README.md for how to publish new builds of this container image
 
-FROM ruby:3.2.4-bookworm
-
-# Make apt non-interactive
-RUN echo 'APT::Get::Assume-Yes "true";' > /etc/apt/apt.conf.d/90circleci \
-  && echo 'DPkg::Options "--force-confnew";' >> /etc/apt/apt.conf.d/90circleci
-
-ENV DEBIAN_FRONTEND=noninteractive
+FROM ghcr.io/datadog/images-rb/engines/ruby:3.2
 
 # Install required packages
 RUN set -ex; \
@@ -18,14 +12,6 @@ RUN set -ex; \
             net-tools netcat-openbsd unzip zip bzip2 gnupg curl wget \
             tzdata rsync vim less jq; \
         rm -rf /var/lib/apt/lists/*;
-
-# Set timezone to UTC by default
-RUN ln -sf /usr/share/zoneinfo/Etc/UTC /etc/localtime
-
-# Set language
-RUN locale-gen en_US.UTF-8
-ENV LANG en_US.UTF-8
-ENV LANGUAGE en_US:en
 
 # Install Docker
 RUN set -ex \
@@ -53,14 +39,6 @@ RUN DOCKERIZE_URL="https://github.com/powerman/dockerize/releases/download/v0.17
   && curl --silent --show-error --location --fail --retry 3 --output /usr/local/bin/dockerize $DOCKERIZE_URL \
   && chmod +x /usr/local/bin/dockerize \
   && dockerize --version
-
-# Install RubyGems
-RUN mkdir -p "$GEM_HOME" && chmod -R 777 "$GEM_HOME"
-
-# Upgrade RubyGems and Bundler
-RUN gem update --system 3.3.26
-RUN gem install bundler -v '~> 2.3.26'
-ENV BUNDLE_SILENCE_ROOT_WARNING 1
 
 RUN mkdir /app
 WORKDIR /app

--- a/.circleci/images/primary/Dockerfile-3.3.2
+++ b/.circleci/images/primary/Dockerfile-3.3.2
@@ -1,12 +1,6 @@
 # Note: See the "Publishing updates to images" note in ./README.md for how to publish new builds of this container image
 
-FROM ruby:3.3.2-bookworm
-
-# Make apt non-interactive
-RUN echo 'APT::Get::Assume-Yes "true";' > /etc/apt/apt.conf.d/90circleci \
-  && echo 'DPkg::Options "--force-confnew";' >> /etc/apt/apt.conf.d/90circleci
-
-ENV DEBIAN_FRONTEND=noninteractive
+FROM ghcr.io/datadog/images-rb/engines/ruby:3.3
 
 # Install required packages
 RUN set -ex; \
@@ -18,14 +12,6 @@ RUN set -ex; \
             net-tools netcat-openbsd unzip zip bzip2 gnupg curl wget \
             tzdata rsync vim less jq; \
         rm -rf /var/lib/apt/lists/*;
-
-# Set timezone to UTC by default
-RUN ln -sf /usr/share/zoneinfo/Etc/UTC /etc/localtime
-
-# Set language
-RUN locale-gen en_US.UTF-8
-ENV LANG en_US.UTF-8
-ENV LANGUAGE en_US:en
 
 # Install Docker
 RUN set -ex \
@@ -53,14 +39,6 @@ RUN DOCKERIZE_URL="https://github.com/powerman/dockerize/releases/download/v0.17
   && curl --silent --show-error --location --fail --retry 3 --output /usr/local/bin/dockerize $DOCKERIZE_URL \
   && chmod +x /usr/local/bin/dockerize \
   && dockerize --version
-
-# Install RubyGems
-RUN mkdir -p "$GEM_HOME" && chmod -R 777 "$GEM_HOME"
-
-# Upgrade RubyGems and Bundler
-RUN gem update --system 3.3.26
-RUN gem install bundler -v '~> 2.3.26'
-ENV BUNDLE_SILENCE_ROOT_WARNING 1
 
 RUN mkdir /app
 WORKDIR /app

--- a/.circleci/images/primary/Dockerfile-3.4.0
+++ b/.circleci/images/primary/Dockerfile-3.4.0
@@ -1,12 +1,6 @@
 # Note: See the "Publishing updates to images" note in ./README.md for how to publish new builds of this container image
 
-FROM ruby:3.4.0-preview1-bookworm
-
-# Make apt non-interactive
-RUN echo 'APT::Get::Assume-Yes "true";' > /etc/apt/apt.conf.d/90circleci \
-  && echo 'DPkg::Options "--force-confnew";' >> /etc/apt/apt.conf.d/90circleci
-
-ENV DEBIAN_FRONTEND=noninteractive
+FROM ghcr.io/datadog/images-rb/engines/ruby:3.4
 
 # Install required packages
 RUN set -ex; \
@@ -18,14 +12,6 @@ RUN set -ex; \
             net-tools netcat-openbsd unzip zip bzip2 gnupg curl wget \
             tzdata rsync vim less jq; \
         rm -rf /var/lib/apt/lists/*;
-
-# Set timezone to UTC by default
-RUN ln -sf /usr/share/zoneinfo/Etc/UTC /etc/localtime
-
-# Set language
-RUN locale-gen en_US.UTF-8
-ENV LANG en_US.UTF-8
-ENV LANGUAGE en_US:en
 
 # Install Docker
 RUN set -ex \
@@ -53,11 +39,6 @@ RUN DOCKERIZE_URL="https://github.com/powerman/dockerize/releases/download/v0.17
   && curl --silent --show-error --location --fail --retry 3 --output /usr/local/bin/dockerize $DOCKERIZE_URL \
   && chmod +x /usr/local/bin/dockerize \
   && dockerize --version
-
-# Install RubyGems
-RUN mkdir -p "$GEM_HOME" && chmod -R 777 "$GEM_HOME"
-
-ENV BUNDLE_SILENCE_ROOT_WARNING 1
 
 RUN mkdir /app
 WORKDIR /app

--- a/.circleci/images/primary/Dockerfile-jruby-9.2.21.0
+++ b/.circleci/images/primary/Dockerfile-jruby-9.2.21.0
@@ -1,47 +1,6 @@
 # Note: See the "Publishing updates to images" note in ./README.md for how to publish new builds of this container image
 
-FROM eclipse-temurin:8-jammy AS jruby-9.2.21.0-jre8
-
-RUN apt-get update && apt-get install -y libc6-dev --no-install-recommends && rm -rf /var/lib/apt/lists/*
-
-ENV JRUBY_VERSION 9.2.21.0
-ENV JRUBY_SHA256 dbf05fca4f61bd7d5131d9b83c5f4d1a249213c474b82def37e82013969c8b8a
-RUN mkdir /opt/jruby \
-  && curl -fSL https://repo1.maven.org/maven2/org/jruby/jruby-dist/${JRUBY_VERSION}/jruby-dist-${JRUBY_VERSION}-bin.tar.gz -o /tmp/jruby.tar.gz \
-  && echo "$JRUBY_SHA256 /tmp/jruby.tar.gz" | sha256sum -c - \
-  && tar -zx --strip-components=1 -f /tmp/jruby.tar.gz -C /opt/jruby \
-  && rm /tmp/jruby.tar.gz \
-  && update-alternatives --install /usr/local/bin/ruby ruby /opt/jruby/bin/jruby 1
-ENV PATH /opt/jruby/bin:$PATH
-
-# skip installing gem documentation
-RUN mkdir -p /opt/jruby/etc \
-  && { \
-    echo 'install: --no-document'; \
-    echo 'update: --no-document'; \
-  } >> /opt/jruby/etc/gemrc
-
-RUN gem install rake net-telnet xmlrpc
-
-# install things globally, for great justice
-# and don't create ".bundle" in all our apps
-ENV GEM_HOME /usr/local/bundle
-ENV BUNDLE_BIN="$GEM_HOME/bin" \
-    BUNDLE_SILENCE_ROOT_WARNING=1 \
-    BUNDLE_APP_CONFIG="$GEM_HOME"
-ENV PATH $BUNDLE_BIN:$PATH
-RUN mkdir -p "$GEM_HOME" "$BUNDLE_BIN" \
-  && chmod 777 "$GEM_HOME" "$BUNDLE_BIN"
-
-CMD [ "irb" ]
-
-FROM jruby-9.2.21.0-jre8
-
-# Make apt non-interactive
-RUN echo 'APT::Get::Assume-Yes "true";' > /etc/apt/apt.conf.d/90circleci \
-  && echo 'DPkg::Options "--force-confnew";' >> /etc/apt/apt.conf.d/90circleci
-
-ENV DEBIAN_FRONTEND=noninteractive
+FROM ghcr.io/datadog/images-rb/engines/jruby:9.2
 
 # Install required packages
 RUN set -ex; \
@@ -55,14 +14,6 @@ RUN set -ex; \
             build-essential \
             shared-mime-info; \
         rm -rf /var/lib/apt/lists/*;
-
-# Set timezone to UTC by default
-RUN ln -sf /usr/share/zoneinfo/Etc/UTC /etc/localtime
-
-# Set language
-RUN locale-gen en_US.UTF-8
-ENV LANG en_US.UTF-8
-ENV LANGUAGE en_US:en
 
 # Install Docker
 RUN set -ex \
@@ -90,17 +41,6 @@ RUN DOCKERIZE_URL="https://github.com/powerman/dockerize/releases/download/v0.17
   && curl --silent --show-error --location --fail --retry 3 --output /usr/local/bin/dockerize $DOCKERIZE_URL \
   && chmod +x /usr/local/bin/dockerize \
   && dockerize --version
-
-# Install RubyGems
-RUN mkdir -p "$GEM_HOME" && chmod -R 777 "$GEM_HOME"
-
-# Upgrade RubyGems and Bundler
-RUN gem update --system 3.3.26
-RUN gem install bundler -v '~> 2.3.26'
-ENV BUNDLE_SILENCE_ROOT_WARNING 1
-
-# Ensure JRuby is available when running "bash --login"
-RUN echo "export PATH=/opt/jruby/bin:$BUNDLE_BIN:\$PATH" >> ~/.profile
 
 RUN mkdir /app
 WORKDIR /app

--- a/.circleci/images/primary/Dockerfile-jruby-9.3.9.0
+++ b/.circleci/images/primary/Dockerfile-jruby-9.3.9.0
@@ -1,47 +1,6 @@
 # Note: See the "Publishing updates to images" note in ./README.md for how to publish new builds of this container image
 
-FROM eclipse-temurin:11-jammy AS jruby-9.3.9.0-jre11
-
-RUN apt-get update && apt-get install -y libc6-dev --no-install-recommends && rm -rf /var/lib/apt/lists/*
-
-ENV JRUBY_VERSION 9.3.9.0
-ENV JRUBY_SHA256 251e6dd8d1d2f82922c8c778d7857e1bef82fe5ca2cf77bc09356421d0b05ab8
-RUN mkdir /opt/jruby \
-  && curl -fSL https://repo1.maven.org/maven2/org/jruby/jruby-dist/${JRUBY_VERSION}/jruby-dist-${JRUBY_VERSION}-bin.tar.gz -o /tmp/jruby.tar.gz \
-  && echo "$JRUBY_SHA256 /tmp/jruby.tar.gz" | sha256sum -c - \
-  && tar -zx --strip-components=1 -f /tmp/jruby.tar.gz -C /opt/jruby \
-  && rm /tmp/jruby.tar.gz \
-  && update-alternatives --install /usr/local/bin/ruby ruby /opt/jruby/bin/jruby 1
-ENV PATH /opt/jruby/bin:$PATH
-
-# skip installing gem documentation
-RUN mkdir -p /opt/jruby/etc \
-  && { \
-    echo 'install: --no-document'; \
-    echo 'update: --no-document'; \
-  } >> /opt/jruby/etc/gemrc
-
-RUN gem install rake net-telnet xmlrpc
-
-# install things globally, for great justice
-# and don't create ".bundle" in all our apps
-ENV GEM_HOME /usr/local/bundle
-ENV BUNDLE_BIN="$GEM_HOME/bin" \
-    BUNDLE_SILENCE_ROOT_WARNING=1 \
-    BUNDLE_APP_CONFIG="$GEM_HOME"
-ENV PATH $BUNDLE_BIN:$PATH
-RUN mkdir -p "$GEM_HOME" "$BUNDLE_BIN" \
-  && chmod 777 "$GEM_HOME" "$BUNDLE_BIN"
-
-CMD [ "irb" ]
-
-FROM jruby-9.3.9.0-jre11
-
-# Make apt non-interactive
-RUN echo 'APT::Get::Assume-Yes "true";' > /etc/apt/apt.conf.d/90circleci \
-  && echo 'DPkg::Options "--force-confnew";' >> /etc/apt/apt.conf.d/90circleci
-
-ENV DEBIAN_FRONTEND=noninteractive
+FROM ghcr.io/datadog/images-rb/engines/jruby:9.2
 
 # Install required packages
 RUN set -ex; \
@@ -55,14 +14,6 @@ RUN set -ex; \
             build-essential \
             shared-mime-info; \
         rm -rf /var/lib/apt/lists/*;
-
-# Set timezone to UTC by default
-RUN ln -sf /usr/share/zoneinfo/Etc/UTC /etc/localtime
-
-# Set language
-RUN locale-gen en_US.UTF-8
-ENV LANG en_US.UTF-8
-ENV LANGUAGE en_US:en
 
 # Install Docker
 RUN set -ex \
@@ -90,17 +41,6 @@ RUN DOCKERIZE_URL="https://github.com/powerman/dockerize/releases/download/v0.17
   && curl --silent --show-error --location --fail --retry 3 --output /usr/local/bin/dockerize $DOCKERIZE_URL \
   && chmod +x /usr/local/bin/dockerize \
   && dockerize --version
-
-# Install RubyGems
-RUN mkdir -p "$GEM_HOME" && chmod -R 777 "$GEM_HOME"
-
-# Upgrade RubyGems and Bundler
-RUN gem update --system 3.3.26
-RUN gem install bundler -v '~> 2.3.26'
-ENV BUNDLE_SILENCE_ROOT_WARNING 1
-
-# Ensure JRuby is available when running "bash --login"
-RUN echo "export PATH=/opt/jruby/bin:$BUNDLE_BIN:\$PATH" >> ~/.profile
 
 RUN mkdir /app
 WORKDIR /app

--- a/.circleci/images/primary/Dockerfile-jruby-9.4.7.0
+++ b/.circleci/images/primary/Dockerfile-jruby-9.4.7.0
@@ -1,47 +1,6 @@
 # Note: See the "Publishing updates to images" note in ./README.md for how to publish new builds of this container image
 
-FROM eclipse-temurin:11-jammy AS jruby-9.4.7.0-jre11
-
-RUN apt-get update && apt-get install -y libc6-dev --no-install-recommends && rm -rf /var/lib/apt/lists/*
-
-ENV JRUBY_VERSION 9.4.7.0
-ENV JRUBY_SHA256 f1c39f8257505300a528ff83fe4721fbe61a855abb25e3d27d52d43ac97a4d80
-RUN mkdir /opt/jruby \
-  && curl -fSL https://repo1.maven.org/maven2/org/jruby/jruby-dist/${JRUBY_VERSION}/jruby-dist-${JRUBY_VERSION}-bin.tar.gz -o /tmp/jruby.tar.gz \
-  && echo "$JRUBY_SHA256 /tmp/jruby.tar.gz" | sha256sum -c - \
-  && tar -zx --strip-components=1 -f /tmp/jruby.tar.gz -C /opt/jruby \
-  && rm /tmp/jruby.tar.gz \
-  && update-alternatives --install /usr/local/bin/ruby ruby /opt/jruby/bin/jruby 1
-ENV PATH /opt/jruby/bin:$PATH
-
-# skip installing gem documentation
-RUN mkdir -p /opt/jruby/etc \
-  && { \
-    echo 'install: --no-document'; \
-    echo 'update: --no-document'; \
-  } >> /opt/jruby/etc/gemrc
-
-RUN gem install rake net-telnet xmlrpc
-
-# install things globally, for great justice
-# and don't create ".bundle" in all our apps
-ENV GEM_HOME /usr/local/bundle
-ENV BUNDLE_BIN="$GEM_HOME/bin" \
-    BUNDLE_SILENCE_ROOT_WARNING=1 \
-    BUNDLE_APP_CONFIG="$GEM_HOME"
-ENV PATH $BUNDLE_BIN:$PATH
-RUN mkdir -p "$GEM_HOME" "$BUNDLE_BIN" \
-  && chmod 777 "$GEM_HOME" "$BUNDLE_BIN"
-
-CMD [ "irb" ]
-
-FROM jruby-9.4.7.0-jre11
-
-# Make apt non-interactive
-RUN echo 'APT::Get::Assume-Yes "true";' > /etc/apt/apt.conf.d/90circleci \
-  && echo 'DPkg::Options "--force-confnew";' >> /etc/apt/apt.conf.d/90circleci
-
-ENV DEBIAN_FRONTEND=noninteractive
+FROM ghcr.io/datadog/images-rb/engines/jruby:9.2
 
 # Install required packages
 RUN set -ex; \
@@ -55,14 +14,6 @@ RUN set -ex; \
             build-essential \
             shared-mime-info; \
         rm -rf /var/lib/apt/lists/*;
-
-# Set timezone to UTC by default
-RUN ln -sf /usr/share/zoneinfo/Etc/UTC /etc/localtime
-
-# Set language
-RUN locale-gen en_US.UTF-8
-ENV LANG en_US.UTF-8
-ENV LANGUAGE en_US:en
 
 # Install Docker
 RUN set -ex \
@@ -90,17 +41,6 @@ RUN DOCKERIZE_URL="https://github.com/powerman/dockerize/releases/download/v0.17
   && curl --silent --show-error --location --fail --retry 3 --output /usr/local/bin/dockerize $DOCKERIZE_URL \
   && chmod +x /usr/local/bin/dockerize \
   && dockerize --version
-
-# Install RubyGems
-RUN mkdir -p "$GEM_HOME" && chmod -R 777 "$GEM_HOME"
-
-# Upgrade RubyGems and Bundler
-RUN gem update --system 3.3.26
-RUN gem install bundler -v '~> 2.3.26'
-ENV BUNDLE_SILENCE_ROOT_WARNING 1
-
-# Ensure JRuby is available when running "bash --login"
-RUN echo "export PATH=/opt/jruby/bin:$BUNDLE_BIN:\$PATH" >> ~/.profile
 
 RUN mkdir /app
 WORKDIR /app


### PR DESCRIPTION
<!--
Check out the
https://github.com/DataDog/dd-trace-rb/blob/master/docs/DevelopmentGuide.md
for guidance on how to set up your development environment,
run the test suite, write new integrations, and more.
-->

**What does this PR do?**

Start using images from ghrc.io/datadog/images-rb

**Motivation:**

- Centralise image management across Ruby repositories
- Decouple image generation from this repository, which causes conundrums such as in this very PR: to make use of the new images this PR must be merged without actually making use of the images in the actual CI, then a public workflow to publish the images must be triggered, and finally a second PR must be opened to actually make use of the new images.

**Additional Notes:**
<!-- Anything else we should know when reviewing? -->

- Part of the CI being in CircleCI makes it annoying: I can't even hack something where the image build would happen and CircleCI would use those.
- The integration tests are especially annoying as well, with some additional `docker-compose` stuff _inside_ Docker.

**How to test the change?**
<!--
Describe here how the change can be validated.
You are strongly encouraged to provide automated tests for this PR (unit or integration).
If this change cannot be feasibly tested, please explain why,
unless the change does not modify code (e.g. only modifies docs, comments).
-->

Hard.

