### PR TITLE
[PROF-10128] Refactor and speed up profiler stack sampling

### DIFF
--- a/ext/datadog_profiling_native_extension/collectors_discrete_dynamic_sampler.c
+++ b/ext/datadog_profiling_native_extension/collectors_discrete_dynamic_sampler.c
@@ -269,9 +269,7 @@ void discrete_dynamic_sampler_readjust(discrete_dynamic_sampler *sampler, long n
     double num_this_windows_in_60s = 60 * 1e9 / this_window_time_ns;
     double real_total_sampling_time_in_60s = sampler->sampling_time_since_last_readjustment_ns * num_this_windows_in_60s / 1e9;
 
-    const char* readjustment_reason = should_readjust_based_on_time ? "time" : "samples";
-
-    fprintf(stderr, "[dds.%s] readjusting due to %s...\n", sampler->debug_name, readjustment_reason);
+    fprintf(stderr, "[dds.%s] readjusting...\n", sampler->debug_name);
     fprintf(stderr, "events_since_last_readjustment=%ld\n", sampler->events_since_last_readjustment);
     fprintf(stderr, "samples_since_last_readjustment=%ld\n", sampler->samples_since_last_readjustment);
     fprintf(stderr, "this_window_time=%ld\n", this_window_time_ns);

--- a/ext/datadog_profiling_native_extension/collectors_stack.c
+++ b/ext/datadog_profiling_native_extension/collectors_stack.c
@@ -161,6 +161,14 @@ void sample_thread(
     return;
   }
 
+  // if (captured_frames > 0) {
+  //   int cache_hits = 0;
+  //   for (int i = 0; i < captured_frames; i++) {
+  //     if (buffer->stack_buffer[i].same_frame) cache_hits++;
+  //   }
+  //   fprintf(stderr, "Sampling cache hits: %f\n", ((double) cache_hits / captured_frames) * 100);
+  // }
+
   // Ruby does not give us path and line number for methods implemented using native code.
   // The convention in Kernel#caller_locations is to instead use the path and line number of the first Ruby frame
   // on the stack that is below (e.g. directly or indirectly has called) the native method.

--- a/ext/datadog_profiling_native_extension/collectors_stack.c
+++ b/ext/datadog_profiling_native_extension/collectors_stack.c
@@ -15,7 +15,7 @@ static VALUE missing_string = Qnil;
 
 // Used as scratch space during sampling
 struct sampling_buffer {
-  unsigned int max_frames;
+  uint16_t max_frames;
   ddog_prof_Location *locations;
   VALUE *stack_buffer;
   int *lines_buffer;

--- a/ext/datadog_profiling_native_extension/collectors_stack.c
+++ b/ext/datadog_profiling_native_extension/collectors_stack.c
@@ -169,8 +169,8 @@ void sample_thread(
   // The convention in Kernel#caller_locations is to instead use the path and line number of the first Ruby frame
   // on the stack that is below (e.g. directly or indirectly has called) the native method.
   // Thus, we keep that frame here to able to replicate that behavior.
-  // (This is why we also iterate the sampling buffers backwards below -- so that it's easier to keep the last_ruby_frame)
-  VALUE last_ruby_frame = Qnil;
+  // (This is why we also iterate the sampling buffers backwards below -- so that it's easier to keep the last_ruby_frame_filename)
+  VALUE last_ruby_frame_filename = Qnil;
   int last_ruby_line = 0;
 
   ddog_prof_Label *state_label = labels.state_label;
@@ -187,15 +187,15 @@ void sample_thread(
     int line;
 
     if (buffer->is_ruby_frame[i]) {
-      last_ruby_frame = buffer->stack_buffer[i];
-      last_ruby_line = buffer->lines_buffer[i];
-
       name = rb_profile_frame_base_label(buffer->stack_buffer[i]);
       filename = rb_profile_frame_path(buffer->stack_buffer[i]);
       line = buffer->lines_buffer[i];
+
+      last_ruby_frame_filename = filename;
+      last_ruby_line = line;
     } else {
       name = ddtrace_rb_profile_frame_method_name(buffer->stack_buffer[i]);
-      filename = NIL_P(last_ruby_frame) ? Qnil : rb_profile_frame_path(last_ruby_frame);
+      filename = last_ruby_frame_filename;
       line = last_ruby_line;
     }
 

--- a/ext/datadog_profiling_native_extension/collectors_stack.c
+++ b/ext/datadog_profiling_native_extension/collectors_stack.c
@@ -34,6 +34,11 @@ static void maybe_add_placeholder_frames_omitted(VALUE thread, sampling_buffer* 
 static void record_placeholder_stack_in_native_code(VALUE recorder_instance, sample_values values, sample_labels labels);
 static void maybe_trim_template_random_ids(ddog_CharSlice *name_slice, ddog_CharSlice *filename_slice);
 
+// These two functions are exposed as symbols by the VM but are not in any header.
+// Their signatures actually take a `const rb_iseq_t *iseq` but it gets casted back and forth between VALUE.
+extern VALUE rb_iseq_path(const VALUE);
+extern VALUE rb_iseq_base_label(const VALUE);
+
 void collectors_stack_init(VALUE profiling_module) {
   VALUE collectors_module = rb_define_module_under(profiling_module, "Collectors");
   VALUE collectors_stack_class = rb_define_class_under(collectors_module, "Stack", rb_cObject);
@@ -191,8 +196,8 @@ void sample_thread(
     int line;
 
     if (buffer->stack_buffer[i].is_ruby_frame) {
-      name = rb_profile_frame_base_label(buffer->stack_buffer[i].as.ruby_frame.iseq);
-      filename = rb_profile_frame_path(buffer->stack_buffer[i].as.ruby_frame.iseq);
+      name = rb_iseq_base_label(buffer->stack_buffer[i].as.ruby_frame.iseq);
+      filename = rb_iseq_path(buffer->stack_buffer[i].as.ruby_frame.iseq);
       line = buffer->stack_buffer[i].as.ruby_frame.line;
 
       last_ruby_frame_filename = filename;

--- a/ext/datadog_profiling_native_extension/collectors_stack.c
+++ b/ext/datadog_profiling_native_extension/collectors_stack.c
@@ -385,9 +385,14 @@ void record_placeholder_stack(
   );
 }
 
-sampling_buffer *sampling_buffer_new(unsigned int max_frames) {
+uint16_t sampling_buffer_check_max_frames(int max_frames) {
   if (max_frames < 5) rb_raise(rb_eArgError, "Invalid max_frames: value must be >= 5");
   if (max_frames > MAX_FRAMES_LIMIT) rb_raise(rb_eArgError, "Invalid max_frames: value must be <= " MAX_FRAMES_LIMIT_AS_STRING);
+  return max_frames;
+}
+
+sampling_buffer *sampling_buffer_new(uint16_t max_frames) {
+  sampling_buffer_check_max_frames(max_frames);
 
   // Note: never returns NULL; if out of memory, it calls the Ruby out-of-memory handlers
   sampling_buffer* buffer = ruby_xcalloc(1, sizeof(sampling_buffer));

--- a/ext/datadog_profiling_native_extension/collectors_stack.h
+++ b/ext/datadog_profiling_native_extension/collectors_stack.h
@@ -22,5 +22,6 @@ void record_placeholder_stack(
   sample_labels labels,
   ddog_CharSlice placeholder_stack
 );
-sampling_buffer *sampling_buffer_new(unsigned int max_frames);
+uint16_t sampling_buffer_check_max_frames(int max_frames);
+sampling_buffer *sampling_buffer_new(uint16_t max_frames);
 void sampling_buffer_free(sampling_buffer *buffer);

--- a/ext/datadog_profiling_native_extension/collectors_stack.h
+++ b/ext/datadog_profiling_native_extension/collectors_stack.h
@@ -23,5 +23,5 @@ void record_placeholder_stack(
   ddog_CharSlice placeholder_stack
 );
 uint16_t sampling_buffer_check_max_frames(int max_frames);
-sampling_buffer *sampling_buffer_new(uint16_t max_frames);
+sampling_buffer *sampling_buffer_new(uint16_t max_frames, ddog_prof_Location *locations);
 void sampling_buffer_free(sampling_buffer *buffer);

--- a/ext/datadog_profiling_native_extension/collectors_stack.h
+++ b/ext/datadog_profiling_native_extension/collectors_stack.h
@@ -17,7 +17,6 @@ void sample_thread(
   sample_labels labels
 );
 void record_placeholder_stack(
-  sampling_buffer* buffer,
   VALUE recorder_instance,
   sample_values values,
   sample_labels labels,

--- a/ext/datadog_profiling_native_extension/collectors_thread_context.c
+++ b/ext/datadog_profiling_native_extension/collectors_thread_context.c
@@ -675,7 +675,6 @@ VALUE thread_context_collector_sample_after_gc(VALUE self_instance) {
   }
 
   record_placeholder_stack(
-    state->sampling_buffer,
     state->recorder_instance,
     (sample_values) {
       // This event gets both a regular cpu/wall-time duration, as a normal cpu/wall-time sample would, as well as a
@@ -1432,7 +1431,6 @@ void thread_context_collector_sample_skipped_allocation_samples(VALUE self_insta
   ddog_prof_Slice_Label slice_labels = {.ptr = labels, .len = sizeof(labels) / sizeof(labels[0])};
 
   record_placeholder_stack(
-    state->sampling_buffer,
     state->recorder_instance,
     (sample_values) {.alloc_samples = skipped_samples},
     (sample_labels) {

--- a/ext/datadog_profiling_native_extension/collectors_thread_context.c
+++ b/ext/datadog_profiling_native_extension/collectors_thread_context.c
@@ -184,7 +184,7 @@ static VALUE _native_sample_after_gc(DDTRACE_UNUSED VALUE self, VALUE collector_
 void update_metrics_and_sample(
   struct thread_context_collector_state *state,
   VALUE thread_being_sampled,
-  VALUE profiler_overhead_stack_thread,
+  VALUE stack_from_thread,
   struct per_thread_context *thread_context,
   long current_cpu_time_ns,
   long current_monotonic_wall_time_ns

--- a/ext/datadog_profiling_native_extension/datadog_ruby_common.h
+++ b/ext/datadog_profiling_native_extension/datadog_ruby_common.h
@@ -35,7 +35,7 @@ VALUE datadog_gem_version(void);
 
 inline static ddog_CharSlice char_slice_from_ruby_string(VALUE string) {
   ENFORCE_TYPE(string, T_STRING);
-  ddog_CharSlice char_slice = {.ptr = StringValuePtr(string), .len = RSTRING_LEN(string)};
+  ddog_CharSlice char_slice = {.ptr = RSTRING_PTR(string), .len = RSTRING_LEN(string)};
   return char_slice;
 }
 

--- a/ext/datadog_profiling_native_extension/extconf.rb
+++ b/ext/datadog_profiling_native_extension/extconf.rb
@@ -172,9 +172,6 @@ $defs << '-DNO_JIT_RETURN' if RUBY_VERSION < '3.1'
 # obj_to_id_tbl mappings.
 $defs << '-DHAVE_WORKING_RB_GC_FORCE_RECYCLE' if RUBY_VERSION < '3.1'
 
-# On older Rubies, we need to use a backported version of this function. See private_vm_api_access.h for details.
-$defs << '-DUSE_BACKPORTED_RB_PROFILE_FRAME_METHOD_NAME' if RUBY_VERSION < '3'
-
 # On older Rubies, there are no Ractors
 $defs << '-DNO_RACTORS' if RUBY_VERSION < '3'
 

--- a/ext/datadog_profiling_native_extension/heap_recorder.c
+++ b/ext/datadog_profiling_native_extension/heap_recorder.c
@@ -842,6 +842,7 @@ VALUE object_record_inspect(object_record *record) {
   if (!ruby_ref_from_id(LONG2NUM(record->obj_id), &ref)) {
     rb_str_catf(inspect, "object=<invalid>");
   } else {
+    rb_str_catf(inspect, "value=%p ", (void *) ref);
     VALUE ruby_inspect = ruby_safe_inspect(ref);
     if (ruby_inspect != Qnil) {
       rb_str_catf(inspect, "object=%"PRIsVALUE, ruby_inspect);

--- a/ext/datadog_profiling_native_extension/private_vm_api_access.c
+++ b/ext/datadog_profiling_native_extension/private_vm_api_access.c
@@ -490,6 +490,7 @@ int ddtrace_rb_profile_frames(VALUE thread, int start, int limit, frame_info *st
               continue;
             }
 
+            // dd-trace-rb NOTE:
             // Upstream Ruby has code here to retrieve the rb_callable_method_entry_t (cme) and in some cases to use it
             // instead of the iseq.
             // In practice, they are usually the same; the difference is that when you have e.g. block, one gets you a
@@ -498,6 +499,9 @@ int ddtrace_rb_profile_frames(VALUE thread, int start, int limit, frame_info *st
             // of just "foo". But we're currently using `rb_profile_frame_base_label` which I believe is always the same
             // between the rb_callable_method_entry_t and the iseq. Thus, to simplify a bit our logic and reduce a bit
             // the overhead, we always use the iseq here.
+            //
+            // @ivoanjo: I've left the upstream Ruby code commented out below for reference, so it's more obvious that
+            // we're diverging, and we can easily compare and experiment with the upstream version in the future.
             //
             // cme = rb_vm_frame_method_entry(cfp);
 

--- a/ext/datadog_profiling_native_extension/private_vm_api_access.c
+++ b/ext/datadog_profiling_native_extension/private_vm_api_access.c
@@ -376,8 +376,8 @@ calc_lineno(const rb_iseq_t *iseq, const VALUE *pc)
 // Copyright (C) 1993-2012 Yukihiro Matsumoto
 // Modifications:
 // * Renamed rb_profile_frames => ddtrace_rb_profile_frames
-// * Add thread argument
-// * Add is_ruby_frame argument
+// * Add thread argument (this is now upstream, actually!)
+// * Add frame_flags.is_ruby_frame argument
 // * Removed `if (lines)` tests -- require/assume that like `buff`, `lines` is always specified
 // * Skip dummy frame that shows up in main thread
 // * Add `end_cfp == NULL` and `end_cfp <= cfp` safety checks. These are used in a bunch of places in
@@ -422,8 +422,7 @@ calc_lineno(const rb_iseq_t *iseq, const VALUE *pc)
 //    and friends). We've found quite a few situations where the data from rb_profile_frames and the reference APIs
 //    disagree, and quite a few of them seem oversights/bugs (speculation from my part) rather than deliberate
 //    decisions.
-int ddtrace_rb_profile_frames(VALUE thread, int start, int limit, VALUE *buff, int *lines, bool* is_ruby_frame)
-{
+int ddtrace_rb_profile_frames(VALUE thread, int start, int limit, frame_info *stack_buffer) {
     int i;
     // Modified from upstream: Instead of using `GET_EC` to collect info from the current thread,
     // support sampling any thread (including the current) passed as an argument
@@ -499,7 +498,7 @@ int ddtrace_rb_profile_frames(VALUE thread, int start, int limit, VALUE *buff, i
             //     buff[i] = (VALUE)cme;
             // }
             // else {
-            buff[i] = (VALUE)cfp->iseq;
+            stack_buffer[i].as.ruby_frame.iseq = (VALUE)cfp->iseq;
             // }
 
             // The topmost frame may not have an updated PC because the JIT
@@ -508,23 +507,22 @@ int ddtrace_rb_profile_frames(VALUE thread, int start, int limit, VALUE *buff, i
             // so only the topmost frame could possibly have an out of date PC
             #ifndef NO_JIT_RETURN
               if (cfp == top && cfp->jit_return) {
-                lines[i] = 0;
+                stack_buffer[i].as.ruby_frame.line = 0;
               } else {
-                lines[i] = calc_lineno(cfp->iseq, cfp->pc);
+                stack_buffer[i].as.ruby_frame.line = calc_lineno(cfp->iseq, cfp->pc);
               }
             #else // Ruby < 3.1
-              lines[i] = calc_lineno(cfp->iseq, cfp->pc);
+              stack_buffer[i].as.ruby_frame.line = calc_lineno(cfp->iseq, cfp->pc);
             #endif
 
-            is_ruby_frame[i] = true;
+            stack_buffer[i].is_ruby_frame = true;
             i++;
         }
         else {
             cme = rb_vm_frame_method_entry(cfp);
             if (cme && cme->def->type == VM_METHOD_TYPE_CFUNC) {
-                buff[i] = (VALUE)cme;
-                lines[i] = 0;
-                is_ruby_frame[i] = false;
+                stack_buffer[i].as.native_frame.method_id = cme->def->original_id;
+                stack_buffer[i].is_ruby_frame = false;
                 i++;
             }
         }
@@ -533,104 +531,6 @@ int ddtrace_rb_profile_frames(VALUE thread, int start, int limit, VALUE *buff, i
 
     return i;
 }
-
-#ifdef USE_BACKPORTED_RB_PROFILE_FRAME_METHOD_NAME
-
-// Taken from upstream vm_backtrace.c at commit 5f10bd634fb6ae8f74a4ea730176233b0ca96954 (March 2022, Ruby 3.2 trunk)
-// Copyright (C) 1993-2012 Yukihiro Matsumoto
-// to support our custom rb_profile_frame_method_name (see below)
-// Modifications: None
-static VALUE
-id2str(ID id)
-{
-    VALUE str = rb_id2str(id);
-    if (!str) return Qnil;
-    return str;
-}
-#define rb_id2str(id) id2str(id)
-
-// Taken from upstream vm_backtrace.c at commit 5f10bd634fb6ae8f74a4ea730176233b0ca96954 (March 2022, Ruby 3.2 trunk)
-// Copyright (C) 1993-2012 Yukihiro Matsumoto
-// to support our custom rb_profile_frame_method_name (see below)
-// Modifications: None
-static const rb_iseq_t *
-frame2iseq(VALUE frame)
-{
-    if (NIL_P(frame)) return NULL;
-
-    if (RB_TYPE_P(frame, T_IMEMO)) {
-    switch (imemo_type(frame)) {
-      case imemo_iseq:
-        return (const rb_iseq_t *)frame;
-      case imemo_ment:
-        {
-        const rb_callable_method_entry_t *cme = (rb_callable_method_entry_t *)frame;
-        switch (cme->def->type) {
-          case VM_METHOD_TYPE_ISEQ:
-            return cme->def->body.iseq.iseqptr;
-          default:
-            return NULL;
-        }
-        }
-      default:
-        break;
-    }
-    }
-    rb_bug("frame2iseq: unreachable");
-}
-
-// Taken from upstream vm_backtrace.c at commit 5f10bd634fb6ae8f74a4ea730176233b0ca96954 (March 2022, Ruby 3.2 trunk)
-// Copyright (C) 1993-2012 Yukihiro Matsumoto
-// to support our custom rb_profile_frame_method_name (see below)
-// Modifications: None
-static const rb_callable_method_entry_t *
-cframe(VALUE frame)
-{
-    if (NIL_P(frame)) return NULL;
-
-    if (RB_TYPE_P(frame, T_IMEMO)) {
-    switch (imemo_type(frame)) {
-      case imemo_ment:
-            {
-        const rb_callable_method_entry_t *cme = (rb_callable_method_entry_t *)frame;
-        switch (cme->def->type) {
-          case VM_METHOD_TYPE_CFUNC:
-            return cme;
-          default:
-            return NULL;
-        }
-            }
-          default:
-            return NULL;
-        }
-    }
-
-    return NULL;
-}
-
-// Taken from upstream vm_backtrace.c at commit 5f10bd634fb6ae8f74a4ea730176233b0ca96954 (March 2022, Ruby 3.2 trunk)
-// Copyright (C) 1993-2012 Yukihiro Matsumoto
-//
-// Ruby 3.0 finally added support for showing CFUNC frames (frames for methods written using native code)
-// in stack traces gathered via `rb_profile_frames` (https://github.com/ruby/ruby/pull/3299).
-// To access this information on older Rubies, beyond using our custom `ddtrace_rb_profile_frames` above, we also need
-// to backport the Ruby 3.0+ version of `rb_profile_frame_method_name`.
-//
-// Modifications:
-// * Renamed rb_profile_frame_method_name => ddtrace_rb_profile_frame_method_name
-VALUE
-ddtrace_rb_profile_frame_method_name(VALUE frame)
-{
-    const rb_callable_method_entry_t *cme = cframe(frame);
-    if (cme) {
-        ID mid = cme->def->original_id;
-        return id2str(mid);
-    }
-    const rb_iseq_t *iseq = frame2iseq(frame);
-    return iseq ? rb_iseq_method_name(iseq) : Qnil;
-}
-
-#endif // USE_BACKPORTED_RB_PROFILE_FRAME_METHOD_NAME
 
 // Support code for older Rubies that cannot use the MJIT header
 #ifndef RUBY_MJIT_HEADER

--- a/ext/datadog_profiling_native_extension/private_vm_api_access.h
+++ b/ext/datadog_profiling_native_extension/private_vm_api_access.h
@@ -22,13 +22,16 @@ typedef struct frame_info {
   union {
     struct {
       VALUE iseq;
+      void *caching_pc; // For caching only
       int line;
     } ruby_frame;
     struct {
+      VALUE caching_cme; // For caching only
       ID method_id;
     } native_frame;
   } as;
   bool is_ruby_frame : 1;
+  bool same_frame : 1;
 } frame_info;
 
 rb_nativethread_id_t pthread_id_for(VALUE thread);

--- a/ext/libdatadog_api/datadog_ruby_common.h
+++ b/ext/libdatadog_api/datadog_ruby_common.h
@@ -35,7 +35,7 @@ VALUE datadog_gem_version(void);
 
 inline static ddog_CharSlice char_slice_from_ruby_string(VALUE string) {
   ENFORCE_TYPE(string, T_STRING);
-  ddog_CharSlice char_slice = {.ptr = StringValuePtr(string), .len = RSTRING_LEN(string)};
+  ddog_CharSlice char_slice = {.ptr = RSTRING_PTR(string), .len = RSTRING_LEN(string)};
   return char_slice;
 }
 

--- a/ext/libdatadog_api/extconf.rb
+++ b/ext/libdatadog_api/extconf.rb
@@ -67,7 +67,7 @@ append_cflags '-Wextra'
 
 if ENV['DDTRACE_DEBUG'] == 'true'
   $defs << '-DDD_DEBUG'
-  CONFIG['optflags'] = '-O0'
+  CONFIG['optflags'] = '-O1'
   CONFIG['debugflags'] = '-ggdb3'
 end
 


### PR DESCRIPTION
**What does this PR do?**

This PR refactors the way the profiler samples the Ruby stack, and then builds on that refactoring to speed up sampling.

It also opens the door to future speedups once libdatadog allows us to skip re-interning strings, frames and stacks that we know have been sampled before.

Specifically this PR does the following:
1. It tweaks the data that `ddtrace_rb_profile_frames` returns from sampling the Ruby stack so that the stack collector can use cheaper APIs to get the same information as before.
2. It changes the sampling buffer we put stack traces in to be per-thread. This allows us to reuse some of the work we do from sample to sample, in cases where frames on the stack are the same. Thus sampling the same stack over and over will be slightly cheaper.
3. It adds a few more micro-optimizations that I spotted from profiling the profiler :)
4. When we sample stacks, we expose a flag that can be used to determine if a frame was unchanged from the last sample. This is what opens the door for future optimizations using libdatadog.

Here's the results of running benchmarks/profiler_sample_loop_v2.rb with these changes on my local machine:

```
Warming up --------------------------------------
stack collector improved-sampling
                       783.000 i/100ms
Calculating -------------------------------------
stack collector improved-sampling
                          7.828k (± 3.3%) i/s -    234.900k in  30.042969s

Warming up --------------------------------------
stack collector master
                       746.000 i/100ms
Calculating -------------------------------------
stack collector master
                          7.057k (± 3.3%) i/s -    211.864k in  30.058848s

Comparison:
stack collector improved-sampling:     7827.8 i/s
stack collector master:     7056.8 i/s - 1.11x  slower
```

**Motivation:**

This PR further reduces the overhead of profiling, especially more complex/deep stacks. I started looking into this with the goal of improving allocation profiling, but stack sampling is shared with cpu/wall-time profiling as well, so those will also be able to take advantage of the improvement.

**Additional Notes:**

There's a lot of small parts moving around in this PR. I recommend reviewing commit-by-commit, as I tried to break every change into a small standalone step that can be reviewed in a much nicer way.

**How to test the change?**

Our existing tests cover these changes.
