### PR TITLE
Suppress startup logs in test and development environments

### DIFF
--- a/lib/datadog/core/diagnostics/environment_logger.rb
+++ b/lib/datadog/core/diagnostics/environment_logger.rb
@@ -8,6 +8,8 @@ module Datadog
   module Core
     module Diagnostics
       # Base class for EnvironmentLoggers - should allow for easy reporting by users to Datadog support.
+      #
+      # The EnvironmentLogger should not pollute the logs in a development environment.
       module EnvironmentLogging
         def log_configuration!(prefix, data)
           logger.info("DATADOG CONFIGURATION - #{prefix} - #{data}")
@@ -31,20 +33,11 @@ module Datadog
         def log?
           startup_logs_enabled = Datadog.configuration.diagnostics.startup_logs.enabled
           if startup_logs_enabled.nil?
-            !repl? && !rspec? # Suppress logs if we are running in a REPL or rspec
+            # Do not pollute the logs in a development environment.
+            !Datadog::Core::Environment::Execution.development?
           else
             startup_logs_enabled
           end
-        end
-
-        REPL_PROGRAM_NAMES = %w[irb pry].freeze
-
-        def repl?
-          REPL_PROGRAM_NAMES.include?($PROGRAM_NAME)
-        end
-
-        def rspec?
-          $PROGRAM_NAME.end_with?('rspec')
         end
       end
 

--- a/sig/datadog/core/diagnostics/environment_logger.rbs
+++ b/sig/datadog/core/diagnostics/environment_logger.rbs
@@ -2,26 +2,23 @@ module Datadog
   module Core
     module Diagnostics
       module EnvironmentLogging
-        def log_configuration!: (untyped prefix, untyped data) -> untyped
+        def log_configuration!: (string prefix, string data) -> void
 
-        def log_error!: (untyped prefix, untyped type, untyped error) -> untyped
+        def log_debug!: (string prefix, string data) -> void
 
-        def logger: () -> untyped
-        def log?: () -> untyped
+        def log_error!: (string prefix, string type, string error) -> void
 
-        REPL_PROGRAM_NAMES: ::Array[::String]
-
-        def repl?: () -> untyped
-
-        def rspec?: () -> untyped
+        def logger: () -> ::Logger
+        def log?: () -> bool
       end
       module EnvironmentLogger
         extend EnvironmentLogging
 
-        def self.collect_and_log!: (untyped extra_fields) -> untyped
+        def self.collect_and_log!: (Hash[Symbol, untyped] extra_fields) -> void
       end
       module EnvironmentCollector
         def self.collect_config!: () -> { date: untyped, os_name: untyped, version: untyped, lang: untyped, lang_version: untyped, env: untyped, service: untyped, dd_version: untyped, debug: untyped, tags: untyped, runtime_metrics_enabled: untyped, vm: untyped, health_metrics_enabled: untyped }
+
         def self.date: () -> untyped
         def self.os_name: () -> untyped
         def self.version: () -> untyped

--- a/sig/datadog/core/environment/execution.rbs
+++ b/sig/datadog/core/environment/execution.rbs
@@ -5,8 +5,6 @@ module Datadog
         def self.development?: () -> bool
         def self.webmock_enabled?: () -> bool
 
-        def self.cucumber?: -> bool
-
         private
         def self.test?: () -> bool
         def self.repl?: () -> bool
@@ -16,6 +14,8 @@ module Datadog
 
         RSPEC_PROGRAM_NAME: ::String
         def self.minitest?: () -> bool
+
+        def self.cucumber?: -> bool
 
         def self.rails_development?: -> bool
 

--- a/spec/datadog/core/diagnostics/environment_logger_spec.rb
+++ b/spec/datadog/core/diagnostics/environment_logger_spec.rb
@@ -18,6 +18,8 @@ RSpec.describe Datadog::Core::Diagnostics::EnvironmentLogger do
   end
 
   describe '#collect_and_log!' do
+    include_context 'non-development execution environment'
+
     subject(:collect_and_log!) { env_logger.collect_and_log! }
 
     let(:logger) { instance_double(Datadog::Core::Logger) }
@@ -40,7 +42,6 @@ RSpec.describe Datadog::Core::Diagnostics::EnvironmentLogger do
     end
 
     before do
-      allow(env_logger).to receive(:rspec?).and_return(false) # Allow rspec to log for testing purposes
       allow(Datadog).to receive(:logger).and_return(logger)
       allow(logger).to receive(:debug?).and_return(true)
       allow(logger).to receive(:debug)
@@ -56,22 +57,10 @@ RSpec.describe Datadog::Core::Diagnostics::EnvironmentLogger do
       end
     end
 
-    context 'under a REPL' do
-      around do |example|
-        begin
-          original = $PROGRAM_NAME
-          $0 = 'irb'
-          example.run
-        ensure
-          $0 = original
-        end
-      end
+    context 'in a development execution environment' do
+      before { allow(Datadog::Core::Environment::Execution).to receive(:development?).and_return(true) }
 
       context 'with default settings' do
-        before do
-          allow(env_logger).to receive(:rspec?).and_return(true) # Prevent rspec from logging
-        end
-
         it { expect(logger).to_not have_received(:info) }
       end
 

--- a/spec/datadog/tracing/diagnostics/environment_logger_spec.rb
+++ b/spec/datadog/tracing/diagnostics/environment_logger_spec.rb
@@ -23,12 +23,13 @@ RSpec.describe Datadog::Tracing::Diagnostics::EnvironmentLogger do
   end
 
   describe '#collect_and_log!' do
+    include_context 'non-development execution environment'
+
     subject(:collect_and_log!) { env_logger.collect_and_log! }
 
     let(:logger) { instance_double(Datadog::Core::Logger) }
 
     before do
-      allow(env_logger).to receive(:rspec?).and_return(false) # Allow rspec to log for testing purposes
       allow(Datadog).to receive(:logger).and_return(logger)
       allow(logger).to receive(:debug?).and_return true
       allow(logger).to receive(:debug)
@@ -91,22 +92,10 @@ RSpec.describe Datadog::Tracing::Diagnostics::EnvironmentLogger do
       end
     end
 
-    context 'under a REPL' do
-      around do |example|
-        begin
-          original = $PROGRAM_NAME
-          $0 = 'irb'
-          example.run
-        ensure
-          $0 = original
-        end
-      end
+    context 'in a development execution environment' do
+      before { allow(Datadog::Core::Environment::Execution).to receive(:development?).and_return(true) }
 
       context 'with default settings' do
-        before do
-          allow(env_logger).to receive(:rspec?).and_return(true) # Prevent rspec from logging
-        end
-
         it do
           collect_and_log!
           expect(logger).to_not have_received(:info)


### PR DESCRIPTION
Fixes #3807

This PR aligns the development environment detection for remote configuration, telemetry and, now, startup logs.

The development environment detection for startup logs now includes test environments and local development environments.