### PR TITLE
[NO-TICKET] Fix profiler flaky test

### DIFF
--- a/spec/datadog/profiling/collectors/cpu_and_wall_time_worker_spec.rb
+++ b/spec/datadog/profiling/collectors/cpu_and_wall_time_worker_spec.rb
@@ -546,22 +546,33 @@ RSpec.describe Datadog::Profiling::Collectors::CpuAndWallTimeWorker do
         # and we clamp it if it goes over the limit.
         # But the total amount of allocations recorded should match the number we observed, and thus we record the
         # remainder above the clamped value as a separate "Skipped Samples" step.
-        it 'records skipped allocation samples when weights are clamped' do
-          start
+        context 'with a high allocation rate' do
+          let(:thread_that_allocates_as_fast_as_possible) { Thread.new { loop { BasicObject.new } } }
 
-          thread_that_allocates_as_fast_as_possible = Thread.new { loop { BasicObject.new } }
-
-          allocation_samples = try_wait_until do
-            samples = samples_from_pprof(recorder.serialize!).select { |it| it.values[:'alloc-samples'] > 0 }
-            samples if samples.any? { |it| it.labels[:'thread name'] == 'Skipped Samples' }
+          after do
+            thread_that_allocates_as_fast_as_possible.kill
+            thread_that_allocates_as_fast_as_possible.join
           end
 
-          thread_that_allocates_as_fast_as_possible.kill
-          thread_that_allocates_as_fast_as_possible.join
+          it 'records skipped allocation samples when weights are clamped' do
+            start
 
-          cpu_and_wall_time_worker.stop
+            # Trigger thread creation
+            thread_that_allocates_as_fast_as_possible
 
-          expect(allocation_samples).to_not be_empty
+            allocation_samples = try_wait_until do
+              samples = samples_from_pprof(recorder.serialize!).select { |it| it.values[:'alloc-samples'] > 0 }
+              samples if samples.any? { |it| it.labels[:'thread name'] == 'Skipped Samples' }
+            end
+
+            # Stop thread earlier, since it will slow down the Ruby VM
+            thread_that_allocates_as_fast_as_possible.kill
+            thread_that_allocates_as_fast_as_possible.join
+
+            cpu_and_wall_time_worker.stop
+
+            expect(allocation_samples).to_not be_empty
+          end
         end
       end
 

--- a/spec/datadog/profiling/collectors/cpu_and_wall_time_worker_spec.rb
+++ b/spec/datadog/profiling/collectors/cpu_and_wall_time_worker_spec.rb
@@ -547,6 +547,7 @@ RSpec.describe Datadog::Profiling::Collectors::CpuAndWallTimeWorker do
         # But the total amount of allocations recorded should match the number we observed, and thus we record the
         # remainder above the clamped value as a separate "Skipped Samples" step.
         context 'with a high allocation rate' do
+          let(:options) { { **super(), dynamic_sampling_rate_overhead_target_percentage: 0.1 } }
           let(:thread_that_allocates_as_fast_as_possible) { Thread.new { loop { BasicObject.new } } }
 
           after do


### PR DESCRIPTION
**What does this PR do?**

This PR [fixes a flaky test](https://app.circleci.com/pipelines/github/DataDog/dd-trace-rb/15605/workflows/5b32e4bb-155e-4a94-bf8b-980599eaafae/jobs/568892) introduced by #3792:

```
Failures:

  1) Datadog::Profiling::Collectors::CpuAndWallTimeWorker#start when allocation profiling is enabled with dynamic_sampling_rate_enabled records skipped allocation samples when weights are clamped
     Failure/Error: raise('Wait time exhausted!')
     
     RuntimeError:
       Wait time exhausted!
     # ./spec/support/synchronization_helpers.rb:97:in `try_wait_until'
     # ./spec/datadog/profiling/collectors/cpu_and_wall_time_worker_spec.rb:554:in `block (5 levels) in <top (required)>'
     # ./spec/spec_helper.rb:230:in `block (2 levels) in <top (required)>'
     # ./spec/spec_helper.rb:115:in `block (2 levels) in <top (required)>'
     # /usr/local/bundle/gems/webmock-3.13.0/lib/webmock/rspec.rb:37:in `block (2 levels) in <top (required)>'
     # /usr/local/bundle/gems/rspec-wait-0.0.9/lib/rspec/wait.rb:46:in `block (2 levels) in <top (required)>'

  2) Datadog::Profiling::Collectors::CpuAndWallTimeWorker#start when all threads are sleeping (no thread holds the Global VM Lock) is able to sample even when all threads are sleeping
     Failure/Error:
       expect(simulated_signal_delivery.to_f / trigger_sample_attempts).to (be >= 0.8), \
         "Expected at least 80% of signals to be simulated, stats: #{stats}, debug_failures: #{debug_failures}"
     
       Expected at least 80% of signals to be simulated, stats: {:trigger_sample_attempts=>60, :trigger_simulated_signal_delivery_attempts=>0, :simulated_signal_delivery=>0, :signal_handler_enqueued_sample=>60, :signal_handler_wrong_thread=>0, :postponed_job_skipped_already_existed=>0, :postponed_job_success=>60, :postponed_job_full=>0, :postponed_job_unknown_result=>0, :interrupt_thread_attempts=>60, :cpu_sampled=>60, :cpu_skipped=>0, :cpu_effective_sample_rate=>1.0, :cpu_sampling_time_ns_min=>78969, :cpu_sampling_time_ns_max=>141799, :cpu_sampling_time_ns_total=>5846823, :cpu_sampling_time_ns_avg=>97447.05, :allocation_sampled=>nil, :allocation_skipped=>nil, :allocation_effective_sample_rate=>nil, :allocation_sampling_time_ns_min=>nil, :allocation_sampling_time_ns_max=>nil, :allocation_sampling_time_ns_total=>nil, :allocation_sampling_time_ns_avg=>nil, :allocation_sampler_snapshot=>nil, :allocations_during_sample=>nil}, debug_failures: {(omitted)}
     # ./spec/datadog/profiling/collectors/cpu_and_wall_time_worker_spec.rb:397:in `block (4 levels) in <top (required)>'
     # ./spec/spec_helper.rb:230:in `block (2 levels) in <top (required)>'
     # ./spec/spec_helper.rb:115:in `block (2 levels) in <top (required)>'
     # /usr/local/bundle/gems/webmock-3.13.0/lib/webmock/rspec.rb:37:in `block (2 levels) in <top (required)>'
     # /usr/local/bundle/gems/rspec-wait-0.0.9/lib/rspec/wait.rb:46:in `block (2 levels) in <top (required)>'

Finished in 8 minutes 55 seconds (files took 1.3 seconds to load)
758 examples, 2 failures, 19 pending

Failed examples:

rspec ./spec/datadog/profiling/collectors/cpu_and_wall_time_worker_spec.rb:549 # Datadog::Profiling::Collectors::CpuAndWallTimeWorker#start when allocation profiling is enabled with dynamic_sampling_rate_enabled records skipped allocation samples when weights are clamped
rspec ./spec/datadog/profiling/collectors/cpu_and_wall_time_worker_spec.rb:379 # Datadog::Profiling::Collectors::CpuAndWallTimeWorker#start when all threads are sleeping (no thread holds the Global VM Lock) is able to sample even when all threads are sleeping
```

Specifically, the first test failed due to 4d7cbceced2cf9dd990e5b1f978731caa8481d24 -- the profiler was able to "keep up" with the allocation rate of the Ruby VM and never had to skip samples.

The second test then failed because the first test leaked the `thread_that_allocates_as_fast_as_possible`. For the second test, we require that the Ruby VM is fully idle for a certain period, and the leaked thread never allowed the Ruby VM to be idle.

The debug output from the second test (this test already has a bunch of extra custom output on failure since it has flaked in the past, although not always by its fault) showed this:

```
#<struct ProfileHelpers::Sample locations=[
#<struct ProfileHelpers::Frame base_label="initialize", path="/app/spec/datadog/profiling/collectors/cpu_and_wall_time_worker_spec.rb", lineno=552>, 
...
], values={:"cpu-samples"=>55, :"wall-time"=>549571399, :"cpu-time"=>470431681, :"alloc-samples"=>0, :"alloc-samples-unscaled"=>0},
labels={:"thread id"=>"1888 (34120)", :"thread name"=>"/app/spec/spec_helper.rb:245", :state=>"had cpu"}>,
```

E.g. you can see that the thread started by the other spec was hot on the cpu (lots of `cpu-time`) and that's why the Ruby VM was not idle.

**Motivation:**

The profiler aims for zero flaky tests always! If you find a flaky test in the profiler, I don't know about it, please do let me know :)

**Additional Notes:**

Interestingly, our leaked threads detector did flag this issue:

```
      with dynamic_sampling_rate_enabled

Spec leaked 1 threads in "Datadog::Profiling::Collectors::CpuAndWallTimeWorker#start when allocation profiling is enabled with dynamic_sampling_rate_enabled records skipped allocation samples when weights are clamped".
Ensure all threads are terminated when test finishes.
For help fixing this issue, see "Ensuring tests don't leak resources" in docs/DevelopmentGuide.md.
```

...I somewhat wish we were already 100% clean of leaked threads so that we could make a thread leak an instant test suite failure.

**How to test the change?**

Validate that CI is beautiful green.