### PR TITLE
Backport: Return empty log correlation when tracing is disabled #3731 

### DIFF
--- a/lib/datadog/tracing.rb
+++ b/lib/datadog/tracing.rb
@@ -96,9 +96,11 @@ module Datadog
       # # dd.env=prod dd.service=auth dd.version=13.8 dd.trace_id=5458478252992251 dd.span_id=7117552347370098 My message
       # ```
       #
-      # @return [String] correlation information
+      # @return [String] correlation information; or an empty String if Tracing is disabled (`!enabled?`)
       # @public_api
       def log_correlation
+        return '' unless enabled?
+
         correlation.to_log_format
       end
 

--- a/spec/datadog/tracing_spec.rb
+++ b/spec/datadog/tracing_spec.rb
@@ -106,6 +106,16 @@ RSpec.describe Datadog::Tracing do
       expect(log_correlation).to eq(returned)
     end
     # rubocop:enable RSpec/MessageChain
+
+    context 'with tracing disabled' do
+      before do
+        allow(Datadog.send(:components).tracer).to receive(:enabled).and_return(false)
+      end
+
+      it 'returns an empty string' do
+        expect(log_correlation).to eq('')
+      end
+    end
   end
 
   describe '.shutdown!' do


### PR DESCRIPTION
Backports #3731