### PR TITLE
Disable "Consider using fetch on hash key" cop

### DIFF
--- a/static-analysis.datadog.yml
+++ b/static-analysis.datadog.yml
@@ -4,6 +4,9 @@ rulesets:
   - ruby-security
   - ruby-best-practices:
     rules:
+      hash-fetch:
+        ignore:
+          - "**"
       percent-w:
         ignore:
           - "**"


### PR DESCRIPTION
This a static analysis check that does not align with our current Rubocop cops, and goes againts the standard Ruby Hash access syntax:
![Screenshot 2024-07-26 at 1 10 43 PM](https://github.com/user-attachments/assets/3bb070b4-e6a5-4751-b6db-b397f602a03d)
