### PR TITLE
Use minimalistic post-install upgrade message

### DIFF
--- a/ddtrace.gemspec
+++ b/ddtrace.gemspec
@@ -77,12 +77,6 @@ Gem::Specification.new do |spec|
   spec.extensions = ['ext/datadog_profiling_native_extension/extconf.rb', 'ext/datadog_profiling_loader/extconf.rb']
 
   spec.post_install_message = <<-MSG
-    Thank you for installing ddtrace. We have released our next major version!
-
-    As of version 2, `ddtrace` gem has been renamed to `datadog`.
-    The 1.x series will now only receive maintenance updates for security and critical bug fixes.
-
-    To upgrade, please replace gem `ddtrace` with gem `datadog`.
-    For detailed instructions on migration, see: https://dtdg.co/ruby-v2-upgrade
+    The ddtrace gem has been renamed to datadog. We recommend upgrading: https://dtdg.co/ruby-v2-upgrade
   MSG
 end

--- a/ddtrace.gemspec
+++ b/ddtrace.gemspec
@@ -77,6 +77,7 @@ Gem::Specification.new do |spec|
   spec.extensions = ['ext/datadog_profiling_native_extension/extconf.rb', 'ext/datadog_profiling_loader/extconf.rb']
 
   spec.post_install_message = <<-MSG
-    The ddtrace gem has been renamed to datadog. We recommend upgrading: https://dtdg.co/ruby-v2-upgrade
+    The ddtrace gem has been renamed to datadog in version 2. Upgrading is easy: https://dtdg.co/ruby-v2-upgrade
+    ddtrace 1.x will only receive security updates and critical bug fixes.
   MSG
 end


### PR DESCRIPTION
**What does this PR do?**

This PR is a follow-up on #3723.

For the 1.23.3 dd-trace-rb release, we included a quite detailed post-install message to tell customers that the new release was out:

```
Thank you for installing ddtrace. We have released our next major version!

As of version 2, `ddtrace` gem has been renamed to `datadog`.
The 1.x series will now only receive maintenance updates for security and critical bug fixes.

To upgrade, please replace gem `ddtrace` with gem `datadog`.
For detailed instructions on migration, see: https://dtdg.co/ruby-v2-upgrade
```

My thinking is -- some customers may not be able to move to 2.x as quickly as they wanted, and thus seeing that message again and again may start to be slightly annoying.

Thus, this PR replaces with with the minimalistic

```
The ddtrace gem has been renamed to datadog. We recommend upgrading: https://dtdg.co/ruby-v2-upgrade
```

**Motivation:**

Continue suggesting to customers that the should upgrade, while at the same time not being too annoying about it.

**Additional Notes:**

It actually may not a half-bad idea that we released a version with the big message, and then shortened it.

Specifically, customers that mostly keep up-to-date will probably see that message quite quickly, and thus upgrade.

For the long tail of customers that may need to remain on 1.x, the more minimalistic message that will go out in a few weeks/months on a future 1.x maintenance release will continue to remind them.

**How to test the change?**

```bash
$ bundle exec rake build
 # ...

ddtrace 1.23.3 built to pkg/ddtrace-1.23.3.gem.

$ gem install pkg/ddtrace-1.23.3.gem
Building native extensions. This could take a while...
    The ddtrace gem has been renamed to datadog. We recommend upgrading: https://dtdg.co/ruby-v2-upgrade
```