### PR TITLE
Add missing includes to fix build and LSP errors on Mac

### DIFF
--- a/ext/datadog_profiling_native_extension/clock_id.h
+++ b/ext/datadog_profiling_native_extension/clock_id.h
@@ -2,6 +2,7 @@
 
 #include <stdbool.h>
 #include <time.h>
+#include <ruby.h>
 
 // Contains the operating-system specific identifier needed to fetch CPU-time, and a flag to indicate if we failed to fetch it
 typedef struct thread_cpu_time_id {

--- a/ext/datadog_profiling_native_extension/clock_id_from_pthread.c
+++ b/ext/datadog_profiling_native_extension/clock_id_from_pthread.c
@@ -7,11 +7,10 @@
 #include <pthread.h>
 #include <time.h>
 #include <errno.h>
-#include <ruby.h>
 
+#include "clock_id.h"
 #include "helpers.h"
 #include "private_vm_api_access.h"
-#include "clock_id.h"
 #include "time_helpers.h"
 
 // Validate that our home-cooked pthread_id_for() matches pthread_self() for the current thread

--- a/ext/datadog_profiling_native_extension/clock_id_noop.c
+++ b/ext/datadog_profiling_native_extension/clock_id_noop.c
@@ -4,10 +4,9 @@
 // is not available.
 #ifndef HAVE_PTHREAD_GETCPUCLOCKID
 
-#include <ruby.h>
-
 #include "clock_id.h"
 #include "helpers.h"
+#include "datadog_ruby_common.h"
 
 void self_test_clock_id(void) { } // Nothing to check
 


### PR DESCRIPTION
**What does this PR do?**
* Add missing include to `clock_id_noop.c`.
* Move `ruby.h` include to `clock_id.h` since that file already references `VALUE`.

**Motivation:**

Fix a compilation error on mac:

```
❯ rake compile                     
/opt/homebrew/bin/gmake install sitearchdir=../../../../lib sitelibdir=../../../../lib target_prefix=
compiling ../../../../ext/datadog_profiling_native_extension/clock_id_from_pthread.c
compiling ../../../../ext/datadog_profiling_native_extension/clock_id_noop.c
../../../../ext/datadog_profiling_native_extension/clock_id_noop.c:14:43: error: unknown type name 'DDTRACE_UNUSED'
thread_cpu_time_id thread_cpu_time_id_for(DDTRACE_UNUSED VALUE _thread) {
                                          ^
../../../../ext/datadog_profiling_native_extension/clock_id_noop.c:14:64: error: expected ')'
thread_cpu_time_id thread_cpu_time_id_for(DDTRACE_UNUSED VALUE _thread) {
                                                               ^
../../../../ext/datadog_profiling_native_extension/clock_id_noop.c:14:42: note: to match this '('
thread_cpu_time_id thread_cpu_time_id_for(DDTRACE_UNUSED VALUE _thread) {
                                         ^
../../../../ext/datadog_profiling_native_extension/clock_id_noop.c:18:37: error: unknown type name 'DDTRACE_UNUSED'
thread_cpu_time thread_cpu_time_for(DDTRACE_UNUSED thread_cpu_time_id _time_id) {
                                    ^
../../../../ext/datadog_profiling_native_extension/clock_id_noop.c:18:71: error: expected ')'
thread_cpu_time thread_cpu_time_for(DDTRACE_UNUSED thread_cpu_time_id _time_id) {
                                                                      ^
../../../../ext/datadog_profiling_native_extension/clock_id_noop.c:18:36: note: to match this '('
thread_cpu_time thread_cpu_time_for(DDTRACE_UNUSED thread_cpu_time_id _time_id) {
```

This is not a problem on CI or Ivo™️ builds because they'll use `clock_id_from_pthread.c`, not `clock_id_noop.c`.

As for the `ruby.h` include move to the header, it's mainly to address the clang LSP diagnostic:

<img width="1281" alt="image" src="https://github.com/user-attachments/assets/056b83e2-0a0a-45c3-8e30-68d35c4a4433">

Builds themselves work because all current includers of `clock_id.h` have already included `ruby.h` before.


**Additional Notes:**
<!-- Anything else we should know when reviewing? -->

**How to test the change?**
<!--
Describe here how the change can be validated.
You are strongly encouraged to provide automated tests for this PR (unit or integration).
If this change cannot be feasibly tested, please explain why,
unless the change does not modify code (e.g. only modifies docs, comments).
-->

Unsure? Have a question? Request a review!
