### PR TITLE
Add Github Token as argument to `appsec:ruleset:update` task

### DIFF
--- a/tasks/appsec.rake
+++ b/tasks/appsec.rake
@@ -5,10 +5,12 @@ namespace :appsec do
       require 'net/http'
 
       version = args.to_a[0]
+      raise ArgumentError, 'You must provide a version' if version.nil?
 
       # You need to generate a token with the `repo` scope
       # and configure SSO for DataDog's GitHub organization
       token = ENV['GITHUB_TOKEN']
+      raise ArgumentError, 'You must set GITHUB_TOKEN env variable' if token.nil?
 
       ['recommended', 'strict'].each do |ruleset|
         uri = URI("https://api.github.com/repos/DataDog/appsec-event-rules/contents/build/#{ruleset}.json?ref=#{version}")

--- a/tasks/appsec.rake
+++ b/tasks/appsec.rake
@@ -25,7 +25,10 @@ namespace :appsec do
         http.request(req) do |res|
           case res
           when Net::HTTPSuccess
-            File.open("lib/datadog/appsec/assets/waf_rules/#{ruleset}.json", 'wb') do |f|
+            filename = "lib/datadog/appsec/assets/waf_rules/#{ruleset}.json"
+            raise "File '#{filename}' was moved or deleted, please review the rake task" unless File.exist?(filename)
+
+            File.open(filename, 'wb') do |f|
               res.read_body do |chunk|
                 f << chunk
               end

--- a/tasks/appsec.rake
+++ b/tasks/appsec.rake
@@ -6,10 +6,32 @@ namespace :appsec do
 
       version = args.to_a[0]
 
-      ['recommended', 'strict'].each do |ruleset|
-        uri = URI("https://raw.githubusercontent.com/DataDog/appsec-event-rules/#{version}/build/#{ruleset}.json")
+      # You need to generate a token with the `repo` scope
+      # and configure SSO for DataDog's GitHub organization
+      token = ENV['GITHUB_TOKEN']
 
-        File.open("lib/datadog/appsec/assets/waf_rules/#{ruleset}.json", 'wb') { |f| f << Net::HTTP::get(uri) }
+      ['recommended', 'strict'].each do |ruleset|
+        uri = URI("https://api.github.com/repos/DataDog/appsec-event-rules/contents/build/#{ruleset}.json?ref=#{version}")
+
+        http = Net::HTTP.new(uri.host, uri.port)
+        http.use_ssl = true
+
+        req = Net::HTTP::Get.new(uri)
+        req['Authorization'] = "Bearer #{token}"
+        req['Accept'] = 'application/vnd.github.raw+json'
+
+        http.request(req) do |res|
+          case res
+          when Net::HTTPSuccess
+            File.open("lib/datadog/appsec/assets/waf_rules/#{ruleset}.json", 'wb') do |f|
+              res.read_body do |chunk|
+                f << chunk
+              end
+            end
+          else
+            raise "Failed to download #{ruleset}.json: #{response.code} #{response.message}"
+          end
+        end
       end
     end
   end


### PR DESCRIPTION
**What does this PR do?**
This PR modifies `appsec:ruleset:update` rake task to use `GITHUB_TOKEN` env variable for fetching AppSec rulesets.

**Motivation:**
Repository `appsec-event-rules` is now private, so we can't download ruleset files without a token.

**Additional Notes:**
\-

**How to test the change?**
Run `GITHUB_TOKEN=... bundle exec rake appsec:ruleset:update[1.13.1]`