### PR TITLE
Use ActiveSupport events to instrument ActiveSupport::Cache

### DIFF
--- a/lib/datadog/tracing/contrib/active_support/cache/event.rb
+++ b/lib/datadog/tracing/contrib/active_support/cache/event.rb
@@ -1,0 +1,32 @@
+# frozen_string_literal: true
+
+require_relative '../notifications/event'
+
+module Datadog
+  module Tracing
+    module Contrib
+      module ActiveSupport
+        module Cache
+          # Defines basic behaviors for an ActiveSupport event.
+          module Event
+            def self.included(base)
+              base.include(ActiveSupport::Notifications::Event)
+              base.extend(ClassMethods)
+            end
+
+            # Class methods for ActiveRecord events.
+            module ClassMethods
+              def span_options
+                {}
+              end
+
+              def configuration
+                Datadog.configuration.tracing[:active_support]
+              end
+            end
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/datadog/tracing/contrib/active_support/cache/events.rb
+++ b/lib/datadog/tracing/contrib/active_support/cache/events.rb
@@ -1,0 +1,34 @@
+# frozen_string_literal: true
+
+require_relative 'events/cache'
+
+module Datadog
+  module Tracing
+    module Contrib
+      module ActiveSupport
+        module Cache
+          # Defines collection of instrumented ActiveSupport events
+          module Events
+            ALL = [
+              Events::Cache,
+            ].freeze
+
+            module_function
+
+            def all
+              self::ALL
+            end
+
+            def subscriptions
+              all.collect(&:subscriptions).collect(&:to_a).flatten
+            end
+
+            def subscribe!
+              all.each(&:subscribe!)
+            end
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/datadog/tracing/contrib/active_support/cache/events/cache.rb
+++ b/lib/datadog/tracing/contrib/active_support/cache/events/cache.rb
@@ -1,0 +1,156 @@
+# frozen_string_literal: true
+
+require_relative '../../ext'
+require_relative '../event'
+
+module Datadog
+  module Tracing
+    module Contrib
+      module ActiveSupport
+        module Cache
+          module Events
+            # Defines instrumentation for instantiation.active_record event
+            module Cache
+              include ActiveSupport::Cache::Event
+
+              module_function
+
+              # Acts as this module's initializer.
+              def subscribe!
+                @cache_backend = {}
+                super
+              end
+
+              def event_name
+                /\Acache_(?:delete|read|read_multi|write|write_multi)\.active_support\z/
+              end
+
+              def span_name
+                Ext::SPAN_CACHE
+              end
+
+              def span_options
+                {
+                  type: Ext::SPAN_TYPE_CACHE
+                }
+              end
+
+              # DEV: Look for other uses of `ActiveSupport::Cache::Store#instrument`, to find other useful event keys.
+              MAPPING = {
+                'cache_delete.active_support' => { resource: Ext::RESOURCE_CACHE_DELETE },
+                'cache_read.active_support' => { resource: Ext::RESOURCE_CACHE_GET },
+                'cache_read_multi.active_support' => { resource: Ext::RESOURCE_CACHE_MGET, multi_key: true },
+                'cache_write.active_support' => { resource: Ext::RESOURCE_CACHE_SET },
+                'cache_write_multi.active_support' => { resource: Ext::RESOURCE_CACHE_MSET, multi_key: true }
+              }.freeze
+
+              def trace?(event, _payload)
+                return false if !Tracing.enabled? || !configuration.enabled
+
+                # DEV-3.0: Backwards compatibility code for the 2.x gem series.
+                # DEV-3.0: See documentation at {Datadog::Tracing::Contrib::ActiveSupport::Cache::Instrumentation}
+                # DEV-3.0: for the complete information about this backwards compatibility code.
+                case event
+                when 'cache_read.active_support'
+                  !ActiveSupport::Cache::Instrumentation.nested_read?
+                when 'cache_read_multi.active_support'
+                  !ActiveSupport::Cache::Instrumentation.nested_multiread?
+                else
+                  true
+                end
+              end
+
+              def on_start(span, event, _id, payload)
+                key = payload[:key]
+                store = payload[:store]
+
+                mapping = MAPPING[event]
+
+                span.service = configuration[:cache_service]
+                span.resource = mapping[:resource]
+
+                span.set_tag(Tracing::Metadata::Ext::TAG_COMPONENT, Ext::TAG_COMPONENT)
+                span.set_tag(Tracing::Metadata::Ext::TAG_OPERATION, Ext::TAG_OPERATION_CACHE)
+
+                if span.service != Datadog.configuration.service
+                  span.set_tag(Tracing::Contrib::Ext::Metadata::TAG_BASE_SERVICE, Datadog.configuration.service)
+                end
+
+                span.set_tag(Ext::TAG_CACHE_BACKEND, cache_backend(store))
+
+                span.set_tag('EVENT', event)
+
+                set_cache_key(span, key, mapping[:multi_key])
+              end
+
+              def set_cache_key(span, key, multi_key)
+                if multi_key
+                  keys = key.is_a?(Hash) ? key.keys : key # `write`s use Hashes, while `read`s use Arrays
+                  resolved_key = keys.map { |k| ::ActiveSupport::Cache.expand_cache_key(k) }
+                  cache_key = Core::Utils.truncate(resolved_key, Ext::QUANTIZE_CACHE_MAX_KEY_SIZE)
+                  span.set_tag(Ext::TAG_CACHE_KEY_MULTI, cache_key)
+                else
+                  resolved_key = ::ActiveSupport::Cache.expand_cache_key(key)
+                  cache_key = Core::Utils.truncate(resolved_key, Ext::QUANTIZE_CACHE_MAX_KEY_SIZE)
+                  span.set_tag(Ext::TAG_CACHE_KEY, cache_key)
+                end
+              end
+
+              # The name of the `store` is never saved by Rails.
+              # ActiveSupport looks up stores by converting a symbol into a 'require' path,
+              # then "camelizing" it for a `const_get` call:
+              # ```
+              # require "active_support/cache/#{store}"
+              # ActiveSupport::Cache.const_get(store.to_s.camelize)
+              # ```
+              # @see https://github.com/rails/rails/blob/261975dbef77731d2c76f907f1076c5132ebc0e4/activesupport/lib/active_support/cache.rb#L139-L149
+              #
+              # We can reverse engineer
+              # the original symbol by converting the class name to snake case:
+              # e.g. ActiveSupport::Cache::RedisStore -> active_support/cache/redis_store
+              # In this case, `redis_store` is the store name.
+              #
+              # Because there's no API retrieve only the class name
+              # (only `RedisStore`, and not `ActiveSupport::Cache::RedisStore`)
+              # the easiest way to retrieve the store symbol is to convert the fully qualified
+              # name using the Rails-provided method `#underscore`, which is the reverse of `#camelize`,
+              # then extracting the last part of it.
+              #
+              # Also, this method caches the store name, given this value will be retrieve
+              # multiple times and involves string manipulation.
+              def cache_backend(store)
+                # Cache the backend name to avoid the expensive string manipulation required to calculate it.
+                # DEV: We can't store it directly in the `store` object because it is a frozen String.
+                if (name = @cache_backend[store])
+                  return name
+                end
+
+                # DEV: #underscore is available through ActiveSupport, and is
+                # DEV: the exact reverse operation to `#camelize`.
+                # DEV: #demodulize is available through ActiveSupport, and is
+                # DEV: used to remove the module ('*::') part of a constant name.
+                name = ::ActiveSupport::Inflector.demodulize(store)
+                name = ::ActiveSupport::Inflector.underscore(name)
+
+                # Despite a given application only ever having 1-3 store types,
+                # we limit the size of the `@cache_backend` just in case, because
+                # the user can create custom Cache store classes themselves.
+                @cache_backend[store] = name if @cache_backend.size < 50
+
+                name
+              end
+
+              # DEV: There are two possibly interesting fields in the `on_finish` payload:
+              # | `:hit`             | If this read is a hit   |
+              # | `:super_operation` | `:fetch` if a read is done with [`fetch`][ActiveSupport::Cache::Store#fetch] |
+              # @see https://github.com/rails/rails/blob/b9d6759401c3d50a51e0a7650cb2331f4218d11f/guides/source/active_support_instrumentation.md?plain=1#L528-L529
+              # def on_finish(span, event, id, payload)
+              #   super
+              # end
+            end
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/datadog/tracing/contrib/active_support/cache/redis.rb
+++ b/lib/datadog/tracing/contrib/active_support/cache/redis.rb
@@ -30,7 +30,10 @@ module Datadog
 
               def cache_store_class(meth)
                 if patch_redis?(meth)
-                  ::ActiveSupport::Cache::RedisStore
+                  [::ActiveSupport::Cache::RedisStore, ::ActiveSupport::Cache::Store]
+                elsif Gem.loaded_specs['redis'] && defined?(::ActiveSupport::Cache::RedisCacheStore) \
+                    && ::ActiveSupport::Cache::RedisCacheStore.instance_methods(false).include?(meth)
+                  [::ActiveSupport::Cache::RedisCacheStore, ::ActiveSupport::Cache::Store]
                 else
                   super
                 end

--- a/lib/datadog/tracing/contrib/active_support/notifications/event.rb
+++ b/lib/datadog/tracing/contrib/active_support/notifications/event.rb
@@ -26,12 +26,13 @@ module Datadog
                 super
               end
 
-              def subscription(span_name = nil, span_options = nil, on_start: nil, on_finish: nil)
+              def subscription(span_name = nil, span_options = nil, on_start: nil, on_finish: nil, trace: nil)
                 super(
                   span_name || self.span_name,
                   span_options || self.span_options,
                   on_start: on_start,
-                  on_finish: on_finish
+                  on_finish: on_finish,
+                  trace: trace
                 )
               end
 
@@ -42,7 +43,8 @@ module Datadog
                     span_name || self.span_name,
                     span_options || self.span_options,
                     on_start: method(:on_start),
-                    on_finish: method(:on_finish)
+                    on_finish: method(:on_finish),
+                    trace: method(:trace?)
                   )
                 end
               end
@@ -69,6 +71,10 @@ module Datadog
 
               def on_finish(span, _event, _id, payload)
                 record_exception(span, payload)
+              end
+
+              def trace?(_event, _payload)
+                true
               end
 
               def record_exception(span, payload)

--- a/lib/datadog/tracing/contrib/active_support/notifications/subscriber.rb
+++ b/lib/datadog/tracing/contrib/active_support/notifications/subscriber.rb
@@ -45,16 +45,28 @@ module Datadog
               end
 
               # Creates a subscription and immediately activates it.
-              def subscribe(pattern, span_name, span_options = {}, on_start: nil, on_finish: nil)
-                subscription(span_name, span_options, on_start: on_start, on_finish: on_finish).tap do |subscription|
+              def subscribe(pattern, span_name, span_options = {}, on_start: nil, on_finish: nil, trace: nil)
+                subscription(
+                  span_name,
+                  span_options,
+                  on_start: on_start,
+                  on_finish: on_finish,
+                  trace: trace
+                ).tap do |subscription|
                   subscription.subscribe(pattern)
                 end
               end
 
               # Creates a subscription without activating it.
               # Subscription is added to the inheriting class' list of subscriptions.
-              def subscription(span_name, span_options = {}, on_start: nil, on_finish: nil)
-                Subscription.new(span_name, span_options, on_start: on_start, on_finish: on_finish).tap do |subscription|
+              def subscription(span_name, span_options = {}, on_start: nil, on_finish: nil, trace: nil)
+                Subscription.new(
+                  span_name,
+                  span_options,
+                  on_start: on_start,
+                  on_finish: on_finish,
+                  trace: trace
+                ).tap do |subscription|
                   subscriptions << subscription
                 end
               end

--- a/sig/datadog/tracing/contrib/active_support/cache/event.rbs
+++ b/sig/datadog/tracing/contrib/active_support/cache/event.rbs
@@ -1,0 +1,18 @@
+module Datadog
+  module Tracing
+    module Contrib
+      module ActiveSupport
+        module Cache
+          module Event
+            def self.included: (untyped base) -> untyped
+            module ClassMethods
+              def span_options: () -> ::Hash[untyped, untyped]
+
+              def configuration: () -> untyped
+            end
+          end
+        end
+      end
+    end
+  end
+end

--- a/sig/datadog/tracing/contrib/active_support/cache/events.rbs
+++ b/sig/datadog/tracing/contrib/active_support/cache/events.rbs
@@ -1,0 +1,19 @@
+module Datadog
+  module Tracing
+    module Contrib
+      module ActiveSupport
+        module Cache
+          module Events
+            ALL: ::Array[untyped]
+
+            def self?.all: () -> untyped
+
+            def self?.subscriptions: () -> untyped
+
+            def self?.subscribe!: () -> untyped
+          end
+        end
+      end
+    end
+  end
+end

--- a/sig/datadog/tracing/contrib/active_support/cache/events/cache.rbs
+++ b/sig/datadog/tracing/contrib/active_support/cache/events/cache.rbs
@@ -1,0 +1,32 @@
+module Datadog
+  module Tracing
+    module Contrib
+      module ActiveSupport
+        module Cache
+          module Events
+            module Cache
+              @cache_backend: untyped
+
+              include ActiveSupport::Cache::Event
+              def self?.subscribe!: () -> untyped
+
+              def self?.event_name: () -> ::Regexp
+
+              def self?.span_name: () -> untyped
+
+              def self?.span_options: () -> { type: untyped }
+              MAPPING: ::Hash[::String, { resource: untyped } | { resource: untyped, multi_key: true }]
+
+              def self?.trace?: (untyped event, untyped _payload) -> (false | untyped)
+
+              def self?.on_start: (untyped span, untyped event, untyped _id, untyped payload) -> untyped
+
+              def self?.set_cache_key: (untyped span, untyped key, untyped multi_key) -> untyped
+              def self?.cache_backend: (untyped store) -> untyped
+            end
+          end
+        end
+      end
+    end
+  end
+end

--- a/sig/datadog/tracing/contrib/active_support/cache/instrumentation.rbs
+++ b/sig/datadog/tracing/contrib/active_support/cache/instrumentation.rbs
@@ -26,9 +26,6 @@ module Datadog
             module Write
               def write: (*untyped args) ?{ () -> untyped } -> untyped
             end
-            module WriteMulti
-              def write_multi: (untyped hash, ?untyped? options) -> untyped
-            end
             module Delete
               def delete: (*untyped args) ?{ () -> untyped } -> untyped
             end

--- a/spec/datadog/tracing/contrib/active_support/notifications/event_spec.rb
+++ b/spec/datadog/tracing/contrib/active_support/notifications/event_spec.rb
@@ -26,7 +26,8 @@ RSpec.describe Datadog::Tracing::Contrib::ActiveSupport::Notifications::Event do
     let(:callbacks) do
       {
         on_start: test_class.method(:on_start),
-        on_finish: test_class.method(:on_finish)
+        on_finish: test_class.method(:on_finish),
+        trace: test_class.method(:trace?)
       }
     end
 
@@ -99,16 +100,19 @@ RSpec.describe Datadog::Tracing::Contrib::ActiveSupport::Notifications::Event do
           end
 
           context 'when given options' do
-            subject(:subscription) { test_class.subscription(span_name, options, on_start: on_start, on_finish: on_finish) }
+            subject(:subscription) do
+              test_class.subscription(span_name, options, on_start: on_start, on_finish: on_finish, trace: trace)
+            end
 
             let(:span_name) { double('span name') }
             let(:options) { double('options') }
             let(:on_start) { double('on_start') }
             let(:on_finish) { double('on_finish') }
+            let(:trace) { double('trace') }
 
             before do
               expect(Datadog::Tracing::Contrib::ActiveSupport::Notifications::Subscription).to receive(:new)
-                .with(span_name, options, on_start: on_start, on_finish: on_finish)
+                .with(span_name, options, on_start: on_start, on_finish: on_finish, trace: trace)
                 .and_call_original
             end
 

--- a/spec/datadog/tracing/contrib/active_support/notifications/subscriber_spec.rb
+++ b/spec/datadog/tracing/contrib/active_support/notifications/subscriber_spec.rb
@@ -15,6 +15,7 @@ RSpec.describe Datadog::Tracing::Contrib::ActiveSupport::Notifications::Subscrib
       describe 'behavior' do
         let(:on_start) { double('on start') }
         let(:on_finish) { double('on finish') }
+        let(:trace) { double('trace') }
 
         describe '#subscriptions' do
           subject(:subscriptions) { test_class.subscriptions }
@@ -92,7 +93,15 @@ RSpec.describe Datadog::Tracing::Contrib::ActiveSupport::Notifications::Subscrib
 
           describe '#subscribe' do
             subject(:subscription) do
-              test_class.send(:subscribe, pattern, span_name, options, on_start: on_start, on_finish: on_finish)
+              test_class.send(
+                :subscribe,
+                pattern,
+                span_name,
+                options,
+                on_start: on_start,
+                on_finish: on_finish,
+                trace: trace
+              )
             end
 
             let(:pattern) { double('pattern') }
@@ -101,7 +110,7 @@ RSpec.describe Datadog::Tracing::Contrib::ActiveSupport::Notifications::Subscrib
 
             before do
               expect(Datadog::Tracing::Contrib::ActiveSupport::Notifications::Subscription).to receive(:new)
-                .with(span_name, options, on_start: on_start, on_finish: on_finish)
+                .with(span_name, options, on_start: on_start, on_finish: on_finish, trace: trace)
                 .and_call_original
 
               expect_any_instance_of(Datadog::Tracing::Contrib::ActiveSupport::Notifications::Subscription)
@@ -115,7 +124,7 @@ RSpec.describe Datadog::Tracing::Contrib::ActiveSupport::Notifications::Subscrib
 
           describe '#subscription' do
             subject(:subscription) do
-              test_class.send(:subscription, span_name, options, on_start: on_start, on_finish: on_finish)
+              test_class.send(:subscription, span_name, options, on_start: on_start, on_finish: on_finish, trace: trace)
             end
 
             let(:span_name) { double('span name') }
@@ -123,7 +132,7 @@ RSpec.describe Datadog::Tracing::Contrib::ActiveSupport::Notifications::Subscrib
 
             before do
               expect(Datadog::Tracing::Contrib::ActiveSupport::Notifications::Subscription).to receive(:new)
-                .with(span_name, options, on_start: on_start, on_finish: on_finish)
+                .with(span_name, options, on_start: on_start, on_finish: on_finish, trace: trace)
                 .and_call_original
             end
 

--- a/spec/datadog/tracing/contrib/rails/cache_spec.rb
+++ b/spec/datadog/tracing/contrib/rails/cache_spec.rb
@@ -172,7 +172,9 @@ RSpec.describe 'Rails cache' do
     end
 
     context 'with custom cache_service' do
-      before { Datadog.configuration.tracing[:active_support][:cache_service] = 'service-cache' }
+      before do
+        Datadog.configuration.tracing[:active_support][:cache_service] = 'service-cache'
+      end
 
       it 'uses the proper service name' do
         write
@@ -242,14 +244,12 @@ RSpec.describe 'Rails cache' do
 
     context 'when the method is not defined' do
       before do
-        if ::ActiveSupport::Cache::Store.public_method_defined?(:write_multi)
-          skip 'Test is not applicable to this Rails version'
-        end
+        skip 'Test is not applicable to this Rails version' if ::ActiveSupport::Cache::Store.public_method_defined?(:fetch)
       end
 
       it do
         expect(::ActiveSupport::Cache::Store.ancestors).not_to(
-          include(::Datadog::Tracing::Contrib::ActiveSupport::Cache::Instrumentation::WriteMulti)
+          include(::Datadog::Tracing::Contrib::ActiveSupport::Cache::Instrumentation::Fetch)
         )
       end
 


### PR DESCRIPTION
Fixes #3607, fixes #3549, fixes #858

For tracing `ActiveSupport::Cache`, this PR moves away from monkey-patching to subscribing to `ActiveSupport::Notifications` events [emitted by ActiveSupport Caching](https://guides.rubyonrails.org/v7.1/active_support_instrumentation.html#active-support-%E2%80%94-caching).

We are still required to keep some monkey-patching to ensure backwards compatibility, and to support a few specific methods in old versions of Rails.

**Motivation:**

This improves the maintainability of the instrumentation, given the events we subscribe to are Rails' public APIs.
It is also more consistent across different caching backends (e.g. Redis, Memcached), allowing us to simplify our implementation.

**How to test the change?**
All changes are covered in the test suite.
