### PR TITLE
Add ostruct to Gemfile for Ruby >= 3.3.5

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -62,6 +62,8 @@ if RUBY_VERSION >= '2.6.0'
   gem 'rubocop-rspec', ['~> 2.20', '< 2.21'], require: false
 end
 
+gem 'ostruct' if RUBY_VERSION >= '3.3'
+
 # Optional extensions
 # TODO: Move this to Appraisals?
 # dogstatsd v5, but lower than 5.2, has possible memory leak with datadog.

--- a/Gemfile
+++ b/Gemfile
@@ -62,7 +62,10 @@ if RUBY_VERSION >= '2.6.0'
   gem 'rubocop-rspec', ['~> 2.20', '< 2.21'], require: false
 end
 
-gem 'ostruct' if RUBY_VERSION >= '3.3'
+if RUBY_VERSION >= '3.3'
+  gem 'fiddle'
+  gem 'ostruct'
+end
 
 # Optional extensions
 # TODO: Move this to Appraisals?

--- a/gemfiles/ruby_2.5_stripe_10.gemfile.lock
+++ b/gemfiles/ruby_2.5_stripe_10.gemfile.lock
@@ -47,11 +47,15 @@ GEM
     extlz4 (0.3.4)
     ffi (1.16.3)
     google-protobuf (3.19.1)
+    google-protobuf (3.19.1-x86_64-linux)
     hashdiff (1.1.1)
     json-schema (2.8.1)
       addressable (>= 2.4)
     libdatadog (11.0.0.1.0-aarch64-linux)
+    libdatadog (11.0.0.1.0-x86_64-linux)
     libddwaf (1.14.0.0.0-aarch64-linux)
+      ffi (~> 1.0)
+    libddwaf (1.14.0.0.0-x86_64-linux)
       ffi (~> 1.0)
     memory_profiler (0.9.14)
     method_source (1.1.0)
@@ -108,6 +112,7 @@ GEM
 
 PLATFORMS
   aarch64-linux
+  x86_64-linux
 
 DEPENDENCIES
   appraisal (~> 2.4.0)

--- a/gemfiles/ruby_2.5_stripe_11.gemfile.lock
+++ b/gemfiles/ruby_2.5_stripe_11.gemfile.lock
@@ -47,11 +47,15 @@ GEM
     extlz4 (0.3.4)
     ffi (1.16.3)
     google-protobuf (3.19.1)
+    google-protobuf (3.19.1-x86_64-linux)
     hashdiff (1.1.1)
     json-schema (2.8.1)
       addressable (>= 2.4)
     libdatadog (11.0.0.1.0-aarch64-linux)
+    libdatadog (11.0.0.1.0-x86_64-linux)
     libddwaf (1.14.0.0.0-aarch64-linux)
+      ffi (~> 1.0)
+    libddwaf (1.14.0.0.0-x86_64-linux)
       ffi (~> 1.0)
     memory_profiler (0.9.14)
     method_source (1.1.0)
@@ -108,6 +112,7 @@ GEM
 
 PLATFORMS
   aarch64-linux
+  x86_64-linux
 
 DEPENDENCIES
   appraisal (~> 2.4.0)

--- a/gemfiles/ruby_2.5_stripe_12.gemfile.lock
+++ b/gemfiles/ruby_2.5_stripe_12.gemfile.lock
@@ -47,11 +47,15 @@ GEM
     extlz4 (0.3.4)
     ffi (1.16.3)
     google-protobuf (3.19.1)
+    google-protobuf (3.19.1-x86_64-linux)
     hashdiff (1.1.1)
     json-schema (2.8.1)
       addressable (>= 2.4)
     libdatadog (11.0.0.1.0-aarch64-linux)
+    libdatadog (11.0.0.1.0-x86_64-linux)
     libddwaf (1.14.0.0.0-aarch64-linux)
+      ffi (~> 1.0)
+    libddwaf (1.14.0.0.0-x86_64-linux)
       ffi (~> 1.0)
     memory_profiler (0.9.14)
     method_source (1.1.0)
@@ -108,6 +112,7 @@ GEM
 
 PLATFORMS
   aarch64-linux
+  x86_64-linux
 
 DEPENDENCIES
   appraisal (~> 2.4.0)

--- a/gemfiles/ruby_2.5_stripe_7.gemfile.lock
+++ b/gemfiles/ruby_2.5_stripe_7.gemfile.lock
@@ -47,11 +47,15 @@ GEM
     extlz4 (0.3.4)
     ffi (1.16.3)
     google-protobuf (3.19.1)
+    google-protobuf (3.19.1-x86_64-linux)
     hashdiff (1.1.1)
     json-schema (2.8.1)
       addressable (>= 2.4)
     libdatadog (11.0.0.1.0-aarch64-linux)
+    libdatadog (11.0.0.1.0-x86_64-linux)
     libddwaf (1.14.0.0.0-aarch64-linux)
+      ffi (~> 1.0)
+    libddwaf (1.14.0.0.0-x86_64-linux)
       ffi (~> 1.0)
     memory_profiler (0.9.14)
     method_source (1.1.0)
@@ -108,6 +112,7 @@ GEM
 
 PLATFORMS
   aarch64-linux
+  x86_64-linux
 
 DEPENDENCIES
   appraisal (~> 2.4.0)

--- a/gemfiles/ruby_2.5_stripe_8.gemfile.lock
+++ b/gemfiles/ruby_2.5_stripe_8.gemfile.lock
@@ -47,11 +47,15 @@ GEM
     extlz4 (0.3.4)
     ffi (1.16.3)
     google-protobuf (3.19.1)
+    google-protobuf (3.19.1-x86_64-linux)
     hashdiff (1.1.1)
     json-schema (2.8.1)
       addressable (>= 2.4)
     libdatadog (11.0.0.1.0-aarch64-linux)
+    libdatadog (11.0.0.1.0-x86_64-linux)
     libddwaf (1.14.0.0.0-aarch64-linux)
+      ffi (~> 1.0)
+    libddwaf (1.14.0.0.0-x86_64-linux)
       ffi (~> 1.0)
     memory_profiler (0.9.14)
     method_source (1.1.0)
@@ -108,6 +112,7 @@ GEM
 
 PLATFORMS
   aarch64-linux
+  x86_64-linux
 
 DEPENDENCIES
   appraisal (~> 2.4.0)

--- a/gemfiles/ruby_2.5_stripe_9.gemfile.lock
+++ b/gemfiles/ruby_2.5_stripe_9.gemfile.lock
@@ -47,11 +47,15 @@ GEM
     extlz4 (0.3.4)
     ffi (1.16.3)
     google-protobuf (3.19.1)
+    google-protobuf (3.19.1-x86_64-linux)
     hashdiff (1.1.1)
     json-schema (2.8.1)
       addressable (>= 2.4)
     libdatadog (11.0.0.1.0-aarch64-linux)
+    libdatadog (11.0.0.1.0-x86_64-linux)
     libddwaf (1.14.0.0.0-aarch64-linux)
+      ffi (~> 1.0)
+    libddwaf (1.14.0.0.0-x86_64-linux)
       ffi (~> 1.0)
     memory_profiler (0.9.14)
     method_source (1.1.0)
@@ -108,6 +112,7 @@ GEM
 
 PLATFORMS
   aarch64-linux
+  x86_64-linux
 
 DEPENDENCIES
   appraisal (~> 2.4.0)

--- a/gemfiles/ruby_2.6_stripe_10.gemfile.lock
+++ b/gemfiles/ruby_2.6_stripe_10.gemfile.lock
@@ -49,12 +49,16 @@ GEM
     extlz4 (0.3.4)
     ffi (1.16.3)
     google-protobuf (3.19.1)
+    google-protobuf (3.19.1-x86_64-linux)
     hashdiff (1.1.1)
     json (2.7.2)
     json-schema (2.8.1)
       addressable (>= 2.4)
     libdatadog (11.0.0.1.0-aarch64-linux)
+    libdatadog (11.0.0.1.0-x86_64-linux)
     libddwaf (1.14.0.0.0-aarch64-linux)
+      ffi (~> 1.0)
+    libddwaf (1.14.0.0.0-x86_64-linux)
       ffi (~> 1.0)
     memory_profiler (0.9.14)
     method_source (1.1.0)
@@ -143,6 +147,7 @@ GEM
 
 PLATFORMS
   aarch64-linux
+  x86_64-linux
 
 DEPENDENCIES
   appraisal (~> 2.4.0)

--- a/gemfiles/ruby_2.6_stripe_11.gemfile.lock
+++ b/gemfiles/ruby_2.6_stripe_11.gemfile.lock
@@ -49,12 +49,16 @@ GEM
     extlz4 (0.3.4)
     ffi (1.16.3)
     google-protobuf (3.19.1)
+    google-protobuf (3.19.1-x86_64-linux)
     hashdiff (1.1.1)
     json (2.7.2)
     json-schema (2.8.1)
       addressable (>= 2.4)
     libdatadog (11.0.0.1.0-aarch64-linux)
+    libdatadog (11.0.0.1.0-x86_64-linux)
     libddwaf (1.14.0.0.0-aarch64-linux)
+      ffi (~> 1.0)
+    libddwaf (1.14.0.0.0-x86_64-linux)
       ffi (~> 1.0)
     memory_profiler (0.9.14)
     method_source (1.1.0)
@@ -143,6 +147,7 @@ GEM
 
 PLATFORMS
   aarch64-linux
+  x86_64-linux
 
 DEPENDENCIES
   appraisal (~> 2.4.0)

--- a/gemfiles/ruby_2.6_stripe_12.gemfile.lock
+++ b/gemfiles/ruby_2.6_stripe_12.gemfile.lock
@@ -49,12 +49,16 @@ GEM
     extlz4 (0.3.4)
     ffi (1.16.3)
     google-protobuf (3.19.1)
+    google-protobuf (3.19.1-x86_64-linux)
     hashdiff (1.1.1)
     json (2.7.2)
     json-schema (2.8.1)
       addressable (>= 2.4)
     libdatadog (11.0.0.1.0-aarch64-linux)
+    libdatadog (11.0.0.1.0-x86_64-linux)
     libddwaf (1.14.0.0.0-aarch64-linux)
+      ffi (~> 1.0)
+    libddwaf (1.14.0.0.0-x86_64-linux)
       ffi (~> 1.0)
     memory_profiler (0.9.14)
     method_source (1.1.0)
@@ -143,6 +147,7 @@ GEM
 
 PLATFORMS
   aarch64-linux
+  x86_64-linux
 
 DEPENDENCIES
   appraisal (~> 2.4.0)

--- a/gemfiles/ruby_2.6_stripe_7.gemfile.lock
+++ b/gemfiles/ruby_2.6_stripe_7.gemfile.lock
@@ -49,12 +49,16 @@ GEM
     extlz4 (0.3.4)
     ffi (1.16.3)
     google-protobuf (3.19.1)
+    google-protobuf (3.19.1-x86_64-linux)
     hashdiff (1.1.1)
     json (2.7.2)
     json-schema (2.8.1)
       addressable (>= 2.4)
     libdatadog (11.0.0.1.0-aarch64-linux)
+    libdatadog (11.0.0.1.0-x86_64-linux)
     libddwaf (1.14.0.0.0-aarch64-linux)
+      ffi (~> 1.0)
+    libddwaf (1.14.0.0.0-x86_64-linux)
       ffi (~> 1.0)
     memory_profiler (0.9.14)
     method_source (1.1.0)
@@ -143,6 +147,7 @@ GEM
 
 PLATFORMS
   aarch64-linux
+  x86_64-linux
 
 DEPENDENCIES
   appraisal (~> 2.4.0)

--- a/gemfiles/ruby_2.6_stripe_8.gemfile.lock
+++ b/gemfiles/ruby_2.6_stripe_8.gemfile.lock
@@ -49,12 +49,16 @@ GEM
     extlz4 (0.3.4)
     ffi (1.16.3)
     google-protobuf (3.19.1)
+    google-protobuf (3.19.1-x86_64-linux)
     hashdiff (1.1.1)
     json (2.7.2)
     json-schema (2.8.1)
       addressable (>= 2.4)
     libdatadog (11.0.0.1.0-aarch64-linux)
+    libdatadog (11.0.0.1.0-x86_64-linux)
     libddwaf (1.14.0.0.0-aarch64-linux)
+      ffi (~> 1.0)
+    libddwaf (1.14.0.0.0-x86_64-linux)
       ffi (~> 1.0)
     memory_profiler (0.9.14)
     method_source (1.1.0)
@@ -143,6 +147,7 @@ GEM
 
 PLATFORMS
   aarch64-linux
+  x86_64-linux
 
 DEPENDENCIES
   appraisal (~> 2.4.0)

--- a/gemfiles/ruby_2.6_stripe_9.gemfile.lock
+++ b/gemfiles/ruby_2.6_stripe_9.gemfile.lock
@@ -49,12 +49,16 @@ GEM
     extlz4 (0.3.4)
     ffi (1.16.3)
     google-protobuf (3.19.1)
+    google-protobuf (3.19.1-x86_64-linux)
     hashdiff (1.1.1)
     json (2.7.2)
     json-schema (2.8.1)
       addressable (>= 2.4)
     libdatadog (11.0.0.1.0-aarch64-linux)
+    libdatadog (11.0.0.1.0-x86_64-linux)
     libddwaf (1.14.0.0.0-aarch64-linux)
+      ffi (~> 1.0)
+    libddwaf (1.14.0.0.0-x86_64-linux)
       ffi (~> 1.0)
     memory_profiler (0.9.14)
     method_source (1.1.0)
@@ -143,6 +147,7 @@ GEM
 
 PLATFORMS
   aarch64-linux
+  x86_64-linux
 
 DEPENDENCIES
   appraisal (~> 2.4.0)

--- a/gemfiles/ruby_2.7_stripe_10.gemfile.lock
+++ b/gemfiles/ruby_2.7_stripe_10.gemfile.lock
@@ -54,7 +54,10 @@ GEM
     json-schema (2.8.1)
       addressable (>= 2.4)
     libdatadog (11.0.0.1.0-aarch64-linux)
+    libdatadog (11.0.0.1.0-x86_64-linux)
     libddwaf (1.14.0.0.0-aarch64-linux)
+      ffi (~> 1.0)
+    libddwaf (1.14.0.0.0-x86_64-linux)
       ffi (~> 1.0)
     memory_profiler (0.9.14)
     method_source (1.1.0)
@@ -143,6 +146,7 @@ GEM
 
 PLATFORMS
   aarch64-linux
+  x86_64-linux
 
 DEPENDENCIES
   appraisal (~> 2.4.0)

--- a/gemfiles/ruby_2.7_stripe_11.gemfile.lock
+++ b/gemfiles/ruby_2.7_stripe_11.gemfile.lock
@@ -54,7 +54,10 @@ GEM
     json-schema (2.8.1)
       addressable (>= 2.4)
     libdatadog (11.0.0.1.0-aarch64-linux)
+    libdatadog (11.0.0.1.0-x86_64-linux)
     libddwaf (1.14.0.0.0-aarch64-linux)
+      ffi (~> 1.0)
+    libddwaf (1.14.0.0.0-x86_64-linux)
       ffi (~> 1.0)
     memory_profiler (0.9.14)
     method_source (1.1.0)
@@ -143,6 +146,7 @@ GEM
 
 PLATFORMS
   aarch64-linux
+  x86_64-linux
 
 DEPENDENCIES
   appraisal (~> 2.4.0)

--- a/gemfiles/ruby_2.7_stripe_12.gemfile.lock
+++ b/gemfiles/ruby_2.7_stripe_12.gemfile.lock
@@ -54,7 +54,10 @@ GEM
     json-schema (2.8.1)
       addressable (>= 2.4)
     libdatadog (11.0.0.1.0-aarch64-linux)
+    libdatadog (11.0.0.1.0-x86_64-linux)
     libddwaf (1.14.0.0.0-aarch64-linux)
+      ffi (~> 1.0)
+    libddwaf (1.14.0.0.0-x86_64-linux)
       ffi (~> 1.0)
     memory_profiler (0.9.14)
     method_source (1.1.0)
@@ -143,6 +146,7 @@ GEM
 
 PLATFORMS
   aarch64-linux
+  x86_64-linux
 
 DEPENDENCIES
   appraisal (~> 2.4.0)

--- a/gemfiles/ruby_2.7_stripe_7.gemfile.lock
+++ b/gemfiles/ruby_2.7_stripe_7.gemfile.lock
@@ -54,7 +54,10 @@ GEM
     json-schema (2.8.1)
       addressable (>= 2.4)
     libdatadog (11.0.0.1.0-aarch64-linux)
+    libdatadog (11.0.0.1.0-x86_64-linux)
     libddwaf (1.14.0.0.0-aarch64-linux)
+      ffi (~> 1.0)
+    libddwaf (1.14.0.0.0-x86_64-linux)
       ffi (~> 1.0)
     memory_profiler (0.9.14)
     method_source (1.1.0)
@@ -143,6 +146,7 @@ GEM
 
 PLATFORMS
   aarch64-linux
+  x86_64-linux
 
 DEPENDENCIES
   appraisal (~> 2.4.0)

--- a/gemfiles/ruby_2.7_stripe_8.gemfile.lock
+++ b/gemfiles/ruby_2.7_stripe_8.gemfile.lock
@@ -54,7 +54,10 @@ GEM
     json-schema (2.8.1)
       addressable (>= 2.4)
     libdatadog (11.0.0.1.0-aarch64-linux)
+    libdatadog (11.0.0.1.0-x86_64-linux)
     libddwaf (1.14.0.0.0-aarch64-linux)
+      ffi (~> 1.0)
+    libddwaf (1.14.0.0.0-x86_64-linux)
       ffi (~> 1.0)
     memory_profiler (0.9.14)
     method_source (1.1.0)
@@ -143,6 +146,7 @@ GEM
 
 PLATFORMS
   aarch64-linux
+  x86_64-linux
 
 DEPENDENCIES
   appraisal (~> 2.4.0)

--- a/gemfiles/ruby_2.7_stripe_9.gemfile.lock
+++ b/gemfiles/ruby_2.7_stripe_9.gemfile.lock
@@ -54,7 +54,10 @@ GEM
     json-schema (2.8.1)
       addressable (>= 2.4)
     libdatadog (11.0.0.1.0-aarch64-linux)
+    libdatadog (11.0.0.1.0-x86_64-linux)
     libddwaf (1.14.0.0.0-aarch64-linux)
+      ffi (~> 1.0)
+    libddwaf (1.14.0.0.0-x86_64-linux)
       ffi (~> 1.0)
     memory_profiler (0.9.14)
     method_source (1.1.0)
@@ -143,6 +146,7 @@ GEM
 
 PLATFORMS
   aarch64-linux
+  x86_64-linux
 
 DEPENDENCIES
   appraisal (~> 2.4.0)

--- a/gemfiles/ruby_3.0_stripe_10.gemfile.lock
+++ b/gemfiles/ruby_3.0_stripe_10.gemfile.lock
@@ -49,12 +49,16 @@ GEM
     extlz4 (0.3.4)
     ffi (1.16.3)
     google-protobuf (3.25.4-aarch64-linux)
+    google-protobuf (3.25.4-x86_64-linux)
     hashdiff (1.1.1)
     json (2.7.2)
     json-schema (2.8.1)
       addressable (>= 2.4)
     libdatadog (11.0.0.1.0-aarch64-linux)
+    libdatadog (11.0.0.1.0-x86_64-linux)
     libddwaf (1.14.0.0.0-aarch64-linux)
+      ffi (~> 1.0)
+    libddwaf (1.14.0.0.0-x86_64-linux)
       ffi (~> 1.0)
     memory_profiler (0.9.14)
     method_source (1.1.0)
@@ -144,6 +148,7 @@ GEM
 
 PLATFORMS
   aarch64-linux
+  x86_64-linux
 
 DEPENDENCIES
   appraisal (~> 2.4.0)

--- a/gemfiles/ruby_3.0_stripe_11.gemfile.lock
+++ b/gemfiles/ruby_3.0_stripe_11.gemfile.lock
@@ -49,12 +49,16 @@ GEM
     extlz4 (0.3.4)
     ffi (1.16.3)
     google-protobuf (3.25.4-aarch64-linux)
+    google-protobuf (3.25.4-x86_64-linux)
     hashdiff (1.1.1)
     json (2.7.2)
     json-schema (2.8.1)
       addressable (>= 2.4)
     libdatadog (11.0.0.1.0-aarch64-linux)
+    libdatadog (11.0.0.1.0-x86_64-linux)
     libddwaf (1.14.0.0.0-aarch64-linux)
+      ffi (~> 1.0)
+    libddwaf (1.14.0.0.0-x86_64-linux)
       ffi (~> 1.0)
     memory_profiler (0.9.14)
     method_source (1.1.0)
@@ -144,6 +148,7 @@ GEM
 
 PLATFORMS
   aarch64-linux
+  x86_64-linux
 
 DEPENDENCIES
   appraisal (~> 2.4.0)

--- a/gemfiles/ruby_3.0_stripe_12.gemfile.lock
+++ b/gemfiles/ruby_3.0_stripe_12.gemfile.lock
@@ -49,12 +49,16 @@ GEM
     extlz4 (0.3.4)
     ffi (1.16.3)
     google-protobuf (3.25.4-aarch64-linux)
+    google-protobuf (3.25.4-x86_64-linux)
     hashdiff (1.1.1)
     json (2.7.2)
     json-schema (2.8.1)
       addressable (>= 2.4)
     libdatadog (11.0.0.1.0-aarch64-linux)
+    libdatadog (11.0.0.1.0-x86_64-linux)
     libddwaf (1.14.0.0.0-aarch64-linux)
+      ffi (~> 1.0)
+    libddwaf (1.14.0.0.0-x86_64-linux)
       ffi (~> 1.0)
     memory_profiler (0.9.14)
     method_source (1.1.0)
@@ -144,6 +148,7 @@ GEM
 
 PLATFORMS
   aarch64-linux
+  x86_64-linux
 
 DEPENDENCIES
   appraisal (~> 2.4.0)

--- a/gemfiles/ruby_3.0_stripe_7.gemfile.lock
+++ b/gemfiles/ruby_3.0_stripe_7.gemfile.lock
@@ -49,12 +49,16 @@ GEM
     extlz4 (0.3.4)
     ffi (1.16.3)
     google-protobuf (3.25.4-aarch64-linux)
+    google-protobuf (3.25.4-x86_64-linux)
     hashdiff (1.1.1)
     json (2.7.2)
     json-schema (2.8.1)
       addressable (>= 2.4)
     libdatadog (11.0.0.1.0-aarch64-linux)
+    libdatadog (11.0.0.1.0-x86_64-linux)
     libddwaf (1.14.0.0.0-aarch64-linux)
+      ffi (~> 1.0)
+    libddwaf (1.14.0.0.0-x86_64-linux)
       ffi (~> 1.0)
     memory_profiler (0.9.14)
     method_source (1.1.0)
@@ -144,6 +148,7 @@ GEM
 
 PLATFORMS
   aarch64-linux
+  x86_64-linux
 
 DEPENDENCIES
   appraisal (~> 2.4.0)

--- a/gemfiles/ruby_3.0_stripe_8.gemfile.lock
+++ b/gemfiles/ruby_3.0_stripe_8.gemfile.lock
@@ -49,12 +49,16 @@ GEM
     extlz4 (0.3.4)
     ffi (1.16.3)
     google-protobuf (3.25.4-aarch64-linux)
+    google-protobuf (3.25.4-x86_64-linux)
     hashdiff (1.1.1)
     json (2.7.2)
     json-schema (2.8.1)
       addressable (>= 2.4)
     libdatadog (11.0.0.1.0-aarch64-linux)
+    libdatadog (11.0.0.1.0-x86_64-linux)
     libddwaf (1.14.0.0.0-aarch64-linux)
+      ffi (~> 1.0)
+    libddwaf (1.14.0.0.0-x86_64-linux)
       ffi (~> 1.0)
     memory_profiler (0.9.14)
     method_source (1.1.0)
@@ -144,6 +148,7 @@ GEM
 
 PLATFORMS
   aarch64-linux
+  x86_64-linux
 
 DEPENDENCIES
   appraisal (~> 2.4.0)

--- a/gemfiles/ruby_3.0_stripe_9.gemfile.lock
+++ b/gemfiles/ruby_3.0_stripe_9.gemfile.lock
@@ -49,12 +49,16 @@ GEM
     extlz4 (0.3.4)
     ffi (1.16.3)
     google-protobuf (3.25.4-aarch64-linux)
+    google-protobuf (3.25.4-x86_64-linux)
     hashdiff (1.1.1)
     json (2.7.2)
     json-schema (2.8.1)
       addressable (>= 2.4)
     libdatadog (11.0.0.1.0-aarch64-linux)
+    libdatadog (11.0.0.1.0-x86_64-linux)
     libddwaf (1.14.0.0.0-aarch64-linux)
+      ffi (~> 1.0)
+    libddwaf (1.14.0.0.0-x86_64-linux)
       ffi (~> 1.0)
     memory_profiler (0.9.14)
     method_source (1.1.0)
@@ -144,6 +148,7 @@ GEM
 
 PLATFORMS
   aarch64-linux
+  x86_64-linux
 
 DEPENDENCIES
   appraisal (~> 2.4.0)

--- a/gemfiles/ruby_3.1_stripe_10.gemfile.lock
+++ b/gemfiles/ruby_3.1_stripe_10.gemfile.lock
@@ -49,12 +49,16 @@ GEM
     extlz4 (0.3.4)
     ffi (1.16.3)
     google-protobuf (3.25.4-aarch64-linux)
+    google-protobuf (3.25.4-x86_64-linux)
     hashdiff (1.1.1)
     json (2.7.2)
     json-schema (2.8.1)
       addressable (>= 2.4)
     libdatadog (11.0.0.1.0-aarch64-linux)
+    libdatadog (11.0.0.1.0-x86_64-linux)
     libddwaf (1.14.0.0.0-aarch64-linux)
+      ffi (~> 1.0)
+    libddwaf (1.14.0.0.0-x86_64-linux)
       ffi (~> 1.0)
     memory_profiler (0.9.14)
     method_source (1.1.0)
@@ -144,6 +148,7 @@ GEM
 
 PLATFORMS
   aarch64-linux
+  x86_64-linux
 
 DEPENDENCIES
   appraisal (~> 2.4.0)

--- a/gemfiles/ruby_3.1_stripe_11.gemfile.lock
+++ b/gemfiles/ruby_3.1_stripe_11.gemfile.lock
@@ -49,12 +49,16 @@ GEM
     extlz4 (0.3.4)
     ffi (1.16.3)
     google-protobuf (3.25.4-aarch64-linux)
+    google-protobuf (3.25.4-x86_64-linux)
     hashdiff (1.1.1)
     json (2.7.2)
     json-schema (2.8.1)
       addressable (>= 2.4)
     libdatadog (11.0.0.1.0-aarch64-linux)
+    libdatadog (11.0.0.1.0-x86_64-linux)
     libddwaf (1.14.0.0.0-aarch64-linux)
+      ffi (~> 1.0)
+    libddwaf (1.14.0.0.0-x86_64-linux)
       ffi (~> 1.0)
     memory_profiler (0.9.14)
     method_source (1.1.0)
@@ -144,6 +148,7 @@ GEM
 
 PLATFORMS
   aarch64-linux
+  x86_64-linux
 
 DEPENDENCIES
   appraisal (~> 2.4.0)

--- a/gemfiles/ruby_3.1_stripe_12.gemfile.lock
+++ b/gemfiles/ruby_3.1_stripe_12.gemfile.lock
@@ -49,12 +49,16 @@ GEM
     extlz4 (0.3.4)
     ffi (1.16.3)
     google-protobuf (3.25.4-aarch64-linux)
+    google-protobuf (3.25.4-x86_64-linux)
     hashdiff (1.1.1)
     json (2.7.2)
     json-schema (2.8.1)
       addressable (>= 2.4)
     libdatadog (11.0.0.1.0-aarch64-linux)
+    libdatadog (11.0.0.1.0-x86_64-linux)
     libddwaf (1.14.0.0.0-aarch64-linux)
+      ffi (~> 1.0)
+    libddwaf (1.14.0.0.0-x86_64-linux)
       ffi (~> 1.0)
     memory_profiler (0.9.14)
     method_source (1.1.0)
@@ -144,6 +148,7 @@ GEM
 
 PLATFORMS
   aarch64-linux
+  x86_64-linux
 
 DEPENDENCIES
   appraisal (~> 2.4.0)

--- a/gemfiles/ruby_3.1_stripe_7.gemfile.lock
+++ b/gemfiles/ruby_3.1_stripe_7.gemfile.lock
@@ -49,12 +49,16 @@ GEM
     extlz4 (0.3.4)
     ffi (1.16.3)
     google-protobuf (3.25.4-aarch64-linux)
+    google-protobuf (3.25.4-x86_64-linux)
     hashdiff (1.1.1)
     json (2.7.2)
     json-schema (2.8.1)
       addressable (>= 2.4)
     libdatadog (11.0.0.1.0-aarch64-linux)
+    libdatadog (11.0.0.1.0-x86_64-linux)
     libddwaf (1.14.0.0.0-aarch64-linux)
+      ffi (~> 1.0)
+    libddwaf (1.14.0.0.0-x86_64-linux)
       ffi (~> 1.0)
     memory_profiler (0.9.14)
     method_source (1.1.0)
@@ -144,6 +148,7 @@ GEM
 
 PLATFORMS
   aarch64-linux
+  x86_64-linux
 
 DEPENDENCIES
   appraisal (~> 2.4.0)

--- a/gemfiles/ruby_3.1_stripe_8.gemfile.lock
+++ b/gemfiles/ruby_3.1_stripe_8.gemfile.lock
@@ -49,12 +49,16 @@ GEM
     extlz4 (0.3.4)
     ffi (1.16.3)
     google-protobuf (3.25.4-aarch64-linux)
+    google-protobuf (3.25.4-x86_64-linux)
     hashdiff (1.1.1)
     json (2.7.2)
     json-schema (2.8.1)
       addressable (>= 2.4)
     libdatadog (11.0.0.1.0-aarch64-linux)
+    libdatadog (11.0.0.1.0-x86_64-linux)
     libddwaf (1.14.0.0.0-aarch64-linux)
+      ffi (~> 1.0)
+    libddwaf (1.14.0.0.0-x86_64-linux)
       ffi (~> 1.0)
     memory_profiler (0.9.14)
     method_source (1.1.0)
@@ -144,6 +148,7 @@ GEM
 
 PLATFORMS
   aarch64-linux
+  x86_64-linux
 
 DEPENDENCIES
   appraisal (~> 2.4.0)

--- a/gemfiles/ruby_3.1_stripe_9.gemfile.lock
+++ b/gemfiles/ruby_3.1_stripe_9.gemfile.lock
@@ -49,12 +49,16 @@ GEM
     extlz4 (0.3.4)
     ffi (1.16.3)
     google-protobuf (3.25.4-aarch64-linux)
+    google-protobuf (3.25.4-x86_64-linux)
     hashdiff (1.1.1)
     json (2.7.2)
     json-schema (2.8.1)
       addressable (>= 2.4)
     libdatadog (11.0.0.1.0-aarch64-linux)
+    libdatadog (11.0.0.1.0-x86_64-linux)
     libddwaf (1.14.0.0.0-aarch64-linux)
+      ffi (~> 1.0)
+    libddwaf (1.14.0.0.0-x86_64-linux)
       ffi (~> 1.0)
     memory_profiler (0.9.14)
     method_source (1.1.0)
@@ -144,6 +148,7 @@ GEM
 
 PLATFORMS
   aarch64-linux
+  x86_64-linux
 
 DEPENDENCIES
   appraisal (~> 2.4.0)

--- a/gemfiles/ruby_3.2_stripe_10.gemfile.lock
+++ b/gemfiles/ruby_3.2_stripe_10.gemfile.lock
@@ -48,12 +48,16 @@ GEM
     extlz4 (0.3.4)
     ffi (1.16.3)
     google-protobuf (3.25.4-aarch64-linux)
+    google-protobuf (3.25.4-x86_64-linux)
     hashdiff (1.1.1)
     json (2.7.2)
     json-schema (2.8.1)
       addressable (>= 2.4)
     libdatadog (11.0.0.1.0-aarch64-linux)
+    libdatadog (11.0.0.1.0-x86_64-linux)
     libddwaf (1.14.0.0.0-aarch64-linux)
+      ffi (~> 1.0)
+    libddwaf (1.14.0.0.0-x86_64-linux)
       ffi (~> 1.0)
     memory_profiler (0.9.14)
     method_source (1.1.0)
@@ -140,6 +144,7 @@ GEM
 
 PLATFORMS
   aarch64-linux
+  x86_64-linux
 
 DEPENDENCIES
   appraisal (~> 2.4.0)

--- a/gemfiles/ruby_3.2_stripe_11.gemfile.lock
+++ b/gemfiles/ruby_3.2_stripe_11.gemfile.lock
@@ -48,12 +48,16 @@ GEM
     extlz4 (0.3.4)
     ffi (1.16.3)
     google-protobuf (3.25.4-aarch64-linux)
+    google-protobuf (3.25.4-x86_64-linux)
     hashdiff (1.1.1)
     json (2.7.2)
     json-schema (2.8.1)
       addressable (>= 2.4)
     libdatadog (11.0.0.1.0-aarch64-linux)
+    libdatadog (11.0.0.1.0-x86_64-linux)
     libddwaf (1.14.0.0.0-aarch64-linux)
+      ffi (~> 1.0)
+    libddwaf (1.14.0.0.0-x86_64-linux)
       ffi (~> 1.0)
     memory_profiler (0.9.14)
     method_source (1.1.0)
@@ -140,6 +144,7 @@ GEM
 
 PLATFORMS
   aarch64-linux
+  x86_64-linux
 
 DEPENDENCIES
   appraisal (~> 2.4.0)

--- a/gemfiles/ruby_3.2_stripe_12.gemfile.lock
+++ b/gemfiles/ruby_3.2_stripe_12.gemfile.lock
@@ -48,12 +48,16 @@ GEM
     extlz4 (0.3.4)
     ffi (1.16.3)
     google-protobuf (3.25.4-aarch64-linux)
+    google-protobuf (3.25.4-x86_64-linux)
     hashdiff (1.1.1)
     json (2.7.2)
     json-schema (2.8.1)
       addressable (>= 2.4)
     libdatadog (11.0.0.1.0-aarch64-linux)
+    libdatadog (11.0.0.1.0-x86_64-linux)
     libddwaf (1.14.0.0.0-aarch64-linux)
+      ffi (~> 1.0)
+    libddwaf (1.14.0.0.0-x86_64-linux)
       ffi (~> 1.0)
     memory_profiler (0.9.14)
     method_source (1.1.0)
@@ -140,6 +144,7 @@ GEM
 
 PLATFORMS
   aarch64-linux
+  x86_64-linux
 
 DEPENDENCIES
   appraisal (~> 2.4.0)

--- a/gemfiles/ruby_3.2_stripe_7.gemfile.lock
+++ b/gemfiles/ruby_3.2_stripe_7.gemfile.lock
@@ -48,12 +48,16 @@ GEM
     extlz4 (0.3.4)
     ffi (1.16.3)
     google-protobuf (3.25.4-aarch64-linux)
+    google-protobuf (3.25.4-x86_64-linux)
     hashdiff (1.1.1)
     json (2.7.2)
     json-schema (2.8.1)
       addressable (>= 2.4)
     libdatadog (11.0.0.1.0-aarch64-linux)
+    libdatadog (11.0.0.1.0-x86_64-linux)
     libddwaf (1.14.0.0.0-aarch64-linux)
+      ffi (~> 1.0)
+    libddwaf (1.14.0.0.0-x86_64-linux)
       ffi (~> 1.0)
     memory_profiler (0.9.14)
     method_source (1.1.0)
@@ -140,6 +144,7 @@ GEM
 
 PLATFORMS
   aarch64-linux
+  x86_64-linux
 
 DEPENDENCIES
   appraisal (~> 2.4.0)

--- a/gemfiles/ruby_3.2_stripe_8.gemfile.lock
+++ b/gemfiles/ruby_3.2_stripe_8.gemfile.lock
@@ -48,12 +48,16 @@ GEM
     extlz4 (0.3.4)
     ffi (1.16.3)
     google-protobuf (3.25.4-aarch64-linux)
+    google-protobuf (3.25.4-x86_64-linux)
     hashdiff (1.1.1)
     json (2.7.2)
     json-schema (2.8.1)
       addressable (>= 2.4)
     libdatadog (11.0.0.1.0-aarch64-linux)
+    libdatadog (11.0.0.1.0-x86_64-linux)
     libddwaf (1.14.0.0.0-aarch64-linux)
+      ffi (~> 1.0)
+    libddwaf (1.14.0.0.0-x86_64-linux)
       ffi (~> 1.0)
     memory_profiler (0.9.14)
     method_source (1.1.0)
@@ -140,6 +144,7 @@ GEM
 
 PLATFORMS
   aarch64-linux
+  x86_64-linux
 
 DEPENDENCIES
   appraisal (~> 2.4.0)

--- a/gemfiles/ruby_3.2_stripe_9.gemfile.lock
+++ b/gemfiles/ruby_3.2_stripe_9.gemfile.lock
@@ -48,12 +48,16 @@ GEM
     extlz4 (0.3.4)
     ffi (1.16.3)
     google-protobuf (3.25.4-aarch64-linux)
+    google-protobuf (3.25.4-x86_64-linux)
     hashdiff (1.1.1)
     json (2.7.2)
     json-schema (2.8.1)
       addressable (>= 2.4)
     libdatadog (11.0.0.1.0-aarch64-linux)
+    libdatadog (11.0.0.1.0-x86_64-linux)
     libddwaf (1.14.0.0.0-aarch64-linux)
+      ffi (~> 1.0)
+    libddwaf (1.14.0.0.0-x86_64-linux)
       ffi (~> 1.0)
     memory_profiler (0.9.14)
     method_source (1.1.0)
@@ -140,6 +144,7 @@ GEM
 
 PLATFORMS
   aarch64-linux
+  x86_64-linux
 
 DEPENDENCIES
   appraisal (~> 2.4.0)

--- a/gemfiles/ruby_3.3_activesupport.gemfile
+++ b/gemfiles/ruby_3.3_activesupport.gemfile
@@ -32,6 +32,8 @@ gem "rubocop", "~> 1.50.0", require: false
 gem "rubocop-packaging", "~> 0.5.2", require: false
 gem "rubocop-performance", "~> 1.9", require: false
 gem "rubocop-rspec", ["~> 2.20", "< 2.21"], require: false
+gem "fiddle"
+gem "ostruct"
 gem "dogstatsd-ruby", ">= 3.3.0", "!= 5.0.0", "!= 5.0.1", "!= 5.1.0"
 gem "google-protobuf", ["~> 3.0", "!= 3.7.0", "!= 3.7.1"]
 gem "ffi", "~> 1.16.3", require: false

--- a/gemfiles/ruby_3.3_activesupport.gemfile.lock
+++ b/gemfiles/ruby_3.3_activesupport.gemfile.lock
@@ -89,6 +89,7 @@ GEM
     erubi (1.12.0)
     extlz4 (0.3.4)
     ffi (1.16.3)
+    fiddle (1.1.2)
     google-protobuf (3.24.3)
     grape (1.8.0)
       activesupport (>= 5)
@@ -132,6 +133,7 @@ GEM
       mini_portile2 (~> 2.8.2)
       racc (~> 1.4)
     os (1.1.4)
+    ostruct (0.6.0)
     parallel (1.23.0)
     parser (3.2.2.3)
       ast (~> 2.4.1)
@@ -262,12 +264,14 @@ DEPENDENCIES
   dogstatsd-ruby (>= 3.3.0, != 5.1.0, != 5.0.1, != 5.0.0)
   extlz4 (~> 0.3, >= 0.3.3)
   ffi (~> 1.16.3)
+  fiddle
   google-protobuf (~> 3.0, != 3.7.1, != 3.7.0)
   grape
   json-schema (< 3)
   lograge
   memory_profiler (~> 0.9)
   os (~> 1.1)
+  ostruct
   pimpmychangelog (>= 0.1.2)
   pry
   pry-stack_explorer

--- a/gemfiles/ruby_3.3_aws.gemfile
+++ b/gemfiles/ruby_3.3_aws.gemfile
@@ -32,6 +32,8 @@ gem "rubocop", "~> 1.50.0", require: false
 gem "rubocop-packaging", "~> 0.5.2", require: false
 gem "rubocop-performance", "~> 1.9", require: false
 gem "rubocop-rspec", ["~> 2.20", "< 2.21"], require: false
+gem "fiddle"
+gem "ostruct"
 gem "dogstatsd-ruby", ">= 3.3.0", "!= 5.0.0", "!= 5.0.1", "!= 5.1.0"
 gem "google-protobuf", ["~> 3.0", "!= 3.7.0", "!= 3.7.1"]
 gem "ffi", "~> 1.16.3", require: false

--- a/gemfiles/ruby_3.3_aws.gemfile.lock
+++ b/gemfiles/ruby_3.3_aws.gemfile.lock
@@ -1465,6 +1465,7 @@ GEM
     dogstatsd-ruby (5.6.0)
     extlz4 (0.3.4)
     ffi (1.16.3)
+    fiddle (1.1.2)
     google-protobuf (3.24.2)
     hashdiff (1.0.1)
     jmespath (1.6.2)
@@ -1481,6 +1482,7 @@ GEM
     method_source (1.0.0)
     msgpack (1.7.2)
     os (1.1.4)
+    ostruct (0.6.0)
     parallel (1.23.0)
     parser (3.2.2.3)
       ast (~> 2.4.1)
@@ -1578,10 +1580,12 @@ DEPENDENCIES
   dogstatsd-ruby (>= 3.3.0, != 5.1.0, != 5.0.1, != 5.0.0)
   extlz4 (~> 0.3, >= 0.3.3)
   ffi (~> 1.16.3)
+  fiddle
   google-protobuf (~> 3.0, != 3.7.1, != 3.7.0)
   json-schema (< 3)
   memory_profiler (~> 0.9)
   os (~> 1.1)
+  ostruct
   pimpmychangelog (>= 0.1.2)
   pry
   pry-stack_explorer

--- a/gemfiles/ruby_3.3_contrib.gemfile
+++ b/gemfiles/ruby_3.3_contrib.gemfile
@@ -32,6 +32,8 @@ gem "rubocop", "~> 1.50.0", require: false
 gem "rubocop-packaging", "~> 0.5.2", require: false
 gem "rubocop-performance", "~> 1.9", require: false
 gem "rubocop-rspec", ["~> 2.20", "< 2.21"], require: false
+gem "fiddle"
+gem "ostruct"
 gem "dogstatsd-ruby", ">= 3.3.0", "!= 5.0.0", "!= 5.0.1", "!= 5.1.0"
 gem "google-protobuf", ["~> 3.0", "!= 3.7.0", "!= 3.7.1"]
 gem "ffi", "~> 1.16.3", require: false

--- a/gemfiles/ruby_3.3_contrib.gemfile.lock
+++ b/gemfiles/ruby_3.3_contrib.gemfile.lock
@@ -51,6 +51,7 @@ GEM
     dogstatsd-ruby (5.5.0)
     extlz4 (0.3.3)
     ffi (1.16.3)
+    fiddle (1.1.2)
     google-protobuf (3.23.1)
     googleapis-common-protos-types (1.6.0)
       google-protobuf (~> 3.14)
@@ -77,6 +78,7 @@ GEM
     mustermann (3.0.0)
       ruby2_keywords (~> 0.0.1)
     os (1.1.4)
+    ostruct (0.6.0)
     parallel (1.23.0)
     parser (3.2.2.1)
       ast (~> 2.4.1)
@@ -217,12 +219,14 @@ DEPENDENCIES
   dogstatsd-ruby (>= 3.3.0, != 5.1.0, != 5.0.1, != 5.0.0)
   extlz4 (~> 0.3, >= 0.3.3)
   ffi (~> 1.16.3)
+  fiddle
   google-protobuf (~> 3.0, != 3.7.1, != 3.7.0)
   grpc (>= 1.38.0)
   json-schema (< 3)
   memory_profiler (~> 0.9)
   mongo (>= 2.8.0, < 2.15.0)
   os (~> 1.1)
+  ostruct
   pimpmychangelog (>= 0.1.2)
   pry
   pry-stack_explorer

--- a/gemfiles/ruby_3.3_contrib_old.gemfile
+++ b/gemfiles/ruby_3.3_contrib_old.gemfile
@@ -32,6 +32,8 @@ gem "rubocop", "~> 1.50.0", require: false
 gem "rubocop-packaging", "~> 0.5.2", require: false
 gem "rubocop-performance", "~> 1.9", require: false
 gem "rubocop-rspec", ["~> 2.20", "< 2.21"], require: false
+gem "fiddle"
+gem "ostruct"
 gem "dogstatsd-ruby", ">= 3.3.0", "!= 5.0.0", "!= 5.0.1", "!= 5.1.0"
 gem "google-protobuf", ["~> 3.0", "!= 3.7.0", "!= 3.7.1"]
 gem "ffi", "~> 1.16.3", require: false

--- a/gemfiles/ruby_3.3_contrib_old.gemfile.lock
+++ b/gemfiles/ruby_3.3_contrib_old.gemfile.lock
@@ -54,6 +54,7 @@ GEM
     faraday_middleware (0.12.2)
       faraday (>= 0.7.4, < 1.0)
     ffi (1.16.3)
+    fiddle (1.1.2)
     google-protobuf (3.23.1)
     hashdiff (1.0.1)
     hitimes (1.3.1)
@@ -77,6 +78,7 @@ GEM
     mustermann (1.1.2)
       ruby2_keywords (~> 0.0.1)
     os (1.1.4)
+    ostruct (0.6.0)
     parallel (1.23.0)
     parser (3.2.2.1)
       ast (~> 2.4.1)
@@ -204,10 +206,12 @@ DEPENDENCIES
   dogstatsd-ruby (>= 3.3.0, != 5.1.0, != 5.0.1, != 5.0.0)
   extlz4 (~> 0.3, >= 0.3.3)
   ffi (~> 1.16.3)
+  fiddle
   google-protobuf (~> 3.0, != 3.7.1, != 3.7.0)
   json-schema (< 3)
   memory_profiler (~> 0.9)
   os (~> 1.1)
+  ostruct
   pimpmychangelog (>= 0.1.2)
   presto-client (>= 0.5.14)
   pry

--- a/gemfiles/ruby_3.3_core_old.gemfile
+++ b/gemfiles/ruby_3.3_core_old.gemfile
@@ -32,6 +32,8 @@ gem "rubocop", "~> 1.50.0", require: false
 gem "rubocop-packaging", "~> 0.5.2", require: false
 gem "rubocop-performance", "~> 1.9", require: false
 gem "rubocop-rspec", ["~> 2.20", "< 2.21"], require: false
+gem "fiddle"
+gem "ostruct"
 gem "dogstatsd-ruby", "~> 4"
 gem "google-protobuf", ["~> 3.0", "!= 3.7.0", "!= 3.7.1"]
 gem "ffi", "~> 1.16.3", require: false

--- a/gemfiles/ruby_3.3_core_old.gemfile.lock
+++ b/gemfiles/ruby_3.3_core_old.gemfile.lock
@@ -44,6 +44,7 @@ GEM
     dogstatsd-ruby (4.8.3)
     extlz4 (0.3.3)
     ffi (1.16.3)
+    fiddle (1.1.2)
     google-protobuf (3.23.1)
     hashdiff (1.0.1)
     json (2.6.3)
@@ -59,6 +60,7 @@ GEM
     method_source (1.0.0)
     msgpack (1.7.2)
     os (1.1.4)
+    ostruct (0.6.0)
     parallel (1.23.0)
     parser (3.2.2.1)
       ast (~> 2.4.1)
@@ -149,10 +151,12 @@ DEPENDENCIES
   dogstatsd-ruby (~> 4)
   extlz4 (~> 0.3, >= 0.3.3)
   ffi (~> 1.16.3)
+  fiddle
   google-protobuf (~> 3.0, != 3.7.1, != 3.7.0)
   json-schema (< 3)
   memory_profiler (~> 0.9)
   os (~> 1.1)
+  ostruct
   pimpmychangelog (>= 0.1.2)
   pry
   pry-stack_explorer

--- a/gemfiles/ruby_3.3_elasticsearch_7.gemfile
+++ b/gemfiles/ruby_3.3_elasticsearch_7.gemfile
@@ -32,6 +32,8 @@ gem "rubocop", "~> 1.50.0", require: false
 gem "rubocop-packaging", "~> 0.5.2", require: false
 gem "rubocop-performance", "~> 1.9", require: false
 gem "rubocop-rspec", ["~> 2.20", "< 2.21"], require: false
+gem "fiddle"
+gem "ostruct"
 gem "dogstatsd-ruby", ">= 3.3.0", "!= 5.0.0", "!= 5.0.1", "!= 5.1.0"
 gem "google-protobuf", ["~> 3.0", "!= 3.7.0", "!= 3.7.1"]
 gem "ffi", "~> 1.16.3", require: false

--- a/gemfiles/ruby_3.3_elasticsearch_7.gemfile.lock
+++ b/gemfiles/ruby_3.3_elasticsearch_7.gemfile.lock
@@ -76,6 +76,7 @@ GEM
     faraday-rack (1.0.0)
     faraday-retry (1.0.3)
     ffi (1.16.3)
+    fiddle (1.1.2)
     google-protobuf (3.24.4)
     hashdiff (1.0.1)
     json (2.6.3)
@@ -93,6 +94,7 @@ GEM
     multi_json (1.15.0)
     multipart-post (2.3.0)
     os (1.1.4)
+    ostruct (0.6.0)
     parallel (1.23.0)
     parser (3.2.2.4)
       ast (~> 2.4.1)
@@ -188,10 +190,12 @@ DEPENDENCIES
   elasticsearch (~> 7)
   extlz4 (~> 0.3, >= 0.3.3)
   ffi (~> 1.16.3)
+  fiddle
   google-protobuf (~> 3.0, != 3.7.1, != 3.7.0)
   json-schema (< 3)
   memory_profiler (~> 0.9)
   os (~> 1.1)
+  ostruct
   pimpmychangelog (>= 0.1.2)
   pry
   pry-stack_explorer

--- a/gemfiles/ruby_3.3_elasticsearch_8.gemfile
+++ b/gemfiles/ruby_3.3_elasticsearch_8.gemfile
@@ -32,6 +32,8 @@ gem "rubocop", "~> 1.50.0", require: false
 gem "rubocop-packaging", "~> 0.5.2", require: false
 gem "rubocop-performance", "~> 1.9", require: false
 gem "rubocop-rspec", ["~> 2.20", "< 2.21"], require: false
+gem "fiddle"
+gem "ostruct"
 gem "dogstatsd-ruby", ">= 3.3.0", "!= 5.0.0", "!= 5.0.1", "!= 5.1.0"
 gem "google-protobuf", ["~> 3.0", "!= 3.7.0", "!= 3.7.1"]
 gem "ffi", "~> 1.16.3", require: false

--- a/gemfiles/ruby_3.3_elasticsearch_8.gemfile.lock
+++ b/gemfiles/ruby_3.3_elasticsearch_8.gemfile.lock
@@ -59,6 +59,7 @@ GEM
       ruby2_keywords (>= 0.0.4)
     faraday-net_http (3.0.2)
     ffi (1.16.3)
+    fiddle (1.1.2)
     google-protobuf (3.24.4)
     hashdiff (1.0.1)
     json (2.6.3)
@@ -75,6 +76,7 @@ GEM
     msgpack (1.7.2)
     multi_json (1.15.0)
     os (1.1.4)
+    ostruct (0.6.0)
     parallel (1.23.0)
     parser (3.2.2.4)
       ast (~> 2.4.1)
@@ -170,10 +172,12 @@ DEPENDENCIES
   elasticsearch (~> 8)
   extlz4 (~> 0.3, >= 0.3.3)
   ffi (~> 1.16.3)
+  fiddle
   google-protobuf (~> 3.0, != 3.7.1, != 3.7.0)
   json-schema (< 3)
   memory_profiler (~> 0.9)
   os (~> 1.1)
+  ostruct
   pimpmychangelog (>= 0.1.2)
   pry
   pry-stack_explorer

--- a/gemfiles/ruby_3.3_graphql_1.13.gemfile
+++ b/gemfiles/ruby_3.3_graphql_1.13.gemfile
@@ -32,6 +32,8 @@ gem "rubocop", "~> 1.50.0", require: false
 gem "rubocop-packaging", "~> 0.5.2", require: false
 gem "rubocop-performance", "~> 1.9", require: false
 gem "rubocop-rspec", ["~> 2.20", "< 2.21"], require: false
+gem "fiddle"
+gem "ostruct"
 gem "dogstatsd-ruby", ">= 3.3.0", "!= 5.0.0", "!= 5.0.1", "!= 5.1.0"
 gem "google-protobuf", ["~> 3.0", "!= 3.7.0", "!= 3.7.1"]
 gem "ffi", "~> 1.16.3", require: false

--- a/gemfiles/ruby_3.3_graphql_1.13.gemfile.lock
+++ b/gemfiles/ruby_3.3_graphql_1.13.gemfile.lock
@@ -108,6 +108,7 @@ GEM
     erubi (1.13.0)
     extlz4 (0.3.4)
     ffi (1.16.3)
+    fiddle (1.1.2)
     globalid (1.2.1)
       activesupport (>= 6.1)
     google-protobuf (3.25.2)
@@ -158,6 +159,7 @@ GEM
     nokogiri (1.16.6-x86_64-linux)
       racc (~> 1.4)
     os (1.1.4)
+    ostruct (0.6.0)
     parallel (1.24.0)
     parser (3.3.0.5)
       ast (~> 2.4.1)
@@ -299,12 +301,14 @@ DEPENDENCIES
   dogstatsd-ruby (>= 3.3.0, != 5.1.0, != 5.0.1, != 5.0.0)
   extlz4 (~> 0.3, >= 0.3.3)
   ffi (~> 1.16.3)
+  fiddle
   google-protobuf (~> 3.0, != 3.7.1, != 3.7.0)
   graphql (~> 1.13.0)
   json-schema (< 3)
   lograge (~> 0.11)
   memory_profiler (~> 0.9)
   os (~> 1.1)
+  ostruct
   pimpmychangelog (>= 0.1.2)
   pry
   pry-stack_explorer
@@ -329,4 +333,4 @@ DEPENDENCIES
   yard (~> 0.9)
 
 BUNDLED WITH
-   2.3.27
+   2.3.26

--- a/gemfiles/ruby_3.3_graphql_2.0.gemfile
+++ b/gemfiles/ruby_3.3_graphql_2.0.gemfile
@@ -32,6 +32,8 @@ gem "rubocop", "~> 1.50.0", require: false
 gem "rubocop-packaging", "~> 0.5.2", require: false
 gem "rubocop-performance", "~> 1.9", require: false
 gem "rubocop-rspec", ["~> 2.20", "< 2.21"], require: false
+gem "fiddle"
+gem "ostruct"
 gem "dogstatsd-ruby", ">= 3.3.0", "!= 5.0.0", "!= 5.0.1", "!= 5.1.0"
 gem "google-protobuf", ["~> 3.0", "!= 3.7.0", "!= 3.7.1"]
 gem "ffi", "~> 1.16.3", require: false

--- a/gemfiles/ruby_3.3_graphql_2.0.gemfile.lock
+++ b/gemfiles/ruby_3.3_graphql_2.0.gemfile.lock
@@ -108,6 +108,7 @@ GEM
     erubi (1.13.0)
     extlz4 (0.3.4)
     ffi (1.16.3)
+    fiddle (1.1.2)
     globalid (1.2.1)
       activesupport (>= 6.1)
     google-protobuf (3.25.2)
@@ -158,6 +159,7 @@ GEM
     nokogiri (1.16.6-x86_64-linux)
       racc (~> 1.4)
     os (1.1.4)
+    ostruct (0.6.0)
     parallel (1.24.0)
     parser (3.3.0.5)
       ast (~> 2.4.1)
@@ -299,12 +301,14 @@ DEPENDENCIES
   dogstatsd-ruby (>= 3.3.0, != 5.1.0, != 5.0.1, != 5.0.0)
   extlz4 (~> 0.3, >= 0.3.3)
   ffi (~> 1.16.3)
+  fiddle
   google-protobuf (~> 3.0, != 3.7.1, != 3.7.0)
   graphql (~> 2.0.0)
   json-schema (< 3)
   lograge (~> 0.11)
   memory_profiler (~> 0.9)
   os (~> 1.1)
+  ostruct
   pimpmychangelog (>= 0.1.2)
   pry
   pry-stack_explorer
@@ -329,4 +333,4 @@ DEPENDENCIES
   yard (~> 0.9)
 
 BUNDLED WITH
-   2.3.27
+   2.3.26

--- a/gemfiles/ruby_3.3_graphql_2.1.gemfile
+++ b/gemfiles/ruby_3.3_graphql_2.1.gemfile
@@ -32,6 +32,8 @@ gem "rubocop", "~> 1.50.0", require: false
 gem "rubocop-packaging", "~> 0.5.2", require: false
 gem "rubocop-performance", "~> 1.9", require: false
 gem "rubocop-rspec", ["~> 2.20", "< 2.21"], require: false
+gem "fiddle"
+gem "ostruct"
 gem "dogstatsd-ruby", ">= 3.3.0", "!= 5.0.0", "!= 5.0.1", "!= 5.1.0"
 gem "google-protobuf", ["~> 3.0", "!= 3.7.0", "!= 3.7.1"]
 gem "ffi", "~> 1.16.3", require: false

--- a/gemfiles/ruby_3.3_graphql_2.1.gemfile.lock
+++ b/gemfiles/ruby_3.3_graphql_2.1.gemfile.lock
@@ -108,6 +108,7 @@ GEM
     erubi (1.13.0)
     extlz4 (0.3.4)
     ffi (1.16.3)
+    fiddle (1.1.2)
     globalid (1.2.1)
       activesupport (>= 6.1)
     google-protobuf (3.25.2)
@@ -159,6 +160,7 @@ GEM
     nokogiri (1.16.6-x86_64-linux)
       racc (~> 1.4)
     os (1.1.4)
+    ostruct (0.6.0)
     parallel (1.24.0)
     parser (3.3.0.5)
       ast (~> 2.4.1)
@@ -300,12 +302,14 @@ DEPENDENCIES
   dogstatsd-ruby (>= 3.3.0, != 5.1.0, != 5.0.1, != 5.0.0)
   extlz4 (~> 0.3, >= 0.3.3)
   ffi (~> 1.16.3)
+  fiddle
   google-protobuf (~> 3.0, != 3.7.1, != 3.7.0)
   graphql (~> 2.1.0)
   json-schema (< 3)
   lograge (~> 0.11)
   memory_profiler (~> 0.9)
   os (~> 1.1)
+  ostruct
   pimpmychangelog (>= 0.1.2)
   pry
   pry-stack_explorer
@@ -330,4 +334,4 @@ DEPENDENCIES
   yard (~> 0.9)
 
 BUNDLED WITH
-   2.3.27
+   2.3.26

--- a/gemfiles/ruby_3.3_graphql_2.2.gemfile
+++ b/gemfiles/ruby_3.3_graphql_2.2.gemfile
@@ -32,6 +32,8 @@ gem "rubocop", "~> 1.50.0", require: false
 gem "rubocop-packaging", "~> 0.5.2", require: false
 gem "rubocop-performance", "~> 1.9", require: false
 gem "rubocop-rspec", ["~> 2.20", "< 2.21"], require: false
+gem "fiddle"
+gem "ostruct"
 gem "dogstatsd-ruby", ">= 3.3.0", "!= 5.0.0", "!= 5.0.1", "!= 5.1.0"
 gem "google-protobuf", ["~> 3.0", "!= 3.7.0", "!= 3.7.1"]
 gem "ffi", "~> 1.16.3", require: false

--- a/gemfiles/ruby_3.3_graphql_2.2.gemfile.lock
+++ b/gemfiles/ruby_3.3_graphql_2.2.gemfile.lock
@@ -108,6 +108,7 @@ GEM
     erubi (1.13.0)
     extlz4 (0.3.4)
     ffi (1.16.3)
+    fiddle (1.1.2)
     globalid (1.2.1)
       activesupport (>= 6.1)
     google-protobuf (3.25.2)
@@ -159,6 +160,7 @@ GEM
     nokogiri (1.16.6-x86_64-linux)
       racc (~> 1.4)
     os (1.1.4)
+    ostruct (0.6.0)
     parallel (1.24.0)
     parser (3.3.0.5)
       ast (~> 2.4.1)
@@ -300,12 +302,14 @@ DEPENDENCIES
   dogstatsd-ruby (>= 3.3.0, != 5.1.0, != 5.0.1, != 5.0.0)
   extlz4 (~> 0.3, >= 0.3.3)
   ffi (~> 1.16.3)
+  fiddle
   google-protobuf (~> 3.0, != 3.7.1, != 3.7.0)
   graphql (~> 2.2.0)
   json-schema (< 3)
   lograge (~> 0.11)
   memory_profiler (~> 0.9)
   os (~> 1.1)
+  ostruct
   pimpmychangelog (>= 0.1.2)
   pry
   pry-stack_explorer
@@ -330,4 +334,4 @@ DEPENDENCIES
   yard (~> 0.9)
 
 BUNDLED WITH
-   2.3.27
+   2.3.26

--- a/gemfiles/ruby_3.3_graphql_2.3.gemfile
+++ b/gemfiles/ruby_3.3_graphql_2.3.gemfile
@@ -32,6 +32,8 @@ gem "rubocop", "~> 1.50.0", require: false
 gem "rubocop-packaging", "~> 0.5.2", require: false
 gem "rubocop-performance", "~> 1.9", require: false
 gem "rubocop-rspec", ["~> 2.20", "< 2.21"], require: false
+gem "fiddle"
+gem "ostruct"
 gem "dogstatsd-ruby", ">= 3.3.0", "!= 5.0.0", "!= 5.0.1", "!= 5.1.0"
 gem "google-protobuf", ["~> 3.0", "!= 3.7.0", "!= 3.7.1"]
 gem "ffi", "~> 1.16.3", require: false

--- a/gemfiles/ruby_3.3_graphql_2.3.gemfile.lock
+++ b/gemfiles/ruby_3.3_graphql_2.3.gemfile.lock
@@ -110,6 +110,7 @@ GEM
     erubi (1.13.0)
     extlz4 (0.3.4)
     ffi (1.16.3)
+    fiddle (1.1.2)
     globalid (1.2.1)
       activesupport (>= 6.1)
     google-protobuf (3.25.3-aarch64-linux)
@@ -162,6 +163,7 @@ GEM
     nokogiri (1.16.6-x86_64-linux)
       racc (~> 1.4)
     os (1.1.4)
+    ostruct (0.6.0)
     parallel (1.25.1)
     parser (3.3.3.0)
       ast (~> 2.4.1)
@@ -303,12 +305,14 @@ DEPENDENCIES
   dogstatsd-ruby (>= 3.3.0, != 5.1.0, != 5.0.1, != 5.0.0)
   extlz4 (~> 0.3, >= 0.3.3)
   ffi (~> 1.16.3)
+  fiddle
   google-protobuf (~> 3.0, != 3.7.1, != 3.7.0)
   graphql (~> 2.3.0)
   json-schema (< 3)
   lograge (~> 0.11)
   memory_profiler (~> 0.9)
   os (~> 1.1)
+  ostruct
   pimpmychangelog (>= 0.1.2)
   pry
   pry-stack_explorer

--- a/gemfiles/ruby_3.3_http.gemfile
+++ b/gemfiles/ruby_3.3_http.gemfile
@@ -32,6 +32,8 @@ gem "rubocop", "~> 1.50.0", require: false
 gem "rubocop-packaging", "~> 0.5.2", require: false
 gem "rubocop-performance", "~> 1.9", require: false
 gem "rubocop-rspec", ["~> 2.20", "< 2.21"], require: false
+gem "fiddle"
+gem "ostruct"
 gem "dogstatsd-ruby", ">= 3.3.0", "!= 5.0.0", "!= 5.0.1", "!= 5.1.0"
 gem "google-protobuf", ["~> 3.0", "!= 3.7.0", "!= 3.7.1"]
 gem "ffi", "~> 1.16.3", require: false

--- a/gemfiles/ruby_3.3_http.gemfile.lock
+++ b/gemfiles/ruby_3.3_http.gemfile.lock
@@ -56,6 +56,7 @@ GEM
     ffi-compiler (1.0.1)
       ffi (>= 1.0.0)
       rake
+    fiddle (1.1.2)
     google-protobuf (3.24.3)
     hashdiff (1.0.1)
     http (5.0.1)
@@ -88,6 +89,7 @@ GEM
     msgpack (1.7.2)
     netrc (0.11.0)
     os (1.1.4)
+    ostruct (0.6.0)
     parallel (1.23.0)
     parser (3.2.2.3)
       ast (~> 2.4.1)
@@ -194,12 +196,14 @@ DEPENDENCIES
   extlz4 (~> 0.3, >= 0.3.3)
   faraday
   ffi (~> 1.16.3)
+  fiddle
   google-protobuf (~> 3.0, != 3.7.1, != 3.7.0)
   http
   httpclient
   json-schema (< 3)
   memory_profiler (~> 0.9)
   os (~> 1.1)
+  ostruct
   pimpmychangelog (>= 0.1.2)
   pry
   pry-stack_explorer

--- a/gemfiles/ruby_3.3_opensearch_2.gemfile
+++ b/gemfiles/ruby_3.3_opensearch_2.gemfile
@@ -32,6 +32,8 @@ gem "rubocop", "~> 1.50.0", require: false
 gem "rubocop-packaging", "~> 0.5.2", require: false
 gem "rubocop-performance", "~> 1.9", require: false
 gem "rubocop-rspec", ["~> 2.20", "< 2.21"], require: false
+gem "fiddle"
+gem "ostruct"
 gem "dogstatsd-ruby", ">= 3.3.0", "!= 5.0.0", "!= 5.0.1", "!= 5.1.0"
 gem "google-protobuf", ["~> 3.0", "!= 3.7.0", "!= 3.7.1"]
 gem "ffi", "~> 1.16.3", require: false

--- a/gemfiles/ruby_3.3_opensearch_2.gemfile.lock
+++ b/gemfiles/ruby_3.3_opensearch_2.gemfile.lock
@@ -51,6 +51,7 @@ GEM
       ruby2_keywords (>= 0.0.4)
     faraday-net_http (3.0.2)
     ffi (1.16.3)
+    fiddle (1.1.2)
     google-protobuf (3.24.4)
     hashdiff (1.0.1)
     json (2.6.3)
@@ -75,6 +76,7 @@ GEM
       faraday (>= 1.0, < 3)
       multi_json
     os (1.1.4)
+    ostruct (0.6.0)
     parallel (1.23.0)
     parser (3.2.2.4)
       ast (~> 2.4.1)
@@ -169,11 +171,13 @@ DEPENDENCIES
   dogstatsd-ruby (>= 3.3.0, != 5.1.0, != 5.0.1, != 5.0.0)
   extlz4 (~> 0.3, >= 0.3.3)
   ffi (~> 1.16.3)
+  fiddle
   google-protobuf (~> 3.0, != 3.7.1, != 3.7.0)
   json-schema (< 3)
   memory_profiler (~> 0.9)
   opensearch-ruby (~> 2)
   os (~> 1.1)
+  ostruct
   pimpmychangelog (>= 0.1.2)
   pry
   pry-stack_explorer

--- a/gemfiles/ruby_3.3_opensearch_3.gemfile
+++ b/gemfiles/ruby_3.3_opensearch_3.gemfile
@@ -32,6 +32,8 @@ gem "rubocop", "~> 1.50.0", require: false
 gem "rubocop-packaging", "~> 0.5.2", require: false
 gem "rubocop-performance", "~> 1.9", require: false
 gem "rubocop-rspec", ["~> 2.20", "< 2.21"], require: false
+gem "fiddle"
+gem "ostruct"
 gem "dogstatsd-ruby", ">= 3.3.0", "!= 5.0.0", "!= 5.0.1", "!= 5.1.0"
 gem "google-protobuf", ["~> 3.0", "!= 3.7.0", "!= 3.7.1"]
 gem "ffi", "~> 1.16.3", require: false

--- a/gemfiles/ruby_3.3_opensearch_3.gemfile.lock
+++ b/gemfiles/ruby_3.3_opensearch_3.gemfile.lock
@@ -51,6 +51,7 @@ GEM
       ruby2_keywords (>= 0.0.4)
     faraday-net_http (3.0.2)
     ffi (1.16.3)
+    fiddle (1.1.2)
     google-protobuf (3.24.4)
     hashdiff (1.0.1)
     json (2.6.3)
@@ -70,6 +71,7 @@ GEM
       faraday (>= 1.0, < 3)
       multi_json (>= 1.0)
     os (1.1.4)
+    ostruct (0.6.0)
     parallel (1.23.0)
     parser (3.2.2.4)
       ast (~> 2.4.1)
@@ -164,11 +166,13 @@ DEPENDENCIES
   dogstatsd-ruby (>= 3.3.0, != 5.1.0, != 5.0.1, != 5.0.0)
   extlz4 (~> 0.3, >= 0.3.3)
   ffi (~> 1.16.3)
+  fiddle
   google-protobuf (~> 3.0, != 3.7.1, != 3.7.0)
   json-schema (< 3)
   memory_profiler (~> 0.9)
   opensearch-ruby (~> 3)
   os (~> 1.1)
+  ostruct
   pimpmychangelog (>= 0.1.2)
   pry
   pry-stack_explorer

--- a/gemfiles/ruby_3.3_opentelemetry.gemfile
+++ b/gemfiles/ruby_3.3_opentelemetry.gemfile
@@ -32,6 +32,8 @@ gem "rubocop", "~> 1.50.0", require: false
 gem "rubocop-packaging", "~> 0.5.2", require: false
 gem "rubocop-performance", "~> 1.9", require: false
 gem "rubocop-rspec", ["~> 2.20", "< 2.21"], require: false
+gem "fiddle"
+gem "ostruct"
 gem "dogstatsd-ruby", ">= 3.3.0", "!= 5.0.0", "!= 5.0.1", "!= 5.1.0"
 gem "google-protobuf", ["~> 3.0", "!= 3.7.0", "!= 3.7.1"]
 gem "ffi", "~> 1.16.3", require: false

--- a/gemfiles/ruby_3.3_opentelemetry.gemfile.lock
+++ b/gemfiles/ruby_3.3_opentelemetry.gemfile.lock
@@ -44,6 +44,7 @@ GEM
     dogstatsd-ruby (5.5.0)
     extlz4 (0.3.3)
     ffi (1.16.3)
+    fiddle (1.1.2)
     google-protobuf (3.23.1)
     hashdiff (1.0.1)
     json (2.6.3)
@@ -71,6 +72,7 @@ GEM
     opentelemetry-semantic_conventions (1.8.0)
       opentelemetry-api (~> 1.0)
     os (1.1.4)
+    ostruct (0.6.0)
     parallel (1.23.0)
     parser (3.2.2.1)
       ast (~> 2.4.1)
@@ -161,11 +163,13 @@ DEPENDENCIES
   dogstatsd-ruby (>= 3.3.0, != 5.1.0, != 5.0.1, != 5.0.0)
   extlz4 (~> 0.3, >= 0.3.3)
   ffi (~> 1.16.3)
+  fiddle
   google-protobuf (~> 3.0, != 3.7.1, != 3.7.0)
   json-schema (< 3)
   memory_profiler (~> 0.9)
   opentelemetry-sdk (~> 1.1)
   os (~> 1.1)
+  ostruct
   pimpmychangelog (>= 0.1.2)
   pry
   pry-stack_explorer

--- a/gemfiles/ruby_3.3_rack_2.gemfile
+++ b/gemfiles/ruby_3.3_rack_2.gemfile
@@ -32,6 +32,8 @@ gem "rubocop", "~> 1.50.0", require: false
 gem "rubocop-packaging", "~> 0.5.2", require: false
 gem "rubocop-performance", "~> 1.9", require: false
 gem "rubocop-rspec", ["~> 2.20", "< 2.21"], require: false
+gem "fiddle"
+gem "ostruct"
 gem "dogstatsd-ruby", ">= 3.3.0", "!= 5.0.0", "!= 5.0.1", "!= 5.1.0"
 gem "google-protobuf", ["~> 3.0", "!= 3.7.0", "!= 3.7.1"]
 gem "ffi", "~> 1.16.3", require: false

--- a/gemfiles/ruby_3.3_rack_2.gemfile.lock
+++ b/gemfiles/ruby_3.3_rack_2.gemfile.lock
@@ -44,6 +44,7 @@ GEM
     dogstatsd-ruby (5.6.1)
     extlz4 (0.3.4)
     ffi (1.16.3)
+    fiddle (1.1.2)
     google-protobuf (3.24.3)
     hashdiff (1.0.1)
     json (2.6.3)
@@ -59,6 +60,7 @@ GEM
     method_source (1.0.0)
     msgpack (1.7.2)
     os (1.1.4)
+    ostruct (0.6.0)
     parallel (1.23.0)
     parser (3.2.2.3)
       ast (~> 2.4.1)
@@ -156,10 +158,12 @@ DEPENDENCIES
   dogstatsd-ruby (>= 3.3.0, != 5.1.0, != 5.0.1, != 5.0.0)
   extlz4 (~> 0.3, >= 0.3.3)
   ffi (~> 1.16.3)
+  fiddle
   google-protobuf (~> 3.0, != 3.7.1, != 3.7.0)
   json-schema (< 3)
   memory_profiler (~> 0.9)
   os (~> 1.1)
+  ostruct
   pimpmychangelog (>= 0.1.2)
   pry
   pry-stack_explorer

--- a/gemfiles/ruby_3.3_rack_3.gemfile
+++ b/gemfiles/ruby_3.3_rack_3.gemfile
@@ -32,6 +32,8 @@ gem "rubocop", "~> 1.50.0", require: false
 gem "rubocop-packaging", "~> 0.5.2", require: false
 gem "rubocop-performance", "~> 1.9", require: false
 gem "rubocop-rspec", ["~> 2.20", "< 2.21"], require: false
+gem "fiddle"
+gem "ostruct"
 gem "dogstatsd-ruby", ">= 3.3.0", "!= 5.0.0", "!= 5.0.1", "!= 5.1.0"
 gem "google-protobuf", ["~> 3.0", "!= 3.7.0", "!= 3.7.1"]
 gem "ffi", "~> 1.16.3", require: false

--- a/gemfiles/ruby_3.3_rack_3.gemfile.lock
+++ b/gemfiles/ruby_3.3_rack_3.gemfile.lock
@@ -44,6 +44,7 @@ GEM
     dogstatsd-ruby (5.6.1)
     extlz4 (0.3.4)
     ffi (1.16.3)
+    fiddle (1.1.2)
     google-protobuf (3.24.3)
     hashdiff (1.0.1)
     json (2.6.3)
@@ -59,6 +60,7 @@ GEM
     method_source (1.0.0)
     msgpack (1.7.2)
     os (1.1.4)
+    ostruct (0.6.0)
     parallel (1.23.0)
     parser (3.2.2.3)
       ast (~> 2.4.1)
@@ -156,10 +158,12 @@ DEPENDENCIES
   dogstatsd-ruby (>= 3.3.0, != 5.1.0, != 5.0.1, != 5.0.0)
   extlz4 (~> 0.3, >= 0.3.3)
   ffi (~> 1.16.3)
+  fiddle
   google-protobuf (~> 3.0, != 3.7.1, != 3.7.0)
   json-schema (< 3)
   memory_profiler (~> 0.9)
   os (~> 1.1)
+  ostruct
   pimpmychangelog (>= 0.1.2)
   pry
   pry-stack_explorer

--- a/gemfiles/ruby_3.3_rails61_mysql2.gemfile
+++ b/gemfiles/ruby_3.3_rails61_mysql2.gemfile
@@ -32,6 +32,8 @@ gem "rubocop", "~> 1.50.0", require: false
 gem "rubocop-packaging", "~> 0.5.2", require: false
 gem "rubocop-performance", "~> 1.9", require: false
 gem "rubocop-rspec", ["~> 2.20", "< 2.21"], require: false
+gem "fiddle"
+gem "ostruct"
 gem "dogstatsd-ruby", ">= 3.3.0", "!= 5.0.0", "!= 5.0.1", "!= 5.1.0"
 gem "google-protobuf", ["~> 3.0", "!= 3.7.0", "!= 3.7.1"]
 gem "ffi", "~> 1.16.3", require: false

--- a/gemfiles/ruby_3.3_rails61_mysql2.gemfile.lock
+++ b/gemfiles/ruby_3.3_rails61_mysql2.gemfile.lock
@@ -106,6 +106,7 @@ GEM
     erubi (1.12.0)
     extlz4 (0.3.3)
     ffi (1.16.3)
+    fiddle (1.1.2)
     globalid (1.1.0)
       activesupport (>= 5.0)
     google-protobuf (3.23.1)
@@ -156,6 +157,7 @@ GEM
       mini_portile2 (~> 2.8.2)
       racc (~> 1.4)
     os (1.1.4)
+    ostruct (0.6.0)
     parallel (1.23.0)
     parser (3.2.2.1)
       ast (~> 2.4.1)
@@ -292,6 +294,7 @@ DEPENDENCIES
   dogstatsd-ruby (>= 3.3.0, != 5.1.0, != 5.0.1, != 5.0.0)
   extlz4 (~> 0.3, >= 0.3.3)
   ffi (~> 1.16.3)
+  fiddle
   google-protobuf (~> 3.0, != 3.7.1, != 3.7.0)
   json-schema (< 3)
   lograge (~> 0.11)
@@ -299,6 +302,7 @@ DEPENDENCIES
   mysql2 (~> 0.5)
   net-smtp
   os (~> 1.1)
+  ostruct
   pimpmychangelog (>= 0.1.2)
   pry
   pry-stack_explorer

--- a/gemfiles/ruby_3.3_rails61_postgres.gemfile
+++ b/gemfiles/ruby_3.3_rails61_postgres.gemfile
@@ -32,6 +32,8 @@ gem "rubocop", "~> 1.50.0", require: false
 gem "rubocop-packaging", "~> 0.5.2", require: false
 gem "rubocop-performance", "~> 1.9", require: false
 gem "rubocop-rspec", ["~> 2.20", "< 2.21"], require: false
+gem "fiddle"
+gem "ostruct"
 gem "dogstatsd-ruby", ">= 3.3.0", "!= 5.0.0", "!= 5.0.1", "!= 5.1.0"
 gem "google-protobuf", ["~> 3.0", "!= 3.7.0", "!= 3.7.1"]
 gem "ffi", "~> 1.16.3", require: false

--- a/gemfiles/ruby_3.3_rails61_postgres.gemfile.lock
+++ b/gemfiles/ruby_3.3_rails61_postgres.gemfile.lock
@@ -106,6 +106,7 @@ GEM
     erubi (1.12.0)
     extlz4 (0.3.3)
     ffi (1.16.3)
+    fiddle (1.1.2)
     globalid (1.1.0)
       activesupport (>= 5.0)
     google-protobuf (3.23.1)
@@ -155,6 +156,7 @@ GEM
       mini_portile2 (~> 2.8.2)
       racc (~> 1.4)
     os (1.1.4)
+    ostruct (0.6.0)
     parallel (1.23.0)
     parser (3.2.2.1)
       ast (~> 2.4.1)
@@ -292,12 +294,14 @@ DEPENDENCIES
   dogstatsd-ruby (>= 3.3.0, != 5.1.0, != 5.0.1, != 5.0.0)
   extlz4 (~> 0.3, >= 0.3.3)
   ffi (~> 1.16.3)
+  fiddle
   google-protobuf (~> 3.0, != 3.7.1, != 3.7.0)
   json-schema (< 3)
   lograge (~> 0.11)
   memory_profiler (~> 0.9)
   net-smtp
   os (~> 1.1)
+  ostruct
   pg (>= 1.1)
   pimpmychangelog (>= 0.1.2)
   pry

--- a/gemfiles/ruby_3.3_rails61_postgres_redis.gemfile
+++ b/gemfiles/ruby_3.3_rails61_postgres_redis.gemfile
@@ -32,6 +32,8 @@ gem "rubocop", "~> 1.50.0", require: false
 gem "rubocop-packaging", "~> 0.5.2", require: false
 gem "rubocop-performance", "~> 1.9", require: false
 gem "rubocop-rspec", ["~> 2.20", "< 2.21"], require: false
+gem "fiddle"
+gem "ostruct"
 gem "dogstatsd-ruby", ">= 3.3.0", "!= 5.0.0", "!= 5.0.1", "!= 5.1.0"
 gem "google-protobuf", ["~> 3.0", "!= 3.7.0", "!= 3.7.1"]
 gem "ffi", "~> 1.16.3", require: false

--- a/gemfiles/ruby_3.3_rails61_postgres_redis.gemfile.lock
+++ b/gemfiles/ruby_3.3_rails61_postgres_redis.gemfile.lock
@@ -106,6 +106,7 @@ GEM
     erubi (1.12.0)
     extlz4 (0.3.3)
     ffi (1.16.3)
+    fiddle (1.1.2)
     globalid (1.1.0)
       activesupport (>= 5.0)
     google-protobuf (3.23.1)
@@ -155,6 +156,7 @@ GEM
       mini_portile2 (~> 2.8.2)
       racc (~> 1.4)
     os (1.1.4)
+    ostruct (0.6.0)
     parallel (1.23.0)
     parser (3.2.2.1)
       ast (~> 2.4.1)
@@ -293,12 +295,14 @@ DEPENDENCIES
   dogstatsd-ruby (>= 3.3.0, != 5.1.0, != 5.0.1, != 5.0.0)
   extlz4 (~> 0.3, >= 0.3.3)
   ffi (~> 1.16.3)
+  fiddle
   google-protobuf (~> 3.0, != 3.7.1, != 3.7.0)
   json-schema (< 3)
   lograge (~> 0.11)
   memory_profiler (~> 0.9)
   net-smtp
   os (~> 1.1)
+  ostruct
   pg (>= 1.1)
   pimpmychangelog (>= 0.1.2)
   pry

--- a/gemfiles/ruby_3.3_rails61_postgres_sidekiq.gemfile
+++ b/gemfiles/ruby_3.3_rails61_postgres_sidekiq.gemfile
@@ -32,6 +32,8 @@ gem "rubocop", "~> 1.50.0", require: false
 gem "rubocop-packaging", "~> 0.5.2", require: false
 gem "rubocop-performance", "~> 1.9", require: false
 gem "rubocop-rspec", ["~> 2.20", "< 2.21"], require: false
+gem "fiddle"
+gem "ostruct"
 gem "dogstatsd-ruby", ">= 3.3.0", "!= 5.0.0", "!= 5.0.1", "!= 5.1.0"
 gem "google-protobuf", ["~> 3.0", "!= 3.7.0", "!= 3.7.1"]
 gem "ffi", "~> 1.16.3", require: false

--- a/gemfiles/ruby_3.3_rails61_postgres_sidekiq.gemfile.lock
+++ b/gemfiles/ruby_3.3_rails61_postgres_sidekiq.gemfile.lock
@@ -107,6 +107,7 @@ GEM
     erubi (1.12.0)
     extlz4 (0.3.3)
     ffi (1.16.3)
+    fiddle (1.1.2)
     globalid (1.1.0)
       activesupport (>= 5.0)
     google-protobuf (3.23.1)
@@ -156,6 +157,7 @@ GEM
       mini_portile2 (~> 2.8.2)
       racc (~> 1.4)
     os (1.1.4)
+    ostruct (0.6.0)
     parallel (1.23.0)
     parser (3.2.2.1)
       ast (~> 2.4.1)
@@ -306,12 +308,14 @@ DEPENDENCIES
   dogstatsd-ruby (>= 3.3.0, != 5.1.0, != 5.0.1, != 5.0.0)
   extlz4 (~> 0.3, >= 0.3.3)
   ffi (~> 1.16.3)
+  fiddle
   google-protobuf (~> 3.0, != 3.7.1, != 3.7.0)
   json-schema (< 3)
   lograge (~> 0.11)
   memory_profiler (~> 0.9)
   net-smtp
   os (~> 1.1)
+  ostruct
   pg (>= 1.1)
   pimpmychangelog (>= 0.1.2)
   pry

--- a/gemfiles/ruby_3.3_rails61_semantic_logger.gemfile
+++ b/gemfiles/ruby_3.3_rails61_semantic_logger.gemfile
@@ -32,6 +32,8 @@ gem "rubocop", "~> 1.50.0", require: false
 gem "rubocop-packaging", "~> 0.5.2", require: false
 gem "rubocop-performance", "~> 1.9", require: false
 gem "rubocop-rspec", ["~> 2.20", "< 2.21"], require: false
+gem "fiddle"
+gem "ostruct"
 gem "dogstatsd-ruby", ">= 3.3.0", "!= 5.0.0", "!= 5.0.1", "!= 5.1.0"
 gem "google-protobuf", ["~> 3.0", "!= 3.7.0", "!= 3.7.1"]
 gem "ffi", "~> 1.16.3", require: false

--- a/gemfiles/ruby_3.3_rails61_semantic_logger.gemfile.lock
+++ b/gemfiles/ruby_3.3_rails61_semantic_logger.gemfile.lock
@@ -106,6 +106,7 @@ GEM
     erubi (1.12.0)
     extlz4 (0.3.3)
     ffi (1.16.3)
+    fiddle (1.1.2)
     globalid (1.1.0)
       activesupport (>= 5.0)
     google-protobuf (3.23.1)
@@ -150,6 +151,7 @@ GEM
       mini_portile2 (~> 2.8.2)
       racc (~> 1.4)
     os (1.1.4)
+    ostruct (0.6.0)
     parallel (1.23.0)
     parser (3.2.2.1)
       ast (~> 2.4.1)
@@ -291,11 +293,13 @@ DEPENDENCIES
   dogstatsd-ruby (>= 3.3.0, != 5.1.0, != 5.0.1, != 5.0.0)
   extlz4 (~> 0.3, >= 0.3.3)
   ffi (~> 1.16.3)
+  fiddle
   google-protobuf (~> 3.0, != 3.7.1, != 3.7.0)
   json-schema (< 3)
   memory_profiler (~> 0.9)
   net-smtp
   os (~> 1.1)
+  ostruct
   pg (>= 1.1)
   pimpmychangelog (>= 0.1.2)
   pry

--- a/gemfiles/ruby_3.3_rails61_trilogy.gemfile
+++ b/gemfiles/ruby_3.3_rails61_trilogy.gemfile
@@ -32,6 +32,8 @@ gem "rubocop", "~> 1.50.0", require: false
 gem "rubocop-packaging", "~> 0.5.2", require: false
 gem "rubocop-performance", "~> 1.9", require: false
 gem "rubocop-rspec", ["~> 2.20", "< 2.21"], require: false
+gem "fiddle"
+gem "ostruct"
 gem "dogstatsd-ruby", ">= 3.3.0", "!= 5.0.0", "!= 5.0.1", "!= 5.1.0"
 gem "google-protobuf", ["~> 3.0", "!= 3.7.0", "!= 3.7.1"]
 gem "ffi", "~> 1.16.3", require: false

--- a/gemfiles/ruby_3.3_rails61_trilogy.gemfile.lock
+++ b/gemfiles/ruby_3.3_rails61_trilogy.gemfile.lock
@@ -110,6 +110,7 @@ GEM
     erubi (1.12.0)
     extlz4 (0.3.4)
     ffi (1.16.3)
+    fiddle (1.1.2)
     globalid (1.2.1)
       activesupport (>= 6.1)
     google-protobuf (3.25.1)
@@ -159,6 +160,7 @@ GEM
       mini_portile2 (~> 2.8.2)
       racc (~> 1.4)
     os (1.1.4)
+    ostruct (0.6.0)
     parallel (1.23.0)
     parser (3.2.2.4)
       ast (~> 2.4.1)
@@ -301,12 +303,14 @@ DEPENDENCIES
   dogstatsd-ruby (>= 3.3.0, != 5.1.0, != 5.0.1, != 5.0.0)
   extlz4 (~> 0.3, >= 0.3.3)
   ffi (~> 1.16.3)
+  fiddle
   google-protobuf (~> 3.0, != 3.7.1, != 3.7.0)
   json-schema (< 3)
   lograge (~> 0.11)
   memory_profiler (~> 0.9)
   net-smtp
   os (~> 1.1)
+  ostruct
   pimpmychangelog (>= 0.1.2)
   pry
   pry-stack_explorer

--- a/gemfiles/ruby_3.3_redis_3.gemfile
+++ b/gemfiles/ruby_3.3_redis_3.gemfile
@@ -32,6 +32,8 @@ gem "rubocop", "~> 1.50.0", require: false
 gem "rubocop-packaging", "~> 0.5.2", require: false
 gem "rubocop-performance", "~> 1.9", require: false
 gem "rubocop-rspec", ["~> 2.20", "< 2.21"], require: false
+gem "fiddle"
+gem "ostruct"
 gem "dogstatsd-ruby", ">= 3.3.0", "!= 5.0.0", "!= 5.0.1", "!= 5.1.0"
 gem "google-protobuf", ["~> 3.0", "!= 3.7.0", "!= 3.7.1"]
 gem "ffi", "~> 1.16.3", require: false

--- a/gemfiles/ruby_3.3_redis_3.gemfile.lock
+++ b/gemfiles/ruby_3.3_redis_3.gemfile.lock
@@ -44,6 +44,7 @@ GEM
     dogstatsd-ruby (5.5.0)
     extlz4 (0.3.3)
     ffi (1.16.3)
+    fiddle (1.1.2)
     google-protobuf (3.23.1)
     hashdiff (1.0.1)
     json (2.6.3)
@@ -59,6 +60,7 @@ GEM
     method_source (1.0.0)
     msgpack (1.7.2)
     os (1.1.4)
+    ostruct (0.6.0)
     parallel (1.23.0)
     parser (3.2.2.1)
       ast (~> 2.4.1)
@@ -150,10 +152,12 @@ DEPENDENCIES
   dogstatsd-ruby (>= 3.3.0, != 5.1.0, != 5.0.1, != 5.0.0)
   extlz4 (~> 0.3, >= 0.3.3)
   ffi (~> 1.16.3)
+  fiddle
   google-protobuf (~> 3.0, != 3.7.1, != 3.7.0)
   json-schema (< 3)
   memory_profiler (~> 0.9)
   os (~> 1.1)
+  ostruct
   pimpmychangelog (>= 0.1.2)
   pry
   pry-stack_explorer

--- a/gemfiles/ruby_3.3_redis_4.gemfile
+++ b/gemfiles/ruby_3.3_redis_4.gemfile
@@ -32,6 +32,8 @@ gem "rubocop", "~> 1.50.0", require: false
 gem "rubocop-packaging", "~> 0.5.2", require: false
 gem "rubocop-performance", "~> 1.9", require: false
 gem "rubocop-rspec", ["~> 2.20", "< 2.21"], require: false
+gem "fiddle"
+gem "ostruct"
 gem "dogstatsd-ruby", ">= 3.3.0", "!= 5.0.0", "!= 5.0.1", "!= 5.1.0"
 gem "google-protobuf", ["~> 3.0", "!= 3.7.0", "!= 3.7.1"]
 gem "ffi", "~> 1.16.3", require: false

--- a/gemfiles/ruby_3.3_redis_4.gemfile.lock
+++ b/gemfiles/ruby_3.3_redis_4.gemfile.lock
@@ -44,6 +44,7 @@ GEM
     dogstatsd-ruby (5.5.0)
     extlz4 (0.3.3)
     ffi (1.16.3)
+    fiddle (1.1.2)
     google-protobuf (3.23.1)
     hashdiff (1.0.1)
     json (2.6.3)
@@ -59,6 +60,7 @@ GEM
     method_source (1.0.0)
     msgpack (1.7.2)
     os (1.1.4)
+    ostruct (0.6.0)
     parallel (1.23.0)
     parser (3.2.2.1)
       ast (~> 2.4.1)
@@ -150,10 +152,12 @@ DEPENDENCIES
   dogstatsd-ruby (>= 3.3.0, != 5.1.0, != 5.0.1, != 5.0.0)
   extlz4 (~> 0.3, >= 0.3.3)
   ffi (~> 1.16.3)
+  fiddle
   google-protobuf (~> 3.0, != 3.7.1, != 3.7.0)
   json-schema (< 3)
   memory_profiler (~> 0.9)
   os (~> 1.1)
+  ostruct
   pimpmychangelog (>= 0.1.2)
   pry
   pry-stack_explorer

--- a/gemfiles/ruby_3.3_redis_5.gemfile
+++ b/gemfiles/ruby_3.3_redis_5.gemfile
@@ -32,6 +32,8 @@ gem "rubocop", "~> 1.50.0", require: false
 gem "rubocop-packaging", "~> 0.5.2", require: false
 gem "rubocop-performance", "~> 1.9", require: false
 gem "rubocop-rspec", ["~> 2.20", "< 2.21"], require: false
+gem "fiddle"
+gem "ostruct"
 gem "dogstatsd-ruby", ">= 3.3.0", "!= 5.0.0", "!= 5.0.1", "!= 5.1.0"
 gem "google-protobuf", ["~> 3.0", "!= 3.7.0", "!= 3.7.1"]
 gem "ffi", "~> 1.16.3", require: false

--- a/gemfiles/ruby_3.3_redis_5.gemfile.lock
+++ b/gemfiles/ruby_3.3_redis_5.gemfile.lock
@@ -45,6 +45,7 @@ GEM
     dogstatsd-ruby (5.5.0)
     extlz4 (0.3.3)
     ffi (1.16.3)
+    fiddle (1.1.2)
     google-protobuf (3.23.1)
     hashdiff (1.0.1)
     json (2.6.3)
@@ -60,6 +61,7 @@ GEM
     method_source (1.0.0)
     msgpack (1.7.2)
     os (1.1.4)
+    ostruct (0.6.0)
     parallel (1.23.0)
     parser (3.2.2.1)
       ast (~> 2.4.1)
@@ -154,10 +156,12 @@ DEPENDENCIES
   dogstatsd-ruby (>= 3.3.0, != 5.1.0, != 5.0.1, != 5.0.0)
   extlz4 (~> 0.3, >= 0.3.3)
   ffi (~> 1.16.3)
+  fiddle
   google-protobuf (~> 3.0, != 3.7.1, != 3.7.0)
   json-schema (< 3)
   memory_profiler (~> 0.9)
   os (~> 1.1)
+  ostruct
   pimpmychangelog (>= 0.1.2)
   pry
   pry-stack_explorer

--- a/gemfiles/ruby_3.3_relational_db.gemfile
+++ b/gemfiles/ruby_3.3_relational_db.gemfile
@@ -32,6 +32,8 @@ gem "rubocop", "~> 1.50.0", require: false
 gem "rubocop-packaging", "~> 0.5.2", require: false
 gem "rubocop-performance", "~> 1.9", require: false
 gem "rubocop-rspec", ["~> 2.20", "< 2.21"], require: false
+gem "fiddle"
+gem "ostruct"
 gem "dogstatsd-ruby", ">= 3.3.0", "!= 5.0.0", "!= 5.0.1", "!= 5.1.0"
 gem "google-protobuf", ["~> 3.0", "!= 3.7.0", "!= 3.7.1"]
 gem "ffi", "~> 1.16.3", require: false

--- a/gemfiles/ruby_3.3_relational_db.gemfile.lock
+++ b/gemfiles/ruby_3.3_relational_db.gemfile.lock
@@ -59,6 +59,7 @@ GEM
     dogstatsd-ruby (5.6.1)
     extlz4 (0.3.4)
     ffi (1.16.3)
+    fiddle (1.1.2)
     google-protobuf (3.24.3)
     hashdiff (1.0.1)
     i18n (1.14.1)
@@ -81,6 +82,7 @@ GEM
     msgpack (1.7.2)
     mysql2 (0.5.5)
     os (1.1.4)
+    ostruct (0.6.0)
     parallel (1.23.0)
     parser (3.2.2.3)
       ast (~> 2.4.1)
@@ -183,12 +185,14 @@ DEPENDENCIES
   dogstatsd-ruby (>= 3.3.0, != 5.1.0, != 5.0.1, != 5.0.0)
   extlz4 (~> 0.3, >= 0.3.3)
   ffi (~> 1.16.3)
+  fiddle
   google-protobuf (~> 3.0, != 3.7.1, != 3.7.0)
   json-schema (< 3)
   makara (>= 0.6.0.pre)
   memory_profiler (~> 0.9)
   mysql2 (>= 0.5.3)
   os (~> 1.1)
+  ostruct
   pg
   pimpmychangelog (>= 0.1.2)
   pry

--- a/gemfiles/ruby_3.3_resque2_redis3.gemfile
+++ b/gemfiles/ruby_3.3_resque2_redis3.gemfile
@@ -32,6 +32,8 @@ gem "rubocop", "~> 1.50.0", require: false
 gem "rubocop-packaging", "~> 0.5.2", require: false
 gem "rubocop-performance", "~> 1.9", require: false
 gem "rubocop-rspec", ["~> 2.20", "< 2.21"], require: false
+gem "fiddle"
+gem "ostruct"
 gem "dogstatsd-ruby", ">= 3.3.0", "!= 5.0.0", "!= 5.0.1", "!= 5.1.0"
 gem "google-protobuf", ["~> 3.0", "!= 3.7.0", "!= 3.7.1"]
 gem "ffi", "~> 1.16.3", require: false

--- a/gemfiles/ruby_3.3_resque2_redis3.gemfile.lock
+++ b/gemfiles/ruby_3.3_resque2_redis3.gemfile.lock
@@ -44,6 +44,7 @@ GEM
     dogstatsd-ruby (5.5.0)
     extlz4 (0.3.3)
     ffi (1.16.3)
+    fiddle (1.1.2)
     google-protobuf (3.23.1)
     hashdiff (1.0.1)
     json (2.6.3)
@@ -63,6 +64,7 @@ GEM
     mustermann (3.0.0)
       ruby2_keywords (~> 0.0.1)
     os (1.1.4)
+    ostruct (0.6.0)
     parallel (1.23.0)
     parser (3.2.2.1)
       ast (~> 2.4.1)
@@ -171,10 +173,12 @@ DEPENDENCIES
   dogstatsd-ruby (>= 3.3.0, != 5.1.0, != 5.0.1, != 5.0.0)
   extlz4 (~> 0.3, >= 0.3.3)
   ffi (~> 1.16.3)
+  fiddle
   google-protobuf (~> 3.0, != 3.7.1, != 3.7.0)
   json-schema (< 3)
   memory_profiler (~> 0.9)
   os (~> 1.1)
+  ostruct
   pimpmychangelog (>= 0.1.2)
   pry
   pry-stack_explorer

--- a/gemfiles/ruby_3.3_resque2_redis4.gemfile
+++ b/gemfiles/ruby_3.3_resque2_redis4.gemfile
@@ -32,6 +32,8 @@ gem "rubocop", "~> 1.50.0", require: false
 gem "rubocop-packaging", "~> 0.5.2", require: false
 gem "rubocop-performance", "~> 1.9", require: false
 gem "rubocop-rspec", ["~> 2.20", "< 2.21"], require: false
+gem "fiddle"
+gem "ostruct"
 gem "dogstatsd-ruby", ">= 3.3.0", "!= 5.0.0", "!= 5.0.1", "!= 5.1.0"
 gem "google-protobuf", ["~> 3.0", "!= 3.7.0", "!= 3.7.1"]
 gem "ffi", "~> 1.16.3", require: false

--- a/gemfiles/ruby_3.3_resque2_redis4.gemfile.lock
+++ b/gemfiles/ruby_3.3_resque2_redis4.gemfile.lock
@@ -45,6 +45,7 @@ GEM
     dogstatsd-ruby (5.5.0)
     extlz4 (0.3.3)
     ffi (1.16.3)
+    fiddle (1.1.2)
     google-protobuf (3.23.1)
     hashdiff (1.0.1)
     json (2.6.3)
@@ -64,6 +65,7 @@ GEM
     mustermann (3.0.0)
       ruby2_keywords (~> 0.0.1)
     os (1.1.4)
+    ostruct (0.6.0)
     parallel (1.23.0)
     parser (3.2.2.1)
       ast (~> 2.4.1)
@@ -175,10 +177,12 @@ DEPENDENCIES
   dogstatsd-ruby (>= 3.3.0, != 5.1.0, != 5.0.1, != 5.0.0)
   extlz4 (~> 0.3, >= 0.3.3)
   ffi (~> 1.16.3)
+  fiddle
   google-protobuf (~> 3.0, != 3.7.1, != 3.7.0)
   json-schema (< 3)
   memory_profiler (~> 0.9)
   os (~> 1.1)
+  ostruct
   pimpmychangelog (>= 0.1.2)
   pry
   pry-stack_explorer

--- a/gemfiles/ruby_3.3_sinatra_2.gemfile
+++ b/gemfiles/ruby_3.3_sinatra_2.gemfile
@@ -32,6 +32,8 @@ gem "rubocop", "~> 1.50.0", require: false
 gem "rubocop-packaging", "~> 0.5.2", require: false
 gem "rubocop-performance", "~> 1.9", require: false
 gem "rubocop-rspec", ["~> 2.20", "< 2.21"], require: false
+gem "fiddle"
+gem "ostruct"
 gem "dogstatsd-ruby", ">= 3.3.0", "!= 5.0.0", "!= 5.0.1", "!= 5.1.0"
 gem "google-protobuf", ["~> 3.0", "!= 3.7.0", "!= 3.7.1"]
 gem "ffi", "~> 1.16.3", require: false

--- a/gemfiles/ruby_3.3_sinatra_2.gemfile.lock
+++ b/gemfiles/ruby_3.3_sinatra_2.gemfile.lock
@@ -47,6 +47,7 @@ GEM
     dogstatsd-ruby (5.6.1)
     extlz4 (0.3.4)
     ffi (1.16.3)
+    fiddle (1.1.2)
     google-protobuf (3.25.3-aarch64-linux)
     google-protobuf (3.25.3-x86_64-linux)
     hashdiff (1.1.0)
@@ -65,6 +66,7 @@ GEM
     mustermann (2.0.2)
       ruby2_keywords (~> 0.0.1)
     os (1.1.4)
+    ostruct (0.6.0)
     parallel (1.24.0)
     parser (3.3.0.5)
       ast (~> 2.4.1)
@@ -172,10 +174,12 @@ DEPENDENCIES
   dogstatsd-ruby (>= 3.3.0, != 5.1.0, != 5.0.1, != 5.0.0)
   extlz4 (~> 0.3, >= 0.3.3)
   ffi (~> 1.16.3)
+  fiddle
   google-protobuf (~> 3.0, != 3.7.1, != 3.7.0)
   json-schema (< 3)
   memory_profiler (~> 0.9)
   os (~> 1.1)
+  ostruct
   pimpmychangelog (>= 0.1.2)
   pry
   pry-stack_explorer

--- a/gemfiles/ruby_3.3_sinatra_3.gemfile
+++ b/gemfiles/ruby_3.3_sinatra_3.gemfile
@@ -32,6 +32,8 @@ gem "rubocop", "~> 1.50.0", require: false
 gem "rubocop-packaging", "~> 0.5.2", require: false
 gem "rubocop-performance", "~> 1.9", require: false
 gem "rubocop-rspec", ["~> 2.20", "< 2.21"], require: false
+gem "fiddle"
+gem "ostruct"
 gem "dogstatsd-ruby", ">= 3.3.0", "!= 5.0.0", "!= 5.0.1", "!= 5.1.0"
 gem "google-protobuf", ["~> 3.0", "!= 3.7.0", "!= 3.7.1"]
 gem "ffi", "~> 1.16.3", require: false

--- a/gemfiles/ruby_3.3_sinatra_3.gemfile.lock
+++ b/gemfiles/ruby_3.3_sinatra_3.gemfile.lock
@@ -48,6 +48,7 @@ GEM
     dogstatsd-ruby (5.6.1)
     extlz4 (0.3.4)
     ffi (1.16.3)
+    fiddle (1.1.2)
     google-protobuf (3.25.3-aarch64-linux)
     google-protobuf (3.25.3-x86_64-linux)
     hashdiff (1.1.0)
@@ -66,6 +67,7 @@ GEM
     mustermann (3.0.0)
       ruby2_keywords (~> 0.0.1)
     os (1.1.4)
+    ostruct (0.6.0)
     parallel (1.24.0)
     parser (3.3.0.5)
       ast (~> 2.4.1)
@@ -174,10 +176,12 @@ DEPENDENCIES
   dogstatsd-ruby (>= 3.3.0, != 5.1.0, != 5.0.1, != 5.0.0)
   extlz4 (~> 0.3, >= 0.3.3)
   ffi (~> 1.16.3)
+  fiddle
   google-protobuf (~> 3.0, != 3.7.1, != 3.7.0)
   json-schema (< 3)
   memory_profiler (~> 0.9)
   os (~> 1.1)
+  ostruct
   pimpmychangelog (>= 0.1.2)
   pry
   pry-stack_explorer

--- a/gemfiles/ruby_3.3_sinatra_4.gemfile
+++ b/gemfiles/ruby_3.3_sinatra_4.gemfile
@@ -32,6 +32,8 @@ gem "rubocop", "~> 1.50.0", require: false
 gem "rubocop-packaging", "~> 0.5.2", require: false
 gem "rubocop-performance", "~> 1.9", require: false
 gem "rubocop-rspec", ["~> 2.20", "< 2.21"], require: false
+gem "fiddle"
+gem "ostruct"
 gem "dogstatsd-ruby", ">= 3.3.0", "!= 5.0.0", "!= 5.0.1", "!= 5.1.0"
 gem "google-protobuf", ["~> 3.0", "!= 3.7.0", "!= 3.7.1"]
 gem "ffi", "~> 1.16.3", require: false

--- a/gemfiles/ruby_3.3_sinatra_4.gemfile.lock
+++ b/gemfiles/ruby_3.3_sinatra_4.gemfile.lock
@@ -48,6 +48,7 @@ GEM
     dogstatsd-ruby (5.6.1)
     extlz4 (0.3.4)
     ffi (1.16.3)
+    fiddle (1.1.2)
     google-protobuf (3.25.3-aarch64-linux)
     google-protobuf (3.25.3-x86_64-linux)
     hashdiff (1.1.0)
@@ -66,6 +67,7 @@ GEM
     mustermann (3.0.0)
       ruby2_keywords (~> 0.0.1)
     os (1.1.4)
+    ostruct (0.6.0)
     parallel (1.24.0)
     parser (3.3.0.5)
       ast (~> 2.4.1)
@@ -177,10 +179,12 @@ DEPENDENCIES
   dogstatsd-ruby (>= 3.3.0, != 5.1.0, != 5.0.1, != 5.0.0)
   extlz4 (~> 0.3, >= 0.3.3)
   ffi (~> 1.16.3)
+  fiddle
   google-protobuf (~> 3.0, != 3.7.1, != 3.7.0)
   json-schema (< 3)
   memory_profiler (~> 0.9)
   os (~> 1.1)
+  ostruct
   pimpmychangelog (>= 0.1.2)
   pry
   pry-stack_explorer

--- a/gemfiles/ruby_3.3_stripe_10.gemfile
+++ b/gemfiles/ruby_3.3_stripe_10.gemfile
@@ -32,6 +32,8 @@ gem "rubocop", "~> 1.50.0", require: false
 gem "rubocop-packaging", "~> 0.5.2", require: false
 gem "rubocop-performance", "~> 1.9", require: false
 gem "rubocop-rspec", ["~> 2.20", "< 2.21"], require: false
+gem "fiddle"
+gem "ostruct"
 gem "dogstatsd-ruby", ">= 3.3.0", "!= 5.0.0", "!= 5.0.1", "!= 5.1.0"
 gem "google-protobuf", ["~> 3.0", "!= 3.7.0", "!= 3.7.1"]
 gem "ffi", "~> 1.16.3", require: false

--- a/gemfiles/ruby_3.3_stripe_10.gemfile.lock
+++ b/gemfiles/ruby_3.3_stripe_10.gemfile.lock
@@ -47,18 +47,24 @@ GEM
     dogstatsd-ruby (5.6.1)
     extlz4 (0.3.4)
     ffi (1.16.3)
+    fiddle (1.1.2)
     google-protobuf (3.25.4-aarch64-linux)
+    google-protobuf (3.25.4-x86_64-linux)
     hashdiff (1.1.1)
     json (2.7.2)
     json-schema (2.8.1)
       addressable (>= 2.4)
     libdatadog (11.0.0.1.0-aarch64-linux)
+    libdatadog (11.0.0.1.0-x86_64-linux)
     libddwaf (1.14.0.0.0-aarch64-linux)
+      ffi (~> 1.0)
+    libddwaf (1.14.0.0.0-x86_64-linux)
       ffi (~> 1.0)
     memory_profiler (0.9.14)
     method_source (1.1.0)
     msgpack (1.7.2)
     os (1.1.4)
+    ostruct (0.6.0)
     parallel (1.26.3)
     parser (3.3.4.2)
       ast (~> 2.4.1)
@@ -140,6 +146,7 @@ GEM
 
 PLATFORMS
   aarch64-linux
+  x86_64-linux
 
 DEPENDENCIES
   appraisal (~> 2.4.0)
@@ -152,10 +159,12 @@ DEPENDENCIES
   dogstatsd-ruby (>= 3.3.0, != 5.1.0, != 5.0.1, != 5.0.0)
   extlz4 (~> 0.3, >= 0.3.3)
   ffi (~> 1.16.3)
+  fiddle
   google-protobuf (~> 3.0, != 3.7.1, != 3.7.0)
   json-schema (< 3)
   memory_profiler (~> 0.9)
   os (~> 1.1)
+  ostruct
   pimpmychangelog (>= 0.1.2)
   pry
   pry-stack_explorer

--- a/gemfiles/ruby_3.3_stripe_11.gemfile
+++ b/gemfiles/ruby_3.3_stripe_11.gemfile
@@ -32,6 +32,8 @@ gem "rubocop", "~> 1.50.0", require: false
 gem "rubocop-packaging", "~> 0.5.2", require: false
 gem "rubocop-performance", "~> 1.9", require: false
 gem "rubocop-rspec", ["~> 2.20", "< 2.21"], require: false
+gem "fiddle"
+gem "ostruct"
 gem "dogstatsd-ruby", ">= 3.3.0", "!= 5.0.0", "!= 5.0.1", "!= 5.1.0"
 gem "google-protobuf", ["~> 3.0", "!= 3.7.0", "!= 3.7.1"]
 gem "ffi", "~> 1.16.3", require: false

--- a/gemfiles/ruby_3.3_stripe_11.gemfile.lock
+++ b/gemfiles/ruby_3.3_stripe_11.gemfile.lock
@@ -47,18 +47,24 @@ GEM
     dogstatsd-ruby (5.6.1)
     extlz4 (0.3.4)
     ffi (1.16.3)
+    fiddle (1.1.2)
     google-protobuf (3.25.4-aarch64-linux)
+    google-protobuf (3.25.4-x86_64-linux)
     hashdiff (1.1.1)
     json (2.7.2)
     json-schema (2.8.1)
       addressable (>= 2.4)
     libdatadog (11.0.0.1.0-aarch64-linux)
+    libdatadog (11.0.0.1.0-x86_64-linux)
     libddwaf (1.14.0.0.0-aarch64-linux)
+      ffi (~> 1.0)
+    libddwaf (1.14.0.0.0-x86_64-linux)
       ffi (~> 1.0)
     memory_profiler (0.9.14)
     method_source (1.1.0)
     msgpack (1.7.2)
     os (1.1.4)
+    ostruct (0.6.0)
     parallel (1.26.3)
     parser (3.3.4.2)
       ast (~> 2.4.1)
@@ -140,6 +146,7 @@ GEM
 
 PLATFORMS
   aarch64-linux
+  x86_64-linux
 
 DEPENDENCIES
   appraisal (~> 2.4.0)
@@ -152,10 +159,12 @@ DEPENDENCIES
   dogstatsd-ruby (>= 3.3.0, != 5.1.0, != 5.0.1, != 5.0.0)
   extlz4 (~> 0.3, >= 0.3.3)
   ffi (~> 1.16.3)
+  fiddle
   google-protobuf (~> 3.0, != 3.7.1, != 3.7.0)
   json-schema (< 3)
   memory_profiler (~> 0.9)
   os (~> 1.1)
+  ostruct
   pimpmychangelog (>= 0.1.2)
   pry
   pry-stack_explorer

--- a/gemfiles/ruby_3.3_stripe_12.gemfile
+++ b/gemfiles/ruby_3.3_stripe_12.gemfile
@@ -32,6 +32,8 @@ gem "rubocop", "~> 1.50.0", require: false
 gem "rubocop-packaging", "~> 0.5.2", require: false
 gem "rubocop-performance", "~> 1.9", require: false
 gem "rubocop-rspec", ["~> 2.20", "< 2.21"], require: false
+gem "fiddle"
+gem "ostruct"
 gem "dogstatsd-ruby", ">= 3.3.0", "!= 5.0.0", "!= 5.0.1", "!= 5.1.0"
 gem "google-protobuf", ["~> 3.0", "!= 3.7.0", "!= 3.7.1"]
 gem "ffi", "~> 1.16.3", require: false

--- a/gemfiles/ruby_3.3_stripe_12.gemfile.lock
+++ b/gemfiles/ruby_3.3_stripe_12.gemfile.lock
@@ -47,18 +47,24 @@ GEM
     dogstatsd-ruby (5.6.1)
     extlz4 (0.3.4)
     ffi (1.16.3)
+    fiddle (1.1.2)
     google-protobuf (3.25.4-aarch64-linux)
+    google-protobuf (3.25.4-x86_64-linux)
     hashdiff (1.1.1)
     json (2.7.2)
     json-schema (2.8.1)
       addressable (>= 2.4)
     libdatadog (11.0.0.1.0-aarch64-linux)
+    libdatadog (11.0.0.1.0-x86_64-linux)
     libddwaf (1.14.0.0.0-aarch64-linux)
+      ffi (~> 1.0)
+    libddwaf (1.14.0.0.0-x86_64-linux)
       ffi (~> 1.0)
     memory_profiler (0.9.14)
     method_source (1.1.0)
     msgpack (1.7.2)
     os (1.1.4)
+    ostruct (0.6.0)
     parallel (1.26.3)
     parser (3.3.4.2)
       ast (~> 2.4.1)
@@ -140,6 +146,7 @@ GEM
 
 PLATFORMS
   aarch64-linux
+  x86_64-linux
 
 DEPENDENCIES
   appraisal (~> 2.4.0)
@@ -152,10 +159,12 @@ DEPENDENCIES
   dogstatsd-ruby (>= 3.3.0, != 5.1.0, != 5.0.1, != 5.0.0)
   extlz4 (~> 0.3, >= 0.3.3)
   ffi (~> 1.16.3)
+  fiddle
   google-protobuf (~> 3.0, != 3.7.1, != 3.7.0)
   json-schema (< 3)
   memory_profiler (~> 0.9)
   os (~> 1.1)
+  ostruct
   pimpmychangelog (>= 0.1.2)
   pry
   pry-stack_explorer

--- a/gemfiles/ruby_3.3_stripe_7.gemfile
+++ b/gemfiles/ruby_3.3_stripe_7.gemfile
@@ -32,6 +32,8 @@ gem "rubocop", "~> 1.50.0", require: false
 gem "rubocop-packaging", "~> 0.5.2", require: false
 gem "rubocop-performance", "~> 1.9", require: false
 gem "rubocop-rspec", ["~> 2.20", "< 2.21"], require: false
+gem "fiddle"
+gem "ostruct"
 gem "dogstatsd-ruby", ">= 3.3.0", "!= 5.0.0", "!= 5.0.1", "!= 5.1.0"
 gem "google-protobuf", ["~> 3.0", "!= 3.7.0", "!= 3.7.1"]
 gem "ffi", "~> 1.16.3", require: false

--- a/gemfiles/ruby_3.3_stripe_7.gemfile.lock
+++ b/gemfiles/ruby_3.3_stripe_7.gemfile.lock
@@ -47,18 +47,24 @@ GEM
     dogstatsd-ruby (5.6.1)
     extlz4 (0.3.4)
     ffi (1.16.3)
+    fiddle (1.1.2)
     google-protobuf (3.25.4-aarch64-linux)
+    google-protobuf (3.25.4-x86_64-linux)
     hashdiff (1.1.1)
     json (2.7.2)
     json-schema (2.8.1)
       addressable (>= 2.4)
     libdatadog (11.0.0.1.0-aarch64-linux)
+    libdatadog (11.0.0.1.0-x86_64-linux)
     libddwaf (1.14.0.0.0-aarch64-linux)
+      ffi (~> 1.0)
+    libddwaf (1.14.0.0.0-x86_64-linux)
       ffi (~> 1.0)
     memory_profiler (0.9.14)
     method_source (1.1.0)
     msgpack (1.7.2)
     os (1.1.4)
+    ostruct (0.6.0)
     parallel (1.26.3)
     parser (3.3.4.2)
       ast (~> 2.4.1)
@@ -140,6 +146,7 @@ GEM
 
 PLATFORMS
   aarch64-linux
+  x86_64-linux
 
 DEPENDENCIES
   appraisal (~> 2.4.0)
@@ -152,10 +159,12 @@ DEPENDENCIES
   dogstatsd-ruby (>= 3.3.0, != 5.1.0, != 5.0.1, != 5.0.0)
   extlz4 (~> 0.3, >= 0.3.3)
   ffi (~> 1.16.3)
+  fiddle
   google-protobuf (~> 3.0, != 3.7.1, != 3.7.0)
   json-schema (< 3)
   memory_profiler (~> 0.9)
   os (~> 1.1)
+  ostruct
   pimpmychangelog (>= 0.1.2)
   pry
   pry-stack_explorer

--- a/gemfiles/ruby_3.3_stripe_8.gemfile
+++ b/gemfiles/ruby_3.3_stripe_8.gemfile
@@ -32,6 +32,8 @@ gem "rubocop", "~> 1.50.0", require: false
 gem "rubocop-packaging", "~> 0.5.2", require: false
 gem "rubocop-performance", "~> 1.9", require: false
 gem "rubocop-rspec", ["~> 2.20", "< 2.21"], require: false
+gem "fiddle"
+gem "ostruct"
 gem "dogstatsd-ruby", ">= 3.3.0", "!= 5.0.0", "!= 5.0.1", "!= 5.1.0"
 gem "google-protobuf", ["~> 3.0", "!= 3.7.0", "!= 3.7.1"]
 gem "ffi", "~> 1.16.3", require: false

--- a/gemfiles/ruby_3.3_stripe_8.gemfile.lock
+++ b/gemfiles/ruby_3.3_stripe_8.gemfile.lock
@@ -47,18 +47,24 @@ GEM
     dogstatsd-ruby (5.6.1)
     extlz4 (0.3.4)
     ffi (1.16.3)
+    fiddle (1.1.2)
     google-protobuf (3.25.4-aarch64-linux)
+    google-protobuf (3.25.4-x86_64-linux)
     hashdiff (1.1.1)
     json (2.7.2)
     json-schema (2.8.1)
       addressable (>= 2.4)
     libdatadog (11.0.0.1.0-aarch64-linux)
+    libdatadog (11.0.0.1.0-x86_64-linux)
     libddwaf (1.14.0.0.0-aarch64-linux)
+      ffi (~> 1.0)
+    libddwaf (1.14.0.0.0-x86_64-linux)
       ffi (~> 1.0)
     memory_profiler (0.9.14)
     method_source (1.1.0)
     msgpack (1.7.2)
     os (1.1.4)
+    ostruct (0.6.0)
     parallel (1.26.3)
     parser (3.3.4.2)
       ast (~> 2.4.1)
@@ -140,6 +146,7 @@ GEM
 
 PLATFORMS
   aarch64-linux
+  x86_64-linux
 
 DEPENDENCIES
   appraisal (~> 2.4.0)
@@ -152,10 +159,12 @@ DEPENDENCIES
   dogstatsd-ruby (>= 3.3.0, != 5.1.0, != 5.0.1, != 5.0.0)
   extlz4 (~> 0.3, >= 0.3.3)
   ffi (~> 1.16.3)
+  fiddle
   google-protobuf (~> 3.0, != 3.7.1, != 3.7.0)
   json-schema (< 3)
   memory_profiler (~> 0.9)
   os (~> 1.1)
+  ostruct
   pimpmychangelog (>= 0.1.2)
   pry
   pry-stack_explorer

--- a/gemfiles/ruby_3.3_stripe_9.gemfile
+++ b/gemfiles/ruby_3.3_stripe_9.gemfile
@@ -32,6 +32,8 @@ gem "rubocop", "~> 1.50.0", require: false
 gem "rubocop-packaging", "~> 0.5.2", require: false
 gem "rubocop-performance", "~> 1.9", require: false
 gem "rubocop-rspec", ["~> 2.20", "< 2.21"], require: false
+gem "fiddle"
+gem "ostruct"
 gem "dogstatsd-ruby", ">= 3.3.0", "!= 5.0.0", "!= 5.0.1", "!= 5.1.0"
 gem "google-protobuf", ["~> 3.0", "!= 3.7.0", "!= 3.7.1"]
 gem "ffi", "~> 1.16.3", require: false

--- a/gemfiles/ruby_3.3_stripe_9.gemfile.lock
+++ b/gemfiles/ruby_3.3_stripe_9.gemfile.lock
@@ -47,18 +47,24 @@ GEM
     dogstatsd-ruby (5.6.1)
     extlz4 (0.3.4)
     ffi (1.16.3)
+    fiddle (1.1.2)
     google-protobuf (3.25.4-aarch64-linux)
+    google-protobuf (3.25.4-x86_64-linux)
     hashdiff (1.1.1)
     json (2.7.2)
     json-schema (2.8.1)
       addressable (>= 2.4)
     libdatadog (11.0.0.1.0-aarch64-linux)
+    libdatadog (11.0.0.1.0-x86_64-linux)
     libddwaf (1.14.0.0.0-aarch64-linux)
+      ffi (~> 1.0)
+    libddwaf (1.14.0.0.0-x86_64-linux)
       ffi (~> 1.0)
     memory_profiler (0.9.14)
     method_source (1.1.0)
     msgpack (1.7.2)
     os (1.1.4)
+    ostruct (0.6.0)
     parallel (1.26.3)
     parser (3.3.4.2)
       ast (~> 2.4.1)
@@ -140,6 +146,7 @@ GEM
 
 PLATFORMS
   aarch64-linux
+  x86_64-linux
 
 DEPENDENCIES
   appraisal (~> 2.4.0)
@@ -152,10 +159,12 @@ DEPENDENCIES
   dogstatsd-ruby (>= 3.3.0, != 5.1.0, != 5.0.1, != 5.0.0)
   extlz4 (~> 0.3, >= 0.3.3)
   ffi (~> 1.16.3)
+  fiddle
   google-protobuf (~> 3.0, != 3.7.1, != 3.7.0)
   json-schema (< 3)
   memory_profiler (~> 0.9)
   os (~> 1.1)
+  ostruct
   pimpmychangelog (>= 0.1.2)
   pry
   pry-stack_explorer

--- a/gemfiles/ruby_3.4_activesupport.gemfile
+++ b/gemfiles/ruby_3.4_activesupport.gemfile
@@ -32,6 +32,8 @@ gem "rubocop", "~> 1.50.0", require: false
 gem "rubocop-packaging", "~> 0.5.2", require: false
 gem "rubocop-performance", "~> 1.9", require: false
 gem "rubocop-rspec", ["~> 2.20", "< 2.21"], require: false
+gem "fiddle"
+gem "ostruct"
 gem "dogstatsd-ruby", ">= 3.3.0", "!= 5.0.0", "!= 5.0.1", "!= 5.1.0"
 gem "google-protobuf", ["~> 3.0", "!= 3.7.0", "!= 3.7.1"]
 gem "ffi", "~> 1.16.3", require: false

--- a/gemfiles/ruby_3.4_activesupport.gemfile.lock
+++ b/gemfiles/ruby_3.4_activesupport.gemfile.lock
@@ -111,6 +111,7 @@ GEM
     erubi (1.13.0)
     extlz4 (0.3.4)
     ffi (1.16.3)
+    fiddle (1.1.3)
     google-protobuf (3.25.3)
     grape (2.1.2)
       activesupport (>= 6)
@@ -158,6 +159,7 @@ GEM
       mini_portile2 (~> 2.8.2)
       racc (~> 1.4)
     os (1.1.4)
+    ostruct (0.6.0)
     parallel (1.25.1)
     parser (3.3.3.0)
       ast (~> 2.4.1)
@@ -301,12 +303,14 @@ DEPENDENCIES
   dogstatsd-ruby (>= 3.3.0, != 5.1.0, != 5.0.1, != 5.0.0)
   extlz4 (~> 0.3, >= 0.3.3)
   ffi (~> 1.16.3)
+  fiddle
   google-protobuf (~> 3.0, != 3.7.1, != 3.7.0)
   grape
   json-schema (< 3)
   lograge
   memory_profiler (~> 0.9)
   os (~> 1.1)
+  ostruct
   pimpmychangelog (>= 0.1.2)
   pry
   pry-stack_explorer

--- a/gemfiles/ruby_3.4_aws.gemfile
+++ b/gemfiles/ruby_3.4_aws.gemfile
@@ -32,6 +32,8 @@ gem "rubocop", "~> 1.50.0", require: false
 gem "rubocop-packaging", "~> 0.5.2", require: false
 gem "rubocop-performance", "~> 1.9", require: false
 gem "rubocop-rspec", ["~> 2.20", "< 2.21"], require: false
+gem "fiddle"
+gem "ostruct"
 gem "dogstatsd-ruby", ">= 3.3.0", "!= 5.0.0", "!= 5.0.1", "!= 5.1.0"
 gem "google-protobuf", ["~> 3.0", "!= 3.7.0", "!= 3.7.1"]
 gem "ffi", "~> 1.16.3", require: false

--- a/gemfiles/ruby_3.4_aws.gemfile.lock
+++ b/gemfiles/ruby_3.4_aws.gemfile.lock
@@ -1602,6 +1602,7 @@ GEM
     dogstatsd-ruby (5.6.1)
     extlz4 (0.3.4)
     ffi (1.16.3)
+    fiddle (1.1.3)
     google-protobuf (3.25.3)
     hashdiff (1.1.0)
     jmespath (1.6.2)
@@ -1622,6 +1623,7 @@ GEM
       mini_portile2 (~> 2.8.2)
       racc (~> 1.4)
     os (1.1.4)
+    ostruct (0.6.0)
     parallel (1.25.1)
     parser (3.3.3.0)
       ast (~> 2.4.1)
@@ -1721,10 +1723,12 @@ DEPENDENCIES
   dogstatsd-ruby (>= 3.3.0, != 5.1.0, != 5.0.1, != 5.0.0)
   extlz4 (~> 0.3, >= 0.3.3)
   ffi (~> 1.16.3)
+  fiddle
   google-protobuf (~> 3.0, != 3.7.1, != 3.7.0)
   json-schema (< 3)
   memory_profiler (~> 0.9)
   os (~> 1.1)
+  ostruct
   pimpmychangelog (>= 0.1.2)
   pry
   pry-stack_explorer

--- a/gemfiles/ruby_3.4_contrib.gemfile
+++ b/gemfiles/ruby_3.4_contrib.gemfile
@@ -32,6 +32,8 @@ gem "rubocop", "~> 1.50.0", require: false
 gem "rubocop-packaging", "~> 0.5.2", require: false
 gem "rubocop-performance", "~> 1.9", require: false
 gem "rubocop-rspec", ["~> 2.20", "< 2.21"], require: false
+gem "fiddle"
+gem "ostruct"
 gem "dogstatsd-ruby", ">= 3.3.0", "!= 5.0.0", "!= 5.0.1", "!= 5.1.0"
 gem "google-protobuf", ["~> 3.0", "!= 3.7.0", "!= 3.7.1"]
 gem "ffi", "~> 1.16.3", require: false

--- a/gemfiles/ruby_3.4_contrib.gemfile.lock
+++ b/gemfiles/ruby_3.4_contrib.gemfile.lock
@@ -62,6 +62,7 @@ GEM
     dogstatsd-ruby (5.6.1)
     extlz4 (0.3.4)
     ffi (1.16.3)
+    fiddle (1.1.3)
     google-protobuf (3.25.3)
     googleapis-common-protos-types (1.15.0)
       google-protobuf (>= 3.18, < 5.a)
@@ -92,6 +93,7 @@ GEM
       mini_portile2 (~> 2.8.2)
       racc (~> 1.4)
     os (1.1.4)
+    ostruct (0.6.0)
     parallel (1.25.1)
     parser (3.3.3.0)
       ast (~> 2.4.1)
@@ -240,12 +242,14 @@ DEPENDENCIES
   dogstatsd-ruby (>= 3.3.0, != 5.1.0, != 5.0.1, != 5.0.0)
   extlz4 (~> 0.3, >= 0.3.3)
   ffi (~> 1.16.3)
+  fiddle
   google-protobuf (~> 3.0, != 3.7.1, != 3.7.0)
   grpc (>= 1.38.0)
   json-schema (< 3)
   memory_profiler (~> 0.9)
   mongo (>= 2.8.0, < 2.15.0)
   os (~> 1.1)
+  ostruct
   pimpmychangelog (>= 0.1.2)
   pry
   pry-stack_explorer

--- a/gemfiles/ruby_3.4_contrib_old.gemfile
+++ b/gemfiles/ruby_3.4_contrib_old.gemfile
@@ -32,6 +32,8 @@ gem "rubocop", "~> 1.50.0", require: false
 gem "rubocop-packaging", "~> 0.5.2", require: false
 gem "rubocop-performance", "~> 1.9", require: false
 gem "rubocop-rspec", ["~> 2.20", "< 2.21"], require: false
+gem "fiddle"
+gem "ostruct"
 gem "dogstatsd-ruby", ">= 3.3.0", "!= 5.0.0", "!= 5.0.1", "!= 5.1.0"
 gem "google-protobuf", ["~> 3.0", "!= 3.7.0", "!= 3.7.1"]
 gem "ffi", "~> 1.16.3", require: false

--- a/gemfiles/ruby_3.4_contrib_old.gemfile.lock
+++ b/gemfiles/ruby_3.4_contrib_old.gemfile.lock
@@ -64,6 +64,7 @@ GEM
     faraday_middleware (0.12.2)
       faraday (>= 0.7.4, < 1.0)
     ffi (1.16.3)
+    fiddle (1.1.3)
     google-protobuf (3.25.3)
     hashdiff (1.1.0)
     hitimes (1.3.1)
@@ -91,6 +92,7 @@ GEM
       mini_portile2 (~> 2.8.2)
       racc (~> 1.4)
     os (1.1.4)
+    ostruct (0.6.0)
     parallel (1.25.1)
     parser (3.3.3.0)
       ast (~> 2.4.1)
@@ -221,10 +223,12 @@ DEPENDENCIES
   dogstatsd-ruby (>= 3.3.0, != 5.1.0, != 5.0.1, != 5.0.0)
   extlz4 (~> 0.3, >= 0.3.3)
   ffi (~> 1.16.3)
+  fiddle
   google-protobuf (~> 3.0, != 3.7.1, != 3.7.0)
   json-schema (< 3)
   memory_profiler (~> 0.9)
   os (~> 1.1)
+  ostruct
   pimpmychangelog (>= 0.1.2)
   presto-client (>= 0.5.14)
   pry

--- a/gemfiles/ruby_3.4_core_old.gemfile
+++ b/gemfiles/ruby_3.4_core_old.gemfile
@@ -32,6 +32,8 @@ gem "rubocop", "~> 1.50.0", require: false
 gem "rubocop-packaging", "~> 0.5.2", require: false
 gem "rubocop-performance", "~> 1.9", require: false
 gem "rubocop-rspec", ["~> 2.20", "< 2.21"], require: false
+gem "fiddle"
+gem "ostruct"
 gem "dogstatsd-ruby", "~> 4"
 gem "google-protobuf", ["~> 3.0", "!= 3.7.0", "!= 3.7.1"]
 gem "ffi", "~> 1.16.3", require: false

--- a/gemfiles/ruby_3.4_core_old.gemfile.lock
+++ b/gemfiles/ruby_3.4_core_old.gemfile.lock
@@ -54,6 +54,7 @@ GEM
     dogstatsd-ruby (4.8.3)
     extlz4 (0.3.4)
     ffi (1.16.3)
+    fiddle (1.1.3)
     google-protobuf (3.25.3)
     hashdiff (1.1.0)
     json (2.7.2)
@@ -73,6 +74,7 @@ GEM
       mini_portile2 (~> 2.8.2)
       racc (~> 1.4)
     os (1.1.4)
+    ostruct (0.6.0)
     parallel (1.25.1)
     parser (3.3.3.0)
       ast (~> 2.4.1)
@@ -167,10 +169,12 @@ DEPENDENCIES
   dogstatsd-ruby (~> 4)
   extlz4 (~> 0.3, >= 0.3.3)
   ffi (~> 1.16.3)
+  fiddle
   google-protobuf (~> 3.0, != 3.7.1, != 3.7.0)
   json-schema (< 3)
   memory_profiler (~> 0.9)
   os (~> 1.1)
+  ostruct
   pimpmychangelog (>= 0.1.2)
   pry
   pry-stack_explorer

--- a/gemfiles/ruby_3.4_elasticsearch_7.gemfile
+++ b/gemfiles/ruby_3.4_elasticsearch_7.gemfile
@@ -32,6 +32,8 @@ gem "rubocop", "~> 1.50.0", require: false
 gem "rubocop-packaging", "~> 0.5.2", require: false
 gem "rubocop-performance", "~> 1.9", require: false
 gem "rubocop-rspec", ["~> 2.20", "< 2.21"], require: false
+gem "fiddle"
+gem "ostruct"
 gem "dogstatsd-ruby", ">= 3.3.0", "!= 5.0.0", "!= 5.0.1", "!= 5.1.0"
 gem "google-protobuf", ["~> 3.0", "!= 3.7.0", "!= 3.7.1"]
 gem "ffi", "~> 1.16.3", require: false

--- a/gemfiles/ruby_3.4_elasticsearch_7.gemfile.lock
+++ b/gemfiles/ruby_3.4_elasticsearch_7.gemfile.lock
@@ -68,6 +68,7 @@ GEM
     faraday-net_http (3.1.0)
       net-http
     ffi (1.16.3)
+    fiddle (1.1.3)
     google-protobuf (3.25.3)
     hashdiff (1.1.0)
     json (2.7.2)
@@ -90,6 +91,7 @@ GEM
       mini_portile2 (~> 2.8.2)
       racc (~> 1.4)
     os (1.1.4)
+    ostruct (0.6.0)
     parallel (1.25.1)
     parser (3.3.3.0)
       ast (~> 2.4.1)
@@ -186,10 +188,12 @@ DEPENDENCIES
   elasticsearch (~> 7)
   extlz4 (~> 0.3, >= 0.3.3)
   ffi (~> 1.16.3)
+  fiddle
   google-protobuf (~> 3.0, != 3.7.1, != 3.7.0)
   json-schema (< 3)
   memory_profiler (~> 0.9)
   os (~> 1.1)
+  ostruct
   pimpmychangelog (>= 0.1.2)
   pry
   pry-stack_explorer

--- a/gemfiles/ruby_3.4_elasticsearch_8.gemfile
+++ b/gemfiles/ruby_3.4_elasticsearch_8.gemfile
@@ -32,6 +32,8 @@ gem "rubocop", "~> 1.50.0", require: false
 gem "rubocop-packaging", "~> 0.5.2", require: false
 gem "rubocop-performance", "~> 1.9", require: false
 gem "rubocop-rspec", ["~> 2.20", "< 2.21"], require: false
+gem "fiddle"
+gem "ostruct"
 gem "dogstatsd-ruby", ">= 3.3.0", "!= 5.0.0", "!= 5.0.1", "!= 5.1.0"
 gem "google-protobuf", ["~> 3.0", "!= 3.7.0", "!= 3.7.1"]
 gem "ffi", "~> 1.16.3", require: false

--- a/gemfiles/ruby_3.4_elasticsearch_8.gemfile.lock
+++ b/gemfiles/ruby_3.4_elasticsearch_8.gemfile.lock
@@ -66,6 +66,7 @@ GEM
     faraday-net_http (3.1.0)
       net-http
     ffi (1.16.3)
+    fiddle (1.1.3)
     google-protobuf (3.25.3)
     hashdiff (1.1.0)
     json (2.7.2)
@@ -88,6 +89,7 @@ GEM
       mini_portile2 (~> 2.8.2)
       racc (~> 1.4)
     os (1.1.4)
+    ostruct (0.6.0)
     parallel (1.25.1)
     parser (3.3.3.0)
       ast (~> 2.4.1)
@@ -184,10 +186,12 @@ DEPENDENCIES
   elasticsearch (~> 8)
   extlz4 (~> 0.3, >= 0.3.3)
   ffi (~> 1.16.3)
+  fiddle
   google-protobuf (~> 3.0, != 3.7.1, != 3.7.0)
   json-schema (< 3)
   memory_profiler (~> 0.9)
   os (~> 1.1)
+  ostruct
   pimpmychangelog (>= 0.1.2)
   pry
   pry-stack_explorer

--- a/gemfiles/ruby_3.4_graphql_1.13.gemfile
+++ b/gemfiles/ruby_3.4_graphql_1.13.gemfile
@@ -32,6 +32,8 @@ gem "rubocop", "~> 1.50.0", require: false
 gem "rubocop-packaging", "~> 0.5.2", require: false
 gem "rubocop-performance", "~> 1.9", require: false
 gem "rubocop-rspec", ["~> 2.20", "< 2.21"], require: false
+gem "fiddle"
+gem "ostruct"
 gem "dogstatsd-ruby", ">= 3.3.0", "!= 5.0.0", "!= 5.0.1", "!= 5.1.0"
 gem "google-protobuf", ["~> 3.0", "!= 3.7.0", "!= 3.7.1"]
 gem "ffi", "~> 1.16.3", require: false

--- a/gemfiles/ruby_3.4_graphql_1.13.gemfile.lock
+++ b/gemfiles/ruby_3.4_graphql_1.13.gemfile.lock
@@ -117,6 +117,7 @@ GEM
     erubi (1.13.0)
     extlz4 (0.3.4)
     ffi (1.16.3)
+    fiddle (1.1.3)
     globalid (1.2.1)
       activesupport (>= 6.1)
     google-protobuf (3.25.3)
@@ -168,6 +169,7 @@ GEM
       mini_portile2 (~> 2.8.2)
       racc (~> 1.4)
     os (1.1.4)
+    ostruct (0.6.0)
     parallel (1.25.1)
     parser (3.3.3.0)
       ast (~> 2.4.1)
@@ -310,6 +312,7 @@ DEPENDENCIES
   dogstatsd-ruby (>= 3.3.0, != 5.1.0, != 5.0.1, != 5.0.0)
   extlz4 (~> 0.3, >= 0.3.3)
   ffi (~> 1.16.3)
+  fiddle
   google-protobuf (~> 3.0, != 3.7.1, != 3.7.0)
   graphql (~> 1.13.0)
   json-schema (< 3)
@@ -317,6 +320,7 @@ DEPENDENCIES
   memory_profiler (~> 0.9)
   mutex_m (>= 0.1.0)
   os (~> 1.1)
+  ostruct
   pimpmychangelog (>= 0.1.2)
   pry
   pry-stack_explorer

--- a/gemfiles/ruby_3.4_graphql_2.0.gemfile
+++ b/gemfiles/ruby_3.4_graphql_2.0.gemfile
@@ -32,6 +32,8 @@ gem "rubocop", "~> 1.50.0", require: false
 gem "rubocop-packaging", "~> 0.5.2", require: false
 gem "rubocop-performance", "~> 1.9", require: false
 gem "rubocop-rspec", ["~> 2.20", "< 2.21"], require: false
+gem "fiddle"
+gem "ostruct"
 gem "dogstatsd-ruby", ">= 3.3.0", "!= 5.0.0", "!= 5.0.1", "!= 5.1.0"
 gem "google-protobuf", ["~> 3.0", "!= 3.7.0", "!= 3.7.1"]
 gem "ffi", "~> 1.16.3", require: false

--- a/gemfiles/ruby_3.4_graphql_2.0.gemfile.lock
+++ b/gemfiles/ruby_3.4_graphql_2.0.gemfile.lock
@@ -117,6 +117,7 @@ GEM
     erubi (1.13.0)
     extlz4 (0.3.4)
     ffi (1.16.3)
+    fiddle (1.1.3)
     globalid (1.2.1)
       activesupport (>= 6.1)
     google-protobuf (3.25.3)
@@ -168,6 +169,7 @@ GEM
       mini_portile2 (~> 2.8.2)
       racc (~> 1.4)
     os (1.1.4)
+    ostruct (0.6.0)
     parallel (1.25.1)
     parser (3.3.3.0)
       ast (~> 2.4.1)
@@ -310,6 +312,7 @@ DEPENDENCIES
   dogstatsd-ruby (>= 3.3.0, != 5.1.0, != 5.0.1, != 5.0.0)
   extlz4 (~> 0.3, >= 0.3.3)
   ffi (~> 1.16.3)
+  fiddle
   google-protobuf (~> 3.0, != 3.7.1, != 3.7.0)
   graphql (~> 2.0.0)
   json-schema (< 3)
@@ -317,6 +320,7 @@ DEPENDENCIES
   memory_profiler (~> 0.9)
   mutex_m (>= 0.1.0)
   os (~> 1.1)
+  ostruct
   pimpmychangelog (>= 0.1.2)
   pry
   pry-stack_explorer

--- a/gemfiles/ruby_3.4_graphql_2.1.gemfile
+++ b/gemfiles/ruby_3.4_graphql_2.1.gemfile
@@ -32,6 +32,8 @@ gem "rubocop", "~> 1.50.0", require: false
 gem "rubocop-packaging", "~> 0.5.2", require: false
 gem "rubocop-performance", "~> 1.9", require: false
 gem "rubocop-rspec", ["~> 2.20", "< 2.21"], require: false
+gem "fiddle"
+gem "ostruct"
 gem "dogstatsd-ruby", ">= 3.3.0", "!= 5.0.0", "!= 5.0.1", "!= 5.1.0"
 gem "google-protobuf", ["~> 3.0", "!= 3.7.0", "!= 3.7.1"]
 gem "ffi", "~> 1.16.3", require: false

--- a/gemfiles/ruby_3.4_graphql_2.1.gemfile.lock
+++ b/gemfiles/ruby_3.4_graphql_2.1.gemfile.lock
@@ -117,6 +117,7 @@ GEM
     erubi (1.13.0)
     extlz4 (0.3.4)
     ffi (1.16.3)
+    fiddle (1.1.3)
     globalid (1.2.1)
       activesupport (>= 6.1)
     google-protobuf (3.25.3)
@@ -168,6 +169,7 @@ GEM
       mini_portile2 (~> 2.8.2)
       racc (~> 1.4)
     os (1.1.4)
+    ostruct (0.6.0)
     parallel (1.25.1)
     parser (3.3.3.0)
       ast (~> 2.4.1)
@@ -310,6 +312,7 @@ DEPENDENCIES
   dogstatsd-ruby (>= 3.3.0, != 5.1.0, != 5.0.1, != 5.0.0)
   extlz4 (~> 0.3, >= 0.3.3)
   ffi (~> 1.16.3)
+  fiddle
   google-protobuf (~> 3.0, != 3.7.1, != 3.7.0)
   graphql (~> 2.1.0)
   json-schema (< 3)
@@ -317,6 +320,7 @@ DEPENDENCIES
   memory_profiler (~> 0.9)
   mutex_m (>= 0.1.0)
   os (~> 1.1)
+  ostruct
   pimpmychangelog (>= 0.1.2)
   pry
   pry-stack_explorer

--- a/gemfiles/ruby_3.4_graphql_2.2.gemfile
+++ b/gemfiles/ruby_3.4_graphql_2.2.gemfile
@@ -32,6 +32,8 @@ gem "rubocop", "~> 1.50.0", require: false
 gem "rubocop-packaging", "~> 0.5.2", require: false
 gem "rubocop-performance", "~> 1.9", require: false
 gem "rubocop-rspec", ["~> 2.20", "< 2.21"], require: false
+gem "fiddle"
+gem "ostruct"
 gem "dogstatsd-ruby", ">= 3.3.0", "!= 5.0.0", "!= 5.0.1", "!= 5.1.0"
 gem "google-protobuf", ["~> 3.0", "!= 3.7.0", "!= 3.7.1"]
 gem "ffi", "~> 1.16.3", require: false

--- a/gemfiles/ruby_3.4_graphql_2.2.gemfile.lock
+++ b/gemfiles/ruby_3.4_graphql_2.2.gemfile.lock
@@ -117,6 +117,7 @@ GEM
     erubi (1.13.0)
     extlz4 (0.3.4)
     ffi (1.16.3)
+    fiddle (1.1.3)
     globalid (1.2.1)
       activesupport (>= 6.1)
     google-protobuf (3.25.3)
@@ -168,6 +169,7 @@ GEM
       mini_portile2 (~> 2.8.2)
       racc (~> 1.4)
     os (1.1.4)
+    ostruct (0.6.0)
     parallel (1.25.1)
     parser (3.3.3.0)
       ast (~> 2.4.1)
@@ -310,6 +312,7 @@ DEPENDENCIES
   dogstatsd-ruby (>= 3.3.0, != 5.1.0, != 5.0.1, != 5.0.0)
   extlz4 (~> 0.3, >= 0.3.3)
   ffi (~> 1.16.3)
+  fiddle
   google-protobuf (~> 3.0, != 3.7.1, != 3.7.0)
   graphql (~> 2.2.0)
   json-schema (< 3)
@@ -317,6 +320,7 @@ DEPENDENCIES
   memory_profiler (~> 0.9)
   mutex_m (>= 0.1.0)
   os (~> 1.1)
+  ostruct
   pimpmychangelog (>= 0.1.2)
   pry
   pry-stack_explorer

--- a/gemfiles/ruby_3.4_graphql_2.3.gemfile
+++ b/gemfiles/ruby_3.4_graphql_2.3.gemfile
@@ -32,6 +32,8 @@ gem "rubocop", "~> 1.50.0", require: false
 gem "rubocop-packaging", "~> 0.5.2", require: false
 gem "rubocop-performance", "~> 1.9", require: false
 gem "rubocop-rspec", ["~> 2.20", "< 2.21"], require: false
+gem "fiddle"
+gem "ostruct"
 gem "dogstatsd-ruby", ">= 3.3.0", "!= 5.0.0", "!= 5.0.1", "!= 5.1.0"
 gem "google-protobuf", ["~> 3.0", "!= 3.7.0", "!= 3.7.1"]
 gem "ffi", "~> 1.16.3", require: false

--- a/gemfiles/ruby_3.4_graphql_2.3.gemfile.lock
+++ b/gemfiles/ruby_3.4_graphql_2.3.gemfile.lock
@@ -117,6 +117,7 @@ GEM
     erubi (1.13.0)
     extlz4 (0.3.4)
     ffi (1.16.3)
+    fiddle (1.1.3)
     globalid (1.2.1)
       activesupport (>= 6.1)
     google-protobuf (3.25.3)
@@ -168,6 +169,7 @@ GEM
       mini_portile2 (~> 2.8.2)
       racc (~> 1.4)
     os (1.1.4)
+    ostruct (0.6.0)
     parallel (1.25.1)
     parser (3.3.3.0)
       ast (~> 2.4.1)
@@ -310,6 +312,7 @@ DEPENDENCIES
   dogstatsd-ruby (>= 3.3.0, != 5.1.0, != 5.0.1, != 5.0.0)
   extlz4 (~> 0.3, >= 0.3.3)
   ffi (~> 1.16.3)
+  fiddle
   google-protobuf (~> 3.0, != 3.7.1, != 3.7.0)
   graphql (~> 2.3.0)
   json-schema (< 3)
@@ -317,6 +320,7 @@ DEPENDENCIES
   memory_profiler (~> 0.9)
   mutex_m (>= 0.1.0)
   os (~> 1.1)
+  ostruct
   pimpmychangelog (>= 0.1.2)
   pry
   pry-stack_explorer

--- a/gemfiles/ruby_3.4_http.gemfile
+++ b/gemfiles/ruby_3.4_http.gemfile
@@ -32,6 +32,8 @@ gem "rubocop", "~> 1.50.0", require: false
 gem "rubocop-packaging", "~> 0.5.2", require: false
 gem "rubocop-performance", "~> 1.9", require: false
 gem "rubocop-rspec", ["~> 2.20", "< 2.21"], require: false
+gem "fiddle"
+gem "ostruct"
 gem "dogstatsd-ruby", ">= 3.3.0", "!= 5.0.0", "!= 5.0.1", "!= 5.1.0"
 gem "google-protobuf", ["~> 3.0", "!= 3.7.0", "!= 3.7.1"]
 gem "ffi", "~> 1.16.3", require: false

--- a/gemfiles/ruby_3.4_http.gemfile.lock
+++ b/gemfiles/ruby_3.4_http.gemfile.lock
@@ -66,6 +66,7 @@ GEM
     ffi-compiler (1.3.2)
       ffi (>= 1.15.5)
       rake
+    fiddle (1.1.3)
     google-protobuf (3.25.3)
     hashdiff (1.1.0)
     http (5.2.0)
@@ -105,6 +106,7 @@ GEM
       mini_portile2 (~> 2.8.2)
       racc (~> 1.4)
     os (1.1.4)
+    ostruct (0.6.0)
     parallel (1.25.1)
     parser (3.3.3.0)
       ast (~> 2.4.1)
@@ -210,12 +212,14 @@ DEPENDENCIES
   extlz4 (~> 0.3, >= 0.3.3)
   faraday
   ffi (~> 1.16.3)
+  fiddle
   google-protobuf (~> 3.0, != 3.7.1, != 3.7.0)
   http
   httpclient
   json-schema (< 3)
   memory_profiler (~> 0.9)
   os (~> 1.1)
+  ostruct
   pimpmychangelog (>= 0.1.2)
   pry
   pry-stack_explorer

--- a/gemfiles/ruby_3.4_opensearch_2.gemfile
+++ b/gemfiles/ruby_3.4_opensearch_2.gemfile
@@ -32,6 +32,8 @@ gem "rubocop", "~> 1.50.0", require: false
 gem "rubocop-packaging", "~> 0.5.2", require: false
 gem "rubocop-performance", "~> 1.9", require: false
 gem "rubocop-rspec", ["~> 2.20", "< 2.21"], require: false
+gem "fiddle"
+gem "ostruct"
 gem "dogstatsd-ruby", ">= 3.3.0", "!= 5.0.0", "!= 5.0.1", "!= 5.1.0"
 gem "google-protobuf", ["~> 3.0", "!= 3.7.0", "!= 3.7.1"]
 gem "ffi", "~> 1.16.3", require: false

--- a/gemfiles/ruby_3.4_opensearch_2.gemfile.lock
+++ b/gemfiles/ruby_3.4_opensearch_2.gemfile.lock
@@ -58,6 +58,7 @@ GEM
     faraday-net_http (3.1.0)
       net-http
     ffi (1.16.3)
+    fiddle (1.1.3)
     google-protobuf (3.25.3)
     hashdiff (1.1.0)
     json (2.7.2)
@@ -88,6 +89,7 @@ GEM
       faraday (>= 1.0, < 3)
       multi_json
     os (1.1.4)
+    ostruct (0.6.0)
     parallel (1.25.1)
     parser (3.3.3.0)
       ast (~> 2.4.1)
@@ -183,11 +185,13 @@ DEPENDENCIES
   dogstatsd-ruby (>= 3.3.0, != 5.1.0, != 5.0.1, != 5.0.0)
   extlz4 (~> 0.3, >= 0.3.3)
   ffi (~> 1.16.3)
+  fiddle
   google-protobuf (~> 3.0, != 3.7.1, != 3.7.0)
   json-schema (< 3)
   memory_profiler (~> 0.9)
   opensearch-ruby (~> 2)
   os (~> 1.1)
+  ostruct
   pimpmychangelog (>= 0.1.2)
   pry
   pry-stack_explorer

--- a/gemfiles/ruby_3.4_opensearch_3.gemfile
+++ b/gemfiles/ruby_3.4_opensearch_3.gemfile
@@ -32,6 +32,8 @@ gem "rubocop", "~> 1.50.0", require: false
 gem "rubocop-packaging", "~> 0.5.2", require: false
 gem "rubocop-performance", "~> 1.9", require: false
 gem "rubocop-rspec", ["~> 2.20", "< 2.21"], require: false
+gem "fiddle"
+gem "ostruct"
 gem "dogstatsd-ruby", ">= 3.3.0", "!= 5.0.0", "!= 5.0.1", "!= 5.1.0"
 gem "google-protobuf", ["~> 3.0", "!= 3.7.0", "!= 3.7.1"]
 gem "ffi", "~> 1.16.3", require: false

--- a/gemfiles/ruby_3.4_opensearch_3.gemfile.lock
+++ b/gemfiles/ruby_3.4_opensearch_3.gemfile.lock
@@ -58,6 +58,7 @@ GEM
     faraday-net_http (3.1.0)
       net-http
     ffi (1.16.3)
+    fiddle (1.1.3)
     google-protobuf (3.25.3)
     hashdiff (1.1.0)
     json (2.7.2)
@@ -83,6 +84,7 @@ GEM
       faraday (>= 1.0, < 3)
       multi_json (>= 1.0)
     os (1.1.4)
+    ostruct (0.6.0)
     parallel (1.25.1)
     parser (3.3.3.0)
       ast (~> 2.4.1)
@@ -178,11 +180,13 @@ DEPENDENCIES
   dogstatsd-ruby (>= 3.3.0, != 5.1.0, != 5.0.1, != 5.0.0)
   extlz4 (~> 0.3, >= 0.3.3)
   ffi (~> 1.16.3)
+  fiddle
   google-protobuf (~> 3.0, != 3.7.1, != 3.7.0)
   json-schema (< 3)
   memory_profiler (~> 0.9)
   opensearch-ruby (~> 3)
   os (~> 1.1)
+  ostruct
   pimpmychangelog (>= 0.1.2)
   pry
   pry-stack_explorer

--- a/gemfiles/ruby_3.4_opentelemetry.gemfile
+++ b/gemfiles/ruby_3.4_opentelemetry.gemfile
@@ -32,6 +32,8 @@ gem "rubocop", "~> 1.50.0", require: false
 gem "rubocop-packaging", "~> 0.5.2", require: false
 gem "rubocop-performance", "~> 1.9", require: false
 gem "rubocop-rspec", ["~> 2.20", "< 2.21"], require: false
+gem "fiddle"
+gem "ostruct"
 gem "dogstatsd-ruby", ">= 3.3.0", "!= 5.0.0", "!= 5.0.1", "!= 5.1.0"
 gem "google-protobuf", ["~> 3.0", "!= 3.7.0", "!= 3.7.1"]
 gem "ffi", "~> 1.16.3", require: false

--- a/gemfiles/ruby_3.4_opentelemetry.gemfile.lock
+++ b/gemfiles/ruby_3.4_opentelemetry.gemfile.lock
@@ -54,6 +54,7 @@ GEM
     dogstatsd-ruby (5.6.1)
     extlz4 (0.3.4)
     ffi (1.16.3)
+    fiddle (1.1.3)
     google-protobuf (3.25.3)
     hashdiff (1.1.0)
     json (2.7.2)
@@ -85,6 +86,7 @@ GEM
     opentelemetry-semantic_conventions (1.10.0)
       opentelemetry-api (~> 1.0)
     os (1.1.4)
+    ostruct (0.6.0)
     parallel (1.25.1)
     parser (3.3.3.0)
       ast (~> 2.4.1)
@@ -179,11 +181,13 @@ DEPENDENCIES
   dogstatsd-ruby (>= 3.3.0, != 5.1.0, != 5.0.1, != 5.0.0)
   extlz4 (~> 0.3, >= 0.3.3)
   ffi (~> 1.16.3)
+  fiddle
   google-protobuf (~> 3.0, != 3.7.1, != 3.7.0)
   json-schema (< 3)
   memory_profiler (~> 0.9)
   opentelemetry-sdk (~> 1.1)
   os (~> 1.1)
+  ostruct
   pimpmychangelog (>= 0.1.2)
   pry
   pry-stack_explorer

--- a/gemfiles/ruby_3.4_rack_2.gemfile
+++ b/gemfiles/ruby_3.4_rack_2.gemfile
@@ -32,6 +32,8 @@ gem "rubocop", "~> 1.50.0", require: false
 gem "rubocop-packaging", "~> 0.5.2", require: false
 gem "rubocop-performance", "~> 1.9", require: false
 gem "rubocop-rspec", ["~> 2.20", "< 2.21"], require: false
+gem "fiddle"
+gem "ostruct"
 gem "dogstatsd-ruby", ">= 3.3.0", "!= 5.0.0", "!= 5.0.1", "!= 5.1.0"
 gem "google-protobuf", ["~> 3.0", "!= 3.7.0", "!= 3.7.1"]
 gem "ffi", "~> 1.16.3", require: false

--- a/gemfiles/ruby_3.4_rack_2.gemfile.lock
+++ b/gemfiles/ruby_3.4_rack_2.gemfile.lock
@@ -54,6 +54,7 @@ GEM
     dogstatsd-ruby (5.6.1)
     extlz4 (0.3.4)
     ffi (1.16.3)
+    fiddle (1.1.3)
     google-protobuf (3.25.3)
     hashdiff (1.1.0)
     json (2.7.2)
@@ -73,6 +74,7 @@ GEM
       mini_portile2 (~> 2.8.2)
       racc (~> 1.4)
     os (1.1.4)
+    ostruct (0.6.0)
     parallel (1.25.1)
     parser (3.3.3.0)
       ast (~> 2.4.1)
@@ -172,10 +174,12 @@ DEPENDENCIES
   dogstatsd-ruby (>= 3.3.0, != 5.1.0, != 5.0.1, != 5.0.0)
   extlz4 (~> 0.3, >= 0.3.3)
   ffi (~> 1.16.3)
+  fiddle
   google-protobuf (~> 3.0, != 3.7.1, != 3.7.0)
   json-schema (< 3)
   memory_profiler (~> 0.9)
   os (~> 1.1)
+  ostruct
   pimpmychangelog (>= 0.1.2)
   pry
   pry-stack_explorer

--- a/gemfiles/ruby_3.4_rack_3.gemfile
+++ b/gemfiles/ruby_3.4_rack_3.gemfile
@@ -32,6 +32,8 @@ gem "rubocop", "~> 1.50.0", require: false
 gem "rubocop-packaging", "~> 0.5.2", require: false
 gem "rubocop-performance", "~> 1.9", require: false
 gem "rubocop-rspec", ["~> 2.20", "< 2.21"], require: false
+gem "fiddle"
+gem "ostruct"
 gem "dogstatsd-ruby", ">= 3.3.0", "!= 5.0.0", "!= 5.0.1", "!= 5.1.0"
 gem "google-protobuf", ["~> 3.0", "!= 3.7.0", "!= 3.7.1"]
 gem "ffi", "~> 1.16.3", require: false

--- a/gemfiles/ruby_3.4_rack_3.gemfile.lock
+++ b/gemfiles/ruby_3.4_rack_3.gemfile.lock
@@ -54,6 +54,7 @@ GEM
     dogstatsd-ruby (5.6.1)
     extlz4 (0.3.4)
     ffi (1.16.3)
+    fiddle (1.1.3)
     google-protobuf (3.25.3)
     hashdiff (1.1.0)
     json (2.7.2)
@@ -73,6 +74,7 @@ GEM
       mini_portile2 (~> 2.8.2)
       racc (~> 1.4)
     os (1.1.4)
+    ostruct (0.6.0)
     parallel (1.25.1)
     parser (3.3.3.0)
       ast (~> 2.4.1)
@@ -172,10 +174,12 @@ DEPENDENCIES
   dogstatsd-ruby (>= 3.3.0, != 5.1.0, != 5.0.1, != 5.0.0)
   extlz4 (~> 0.3, >= 0.3.3)
   ffi (~> 1.16.3)
+  fiddle
   google-protobuf (~> 3.0, != 3.7.1, != 3.7.0)
   json-schema (< 3)
   memory_profiler (~> 0.9)
   os (~> 1.1)
+  ostruct
   pimpmychangelog (>= 0.1.2)
   pry
   pry-stack_explorer

--- a/gemfiles/ruby_3.4_rails61_mysql2.gemfile
+++ b/gemfiles/ruby_3.4_rails61_mysql2.gemfile
@@ -32,6 +32,8 @@ gem "rubocop", "~> 1.50.0", require: false
 gem "rubocop-packaging", "~> 0.5.2", require: false
 gem "rubocop-performance", "~> 1.9", require: false
 gem "rubocop-rspec", ["~> 2.20", "< 2.21"], require: false
+gem "fiddle"
+gem "ostruct"
 gem "dogstatsd-ruby", ">= 3.3.0", "!= 5.0.0", "!= 5.0.1", "!= 5.1.0"
 gem "google-protobuf", ["~> 3.0", "!= 3.7.0", "!= 3.7.1"]
 gem "ffi", "~> 1.16.3", require: false

--- a/gemfiles/ruby_3.4_rails61_mysql2.gemfile.lock
+++ b/gemfiles/ruby_3.4_rails61_mysql2.gemfile.lock
@@ -117,6 +117,7 @@ GEM
     erubi (1.13.0)
     extlz4 (0.3.4)
     ffi (1.16.3)
+    fiddle (1.1.3)
     globalid (1.2.1)
       activesupport (>= 6.1)
     google-protobuf (3.25.3)
@@ -166,6 +167,7 @@ GEM
       mini_portile2 (~> 2.8.2)
       racc (~> 1.4)
     os (1.1.4)
+    ostruct (0.6.0)
     parallel (1.25.1)
     parser (3.3.3.0)
       ast (~> 2.4.1)
@@ -308,6 +310,7 @@ DEPENDENCIES
   dogstatsd-ruby (>= 3.3.0, != 5.1.0, != 5.0.1, != 5.0.0)
   extlz4 (~> 0.3, >= 0.3.3)
   ffi (~> 1.16.3)
+  fiddle
   google-protobuf (~> 3.0, != 3.7.1, != 3.7.0)
   json-schema (< 3)
   lograge (~> 0.11)
@@ -315,6 +318,7 @@ DEPENDENCIES
   mysql2 (~> 0.5)
   net-smtp
   os (~> 1.1)
+  ostruct
   pimpmychangelog (>= 0.1.2)
   pry
   pry-stack_explorer

--- a/gemfiles/ruby_3.4_rails61_postgres.gemfile
+++ b/gemfiles/ruby_3.4_rails61_postgres.gemfile
@@ -32,6 +32,8 @@ gem "rubocop", "~> 1.50.0", require: false
 gem "rubocop-packaging", "~> 0.5.2", require: false
 gem "rubocop-performance", "~> 1.9", require: false
 gem "rubocop-rspec", ["~> 2.20", "< 2.21"], require: false
+gem "fiddle"
+gem "ostruct"
 gem "dogstatsd-ruby", ">= 3.3.0", "!= 5.0.0", "!= 5.0.1", "!= 5.1.0"
 gem "google-protobuf", ["~> 3.0", "!= 3.7.0", "!= 3.7.1"]
 gem "ffi", "~> 1.16.3", require: false

--- a/gemfiles/ruby_3.4_rails61_postgres.gemfile.lock
+++ b/gemfiles/ruby_3.4_rails61_postgres.gemfile.lock
@@ -117,6 +117,7 @@ GEM
     erubi (1.13.0)
     extlz4 (0.3.4)
     ffi (1.16.3)
+    fiddle (1.1.3)
     globalid (1.2.1)
       activesupport (>= 6.1)
     google-protobuf (3.25.3)
@@ -165,6 +166,7 @@ GEM
       mini_portile2 (~> 2.8.2)
       racc (~> 1.4)
     os (1.1.4)
+    ostruct (0.6.0)
     parallel (1.25.1)
     parser (3.3.3.0)
       ast (~> 2.4.1)
@@ -308,12 +310,14 @@ DEPENDENCIES
   dogstatsd-ruby (>= 3.3.0, != 5.1.0, != 5.0.1, != 5.0.0)
   extlz4 (~> 0.3, >= 0.3.3)
   ffi (~> 1.16.3)
+  fiddle
   google-protobuf (~> 3.0, != 3.7.1, != 3.7.0)
   json-schema (< 3)
   lograge (~> 0.11)
   memory_profiler (~> 0.9)
   net-smtp
   os (~> 1.1)
+  ostruct
   pg (>= 1.1)
   pimpmychangelog (>= 0.1.2)
   pry

--- a/gemfiles/ruby_3.4_rails61_postgres_redis.gemfile
+++ b/gemfiles/ruby_3.4_rails61_postgres_redis.gemfile
@@ -32,6 +32,8 @@ gem "rubocop", "~> 1.50.0", require: false
 gem "rubocop-packaging", "~> 0.5.2", require: false
 gem "rubocop-performance", "~> 1.9", require: false
 gem "rubocop-rspec", ["~> 2.20", "< 2.21"], require: false
+gem "fiddle"
+gem "ostruct"
 gem "dogstatsd-ruby", ">= 3.3.0", "!= 5.0.0", "!= 5.0.1", "!= 5.1.0"
 gem "google-protobuf", ["~> 3.0", "!= 3.7.0", "!= 3.7.1"]
 gem "ffi", "~> 1.16.3", require: false

--- a/gemfiles/ruby_3.4_rails61_postgres_redis.gemfile.lock
+++ b/gemfiles/ruby_3.4_rails61_postgres_redis.gemfile.lock
@@ -117,6 +117,7 @@ GEM
     erubi (1.13.0)
     extlz4 (0.3.4)
     ffi (1.16.3)
+    fiddle (1.1.3)
     globalid (1.2.1)
       activesupport (>= 6.1)
     google-protobuf (3.25.3)
@@ -165,6 +166,7 @@ GEM
       mini_portile2 (~> 2.8.2)
       racc (~> 1.4)
     os (1.1.4)
+    ostruct (0.6.0)
     parallel (1.25.1)
     parser (3.3.3.0)
       ast (~> 2.4.1)
@@ -309,12 +311,14 @@ DEPENDENCIES
   dogstatsd-ruby (>= 3.3.0, != 5.1.0, != 5.0.1, != 5.0.0)
   extlz4 (~> 0.3, >= 0.3.3)
   ffi (~> 1.16.3)
+  fiddle
   google-protobuf (~> 3.0, != 3.7.1, != 3.7.0)
   json-schema (< 3)
   lograge (~> 0.11)
   memory_profiler (~> 0.9)
   net-smtp
   os (~> 1.1)
+  ostruct
   pg (>= 1.1)
   pimpmychangelog (>= 0.1.2)
   pry

--- a/gemfiles/ruby_3.4_rails61_postgres_sidekiq.gemfile
+++ b/gemfiles/ruby_3.4_rails61_postgres_sidekiq.gemfile
@@ -32,6 +32,8 @@ gem "rubocop", "~> 1.50.0", require: false
 gem "rubocop-packaging", "~> 0.5.2", require: false
 gem "rubocop-performance", "~> 1.9", require: false
 gem "rubocop-rspec", ["~> 2.20", "< 2.21"], require: false
+gem "fiddle"
+gem "ostruct"
 gem "dogstatsd-ruby", ">= 3.3.0", "!= 5.0.0", "!= 5.0.1", "!= 5.1.0"
 gem "google-protobuf", ["~> 3.0", "!= 3.7.0", "!= 3.7.1"]
 gem "ffi", "~> 1.16.3", require: false

--- a/gemfiles/ruby_3.4_rails61_postgres_sidekiq.gemfile.lock
+++ b/gemfiles/ruby_3.4_rails61_postgres_sidekiq.gemfile.lock
@@ -118,6 +118,7 @@ GEM
     erubi (1.13.0)
     extlz4 (0.3.4)
     ffi (1.16.3)
+    fiddle (1.1.3)
     globalid (1.2.1)
       activesupport (>= 6.1)
     google-protobuf (3.25.3)
@@ -166,6 +167,7 @@ GEM
       mini_portile2 (~> 2.8.2)
       racc (~> 1.4)
     os (1.1.4)
+    ostruct (0.6.0)
     parallel (1.25.1)
     parser (3.3.3.0)
       ast (~> 2.4.1)
@@ -322,12 +324,14 @@ DEPENDENCIES
   dogstatsd-ruby (>= 3.3.0, != 5.1.0, != 5.0.1, != 5.0.0)
   extlz4 (~> 0.3, >= 0.3.3)
   ffi (~> 1.16.3)
+  fiddle
   google-protobuf (~> 3.0, != 3.7.1, != 3.7.0)
   json-schema (< 3)
   lograge (~> 0.11)
   memory_profiler (~> 0.9)
   net-smtp
   os (~> 1.1)
+  ostruct
   pg (>= 1.1)
   pimpmychangelog (>= 0.1.2)
   pry

--- a/gemfiles/ruby_3.4_rails61_semantic_logger.gemfile
+++ b/gemfiles/ruby_3.4_rails61_semantic_logger.gemfile
@@ -32,6 +32,8 @@ gem "rubocop", "~> 1.50.0", require: false
 gem "rubocop-packaging", "~> 0.5.2", require: false
 gem "rubocop-performance", "~> 1.9", require: false
 gem "rubocop-rspec", ["~> 2.20", "< 2.21"], require: false
+gem "fiddle"
+gem "ostruct"
 gem "dogstatsd-ruby", ">= 3.3.0", "!= 5.0.0", "!= 5.0.1", "!= 5.1.0"
 gem "google-protobuf", ["~> 3.0", "!= 3.7.0", "!= 3.7.1"]
 gem "ffi", "~> 1.16.3", require: false

--- a/gemfiles/ruby_3.4_rails61_semantic_logger.gemfile.lock
+++ b/gemfiles/ruby_3.4_rails61_semantic_logger.gemfile.lock
@@ -117,6 +117,7 @@ GEM
     erubi (1.13.0)
     extlz4 (0.3.4)
     ffi (1.16.3)
+    fiddle (1.1.3)
     globalid (1.2.1)
       activesupport (>= 6.1)
     google-protobuf (3.25.3)
@@ -160,6 +161,7 @@ GEM
       mini_portile2 (~> 2.8.2)
       racc (~> 1.4)
     os (1.1.4)
+    ostruct (0.6.0)
     parallel (1.25.1)
     parser (3.3.3.0)
       ast (~> 2.4.1)
@@ -307,11 +309,13 @@ DEPENDENCIES
   dogstatsd-ruby (>= 3.3.0, != 5.1.0, != 5.0.1, != 5.0.0)
   extlz4 (~> 0.3, >= 0.3.3)
   ffi (~> 1.16.3)
+  fiddle
   google-protobuf (~> 3.0, != 3.7.1, != 3.7.0)
   json-schema (< 3)
   memory_profiler (~> 0.9)
   net-smtp
   os (~> 1.1)
+  ostruct
   pg (>= 1.1)
   pimpmychangelog (>= 0.1.2)
   pry

--- a/gemfiles/ruby_3.4_rails61_trilogy.gemfile
+++ b/gemfiles/ruby_3.4_rails61_trilogy.gemfile
@@ -32,6 +32,8 @@ gem "rubocop", "~> 1.50.0", require: false
 gem "rubocop-packaging", "~> 0.5.2", require: false
 gem "rubocop-performance", "~> 1.9", require: false
 gem "rubocop-rspec", ["~> 2.20", "< 2.21"], require: false
+gem "fiddle"
+gem "ostruct"
 gem "dogstatsd-ruby", ">= 3.3.0", "!= 5.0.0", "!= 5.0.1", "!= 5.1.0"
 gem "google-protobuf", ["~> 3.0", "!= 3.7.0", "!= 3.7.1"]
 gem "ffi", "~> 1.16.3", require: false

--- a/gemfiles/ruby_3.4_rails61_trilogy.gemfile.lock
+++ b/gemfiles/ruby_3.4_rails61_trilogy.gemfile.lock
@@ -120,6 +120,7 @@ GEM
     erubi (1.13.0)
     extlz4 (0.3.4)
     ffi (1.16.3)
+    fiddle (1.1.3)
     globalid (1.2.1)
       activesupport (>= 6.1)
     google-protobuf (3.25.3)
@@ -168,6 +169,7 @@ GEM
       mini_portile2 (~> 2.8.2)
       racc (~> 1.4)
     os (1.1.4)
+    ostruct (0.6.0)
     parallel (1.25.1)
     parser (3.3.3.0)
       ast (~> 2.4.1)
@@ -312,12 +314,14 @@ DEPENDENCIES
   dogstatsd-ruby (>= 3.3.0, != 5.1.0, != 5.0.1, != 5.0.0)
   extlz4 (~> 0.3, >= 0.3.3)
   ffi (~> 1.16.3)
+  fiddle
   google-protobuf (~> 3.0, != 3.7.1, != 3.7.0)
   json-schema (< 3)
   lograge (~> 0.11)
   memory_profiler (~> 0.9)
   net-smtp
   os (~> 1.1)
+  ostruct
   pimpmychangelog (>= 0.1.2)
   pry
   pry-stack_explorer

--- a/gemfiles/ruby_3.4_redis_3.gemfile
+++ b/gemfiles/ruby_3.4_redis_3.gemfile
@@ -32,6 +32,8 @@ gem "rubocop", "~> 1.50.0", require: false
 gem "rubocop-packaging", "~> 0.5.2", require: false
 gem "rubocop-performance", "~> 1.9", require: false
 gem "rubocop-rspec", ["~> 2.20", "< 2.21"], require: false
+gem "fiddle"
+gem "ostruct"
 gem "dogstatsd-ruby", ">= 3.3.0", "!= 5.0.0", "!= 5.0.1", "!= 5.1.0"
 gem "google-protobuf", ["~> 3.0", "!= 3.7.0", "!= 3.7.1"]
 gem "ffi", "~> 1.16.3", require: false

--- a/gemfiles/ruby_3.4_redis_3.gemfile.lock
+++ b/gemfiles/ruby_3.4_redis_3.gemfile.lock
@@ -54,6 +54,7 @@ GEM
     dogstatsd-ruby (5.6.1)
     extlz4 (0.3.4)
     ffi (1.16.3)
+    fiddle (1.1.3)
     google-protobuf (3.25.3)
     hashdiff (1.1.0)
     json (2.7.2)
@@ -73,6 +74,7 @@ GEM
       mini_portile2 (~> 2.8.2)
       racc (~> 1.4)
     os (1.1.4)
+    ostruct (0.6.0)
     parallel (1.25.1)
     parser (3.3.3.0)
       ast (~> 2.4.1)
@@ -168,10 +170,12 @@ DEPENDENCIES
   dogstatsd-ruby (>= 3.3.0, != 5.1.0, != 5.0.1, != 5.0.0)
   extlz4 (~> 0.3, >= 0.3.3)
   ffi (~> 1.16.3)
+  fiddle
   google-protobuf (~> 3.0, != 3.7.1, != 3.7.0)
   json-schema (< 3)
   memory_profiler (~> 0.9)
   os (~> 1.1)
+  ostruct
   pimpmychangelog (>= 0.1.2)
   pry
   pry-stack_explorer

--- a/gemfiles/ruby_3.4_redis_4.gemfile
+++ b/gemfiles/ruby_3.4_redis_4.gemfile
@@ -32,6 +32,8 @@ gem "rubocop", "~> 1.50.0", require: false
 gem "rubocop-packaging", "~> 0.5.2", require: false
 gem "rubocop-performance", "~> 1.9", require: false
 gem "rubocop-rspec", ["~> 2.20", "< 2.21"], require: false
+gem "fiddle"
+gem "ostruct"
 gem "dogstatsd-ruby", ">= 3.3.0", "!= 5.0.0", "!= 5.0.1", "!= 5.1.0"
 gem "google-protobuf", ["~> 3.0", "!= 3.7.0", "!= 3.7.1"]
 gem "ffi", "~> 1.16.3", require: false

--- a/gemfiles/ruby_3.4_redis_4.gemfile.lock
+++ b/gemfiles/ruby_3.4_redis_4.gemfile.lock
@@ -54,6 +54,7 @@ GEM
     dogstatsd-ruby (5.6.1)
     extlz4 (0.3.4)
     ffi (1.16.3)
+    fiddle (1.1.3)
     google-protobuf (3.25.3)
     hashdiff (1.1.0)
     json (2.7.2)
@@ -73,6 +74,7 @@ GEM
       mini_portile2 (~> 2.8.2)
       racc (~> 1.4)
     os (1.1.4)
+    ostruct (0.6.0)
     parallel (1.25.1)
     parser (3.3.3.0)
       ast (~> 2.4.1)
@@ -168,10 +170,12 @@ DEPENDENCIES
   dogstatsd-ruby (>= 3.3.0, != 5.1.0, != 5.0.1, != 5.0.0)
   extlz4 (~> 0.3, >= 0.3.3)
   ffi (~> 1.16.3)
+  fiddle
   google-protobuf (~> 3.0, != 3.7.1, != 3.7.0)
   json-schema (< 3)
   memory_profiler (~> 0.9)
   os (~> 1.1)
+  ostruct
   pimpmychangelog (>= 0.1.2)
   pry
   pry-stack_explorer

--- a/gemfiles/ruby_3.4_redis_5.gemfile
+++ b/gemfiles/ruby_3.4_redis_5.gemfile
@@ -32,6 +32,8 @@ gem "rubocop", "~> 1.50.0", require: false
 gem "rubocop-packaging", "~> 0.5.2", require: false
 gem "rubocop-performance", "~> 1.9", require: false
 gem "rubocop-rspec", ["~> 2.20", "< 2.21"], require: false
+gem "fiddle"
+gem "ostruct"
 gem "dogstatsd-ruby", ">= 3.3.0", "!= 5.0.0", "!= 5.0.1", "!= 5.1.0"
 gem "google-protobuf", ["~> 3.0", "!= 3.7.0", "!= 3.7.1"]
 gem "ffi", "~> 1.16.3", require: false

--- a/gemfiles/ruby_3.4_redis_5.gemfile.lock
+++ b/gemfiles/ruby_3.4_redis_5.gemfile.lock
@@ -55,6 +55,7 @@ GEM
     dogstatsd-ruby (5.6.1)
     extlz4 (0.3.4)
     ffi (1.16.3)
+    fiddle (1.1.3)
     google-protobuf (3.25.3)
     hashdiff (1.1.0)
     json (2.7.2)
@@ -74,6 +75,7 @@ GEM
       mini_portile2 (~> 2.8.2)
       racc (~> 1.4)
     os (1.1.4)
+    ostruct (0.6.0)
     parallel (1.25.1)
     parser (3.3.3.0)
       ast (~> 2.4.1)
@@ -172,10 +174,12 @@ DEPENDENCIES
   dogstatsd-ruby (>= 3.3.0, != 5.1.0, != 5.0.1, != 5.0.0)
   extlz4 (~> 0.3, >= 0.3.3)
   ffi (~> 1.16.3)
+  fiddle
   google-protobuf (~> 3.0, != 3.7.1, != 3.7.0)
   json-schema (< 3)
   memory_profiler (~> 0.9)
   os (~> 1.1)
+  ostruct
   pimpmychangelog (>= 0.1.2)
   pry
   pry-stack_explorer

--- a/gemfiles/ruby_3.4_relational_db.gemfile
+++ b/gemfiles/ruby_3.4_relational_db.gemfile
@@ -32,6 +32,8 @@ gem "rubocop", "~> 1.50.0", require: false
 gem "rubocop-packaging", "~> 0.5.2", require: false
 gem "rubocop-performance", "~> 1.9", require: false
 gem "rubocop-rspec", ["~> 2.20", "< 2.21"], require: false
+gem "fiddle"
+gem "ostruct"
 gem "dogstatsd-ruby", ">= 3.3.0", "!= 5.0.0", "!= 5.0.1", "!= 5.1.0"
 gem "google-protobuf", ["~> 3.0", "!= 3.7.0", "!= 3.7.1"]
 gem "ffi", "~> 1.16.3", require: false

--- a/gemfiles/ruby_3.4_relational_db.gemfile.lock
+++ b/gemfiles/ruby_3.4_relational_db.gemfile.lock
@@ -78,6 +78,7 @@ GEM
     drb (2.2.1)
     extlz4 (0.3.4)
     ffi (1.16.3)
+    fiddle (1.1.3)
     google-protobuf (3.25.3)
     hashdiff (1.1.0)
     i18n (1.14.5)
@@ -104,6 +105,7 @@ GEM
       mini_portile2 (~> 2.8.2)
       racc (~> 1.4)
     os (1.1.4)
+    ostruct (0.6.0)
     parallel (1.25.1)
     parser (3.3.3.0)
       ast (~> 2.4.1)
@@ -209,12 +211,14 @@ DEPENDENCIES
   dogstatsd-ruby (>= 3.3.0, != 5.1.0, != 5.0.1, != 5.0.0)
   extlz4 (~> 0.3, >= 0.3.3)
   ffi (~> 1.16.3)
+  fiddle
   google-protobuf (~> 3.0, != 3.7.1, != 3.7.0)
   json-schema (< 3)
   makara (>= 0.6.0.pre)
   memory_profiler (~> 0.9)
   mysql2 (>= 0.5.3)
   os (~> 1.1)
+  ostruct
   pg
   pimpmychangelog (>= 0.1.2)
   pry

--- a/gemfiles/ruby_3.4_resque2_redis3.gemfile
+++ b/gemfiles/ruby_3.4_resque2_redis3.gemfile
@@ -32,6 +32,8 @@ gem "rubocop", "~> 1.50.0", require: false
 gem "rubocop-packaging", "~> 0.5.2", require: false
 gem "rubocop-performance", "~> 1.9", require: false
 gem "rubocop-rspec", ["~> 2.20", "< 2.21"], require: false
+gem "fiddle"
+gem "ostruct"
 gem "dogstatsd-ruby", ">= 3.3.0", "!= 5.0.0", "!= 5.0.1", "!= 5.1.0"
 gem "google-protobuf", ["~> 3.0", "!= 3.7.0", "!= 3.7.1"]
 gem "ffi", "~> 1.16.3", require: false

--- a/gemfiles/ruby_3.4_resque2_redis3.gemfile.lock
+++ b/gemfiles/ruby_3.4_resque2_redis3.gemfile.lock
@@ -55,6 +55,7 @@ GEM
     dogstatsd-ruby (5.6.1)
     extlz4 (0.3.4)
     ffi (1.16.3)
+    fiddle (1.1.3)
     google-protobuf (3.25.3)
     hashdiff (1.1.0)
     json (2.7.2)
@@ -78,6 +79,7 @@ GEM
       mini_portile2 (~> 2.8.2)
       racc (~> 1.4)
     os (1.1.4)
+    ostruct (0.6.0)
     parallel (1.25.1)
     parser (3.3.3.0)
       ast (~> 2.4.1)
@@ -194,10 +196,12 @@ DEPENDENCIES
   dogstatsd-ruby (>= 3.3.0, != 5.1.0, != 5.0.1, != 5.0.0)
   extlz4 (~> 0.3, >= 0.3.3)
   ffi (~> 1.16.3)
+  fiddle
   google-protobuf (~> 3.0, != 3.7.1, != 3.7.0)
   json-schema (< 3)
   memory_profiler (~> 0.9)
   os (~> 1.1)
+  ostruct
   pimpmychangelog (>= 0.1.2)
   pry
   pry-stack_explorer

--- a/gemfiles/ruby_3.4_resque2_redis4.gemfile
+++ b/gemfiles/ruby_3.4_resque2_redis4.gemfile
@@ -32,6 +32,8 @@ gem "rubocop", "~> 1.50.0", require: false
 gem "rubocop-packaging", "~> 0.5.2", require: false
 gem "rubocop-performance", "~> 1.9", require: false
 gem "rubocop-rspec", ["~> 2.20", "< 2.21"], require: false
+gem "fiddle"
+gem "ostruct"
 gem "dogstatsd-ruby", ">= 3.3.0", "!= 5.0.0", "!= 5.0.1", "!= 5.1.0"
 gem "google-protobuf", ["~> 3.0", "!= 3.7.0", "!= 3.7.1"]
 gem "ffi", "~> 1.16.3", require: false

--- a/gemfiles/ruby_3.4_resque2_redis4.gemfile.lock
+++ b/gemfiles/ruby_3.4_resque2_redis4.gemfile.lock
@@ -56,6 +56,7 @@ GEM
     dogstatsd-ruby (5.6.1)
     extlz4 (0.3.4)
     ffi (1.16.3)
+    fiddle (1.1.3)
     google-protobuf (3.25.3)
     hashdiff (1.1.0)
     json (2.7.2)
@@ -79,6 +80,7 @@ GEM
       mini_portile2 (~> 2.8.2)
       racc (~> 1.4)
     os (1.1.4)
+    ostruct (0.6.0)
     parallel (1.25.1)
     parser (3.3.3.0)
       ast (~> 2.4.1)
@@ -198,10 +200,12 @@ DEPENDENCIES
   dogstatsd-ruby (>= 3.3.0, != 5.1.0, != 5.0.1, != 5.0.0)
   extlz4 (~> 0.3, >= 0.3.3)
   ffi (~> 1.16.3)
+  fiddle
   google-protobuf (~> 3.0, != 3.7.1, != 3.7.0)
   json-schema (< 3)
   memory_profiler (~> 0.9)
   os (~> 1.1)
+  ostruct
   pimpmychangelog (>= 0.1.2)
   pry
   pry-stack_explorer

--- a/gemfiles/ruby_3.4_sinatra_2.gemfile
+++ b/gemfiles/ruby_3.4_sinatra_2.gemfile
@@ -32,6 +32,8 @@ gem "rubocop", "~> 1.50.0", require: false
 gem "rubocop-packaging", "~> 0.5.2", require: false
 gem "rubocop-performance", "~> 1.9", require: false
 gem "rubocop-rspec", ["~> 2.20", "< 2.21"], require: false
+gem "fiddle"
+gem "ostruct"
 gem "dogstatsd-ruby", ">= 3.3.0", "!= 5.0.0", "!= 5.0.1", "!= 5.1.0"
 gem "google-protobuf", ["~> 3.0", "!= 3.7.0", "!= 3.7.1"]
 gem "ffi", "~> 1.16.3", require: false

--- a/gemfiles/ruby_3.4_sinatra_2.gemfile.lock
+++ b/gemfiles/ruby_3.4_sinatra_2.gemfile.lock
@@ -54,6 +54,7 @@ GEM
     dogstatsd-ruby (5.6.1)
     extlz4 (0.3.4)
     ffi (1.16.3)
+    fiddle (1.1.3)
     google-protobuf (3.25.3)
     hashdiff (1.1.0)
     json (2.7.2)
@@ -75,6 +76,7 @@ GEM
       mini_portile2 (~> 2.8.2)
       racc (~> 1.4)
     os (1.1.4)
+    ostruct (0.6.0)
     parallel (1.25.1)
     parser (3.3.3.0)
       ast (~> 2.4.1)
@@ -183,10 +185,12 @@ DEPENDENCIES
   dogstatsd-ruby (>= 3.3.0, != 5.1.0, != 5.0.1, != 5.0.0)
   extlz4 (~> 0.3, >= 0.3.3)
   ffi (~> 1.16.3)
+  fiddle
   google-protobuf (~> 3.0, != 3.7.1, != 3.7.0)
   json-schema (< 3)
   memory_profiler (~> 0.9)
   os (~> 1.1)
+  ostruct
   pimpmychangelog (>= 0.1.2)
   pry
   pry-stack_explorer

--- a/gemfiles/ruby_3.4_sinatra_3.gemfile
+++ b/gemfiles/ruby_3.4_sinatra_3.gemfile
@@ -32,6 +32,8 @@ gem "rubocop", "~> 1.50.0", require: false
 gem "rubocop-packaging", "~> 0.5.2", require: false
 gem "rubocop-performance", "~> 1.9", require: false
 gem "rubocop-rspec", ["~> 2.20", "< 2.21"], require: false
+gem "fiddle"
+gem "ostruct"
 gem "dogstatsd-ruby", ">= 3.3.0", "!= 5.0.0", "!= 5.0.1", "!= 5.1.0"
 gem "google-protobuf", ["~> 3.0", "!= 3.7.0", "!= 3.7.1"]
 gem "ffi", "~> 1.16.3", require: false

--- a/gemfiles/ruby_3.4_sinatra_3.gemfile.lock
+++ b/gemfiles/ruby_3.4_sinatra_3.gemfile.lock
@@ -55,6 +55,7 @@ GEM
     dogstatsd-ruby (5.6.1)
     extlz4 (0.3.4)
     ffi (1.16.3)
+    fiddle (1.1.3)
     google-protobuf (3.25.3)
     hashdiff (1.1.0)
     json (2.7.2)
@@ -76,6 +77,7 @@ GEM
       mini_portile2 (~> 2.8.2)
       racc (~> 1.4)
     os (1.1.4)
+    ostruct (0.6.0)
     parallel (1.25.1)
     parser (3.3.3.0)
       ast (~> 2.4.1)
@@ -185,10 +187,12 @@ DEPENDENCIES
   dogstatsd-ruby (>= 3.3.0, != 5.1.0, != 5.0.1, != 5.0.0)
   extlz4 (~> 0.3, >= 0.3.3)
   ffi (~> 1.16.3)
+  fiddle
   google-protobuf (~> 3.0, != 3.7.1, != 3.7.0)
   json-schema (< 3)
   memory_profiler (~> 0.9)
   os (~> 1.1)
+  ostruct
   pimpmychangelog (>= 0.1.2)
   pry
   pry-stack_explorer

--- a/gemfiles/ruby_3.4_sinatra_4.gemfile
+++ b/gemfiles/ruby_3.4_sinatra_4.gemfile
@@ -32,6 +32,8 @@ gem "rubocop", "~> 1.50.0", require: false
 gem "rubocop-packaging", "~> 0.5.2", require: false
 gem "rubocop-performance", "~> 1.9", require: false
 gem "rubocop-rspec", ["~> 2.20", "< 2.21"], require: false
+gem "fiddle"
+gem "ostruct"
 gem "dogstatsd-ruby", ">= 3.3.0", "!= 5.0.0", "!= 5.0.1", "!= 5.1.0"
 gem "google-protobuf", ["~> 3.0", "!= 3.7.0", "!= 3.7.1"]
 gem "ffi", "~> 1.16.3", require: false

--- a/gemfiles/ruby_3.4_sinatra_4.gemfile.lock
+++ b/gemfiles/ruby_3.4_sinatra_4.gemfile.lock
@@ -55,6 +55,7 @@ GEM
     dogstatsd-ruby (5.6.1)
     extlz4 (0.3.4)
     ffi (1.16.3)
+    fiddle (1.1.3)
     google-protobuf (3.25.3)
     hashdiff (1.1.0)
     json (2.7.2)
@@ -76,6 +77,7 @@ GEM
       mini_portile2 (~> 2.8.2)
       racc (~> 1.4)
     os (1.1.4)
+    ostruct (0.6.0)
     parallel (1.25.1)
     parser (3.3.3.0)
       ast (~> 2.4.1)
@@ -188,10 +190,12 @@ DEPENDENCIES
   dogstatsd-ruby (>= 3.3.0, != 5.1.0, != 5.0.1, != 5.0.0)
   extlz4 (~> 0.3, >= 0.3.3)
   ffi (~> 1.16.3)
+  fiddle
   google-protobuf (~> 3.0, != 3.7.1, != 3.7.0)
   json-schema (< 3)
   memory_profiler (~> 0.9)
   os (~> 1.1)
+  ostruct
   pimpmychangelog (>= 0.1.2)
   pry
   pry-stack_explorer

--- a/gemfiles/ruby_3.4_stripe_10.gemfile
+++ b/gemfiles/ruby_3.4_stripe_10.gemfile
@@ -32,6 +32,8 @@ gem "rubocop", "~> 1.50.0", require: false
 gem "rubocop-packaging", "~> 0.5.2", require: false
 gem "rubocop-performance", "~> 1.9", require: false
 gem "rubocop-rspec", ["~> 2.20", "< 2.21"], require: false
+gem "fiddle"
+gem "ostruct"
 gem "dogstatsd-ruby", ">= 3.3.0", "!= 5.0.0", "!= 5.0.1", "!= 5.1.0"
 gem "google-protobuf", ["~> 3.0", "!= 3.7.0", "!= 3.7.1"]
 gem "ffi", "~> 1.16.3", require: false

--- a/gemfiles/ruby_3.4_stripe_10.gemfile.lock
+++ b/gemfiles/ruby_3.4_stripe_10.gemfile.lock
@@ -54,13 +54,17 @@ GEM
     dogstatsd-ruby (5.6.1)
     extlz4 (0.3.4)
     ffi (1.16.3)
+    fiddle (1.1.3)
     google-protobuf (3.25.4)
     hashdiff (1.1.1)
     json (2.7.2)
     json-schema (2.8.1)
       addressable (>= 2.4)
     libdatadog (11.0.0.1.0-aarch64-linux)
+    libdatadog (11.0.0.1.0-x86_64-linux)
     libddwaf (1.14.0.0.0-aarch64-linux)
+      ffi (~> 1.0)
+    libddwaf (1.14.0.0.0-x86_64-linux)
       ffi (~> 1.0)
     memory_profiler (0.9.14)
     method_source (1.1.0)
@@ -70,6 +74,7 @@ GEM
       mini_portile2 (~> 2.8.2)
       racc (~> 1.4)
     os (1.1.4)
+    ostruct (0.6.0)
     parallel (1.26.3)
     parser (3.3.4.2)
       ast (~> 2.4.1)
@@ -152,6 +157,7 @@ GEM
 
 PLATFORMS
   aarch64-linux
+  x86_64-linux
 
 DEPENDENCIES
   appraisal (~> 2.4.0)
@@ -164,10 +170,12 @@ DEPENDENCIES
   dogstatsd-ruby (>= 3.3.0, != 5.1.0, != 5.0.1, != 5.0.0)
   extlz4 (~> 0.3, >= 0.3.3)
   ffi (~> 1.16.3)
+  fiddle
   google-protobuf (~> 3.0, != 3.7.1, != 3.7.0)
   json-schema (< 3)
   memory_profiler (~> 0.9)
   os (~> 1.1)
+  ostruct
   pimpmychangelog (>= 0.1.2)
   pry
   pry-stack_explorer

--- a/gemfiles/ruby_3.4_stripe_11.gemfile
+++ b/gemfiles/ruby_3.4_stripe_11.gemfile
@@ -32,6 +32,8 @@ gem "rubocop", "~> 1.50.0", require: false
 gem "rubocop-packaging", "~> 0.5.2", require: false
 gem "rubocop-performance", "~> 1.9", require: false
 gem "rubocop-rspec", ["~> 2.20", "< 2.21"], require: false
+gem "fiddle"
+gem "ostruct"
 gem "dogstatsd-ruby", ">= 3.3.0", "!= 5.0.0", "!= 5.0.1", "!= 5.1.0"
 gem "google-protobuf", ["~> 3.0", "!= 3.7.0", "!= 3.7.1"]
 gem "ffi", "~> 1.16.3", require: false

--- a/gemfiles/ruby_3.4_stripe_11.gemfile.lock
+++ b/gemfiles/ruby_3.4_stripe_11.gemfile.lock
@@ -54,13 +54,17 @@ GEM
     dogstatsd-ruby (5.6.1)
     extlz4 (0.3.4)
     ffi (1.16.3)
+    fiddle (1.1.3)
     google-protobuf (3.25.4)
     hashdiff (1.1.1)
     json (2.7.2)
     json-schema (2.8.1)
       addressable (>= 2.4)
     libdatadog (11.0.0.1.0-aarch64-linux)
+    libdatadog (11.0.0.1.0-x86_64-linux)
     libddwaf (1.14.0.0.0-aarch64-linux)
+      ffi (~> 1.0)
+    libddwaf (1.14.0.0.0-x86_64-linux)
       ffi (~> 1.0)
     memory_profiler (0.9.14)
     method_source (1.1.0)
@@ -70,6 +74,7 @@ GEM
       mini_portile2 (~> 2.8.2)
       racc (~> 1.4)
     os (1.1.4)
+    ostruct (0.6.0)
     parallel (1.26.3)
     parser (3.3.4.2)
       ast (~> 2.4.1)
@@ -152,6 +157,7 @@ GEM
 
 PLATFORMS
   aarch64-linux
+  x86_64-linux
 
 DEPENDENCIES
   appraisal (~> 2.4.0)
@@ -164,10 +170,12 @@ DEPENDENCIES
   dogstatsd-ruby (>= 3.3.0, != 5.1.0, != 5.0.1, != 5.0.0)
   extlz4 (~> 0.3, >= 0.3.3)
   ffi (~> 1.16.3)
+  fiddle
   google-protobuf (~> 3.0, != 3.7.1, != 3.7.0)
   json-schema (< 3)
   memory_profiler (~> 0.9)
   os (~> 1.1)
+  ostruct
   pimpmychangelog (>= 0.1.2)
   pry
   pry-stack_explorer

--- a/gemfiles/ruby_3.4_stripe_12.gemfile
+++ b/gemfiles/ruby_3.4_stripe_12.gemfile
@@ -32,6 +32,8 @@ gem "rubocop", "~> 1.50.0", require: false
 gem "rubocop-packaging", "~> 0.5.2", require: false
 gem "rubocop-performance", "~> 1.9", require: false
 gem "rubocop-rspec", ["~> 2.20", "< 2.21"], require: false
+gem "fiddle"
+gem "ostruct"
 gem "dogstatsd-ruby", ">= 3.3.0", "!= 5.0.0", "!= 5.0.1", "!= 5.1.0"
 gem "google-protobuf", ["~> 3.0", "!= 3.7.0", "!= 3.7.1"]
 gem "ffi", "~> 1.16.3", require: false

--- a/gemfiles/ruby_3.4_stripe_12.gemfile.lock
+++ b/gemfiles/ruby_3.4_stripe_12.gemfile.lock
@@ -54,13 +54,17 @@ GEM
     dogstatsd-ruby (5.6.1)
     extlz4 (0.3.4)
     ffi (1.16.3)
+    fiddle (1.1.3)
     google-protobuf (3.25.4)
     hashdiff (1.1.1)
     json (2.7.2)
     json-schema (2.8.1)
       addressable (>= 2.4)
     libdatadog (11.0.0.1.0-aarch64-linux)
+    libdatadog (11.0.0.1.0-x86_64-linux)
     libddwaf (1.14.0.0.0-aarch64-linux)
+      ffi (~> 1.0)
+    libddwaf (1.14.0.0.0-x86_64-linux)
       ffi (~> 1.0)
     memory_profiler (0.9.14)
     method_source (1.1.0)
@@ -70,6 +74,7 @@ GEM
       mini_portile2 (~> 2.8.2)
       racc (~> 1.4)
     os (1.1.4)
+    ostruct (0.6.0)
     parallel (1.26.3)
     parser (3.3.4.2)
       ast (~> 2.4.1)
@@ -152,6 +157,7 @@ GEM
 
 PLATFORMS
   aarch64-linux
+  x86_64-linux
 
 DEPENDENCIES
   appraisal (~> 2.4.0)
@@ -164,10 +170,12 @@ DEPENDENCIES
   dogstatsd-ruby (>= 3.3.0, != 5.1.0, != 5.0.1, != 5.0.0)
   extlz4 (~> 0.3, >= 0.3.3)
   ffi (~> 1.16.3)
+  fiddle
   google-protobuf (~> 3.0, != 3.7.1, != 3.7.0)
   json-schema (< 3)
   memory_profiler (~> 0.9)
   os (~> 1.1)
+  ostruct
   pimpmychangelog (>= 0.1.2)
   pry
   pry-stack_explorer

--- a/gemfiles/ruby_3.4_stripe_7.gemfile
+++ b/gemfiles/ruby_3.4_stripe_7.gemfile
@@ -32,6 +32,8 @@ gem "rubocop", "~> 1.50.0", require: false
 gem "rubocop-packaging", "~> 0.5.2", require: false
 gem "rubocop-performance", "~> 1.9", require: false
 gem "rubocop-rspec", ["~> 2.20", "< 2.21"], require: false
+gem "fiddle"
+gem "ostruct"
 gem "dogstatsd-ruby", ">= 3.3.0", "!= 5.0.0", "!= 5.0.1", "!= 5.1.0"
 gem "google-protobuf", ["~> 3.0", "!= 3.7.0", "!= 3.7.1"]
 gem "ffi", "~> 1.16.3", require: false

--- a/gemfiles/ruby_3.4_stripe_7.gemfile.lock
+++ b/gemfiles/ruby_3.4_stripe_7.gemfile.lock
@@ -54,13 +54,17 @@ GEM
     dogstatsd-ruby (5.6.1)
     extlz4 (0.3.4)
     ffi (1.16.3)
+    fiddle (1.1.3)
     google-protobuf (3.25.4)
     hashdiff (1.1.1)
     json (2.7.2)
     json-schema (2.8.1)
       addressable (>= 2.4)
     libdatadog (11.0.0.1.0-aarch64-linux)
+    libdatadog (11.0.0.1.0-x86_64-linux)
     libddwaf (1.14.0.0.0-aarch64-linux)
+      ffi (~> 1.0)
+    libddwaf (1.14.0.0.0-x86_64-linux)
       ffi (~> 1.0)
     memory_profiler (0.9.14)
     method_source (1.1.0)
@@ -70,6 +74,7 @@ GEM
       mini_portile2 (~> 2.8.2)
       racc (~> 1.4)
     os (1.1.4)
+    ostruct (0.6.0)
     parallel (1.26.3)
     parser (3.3.4.2)
       ast (~> 2.4.1)
@@ -152,6 +157,7 @@ GEM
 
 PLATFORMS
   aarch64-linux
+  x86_64-linux
 
 DEPENDENCIES
   appraisal (~> 2.4.0)
@@ -164,10 +170,12 @@ DEPENDENCIES
   dogstatsd-ruby (>= 3.3.0, != 5.1.0, != 5.0.1, != 5.0.0)
   extlz4 (~> 0.3, >= 0.3.3)
   ffi (~> 1.16.3)
+  fiddle
   google-protobuf (~> 3.0, != 3.7.1, != 3.7.0)
   json-schema (< 3)
   memory_profiler (~> 0.9)
   os (~> 1.1)
+  ostruct
   pimpmychangelog (>= 0.1.2)
   pry
   pry-stack_explorer

--- a/gemfiles/ruby_3.4_stripe_8.gemfile
+++ b/gemfiles/ruby_3.4_stripe_8.gemfile
@@ -32,6 +32,8 @@ gem "rubocop", "~> 1.50.0", require: false
 gem "rubocop-packaging", "~> 0.5.2", require: false
 gem "rubocop-performance", "~> 1.9", require: false
 gem "rubocop-rspec", ["~> 2.20", "< 2.21"], require: false
+gem "fiddle"
+gem "ostruct"
 gem "dogstatsd-ruby", ">= 3.3.0", "!= 5.0.0", "!= 5.0.1", "!= 5.1.0"
 gem "google-protobuf", ["~> 3.0", "!= 3.7.0", "!= 3.7.1"]
 gem "ffi", "~> 1.16.3", require: false

--- a/gemfiles/ruby_3.4_stripe_8.gemfile.lock
+++ b/gemfiles/ruby_3.4_stripe_8.gemfile.lock
@@ -54,13 +54,17 @@ GEM
     dogstatsd-ruby (5.6.1)
     extlz4 (0.3.4)
     ffi (1.16.3)
+    fiddle (1.1.3)
     google-protobuf (3.25.4)
     hashdiff (1.1.1)
     json (2.7.2)
     json-schema (2.8.1)
       addressable (>= 2.4)
     libdatadog (11.0.0.1.0-aarch64-linux)
+    libdatadog (11.0.0.1.0-x86_64-linux)
     libddwaf (1.14.0.0.0-aarch64-linux)
+      ffi (~> 1.0)
+    libddwaf (1.14.0.0.0-x86_64-linux)
       ffi (~> 1.0)
     memory_profiler (0.9.14)
     method_source (1.1.0)
@@ -70,6 +74,7 @@ GEM
       mini_portile2 (~> 2.8.2)
       racc (~> 1.4)
     os (1.1.4)
+    ostruct (0.6.0)
     parallel (1.26.3)
     parser (3.3.4.2)
       ast (~> 2.4.1)
@@ -152,6 +157,7 @@ GEM
 
 PLATFORMS
   aarch64-linux
+  x86_64-linux
 
 DEPENDENCIES
   appraisal (~> 2.4.0)
@@ -164,10 +170,12 @@ DEPENDENCIES
   dogstatsd-ruby (>= 3.3.0, != 5.1.0, != 5.0.1, != 5.0.0)
   extlz4 (~> 0.3, >= 0.3.3)
   ffi (~> 1.16.3)
+  fiddle
   google-protobuf (~> 3.0, != 3.7.1, != 3.7.0)
   json-schema (< 3)
   memory_profiler (~> 0.9)
   os (~> 1.1)
+  ostruct
   pimpmychangelog (>= 0.1.2)
   pry
   pry-stack_explorer

--- a/gemfiles/ruby_3.4_stripe_9.gemfile
+++ b/gemfiles/ruby_3.4_stripe_9.gemfile
@@ -32,6 +32,8 @@ gem "rubocop", "~> 1.50.0", require: false
 gem "rubocop-packaging", "~> 0.5.2", require: false
 gem "rubocop-performance", "~> 1.9", require: false
 gem "rubocop-rspec", ["~> 2.20", "< 2.21"], require: false
+gem "fiddle"
+gem "ostruct"
 gem "dogstatsd-ruby", ">= 3.3.0", "!= 5.0.0", "!= 5.0.1", "!= 5.1.0"
 gem "google-protobuf", ["~> 3.0", "!= 3.7.0", "!= 3.7.1"]
 gem "ffi", "~> 1.16.3", require: false

--- a/gemfiles/ruby_3.4_stripe_9.gemfile.lock
+++ b/gemfiles/ruby_3.4_stripe_9.gemfile.lock
@@ -54,13 +54,17 @@ GEM
     dogstatsd-ruby (5.6.1)
     extlz4 (0.3.4)
     ffi (1.16.3)
+    fiddle (1.1.3)
     google-protobuf (3.25.4)
     hashdiff (1.1.1)
     json (2.7.2)
     json-schema (2.8.1)
       addressable (>= 2.4)
     libdatadog (11.0.0.1.0-aarch64-linux)
+    libdatadog (11.0.0.1.0-x86_64-linux)
     libddwaf (1.14.0.0.0-aarch64-linux)
+      ffi (~> 1.0)
+    libddwaf (1.14.0.0.0-x86_64-linux)
       ffi (~> 1.0)
     memory_profiler (0.9.14)
     method_source (1.1.0)
@@ -70,6 +74,7 @@ GEM
       mini_portile2 (~> 2.8.2)
       racc (~> 1.4)
     os (1.1.4)
+    ostruct (0.6.0)
     parallel (1.26.3)
     parser (3.3.4.2)
       ast (~> 2.4.1)
@@ -152,6 +157,7 @@ GEM
 
 PLATFORMS
   aarch64-linux
+  x86_64-linux
 
 DEPENDENCIES
   appraisal (~> 2.4.0)
@@ -164,10 +170,12 @@ DEPENDENCIES
   dogstatsd-ruby (>= 3.3.0, != 5.1.0, != 5.0.1, != 5.0.0)
   extlz4 (~> 0.3, >= 0.3.3)
   ffi (~> 1.16.3)
+  fiddle
   google-protobuf (~> 3.0, != 3.7.1, != 3.7.0)
   json-schema (< 3)
   memory_profiler (~> 0.9)
   os (~> 1.1)
+  ostruct
   pimpmychangelog (>= 0.1.2)
   pry
   pry-stack_explorer

--- a/spec/datadog/core/environment/execution_spec.rb
+++ b/spec/datadog/core/environment/execution_spec.rb
@@ -260,6 +260,12 @@ RSpec.describe Datadog::Core::Environment::Execution do
             gemfile(true, quiet: true) do
               source 'https://rubygems.org'
               gem 'webmock'
+
+              if RUBY_VERSION >= '3.3'
+                # ostruct and fiddle will be removed from standard library in Ruby 3.5
+                gem 'ostruct'
+                gem 'fiddle'
+              end
             end
 
             require 'webmock'


### PR DESCRIPTION
This addresses the deprecation warning that `ostruct` will not be part of standard library since ruby 3.5

**What does this PR do?**
This PR adds `ostruct` gem to Gemfile for Ruby version 3.3.5 and higher.

**Motivation:**
Failing tests due to a deprecation warning:
https://github.com/DataDog/dd-trace-rb/actions/runs/10703793866/job/29675192240?pr=3887