### PR TITLE
Add directives support for graphql appsec

### DIFF
--- a/lib/datadog/appsec/contrib/graphql/gateway/multiplex.rb
+++ b/lib/datadog/appsec/contrib/graphql/gateway/multiplex.rb
@@ -32,28 +32,38 @@ module Datadog
               args = {}
               @multiplex.queries.each_with_index do |query, index|
                 resolver_args = {}
+                resolver_dirs = {}
                 selections = (query.selected_operation.selections.dup if query.selected_operation) || []
                 # Iterative tree traversal
                 while selections.any?
                   selection = selections.shift
-                  if selection.arguments.any?
-                    selection.arguments.each do |arg|
-                      resolver_args[arg.name] =
-                        if arg.value.is_a?(::GraphQL::Language::Nodes::VariableIdentifier)
-                          query.provided_variables[arg.value.name]
-                        else
-                          arg.value
-                        end
-                    end
+                  set_hash_with_variables(resolver_args, selection.arguments, query.provided_variables)
+                  selection.directives.each do |dir|
+                    resolver_dirs[dir.name] ||= {}
+                    set_hash_with_variables(resolver_dirs[dir.name], dir.arguments, query.provided_variables)
                   end
                   selections.concat(selection.selections)
                 end
-                unless resolver_args.empty?
-                  args[query.operation_name || "query#{index + 1}"] ||= []
-                  args[query.operation_name || "query#{index + 1}"] << resolver_args
-                end
+                next if resolver_args.empty? && resolver_dirs.empty?
+
+                args_resolver = (args[query.operation_name || "query#{index + 1}"] ||= [])
+                # We don't want to add empty hashes so we check again if the arguments and directives are empty
+                args_resolver << resolver_args unless resolver_args.empty?
+                args_resolver << resolver_dirs unless resolver_dirs.empty?
               end
               args
+            end
+
+            # Set the resolver hash (resolver_args and resolver_dirs) with the arguments and provided variables
+            def set_hash_with_variables(resolver_hash, arguments, provided_variables)
+              arguments.each do |arg|
+                resolver_hash[arg.name] =
+                  if arg.value.is_a?(::GraphQL::Language::Nodes::VariableIdentifier)
+                    provided_variables[arg.value.name]
+                  else
+                    arg.value
+                  end
+              end
             end
           end
         end

--- a/sig/datadog/appsec/contrib/graphql/gateway/multiplex.rbs
+++ b/sig/datadog/appsec/contrib/graphql/gateway/multiplex.rbs
@@ -19,6 +19,8 @@ module Datadog
             private
 
             def create_arguments_hash: () -> Hash[String, Array[Hash[String, String]]]
+
+            def set_hash_with_variables: (Hash[String, String] resolver_hash, Array[GraphQL::Language::Nodes::Argument] arguments, Hash[String, String|Integer] provided_variables) -> void
           end
         end
       end

--- a/spec/datadog/appsec/contrib/graphql/appsec_trace_spec.rb
+++ b/spec/datadog/appsec/contrib/graphql/appsec_trace_spec.rb
@@ -28,10 +28,10 @@ RSpec.describe Datadog::AppSec::Contrib::GraphQL::AppSecTrace do
     expect(result.to_h['errors']).to eq(
       [
         {
-          'message' => "Field 'error' doesn't exist on type 'TestGraphQLQuery'",
+          'message' => "Field 'error' doesn't exist on type 'Query'",
           'locations' => [{ 'line' => 1, 'column' => 13 }],
           'path' => ['query test', 'error'],
-          'extensions' => { 'code' => 'undefinedField', 'typeName' => 'TestGraphQLQuery', 'fieldName' => 'error' }
+          'extensions' => { 'code' => 'undefinedField', 'typeName' => 'Query', 'fieldName' => 'error' }
         }
       ]
     )
@@ -89,10 +89,10 @@ RSpec.describe Datadog::AppSec::Contrib::GraphQL::AppSecTrace do
           'errors' =>
           [
             {
-              'message' => "Field 'error' doesn't exist on type 'TestGraphQLQuery'",
+              'message' => "Field 'error' doesn't exist on type 'Query'",
               'locations' => [{ 'line' => 1, 'column' => 13 }],
               'path' => ['query test', 'error'],
-              'extensions' => { 'code' => 'undefinedField', 'typeName' => 'TestGraphQLQuery', 'fieldName' => 'error' }
+              'extensions' => { 'code' => 'undefinedField', 'typeName' => 'Query', 'fieldName' => 'error' }
             }
           ]
         }

--- a/spec/datadog/appsec/contrib/graphql/integration_test_spec.rb
+++ b/spec/datadog/appsec/contrib/graphql/integration_test_spec.rb
@@ -287,7 +287,7 @@ RSpec.describe 'GraphQL integration tests',
             it do
               post '/graphql', query: 'mutation { createUser(name: "$testattack") { user { name, id } } }'
               expect(JSON.parse(last_response.body)['errors'][0]['title']).to eq('Blocked')
-              expect(Users.users['$testattack']).to be_nil
+              expect(TestGraphQL::Users.users['$testattack']).to be_nil
             end
           end
         end

--- a/spec/datadog/appsec/contrib/graphql/integration_test_spec.rb
+++ b/spec/datadog/appsec/contrib/graphql/integration_test_spec.rb
@@ -459,5 +459,118 @@ RSpec.describe 'GraphQL integration tests',
           end
         end
       end
+
+      describe 'a query with directives' do
+        subject(:response) { post '/graphql', _json: queries }
+
+        context 'with a non-triggering multiplex' do
+          let(:appsec_ruleset) { blocking_testattack }
+          let(:queries) do
+            [
+              {
+                'query' => 'query Test($format: String!) { user(id: 1) { name @case(format: $format) } }',
+                'variables' => { 'format' => 'upcase' }
+              }
+            ]
+          end
+
+          it do
+            expect(last_response.body).to eq(
+              [
+                { 'data' => { 'user' => { 'name' => 'BITS' } } },
+              ].to_json
+            )
+            expect(spans).to include(
+              an_object_having_attributes(
+                name: 'graphql.parse',
+              ),
+              an_object_having_attributes(
+                name: 'graphql.execute_multiplex',
+              ),
+              an_object_having_attributes(
+                name: 'graphql.execute',
+              )
+            )
+          end
+
+          it_behaves_like 'a POST 200 span'
+          it_behaves_like 'a trace with AppSec tags'
+          it_behaves_like 'a trace without AppSec events'
+        end
+
+        context 'with a multiplex containing a non-blocking query' do
+          let(:appsec_ruleset) { nonblocking_testattack }
+          let(:queries) do
+            [
+              {
+                'query' => 'query Test($format: String!) { user(id: 1) { name @case(format: $format) } }',
+                'variables' => { 'format' => '$testattack' }
+              }
+            ]
+          end
+
+          it do
+            expect(last_response.body).to eq(
+              [
+                { 'data' => { 'user' => { 'name' => 'Bits' } } }
+              ].to_json
+            )
+            expect(spans).to include(
+              an_object_having_attributes(
+                name: 'graphql.parse',
+              )
+            ).once
+            expect(spans).to include(
+              an_object_having_attributes(
+                name: 'graphql.execute_multiplex',
+              )
+            ).once
+            expect(spans).to include(
+              an_object_having_attributes(
+                name: 'graphql.execute',
+              )
+            ).once
+          end
+
+          it_behaves_like 'a POST 200 span'
+          it_behaves_like 'a trace with AppSec tags'
+          it_behaves_like 'a trace with AppSec events'
+        end
+
+        context 'with a multiplex containing a blocking query' do
+          let(:appsec_ruleset) { blocking_testattack }
+          let(:queries) do
+            [
+              {
+                'query' => 'query Test($format: String!) { user(id: 1) { name @case(format: $format) } }',
+                'variables' => { 'format' => '$testattack' }
+              }
+            ]
+          end
+
+          it do
+            expect(last_response.body).to eq(
+              [
+                { 'errors' => [{ 'title' => 'Blocked', 'detail' => 'Security provided by Datadog.' }] }
+              ].to_json
+            )
+            expect(spans).to include(
+              an_object_having_attributes(
+                name: 'graphql.parse',
+              )
+            ).once
+            expect(spans).to include(
+              an_object_having_attributes(
+                name: 'graphql.execute_multiplex',
+              )
+            ).once
+            expect(spans).not_to include(
+              an_object_having_attributes(
+                name: 'graphql.execute',
+              )
+            )
+          end
+        end
+      end
     end
   end

--- a/spec/datadog/tracing/contrib/graphql/support/application.rb
+++ b/spec/datadog/tracing/contrib/graphql/support/application.rb
@@ -31,15 +31,16 @@ RSpec.shared_context 'with GraphQL schema' do
   # TODO: Cleaner way to reset the schema between tests (and most likely clean ::GraphQL::Schema too)
   # stub_const is required for GraphqlController, and we cannot use variables defined in let blocks in stub_const
   before do
-    Object.send(:remove_const, :TestGraphQLSchema) if defined?(TestGraphQLSchema)
-    Object.send(:remove_const, :TestGraphQLQuery) if defined?(TestGraphQLQuery)
-    Object.send(:remove_const, :TestGraphQLMutationType) if defined?(TestGraphQLMutationType)
-    Object.send(:remove_const, :Users) if defined?(Users)
-    Object.send(:remove_const, :TestUserType) if defined?(TestUserType)
+    TestGraphQL.send(:remove_const, :Case) if defined?(TestGraphQL::Case)
+    TestGraphQL.send(:remove_const, :Schema) if defined?(TestGraphQL::Schema)
+    TestGraphQL.send(:remove_const, :Query) if defined?(TestGraphQL::Query)
+    TestGraphQL.send(:remove_const, :MutationType) if defined?(TestGraphQL::MutationType)
+    TestGraphQL.send(:remove_const, :Users) if defined?(TestGraphQL::Users)
+    TestGraphQL.send(:remove_const, :UserType) if defined?(TestGraphQL::UserType)
     load 'spec/datadog/tracing/contrib/graphql/support/application_schema.rb'
   end
   let(:operation) { Datadog::AppSec::Reactive::Operation.new('test') }
-  let(:schema) { TestGraphQLSchema }
+  let(:schema) { TestGraphQL::Schema }
 end
 
 RSpec.shared_context 'with GraphQL multiplex' do
@@ -94,9 +95,9 @@ RSpec.shared_context 'GraphQL test application' do
                          context: {}
                        }
                      end
-                     TestGraphQLSchema.multiplex(queries)
+                     TestGraphQL::Schema.multiplex(queries)
                    else
-                     TestGraphQLSchema.execute(
+                     TestGraphQL::Schema.execute(
                        query: params[:query],
                        operation_name: params[:operationName],
                        variables: prepare_variables(params[:variables]),

--- a/spec/datadog/tracing/contrib/graphql/support/application_schema.rb
+++ b/spec/datadog/tracing/contrib/graphql/support/application_schema.rb
@@ -7,10 +7,10 @@ module TestGraphQL
     locations FIELD
 
     TRANSFORMS = [
-      "upcase",
-      "downcase",
-      # ??
-    ]
+      'upcase',
+      'downcase',
+    ].freeze
+
     # Implement the Directive API
     def self.resolve(object, arguments, context)
       path = context.namespace(:interpreter)[:current_path]
@@ -27,9 +27,7 @@ module TestGraphQL
             break
           end
         end
-        if response
-          response[last] = return_value
-        end
+        response[last] = return_value if response
         nil
       end
     end

--- a/spec/datadog/tracing/contrib/graphql/support/application_schema.rb
+++ b/spec/datadog/tracing/contrib/graphql/support/application_schema.rb
@@ -1,80 +1,116 @@
 require 'graphql'
 require 'json'
 
-class TestUserType < ::GraphQL::Schema::Object
-  field :id, ::GraphQL::Types::ID, null: false
-  field :name, ::GraphQL::Types::String, null: true
-  field :created_at, ::GraphQL::Types::String, null: false
-  field :updated_at, ::GraphQL::Types::String, null: false
-end
+module TestGraphQL
+  class Case < GraphQL::Schema::Directive
+    argument :format, String
+    locations FIELD
 
-class TestGraphQLQuery < ::GraphQL::Schema::Object
-  field :user, TestUserType, null: false, description: 'Find an user by ID' do
-    argument :id, ::GraphQL::Types::ID, required: true
-  end
-
-  def user(id:)
-    return OpenStruct.new(id: id, name: 'Caniche') if Integer(id) == 10
-
-    OpenStruct.new(id: id, name: 'Bits')
-  end
-
-  field :userByName, TestUserType, null: false, description: 'Find an user by name' do
-    argument :name, ::GraphQL::Types::String, required: true
-  end
-
-  # rubocop:disable Naming/MethodName
-  def userByName(name:)
-    return OpenStruct.new(id: 10, name: name) if name == 'Caniche'
-
-    OpenStruct.new(id: 1, name: name)
-  end
-
-  field :mutationUserByName, TestUserType, null: false, description: 'Find an user by name' do
-    argument :name, ::GraphQL::Types::String, required: true
-  end
-
-  def mutationUserByName(name:)
-    if Users.users[name].nil?
-      ::GraphQL::ExecutionError.new('User not found')
-    else
-      OpenStruct.new(id: Users.users[name], name: name)
-    end
-  end
-  # rubocop:enable Naming/MethodName
-end
-
-class Users
-  class << self
-    def users
-      @users ||= {}
-    end
-  end
-end
-
-class TestGraphQLMutationType < ::GraphQL::Schema::Object
-  class TestGraphQLMutation < ::GraphQL::Schema::Mutation
-    argument :name, ::GraphQL::Types::String, required: true
-
-    field :user, TestUserType
-    field :errors, [String], null: false
-
-    def resolve(name:)
-      if Users.users.nil? || Users.users[name].nil?
-        Users.users ||= {}
-        item = OpenStruct.new(id: Users.users.size + 1, name: name)
-        Users.users[name] = Users.users.size + 1
-        { user: item, errors: [] }
-      else
-        ::GraphQL::ExecutionError.new('User already exists')
+    TRANSFORMS = [
+      "upcase",
+      "downcase",
+      # ??
+    ]
+    # Implement the Directive API
+    def self.resolve(object, arguments, context)
+      path = context.namespace(:interpreter)[:current_path]
+      return_value = yield
+      transform_name = arguments[:format]
+      if TRANSFORMS.include?(transform_name) && return_value.respond_to?(transform_name)
+        return_value = return_value.public_send(transform_name)
+        response = context.namespace(:interpreter_runtime)[:runtime].final_result
+        *keys, last = path
+        keys.each do |key|
+          if response && (response = response[key])
+            next
+          else
+            break
+          end
+        end
+        if response
+          response[last] = return_value
+        end
+        nil
       end
     end
   end
 
-  field :create_user, mutation: TestGraphQLMutation
-end
+  class UserType < ::GraphQL::Schema::Object
+    field :id, ::GraphQL::Types::ID, null: false
+    field :name, ::GraphQL::Types::String, null: true
+    field :created_at, ::GraphQL::Types::String, null: false
+    field :updated_at, ::GraphQL::Types::String, null: false
+  end
 
-class TestGraphQLSchema < ::GraphQL::Schema
-  mutation(TestGraphQLMutationType)
-  query(TestGraphQLQuery)
+  class Query < ::GraphQL::Schema::Object
+    field :user, UserType, null: false, description: 'Find an user by ID' do
+      argument :id, ::GraphQL::Types::ID, required: true
+    end
+
+    def user(id:)
+      return OpenStruct.new(id: id, name: 'Caniche') if Integer(id) == 10
+
+      OpenStruct.new(id: id, name: 'Bits')
+    end
+
+    field :userByName, UserType, null: false, description: 'Find an user by name' do
+      argument :name, ::GraphQL::Types::String, required: true
+    end
+
+    # rubocop:disable Naming/MethodName
+    def userByName(name:)
+      return OpenStruct.new(id: 10, name: name) if name == 'Caniche'
+
+      OpenStruct.new(id: 1, name: name)
+    end
+
+    field :mutationUserByName, UserType, null: false, description: 'Find an user by name' do
+      argument :name, ::GraphQL::Types::String, required: true
+    end
+
+    def mutationUserByName(name:)
+      if Users.users[name].nil?
+        ::GraphQL::ExecutionError.new('User not found')
+      else
+        OpenStruct.new(id: Users.users[name], name: name)
+      end
+    end
+    # rubocop:enable Naming/MethodName
+  end
+
+  class Users
+    class << self
+      def users
+        @users ||= {}
+      end
+    end
+  end
+
+  class MutationType < ::GraphQL::Schema::Object
+    class Mutation < ::GraphQL::Schema::Mutation
+      argument :name, ::GraphQL::Types::String, required: true
+
+      field :user, UserType
+      field :errors, [String], null: false
+
+      def resolve(name:)
+        if Users.users.nil? || Users.users[name].nil?
+          Users.users ||= {}
+          item = OpenStruct.new(id: Users.users.size + 1, name: name)
+          Users.users[name] = Users.users.size + 1
+          { user: item, errors: [] }
+        else
+          ::GraphQL::ExecutionError.new('User already exists')
+        end
+      end
+    end
+
+    field :create_user, mutation: Mutation
+  end
+
+  class Schema < ::GraphQL::Schema
+    mutation(MutationType)
+    query(Query)
+    directive(Case)
+  end
 end

--- a/vendor/rbs/graphql/0/graphql.rbs
+++ b/vendor/rbs/graphql/0/graphql.rbs
@@ -22,6 +22,9 @@ module GraphQL
 
       class Field
       end
+
+      class Argument
+      end
     end
   end
 


### PR DESCRIPTION
<!--
Check out the
https://github.com/DataDog/dd-trace-rb/blob/master/docs/DevelopmentGuide.md
for guidance on how to set up your development environment,
run the test suite, write new integrations, and more.
-->

**What does this PR do?**
<!-- A brief description of the change being made with this pull request. -->
This add support for directive on GraphQL Threats protection

**Motivation:**
<!-- What inspired you to submit this pull request? -->
This was missed during development and found using system-tests

**Additional Notes:**
<!-- Anything else we should know when reviewing? -->
This also reorganize the integration tests a bit, and add a custom directive to the test schema.

**How to test the change?**
<!--
Describe here how the change can be validated.
You are strongly encouraged to provide automated tests for this PR (unit or integration).
If this change cannot be feasibly tested, please explain why,
unless the change does not modify code (e.g. only modifies docs, comments).
-->

This includes integration tests accordingly. This can also be tests using this branch of system-tests :
https://github.com/DataDog/system-tests/tree/vpellan/ruby-graphql-threats

Unsure? Have a question? Request a review!
