### PR TITLE
Remove obsolete OnlyOnce during patching

### DIFF
--- a/lib/datadog/tracing/contrib/action_cable/instrumentation.rb
+++ b/lib/datadog/tracing/contrib/action_cable/instrumentation.rb
@@ -14,21 +14,17 @@ module Datadog
           module ActionCableConnection
             def on_open
               Tracing.trace(Ext::SPAN_ON_OPEN) do |span, trace|
-                begin
-                  span.resource = "#{self.class}#on_open"
-                  span.type = Tracing::Metadata::Ext::AppTypes::TYPE_WEB
+                span.resource = "#{self.class}#on_open"
+                span.type = Tracing::Metadata::Ext::AppTypes::TYPE_WEB
 
-                  span.set_tag(Ext::TAG_ACTION, 'on_open')
-                  span.set_tag(Ext::TAG_CONNECTION, self.class.to_s)
+                span.set_tag(Ext::TAG_ACTION, 'on_open')
+                span.set_tag(Ext::TAG_CONNECTION, self.class.to_s)
 
-                  span.set_tag(Tracing::Metadata::Ext::TAG_COMPONENT, Ext::TAG_COMPONENT)
-                  span.set_tag(Tracing::Metadata::Ext::TAG_OPERATION, Ext::TAG_OPERATION_ON_OPEN)
+                span.set_tag(Tracing::Metadata::Ext::TAG_COMPONENT, Ext::TAG_COMPONENT)
+                span.set_tag(Tracing::Metadata::Ext::TAG_OPERATION, Ext::TAG_OPERATION_ON_OPEN)
 
-                  # Set the resource name of the trace
-                  trace.resource = span.resource
-                rescue StandardError => e
-                  Datadog.logger.error("Error preparing span for ActionCable::Connection: #{e}")
-                end
+                # Set the resource name of the trace
+                trace.resource = span.resource
 
                 super
               end

--- a/lib/datadog/tracing/contrib/httpclient/patcher.rb
+++ b/lib/datadog/tracing/contrib/httpclient/patcher.rb
@@ -13,27 +13,14 @@ module Datadog
         module Patcher
           include Contrib::Patcher
 
-          PATCH_ONLY_ONCE = Core::Utils::OnlyOnce.new
-
           module_function
-
-          def patched?
-            PATCH_ONLY_ONCE.ran?
-          end
 
           def target_version
             Integration.version
           end
 
-          # patch applies our patch
           def patch
-            PATCH_ONLY_ONCE.run do
-              begin
-                ::HTTPClient.include(Instrumentation)
-              rescue StandardError => e
-                Datadog.logger.error("Unable to apply httpclient integration: #{e}")
-              end
-            end
+            ::HTTPClient.include(Instrumentation)
           end
         end
       end

--- a/lib/datadog/tracing/contrib/httprb/patcher.rb
+++ b/lib/datadog/tracing/contrib/httprb/patcher.rb
@@ -13,27 +13,14 @@ module Datadog
         module Patcher
           include Contrib::Patcher
 
-          PATCH_ONLY_ONCE = Core::Utils::OnlyOnce.new
-
           module_function
-
-          def patched?
-            PATCH_ONLY_ONCE.ran?
-          end
 
           def target_version
             Integration.version
           end
 
-          # patch applies our patch
           def patch
-            PATCH_ONLY_ONCE.run do
-              begin
-                ::HTTP::Client.include(Instrumentation)
-              rescue StandardError => e
-                Datadog.logger.error("Unable to apply httprb integration: #{e}")
-              end
-            end
+            ::HTTP::Client.include(Instrumentation)
           end
         end
       end

--- a/lib/datadog/tracing/contrib/lograge/patcher.rb
+++ b/lib/datadog/tracing/contrib/lograge/patcher.rb
@@ -24,8 +24,7 @@ module Datadog
             if defined?(::ActiveSupport::TaggedLogging::Formatter) &&
                 ::Lograge::LogSubscribers::ActionController
                     .logger&.formatter.is_a?(::ActiveSupport::TaggedLogging::Formatter)
-
-              Datadog.logger.error(
+              Datadog.logger.warn(
                 'Lograge and ActiveSupport::TaggedLogging (the default Rails log formatter) are not compatible: ' \
                   'Lograge does not account for Rails log tags, creating polluted logs and breaking log formatting. ' \
                   'Traces and Logs correlation may not work. ' \

--- a/lib/datadog/tracing/contrib/presto/patcher.rb
+++ b/lib/datadog/tracing/contrib/presto/patcher.rb
@@ -13,22 +13,10 @@ module Datadog
         module Patcher
           include Contrib::Patcher
 
-          PATCH_ONLY_ONCE = Core::Utils::OnlyOnce.new
-
           module_function
 
-          def patched?
-            PATCH_ONLY_ONCE.ran?
-          end
-
           def patch
-            PATCH_ONLY_ONCE.run do
-              begin
-                ::Presto::Client::Client.include(Instrumentation::Client)
-              rescue StandardError => e
-                Datadog.logger.error("Unable to apply Presto integration: #{e}")
-              end
-            end
+            ::Presto::Client::Client.include(Instrumentation::Client)
           end
         end
       end

--- a/spec/datadog/tracing/contrib/lograge/patcher_spec.rb
+++ b/spec/datadog/tracing/contrib/lograge/patcher_spec.rb
@@ -15,7 +15,7 @@ RSpec.describe Datadog::Tracing::Contrib::Lograge::Patcher do
 
     context 'without Rails tagged logging' do
       it 'does not log incompatibility error' do
-        expect(Datadog.logger).to_not receive(:error)
+        expect(Datadog.logger).to_not receive(:warn)
 
         described_class.patch
       end
@@ -26,7 +26,7 @@ RSpec.describe Datadog::Tracing::Contrib::Lograge::Patcher do
         logger = ActiveSupport::TaggedLogging.new(Logger.new(File::NULL))
         stub_const('Lograge::LogSubscribers::ActionController', double('controller', logger: logger))
 
-        expect(Datadog.logger).to receive(:error).with(/ActiveSupport::TaggedLogging/)
+        expect(Datadog.logger).to receive(:warn).with(/ActiveSupport::TaggedLogging/)
 
         described_class.patch
       end


### PR DESCRIPTION
**What does this PR do?**

Internal refactoring for some instrumentation

1. Remove redundant `OnlyOnce` guard for during patching `httprb`, `httpclient` and `presto`
2. Remove redundant `ActionCable` rescue 
3. Change lograge incompatibility to warn