### PR TITLE
Update mysql 8.0

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -486,12 +486,12 @@ job_configuration:
     <<: *filters_all_branches_and_tags
     ruby_version: 'jruby-9.2.21.0'
     image: ghcr.io/datadog/dd-trace-rb/jruby:9.2.21.0-dd
-    resource_class_to_use: medium+
+    resource_class_to_use: large
   - &config-jruby-9_3
     <<: *filters_all_branches_and_tags
     ruby_version: 'jruby-9.3.9.0'
     image: ghcr.io/datadog/dd-trace-rb/jruby:9.3.9.0-dd
-    resource_class_to_use: medium+
+    resource_class_to_use: large
 
 workflows:
   version: 2

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -65,7 +65,8 @@ test_containers:
     image: starburstdata/presto:332-e.9
   - &presto_port 8080
   - &container_mysql
-    image: mysql:5.6
+    image: mysql:8.0
+    command: --default-authentication-plugin=mysql_native_password
     environment:
       - MYSQL_ROOT_PASSWORD=root
       - MYSQL_PASSWORD=mysql

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -357,14 +357,13 @@ services:
     ports:
       - "127.0.0.1:${TEST_MONGODB_PORT}:27017"
   mysql:
-    image: mysql:8
+    image: mysql:8.0
     environment:
       - MYSQL_DATABASE=$TEST_MYSQL_DB
       - MYSQL_ROOT_PASSWORD=$TEST_MYSQL_ROOT_PASSWORD
       - MYSQL_PASSWORD=$TEST_MYSQL_PASSWORD
       - MYSQL_USER=$TEST_MYSQL_USER
-    command:
-      - '--default-authentication-plugin=mysql_native_password'
+    command: --default-authentication-plugin=mysql_native_password
     expose:
       - "3306"
     ports:


### PR DESCRIPTION
**What does this PR do?**

Update mysql image with 8.0

**Motivation:**

The mysql usage is different between docker-compose and circleci.

- Docker compose: `mysql:8` using verison `8.4.0` 
- CircleCI: `mysql:5.6`

**Why choose `mysql:8.0`:**

1. `mysql2` gem does not test with `8.4`, https://github.com/brianmario/mysql2?tab=readme-ov-file#compatibility
2. Docker compose using `8.4.0` is failing with (This is causing local test failure, such as `action_cable`)
```
2024-06-26 11:45:22+00:00 [Note] [Entrypoint]: Entrypoint script for MySQL Server 8.4.0-1.el8 started.
2024-06-26 11:45:22+00:00 [Note] [Entrypoint]: Switching to dedicated user 'mysql'
2024-06-26 11:45:22+00:00 [Note] [Entrypoint]: Entrypoint script for MySQL Server 8.4.0-1.el8 started.
2024-06-26 11:45:22+00:00 [Note] [Entrypoint]: Initializing database files
2024-06-26T11:45:22.556304Z 0 [System] [MY-015017] [Server] MySQL Server Initialization - start.
2024-06-26T11:45:22.557430Z 0 [System] [MY-013169] [Server] /usr/sbin/mysqld (mysqld 8.4.0) initializing of server in progress as process 79
2024-06-26T11:45:22.565682Z 1 [System] [MY-013576] [InnoDB] InnoDB initialization has started.
2024-06-26T11:45:22.811802Z 1 [System] [MY-013577] [InnoDB] InnoDB initialization has ended.
2024-06-26T11:45:23.726832Z 0 [ERROR] [MY-000067] [Server] unknown variable 'default-authentication-plugin=mysql_native_password'.
2024-06-26T11:45:23.727126Z 0 [ERROR] [MY-013236] [Server] The designated data directory /var/lib/mysql/ is unusable. You can remove all files that the server added to it.
2024-06-26T11:45:23.727137Z 0 [ERROR] [MY-010119] [Server] Aborting
2024-06-26T11:45:25.008515Z 0 [System] [MY-015018] [Server] MySQL Server Initialization - end.
```
3. My laptop (M1) cannot install `mysql:5.6`, because
```
no matching manifest for linux/arm64/v8 in the manifest list entries
```
4. `8.4.0` authentication become very verbose with SSL. Needs a ton of changes and still more failing with 
- Many database adapter failed.
- `Mysql2::Error: RSA Encryption not supported - caching_sha2_password plugin was built with GnuTLS support`
- `Trilogy::QueryError: trilogy_auth_recv: TRILOGY_UNEXPECTED_PACKET`, can be fixed by [upgrade 2.8.0 ](https://github.com/trilogy-libraries/trilogy/blob/main/CHANGELOG.md#280) and provide SSL 
```diff --git a/spec/datadog/tracing/contrib/rails/support/database.rb b/spec/datadog/tracing/contrib/rails/support/database.rb
index e62fb0719..932248c2e 100644
--- a/spec/datadog/tracing/contrib/rails/support/database.rb
+++ b/spec/datadog/tracing/contrib/rails/support/database.rb
@@ -23,7 +23,7 @@ module Datadog
                   elsif adapter.include?('mysql')
                     connector = mysql_url
                   elsif adapter == 'activerecord-trilogy-adapter'
-                    connector = mysql_url('trilogy')
+                    connector = trilogy_url
                   end
                 rescue LoadError
                   puts "#{adapter} gem not found, trying another connector"
@@ -50,9 +50,16 @@ module Datadog
               }
             end

-            def mysql_url(protocol = 'mysql2')
+            def mysql_url
               hash = mysql_hash
-              "#{protocol}://root:#{hash[:password]}@#{hash[:host]}:#{hash[:port]}/#{hash[:database]}"
+
+              "mysql2://root:#{hash[:password]}@#{hash[:host]}:#{hash[:port]}/#{hash[:database]}"
+            end
+
+            def trilogy_url
+              hash = mysql_hash
+
+              "trilogy://root:#{hash[:password]}@#{hash[:host]}:#{hash[:port]}/#{hash[:database]}?ssl_mode=SSL_MODE_PREFERRED"
             end

             def mysql_hash
diff --git a/spec/datadog/tracing/contrib/trilogy/patcher_spec.rb b/spec/datadog/tracing/contrib/trilogy/patcher_spec.rb
index c7641f4b0..750fd550c 100644
--- a/spec/datadog/tracing/contrib/trilogy/patcher_spec.rb
+++ b/spec/datadog/tracing/contrib/trilogy/patcher_spec.rb
@@ -20,7 +20,10 @@ RSpec.describe 'Trlogy::Client patcher' do
       port: port,
       database: database,
       username: username,
-      password: password
+      password: password,
+      ssl: true,
+      ssl_mode: Trilogy::SSL_PREFERRED_NOVERIFY,
+      tls_min_version: Trilogy::TLS_VERSION_12
     )
   end
```

5. `8.4.0` JDBC need to allow public key retrieval
```
ActiveRecord::JDBCError: Public Key Retrieval is not allowed
```
**NOTE**

As of MySQL 8.0, `caching_sha2_password` is now the default authentication plugin rather than `mysql_native_password ` which was the default in previous versions. This means that clients that rely on the `mysql_native_password` won't be able to connect because of this change.


