### PR TITLE
Telemetry log: Add `stack_trace` field when given an exception

### DIFF
--- a/gemfiles/ruby_3.4_activesupport.gemfile
+++ b/gemfiles/ruby_3.4_activesupport.gemfile
@@ -26,7 +26,7 @@ gem "simplecov-cobertura", "~> 2.1.0"
 gem "warning", "~> 1"
 gem "webmock", ">= 3.10.0"
 gem "rexml", ">= 3.2.7"
-gem "webrick", ">= 1.7.0"
+gem "webrick", git: "https://github.com/ruby/webrick.git", ref: "0c600e169bd4ae267cb5eeb6197277c848323bbe"
 gem "yard", "~> 0.9"
 gem "rubocop", "~> 1.50.0", require: false
 gem "rubocop-packaging", "~> 0.5.2", require: false
@@ -45,7 +45,7 @@ gem "racecar", ">= 0.3.5"
 gem "ruby-kafka", ">= 0.7.10"
 
 group :check do
-
+  gem "ruby_memcheck", ">= 3"
 end
 
 group :dev do

--- a/gemfiles/ruby_3.4_activesupport.gemfile.lock
+++ b/gemfiles/ruby_3.4_activesupport.gemfile.lock
@@ -8,6 +8,13 @@ GIT
       simplecov-html (~> 0.11)
       simplecov_json_formatter (~> 0.1)
 
+GIT
+  remote: https://github.com/ruby/webrick.git
+  revision: 0c600e169bd4ae267cb5eeb6197277c848323bbe
+  ref: 0c600e169bd4ae267cb5eeb6197277c848323bbe
+  specs:
+    webrick (1.8.1)
+
 PATH
   remote: ..
   specs:
@@ -254,6 +261,8 @@ GEM
       digest-crc
     ruby-progressbar (1.13.0)
     ruby2_keywords (0.0.5)
+    ruby_memcheck (3.0.0)
+      nokogiri
     simplecov-cobertura (2.1.0)
       rexml
       simplecov (~> 0.19)
@@ -270,7 +279,6 @@ GEM
       addressable (>= 2.8.0)
       crack (>= 0.3.2)
       hashdiff (>= 0.4.0, < 2.0.0)
-    webrick (1.8.1)
     yard (0.9.36)
     zeitwerk (2.6.16)
 
@@ -315,11 +323,12 @@ DEPENDENCIES
   rubocop-performance (~> 1.9)
   rubocop-rspec (~> 2.20, < 2.21)
   ruby-kafka (>= 0.7.10)
+  ruby_memcheck (>= 3)
   simplecov!
   simplecov-cobertura (~> 2.1.0)
   warning (~> 1)
   webmock (>= 3.10.0)
-  webrick (>= 1.7.0)
+  webrick!
   yard (~> 0.9)
 
 BUNDLED WITH

--- a/gemfiles/ruby_3.4_aws.gemfile
+++ b/gemfiles/ruby_3.4_aws.gemfile
@@ -26,7 +26,7 @@ gem "simplecov-cobertura", "~> 2.1.0"
 gem "warning", "~> 1"
 gem "webmock", ">= 3.10.0"
 gem "rexml", ">= 3.2.7"
-gem "webrick", ">= 1.7.0"
+gem "webrick", git: "https://github.com/ruby/webrick.git", ref: "0c600e169bd4ae267cb5eeb6197277c848323bbe"
 gem "yard", "~> 0.9"
 gem "rubocop", "~> 1.50.0", require: false
 gem "rubocop-packaging", "~> 0.5.2", require: false
@@ -39,7 +39,7 @@ gem "aws-sdk"
 gem "shoryuken"
 
 group :check do
-
+  gem "ruby_memcheck", ">= 3"
 end
 
 group :dev do

--- a/gemfiles/ruby_3.4_aws.gemfile.lock
+++ b/gemfiles/ruby_3.4_aws.gemfile.lock
@@ -8,6 +8,13 @@ GIT
       simplecov-html (~> 0.11)
       simplecov_json_formatter (~> 0.1)
 
+GIT
+  remote: https://github.com/ruby/webrick.git
+  revision: 0c600e169bd4ae267cb5eeb6197277c848323bbe
+  ref: 0c600e169bd4ae267cb5eeb6197277c848323bbe
+  specs:
+    webrick (1.8.1)
+
 PATH
   remote: ..
   specs:
@@ -1609,7 +1616,11 @@ GEM
       ffi (~> 1.0)
     memory_profiler (0.9.14)
     method_source (1.1.0)
+    mini_portile2 (2.8.7)
     msgpack (1.7.2)
+    nokogiri (1.16.7)
+      mini_portile2 (~> 2.8.2)
+      racc (~> 1.4)
     os (1.1.4)
     parallel (1.25.1)
     parser (3.3.3.0)
@@ -1673,6 +1684,8 @@ GEM
       rubocop (~> 1.33)
       rubocop-capybara (~> 2.17)
     ruby-progressbar (1.13.0)
+    ruby_memcheck (3.0.0)
+      nokogiri
     shoryuken (6.2.1)
       aws-sdk-core (>= 2)
       concurrent-ruby
@@ -1690,7 +1703,6 @@ GEM
       addressable (>= 2.8.0)
       crack (>= 0.3.2)
       hashdiff (>= 0.4.0, < 2.0.0)
-    webrick (1.8.1)
     yard (0.9.36)
 
 PLATFORMS
@@ -1727,12 +1739,13 @@ DEPENDENCIES
   rubocop-packaging (~> 0.5.2)
   rubocop-performance (~> 1.9)
   rubocop-rspec (~> 2.20, < 2.21)
+  ruby_memcheck (>= 3)
   shoryuken
   simplecov!
   simplecov-cobertura (~> 2.1.0)
   warning (~> 1)
   webmock (>= 3.10.0)
-  webrick (>= 1.7.0)
+  webrick!
   yard (~> 0.9)
 
 BUNDLED WITH

--- a/gemfiles/ruby_3.4_contrib.gemfile
+++ b/gemfiles/ruby_3.4_contrib.gemfile
@@ -26,7 +26,7 @@ gem "simplecov-cobertura", "~> 2.1.0"
 gem "warning", "~> 1"
 gem "webmock", ">= 3.10.0"
 gem "rexml", ">= 3.2.7"
-gem "webrick", ">= 1.7.0"
+gem "webrick", git: "https://github.com/ruby/webrick.git", ref: "0c600e169bd4ae267cb5eeb6197277c848323bbe"
 gem "yard", "~> 0.9"
 gem "rubocop", "~> 1.50.0", require: false
 gem "rubocop-packaging", "~> 0.5.2", require: false
@@ -48,7 +48,7 @@ gem "sucker_punch"
 gem "que", ">= 1.0.0"
 
 group :check do
-
+  gem "ruby_memcheck", ">= 3"
 end
 
 group :dev do

--- a/gemfiles/ruby_3.4_contrib.gemfile.lock
+++ b/gemfiles/ruby_3.4_contrib.gemfile.lock
@@ -8,6 +8,13 @@ GIT
       simplecov-html (~> 0.11)
       simplecov_json_formatter (~> 0.1)
 
+GIT
+  remote: https://github.com/ruby/webrick.git
+  revision: 0c600e169bd4ae267cb5eeb6197277c848323bbe
+  ref: 0c600e169bd4ae267cb5eeb6197277c848323bbe
+  specs:
+    webrick (1.8.1)
+
 PATH
   remote: ..
   specs:
@@ -73,6 +80,7 @@ GEM
       ffi (~> 1.0)
     memory_profiler (0.9.14)
     method_source (1.1.0)
+    mini_portile2 (2.8.7)
     mongo (2.14.1)
       bson (>= 4.8.2, < 5.0.0)
     mono_logger (1.1.2)
@@ -80,6 +88,9 @@ GEM
     multi_json (1.15.0)
     mustermann (3.0.0)
       ruby2_keywords (~> 0.0.1)
+    nokogiri (1.16.7)
+      mini_portile2 (~> 2.8.2)
+      racc (~> 1.4)
     os (1.1.4)
     parallel (1.25.1)
     parser (3.3.3.0)
@@ -167,6 +178,8 @@ GEM
       rubocop-capybara (~> 2.17)
     ruby-progressbar (1.13.0)
     ruby2_keywords (0.0.5)
+    ruby_memcheck (3.0.0)
+      nokogiri
     semantic_logger (4.15.0)
       concurrent-ruby (~> 1.0)
     serverengine (2.1.1)
@@ -209,7 +222,6 @@ GEM
       addressable (>= 2.8.0)
       crack (>= 0.3.2)
       hashdiff (>= 0.4.0, < 2.0.0)
-    webrick (1.8.1)
     yard (0.9.36)
 
 PLATFORMS
@@ -252,6 +264,7 @@ DEPENDENCIES
   rubocop-packaging (~> 0.5.2)
   rubocop-performance (~> 1.9)
   rubocop-rspec (~> 2.20, < 2.21)
+  ruby_memcheck (>= 3)
   semantic_logger (~> 4.0)
   sidekiq (~> 7)
   simplecov!
@@ -260,7 +273,7 @@ DEPENDENCIES
   sucker_punch
   warning (~> 1)
   webmock (>= 3.10.0)
-  webrick (>= 1.7.0)
+  webrick!
   yard (~> 0.9)
 
 BUNDLED WITH

--- a/gemfiles/ruby_3.4_contrib_old.gemfile
+++ b/gemfiles/ruby_3.4_contrib_old.gemfile
@@ -26,7 +26,7 @@ gem "simplecov-cobertura", "~> 2.1.0"
 gem "warning", "~> 1"
 gem "webmock", ">= 3.10.0"
 gem "rexml", ">= 3.2.7"
-gem "webrick", ">= 1.7.0"
+gem "webrick", git: "https://github.com/ruby/webrick.git", ref: "0c600e169bd4ae267cb5eeb6197277c848323bbe"
 gem "yard", "~> 0.9"
 gem "rubocop", "~> 1.50.0", require: false
 gem "rubocop-packaging", "~> 0.5.2", require: false
@@ -41,7 +41,7 @@ gem "qless", "0.12.0"
 gem "racc"
 
 group :check do
-
+  gem "ruby_memcheck", ">= 3"
 end
 
 group :dev do

--- a/gemfiles/ruby_3.4_contrib_old.gemfile.lock
+++ b/gemfiles/ruby_3.4_contrib_old.gemfile.lock
@@ -8,6 +8,13 @@ GIT
       simplecov-html (~> 0.11)
       simplecov_json_formatter (~> 0.1)
 
+GIT
+  remote: https://github.com/ruby/webrick.git
+  revision: 0c600e169bd4ae267cb5eeb6197277c848323bbe
+  ref: 0c600e169bd4ae267cb5eeb6197277c848323bbe
+  specs:
+    webrick (1.8.1)
+
 PATH
   remote: ..
   specs:
@@ -75,10 +82,14 @@ GEM
       atomic (~> 1.0)
       avl_tree (~> 1.2.0)
       hitimes (~> 1.1)
+    mini_portile2 (2.8.7)
     msgpack (1.7.2)
     multipart-post (2.4.1)
     mustermann (1.1.2)
       ruby2_keywords (~> 0.0.1)
+    nokogiri (1.16.7)
+      mini_portile2 (~> 2.8.2)
+      racc (~> 1.4)
     os (1.1.4)
     parallel (1.25.1)
     parser (3.3.3.0)
@@ -161,6 +172,8 @@ GEM
       rubocop-capybara (~> 2.17)
     ruby-progressbar (1.13.0)
     ruby2_keywords (0.0.5)
+    ruby_memcheck (3.0.0)
+      nokogiri
     rusage (0.2.0)
     sentry-raven (0.15.6)
       faraday (>= 0.7.6)
@@ -190,7 +203,6 @@ GEM
       addressable (>= 2.8.0)
       crack (>= 0.3.2)
       hashdiff (>= 0.4.0, < 2.0.0)
-    webrick (1.8.1)
     yard (0.9.36)
 
 PLATFORMS
@@ -230,11 +242,12 @@ DEPENDENCIES
   rubocop-packaging (~> 0.5.2)
   rubocop-performance (~> 1.9)
   rubocop-rspec (~> 2.20, < 2.21)
+  ruby_memcheck (>= 3)
   simplecov!
   simplecov-cobertura (~> 2.1.0)
   warning (~> 1)
   webmock (>= 3.10.0)
-  webrick (>= 1.7.0)
+  webrick!
   yard (~> 0.9)
 
 BUNDLED WITH

--- a/gemfiles/ruby_3.4_core_old.gemfile
+++ b/gemfiles/ruby_3.4_core_old.gemfile
@@ -26,7 +26,7 @@ gem "simplecov-cobertura", "~> 2.1.0"
 gem "warning", "~> 1"
 gem "webmock", ">= 3.10.0"
 gem "rexml", ">= 3.2.7"
-gem "webrick", ">= 1.7.0"
+gem "webrick", git: "https://github.com/ruby/webrick.git", ref: "0c600e169bd4ae267cb5eeb6197277c848323bbe"
 gem "yard", "~> 0.9"
 gem "rubocop", "~> 1.50.0", require: false
 gem "rubocop-packaging", "~> 0.5.2", require: false
@@ -37,7 +37,7 @@ gem "google-protobuf", ["~> 3.0", "!= 3.7.0", "!= 3.7.1"]
 gem "ffi", "~> 1.16.3", require: false
 
 group :check do
-
+  gem "ruby_memcheck", ">= 3"
 end
 
 group :dev do

--- a/gemfiles/ruby_3.4_core_old.gemfile.lock
+++ b/gemfiles/ruby_3.4_core_old.gemfile.lock
@@ -8,6 +8,13 @@ GIT
       simplecov-html (~> 0.11)
       simplecov_json_formatter (~> 0.1)
 
+GIT
+  remote: https://github.com/ruby/webrick.git
+  revision: 0c600e169bd4ae267cb5eeb6197277c848323bbe
+  ref: 0c600e169bd4ae267cb5eeb6197277c848323bbe
+  specs:
+    webrick (1.8.1)
+
 PATH
   remote: ..
   specs:
@@ -60,7 +67,11 @@ GEM
       ffi (~> 1.0)
     memory_profiler (0.9.14)
     method_source (1.1.0)
+    mini_portile2 (2.8.7)
     msgpack (1.7.2)
+    nokogiri (1.16.7)
+      mini_portile2 (~> 2.8.2)
+      racc (~> 1.4)
     os (1.1.4)
     parallel (1.25.1)
     parser (3.3.3.0)
@@ -124,6 +135,8 @@ GEM
       rubocop (~> 1.33)
       rubocop-capybara (~> 2.17)
     ruby-progressbar (1.13.0)
+    ruby_memcheck (3.0.0)
+      nokogiri
     simplecov-cobertura (2.1.0)
       rexml
       simplecov (~> 0.19)
@@ -137,7 +150,6 @@ GEM
       addressable (>= 2.8.0)
       crack (>= 0.3.2)
       hashdiff (>= 0.4.0, < 2.0.0)
-    webrick (1.8.1)
     yard (0.9.36)
 
 PLATFORMS
@@ -173,11 +185,12 @@ DEPENDENCIES
   rubocop-packaging (~> 0.5.2)
   rubocop-performance (~> 1.9)
   rubocop-rspec (~> 2.20, < 2.21)
+  ruby_memcheck (>= 3)
   simplecov!
   simplecov-cobertura (~> 2.1.0)
   warning (~> 1)
   webmock (>= 3.10.0)
-  webrick (>= 1.7.0)
+  webrick!
   yard (~> 0.9)
 
 BUNDLED WITH

--- a/gemfiles/ruby_3.4_elasticsearch_7.gemfile
+++ b/gemfiles/ruby_3.4_elasticsearch_7.gemfile
@@ -26,7 +26,7 @@ gem "simplecov-cobertura", "~> 2.1.0"
 gem "warning", "~> 1"
 gem "webmock", ">= 3.10.0"
 gem "rexml", ">= 3.2.7"
-gem "webrick", ">= 1.7.0"
+gem "webrick", git: "https://github.com/ruby/webrick.git", ref: "0c600e169bd4ae267cb5eeb6197277c848323bbe"
 gem "yard", "~> 0.9"
 gem "rubocop", "~> 1.50.0", require: false
 gem "rubocop-packaging", "~> 0.5.2", require: false
@@ -38,7 +38,7 @@ gem "ffi", "~> 1.16.3", require: false
 gem "elasticsearch", "~> 7"
 
 group :check do
-
+  gem "ruby_memcheck", ">= 3"
 end
 
 group :dev do

--- a/gemfiles/ruby_3.4_elasticsearch_7.gemfile.lock
+++ b/gemfiles/ruby_3.4_elasticsearch_7.gemfile.lock
@@ -8,6 +8,13 @@ GIT
       simplecov-html (~> 0.11)
       simplecov_json_formatter (~> 0.1)
 
+GIT
+  remote: https://github.com/ruby/webrick.git
+  revision: 0c600e169bd4ae267cb5eeb6197277c848323bbe
+  ref: 0c600e169bd4ae267cb5eeb6197277c848323bbe
+  specs:
+    webrick (1.8.1)
+
 PATH
   remote: ..
   specs:
@@ -74,10 +81,14 @@ GEM
       ffi (~> 1.0)
     memory_profiler (0.9.14)
     method_source (1.1.0)
+    mini_portile2 (2.8.7)
     msgpack (1.7.2)
     multi_json (1.15.0)
     net-http (0.4.1)
       uri
+    nokogiri (1.16.7)
+      mini_portile2 (~> 2.8.2)
+      racc (~> 1.4)
     os (1.1.4)
     parallel (1.25.1)
     parser (3.3.3.0)
@@ -141,6 +152,8 @@ GEM
       rubocop (~> 1.33)
       rubocop-capybara (~> 2.17)
     ruby-progressbar (1.13.0)
+    ruby_memcheck (3.0.0)
+      nokogiri
     simplecov-cobertura (2.1.0)
       rexml
       simplecov (~> 0.19)
@@ -155,7 +168,6 @@ GEM
       addressable (>= 2.8.0)
       crack (>= 0.3.2)
       hashdiff (>= 0.4.0, < 2.0.0)
-    webrick (1.8.1)
     yard (0.9.36)
 
 PLATFORMS
@@ -192,11 +204,12 @@ DEPENDENCIES
   rubocop-packaging (~> 0.5.2)
   rubocop-performance (~> 1.9)
   rubocop-rspec (~> 2.20, < 2.21)
+  ruby_memcheck (>= 3)
   simplecov!
   simplecov-cobertura (~> 2.1.0)
   warning (~> 1)
   webmock (>= 3.10.0)
-  webrick (>= 1.7.0)
+  webrick!
   yard (~> 0.9)
 
 BUNDLED WITH

--- a/gemfiles/ruby_3.4_elasticsearch_8.gemfile
+++ b/gemfiles/ruby_3.4_elasticsearch_8.gemfile
@@ -26,7 +26,7 @@ gem "simplecov-cobertura", "~> 2.1.0"
 gem "warning", "~> 1"
 gem "webmock", ">= 3.10.0"
 gem "rexml", ">= 3.2.7"
-gem "webrick", ">= 1.7.0"
+gem "webrick", git: "https://github.com/ruby/webrick.git", ref: "0c600e169bd4ae267cb5eeb6197277c848323bbe"
 gem "yard", "~> 0.9"
 gem "rubocop", "~> 1.50.0", require: false
 gem "rubocop-packaging", "~> 0.5.2", require: false
@@ -38,7 +38,7 @@ gem "ffi", "~> 1.16.3", require: false
 gem "elasticsearch", "~> 8"
 
 group :check do
-
+  gem "ruby_memcheck", ">= 3"
 end
 
 group :dev do

--- a/gemfiles/ruby_3.4_elasticsearch_8.gemfile.lock
+++ b/gemfiles/ruby_3.4_elasticsearch_8.gemfile.lock
@@ -8,6 +8,13 @@ GIT
       simplecov-html (~> 0.11)
       simplecov_json_formatter (~> 0.1)
 
+GIT
+  remote: https://github.com/ruby/webrick.git
+  revision: 0c600e169bd4ae267cb5eeb6197277c848323bbe
+  ref: 0c600e169bd4ae267cb5eeb6197277c848323bbe
+  specs:
+    webrick (1.8.1)
+
 PATH
   remote: ..
   specs:
@@ -72,10 +79,14 @@ GEM
       ffi (~> 1.0)
     memory_profiler (0.9.14)
     method_source (1.1.0)
+    mini_portile2 (2.8.7)
     msgpack (1.7.2)
     multi_json (1.15.0)
     net-http (0.4.1)
       uri
+    nokogiri (1.16.7)
+      mini_portile2 (~> 2.8.2)
+      racc (~> 1.4)
     os (1.1.4)
     parallel (1.25.1)
     parser (3.3.3.0)
@@ -139,6 +150,8 @@ GEM
       rubocop (~> 1.33)
       rubocop-capybara (~> 2.17)
     ruby-progressbar (1.13.0)
+    ruby_memcheck (3.0.0)
+      nokogiri
     simplecov-cobertura (2.1.0)
       rexml
       simplecov (~> 0.19)
@@ -153,7 +166,6 @@ GEM
       addressable (>= 2.8.0)
       crack (>= 0.3.2)
       hashdiff (>= 0.4.0, < 2.0.0)
-    webrick (1.8.1)
     yard (0.9.36)
 
 PLATFORMS
@@ -190,11 +202,12 @@ DEPENDENCIES
   rubocop-packaging (~> 0.5.2)
   rubocop-performance (~> 1.9)
   rubocop-rspec (~> 2.20, < 2.21)
+  ruby_memcheck (>= 3)
   simplecov!
   simplecov-cobertura (~> 2.1.0)
   warning (~> 1)
   webmock (>= 3.10.0)
-  webrick (>= 1.7.0)
+  webrick!
   yard (~> 0.9)
 
 BUNDLED WITH

--- a/gemfiles/ruby_3.4_graphql_1.13.gemfile
+++ b/gemfiles/ruby_3.4_graphql_1.13.gemfile
@@ -26,7 +26,7 @@ gem "simplecov-cobertura", "~> 2.1.0"
 gem "warning", "~> 1"
 gem "webmock", ">= 3.10.0"
 gem "rexml", ">= 3.2.7"
-gem "webrick", ">= 1.7.0"
+gem "webrick", git: "https://github.com/ruby/webrick.git", ref: "0c600e169bd4ae267cb5eeb6197277c848323bbe"
 gem "yard", "~> 0.9"
 gem "rubocop", "~> 1.50.0", require: false
 gem "rubocop-packaging", "~> 0.5.2", require: false
@@ -42,7 +42,7 @@ gem "lograge", "~> 0.11"
 gem "mutex_m", ">= 0.1.0"
 
 group :check do
-
+  gem "ruby_memcheck", ">= 3"
 end
 
 group :dev do

--- a/gemfiles/ruby_3.4_graphql_1.13.gemfile.lock
+++ b/gemfiles/ruby_3.4_graphql_1.13.gemfile.lock
@@ -8,6 +8,13 @@ GIT
       simplecov-html (~> 0.11)
       simplecov_json_formatter (~> 0.1)
 
+GIT
+  remote: https://github.com/ruby/webrick.git
+  revision: 0c600e169bd4ae267cb5eeb6197277c848323bbe
+  ref: 0c600e169bd4ae267cb5eeb6197277c848323bbe
+  specs:
+    webrick (1.8.1)
+
 PATH
   remote: ..
   specs:
@@ -256,6 +263,8 @@ GEM
       rubocop (~> 1.33)
       rubocop-capybara (~> 2.17)
     ruby-progressbar (1.13.0)
+    ruby_memcheck (3.0.0)
+      nokogiri
     simplecov-cobertura (2.1.0)
       rexml
       simplecov (~> 0.19)
@@ -280,7 +289,6 @@ GEM
       addressable (>= 2.8.0)
       crack (>= 0.3.2)
       hashdiff (>= 0.4.0, < 2.0.0)
-    webrick (1.8.1)
     websocket-driver (0.7.6)
       websocket-extensions (>= 0.1.0)
     websocket-extensions (0.1.5)
@@ -324,12 +332,13 @@ DEPENDENCIES
   rubocop-packaging (~> 0.5.2)
   rubocop-performance (~> 1.9)
   rubocop-rspec (~> 2.20, < 2.21)
+  ruby_memcheck (>= 3)
   simplecov!
   simplecov-cobertura (~> 2.1.0)
   sprockets (< 4)
   warning (~> 1)
   webmock (>= 3.10.0)
-  webrick (>= 1.7.0)
+  webrick!
   yard (~> 0.9)
 
 BUNDLED WITH

--- a/gemfiles/ruby_3.4_graphql_2.0.gemfile
+++ b/gemfiles/ruby_3.4_graphql_2.0.gemfile
@@ -26,7 +26,7 @@ gem "simplecov-cobertura", "~> 2.1.0"
 gem "warning", "~> 1"
 gem "webmock", ">= 3.10.0"
 gem "rexml", ">= 3.2.7"
-gem "webrick", ">= 1.7.0"
+gem "webrick", git: "https://github.com/ruby/webrick.git", ref: "0c600e169bd4ae267cb5eeb6197277c848323bbe"
 gem "yard", "~> 0.9"
 gem "rubocop", "~> 1.50.0", require: false
 gem "rubocop-packaging", "~> 0.5.2", require: false
@@ -42,7 +42,7 @@ gem "lograge", "~> 0.11"
 gem "mutex_m", ">= 0.1.0"
 
 group :check do
-
+  gem "ruby_memcheck", ">= 3"
 end
 
 group :dev do

--- a/gemfiles/ruby_3.4_graphql_2.0.gemfile.lock
+++ b/gemfiles/ruby_3.4_graphql_2.0.gemfile.lock
@@ -8,6 +8,13 @@ GIT
       simplecov-html (~> 0.11)
       simplecov_json_formatter (~> 0.1)
 
+GIT
+  remote: https://github.com/ruby/webrick.git
+  revision: 0c600e169bd4ae267cb5eeb6197277c848323bbe
+  ref: 0c600e169bd4ae267cb5eeb6197277c848323bbe
+  specs:
+    webrick (1.8.1)
+
 PATH
   remote: ..
   specs:
@@ -256,6 +263,8 @@ GEM
       rubocop (~> 1.33)
       rubocop-capybara (~> 2.17)
     ruby-progressbar (1.13.0)
+    ruby_memcheck (3.0.0)
+      nokogiri
     simplecov-cobertura (2.1.0)
       rexml
       simplecov (~> 0.19)
@@ -280,7 +289,6 @@ GEM
       addressable (>= 2.8.0)
       crack (>= 0.3.2)
       hashdiff (>= 0.4.0, < 2.0.0)
-    webrick (1.8.1)
     websocket-driver (0.7.6)
       websocket-extensions (>= 0.1.0)
     websocket-extensions (0.1.5)
@@ -324,12 +332,13 @@ DEPENDENCIES
   rubocop-packaging (~> 0.5.2)
   rubocop-performance (~> 1.9)
   rubocop-rspec (~> 2.20, < 2.21)
+  ruby_memcheck (>= 3)
   simplecov!
   simplecov-cobertura (~> 2.1.0)
   sprockets (< 4)
   warning (~> 1)
   webmock (>= 3.10.0)
-  webrick (>= 1.7.0)
+  webrick!
   yard (~> 0.9)
 
 BUNDLED WITH

--- a/gemfiles/ruby_3.4_graphql_2.1.gemfile
+++ b/gemfiles/ruby_3.4_graphql_2.1.gemfile
@@ -26,7 +26,7 @@ gem "simplecov-cobertura", "~> 2.1.0"
 gem "warning", "~> 1"
 gem "webmock", ">= 3.10.0"
 gem "rexml", ">= 3.2.7"
-gem "webrick", ">= 1.7.0"
+gem "webrick", git: "https://github.com/ruby/webrick.git", ref: "0c600e169bd4ae267cb5eeb6197277c848323bbe"
 gem "yard", "~> 0.9"
 gem "rubocop", "~> 1.50.0", require: false
 gem "rubocop-packaging", "~> 0.5.2", require: false
@@ -42,7 +42,7 @@ gem "lograge", "~> 0.11"
 gem "mutex_m", ">= 0.1.0"
 
 group :check do
-
+  gem "ruby_memcheck", ">= 3"
 end
 
 group :dev do

--- a/gemfiles/ruby_3.4_graphql_2.1.gemfile.lock
+++ b/gemfiles/ruby_3.4_graphql_2.1.gemfile.lock
@@ -8,6 +8,13 @@ GIT
       simplecov-html (~> 0.11)
       simplecov_json_formatter (~> 0.1)
 
+GIT
+  remote: https://github.com/ruby/webrick.git
+  revision: 0c600e169bd4ae267cb5eeb6197277c848323bbe
+  ref: 0c600e169bd4ae267cb5eeb6197277c848323bbe
+  specs:
+    webrick (1.8.1)
+
 PATH
   remote: ..
   specs:
@@ -256,6 +263,8 @@ GEM
       rubocop (~> 1.33)
       rubocop-capybara (~> 2.17)
     ruby-progressbar (1.13.0)
+    ruby_memcheck (3.0.0)
+      nokogiri
     simplecov-cobertura (2.1.0)
       rexml
       simplecov (~> 0.19)
@@ -280,7 +289,6 @@ GEM
       addressable (>= 2.8.0)
       crack (>= 0.3.2)
       hashdiff (>= 0.4.0, < 2.0.0)
-    webrick (1.8.1)
     websocket-driver (0.7.6)
       websocket-extensions (>= 0.1.0)
     websocket-extensions (0.1.5)
@@ -324,12 +332,13 @@ DEPENDENCIES
   rubocop-packaging (~> 0.5.2)
   rubocop-performance (~> 1.9)
   rubocop-rspec (~> 2.20, < 2.21)
+  ruby_memcheck (>= 3)
   simplecov!
   simplecov-cobertura (~> 2.1.0)
   sprockets (< 4)
   warning (~> 1)
   webmock (>= 3.10.0)
-  webrick (>= 1.7.0)
+  webrick!
   yard (~> 0.9)
 
 BUNDLED WITH

--- a/gemfiles/ruby_3.4_graphql_2.2.gemfile
+++ b/gemfiles/ruby_3.4_graphql_2.2.gemfile
@@ -26,7 +26,7 @@ gem "simplecov-cobertura", "~> 2.1.0"
 gem "warning", "~> 1"
 gem "webmock", ">= 3.10.0"
 gem "rexml", ">= 3.2.7"
-gem "webrick", ">= 1.7.0"
+gem "webrick", git: "https://github.com/ruby/webrick.git", ref: "0c600e169bd4ae267cb5eeb6197277c848323bbe"
 gem "yard", "~> 0.9"
 gem "rubocop", "~> 1.50.0", require: false
 gem "rubocop-packaging", "~> 0.5.2", require: false
@@ -42,7 +42,7 @@ gem "lograge", "~> 0.11"
 gem "mutex_m", ">= 0.1.0"
 
 group :check do
-
+  gem "ruby_memcheck", ">= 3"
 end
 
 group :dev do

--- a/gemfiles/ruby_3.4_graphql_2.2.gemfile.lock
+++ b/gemfiles/ruby_3.4_graphql_2.2.gemfile.lock
@@ -8,6 +8,13 @@ GIT
       simplecov-html (~> 0.11)
       simplecov_json_formatter (~> 0.1)
 
+GIT
+  remote: https://github.com/ruby/webrick.git
+  revision: 0c600e169bd4ae267cb5eeb6197277c848323bbe
+  ref: 0c600e169bd4ae267cb5eeb6197277c848323bbe
+  specs:
+    webrick (1.8.1)
+
 PATH
   remote: ..
   specs:
@@ -256,6 +263,8 @@ GEM
       rubocop (~> 1.33)
       rubocop-capybara (~> 2.17)
     ruby-progressbar (1.13.0)
+    ruby_memcheck (3.0.0)
+      nokogiri
     simplecov-cobertura (2.1.0)
       rexml
       simplecov (~> 0.19)
@@ -280,7 +289,6 @@ GEM
       addressable (>= 2.8.0)
       crack (>= 0.3.2)
       hashdiff (>= 0.4.0, < 2.0.0)
-    webrick (1.8.1)
     websocket-driver (0.7.6)
       websocket-extensions (>= 0.1.0)
     websocket-extensions (0.1.5)
@@ -324,12 +332,13 @@ DEPENDENCIES
   rubocop-packaging (~> 0.5.2)
   rubocop-performance (~> 1.9)
   rubocop-rspec (~> 2.20, < 2.21)
+  ruby_memcheck (>= 3)
   simplecov!
   simplecov-cobertura (~> 2.1.0)
   sprockets (< 4)
   warning (~> 1)
   webmock (>= 3.10.0)
-  webrick (>= 1.7.0)
+  webrick!
   yard (~> 0.9)
 
 BUNDLED WITH

--- a/gemfiles/ruby_3.4_graphql_2.3.gemfile
+++ b/gemfiles/ruby_3.4_graphql_2.3.gemfile
@@ -26,7 +26,7 @@ gem "simplecov-cobertura", "~> 2.1.0"
 gem "warning", "~> 1"
 gem "webmock", ">= 3.10.0"
 gem "rexml", ">= 3.2.7"
-gem "webrick", ">= 1.7.0"
+gem "webrick", git: "https://github.com/ruby/webrick.git", ref: "0c600e169bd4ae267cb5eeb6197277c848323bbe"
 gem "yard", "~> 0.9"
 gem "rubocop", "~> 1.50.0", require: false
 gem "rubocop-packaging", "~> 0.5.2", require: false
@@ -42,7 +42,7 @@ gem "lograge", "~> 0.11"
 gem "mutex_m", ">= 0.1.0"
 
 group :check do
-
+  gem "ruby_memcheck", ">= 3"
 end
 
 group :dev do

--- a/gemfiles/ruby_3.4_graphql_2.3.gemfile.lock
+++ b/gemfiles/ruby_3.4_graphql_2.3.gemfile.lock
@@ -8,6 +8,13 @@ GIT
       simplecov-html (~> 0.11)
       simplecov_json_formatter (~> 0.1)
 
+GIT
+  remote: https://github.com/ruby/webrick.git
+  revision: 0c600e169bd4ae267cb5eeb6197277c848323bbe
+  ref: 0c600e169bd4ae267cb5eeb6197277c848323bbe
+  specs:
+    webrick (1.8.1)
+
 PATH
   remote: ..
   specs:
@@ -256,6 +263,8 @@ GEM
       rubocop (~> 1.33)
       rubocop-capybara (~> 2.17)
     ruby-progressbar (1.13.0)
+    ruby_memcheck (3.0.0)
+      nokogiri
     simplecov-cobertura (2.1.0)
       rexml
       simplecov (~> 0.19)
@@ -280,7 +289,6 @@ GEM
       addressable (>= 2.8.0)
       crack (>= 0.3.2)
       hashdiff (>= 0.4.0, < 2.0.0)
-    webrick (1.8.1)
     websocket-driver (0.7.6)
       websocket-extensions (>= 0.1.0)
     websocket-extensions (0.1.5)
@@ -324,12 +332,13 @@ DEPENDENCIES
   rubocop-packaging (~> 0.5.2)
   rubocop-performance (~> 1.9)
   rubocop-rspec (~> 2.20, < 2.21)
+  ruby_memcheck (>= 3)
   simplecov!
   simplecov-cobertura (~> 2.1.0)
   sprockets (< 4)
   warning (~> 1)
   webmock (>= 3.10.0)
-  webrick (>= 1.7.0)
+  webrick!
   yard (~> 0.9)
 
 BUNDLED WITH

--- a/gemfiles/ruby_3.4_http.gemfile
+++ b/gemfiles/ruby_3.4_http.gemfile
@@ -26,7 +26,7 @@ gem "simplecov-cobertura", "~> 2.1.0"
 gem "warning", "~> 1"
 gem "webmock", ">= 3.10.0"
 gem "rexml", ">= 3.2.7"
-gem "webrick", ">= 1.7.0"
+gem "webrick", git: "https://github.com/ruby/webrick.git", ref: "0c600e169bd4ae267cb5eeb6197277c848323bbe"
 gem "yard", "~> 0.9"
 gem "rubocop", "~> 1.50.0", require: false
 gem "rubocop-packaging", "~> 0.5.2", require: false
@@ -45,7 +45,7 @@ gem "stripe"
 gem "typhoeus"
 
 group :check do
-
+  gem "ruby_memcheck", ">= 3"
 end
 
 group :dev do

--- a/gemfiles/ruby_3.4_http.gemfile.lock
+++ b/gemfiles/ruby_3.4_http.gemfile.lock
@@ -8,6 +8,13 @@ GIT
       simplecov-html (~> 0.11)
       simplecov_json_formatter (~> 0.1)
 
+GIT
+  remote: https://github.com/ruby/webrick.git
+  revision: 0c600e169bd4ae267cb5eeb6197277c848323bbe
+  ref: 0c600e169bd4ae267cb5eeb6197277c848323bbe
+  specs:
+    webrick (1.8.1)
+
 PATH
   remote: ..
   specs:
@@ -89,10 +96,14 @@ GEM
     mime-types (3.5.2)
       mime-types-data (~> 3.2015)
     mime-types-data (3.2024.0604)
+    mini_portile2 (2.8.7)
     msgpack (1.7.2)
     net-http (0.4.1)
       uri
     netrc (0.11.0)
+    nokogiri (1.16.7)
+      mini_portile2 (~> 2.8.2)
+      racc (~> 1.4)
     os (1.1.4)
     parallel (1.25.1)
     parser (3.3.3.0)
@@ -161,6 +172,8 @@ GEM
       rubocop (~> 1.33)
       rubocop-capybara (~> 2.17)
     ruby-progressbar (1.13.0)
+    ruby_memcheck (3.0.0)
+      nokogiri
     simplecov-cobertura (2.1.0)
       rexml
       simplecov (~> 0.19)
@@ -178,7 +191,6 @@ GEM
       addressable (>= 2.8.0)
       crack (>= 0.3.2)
       hashdiff (>= 0.4.0, < 2.0.0)
-    webrick (1.8.1)
     yard (0.9.36)
 
 PLATFORMS
@@ -220,13 +232,14 @@ DEPENDENCIES
   rubocop-packaging (~> 0.5.2)
   rubocop-performance (~> 1.9)
   rubocop-rspec (~> 2.20, < 2.21)
+  ruby_memcheck (>= 3)
   simplecov!
   simplecov-cobertura (~> 2.1.0)
   stripe
   typhoeus
   warning (~> 1)
   webmock (>= 3.10.0)
-  webrick (>= 1.7.0)
+  webrick!
   yard (~> 0.9)
 
 BUNDLED WITH

--- a/gemfiles/ruby_3.4_opensearch_2.gemfile
+++ b/gemfiles/ruby_3.4_opensearch_2.gemfile
@@ -26,7 +26,7 @@ gem "simplecov-cobertura", "~> 2.1.0"
 gem "warning", "~> 1"
 gem "webmock", ">= 3.10.0"
 gem "rexml", ">= 3.2.7"
-gem "webrick", ">= 1.7.0"
+gem "webrick", git: "https://github.com/ruby/webrick.git", ref: "0c600e169bd4ae267cb5eeb6197277c848323bbe"
 gem "yard", "~> 0.9"
 gem "rubocop", "~> 1.50.0", require: false
 gem "rubocop-packaging", "~> 0.5.2", require: false
@@ -38,7 +38,7 @@ gem "ffi", "~> 1.16.3", require: false
 gem "opensearch-ruby", "~> 2"
 
 group :check do
-
+  gem "ruby_memcheck", ">= 3"
 end
 
 group :dev do

--- a/gemfiles/ruby_3.4_opensearch_2.gemfile.lock
+++ b/gemfiles/ruby_3.4_opensearch_2.gemfile.lock
@@ -8,6 +8,13 @@ GIT
       simplecov-html (~> 0.11)
       simplecov_json_formatter (~> 0.1)
 
+GIT
+  remote: https://github.com/ruby/webrick.git
+  revision: 0c600e169bd4ae267cb5eeb6197277c848323bbe
+  ref: 0c600e169bd4ae267cb5eeb6197277c848323bbe
+  specs:
+    webrick (1.8.1)
+
 PATH
   remote: ..
   specs:
@@ -64,10 +71,14 @@ GEM
       ffi (~> 1.0)
     memory_profiler (0.9.14)
     method_source (1.1.0)
+    mini_portile2 (2.8.7)
     msgpack (1.7.2)
     multi_json (1.15.0)
     net-http (0.4.1)
       uri
+    nokogiri (1.16.7)
+      mini_portile2 (~> 2.8.2)
+      racc (~> 1.4)
     opensearch-api (2.2.0)
       multi_json
     opensearch-ruby (2.1.0)
@@ -139,6 +150,8 @@ GEM
       rubocop (~> 1.33)
       rubocop-capybara (~> 2.17)
     ruby-progressbar (1.13.0)
+    ruby_memcheck (3.0.0)
+      nokogiri
     simplecov-cobertura (2.1.0)
       rexml
       simplecov (~> 0.19)
@@ -153,7 +166,6 @@ GEM
       addressable (>= 2.8.0)
       crack (>= 0.3.2)
       hashdiff (>= 0.4.0, < 2.0.0)
-    webrick (1.8.1)
     yard (0.9.36)
 
 PLATFORMS
@@ -190,11 +202,12 @@ DEPENDENCIES
   rubocop-packaging (~> 0.5.2)
   rubocop-performance (~> 1.9)
   rubocop-rspec (~> 2.20, < 2.21)
+  ruby_memcheck (>= 3)
   simplecov!
   simplecov-cobertura (~> 2.1.0)
   warning (~> 1)
   webmock (>= 3.10.0)
-  webrick (>= 1.7.0)
+  webrick!
   yard (~> 0.9)
 
 BUNDLED WITH

--- a/gemfiles/ruby_3.4_opensearch_3.gemfile
+++ b/gemfiles/ruby_3.4_opensearch_3.gemfile
@@ -26,7 +26,7 @@ gem "simplecov-cobertura", "~> 2.1.0"
 gem "warning", "~> 1"
 gem "webmock", ">= 3.10.0"
 gem "rexml", ">= 3.2.7"
-gem "webrick", ">= 1.7.0"
+gem "webrick", git: "https://github.com/ruby/webrick.git", ref: "0c600e169bd4ae267cb5eeb6197277c848323bbe"
 gem "yard", "~> 0.9"
 gem "rubocop", "~> 1.50.0", require: false
 gem "rubocop-packaging", "~> 0.5.2", require: false
@@ -38,7 +38,7 @@ gem "ffi", "~> 1.16.3", require: false
 gem "opensearch-ruby", "~> 3"
 
 group :check do
-
+  gem "ruby_memcheck", ">= 3"
 end
 
 group :dev do

--- a/gemfiles/ruby_3.4_opensearch_3.gemfile.lock
+++ b/gemfiles/ruby_3.4_opensearch_3.gemfile.lock
@@ -8,6 +8,13 @@ GIT
       simplecov-html (~> 0.11)
       simplecov_json_formatter (~> 0.1)
 
+GIT
+  remote: https://github.com/ruby/webrick.git
+  revision: 0c600e169bd4ae267cb5eeb6197277c848323bbe
+  ref: 0c600e169bd4ae267cb5eeb6197277c848323bbe
+  specs:
+    webrick (1.8.1)
+
 PATH
   remote: ..
   specs:
@@ -64,10 +71,14 @@ GEM
       ffi (~> 1.0)
     memory_profiler (0.9.14)
     method_source (1.1.0)
+    mini_portile2 (2.8.7)
     msgpack (1.7.2)
     multi_json (1.15.0)
     net-http (0.4.1)
       uri
+    nokogiri (1.16.7)
+      mini_portile2 (~> 2.8.2)
+      racc (~> 1.4)
     opensearch-ruby (3.3.0)
       faraday (>= 1.0, < 3)
       multi_json (>= 1.0)
@@ -134,6 +145,8 @@ GEM
       rubocop (~> 1.33)
       rubocop-capybara (~> 2.17)
     ruby-progressbar (1.13.0)
+    ruby_memcheck (3.0.0)
+      nokogiri
     simplecov-cobertura (2.1.0)
       rexml
       simplecov (~> 0.19)
@@ -148,7 +161,6 @@ GEM
       addressable (>= 2.8.0)
       crack (>= 0.3.2)
       hashdiff (>= 0.4.0, < 2.0.0)
-    webrick (1.8.1)
     yard (0.9.36)
 
 PLATFORMS
@@ -185,11 +197,12 @@ DEPENDENCIES
   rubocop-packaging (~> 0.5.2)
   rubocop-performance (~> 1.9)
   rubocop-rspec (~> 2.20, < 2.21)
+  ruby_memcheck (>= 3)
   simplecov!
   simplecov-cobertura (~> 2.1.0)
   warning (~> 1)
   webmock (>= 3.10.0)
-  webrick (>= 1.7.0)
+  webrick!
   yard (~> 0.9)
 
 BUNDLED WITH

--- a/gemfiles/ruby_3.4_opentelemetry.gemfile
+++ b/gemfiles/ruby_3.4_opentelemetry.gemfile
@@ -26,7 +26,7 @@ gem "simplecov-cobertura", "~> 2.1.0"
 gem "warning", "~> 1"
 gem "webmock", ">= 3.10.0"
 gem "rexml", ">= 3.2.7"
-gem "webrick", ">= 1.7.0"
+gem "webrick", git: "https://github.com/ruby/webrick.git", ref: "0c600e169bd4ae267cb5eeb6197277c848323bbe"
 gem "yard", "~> 0.9"
 gem "rubocop", "~> 1.50.0", require: false
 gem "rubocop-packaging", "~> 0.5.2", require: false
@@ -38,7 +38,7 @@ gem "ffi", "~> 1.16.3", require: false
 gem "opentelemetry-sdk", "~> 1.1"
 
 group :check do
-
+  gem "ruby_memcheck", ">= 3"
 end
 
 group :dev do

--- a/gemfiles/ruby_3.4_opentelemetry.gemfile.lock
+++ b/gemfiles/ruby_3.4_opentelemetry.gemfile.lock
@@ -8,6 +8,13 @@ GIT
       simplecov-html (~> 0.11)
       simplecov_json_formatter (~> 0.1)
 
+GIT
+  remote: https://github.com/ruby/webrick.git
+  revision: 0c600e169bd4ae267cb5eeb6197277c848323bbe
+  ref: 0c600e169bd4ae267cb5eeb6197277c848323bbe
+  specs:
+    webrick (1.8.1)
+
 PATH
   remote: ..
   specs:
@@ -60,7 +67,11 @@ GEM
       ffi (~> 1.0)
     memory_profiler (0.9.14)
     method_source (1.1.0)
+    mini_portile2 (2.8.7)
     msgpack (1.7.2)
+    nokogiri (1.16.7)
+      mini_portile2 (~> 2.8.2)
+      racc (~> 1.4)
     opentelemetry-api (1.2.5)
     opentelemetry-common (0.21.0)
       opentelemetry-api (~> 1.0)
@@ -136,6 +147,8 @@ GEM
       rubocop (~> 1.33)
       rubocop-capybara (~> 2.17)
     ruby-progressbar (1.13.0)
+    ruby_memcheck (3.0.0)
+      nokogiri
     simplecov-cobertura (2.1.0)
       rexml
       simplecov (~> 0.19)
@@ -149,7 +162,6 @@ GEM
       addressable (>= 2.8.0)
       crack (>= 0.3.2)
       hashdiff (>= 0.4.0, < 2.0.0)
-    webrick (1.8.1)
     yard (0.9.36)
 
 PLATFORMS
@@ -186,11 +198,12 @@ DEPENDENCIES
   rubocop-packaging (~> 0.5.2)
   rubocop-performance (~> 1.9)
   rubocop-rspec (~> 2.20, < 2.21)
+  ruby_memcheck (>= 3)
   simplecov!
   simplecov-cobertura (~> 2.1.0)
   warning (~> 1)
   webmock (>= 3.10.0)
-  webrick (>= 1.7.0)
+  webrick!
   yard (~> 0.9)
 
 BUNDLED WITH

--- a/gemfiles/ruby_3.4_rack_2.gemfile
+++ b/gemfiles/ruby_3.4_rack_2.gemfile
@@ -26,7 +26,7 @@ gem "simplecov-cobertura", "~> 2.1.0"
 gem "warning", "~> 1"
 gem "webmock", ">= 3.10.0"
 gem "rexml", ">= 3.2.7"
-gem "webrick", ">= 1.7.0"
+gem "webrick", git: "https://github.com/ruby/webrick.git", ref: "0c600e169bd4ae267cb5eeb6197277c848323bbe"
 gem "yard", "~> 0.9"
 gem "rubocop", "~> 1.50.0", require: false
 gem "rubocop-packaging", "~> 0.5.2", require: false
@@ -40,7 +40,7 @@ gem "rack-contrib"
 gem "rack-test"
 
 group :check do
-
+  gem "ruby_memcheck", ">= 3"
 end
 
 group :dev do

--- a/gemfiles/ruby_3.4_rack_2.gemfile.lock
+++ b/gemfiles/ruby_3.4_rack_2.gemfile.lock
@@ -8,6 +8,13 @@ GIT
       simplecov-html (~> 0.11)
       simplecov_json_formatter (~> 0.1)
 
+GIT
+  remote: https://github.com/ruby/webrick.git
+  revision: 0c600e169bd4ae267cb5eeb6197277c848323bbe
+  ref: 0c600e169bd4ae267cb5eeb6197277c848323bbe
+  specs:
+    webrick (1.8.1)
+
 PATH
   remote: ..
   specs:
@@ -60,7 +67,11 @@ GEM
       ffi (~> 1.0)
     memory_profiler (0.9.14)
     method_source (1.1.0)
+    mini_portile2 (2.8.7)
     msgpack (1.7.2)
+    nokogiri (1.16.7)
+      mini_portile2 (~> 2.8.2)
+      racc (~> 1.4)
     os (1.1.4)
     parallel (1.25.1)
     parser (3.3.3.0)
@@ -129,6 +140,8 @@ GEM
       rubocop (~> 1.33)
       rubocop-capybara (~> 2.17)
     ruby-progressbar (1.13.0)
+    ruby_memcheck (3.0.0)
+      nokogiri
     simplecov-cobertura (2.1.0)
       rexml
       simplecov (~> 0.19)
@@ -142,7 +155,6 @@ GEM
       addressable (>= 2.8.0)
       crack (>= 0.3.2)
       hashdiff (>= 0.4.0, < 2.0.0)
-    webrick (1.8.1)
     yard (0.9.36)
 
 PLATFORMS
@@ -181,11 +193,12 @@ DEPENDENCIES
   rubocop-packaging (~> 0.5.2)
   rubocop-performance (~> 1.9)
   rubocop-rspec (~> 2.20, < 2.21)
+  ruby_memcheck (>= 3)
   simplecov!
   simplecov-cobertura (~> 2.1.0)
   warning (~> 1)
   webmock (>= 3.10.0)
-  webrick (>= 1.7.0)
+  webrick!
   yard (~> 0.9)
 
 BUNDLED WITH

--- a/gemfiles/ruby_3.4_rack_3.gemfile
+++ b/gemfiles/ruby_3.4_rack_3.gemfile
@@ -26,7 +26,7 @@ gem "simplecov-cobertura", "~> 2.1.0"
 gem "warning", "~> 1"
 gem "webmock", ">= 3.10.0"
 gem "rexml", ">= 3.2.7"
-gem "webrick", ">= 1.7.0"
+gem "webrick", git: "https://github.com/ruby/webrick.git", ref: "0c600e169bd4ae267cb5eeb6197277c848323bbe"
 gem "yard", "~> 0.9"
 gem "rubocop", "~> 1.50.0", require: false
 gem "rubocop-packaging", "~> 0.5.2", require: false
@@ -40,7 +40,7 @@ gem "rack-contrib"
 gem "rack-test"
 
 group :check do
-
+  gem "ruby_memcheck", ">= 3"
 end
 
 group :dev do

--- a/gemfiles/ruby_3.4_rack_3.gemfile.lock
+++ b/gemfiles/ruby_3.4_rack_3.gemfile.lock
@@ -8,6 +8,13 @@ GIT
       simplecov-html (~> 0.11)
       simplecov_json_formatter (~> 0.1)
 
+GIT
+  remote: https://github.com/ruby/webrick.git
+  revision: 0c600e169bd4ae267cb5eeb6197277c848323bbe
+  ref: 0c600e169bd4ae267cb5eeb6197277c848323bbe
+  specs:
+    webrick (1.8.1)
+
 PATH
   remote: ..
   specs:
@@ -60,7 +67,11 @@ GEM
       ffi (~> 1.0)
     memory_profiler (0.9.14)
     method_source (1.1.0)
+    mini_portile2 (2.8.7)
     msgpack (1.7.2)
+    nokogiri (1.16.7)
+      mini_portile2 (~> 2.8.2)
+      racc (~> 1.4)
     os (1.1.4)
     parallel (1.25.1)
     parser (3.3.3.0)
@@ -129,6 +140,8 @@ GEM
       rubocop (~> 1.33)
       rubocop-capybara (~> 2.17)
     ruby-progressbar (1.13.0)
+    ruby_memcheck (3.0.0)
+      nokogiri
     simplecov-cobertura (2.1.0)
       rexml
       simplecov (~> 0.19)
@@ -142,7 +155,6 @@ GEM
       addressable (>= 2.8.0)
       crack (>= 0.3.2)
       hashdiff (>= 0.4.0, < 2.0.0)
-    webrick (1.8.1)
     yard (0.9.36)
 
 PLATFORMS
@@ -181,11 +193,12 @@ DEPENDENCIES
   rubocop-packaging (~> 0.5.2)
   rubocop-performance (~> 1.9)
   rubocop-rspec (~> 2.20, < 2.21)
+  ruby_memcheck (>= 3)
   simplecov!
   simplecov-cobertura (~> 2.1.0)
   warning (~> 1)
   webmock (>= 3.10.0)
-  webrick (>= 1.7.0)
+  webrick!
   yard (~> 0.9)
 
 BUNDLED WITH

--- a/gemfiles/ruby_3.4_rails61_mysql2.gemfile
+++ b/gemfiles/ruby_3.4_rails61_mysql2.gemfile
@@ -26,7 +26,7 @@ gem "simplecov-cobertura", "~> 2.1.0"
 gem "warning", "~> 1"
 gem "webmock", ">= 3.10.0"
 gem "rexml", ">= 3.2.7"
-gem "webrick", ">= 1.7.0"
+gem "webrick", git: "https://github.com/ruby/webrick.git", ref: "0c600e169bd4ae267cb5eeb6197277c848323bbe"
 gem "yard", "~> 0.9"
 gem "rubocop", "~> 1.50.0", require: false
 gem "rubocop-packaging", "~> 0.5.2", require: false
@@ -42,7 +42,7 @@ gem "lograge", "~> 0.11"
 gem "net-smtp"
 
 group :check do
-
+  gem "ruby_memcheck", ">= 3"
 end
 
 group :dev do

--- a/gemfiles/ruby_3.4_rails61_mysql2.gemfile.lock
+++ b/gemfiles/ruby_3.4_rails61_mysql2.gemfile.lock
@@ -8,6 +8,13 @@ GIT
       simplecov-html (~> 0.11)
       simplecov_json_formatter (~> 0.1)
 
+GIT
+  remote: https://github.com/ruby/webrick.git
+  revision: 0c600e169bd4ae267cb5eeb6197277c848323bbe
+  ref: 0c600e169bd4ae267cb5eeb6197277c848323bbe
+  specs:
+    webrick (1.8.1)
+
 PATH
   remote: ..
   specs:
@@ -254,6 +261,8 @@ GEM
       rubocop (~> 1.33)
       rubocop-capybara (~> 2.17)
     ruby-progressbar (1.13.0)
+    ruby_memcheck (3.0.0)
+      nokogiri
     simplecov-cobertura (2.1.0)
       rexml
       simplecov (~> 0.19)
@@ -278,7 +287,6 @@ GEM
       addressable (>= 2.8.0)
       crack (>= 0.3.2)
       hashdiff (>= 0.4.0, < 2.0.0)
-    webrick (1.8.1)
     websocket-driver (0.7.6)
       websocket-extensions (>= 0.1.0)
     websocket-extensions (0.1.5)
@@ -322,12 +330,13 @@ DEPENDENCIES
   rubocop-packaging (~> 0.5.2)
   rubocop-performance (~> 1.9)
   rubocop-rspec (~> 2.20, < 2.21)
+  ruby_memcheck (>= 3)
   simplecov!
   simplecov-cobertura (~> 2.1.0)
   sprockets (< 4)
   warning (~> 1)
   webmock (>= 3.10.0)
-  webrick (>= 1.7.0)
+  webrick!
   yard (~> 0.9)
 
 BUNDLED WITH

--- a/gemfiles/ruby_3.4_rails61_postgres.gemfile
+++ b/gemfiles/ruby_3.4_rails61_postgres.gemfile
@@ -26,7 +26,7 @@ gem "simplecov-cobertura", "~> 2.1.0"
 gem "warning", "~> 1"
 gem "webmock", ">= 3.10.0"
 gem "rexml", ">= 3.2.7"
-gem "webrick", ">= 1.7.0"
+gem "webrick", git: "https://github.com/ruby/webrick.git", ref: "0c600e169bd4ae267cb5eeb6197277c848323bbe"
 gem "yard", "~> 0.9"
 gem "rubocop", "~> 1.50.0", require: false
 gem "rubocop-packaging", "~> 0.5.2", require: false
@@ -42,7 +42,7 @@ gem "lograge", "~> 0.11"
 gem "net-smtp"
 
 group :check do
-
+  gem "ruby_memcheck", ">= 3"
 end
 
 group :dev do

--- a/gemfiles/ruby_3.4_rails61_postgres.gemfile.lock
+++ b/gemfiles/ruby_3.4_rails61_postgres.gemfile.lock
@@ -8,6 +8,13 @@ GIT
       simplecov-html (~> 0.11)
       simplecov_json_formatter (~> 0.1)
 
+GIT
+  remote: https://github.com/ruby/webrick.git
+  revision: 0c600e169bd4ae267cb5eeb6197277c848323bbe
+  ref: 0c600e169bd4ae267cb5eeb6197277c848323bbe
+  specs:
+    webrick (1.8.1)
+
 PATH
   remote: ..
   specs:
@@ -254,6 +261,8 @@ GEM
       rubocop (~> 1.33)
       rubocop-capybara (~> 2.17)
     ruby-progressbar (1.13.0)
+    ruby_memcheck (3.0.0)
+      nokogiri
     simplecov-cobertura (2.1.0)
       rexml
       simplecov (~> 0.19)
@@ -278,7 +287,6 @@ GEM
       addressable (>= 2.8.0)
       crack (>= 0.3.2)
       hashdiff (>= 0.4.0, < 2.0.0)
-    webrick (1.8.1)
     websocket-driver (0.7.6)
       websocket-extensions (>= 0.1.0)
     websocket-extensions (0.1.5)
@@ -322,12 +330,13 @@ DEPENDENCIES
   rubocop-packaging (~> 0.5.2)
   rubocop-performance (~> 1.9)
   rubocop-rspec (~> 2.20, < 2.21)
+  ruby_memcheck (>= 3)
   simplecov!
   simplecov-cobertura (~> 2.1.0)
   sprockets (< 4)
   warning (~> 1)
   webmock (>= 3.10.0)
-  webrick (>= 1.7.0)
+  webrick!
   yard (~> 0.9)
 
 BUNDLED WITH

--- a/gemfiles/ruby_3.4_rails61_postgres_redis.gemfile
+++ b/gemfiles/ruby_3.4_rails61_postgres_redis.gemfile
@@ -26,7 +26,7 @@ gem "simplecov-cobertura", "~> 2.1.0"
 gem "warning", "~> 1"
 gem "webmock", ">= 3.10.0"
 gem "rexml", ">= 3.2.7"
-gem "webrick", ">= 1.7.0"
+gem "webrick", git: "https://github.com/ruby/webrick.git", ref: "0c600e169bd4ae267cb5eeb6197277c848323bbe"
 gem "yard", "~> 0.9"
 gem "rubocop", "~> 1.50.0", require: false
 gem "rubocop-packaging", "~> 0.5.2", require: false
@@ -43,7 +43,7 @@ gem "lograge", "~> 0.11"
 gem "net-smtp"
 
 group :check do
-
+  gem "ruby_memcheck", ">= 3"
 end
 
 group :dev do

--- a/gemfiles/ruby_3.4_rails61_postgres_redis.gemfile.lock
+++ b/gemfiles/ruby_3.4_rails61_postgres_redis.gemfile.lock
@@ -8,6 +8,13 @@ GIT
       simplecov-html (~> 0.11)
       simplecov_json_formatter (~> 0.1)
 
+GIT
+  remote: https://github.com/ruby/webrick.git
+  revision: 0c600e169bd4ae267cb5eeb6197277c848323bbe
+  ref: 0c600e169bd4ae267cb5eeb6197277c848323bbe
+  specs:
+    webrick (1.8.1)
+
 PATH
   remote: ..
   specs:
@@ -255,6 +262,8 @@ GEM
       rubocop (~> 1.33)
       rubocop-capybara (~> 2.17)
     ruby-progressbar (1.13.0)
+    ruby_memcheck (3.0.0)
+      nokogiri
     simplecov-cobertura (2.1.0)
       rexml
       simplecov (~> 0.19)
@@ -279,7 +288,6 @@ GEM
       addressable (>= 2.8.0)
       crack (>= 0.3.2)
       hashdiff (>= 0.4.0, < 2.0.0)
-    webrick (1.8.1)
     websocket-driver (0.7.6)
       websocket-extensions (>= 0.1.0)
     websocket-extensions (0.1.5)
@@ -324,12 +332,13 @@ DEPENDENCIES
   rubocop-packaging (~> 0.5.2)
   rubocop-performance (~> 1.9)
   rubocop-rspec (~> 2.20, < 2.21)
+  ruby_memcheck (>= 3)
   simplecov!
   simplecov-cobertura (~> 2.1.0)
   sprockets (< 4)
   warning (~> 1)
   webmock (>= 3.10.0)
-  webrick (>= 1.7.0)
+  webrick!
   yard (~> 0.9)
 
 BUNDLED WITH

--- a/gemfiles/ruby_3.4_rails61_postgres_sidekiq.gemfile
+++ b/gemfiles/ruby_3.4_rails61_postgres_sidekiq.gemfile
@@ -26,7 +26,7 @@ gem "simplecov-cobertura", "~> 2.1.0"
 gem "warning", "~> 1"
 gem "webmock", ">= 3.10.0"
 gem "rexml", ">= 3.2.7"
-gem "webrick", ">= 1.7.0"
+gem "webrick", git: "https://github.com/ruby/webrick.git", ref: "0c600e169bd4ae267cb5eeb6197277c848323bbe"
 gem "yard", "~> 0.9"
 gem "rubocop", "~> 1.50.0", require: false
 gem "rubocop-packaging", "~> 0.5.2", require: false
@@ -44,7 +44,7 @@ gem "rails_semantic_logger", "~> 4.0"
 gem "net-smtp"
 
 group :check do
-
+  gem "ruby_memcheck", ">= 3"
 end
 
 group :dev do

--- a/gemfiles/ruby_3.4_rails61_postgres_sidekiq.gemfile.lock
+++ b/gemfiles/ruby_3.4_rails61_postgres_sidekiq.gemfile.lock
@@ -8,6 +8,13 @@ GIT
       simplecov-html (~> 0.11)
       simplecov_json_formatter (~> 0.1)
 
+GIT
+  remote: https://github.com/ruby/webrick.git
+  revision: 0c600e169bd4ae267cb5eeb6197277c848323bbe
+  ref: 0c600e169bd4ae267cb5eeb6197277c848323bbe
+  specs:
+    webrick (1.8.1)
+
 PATH
   remote: ..
   specs:
@@ -261,6 +268,8 @@ GEM
       rubocop (~> 1.33)
       rubocop-capybara (~> 2.17)
     ruby-progressbar (1.13.0)
+    ruby_memcheck (3.0.0)
+      nokogiri
     semantic_logger (4.15.0)
       concurrent-ruby (~> 1.0)
     sidekiq (7.2.4)
@@ -292,7 +301,6 @@ GEM
       addressable (>= 2.8.0)
       crack (>= 0.3.2)
       hashdiff (>= 0.4.0, < 2.0.0)
-    webrick (1.8.1)
     websocket-driver (0.7.6)
       websocket-extensions (>= 0.1.0)
     websocket-extensions (0.1.5)
@@ -337,13 +345,14 @@ DEPENDENCIES
   rubocop-packaging (~> 0.5.2)
   rubocop-performance (~> 1.9)
   rubocop-rspec (~> 2.20, < 2.21)
+  ruby_memcheck (>= 3)
   sidekiq (>= 6.1.2)
   simplecov!
   simplecov-cobertura (~> 2.1.0)
   sprockets (< 4)
   warning (~> 1)
   webmock (>= 3.10.0)
-  webrick (>= 1.7.0)
+  webrick!
   yard (~> 0.9)
 
 BUNDLED WITH

--- a/gemfiles/ruby_3.4_rails61_semantic_logger.gemfile
+++ b/gemfiles/ruby_3.4_rails61_semantic_logger.gemfile
@@ -26,7 +26,7 @@ gem "simplecov-cobertura", "~> 2.1.0"
 gem "warning", "~> 1"
 gem "webmock", ">= 3.10.0"
 gem "rexml", ">= 3.2.7"
-gem "webrick", ">= 1.7.0"
+gem "webrick", git: "https://github.com/ruby/webrick.git", ref: "0c600e169bd4ae267cb5eeb6197277c848323bbe"
 gem "yard", "~> 0.9"
 gem "rubocop", "~> 1.50.0", require: false
 gem "rubocop-packaging", "~> 0.5.2", require: false
@@ -42,7 +42,7 @@ gem "rails_semantic_logger", "~> 4.0"
 gem "net-smtp"
 
 group :check do
-
+  gem "ruby_memcheck", ">= 3"
 end
 
 group :dev do

--- a/gemfiles/ruby_3.4_rails61_semantic_logger.gemfile.lock
+++ b/gemfiles/ruby_3.4_rails61_semantic_logger.gemfile.lock
@@ -8,6 +8,13 @@ GIT
       simplecov-html (~> 0.11)
       simplecov_json_formatter (~> 0.1)
 
+GIT
+  remote: https://github.com/ruby/webrick.git
+  revision: 0c600e169bd4ae267cb5eeb6197277c848323bbe
+  ref: 0c600e169bd4ae267cb5eeb6197277c848323bbe
+  specs:
+    webrick (1.8.1)
+
 PATH
   remote: ..
   specs:
@@ -251,6 +258,8 @@ GEM
       rubocop (~> 1.33)
       rubocop-capybara (~> 2.17)
     ruby-progressbar (1.13.0)
+    ruby_memcheck (3.0.0)
+      nokogiri
     semantic_logger (4.15.0)
       concurrent-ruby (~> 1.0)
     simplecov-cobertura (2.1.0)
@@ -277,7 +286,6 @@ GEM
       addressable (>= 2.8.0)
       crack (>= 0.3.2)
       hashdiff (>= 0.4.0, < 2.0.0)
-    webrick (1.8.1)
     websocket-driver (0.7.6)
       websocket-extensions (>= 0.1.0)
     websocket-extensions (0.1.5)
@@ -321,12 +329,13 @@ DEPENDENCIES
   rubocop-packaging (~> 0.5.2)
   rubocop-performance (~> 1.9)
   rubocop-rspec (~> 2.20, < 2.21)
+  ruby_memcheck (>= 3)
   simplecov!
   simplecov-cobertura (~> 2.1.0)
   sprockets (< 4)
   warning (~> 1)
   webmock (>= 3.10.0)
-  webrick (>= 1.7.0)
+  webrick!
   yard (~> 0.9)
 
 BUNDLED WITH

--- a/gemfiles/ruby_3.4_rails61_trilogy.gemfile
+++ b/gemfiles/ruby_3.4_rails61_trilogy.gemfile
@@ -26,7 +26,7 @@ gem "simplecov-cobertura", "~> 2.1.0"
 gem "warning", "~> 1"
 gem "webmock", ">= 3.10.0"
 gem "rexml", ">= 3.2.7"
-gem "webrick", ">= 1.7.0"
+gem "webrick", git: "https://github.com/ruby/webrick.git", ref: "0c600e169bd4ae267cb5eeb6197277c848323bbe"
 gem "yard", "~> 0.9"
 gem "rubocop", "~> 1.50.0", require: false
 gem "rubocop-packaging", "~> 0.5.2", require: false
@@ -43,7 +43,7 @@ gem "lograge", "~> 0.11"
 gem "net-smtp"
 
 group :check do
-
+  gem "ruby_memcheck", ">= 3"
 end
 
 group :dev do

--- a/gemfiles/ruby_3.4_rails61_trilogy.gemfile.lock
+++ b/gemfiles/ruby_3.4_rails61_trilogy.gemfile.lock
@@ -8,6 +8,13 @@ GIT
       simplecov-html (~> 0.11)
       simplecov_json_formatter (~> 0.1)
 
+GIT
+  remote: https://github.com/ruby/webrick.git
+  revision: 0c600e169bd4ae267cb5eeb6197277c848323bbe
+  ref: 0c600e169bd4ae267cb5eeb6197277c848323bbe
+  specs:
+    webrick (1.8.1)
+
 PATH
   remote: ..
   specs:
@@ -256,6 +263,8 @@ GEM
       rubocop (~> 1.33)
       rubocop-capybara (~> 2.17)
     ruby-progressbar (1.13.0)
+    ruby_memcheck (3.0.0)
+      nokogiri
     simplecov-cobertura (2.1.0)
       rexml
       simplecov (~> 0.19)
@@ -281,7 +290,6 @@ GEM
       addressable (>= 2.8.0)
       crack (>= 0.3.2)
       hashdiff (>= 0.4.0, < 2.0.0)
-    webrick (1.8.1)
     websocket-driver (0.7.6)
       websocket-extensions (>= 0.1.0)
     websocket-extensions (0.1.5)
@@ -325,13 +333,14 @@ DEPENDENCIES
   rubocop-packaging (~> 0.5.2)
   rubocop-performance (~> 1.9)
   rubocop-rspec (~> 2.20, < 2.21)
+  ruby_memcheck (>= 3)
   simplecov!
   simplecov-cobertura (~> 2.1.0)
   sprockets (< 4)
   trilogy
   warning (~> 1)
   webmock (>= 3.10.0)
-  webrick (>= 1.7.0)
+  webrick!
   yard (~> 0.9)
 
 BUNDLED WITH

--- a/gemfiles/ruby_3.4_redis_3.gemfile
+++ b/gemfiles/ruby_3.4_redis_3.gemfile
@@ -26,7 +26,7 @@ gem "simplecov-cobertura", "~> 2.1.0"
 gem "warning", "~> 1"
 gem "webmock", ">= 3.10.0"
 gem "rexml", ">= 3.2.7"
-gem "webrick", ">= 1.7.0"
+gem "webrick", git: "https://github.com/ruby/webrick.git", ref: "0c600e169bd4ae267cb5eeb6197277c848323bbe"
 gem "yard", "~> 0.9"
 gem "rubocop", "~> 1.50.0", require: false
 gem "rubocop-packaging", "~> 0.5.2", require: false
@@ -38,7 +38,7 @@ gem "ffi", "~> 1.16.3", require: false
 gem "redis", "~> 3"
 
 group :check do
-
+  gem "ruby_memcheck", ">= 3"
 end
 
 group :dev do

--- a/gemfiles/ruby_3.4_redis_3.gemfile.lock
+++ b/gemfiles/ruby_3.4_redis_3.gemfile.lock
@@ -8,6 +8,13 @@ GIT
       simplecov-html (~> 0.11)
       simplecov_json_formatter (~> 0.1)
 
+GIT
+  remote: https://github.com/ruby/webrick.git
+  revision: 0c600e169bd4ae267cb5eeb6197277c848323bbe
+  ref: 0c600e169bd4ae267cb5eeb6197277c848323bbe
+  specs:
+    webrick (1.8.1)
+
 PATH
   remote: ..
   specs:
@@ -60,7 +67,11 @@ GEM
       ffi (~> 1.0)
     memory_profiler (0.9.14)
     method_source (1.1.0)
+    mini_portile2 (2.8.7)
     msgpack (1.7.2)
+    nokogiri (1.16.7)
+      mini_portile2 (~> 2.8.2)
+      racc (~> 1.4)
     os (1.1.4)
     parallel (1.25.1)
     parser (3.3.3.0)
@@ -125,6 +136,8 @@ GEM
       rubocop (~> 1.33)
       rubocop-capybara (~> 2.17)
     ruby-progressbar (1.13.0)
+    ruby_memcheck (3.0.0)
+      nokogiri
     simplecov-cobertura (2.1.0)
       rexml
       simplecov (~> 0.19)
@@ -138,7 +151,6 @@ GEM
       addressable (>= 2.8.0)
       crack (>= 0.3.2)
       hashdiff (>= 0.4.0, < 2.0.0)
-    webrick (1.8.1)
     yard (0.9.36)
 
 PLATFORMS
@@ -175,11 +187,12 @@ DEPENDENCIES
   rubocop-packaging (~> 0.5.2)
   rubocop-performance (~> 1.9)
   rubocop-rspec (~> 2.20, < 2.21)
+  ruby_memcheck (>= 3)
   simplecov!
   simplecov-cobertura (~> 2.1.0)
   warning (~> 1)
   webmock (>= 3.10.0)
-  webrick (>= 1.7.0)
+  webrick!
   yard (~> 0.9)
 
 BUNDLED WITH

--- a/gemfiles/ruby_3.4_redis_4.gemfile
+++ b/gemfiles/ruby_3.4_redis_4.gemfile
@@ -26,7 +26,7 @@ gem "simplecov-cobertura", "~> 2.1.0"
 gem "warning", "~> 1"
 gem "webmock", ">= 3.10.0"
 gem "rexml", ">= 3.2.7"
-gem "webrick", ">= 1.7.0"
+gem "webrick", git: "https://github.com/ruby/webrick.git", ref: "0c600e169bd4ae267cb5eeb6197277c848323bbe"
 gem "yard", "~> 0.9"
 gem "rubocop", "~> 1.50.0", require: false
 gem "rubocop-packaging", "~> 0.5.2", require: false
@@ -38,7 +38,7 @@ gem "ffi", "~> 1.16.3", require: false
 gem "redis", "~> 4"
 
 group :check do
-
+  gem "ruby_memcheck", ">= 3"
 end
 
 group :dev do

--- a/gemfiles/ruby_3.4_redis_4.gemfile.lock
+++ b/gemfiles/ruby_3.4_redis_4.gemfile.lock
@@ -8,6 +8,13 @@ GIT
       simplecov-html (~> 0.11)
       simplecov_json_formatter (~> 0.1)
 
+GIT
+  remote: https://github.com/ruby/webrick.git
+  revision: 0c600e169bd4ae267cb5eeb6197277c848323bbe
+  ref: 0c600e169bd4ae267cb5eeb6197277c848323bbe
+  specs:
+    webrick (1.8.1)
+
 PATH
   remote: ..
   specs:
@@ -60,7 +67,11 @@ GEM
       ffi (~> 1.0)
     memory_profiler (0.9.14)
     method_source (1.1.0)
+    mini_portile2 (2.8.7)
     msgpack (1.7.2)
+    nokogiri (1.16.7)
+      mini_portile2 (~> 2.8.2)
+      racc (~> 1.4)
     os (1.1.4)
     parallel (1.25.1)
     parser (3.3.3.0)
@@ -125,6 +136,8 @@ GEM
       rubocop (~> 1.33)
       rubocop-capybara (~> 2.17)
     ruby-progressbar (1.13.0)
+    ruby_memcheck (3.0.0)
+      nokogiri
     simplecov-cobertura (2.1.0)
       rexml
       simplecov (~> 0.19)
@@ -138,7 +151,6 @@ GEM
       addressable (>= 2.8.0)
       crack (>= 0.3.2)
       hashdiff (>= 0.4.0, < 2.0.0)
-    webrick (1.8.1)
     yard (0.9.36)
 
 PLATFORMS
@@ -175,11 +187,12 @@ DEPENDENCIES
   rubocop-packaging (~> 0.5.2)
   rubocop-performance (~> 1.9)
   rubocop-rspec (~> 2.20, < 2.21)
+  ruby_memcheck (>= 3)
   simplecov!
   simplecov-cobertura (~> 2.1.0)
   warning (~> 1)
   webmock (>= 3.10.0)
-  webrick (>= 1.7.0)
+  webrick!
   yard (~> 0.9)
 
 BUNDLED WITH

--- a/gemfiles/ruby_3.4_redis_5.gemfile
+++ b/gemfiles/ruby_3.4_redis_5.gemfile
@@ -26,7 +26,7 @@ gem "simplecov-cobertura", "~> 2.1.0"
 gem "warning", "~> 1"
 gem "webmock", ">= 3.10.0"
 gem "rexml", ">= 3.2.7"
-gem "webrick", ">= 1.7.0"
+gem "webrick", git: "https://github.com/ruby/webrick.git", ref: "0c600e169bd4ae267cb5eeb6197277c848323bbe"
 gem "yard", "~> 0.9"
 gem "rubocop", "~> 1.50.0", require: false
 gem "rubocop-packaging", "~> 0.5.2", require: false
@@ -38,7 +38,7 @@ gem "ffi", "~> 1.16.3", require: false
 gem "redis", "~> 5"
 
 group :check do
-
+  gem "ruby_memcheck", ">= 3"
 end
 
 group :dev do

--- a/gemfiles/ruby_3.4_redis_5.gemfile.lock
+++ b/gemfiles/ruby_3.4_redis_5.gemfile.lock
@@ -8,6 +8,13 @@ GIT
       simplecov-html (~> 0.11)
       simplecov_json_formatter (~> 0.1)
 
+GIT
+  remote: https://github.com/ruby/webrick.git
+  revision: 0c600e169bd4ae267cb5eeb6197277c848323bbe
+  ref: 0c600e169bd4ae267cb5eeb6197277c848323bbe
+  specs:
+    webrick (1.8.1)
+
 PATH
   remote: ..
   specs:
@@ -61,7 +68,11 @@ GEM
       ffi (~> 1.0)
     memory_profiler (0.9.14)
     method_source (1.1.0)
+    mini_portile2 (2.8.7)
     msgpack (1.7.2)
+    nokogiri (1.16.7)
+      mini_portile2 (~> 2.8.2)
+      racc (~> 1.4)
     os (1.1.4)
     parallel (1.25.1)
     parser (3.3.3.0)
@@ -129,6 +140,8 @@ GEM
       rubocop (~> 1.33)
       rubocop-capybara (~> 2.17)
     ruby-progressbar (1.13.0)
+    ruby_memcheck (3.0.0)
+      nokogiri
     simplecov-cobertura (2.1.0)
       rexml
       simplecov (~> 0.19)
@@ -142,7 +155,6 @@ GEM
       addressable (>= 2.8.0)
       crack (>= 0.3.2)
       hashdiff (>= 0.4.0, < 2.0.0)
-    webrick (1.8.1)
     yard (0.9.36)
 
 PLATFORMS
@@ -179,11 +191,12 @@ DEPENDENCIES
   rubocop-packaging (~> 0.5.2)
   rubocop-performance (~> 1.9)
   rubocop-rspec (~> 2.20, < 2.21)
+  ruby_memcheck (>= 3)
   simplecov!
   simplecov-cobertura (~> 2.1.0)
   warning (~> 1)
   webmock (>= 3.10.0)
-  webrick (>= 1.7.0)
+  webrick!
   yard (~> 0.9)
 
 BUNDLED WITH

--- a/gemfiles/ruby_3.4_relational_db.gemfile
+++ b/gemfiles/ruby_3.4_relational_db.gemfile
@@ -26,7 +26,7 @@ gem "simplecov-cobertura", "~> 2.1.0"
 gem "warning", "~> 1"
 gem "webmock", ">= 3.10.0"
 gem "rexml", ">= 3.2.7"
-gem "webrick", ">= 1.7.0"
+gem "webrick", git: "https://github.com/ruby/webrick.git", ref: "0c600e169bd4ae267cb5eeb6197277c848323bbe"
 gem "yard", "~> 0.9"
 gem "rubocop", "~> 1.50.0", require: false
 gem "rubocop-packaging", "~> 0.5.2", require: false
@@ -46,7 +46,7 @@ gem "sequel", "~> 5.54.0"
 gem "trilogy"
 
 group :check do
-
+  gem "ruby_memcheck", ">= 3"
 end
 
 group :dev do

--- a/gemfiles/ruby_3.4_relational_db.gemfile.lock
+++ b/gemfiles/ruby_3.4_relational_db.gemfile.lock
@@ -8,6 +8,13 @@ GIT
       simplecov-html (~> 0.11)
       simplecov_json_formatter (~> 0.1)
 
+GIT
+  remote: https://github.com/ruby/webrick.git
+  revision: 0c600e169bd4ae267cb5eeb6197277c848323bbe
+  ref: 0c600e169bd4ae267cb5eeb6197277c848323bbe
+  specs:
+    webrick (1.8.1)
+
 PATH
   remote: ..
   specs:
@@ -93,6 +100,9 @@ GEM
     msgpack (1.7.2)
     mutex_m (0.2.0)
     mysql2 (0.5.6)
+    nokogiri (1.16.7)
+      mini_portile2 (~> 2.8.2)
+      racc (~> 1.4)
     os (1.1.4)
     parallel (1.25.1)
     parser (3.3.3.0)
@@ -157,6 +167,8 @@ GEM
       rubocop (~> 1.33)
       rubocop-capybara (~> 2.17)
     ruby-progressbar (1.13.0)
+    ruby_memcheck (3.0.0)
+      nokogiri
     sequel (5.54.0)
     simplecov-cobertura (2.1.0)
       rexml
@@ -177,7 +189,6 @@ GEM
       addressable (>= 2.8.0)
       crack (>= 0.3.2)
       hashdiff (>= 0.4.0, < 2.0.0)
-    webrick (1.8.1)
     yard (0.9.36)
 
 PLATFORMS
@@ -219,6 +230,7 @@ DEPENDENCIES
   rubocop-packaging (~> 0.5.2)
   rubocop-performance (~> 1.9)
   rubocop-rspec (~> 2.20, < 2.21)
+  ruby_memcheck (>= 3)
   sequel (~> 5.54.0)
   simplecov!
   simplecov-cobertura (~> 2.1.0)
@@ -226,7 +238,7 @@ DEPENDENCIES
   trilogy
   warning (~> 1)
   webmock (>= 3.10.0)
-  webrick (>= 1.7.0)
+  webrick!
   yard (~> 0.9)
 
 BUNDLED WITH

--- a/gemfiles/ruby_3.4_resque2_redis3.gemfile
+++ b/gemfiles/ruby_3.4_resque2_redis3.gemfile
@@ -26,7 +26,7 @@ gem "simplecov-cobertura", "~> 2.1.0"
 gem "warning", "~> 1"
 gem "webmock", ">= 3.10.0"
 gem "rexml", ">= 3.2.7"
-gem "webrick", ">= 1.7.0"
+gem "webrick", git: "https://github.com/ruby/webrick.git", ref: "0c600e169bd4ae267cb5eeb6197277c848323bbe"
 gem "yard", "~> 0.9"
 gem "rubocop", "~> 1.50.0", require: false
 gem "rubocop-packaging", "~> 0.5.2", require: false
@@ -39,7 +39,7 @@ gem "redis", "< 4.0"
 gem "resque", ">= 2.0"
 
 group :check do
-
+  gem "ruby_memcheck", ">= 3"
 end
 
 group :dev do

--- a/gemfiles/ruby_3.4_resque2_redis3.gemfile.lock
+++ b/gemfiles/ruby_3.4_resque2_redis3.gemfile.lock
@@ -8,6 +8,13 @@ GIT
       simplecov-html (~> 0.11)
       simplecov_json_formatter (~> 0.1)
 
+GIT
+  remote: https://github.com/ruby/webrick.git
+  revision: 0c600e169bd4ae267cb5eeb6197277c848323bbe
+  ref: 0c600e169bd4ae267cb5eeb6197277c848323bbe
+  specs:
+    webrick (1.8.1)
+
 PATH
   remote: ..
   specs:
@@ -61,11 +68,15 @@ GEM
       ffi (~> 1.0)
     memory_profiler (0.9.14)
     method_source (1.1.0)
+    mini_portile2 (2.8.7)
     mono_logger (1.1.2)
     msgpack (1.7.2)
     multi_json (1.15.0)
     mustermann (3.0.0)
       ruby2_keywords (~> 0.0.1)
+    nokogiri (1.16.7)
+      mini_portile2 (~> 2.8.2)
+      racc (~> 1.4)
     os (1.1.4)
     parallel (1.25.1)
     parser (3.3.3.0)
@@ -144,6 +155,8 @@ GEM
       rubocop-capybara (~> 2.17)
     ruby-progressbar (1.13.0)
     ruby2_keywords (0.0.5)
+    ruby_memcheck (3.0.0)
+      nokogiri
     simplecov-cobertura (2.1.0)
       rexml
       simplecov (~> 0.19)
@@ -164,7 +177,6 @@ GEM
       addressable (>= 2.8.0)
       crack (>= 0.3.2)
       hashdiff (>= 0.4.0, < 2.0.0)
-    webrick (1.8.1)
     yard (0.9.36)
 
 PLATFORMS
@@ -202,11 +214,12 @@ DEPENDENCIES
   rubocop-packaging (~> 0.5.2)
   rubocop-performance (~> 1.9)
   rubocop-rspec (~> 2.20, < 2.21)
+  ruby_memcheck (>= 3)
   simplecov!
   simplecov-cobertura (~> 2.1.0)
   warning (~> 1)
   webmock (>= 3.10.0)
-  webrick (>= 1.7.0)
+  webrick!
   yard (~> 0.9)
 
 BUNDLED WITH

--- a/gemfiles/ruby_3.4_resque2_redis4.gemfile
+++ b/gemfiles/ruby_3.4_resque2_redis4.gemfile
@@ -26,7 +26,7 @@ gem "simplecov-cobertura", "~> 2.1.0"
 gem "warning", "~> 1"
 gem "webmock", ">= 3.10.0"
 gem "rexml", ">= 3.2.7"
-gem "webrick", ">= 1.7.0"
+gem "webrick", git: "https://github.com/ruby/webrick.git", ref: "0c600e169bd4ae267cb5eeb6197277c848323bbe"
 gem "yard", "~> 0.9"
 gem "rubocop", "~> 1.50.0", require: false
 gem "rubocop-packaging", "~> 0.5.2", require: false
@@ -39,7 +39,7 @@ gem "redis", ">= 4.0"
 gem "resque", ">= 2.0"
 
 group :check do
-
+  gem "ruby_memcheck", ">= 3"
 end
 
 group :dev do

--- a/gemfiles/ruby_3.4_resque2_redis4.gemfile.lock
+++ b/gemfiles/ruby_3.4_resque2_redis4.gemfile.lock
@@ -8,6 +8,13 @@ GIT
       simplecov-html (~> 0.11)
       simplecov_json_formatter (~> 0.1)
 
+GIT
+  remote: https://github.com/ruby/webrick.git
+  revision: 0c600e169bd4ae267cb5eeb6197277c848323bbe
+  ref: 0c600e169bd4ae267cb5eeb6197277c848323bbe
+  specs:
+    webrick (1.8.1)
+
 PATH
   remote: ..
   specs:
@@ -62,11 +69,15 @@ GEM
       ffi (~> 1.0)
     memory_profiler (0.9.14)
     method_source (1.1.0)
+    mini_portile2 (2.8.7)
     mono_logger (1.1.2)
     msgpack (1.7.2)
     multi_json (1.15.0)
     mustermann (3.0.0)
       ruby2_keywords (~> 0.0.1)
+    nokogiri (1.16.7)
+      mini_portile2 (~> 2.8.2)
+      racc (~> 1.4)
     os (1.1.4)
     parallel (1.25.1)
     parser (3.3.3.0)
@@ -148,6 +159,8 @@ GEM
       rubocop-capybara (~> 2.17)
     ruby-progressbar (1.13.0)
     ruby2_keywords (0.0.5)
+    ruby_memcheck (3.0.0)
+      nokogiri
     simplecov-cobertura (2.1.0)
       rexml
       simplecov (~> 0.19)
@@ -168,7 +181,6 @@ GEM
       addressable (>= 2.8.0)
       crack (>= 0.3.2)
       hashdiff (>= 0.4.0, < 2.0.0)
-    webrick (1.8.1)
     yard (0.9.36)
 
 PLATFORMS
@@ -206,11 +218,12 @@ DEPENDENCIES
   rubocop-packaging (~> 0.5.2)
   rubocop-performance (~> 1.9)
   rubocop-rspec (~> 2.20, < 2.21)
+  ruby_memcheck (>= 3)
   simplecov!
   simplecov-cobertura (~> 2.1.0)
   warning (~> 1)
   webmock (>= 3.10.0)
-  webrick (>= 1.7.0)
+  webrick!
   yard (~> 0.9)
 
 BUNDLED WITH

--- a/gemfiles/ruby_3.4_sinatra_2.gemfile
+++ b/gemfiles/ruby_3.4_sinatra_2.gemfile
@@ -26,7 +26,7 @@ gem "simplecov-cobertura", "~> 2.1.0"
 gem "warning", "~> 1"
 gem "webmock", ">= 3.10.0"
 gem "rexml", ">= 3.2.7"
-gem "webrick", ">= 1.7.0"
+gem "webrick", git: "https://github.com/ruby/webrick.git", ref: "0c600e169bd4ae267cb5eeb6197277c848323bbe"
 gem "yard", "~> 0.9"
 gem "rubocop", "~> 1.50.0", require: false
 gem "rubocop-packaging", "~> 0.5.2", require: false
@@ -40,7 +40,7 @@ gem "rack-contrib"
 gem "rack-test"
 
 group :check do
-
+  gem "ruby_memcheck", ">= 3"
 end
 
 group :dev do

--- a/gemfiles/ruby_3.4_sinatra_2.gemfile.lock
+++ b/gemfiles/ruby_3.4_sinatra_2.gemfile.lock
@@ -8,6 +8,13 @@ GIT
       simplecov-html (~> 0.11)
       simplecov_json_formatter (~> 0.1)
 
+GIT
+  remote: https://github.com/ruby/webrick.git
+  revision: 0c600e169bd4ae267cb5eeb6197277c848323bbe
+  ref: 0c600e169bd4ae267cb5eeb6197277c848323bbe
+  specs:
+    webrick (1.8.1)
+
 PATH
   remote: ..
   specs:
@@ -60,9 +67,13 @@ GEM
       ffi (~> 1.0)
     memory_profiler (0.9.14)
     method_source (1.1.0)
+    mini_portile2 (2.8.7)
     msgpack (1.7.2)
     mustermann (2.0.2)
       ruby2_keywords (~> 0.0.1)
+    nokogiri (1.16.7)
+      mini_portile2 (~> 2.8.2)
+      racc (~> 1.4)
     os (1.1.4)
     parallel (1.25.1)
     parser (3.3.3.0)
@@ -134,6 +145,8 @@ GEM
       rubocop-capybara (~> 2.17)
     ruby-progressbar (1.13.0)
     ruby2_keywords (0.0.5)
+    ruby_memcheck (3.0.0)
+      nokogiri
     simplecov-cobertura (2.1.0)
       rexml
       simplecov (~> 0.19)
@@ -153,7 +166,6 @@ GEM
       addressable (>= 2.8.0)
       crack (>= 0.3.2)
       hashdiff (>= 0.4.0, < 2.0.0)
-    webrick (1.8.1)
     yard (0.9.36)
 
 PLATFORMS
@@ -191,12 +203,13 @@ DEPENDENCIES
   rubocop-packaging (~> 0.5.2)
   rubocop-performance (~> 1.9)
   rubocop-rspec (~> 2.20, < 2.21)
+  ruby_memcheck (>= 3)
   simplecov!
   simplecov-cobertura (~> 2.1.0)
   sinatra (~> 2)
   warning (~> 1)
   webmock (>= 3.10.0)
-  webrick (>= 1.7.0)
+  webrick!
   yard (~> 0.9)
 
 BUNDLED WITH

--- a/gemfiles/ruby_3.4_sinatra_3.gemfile
+++ b/gemfiles/ruby_3.4_sinatra_3.gemfile
@@ -26,7 +26,7 @@ gem "simplecov-cobertura", "~> 2.1.0"
 gem "warning", "~> 1"
 gem "webmock", ">= 3.10.0"
 gem "rexml", ">= 3.2.7"
-gem "webrick", ">= 1.7.0"
+gem "webrick", git: "https://github.com/ruby/webrick.git", ref: "0c600e169bd4ae267cb5eeb6197277c848323bbe"
 gem "yard", "~> 0.9"
 gem "rubocop", "~> 1.50.0", require: false
 gem "rubocop-packaging", "~> 0.5.2", require: false
@@ -40,7 +40,7 @@ gem "rack-contrib"
 gem "rack-test"
 
 group :check do
-
+  gem "ruby_memcheck", ">= 3"
 end
 
 group :dev do

--- a/gemfiles/ruby_3.4_sinatra_3.gemfile.lock
+++ b/gemfiles/ruby_3.4_sinatra_3.gemfile.lock
@@ -8,6 +8,13 @@ GIT
       simplecov-html (~> 0.11)
       simplecov_json_formatter (~> 0.1)
 
+GIT
+  remote: https://github.com/ruby/webrick.git
+  revision: 0c600e169bd4ae267cb5eeb6197277c848323bbe
+  ref: 0c600e169bd4ae267cb5eeb6197277c848323bbe
+  specs:
+    webrick (1.8.1)
+
 PATH
   remote: ..
   specs:
@@ -61,9 +68,13 @@ GEM
       ffi (~> 1.0)
     memory_profiler (0.9.14)
     method_source (1.1.0)
+    mini_portile2 (2.8.7)
     msgpack (1.7.2)
     mustermann (3.0.0)
       ruby2_keywords (~> 0.0.1)
+    nokogiri (1.16.7)
+      mini_portile2 (~> 2.8.2)
+      racc (~> 1.4)
     os (1.1.4)
     parallel (1.25.1)
     parser (3.3.3.0)
@@ -136,6 +147,8 @@ GEM
       rubocop-capybara (~> 2.17)
     ruby-progressbar (1.13.0)
     ruby2_keywords (0.0.5)
+    ruby_memcheck (3.0.0)
+      nokogiri
     simplecov-cobertura (2.1.0)
       rexml
       simplecov (~> 0.19)
@@ -155,7 +168,6 @@ GEM
       addressable (>= 2.8.0)
       crack (>= 0.3.2)
       hashdiff (>= 0.4.0, < 2.0.0)
-    webrick (1.8.1)
     yard (0.9.36)
 
 PLATFORMS
@@ -193,12 +205,13 @@ DEPENDENCIES
   rubocop-packaging (~> 0.5.2)
   rubocop-performance (~> 1.9)
   rubocop-rspec (~> 2.20, < 2.21)
+  ruby_memcheck (>= 3)
   simplecov!
   simplecov-cobertura (~> 2.1.0)
   sinatra (~> 3)
   warning (~> 1)
   webmock (>= 3.10.0)
-  webrick (>= 1.7.0)
+  webrick!
   yard (~> 0.9)
 
 BUNDLED WITH

--- a/gemfiles/ruby_3.4_sinatra_4.gemfile
+++ b/gemfiles/ruby_3.4_sinatra_4.gemfile
@@ -26,7 +26,7 @@ gem "simplecov-cobertura", "~> 2.1.0"
 gem "warning", "~> 1"
 gem "webmock", ">= 3.10.0"
 gem "rexml", ">= 3.2.7"
-gem "webrick", ">= 1.7.0"
+gem "webrick", git: "https://github.com/ruby/webrick.git", ref: "0c600e169bd4ae267cb5eeb6197277c848323bbe"
 gem "yard", "~> 0.9"
 gem "rubocop", "~> 1.50.0", require: false
 gem "rubocop-packaging", "~> 0.5.2", require: false
@@ -40,7 +40,7 @@ gem "rack-contrib"
 gem "rack-test"
 
 group :check do
-
+  gem "ruby_memcheck", ">= 3"
 end
 
 group :dev do

--- a/gemfiles/ruby_3.4_sinatra_4.gemfile.lock
+++ b/gemfiles/ruby_3.4_sinatra_4.gemfile.lock
@@ -8,6 +8,13 @@ GIT
       simplecov-html (~> 0.11)
       simplecov_json_formatter (~> 0.1)
 
+GIT
+  remote: https://github.com/ruby/webrick.git
+  revision: 0c600e169bd4ae267cb5eeb6197277c848323bbe
+  ref: 0c600e169bd4ae267cb5eeb6197277c848323bbe
+  specs:
+    webrick (1.8.1)
+
 PATH
   remote: ..
   specs:
@@ -61,9 +68,13 @@ GEM
       ffi (~> 1.0)
     memory_profiler (0.9.14)
     method_source (1.1.0)
+    mini_portile2 (2.8.7)
     msgpack (1.7.2)
     mustermann (3.0.0)
       ruby2_keywords (~> 0.0.1)
+    nokogiri (1.16.7)
+      mini_portile2 (~> 2.8.2)
+      racc (~> 1.4)
     os (1.1.4)
     parallel (1.25.1)
     parser (3.3.3.0)
@@ -138,6 +149,8 @@ GEM
       rubocop-capybara (~> 2.17)
     ruby-progressbar (1.13.0)
     ruby2_keywords (0.0.5)
+    ruby_memcheck (3.0.0)
+      nokogiri
     simplecov-cobertura (2.1.0)
       rexml
       simplecov (~> 0.19)
@@ -158,7 +171,6 @@ GEM
       addressable (>= 2.8.0)
       crack (>= 0.3.2)
       hashdiff (>= 0.4.0, < 2.0.0)
-    webrick (1.8.1)
     yard (0.9.36)
 
 PLATFORMS
@@ -196,12 +208,13 @@ DEPENDENCIES
   rubocop-packaging (~> 0.5.2)
   rubocop-performance (~> 1.9)
   rubocop-rspec (~> 2.20, < 2.21)
+  ruby_memcheck (>= 3)
   simplecov!
   simplecov-cobertura (~> 2.1.0)
   sinatra (~> 4)
   warning (~> 1)
   webmock (>= 3.10.0)
-  webrick (>= 1.7.0)
+  webrick!
   yard (~> 0.9)
 
 BUNDLED WITH

--- a/lib/datadog/core/telemetry/event.rb
+++ b/lib/datadog/core/telemetry/event.rb
@@ -356,10 +356,8 @@ module Datadog
             {
               logs: [
                 {
-                  # Required fields
                   message: @message,
                   level: @level,
-                  # More optional fields to be added here...
                   stack_trace: @stack_trace,
                 }.compact
               ]

--- a/lib/datadog/core/telemetry/event.rb
+++ b/lib/datadog/core/telemetry/event.rb
@@ -346,19 +346,23 @@ module Datadog
             'logs'
           end
 
-          def initialize(message:, level:)
+          def initialize(message:, level:, stack_trace: nil)
             super()
             @message = message
+            @stack_trace = stack_trace
             @level = LEVELS.fetch(level) { |k| raise ArgumentError, "Invalid log level :#{k}" }
           end
 
           def payload
             {
-              logs: [{
-                message: @message,
-                level: @level,
-                # More optional fields to be added here...
-              }]
+              logs: [
+                {
+                  message: @message,
+                  level: @level,
+                  # More optional fields to be added here...
+                  stack_trace: @stack_trace,
+                }.compact
+              ]
             }
           end
         end

--- a/lib/datadog/core/telemetry/event.rb
+++ b/lib/datadog/core/telemetry/event.rb
@@ -338,7 +338,6 @@ module Datadog
         class Log < Base
           LEVELS = {
             error: 'ERROR',
-            debug: 'DEBUG',
             warn: 'WARN',
           }.freeze
 
@@ -357,6 +356,7 @@ module Datadog
             {
               logs: [
                 {
+                  # Required fields
                   message: @message,
                   level: @level,
                   # More optional fields to be added here...

--- a/lib/datadog/core/telemetry/logging.rb
+++ b/lib/datadog/core/telemetry/logging.rb
@@ -5,10 +5,19 @@ require_relative 'event'
 module Datadog
   module Core
     module Telemetry
-      # Logging interface for sending telemetry logs.
+      # === INTRENAL USAGE ONLY ===
       #
-      # Reporting internal error so that we can fix them.
-      # IMPORTANT: Make sure to not log any sensitive information.
+      # Logging interface for sending telemetry logs... so we can fix them.
+      #
+      # For developer using this module:
+      # - MUST NOT provide any sensitive information (PII)
+      # - SHOULD reduce the data cardinality for batching/aggregation
+      #
+      # Before using it, ask yourself:
+      # - Do we need to know about this (ie. internal error or client error)?
+      # - How severe/critical is this error? (ie. error, warning, fatal)
+      # - What information needed to make it actionable?
+      #
       module Logging
         extend self
 

--- a/sig/datadog/core/telemetry/event.rbs
+++ b/sig/datadog/core/telemetry/event.rbs
@@ -72,10 +72,11 @@ module Datadog
 
           @message: String
           @level: "ERROR" | "DEBUG" | "WARN"
+          @stack_trace: String?
 
-          def initialize: (message: String, level: Symbol) -> void
+          def initialize: (message: String, level: Symbol, ?stack_trace: String?) -> void
 
-          def payload: () -> { logs: [{ message: String, level: String }] }
+          def payload: () -> { logs: [Hash[Symbol, String]] }
         end
 
         class Distributions < GenerateMetrics

--- a/sig/datadog/core/telemetry/logging.rbs
+++ b/sig/datadog/core/telemetry/logging.rbs
@@ -2,6 +2,11 @@ module Datadog
   module Core
     module Telemetry
       module Logging
+        module DatadogStackTrace
+          REGEX: Regexp
+          def self.from: (Exception exception) -> String?
+        end
+
         extend Datadog::Core::Telemetry::Logging
 
         def report: (Exception exception, level: Symbol, ?description: String?) -> void

--- a/sig/datadog/core/telemetry/logging.rbs
+++ b/sig/datadog/core/telemetry/logging.rbs
@@ -3,7 +3,8 @@ module Datadog
     module Telemetry
       module Logging
         module DatadogStackTrace
-          REGEX: Regexp
+          GEM_ROOT: String
+
           def self.from: (Exception exception) -> String?
         end
 

--- a/spec/datadog/core/telemetry/event_spec.rb
+++ b/spec/datadog/core/telemetry/event_spec.rb
@@ -228,19 +228,6 @@ RSpec.describe Datadog::Core::Telemetry::Event do
     end
 
     it do
-      event = Datadog::Core::Telemetry::Event::Log.new(message: 'Hi', level: :debug)
-      expect(event.type).to eq('logs')
-      expect(event.payload).to eq(
-        {
-          logs: [{
-            message: 'Hi',
-            level: 'DEBUG'
-          }]
-        }
-      )
-    end
-
-    it do
       event = Datadog::Core::Telemetry::Event::Log.new(message: 'Hi', level: :warn)
       expect(event.type).to eq('logs')
       expect(event.payload).to eq(

--- a/spec/datadog/core/telemetry/logging_spec.rb
+++ b/spec/datadog/core/telemetry/logging_spec.rb
@@ -130,10 +130,12 @@ RSpec.describe Datadog::Core::Telemetry::Logging::DatadogStackTrace do
     end
 
     it 'returns redacted stack trace' do
+      gem_root = Datadog::Core::Telemetry::Logging::DatadogStackTrace::GEM_ROOT
+
       exception = StandardError.new('Yo!')
       exception.set_backtrace(
         [
-          '/usr/local/bundle/gems/datadog-2.3.0.beta1/lib/datadog/core/telemetry/logging.rb:1 in `report`',
+          "#{gem_root}/lib/datadog/core/telemetry/logging.rb:1 in `report`",
           '/foo/bar/baz.rb:1 in `baz`',
           '/foo/bar.rb:1 in `bar`',
           '/foo.rb:1 in `foo`',

--- a/spec/datadog/core/telemetry/logging_spec.rb
+++ b/spec/datadog/core/telemetry/logging_spec.rb
@@ -144,7 +144,7 @@ RSpec.describe Datadog::Core::Telemetry::Logging::DatadogStackTrace do
 
       expect(result).to eq(
         [
-          'datadog-2.3.0.beta1/lib/datadog/core/telemetry/logging.rb:1 in `report`',
+          '/lib/datadog/core/telemetry/logging.rb:1 in `report`',
           'REDACTED',
           'REDACTED',
           'REDACTED'

--- a/spec/datadog/core/telemetry/logging_spec.rb
+++ b/spec/datadog/core/telemetry/logging_spec.rb
@@ -130,28 +130,14 @@ RSpec.describe Datadog::Core::Telemetry::Logging::DatadogStackTrace do
     end
 
     it 'returns redacted stack trace' do
-      gem_root = Datadog::Core::Telemetry::Logging::DatadogStackTrace::GEM_ROOT
+      begin
+        raise 'Invalid token: p@ssw0rd'
+      rescue StandardError => e
+        result = described_class.from(e)
+      end
 
-      exception = StandardError.new('Yo!')
-      exception.set_backtrace(
-        [
-          "#{gem_root}/lib/datadog/core/telemetry/logging.rb:1 in `report`",
-          '/foo/bar/baz.rb:1 in `baz`',
-          '/foo/bar.rb:1 in `bar`',
-          '/foo.rb:1 in `foo`',
-        ]
-      )
-
-      result = described_class.from(exception)
-
-      expect(result).to eq(
-        [
-          '/lib/datadog/core/telemetry/logging.rb:1 in `report`',
-          'REDACTED',
-          'REDACTED',
-          'REDACTED'
-        ].join(',')
-      )
+      expect(result).to start_with('/spec/datadog/core/telemetry/logging_spec.rb')
+      expect(result).to end_with('REDACTED')
     end
   end
 end


### PR DESCRIPTION
**What does this PR do?**

Providing a class name of the exception is not very useful. Sending stack_trace help us identified the location is helpful

1. Add `stack_trace` field with reporting an exception
2. Obfuscate backtrace
3. Remove redundant `debug` level (The enriched data for debugging can be a risk and high data cardinality)