### PR TITLE
[NO-TICKET] Raise benchmark default durations

### DIFF
--- a/benchmarks/profiler_allocation.rb
+++ b/benchmarks/profiler_allocation.rb
@@ -19,7 +19,7 @@ end
 class ProfilerAllocationBenchmark
   def run_benchmark
     Benchmark.ips do |x|
-      benchmark_time = VALIDATE_BENCHMARK_MODE ? { time: 0.01, warmup: 0 } : { time: 10, warmup: 2 }
+      benchmark_time = VALIDATE_BENCHMARK_MODE ? { time: 0.01, warmup: 0 } : { time: 30, warmup: 2 }
       x.config(
         **benchmark_time,
       )
@@ -41,7 +41,7 @@ class ProfilerAllocationBenchmark
     3.times { GC.start }
 
     Benchmark.ips do |x|
-      benchmark_time = VALIDATE_BENCHMARK_MODE ? { time: 0.01, warmup: 0 } : { time: 10, warmup: 2 }
+      benchmark_time = VALIDATE_BENCHMARK_MODE ? { time: 0.01, warmup: 0 } : { time: 30, warmup: 2 }
       x.config(
         **benchmark_time,
       )

--- a/benchmarks/profiler_allocation.rb
+++ b/benchmarks/profiler_allocation.rb
@@ -19,7 +19,7 @@ end
 class ProfilerAllocationBenchmark
   def run_benchmark
     Benchmark.ips do |x|
-      benchmark_time = VALIDATE_BENCHMARK_MODE ? { time: 0.01, warmup: 0 } : { time: 30, warmup: 2 }
+      benchmark_time = VALIDATE_BENCHMARK_MODE ? { time: 0.01, warmup: 0 } : { time: 60, warmup: 2 }
       x.config(
         **benchmark_time,
       )
@@ -41,7 +41,7 @@ class ProfilerAllocationBenchmark
     3.times { GC.start }
 
     Benchmark.ips do |x|
-      benchmark_time = VALIDATE_BENCHMARK_MODE ? { time: 0.01, warmup: 0 } : { time: 30, warmup: 2 }
+      benchmark_time = VALIDATE_BENCHMARK_MODE ? { time: 0.01, warmup: 0 } : { time: 60, warmup: 2 }
       x.config(
         **benchmark_time,
       )

--- a/benchmarks/profiler_gc.rb
+++ b/benchmarks/profiler_gc.rb
@@ -28,7 +28,7 @@ class ProfilerGcBenchmark
 
   def run_benchmark
     Benchmark.ips do |x|
-      benchmark_time = VALIDATE_BENCHMARK_MODE ? { time: 0.01, warmup: 0 } : { time: 30, warmup: 2 }
+      benchmark_time = VALIDATE_BENCHMARK_MODE ? { time: 0.01, warmup: 0 } : { time: 60, warmup: 2 }
       x.config(
         **benchmark_time,
       )
@@ -46,7 +46,7 @@ class ProfilerGcBenchmark
     end
 
     Benchmark.ips do |x|
-      benchmark_time = VALIDATE_BENCHMARK_MODE ? { time: 0.01, warmup: 0 } : { time: 30, warmup: 2 }
+      benchmark_time = VALIDATE_BENCHMARK_MODE ? { time: 0.01, warmup: 0 } : { time: 60, warmup: 2 }
       x.config(
         **benchmark_time,
       )
@@ -72,7 +72,7 @@ class ProfilerGcBenchmark
     end
 
     Benchmark.ips do |x|
-      benchmark_time = VALIDATE_BENCHMARK_MODE ? { time: 0.01, warmup: 0 } : { time: 30, warmup: 2 }
+      benchmark_time = VALIDATE_BENCHMARK_MODE ? { time: 0.01, warmup: 0 } : { time: 60, warmup: 2 }
       x.config(
         **benchmark_time,
       )
@@ -91,7 +91,7 @@ class ProfilerGcBenchmark
     Datadog::Profiling.wait_until_running
 
     Benchmark.ips do |x|
-      benchmark_time = VALIDATE_BENCHMARK_MODE ? { time: 0.01, warmup: 0 } : { time: 30, warmup: 2 }
+      benchmark_time = VALIDATE_BENCHMARK_MODE ? { time: 0.01, warmup: 0 } : { time: 60, warmup: 2 }
       x.config(
         **benchmark_time,
       )
@@ -105,7 +105,7 @@ class ProfilerGcBenchmark
     Datadog.configure { |c| c.profiling.enabled = false }
 
     Benchmark.ips do |x|
-      benchmark_time = VALIDATE_BENCHMARK_MODE ? { time: 0.01, warmup: 0 } : { time: 30, warmup: 2 }
+      benchmark_time = VALIDATE_BENCHMARK_MODE ? { time: 0.01, warmup: 0 } : { time: 60, warmup: 2 }
       x.config(
         **benchmark_time,
       )
@@ -124,7 +124,7 @@ class ProfilerGcBenchmark
     Datadog::Profiling.wait_until_running
 
     Benchmark.ips do |x|
-      benchmark_time = VALIDATE_BENCHMARK_MODE ? { time: 0.01, warmup: 0 } : { time: 30, warmup: 2 }
+      benchmark_time = VALIDATE_BENCHMARK_MODE ? { time: 0.01, warmup: 0 } : { time: 60, warmup: 2 }
       x.config(
         **benchmark_time,
       )

--- a/benchmarks/profiler_gc.rb
+++ b/benchmarks/profiler_gc.rb
@@ -28,7 +28,7 @@ class ProfilerGcBenchmark
 
   def run_benchmark
     Benchmark.ips do |x|
-      benchmark_time = VALIDATE_BENCHMARK_MODE ? { time: 0.01, warmup: 0 } : { time: 10, warmup: 2 }
+      benchmark_time = VALIDATE_BENCHMARK_MODE ? { time: 0.01, warmup: 0 } : { time: 30, warmup: 2 }
       x.config(
         **benchmark_time,
       )
@@ -46,7 +46,7 @@ class ProfilerGcBenchmark
     end
 
     Benchmark.ips do |x|
-      benchmark_time = VALIDATE_BENCHMARK_MODE ? { time: 0.01, warmup: 0 } : { time: 10, warmup: 2 }
+      benchmark_time = VALIDATE_BENCHMARK_MODE ? { time: 0.01, warmup: 0 } : { time: 30, warmup: 2 }
       x.config(
         **benchmark_time,
       )
@@ -72,7 +72,7 @@ class ProfilerGcBenchmark
     end
 
     Benchmark.ips do |x|
-      benchmark_time = VALIDATE_BENCHMARK_MODE ? { time: 0.01, warmup: 0 } : { time: 10, warmup: 2 }
+      benchmark_time = VALIDATE_BENCHMARK_MODE ? { time: 0.01, warmup: 0 } : { time: 30, warmup: 2 }
       x.config(
         **benchmark_time,
       )
@@ -91,7 +91,7 @@ class ProfilerGcBenchmark
     Datadog::Profiling.wait_until_running
 
     Benchmark.ips do |x|
-      benchmark_time = VALIDATE_BENCHMARK_MODE ? { time: 0.01, warmup: 0 } : { time: 10, warmup: 2 }
+      benchmark_time = VALIDATE_BENCHMARK_MODE ? { time: 0.01, warmup: 0 } : { time: 30, warmup: 2 }
       x.config(
         **benchmark_time,
       )
@@ -105,7 +105,7 @@ class ProfilerGcBenchmark
     Datadog.configure { |c| c.profiling.enabled = false }
 
     Benchmark.ips do |x|
-      benchmark_time = VALIDATE_BENCHMARK_MODE ? { time: 0.01, warmup: 0 } : { time: 10, warmup: 2 }
+      benchmark_time = VALIDATE_BENCHMARK_MODE ? { time: 0.01, warmup: 0 } : { time: 30, warmup: 2 }
       x.config(
         **benchmark_time,
       )
@@ -124,7 +124,7 @@ class ProfilerGcBenchmark
     Datadog::Profiling.wait_until_running
 
     Benchmark.ips do |x|
-      benchmark_time = VALIDATE_BENCHMARK_MODE ? { time: 0.01, warmup: 0 } : { time: 10, warmup: 2 }
+      benchmark_time = VALIDATE_BENCHMARK_MODE ? { time: 0.01, warmup: 0 } : { time: 30, warmup: 2 }
       x.config(
         **benchmark_time,
       )

--- a/benchmarks/profiler_hold_resume_interruptions.rb
+++ b/benchmarks/profiler_hold_resume_interruptions.rb
@@ -16,7 +16,7 @@ class ProfilerHoldResumeInterruptions
 
   def run_benchmark
     Benchmark.ips do |x|
-      benchmark_time = VALIDATE_BENCHMARK_MODE ? { time: 0.01, warmup: 0 } : { time: 10, warmup: 2 }
+      benchmark_time = VALIDATE_BENCHMARK_MODE ? { time: 0.01, warmup: 0 } : { time: 30, warmup: 2 }
       x.config(
         **benchmark_time,
       )

--- a/benchmarks/profiler_hold_resume_interruptions.rb
+++ b/benchmarks/profiler_hold_resume_interruptions.rb
@@ -16,7 +16,7 @@ class ProfilerHoldResumeInterruptions
 
   def run_benchmark
     Benchmark.ips do |x|
-      benchmark_time = VALIDATE_BENCHMARK_MODE ? { time: 0.01, warmup: 0 } : { time: 30, warmup: 2 }
+      benchmark_time = VALIDATE_BENCHMARK_MODE ? { time: 0.01, warmup: 0 } : { time: 60, warmup: 2 }
       x.config(
         **benchmark_time,
       )

--- a/benchmarks/profiler_memory_sample_serialize.rb
+++ b/benchmarks/profiler_memory_sample_serialize.rb
@@ -60,7 +60,7 @@ class ProfilerMemorySampleSerializeBenchmark
 
   def run_benchmark
     Benchmark.ips do |x|
-      benchmark_time = VALIDATE_BENCHMARK_MODE ? { time: 0.01, warmup: 0 } : { time: 30, warmup: 2 }
+      benchmark_time = VALIDATE_BENCHMARK_MODE ? { time: 0.01, warmup: 0 } : { time: 60, warmup: 2 }
       x.config(
         **benchmark_time,
       )

--- a/benchmarks/profiler_sample_loop_v2.rb
+++ b/benchmarks/profiler_sample_loop_v2.rb
@@ -40,7 +40,7 @@ class ProfilerSampleLoopBenchmark
 
   def run_benchmark
     Benchmark.ips do |x|
-      benchmark_time = VALIDATE_BENCHMARK_MODE ? { time: 0.01, warmup: 0 } : { time: 30, warmup: 2 }
+      benchmark_time = VALIDATE_BENCHMARK_MODE ? { time: 0.01, warmup: 0 } : { time: 60, warmup: 2 }
       x.config(
         **benchmark_time,
       )

--- a/benchmarks/profiler_sample_loop_v2.rb
+++ b/benchmarks/profiler_sample_loop_v2.rb
@@ -40,7 +40,7 @@ class ProfilerSampleLoopBenchmark
 
   def run_benchmark
     Benchmark.ips do |x|
-      benchmark_time = VALIDATE_BENCHMARK_MODE ? { time: 0.01, warmup: 0 } : { time: 10, warmup: 2 }
+      benchmark_time = VALIDATE_BENCHMARK_MODE ? { time: 0.01, warmup: 0 } : { time: 30, warmup: 2 }
       x.config(
         **benchmark_time,
       )

--- a/benchmarks/profiler_sample_serialize.rb
+++ b/benchmarks/profiler_sample_serialize.rb
@@ -34,7 +34,7 @@ class ProfilerSampleSerializeBenchmark
 
   def run_benchmark
     Benchmark.ips do |x|
-      benchmark_time = VALIDATE_BENCHMARK_MODE ? { time: 0.01, warmup: 0 } : { time: 10, warmup: 2 }
+      benchmark_time = VALIDATE_BENCHMARK_MODE ? { time: 0.01, warmup: 0 } : { time: 30, warmup: 2 }
       x.config(
         **benchmark_time,
       )

--- a/benchmarks/profiler_sample_serialize.rb
+++ b/benchmarks/profiler_sample_serialize.rb
@@ -34,7 +34,7 @@ class ProfilerSampleSerializeBenchmark
 
   def run_benchmark
     Benchmark.ips do |x|
-      benchmark_time = VALIDATE_BENCHMARK_MODE ? { time: 0.01, warmup: 0 } : { time: 30, warmup: 2 }
+      benchmark_time = VALIDATE_BENCHMARK_MODE ? { time: 0.01, warmup: 0 } : { time: 60, warmup: 2 }
       x.config(
         **benchmark_time,
       )

--- a/benchmarks/tracing_trace.rb
+++ b/benchmarks/tracing_trace.rb
@@ -24,7 +24,7 @@ class TracingTraceBenchmark
   #   benchmarking platform to calculate helpful aggregate stats. Because benchmark-ips tries to run one iteration
   #   per 100ms, this means we'll have around 120 samples (give or take a small margin of error).
   # @param [Integer] warmup in seconds. The default is 2 seconds.
-  def benchmark_time(time: 12, warmup: 2)
+  def benchmark_time(time: 30, warmup: 2)
     VALIDATE_BENCHMARK_MODE ? { time: 0.001, warmup: 0 } : { time: time, warmup: warmup }
   end
 

--- a/benchmarks/tracing_trace.rb
+++ b/benchmarks/tracing_trace.rb
@@ -24,7 +24,7 @@ class TracingTraceBenchmark
   #   benchmarking platform to calculate helpful aggregate stats. Because benchmark-ips tries to run one iteration
   #   per 100ms, this means we'll have around 120 samples (give or take a small margin of error).
   # @param [Integer] warmup in seconds. The default is 2 seconds.
-  def benchmark_time(time: 30, warmup: 2)
+  def benchmark_time(time: 60, warmup: 2)
     VALIDATE_BENCHMARK_MODE ? { time: 0.001, warmup: 0 } : { time: time, warmup: warmup }
   end
 


### PR DESCRIPTION
**What does this PR do?**

This PR goes through our existing benchmarks, and for those that used a default duration of 10 or 12 seconds, raises the duration to 30s.

**Motivation:**

We've observed most of these benchmarks having flaky regressions/improvements on PRs that shouldn't affect them.

I suspect that the running the benchmarks for such short time may be contributing to flakiness. For instance, one of the benchmarks that flakes the most often is `profiler_sample_serialize.rb`, and concidentally that's a benchmark where each iteration does a lot of work, and thus in a typical 10 second run we may only see around 70 iterations.

Hopefully by running the benchmarks for slightly longer we'll have more consistent results.

**Additional Notes:**

There is a downside to this -- because our benchmarks are currently executed sequentially in CI, this will make the benchmark run took quite longer than it used to.

Hopefully this trade-off is reasonable; if not, we can re-evaluate.

**How to test the change?**

Check the latest benchmarks CI run, and confirm the tests are running for 30 seconds, rather than 10/12.
