### PR TITLE
Fix a small typo about `Datadog::Tracing::Correlation::Identifier` in UpgradeGuide2.md

### DIFF
--- a/docs/UpgradeGuide2.md
+++ b/docs/UpgradeGuide2.md
@@ -202,7 +202,7 @@ end
 
 <h3 id="2.0-log-correlation">Log Correlation</h3>
 
-The following fields have been from `Datadog::Tracing::Correlation::Identifier`, and it no longer responds to them
+The following fields have been removed from `Datadog::Tracing::Correlation::Identifier`, and it no longer responds to them
 
 - `Datadog::Tracing::Correlation::Identifier#span_name`
 - `Datadog::Tracing::Correlation::Identifier#span_resource`


### PR DESCRIPTION

**What does this PR do?**

Fix a small typo in `UpgradeGuide2.md`

**Motivation:**

Allow to understand the change of `Datadog::Tracing::Correlation::Identifier`.

