### PR TITLE
[NO-TICKET] Fix profiler `inline` helpers not working when optimization disabled

### DIFF
--- a/ext/datadog_profiling_native_extension/collectors_discrete_dynamic_sampler.c
+++ b/ext/datadog_profiling_native_extension/collectors_discrete_dynamic_sampler.c
@@ -21,7 +21,7 @@
 #define EMA_SMOOTHING_FACTOR 0.6
 
 static void maybe_readjust(discrete_dynamic_sampler *sampler, long now_ns);
-inline bool should_readjust(discrete_dynamic_sampler *sampler, coarse_instant now);
+static inline bool should_readjust(discrete_dynamic_sampler *sampler, coarse_instant now);
 
 void discrete_dynamic_sampler_init(discrete_dynamic_sampler *sampler, const char *debug_name, long now_ns) {
   sampler->debug_name = debug_name;
@@ -119,7 +119,7 @@ static void maybe_readjust(discrete_dynamic_sampler *sampler, long now_ns) {
   if (should_readjust(sampler, to_coarse_instant(now_ns))) discrete_dynamic_sampler_readjust(sampler, now_ns);
 }
 
-inline bool should_readjust(discrete_dynamic_sampler *sampler, coarse_instant now) {
+static inline bool should_readjust(discrete_dynamic_sampler *sampler, coarse_instant now) {
   long this_window_time_ns =
     sampler->last_readjust_time_ns == 0 ? ADJUSTMENT_WINDOW_NS : now.timestamp_ns - sampler->last_readjust_time_ns;
 

--- a/ext/datadog_profiling_native_extension/datadog_ruby_common.h
+++ b/ext/datadog_profiling_native_extension/datadog_ruby_common.h
@@ -33,7 +33,7 @@ NORETURN(void raise_unexpected_type(VALUE value, const char *value_name, const c
 // Helper to retrieve Datadog::VERSION::STRING
 VALUE datadog_gem_version(void);
 
-inline static ddog_CharSlice char_slice_from_ruby_string(VALUE string) {
+static inline ddog_CharSlice char_slice_from_ruby_string(VALUE string) {
   ENFORCE_TYPE(string, T_STRING);
   ddog_CharSlice char_slice = {.ptr = RSTRING_PTR(string), .len = RSTRING_LEN(string)};
   return char_slice;
@@ -45,12 +45,12 @@ ddog_prof_Endpoint endpoint_from(VALUE exporter_configuration);
 __attribute__((warn_unused_result))
 ddog_Vec_Tag convert_tags(VALUE tags_as_array);
 
-inline static VALUE ruby_string_from_error(const ddog_Error *error) {
+static inline VALUE ruby_string_from_error(const ddog_Error *error) {
   ddog_CharSlice char_slice = ddog_Error_message(error);
   return rb_str_new(char_slice.ptr, char_slice.len);
 }
 
-inline static VALUE get_error_details_and_drop(ddog_Error *error) {
+static inline VALUE get_error_details_and_drop(ddog_Error *error) {
   VALUE result = ruby_string_from_error(error);
   ddog_Error_drop(error);
   return result;

--- a/ext/datadog_profiling_native_extension/helpers.h
+++ b/ext/datadog_profiling_native_extension/helpers.h
@@ -4,9 +4,9 @@
 
 // @ivoanjo: After trying to read through https://stackoverflow.com/questions/3437404/min-and-max-in-c I decided I
 // don't like C and I just implemented this as a function.
-inline static uint64_t uint64_max_of(uint64_t a, uint64_t b) { return a > b ? a : b; }
-inline static uint64_t uint64_min_of(uint64_t a, uint64_t b) { return a > b ? b : a; }
-inline static long long_max_of(long a, long b) { return a > b ? a : b; }
-inline static long long_min_of(long a, long b) { return a > b ? b : a; }
-inline static double double_max_of(double a, double b) { return a > b ? a : b; }
-inline static double double_min_of(double a, double b) { return a > b ? b : a; }
+static inline uint64_t uint64_max_of(uint64_t a, uint64_t b) { return a > b ? a : b; }
+static inline uint64_t uint64_min_of(uint64_t a, uint64_t b) { return a > b ? b : a; }
+static inline long long_max_of(long a, long b) { return a > b ? a : b; }
+static inline long long_min_of(long a, long b) { return a > b ? b : a; }
+static inline double double_max_of(double a, double b) { return a > b ? a : b; }
+static inline double double_min_of(double a, double b) { return a > b ? b : a; }

--- a/ext/datadog_profiling_native_extension/http_transport.c
+++ b/ext/datadog_profiling_native_extension/http_transport.c
@@ -21,7 +21,7 @@ struct call_exporter_without_gvl_arguments {
   bool send_ran;
 };
 
-inline static ddog_ByteSlice byte_slice_from_ruby_string(VALUE string);
+static inline ddog_ByteSlice byte_slice_from_ruby_string(VALUE string);
 static VALUE _native_validate_exporter(VALUE self, VALUE exporter_configuration);
 static ddog_prof_Exporter_NewResult create_exporter(VALUE exporter_configuration, VALUE tags_as_array);
 static VALUE handle_exporter_failure(ddog_prof_Exporter_NewResult exporter_result);
@@ -57,7 +57,7 @@ void http_transport_init(VALUE profiling_module) {
   rb_global_variable(&library_version_string);
 }
 
-inline static ddog_ByteSlice byte_slice_from_ruby_string(VALUE string) {
+static inline ddog_ByteSlice byte_slice_from_ruby_string(VALUE string) {
   ENFORCE_TYPE(string, T_STRING);
   ddog_ByteSlice byte_slice = {.ptr = (uint8_t *) StringValuePtr(string), .len = RSTRING_LEN(string)};
   return byte_slice;

--- a/ext/datadog_profiling_native_extension/libdatadog_helpers.h
+++ b/ext/datadog_profiling_native_extension/libdatadog_helpers.h
@@ -3,7 +3,7 @@
 #include <datadog/profiling.h>
 #include "ruby_helpers.h"
 
-inline static VALUE ruby_string_from_vec_u8(ddog_Vec_U8 string) {
+static inline VALUE ruby_string_from_vec_u8(ddog_Vec_U8 string) {
   return rb_str_new((char *) string.ptr, string.len);
 }
 
@@ -20,6 +20,6 @@ ddog_CharSlice ruby_value_type_to_char_slice(enum ruby_value_type type);
 
 // Returns a dynamically allocated string from the provided char slice.
 // WARN: The returned string must be explicitly freed with ruby_xfree.
-inline static char* string_from_char_slice(ddog_CharSlice slice) {
+static inline char* string_from_char_slice(ddog_CharSlice slice) {
   return ruby_strndup(slice.ptr, slice.len);
 }

--- a/ext/datadog_profiling_native_extension/private_vm_api_access.c
+++ b/ext/datadog_profiling_native_extension/private_vm_api_access.c
@@ -311,7 +311,7 @@ VALUE thread_name_for(VALUE thread) {
 // with diagnostic stuff. See https://nelkinda.com/blog/suppress-warnings-in-gcc-and-clang/#d11e364 for details.
 #pragma GCC diagnostic push
 #pragma GCC diagnostic ignored "-Wunused-parameter"
-inline static int
+static inline int
 calc_pos(const rb_iseq_t *iseq, const VALUE *pc, int *lineno, int *node_id)
 {
     VM_ASSERT(iseq);
@@ -364,7 +364,7 @@ calc_pos(const rb_iseq_t *iseq, const VALUE *pc, int *lineno, int *node_id)
 // Copyright (C) 1993-2012 Yukihiro Matsumoto
 // to support our custom rb_profile_frames (see below)
 // Modifications: None
-inline static int
+static inline int
 calc_lineno(const rb_iseq_t *iseq, const VALUE *pc)
 {
     int lineno;

--- a/ext/datadog_profiling_native_extension/time_helpers.h
+++ b/ext/datadog_profiling_native_extension/time_helpers.h
@@ -21,7 +21,7 @@ typedef struct {
 
 #define MONOTONIC_TO_SYSTEM_EPOCH_INITIALIZER {.system_epoch_ns_reference = INVALID_TIME, .delta_to_epoch_ns = INVALID_TIME}
 
-inline long retrieve_clock_as_ns(clockid_t clock_id, raise_on_failure_setting raise_on_failure) {
+static inline long retrieve_clock_as_ns(clockid_t clock_id, raise_on_failure_setting raise_on_failure) {
   struct timespec clock_value;
 
   if (clock_gettime(clock_id, &clock_value) != 0) {
@@ -32,8 +32,8 @@ inline long retrieve_clock_as_ns(clockid_t clock_id, raise_on_failure_setting ra
   return clock_value.tv_nsec + SECONDS_AS_NS(clock_value.tv_sec);
 }
 
-inline long monotonic_wall_time_now_ns(raise_on_failure_setting raise_on_failure) { return retrieve_clock_as_ns(CLOCK_MONOTONIC, raise_on_failure); }
-inline long system_epoch_time_now_ns(raise_on_failure_setting raise_on_failure)   { return retrieve_clock_as_ns(CLOCK_REALTIME,  raise_on_failure); }
+static inline long monotonic_wall_time_now_ns(raise_on_failure_setting raise_on_failure) { return retrieve_clock_as_ns(CLOCK_MONOTONIC, raise_on_failure); }
+static inline long system_epoch_time_now_ns(raise_on_failure_setting raise_on_failure)   { return retrieve_clock_as_ns(CLOCK_REALTIME,  raise_on_failure); }
 
 // Coarse instants use CLOCK_MONOTONIC_COARSE on Linux which is expected to provide resolution in the millisecond range:
 // https://docs.redhat.com/en/documentation/red_hat_enterprise_linux_for_real_time/7/html/reference_guide/sect-posix_clocks#Using_clock_getres_to_compare_clock_resolution
@@ -43,9 +43,9 @@ typedef struct coarse_instant {
   long timestamp_ns;
 } coarse_instant;
 
-inline coarse_instant to_coarse_instant(long timestamp_ns) { return (coarse_instant) {.timestamp_ns = timestamp_ns}; }
+static inline coarse_instant to_coarse_instant(long timestamp_ns) { return (coarse_instant) {.timestamp_ns = timestamp_ns}; }
 
-inline coarse_instant monotonic_coarse_wall_time_now_ns(void) {
+static inline coarse_instant monotonic_coarse_wall_time_now_ns(void) {
  #ifdef HAVE_CLOCK_MONOTONIC_COARSE // Linux
     return to_coarse_instant(retrieve_clock_as_ns(CLOCK_MONOTONIC_COARSE, DO_NOT_RAISE_ON_FAILURE));
   #else // macOS

--- a/ext/libdatadog_api/datadog_ruby_common.h
+++ b/ext/libdatadog_api/datadog_ruby_common.h
@@ -33,7 +33,7 @@ NORETURN(void raise_unexpected_type(VALUE value, const char *value_name, const c
 // Helper to retrieve Datadog::VERSION::STRING
 VALUE datadog_gem_version(void);
 
-inline static ddog_CharSlice char_slice_from_ruby_string(VALUE string) {
+static inline ddog_CharSlice char_slice_from_ruby_string(VALUE string) {
   ENFORCE_TYPE(string, T_STRING);
   ddog_CharSlice char_slice = {.ptr = RSTRING_PTR(string), .len = RSTRING_LEN(string)};
   return char_slice;
@@ -45,12 +45,12 @@ ddog_prof_Endpoint endpoint_from(VALUE exporter_configuration);
 __attribute__((warn_unused_result))
 ddog_Vec_Tag convert_tags(VALUE tags_as_array);
 
-inline static VALUE ruby_string_from_error(const ddog_Error *error) {
+static inline VALUE ruby_string_from_error(const ddog_Error *error) {
   ddog_CharSlice char_slice = ddog_Error_message(error);
   return rb_str_new(char_slice.ptr, char_slice.len);
 }
 
-inline static VALUE get_error_details_and_drop(ddog_Error *error) {
+static inline VALUE get_error_details_and_drop(ddog_Error *error) {
   VALUE result = ruby_string_from_error(error);
   ddog_Error_drop(error);
   return result;

--- a/ext/libdatadog_api/extconf.rb
+++ b/ext/libdatadog_api/extconf.rb
@@ -67,7 +67,7 @@ append_cflags '-Wextra'
 
 if ENV['DDTRACE_DEBUG'] == 'true'
   $defs << '-DDD_DEBUG'
-  CONFIG['optflags'] = '-O1'
+  CONFIG['optflags'] = '-O0'
   CONFIG['debugflags'] = '-ggdb3'
 end
 


### PR DESCRIPTION
**What does this PR do?**

This PR makes sure that every `inline` helper in the profile is marked as `static inline`.

As documented in <https://gcc.gnu.org/onlinedocs/gcc/Inline.html#Inline>:

> When a function is both inline and static, if all calls to the function
> are integrated into the caller, and the function’s address is never
> used, then the function’s own assembler code is never referenced.

this is different from just `inline`:

> When an inline function is not static, then the compiler must assume
> that there may be calls from other source files; since a global
> symbol can be defined only once in any program, the function must not
> be defined in the other source files, so the calls therein cannot
> be integrated. Therefore, a non-static inline function is always
> compiled on its own in the usual fashion.

In practice, this manifested as errors such as

> symbol lookup error: datadog_profiling_native_extension.3.4.0_x86_64-linux.so:
> undefined symbol: monotonic_wall_time_now_ns

when building Ruby or the profiler with optimization disabled (`-O0`).

With this fix, these errors no longer show up when building with optimization disabled.

**Motivation:**

Avoid runtime failures in the profiler on Ruby builds with optimization disabled / when debugging the profiler.

**Additional Notes:**

Most of these methods with only `inline` were still unreleased to customers so hopefully nobody was impacted by this issue.

For consistency, I've also made sure that all methods are `static inline` as we had a mix of `inline static` as well.

**How to test the change?**

I was able to trigger the issue by running

```
$ DDTRACE_DEBUG=true bundle exec rake clean compile
$ bundle exec rspec spec/datadog/profiling/
```
