### PR TITLE
[PROF-10125] Track unscaled allocation counts in allocation profiler

### DIFF
--- a/ext/datadog_profiling_native_extension/collectors_stack.c
+++ b/ext/datadog_profiling_native_extension/collectors_stack.c
@@ -70,6 +70,7 @@ static VALUE _native_sample(
     .cpu_or_wall_samples = NUM2UINT(rb_hash_lookup2(metric_values_hash, rb_str_new_cstr("cpu-samples"), zero)),
     .wall_time_ns  = NUM2UINT(rb_hash_lookup2(metric_values_hash, rb_str_new_cstr("wall-time"),     zero)),
     .alloc_samples = NUM2UINT(rb_hash_lookup2(metric_values_hash, rb_str_new_cstr("alloc-samples"), zero)),
+    .alloc_samples_unscaled = NUM2UINT(rb_hash_lookup2(metric_values_hash, rb_str_new_cstr("alloc-samples-unscaled"), zero)),
     .timeline_wall_time_ns = NUM2UINT(rb_hash_lookup2(metric_values_hash, rb_str_new_cstr("timeline"), zero)),
   };
 

--- a/ext/datadog_profiling_native_extension/collectors_thread_context.c
+++ b/ext/datadog_profiling_native_extension/collectors_thread_context.c
@@ -1292,7 +1292,7 @@ void thread_context_collector_sample_allocation(VALUE self_instance, unsigned in
     /* thread: */  current_thread,
     /* stack_from_thread: */ current_thread,
     get_or_create_context_for(current_thread, state),
-    (sample_values) {.alloc_samples = sample_weight},
+    (sample_values) {.alloc_samples = sample_weight, .alloc_samples_unscaled = 1},
     INVALID_TIME, // For now we're not collecting timestamps for allocation events, as per profiling team internal discussions
     &ruby_vm_type,
     optional_class_name

--- a/ext/datadog_profiling_native_extension/stack_recorder.h
+++ b/ext/datadog_profiling_native_extension/stack_recorder.h
@@ -8,6 +8,7 @@ typedef struct {
   int64_t wall_time_ns;
   uint32_t cpu_or_wall_samples;
   uint32_t alloc_samples;
+  uint32_t alloc_samples_unscaled;
   int64_t timeline_wall_time_ns;
 } sample_values;
 

--- a/spec/datadog/profiling/collectors/thread_context_spec.rb
+++ b/spec/datadog/profiling/collectors/thread_context_spec.rb
@@ -1048,6 +1048,12 @@ RSpec.describe Datadog::Profiling::Collectors::ThreadContext do
       expect(single_sample.values).to include(:'alloc-samples' => 123)
     end
 
+    it 'tags the sample with the unscaled weight' do
+      sample_allocation(weight: 123)
+
+      expect(single_sample.values).to include('alloc-samples-unscaled': 1)
+    end
+
     it 'includes the thread names, if available' do
       thread_with_name = Thread.new do
         Thread.current.name = 'thread_with_name'


### PR DESCRIPTION
**What does this PR do?**

This PR extends the allocation profiler to also track the unscaled allocation counts.

Specifically, like other profile types, the allocation profiler assigns a weight to every sample, making it "represent" all the objects that weren't sampled.

**Motivation:**

For debugging, in corner cases, it comes in handy to know exactly how many samples the profiler observed, and what was the impact of scaling.

As part of preparing the allocation profiler feature for GA, I'm adding this feature so we can use it to confirm the exact sample counts whenever needed.

Note also this is something we do for the cpu/wall-time profiler, where we track the `cpu_or_wall_samples` as an exact count of how many samples were taken (and again, without the weight -- which in the case of those profilers, represents time).

**Additional Notes:**

N/A

**How to test the change?**

This change includes test coverage.
