### PR TITLE
[PROF-10241] Add extra tags to crash reports

### DIFF
--- a/lib/datadog/core/crashtracking/tag_builder.rb
+++ b/lib/datadog/core/crashtracking/tag_builder.rb
@@ -23,7 +23,10 @@ module Datadog
             'version' => settings.version,
             'git.repository_url' => Environment::Git.git_repository_url,
             'git.commit.sha' => Environment::Git.git_commit_sha,
-            'is_crash' => true
+            'is_crash' => 'true',
+            'severity' => 'crash',
+            'language' => 'ruby',
+            'profiler_version' => Core::Environment::Identity.gem_datadog_version,
           }.compact
 
           # Make sure everything is an utf-8 string, to avoid encoding issues in downstream

--- a/lib/datadog/core/crashtracking/tag_builder.rb
+++ b/lib/datadog/core/crashtracking/tag_builder.rb
@@ -24,7 +24,6 @@ module Datadog
             'git.repository_url' => Environment::Git.git_repository_url,
             'git.commit.sha' => Environment::Git.git_commit_sha,
             'is_crash' => 'true',
-            'severity' => 'crash',
             'language' => 'ruby',
             'profiler_version' => Core::Environment::Identity.gem_datadog_version,
           }.compact

--- a/lib/datadog/core/crashtracking/tag_builder.rb
+++ b/lib/datadog/core/crashtracking/tag_builder.rb
@@ -25,7 +25,7 @@ module Datadog
             'git.commit.sha' => Environment::Git.git_commit_sha,
             'is_crash' => 'true',
             'language' => 'ruby',
-            'profiler_version' => Core::Environment::Identity.gem_datadog_version,
+            'library_version' => Core::Environment::Identity.gem_datadog_version,
           }.compact
 
           # Make sure everything is an utf-8 string, to avoid encoding issues in downstream

--- a/spec/datadog/core/crashtracking/tag_builder_spec.rb
+++ b/spec/datadog/core/crashtracking/tag_builder_spec.rb
@@ -16,7 +16,6 @@ RSpec.describe Datadog::Core::Crashtracking::TagBuilder do
         'runtime_platform' => RUBY_PLATFORM,
         'runtime_version' => RUBY_VERSION,
         'is_crash' => 'true',
-        'severity' => 'crash',
         'language' => 'ruby',
         'profiler_version' => Datadog::Core::Environment::Identity.gem_datadog_version,
       )

--- a/spec/datadog/core/crashtracking/tag_builder_spec.rb
+++ b/spec/datadog/core/crashtracking/tag_builder_spec.rb
@@ -16,6 +16,9 @@ RSpec.describe Datadog::Core::Crashtracking::TagBuilder do
         'runtime_platform' => RUBY_PLATFORM,
         'runtime_version' => RUBY_VERSION,
         'is_crash' => 'true',
+        'severity' => 'crash',
+        'language' => 'ruby',
+        'profiler_version' => Datadog::Core::Environment::Identity.gem_datadog_version,
       )
     end
 

--- a/spec/datadog/core/crashtracking/tag_builder_spec.rb
+++ b/spec/datadog/core/crashtracking/tag_builder_spec.rb
@@ -17,7 +17,7 @@ RSpec.describe Datadog::Core::Crashtracking::TagBuilder do
         'runtime_version' => RUBY_VERSION,
         'is_crash' => 'true',
         'language' => 'ruby',
-        'profiler_version' => Datadog::Core::Environment::Identity.gem_datadog_version,
+        'library_version' => Datadog::Core::Environment::Identity.gem_datadog_version,
       )
     end
 


### PR DESCRIPTION
**What does this PR do?**

This PR adds the following tags to crashtracker reports:
* language
* ~~severity~~
* ~~profiler_version~~ library_version

~~Severity is similar to what we do in Python in
https://github.com/DataDog/dd-trace-py/pull/10199 .~~ Update: We decided to not go with this one for now.

The other two tags seem redundant, but right now if we don't pass them as tags to libdatadog they don't get picked up correctly.

In the future, this won't be needed by libdatadog, but for now this makes it easier for us to analyze reported crashes.

**Motivation:**

Improve crash reports.

**Additional Notes:**

N/A

**How to test the change?**

Change includes test coverage.

For Datadog folks: With this branch, if you crash Ruby, you'll see the crash show up in the usual dashboards. Crashes were not showing up without the "language" tag being set.
