### PR TITLE
sample before propagation, context switching, and writing

### DIFF
--- a/lib/datadog/tracing/distributed/propagation.rb
+++ b/lib/datadog/tracing/distributed/propagation.rb
@@ -62,6 +62,12 @@ module Datadog
           end
 
           result = false
+          # Probably sample here
+          # Do we need to update tags on the parent span here first?
+          # That should probably be done in the tracer, not here.
+          # Can we sample off of digest or do we need to grab the parent span?
+          # Looking at how we do span sampling would be helpful to answer some of this.
+          components.sampler.sample!(digest)
 
           # Inject all configured propagation styles
           @propagation_style_inject.each do |propagator|


### PR DESCRIPTION
**What does this PR do?**
This change is so that sampling will be performed as late as possible for a trace. This gives us the greatest amount of information we can have on a trace available (namely tags and resource name) to choose if that trace should be sampled or not.

1. Modifies the sampler so that it can evaluate right before propagation, forking, or writing occurs.
2. Samples right before the above scenarios
3. Removes sampling on span creation.

**Motivation:**
Bring Ruby tracer in line with other tracers and allow further user fine grain control over sampling.


**How to test the change?**
<!--
Describe here how the change can be validated.
You are strongly encouraged to provide automated tests for this PR (unit or integration).
If this change cannot be feasibly tested, please explain why,
unless the change does not modify code (e.g. only modifies docs, comments).
-->

Unsure? Have a question? Request a review!
