### PR TITLE
[PROF-10241] Fix issue in tests by simplifying `at_fork` monkey patch

### DIFF
--- a/lib/datadog/core/utils/at_fork_monkey_patch.rb
+++ b/lib/datadog/core/utils/at_fork_monkey_patch.rb
@@ -3,9 +3,12 @@
 module Datadog
   module Core
     module Utils
-      # Monkey patches `Kernel#fork` and similar functions, adding a `Process#datadog_at_fork` callback mechanism which
+      # Monkey patches `Kernel#fork` and similar functions, adding an `at_fork` callback mechanism which
       # is used to restart observability after the VM forks (e.g. in multiprocess Ruby apps).
       module AtForkMonkeyPatch
+        AT_FORK_CHILD_BLOCKS = [] # rubocop:disable Style/MutableConstant Used to store blocks to run, mutable by design.
+        private_constant :AT_FORK_CHILD_BLOCKS
+
         def self.supported?
           Process.respond_to?(:fork)
         end
@@ -28,14 +31,28 @@ module Datadog
           true
         end
 
-        # Adds `datadog_at_fork` behavior; see parent module for details.
+        def self.run_at_fork_blocks(stage)
+          raise(ArgumentError, "Unsupported stage #{stage}") unless stage == :child
+
+          AT_FORK_CHILD_BLOCKS.each(&:call)
+        end
+
+        def self.at_fork(stage, &block)
+          raise(ArgumentError, "Unsupported stage #{stage}") unless stage == :child
+          raise(ArgumentError, 'Missing block argument') unless block
+
+          AT_FORK_CHILD_BLOCKS << block
+
+          true
+        end
+
+        # Adds `at_fork` behavior; see parent module for details.
         module KernelMonkeyPatch
           def fork
             # If a block is provided, it must be wrapped to trigger callbacks.
             child_block = if block_given?
                             proc do
-                              # Trigger :child callback
-                              datadog_at_fork_blocks[:child].each(&:call) if datadog_at_fork_blocks.key?(:child)
+                              AtForkMonkeyPatch.run_at_fork_blocks(:child)
 
                               # Invoke original block
                               yield
@@ -50,30 +67,20 @@ module Datadog
             # If we're in the fork, result = nil: trigger child callbacks.
             # If we're in the parent, result = pid: we do nothing.
             # (If it gets called with a block, it only returns on the parent)
-            datadog_at_fork_blocks[:child].each(&:call) if result.nil? && datadog_at_fork_blocks.key?(:child)
+            AtForkMonkeyPatch.run_at_fork_blocks(:child) if result.nil?
 
             result
           end
-
-          module_function
-
-          def datadog_at_fork_blocks
-            # Blocks are shared across all users of this module,
-            # e.g. Process#fork, Kernel#fork, etc. should all invoke the same callbacks.
-            @@datadog_at_fork_blocks ||= {} # rubocop:disable Style/ClassVars
-          end
         end
 
-        # Adds `datadog_at_fork` behavior; see parent module for details.
+        # Adds `at_fork` behavior; see parent module for details.
         module ProcessMonkeyPatch
           # Hook provided by Ruby 3.1+ for observability libraries that want to know about fork, see
           # https://github.com/ruby/ruby/pull/5017 and https://bugs.ruby-lang.org/issues/17795
           def _fork
-            datadog_at_fork_blocks = Datadog::Core::Utils::AtForkMonkeyPatch::KernelMonkeyPatch.datadog_at_fork_blocks
-
             pid = super
 
-            datadog_at_fork_blocks[:child].each(&:call) if pid == 0 && datadog_at_fork_blocks.key?(:child)
+            AtForkMonkeyPatch.run_at_fork_blocks(:child) if pid == 0
 
             pid
           end
@@ -82,30 +89,11 @@ module Datadog
           # keeps executing code in the child process, killing off the parent, thus effectively replacing it.
           # This is not covered by `_fork` and thus we have some extra code for it.
           def daemon(*args)
-            datadog_at_fork_blocks = Datadog::Core::Utils::AtForkMonkeyPatch::KernelMonkeyPatch.datadog_at_fork_blocks
-
             result = super
 
-            datadog_at_fork_blocks[:child].each(&:call) if datadog_at_fork_blocks.key?(:child)
+            AtForkMonkeyPatch.run_at_fork_blocks(:child)
 
             result
-          end
-
-          # NOTE: You probably want to wrap any calls to datadog_at_fork with a OnlyOnce so as to not re-register
-          #       the same block/behavior more than once.
-          def datadog_at_fork(stage, &block)
-            ProcessMonkeyPatch.datadog_at_fork(stage, &block)
-          end
-
-          # Also allow calling without going through Process for tests
-          def self.datadog_at_fork(stage, &block)
-            raise ArgumentError, 'Bad \'stage\' for ::datadog_at_fork' unless stage == :child
-
-            datadog_at_fork_blocks = Datadog::Core::Utils::AtForkMonkeyPatch::KernelMonkeyPatch.datadog_at_fork_blocks
-            datadog_at_fork_blocks[stage] ||= []
-            datadog_at_fork_blocks[stage] << block
-
-            nil
           end
         end
       end

--- a/lib/datadog/profiling/tasks/setup.rb
+++ b/lib/datadog/profiling/tasks/setup.rb
@@ -27,20 +27,16 @@ module Datadog
         private
 
         def setup_at_fork_hooks
-          if Process.respond_to?(:datadog_at_fork)
-            Process.datadog_at_fork(:child) do
-              begin
-                # Restart profiler, if enabled
-                Profiling.start_if_enabled
-              rescue StandardError => e
-                Datadog.logger.warn do
-                  "Error during post-fork hooks. Cause: #{e.class.name} #{e.message} " \
-                  "Location: #{Array(e.backtrace).first}"
-                end
+          Datadog::Core::Utils::AtForkMonkeyPatch.at_fork(:child) do
+            begin
+              # Restart profiler, if enabled
+              Profiling.start_if_enabled
+            rescue StandardError => e
+              Datadog.logger.warn do
+                "Error during post-fork hooks. Cause: #{e.class.name} #{e.message} " \
+                "Location: #{Array(e.backtrace).first}"
               end
             end
-          else
-            Datadog.logger.debug 'Unexpected: At fork hooks not available'
           end
         end
       end

--- a/spec/datadog/profiling/tasks/setup_spec.rb
+++ b/spec/datadog/profiling/tasks/setup_spec.rb
@@ -34,69 +34,44 @@ RSpec.describe Datadog::Profiling::Tasks::Setup do
   describe '#setup_at_fork_hooks' do
     subject(:setup_at_fork_hooks) { task.send(:setup_at_fork_hooks) }
 
-    context 'when Process#datadog_at_fork is available' do
+    let(:at_fork_hook) do
+      the_hook = nil
+
+      expect(Datadog::Core::Utils::AtForkMonkeyPatch).to receive(:at_fork) do |stage, &block|
+        expect(stage).to be :child
+
+        the_hook = block
+      end
+
+      setup_at_fork_hooks
+
+      expect(the_hook).to_not be nil
+
+      the_hook
+    end
+
+    it 'sets up an at_fork hook that restarts the profiler' do
+      expect(Datadog::Profiling).to receive(:start_if_enabled)
+
+      at_fork_hook.call
+    end
+
+    context 'when there is an issue starting the profiler' do
       before do
-        allow(Process).to receive(:respond_to?).with(:datadog_at_fork).and_return(true)
-        allow(Datadog::Profiling).to receive(:start_if_enabled)
-
-        without_partial_double_verification do
-          allow(Process).to receive(:datadog_at_fork)
-        end
+        expect(Datadog::Profiling).to receive(:start_if_enabled).and_raise('Dummy exception')
+        allow(Datadog.logger).to receive(:warn) # Silence logging during tests
       end
 
-      let(:at_fork_hook) do
-        the_hook = nil
-
-        without_partial_double_verification do
-          expect(Process).to receive(:datadog_at_fork).with(:child) do |&block|
-            the_hook = block
-          end
-        end
-
-        setup_at_fork_hooks
-
-        the_hook
-      end
-
-      it 'sets up an at_fork hook that restarts the profiler' do
-        expect(Datadog::Profiling).to receive(:start_if_enabled)
-
+      it 'does not raise any error' do
         at_fork_hook.call
       end
 
-      context 'when there is an issue starting the profiler' do
-        before do
-          expect(Datadog::Profiling).to receive(:start_if_enabled).and_raise('Dummy exception')
-          allow(Datadog.logger).to receive(:warn) # Silence logging during tests
+      it 'logs an exception' do
+        expect(Datadog.logger).to receive(:warn) do |&message|
+          expect(message.call).to include('Dummy exception')
         end
 
-        it 'does not raise any error' do
-          at_fork_hook.call
-        end
-
-        it 'logs an exception' do
-          expect(Datadog.logger).to receive(:warn) do |&message|
-            expect(message.call).to include('Dummy exception')
-          end
-
-          at_fork_hook.call
-        end
-      end
-    end
-
-    context 'when #datadog_at_fork is not available' do
-      before do
-        allow(Process).to receive(:respond_to?).with(:datadog_at_fork).and_return(false)
-      end
-
-      it 'logs a debug message' do
-        expect(Datadog.logger).to receive(:debug).with(/hooks not available/)
-
-        without_partial_double_verification do
-          expect(Process).to_not receive(:datadog_at_fork)
-
-          setup_at_fork_hooks
-        end
+        at_fork_hook.call
       end
     end
   end


### PR DESCRIPTION
**What does this PR do?**

This PR fixes an issue that we identified in the
`profiling/tasks/setup_spec.rb` that was triggered by applying the at_fork monkey patch before running that spec.

This issue could be triggered by adding

```ruby
Datadog::Core::Utils::AtForkMonkeyPatch.apply!
```

to the top of the `setup_spec.rb` (before the `RSpec.describe`).

```
Datadog::Profiling::Tasks::Setup
  #run
    actives the forking extension before setting up the at_fork hooks
    only sets up the extensions and hooks once, even across different instances
  #setup_at_fork_hooks
    when Process#datadog_at_fork is available
      sets up an at_fork hook that restarts the profiler (FAILED - 1)
      when there is an issue starting the profiler
        logs an exception (FAILED - 2)
        does not raise any error (FAILED - 3)
    when #datadog_at_fork is not available
      logs a debug message

Failures:

  1) Datadog::Profiling::Tasks::Setup#setup_at_fork_hooks when Process#datadog_at_fork is available sets up an at_fork hook that restarts the profiler
     Failure/Error:
       example.run.tap do
         tracer_shutdown!
       end

     NameError:
       undefined method `datadog_at_fork' for class `#<Class:Process>'

               object_singleton_class.__send__(@original_visibility, method_name)
                                     ^^^^^^^^^
     # ./spec/spec_helper.rb:230:in `block (2 levels) in <top (required)>'
     # ./spec/spec_helper.rb:115:in `block (2 levels) in <top (required)>'
     # webmock-3.23.1/lib/webmock/rspec.rb:39:in `block (2 levels) in <top (required)>'
     # rspec-wait-0.0.10/lib/rspec/wait.rb:47:in `block (2 levels) in <top (required)>'

  2) Datadog::Profiling::Tasks::Setup#setup_at_fork_hooks when Process#datadog_at_fork is available when there is an issue starting the profiler logs an exception
     Failure/Error: at_fork_hook.call

     NoMethodError:
       undefined method `call' for nil:NilClass

                 at_fork_hook.call
                             ^^^^^
     # ./spec/datadog/profiling/tasks/setup_spec.rb:84:in `block (5 levels) in <top (required)>'
     # ./spec/spec_helper.rb:230:in `block (2 levels) in <top (required)>'
     # ./spec/spec_helper.rb:115:in `block (2 levels) in <top (required)>'
     # webmock-3.23.1/lib/webmock/rspec.rb:39:in `block (2 levels) in <top (required)>'
     # rspec-wait-0.0.10/lib/rspec/wait.rb:47:in `block (2 levels) in <top (required)>'

  3) Datadog::Profiling::Tasks::Setup#setup_at_fork_hooks when Process#datadog_at_fork is available when there is an issue starting the profiler does not raise any error
     Failure/Error: at_fork_hook.call

     NoMethodError:
       undefined method `call' for nil:NilClass

                 at_fork_hook.call
                             ^^^^^
     # ./spec/datadog/profiling/tasks/setup_spec.rb:76:in `block (5 levels) in <top (required)>'
     # ./spec/spec_helper.rb:230:in `block (2 levels) in <top (required)>'
     # ./spec/spec_helper.rb:115:in `block (2 levels) in <top (required)>'
     # webmock-3.23.1/lib/webmock/rspec.rb:39:in `block (2 levels) in <top (required)>'
     # rspec-wait-0.0.10/lib/rspec/wait.rb:47:in `block (2 levels) in <top (required)>'
```

This issue was caused by an incompatibility between rspec-mocks (not entirely sure if it's a bug) and the monkey patching we were doing.

Rather than fighting with more monkey patch weirdness or rspec, I decided to fix the issue by simplifying the at fork monkey patch module by making it as minimal as possible:

* It no longer places extra unneeded functions in Ruby classes, e.g. `datadog_at_fork_blocks` and `datadog_at_fork`
* It no longer stores its data in a weird class var

This enabled a bunch of simplifications, and the affected spec was fixed as a side-effect of this.

**Motivation:**

Get the at_fork monkey patch in shape to be used by the crashtracker as well.

**Additional Notes:**

I was tempted to do a larger refactoring of this module when I was extracting it, but I decided to aim for a smaller diff.

Since I needed to dive in again to fix the issue with the spec, I decided to finally go for it.

**I suggest reviewing the diff without whitespace differences**

**How to test the change?**

These changes include test coverage.

Here's a tiny app that can be used to experiment with this:

```ruby
puts RUBY_DESCRIPTION

require 'datadog/core/utils/at_fork_monkey_patch'

Datadog::Core::Utils::AtForkMonkeyPatch.apply!

Datadog::Core::Utils::AtForkMonkeyPatch.at_fork(:child) { puts "Hello from child process: #{Process.pid} "}

puts "Parent pid: #{Process.pid}"

puts "fork { }"
fork { }
Process.wait

puts "Kernel.fork { }"
Kernel.fork { }
Process.wait

puts "Process.fork { }"
Process.fork { }
Process.wait

puts "Foo.new.call"
class Foo
  def call
    fork { }
  end

  def self.do_fork
    fork {  }
  end
end
Foo.new.call
Process.wait

puts "Foo.do_fork"
Foo.do_fork
Process.wait

puts "Fork from outside"
Foo.new.send(:fork) { }
Process.wait

class BasicFoo < BasicObject
  include ::Kernel

  def call
    fork { }
  end

  def self.do_fork
    fork { }
  end
end

puts "BasicFoo.new.call"
BasicFoo.new.call
Process.wait

puts "BasicObject:"
Class.new(BasicObject) { include(::Kernel); def call; fork { }; end }.new.call
Process.wait

puts "BasicFork.do_fork"
BasicFoo.do_fork
Process.wait
```