### PR TITLE
Telemetry logs for AppSec

### DIFF
--- a/lib/datadog/appsec/processor.rb
+++ b/lib/datadog/appsec/processor.rb
@@ -1,5 +1,7 @@
 # frozen_string_literal: true
 
+require_relative '../core/telemetry/logging'
+
 module Datadog
   module AppSec
     # Processor integrates libddwaf into datadog/appsec
@@ -119,6 +121,7 @@ module Datadog
         Datadog.logger.error do
           "libddwaf failed to initialize, error: #{e.inspect}"
         end
+        Datadog::Core::Telemetry::Logging.report(e, level: :error, description: 'libddwaf failed to initialize')
 
         @diagnostics = e.diagnostics if e.diagnostics
 
@@ -127,6 +130,7 @@ module Datadog
         Datadog.logger.error do
           "libddwaf failed to initialize, error: #{e.inspect}"
         end
+        Datadog::Core::Telemetry::Logging.report(e, level: :error, description: 'libddwaf failed to initialize')
 
         false
       end
@@ -150,6 +154,7 @@ module Datadog
             'libddwaf failed to load,' \
               "installed platform: #{libddwaf_platform} ruby platforms: #{ruby_platforms} error: #{e.inspect}"
           end
+          Datadog::Core::Telemetry::Logging.report(e, level: :error, description: 'libddwaf failed to load')
 
           false
         end

--- a/lib/datadog/appsec/processor/rule_loader.rb
+++ b/lib/datadog/appsec/processor/rule_loader.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 require_relative '../assets'
+require_relative '../../core/telemetry/logging'
 
 module Datadog
   module AppSec
@@ -34,6 +35,8 @@ module Datadog
               Datadog.logger.error do
                 "libddwaf ruleset failed to load, ruleset: #{ruleset.inspect} error: #{e.inspect}"
               end
+
+              Core::Telemetry::Logging.report(e, level: :error, description: 'libddwaf ruleset failed to load')
 
               nil
             end

--- a/sig/datadog/appsec/processor/rule_merger.rbs
+++ b/sig/datadog/appsec/processor/rule_merger.rbs
@@ -14,12 +14,17 @@ module Datadog
         type processors = ::Array[::Hash[::String, untyped]]
         type scanners = ::Array[::Hash[::String, untyped]]
 
-        DEFAULT_WAF_PROCESSORS: processors
-        DEFAULT_WAF_SCANNERS: processors
-
-        def self.merge: (rules: ::Array[rules], ?data: ::Array[data], ?overrides: overrides, ?exclusions: exclusions, ?custom_rules: custom_rules, ?processors: processors, ?scanners: scanners) -> rules
+        def self.merge: (rules: ::Array[rules], ?data: ::Array[data], ?overrides: overrides, ?exclusions: exclusions, ?custom_rules: custom_rules, ?processors: processors?, ?scanners: scanners?) -> rules
 
         private
+
+        self.@default_waf_processors: processors
+
+        self.@default_waf_scanners: scanners
+
+        def self.default_waf_processors: -> processors
+
+        def self.default_waf_scanners: -> scanners
 
         def self.combine_rules: (::Array[rules] rules) -> rules
 

--- a/spec/datadog/appsec/processor/rule_loader_spec.rb
+++ b/spec/datadog/appsec/processor/rule_loader_spec.rb
@@ -60,7 +60,15 @@ RSpec.describe Datadog::AppSec::Processor::RuleLoader do
     context 'when ruleset is a non existing path' do
       let(:ruleset) { '/does/not/exist' }
 
-      it { expect(rules).to be_nil }
+      it 'returns `nil`' do
+        expect(Datadog::Core::Telemetry::Logging).to receive(:report).with(
+          an_instance_of(Errno::ENOENT),
+          level: :error,
+          description: 'libddwaf ruleset failed to load'
+        )
+
+        expect(rules).to be_nil
+      end
     end
 
     context 'when ruleset is IO-like' do
@@ -84,7 +92,15 @@ RSpec.describe Datadog::AppSec::Processor::RuleLoader do
     context 'when ruleset is not parseable' do
       let(:ruleset) { StringIO.new('this is not json') }
 
-      it { expect(rules).to be_nil }
+      it 'returns `nil`' do
+        expect(Datadog::Core::Telemetry::Logging).to receive(:report).with(
+          an_instance_of(JSON::ParserError),
+          level: :error,
+          description: 'libddwaf ruleset failed to load'
+        )
+
+        expect(rules).to be_nil
+      end
     end
   end
 

--- a/spec/datadog/appsec/remote_spec.rb
+++ b/spec/datadog/appsec/remote_spec.rb
@@ -160,8 +160,8 @@ RSpec.describe Datadog::AppSec::Remote do
               'transformers' => [],
               'on_match' => ['block']
             }],
-            'processors' => Datadog::AppSec::Processor::RuleMerger::DEFAULT_WAF_PROCESSORS,
-            'scanners' => Datadog::AppSec::Processor::RuleMerger::DEFAULT_WAF_SCANNERS,
+            'processors' => Datadog::AppSec::Processor::RuleMerger.default_waf_processors,
+            'scanners' => Datadog::AppSec::Processor::RuleMerger.default_waf_scanners,
           }
 
           expect(Datadog::AppSec).to receive(:reconfigure).with(ruleset: expected_ruleset, actions: [])


### PR DESCRIPTION
**What does this PR do?**

Send telemetry logs about AppSec errors. The errors are mostly related to load waf rules and related data. 

I refactor constant `DEFAULT_WAF_PROCESSORS `and `DEFAULT_WAF_SCANNERS` to methods with instance variable cache in order to avoid eager loading before telemetry component becomes ready during the components initialization lifecycle. 
