### PR TITLE
Fix permissions system-tests workflow

### DIFF
--- a/.github/workflows/system-tests.yml
+++ b/.github/workflows/system-tests.yml
@@ -28,6 +28,8 @@ jobs:
           - name: proxy
             internal: datadog/system-tests:proxy-v1
     runs-on: ubuntu-latest
+    permissions:
+      packages: write
     name: Build (${{ matrix.image.name }})
     steps:
       - name: Checkout
@@ -101,6 +103,8 @@ jobs:
           - graphql23
     runs-on: ubuntu-latest
     name: Build (${{ matrix.app }})
+    permissions:
+      packages: write
     steps:
       - name: Checkout
         uses: actions/checkout@v4


### PR DESCRIPTION
**What does this PR do?**
Fixes permissions for system-tests Github Workflow.

**Motivation:**
System tests failing for PR #3849
https://github.com/DataDog/dd-trace-rb/actions/runs/10633708151/job/29479572745?pr=3849

**Additional Notes:**
Similar to https://github.com/DataDog/dd-trace-rb/pull/3878

**How to test the change?**
System tests should not fail.