### PR TITLE
Make user_id optional for track_login_failure

### DIFF
--- a/lib/datadog/kit/appsec/events.rb
+++ b/lib/datadog/kit/appsec/events.rb
@@ -53,13 +53,11 @@ module Datadog
           # @param user_exists [bool] Whether the user id that did a login attempt exists.
           # @param others [Hash<String || Symbol, String>] Additional free-form
           #   event information to attach to the trace.
-          def track_login_failure(trace = nil, span = nil, user_id:, user_exists:, **others)
+          def track_login_failure(trace = nil, span = nil, user_exists:, user_id: nil, **others)
             set_trace_and_span_context('track_login_failure', trace, span) do |active_trace, active_span|
-              raise ArgumentError, 'user_id cannot be nil' if user_id.nil?
-
               track(LOGIN_FAILURE_EVENT, active_trace, active_span, **others)
 
-              active_span.set_tag('appsec.events.users.login.failure.usr.id', user_id)
+              active_span.set_tag('appsec.events.users.login.failure.usr.id', user_id) if user_id
               active_span.set_tag('appsec.events.users.login.failure.usr.exists', user_exists)
             end
           end

--- a/spec/datadog/kit/appsec/events_spec.rb
+++ b/spec/datadog/kit/appsec/events_spec.rb
@@ -120,17 +120,26 @@ RSpec.describe Datadog::Kit::AppSec::Events do
       end
     end
 
-    it 'sets user non-existence  on trace' do
-      trace_op.measure('root') do |span, _trace|
-        described_class.track_login_failure(trace_op, user_id: '42', user_exists: false)
-        expect(span.tags).to include('appsec.events.users.login.failure.usr.exists' => 'false')
-      end
-    end
-
     it 'sets other keys on trace' do
       trace_op.measure('root') do |span, _trace|
         described_class.track_login_failure(trace_op, user_id: '42', user_exists: true, foo: 'bar')
         expect(span.tags).to include('appsec.events.users.login.failure.foo' => 'bar')
+      end
+    end
+
+    context 'when user does not exist' do
+      it 'sets user non-existence on trace' do
+        trace_op.measure('root') do |span, _trace|
+          described_class.track_login_failure(trace_op, user_exists: false)
+          expect(span.tags).to include('appsec.events.users.login.failure.usr.exists' => 'false')
+        end
+      end
+
+      it 'does not set user id on trace' do
+        trace_op.measure('root') do |span, _trace|
+          described_class.track_login_failure(trace_op, user_exists: false)
+          expect(span.tags).not_to have_key('appsec.events.users.login.failure.usr.id')
+        end
       end
     end
 


### PR DESCRIPTION
Fixes #3840.

**What does this PR do?**
This PR fixes a bug when `Datadog::Kit::AppSec::Events.track_login_failure` is raising an `ArgumentError` when `user_id` is not provided and `user_exists` flag is set to false.

**Motivation:**
[Issue #3840](https://github.com/DataDog/dd-trace-rb/issues/3840)
