### PR TITLE
[PROF-10128] Fix profiling benchmarking configuration still having auto_instrument overhead

### DIFF
--- a/.gitlab/benchmarks.yml
+++ b/.gitlab/benchmarks.yml
@@ -85,6 +85,7 @@ only-profiling:
   variables:
     DD_BENCHMARKS_CONFIGURATION: only-profiling
     DD_PROFILING_ENABLED: "true"
+    ADD_TO_GEMFILE: "gem 'datadog', github: 'datadog/dd-trace-rb', ref: '$CI_COMMIT_SHA'"
 
 only-profiling-alloc:
   extends: .benchmarks
@@ -92,6 +93,7 @@ only-profiling-alloc:
     DD_BENCHMARKS_CONFIGURATION: only-profiling
     DD_PROFILING_ENABLED: "true"
     DD_PROFILING_ALLOCATION_ENABLED: "true"
+    ADD_TO_GEMFILE: "gem 'datadog', github: 'datadog/dd-trace-rb', ref: '$CI_COMMIT_SHA'"
 
 only-profiling-alloc-ddprof:
   extends: .benchmarks
@@ -100,6 +102,7 @@ only-profiling-alloc-ddprof:
     DD_BENCHMARKS_CONFIGURATION: only-profiling
     DD_PROFILING_ENABLED: "true"
     DD_PROFILING_ALLOCATION_ENABLED: "true"
+    ADD_TO_GEMFILE: "gem 'datadog', github: 'datadog/dd-trace-rb', ref: '$CI_COMMIT_SHA'"
 
 only-profiling-heap:
   extends: .benchmarks
@@ -108,6 +111,7 @@ only-profiling-heap:
     DD_PROFILING_ENABLED: "true"
     DD_PROFILING_ALLOCATION_ENABLED: "true"
     DD_PROFILING_EXPERIMENTAL_HEAP_ENABLED: "true"
+    ADD_TO_GEMFILE: "gem 'datadog', github: 'datadog/dd-trace-rb', ref: '$CI_COMMIT_SHA'"
 
 only-profiling-crashtracking:
   extends: .benchmarks


### PR DESCRIPTION
**What does this PR do?**

This PR tweaks the `ADD_TO_GEMFILE` environment variable for benchmarking configurations where only the profiler should be active to not include `require: 'datadog/auto_instrument'`.

It turns out this change was added in #3614 when we fixed the benchmarks not running. Loading the instrumentation code and then disabling tracing has a measurable performance overhead vs not loading it at all (20% regression of median throughput in high load gitlab tests).

**Motivation:**

I expect that with this change, the `only-profiling` configuration will reflect historical data we had before the change in #3614.

This is relevant because we use this data as basis for comparison with other profiling features (e.g. allocation) and thus it's important to have a correct baseline.

**Additional Notes:**

I noticed a similar-ish configuration issue in our reliability environment. I'll open a separate PR for that one as well.

**How to test the change?**

I've tested a similar configuration using `bp-runner` locally and confirmed that overhead is reduced. Once we merge this in, I'll validate that the nightly runs show performance is back to where it was on the 18th of April.