### PR TITLE
[SDTEST-409] Automatically avoid webmock stubs when sending telemetry events

### DIFF
--- a/lib/datadog/core/telemetry/http/adapters/net.rb
+++ b/lib/datadog/core/telemetry/http/adapters/net.rb
@@ -25,7 +25,7 @@ module Datadog
             end
 
             def open(&block)
-              req = ::Net::HTTP.new(@hostname, @port)
+              req = net_http_client.new(@hostname, @port)
 
               req.use_ssl = @ssl
               req.open_timeout = req.read_timeout = @timeout
@@ -102,6 +102,14 @@ module Datadog
               def inspect
                 "#{super}, http_response:#{http_response}"
               end
+            end
+
+            private
+
+            def net_http_client
+              return ::Net::HTTP unless defined?(WebMock::HttpLibAdapters::NetHttpAdapter::OriginalNetHTTP)
+
+              WebMock::HttpLibAdapters::NetHttpAdapter::OriginalNetHTTP
             end
           end
         end

--- a/lib/datadog/core/telemetry/http/adapters/net.rb
+++ b/lib/datadog/core/telemetry/http/adapters/net.rb
@@ -34,19 +34,17 @@ module Datadog
             end
 
             def post(env)
-              begin
-                post = ::Net::HTTP::Post.new(env.path, env.headers)
-                post.body = env.body
+              post = ::Net::HTTP::Post.new(env.path, env.headers)
+              post.body = env.body
 
-                http_response = open do |http|
-                  http.request(post)
-                end
-
-                Response.new(http_response)
-              rescue StandardError => e
-                Datadog.logger.debug("Unable to send telemetry event to agent: #{e}")
-                Telemetry::Http::InternalErrorResponse.new(e)
+              http_response = open do |http|
+                http.request(post)
               end
+
+              Response.new(http_response)
+            rescue StandardError => e
+              Datadog.logger.debug("Unable to send telemetry event to agent: #{e}")
+              Telemetry::Http::InternalErrorResponse.new(e)
             end
 
             # Data structure for an HTTP Response

--- a/sig/datadog/core/telemetry/http/adapters/net.rbs
+++ b/sig/datadog/core/telemetry/http/adapters/net.rbs
@@ -45,6 +45,10 @@ module Datadog
 
               def inspect: () -> ::String
             end
+
+            private
+
+            def net_http_client: () -> singleton(::Net::HTTP)
           end
         end
       end

--- a/spec/datadog/core/telemetry/http/adapters/net_spec.rb
+++ b/spec/datadog/core/telemetry/http/adapters/net_spec.rb
@@ -135,7 +135,7 @@ RSpec.describe Datadog::Core::Telemetry::Http::Adapters::Net do
       end
 
       after do
-        WebMock.disable!
+        WebMock.allow_net_connect!
       end
 
       it 'makes real HTTP request and fails' do

--- a/static-analysis.datadog.yml
+++ b/static-analysis.datadog.yml
@@ -2,4 +2,17 @@ schema-version: v1
 rulesets:
   - ruby-code-style
   - ruby-security
-  - ruby-best-practices
+  - ruby-best-practices:
+    rules:
+      symbols-as-keys:
+        ignore:
+          - "**"
+      hash-fetch:
+        ignore:
+          - "**"
+      percent-w:
+        ignore:
+          - spec/**/*
+      no-optional-hash-params:
+        ignore:
+          - "**"

--- a/vendor/rbs/webmock/0/webmock.rbs
+++ b/vendor/rbs/webmock/0/webmock.rbs
@@ -4,6 +4,8 @@ module WebMock
       def self.enable!: -> void
 
       def self.disable!: -> void
+
+      OriginalNetHTTP: singleton(::Net::HTTP)
     end
   end
 end


### PR DESCRIPTION
**What does this PR do?**
Configures telemetry transport to use the original ::Net::HTTP client even if it is stubbed by WebMock. We do this by using WebMock::HttpLibAdapters::NetHttpAdapter::OriginalNetHTTP in place of Net::HTTP (if OriginalNetHTTP is present).

One can see that WebMock stores the original Net::HTTP in this constant here:
https://github.com/bblimke/webmock/blob/fc6a2ab897a069d861adbc1c88e51b2cf8aa88ac/lib/webmock/http_lib_adapters/net_http.rb#L14

See the PR adding the same functionality to the datadog-ci gem:
https://github.com/DataDog/datadog-ci-rb/pull/193

It was released in version 1.1 of datadog-ci.

**Motivation:**
WebMock is often used when running test suites, but we still need to report library telemetry. 

Currently we recommend in our docs making an exception for Datadog endpoints when using datadog-ci gem but this exception is error-prone and leads to a lot of support version. Since v1.1 of datadog-ci we use this approach to send HTTP requests avoiding webmock stubs automatically, without user intervention. This PR adds the same capabilities to the telemetry transport.

**How to test the change?**
There is a unit with assertion that webmock is not raising even after `WebMock.disable_net_connect!` is called.

`datadog-ci` gem uses exactly the same approach for WebMock handling:
https://github.com/DataDog/datadog-ci-rb/pull/193

Example project where we use test visibility without any custom configuration and webmock is enabled:

https://github.com/DataDog/fast_castle/blob/main/spec/spec_helper.rb#L5

https://github.com/DataDog/fast_castle/pull/6