### PR TITLE
Add missing RC capabilities

### DIFF
--- a/lib/datadog/tracing/remote.rb
+++ b/lib/datadog/tracing/remote.rb
@@ -13,7 +13,10 @@ module Datadog
         PRODUCT = 'APM_TRACING'
 
         CAPABILITIES = [
-          1 << 29 # APM_TRACING_SAMPLE_RULES: Dynamic trace sampling rules configuration
+          1 << 12, # APM_TRACING_SAMPLE_RATE: Dynamic trace sampling rate configuration
+          1 << 13, # APM_TRACING_LOGS_INJECTION: Dynamic trace logs injection configuration
+          1 << 14, # APM_TRACING_HTTP_HEADER_TAGS: Dynamic trace HTTP header tags configuration
+          1 << 29, # APM_TRACING_SAMPLE_RULES: Dynamic trace sampling rules configuration
         ].freeze
 
         def products

--- a/spec/datadog/core/remote/client/capabilities_spec.rb
+++ b/spec/datadog/core/remote/client/capabilities_spec.rb
@@ -35,7 +35,7 @@ RSpec.describe Datadog::Core::Remote::Client::Capabilities do
 
       describe '#base64_capabilities' do
         it 'matches tracing capabilities only' do
-          expect(capabilities.base64_capabilities).to eq('IAAAAA==')
+          expect(capabilities.base64_capabilities).to eq('IABwAA==')
         end
       end
     end
@@ -53,7 +53,7 @@ RSpec.describe Datadog::Core::Remote::Client::Capabilities do
 
       describe '#base64_capabilities' do
         it 'matches tracing capabilities only' do
-          expect(capabilities.base64_capabilities).to eq('IAAAAA==')
+          expect(capabilities.base64_capabilities).to eq('IABwAA==')
         end
       end
     end
@@ -85,7 +85,7 @@ RSpec.describe Datadog::Core::Remote::Client::Capabilities do
 
   context 'Tracing component' do
     it 'register capabilities, products, and receivers' do
-      expect(capabilities.capabilities).to eq([1 << 29])
+      expect(capabilities.capabilities).to contain_exactly(1 << 12, 1 << 13, 1 << 14, 1 << 29)
       expect(capabilities.products).to include('APM_TRACING')
       expect(capabilities.receivers).to include(
         lambda { |r|

--- a/spec/datadog/tracing/remote_spec.rb
+++ b/spec/datadog/tracing/remote_spec.rb
@@ -9,7 +9,7 @@ RSpec.describe Datadog::Tracing::Remote do
   end
 
   it 'declares rule sampling capabilities' do
-    expect(remote.capabilities).to eq([1 << 29])
+    expect(remote.capabilities).to contain_exactly(1 << 12, 1 << 13, 1 << 14, 1 << 29)
   end
 
   it 'declares matches that match APM_TRACING' do


### PR DESCRIPTION
This PR reports dynamic configuration capabilities that are already supported, but were not reported as such. These missing capabilities are: `APM_TRACING_SAMPLE_RATE`, `APM_TRACING_LOGS_INJECTION`, `APM_TRACING_HTTP_HEADER_TAGS`.

**How to test the change?**
System tests have been enabled for these capabilities: https://github.com/DataDog/system-tests/pull/3011

Unsure? Have a question? Request a review!
