### PR TITLE
Fix AppSec crash when parsing integer http headers

### DIFF
--- a/lib/datadog/appsec/contrib/rack/gateway/request.rb
+++ b/lib/datadog/appsec/contrib/rack/gateway/request.rb
@@ -44,10 +44,11 @@ module Datadog
                 # When multiple headers with the same name are present, they are concatenated with a comma
                 # https://www.w3.org/Protocols/rfc2616/rfc2616-sec4.html#sec4.2
                 # Because headers are case insensitive, HTTP_FOO and HTTP_Foo is the same, and should be merged
-                if k =~ /^HTTP_/
-                  key = k.gsub(/^HTTP_/, '').tap(&:downcase!).tap { |s| s.tr!('_', '-') }
-                  h[key] = h[key].nil? ? v : "#{h[key]}, #{v}"
-                end
+                next unless k.start_with?('HTTP_')
+
+                key = k.delete_prefix('HTTP_').tap(&:downcase!).tap { |s| s.tr!('_', '-') }
+                current_val = h[key]
+                h[key] = current_val.nil? ? v : "#{current_val}, #{v}"
               end
 
               result['content-type'] = request.content_type if request.content_type

--- a/lib/datadog/appsec/contrib/rack/gateway/request.rb
+++ b/lib/datadog/appsec/contrib/rack/gateway/request.rb
@@ -41,14 +41,7 @@ module Datadog
 
             def headers
               result = request.env.each_with_object({}) do |(k, v), h|
-                # When multiple headers with the same name are present, they are concatenated with a comma
-                # https://www.w3.org/Protocols/rfc2616/rfc2616-sec4.html#sec4.2
-                # Because headers are case insensitive, HTTP_FOO and HTTP_Foo is the same, and should be merged
-                next unless k.start_with?('HTTP_')
-
-                key = k.delete_prefix('HTTP_').tap(&:downcase!).tap { |s| s.tr!('_', '-') }
-                current_val = h[key]
-                h[key] = current_val.nil? ? v : "#{current_val}, #{v}"
+                h[k.delete_prefix('HTTP_').tap(&:downcase!).tap { |s| s.tr!('_', '-') }] = v if k.start_with?('HTTP_')
               end
 
               result['content-type'] = request.content_type if request.content_type

--- a/lib/datadog/appsec/contrib/rack/gateway/request.rb
+++ b/lib/datadog/appsec/contrib/rack/gateway/request.rb
@@ -41,7 +41,7 @@ module Datadog
 
             def headers
               result = request.env.each_with_object({}) do |(k, v), h|
-                h[k.gsub(/^HTTP_/, '').downcase!.tr('_', '-')] = v if k =~ /^HTTP_/
+                h[k.gsub(/^HTTP_/, '').tap(&:downcase!).tap { |s| s.tr!('_', '-') }] = v if k =~ /^HTTP_/
               end
 
               result['content-type'] = request.content_type if request.content_type

--- a/spec/datadog/appsec/contrib/rack/gateway/request_spec.rb
+++ b/spec/datadog/appsec/contrib/rack/gateway/request_spec.rb
@@ -43,8 +43,7 @@ RSpec.describe Datadog::AppSec::Contrib::Rack::Gateway::Request do
               'REQUEST_METHOD' => 'GET', 'REMOTE_ADDR' => '10.10.10.10', 'CONTENT_TYPE' => 'text/html',
               'HTTP_COOKIE' => 'foo=bar', 'HTTP_USER_AGENT' => 'WebKit',
               'HTTP_' => 'empty header', 'HTTP_123' => 'numbered header',
-              'HTTP_123_FOO' => 'alphanumerical header', 'HTTP_FOO_123' => 'reverse alphanumerical header',
-              'HTTP_foo' => 'lowercase header', 'HTTP_Foo' => 'mixed case header'
+              'HTTP_123_FOO' => 'alphanumerical header', 'HTTP_FOO_123' => 'reverse alphanumerical header'
             }
           )
         )
@@ -59,8 +58,7 @@ RSpec.describe Datadog::AppSec::Contrib::Rack::Gateway::Request do
           '' => 'empty header',
           '123' => 'numbered header',
           '123-foo' => 'alphanumerical header',
-          'foo-123' => 'reverse alphanumerical header',
-          'foo' => 'lowercase header, mixed case header'
+          'foo-123' => 'reverse alphanumerical header'
         }
         expect(request.headers).to eq(expected_headers)
       end

--- a/spec/datadog/appsec/contrib/rack/gateway/request_spec.rb
+++ b/spec/datadog/appsec/contrib/rack/gateway/request_spec.rb
@@ -33,6 +33,33 @@ RSpec.describe Datadog::AppSec::Contrib::Rack::Gateway::Request do
       }
       expect(request.headers).to eq(expected_headers)
     end
+
+    context 'with malformed headers' do
+      let(:request) do
+        described_class.new(
+          Rack::MockRequest.env_for(
+            'http://example.com:8080/?a=foo&a=bar&b=baz',
+            {
+              'REQUEST_METHOD' => 'GET', 'REMOTE_ADDR' => '10.10.10.10', 'CONTENT_TYPE' => 'text/html',
+              'HTTP_COOKIE' => 'foo=bar', 'HTTP_USER_AGENT' => 'WebKit',
+              'HTTP_' => 'empty header', 'HTTP_123' => 'numbered header'
+            }
+          )
+        )
+      end
+
+      it 'returns the header information. Strip the HTTP_ prefix and append content-type and content-length information' do
+        expected_headers = {
+          'content-type' => 'text/html',
+          'cookie' => 'foo=bar',
+          'user-agent' => 'WebKit',
+          'content-length' => '0',
+          '' => 'empty header',
+          '123' => 'numbered header'
+        }
+        expect(request.headers).to eq(expected_headers)
+      end
+    end
   end
 
   describe '#body' do

--- a/spec/datadog/appsec/contrib/rack/gateway/request_spec.rb
+++ b/spec/datadog/appsec/contrib/rack/gateway/request_spec.rb
@@ -42,7 +42,9 @@ RSpec.describe Datadog::AppSec::Contrib::Rack::Gateway::Request do
             {
               'REQUEST_METHOD' => 'GET', 'REMOTE_ADDR' => '10.10.10.10', 'CONTENT_TYPE' => 'text/html',
               'HTTP_COOKIE' => 'foo=bar', 'HTTP_USER_AGENT' => 'WebKit',
-              'HTTP_' => 'empty header', 'HTTP_123' => 'numbered header'
+              'HTTP_' => 'empty header', 'HTTP_123' => 'numbered header',
+              'HTTP_123_FOO' => 'alphanumerical header', 'HTTP_FOO_123' => 'reverse alphanumerical header',
+              'HTTP_foo' => 'lowercase header', 'HTTP_Foo' => 'mixed case header'
             }
           )
         )
@@ -55,7 +57,10 @@ RSpec.describe Datadog::AppSec::Contrib::Rack::Gateway::Request do
           'user-agent' => 'WebKit',
           'content-length' => '0',
           '' => 'empty header',
-          '123' => 'numbered header'
+          '123' => 'numbered header',
+          '123-foo' => 'alphanumerical header',
+          'foo-123' => 'reverse alphanumerical header',
+          'foo' => 'lowercase header, mixed case header'
         }
         expect(request.headers).to eq(expected_headers)
       end


### PR DESCRIPTION
**What does this PR do?**
<!-- A brief description of the change being made with this pull request. -->
This fixes a crash when malformed headers are sent (e.g. headers with numbers)

**Motivation:**
<!-- What inspired you to submit this pull request? -->
This fixes issue #3782 

**Additional Notes:**
<!-- Anything else we should know when reviewing? -->

**How to test the change?**
<!--
Describe here how the change can be validated.
You are strongly encouraged to provide automated tests for this PR (unit or integration).
If this change cannot be feasibly tested, please explain why,
unless the change does not modify code (e.g. only modifies docs, comments).
-->

`bundle exec appraisal ruby-x.x-rack-x rake spec:appsec:rack`
