### PR TITLE
Add Ruby LSP support for VSCode (and possibly others)

### DIFF
--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -1,0 +1,8 @@
+{
+    "recommendations": [
+        "shopify.ruby-lsp",
+        "editorconfig.editorconfig",
+        "soutaro.rbs-syntax",
+        "soutaro.steep-vscode"
+    ]
+}

--- a/Appraisals
+++ b/Appraisals
@@ -17,6 +17,9 @@ REMOVED_GEMS = {
     'rbs',
     'steep',
   ],
+  :dev => [
+    'ruby-lsp',
+  ],
 }
 
 def appraise(group, &block)

--- a/Gemfile
+++ b/Gemfile
@@ -84,6 +84,10 @@ group :check do
   end
 end
 
+group :dev do
+  gem 'ruby-lsp', require: false if RUBY_VERSION >= '3.0.0' && RUBY_PLATFORM != 'java'
+end
+
 # `1.17.0` provides broken RBS type definitions
 # https://github.com/ffi/ffi/blob/master/CHANGELOG.md#1170rc1--2024-04-08
 #


### PR DESCRIPTION
<!--
Check out the
https://github.com/DataDog/dd-trace-rb/blob/master/docs/DevelopmentGuide.md
for guidance on how to set up your development environment,
run the test suite, write new integrations, and more.
-->

**What does this PR do?**

- Add a `:dev` `Gemfile` group for development-oriented gems.
- Add the `ruby-lsp` gem to that group.
- Remove the gem/group for appraisals.
- Suggest the Ruby LSP VSCode extension for this workspace.

**Motivation:**

This gem is used by the VSCode `Ruby LSP` extension from Shopify, and possibly other IDEs as well. Having it in the `Gemfile` for development provides a good out-of-the-box experience.

**Additional Notes:**

A few other extensions are recommended as well:

- EditorConfig: since we use that
- Steep and RBS: the official extensions

The suggestion should only pop up once and the user is free to install or dismiss.

**How to test the change?**

Using VS Code with the Ruby LSP extension should provide an immediate OOTB experience that uses the LSP.

If not installed already, the extension should be suggested by VSCode as a recommendation, which is also free to be dismissed.
