### PR TITLE
Fix RSpec #log_deprecation matcher error when #log_deprecation uses :key

### DIFF
--- a/spec/support/core_helpers.rb
+++ b/spec/support/core_helpers.rb
@@ -15,7 +15,7 @@ module CoreHelpers
   #   expect { subject }.to_not log_deprecation(include('no_longer_deprecated_option'))
   RSpec::Matchers.define :log_deprecation do |message_matcher|
     match(notify_expectation_failures: true) do |block|
-      expect(::Datadog::Core).to receive(:log_deprecation).with(no_args) do |&message_block|
+      expect(::Datadog::Core).to receive(:log_deprecation).with(any_args) do |&message_block|
         expect(message_block.call).to match(message_matcher) if message_matcher
       end
 
@@ -26,7 +26,7 @@ module CoreHelpers
 
     match_when_negated(notify_expectation_failures: true) do |block|
       if message_matcher
-        allow(::Datadog::Core).to receive(:log_deprecation).with(no_args) do |&message_block|
+        allow(::Datadog::Core).to receive(:log_deprecation).with(any_args) do |&message_block|
           expect(message_block.call).to_not match(message_matcher)
         end
       else


### PR DESCRIPTION
**What does this PR do?**

#3675 added a limit feature to `log_deprecation`. However, leveraging this feature (by passing `key:` as an arg) will cause the use of the `log_deprecation` RSpec matcher to fail, because it explicitly expects `no_args`. This bug has no effect on production, only our test suite.

This feature loosens this constraint, allowing use of `key` args with `log_deprecation` and corresponding RSpec matcher.

**Additional Notes:**

This will also need to be backported to 1.x.

It would also be nice to augment the `log_deprecation` matcher to more explicitly handle the presence of a `key` arg in a way that tests the limitation set in place, aka `expect { set_service_name }.to log_deprecation(include('service name')).with_limit(key: :deprecation_conf_service_name)`. However, this may not be an insignificant effort, and is out of scope for my efforts right now.