### PR TITLE
[PROF-10198] Set service/env for GitLab runs in benchmark platform

### DIFF
--- a/.gitlab/benchmarks.yml
+++ b/.gitlab/benchmarks.yml
@@ -30,6 +30,10 @@ variables:
     # Benchmark's env variables. Modify to tweak benchmark parameters.
     DD_TRACE_DEBUG: "false"
     DD_RUNTIME_METRICS_ENABLED: "true"
+
+    DD_SERVICE: "bp-ruby-gitlab"
+    DD_ENV: "staging"
+
     # Gitlab makes use of the rugged gem, which triggers the automatic no signals workaround use, see
     # https://docs.datadoghq.com/profiler/profiler_troubleshooting/ruby/#unexpected-failures-or-errors-from-ruby-gems-that-use-native-extensions-in-dd-trace-rb-1110
     # But in practice the endpoints we test it aren't affected, so we prefer to run the profiler in its default,


### PR DESCRIPTION
**What does this PR do?**

This PR sets the `DD_SERVICE` and `DD_ENV` for the gitlab benchmark in the benchmarking platform.

**Motivation:**

While testing a few changes, I realized these benchmarks were running with no name, thus ending up with `gitlab-runner` which is not a very clear name (and makes it hard to know what it is).

To align with the reliability environment (`rp-ruby-gitlab`) I've explicitly set a matching name.

**Additional Notes:**

N/A

**How to test the change?**

I've tested this with the `bp-runner`:

> ![image](https://github.com/user-attachments/assets/148e549c-0b4d-4182-93da-361d3fc7e129)
