### PR TITLE
Switch system-tests to python 3.12

### DIFF
--- a/.github/workflows/system-tests.yml
+++ b/.github/workflows/system-tests.yml
@@ -302,10 +302,10 @@ jobs:
     if: ${{ always() }}
     name: Aggregate (${{ matrix.app }})
     steps:
-      - name: Setup python 3.9
+      - name: Setup python 3.12
         uses: actions/setup-python@v5
         with:
-          python-version: '3.9'
+          python-version: '3.12'
       - name: Checkout
         uses: actions/checkout@v4
         with:


### PR DESCRIPTION
<!--
Check out the
https://github.com/DataDog/dd-trace-rb/blob/master/docs/DevelopmentGuide.md
for guidance on how to set up your development environment,
run the test suite, write new integrations, and more.
-->

**What does this PR do?**
Switch system-tests to python 3.12

**Motivation:**
System-tests won't support python 3.9 by end of month.

**Additional Notes:**
<!-- Anything else we should know when reviewing? -->

**How to test the change?**
<!--
Describe here how the change can be validated.
You are strongly encouraged to provide automated tests for this PR (unit or integration).
If this change cannot be feasibly tested, please explain why,
unless the change does not modify code (e.g. only modifies docs, comments).
-->

Unsure? Have a question? Request a review!
