### PR TITLE
[SDTEST-409] Add metrics management capabilities

### DIFF
--- a/lib/datadog/core/telemetry/metric.rb
+++ b/lib/datadog/core/telemetry/metric.rb
@@ -82,14 +82,6 @@ module Datadog
             TYPE
           end
 
-          def inc(value = 1)
-            track(value)
-          end
-
-          def dec(value = 1)
-            track(-value)
-          end
-
           def track(value)
             value = value.to_i
 

--- a/lib/datadog/core/telemetry/metrics_collection.rb
+++ b/lib/datadog/core/telemetry/metrics_collection.rb
@@ -1,10 +1,12 @@
 # frozen_string_literal: true
 
+require_relative 'event'
 require_relative 'metric'
 
 module Datadog
   module Core
     module Telemetry
+      # MetricsCollection is a thread-safe collection of metrics per namespace
       class MetricsCollection
         attr_reader :namespace
 
@@ -19,88 +21,89 @@ module Datadog
         end
 
         def inc(metric_name, value, tags: {}, common: true)
-          metric_id = Metric.metric_id(Metric::Count::TYPE, metric_name, tags)
+          metric = Metric::Count.new(metric_name, tags: tags, common: common)
 
           @mutex.synchronize do
-            metric = @metrics.key?[metric_id]
-            if metric.nil?
-              metric = Metric::Count.new(metric_name, tags: tags, common: common)
-              @metrics[metric_id] = metric
+            if @metrics.key?(metric.id)
+              metric = @metrics[metric.id]
+            else
+              @metrics[metric.id] = metric
             end
 
             metric.inc(value)
           end
+          nil
         end
 
         def dec(metric_name, value, tags: {}, common: true)
-          metric_id = Metric.metric_id(Metric::Count::TYPE, metric_name, tags)
+          metric = Metric::Count.new(metric_name, tags: tags, common: common)
 
           @mutex.synchronize do
-            metric = @metrics.key?[metric_id]
-            if metric.nil?
-              metric = Metric::Count.new(metric_name, tags: tags, common: common)
-              @metrics[metric_id] = metric
+            if @metrics.key?(metric.id)
+              metric = @metrics[metric.id]
+            else
+              @metrics[metric.id] = metric
             end
 
             metric.dec(value)
           end
+          nil
         end
 
         def gauge(metric_name, value, tags: {}, common: true)
-          metric_id = Metric.metric_id(Metric::Gauge::TYPE, metric_name, tags)
+          metric = Metric::Gauge.new(metric_name, tags: tags, common: common, interval: @interval)
 
           @mutex.synchronize do
-            metric = @metrics.key?[metric_id]
-            if metric.nil?
-              metric = Metric::Gauge.new(metric_name, tags: tags, common: common, interval: @interval)
-              @metrics[metric_id] = metric
+            if @metrics.key?(metric.id)
+              metric = @metrics[metric.id]
+            else
+              @metrics[metric.id] = metric
             end
 
             metric.track(value)
           end
+          nil
         end
 
         def rate(metric_name, value, tags: {}, common: true)
-          metric_id = Metric.metric_id(Metric::Rate::TYPE, metric_name, tags) # this will fail, it expects array of tags
+          metric = Metric::Rate.new(metric_name, tags: tags, common: common, interval: @interval)
 
           @mutex.synchronize do
-            metric = @metrics.key?[metric_id]
-            if metric.nil?
-              metric = Metric::Rate.new(metric_name, tags: tags, common: common, interval: @interval)
-              @metrics[metric_id] = metric
+            if @metrics.key?(metric.id)
+              metric = @metrics[metric.id]
+            else
+              @metrics[metric.id] = metric
             end
 
             metric.track(value)
           end
+          nil
         end
 
         def distribution(metric_name, value, tags: {}, common: true)
-          metric_id = Metric.metric_id(Metric::Distribution::TYPE, metric_name, tags)
+          metric = Metric::Distribution.new(metric_name, tags: tags, common: common)
 
           @mutex.synchronize do
-            metric = @distributions.key?[metric_id]
-            if metric.nil?
-              metric = Metric::Distribution.new(metric_name, tags: tags, common: common)
-              @distributions[metric_id] = metric
+            if @distributions.key?(metric.id)
+              metric = @distributions[metric.id]
+            else
+              @distributions[metric.id] = metric
             end
 
             metric.track(value)
           end
+          nil
         end
 
-        def flush!
-          events = []
-
+        def flush!(queue)
           @mutex.synchronize do
-            events << Event::GenerateMetrics.new(@namespace, @metrics.values) if @metrics.any?
-
-            events << Event::Distributions.new(@namespace, @distributions.values) if @distributions.any?
+            queue.enqueue(Event::GenerateMetrics.new(@namespace, @metrics.values)) if @metrics.any?
+            queue.enqueue(Event::Distributions.new(@namespace, @distributions.values)) if @distributions.any?
 
             @metrics = {}
             @distributions = {}
           end
-
-          events
+          nil
         end
       end
     end

--- a/lib/datadog/core/telemetry/metrics_collection.rb
+++ b/lib/datadog/core/telemetry/metrics_collection.rb
@@ -22,52 +22,27 @@ module Datadog
 
         def inc(metric_name, value, tags: {}, common: true)
           metric = Metric::Count.new(metric_name, tags: tags, common: common)
-
-          @mutex.synchronize do
-            metric = fetch_or_add_metric(metric, @metrics)
-            metric.inc(value)
-          end
-          nil
+          fetch_or_add_metric(metric, value)
         end
 
         def dec(metric_name, value, tags: {}, common: true)
           metric = Metric::Count.new(metric_name, tags: tags, common: common)
-
-          @mutex.synchronize do
-            metric = fetch_or_add_metric(metric, @metrics)
-            metric.dec(value)
-          end
-          nil
+          fetch_or_add_metric(metric, -value)
         end
 
         def gauge(metric_name, value, tags: {}, common: true)
           metric = Metric::Gauge.new(metric_name, tags: tags, common: common, interval: @interval)
-
-          @mutex.synchronize do
-            metric = fetch_or_add_metric(metric, @metrics)
-            metric.track(value)
-          end
-          nil
+          fetch_or_add_metric(metric, value)
         end
 
         def rate(metric_name, value, tags: {}, common: true)
           metric = Metric::Rate.new(metric_name, tags: tags, common: common, interval: @interval)
-
-          @mutex.synchronize do
-            metric = fetch_or_add_metric(metric, @metrics)
-            metric.track(value)
-          end
-          nil
+          fetch_or_add_metric(metric, value)
         end
 
         def distribution(metric_name, value, tags: {}, common: true)
           metric = Metric::Distribution.new(metric_name, tags: tags, common: common)
-
-          @mutex.synchronize do
-            metric = fetch_or_add_metric(metric, @distributions)
-            metric.track(value)
-          end
-          nil
+          fetch_or_add_distribution(metric, value)
         end
 
         def flush!(queue)
@@ -83,8 +58,20 @@ module Datadog
 
         private
 
-        def fetch_or_add_metric(metric, collection)
-          collection[metric.id] ||= metric
+        def fetch_or_add_metric(metric, value)
+          @mutex.synchronize do
+            m = (@metrics[metric.id] ||= metric)
+            m.track(value)
+          end
+          nil
+        end
+
+        def fetch_or_add_distribution(metric, value)
+          @mutex.synchronize do
+            m = (@distributions[metric.id] ||= metric)
+            m.track(value)
+          end
+          nil
         end
       end
     end

--- a/lib/datadog/core/telemetry/metrics_collection.rb
+++ b/lib/datadog/core/telemetry/metrics_collection.rb
@@ -8,7 +8,7 @@ module Datadog
     module Telemetry
       # MetricsCollection is a thread-safe collection of metrics per namespace
       class MetricsCollection
-        attr_reader :namespace
+        attr_reader :namespace, :interval
 
         def initialize(namespace, aggregation_interval:)
           @namespace = namespace

--- a/lib/datadog/core/telemetry/metrics_collection.rb
+++ b/lib/datadog/core/telemetry/metrics_collection.rb
@@ -24,12 +24,7 @@ module Datadog
           metric = Metric::Count.new(metric_name, tags: tags, common: common)
 
           @mutex.synchronize do
-            if @metrics.key?(metric.id)
-              metric = @metrics[metric.id]
-            else
-              @metrics[metric.id] = metric
-            end
-
+            metric = fetch_or_add_metric(metric, @metrics)
             metric.inc(value)
           end
           nil
@@ -39,12 +34,7 @@ module Datadog
           metric = Metric::Count.new(metric_name, tags: tags, common: common)
 
           @mutex.synchronize do
-            if @metrics.key?(metric.id)
-              metric = @metrics[metric.id]
-            else
-              @metrics[metric.id] = metric
-            end
-
+            metric = fetch_or_add_metric(metric, @metrics)
             metric.dec(value)
           end
           nil
@@ -54,12 +44,7 @@ module Datadog
           metric = Metric::Gauge.new(metric_name, tags: tags, common: common, interval: @interval)
 
           @mutex.synchronize do
-            if @metrics.key?(metric.id)
-              metric = @metrics[metric.id]
-            else
-              @metrics[metric.id] = metric
-            end
-
+            metric = fetch_or_add_metric(metric, @metrics)
             metric.track(value)
           end
           nil
@@ -69,12 +54,7 @@ module Datadog
           metric = Metric::Rate.new(metric_name, tags: tags, common: common, interval: @interval)
 
           @mutex.synchronize do
-            if @metrics.key?(metric.id)
-              metric = @metrics[metric.id]
-            else
-              @metrics[metric.id] = metric
-            end
-
+            metric = fetch_or_add_metric(metric, @metrics)
             metric.track(value)
           end
           nil
@@ -84,12 +64,7 @@ module Datadog
           metric = Metric::Distribution.new(metric_name, tags: tags, common: common)
 
           @mutex.synchronize do
-            if @distributions.key?(metric.id)
-              metric = @distributions[metric.id]
-            else
-              @distributions[metric.id] = metric
-            end
-
+            metric = fetch_or_add_metric(metric, @distributions)
             metric.track(value)
           end
           nil
@@ -104,6 +79,12 @@ module Datadog
             @distributions = {}
           end
           nil
+        end
+
+        private
+
+        def fetch_or_add_metric(metric, collection)
+          collection[metric.id] ||= metric
         end
       end
     end

--- a/lib/datadog/core/telemetry/metrics_collection.rb
+++ b/lib/datadog/core/telemetry/metrics_collection.rb
@@ -1,0 +1,108 @@
+# frozen_string_literal: true
+
+require_relative 'metric'
+
+module Datadog
+  module Core
+    module Telemetry
+      class MetricsCollection
+        attr_reader :namespace
+
+        def initialize(namespace, aggregation_interval:)
+          @namespace = namespace
+          @interval = aggregation_interval
+
+          @mutex = Mutex.new
+
+          @metrics = {}
+          @distributions = {}
+        end
+
+        def inc(metric_name, value, tags: {}, common: true)
+          metric_id = Metric.metric_id(Metric::Count::TYPE, metric_name, tags)
+
+          @mutex.synchronize do
+            metric = @metrics.key?[metric_id]
+            if metric.nil?
+              metric = Metric::Count.new(metric_name, tags: tags, common: common)
+              @metrics[metric_id] = metric
+            end
+
+            metric.inc(value)
+          end
+        end
+
+        def dec(metric_name, value, tags: {}, common: true)
+          metric_id = Metric.metric_id(Metric::Count::TYPE, metric_name, tags)
+
+          @mutex.synchronize do
+            metric = @metrics.key?[metric_id]
+            if metric.nil?
+              metric = Metric::Count.new(metric_name, tags: tags, common: common)
+              @metrics[metric_id] = metric
+            end
+
+            metric.dec(value)
+          end
+        end
+
+        def gauge(metric_name, value, tags: {}, common: true)
+          metric_id = Metric.metric_id(Metric::Gauge::TYPE, metric_name, tags)
+
+          @mutex.synchronize do
+            metric = @metrics.key?[metric_id]
+            if metric.nil?
+              metric = Metric::Gauge.new(metric_name, tags: tags, common: common, interval: @interval)
+              @metrics[metric_id] = metric
+            end
+
+            metric.track(value)
+          end
+        end
+
+        def rate(metric_name, value, tags: {}, common: true)
+          metric_id = Metric.metric_id(Metric::Rate::TYPE, metric_name, tags) # this will fail, it expects array of tags
+
+          @mutex.synchronize do
+            metric = @metrics.key?[metric_id]
+            if metric.nil?
+              metric = Metric::Rate.new(metric_name, tags: tags, common: common, interval: @interval)
+              @metrics[metric_id] = metric
+            end
+
+            metric.track(value)
+          end
+        end
+
+        def distribution(metric_name, value, tags: {}, common: true)
+          metric_id = Metric.metric_id(Metric::Distribution::TYPE, metric_name, tags)
+
+          @mutex.synchronize do
+            metric = @distributions.key?[metric_id]
+            if metric.nil?
+              metric = Metric::Distribution.new(metric_name, tags: tags, common: common)
+              @distributions[metric_id] = metric
+            end
+
+            metric.track(value)
+          end
+        end
+
+        def flush!
+          events = []
+
+          @mutex.synchronize do
+            events << Event::GenerateMetrics.new(@namespace, @metrics.values) if @metrics.any?
+
+            events << Event::Distributions.new(@namespace, @distributions.values) if @distributions.any?
+
+            @metrics = {}
+            @distributions = {}
+          end
+
+          events
+        end
+      end
+    end
+  end
+end

--- a/lib/datadog/core/telemetry/metrics_manager.rb
+++ b/lib/datadog/core/telemetry/metrics_manager.rb
@@ -20,6 +20,7 @@ module Datadog
         def inc(namespace, metric_name, value, tags: {}, common: true)
           return unless @enabled
 
+          # collection is thread-safe internally
           collection = fetch_or_create_collection(namespace)
           collection.inc(metric_name, value, tags: tags, common: common)
         end
@@ -27,6 +28,7 @@ module Datadog
         def dec(namespace, metric_name, value, tags: {}, common: true)
           return unless @enabled
 
+          # collection is thread-safe internally
           collection = fetch_or_create_collection(namespace)
           collection.dec(metric_name, value, tags: tags, common: common)
         end
@@ -34,6 +36,7 @@ module Datadog
         def gauge(namespace, metric_name, value, tags: {}, common: true)
           return unless @enabled
 
+          # collection is thread-safe internally
           collection = fetch_or_create_collection(namespace)
           collection.gauge(metric_name, value, tags: tags, common: common)
         end
@@ -41,6 +44,7 @@ module Datadog
         def rate(namespace, metric_name, value, tags: {}, common: true)
           return unless @enabled
 
+          # collection is thread-safe internally
           collection = fetch_or_create_collection(namespace)
           collection.rate(metric_name, value, tags: tags, common: common)
         end
@@ -48,6 +52,7 @@ module Datadog
         def distribution(namespace, metric_name, value, tags: {}, common: true)
           return unless @enabled
 
+          # collection is thread-safe internally
           collection = fetch_or_create_collection(namespace)
           collection.distribution(metric_name, value, tags: tags, common: common)
         end
@@ -55,9 +60,9 @@ module Datadog
         def flush!(queue)
           return unless @enabled
 
-          @mutex.synchronize do
-            @collections.each_value { |col| col.flush!(queue) }
-          end
+          collections = @mutex.synchronize { @collections.values }
+          collections.each { |col| col.flush!(queue) }
+
           nil
         end
 

--- a/lib/datadog/core/telemetry/metrics_manager.rb
+++ b/lib/datadog/core/telemetry/metrics_manager.rb
@@ -1,0 +1,72 @@
+# frozen_string_literal: true
+
+require_relative 'metrics_collection'
+
+module Datadog
+  module Core
+    module Telemetry
+      # MetricsManager aggregates and flushes metrics and distributions
+      class MetricsManager
+        def initialize(aggregation_interval:, enabled:)
+          @interval = aggregation_interval
+          @enabled = enabled
+          @mutex = Mutex.new
+
+          @collections = {}
+        end
+
+        def inc(namespace, metric_name, value, tags: {}, common: true)
+          return unless @enabled
+
+          collection = fetch_or_create_collection(namespace)
+          collection.inc(metric_name, value, tags: tags, common: common)
+        end
+
+        def dec(namespace, metric_name, value, tags: {}, common: true)
+          return unless @enabled
+
+          collection = fetch_or_create_collection(namespace)
+          collection.dec(metric_name, value, tags: tags, common: common)
+        end
+
+        def gauge(namespace, metric_name, value, tags: {}, common: true)
+          return unless @enabled
+
+          collection = fetch_or_create_collection(namespace)
+          collection.gauge(metric_name, value, tags: tags, common: common)
+        end
+
+        def rate(namespace, metric_name, value, tags: {}, common: true)
+          return unless @enabled
+
+          collection = fetch_or_create_collection(namespace)
+          collection.rate(metric_name, value, tags: tags, common: common)
+        end
+
+        def distribution(namespace, metric_name, value, tags: {}, common: true)
+          return unless @enabled
+
+          collection = fetch_or_create_collection(namespace)
+          collection.distribution(metric_name, value, tags: tags, common: common)
+        end
+
+        def flush!(queue)
+          return unless @enabled
+
+          @mutex.synchronize do
+            @collections.each_value { |col| col.flush!(queue) }
+          end
+          nil
+        end
+
+        private
+
+        def fetch_or_create_collection(namespace)
+          @mutex.synchronize do
+            @collections[namespace] ||= MetricsCollection.new(namespace, aggregation_interval: @interval)
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/datadog/core/telemetry/metrics_manager.rb
+++ b/lib/datadog/core/telemetry/metrics_manager.rb
@@ -7,6 +7,8 @@ module Datadog
     module Telemetry
       # MetricsManager aggregates and flushes metrics and distributions
       class MetricsManager
+        attr_reader :enabled
+
         def initialize(aggregation_interval:, enabled:)
           @interval = aggregation_interval
           @enabled = enabled
@@ -57,6 +59,10 @@ module Datadog
             @collections.each_value { |col| col.flush!(queue) }
           end
           nil
+        end
+
+        def disable!
+          @enabled = false
         end
 
         private

--- a/sig/datadog/core/telemetry/metric.rbs
+++ b/sig/datadog/core/telemetry/metric.rbs
@@ -22,8 +22,6 @@ module Datadog
 
           @common: bool
 
-          @interval: Integer?
-
           attr_reader name: String
 
           attr_reader tags: Array[String]
@@ -32,9 +30,8 @@ module Datadog
 
           attr_reader common: bool
 
-          attr_reader interval: Integer?
 
-          def initialize: (String name, ?tags: tags_input, ?common: bool, ?interval: Integer?) -> void
+          def initialize: (String name, ?tags: tags_input, ?common: bool) -> void
 
           def id: () -> String
 
@@ -47,6 +44,14 @@ module Datadog
           private
 
           def tags_to_array: (tags_input tags) -> Array[String]
+        end
+
+        class IntervalMetric < Base
+          @interval: Integer
+
+          attr_reader interval: Integer
+
+          def initialize: (String name, ?tags: tags_input, ?common: bool, interval: Integer) -> void
         end
 
         class Count < Base
@@ -64,7 +69,7 @@ module Datadog
           def track: (input_value value) -> void
         end
 
-        class Gauge < Base
+        class Gauge < IntervalMetric
           TYPE: "gauge"
 
           def type: () -> "gauge"
@@ -72,15 +77,13 @@ module Datadog
           def track: (input_value value) -> void
         end
 
-        class Rate < Base
+        class Rate < IntervalMetric
           @value: Float
 
           @values: Array[metric_value]
           attr_reader values: Array[metric_value]
 
           TYPE: "rate"
-
-          def initialize: (String name, ?tags: tags_input, ?common: bool, ?interval: Integer?) -> void
 
           def type: () -> "rate"
 

--- a/sig/datadog/core/telemetry/metric.rbs
+++ b/sig/datadog/core/telemetry/metric.rbs
@@ -62,10 +62,6 @@ module Datadog
 
           def type: () -> "count"
 
-          def inc: (?input_value value) -> void
-
-          def dec: (?input_value value) -> void
-
           def track: (input_value value) -> void
         end
 

--- a/sig/datadog/core/telemetry/metric.rbs
+++ b/sig/datadog/core/telemetry/metric.rbs
@@ -9,12 +9,12 @@ module Datadog
         type metric_value = Array[input_value]
         type distribution_value = input_value
 
-        type tags_input = ::Hash[String, String] | Array[String]
-
-        def self.metric_id: (metric_type type, String name, ?Array[String] tags) -> ::String
+        type tags_input = ::Hash[String | Symbol, String] | Array[String]
 
         class Base
           @name: String
+
+          @id: String
 
           @values: Array[untyped]
 
@@ -36,6 +36,8 @@ module Datadog
 
           def initialize: (String name, ?tags: tags_input, ?common: bool, ?interval: Integer?) -> void
 
+          def id: () -> String
+
           def track: (Numeric value) -> void
 
           def type: () -> metric_type
@@ -55,11 +57,11 @@ module Datadog
 
           def type: () -> "count"
 
-          def inc: (?::Integer value) -> void
+          def inc: (?input_value value) -> void
 
-          def dec: (?::Integer value) -> void
+          def dec: (?input_value value) -> void
 
-          def track: (Integer value) -> void
+          def track: (input_value value) -> void
         end
 
         class Gauge < Base
@@ -82,7 +84,7 @@ module Datadog
 
           def type: () -> "rate"
 
-          def track: (?::Float value) -> void
+          def track: (?input_value value) -> void
         end
 
         class Distribution < Base

--- a/sig/datadog/core/telemetry/metrics_collection.rbs
+++ b/sig/datadog/core/telemetry/metrics_collection.rbs
@@ -34,7 +34,9 @@ module Datadog
 
         private
 
-        def fetch_or_add_metric: (untyped metric, Hash[untyped, untyped] collection) -> untyped
+        def fetch_or_add_metric: (Datadog::Core::Telemetry::Metric::Base metric, Datadog::Core::Telemetry::Metric::input_value value) -> void
+
+        def fetch_or_add_distribution: (Datadog::Core::Telemetry::Metric::Distribution metric, Datadog::Core::Telemetry::Metric::input_value value) -> void
       end
     end
   end

--- a/sig/datadog/core/telemetry/metrics_collection.rbs
+++ b/sig/datadog/core/telemetry/metrics_collection.rbs
@@ -1,0 +1,37 @@
+module Datadog
+  module Core
+    module Telemetry
+      class MetricsCollection
+        interface _Queue
+          def enqueue: (Datadog::Core::Telemetry::Event::Base event) -> void
+        end
+
+        @namespace: String
+
+        @interval: Integer
+
+        @mutex: Thread::Mutex
+
+        @metrics: Hash[String, Datadog::Core::Telemetry::Metric::Base]
+
+        @distributions: Hash[String, Datadog::Core::Telemetry::Metric::Distribution]
+
+        attr_reader namespace: String
+
+        def initialize: (String namespace, aggregation_interval: Integer) -> void
+
+        def inc: (String metric_name, Datadog::Core::Telemetry::Metric::input_value value, ?tags: Datadog::Core::Telemetry::Metric::tags_input, ?common: bool) -> void
+
+        def dec: (String metric_name, Datadog::Core::Telemetry::Metric::input_value value, ?tags: Datadog::Core::Telemetry::Metric::tags_input, ?common: bool) -> void
+
+        def gauge: (String metric_name, Datadog::Core::Telemetry::Metric::input_value value, ?tags: Datadog::Core::Telemetry::Metric::tags_input, ?common: bool) -> void
+
+        def rate: (String metric_name, Datadog::Core::Telemetry::Metric::input_value value, ?tags: Datadog::Core::Telemetry::Metric::tags_input, ?common: bool) -> void
+
+        def distribution: (String metric_name, Datadog::Core::Telemetry::Metric::input_value value, ?tags: Datadog::Core::Telemetry::Metric::tags_input, ?common: bool) -> void
+
+        def flush!: (_Queue queue) -> void
+      end
+    end
+  end
+end

--- a/sig/datadog/core/telemetry/metrics_collection.rbs
+++ b/sig/datadog/core/telemetry/metrics_collection.rbs
@@ -31,6 +31,10 @@ module Datadog
         def distribution: (String metric_name, Datadog::Core::Telemetry::Metric::input_value value, ?tags: Datadog::Core::Telemetry::Metric::tags_input, ?common: bool) -> void
 
         def flush!: (_Queue queue) -> void
+
+        private
+
+        def fetch_or_add_metric: (untyped metric, Hash[untyped, untyped] collection) -> untyped
       end
     end
   end

--- a/sig/datadog/core/telemetry/metrics_manager.rbs
+++ b/sig/datadog/core/telemetry/metrics_manager.rbs
@@ -14,6 +14,8 @@ module Datadog
 
         @collections: Hash[String, Datadog::Core::Telemetry::MetricsCollection]
 
+        attr_reader enabled: bool
+
         def initialize: (aggregation_interval: Integer, enabled: bool) -> void
 
         def inc: (String namespace, String metric_name, Datadog::Core::Telemetry::Metric::input_value value, ?tags: Datadog::Core::Telemetry::Metric::tags_input, ?common: bool) -> void
@@ -27,6 +29,8 @@ module Datadog
         def distribution: (String namespace, String metric_name, Datadog::Core::Telemetry::Metric::input_value value, ?tags: Datadog::Core::Telemetry::Metric::tags_input, ?common: bool) -> void
 
         def flush!: (_Queue queue) -> void
+
+        def disable!: () -> void
 
         private
 

--- a/sig/datadog/core/telemetry/metrics_manager.rbs
+++ b/sig/datadog/core/telemetry/metrics_manager.rbs
@@ -1,0 +1,37 @@
+module Datadog
+  module Core
+    module Telemetry
+      class MetricsManager
+        interface _Queue
+          def enqueue: (Datadog::Core::Telemetry::Event::Base event) -> void
+        end
+
+        @interval: Integer
+
+        @enabled: bool
+
+        @mutex: Thread::Mutex
+
+        @collections: Hash[String, Datadog::Core::Telemetry::MetricsCollection]
+
+        def initialize: (aggregation_interval: Integer, enabled: bool) -> void
+
+        def inc: (String namespace, String metric_name, Datadog::Core::Telemetry::Metric::input_value value, ?tags: Datadog::Core::Telemetry::Metric::tags_input, ?common: bool) -> void
+
+        def dec: (String namespace, String metric_name, Datadog::Core::Telemetry::Metric::input_value value, ?tags: Datadog::Core::Telemetry::Metric::tags_input, ?common: bool) -> void
+
+        def gauge: (String namespace, String metric_name, Datadog::Core::Telemetry::Metric::input_value value, ?tags: Datadog::Core::Telemetry::Metric::tags_input, ?common: bool) -> void
+
+        def rate: (String namespace, String metric_name, Datadog::Core::Telemetry::Metric::input_value value, ?tags: Datadog::Core::Telemetry::Metric::tags_input, ?common: bool) -> void
+
+        def distribution: (String namespace, String metric_name, Datadog::Core::Telemetry::Metric::input_value value, ?tags: Datadog::Core::Telemetry::Metric::tags_input, ?common: bool) -> void
+
+        def flush!: (_Queue queue) -> void
+
+        private
+
+        def fetch_or_create_collection: (String namespace) -> Datadog::Core::Telemetry::MetricsCollection
+      end
+    end
+  end
+end

--- a/spec/datadog/core/telemetry/metric_spec.rb
+++ b/spec/datadog/core/telemetry/metric_spec.rb
@@ -16,7 +16,6 @@ RSpec.describe Datadog::Core::Telemetry::Metric do
       is_expected.to have_attributes(
         name: name,
         tags: ['tag1:val1', 'tag2:val2'],
-        interval: nil,
         common: true,
         values: []
       )
@@ -198,8 +197,8 @@ RSpec.describe Datadog::Core::Telemetry::Metric do
       context 'interval is nil' do
         let(:interval) { nil }
 
-        it 'sets rate to zero' do
-          expect { track }.to change { metric.values }.from([]).to([[now, 0.0]])
+        it 'raises error' do
+          expect { metric }.to raise_error(ArgumentError, 'interval must be a positive number')
         end
       end
     end
@@ -235,7 +234,6 @@ RSpec.describe Datadog::Core::Telemetry::Metric do
       is_expected.to have_attributes(
         name: name,
         tags: ['tag1:val1', 'tag2:val2'],
-        interval: nil,
         common: true,
         values: []
       )

--- a/spec/datadog/core/telemetry/metric_spec.rb
+++ b/spec/datadog/core/telemetry/metric_spec.rb
@@ -6,16 +6,6 @@ RSpec.describe Datadog::Core::Telemetry::Metric do
   let(:now) { 123123 }
   before { allow(Time).to receive(:now).and_return(now, now + 1, now + 2, now + 3) }
 
-  describe '.metric_id' do
-    subject(:metric_id) { described_class.metric_id(type, name, tags) }
-
-    let(:type) { 'type' }
-    let(:name) { 'name' }
-    let(:tags) { ['tag1:val1', 'tag2:val2'] }
-
-    it { is_expected.to eq('type::name::tag1:val1,tag2:val2') }
-  end
-
   describe Datadog::Core::Telemetry::Metric::Count do
     subject(:metric) { described_class.new(name, tags: tags) }
 
@@ -30,6 +20,12 @@ RSpec.describe Datadog::Core::Telemetry::Metric do
         common: true,
         values: []
       )
+    end
+
+    describe '#id' do
+      subject(:id) { metric.id }
+
+      it { is_expected.to eq('count::metric_name::tag1:val1,tag2:val2') }
     end
 
     describe '#type' do
@@ -102,6 +98,12 @@ RSpec.describe Datadog::Core::Telemetry::Metric do
       )
     end
 
+    describe '#id' do
+      subject(:id) { metric.id }
+
+      it { is_expected.to eq('gauge::metric_name::tag1:val1,tag2:val2') }
+    end
+
     describe '#type' do
       subject(:type) { metric.type }
 
@@ -161,6 +163,12 @@ RSpec.describe Datadog::Core::Telemetry::Metric do
         common: true,
         values: []
       )
+    end
+
+    describe '#id' do
+      subject(:id) { metric.id }
+
+      it { is_expected.to eq('rate::metric_name::tag1:val1,tag2:val2') }
     end
 
     describe '#type' do
@@ -231,6 +239,12 @@ RSpec.describe Datadog::Core::Telemetry::Metric do
         common: true,
         values: []
       )
+    end
+
+    describe '#id' do
+      subject(:id) { metric.id }
+
+      it { is_expected.to eq('distributions::metric_name::tag1:val1,tag2:val2') }
     end
 
     describe '#type' do

--- a/spec/datadog/core/telemetry/metric_spec.rb
+++ b/spec/datadog/core/telemetry/metric_spec.rb
@@ -33,30 +33,20 @@ RSpec.describe Datadog::Core::Telemetry::Metric do
       it { is_expected.to eq('count') }
     end
 
-    describe '#inc' do
-      subject(:inc) { metric.inc(value) }
+    describe '#track' do
+      subject(:track) { metric.track(value) }
 
       let(:value) { 5 }
 
       it 'tracks the value' do
-        expect { inc }.to change { metric.values }.from([]).to([[now, value]])
+        expect { track }.to change { metric.values }.from([]).to([[now, value]])
       end
 
-      context 'incrementing again' do
+      context 'tracking again' do
         it 'adds the value to the previous one and updates timestamp' do
-          metric.inc(value)
-          expect { inc }.to change { metric.values }.from([[now, value]]).to([[now + 1, value + value]])
+          metric.track(value)
+          expect { track }.to change { metric.values }.from([[now, value]]).to([[now + 1, value + value]])
         end
-      end
-    end
-
-    describe '#dec' do
-      subject(:dec) { metric.dec(value) }
-
-      let(:value) { 5 }
-
-      it 'tracks the value' do
-        expect { dec }.to change { metric.values }.from([]).to([[now, -value]])
       end
     end
 
@@ -65,7 +55,7 @@ RSpec.describe Datadog::Core::Telemetry::Metric do
       let(:value) { 2 }
 
       before do
-        metric.inc(value)
+        metric.track(value)
       end
 
       it do

--- a/spec/datadog/core/telemetry/metrics_collection_spec.rb
+++ b/spec/datadog/core/telemetry/metrics_collection_spec.rb
@@ -253,7 +253,7 @@ RSpec.describe Datadog::Core::Telemetry::MetricsCollection do
 
       expect(queue).to receive(:enqueue) do |event|
         expect(event).to be_a(Datadog::Core::Telemetry::Event::GenerateMetrics)
-        payload = event.payload(1)
+        payload = event.payload
 
         expect(payload[:namespace]).to eq(namespace)
         expect(payload[:series]).to have(2).items
@@ -275,7 +275,7 @@ RSpec.describe Datadog::Core::Telemetry::MetricsCollection do
 
       expect(queue).to receive(:enqueue) do |event|
         expect(event).to be_a(Datadog::Core::Telemetry::Event::Distributions)
-        payload = event.payload(1)
+        payload = event.payload
 
         expect(payload[:namespace]).to eq(namespace)
         expect(payload[:series]).to have(2).items
@@ -292,13 +292,13 @@ RSpec.describe Datadog::Core::Telemetry::MetricsCollection do
       expect(distributions.size).to eq(0)
     end
 
-    it 'does not loose metrics when running in multiple threads' do
+    it 'does not lose metrics when running in multiple threads' do
       mutex = Mutex.new
       threads_count = 5
       metrics_count = 0
 
       expect(queue).to receive(:enqueue) do |event|
-        mutex.synchronize { metrics_count += event.payload(1)[:series].size }
+        mutex.synchronize { metrics_count += event.payload[:series].size }
       end.at_least(:once)
 
       threads = Array.new(threads_count) do |i|

--- a/spec/datadog/core/telemetry/metrics_collection_spec.rb
+++ b/spec/datadog/core/telemetry/metrics_collection_spec.rb
@@ -24,13 +24,13 @@ RSpec.describe Datadog::Core::Telemetry::MetricsCollection do
   let(:namespace) { 'namespace' }
   let(:interval) { 10 }
 
+  let(:metric_name) { 'metric_name' }
+  let(:value) { 5 }
+  let(:tags) { { tag1: 'val1', tag2: 'val2' } }
+  let(:common) { true }
+
   describe '#inc' do
     subject(:inc) { collection.inc(metric_name, value, tags: tags, common: common) }
-
-    let(:metric_name) { 'metric_name' }
-    let(:value) { 5 }
-    let(:tags) { { tag1: 'val1', tag2: 'val2' } }
-    let(:common) { true }
 
     it 'tracks the metric' do
       expect { inc }.to change { metrics.size }.by(1)
@@ -77,11 +77,6 @@ RSpec.describe Datadog::Core::Telemetry::MetricsCollection do
   describe '#dec' do
     subject(:dec) { collection.dec(metric_name, value, tags: tags, common: common) }
 
-    let(:metric_name) { 'metric_name' }
-    let(:value) { 5 }
-    let(:tags) { { tag1: 'val1', tag2: 'val2' } }
-    let(:common) { true }
-
     it 'tracks the metric' do
       expect { dec }.to change { metrics.size }.by(1)
       expect(first_metric_value).to eq(-value)
@@ -127,11 +122,6 @@ RSpec.describe Datadog::Core::Telemetry::MetricsCollection do
   describe '#gauge' do
     subject(:gauge) { collection.gauge(metric_name, value, tags: tags, common: common) }
 
-    let(:metric_name) { 'metric_name' }
-    let(:value) { 5 }
-    let(:tags) { { tag1: 'val1', tag2: 'val2' } }
-    let(:common) { true }
-
     it 'tracks the metric' do
       expect { gauge }.to change { metrics.size }.by(1)
       expect(first_metric_value).to eq(value)
@@ -162,11 +152,6 @@ RSpec.describe Datadog::Core::Telemetry::MetricsCollection do
 
   describe '#rate' do
     subject(:rate) { collection.rate(metric_name, value, tags: tags, common: common) }
-
-    let(:metric_name) { 'metric_name' }
-    let(:value) { 5 }
-    let(:tags) { { tag1: 'val1', tag2: 'val2' } }
-    let(:common) { true }
 
     it 'tracks the metric' do
       expect { rate }.to change { metrics.size }.by(1)
@@ -212,11 +197,6 @@ RSpec.describe Datadog::Core::Telemetry::MetricsCollection do
 
   describe '#distribution' do
     subject(:distribution) { collection.distribution(metric_name, value, tags: tags, common: common) }
-
-    let(:metric_name) { 'metric_name' }
-    let(:value) { 5 }
-    let(:tags) { { tag1: 'val1', tag2: 'val2' } }
-    let(:common) { true }
 
     it 'tracks the metric' do
       expect { distribution }.to change { distributions.size }.by(1)

--- a/spec/datadog/core/telemetry/metrics_collection_spec.rb
+++ b/spec/datadog/core/telemetry/metrics_collection_spec.rb
@@ -1,0 +1,341 @@
+require 'spec_helper'
+
+require 'datadog/core/telemetry/metrics_collection'
+
+RSpec.describe Datadog::Core::Telemetry::MetricsCollection do
+  subject(:collection) { described_class.new(namespace, aggregation_interval: interval) }
+
+  def metrics
+    collection.instance_variable_get(:@metrics)
+  end
+
+  def first_metric_value
+    metrics.values.first.values.first.last
+  end
+
+  def distributions
+    collection.instance_variable_get(:@distributions)
+  end
+
+  def first_distribution_values
+    distributions.values.first.values
+  end
+
+  let(:namespace) { 'namespace' }
+  let(:interval) { 10 }
+
+  describe '#inc' do
+    subject(:inc) { collection.inc(metric_name, value, tags: tags, common: common) }
+
+    let(:metric_name) { 'metric_name' }
+    let(:value) { 5 }
+    let(:tags) { { tag1: 'val1', tag2: 'val2' } }
+    let(:common) { true }
+
+    it 'tracks the metric' do
+      expect { inc }.to change { metrics.size }.by(1)
+      expect(first_metric_value).to eq(value)
+    end
+
+    context 'incrementing again' do
+      it 'aggregates the metric' do
+        inc
+
+        expect do
+          collection.inc(metric_name, value, tags: tags, common: common)
+        end.to change { metrics.size }.by(0)
+
+        expect(first_metric_value).to eq(value * 2)
+      end
+    end
+
+    context 'incrementing the same metric with different tags' do
+      it 'tracks new metric' do
+        inc
+
+        expect do
+          collection.inc(metric_name, value, tags: { tag1: 'val1', tag2: 'val3' }, common: common)
+        end.to change { metrics.size }.by(1)
+      end
+    end
+
+    context 'concurrent incrementing' do
+      it 'aggregates all values in the same metric' do
+        threads = Array.new(5) do
+          Thread.new do
+            collection.inc(metric_name, value, tags: tags, common: common)
+          end
+        end
+
+        threads.each(&:join)
+
+        expect(first_metric_value).to eq(value * threads.size)
+      end
+    end
+  end
+
+  describe '#dec' do
+    subject(:dec) { collection.dec(metric_name, value, tags: tags, common: common) }
+
+    let(:metric_name) { 'metric_name' }
+    let(:value) { 5 }
+    let(:tags) { { tag1: 'val1', tag2: 'val2' } }
+    let(:common) { true }
+
+    it 'tracks the metric' do
+      expect { dec }.to change { metrics.size }.by(1)
+      expect(first_metric_value).to eq(-value)
+    end
+
+    context 'decrementing again' do
+      it 'aggregates the metric' do
+        dec
+
+        expect do
+          collection.dec(metric_name, value, tags: tags, common: common)
+        end.to change { metrics.size }.by(0)
+
+        expect(first_metric_value).to eq(-value * 2)
+      end
+    end
+
+    context 'decrementing the same metric with different tags' do
+      it 'tracks new metric' do
+        dec
+
+        expect do
+          collection.dec(metric_name, value, tags: { tag1: 'val1', tag2: 'val3' }, common: common)
+        end.to change { metrics.size }.by(1)
+      end
+    end
+
+    context 'concurrent decrementing' do
+      it 'aggregates all values in the same metric' do
+        threads = Array.new(5) do
+          Thread.new do
+            collection.dec(metric_name, value, tags: tags, common: common)
+          end
+        end
+
+        threads.each(&:join)
+
+        expect(first_metric_value).to eq(-value * threads.size)
+      end
+    end
+  end
+
+  describe '#gauge' do
+    subject(:gauge) { collection.gauge(metric_name, value, tags: tags, common: common) }
+
+    let(:metric_name) { 'metric_name' }
+    let(:value) { 5 }
+    let(:tags) { { tag1: 'val1', tag2: 'val2' } }
+    let(:common) { true }
+
+    it 'tracks the metric' do
+      expect { gauge }.to change { metrics.size }.by(1)
+      expect(first_metric_value).to eq(value)
+    end
+
+    context 'gauge again' do
+      it 'aggregates the metric' do
+        gauge
+
+        expect do
+          collection.gauge(metric_name, value + 2, tags: tags, common: common)
+        end.to change { metrics.size }.by(0)
+
+        expect(first_metric_value).to eq(value + 2)
+      end
+    end
+
+    context 'gauge with different tags' do
+      it 'tracks the new metric' do
+        gauge
+
+        expect do
+          collection.gauge(metric_name, value, tags: { tag1: 'val1', tag2: 'val3' }, common: common)
+        end.to change { metrics.size }.by(1)
+      end
+    end
+  end
+
+  describe '#rate' do
+    subject(:rate) { collection.rate(metric_name, value, tags: tags, common: common) }
+
+    let(:metric_name) { 'metric_name' }
+    let(:value) { 5 }
+    let(:tags) { { tag1: 'val1', tag2: 'val2' } }
+    let(:common) { true }
+
+    it 'tracks the metric' do
+      expect { rate }.to change { metrics.size }.by(1)
+      expect(first_metric_value).to eq(value.to_f / interval)
+    end
+
+    context 'rate again' do
+      it 'aggregates the metric' do
+        rate
+
+        expect do
+          collection.rate(metric_name, value, tags: tags, common: common)
+        end.to change { metrics.size }.by(0)
+
+        expect(first_metric_value).to eq(1)
+      end
+    end
+
+    context 'rate with different tags' do
+      it 'tracks the new metric' do
+        rate
+
+        expect do
+          collection.rate(metric_name, value, tags: { tag1: 'val1', tag2: 'val3' }, common: common)
+        end.to change { metrics.size }.by(1)
+      end
+    end
+
+    context 'concurrent rate' do
+      it 'aggregates all values in the same metric' do
+        threads = Array.new(5) do
+          Thread.new do
+            collection.rate(metric_name, value, tags: tags, common: common)
+          end
+        end
+
+        threads.each(&:join)
+
+        expect(first_metric_value).to eq(value.to_f * threads.size / interval)
+      end
+    end
+  end
+
+  describe '#distribution' do
+    subject(:distribution) { collection.distribution(metric_name, value, tags: tags, common: common) }
+
+    let(:metric_name) { 'metric_name' }
+    let(:value) { 5 }
+    let(:tags) { { tag1: 'val1', tag2: 'val2' } }
+    let(:common) { true }
+
+    it 'tracks the metric' do
+      expect { distribution }.to change { distributions.size }.by(1)
+      expect(first_distribution_values).to eq([value])
+    end
+
+    context 'distribution again' do
+      it 'aggregates the metric' do
+        distribution
+
+        expect do
+          collection.distribution(metric_name, value, tags: tags, common: common)
+        end.to change { distributions.size }.by(0)
+
+        expect(first_distribution_values).to eq([value, value])
+      end
+    end
+
+    context 'distribution with different tags' do
+      it 'tracks the new metric' do
+        distribution
+
+        expect do
+          collection.distribution(metric_name, value, tags: { tag1: 'val1', tag2: 'val3' }, common: common)
+        end.to change { distributions.size }.by(1)
+      end
+    end
+
+    context 'concurrent distribution' do
+      it 'aggregates all values in the same metric' do
+        threads = Array.new(5) do
+          Thread.new do
+            collection.distribution(metric_name, value, tags: tags, common: common)
+          end
+        end
+
+        threads.each(&:join)
+
+        expect(first_distribution_values).to eq([value] * threads.size)
+      end
+    end
+  end
+
+  describe '#flush!' do
+    let(:queue) { double('queue') }
+
+    before do
+      allow(queue).to receive(:enqueue)
+    end
+
+    it 'flushes metrics' do
+      collection.inc('metric_name', 5, tags: { tag1: 'val1', tag2: 'val2' }, common: true)
+      collection.inc('metric_name', 5, tags: { tag1: 'val1', tag2: 'val3' }, common: true)
+
+      expect(queue).to receive(:enqueue) do |event|
+        expect(event).to be_a(Datadog::Core::Telemetry::Event::GenerateMetrics)
+        payload = event.payload(1)
+
+        expect(payload[:namespace]).to eq(namespace)
+        expect(payload[:series]).to have(2).items
+
+        tags = payload[:series].map { |s| s[:tags] }.sort
+        expect(tags).to eq([['tag1:val1', 'tag2:val2'], ['tag1:val1', 'tag2:val3']])
+      end.once
+
+      collection.flush!(queue)
+
+      expect(metrics.size).to eq(0)
+    end
+
+    it 'flushes distributions' do
+      collection.distribution('metric_name', 5, tags: { tag1: 'val1', tag2: 'val2' }, common: true)
+      collection.distribution('metric_name', 6, tags: { tag1: 'val1', tag2: 'val2' }, common: true)
+      collection.distribution('metric_name', 5, tags: { tag1: 'val1', tag2: 'val3' }, common: true)
+      collection.distribution('metric_name', 7, tags: { tag1: 'val1', tag2: 'val3' }, common: true)
+
+      expect(queue).to receive(:enqueue) do |event|
+        expect(event).to be_a(Datadog::Core::Telemetry::Event::Distributions)
+        payload = event.payload(1)
+
+        expect(payload[:namespace]).to eq(namespace)
+        expect(payload[:series]).to have(2).items
+
+        tags = payload[:series].map { |s| s[:tags] }.sort
+        expect(tags).to eq([['tag1:val1', 'tag2:val2'], ['tag1:val1', 'tag2:val3']])
+
+        values = payload[:series].map { |s| s[:points] }.sort
+        expect(values).to eq([[5, 6], [5, 7]])
+      end.once
+
+      collection.flush!(queue)
+
+      expect(distributions.size).to eq(0)
+    end
+
+    it 'does not loose metrics when running in multiple threads' do
+      threads_count = 5
+      metrics_count = 0
+      expect(queue).to receive(:enqueue) do |event|
+        metrics_count += event.payload(1)[:series].size
+      end.at_least(:once)
+
+      threads = Array.new(threads_count) do |i|
+        Thread.new do
+          collection.inc("metric_name_#{i}", 5, tags: { tag1: 'val1', tag2: 'val2' }, common: true)
+          collection.flush!(queue)
+          collection.inc("metric_name_#{i}", 5, tags: { tag1: 'val1', tag2: 'val3' }, common: true)
+          collection.distribution("metric_name_#{i}", 5, tags: { tag1: 'val1', tag2: 'val2' }, common: true)
+          collection.distribution("metric_name_#{i}", 5, tags: { tag1: 'val1', tag2: 'val3' }, common: true)
+          collection.flush!(queue)
+        end
+      end
+
+      threads.each(&:join)
+
+      expect(metrics.size).to eq(0)
+      expect(distributions.size).to eq(0)
+
+      expect(metrics_count).to eq(4 * threads_count)
+    end
+  end
+end

--- a/spec/datadog/core/telemetry/metrics_collection_spec.rb
+++ b/spec/datadog/core/telemetry/metrics_collection_spec.rb
@@ -293,10 +293,12 @@ RSpec.describe Datadog::Core::Telemetry::MetricsCollection do
     end
 
     it 'does not loose metrics when running in multiple threads' do
+      mutex = Mutex.new
       threads_count = 5
       metrics_count = 0
+
       expect(queue).to receive(:enqueue) do |event|
-        metrics_count += event.payload(1)[:series].size
+        mutex.synchronize { metrics_count += event.payload(1)[:series].size }
       end.at_least(:once)
 
       threads = Array.new(threads_count) do |i|

--- a/spec/datadog/core/telemetry/metrics_manager_spec.rb
+++ b/spec/datadog/core/telemetry/metrics_manager_spec.rb
@@ -223,7 +223,7 @@ RSpec.describe Datadog::Core::Telemetry::MetricsManager do
 
         flushed_metrics_count = 0
         allow(queue).to receive(:enqueue) do |event|
-          mutex.synchronize { flushed_metrics_count += event.payload(1)[:series].count }
+          mutex.synchronize { flushed_metrics_count += event.payload[:series].count }
         end
 
         threads = Array.new(threads_count) do |n|

--- a/spec/datadog/core/telemetry/metrics_manager_spec.rb
+++ b/spec/datadog/core/telemetry/metrics_manager_spec.rb
@@ -1,0 +1,213 @@
+require 'spec_helper'
+
+require 'datadog/core/telemetry/metrics_manager'
+
+RSpec.describe Datadog::Core::Telemetry::MetricsManager do
+  subject(:manager) { described_class.new(aggregation_interval: interval, enabled: enabled) }
+
+  def collections
+    manager.instance_variable_get(:@collections)
+  end
+
+  def first_collection
+    collections.values.first
+  end
+
+  let(:interval) { 10 }
+  let(:enabled) { true }
+  let(:namespace) { 'namespace' }
+  let(:metric_name) { 'metric_name' }
+  let(:value) { 5 }
+  let(:tags) { { tag1: 'val1', tag2: 'val2' } }
+  let(:common) { true }
+
+  describe '#inc' do
+    subject(:inc) { manager.inc(namespace, metric_name, value, tags: tags, common: common) }
+
+    it 'creates a new collection' do
+      expect { inc }.to change(collections, :size).from(0).to(1)
+      expect(first_collection.namespace).to eq(namespace)
+      expect(first_collection.interval).to eq(interval)
+    end
+
+    it 'forwards the action to the collection' do
+      collection = double(:collection)
+      expect(Datadog::Core::Telemetry::MetricsCollection).to receive(:new).and_return(collection)
+      expect(collection).to receive(:inc).with(metric_name, value, tags: tags, common: common)
+
+      inc
+    end
+
+    context 'with different namespaces' do
+      it 'creates collection per namespace' do
+        inc
+
+        expect { manager.inc('another_namespace', metric_name, value, tags: tags, common: common) }
+          .to change(collections, :size).from(1).to(2)
+      end
+    end
+
+    context 'when disabled' do
+      let(:enabled) { false }
+
+      it 'does nothing' do
+        expect { inc }.not_to change(collections, :size)
+      end
+    end
+  end
+
+  describe '#dec' do
+    subject(:dec) { manager.dec(namespace, metric_name, value, tags: tags, common: common) }
+
+    it 'creates a new collection' do
+      expect { dec }.to change(collections, :size).from(0).to(1)
+      expect(first_collection.namespace).to eq(namespace)
+      expect(first_collection.interval).to eq(interval)
+    end
+
+    it 'forwards the action to the collection' do
+      collection = double(:collection)
+      expect(Datadog::Core::Telemetry::MetricsCollection).to receive(:new).and_return(collection)
+      expect(collection).to receive(:dec).with(metric_name, value, tags: tags, common: common)
+
+      dec
+    end
+
+    context 'when disabled' do
+      let(:enabled) { false }
+
+      it 'does nothing' do
+        expect { dec }.not_to change(collections, :size)
+      end
+    end
+  end
+
+  describe '#gauge' do
+    subject(:gauge) { manager.gauge(namespace, metric_name, value, tags: tags, common: common) }
+
+    it 'creates a new collection' do
+      expect { gauge }.to change(collections, :size).from(0).to(1)
+      expect(first_collection.namespace).to eq(namespace)
+      expect(first_collection.interval).to eq(interval)
+    end
+
+    it 'forwards the action to the collection' do
+      collection = double(:collection)
+      expect(Datadog::Core::Telemetry::MetricsCollection).to receive(:new).and_return(collection)
+      expect(collection).to receive(:gauge).with(metric_name, value, tags: tags, common: common)
+
+      gauge
+    end
+
+    context 'with different namespaces' do
+      it 'creates collection per namespace' do
+        gauge
+
+        expect { manager.gauge('another_namespace', metric_name, value, tags: tags, common: common) }
+          .to change(collections, :size).from(1).to(2)
+      end
+    end
+
+    context 'when disabled' do
+      let(:enabled) { false }
+
+      it 'does nothing' do
+        expect { gauge }.not_to change(collections, :size)
+      end
+    end
+  end
+
+  describe '#rate' do
+    subject(:rate) { manager.rate(namespace, metric_name, value, tags: tags, common: common) }
+
+    it 'creates a new collection' do
+      expect { rate }.to change(collections, :size).from(0).to(1)
+      expect(first_collection.namespace).to eq(namespace)
+      expect(first_collection.interval).to eq(interval)
+    end
+
+    it 'forwards the action to the collection' do
+      collection = double(:collection)
+      expect(Datadog::Core::Telemetry::MetricsCollection).to receive(:new).and_return(collection)
+      expect(collection).to receive(:rate).with(metric_name, value, tags: tags, common: common)
+
+      rate
+    end
+
+    context 'with different namespaces' do
+      it 'creates collection per namespace' do
+        rate
+
+        expect { manager.rate('another_namespace', metric_name, value, tags: tags, common: common) }
+          .to change(collections, :size).from(1).to(2)
+      end
+    end
+
+    context 'when disabled' do
+      let(:enabled) { false }
+
+      it 'does nothing' do
+        expect { rate }.not_to change(collections, :size)
+      end
+    end
+  end
+
+  describe '#distribution' do
+    subject(:distribution) { manager.distribution(namespace, metric_name, value, tags: tags, common: common) }
+
+    it 'creates a new collection' do
+      expect { distribution }.to change(collections, :size).from(0).to(1)
+      expect(first_collection.namespace).to eq(namespace)
+      expect(first_collection.interval).to eq(interval)
+    end
+
+    it 'forwards the action to the collection' do
+      collection = double(:collection)
+      expect(Datadog::Core::Telemetry::MetricsCollection).to receive(:new).and_return(collection)
+      expect(collection).to receive(:distribution).with(metric_name, value, tags: tags, common: common)
+
+      distribution
+    end
+
+    context 'with different namespaces' do
+      it 'creates collection per namespace' do
+        distribution
+
+        expect { manager.distribution('another_namespace', metric_name, value, tags: tags, common: common) }
+          .to change(collections, :size).from(1).to(2)
+      end
+    end
+
+    context 'when disabled' do
+      let(:enabled) { false }
+
+      it 'does nothing' do
+        expect { distribution }.not_to change(collections, :size)
+      end
+    end
+  end
+
+  describe '#flush!' do
+    subject(:flush!) { manager.flush!(queue) }
+
+    let(:queue) { [] }
+
+    it 'forwards flush to the collections' do
+      collection = double(:collection)
+      expect(Datadog::Core::Telemetry::MetricsCollection).to receive(:new).and_return(collection)
+      expect(collection).to receive(:inc)
+      expect(collection).to receive(:flush!).with(queue)
+
+      manager.inc(namespace, metric_name, value, tags: tags)
+      flush!
+    end
+
+    context 'when disabled' do
+      let(:enabled) { false }
+
+      it 'does nothing' do
+        flush!
+      end
+    end
+  end
+end

--- a/spec/datadog/core/telemetry/metrics_manager_spec.rb
+++ b/spec/datadog/core/telemetry/metrics_manager_spec.rb
@@ -206,6 +206,8 @@ RSpec.describe Datadog::Core::Telemetry::MetricsManager do
       let(:enabled) { false }
 
       it 'does nothing' do
+        expect(Datadog::Core::Telemetry::MetricsCollection).to_not receive(:new)
+
         flush!
       end
     end

--- a/spec/datadog/core/telemetry/metrics_manager_spec.rb
+++ b/spec/datadog/core/telemetry/metrics_manager_spec.rb
@@ -210,4 +210,12 @@ RSpec.describe Datadog::Core::Telemetry::MetricsManager do
       end
     end
   end
+
+  describe '#disable!' do
+    subject(:disable!) { manager.disable! }
+
+    it 'disables the manager' do
+      expect { disable! }.to change(manager, :enabled).from(true).to(false)
+    end
+  end
 end

--- a/spec/datadog/core/telemetry/metrics_manager_spec.rb
+++ b/spec/datadog/core/telemetry/metrics_manager_spec.rb
@@ -216,11 +216,13 @@ RSpec.describe Datadog::Core::Telemetry::MetricsManager do
       let(:queue) { double('queue') }
 
       it 'flushes all metrics' do
+        mutex = Mutex.new
+
         threads_count = 5
         events_count = 0
 
         allow(queue).to receive(:enqueue) do
-          events_count += 1
+          mutex.synchronize { events_count += 1 }
         end
 
         threads = Array.new(threads_count) do |n|


### PR DESCRIPTION
**What does this PR do?**
Adds entities to collect metrics and flush them to telemetry events:
- `MetricsCollection` aggregates metrics per **namespace** and on demand flushes them to a queue passed as a param - this is going to be `Telemetry::Worker`. At most 2 events are created on flush: one for metrics, one for distributions. The methods of `MetricsCollection` are synchronized, protecting access to at most one thread at a time.
- `MetricsManager` is a central piece of metrics aggregation: it manages collections, one per namespace. It synchronizes access to a hashmap with all collections, but allows concurrent access to a collection after it's fetched from the map. The method `flush!` locks access to the collections map and flushes each collection in order.

The concerns of managing metrics and managing namespaces are separated for the following reasons:
- makes it easier to reason about concurrency and thread-safety of each component in isolation
- allows concurrent access to several metrics namespaces at once, i.e. "civisibility" and "tracing" workers can add metrics without being blocked by each other.

**Motivation:**
Next small step to achieving metrics support for internal DD telemetry.

**How to test the change?**
Only unit tests for now (including several concurrency tests).