### PR TITLE
Remove old ddtrace require from tracing benchmarks

### DIFF
--- a/benchmarks/tracing_trace.rb
+++ b/benchmarks/tracing_trace.rb
@@ -5,13 +5,7 @@ return unless __FILE__ == $PROGRAM_NAME || VALIDATE_BENCHMARK_MODE
 
 require 'benchmark/ips'
 require 'open3'
-
-begin
-  require 'datadog'
-rescue LoadError # TODO: Remove when ddtrace 2.0 is merged to master
-  # This is required to run benchmarks against ddtrace 1.x.
-  require 'ddtrace'
-end
+require 'datadog'
 
 class TracingTraceBenchmark
   module NoopWriter


### PR DESCRIPTION
The library has been renamed to datadog,
this appears to be the last location where ddtrace is required in the test suite.

<!--
Check out the
https://github.com/DataDog/dd-trace-rb/blob/master/docs/DevelopmentGuide.md
for guidance on how to set up your development environment,
run the test suite, write new integrations, and more.
-->

**What does this PR do?**
<!-- A brief description of the change being made with this pull request. -->
Removes fallback `ddtrace` require.

**Motivation:**
<!-- What inspired you to submit this pull request? -->
Code inspection

**Additional Notes:**
<!-- Anything else we should know when reviewing? -->
None

**How to test the change?**
<!--
Describe here how the change can be validated.
You are strongly encouraged to provide automated tests for this PR (unit or integration).
If this change cannot be feasibly tested, please explain why,
unless the change does not modify code (e.g. only modifies docs, comments).
-->
Change is in the test suite