### PR TITLE
Update dependency tasks

### DIFF
--- a/tasks/edge.rake
+++ b/tasks/edge.rake
@@ -13,6 +13,7 @@ namespace :edge do
 
     [
       'stripe',
+      'elasticsearch',
       # more integrations here
     ].each do |integration|
       candidates = TEST_METADATA.fetch(integration).select do |_, rubies|

--- a/tasks/edge.rake
+++ b/tasks/edge.rake
@@ -3,19 +3,59 @@
 require 'open3'
 require 'pathname'
 
+# This module translates our custom mapping between appraisal and bundler.
+#
+# It cannot be included into `Appraisal` file, because it was invoked via `instance_eval`.
+module AppraisalConversion
+  module_function
+
+  @gemfile_dir = 'gemfiles'
+  @definition_dir = 'appraisal'
+
+  def to_bundle_gemfile(group)
+    gemfile = "#{runtime_identifier}_#{group}.gemfile".tr('-', '_')
+    path = root_path.join(@gemfile_dir, gemfile)
+
+    if path.exist?
+      path.to_s
+    else
+      raise "Gemfile not found at #{path}"
+    end
+  end
+
+  def definition
+    path = root_path.join(@definition_dir, "#{runtime_identifier}.rb")
+
+    if path.exist?
+      path.to_s
+    else
+      raise "Definition not found at #{path}"
+    end
+  end
+
+  def runtime_identifier
+    major, minor, = Gem::Version.new(RUBY_ENGINE_VERSION).segments
+    "#{RUBY_ENGINE}-#{major}.#{minor}"
+  end
+
+  def root_path
+    Pathname.pwd
+  end
+end
+
 namespace :edge do
   desc 'Update edge build for current ruby runtime'
-  task :update do
+  task :update do |_t, args|
     ruby_version = RUBY_VERSION[0..2]
-
-    prefix = "#{RUBY_ENGINE}-#{ruby_version}"
-    project_root = Pathname.new("#{__dir__}/../").cleanpath.to_s
-
-    [
+    whitelist = [
       'stripe',
       'elasticsearch',
-      # more integrations here
-    ].each do |integration|
+      # Add more integrations here, when they are extracted to its own isolated group
+    ]
+
+    whitelist &= args.extras if args.extras.any?
+
+    whitelist.each do |integration|
       candidates = TEST_METADATA.fetch(integration).select do |_, rubies|
         if RUBY_PLATFORM == 'java'
           rubies.include?("✅ #{ruby_version}") && rubies.include?('✅ jruby')
@@ -25,12 +65,13 @@ namespace :edge do
       end
 
       gemfiles = candidates.keys.map do |group|
-        "#{project_root}/gemfiles/#{prefix}-#{group}.gemfile".tr('-', '_')
+        AppraisalConversion.to_bundle_gemfile(group)
       end
 
       gemfiles.each do |gemfile|
         Bundler.with_unbundled_env do
-          output, = Open3.capture2e({ 'BUNDLE_GEMFILE' => gemfile }, "bundle lock --update=#{integration}")
+          puts "======== Updating #{integration} in #{gemfile} ========\n"
+          output, = Open3.capture2e({ 'BUNDLE_GEMFILE' => gemfile.to_s }, "bundle lock --update=#{integration}")
 
           puts output
         end

--- a/tasks/edge.rake
+++ b/tasks/edge.rake
@@ -1,0 +1,39 @@
+# frozen_string_literal: true
+
+require 'open3'
+require 'pathname'
+
+namespace :edge do
+  desc 'Update edge build for current ruby runtime'
+  task :update do
+    ruby_version = RUBY_VERSION[0..2]
+
+    prefix = "#{RUBY_ENGINE}-#{ruby_version}"
+    project_root = Pathname.new("#{__dir__}/../").cleanpath.to_s
+
+    [
+      'stripe',
+      # more integrations here
+    ].each do |integration|
+      candidates = TEST_METADATA.fetch(integration).select do |_, rubies|
+        if RUBY_PLATFORM == 'java'
+          rubies.include?("✅ #{ruby_version}") && rubies.include?('✅ jruby')
+        else
+          rubies.include?("✅ #{ruby_version}")
+        end
+      end
+
+      gemfiles = candidates.keys.map do |group|
+        "#{project_root}/gemfiles/#{prefix}-#{group}.gemfile".tr('-', '_')
+      end
+
+      gemfiles.each do |gemfile|
+        Bundler.with_unbundled_env do
+          output, = Open3.capture2e({ 'BUNDLE_GEMFILE' => gemfile }, "bundle lock --update=#{integration}")
+
+          puts output
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
**What does this PR do?**

Provides a task to update a gem to the latest version for an integration. 

Update the all the predefined integration of current runtime version.
```
bundle exec rake edge:update
```

It takes variables:
```
bundle exec rake edge:update[elasticsearch,opensearch]
``` 

PS. I do not commit the diff from the lockfiles because we are working on automation for that. 