### PR TITLE
[NO TICKET] add datadog static analysis and SCA

### DIFF
--- a/.github/workflows/datadog-sca.yml
+++ b/.github/workflows/datadog-sca.yml
@@ -1,0 +1,25 @@
+on: [push]
+
+name: Datadog Software Composition Analysis
+
+jobs:
+  software-composition-analysis:
+    runs-on: ubuntu-latest
+    name: Datadog SBOM Generation and Upload
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+      - name: Set up Ruby
+        uses: ruby/setup-ruby@v1
+        with:
+          bundler-cache: true
+          ruby-version: "3.3"
+      - name: Check imported libraries are secure and compliant
+        id: datadog-software-composition-analysis
+        uses: DataDog/datadog-sca-github-action@main
+        with:
+          dd_api_key: ${{ secrets.DD_API_KEY }}
+          dd_app_key: ${{ secrets.DD_APP_KEY }}
+          dd_service: dd-trace-rb
+          dd_env: ci
+          dd_site: datadoghq.com

--- a/.github/workflows/datadog-static-analysis.yml
+++ b/.github/workflows/datadog-static-analysis.yml
@@ -1,0 +1,21 @@
+on: [push]
+
+name: Datadog Static Analysis
+
+jobs:
+  static-analysis:
+    runs-on: ubuntu-latest
+    name: Datadog Static Analyzer
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+      - name: Check code meets quality and security standards
+        id: datadog-static-analysis
+        uses: DataDog/datadog-static-analyzer-github-action@v1
+        with:
+          dd_api_key: ${{ secrets.DD_API_KEY }}
+          dd_app_key: ${{ secrets.DD_APP_KEY }}
+          dd_service: dd-trace-rb
+          dd_env: ci
+          dd_site: datadoghq.com
+          cpu_count: 2

--- a/sig/datadog/core/environment/git.rbs
+++ b/sig/datadog/core/environment/git.rbs
@@ -2,9 +2,9 @@ module Datadog
   module Core
     module Environment
       module Git
-        @git_repository_url: String?
+        self.@git_repository_url: String?
 
-        @git_commit_sha: String?
+        self.@git_commit_sha: String?
 
         def self?.git_repository_url: () -> String?
 

--- a/spec/datadog/release_gem_spec.rb
+++ b/spec/datadog/release_gem_spec.rb
@@ -35,6 +35,7 @@ RSpec.describe 'gem release process' do
            |datadog\.gemspec
            |docker-compose\.yml
            |shell\.nix
+           |static-analysis\.datadog\.yml
           )
           $
         }x

--- a/static-analysis.datadog.yml
+++ b/static-analysis.datadog.yml
@@ -1,0 +1,5 @@
+schema-version: v1
+rulesets:
+  - ruby-code-style
+  - ruby-security
+  - ruby-best-practices


### PR DESCRIPTION
**What does this PR do?**
Adds Datadog static analysis and static composition analysis

**Motivation:**
Dogfooding software delivery tooling and increasing code quality

**How to test the change?**
Here are the issues found:
https://app.datadoghq.com/ci/code-analysis/github.com%2Fdatadog%2Fdd-trace-rb/anmarchenko%2Fdd_sca_sa/e1f1babe0c3221c106960cf60cc853a9dc5eb112/code-vulnerabilities?query=%40git.repository.id%3Agithub.com%2Fdatadog%2Fdd-trace-rb%20%40git.branch%3Aanmarchenko%2Fdd_sca_sa%20%40git.commit.sha%3Ae1f1babe0c3221c106960cf60cc853a9dc5eb112%20%40static_analysis.result.category%3Asecurity%20-%40static_analysis.result.item_type%3Asecret&fromUser=false&index=cicodescan&start=1719929424577&end=1720016245719&paused=false
