### PR TITLE
Fix GraphQL patchers 'require' issue

### DIFF
--- a/lib/datadog/appsec/contrib/graphql/gateway/multiplex.rb
+++ b/lib/datadog/appsec/contrib/graphql/gateway/multiplex.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-require 'graphql/language/nodes'
+require 'graphql'
 
 require_relative '../../../instrumentation/gateway/argument'
 

--- a/lib/datadog/appsec/contrib/graphql/patcher.rb
+++ b/lib/datadog/appsec/contrib/graphql/patcher.rb
@@ -2,6 +2,7 @@
 
 require_relative '../patcher'
 require_relative 'gateway/watcher'
+require_relative 'appsec_trace' if Gem.loaded_specs['graphql'] && Gem.loaded_specs['graphql'].version >= Gem::Version.new('2.0.19')
 
 module Datadog
   module AppSec
@@ -22,7 +23,6 @@ module Datadog
           end
 
           def patch
-            require_relative 'appsec_trace'
             Gateway::Watcher.watch
             ::GraphQL::Schema.trace_with(AppSecTrace)
             Patcher.instance_variable_set(:@patched, true)

--- a/lib/datadog/appsec/contrib/graphql/patcher.rb
+++ b/lib/datadog/appsec/contrib/graphql/patcher.rb
@@ -2,7 +2,10 @@
 
 require_relative '../patcher'
 require_relative 'gateway/watcher'
-require_relative 'appsec_trace' if Gem.loaded_specs['graphql'] && Gem.loaded_specs['graphql'].version >= Gem::Version.new('2.0.19')
+
+if Gem.loaded_specs['graphql'] && Gem.loaded_specs['graphql'].version >= Gem::Version.new('2.0.19')
+  require_relative 'appsec_trace'
+end
 
 module Datadog
   module AppSec

--- a/lib/datadog/tracing/contrib/graphql/unified_trace.rb
+++ b/lib/datadog/tracing/contrib/graphql/unified_trace.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-require 'graphql/tracing'
+require 'graphql'
 
 module Datadog
   module Tracing

--- a/lib/datadog/tracing/contrib/graphql/unified_trace_patcher.rb
+++ b/lib/datadog/tracing/contrib/graphql/unified_trace_patcher.rb
@@ -1,6 +1,8 @@
 # frozen_string_literal: true
 
-require_relative 'unified_trace' if Gem.loaded_specs['graphql'] && Gem.loaded_specs['graphql'].version >= Gem::Version.new('2.0.19')
+if Gem.loaded_specs['graphql'] && Gem.loaded_specs['graphql'].version >= Gem::Version.new('2.0.19')
+  require_relative 'unified_trace'
+end
 
 module Datadog
   module Tracing

--- a/lib/datadog/tracing/contrib/graphql/unified_trace_patcher.rb
+++ b/lib/datadog/tracing/contrib/graphql/unified_trace_patcher.rb
@@ -1,5 +1,7 @@
 # frozen_string_literal: true
 
+require_relative 'unified_trace' if Gem.loaded_specs['graphql'] && Gem.loaded_specs['graphql'].version >= Gem::Version.new('2.0.19')
+
 module Datadog
   module Tracing
     module Contrib
@@ -9,7 +11,6 @@ module Datadog
           module_function
 
           def patch!(schemas, options)
-            require_relative 'unified_trace'
             if schemas.empty?
               ::GraphQL::Schema.trace_with(UnifiedTrace, **options)
             else


### PR DESCRIPTION
<!--
Check out the
https://github.com/DataDog/dd-trace-rb/blob/master/docs/DevelopmentGuide.md
for guidance on how to set up your development environment,
run the test suite, write new integrations, and more.
-->

**What does this PR do?**
<!-- A brief description of the change being made with this pull request. -->
Making a custom tracer based on unified_tracer should now not need to require explicitly the unified_tracer.rb file anymore. This also fixes the problem with currently unreleased appsec_tracer.

**Motivation:**
<!-- What inspired you to submit this pull request? -->
Fixes issue #3804 

**Additional Notes:**
<!-- Anything else we should know when reviewing? -->

**How to test the change?**
<!--
Describe here how the change can be validated.
You are strongly encouraged to provide automated tests for this PR (unit or integration).
If this change cannot be feasibly tested, please explain why,
unless the change does not modify code (e.g. only modifies docs, comments).
-->

Create a Rails + GraphQL app with a custom tracer that includes unified_tracer. GraphQL AppSec test app is using this so if system-tests passes, it works.

Unsure? Have a question? Request a review!
