### PR TITLE
[PROF-10124] Lower value used to clamp very high allocation profiling weights

### DIFF
--- a/ext/datadog_profiling_native_extension/collectors_cpu_and_wall_time_worker.c
+++ b/ext/datadog_profiling_native_extension/collectors_cpu_and_wall_time_worker.c
@@ -20,7 +20,9 @@
 #define ERR_CLOCK_FAIL "failed to get clock time"
 
 // Maximum allowed value for an allocation weight. Attempts to use higher values will result in clamping.
-unsigned int MAX_ALLOC_WEIGHT = 65535;
+// See https://docs.google.com/document/d/1lWLB714wlLBBq6T4xZyAc4a5wtWhSmr4-hgiPKeErlA/edit#heading=h.ugp0zxcj5iqh
+// (Datadog-only link) for research backing the choice of this value.
+unsigned int MAX_ALLOC_WEIGHT = 10000;
 
 // Used to trigger the execution of Collectors::ThreadState, which implements all of the sampling logic
 // itself; this class only implements the "when to do it" part.


### PR DESCRIPTION
**What does this PR do?**

This PR lowers the profiling internal constant `MAX_ALLOC_WEIGHT` from 65535 to 10000.

This value is used when clamping very high allocation profiling weights.

Aka: Each allocation sample taken by the profiler has a weight assigned to it; this weight is clamped (e.g. limited to) this maximum value. The remaining weight is assigned to a separate "skipped samples" placeholder (see #3792).

**Motivation:**

Very large weights on samples can produce biased results; by lowering the maximum we reduce the maximum bias that can ever be introduced.

**Additional Notes:**

I've gathered data from a number of apps when choosing this value, see <https://docs.google.com/document/d/1lWLB714wlLBBq6T4xZyAc4a5wtWhSmr4-hgiPKeErlA/edit> for details (Datadog-only link, sorry!).

**How to test the change?**

The tests for #3792 also cover this change (although the changes are otherwise independent).
