### PR TITLE
Implement telemetry log

### DIFF
--- a/lib/datadog/core/telemetry/component.rb
+++ b/lib/datadog/core/telemetry/component.rb
@@ -111,6 +111,12 @@ module Datadog
           @worker.enqueue(Event::AppIntegrationsChange.new)
         end
 
+        def log!(event)
+          return unless @enabled || forked?
+
+          @worker.enqueue(event)
+        end
+
         # Report configuration changes caused by Remote Configuration.
         def client_configuration_change!(changes)
           return if !@enabled || forked?

--- a/lib/datadog/core/telemetry/event.rb
+++ b/lib/datadog/core/telemetry/event.rb
@@ -334,6 +334,33 @@ module Datadog
           end
         end
 
+        # Telemetry class for the 'logs' event
+        class Log < Base
+          LEVELS = {
+            error: 'ERROR',
+            debug: 'DEBUG',
+            warn: 'WARN',
+          }.freeze
+
+          def type
+            'logs'
+          end
+
+          def initialize(message:, level:)
+            super()
+            @message = message
+            @level = LEVELS.fetch(level) { |k| raise ArgumentError, "Invalid log level :#{k}"}
+          end
+
+          def payload
+            {
+              message: @message,
+              level: @level,
+              # More optional fields to be added here...
+            }
+          end
+        end
+
         # Telemetry class for the 'distributions' event
         class Distributions < GenerateMetrics
           def type

--- a/lib/datadog/core/telemetry/event.rb
+++ b/lib/datadog/core/telemetry/event.rb
@@ -349,7 +349,7 @@ module Datadog
           def initialize(message:, level:)
             super()
             @message = message
-            @level = LEVELS.fetch(level) { |k| raise ArgumentError, "Invalid log level :#{k}"}
+            @level = LEVELS.fetch(level) { |k| raise ArgumentError, "Invalid log level :#{k}" }
           end
 
           def payload

--- a/lib/datadog/core/telemetry/event.rb
+++ b/lib/datadog/core/telemetry/event.rb
@@ -354,9 +354,11 @@ module Datadog
 
           def payload
             {
-              message: @message,
-              level: @level,
-              # More optional fields to be added here...
+              logs: [{
+                message: @message,
+                level: @level,
+                # More optional fields to be added here...
+              }]
             }
           end
         end

--- a/lib/datadog/core/telemetry/logging.rb
+++ b/lib/datadog/core/telemetry/logging.rb
@@ -1,0 +1,35 @@
+# frozen_string_literal: true
+
+require_relative 'event'
+
+module Datadog
+  module Core
+    module Telemetry
+      # Logging interface for sending telemetry logs.
+      #
+      # Reporting internal error so that we can fix them.
+      # IMPORTANT: Make sure to not log any sensitive information.
+      module Logging
+        module_function
+
+        def report(exception, level:)
+          # Annoymous exceptions to be logged as <Class:0x00007f8b1c0b3b40>
+          message = exception.class.name || exception.class.inspect
+
+          event = Event::Log.new(
+            message: message,
+            level: level
+          )
+
+          if (telemetry = Datadog.send(:components).telemetry)
+            telemetry.log!(event)
+          else
+            Datadog.logger.debug do
+              "Attempting to send telemetry log when telemetry component is not ready: #{message}"
+            end
+          end
+        end
+      end
+    end
+  end
+end

--- a/sig/datadog/core/telemetry/component.rbs
+++ b/sig/datadog/core/telemetry/component.rbs
@@ -25,6 +25,8 @@ module Datadog
 
         def integrations_change!: () -> void
 
+        def log!: (Datadog::Core::Telemetry::Event::Log) -> void
+
         def inc: (String namespace, String metric_name, Datadog::Core::Telemetry::Metric::input_value value, ?tags: Datadog::Core::Telemetry::Metric::tags_input, ?common: bool) -> void
 
         def dec: (String namespace, String metric_name, Datadog::Core::Telemetry::Metric::input_value value, ?tags: Datadog::Core::Telemetry::Metric::tags_input, ?common: bool) -> void

--- a/sig/datadog/core/telemetry/event.rbs
+++ b/sig/datadog/core/telemetry/event.rbs
@@ -67,6 +67,17 @@ module Datadog
           def initialize: (String namespace, Enumerable[Datadog::Core::Telemetry::Metric::Base] metric_series) -> void
         end
 
+        class Log < Base
+          LEVELS: Hash[Symbol, String]
+
+          @message: String
+          @level: "ERROR" | "DEBUG" | "WARN"
+
+          def initialize: (message: String, level: Symbol) -> void
+
+          def payload: () -> { message: String, level: String }
+        end
+
         class Distributions < GenerateMetrics
         end
 

--- a/sig/datadog/core/telemetry/event.rbs
+++ b/sig/datadog/core/telemetry/event.rbs
@@ -75,7 +75,7 @@ module Datadog
 
           def initialize: (message: String, level: Symbol) -> void
 
-          def payload: () -> { message: String, level: String }
+          def payload: () -> { logs: [{ message: String, level: String }] }
         end
 
         class Distributions < GenerateMetrics

--- a/sig/datadog/core/telemetry/logging.rbs
+++ b/sig/datadog/core/telemetry/logging.rbs
@@ -1,0 +1,9 @@
+module Datadog
+  module Core
+    module Telemetry
+      module Logging
+        def report: (Exception exception, level: Symbol) -> void
+      end
+    end
+  end
+end

--- a/spec/datadog/core/telemetry/component_spec.rb
+++ b/spec/datadog/core/telemetry/component_spec.rb
@@ -227,7 +227,7 @@ RSpec.describe Datadog::Core::Telemetry::Component do
     describe 'when enabled' do
       let(:enabled) { true }
       it do
-        event = double('event')
+        event = instance_double(Datadog::Core::Telemetry::Event::Log)
         telemetry.log!(event)
 
         expect(worker).to have_received(:enqueue).with(event)
@@ -236,7 +236,7 @@ RSpec.describe Datadog::Core::Telemetry::Component do
       context 'when in fork', skip: !Process.respond_to?(:fork) do
         it do
           expect_in_fork do
-            event = double('event')
+            event = instance_double(Datadog::Core::Telemetry::Event::Log)
             telemetry.log!(event)
 
             expect(worker).to have_received(:enqueue).with(event)
@@ -249,7 +249,7 @@ RSpec.describe Datadog::Core::Telemetry::Component do
       let(:enabled) { false }
 
       it do
-        event = double('event')
+        event = instance_double(Datadog::Core::Telemetry::Event::Log)
         telemetry.log!(event)
 
         expect(worker).not_to have_received(:enqueue)
@@ -258,7 +258,7 @@ RSpec.describe Datadog::Core::Telemetry::Component do
       context 'when in fork', skip: !Process.respond_to?(:fork) do
         it do
           expect_in_fork do
-            event = double('event')
+            event = instance_double(Datadog::Core::Telemetry::Event::Log)
             telemetry.log!(event)
 
             expect(worker).not_to have_received(:enqueue)

--- a/spec/datadog/core/telemetry/event_spec.rb
+++ b/spec/datadog/core/telemetry/event_spec.rb
@@ -213,6 +213,41 @@ RSpec.describe Datadog::Core::Telemetry::Event do
     end
   end
 
+  context 'Logs' do
+    it do
+      event = Datadog::Core::Telemetry::Event::Log.new(message: 'Hi', level: :error)
+      expect(event.type).to eq('logs')
+      expect(event.payload).to eq(
+        message: 'Hi',
+        level: 'ERROR'
+      )
+    end
+
+    it do
+      event = Datadog::Core::Telemetry::Event::Log.new(message: 'Hi', level: :debug)
+      expect(event.type).to eq('logs')
+      expect(event.payload).to eq(
+        message: 'Hi',
+        level: 'DEBUG'
+      )
+    end
+
+    it do
+      event = Datadog::Core::Telemetry::Event::Log.new(message: 'Hi', level: :warn)
+      expect(event.type).to eq('logs')
+      expect(event.payload).to eq(
+        message: 'Hi',
+        level: 'WARN'
+      )
+    end
+
+    it do
+      expect do
+        Datadog::Core::Telemetry::Event::Log.new(message: 'Hi', level: :unknown)
+      end.to raise_error(ArgumentError, /Invalid log level/)
+    end
+  end
+
   context 'GenerateMetrics' do
     let(:event) { described_class::GenerateMetrics.new(namespace, metrics) }
 

--- a/spec/datadog/core/telemetry/event_spec.rb
+++ b/spec/datadog/core/telemetry/event_spec.rb
@@ -219,10 +219,10 @@ RSpec.describe Datadog::Core::Telemetry::Event do
       expect(event.type).to eq('logs')
       expect(event.payload).to eq(
         {
-          logs: [
+          logs: [{
             message: 'Hi',
             level: 'ERROR'
-          ]
+          }]
         }
       )
     end
@@ -232,10 +232,10 @@ RSpec.describe Datadog::Core::Telemetry::Event do
       expect(event.type).to eq('logs')
       expect(event.payload).to eq(
         {
-          logs: [
+          logs: [{
             message: 'Hi',
             level: 'DEBUG'
-          ]
+          }]
         }
       )
     end
@@ -245,10 +245,10 @@ RSpec.describe Datadog::Core::Telemetry::Event do
       expect(event.type).to eq('logs')
       expect(event.payload).to eq(
         {
-          logs: [
+          logs: [{
             message: 'Hi',
             level: 'WARN'
-          ]
+          }]
         }
       )
     end

--- a/spec/datadog/core/telemetry/event_spec.rb
+++ b/spec/datadog/core/telemetry/event_spec.rb
@@ -218,8 +218,12 @@ RSpec.describe Datadog::Core::Telemetry::Event do
       event = Datadog::Core::Telemetry::Event::Log.new(message: 'Hi', level: :error)
       expect(event.type).to eq('logs')
       expect(event.payload).to eq(
-        message: 'Hi',
-        level: 'ERROR'
+        {
+          logs: [
+            message: 'Hi',
+            level: 'ERROR'
+          ]
+        }
       )
     end
 
@@ -227,8 +231,12 @@ RSpec.describe Datadog::Core::Telemetry::Event do
       event = Datadog::Core::Telemetry::Event::Log.new(message: 'Hi', level: :debug)
       expect(event.type).to eq('logs')
       expect(event.payload).to eq(
-        message: 'Hi',
-        level: 'DEBUG'
+        {
+          logs: [
+            message: 'Hi',
+            level: 'DEBUG'
+          ]
+        }
       )
     end
 
@@ -236,8 +244,12 @@ RSpec.describe Datadog::Core::Telemetry::Event do
       event = Datadog::Core::Telemetry::Event::Log.new(message: 'Hi', level: :warn)
       expect(event.type).to eq('logs')
       expect(event.payload).to eq(
-        message: 'Hi',
-        level: 'WARN'
+        {
+          logs: [
+            message: 'Hi',
+            level: 'WARN'
+          ]
+        }
       )
     end
 

--- a/spec/datadog/core/telemetry/logging_spec.rb
+++ b/spec/datadog/core/telemetry/logging_spec.rb
@@ -1,12 +1,13 @@
 require 'spec_helper'
 
 require 'datadog/core/telemetry/logging'
+require 'datadog/core/telemetry/component'
 
 RSpec.describe Datadog::Core::Telemetry::Logging do
   describe '.report' do
     context 'with named exception' do
       it 'sends a log event to via telemetry' do
-        telemetry = double('telemetry')
+        telemetry = instance_double(Datadog::Core::Telemetry::Component)
         allow(Datadog.send(:components)).to receive(:telemetry).and_return(telemetry)
         expect(telemetry).to receive(:log!).with(instance_of(Datadog::Core::Telemetry::Event::Log)) do |event|
           expect(event.payload).to include(message: 'RuntimeError', level: 'ERROR')
@@ -22,7 +23,7 @@ RSpec.describe Datadog::Core::Telemetry::Logging do
 
     context 'with anonymous exception' do
       it 'sends a log event to via telemetry' do
-        telemetry = double('telemetry')
+        telemetry = instance_double(Datadog::Core::Telemetry::Component)
         allow(Datadog.send(:components)).to receive(:telemetry).and_return(telemetry)
         expect(telemetry).to receive(:log!).with(instance_of(Datadog::Core::Telemetry::Event::Log)) do |event|
           expect(event.payload).to include(message: /#<Class:/, level: 'ERROR')

--- a/spec/datadog/core/telemetry/logging_spec.rb
+++ b/spec/datadog/core/telemetry/logging_spec.rb
@@ -1,0 +1,58 @@
+require 'spec_helper'
+
+require 'datadog/core/telemetry/logging'
+
+RSpec.describe Datadog::Core::Telemetry::Logging do
+  describe '.report' do
+    context 'with named exception' do
+      it 'sends a log event to via telemetry' do
+        telemetry = double('telemetry')
+        allow(Datadog.send(:components)).to receive(:telemetry).and_return(telemetry)
+        expect(telemetry).to receive(:log!).with(instance_of(Datadog::Core::Telemetry::Event::Log)) do |event|
+          expect(event.payload).to include(message: 'RuntimeError', level: 'ERROR')
+        end
+
+        begin
+          raise 'Invalid token: p@ssw0rd'
+        rescue StandardError => e
+          described_class.report(e, level: :error)
+        end
+      end
+    end
+
+    context 'with anonymous exception' do
+      it 'sends a log event to via telemetry' do
+        telemetry = double('telemetry')
+        allow(Datadog.send(:components)).to receive(:telemetry).and_return(telemetry)
+        expect(telemetry).to receive(:log!).with(instance_of(Datadog::Core::Telemetry::Event::Log)) do |event|
+          expect(event.payload).to include(message: /#<Class:/, level: 'ERROR')
+        end
+
+        customer_exception = Class.new(StandardError)
+
+        begin
+          raise customer_exception, 'Invalid token: p@ssw0rd'
+        rescue StandardError => e
+          described_class.report(e, level: :error)
+        end
+      end
+    end
+
+    context 'when telemetry component is not available' do
+      it 'does not sends a log event to via telemetry' do
+        logger = Logger.new($stdout)
+        expect(Datadog.send(:components)).to receive(:telemetry).and_return(nil)
+        expect(Datadog).to receive(:logger).and_return(logger)
+        expect(logger).to receive(:debug).with(no_args) do |&block|
+          expect(block.call).to match /Attempting to send telemetry log when telemetry component is not ready/
+        end
+
+        begin
+          raise 'Invalid token: p@ssw0rd'
+        rescue StandardError => e
+          described_class.report(e, level: :error)
+        end
+      end
+    end
+  end
+end

--- a/spec/datadog/core/telemetry/logging_spec.rb
+++ b/spec/datadog/core/telemetry/logging_spec.rb
@@ -45,7 +45,7 @@ RSpec.describe Datadog::Core::Telemetry::Logging do
         expect(Datadog.send(:components)).to receive(:telemetry).and_return(nil)
         expect(Datadog).to receive(:logger).and_return(logger)
         expect(logger).to receive(:debug).with(no_args) do |&block|
-          expect(block.call).to match /Attempting to send telemetry log when telemetry component is not ready/
+          expect(block.call).to match(/Attempting to send telemetry log when telemetry component is not ready/)
         end
 
         begin

--- a/spec/datadog/core/telemetry/logging_spec.rb
+++ b/spec/datadog/core/telemetry/logging_spec.rb
@@ -10,7 +10,7 @@ RSpec.describe Datadog::Core::Telemetry::Logging do
         telemetry = instance_double(Datadog::Core::Telemetry::Component)
         allow(Datadog.send(:components)).to receive(:telemetry).and_return(telemetry)
         expect(telemetry).to receive(:log!).with(instance_of(Datadog::Core::Telemetry::Event::Log)) do |event|
-          expect(event.payload).to include(message: 'RuntimeError', level: 'ERROR')
+          expect(event.payload).to include(logs: [{ message: 'RuntimeError', level: 'ERROR' }])
         end
 
         begin
@@ -26,7 +26,7 @@ RSpec.describe Datadog::Core::Telemetry::Logging do
         telemetry = instance_double(Datadog::Core::Telemetry::Component)
         allow(Datadog.send(:components)).to receive(:telemetry).and_return(telemetry)
         expect(telemetry).to receive(:log!).with(instance_of(Datadog::Core::Telemetry::Event::Log)) do |event|
-          expect(event.payload).to include(message: /#<Class:/, level: 'ERROR')
+          expect(event.payload).to include(logs: [{ message: /#<Class:/, level: 'ERROR' }])
         end
 
         customer_exception = Class.new(StandardError)


### PR DESCRIPTION
**What does this PR do?**

This PR enables developer to send telemetry logs for internal observability.