### PR TITLE
Fix symlink from injection artifact

### DIFF
--- a/.gitlab/prepare-oci-package.sh
+++ b/.gitlab/prepare-oci-package.sh
@@ -6,7 +6,7 @@ mkdir sources
 
 cp ../lib-injection/host_inject.rb sources
 # Kubernetes injection expects a different path
-ln -s sources/host_inject.rb sources/auto_inject.rb
+ln -rs sources/host_inject.rb sources/auto_inject.rb
 
 cp -r ../tmp/${ARCH}/* sources
 


### PR DESCRIPTION
**What does this PR do?**

From
```
~ % docker run -ti --rm ghcr.io/datadog/dd-trace-rb/dd-lib-ruby-init:latest_snapshot sh
/datadog-init $ ls -al package/
total 36
drwxr-xr-x    1 datadog  datadog       4096 Jul 30 20:08 .
drwxr-xr-x    1 root     root          4096 Jul 30 20:08 ..
drwxr-xr-x    1 datadog  datadog       4096 Jul 30 20:07 2.7.0
drwxr-xr-x    1 datadog  datadog       4096 Jul 30 20:08 3.0.0
drwxr-xr-x    1 datadog  datadog       4096 Jul 30 20:08 3.1.0
drwxr-xr-x    1 datadog  datadog       4096 Jul 30 20:08 3.2.0
lrwxrwxrwx    1 datadog  datadog         22 Jul 30 20:08 auto_inject.rb -> sources/host_inject.rb
-rw-r--r--    1 datadog  datadog       7868 Jul 30 20:08 host_inject.rb
-rw-r--r--    1 datadog  datadog         42 Jul 30 20:08 version
/datadog-init $ cat package/auto_inject.rb
cat: can't open 'package/auto_inject.rb': No such file or directory
```
To 

```
dd-trace-rb tonycthsu/fix-link % d run -ti --rm ghcr.io/datadog/dd-trace-rb/dd-lib-ruby-init:2631bfb0795c530f340a334cdb7555ec185ec6ab sh -c "ls -al package"
total 36
drwxr-xr-x    1 datadog  datadog       4096 Jul 31 11:41 .
drwxr-xr-x    1 root     root          4096 Jul 31 11:41 ..
drwxr-xr-x    1 datadog  datadog       4096 Jul 31 11:41 2.7.0
drwxr-xr-x    1 datadog  datadog       4096 Jul 31 11:41 3.0.0
drwxr-xr-x    1 datadog  datadog       4096 Jul 31 11:41 3.1.0
drwxr-xr-x    1 datadog  datadog       4096 Jul 31 11:41 3.2.0
lrwxrwxrwx    1 datadog  datadog         14 Jul 31 11:41 auto_inject.rb -> host_inject.rb
-rw-r--r--    1 datadog  datadog       7868 Jul 31 11:41 host_inject.rb
-rw-r--r--    1 datadog  datadog         42 Jul 31 11:41 version
```