### PR TITLE
DEBUG-2334 default token bucket allow? size to 1

### DIFF
--- a/lib/datadog/core/rate_limiter.rb
+++ b/lib/datadog/core/rate_limiter.rb
@@ -13,7 +13,7 @@ module Datadog
       # to be side-effect free.
       #
       # @return [Boolean] whether a resource conforms with the current limit
-      def allow?(size); end
+      def allow?(size = 1); end
 
       # The effective rate limiting ratio based on
       # recent calls to `allow?`.
@@ -61,7 +61,7 @@ module Datadog
       # the tokens from the bucket.
       #
       # @return [Boolean] +true+ if message conforms with current bucket limit
-      def allow?(size)
+      def allow?(size = 1)
         allowed = should_allow?(size)
         update_rate_counts(allowed)
         allowed
@@ -125,7 +125,7 @@ module Datadog
         @conforming_messages += 1
       end
 
-      def should_allow?(size)
+      def should_allow?(size = 1)
         # rate limit of 0 blocks everything
         return false if @rate.zero?
 
@@ -170,7 +170,7 @@ module Datadog
     # with no limits.
     class UnlimitedLimiter < RateLimiter
       # @return [Boolean] always +true+
-      def allow?(_)
+      def allow?(_ = 1)
         true
       end
 

--- a/lib/datadog/tracing/sampling/rule_sampler.rb
+++ b/lib/datadog/tracing/sampling/rule_sampler.rb
@@ -121,7 +121,7 @@ module Datadog
 
           return false unless sampled
 
-          rate_limiter.allow?(1).tap do |allowed|
+          rate_limiter.allow?.tap do |allowed|
             set_priority(trace, allowed)
             set_limiter_metrics(trace, rate_limiter.effective_rate)
 

--- a/lib/datadog/tracing/sampling/span/rule.rb
+++ b/lib/datadog/tracing/sampling/span/rule.rb
@@ -54,7 +54,7 @@ module Datadog
           def sample!(trace_op, span_op)
             return :not_matched unless @matcher.match?(span_op)
 
-            if @rate_limiter.allow?(1) && @sampler.sample!(trace_op)
+            if @rate_limiter.allow? && @sampler.sample!(trace_op)
               span_op.set_metric(Span::Ext::TAG_MECHANISM, Sampling::Ext::Mechanism::SPAN_SAMPLING_RATE)
               span_op.set_metric(Span::Ext::TAG_RULE_RATE, @sample_rate)
               span_op.set_metric(Span::Ext::TAG_MAX_PER_SECOND, @rate_limit)

--- a/spec/datadog/core/rate_limiter_spec.rb
+++ b/spec/datadog/core/rate_limiter_spec.rb
@@ -102,6 +102,28 @@ RSpec.describe Datadog::Core::TokenBucket do
       end
     end
 
+    context 'when size is not given' do
+      subject(:allow?) { bucket.allow? }
+
+      context 'when tokens are available' do
+        it 'returns true' do
+          is_expected.to be true
+        end
+      end
+
+      context 'when tokens are not available' do
+        let(:max_tokens) { 1 }
+
+        before do
+          bucket.allow?
+        end
+
+        it 'returns false' do
+          is_expected.to be false
+        end
+      end
+    end
+
     context 'with negative rate' do
       let(:rate) { -1 }
 

--- a/spec/datadog/tracing/sampling/rule_sampler_spec.rb
+++ b/spec/datadog/tracing/sampling/rule_sampler_spec.rb
@@ -17,7 +17,7 @@ RSpec.describe Datadog::Tracing::Sampling::RuleSampler do
 
   before do
     allow(rate_limiter).to receive(:effective_rate).and_return(effective_rate)
-    allow(rate_limiter).to receive(:allow?).with(1).and_return(allow?)
+    allow(rate_limiter).to receive(:allow?).and_return(allow?)
   end
 
   shared_examples 'a simple rule that matches all span operations' do |options = { sample_rate: 1.0 }|


### PR DESCRIPTION


<!--
Check out the
https://github.com/DataDog/dd-trace-rb/blob/master/docs/DevelopmentGuide.md
for guidance on how to set up your development environment,
run the test suite, write new integrations, and more.
-->

**What does this PR do?**
<!-- A brief description of the change being made with this pull request. -->
The only usage of token bucket rate limiter currently in our code uses a size of 1 (to perform one action). Default the size parameter to 1 to simplify the API for using token bucket on the caller side.

**Motivation:**
<!-- What inspired you to submit this pull request? -->
Dynamic instrumentation will also use token bucket and will also call allow? with the size of 1.

**Additional Notes:**
<!-- Anything else we should know when reviewing? -->

**How to test the change?**
<!--
Describe here how the change can be validated.
You are strongly encouraged to provide automated tests for this PR (unit or integration).
If this change cannot be feasibly tested, please explain why,
unless the change does not modify code (e.g. only modifies docs, comments).
-->
Unit tests

