### PR TITLE
Add quick link to support in issue creation form

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,5 +1,5 @@
 ---
-name: Bug report
+name: 🐛 Bug report
 about: File a bug report
 title: ''
 labels: community, bug

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,5 @@
+blank_issues_enabled: true
+contact_links:
+  - name: ℹ️ Datadog Support
+    url: https://www.datadoghq.com/support/
+    about: Get help from the Datadog support team

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -1,5 +1,5 @@
 ---
-name: Feature request
+name: 💡 Feature request
 about: Suggest an idea for this project
 title: ''
 labels: community, feature-request


### PR DESCRIPTION
**What does this PR do?**

This PR adds a quick link to talk to Datadog support as part of the issue creation flow. Of course, folks still can (and are very much encouraged to) file tickets as needed, but often support will be faster and can delve into account specifics to provide better help.

I borrowed this idea from https://github.com/DataDog/test-template/issues/new/choose and you can see it working live in there.

**Motivation:**

Improve support experience for Ruby users.

**Additional Notes:**

I've also added some cool emoji to the existing issue types.

**How to test the change?**

Other than looking at the template repo, I'm not sure if there's a way to see these changes live before we merge them.

But, on the other hand, it's very easy to check and revert, so the risk is very low.
