### PR TITLE
ci: disable persist-credentials for actions/checkout in system-tests

### DIFF
--- a/.github/workflows/system-tests.yml
+++ b/.github/workflows/system-tests.yml
@@ -35,6 +35,7 @@ jobs:
         with:
           repository: 'DataDog/system-tests'
           ref: ${{ env.ST_REF }}
+          persist-credentials: false
       - name: Pull released image
         run: |
           if docker pull ${{ env.REPO }}/system-tests/${{ matrix.image.name }}:latest; then
@@ -106,12 +107,14 @@ jobs:
         with:
           repository: 'DataDog/system-tests'
           ref: ${{ env.ST_REF }}
+          persist-credentials: false
       - name: Checkout ${{ matrix.library.repository }}
         uses: actions/checkout@v4
         with:
           repository: '${{ matrix.library.repository }}'
           path: 'binaries/${{ matrix.library.path }}'
           fetch-depth: 2
+          persist-credentials: false
       - name: Pull released image
         run: |
           if docker pull ${{ env.REPO }}/system-tests/${{ matrix.library.name }}/${{ matrix.image }}-${{ matrix.app }}:latest; then
@@ -252,6 +255,7 @@ jobs:
         with:
           repository: 'DataDog/system-tests'
           ref: ${{ env.ST_REF }}
+          persist-credentials: false
       - name: Pull runner image
         run: |
           docker pull ${{ env.REPO }}/system-tests/runner:gha${{ github.run_id }}-g${{ github.sha }}
@@ -317,6 +321,7 @@ jobs:
         with:
           repository: 'DataDog/system-tests'
           ref: ${{ env.ST_REF }}
+          persist-credentials: false
       - name: Retrieve logs
         uses: actions/download-artifact@v4
         with:


### PR DESCRIPTION
<!--
Check out the
https://github.com/DataDog/dd-trace-rb/blob/master/docs/DevelopmentGuide.md
for guidance on how to set up your development environment,
run the test suite, write new integrations, and more.
-->

**What does this PR do?**
Add `persist-credentials: false` to checkout jobs in system-tests workflow

**Additional Notes:**
<!-- Anything else we should know when reviewing? -->

**How to test the change?**
<!--
Describe here how the change can be validated.
You are strongly encouraged to provide automated tests for this PR (unit or integration).
If this change cannot be feasibly tested, please explain why,
unless the change does not modify code (e.g. only modifies docs, comments).
-->

Unsure? Have a question? Request a review!
