### PR TITLE
[PROF-10198] Add benchmark config with allocation profiling + ddprof

### DIFF
--- a/.gitlab/benchmarks.yml
+++ b/.gitlab/benchmarks.yml
@@ -88,6 +88,14 @@ only-profiling-alloc:
     DD_PROFILING_ENABLED: "true"
     DD_PROFILING_ALLOCATION_ENABLED: "true"
 
+only-profiling-alloc-ddprof:
+  extends: .benchmarks
+  variables:
+    DD_BENCHMARKS_DDPROF: "true"
+    DD_BENCHMARKS_CONFIGURATION: only-profiling
+    DD_PROFILING_ENABLED: "true"
+    DD_PROFILING_ALLOCATION_ENABLED: "true"
+
 only-profiling-heap:
   extends: .benchmarks
   variables:


### PR DESCRIPTION
**What does this PR do?**

This PR adds a new benchmarking configuration for testing allocation profiling with `ddprof` enabled.

(As a reminder, `ddprof` is the Datadog native profiler).

**Motivation:**

The intention is to allow us to use ddprof to profile the Ruby profiler, so we can identify optimization opportunities and validate any changes we make.

**Additional Notes:**

N/A

**How to test the change?**

I've tried to test this PR locally using the `bp-runner` tool, but for some reason I get benchmark results, but no profiles. Nevertheless, this change is harmless so I'm thinking of merging this in and seeing if it shows up correctly on the next nightly run.
