### PR TITLE
Fix ruby 2.5 opentelemetry sdk trace id generator

### DIFF
--- a/lib/datadog/opentelemetry/sdk/id_generator.rb
+++ b/lib/datadog/opentelemetry/sdk/id_generator.rb
@@ -15,7 +15,7 @@ module Datadog
           # @return [String] a valid trace ID.
           def generate_trace_id
             loop do
-              id = Random.bytes(8) # DEV: Change to 16 (16*8-byte) when 128-bit trace_id is supported.
+              id = Random.new.bytes(8) # DEV: Change to 16 (16*8-byte) when 128-bit trace_id is supported.
               return id unless id == ::OpenTelemetry::Trace::INVALID_SPAN_ID
             end
           end


### PR DESCRIPTION
<!--
Check out the
https://github.com/DataDog/dd-trace-rb/blob/master/docs/DevelopmentGuide.md
for guidance on how to set up your development environment,
run the test suite, write new integrations, and more.
-->

**What does this PR do?**

`Opentelemetry::SDK::IdGenerator` was depending on `Random.bytes` but that method was not introduced until [Ruby 2.6](https://bugs.ruby-lang.org/issues/4938). Existing specs were failing for the Ruby 2.5 build. 

```shell
Failures:

  1) Datadog::OpenTelemetry with Datadog TraceProvider #record_exception attributes is nil sets records an exception event and sets span error tags using the Exception object
     Failure/Error: id = Random.bytes(8) # DEV: Change to 16 (16*8-byte) when 128-bit trace_id is supported.

     NoMethodError:
       undefined method `bytes' for Random:Class
     # ./lib/datadog/opentelemetry/sdk/id_generator.rb:18:in `block in generate_trace_id'
     # ./lib/datadog/opentelemetry/sdk/id_generator.rb:17:in `loop'
     # ./lib/datadog/opentelemetry/sdk/id_generator.rb:17:in `generate_trace_id'
     # /usr/local/bundle/gems/opentelemetry-sdk-1.0.3/lib/opentelemetry/sdk/trace/tracer_provider.rb:136:in `internal_create_span'
     # /usr/local/bundle/gems/opentelemetry-sdk-1.0.3/lib/opentelemetry/sdk/trace/tracer.rb:41:in `start_span'
     # ./spec/datadog/opentelemetry_spec.rb:614:in `block (4 levels) in <top (required)>'
     # ./spec/datadog/opentelemetry_spec.rb:609:in `block (4 levels) in <top (required)>'
     # ./spec/spec_helper.rb:230:in `block (2 levels) in <top (required)>'
     # ./spec/spec_helper.rb:115:in `block (2 levels) in <top (required)>'
     # /usr/local/bundle/gems/webmock-3.23.1/lib/webmock/rspec.rb:39:in `block (2 levels) in <top (required)>'
     # /usr/local/bundle/gems/rspec-wait-0.0.10/lib/rspec/wait.rb:47:in `block (2 levels) in <top (required)>'

Finished in 0.0265 seconds (files took 3.64 seconds to load)
2 examples, 1 failure

Failed examples:

rspec './spec/datadog/opentelemetry_spec.rb[1:1:6:1:1]' # Datadog::OpenTelemetry with Datadog TraceProvider #record_exception attributes is nil sets records an exception event and sets span error tags using the Exception object
```

**Motivation:**

I was testing trying to utilize OpenTelemetry instrumentation with v 2.2.0 of the Datadog tracer gem and 1.0.3 of the opentelemetry-sdk while running Ruby 2.5.9 and ran into the same exception thrown from the spec. I dug into the stack trace and confirmed in the console and Ruby documentation that `.bytes` is not available as class method until 2.6.

**Additional Notes:**

This might technically be mutating global state during the test as I believe it changes the default seed PRNG that is used by `Random`, but I would hope that no tests are dependent on that being consistent.

**How to test the change?**

This change only encompassed getting failing tests to pass. I also tested it under 3.2 to confirm it was compatible with the next major version.

Unsure? Have a question? Request a review!
