### PR TITLE
[NO-TICKET] Fix stale apt cache in memory leaks CI test

### DIFF
--- a/.github/workflows/test-memory-leaks.yaml
+++ b/.github/workflows/test-memory-leaks.yaml
@@ -11,7 +11,7 @@ jobs:
           bundler-cache: true # runs 'bundle install' and caches installed gems automatically
           bundler: latest
           cache-version: v1 # bump this to invalidate cache
-      - run: sudo apt install -y valgrind && valgrind --version
+      - run: sudo apt update && sudo apt install -y valgrind && valgrind --version
       - run: bundle exec rake compile spec:profiling:memcheck
   test-asan:
     runs-on: ubuntu-24.04


### PR DESCRIPTION
**What does this PR do?**

This PR adds an extra `apt update` step before trying to install valgrind on the memory leaks CI test.

**Motivation:**

I noticed
[this](https://github.com/DataDog/dd-trace-rb/actions/runs/10579363384/job/29321151830) CI run was failing with

```
Run sudo apt install -y valgrind && valgrind --version

WARNING: apt does not have a stable CLI interface. Use with caution in scripts.
Reading package lists...
Building dependency tree...
Reading state information...
The following additional packages will be installed:
  gdb libbabeltrace1 libc6-dbg libdebuginfod-common libdebuginfod1t64 libipt2
  libsource-highlight-common libsource-highlight4t64
Suggested packages:
  gdb-doc gdbserver valgrind-dbg valgrind-mpi kcachegrind alleyoop valkyrie
The following NEW packages will be installed:
  gdb libbabeltrace1 libc6-dbg libdebuginfod-common libdebuginfod1t64 libipt2
  libsource-highlight-common libsource-highlight4t64 valgrind
0 upgraded, 9 newly installed, 0 to remove and 13 not upgraded.
Need to get 26.9 MB of archives.
After this operation, 105 MB of additional disk space will be used.
Get:1 http://azure.archive.ubuntu.com/ubuntu noble/main amd64 libdebuginfod-common all 0.190-1.1build4 [14.2 kB]
Get:2 http://azure.archive.ubuntu.com/ubuntu noble/main amd64 libbabeltrace1 amd64 1.5.11-3build3 [164 kB]
Get:3 http://azure.archive.ubuntu.com/ubuntu noble/main amd64 libdebuginfod1t64 amd64 0.190-1.1build4 [17.1 kB]
Get:4 http://azure.archive.ubuntu.com/ubuntu noble/main amd64 libipt2 amd64 2.0.6-1build1 [45.7 kB]
Get:5 http://azure.archive.ubuntu.com/ubuntu noble/main amd64 libsource-highlight-common all 3.1.9-4.3build1 [64.2 kB]
Get:6 http://azure.archive.ubuntu.com/ubuntu noble/main amd64 libsource-highlight4t64 amd64 3.1.9-4.3build1 [258 kB]
Get:7 http://azure.archive.ubuntu.com/ubuntu noble/main amd64 gdb amd64 15.0.50.20240403-0ubuntu1 [4010 kB]
Ign:8 http://azure.archive.ubuntu.com/ubuntu noble-updates/main amd64 libc6-dbg amd64 2.39-0ubuntu8.2
Get:9 http://azure.archive.ubuntu.com/ubuntu noble/main amd64 valgrind amd64 1:3.22.0-0ubuntu3 [14.9 MB]
Err:8 http://azure.archive.ubuntu.com/ubuntu noble-updates/main amd64 libc6-dbg amd64 2.39-0ubuntu8.2
  404  Not Found [IP: 20.106.104.242 80]
Fetched 19.5 MB in 2s (10.5 MB/s)
E: Failed to fetch http://azure.archive.ubuntu.com/ubuntu/pool/main/g/glibc/libc6-dbg_2.39-0ubuntu8.2_amd64.deb  404  Not Found [IP: 20.106.104.242 80]
E: Unable to fetch some archives, maybe run apt-get update or try with --fix-missing?
```

I suspect what happened here is that there's a newer version of this package on the mirror, and the old one was removed.

**Additional Notes:**

N/A

**How to test the change?**

Validate that CI passes again.