### PR TITLE
[NO-TICKET] Add memory leak testing for profiling + fix (small) memory leak in profiler

### DIFF
--- a/.github/workflows/test-memory-leaks.yaml
+++ b/.github/workflows/test-memory-leaks.yaml
@@ -2,7 +2,7 @@ name: Test for memory leaks
 on: [push]
 jobs:
   test-memcheck:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     steps:
       - uses: actions/checkout@v4
       - uses: ruby/setup-ruby@v1

--- a/.github/workflows/test-memory-leaks.yaml
+++ b/.github/workflows/test-memory-leaks.yaml
@@ -11,4 +11,5 @@ jobs:
           bundler-cache: true # runs 'bundle install' and caches installed gems automatically
           bundler: latest
           cache-version: v1 # bump this to invalidate cache
+      - run: sudo apt install -y valgrind && valgrind --version
       - run: bundle exec rake compile spec:profiling:memcheck

--- a/.github/workflows/test-memory-leaks.yaml
+++ b/.github/workflows/test-memory-leaks.yaml
@@ -1,0 +1,14 @@
+name: Test for memory leaks
+on: [push]
+jobs:
+  test-memcheck:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: ruby/setup-ruby@v1
+        with:
+          ruby-version: 3.4.0-preview1 # TODO: Use stable version once 3.4 is out
+          bundler-cache: true # runs 'bundle install' and caches installed gems automatically
+          bundler: latest
+          cache-version: v1 # bump this to invalidate cache
+      - run: bundle exec rake compile spec:profiling:memcheck

--- a/Gemfile
+++ b/Gemfile
@@ -44,7 +44,12 @@ gem 'webmock', '>= 3.10.0'
 
 gem 'rexml', '>= 3.2.7' # https://www.ruby-lang.org/en/news/2024/05/16/dos-rexml-cve-2024-35176/
 
-gem 'webrick', '>= 1.7.0' if RUBY_VERSION >= '3.0.0' # No longer bundled by default since Ruby 3.0
+if RUBY_VERSION.start_with?('3.4.')
+  # ruby 3.4 breaks stable webrick; we need this fix until a version later than 1.8.1 comes out
+  gem 'webrick', git: 'https://github.com/ruby/webrick.git', ref: '0c600e169bd4ae267cb5eeb6197277c848323bbe'
+elsif RUBY_VERSION >= '3.0.0' # No longer bundled by default since Ruby 3.0
+  gem 'webrick', '>= 1.7.0'
+end
 
 gem 'yard', '~> 0.9' # NOTE: YardDoc is generated with ruby 3.2 in GitHub Actions
 

--- a/Gemfile
+++ b/Gemfile
@@ -83,6 +83,7 @@ group :check do
     gem 'steep', '~> 1.6.0', require: false
   end
   gem 'standard', require: false
+  gem 'ruby_memcheck', '>= 3' if RUBY_VERSION >= '3.4.0' && RUBY_PLATFORM != 'java'
 end
 
 group :dev do

--- a/Gemfile
+++ b/Gemfile
@@ -87,8 +87,8 @@ group :check do
     gem 'rbs', '~> 3.2.0', require: false
     gem 'steep', '~> 1.6.0', require: false
   end
-  gem 'standard', require: false
   gem 'ruby_memcheck', '>= 3' if RUBY_VERSION >= '3.4.0' && RUBY_PLATFORM != 'java'
+  gem 'standard', require: false
 end
 
 group :dev do

--- a/benchmarks/profiler_gc.rb
+++ b/benchmarks/profiler_gc.rb
@@ -38,7 +38,7 @@ class ProfilerGcBenchmark
       x.report('profiler gc') do
         Datadog::Profiling::Collectors::ThreadContext::Testing._native_on_gc_start(@collector)
         Datadog::Profiling::Collectors::ThreadContext::Testing._native_on_gc_finish(@collector)
-        Datadog::Profiling::Collectors::ThreadContext::Testing._native_sample_after_gc(@collector)
+        Datadog::Profiling::Collectors::ThreadContext::Testing._native_sample_after_gc(@collector, false)
       end
 
       x.save! "#{File.basename(__FILE__)}-results.json" unless VALIDATE_BENCHMARK_MODE
@@ -61,7 +61,7 @@ class ProfilerGcBenchmark
         estimated_gc_per_minute.times do
           Datadog::Profiling::Collectors::ThreadContext::Testing._native_on_gc_start(@collector)
           Datadog::Profiling::Collectors::ThreadContext::Testing._native_on_gc_finish(@collector)
-          Datadog::Profiling::Collectors::ThreadContext::Testing._native_sample_after_gc(@collector)
+          Datadog::Profiling::Collectors::ThreadContext::Testing._native_sample_after_gc(@collector, false)
         end
 
         @recorder.serialize

--- a/ext/datadog_profiling_native_extension/collectors_stack.c
+++ b/ext/datadog_profiling_native_extension/collectors_stack.c
@@ -117,8 +117,7 @@ static VALUE _native_sample(
     };
   }
 
-  int max_frames_requested = NUM2INT(max_frames);
-  if (max_frames_requested < 0) rb_raise(rb_eArgError, "Invalid max_frames: value must not be negative");
+  int max_frames_requested = sampling_buffer_check_max_frames(NUM2INT(max_frames));
 
   ddog_prof_Location *locations = ruby_xcalloc(max_frames_requested, sizeof(ddog_prof_Location));
   sampling_buffer *buffer = sampling_buffer_new(max_frames_requested, locations);

--- a/ext/datadog_profiling_native_extension/collectors_thread_context.c
+++ b/ext/datadog_profiling_native_extension/collectors_thread_context.c
@@ -1223,6 +1223,9 @@ static VALUE _native_reset_after_fork(DDTRACE_UNUSED VALUE self, VALUE collector
   struct thread_context_collector_state *state;
   TypedData_Get_Struct(collector_instance, struct thread_context_collector_state, &thread_context_collector_typed_data, state);
 
+  // Release all context memory before clearing the existing context
+  st_foreach(state->hash_map_per_thread_context, hash_map_per_thread_context_free_values, 0 /* unused */);
+
   st_clear(state->hash_map_per_thread_context);
 
   state->stats = (struct stats) {}; // Resets all stats back to zero

--- a/ext/datadog_profiling_native_extension/private_vm_api_access.c
+++ b/ext/datadog_profiling_native_extension/private_vm_api_access.c
@@ -182,7 +182,7 @@ uint64_t native_thread_id_for(VALUE thread) {
   #if !defined(NO_THREAD_TID) && defined(RB_THREAD_T_HAS_NATIVE_ID)
     #ifndef NO_RB_NATIVE_THREAD
       struct rb_native_thread* native_thread = thread_struct_from_object(thread)->nt;
-      if (native_thread == NULL) rb_raise(rb_eRuntimeError, "BUG: rb_native_thread* is null. Is this Ruby running with RUBY_MN_THREADS=1?");
+      if (native_thread == NULL) return 0;
       return native_thread->tid;
     #else
       return thread_struct_from_object(thread)->tid;

--- a/spec/datadog/profiling/collectors/cpu_and_wall_time_worker_spec.rb
+++ b/spec/datadog/profiling/collectors/cpu_and_wall_time_worker_spec.rb
@@ -168,7 +168,7 @@ RSpec.describe Datadog::Profiling::Collectors::CpuAndWallTimeWorker do
       # See native bits for more details.
       let(:options) { {**super(), skip_idle_samples_for_testing: true} }
 
-      it "triggers sampling and records the results" do
+      it "triggers sampling and records the results", :memcheck_valgrind_skip do
         start
 
         all_samples = loop_until do
@@ -182,6 +182,7 @@ RSpec.describe Datadog::Profiling::Collectors::CpuAndWallTimeWorker do
       it(
         "keeps statistics on how many samples were triggered by the background thread, " \
         "as well as how many samples were requested from the VM",
+        :memcheck_valgrind_skip,
       ) do
         start
 
@@ -337,7 +338,7 @@ RSpec.describe Datadog::Profiling::Collectors::CpuAndWallTimeWorker do
         background_thread.join
       end
 
-      it "is able to sample even when the main thread is sleeping" do
+      it "is able to sample even when the main thread is sleeping", :memcheck_valgrind_skip do
         background_thread
         ready_queue.pop
 
@@ -546,7 +547,7 @@ RSpec.describe Datadog::Profiling::Collectors::CpuAndWallTimeWorker do
         # and we clamp it if it goes over the limit.
         # But the total amount of allocations recorded should match the number we observed, and thus we record the
         # remainder above the clamped value as a separate "Skipped Samples" step.
-        context "with a high allocation rate" do
+        context "with a high allocation rate", :memcheck_valgrind_skip do
           let(:options) { {**super(), dynamic_sampling_rate_overhead_target_percentage: 0.1} }
           let(:thread_that_allocates_as_fast_as_possible) { Thread.new { loop { BasicObject.new } } }
 

--- a/spec/datadog/profiling/collectors/thread_context_spec.rb
+++ b/spec/datadog/profiling/collectors/thread_context_spec.rb
@@ -71,8 +71,8 @@ RSpec.describe Datadog::Profiling::Collectors::ThreadContext do
     described_class::Testing._native_on_gc_finish(cpu_and_wall_time_collector)
   end
 
-  def sample_after_gc
-    described_class::Testing._native_sample_after_gc(cpu_and_wall_time_collector)
+  def sample_after_gc(reset_monotonic_to_system_state: false)
+    described_class::Testing._native_sample_after_gc(cpu_and_wall_time_collector, reset_monotonic_to_system_state)
   end
 
   def sample_allocation(weight:, new_object: Object.new)
@@ -1019,7 +1019,7 @@ RSpec.describe Datadog::Profiling::Collectors::ThreadContext do
         end
 
         it "creates a Garbage Collection sample using the timestamp set by on_gc_finish, converted to epoch ns" do
-          sample_after_gc
+          sample_after_gc(reset_monotonic_to_system_state: true)
 
           expect(gc_sample.labels.fetch(:end_timestamp_ns)).to be_between(@time_before, @time_after)
         end

--- a/spec/datadog/profiling/native_extension_spec.rb
+++ b/spec/datadog/profiling/native_extension_spec.rb
@@ -120,7 +120,7 @@ RSpec.describe Datadog::Profiling::NativeExtension do
       it { is_expected.to be false }
     end
 
-    describe "correctness" do
+    describe "correctness", :memcheck_valgrind_skip do
       let(:ready_queue) { Queue.new }
       let(:background_thread) do
         Thread.new do

--- a/spec/datadog/profiling/validate_benchmarks_spec.rb
+++ b/spec/datadog/profiling/validate_benchmarks_spec.rb
@@ -1,6 +1,6 @@
 require "datadog/profiling/spec_helper"
 
-RSpec.describe "Profiling benchmarks" do
+RSpec.describe "Profiling benchmarks", :memcheck_valgrind_skip do
   before { skip_if_profiling_not_supported(self) }
 
   around do |example|

--- a/spec/datadog/release_gem_spec.rb
+++ b/spec/datadog/release_gem_spec.rb
@@ -59,6 +59,7 @@ RSpec.describe 'gem release process' do
             |tasks
             |yard
             |vendor/rbs
+            |suppressions
           )/
         }x
 

--- a/suppressions/ruby-3.4.supp
+++ b/suppressions/ruby-3.4.supp
@@ -15,3 +15,10 @@
   ...
 }
 
+{
+  pkg-config-memory
+  Memcheck:Leak
+  ...
+  obj:/usr/bin/pkg-config
+  ...
+}

--- a/suppressions/ruby-3.4.supp
+++ b/suppressions/ruby-3.4.supp
@@ -1,0 +1,17 @@
+# This is a valgrind suppression configuration file.
+#
+# We use it together with the ruby_memcheck gem to find issues in the dd-trace-rb native extensions; in some cases
+# we need to ignore potential issues as they're not something we can fix (e.g. outside our code.)
+#
+# See https://valgrind.org/docs/manual/manual-core.html#manual-core.suppress for details.
+
+{
+  ruby-weak-map
+  Memcheck:Addr8
+  fun:wmap_cmp
+  fun:find_table_bin_ind
+  fun:st_general_foreach
+  fun:rb_st_foreach
+  ...
+}
+

--- a/suppressions/ruby-3.4.supp
+++ b/suppressions/ruby-3.4.supp
@@ -5,6 +5,7 @@
 #
 # See https://valgrind.org/docs/manual/manual-core.html#manual-core.suppress for details.
 
+# Ruby weak maps seem to be able to cause invalid reads?
 {
   ruby-weak-map
   Memcheck:Addr8
@@ -15,10 +16,25 @@
   ...
 }
 
+# We don't care about the pkg-config external tool
 {
   pkg-config-memory
   Memcheck:Leak
   ...
   obj:/usr/bin/pkg-config
+  ...
+}
+
+# When a Ruby process forks, it looks like Ruby doesn't clean up the memory of old threads?
+{
+  ruby-native-thread-memory
+  Memcheck:Leak
+  fun:calloc
+  fun:calloc1
+  fun:rb_gc_impl_calloc
+  fun:native_thread_alloc
+  fun:native_thread_create_dedicated
+  fun:native_thread_create
+  fun:thread_create_core
   ...
 }

--- a/suppressions/ruby-3.4.supp
+++ b/suppressions/ruby-3.4.supp
@@ -16,15 +16,6 @@
   ...
 }
 
-# We don't care about the pkg-config external tool
-{
-  pkg-config-memory
-  Memcheck:Leak
-  ...
-  obj:/usr/bin/pkg-config
-  ...
-}
-
 # When a Ruby process forks, it looks like Ruby doesn't clean up the memory of old threads?
 {
   ruby-native-thread-memory
@@ -51,5 +42,23 @@
   fun:native_thread_create_dedicated
   fun:native_thread_create
   fun:thread_create_core
+  ...
+}
+
+# We don't care about the pkg-config external tool
+{
+  pkg-config-memory
+  Memcheck:Leak
+  ...
+  obj:/usr/bin/pkg-config
+  ...
+}
+
+# We don't care about the tr external tool
+{
+  pkg-config-memory
+  Memcheck:Leak
+  ...
+  obj:/usr/bin/tr
   ...
 }

--- a/suppressions/ruby-3.4.supp
+++ b/suppressions/ruby-3.4.supp
@@ -38,3 +38,18 @@
   fun:thread_create_core
   ...
 }
+
+# When a Ruby process forks, it looks like Ruby doesn't clean up the memory of old threads?
+{
+  ruby-native-thread-memory-2
+  Memcheck:Leak
+  fun:calloc
+  fun:calloc1
+  fun:objspace_xcalloc
+  fun:ruby_xcalloc_body
+  fun:native_thread_alloc
+  fun:native_thread_create_dedicated
+  fun:native_thread_create
+  fun:thread_create_core
+  ...
+}


### PR DESCRIPTION
**What does this PR do?**

The [`ruby_memcheck`](https://github.com/Shopify/ruby_memcheck) gem provides a Ruby-specific user-friendly wrapper around valgrind.

This PR sets up this gem to run the profiling test suite in CI with this gem, thus helping us catch memory leaks during development.

It also fixes a few memory leaks:
* We were leaking a small amount of memory when the Ruby process forked with the profiler enabled (we cleaned up the per-thread context hashtable, but did not call free on the things it contained)
* The stack collector native test code was a bit YOLO with exceptions and would not release memory in a few cases when exceptions were raised. This code was only used for running specs, so it did not impact actual usage, but solving it allows us to have a 100% clean ruby_memcheck run

**Motivation:**

Improve validation of our native bits.

**Additional Notes:**

I've chosen to use GitHub Actions for the new CI job, rather than CircleCI. I don't have a very strong preference for either, it's just that it was easier to use the latest valgrind version by picking the latest Ubuntu image on GHA.

In some cases, some of our tests were hanging or timing out due to how valgrind runs code in a sequential manner. I've added a new tag to be able to skip such tests.

I also explored using valgrind's `fair-sched` option (see https://github.com/Shopify/ruby_memcheck/issues/51) but ran into issues with its output being incomplete, so decided to go the skip route instead.

Initially I started testing `ruby_memcheck` with Ruby 3.3, but on that version the filtering of valgrind output is too aggressive for our setup, and it did not report anything [(see here for more details)](https://github.com/Shopify/ruby_memcheck#:~:text=use_only_ruby_free_at_exit). Thus, I moved my experiments to Ruby 3.4 and it worked much better.

**How to test the change?**

You can run the new job with `bundle exec rake spec:profiling:memcheck`.

Here's a successful run of the new CI job: https://github.com/DataDog/dd-trace-rb/actions/runs/10468881841/job/28990709088

Also, if you're curious how it looks, comment freeing any libdatadog resource or other profiler native resource, and you will see valgrind complaining. Here's what happened when I did that: https://github.com/DataDog/dd-trace-rb/actions/runs/10469151578/job/28991521438