### PR TITLE
Fix update-gemfiles workflow permissions

### DIFF
--- a/.github/workflows/update-gemfiles.yml
+++ b/.github/workflows/update-gemfiles.yml
@@ -29,6 +29,9 @@ jobs:
   check:
     name: Update Gemfiles
     runs-on: ubuntu-22.04
+    permissions:
+      contents: write
+      pull-requests: write
     steps:
       # Only execute if there's a PR attached to this branch.
       # Because we execute on `push`, we have to double check here if this is part of a PR.


### PR DESCRIPTION

<!--
Check out the
https://github.com/DataDog/dd-trace-rb/blob/master/docs/DevelopmentGuide.md
for guidance on how to set up your development environment,
run the test suite, write new integrations, and more.
-->

**What does this PR do?**

Fix update-gemfiles workflow permissions

**Motivation:**

No permission is declared in the workflow file, when a switch to a more restrictive global setting would cause the workflow to fail.

**Additional Notes:**

None.

**JIRA:**

- [VULN-8195](https://datadoghq.atlassian.net/browse/VULN-8195)

**How to test the change?**
<!--
Describe here how the change can be validated.
You are strongly encouraged to provide automated tests for this PR (unit or integration).
If this change cannot be feasibly tested, please explain why,
unless the change does not modify code (e.g. only modifies docs, comments).
-->

Unsure? Have a question? Request a review!


[VULN-8195]: https://datadoghq.atlassian.net/browse/VULN-8195?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ