### PR TITLE
Allow GraphQL integration reconfiguration

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -84,6 +84,7 @@ desc 'Run RSpec'
 # rubocop:disable Metrics/BlockLength
 namespace :spec do
   task all: [:main, :benchmark,
+             :graphql, :graphql_unified_trace_patcher, :graphql_trace_patcher, :graphql_tracing_patcher,
              :rails, :railsredis, :railsredis_activesupport, :railsactivejob,
              :elasticsearch, :http, :redis, :sidekiq, :sinatra, :hanami, :hanami_autoinstrument,
              :profiling, :crashtracking]
@@ -98,6 +99,27 @@ namespace :spec do
 
   RSpec::Core::RakeTask.new(:benchmark) do |t, args|
     t.pattern = 'spec/datadog/benchmark/**/*_spec.rb'
+    t.rspec_opts = args.to_a.join(' ')
+  end
+
+  RSpec::Core::RakeTask.new(:graphql) do |t, args|
+    t.pattern = 'spec/datadog/tracing/contrib/graphql/**/*_spec.rb'
+    t.exclude_pattern = 'spec/datadog/tracing/contrib/graphql/{unified_trace,trace,tracing}_patcher_spec.rb'
+    t.rspec_opts = args.to_a.join(' ')
+  end
+
+  RSpec::Core::RakeTask.new(:graphql_unified_trace_patcher) do |t, args|
+    t.pattern = 'spec/datadog/tracing/contrib/graphql/unified_trace_patcher_spec.rb'
+    t.rspec_opts = args.to_a.join(' ')
+  end
+
+  RSpec::Core::RakeTask.new(:graphql_trace_patcher) do |t, args|
+    t.pattern = 'spec/datadog/tracing/contrib/graphql/trace_patcher_spec.rb'
+    t.rspec_opts = args.to_a.join(' ')
+  end
+
+  RSpec::Core::RakeTask.new(:graphql_tracing_patcher) do |t, args|
+    t.pattern = 'spec/datadog/tracing/contrib/graphql/tracing_patcher_spec.rb'
     t.rspec_opts = args.to_a.join(' ')
   end
 
@@ -223,7 +245,6 @@ namespace :spec do
     :excon,
     :faraday,
     :grape,
-    :graphql,
     :grpc,
     :http,
     :httpclient,

--- a/lib/datadog/tracing/contrib/graphql/patcher.rb
+++ b/lib/datadog/tracing/contrib/graphql/patcher.rb
@@ -21,13 +21,18 @@ module Datadog
           end
 
           def patch
+            # DEV-3.0: We should remove as many patching options as possible, given the alternatives do not
+            # DEV-3.0: provide any benefit to the recommended `with_unified_tracer` patching method.
+            # DEV-3.0: `with_deprecated_tracer` is likely safe to remove.
+            # DEV-3.0: `with_unified_tracer: false` should be removed if possible.
+            # DEV-3.0: `with_unified_tracer: true` should be the default and hopefully not even necessary as an option.
             if configuration[:with_deprecated_tracer]
-              TracingPatcher.patch!(schemas, trace_options)
+              TracingPatcher.patch!(schemas)
             elsif Integration.trace_supported?
               if configuration[:with_unified_tracer]
-                UnifiedTracePatcher.patch!(schemas, trace_options)
+                UnifiedTracePatcher.patch!(schemas)
               else
-                TracePatcher.patch!(schemas, trace_options)
+                TracePatcher.patch!(schemas)
               end
             else
               Datadog.logger.warn(
@@ -35,16 +40,8 @@ module Datadog
                 'or Datadog::Tracing::Contrib::GraphQL::UnifiedTrace.'\
                 'Falling back to GraphQL::Tracing::DataDogTracing.'
               )
-              TracingPatcher.patch!(schemas, trace_options)
+              TracingPatcher.patch!(schemas)
             end
-          end
-
-          def trace_options
-            {
-              service: configuration[:service_name],
-              analytics_enabled: Contrib::Analytics.enabled?(configuration[:analytics_enabled]),
-              analytics_sample_rate: configuration[:analytics_sample_rate]
-            }
           end
 
           def configuration

--- a/lib/datadog/tracing/contrib/graphql/trace_patcher.rb
+++ b/lib/datadog/tracing/contrib/graphql/trace_patcher.rb
@@ -8,12 +8,12 @@ module Datadog
         module TracePatcher
           module_function
 
-          def patch!(schemas, options)
+          def patch!(schemas)
             if schemas.empty?
-              ::GraphQL::Schema.trace_with(::GraphQL::Tracing::DataDogTrace, **options)
+              ::GraphQL::Schema.trace_with(::GraphQL::Tracing::DataDogTrace)
             else
               schemas.each do |schema|
-                schema.trace_with(::GraphQL::Tracing::DataDogTrace, **options)
+                schema.trace_with(::GraphQL::Tracing::DataDogTrace)
               end
             end
           end

--- a/lib/datadog/tracing/contrib/graphql/tracing_patcher.rb
+++ b/lib/datadog/tracing/contrib/graphql/tracing_patcher.rb
@@ -8,13 +8,13 @@ module Datadog
         module TracingPatcher
           module_function
 
-          def patch!(schemas, options)
+          def patch!(schemas)
             if schemas.empty?
-              ::GraphQL::Schema.tracer(::GraphQL::Tracing::DataDogTracing.new(**options))
+              ::GraphQL::Schema.tracer(::GraphQL::Tracing::DataDogTracing.new)
             else
               schemas.each do |schema|
                 if schema.respond_to? :use
-                  schema.use(::GraphQL::Tracing::DataDogTracing, **options)
+                  schema.use(::GraphQL::Tracing::DataDogTracing)
                 else
                   Datadog.logger.warn("Unable to patch #{schema}: Please migrate to class-based schema.")
                 end

--- a/lib/datadog/tracing/contrib/graphql/unified_trace_patcher.rb
+++ b/lib/datadog/tracing/contrib/graphql/unified_trace_patcher.rb
@@ -12,12 +12,15 @@ module Datadog
         module UnifiedTracePatcher
           module_function
 
-          def patch!(schemas, options)
+          # TODO: `GraphQL::Schema.trace_with` and `YOUR_SCHEMA.trace_with` don't mix.
+          # TODO: They create duplicate spans when combined.
+          # TODO: We should measure how frequently users use `YOUR_SCHEMA.trace_with`, and hopefully we can remove it.
+          def patch!(schemas)
             if schemas.empty?
-              ::GraphQL::Schema.trace_with(UnifiedTrace, **options)
+              ::GraphQL::Schema.trace_with(UnifiedTrace)
             else
               schemas.each do |schema|
-                schema.trace_with(UnifiedTrace, **options)
+                schema.trace_with(UnifiedTrace)
               end
             end
           end

--- a/spec/datadog/tracing/contrib/graphql/patcher_spec.rb
+++ b/spec/datadog/tracing/contrib/graphql/patcher_spec.rb
@@ -7,9 +7,14 @@ require 'datadog/tracing/contrib/graphql/unified_trace_patcher'
 require 'datadog'
 
 RSpec.describe Datadog::Tracing::Contrib::GraphQL::Patcher do
+  before(:context) { load_test_schema }
+  after(:context) do
+    unload_test_schema
+    remove_patch!(:graphql)
+  end
+
   around do |example|
     remove_patch!(:graphql)
-    Datadog.configuration.reset!
     Datadog.configuration.tracing[:graphql].reset!
 
     without_warnings do
@@ -17,7 +22,6 @@ RSpec.describe Datadog::Tracing::Contrib::GraphQL::Patcher do
     end
 
     remove_patch!(:graphql)
-    Datadog.configuration.reset!
     Datadog.configuration.tracing[:graphql].reset!
   end
 
@@ -26,10 +30,7 @@ RSpec.describe Datadog::Tracing::Contrib::GraphQL::Patcher do
       context 'with default configuration' do
         it 'patches GraphQL' do
           allow(Datadog::Tracing::Contrib::GraphQL::Integration).to receive(:trace_supported?).and_return(true)
-          expect(Datadog::Tracing::Contrib::GraphQL::TracePatcher).to receive(:patch!).with(
-            [],
-            hash_including(:analytics_enabled, :analytics_sample_rate, :service)
-          )
+          expect(Datadog::Tracing::Contrib::GraphQL::TracePatcher).to receive(:patch!).with([])
 
           Datadog.configure do |c|
             c.tracing.instrument :graphql
@@ -40,10 +41,7 @@ RSpec.describe Datadog::Tracing::Contrib::GraphQL::Patcher do
       context 'with with_deprecated_tracer enabled' do
         it do
           allow(Datadog::Tracing::Contrib::GraphQL::Integration).to receive(:trace_supported?).and_return(true)
-          expect(Datadog::Tracing::Contrib::GraphQL::TracingPatcher).to receive(:patch!).with(
-            [],
-            hash_including(:analytics_enabled, :analytics_sample_rate, :service)
-          )
+          expect(Datadog::Tracing::Contrib::GraphQL::TracingPatcher).to receive(:patch!).with([])
 
           Datadog.configure do |c|
             c.tracing.instrument :graphql, with_deprecated_tracer: true
@@ -54,10 +52,7 @@ RSpec.describe Datadog::Tracing::Contrib::GraphQL::Patcher do
       context 'with with_deprecated_tracer disabled' do
         it do
           allow(Datadog::Tracing::Contrib::GraphQL::Integration).to receive(:trace_supported?).and_return(true)
-          expect(Datadog::Tracing::Contrib::GraphQL::TracePatcher).to receive(:patch!).with(
-            [],
-            hash_including(:analytics_enabled, :analytics_sample_rate, :service)
-          )
+          expect(Datadog::Tracing::Contrib::GraphQL::TracePatcher).to receive(:patch!).with([])
 
           Datadog.configure do |c|
             c.tracing.instrument :graphql, with_deprecated_tracer: false
@@ -68,10 +63,7 @@ RSpec.describe Datadog::Tracing::Contrib::GraphQL::Patcher do
       context 'with with_unified_tracer enabled' do
         it do
           allow(Datadog::Tracing::Contrib::GraphQL::Integration).to receive(:trace_supported?).and_return(true)
-          expect(Datadog::Tracing::Contrib::GraphQL::UnifiedTracePatcher).to receive(:patch!).with(
-            [],
-            hash_including(:analytics_enabled, :analytics_sample_rate, :service)
-          )
+          expect(Datadog::Tracing::Contrib::GraphQL::UnifiedTracePatcher).to receive(:patch!).with([])
 
           Datadog.configure do |c|
             c.tracing.instrument :graphql, with_unified_tracer: true
@@ -82,10 +74,7 @@ RSpec.describe Datadog::Tracing::Contrib::GraphQL::Patcher do
       context 'with with_unified_tracer disabled' do
         it do
           allow(Datadog::Tracing::Contrib::GraphQL::Integration).to receive(:trace_supported?).and_return(true)
-          expect(Datadog::Tracing::Contrib::GraphQL::TracePatcher).to receive(:patch!).with(
-            [],
-            hash_including(:analytics_enabled, :analytics_sample_rate, :service)
-          )
+          expect(Datadog::Tracing::Contrib::GraphQL::TracePatcher).to receive(:patch!).with([])
 
           Datadog.configure do |c|
             c.tracing.instrument :graphql, with_unified_tracer: false
@@ -96,10 +85,7 @@ RSpec.describe Datadog::Tracing::Contrib::GraphQL::Patcher do
       context 'with with_unified_tracer enabled and with_deprecated_tracer enabled' do
         it do
           allow(Datadog::Tracing::Contrib::GraphQL::Integration).to receive(:trace_supported?).and_return(true)
-          expect(Datadog::Tracing::Contrib::GraphQL::TracingPatcher).to receive(:patch!).with(
-            [],
-            hash_including(:analytics_enabled, :analytics_sample_rate, :service)
-          )
+          expect(Datadog::Tracing::Contrib::GraphQL::TracingPatcher).to receive(:patch!).with([])
 
           Datadog.configure do |c|
             c.tracing.instrument :graphql, with_unified_tracer: true, with_deprecated_tracer: true
@@ -110,10 +96,7 @@ RSpec.describe Datadog::Tracing::Contrib::GraphQL::Patcher do
       context 'with given schema' do
         it do
           allow(Datadog::Tracing::Contrib::GraphQL::Integration).to receive(:trace_supported?).and_return(true)
-          expect(Datadog::Tracing::Contrib::GraphQL::TracePatcher).to receive(:patch!).with(
-            [TestGraphQLSchema],
-            hash_including(:analytics_enabled, :analytics_sample_rate, :service)
-          )
+          expect(Datadog::Tracing::Contrib::GraphQL::TracePatcher).to receive(:patch!).with([TestGraphQLSchema])
 
           Datadog.configure do |c|
             c.tracing.instrument :graphql, schemas: [TestGraphQLSchema]
@@ -126,10 +109,7 @@ RSpec.describe Datadog::Tracing::Contrib::GraphQL::Patcher do
       context 'with default configuration' do
         it 'patches GraphQL' do
           allow(Datadog::Tracing::Contrib::GraphQL::Integration).to receive(:trace_supported?).and_return(false)
-          expect(Datadog::Tracing::Contrib::GraphQL::TracingPatcher).to receive(:patch!).with(
-            [],
-            hash_including(:analytics_enabled, :analytics_sample_rate, :service)
-          )
+          expect(Datadog::Tracing::Contrib::GraphQL::TracingPatcher).to receive(:patch!).with([])
           expect_any_instance_of(Datadog::Core::Logger).to receive(:warn)
             .with(/Falling back to GraphQL::Tracing::DataDogTracing/)
 
@@ -142,10 +122,7 @@ RSpec.describe Datadog::Tracing::Contrib::GraphQL::Patcher do
       context 'with with_deprecated_tracer enabled' do
         it do
           allow(Datadog::Tracing::Contrib::GraphQL::Integration).to receive(:trace_supported?).and_return(false)
-          expect(Datadog::Tracing::Contrib::GraphQL::TracingPatcher).to receive(:patch!).with(
-            [],
-            hash_including(:analytics_enabled, :analytics_sample_rate, :service)
-          )
+          expect(Datadog::Tracing::Contrib::GraphQL::TracingPatcher).to receive(:patch!).with([])
           expect_any_instance_of(Datadog::Core::Logger).not_to receive(:warn)
 
           Datadog.configure do |c|
@@ -157,10 +134,7 @@ RSpec.describe Datadog::Tracing::Contrib::GraphQL::Patcher do
       context 'with with_deprecated_tracer disabled' do
         it do
           allow(Datadog::Tracing::Contrib::GraphQL::Integration).to receive(:trace_supported?).and_return(false)
-          expect(Datadog::Tracing::Contrib::GraphQL::TracingPatcher).to receive(:patch!).with(
-            [],
-            hash_including(:analytics_enabled, :analytics_sample_rate, :service)
-          )
+          expect(Datadog::Tracing::Contrib::GraphQL::TracingPatcher).to receive(:patch!).with([])
           expect_any_instance_of(Datadog::Core::Logger).to receive(:warn)
             .with(/Falling back to GraphQL::Tracing::DataDogTracing/)
 
@@ -173,10 +147,7 @@ RSpec.describe Datadog::Tracing::Contrib::GraphQL::Patcher do
       context 'with with_unified_tracer enabled' do
         it do
           allow(Datadog::Tracing::Contrib::GraphQL::Integration).to receive(:trace_supported?).and_return(false)
-          expect(Datadog::Tracing::Contrib::GraphQL::TracingPatcher).to receive(:patch!).with(
-            [],
-            hash_including(:analytics_enabled, :analytics_sample_rate, :service)
-          )
+          expect(Datadog::Tracing::Contrib::GraphQL::TracingPatcher).to receive(:patch!).with([])
           expect_any_instance_of(Datadog::Core::Logger).to receive(:warn)
             .with(/Falling back to GraphQL::Tracing::DataDogTracing/)
 
@@ -189,10 +160,7 @@ RSpec.describe Datadog::Tracing::Contrib::GraphQL::Patcher do
       context 'with with_unified_tracer disabled' do
         it do
           allow(Datadog::Tracing::Contrib::GraphQL::Integration).to receive(:trace_supported?).and_return(false)
-          expect(Datadog::Tracing::Contrib::GraphQL::TracingPatcher).to receive(:patch!).with(
-            [],
-            hash_including(:analytics_enabled, :analytics_sample_rate, :service)
-          )
+          expect(Datadog::Tracing::Contrib::GraphQL::TracingPatcher).to receive(:patch!).with([])
           expect_any_instance_of(Datadog::Core::Logger).to receive(:warn)
             .with(/Falling back to GraphQL::Tracing::DataDogTracing/)
 
@@ -205,10 +173,7 @@ RSpec.describe Datadog::Tracing::Contrib::GraphQL::Patcher do
       context 'with with_unified_tracer enabled and with_deprecated_tracer enabled' do
         it do
           allow(Datadog::Tracing::Contrib::GraphQL::Integration).to receive(:trace_supported?).and_return(false)
-          expect(Datadog::Tracing::Contrib::GraphQL::TracingPatcher).to receive(:patch!).with(
-            [],
-            hash_including(:analytics_enabled, :analytics_sample_rate, :service)
-          )
+          expect(Datadog::Tracing::Contrib::GraphQL::TracingPatcher).to receive(:patch!).with([])
 
           Datadog.configure do |c|
             c.tracing.instrument :graphql, with_unified_tracer: true, with_deprecated_tracer: true
@@ -219,10 +184,7 @@ RSpec.describe Datadog::Tracing::Contrib::GraphQL::Patcher do
       context 'with given schema' do
         it do
           allow(Datadog::Tracing::Contrib::GraphQL::Integration).to receive(:trace_supported?).and_return(false)
-          expect(Datadog::Tracing::Contrib::GraphQL::TracingPatcher).to receive(:patch!).with(
-            [TestGraphQLSchema],
-            hash_including(:analytics_enabled, :analytics_sample_rate, :service)
-          )
+          expect(Datadog::Tracing::Contrib::GraphQL::TracingPatcher).to receive(:patch!).with([TestGraphQLSchema])
           expect_any_instance_of(Datadog::Core::Logger).to receive(:warn)
             .with(/Falling back to GraphQL::Tracing::DataDogTracing/)
 

--- a/spec/datadog/tracing/contrib/graphql/trace_patcher_spec.rb
+++ b/spec/datadog/tracing/contrib/graphql/trace_patcher_spec.rb
@@ -6,11 +6,19 @@ require 'datadog'
 
 RSpec.describe Datadog::Tracing::Contrib::GraphQL::TracePatcher,
   skip: Gem::Version.new(::GraphQL::VERSION) < Gem::Version.new('2.0.19') do
+    before(:context) { load_test_schema }
+    after(:context) do
+      unload_test_schema
+      remove_patch!(:graphql)
+    end
+
     describe '#patch!' do
       context 'with empty schema configuration' do
         it_behaves_like 'graphql default instrumentation' do
           before do
-            described_class.patch!([], {})
+            Datadog.configure do |c|
+              c.tracing.instrument :graphql
+            end
           end
         end
       end
@@ -18,7 +26,9 @@ RSpec.describe Datadog::Tracing::Contrib::GraphQL::TracePatcher,
       context 'with specified schemas configuration' do
         it_behaves_like 'graphql default instrumentation' do
           before do
-            described_class.patch!([TestGraphQLSchema], {})
+            Datadog.configure do |c|
+              c.tracing.instrument :graphql, schemas: [TestGraphQLSchema]
+            end
           end
         end
       end

--- a/spec/datadog/tracing/contrib/graphql/tracing_patcher_spec.rb
+++ b/spec/datadog/tracing/contrib/graphql/tracing_patcher_spec.rb
@@ -5,11 +5,23 @@ require 'datadog/tracing/contrib/graphql/tracing_patcher'
 require 'datadog'
 
 RSpec.describe Datadog::Tracing::Contrib::GraphQL::TracingPatcher do
+  before(:context) { load_test_schema }
+  after(:context) do
+    unload_test_schema
+    remove_patch!(:graphql)
+  end
+
   describe '#patch!' do
+    before do
+      Datadog.configuration.tracing[:graphql].reset!
+    end
+
     context 'with empty schema configuration' do
       it_behaves_like 'graphql default instrumentation' do
         before do
-          described_class.patch!([], {})
+          Datadog.configure do |c|
+            c.tracing.instrument :graphql, with_deprecated_tracer: true
+          end
         end
       end
     end
@@ -17,16 +29,22 @@ RSpec.describe Datadog::Tracing::Contrib::GraphQL::TracingPatcher do
     context 'with specified schemas configuration' do
       it_behaves_like 'graphql default instrumentation' do
         before do
-          described_class.patch!([TestGraphQLSchema], {})
+          Datadog.configure do |c|
+            c.tracing.instrument :graphql, with_deprecated_tracer: true, schemas: [TestGraphQLSchema]
+          end
         end
       end
     end
 
     context 'when given something else' do
+      before { remove_patch!(:graphql) }
+
       it do
         expect_any_instance_of(Datadog::Core::Logger).to receive(:warn).with(/Unable to patch/)
 
-        described_class.patch!([OpenStruct.new], {})
+        Datadog.configure do |c|
+          c.tracing.instrument :graphql, with_deprecated_tracer: true, schemas: [OpenStruct.new]
+        end
       end
     end
   end

--- a/spec/datadog/tracing/contrib/graphql/unified_trace_patcher_spec.rb
+++ b/spec/datadog/tracing/contrib/graphql/unified_trace_patcher_spec.rb
@@ -6,19 +6,45 @@ require 'datadog'
 
 RSpec.describe Datadog::Tracing::Contrib::GraphQL::UnifiedTracePatcher,
   skip: Gem::Version.new(::GraphQL::VERSION) < Gem::Version.new('2.0.19') do
+    before(:context) { load_test_schema }
+    after(:context) do
+      unload_test_schema
+      remove_patch!(:graphql)
+    end
+
     describe '#patch!' do
+      before do
+        Datadog.configuration.tracing[:graphql].reset!
+      end
+
       context 'with empty schema configuration' do
         it_behaves_like 'graphql instrumentation with unified naming convention trace' do
           before do
-            described_class.patch!([], {})
+            Datadog.configure do |c|
+              c.tracing.instrument :graphql, with_unified_tracer: true
+            end
           end
+        end
+      end
+
+      context 'with a custom service name' do
+        it_behaves_like 'graphql instrumentation with unified naming convention trace' do
+          before do
+            Datadog.configure do |c|
+              c.tracing.instrument :graphql, with_unified_tracer: true, service_name: 'my-graphql'
+            end
+          end
+
+          let(:service) { 'my-graphql' }
         end
       end
 
       context 'with specified schemas configuration' do
         it_behaves_like 'graphql instrumentation with unified naming convention trace' do
           before do
-            described_class.patch!([TestGraphQLSchema], {})
+            Datadog.configure do |c|
+              c.tracing.instrument :graphql, with_unified_tracer: true, schemas: [TestGraphQLSchema]
+            end
           end
         end
       end
@@ -28,16 +54,26 @@ RSpec.describe Datadog::Tracing::Contrib::GraphQL::UnifiedTracePatcher,
     # But this should work the same way without the need to require the tracer in the schema.
     describe '#trace_with' do
       context 'with schema using trace_with' do
-        it_behaves_like 'graphql instrumentation with unified naming convention trace' do
+        it_behaves_like 'graphql instrumentation with unified naming convention trace', prefix: 'TraceWith' do
           before do
+            load_test_schema(prefix: 'TraceWith')
+
+            Datadog.configuration.tracing[:graphql].reset!
+
+            # Datadog.configure do |c|
+            #   c.tracing.instrument :graphql, with_unified_tracer: true
+            # end
+
             # Monkey patch the schema to use the unified tracer
             # As we're not adding a new method, we cannot use allow(...).to receive(...)
             # rubocop:disable Lint/ConstantDefinitionInBlock, RSpec/LeakyConstantDeclaration
-            class TestGraphQLSchema
+            class TraceWithTestGraphQLSchema
               trace_with Datadog::Tracing::Contrib::GraphQL::UnifiedTrace
             end
             # rubocop:enable Lint/ConstantDefinitionInBlock, RSpec/LeakyConstantDeclaration
           end
+
+          after { unload_test_schema(prefix: 'TraceWith') }
         end
       end
     end


### PR DESCRIPTION
This PR fixes an issue where it is not possible to reconfigure the GraphQL integration.

This is especially important when using auto instrumentation (`gem 'datadog', require: 'datadog/auto_instrument'`) because any configuration inside a `Datadog.configure{}` block in an auto instrumented application is in fact a reconfiguration.

The main use case for this PR is supporting changing the service name for GraphQL spans.

**Additional Notes:**
One important caveat I found while working on this PR is that it is not possible to change GraphQL instrumentation strategies at runtime, as instrumentation pollutes internal GraphQL classes in irreversible ways. 
This was already the case before this PR, and I was not able to address this without a breaking change, thus this limitation remains.
I add public documentation about this in the GettingStarted guide.
I also slip the GraphQL test in the Rakefile to ensure conflicting instrumentation strategies do not run in the same process. This was not required before due to precise class manipulation surgery, but it became way too complex when I tried to adapt the existing class manipulation to this PR.

I added my recommendation on how to address this limitation, during the next major release, in inline comments.

**How to test the change?**
There are integration tests for all the changes.

Unsure? Have a question? Request a review!
