### PR TITLE
Fix system tests

### DIFF
--- a/.github/workflows/system-tests.yml
+++ b/.github/workflows/system-tests.yml
@@ -312,6 +312,8 @@ jobs:
           - graphql23
     runs-on: ubuntu-latest
     needs:
+      - build-harness
+      - build-apps
       - test
     if: ${{ always() }}
     name: Aggregate (${{ matrix.app }})


### PR DESCRIPTION
Add build-harness and build-apps to the list of needs for aggregate job so it won't run if a build job fails
