### PR TITLE
Fix leaky db test

### DIFF
--- a/spec/datadog/tracing/contrib/active_record/instantiation_spec.rb
+++ b/spec/datadog/tracing/contrib/active_record/instantiation_spec.rb
@@ -34,6 +34,10 @@ RSpec.describe 'ActiveRecord instantiation instrumentation' do
     Datadog.registry[:active_record].reset_configuration!
   end
 
+  after do
+    Article.delete_all
+  end
+
   context 'when a model is instantiated' do
     before { article }
 


### PR DESCRIPTION
**What does this PR do?**

Fix leaky db tests

```
Failures:

  1) Rails database on record creation with instantiation support is expected to eq 1
     Failure/Error: expect(span.get_tag('active_record.instantiation.record_count')).to eq(1)
     
       expected: 1
            got: 34.0
     
       (compared using ==)
     # ./spec/datadog/tracing/contrib/rails/database_spec.rb:89:in `block in <main>'
     # ./spec/datadog/tracing/contrib/rails/support/log_configuration.rb:6:in `block in <main>'
     # ./spec/datadog/tracing/contrib/support/tracer_helpers.rb:96:in `block in TracerHelpers'
     # ./spec/spec_helper.rb:230:in `block in <main>'
     # ./spec/spec_helper.rb:115:in `block in <main>'
     # /usr/local/bundle/gems/webmock-3.23.1/lib/webmock/rspec.rb:39:in `block in <main>'
     # /usr/local/bundle/gems/rspec-wait-0.0.10/lib/rspec/wait.rb:47:in `block in <main>'

Finished in 3 minutes 9.6 seconds (files took 6.69 seconds to load)
269 examples, 1 failure, 8 pending

Failed examples:

rspec ./spec/datadog/tracing/contrib/rails/database_spec.rb:79 # Rails database on record creation with instantiation support is expected to eq 1
```
**How to reproduce**

In Jruby 9.4 environment

```bash
echo "--seed 43133" >> .rspec
bundle exec appraisal jruby-9.4-relational_db rake spec:active_record
bundle exec appraisal jruby-9.4-rails61-mysql2 rake spec:rails
```
After the spec task for active record, the db is polluted with records 

```ruby
=>
[#<Article:0x48306567 id: 1, title: "test", created_at: 2024-07-08 12:02:35 UTC, updated_at: 2024-07-08 12:02:35 UTC>,
 #<Article:0x3a4181ba id: 2, title: "test", created_at: 2024-07-08 12:02:35 UTC, updated_at: 2024-07-08 12:02:35 UTC>,
 #<Article:0x41185195 id: 3, title: "test", created_at: 2024-07-08 12:02:35 UTC, updated_at: 2024-07-08 12:02:35 UTC>,
 #<Article:0x1d5e0621 id: 4, title: "test", created_at: 2024-07-08 12:02:35 UTC, updated_at: 2024-07-08 12:02:35 UTC>,
 #<Article:0x4823f3b8 id: 5, title: "test", created_at: 2024-07-08 12:02:35 UTC, updated_at: 2024-07-08 12:02:35 UTC>,
 #<Article:0x53425450 id: 6, title: "test", created_at: 2024-07-08 12:02:36 UTC, updated_at: 2024-07-08 12:02:36 UTC>,
 #<Article:0x1aa21319 id: 7, title: "test", created_at: 2024-07-08 12:02:36 UTC, updated_at: 2024-07-08 12:02:36 UTC>,
 #<Article:0x4149067d id: 8, title: "test", created_at: 2024-07-08 12:02:36 UTC, updated_at: 2024-07-08 12:02:36 UTC>,
 #<Article:0x48860fb8 id: 9, title: "test", created_at: 2024-07-08 12:02:36 UTC, updated_at: 2024-07-08 12:02:36 UTC>,
```
