### PR TITLE
[SDTEST-756] add +ci-X.Y.Z to the tracer_version reported to internal telemetry if datadog-ci is present and CI mode is enabled

### DIFF
--- a/Steepfile
+++ b/Steepfile
@@ -569,6 +569,7 @@ target :datadog do
   library 'passenger'
   library 'webmock'
   library 'graphql'
+  library 'datadog-ci'
 
   # TODO: gem 'libddwaf'
   library 'libddwaf'

--- a/lib/datadog/core/telemetry/request.rb
+++ b/lib/datadog/core/telemetry/request.rb
@@ -33,8 +33,8 @@ module Datadog
             config = Datadog.configuration
 
             tracer_version = Core::Environment::Identity.gem_datadog_version_semver2
-            if config.respond_to?(:ci) && config.ci.enabled && defined?(::Datadog::CI::VERSION)
-              tracer_version = "#{tracer_version}+ci-#{::Datadog::CI::VERSION}"
+            if defined?(::Datadog::CI::VERSION) && config.respond_to?(:ci) && config.ci.enabled
+              tracer_version = "#{tracer_version}-ci-#{::Datadog::CI::VERSION::STRING}"
             end
 
             {

--- a/lib/datadog/core/telemetry/request.rb
+++ b/lib/datadog/core/telemetry/request.rb
@@ -31,6 +31,12 @@ module Datadog
 
           def application
             config = Datadog.configuration
+
+            tracer_version = Core::Environment::Identity.gem_datadog_version_semver2
+            if config.respond_to?(:ci) && config.ci.enabled && defined?(::Datadog::CI::VERSION)
+              tracer_version = "#{tracer_version}+ci-#{::Datadog::CI::VERSION}"
+            end
+
             {
               env: config.env,
               language_name: Core::Environment::Ext::LANG,
@@ -39,7 +45,7 @@ module Datadog
               runtime_version: Core::Environment::Ext::ENGINE_VERSION,
               service_name: config.service,
               service_version: config.version,
-              tracer_version: Core::Environment::Identity.gem_datadog_version_semver2
+              tracer_version: tracer_version
             }
           end
 

--- a/lib/datadog/core/telemetry/request.rb
+++ b/lib/datadog/core/telemetry/request.rb
@@ -33,6 +33,12 @@ module Datadog
             config = Datadog.configuration
 
             tracer_version = Core::Environment::Identity.gem_datadog_version_semver2
+
+            # We need some to distinguish datadog-ci gem versions
+            # when examining telemetry metrics emitted from the datadog-ci gem.
+            #
+            # This code checks that Datadog::CI is loaded and ci mode is enabled and adds
+            # "-ci-X.Y.Z" suffix to the tracer version.
             if defined?(::Datadog::CI::VERSION) && config.respond_to?(:ci) && config.ci.enabled
               tracer_version = "#{tracer_version}-ci-#{::Datadog::CI::VERSION::STRING}"
             end

--- a/spec/datadog/core/telemetry/request_spec.rb
+++ b/spec/datadog/core/telemetry/request_spec.rb
@@ -74,5 +74,34 @@ RSpec.describe Datadog::Core::Telemetry::Request do
         tracer_time: tracer_time,
       )
     end
+
+    context "when Datadog::CI is loaded and ci mode is enabled" do
+      before do
+        stub_const('Datadog::CI::VERSION::STRING', '1.2.3')
+        expect(Datadog).to receive(:configuration).and_return(
+          double(
+            'configuration',
+            ci: double('ci', enabled: true),
+            env: env,
+            service: service_name,
+            version: service_version
+          )
+        )
+      end
+
+      it do
+        is_expected.to eq(
+          api_version: api_version,
+          application: application.merge(tracer_version: "#{tracer_version}-ci-1.2.3"),
+          debug: debug,
+          host: host,
+          payload: payload,
+          request_type: request_type,
+          runtime_id: runtime_id,
+          seq_id: seq_id,
+          tracer_time: tracer_time,
+        )
+      end
+    end
   end
 end

--- a/spec/datadog/core/telemetry/request_spec.rb
+++ b/spec/datadog/core/telemetry/request_spec.rb
@@ -75,7 +75,7 @@ RSpec.describe Datadog::Core::Telemetry::Request do
       )
     end
 
-    context "when Datadog::CI is loaded and ci mode is enabled" do
+    context 'when Datadog::CI is loaded and ci mode is enabled' do
       before do
         stub_const('Datadog::CI::VERSION::STRING', '1.2.3')
         expect(Datadog).to receive(:configuration).and_return(

--- a/vendor/rbs/datadog-ci/0/datadog_ci.rbs
+++ b/vendor/rbs/datadog-ci/0/datadog_ci.rbs
@@ -1,0 +1,7 @@
+module Datadog
+  module CI
+    module VERSION
+      STRING: String
+    end
+  end
+end


### PR DESCRIPTION
**What does this PR do?**
As discussed before, we will extend tracer_version reported for internal telemetry with datadog-ci gem version if tracing is running in CI mode.

The monkey patch should be removed in the next release: https://github.com/DataDog/datadog-ci-rb/pull/228

**Motivation:**
We need a better solution to distinguish datadog-ci versions when examining telemetry metrics emitted from the datadog-ci gem.

**Additional Notes:**
The original idea with `+ci-X.Y.Z` doesn't work perfect - it gets replaced by `_`:
<img width="650" alt="image" src="https://github.com/user-attachments/assets/cb3f3a7b-259c-4e68-9452-40e38690cf11">

`-ci-X.Y.Z` works fine though:
<img width="637" alt="image" src="https://github.com/user-attachments/assets/353fff38-d399-4472-a734-d3267b2f17f1">

**How to test the change?**
Tested using staging (see reported tracer versions above). I didn't add unit tests because it would require bringing datadog-ci in appraisals which would be an overkill.