### PR TITLE
DEBUG-2334 Dynamic Instrumentation Serializer component

### DIFF
--- a/lib/datadog/di/serializer.rb
+++ b/lib/datadog/di/serializer.rb
@@ -1,0 +1,168 @@
+# frozen_string_literal: true
+
+require_relative "redactor"
+
+module Datadog
+  module DI
+    # Serializes captured snapshot to primitive types, which are subsequently
+    # serialized to JSON and sent to the backend.
+    #
+    # This class performs actual removal of sensitive values from the
+    # snapshots. It uses Redactor to determine which values are sensitive
+    # and need to be removed.
+    #
+    # Serializer normally ought not to invoke user (application) code,
+    # to guarantee predictable performance. However, objects like ActiveRecord
+    # models cannot be usefully serialized into primitive types without
+    # custom logic (for example, the attributes are more than 3 levels
+    # down from the top-level object which is the default capture depth,
+    # thus they won't be captured at all). To accommodate complex objects,
+    # there is an extension mechanism implemented permitting registration
+    # of serializer callbacks for arbitrary types. Applications and libraries
+    # definining such serializer callbacks should be very careful to
+    # have predictable performance and avoid exceptions and infinite loops
+    # and other such issues.
+    #
+    # All serialization methods take the names of the variables being
+    # serialized in order to be able to redact values.
+    #
+    # @api private
+    class Serializer
+      def initialize(settings, redactor)
+        @settings = settings
+        @redactor = redactor
+      end
+
+      attr_reader :settings
+      attr_reader :redactor
+
+      # Serializes positional and keyword arguments to a method,
+      # as obtained by a method probe.
+      #
+      # UI supports a single argument list only and does not distinguish
+      # between positional and keyword arguments. We convert positional
+      # arguments to keyword arguments ("arg1", "arg2", ...) and ensure
+      # the positional arguments are listed first.
+      def serialize_args(args, kwargs)
+        counter = 0
+        combined = args.each_with_object({}) do |value, c|
+          counter += 1
+          # Conversion to symbol is needed here to put args ahead of
+          # kwargs when they are merged below.
+          c[:"arg#{counter}"] = value
+        end.update(kwargs)
+        serialize_vars(combined)
+      end
+
+      # Serializes variables captured by a line probe.
+      #
+      # These are normally local variables that exist on a particular line
+      # of executed code.
+      def serialize_vars(vars)
+        vars.map do |k, v|
+          [k, serialize_value(k, v)]
+        end.to_h
+      end
+
+      private
+
+      # Serializes a single named value.
+      #
+      # The name is necessary to perform sensitive data redaction.
+      #
+      # Returns a data structure comprised of only values of basic types
+      # (integers, strings, arrays, hashes).
+      #
+      # Respects string length, collection size and traversal depth limits.
+      def serialize_value(name, value, depth: settings.dynamic_instrumentation.max_capture_depth)
+        if redactor.redact_type?(value)
+          return {type: class_name(value.class), notCapturedReason: "redactedType"}
+        end
+
+        if name && redactor.redact_identifier?(name)
+          return {type: class_name(value.class), notCapturedReason: "redactedIdent"}
+        end
+
+        serialized = {type: class_name(value.class)}
+        case value
+        when NilClass
+          serialized.update(isNull: true)
+        when Integer, Float, TrueClass, FalseClass
+          serialized.update(value: value.to_s)
+        when String, Symbol
+          value = value.to_s
+          max = settings.dynamic_instrumentation.max_capture_string_length
+          if value.length > max
+            serialized.update(notCapturedReason: "length", size: value.length)
+            # steep misunderstands string slice types.
+            # https://github.com/soutaro/steep/issues/1219
+            value = (value[0...max] || "") + "..."
+          end
+          serialized.update(value: value)
+        when Array
+          if depth < 0
+            serialized.update(notCapturedReason: "depth")
+          else
+            max = settings.dynamic_instrumentation.max_capture_collection_size
+            if max != 0 && value.length > max
+              serialized.update(notCapturedReason: "collectionSize", size: value.length)
+              # same steep failure with array slices.
+              # https://github.com/soutaro/steep/issues/1219
+              value = value[0...max] || []
+            end
+            entries = value.map do |elt|
+              serialize_value(nil, elt, depth: depth - 1)
+            end
+            serialized.update(elements: entries)
+          end
+        when Hash
+          if depth < 0
+            serialized.update(notCapturedReason: "depth")
+          else
+            max = settings.dynamic_instrumentation.max_capture_collection_size
+            cur = 0
+            entries = []
+            value.each do |k, v|
+              if max != 0 && cur >= max
+                serialized.update(notCapturedReason: "collectionSize", size: value.length)
+                break
+              end
+              cur += 1
+              entries << [serialize_value(nil, k, depth: depth - 1), serialize_value(k, v, depth: depth - 1)]
+            end
+            serialized.update(entries: entries)
+          end
+        else
+          if depth < 0
+            serialized.update(notCapturedReason: "depth")
+          else
+            fields = {}
+            max = settings.dynamic_instrumentation.max_capture_attribute_count
+            cur = 0
+            value.instance_variables.each do |ivar|
+              if cur >= max
+                serialized.update(notCapturedReason: "fieldCount", fields: fields)
+                break
+              end
+              cur += 1
+              fields[ivar] = serialize_value(ivar, value.instance_variable_get(ivar), depth: depth - 1)
+            end
+            serialized.update(fields: fields)
+          end
+        end
+        serialized
+      end
+
+      # Returns the name for the specified class object.
+      #
+      # Ruby can have nameless classes, e.g. Class.new is a class object
+      # with no name. We return a placeholder for such nameless classes.
+      def class_name(cls)
+        # We could call `cls.to_s` to get the "standard" Ruby inspection of
+        # the class, but it is likely that user code can override #to_s
+        # and we don't want to invoke user code.
+        cls.name || "[Unnamed class]"
+      end
+    end
+  end
+end

--- a/lib/datadog/di/serializer.rb
+++ b/lib/datadog/di/serializer.rb
@@ -93,10 +93,8 @@ module Datadog
           value = value.to_s
           max = settings.dynamic_instrumentation.max_capture_string_length
           if value.length > max
-            serialized.update(notCapturedReason: "length", size: value.length)
-            # steep misunderstands string slice types.
-            # https://github.com/soutaro/steep/issues/1219
-            value = (value[0...max] || "") + "..."
+            serialized.update(truncated: true, size: value.length)
+            value = value[0...max]
           end
           serialized.update(value: value)
         when Array

--- a/lib/datadog/di/serializer.rb
+++ b/lib/datadog/di/serializer.rb
@@ -137,7 +137,30 @@ module Datadog
             fields = {}
             max = settings.dynamic_instrumentation.max_capture_attribute_count
             cur = 0
-            value.instance_variables.each do |ivar|
+
+            # MRI and JRuby 9.4.5+ preserve instance variable definition
+            # order when calling #instance_variables. Previous JRuby versions
+            # did not preserve order and returned the variables in arbitrary
+            # order.
+            #
+            # The arbitrary order is problematic because 1) when there are
+            # fewer instance variables than capture limit, the order in which
+            # the variables are shown in UI will change from one capture to
+            # the next and generally will be arbitrary to the user, and
+            # 2) when there are more instance variables than capture limit,
+            # *which* variables are captured will also change meaning user
+            # looking at the UI may have "new" instance variables appear and
+            # existing ones disappear as they are looking at multiple captures.
+            #
+            # For consistency, we should have some kind of stable order of
+            # instance variables on all supported Ruby runtimes, so that the UI
+            # stays consistent. Given that initial implementation of Ruby DI
+            # does not support JRuby, we don't handle JRuby's lack of ordering
+            # of #instance_variables here, but if JRuby is supported in the
+            # future this may need to be addressed.
+            ivars = value.instance_variables
+
+            ivars.each do |ivar|
               if cur >= max
                 serialized.update(notCapturedReason: "fieldCount", fields: fields)
                 break

--- a/lib/datadog/di/serializer.rb
+++ b/lib/datadog/di/serializer.rb
@@ -59,9 +59,9 @@ module Datadog
       # These are normally local variables that exist on a particular line
       # of executed code.
       def serialize_vars(vars)
-        vars.map do |k, v|
-          [k, serialize_value(k, v)]
-        end.to_h
+        vars.each_with_object({}) do |(k, v), agg|
+          agg[k] = serialize_value(k, v)
+        end
       end
 
       private

--- a/sig/datadog/di/serializer.rbs
+++ b/sig/datadog/di/serializer.rbs
@@ -1,0 +1,21 @@
+module Datadog
+  module DI
+    class Serializer
+      @settings: untyped
+
+      @redactor: untyped
+
+      def initialize: (untyped settings, untyped redactor) -> void
+
+      attr_reader settings: untyped
+
+      attr_reader redactor: untyped
+      def serialize_args: (untyped args, untyped kwargs) -> untyped
+      def serialize_vars: (untyped vars) -> untyped
+
+      private
+      def serialize_value: (untyped name, untyped value, ?depth: untyped) -> ({ type: untyped, notCapturedReason: "redactedType" } | { type: untyped, notCapturedReason: "redactedIdent" } | untyped)
+      def class_name: (untyped cls) -> untyped
+    end
+  end
+end

--- a/spec/datadog/di/redactor_spec.rb
+++ b/spec/datadog/di/redactor_spec.rb
@@ -1,3 +1,4 @@
+require "datadog/di/spec_helper"
 require "datadog/di/redactor"
 
 class DIRedactorSpecSensitiveType; end
@@ -27,6 +28,8 @@ module DIRedactorSpec
 end
 
 RSpec.describe Datadog::DI::Redactor do
+  di_test
+
   let(:settings) do
     double("settings").tap do |settings|
       allow(settings).to receive(:dynamic_instrumentation).and_return(di_settings)

--- a/spec/datadog/di/serializer_spec.rb
+++ b/spec/datadog/di/serializer_spec.rb
@@ -1,3 +1,4 @@
+require "datadog/di/spec_helper"
 require "datadog/di/serializer"
 
 class DISerializerSpecSensitiveType
@@ -29,6 +30,8 @@ end
 class DISerializerSpecTestClass; end
 
 RSpec.describe Datadog::DI::Serializer do
+  di_test
+
   let(:settings) do
     double("settings").tap do |settings|
       allow(settings).to receive(:dynamic_instrumentation).and_return(di_settings)

--- a/spec/datadog/di/serializer_spec.rb
+++ b/spec/datadog/di/serializer_spec.rb
@@ -210,9 +210,9 @@ RSpec.describe Datadog::DI::Serializer do
 
       cases = [
         {name: "string too long", input: {a: "abcde"},
-         expected: {a: {type: "String", value: "abc...", size: 5, notCapturedReason: "length"}}},
+         expected: {a: {type: "String", value: "abc", size: 5, truncated: true}}},
         {name: "symbol too long", input: {a: :abcde},
-         expected: {a: {type: "Symbol", value: "abc...", size: 5, notCapturedReason: "length"}}},
+         expected: {a: {type: "Symbol", value: "abc", size: 5, truncated: true}}},
       ]
 
       define_cases(cases)

--- a/spec/datadog/di/serializer_spec.rb
+++ b/spec/datadog/di/serializer_spec.rb
@@ -1,0 +1,286 @@
+require "datadog/di/serializer"
+
+class DISerializerSpecSensitiveType
+end
+
+class DISerializerSpecWildCardClass; end
+
+class DISerializerSpecInstanceVariable
+  def initialize(value)
+    @ivar = value
+  end
+end
+
+class DISerializerSpecRedactedInstanceVariable
+  def initialize(value)
+    @session = value
+  end
+end
+
+class DISerializerSpecManyInstanceVariables
+  def initialize
+    1.upto(100) do |i|
+      instance_variable_set("@v#{i}", i)
+    end
+  end
+end
+
+# Should have no instance variables
+class DISerializerSpecTestClass; end
+
+RSpec.describe Datadog::DI::Serializer do
+  let(:settings) do
+    double("settings").tap do |settings|
+      allow(settings).to receive(:dynamic_instrumentation).and_return(di_settings)
+    end
+  end
+
+  let(:di_settings) do
+    double("di settings").tap do |settings|
+      allow(settings).to receive(:enabled).and_return(true)
+      allow(settings).to receive(:propagate_all_exceptions).and_return(false)
+      allow(settings).to receive(:redacted_identifiers).and_return([])
+      allow(settings).to receive(:redacted_type_names).and_return(%w[
+        DISerializerSpecSensitiveType DISerializerSpecWildCard*
+      ])
+      allow(settings).to receive(:max_capture_collection_size).and_return(10)
+      allow(settings).to receive(:max_capture_attribute_count).and_return(10)
+      # Reduce max capture depth to 2 from default of 3
+      allow(settings).to receive(:max_capture_depth).and_return(2)
+      allow(settings).to receive(:max_capture_string_length).and_return(100)
+    end
+  end
+
+  let(:redactor) do
+    Datadog::DI::Redactor.new(settings)
+  end
+
+  let(:serializer) do
+    described_class.new(settings, redactor)
+  end
+
+  describe "#serialize_vars" do
+    let(:serialized) do
+      serializer.serialize_vars(vars)
+    end
+
+    def self.define_cases(cases)
+      cases.each do |c|
+        value = c.fetch(:input)
+        expected = c.fetch(:expected)
+
+        context c.fetch(:name) do
+          let(:vars) { value }
+
+          it "serializes as expected" do
+            expect(serialized).to eq(expected)
+          end
+        end
+      end
+    end
+
+    cases = [
+      {name: "nil value", input: {a: nil}, expected: {a: {type: "NilClass", isNull: true}}},
+      {name: "true value", input: {a: true}, expected: {a: {type: "TrueClass", value: "true"}}},
+      {name: "false value", input: {a: false}, expected: {a: {type: "FalseClass", value: "false"}}},
+      {name: "int value", input: {a: 42}, expected: {a: {type: "Integer", value: "42"}}},
+      {name: "bigint value", input: {a: 420000000000000000000042}, expected: {a: {type: "Integer", value: "420000000000000000000042"}}},
+      {name: "float value", input: {a: 42.02}, expected: {a: {type: "Float", value: "42.02"}}},
+      {name: "string value", input: {a: "x"}, expected: {a: {type: "String", value: "x"}}},
+      {name: "symbol value", input: {a: :x}, expected: {a: {type: "Symbol", value: "x"}}},
+      {name: "redacted value in predefined list", input: {password: "123"},
+       expected: {password: {type: "String", notCapturedReason: "redactedIdent"}}},
+      {name: "redacted type", input: {value: DISerializerSpecSensitiveType.new},
+       expected: {value: {type: "DISerializerSpecSensitiveType", notCapturedReason: "redactedType"}}},
+      {name: "redacted wild card type", input: {value: DISerializerSpecWildCardClass.new},
+       expected: {value: {type: "DISerializerSpecWildCardClass", notCapturedReason: "redactedType"}}},
+      {name: "empty array", input: {arr: []},
+       expected: {arr: {type: "Array", elements: []}}},
+      {name: "array of primitives", input: {arr: [42, "hello", nil, true]},
+       expected: {arr: {type: "Array", elements: [
+         {type: "Integer", value: "42"},
+         {type: "String", value: "hello"},
+         {type: "NilClass", isNull: true},
+         {type: "TrueClass", value: "true"},
+       ]}}},
+      {name: "array with value of redacted type", input: {arr: [1, DISerializerSpecSensitiveType.new]},
+       expected: {arr: {type: "Array", elements: [
+         {type: "Integer", value: "1"},
+         {type: "DISerializerSpecSensitiveType", notCapturedReason: "redactedType"},
+       ]}}},
+      {name: "empty hash", input: {h: {}}, expected: {h: {type: "Hash", entries: []}}},
+      {name: "hash with symbol key", input: {h: {hello: 42}}, expected: {h: {type: "Hash", entries: [
+        [{type: "Symbol", value: "hello"}, {type: "Integer", value: "42"}],
+      ]}}},
+      {name: "hash with string key", input: {h: {"hello" => 42}}, expected: {h: {type: "Hash", entries: [
+        [{type: "String", value: "hello"}, {type: "Integer", value: "42"}],
+      ]}}},
+      {name: "hash with redacted identifier", input: {h: {"session-key" => 42}}, expected: {h: {type: "Hash", entries: [
+        [{type: "String", value: "session-key"}, {type: "Integer", notCapturedReason: "redactedIdent"}],
+      ]}}},
+      {name: "empty object", input: {x: Object.new}, expected: {x: {type: "Object", fields: {}}}},
+      {name: "object with instance variable", input: {x: DISerializerSpecInstanceVariable.new(42)},
+       expected: {x: {type: "DISerializerSpecInstanceVariable", fields: {
+         "@ivar": {type: "Integer", value: "42"},
+       }}}},
+      {name: "object with redacted instance variable", input: {x: DISerializerSpecRedactedInstanceVariable.new(42)},
+       expected: {x: {type: "DISerializerSpecRedactedInstanceVariable", fields: {
+         "@session": {type: "Integer", notCapturedReason: "redactedIdent"},
+       }}}},
+      {name: "depth exceeded: array", input: {v: {a: {b: {c: []}}}},
+       expected: {v: {type: "Hash", entries: [
+         [{type: "Symbol", value: "a"}, {type: "Hash", entries: [
+           [{type: "Symbol", value: "b"}, {type: "Hash", entries: [
+             [{type: "Symbol", value: "c"}, {type: "Array", notCapturedReason: "depth"}],
+           ]}],
+         ]}],
+       ]}}},
+      {name: "depth exceeded: hash", input: {v: {a: {b: {c: {}}}}},
+       expected: {v: {type: "Hash", entries: [
+         [{type: "Symbol", value: "a"}, {type: "Hash", entries: [
+           [{type: "Symbol", value: "b"}, {type: "Hash", entries: [
+             [{type: "Symbol", value: "c"}, {type: "Hash", notCapturedReason: "depth"}],
+           ]}],
+         ]}],
+       ]}}},
+      {name: "depth exceeded: object", input: {v: {a: {b: {c: Object.new}}}},
+       expected: {v: {type: "Hash", entries: [
+         [{type: "Symbol", value: "a"}, {type: "Hash", entries: [
+           [{type: "Symbol", value: "b"}, {type: "Hash", entries: [
+             [{type: "Symbol", value: "c"}, {type: "Object", notCapturedReason: "depth"}],
+           ]}],
+         ]}],
+       ]}}},
+      {name: "object with no attributes", input: {v: DISerializerSpecTestClass.new},
+       expected: {v: {type: "DISerializerSpecTestClass", fields: {}}},},
+      {name: "object of anonymous class with no attributes", input: {v: Class.new.new},
+       expected: {v: {type: "[Unnamed class]", fields: {}}},},
+      # TODO hash with a complex object as key?
+    ]
+
+    define_cases(cases)
+
+    context "when data exceeds collection limits" do
+      before do
+        allow(di_settings).to receive(:max_capture_collection_size).and_return(3)
+      end
+
+      cases = [
+        {name: "array too long", input: {a: [10] * 1000},
+         expected: {a: {type: "Array",
+                        elements: [
+                          {type: "Integer", value: "10"},
+                          {type: "Integer", value: "10"},
+                          {type: "Integer", value: "10"},
+                        ], notCapturedReason: "collectionSize", size: 1000}}},
+        {name: "hash too long", input: {v: {a: 1, b: 2, c: 3, d: 4, e: 5}},
+         expected: {v: {type: "Hash",
+                        entries: [
+                          [{type: "Symbol", value: "a"}, {type: "Integer", value: "1"}],
+                          [{type: "Symbol", value: "b"}, {type: "Integer", value: "2"}],
+                          [{type: "Symbol", value: "c"}, {type: "Integer", value: "3"}],
+                        ], notCapturedReason: "collectionSize", size: 5}}},
+      ]
+
+      define_cases(cases)
+    end
+
+    context "when data exceeds attribute limits" do
+      before do
+        allow(di_settings).to receive(:max_capture_attribute_count).and_return(3)
+      end
+
+      cases = [
+        {name: "too many attributes", input: {a: DISerializerSpecManyInstanceVariables.new},
+         expected: {a: {type: "DISerializerSpecManyInstanceVariables",
+                        fields: {
+                          "@v1": {type: "Integer", value: "1"},
+                          "@v2": {type: "Integer", value: "2"},
+                          "@v3": {type: "Integer", value: "3"},
+                        }, notCapturedReason: "fieldCount"}}},
+      ]
+
+      define_cases(cases)
+    end
+
+    context "when strings exceed max length" do
+      before do
+        allow(di_settings).to receive(:max_capture_string_length).and_return(3)
+      end
+
+      cases = [
+        {name: "string too long", input: {a: "abcde"},
+         expected: {a: {type: "String", value: "abc...", size: 5, notCapturedReason: "length"}}},
+        {name: "symbol too long", input: {a: :abcde},
+         expected: {a: {type: "Symbol", value: "abc...", size: 5, notCapturedReason: "length"}}},
+      ]
+
+      define_cases(cases)
+    end
+
+    context "when limits are zero" do
+      before do
+        allow(di_settings).to receive(:max_capture_collection_size).and_return(0)
+      end
+
+      cases = [
+        {name: "array", input: {a: [10] * 5},
+         expected: {a: {type: "Array",
+                        elements: [
+                          {type: "Integer", value: "10"},
+                          {type: "Integer", value: "10"},
+                          {type: "Integer", value: "10"},
+                          {type: "Integer", value: "10"},
+                          {type: "Integer", value: "10"},
+                        ]}}},
+        {name: "hash", input: {v: {a: 1, b: 2, c: 3, d: 4, e: 5}},
+         expected: {v: {type: "Hash",
+                        entries: [
+                          [{type: "Symbol", value: "a"}, {type: "Integer", value: "1"}],
+                          [{type: "Symbol", value: "b"}, {type: "Integer", value: "2"}],
+                          [{type: "Symbol", value: "c"}, {type: "Integer", value: "3"}],
+                          [{type: "Symbol", value: "d"}, {type: "Integer", value: "4"}],
+                          [{type: "Symbol", value: "e"}, {type: "Integer", value: "5"}],
+                        ]}}},
+      ]
+
+      define_cases(cases)
+    end
+  end
+
+  describe "#serialize_args" do
+    let(:serialized) do
+      serializer.serialize_args(args, kwargs)
+    end
+
+    cases = [
+      {name: "both args and kwargs",
+       args: [1, "x"],
+       kwargs: {a: 42},
+       expected: {arg1: {type: "Integer", value: "1"},
+                  arg2: {type: "String", value: "x"},
+                  a: {type: "Integer", value: "42"}},},
+      {name: "kwargs contains redacted identifier",
+       args: [1, "x"],
+       kwargs: {password: 42},
+       expected: {arg1: {type: "Integer", value: "1"},
+                  arg2: {type: "String", value: "x"},
+                  password: {type: "Integer", notCapturedReason: "redactedIdent"}},},
+    ]
+
+    cases.each do |c|
+      args = c.fetch(:args)
+      kwargs = c.fetch(:kwargs)
+      expected = c.fetch(:expected)
+
+      context c.fetch(:name) do
+        let(:args) { args }
+        let(:kwargs) { kwargs }
+
+        it "serializes as expected" do
+          expect(serialized).to eq(expected)
+        end
+      end
+    end
+  end
+end

--- a/spec/datadog/di/spec_helper.rb
+++ b/spec/datadog/di/spec_helper.rb
@@ -1,0 +1,15 @@
+module DIHelpers
+  module ClassMethods
+    def di_test
+      if PlatformHelpers.jruby?
+        before(:all) do
+          skip "Dynamic instrumentation is not supported on JRuby"
+        end
+      end
+    end
+  end
+end
+
+RSpec.configure do |config|
+  config.extend DIHelpers::ClassMethods
+end


### PR DESCRIPTION
<!--
Check out the
https://github.com/DataDog/dd-trace-rb/blob/master/docs/DevelopmentGuide.md
for guidance on how to set up your development environment,
run the test suite, write new integrations, and more.
-->

**What does this PR do?**
<!-- A brief description of the change being made with this pull request. -->
Adds the Serializer component which is responsible for converting arbitrary Ruby objects to object trees made up of basic types.

**Motivation:**
<!-- What inspired you to submit this pull request? -->
Ruby DI implementation

**Additional Notes:**
<!-- Anything else we should know when reviewing? -->

**How to test the change?**
Unit tests only in this PR.
<!--
Describe here how the change can be validated.
You are strongly encouraged to provide automated tests for this PR (unit or integration).
If this change cannot be feasibly tested, please explain why,
unless the change does not modify code (e.g. only modifies docs, comments).
-->

Unsure? Have a question? Request a review!
