### PR TITLE
[NO-TICKET] Small set of profiler cleanups from ASAN testing branch

### DIFF
--- a/ext/datadog_profiling_loader/datadog_profiling_loader.c
+++ b/ext/datadog_profiling_loader/datadog_profiling_loader.c
@@ -65,7 +65,15 @@ static VALUE _native_load(DDTRACE_UNUSED VALUE self, VALUE ruby_path, VALUE ruby
   char *path = StringValueCStr(ruby_path);
   char *init_name = StringValueCStr(ruby_init_name);
 
-  void *handle = dlopen(path, RTLD_LAZY | RTLD_LOCAL | RTLD_DEEPBIND);
+  int dlopen_flags = RTLD_LAZY | RTLD_LOCAL | RTLD_DEEPBIND;
+
+  #if defined(__has_feature)
+    #if __has_feature(address_sanitizer)
+      dlopen_flags &= ~RTLD_DEEPBIND; // Not supported by ASAN
+    #endif
+  #endif
+
+  void *handle = dlopen(path, dlopen_flags);
 
   VALUE failure_details = Qnil;
 

--- a/ext/datadog_profiling_loader/extconf.rb
+++ b/ext/datadog_profiling_loader/extconf.rb
@@ -12,38 +12,28 @@ end
 
 require "mkmf"
 
-# mkmf on modern Rubies actually has an append_cflags that does something similar
-# (see https://github.com/ruby/ruby/pull/5760), but as usual we need a bit more boilerplate to deal with legacy Rubies
-def add_compiler_flag(flag)
-  if try_cflags(flag)
-    $CFLAGS << " " << flag
-  else
-    $stderr.puts("WARNING: '#{flag}' not accepted by compiler, skipping it")
-  end
-end
-
 # Because we can't control what compiler versions our customers use, shipping with -Werror by default is a no-go.
 # But we can enable it in CI, so that we quickly spot any new warnings that just got introduced.
-add_compiler_flag "-Werror" if ENV["DATADOG_GEM_CI"] == "true"
+append_cflags "-Werror" if ENV["DATADOG_GEM_CI"] == "true"
 
 # Older gcc releases may not default to C99 and we need to ask for this. This is also used:
 # * by upstream Ruby -- search for gnu99 in the codebase
 # * by msgpack, another datadog gem dependency
 #   (https://github.com/msgpack/msgpack-ruby/blob/18ce08f6d612fe973843c366ac9a0b74c4e50599/ext/msgpack/extconf.rb#L8)
-add_compiler_flag "-std=gnu99"
+append_cflags "-std=gnu99"
 
 # Gets really noisy when we include the MJIT header, let's omit it (TODO: Use #pragma GCC diagnostic instead?)
-add_compiler_flag "-Wno-unused-function"
+append_cflags "-Wno-unused-function"
 
 # Allow defining variables at any point in a function
-add_compiler_flag "-Wno-declaration-after-statement"
+append_cflags "-Wno-declaration-after-statement"
 
 # If we forget to include a Ruby header, the function call may still appear to work, but then
 # cause a segfault later. Let's ensure that never happens.
-add_compiler_flag "-Werror-implicit-function-declaration"
+append_cflags "-Werror-implicit-function-declaration"
 
 # Warn on unused parameters to functions. Use `DDTRACE_UNUSED` to mark things as known-to-not-be-used.
-add_compiler_flag "-Wunused-parameter"
+append_cflags "-Wunused-parameter"
 
 # The native extension is not intended to expose any symbols/functions for other native libraries to use;
 # the sole exception being `Init_datadog_profiling_loader` which needs to be visible for Ruby to call it when
@@ -51,14 +41,14 @@ add_compiler_flag "-Wunused-parameter"
 #
 # By setting this compiler flag, we tell it to assume that everything is private unless explicitly stated.
 # For more details see https://gcc.gnu.org/wiki/Visibility
-add_compiler_flag "-fvisibility=hidden"
+append_cflags "-fvisibility=hidden"
 
 # Avoid legacy C definitions
-add_compiler_flag "-Wold-style-definition"
+append_cflags "-Wold-style-definition"
 
 # Enable all other compiler warnings
-add_compiler_flag "-Wall"
-add_compiler_flag "-Wextra"
+append_cflags "-Wall"
+append_cflags "-Wextra"
 
 # Tag the native extension library with the Ruby version and Ruby platform.
 # This makes it easier for development (avoids "oops I forgot to rebuild when I switched my Ruby") and ensures that

--- a/ext/datadog_profiling_loader/extconf.rb
+++ b/ext/datadog_profiling_loader/extconf.rb
@@ -1,5 +1,4 @@
 # rubocop:disable Style/StderrPuts
-# rubocop:disable Style/GlobalVars
 
 if RUBY_ENGINE != "ruby" || Gem.win_platform?
   $stderr.puts(
@@ -58,5 +57,4 @@ EXTENSION_NAME = "datadog_profiling_loader.#{RUBY_VERSION}_#{RUBY_PLATFORM}".fre
 
 create_makefile(EXTENSION_NAME)
 
-# rubocop:enable Style/GlobalVars
 # rubocop:enable Style/StderrPuts

--- a/ext/datadog_profiling_native_extension/collectors_cpu_and_wall_time_worker.c
+++ b/ext/datadog_profiling_native_extension/collectors_cpu_and_wall_time_worker.c
@@ -1211,7 +1211,8 @@ static VALUE rescued_sample_allocation(DDTRACE_UNUSED VALUE unused) {
   thread_context_collector_sample_allocation(state->thread_context_collector_instance, weight, new_object);
   // ...but we still represent the skipped samples in the profile, thus the data will account for all allocations.
   if (weight < allocations_since_last_sample) {
-    thread_context_collector_sample_skipped_allocation_samples(state->thread_context_collector_instance, allocations_since_last_sample - weight);
+    uint32_t skipped_samples = (uint32_t) uint64_min_of(allocations_since_last_sample - weight, UINT32_MAX);
+    thread_context_collector_sample_skipped_allocation_samples(state->thread_context_collector_instance, skipped_samples);
   }
 
   // Return a dummy VALUE because we're called from rb_rescue2 which requires it

--- a/ext/datadog_profiling_native_extension/collectors_discrete_dynamic_sampler.c
+++ b/ext/datadog_profiling_native_extension/collectors_discrete_dynamic_sampler.c
@@ -92,7 +92,7 @@ double discrete_dynamic_sampler_probability(discrete_dynamic_sampler *sampler) {
   return sampler->sampling_probability * 100.;
 }
 
-size_t discrete_dynamic_sampler_events_since_last_sample(discrete_dynamic_sampler *sampler) {
+unsigned long discrete_dynamic_sampler_events_since_last_sample(discrete_dynamic_sampler *sampler) {
   return sampler->events_since_last_sample;
 }
 

--- a/ext/datadog_profiling_native_extension/collectors_discrete_dynamic_sampler.c
+++ b/ext/datadog_profiling_native_extension/collectors_discrete_dynamic_sampler.c
@@ -259,7 +259,9 @@ void discrete_dynamic_sampler_readjust(discrete_dynamic_sampler *sampler, long n
   //       are so big they don't fit into the sampling_interval. In both cases lets just disable sampling until next readjustment
   //       by setting interval to 0.
   double sampling_interval = sampler->sampling_probability == 0 ? 0 : ceil(1.0 / sampler->sampling_probability);
-  sampler->sampling_interval = sampling_interval > ULONG_MAX ? 0 : sampling_interval;
+  // NOTE: We use UINT32_MAX instead of ULONG_MAX here to avoid clang warnings; in practice, we shouldn't ever hit
+  // such high sampling intervals.
+  sampler->sampling_interval = sampling_interval > UINT32_MAX ? 0 : sampling_interval;
 
   #ifdef DD_DEBUG
     double allocs_in_60s = sampler->events_per_ns * 1e9 * 60;

--- a/ext/datadog_profiling_native_extension/collectors_stack.c
+++ b/ext/datadog_profiling_native_extension/collectors_stack.c
@@ -292,10 +292,8 @@ void sample_thread(
     }
 
     buffer->locations[i] = (ddog_prof_Location) {
-      .function = (ddog_prof_Function) {
-        .name = name_slice,
-        .filename = filename_slice,
-      },
+      .mapping = {.filename = DDOG_CHARSLICE_C(""), .build_id = DDOG_CHARSLICE_C("")},
+      .function = (ddog_prof_Function) {.name = name_slice, .filename = filename_slice},
       .line = line,
     };
   }
@@ -371,6 +369,7 @@ static void maybe_add_placeholder_frames_omitted(VALUE thread, sampling_buffer* 
   ddog_CharSlice function_name = DDOG_CHARSLICE_C("");
   ddog_CharSlice function_filename = {.ptr = frames_omitted_message, .len = strlen(frames_omitted_message)};
   buffer->locations[buffer->max_frames - 1] = (ddog_prof_Location) {
+    .mapping = {.filename = DDOG_CHARSLICE_C(""), .build_id = DDOG_CHARSLICE_C("")},
     .function = (ddog_prof_Function) {.name = function_name, .filename = function_filename},
     .line = 0,
   };
@@ -417,6 +416,7 @@ void record_placeholder_stack(
   ddog_CharSlice placeholder_stack
 ) {
   ddog_prof_Location placeholder_location = {
+    .mapping = {.filename = DDOG_CHARSLICE_C(""), .build_id = DDOG_CHARSLICE_C("")},
     .function = {.name = DDOG_CHARSLICE_C(""), .filename = placeholder_stack},
     .line = 0,
   };

--- a/ext/datadog_profiling_native_extension/collectors_stack.c
+++ b/ext/datadog_profiling_native_extension/collectors_stack.c
@@ -331,7 +331,9 @@ static void maybe_trim_template_random_ids(ddog_CharSlice *name_slice, ddog_Char
   // Check filename doesn't end with ".rb"; templates are usually along the lines of .html.erb/.html.haml/...
   if (filename_slice->len < 3 || memcmp(filename_slice->ptr + filename_slice->len - 3, ".rb", 3) == 0) return;
 
-  int pos = name_slice->len - 1;
+  if (name_slice->len > 1024) return;
+
+  int pos = ((int) name_slice->len) - 1;
 
   // Let's match on something__number_number:
   // Find start of id suffix from the end...

--- a/ext/datadog_profiling_native_extension/collectors_thread_context.c
+++ b/ext/datadog_profiling_native_extension/collectors_thread_context.c
@@ -896,9 +896,9 @@ static struct per_thread_context *get_context_for(VALUE thread, struct thread_co
 // to either run Ruby code during sampling (not great), or otherwise use some of the VM private APIs to detect this.
 //
 static bool is_logging_gem_monkey_patch(VALUE invoke_file_location) {
-  int logging_gem_path_len = strlen(LOGGING_GEM_PATH);
+  unsigned long logging_gem_path_len = strlen(LOGGING_GEM_PATH);
   char *invoke_file = StringValueCStr(invoke_file_location);
-  int invoke_file_len = strlen(invoke_file);
+  unsigned long invoke_file_len = strlen(invoke_file);
 
   if (invoke_file_len < logging_gem_path_len) return false;
 
@@ -1209,7 +1209,7 @@ static bool should_collect_resource(VALUE root_span) {
   if (root_span_type == Qnil) return false;
   ENFORCE_TYPE(root_span_type, T_STRING);
 
-  int root_span_type_length = RSTRING_LEN(root_span_type);
+  long root_span_type_length = RSTRING_LEN(root_span_type);
   const char *root_span_type_value = StringValuePtr(root_span_type);
 
   bool is_web_request =

--- a/ext/datadog_profiling_native_extension/extconf.rb
+++ b/ext/datadog_profiling_native_extension/extconf.rb
@@ -74,35 +74,25 @@ Logging.message("[datadog] Using compiler:\n")
 xsystem("#{CONFIG["CC"]} -v")
 Logging.message("[datadog] End of compiler information\n")
 
-# mkmf on modern Rubies actually has an append_cflags that does something similar
-# (see https://github.com/ruby/ruby/pull/5760), but as usual we need a bit more boilerplate to deal with legacy Rubies
-def add_compiler_flag(flag)
-  if try_cflags(flag)
-    $CFLAGS << " " << flag
-  else
-    $stderr.puts("WARNING: '#{flag}' not accepted by compiler, skipping it")
-  end
-end
-
 # Because we can't control what compiler versions our customers use, shipping with -Werror by default is a no-go.
 # But we can enable it in CI, so that we quickly spot any new warnings that just got introduced.
-add_compiler_flag "-Werror" if ENV["DATADOG_GEM_CI"] == "true"
+append_cflags "-Werror" if ENV["DATADOG_GEM_CI"] == "true"
 
 # Older gcc releases may not default to C99 and we need to ask for this. This is also used:
 # * by upstream Ruby -- search for gnu99 in the codebase
 # * by msgpack, another datadog gem dependency
 #   (https://github.com/msgpack/msgpack-ruby/blob/18ce08f6d612fe973843c366ac9a0b74c4e50599/ext/msgpack/extconf.rb#L8)
-add_compiler_flag "-std=gnu99"
+append_cflags "-std=gnu99"
 
 # Gets really noisy when we include the MJIT header, let's omit it (TODO: Use #pragma GCC diagnostic instead?)
-add_compiler_flag "-Wno-unused-function"
+append_cflags "-Wno-unused-function"
 
 # Allow defining variables at any point in a function
-add_compiler_flag "-Wno-declaration-after-statement"
+append_cflags "-Wno-declaration-after-statement"
 
 # If we forget to include a Ruby header, the function call may still appear to work, but then
 # cause a segfault later. Let's ensure that never happens.
-add_compiler_flag "-Werror-implicit-function-declaration"
+append_cflags "-Werror-implicit-function-declaration"
 
 # The native extension is not intended to expose any symbols/functions for other native libraries to use;
 # the sole exception being `Init_datadog_profiling_native_extension` which needs to be visible for Ruby to call it when
@@ -110,14 +100,14 @@ add_compiler_flag "-Werror-implicit-function-declaration"
 #
 # By setting this compiler flag, we tell it to assume that everything is private unless explicitly stated.
 # For more details see https://gcc.gnu.org/wiki/Visibility
-add_compiler_flag "-fvisibility=hidden"
+append_cflags "-fvisibility=hidden"
 
 # Avoid legacy C definitions
-add_compiler_flag "-Wold-style-definition"
+append_cflags "-Wold-style-definition"
 
 # Enable all other compiler warnings
-add_compiler_flag "-Wall"
-add_compiler_flag "-Wextra"
+append_cflags "-Wall"
+append_cflags "-Wextra"
 
 if ENV["DDTRACE_DEBUG"] == "true"
   $defs << "-DDD_DEBUG"
@@ -255,7 +245,7 @@ if Datadog::Profiling::NativeExtensionHelpers::CAN_USE_MJIT_HEADER
 
   # Warn on unused parameters to functions. Use `DDTRACE_UNUSED` to mark things as known-to-not-be-used.
   # See the comment on the same flag below for why this is done last.
-  add_compiler_flag "-Wunused-parameter"
+  append_cflags "-Wunused-parameter"
 
   create_makefile EXTENSION_NAME
 else
@@ -282,7 +272,7 @@ else
           # This is added as late as possible because in some Rubies we support (e.g. 3.3), adding this flag before
           # checking if internal VM headers are available causes those checks to fail because of this warning (and not
           # because the headers are not available.)
-          add_compiler_flag "-Wunused-parameter"
+          append_cflags "-Wunused-parameter"
         end
 
         headers_available

--- a/ext/datadog_profiling_native_extension/heap_recorder.c
+++ b/ext/datadog_profiling_native_extension/heap_recorder.c
@@ -632,12 +632,14 @@ static int st_object_records_iterate(DDTRACE_UNUSED st_data_t key, st_data_t val
   ddog_prof_Location *locations = recorder->reusable_locations;
   for (uint16_t i = 0; i < stack->frames_len; i++) {
     const heap_frame *frame = &stack->frames[i];
-    ddog_prof_Location *location = &locations[i];
-    location->function.name.ptr = frame->name;
-    location->function.name.len = strlen(frame->name);
-    location->function.filename.ptr = frame->filename;
-    location->function.filename.len = strlen(frame->filename);
-    location->line = frame->line;
+    locations[i] = (ddog_prof_Location) {
+      .mapping = {.filename = DDOG_CHARSLICE_C(""), .build_id = DDOG_CHARSLICE_C("")},
+      .function = {
+        .name = {.ptr = frame->name, .len = strlen(frame->name)},
+        .filename = {.ptr = frame->filename, .len = strlen(frame->filename)},
+      },
+      .line = frame->line,
+    };
   }
 
   heap_recorder_iteration_data iteration_data;

--- a/ext/datadog_profiling_native_extension/profiling.c
+++ b/ext/datadog_profiling_native_extension/profiling.c
@@ -253,7 +253,7 @@ static VALUE _native_enforce_success(DDTRACE_UNUSED VALUE _self, VALUE syserr_er
 
 static void *trigger_enforce_success(void *trigger_args) {
   intptr_t syserr_errno = (intptr_t) trigger_args;
-  ENFORCE_SUCCESS_NO_GVL(syserr_errno);
+  ENFORCE_SUCCESS_NO_GVL((int) syserr_errno);
   return NULL;
 }
 


### PR DESCRIPTION
**What does this PR do?**

I've been experimenting with building the profiler with [AddressSanitizer](https://clang.llvm.org/docs/AddressSanitizer.html) (aka ASAN).

So far, I did not discover any issue in the profiler, but I ended up collecting a few tweaks and improvements:
* Compiling the profiler with Clang 18 got me extra warnings to fix that I hadn't seem before
* I needed to add a tiny asan-specific workaround for extension loading
* I ended up doing a cleanup of our `extconf.rb`

**Motivation:**

Since I'm not sure I'll have the full ASAN testing working on CI soon, I decided to open up a PR with the fixes I had collected.

**Additional Notes:**

Although the PR is not big/particularly complex, it may be even easier to review commit-by-commit.

This PR is atop #3852 as it was easier for me to test all of the improvements together, but they are otherwise unrelated. I'll wait until #3852 is merged to master before merging this one.

**How to test the change?**

Validate that CI still passes, and with no compilation warnings. You can also try compiling the profiler locally with clang and confirm that there are also no warnings emitted by clang.