### PR TITLE
[NO-TICKET] Add more memory leak testing for profiling using asan

### DIFF
--- a/.github/workflows/test-memory-leaks.yaml
+++ b/.github/workflows/test-memory-leaks.yaml
@@ -13,3 +13,21 @@ jobs:
           cache-version: v1 # bump this to invalidate cache
       - run: sudo apt install -y valgrind && valgrind --version
       - run: bundle exec rake compile spec:profiling:memcheck
+  test-asan:
+    runs-on: ubuntu-24.04
+    steps:
+      - uses: actions/checkout@v4
+      # We're using a fork of ruby/setup-ruby because the "asan" tool is built into the clang compiler toolchain, and
+      # needs Ruby to be built with a special configuration.
+      #
+      # The special configuration is not yet available in the upstream `ruby/setup-ruby` github action, so I needed to
+      # fork it and push a small tweak to make it available.
+      #
+      # (The Ruby builds were added in https://github.com/ruby/ruby-dev-builder/pull/10 ).
+      - uses: datadog/setup-ruby@0c7206d6db81faf999795ceebfac00d164298bd5
+        with:
+          ruby-version: asan
+          bundler-cache: true # runs 'bundle install' and caches installed gems automatically
+          bundler: latest
+          cache-version: v1 # bump this to invalidate cache
+      - run: env RUBY_FREE_AT_EXIT=1 LSAN_OPTIONS=verbosity=0:log_threads=1:suppressions=`pwd`/suppressions/lsan.supp ASAN_OPTIONS=detect_leaks=1 bundle exec rake spec:profiling:main

--- a/suppressions/lsan.supp
+++ b/suppressions/lsan.supp
@@ -1,0 +1,9 @@
+# This is a Leak Sanitizer ("lsan") suppression configuration file.
+#
+# We use it together with special builds for Ruby
+# (https://github.com/ruby/ruby/blob/master/doc/contributing/building_ruby.md#building-with-address-sanitizer)
+# to find issues and memory leaks in the dd-trace-rb native extensions; in some cases
+# we need to ignore potential issues as they're not something we can fix (e.g. outside our code.)
+#
+# See https://github.com/google/sanitizers/wiki/AddressSanitizerLeakSanitizer for details.
+leak:native_thread_create


### PR DESCRIPTION
**What does this PR do?**

This PR builds atop the work from #3852 and #3862 to enable running the profiler test suite using the AddressSanitizer ("asan") tool (see https://github.com/google/sanitizers/wiki/AddressSanitizerLeakSanitizer ).

This check will enable us to find bugs in the profiler that may not be otherwise caught.

**Motivation:**

Improve validation of the profiler native extension.

**Additional Notes:**

The "asan" tool is built into the clang compiler toolchain, and needs Ruby to be built with a special configuration.

The special configuration is not yet available in the upstream `ruby/setup-ruby` github action, so I needed to fork it and push a small tweak to make it available.

(The Ruby builds were added in https://github.com/ruby/ruby-dev-builder/pull/10 ).

**How to test the change?**

Here's a passing CI run: https://github.com/DataDog/dd-trace-rb/actions/runs/10524502494/job/29161364590

I've also tested it by adding a memory leak (e.g. for instance commenting out `ddog_Vec_Tag_drop(tags);` in `http_transport.c` and confirmed the issue was flagged.

Here's the failing CI run: https://github.com/DataDog/dd-trace-rb/actions/runs/10524803685/job/29162274392
