### PR TITLE
[NO-TICKET] add missing permissions for add-milestone gha workflow

### DIFF
--- a/.github/workflows/add-milestone-to-pull-requests.yml
+++ b/.github/workflows/add-milestone-to-pull-requests.yml
@@ -5,6 +5,9 @@ on:
 
 jobs:
   add_milestone:
+    permissions:
+      contents: read
+      pull-requests: write
     runs-on: ubuntu-latest
     if: github.event.pull_request.merged == true && github.event.pull_request.milestone == null
     steps:


### PR DESCRIPTION
**What does this PR do?**
Adds additional permissions to a github actions workflow that adds milestones to merged PRs

**Motivation:**
"Add milestone to PR" workflow is broken after recent settings change

