### PR TITLE
Update Sequel test matrix with latest 5.83.1

### DIFF
--- a/appraisal/jruby-9.2.rb
+++ b/appraisal/jruby-9.2.rb
@@ -214,7 +214,7 @@ appraise 'relational_db' do
   gem 'makara'
   gem 'activerecord-jdbcmysql-adapter', '>= 52', platform: :jruby
   gem 'activerecord-jdbcpostgresql-adapter', '>= 52', platform: :jruby
-  gem 'sequel', '~> 5.54.0' # TODO: Support sequel 5.62.0+
+  gem 'sequel'
   gem 'activerecord-jdbcsqlite3-adapter', '>= 52', platform: :jruby
 end
 

--- a/appraisal/jruby-9.3.rb
+++ b/appraisal/jruby-9.3.rb
@@ -187,7 +187,7 @@ appraise 'relational_db' do
   gem 'makara'
   gem 'activerecord-jdbcmysql-adapter', platform: :jruby
   gem 'activerecord-jdbcpostgresql-adapter', platform: :jruby
-  gem 'sequel', '~> 5.54.0' # TODO: Support sequel 5.62.0+
+  gem 'sequel'
   gem 'jdbc-sqlite3', '>= 3.28', platform: :jruby
 end
 

--- a/appraisal/jruby-9.4.rb
+++ b/appraisal/jruby-9.4.rb
@@ -91,7 +91,7 @@ appraise 'relational_db' do
   gem 'makara', '>= 0.6.0.pre' # Ruby 3 requires >= 0.6.0, which is currently in pre-release: https://rubygems.org/gems/makara/versions
   gem 'activerecord-jdbcmysql-adapter', '~> 61.0', platform: :jruby
   gem 'activerecord-jdbcpostgresql-adapter', '~> 61.0', platform: :jruby
-  gem 'sequel', '~> 5.54.0' # TODO: Support sequel 5.62.0+
+  gem 'sequel'
   gem 'jdbc-sqlite3', '>= 3.28', platform: :jruby
 end
 

--- a/appraisal/ruby-2.5.rb
+++ b/appraisal/ruby-2.5.rb
@@ -234,7 +234,7 @@ appraise 'relational_db' do
   gem 'makara'
   gem 'mysql2', '< 1', platform: :ruby
   gem 'pg', '>= 0.18.4', platform: :ruby
-  gem 'sequel', '~> 5.54.0' # TODO: Support sequel 5.62.0+
+  gem 'sequel'
   gem 'sqlite3', '~> 1.4.1', platform: :ruby
 end
 

--- a/appraisal/ruby-2.6.rb
+++ b/appraisal/ruby-2.6.rb
@@ -187,7 +187,7 @@ appraise 'relational_db' do
   gem 'makara'
   gem 'mysql2', '< 1', platform: :ruby
   gem 'pg', '>= 0.18.4', platform: :ruby
-  gem 'sequel', '~> 5.54.0' # TODO: Support sequel 5.62.0+
+  gem 'sequel'
   gem 'sqlite3', '~> 1.4.1', platform: :ruby
 end
 

--- a/appraisal/ruby-2.7.rb
+++ b/appraisal/ruby-2.7.rb
@@ -187,7 +187,7 @@ appraise 'relational_db' do
   gem 'makara'
   gem 'mysql2', '< 1', platform: :ruby
   gem 'pg', '>= 0.18.4', platform: :ruby
-  gem 'sequel', '~> 5.54.0' # TODO: Support sequel 5.62.0+
+  gem 'sequel'
   gem 'sqlite3', '~> 1.4.1'
 end
 

--- a/appraisal/ruby-3.0.rb
+++ b/appraisal/ruby-3.0.rb
@@ -101,7 +101,7 @@ appraise 'relational_db' do
   gem 'mysql2', '>= 0.5.3', platform: :ruby
   gem 'pg', platform: :ruby
   gem 'sqlite3', '>= 1.4.2', platform: :ruby
-  gem 'sequel', '~> 5.54.0' # TODO: Support sequel 5.62.0+
+  gem 'sequel'
   gem 'trilogy'
 end
 

--- a/appraisal/ruby-3.1.rb
+++ b/appraisal/ruby-3.1.rb
@@ -101,7 +101,7 @@ appraise 'relational_db' do
   gem 'mysql2', '>= 0.5.3', platform: :ruby
   gem 'pg', platform: :ruby
   gem 'sqlite3', '>= 1.4.2', platform: :ruby
-  gem 'sequel', '~> 5.54.0' # TODO: Support sequel 5.62.0+
+  gem 'sequel'
   gem 'trilogy'
 end
 

--- a/appraisal/ruby-3.2.rb
+++ b/appraisal/ruby-3.2.rb
@@ -101,7 +101,7 @@ appraise 'relational_db' do
   gem 'mysql2', '>= 0.5.3', platform: :ruby
   gem 'pg', platform: :ruby
   gem 'sqlite3', '>= 1.4.2', platform: :ruby
-  gem 'sequel', '~> 5.54.0' # TODO: Support sequel 5.62.0+
+  gem 'sequel'
   gem 'trilogy'
 end
 

--- a/appraisal/ruby-3.3.rb
+++ b/appraisal/ruby-3.3.rb
@@ -101,7 +101,7 @@ appraise 'relational_db' do
   gem 'mysql2', '>= 0.5.3', platform: :ruby
   gem 'pg', platform: :ruby
   gem 'sqlite3', '>= 1.4.2', platform: :ruby
-  gem 'sequel', '~> 5.54.0' # TODO: Support sequel 5.62.0+
+  gem 'sequel'
   gem 'trilogy'
 end
 

--- a/appraisal/ruby-3.4.rb
+++ b/appraisal/ruby-3.4.rb
@@ -101,7 +101,7 @@ appraise 'relational_db' do
   gem 'mysql2', '>= 0.5.3', platform: :ruby
   gem 'pg', platform: :ruby
   gem 'sqlite3', '>= 1.4.2', platform: :ruby
-  gem 'sequel', '~> 5.54.0' # TODO: Support sequel 5.62.0+
+  gem 'sequel'
   gem 'trilogy'
 end
 

--- a/gemfiles/jruby_9.2_relational_db.gemfile
+++ b/gemfiles/jruby_9.2_relational_db.gemfile
@@ -34,7 +34,7 @@ gem "delayed_job_active_record"
 gem "makara"
 gem "activerecord-jdbcmysql-adapter", ">= 52", platform: :jruby
 gem "activerecord-jdbcpostgresql-adapter", ">= 52", platform: :jruby
-gem "sequel", "~> 5.54.0"
+gem "sequel"
 gem "activerecord-jdbcsqlite3-adapter", ">= 52", platform: :jruby
 
 group :check do

--- a/gemfiles/jruby_9.2_relational_db.gemfile.lock
+++ b/gemfiles/jruby_9.2_relational_db.gemfile.lock
@@ -51,6 +51,7 @@ GEM
     benchmark-ips (2.12.0)
     benchmark-memory (0.1.2)
       memory_profiler (~> 0.9)
+    bigdecimal (3.1.8-java)
     builder (3.2.4)
     climate_control (0.2.0)
     coderay (1.1.3)
@@ -118,7 +119,8 @@ GEM
     rspec_junit_formatter (0.6.0)
       rspec-core (>= 2, < 4, != 2.12.0)
     ruby-debug-base (0.11.0-java)
-    sequel (5.54.0)
+    sequel (5.83.1)
+      bigdecimal
     simplecov-cobertura (2.1.0)
       rexml
       simplecov (~> 0.19)
@@ -171,7 +173,7 @@ DEPENDENCIES
   rspec-collection_matchers (~> 1.1)
   rspec-wait (~> 0)
   rspec_junit_formatter (>= 0.5.1)
-  sequel (~> 5.54.0)
+  sequel
   simplecov!
   simplecov-cobertura (~> 2.1.0)
   warning (~> 1)

--- a/gemfiles/jruby_9.3_relational_db.gemfile
+++ b/gemfiles/jruby_9.3_relational_db.gemfile
@@ -38,7 +38,7 @@ gem "delayed_job_active_record"
 gem "makara"
 gem "activerecord-jdbcmysql-adapter", platform: :jruby
 gem "activerecord-jdbcpostgresql-adapter", platform: :jruby
-gem "sequel", "~> 5.54.0"
+gem "sequel"
 gem "jdbc-sqlite3", ">= 3.28", platform: :jruby
 
 group :check do

--- a/gemfiles/jruby_9.3_relational_db.gemfile.lock
+++ b/gemfiles/jruby_9.3_relational_db.gemfile.lock
@@ -48,6 +48,7 @@ GEM
     benchmark-ips (2.12.0)
     benchmark-memory (0.1.2)
       memory_profiler (~> 0.9)
+    bigdecimal (3.1.8-java)
     builder (3.2.4)
     climate_control (0.2.0)
     coderay (1.1.3)
@@ -146,7 +147,8 @@ GEM
       rubocop-capybara (~> 2.17)
     ruby-debug-base (0.11.0-java)
     ruby-progressbar (1.13.0)
-    sequel (5.54.0)
+    sequel (5.83.1)
+      bigdecimal
     simplecov-cobertura (2.1.0)
       rexml
       simplecov (~> 0.19)
@@ -205,7 +207,7 @@ DEPENDENCIES
   rubocop-packaging (~> 0.5.2)
   rubocop-performance (~> 1.9)
   rubocop-rspec (~> 2.20, < 2.21)
-  sequel (~> 5.54.0)
+  sequel
   simplecov!
   simplecov-cobertura (~> 2.1.0)
   warning (~> 1)

--- a/gemfiles/jruby_9.4_relational_db.gemfile
+++ b/gemfiles/jruby_9.4_relational_db.gemfile
@@ -39,7 +39,7 @@ gem "delayed_job_active_record"
 gem "makara", ">= 0.6.0.pre"
 gem "activerecord-jdbcmysql-adapter", "~> 61.0", platform: :jruby
 gem "activerecord-jdbcpostgresql-adapter", "~> 61.0", platform: :jruby
-gem "sequel", "~> 5.54.0"
+gem "sequel"
 gem "jdbc-sqlite3", ">= 3.28", platform: :jruby
 
 group :check do

--- a/gemfiles/jruby_9.4_relational_db.gemfile.lock
+++ b/gemfiles/jruby_9.4_relational_db.gemfile.lock
@@ -150,7 +150,8 @@ GEM
       rubocop-capybara (~> 2.17)
     ruby-debug-base (0.11.0-java)
     ruby-progressbar (1.13.0)
-    sequel (5.54.0)
+    sequel (5.83.1)
+      bigdecimal
     simplecov-cobertura (2.1.0)
       rexml
       simplecov (~> 0.19)
@@ -209,7 +210,7 @@ DEPENDENCIES
   rubocop-packaging (~> 0.5.2)
   rubocop-performance (~> 1.9)
   rubocop-rspec (~> 2.20, < 2.21)
-  sequel (~> 5.54.0)
+  sequel
   simplecov!
   simplecov-cobertura (~> 2.1.0)
   warning (~> 1)

--- a/gemfiles/ruby_2.5_relational_db.gemfile
+++ b/gemfiles/ruby_2.5_relational_db.gemfile
@@ -37,7 +37,7 @@ gem "delayed_job_active_record"
 gem "makara"
 gem "mysql2", "< 1", platform: :ruby
 gem "pg", ">= 0.18.4", platform: :ruby
-gem "sequel", "~> 5.54.0"
+gem "sequel"
 gem "sqlite3", "~> 1.4.1", platform: :ruby
 
 group :check do

--- a/gemfiles/ruby_2.5_relational_db.gemfile.lock
+++ b/gemfiles/ruby_2.5_relational_db.gemfile.lock
@@ -40,6 +40,7 @@ GEM
     benchmark-ips (2.12.0)
     benchmark-memory (0.1.2)
       memory_profiler (~> 0.9)
+    bigdecimal (3.1.8)
     binding_of_caller (0.8.0)
       debug_inspector (>= 0.0.1)
     builder (3.2.4)
@@ -115,7 +116,8 @@ GEM
       rspec (>= 3, < 4)
     rspec_junit_formatter (0.6.0)
       rspec-core (>= 2, < 4, != 2.12.0)
-    sequel (5.54.0)
+    sequel (5.83.1)
+      bigdecimal
     simplecov-cobertura (2.1.0)
       rexml
       simplecov (~> 0.19)
@@ -170,7 +172,7 @@ DEPENDENCIES
   rspec-collection_matchers (~> 1.1)
   rspec-wait (~> 0)
   rspec_junit_formatter (>= 0.5.1)
-  sequel (~> 5.54.0)
+  sequel
   simplecov!
   simplecov-cobertura (~> 2.1.0)
   sqlite3 (~> 1.4.1)

--- a/gemfiles/ruby_2.5_stripe_10.gemfile.lock
+++ b/gemfiles/ruby_2.5_stripe_10.gemfile.lock
@@ -47,11 +47,15 @@ GEM
     extlz4 (0.3.4)
     ffi (1.16.3)
     google-protobuf (3.19.1)
+    google-protobuf (3.19.1-x86_64-linux)
     hashdiff (1.1.1)
     json-schema (2.8.1)
       addressable (>= 2.4)
     libdatadog (11.0.0.1.0-aarch64-linux)
+    libdatadog (11.0.0.1.0-x86_64-linux)
     libddwaf (1.14.0.0.0-aarch64-linux)
+      ffi (~> 1.0)
+    libddwaf (1.14.0.0.0-x86_64-linux)
       ffi (~> 1.0)
     memory_profiler (0.9.14)
     method_source (1.1.0)
@@ -108,6 +112,7 @@ GEM
 
 PLATFORMS
   aarch64-linux
+  x86_64-linux
 
 DEPENDENCIES
   appraisal (~> 2.4.0)

--- a/gemfiles/ruby_2.5_stripe_11.gemfile.lock
+++ b/gemfiles/ruby_2.5_stripe_11.gemfile.lock
@@ -47,11 +47,15 @@ GEM
     extlz4 (0.3.4)
     ffi (1.16.3)
     google-protobuf (3.19.1)
+    google-protobuf (3.19.1-x86_64-linux)
     hashdiff (1.1.1)
     json-schema (2.8.1)
       addressable (>= 2.4)
     libdatadog (11.0.0.1.0-aarch64-linux)
+    libdatadog (11.0.0.1.0-x86_64-linux)
     libddwaf (1.14.0.0.0-aarch64-linux)
+      ffi (~> 1.0)
+    libddwaf (1.14.0.0.0-x86_64-linux)
       ffi (~> 1.0)
     memory_profiler (0.9.14)
     method_source (1.1.0)
@@ -108,6 +112,7 @@ GEM
 
 PLATFORMS
   aarch64-linux
+  x86_64-linux
 
 DEPENDENCIES
   appraisal (~> 2.4.0)

--- a/gemfiles/ruby_2.5_stripe_12.gemfile.lock
+++ b/gemfiles/ruby_2.5_stripe_12.gemfile.lock
@@ -47,11 +47,15 @@ GEM
     extlz4 (0.3.4)
     ffi (1.16.3)
     google-protobuf (3.19.1)
+    google-protobuf (3.19.1-x86_64-linux)
     hashdiff (1.1.1)
     json-schema (2.8.1)
       addressable (>= 2.4)
     libdatadog (11.0.0.1.0-aarch64-linux)
+    libdatadog (11.0.0.1.0-x86_64-linux)
     libddwaf (1.14.0.0.0-aarch64-linux)
+      ffi (~> 1.0)
+    libddwaf (1.14.0.0.0-x86_64-linux)
       ffi (~> 1.0)
     memory_profiler (0.9.14)
     method_source (1.1.0)
@@ -108,6 +112,7 @@ GEM
 
 PLATFORMS
   aarch64-linux
+  x86_64-linux
 
 DEPENDENCIES
   appraisal (~> 2.4.0)

--- a/gemfiles/ruby_2.5_stripe_7.gemfile.lock
+++ b/gemfiles/ruby_2.5_stripe_7.gemfile.lock
@@ -47,11 +47,15 @@ GEM
     extlz4 (0.3.4)
     ffi (1.16.3)
     google-protobuf (3.19.1)
+    google-protobuf (3.19.1-x86_64-linux)
     hashdiff (1.1.1)
     json-schema (2.8.1)
       addressable (>= 2.4)
     libdatadog (11.0.0.1.0-aarch64-linux)
+    libdatadog (11.0.0.1.0-x86_64-linux)
     libddwaf (1.14.0.0.0-aarch64-linux)
+      ffi (~> 1.0)
+    libddwaf (1.14.0.0.0-x86_64-linux)
       ffi (~> 1.0)
     memory_profiler (0.9.14)
     method_source (1.1.0)
@@ -108,6 +112,7 @@ GEM
 
 PLATFORMS
   aarch64-linux
+  x86_64-linux
 
 DEPENDENCIES
   appraisal (~> 2.4.0)

--- a/gemfiles/ruby_2.5_stripe_8.gemfile.lock
+++ b/gemfiles/ruby_2.5_stripe_8.gemfile.lock
@@ -47,11 +47,15 @@ GEM
     extlz4 (0.3.4)
     ffi (1.16.3)
     google-protobuf (3.19.1)
+    google-protobuf (3.19.1-x86_64-linux)
     hashdiff (1.1.1)
     json-schema (2.8.1)
       addressable (>= 2.4)
     libdatadog (11.0.0.1.0-aarch64-linux)
+    libdatadog (11.0.0.1.0-x86_64-linux)
     libddwaf (1.14.0.0.0-aarch64-linux)
+      ffi (~> 1.0)
+    libddwaf (1.14.0.0.0-x86_64-linux)
       ffi (~> 1.0)
     memory_profiler (0.9.14)
     method_source (1.1.0)
@@ -108,6 +112,7 @@ GEM
 
 PLATFORMS
   aarch64-linux
+  x86_64-linux
 
 DEPENDENCIES
   appraisal (~> 2.4.0)

--- a/gemfiles/ruby_2.5_stripe_9.gemfile.lock
+++ b/gemfiles/ruby_2.5_stripe_9.gemfile.lock
@@ -47,11 +47,15 @@ GEM
     extlz4 (0.3.4)
     ffi (1.16.3)
     google-protobuf (3.19.1)
+    google-protobuf (3.19.1-x86_64-linux)
     hashdiff (1.1.1)
     json-schema (2.8.1)
       addressable (>= 2.4)
     libdatadog (11.0.0.1.0-aarch64-linux)
+    libdatadog (11.0.0.1.0-x86_64-linux)
     libddwaf (1.14.0.0.0-aarch64-linux)
+      ffi (~> 1.0)
+    libddwaf (1.14.0.0.0-x86_64-linux)
       ffi (~> 1.0)
     memory_profiler (0.9.14)
     method_source (1.1.0)
@@ -108,6 +112,7 @@ GEM
 
 PLATFORMS
   aarch64-linux
+  x86_64-linux
 
 DEPENDENCIES
   appraisal (~> 2.4.0)

--- a/gemfiles/ruby_2.6_relational_db.gemfile
+++ b/gemfiles/ruby_2.6_relational_db.gemfile
@@ -41,7 +41,7 @@ gem "delayed_job_active_record"
 gem "makara"
 gem "mysql2", "< 1", platform: :ruby
 gem "pg", ">= 0.18.4", platform: :ruby
-gem "sequel", "~> 5.54.0"
+gem "sequel"
 gem "sqlite3", "~> 1.4.1", platform: :ruby
 
 group :check do

--- a/gemfiles/ruby_2.6_relational_db.gemfile.lock
+++ b/gemfiles/ruby_2.6_relational_db.gemfile.lock
@@ -40,6 +40,7 @@ GEM
     benchmark-ips (2.12.0)
     benchmark-memory (0.1.2)
       memory_profiler (~> 0.9)
+    bigdecimal (3.1.8)
     binding_of_caller (1.0.0)
       debug_inspector (>= 0.0.1)
     builder (3.2.4)
@@ -148,7 +149,8 @@ GEM
       rubocop (~> 1.33)
       rubocop-capybara (~> 2.17)
     ruby-progressbar (1.13.0)
-    sequel (5.54.0)
+    sequel (5.83.1)
+      bigdecimal
     simplecov-cobertura (2.1.0)
       rexml
       simplecov (~> 0.19)
@@ -209,7 +211,7 @@ DEPENDENCIES
   rubocop-packaging (~> 0.5.2)
   rubocop-performance (~> 1.9)
   rubocop-rspec (~> 2.20, < 2.21)
-  sequel (~> 5.54.0)
+  sequel
   simplecov!
   simplecov-cobertura (~> 2.1.0)
   sqlite3 (~> 1.4.1)

--- a/gemfiles/ruby_2.6_stripe_10.gemfile.lock
+++ b/gemfiles/ruby_2.6_stripe_10.gemfile.lock
@@ -49,12 +49,16 @@ GEM
     extlz4 (0.3.4)
     ffi (1.16.3)
     google-protobuf (3.19.1)
+    google-protobuf (3.19.1-x86_64-linux)
     hashdiff (1.1.1)
     json (2.7.2)
     json-schema (2.8.1)
       addressable (>= 2.4)
     libdatadog (11.0.0.1.0-aarch64-linux)
+    libdatadog (11.0.0.1.0-x86_64-linux)
     libddwaf (1.14.0.0.0-aarch64-linux)
+      ffi (~> 1.0)
+    libddwaf (1.14.0.0.0-x86_64-linux)
       ffi (~> 1.0)
     memory_profiler (0.9.14)
     method_source (1.1.0)
@@ -143,6 +147,7 @@ GEM
 
 PLATFORMS
   aarch64-linux
+  x86_64-linux
 
 DEPENDENCIES
   appraisal (~> 2.4.0)

--- a/gemfiles/ruby_2.6_stripe_11.gemfile.lock
+++ b/gemfiles/ruby_2.6_stripe_11.gemfile.lock
@@ -49,12 +49,16 @@ GEM
     extlz4 (0.3.4)
     ffi (1.16.3)
     google-protobuf (3.19.1)
+    google-protobuf (3.19.1-x86_64-linux)
     hashdiff (1.1.1)
     json (2.7.2)
     json-schema (2.8.1)
       addressable (>= 2.4)
     libdatadog (11.0.0.1.0-aarch64-linux)
+    libdatadog (11.0.0.1.0-x86_64-linux)
     libddwaf (1.14.0.0.0-aarch64-linux)
+      ffi (~> 1.0)
+    libddwaf (1.14.0.0.0-x86_64-linux)
       ffi (~> 1.0)
     memory_profiler (0.9.14)
     method_source (1.1.0)
@@ -143,6 +147,7 @@ GEM
 
 PLATFORMS
   aarch64-linux
+  x86_64-linux
 
 DEPENDENCIES
   appraisal (~> 2.4.0)

--- a/gemfiles/ruby_2.6_stripe_12.gemfile.lock
+++ b/gemfiles/ruby_2.6_stripe_12.gemfile.lock
@@ -49,12 +49,16 @@ GEM
     extlz4 (0.3.4)
     ffi (1.16.3)
     google-protobuf (3.19.1)
+    google-protobuf (3.19.1-x86_64-linux)
     hashdiff (1.1.1)
     json (2.7.2)
     json-schema (2.8.1)
       addressable (>= 2.4)
     libdatadog (11.0.0.1.0-aarch64-linux)
+    libdatadog (11.0.0.1.0-x86_64-linux)
     libddwaf (1.14.0.0.0-aarch64-linux)
+      ffi (~> 1.0)
+    libddwaf (1.14.0.0.0-x86_64-linux)
       ffi (~> 1.0)
     memory_profiler (0.9.14)
     method_source (1.1.0)
@@ -143,6 +147,7 @@ GEM
 
 PLATFORMS
   aarch64-linux
+  x86_64-linux
 
 DEPENDENCIES
   appraisal (~> 2.4.0)

--- a/gemfiles/ruby_2.6_stripe_7.gemfile.lock
+++ b/gemfiles/ruby_2.6_stripe_7.gemfile.lock
@@ -49,12 +49,16 @@ GEM
     extlz4 (0.3.4)
     ffi (1.16.3)
     google-protobuf (3.19.1)
+    google-protobuf (3.19.1-x86_64-linux)
     hashdiff (1.1.1)
     json (2.7.2)
     json-schema (2.8.1)
       addressable (>= 2.4)
     libdatadog (11.0.0.1.0-aarch64-linux)
+    libdatadog (11.0.0.1.0-x86_64-linux)
     libddwaf (1.14.0.0.0-aarch64-linux)
+      ffi (~> 1.0)
+    libddwaf (1.14.0.0.0-x86_64-linux)
       ffi (~> 1.0)
     memory_profiler (0.9.14)
     method_source (1.1.0)
@@ -143,6 +147,7 @@ GEM
 
 PLATFORMS
   aarch64-linux
+  x86_64-linux
 
 DEPENDENCIES
   appraisal (~> 2.4.0)

--- a/gemfiles/ruby_2.6_stripe_8.gemfile.lock
+++ b/gemfiles/ruby_2.6_stripe_8.gemfile.lock
@@ -49,12 +49,16 @@ GEM
     extlz4 (0.3.4)
     ffi (1.16.3)
     google-protobuf (3.19.1)
+    google-protobuf (3.19.1-x86_64-linux)
     hashdiff (1.1.1)
     json (2.7.2)
     json-schema (2.8.1)
       addressable (>= 2.4)
     libdatadog (11.0.0.1.0-aarch64-linux)
+    libdatadog (11.0.0.1.0-x86_64-linux)
     libddwaf (1.14.0.0.0-aarch64-linux)
+      ffi (~> 1.0)
+    libddwaf (1.14.0.0.0-x86_64-linux)
       ffi (~> 1.0)
     memory_profiler (0.9.14)
     method_source (1.1.0)
@@ -143,6 +147,7 @@ GEM
 
 PLATFORMS
   aarch64-linux
+  x86_64-linux
 
 DEPENDENCIES
   appraisal (~> 2.4.0)

--- a/gemfiles/ruby_2.6_stripe_9.gemfile.lock
+++ b/gemfiles/ruby_2.6_stripe_9.gemfile.lock
@@ -49,12 +49,16 @@ GEM
     extlz4 (0.3.4)
     ffi (1.16.3)
     google-protobuf (3.19.1)
+    google-protobuf (3.19.1-x86_64-linux)
     hashdiff (1.1.1)
     json (2.7.2)
     json-schema (2.8.1)
       addressable (>= 2.4)
     libdatadog (11.0.0.1.0-aarch64-linux)
+    libdatadog (11.0.0.1.0-x86_64-linux)
     libddwaf (1.14.0.0.0-aarch64-linux)
+      ffi (~> 1.0)
+    libddwaf (1.14.0.0.0-x86_64-linux)
       ffi (~> 1.0)
     memory_profiler (0.9.14)
     method_source (1.1.0)
@@ -143,6 +147,7 @@ GEM
 
 PLATFORMS
   aarch64-linux
+  x86_64-linux
 
 DEPENDENCIES
   appraisal (~> 2.4.0)

--- a/gemfiles/ruby_2.7_relational_db.gemfile
+++ b/gemfiles/ruby_2.7_relational_db.gemfile
@@ -41,7 +41,7 @@ gem "delayed_job_active_record"
 gem "makara"
 gem "mysql2", "< 1", platform: :ruby
 gem "pg", ">= 0.18.4", platform: :ruby
-gem "sequel", "~> 5.54.0"
+gem "sequel"
 gem "sqlite3", "~> 1.4.1"
 
 group :check do

--- a/gemfiles/ruby_2.7_relational_db.gemfile.lock
+++ b/gemfiles/ruby_2.7_relational_db.gemfile.lock
@@ -40,6 +40,7 @@ GEM
     benchmark-ips (2.12.0)
     benchmark-memory (0.1.2)
       memory_profiler (~> 0.9)
+    bigdecimal (3.1.8)
     binding_of_caller (1.0.0)
       debug_inspector (>= 0.0.1)
     builder (3.2.4)
@@ -148,7 +149,8 @@ GEM
       rubocop (~> 1.33)
       rubocop-capybara (~> 2.17)
     ruby-progressbar (1.13.0)
-    sequel (5.54.0)
+    sequel (5.83.1)
+      bigdecimal
     simplecov-cobertura (2.1.0)
       rexml
       simplecov (~> 0.19)
@@ -208,7 +210,7 @@ DEPENDENCIES
   rubocop-packaging (~> 0.5.2)
   rubocop-performance (~> 1.9)
   rubocop-rspec (~> 2.20, < 2.21)
-  sequel (~> 5.54.0)
+  sequel
   simplecov!
   simplecov-cobertura (~> 2.1.0)
   sqlite3 (~> 1.4.1)

--- a/gemfiles/ruby_2.7_stripe_10.gemfile.lock
+++ b/gemfiles/ruby_2.7_stripe_10.gemfile.lock
@@ -54,7 +54,10 @@ GEM
     json-schema (2.8.1)
       addressable (>= 2.4)
     libdatadog (11.0.0.1.0-aarch64-linux)
+    libdatadog (11.0.0.1.0-x86_64-linux)
     libddwaf (1.14.0.0.0-aarch64-linux)
+      ffi (~> 1.0)
+    libddwaf (1.14.0.0.0-x86_64-linux)
       ffi (~> 1.0)
     memory_profiler (0.9.14)
     method_source (1.1.0)
@@ -143,6 +146,7 @@ GEM
 
 PLATFORMS
   aarch64-linux
+  x86_64-linux
 
 DEPENDENCIES
   appraisal (~> 2.4.0)

--- a/gemfiles/ruby_2.7_stripe_11.gemfile.lock
+++ b/gemfiles/ruby_2.7_stripe_11.gemfile.lock
@@ -54,7 +54,10 @@ GEM
     json-schema (2.8.1)
       addressable (>= 2.4)
     libdatadog (11.0.0.1.0-aarch64-linux)
+    libdatadog (11.0.0.1.0-x86_64-linux)
     libddwaf (1.14.0.0.0-aarch64-linux)
+      ffi (~> 1.0)
+    libddwaf (1.14.0.0.0-x86_64-linux)
       ffi (~> 1.0)
     memory_profiler (0.9.14)
     method_source (1.1.0)
@@ -143,6 +146,7 @@ GEM
 
 PLATFORMS
   aarch64-linux
+  x86_64-linux
 
 DEPENDENCIES
   appraisal (~> 2.4.0)

--- a/gemfiles/ruby_2.7_stripe_12.gemfile.lock
+++ b/gemfiles/ruby_2.7_stripe_12.gemfile.lock
@@ -54,7 +54,10 @@ GEM
     json-schema (2.8.1)
       addressable (>= 2.4)
     libdatadog (11.0.0.1.0-aarch64-linux)
+    libdatadog (11.0.0.1.0-x86_64-linux)
     libddwaf (1.14.0.0.0-aarch64-linux)
+      ffi (~> 1.0)
+    libddwaf (1.14.0.0.0-x86_64-linux)
       ffi (~> 1.0)
     memory_profiler (0.9.14)
     method_source (1.1.0)
@@ -143,6 +146,7 @@ GEM
 
 PLATFORMS
   aarch64-linux
+  x86_64-linux
 
 DEPENDENCIES
   appraisal (~> 2.4.0)

--- a/gemfiles/ruby_2.7_stripe_7.gemfile.lock
+++ b/gemfiles/ruby_2.7_stripe_7.gemfile.lock
@@ -54,7 +54,10 @@ GEM
     json-schema (2.8.1)
       addressable (>= 2.4)
     libdatadog (11.0.0.1.0-aarch64-linux)
+    libdatadog (11.0.0.1.0-x86_64-linux)
     libddwaf (1.14.0.0.0-aarch64-linux)
+      ffi (~> 1.0)
+    libddwaf (1.14.0.0.0-x86_64-linux)
       ffi (~> 1.0)
     memory_profiler (0.9.14)
     method_source (1.1.0)
@@ -143,6 +146,7 @@ GEM
 
 PLATFORMS
   aarch64-linux
+  x86_64-linux
 
 DEPENDENCIES
   appraisal (~> 2.4.0)

--- a/gemfiles/ruby_2.7_stripe_8.gemfile.lock
+++ b/gemfiles/ruby_2.7_stripe_8.gemfile.lock
@@ -54,7 +54,10 @@ GEM
     json-schema (2.8.1)
       addressable (>= 2.4)
     libdatadog (11.0.0.1.0-aarch64-linux)
+    libdatadog (11.0.0.1.0-x86_64-linux)
     libddwaf (1.14.0.0.0-aarch64-linux)
+      ffi (~> 1.0)
+    libddwaf (1.14.0.0.0-x86_64-linux)
       ffi (~> 1.0)
     memory_profiler (0.9.14)
     method_source (1.1.0)
@@ -143,6 +146,7 @@ GEM
 
 PLATFORMS
   aarch64-linux
+  x86_64-linux
 
 DEPENDENCIES
   appraisal (~> 2.4.0)

--- a/gemfiles/ruby_2.7_stripe_9.gemfile.lock
+++ b/gemfiles/ruby_2.7_stripe_9.gemfile.lock
@@ -54,7 +54,10 @@ GEM
     json-schema (2.8.1)
       addressable (>= 2.4)
     libdatadog (11.0.0.1.0-aarch64-linux)
+    libdatadog (11.0.0.1.0-x86_64-linux)
     libddwaf (1.14.0.0.0-aarch64-linux)
+      ffi (~> 1.0)
+    libddwaf (1.14.0.0.0-x86_64-linux)
       ffi (~> 1.0)
     memory_profiler (0.9.14)
     method_source (1.1.0)
@@ -143,6 +146,7 @@ GEM
 
 PLATFORMS
   aarch64-linux
+  x86_64-linux
 
 DEPENDENCIES
   appraisal (~> 2.4.0)

--- a/gemfiles/ruby_3.0_relational_db.gemfile
+++ b/gemfiles/ruby_3.0_relational_db.gemfile
@@ -43,7 +43,7 @@ gem "makara", ">= 0.6.0.pre"
 gem "mysql2", ">= 0.5.3", platform: :ruby
 gem "pg", platform: :ruby
 gem "sqlite3", ">= 1.4.2", platform: :ruby
-gem "sequel", "~> 5.54.0"
+gem "sequel"
 gem "trilogy"
 
 group :check do

--- a/gemfiles/ruby_3.0_relational_db.gemfile.lock
+++ b/gemfiles/ruby_3.0_relational_db.gemfile.lock
@@ -39,6 +39,7 @@ GEM
     benchmark-ips (2.12.0)
     benchmark-memory (0.1.2)
       memory_profiler (~> 0.9)
+    bigdecimal (3.1.8)
     binding_of_caller (1.0.0)
       debug_inspector (>= 0.0.1)
     builder (3.2.4)
@@ -147,7 +148,8 @@ GEM
       rubocop (~> 1.33)
       rubocop-capybara (~> 2.17)
     ruby-progressbar (1.13.0)
-    sequel (5.54.0)
+    sequel (5.83.1)
+      bigdecimal
     simplecov-cobertura (2.1.0)
       rexml
       simplecov (~> 0.19)
@@ -209,7 +211,7 @@ DEPENDENCIES
   rubocop-packaging (~> 0.5.2)
   rubocop-performance (~> 1.9)
   rubocop-rspec (~> 2.20, < 2.21)
-  sequel (~> 5.54.0)
+  sequel
   simplecov!
   simplecov-cobertura (~> 2.1.0)
   sqlite3 (>= 1.4.2)

--- a/gemfiles/ruby_3.0_stripe_10.gemfile.lock
+++ b/gemfiles/ruby_3.0_stripe_10.gemfile.lock
@@ -49,12 +49,16 @@ GEM
     extlz4 (0.3.4)
     ffi (1.16.3)
     google-protobuf (3.25.4-aarch64-linux)
+    google-protobuf (3.25.4-x86_64-linux)
     hashdiff (1.1.1)
     json (2.7.2)
     json-schema (2.8.1)
       addressable (>= 2.4)
     libdatadog (11.0.0.1.0-aarch64-linux)
+    libdatadog (11.0.0.1.0-x86_64-linux)
     libddwaf (1.14.0.0.0-aarch64-linux)
+      ffi (~> 1.0)
+    libddwaf (1.14.0.0.0-x86_64-linux)
       ffi (~> 1.0)
     memory_profiler (0.9.14)
     method_source (1.1.0)
@@ -144,6 +148,7 @@ GEM
 
 PLATFORMS
   aarch64-linux
+  x86_64-linux
 
 DEPENDENCIES
   appraisal (~> 2.4.0)

--- a/gemfiles/ruby_3.0_stripe_11.gemfile.lock
+++ b/gemfiles/ruby_3.0_stripe_11.gemfile.lock
@@ -49,12 +49,16 @@ GEM
     extlz4 (0.3.4)
     ffi (1.16.3)
     google-protobuf (3.25.4-aarch64-linux)
+    google-protobuf (3.25.4-x86_64-linux)
     hashdiff (1.1.1)
     json (2.7.2)
     json-schema (2.8.1)
       addressable (>= 2.4)
     libdatadog (11.0.0.1.0-aarch64-linux)
+    libdatadog (11.0.0.1.0-x86_64-linux)
     libddwaf (1.14.0.0.0-aarch64-linux)
+      ffi (~> 1.0)
+    libddwaf (1.14.0.0.0-x86_64-linux)
       ffi (~> 1.0)
     memory_profiler (0.9.14)
     method_source (1.1.0)
@@ -144,6 +148,7 @@ GEM
 
 PLATFORMS
   aarch64-linux
+  x86_64-linux
 
 DEPENDENCIES
   appraisal (~> 2.4.0)

--- a/gemfiles/ruby_3.0_stripe_12.gemfile.lock
+++ b/gemfiles/ruby_3.0_stripe_12.gemfile.lock
@@ -49,12 +49,16 @@ GEM
     extlz4 (0.3.4)
     ffi (1.16.3)
     google-protobuf (3.25.4-aarch64-linux)
+    google-protobuf (3.25.4-x86_64-linux)
     hashdiff (1.1.1)
     json (2.7.2)
     json-schema (2.8.1)
       addressable (>= 2.4)
     libdatadog (11.0.0.1.0-aarch64-linux)
+    libdatadog (11.0.0.1.0-x86_64-linux)
     libddwaf (1.14.0.0.0-aarch64-linux)
+      ffi (~> 1.0)
+    libddwaf (1.14.0.0.0-x86_64-linux)
       ffi (~> 1.0)
     memory_profiler (0.9.14)
     method_source (1.1.0)
@@ -144,6 +148,7 @@ GEM
 
 PLATFORMS
   aarch64-linux
+  x86_64-linux
 
 DEPENDENCIES
   appraisal (~> 2.4.0)

--- a/gemfiles/ruby_3.0_stripe_7.gemfile.lock
+++ b/gemfiles/ruby_3.0_stripe_7.gemfile.lock
@@ -49,12 +49,16 @@ GEM
     extlz4 (0.3.4)
     ffi (1.16.3)
     google-protobuf (3.25.4-aarch64-linux)
+    google-protobuf (3.25.4-x86_64-linux)
     hashdiff (1.1.1)
     json (2.7.2)
     json-schema (2.8.1)
       addressable (>= 2.4)
     libdatadog (11.0.0.1.0-aarch64-linux)
+    libdatadog (11.0.0.1.0-x86_64-linux)
     libddwaf (1.14.0.0.0-aarch64-linux)
+      ffi (~> 1.0)
+    libddwaf (1.14.0.0.0-x86_64-linux)
       ffi (~> 1.0)
     memory_profiler (0.9.14)
     method_source (1.1.0)
@@ -144,6 +148,7 @@ GEM
 
 PLATFORMS
   aarch64-linux
+  x86_64-linux
 
 DEPENDENCIES
   appraisal (~> 2.4.0)

--- a/gemfiles/ruby_3.0_stripe_8.gemfile.lock
+++ b/gemfiles/ruby_3.0_stripe_8.gemfile.lock
@@ -49,12 +49,16 @@ GEM
     extlz4 (0.3.4)
     ffi (1.16.3)
     google-protobuf (3.25.4-aarch64-linux)
+    google-protobuf (3.25.4-x86_64-linux)
     hashdiff (1.1.1)
     json (2.7.2)
     json-schema (2.8.1)
       addressable (>= 2.4)
     libdatadog (11.0.0.1.0-aarch64-linux)
+    libdatadog (11.0.0.1.0-x86_64-linux)
     libddwaf (1.14.0.0.0-aarch64-linux)
+      ffi (~> 1.0)
+    libddwaf (1.14.0.0.0-x86_64-linux)
       ffi (~> 1.0)
     memory_profiler (0.9.14)
     method_source (1.1.0)
@@ -144,6 +148,7 @@ GEM
 
 PLATFORMS
   aarch64-linux
+  x86_64-linux
 
 DEPENDENCIES
   appraisal (~> 2.4.0)

--- a/gemfiles/ruby_3.0_stripe_9.gemfile.lock
+++ b/gemfiles/ruby_3.0_stripe_9.gemfile.lock
@@ -49,12 +49,16 @@ GEM
     extlz4 (0.3.4)
     ffi (1.16.3)
     google-protobuf (3.25.4-aarch64-linux)
+    google-protobuf (3.25.4-x86_64-linux)
     hashdiff (1.1.1)
     json (2.7.2)
     json-schema (2.8.1)
       addressable (>= 2.4)
     libdatadog (11.0.0.1.0-aarch64-linux)
+    libdatadog (11.0.0.1.0-x86_64-linux)
     libddwaf (1.14.0.0.0-aarch64-linux)
+      ffi (~> 1.0)
+    libddwaf (1.14.0.0.0-x86_64-linux)
       ffi (~> 1.0)
     memory_profiler (0.9.14)
     method_source (1.1.0)
@@ -144,6 +148,7 @@ GEM
 
 PLATFORMS
   aarch64-linux
+  x86_64-linux
 
 DEPENDENCIES
   appraisal (~> 2.4.0)

--- a/gemfiles/ruby_3.1_relational_db.gemfile
+++ b/gemfiles/ruby_3.1_relational_db.gemfile
@@ -43,7 +43,7 @@ gem "makara", ">= 0.6.0.pre"
 gem "mysql2", ">= 0.5.3", platform: :ruby
 gem "pg", platform: :ruby
 gem "sqlite3", ">= 1.4.2", platform: :ruby
-gem "sequel", "~> 5.54.0"
+gem "sequel"
 gem "trilogy"
 
 group :check do

--- a/gemfiles/ruby_3.1_relational_db.gemfile.lock
+++ b/gemfiles/ruby_3.1_relational_db.gemfile.lock
@@ -39,6 +39,7 @@ GEM
     benchmark-ips (2.12.0)
     benchmark-memory (0.1.2)
       memory_profiler (~> 0.9)
+    bigdecimal (3.1.8)
     binding_of_caller (1.0.0)
       debug_inspector (>= 0.0.1)
     builder (3.2.4)
@@ -147,7 +148,8 @@ GEM
       rubocop (~> 1.33)
       rubocop-capybara (~> 2.17)
     ruby-progressbar (1.13.0)
-    sequel (5.54.0)
+    sequel (5.83.1)
+      bigdecimal
     simplecov-cobertura (2.1.0)
       rexml
       simplecov (~> 0.19)
@@ -209,7 +211,7 @@ DEPENDENCIES
   rubocop-packaging (~> 0.5.2)
   rubocop-performance (~> 1.9)
   rubocop-rspec (~> 2.20, < 2.21)
-  sequel (~> 5.54.0)
+  sequel
   simplecov!
   simplecov-cobertura (~> 2.1.0)
   sqlite3 (>= 1.4.2)

--- a/gemfiles/ruby_3.1_stripe_10.gemfile.lock
+++ b/gemfiles/ruby_3.1_stripe_10.gemfile.lock
@@ -49,12 +49,16 @@ GEM
     extlz4 (0.3.4)
     ffi (1.16.3)
     google-protobuf (3.25.4-aarch64-linux)
+    google-protobuf (3.25.4-x86_64-linux)
     hashdiff (1.1.1)
     json (2.7.2)
     json-schema (2.8.1)
       addressable (>= 2.4)
     libdatadog (11.0.0.1.0-aarch64-linux)
+    libdatadog (11.0.0.1.0-x86_64-linux)
     libddwaf (1.14.0.0.0-aarch64-linux)
+      ffi (~> 1.0)
+    libddwaf (1.14.0.0.0-x86_64-linux)
       ffi (~> 1.0)
     memory_profiler (0.9.14)
     method_source (1.1.0)
@@ -144,6 +148,7 @@ GEM
 
 PLATFORMS
   aarch64-linux
+  x86_64-linux
 
 DEPENDENCIES
   appraisal (~> 2.4.0)

--- a/gemfiles/ruby_3.1_stripe_11.gemfile.lock
+++ b/gemfiles/ruby_3.1_stripe_11.gemfile.lock
@@ -49,12 +49,16 @@ GEM
     extlz4 (0.3.4)
     ffi (1.16.3)
     google-protobuf (3.25.4-aarch64-linux)
+    google-protobuf (3.25.4-x86_64-linux)
     hashdiff (1.1.1)
     json (2.7.2)
     json-schema (2.8.1)
       addressable (>= 2.4)
     libdatadog (11.0.0.1.0-aarch64-linux)
+    libdatadog (11.0.0.1.0-x86_64-linux)
     libddwaf (1.14.0.0.0-aarch64-linux)
+      ffi (~> 1.0)
+    libddwaf (1.14.0.0.0-x86_64-linux)
       ffi (~> 1.0)
     memory_profiler (0.9.14)
     method_source (1.1.0)
@@ -144,6 +148,7 @@ GEM
 
 PLATFORMS
   aarch64-linux
+  x86_64-linux
 
 DEPENDENCIES
   appraisal (~> 2.4.0)

--- a/gemfiles/ruby_3.1_stripe_12.gemfile.lock
+++ b/gemfiles/ruby_3.1_stripe_12.gemfile.lock
@@ -49,12 +49,16 @@ GEM
     extlz4 (0.3.4)
     ffi (1.16.3)
     google-protobuf (3.25.4-aarch64-linux)
+    google-protobuf (3.25.4-x86_64-linux)
     hashdiff (1.1.1)
     json (2.7.2)
     json-schema (2.8.1)
       addressable (>= 2.4)
     libdatadog (11.0.0.1.0-aarch64-linux)
+    libdatadog (11.0.0.1.0-x86_64-linux)
     libddwaf (1.14.0.0.0-aarch64-linux)
+      ffi (~> 1.0)
+    libddwaf (1.14.0.0.0-x86_64-linux)
       ffi (~> 1.0)
     memory_profiler (0.9.14)
     method_source (1.1.0)
@@ -144,6 +148,7 @@ GEM
 
 PLATFORMS
   aarch64-linux
+  x86_64-linux
 
 DEPENDENCIES
   appraisal (~> 2.4.0)

--- a/gemfiles/ruby_3.1_stripe_7.gemfile.lock
+++ b/gemfiles/ruby_3.1_stripe_7.gemfile.lock
@@ -49,12 +49,16 @@ GEM
     extlz4 (0.3.4)
     ffi (1.16.3)
     google-protobuf (3.25.4-aarch64-linux)
+    google-protobuf (3.25.4-x86_64-linux)
     hashdiff (1.1.1)
     json (2.7.2)
     json-schema (2.8.1)
       addressable (>= 2.4)
     libdatadog (11.0.0.1.0-aarch64-linux)
+    libdatadog (11.0.0.1.0-x86_64-linux)
     libddwaf (1.14.0.0.0-aarch64-linux)
+      ffi (~> 1.0)
+    libddwaf (1.14.0.0.0-x86_64-linux)
       ffi (~> 1.0)
     memory_profiler (0.9.14)
     method_source (1.1.0)
@@ -144,6 +148,7 @@ GEM
 
 PLATFORMS
   aarch64-linux
+  x86_64-linux
 
 DEPENDENCIES
   appraisal (~> 2.4.0)

--- a/gemfiles/ruby_3.1_stripe_8.gemfile.lock
+++ b/gemfiles/ruby_3.1_stripe_8.gemfile.lock
@@ -49,12 +49,16 @@ GEM
     extlz4 (0.3.4)
     ffi (1.16.3)
     google-protobuf (3.25.4-aarch64-linux)
+    google-protobuf (3.25.4-x86_64-linux)
     hashdiff (1.1.1)
     json (2.7.2)
     json-schema (2.8.1)
       addressable (>= 2.4)
     libdatadog (11.0.0.1.0-aarch64-linux)
+    libdatadog (11.0.0.1.0-x86_64-linux)
     libddwaf (1.14.0.0.0-aarch64-linux)
+      ffi (~> 1.0)
+    libddwaf (1.14.0.0.0-x86_64-linux)
       ffi (~> 1.0)
     memory_profiler (0.9.14)
     method_source (1.1.0)
@@ -144,6 +148,7 @@ GEM
 
 PLATFORMS
   aarch64-linux
+  x86_64-linux
 
 DEPENDENCIES
   appraisal (~> 2.4.0)

--- a/gemfiles/ruby_3.1_stripe_9.gemfile.lock
+++ b/gemfiles/ruby_3.1_stripe_9.gemfile.lock
@@ -49,12 +49,16 @@ GEM
     extlz4 (0.3.4)
     ffi (1.16.3)
     google-protobuf (3.25.4-aarch64-linux)
+    google-protobuf (3.25.4-x86_64-linux)
     hashdiff (1.1.1)
     json (2.7.2)
     json-schema (2.8.1)
       addressable (>= 2.4)
     libdatadog (11.0.0.1.0-aarch64-linux)
+    libdatadog (11.0.0.1.0-x86_64-linux)
     libddwaf (1.14.0.0.0-aarch64-linux)
+      ffi (~> 1.0)
+    libddwaf (1.14.0.0.0-x86_64-linux)
       ffi (~> 1.0)
     memory_profiler (0.9.14)
     method_source (1.1.0)
@@ -144,6 +148,7 @@ GEM
 
 PLATFORMS
   aarch64-linux
+  x86_64-linux
 
 DEPENDENCIES
   appraisal (~> 2.4.0)

--- a/gemfiles/ruby_3.2_relational_db.gemfile
+++ b/gemfiles/ruby_3.2_relational_db.gemfile
@@ -42,7 +42,7 @@ gem "makara", ">= 0.6.0.pre"
 gem "mysql2", ">= 0.5.3", platform: :ruby
 gem "pg", platform: :ruby
 gem "sqlite3", ">= 1.4.2", platform: :ruby
-gem "sequel", "~> 5.54.0"
+gem "sequel"
 gem "trilogy"
 
 group :check do

--- a/gemfiles/ruby_3.2_relational_db.gemfile.lock
+++ b/gemfiles/ruby_3.2_relational_db.gemfile.lock
@@ -39,6 +39,7 @@ GEM
     benchmark-ips (2.12.0)
     benchmark-memory (0.1.2)
       memory_profiler (~> 0.9)
+    bigdecimal (3.1.8)
     binding_of_caller (1.0.0)
       debug_inspector (>= 0.0.1)
     builder (3.2.4)
@@ -143,7 +144,8 @@ GEM
       rubocop (~> 1.33)
       rubocop-capybara (~> 2.17)
     ruby-progressbar (1.13.0)
-    sequel (5.54.0)
+    sequel (5.83.1)
+      bigdecimal
     simplecov-cobertura (2.1.0)
       rexml
       simplecov (~> 0.19)
@@ -204,7 +206,7 @@ DEPENDENCIES
   rubocop-packaging (~> 0.5.2)
   rubocop-performance (~> 1.9)
   rubocop-rspec (~> 2.20, < 2.21)
-  sequel (~> 5.54.0)
+  sequel
   simplecov!
   simplecov-cobertura (~> 2.1.0)
   sqlite3 (>= 1.4.2)

--- a/gemfiles/ruby_3.2_stripe_10.gemfile.lock
+++ b/gemfiles/ruby_3.2_stripe_10.gemfile.lock
@@ -48,12 +48,16 @@ GEM
     extlz4 (0.3.4)
     ffi (1.16.3)
     google-protobuf (3.25.4-aarch64-linux)
+    google-protobuf (3.25.4-x86_64-linux)
     hashdiff (1.1.1)
     json (2.7.2)
     json-schema (2.8.1)
       addressable (>= 2.4)
     libdatadog (11.0.0.1.0-aarch64-linux)
+    libdatadog (11.0.0.1.0-x86_64-linux)
     libddwaf (1.14.0.0.0-aarch64-linux)
+      ffi (~> 1.0)
+    libddwaf (1.14.0.0.0-x86_64-linux)
       ffi (~> 1.0)
     memory_profiler (0.9.14)
     method_source (1.1.0)
@@ -140,6 +144,7 @@ GEM
 
 PLATFORMS
   aarch64-linux
+  x86_64-linux
 
 DEPENDENCIES
   appraisal (~> 2.4.0)

--- a/gemfiles/ruby_3.2_stripe_11.gemfile.lock
+++ b/gemfiles/ruby_3.2_stripe_11.gemfile.lock
@@ -48,12 +48,16 @@ GEM
     extlz4 (0.3.4)
     ffi (1.16.3)
     google-protobuf (3.25.4-aarch64-linux)
+    google-protobuf (3.25.4-x86_64-linux)
     hashdiff (1.1.1)
     json (2.7.2)
     json-schema (2.8.1)
       addressable (>= 2.4)
     libdatadog (11.0.0.1.0-aarch64-linux)
+    libdatadog (11.0.0.1.0-x86_64-linux)
     libddwaf (1.14.0.0.0-aarch64-linux)
+      ffi (~> 1.0)
+    libddwaf (1.14.0.0.0-x86_64-linux)
       ffi (~> 1.0)
     memory_profiler (0.9.14)
     method_source (1.1.0)
@@ -140,6 +144,7 @@ GEM
 
 PLATFORMS
   aarch64-linux
+  x86_64-linux
 
 DEPENDENCIES
   appraisal (~> 2.4.0)

--- a/gemfiles/ruby_3.2_stripe_12.gemfile.lock
+++ b/gemfiles/ruby_3.2_stripe_12.gemfile.lock
@@ -48,12 +48,16 @@ GEM
     extlz4 (0.3.4)
     ffi (1.16.3)
     google-protobuf (3.25.4-aarch64-linux)
+    google-protobuf (3.25.4-x86_64-linux)
     hashdiff (1.1.1)
     json (2.7.2)
     json-schema (2.8.1)
       addressable (>= 2.4)
     libdatadog (11.0.0.1.0-aarch64-linux)
+    libdatadog (11.0.0.1.0-x86_64-linux)
     libddwaf (1.14.0.0.0-aarch64-linux)
+      ffi (~> 1.0)
+    libddwaf (1.14.0.0.0-x86_64-linux)
       ffi (~> 1.0)
     memory_profiler (0.9.14)
     method_source (1.1.0)
@@ -140,6 +144,7 @@ GEM
 
 PLATFORMS
   aarch64-linux
+  x86_64-linux
 
 DEPENDENCIES
   appraisal (~> 2.4.0)

--- a/gemfiles/ruby_3.2_stripe_7.gemfile.lock
+++ b/gemfiles/ruby_3.2_stripe_7.gemfile.lock
@@ -48,12 +48,16 @@ GEM
     extlz4 (0.3.4)
     ffi (1.16.3)
     google-protobuf (3.25.4-aarch64-linux)
+    google-protobuf (3.25.4-x86_64-linux)
     hashdiff (1.1.1)
     json (2.7.2)
     json-schema (2.8.1)
       addressable (>= 2.4)
     libdatadog (11.0.0.1.0-aarch64-linux)
+    libdatadog (11.0.0.1.0-x86_64-linux)
     libddwaf (1.14.0.0.0-aarch64-linux)
+      ffi (~> 1.0)
+    libddwaf (1.14.0.0.0-x86_64-linux)
       ffi (~> 1.0)
     memory_profiler (0.9.14)
     method_source (1.1.0)
@@ -140,6 +144,7 @@ GEM
 
 PLATFORMS
   aarch64-linux
+  x86_64-linux
 
 DEPENDENCIES
   appraisal (~> 2.4.0)

--- a/gemfiles/ruby_3.2_stripe_8.gemfile.lock
+++ b/gemfiles/ruby_3.2_stripe_8.gemfile.lock
@@ -48,12 +48,16 @@ GEM
     extlz4 (0.3.4)
     ffi (1.16.3)
     google-protobuf (3.25.4-aarch64-linux)
+    google-protobuf (3.25.4-x86_64-linux)
     hashdiff (1.1.1)
     json (2.7.2)
     json-schema (2.8.1)
       addressable (>= 2.4)
     libdatadog (11.0.0.1.0-aarch64-linux)
+    libdatadog (11.0.0.1.0-x86_64-linux)
     libddwaf (1.14.0.0.0-aarch64-linux)
+      ffi (~> 1.0)
+    libddwaf (1.14.0.0.0-x86_64-linux)
       ffi (~> 1.0)
     memory_profiler (0.9.14)
     method_source (1.1.0)
@@ -140,6 +144,7 @@ GEM
 
 PLATFORMS
   aarch64-linux
+  x86_64-linux
 
 DEPENDENCIES
   appraisal (~> 2.4.0)

--- a/gemfiles/ruby_3.2_stripe_9.gemfile.lock
+++ b/gemfiles/ruby_3.2_stripe_9.gemfile.lock
@@ -48,12 +48,16 @@ GEM
     extlz4 (0.3.4)
     ffi (1.16.3)
     google-protobuf (3.25.4-aarch64-linux)
+    google-protobuf (3.25.4-x86_64-linux)
     hashdiff (1.1.1)
     json (2.7.2)
     json-schema (2.8.1)
       addressable (>= 2.4)
     libdatadog (11.0.0.1.0-aarch64-linux)
+    libdatadog (11.0.0.1.0-x86_64-linux)
     libddwaf (1.14.0.0.0-aarch64-linux)
+      ffi (~> 1.0)
+    libddwaf (1.14.0.0.0-x86_64-linux)
       ffi (~> 1.0)
     memory_profiler (0.9.14)
     method_source (1.1.0)
@@ -140,6 +144,7 @@ GEM
 
 PLATFORMS
   aarch64-linux
+  x86_64-linux
 
 DEPENDENCIES
   appraisal (~> 2.4.0)

--- a/gemfiles/ruby_3.3_relational_db.gemfile
+++ b/gemfiles/ruby_3.3_relational_db.gemfile
@@ -42,7 +42,7 @@ gem "makara", ">= 0.6.0.pre"
 gem "mysql2", ">= 0.5.3", platform: :ruby
 gem "pg", platform: :ruby
 gem "sqlite3", ">= 1.4.2", platform: :ruby
-gem "sequel", "~> 5.54.0"
+gem "sequel"
 gem "trilogy"
 
 group :check do

--- a/gemfiles/ruby_3.3_relational_db.gemfile.lock
+++ b/gemfiles/ruby_3.3_relational_db.gemfile.lock
@@ -39,6 +39,7 @@ GEM
     benchmark-ips (2.12.0)
     benchmark-memory (0.1.2)
       memory_profiler (~> 0.9)
+    bigdecimal (3.1.8)
     binding_of_caller (1.0.0)
       debug_inspector (>= 0.0.1)
     builder (3.2.4)
@@ -143,7 +144,8 @@ GEM
       rubocop (~> 1.33)
       rubocop-capybara (~> 2.17)
     ruby-progressbar (1.13.0)
-    sequel (5.54.0)
+    sequel (5.83.1)
+      bigdecimal
     simplecov-cobertura (2.1.0)
       rexml
       simplecov (~> 0.19)
@@ -204,7 +206,7 @@ DEPENDENCIES
   rubocop-packaging (~> 0.5.2)
   rubocop-performance (~> 1.9)
   rubocop-rspec (~> 2.20, < 2.21)
-  sequel (~> 5.54.0)
+  sequel
   simplecov!
   simplecov-cobertura (~> 2.1.0)
   sqlite3 (>= 1.4.2)

--- a/gemfiles/ruby_3.3_stripe_10.gemfile.lock
+++ b/gemfiles/ruby_3.3_stripe_10.gemfile.lock
@@ -48,12 +48,16 @@ GEM
     extlz4 (0.3.4)
     ffi (1.16.3)
     google-protobuf (3.25.4-aarch64-linux)
+    google-protobuf (3.25.4-x86_64-linux)
     hashdiff (1.1.1)
     json (2.7.2)
     json-schema (2.8.1)
       addressable (>= 2.4)
     libdatadog (11.0.0.1.0-aarch64-linux)
+    libdatadog (11.0.0.1.0-x86_64-linux)
     libddwaf (1.14.0.0.0-aarch64-linux)
+      ffi (~> 1.0)
+    libddwaf (1.14.0.0.0-x86_64-linux)
       ffi (~> 1.0)
     memory_profiler (0.9.14)
     method_source (1.1.0)
@@ -140,6 +144,7 @@ GEM
 
 PLATFORMS
   aarch64-linux
+  x86_64-linux
 
 DEPENDENCIES
   appraisal (~> 2.4.0)

--- a/gemfiles/ruby_3.3_stripe_11.gemfile.lock
+++ b/gemfiles/ruby_3.3_stripe_11.gemfile.lock
@@ -48,12 +48,16 @@ GEM
     extlz4 (0.3.4)
     ffi (1.16.3)
     google-protobuf (3.25.4-aarch64-linux)
+    google-protobuf (3.25.4-x86_64-linux)
     hashdiff (1.1.1)
     json (2.7.2)
     json-schema (2.8.1)
       addressable (>= 2.4)
     libdatadog (11.0.0.1.0-aarch64-linux)
+    libdatadog (11.0.0.1.0-x86_64-linux)
     libddwaf (1.14.0.0.0-aarch64-linux)
+      ffi (~> 1.0)
+    libddwaf (1.14.0.0.0-x86_64-linux)
       ffi (~> 1.0)
     memory_profiler (0.9.14)
     method_source (1.1.0)
@@ -140,6 +144,7 @@ GEM
 
 PLATFORMS
   aarch64-linux
+  x86_64-linux
 
 DEPENDENCIES
   appraisal (~> 2.4.0)

--- a/gemfiles/ruby_3.3_stripe_12.gemfile.lock
+++ b/gemfiles/ruby_3.3_stripe_12.gemfile.lock
@@ -48,12 +48,16 @@ GEM
     extlz4 (0.3.4)
     ffi (1.16.3)
     google-protobuf (3.25.4-aarch64-linux)
+    google-protobuf (3.25.4-x86_64-linux)
     hashdiff (1.1.1)
     json (2.7.2)
     json-schema (2.8.1)
       addressable (>= 2.4)
     libdatadog (11.0.0.1.0-aarch64-linux)
+    libdatadog (11.0.0.1.0-x86_64-linux)
     libddwaf (1.14.0.0.0-aarch64-linux)
+      ffi (~> 1.0)
+    libddwaf (1.14.0.0.0-x86_64-linux)
       ffi (~> 1.0)
     memory_profiler (0.9.14)
     method_source (1.1.0)
@@ -140,6 +144,7 @@ GEM
 
 PLATFORMS
   aarch64-linux
+  x86_64-linux
 
 DEPENDENCIES
   appraisal (~> 2.4.0)

--- a/gemfiles/ruby_3.3_stripe_7.gemfile.lock
+++ b/gemfiles/ruby_3.3_stripe_7.gemfile.lock
@@ -48,12 +48,16 @@ GEM
     extlz4 (0.3.4)
     ffi (1.16.3)
     google-protobuf (3.25.4-aarch64-linux)
+    google-protobuf (3.25.4-x86_64-linux)
     hashdiff (1.1.1)
     json (2.7.2)
     json-schema (2.8.1)
       addressable (>= 2.4)
     libdatadog (11.0.0.1.0-aarch64-linux)
+    libdatadog (11.0.0.1.0-x86_64-linux)
     libddwaf (1.14.0.0.0-aarch64-linux)
+      ffi (~> 1.0)
+    libddwaf (1.14.0.0.0-x86_64-linux)
       ffi (~> 1.0)
     memory_profiler (0.9.14)
     method_source (1.1.0)
@@ -140,6 +144,7 @@ GEM
 
 PLATFORMS
   aarch64-linux
+  x86_64-linux
 
 DEPENDENCIES
   appraisal (~> 2.4.0)

--- a/gemfiles/ruby_3.3_stripe_8.gemfile.lock
+++ b/gemfiles/ruby_3.3_stripe_8.gemfile.lock
@@ -48,12 +48,16 @@ GEM
     extlz4 (0.3.4)
     ffi (1.16.3)
     google-protobuf (3.25.4-aarch64-linux)
+    google-protobuf (3.25.4-x86_64-linux)
     hashdiff (1.1.1)
     json (2.7.2)
     json-schema (2.8.1)
       addressable (>= 2.4)
     libdatadog (11.0.0.1.0-aarch64-linux)
+    libdatadog (11.0.0.1.0-x86_64-linux)
     libddwaf (1.14.0.0.0-aarch64-linux)
+      ffi (~> 1.0)
+    libddwaf (1.14.0.0.0-x86_64-linux)
       ffi (~> 1.0)
     memory_profiler (0.9.14)
     method_source (1.1.0)
@@ -140,6 +144,7 @@ GEM
 
 PLATFORMS
   aarch64-linux
+  x86_64-linux
 
 DEPENDENCIES
   appraisal (~> 2.4.0)

--- a/gemfiles/ruby_3.3_stripe_9.gemfile.lock
+++ b/gemfiles/ruby_3.3_stripe_9.gemfile.lock
@@ -48,12 +48,16 @@ GEM
     extlz4 (0.3.4)
     ffi (1.16.3)
     google-protobuf (3.25.4-aarch64-linux)
+    google-protobuf (3.25.4-x86_64-linux)
     hashdiff (1.1.1)
     json (2.7.2)
     json-schema (2.8.1)
       addressable (>= 2.4)
     libdatadog (11.0.0.1.0-aarch64-linux)
+    libdatadog (11.0.0.1.0-x86_64-linux)
     libddwaf (1.14.0.0.0-aarch64-linux)
+      ffi (~> 1.0)
+    libddwaf (1.14.0.0.0-x86_64-linux)
       ffi (~> 1.0)
     memory_profiler (0.9.14)
     method_source (1.1.0)
@@ -140,6 +144,7 @@ GEM
 
 PLATFORMS
   aarch64-linux
+  x86_64-linux
 
 DEPENDENCIES
   appraisal (~> 2.4.0)

--- a/gemfiles/ruby_3.4_relational_db.gemfile
+++ b/gemfiles/ruby_3.4_relational_db.gemfile
@@ -42,7 +42,7 @@ gem "makara", ">= 0.6.0.pre"
 gem "mysql2", ">= 0.5.3", platform: :ruby
 gem "pg", platform: :ruby
 gem "sqlite3", ">= 1.4.2", platform: :ruby
-gem "sequel", "~> 5.54.0"
+gem "sequel"
 gem "trilogy"
 
 group :check do

--- a/gemfiles/ruby_3.4_relational_db.gemfile.lock
+++ b/gemfiles/ruby_3.4_relational_db.gemfile.lock
@@ -169,7 +169,8 @@ GEM
     ruby-progressbar (1.13.0)
     ruby_memcheck (3.0.0)
       nokogiri
-    sequel (5.54.0)
+    sequel (5.83.1)
+      bigdecimal
     simplecov-cobertura (2.1.0)
       rexml
       simplecov (~> 0.19)
@@ -231,7 +232,7 @@ DEPENDENCIES
   rubocop-performance (~> 1.9)
   rubocop-rspec (~> 2.20, < 2.21)
   ruby_memcheck (>= 3)
-  sequel (~> 5.54.0)
+  sequel
   simplecov!
   simplecov-cobertura (~> 2.1.0)
   sqlite3 (>= 1.4.2)

--- a/gemfiles/ruby_3.4_stripe_10.gemfile.lock
+++ b/gemfiles/ruby_3.4_stripe_10.gemfile.lock
@@ -60,7 +60,10 @@ GEM
     json-schema (2.8.1)
       addressable (>= 2.4)
     libdatadog (11.0.0.1.0-aarch64-linux)
+    libdatadog (11.0.0.1.0-x86_64-linux)
     libddwaf (1.14.0.0.0-aarch64-linux)
+      ffi (~> 1.0)
+    libddwaf (1.14.0.0.0-x86_64-linux)
       ffi (~> 1.0)
     memory_profiler (0.9.14)
     method_source (1.1.0)
@@ -152,6 +155,7 @@ GEM
 
 PLATFORMS
   aarch64-linux
+  x86_64-linux
 
 DEPENDENCIES
   appraisal (~> 2.4.0)

--- a/gemfiles/ruby_3.4_stripe_11.gemfile.lock
+++ b/gemfiles/ruby_3.4_stripe_11.gemfile.lock
@@ -60,7 +60,10 @@ GEM
     json-schema (2.8.1)
       addressable (>= 2.4)
     libdatadog (11.0.0.1.0-aarch64-linux)
+    libdatadog (11.0.0.1.0-x86_64-linux)
     libddwaf (1.14.0.0.0-aarch64-linux)
+      ffi (~> 1.0)
+    libddwaf (1.14.0.0.0-x86_64-linux)
       ffi (~> 1.0)
     memory_profiler (0.9.14)
     method_source (1.1.0)
@@ -152,6 +155,7 @@ GEM
 
 PLATFORMS
   aarch64-linux
+  x86_64-linux
 
 DEPENDENCIES
   appraisal (~> 2.4.0)

--- a/gemfiles/ruby_3.4_stripe_12.gemfile.lock
+++ b/gemfiles/ruby_3.4_stripe_12.gemfile.lock
@@ -60,7 +60,10 @@ GEM
     json-schema (2.8.1)
       addressable (>= 2.4)
     libdatadog (11.0.0.1.0-aarch64-linux)
+    libdatadog (11.0.0.1.0-x86_64-linux)
     libddwaf (1.14.0.0.0-aarch64-linux)
+      ffi (~> 1.0)
+    libddwaf (1.14.0.0.0-x86_64-linux)
       ffi (~> 1.0)
     memory_profiler (0.9.14)
     method_source (1.1.0)
@@ -152,6 +155,7 @@ GEM
 
 PLATFORMS
   aarch64-linux
+  x86_64-linux
 
 DEPENDENCIES
   appraisal (~> 2.4.0)

--- a/gemfiles/ruby_3.4_stripe_7.gemfile.lock
+++ b/gemfiles/ruby_3.4_stripe_7.gemfile.lock
@@ -60,7 +60,10 @@ GEM
     json-schema (2.8.1)
       addressable (>= 2.4)
     libdatadog (11.0.0.1.0-aarch64-linux)
+    libdatadog (11.0.0.1.0-x86_64-linux)
     libddwaf (1.14.0.0.0-aarch64-linux)
+      ffi (~> 1.0)
+    libddwaf (1.14.0.0.0-x86_64-linux)
       ffi (~> 1.0)
     memory_profiler (0.9.14)
     method_source (1.1.0)
@@ -152,6 +155,7 @@ GEM
 
 PLATFORMS
   aarch64-linux
+  x86_64-linux
 
 DEPENDENCIES
   appraisal (~> 2.4.0)

--- a/gemfiles/ruby_3.4_stripe_8.gemfile.lock
+++ b/gemfiles/ruby_3.4_stripe_8.gemfile.lock
@@ -60,7 +60,10 @@ GEM
     json-schema (2.8.1)
       addressable (>= 2.4)
     libdatadog (11.0.0.1.0-aarch64-linux)
+    libdatadog (11.0.0.1.0-x86_64-linux)
     libddwaf (1.14.0.0.0-aarch64-linux)
+      ffi (~> 1.0)
+    libddwaf (1.14.0.0.0-x86_64-linux)
       ffi (~> 1.0)
     memory_profiler (0.9.14)
     method_source (1.1.0)
@@ -152,6 +155,7 @@ GEM
 
 PLATFORMS
   aarch64-linux
+  x86_64-linux
 
 DEPENDENCIES
   appraisal (~> 2.4.0)

--- a/gemfiles/ruby_3.4_stripe_9.gemfile.lock
+++ b/gemfiles/ruby_3.4_stripe_9.gemfile.lock
@@ -60,7 +60,10 @@ GEM
     json-schema (2.8.1)
       addressable (>= 2.4)
     libdatadog (11.0.0.1.0-aarch64-linux)
+    libdatadog (11.0.0.1.0-x86_64-linux)
     libddwaf (1.14.0.0.0-aarch64-linux)
+      ffi (~> 1.0)
+    libddwaf (1.14.0.0.0-x86_64-linux)
       ffi (~> 1.0)
     memory_profiler (0.9.14)
     method_source (1.1.0)
@@ -152,6 +155,7 @@ GEM
 
 PLATFORMS
   aarch64-linux
+  x86_64-linux
 
 DEPENDENCIES
   appraisal (~> 2.4.0)

--- a/tasks/appraisal.rake
+++ b/tasks/appraisal.rake
@@ -202,6 +202,7 @@ TRACER_VERSIONS = [
   '3.2',
   '3.3',
   '3.4',
+  # ADD NEW RUBIES HERE
   'jruby-9.2',
   'jruby-9.3',
   'jruby-9.4',


### PR DESCRIPTION
**What does this PR do?**

We weren't able to update the test matrix for sequel for a long time, because of a test failure. 

The test failure does not mean we have a faulty instrumentation, but rather our test assertions could be brittle. 

For the example of sequel, it was caused by inconsistent ordering of some internal spans with pg.

I fixed them and updated the dependencies to the latest `5.83.1` 