### PR TITLE
[NO-TICKET] Move tracing integrations logging under a debug log

### DIFF
--- a/lib/datadog/core/diagnostics/environment_logger.rb
+++ b/lib/datadog/core/diagnostics/environment_logger.rb
@@ -13,6 +13,10 @@ module Datadog
           logger.info("DATADOG CONFIGURATION - #{prefix} - #{data}")
         end
 
+        def log_debug!(prefix, data)
+          logger.debug("DATADOG CONFIGURATION - #{prefix} - #{data}")
+        end
+
         def log_error!(prefix, type, error)
           logger.warn("DATADOG ERROR - #{prefix} - #{type}: #{error}")
         end


### PR DESCRIPTION
**What does this PR do?**

This PR reduces the amount of logging emitted by default by the tracing environment logger.

It does this by breaking what was previously a single log message -- containing tracing settings and a list of all the loaded intergration settings -- into two:
* One info-level message with tracing settings + list of loaded integrations
* One debug-level message with only the integrations settings

I've also gone ahead and did two small tweaks:
* Omitted the prefix `integration_` from every integration setting, since the whole message is now prefixed with "TRACING INTEGRATIONS" anyway
* Did a few optimizations around the code to gather settings to avoid allocating so many intermediate objects

**Motivation:**

The main objective of this change is to reduce the logging that gets emitted by default.

Here's how it looked before when running
`bundle exec ruby -e 'require "datadog/auto_instrument"; Datadog::Tracing.trace("foo") { }'`:

> I, [2024-07-16T15:51:50.628033 #326057]  INFO -- datadog: [datadog] DATADOG CONFIGURATION - TRACING - {"enabled":true,"agent_url":"http://127.0.0.1:8126?timeout=30","analytics_enabled":false,"sample_rate":null,"sampling_rules":null,"integrations_loaded":"action_cable@,action_mailer@,http@3.1.4,action_pack@,action_view@,active_model_serializers@,active_job@,active_record@,active_support@,aws@,concurrent_ruby@,dalli@,delayed_job@,elasticsearch@,ethon@,excon@,faraday@,grape@,graphql@,grpc@,hanami@,httpclient@,httprb@,kafka@,mongo@,mysql2@,opensearch@,pg@,presto@,que@,racecar@,rack@,rails@,rake@,redis@,resque@,rest_client@,roda@,sequel@,shoryuken@,sidekiq@,sinatra@,sneakers@,stripe@,sucker_punch@,trilogy@","partial_flushing_enabled":false,"integration_action_cable_analytics_enabled":"false","integration_action_cable_analytics_sample_rate":"1.0","integration_action_cable_enabled":"true","integration_action_cable_service_name":"","integration_action_mailer_analytics_enabled":"false","integration_action_mailer_analytics_sample_rate":"1.0","integration_action_mailer_enabled":"true","integration_action_mailer_service_name":"","integration_action_mailer_email_data":"false","integration_http_analytics_enabled":"false","integration_http_analytics_sample_rate":"1.0","integration_http_enabled":"true","integration_http_service_name":"net/http","integration_http_distributed_tracing":"true","integration_http_error_status_codes":"#<Datadog::Tracing::Contrib::StatusRangeMatcher:0x00007c42660405b8>","integration_http_peer_service":"","integration_http_split_by_domain":"false","integration_action_pack_analytics_enabled":"","integration_action_pack_analytics_sample_rate":"1.0","integration_action_pack_enabled":"true","integration_action_pack_service_name":"","integration_action_view_analytics_enabled":"false","integration_action_view_analytics_sample_rate":"1.0","integration_action_view_enabled":"true","integration_action_view_service_name":"","integration_action_view_template_base_path":"views/","integration_active_model_serializers_analytics_enabled":"false","integration_active_model_serializers_analytics_sample_rate":"1.0","integration_active_model_serializers_enabled":"true","integration_active_model_serializers_service_name":"","integration_active_job_analytics_enabled":"false","integration_active_job_analytics_sample_rate":"1.0","integration_active_job_enabled":"true","integration_active_job_service_name":"","integration_active_record_analytics_enabled":"false","integration_active_record_analytics_sample_rate":"1.0","integration_active_record_enabled":"true","integration_active_record_service_name":"defaultdb","integration_active_support_analytics_enabled":"false","integration_active_support_analytics_sample_rate":"1.0","integration_active_support_enabled":"true","integration_active_support_service_name":"","integration_active_support_cache_service":"active_support-cache","integration_aws_analytics_enabled":"false","integration_aws_analytics_sample_rate":"1.0","integration_aws_enabled":"true","integration_aws_service_name":"aws","integration_aws_peer_service":"","integration_concurrent_ruby_analytics_enabled":"false","integration_concurrent_ruby_analytics_sample_rate":"1.0","integration_concurrent_ruby_enabled":"true","integration_concurrent_ruby_service_name":"","integration_dalli_analytics_enabled":"false","integration_dalli_analytics_sample_rate":"1.0","integration_dalli_enabled":"true","integration_dalli_service_name":"memcached","integration_dalli_peer_service":"","integration_dalli_command_enabled":"false","integration_delayed_job_analytics_enabled":"false","integration_delayed_job_analytics_sample_rate":"1.0","integration_delayed_job_enabled":"true","integration_delayed_job_service_name":"","integration_delayed_job_client_service_name":"","integration_delayed_job_on_error":"","integration_elasticsearch_analytics_enabled":"false","integration_elasticsearch_analytics_sample_rate":"1.0","integration_elasticsearch_enabled":"true","integration_elasticsearch_service_name":"elasticsearch","integration_elasticsearch_quantize":"{}","integration_elasticsearch_peer_service":"","integration_ethon_analytics_enabled":"false","integration_ethon_analytics_sample_rate":"1.0","integration_ethon_enabled":"true","integration_ethon_service_name":"ethon","integration_ethon_distributed_tracing":"true","integration_ethon_split_by_domain":"false","integration_ethon_peer_service":"","integration_excon_analytics_enabled":"false","integration_excon_analytics_sample_rate":"1.0","integration_excon_enabled":"true","integration_excon_service_name":"excon","integration_excon_distributed_tracing":"true","integration_excon_on_error":"","integration_excon_error_status_codes":"#<Datadog::Tracing::Contrib::StatusRangeMatcher:0x00007c426625c478>","integration_excon_split_by_domain":"false","integration_excon_peer_service":"","integration_faraday_analytics_enabled":"false","integration_faraday_analytics_sample_rate":"1.0","integration_faraday_enabled":"true","integration_faraday_service_name":"faraday","integration_faraday_distributed_tracing":"true","integration_faraday_on_error":"","integration_faraday_error_status_codes":"#<Datadog::Tracing::Contrib::StatusRangeMatcher:0x00007c4266268610>","integration_faraday_split_by_domain":"false","integration_faraday_peer_service":"","integration_grape_analytics_enabled":"","integration_grape_analytics_sample_rate":"1.0","integration_grape_enabled":"true","integration_grape_service_name":"","integration_grape_on_error":"","integration_grape_error_status_codes":"#<Datadog::Tracing::Contrib::StatusRangeMatcher:0x00007c42662aa308>","integration_graphql_analytics_enabled":"","integration_graphql_analytics_sample_rate":"1.0","integration_graphql_enabled":"true","integration_graphql_service_name":"","integration_graphql_schemas":"[]","integration_graphql_with_deprecated_tracer":"false","integration_grpc_analytics_enabled":"false","integration_grpc_analytics_sample_rate":"1.0","integration_grpc_enabled":"true","integration_grpc_service_name":"grpc","integration_grpc_distributed_tracing":"true","integration_grpc_peer_service":"","integration_grpc_on_error":"","integration_hanami_analytics_enabled":"false","integration_hanami_analytics_sample_rate":"1.0","integration_hanami_enabled":"true","integration_hanami_service_name":"","integration_httpclient_analytics_enabled":"false","integration_httpclient_analytics_sample_rate":"1.0","integration_httpclient_enabled":"true","integration_httpclient_service_name":"httpclient","integration_httpclient_distributed_tracing":"true","integration_httpclient_error_status_codes":"#<Datadog::Tracing::Contrib::StatusRangeMatcher:0x00007c426634d0a8>","integration_httpclient_peer_service":"","integration_httpclient_split_by_domain":"false","integration_httprb_analytics_enabled":"false","integration_httprb_analytics_sample_rate":"1.0","integration_httprb_enabled":"true","integration_httprb_service_name":"httprb","integration_httprb_distributed_tracing":"true","integration_httprb_error_status_codes":"#<Datadog::Tracing::Contrib::StatusRangeMatcher:0x00007c4266359808>","integration_httprb_peer_service":"","integration_httprb_split_by_domain":"false","integration_kafka_analytics_enabled":"false","integration_kafka_analytics_sample_rate":"1.0","integration_kafka_enabled":"true","integration_kafka_service_name":"","integration_mongo_analytics_enabled":"false","integration_mongo_analytics_sample_rate":"1.0","integration_mongo_enabled":"true","integration_mongo_service_name":"mongodb","integration_mongo_quantize":"{:show=>[:collection, :database, :operation]}","integration_mongo_peer_service":"","integration_mysql2_analytics_enabled":"false","integration_mysql2_analytics_sample_rate":"1.0","integration_mysql2_enabled":"true","integration_mysql2_service_name":"mysql2","integration_mysql2_comment_propagation":"disabled","integration_mysql2_peer_service":"","integration_mysql2_on_error":"","integration_opensearch_analytics_enabled":"false","integration_opensearch_analytics_sample_rate":"1.0","integration_opensearch_enabled":"true","integration_opensearch_service_name":"opensearch","integration_opensearch_quantize":"{}","integration_opensearch_peer_service":"","integration_pg_analytics_enabled":"false","integration_pg_analytics_sample_rate":"1.0","integration_pg_enabled":"true","integration_pg_service_name":"pg","integration_pg_on_error":"","integration_pg_comment_propagation":"disabled","integration_pg_peer_service":"","integration_presto_analytics_enabled":"false","integration_presto_analytics_sample_rate":"1.0","integration_presto_enabled":"true","integration_presto_service_name":"presto","integration_presto_peer_service":"","integration_que_analytics_enabled":"false","integration_que_analytics_sample_rate":"1.0","integration_que_enabled":"true","integration_que_service_name":"","integration_que_distributed_tracing":"true","integration_que_tag_args":"false","integration_que_tag_data":"false","integration_que_on_error":"","integration_racecar_analytics_enabled":"false","integration_racecar_analytics_sample_rate":"1.0","integration_racecar_enabled":"true","integration_racecar_service_name":"racecar","integration_rack_analytics_enabled":"","integration_rack_analytics_sample_rate":"1.0","integration_rack_enabled":"true","integration_rack_service_name":"","integration_rack_application":"","integration_rack_distributed_tracing":"true","integration_rack_headers":"{:response=>[\"Content-Type\", \"X-Request-ID\"]}","integration_rack_middleware_names":"false","integration_rack_quantize":"{}","integration_rack_request_queuing":"false","integration_rack_web_service_name":"web-server","integration_rails_analytics_enabled":"","integration_rails_analytics_sample_rate":"1.0","integration_rails_enabled":"true","integration_rails_service_name":"","integration_rails_distributed_tracing":"true","integration_rails_request_queuing":"false","integration_rails_middleware":"true","integration_rails_middleware_names":"false","integration_rails_template_base_path":"views/","integration_rake_analytics_enabled":"false","integration_rake_analytics_sample_rate":"1.0","integration_rake_enabled":"true","integration_rake_service_name":"","integration_rake_quantize":"{}","integration_rake_tasks":"[]","integration_redis_analytics_enabled":"false","integration_redis_analytics_sample_rate":"1.0","integration_redis_enabled":"true","integration_redis_service_name":"redis","integration_redis_command_args":"false","integration_redis_peer_service":"","integration_resque_analytics_enabled":"false","integration_resque_analytics_sample_rate":"1.0","integration_resque_enabled":"true","integration_resque_service_name":"","integration_resque_on_error":"","integration_rest_client_analytics_enabled":"false","integration_rest_client_analytics_sample_rate":"1.0","integration_rest_client_enabled":"true","integration_rest_client_service_name":"rest_client","integration_rest_client_distributed_tracing":"true","integration_rest_client_peer_service":"","integration_rest_client_split_by_domain":"false","integration_roda_analytics_enabled":"false","integration_roda_analytics_sample_rate":"1.0","integration_roda_enabled":"true","integration_roda_service_name":"","integration_sequel_analytics_enabled":"false","integration_sequel_analytics_sample_rate":"1.0","integration_sequel_enabled":"true","integration_sequel_service_name":"","integration_shoryuken_analytics_enabled":"false","integration_shoryuken_analytics_sample_rate":"1.0","integration_shoryuken_enabled":"true","integration_shoryuken_service_name":"","integration_shoryuken_on_error":"","integration_shoryuken_tag_body":"false","integration_sidekiq_analytics_enabled":"false","integration_sidekiq_analytics_sample_rate":"1.0","integration_sidekiq_enabled":"true","integration_sidekiq_service_name":"","integration_sidekiq_client_service_name":"","integration_sidekiq_on_error":"","integration_sidekiq_quantize":"{}","integration_sidekiq_distributed_tracing":"false","integration_sinatra_analytics_enabled":"","integration_sinatra_analytics_sample_rate":"1.0","integration_sinatra_enabled":"true","integration_sinatra_service_name":"","integration_sinatra_distributed_tracing":"true","integration_sinatra_headers":"{:response=>[\"Content-Type\", \"X-Request-ID\"]}","integration_sinatra_resource_script_names":"false","integration_sneakers_analytics_enabled":"false","integration_sneakers_analytics_sample_rate":"1.0","integration_sneakers_enabled":"true","integration_sneakers_service_name":"","integration_sneakers_on_error":"","integration_sneakers_tag_body":"false","integration_stripe_analytics_enabled":"false","integration_stripe_analytics_sample_rate":"1.0","integration_stripe_enabled":"true","integration_stripe_service_name":"","integration_sucker_punch_analytics_enabled":"false","integration_sucker_punch_analytics_sample_rate":"1.0","integration_sucker_punch_enabled":"true","integration_sucker_punch_service_name":"","integration_trilogy_analytics_enabled":"false","integration_trilogy_analytics_sample_rate":"1.0","integration_trilogy_enabled":"true","integration_trilogy_service_name":"trilogy","integration_trilogy_comment_propagation":"disabled","integration_trilogy_peer_service":""}

...and here's how it looks now by default:

> I, [2024-07-16T15:54:04.025334 #327699]  INFO -- datadog: [datadog] DATADOG CONFIGURATION - TRACING - {"enabled":true,"agent_url":"http://127.0.0.1:8126?timeout=30","analytics_enabled":false,"sample_rate":null,"sampling_rules":null,"integrations_loaded":"action_cable@,action_mailer@,http@3.1.4,action_pack@,action_view@,active_model_serializers@,active_job@,active_record@,active_support@7.1.3.4,aws@,concurrent_ruby@1.3.3,dalli@,delayed_job@,elasticsearch@,ethon@,excon@,faraday@,grape@,graphql@,grpc@,hanami@,httpclient@,httprb@,kafka@,mongo@,mysql2@,opensearch@,pg@,presto@,que@,racecar@,rack@,rails@,rake@13.2.1,redis@,resque@,rest_client@,roda@,sequel@,shoryuken@,sidekiq@,sinatra@,sneakers@,stripe@,sucker_punch@,trilogy@","partial_flushing_enabled":false}

...and here's how the second log looks if enabled via `DD_TRACE_DEBUG=true`:

> D, [2024-07-16T15:54:39.386684 #327838] DEBUG -- datadog: [datadog] (/home/ivo.anjo/datadog/dd-trace-rb/lib/datadog/core/diagnostics/environment_logger.rb:17:in `log_debug!') DATADOG CONFIGURATION - TRACING INTEGRATIONS - {"action_cable_analytics_enabled":"false","action_cable_analytics_sample_rate":"1.0","action_cable_enabled":"true","action_cable_service_name":"","action_mailer_analytics_enabled":"false","action_mailer_analytics_sample_rate":"1.0","action_mailer_enabled":"true","action_mailer_service_name":"","action_mailer_email_data":"false","http_analytics_enabled":"false","http_analytics_sample_rate":"1.0","http_enabled":"true","http_service_name":"net/http","http_distributed_tracing":"true","http_error_status_codes":"#<Datadog::Tracing::Contrib::StatusRangeMatcher:0x00007d61f12aa528>","http_peer_service":"","http_split_by_domain":"false","action_pack_analytics_enabled":"","action_pack_analytics_sample_rate":"1.0","action_pack_enabled":"true","action_pack_service_name":"","action_view_analytics_enabled":"false","action_view_analytics_sample_rate":"1.0","action_view_enabled":"true","action_view_service_name":"","action_view_template_base_path":"views/","active_model_serializers_analytics_enabled":"false","active_model_serializers_analytics_sample_rate":"1.0","active_model_serializers_enabled":"true","active_model_serializers_service_name":"","active_job_analytics_enabled":"false","active_job_analytics_sample_rate":"1.0","active_job_enabled":"true","active_job_service_name":"","active_record_analytics_enabled":"false","active_record_analytics_sample_rate":"1.0","active_record_enabled":"true","active_record_service_name":"defaultdb","active_support_analytics_enabled":"false","active_support_analytics_sample_rate":"1.0","active_support_enabled":"true","active_support_service_name":"","active_support_cache_service":"active_support-cache","aws_analytics_enabled":"false","aws_analytics_sample_rate":"1.0","aws_enabled":"true","aws_service_name":"aws","aws_peer_service":"","concurrent_ruby_analytics_enabled":"false","concurrent_ruby_analytics_sample_rate":"1.0","concurrent_ruby_enabled":"true","concurrent_ruby_service_name":"","dalli_analytics_enabled":"false","dalli_analytics_sample_rate":"1.0","dalli_enabled":"true","dalli_service_name":"memcached","dalli_peer_service":"","dalli_command_enabled":"false","delayed_job_analytics_enabled":"false","delayed_job_analytics_sample_rate":"1.0","delayed_job_enabled":"true","delayed_job_service_name":"","delayed_job_client_service_name":"","delayed_job_on_error":"","elasticsearch_analytics_enabled":"false","elasticsearch_analytics_sample_rate":"1.0","elasticsearch_enabled":"true","elasticsearch_service_name":"elasticsearch","elasticsearch_quantize":"{}","elasticsearch_peer_service":"","ethon_analytics_enabled":"false","ethon_analytics_sample_rate":"1.0","ethon_enabled":"true","ethon_service_name":"ethon","ethon_distributed_tracing":"true","ethon_split_by_domain":"false","ethon_peer_service":"","excon_analytics_enabled":"false","excon_analytics_sample_rate":"1.0","excon_enabled":"true","excon_service_name":"excon","excon_distributed_tracing":"true","excon_on_error":"","excon_error_status_codes":"#<Datadog::Tracing::Contrib::StatusRangeMatcher:0x00007d61f12deda0>","excon_split_by_domain":"false","excon_peer_service":"","faraday_analytics_enabled":"false","faraday_analytics_sample_rate":"1.0","faraday_enabled":"true","faraday_service_name":"faraday","faraday_distributed_tracing":"true","faraday_on_error":"","faraday_error_status_codes":"#<Datadog::Tracing::Contrib::StatusRangeMatcher:0x00007d61f12e2220>","faraday_split_by_domain":"false","faraday_peer_service":"","grape_analytics_enabled":"","grape_analytics_sample_rate":"1.0","grape_enabled":"true","grape_service_name":"","grape_on_error":"","grape_error_status_codes":"#<Datadog::Tracing::Contrib::StatusRangeMatcher:0x00007d61f12e65f0>","graphql_analytics_enabled":"","graphql_analytics_sample_rate":"1.0","graphql_enabled":"true","graphql_service_name":"","graphql_schemas":"[]","graphql_with_deprecated_tracer":"false","graphql_with_unified_tracer":"false","grpc_analytics_enabled":"false","grpc_analytics_sample_rate":"1.0","grpc_enabled":"true","grpc_service_name":"grpc","grpc_distributed_tracing":"true","grpc_peer_service":"","grpc_on_error":"","hanami_analytics_enabled":"false","hanami_analytics_sample_rate":"1.0","hanami_enabled":"true","hanami_service_name":"","httpclient_analytics_enabled":"false","httpclient_analytics_sample_rate":"1.0","httpclient_enabled":"true","httpclient_service_name":"httpclient","httpclient_distributed_tracing":"true","httpclient_error_status_codes":"#<Datadog::Tracing::Contrib::StatusRangeMatcher:0x00007d61f12ec270>","httpclient_peer_service":"","httpclient_split_by_domain":"false","httprb_analytics_enabled":"false","httprb_analytics_sample_rate":"1.0","httprb_enabled":"true","httprb_service_name":"httprb","httprb_distributed_tracing":"true","httprb_error_status_codes":"#<Datadog::Tracing::Contrib::StatusRangeMatcher:0x00007d61ed3b7dc0>","httprb_peer_service":"","httprb_split_by_domain":"false","kafka_analytics_enabled":"false","kafka_analytics_sample_rate":"1.0","kafka_enabled":"true","kafka_service_name":"","mongo_analytics_enabled":"false","mongo_analytics_sample_rate":"1.0","mongo_enabled":"true","mongo_service_name":"mongodb","mongo_quantize":"{:show=>[:collection, :database, :operation]}","mongo_peer_service":"","mysql2_analytics_enabled":"false","mysql2_analytics_sample_rate":"1.0","mysql2_enabled":"true","mysql2_service_name":"mysql2","mysql2_comment_propagation":"disabled","mysql2_peer_service":"","mysql2_on_error":"","opensearch_analytics_enabled":"false","opensearch_analytics_sample_rate":"1.0","opensearch_enabled":"true","opensearch_service_name":"opensearch","opensearch_quantize":"{}","opensearch_peer_service":"","pg_analytics_enabled":"false","pg_analytics_sample_rate":"1.0","pg_enabled":"true","pg_service_name":"pg","pg_on_error":"","pg_comment_propagation":"disabled","pg_peer_service":"","presto_analytics_enabled":"false","presto_analytics_sample_rate":"1.0","presto_enabled":"true","presto_service_name":"presto","presto_peer_service":"","que_analytics_enabled":"false","que_analytics_sample_rate":"1.0","que_enabled":"true","que_service_name":"","que_distributed_tracing":"true","que_tag_args":"false","que_tag_data":"false","que_on_error":"","racecar_analytics_enabled":"false","racecar_analytics_sample_rate":"1.0","racecar_enabled":"true","racecar_service_name":"racecar","rack_analytics_enabled":"","rack_analytics_sample_rate":"1.0","rack_enabled":"true","rack_service_name":"","rack_application":"","rack_distributed_tracing":"true","rack_headers":"{:response=>[\"Content-Type\", \"X-Request-ID\"]}","rack_middleware_names":"false","rack_quantize":"{}","rack_request_queuing":"false","rack_web_service_name":"web-server","rails_analytics_enabled":"","rails_analytics_sample_rate":"1.0","rails_enabled":"true","rails_service_name":"","rails_distributed_tracing":"true","rails_request_queuing":"false","rails_middleware":"true","rails_middleware_names":"false","rails_template_base_path":"views/","rake_analytics_enabled":"false","rake_analytics_sample_rate":"1.0","rake_enabled":"true","rake_service_name":"","rake_quantize":"{}","rake_tasks":"[]","redis_analytics_enabled":"false","redis_analytics_sample_rate":"1.0","redis_enabled":"true","redis_service_name":"redis","redis_command_args":"false","redis_peer_service":"","resque_analytics_enabled":"false","resque_analytics_sample_rate":"1.0","resque_enabled":"true","resque_service_name":"","resque_on_error":"","rest_client_analytics_enabled":"false","rest_client_analytics_sample_rate":"1.0","rest_client_enabled":"true","rest_client_service_name":"rest_client","rest_client_distributed_tracing":"true","rest_client_peer_service":"","rest_client_split_by_domain":"false","roda_analytics_enabled":"false","roda_analytics_sample_rate":"1.0","roda_enabled":"true","roda_service_name":"","sequel_analytics_enabled":"false","sequel_analytics_sample_rate":"1.0","sequel_enabled":"true","sequel_service_name":"","shoryuken_analytics_enabled":"false","shoryuken_analytics_sample_rate":"1.0","shoryuken_enabled":"true","shoryuken_service_name":"","shoryuken_on_error":"","shoryuken_tag_body":"false","sidekiq_analytics_enabled":"false","sidekiq_analytics_sample_rate":"1.0","sidekiq_enabled":"true","sidekiq_service_name":"","sidekiq_client_service_name":"","sidekiq_on_error":"","sidekiq_quantize":"{}","sidekiq_distributed_tracing":"false","sinatra_analytics_enabled":"","sinatra_analytics_sample_rate":"1.0","sinatra_enabled":"true","sinatra_service_name":"","sinatra_distributed_tracing":"true","sinatra_headers":"{:response=>[\"Content-Type\", \"X-Request-ID\"]}","sinatra_resource_script_names":"false","sneakers_analytics_enabled":"false","sneakers_analytics_sample_rate":"1.0","sneakers_enabled":"true","sneakers_service_name":"","sneakers_on_error":"","sneakers_tag_body":"false","stripe_analytics_enabled":"false","stripe_analytics_sample_rate":"1.0","stripe_enabled":"true","stripe_service_name":"","sucker_punch_analytics_enabled":"false","sucker_punch_analytics_sample_rate":"1.0","sucker_punch_enabled":"true","sucker_punch_service_name":"","trilogy_analytics_enabled":"false","trilogy_analytics_sample_rate":"1.0","trilogy_enabled":"true","trilogy_service_name":"trilogy","trilogy_comment_propagation":"disabled","trilogy_peer_service":""}

**Additional Notes:**

N/A

**How to test the change?**

This change includes test coverage; see also above for an example on how to trigger these messages.