### PR TITLE
fix(errors): revert breaking change

### DIFF
--- a/lib/datadog/tracing/metadata/errors.rb
+++ b/lib/datadog/tracing/metadata/errors.rb
@@ -10,6 +10,14 @@ module Datadog
       # Adds error tagging behavior
       # @public_api
       module Errors
+        def set_error(e)
+          Datadog::Core.log_deprecation do
+            'Errors.set_error(..) is deprecated. ' \
+            'Use Errors.set_error_tags(..) instead.'
+          end
+          set_error_tags(e)
+        end
+
         # Mark the span with the given error.
         def set_error_tags(e)
           e = Core::Error.build_from(e)

--- a/spec/datadog/tracing/metadata/errors_spec.rb
+++ b/spec/datadog/tracing/metadata/errors_spec.rb
@@ -12,21 +12,23 @@ RSpec.describe Datadog::Tracing::Metadata::Errors do
     end
   end
 
-  describe '#set_error_tags' do
-    subject(:set_error_tags) { test_object.set_error_tags(error) }
+  Array(['set_error', 'set_error_tags']) do |method_name|
+    describe "##{method_name}" do
+      subject(:error_setter) { test_object.send(method_name) }
 
-    let(:error) { RuntimeError.new('oops') }
-    let(:backtrace) { %w[method1 method2 method3] }
+      let(:error) { RuntimeError.new('oops') }
+      let(:backtrace) { %w[method1 method2 method3] }
 
-    before { error.set_backtrace(backtrace) }
+      before { error.set_backtrace(backtrace) }
 
-    it do
-      set_error_tags
+      it do
+        error_setter
 
-      expect(test_object).to have_error_message('oops')
-      expect(test_object).to have_error_type('RuntimeError')
-      backtrace.each do |method|
-        expect(test_object).to have_error_stack(include(method))
+        expect(test_object).to have_error_message('oops')
+        expect(test_object).to have_error_type('RuntimeError')
+        backtrace.each do |method|
+          expect(test_object).to have_error_stack(include(method))
+        end
       end
     end
   end


### PR DESCRIPTION
**What does this PR do?**

https://github.com/DataDog/dd-trace-rb/pull/3776 renamed the Error.set_error method to set_error_tags. Renaming a method in the public api is a breaking change. This PR reverts this breaking change and adds deprecation warning.  


**Motivation:**
<!-- What inspired you to submit this pull request? -->

**Additional Notes:**
<!-- Anything else we should know when reviewing? -->

**How to test the change?**
<!--
Describe here how the change can be validated.
You are strongly encouraged to provide automated tests for this PR (unit or integration).
If this change cannot be feasibly tested, please explain why,
unless the change does not modify code (e.g. only modifies docs, comments).
-->

Unsure? Have a question? Request a review!
