### PR TITLE
[PROF-10201] Reduce allocation profiling overhead by using coarse timestamps

### DIFF
--- a/benchmarks/profiler_allocation.rb
+++ b/benchmarks/profiler_allocation.rb
@@ -1,0 +1,66 @@
+# Used to quickly run benchmark under RSpec as part of the usual test suite, to validate it didn't bitrot
+VALIDATE_BENCHMARK_MODE = ENV['VALIDATE_BENCHMARK'] == 'true'
+
+return unless __FILE__ == $PROGRAM_NAME || VALIDATE_BENCHMARK_MODE
+
+require 'benchmark/ips'
+require 'datadog'
+require 'pry'
+require_relative 'dogstatsd_reporter'
+
+# This benchmark measures the performance of allocation profiling
+
+class ExportToFile
+  PPROF_PREFIX = ENV.fetch('DD_PROFILING_PPROF_PREFIX', 'profiler-allocation')
+
+  def export(flush)
+    File.write("#{PPROF_PREFIX}#{flush.start.strftime('%Y%m%dT%H%M%SZ')}.pprof", flush.pprof_data)
+    true
+  end
+end
+
+class ProfilerAllocationBenchmark
+  def run_benchmark
+    Benchmark.ips do |x|
+      benchmark_time = VALIDATE_BENCHMARK_MODE ? { time: 0.01, warmup: 0 } : { time: 10, warmup: 2 }
+      x.config(
+        **benchmark_time,
+        suite: report_to_dogstatsd_if_enabled_via_environment_variable(benchmark_name: 'profiler_allocation')
+      )
+
+      x.report('Allocations (baseline)', 'BasicObject.new')
+
+      x.save! 'profiler-allocation-results.json' unless VALIDATE_BENCHMARK_MODE
+      x.compare!
+    end
+
+    Datadog.configure do |c|
+      c.profiling.enabled = true
+      c.profiling.allocation_enabled = true
+      c.profiling.advanced.gc_enabled = false
+      c.profiling.exporter.transport = ExportToFile.new unless VALIDATE_BENCHMARK_MODE
+    end
+    Datadog::Profiling.wait_until_running
+
+    3.times { GC.start }
+
+    Benchmark.ips do |x|
+      benchmark_time = VALIDATE_BENCHMARK_MODE ? { time: 0.01, warmup: 0 } : { time: 10, warmup: 2 }
+      x.config(
+        **benchmark_time,
+        suite: report_to_dogstatsd_if_enabled_via_environment_variable(benchmark_name: 'profiler_allocation')
+      )
+
+      x.report("Allocations (#{ENV['CONFIG']})", 'BasicObject.new')
+
+      x.save! 'profiler-allocation-results.json' unless VALIDATE_BENCHMARK_MODE
+      x.compare!
+    end
+  end
+end
+
+puts "Current pid is #{Process.pid}"
+
+ProfilerAllocationBenchmark.new.instance_exec do
+  run_benchmark
+end

--- a/ext/datadog_profiling_native_extension/extconf.rb
+++ b/ext/datadog_profiling_native_extension/extconf.rb
@@ -129,6 +129,9 @@ if RUBY_PLATFORM.include?('linux')
   # but it's slower to build
   # so instead we just assume that we have the function we need on Linux, and nowhere else
   $defs << '-DHAVE_PTHREAD_GETCPUCLOCKID'
+
+  # Not available on macOS
+  $defs << '-DHAVE_CLOCK_MONOTONIC_COARSE'
 end
 
 have_func 'malloc_stats'

--- a/ext/datadog_profiling_native_extension/time_helpers.c
+++ b/ext/datadog_profiling_native_extension/time_helpers.c
@@ -4,21 +4,6 @@
 #include "ruby_helpers.h"
 #include "time_helpers.h"
 
-// Safety: This function is assumed never to raise exceptions by callers when raise_on_failure == false
-long retrieve_clock_as_ns(clockid_t clock_id, bool raise_on_failure) {
-  struct timespec clock_value;
-
-  if (clock_gettime(clock_id, &clock_value) != 0) {
-    if (raise_on_failure) ENFORCE_SUCCESS_GVL(errno);
-    return 0;
-  }
-
-  return clock_value.tv_nsec + SECONDS_AS_NS(clock_value.tv_sec);
-}
-
-long monotonic_wall_time_now_ns(bool raise_on_failure) { return retrieve_clock_as_ns(CLOCK_MONOTONIC, raise_on_failure); }
-long system_epoch_time_now_ns(bool raise_on_failure)   { return retrieve_clock_as_ns(CLOCK_REALTIME,  raise_on_failure); }
-
 // Design: The monotonic_to_system_epoch_state struct is kept somewhere by the caller, and MUST be initialized to
 // MONOTONIC_TO_SYSTEM_EPOCH_INITIALIZER.
 //

--- a/ext/datadog_profiling_native_extension/time_helpers.h
+++ b/ext/datadog_profiling_native_extension/time_helpers.h
@@ -37,17 +37,19 @@ inline long system_epoch_time_now_ns(raise_on_failure_setting raise_on_failure) 
 
 // Coarse instants use CLOCK_MONOTONIC_COARSE on Linux which is expected to provide resolution in the millisecond range:
 // https://docs.redhat.com/en/documentation/red_hat_enterprise_linux_for_real_time/7/html/reference_guide/sect-posix_clocks#Using_clock_getres_to_compare_clock_resolution
-// We introduce here a separate type for it, so as to make it harder/more explicit when these timestamps are used
+// We introduce here a separate type for it, so as to make it harder to misuse/more explicit when these timestamps are used
 
 typedef struct coarse_instant {
   long timestamp_ns;
 } coarse_instant;
 
+inline coarse_instant to_coarse_instant(long timestamp_ns) { return (coarse_instant) {.timestamp_ns = timestamp_ns}; }
+
 inline coarse_instant monotonic_coarse_wall_time_now_ns(void) {
-  #ifdef HAVE_CLOCK_MONOTONIC_COARSE // Linux
-    return (coarse_instant) {.timestamp_ns = retrieve_clock_as_ns(CLOCK_MONOTONIC_COARSE, DO_NOT_RAISE_ON_FAILURE)};
+ #ifdef HAVE_CLOCK_MONOTONIC_COARSE // Linux
+    return to_coarse_instant(retrieve_clock_as_ns(CLOCK_MONOTONIC_COARSE, DO_NOT_RAISE_ON_FAILURE));
   #else // macOS
-    return (coarse_instant) {.timestamp_ns = retrieve_clock_as_ns(CLOCK_MONOTONIC, DO_NOT_RAISE_ON_FAILURE)};
+    return to_coarse_instant(retrieve_clock_as_ns(CLOCK_MONOTONIC, DO_NOT_RAISE_ON_FAILURE));
   #endif
 }
 

--- a/ext/datadog_profiling_native_extension/time_helpers.h
+++ b/ext/datadog_profiling_native_extension/time_helpers.h
@@ -4,6 +4,7 @@
 #include <errno.h>
 #include <time.h>
 
+#include "extconf.h" // Needed for HAVE_CLOCK_MONOTONIC_COARSE
 #include "ruby_helpers.h"
 
 #define SECONDS_AS_NS(value) (value * 1000 * 1000 * 1000L)
@@ -33,5 +34,21 @@ inline long retrieve_clock_as_ns(clockid_t clock_id, raise_on_failure_setting ra
 
 inline long monotonic_wall_time_now_ns(raise_on_failure_setting raise_on_failure) { return retrieve_clock_as_ns(CLOCK_MONOTONIC, raise_on_failure); }
 inline long system_epoch_time_now_ns(raise_on_failure_setting raise_on_failure)   { return retrieve_clock_as_ns(CLOCK_REALTIME,  raise_on_failure); }
+
+// Coarse instants use CLOCK_MONOTONIC_COARSE on Linux which is expected to provide resolution in the millisecond range:
+// https://docs.redhat.com/en/documentation/red_hat_enterprise_linux_for_real_time/7/html/reference_guide/sect-posix_clocks#Using_clock_getres_to_compare_clock_resolution
+// We introduce here a separate type for it, so as to make it harder/more explicit when these timestamps are used
+
+typedef struct coarse_instant {
+  long timestamp_ns;
+} coarse_instant;
+
+inline coarse_instant monotonic_coarse_wall_time_now_ns(void) {
+  #ifdef HAVE_CLOCK_MONOTONIC_COARSE // Linux
+    return (coarse_instant) {.timestamp_ns = retrieve_clock_as_ns(CLOCK_MONOTONIC_COARSE, DO_NOT_RAISE_ON_FAILURE)};
+  #else // macOS
+    return (coarse_instant) {.timestamp_ns = retrieve_clock_as_ns(CLOCK_MONOTONIC, DO_NOT_RAISE_ON_FAILURE)};
+  #endif
+}
 
 long monotonic_to_system_epoch_ns(monotonic_to_system_epoch_state *state, long monotonic_wall_time_ns);

--- a/ext/datadog_profiling_native_extension/time_helpers.h
+++ b/ext/datadog_profiling_native_extension/time_helpers.h
@@ -1,12 +1,15 @@
 #pragma once
 
 #include <stdbool.h>
+#include <errno.h>
+#include <time.h>
+
+#include "ruby_helpers.h"
 
 #define SECONDS_AS_NS(value) (value * 1000 * 1000 * 1000L)
 #define MILLIS_AS_NS(value) (value * 1000 * 1000L)
 
-#define RAISE_ON_FAILURE true
-#define DO_NOT_RAISE_ON_FAILURE false
+typedef enum { RAISE_ON_FAILURE, DO_NOT_RAISE_ON_FAILURE } raise_on_failure_setting;
 
 #define INVALID_TIME -1
 
@@ -17,10 +20,18 @@ typedef struct {
 
 #define MONOTONIC_TO_SYSTEM_EPOCH_INITIALIZER {.system_epoch_ns_reference = INVALID_TIME, .delta_to_epoch_ns = INVALID_TIME}
 
-// Safety: This function is assumed never to raise exceptions by callers when raise_on_failure == false
-long monotonic_wall_time_now_ns(bool raise_on_failure);
+inline long retrieve_clock_as_ns(clockid_t clock_id, raise_on_failure_setting raise_on_failure) {
+  struct timespec clock_value;
 
-// Safety: This function is assumed never to raise exceptions by callers when raise_on_failure == false
-long system_epoch_time_now_ns(bool raise_on_failure);
+  if (clock_gettime(clock_id, &clock_value) != 0) {
+    if (raise_on_failure == RAISE_ON_FAILURE) ENFORCE_SUCCESS_GVL(errno);
+    return 0;
+  }
+
+  return clock_value.tv_nsec + SECONDS_AS_NS(clock_value.tv_sec);
+}
+
+inline long monotonic_wall_time_now_ns(raise_on_failure_setting raise_on_failure) { return retrieve_clock_as_ns(CLOCK_MONOTONIC, raise_on_failure); }
+inline long system_epoch_time_now_ns(raise_on_failure_setting raise_on_failure)   { return retrieve_clock_as_ns(CLOCK_REALTIME,  raise_on_failure); }
 
 long monotonic_to_system_epoch_ns(monotonic_to_system_epoch_state *state, long monotonic_wall_time_ns);

--- a/spec/datadog/profiling/validate_benchmarks_spec.rb
+++ b/spec/datadog/profiling/validate_benchmarks_spec.rb
@@ -16,6 +16,7 @@ RSpec.describe 'Profiling benchmarks' do
     'profiler_memory_sample_serialize',
     'profiler_gc',
     'profiler_hold_resume_interruptions',
+    'profiler_allocation',
   ].freeze
 
   benchmarks_to_validate.each do |benchmark|


### PR DESCRIPTION
**What does this PR do?**

This PR reduces the allocation profiling overhead (or: optimizes allocation profiling :D ) by using coarse timestamps on the `on_newobj_event` hot path.

**Motivation:**

When allocation profiling is enabled, the profiler gets called for almost every object allocated in the Ruby VM. Thus, this code path is extremely sensitive: the less work we can do before we return control over to Ruby, the less impact allocation profiling has on the application.

The dynamic sampling rate mechanism we employ takes the current timestamp as an input, to decide if "enough time" has elapsed since it last readjusted itself. But "enough time" right now is *one second* and thus we can get away with using `CLOCK_MONOTONIC_COARSE` on Linux which is noticeably cheaper than the regular `CLOCK_MONOTONIC`.

**Additional Notes:**

Enabling the use of the monotonic clock _sometimes_ on the discrete dynamic sampler required it to "spill" some of its guts out to the caller, so that the caller could correctly use the coarse clock on the hot path.

**How to test the change?**

Here's my experiment to compare three different clock sources I evaluated:

```c++
 // Build with
 // `g++ time_sources.cpp -o time_sources -lbenchmark -lpthread`
 // where benchmark is <https://github.com/google/benchmark> aka
 // `apt install libbenchmark1 libbenchmark-dev` on ubuntu/debian

 #include <benchmark/benchmark.h>
 #include <x86intrin.h> // For __rdtsc
 #include <ctime>       // For clock_gettime

static void BM_RDTSC(benchmark::State& state) {
    for (auto _ : state) {
        benchmark::DoNotOptimize(__rdtsc());
    }
}

static void BM_ClockMonotonic(benchmark::State& state) {
    timespec ts;
    for (auto _ : state) {
        clock_gettime(CLOCK_MONOTONIC, &ts);
        benchmark::DoNotOptimize(ts);
    }
}

static void BM_ClockMonotonicCoarse(benchmark::State& state) {
    timespec ts;
    for (auto _ : state) {
        clock_gettime(CLOCK_MONOTONIC_COARSE, &ts);
        benchmark::DoNotOptimize(ts);
    }
}

BENCHMARK(BM_RDTSC);
BENCHMARK(BM_ClockMonotonic);
BENCHMARK(BM_ClockMonotonicCoarse);

BENCHMARK_MAIN();
```

Results on my machine:

```
./time_sources --benchmark_repetitions=10 --benchmark_report_aggregates_only=true
2024-07-19T10:48:20+01:00
Running ./time_sources
Run on (20 X 4900 MHz CPU s)
CPU Caches:
  L1 Data 48 KiB (x10)
  L1 Instruction 32 KiB (x10)
  L2 Unified 1280 KiB (x10)
  L3 Unified 24576 KiB (x1)
Load Average: 1.23, 1.30, 1.11
***WARNING*** CPU scaling is enabled, the benchmark real time measurements may be noisy and will incur extra overhead.
-------------------------------------------------------------------------
Benchmark                               Time             CPU   Iterations
-------------------------------------------------------------------------
BM_RDTSC_mean                        5.52 ns         5.52 ns           10
BM_RDTSC_median                      5.44 ns         5.44 ns           10
BM_RDTSC_stddev                     0.148 ns        0.147 ns           10
BM_RDTSC_cv                          2.67 %          2.67 %            10
BM_ClockMonotonic_mean               15.8 ns         15.8 ns           10
BM_ClockMonotonic_median             15.4 ns         15.4 ns           10
BM_ClockMonotonic_stddev             1.07 ns         1.07 ns           10
BM_ClockMonotonic_cv                 6.77 %          6.77 %            10
BM_ClockMonotonicCoarse_mean         5.92 ns         5.92 ns           10
BM_ClockMonotonicCoarse_median       5.93 ns         5.93 ns           10
BM_ClockMonotonicCoarse_stddev      0.041 ns        0.041 ns           10
BM_ClockMonotonicCoarse_cv           0.68 %          0.68 %            10
```

and here's the result of running `benchmarks/profiler_allocation.rb` comparing master to this branch:

```
ruby 2.7.7p221 (2022-11-24 revision 168ec2b1e5) [x86_64-linux]
Warming up --------------------------------------
Allocations (baseline)   1.431M i/100ms
Calculating -------------------------------------
Allocations (baseline)   14.370M (± 2.0%) i/s -    144.541M in  10.062635s

Warming up --------------------------------------
Allocations (master)     1.014M i/100ms
Calculating -------------------------------------
Allocations (master)     10.165M (± 1.0%) i/s -    102.390M in  10.074151s

Warming up --------------------------------------
Allocations (coarse)     1.179M i/100ms
Calculating -------------------------------------
Allocations (coarse)     11.495M (± 2.5%) i/s -    115.573M in  10.059971s

Comparison:
Allocations (baseline): 14369960.1 i/s
Allocations (coarse): 11495418.2 i/s - 1.25x  slower
Allocations (master): 10164615.7 i/s - 1.41x  slower
```

I've specifically used Ruby 2.7 for this comparison since this benchmark had a lot more variance (including baseline) on latter Rubies, and I wanted to isolate the specific changes to this code path.
