### PR TITLE
Propagate docs fixes from #3761 to master

### DIFF
--- a/docs/GettingStarted.md
+++ b/docs/GettingStarted.md
@@ -2746,6 +2746,6 @@ See [this issue](https://github.com/DataDog/dd-trace-rb/issues/3015) for a discu
 
 <!---->
 
-[header tags]: https://docs.datadoghq.com/tracing/configure_data_security/#applying-header-tags-to-root-spans
+[header tags]: https://docs.datadoghq.com/tracing/configure_data_security/#collect-headers
 [1]: https://docs.datadoghq.com/tracing/trace_collection/compatibility/ruby/
 [2]: https://docs.datadoghq.com/tracing/trace_collection/compatibility/ruby#integrations

--- a/docs/legacy/GettingStarted-v1.md
+++ b/docs/legacy/GettingStarted-v1.md
@@ -2841,7 +2841,7 @@ See [this issue](https://github.com/DataDog/dd-trace-rb/issues/3015) for a discu
 
 <!---->
 
-[header tags]: https://docs.datadoghq.com/tracing/configure_data_security/#applying-header-tags-to-root-spans
+[header tags]: https://docs.datadoghq.com/tracing/configure_data_security/#collect-headers
 [1]: https://docs.datadoghq.com/tracing/trace_collection/compatibility/ruby/
 [2]: https://docs.datadoghq.com/tracing/trace_collection/compatibility/ruby#integrations
 [3]: https://docs.datadoghq.com/tracing/trace_collection/compatibility/ruby#ci-visibility-integrations


### PR DESCRIPTION
**What does this PR do?**

In https://github.com/DataDog/dd-trace-rb/pull/3761 we fixed a couple of links in our docs. 

That PR was only applied to the release branch, so this PR backports the changes to master.

**Motivation:**

Make sure that docs fixes are not lost when we release the next `datadog` gem version.

**Additional Notes:**

N/A

**How to test the change?**

Look at the docs! :)