### PR TITLE
 Emit log message for incompatible Lograge setup 

### DIFF
--- a/lib/datadog/tracing/contrib/lograge/patcher.rb
+++ b/lib/datadog/tracing/contrib/lograge/patcher.rb
@@ -20,6 +20,22 @@ module Datadog
 
           # patch applies our patch
           def patch
+            # ActiveSupport::TaggedLogging is the default Rails logger since Rails 5
+            if defined?(::ActiveSupport::TaggedLogging::Formatter) &&
+                ::Lograge::LogSubscribers::ActionController
+                    .logger&.formatter.is_a?(::ActiveSupport::TaggedLogging::Formatter)
+
+              Datadog.logger.error(
+                'Lograge and ActiveSupport::TaggedLogging (the default Rails log formatter) are not compatible: ' \
+                  'Lograge does not account for Rails log tags, creating polluted logs and breaking log formatting. ' \
+                  'Traces and Logs correlation may not work. ' \
+                  'Either: 1. Disable tagged logging in your Rails configuration ' \
+                  '`config.logger = ActiveSupport::Logger.new(STDOUT); ' \
+                  'config.active_job.logger = ActiveSupport::Logger.new(STDOUT)` ' \
+                  'or 2. Use the `semantic_logger` gem instead of `lograge`.'
+              )
+            end
+
             ::Lograge::LogSubscribers::Base.include(Instrumentation)
           end
         end

--- a/spec/datadog/tracing/contrib/lograge/patcher_spec.rb
+++ b/spec/datadog/tracing/contrib/lograge/patcher_spec.rb
@@ -5,10 +5,31 @@ require 'datadog/tracing/contrib/lograge/patcher'
 
 RSpec.describe Datadog::Tracing::Contrib::Lograge::Patcher do
   describe '.patch' do
+    before { described_class.instance_variable_get(:@patch_only_once)&.send(:reset_ran_once_state_for_tests) }
+
     it 'adds Instrumentation to ancestors of LogSubscribers::Base class' do
       described_class.patch
 
       expect(Lograge::LogSubscribers::Base.ancestors).to include(Datadog::Tracing::Contrib::Lograge::Instrumentation)
+    end
+
+    context 'without Rails tagged logging' do
+      it 'does not log incompatibility error' do
+        expect(Datadog.logger).to_not receive(:error)
+
+        described_class.patch
+      end
+    end
+
+    context 'with Rails tagged logging' do
+      it 'logs an incompatibility error' do
+        logger = ActiveSupport::TaggedLogging.new(Logger.new(File::NULL))
+        stub_const('Lograge::LogSubscribers::ActionController', double('controller', logger: logger))
+
+        expect(Datadog.logger).to receive(:error).with(/ActiveSupport::TaggedLogging/)
+
+        described_class.patch
+      end
     end
   end
 end


### PR DESCRIPTION
Closes #2012

This PR emits an error-level log message when the `lograge` gem is used with Rails tagged logging, which is configured by default in Rails since Rails 5.

We can't practically fix the issue here in `dd-trace-rb`, since the issue is a log formatting conflict between `lograge` and `Rails`.
The reason this affects APM Tracing is because it breaks trace-log correlation.

The only alternatives are to either: disable Rails tagged logging; or not use `lograge`.

The investigation and suggest alternatives are well documented here: https://github.com/DataDog/dd-trace-rb/issues/2012#issuecomment-2038438494
