### PR TITLE
[SDTEST-409] Send telemetry events in batches

### DIFF
--- a/lib/datadog/core/telemetry/event.rb
+++ b/lib/datadog/core/telemetry/event.rb
@@ -316,6 +316,8 @@ module Datadog
 
         # Telemetry class for the 'message-batch' event
         class MessageBatch
+          attr_reader :events
+
           def type
             'message-batch'
           end

--- a/lib/datadog/core/telemetry/event.rb
+++ b/lib/datadog/core/telemetry/event.rb
@@ -313,6 +313,26 @@ module Datadog
             'distributions'
           end
         end
+
+        # Telemetry class for the 'message-batch' event
+        class MessageBatch
+          def type
+            'message-batch'
+          end
+
+          def initialize(events)
+            @events = events
+          end
+
+          def payload(seq_id)
+            @events.map do |event|
+              {
+                request_type: event.type,
+                payload: event.payload(seq_id),
+              }
+            end
+          end
+        end
       end
     end
   end

--- a/lib/datadog/core/telemetry/event.rb
+++ b/lib/datadog/core/telemetry/event.rb
@@ -3,7 +3,16 @@
 module Datadog
   module Core
     module Telemetry
+      # Collection of telemetry events
       class Event
+        extend Core::Utils::Forking
+
+        # returns sequence that increments every time the configuration changes
+        def self.configuration_sequence
+          after_fork! { @sequence = Datadog::Core::Utils::Sequence.new(1) }
+          @sequence ||= Datadog::Core::Utils::Sequence.new(1)
+        end
+
         # Base class for all Telemetry V2 events.
         class Base
           # The type of the event.
@@ -12,8 +21,7 @@ module Datadog
           def type; end
 
           # The JSON payload for the event.
-          # @param seq_id [Integer] The sequence ID for the event.
-          def payload(seq_id)
+          def payload
             {}
           end
         end
@@ -24,8 +32,7 @@ module Datadog
             'app-started'
           end
 
-          def payload(seq_id)
-            @seq_id = seq_id
+          def payload
             {
               products: products,
               configuration: configuration,
@@ -80,16 +87,19 @@ module Datadog
           ].freeze
 
           # rubocop:disable Metrics/AbcSize
+          # rubocop:disable Metrics/MethodLength
           def configuration
             config = Datadog.configuration
+            seq_id = Event.configuration_sequence.next
 
             list = [
-              conf_value('DD_AGENT_HOST', config.agent.host),
-              conf_value('DD_AGENT_TRANSPORT', agent_transport(config)),
-              conf_value('DD_TRACE_SAMPLE_RATE', to_value(config.tracing.sampling.default_rate)),
+              conf_value('DD_AGENT_HOST', config.agent.host, seq_id),
+              conf_value('DD_AGENT_TRANSPORT', agent_transport(config), seq_id),
+              conf_value('DD_TRACE_SAMPLE_RATE', to_value(config.tracing.sampling.default_rate), seq_id),
               conf_value(
                 'DD_TRACE_REMOVE_INTEGRATION_SERVICE_NAMES_ENABLED',
-                config.tracing.contrib.global_default_service_name.enabled
+                config.tracing.contrib.global_default_service_name.enabled,
+                seq_id
               ),
             ]
 
@@ -98,32 +108,45 @@ module Datadog
               peer_service_mapping = config.tracing.contrib.peer_service_mapping
               peer_service_mapping_str = peer_service_mapping.map { |key, value| "#{key}:#{value}" }.join(',')
             end
-            list << conf_value('DD_TRACE_PEER_SERVICE_MAPPING', peer_service_mapping_str)
+            list << conf_value('DD_TRACE_PEER_SERVICE_MAPPING', peer_service_mapping_str, seq_id)
 
             # Whitelist of configuration options to send in additional payload object
             TARGET_OPTIONS.each do |option|
               split_option = option.split('.')
-              list << conf_value(option, to_value(config.dig(*split_option)))
+              list << conf_value(option, to_value(config.dig(*split_option)), seq_id)
             end
 
             # Add some more custom additional payload values here
             list.push(
-              conf_value('tracing.auto_instrument.enabled', !defined?(Datadog::AutoInstrument::LOADED).nil?),
-              conf_value('tracing.writer_options.buffer_size', to_value(config.tracing.writer_options[:buffer_size])),
-              conf_value('tracing.writer_options.flush_interval', to_value(config.tracing.writer_options[:flush_interval])),
-              conf_value('tracing.opentelemetry.enabled', !defined?(Datadog::OpenTelemetry::LOADED).nil?),
+              conf_value('tracing.auto_instrument.enabled', !defined?(Datadog::AutoInstrument::LOADED).nil?, seq_id),
+              conf_value(
+                'tracing.writer_options.buffer_size',
+                to_value(config.tracing.writer_options[:buffer_size]),
+                seq_id
+              ),
+              conf_value(
+                'tracing.writer_options.flush_interval',
+                to_value(config.tracing.writer_options[:flush_interval]),
+                seq_id
+              ),
+              conf_value(
+                'tracing.opentelemetry.enabled',
+                !defined?(Datadog::OpenTelemetry::LOADED).nil?,
+                seq_id
+              ),
             )
-            list << conf_value('logger.instance', config.logger.instance.class.to_s) if config.logger.instance
+            list << conf_value('logger.instance', config.logger.instance.class.to_s, seq_id) if config.logger.instance
             if config.respond_to?('appsec')
-              list << conf_value('appsec.enabled', config.dig('appsec', 'enabled'))
-              list << conf_value('appsec.sca_enabled', config.dig('appsec', 'sca_enabled'))
+              list << conf_value('appsec.enabled', config.dig('appsec', 'enabled'), seq_id)
+              list << conf_value('appsec.sca_enabled', config.dig('appsec', 'sca_enabled'), seq_id)
             end
-            list << conf_value('ci.enabled', config.dig('ci', 'enabled')) if config.respond_to?('ci')
+            list << conf_value('ci.enabled', config.dig('ci', 'enabled'), seq_id) if config.respond_to?('ci')
 
             list.reject! { |entry| entry[:value].nil? }
             list
           end
           # rubocop:enable Metrics/AbcSize
+          # rubocop:enable Metrics/MethodLength
 
           def agent_transport(config)
             adapter = Core::Configuration::AgentSettingsResolver.call(config).adapter
@@ -134,12 +157,12 @@ module Datadog
             end
           end
 
-          def conf_value(name, value, origin = 'code')
+          def conf_value(name, value, seq_id, origin = 'code')
             {
               name: name,
               value: value,
               origin: origin,
-              seq_id: @seq_id,
+              seq_id: seq_id,
             }
           end
 
@@ -169,7 +192,7 @@ module Datadog
             'app-dependencies-loaded'
           end
 
-          def payload(seq_id)
+          def payload
             { dependencies: dependencies }
           end
 
@@ -192,7 +215,7 @@ module Datadog
             'app-integrations-change'
           end
 
-          def payload(seq_id)
+          def payload
             { integrations: integrations }
           end
 
@@ -245,18 +268,20 @@ module Datadog
             @origin = origin
           end
 
-          def payload(seq_id)
-            { configuration: configuration(seq_id) }
+          def payload
+            { configuration: configuration }
           end
 
-          def configuration(seq_id)
+          def configuration
             config = Datadog.configuration
+            seq_id = Event.configuration_sequence.next
 
             res = @changes.map do |name, value|
               {
                 name: name,
                 value: value,
                 origin: @origin,
+                seq_id: seq_id,
               }
             end
 
@@ -299,7 +324,7 @@ module Datadog
             @metric_series = metric_series
           end
 
-          def payload(_)
+          def payload
             {
               namespace: @namespace,
               series: @metric_series.map(&:to_h)
@@ -326,11 +351,11 @@ module Datadog
             @events = events
           end
 
-          def payload(seq_id)
+          def payload
             @events.map do |event|
               {
                 request_type: event.type,
-                payload: event.payload(seq_id),
+                payload: event.payload,
               }
             end
           end

--- a/lib/datadog/core/telemetry/request.rb
+++ b/lib/datadog/core/telemetry/request.rb
@@ -17,7 +17,7 @@ module Datadog
               application: application,
               debug: false,
               host: host,
-              payload: event.payload(seq_id),
+              payload: event.payload,
               request_type: event.type,
               runtime_id: Core::Environment::Identity.id,
               seq_id: seq_id,

--- a/lib/datadog/core/telemetry/worker.rb
+++ b/lib/datadog/core/telemetry/worker.rb
@@ -82,19 +82,17 @@ module Datadog
         end
 
         def flush_events(events)
-          return if events.nil?
+          return if events.nil? || events.empty?
           return if !enabled? || !sent_started_event?
 
           Datadog.logger.debug { "Sending #{events&.count} telemetry events" }
-          events.each do |event|
-            send_event(event)
-          end
+          send_event(Event::MessageBatch.new(events))
         end
 
         def heartbeat!
           return if !enabled? || !sent_started_event?
 
-          send_event(Event::AppHeartbeat.new)
+          enqueue(Event::AppHeartbeat.new)
         end
 
         def started!

--- a/lib/datadog/core/telemetry/worker.rb
+++ b/lib/datadog/core/telemetry/worker.rb
@@ -92,7 +92,7 @@ module Datadog
         def heartbeat!
           return if !enabled? || !sent_started_event?
 
-          enqueue(Event::AppHeartbeat.new)
+          send_event(Event::AppHeartbeat.new)
         end
 
         def started!

--- a/sig/datadog/core/telemetry/emitter.rbs
+++ b/sig/datadog/core/telemetry/emitter.rbs
@@ -2,7 +2,7 @@ module Datadog
   module Core
     module Telemetry
       class Emitter
-        @sequence: Datadog::Core::Utils::Sequence
+        self.@sequence: Datadog::Core::Utils::Sequence
 
         attr_reader http_transport: untyped
 

--- a/sig/datadog/core/telemetry/event.rbs
+++ b/sig/datadog/core/telemetry/event.rbs
@@ -3,7 +3,7 @@ module Datadog
     module Telemetry
       class Event
         class Base
-          def payload: (int seq_id) -> Hash[Symbol, untyped]
+          def payload: (int seq_id) -> (Hash[Symbol, untyped] | Array[Hash[Symbol, untyped]])
           def type: -> String?
         end
 
@@ -64,6 +64,12 @@ module Datadog
         end
 
         class Distributions < GenerateMetrics
+        end
+
+        class MessageBatch < Base
+          @events: Array[Datadog::Core::Telemetry::Event::Base]
+
+          def initialize: (Array[Datadog::Core::Telemetry::Event::Base] events) -> void
         end
       end
     end

--- a/sig/datadog/core/telemetry/event.rbs
+++ b/sig/datadog/core/telemetry/event.rbs
@@ -67,6 +67,7 @@ module Datadog
         end
 
         class MessageBatch < Base
+          attr_reader events: Array[Datadog::Core::Telemetry::Event::Base]
           @events: Array[Datadog::Core::Telemetry::Event::Base]
 
           def initialize: (Array[Datadog::Core::Telemetry::Event::Base] events) -> void

--- a/sig/datadog/core/telemetry/event.rbs
+++ b/sig/datadog/core/telemetry/event.rbs
@@ -2,15 +2,19 @@ module Datadog
   module Core
     module Telemetry
       class Event
+        extend Core::Utils::Forking
+
+        self.@sequence: Datadog::Core::Utils::Sequence
+
+        def self.configuration_sequence: () -> Datadog::Core::Utils::Sequence
+
         class Base
-          def payload: (int seq_id) -> (Hash[Symbol, untyped] | Array[Hash[Symbol, untyped]])
+          def payload: () -> (Hash[Symbol, untyped] | Array[Hash[Symbol, untyped]])
           def type: -> String?
         end
 
         class AppStarted < Base
           TARGET_OPTIONS: Array[String]
-
-          @seq_id: int
 
           private
 
@@ -20,7 +24,7 @@ module Datadog
 
           def agent_transport: (untyped config) -> String
 
-          def conf_value: (String name, Object value, ?String origin) -> Hash[Symbol, untyped]
+          def conf_value: (String name, Object value, Integer seq_id, ?String origin) -> Hash[Symbol, untyped]
 
           def to_value: (Object value) -> Object
 
@@ -47,7 +51,7 @@ module Datadog
 
           def initialize: (Enumerable[[String, Numeric | bool | String]] changes, String origin) -> void
 
-          def configuration: (int seq_id) -> Array[Hash[Symbol, untyped]]
+          def configuration: () -> Array[Hash[Symbol, untyped]]
         end
 
         class AppHeartbeat < Base

--- a/spec/datadog/core/telemetry/event_spec.rb
+++ b/spec/datadog/core/telemetry/event_spec.rb
@@ -252,4 +252,25 @@ RSpec.describe Datadog::Core::Telemetry::Event do
       )
     end
   end
+
+  context 'MessageBatch' do
+    let(:event) { described_class::MessageBatch.new(events) }
+
+    let(:events) { [described_class::AppClosing.new, described_class::AppHeartbeat.new] }
+
+    it do
+      is_expected.to eq(
+        [
+          {
+            request_type: 'app-closing',
+            payload: {}
+          },
+          {
+            request_type: 'app-heartbeat',
+            payload: {}
+          }
+        ]
+      )
+    end
+  end
 end

--- a/spec/datadog/core/telemetry/event_spec.rb
+++ b/spec/datadog/core/telemetry/event_spec.rb
@@ -5,7 +5,7 @@ require 'datadog/core/telemetry/metric'
 
 RSpec.describe Datadog::Core::Telemetry::Event do
   let(:id) { double('seq_id') }
-  subject(:payload) { event.payload(id) }
+  subject(:payload) { event.payload }
 
   context 'AppStarted' do
     let(:event) { described_class::AppStarted.new }
@@ -14,6 +14,8 @@ RSpec.describe Datadog::Core::Telemetry::Event do
     end
 
     before do
+      allow_any_instance_of(Datadog::Core::Utils::Sequence).to receive(:next).and_return(id)
+
       Datadog.configure do |c|
         c.agent.host = '1.2.3.4'
         c.tracing.sampling.default_rate = 0.5
@@ -164,12 +166,17 @@ RSpec.describe Datadog::Core::Telemetry::Event do
     let(:name) { 'key' }
     let(:value) { 'value' }
 
+    before do
+      allow_any_instance_of(Datadog::Core::Utils::Sequence).to receive(:next).and_return(id)
+    end
+
     it 'has a list of client configurations' do
       is_expected.to eq(
         configuration: [{
           name: name,
           value: value,
           origin: origin,
+          seq_id: id
         }]
       )
     end
@@ -185,7 +192,7 @@ RSpec.describe Datadog::Core::Telemetry::Event do
         is_expected.to eq(
           configuration:
           [
-            { name: name, value: value, origin: origin },
+            { name: name, value: value, origin: origin, seq_id: id },
             { name: 'appsec.sca_enabled', value: false, origin: 'code', seq_id: id }
           ]
         )

--- a/spec/datadog/core/telemetry/worker_spec.rb
+++ b/spec/datadog/core/telemetry/worker_spec.rb
@@ -295,8 +295,10 @@ RSpec.describe Datadog::Core::Telemetry::Worker do
       allow(emitter).to receive(:request).with(
         an_instance_of(Datadog::Core::Telemetry::Event::MessageBatch)
       ) do |event|
-        mutex.synchronize do
-          events_received += event.events.count
+        event.events.each do |subevent|
+          mutex.synchronize do
+            events_received += 1 if subevent.is_a?(Datadog::Core::Telemetry::Event::AppIntegrationsChange)
+          end
         end
 
         response

--- a/spec/datadog/core/telemetry/worker_spec.rb
+++ b/spec/datadog/core/telemetry/worker_spec.rb
@@ -283,10 +283,7 @@ RSpec.describe Datadog::Core::Telemetry::Worker do
       ) do |event|
         event.events.each do |subevent|
           mutex.synchronize do
-            if subevent.is_a?(Datadog::Core::Telemetry::Event::AppIntegrationsChange)
-              p "received event"
-              events_received += 1
-            end
+            events_received += 1 if subevent.is_a?(Datadog::Core::Telemetry::Event::AppIntegrationsChange)
           end
         end
 
@@ -294,7 +291,6 @@ RSpec.describe Datadog::Core::Telemetry::Worker do
       end
 
       worker.enqueue(Datadog::Core::Telemetry::Event::AppIntegrationsChange.new)
-      p "stop worker"
       worker.stop(true)
 
       try_wait_until { events_received == 1 }

--- a/spec/datadog/core/telemetry/worker_spec.rb
+++ b/spec/datadog/core/telemetry/worker_spec.rb
@@ -291,10 +291,13 @@ RSpec.describe Datadog::Core::Telemetry::Worker do
   describe '#enqueue' do
     it 'adds events to the buffer and flushes them later' do
       events_received = 0
+      mutex = Mutex.new
       allow(emitter).to receive(:request).with(
         an_instance_of(Datadog::Core::Telemetry::Event::MessageBatch)
       ) do |event|
-        events_received += event.events.count
+        mutex.synchronize do
+          events_received += event.events.count
+        end
 
         response
       end

--- a/spec/datadog/core/telemetry/worker_spec.rb
+++ b/spec/datadog/core/telemetry/worker_spec.rb
@@ -76,15 +76,12 @@ RSpec.describe Datadog::Core::Telemetry::Worker do
         it 'disables the worker' do
           worker.start
 
-          try_wait_until { @received_started }
+          try_wait_until { !worker.enabled? }
 
-          expect(worker).to have_attributes(
-            enabled?: false,
-            loop_base_interval: heartbeat_interval_seconds,
-          )
           expect(Datadog.logger).to have_received(:debug).with(
             'Agent does not support telemetry; disabling future telemetry events.'
           )
+          expect(@received_started).to be(true)
           expect(@received_heartbeat).to be(false)
         end
       end


### PR DESCRIPTION
**What does this PR do?**
Optimises telemetry events sending by sending them in batches using `message-batch` event type.

**Motivation:**
I expect the number of telemetry events to grow as soon as products start using metrics. We can save time by batching the list of events into a single event.

**How to test the change?**
System tests pass for telemetry events.

Logs from rails app with DD_TRACE_DEBUG=1:

```bash
D, [2024-07-01T16:08:58.970222 #20478] DEBUG -- datadog: [datadog] (/Users/andrey.marchenko/p/dd-trace-rb/lib/datadog/core/telemetry/worker.rb:88:in `flush_events') Sending 2 telemetry events
D, [2024-07-01T16:08:59.137402 #20478] DEBUG -- datadog: [datadog] (/Users/andrey.marchenko/p/dd-trace-rb/lib/datadog/core/telemetry/emitter.rb:29:in `request') Telemetry sent for event `message-batch` (code: 202)
```