### PR TITLE
Prevent telemetry deadlock with no-op

### DIFF
--- a/lib/datadog/core/telemetry/logger.rb
+++ b/lib/datadog/core/telemetry/logger.rb
@@ -31,7 +31,7 @@ module Datadog
             if components && components.telemetry
               components.telemetry
             else
-              Datadog.logger.error(
+              Datadog.logger.warn(
                 'Fail to send telemetry log before components initialization or within components lifecycle'
               )
               nil

--- a/lib/datadog/core/telemetry/logger.rb
+++ b/lib/datadog/core/telemetry/logger.rb
@@ -25,7 +25,8 @@ module Datadog
           private
 
           def instance
-            # `allow_initialization: false` to prevent deadlock from components lifecycle
+            # `allow_initialization: false` would avoid referencing the components via `safely_synchronize` (mutex)
+            # which could cause deadlock during components initialization.
             components = Datadog.send(:components, allow_initialization: false)
 
             if components && components.telemetry

--- a/lib/datadog/core/telemetry/logger.rb
+++ b/lib/datadog/core/telemetry/logger.rb
@@ -3,7 +3,7 @@
 module Datadog
   module Core
     module Telemetry
-      # === INTRENAL USAGE ONLY ===
+      # === INTERNAL USAGE ONLY ===
       #
       # Report telemetry logs via delegating to the telemetry component instance via mutex.
       #

--- a/lib/datadog/core/telemetry/logging.rb
+++ b/lib/datadog/core/telemetry/logging.rb
@@ -7,7 +7,7 @@ require 'pathname'
 module Datadog
   module Core
     module Telemetry
-      # === INTRENAL USAGE ONLY ===
+      # === INTERNAL USAGE ONLY ===
       #
       # Logging interface for sending telemetry logs... so we can fix them.
       #

--- a/spec/datadog/core/telemetry/logger_spec.rb
+++ b/spec/datadog/core/telemetry/logger_spec.rb
@@ -10,7 +10,7 @@ RSpec.describe Datadog::Core::Telemetry::Logger do
         telemetry = instance_double(Datadog::Core::Telemetry::Component)
         allow(Datadog.send(:components)).to receive(:telemetry).and_return(telemetry)
         expect(telemetry).to receive(:report).with(exception, level: :error, description: 'Oops...')
-        expect(Datadog.logger).not_to receive(:debug)
+        expect(Datadog.logger).not_to receive(:warn)
 
         expect do
           described_class.report(exception, level: :error, description: 'Oops...')
@@ -23,7 +23,7 @@ RSpec.describe Datadog::Core::Telemetry::Logger do
           telemetry = instance_double(Datadog::Core::Telemetry::Component)
           allow(Datadog.send(:components)).to receive(:telemetry).and_return(telemetry)
           expect(telemetry).to receive(:report).with(exception, level: :error, description: nil)
-          expect(Datadog.logger).not_to receive(:debug)
+          expect(Datadog.logger).not_to receive(:warn)
 
           expect do
             described_class.report(exception)
@@ -36,7 +36,7 @@ RSpec.describe Datadog::Core::Telemetry::Logger do
       it do
         exception = StandardError.new
         allow(Datadog.send(:components)).to receive(:telemetry).and_return(nil)
-        expect(Datadog.logger).to receive(:error).with(/Fail to send telemetry log/)
+        expect(Datadog.logger).to receive(:warn).with(/Fail to send telemetry log/)
 
         expect do
           described_class.report(exception, level: :error, description: 'Oops...')
@@ -51,7 +51,7 @@ RSpec.describe Datadog::Core::Telemetry::Logger do
         telemetry = instance_double(Datadog::Core::Telemetry::Component)
         allow(Datadog.send(:components)).to receive(:telemetry).and_return(telemetry)
         expect(telemetry).to receive(:error).with('description')
-        expect(Datadog.logger).not_to receive(:debug)
+        expect(Datadog.logger).not_to receive(:warn)
 
         expect { described_class.error('description') }.not_to raise_error
       end
@@ -60,7 +60,7 @@ RSpec.describe Datadog::Core::Telemetry::Logger do
     context 'when there is no telemetry component configured' do
       it do
         allow(Datadog.send(:components)).to receive(:telemetry).and_return(nil)
-        expect(Datadog.logger).to receive(:error).with(/Fail to send telemetry log/)
+        expect(Datadog.logger).to receive(:warn).with(/Fail to send telemetry log/)
 
         expect { described_class.error('description') }.not_to raise_error
       end

--- a/spec/datadog/core/telemetry/logger_spec.rb
+++ b/spec/datadog/core/telemetry/logger_spec.rb
@@ -10,6 +10,7 @@ RSpec.describe Datadog::Core::Telemetry::Logger do
         telemetry = instance_double(Datadog::Core::Telemetry::Component)
         allow(Datadog.send(:components)).to receive(:telemetry).and_return(telemetry)
         expect(telemetry).to receive(:report).with(exception, level: :error, description: 'Oops...')
+        expect(Datadog.logger).not_to receive(:debug)
 
         expect do
           described_class.report(exception, level: :error, description: 'Oops...')
@@ -22,6 +23,7 @@ RSpec.describe Datadog::Core::Telemetry::Logger do
           telemetry = instance_double(Datadog::Core::Telemetry::Component)
           allow(Datadog.send(:components)).to receive(:telemetry).and_return(telemetry)
           expect(telemetry).to receive(:report).with(exception, level: :error, description: nil)
+          expect(Datadog.logger).not_to receive(:debug)
 
           expect do
             described_class.report(exception)
@@ -34,6 +36,7 @@ RSpec.describe Datadog::Core::Telemetry::Logger do
       it do
         exception = StandardError.new
         allow(Datadog.send(:components)).to receive(:telemetry).and_return(nil)
+        expect(Datadog.logger).to receive(:error).with(/Fail to send telemetry log/)
 
         expect do
           described_class.report(exception, level: :error, description: 'Oops...')
@@ -48,6 +51,7 @@ RSpec.describe Datadog::Core::Telemetry::Logger do
         telemetry = instance_double(Datadog::Core::Telemetry::Component)
         allow(Datadog.send(:components)).to receive(:telemetry).and_return(telemetry)
         expect(telemetry).to receive(:error).with('description')
+        expect(Datadog.logger).not_to receive(:debug)
 
         expect { described_class.error('description') }.not_to raise_error
       end
@@ -56,6 +60,7 @@ RSpec.describe Datadog::Core::Telemetry::Logger do
     context 'when there is no telemetry component configured' do
       it do
         allow(Datadog.send(:components)).to receive(:telemetry).and_return(nil)
+        expect(Datadog.logger).to receive(:error).with(/Fail to send telemetry log/)
 
         expect { described_class.error('description') }.not_to raise_error
       end


### PR DESCRIPTION
**What does this PR do?**

It is still far too dangerous for `Telemetry::Logger` to hit a deadlock. This is the risk should be mitigated especially for telemetry which is considered to be a kind of best effort utility.