### PR TITLE
Fix confusion in the SpanFilter docstring

### DIFF
--- a/lib/datadog/tracing/pipeline/span_filter.rb
+++ b/lib/datadog/tracing/pipeline/span_filter.rb
@@ -10,8 +10,8 @@ module Datadog
       # This processor executes the configured `operation` for each {Datadog::Tracing::Span}
       # in a {Datadog::Tracing::TraceSegment}.
       #
-      # If `operation` returns a truthy value for a span, that span is kept,
-      # otherwise the span is removed from the trace.
+      # If `operation` returns a truthy value for a span, that span is dropped,
+      # otherwise the span is kept.
       #
       # @public_api
       class SpanFilter < SpanProcessor


### PR DESCRIPTION
**What does this PR do?**
The docstring was claiming that a truthy value from the filter block keeps the span, but in fact it's the other way around, a truthy value drops the span.

**Motivation:**
Found this by accident, and given that "truthy to filter" is already unintuitive enough, having the docs lie doesn't exactly help :D

**Additional Notes:**
Nope.

**How to test the change?**
Visual review should suffice.
