### PR TITLE
Fix lib injection with fork

### DIFF
--- a/lib-injection/host_inject.rb
+++ b/lib-injection/host_inject.rb
@@ -93,7 +93,13 @@ begin
   end
 
   already_installed = ['ddtrace', 'datadog'].any? do |gem|
-    !!Bundler::CLI::Common.select_spec(gem) rescue false
+    fork {
+      $stdout = File.new("/dev/null", "w")
+      $stderr = File.new("/dev/null", "w")
+      Bundler::CLI::Common.select_spec(gem)
+    }
+    _, status = Process.wait2
+    status.success?
   end
 
   if already_installed
@@ -144,7 +150,14 @@ begin
     'libddwaf',
     'datadog'
   ].each do |gem|
-    if (Bundler::CLI::Common.select_spec(gem) rescue false)
+    fork {
+      $stdout = File.new("/dev/null", "w")
+      $stderr = File.new("/dev/null", "w")
+      Bundler::CLI::Common.select_spec(gem)
+    }
+
+    _, status = Process.wait2
+    if status.success?
       dd_debug_log "#{gem} already installed... skipping..."
       next
     end

--- a/lib-injection/host_inject.rb
+++ b/lib-injection/host_inject.rb
@@ -191,8 +191,7 @@ begin
 
     # Also apply to the environment variable, to guarantee any spawned processes will respected the modified `GEM_PATH`.
     ENV['GEM_PATH'] = Gem.path.join(':')
-    ::FileUtils.cp datadog_gemfile, gemfile
-    ::FileUtils.cp datadog_lockfile, lockfile
+    ENV['BUNDLE_GEMFILE'] = datadog_gemfile.to_s
 
     dd_send_telemetry([{ name: 'library_entrypoint.complete', tags: ['injection_forced:false'] }])
   end

--- a/lib-injection/host_inject.rb
+++ b/lib-injection/host_inject.rb
@@ -178,7 +178,8 @@ begin
 
     # Also apply to the environment variable, to guarantee any spawned processes will respected the modified `GEM_PATH`.
     ENV['GEM_PATH'] = Gem.path.join(':')
-    ENV['BUNDLE_GEMFILE'] = datadog_gemfile.to_s
+    ::FileUtils.cp datadog_gemfile, gemfile
+    ::FileUtils.cp datadog_lockfile, lockfile
 
     dd_send_telemetry([{ name: 'library_entrypoint.complete', tags: ['injection_forced:false'] }])
   end


### PR DESCRIPTION
**What does this PR do?**

From: https://github.com/DataDog/dd-trace-rb/pull/3676

In the previous PR, I implement `Bundler::CLI::Common.select_spec(gem)` to avoid false positive result. However, this implementation has side effect with loading specs. Causing multiple injection and missing environment variables.

To mitigate this I encapsulate this check in a forked process to prevent side effect.

It is supposed to work with different command variants

```
rails
bin/rails
bundle exec rails
```