### PR TITLE
Pin passenger version for integration test

### DIFF
--- a/integration/apps/rack/Gemfile
+++ b/integration/apps/rack/Gemfile
@@ -4,7 +4,11 @@ source "https://rubygems.org"
 
 gem 'puma'
 gem 'unicorn'
-gem 'passenger'
+if RUBY_VERSION < '2.6.0'
+  gem 'passenger', '< 6.0.23'
+else
+  gem 'passenger'
+end
 gem 'rack'
 gem 'rackup' if RUBY_VERSION >= '2.4'  # The `rackup` is its own gem since Rack 3.0
 


### PR DESCRIPTION
**What does this PR do?**

Fix integration test on Ruby 2.5

```
[36mapp_1                 |[0m 
[36mapp_1                 |[0m [1m[31mSome required software is not installed.[0m[37m[40m
[36mapp_1                 |[0m But don't worry, this installer will tell you how to install them.
[36mapp_1                 |[0m [1mPress Enter to continue, or Ctrl-C to abort.[0m[37m[40m
```
