### PR TITLE
DEBUG-2334 Add more redaction test cases

### DIFF
--- a/spec/datadog/di/redactor_spec.rb
+++ b/spec/datadog/di/redactor_spec.rb
@@ -71,17 +71,22 @@ RSpec.describe Datadog::DI::Redactor do
 
     context "when user-defined redacted identifiers exist" do
       before do
-        expect(di_settings).to receive(:redacted_identifiers).and_return(%w[foo пароль Ключ])
+        expect(di_settings).to receive(:redacted_identifiers).and_return(%w[foo пароль Ключ @var])
       end
 
       cases = [
         ["exact user-defined identifier", "foo", true],
         ["prefix of user-defined identifier", "f", false],
         ["suffix of user-defined identifier", "oo", false],
-        ["user-defined identifier with extra punctuation", "f-o-o", true],
-        ["user-defined identifier is not ascii", "ПАРОЛь", true],
+        ["user-defined identifier with extra removeable punctuation", "f-o-o", true],
+        ["user-defined identifier with extra non-removeable punctuation", "f.o.o", false],
+        ["user-defined identifier is not ascii, target identifier is in another case", "ПАРОЛь", true],
         ["user-defined identifier is not ascii and uses mixed case in definition", "ключ", true],
         ["user-defined identifier is not ascii and uses mixed case in definition and is not exact match", "ключ1", false],
+        ["@ in definition", "var", true],
+        ["@ in definition but name does not match", "var1", false],
+        ["@ in target identifier", "@foo", true],
+        ["@ in target identifier but name does not match", "@foo1", false],
       ]
 
       define_cases(cases)


### PR DESCRIPTION
This tests specifically @ sign in identifier names which has special meaning in Ruby but is considered generic punctuation in Redactor.

<!--
Check out the
https://github.com/DataDog/dd-trace-rb/blob/master/docs/DevelopmentGuide.md
for guidance on how to set up your development environment,
run the test suite, write new integrations, and more.
-->

**What does this PR do?**
<!-- A brief description of the change being made with this pull request. -->
Adds unit tests.

**Motivation:**
<!-- What inspired you to submit this pull request? -->
Better test coverage of DI.


**How to test the change?**
Unit tests
<!--
Describe here how the change can be validated.
You are strongly encouraged to provide automated tests for this PR (unit or integration).
If this change cannot be feasibly tested, please explain why,
unless the change does not modify code (e.g. only modifies docs, comments).
-->

Unsure? Have a question? Request a review!
