### PR TITLE
Fix Yard Github action

### DIFF
--- a/.github/workflows/yard.yml
+++ b/.github/workflows/yard.yml
@@ -25,15 +25,18 @@ jobs:
       name: github-pages
       url: ${{ steps.deployment.outputs.page_url }}
     runs-on: ubuntu-latest
+    container:
+      image: ghcr.io/datadog/images-rb/engines/ruby:3.2
+      env:
+        BUNDLE_GEMFILE: tools/yard.gemfile
     steps:
       - name: Checkout
         uses: actions/checkout@v4
-      - uses: ruby/setup-ruby@v1
-        with:
-          ruby-version: '3.2'
-          bundler-cache: true
+      - run: ls -al
+      - name: Bundle
+        run: bundle install
       - name: Generate YARD documentation
-        run: bundle exec rake docs
+        run: bundle exec rake docs --rakefile=tasks/yard.rake
       - name: Setup Pages
         uses: actions/configure-pages@v3
       - name: Upload artifact

--- a/.standard_todo.yml
+++ b/.standard_todo.yml
@@ -41,4 +41,5 @@ ignore:
 - spec/datadog/tracing/**/**
 - spec/support/**/**
 - tasks/**/**
+- tools/**/**
 - yard/**/**

--- a/Gemfile
+++ b/Gemfile
@@ -51,8 +51,6 @@ elsif RUBY_VERSION >= '3.0.0' # No longer bundled by default since Ruby 3.0
   gem 'webrick', '>= 1.7.0'
 end
 
-gem 'yard', '~> 0.9' # NOTE: YardDoc is generated with ruby 3.2 in GitHub Actions
-
 if RUBY_VERSION >= '2.6.0'
   # 1.50 is the last version to support Ruby 2.6
   gem 'rubocop', '~> 1.50.0', require: false

--- a/Rakefile
+++ b/Rakefile
@@ -4,7 +4,6 @@ require 'rubocop/rake_task' if Gem.loaded_specs.key? 'rubocop'
 require 'standard/rake' if Gem.loaded_specs.key? 'standard'
 require 'rspec/core/rake_task'
 require 'rake/extensiontask'
-require 'yard'
 require 'os'
 if Gem.loaded_specs.key? 'ruby_memcheck'
   require 'ruby_memcheck'
@@ -348,17 +347,6 @@ end
 if defined?(RuboCop::RakeTask)
   RuboCop::RakeTask.new(:rubocop) do |_t|
   end
-end
-
-YARD::Rake::YardocTask.new(:docs) do |t|
-  # Options defined in `.yardopts` are read first, then merged with
-  # options defined here.
-  #
-  # It's recommended to define options in `.yardopts` instead of here,
-  # as `.yardopts` can be read by external YARD tools, like the
-  # hot-reload YARD server `yard server --reload`.
-
-  t.options += ['--title', "datadog #{Datadog::VERSION::STRING} documentation"]
 end
 
 # Jobs are parallelized if running in CI.

--- a/gemfiles/jruby_9.2_activesupport.gemfile
+++ b/gemfiles/jruby_9.2_activesupport.gemfile
@@ -25,7 +25,6 @@ gem "simplecov-cobertura", "~> 2.1.0"
 gem "warning", "~> 1"
 gem "webmock", ">= 3.10.0"
 gem "rexml", ">= 3.2.7"
-gem "yard", "~> 0.9"
 gem "dogstatsd-ruby", ">= 3.3.0", "!= 5.0.0", "!= 5.0.1", "!= 5.1.0"
 gem "ffi", "~> 1.16.3", require: false
 gem "activesupport", "~> 5"

--- a/gemfiles/jruby_9.2_activesupport.gemfile.lock
+++ b/gemfiles/jruby_9.2_activesupport.gemfile.lock
@@ -205,7 +205,6 @@ GEM
       addressable (>= 2.3.6)
       crack (>= 0.3.2)
       hashdiff (>= 0.4.0, < 2.0.0)
-    yard (0.9.34)
 
 PLATFORMS
   universal-java-1.8
@@ -245,7 +244,6 @@ DEPENDENCIES
   simplecov-cobertura (~> 2.1.0)
   warning (~> 1)
   webmock (>= 3.10.0)
-  yard (~> 0.9)
 
 BUNDLED WITH
    2.3.27

--- a/gemfiles/jruby_9.2_aws.gemfile
+++ b/gemfiles/jruby_9.2_aws.gemfile
@@ -25,7 +25,6 @@ gem "simplecov-cobertura", "~> 2.1.0"
 gem "warning", "~> 1"
 gem "webmock", ">= 3.10.0"
 gem "rexml", "= 3.2.6"
-gem "yard", "~> 0.9"
 gem "dogstatsd-ruby", ">= 3.3.0", "!= 5.0.0", "!= 5.0.1", "!= 5.1.0"
 gem "ffi", "~> 1.16.3", require: false
 gem "aws-sdk"

--- a/gemfiles/jruby_9.2_aws.gemfile.lock
+++ b/gemfiles/jruby_9.2_aws.gemfile.lock
@@ -1520,7 +1520,6 @@ GEM
       addressable (>= 2.3.6)
       crack (>= 0.3.2)
       hashdiff (>= 0.4.0, < 2.0.0)
-    yard (0.9.34)
 
 PLATFORMS
   universal-java-1.8
@@ -1554,7 +1553,6 @@ DEPENDENCIES
   simplecov-cobertura (~> 2.1.0)
   warning (~> 1)
   webmock (>= 3.10.0)
-  yard (~> 0.9)
 
 BUNDLED WITH
    2.3.27

--- a/gemfiles/jruby_9.2_contrib.gemfile
+++ b/gemfiles/jruby_9.2_contrib.gemfile
@@ -25,7 +25,6 @@ gem "simplecov-cobertura", "~> 2.1.0"
 gem "warning", "~> 1"
 gem "webmock", ">= 3.10.0"
 gem "rexml", ">= 3.2.7"
-gem "yard", "~> 0.9"
 gem "dogstatsd-ruby", ">= 3.3.0", "!= 5.0.0", "!= 5.0.1", "!= 5.1.0"
 gem "ffi", "~> 1.16.3", require: false
 gem "dalli", ">= 3.0.0"

--- a/gemfiles/jruby_9.2_contrib.gemfile.lock
+++ b/gemfiles/jruby_9.2_contrib.gemfile.lock
@@ -152,9 +152,6 @@ GEM
       addressable (>= 2.3.6)
       crack (>= 0.3.2)
       hashdiff (>= 0.4.0, < 2.0.0)
-    webrick (1.7.0)
-    yard (0.9.28)
-      webrick (~> 1.7.0)
 
 PLATFORMS
   universal-java-1.8
@@ -198,7 +195,6 @@ DEPENDENCIES
   sucker_punch
   warning (~> 1)
   webmock (>= 3.10.0)
-  yard (~> 0.9)
 
 BUNDLED WITH
    2.3.27

--- a/gemfiles/jruby_9.2_contrib_old.gemfile
+++ b/gemfiles/jruby_9.2_contrib_old.gemfile
@@ -25,7 +25,6 @@ gem "simplecov-cobertura", "~> 2.1.0"
 gem "warning", "~> 1"
 gem "webmock", ">= 3.10.0"
 gem "rexml", ">= 3.2.7"
-gem "yard", "~> 0.9"
 gem "dogstatsd-ruby", ">= 3.3.0", "!= 5.0.0", "!= 5.0.1", "!= 5.1.0"
 gem "ffi", "~> 1.16.3", require: false
 gem "dalli", "< 3.0.0"

--- a/gemfiles/jruby_9.2_contrib_old.gemfile.lock
+++ b/gemfiles/jruby_9.2_contrib_old.gemfile.lock
@@ -109,9 +109,6 @@ GEM
       addressable (>= 2.3.6)
       crack (>= 0.3.2)
       hashdiff (>= 0.4.0, < 2.0.0)
-    webrick (1.7.0)
-    yard (0.9.28)
-      webrick (~> 1.7.0)
 
 PLATFORMS
   universal-java-1.8
@@ -148,7 +145,6 @@ DEPENDENCIES
   simplecov-cobertura (~> 2.1.0)
   warning (~> 1)
   webmock (>= 3.10.0)
-  yard (~> 0.9)
 
 BUNDLED WITH
    2.3.27

--- a/gemfiles/jruby_9.2_core_old.gemfile
+++ b/gemfiles/jruby_9.2_core_old.gemfile
@@ -25,7 +25,6 @@ gem "simplecov-cobertura", "~> 2.1.0"
 gem "warning", "~> 1"
 gem "webmock", ">= 3.10.0"
 gem "rexml", ">= 3.2.7"
-gem "yard", "~> 0.9"
 gem "dogstatsd-ruby", "~> 4"
 gem "ffi", "~> 1.16.3", require: false
 

--- a/gemfiles/jruby_9.2_core_old.gemfile.lock
+++ b/gemfiles/jruby_9.2_core_old.gemfile.lock
@@ -96,9 +96,6 @@ GEM
       addressable (>= 2.3.6)
       crack (>= 0.3.2)
       hashdiff (>= 0.4.0, < 2.0.0)
-    webrick (1.7.0)
-    yard (0.9.28)
-      webrick (~> 1.7.0)
 
 PLATFORMS
   universal-java-1.8
@@ -130,7 +127,6 @@ DEPENDENCIES
   simplecov-cobertura (~> 2.1.0)
   warning (~> 1)
   webmock (>= 3.10.0)
-  yard (~> 0.9)
 
 BUNDLED WITH
    2.3.27

--- a/gemfiles/jruby_9.2_elasticsearch_7.gemfile
+++ b/gemfiles/jruby_9.2_elasticsearch_7.gemfile
@@ -25,7 +25,6 @@ gem "simplecov-cobertura", "~> 2.1.0"
 gem "warning", "~> 1"
 gem "webmock", ">= 3.10.0"
 gem "rexml", ">= 3.2.7"
-gem "yard", "~> 0.9"
 gem "dogstatsd-ruby", ">= 3.3.0", "!= 5.0.0", "!= 5.0.1", "!= 5.1.0"
 gem "ffi", "~> 1.16.3", require: false
 gem "elasticsearch", "~> 7"

--- a/gemfiles/jruby_9.2_elasticsearch_7.gemfile.lock
+++ b/gemfiles/jruby_9.2_elasticsearch_7.gemfile.lock
@@ -132,7 +132,6 @@ GEM
       addressable (>= 2.8.0)
       crack (>= 0.3.2)
       hashdiff (>= 0.4.0, < 2.0.0)
-    yard (0.9.34)
 
 PLATFORMS
   universal-java-1.8
@@ -165,7 +164,6 @@ DEPENDENCIES
   simplecov-cobertura (~> 2.1.0)
   warning (~> 1)
   webmock (>= 3.10.0)
-  yard (~> 0.9)
 
 BUNDLED WITH
    2.3.27

--- a/gemfiles/jruby_9.2_elasticsearch_8.gemfile
+++ b/gemfiles/jruby_9.2_elasticsearch_8.gemfile
@@ -25,7 +25,6 @@ gem "simplecov-cobertura", "~> 2.1.0"
 gem "warning", "~> 1"
 gem "webmock", ">= 3.10.0"
 gem "rexml", ">= 3.2.7"
-gem "yard", "~> 0.9"
 gem "dogstatsd-ruby", ">= 3.3.0", "!= 5.0.0", "!= 5.0.1", "!= 5.1.0"
 gem "ffi", "~> 1.16.3", require: false
 gem "elasticsearch", "~> 8"

--- a/gemfiles/jruby_9.2_elasticsearch_8.gemfile.lock
+++ b/gemfiles/jruby_9.2_elasticsearch_8.gemfile.lock
@@ -132,7 +132,6 @@ GEM
       addressable (>= 2.8.0)
       crack (>= 0.3.2)
       hashdiff (>= 0.4.0, < 2.0.0)
-    yard (0.9.34)
 
 PLATFORMS
   universal-java-1.8
@@ -165,7 +164,6 @@ DEPENDENCIES
   simplecov-cobertura (~> 2.1.0)
   warning (~> 1)
   webmock (>= 3.10.0)
-  yard (~> 0.9)
 
 BUNDLED WITH
    2.3.27

--- a/gemfiles/jruby_9.2_graphql_2.0.gemfile
+++ b/gemfiles/jruby_9.2_graphql_2.0.gemfile
@@ -25,7 +25,6 @@ gem "simplecov-cobertura", "~> 2.1.0"
 gem "warning", "~> 1"
 gem "webmock", ">= 3.10.0"
 gem "rexml", ">= 3.2.7"
-gem "yard", "~> 0.9"
 gem "dogstatsd-ruby", ">= 3.3.0", "!= 5.0.0", "!= 5.0.1", "!= 5.1.0"
 gem "ffi", "~> 1.16.3", require: false
 gem "rails", "~> 6.1.0"

--- a/gemfiles/jruby_9.2_graphql_2.0.gemfile.lock
+++ b/gemfiles/jruby_9.2_graphql_2.0.gemfile.lock
@@ -246,7 +246,6 @@ GEM
     websocket-driver (0.7.6-java)
       websocket-extensions (>= 0.1.0)
     websocket-extensions (0.1.5)
-    yard (0.9.34)
     zeitwerk (2.6.16)
 
 PLATFORMS
@@ -283,7 +282,6 @@ DEPENDENCIES
   sprockets (< 4)
   warning (~> 1)
   webmock (>= 3.10.0)
-  yard (~> 0.9)
 
 BUNDLED WITH
    2.3.27

--- a/gemfiles/jruby_9.2_http.gemfile
+++ b/gemfiles/jruby_9.2_http.gemfile
@@ -25,7 +25,6 @@ gem "simplecov-cobertura", "~> 2.1.0"
 gem "warning", "~> 1"
 gem "webmock", ">= 3.10.0"
 gem "rexml", ">= 3.2.7"
-gem "yard", "~> 0.9"
 gem "dogstatsd-ruby", ">= 3.3.0", "!= 5.0.0", "!= 5.0.1", "!= 5.1.0"
 gem "ffi", "~> 1.16.3", require: false
 gem "ethon", "< 0.15.0"

--- a/gemfiles/jruby_9.2_http.gemfile.lock
+++ b/gemfiles/jruby_9.2_http.gemfile.lock
@@ -153,7 +153,6 @@ GEM
       addressable (>= 2.3.6)
       crack (>= 0.3.2)
       hashdiff (>= 0.4.0, < 2.0.0)
-    yard (0.9.34)
 
 PLATFORMS
   universal-java-1.8
@@ -192,7 +191,6 @@ DEPENDENCIES
   typhoeus
   warning (~> 1)
   webmock (>= 3.10.0)
-  yard (~> 0.9)
 
 BUNDLED WITH
    2.3.27

--- a/gemfiles/jruby_9.2_opensearch_2.gemfile
+++ b/gemfiles/jruby_9.2_opensearch_2.gemfile
@@ -25,7 +25,6 @@ gem "simplecov-cobertura", "~> 2.1.0"
 gem "warning", "~> 1"
 gem "webmock", ">= 3.10.0"
 gem "rexml", ">= 3.2.7"
-gem "yard", "~> 0.9"
 gem "dogstatsd-ruby", ">= 3.3.0", "!= 5.0.0", "!= 5.0.1", "!= 5.1.0"
 gem "ffi", "~> 1.16.3", require: false
 gem "opensearch-ruby", "~> 2"

--- a/gemfiles/jruby_9.2_opensearch_2.gemfile.lock
+++ b/gemfiles/jruby_9.2_opensearch_2.gemfile.lock
@@ -132,7 +132,6 @@ GEM
       addressable (>= 2.8.0)
       crack (>= 0.3.2)
       hashdiff (>= 0.4.0, < 2.0.0)
-    yard (0.9.34)
 
 PLATFORMS
   universal-java-1.8
@@ -165,7 +164,6 @@ DEPENDENCIES
   simplecov-cobertura (~> 2.1.0)
   warning (~> 1)
   webmock (>= 3.10.0)
-  yard (~> 0.9)
 
 BUNDLED WITH
    2.3.27

--- a/gemfiles/jruby_9.2_opensearch_3.gemfile
+++ b/gemfiles/jruby_9.2_opensearch_3.gemfile
@@ -25,7 +25,6 @@ gem "simplecov-cobertura", "~> 2.1.0"
 gem "warning", "~> 1"
 gem "webmock", ">= 3.10.0"
 gem "rexml", ">= 3.2.7"
-gem "yard", "~> 0.9"
 gem "dogstatsd-ruby", ">= 3.3.0", "!= 5.0.0", "!= 5.0.1", "!= 5.1.0"
 gem "ffi", "~> 1.16.3", require: false
 gem "opensearch-ruby", "~> 3"

--- a/gemfiles/jruby_9.2_opensearch_3.gemfile.lock
+++ b/gemfiles/jruby_9.2_opensearch_3.gemfile.lock
@@ -127,7 +127,6 @@ GEM
       addressable (>= 2.8.0)
       crack (>= 0.3.2)
       hashdiff (>= 0.4.0, < 2.0.0)
-    yard (0.9.34)
 
 PLATFORMS
   universal-java-1.8
@@ -160,7 +159,6 @@ DEPENDENCIES
   simplecov-cobertura (~> 2.1.0)
   warning (~> 1)
   webmock (>= 3.10.0)
-  yard (~> 0.9)
 
 BUNDLED WITH
    2.3.27

--- a/gemfiles/jruby_9.2_rack_1.gemfile
+++ b/gemfiles/jruby_9.2_rack_1.gemfile
@@ -25,7 +25,6 @@ gem "simplecov-cobertura", "~> 2.1.0"
 gem "warning", "~> 1"
 gem "webmock", ">= 3.10.0"
 gem "rexml", ">= 3.2.7"
-gem "yard", "~> 0.9"
 gem "dogstatsd-ruby", ">= 3.3.0", "!= 5.0.0", "!= 5.0.1", "!= 5.1.0"
 gem "ffi", "~> 1.16.3", require: false
 gem "rack", "~> 1"

--- a/gemfiles/jruby_9.2_rack_1.gemfile.lock
+++ b/gemfiles/jruby_9.2_rack_1.gemfile.lock
@@ -101,7 +101,6 @@ GEM
       addressable (>= 2.3.6)
       crack (>= 0.3.2)
       hashdiff (>= 0.4.0, < 2.0.0)
-    yard (0.9.34)
 
 PLATFORMS
   universal-java-1.8
@@ -136,7 +135,6 @@ DEPENDENCIES
   simplecov-cobertura (~> 2.1.0)
   warning (~> 1)
   webmock (>= 3.10.0)
-  yard (~> 0.9)
 
 BUNDLED WITH
    2.3.27

--- a/gemfiles/jruby_9.2_rack_2.gemfile
+++ b/gemfiles/jruby_9.2_rack_2.gemfile
@@ -25,7 +25,6 @@ gem "simplecov-cobertura", "~> 2.1.0"
 gem "warning", "~> 1"
 gem "webmock", ">= 3.10.0"
 gem "rexml", ">= 3.2.7"
-gem "yard", "~> 0.9"
 gem "dogstatsd-ruby", ">= 3.3.0", "!= 5.0.0", "!= 5.0.1", "!= 5.1.0"
 gem "ffi", "~> 1.16.3", require: false
 gem "rack", "~> 2"

--- a/gemfiles/jruby_9.2_rack_2.gemfile.lock
+++ b/gemfiles/jruby_9.2_rack_2.gemfile.lock
@@ -101,7 +101,6 @@ GEM
       addressable (>= 2.3.6)
       crack (>= 0.3.2)
       hashdiff (>= 0.4.0, < 2.0.0)
-    yard (0.9.34)
 
 PLATFORMS
   universal-java-1.8
@@ -136,7 +135,6 @@ DEPENDENCIES
   simplecov-cobertura (~> 2.1.0)
   warning (~> 1)
   webmock (>= 3.10.0)
-  yard (~> 0.9)
 
 BUNDLED WITH
    2.3.27

--- a/gemfiles/jruby_9.2_rack_3.gemfile
+++ b/gemfiles/jruby_9.2_rack_3.gemfile
@@ -25,7 +25,6 @@ gem "simplecov-cobertura", "~> 2.1.0"
 gem "warning", "~> 1"
 gem "webmock", ">= 3.10.0"
 gem "rexml", ">= 3.2.7"
-gem "yard", "~> 0.9"
 gem "dogstatsd-ruby", ">= 3.3.0", "!= 5.0.0", "!= 5.0.1", "!= 5.1.0"
 gem "ffi", "~> 1.16.3", require: false
 gem "rack", "~> 3"

--- a/gemfiles/jruby_9.2_rack_3.gemfile.lock
+++ b/gemfiles/jruby_9.2_rack_3.gemfile.lock
@@ -101,7 +101,6 @@ GEM
       addressable (>= 2.3.6)
       crack (>= 0.3.2)
       hashdiff (>= 0.4.0, < 2.0.0)
-    yard (0.9.34)
 
 PLATFORMS
   universal-java-1.8
@@ -136,7 +135,6 @@ DEPENDENCIES
   simplecov-cobertura (~> 2.1.0)
   warning (~> 1)
   webmock (>= 3.10.0)
-  yard (~> 0.9)
 
 BUNDLED WITH
    2.3.27

--- a/gemfiles/jruby_9.2_rails5_mysql2.gemfile
+++ b/gemfiles/jruby_9.2_rails5_mysql2.gemfile
@@ -25,7 +25,6 @@ gem "simplecov-cobertura", "~> 2.1.0"
 gem "warning", "~> 1"
 gem "webmock", ">= 3.10.0"
 gem "rexml", ">= 3.2.7"
-gem "yard", "~> 0.9"
 gem "dogstatsd-ruby", ">= 3.3.0", "!= 5.0.0", "!= 5.0.1", "!= 5.1.0"
 gem "ffi", "~> 1.16.3", require: false
 gem "rails", "~> 5.2.1"

--- a/gemfiles/jruby_9.2_rails5_mysql2.gemfile.lock
+++ b/gemfiles/jruby_9.2_rails5_mysql2.gemfile.lock
@@ -206,12 +206,9 @@ GEM
       addressable (>= 2.3.6)
       crack (>= 0.3.2)
       hashdiff (>= 0.4.0, < 2.0.0)
-    webrick (1.7.0)
     websocket-driver (0.7.5-java)
       websocket-extensions (>= 0.1.0)
     websocket-extensions (0.1.5)
-    yard (0.9.28)
-      webrick (~> 1.7.0)
 
 PLATFORMS
   universal-java-1.8
@@ -249,7 +246,6 @@ DEPENDENCIES
   sprockets (< 4)
   warning (~> 1)
   webmock (>= 3.10.0)
-  yard (~> 0.9)
 
 BUNDLED WITH
    2.3.27

--- a/gemfiles/jruby_9.2_rails5_postgres.gemfile
+++ b/gemfiles/jruby_9.2_rails5_postgres.gemfile
@@ -25,7 +25,6 @@ gem "simplecov-cobertura", "~> 2.1.0"
 gem "warning", "~> 1"
 gem "webmock", ">= 3.10.0"
 gem "rexml", ">= 3.2.7"
-gem "yard", "~> 0.9"
 gem "dogstatsd-ruby", ">= 3.3.0", "!= 5.0.0", "!= 5.0.1", "!= 5.1.0"
 gem "ffi", "~> 1.16.3", require: false
 gem "rails", "~> 5.2.1"

--- a/gemfiles/jruby_9.2_rails5_postgres.gemfile.lock
+++ b/gemfiles/jruby_9.2_rails5_postgres.gemfile.lock
@@ -225,12 +225,9 @@ GEM
       addressable (>= 2.3.6)
       crack (>= 0.3.2)
       hashdiff (>= 0.4.0, < 2.0.0)
-    webrick (1.7.0)
     websocket-driver (0.7.5-java)
       websocket-extensions (>= 0.1.0)
     websocket-extensions (0.1.5)
-    yard (0.9.28)
-      webrick (~> 1.7.0)
 
 PLATFORMS
   universal-java-1.8
@@ -267,7 +264,6 @@ DEPENDENCIES
   sprockets (< 4)
   warning (~> 1)
   webmock (>= 3.10.0)
-  yard (~> 0.9)
 
 BUNDLED WITH
    2.3.27

--- a/gemfiles/jruby_9.2_rails5_postgres_redis.gemfile
+++ b/gemfiles/jruby_9.2_rails5_postgres_redis.gemfile
@@ -25,7 +25,6 @@ gem "simplecov-cobertura", "~> 2.1.0"
 gem "warning", "~> 1"
 gem "webmock", ">= 3.10.0"
 gem "rexml", ">= 3.2.7"
-gem "yard", "~> 0.9"
 gem "dogstatsd-ruby", ">= 3.3.0", "!= 5.0.0", "!= 5.0.1", "!= 5.1.0"
 gem "ffi", "~> 1.16.3", require: false
 gem "rails", "~> 5.2.1"

--- a/gemfiles/jruby_9.2_rails5_postgres_redis.gemfile.lock
+++ b/gemfiles/jruby_9.2_rails5_postgres_redis.gemfile.lock
@@ -230,12 +230,9 @@ GEM
       addressable (>= 2.3.6)
       crack (>= 0.3.2)
       hashdiff (>= 0.4.0, < 2.0.0)
-    webrick (1.7.0)
     websocket-driver (0.7.5-java)
       websocket-extensions (>= 0.1.0)
     websocket-extensions (0.1.5)
-    yard (0.9.28)
-      webrick (~> 1.7.0)
 
 PLATFORMS
   universal-java-1.8
@@ -273,7 +270,6 @@ DEPENDENCIES
   sprockets (< 4)
   warning (~> 1)
   webmock (>= 3.10.0)
-  yard (~> 0.9)
 
 BUNDLED WITH
    2.3.27

--- a/gemfiles/jruby_9.2_rails5_postgres_redis_activesupport.gemfile
+++ b/gemfiles/jruby_9.2_rails5_postgres_redis_activesupport.gemfile
@@ -25,7 +25,6 @@ gem "simplecov-cobertura", "~> 2.1.0"
 gem "warning", "~> 1"
 gem "webmock", ">= 3.10.0"
 gem "rexml", ">= 3.2.7"
-gem "yard", "~> 0.9"
 gem "dogstatsd-ruby", ">= 3.3.0", "!= 5.0.0", "!= 5.0.1", "!= 5.1.0"
 gem "ffi", "~> 1.16.3", require: false
 gem "rails", "~> 5.2.1"

--- a/gemfiles/jruby_9.2_rails5_postgres_redis_activesupport.gemfile.lock
+++ b/gemfiles/jruby_9.2_rails5_postgres_redis_activesupport.gemfile.lock
@@ -242,12 +242,9 @@ GEM
       addressable (>= 2.3.6)
       crack (>= 0.3.2)
       hashdiff (>= 0.4.0, < 2.0.0)
-    webrick (1.7.0)
     websocket-driver (0.7.5-java)
       websocket-extensions (>= 0.1.0)
     websocket-extensions (0.1.5)
-    yard (0.9.28)
-      webrick (~> 1.7.0)
 
 PLATFORMS
   universal-java-1.8
@@ -287,7 +284,6 @@ DEPENDENCIES
   sprockets (< 4)
   warning (~> 1)
   webmock (>= 3.10.0)
-  yard (~> 0.9)
 
 BUNDLED WITH
    2.3.27

--- a/gemfiles/jruby_9.2_rails5_postgres_sidekiq.gemfile
+++ b/gemfiles/jruby_9.2_rails5_postgres_sidekiq.gemfile
@@ -25,7 +25,6 @@ gem "simplecov-cobertura", "~> 2.1.0"
 gem "warning", "~> 1"
 gem "webmock", ">= 3.10.0"
 gem "rexml", ">= 3.2.7"
-gem "yard", "~> 0.9"
 gem "dogstatsd-ruby", ">= 3.3.0", "!= 5.0.0", "!= 5.0.1", "!= 5.1.0"
 gem "ffi", "~> 1.16.3", require: false
 gem "rails", "~> 5.2.1"

--- a/gemfiles/jruby_9.2_rails5_postgres_sidekiq.gemfile.lock
+++ b/gemfiles/jruby_9.2_rails5_postgres_sidekiq.gemfile.lock
@@ -231,12 +231,9 @@ GEM
       addressable (>= 2.3.6)
       crack (>= 0.3.2)
       hashdiff (>= 0.4.0, < 2.0.0)
-    webrick (1.7.0)
     websocket-driver (0.7.5-java)
       websocket-extensions (>= 0.1.0)
     websocket-extensions (0.1.5)
-    yard (0.9.28)
-      webrick (~> 1.7.0)
 
 PLATFORMS
   universal-java-1.8
@@ -275,7 +272,6 @@ DEPENDENCIES
   sprockets (< 4)
   warning (~> 1)
   webmock (>= 3.10.0)
-  yard (~> 0.9)
 
 BUNDLED WITH
    2.3.27

--- a/gemfiles/jruby_9.2_rails5_semantic_logger.gemfile
+++ b/gemfiles/jruby_9.2_rails5_semantic_logger.gemfile
@@ -25,7 +25,6 @@ gem "simplecov-cobertura", "~> 2.1.0"
 gem "warning", "~> 1"
 gem "webmock", ">= 3.10.0"
 gem "rexml", ">= 3.2.7"
-gem "yard", "~> 0.9"
 gem "dogstatsd-ruby", ">= 3.3.0", "!= 5.0.0", "!= 5.0.1", "!= 5.1.0"
 gem "ffi", "~> 1.16.3", require: false
 gem "rails", "~> 5.2.1"

--- a/gemfiles/jruby_9.2_rails5_semantic_logger.gemfile.lock
+++ b/gemfiles/jruby_9.2_rails5_semantic_logger.gemfile.lock
@@ -224,12 +224,9 @@ GEM
       addressable (>= 2.3.6)
       crack (>= 0.3.2)
       hashdiff (>= 0.4.0, < 2.0.0)
-    webrick (1.7.0)
     websocket-driver (0.7.5-java)
       websocket-extensions (>= 0.1.0)
     websocket-extensions (0.1.5)
-    yard (0.9.28)
-      webrick (~> 1.7.0)
 
 PLATFORMS
   universal-java-1.8
@@ -266,7 +263,6 @@ DEPENDENCIES
   sprockets (< 4)
   warning (~> 1)
   webmock (>= 3.10.0)
-  yard (~> 0.9)
 
 BUNDLED WITH
    2.3.27

--- a/gemfiles/jruby_9.2_rails61_mysql2.gemfile
+++ b/gemfiles/jruby_9.2_rails61_mysql2.gemfile
@@ -25,7 +25,6 @@ gem "simplecov-cobertura", "~> 2.1.0"
 gem "warning", "~> 1"
 gem "webmock", ">= 3.10.0"
 gem "rexml", ">= 3.2.7"
-gem "yard", "~> 0.9"
 gem "dogstatsd-ruby", ">= 3.3.0", "!= 5.0.0", "!= 5.0.1", "!= 5.1.0"
 gem "ffi", "~> 1.16.3", require: false
 gem "rails", "~> 6.1.0"

--- a/gemfiles/jruby_9.2_rails61_mysql2.gemfile.lock
+++ b/gemfiles/jruby_9.2_rails61_mysql2.gemfile.lock
@@ -224,12 +224,9 @@ GEM
       addressable (>= 2.3.6)
       crack (>= 0.3.2)
       hashdiff (>= 0.4.0, < 2.0.0)
-    webrick (1.7.0)
     websocket-driver (0.7.5-java)
       websocket-extensions (>= 0.1.0)
     websocket-extensions (0.1.5)
-    yard (0.9.28)
-      webrick (~> 1.7.0)
     zeitwerk (2.6.6)
 
 PLATFORMS
@@ -268,7 +265,6 @@ DEPENDENCIES
   sprockets (< 4)
   warning (~> 1)
   webmock (>= 3.10.0)
-  yard (~> 0.9)
 
 BUNDLED WITH
    2.3.27

--- a/gemfiles/jruby_9.2_rails61_postgres.gemfile
+++ b/gemfiles/jruby_9.2_rails61_postgres.gemfile
@@ -25,7 +25,6 @@ gem "simplecov-cobertura", "~> 2.1.0"
 gem "warning", "~> 1"
 gem "webmock", ">= 3.10.0"
 gem "rexml", ">= 3.2.7"
-gem "yard", "~> 0.9"
 gem "dogstatsd-ruby", ">= 3.3.0", "!= 5.0.0", "!= 5.0.1", "!= 5.1.0"
 gem "ffi", "~> 1.16.3", require: false
 gem "rails", "~> 6.1.0"

--- a/gemfiles/jruby_9.2_rails61_postgres.gemfile.lock
+++ b/gemfiles/jruby_9.2_rails61_postgres.gemfile.lock
@@ -243,12 +243,9 @@ GEM
       addressable (>= 2.3.6)
       crack (>= 0.3.2)
       hashdiff (>= 0.4.0, < 2.0.0)
-    webrick (1.7.0)
     websocket-driver (0.7.5-java)
       websocket-extensions (>= 0.1.0)
     websocket-extensions (0.1.5)
-    yard (0.9.28)
-      webrick (~> 1.7.0)
     zeitwerk (2.6.6)
 
 PLATFORMS
@@ -286,7 +283,6 @@ DEPENDENCIES
   sprockets (< 4)
   warning (~> 1)
   webmock (>= 3.10.0)
-  yard (~> 0.9)
 
 BUNDLED WITH
    2.3.27

--- a/gemfiles/jruby_9.2_rails61_postgres_redis.gemfile
+++ b/gemfiles/jruby_9.2_rails61_postgres_redis.gemfile
@@ -25,7 +25,6 @@ gem "simplecov-cobertura", "~> 2.1.0"
 gem "warning", "~> 1"
 gem "webmock", ">= 3.10.0"
 gem "rexml", ">= 3.2.7"
-gem "yard", "~> 0.9"
 gem "dogstatsd-ruby", ">= 3.3.0", "!= 5.0.0", "!= 5.0.1", "!= 5.1.0"
 gem "ffi", "~> 1.16.3", require: false
 gem "rails", "~> 6.1.0"

--- a/gemfiles/jruby_9.2_rails61_postgres_redis.gemfile.lock
+++ b/gemfiles/jruby_9.2_rails61_postgres_redis.gemfile.lock
@@ -248,12 +248,9 @@ GEM
       addressable (>= 2.3.6)
       crack (>= 0.3.2)
       hashdiff (>= 0.4.0, < 2.0.0)
-    webrick (1.7.0)
     websocket-driver (0.7.5-java)
       websocket-extensions (>= 0.1.0)
     websocket-extensions (0.1.5)
-    yard (0.9.28)
-      webrick (~> 1.7.0)
     zeitwerk (2.6.6)
 
 PLATFORMS
@@ -292,7 +289,6 @@ DEPENDENCIES
   sprockets (< 4)
   warning (~> 1)
   webmock (>= 3.10.0)
-  yard (~> 0.9)
 
 BUNDLED WITH
    2.3.27

--- a/gemfiles/jruby_9.2_rails61_postgres_sidekiq.gemfile
+++ b/gemfiles/jruby_9.2_rails61_postgres_sidekiq.gemfile
@@ -25,7 +25,6 @@ gem "simplecov-cobertura", "~> 2.1.0"
 gem "warning", "~> 1"
 gem "webmock", ">= 3.10.0"
 gem "rexml", ">= 3.2.7"
-gem "yard", "~> 0.9"
 gem "dogstatsd-ruby", ">= 3.3.0", "!= 5.0.0", "!= 5.0.1", "!= 5.1.0"
 gem "ffi", "~> 1.16.3", require: false
 gem "rails", "~> 6.1.0"

--- a/gemfiles/jruby_9.2_rails61_postgres_sidekiq.gemfile.lock
+++ b/gemfiles/jruby_9.2_rails61_postgres_sidekiq.gemfile.lock
@@ -249,12 +249,9 @@ GEM
       addressable (>= 2.3.6)
       crack (>= 0.3.2)
       hashdiff (>= 0.4.0, < 2.0.0)
-    webrick (1.7.0)
     websocket-driver (0.7.5-java)
       websocket-extensions (>= 0.1.0)
     websocket-extensions (0.1.5)
-    yard (0.9.28)
-      webrick (~> 1.7.0)
     zeitwerk (2.6.6)
 
 PLATFORMS
@@ -293,7 +290,6 @@ DEPENDENCIES
   sprockets (< 4)
   warning (~> 1)
   webmock (>= 3.10.0)
-  yard (~> 0.9)
 
 BUNDLED WITH
    2.3.27

--- a/gemfiles/jruby_9.2_rails61_semantic_logger.gemfile
+++ b/gemfiles/jruby_9.2_rails61_semantic_logger.gemfile
@@ -25,7 +25,6 @@ gem "simplecov-cobertura", "~> 2.1.0"
 gem "warning", "~> 1"
 gem "webmock", ">= 3.10.0"
 gem "rexml", ">= 3.2.7"
-gem "yard", "~> 0.9"
 gem "dogstatsd-ruby", ">= 3.3.0", "!= 5.0.0", "!= 5.0.1", "!= 5.1.0"
 gem "ffi", "~> 1.16.3", require: false
 gem "rails", "~> 6.1.0"

--- a/gemfiles/jruby_9.2_rails61_semantic_logger.gemfile.lock
+++ b/gemfiles/jruby_9.2_rails61_semantic_logger.gemfile.lock
@@ -242,12 +242,9 @@ GEM
       addressable (>= 2.3.6)
       crack (>= 0.3.2)
       hashdiff (>= 0.4.0, < 2.0.0)
-    webrick (1.7.0)
     websocket-driver (0.7.5-java)
       websocket-extensions (>= 0.1.0)
     websocket-extensions (0.1.5)
-    yard (0.9.28)
-      webrick (~> 1.7.0)
     zeitwerk (2.6.6)
 
 PLATFORMS
@@ -285,7 +282,6 @@ DEPENDENCIES
   sprockets (< 4)
   warning (~> 1)
   webmock (>= 3.10.0)
-  yard (~> 0.9)
 
 BUNDLED WITH
    2.3.27

--- a/gemfiles/jruby_9.2_rails6_mysql2.gemfile
+++ b/gemfiles/jruby_9.2_rails6_mysql2.gemfile
@@ -25,7 +25,6 @@ gem "simplecov-cobertura", "~> 2.1.0"
 gem "warning", "~> 1"
 gem "webmock", ">= 3.10.0"
 gem "rexml", ">= 3.2.7"
-gem "yard", "~> 0.9"
 gem "dogstatsd-ruby", ">= 3.3.0", "!= 5.0.0", "!= 5.0.1", "!= 5.1.0"
 gem "ffi", "~> 1.16.3", require: false
 gem "rails", "~> 6.0.0"

--- a/gemfiles/jruby_9.2_rails6_mysql2.gemfile.lock
+++ b/gemfiles/jruby_9.2_rails6_mysql2.gemfile.lock
@@ -221,12 +221,9 @@ GEM
       addressable (>= 2.3.6)
       crack (>= 0.3.2)
       hashdiff (>= 0.4.0, < 2.0.0)
-    webrick (1.7.0)
     websocket-driver (0.7.5-java)
       websocket-extensions (>= 0.1.0)
     websocket-extensions (0.1.5)
-    yard (0.9.28)
-      webrick (~> 1.7.0)
     zeitwerk (2.6.6)
 
 PLATFORMS
@@ -265,7 +262,6 @@ DEPENDENCIES
   sprockets (< 4)
   warning (~> 1)
   webmock (>= 3.10.0)
-  yard (~> 0.9)
 
 BUNDLED WITH
    2.3.27

--- a/gemfiles/jruby_9.2_rails6_postgres.gemfile
+++ b/gemfiles/jruby_9.2_rails6_postgres.gemfile
@@ -25,7 +25,6 @@ gem "simplecov-cobertura", "~> 2.1.0"
 gem "warning", "~> 1"
 gem "webmock", ">= 3.10.0"
 gem "rexml", ">= 3.2.7"
-gem "yard", "~> 0.9"
 gem "dogstatsd-ruby", ">= 3.3.0", "!= 5.0.0", "!= 5.0.1", "!= 5.1.0"
 gem "ffi", "~> 1.16.3", require: false
 gem "rails", "~> 6.0.0"

--- a/gemfiles/jruby_9.2_rails6_postgres.gemfile.lock
+++ b/gemfiles/jruby_9.2_rails6_postgres.gemfile.lock
@@ -240,12 +240,9 @@ GEM
       addressable (>= 2.3.6)
       crack (>= 0.3.2)
       hashdiff (>= 0.4.0, < 2.0.0)
-    webrick (1.7.0)
     websocket-driver (0.7.5-java)
       websocket-extensions (>= 0.1.0)
     websocket-extensions (0.1.5)
-    yard (0.9.28)
-      webrick (~> 1.7.0)
     zeitwerk (2.6.6)
 
 PLATFORMS
@@ -283,7 +280,6 @@ DEPENDENCIES
   sprockets (< 4)
   warning (~> 1)
   webmock (>= 3.10.0)
-  yard (~> 0.9)
 
 BUNDLED WITH
    2.3.27

--- a/gemfiles/jruby_9.2_rails6_postgres_redis.gemfile
+++ b/gemfiles/jruby_9.2_rails6_postgres_redis.gemfile
@@ -25,7 +25,6 @@ gem "simplecov-cobertura", "~> 2.1.0"
 gem "warning", "~> 1"
 gem "webmock", ">= 3.10.0"
 gem "rexml", ">= 3.2.7"
-gem "yard", "~> 0.9"
 gem "dogstatsd-ruby", ">= 3.3.0", "!= 5.0.0", "!= 5.0.1", "!= 5.1.0"
 gem "ffi", "~> 1.16.3", require: false
 gem "rails", "~> 6.0.0"

--- a/gemfiles/jruby_9.2_rails6_postgres_redis.gemfile.lock
+++ b/gemfiles/jruby_9.2_rails6_postgres_redis.gemfile.lock
@@ -245,12 +245,9 @@ GEM
       addressable (>= 2.3.6)
       crack (>= 0.3.2)
       hashdiff (>= 0.4.0, < 2.0.0)
-    webrick (1.7.0)
     websocket-driver (0.7.5-java)
       websocket-extensions (>= 0.1.0)
     websocket-extensions (0.1.5)
-    yard (0.9.28)
-      webrick (~> 1.7.0)
     zeitwerk (2.6.6)
 
 PLATFORMS
@@ -289,7 +286,6 @@ DEPENDENCIES
   sprockets (< 4)
   warning (~> 1)
   webmock (>= 3.10.0)
-  yard (~> 0.9)
 
 BUNDLED WITH
    2.3.27

--- a/gemfiles/jruby_9.2_rails6_postgres_redis_activesupport.gemfile
+++ b/gemfiles/jruby_9.2_rails6_postgres_redis_activesupport.gemfile
@@ -25,7 +25,6 @@ gem "simplecov-cobertura", "~> 2.1.0"
 gem "warning", "~> 1"
 gem "webmock", ">= 3.10.0"
 gem "rexml", ">= 3.2.7"
-gem "yard", "~> 0.9"
 gem "dogstatsd-ruby", ">= 3.3.0", "!= 5.0.0", "!= 5.0.1", "!= 5.1.0"
 gem "ffi", "~> 1.16.3", require: false
 gem "rails", "~> 6.0.0"

--- a/gemfiles/jruby_9.2_rails6_postgres_redis_activesupport.gemfile.lock
+++ b/gemfiles/jruby_9.2_rails6_postgres_redis_activesupport.gemfile.lock
@@ -257,12 +257,9 @@ GEM
       addressable (>= 2.3.6)
       crack (>= 0.3.2)
       hashdiff (>= 0.4.0, < 2.0.0)
-    webrick (1.7.0)
     websocket-driver (0.7.5-java)
       websocket-extensions (>= 0.1.0)
     websocket-extensions (0.1.5)
-    yard (0.9.28)
-      webrick (~> 1.7.0)
     zeitwerk (2.6.6)
 
 PLATFORMS
@@ -303,7 +300,6 @@ DEPENDENCIES
   sprockets (< 4)
   warning (~> 1)
   webmock (>= 3.10.0)
-  yard (~> 0.9)
 
 BUNDLED WITH
    2.3.27

--- a/gemfiles/jruby_9.2_rails6_postgres_sidekiq.gemfile
+++ b/gemfiles/jruby_9.2_rails6_postgres_sidekiq.gemfile
@@ -25,7 +25,6 @@ gem "simplecov-cobertura", "~> 2.1.0"
 gem "warning", "~> 1"
 gem "webmock", ">= 3.10.0"
 gem "rexml", ">= 3.2.7"
-gem "yard", "~> 0.9"
 gem "dogstatsd-ruby", ">= 3.3.0", "!= 5.0.0", "!= 5.0.1", "!= 5.1.0"
 gem "ffi", "~> 1.16.3", require: false
 gem "rails", "~> 6.0.0"

--- a/gemfiles/jruby_9.2_rails6_postgres_sidekiq.gemfile.lock
+++ b/gemfiles/jruby_9.2_rails6_postgres_sidekiq.gemfile.lock
@@ -246,12 +246,9 @@ GEM
       addressable (>= 2.3.6)
       crack (>= 0.3.2)
       hashdiff (>= 0.4.0, < 2.0.0)
-    webrick (1.7.0)
     websocket-driver (0.7.5-java)
       websocket-extensions (>= 0.1.0)
     websocket-extensions (0.1.5)
-    yard (0.9.28)
-      webrick (~> 1.7.0)
     zeitwerk (2.6.6)
 
 PLATFORMS
@@ -291,7 +288,6 @@ DEPENDENCIES
   sprockets (< 4)
   warning (~> 1)
   webmock (>= 3.10.0)
-  yard (~> 0.9)
 
 BUNDLED WITH
    2.3.27

--- a/gemfiles/jruby_9.2_rails6_semantic_logger.gemfile
+++ b/gemfiles/jruby_9.2_rails6_semantic_logger.gemfile
@@ -25,7 +25,6 @@ gem "simplecov-cobertura", "~> 2.1.0"
 gem "warning", "~> 1"
 gem "webmock", ">= 3.10.0"
 gem "rexml", ">= 3.2.7"
-gem "yard", "~> 0.9"
 gem "dogstatsd-ruby", ">= 3.3.0", "!= 5.0.0", "!= 5.0.1", "!= 5.1.0"
 gem "ffi", "~> 1.16.3", require: false
 gem "rails", "~> 6.0.0"

--- a/gemfiles/jruby_9.2_rails6_semantic_logger.gemfile.lock
+++ b/gemfiles/jruby_9.2_rails6_semantic_logger.gemfile.lock
@@ -239,12 +239,9 @@ GEM
       addressable (>= 2.3.6)
       crack (>= 0.3.2)
       hashdiff (>= 0.4.0, < 2.0.0)
-    webrick (1.7.0)
     websocket-driver (0.7.5-java)
       websocket-extensions (>= 0.1.0)
     websocket-extensions (0.1.5)
-    yard (0.9.28)
-      webrick (~> 1.7.0)
     zeitwerk (2.6.6)
 
 PLATFORMS
@@ -282,7 +279,6 @@ DEPENDENCIES
   sprockets (< 4)
   warning (~> 1)
   webmock (>= 3.10.0)
-  yard (~> 0.9)
 
 BUNDLED WITH
    2.3.27

--- a/gemfiles/jruby_9.2_redis_3.gemfile
+++ b/gemfiles/jruby_9.2_redis_3.gemfile
@@ -25,7 +25,6 @@ gem "simplecov-cobertura", "~> 2.1.0"
 gem "warning", "~> 1"
 gem "webmock", ">= 3.10.0"
 gem "rexml", ">= 3.2.7"
-gem "yard", "~> 0.9"
 gem "dogstatsd-ruby", ">= 3.3.0", "!= 5.0.0", "!= 5.0.1", "!= 5.1.0"
 gem "ffi", "~> 1.16.3", require: false
 gem "redis", "~> 3"

--- a/gemfiles/jruby_9.2_redis_3.gemfile.lock
+++ b/gemfiles/jruby_9.2_redis_3.gemfile.lock
@@ -97,9 +97,6 @@ GEM
       addressable (>= 2.3.6)
       crack (>= 0.3.2)
       hashdiff (>= 0.4.0, < 2.0.0)
-    webrick (1.7.0)
-    yard (0.9.28)
-      webrick (~> 1.7.0)
 
 PLATFORMS
   universal-java-1.8
@@ -132,7 +129,6 @@ DEPENDENCIES
   simplecov-cobertura (~> 2.1.0)
   warning (~> 1)
   webmock (>= 3.10.0)
-  yard (~> 0.9)
 
 BUNDLED WITH
    2.3.27

--- a/gemfiles/jruby_9.2_redis_4.gemfile
+++ b/gemfiles/jruby_9.2_redis_4.gemfile
@@ -25,7 +25,6 @@ gem "simplecov-cobertura", "~> 2.1.0"
 gem "warning", "~> 1"
 gem "webmock", ">= 3.10.0"
 gem "rexml", ">= 3.2.7"
-gem "yard", "~> 0.9"
 gem "dogstatsd-ruby", ">= 3.3.0", "!= 5.0.0", "!= 5.0.1", "!= 5.1.0"
 gem "ffi", "~> 1.16.3", require: false
 gem "redis", "~> 4"

--- a/gemfiles/jruby_9.2_redis_4.gemfile.lock
+++ b/gemfiles/jruby_9.2_redis_4.gemfile.lock
@@ -97,9 +97,6 @@ GEM
       addressable (>= 2.3.6)
       crack (>= 0.3.2)
       hashdiff (>= 0.4.0, < 2.0.0)
-    webrick (1.7.0)
-    yard (0.9.28)
-      webrick (~> 1.7.0)
 
 PLATFORMS
   universal-java-1.8
@@ -132,7 +129,6 @@ DEPENDENCIES
   simplecov-cobertura (~> 2.1.0)
   warning (~> 1)
   webmock (>= 3.10.0)
-  yard (~> 0.9)
 
 BUNDLED WITH
    2.3.27

--- a/gemfiles/jruby_9.2_redis_5.gemfile
+++ b/gemfiles/jruby_9.2_redis_5.gemfile
@@ -25,7 +25,6 @@ gem "simplecov-cobertura", "~> 2.1.0"
 gem "warning", "~> 1"
 gem "webmock", ">= 3.10.0"
 gem "rexml", ">= 3.2.7"
-gem "yard", "~> 0.9"
 gem "dogstatsd-ruby", ">= 3.3.0", "!= 5.0.0", "!= 5.0.1", "!= 5.1.0"
 gem "ffi", "~> 1.16.3", require: false
 gem "redis", "~> 5"

--- a/gemfiles/jruby_9.2_redis_5.gemfile.lock
+++ b/gemfiles/jruby_9.2_redis_5.gemfile.lock
@@ -101,9 +101,6 @@ GEM
       addressable (>= 2.3.6)
       crack (>= 0.3.2)
       hashdiff (>= 0.4.0, < 2.0.0)
-    webrick (1.7.0)
-    yard (0.9.28)
-      webrick (~> 1.7.0)
 
 PLATFORMS
   universal-java-1.8
@@ -136,7 +133,6 @@ DEPENDENCIES
   simplecov-cobertura (~> 2.1.0)
   warning (~> 1)
   webmock (>= 3.10.0)
-  yard (~> 0.9)
 
 BUNDLED WITH
    2.3.27

--- a/gemfiles/jruby_9.2_relational_db.gemfile
+++ b/gemfiles/jruby_9.2_relational_db.gemfile
@@ -25,7 +25,6 @@ gem "simplecov-cobertura", "~> 2.1.0"
 gem "warning", "~> 1"
 gem "webmock", ">= 3.10.0"
 gem "rexml", ">= 3.2.7"
-gem "yard", "~> 0.9"
 gem "dogstatsd-ruby", ">= 3.3.0", "!= 5.0.0", "!= 5.0.1", "!= 5.1.0"
 gem "ffi", "~> 1.16.3", require: false
 gem "activerecord", "~> 5"

--- a/gemfiles/jruby_9.2_relational_db.gemfile.lock
+++ b/gemfiles/jruby_9.2_relational_db.gemfile.lock
@@ -138,7 +138,6 @@ GEM
       addressable (>= 2.3.6)
       crack (>= 0.3.2)
       hashdiff (>= 0.4.0, < 2.0.0)
-    yard (0.9.34)
 
 PLATFORMS
   universal-java-1.8
@@ -178,7 +177,6 @@ DEPENDENCIES
   simplecov-cobertura (~> 2.1.0)
   warning (~> 1)
   webmock (>= 3.10.0)
-  yard (~> 0.9)
 
 BUNDLED WITH
    2.3.27

--- a/gemfiles/jruby_9.2_resque2_redis3.gemfile
+++ b/gemfiles/jruby_9.2_resque2_redis3.gemfile
@@ -25,7 +25,6 @@ gem "simplecov-cobertura", "~> 2.1.0"
 gem "warning", "~> 1"
 gem "webmock", ">= 3.10.0"
 gem "rexml", ">= 3.2.7"
-gem "yard", "~> 0.9"
 gem "dogstatsd-ruby", ">= 3.3.0", "!= 5.0.0", "!= 5.0.1", "!= 5.1.0"
 gem "ffi", "~> 1.16.3", require: false
 gem "redis", "< 4.0"

--- a/gemfiles/jruby_9.2_resque2_redis3.gemfile.lock
+++ b/gemfiles/jruby_9.2_resque2_redis3.gemfile.lock
@@ -118,9 +118,6 @@ GEM
       addressable (>= 2.3.6)
       crack (>= 0.3.2)
       hashdiff (>= 0.4.0, < 2.0.0)
-    webrick (1.7.0)
-    yard (0.9.28)
-      webrick (~> 1.7.0)
 
 PLATFORMS
   universal-java-1.8
@@ -154,7 +151,6 @@ DEPENDENCIES
   simplecov-cobertura (~> 2.1.0)
   warning (~> 1)
   webmock (>= 3.10.0)
-  yard (~> 0.9)
 
 BUNDLED WITH
    2.3.27

--- a/gemfiles/jruby_9.2_resque2_redis4.gemfile
+++ b/gemfiles/jruby_9.2_resque2_redis4.gemfile
@@ -25,7 +25,6 @@ gem "simplecov-cobertura", "~> 2.1.0"
 gem "warning", "~> 1"
 gem "webmock", ">= 3.10.0"
 gem "rexml", ">= 3.2.7"
-gem "yard", "~> 0.9"
 gem "dogstatsd-ruby", ">= 3.3.0", "!= 5.0.0", "!= 5.0.1", "!= 5.1.0"
 gem "ffi", "~> 1.16.3", require: false
 gem "redis", ">= 4.0"

--- a/gemfiles/jruby_9.2_resque2_redis4.gemfile.lock
+++ b/gemfiles/jruby_9.2_resque2_redis4.gemfile.lock
@@ -122,9 +122,6 @@ GEM
       addressable (>= 2.3.6)
       crack (>= 0.3.2)
       hashdiff (>= 0.4.0, < 2.0.0)
-    webrick (1.7.0)
-    yard (0.9.28)
-      webrick (~> 1.7.0)
 
 PLATFORMS
   universal-java-1.8
@@ -158,7 +155,6 @@ DEPENDENCIES
   simplecov-cobertura (~> 2.1.0)
   warning (~> 1)
   webmock (>= 3.10.0)
-  yard (~> 0.9)
 
 BUNDLED WITH
    2.3.27

--- a/gemfiles/jruby_9.2_sinatra_2.gemfile
+++ b/gemfiles/jruby_9.2_sinatra_2.gemfile
@@ -25,7 +25,6 @@ gem "simplecov-cobertura", "~> 2.1.0"
 gem "warning", "~> 1"
 gem "webmock", ">= 3.10.0"
 gem "rexml", ">= 3.2.7"
-gem "yard", "~> 0.9"
 gem "dogstatsd-ruby", ">= 3.3.0", "!= 5.0.0", "!= 5.0.1", "!= 5.1.0"
 gem "ffi", "~> 1.16.3", require: false
 gem "sinatra", "~> 2"

--- a/gemfiles/jruby_9.2_sinatra_2.gemfile.lock
+++ b/gemfiles/jruby_9.2_sinatra_2.gemfile.lock
@@ -116,7 +116,6 @@ GEM
       addressable (>= 2.8.0)
       crack (>= 0.3.2)
       hashdiff (>= 0.4.0, < 2.0.0)
-    yard (0.9.36)
 
 PLATFORMS
   universal-java-1.8
@@ -151,7 +150,6 @@ DEPENDENCIES
   sinatra (~> 2)
   warning (~> 1)
   webmock (>= 3.10.0)
-  yard (~> 0.9)
 
 BUNDLED WITH
    2.3.27

--- a/gemfiles/jruby_9.2_stripe_10.gemfile
+++ b/gemfiles/jruby_9.2_stripe_10.gemfile
@@ -25,7 +25,6 @@ gem "simplecov-cobertura", "~> 2.1.0"
 gem "warning", "~> 1"
 gem "webmock", ">= 3.10.0"
 gem "rexml", ">= 3.2.7"
-gem "yard", "~> 0.9"
 gem "dogstatsd-ruby", ">= 3.3.0", "!= 5.0.0", "!= 5.0.1", "!= 5.1.0"
 gem "ffi", "~> 1.16.3", require: false
 gem "stripe", "~> 10"

--- a/gemfiles/jruby_9.2_stripe_10.gemfile.lock
+++ b/gemfiles/jruby_9.2_stripe_10.gemfile.lock
@@ -101,7 +101,6 @@ GEM
       addressable (>= 2.8.0)
       crack (>= 0.3.2)
       hashdiff (>= 0.4.0, < 2.0.0)
-    yard (0.9.36)
 
 PLATFORMS
   universal-java-1.8
@@ -134,7 +133,6 @@ DEPENDENCIES
   stripe (~> 10)
   warning (~> 1)
   webmock (>= 3.10.0)
-  yard (~> 0.9)
 
 BUNDLED WITH
    2.3.27

--- a/gemfiles/jruby_9.2_stripe_11.gemfile
+++ b/gemfiles/jruby_9.2_stripe_11.gemfile
@@ -25,7 +25,6 @@ gem "simplecov-cobertura", "~> 2.1.0"
 gem "warning", "~> 1"
 gem "webmock", ">= 3.10.0"
 gem "rexml", ">= 3.2.7"
-gem "yard", "~> 0.9"
 gem "dogstatsd-ruby", ">= 3.3.0", "!= 5.0.0", "!= 5.0.1", "!= 5.1.0"
 gem "ffi", "~> 1.16.3", require: false
 gem "stripe", "~> 11"

--- a/gemfiles/jruby_9.2_stripe_11.gemfile.lock
+++ b/gemfiles/jruby_9.2_stripe_11.gemfile.lock
@@ -101,7 +101,6 @@ GEM
       addressable (>= 2.8.0)
       crack (>= 0.3.2)
       hashdiff (>= 0.4.0, < 2.0.0)
-    yard (0.9.36)
 
 PLATFORMS
   universal-java-1.8
@@ -134,7 +133,6 @@ DEPENDENCIES
   stripe (~> 11)
   warning (~> 1)
   webmock (>= 3.10.0)
-  yard (~> 0.9)
 
 BUNDLED WITH
    2.3.27

--- a/gemfiles/jruby_9.2_stripe_12.gemfile
+++ b/gemfiles/jruby_9.2_stripe_12.gemfile
@@ -25,7 +25,6 @@ gem "simplecov-cobertura", "~> 2.1.0"
 gem "warning", "~> 1"
 gem "webmock", ">= 3.10.0"
 gem "rexml", ">= 3.2.7"
-gem "yard", "~> 0.9"
 gem "dogstatsd-ruby", ">= 3.3.0", "!= 5.0.0", "!= 5.0.1", "!= 5.1.0"
 gem "ffi", "~> 1.16.3", require: false
 gem "stripe", "~> 12"

--- a/gemfiles/jruby_9.2_stripe_12.gemfile.lock
+++ b/gemfiles/jruby_9.2_stripe_12.gemfile.lock
@@ -101,7 +101,6 @@ GEM
       addressable (>= 2.8.0)
       crack (>= 0.3.2)
       hashdiff (>= 0.4.0, < 2.0.0)
-    yard (0.9.36)
 
 PLATFORMS
   universal-java-1.8
@@ -134,7 +133,6 @@ DEPENDENCIES
   stripe (~> 12)
   warning (~> 1)
   webmock (>= 3.10.0)
-  yard (~> 0.9)
 
 BUNDLED WITH
    2.3.27

--- a/gemfiles/jruby_9.2_stripe_7.gemfile
+++ b/gemfiles/jruby_9.2_stripe_7.gemfile
@@ -25,7 +25,6 @@ gem "simplecov-cobertura", "~> 2.1.0"
 gem "warning", "~> 1"
 gem "webmock", ">= 3.10.0"
 gem "rexml", ">= 3.2.7"
-gem "yard", "~> 0.9"
 gem "dogstatsd-ruby", ">= 3.3.0", "!= 5.0.0", "!= 5.0.1", "!= 5.1.0"
 gem "ffi", "~> 1.16.3", require: false
 gem "stripe", "~> 7"

--- a/gemfiles/jruby_9.2_stripe_7.gemfile.lock
+++ b/gemfiles/jruby_9.2_stripe_7.gemfile.lock
@@ -101,7 +101,6 @@ GEM
       addressable (>= 2.8.0)
       crack (>= 0.3.2)
       hashdiff (>= 0.4.0, < 2.0.0)
-    yard (0.9.36)
 
 PLATFORMS
   universal-java-1.8
@@ -134,7 +133,6 @@ DEPENDENCIES
   stripe (~> 7)
   warning (~> 1)
   webmock (>= 3.10.0)
-  yard (~> 0.9)
 
 BUNDLED WITH
    2.3.27

--- a/gemfiles/jruby_9.2_stripe_8.gemfile
+++ b/gemfiles/jruby_9.2_stripe_8.gemfile
@@ -25,7 +25,6 @@ gem "simplecov-cobertura", "~> 2.1.0"
 gem "warning", "~> 1"
 gem "webmock", ">= 3.10.0"
 gem "rexml", ">= 3.2.7"
-gem "yard", "~> 0.9"
 gem "dogstatsd-ruby", ">= 3.3.0", "!= 5.0.0", "!= 5.0.1", "!= 5.1.0"
 gem "ffi", "~> 1.16.3", require: false
 gem "stripe", "~> 8"

--- a/gemfiles/jruby_9.2_stripe_8.gemfile.lock
+++ b/gemfiles/jruby_9.2_stripe_8.gemfile.lock
@@ -101,7 +101,6 @@ GEM
       addressable (>= 2.8.0)
       crack (>= 0.3.2)
       hashdiff (>= 0.4.0, < 2.0.0)
-    yard (0.9.36)
 
 PLATFORMS
   universal-java-1.8
@@ -134,7 +133,6 @@ DEPENDENCIES
   stripe (~> 8)
   warning (~> 1)
   webmock (>= 3.10.0)
-  yard (~> 0.9)
 
 BUNDLED WITH
    2.3.27

--- a/gemfiles/jruby_9.2_stripe_9.gemfile
+++ b/gemfiles/jruby_9.2_stripe_9.gemfile
@@ -25,7 +25,6 @@ gem "simplecov-cobertura", "~> 2.1.0"
 gem "warning", "~> 1"
 gem "webmock", ">= 3.10.0"
 gem "rexml", ">= 3.2.7"
-gem "yard", "~> 0.9"
 gem "dogstatsd-ruby", ">= 3.3.0", "!= 5.0.0", "!= 5.0.1", "!= 5.1.0"
 gem "ffi", "~> 1.16.3", require: false
 gem "stripe", "~> 9"

--- a/gemfiles/jruby_9.2_stripe_9.gemfile.lock
+++ b/gemfiles/jruby_9.2_stripe_9.gemfile.lock
@@ -101,7 +101,6 @@ GEM
       addressable (>= 2.8.0)
       crack (>= 0.3.2)
       hashdiff (>= 0.4.0, < 2.0.0)
-    yard (0.9.36)
 
 PLATFORMS
   universal-java-1.8
@@ -134,7 +133,6 @@ DEPENDENCIES
   stripe (~> 9)
   warning (~> 1)
   webmock (>= 3.10.0)
-  yard (~> 0.9)
 
 BUNDLED WITH
    2.3.27

--- a/gemfiles/jruby_9.3_activesupport.gemfile
+++ b/gemfiles/jruby_9.3_activesupport.gemfile
@@ -25,7 +25,6 @@ gem "simplecov-cobertura", "~> 2.1.0"
 gem "warning", "~> 1"
 gem "webmock", ">= 3.10.0"
 gem "rexml", ">= 3.2.7"
-gem "yard", "~> 0.9"
 gem "rubocop", "~> 1.50.0", require: false
 gem "rubocop-packaging", "~> 0.5.2", require: false
 gem "rubocop-performance", "~> 1.9", require: false

--- a/gemfiles/jruby_9.3_activesupport.gemfile.lock
+++ b/gemfiles/jruby_9.3_activesupport.gemfile.lock
@@ -238,7 +238,6 @@ GEM
       addressable (>= 2.3.6)
       crack (>= 0.3.2)
       hashdiff (>= 0.4.0, < 2.0.0)
-    yard (0.9.34)
     zeitwerk (2.6.11)
 
 PLATFORMS
@@ -283,7 +282,6 @@ DEPENDENCIES
   simplecov-cobertura (~> 2.1.0)
   warning (~> 1)
   webmock (>= 3.10.0)
-  yard (~> 0.9)
 
 BUNDLED WITH
    2.3.27

--- a/gemfiles/jruby_9.3_aws.gemfile
+++ b/gemfiles/jruby_9.3_aws.gemfile
@@ -25,7 +25,6 @@ gem "simplecov-cobertura", "~> 2.1.0"
 gem "warning", "~> 1"
 gem "webmock", ">= 3.10.0"
 gem "rexml", "= 3.2.6"
-gem "yard", "~> 0.9"
 gem "rubocop", "~> 1.50.0", require: false
 gem "rubocop-packaging", "~> 0.5.2", require: false
 gem "rubocop-performance", "~> 1.9", require: false

--- a/gemfiles/jruby_9.3_aws.gemfile.lock
+++ b/gemfiles/jruby_9.3_aws.gemfile.lock
@@ -1553,7 +1553,6 @@ GEM
       addressable (>= 2.3.6)
       crack (>= 0.3.2)
       hashdiff (>= 0.4.0, < 2.0.0)
-    yard (0.9.34)
 
 PLATFORMS
   universal-java-11
@@ -1591,7 +1590,6 @@ DEPENDENCIES
   simplecov-cobertura (~> 2.1.0)
   warning (~> 1)
   webmock (>= 3.10.0)
-  yard (~> 0.9)
 
 BUNDLED WITH
    2.3.27

--- a/gemfiles/jruby_9.3_contrib.gemfile
+++ b/gemfiles/jruby_9.3_contrib.gemfile
@@ -25,7 +25,6 @@ gem "simplecov-cobertura", "~> 2.1.0"
 gem "warning", "~> 1"
 gem "webmock", ">= 3.10.0"
 gem "rexml", ">= 3.2.7"
-gem "yard", "~> 0.9"
 gem "rubocop", "~> 1.50.0", require: false
 gem "rubocop-packaging", "~> 0.5.2", require: false
 gem "rubocop-performance", "~> 1.9", require: false

--- a/gemfiles/jruby_9.3_contrib.gemfile.lock
+++ b/gemfiles/jruby_9.3_contrib.gemfile.lock
@@ -183,9 +183,6 @@ GEM
       addressable (>= 2.3.6)
       crack (>= 0.3.2)
       hashdiff (>= 0.4.0, < 2.0.0)
-    webrick (1.7.0)
-    yard (0.9.28)
-      webrick (~> 1.7.0)
 
 PLATFORMS
   universal-java-11
@@ -232,7 +229,6 @@ DEPENDENCIES
   sucker_punch
   warning (~> 1)
   webmock (>= 3.10.0)
-  yard (~> 0.9)
 
 BUNDLED WITH
    2.3.27

--- a/gemfiles/jruby_9.3_contrib_old.gemfile
+++ b/gemfiles/jruby_9.3_contrib_old.gemfile
@@ -25,7 +25,6 @@ gem "simplecov-cobertura", "~> 2.1.0"
 gem "warning", "~> 1"
 gem "webmock", ">= 3.10.0"
 gem "rexml", ">= 3.2.7"
-gem "yard", "~> 0.9"
 gem "rubocop", "~> 1.50.0", require: false
 gem "rubocop-packaging", "~> 0.5.2", require: false
 gem "rubocop-performance", "~> 1.9", require: false

--- a/gemfiles/jruby_9.3_contrib_old.gemfile.lock
+++ b/gemfiles/jruby_9.3_contrib_old.gemfile.lock
@@ -142,9 +142,6 @@ GEM
       addressable (>= 2.3.6)
       crack (>= 0.3.2)
       hashdiff (>= 0.4.0, < 2.0.0)
-    webrick (1.7.0)
-    yard (0.9.28)
-      webrick (~> 1.7.0)
 
 PLATFORMS
   universal-java-11
@@ -185,7 +182,6 @@ DEPENDENCIES
   simplecov-cobertura (~> 2.1.0)
   warning (~> 1)
   webmock (>= 3.10.0)
-  yard (~> 0.9)
 
 BUNDLED WITH
    2.3.27

--- a/gemfiles/jruby_9.3_core_old.gemfile
+++ b/gemfiles/jruby_9.3_core_old.gemfile
@@ -25,7 +25,6 @@ gem "simplecov-cobertura", "~> 2.1.0"
 gem "warning", "~> 1"
 gem "webmock", ">= 3.10.0"
 gem "rexml", ">= 3.2.7"
-gem "yard", "~> 0.9"
 gem "rubocop", "~> 1.50.0", require: false
 gem "rubocop-packaging", "~> 0.5.2", require: false
 gem "rubocop-performance", "~> 1.9", require: false

--- a/gemfiles/jruby_9.3_core_old.gemfile.lock
+++ b/gemfiles/jruby_9.3_core_old.gemfile.lock
@@ -129,9 +129,6 @@ GEM
       addressable (>= 2.3.6)
       crack (>= 0.3.2)
       hashdiff (>= 0.4.0, < 2.0.0)
-    webrick (1.7.0)
-    yard (0.9.28)
-      webrick (~> 1.7.0)
 
 PLATFORMS
   universal-java-11
@@ -167,7 +164,6 @@ DEPENDENCIES
   simplecov-cobertura (~> 2.1.0)
   warning (~> 1)
   webmock (>= 3.10.0)
-  yard (~> 0.9)
 
 BUNDLED WITH
    2.3.27

--- a/gemfiles/jruby_9.3_elasticsearch_7.gemfile
+++ b/gemfiles/jruby_9.3_elasticsearch_7.gemfile
@@ -25,7 +25,6 @@ gem "simplecov-cobertura", "~> 2.1.0"
 gem "warning", "~> 1"
 gem "webmock", ">= 3.10.0"
 gem "rexml", ">= 3.2.7"
-gem "yard", "~> 0.9"
 gem "rubocop", "~> 1.50.0", require: false
 gem "rubocop-packaging", "~> 0.5.2", require: false
 gem "rubocop-performance", "~> 1.9", require: false

--- a/gemfiles/jruby_9.3_elasticsearch_7.gemfile.lock
+++ b/gemfiles/jruby_9.3_elasticsearch_7.gemfile.lock
@@ -165,7 +165,6 @@ GEM
       addressable (>= 2.8.0)
       crack (>= 0.3.2)
       hashdiff (>= 0.4.0, < 2.0.0)
-    yard (0.9.34)
 
 PLATFORMS
   universal-java-11
@@ -202,7 +201,6 @@ DEPENDENCIES
   simplecov-cobertura (~> 2.1.0)
   warning (~> 1)
   webmock (>= 3.10.0)
-  yard (~> 0.9)
 
 BUNDLED WITH
    2.3.27

--- a/gemfiles/jruby_9.3_elasticsearch_8.gemfile
+++ b/gemfiles/jruby_9.3_elasticsearch_8.gemfile
@@ -25,7 +25,6 @@ gem "simplecov-cobertura", "~> 2.1.0"
 gem "warning", "~> 1"
 gem "webmock", ">= 3.10.0"
 gem "rexml", ">= 3.2.7"
-gem "yard", "~> 0.9"
 gem "rubocop", "~> 1.50.0", require: false
 gem "rubocop-packaging", "~> 0.5.2", require: false
 gem "rubocop-performance", "~> 1.9", require: false

--- a/gemfiles/jruby_9.3_elasticsearch_8.gemfile.lock
+++ b/gemfiles/jruby_9.3_elasticsearch_8.gemfile.lock
@@ -147,7 +147,6 @@ GEM
       addressable (>= 2.8.0)
       crack (>= 0.3.2)
       hashdiff (>= 0.4.0, < 2.0.0)
-    yard (0.9.34)
 
 PLATFORMS
   universal-java-11
@@ -184,7 +183,6 @@ DEPENDENCIES
   simplecov-cobertura (~> 2.1.0)
   warning (~> 1)
   webmock (>= 3.10.0)
-  yard (~> 0.9)
 
 BUNDLED WITH
    2.3.27

--- a/gemfiles/jruby_9.3_graphql_1.13.gemfile
+++ b/gemfiles/jruby_9.3_graphql_1.13.gemfile
@@ -25,7 +25,6 @@ gem "simplecov-cobertura", "~> 2.1.0"
 gem "warning", "~> 1"
 gem "webmock", ">= 3.10.0"
 gem "rexml", ">= 3.2.7"
-gem "yard", "~> 0.9"
 gem "rubocop", "~> 1.50.0", require: false
 gem "rubocop-packaging", "~> 0.5.2", require: false
 gem "rubocop-performance", "~> 1.9", require: false

--- a/gemfiles/jruby_9.3_graphql_1.13.gemfile.lock
+++ b/gemfiles/jruby_9.3_graphql_1.13.gemfile.lock
@@ -273,7 +273,6 @@ GEM
     websocket-driver (0.7.6-java)
       websocket-extensions (>= 0.1.0)
     websocket-extensions (0.1.5)
-    yard (0.9.34)
     zeitwerk (2.6.16)
 
 PLATFORMS
@@ -314,7 +313,6 @@ DEPENDENCIES
   sprockets (< 4)
   warning (~> 1)
   webmock (>= 3.10.0)
-  yard (~> 0.9)
 
 BUNDLED WITH
    2.3.27

--- a/gemfiles/jruby_9.3_graphql_2.0.gemfile
+++ b/gemfiles/jruby_9.3_graphql_2.0.gemfile
@@ -25,7 +25,6 @@ gem "simplecov-cobertura", "~> 2.1.0"
 gem "warning", "~> 1"
 gem "webmock", ">= 3.10.0"
 gem "rexml", ">= 3.2.7"
-gem "yard", "~> 0.9"
 gem "rubocop", "~> 1.50.0", require: false
 gem "rubocop-packaging", "~> 0.5.2", require: false
 gem "rubocop-performance", "~> 1.9", require: false

--- a/gemfiles/jruby_9.3_graphql_2.0.gemfile.lock
+++ b/gemfiles/jruby_9.3_graphql_2.0.gemfile.lock
@@ -273,7 +273,6 @@ GEM
     websocket-driver (0.7.6-java)
       websocket-extensions (>= 0.1.0)
     websocket-extensions (0.1.5)
-    yard (0.9.34)
     zeitwerk (2.6.16)
 
 PLATFORMS
@@ -314,7 +313,6 @@ DEPENDENCIES
   sprockets (< 4)
   warning (~> 1)
   webmock (>= 3.10.0)
-  yard (~> 0.9)
 
 BUNDLED WITH
    2.3.27

--- a/gemfiles/jruby_9.3_http.gemfile
+++ b/gemfiles/jruby_9.3_http.gemfile
@@ -25,7 +25,6 @@ gem "simplecov-cobertura", "~> 2.1.0"
 gem "warning", "~> 1"
 gem "webmock", ">= 3.10.0"
 gem "rexml", ">= 3.2.7"
-gem "yard", "~> 0.9"
 gem "rubocop", "~> 1.50.0", require: false
 gem "rubocop-packaging", "~> 0.5.2", require: false
 gem "rubocop-performance", "~> 1.9", require: false

--- a/gemfiles/jruby_9.3_http.gemfile.lock
+++ b/gemfiles/jruby_9.3_http.gemfile.lock
@@ -166,7 +166,6 @@ GEM
       addressable (>= 2.3.6)
       crack (>= 0.3.2)
       hashdiff (>= 0.4.0, < 2.0.0)
-    yard (0.9.34)
 
 PLATFORMS
   universal-java-11
@@ -209,7 +208,6 @@ DEPENDENCIES
   typhoeus
   warning (~> 1)
   webmock (>= 3.10.0)
-  yard (~> 0.9)
 
 BUNDLED WITH
    2.3.27

--- a/gemfiles/jruby_9.3_opensearch_2.gemfile
+++ b/gemfiles/jruby_9.3_opensearch_2.gemfile
@@ -25,7 +25,6 @@ gem "simplecov-cobertura", "~> 2.1.0"
 gem "warning", "~> 1"
 gem "webmock", ">= 3.10.0"
 gem "rexml", ">= 3.2.7"
-gem "yard", "~> 0.9"
 gem "rubocop", "~> 1.50.0", require: false
 gem "rubocop-packaging", "~> 0.5.2", require: false
 gem "rubocop-performance", "~> 1.9", require: false

--- a/gemfiles/jruby_9.3_opensearch_2.gemfile.lock
+++ b/gemfiles/jruby_9.3_opensearch_2.gemfile.lock
@@ -147,7 +147,6 @@ GEM
       addressable (>= 2.8.0)
       crack (>= 0.3.2)
       hashdiff (>= 0.4.0, < 2.0.0)
-    yard (0.9.34)
 
 PLATFORMS
   universal-java-11
@@ -184,7 +183,6 @@ DEPENDENCIES
   simplecov-cobertura (~> 2.1.0)
   warning (~> 1)
   webmock (>= 3.10.0)
-  yard (~> 0.9)
 
 BUNDLED WITH
    2.3.27

--- a/gemfiles/jruby_9.3_opensearch_3.gemfile
+++ b/gemfiles/jruby_9.3_opensearch_3.gemfile
@@ -25,7 +25,6 @@ gem "simplecov-cobertura", "~> 2.1.0"
 gem "warning", "~> 1"
 gem "webmock", ">= 3.10.0"
 gem "rexml", ">= 3.2.7"
-gem "yard", "~> 0.9"
 gem "rubocop", "~> 1.50.0", require: false
 gem "rubocop-packaging", "~> 0.5.2", require: false
 gem "rubocop-performance", "~> 1.9", require: false

--- a/gemfiles/jruby_9.3_opensearch_3.gemfile.lock
+++ b/gemfiles/jruby_9.3_opensearch_3.gemfile.lock
@@ -142,7 +142,6 @@ GEM
       addressable (>= 2.8.0)
       crack (>= 0.3.2)
       hashdiff (>= 0.4.0, < 2.0.0)
-    yard (0.9.34)
 
 PLATFORMS
   universal-java-11
@@ -179,7 +178,6 @@ DEPENDENCIES
   simplecov-cobertura (~> 2.1.0)
   warning (~> 1)
   webmock (>= 3.10.0)
-  yard (~> 0.9)
 
 BUNDLED WITH
    2.3.27

--- a/gemfiles/jruby_9.3_rack_1.gemfile
+++ b/gemfiles/jruby_9.3_rack_1.gemfile
@@ -25,7 +25,6 @@ gem "simplecov-cobertura", "~> 2.1.0"
 gem "warning", "~> 1"
 gem "webmock", ">= 3.10.0"
 gem "rexml", ">= 3.2.7"
-gem "yard", "~> 0.9"
 gem "rubocop", "~> 1.50.0", require: false
 gem "rubocop-packaging", "~> 0.5.2", require: false
 gem "rubocop-performance", "~> 1.9", require: false

--- a/gemfiles/jruby_9.3_rack_1.gemfile.lock
+++ b/gemfiles/jruby_9.3_rack_1.gemfile.lock
@@ -134,7 +134,6 @@ GEM
       addressable (>= 2.3.6)
       crack (>= 0.3.2)
       hashdiff (>= 0.4.0, < 2.0.0)
-    yard (0.9.34)
 
 PLATFORMS
   universal-java-11
@@ -173,7 +172,6 @@ DEPENDENCIES
   simplecov-cobertura (~> 2.1.0)
   warning (~> 1)
   webmock (>= 3.10.0)
-  yard (~> 0.9)
 
 BUNDLED WITH
    2.3.27

--- a/gemfiles/jruby_9.3_rack_2.gemfile
+++ b/gemfiles/jruby_9.3_rack_2.gemfile
@@ -25,7 +25,6 @@ gem "simplecov-cobertura", "~> 2.1.0"
 gem "warning", "~> 1"
 gem "webmock", ">= 3.10.0"
 gem "rexml", ">= 3.2.7"
-gem "yard", "~> 0.9"
 gem "rubocop", "~> 1.50.0", require: false
 gem "rubocop-packaging", "~> 0.5.2", require: false
 gem "rubocop-performance", "~> 1.9", require: false

--- a/gemfiles/jruby_9.3_rack_2.gemfile.lock
+++ b/gemfiles/jruby_9.3_rack_2.gemfile.lock
@@ -134,7 +134,6 @@ GEM
       addressable (>= 2.3.6)
       crack (>= 0.3.2)
       hashdiff (>= 0.4.0, < 2.0.0)
-    yard (0.9.34)
 
 PLATFORMS
   universal-java-11
@@ -173,7 +172,6 @@ DEPENDENCIES
   simplecov-cobertura (~> 2.1.0)
   warning (~> 1)
   webmock (>= 3.10.0)
-  yard (~> 0.9)
 
 BUNDLED WITH
    2.3.27

--- a/gemfiles/jruby_9.3_rack_3.gemfile
+++ b/gemfiles/jruby_9.3_rack_3.gemfile
@@ -25,7 +25,6 @@ gem "simplecov-cobertura", "~> 2.1.0"
 gem "warning", "~> 1"
 gem "webmock", ">= 3.10.0"
 gem "rexml", ">= 3.2.7"
-gem "yard", "~> 0.9"
 gem "rubocop", "~> 1.50.0", require: false
 gem "rubocop-packaging", "~> 0.5.2", require: false
 gem "rubocop-performance", "~> 1.9", require: false

--- a/gemfiles/jruby_9.3_rack_3.gemfile.lock
+++ b/gemfiles/jruby_9.3_rack_3.gemfile.lock
@@ -134,7 +134,6 @@ GEM
       addressable (>= 2.3.6)
       crack (>= 0.3.2)
       hashdiff (>= 0.4.0, < 2.0.0)
-    yard (0.9.34)
 
 PLATFORMS
   universal-java-11
@@ -173,7 +172,6 @@ DEPENDENCIES
   simplecov-cobertura (~> 2.1.0)
   warning (~> 1)
   webmock (>= 3.10.0)
-  yard (~> 0.9)
 
 BUNDLED WITH
    2.3.27

--- a/gemfiles/jruby_9.3_rails5_mysql2.gemfile
+++ b/gemfiles/jruby_9.3_rails5_mysql2.gemfile
@@ -25,7 +25,6 @@ gem "simplecov-cobertura", "~> 2.1.0"
 gem "warning", "~> 1"
 gem "webmock", ">= 3.10.0"
 gem "rexml", ">= 3.2.7"
-gem "yard", "~> 0.9"
 gem "rubocop", "~> 1.50.0", require: false
 gem "rubocop-packaging", "~> 0.5.2", require: false
 gem "rubocop-performance", "~> 1.9", require: false

--- a/gemfiles/jruby_9.3_rails5_mysql2.gemfile.lock
+++ b/gemfiles/jruby_9.3_rails5_mysql2.gemfile.lock
@@ -252,12 +252,9 @@ GEM
       addressable (>= 2.3.6)
       crack (>= 0.3.2)
       hashdiff (>= 0.4.0, < 2.0.0)
-    webrick (1.7.0)
     websocket-driver (0.7.5-java)
       websocket-extensions (>= 0.1.0)
     websocket-extensions (0.1.5)
-    yard (0.9.28)
-      webrick (~> 1.7.0)
 
 PLATFORMS
   universal-java-11
@@ -297,7 +294,6 @@ DEPENDENCIES
   sprockets (< 4)
   warning (~> 1)
   webmock (>= 3.10.0)
-  yard (~> 0.9)
 
 BUNDLED WITH
    2.3.27

--- a/gemfiles/jruby_9.3_rails5_postgres.gemfile
+++ b/gemfiles/jruby_9.3_rails5_postgres.gemfile
@@ -25,7 +25,6 @@ gem "simplecov-cobertura", "~> 2.1.0"
 gem "warning", "~> 1"
 gem "webmock", ">= 3.10.0"
 gem "rexml", ">= 3.2.7"
-gem "yard", "~> 0.9"
 gem "rubocop", "~> 1.50.0", require: false
 gem "rubocop-packaging", "~> 0.5.2", require: false
 gem "rubocop-performance", "~> 1.9", require: false

--- a/gemfiles/jruby_9.3_rails5_postgres.gemfile.lock
+++ b/gemfiles/jruby_9.3_rails5_postgres.gemfile.lock
@@ -252,12 +252,9 @@ GEM
       addressable (>= 2.3.6)
       crack (>= 0.3.2)
       hashdiff (>= 0.4.0, < 2.0.0)
-    webrick (1.7.0)
     websocket-driver (0.7.5-java)
       websocket-extensions (>= 0.1.0)
     websocket-extensions (0.1.5)
-    yard (0.9.28)
-      webrick (~> 1.7.0)
 
 PLATFORMS
   universal-java-11
@@ -297,7 +294,6 @@ DEPENDENCIES
   sprockets (< 4)
   warning (~> 1)
   webmock (>= 3.10.0)
-  yard (~> 0.9)
 
 BUNDLED WITH
    2.3.27

--- a/gemfiles/jruby_9.3_rails5_postgres_redis.gemfile
+++ b/gemfiles/jruby_9.3_rails5_postgres_redis.gemfile
@@ -25,7 +25,6 @@ gem "simplecov-cobertura", "~> 2.1.0"
 gem "warning", "~> 1"
 gem "webmock", ">= 3.10.0"
 gem "rexml", ">= 3.2.7"
-gem "yard", "~> 0.9"
 gem "rubocop", "~> 1.50.0", require: false
 gem "rubocop-packaging", "~> 0.5.2", require: false
 gem "rubocop-performance", "~> 1.9", require: false

--- a/gemfiles/jruby_9.3_rails5_postgres_redis.gemfile.lock
+++ b/gemfiles/jruby_9.3_rails5_postgres_redis.gemfile.lock
@@ -253,12 +253,9 @@ GEM
       addressable (>= 2.3.6)
       crack (>= 0.3.2)
       hashdiff (>= 0.4.0, < 2.0.0)
-    webrick (1.7.0)
     websocket-driver (0.7.5-java)
       websocket-extensions (>= 0.1.0)
     websocket-extensions (0.1.5)
-    yard (0.9.28)
-      webrick (~> 1.7.0)
 
 PLATFORMS
   universal-java-11
@@ -299,7 +296,6 @@ DEPENDENCIES
   sprockets (< 4)
   warning (~> 1)
   webmock (>= 3.10.0)
-  yard (~> 0.9)
 
 BUNDLED WITH
    2.3.27

--- a/gemfiles/jruby_9.3_rails5_postgres_redis_activesupport.gemfile
+++ b/gemfiles/jruby_9.3_rails5_postgres_redis_activesupport.gemfile
@@ -25,7 +25,6 @@ gem "simplecov-cobertura", "~> 2.1.0"
 gem "warning", "~> 1"
 gem "webmock", ">= 3.10.0"
 gem "rexml", ">= 3.2.7"
-gem "yard", "~> 0.9"
 gem "rubocop", "~> 1.50.0", require: false
 gem "rubocop-packaging", "~> 0.5.2", require: false
 gem "rubocop-performance", "~> 1.9", require: false

--- a/gemfiles/jruby_9.3_rails5_postgres_redis_activesupport.gemfile.lock
+++ b/gemfiles/jruby_9.3_rails5_postgres_redis_activesupport.gemfile.lock
@@ -269,12 +269,9 @@ GEM
       addressable (>= 2.3.6)
       crack (>= 0.3.2)
       hashdiff (>= 0.4.0, < 2.0.0)
-    webrick (1.7.0)
     websocket-driver (0.7.5-java)
       websocket-extensions (>= 0.1.0)
     websocket-extensions (0.1.5)
-    yard (0.9.28)
-      webrick (~> 1.7.0)
 
 PLATFORMS
   universal-java-11
@@ -317,7 +314,6 @@ DEPENDENCIES
   sprockets (< 4)
   warning (~> 1)
   webmock (>= 3.10.0)
-  yard (~> 0.9)
 
 BUNDLED WITH
    2.3.27

--- a/gemfiles/jruby_9.3_rails5_postgres_sidekiq.gemfile
+++ b/gemfiles/jruby_9.3_rails5_postgres_sidekiq.gemfile
@@ -25,7 +25,6 @@ gem "simplecov-cobertura", "~> 2.1.0"
 gem "warning", "~> 1"
 gem "webmock", ">= 3.10.0"
 gem "rexml", ">= 3.2.7"
-gem "yard", "~> 0.9"
 gem "rubocop", "~> 1.50.0", require: false
 gem "rubocop-packaging", "~> 0.5.2", require: false
 gem "rubocop-performance", "~> 1.9", require: false

--- a/gemfiles/jruby_9.3_rails5_postgres_sidekiq.gemfile.lock
+++ b/gemfiles/jruby_9.3_rails5_postgres_sidekiq.gemfile.lock
@@ -258,12 +258,9 @@ GEM
       addressable (>= 2.3.6)
       crack (>= 0.3.2)
       hashdiff (>= 0.4.0, < 2.0.0)
-    webrick (1.7.0)
     websocket-driver (0.7.5-java)
       websocket-extensions (>= 0.1.0)
     websocket-extensions (0.1.5)
-    yard (0.9.28)
-      webrick (~> 1.7.0)
 
 PLATFORMS
   universal-java-11
@@ -305,7 +302,6 @@ DEPENDENCIES
   sprockets (< 4)
   warning (~> 1)
   webmock (>= 3.10.0)
-  yard (~> 0.9)
 
 BUNDLED WITH
    2.3.27

--- a/gemfiles/jruby_9.3_rails5_semantic_logger.gemfile
+++ b/gemfiles/jruby_9.3_rails5_semantic_logger.gemfile
@@ -25,7 +25,6 @@ gem "simplecov-cobertura", "~> 2.1.0"
 gem "warning", "~> 1"
 gem "webmock", ">= 3.10.0"
 gem "rexml", ">= 3.2.7"
-gem "yard", "~> 0.9"
 gem "rubocop", "~> 1.50.0", require: false
 gem "rubocop-packaging", "~> 0.5.2", require: false
 gem "rubocop-performance", "~> 1.9", require: false

--- a/gemfiles/jruby_9.3_rails5_semantic_logger.gemfile.lock
+++ b/gemfiles/jruby_9.3_rails5_semantic_logger.gemfile.lock
@@ -251,12 +251,9 @@ GEM
       addressable (>= 2.3.6)
       crack (>= 0.3.2)
       hashdiff (>= 0.4.0, < 2.0.0)
-    webrick (1.7.0)
     websocket-driver (0.7.5-java)
       websocket-extensions (>= 0.1.0)
     websocket-extensions (0.1.5)
-    yard (0.9.28)
-      webrick (~> 1.7.0)
 
 PLATFORMS
   universal-java-11
@@ -296,7 +293,6 @@ DEPENDENCIES
   sprockets (< 4)
   warning (~> 1)
   webmock (>= 3.10.0)
-  yard (~> 0.9)
 
 BUNDLED WITH
    2.3.27

--- a/gemfiles/jruby_9.3_rails61_mysql2.gemfile
+++ b/gemfiles/jruby_9.3_rails61_mysql2.gemfile
@@ -25,7 +25,6 @@ gem "simplecov-cobertura", "~> 2.1.0"
 gem "warning", "~> 1"
 gem "webmock", ">= 3.10.0"
 gem "rexml", ">= 3.2.7"
-gem "yard", "~> 0.9"
 gem "rubocop", "~> 1.50.0", require: false
 gem "rubocop-packaging", "~> 0.5.2", require: false
 gem "rubocop-performance", "~> 1.9", require: false

--- a/gemfiles/jruby_9.3_rails61_mysql2.gemfile.lock
+++ b/gemfiles/jruby_9.3_rails61_mysql2.gemfile.lock
@@ -270,12 +270,9 @@ GEM
       addressable (>= 2.3.6)
       crack (>= 0.3.2)
       hashdiff (>= 0.4.0, < 2.0.0)
-    webrick (1.7.0)
     websocket-driver (0.7.5-java)
       websocket-extensions (>= 0.1.0)
     websocket-extensions (0.1.5)
-    yard (0.9.28)
-      webrick (~> 1.7.0)
     zeitwerk (2.6.6)
 
 PLATFORMS
@@ -316,7 +313,6 @@ DEPENDENCIES
   sprockets (< 4)
   warning (~> 1)
   webmock (>= 3.10.0)
-  yard (~> 0.9)
 
 BUNDLED WITH
    2.3.27

--- a/gemfiles/jruby_9.3_rails61_postgres.gemfile
+++ b/gemfiles/jruby_9.3_rails61_postgres.gemfile
@@ -25,7 +25,6 @@ gem "simplecov-cobertura", "~> 2.1.0"
 gem "warning", "~> 1"
 gem "webmock", ">= 3.10.0"
 gem "rexml", ">= 3.2.7"
-gem "yard", "~> 0.9"
 gem "rubocop", "~> 1.50.0", require: false
 gem "rubocop-packaging", "~> 0.5.2", require: false
 gem "rubocop-performance", "~> 1.9", require: false

--- a/gemfiles/jruby_9.3_rails61_postgres.gemfile.lock
+++ b/gemfiles/jruby_9.3_rails61_postgres.gemfile.lock
@@ -270,12 +270,9 @@ GEM
       addressable (>= 2.3.6)
       crack (>= 0.3.2)
       hashdiff (>= 0.4.0, < 2.0.0)
-    webrick (1.7.0)
     websocket-driver (0.7.5-java)
       websocket-extensions (>= 0.1.0)
     websocket-extensions (0.1.5)
-    yard (0.9.28)
-      webrick (~> 1.7.0)
     zeitwerk (2.6.6)
 
 PLATFORMS
@@ -316,7 +313,6 @@ DEPENDENCIES
   sprockets (< 4)
   warning (~> 1)
   webmock (>= 3.10.0)
-  yard (~> 0.9)
 
 BUNDLED WITH
    2.3.27

--- a/gemfiles/jruby_9.3_rails61_postgres_redis.gemfile
+++ b/gemfiles/jruby_9.3_rails61_postgres_redis.gemfile
@@ -25,7 +25,6 @@ gem "simplecov-cobertura", "~> 2.1.0"
 gem "warning", "~> 1"
 gem "webmock", ">= 3.10.0"
 gem "rexml", ">= 3.2.7"
-gem "yard", "~> 0.9"
 gem "rubocop", "~> 1.50.0", require: false
 gem "rubocop-packaging", "~> 0.5.2", require: false
 gem "rubocop-performance", "~> 1.9", require: false

--- a/gemfiles/jruby_9.3_rails61_postgres_redis.gemfile.lock
+++ b/gemfiles/jruby_9.3_rails61_postgres_redis.gemfile.lock
@@ -271,12 +271,9 @@ GEM
       addressable (>= 2.3.6)
       crack (>= 0.3.2)
       hashdiff (>= 0.4.0, < 2.0.0)
-    webrick (1.7.0)
     websocket-driver (0.7.5-java)
       websocket-extensions (>= 0.1.0)
     websocket-extensions (0.1.5)
-    yard (0.9.28)
-      webrick (~> 1.7.0)
     zeitwerk (2.6.6)
 
 PLATFORMS
@@ -318,7 +315,6 @@ DEPENDENCIES
   sprockets (< 4)
   warning (~> 1)
   webmock (>= 3.10.0)
-  yard (~> 0.9)
 
 BUNDLED WITH
    2.3.27

--- a/gemfiles/jruby_9.3_rails61_postgres_sidekiq.gemfile
+++ b/gemfiles/jruby_9.3_rails61_postgres_sidekiq.gemfile
@@ -25,7 +25,6 @@ gem "simplecov-cobertura", "~> 2.1.0"
 gem "warning", "~> 1"
 gem "webmock", ">= 3.10.0"
 gem "rexml", ">= 3.2.7"
-gem "yard", "~> 0.9"
 gem "rubocop", "~> 1.50.0", require: false
 gem "rubocop-packaging", "~> 0.5.2", require: false
 gem "rubocop-performance", "~> 1.9", require: false

--- a/gemfiles/jruby_9.3_rails61_postgres_sidekiq.gemfile.lock
+++ b/gemfiles/jruby_9.3_rails61_postgres_sidekiq.gemfile.lock
@@ -276,12 +276,9 @@ GEM
       addressable (>= 2.3.6)
       crack (>= 0.3.2)
       hashdiff (>= 0.4.0, < 2.0.0)
-    webrick (1.7.0)
     websocket-driver (0.7.5-java)
       websocket-extensions (>= 0.1.0)
     websocket-extensions (0.1.5)
-    yard (0.9.28)
-      webrick (~> 1.7.0)
     zeitwerk (2.6.6)
 
 PLATFORMS
@@ -323,7 +320,6 @@ DEPENDENCIES
   sprockets (< 4)
   warning (~> 1)
   webmock (>= 3.10.0)
-  yard (~> 0.9)
 
 BUNDLED WITH
    2.3.27

--- a/gemfiles/jruby_9.3_rails61_semantic_logger.gemfile
+++ b/gemfiles/jruby_9.3_rails61_semantic_logger.gemfile
@@ -25,7 +25,6 @@ gem "simplecov-cobertura", "~> 2.1.0"
 gem "warning", "~> 1"
 gem "webmock", ">= 3.10.0"
 gem "rexml", ">= 3.2.7"
-gem "yard", "~> 0.9"
 gem "rubocop", "~> 1.50.0", require: false
 gem "rubocop-packaging", "~> 0.5.2", require: false
 gem "rubocop-performance", "~> 1.9", require: false

--- a/gemfiles/jruby_9.3_rails61_semantic_logger.gemfile.lock
+++ b/gemfiles/jruby_9.3_rails61_semantic_logger.gemfile.lock
@@ -269,12 +269,9 @@ GEM
       addressable (>= 2.3.6)
       crack (>= 0.3.2)
       hashdiff (>= 0.4.0, < 2.0.0)
-    webrick (1.7.0)
     websocket-driver (0.7.5-java)
       websocket-extensions (>= 0.1.0)
     websocket-extensions (0.1.5)
-    yard (0.9.28)
-      webrick (~> 1.7.0)
     zeitwerk (2.6.6)
 
 PLATFORMS
@@ -315,7 +312,6 @@ DEPENDENCIES
   sprockets (< 4)
   warning (~> 1)
   webmock (>= 3.10.0)
-  yard (~> 0.9)
 
 BUNDLED WITH
    2.3.27

--- a/gemfiles/jruby_9.3_rails6_mysql2.gemfile
+++ b/gemfiles/jruby_9.3_rails6_mysql2.gemfile
@@ -25,7 +25,6 @@ gem "simplecov-cobertura", "~> 2.1.0"
 gem "warning", "~> 1"
 gem "webmock", ">= 3.10.0"
 gem "rexml", ">= 3.2.7"
-gem "yard", "~> 0.9"
 gem "rubocop", "~> 1.50.0", require: false
 gem "rubocop-packaging", "~> 0.5.2", require: false
 gem "rubocop-performance", "~> 1.9", require: false

--- a/gemfiles/jruby_9.3_rails6_mysql2.gemfile.lock
+++ b/gemfiles/jruby_9.3_rails6_mysql2.gemfile.lock
@@ -267,12 +267,9 @@ GEM
       addressable (>= 2.3.6)
       crack (>= 0.3.2)
       hashdiff (>= 0.4.0, < 2.0.0)
-    webrick (1.7.0)
     websocket-driver (0.7.5-java)
       websocket-extensions (>= 0.1.0)
     websocket-extensions (0.1.5)
-    yard (0.9.28)
-      webrick (~> 1.7.0)
     zeitwerk (2.6.6)
 
 PLATFORMS
@@ -313,7 +310,6 @@ DEPENDENCIES
   sprockets (< 4)
   warning (~> 1)
   webmock (>= 3.10.0)
-  yard (~> 0.9)
 
 BUNDLED WITH
    2.3.27

--- a/gemfiles/jruby_9.3_rails6_postgres.gemfile
+++ b/gemfiles/jruby_9.3_rails6_postgres.gemfile
@@ -25,7 +25,6 @@ gem "simplecov-cobertura", "~> 2.1.0"
 gem "warning", "~> 1"
 gem "webmock", ">= 3.10.0"
 gem "rexml", ">= 3.2.7"
-gem "yard", "~> 0.9"
 gem "rubocop", "~> 1.50.0", require: false
 gem "rubocop-packaging", "~> 0.5.2", require: false
 gem "rubocop-performance", "~> 1.9", require: false

--- a/gemfiles/jruby_9.3_rails6_postgres.gemfile.lock
+++ b/gemfiles/jruby_9.3_rails6_postgres.gemfile.lock
@@ -267,12 +267,9 @@ GEM
       addressable (>= 2.3.6)
       crack (>= 0.3.2)
       hashdiff (>= 0.4.0, < 2.0.0)
-    webrick (1.7.0)
     websocket-driver (0.7.5-java)
       websocket-extensions (>= 0.1.0)
     websocket-extensions (0.1.5)
-    yard (0.9.28)
-      webrick (~> 1.7.0)
     zeitwerk (2.6.6)
 
 PLATFORMS
@@ -313,7 +310,6 @@ DEPENDENCIES
   sprockets (< 4)
   warning (~> 1)
   webmock (>= 3.10.0)
-  yard (~> 0.9)
 
 BUNDLED WITH
    2.3.27

--- a/gemfiles/jruby_9.3_rails6_postgres_redis.gemfile
+++ b/gemfiles/jruby_9.3_rails6_postgres_redis.gemfile
@@ -25,7 +25,6 @@ gem "simplecov-cobertura", "~> 2.1.0"
 gem "warning", "~> 1"
 gem "webmock", ">= 3.10.0"
 gem "rexml", ">= 3.2.7"
-gem "yard", "~> 0.9"
 gem "rubocop", "~> 1.50.0", require: false
 gem "rubocop-packaging", "~> 0.5.2", require: false
 gem "rubocop-performance", "~> 1.9", require: false

--- a/gemfiles/jruby_9.3_rails6_postgres_redis.gemfile.lock
+++ b/gemfiles/jruby_9.3_rails6_postgres_redis.gemfile.lock
@@ -268,12 +268,9 @@ GEM
       addressable (>= 2.3.6)
       crack (>= 0.3.2)
       hashdiff (>= 0.4.0, < 2.0.0)
-    webrick (1.7.0)
     websocket-driver (0.7.5-java)
       websocket-extensions (>= 0.1.0)
     websocket-extensions (0.1.5)
-    yard (0.9.28)
-      webrick (~> 1.7.0)
     zeitwerk (2.6.6)
 
 PLATFORMS
@@ -315,7 +312,6 @@ DEPENDENCIES
   sprockets (< 4)
   warning (~> 1)
   webmock (>= 3.10.0)
-  yard (~> 0.9)
 
 BUNDLED WITH
    2.3.27

--- a/gemfiles/jruby_9.3_rails6_postgres_redis_activesupport.gemfile
+++ b/gemfiles/jruby_9.3_rails6_postgres_redis_activesupport.gemfile
@@ -25,7 +25,6 @@ gem "simplecov-cobertura", "~> 2.1.0"
 gem "warning", "~> 1"
 gem "webmock", ">= 3.10.0"
 gem "rexml", ">= 3.2.7"
-gem "yard", "~> 0.9"
 gem "rubocop", "~> 1.50.0", require: false
 gem "rubocop-packaging", "~> 0.5.2", require: false
 gem "rubocop-performance", "~> 1.9", require: false

--- a/gemfiles/jruby_9.3_rails6_postgres_redis_activesupport.gemfile.lock
+++ b/gemfiles/jruby_9.3_rails6_postgres_redis_activesupport.gemfile.lock
@@ -284,12 +284,9 @@ GEM
       addressable (>= 2.3.6)
       crack (>= 0.3.2)
       hashdiff (>= 0.4.0, < 2.0.0)
-    webrick (1.7.0)
     websocket-driver (0.7.5-java)
       websocket-extensions (>= 0.1.0)
     websocket-extensions (0.1.5)
-    yard (0.9.28)
-      webrick (~> 1.7.0)
     zeitwerk (2.6.6)
 
 PLATFORMS
@@ -333,7 +330,6 @@ DEPENDENCIES
   sprockets (< 4)
   warning (~> 1)
   webmock (>= 3.10.0)
-  yard (~> 0.9)
 
 BUNDLED WITH
    2.3.27

--- a/gemfiles/jruby_9.3_rails6_postgres_sidekiq.gemfile
+++ b/gemfiles/jruby_9.3_rails6_postgres_sidekiq.gemfile
@@ -25,7 +25,6 @@ gem "simplecov-cobertura", "~> 2.1.0"
 gem "warning", "~> 1"
 gem "webmock", ">= 3.10.0"
 gem "rexml", ">= 3.2.7"
-gem "yard", "~> 0.9"
 gem "rubocop", "~> 1.50.0", require: false
 gem "rubocop-packaging", "~> 0.5.2", require: false
 gem "rubocop-performance", "~> 1.9", require: false

--- a/gemfiles/jruby_9.3_rails6_postgres_sidekiq.gemfile.lock
+++ b/gemfiles/jruby_9.3_rails6_postgres_sidekiq.gemfile.lock
@@ -273,12 +273,9 @@ GEM
       addressable (>= 2.3.6)
       crack (>= 0.3.2)
       hashdiff (>= 0.4.0, < 2.0.0)
-    webrick (1.7.0)
     websocket-driver (0.7.5-java)
       websocket-extensions (>= 0.1.0)
     websocket-extensions (0.1.5)
-    yard (0.9.28)
-      webrick (~> 1.7.0)
     zeitwerk (2.6.6)
 
 PLATFORMS
@@ -321,7 +318,6 @@ DEPENDENCIES
   sprockets (< 4)
   warning (~> 1)
   webmock (>= 3.10.0)
-  yard (~> 0.9)
 
 BUNDLED WITH
    2.3.27

--- a/gemfiles/jruby_9.3_rails6_semantic_logger.gemfile
+++ b/gemfiles/jruby_9.3_rails6_semantic_logger.gemfile
@@ -25,7 +25,6 @@ gem "simplecov-cobertura", "~> 2.1.0"
 gem "warning", "~> 1"
 gem "webmock", ">= 3.10.0"
 gem "rexml", ">= 3.2.7"
-gem "yard", "~> 0.9"
 gem "rubocop", "~> 1.50.0", require: false
 gem "rubocop-packaging", "~> 0.5.2", require: false
 gem "rubocop-performance", "~> 1.9", require: false

--- a/gemfiles/jruby_9.3_rails6_semantic_logger.gemfile.lock
+++ b/gemfiles/jruby_9.3_rails6_semantic_logger.gemfile.lock
@@ -266,12 +266,9 @@ GEM
       addressable (>= 2.3.6)
       crack (>= 0.3.2)
       hashdiff (>= 0.4.0, < 2.0.0)
-    webrick (1.7.0)
     websocket-driver (0.7.5-java)
       websocket-extensions (>= 0.1.0)
     websocket-extensions (0.1.5)
-    yard (0.9.28)
-      webrick (~> 1.7.0)
     zeitwerk (2.6.6)
 
 PLATFORMS
@@ -312,7 +309,6 @@ DEPENDENCIES
   sprockets (< 4)
   warning (~> 1)
   webmock (>= 3.10.0)
-  yard (~> 0.9)
 
 BUNDLED WITH
    2.3.27

--- a/gemfiles/jruby_9.3_redis_3.gemfile
+++ b/gemfiles/jruby_9.3_redis_3.gemfile
@@ -25,7 +25,6 @@ gem "simplecov-cobertura", "~> 2.1.0"
 gem "warning", "~> 1"
 gem "webmock", ">= 3.10.0"
 gem "rexml", ">= 3.2.7"
-gem "yard", "~> 0.9"
 gem "rubocop", "~> 1.50.0", require: false
 gem "rubocop-packaging", "~> 0.5.2", require: false
 gem "rubocop-performance", "~> 1.9", require: false

--- a/gemfiles/jruby_9.3_redis_3.gemfile.lock
+++ b/gemfiles/jruby_9.3_redis_3.gemfile.lock
@@ -130,9 +130,6 @@ GEM
       addressable (>= 2.3.6)
       crack (>= 0.3.2)
       hashdiff (>= 0.4.0, < 2.0.0)
-    webrick (1.7.0)
-    yard (0.9.28)
-      webrick (~> 1.7.0)
 
 PLATFORMS
   universal-java-11
@@ -169,7 +166,6 @@ DEPENDENCIES
   simplecov-cobertura (~> 2.1.0)
   warning (~> 1)
   webmock (>= 3.10.0)
-  yard (~> 0.9)
 
 BUNDLED WITH
    2.3.27

--- a/gemfiles/jruby_9.3_redis_4.gemfile
+++ b/gemfiles/jruby_9.3_redis_4.gemfile
@@ -25,7 +25,6 @@ gem "simplecov-cobertura", "~> 2.1.0"
 gem "warning", "~> 1"
 gem "webmock", ">= 3.10.0"
 gem "rexml", ">= 3.2.7"
-gem "yard", "~> 0.9"
 gem "rubocop", "~> 1.50.0", require: false
 gem "rubocop-packaging", "~> 0.5.2", require: false
 gem "rubocop-performance", "~> 1.9", require: false

--- a/gemfiles/jruby_9.3_redis_4.gemfile.lock
+++ b/gemfiles/jruby_9.3_redis_4.gemfile.lock
@@ -130,9 +130,6 @@ GEM
       addressable (>= 2.3.6)
       crack (>= 0.3.2)
       hashdiff (>= 0.4.0, < 2.0.0)
-    webrick (1.7.0)
-    yard (0.9.28)
-      webrick (~> 1.7.0)
 
 PLATFORMS
   universal-java-11
@@ -169,7 +166,6 @@ DEPENDENCIES
   simplecov-cobertura (~> 2.1.0)
   warning (~> 1)
   webmock (>= 3.10.0)
-  yard (~> 0.9)
 
 BUNDLED WITH
    2.3.27

--- a/gemfiles/jruby_9.3_redis_5.gemfile
+++ b/gemfiles/jruby_9.3_redis_5.gemfile
@@ -25,7 +25,6 @@ gem "simplecov-cobertura", "~> 2.1.0"
 gem "warning", "~> 1"
 gem "webmock", ">= 3.10.0"
 gem "rexml", ">= 3.2.7"
-gem "yard", "~> 0.9"
 gem "rubocop", "~> 1.50.0", require: false
 gem "rubocop-packaging", "~> 0.5.2", require: false
 gem "rubocop-performance", "~> 1.9", require: false

--- a/gemfiles/jruby_9.3_redis_5.gemfile.lock
+++ b/gemfiles/jruby_9.3_redis_5.gemfile.lock
@@ -134,9 +134,6 @@ GEM
       addressable (>= 2.3.6)
       crack (>= 0.3.2)
       hashdiff (>= 0.4.0, < 2.0.0)
-    webrick (1.7.0)
-    yard (0.9.28)
-      webrick (~> 1.7.0)
 
 PLATFORMS
   universal-java-11
@@ -173,7 +170,6 @@ DEPENDENCIES
   simplecov-cobertura (~> 2.1.0)
   warning (~> 1)
   webmock (>= 3.10.0)
-  yard (~> 0.9)
 
 BUNDLED WITH
    2.3.27

--- a/gemfiles/jruby_9.3_relational_db.gemfile
+++ b/gemfiles/jruby_9.3_relational_db.gemfile
@@ -25,7 +25,6 @@ gem "simplecov-cobertura", "~> 2.1.0"
 gem "warning", "~> 1"
 gem "webmock", ">= 3.10.0"
 gem "rexml", ">= 3.2.7"
-gem "yard", "~> 0.9"
 gem "rubocop", "~> 1.50.0", require: false
 gem "rubocop-packaging", "~> 0.5.2", require: false
 gem "rubocop-performance", "~> 1.9", require: false

--- a/gemfiles/jruby_9.3_relational_db.gemfile.lock
+++ b/gemfiles/jruby_9.3_relational_db.gemfile.lock
@@ -167,7 +167,6 @@ GEM
       addressable (>= 2.3.6)
       crack (>= 0.3.2)
       hashdiff (>= 0.4.0, < 2.0.0)
-    yard (0.9.34)
     zeitwerk (2.6.11)
 
 PLATFORMS
@@ -212,7 +211,6 @@ DEPENDENCIES
   simplecov-cobertura (~> 2.1.0)
   warning (~> 1)
   webmock (>= 3.10.0)
-  yard (~> 0.9)
 
 BUNDLED WITH
    2.3.27

--- a/gemfiles/jruby_9.3_resque2_redis3.gemfile
+++ b/gemfiles/jruby_9.3_resque2_redis3.gemfile
@@ -25,7 +25,6 @@ gem "simplecov-cobertura", "~> 2.1.0"
 gem "warning", "~> 1"
 gem "webmock", ">= 3.10.0"
 gem "rexml", ">= 3.2.7"
-gem "yard", "~> 0.9"
 gem "rubocop", "~> 1.50.0", require: false
 gem "rubocop-packaging", "~> 0.5.2", require: false
 gem "rubocop-performance", "~> 1.9", require: false

--- a/gemfiles/jruby_9.3_resque2_redis3.gemfile.lock
+++ b/gemfiles/jruby_9.3_resque2_redis3.gemfile.lock
@@ -151,9 +151,6 @@ GEM
       addressable (>= 2.3.6)
       crack (>= 0.3.2)
       hashdiff (>= 0.4.0, < 2.0.0)
-    webrick (1.7.0)
-    yard (0.9.28)
-      webrick (~> 1.7.0)
 
 PLATFORMS
   universal-java-11
@@ -191,7 +188,6 @@ DEPENDENCIES
   simplecov-cobertura (~> 2.1.0)
   warning (~> 1)
   webmock (>= 3.10.0)
-  yard (~> 0.9)
 
 BUNDLED WITH
    2.3.27

--- a/gemfiles/jruby_9.3_resque2_redis4.gemfile
+++ b/gemfiles/jruby_9.3_resque2_redis4.gemfile
@@ -25,7 +25,6 @@ gem "simplecov-cobertura", "~> 2.1.0"
 gem "warning", "~> 1"
 gem "webmock", ">= 3.10.0"
 gem "rexml", ">= 3.2.7"
-gem "yard", "~> 0.9"
 gem "rubocop", "~> 1.50.0", require: false
 gem "rubocop-packaging", "~> 0.5.2", require: false
 gem "rubocop-performance", "~> 1.9", require: false

--- a/gemfiles/jruby_9.3_resque2_redis4.gemfile.lock
+++ b/gemfiles/jruby_9.3_resque2_redis4.gemfile.lock
@@ -151,9 +151,6 @@ GEM
       addressable (>= 2.3.6)
       crack (>= 0.3.2)
       hashdiff (>= 0.4.0, < 2.0.0)
-    webrick (1.7.0)
-    yard (0.9.28)
-      webrick (~> 1.7.0)
 
 PLATFORMS
   universal-java-11
@@ -191,7 +188,6 @@ DEPENDENCIES
   simplecov-cobertura (~> 2.1.0)
   warning (~> 1)
   webmock (>= 3.10.0)
-  yard (~> 0.9)
 
 BUNDLED WITH
    2.3.27

--- a/gemfiles/jruby_9.3_sinatra_2.gemfile
+++ b/gemfiles/jruby_9.3_sinatra_2.gemfile
@@ -25,7 +25,6 @@ gem "simplecov-cobertura", "~> 2.1.0"
 gem "warning", "~> 1"
 gem "webmock", ">= 3.10.0"
 gem "rexml", ">= 3.2.7"
-gem "yard", "~> 0.9"
 gem "rubocop", "~> 1.50.0", require: false
 gem "rubocop-packaging", "~> 0.5.2", require: false
 gem "rubocop-performance", "~> 1.9", require: false

--- a/gemfiles/jruby_9.3_sinatra_2.gemfile.lock
+++ b/gemfiles/jruby_9.3_sinatra_2.gemfile.lock
@@ -149,7 +149,6 @@ GEM
       addressable (>= 2.8.0)
       crack (>= 0.3.2)
       hashdiff (>= 0.4.0, < 2.0.0)
-    yard (0.9.36)
 
 PLATFORMS
   universal-java-11
@@ -188,7 +187,6 @@ DEPENDENCIES
   sinatra (~> 2)
   warning (~> 1)
   webmock (>= 3.10.0)
-  yard (~> 0.9)
 
 BUNDLED WITH
    2.3.27

--- a/gemfiles/jruby_9.3_sinatra_3.gemfile
+++ b/gemfiles/jruby_9.3_sinatra_3.gemfile
@@ -25,7 +25,6 @@ gem "simplecov-cobertura", "~> 2.1.0"
 gem "warning", "~> 1"
 gem "webmock", ">= 3.10.0"
 gem "rexml", ">= 3.2.7"
-gem "yard", "~> 0.9"
 gem "rubocop", "~> 1.50.0", require: false
 gem "rubocop-packaging", "~> 0.5.2", require: false
 gem "rubocop-performance", "~> 1.9", require: false

--- a/gemfiles/jruby_9.3_sinatra_3.gemfile.lock
+++ b/gemfiles/jruby_9.3_sinatra_3.gemfile.lock
@@ -151,7 +151,6 @@ GEM
       addressable (>= 2.8.0)
       crack (>= 0.3.2)
       hashdiff (>= 0.4.0, < 2.0.0)
-    yard (0.9.36)
 
 PLATFORMS
   universal-java-11
@@ -190,7 +189,6 @@ DEPENDENCIES
   sinatra (~> 3)
   warning (~> 1)
   webmock (>= 3.10.0)
-  yard (~> 0.9)
 
 BUNDLED WITH
    2.3.27

--- a/gemfiles/jruby_9.3_stripe_10.gemfile
+++ b/gemfiles/jruby_9.3_stripe_10.gemfile
@@ -25,7 +25,6 @@ gem "simplecov-cobertura", "~> 2.1.0"
 gem "warning", "~> 1"
 gem "webmock", ">= 3.10.0"
 gem "rexml", ">= 3.2.7"
-gem "yard", "~> 0.9"
 gem "rubocop", "~> 1.50.0", require: false
 gem "rubocop-packaging", "~> 0.5.2", require: false
 gem "rubocop-performance", "~> 1.9", require: false

--- a/gemfiles/jruby_9.3_stripe_10.gemfile.lock
+++ b/gemfiles/jruby_9.3_stripe_10.gemfile.lock
@@ -134,7 +134,6 @@ GEM
       addressable (>= 2.8.0)
       crack (>= 0.3.2)
       hashdiff (>= 0.4.0, < 2.0.0)
-    yard (0.9.36)
 
 PLATFORMS
   universal-java-11
@@ -171,7 +170,6 @@ DEPENDENCIES
   stripe (~> 10)
   warning (~> 1)
   webmock (>= 3.10.0)
-  yard (~> 0.9)
 
 BUNDLED WITH
    2.3.27

--- a/gemfiles/jruby_9.3_stripe_11.gemfile
+++ b/gemfiles/jruby_9.3_stripe_11.gemfile
@@ -25,7 +25,6 @@ gem "simplecov-cobertura", "~> 2.1.0"
 gem "warning", "~> 1"
 gem "webmock", ">= 3.10.0"
 gem "rexml", ">= 3.2.7"
-gem "yard", "~> 0.9"
 gem "rubocop", "~> 1.50.0", require: false
 gem "rubocop-packaging", "~> 0.5.2", require: false
 gem "rubocop-performance", "~> 1.9", require: false

--- a/gemfiles/jruby_9.3_stripe_11.gemfile.lock
+++ b/gemfiles/jruby_9.3_stripe_11.gemfile.lock
@@ -134,7 +134,6 @@ GEM
       addressable (>= 2.8.0)
       crack (>= 0.3.2)
       hashdiff (>= 0.4.0, < 2.0.0)
-    yard (0.9.36)
 
 PLATFORMS
   universal-java-11
@@ -171,7 +170,6 @@ DEPENDENCIES
   stripe (~> 11)
   warning (~> 1)
   webmock (>= 3.10.0)
-  yard (~> 0.9)
 
 BUNDLED WITH
    2.3.27

--- a/gemfiles/jruby_9.3_stripe_12.gemfile
+++ b/gemfiles/jruby_9.3_stripe_12.gemfile
@@ -25,7 +25,6 @@ gem "simplecov-cobertura", "~> 2.1.0"
 gem "warning", "~> 1"
 gem "webmock", ">= 3.10.0"
 gem "rexml", ">= 3.2.7"
-gem "yard", "~> 0.9"
 gem "rubocop", "~> 1.50.0", require: false
 gem "rubocop-packaging", "~> 0.5.2", require: false
 gem "rubocop-performance", "~> 1.9", require: false

--- a/gemfiles/jruby_9.3_stripe_12.gemfile.lock
+++ b/gemfiles/jruby_9.3_stripe_12.gemfile.lock
@@ -134,7 +134,6 @@ GEM
       addressable (>= 2.8.0)
       crack (>= 0.3.2)
       hashdiff (>= 0.4.0, < 2.0.0)
-    yard (0.9.36)
 
 PLATFORMS
   universal-java-11
@@ -171,7 +170,6 @@ DEPENDENCIES
   stripe (~> 12)
   warning (~> 1)
   webmock (>= 3.10.0)
-  yard (~> 0.9)
 
 BUNDLED WITH
    2.3.27

--- a/gemfiles/jruby_9.3_stripe_7.gemfile
+++ b/gemfiles/jruby_9.3_stripe_7.gemfile
@@ -25,7 +25,6 @@ gem "simplecov-cobertura", "~> 2.1.0"
 gem "warning", "~> 1"
 gem "webmock", ">= 3.10.0"
 gem "rexml", ">= 3.2.7"
-gem "yard", "~> 0.9"
 gem "rubocop", "~> 1.50.0", require: false
 gem "rubocop-packaging", "~> 0.5.2", require: false
 gem "rubocop-performance", "~> 1.9", require: false

--- a/gemfiles/jruby_9.3_stripe_7.gemfile.lock
+++ b/gemfiles/jruby_9.3_stripe_7.gemfile.lock
@@ -134,7 +134,6 @@ GEM
       addressable (>= 2.8.0)
       crack (>= 0.3.2)
       hashdiff (>= 0.4.0, < 2.0.0)
-    yard (0.9.36)
 
 PLATFORMS
   universal-java-11
@@ -171,7 +170,6 @@ DEPENDENCIES
   stripe (~> 7)
   warning (~> 1)
   webmock (>= 3.10.0)
-  yard (~> 0.9)
 
 BUNDLED WITH
    2.3.27

--- a/gemfiles/jruby_9.3_stripe_8.gemfile
+++ b/gemfiles/jruby_9.3_stripe_8.gemfile
@@ -25,7 +25,6 @@ gem "simplecov-cobertura", "~> 2.1.0"
 gem "warning", "~> 1"
 gem "webmock", ">= 3.10.0"
 gem "rexml", ">= 3.2.7"
-gem "yard", "~> 0.9"
 gem "rubocop", "~> 1.50.0", require: false
 gem "rubocop-packaging", "~> 0.5.2", require: false
 gem "rubocop-performance", "~> 1.9", require: false

--- a/gemfiles/jruby_9.3_stripe_8.gemfile.lock
+++ b/gemfiles/jruby_9.3_stripe_8.gemfile.lock
@@ -134,7 +134,6 @@ GEM
       addressable (>= 2.8.0)
       crack (>= 0.3.2)
       hashdiff (>= 0.4.0, < 2.0.0)
-    yard (0.9.36)
 
 PLATFORMS
   universal-java-11
@@ -171,7 +170,6 @@ DEPENDENCIES
   stripe (~> 8)
   warning (~> 1)
   webmock (>= 3.10.0)
-  yard (~> 0.9)
 
 BUNDLED WITH
    2.3.27

--- a/gemfiles/jruby_9.3_stripe_9.gemfile
+++ b/gemfiles/jruby_9.3_stripe_9.gemfile
@@ -25,7 +25,6 @@ gem "simplecov-cobertura", "~> 2.1.0"
 gem "warning", "~> 1"
 gem "webmock", ">= 3.10.0"
 gem "rexml", ">= 3.2.7"
-gem "yard", "~> 0.9"
 gem "rubocop", "~> 1.50.0", require: false
 gem "rubocop-packaging", "~> 0.5.2", require: false
 gem "rubocop-performance", "~> 1.9", require: false

--- a/gemfiles/jruby_9.3_stripe_9.gemfile.lock
+++ b/gemfiles/jruby_9.3_stripe_9.gemfile.lock
@@ -134,7 +134,6 @@ GEM
       addressable (>= 2.8.0)
       crack (>= 0.3.2)
       hashdiff (>= 0.4.0, < 2.0.0)
-    yard (0.9.36)
 
 PLATFORMS
   universal-java-11
@@ -171,7 +170,6 @@ DEPENDENCIES
   stripe (~> 9)
   warning (~> 1)
   webmock (>= 3.10.0)
-  yard (~> 0.9)
 
 BUNDLED WITH
    2.3.27

--- a/gemfiles/jruby_9.4_activesupport.gemfile
+++ b/gemfiles/jruby_9.4_activesupport.gemfile
@@ -26,7 +26,6 @@ gem "warning", "~> 1"
 gem "webmock", ">= 3.10.0"
 gem "rexml", ">= 3.2.7"
 gem "webrick", ">= 1.7.0"
-gem "yard", "~> 0.9"
 gem "rubocop", "~> 1.50.0", require: false
 gem "rubocop-packaging", "~> 0.5.2", require: false
 gem "rubocop-performance", "~> 1.9", require: false

--- a/gemfiles/jruby_9.4_activesupport.gemfile.lock
+++ b/gemfiles/jruby_9.4_activesupport.gemfile.lock
@@ -235,7 +235,6 @@ GEM
       crack (>= 0.3.2)
       hashdiff (>= 0.4.0, < 2.0.0)
     webrick (1.8.1)
-    yard (0.9.34)
     zeitwerk (2.6.11)
 
 PLATFORMS
@@ -281,7 +280,6 @@ DEPENDENCIES
   warning (~> 1)
   webmock (>= 3.10.0)
   webrick (>= 1.7.0)
-  yard (~> 0.9)
 
 BUNDLED WITH
    2.3.27

--- a/gemfiles/jruby_9.4_aws.gemfile
+++ b/gemfiles/jruby_9.4_aws.gemfile
@@ -26,7 +26,6 @@ gem "warning", "~> 1"
 gem "webmock", ">= 3.10.0"
 gem "rexml", ">= 3.2.7"
 gem "webrick", ">= 1.7.0"
-gem "yard", "~> 0.9"
 gem "rubocop", "~> 1.50.0", require: false
 gem "rubocop-packaging", "~> 0.5.2", require: false
 gem "rubocop-performance", "~> 1.9", require: false

--- a/gemfiles/jruby_9.4_aws.gemfile.lock
+++ b/gemfiles/jruby_9.4_aws.gemfile.lock
@@ -1556,7 +1556,6 @@ GEM
       crack (>= 0.3.2)
       hashdiff (>= 0.4.0, < 2.0.0)
     webrick (1.8.1)
-    yard (0.9.34)
 
 PLATFORMS
   universal-java-11
@@ -1595,7 +1594,6 @@ DEPENDENCIES
   warning (~> 1)
   webmock (>= 3.10.0)
   webrick (>= 1.7.0)
-  yard (~> 0.9)
 
 BUNDLED WITH
    2.3.27

--- a/gemfiles/jruby_9.4_contrib.gemfile
+++ b/gemfiles/jruby_9.4_contrib.gemfile
@@ -26,7 +26,6 @@ gem "warning", "~> 1"
 gem "webmock", ">= 3.10.0"
 gem "rexml", ">= 3.2.7"
 gem "webrick", ">= 1.7.0"
-gem "yard", "~> 0.9"
 gem "rubocop", "~> 1.50.0", require: false
 gem "rubocop-packaging", "~> 0.5.2", require: false
 gem "rubocop-performance", "~> 1.9", require: false

--- a/gemfiles/jruby_9.4_contrib.gemfile.lock
+++ b/gemfiles/jruby_9.4_contrib.gemfile.lock
@@ -187,8 +187,6 @@ GEM
       crack (>= 0.3.2)
       hashdiff (>= 0.4.0, < 2.0.0)
     webrick (1.7.0)
-    yard (0.9.28)
-      webrick (~> 1.7.0)
 
 PLATFORMS
   universal-java-11
@@ -235,7 +233,6 @@ DEPENDENCIES
   warning (~> 1)
   webmock (>= 3.10.0)
   webrick (>= 1.7.0)
-  yard (~> 0.9)
 
 BUNDLED WITH
    2.3.27

--- a/gemfiles/jruby_9.4_contrib_old.gemfile
+++ b/gemfiles/jruby_9.4_contrib_old.gemfile
@@ -26,7 +26,6 @@ gem "warning", "~> 1"
 gem "webmock", ">= 3.10.0"
 gem "rexml", ">= 3.2.7"
 gem "webrick", ">= 1.7.0"
-gem "yard", "~> 0.9"
 gem "rubocop", "~> 1.50.0", require: false
 gem "rubocop-packaging", "~> 0.5.2", require: false
 gem "rubocop-performance", "~> 1.9", require: false

--- a/gemfiles/jruby_9.4_contrib_old.gemfile.lock
+++ b/gemfiles/jruby_9.4_contrib_old.gemfile.lock
@@ -143,8 +143,6 @@ GEM
       crack (>= 0.3.2)
       hashdiff (>= 0.4.0, < 2.0.0)
     webrick (1.7.0)
-    yard (0.9.28)
-      webrick (~> 1.7.0)
 
 PLATFORMS
   universal-java-11
@@ -185,7 +183,6 @@ DEPENDENCIES
   warning (~> 1)
   webmock (>= 3.10.0)
   webrick (>= 1.7.0)
-  yard (~> 0.9)
 
 BUNDLED WITH
    2.3.27

--- a/gemfiles/jruby_9.4_core_old.gemfile
+++ b/gemfiles/jruby_9.4_core_old.gemfile
@@ -26,7 +26,6 @@ gem "warning", "~> 1"
 gem "webmock", ">= 3.10.0"
 gem "rexml", ">= 3.2.7"
 gem "webrick", ">= 1.7.0"
-gem "yard", "~> 0.9"
 gem "rubocop", "~> 1.50.0", require: false
 gem "rubocop-packaging", "~> 0.5.2", require: false
 gem "rubocop-performance", "~> 1.9", require: false

--- a/gemfiles/jruby_9.4_core_old.gemfile.lock
+++ b/gemfiles/jruby_9.4_core_old.gemfile.lock
@@ -130,8 +130,6 @@ GEM
       crack (>= 0.3.2)
       hashdiff (>= 0.4.0, < 2.0.0)
     webrick (1.7.0)
-    yard (0.9.28)
-      webrick (~> 1.7.0)
 
 PLATFORMS
   universal-java-11
@@ -168,7 +166,6 @@ DEPENDENCIES
   warning (~> 1)
   webmock (>= 3.10.0)
   webrick (>= 1.7.0)
-  yard (~> 0.9)
 
 BUNDLED WITH
    2.3.27

--- a/gemfiles/jruby_9.4_elasticsearch_7.gemfile
+++ b/gemfiles/jruby_9.4_elasticsearch_7.gemfile
@@ -26,7 +26,6 @@ gem "warning", "~> 1"
 gem "webmock", ">= 3.10.0"
 gem "rexml", ">= 3.2.7"
 gem "webrick", ">= 1.7.0"
-gem "yard", "~> 0.9"
 gem "rubocop", "~> 1.50.0", require: false
 gem "rubocop-packaging", "~> 0.5.2", require: false
 gem "rubocop-performance", "~> 1.9", require: false

--- a/gemfiles/jruby_9.4_elasticsearch_7.gemfile.lock
+++ b/gemfiles/jruby_9.4_elasticsearch_7.gemfile.lock
@@ -166,7 +166,6 @@ GEM
       crack (>= 0.3.2)
       hashdiff (>= 0.4.0, < 2.0.0)
     webrick (1.8.1)
-    yard (0.9.34)
 
 PLATFORMS
   universal-java-11
@@ -204,7 +203,6 @@ DEPENDENCIES
   warning (~> 1)
   webmock (>= 3.10.0)
   webrick (>= 1.7.0)
-  yard (~> 0.9)
 
 BUNDLED WITH
    2.3.27

--- a/gemfiles/jruby_9.4_elasticsearch_8.gemfile
+++ b/gemfiles/jruby_9.4_elasticsearch_8.gemfile
@@ -26,7 +26,6 @@ gem "warning", "~> 1"
 gem "webmock", ">= 3.10.0"
 gem "rexml", ">= 3.2.7"
 gem "webrick", ">= 1.7.0"
-gem "yard", "~> 0.9"
 gem "rubocop", "~> 1.50.0", require: false
 gem "rubocop-packaging", "~> 0.5.2", require: false
 gem "rubocop-performance", "~> 1.9", require: false

--- a/gemfiles/jruby_9.4_elasticsearch_8.gemfile.lock
+++ b/gemfiles/jruby_9.4_elasticsearch_8.gemfile.lock
@@ -148,7 +148,6 @@ GEM
       crack (>= 0.3.2)
       hashdiff (>= 0.4.0, < 2.0.0)
     webrick (1.8.1)
-    yard (0.9.34)
 
 PLATFORMS
   universal-java-11
@@ -186,7 +185,6 @@ DEPENDENCIES
   warning (~> 1)
   webmock (>= 3.10.0)
   webrick (>= 1.7.0)
-  yard (~> 0.9)
 
 BUNDLED WITH
    2.3.27

--- a/gemfiles/jruby_9.4_graphql_1.13.gemfile
+++ b/gemfiles/jruby_9.4_graphql_1.13.gemfile
@@ -26,7 +26,6 @@ gem "warning", "~> 1"
 gem "webmock", ">= 3.10.0"
 gem "rexml", ">= 3.2.7"
 gem "webrick", ">= 1.7.0"
-gem "yard", "~> 0.9"
 gem "rubocop", "~> 1.50.0", require: false
 gem "rubocop-packaging", "~> 0.5.2", require: false
 gem "rubocop-performance", "~> 1.9", require: false

--- a/gemfiles/jruby_9.4_graphql_1.13.gemfile.lock
+++ b/gemfiles/jruby_9.4_graphql_1.13.gemfile.lock
@@ -275,7 +275,6 @@ GEM
     websocket-driver (0.7.6-java)
       websocket-extensions (>= 0.1.0)
     websocket-extensions (0.1.5)
-    yard (0.9.34)
     zeitwerk (2.6.16)
 
 PLATFORMS
@@ -317,7 +316,6 @@ DEPENDENCIES
   warning (~> 1)
   webmock (>= 3.10.0)
   webrick (>= 1.7.0)
-  yard (~> 0.9)
 
 BUNDLED WITH
    2.3.27

--- a/gemfiles/jruby_9.4_graphql_2.0.gemfile
+++ b/gemfiles/jruby_9.4_graphql_2.0.gemfile
@@ -26,7 +26,6 @@ gem "warning", "~> 1"
 gem "webmock", ">= 3.10.0"
 gem "rexml", ">= 3.2.7"
 gem "webrick", ">= 1.7.0"
-gem "yard", "~> 0.9"
 gem "rubocop", "~> 1.50.0", require: false
 gem "rubocop-packaging", "~> 0.5.2", require: false
 gem "rubocop-performance", "~> 1.9", require: false

--- a/gemfiles/jruby_9.4_graphql_2.0.gemfile.lock
+++ b/gemfiles/jruby_9.4_graphql_2.0.gemfile.lock
@@ -275,7 +275,6 @@ GEM
     websocket-driver (0.7.6-java)
       websocket-extensions (>= 0.1.0)
     websocket-extensions (0.1.5)
-    yard (0.9.34)
     zeitwerk (2.6.16)
 
 PLATFORMS
@@ -317,7 +316,6 @@ DEPENDENCIES
   warning (~> 1)
   webmock (>= 3.10.0)
   webrick (>= 1.7.0)
-  yard (~> 0.9)
 
 BUNDLED WITH
    2.3.27

--- a/gemfiles/jruby_9.4_graphql_2.1.gemfile
+++ b/gemfiles/jruby_9.4_graphql_2.1.gemfile
@@ -26,7 +26,6 @@ gem "warning", "~> 1"
 gem "webmock", ">= 3.10.0"
 gem "rexml", ">= 3.2.7"
 gem "webrick", ">= 1.7.0"
-gem "yard", "~> 0.9"
 gem "rubocop", "~> 1.50.0", require: false
 gem "rubocop-packaging", "~> 0.5.2", require: false
 gem "rubocop-performance", "~> 1.9", require: false

--- a/gemfiles/jruby_9.4_graphql_2.1.gemfile.lock
+++ b/gemfiles/jruby_9.4_graphql_2.1.gemfile.lock
@@ -276,7 +276,6 @@ GEM
     websocket-driver (0.7.6-java)
       websocket-extensions (>= 0.1.0)
     websocket-extensions (0.1.5)
-    yard (0.9.34)
     zeitwerk (2.6.16)
 
 PLATFORMS
@@ -318,7 +317,6 @@ DEPENDENCIES
   warning (~> 1)
   webmock (>= 3.10.0)
   webrick (>= 1.7.0)
-  yard (~> 0.9)
 
 BUNDLED WITH
    2.3.27

--- a/gemfiles/jruby_9.4_graphql_2.2.gemfile
+++ b/gemfiles/jruby_9.4_graphql_2.2.gemfile
@@ -26,7 +26,6 @@ gem "warning", "~> 1"
 gem "webmock", ">= 3.10.0"
 gem "rexml", ">= 3.2.7"
 gem "webrick", ">= 1.7.0"
-gem "yard", "~> 0.9"
 gem "rubocop", "~> 1.50.0", require: false
 gem "rubocop-packaging", "~> 0.5.2", require: false
 gem "rubocop-performance", "~> 1.9", require: false

--- a/gemfiles/jruby_9.4_graphql_2.2.gemfile.lock
+++ b/gemfiles/jruby_9.4_graphql_2.2.gemfile.lock
@@ -276,7 +276,6 @@ GEM
     websocket-driver (0.7.6-java)
       websocket-extensions (>= 0.1.0)
     websocket-extensions (0.1.5)
-    yard (0.9.34)
     zeitwerk (2.6.16)
 
 PLATFORMS
@@ -318,7 +317,6 @@ DEPENDENCIES
   warning (~> 1)
   webmock (>= 3.10.0)
   webrick (>= 1.7.0)
-  yard (~> 0.9)
 
 BUNDLED WITH
    2.3.27

--- a/gemfiles/jruby_9.4_graphql_2.3.gemfile
+++ b/gemfiles/jruby_9.4_graphql_2.3.gemfile
@@ -26,7 +26,6 @@ gem "warning", "~> 1"
 gem "webmock", ">= 3.10.0"
 gem "rexml", ">= 3.2.7"
 gem "webrick", ">= 1.7.0"
-gem "yard", "~> 0.9"
 gem "rubocop", "~> 1.50.0", require: false
 gem "rubocop-packaging", "~> 0.5.2", require: false
 gem "rubocop-performance", "~> 1.9", require: false

--- a/gemfiles/jruby_9.4_graphql_2.3.gemfile.lock
+++ b/gemfiles/jruby_9.4_graphql_2.3.gemfile.lock
@@ -278,7 +278,6 @@ GEM
     websocket-driver (0.7.6-java)
       websocket-extensions (>= 0.1.0)
     websocket-extensions (0.1.5)
-    yard (0.9.36)
     zeitwerk (2.6.16)
 
 PLATFORMS
@@ -320,7 +319,6 @@ DEPENDENCIES
   warning (~> 1)
   webmock (>= 3.10.0)
   webrick (>= 1.7.0)
-  yard (~> 0.9)
 
 BUNDLED WITH
    2.3.27

--- a/gemfiles/jruby_9.4_http.gemfile
+++ b/gemfiles/jruby_9.4_http.gemfile
@@ -26,7 +26,6 @@ gem "warning", "~> 1"
 gem "webmock", ">= 3.10.0"
 gem "rexml", ">= 3.2.7"
 gem "webrick", ">= 1.7.0"
-gem "yard", "~> 0.9"
 gem "rubocop", "~> 1.50.0", require: false
 gem "rubocop-packaging", "~> 0.5.2", require: false
 gem "rubocop-performance", "~> 1.9", require: false

--- a/gemfiles/jruby_9.4_http.gemfile.lock
+++ b/gemfiles/jruby_9.4_http.gemfile.lock
@@ -167,7 +167,6 @@ GEM
       crack (>= 0.3.2)
       hashdiff (>= 0.4.0, < 2.0.0)
     webrick (1.8.1)
-    yard (0.9.34)
 
 PLATFORMS
   universal-java-11
@@ -211,7 +210,6 @@ DEPENDENCIES
   warning (~> 1)
   webmock (>= 3.10.0)
   webrick (>= 1.7.0)
-  yard (~> 0.9)
 
 BUNDLED WITH
    2.3.27

--- a/gemfiles/jruby_9.4_opensearch_2.gemfile
+++ b/gemfiles/jruby_9.4_opensearch_2.gemfile
@@ -26,7 +26,6 @@ gem "warning", "~> 1"
 gem "webmock", ">= 3.10.0"
 gem "rexml", ">= 3.2.7"
 gem "webrick", ">= 1.7.0"
-gem "yard", "~> 0.9"
 gem "rubocop", "~> 1.50.0", require: false
 gem "rubocop-packaging", "~> 0.5.2", require: false
 gem "rubocop-performance", "~> 1.9", require: false

--- a/gemfiles/jruby_9.4_opensearch_2.gemfile.lock
+++ b/gemfiles/jruby_9.4_opensearch_2.gemfile.lock
@@ -148,7 +148,6 @@ GEM
       crack (>= 0.3.2)
       hashdiff (>= 0.4.0, < 2.0.0)
     webrick (1.8.1)
-    yard (0.9.34)
 
 PLATFORMS
   universal-java-11
@@ -186,7 +185,6 @@ DEPENDENCIES
   warning (~> 1)
   webmock (>= 3.10.0)
   webrick (>= 1.7.0)
-  yard (~> 0.9)
 
 BUNDLED WITH
    2.3.27

--- a/gemfiles/jruby_9.4_opensearch_3.gemfile
+++ b/gemfiles/jruby_9.4_opensearch_3.gemfile
@@ -26,7 +26,6 @@ gem "warning", "~> 1"
 gem "webmock", ">= 3.10.0"
 gem "rexml", ">= 3.2.7"
 gem "webrick", ">= 1.7.0"
-gem "yard", "~> 0.9"
 gem "rubocop", "~> 1.50.0", require: false
 gem "rubocop-packaging", "~> 0.5.2", require: false
 gem "rubocop-performance", "~> 1.9", require: false

--- a/gemfiles/jruby_9.4_opensearch_3.gemfile.lock
+++ b/gemfiles/jruby_9.4_opensearch_3.gemfile.lock
@@ -143,7 +143,6 @@ GEM
       crack (>= 0.3.2)
       hashdiff (>= 0.4.0, < 2.0.0)
     webrick (1.8.1)
-    yard (0.9.34)
 
 PLATFORMS
   universal-java-11
@@ -181,7 +180,6 @@ DEPENDENCIES
   warning (~> 1)
   webmock (>= 3.10.0)
   webrick (>= 1.7.0)
-  yard (~> 0.9)
 
 BUNDLED WITH
    2.3.27

--- a/gemfiles/jruby_9.4_rack_1.gemfile
+++ b/gemfiles/jruby_9.4_rack_1.gemfile
@@ -26,7 +26,6 @@ gem "warning", "~> 1"
 gem "webmock", ">= 3.10.0"
 gem "rexml", ">= 3.2.7"
 gem "webrick", ">= 1.7.0"
-gem "yard", "~> 0.9"
 gem "rubocop", "~> 1.50.0", require: false
 gem "rubocop-packaging", "~> 0.5.2", require: false
 gem "rubocop-performance", "~> 1.9", require: false

--- a/gemfiles/jruby_9.4_rack_1.gemfile.lock
+++ b/gemfiles/jruby_9.4_rack_1.gemfile.lock
@@ -135,7 +135,6 @@ GEM
       crack (>= 0.3.2)
       hashdiff (>= 0.4.0, < 2.0.0)
     webrick (1.8.1)
-    yard (0.9.34)
 
 PLATFORMS
   universal-java-11
@@ -175,7 +174,6 @@ DEPENDENCIES
   warning (~> 1)
   webmock (>= 3.10.0)
   webrick (>= 1.7.0)
-  yard (~> 0.9)
 
 BUNDLED WITH
    2.3.27

--- a/gemfiles/jruby_9.4_rack_2.gemfile
+++ b/gemfiles/jruby_9.4_rack_2.gemfile
@@ -26,7 +26,6 @@ gem "warning", "~> 1"
 gem "webmock", ">= 3.10.0"
 gem "rexml", ">= 3.2.7"
 gem "webrick", ">= 1.7.0"
-gem "yard", "~> 0.9"
 gem "rubocop", "~> 1.50.0", require: false
 gem "rubocop-packaging", "~> 0.5.2", require: false
 gem "rubocop-performance", "~> 1.9", require: false

--- a/gemfiles/jruby_9.4_rack_2.gemfile.lock
+++ b/gemfiles/jruby_9.4_rack_2.gemfile.lock
@@ -135,7 +135,6 @@ GEM
       crack (>= 0.3.2)
       hashdiff (>= 0.4.0, < 2.0.0)
     webrick (1.8.1)
-    yard (0.9.34)
 
 PLATFORMS
   universal-java-11
@@ -175,7 +174,6 @@ DEPENDENCIES
   warning (~> 1)
   webmock (>= 3.10.0)
   webrick (>= 1.7.0)
-  yard (~> 0.9)
 
 BUNDLED WITH
    2.3.27

--- a/gemfiles/jruby_9.4_rack_3.gemfile
+++ b/gemfiles/jruby_9.4_rack_3.gemfile
@@ -26,7 +26,6 @@ gem "warning", "~> 1"
 gem "webmock", ">= 3.10.0"
 gem "rexml", ">= 3.2.7"
 gem "webrick", ">= 1.7.0"
-gem "yard", "~> 0.9"
 gem "rubocop", "~> 1.50.0", require: false
 gem "rubocop-packaging", "~> 0.5.2", require: false
 gem "rubocop-performance", "~> 1.9", require: false

--- a/gemfiles/jruby_9.4_rack_3.gemfile.lock
+++ b/gemfiles/jruby_9.4_rack_3.gemfile.lock
@@ -135,7 +135,6 @@ GEM
       crack (>= 0.3.2)
       hashdiff (>= 0.4.0, < 2.0.0)
     webrick (1.8.1)
-    yard (0.9.34)
 
 PLATFORMS
   universal-java-11
@@ -175,7 +174,6 @@ DEPENDENCIES
   warning (~> 1)
   webmock (>= 3.10.0)
   webrick (>= 1.7.0)
-  yard (~> 0.9)
 
 BUNDLED WITH
    2.3.27

--- a/gemfiles/jruby_9.4_rails61_mysql2.gemfile
+++ b/gemfiles/jruby_9.4_rails61_mysql2.gemfile
@@ -26,7 +26,6 @@ gem "warning", "~> 1"
 gem "webmock", ">= 3.10.0"
 gem "rexml", ">= 3.2.7"
 gem "webrick", ">= 1.7.0"
-gem "yard", "~> 0.9"
 gem "rubocop", "~> 1.50.0", require: false
 gem "rubocop-packaging", "~> 0.5.2", require: false
 gem "rubocop-performance", "~> 1.9", require: false

--- a/gemfiles/jruby_9.4_rails61_mysql2.gemfile.lock
+++ b/gemfiles/jruby_9.4_rails61_mysql2.gemfile.lock
@@ -282,7 +282,6 @@ GEM
     websocket-driver (0.7.6-java)
       websocket-extensions (>= 0.1.0)
     websocket-extensions (0.1.5)
-    yard (0.9.36)
     zeitwerk (2.6.16)
 
 PLATFORMS
@@ -325,7 +324,6 @@ DEPENDENCIES
   warning (~> 1)
   webmock (>= 3.10.0)
   webrick (>= 1.7.0)
-  yard (~> 0.9)
 
 BUNDLED WITH
    2.3.27

--- a/gemfiles/jruby_9.4_rails61_postgres.gemfile
+++ b/gemfiles/jruby_9.4_rails61_postgres.gemfile
@@ -26,7 +26,6 @@ gem "warning", "~> 1"
 gem "webmock", ">= 3.10.0"
 gem "rexml", ">= 3.2.7"
 gem "webrick", ">= 1.7.0"
-gem "yard", "~> 0.9"
 gem "rubocop", "~> 1.50.0", require: false
 gem "rubocop-packaging", "~> 0.5.2", require: false
 gem "rubocop-performance", "~> 1.9", require: false

--- a/gemfiles/jruby_9.4_rails61_postgres.gemfile.lock
+++ b/gemfiles/jruby_9.4_rails61_postgres.gemfile.lock
@@ -274,8 +274,6 @@ GEM
     websocket-driver (0.7.5-java)
       websocket-extensions (>= 0.1.0)
     websocket-extensions (0.1.5)
-    yard (0.9.28)
-      webrick (~> 1.7.0)
     zeitwerk (2.6.6)
 
 PLATFORMS
@@ -318,7 +316,6 @@ DEPENDENCIES
   warning (~> 1)
   webmock (>= 3.10.0)
   webrick (>= 1.7.0)
-  yard (~> 0.9)
 
 BUNDLED WITH
    2.3.27

--- a/gemfiles/jruby_9.4_rails61_postgres_redis.gemfile
+++ b/gemfiles/jruby_9.4_rails61_postgres_redis.gemfile
@@ -26,7 +26,6 @@ gem "warning", "~> 1"
 gem "webmock", ">= 3.10.0"
 gem "rexml", ">= 3.2.7"
 gem "webrick", ">= 1.7.0"
-gem "yard", "~> 0.9"
 gem "rubocop", "~> 1.50.0", require: false
 gem "rubocop-packaging", "~> 0.5.2", require: false
 gem "rubocop-performance", "~> 1.9", require: false

--- a/gemfiles/jruby_9.4_rails61_postgres_redis.gemfile.lock
+++ b/gemfiles/jruby_9.4_rails61_postgres_redis.gemfile.lock
@@ -275,8 +275,6 @@ GEM
     websocket-driver (0.7.5-java)
       websocket-extensions (>= 0.1.0)
     websocket-extensions (0.1.5)
-    yard (0.9.28)
-      webrick (~> 1.7.0)
     zeitwerk (2.6.6)
 
 PLATFORMS
@@ -320,7 +318,6 @@ DEPENDENCIES
   warning (~> 1)
   webmock (>= 3.10.0)
   webrick (>= 1.7.0)
-  yard (~> 0.9)
 
 BUNDLED WITH
    2.3.27

--- a/gemfiles/jruby_9.4_rails61_postgres_sidekiq.gemfile
+++ b/gemfiles/jruby_9.4_rails61_postgres_sidekiq.gemfile
@@ -26,7 +26,6 @@ gem "warning", "~> 1"
 gem "webmock", ">= 3.10.0"
 gem "rexml", ">= 3.2.7"
 gem "webrick", ">= 1.7.0"
-gem "yard", "~> 0.9"
 gem "rubocop", "~> 1.50.0", require: false
 gem "rubocop-packaging", "~> 0.5.2", require: false
 gem "rubocop-performance", "~> 1.9", require: false

--- a/gemfiles/jruby_9.4_rails61_postgres_sidekiq.gemfile.lock
+++ b/gemfiles/jruby_9.4_rails61_postgres_sidekiq.gemfile.lock
@@ -288,8 +288,6 @@ GEM
     websocket-driver (0.7.5-java)
       websocket-extensions (>= 0.1.0)
     websocket-extensions (0.1.5)
-    yard (0.9.28)
-      webrick (~> 1.7.0)
     zeitwerk (2.6.6)
 
 PLATFORMS
@@ -334,7 +332,6 @@ DEPENDENCIES
   warning (~> 1)
   webmock (>= 3.10.0)
   webrick (>= 1.7.0)
-  yard (~> 0.9)
 
 BUNDLED WITH
    2.3.27

--- a/gemfiles/jruby_9.4_rails61_semantic_logger.gemfile
+++ b/gemfiles/jruby_9.4_rails61_semantic_logger.gemfile
@@ -26,7 +26,6 @@ gem "warning", "~> 1"
 gem "webmock", ">= 3.10.0"
 gem "rexml", ">= 3.2.7"
 gem "webrick", ">= 1.7.0"
-gem "yard", "~> 0.9"
 gem "rubocop", "~> 1.50.0", require: false
 gem "rubocop-packaging", "~> 0.5.2", require: false
 gem "rubocop-performance", "~> 1.9", require: false

--- a/gemfiles/jruby_9.4_rails61_semantic_logger.gemfile.lock
+++ b/gemfiles/jruby_9.4_rails61_semantic_logger.gemfile.lock
@@ -273,8 +273,6 @@ GEM
     websocket-driver (0.7.5-java)
       websocket-extensions (>= 0.1.0)
     websocket-extensions (0.1.5)
-    yard (0.9.28)
-      webrick (~> 1.7.0)
     zeitwerk (2.6.6)
 
 PLATFORMS
@@ -317,7 +315,6 @@ DEPENDENCIES
   warning (~> 1)
   webmock (>= 3.10.0)
   webrick (>= 1.7.0)
-  yard (~> 0.9)
 
 BUNDLED WITH
    2.3.27

--- a/gemfiles/jruby_9.4_redis_3.gemfile
+++ b/gemfiles/jruby_9.4_redis_3.gemfile
@@ -26,7 +26,6 @@ gem "warning", "~> 1"
 gem "webmock", ">= 3.10.0"
 gem "rexml", ">= 3.2.7"
 gem "webrick", ">= 1.7.0"
-gem "yard", "~> 0.9"
 gem "rubocop", "~> 1.50.0", require: false
 gem "rubocop-packaging", "~> 0.5.2", require: false
 gem "rubocop-performance", "~> 1.9", require: false

--- a/gemfiles/jruby_9.4_redis_3.gemfile.lock
+++ b/gemfiles/jruby_9.4_redis_3.gemfile.lock
@@ -131,8 +131,6 @@ GEM
       crack (>= 0.3.2)
       hashdiff (>= 0.4.0, < 2.0.0)
     webrick (1.7.0)
-    yard (0.9.28)
-      webrick (~> 1.7.0)
 
 PLATFORMS
   universal-java-11
@@ -170,7 +168,6 @@ DEPENDENCIES
   warning (~> 1)
   webmock (>= 3.10.0)
   webrick (>= 1.7.0)
-  yard (~> 0.9)
 
 BUNDLED WITH
    2.3.27

--- a/gemfiles/jruby_9.4_redis_4.gemfile
+++ b/gemfiles/jruby_9.4_redis_4.gemfile
@@ -26,7 +26,6 @@ gem "warning", "~> 1"
 gem "webmock", ">= 3.10.0"
 gem "rexml", ">= 3.2.7"
 gem "webrick", ">= 1.7.0"
-gem "yard", "~> 0.9"
 gem "rubocop", "~> 1.50.0", require: false
 gem "rubocop-packaging", "~> 0.5.2", require: false
 gem "rubocop-performance", "~> 1.9", require: false

--- a/gemfiles/jruby_9.4_redis_4.gemfile.lock
+++ b/gemfiles/jruby_9.4_redis_4.gemfile.lock
@@ -131,8 +131,6 @@ GEM
       crack (>= 0.3.2)
       hashdiff (>= 0.4.0, < 2.0.0)
     webrick (1.7.0)
-    yard (0.9.28)
-      webrick (~> 1.7.0)
 
 PLATFORMS
   universal-java-11
@@ -170,7 +168,6 @@ DEPENDENCIES
   warning (~> 1)
   webmock (>= 3.10.0)
   webrick (>= 1.7.0)
-  yard (~> 0.9)
 
 BUNDLED WITH
    2.3.27

--- a/gemfiles/jruby_9.4_redis_5.gemfile
+++ b/gemfiles/jruby_9.4_redis_5.gemfile
@@ -26,7 +26,6 @@ gem "warning", "~> 1"
 gem "webmock", ">= 3.10.0"
 gem "rexml", ">= 3.2.7"
 gem "webrick", ">= 1.7.0"
-gem "yard", "~> 0.9"
 gem "rubocop", "~> 1.50.0", require: false
 gem "rubocop-packaging", "~> 0.5.2", require: false
 gem "rubocop-performance", "~> 1.9", require: false

--- a/gemfiles/jruby_9.4_redis_5.gemfile.lock
+++ b/gemfiles/jruby_9.4_redis_5.gemfile.lock
@@ -135,8 +135,6 @@ GEM
       crack (>= 0.3.2)
       hashdiff (>= 0.4.0, < 2.0.0)
     webrick (1.7.0)
-    yard (0.9.28)
-      webrick (~> 1.7.0)
 
 PLATFORMS
   universal-java-11
@@ -174,7 +172,6 @@ DEPENDENCIES
   warning (~> 1)
   webmock (>= 3.10.0)
   webrick (>= 1.7.0)
-  yard (~> 0.9)
 
 BUNDLED WITH
    2.3.27

--- a/gemfiles/jruby_9.4_relational_db.gemfile
+++ b/gemfiles/jruby_9.4_relational_db.gemfile
@@ -26,7 +26,6 @@ gem "warning", "~> 1"
 gem "webmock", ">= 3.10.0"
 gem "rexml", ">= 3.2.7"
 gem "webrick", ">= 1.7.0"
-gem "yard", "~> 0.9"
 gem "rubocop", "~> 1.50.0", require: false
 gem "rubocop-packaging", "~> 0.5.2", require: false
 gem "rubocop-performance", "~> 1.9", require: false

--- a/gemfiles/jruby_9.4_relational_db.gemfile.lock
+++ b/gemfiles/jruby_9.4_relational_db.gemfile.lock
@@ -170,7 +170,6 @@ GEM
       crack (>= 0.3.2)
       hashdiff (>= 0.4.0, < 2.0.0)
     webrick (1.8.1)
-    yard (0.9.36)
     zeitwerk (2.6.16)
 
 PLATFORMS
@@ -216,7 +215,6 @@ DEPENDENCIES
   warning (~> 1)
   webmock (>= 3.10.0)
   webrick (>= 1.7.0)
-  yard (~> 0.9)
 
 BUNDLED WITH
    2.3.27

--- a/gemfiles/jruby_9.4_resque2_redis3.gemfile
+++ b/gemfiles/jruby_9.4_resque2_redis3.gemfile
@@ -26,7 +26,6 @@ gem "warning", "~> 1"
 gem "webmock", ">= 3.10.0"
 gem "rexml", ">= 3.2.7"
 gem "webrick", ">= 1.7.0"
-gem "yard", "~> 0.9"
 gem "rubocop", "~> 1.50.0", require: false
 gem "rubocop-packaging", "~> 0.5.2", require: false
 gem "rubocop-performance", "~> 1.9", require: false

--- a/gemfiles/jruby_9.4_resque2_redis3.gemfile.lock
+++ b/gemfiles/jruby_9.4_resque2_redis3.gemfile.lock
@@ -152,8 +152,6 @@ GEM
       crack (>= 0.3.2)
       hashdiff (>= 0.4.0, < 2.0.0)
     webrick (1.7.0)
-    yard (0.9.28)
-      webrick (~> 1.7.0)
 
 PLATFORMS
   universal-java-11
@@ -192,7 +190,6 @@ DEPENDENCIES
   warning (~> 1)
   webmock (>= 3.10.0)
   webrick (>= 1.7.0)
-  yard (~> 0.9)
 
 BUNDLED WITH
    2.3.27

--- a/gemfiles/jruby_9.4_resque2_redis4.gemfile
+++ b/gemfiles/jruby_9.4_resque2_redis4.gemfile
@@ -26,7 +26,6 @@ gem "warning", "~> 1"
 gem "webmock", ">= 3.10.0"
 gem "rexml", ">= 3.2.7"
 gem "webrick", ">= 1.7.0"
-gem "yard", "~> 0.9"
 gem "rubocop", "~> 1.50.0", require: false
 gem "rubocop-packaging", "~> 0.5.2", require: false
 gem "rubocop-performance", "~> 1.9", require: false

--- a/gemfiles/jruby_9.4_resque2_redis4.gemfile.lock
+++ b/gemfiles/jruby_9.4_resque2_redis4.gemfile.lock
@@ -156,8 +156,6 @@ GEM
       crack (>= 0.3.2)
       hashdiff (>= 0.4.0, < 2.0.0)
     webrick (1.7.0)
-    yard (0.9.28)
-      webrick (~> 1.7.0)
 
 PLATFORMS
   universal-java-11
@@ -196,7 +194,6 @@ DEPENDENCIES
   warning (~> 1)
   webmock (>= 3.10.0)
   webrick (>= 1.7.0)
-  yard (~> 0.9)
 
 BUNDLED WITH
    2.3.27

--- a/gemfiles/jruby_9.4_sinatra_2.gemfile
+++ b/gemfiles/jruby_9.4_sinatra_2.gemfile
@@ -26,7 +26,6 @@ gem "warning", "~> 1"
 gem "webmock", ">= 3.10.0"
 gem "rexml", ">= 3.2.7"
 gem "webrick", ">= 1.7.0"
-gem "yard", "~> 0.9"
 gem "rubocop", "~> 1.50.0", require: false
 gem "rubocop-packaging", "~> 0.5.2", require: false
 gem "rubocop-performance", "~> 1.9", require: false

--- a/gemfiles/jruby_9.4_sinatra_2.gemfile.lock
+++ b/gemfiles/jruby_9.4_sinatra_2.gemfile.lock
@@ -150,7 +150,6 @@ GEM
       crack (>= 0.3.2)
       hashdiff (>= 0.4.0, < 2.0.0)
     webrick (1.8.1)
-    yard (0.9.36)
 
 PLATFORMS
   universal-java-11
@@ -190,7 +189,6 @@ DEPENDENCIES
   warning (~> 1)
   webmock (>= 3.10.0)
   webrick (>= 1.7.0)
-  yard (~> 0.9)
 
 BUNDLED WITH
    2.3.27

--- a/gemfiles/jruby_9.4_sinatra_3.gemfile
+++ b/gemfiles/jruby_9.4_sinatra_3.gemfile
@@ -26,7 +26,6 @@ gem "warning", "~> 1"
 gem "webmock", ">= 3.10.0"
 gem "rexml", ">= 3.2.7"
 gem "webrick", ">= 1.7.0"
-gem "yard", "~> 0.9"
 gem "rubocop", "~> 1.50.0", require: false
 gem "rubocop-packaging", "~> 0.5.2", require: false
 gem "rubocop-performance", "~> 1.9", require: false

--- a/gemfiles/jruby_9.4_sinatra_3.gemfile.lock
+++ b/gemfiles/jruby_9.4_sinatra_3.gemfile.lock
@@ -152,7 +152,6 @@ GEM
       crack (>= 0.3.2)
       hashdiff (>= 0.4.0, < 2.0.0)
     webrick (1.8.1)
-    yard (0.9.36)
 
 PLATFORMS
   universal-java-11
@@ -192,7 +191,6 @@ DEPENDENCIES
   warning (~> 1)
   webmock (>= 3.10.0)
   webrick (>= 1.7.0)
-  yard (~> 0.9)
 
 BUNDLED WITH
    2.3.27

--- a/gemfiles/jruby_9.4_sinatra_4.gemfile
+++ b/gemfiles/jruby_9.4_sinatra_4.gemfile
@@ -26,7 +26,6 @@ gem "warning", "~> 1"
 gem "webmock", ">= 3.10.0"
 gem "rexml", ">= 3.2.7"
 gem "webrick", ">= 1.7.0"
-gem "yard", "~> 0.9"
 gem "rubocop", "~> 1.50.0", require: false
 gem "rubocop-packaging", "~> 0.5.2", require: false
 gem "rubocop-performance", "~> 1.9", require: false

--- a/gemfiles/jruby_9.4_sinatra_4.gemfile.lock
+++ b/gemfiles/jruby_9.4_sinatra_4.gemfile.lock
@@ -155,7 +155,6 @@ GEM
       crack (>= 0.3.2)
       hashdiff (>= 0.4.0, < 2.0.0)
     webrick (1.8.1)
-    yard (0.9.36)
 
 PLATFORMS
   universal-java-11
@@ -195,7 +194,6 @@ DEPENDENCIES
   warning (~> 1)
   webmock (>= 3.10.0)
   webrick (>= 1.7.0)
-  yard (~> 0.9)
 
 BUNDLED WITH
    2.3.27

--- a/gemfiles/jruby_9.4_stripe_10.gemfile
+++ b/gemfiles/jruby_9.4_stripe_10.gemfile
@@ -26,7 +26,6 @@ gem "warning", "~> 1"
 gem "webmock", ">= 3.10.0"
 gem "rexml", ">= 3.2.7"
 gem "webrick", ">= 1.7.0"
-gem "yard", "~> 0.9"
 gem "rubocop", "~> 1.50.0", require: false
 gem "rubocop-packaging", "~> 0.5.2", require: false
 gem "rubocop-performance", "~> 1.9", require: false

--- a/gemfiles/jruby_9.4_stripe_10.gemfile.lock
+++ b/gemfiles/jruby_9.4_stripe_10.gemfile.lock
@@ -135,7 +135,6 @@ GEM
       crack (>= 0.3.2)
       hashdiff (>= 0.4.0, < 2.0.0)
     webrick (1.8.1)
-    yard (0.9.36)
 
 PLATFORMS
   universal-java-11
@@ -173,7 +172,6 @@ DEPENDENCIES
   warning (~> 1)
   webmock (>= 3.10.0)
   webrick (>= 1.7.0)
-  yard (~> 0.9)
 
 BUNDLED WITH
    2.3.27

--- a/gemfiles/jruby_9.4_stripe_11.gemfile
+++ b/gemfiles/jruby_9.4_stripe_11.gemfile
@@ -26,7 +26,6 @@ gem "warning", "~> 1"
 gem "webmock", ">= 3.10.0"
 gem "rexml", ">= 3.2.7"
 gem "webrick", ">= 1.7.0"
-gem "yard", "~> 0.9"
 gem "rubocop", "~> 1.50.0", require: false
 gem "rubocop-packaging", "~> 0.5.2", require: false
 gem "rubocop-performance", "~> 1.9", require: false

--- a/gemfiles/jruby_9.4_stripe_11.gemfile.lock
+++ b/gemfiles/jruby_9.4_stripe_11.gemfile.lock
@@ -135,7 +135,6 @@ GEM
       crack (>= 0.3.2)
       hashdiff (>= 0.4.0, < 2.0.0)
     webrick (1.8.1)
-    yard (0.9.36)
 
 PLATFORMS
   universal-java-11
@@ -173,7 +172,6 @@ DEPENDENCIES
   warning (~> 1)
   webmock (>= 3.10.0)
   webrick (>= 1.7.0)
-  yard (~> 0.9)
 
 BUNDLED WITH
    2.3.27

--- a/gemfiles/jruby_9.4_stripe_12.gemfile
+++ b/gemfiles/jruby_9.4_stripe_12.gemfile
@@ -26,7 +26,6 @@ gem "warning", "~> 1"
 gem "webmock", ">= 3.10.0"
 gem "rexml", ">= 3.2.7"
 gem "webrick", ">= 1.7.0"
-gem "yard", "~> 0.9"
 gem "rubocop", "~> 1.50.0", require: false
 gem "rubocop-packaging", "~> 0.5.2", require: false
 gem "rubocop-performance", "~> 1.9", require: false

--- a/gemfiles/jruby_9.4_stripe_12.gemfile.lock
+++ b/gemfiles/jruby_9.4_stripe_12.gemfile.lock
@@ -135,7 +135,6 @@ GEM
       crack (>= 0.3.2)
       hashdiff (>= 0.4.0, < 2.0.0)
     webrick (1.8.1)
-    yard (0.9.36)
 
 PLATFORMS
   universal-java-11
@@ -173,7 +172,6 @@ DEPENDENCIES
   warning (~> 1)
   webmock (>= 3.10.0)
   webrick (>= 1.7.0)
-  yard (~> 0.9)
 
 BUNDLED WITH
    2.3.27

--- a/gemfiles/jruby_9.4_stripe_7.gemfile
+++ b/gemfiles/jruby_9.4_stripe_7.gemfile
@@ -26,7 +26,6 @@ gem "warning", "~> 1"
 gem "webmock", ">= 3.10.0"
 gem "rexml", ">= 3.2.7"
 gem "webrick", ">= 1.7.0"
-gem "yard", "~> 0.9"
 gem "rubocop", "~> 1.50.0", require: false
 gem "rubocop-packaging", "~> 0.5.2", require: false
 gem "rubocop-performance", "~> 1.9", require: false

--- a/gemfiles/jruby_9.4_stripe_7.gemfile.lock
+++ b/gemfiles/jruby_9.4_stripe_7.gemfile.lock
@@ -135,7 +135,6 @@ GEM
       crack (>= 0.3.2)
       hashdiff (>= 0.4.0, < 2.0.0)
     webrick (1.8.1)
-    yard (0.9.36)
 
 PLATFORMS
   universal-java-11
@@ -173,7 +172,6 @@ DEPENDENCIES
   warning (~> 1)
   webmock (>= 3.10.0)
   webrick (>= 1.7.0)
-  yard (~> 0.9)
 
 BUNDLED WITH
    2.3.27

--- a/gemfiles/jruby_9.4_stripe_8.gemfile
+++ b/gemfiles/jruby_9.4_stripe_8.gemfile
@@ -26,7 +26,6 @@ gem "warning", "~> 1"
 gem "webmock", ">= 3.10.0"
 gem "rexml", ">= 3.2.7"
 gem "webrick", ">= 1.7.0"
-gem "yard", "~> 0.9"
 gem "rubocop", "~> 1.50.0", require: false
 gem "rubocop-packaging", "~> 0.5.2", require: false
 gem "rubocop-performance", "~> 1.9", require: false

--- a/gemfiles/jruby_9.4_stripe_8.gemfile.lock
+++ b/gemfiles/jruby_9.4_stripe_8.gemfile.lock
@@ -135,7 +135,6 @@ GEM
       crack (>= 0.3.2)
       hashdiff (>= 0.4.0, < 2.0.0)
     webrick (1.8.1)
-    yard (0.9.36)
 
 PLATFORMS
   universal-java-11
@@ -173,7 +172,6 @@ DEPENDENCIES
   warning (~> 1)
   webmock (>= 3.10.0)
   webrick (>= 1.7.0)
-  yard (~> 0.9)
 
 BUNDLED WITH
    2.3.27

--- a/gemfiles/jruby_9.4_stripe_9.gemfile
+++ b/gemfiles/jruby_9.4_stripe_9.gemfile
@@ -26,7 +26,6 @@ gem "warning", "~> 1"
 gem "webmock", ">= 3.10.0"
 gem "rexml", ">= 3.2.7"
 gem "webrick", ">= 1.7.0"
-gem "yard", "~> 0.9"
 gem "rubocop", "~> 1.50.0", require: false
 gem "rubocop-packaging", "~> 0.5.2", require: false
 gem "rubocop-performance", "~> 1.9", require: false

--- a/gemfiles/jruby_9.4_stripe_9.gemfile.lock
+++ b/gemfiles/jruby_9.4_stripe_9.gemfile.lock
@@ -135,7 +135,6 @@ GEM
       crack (>= 0.3.2)
       hashdiff (>= 0.4.0, < 2.0.0)
     webrick (1.8.1)
-    yard (0.9.36)
 
 PLATFORMS
   universal-java-11
@@ -173,7 +172,6 @@ DEPENDENCIES
   warning (~> 1)
   webmock (>= 3.10.0)
   webrick (>= 1.7.0)
-  yard (~> 0.9)
 
 BUNDLED WITH
    2.3.27

--- a/gemfiles/ruby_2.5_activesupport.gemfile
+++ b/gemfiles/ruby_2.5_activesupport.gemfile
@@ -27,7 +27,6 @@ gem "simplecov-cobertura", "~> 2.1.0"
 gem "warning", "~> 1"
 gem "webmock", ">= 3.10.0"
 gem "rexml", ">= 3.2.7"
-gem "yard", "~> 0.9"
 gem "dogstatsd-ruby", ">= 3.3.0", "!= 5.0.0", "!= 5.0.1", "!= 5.1.0"
 gem "google-protobuf", ["~> 3.0", "!= 3.7.0", "!= 3.7.1", "< 3.19.2"]
 gem "ffi", "~> 1.16.3", require: false

--- a/gemfiles/ruby_2.5_activesupport.gemfile.lock
+++ b/gemfiles/ruby_2.5_activesupport.gemfile.lock
@@ -215,7 +215,6 @@ GEM
       addressable (>= 2.3.6)
       crack (>= 0.3.2)
       hashdiff (>= 0.4.0, < 2.0.0)
-    yard (0.9.34)
 
 PLATFORMS
   aarch64-linux
@@ -259,7 +258,6 @@ DEPENDENCIES
   simplecov-cobertura (~> 2.1.0)
   warning (~> 1)
   webmock (>= 3.10.0)
-  yard (~> 0.9)
 
 BUNDLED WITH
    2.3.26

--- a/gemfiles/ruby_2.5_aws.gemfile
+++ b/gemfiles/ruby_2.5_aws.gemfile
@@ -27,7 +27,6 @@ gem "simplecov-cobertura", "~> 2.1.0"
 gem "warning", "~> 1"
 gem "webmock", ">= 3.10.0"
 gem "rexml", ">= 3.2.7"
-gem "yard", "~> 0.9"
 gem "dogstatsd-ruby", ">= 3.3.0", "!= 5.0.0", "!= 5.0.1", "!= 5.1.0"
 gem "google-protobuf", ["~> 3.0", "!= 3.7.0", "!= 3.7.1", "< 3.19.2"]
 gem "ffi", "~> 1.16.3", require: false

--- a/gemfiles/ruby_2.5_aws.gemfile.lock
+++ b/gemfiles/ruby_2.5_aws.gemfile.lock
@@ -1529,7 +1529,6 @@ GEM
       addressable (>= 2.3.6)
       crack (>= 0.3.2)
       hashdiff (>= 0.4.0, < 2.0.0)
-    yard (0.9.34)
 
 PLATFORMS
   aarch64-linux
@@ -1567,7 +1566,6 @@ DEPENDENCIES
   simplecov-cobertura (~> 2.1.0)
   warning (~> 1)
   webmock (>= 3.10.0)
-  yard (~> 0.9)
 
 BUNDLED WITH
    2.3.26

--- a/gemfiles/ruby_2.5_contrib.gemfile
+++ b/gemfiles/ruby_2.5_contrib.gemfile
@@ -27,7 +27,6 @@ gem "simplecov-cobertura", "~> 2.1.0"
 gem "warning", "~> 1"
 gem "webmock", ">= 3.10.0"
 gem "rexml", ">= 3.2.7"
-gem "yard", "~> 0.9"
 gem "dogstatsd-ruby", ">= 3.3.0", "!= 5.0.0", "!= 5.0.1", "!= 5.1.0"
 gem "google-protobuf", ["~> 3.0", "!= 3.7.0", "!= 3.7.1", "< 3.19.2"]
 gem "ffi", "~> 1.16.3", require: false

--- a/gemfiles/ruby_2.5_contrib.gemfile.lock
+++ b/gemfiles/ruby_2.5_contrib.gemfile.lock
@@ -169,9 +169,6 @@ GEM
       addressable (>= 2.3.6)
       crack (>= 0.3.2)
       hashdiff (>= 0.4.0, < 2.0.0)
-    webrick (1.7.0)
-    yard (0.9.28)
-      webrick (~> 1.7.0)
 
 PLATFORMS
   aarch64-linux
@@ -219,7 +216,6 @@ DEPENDENCIES
   sucker_punch
   warning (~> 1)
   webmock (>= 3.10.0)
-  yard (~> 0.9)
 
 BUNDLED WITH
    2.3.26

--- a/gemfiles/ruby_2.5_contrib_old.gemfile
+++ b/gemfiles/ruby_2.5_contrib_old.gemfile
@@ -27,7 +27,6 @@ gem "simplecov-cobertura", "~> 2.1.0"
 gem "warning", "~> 1"
 gem "webmock", ">= 3.10.0"
 gem "rexml", ">= 3.2.7"
-gem "yard", "~> 0.9"
 gem "dogstatsd-ruby", ">= 3.3.0", "!= 5.0.0", "!= 5.0.1", "!= 5.1.0"
 gem "google-protobuf", ["~> 3.0", "!= 3.7.0", "!= 3.7.1", "< 3.19.2"]
 gem "ffi", "~> 1.16.3", require: false

--- a/gemfiles/ruby_2.5_contrib_old.gemfile.lock
+++ b/gemfiles/ruby_2.5_contrib_old.gemfile.lock
@@ -156,9 +156,6 @@ GEM
       addressable (>= 2.3.6)
       crack (>= 0.3.2)
       hashdiff (>= 0.4.0, < 2.0.0)
-    webrick (1.7.0)
-    yard (0.9.28)
-      webrick (~> 1.7.0)
 
 PLATFORMS
   aarch64-linux
@@ -198,7 +195,6 @@ DEPENDENCIES
   simplecov-cobertura (~> 2.1.0)
   warning (~> 1)
   webmock (>= 3.10.0)
-  yard (~> 0.9)
 
 BUNDLED WITH
    2.3.26

--- a/gemfiles/ruby_2.5_core_old.gemfile
+++ b/gemfiles/ruby_2.5_core_old.gemfile
@@ -27,7 +27,6 @@ gem "simplecov-cobertura", "~> 2.1.0"
 gem "warning", "~> 1"
 gem "webmock", ">= 3.10.0"
 gem "rexml", ">= 3.2.7"
-gem "yard", "~> 0.9"
 gem "dogstatsd-ruby", "~> 4"
 gem "google-protobuf", ["~> 3.0", "!= 3.7.0", "!= 3.7.1", "< 3.19.2"]
 gem "ffi", "~> 1.16.3", require: false

--- a/gemfiles/ruby_2.5_core_old.gemfile.lock
+++ b/gemfiles/ruby_2.5_core_old.gemfile.lock
@@ -103,9 +103,6 @@ GEM
       addressable (>= 2.3.6)
       crack (>= 0.3.2)
       hashdiff (>= 0.4.0, < 2.0.0)
-    webrick (1.7.0)
-    yard (0.9.28)
-      webrick (~> 1.7.0)
 
 PLATFORMS
   aarch64-linux
@@ -141,7 +138,6 @@ DEPENDENCIES
   simplecov-cobertura (~> 2.1.0)
   warning (~> 1)
   webmock (>= 3.10.0)
-  yard (~> 0.9)
 
 BUNDLED WITH
    2.3.26

--- a/gemfiles/ruby_2.5_elasticsearch_7.gemfile
+++ b/gemfiles/ruby_2.5_elasticsearch_7.gemfile
@@ -27,7 +27,6 @@ gem "simplecov-cobertura", "~> 2.1.0"
 gem "warning", "~> 1"
 gem "webmock", ">= 3.10.0"
 gem "rexml", ">= 3.2.7"
-gem "yard", "~> 0.9"
 gem "dogstatsd-ruby", ">= 3.3.0", "!= 5.0.0", "!= 5.0.1", "!= 5.1.0"
 gem "google-protobuf", ["~> 3.0", "!= 3.7.0", "!= 3.7.1", "< 3.19.2"]
 gem "ffi", "~> 1.16.3", require: false

--- a/gemfiles/ruby_2.5_elasticsearch_7.gemfile.lock
+++ b/gemfiles/ruby_2.5_elasticsearch_7.gemfile.lock
@@ -139,7 +139,6 @@ GEM
       addressable (>= 2.8.0)
       crack (>= 0.3.2)
       hashdiff (>= 0.4.0, < 2.0.0)
-    yard (0.9.34)
 
 PLATFORMS
   aarch64-linux
@@ -176,7 +175,6 @@ DEPENDENCIES
   simplecov-cobertura (~> 2.1.0)
   warning (~> 1)
   webmock (>= 3.10.0)
-  yard (~> 0.9)
 
 BUNDLED WITH
    2.3.26

--- a/gemfiles/ruby_2.5_elasticsearch_8.gemfile
+++ b/gemfiles/ruby_2.5_elasticsearch_8.gemfile
@@ -27,7 +27,6 @@ gem "simplecov-cobertura", "~> 2.1.0"
 gem "warning", "~> 1"
 gem "webmock", ">= 3.10.0"
 gem "rexml", ">= 3.2.7"
-gem "yard", "~> 0.9"
 gem "dogstatsd-ruby", ">= 3.3.0", "!= 5.0.0", "!= 5.0.1", "!= 5.1.0"
 gem "google-protobuf", ["~> 3.0", "!= 3.7.0", "!= 3.7.1", "< 3.19.2"]
 gem "ffi", "~> 1.16.3", require: false

--- a/gemfiles/ruby_2.5_elasticsearch_8.gemfile.lock
+++ b/gemfiles/ruby_2.5_elasticsearch_8.gemfile.lock
@@ -139,7 +139,6 @@ GEM
       addressable (>= 2.8.0)
       crack (>= 0.3.2)
       hashdiff (>= 0.4.0, < 2.0.0)
-    yard (0.9.34)
 
 PLATFORMS
   aarch64-linux
@@ -176,7 +175,6 @@ DEPENDENCIES
   simplecov-cobertura (~> 2.1.0)
   warning (~> 1)
   webmock (>= 3.10.0)
-  yard (~> 0.9)
 
 BUNDLED WITH
    2.3.26

--- a/gemfiles/ruby_2.5_graphql_2.0.gemfile
+++ b/gemfiles/ruby_2.5_graphql_2.0.gemfile
@@ -27,7 +27,6 @@ gem "simplecov-cobertura", "~> 2.1.0"
 gem "warning", "~> 1"
 gem "webmock", ">= 3.10.0"
 gem "rexml", ">= 3.2.7"
-gem "yard", "~> 0.9"
 gem "dogstatsd-ruby", ">= 3.3.0", "!= 5.0.0", "!= 5.0.1", "!= 5.1.0"
 gem "google-protobuf", ["~> 3.0", "!= 3.7.0", "!= 3.7.1", "< 3.19.2"]
 gem "ffi", "~> 1.16.3", require: false

--- a/gemfiles/ruby_2.5_graphql_2.0.gemfile.lock
+++ b/gemfiles/ruby_2.5_graphql_2.0.gemfile.lock
@@ -257,7 +257,6 @@ GEM
     websocket-driver (0.7.6)
       websocket-extensions (>= 0.1.0)
     websocket-extensions (0.1.5)
-    yard (0.9.34)
     zeitwerk (2.6.16)
 
 PLATFORMS
@@ -298,7 +297,6 @@ DEPENDENCIES
   sprockets (< 4)
   warning (~> 1)
   webmock (>= 3.10.0)
-  yard (~> 0.9)
 
 BUNDLED WITH
    2.3.26

--- a/gemfiles/ruby_2.5_hanami_1.gemfile
+++ b/gemfiles/ruby_2.5_hanami_1.gemfile
@@ -27,7 +27,6 @@ gem "simplecov-cobertura", "~> 2.1.0"
 gem "warning", "~> 1"
 gem "webmock", ">= 3.10.0"
 gem "rexml", ">= 3.2.7"
-gem "yard", "~> 0.9"
 gem "dogstatsd-ruby", ">= 3.3.0", "!= 5.0.0", "!= 5.0.1", "!= 5.1.0"
 gem "google-protobuf", ["~> 3.0", "!= 3.7.0", "!= 3.7.1", "< 3.19.2"]
 gem "ffi", "~> 1.16.3", require: false

--- a/gemfiles/ruby_2.5_hanami_1.gemfile.lock
+++ b/gemfiles/ruby_2.5_hanami_1.gemfile.lock
@@ -206,9 +206,6 @@ GEM
       addressable (>= 2.3.6)
       crack (>= 0.3.2)
       hashdiff (>= 0.4.0, < 2.0.0)
-    webrick (1.7.0)
-    yard (0.9.28)
-      webrick (~> 1.7.0)
 
 PLATFORMS
   aarch64-linux
@@ -247,7 +244,6 @@ DEPENDENCIES
   simplecov-cobertura (~> 2.1.0)
   warning (~> 1)
   webmock (>= 3.10.0)
-  yard (~> 0.9)
 
 BUNDLED WITH
    2.3.26

--- a/gemfiles/ruby_2.5_http.gemfile
+++ b/gemfiles/ruby_2.5_http.gemfile
@@ -27,7 +27,6 @@ gem "simplecov-cobertura", "~> 2.1.0"
 gem "warning", "~> 1"
 gem "webmock", ">= 3.10.0"
 gem "rexml", ">= 3.2.7"
-gem "yard", "~> 0.9"
 gem "dogstatsd-ruby", ">= 3.3.0", "!= 5.0.0", "!= 5.0.1", "!= 5.1.0"
 gem "google-protobuf", ["~> 3.0", "!= 3.7.0", "!= 3.7.1", "< 3.19.2"]
 gem "ffi", "~> 1.16.3", require: false

--- a/gemfiles/ruby_2.5_http.gemfile.lock
+++ b/gemfiles/ruby_2.5_http.gemfile.lock
@@ -163,7 +163,6 @@ GEM
       addressable (>= 2.3.6)
       crack (>= 0.3.2)
       hashdiff (>= 0.4.0, < 2.0.0)
-    yard (0.9.34)
 
 PLATFORMS
   aarch64-linux
@@ -206,7 +205,6 @@ DEPENDENCIES
   typhoeus
   warning (~> 1)
   webmock (>= 3.10.0)
-  yard (~> 0.9)
 
 BUNDLED WITH
    2.3.26

--- a/gemfiles/ruby_2.5_opensearch_2.gemfile
+++ b/gemfiles/ruby_2.5_opensearch_2.gemfile
@@ -27,7 +27,6 @@ gem "simplecov-cobertura", "~> 2.1.0"
 gem "warning", "~> 1"
 gem "webmock", ">= 3.10.0"
 gem "rexml", ">= 3.2.7"
-gem "yard", "~> 0.9"
 gem "dogstatsd-ruby", ">= 3.3.0", "!= 5.0.0", "!= 5.0.1", "!= 5.1.0"
 gem "google-protobuf", ["~> 3.0", "!= 3.7.0", "!= 3.7.1", "< 3.19.2"]
 gem "ffi", "~> 1.16.3", require: false

--- a/gemfiles/ruby_2.5_opensearch_2.gemfile.lock
+++ b/gemfiles/ruby_2.5_opensearch_2.gemfile.lock
@@ -139,7 +139,6 @@ GEM
       addressable (>= 2.8.0)
       crack (>= 0.3.2)
       hashdiff (>= 0.4.0, < 2.0.0)
-    yard (0.9.34)
 
 PLATFORMS
   aarch64-linux
@@ -176,7 +175,6 @@ DEPENDENCIES
   simplecov-cobertura (~> 2.1.0)
   warning (~> 1)
   webmock (>= 3.10.0)
-  yard (~> 0.9)
 
 BUNDLED WITH
    2.3.26

--- a/gemfiles/ruby_2.5_opensearch_3.gemfile
+++ b/gemfiles/ruby_2.5_opensearch_3.gemfile
@@ -27,7 +27,6 @@ gem "simplecov-cobertura", "~> 2.1.0"
 gem "warning", "~> 1"
 gem "webmock", ">= 3.10.0"
 gem "rexml", ">= 3.2.7"
-gem "yard", "~> 0.9"
 gem "dogstatsd-ruby", ">= 3.3.0", "!= 5.0.0", "!= 5.0.1", "!= 5.1.0"
 gem "google-protobuf", ["~> 3.0", "!= 3.7.0", "!= 3.7.1", "< 3.19.2"]
 gem "ffi", "~> 1.16.3", require: false

--- a/gemfiles/ruby_2.5_opensearch_3.gemfile.lock
+++ b/gemfiles/ruby_2.5_opensearch_3.gemfile.lock
@@ -134,7 +134,6 @@ GEM
       addressable (>= 2.8.0)
       crack (>= 0.3.2)
       hashdiff (>= 0.4.0, < 2.0.0)
-    yard (0.9.34)
 
 PLATFORMS
   aarch64-linux
@@ -171,7 +170,6 @@ DEPENDENCIES
   simplecov-cobertura (~> 2.1.0)
   warning (~> 1)
   webmock (>= 3.10.0)
-  yard (~> 0.9)
 
 BUNDLED WITH
    2.3.26

--- a/gemfiles/ruby_2.5_rack_1.gemfile
+++ b/gemfiles/ruby_2.5_rack_1.gemfile
@@ -27,7 +27,6 @@ gem "simplecov-cobertura", "~> 2.1.0"
 gem "warning", "~> 1"
 gem "webmock", ">= 3.10.0"
 gem "rexml", ">= 3.2.7"
-gem "yard", "~> 0.9"
 gem "dogstatsd-ruby", ">= 3.3.0", "!= 5.0.0", "!= 5.0.1", "!= 5.1.0"
 gem "google-protobuf", ["~> 3.0", "!= 3.7.0", "!= 3.7.1", "< 3.19.2"]
 gem "ffi", "~> 1.16.3", require: false

--- a/gemfiles/ruby_2.5_rack_1.gemfile.lock
+++ b/gemfiles/ruby_2.5_rack_1.gemfile.lock
@@ -108,7 +108,6 @@ GEM
       addressable (>= 2.3.6)
       crack (>= 0.3.2)
       hashdiff (>= 0.4.0, < 2.0.0)
-    yard (0.9.34)
 
 PLATFORMS
   aarch64-linux
@@ -147,7 +146,6 @@ DEPENDENCIES
   simplecov-cobertura (~> 2.1.0)
   warning (~> 1)
   webmock (>= 3.10.0)
-  yard (~> 0.9)
 
 BUNDLED WITH
    2.3.26

--- a/gemfiles/ruby_2.5_rack_2.gemfile
+++ b/gemfiles/ruby_2.5_rack_2.gemfile
@@ -27,7 +27,6 @@ gem "simplecov-cobertura", "~> 2.1.0"
 gem "warning", "~> 1"
 gem "webmock", ">= 3.10.0"
 gem "rexml", ">= 3.2.7"
-gem "yard", "~> 0.9"
 gem "dogstatsd-ruby", ">= 3.3.0", "!= 5.0.0", "!= 5.0.1", "!= 5.1.0"
 gem "google-protobuf", ["~> 3.0", "!= 3.7.0", "!= 3.7.1", "< 3.19.2"]
 gem "ffi", "~> 1.16.3", require: false

--- a/gemfiles/ruby_2.5_rack_2.gemfile.lock
+++ b/gemfiles/ruby_2.5_rack_2.gemfile.lock
@@ -108,7 +108,6 @@ GEM
       addressable (>= 2.3.6)
       crack (>= 0.3.2)
       hashdiff (>= 0.4.0, < 2.0.0)
-    yard (0.9.34)
 
 PLATFORMS
   aarch64-linux
@@ -147,7 +146,6 @@ DEPENDENCIES
   simplecov-cobertura (~> 2.1.0)
   warning (~> 1)
   webmock (>= 3.10.0)
-  yard (~> 0.9)
 
 BUNDLED WITH
    2.3.26

--- a/gemfiles/ruby_2.5_rack_3.gemfile
+++ b/gemfiles/ruby_2.5_rack_3.gemfile
@@ -27,7 +27,6 @@ gem "simplecov-cobertura", "~> 2.1.0"
 gem "warning", "~> 1"
 gem "webmock", ">= 3.10.0"
 gem "rexml", ">= 3.2.7"
-gem "yard", "~> 0.9"
 gem "dogstatsd-ruby", ">= 3.3.0", "!= 5.0.0", "!= 5.0.1", "!= 5.1.0"
 gem "google-protobuf", ["~> 3.0", "!= 3.7.0", "!= 3.7.1", "< 3.19.2"]
 gem "ffi", "~> 1.16.3", require: false

--- a/gemfiles/ruby_2.5_rack_3.gemfile.lock
+++ b/gemfiles/ruby_2.5_rack_3.gemfile.lock
@@ -108,7 +108,6 @@ GEM
       addressable (>= 2.3.6)
       crack (>= 0.3.2)
       hashdiff (>= 0.4.0, < 2.0.0)
-    yard (0.9.34)
 
 PLATFORMS
   aarch64-linux
@@ -147,7 +146,6 @@ DEPENDENCIES
   simplecov-cobertura (~> 2.1.0)
   warning (~> 1)
   webmock (>= 3.10.0)
-  yard (~> 0.9)
 
 BUNDLED WITH
    2.3.26

--- a/gemfiles/ruby_2.5_rails4_mysql2.gemfile
+++ b/gemfiles/ruby_2.5_rails4_mysql2.gemfile
@@ -27,7 +27,6 @@ gem "simplecov-cobertura", "~> 2.1.0"
 gem "warning", "~> 1"
 gem "webmock", ">= 3.10.0"
 gem "rexml", ">= 3.2.7"
-gem "yard", "~> 0.9"
 gem "dogstatsd-ruby", ">= 3.3.0", "!= 5.0.0", "!= 5.0.1", "!= 5.1.0"
 gem "google-protobuf", ["~> 3.0", "!= 3.7.0", "!= 3.7.1", "< 3.19.2"]
 gem "ffi", "~> 1.16.3", require: false

--- a/gemfiles/ruby_2.5_rails4_mysql2.gemfile.lock
+++ b/gemfiles/ruby_2.5_rails4_mysql2.gemfile.lock
@@ -230,7 +230,6 @@ GEM
       addressable (>= 2.8.0)
       crack (>= 0.3.2)
       hashdiff (>= 0.4.0, < 2.0.0)
-    yard (0.9.34)
 
 PLATFORMS
   aarch64-linux
@@ -270,7 +269,6 @@ DEPENDENCIES
   sprockets (< 4)
   warning (~> 1)
   webmock (>= 3.10.0)
-  yard (~> 0.9)
 
 BUNDLED WITH
    2.3.26

--- a/gemfiles/ruby_2.5_rails4_postgres.gemfile
+++ b/gemfiles/ruby_2.5_rails4_postgres.gemfile
@@ -27,7 +27,6 @@ gem "simplecov-cobertura", "~> 2.1.0"
 gem "warning", "~> 1"
 gem "webmock", ">= 3.10.0"
 gem "rexml", ">= 3.2.7"
-gem "yard", "~> 0.9"
 gem "dogstatsd-ruby", ">= 3.3.0", "!= 5.0.0", "!= 5.0.1", "!= 5.1.0"
 gem "google-protobuf", ["~> 3.0", "!= 3.7.0", "!= 3.7.1", "< 3.19.2"]
 gem "ffi", "~> 1.16.3", require: false

--- a/gemfiles/ruby_2.5_rails4_postgres.gemfile.lock
+++ b/gemfiles/ruby_2.5_rails4_postgres.gemfile.lock
@@ -230,7 +230,6 @@ GEM
       addressable (>= 2.8.0)
       crack (>= 0.3.2)
       hashdiff (>= 0.4.0, < 2.0.0)
-    yard (0.9.34)
 
 PLATFORMS
   aarch64-linux
@@ -270,7 +269,6 @@ DEPENDENCIES
   sprockets (< 4)
   warning (~> 1)
   webmock (>= 3.10.0)
-  yard (~> 0.9)
 
 BUNDLED WITH
    2.3.26

--- a/gemfiles/ruby_2.5_rails4_postgres_redis.gemfile
+++ b/gemfiles/ruby_2.5_rails4_postgres_redis.gemfile
@@ -27,7 +27,6 @@ gem "simplecov-cobertura", "~> 2.1.0"
 gem "warning", "~> 1"
 gem "webmock", ">= 3.10.0"
 gem "rexml", ">= 3.2.7"
-gem "yard", "~> 0.9"
 gem "dogstatsd-ruby", ">= 3.3.0", "!= 5.0.0", "!= 5.0.1", "!= 5.1.0"
 gem "google-protobuf", ["~> 3.0", "!= 3.7.0", "!= 3.7.1", "< 3.19.2"]
 gem "ffi", "~> 1.16.3", require: false

--- a/gemfiles/ruby_2.5_rails4_postgres_redis.gemfile.lock
+++ b/gemfiles/ruby_2.5_rails4_postgres_redis.gemfile.lock
@@ -247,7 +247,6 @@ GEM
       addressable (>= 2.8.0)
       crack (>= 0.3.2)
       hashdiff (>= 0.4.0, < 2.0.0)
-    yard (0.9.34)
 
 PLATFORMS
   aarch64-linux
@@ -289,7 +288,6 @@ DEPENDENCIES
   sprockets (< 4)
   warning (~> 1)
   webmock (>= 3.10.0)
-  yard (~> 0.9)
 
 BUNDLED WITH
    2.3.26

--- a/gemfiles/ruby_2.5_rails4_postgres_sidekiq.gemfile
+++ b/gemfiles/ruby_2.5_rails4_postgres_sidekiq.gemfile
@@ -27,7 +27,6 @@ gem "simplecov-cobertura", "~> 2.1.0"
 gem "warning", "~> 1"
 gem "webmock", ">= 3.10.0"
 gem "rexml", ">= 3.2.7"
-gem "yard", "~> 0.9"
 gem "dogstatsd-ruby", ">= 3.3.0", "!= 5.0.0", "!= 5.0.1", "!= 5.1.0"
 gem "google-protobuf", ["~> 3.0", "!= 3.7.0", "!= 3.7.1", "< 3.19.2"]
 gem "ffi", "~> 1.16.3", require: false

--- a/gemfiles/ruby_2.5_rails4_postgres_sidekiq.gemfile.lock
+++ b/gemfiles/ruby_2.5_rails4_postgres_sidekiq.gemfile.lock
@@ -239,7 +239,6 @@ GEM
       addressable (>= 2.8.0)
       crack (>= 0.3.2)
       hashdiff (>= 0.4.0, < 2.0.0)
-    yard (0.9.34)
 
 PLATFORMS
   aarch64-linux
@@ -281,7 +280,6 @@ DEPENDENCIES
   sprockets (< 4)
   warning (~> 1)
   webmock (>= 3.10.0)
-  yard (~> 0.9)
 
 BUNDLED WITH
    2.3.26

--- a/gemfiles/ruby_2.5_rails4_semantic_logger.gemfile
+++ b/gemfiles/ruby_2.5_rails4_semantic_logger.gemfile
@@ -27,7 +27,6 @@ gem "simplecov-cobertura", "~> 2.1.0"
 gem "warning", "~> 1"
 gem "webmock", ">= 3.10.0"
 gem "rexml", ">= 3.2.7"
-gem "yard", "~> 0.9"
 gem "dogstatsd-ruby", ">= 3.3.0", "!= 5.0.0", "!= 5.0.1", "!= 5.1.0"
 gem "google-protobuf", ["~> 3.0", "!= 3.7.0", "!= 3.7.1", "< 3.19.2"]
 gem "ffi", "~> 1.16.3", require: false

--- a/gemfiles/ruby_2.5_rails4_semantic_logger.gemfile.lock
+++ b/gemfiles/ruby_2.5_rails4_semantic_logger.gemfile.lock
@@ -229,7 +229,6 @@ GEM
       addressable (>= 2.8.0)
       crack (>= 0.3.2)
       hashdiff (>= 0.4.0, < 2.0.0)
-    yard (0.9.34)
 
 PLATFORMS
   aarch64-linux
@@ -269,7 +268,6 @@ DEPENDENCIES
   sprockets (< 4)
   warning (~> 1)
   webmock (>= 3.10.0)
-  yard (~> 0.9)
 
 BUNDLED WITH
    2.3.26

--- a/gemfiles/ruby_2.5_rails5_mysql2.gemfile
+++ b/gemfiles/ruby_2.5_rails5_mysql2.gemfile
@@ -27,7 +27,6 @@ gem "simplecov-cobertura", "~> 2.1.0"
 gem "warning", "~> 1"
 gem "webmock", ">= 3.10.0"
 gem "rexml", ">= 3.2.7"
-gem "yard", "~> 0.9"
 gem "dogstatsd-ruby", ">= 3.3.0", "!= 5.0.0", "!= 5.0.1", "!= 5.1.0"
 gem "google-protobuf", ["~> 3.0", "!= 3.7.0", "!= 3.7.1", "< 3.19.2"]
 gem "ffi", "~> 1.16.3", require: false

--- a/gemfiles/ruby_2.5_rails5_mysql2.gemfile.lock
+++ b/gemfiles/ruby_2.5_rails5_mysql2.gemfile.lock
@@ -212,12 +212,9 @@ GEM
       addressable (>= 2.3.6)
       crack (>= 0.3.2)
       hashdiff (>= 0.4.0, < 2.0.0)
-    webrick (1.7.0)
     websocket-driver (0.7.5)
       websocket-extensions (>= 0.1.0)
     websocket-extensions (0.1.5)
-    yard (0.9.28)
-      webrick (~> 1.7.0)
 
 PLATFORMS
   aarch64-linux
@@ -258,7 +255,6 @@ DEPENDENCIES
   sprockets (< 4)
   warning (~> 1)
   webmock (>= 3.10.0)
-  yard (~> 0.9)
 
 BUNDLED WITH
    2.3.26

--- a/gemfiles/ruby_2.5_rails5_postgres.gemfile
+++ b/gemfiles/ruby_2.5_rails5_postgres.gemfile
@@ -27,7 +27,6 @@ gem "simplecov-cobertura", "~> 2.1.0"
 gem "warning", "~> 1"
 gem "webmock", ">= 3.10.0"
 gem "rexml", ">= 3.2.7"
-gem "yard", "~> 0.9"
 gem "dogstatsd-ruby", ">= 3.3.0", "!= 5.0.0", "!= 5.0.1", "!= 5.1.0"
 gem "google-protobuf", ["~> 3.0", "!= 3.7.0", "!= 3.7.1", "< 3.19.2"]
 gem "ffi", "~> 1.16.3", require: false

--- a/gemfiles/ruby_2.5_rails5_postgres.gemfile.lock
+++ b/gemfiles/ruby_2.5_rails5_postgres.gemfile.lock
@@ -231,12 +231,9 @@ GEM
       addressable (>= 2.3.6)
       crack (>= 0.3.2)
       hashdiff (>= 0.4.0, < 2.0.0)
-    webrick (1.7.0)
     websocket-driver (0.7.5)
       websocket-extensions (>= 0.1.0)
     websocket-extensions (0.1.5)
-    yard (0.9.28)
-      webrick (~> 1.7.0)
 
 PLATFORMS
   aarch64-linux
@@ -276,7 +273,6 @@ DEPENDENCIES
   sprockets (< 4)
   warning (~> 1)
   webmock (>= 3.10.0)
-  yard (~> 0.9)
 
 BUNDLED WITH
    2.3.26

--- a/gemfiles/ruby_2.5_rails5_postgres_redis.gemfile
+++ b/gemfiles/ruby_2.5_rails5_postgres_redis.gemfile
@@ -27,7 +27,6 @@ gem "simplecov-cobertura", "~> 2.1.0"
 gem "warning", "~> 1"
 gem "webmock", ">= 3.10.0"
 gem "rexml", ">= 3.2.7"
-gem "yard", "~> 0.9"
 gem "dogstatsd-ruby", ">= 3.3.0", "!= 5.0.0", "!= 5.0.1", "!= 5.1.0"
 gem "google-protobuf", ["~> 3.0", "!= 3.7.0", "!= 3.7.1", "< 3.19.2"]
 gem "ffi", "~> 1.16.3", require: false

--- a/gemfiles/ruby_2.5_rails5_postgres_redis.gemfile.lock
+++ b/gemfiles/ruby_2.5_rails5_postgres_redis.gemfile.lock
@@ -236,12 +236,9 @@ GEM
       addressable (>= 2.3.6)
       crack (>= 0.3.2)
       hashdiff (>= 0.4.0, < 2.0.0)
-    webrick (1.7.0)
     websocket-driver (0.7.5)
       websocket-extensions (>= 0.1.0)
     websocket-extensions (0.1.5)
-    yard (0.9.28)
-      webrick (~> 1.7.0)
 
 PLATFORMS
   aarch64-linux
@@ -282,7 +279,6 @@ DEPENDENCIES
   sprockets (< 4)
   warning (~> 1)
   webmock (>= 3.10.0)
-  yard (~> 0.9)
 
 BUNDLED WITH
    2.3.26

--- a/gemfiles/ruby_2.5_rails5_postgres_redis_activesupport.gemfile
+++ b/gemfiles/ruby_2.5_rails5_postgres_redis_activesupport.gemfile
@@ -27,7 +27,6 @@ gem "simplecov-cobertura", "~> 2.1.0"
 gem "warning", "~> 1"
 gem "webmock", ">= 3.10.0"
 gem "rexml", ">= 3.2.7"
-gem "yard", "~> 0.9"
 gem "dogstatsd-ruby", ">= 3.3.0", "!= 5.0.0", "!= 5.0.1", "!= 5.1.0"
 gem "google-protobuf", ["~> 3.0", "!= 3.7.0", "!= 3.7.1", "< 3.19.2"]
 gem "ffi", "~> 1.16.3", require: false

--- a/gemfiles/ruby_2.5_rails5_postgres_redis_activesupport.gemfile.lock
+++ b/gemfiles/ruby_2.5_rails5_postgres_redis_activesupport.gemfile.lock
@@ -248,12 +248,9 @@ GEM
       addressable (>= 2.3.6)
       crack (>= 0.3.2)
       hashdiff (>= 0.4.0, < 2.0.0)
-    webrick (1.7.0)
     websocket-driver (0.7.5)
       websocket-extensions (>= 0.1.0)
     websocket-extensions (0.1.5)
-    yard (0.9.28)
-      webrick (~> 1.7.0)
 
 PLATFORMS
   aarch64-linux
@@ -296,7 +293,6 @@ DEPENDENCIES
   sprockets (< 4)
   warning (~> 1)
   webmock (>= 3.10.0)
-  yard (~> 0.9)
 
 BUNDLED WITH
    2.3.26

--- a/gemfiles/ruby_2.5_rails5_postgres_sidekiq.gemfile
+++ b/gemfiles/ruby_2.5_rails5_postgres_sidekiq.gemfile
@@ -27,7 +27,6 @@ gem "simplecov-cobertura", "~> 2.1.0"
 gem "warning", "~> 1"
 gem "webmock", ">= 3.10.0"
 gem "rexml", ">= 3.2.7"
-gem "yard", "~> 0.9"
 gem "dogstatsd-ruby", ">= 3.3.0", "!= 5.0.0", "!= 5.0.1", "!= 5.1.0"
 gem "google-protobuf", ["~> 3.0", "!= 3.7.0", "!= 3.7.1", "< 3.19.2"]
 gem "ffi", "~> 1.16.3", require: false

--- a/gemfiles/ruby_2.5_rails5_postgres_sidekiq.gemfile.lock
+++ b/gemfiles/ruby_2.5_rails5_postgres_sidekiq.gemfile.lock
@@ -237,12 +237,9 @@ GEM
       addressable (>= 2.3.6)
       crack (>= 0.3.2)
       hashdiff (>= 0.4.0, < 2.0.0)
-    webrick (1.7.0)
     websocket-driver (0.7.5)
       websocket-extensions (>= 0.1.0)
     websocket-extensions (0.1.5)
-    yard (0.9.28)
-      webrick (~> 1.7.0)
 
 PLATFORMS
   aarch64-linux
@@ -284,7 +281,6 @@ DEPENDENCIES
   sprockets (< 4)
   warning (~> 1)
   webmock (>= 3.10.0)
-  yard (~> 0.9)
 
 BUNDLED WITH
    2.3.26

--- a/gemfiles/ruby_2.5_rails5_semantic_logger.gemfile
+++ b/gemfiles/ruby_2.5_rails5_semantic_logger.gemfile
@@ -27,7 +27,6 @@ gem "simplecov-cobertura", "~> 2.1.0"
 gem "warning", "~> 1"
 gem "webmock", ">= 3.10.0"
 gem "rexml", ">= 3.2.7"
-gem "yard", "~> 0.9"
 gem "dogstatsd-ruby", ">= 3.3.0", "!= 5.0.0", "!= 5.0.1", "!= 5.1.0"
 gem "google-protobuf", ["~> 3.0", "!= 3.7.0", "!= 3.7.1", "< 3.19.2"]
 gem "ffi", "~> 1.16.3", require: false

--- a/gemfiles/ruby_2.5_rails5_semantic_logger.gemfile.lock
+++ b/gemfiles/ruby_2.5_rails5_semantic_logger.gemfile.lock
@@ -230,12 +230,9 @@ GEM
       addressable (>= 2.3.6)
       crack (>= 0.3.2)
       hashdiff (>= 0.4.0, < 2.0.0)
-    webrick (1.7.0)
     websocket-driver (0.7.5)
       websocket-extensions (>= 0.1.0)
     websocket-extensions (0.1.5)
-    yard (0.9.28)
-      webrick (~> 1.7.0)
 
 PLATFORMS
   aarch64-linux
@@ -275,7 +272,6 @@ DEPENDENCIES
   sprockets (< 4)
   warning (~> 1)
   webmock (>= 3.10.0)
-  yard (~> 0.9)
 
 BUNDLED WITH
    2.3.26

--- a/gemfiles/ruby_2.5_rails61_mysql2.gemfile
+++ b/gemfiles/ruby_2.5_rails61_mysql2.gemfile
@@ -27,7 +27,6 @@ gem "simplecov-cobertura", "~> 2.1.0"
 gem "warning", "~> 1"
 gem "webmock", ">= 3.10.0"
 gem "rexml", ">= 3.2.7"
-gem "yard", "~> 0.9"
 gem "dogstatsd-ruby", ">= 3.3.0", "!= 5.0.0", "!= 5.0.1", "!= 5.1.0"
 gem "google-protobuf", ["~> 3.0", "!= 3.7.0", "!= 3.7.1", "< 3.19.2"]
 gem "ffi", "~> 1.16.3", require: false

--- a/gemfiles/ruby_2.5_rails61_mysql2.gemfile.lock
+++ b/gemfiles/ruby_2.5_rails61_mysql2.gemfile.lock
@@ -230,12 +230,9 @@ GEM
       addressable (>= 2.3.6)
       crack (>= 0.3.2)
       hashdiff (>= 0.4.0, < 2.0.0)
-    webrick (1.7.0)
     websocket-driver (0.7.5)
       websocket-extensions (>= 0.1.0)
     websocket-extensions (0.1.5)
-    yard (0.9.28)
-      webrick (~> 1.7.0)
     zeitwerk (2.6.7)
 
 PLATFORMS
@@ -277,7 +274,6 @@ DEPENDENCIES
   sprockets (< 4)
   warning (~> 1)
   webmock (>= 3.10.0)
-  yard (~> 0.9)
 
 BUNDLED WITH
    2.3.26

--- a/gemfiles/ruby_2.5_rails61_postgres.gemfile
+++ b/gemfiles/ruby_2.5_rails61_postgres.gemfile
@@ -27,7 +27,6 @@ gem "simplecov-cobertura", "~> 2.1.0"
 gem "warning", "~> 1"
 gem "webmock", ">= 3.10.0"
 gem "rexml", ">= 3.2.7"
-gem "yard", "~> 0.9"
 gem "dogstatsd-ruby", ">= 3.3.0", "!= 5.0.0", "!= 5.0.1", "!= 5.1.0"
 gem "google-protobuf", ["~> 3.0", "!= 3.7.0", "!= 3.7.1", "< 3.19.2"]
 gem "ffi", "~> 1.16.3", require: false

--- a/gemfiles/ruby_2.5_rails61_postgres.gemfile.lock
+++ b/gemfiles/ruby_2.5_rails61_postgres.gemfile.lock
@@ -249,12 +249,9 @@ GEM
       addressable (>= 2.3.6)
       crack (>= 0.3.2)
       hashdiff (>= 0.4.0, < 2.0.0)
-    webrick (1.7.0)
     websocket-driver (0.7.5)
       websocket-extensions (>= 0.1.0)
     websocket-extensions (0.1.5)
-    yard (0.9.28)
-      webrick (~> 1.7.0)
     zeitwerk (2.6.7)
 
 PLATFORMS
@@ -295,7 +292,6 @@ DEPENDENCIES
   sprockets (< 4)
   warning (~> 1)
   webmock (>= 3.10.0)
-  yard (~> 0.9)
 
 BUNDLED WITH
    2.3.26

--- a/gemfiles/ruby_2.5_rails61_postgres_redis.gemfile
+++ b/gemfiles/ruby_2.5_rails61_postgres_redis.gemfile
@@ -27,7 +27,6 @@ gem "simplecov-cobertura", "~> 2.1.0"
 gem "warning", "~> 1"
 gem "webmock", ">= 3.10.0"
 gem "rexml", ">= 3.2.7"
-gem "yard", "~> 0.9"
 gem "dogstatsd-ruby", ">= 3.3.0", "!= 5.0.0", "!= 5.0.1", "!= 5.1.0"
 gem "google-protobuf", ["~> 3.0", "!= 3.7.0", "!= 3.7.1", "< 3.19.2"]
 gem "ffi", "~> 1.16.3", require: false

--- a/gemfiles/ruby_2.5_rails61_postgres_redis.gemfile.lock
+++ b/gemfiles/ruby_2.5_rails61_postgres_redis.gemfile.lock
@@ -254,12 +254,9 @@ GEM
       addressable (>= 2.3.6)
       crack (>= 0.3.2)
       hashdiff (>= 0.4.0, < 2.0.0)
-    webrick (1.7.0)
     websocket-driver (0.7.5)
       websocket-extensions (>= 0.1.0)
     websocket-extensions (0.1.5)
-    yard (0.9.28)
-      webrick (~> 1.7.0)
     zeitwerk (2.6.7)
 
 PLATFORMS
@@ -301,7 +298,6 @@ DEPENDENCIES
   sprockets (< 4)
   warning (~> 1)
   webmock (>= 3.10.0)
-  yard (~> 0.9)
 
 BUNDLED WITH
    2.3.26

--- a/gemfiles/ruby_2.5_rails61_postgres_sidekiq.gemfile
+++ b/gemfiles/ruby_2.5_rails61_postgres_sidekiq.gemfile
@@ -27,7 +27,6 @@ gem "simplecov-cobertura", "~> 2.1.0"
 gem "warning", "~> 1"
 gem "webmock", ">= 3.10.0"
 gem "rexml", ">= 3.2.7"
-gem "yard", "~> 0.9"
 gem "dogstatsd-ruby", ">= 3.3.0", "!= 5.0.0", "!= 5.0.1", "!= 5.1.0"
 gem "google-protobuf", ["~> 3.0", "!= 3.7.0", "!= 3.7.1", "< 3.19.2"]
 gem "ffi", "~> 1.16.3", require: false

--- a/gemfiles/ruby_2.5_rails61_postgres_sidekiq.gemfile.lock
+++ b/gemfiles/ruby_2.5_rails61_postgres_sidekiq.gemfile.lock
@@ -255,12 +255,9 @@ GEM
       addressable (>= 2.3.6)
       crack (>= 0.3.2)
       hashdiff (>= 0.4.0, < 2.0.0)
-    webrick (1.7.0)
     websocket-driver (0.7.5)
       websocket-extensions (>= 0.1.0)
     websocket-extensions (0.1.5)
-    yard (0.9.28)
-      webrick (~> 1.7.0)
     zeitwerk (2.6.7)
 
 PLATFORMS
@@ -302,7 +299,6 @@ DEPENDENCIES
   sprockets (< 4)
   warning (~> 1)
   webmock (>= 3.10.0)
-  yard (~> 0.9)
 
 BUNDLED WITH
    2.3.26

--- a/gemfiles/ruby_2.5_rails61_semantic_logger.gemfile
+++ b/gemfiles/ruby_2.5_rails61_semantic_logger.gemfile
@@ -27,7 +27,6 @@ gem "simplecov-cobertura", "~> 2.1.0"
 gem "warning", "~> 1"
 gem "webmock", ">= 3.10.0"
 gem "rexml", ">= 3.2.7"
-gem "yard", "~> 0.9"
 gem "dogstatsd-ruby", ">= 3.3.0", "!= 5.0.0", "!= 5.0.1", "!= 5.1.0"
 gem "google-protobuf", ["~> 3.0", "!= 3.7.0", "!= 3.7.1", "< 3.19.2"]
 gem "ffi", "~> 1.16.3", require: false

--- a/gemfiles/ruby_2.5_rails61_semantic_logger.gemfile.lock
+++ b/gemfiles/ruby_2.5_rails61_semantic_logger.gemfile.lock
@@ -248,12 +248,9 @@ GEM
       addressable (>= 2.3.6)
       crack (>= 0.3.2)
       hashdiff (>= 0.4.0, < 2.0.0)
-    webrick (1.7.0)
     websocket-driver (0.7.5)
       websocket-extensions (>= 0.1.0)
     websocket-extensions (0.1.5)
-    yard (0.9.28)
-      webrick (~> 1.7.0)
     zeitwerk (2.6.7)
 
 PLATFORMS
@@ -294,7 +291,6 @@ DEPENDENCIES
   sprockets (< 4)
   warning (~> 1)
   webmock (>= 3.10.0)
-  yard (~> 0.9)
 
 BUNDLED WITH
    2.3.26

--- a/gemfiles/ruby_2.5_rails6_mysql2.gemfile
+++ b/gemfiles/ruby_2.5_rails6_mysql2.gemfile
@@ -27,7 +27,6 @@ gem "simplecov-cobertura", "~> 2.1.0"
 gem "warning", "~> 1"
 gem "webmock", ">= 3.10.0"
 gem "rexml", ">= 3.2.7"
-gem "yard", "~> 0.9"
 gem "dogstatsd-ruby", ">= 3.3.0", "!= 5.0.0", "!= 5.0.1", "!= 5.1.0"
 gem "google-protobuf", ["~> 3.0", "!= 3.7.0", "!= 3.7.1", "< 3.19.2"]
 gem "ffi", "~> 1.16.3", require: false

--- a/gemfiles/ruby_2.5_rails6_mysql2.gemfile.lock
+++ b/gemfiles/ruby_2.5_rails6_mysql2.gemfile.lock
@@ -227,12 +227,9 @@ GEM
       addressable (>= 2.3.6)
       crack (>= 0.3.2)
       hashdiff (>= 0.4.0, < 2.0.0)
-    webrick (1.7.0)
     websocket-driver (0.7.5)
       websocket-extensions (>= 0.1.0)
     websocket-extensions (0.1.5)
-    yard (0.9.28)
-      webrick (~> 1.7.0)
     zeitwerk (2.6.7)
 
 PLATFORMS
@@ -274,7 +271,6 @@ DEPENDENCIES
   sprockets (< 4)
   warning (~> 1)
   webmock (>= 3.10.0)
-  yard (~> 0.9)
 
 BUNDLED WITH
    2.3.26

--- a/gemfiles/ruby_2.5_rails6_postgres.gemfile
+++ b/gemfiles/ruby_2.5_rails6_postgres.gemfile
@@ -27,7 +27,6 @@ gem "simplecov-cobertura", "~> 2.1.0"
 gem "warning", "~> 1"
 gem "webmock", ">= 3.10.0"
 gem "rexml", ">= 3.2.7"
-gem "yard", "~> 0.9"
 gem "dogstatsd-ruby", ">= 3.3.0", "!= 5.0.0", "!= 5.0.1", "!= 5.1.0"
 gem "google-protobuf", ["~> 3.0", "!= 3.7.0", "!= 3.7.1", "< 3.19.2"]
 gem "ffi", "~> 1.16.3", require: false

--- a/gemfiles/ruby_2.5_rails6_postgres.gemfile.lock
+++ b/gemfiles/ruby_2.5_rails6_postgres.gemfile.lock
@@ -246,12 +246,9 @@ GEM
       addressable (>= 2.3.6)
       crack (>= 0.3.2)
       hashdiff (>= 0.4.0, < 2.0.0)
-    webrick (1.7.0)
     websocket-driver (0.7.5)
       websocket-extensions (>= 0.1.0)
     websocket-extensions (0.1.5)
-    yard (0.9.28)
-      webrick (~> 1.7.0)
     zeitwerk (2.6.7)
 
 PLATFORMS
@@ -292,7 +289,6 @@ DEPENDENCIES
   sprockets (< 4)
   warning (~> 1)
   webmock (>= 3.10.0)
-  yard (~> 0.9)
 
 BUNDLED WITH
    2.3.26

--- a/gemfiles/ruby_2.5_rails6_postgres_redis.gemfile
+++ b/gemfiles/ruby_2.5_rails6_postgres_redis.gemfile
@@ -27,7 +27,6 @@ gem "simplecov-cobertura", "~> 2.1.0"
 gem "warning", "~> 1"
 gem "webmock", ">= 3.10.0"
 gem "rexml", ">= 3.2.7"
-gem "yard", "~> 0.9"
 gem "dogstatsd-ruby", ">= 3.3.0", "!= 5.0.0", "!= 5.0.1", "!= 5.1.0"
 gem "google-protobuf", ["~> 3.0", "!= 3.7.0", "!= 3.7.1", "< 3.19.2"]
 gem "ffi", "~> 1.16.3", require: false

--- a/gemfiles/ruby_2.5_rails6_postgres_redis.gemfile.lock
+++ b/gemfiles/ruby_2.5_rails6_postgres_redis.gemfile.lock
@@ -251,12 +251,9 @@ GEM
       addressable (>= 2.3.6)
       crack (>= 0.3.2)
       hashdiff (>= 0.4.0, < 2.0.0)
-    webrick (1.7.0)
     websocket-driver (0.7.5)
       websocket-extensions (>= 0.1.0)
     websocket-extensions (0.1.5)
-    yard (0.9.28)
-      webrick (~> 1.7.0)
     zeitwerk (2.6.7)
 
 PLATFORMS
@@ -298,7 +295,6 @@ DEPENDENCIES
   sprockets (< 4)
   warning (~> 1)
   webmock (>= 3.10.0)
-  yard (~> 0.9)
 
 BUNDLED WITH
    2.3.26

--- a/gemfiles/ruby_2.5_rails6_postgres_redis_activesupport.gemfile
+++ b/gemfiles/ruby_2.5_rails6_postgres_redis_activesupport.gemfile
@@ -27,7 +27,6 @@ gem "simplecov-cobertura", "~> 2.1.0"
 gem "warning", "~> 1"
 gem "webmock", ">= 3.10.0"
 gem "rexml", ">= 3.2.7"
-gem "yard", "~> 0.9"
 gem "dogstatsd-ruby", ">= 3.3.0", "!= 5.0.0", "!= 5.0.1", "!= 5.1.0"
 gem "google-protobuf", ["~> 3.0", "!= 3.7.0", "!= 3.7.1", "< 3.19.2"]
 gem "ffi", "~> 1.16.3", require: false

--- a/gemfiles/ruby_2.5_rails6_postgres_redis_activesupport.gemfile.lock
+++ b/gemfiles/ruby_2.5_rails6_postgres_redis_activesupport.gemfile.lock
@@ -263,12 +263,9 @@ GEM
       addressable (>= 2.3.6)
       crack (>= 0.3.2)
       hashdiff (>= 0.4.0, < 2.0.0)
-    webrick (1.7.0)
     websocket-driver (0.7.5)
       websocket-extensions (>= 0.1.0)
     websocket-extensions (0.1.5)
-    yard (0.9.28)
-      webrick (~> 1.7.0)
     zeitwerk (2.6.7)
 
 PLATFORMS
@@ -312,7 +309,6 @@ DEPENDENCIES
   sprockets (< 4)
   warning (~> 1)
   webmock (>= 3.10.0)
-  yard (~> 0.9)
 
 BUNDLED WITH
    2.3.26

--- a/gemfiles/ruby_2.5_rails6_postgres_sidekiq.gemfile
+++ b/gemfiles/ruby_2.5_rails6_postgres_sidekiq.gemfile
@@ -27,7 +27,6 @@ gem "simplecov-cobertura", "~> 2.1.0"
 gem "warning", "~> 1"
 gem "webmock", ">= 3.10.0"
 gem "rexml", ">= 3.2.7"
-gem "yard", "~> 0.9"
 gem "dogstatsd-ruby", ">= 3.3.0", "!= 5.0.0", "!= 5.0.1", "!= 5.1.0"
 gem "google-protobuf", ["~> 3.0", "!= 3.7.0", "!= 3.7.1", "< 3.19.2"]
 gem "ffi", "~> 1.16.3", require: false

--- a/gemfiles/ruby_2.5_rails6_postgres_sidekiq.gemfile.lock
+++ b/gemfiles/ruby_2.5_rails6_postgres_sidekiq.gemfile.lock
@@ -252,12 +252,9 @@ GEM
       addressable (>= 2.3.6)
       crack (>= 0.3.2)
       hashdiff (>= 0.4.0, < 2.0.0)
-    webrick (1.7.0)
     websocket-driver (0.7.5)
       websocket-extensions (>= 0.1.0)
     websocket-extensions (0.1.5)
-    yard (0.9.28)
-      webrick (~> 1.7.0)
     zeitwerk (2.6.7)
 
 PLATFORMS
@@ -300,7 +297,6 @@ DEPENDENCIES
   sprockets (< 4)
   warning (~> 1)
   webmock (>= 3.10.0)
-  yard (~> 0.9)
 
 BUNDLED WITH
    2.3.26

--- a/gemfiles/ruby_2.5_rails6_semantic_logger.gemfile
+++ b/gemfiles/ruby_2.5_rails6_semantic_logger.gemfile
@@ -27,7 +27,6 @@ gem "simplecov-cobertura", "~> 2.1.0"
 gem "warning", "~> 1"
 gem "webmock", ">= 3.10.0"
 gem "rexml", ">= 3.2.7"
-gem "yard", "~> 0.9"
 gem "dogstatsd-ruby", ">= 3.3.0", "!= 5.0.0", "!= 5.0.1", "!= 5.1.0"
 gem "google-protobuf", ["~> 3.0", "!= 3.7.0", "!= 3.7.1", "< 3.19.2"]
 gem "ffi", "~> 1.16.3", require: false

--- a/gemfiles/ruby_2.5_rails6_semantic_logger.gemfile.lock
+++ b/gemfiles/ruby_2.5_rails6_semantic_logger.gemfile.lock
@@ -245,12 +245,9 @@ GEM
       addressable (>= 2.3.6)
       crack (>= 0.3.2)
       hashdiff (>= 0.4.0, < 2.0.0)
-    webrick (1.7.0)
     websocket-driver (0.7.5)
       websocket-extensions (>= 0.1.0)
     websocket-extensions (0.1.5)
-    yard (0.9.28)
-      webrick (~> 1.7.0)
     zeitwerk (2.6.7)
 
 PLATFORMS
@@ -291,7 +288,6 @@ DEPENDENCIES
   sprockets (< 4)
   warning (~> 1)
   webmock (>= 3.10.0)
-  yard (~> 0.9)
 
 BUNDLED WITH
    2.3.26

--- a/gemfiles/ruby_2.5_redis_3.gemfile
+++ b/gemfiles/ruby_2.5_redis_3.gemfile
@@ -27,7 +27,6 @@ gem "simplecov-cobertura", "~> 2.1.0"
 gem "warning", "~> 1"
 gem "webmock", ">= 3.10.0"
 gem "rexml", ">= 3.2.7"
-gem "yard", "~> 0.9"
 gem "dogstatsd-ruby", ">= 3.3.0", "!= 5.0.0", "!= 5.0.1", "!= 5.1.0"
 gem "google-protobuf", ["~> 3.0", "!= 3.7.0", "!= 3.7.1", "< 3.19.2"]
 gem "ffi", "~> 1.16.3", require: false

--- a/gemfiles/ruby_2.5_redis_3.gemfile.lock
+++ b/gemfiles/ruby_2.5_redis_3.gemfile.lock
@@ -104,9 +104,6 @@ GEM
       addressable (>= 2.3.6)
       crack (>= 0.3.2)
       hashdiff (>= 0.4.0, < 2.0.0)
-    webrick (1.7.0)
-    yard (0.9.28)
-      webrick (~> 1.7.0)
 
 PLATFORMS
   aarch64-linux
@@ -143,7 +140,6 @@ DEPENDENCIES
   simplecov-cobertura (~> 2.1.0)
   warning (~> 1)
   webmock (>= 3.10.0)
-  yard (~> 0.9)
 
 BUNDLED WITH
    2.3.26

--- a/gemfiles/ruby_2.5_redis_4.gemfile
+++ b/gemfiles/ruby_2.5_redis_4.gemfile
@@ -27,7 +27,6 @@ gem "simplecov-cobertura", "~> 2.1.0"
 gem "warning", "~> 1"
 gem "webmock", ">= 3.10.0"
 gem "rexml", ">= 3.2.7"
-gem "yard", "~> 0.9"
 gem "dogstatsd-ruby", ">= 3.3.0", "!= 5.0.0", "!= 5.0.1", "!= 5.1.0"
 gem "google-protobuf", ["~> 3.0", "!= 3.7.0", "!= 3.7.1", "< 3.19.2"]
 gem "ffi", "~> 1.16.3", require: false

--- a/gemfiles/ruby_2.5_redis_4.gemfile.lock
+++ b/gemfiles/ruby_2.5_redis_4.gemfile.lock
@@ -104,9 +104,6 @@ GEM
       addressable (>= 2.3.6)
       crack (>= 0.3.2)
       hashdiff (>= 0.4.0, < 2.0.0)
-    webrick (1.7.0)
-    yard (0.9.28)
-      webrick (~> 1.7.0)
 
 PLATFORMS
   aarch64-linux
@@ -143,7 +140,6 @@ DEPENDENCIES
   simplecov-cobertura (~> 2.1.0)
   warning (~> 1)
   webmock (>= 3.10.0)
-  yard (~> 0.9)
 
 BUNDLED WITH
    2.3.26

--- a/gemfiles/ruby_2.5_redis_5.gemfile
+++ b/gemfiles/ruby_2.5_redis_5.gemfile
@@ -27,7 +27,6 @@ gem "simplecov-cobertura", "~> 2.1.0"
 gem "warning", "~> 1"
 gem "webmock", ">= 3.10.0"
 gem "rexml", ">= 3.2.7"
-gem "yard", "~> 0.9"
 gem "dogstatsd-ruby", ">= 3.3.0", "!= 5.0.0", "!= 5.0.1", "!= 5.1.0"
 gem "google-protobuf", ["~> 3.0", "!= 3.7.0", "!= 3.7.1", "< 3.19.2"]
 gem "ffi", "~> 1.16.3", require: false

--- a/gemfiles/ruby_2.5_redis_5.gemfile.lock
+++ b/gemfiles/ruby_2.5_redis_5.gemfile.lock
@@ -108,9 +108,6 @@ GEM
       addressable (>= 2.3.6)
       crack (>= 0.3.2)
       hashdiff (>= 0.4.0, < 2.0.0)
-    webrick (1.7.0)
-    yard (0.9.28)
-      webrick (~> 1.7.0)
 
 PLATFORMS
   aarch64-linux
@@ -147,7 +144,6 @@ DEPENDENCIES
   simplecov-cobertura (~> 2.1.0)
   warning (~> 1)
   webmock (>= 3.10.0)
-  yard (~> 0.9)
 
 BUNDLED WITH
    2.3.26

--- a/gemfiles/ruby_2.5_relational_db.gemfile
+++ b/gemfiles/ruby_2.5_relational_db.gemfile
@@ -27,7 +27,6 @@ gem "simplecov-cobertura", "~> 2.1.0"
 gem "warning", "~> 1"
 gem "webmock", ">= 3.10.0"
 gem "rexml", ">= 3.2.7"
-gem "yard", "~> 0.9"
 gem "dogstatsd-ruby", ">= 3.3.0", "!= 5.0.0", "!= 5.0.1", "!= 5.1.0"
 gem "google-protobuf", ["~> 3.0", "!= 3.7.0", "!= 3.7.1", "< 3.19.2"]
 gem "ffi", "~> 1.16.3", require: false

--- a/gemfiles/ruby_2.5_relational_db.gemfile.lock
+++ b/gemfiles/ruby_2.5_relational_db.gemfile.lock
@@ -134,7 +134,6 @@ GEM
       addressable (>= 2.3.6)
       crack (>= 0.3.2)
       hashdiff (>= 0.4.0, < 2.0.0)
-    yard (0.9.34)
 
 PLATFORMS
   aarch64-linux
@@ -178,7 +177,6 @@ DEPENDENCIES
   sqlite3 (~> 1.4.1)
   warning (~> 1)
   webmock (>= 3.10.0)
-  yard (~> 0.9)
 
 BUNDLED WITH
    2.3.26

--- a/gemfiles/ruby_2.5_resque2_redis3.gemfile
+++ b/gemfiles/ruby_2.5_resque2_redis3.gemfile
@@ -27,7 +27,6 @@ gem "simplecov-cobertura", "~> 2.1.0"
 gem "warning", "~> 1"
 gem "webmock", ">= 3.10.0"
 gem "rexml", ">= 3.2.7"
-gem "yard", "~> 0.9"
 gem "dogstatsd-ruby", ">= 3.3.0", "!= 5.0.0", "!= 5.0.1", "!= 5.1.0"
 gem "google-protobuf", ["~> 3.0", "!= 3.7.0", "!= 3.7.1", "< 3.19.2"]
 gem "ffi", "~> 1.16.3", require: false

--- a/gemfiles/ruby_2.5_resque2_redis3.gemfile.lock
+++ b/gemfiles/ruby_2.5_resque2_redis3.gemfile.lock
@@ -125,9 +125,6 @@ GEM
       addressable (>= 2.3.6)
       crack (>= 0.3.2)
       hashdiff (>= 0.4.0, < 2.0.0)
-    webrick (1.7.0)
-    yard (0.9.28)
-      webrick (~> 1.7.0)
 
 PLATFORMS
   aarch64-linux
@@ -165,7 +162,6 @@ DEPENDENCIES
   simplecov-cobertura (~> 2.1.0)
   warning (~> 1)
   webmock (>= 3.10.0)
-  yard (~> 0.9)
 
 BUNDLED WITH
    2.3.26

--- a/gemfiles/ruby_2.5_resque2_redis4.gemfile
+++ b/gemfiles/ruby_2.5_resque2_redis4.gemfile
@@ -27,7 +27,6 @@ gem "simplecov-cobertura", "~> 2.1.0"
 gem "warning", "~> 1"
 gem "webmock", ">= 3.10.0"
 gem "rexml", ">= 3.2.7"
-gem "yard", "~> 0.9"
 gem "dogstatsd-ruby", ">= 3.3.0", "!= 5.0.0", "!= 5.0.1", "!= 5.1.0"
 gem "google-protobuf", ["~> 3.0", "!= 3.7.0", "!= 3.7.1", "< 3.19.2"]
 gem "ffi", "~> 1.16.3", require: false

--- a/gemfiles/ruby_2.5_resque2_redis4.gemfile.lock
+++ b/gemfiles/ruby_2.5_resque2_redis4.gemfile.lock
@@ -129,9 +129,6 @@ GEM
       addressable (>= 2.3.6)
       crack (>= 0.3.2)
       hashdiff (>= 0.4.0, < 2.0.0)
-    webrick (1.7.0)
-    yard (0.9.28)
-      webrick (~> 1.7.0)
 
 PLATFORMS
   aarch64-linux
@@ -169,7 +166,6 @@ DEPENDENCIES
   simplecov-cobertura (~> 2.1.0)
   warning (~> 1)
   webmock (>= 3.10.0)
-  yard (~> 0.9)
 
 BUNDLED WITH
    2.3.26

--- a/gemfiles/ruby_2.5_sinatra_2.gemfile
+++ b/gemfiles/ruby_2.5_sinatra_2.gemfile
@@ -27,7 +27,6 @@ gem "simplecov-cobertura", "~> 2.1.0"
 gem "warning", "~> 1"
 gem "webmock", ">= 3.10.0"
 gem "rexml", ">= 3.2.7"
-gem "yard", "~> 0.9"
 gem "dogstatsd-ruby", ">= 3.3.0", "!= 5.0.0", "!= 5.0.1", "!= 5.1.0"
 gem "google-protobuf", ["~> 3.0", "!= 3.7.0", "!= 3.7.1", "< 3.19.2"]
 gem "ffi", "~> 1.16.3", require: false

--- a/gemfiles/ruby_2.5_sinatra_2.gemfile.lock
+++ b/gemfiles/ruby_2.5_sinatra_2.gemfile.lock
@@ -123,7 +123,6 @@ GEM
       addressable (>= 2.8.0)
       crack (>= 0.3.2)
       hashdiff (>= 0.4.0, < 2.0.0)
-    yard (0.9.36)
 
 PLATFORMS
   aarch64-linux
@@ -162,7 +161,6 @@ DEPENDENCIES
   sinatra (~> 2)
   warning (~> 1)
   webmock (>= 3.10.0)
-  yard (~> 0.9)
 
 BUNDLED WITH
    2.3.26

--- a/gemfiles/ruby_2.5_stripe_10.gemfile
+++ b/gemfiles/ruby_2.5_stripe_10.gemfile
@@ -27,7 +27,6 @@ gem "simplecov-cobertura", "~> 2.1.0"
 gem "warning", "~> 1"
 gem "webmock", ">= 3.10.0"
 gem "rexml", ">= 3.2.7"
-gem "yard", "~> 0.9"
 gem "dogstatsd-ruby", ">= 3.3.0", "!= 5.0.0", "!= 5.0.1", "!= 5.1.0"
 gem "google-protobuf", ["~> 3.0", "!= 3.7.0", "!= 3.7.1", "< 3.19.2"]
 gem "ffi", "~> 1.16.3", require: false

--- a/gemfiles/ruby_2.5_stripe_10.gemfile.lock
+++ b/gemfiles/ruby_2.5_stripe_10.gemfile.lock
@@ -108,7 +108,6 @@ GEM
       addressable (>= 2.8.0)
       crack (>= 0.3.2)
       hashdiff (>= 0.4.0, < 2.0.0)
-    yard (0.9.36)
 
 PLATFORMS
   aarch64-linux
@@ -145,7 +144,6 @@ DEPENDENCIES
   stripe (~> 10)
   warning (~> 1)
   webmock (>= 3.10.0)
-  yard (~> 0.9)
 
 BUNDLED WITH
    2.3.26

--- a/gemfiles/ruby_2.5_stripe_11.gemfile
+++ b/gemfiles/ruby_2.5_stripe_11.gemfile
@@ -27,7 +27,6 @@ gem "simplecov-cobertura", "~> 2.1.0"
 gem "warning", "~> 1"
 gem "webmock", ">= 3.10.0"
 gem "rexml", ">= 3.2.7"
-gem "yard", "~> 0.9"
 gem "dogstatsd-ruby", ">= 3.3.0", "!= 5.0.0", "!= 5.0.1", "!= 5.1.0"
 gem "google-protobuf", ["~> 3.0", "!= 3.7.0", "!= 3.7.1", "< 3.19.2"]
 gem "ffi", "~> 1.16.3", require: false

--- a/gemfiles/ruby_2.5_stripe_11.gemfile.lock
+++ b/gemfiles/ruby_2.5_stripe_11.gemfile.lock
@@ -108,7 +108,6 @@ GEM
       addressable (>= 2.8.0)
       crack (>= 0.3.2)
       hashdiff (>= 0.4.0, < 2.0.0)
-    yard (0.9.36)
 
 PLATFORMS
   aarch64-linux
@@ -145,7 +144,6 @@ DEPENDENCIES
   stripe (~> 11)
   warning (~> 1)
   webmock (>= 3.10.0)
-  yard (~> 0.9)
 
 BUNDLED WITH
    2.3.26

--- a/gemfiles/ruby_2.5_stripe_12.gemfile
+++ b/gemfiles/ruby_2.5_stripe_12.gemfile
@@ -27,7 +27,6 @@ gem "simplecov-cobertura", "~> 2.1.0"
 gem "warning", "~> 1"
 gem "webmock", ">= 3.10.0"
 gem "rexml", ">= 3.2.7"
-gem "yard", "~> 0.9"
 gem "dogstatsd-ruby", ">= 3.3.0", "!= 5.0.0", "!= 5.0.1", "!= 5.1.0"
 gem "google-protobuf", ["~> 3.0", "!= 3.7.0", "!= 3.7.1", "< 3.19.2"]
 gem "ffi", "~> 1.16.3", require: false

--- a/gemfiles/ruby_2.5_stripe_12.gemfile.lock
+++ b/gemfiles/ruby_2.5_stripe_12.gemfile.lock
@@ -108,7 +108,6 @@ GEM
       addressable (>= 2.8.0)
       crack (>= 0.3.2)
       hashdiff (>= 0.4.0, < 2.0.0)
-    yard (0.9.36)
 
 PLATFORMS
   aarch64-linux
@@ -145,7 +144,6 @@ DEPENDENCIES
   stripe (~> 12)
   warning (~> 1)
   webmock (>= 3.10.0)
-  yard (~> 0.9)
 
 BUNDLED WITH
    2.3.26

--- a/gemfiles/ruby_2.5_stripe_7.gemfile
+++ b/gemfiles/ruby_2.5_stripe_7.gemfile
@@ -27,7 +27,6 @@ gem "simplecov-cobertura", "~> 2.1.0"
 gem "warning", "~> 1"
 gem "webmock", ">= 3.10.0"
 gem "rexml", ">= 3.2.7"
-gem "yard", "~> 0.9"
 gem "dogstatsd-ruby", ">= 3.3.0", "!= 5.0.0", "!= 5.0.1", "!= 5.1.0"
 gem "google-protobuf", ["~> 3.0", "!= 3.7.0", "!= 3.7.1", "< 3.19.2"]
 gem "ffi", "~> 1.16.3", require: false

--- a/gemfiles/ruby_2.5_stripe_7.gemfile.lock
+++ b/gemfiles/ruby_2.5_stripe_7.gemfile.lock
@@ -108,7 +108,6 @@ GEM
       addressable (>= 2.8.0)
       crack (>= 0.3.2)
       hashdiff (>= 0.4.0, < 2.0.0)
-    yard (0.9.36)
 
 PLATFORMS
   aarch64-linux
@@ -145,7 +144,6 @@ DEPENDENCIES
   stripe (~> 7)
   warning (~> 1)
   webmock (>= 3.10.0)
-  yard (~> 0.9)
 
 BUNDLED WITH
    2.3.26

--- a/gemfiles/ruby_2.5_stripe_8.gemfile
+++ b/gemfiles/ruby_2.5_stripe_8.gemfile
@@ -27,7 +27,6 @@ gem "simplecov-cobertura", "~> 2.1.0"
 gem "warning", "~> 1"
 gem "webmock", ">= 3.10.0"
 gem "rexml", ">= 3.2.7"
-gem "yard", "~> 0.9"
 gem "dogstatsd-ruby", ">= 3.3.0", "!= 5.0.0", "!= 5.0.1", "!= 5.1.0"
 gem "google-protobuf", ["~> 3.0", "!= 3.7.0", "!= 3.7.1", "< 3.19.2"]
 gem "ffi", "~> 1.16.3", require: false

--- a/gemfiles/ruby_2.5_stripe_8.gemfile.lock
+++ b/gemfiles/ruby_2.5_stripe_8.gemfile.lock
@@ -108,7 +108,6 @@ GEM
       addressable (>= 2.8.0)
       crack (>= 0.3.2)
       hashdiff (>= 0.4.0, < 2.0.0)
-    yard (0.9.36)
 
 PLATFORMS
   aarch64-linux
@@ -145,7 +144,6 @@ DEPENDENCIES
   stripe (~> 8)
   warning (~> 1)
   webmock (>= 3.10.0)
-  yard (~> 0.9)
 
 BUNDLED WITH
    2.3.26

--- a/gemfiles/ruby_2.5_stripe_9.gemfile
+++ b/gemfiles/ruby_2.5_stripe_9.gemfile
@@ -27,7 +27,6 @@ gem "simplecov-cobertura", "~> 2.1.0"
 gem "warning", "~> 1"
 gem "webmock", ">= 3.10.0"
 gem "rexml", ">= 3.2.7"
-gem "yard", "~> 0.9"
 gem "dogstatsd-ruby", ">= 3.3.0", "!= 5.0.0", "!= 5.0.1", "!= 5.1.0"
 gem "google-protobuf", ["~> 3.0", "!= 3.7.0", "!= 3.7.1", "< 3.19.2"]
 gem "ffi", "~> 1.16.3", require: false

--- a/gemfiles/ruby_2.5_stripe_9.gemfile.lock
+++ b/gemfiles/ruby_2.5_stripe_9.gemfile.lock
@@ -108,7 +108,6 @@ GEM
       addressable (>= 2.8.0)
       crack (>= 0.3.2)
       hashdiff (>= 0.4.0, < 2.0.0)
-    yard (0.9.36)
 
 PLATFORMS
   aarch64-linux
@@ -145,7 +144,6 @@ DEPENDENCIES
   stripe (~> 9)
   warning (~> 1)
   webmock (>= 3.10.0)
-  yard (~> 0.9)
 
 BUNDLED WITH
    2.3.26

--- a/gemfiles/ruby_2.6_activesupport.gemfile
+++ b/gemfiles/ruby_2.6_activesupport.gemfile
@@ -27,7 +27,6 @@ gem "simplecov-cobertura", "~> 2.1.0"
 gem "warning", "~> 1"
 gem "webmock", ">= 3.10.0"
 gem "rexml", ">= 3.2.7"
-gem "yard", "~> 0.9"
 gem "rubocop", "~> 1.50.0", require: false
 gem "rubocop-packaging", "~> 0.5.2", require: false
 gem "rubocop-performance", "~> 1.9", require: false

--- a/gemfiles/ruby_2.6_activesupport.gemfile.lock
+++ b/gemfiles/ruby_2.6_activesupport.gemfile.lock
@@ -249,7 +249,6 @@ GEM
       addressable (>= 2.3.6)
       crack (>= 0.3.2)
       hashdiff (>= 0.4.0, < 2.0.0)
-    yard (0.9.34)
     zeitwerk (2.6.11)
 
 PLATFORMS
@@ -298,7 +297,6 @@ DEPENDENCIES
   simplecov-cobertura (~> 2.1.0)
   warning (~> 1)
   webmock (>= 3.10.0)
-  yard (~> 0.9)
 
 BUNDLED WITH
    2.3.26

--- a/gemfiles/ruby_2.6_aws.gemfile
+++ b/gemfiles/ruby_2.6_aws.gemfile
@@ -27,7 +27,6 @@ gem "simplecov-cobertura", "~> 2.1.0"
 gem "warning", "~> 1"
 gem "webmock", ">= 3.10.0"
 gem "rexml", ">= 3.2.7"
-gem "yard", "~> 0.9"
 gem "rubocop", "~> 1.50.0", require: false
 gem "rubocop-packaging", "~> 0.5.2", require: false
 gem "rubocop-performance", "~> 1.9", require: false

--- a/gemfiles/ruby_2.6_aws.gemfile.lock
+++ b/gemfiles/ruby_2.6_aws.gemfile.lock
@@ -1564,7 +1564,6 @@ GEM
       addressable (>= 2.3.6)
       crack (>= 0.3.2)
       hashdiff (>= 0.4.0, < 2.0.0)
-    yard (0.9.34)
 
 PLATFORMS
   aarch64-linux
@@ -1606,7 +1605,6 @@ DEPENDENCIES
   simplecov-cobertura (~> 2.1.0)
   warning (~> 1)
   webmock (>= 3.10.0)
-  yard (~> 0.9)
 
 BUNDLED WITH
    2.3.26

--- a/gemfiles/ruby_2.6_contrib.gemfile
+++ b/gemfiles/ruby_2.6_contrib.gemfile
@@ -27,7 +27,6 @@ gem "simplecov-cobertura", "~> 2.1.0"
 gem "warning", "~> 1"
 gem "webmock", ">= 3.10.0"
 gem "rexml", ">= 3.2.7"
-gem "yard", "~> 0.9"
 gem "rubocop", "~> 1.50.0", require: false
 gem "rubocop-packaging", "~> 0.5.2", require: false
 gem "rubocop-performance", "~> 1.9", require: false

--- a/gemfiles/ruby_2.6_contrib.gemfile.lock
+++ b/gemfiles/ruby_2.6_contrib.gemfile.lock
@@ -202,9 +202,6 @@ GEM
       addressable (>= 2.3.6)
       crack (>= 0.3.2)
       hashdiff (>= 0.4.0, < 2.0.0)
-    webrick (1.7.0)
-    yard (0.9.28)
-      webrick (~> 1.7.0)
 
 PLATFORMS
   aarch64-linux
@@ -256,7 +253,6 @@ DEPENDENCIES
   sucker_punch
   warning (~> 1)
   webmock (>= 3.10.0)
-  yard (~> 0.9)
 
 BUNDLED WITH
    2.3.26

--- a/gemfiles/ruby_2.6_contrib_old.gemfile
+++ b/gemfiles/ruby_2.6_contrib_old.gemfile
@@ -27,7 +27,6 @@ gem "simplecov-cobertura", "~> 2.1.0"
 gem "warning", "~> 1"
 gem "webmock", ">= 3.10.0"
 gem "rexml", ">= 3.2.7"
-gem "yard", "~> 0.9"
 gem "rubocop", "~> 1.50.0", require: false
 gem "rubocop-packaging", "~> 0.5.2", require: false
 gem "rubocop-performance", "~> 1.9", require: false

--- a/gemfiles/ruby_2.6_contrib_old.gemfile.lock
+++ b/gemfiles/ruby_2.6_contrib_old.gemfile.lock
@@ -189,9 +189,6 @@ GEM
       addressable (>= 2.3.6)
       crack (>= 0.3.2)
       hashdiff (>= 0.4.0, < 2.0.0)
-    webrick (1.7.0)
-    yard (0.9.28)
-      webrick (~> 1.7.0)
 
 PLATFORMS
   aarch64-linux
@@ -235,7 +232,6 @@ DEPENDENCIES
   simplecov-cobertura (~> 2.1.0)
   warning (~> 1)
   webmock (>= 3.10.0)
-  yard (~> 0.9)
 
 BUNDLED WITH
    2.3.26

--- a/gemfiles/ruby_2.6_core_old.gemfile
+++ b/gemfiles/ruby_2.6_core_old.gemfile
@@ -27,7 +27,6 @@ gem "simplecov-cobertura", "~> 2.1.0"
 gem "warning", "~> 1"
 gem "webmock", ">= 3.10.0"
 gem "rexml", ">= 3.2.7"
-gem "yard", "~> 0.9"
 gem "rubocop", "~> 1.50.0", require: false
 gem "rubocop-packaging", "~> 0.5.2", require: false
 gem "rubocop-performance", "~> 1.9", require: false

--- a/gemfiles/ruby_2.6_core_old.gemfile.lock
+++ b/gemfiles/ruby_2.6_core_old.gemfile.lock
@@ -136,9 +136,6 @@ GEM
       addressable (>= 2.3.6)
       crack (>= 0.3.2)
       hashdiff (>= 0.4.0, < 2.0.0)
-    webrick (1.7.0)
-    yard (0.9.28)
-      webrick (~> 1.7.0)
 
 PLATFORMS
   aarch64-linux
@@ -178,7 +175,6 @@ DEPENDENCIES
   simplecov-cobertura (~> 2.1.0)
   warning (~> 1)
   webmock (>= 3.10.0)
-  yard (~> 0.9)
 
 BUNDLED WITH
    2.3.26

--- a/gemfiles/ruby_2.6_elasticsearch_7.gemfile
+++ b/gemfiles/ruby_2.6_elasticsearch_7.gemfile
@@ -27,7 +27,6 @@ gem "simplecov-cobertura", "~> 2.1.0"
 gem "warning", "~> 1"
 gem "webmock", ">= 3.10.0"
 gem "rexml", ">= 3.2.7"
-gem "yard", "~> 0.9"
 gem "rubocop", "~> 1.50.0", require: false
 gem "rubocop-packaging", "~> 0.5.2", require: false
 gem "rubocop-performance", "~> 1.9", require: false

--- a/gemfiles/ruby_2.6_elasticsearch_7.gemfile.lock
+++ b/gemfiles/ruby_2.6_elasticsearch_7.gemfile.lock
@@ -174,7 +174,6 @@ GEM
       addressable (>= 2.8.0)
       crack (>= 0.3.2)
       hashdiff (>= 0.4.0, < 2.0.0)
-    yard (0.9.34)
 
 PLATFORMS
   aarch64-linux
@@ -215,7 +214,6 @@ DEPENDENCIES
   simplecov-cobertura (~> 2.1.0)
   warning (~> 1)
   webmock (>= 3.10.0)
-  yard (~> 0.9)
 
 BUNDLED WITH
    2.3.26

--- a/gemfiles/ruby_2.6_elasticsearch_8.gemfile
+++ b/gemfiles/ruby_2.6_elasticsearch_8.gemfile
@@ -27,7 +27,6 @@ gem "simplecov-cobertura", "~> 2.1.0"
 gem "warning", "~> 1"
 gem "webmock", ">= 3.10.0"
 gem "rexml", ">= 3.2.7"
-gem "yard", "~> 0.9"
 gem "rubocop", "~> 1.50.0", require: false
 gem "rubocop-packaging", "~> 0.5.2", require: false
 gem "rubocop-performance", "~> 1.9", require: false

--- a/gemfiles/ruby_2.6_elasticsearch_8.gemfile.lock
+++ b/gemfiles/ruby_2.6_elasticsearch_8.gemfile.lock
@@ -156,7 +156,6 @@ GEM
       addressable (>= 2.8.0)
       crack (>= 0.3.2)
       hashdiff (>= 0.4.0, < 2.0.0)
-    yard (0.9.34)
 
 PLATFORMS
   aarch64-linux
@@ -197,7 +196,6 @@ DEPENDENCIES
   simplecov-cobertura (~> 2.1.0)
   warning (~> 1)
   webmock (>= 3.10.0)
-  yard (~> 0.9)
 
 BUNDLED WITH
    2.3.26

--- a/gemfiles/ruby_2.6_graphql_1.13.gemfile
+++ b/gemfiles/ruby_2.6_graphql_1.13.gemfile
@@ -27,7 +27,6 @@ gem "simplecov-cobertura", "~> 2.1.0"
 gem "warning", "~> 1"
 gem "webmock", ">= 3.10.0"
 gem "rexml", ">= 3.2.7"
-gem "yard", "~> 0.9"
 gem "rubocop", "~> 1.50.0", require: false
 gem "rubocop-packaging", "~> 0.5.2", require: false
 gem "rubocop-performance", "~> 1.9", require: false

--- a/gemfiles/ruby_2.6_graphql_1.13.gemfile.lock
+++ b/gemfiles/ruby_2.6_graphql_1.13.gemfile.lock
@@ -284,7 +284,6 @@ GEM
     websocket-driver (0.7.6)
       websocket-extensions (>= 0.1.0)
     websocket-extensions (0.1.5)
-    yard (0.9.34)
     zeitwerk (2.6.16)
 
 PLATFORMS
@@ -329,7 +328,6 @@ DEPENDENCIES
   sprockets (< 4)
   warning (~> 1)
   webmock (>= 3.10.0)
-  yard (~> 0.9)
 
 BUNDLED WITH
    2.3.26

--- a/gemfiles/ruby_2.6_graphql_2.0.gemfile
+++ b/gemfiles/ruby_2.6_graphql_2.0.gemfile
@@ -27,7 +27,6 @@ gem "simplecov-cobertura", "~> 2.1.0"
 gem "warning", "~> 1"
 gem "webmock", ">= 3.10.0"
 gem "rexml", ">= 3.2.7"
-gem "yard", "~> 0.9"
 gem "rubocop", "~> 1.50.0", require: false
 gem "rubocop-packaging", "~> 0.5.2", require: false
 gem "rubocop-performance", "~> 1.9", require: false

--- a/gemfiles/ruby_2.6_graphql_2.0.gemfile.lock
+++ b/gemfiles/ruby_2.6_graphql_2.0.gemfile.lock
@@ -284,7 +284,6 @@ GEM
     websocket-driver (0.7.6)
       websocket-extensions (>= 0.1.0)
     websocket-extensions (0.1.5)
-    yard (0.9.34)
     zeitwerk (2.6.16)
 
 PLATFORMS
@@ -329,7 +328,6 @@ DEPENDENCIES
   sprockets (< 4)
   warning (~> 1)
   webmock (>= 3.10.0)
-  yard (~> 0.9)
 
 BUNDLED WITH
    2.3.26

--- a/gemfiles/ruby_2.6_hanami_1.gemfile
+++ b/gemfiles/ruby_2.6_hanami_1.gemfile
@@ -27,7 +27,6 @@ gem "simplecov-cobertura", "~> 2.1.0"
 gem "warning", "~> 1"
 gem "webmock", ">= 3.10.0"
 gem "rexml", ">= 3.2.7"
-gem "yard", "~> 0.9"
 gem "rubocop", "~> 1.50.0", require: false
 gem "rubocop-packaging", "~> 0.5.2", require: false
 gem "rubocop-performance", "~> 1.9", require: false

--- a/gemfiles/ruby_2.6_hanami_1.gemfile.lock
+++ b/gemfiles/ruby_2.6_hanami_1.gemfile.lock
@@ -234,9 +234,6 @@ GEM
       addressable (>= 2.3.6)
       crack (>= 0.3.2)
       hashdiff (>= 0.4.0, < 2.0.0)
-    webrick (1.7.0)
-    yard (0.9.28)
-      webrick (~> 1.7.0)
 
 PLATFORMS
   aarch64-linux
@@ -279,7 +276,6 @@ DEPENDENCIES
   simplecov-cobertura (~> 2.1.0)
   warning (~> 1)
   webmock (>= 3.10.0)
-  yard (~> 0.9)
 
 BUNDLED WITH
    2.3.26

--- a/gemfiles/ruby_2.6_http.gemfile
+++ b/gemfiles/ruby_2.6_http.gemfile
@@ -27,7 +27,6 @@ gem "simplecov-cobertura", "~> 2.1.0"
 gem "warning", "~> 1"
 gem "webmock", ">= 3.10.0"
 gem "rexml", ">= 3.2.7"
-gem "yard", "~> 0.9"
 gem "rubocop", "~> 1.50.0", require: false
 gem "rubocop-packaging", "~> 0.5.2", require: false
 gem "rubocop-performance", "~> 1.9", require: false

--- a/gemfiles/ruby_2.6_http.gemfile.lock
+++ b/gemfiles/ruby_2.6_http.gemfile.lock
@@ -178,7 +178,6 @@ GEM
       addressable (>= 2.3.6)
       crack (>= 0.3.2)
       hashdiff (>= 0.4.0, < 2.0.0)
-    yard (0.9.34)
 
 PLATFORMS
   aarch64-linux
@@ -225,7 +224,6 @@ DEPENDENCIES
   typhoeus
   warning (~> 1)
   webmock (>= 3.10.0)
-  yard (~> 0.9)
 
 BUNDLED WITH
    2.3.26

--- a/gemfiles/ruby_2.6_opensearch_2.gemfile
+++ b/gemfiles/ruby_2.6_opensearch_2.gemfile
@@ -27,7 +27,6 @@ gem "simplecov-cobertura", "~> 2.1.0"
 gem "warning", "~> 1"
 gem "webmock", ">= 3.10.0"
 gem "rexml", ">= 3.2.7"
-gem "yard", "~> 0.9"
 gem "rubocop", "~> 1.50.0", require: false
 gem "rubocop-packaging", "~> 0.5.2", require: false
 gem "rubocop-performance", "~> 1.9", require: false

--- a/gemfiles/ruby_2.6_opensearch_2.gemfile.lock
+++ b/gemfiles/ruby_2.6_opensearch_2.gemfile.lock
@@ -156,7 +156,6 @@ GEM
       addressable (>= 2.8.0)
       crack (>= 0.3.2)
       hashdiff (>= 0.4.0, < 2.0.0)
-    yard (0.9.34)
 
 PLATFORMS
   aarch64-linux
@@ -197,7 +196,6 @@ DEPENDENCIES
   simplecov-cobertura (~> 2.1.0)
   warning (~> 1)
   webmock (>= 3.10.0)
-  yard (~> 0.9)
 
 BUNDLED WITH
    2.3.26

--- a/gemfiles/ruby_2.6_opensearch_3.gemfile
+++ b/gemfiles/ruby_2.6_opensearch_3.gemfile
@@ -27,7 +27,6 @@ gem "simplecov-cobertura", "~> 2.1.0"
 gem "warning", "~> 1"
 gem "webmock", ">= 3.10.0"
 gem "rexml", ">= 3.2.7"
-gem "yard", "~> 0.9"
 gem "rubocop", "~> 1.50.0", require: false
 gem "rubocop-packaging", "~> 0.5.2", require: false
 gem "rubocop-performance", "~> 1.9", require: false

--- a/gemfiles/ruby_2.6_opensearch_3.gemfile.lock
+++ b/gemfiles/ruby_2.6_opensearch_3.gemfile.lock
@@ -151,7 +151,6 @@ GEM
       addressable (>= 2.8.0)
       crack (>= 0.3.2)
       hashdiff (>= 0.4.0, < 2.0.0)
-    yard (0.9.34)
 
 PLATFORMS
   aarch64-linux
@@ -192,7 +191,6 @@ DEPENDENCIES
   simplecov-cobertura (~> 2.1.0)
   warning (~> 1)
   webmock (>= 3.10.0)
-  yard (~> 0.9)
 
 BUNDLED WITH
    2.3.26

--- a/gemfiles/ruby_2.6_opentelemetry.gemfile
+++ b/gemfiles/ruby_2.6_opentelemetry.gemfile
@@ -27,7 +27,6 @@ gem "simplecov-cobertura", "~> 2.1.0"
 gem "warning", "~> 1"
 gem "webmock", ">= 3.10.0"
 gem "rexml", ">= 3.2.7"
-gem "yard", "~> 0.9"
 gem "rubocop", "~> 1.50.0", require: false
 gem "rubocop-packaging", "~> 0.5.2", require: false
 gem "rubocop-performance", "~> 1.9", require: false

--- a/gemfiles/ruby_2.6_opentelemetry.gemfile.lock
+++ b/gemfiles/ruby_2.6_opentelemetry.gemfile.lock
@@ -148,9 +148,6 @@ GEM
       addressable (>= 2.3.6)
       crack (>= 0.3.2)
       hashdiff (>= 0.4.0, < 2.0.0)
-    webrick (1.7.0)
-    yard (0.9.28)
-      webrick (~> 1.7.0)
 
 PLATFORMS
   aarch64-linux
@@ -191,7 +188,6 @@ DEPENDENCIES
   simplecov-cobertura (~> 2.1.0)
   warning (~> 1)
   webmock (>= 3.10.0)
-  yard (~> 0.9)
 
 BUNDLED WITH
    2.3.26

--- a/gemfiles/ruby_2.6_rack_1.gemfile
+++ b/gemfiles/ruby_2.6_rack_1.gemfile
@@ -27,7 +27,6 @@ gem "simplecov-cobertura", "~> 2.1.0"
 gem "warning", "~> 1"
 gem "webmock", ">= 3.10.0"
 gem "rexml", ">= 3.2.7"
-gem "yard", "~> 0.9"
 gem "rubocop", "~> 1.50.0", require: false
 gem "rubocop-packaging", "~> 0.5.2", require: false
 gem "rubocop-performance", "~> 1.9", require: false

--- a/gemfiles/ruby_2.6_rack_1.gemfile.lock
+++ b/gemfiles/ruby_2.6_rack_1.gemfile.lock
@@ -143,7 +143,6 @@ GEM
       addressable (>= 2.3.6)
       crack (>= 0.3.2)
       hashdiff (>= 0.4.0, < 2.0.0)
-    yard (0.9.34)
 
 PLATFORMS
   aarch64-linux
@@ -186,7 +185,6 @@ DEPENDENCIES
   simplecov-cobertura (~> 2.1.0)
   warning (~> 1)
   webmock (>= 3.10.0)
-  yard (~> 0.9)
 
 BUNDLED WITH
    2.3.26

--- a/gemfiles/ruby_2.6_rack_2.gemfile
+++ b/gemfiles/ruby_2.6_rack_2.gemfile
@@ -27,7 +27,6 @@ gem "simplecov-cobertura", "~> 2.1.0"
 gem "warning", "~> 1"
 gem "webmock", ">= 3.10.0"
 gem "rexml", ">= 3.2.7"
-gem "yard", "~> 0.9"
 gem "rubocop", "~> 1.50.0", require: false
 gem "rubocop-packaging", "~> 0.5.2", require: false
 gem "rubocop-performance", "~> 1.9", require: false

--- a/gemfiles/ruby_2.6_rack_2.gemfile.lock
+++ b/gemfiles/ruby_2.6_rack_2.gemfile.lock
@@ -143,7 +143,6 @@ GEM
       addressable (>= 2.3.6)
       crack (>= 0.3.2)
       hashdiff (>= 0.4.0, < 2.0.0)
-    yard (0.9.34)
 
 PLATFORMS
   aarch64-linux
@@ -186,7 +185,6 @@ DEPENDENCIES
   simplecov-cobertura (~> 2.1.0)
   warning (~> 1)
   webmock (>= 3.10.0)
-  yard (~> 0.9)
 
 BUNDLED WITH
    2.3.26

--- a/gemfiles/ruby_2.6_rack_3.gemfile
+++ b/gemfiles/ruby_2.6_rack_3.gemfile
@@ -27,7 +27,6 @@ gem "simplecov-cobertura", "~> 2.1.0"
 gem "warning", "~> 1"
 gem "webmock", ">= 3.10.0"
 gem "rexml", ">= 3.2.7"
-gem "yard", "~> 0.9"
 gem "rubocop", "~> 1.50.0", require: false
 gem "rubocop-packaging", "~> 0.5.2", require: false
 gem "rubocop-performance", "~> 1.9", require: false

--- a/gemfiles/ruby_2.6_rack_3.gemfile.lock
+++ b/gemfiles/ruby_2.6_rack_3.gemfile.lock
@@ -143,7 +143,6 @@ GEM
       addressable (>= 2.3.6)
       crack (>= 0.3.2)
       hashdiff (>= 0.4.0, < 2.0.0)
-    yard (0.9.34)
 
 PLATFORMS
   aarch64-linux
@@ -186,7 +185,6 @@ DEPENDENCIES
   simplecov-cobertura (~> 2.1.0)
   warning (~> 1)
   webmock (>= 3.10.0)
-  yard (~> 0.9)
 
 BUNDLED WITH
    2.3.26

--- a/gemfiles/ruby_2.6_rails5_mysql2.gemfile
+++ b/gemfiles/ruby_2.6_rails5_mysql2.gemfile
@@ -27,7 +27,6 @@ gem "simplecov-cobertura", "~> 2.1.0"
 gem "warning", "~> 1"
 gem "webmock", ">= 3.10.0"
 gem "rexml", ">= 3.2.7"
-gem "yard", "~> 0.9"
 gem "rubocop", "~> 1.50.0", require: false
 gem "rubocop-packaging", "~> 0.5.2", require: false
 gem "rubocop-performance", "~> 1.9", require: false

--- a/gemfiles/ruby_2.6_rails5_mysql2.gemfile.lock
+++ b/gemfiles/ruby_2.6_rails5_mysql2.gemfile.lock
@@ -257,12 +257,9 @@ GEM
       addressable (>= 2.3.6)
       crack (>= 0.3.2)
       hashdiff (>= 0.4.0, < 2.0.0)
-    webrick (1.7.0)
     websocket-driver (0.7.5)
       websocket-extensions (>= 0.1.0)
     websocket-extensions (0.1.5)
-    yard (0.9.28)
-      webrick (~> 1.7.0)
 
 PLATFORMS
   aarch64-linux
@@ -306,7 +303,6 @@ DEPENDENCIES
   sprockets (< 4)
   warning (~> 1)
   webmock (>= 3.10.0)
-  yard (~> 0.9)
 
 BUNDLED WITH
    2.3.26

--- a/gemfiles/ruby_2.6_rails5_postgres.gemfile
+++ b/gemfiles/ruby_2.6_rails5_postgres.gemfile
@@ -27,7 +27,6 @@ gem "simplecov-cobertura", "~> 2.1.0"
 gem "warning", "~> 1"
 gem "webmock", ">= 3.10.0"
 gem "rexml", ">= 3.2.7"
-gem "yard", "~> 0.9"
 gem "rubocop", "~> 1.50.0", require: false
 gem "rubocop-packaging", "~> 0.5.2", require: false
 gem "rubocop-performance", "~> 1.9", require: false

--- a/gemfiles/ruby_2.6_rails5_postgres.gemfile.lock
+++ b/gemfiles/ruby_2.6_rails5_postgres.gemfile.lock
@@ -257,12 +257,9 @@ GEM
       addressable (>= 2.3.6)
       crack (>= 0.3.2)
       hashdiff (>= 0.4.0, < 2.0.0)
-    webrick (1.7.0)
     websocket-driver (0.7.5)
       websocket-extensions (>= 0.1.0)
     websocket-extensions (0.1.5)
-    yard (0.9.28)
-      webrick (~> 1.7.0)
 
 PLATFORMS
   aarch64-linux
@@ -306,7 +303,6 @@ DEPENDENCIES
   sprockets (< 4)
   warning (~> 1)
   webmock (>= 3.10.0)
-  yard (~> 0.9)
 
 BUNDLED WITH
    2.3.26

--- a/gemfiles/ruby_2.6_rails5_postgres_redis.gemfile
+++ b/gemfiles/ruby_2.6_rails5_postgres_redis.gemfile
@@ -27,7 +27,6 @@ gem "simplecov-cobertura", "~> 2.1.0"
 gem "warning", "~> 1"
 gem "webmock", ">= 3.10.0"
 gem "rexml", ">= 3.2.7"
-gem "yard", "~> 0.9"
 gem "rubocop", "~> 1.50.0", require: false
 gem "rubocop-packaging", "~> 0.5.2", require: false
 gem "rubocop-performance", "~> 1.9", require: false

--- a/gemfiles/ruby_2.6_rails5_postgres_redis.gemfile.lock
+++ b/gemfiles/ruby_2.6_rails5_postgres_redis.gemfile.lock
@@ -258,12 +258,9 @@ GEM
       addressable (>= 2.3.6)
       crack (>= 0.3.2)
       hashdiff (>= 0.4.0, < 2.0.0)
-    webrick (1.7.0)
     websocket-driver (0.7.5)
       websocket-extensions (>= 0.1.0)
     websocket-extensions (0.1.5)
-    yard (0.9.28)
-      webrick (~> 1.7.0)
 
 PLATFORMS
   aarch64-linux
@@ -308,7 +305,6 @@ DEPENDENCIES
   sprockets (< 4)
   warning (~> 1)
   webmock (>= 3.10.0)
-  yard (~> 0.9)
 
 BUNDLED WITH
    2.3.26

--- a/gemfiles/ruby_2.6_rails5_postgres_redis_activesupport.gemfile
+++ b/gemfiles/ruby_2.6_rails5_postgres_redis_activesupport.gemfile
@@ -27,7 +27,6 @@ gem "simplecov-cobertura", "~> 2.1.0"
 gem "warning", "~> 1"
 gem "webmock", ">= 3.10.0"
 gem "rexml", ">= 3.2.7"
-gem "yard", "~> 0.9"
 gem "rubocop", "~> 1.50.0", require: false
 gem "rubocop-packaging", "~> 0.5.2", require: false
 gem "rubocop-performance", "~> 1.9", require: false

--- a/gemfiles/ruby_2.6_rails5_postgres_redis_activesupport.gemfile.lock
+++ b/gemfiles/ruby_2.6_rails5_postgres_redis_activesupport.gemfile.lock
@@ -274,12 +274,9 @@ GEM
       addressable (>= 2.3.6)
       crack (>= 0.3.2)
       hashdiff (>= 0.4.0, < 2.0.0)
-    webrick (1.7.0)
     websocket-driver (0.7.5)
       websocket-extensions (>= 0.1.0)
     websocket-extensions (0.1.5)
-    yard (0.9.28)
-      webrick (~> 1.7.0)
 
 PLATFORMS
   aarch64-linux
@@ -326,7 +323,6 @@ DEPENDENCIES
   sprockets (< 4)
   warning (~> 1)
   webmock (>= 3.10.0)
-  yard (~> 0.9)
 
 BUNDLED WITH
    2.3.26

--- a/gemfiles/ruby_2.6_rails5_postgres_sidekiq.gemfile
+++ b/gemfiles/ruby_2.6_rails5_postgres_sidekiq.gemfile
@@ -27,7 +27,6 @@ gem "simplecov-cobertura", "~> 2.1.0"
 gem "warning", "~> 1"
 gem "webmock", ">= 3.10.0"
 gem "rexml", ">= 3.2.7"
-gem "yard", "~> 0.9"
 gem "rubocop", "~> 1.50.0", require: false
 gem "rubocop-packaging", "~> 0.5.2", require: false
 gem "rubocop-performance", "~> 1.9", require: false

--- a/gemfiles/ruby_2.6_rails5_postgres_sidekiq.gemfile.lock
+++ b/gemfiles/ruby_2.6_rails5_postgres_sidekiq.gemfile.lock
@@ -263,12 +263,9 @@ GEM
       addressable (>= 2.3.6)
       crack (>= 0.3.2)
       hashdiff (>= 0.4.0, < 2.0.0)
-    webrick (1.7.0)
     websocket-driver (0.7.5)
       websocket-extensions (>= 0.1.0)
     websocket-extensions (0.1.5)
-    yard (0.9.28)
-      webrick (~> 1.7.0)
 
 PLATFORMS
   aarch64-linux
@@ -314,7 +311,6 @@ DEPENDENCIES
   sprockets (< 4)
   warning (~> 1)
   webmock (>= 3.10.0)
-  yard (~> 0.9)
 
 BUNDLED WITH
    2.3.26

--- a/gemfiles/ruby_2.6_rails5_semantic_logger.gemfile
+++ b/gemfiles/ruby_2.6_rails5_semantic_logger.gemfile
@@ -27,7 +27,6 @@ gem "simplecov-cobertura", "~> 2.1.0"
 gem "warning", "~> 1"
 gem "webmock", ">= 3.10.0"
 gem "rexml", ">= 3.2.7"
-gem "yard", "~> 0.9"
 gem "rubocop", "~> 1.50.0", require: false
 gem "rubocop-packaging", "~> 0.5.2", require: false
 gem "rubocop-performance", "~> 1.9", require: false

--- a/gemfiles/ruby_2.6_rails5_semantic_logger.gemfile.lock
+++ b/gemfiles/ruby_2.6_rails5_semantic_logger.gemfile.lock
@@ -256,12 +256,9 @@ GEM
       addressable (>= 2.3.6)
       crack (>= 0.3.2)
       hashdiff (>= 0.4.0, < 2.0.0)
-    webrick (1.7.0)
     websocket-driver (0.7.5)
       websocket-extensions (>= 0.1.0)
     websocket-extensions (0.1.5)
-    yard (0.9.28)
-      webrick (~> 1.7.0)
 
 PLATFORMS
   aarch64-linux
@@ -305,7 +302,6 @@ DEPENDENCIES
   sprockets (< 4)
   warning (~> 1)
   webmock (>= 3.10.0)
-  yard (~> 0.9)
 
 BUNDLED WITH
    2.3.26

--- a/gemfiles/ruby_2.6_rails61_mysql2.gemfile
+++ b/gemfiles/ruby_2.6_rails61_mysql2.gemfile
@@ -27,7 +27,6 @@ gem "simplecov-cobertura", "~> 2.1.0"
 gem "warning", "~> 1"
 gem "webmock", ">= 3.10.0"
 gem "rexml", ">= 3.2.7"
-gem "yard", "~> 0.9"
 gem "rubocop", "~> 1.50.0", require: false
 gem "rubocop-packaging", "~> 0.5.2", require: false
 gem "rubocop-performance", "~> 1.9", require: false

--- a/gemfiles/ruby_2.6_rails61_mysql2.gemfile.lock
+++ b/gemfiles/ruby_2.6_rails61_mysql2.gemfile.lock
@@ -275,12 +275,9 @@ GEM
       addressable (>= 2.3.6)
       crack (>= 0.3.2)
       hashdiff (>= 0.4.0, < 2.0.0)
-    webrick (1.7.0)
     websocket-driver (0.7.5)
       websocket-extensions (>= 0.1.0)
     websocket-extensions (0.1.5)
-    yard (0.9.28)
-      webrick (~> 1.7.0)
     zeitwerk (2.6.7)
 
 PLATFORMS
@@ -325,7 +322,6 @@ DEPENDENCIES
   sprockets (< 4)
   warning (~> 1)
   webmock (>= 3.10.0)
-  yard (~> 0.9)
 
 BUNDLED WITH
    2.3.26

--- a/gemfiles/ruby_2.6_rails61_postgres.gemfile
+++ b/gemfiles/ruby_2.6_rails61_postgres.gemfile
@@ -27,7 +27,6 @@ gem "simplecov-cobertura", "~> 2.1.0"
 gem "warning", "~> 1"
 gem "webmock", ">= 3.10.0"
 gem "rexml", ">= 3.2.7"
-gem "yard", "~> 0.9"
 gem "rubocop", "~> 1.50.0", require: false
 gem "rubocop-packaging", "~> 0.5.2", require: false
 gem "rubocop-performance", "~> 1.9", require: false

--- a/gemfiles/ruby_2.6_rails61_postgres.gemfile.lock
+++ b/gemfiles/ruby_2.6_rails61_postgres.gemfile.lock
@@ -275,12 +275,9 @@ GEM
       addressable (>= 2.3.6)
       crack (>= 0.3.2)
       hashdiff (>= 0.4.0, < 2.0.0)
-    webrick (1.7.0)
     websocket-driver (0.7.5)
       websocket-extensions (>= 0.1.0)
     websocket-extensions (0.1.5)
-    yard (0.9.28)
-      webrick (~> 1.7.0)
     zeitwerk (2.6.7)
 
 PLATFORMS
@@ -325,7 +322,6 @@ DEPENDENCIES
   sprockets (< 4)
   warning (~> 1)
   webmock (>= 3.10.0)
-  yard (~> 0.9)
 
 BUNDLED WITH
    2.3.26

--- a/gemfiles/ruby_2.6_rails61_postgres_redis.gemfile
+++ b/gemfiles/ruby_2.6_rails61_postgres_redis.gemfile
@@ -27,7 +27,6 @@ gem "simplecov-cobertura", "~> 2.1.0"
 gem "warning", "~> 1"
 gem "webmock", ">= 3.10.0"
 gem "rexml", ">= 3.2.7"
-gem "yard", "~> 0.9"
 gem "rubocop", "~> 1.50.0", require: false
 gem "rubocop-packaging", "~> 0.5.2", require: false
 gem "rubocop-performance", "~> 1.9", require: false

--- a/gemfiles/ruby_2.6_rails61_postgres_redis.gemfile.lock
+++ b/gemfiles/ruby_2.6_rails61_postgres_redis.gemfile.lock
@@ -276,12 +276,9 @@ GEM
       addressable (>= 2.3.6)
       crack (>= 0.3.2)
       hashdiff (>= 0.4.0, < 2.0.0)
-    webrick (1.7.0)
     websocket-driver (0.7.5)
       websocket-extensions (>= 0.1.0)
     websocket-extensions (0.1.5)
-    yard (0.9.28)
-      webrick (~> 1.7.0)
     zeitwerk (2.6.7)
 
 PLATFORMS
@@ -327,7 +324,6 @@ DEPENDENCIES
   sprockets (< 4)
   warning (~> 1)
   webmock (>= 3.10.0)
-  yard (~> 0.9)
 
 BUNDLED WITH
    2.3.26

--- a/gemfiles/ruby_2.6_rails61_postgres_sidekiq.gemfile
+++ b/gemfiles/ruby_2.6_rails61_postgres_sidekiq.gemfile
@@ -27,7 +27,6 @@ gem "simplecov-cobertura", "~> 2.1.0"
 gem "warning", "~> 1"
 gem "webmock", ">= 3.10.0"
 gem "rexml", ">= 3.2.7"
-gem "yard", "~> 0.9"
 gem "rubocop", "~> 1.50.0", require: false
 gem "rubocop-packaging", "~> 0.5.2", require: false
 gem "rubocop-performance", "~> 1.9", require: false

--- a/gemfiles/ruby_2.6_rails61_postgres_sidekiq.gemfile.lock
+++ b/gemfiles/ruby_2.6_rails61_postgres_sidekiq.gemfile.lock
@@ -281,12 +281,9 @@ GEM
       addressable (>= 2.3.6)
       crack (>= 0.3.2)
       hashdiff (>= 0.4.0, < 2.0.0)
-    webrick (1.7.0)
     websocket-driver (0.7.5)
       websocket-extensions (>= 0.1.0)
     websocket-extensions (0.1.5)
-    yard (0.9.28)
-      webrick (~> 1.7.0)
     zeitwerk (2.6.7)
 
 PLATFORMS
@@ -332,7 +329,6 @@ DEPENDENCIES
   sprockets (< 4)
   warning (~> 1)
   webmock (>= 3.10.0)
-  yard (~> 0.9)
 
 BUNDLED WITH
    2.3.26

--- a/gemfiles/ruby_2.6_rails61_semantic_logger.gemfile
+++ b/gemfiles/ruby_2.6_rails61_semantic_logger.gemfile
@@ -27,7 +27,6 @@ gem "simplecov-cobertura", "~> 2.1.0"
 gem "warning", "~> 1"
 gem "webmock", ">= 3.10.0"
 gem "rexml", ">= 3.2.7"
-gem "yard", "~> 0.9"
 gem "rubocop", "~> 1.50.0", require: false
 gem "rubocop-packaging", "~> 0.5.2", require: false
 gem "rubocop-performance", "~> 1.9", require: false

--- a/gemfiles/ruby_2.6_rails61_semantic_logger.gemfile.lock
+++ b/gemfiles/ruby_2.6_rails61_semantic_logger.gemfile.lock
@@ -274,12 +274,9 @@ GEM
       addressable (>= 2.3.6)
       crack (>= 0.3.2)
       hashdiff (>= 0.4.0, < 2.0.0)
-    webrick (1.7.0)
     websocket-driver (0.7.5)
       websocket-extensions (>= 0.1.0)
     websocket-extensions (0.1.5)
-    yard (0.9.28)
-      webrick (~> 1.7.0)
     zeitwerk (2.6.7)
 
 PLATFORMS
@@ -324,7 +321,6 @@ DEPENDENCIES
   sprockets (< 4)
   warning (~> 1)
   webmock (>= 3.10.0)
-  yard (~> 0.9)
 
 BUNDLED WITH
    2.3.26

--- a/gemfiles/ruby_2.6_rails6_mysql2.gemfile
+++ b/gemfiles/ruby_2.6_rails6_mysql2.gemfile
@@ -27,7 +27,6 @@ gem "simplecov-cobertura", "~> 2.1.0"
 gem "warning", "~> 1"
 gem "webmock", ">= 3.10.0"
 gem "rexml", ">= 3.2.7"
-gem "yard", "~> 0.9"
 gem "rubocop", "~> 1.50.0", require: false
 gem "rubocop-packaging", "~> 0.5.2", require: false
 gem "rubocop-performance", "~> 1.9", require: false

--- a/gemfiles/ruby_2.6_rails6_mysql2.gemfile.lock
+++ b/gemfiles/ruby_2.6_rails6_mysql2.gemfile.lock
@@ -272,12 +272,9 @@ GEM
       addressable (>= 2.3.6)
       crack (>= 0.3.2)
       hashdiff (>= 0.4.0, < 2.0.0)
-    webrick (1.7.0)
     websocket-driver (0.7.5)
       websocket-extensions (>= 0.1.0)
     websocket-extensions (0.1.5)
-    yard (0.9.28)
-      webrick (~> 1.7.0)
     zeitwerk (2.6.7)
 
 PLATFORMS
@@ -322,7 +319,6 @@ DEPENDENCIES
   sprockets (< 4)
   warning (~> 1)
   webmock (>= 3.10.0)
-  yard (~> 0.9)
 
 BUNDLED WITH
    2.3.26

--- a/gemfiles/ruby_2.6_rails6_postgres.gemfile
+++ b/gemfiles/ruby_2.6_rails6_postgres.gemfile
@@ -27,7 +27,6 @@ gem "simplecov-cobertura", "~> 2.1.0"
 gem "warning", "~> 1"
 gem "webmock", ">= 3.10.0"
 gem "rexml", ">= 3.2.7"
-gem "yard", "~> 0.9"
 gem "rubocop", "~> 1.50.0", require: false
 gem "rubocop-packaging", "~> 0.5.2", require: false
 gem "rubocop-performance", "~> 1.9", require: false

--- a/gemfiles/ruby_2.6_rails6_postgres.gemfile.lock
+++ b/gemfiles/ruby_2.6_rails6_postgres.gemfile.lock
@@ -272,12 +272,9 @@ GEM
       addressable (>= 2.3.6)
       crack (>= 0.3.2)
       hashdiff (>= 0.4.0, < 2.0.0)
-    webrick (1.7.0)
     websocket-driver (0.7.5)
       websocket-extensions (>= 0.1.0)
     websocket-extensions (0.1.5)
-    yard (0.9.28)
-      webrick (~> 1.7.0)
     zeitwerk (2.6.7)
 
 PLATFORMS
@@ -322,7 +319,6 @@ DEPENDENCIES
   sprockets (< 4)
   warning (~> 1)
   webmock (>= 3.10.0)
-  yard (~> 0.9)
 
 BUNDLED WITH
    2.3.26

--- a/gemfiles/ruby_2.6_rails6_postgres_redis.gemfile
+++ b/gemfiles/ruby_2.6_rails6_postgres_redis.gemfile
@@ -27,7 +27,6 @@ gem "simplecov-cobertura", "~> 2.1.0"
 gem "warning", "~> 1"
 gem "webmock", ">= 3.10.0"
 gem "rexml", ">= 3.2.7"
-gem "yard", "~> 0.9"
 gem "rubocop", "~> 1.50.0", require: false
 gem "rubocop-packaging", "~> 0.5.2", require: false
 gem "rubocop-performance", "~> 1.9", require: false

--- a/gemfiles/ruby_2.6_rails6_postgres_redis.gemfile.lock
+++ b/gemfiles/ruby_2.6_rails6_postgres_redis.gemfile.lock
@@ -273,12 +273,9 @@ GEM
       addressable (>= 2.3.6)
       crack (>= 0.3.2)
       hashdiff (>= 0.4.0, < 2.0.0)
-    webrick (1.7.0)
     websocket-driver (0.7.5)
       websocket-extensions (>= 0.1.0)
     websocket-extensions (0.1.5)
-    yard (0.9.28)
-      webrick (~> 1.7.0)
     zeitwerk (2.6.7)
 
 PLATFORMS
@@ -324,7 +321,6 @@ DEPENDENCIES
   sprockets (< 4)
   warning (~> 1)
   webmock (>= 3.10.0)
-  yard (~> 0.9)
 
 BUNDLED WITH
    2.3.26

--- a/gemfiles/ruby_2.6_rails6_postgres_redis_activesupport.gemfile
+++ b/gemfiles/ruby_2.6_rails6_postgres_redis_activesupport.gemfile
@@ -27,7 +27,6 @@ gem "simplecov-cobertura", "~> 2.1.0"
 gem "warning", "~> 1"
 gem "webmock", ">= 3.10.0"
 gem "rexml", ">= 3.2.7"
-gem "yard", "~> 0.9"
 gem "rubocop", "~> 1.50.0", require: false
 gem "rubocop-packaging", "~> 0.5.2", require: false
 gem "rubocop-performance", "~> 1.9", require: false

--- a/gemfiles/ruby_2.6_rails6_postgres_redis_activesupport.gemfile.lock
+++ b/gemfiles/ruby_2.6_rails6_postgres_redis_activesupport.gemfile.lock
@@ -289,12 +289,9 @@ GEM
       addressable (>= 2.3.6)
       crack (>= 0.3.2)
       hashdiff (>= 0.4.0, < 2.0.0)
-    webrick (1.7.0)
     websocket-driver (0.7.5)
       websocket-extensions (>= 0.1.0)
     websocket-extensions (0.1.5)
-    yard (0.9.28)
-      webrick (~> 1.7.0)
     zeitwerk (2.6.7)
 
 PLATFORMS
@@ -342,7 +339,6 @@ DEPENDENCIES
   sprockets (< 4)
   warning (~> 1)
   webmock (>= 3.10.0)
-  yard (~> 0.9)
 
 BUNDLED WITH
    2.3.26

--- a/gemfiles/ruby_2.6_rails6_postgres_sidekiq.gemfile
+++ b/gemfiles/ruby_2.6_rails6_postgres_sidekiq.gemfile
@@ -27,7 +27,6 @@ gem "simplecov-cobertura", "~> 2.1.0"
 gem "warning", "~> 1"
 gem "webmock", ">= 3.10.0"
 gem "rexml", ">= 3.2.7"
-gem "yard", "~> 0.9"
 gem "rubocop", "~> 1.50.0", require: false
 gem "rubocop-packaging", "~> 0.5.2", require: false
 gem "rubocop-performance", "~> 1.9", require: false

--- a/gemfiles/ruby_2.6_rails6_postgres_sidekiq.gemfile.lock
+++ b/gemfiles/ruby_2.6_rails6_postgres_sidekiq.gemfile.lock
@@ -278,12 +278,9 @@ GEM
       addressable (>= 2.3.6)
       crack (>= 0.3.2)
       hashdiff (>= 0.4.0, < 2.0.0)
-    webrick (1.7.0)
     websocket-driver (0.7.5)
       websocket-extensions (>= 0.1.0)
     websocket-extensions (0.1.5)
-    yard (0.9.28)
-      webrick (~> 1.7.0)
     zeitwerk (2.6.7)
 
 PLATFORMS
@@ -330,7 +327,6 @@ DEPENDENCIES
   sprockets (< 4)
   warning (~> 1)
   webmock (>= 3.10.0)
-  yard (~> 0.9)
 
 BUNDLED WITH
    2.3.26

--- a/gemfiles/ruby_2.6_rails6_semantic_logger.gemfile
+++ b/gemfiles/ruby_2.6_rails6_semantic_logger.gemfile
@@ -27,7 +27,6 @@ gem "simplecov-cobertura", "~> 2.1.0"
 gem "warning", "~> 1"
 gem "webmock", ">= 3.10.0"
 gem "rexml", ">= 3.2.7"
-gem "yard", "~> 0.9"
 gem "rubocop", "~> 1.50.0", require: false
 gem "rubocop-packaging", "~> 0.5.2", require: false
 gem "rubocop-performance", "~> 1.9", require: false

--- a/gemfiles/ruby_2.6_rails6_semantic_logger.gemfile.lock
+++ b/gemfiles/ruby_2.6_rails6_semantic_logger.gemfile.lock
@@ -271,12 +271,9 @@ GEM
       addressable (>= 2.3.6)
       crack (>= 0.3.2)
       hashdiff (>= 0.4.0, < 2.0.0)
-    webrick (1.7.0)
     websocket-driver (0.7.5)
       websocket-extensions (>= 0.1.0)
     websocket-extensions (0.1.5)
-    yard (0.9.28)
-      webrick (~> 1.7.0)
     zeitwerk (2.6.7)
 
 PLATFORMS
@@ -321,7 +318,6 @@ DEPENDENCIES
   sprockets (< 4)
   warning (~> 1)
   webmock (>= 3.10.0)
-  yard (~> 0.9)
 
 BUNDLED WITH
    2.3.26

--- a/gemfiles/ruby_2.6_redis_3.gemfile
+++ b/gemfiles/ruby_2.6_redis_3.gemfile
@@ -27,7 +27,6 @@ gem "simplecov-cobertura", "~> 2.1.0"
 gem "warning", "~> 1"
 gem "webmock", ">= 3.10.0"
 gem "rexml", ">= 3.2.7"
-gem "yard", "~> 0.9"
 gem "rubocop", "~> 1.50.0", require: false
 gem "rubocop-packaging", "~> 0.5.2", require: false
 gem "rubocop-performance", "~> 1.9", require: false

--- a/gemfiles/ruby_2.6_redis_3.gemfile.lock
+++ b/gemfiles/ruby_2.6_redis_3.gemfile.lock
@@ -137,9 +137,6 @@ GEM
       addressable (>= 2.3.6)
       crack (>= 0.3.2)
       hashdiff (>= 0.4.0, < 2.0.0)
-    webrick (1.7.0)
-    yard (0.9.28)
-      webrick (~> 1.7.0)
 
 PLATFORMS
   aarch64-linux
@@ -180,7 +177,6 @@ DEPENDENCIES
   simplecov-cobertura (~> 2.1.0)
   warning (~> 1)
   webmock (>= 3.10.0)
-  yard (~> 0.9)
 
 BUNDLED WITH
    2.3.26

--- a/gemfiles/ruby_2.6_redis_4.gemfile
+++ b/gemfiles/ruby_2.6_redis_4.gemfile
@@ -27,7 +27,6 @@ gem "simplecov-cobertura", "~> 2.1.0"
 gem "warning", "~> 1"
 gem "webmock", ">= 3.10.0"
 gem "rexml", ">= 3.2.7"
-gem "yard", "~> 0.9"
 gem "rubocop", "~> 1.50.0", require: false
 gem "rubocop-packaging", "~> 0.5.2", require: false
 gem "rubocop-performance", "~> 1.9", require: false

--- a/gemfiles/ruby_2.6_redis_4.gemfile.lock
+++ b/gemfiles/ruby_2.6_redis_4.gemfile.lock
@@ -137,9 +137,6 @@ GEM
       addressable (>= 2.3.6)
       crack (>= 0.3.2)
       hashdiff (>= 0.4.0, < 2.0.0)
-    webrick (1.7.0)
-    yard (0.9.28)
-      webrick (~> 1.7.0)
 
 PLATFORMS
   aarch64-linux
@@ -180,7 +177,6 @@ DEPENDENCIES
   simplecov-cobertura (~> 2.1.0)
   warning (~> 1)
   webmock (>= 3.10.0)
-  yard (~> 0.9)
 
 BUNDLED WITH
    2.3.26

--- a/gemfiles/ruby_2.6_redis_5.gemfile
+++ b/gemfiles/ruby_2.6_redis_5.gemfile
@@ -27,7 +27,6 @@ gem "simplecov-cobertura", "~> 2.1.0"
 gem "warning", "~> 1"
 gem "webmock", ">= 3.10.0"
 gem "rexml", ">= 3.2.7"
-gem "yard", "~> 0.9"
 gem "rubocop", "~> 1.50.0", require: false
 gem "rubocop-packaging", "~> 0.5.2", require: false
 gem "rubocop-performance", "~> 1.9", require: false

--- a/gemfiles/ruby_2.6_redis_5.gemfile.lock
+++ b/gemfiles/ruby_2.6_redis_5.gemfile.lock
@@ -141,9 +141,6 @@ GEM
       addressable (>= 2.3.6)
       crack (>= 0.3.2)
       hashdiff (>= 0.4.0, < 2.0.0)
-    webrick (1.7.0)
-    yard (0.9.28)
-      webrick (~> 1.7.0)
 
 PLATFORMS
   aarch64-linux
@@ -184,7 +181,6 @@ DEPENDENCIES
   simplecov-cobertura (~> 2.1.0)
   warning (~> 1)
   webmock (>= 3.10.0)
-  yard (~> 0.9)
 
 BUNDLED WITH
    2.3.26

--- a/gemfiles/ruby_2.6_relational_db.gemfile
+++ b/gemfiles/ruby_2.6_relational_db.gemfile
@@ -27,7 +27,6 @@ gem "simplecov-cobertura", "~> 2.1.0"
 gem "warning", "~> 1"
 gem "webmock", ">= 3.10.0"
 gem "rexml", ">= 3.2.7"
-gem "yard", "~> 0.9"
 gem "rubocop", "~> 1.50.0", require: false
 gem "rubocop-packaging", "~> 0.5.2", require: false
 gem "rubocop-performance", "~> 1.9", require: false

--- a/gemfiles/ruby_2.6_relational_db.gemfile.lock
+++ b/gemfiles/ruby_2.6_relational_db.gemfile.lock
@@ -168,7 +168,6 @@ GEM
       addressable (>= 2.3.6)
       crack (>= 0.3.2)
       hashdiff (>= 0.4.0, < 2.0.0)
-    yard (0.9.34)
     zeitwerk (2.6.11)
 
 PLATFORMS
@@ -217,7 +216,6 @@ DEPENDENCIES
   sqlite3 (~> 1.4.1)
   warning (~> 1)
   webmock (>= 3.10.0)
-  yard (~> 0.9)
 
 BUNDLED WITH
    2.3.26

--- a/gemfiles/ruby_2.6_resque2_redis3.gemfile
+++ b/gemfiles/ruby_2.6_resque2_redis3.gemfile
@@ -27,7 +27,6 @@ gem "simplecov-cobertura", "~> 2.1.0"
 gem "warning", "~> 1"
 gem "webmock", ">= 3.10.0"
 gem "rexml", ">= 3.2.7"
-gem "yard", "~> 0.9"
 gem "rubocop", "~> 1.50.0", require: false
 gem "rubocop-packaging", "~> 0.5.2", require: false
 gem "rubocop-performance", "~> 1.9", require: false

--- a/gemfiles/ruby_2.6_resque2_redis3.gemfile.lock
+++ b/gemfiles/ruby_2.6_resque2_redis3.gemfile.lock
@@ -158,9 +158,6 @@ GEM
       addressable (>= 2.3.6)
       crack (>= 0.3.2)
       hashdiff (>= 0.4.0, < 2.0.0)
-    webrick (1.7.0)
-    yard (0.9.28)
-      webrick (~> 1.7.0)
 
 PLATFORMS
   aarch64-linux
@@ -202,7 +199,6 @@ DEPENDENCIES
   simplecov-cobertura (~> 2.1.0)
   warning (~> 1)
   webmock (>= 3.10.0)
-  yard (~> 0.9)
 
 BUNDLED WITH
    2.3.26

--- a/gemfiles/ruby_2.6_resque2_redis4.gemfile
+++ b/gemfiles/ruby_2.6_resque2_redis4.gemfile
@@ -27,7 +27,6 @@ gem "simplecov-cobertura", "~> 2.1.0"
 gem "warning", "~> 1"
 gem "webmock", ">= 3.10.0"
 gem "rexml", ">= 3.2.7"
-gem "yard", "~> 0.9"
 gem "rubocop", "~> 1.50.0", require: false
 gem "rubocop-packaging", "~> 0.5.2", require: false
 gem "rubocop-performance", "~> 1.9", require: false

--- a/gemfiles/ruby_2.6_resque2_redis4.gemfile.lock
+++ b/gemfiles/ruby_2.6_resque2_redis4.gemfile.lock
@@ -158,9 +158,6 @@ GEM
       addressable (>= 2.3.6)
       crack (>= 0.3.2)
       hashdiff (>= 0.4.0, < 2.0.0)
-    webrick (1.7.0)
-    yard (0.9.28)
-      webrick (~> 1.7.0)
 
 PLATFORMS
   aarch64-linux
@@ -202,7 +199,6 @@ DEPENDENCIES
   simplecov-cobertura (~> 2.1.0)
   warning (~> 1)
   webmock (>= 3.10.0)
-  yard (~> 0.9)
 
 BUNDLED WITH
    2.3.26

--- a/gemfiles/ruby_2.6_sinatra_2.gemfile
+++ b/gemfiles/ruby_2.6_sinatra_2.gemfile
@@ -27,7 +27,6 @@ gem "simplecov-cobertura", "~> 2.1.0"
 gem "warning", "~> 1"
 gem "webmock", ">= 3.10.0"
 gem "rexml", ">= 3.2.7"
-gem "yard", "~> 0.9"
 gem "rubocop", "~> 1.50.0", require: false
 gem "rubocop-packaging", "~> 0.5.2", require: false
 gem "rubocop-performance", "~> 1.9", require: false

--- a/gemfiles/ruby_2.6_sinatra_2.gemfile.lock
+++ b/gemfiles/ruby_2.6_sinatra_2.gemfile.lock
@@ -158,7 +158,6 @@ GEM
       addressable (>= 2.8.0)
       crack (>= 0.3.2)
       hashdiff (>= 0.4.0, < 2.0.0)
-    yard (0.9.36)
 
 PLATFORMS
   aarch64-linux
@@ -201,7 +200,6 @@ DEPENDENCIES
   sinatra (~> 2)
   warning (~> 1)
   webmock (>= 3.10.0)
-  yard (~> 0.9)
 
 BUNDLED WITH
    2.3.26

--- a/gemfiles/ruby_2.6_sinatra_3.gemfile
+++ b/gemfiles/ruby_2.6_sinatra_3.gemfile
@@ -27,7 +27,6 @@ gem "simplecov-cobertura", "~> 2.1.0"
 gem "warning", "~> 1"
 gem "webmock", ">= 3.10.0"
 gem "rexml", ">= 3.2.7"
-gem "yard", "~> 0.9"
 gem "rubocop", "~> 1.50.0", require: false
 gem "rubocop-packaging", "~> 0.5.2", require: false
 gem "rubocop-performance", "~> 1.9", require: false

--- a/gemfiles/ruby_2.6_sinatra_3.gemfile.lock
+++ b/gemfiles/ruby_2.6_sinatra_3.gemfile.lock
@@ -160,7 +160,6 @@ GEM
       addressable (>= 2.8.0)
       crack (>= 0.3.2)
       hashdiff (>= 0.4.0, < 2.0.0)
-    yard (0.9.36)
 
 PLATFORMS
   aarch64-linux
@@ -203,7 +202,6 @@ DEPENDENCIES
   sinatra (~> 3)
   warning (~> 1)
   webmock (>= 3.10.0)
-  yard (~> 0.9)
 
 BUNDLED WITH
    2.3.26

--- a/gemfiles/ruby_2.6_stripe_10.gemfile
+++ b/gemfiles/ruby_2.6_stripe_10.gemfile
@@ -27,7 +27,6 @@ gem "simplecov-cobertura", "~> 2.1.0"
 gem "warning", "~> 1"
 gem "webmock", ">= 3.10.0"
 gem "rexml", ">= 3.2.7"
-gem "yard", "~> 0.9"
 gem "rubocop", "~> 1.50.0", require: false
 gem "rubocop-packaging", "~> 0.5.2", require: false
 gem "rubocop-performance", "~> 1.9", require: false

--- a/gemfiles/ruby_2.6_stripe_10.gemfile.lock
+++ b/gemfiles/ruby_2.6_stripe_10.gemfile.lock
@@ -143,7 +143,6 @@ GEM
       addressable (>= 2.8.0)
       crack (>= 0.3.2)
       hashdiff (>= 0.4.0, < 2.0.0)
-    yard (0.9.36)
 
 PLATFORMS
   aarch64-linux
@@ -184,7 +183,6 @@ DEPENDENCIES
   stripe (~> 10)
   warning (~> 1)
   webmock (>= 3.10.0)
-  yard (~> 0.9)
 
 BUNDLED WITH
    2.3.26

--- a/gemfiles/ruby_2.6_stripe_11.gemfile
+++ b/gemfiles/ruby_2.6_stripe_11.gemfile
@@ -27,7 +27,6 @@ gem "simplecov-cobertura", "~> 2.1.0"
 gem "warning", "~> 1"
 gem "webmock", ">= 3.10.0"
 gem "rexml", ">= 3.2.7"
-gem "yard", "~> 0.9"
 gem "rubocop", "~> 1.50.0", require: false
 gem "rubocop-packaging", "~> 0.5.2", require: false
 gem "rubocop-performance", "~> 1.9", require: false

--- a/gemfiles/ruby_2.6_stripe_11.gemfile.lock
+++ b/gemfiles/ruby_2.6_stripe_11.gemfile.lock
@@ -143,7 +143,6 @@ GEM
       addressable (>= 2.8.0)
       crack (>= 0.3.2)
       hashdiff (>= 0.4.0, < 2.0.0)
-    yard (0.9.36)
 
 PLATFORMS
   aarch64-linux
@@ -184,7 +183,6 @@ DEPENDENCIES
   stripe (~> 11)
   warning (~> 1)
   webmock (>= 3.10.0)
-  yard (~> 0.9)
 
 BUNDLED WITH
    2.3.26

--- a/gemfiles/ruby_2.6_stripe_12.gemfile
+++ b/gemfiles/ruby_2.6_stripe_12.gemfile
@@ -27,7 +27,6 @@ gem "simplecov-cobertura", "~> 2.1.0"
 gem "warning", "~> 1"
 gem "webmock", ">= 3.10.0"
 gem "rexml", ">= 3.2.7"
-gem "yard", "~> 0.9"
 gem "rubocop", "~> 1.50.0", require: false
 gem "rubocop-packaging", "~> 0.5.2", require: false
 gem "rubocop-performance", "~> 1.9", require: false

--- a/gemfiles/ruby_2.6_stripe_12.gemfile.lock
+++ b/gemfiles/ruby_2.6_stripe_12.gemfile.lock
@@ -143,7 +143,6 @@ GEM
       addressable (>= 2.8.0)
       crack (>= 0.3.2)
       hashdiff (>= 0.4.0, < 2.0.0)
-    yard (0.9.36)
 
 PLATFORMS
   aarch64-linux
@@ -184,7 +183,6 @@ DEPENDENCIES
   stripe (~> 12)
   warning (~> 1)
   webmock (>= 3.10.0)
-  yard (~> 0.9)
 
 BUNDLED WITH
    2.3.26

--- a/gemfiles/ruby_2.6_stripe_7.gemfile
+++ b/gemfiles/ruby_2.6_stripe_7.gemfile
@@ -27,7 +27,6 @@ gem "simplecov-cobertura", "~> 2.1.0"
 gem "warning", "~> 1"
 gem "webmock", ">= 3.10.0"
 gem "rexml", ">= 3.2.7"
-gem "yard", "~> 0.9"
 gem "rubocop", "~> 1.50.0", require: false
 gem "rubocop-packaging", "~> 0.5.2", require: false
 gem "rubocop-performance", "~> 1.9", require: false

--- a/gemfiles/ruby_2.6_stripe_7.gemfile.lock
+++ b/gemfiles/ruby_2.6_stripe_7.gemfile.lock
@@ -143,7 +143,6 @@ GEM
       addressable (>= 2.8.0)
       crack (>= 0.3.2)
       hashdiff (>= 0.4.0, < 2.0.0)
-    yard (0.9.36)
 
 PLATFORMS
   aarch64-linux
@@ -184,7 +183,6 @@ DEPENDENCIES
   stripe (~> 7)
   warning (~> 1)
   webmock (>= 3.10.0)
-  yard (~> 0.9)
 
 BUNDLED WITH
    2.3.26

--- a/gemfiles/ruby_2.6_stripe_8.gemfile
+++ b/gemfiles/ruby_2.6_stripe_8.gemfile
@@ -27,7 +27,6 @@ gem "simplecov-cobertura", "~> 2.1.0"
 gem "warning", "~> 1"
 gem "webmock", ">= 3.10.0"
 gem "rexml", ">= 3.2.7"
-gem "yard", "~> 0.9"
 gem "rubocop", "~> 1.50.0", require: false
 gem "rubocop-packaging", "~> 0.5.2", require: false
 gem "rubocop-performance", "~> 1.9", require: false

--- a/gemfiles/ruby_2.6_stripe_8.gemfile.lock
+++ b/gemfiles/ruby_2.6_stripe_8.gemfile.lock
@@ -143,7 +143,6 @@ GEM
       addressable (>= 2.8.0)
       crack (>= 0.3.2)
       hashdiff (>= 0.4.0, < 2.0.0)
-    yard (0.9.36)
 
 PLATFORMS
   aarch64-linux
@@ -184,7 +183,6 @@ DEPENDENCIES
   stripe (~> 8)
   warning (~> 1)
   webmock (>= 3.10.0)
-  yard (~> 0.9)
 
 BUNDLED WITH
    2.3.26

--- a/gemfiles/ruby_2.6_stripe_9.gemfile
+++ b/gemfiles/ruby_2.6_stripe_9.gemfile
@@ -27,7 +27,6 @@ gem "simplecov-cobertura", "~> 2.1.0"
 gem "warning", "~> 1"
 gem "webmock", ">= 3.10.0"
 gem "rexml", ">= 3.2.7"
-gem "yard", "~> 0.9"
 gem "rubocop", "~> 1.50.0", require: false
 gem "rubocop-packaging", "~> 0.5.2", require: false
 gem "rubocop-performance", "~> 1.9", require: false

--- a/gemfiles/ruby_2.6_stripe_9.gemfile.lock
+++ b/gemfiles/ruby_2.6_stripe_9.gemfile.lock
@@ -143,7 +143,6 @@ GEM
       addressable (>= 2.8.0)
       crack (>= 0.3.2)
       hashdiff (>= 0.4.0, < 2.0.0)
-    yard (0.9.36)
 
 PLATFORMS
   aarch64-linux
@@ -184,7 +183,6 @@ DEPENDENCIES
   stripe (~> 9)
   warning (~> 1)
   webmock (>= 3.10.0)
-  yard (~> 0.9)
 
 BUNDLED WITH
    2.3.26

--- a/gemfiles/ruby_2.7_activesupport.gemfile
+++ b/gemfiles/ruby_2.7_activesupport.gemfile
@@ -27,7 +27,6 @@ gem "simplecov-cobertura", "~> 2.1.0"
 gem "warning", "~> 1"
 gem "webmock", ">= 3.10.0"
 gem "rexml", ">= 3.2.7"
-gem "yard", "~> 0.9"
 gem "rubocop", "~> 1.50.0", require: false
 gem "rubocop-packaging", "~> 0.5.2", require: false
 gem "rubocop-performance", "~> 1.9", require: false

--- a/gemfiles/ruby_2.7_activesupport.gemfile.lock
+++ b/gemfiles/ruby_2.7_activesupport.gemfile.lock
@@ -245,7 +245,6 @@ GEM
       addressable (>= 2.3.6)
       crack (>= 0.3.2)
       hashdiff (>= 0.4.0, < 2.0.0)
-    yard (0.9.34)
     zeitwerk (2.6.11)
 
 PLATFORMS
@@ -294,7 +293,6 @@ DEPENDENCIES
   simplecov-cobertura (~> 2.1.0)
   warning (~> 1)
   webmock (>= 3.10.0)
-  yard (~> 0.9)
 
 BUNDLED WITH
    2.3.26

--- a/gemfiles/ruby_2.7_aws.gemfile
+++ b/gemfiles/ruby_2.7_aws.gemfile
@@ -27,7 +27,6 @@ gem "simplecov-cobertura", "~> 2.1.0"
 gem "warning", "~> 1"
 gem "webmock", ">= 3.10.0"
 gem "rexml", ">= 3.2.7"
-gem "yard", "~> 0.9"
 gem "rubocop", "~> 1.50.0", require: false
 gem "rubocop-packaging", "~> 0.5.2", require: false
 gem "rubocop-performance", "~> 1.9", require: false

--- a/gemfiles/ruby_2.7_aws.gemfile.lock
+++ b/gemfiles/ruby_2.7_aws.gemfile.lock
@@ -1564,7 +1564,6 @@ GEM
       addressable (>= 2.3.6)
       crack (>= 0.3.2)
       hashdiff (>= 0.4.0, < 2.0.0)
-    yard (0.9.34)
 
 PLATFORMS
   aarch64-linux
@@ -1606,7 +1605,6 @@ DEPENDENCIES
   simplecov-cobertura (~> 2.1.0)
   warning (~> 1)
   webmock (>= 3.10.0)
-  yard (~> 0.9)
 
 BUNDLED WITH
    2.3.26

--- a/gemfiles/ruby_2.7_contrib.gemfile
+++ b/gemfiles/ruby_2.7_contrib.gemfile
@@ -27,7 +27,6 @@ gem "simplecov-cobertura", "~> 2.1.0"
 gem "warning", "~> 1"
 gem "webmock", ">= 3.10.0"
 gem "rexml", ">= 3.2.7"
-gem "yard", "~> 0.9"
 gem "rubocop", "~> 1.50.0", require: false
 gem "rubocop-packaging", "~> 0.5.2", require: false
 gem "rubocop-performance", "~> 1.9", require: false

--- a/gemfiles/ruby_2.7_contrib.gemfile.lock
+++ b/gemfiles/ruby_2.7_contrib.gemfile.lock
@@ -202,9 +202,6 @@ GEM
       addressable (>= 2.3.6)
       crack (>= 0.3.2)
       hashdiff (>= 0.4.0, < 2.0.0)
-    webrick (1.7.0)
-    yard (0.9.28)
-      webrick (~> 1.7.0)
 
 PLATFORMS
   aarch64-linux
@@ -255,7 +252,6 @@ DEPENDENCIES
   sucker_punch
   warning (~> 1)
   webmock (>= 3.10.0)
-  yard (~> 0.9)
 
 BUNDLED WITH
    2.3.26

--- a/gemfiles/ruby_2.7_contrib_old.gemfile
+++ b/gemfiles/ruby_2.7_contrib_old.gemfile
@@ -27,7 +27,6 @@ gem "simplecov-cobertura", "~> 2.1.0"
 gem "warning", "~> 1"
 gem "webmock", ">= 3.10.0"
 gem "rexml", ">= 3.2.7"
-gem "yard", "~> 0.9"
 gem "rubocop", "~> 1.50.0", require: false
 gem "rubocop-packaging", "~> 0.5.2", require: false
 gem "rubocop-performance", "~> 1.9", require: false

--- a/gemfiles/ruby_2.7_contrib_old.gemfile.lock
+++ b/gemfiles/ruby_2.7_contrib_old.gemfile.lock
@@ -189,9 +189,6 @@ GEM
       addressable (>= 2.3.6)
       crack (>= 0.3.2)
       hashdiff (>= 0.4.0, < 2.0.0)
-    webrick (1.7.0)
-    yard (0.9.28)
-      webrick (~> 1.7.0)
 
 PLATFORMS
   aarch64-linux
@@ -235,7 +232,6 @@ DEPENDENCIES
   simplecov-cobertura (~> 2.1.0)
   warning (~> 1)
   webmock (>= 3.10.0)
-  yard (~> 0.9)
 
 BUNDLED WITH
    2.3.26

--- a/gemfiles/ruby_2.7_core_old.gemfile
+++ b/gemfiles/ruby_2.7_core_old.gemfile
@@ -27,7 +27,6 @@ gem "simplecov-cobertura", "~> 2.1.0"
 gem "warning", "~> 1"
 gem "webmock", ">= 3.10.0"
 gem "rexml", ">= 3.2.7"
-gem "yard", "~> 0.9"
 gem "rubocop", "~> 1.50.0", require: false
 gem "rubocop-packaging", "~> 0.5.2", require: false
 gem "rubocop-performance", "~> 1.9", require: false

--- a/gemfiles/ruby_2.7_core_old.gemfile.lock
+++ b/gemfiles/ruby_2.7_core_old.gemfile.lock
@@ -136,9 +136,6 @@ GEM
       addressable (>= 2.3.6)
       crack (>= 0.3.2)
       hashdiff (>= 0.4.0, < 2.0.0)
-    webrick (1.7.0)
-    yard (0.9.28)
-      webrick (~> 1.7.0)
 
 PLATFORMS
   aarch64-linux
@@ -178,7 +175,6 @@ DEPENDENCIES
   simplecov-cobertura (~> 2.1.0)
   warning (~> 1)
   webmock (>= 3.10.0)
-  yard (~> 0.9)
 
 BUNDLED WITH
    2.3.26

--- a/gemfiles/ruby_2.7_elasticsearch_7.gemfile
+++ b/gemfiles/ruby_2.7_elasticsearch_7.gemfile
@@ -27,7 +27,6 @@ gem "simplecov-cobertura", "~> 2.1.0"
 gem "warning", "~> 1"
 gem "webmock", ">= 3.10.0"
 gem "rexml", ">= 3.2.7"
-gem "yard", "~> 0.9"
 gem "rubocop", "~> 1.50.0", require: false
 gem "rubocop-packaging", "~> 0.5.2", require: false
 gem "rubocop-performance", "~> 1.9", require: false

--- a/gemfiles/ruby_2.7_elasticsearch_7.gemfile.lock
+++ b/gemfiles/ruby_2.7_elasticsearch_7.gemfile.lock
@@ -174,7 +174,6 @@ GEM
       addressable (>= 2.8.0)
       crack (>= 0.3.2)
       hashdiff (>= 0.4.0, < 2.0.0)
-    yard (0.9.34)
 
 PLATFORMS
   aarch64-linux
@@ -215,7 +214,6 @@ DEPENDENCIES
   simplecov-cobertura (~> 2.1.0)
   warning (~> 1)
   webmock (>= 3.10.0)
-  yard (~> 0.9)
 
 BUNDLED WITH
    2.3.26

--- a/gemfiles/ruby_2.7_elasticsearch_8.gemfile
+++ b/gemfiles/ruby_2.7_elasticsearch_8.gemfile
@@ -27,7 +27,6 @@ gem "simplecov-cobertura", "~> 2.1.0"
 gem "warning", "~> 1"
 gem "webmock", ">= 3.10.0"
 gem "rexml", ">= 3.2.7"
-gem "yard", "~> 0.9"
 gem "rubocop", "~> 1.50.0", require: false
 gem "rubocop-packaging", "~> 0.5.2", require: false
 gem "rubocop-performance", "~> 1.9", require: false

--- a/gemfiles/ruby_2.7_elasticsearch_8.gemfile.lock
+++ b/gemfiles/ruby_2.7_elasticsearch_8.gemfile.lock
@@ -156,7 +156,6 @@ GEM
       addressable (>= 2.8.0)
       crack (>= 0.3.2)
       hashdiff (>= 0.4.0, < 2.0.0)
-    yard (0.9.34)
 
 PLATFORMS
   aarch64-linux
@@ -197,7 +196,6 @@ DEPENDENCIES
   simplecov-cobertura (~> 2.1.0)
   warning (~> 1)
   webmock (>= 3.10.0)
-  yard (~> 0.9)
 
 BUNDLED WITH
    2.3.26

--- a/gemfiles/ruby_2.7_graphql_1.13.gemfile
+++ b/gemfiles/ruby_2.7_graphql_1.13.gemfile
@@ -27,7 +27,6 @@ gem "simplecov-cobertura", "~> 2.1.0"
 gem "warning", "~> 1"
 gem "webmock", ">= 3.10.0"
 gem "rexml", ">= 3.2.7"
-gem "yard", "~> 0.9"
 gem "rubocop", "~> 1.50.0", require: false
 gem "rubocop-packaging", "~> 0.5.2", require: false
 gem "rubocop-performance", "~> 1.9", require: false

--- a/gemfiles/ruby_2.7_graphql_1.13.gemfile.lock
+++ b/gemfiles/ruby_2.7_graphql_1.13.gemfile.lock
@@ -285,7 +285,6 @@ GEM
     websocket-driver (0.7.6)
       websocket-extensions (>= 0.1.0)
     websocket-extensions (0.1.5)
-    yard (0.9.34)
     zeitwerk (2.6.16)
 
 PLATFORMS
@@ -330,7 +329,6 @@ DEPENDENCIES
   sprockets (< 4)
   warning (~> 1)
   webmock (>= 3.10.0)
-  yard (~> 0.9)
 
 BUNDLED WITH
    2.3.26

--- a/gemfiles/ruby_2.7_graphql_2.0.gemfile
+++ b/gemfiles/ruby_2.7_graphql_2.0.gemfile
@@ -27,7 +27,6 @@ gem "simplecov-cobertura", "~> 2.1.0"
 gem "warning", "~> 1"
 gem "webmock", ">= 3.10.0"
 gem "rexml", ">= 3.2.7"
-gem "yard", "~> 0.9"
 gem "rubocop", "~> 1.50.0", require: false
 gem "rubocop-packaging", "~> 0.5.2", require: false
 gem "rubocop-performance", "~> 1.9", require: false

--- a/gemfiles/ruby_2.7_graphql_2.0.gemfile.lock
+++ b/gemfiles/ruby_2.7_graphql_2.0.gemfile.lock
@@ -285,7 +285,6 @@ GEM
     websocket-driver (0.7.6)
       websocket-extensions (>= 0.1.0)
     websocket-extensions (0.1.5)
-    yard (0.9.34)
     zeitwerk (2.6.16)
 
 PLATFORMS
@@ -330,7 +329,6 @@ DEPENDENCIES
   sprockets (< 4)
   warning (~> 1)
   webmock (>= 3.10.0)
-  yard (~> 0.9)
 
 BUNDLED WITH
    2.3.26

--- a/gemfiles/ruby_2.7_graphql_2.1.gemfile
+++ b/gemfiles/ruby_2.7_graphql_2.1.gemfile
@@ -27,7 +27,6 @@ gem "simplecov-cobertura", "~> 2.1.0"
 gem "warning", "~> 1"
 gem "webmock", ">= 3.10.0"
 gem "rexml", ">= 3.2.7"
-gem "yard", "~> 0.9"
 gem "rubocop", "~> 1.50.0", require: false
 gem "rubocop-packaging", "~> 0.5.2", require: false
 gem "rubocop-performance", "~> 1.9", require: false

--- a/gemfiles/ruby_2.7_graphql_2.1.gemfile.lock
+++ b/gemfiles/ruby_2.7_graphql_2.1.gemfile.lock
@@ -286,7 +286,6 @@ GEM
     websocket-driver (0.7.6)
       websocket-extensions (>= 0.1.0)
     websocket-extensions (0.1.5)
-    yard (0.9.34)
     zeitwerk (2.6.16)
 
 PLATFORMS
@@ -331,7 +330,6 @@ DEPENDENCIES
   sprockets (< 4)
   warning (~> 1)
   webmock (>= 3.10.0)
-  yard (~> 0.9)
 
 BUNDLED WITH
    2.3.26

--- a/gemfiles/ruby_2.7_graphql_2.2.gemfile
+++ b/gemfiles/ruby_2.7_graphql_2.2.gemfile
@@ -27,7 +27,6 @@ gem "simplecov-cobertura", "~> 2.1.0"
 gem "warning", "~> 1"
 gem "webmock", ">= 3.10.0"
 gem "rexml", ">= 3.2.7"
-gem "yard", "~> 0.9"
 gem "rubocop", "~> 1.50.0", require: false
 gem "rubocop-packaging", "~> 0.5.2", require: false
 gem "rubocop-performance", "~> 1.9", require: false

--- a/gemfiles/ruby_2.7_graphql_2.2.gemfile.lock
+++ b/gemfiles/ruby_2.7_graphql_2.2.gemfile.lock
@@ -286,7 +286,6 @@ GEM
     websocket-driver (0.7.6)
       websocket-extensions (>= 0.1.0)
     websocket-extensions (0.1.5)
-    yard (0.9.34)
     zeitwerk (2.6.16)
 
 PLATFORMS
@@ -331,7 +330,6 @@ DEPENDENCIES
   sprockets (< 4)
   warning (~> 1)
   webmock (>= 3.10.0)
-  yard (~> 0.9)
 
 BUNDLED WITH
    2.3.26

--- a/gemfiles/ruby_2.7_graphql_2.3.gemfile
+++ b/gemfiles/ruby_2.7_graphql_2.3.gemfile
@@ -27,7 +27,6 @@ gem "simplecov-cobertura", "~> 2.1.0"
 gem "warning", "~> 1"
 gem "webmock", ">= 3.10.0"
 gem "rexml", ">= 3.2.7"
-gem "yard", "~> 0.9"
 gem "rubocop", "~> 1.50.0", require: false
 gem "rubocop-packaging", "~> 0.5.2", require: false
 gem "rubocop-performance", "~> 1.9", require: false

--- a/gemfiles/ruby_2.7_graphql_2.3.gemfile.lock
+++ b/gemfiles/ruby_2.7_graphql_2.3.gemfile.lock
@@ -287,7 +287,6 @@ GEM
     websocket-driver (0.7.6)
       websocket-extensions (>= 0.1.0)
     websocket-extensions (0.1.5)
-    yard (0.9.36)
     zeitwerk (2.6.16)
 
 PLATFORMS
@@ -332,7 +331,6 @@ DEPENDENCIES
   sprockets (< 4)
   warning (~> 1)
   webmock (>= 3.10.0)
-  yard (~> 0.9)
 
 BUNDLED WITH
    2.3.26

--- a/gemfiles/ruby_2.7_hanami_1.gemfile
+++ b/gemfiles/ruby_2.7_hanami_1.gemfile
@@ -27,7 +27,6 @@ gem "simplecov-cobertura", "~> 2.1.0"
 gem "warning", "~> 1"
 gem "webmock", ">= 3.10.0"
 gem "rexml", ">= 3.2.7"
-gem "yard", "~> 0.9"
 gem "rubocop", "~> 1.50.0", require: false
 gem "rubocop-packaging", "~> 0.5.2", require: false
 gem "rubocop-performance", "~> 1.9", require: false

--- a/gemfiles/ruby_2.7_hanami_1.gemfile.lock
+++ b/gemfiles/ruby_2.7_hanami_1.gemfile.lock
@@ -235,9 +235,6 @@ GEM
       addressable (>= 2.3.6)
       crack (>= 0.3.2)
       hashdiff (>= 0.4.0, < 2.0.0)
-    webrick (1.7.0)
-    yard (0.9.28)
-      webrick (~> 1.7.0)
     zeitwerk (2.6.7)
 
 PLATFORMS
@@ -281,7 +278,6 @@ DEPENDENCIES
   simplecov-cobertura (~> 2.1.0)
   warning (~> 1)
   webmock (>= 3.10.0)
-  yard (~> 0.9)
 
 BUNDLED WITH
    2.3.26

--- a/gemfiles/ruby_2.7_http.gemfile
+++ b/gemfiles/ruby_2.7_http.gemfile
@@ -27,7 +27,6 @@ gem "simplecov-cobertura", "~> 2.1.0"
 gem "warning", "~> 1"
 gem "webmock", ">= 3.10.0"
 gem "rexml", ">= 3.2.7"
-gem "yard", "~> 0.9"
 gem "rubocop", "~> 1.50.0", require: false
 gem "rubocop-packaging", "~> 0.5.2", require: false
 gem "rubocop-performance", "~> 1.9", require: false

--- a/gemfiles/ruby_2.7_http.gemfile.lock
+++ b/gemfiles/ruby_2.7_http.gemfile.lock
@@ -178,7 +178,6 @@ GEM
       addressable (>= 2.3.6)
       crack (>= 0.3.2)
       hashdiff (>= 0.4.0, < 2.0.0)
-    yard (0.9.34)
 
 PLATFORMS
   aarch64-linux
@@ -225,7 +224,6 @@ DEPENDENCIES
   typhoeus
   warning (~> 1)
   webmock (>= 3.10.0)
-  yard (~> 0.9)
 
 BUNDLED WITH
    2.3.26

--- a/gemfiles/ruby_2.7_opensearch_2.gemfile
+++ b/gemfiles/ruby_2.7_opensearch_2.gemfile
@@ -27,7 +27,6 @@ gem "simplecov-cobertura", "~> 2.1.0"
 gem "warning", "~> 1"
 gem "webmock", ">= 3.10.0"
 gem "rexml", ">= 3.2.7"
-gem "yard", "~> 0.9"
 gem "rubocop", "~> 1.50.0", require: false
 gem "rubocop-packaging", "~> 0.5.2", require: false
 gem "rubocop-performance", "~> 1.9", require: false

--- a/gemfiles/ruby_2.7_opensearch_2.gemfile.lock
+++ b/gemfiles/ruby_2.7_opensearch_2.gemfile.lock
@@ -156,7 +156,6 @@ GEM
       addressable (>= 2.8.0)
       crack (>= 0.3.2)
       hashdiff (>= 0.4.0, < 2.0.0)
-    yard (0.9.34)
 
 PLATFORMS
   aarch64-linux
@@ -197,7 +196,6 @@ DEPENDENCIES
   simplecov-cobertura (~> 2.1.0)
   warning (~> 1)
   webmock (>= 3.10.0)
-  yard (~> 0.9)
 
 BUNDLED WITH
    2.3.26

--- a/gemfiles/ruby_2.7_opensearch_3.gemfile
+++ b/gemfiles/ruby_2.7_opensearch_3.gemfile
@@ -27,7 +27,6 @@ gem "simplecov-cobertura", "~> 2.1.0"
 gem "warning", "~> 1"
 gem "webmock", ">= 3.10.0"
 gem "rexml", ">= 3.2.7"
-gem "yard", "~> 0.9"
 gem "rubocop", "~> 1.50.0", require: false
 gem "rubocop-packaging", "~> 0.5.2", require: false
 gem "rubocop-performance", "~> 1.9", require: false

--- a/gemfiles/ruby_2.7_opensearch_3.gemfile.lock
+++ b/gemfiles/ruby_2.7_opensearch_3.gemfile.lock
@@ -151,7 +151,6 @@ GEM
       addressable (>= 2.8.0)
       crack (>= 0.3.2)
       hashdiff (>= 0.4.0, < 2.0.0)
-    yard (0.9.34)
 
 PLATFORMS
   aarch64-linux
@@ -192,7 +191,6 @@ DEPENDENCIES
   simplecov-cobertura (~> 2.1.0)
   warning (~> 1)
   webmock (>= 3.10.0)
-  yard (~> 0.9)
 
 BUNDLED WITH
    2.3.26

--- a/gemfiles/ruby_2.7_opentelemetry.gemfile
+++ b/gemfiles/ruby_2.7_opentelemetry.gemfile
@@ -27,7 +27,6 @@ gem "simplecov-cobertura", "~> 2.1.0"
 gem "warning", "~> 1"
 gem "webmock", ">= 3.10.0"
 gem "rexml", ">= 3.2.7"
-gem "yard", "~> 0.9"
 gem "rubocop", "~> 1.50.0", require: false
 gem "rubocop-packaging", "~> 0.5.2", require: false
 gem "rubocop-performance", "~> 1.9", require: false

--- a/gemfiles/ruby_2.7_opentelemetry.gemfile.lock
+++ b/gemfiles/ruby_2.7_opentelemetry.gemfile.lock
@@ -148,9 +148,6 @@ GEM
       addressable (>= 2.3.6)
       crack (>= 0.3.2)
       hashdiff (>= 0.4.0, < 2.0.0)
-    webrick (1.7.0)
-    yard (0.9.28)
-      webrick (~> 1.7.0)
 
 PLATFORMS
   aarch64-linux
@@ -191,7 +188,6 @@ DEPENDENCIES
   simplecov-cobertura (~> 2.1.0)
   warning (~> 1)
   webmock (>= 3.10.0)
-  yard (~> 0.9)
 
 BUNDLED WITH
    2.3.26

--- a/gemfiles/ruby_2.7_rack_1.gemfile
+++ b/gemfiles/ruby_2.7_rack_1.gemfile
@@ -27,7 +27,6 @@ gem "simplecov-cobertura", "~> 2.1.0"
 gem "warning", "~> 1"
 gem "webmock", ">= 3.10.0"
 gem "rexml", ">= 3.2.7"
-gem "yard", "~> 0.9"
 gem "rubocop", "~> 1.50.0", require: false
 gem "rubocop-packaging", "~> 0.5.2", require: false
 gem "rubocop-performance", "~> 1.9", require: false

--- a/gemfiles/ruby_2.7_rack_1.gemfile.lock
+++ b/gemfiles/ruby_2.7_rack_1.gemfile.lock
@@ -143,7 +143,6 @@ GEM
       addressable (>= 2.3.6)
       crack (>= 0.3.2)
       hashdiff (>= 0.4.0, < 2.0.0)
-    yard (0.9.34)
 
 PLATFORMS
   aarch64-linux
@@ -186,7 +185,6 @@ DEPENDENCIES
   simplecov-cobertura (~> 2.1.0)
   warning (~> 1)
   webmock (>= 3.10.0)
-  yard (~> 0.9)
 
 BUNDLED WITH
    2.3.26

--- a/gemfiles/ruby_2.7_rack_2.gemfile
+++ b/gemfiles/ruby_2.7_rack_2.gemfile
@@ -27,7 +27,6 @@ gem "simplecov-cobertura", "~> 2.1.0"
 gem "warning", "~> 1"
 gem "webmock", ">= 3.10.0"
 gem "rexml", ">= 3.2.7"
-gem "yard", "~> 0.9"
 gem "rubocop", "~> 1.50.0", require: false
 gem "rubocop-packaging", "~> 0.5.2", require: false
 gem "rubocop-performance", "~> 1.9", require: false

--- a/gemfiles/ruby_2.7_rack_2.gemfile.lock
+++ b/gemfiles/ruby_2.7_rack_2.gemfile.lock
@@ -143,7 +143,6 @@ GEM
       addressable (>= 2.3.6)
       crack (>= 0.3.2)
       hashdiff (>= 0.4.0, < 2.0.0)
-    yard (0.9.34)
 
 PLATFORMS
   aarch64-linux
@@ -186,7 +185,6 @@ DEPENDENCIES
   simplecov-cobertura (~> 2.1.0)
   warning (~> 1)
   webmock (>= 3.10.0)
-  yard (~> 0.9)
 
 BUNDLED WITH
    2.3.26

--- a/gemfiles/ruby_2.7_rack_3.gemfile
+++ b/gemfiles/ruby_2.7_rack_3.gemfile
@@ -27,7 +27,6 @@ gem "simplecov-cobertura", "~> 2.1.0"
 gem "warning", "~> 1"
 gem "webmock", ">= 3.10.0"
 gem "rexml", ">= 3.2.7"
-gem "yard", "~> 0.9"
 gem "rubocop", "~> 1.50.0", require: false
 gem "rubocop-packaging", "~> 0.5.2", require: false
 gem "rubocop-performance", "~> 1.9", require: false

--- a/gemfiles/ruby_2.7_rack_3.gemfile.lock
+++ b/gemfiles/ruby_2.7_rack_3.gemfile.lock
@@ -143,7 +143,6 @@ GEM
       addressable (>= 2.3.6)
       crack (>= 0.3.2)
       hashdiff (>= 0.4.0, < 2.0.0)
-    yard (0.9.34)
 
 PLATFORMS
   aarch64-linux
@@ -186,7 +185,6 @@ DEPENDENCIES
   simplecov-cobertura (~> 2.1.0)
   warning (~> 1)
   webmock (>= 3.10.0)
-  yard (~> 0.9)
 
 BUNDLED WITH
    2.3.26

--- a/gemfiles/ruby_2.7_rails5_mysql2.gemfile
+++ b/gemfiles/ruby_2.7_rails5_mysql2.gemfile
@@ -27,7 +27,6 @@ gem "simplecov-cobertura", "~> 2.1.0"
 gem "warning", "~> 1"
 gem "webmock", ">= 3.10.0"
 gem "rexml", ">= 3.2.7"
-gem "yard", "~> 0.9"
 gem "rubocop", "~> 1.50.0", require: false
 gem "rubocop-packaging", "~> 0.5.2", require: false
 gem "rubocop-performance", "~> 1.9", require: false

--- a/gemfiles/ruby_2.7_rails5_mysql2.gemfile.lock
+++ b/gemfiles/ruby_2.7_rails5_mysql2.gemfile.lock
@@ -257,12 +257,9 @@ GEM
       addressable (>= 2.3.6)
       crack (>= 0.3.2)
       hashdiff (>= 0.4.0, < 2.0.0)
-    webrick (1.7.0)
     websocket-driver (0.7.5)
       websocket-extensions (>= 0.1.0)
     websocket-extensions (0.1.5)
-    yard (0.9.28)
-      webrick (~> 1.7.0)
 
 PLATFORMS
   aarch64-linux
@@ -306,7 +303,6 @@ DEPENDENCIES
   sprockets (< 4)
   warning (~> 1)
   webmock (>= 3.10.0)
-  yard (~> 0.9)
 
 BUNDLED WITH
    2.3.26

--- a/gemfiles/ruby_2.7_rails5_postgres.gemfile
+++ b/gemfiles/ruby_2.7_rails5_postgres.gemfile
@@ -27,7 +27,6 @@ gem "simplecov-cobertura", "~> 2.1.0"
 gem "warning", "~> 1"
 gem "webmock", ">= 3.10.0"
 gem "rexml", ">= 3.2.7"
-gem "yard", "~> 0.9"
 gem "rubocop", "~> 1.50.0", require: false
 gem "rubocop-packaging", "~> 0.5.2", require: false
 gem "rubocop-performance", "~> 1.9", require: false

--- a/gemfiles/ruby_2.7_rails5_postgres.gemfile.lock
+++ b/gemfiles/ruby_2.7_rails5_postgres.gemfile.lock
@@ -257,12 +257,9 @@ GEM
       addressable (>= 2.3.6)
       crack (>= 0.3.2)
       hashdiff (>= 0.4.0, < 2.0.0)
-    webrick (1.7.0)
     websocket-driver (0.7.5)
       websocket-extensions (>= 0.1.0)
     websocket-extensions (0.1.5)
-    yard (0.9.28)
-      webrick (~> 1.7.0)
 
 PLATFORMS
   aarch64-linux
@@ -306,7 +303,6 @@ DEPENDENCIES
   sprockets (< 4)
   warning (~> 1)
   webmock (>= 3.10.0)
-  yard (~> 0.9)
 
 BUNDLED WITH
    2.3.26

--- a/gemfiles/ruby_2.7_rails5_postgres_redis.gemfile
+++ b/gemfiles/ruby_2.7_rails5_postgres_redis.gemfile
@@ -27,7 +27,6 @@ gem "simplecov-cobertura", "~> 2.1.0"
 gem "warning", "~> 1"
 gem "webmock", ">= 3.10.0"
 gem "rexml", ">= 3.2.7"
-gem "yard", "~> 0.9"
 gem "rubocop", "~> 1.50.0", require: false
 gem "rubocop-packaging", "~> 0.5.2", require: false
 gem "rubocop-performance", "~> 1.9", require: false

--- a/gemfiles/ruby_2.7_rails5_postgres_redis.gemfile.lock
+++ b/gemfiles/ruby_2.7_rails5_postgres_redis.gemfile.lock
@@ -258,12 +258,9 @@ GEM
       addressable (>= 2.3.6)
       crack (>= 0.3.2)
       hashdiff (>= 0.4.0, < 2.0.0)
-    webrick (1.7.0)
     websocket-driver (0.7.5)
       websocket-extensions (>= 0.1.0)
     websocket-extensions (0.1.5)
-    yard (0.9.28)
-      webrick (~> 1.7.0)
 
 PLATFORMS
   aarch64-linux
@@ -308,7 +305,6 @@ DEPENDENCIES
   sprockets (< 4)
   warning (~> 1)
   webmock (>= 3.10.0)
-  yard (~> 0.9)
 
 BUNDLED WITH
    2.3.26

--- a/gemfiles/ruby_2.7_rails5_postgres_redis_activesupport.gemfile
+++ b/gemfiles/ruby_2.7_rails5_postgres_redis_activesupport.gemfile
@@ -27,7 +27,6 @@ gem "simplecov-cobertura", "~> 2.1.0"
 gem "warning", "~> 1"
 gem "webmock", ">= 3.10.0"
 gem "rexml", ">= 3.2.7"
-gem "yard", "~> 0.9"
 gem "rubocop", "~> 1.50.0", require: false
 gem "rubocop-packaging", "~> 0.5.2", require: false
 gem "rubocop-performance", "~> 1.9", require: false

--- a/gemfiles/ruby_2.7_rails5_postgres_redis_activesupport.gemfile.lock
+++ b/gemfiles/ruby_2.7_rails5_postgres_redis_activesupport.gemfile.lock
@@ -274,12 +274,9 @@ GEM
       addressable (>= 2.3.6)
       crack (>= 0.3.2)
       hashdiff (>= 0.4.0, < 2.0.0)
-    webrick (1.7.0)
     websocket-driver (0.7.5)
       websocket-extensions (>= 0.1.0)
     websocket-extensions (0.1.5)
-    yard (0.9.28)
-      webrick (~> 1.7.0)
 
 PLATFORMS
   aarch64-linux
@@ -326,7 +323,6 @@ DEPENDENCIES
   sprockets (< 4)
   warning (~> 1)
   webmock (>= 3.10.0)
-  yard (~> 0.9)
 
 BUNDLED WITH
    2.3.26

--- a/gemfiles/ruby_2.7_rails5_postgres_sidekiq.gemfile
+++ b/gemfiles/ruby_2.7_rails5_postgres_sidekiq.gemfile
@@ -27,7 +27,6 @@ gem "simplecov-cobertura", "~> 2.1.0"
 gem "warning", "~> 1"
 gem "webmock", ">= 3.10.0"
 gem "rexml", ">= 3.2.7"
-gem "yard", "~> 0.9"
 gem "rubocop", "~> 1.50.0", require: false
 gem "rubocop-packaging", "~> 0.5.2", require: false
 gem "rubocop-performance", "~> 1.9", require: false

--- a/gemfiles/ruby_2.7_rails5_postgres_sidekiq.gemfile.lock
+++ b/gemfiles/ruby_2.7_rails5_postgres_sidekiq.gemfile.lock
@@ -263,12 +263,9 @@ GEM
       addressable (>= 2.3.6)
       crack (>= 0.3.2)
       hashdiff (>= 0.4.0, < 2.0.0)
-    webrick (1.7.0)
     websocket-driver (0.7.5)
       websocket-extensions (>= 0.1.0)
     websocket-extensions (0.1.5)
-    yard (0.9.28)
-      webrick (~> 1.7.0)
 
 PLATFORMS
   aarch64-linux
@@ -314,7 +311,6 @@ DEPENDENCIES
   sprockets (< 4)
   warning (~> 1)
   webmock (>= 3.10.0)
-  yard (~> 0.9)
 
 BUNDLED WITH
    2.3.26

--- a/gemfiles/ruby_2.7_rails5_semantic_logger.gemfile
+++ b/gemfiles/ruby_2.7_rails5_semantic_logger.gemfile
@@ -27,7 +27,6 @@ gem "simplecov-cobertura", "~> 2.1.0"
 gem "warning", "~> 1"
 gem "webmock", ">= 3.10.0"
 gem "rexml", ">= 3.2.7"
-gem "yard", "~> 0.9"
 gem "rubocop", "~> 1.50.0", require: false
 gem "rubocop-packaging", "~> 0.5.2", require: false
 gem "rubocop-performance", "~> 1.9", require: false

--- a/gemfiles/ruby_2.7_rails5_semantic_logger.gemfile.lock
+++ b/gemfiles/ruby_2.7_rails5_semantic_logger.gemfile.lock
@@ -256,12 +256,9 @@ GEM
       addressable (>= 2.3.6)
       crack (>= 0.3.2)
       hashdiff (>= 0.4.0, < 2.0.0)
-    webrick (1.7.0)
     websocket-driver (0.7.5)
       websocket-extensions (>= 0.1.0)
     websocket-extensions (0.1.5)
-    yard (0.9.28)
-      webrick (~> 1.7.0)
 
 PLATFORMS
   aarch64-linux
@@ -305,7 +302,6 @@ DEPENDENCIES
   sprockets (< 4)
   warning (~> 1)
   webmock (>= 3.10.0)
-  yard (~> 0.9)
 
 BUNDLED WITH
    2.3.26

--- a/gemfiles/ruby_2.7_rails61_mysql2.gemfile
+++ b/gemfiles/ruby_2.7_rails61_mysql2.gemfile
@@ -27,7 +27,6 @@ gem "simplecov-cobertura", "~> 2.1.0"
 gem "warning", "~> 1"
 gem "webmock", ">= 3.10.0"
 gem "rexml", ">= 3.2.7"
-gem "yard", "~> 0.9"
 gem "rubocop", "~> 1.50.0", require: false
 gem "rubocop-packaging", "~> 0.5.2", require: false
 gem "rubocop-performance", "~> 1.9", require: false

--- a/gemfiles/ruby_2.7_rails61_mysql2.gemfile.lock
+++ b/gemfiles/ruby_2.7_rails61_mysql2.gemfile.lock
@@ -275,12 +275,9 @@ GEM
       addressable (>= 2.3.6)
       crack (>= 0.3.2)
       hashdiff (>= 0.4.0, < 2.0.0)
-    webrick (1.7.0)
     websocket-driver (0.7.5)
       websocket-extensions (>= 0.1.0)
     websocket-extensions (0.1.5)
-    yard (0.9.28)
-      webrick (~> 1.7.0)
     zeitwerk (2.6.7)
 
 PLATFORMS
@@ -325,7 +322,6 @@ DEPENDENCIES
   sprockets (< 4)
   warning (~> 1)
   webmock (>= 3.10.0)
-  yard (~> 0.9)
 
 BUNDLED WITH
    2.3.26

--- a/gemfiles/ruby_2.7_rails61_postgres.gemfile
+++ b/gemfiles/ruby_2.7_rails61_postgres.gemfile
@@ -27,7 +27,6 @@ gem "simplecov-cobertura", "~> 2.1.0"
 gem "warning", "~> 1"
 gem "webmock", ">= 3.10.0"
 gem "rexml", ">= 3.2.7"
-gem "yard", "~> 0.9"
 gem "rubocop", "~> 1.50.0", require: false
 gem "rubocop-packaging", "~> 0.5.2", require: false
 gem "rubocop-performance", "~> 1.9", require: false

--- a/gemfiles/ruby_2.7_rails61_postgres.gemfile.lock
+++ b/gemfiles/ruby_2.7_rails61_postgres.gemfile.lock
@@ -275,12 +275,9 @@ GEM
       addressable (>= 2.3.6)
       crack (>= 0.3.2)
       hashdiff (>= 0.4.0, < 2.0.0)
-    webrick (1.7.0)
     websocket-driver (0.7.5)
       websocket-extensions (>= 0.1.0)
     websocket-extensions (0.1.5)
-    yard (0.9.28)
-      webrick (~> 1.7.0)
     zeitwerk (2.6.7)
 
 PLATFORMS
@@ -325,7 +322,6 @@ DEPENDENCIES
   sprockets (< 4)
   warning (~> 1)
   webmock (>= 3.10.0)
-  yard (~> 0.9)
 
 BUNDLED WITH
    2.3.26

--- a/gemfiles/ruby_2.7_rails61_postgres_redis.gemfile
+++ b/gemfiles/ruby_2.7_rails61_postgres_redis.gemfile
@@ -27,7 +27,6 @@ gem "simplecov-cobertura", "~> 2.1.0"
 gem "warning", "~> 1"
 gem "webmock", ">= 3.10.0"
 gem "rexml", ">= 3.2.7"
-gem "yard", "~> 0.9"
 gem "rubocop", "~> 1.50.0", require: false
 gem "rubocop-packaging", "~> 0.5.2", require: false
 gem "rubocop-performance", "~> 1.9", require: false

--- a/gemfiles/ruby_2.7_rails61_postgres_redis.gemfile.lock
+++ b/gemfiles/ruby_2.7_rails61_postgres_redis.gemfile.lock
@@ -276,12 +276,9 @@ GEM
       addressable (>= 2.3.6)
       crack (>= 0.3.2)
       hashdiff (>= 0.4.0, < 2.0.0)
-    webrick (1.7.0)
     websocket-driver (0.7.5)
       websocket-extensions (>= 0.1.0)
     websocket-extensions (0.1.5)
-    yard (0.9.28)
-      webrick (~> 1.7.0)
     zeitwerk (2.6.7)
 
 PLATFORMS
@@ -327,7 +324,6 @@ DEPENDENCIES
   sprockets (< 4)
   warning (~> 1)
   webmock (>= 3.10.0)
-  yard (~> 0.9)
 
 BUNDLED WITH
    2.3.26

--- a/gemfiles/ruby_2.7_rails61_postgres_sidekiq.gemfile
+++ b/gemfiles/ruby_2.7_rails61_postgres_sidekiq.gemfile
@@ -27,7 +27,6 @@ gem "simplecov-cobertura", "~> 2.1.0"
 gem "warning", "~> 1"
 gem "webmock", ">= 3.10.0"
 gem "rexml", ">= 3.2.7"
-gem "yard", "~> 0.9"
 gem "rubocop", "~> 1.50.0", require: false
 gem "rubocop-packaging", "~> 0.5.2", require: false
 gem "rubocop-performance", "~> 1.9", require: false

--- a/gemfiles/ruby_2.7_rails61_postgres_sidekiq.gemfile.lock
+++ b/gemfiles/ruby_2.7_rails61_postgres_sidekiq.gemfile.lock
@@ -283,12 +283,9 @@ GEM
       addressable (>= 2.3.6)
       crack (>= 0.3.2)
       hashdiff (>= 0.4.0, < 2.0.0)
-    webrick (1.7.0)
     websocket-driver (0.7.5)
       websocket-extensions (>= 0.1.0)
     websocket-extensions (0.1.5)
-    yard (0.9.28)
-      webrick (~> 1.7.0)
     zeitwerk (2.6.7)
 
 PLATFORMS
@@ -334,7 +331,6 @@ DEPENDENCIES
   sprockets (< 4)
   warning (~> 1)
   webmock (>= 3.10.0)
-  yard (~> 0.9)
 
 BUNDLED WITH
    2.3.26

--- a/gemfiles/ruby_2.7_rails61_semantic_logger.gemfile
+++ b/gemfiles/ruby_2.7_rails61_semantic_logger.gemfile
@@ -27,7 +27,6 @@ gem "simplecov-cobertura", "~> 2.1.0"
 gem "warning", "~> 1"
 gem "webmock", ">= 3.10.0"
 gem "rexml", ">= 3.2.7"
-gem "yard", "~> 0.9"
 gem "rubocop", "~> 1.50.0", require: false
 gem "rubocop-packaging", "~> 0.5.2", require: false
 gem "rubocop-performance", "~> 1.9", require: false

--- a/gemfiles/ruby_2.7_rails61_semantic_logger.gemfile.lock
+++ b/gemfiles/ruby_2.7_rails61_semantic_logger.gemfile.lock
@@ -274,12 +274,9 @@ GEM
       addressable (>= 2.3.6)
       crack (>= 0.3.2)
       hashdiff (>= 0.4.0, < 2.0.0)
-    webrick (1.7.0)
     websocket-driver (0.7.5)
       websocket-extensions (>= 0.1.0)
     websocket-extensions (0.1.5)
-    yard (0.9.28)
-      webrick (~> 1.7.0)
     zeitwerk (2.6.7)
 
 PLATFORMS
@@ -324,7 +321,6 @@ DEPENDENCIES
   sprockets (< 4)
   warning (~> 1)
   webmock (>= 3.10.0)
-  yard (~> 0.9)
 
 BUNDLED WITH
    2.3.26

--- a/gemfiles/ruby_2.7_rails6_mysql2.gemfile
+++ b/gemfiles/ruby_2.7_rails6_mysql2.gemfile
@@ -27,7 +27,6 @@ gem "simplecov-cobertura", "~> 2.1.0"
 gem "warning", "~> 1"
 gem "webmock", ">= 3.10.0"
 gem "rexml", ">= 3.2.7"
-gem "yard", "~> 0.9"
 gem "rubocop", "~> 1.50.0", require: false
 gem "rubocop-packaging", "~> 0.5.2", require: false
 gem "rubocop-performance", "~> 1.9", require: false

--- a/gemfiles/ruby_2.7_rails6_mysql2.gemfile.lock
+++ b/gemfiles/ruby_2.7_rails6_mysql2.gemfile.lock
@@ -272,12 +272,9 @@ GEM
       addressable (>= 2.3.6)
       crack (>= 0.3.2)
       hashdiff (>= 0.4.0, < 2.0.0)
-    webrick (1.7.0)
     websocket-driver (0.7.5)
       websocket-extensions (>= 0.1.0)
     websocket-extensions (0.1.5)
-    yard (0.9.28)
-      webrick (~> 1.7.0)
     zeitwerk (2.6.7)
 
 PLATFORMS
@@ -322,7 +319,6 @@ DEPENDENCIES
   sprockets (< 4)
   warning (~> 1)
   webmock (>= 3.10.0)
-  yard (~> 0.9)
 
 BUNDLED WITH
    2.3.26

--- a/gemfiles/ruby_2.7_rails6_postgres.gemfile
+++ b/gemfiles/ruby_2.7_rails6_postgres.gemfile
@@ -27,7 +27,6 @@ gem "simplecov-cobertura", "~> 2.1.0"
 gem "warning", "~> 1"
 gem "webmock", ">= 3.10.0"
 gem "rexml", ">= 3.2.7"
-gem "yard", "~> 0.9"
 gem "rubocop", "~> 1.50.0", require: false
 gem "rubocop-packaging", "~> 0.5.2", require: false
 gem "rubocop-performance", "~> 1.9", require: false

--- a/gemfiles/ruby_2.7_rails6_postgres.gemfile.lock
+++ b/gemfiles/ruby_2.7_rails6_postgres.gemfile.lock
@@ -272,12 +272,9 @@ GEM
       addressable (>= 2.3.6)
       crack (>= 0.3.2)
       hashdiff (>= 0.4.0, < 2.0.0)
-    webrick (1.7.0)
     websocket-driver (0.7.5)
       websocket-extensions (>= 0.1.0)
     websocket-extensions (0.1.5)
-    yard (0.9.28)
-      webrick (~> 1.7.0)
     zeitwerk (2.6.7)
 
 PLATFORMS
@@ -322,7 +319,6 @@ DEPENDENCIES
   sprockets (< 4)
   warning (~> 1)
   webmock (>= 3.10.0)
-  yard (~> 0.9)
 
 BUNDLED WITH
    2.3.26

--- a/gemfiles/ruby_2.7_rails6_postgres_redis.gemfile
+++ b/gemfiles/ruby_2.7_rails6_postgres_redis.gemfile
@@ -27,7 +27,6 @@ gem "simplecov-cobertura", "~> 2.1.0"
 gem "warning", "~> 1"
 gem "webmock", ">= 3.10.0"
 gem "rexml", ">= 3.2.7"
-gem "yard", "~> 0.9"
 gem "rubocop", "~> 1.50.0", require: false
 gem "rubocop-packaging", "~> 0.5.2", require: false
 gem "rubocop-performance", "~> 1.9", require: false

--- a/gemfiles/ruby_2.7_rails6_postgres_redis.gemfile.lock
+++ b/gemfiles/ruby_2.7_rails6_postgres_redis.gemfile.lock
@@ -273,12 +273,9 @@ GEM
       addressable (>= 2.3.6)
       crack (>= 0.3.2)
       hashdiff (>= 0.4.0, < 2.0.0)
-    webrick (1.7.0)
     websocket-driver (0.7.5)
       websocket-extensions (>= 0.1.0)
     websocket-extensions (0.1.5)
-    yard (0.9.28)
-      webrick (~> 1.7.0)
     zeitwerk (2.6.7)
 
 PLATFORMS
@@ -324,7 +321,6 @@ DEPENDENCIES
   sprockets (< 4)
   warning (~> 1)
   webmock (>= 3.10.0)
-  yard (~> 0.9)
 
 BUNDLED WITH
    2.3.26

--- a/gemfiles/ruby_2.7_rails6_postgres_redis_activesupport.gemfile
+++ b/gemfiles/ruby_2.7_rails6_postgres_redis_activesupport.gemfile
@@ -27,7 +27,6 @@ gem "simplecov-cobertura", "~> 2.1.0"
 gem "warning", "~> 1"
 gem "webmock", ">= 3.10.0"
 gem "rexml", ">= 3.2.7"
-gem "yard", "~> 0.9"
 gem "rubocop", "~> 1.50.0", require: false
 gem "rubocop-packaging", "~> 0.5.2", require: false
 gem "rubocop-performance", "~> 1.9", require: false

--- a/gemfiles/ruby_2.7_rails6_postgres_redis_activesupport.gemfile.lock
+++ b/gemfiles/ruby_2.7_rails6_postgres_redis_activesupport.gemfile.lock
@@ -289,12 +289,9 @@ GEM
       addressable (>= 2.3.6)
       crack (>= 0.3.2)
       hashdiff (>= 0.4.0, < 2.0.0)
-    webrick (1.7.0)
     websocket-driver (0.7.5)
       websocket-extensions (>= 0.1.0)
     websocket-extensions (0.1.5)
-    yard (0.9.28)
-      webrick (~> 1.7.0)
     zeitwerk (2.6.7)
 
 PLATFORMS
@@ -342,7 +339,6 @@ DEPENDENCIES
   sprockets (< 4)
   warning (~> 1)
   webmock (>= 3.10.0)
-  yard (~> 0.9)
 
 BUNDLED WITH
    2.3.26

--- a/gemfiles/ruby_2.7_rails6_postgres_sidekiq.gemfile
+++ b/gemfiles/ruby_2.7_rails6_postgres_sidekiq.gemfile
@@ -27,7 +27,6 @@ gem "simplecov-cobertura", "~> 2.1.0"
 gem "warning", "~> 1"
 gem "webmock", ">= 3.10.0"
 gem "rexml", ">= 3.2.7"
-gem "yard", "~> 0.9"
 gem "rubocop", "~> 1.50.0", require: false
 gem "rubocop-packaging", "~> 0.5.2", require: false
 gem "rubocop-performance", "~> 1.9", require: false

--- a/gemfiles/ruby_2.7_rails6_postgres_sidekiq.gemfile.lock
+++ b/gemfiles/ruby_2.7_rails6_postgres_sidekiq.gemfile.lock
@@ -278,12 +278,9 @@ GEM
       addressable (>= 2.3.6)
       crack (>= 0.3.2)
       hashdiff (>= 0.4.0, < 2.0.0)
-    webrick (1.7.0)
     websocket-driver (0.7.5)
       websocket-extensions (>= 0.1.0)
     websocket-extensions (0.1.5)
-    yard (0.9.28)
-      webrick (~> 1.7.0)
     zeitwerk (2.6.7)
 
 PLATFORMS
@@ -330,7 +327,6 @@ DEPENDENCIES
   sprockets (< 4)
   warning (~> 1)
   webmock (>= 3.10.0)
-  yard (~> 0.9)
 
 BUNDLED WITH
    2.3.26

--- a/gemfiles/ruby_2.7_rails6_semantic_logger.gemfile
+++ b/gemfiles/ruby_2.7_rails6_semantic_logger.gemfile
@@ -27,7 +27,6 @@ gem "simplecov-cobertura", "~> 2.1.0"
 gem "warning", "~> 1"
 gem "webmock", ">= 3.10.0"
 gem "rexml", ">= 3.2.7"
-gem "yard", "~> 0.9"
 gem "rubocop", "~> 1.50.0", require: false
 gem "rubocop-packaging", "~> 0.5.2", require: false
 gem "rubocop-performance", "~> 1.9", require: false

--- a/gemfiles/ruby_2.7_rails6_semantic_logger.gemfile.lock
+++ b/gemfiles/ruby_2.7_rails6_semantic_logger.gemfile.lock
@@ -271,12 +271,9 @@ GEM
       addressable (>= 2.3.6)
       crack (>= 0.3.2)
       hashdiff (>= 0.4.0, < 2.0.0)
-    webrick (1.7.0)
     websocket-driver (0.7.5)
       websocket-extensions (>= 0.1.0)
     websocket-extensions (0.1.5)
-    yard (0.9.28)
-      webrick (~> 1.7.0)
     zeitwerk (2.6.7)
 
 PLATFORMS
@@ -321,7 +318,6 @@ DEPENDENCIES
   sprockets (< 4)
   warning (~> 1)
   webmock (>= 3.10.0)
-  yard (~> 0.9)
 
 BUNDLED WITH
    2.3.26

--- a/gemfiles/ruby_2.7_redis_3.gemfile
+++ b/gemfiles/ruby_2.7_redis_3.gemfile
@@ -27,7 +27,6 @@ gem "simplecov-cobertura", "~> 2.1.0"
 gem "warning", "~> 1"
 gem "webmock", ">= 3.10.0"
 gem "rexml", ">= 3.2.7"
-gem "yard", "~> 0.9"
 gem "rubocop", "~> 1.50.0", require: false
 gem "rubocop-packaging", "~> 0.5.2", require: false
 gem "rubocop-performance", "~> 1.9", require: false

--- a/gemfiles/ruby_2.7_redis_3.gemfile.lock
+++ b/gemfiles/ruby_2.7_redis_3.gemfile.lock
@@ -137,9 +137,6 @@ GEM
       addressable (>= 2.3.6)
       crack (>= 0.3.2)
       hashdiff (>= 0.4.0, < 2.0.0)
-    webrick (1.7.0)
-    yard (0.9.28)
-      webrick (~> 1.7.0)
 
 PLATFORMS
   aarch64-linux
@@ -180,7 +177,6 @@ DEPENDENCIES
   simplecov-cobertura (~> 2.1.0)
   warning (~> 1)
   webmock (>= 3.10.0)
-  yard (~> 0.9)
 
 BUNDLED WITH
    2.3.26

--- a/gemfiles/ruby_2.7_redis_4.gemfile
+++ b/gemfiles/ruby_2.7_redis_4.gemfile
@@ -27,7 +27,6 @@ gem "simplecov-cobertura", "~> 2.1.0"
 gem "warning", "~> 1"
 gem "webmock", ">= 3.10.0"
 gem "rexml", ">= 3.2.7"
-gem "yard", "~> 0.9"
 gem "rubocop", "~> 1.50.0", require: false
 gem "rubocop-packaging", "~> 0.5.2", require: false
 gem "rubocop-performance", "~> 1.9", require: false

--- a/gemfiles/ruby_2.7_redis_4.gemfile.lock
+++ b/gemfiles/ruby_2.7_redis_4.gemfile.lock
@@ -137,9 +137,6 @@ GEM
       addressable (>= 2.3.6)
       crack (>= 0.3.2)
       hashdiff (>= 0.4.0, < 2.0.0)
-    webrick (1.7.0)
-    yard (0.9.28)
-      webrick (~> 1.7.0)
 
 PLATFORMS
   aarch64-linux
@@ -180,7 +177,6 @@ DEPENDENCIES
   simplecov-cobertura (~> 2.1.0)
   warning (~> 1)
   webmock (>= 3.10.0)
-  yard (~> 0.9)
 
 BUNDLED WITH
    2.3.26

--- a/gemfiles/ruby_2.7_redis_5.gemfile
+++ b/gemfiles/ruby_2.7_redis_5.gemfile
@@ -27,7 +27,6 @@ gem "simplecov-cobertura", "~> 2.1.0"
 gem "warning", "~> 1"
 gem "webmock", ">= 3.10.0"
 gem "rexml", ">= 3.2.7"
-gem "yard", "~> 0.9"
 gem "rubocop", "~> 1.50.0", require: false
 gem "rubocop-packaging", "~> 0.5.2", require: false
 gem "rubocop-performance", "~> 1.9", require: false

--- a/gemfiles/ruby_2.7_redis_5.gemfile.lock
+++ b/gemfiles/ruby_2.7_redis_5.gemfile.lock
@@ -141,9 +141,6 @@ GEM
       addressable (>= 2.3.6)
       crack (>= 0.3.2)
       hashdiff (>= 0.4.0, < 2.0.0)
-    webrick (1.7.0)
-    yard (0.9.28)
-      webrick (~> 1.7.0)
 
 PLATFORMS
   aarch64-linux
@@ -184,7 +181,6 @@ DEPENDENCIES
   simplecov-cobertura (~> 2.1.0)
   warning (~> 1)
   webmock (>= 3.10.0)
-  yard (~> 0.9)
 
 BUNDLED WITH
    2.3.26

--- a/gemfiles/ruby_2.7_relational_db.gemfile
+++ b/gemfiles/ruby_2.7_relational_db.gemfile
@@ -27,7 +27,6 @@ gem "simplecov-cobertura", "~> 2.1.0"
 gem "warning", "~> 1"
 gem "webmock", ">= 3.10.0"
 gem "rexml", ">= 3.2.7"
-gem "yard", "~> 0.9"
 gem "rubocop", "~> 1.50.0", require: false
 gem "rubocop-packaging", "~> 0.5.2", require: false
 gem "rubocop-performance", "~> 1.9", require: false

--- a/gemfiles/ruby_2.7_relational_db.gemfile.lock
+++ b/gemfiles/ruby_2.7_relational_db.gemfile.lock
@@ -167,7 +167,6 @@ GEM
       addressable (>= 2.3.6)
       crack (>= 0.3.2)
       hashdiff (>= 0.4.0, < 2.0.0)
-    yard (0.9.34)
     zeitwerk (2.6.11)
 
 PLATFORMS
@@ -216,7 +215,6 @@ DEPENDENCIES
   sqlite3 (~> 1.4.1)
   warning (~> 1)
   webmock (>= 3.10.0)
-  yard (~> 0.9)
 
 BUNDLED WITH
    2.3.26

--- a/gemfiles/ruby_2.7_resque2_redis3.gemfile
+++ b/gemfiles/ruby_2.7_resque2_redis3.gemfile
@@ -27,7 +27,6 @@ gem "simplecov-cobertura", "~> 2.1.0"
 gem "warning", "~> 1"
 gem "webmock", ">= 3.10.0"
 gem "rexml", ">= 3.2.7"
-gem "yard", "~> 0.9"
 gem "rubocop", "~> 1.50.0", require: false
 gem "rubocop-packaging", "~> 0.5.2", require: false
 gem "rubocop-performance", "~> 1.9", require: false

--- a/gemfiles/ruby_2.7_resque2_redis3.gemfile.lock
+++ b/gemfiles/ruby_2.7_resque2_redis3.gemfile.lock
@@ -158,9 +158,6 @@ GEM
       addressable (>= 2.3.6)
       crack (>= 0.3.2)
       hashdiff (>= 0.4.0, < 2.0.0)
-    webrick (1.7.0)
-    yard (0.9.28)
-      webrick (~> 1.7.0)
 
 PLATFORMS
   aarch64-linux
@@ -202,7 +199,6 @@ DEPENDENCIES
   simplecov-cobertura (~> 2.1.0)
   warning (~> 1)
   webmock (>= 3.10.0)
-  yard (~> 0.9)
 
 BUNDLED WITH
    2.3.26

--- a/gemfiles/ruby_2.7_resque2_redis4.gemfile
+++ b/gemfiles/ruby_2.7_resque2_redis4.gemfile
@@ -27,7 +27,6 @@ gem "simplecov-cobertura", "~> 2.1.0"
 gem "warning", "~> 1"
 gem "webmock", ">= 3.10.0"
 gem "rexml", ">= 3.2.7"
-gem "yard", "~> 0.9"
 gem "rubocop", "~> 1.50.0", require: false
 gem "rubocop-packaging", "~> 0.5.2", require: false
 gem "rubocop-performance", "~> 1.9", require: false

--- a/gemfiles/ruby_2.7_resque2_redis4.gemfile.lock
+++ b/gemfiles/ruby_2.7_resque2_redis4.gemfile.lock
@@ -158,9 +158,6 @@ GEM
       addressable (>= 2.3.6)
       crack (>= 0.3.2)
       hashdiff (>= 0.4.0, < 2.0.0)
-    webrick (1.7.0)
-    yard (0.9.28)
-      webrick (~> 1.7.0)
 
 PLATFORMS
   aarch64-linux
@@ -202,7 +199,6 @@ DEPENDENCIES
   simplecov-cobertura (~> 2.1.0)
   warning (~> 1)
   webmock (>= 3.10.0)
-  yard (~> 0.9)
 
 BUNDLED WITH
    2.3.26

--- a/gemfiles/ruby_2.7_sinatra_2.gemfile
+++ b/gemfiles/ruby_2.7_sinatra_2.gemfile
@@ -27,7 +27,6 @@ gem "simplecov-cobertura", "~> 2.1.0"
 gem "warning", "~> 1"
 gem "webmock", ">= 3.10.0"
 gem "rexml", ">= 3.2.7"
-gem "yard", "~> 0.9"
 gem "rubocop", "~> 1.50.0", require: false
 gem "rubocop-packaging", "~> 0.5.2", require: false
 gem "rubocop-performance", "~> 1.9", require: false

--- a/gemfiles/ruby_2.7_sinatra_2.gemfile.lock
+++ b/gemfiles/ruby_2.7_sinatra_2.gemfile.lock
@@ -158,7 +158,6 @@ GEM
       addressable (>= 2.8.0)
       crack (>= 0.3.2)
       hashdiff (>= 0.4.0, < 2.0.0)
-    yard (0.9.36)
 
 PLATFORMS
   aarch64-linux
@@ -201,7 +200,6 @@ DEPENDENCIES
   sinatra (~> 2)
   warning (~> 1)
   webmock (>= 3.10.0)
-  yard (~> 0.9)
 
 BUNDLED WITH
    2.3.26

--- a/gemfiles/ruby_2.7_sinatra_3.gemfile
+++ b/gemfiles/ruby_2.7_sinatra_3.gemfile
@@ -27,7 +27,6 @@ gem "simplecov-cobertura", "~> 2.1.0"
 gem "warning", "~> 1"
 gem "webmock", ">= 3.10.0"
 gem "rexml", ">= 3.2.7"
-gem "yard", "~> 0.9"
 gem "rubocop", "~> 1.50.0", require: false
 gem "rubocop-packaging", "~> 0.5.2", require: false
 gem "rubocop-performance", "~> 1.9", require: false

--- a/gemfiles/ruby_2.7_sinatra_3.gemfile.lock
+++ b/gemfiles/ruby_2.7_sinatra_3.gemfile.lock
@@ -160,7 +160,6 @@ GEM
       addressable (>= 2.8.0)
       crack (>= 0.3.2)
       hashdiff (>= 0.4.0, < 2.0.0)
-    yard (0.9.36)
 
 PLATFORMS
   aarch64-linux
@@ -203,7 +202,6 @@ DEPENDENCIES
   sinatra (~> 3)
   warning (~> 1)
   webmock (>= 3.10.0)
-  yard (~> 0.9)
 
 BUNDLED WITH
    2.3.26

--- a/gemfiles/ruby_2.7_stripe_10.gemfile
+++ b/gemfiles/ruby_2.7_stripe_10.gemfile
@@ -27,7 +27,6 @@ gem "simplecov-cobertura", "~> 2.1.0"
 gem "warning", "~> 1"
 gem "webmock", ">= 3.10.0"
 gem "rexml", ">= 3.2.7"
-gem "yard", "~> 0.9"
 gem "rubocop", "~> 1.50.0", require: false
 gem "rubocop-packaging", "~> 0.5.2", require: false
 gem "rubocop-performance", "~> 1.9", require: false

--- a/gemfiles/ruby_2.7_stripe_10.gemfile.lock
+++ b/gemfiles/ruby_2.7_stripe_10.gemfile.lock
@@ -142,7 +142,6 @@ GEM
       addressable (>= 2.8.0)
       crack (>= 0.3.2)
       hashdiff (>= 0.4.0, < 2.0.0)
-    yard (0.9.36)
 
 PLATFORMS
   aarch64-linux
@@ -183,7 +182,6 @@ DEPENDENCIES
   stripe (~> 10)
   warning (~> 1)
   webmock (>= 3.10.0)
-  yard (~> 0.9)
 
 BUNDLED WITH
    2.3.26

--- a/gemfiles/ruby_2.7_stripe_11.gemfile
+++ b/gemfiles/ruby_2.7_stripe_11.gemfile
@@ -27,7 +27,6 @@ gem "simplecov-cobertura", "~> 2.1.0"
 gem "warning", "~> 1"
 gem "webmock", ">= 3.10.0"
 gem "rexml", ">= 3.2.7"
-gem "yard", "~> 0.9"
 gem "rubocop", "~> 1.50.0", require: false
 gem "rubocop-packaging", "~> 0.5.2", require: false
 gem "rubocop-performance", "~> 1.9", require: false

--- a/gemfiles/ruby_2.7_stripe_11.gemfile.lock
+++ b/gemfiles/ruby_2.7_stripe_11.gemfile.lock
@@ -142,7 +142,6 @@ GEM
       addressable (>= 2.8.0)
       crack (>= 0.3.2)
       hashdiff (>= 0.4.0, < 2.0.0)
-    yard (0.9.36)
 
 PLATFORMS
   aarch64-linux
@@ -183,7 +182,6 @@ DEPENDENCIES
   stripe (~> 11)
   warning (~> 1)
   webmock (>= 3.10.0)
-  yard (~> 0.9)
 
 BUNDLED WITH
    2.3.26

--- a/gemfiles/ruby_2.7_stripe_12.gemfile
+++ b/gemfiles/ruby_2.7_stripe_12.gemfile
@@ -27,7 +27,6 @@ gem "simplecov-cobertura", "~> 2.1.0"
 gem "warning", "~> 1"
 gem "webmock", ">= 3.10.0"
 gem "rexml", ">= 3.2.7"
-gem "yard", "~> 0.9"
 gem "rubocop", "~> 1.50.0", require: false
 gem "rubocop-packaging", "~> 0.5.2", require: false
 gem "rubocop-performance", "~> 1.9", require: false

--- a/gemfiles/ruby_2.7_stripe_12.gemfile.lock
+++ b/gemfiles/ruby_2.7_stripe_12.gemfile.lock
@@ -142,7 +142,6 @@ GEM
       addressable (>= 2.8.0)
       crack (>= 0.3.2)
       hashdiff (>= 0.4.0, < 2.0.0)
-    yard (0.9.36)
 
 PLATFORMS
   aarch64-linux
@@ -183,7 +182,6 @@ DEPENDENCIES
   stripe (~> 12)
   warning (~> 1)
   webmock (>= 3.10.0)
-  yard (~> 0.9)
 
 BUNDLED WITH
    2.3.26

--- a/gemfiles/ruby_2.7_stripe_7.gemfile
+++ b/gemfiles/ruby_2.7_stripe_7.gemfile
@@ -27,7 +27,6 @@ gem "simplecov-cobertura", "~> 2.1.0"
 gem "warning", "~> 1"
 gem "webmock", ">= 3.10.0"
 gem "rexml", ">= 3.2.7"
-gem "yard", "~> 0.9"
 gem "rubocop", "~> 1.50.0", require: false
 gem "rubocop-packaging", "~> 0.5.2", require: false
 gem "rubocop-performance", "~> 1.9", require: false

--- a/gemfiles/ruby_2.7_stripe_7.gemfile.lock
+++ b/gemfiles/ruby_2.7_stripe_7.gemfile.lock
@@ -142,7 +142,6 @@ GEM
       addressable (>= 2.8.0)
       crack (>= 0.3.2)
       hashdiff (>= 0.4.0, < 2.0.0)
-    yard (0.9.36)
 
 PLATFORMS
   aarch64-linux
@@ -183,7 +182,6 @@ DEPENDENCIES
   stripe (~> 7)
   warning (~> 1)
   webmock (>= 3.10.0)
-  yard (~> 0.9)
 
 BUNDLED WITH
    2.3.26

--- a/gemfiles/ruby_2.7_stripe_8.gemfile
+++ b/gemfiles/ruby_2.7_stripe_8.gemfile
@@ -27,7 +27,6 @@ gem "simplecov-cobertura", "~> 2.1.0"
 gem "warning", "~> 1"
 gem "webmock", ">= 3.10.0"
 gem "rexml", ">= 3.2.7"
-gem "yard", "~> 0.9"
 gem "rubocop", "~> 1.50.0", require: false
 gem "rubocop-packaging", "~> 0.5.2", require: false
 gem "rubocop-performance", "~> 1.9", require: false

--- a/gemfiles/ruby_2.7_stripe_8.gemfile.lock
+++ b/gemfiles/ruby_2.7_stripe_8.gemfile.lock
@@ -142,7 +142,6 @@ GEM
       addressable (>= 2.8.0)
       crack (>= 0.3.2)
       hashdiff (>= 0.4.0, < 2.0.0)
-    yard (0.9.36)
 
 PLATFORMS
   aarch64-linux
@@ -183,7 +182,6 @@ DEPENDENCIES
   stripe (~> 8)
   warning (~> 1)
   webmock (>= 3.10.0)
-  yard (~> 0.9)
 
 BUNDLED WITH
    2.3.26

--- a/gemfiles/ruby_2.7_stripe_9.gemfile
+++ b/gemfiles/ruby_2.7_stripe_9.gemfile
@@ -27,7 +27,6 @@ gem "simplecov-cobertura", "~> 2.1.0"
 gem "warning", "~> 1"
 gem "webmock", ">= 3.10.0"
 gem "rexml", ">= 3.2.7"
-gem "yard", "~> 0.9"
 gem "rubocop", "~> 1.50.0", require: false
 gem "rubocop-packaging", "~> 0.5.2", require: false
 gem "rubocop-performance", "~> 1.9", require: false

--- a/gemfiles/ruby_2.7_stripe_9.gemfile.lock
+++ b/gemfiles/ruby_2.7_stripe_9.gemfile.lock
@@ -142,7 +142,6 @@ GEM
       addressable (>= 2.8.0)
       crack (>= 0.3.2)
       hashdiff (>= 0.4.0, < 2.0.0)
-    yard (0.9.36)
 
 PLATFORMS
   aarch64-linux
@@ -183,7 +182,6 @@ DEPENDENCIES
   stripe (~> 9)
   warning (~> 1)
   webmock (>= 3.10.0)
-  yard (~> 0.9)
 
 BUNDLED WITH
    2.3.26

--- a/gemfiles/ruby_3.0_activesupport.gemfile
+++ b/gemfiles/ruby_3.0_activesupport.gemfile
@@ -28,7 +28,6 @@ gem "warning", "~> 1"
 gem "webmock", ">= 3.10.0"
 gem "rexml", ">= 3.2.7"
 gem "webrick", ">= 1.7.0"
-gem "yard", "~> 0.9"
 gem "rubocop", "~> 1.50.0", require: false
 gem "rubocop-packaging", "~> 0.5.2", require: false
 gem "rubocop-performance", "~> 1.9", require: false

--- a/gemfiles/ruby_3.0_activesupport.gemfile.lock
+++ b/gemfiles/ruby_3.0_activesupport.gemfile.lock
@@ -246,7 +246,6 @@ GEM
       crack (>= 0.3.2)
       hashdiff (>= 0.4.0, < 2.0.0)
     webrick (1.8.1)
-    yard (0.9.34)
     zeitwerk (2.6.11)
 
 PLATFORMS
@@ -296,7 +295,6 @@ DEPENDENCIES
   warning (~> 1)
   webmock (>= 3.10.0)
   webrick (>= 1.7.0)
-  yard (~> 0.9)
 
 BUNDLED WITH
    2.3.26

--- a/gemfiles/ruby_3.0_aws.gemfile
+++ b/gemfiles/ruby_3.0_aws.gemfile
@@ -28,7 +28,6 @@ gem "warning", "~> 1"
 gem "webmock", ">= 3.10.0"
 gem "rexml", ">= 3.2.7"
 gem "webrick", ">= 1.7.0"
-gem "yard", "~> 0.9"
 gem "rubocop", "~> 1.50.0", require: false
 gem "rubocop-packaging", "~> 0.5.2", require: false
 gem "rubocop-performance", "~> 1.9", require: false

--- a/gemfiles/ruby_3.0_aws.gemfile.lock
+++ b/gemfiles/ruby_3.0_aws.gemfile.lock
@@ -1565,7 +1565,6 @@ GEM
       crack (>= 0.3.2)
       hashdiff (>= 0.4.0, < 2.0.0)
     webrick (1.8.1)
-    yard (0.9.34)
 
 PLATFORMS
   aarch64-linux
@@ -1608,7 +1607,6 @@ DEPENDENCIES
   warning (~> 1)
   webmock (>= 3.10.0)
   webrick (>= 1.7.0)
-  yard (~> 0.9)
 
 BUNDLED WITH
    2.3.26

--- a/gemfiles/ruby_3.0_contrib.gemfile
+++ b/gemfiles/ruby_3.0_contrib.gemfile
@@ -28,7 +28,6 @@ gem "warning", "~> 1"
 gem "webmock", ">= 3.10.0"
 gem "rexml", ">= 3.2.7"
 gem "webrick", ">= 1.7.0"
-gem "yard", "~> 0.9"
 gem "rubocop", "~> 1.50.0", require: false
 gem "rubocop-packaging", "~> 0.5.2", require: false
 gem "rubocop-performance", "~> 1.9", require: false

--- a/gemfiles/ruby_3.0_contrib.gemfile.lock
+++ b/gemfiles/ruby_3.0_contrib.gemfile.lock
@@ -206,8 +206,6 @@ GEM
       crack (>= 0.3.2)
       hashdiff (>= 0.4.0, < 2.0.0)
     webrick (1.7.0)
-    yard (0.9.28)
-      webrick (~> 1.7.0)
 
 PLATFORMS
   aarch64-linux
@@ -259,7 +257,6 @@ DEPENDENCIES
   warning (~> 1)
   webmock (>= 3.10.0)
   webrick (>= 1.7.0)
-  yard (~> 0.9)
 
 BUNDLED WITH
    2.3.26

--- a/gemfiles/ruby_3.0_contrib_old.gemfile
+++ b/gemfiles/ruby_3.0_contrib_old.gemfile
@@ -28,7 +28,6 @@ gem "warning", "~> 1"
 gem "webmock", ">= 3.10.0"
 gem "rexml", ">= 3.2.7"
 gem "webrick", ">= 1.7.0"
-gem "yard", "~> 0.9"
 gem "rubocop", "~> 1.50.0", require: false
 gem "rubocop-packaging", "~> 0.5.2", require: false
 gem "rubocop-performance", "~> 1.9", require: false

--- a/gemfiles/ruby_3.0_contrib_old.gemfile.lock
+++ b/gemfiles/ruby_3.0_contrib_old.gemfile.lock
@@ -190,8 +190,6 @@ GEM
       crack (>= 0.3.2)
       hashdiff (>= 0.4.0, < 2.0.0)
     webrick (1.7.0)
-    yard (0.9.28)
-      webrick (~> 1.7.0)
 
 PLATFORMS
   aarch64-linux
@@ -235,7 +233,6 @@ DEPENDENCIES
   warning (~> 1)
   webmock (>= 3.10.0)
   webrick (>= 1.7.0)
-  yard (~> 0.9)
 
 BUNDLED WITH
    2.3.26

--- a/gemfiles/ruby_3.0_core_old.gemfile
+++ b/gemfiles/ruby_3.0_core_old.gemfile
@@ -28,7 +28,6 @@ gem "warning", "~> 1"
 gem "webmock", ">= 3.10.0"
 gem "rexml", ">= 3.2.7"
 gem "webrick", ">= 1.7.0"
-gem "yard", "~> 0.9"
 gem "rubocop", "~> 1.50.0", require: false
 gem "rubocop-packaging", "~> 0.5.2", require: false
 gem "rubocop-performance", "~> 1.9", require: false

--- a/gemfiles/ruby_3.0_core_old.gemfile.lock
+++ b/gemfiles/ruby_3.0_core_old.gemfile.lock
@@ -137,8 +137,6 @@ GEM
       crack (>= 0.3.2)
       hashdiff (>= 0.4.0, < 2.0.0)
     webrick (1.7.0)
-    yard (0.9.28)
-      webrick (~> 1.7.0)
 
 PLATFORMS
   aarch64-linux
@@ -179,7 +177,6 @@ DEPENDENCIES
   warning (~> 1)
   webmock (>= 3.10.0)
   webrick (>= 1.7.0)
-  yard (~> 0.9)
 
 BUNDLED WITH
    2.3.26

--- a/gemfiles/ruby_3.0_elasticsearch_7.gemfile
+++ b/gemfiles/ruby_3.0_elasticsearch_7.gemfile
@@ -28,7 +28,6 @@ gem "warning", "~> 1"
 gem "webmock", ">= 3.10.0"
 gem "rexml", ">= 3.2.7"
 gem "webrick", ">= 1.7.0"
-gem "yard", "~> 0.9"
 gem "rubocop", "~> 1.50.0", require: false
 gem "rubocop-packaging", "~> 0.5.2", require: false
 gem "rubocop-performance", "~> 1.9", require: false

--- a/gemfiles/ruby_3.0_elasticsearch_7.gemfile.lock
+++ b/gemfiles/ruby_3.0_elasticsearch_7.gemfile.lock
@@ -175,7 +175,6 @@ GEM
       crack (>= 0.3.2)
       hashdiff (>= 0.4.0, < 2.0.0)
     webrick (1.8.1)
-    yard (0.9.34)
 
 PLATFORMS
   aarch64-linux
@@ -217,7 +216,6 @@ DEPENDENCIES
   warning (~> 1)
   webmock (>= 3.10.0)
   webrick (>= 1.7.0)
-  yard (~> 0.9)
 
 BUNDLED WITH
    2.3.26

--- a/gemfiles/ruby_3.0_elasticsearch_8.gemfile
+++ b/gemfiles/ruby_3.0_elasticsearch_8.gemfile
@@ -28,7 +28,6 @@ gem "warning", "~> 1"
 gem "webmock", ">= 3.10.0"
 gem "rexml", ">= 3.2.7"
 gem "webrick", ">= 1.7.0"
-gem "yard", "~> 0.9"
 gem "rubocop", "~> 1.50.0", require: false
 gem "rubocop-packaging", "~> 0.5.2", require: false
 gem "rubocop-performance", "~> 1.9", require: false

--- a/gemfiles/ruby_3.0_elasticsearch_8.gemfile.lock
+++ b/gemfiles/ruby_3.0_elasticsearch_8.gemfile.lock
@@ -157,7 +157,6 @@ GEM
       crack (>= 0.3.2)
       hashdiff (>= 0.4.0, < 2.0.0)
     webrick (1.8.1)
-    yard (0.9.34)
 
 PLATFORMS
   aarch64-linux
@@ -199,7 +198,6 @@ DEPENDENCIES
   warning (~> 1)
   webmock (>= 3.10.0)
   webrick (>= 1.7.0)
-  yard (~> 0.9)
 
 BUNDLED WITH
    2.3.26

--- a/gemfiles/ruby_3.0_graphql_1.13.gemfile
+++ b/gemfiles/ruby_3.0_graphql_1.13.gemfile
@@ -28,7 +28,6 @@ gem "warning", "~> 1"
 gem "webmock", ">= 3.10.0"
 gem "rexml", ">= 3.2.7"
 gem "webrick", ">= 1.7.0"
-gem "yard", "~> 0.9"
 gem "rubocop", "~> 1.50.0", require: false
 gem "rubocop-packaging", "~> 0.5.2", require: false
 gem "rubocop-performance", "~> 1.9", require: false

--- a/gemfiles/ruby_3.0_graphql_1.13.gemfile.lock
+++ b/gemfiles/ruby_3.0_graphql_1.13.gemfile.lock
@@ -286,7 +286,6 @@ GEM
     websocket-driver (0.7.6)
       websocket-extensions (>= 0.1.0)
     websocket-extensions (0.1.5)
-    yard (0.9.34)
     zeitwerk (2.6.16)
 
 PLATFORMS
@@ -332,7 +331,6 @@ DEPENDENCIES
   warning (~> 1)
   webmock (>= 3.10.0)
   webrick (>= 1.7.0)
-  yard (~> 0.9)
 
 BUNDLED WITH
    2.3.26

--- a/gemfiles/ruby_3.0_graphql_2.0.gemfile
+++ b/gemfiles/ruby_3.0_graphql_2.0.gemfile
@@ -28,7 +28,6 @@ gem "warning", "~> 1"
 gem "webmock", ">= 3.10.0"
 gem "rexml", ">= 3.2.7"
 gem "webrick", ">= 1.7.0"
-gem "yard", "~> 0.9"
 gem "rubocop", "~> 1.50.0", require: false
 gem "rubocop-packaging", "~> 0.5.2", require: false
 gem "rubocop-performance", "~> 1.9", require: false

--- a/gemfiles/ruby_3.0_graphql_2.0.gemfile.lock
+++ b/gemfiles/ruby_3.0_graphql_2.0.gemfile.lock
@@ -286,7 +286,6 @@ GEM
     websocket-driver (0.7.6)
       websocket-extensions (>= 0.1.0)
     websocket-extensions (0.1.5)
-    yard (0.9.34)
     zeitwerk (2.6.16)
 
 PLATFORMS
@@ -332,7 +331,6 @@ DEPENDENCIES
   warning (~> 1)
   webmock (>= 3.10.0)
   webrick (>= 1.7.0)
-  yard (~> 0.9)
 
 BUNDLED WITH
    2.3.26

--- a/gemfiles/ruby_3.0_graphql_2.1.gemfile
+++ b/gemfiles/ruby_3.0_graphql_2.1.gemfile
@@ -28,7 +28,6 @@ gem "warning", "~> 1"
 gem "webmock", ">= 3.10.0"
 gem "rexml", ">= 3.2.7"
 gem "webrick", ">= 1.7.0"
-gem "yard", "~> 0.9"
 gem "rubocop", "~> 1.50.0", require: false
 gem "rubocop-packaging", "~> 0.5.2", require: false
 gem "rubocop-performance", "~> 1.9", require: false

--- a/gemfiles/ruby_3.0_graphql_2.1.gemfile.lock
+++ b/gemfiles/ruby_3.0_graphql_2.1.gemfile.lock
@@ -287,7 +287,6 @@ GEM
     websocket-driver (0.7.6)
       websocket-extensions (>= 0.1.0)
     websocket-extensions (0.1.5)
-    yard (0.9.34)
     zeitwerk (2.6.16)
 
 PLATFORMS
@@ -333,7 +332,6 @@ DEPENDENCIES
   warning (~> 1)
   webmock (>= 3.10.0)
   webrick (>= 1.7.0)
-  yard (~> 0.9)
 
 BUNDLED WITH
    2.3.26

--- a/gemfiles/ruby_3.0_graphql_2.2.gemfile
+++ b/gemfiles/ruby_3.0_graphql_2.2.gemfile
@@ -28,7 +28,6 @@ gem "warning", "~> 1"
 gem "webmock", ">= 3.10.0"
 gem "rexml", ">= 3.2.7"
 gem "webrick", ">= 1.7.0"
-gem "yard", "~> 0.9"
 gem "rubocop", "~> 1.50.0", require: false
 gem "rubocop-packaging", "~> 0.5.2", require: false
 gem "rubocop-performance", "~> 1.9", require: false

--- a/gemfiles/ruby_3.0_graphql_2.2.gemfile.lock
+++ b/gemfiles/ruby_3.0_graphql_2.2.gemfile.lock
@@ -287,7 +287,6 @@ GEM
     websocket-driver (0.7.6)
       websocket-extensions (>= 0.1.0)
     websocket-extensions (0.1.5)
-    yard (0.9.34)
     zeitwerk (2.6.16)
 
 PLATFORMS
@@ -333,7 +332,6 @@ DEPENDENCIES
   warning (~> 1)
   webmock (>= 3.10.0)
   webrick (>= 1.7.0)
-  yard (~> 0.9)
 
 BUNDLED WITH
    2.3.26

--- a/gemfiles/ruby_3.0_graphql_2.3.gemfile
+++ b/gemfiles/ruby_3.0_graphql_2.3.gemfile
@@ -28,7 +28,6 @@ gem "warning", "~> 1"
 gem "webmock", ">= 3.10.0"
 gem "rexml", ">= 3.2.7"
 gem "webrick", ">= 1.7.0"
-gem "yard", "~> 0.9"
 gem "rubocop", "~> 1.50.0", require: false
 gem "rubocop-packaging", "~> 0.5.2", require: false
 gem "rubocop-performance", "~> 1.9", require: false

--- a/gemfiles/ruby_3.0_graphql_2.3.gemfile.lock
+++ b/gemfiles/ruby_3.0_graphql_2.3.gemfile.lock
@@ -289,7 +289,6 @@ GEM
     websocket-driver (0.7.6)
       websocket-extensions (>= 0.1.0)
     websocket-extensions (0.1.5)
-    yard (0.9.36)
     zeitwerk (2.6.16)
 
 PLATFORMS
@@ -335,7 +334,6 @@ DEPENDENCIES
   warning (~> 1)
   webmock (>= 3.10.0)
   webrick (>= 1.7.0)
-  yard (~> 0.9)
 
 BUNDLED WITH
    2.3.26

--- a/gemfiles/ruby_3.0_http.gemfile
+++ b/gemfiles/ruby_3.0_http.gemfile
@@ -28,7 +28,6 @@ gem "warning", "~> 1"
 gem "webmock", ">= 3.10.0"
 gem "rexml", ">= 3.2.7"
 gem "webrick", ">= 1.7.0"
-gem "yard", "~> 0.9"
 gem "rubocop", "~> 1.50.0", require: false
 gem "rubocop-packaging", "~> 0.5.2", require: false
 gem "rubocop-performance", "~> 1.9", require: false

--- a/gemfiles/ruby_3.0_http.gemfile.lock
+++ b/gemfiles/ruby_3.0_http.gemfile.lock
@@ -179,7 +179,6 @@ GEM
       crack (>= 0.3.2)
       hashdiff (>= 0.4.0, < 2.0.0)
     webrick (1.8.1)
-    yard (0.9.34)
 
 PLATFORMS
   aarch64-linux
@@ -227,7 +226,6 @@ DEPENDENCIES
   warning (~> 1)
   webmock (>= 3.10.0)
   webrick (>= 1.7.0)
-  yard (~> 0.9)
 
 BUNDLED WITH
    2.3.26

--- a/gemfiles/ruby_3.0_opensearch_2.gemfile
+++ b/gemfiles/ruby_3.0_opensearch_2.gemfile
@@ -28,7 +28,6 @@ gem "warning", "~> 1"
 gem "webmock", ">= 3.10.0"
 gem "rexml", ">= 3.2.7"
 gem "webrick", ">= 1.7.0"
-gem "yard", "~> 0.9"
 gem "rubocop", "~> 1.50.0", require: false
 gem "rubocop-packaging", "~> 0.5.2", require: false
 gem "rubocop-performance", "~> 1.9", require: false

--- a/gemfiles/ruby_3.0_opensearch_2.gemfile.lock
+++ b/gemfiles/ruby_3.0_opensearch_2.gemfile.lock
@@ -157,7 +157,6 @@ GEM
       crack (>= 0.3.2)
       hashdiff (>= 0.4.0, < 2.0.0)
     webrick (1.8.1)
-    yard (0.9.34)
 
 PLATFORMS
   aarch64-linux
@@ -199,7 +198,6 @@ DEPENDENCIES
   warning (~> 1)
   webmock (>= 3.10.0)
   webrick (>= 1.7.0)
-  yard (~> 0.9)
 
 BUNDLED WITH
    2.3.26

--- a/gemfiles/ruby_3.0_opensearch_3.gemfile
+++ b/gemfiles/ruby_3.0_opensearch_3.gemfile
@@ -28,7 +28,6 @@ gem "warning", "~> 1"
 gem "webmock", ">= 3.10.0"
 gem "rexml", ">= 3.2.7"
 gem "webrick", ">= 1.7.0"
-gem "yard", "~> 0.9"
 gem "rubocop", "~> 1.50.0", require: false
 gem "rubocop-packaging", "~> 0.5.2", require: false
 gem "rubocop-performance", "~> 1.9", require: false

--- a/gemfiles/ruby_3.0_opensearch_3.gemfile.lock
+++ b/gemfiles/ruby_3.0_opensearch_3.gemfile.lock
@@ -152,7 +152,6 @@ GEM
       crack (>= 0.3.2)
       hashdiff (>= 0.4.0, < 2.0.0)
     webrick (1.8.1)
-    yard (0.9.34)
 
 PLATFORMS
   aarch64-linux
@@ -194,7 +193,6 @@ DEPENDENCIES
   warning (~> 1)
   webmock (>= 3.10.0)
   webrick (>= 1.7.0)
-  yard (~> 0.9)
 
 BUNDLED WITH
    2.3.26

--- a/gemfiles/ruby_3.0_opentelemetry.gemfile
+++ b/gemfiles/ruby_3.0_opentelemetry.gemfile
@@ -28,7 +28,6 @@ gem "warning", "~> 1"
 gem "webmock", ">= 3.10.0"
 gem "rexml", ">= 3.2.7"
 gem "webrick", ">= 1.7.0"
-gem "yard", "~> 0.9"
 gem "rubocop", "~> 1.50.0", require: false
 gem "rubocop-packaging", "~> 0.5.2", require: false
 gem "rubocop-performance", "~> 1.9", require: false

--- a/gemfiles/ruby_3.0_opentelemetry.gemfile.lock
+++ b/gemfiles/ruby_3.0_opentelemetry.gemfile.lock
@@ -149,8 +149,6 @@ GEM
       crack (>= 0.3.2)
       hashdiff (>= 0.4.0, < 2.0.0)
     webrick (1.7.0)
-    yard (0.9.28)
-      webrick (~> 1.7.0)
 
 PLATFORMS
   aarch64-linux
@@ -192,7 +190,6 @@ DEPENDENCIES
   warning (~> 1)
   webmock (>= 3.10.0)
   webrick (>= 1.7.0)
-  yard (~> 0.9)
 
 BUNDLED WITH
    2.3.26

--- a/gemfiles/ruby_3.0_rack_1.gemfile
+++ b/gemfiles/ruby_3.0_rack_1.gemfile
@@ -28,7 +28,6 @@ gem "warning", "~> 1"
 gem "webmock", ">= 3.10.0"
 gem "rexml", ">= 3.2.7"
 gem "webrick", ">= 1.7.0"
-gem "yard", "~> 0.9"
 gem "rubocop", "~> 1.50.0", require: false
 gem "rubocop-packaging", "~> 0.5.2", require: false
 gem "rubocop-performance", "~> 1.9", require: false

--- a/gemfiles/ruby_3.0_rack_1.gemfile.lock
+++ b/gemfiles/ruby_3.0_rack_1.gemfile.lock
@@ -144,7 +144,6 @@ GEM
       crack (>= 0.3.2)
       hashdiff (>= 0.4.0, < 2.0.0)
     webrick (1.8.1)
-    yard (0.9.34)
 
 PLATFORMS
   aarch64-linux
@@ -188,7 +187,6 @@ DEPENDENCIES
   warning (~> 1)
   webmock (>= 3.10.0)
   webrick (>= 1.7.0)
-  yard (~> 0.9)
 
 BUNDLED WITH
    2.3.26

--- a/gemfiles/ruby_3.0_rack_2.gemfile
+++ b/gemfiles/ruby_3.0_rack_2.gemfile
@@ -28,7 +28,6 @@ gem "warning", "~> 1"
 gem "webmock", ">= 3.10.0"
 gem "rexml", ">= 3.2.7"
 gem "webrick", ">= 1.7.0"
-gem "yard", "~> 0.9"
 gem "rubocop", "~> 1.50.0", require: false
 gem "rubocop-packaging", "~> 0.5.2", require: false
 gem "rubocop-performance", "~> 1.9", require: false

--- a/gemfiles/ruby_3.0_rack_2.gemfile.lock
+++ b/gemfiles/ruby_3.0_rack_2.gemfile.lock
@@ -144,7 +144,6 @@ GEM
       crack (>= 0.3.2)
       hashdiff (>= 0.4.0, < 2.0.0)
     webrick (1.8.1)
-    yard (0.9.34)
 
 PLATFORMS
   aarch64-linux
@@ -188,7 +187,6 @@ DEPENDENCIES
   warning (~> 1)
   webmock (>= 3.10.0)
   webrick (>= 1.7.0)
-  yard (~> 0.9)
 
 BUNDLED WITH
    2.3.26

--- a/gemfiles/ruby_3.0_rack_3.gemfile
+++ b/gemfiles/ruby_3.0_rack_3.gemfile
@@ -28,7 +28,6 @@ gem "warning", "~> 1"
 gem "webmock", ">= 3.10.0"
 gem "rexml", ">= 3.2.7"
 gem "webrick", ">= 1.7.0"
-gem "yard", "~> 0.9"
 gem "rubocop", "~> 1.50.0", require: false
 gem "rubocop-packaging", "~> 0.5.2", require: false
 gem "rubocop-performance", "~> 1.9", require: false

--- a/gemfiles/ruby_3.0_rack_3.gemfile.lock
+++ b/gemfiles/ruby_3.0_rack_3.gemfile.lock
@@ -144,7 +144,6 @@ GEM
       crack (>= 0.3.2)
       hashdiff (>= 0.4.0, < 2.0.0)
     webrick (1.8.1)
-    yard (0.9.34)
 
 PLATFORMS
   aarch64-linux
@@ -188,7 +187,6 @@ DEPENDENCIES
   warning (~> 1)
   webmock (>= 3.10.0)
   webrick (>= 1.7.0)
-  yard (~> 0.9)
 
 BUNDLED WITH
    2.3.26

--- a/gemfiles/ruby_3.0_rails61_mysql2.gemfile
+++ b/gemfiles/ruby_3.0_rails61_mysql2.gemfile
@@ -28,7 +28,6 @@ gem "warning", "~> 1"
 gem "webmock", ">= 3.10.0"
 gem "rexml", ">= 3.2.7"
 gem "webrick", ">= 1.7.0"
-gem "yard", "~> 0.9"
 gem "rubocop", "~> 1.50.0", require: false
 gem "rubocop-packaging", "~> 0.5.2", require: false
 gem "rubocop-performance", "~> 1.9", require: false

--- a/gemfiles/ruby_3.0_rails61_mysql2.gemfile.lock
+++ b/gemfiles/ruby_3.0_rails61_mysql2.gemfile.lock
@@ -279,8 +279,6 @@ GEM
     websocket-driver (0.7.5)
       websocket-extensions (>= 0.1.0)
     websocket-extensions (0.1.5)
-    yard (0.9.28)
-      webrick (~> 1.7.0)
     zeitwerk (2.6.7)
 
 PLATFORMS
@@ -327,7 +325,6 @@ DEPENDENCIES
   warning (~> 1)
   webmock (>= 3.10.0)
   webrick (>= 1.7.0)
-  yard (~> 0.9)
 
 BUNDLED WITH
    2.3.26

--- a/gemfiles/ruby_3.0_rails61_postgres.gemfile
+++ b/gemfiles/ruby_3.0_rails61_postgres.gemfile
@@ -28,7 +28,6 @@ gem "warning", "~> 1"
 gem "webmock", ">= 3.10.0"
 gem "rexml", ">= 3.2.7"
 gem "webrick", ">= 1.7.0"
-gem "yard", "~> 0.9"
 gem "rubocop", "~> 1.50.0", require: false
 gem "rubocop-packaging", "~> 0.5.2", require: false
 gem "rubocop-performance", "~> 1.9", require: false

--- a/gemfiles/ruby_3.0_rails61_postgres.gemfile.lock
+++ b/gemfiles/ruby_3.0_rails61_postgres.gemfile.lock
@@ -279,8 +279,6 @@ GEM
     websocket-driver (0.7.5)
       websocket-extensions (>= 0.1.0)
     websocket-extensions (0.1.5)
-    yard (0.9.28)
-      webrick (~> 1.7.0)
     zeitwerk (2.6.7)
 
 PLATFORMS
@@ -327,7 +325,6 @@ DEPENDENCIES
   warning (~> 1)
   webmock (>= 3.10.0)
   webrick (>= 1.7.0)
-  yard (~> 0.9)
 
 BUNDLED WITH
    2.3.26

--- a/gemfiles/ruby_3.0_rails61_postgres_redis.gemfile
+++ b/gemfiles/ruby_3.0_rails61_postgres_redis.gemfile
@@ -28,7 +28,6 @@ gem "warning", "~> 1"
 gem "webmock", ">= 3.10.0"
 gem "rexml", ">= 3.2.7"
 gem "webrick", ">= 1.7.0"
-gem "yard", "~> 0.9"
 gem "rubocop", "~> 1.50.0", require: false
 gem "rubocop-packaging", "~> 0.5.2", require: false
 gem "rubocop-performance", "~> 1.9", require: false

--- a/gemfiles/ruby_3.0_rails61_postgres_redis.gemfile.lock
+++ b/gemfiles/ruby_3.0_rails61_postgres_redis.gemfile.lock
@@ -280,8 +280,6 @@ GEM
     websocket-driver (0.7.5)
       websocket-extensions (>= 0.1.0)
     websocket-extensions (0.1.5)
-    yard (0.9.28)
-      webrick (~> 1.7.0)
     zeitwerk (2.6.7)
 
 PLATFORMS
@@ -329,7 +327,6 @@ DEPENDENCIES
   warning (~> 1)
   webmock (>= 3.10.0)
   webrick (>= 1.7.0)
-  yard (~> 0.9)
 
 BUNDLED WITH
    2.3.26

--- a/gemfiles/ruby_3.0_rails61_postgres_sidekiq.gemfile
+++ b/gemfiles/ruby_3.0_rails61_postgres_sidekiq.gemfile
@@ -28,7 +28,6 @@ gem "warning", "~> 1"
 gem "webmock", ">= 3.10.0"
 gem "rexml", ">= 3.2.7"
 gem "webrick", ">= 1.7.0"
-gem "yard", "~> 0.9"
 gem "rubocop", "~> 1.50.0", require: false
 gem "rubocop-packaging", "~> 0.5.2", require: false
 gem "rubocop-performance", "~> 1.9", require: false

--- a/gemfiles/ruby_3.0_rails61_postgres_sidekiq.gemfile.lock
+++ b/gemfiles/ruby_3.0_rails61_postgres_sidekiq.gemfile.lock
@@ -293,8 +293,6 @@ GEM
     websocket-driver (0.7.5)
       websocket-extensions (>= 0.1.0)
     websocket-extensions (0.1.5)
-    yard (0.9.28)
-      webrick (~> 1.7.0)
     zeitwerk (2.6.7)
 
 PLATFORMS
@@ -343,7 +341,6 @@ DEPENDENCIES
   warning (~> 1)
   webmock (>= 3.10.0)
   webrick (>= 1.7.0)
-  yard (~> 0.9)
 
 BUNDLED WITH
    2.3.26

--- a/gemfiles/ruby_3.0_rails61_semantic_logger.gemfile
+++ b/gemfiles/ruby_3.0_rails61_semantic_logger.gemfile
@@ -28,7 +28,6 @@ gem "warning", "~> 1"
 gem "webmock", ">= 3.10.0"
 gem "rexml", ">= 3.2.7"
 gem "webrick", ">= 1.7.0"
-gem "yard", "~> 0.9"
 gem "rubocop", "~> 1.50.0", require: false
 gem "rubocop-packaging", "~> 0.5.2", require: false
 gem "rubocop-performance", "~> 1.9", require: false

--- a/gemfiles/ruby_3.0_rails61_semantic_logger.gemfile.lock
+++ b/gemfiles/ruby_3.0_rails61_semantic_logger.gemfile.lock
@@ -278,8 +278,6 @@ GEM
     websocket-driver (0.7.5)
       websocket-extensions (>= 0.1.0)
     websocket-extensions (0.1.5)
-    yard (0.9.28)
-      webrick (~> 1.7.0)
     zeitwerk (2.6.7)
 
 PLATFORMS
@@ -326,7 +324,6 @@ DEPENDENCIES
   warning (~> 1)
   webmock (>= 3.10.0)
   webrick (>= 1.7.0)
-  yard (~> 0.9)
 
 BUNDLED WITH
    2.3.26

--- a/gemfiles/ruby_3.0_rails61_trilogy.gemfile
+++ b/gemfiles/ruby_3.0_rails61_trilogy.gemfile
@@ -28,7 +28,6 @@ gem "warning", "~> 1"
 gem "webmock", ">= 3.10.0"
 gem "rexml", ">= 3.2.7"
 gem "webrick", ">= 1.7.0"
-gem "yard", "~> 0.9"
 gem "rubocop", "~> 1.50.0", require: false
 gem "rubocop-packaging", "~> 0.5.2", require: false
 gem "rubocop-performance", "~> 1.9", require: false

--- a/gemfiles/ruby_3.0_rails61_trilogy.gemfile.lock
+++ b/gemfiles/ruby_3.0_rails61_trilogy.gemfile.lock
@@ -287,7 +287,6 @@ GEM
     websocket-driver (0.7.6)
       websocket-extensions (>= 0.1.0)
     websocket-extensions (0.1.5)
-    yard (0.9.34)
     zeitwerk (2.6.12)
 
 PLATFORMS
@@ -335,7 +334,6 @@ DEPENDENCIES
   warning (~> 1)
   webmock (>= 3.10.0)
   webrick (>= 1.7.0)
-  yard (~> 0.9)
 
 BUNDLED WITH
    2.3.26

--- a/gemfiles/ruby_3.0_redis_3.gemfile
+++ b/gemfiles/ruby_3.0_redis_3.gemfile
@@ -28,7 +28,6 @@ gem "warning", "~> 1"
 gem "webmock", ">= 3.10.0"
 gem "rexml", ">= 3.2.7"
 gem "webrick", ">= 1.7.0"
-gem "yard", "~> 0.9"
 gem "rubocop", "~> 1.50.0", require: false
 gem "rubocop-packaging", "~> 0.5.2", require: false
 gem "rubocop-performance", "~> 1.9", require: false

--- a/gemfiles/ruby_3.0_redis_3.gemfile.lock
+++ b/gemfiles/ruby_3.0_redis_3.gemfile.lock
@@ -138,8 +138,6 @@ GEM
       crack (>= 0.3.2)
       hashdiff (>= 0.4.0, < 2.0.0)
     webrick (1.7.0)
-    yard (0.9.28)
-      webrick (~> 1.7.0)
 
 PLATFORMS
   aarch64-linux
@@ -181,7 +179,6 @@ DEPENDENCIES
   warning (~> 1)
   webmock (>= 3.10.0)
   webrick (>= 1.7.0)
-  yard (~> 0.9)
 
 BUNDLED WITH
    2.3.26

--- a/gemfiles/ruby_3.0_redis_4.gemfile
+++ b/gemfiles/ruby_3.0_redis_4.gemfile
@@ -28,7 +28,6 @@ gem "warning", "~> 1"
 gem "webmock", ">= 3.10.0"
 gem "rexml", ">= 3.2.7"
 gem "webrick", ">= 1.7.0"
-gem "yard", "~> 0.9"
 gem "rubocop", "~> 1.50.0", require: false
 gem "rubocop-packaging", "~> 0.5.2", require: false
 gem "rubocop-performance", "~> 1.9", require: false

--- a/gemfiles/ruby_3.0_redis_4.gemfile.lock
+++ b/gemfiles/ruby_3.0_redis_4.gemfile.lock
@@ -138,8 +138,6 @@ GEM
       crack (>= 0.3.2)
       hashdiff (>= 0.4.0, < 2.0.0)
     webrick (1.7.0)
-    yard (0.9.28)
-      webrick (~> 1.7.0)
 
 PLATFORMS
   aarch64-linux
@@ -181,7 +179,6 @@ DEPENDENCIES
   warning (~> 1)
   webmock (>= 3.10.0)
   webrick (>= 1.7.0)
-  yard (~> 0.9)
 
 BUNDLED WITH
    2.3.26

--- a/gemfiles/ruby_3.0_redis_5.gemfile
+++ b/gemfiles/ruby_3.0_redis_5.gemfile
@@ -28,7 +28,6 @@ gem "warning", "~> 1"
 gem "webmock", ">= 3.10.0"
 gem "rexml", ">= 3.2.7"
 gem "webrick", ">= 1.7.0"
-gem "yard", "~> 0.9"
 gem "rubocop", "~> 1.50.0", require: false
 gem "rubocop-packaging", "~> 0.5.2", require: false
 gem "rubocop-performance", "~> 1.9", require: false

--- a/gemfiles/ruby_3.0_redis_5.gemfile.lock
+++ b/gemfiles/ruby_3.0_redis_5.gemfile.lock
@@ -142,8 +142,6 @@ GEM
       crack (>= 0.3.2)
       hashdiff (>= 0.4.0, < 2.0.0)
     webrick (1.7.0)
-    yard (0.9.28)
-      webrick (~> 1.7.0)
 
 PLATFORMS
   aarch64-linux
@@ -185,7 +183,6 @@ DEPENDENCIES
   warning (~> 1)
   webmock (>= 3.10.0)
   webrick (>= 1.7.0)
-  yard (~> 0.9)
 
 BUNDLED WITH
    2.3.26

--- a/gemfiles/ruby_3.0_relational_db.gemfile
+++ b/gemfiles/ruby_3.0_relational_db.gemfile
@@ -28,7 +28,6 @@ gem "warning", "~> 1"
 gem "webmock", ">= 3.10.0"
 gem "rexml", ">= 3.2.7"
 gem "webrick", ">= 1.7.0"
-gem "yard", "~> 0.9"
 gem "rubocop", "~> 1.50.0", require: false
 gem "rubocop-packaging", "~> 0.5.2", require: false
 gem "rubocop-performance", "~> 1.9", require: false

--- a/gemfiles/ruby_3.0_relational_db.gemfile.lock
+++ b/gemfiles/ruby_3.0_relational_db.gemfile.lock
@@ -169,7 +169,6 @@ GEM
       crack (>= 0.3.2)
       hashdiff (>= 0.4.0, < 2.0.0)
     webrick (1.8.1)
-    yard (0.9.34)
 
 PLATFORMS
   aarch64-linux
@@ -219,7 +218,6 @@ DEPENDENCIES
   warning (~> 1)
   webmock (>= 3.10.0)
   webrick (>= 1.7.0)
-  yard (~> 0.9)
 
 BUNDLED WITH
    2.3.26

--- a/gemfiles/ruby_3.0_resque2_redis3.gemfile
+++ b/gemfiles/ruby_3.0_resque2_redis3.gemfile
@@ -28,7 +28,6 @@ gem "warning", "~> 1"
 gem "webmock", ">= 3.10.0"
 gem "rexml", ">= 3.2.7"
 gem "webrick", ">= 1.7.0"
-gem "yard", "~> 0.9"
 gem "rubocop", "~> 1.50.0", require: false
 gem "rubocop-packaging", "~> 0.5.2", require: false
 gem "rubocop-performance", "~> 1.9", require: false

--- a/gemfiles/ruby_3.0_resque2_redis3.gemfile.lock
+++ b/gemfiles/ruby_3.0_resque2_redis3.gemfile.lock
@@ -159,8 +159,6 @@ GEM
       crack (>= 0.3.2)
       hashdiff (>= 0.4.0, < 2.0.0)
     webrick (1.7.0)
-    yard (0.9.28)
-      webrick (~> 1.7.0)
 
 PLATFORMS
   aarch64-linux
@@ -203,7 +201,6 @@ DEPENDENCIES
   warning (~> 1)
   webmock (>= 3.10.0)
   webrick (>= 1.7.0)
-  yard (~> 0.9)
 
 BUNDLED WITH
    2.3.26

--- a/gemfiles/ruby_3.0_resque2_redis4.gemfile
+++ b/gemfiles/ruby_3.0_resque2_redis4.gemfile
@@ -28,7 +28,6 @@ gem "warning", "~> 1"
 gem "webmock", ">= 3.10.0"
 gem "rexml", ">= 3.2.7"
 gem "webrick", ">= 1.7.0"
-gem "yard", "~> 0.9"
 gem "rubocop", "~> 1.50.0", require: false
 gem "rubocop-packaging", "~> 0.5.2", require: false
 gem "rubocop-performance", "~> 1.9", require: false

--- a/gemfiles/ruby_3.0_resque2_redis4.gemfile.lock
+++ b/gemfiles/ruby_3.0_resque2_redis4.gemfile.lock
@@ -163,8 +163,6 @@ GEM
       crack (>= 0.3.2)
       hashdiff (>= 0.4.0, < 2.0.0)
     webrick (1.7.0)
-    yard (0.9.28)
-      webrick (~> 1.7.0)
 
 PLATFORMS
   aarch64-linux
@@ -207,7 +205,6 @@ DEPENDENCIES
   warning (~> 1)
   webmock (>= 3.10.0)
   webrick (>= 1.7.0)
-  yard (~> 0.9)
 
 BUNDLED WITH
    2.3.26

--- a/gemfiles/ruby_3.0_sinatra_2.gemfile
+++ b/gemfiles/ruby_3.0_sinatra_2.gemfile
@@ -28,7 +28,6 @@ gem "warning", "~> 1"
 gem "webmock", ">= 3.10.0"
 gem "rexml", ">= 3.2.7"
 gem "webrick", ">= 1.7.0"
-gem "yard", "~> 0.9"
 gem "rubocop", "~> 1.50.0", require: false
 gem "rubocop-packaging", "~> 0.5.2", require: false
 gem "rubocop-performance", "~> 1.9", require: false

--- a/gemfiles/ruby_3.0_sinatra_2.gemfile.lock
+++ b/gemfiles/ruby_3.0_sinatra_2.gemfile.lock
@@ -159,7 +159,6 @@ GEM
       crack (>= 0.3.2)
       hashdiff (>= 0.4.0, < 2.0.0)
     webrick (1.8.1)
-    yard (0.9.36)
 
 PLATFORMS
   aarch64-linux
@@ -203,7 +202,6 @@ DEPENDENCIES
   warning (~> 1)
   webmock (>= 3.10.0)
   webrick (>= 1.7.0)
-  yard (~> 0.9)
 
 BUNDLED WITH
    2.3.26

--- a/gemfiles/ruby_3.0_sinatra_3.gemfile
+++ b/gemfiles/ruby_3.0_sinatra_3.gemfile
@@ -28,7 +28,6 @@ gem "warning", "~> 1"
 gem "webmock", ">= 3.10.0"
 gem "rexml", ">= 3.2.7"
 gem "webrick", ">= 1.7.0"
-gem "yard", "~> 0.9"
 gem "rubocop", "~> 1.50.0", require: false
 gem "rubocop-packaging", "~> 0.5.2", require: false
 gem "rubocop-performance", "~> 1.9", require: false

--- a/gemfiles/ruby_3.0_sinatra_3.gemfile.lock
+++ b/gemfiles/ruby_3.0_sinatra_3.gemfile.lock
@@ -161,7 +161,6 @@ GEM
       crack (>= 0.3.2)
       hashdiff (>= 0.4.0, < 2.0.0)
     webrick (1.8.1)
-    yard (0.9.36)
 
 PLATFORMS
   aarch64-linux
@@ -205,7 +204,6 @@ DEPENDENCIES
   warning (~> 1)
   webmock (>= 3.10.0)
   webrick (>= 1.7.0)
-  yard (~> 0.9)
 
 BUNDLED WITH
    2.3.26

--- a/gemfiles/ruby_3.0_sinatra_4.gemfile
+++ b/gemfiles/ruby_3.0_sinatra_4.gemfile
@@ -28,7 +28,6 @@ gem "warning", "~> 1"
 gem "webmock", ">= 3.10.0"
 gem "rexml", ">= 3.2.7"
 gem "webrick", ">= 1.7.0"
-gem "yard", "~> 0.9"
 gem "rubocop", "~> 1.50.0", require: false
 gem "rubocop-packaging", "~> 0.5.2", require: false
 gem "rubocop-performance", "~> 1.9", require: false

--- a/gemfiles/ruby_3.0_sinatra_4.gemfile.lock
+++ b/gemfiles/ruby_3.0_sinatra_4.gemfile.lock
@@ -164,7 +164,6 @@ GEM
       crack (>= 0.3.2)
       hashdiff (>= 0.4.0, < 2.0.0)
     webrick (1.8.1)
-    yard (0.9.36)
 
 PLATFORMS
   aarch64-linux
@@ -208,7 +207,6 @@ DEPENDENCIES
   warning (~> 1)
   webmock (>= 3.10.0)
   webrick (>= 1.7.0)
-  yard (~> 0.9)
 
 BUNDLED WITH
    2.3.26

--- a/gemfiles/ruby_3.0_stripe_10.gemfile
+++ b/gemfiles/ruby_3.0_stripe_10.gemfile
@@ -28,7 +28,6 @@ gem "warning", "~> 1"
 gem "webmock", ">= 3.10.0"
 gem "rexml", ">= 3.2.7"
 gem "webrick", ">= 1.7.0"
-gem "yard", "~> 0.9"
 gem "rubocop", "~> 1.50.0", require: false
 gem "rubocop-packaging", "~> 0.5.2", require: false
 gem "rubocop-performance", "~> 1.9", require: false

--- a/gemfiles/ruby_3.0_stripe_10.gemfile.lock
+++ b/gemfiles/ruby_3.0_stripe_10.gemfile.lock
@@ -144,7 +144,6 @@ GEM
       crack (>= 0.3.2)
       hashdiff (>= 0.4.0, < 2.0.0)
     webrick (1.8.1)
-    yard (0.9.36)
 
 PLATFORMS
   aarch64-linux
@@ -186,7 +185,6 @@ DEPENDENCIES
   warning (~> 1)
   webmock (>= 3.10.0)
   webrick (>= 1.7.0)
-  yard (~> 0.9)
 
 BUNDLED WITH
    2.3.26

--- a/gemfiles/ruby_3.0_stripe_11.gemfile
+++ b/gemfiles/ruby_3.0_stripe_11.gemfile
@@ -28,7 +28,6 @@ gem "warning", "~> 1"
 gem "webmock", ">= 3.10.0"
 gem "rexml", ">= 3.2.7"
 gem "webrick", ">= 1.7.0"
-gem "yard", "~> 0.9"
 gem "rubocop", "~> 1.50.0", require: false
 gem "rubocop-packaging", "~> 0.5.2", require: false
 gem "rubocop-performance", "~> 1.9", require: false

--- a/gemfiles/ruby_3.0_stripe_11.gemfile.lock
+++ b/gemfiles/ruby_3.0_stripe_11.gemfile.lock
@@ -144,7 +144,6 @@ GEM
       crack (>= 0.3.2)
       hashdiff (>= 0.4.0, < 2.0.0)
     webrick (1.8.1)
-    yard (0.9.36)
 
 PLATFORMS
   aarch64-linux
@@ -186,7 +185,6 @@ DEPENDENCIES
   warning (~> 1)
   webmock (>= 3.10.0)
   webrick (>= 1.7.0)
-  yard (~> 0.9)
 
 BUNDLED WITH
    2.3.26

--- a/gemfiles/ruby_3.0_stripe_12.gemfile
+++ b/gemfiles/ruby_3.0_stripe_12.gemfile
@@ -28,7 +28,6 @@ gem "warning", "~> 1"
 gem "webmock", ">= 3.10.0"
 gem "rexml", ">= 3.2.7"
 gem "webrick", ">= 1.7.0"
-gem "yard", "~> 0.9"
 gem "rubocop", "~> 1.50.0", require: false
 gem "rubocop-packaging", "~> 0.5.2", require: false
 gem "rubocop-performance", "~> 1.9", require: false

--- a/gemfiles/ruby_3.0_stripe_12.gemfile.lock
+++ b/gemfiles/ruby_3.0_stripe_12.gemfile.lock
@@ -144,7 +144,6 @@ GEM
       crack (>= 0.3.2)
       hashdiff (>= 0.4.0, < 2.0.0)
     webrick (1.8.1)
-    yard (0.9.36)
 
 PLATFORMS
   aarch64-linux
@@ -186,7 +185,6 @@ DEPENDENCIES
   warning (~> 1)
   webmock (>= 3.10.0)
   webrick (>= 1.7.0)
-  yard (~> 0.9)
 
 BUNDLED WITH
    2.3.26

--- a/gemfiles/ruby_3.0_stripe_7.gemfile
+++ b/gemfiles/ruby_3.0_stripe_7.gemfile
@@ -28,7 +28,6 @@ gem "warning", "~> 1"
 gem "webmock", ">= 3.10.0"
 gem "rexml", ">= 3.2.7"
 gem "webrick", ">= 1.7.0"
-gem "yard", "~> 0.9"
 gem "rubocop", "~> 1.50.0", require: false
 gem "rubocop-packaging", "~> 0.5.2", require: false
 gem "rubocop-performance", "~> 1.9", require: false

--- a/gemfiles/ruby_3.0_stripe_7.gemfile.lock
+++ b/gemfiles/ruby_3.0_stripe_7.gemfile.lock
@@ -144,7 +144,6 @@ GEM
       crack (>= 0.3.2)
       hashdiff (>= 0.4.0, < 2.0.0)
     webrick (1.8.1)
-    yard (0.9.36)
 
 PLATFORMS
   aarch64-linux
@@ -186,7 +185,6 @@ DEPENDENCIES
   warning (~> 1)
   webmock (>= 3.10.0)
   webrick (>= 1.7.0)
-  yard (~> 0.9)
 
 BUNDLED WITH
    2.3.26

--- a/gemfiles/ruby_3.0_stripe_8.gemfile
+++ b/gemfiles/ruby_3.0_stripe_8.gemfile
@@ -28,7 +28,6 @@ gem "warning", "~> 1"
 gem "webmock", ">= 3.10.0"
 gem "rexml", ">= 3.2.7"
 gem "webrick", ">= 1.7.0"
-gem "yard", "~> 0.9"
 gem "rubocop", "~> 1.50.0", require: false
 gem "rubocop-packaging", "~> 0.5.2", require: false
 gem "rubocop-performance", "~> 1.9", require: false

--- a/gemfiles/ruby_3.0_stripe_8.gemfile.lock
+++ b/gemfiles/ruby_3.0_stripe_8.gemfile.lock
@@ -144,7 +144,6 @@ GEM
       crack (>= 0.3.2)
       hashdiff (>= 0.4.0, < 2.0.0)
     webrick (1.8.1)
-    yard (0.9.36)
 
 PLATFORMS
   aarch64-linux
@@ -186,7 +185,6 @@ DEPENDENCIES
   warning (~> 1)
   webmock (>= 3.10.0)
   webrick (>= 1.7.0)
-  yard (~> 0.9)
 
 BUNDLED WITH
    2.3.26

--- a/gemfiles/ruby_3.0_stripe_9.gemfile
+++ b/gemfiles/ruby_3.0_stripe_9.gemfile
@@ -28,7 +28,6 @@ gem "warning", "~> 1"
 gem "webmock", ">= 3.10.0"
 gem "rexml", ">= 3.2.7"
 gem "webrick", ">= 1.7.0"
-gem "yard", "~> 0.9"
 gem "rubocop", "~> 1.50.0", require: false
 gem "rubocop-packaging", "~> 0.5.2", require: false
 gem "rubocop-performance", "~> 1.9", require: false

--- a/gemfiles/ruby_3.0_stripe_9.gemfile.lock
+++ b/gemfiles/ruby_3.0_stripe_9.gemfile.lock
@@ -144,7 +144,6 @@ GEM
       crack (>= 0.3.2)
       hashdiff (>= 0.4.0, < 2.0.0)
     webrick (1.8.1)
-    yard (0.9.36)
 
 PLATFORMS
   aarch64-linux
@@ -186,7 +185,6 @@ DEPENDENCIES
   warning (~> 1)
   webmock (>= 3.10.0)
   webrick (>= 1.7.0)
-  yard (~> 0.9)
 
 BUNDLED WITH
    2.3.26

--- a/gemfiles/ruby_3.1_activesupport.gemfile
+++ b/gemfiles/ruby_3.1_activesupport.gemfile
@@ -28,7 +28,6 @@ gem "warning", "~> 1"
 gem "webmock", ">= 3.10.0"
 gem "rexml", ">= 3.2.7"
 gem "webrick", ">= 1.7.0"
-gem "yard", "~> 0.9"
 gem "rubocop", "~> 1.50.0", require: false
 gem "rubocop-packaging", "~> 0.5.2", require: false
 gem "rubocop-performance", "~> 1.9", require: false

--- a/gemfiles/ruby_3.1_activesupport.gemfile.lock
+++ b/gemfiles/ruby_3.1_activesupport.gemfile.lock
@@ -246,7 +246,6 @@ GEM
       crack (>= 0.3.2)
       hashdiff (>= 0.4.0, < 2.0.0)
     webrick (1.8.1)
-    yard (0.9.34)
     zeitwerk (2.6.11)
 
 PLATFORMS
@@ -296,7 +295,6 @@ DEPENDENCIES
   warning (~> 1)
   webmock (>= 3.10.0)
   webrick (>= 1.7.0)
-  yard (~> 0.9)
 
 BUNDLED WITH
    2.3.26

--- a/gemfiles/ruby_3.1_aws.gemfile
+++ b/gemfiles/ruby_3.1_aws.gemfile
@@ -28,7 +28,6 @@ gem "warning", "~> 1"
 gem "webmock", ">= 3.10.0"
 gem "rexml", ">= 3.2.7"
 gem "webrick", ">= 1.7.0"
-gem "yard", "~> 0.9"
 gem "rubocop", "~> 1.50.0", require: false
 gem "rubocop-packaging", "~> 0.5.2", require: false
 gem "rubocop-performance", "~> 1.9", require: false

--- a/gemfiles/ruby_3.1_aws.gemfile.lock
+++ b/gemfiles/ruby_3.1_aws.gemfile.lock
@@ -1565,7 +1565,6 @@ GEM
       crack (>= 0.3.2)
       hashdiff (>= 0.4.0, < 2.0.0)
     webrick (1.8.1)
-    yard (0.9.34)
 
 PLATFORMS
   aarch64-linux
@@ -1608,7 +1607,6 @@ DEPENDENCIES
   warning (~> 1)
   webmock (>= 3.10.0)
   webrick (>= 1.7.0)
-  yard (~> 0.9)
 
 BUNDLED WITH
    2.3.26

--- a/gemfiles/ruby_3.1_contrib.gemfile
+++ b/gemfiles/ruby_3.1_contrib.gemfile
@@ -28,7 +28,6 @@ gem "warning", "~> 1"
 gem "webmock", ">= 3.10.0"
 gem "rexml", ">= 3.2.7"
 gem "webrick", ">= 1.7.0"
-gem "yard", "~> 0.9"
 gem "rubocop", "~> 1.50.0", require: false
 gem "rubocop-packaging", "~> 0.5.2", require: false
 gem "rubocop-performance", "~> 1.9", require: false

--- a/gemfiles/ruby_3.1_contrib.gemfile.lock
+++ b/gemfiles/ruby_3.1_contrib.gemfile.lock
@@ -206,8 +206,6 @@ GEM
       crack (>= 0.3.2)
       hashdiff (>= 0.4.0, < 2.0.0)
     webrick (1.7.0)
-    yard (0.9.28)
-      webrick (~> 1.7.0)
 
 PLATFORMS
   aarch64-linux
@@ -259,7 +257,6 @@ DEPENDENCIES
   warning (~> 1)
   webmock (>= 3.10.0)
   webrick (>= 1.7.0)
-  yard (~> 0.9)
 
 BUNDLED WITH
    2.3.26

--- a/gemfiles/ruby_3.1_contrib_old.gemfile
+++ b/gemfiles/ruby_3.1_contrib_old.gemfile
@@ -28,7 +28,6 @@ gem "warning", "~> 1"
 gem "webmock", ">= 3.10.0"
 gem "rexml", ">= 3.2.7"
 gem "webrick", ">= 1.7.0"
-gem "yard", "~> 0.9"
 gem "rubocop", "~> 1.50.0", require: false
 gem "rubocop-packaging", "~> 0.5.2", require: false
 gem "rubocop-performance", "~> 1.9", require: false

--- a/gemfiles/ruby_3.1_contrib_old.gemfile.lock
+++ b/gemfiles/ruby_3.1_contrib_old.gemfile.lock
@@ -190,8 +190,6 @@ GEM
       crack (>= 0.3.2)
       hashdiff (>= 0.4.0, < 2.0.0)
     webrick (1.7.0)
-    yard (0.9.28)
-      webrick (~> 1.7.0)
 
 PLATFORMS
   aarch64-linux
@@ -235,7 +233,6 @@ DEPENDENCIES
   warning (~> 1)
   webmock (>= 3.10.0)
   webrick (>= 1.7.0)
-  yard (~> 0.9)
 
 BUNDLED WITH
    2.3.26

--- a/gemfiles/ruby_3.1_core_old.gemfile
+++ b/gemfiles/ruby_3.1_core_old.gemfile
@@ -28,7 +28,6 @@ gem "warning", "~> 1"
 gem "webmock", ">= 3.10.0"
 gem "rexml", ">= 3.2.7"
 gem "webrick", ">= 1.7.0"
-gem "yard", "~> 0.9"
 gem "rubocop", "~> 1.50.0", require: false
 gem "rubocop-packaging", "~> 0.5.2", require: false
 gem "rubocop-performance", "~> 1.9", require: false

--- a/gemfiles/ruby_3.1_core_old.gemfile.lock
+++ b/gemfiles/ruby_3.1_core_old.gemfile.lock
@@ -137,8 +137,6 @@ GEM
       crack (>= 0.3.2)
       hashdiff (>= 0.4.0, < 2.0.0)
     webrick (1.7.0)
-    yard (0.9.28)
-      webrick (~> 1.7.0)
 
 PLATFORMS
   aarch64-linux
@@ -179,7 +177,6 @@ DEPENDENCIES
   warning (~> 1)
   webmock (>= 3.10.0)
   webrick (>= 1.7.0)
-  yard (~> 0.9)
 
 BUNDLED WITH
    2.3.26

--- a/gemfiles/ruby_3.1_elasticsearch_7.gemfile
+++ b/gemfiles/ruby_3.1_elasticsearch_7.gemfile
@@ -28,7 +28,6 @@ gem "warning", "~> 1"
 gem "webmock", ">= 3.10.0"
 gem "rexml", ">= 3.2.7"
 gem "webrick", ">= 1.7.0"
-gem "yard", "~> 0.9"
 gem "rubocop", "~> 1.50.0", require: false
 gem "rubocop-packaging", "~> 0.5.2", require: false
 gem "rubocop-performance", "~> 1.9", require: false

--- a/gemfiles/ruby_3.1_elasticsearch_7.gemfile.lock
+++ b/gemfiles/ruby_3.1_elasticsearch_7.gemfile.lock
@@ -175,7 +175,6 @@ GEM
       crack (>= 0.3.2)
       hashdiff (>= 0.4.0, < 2.0.0)
     webrick (1.8.1)
-    yard (0.9.34)
 
 PLATFORMS
   aarch64-linux
@@ -217,7 +216,6 @@ DEPENDENCIES
   warning (~> 1)
   webmock (>= 3.10.0)
   webrick (>= 1.7.0)
-  yard (~> 0.9)
 
 BUNDLED WITH
    2.3.26

--- a/gemfiles/ruby_3.1_elasticsearch_8.gemfile
+++ b/gemfiles/ruby_3.1_elasticsearch_8.gemfile
@@ -28,7 +28,6 @@ gem "warning", "~> 1"
 gem "webmock", ">= 3.10.0"
 gem "rexml", ">= 3.2.7"
 gem "webrick", ">= 1.7.0"
-gem "yard", "~> 0.9"
 gem "rubocop", "~> 1.50.0", require: false
 gem "rubocop-packaging", "~> 0.5.2", require: false
 gem "rubocop-performance", "~> 1.9", require: false

--- a/gemfiles/ruby_3.1_elasticsearch_8.gemfile.lock
+++ b/gemfiles/ruby_3.1_elasticsearch_8.gemfile.lock
@@ -157,7 +157,6 @@ GEM
       crack (>= 0.3.2)
       hashdiff (>= 0.4.0, < 2.0.0)
     webrick (1.8.1)
-    yard (0.9.34)
 
 PLATFORMS
   aarch64-linux
@@ -199,7 +198,6 @@ DEPENDENCIES
   warning (~> 1)
   webmock (>= 3.10.0)
   webrick (>= 1.7.0)
-  yard (~> 0.9)
 
 BUNDLED WITH
    2.3.26

--- a/gemfiles/ruby_3.1_graphql_1.13.gemfile
+++ b/gemfiles/ruby_3.1_graphql_1.13.gemfile
@@ -28,7 +28,6 @@ gem "warning", "~> 1"
 gem "webmock", ">= 3.10.0"
 gem "rexml", ">= 3.2.7"
 gem "webrick", ">= 1.7.0"
-gem "yard", "~> 0.9"
 gem "rubocop", "~> 1.50.0", require: false
 gem "rubocop-packaging", "~> 0.5.2", require: false
 gem "rubocop-performance", "~> 1.9", require: false

--- a/gemfiles/ruby_3.1_graphql_1.13.gemfile.lock
+++ b/gemfiles/ruby_3.1_graphql_1.13.gemfile.lock
@@ -286,7 +286,6 @@ GEM
     websocket-driver (0.7.6)
       websocket-extensions (>= 0.1.0)
     websocket-extensions (0.1.5)
-    yard (0.9.34)
     zeitwerk (2.6.16)
 
 PLATFORMS
@@ -332,7 +331,6 @@ DEPENDENCIES
   warning (~> 1)
   webmock (>= 3.10.0)
   webrick (>= 1.7.0)
-  yard (~> 0.9)
 
 BUNDLED WITH
    2.3.26

--- a/gemfiles/ruby_3.1_graphql_2.0.gemfile
+++ b/gemfiles/ruby_3.1_graphql_2.0.gemfile
@@ -28,7 +28,6 @@ gem "warning", "~> 1"
 gem "webmock", ">= 3.10.0"
 gem "rexml", ">= 3.2.7"
 gem "webrick", ">= 1.7.0"
-gem "yard", "~> 0.9"
 gem "rubocop", "~> 1.50.0", require: false
 gem "rubocop-packaging", "~> 0.5.2", require: false
 gem "rubocop-performance", "~> 1.9", require: false

--- a/gemfiles/ruby_3.1_graphql_2.0.gemfile.lock
+++ b/gemfiles/ruby_3.1_graphql_2.0.gemfile.lock
@@ -286,7 +286,6 @@ GEM
     websocket-driver (0.7.6)
       websocket-extensions (>= 0.1.0)
     websocket-extensions (0.1.5)
-    yard (0.9.34)
     zeitwerk (2.6.16)
 
 PLATFORMS
@@ -332,7 +331,6 @@ DEPENDENCIES
   warning (~> 1)
   webmock (>= 3.10.0)
   webrick (>= 1.7.0)
-  yard (~> 0.9)
 
 BUNDLED WITH
    2.3.26

--- a/gemfiles/ruby_3.1_graphql_2.1.gemfile
+++ b/gemfiles/ruby_3.1_graphql_2.1.gemfile
@@ -28,7 +28,6 @@ gem "warning", "~> 1"
 gem "webmock", ">= 3.10.0"
 gem "rexml", ">= 3.2.7"
 gem "webrick", ">= 1.7.0"
-gem "yard", "~> 0.9"
 gem "rubocop", "~> 1.50.0", require: false
 gem "rubocop-packaging", "~> 0.5.2", require: false
 gem "rubocop-performance", "~> 1.9", require: false

--- a/gemfiles/ruby_3.1_graphql_2.1.gemfile.lock
+++ b/gemfiles/ruby_3.1_graphql_2.1.gemfile.lock
@@ -287,7 +287,6 @@ GEM
     websocket-driver (0.7.6)
       websocket-extensions (>= 0.1.0)
     websocket-extensions (0.1.5)
-    yard (0.9.34)
     zeitwerk (2.6.16)
 
 PLATFORMS
@@ -333,7 +332,6 @@ DEPENDENCIES
   warning (~> 1)
   webmock (>= 3.10.0)
   webrick (>= 1.7.0)
-  yard (~> 0.9)
 
 BUNDLED WITH
    2.3.26

--- a/gemfiles/ruby_3.1_graphql_2.2.gemfile
+++ b/gemfiles/ruby_3.1_graphql_2.2.gemfile
@@ -28,7 +28,6 @@ gem "warning", "~> 1"
 gem "webmock", ">= 3.10.0"
 gem "rexml", ">= 3.2.7"
 gem "webrick", ">= 1.7.0"
-gem "yard", "~> 0.9"
 gem "rubocop", "~> 1.50.0", require: false
 gem "rubocop-packaging", "~> 0.5.2", require: false
 gem "rubocop-performance", "~> 1.9", require: false

--- a/gemfiles/ruby_3.1_graphql_2.2.gemfile.lock
+++ b/gemfiles/ruby_3.1_graphql_2.2.gemfile.lock
@@ -287,7 +287,6 @@ GEM
     websocket-driver (0.7.6)
       websocket-extensions (>= 0.1.0)
     websocket-extensions (0.1.5)
-    yard (0.9.34)
     zeitwerk (2.6.16)
 
 PLATFORMS
@@ -333,7 +332,6 @@ DEPENDENCIES
   warning (~> 1)
   webmock (>= 3.10.0)
   webrick (>= 1.7.0)
-  yard (~> 0.9)
 
 BUNDLED WITH
    2.3.26

--- a/gemfiles/ruby_3.1_graphql_2.3.gemfile
+++ b/gemfiles/ruby_3.1_graphql_2.3.gemfile
@@ -28,7 +28,6 @@ gem "warning", "~> 1"
 gem "webmock", ">= 3.10.0"
 gem "rexml", ">= 3.2.7"
 gem "webrick", ">= 1.7.0"
-gem "yard", "~> 0.9"
 gem "rubocop", "~> 1.50.0", require: false
 gem "rubocop-packaging", "~> 0.5.2", require: false
 gem "rubocop-performance", "~> 1.9", require: false

--- a/gemfiles/ruby_3.1_graphql_2.3.gemfile.lock
+++ b/gemfiles/ruby_3.1_graphql_2.3.gemfile.lock
@@ -289,7 +289,6 @@ GEM
     websocket-driver (0.7.6)
       websocket-extensions (>= 0.1.0)
     websocket-extensions (0.1.5)
-    yard (0.9.36)
     zeitwerk (2.6.16)
 
 PLATFORMS
@@ -335,7 +334,6 @@ DEPENDENCIES
   warning (~> 1)
   webmock (>= 3.10.0)
   webrick (>= 1.7.0)
-  yard (~> 0.9)
 
 BUNDLED WITH
    2.3.26

--- a/gemfiles/ruby_3.1_http.gemfile
+++ b/gemfiles/ruby_3.1_http.gemfile
@@ -28,7 +28,6 @@ gem "warning", "~> 1"
 gem "webmock", ">= 3.10.0"
 gem "rexml", ">= 3.2.7"
 gem "webrick", ">= 1.7.0"
-gem "yard", "~> 0.9"
 gem "rubocop", "~> 1.50.0", require: false
 gem "rubocop-packaging", "~> 0.5.2", require: false
 gem "rubocop-performance", "~> 1.9", require: false

--- a/gemfiles/ruby_3.1_http.gemfile.lock
+++ b/gemfiles/ruby_3.1_http.gemfile.lock
@@ -179,7 +179,6 @@ GEM
       crack (>= 0.3.2)
       hashdiff (>= 0.4.0, < 2.0.0)
     webrick (1.8.1)
-    yard (0.9.34)
 
 PLATFORMS
   aarch64-linux
@@ -227,7 +226,6 @@ DEPENDENCIES
   warning (~> 1)
   webmock (>= 3.10.0)
   webrick (>= 1.7.0)
-  yard (~> 0.9)
 
 BUNDLED WITH
    2.3.26

--- a/gemfiles/ruby_3.1_opensearch_2.gemfile
+++ b/gemfiles/ruby_3.1_opensearch_2.gemfile
@@ -28,7 +28,6 @@ gem "warning", "~> 1"
 gem "webmock", ">= 3.10.0"
 gem "rexml", ">= 3.2.7"
 gem "webrick", ">= 1.7.0"
-gem "yard", "~> 0.9"
 gem "rubocop", "~> 1.50.0", require: false
 gem "rubocop-packaging", "~> 0.5.2", require: false
 gem "rubocop-performance", "~> 1.9", require: false

--- a/gemfiles/ruby_3.1_opensearch_2.gemfile.lock
+++ b/gemfiles/ruby_3.1_opensearch_2.gemfile.lock
@@ -157,7 +157,6 @@ GEM
       crack (>= 0.3.2)
       hashdiff (>= 0.4.0, < 2.0.0)
     webrick (1.8.1)
-    yard (0.9.34)
 
 PLATFORMS
   aarch64-linux
@@ -199,7 +198,6 @@ DEPENDENCIES
   warning (~> 1)
   webmock (>= 3.10.0)
   webrick (>= 1.7.0)
-  yard (~> 0.9)
 
 BUNDLED WITH
    2.3.26

--- a/gemfiles/ruby_3.1_opensearch_3.gemfile
+++ b/gemfiles/ruby_3.1_opensearch_3.gemfile
@@ -28,7 +28,6 @@ gem "warning", "~> 1"
 gem "webmock", ">= 3.10.0"
 gem "rexml", ">= 3.2.7"
 gem "webrick", ">= 1.7.0"
-gem "yard", "~> 0.9"
 gem "rubocop", "~> 1.50.0", require: false
 gem "rubocop-packaging", "~> 0.5.2", require: false
 gem "rubocop-performance", "~> 1.9", require: false

--- a/gemfiles/ruby_3.1_opensearch_3.gemfile.lock
+++ b/gemfiles/ruby_3.1_opensearch_3.gemfile.lock
@@ -152,7 +152,6 @@ GEM
       crack (>= 0.3.2)
       hashdiff (>= 0.4.0, < 2.0.0)
     webrick (1.8.1)
-    yard (0.9.34)
 
 PLATFORMS
   aarch64-linux
@@ -194,7 +193,6 @@ DEPENDENCIES
   warning (~> 1)
   webmock (>= 3.10.0)
   webrick (>= 1.7.0)
-  yard (~> 0.9)
 
 BUNDLED WITH
    2.3.26

--- a/gemfiles/ruby_3.1_opentelemetry.gemfile
+++ b/gemfiles/ruby_3.1_opentelemetry.gemfile
@@ -28,7 +28,6 @@ gem "warning", "~> 1"
 gem "webmock", ">= 3.10.0"
 gem "rexml", ">= 3.2.7"
 gem "webrick", ">= 1.7.0"
-gem "yard", "~> 0.9"
 gem "rubocop", "~> 1.50.0", require: false
 gem "rubocop-packaging", "~> 0.5.2", require: false
 gem "rubocop-performance", "~> 1.9", require: false

--- a/gemfiles/ruby_3.1_opentelemetry.gemfile.lock
+++ b/gemfiles/ruby_3.1_opentelemetry.gemfile.lock
@@ -153,8 +153,6 @@ GEM
       crack (>= 0.3.2)
       hashdiff (>= 0.4.0, < 2.0.0)
     webrick (1.7.0)
-    yard (0.9.28)
-      webrick (~> 1.7.0)
 
 PLATFORMS
   aarch64-linux
@@ -197,7 +195,6 @@ DEPENDENCIES
   warning (~> 1)
   webmock (>= 3.10.0)
   webrick (>= 1.7.0)
-  yard (~> 0.9)
 
 BUNDLED WITH
    2.3.26

--- a/gemfiles/ruby_3.1_rack_1.gemfile
+++ b/gemfiles/ruby_3.1_rack_1.gemfile
@@ -28,7 +28,6 @@ gem "warning", "~> 1"
 gem "webmock", ">= 3.10.0"
 gem "rexml", ">= 3.2.7"
 gem "webrick", ">= 1.7.0"
-gem "yard", "~> 0.9"
 gem "rubocop", "~> 1.50.0", require: false
 gem "rubocop-packaging", "~> 0.5.2", require: false
 gem "rubocop-performance", "~> 1.9", require: false

--- a/gemfiles/ruby_3.1_rack_1.gemfile.lock
+++ b/gemfiles/ruby_3.1_rack_1.gemfile.lock
@@ -144,7 +144,6 @@ GEM
       crack (>= 0.3.2)
       hashdiff (>= 0.4.0, < 2.0.0)
     webrick (1.8.1)
-    yard (0.9.34)
 
 PLATFORMS
   aarch64-linux
@@ -188,7 +187,6 @@ DEPENDENCIES
   warning (~> 1)
   webmock (>= 3.10.0)
   webrick (>= 1.7.0)
-  yard (~> 0.9)
 
 BUNDLED WITH
    2.3.26

--- a/gemfiles/ruby_3.1_rack_2.gemfile
+++ b/gemfiles/ruby_3.1_rack_2.gemfile
@@ -28,7 +28,6 @@ gem "warning", "~> 1"
 gem "webmock", ">= 3.10.0"
 gem "rexml", ">= 3.2.7"
 gem "webrick", ">= 1.7.0"
-gem "yard", "~> 0.9"
 gem "rubocop", "~> 1.50.0", require: false
 gem "rubocop-packaging", "~> 0.5.2", require: false
 gem "rubocop-performance", "~> 1.9", require: false

--- a/gemfiles/ruby_3.1_rack_2.gemfile.lock
+++ b/gemfiles/ruby_3.1_rack_2.gemfile.lock
@@ -144,7 +144,6 @@ GEM
       crack (>= 0.3.2)
       hashdiff (>= 0.4.0, < 2.0.0)
     webrick (1.8.1)
-    yard (0.9.34)
 
 PLATFORMS
   aarch64-linux
@@ -188,7 +187,6 @@ DEPENDENCIES
   warning (~> 1)
   webmock (>= 3.10.0)
   webrick (>= 1.7.0)
-  yard (~> 0.9)
 
 BUNDLED WITH
    2.3.26

--- a/gemfiles/ruby_3.1_rack_3.gemfile
+++ b/gemfiles/ruby_3.1_rack_3.gemfile
@@ -28,7 +28,6 @@ gem "warning", "~> 1"
 gem "webmock", ">= 3.10.0"
 gem "rexml", ">= 3.2.7"
 gem "webrick", ">= 1.7.0"
-gem "yard", "~> 0.9"
 gem "rubocop", "~> 1.50.0", require: false
 gem "rubocop-packaging", "~> 0.5.2", require: false
 gem "rubocop-performance", "~> 1.9", require: false

--- a/gemfiles/ruby_3.1_rack_3.gemfile.lock
+++ b/gemfiles/ruby_3.1_rack_3.gemfile.lock
@@ -144,7 +144,6 @@ GEM
       crack (>= 0.3.2)
       hashdiff (>= 0.4.0, < 2.0.0)
     webrick (1.8.1)
-    yard (0.9.34)
 
 PLATFORMS
   aarch64-linux
@@ -188,7 +187,6 @@ DEPENDENCIES
   warning (~> 1)
   webmock (>= 3.10.0)
   webrick (>= 1.7.0)
-  yard (~> 0.9)
 
 BUNDLED WITH
    2.3.26

--- a/gemfiles/ruby_3.1_rails61_mysql2.gemfile
+++ b/gemfiles/ruby_3.1_rails61_mysql2.gemfile
@@ -28,7 +28,6 @@ gem "warning", "~> 1"
 gem "webmock", ">= 3.10.0"
 gem "rexml", ">= 3.2.7"
 gem "webrick", ">= 1.7.0"
-gem "yard", "~> 0.9"
 gem "rubocop", "~> 1.50.0", require: false
 gem "rubocop-packaging", "~> 0.5.2", require: false
 gem "rubocop-performance", "~> 1.9", require: false

--- a/gemfiles/ruby_3.1_rails61_mysql2.gemfile.lock
+++ b/gemfiles/ruby_3.1_rails61_mysql2.gemfile.lock
@@ -279,8 +279,6 @@ GEM
     websocket-driver (0.7.5)
       websocket-extensions (>= 0.1.0)
     websocket-extensions (0.1.5)
-    yard (0.9.28)
-      webrick (~> 1.7.0)
     zeitwerk (2.6.7)
 
 PLATFORMS
@@ -327,7 +325,6 @@ DEPENDENCIES
   warning (~> 1)
   webmock (>= 3.10.0)
   webrick (>= 1.7.0)
-  yard (~> 0.9)
 
 BUNDLED WITH
    2.3.26

--- a/gemfiles/ruby_3.1_rails61_postgres.gemfile
+++ b/gemfiles/ruby_3.1_rails61_postgres.gemfile
@@ -28,7 +28,6 @@ gem "warning", "~> 1"
 gem "webmock", ">= 3.10.0"
 gem "rexml", ">= 3.2.7"
 gem "webrick", ">= 1.7.0"
-gem "yard", "~> 0.9"
 gem "rubocop", "~> 1.50.0", require: false
 gem "rubocop-packaging", "~> 0.5.2", require: false
 gem "rubocop-performance", "~> 1.9", require: false

--- a/gemfiles/ruby_3.1_rails61_postgres.gemfile.lock
+++ b/gemfiles/ruby_3.1_rails61_postgres.gemfile.lock
@@ -279,8 +279,6 @@ GEM
     websocket-driver (0.7.5)
       websocket-extensions (>= 0.1.0)
     websocket-extensions (0.1.5)
-    yard (0.9.28)
-      webrick (~> 1.7.0)
     zeitwerk (2.6.7)
 
 PLATFORMS
@@ -327,7 +325,6 @@ DEPENDENCIES
   warning (~> 1)
   webmock (>= 3.10.0)
   webrick (>= 1.7.0)
-  yard (~> 0.9)
 
 BUNDLED WITH
    2.3.26

--- a/gemfiles/ruby_3.1_rails61_postgres_redis.gemfile
+++ b/gemfiles/ruby_3.1_rails61_postgres_redis.gemfile
@@ -28,7 +28,6 @@ gem "warning", "~> 1"
 gem "webmock", ">= 3.10.0"
 gem "rexml", ">= 3.2.7"
 gem "webrick", ">= 1.7.0"
-gem "yard", "~> 0.9"
 gem "rubocop", "~> 1.50.0", require: false
 gem "rubocop-packaging", "~> 0.5.2", require: false
 gem "rubocop-performance", "~> 1.9", require: false

--- a/gemfiles/ruby_3.1_rails61_postgres_redis.gemfile.lock
+++ b/gemfiles/ruby_3.1_rails61_postgres_redis.gemfile.lock
@@ -280,8 +280,6 @@ GEM
     websocket-driver (0.7.5)
       websocket-extensions (>= 0.1.0)
     websocket-extensions (0.1.5)
-    yard (0.9.28)
-      webrick (~> 1.7.0)
     zeitwerk (2.6.7)
 
 PLATFORMS
@@ -329,7 +327,6 @@ DEPENDENCIES
   warning (~> 1)
   webmock (>= 3.10.0)
   webrick (>= 1.7.0)
-  yard (~> 0.9)
 
 BUNDLED WITH
    2.3.26

--- a/gemfiles/ruby_3.1_rails61_postgres_sidekiq.gemfile
+++ b/gemfiles/ruby_3.1_rails61_postgres_sidekiq.gemfile
@@ -28,7 +28,6 @@ gem "warning", "~> 1"
 gem "webmock", ">= 3.10.0"
 gem "rexml", ">= 3.2.7"
 gem "webrick", ">= 1.7.0"
-gem "yard", "~> 0.9"
 gem "rubocop", "~> 1.50.0", require: false
 gem "rubocop-packaging", "~> 0.5.2", require: false
 gem "rubocop-performance", "~> 1.9", require: false

--- a/gemfiles/ruby_3.1_rails61_postgres_sidekiq.gemfile.lock
+++ b/gemfiles/ruby_3.1_rails61_postgres_sidekiq.gemfile.lock
@@ -293,8 +293,6 @@ GEM
     websocket-driver (0.7.5)
       websocket-extensions (>= 0.1.0)
     websocket-extensions (0.1.5)
-    yard (0.9.28)
-      webrick (~> 1.7.0)
     zeitwerk (2.6.7)
 
 PLATFORMS
@@ -343,7 +341,6 @@ DEPENDENCIES
   warning (~> 1)
   webmock (>= 3.10.0)
   webrick (>= 1.7.0)
-  yard (~> 0.9)
 
 BUNDLED WITH
    2.3.26

--- a/gemfiles/ruby_3.1_rails61_semantic_logger.gemfile
+++ b/gemfiles/ruby_3.1_rails61_semantic_logger.gemfile
@@ -28,7 +28,6 @@ gem "warning", "~> 1"
 gem "webmock", ">= 3.10.0"
 gem "rexml", ">= 3.2.7"
 gem "webrick", ">= 1.7.0"
-gem "yard", "~> 0.9"
 gem "rubocop", "~> 1.50.0", require: false
 gem "rubocop-packaging", "~> 0.5.2", require: false
 gem "rubocop-performance", "~> 1.9", require: false

--- a/gemfiles/ruby_3.1_rails61_semantic_logger.gemfile.lock
+++ b/gemfiles/ruby_3.1_rails61_semantic_logger.gemfile.lock
@@ -278,8 +278,6 @@ GEM
     websocket-driver (0.7.5)
       websocket-extensions (>= 0.1.0)
     websocket-extensions (0.1.5)
-    yard (0.9.28)
-      webrick (~> 1.7.0)
     zeitwerk (2.6.7)
 
 PLATFORMS
@@ -326,7 +324,6 @@ DEPENDENCIES
   warning (~> 1)
   webmock (>= 3.10.0)
   webrick (>= 1.7.0)
-  yard (~> 0.9)
 
 BUNDLED WITH
    2.3.26

--- a/gemfiles/ruby_3.1_rails61_trilogy.gemfile
+++ b/gemfiles/ruby_3.1_rails61_trilogy.gemfile
@@ -28,7 +28,6 @@ gem "warning", "~> 1"
 gem "webmock", ">= 3.10.0"
 gem "rexml", ">= 3.2.7"
 gem "webrick", ">= 1.7.0"
-gem "yard", "~> 0.9"
 gem "rubocop", "~> 1.50.0", require: false
 gem "rubocop-packaging", "~> 0.5.2", require: false
 gem "rubocop-performance", "~> 1.9", require: false

--- a/gemfiles/ruby_3.1_rails61_trilogy.gemfile.lock
+++ b/gemfiles/ruby_3.1_rails61_trilogy.gemfile.lock
@@ -287,7 +287,6 @@ GEM
     websocket-driver (0.7.6)
       websocket-extensions (>= 0.1.0)
     websocket-extensions (0.1.5)
-    yard (0.9.34)
     zeitwerk (2.6.12)
 
 PLATFORMS
@@ -335,7 +334,6 @@ DEPENDENCIES
   warning (~> 1)
   webmock (>= 3.10.0)
   webrick (>= 1.7.0)
-  yard (~> 0.9)
 
 BUNDLED WITH
    2.3.26

--- a/gemfiles/ruby_3.1_redis_3.gemfile
+++ b/gemfiles/ruby_3.1_redis_3.gemfile
@@ -28,7 +28,6 @@ gem "warning", "~> 1"
 gem "webmock", ">= 3.10.0"
 gem "rexml", ">= 3.2.7"
 gem "webrick", ">= 1.7.0"
-gem "yard", "~> 0.9"
 gem "rubocop", "~> 1.50.0", require: false
 gem "rubocop-packaging", "~> 0.5.2", require: false
 gem "rubocop-performance", "~> 1.9", require: false

--- a/gemfiles/ruby_3.1_redis_3.gemfile.lock
+++ b/gemfiles/ruby_3.1_redis_3.gemfile.lock
@@ -138,8 +138,6 @@ GEM
       crack (>= 0.3.2)
       hashdiff (>= 0.4.0, < 2.0.0)
     webrick (1.7.0)
-    yard (0.9.28)
-      webrick (~> 1.7.0)
 
 PLATFORMS
   aarch64-linux
@@ -181,7 +179,6 @@ DEPENDENCIES
   warning (~> 1)
   webmock (>= 3.10.0)
   webrick (>= 1.7.0)
-  yard (~> 0.9)
 
 BUNDLED WITH
    2.3.26

--- a/gemfiles/ruby_3.1_redis_4.gemfile
+++ b/gemfiles/ruby_3.1_redis_4.gemfile
@@ -28,7 +28,6 @@ gem "warning", "~> 1"
 gem "webmock", ">= 3.10.0"
 gem "rexml", ">= 3.2.7"
 gem "webrick", ">= 1.7.0"
-gem "yard", "~> 0.9"
 gem "rubocop", "~> 1.50.0", require: false
 gem "rubocop-packaging", "~> 0.5.2", require: false
 gem "rubocop-performance", "~> 1.9", require: false

--- a/gemfiles/ruby_3.1_redis_4.gemfile.lock
+++ b/gemfiles/ruby_3.1_redis_4.gemfile.lock
@@ -138,8 +138,6 @@ GEM
       crack (>= 0.3.2)
       hashdiff (>= 0.4.0, < 2.0.0)
     webrick (1.7.0)
-    yard (0.9.28)
-      webrick (~> 1.7.0)
 
 PLATFORMS
   aarch64-linux
@@ -181,7 +179,6 @@ DEPENDENCIES
   warning (~> 1)
   webmock (>= 3.10.0)
   webrick (>= 1.7.0)
-  yard (~> 0.9)
 
 BUNDLED WITH
    2.3.26

--- a/gemfiles/ruby_3.1_redis_5.gemfile
+++ b/gemfiles/ruby_3.1_redis_5.gemfile
@@ -28,7 +28,6 @@ gem "warning", "~> 1"
 gem "webmock", ">= 3.10.0"
 gem "rexml", ">= 3.2.7"
 gem "webrick", ">= 1.7.0"
-gem "yard", "~> 0.9"
 gem "rubocop", "~> 1.50.0", require: false
 gem "rubocop-packaging", "~> 0.5.2", require: false
 gem "rubocop-performance", "~> 1.9", require: false

--- a/gemfiles/ruby_3.1_redis_5.gemfile.lock
+++ b/gemfiles/ruby_3.1_redis_5.gemfile.lock
@@ -142,8 +142,6 @@ GEM
       crack (>= 0.3.2)
       hashdiff (>= 0.4.0, < 2.0.0)
     webrick (1.7.0)
-    yard (0.9.28)
-      webrick (~> 1.7.0)
 
 PLATFORMS
   aarch64-linux
@@ -185,7 +183,6 @@ DEPENDENCIES
   warning (~> 1)
   webmock (>= 3.10.0)
   webrick (>= 1.7.0)
-  yard (~> 0.9)
 
 BUNDLED WITH
    2.3.26

--- a/gemfiles/ruby_3.1_relational_db.gemfile
+++ b/gemfiles/ruby_3.1_relational_db.gemfile
@@ -28,7 +28,6 @@ gem "warning", "~> 1"
 gem "webmock", ">= 3.10.0"
 gem "rexml", ">= 3.2.7"
 gem "webrick", ">= 1.7.0"
-gem "yard", "~> 0.9"
 gem "rubocop", "~> 1.50.0", require: false
 gem "rubocop-packaging", "~> 0.5.2", require: false
 gem "rubocop-performance", "~> 1.9", require: false

--- a/gemfiles/ruby_3.1_relational_db.gemfile.lock
+++ b/gemfiles/ruby_3.1_relational_db.gemfile.lock
@@ -169,7 +169,6 @@ GEM
       crack (>= 0.3.2)
       hashdiff (>= 0.4.0, < 2.0.0)
     webrick (1.8.1)
-    yard (0.9.34)
 
 PLATFORMS
   aarch64-linux
@@ -219,7 +218,6 @@ DEPENDENCIES
   warning (~> 1)
   webmock (>= 3.10.0)
   webrick (>= 1.7.0)
-  yard (~> 0.9)
 
 BUNDLED WITH
    2.3.26

--- a/gemfiles/ruby_3.1_resque2_redis3.gemfile
+++ b/gemfiles/ruby_3.1_resque2_redis3.gemfile
@@ -28,7 +28,6 @@ gem "warning", "~> 1"
 gem "webmock", ">= 3.10.0"
 gem "rexml", ">= 3.2.7"
 gem "webrick", ">= 1.7.0"
-gem "yard", "~> 0.9"
 gem "rubocop", "~> 1.50.0", require: false
 gem "rubocop-packaging", "~> 0.5.2", require: false
 gem "rubocop-performance", "~> 1.9", require: false

--- a/gemfiles/ruby_3.1_resque2_redis3.gemfile.lock
+++ b/gemfiles/ruby_3.1_resque2_redis3.gemfile.lock
@@ -159,8 +159,6 @@ GEM
       crack (>= 0.3.2)
       hashdiff (>= 0.4.0, < 2.0.0)
     webrick (1.7.0)
-    yard (0.9.28)
-      webrick (~> 1.7.0)
 
 PLATFORMS
   aarch64-linux
@@ -203,7 +201,6 @@ DEPENDENCIES
   warning (~> 1)
   webmock (>= 3.10.0)
   webrick (>= 1.7.0)
-  yard (~> 0.9)
 
 BUNDLED WITH
    2.3.26

--- a/gemfiles/ruby_3.1_resque2_redis4.gemfile
+++ b/gemfiles/ruby_3.1_resque2_redis4.gemfile
@@ -28,7 +28,6 @@ gem "warning", "~> 1"
 gem "webmock", ">= 3.10.0"
 gem "rexml", ">= 3.2.7"
 gem "webrick", ">= 1.7.0"
-gem "yard", "~> 0.9"
 gem "rubocop", "~> 1.50.0", require: false
 gem "rubocop-packaging", "~> 0.5.2", require: false
 gem "rubocop-performance", "~> 1.9", require: false

--- a/gemfiles/ruby_3.1_resque2_redis4.gemfile.lock
+++ b/gemfiles/ruby_3.1_resque2_redis4.gemfile.lock
@@ -163,8 +163,6 @@ GEM
       crack (>= 0.3.2)
       hashdiff (>= 0.4.0, < 2.0.0)
     webrick (1.7.0)
-    yard (0.9.28)
-      webrick (~> 1.7.0)
 
 PLATFORMS
   aarch64-linux
@@ -207,7 +205,6 @@ DEPENDENCIES
   warning (~> 1)
   webmock (>= 3.10.0)
   webrick (>= 1.7.0)
-  yard (~> 0.9)
 
 BUNDLED WITH
    2.3.26

--- a/gemfiles/ruby_3.1_sinatra_2.gemfile
+++ b/gemfiles/ruby_3.1_sinatra_2.gemfile
@@ -28,7 +28,6 @@ gem "warning", "~> 1"
 gem "webmock", ">= 3.10.0"
 gem "rexml", ">= 3.2.7"
 gem "webrick", ">= 1.7.0"
-gem "yard", "~> 0.9"
 gem "rubocop", "~> 1.50.0", require: false
 gem "rubocop-packaging", "~> 0.5.2", require: false
 gem "rubocop-performance", "~> 1.9", require: false

--- a/gemfiles/ruby_3.1_sinatra_2.gemfile.lock
+++ b/gemfiles/ruby_3.1_sinatra_2.gemfile.lock
@@ -159,7 +159,6 @@ GEM
       crack (>= 0.3.2)
       hashdiff (>= 0.4.0, < 2.0.0)
     webrick (1.8.1)
-    yard (0.9.36)
 
 PLATFORMS
   aarch64-linux
@@ -203,7 +202,6 @@ DEPENDENCIES
   warning (~> 1)
   webmock (>= 3.10.0)
   webrick (>= 1.7.0)
-  yard (~> 0.9)
 
 BUNDLED WITH
    2.3.26

--- a/gemfiles/ruby_3.1_sinatra_3.gemfile
+++ b/gemfiles/ruby_3.1_sinatra_3.gemfile
@@ -28,7 +28,6 @@ gem "warning", "~> 1"
 gem "webmock", ">= 3.10.0"
 gem "rexml", ">= 3.2.7"
 gem "webrick", ">= 1.7.0"
-gem "yard", "~> 0.9"
 gem "rubocop", "~> 1.50.0", require: false
 gem "rubocop-packaging", "~> 0.5.2", require: false
 gem "rubocop-performance", "~> 1.9", require: false

--- a/gemfiles/ruby_3.1_sinatra_3.gemfile.lock
+++ b/gemfiles/ruby_3.1_sinatra_3.gemfile.lock
@@ -161,7 +161,6 @@ GEM
       crack (>= 0.3.2)
       hashdiff (>= 0.4.0, < 2.0.0)
     webrick (1.8.1)
-    yard (0.9.36)
 
 PLATFORMS
   aarch64-linux
@@ -205,7 +204,6 @@ DEPENDENCIES
   warning (~> 1)
   webmock (>= 3.10.0)
   webrick (>= 1.7.0)
-  yard (~> 0.9)
 
 BUNDLED WITH
    2.3.26

--- a/gemfiles/ruby_3.1_sinatra_4.gemfile
+++ b/gemfiles/ruby_3.1_sinatra_4.gemfile
@@ -28,7 +28,6 @@ gem "warning", "~> 1"
 gem "webmock", ">= 3.10.0"
 gem "rexml", ">= 3.2.7"
 gem "webrick", ">= 1.7.0"
-gem "yard", "~> 0.9"
 gem "rubocop", "~> 1.50.0", require: false
 gem "rubocop-packaging", "~> 0.5.2", require: false
 gem "rubocop-performance", "~> 1.9", require: false

--- a/gemfiles/ruby_3.1_sinatra_4.gemfile.lock
+++ b/gemfiles/ruby_3.1_sinatra_4.gemfile.lock
@@ -164,7 +164,6 @@ GEM
       crack (>= 0.3.2)
       hashdiff (>= 0.4.0, < 2.0.0)
     webrick (1.8.1)
-    yard (0.9.36)
 
 PLATFORMS
   aarch64-linux
@@ -208,7 +207,6 @@ DEPENDENCIES
   warning (~> 1)
   webmock (>= 3.10.0)
   webrick (>= 1.7.0)
-  yard (~> 0.9)
 
 BUNDLED WITH
    2.3.26

--- a/gemfiles/ruby_3.1_stripe_10.gemfile
+++ b/gemfiles/ruby_3.1_stripe_10.gemfile
@@ -28,7 +28,6 @@ gem "warning", "~> 1"
 gem "webmock", ">= 3.10.0"
 gem "rexml", ">= 3.2.7"
 gem "webrick", ">= 1.7.0"
-gem "yard", "~> 0.9"
 gem "rubocop", "~> 1.50.0", require: false
 gem "rubocop-packaging", "~> 0.5.2", require: false
 gem "rubocop-performance", "~> 1.9", require: false

--- a/gemfiles/ruby_3.1_stripe_10.gemfile.lock
+++ b/gemfiles/ruby_3.1_stripe_10.gemfile.lock
@@ -144,7 +144,6 @@ GEM
       crack (>= 0.3.2)
       hashdiff (>= 0.4.0, < 2.0.0)
     webrick (1.8.1)
-    yard (0.9.36)
 
 PLATFORMS
   aarch64-linux
@@ -186,7 +185,6 @@ DEPENDENCIES
   warning (~> 1)
   webmock (>= 3.10.0)
   webrick (>= 1.7.0)
-  yard (~> 0.9)
 
 BUNDLED WITH
    2.3.26

--- a/gemfiles/ruby_3.1_stripe_11.gemfile
+++ b/gemfiles/ruby_3.1_stripe_11.gemfile
@@ -28,7 +28,6 @@ gem "warning", "~> 1"
 gem "webmock", ">= 3.10.0"
 gem "rexml", ">= 3.2.7"
 gem "webrick", ">= 1.7.0"
-gem "yard", "~> 0.9"
 gem "rubocop", "~> 1.50.0", require: false
 gem "rubocop-packaging", "~> 0.5.2", require: false
 gem "rubocop-performance", "~> 1.9", require: false

--- a/gemfiles/ruby_3.1_stripe_11.gemfile.lock
+++ b/gemfiles/ruby_3.1_stripe_11.gemfile.lock
@@ -144,7 +144,6 @@ GEM
       crack (>= 0.3.2)
       hashdiff (>= 0.4.0, < 2.0.0)
     webrick (1.8.1)
-    yard (0.9.36)
 
 PLATFORMS
   aarch64-linux
@@ -186,7 +185,6 @@ DEPENDENCIES
   warning (~> 1)
   webmock (>= 3.10.0)
   webrick (>= 1.7.0)
-  yard (~> 0.9)
 
 BUNDLED WITH
    2.3.26

--- a/gemfiles/ruby_3.1_stripe_12.gemfile
+++ b/gemfiles/ruby_3.1_stripe_12.gemfile
@@ -28,7 +28,6 @@ gem "warning", "~> 1"
 gem "webmock", ">= 3.10.0"
 gem "rexml", ">= 3.2.7"
 gem "webrick", ">= 1.7.0"
-gem "yard", "~> 0.9"
 gem "rubocop", "~> 1.50.0", require: false
 gem "rubocop-packaging", "~> 0.5.2", require: false
 gem "rubocop-performance", "~> 1.9", require: false

--- a/gemfiles/ruby_3.1_stripe_12.gemfile.lock
+++ b/gemfiles/ruby_3.1_stripe_12.gemfile.lock
@@ -144,7 +144,6 @@ GEM
       crack (>= 0.3.2)
       hashdiff (>= 0.4.0, < 2.0.0)
     webrick (1.8.1)
-    yard (0.9.36)
 
 PLATFORMS
   aarch64-linux
@@ -186,7 +185,6 @@ DEPENDENCIES
   warning (~> 1)
   webmock (>= 3.10.0)
   webrick (>= 1.7.0)
-  yard (~> 0.9)
 
 BUNDLED WITH
    2.3.26

--- a/gemfiles/ruby_3.1_stripe_7.gemfile
+++ b/gemfiles/ruby_3.1_stripe_7.gemfile
@@ -28,7 +28,6 @@ gem "warning", "~> 1"
 gem "webmock", ">= 3.10.0"
 gem "rexml", ">= 3.2.7"
 gem "webrick", ">= 1.7.0"
-gem "yard", "~> 0.9"
 gem "rubocop", "~> 1.50.0", require: false
 gem "rubocop-packaging", "~> 0.5.2", require: false
 gem "rubocop-performance", "~> 1.9", require: false

--- a/gemfiles/ruby_3.1_stripe_7.gemfile.lock
+++ b/gemfiles/ruby_3.1_stripe_7.gemfile.lock
@@ -144,7 +144,6 @@ GEM
       crack (>= 0.3.2)
       hashdiff (>= 0.4.0, < 2.0.0)
     webrick (1.8.1)
-    yard (0.9.36)
 
 PLATFORMS
   aarch64-linux
@@ -186,7 +185,6 @@ DEPENDENCIES
   warning (~> 1)
   webmock (>= 3.10.0)
   webrick (>= 1.7.0)
-  yard (~> 0.9)
 
 BUNDLED WITH
    2.3.26

--- a/gemfiles/ruby_3.1_stripe_8.gemfile
+++ b/gemfiles/ruby_3.1_stripe_8.gemfile
@@ -28,7 +28,6 @@ gem "warning", "~> 1"
 gem "webmock", ">= 3.10.0"
 gem "rexml", ">= 3.2.7"
 gem "webrick", ">= 1.7.0"
-gem "yard", "~> 0.9"
 gem "rubocop", "~> 1.50.0", require: false
 gem "rubocop-packaging", "~> 0.5.2", require: false
 gem "rubocop-performance", "~> 1.9", require: false

--- a/gemfiles/ruby_3.1_stripe_8.gemfile.lock
+++ b/gemfiles/ruby_3.1_stripe_8.gemfile.lock
@@ -144,7 +144,6 @@ GEM
       crack (>= 0.3.2)
       hashdiff (>= 0.4.0, < 2.0.0)
     webrick (1.8.1)
-    yard (0.9.36)
 
 PLATFORMS
   aarch64-linux
@@ -186,7 +185,6 @@ DEPENDENCIES
   warning (~> 1)
   webmock (>= 3.10.0)
   webrick (>= 1.7.0)
-  yard (~> 0.9)
 
 BUNDLED WITH
    2.3.26

--- a/gemfiles/ruby_3.1_stripe_9.gemfile
+++ b/gemfiles/ruby_3.1_stripe_9.gemfile
@@ -28,7 +28,6 @@ gem "warning", "~> 1"
 gem "webmock", ">= 3.10.0"
 gem "rexml", ">= 3.2.7"
 gem "webrick", ">= 1.7.0"
-gem "yard", "~> 0.9"
 gem "rubocop", "~> 1.50.0", require: false
 gem "rubocop-packaging", "~> 0.5.2", require: false
 gem "rubocop-performance", "~> 1.9", require: false

--- a/gemfiles/ruby_3.1_stripe_9.gemfile.lock
+++ b/gemfiles/ruby_3.1_stripe_9.gemfile.lock
@@ -144,7 +144,6 @@ GEM
       crack (>= 0.3.2)
       hashdiff (>= 0.4.0, < 2.0.0)
     webrick (1.8.1)
-    yard (0.9.36)
 
 PLATFORMS
   aarch64-linux
@@ -186,7 +185,6 @@ DEPENDENCIES
   warning (~> 1)
   webmock (>= 3.10.0)
   webrick (>= 1.7.0)
-  yard (~> 0.9)
 
 BUNDLED WITH
    2.3.26

--- a/gemfiles/ruby_3.2_activesupport.gemfile
+++ b/gemfiles/ruby_3.2_activesupport.gemfile
@@ -27,7 +27,6 @@ gem "warning", "~> 1"
 gem "webmock", ">= 3.10.0"
 gem "rexml", ">= 3.2.7"
 gem "webrick", ">= 1.7.0"
-gem "yard", "~> 0.9"
 gem "rubocop", "~> 1.50.0", require: false
 gem "rubocop-packaging", "~> 0.5.2", require: false
 gem "rubocop-performance", "~> 1.9", require: false

--- a/gemfiles/ruby_3.2_activesupport.gemfile.lock
+++ b/gemfiles/ruby_3.2_activesupport.gemfile.lock
@@ -242,7 +242,6 @@ GEM
       crack (>= 0.3.2)
       hashdiff (>= 0.4.0, < 2.0.0)
     webrick (1.8.1)
-    yard (0.9.34)
     zeitwerk (2.6.11)
 
 PLATFORMS
@@ -291,7 +290,6 @@ DEPENDENCIES
   warning (~> 1)
   webmock (>= 3.10.0)
   webrick (>= 1.7.0)
-  yard (~> 0.9)
 
 BUNDLED WITH
    2.3.26

--- a/gemfiles/ruby_3.2_aws.gemfile
+++ b/gemfiles/ruby_3.2_aws.gemfile
@@ -27,7 +27,6 @@ gem "warning", "~> 1"
 gem "webmock", ">= 3.10.0"
 gem "rexml", ">= 3.2.7"
 gem "webrick", ">= 1.7.0"
-gem "yard", "~> 0.9"
 gem "rubocop", "~> 1.50.0", require: false
 gem "rubocop-packaging", "~> 0.5.2", require: false
 gem "rubocop-performance", "~> 1.9", require: false

--- a/gemfiles/ruby_3.2_aws.gemfile.lock
+++ b/gemfiles/ruby_3.2_aws.gemfile.lock
@@ -1561,7 +1561,6 @@ GEM
       crack (>= 0.3.2)
       hashdiff (>= 0.4.0, < 2.0.0)
     webrick (1.8.1)
-    yard (0.9.34)
 
 PLATFORMS
   aarch64-linux
@@ -1603,7 +1602,6 @@ DEPENDENCIES
   warning (~> 1)
   webmock (>= 3.10.0)
   webrick (>= 1.7.0)
-  yard (~> 0.9)
 
 BUNDLED WITH
    2.3.26

--- a/gemfiles/ruby_3.2_contrib.gemfile
+++ b/gemfiles/ruby_3.2_contrib.gemfile
@@ -27,7 +27,6 @@ gem "warning", "~> 1"
 gem "webmock", ">= 3.10.0"
 gem "rexml", ">= 3.2.7"
 gem "webrick", ">= 1.7.0"
-gem "yard", "~> 0.9"
 gem "rubocop", "~> 1.50.0", require: false
 gem "rubocop-packaging", "~> 0.5.2", require: false
 gem "rubocop-performance", "~> 1.9", require: false

--- a/gemfiles/ruby_3.2_contrib.gemfile.lock
+++ b/gemfiles/ruby_3.2_contrib.gemfile.lock
@@ -202,8 +202,6 @@ GEM
       crack (>= 0.3.2)
       hashdiff (>= 0.4.0, < 2.0.0)
     webrick (1.7.0)
-    yard (0.9.28)
-      webrick (~> 1.7.0)
 
 PLATFORMS
   aarch64-linux
@@ -254,7 +252,6 @@ DEPENDENCIES
   warning (~> 1)
   webmock (>= 3.10.0)
   webrick (>= 1.7.0)
-  yard (~> 0.9)
 
 BUNDLED WITH
    2.3.26

--- a/gemfiles/ruby_3.2_contrib_old.gemfile
+++ b/gemfiles/ruby_3.2_contrib_old.gemfile
@@ -27,7 +27,6 @@ gem "warning", "~> 1"
 gem "webmock", ">= 3.10.0"
 gem "rexml", ">= 3.2.7"
 gem "webrick", ">= 1.7.0"
-gem "yard", "~> 0.9"
 gem "rubocop", "~> 1.50.0", require: false
 gem "rubocop-packaging", "~> 0.5.2", require: false
 gem "rubocop-performance", "~> 1.9", require: false

--- a/gemfiles/ruby_3.2_contrib_old.gemfile.lock
+++ b/gemfiles/ruby_3.2_contrib_old.gemfile.lock
@@ -186,8 +186,6 @@ GEM
       crack (>= 0.3.2)
       hashdiff (>= 0.4.0, < 2.0.0)
     webrick (1.7.0)
-    yard (0.9.28)
-      webrick (~> 1.7.0)
 
 PLATFORMS
   aarch64-linux
@@ -230,7 +228,6 @@ DEPENDENCIES
   warning (~> 1)
   webmock (>= 3.10.0)
   webrick (>= 1.7.0)
-  yard (~> 0.9)
 
 BUNDLED WITH
    2.3.26

--- a/gemfiles/ruby_3.2_core_old.gemfile
+++ b/gemfiles/ruby_3.2_core_old.gemfile
@@ -27,7 +27,6 @@ gem "warning", "~> 1"
 gem "webmock", ">= 3.10.0"
 gem "rexml", ">= 3.2.7"
 gem "webrick", ">= 1.7.0"
-gem "yard", "~> 0.9"
 gem "rubocop", "~> 1.50.0", require: false
 gem "rubocop-packaging", "~> 0.5.2", require: false
 gem "rubocop-performance", "~> 1.9", require: false

--- a/gemfiles/ruby_3.2_core_old.gemfile.lock
+++ b/gemfiles/ruby_3.2_core_old.gemfile.lock
@@ -133,8 +133,6 @@ GEM
       crack (>= 0.3.2)
       hashdiff (>= 0.4.0, < 2.0.0)
     webrick (1.7.0)
-    yard (0.9.28)
-      webrick (~> 1.7.0)
 
 PLATFORMS
   aarch64-linux
@@ -174,7 +172,6 @@ DEPENDENCIES
   warning (~> 1)
   webmock (>= 3.10.0)
   webrick (>= 1.7.0)
-  yard (~> 0.9)
 
 BUNDLED WITH
    2.3.26

--- a/gemfiles/ruby_3.2_elasticsearch_7.gemfile
+++ b/gemfiles/ruby_3.2_elasticsearch_7.gemfile
@@ -27,7 +27,6 @@ gem "warning", "~> 1"
 gem "webmock", ">= 3.10.0"
 gem "rexml", ">= 3.2.7"
 gem "webrick", ">= 1.7.0"
-gem "yard", "~> 0.9"
 gem "rubocop", "~> 1.50.0", require: false
 gem "rubocop-packaging", "~> 0.5.2", require: false
 gem "rubocop-performance", "~> 1.9", require: false

--- a/gemfiles/ruby_3.2_elasticsearch_7.gemfile.lock
+++ b/gemfiles/ruby_3.2_elasticsearch_7.gemfile.lock
@@ -171,7 +171,6 @@ GEM
       crack (>= 0.3.2)
       hashdiff (>= 0.4.0, < 2.0.0)
     webrick (1.8.1)
-    yard (0.9.34)
 
 PLATFORMS
   aarch64-linux
@@ -212,7 +211,6 @@ DEPENDENCIES
   warning (~> 1)
   webmock (>= 3.10.0)
   webrick (>= 1.7.0)
-  yard (~> 0.9)
 
 BUNDLED WITH
    2.3.26

--- a/gemfiles/ruby_3.2_elasticsearch_8.gemfile
+++ b/gemfiles/ruby_3.2_elasticsearch_8.gemfile
@@ -27,7 +27,6 @@ gem "warning", "~> 1"
 gem "webmock", ">= 3.10.0"
 gem "rexml", ">= 3.2.7"
 gem "webrick", ">= 1.7.0"
-gem "yard", "~> 0.9"
 gem "rubocop", "~> 1.50.0", require: false
 gem "rubocop-packaging", "~> 0.5.2", require: false
 gem "rubocop-performance", "~> 1.9", require: false

--- a/gemfiles/ruby_3.2_elasticsearch_8.gemfile.lock
+++ b/gemfiles/ruby_3.2_elasticsearch_8.gemfile.lock
@@ -153,7 +153,6 @@ GEM
       crack (>= 0.3.2)
       hashdiff (>= 0.4.0, < 2.0.0)
     webrick (1.8.1)
-    yard (0.9.34)
 
 PLATFORMS
   aarch64-linux
@@ -194,7 +193,6 @@ DEPENDENCIES
   warning (~> 1)
   webmock (>= 3.10.0)
   webrick (>= 1.7.0)
-  yard (~> 0.9)
 
 BUNDLED WITH
    2.3.26

--- a/gemfiles/ruby_3.2_graphql_1.13.gemfile
+++ b/gemfiles/ruby_3.2_graphql_1.13.gemfile
@@ -27,7 +27,6 @@ gem "warning", "~> 1"
 gem "webmock", ">= 3.10.0"
 gem "rexml", ">= 3.2.7"
 gem "webrick", ">= 1.7.0"
-gem "yard", "~> 0.9"
 gem "rubocop", "~> 1.50.0", require: false
 gem "rubocop-packaging", "~> 0.5.2", require: false
 gem "rubocop-performance", "~> 1.9", require: false

--- a/gemfiles/ruby_3.2_graphql_1.13.gemfile.lock
+++ b/gemfiles/ruby_3.2_graphql_1.13.gemfile.lock
@@ -280,7 +280,6 @@ GEM
     websocket-driver (0.7.6)
       websocket-extensions (>= 0.1.0)
     websocket-extensions (0.1.5)
-    yard (0.9.34)
     zeitwerk (2.6.12)
 
 PLATFORMS
@@ -325,7 +324,6 @@ DEPENDENCIES
   warning (~> 1)
   webmock (>= 3.10.0)
   webrick (>= 1.7.0)
-  yard (~> 0.9)
 
 BUNDLED WITH
    2.3.26

--- a/gemfiles/ruby_3.2_graphql_2.0.gemfile
+++ b/gemfiles/ruby_3.2_graphql_2.0.gemfile
@@ -27,7 +27,6 @@ gem "warning", "~> 1"
 gem "webmock", ">= 3.10.0"
 gem "rexml", ">= 3.2.7"
 gem "webrick", ">= 1.7.0"
-gem "yard", "~> 0.9"
 gem "rubocop", "~> 1.50.0", require: false
 gem "rubocop-packaging", "~> 0.5.2", require: false
 gem "rubocop-performance", "~> 1.9", require: false

--- a/gemfiles/ruby_3.2_graphql_2.0.gemfile.lock
+++ b/gemfiles/ruby_3.2_graphql_2.0.gemfile.lock
@@ -280,7 +280,6 @@ GEM
     websocket-driver (0.7.6)
       websocket-extensions (>= 0.1.0)
     websocket-extensions (0.1.5)
-    yard (0.9.34)
     zeitwerk (2.6.12)
 
 PLATFORMS
@@ -325,7 +324,6 @@ DEPENDENCIES
   warning (~> 1)
   webmock (>= 3.10.0)
   webrick (>= 1.7.0)
-  yard (~> 0.9)
 
 BUNDLED WITH
    2.3.26

--- a/gemfiles/ruby_3.2_graphql_2.1.gemfile
+++ b/gemfiles/ruby_3.2_graphql_2.1.gemfile
@@ -27,7 +27,6 @@ gem "warning", "~> 1"
 gem "webmock", ">= 3.10.0"
 gem "rexml", ">= 3.2.7"
 gem "webrick", ">= 1.7.0"
-gem "yard", "~> 0.9"
 gem "rubocop", "~> 1.50.0", require: false
 gem "rubocop-packaging", "~> 0.5.2", require: false
 gem "rubocop-performance", "~> 1.9", require: false

--- a/gemfiles/ruby_3.2_graphql_2.1.gemfile.lock
+++ b/gemfiles/ruby_3.2_graphql_2.1.gemfile.lock
@@ -281,7 +281,6 @@ GEM
     websocket-driver (0.7.6)
       websocket-extensions (>= 0.1.0)
     websocket-extensions (0.1.5)
-    yard (0.9.34)
     zeitwerk (2.6.12)
 
 PLATFORMS
@@ -326,7 +325,6 @@ DEPENDENCIES
   warning (~> 1)
   webmock (>= 3.10.0)
   webrick (>= 1.7.0)
-  yard (~> 0.9)
 
 BUNDLED WITH
    2.3.26

--- a/gemfiles/ruby_3.2_graphql_2.2.gemfile
+++ b/gemfiles/ruby_3.2_graphql_2.2.gemfile
@@ -27,7 +27,6 @@ gem "warning", "~> 1"
 gem "webmock", ">= 3.10.0"
 gem "rexml", ">= 3.2.7"
 gem "webrick", ">= 1.7.0"
-gem "yard", "~> 0.9"
 gem "rubocop", "~> 1.50.0", require: false
 gem "rubocop-packaging", "~> 0.5.2", require: false
 gem "rubocop-performance", "~> 1.9", require: false

--- a/gemfiles/ruby_3.2_graphql_2.2.gemfile.lock
+++ b/gemfiles/ruby_3.2_graphql_2.2.gemfile.lock
@@ -281,7 +281,6 @@ GEM
     websocket-driver (0.7.6)
       websocket-extensions (>= 0.1.0)
     websocket-extensions (0.1.5)
-    yard (0.9.34)
     zeitwerk (2.6.12)
 
 PLATFORMS
@@ -326,7 +325,6 @@ DEPENDENCIES
   warning (~> 1)
   webmock (>= 3.10.0)
   webrick (>= 1.7.0)
-  yard (~> 0.9)
 
 BUNDLED WITH
    2.3.26

--- a/gemfiles/ruby_3.2_graphql_2.3.gemfile
+++ b/gemfiles/ruby_3.2_graphql_2.3.gemfile
@@ -27,7 +27,6 @@ gem "warning", "~> 1"
 gem "webmock", ">= 3.10.0"
 gem "rexml", ">= 3.2.7"
 gem "webrick", ">= 1.7.0"
-gem "yard", "~> 0.9"
 gem "rubocop", "~> 1.50.0", require: false
 gem "rubocop-packaging", "~> 0.5.2", require: false
 gem "rubocop-performance", "~> 1.9", require: false

--- a/gemfiles/ruby_3.2_graphql_2.3.gemfile.lock
+++ b/gemfiles/ruby_3.2_graphql_2.3.gemfile.lock
@@ -285,7 +285,6 @@ GEM
     websocket-driver (0.7.6)
       websocket-extensions (>= 0.1.0)
     websocket-extensions (0.1.5)
-    yard (0.9.36)
     zeitwerk (2.6.16)
 
 PLATFORMS
@@ -330,7 +329,6 @@ DEPENDENCIES
   warning (~> 1)
   webmock (>= 3.10.0)
   webrick (>= 1.7.0)
-  yard (~> 0.9)
 
 BUNDLED WITH
    2.3.26

--- a/gemfiles/ruby_3.2_http.gemfile
+++ b/gemfiles/ruby_3.2_http.gemfile
@@ -27,7 +27,6 @@ gem "warning", "~> 1"
 gem "webmock", ">= 3.10.0"
 gem "rexml", ">= 3.2.7"
 gem "webrick", ">= 1.7.0"
-gem "yard", "~> 0.9"
 gem "rubocop", "~> 1.50.0", require: false
 gem "rubocop-packaging", "~> 0.5.2", require: false
 gem "rubocop-performance", "~> 1.9", require: false

--- a/gemfiles/ruby_3.2_http.gemfile.lock
+++ b/gemfiles/ruby_3.2_http.gemfile.lock
@@ -175,7 +175,6 @@ GEM
       crack (>= 0.3.2)
       hashdiff (>= 0.4.0, < 2.0.0)
     webrick (1.8.1)
-    yard (0.9.34)
 
 PLATFORMS
   aarch64-linux
@@ -222,7 +221,6 @@ DEPENDENCIES
   warning (~> 1)
   webmock (>= 3.10.0)
   webrick (>= 1.7.0)
-  yard (~> 0.9)
 
 BUNDLED WITH
    2.3.26

--- a/gemfiles/ruby_3.2_opensearch_2.gemfile
+++ b/gemfiles/ruby_3.2_opensearch_2.gemfile
@@ -27,7 +27,6 @@ gem "warning", "~> 1"
 gem "webmock", ">= 3.10.0"
 gem "rexml", ">= 3.2.7"
 gem "webrick", ">= 1.7.0"
-gem "yard", "~> 0.9"
 gem "rubocop", "~> 1.50.0", require: false
 gem "rubocop-packaging", "~> 0.5.2", require: false
 gem "rubocop-performance", "~> 1.9", require: false

--- a/gemfiles/ruby_3.2_opensearch_2.gemfile.lock
+++ b/gemfiles/ruby_3.2_opensearch_2.gemfile.lock
@@ -153,7 +153,6 @@ GEM
       crack (>= 0.3.2)
       hashdiff (>= 0.4.0, < 2.0.0)
     webrick (1.8.1)
-    yard (0.9.34)
 
 PLATFORMS
   aarch64-linux
@@ -194,7 +193,6 @@ DEPENDENCIES
   warning (~> 1)
   webmock (>= 3.10.0)
   webrick (>= 1.7.0)
-  yard (~> 0.9)
 
 BUNDLED WITH
    2.3.26

--- a/gemfiles/ruby_3.2_opensearch_3.gemfile
+++ b/gemfiles/ruby_3.2_opensearch_3.gemfile
@@ -27,7 +27,6 @@ gem "warning", "~> 1"
 gem "webmock", ">= 3.10.0"
 gem "rexml", ">= 3.2.7"
 gem "webrick", ">= 1.7.0"
-gem "yard", "~> 0.9"
 gem "rubocop", "~> 1.50.0", require: false
 gem "rubocop-packaging", "~> 0.5.2", require: false
 gem "rubocop-performance", "~> 1.9", require: false

--- a/gemfiles/ruby_3.2_opensearch_3.gemfile.lock
+++ b/gemfiles/ruby_3.2_opensearch_3.gemfile.lock
@@ -148,7 +148,6 @@ GEM
       crack (>= 0.3.2)
       hashdiff (>= 0.4.0, < 2.0.0)
     webrick (1.8.1)
-    yard (0.9.34)
 
 PLATFORMS
   aarch64-linux
@@ -189,7 +188,6 @@ DEPENDENCIES
   warning (~> 1)
   webmock (>= 3.10.0)
   webrick (>= 1.7.0)
-  yard (~> 0.9)
 
 BUNDLED WITH
    2.3.26

--- a/gemfiles/ruby_3.2_opentelemetry.gemfile
+++ b/gemfiles/ruby_3.2_opentelemetry.gemfile
@@ -27,7 +27,6 @@ gem "warning", "~> 1"
 gem "webmock", ">= 3.10.0"
 gem "rexml", ">= 3.2.7"
 gem "webrick", ">= 1.7.0"
-gem "yard", "~> 0.9"
 gem "rubocop", "~> 1.50.0", require: false
 gem "rubocop-packaging", "~> 0.5.2", require: false
 gem "rubocop-performance", "~> 1.9", require: false

--- a/gemfiles/ruby_3.2_opentelemetry.gemfile.lock
+++ b/gemfiles/ruby_3.2_opentelemetry.gemfile.lock
@@ -145,8 +145,6 @@ GEM
       crack (>= 0.3.2)
       hashdiff (>= 0.4.0, < 2.0.0)
     webrick (1.7.0)
-    yard (0.9.28)
-      webrick (~> 1.7.0)
 
 PLATFORMS
   aarch64-linux
@@ -187,7 +185,6 @@ DEPENDENCIES
   warning (~> 1)
   webmock (>= 3.10.0)
   webrick (>= 1.7.0)
-  yard (~> 0.9)
 
 BUNDLED WITH
    2.3.26

--- a/gemfiles/ruby_3.2_rack_1.gemfile
+++ b/gemfiles/ruby_3.2_rack_1.gemfile
@@ -27,7 +27,6 @@ gem "warning", "~> 1"
 gem "webmock", ">= 3.10.0"
 gem "rexml", ">= 3.2.7"
 gem "webrick", ">= 1.7.0"
-gem "yard", "~> 0.9"
 gem "rubocop", "~> 1.50.0", require: false
 gem "rubocop-packaging", "~> 0.5.2", require: false
 gem "rubocop-performance", "~> 1.9", require: false

--- a/gemfiles/ruby_3.2_rack_1.gemfile.lock
+++ b/gemfiles/ruby_3.2_rack_1.gemfile.lock
@@ -140,7 +140,6 @@ GEM
       crack (>= 0.3.2)
       hashdiff (>= 0.4.0, < 2.0.0)
     webrick (1.8.1)
-    yard (0.9.34)
 
 PLATFORMS
   aarch64-linux
@@ -183,7 +182,6 @@ DEPENDENCIES
   warning (~> 1)
   webmock (>= 3.10.0)
   webrick (>= 1.7.0)
-  yard (~> 0.9)
 
 BUNDLED WITH
    2.3.26

--- a/gemfiles/ruby_3.2_rack_2.gemfile
+++ b/gemfiles/ruby_3.2_rack_2.gemfile
@@ -27,7 +27,6 @@ gem "warning", "~> 1"
 gem "webmock", ">= 3.10.0"
 gem "rexml", ">= 3.2.7"
 gem "webrick", ">= 1.7.0"
-gem "yard", "~> 0.9"
 gem "rubocop", "~> 1.50.0", require: false
 gem "rubocop-packaging", "~> 0.5.2", require: false
 gem "rubocop-performance", "~> 1.9", require: false

--- a/gemfiles/ruby_3.2_rack_2.gemfile.lock
+++ b/gemfiles/ruby_3.2_rack_2.gemfile.lock
@@ -140,7 +140,6 @@ GEM
       crack (>= 0.3.2)
       hashdiff (>= 0.4.0, < 2.0.0)
     webrick (1.8.1)
-    yard (0.9.34)
 
 PLATFORMS
   aarch64-linux
@@ -183,7 +182,6 @@ DEPENDENCIES
   warning (~> 1)
   webmock (>= 3.10.0)
   webrick (>= 1.7.0)
-  yard (~> 0.9)
 
 BUNDLED WITH
    2.3.26

--- a/gemfiles/ruby_3.2_rack_3.gemfile
+++ b/gemfiles/ruby_3.2_rack_3.gemfile
@@ -27,7 +27,6 @@ gem "warning", "~> 1"
 gem "webmock", ">= 3.10.0"
 gem "rexml", ">= 3.2.7"
 gem "webrick", ">= 1.7.0"
-gem "yard", "~> 0.9"
 gem "rubocop", "~> 1.50.0", require: false
 gem "rubocop-packaging", "~> 0.5.2", require: false
 gem "rubocop-performance", "~> 1.9", require: false

--- a/gemfiles/ruby_3.2_rack_3.gemfile.lock
+++ b/gemfiles/ruby_3.2_rack_3.gemfile.lock
@@ -140,7 +140,6 @@ GEM
       crack (>= 0.3.2)
       hashdiff (>= 0.4.0, < 2.0.0)
     webrick (1.8.1)
-    yard (0.9.34)
 
 PLATFORMS
   aarch64-linux
@@ -183,7 +182,6 @@ DEPENDENCIES
   warning (~> 1)
   webmock (>= 3.10.0)
   webrick (>= 1.7.0)
-  yard (~> 0.9)
 
 BUNDLED WITH
    2.3.26

--- a/gemfiles/ruby_3.2_rails61_mysql2.gemfile
+++ b/gemfiles/ruby_3.2_rails61_mysql2.gemfile
@@ -27,7 +27,6 @@ gem "warning", "~> 1"
 gem "webmock", ">= 3.10.0"
 gem "rexml", ">= 3.2.7"
 gem "webrick", ">= 1.7.0"
-gem "yard", "~> 0.9"
 gem "rubocop", "~> 1.50.0", require: false
 gem "rubocop-packaging", "~> 0.5.2", require: false
 gem "rubocop-performance", "~> 1.9", require: false

--- a/gemfiles/ruby_3.2_rails61_mysql2.gemfile.lock
+++ b/gemfiles/ruby_3.2_rails61_mysql2.gemfile.lock
@@ -275,8 +275,6 @@ GEM
     websocket-driver (0.7.5)
       websocket-extensions (>= 0.1.0)
     websocket-extensions (0.1.5)
-    yard (0.9.28)
-      webrick (~> 1.7.0)
     zeitwerk (2.6.7)
 
 PLATFORMS
@@ -322,7 +320,6 @@ DEPENDENCIES
   warning (~> 1)
   webmock (>= 3.10.0)
   webrick (>= 1.7.0)
-  yard (~> 0.9)
 
 BUNDLED WITH
    2.3.26

--- a/gemfiles/ruby_3.2_rails61_postgres.gemfile
+++ b/gemfiles/ruby_3.2_rails61_postgres.gemfile
@@ -27,7 +27,6 @@ gem "warning", "~> 1"
 gem "webmock", ">= 3.10.0"
 gem "rexml", ">= 3.2.7"
 gem "webrick", ">= 1.7.0"
-gem "yard", "~> 0.9"
 gem "rubocop", "~> 1.50.0", require: false
 gem "rubocop-packaging", "~> 0.5.2", require: false
 gem "rubocop-performance", "~> 1.9", require: false

--- a/gemfiles/ruby_3.2_rails61_postgres.gemfile.lock
+++ b/gemfiles/ruby_3.2_rails61_postgres.gemfile.lock
@@ -275,8 +275,6 @@ GEM
     websocket-driver (0.7.5)
       websocket-extensions (>= 0.1.0)
     websocket-extensions (0.1.5)
-    yard (0.9.28)
-      webrick (~> 1.7.0)
     zeitwerk (2.6.7)
 
 PLATFORMS
@@ -322,7 +320,6 @@ DEPENDENCIES
   warning (~> 1)
   webmock (>= 3.10.0)
   webrick (>= 1.7.0)
-  yard (~> 0.9)
 
 BUNDLED WITH
    2.3.26

--- a/gemfiles/ruby_3.2_rails61_postgres_redis.gemfile
+++ b/gemfiles/ruby_3.2_rails61_postgres_redis.gemfile
@@ -27,7 +27,6 @@ gem "warning", "~> 1"
 gem "webmock", ">= 3.10.0"
 gem "rexml", ">= 3.2.7"
 gem "webrick", ">= 1.7.0"
-gem "yard", "~> 0.9"
 gem "rubocop", "~> 1.50.0", require: false
 gem "rubocop-packaging", "~> 0.5.2", require: false
 gem "rubocop-performance", "~> 1.9", require: false

--- a/gemfiles/ruby_3.2_rails61_postgres_redis.gemfile.lock
+++ b/gemfiles/ruby_3.2_rails61_postgres_redis.gemfile.lock
@@ -276,8 +276,6 @@ GEM
     websocket-driver (0.7.5)
       websocket-extensions (>= 0.1.0)
     websocket-extensions (0.1.5)
-    yard (0.9.28)
-      webrick (~> 1.7.0)
     zeitwerk (2.6.7)
 
 PLATFORMS
@@ -324,7 +322,6 @@ DEPENDENCIES
   warning (~> 1)
   webmock (>= 3.10.0)
   webrick (>= 1.7.0)
-  yard (~> 0.9)
 
 BUNDLED WITH
    2.3.26

--- a/gemfiles/ruby_3.2_rails61_postgres_sidekiq.gemfile
+++ b/gemfiles/ruby_3.2_rails61_postgres_sidekiq.gemfile
@@ -27,7 +27,6 @@ gem "warning", "~> 1"
 gem "webmock", ">= 3.10.0"
 gem "rexml", ">= 3.2.7"
 gem "webrick", ">= 1.7.0"
-gem "yard", "~> 0.9"
 gem "rubocop", "~> 1.50.0", require: false
 gem "rubocop-packaging", "~> 0.5.2", require: false
 gem "rubocop-performance", "~> 1.9", require: false

--- a/gemfiles/ruby_3.2_rails61_postgres_sidekiq.gemfile.lock
+++ b/gemfiles/ruby_3.2_rails61_postgres_sidekiq.gemfile.lock
@@ -289,8 +289,6 @@ GEM
     websocket-driver (0.7.5)
       websocket-extensions (>= 0.1.0)
     websocket-extensions (0.1.5)
-    yard (0.9.28)
-      webrick (~> 1.7.0)
     zeitwerk (2.6.7)
 
 PLATFORMS
@@ -338,7 +336,6 @@ DEPENDENCIES
   warning (~> 1)
   webmock (>= 3.10.0)
   webrick (>= 1.7.0)
-  yard (~> 0.9)
 
 BUNDLED WITH
    2.3.26

--- a/gemfiles/ruby_3.2_rails61_semantic_logger.gemfile
+++ b/gemfiles/ruby_3.2_rails61_semantic_logger.gemfile
@@ -27,7 +27,6 @@ gem "warning", "~> 1"
 gem "webmock", ">= 3.10.0"
 gem "rexml", ">= 3.2.7"
 gem "webrick", ">= 1.7.0"
-gem "yard", "~> 0.9"
 gem "rubocop", "~> 1.50.0", require: false
 gem "rubocop-packaging", "~> 0.5.2", require: false
 gem "rubocop-performance", "~> 1.9", require: false

--- a/gemfiles/ruby_3.2_rails61_semantic_logger.gemfile.lock
+++ b/gemfiles/ruby_3.2_rails61_semantic_logger.gemfile.lock
@@ -274,8 +274,6 @@ GEM
     websocket-driver (0.7.5)
       websocket-extensions (>= 0.1.0)
     websocket-extensions (0.1.5)
-    yard (0.9.28)
-      webrick (~> 1.7.0)
     zeitwerk (2.6.7)
 
 PLATFORMS
@@ -321,7 +319,6 @@ DEPENDENCIES
   warning (~> 1)
   webmock (>= 3.10.0)
   webrick (>= 1.7.0)
-  yard (~> 0.9)
 
 BUNDLED WITH
    2.3.26

--- a/gemfiles/ruby_3.2_rails61_trilogy.gemfile
+++ b/gemfiles/ruby_3.2_rails61_trilogy.gemfile
@@ -27,7 +27,6 @@ gem "warning", "~> 1"
 gem "webmock", ">= 3.10.0"
 gem "rexml", ">= 3.2.7"
 gem "webrick", ">= 1.7.0"
-gem "yard", "~> 0.9"
 gem "rubocop", "~> 1.50.0", require: false
 gem "rubocop-packaging", "~> 0.5.2", require: false
 gem "rubocop-performance", "~> 1.9", require: false

--- a/gemfiles/ruby_3.2_rails61_trilogy.gemfile.lock
+++ b/gemfiles/ruby_3.2_rails61_trilogy.gemfile.lock
@@ -283,7 +283,6 @@ GEM
     websocket-driver (0.7.6)
       websocket-extensions (>= 0.1.0)
     websocket-extensions (0.1.5)
-    yard (0.9.34)
     zeitwerk (2.6.12)
 
 PLATFORMS
@@ -330,7 +329,6 @@ DEPENDENCIES
   warning (~> 1)
   webmock (>= 3.10.0)
   webrick (>= 1.7.0)
-  yard (~> 0.9)
 
 BUNDLED WITH
    2.3.26

--- a/gemfiles/ruby_3.2_redis_3.gemfile
+++ b/gemfiles/ruby_3.2_redis_3.gemfile
@@ -27,7 +27,6 @@ gem "warning", "~> 1"
 gem "webmock", ">= 3.10.0"
 gem "rexml", ">= 3.2.7"
 gem "webrick", ">= 1.7.0"
-gem "yard", "~> 0.9"
 gem "rubocop", "~> 1.50.0", require: false
 gem "rubocop-packaging", "~> 0.5.2", require: false
 gem "rubocop-performance", "~> 1.9", require: false

--- a/gemfiles/ruby_3.2_redis_3.gemfile.lock
+++ b/gemfiles/ruby_3.2_redis_3.gemfile.lock
@@ -134,8 +134,6 @@ GEM
       crack (>= 0.3.2)
       hashdiff (>= 0.4.0, < 2.0.0)
     webrick (1.7.0)
-    yard (0.9.28)
-      webrick (~> 1.7.0)
 
 PLATFORMS
   aarch64-linux
@@ -176,7 +174,6 @@ DEPENDENCIES
   warning (~> 1)
   webmock (>= 3.10.0)
   webrick (>= 1.7.0)
-  yard (~> 0.9)
 
 BUNDLED WITH
    2.3.26

--- a/gemfiles/ruby_3.2_redis_4.gemfile
+++ b/gemfiles/ruby_3.2_redis_4.gemfile
@@ -27,7 +27,6 @@ gem "warning", "~> 1"
 gem "webmock", ">= 3.10.0"
 gem "rexml", ">= 3.2.7"
 gem "webrick", ">= 1.7.0"
-gem "yard", "~> 0.9"
 gem "rubocop", "~> 1.50.0", require: false
 gem "rubocop-packaging", "~> 0.5.2", require: false
 gem "rubocop-performance", "~> 1.9", require: false

--- a/gemfiles/ruby_3.2_redis_4.gemfile.lock
+++ b/gemfiles/ruby_3.2_redis_4.gemfile.lock
@@ -134,8 +134,6 @@ GEM
       crack (>= 0.3.2)
       hashdiff (>= 0.4.0, < 2.0.0)
     webrick (1.7.0)
-    yard (0.9.28)
-      webrick (~> 1.7.0)
 
 PLATFORMS
   aarch64-linux
@@ -176,7 +174,6 @@ DEPENDENCIES
   warning (~> 1)
   webmock (>= 3.10.0)
   webrick (>= 1.7.0)
-  yard (~> 0.9)
 
 BUNDLED WITH
    2.3.26

--- a/gemfiles/ruby_3.2_redis_5.gemfile
+++ b/gemfiles/ruby_3.2_redis_5.gemfile
@@ -27,7 +27,6 @@ gem "warning", "~> 1"
 gem "webmock", ">= 3.10.0"
 gem "rexml", ">= 3.2.7"
 gem "webrick", ">= 1.7.0"
-gem "yard", "~> 0.9"
 gem "rubocop", "~> 1.50.0", require: false
 gem "rubocop-packaging", "~> 0.5.2", require: false
 gem "rubocop-performance", "~> 1.9", require: false

--- a/gemfiles/ruby_3.2_redis_5.gemfile.lock
+++ b/gemfiles/ruby_3.2_redis_5.gemfile.lock
@@ -138,8 +138,6 @@ GEM
       crack (>= 0.3.2)
       hashdiff (>= 0.4.0, < 2.0.0)
     webrick (1.7.0)
-    yard (0.9.28)
-      webrick (~> 1.7.0)
 
 PLATFORMS
   aarch64-linux
@@ -180,7 +178,6 @@ DEPENDENCIES
   warning (~> 1)
   webmock (>= 3.10.0)
   webrick (>= 1.7.0)
-  yard (~> 0.9)
 
 BUNDLED WITH
    2.3.26

--- a/gemfiles/ruby_3.2_relational_db.gemfile
+++ b/gemfiles/ruby_3.2_relational_db.gemfile
@@ -27,7 +27,6 @@ gem "warning", "~> 1"
 gem "webmock", ">= 3.10.0"
 gem "rexml", ">= 3.2.7"
 gem "webrick", ">= 1.7.0"
-gem "yard", "~> 0.9"
 gem "rubocop", "~> 1.50.0", require: false
 gem "rubocop-packaging", "~> 0.5.2", require: false
 gem "rubocop-performance", "~> 1.9", require: false

--- a/gemfiles/ruby_3.2_relational_db.gemfile.lock
+++ b/gemfiles/ruby_3.2_relational_db.gemfile.lock
@@ -165,7 +165,6 @@ GEM
       crack (>= 0.3.2)
       hashdiff (>= 0.4.0, < 2.0.0)
     webrick (1.8.1)
-    yard (0.9.34)
 
 PLATFORMS
   aarch64-linux
@@ -214,7 +213,6 @@ DEPENDENCIES
   warning (~> 1)
   webmock (>= 3.10.0)
   webrick (>= 1.7.0)
-  yard (~> 0.9)
 
 BUNDLED WITH
    2.3.26

--- a/gemfiles/ruby_3.2_resque2_redis3.gemfile
+++ b/gemfiles/ruby_3.2_resque2_redis3.gemfile
@@ -27,7 +27,6 @@ gem "warning", "~> 1"
 gem "webmock", ">= 3.10.0"
 gem "rexml", ">= 3.2.7"
 gem "webrick", ">= 1.7.0"
-gem "yard", "~> 0.9"
 gem "rubocop", "~> 1.50.0", require: false
 gem "rubocop-packaging", "~> 0.5.2", require: false
 gem "rubocop-performance", "~> 1.9", require: false

--- a/gemfiles/ruby_3.2_resque2_redis3.gemfile.lock
+++ b/gemfiles/ruby_3.2_resque2_redis3.gemfile.lock
@@ -155,8 +155,6 @@ GEM
       crack (>= 0.3.2)
       hashdiff (>= 0.4.0, < 2.0.0)
     webrick (1.7.0)
-    yard (0.9.28)
-      webrick (~> 1.7.0)
 
 PLATFORMS
   aarch64-linux
@@ -198,7 +196,6 @@ DEPENDENCIES
   warning (~> 1)
   webmock (>= 3.10.0)
   webrick (>= 1.7.0)
-  yard (~> 0.9)
 
 BUNDLED WITH
    2.3.26

--- a/gemfiles/ruby_3.2_resque2_redis4.gemfile
+++ b/gemfiles/ruby_3.2_resque2_redis4.gemfile
@@ -27,7 +27,6 @@ gem "warning", "~> 1"
 gem "webmock", ">= 3.10.0"
 gem "rexml", ">= 3.2.7"
 gem "webrick", ">= 1.7.0"
-gem "yard", "~> 0.9"
 gem "rubocop", "~> 1.50.0", require: false
 gem "rubocop-packaging", "~> 0.5.2", require: false
 gem "rubocop-performance", "~> 1.9", require: false

--- a/gemfiles/ruby_3.2_resque2_redis4.gemfile.lock
+++ b/gemfiles/ruby_3.2_resque2_redis4.gemfile.lock
@@ -159,8 +159,6 @@ GEM
       crack (>= 0.3.2)
       hashdiff (>= 0.4.0, < 2.0.0)
     webrick (1.7.0)
-    yard (0.9.28)
-      webrick (~> 1.7.0)
 
 PLATFORMS
   aarch64-linux
@@ -202,7 +200,6 @@ DEPENDENCIES
   warning (~> 1)
   webmock (>= 3.10.0)
   webrick (>= 1.7.0)
-  yard (~> 0.9)
 
 BUNDLED WITH
    2.3.26

--- a/gemfiles/ruby_3.2_sinatra_2.gemfile
+++ b/gemfiles/ruby_3.2_sinatra_2.gemfile
@@ -27,7 +27,6 @@ gem "warning", "~> 1"
 gem "webmock", ">= 3.10.0"
 gem "rexml", ">= 3.2.7"
 gem "webrick", ">= 1.7.0"
-gem "yard", "~> 0.9"
 gem "rubocop", "~> 1.50.0", require: false
 gem "rubocop-packaging", "~> 0.5.2", require: false
 gem "rubocop-performance", "~> 1.9", require: false

--- a/gemfiles/ruby_3.2_sinatra_2.gemfile.lock
+++ b/gemfiles/ruby_3.2_sinatra_2.gemfile.lock
@@ -155,7 +155,6 @@ GEM
       crack (>= 0.3.2)
       hashdiff (>= 0.4.0, < 2.0.0)
     webrick (1.8.1)
-    yard (0.9.36)
 
 PLATFORMS
   aarch64-linux
@@ -198,7 +197,6 @@ DEPENDENCIES
   warning (~> 1)
   webmock (>= 3.10.0)
   webrick (>= 1.7.0)
-  yard (~> 0.9)
 
 BUNDLED WITH
    2.3.26

--- a/gemfiles/ruby_3.2_sinatra_3.gemfile
+++ b/gemfiles/ruby_3.2_sinatra_3.gemfile
@@ -27,7 +27,6 @@ gem "warning", "~> 1"
 gem "webmock", ">= 3.10.0"
 gem "rexml", ">= 3.2.7"
 gem "webrick", ">= 1.7.0"
-gem "yard", "~> 0.9"
 gem "rubocop", "~> 1.50.0", require: false
 gem "rubocop-packaging", "~> 0.5.2", require: false
 gem "rubocop-performance", "~> 1.9", require: false

--- a/gemfiles/ruby_3.2_sinatra_3.gemfile.lock
+++ b/gemfiles/ruby_3.2_sinatra_3.gemfile.lock
@@ -157,7 +157,6 @@ GEM
       crack (>= 0.3.2)
       hashdiff (>= 0.4.0, < 2.0.0)
     webrick (1.8.1)
-    yard (0.9.36)
 
 PLATFORMS
   aarch64-linux
@@ -200,7 +199,6 @@ DEPENDENCIES
   warning (~> 1)
   webmock (>= 3.10.0)
   webrick (>= 1.7.0)
-  yard (~> 0.9)
 
 BUNDLED WITH
    2.3.26

--- a/gemfiles/ruby_3.2_sinatra_4.gemfile
+++ b/gemfiles/ruby_3.2_sinatra_4.gemfile
@@ -27,7 +27,6 @@ gem "warning", "~> 1"
 gem "webmock", ">= 3.10.0"
 gem "rexml", ">= 3.2.7"
 gem "webrick", ">= 1.7.0"
-gem "yard", "~> 0.9"
 gem "rubocop", "~> 1.50.0", require: false
 gem "rubocop-packaging", "~> 0.5.2", require: false
 gem "rubocop-performance", "~> 1.9", require: false

--- a/gemfiles/ruby_3.2_sinatra_4.gemfile.lock
+++ b/gemfiles/ruby_3.2_sinatra_4.gemfile.lock
@@ -160,7 +160,6 @@ GEM
       crack (>= 0.3.2)
       hashdiff (>= 0.4.0, < 2.0.0)
     webrick (1.8.1)
-    yard (0.9.36)
 
 PLATFORMS
   aarch64-linux
@@ -203,7 +202,6 @@ DEPENDENCIES
   warning (~> 1)
   webmock (>= 3.10.0)
   webrick (>= 1.7.0)
-  yard (~> 0.9)
 
 BUNDLED WITH
    2.3.26

--- a/gemfiles/ruby_3.2_stripe_10.gemfile
+++ b/gemfiles/ruby_3.2_stripe_10.gemfile
@@ -27,7 +27,6 @@ gem "warning", "~> 1"
 gem "webmock", ">= 3.10.0"
 gem "rexml", ">= 3.2.7"
 gem "webrick", ">= 1.7.0"
-gem "yard", "~> 0.9"
 gem "rubocop", "~> 1.50.0", require: false
 gem "rubocop-packaging", "~> 0.5.2", require: false
 gem "rubocop-performance", "~> 1.9", require: false

--- a/gemfiles/ruby_3.2_stripe_10.gemfile.lock
+++ b/gemfiles/ruby_3.2_stripe_10.gemfile.lock
@@ -140,7 +140,6 @@ GEM
       crack (>= 0.3.2)
       hashdiff (>= 0.4.0, < 2.0.0)
     webrick (1.8.1)
-    yard (0.9.36)
 
 PLATFORMS
   aarch64-linux
@@ -181,7 +180,6 @@ DEPENDENCIES
   warning (~> 1)
   webmock (>= 3.10.0)
   webrick (>= 1.7.0)
-  yard (~> 0.9)
 
 BUNDLED WITH
    2.3.26

--- a/gemfiles/ruby_3.2_stripe_11.gemfile
+++ b/gemfiles/ruby_3.2_stripe_11.gemfile
@@ -27,7 +27,6 @@ gem "warning", "~> 1"
 gem "webmock", ">= 3.10.0"
 gem "rexml", ">= 3.2.7"
 gem "webrick", ">= 1.7.0"
-gem "yard", "~> 0.9"
 gem "rubocop", "~> 1.50.0", require: false
 gem "rubocop-packaging", "~> 0.5.2", require: false
 gem "rubocop-performance", "~> 1.9", require: false

--- a/gemfiles/ruby_3.2_stripe_11.gemfile.lock
+++ b/gemfiles/ruby_3.2_stripe_11.gemfile.lock
@@ -140,7 +140,6 @@ GEM
       crack (>= 0.3.2)
       hashdiff (>= 0.4.0, < 2.0.0)
     webrick (1.8.1)
-    yard (0.9.36)
 
 PLATFORMS
   aarch64-linux
@@ -181,7 +180,6 @@ DEPENDENCIES
   warning (~> 1)
   webmock (>= 3.10.0)
   webrick (>= 1.7.0)
-  yard (~> 0.9)
 
 BUNDLED WITH
    2.3.26

--- a/gemfiles/ruby_3.2_stripe_12.gemfile
+++ b/gemfiles/ruby_3.2_stripe_12.gemfile
@@ -27,7 +27,6 @@ gem "warning", "~> 1"
 gem "webmock", ">= 3.10.0"
 gem "rexml", ">= 3.2.7"
 gem "webrick", ">= 1.7.0"
-gem "yard", "~> 0.9"
 gem "rubocop", "~> 1.50.0", require: false
 gem "rubocop-packaging", "~> 0.5.2", require: false
 gem "rubocop-performance", "~> 1.9", require: false

--- a/gemfiles/ruby_3.2_stripe_12.gemfile.lock
+++ b/gemfiles/ruby_3.2_stripe_12.gemfile.lock
@@ -140,7 +140,6 @@ GEM
       crack (>= 0.3.2)
       hashdiff (>= 0.4.0, < 2.0.0)
     webrick (1.8.1)
-    yard (0.9.36)
 
 PLATFORMS
   aarch64-linux
@@ -181,7 +180,6 @@ DEPENDENCIES
   warning (~> 1)
   webmock (>= 3.10.0)
   webrick (>= 1.7.0)
-  yard (~> 0.9)
 
 BUNDLED WITH
    2.3.26

--- a/gemfiles/ruby_3.2_stripe_7.gemfile
+++ b/gemfiles/ruby_3.2_stripe_7.gemfile
@@ -27,7 +27,6 @@ gem "warning", "~> 1"
 gem "webmock", ">= 3.10.0"
 gem "rexml", ">= 3.2.7"
 gem "webrick", ">= 1.7.0"
-gem "yard", "~> 0.9"
 gem "rubocop", "~> 1.50.0", require: false
 gem "rubocop-packaging", "~> 0.5.2", require: false
 gem "rubocop-performance", "~> 1.9", require: false

--- a/gemfiles/ruby_3.2_stripe_7.gemfile.lock
+++ b/gemfiles/ruby_3.2_stripe_7.gemfile.lock
@@ -140,7 +140,6 @@ GEM
       crack (>= 0.3.2)
       hashdiff (>= 0.4.0, < 2.0.0)
     webrick (1.8.1)
-    yard (0.9.36)
 
 PLATFORMS
   aarch64-linux
@@ -181,7 +180,6 @@ DEPENDENCIES
   warning (~> 1)
   webmock (>= 3.10.0)
   webrick (>= 1.7.0)
-  yard (~> 0.9)
 
 BUNDLED WITH
    2.3.26

--- a/gemfiles/ruby_3.2_stripe_8.gemfile
+++ b/gemfiles/ruby_3.2_stripe_8.gemfile
@@ -27,7 +27,6 @@ gem "warning", "~> 1"
 gem "webmock", ">= 3.10.0"
 gem "rexml", ">= 3.2.7"
 gem "webrick", ">= 1.7.0"
-gem "yard", "~> 0.9"
 gem "rubocop", "~> 1.50.0", require: false
 gem "rubocop-packaging", "~> 0.5.2", require: false
 gem "rubocop-performance", "~> 1.9", require: false

--- a/gemfiles/ruby_3.2_stripe_8.gemfile.lock
+++ b/gemfiles/ruby_3.2_stripe_8.gemfile.lock
@@ -140,7 +140,6 @@ GEM
       crack (>= 0.3.2)
       hashdiff (>= 0.4.0, < 2.0.0)
     webrick (1.8.1)
-    yard (0.9.36)
 
 PLATFORMS
   aarch64-linux
@@ -181,7 +180,6 @@ DEPENDENCIES
   warning (~> 1)
   webmock (>= 3.10.0)
   webrick (>= 1.7.0)
-  yard (~> 0.9)
 
 BUNDLED WITH
    2.3.26

--- a/gemfiles/ruby_3.2_stripe_9.gemfile
+++ b/gemfiles/ruby_3.2_stripe_9.gemfile
@@ -27,7 +27,6 @@ gem "warning", "~> 1"
 gem "webmock", ">= 3.10.0"
 gem "rexml", ">= 3.2.7"
 gem "webrick", ">= 1.7.0"
-gem "yard", "~> 0.9"
 gem "rubocop", "~> 1.50.0", require: false
 gem "rubocop-packaging", "~> 0.5.2", require: false
 gem "rubocop-performance", "~> 1.9", require: false

--- a/gemfiles/ruby_3.2_stripe_9.gemfile.lock
+++ b/gemfiles/ruby_3.2_stripe_9.gemfile.lock
@@ -140,7 +140,6 @@ GEM
       crack (>= 0.3.2)
       hashdiff (>= 0.4.0, < 2.0.0)
     webrick (1.8.1)
-    yard (0.9.36)
 
 PLATFORMS
   aarch64-linux
@@ -181,7 +180,6 @@ DEPENDENCIES
   warning (~> 1)
   webmock (>= 3.10.0)
   webrick (>= 1.7.0)
-  yard (~> 0.9)
 
 BUNDLED WITH
    2.3.26

--- a/gemfiles/ruby_3.3_activesupport.gemfile
+++ b/gemfiles/ruby_3.3_activesupport.gemfile
@@ -27,7 +27,6 @@ gem "warning", "~> 1"
 gem "webmock", ">= 3.10.0"
 gem "rexml", ">= 3.2.7"
 gem "webrick", ">= 1.7.0"
-gem "yard", "~> 0.9"
 gem "rubocop", "~> 1.50.0", require: false
 gem "rubocop-packaging", "~> 0.5.2", require: false
 gem "rubocop-performance", "~> 1.9", require: false

--- a/gemfiles/ruby_3.3_activesupport.gemfile.lock
+++ b/gemfiles/ruby_3.3_activesupport.gemfile.lock
@@ -240,7 +240,6 @@ GEM
       crack (>= 0.3.2)
       hashdiff (>= 0.4.0, < 2.0.0)
     webrick (1.8.1)
-    yard (0.9.34)
     zeitwerk (2.6.11)
 
 PLATFORMS
@@ -289,7 +288,6 @@ DEPENDENCIES
   warning (~> 1)
   webmock (>= 3.10.0)
   webrick (>= 1.7.0)
-  yard (~> 0.9)
 
 BUNDLED WITH
    2.3.26

--- a/gemfiles/ruby_3.3_aws.gemfile
+++ b/gemfiles/ruby_3.3_aws.gemfile
@@ -27,7 +27,6 @@ gem "warning", "~> 1"
 gem "webmock", ">= 3.10.0"
 gem "rexml", ">= 3.2.7"
 gem "webrick", ">= 1.7.0"
-gem "yard", "~> 0.9"
 gem "rubocop", "~> 1.50.0", require: false
 gem "rubocop-packaging", "~> 0.5.2", require: false
 gem "rubocop-performance", "~> 1.9", require: false

--- a/gemfiles/ruby_3.3_aws.gemfile.lock
+++ b/gemfiles/ruby_3.3_aws.gemfile.lock
@@ -1560,7 +1560,6 @@ GEM
       crack (>= 0.3.2)
       hashdiff (>= 0.4.0, < 2.0.0)
     webrick (1.8.1)
-    yard (0.9.34)
 
 PLATFORMS
   aarch64-linux
@@ -1602,7 +1601,6 @@ DEPENDENCIES
   warning (~> 1)
   webmock (>= 3.10.0)
   webrick (>= 1.7.0)
-  yard (~> 0.9)
 
 BUNDLED WITH
    2.3.26

--- a/gemfiles/ruby_3.3_contrib.gemfile
+++ b/gemfiles/ruby_3.3_contrib.gemfile
@@ -27,7 +27,6 @@ gem "warning", "~> 1"
 gem "webmock", ">= 3.10.0"
 gem "rexml", ">= 3.2.7"
 gem "webrick", ">= 1.7.0"
-gem "yard", "~> 0.9"
 gem "rubocop", "~> 1.50.0", require: false
 gem "rubocop-packaging", "~> 0.5.2", require: false
 gem "rubocop-performance", "~> 1.9", require: false

--- a/gemfiles/ruby_3.3_contrib.gemfile.lock
+++ b/gemfiles/ruby_3.3_contrib.gemfile.lock
@@ -199,7 +199,6 @@ GEM
       crack (>= 0.3.2)
       hashdiff (>= 0.4.0, < 2.0.0)
     webrick (1.8.1)
-    yard (0.9.34)
 
 PLATFORMS
   aarch64-linux
@@ -250,7 +249,6 @@ DEPENDENCIES
   warning (~> 1)
   webmock (>= 3.10.0)
   webrick (>= 1.7.0)
-  yard (~> 0.9)
 
 BUNDLED WITH
    2.3.26

--- a/gemfiles/ruby_3.3_contrib_old.gemfile
+++ b/gemfiles/ruby_3.3_contrib_old.gemfile
@@ -27,7 +27,6 @@ gem "warning", "~> 1"
 gem "webmock", ">= 3.10.0"
 gem "rexml", ">= 3.2.7"
 gem "webrick", ">= 1.7.0"
-gem "yard", "~> 0.9"
 gem "rubocop", "~> 1.50.0", require: false
 gem "rubocop-packaging", "~> 0.5.2", require: false
 gem "rubocop-performance", "~> 1.9", require: false

--- a/gemfiles/ruby_3.3_contrib_old.gemfile.lock
+++ b/gemfiles/ruby_3.3_contrib_old.gemfile.lock
@@ -186,7 +186,6 @@ GEM
       crack (>= 0.3.2)
       hashdiff (>= 0.4.0, < 2.0.0)
     webrick (1.8.1)
-    yard (0.9.34)
 
 PLATFORMS
   aarch64-linux
@@ -230,7 +229,6 @@ DEPENDENCIES
   warning (~> 1)
   webmock (>= 3.10.0)
   webrick (>= 1.7.0)
-  yard (~> 0.9)
 
 BUNDLED WITH
    2.3.26

--- a/gemfiles/ruby_3.3_core_old.gemfile
+++ b/gemfiles/ruby_3.3_core_old.gemfile
@@ -27,7 +27,6 @@ gem "warning", "~> 1"
 gem "webmock", ">= 3.10.0"
 gem "rexml", ">= 3.2.7"
 gem "webrick", ">= 1.7.0"
-gem "yard", "~> 0.9"
 gem "rubocop", "~> 1.50.0", require: false
 gem "rubocop-packaging", "~> 0.5.2", require: false
 gem "rubocop-performance", "~> 1.9", require: false

--- a/gemfiles/ruby_3.3_core_old.gemfile.lock
+++ b/gemfiles/ruby_3.3_core_old.gemfile.lock
@@ -132,7 +132,6 @@ GEM
       crack (>= 0.3.2)
       hashdiff (>= 0.4.0, < 2.0.0)
     webrick (1.8.1)
-    yard (0.9.34)
 
 PLATFORMS
   aarch64-linux
@@ -172,7 +171,6 @@ DEPENDENCIES
   warning (~> 1)
   webmock (>= 3.10.0)
   webrick (>= 1.7.0)
-  yard (~> 0.9)
 
 BUNDLED WITH
    2.3.26

--- a/gemfiles/ruby_3.3_elasticsearch_7.gemfile
+++ b/gemfiles/ruby_3.3_elasticsearch_7.gemfile
@@ -27,7 +27,6 @@ gem "warning", "~> 1"
 gem "webmock", ">= 3.10.0"
 gem "rexml", ">= 3.2.7"
 gem "webrick", ">= 1.7.0"
-gem "yard", "~> 0.9"
 gem "rubocop", "~> 1.50.0", require: false
 gem "rubocop-packaging", "~> 0.5.2", require: false
 gem "rubocop-performance", "~> 1.9", require: false

--- a/gemfiles/ruby_3.3_elasticsearch_7.gemfile.lock
+++ b/gemfiles/ruby_3.3_elasticsearch_7.gemfile.lock
@@ -170,7 +170,6 @@ GEM
       crack (>= 0.3.2)
       hashdiff (>= 0.4.0, < 2.0.0)
     webrick (1.8.1)
-    yard (0.9.34)
 
 PLATFORMS
   aarch64-linux
@@ -211,7 +210,6 @@ DEPENDENCIES
   warning (~> 1)
   webmock (>= 3.10.0)
   webrick (>= 1.7.0)
-  yard (~> 0.9)
 
 BUNDLED WITH
    2.3.26

--- a/gemfiles/ruby_3.3_elasticsearch_8.gemfile
+++ b/gemfiles/ruby_3.3_elasticsearch_8.gemfile
@@ -27,7 +27,6 @@ gem "warning", "~> 1"
 gem "webmock", ">= 3.10.0"
 gem "rexml", ">= 3.2.7"
 gem "webrick", ">= 1.7.0"
-gem "yard", "~> 0.9"
 gem "rubocop", "~> 1.50.0", require: false
 gem "rubocop-packaging", "~> 0.5.2", require: false
 gem "rubocop-performance", "~> 1.9", require: false

--- a/gemfiles/ruby_3.3_elasticsearch_8.gemfile.lock
+++ b/gemfiles/ruby_3.3_elasticsearch_8.gemfile.lock
@@ -152,7 +152,6 @@ GEM
       crack (>= 0.3.2)
       hashdiff (>= 0.4.0, < 2.0.0)
     webrick (1.8.1)
-    yard (0.9.34)
 
 PLATFORMS
   aarch64-linux
@@ -193,7 +192,6 @@ DEPENDENCIES
   warning (~> 1)
   webmock (>= 3.10.0)
   webrick (>= 1.7.0)
-  yard (~> 0.9)
 
 BUNDLED WITH
    2.3.26

--- a/gemfiles/ruby_3.3_graphql_1.13.gemfile
+++ b/gemfiles/ruby_3.3_graphql_1.13.gemfile
@@ -27,7 +27,6 @@ gem "warning", "~> 1"
 gem "webmock", ">= 3.10.0"
 gem "rexml", ">= 3.2.7"
 gem "webrick", ">= 1.7.0"
-gem "yard", "~> 0.9"
 gem "rubocop", "~> 1.50.0", require: false
 gem "rubocop-packaging", "~> 0.5.2", require: false
 gem "rubocop-performance", "~> 1.9", require: false

--- a/gemfiles/ruby_3.3_graphql_1.13.gemfile.lock
+++ b/gemfiles/ruby_3.3_graphql_1.13.gemfile.lock
@@ -281,7 +281,6 @@ GEM
     websocket-driver (0.7.6)
       websocket-extensions (>= 0.1.0)
     websocket-extensions (0.1.5)
-    yard (0.9.34)
     zeitwerk (2.6.16)
 
 PLATFORMS
@@ -326,7 +325,6 @@ DEPENDENCIES
   warning (~> 1)
   webmock (>= 3.10.0)
   webrick (>= 1.7.0)
-  yard (~> 0.9)
 
 BUNDLED WITH
    2.3.26

--- a/gemfiles/ruby_3.3_graphql_2.0.gemfile
+++ b/gemfiles/ruby_3.3_graphql_2.0.gemfile
@@ -27,7 +27,6 @@ gem "warning", "~> 1"
 gem "webmock", ">= 3.10.0"
 gem "rexml", ">= 3.2.7"
 gem "webrick", ">= 1.7.0"
-gem "yard", "~> 0.9"
 gem "rubocop", "~> 1.50.0", require: false
 gem "rubocop-packaging", "~> 0.5.2", require: false
 gem "rubocop-performance", "~> 1.9", require: false

--- a/gemfiles/ruby_3.3_graphql_2.0.gemfile.lock
+++ b/gemfiles/ruby_3.3_graphql_2.0.gemfile.lock
@@ -281,7 +281,6 @@ GEM
     websocket-driver (0.7.6)
       websocket-extensions (>= 0.1.0)
     websocket-extensions (0.1.5)
-    yard (0.9.34)
     zeitwerk (2.6.16)
 
 PLATFORMS
@@ -326,7 +325,6 @@ DEPENDENCIES
   warning (~> 1)
   webmock (>= 3.10.0)
   webrick (>= 1.7.0)
-  yard (~> 0.9)
 
 BUNDLED WITH
    2.3.26

--- a/gemfiles/ruby_3.3_graphql_2.1.gemfile
+++ b/gemfiles/ruby_3.3_graphql_2.1.gemfile
@@ -27,7 +27,6 @@ gem "warning", "~> 1"
 gem "webmock", ">= 3.10.0"
 gem "rexml", ">= 3.2.7"
 gem "webrick", ">= 1.7.0"
-gem "yard", "~> 0.9"
 gem "rubocop", "~> 1.50.0", require: false
 gem "rubocop-packaging", "~> 0.5.2", require: false
 gem "rubocop-performance", "~> 1.9", require: false

--- a/gemfiles/ruby_3.3_graphql_2.1.gemfile.lock
+++ b/gemfiles/ruby_3.3_graphql_2.1.gemfile.lock
@@ -282,7 +282,6 @@ GEM
     websocket-driver (0.7.6)
       websocket-extensions (>= 0.1.0)
     websocket-extensions (0.1.5)
-    yard (0.9.34)
     zeitwerk (2.6.16)
 
 PLATFORMS
@@ -327,7 +326,6 @@ DEPENDENCIES
   warning (~> 1)
   webmock (>= 3.10.0)
   webrick (>= 1.7.0)
-  yard (~> 0.9)
 
 BUNDLED WITH
    2.3.26

--- a/gemfiles/ruby_3.3_graphql_2.2.gemfile
+++ b/gemfiles/ruby_3.3_graphql_2.2.gemfile
@@ -27,7 +27,6 @@ gem "warning", "~> 1"
 gem "webmock", ">= 3.10.0"
 gem "rexml", ">= 3.2.7"
 gem "webrick", ">= 1.7.0"
-gem "yard", "~> 0.9"
 gem "rubocop", "~> 1.50.0", require: false
 gem "rubocop-packaging", "~> 0.5.2", require: false
 gem "rubocop-performance", "~> 1.9", require: false

--- a/gemfiles/ruby_3.3_graphql_2.2.gemfile.lock
+++ b/gemfiles/ruby_3.3_graphql_2.2.gemfile.lock
@@ -282,7 +282,6 @@ GEM
     websocket-driver (0.7.6)
       websocket-extensions (>= 0.1.0)
     websocket-extensions (0.1.5)
-    yard (0.9.34)
     zeitwerk (2.6.16)
 
 PLATFORMS
@@ -327,7 +326,6 @@ DEPENDENCIES
   warning (~> 1)
   webmock (>= 3.10.0)
   webrick (>= 1.7.0)
-  yard (~> 0.9)
 
 BUNDLED WITH
    2.3.26

--- a/gemfiles/ruby_3.3_graphql_2.3.gemfile
+++ b/gemfiles/ruby_3.3_graphql_2.3.gemfile
@@ -27,7 +27,6 @@ gem "warning", "~> 1"
 gem "webmock", ">= 3.10.0"
 gem "rexml", ">= 3.2.7"
 gem "webrick", ">= 1.7.0"
-gem "yard", "~> 0.9"
 gem "rubocop", "~> 1.50.0", require: false
 gem "rubocop-packaging", "~> 0.5.2", require: false
 gem "rubocop-performance", "~> 1.9", require: false

--- a/gemfiles/ruby_3.3_graphql_2.3.gemfile.lock
+++ b/gemfiles/ruby_3.3_graphql_2.3.gemfile.lock
@@ -285,7 +285,6 @@ GEM
     websocket-driver (0.7.6)
       websocket-extensions (>= 0.1.0)
     websocket-extensions (0.1.5)
-    yard (0.9.36)
     zeitwerk (2.6.16)
 
 PLATFORMS
@@ -330,7 +329,6 @@ DEPENDENCIES
   warning (~> 1)
   webmock (>= 3.10.0)
   webrick (>= 1.7.0)
-  yard (~> 0.9)
 
 BUNDLED WITH
    2.3.26

--- a/gemfiles/ruby_3.3_http.gemfile
+++ b/gemfiles/ruby_3.3_http.gemfile
@@ -27,7 +27,6 @@ gem "warning", "~> 1"
 gem "webmock", ">= 3.10.0"
 gem "rexml", ">= 3.2.7"
 gem "webrick", ">= 1.7.0"
-gem "yard", "~> 0.9"
 gem "rubocop", "~> 1.50.0", require: false
 gem "rubocop-packaging", "~> 0.5.2", require: false
 gem "rubocop-performance", "~> 1.9", require: false

--- a/gemfiles/ruby_3.3_http.gemfile.lock
+++ b/gemfiles/ruby_3.3_http.gemfile.lock
@@ -174,7 +174,6 @@ GEM
       crack (>= 0.3.2)
       hashdiff (>= 0.4.0, < 2.0.0)
     webrick (1.8.1)
-    yard (0.9.34)
 
 PLATFORMS
   aarch64-linux
@@ -221,7 +220,6 @@ DEPENDENCIES
   warning (~> 1)
   webmock (>= 3.10.0)
   webrick (>= 1.7.0)
-  yard (~> 0.9)
 
 BUNDLED WITH
    2.3.26

--- a/gemfiles/ruby_3.3_opensearch_2.gemfile
+++ b/gemfiles/ruby_3.3_opensearch_2.gemfile
@@ -27,7 +27,6 @@ gem "warning", "~> 1"
 gem "webmock", ">= 3.10.0"
 gem "rexml", ">= 3.2.7"
 gem "webrick", ">= 1.7.0"
-gem "yard", "~> 0.9"
 gem "rubocop", "~> 1.50.0", require: false
 gem "rubocop-packaging", "~> 0.5.2", require: false
 gem "rubocop-performance", "~> 1.9", require: false

--- a/gemfiles/ruby_3.3_opensearch_2.gemfile.lock
+++ b/gemfiles/ruby_3.3_opensearch_2.gemfile.lock
@@ -152,7 +152,6 @@ GEM
       crack (>= 0.3.2)
       hashdiff (>= 0.4.0, < 2.0.0)
     webrick (1.8.1)
-    yard (0.9.34)
 
 PLATFORMS
   aarch64-linux
@@ -193,7 +192,6 @@ DEPENDENCIES
   warning (~> 1)
   webmock (>= 3.10.0)
   webrick (>= 1.7.0)
-  yard (~> 0.9)
 
 BUNDLED WITH
    2.3.26

--- a/gemfiles/ruby_3.3_opensearch_3.gemfile
+++ b/gemfiles/ruby_3.3_opensearch_3.gemfile
@@ -27,7 +27,6 @@ gem "warning", "~> 1"
 gem "webmock", ">= 3.10.0"
 gem "rexml", ">= 3.2.7"
 gem "webrick", ">= 1.7.0"
-gem "yard", "~> 0.9"
 gem "rubocop", "~> 1.50.0", require: false
 gem "rubocop-packaging", "~> 0.5.2", require: false
 gem "rubocop-performance", "~> 1.9", require: false

--- a/gemfiles/ruby_3.3_opensearch_3.gemfile.lock
+++ b/gemfiles/ruby_3.3_opensearch_3.gemfile.lock
@@ -147,7 +147,6 @@ GEM
       crack (>= 0.3.2)
       hashdiff (>= 0.4.0, < 2.0.0)
     webrick (1.8.1)
-    yard (0.9.34)
 
 PLATFORMS
   aarch64-linux
@@ -188,7 +187,6 @@ DEPENDENCIES
   warning (~> 1)
   webmock (>= 3.10.0)
   webrick (>= 1.7.0)
-  yard (~> 0.9)
 
 BUNDLED WITH
    2.3.26

--- a/gemfiles/ruby_3.3_opentelemetry.gemfile
+++ b/gemfiles/ruby_3.3_opentelemetry.gemfile
@@ -27,7 +27,6 @@ gem "warning", "~> 1"
 gem "webmock", ">= 3.10.0"
 gem "rexml", ">= 3.2.7"
 gem "webrick", ">= 1.7.0"
-gem "yard", "~> 0.9"
 gem "rubocop", "~> 1.50.0", require: false
 gem "rubocop-packaging", "~> 0.5.2", require: false
 gem "rubocop-performance", "~> 1.9", require: false

--- a/gemfiles/ruby_3.3_opentelemetry.gemfile.lock
+++ b/gemfiles/ruby_3.3_opentelemetry.gemfile.lock
@@ -144,7 +144,6 @@ GEM
       crack (>= 0.3.2)
       hashdiff (>= 0.4.0, < 2.0.0)
     webrick (1.8.1)
-    yard (0.9.34)
 
 PLATFORMS
   aarch64-linux
@@ -185,7 +184,6 @@ DEPENDENCIES
   warning (~> 1)
   webmock (>= 3.10.0)
   webrick (>= 1.7.0)
-  yard (~> 0.9)
 
 BUNDLED WITH
    2.3.26

--- a/gemfiles/ruby_3.3_rack_2.gemfile
+++ b/gemfiles/ruby_3.3_rack_2.gemfile
@@ -27,7 +27,6 @@ gem "warning", "~> 1"
 gem "webmock", ">= 3.10.0"
 gem "rexml", ">= 3.2.7"
 gem "webrick", ">= 1.7.0"
-gem "yard", "~> 0.9"
 gem "rubocop", "~> 1.50.0", require: false
 gem "rubocop-packaging", "~> 0.5.2", require: false
 gem "rubocop-performance", "~> 1.9", require: false

--- a/gemfiles/ruby_3.3_rack_2.gemfile.lock
+++ b/gemfiles/ruby_3.3_rack_2.gemfile.lock
@@ -139,7 +139,6 @@ GEM
       crack (>= 0.3.2)
       hashdiff (>= 0.4.0, < 2.0.0)
     webrick (1.8.1)
-    yard (0.9.34)
 
 PLATFORMS
   aarch64-linux
@@ -182,7 +181,6 @@ DEPENDENCIES
   warning (~> 1)
   webmock (>= 3.10.0)
   webrick (>= 1.7.0)
-  yard (~> 0.9)
 
 BUNDLED WITH
    2.3.26

--- a/gemfiles/ruby_3.3_rack_3.gemfile
+++ b/gemfiles/ruby_3.3_rack_3.gemfile
@@ -27,7 +27,6 @@ gem "warning", "~> 1"
 gem "webmock", ">= 3.10.0"
 gem "rexml", ">= 3.2.7"
 gem "webrick", ">= 1.7.0"
-gem "yard", "~> 0.9"
 gem "rubocop", "~> 1.50.0", require: false
 gem "rubocop-packaging", "~> 0.5.2", require: false
 gem "rubocop-performance", "~> 1.9", require: false

--- a/gemfiles/ruby_3.3_rack_3.gemfile.lock
+++ b/gemfiles/ruby_3.3_rack_3.gemfile.lock
@@ -139,7 +139,6 @@ GEM
       crack (>= 0.3.2)
       hashdiff (>= 0.4.0, < 2.0.0)
     webrick (1.8.1)
-    yard (0.9.34)
 
 PLATFORMS
   aarch64-linux
@@ -182,7 +181,6 @@ DEPENDENCIES
   warning (~> 1)
   webmock (>= 3.10.0)
   webrick (>= 1.7.0)
-  yard (~> 0.9)
 
 BUNDLED WITH
    2.3.26

--- a/gemfiles/ruby_3.3_rails61_mysql2.gemfile
+++ b/gemfiles/ruby_3.3_rails61_mysql2.gemfile
@@ -27,7 +27,6 @@ gem "warning", "~> 1"
 gem "webmock", ">= 3.10.0"
 gem "rexml", ">= 3.2.7"
 gem "webrick", ">= 1.7.0"
-gem "yard", "~> 0.9"
 gem "rubocop", "~> 1.50.0", require: false
 gem "rubocop-packaging", "~> 0.5.2", require: false
 gem "rubocop-performance", "~> 1.9", require: false

--- a/gemfiles/ruby_3.3_rails61_mysql2.gemfile.lock
+++ b/gemfiles/ruby_3.3_rails61_mysql2.gemfile.lock
@@ -274,7 +274,6 @@ GEM
     websocket-driver (0.7.5)
       websocket-extensions (>= 0.1.0)
     websocket-extensions (0.1.5)
-    yard (0.9.34)
     zeitwerk (2.6.8)
 
 PLATFORMS
@@ -320,7 +319,6 @@ DEPENDENCIES
   warning (~> 1)
   webmock (>= 3.10.0)
   webrick (>= 1.7.0)
-  yard (~> 0.9)
 
 BUNDLED WITH
    2.3.26

--- a/gemfiles/ruby_3.3_rails61_postgres.gemfile
+++ b/gemfiles/ruby_3.3_rails61_postgres.gemfile
@@ -27,7 +27,6 @@ gem "warning", "~> 1"
 gem "webmock", ">= 3.10.0"
 gem "rexml", ">= 3.2.7"
 gem "webrick", ">= 1.7.0"
-gem "yard", "~> 0.9"
 gem "rubocop", "~> 1.50.0", require: false
 gem "rubocop-packaging", "~> 0.5.2", require: false
 gem "rubocop-performance", "~> 1.9", require: false

--- a/gemfiles/ruby_3.3_rails61_postgres.gemfile.lock
+++ b/gemfiles/ruby_3.3_rails61_postgres.gemfile.lock
@@ -274,7 +274,6 @@ GEM
     websocket-driver (0.7.5)
       websocket-extensions (>= 0.1.0)
     websocket-extensions (0.1.5)
-    yard (0.9.34)
     zeitwerk (2.6.8)
 
 PLATFORMS
@@ -320,7 +319,6 @@ DEPENDENCIES
   warning (~> 1)
   webmock (>= 3.10.0)
   webrick (>= 1.7.0)
-  yard (~> 0.9)
 
 BUNDLED WITH
    2.3.26

--- a/gemfiles/ruby_3.3_rails61_postgres_redis.gemfile
+++ b/gemfiles/ruby_3.3_rails61_postgres_redis.gemfile
@@ -27,7 +27,6 @@ gem "warning", "~> 1"
 gem "webmock", ">= 3.10.0"
 gem "rexml", ">= 3.2.7"
 gem "webrick", ">= 1.7.0"
-gem "yard", "~> 0.9"
 gem "rubocop", "~> 1.50.0", require: false
 gem "rubocop-packaging", "~> 0.5.2", require: false
 gem "rubocop-performance", "~> 1.9", require: false

--- a/gemfiles/ruby_3.3_rails61_postgres_redis.gemfile.lock
+++ b/gemfiles/ruby_3.3_rails61_postgres_redis.gemfile.lock
@@ -275,7 +275,6 @@ GEM
     websocket-driver (0.7.5)
       websocket-extensions (>= 0.1.0)
     websocket-extensions (0.1.5)
-    yard (0.9.34)
     zeitwerk (2.6.8)
 
 PLATFORMS
@@ -322,7 +321,6 @@ DEPENDENCIES
   warning (~> 1)
   webmock (>= 3.10.0)
   webrick (>= 1.7.0)
-  yard (~> 0.9)
 
 BUNDLED WITH
    2.3.26

--- a/gemfiles/ruby_3.3_rails61_postgres_sidekiq.gemfile
+++ b/gemfiles/ruby_3.3_rails61_postgres_sidekiq.gemfile
@@ -27,7 +27,6 @@ gem "warning", "~> 1"
 gem "webmock", ">= 3.10.0"
 gem "rexml", ">= 3.2.7"
 gem "webrick", ">= 1.7.0"
-gem "yard", "~> 0.9"
 gem "rubocop", "~> 1.50.0", require: false
 gem "rubocop-packaging", "~> 0.5.2", require: false
 gem "rubocop-performance", "~> 1.9", require: false

--- a/gemfiles/ruby_3.3_rails61_postgres_sidekiq.gemfile.lock
+++ b/gemfiles/ruby_3.3_rails61_postgres_sidekiq.gemfile.lock
@@ -288,7 +288,6 @@ GEM
     websocket-driver (0.7.5)
       websocket-extensions (>= 0.1.0)
     websocket-extensions (0.1.5)
-    yard (0.9.34)
     zeitwerk (2.6.8)
 
 PLATFORMS
@@ -336,7 +335,6 @@ DEPENDENCIES
   warning (~> 1)
   webmock (>= 3.10.0)
   webrick (>= 1.7.0)
-  yard (~> 0.9)
 
 BUNDLED WITH
    2.3.26

--- a/gemfiles/ruby_3.3_rails61_semantic_logger.gemfile
+++ b/gemfiles/ruby_3.3_rails61_semantic_logger.gemfile
@@ -27,7 +27,6 @@ gem "warning", "~> 1"
 gem "webmock", ">= 3.10.0"
 gem "rexml", ">= 3.2.7"
 gem "webrick", ">= 1.7.0"
-gem "yard", "~> 0.9"
 gem "rubocop", "~> 1.50.0", require: false
 gem "rubocop-packaging", "~> 0.5.2", require: false
 gem "rubocop-performance", "~> 1.9", require: false

--- a/gemfiles/ruby_3.3_rails61_semantic_logger.gemfile.lock
+++ b/gemfiles/ruby_3.3_rails61_semantic_logger.gemfile.lock
@@ -273,7 +273,6 @@ GEM
     websocket-driver (0.7.5)
       websocket-extensions (>= 0.1.0)
     websocket-extensions (0.1.5)
-    yard (0.9.34)
     zeitwerk (2.6.8)
 
 PLATFORMS
@@ -319,7 +318,6 @@ DEPENDENCIES
   warning (~> 1)
   webmock (>= 3.10.0)
   webrick (>= 1.7.0)
-  yard (~> 0.9)
 
 BUNDLED WITH
    2.3.26

--- a/gemfiles/ruby_3.3_rails61_trilogy.gemfile
+++ b/gemfiles/ruby_3.3_rails61_trilogy.gemfile
@@ -27,7 +27,6 @@ gem "warning", "~> 1"
 gem "webmock", ">= 3.10.0"
 gem "rexml", ">= 3.2.7"
 gem "webrick", ">= 1.7.0"
-gem "yard", "~> 0.9"
 gem "rubocop", "~> 1.50.0", require: false
 gem "rubocop-packaging", "~> 0.5.2", require: false
 gem "rubocop-performance", "~> 1.9", require: false

--- a/gemfiles/ruby_3.3_rails61_trilogy.gemfile.lock
+++ b/gemfiles/ruby_3.3_rails61_trilogy.gemfile.lock
@@ -282,7 +282,6 @@ GEM
     websocket-driver (0.7.6)
       websocket-extensions (>= 0.1.0)
     websocket-extensions (0.1.5)
-    yard (0.9.34)
     zeitwerk (2.6.12)
 
 PLATFORMS
@@ -329,7 +328,6 @@ DEPENDENCIES
   warning (~> 1)
   webmock (>= 3.10.0)
   webrick (>= 1.7.0)
-  yard (~> 0.9)
 
 BUNDLED WITH
    2.3.26

--- a/gemfiles/ruby_3.3_redis_3.gemfile
+++ b/gemfiles/ruby_3.3_redis_3.gemfile
@@ -27,7 +27,6 @@ gem "warning", "~> 1"
 gem "webmock", ">= 3.10.0"
 gem "rexml", ">= 3.2.7"
 gem "webrick", ">= 1.7.0"
-gem "yard", "~> 0.9"
 gem "rubocop", "~> 1.50.0", require: false
 gem "rubocop-packaging", "~> 0.5.2", require: false
 gem "rubocop-performance", "~> 1.9", require: false

--- a/gemfiles/ruby_3.3_redis_3.gemfile.lock
+++ b/gemfiles/ruby_3.3_redis_3.gemfile.lock
@@ -133,7 +133,6 @@ GEM
       crack (>= 0.3.2)
       hashdiff (>= 0.4.0, < 2.0.0)
     webrick (1.8.1)
-    yard (0.9.34)
 
 PLATFORMS
   aarch64-linux
@@ -174,7 +173,6 @@ DEPENDENCIES
   warning (~> 1)
   webmock (>= 3.10.0)
   webrick (>= 1.7.0)
-  yard (~> 0.9)
 
 BUNDLED WITH
    2.3.26

--- a/gemfiles/ruby_3.3_redis_4.gemfile
+++ b/gemfiles/ruby_3.3_redis_4.gemfile
@@ -27,7 +27,6 @@ gem "warning", "~> 1"
 gem "webmock", ">= 3.10.0"
 gem "rexml", ">= 3.2.7"
 gem "webrick", ">= 1.7.0"
-gem "yard", "~> 0.9"
 gem "rubocop", "~> 1.50.0", require: false
 gem "rubocop-packaging", "~> 0.5.2", require: false
 gem "rubocop-performance", "~> 1.9", require: false

--- a/gemfiles/ruby_3.3_redis_4.gemfile.lock
+++ b/gemfiles/ruby_3.3_redis_4.gemfile.lock
@@ -133,7 +133,6 @@ GEM
       crack (>= 0.3.2)
       hashdiff (>= 0.4.0, < 2.0.0)
     webrick (1.8.1)
-    yard (0.9.34)
 
 PLATFORMS
   aarch64-linux
@@ -174,7 +173,6 @@ DEPENDENCIES
   warning (~> 1)
   webmock (>= 3.10.0)
   webrick (>= 1.7.0)
-  yard (~> 0.9)
 
 BUNDLED WITH
    2.3.26

--- a/gemfiles/ruby_3.3_redis_5.gemfile
+++ b/gemfiles/ruby_3.3_redis_5.gemfile
@@ -27,7 +27,6 @@ gem "warning", "~> 1"
 gem "webmock", ">= 3.10.0"
 gem "rexml", ">= 3.2.7"
 gem "webrick", ">= 1.7.0"
-gem "yard", "~> 0.9"
 gem "rubocop", "~> 1.50.0", require: false
 gem "rubocop-packaging", "~> 0.5.2", require: false
 gem "rubocop-performance", "~> 1.9", require: false

--- a/gemfiles/ruby_3.3_redis_5.gemfile.lock
+++ b/gemfiles/ruby_3.3_redis_5.gemfile.lock
@@ -137,7 +137,6 @@ GEM
       crack (>= 0.3.2)
       hashdiff (>= 0.4.0, < 2.0.0)
     webrick (1.8.1)
-    yard (0.9.34)
 
 PLATFORMS
   aarch64-linux
@@ -178,7 +177,6 @@ DEPENDENCIES
   warning (~> 1)
   webmock (>= 3.10.0)
   webrick (>= 1.7.0)
-  yard (~> 0.9)
 
 BUNDLED WITH
    2.3.26

--- a/gemfiles/ruby_3.3_relational_db.gemfile
+++ b/gemfiles/ruby_3.3_relational_db.gemfile
@@ -27,7 +27,6 @@ gem "warning", "~> 1"
 gem "webmock", ">= 3.10.0"
 gem "rexml", ">= 3.2.7"
 gem "webrick", ">= 1.7.0"
-gem "yard", "~> 0.9"
 gem "rubocop", "~> 1.50.0", require: false
 gem "rubocop-packaging", "~> 0.5.2", require: false
 gem "rubocop-performance", "~> 1.9", require: false

--- a/gemfiles/ruby_3.3_relational_db.gemfile.lock
+++ b/gemfiles/ruby_3.3_relational_db.gemfile.lock
@@ -165,7 +165,6 @@ GEM
       crack (>= 0.3.2)
       hashdiff (>= 0.4.0, < 2.0.0)
     webrick (1.8.1)
-    yard (0.9.34)
 
 PLATFORMS
   aarch64-linux
@@ -214,7 +213,6 @@ DEPENDENCIES
   warning (~> 1)
   webmock (>= 3.10.0)
   webrick (>= 1.7.0)
-  yard (~> 0.9)
 
 BUNDLED WITH
    2.3.26

--- a/gemfiles/ruby_3.3_resque2_redis3.gemfile
+++ b/gemfiles/ruby_3.3_resque2_redis3.gemfile
@@ -27,7 +27,6 @@ gem "warning", "~> 1"
 gem "webmock", ">= 3.10.0"
 gem "rexml", ">= 3.2.7"
 gem "webrick", ">= 1.7.0"
-gem "yard", "~> 0.9"
 gem "rubocop", "~> 1.50.0", require: false
 gem "rubocop-packaging", "~> 0.5.2", require: false
 gem "rubocop-performance", "~> 1.9", require: false

--- a/gemfiles/ruby_3.3_resque2_redis3.gemfile.lock
+++ b/gemfiles/ruby_3.3_resque2_redis3.gemfile.lock
@@ -154,7 +154,6 @@ GEM
       crack (>= 0.3.2)
       hashdiff (>= 0.4.0, < 2.0.0)
     webrick (1.8.1)
-    yard (0.9.34)
 
 PLATFORMS
   aarch64-linux
@@ -196,7 +195,6 @@ DEPENDENCIES
   warning (~> 1)
   webmock (>= 3.10.0)
   webrick (>= 1.7.0)
-  yard (~> 0.9)
 
 BUNDLED WITH
    2.3.26

--- a/gemfiles/ruby_3.3_resque2_redis4.gemfile
+++ b/gemfiles/ruby_3.3_resque2_redis4.gemfile
@@ -27,7 +27,6 @@ gem "warning", "~> 1"
 gem "webmock", ">= 3.10.0"
 gem "rexml", ">= 3.2.7"
 gem "webrick", ">= 1.7.0"
-gem "yard", "~> 0.9"
 gem "rubocop", "~> 1.50.0", require: false
 gem "rubocop-packaging", "~> 0.5.2", require: false
 gem "rubocop-performance", "~> 1.9", require: false

--- a/gemfiles/ruby_3.3_resque2_redis4.gemfile.lock
+++ b/gemfiles/ruby_3.3_resque2_redis4.gemfile.lock
@@ -158,7 +158,6 @@ GEM
       crack (>= 0.3.2)
       hashdiff (>= 0.4.0, < 2.0.0)
     webrick (1.8.1)
-    yard (0.9.34)
 
 PLATFORMS
   aarch64-linux
@@ -200,7 +199,6 @@ DEPENDENCIES
   warning (~> 1)
   webmock (>= 3.10.0)
   webrick (>= 1.7.0)
-  yard (~> 0.9)
 
 BUNDLED WITH
    2.3.26

--- a/gemfiles/ruby_3.3_sinatra_2.gemfile
+++ b/gemfiles/ruby_3.3_sinatra_2.gemfile
@@ -27,7 +27,6 @@ gem "warning", "~> 1"
 gem "webmock", ">= 3.10.0"
 gem "rexml", ">= 3.2.7"
 gem "webrick", ">= 1.7.0"
-gem "yard", "~> 0.9"
 gem "rubocop", "~> 1.50.0", require: false
 gem "rubocop-packaging", "~> 0.5.2", require: false
 gem "rubocop-performance", "~> 1.9", require: false

--- a/gemfiles/ruby_3.3_sinatra_2.gemfile.lock
+++ b/gemfiles/ruby_3.3_sinatra_2.gemfile.lock
@@ -155,7 +155,6 @@ GEM
       crack (>= 0.3.2)
       hashdiff (>= 0.4.0, < 2.0.0)
     webrick (1.8.1)
-    yard (0.9.36)
 
 PLATFORMS
   aarch64-linux
@@ -198,7 +197,6 @@ DEPENDENCIES
   warning (~> 1)
   webmock (>= 3.10.0)
   webrick (>= 1.7.0)
-  yard (~> 0.9)
 
 BUNDLED WITH
    2.3.26

--- a/gemfiles/ruby_3.3_sinatra_3.gemfile
+++ b/gemfiles/ruby_3.3_sinatra_3.gemfile
@@ -27,7 +27,6 @@ gem "warning", "~> 1"
 gem "webmock", ">= 3.10.0"
 gem "rexml", ">= 3.2.7"
 gem "webrick", ">= 1.7.0"
-gem "yard", "~> 0.9"
 gem "rubocop", "~> 1.50.0", require: false
 gem "rubocop-packaging", "~> 0.5.2", require: false
 gem "rubocop-performance", "~> 1.9", require: false

--- a/gemfiles/ruby_3.3_sinatra_3.gemfile.lock
+++ b/gemfiles/ruby_3.3_sinatra_3.gemfile.lock
@@ -157,7 +157,6 @@ GEM
       crack (>= 0.3.2)
       hashdiff (>= 0.4.0, < 2.0.0)
     webrick (1.8.1)
-    yard (0.9.36)
 
 PLATFORMS
   aarch64-linux
@@ -200,7 +199,6 @@ DEPENDENCIES
   warning (~> 1)
   webmock (>= 3.10.0)
   webrick (>= 1.7.0)
-  yard (~> 0.9)
 
 BUNDLED WITH
    2.3.26

--- a/gemfiles/ruby_3.3_sinatra_4.gemfile
+++ b/gemfiles/ruby_3.3_sinatra_4.gemfile
@@ -27,7 +27,6 @@ gem "warning", "~> 1"
 gem "webmock", ">= 3.10.0"
 gem "rexml", ">= 3.2.7"
 gem "webrick", ">= 1.7.0"
-gem "yard", "~> 0.9"
 gem "rubocop", "~> 1.50.0", require: false
 gem "rubocop-packaging", "~> 0.5.2", require: false
 gem "rubocop-performance", "~> 1.9", require: false

--- a/gemfiles/ruby_3.3_sinatra_4.gemfile.lock
+++ b/gemfiles/ruby_3.3_sinatra_4.gemfile.lock
@@ -160,7 +160,6 @@ GEM
       crack (>= 0.3.2)
       hashdiff (>= 0.4.0, < 2.0.0)
     webrick (1.8.1)
-    yard (0.9.36)
 
 PLATFORMS
   aarch64-linux
@@ -203,7 +202,6 @@ DEPENDENCIES
   warning (~> 1)
   webmock (>= 3.10.0)
   webrick (>= 1.7.0)
-  yard (~> 0.9)
 
 BUNDLED WITH
    2.3.26

--- a/gemfiles/ruby_3.3_stripe_10.gemfile
+++ b/gemfiles/ruby_3.3_stripe_10.gemfile
@@ -27,7 +27,6 @@ gem "warning", "~> 1"
 gem "webmock", ">= 3.10.0"
 gem "rexml", ">= 3.2.7"
 gem "webrick", ">= 1.7.0"
-gem "yard", "~> 0.9"
 gem "rubocop", "~> 1.50.0", require: false
 gem "rubocop-packaging", "~> 0.5.2", require: false
 gem "rubocop-performance", "~> 1.9", require: false

--- a/gemfiles/ruby_3.3_stripe_10.gemfile.lock
+++ b/gemfiles/ruby_3.3_stripe_10.gemfile.lock
@@ -140,7 +140,6 @@ GEM
       crack (>= 0.3.2)
       hashdiff (>= 0.4.0, < 2.0.0)
     webrick (1.8.1)
-    yard (0.9.36)
 
 PLATFORMS
   aarch64-linux
@@ -181,7 +180,6 @@ DEPENDENCIES
   warning (~> 1)
   webmock (>= 3.10.0)
   webrick (>= 1.7.0)
-  yard (~> 0.9)
 
 BUNDLED WITH
    2.3.26

--- a/gemfiles/ruby_3.3_stripe_11.gemfile
+++ b/gemfiles/ruby_3.3_stripe_11.gemfile
@@ -27,7 +27,6 @@ gem "warning", "~> 1"
 gem "webmock", ">= 3.10.0"
 gem "rexml", ">= 3.2.7"
 gem "webrick", ">= 1.7.0"
-gem "yard", "~> 0.9"
 gem "rubocop", "~> 1.50.0", require: false
 gem "rubocop-packaging", "~> 0.5.2", require: false
 gem "rubocop-performance", "~> 1.9", require: false

--- a/gemfiles/ruby_3.3_stripe_11.gemfile.lock
+++ b/gemfiles/ruby_3.3_stripe_11.gemfile.lock
@@ -140,7 +140,6 @@ GEM
       crack (>= 0.3.2)
       hashdiff (>= 0.4.0, < 2.0.0)
     webrick (1.8.1)
-    yard (0.9.36)
 
 PLATFORMS
   aarch64-linux
@@ -181,7 +180,6 @@ DEPENDENCIES
   warning (~> 1)
   webmock (>= 3.10.0)
   webrick (>= 1.7.0)
-  yard (~> 0.9)
 
 BUNDLED WITH
    2.3.26

--- a/gemfiles/ruby_3.3_stripe_12.gemfile
+++ b/gemfiles/ruby_3.3_stripe_12.gemfile
@@ -27,7 +27,6 @@ gem "warning", "~> 1"
 gem "webmock", ">= 3.10.0"
 gem "rexml", ">= 3.2.7"
 gem "webrick", ">= 1.7.0"
-gem "yard", "~> 0.9"
 gem "rubocop", "~> 1.50.0", require: false
 gem "rubocop-packaging", "~> 0.5.2", require: false
 gem "rubocop-performance", "~> 1.9", require: false

--- a/gemfiles/ruby_3.3_stripe_12.gemfile.lock
+++ b/gemfiles/ruby_3.3_stripe_12.gemfile.lock
@@ -140,7 +140,6 @@ GEM
       crack (>= 0.3.2)
       hashdiff (>= 0.4.0, < 2.0.0)
     webrick (1.8.1)
-    yard (0.9.36)
 
 PLATFORMS
   aarch64-linux
@@ -181,7 +180,6 @@ DEPENDENCIES
   warning (~> 1)
   webmock (>= 3.10.0)
   webrick (>= 1.7.0)
-  yard (~> 0.9)
 
 BUNDLED WITH
    2.3.26

--- a/gemfiles/ruby_3.3_stripe_7.gemfile
+++ b/gemfiles/ruby_3.3_stripe_7.gemfile
@@ -27,7 +27,6 @@ gem "warning", "~> 1"
 gem "webmock", ">= 3.10.0"
 gem "rexml", ">= 3.2.7"
 gem "webrick", ">= 1.7.0"
-gem "yard", "~> 0.9"
 gem "rubocop", "~> 1.50.0", require: false
 gem "rubocop-packaging", "~> 0.5.2", require: false
 gem "rubocop-performance", "~> 1.9", require: false

--- a/gemfiles/ruby_3.3_stripe_7.gemfile.lock
+++ b/gemfiles/ruby_3.3_stripe_7.gemfile.lock
@@ -140,7 +140,6 @@ GEM
       crack (>= 0.3.2)
       hashdiff (>= 0.4.0, < 2.0.0)
     webrick (1.8.1)
-    yard (0.9.36)
 
 PLATFORMS
   aarch64-linux
@@ -181,7 +180,6 @@ DEPENDENCIES
   warning (~> 1)
   webmock (>= 3.10.0)
   webrick (>= 1.7.0)
-  yard (~> 0.9)
 
 BUNDLED WITH
    2.3.26

--- a/gemfiles/ruby_3.3_stripe_8.gemfile
+++ b/gemfiles/ruby_3.3_stripe_8.gemfile
@@ -27,7 +27,6 @@ gem "warning", "~> 1"
 gem "webmock", ">= 3.10.0"
 gem "rexml", ">= 3.2.7"
 gem "webrick", ">= 1.7.0"
-gem "yard", "~> 0.9"
 gem "rubocop", "~> 1.50.0", require: false
 gem "rubocop-packaging", "~> 0.5.2", require: false
 gem "rubocop-performance", "~> 1.9", require: false

--- a/gemfiles/ruby_3.3_stripe_8.gemfile.lock
+++ b/gemfiles/ruby_3.3_stripe_8.gemfile.lock
@@ -140,7 +140,6 @@ GEM
       crack (>= 0.3.2)
       hashdiff (>= 0.4.0, < 2.0.0)
     webrick (1.8.1)
-    yard (0.9.36)
 
 PLATFORMS
   aarch64-linux
@@ -181,7 +180,6 @@ DEPENDENCIES
   warning (~> 1)
   webmock (>= 3.10.0)
   webrick (>= 1.7.0)
-  yard (~> 0.9)
 
 BUNDLED WITH
    2.3.26

--- a/gemfiles/ruby_3.3_stripe_9.gemfile
+++ b/gemfiles/ruby_3.3_stripe_9.gemfile
@@ -27,7 +27,6 @@ gem "warning", "~> 1"
 gem "webmock", ">= 3.10.0"
 gem "rexml", ">= 3.2.7"
 gem "webrick", ">= 1.7.0"
-gem "yard", "~> 0.9"
 gem "rubocop", "~> 1.50.0", require: false
 gem "rubocop-packaging", "~> 0.5.2", require: false
 gem "rubocop-performance", "~> 1.9", require: false

--- a/gemfiles/ruby_3.3_stripe_9.gemfile.lock
+++ b/gemfiles/ruby_3.3_stripe_9.gemfile.lock
@@ -140,7 +140,6 @@ GEM
       crack (>= 0.3.2)
       hashdiff (>= 0.4.0, < 2.0.0)
     webrick (1.8.1)
-    yard (0.9.36)
 
 PLATFORMS
   aarch64-linux
@@ -181,7 +180,6 @@ DEPENDENCIES
   warning (~> 1)
   webmock (>= 3.10.0)
   webrick (>= 1.7.0)
-  yard (~> 0.9)
 
 BUNDLED WITH
    2.3.26

--- a/gemfiles/ruby_3.4_activesupport.gemfile
+++ b/gemfiles/ruby_3.4_activesupport.gemfile
@@ -27,7 +27,6 @@ gem "warning", "~> 1"
 gem "webmock", ">= 3.10.0"
 gem "rexml", ">= 3.2.7"
 gem "webrick", git: "https://github.com/ruby/webrick.git", ref: "0c600e169bd4ae267cb5eeb6197277c848323bbe"
-gem "yard", "~> 0.9"
 gem "rubocop", "~> 1.50.0", require: false
 gem "rubocop-packaging", "~> 0.5.2", require: false
 gem "rubocop-performance", "~> 1.9", require: false

--- a/gemfiles/ruby_3.4_activesupport.gemfile.lock
+++ b/gemfiles/ruby_3.4_activesupport.gemfile.lock
@@ -279,7 +279,6 @@ GEM
       addressable (>= 2.8.0)
       crack (>= 0.3.2)
       hashdiff (>= 0.4.0, < 2.0.0)
-    yard (0.9.36)
     zeitwerk (2.6.16)
 
 PLATFORMS
@@ -329,7 +328,6 @@ DEPENDENCIES
   warning (~> 1)
   webmock (>= 3.10.0)
   webrick!
-  yard (~> 0.9)
 
 BUNDLED WITH
    2.3.26

--- a/gemfiles/ruby_3.4_aws.gemfile
+++ b/gemfiles/ruby_3.4_aws.gemfile
@@ -27,7 +27,6 @@ gem "warning", "~> 1"
 gem "webmock", ">= 3.10.0"
 gem "rexml", ">= 3.2.7"
 gem "webrick", git: "https://github.com/ruby/webrick.git", ref: "0c600e169bd4ae267cb5eeb6197277c848323bbe"
-gem "yard", "~> 0.9"
 gem "rubocop", "~> 1.50.0", require: false
 gem "rubocop-packaging", "~> 0.5.2", require: false
 gem "rubocop-performance", "~> 1.9", require: false

--- a/gemfiles/ruby_3.4_aws.gemfile.lock
+++ b/gemfiles/ruby_3.4_aws.gemfile.lock
@@ -1703,7 +1703,6 @@ GEM
       addressable (>= 2.8.0)
       crack (>= 0.3.2)
       hashdiff (>= 0.4.0, < 2.0.0)
-    yard (0.9.36)
 
 PLATFORMS
   aarch64-linux
@@ -1746,7 +1745,6 @@ DEPENDENCIES
   warning (~> 1)
   webmock (>= 3.10.0)
   webrick!
-  yard (~> 0.9)
 
 BUNDLED WITH
    2.3.26

--- a/gemfiles/ruby_3.4_contrib.gemfile
+++ b/gemfiles/ruby_3.4_contrib.gemfile
@@ -27,7 +27,6 @@ gem "warning", "~> 1"
 gem "webmock", ">= 3.10.0"
 gem "rexml", ">= 3.2.7"
 gem "webrick", git: "https://github.com/ruby/webrick.git", ref: "0c600e169bd4ae267cb5eeb6197277c848323bbe"
-gem "yard", "~> 0.9"
 gem "rubocop", "~> 1.50.0", require: false
 gem "rubocop-packaging", "~> 0.5.2", require: false
 gem "rubocop-performance", "~> 1.9", require: false

--- a/gemfiles/ruby_3.4_contrib.gemfile.lock
+++ b/gemfiles/ruby_3.4_contrib.gemfile.lock
@@ -222,7 +222,6 @@ GEM
       addressable (>= 2.8.0)
       crack (>= 0.3.2)
       hashdiff (>= 0.4.0, < 2.0.0)
-    yard (0.9.36)
 
 PLATFORMS
   aarch64-linux
@@ -274,7 +273,6 @@ DEPENDENCIES
   warning (~> 1)
   webmock (>= 3.10.0)
   webrick!
-  yard (~> 0.9)
 
 BUNDLED WITH
    2.3.26

--- a/gemfiles/ruby_3.4_contrib_old.gemfile
+++ b/gemfiles/ruby_3.4_contrib_old.gemfile
@@ -27,7 +27,6 @@ gem "warning", "~> 1"
 gem "webmock", ">= 3.10.0"
 gem "rexml", ">= 3.2.7"
 gem "webrick", git: "https://github.com/ruby/webrick.git", ref: "0c600e169bd4ae267cb5eeb6197277c848323bbe"
-gem "yard", "~> 0.9"
 gem "rubocop", "~> 1.50.0", require: false
 gem "rubocop-packaging", "~> 0.5.2", require: false
 gem "rubocop-performance", "~> 1.9", require: false

--- a/gemfiles/ruby_3.4_contrib_old.gemfile.lock
+++ b/gemfiles/ruby_3.4_contrib_old.gemfile.lock
@@ -203,7 +203,6 @@ GEM
       addressable (>= 2.8.0)
       crack (>= 0.3.2)
       hashdiff (>= 0.4.0, < 2.0.0)
-    yard (0.9.36)
 
 PLATFORMS
   aarch64-linux
@@ -248,7 +247,6 @@ DEPENDENCIES
   warning (~> 1)
   webmock (>= 3.10.0)
   webrick!
-  yard (~> 0.9)
 
 BUNDLED WITH
    2.3.26

--- a/gemfiles/ruby_3.4_core_old.gemfile
+++ b/gemfiles/ruby_3.4_core_old.gemfile
@@ -27,7 +27,6 @@ gem "warning", "~> 1"
 gem "webmock", ">= 3.10.0"
 gem "rexml", ">= 3.2.7"
 gem "webrick", git: "https://github.com/ruby/webrick.git", ref: "0c600e169bd4ae267cb5eeb6197277c848323bbe"
-gem "yard", "~> 0.9"
 gem "rubocop", "~> 1.50.0", require: false
 gem "rubocop-packaging", "~> 0.5.2", require: false
 gem "rubocop-performance", "~> 1.9", require: false

--- a/gemfiles/ruby_3.4_core_old.gemfile.lock
+++ b/gemfiles/ruby_3.4_core_old.gemfile.lock
@@ -150,7 +150,6 @@ GEM
       addressable (>= 2.8.0)
       crack (>= 0.3.2)
       hashdiff (>= 0.4.0, < 2.0.0)
-    yard (0.9.36)
 
 PLATFORMS
   aarch64-linux
@@ -191,7 +190,6 @@ DEPENDENCIES
   warning (~> 1)
   webmock (>= 3.10.0)
   webrick!
-  yard (~> 0.9)
 
 BUNDLED WITH
    2.3.26

--- a/gemfiles/ruby_3.4_elasticsearch_7.gemfile
+++ b/gemfiles/ruby_3.4_elasticsearch_7.gemfile
@@ -27,7 +27,6 @@ gem "warning", "~> 1"
 gem "webmock", ">= 3.10.0"
 gem "rexml", ">= 3.2.7"
 gem "webrick", git: "https://github.com/ruby/webrick.git", ref: "0c600e169bd4ae267cb5eeb6197277c848323bbe"
-gem "yard", "~> 0.9"
 gem "rubocop", "~> 1.50.0", require: false
 gem "rubocop-packaging", "~> 0.5.2", require: false
 gem "rubocop-performance", "~> 1.9", require: false

--- a/gemfiles/ruby_3.4_elasticsearch_7.gemfile.lock
+++ b/gemfiles/ruby_3.4_elasticsearch_7.gemfile.lock
@@ -168,7 +168,6 @@ GEM
       addressable (>= 2.8.0)
       crack (>= 0.3.2)
       hashdiff (>= 0.4.0, < 2.0.0)
-    yard (0.9.36)
 
 PLATFORMS
   aarch64-linux
@@ -210,7 +209,6 @@ DEPENDENCIES
   warning (~> 1)
   webmock (>= 3.10.0)
   webrick!
-  yard (~> 0.9)
 
 BUNDLED WITH
    2.3.26

--- a/gemfiles/ruby_3.4_elasticsearch_8.gemfile
+++ b/gemfiles/ruby_3.4_elasticsearch_8.gemfile
@@ -27,7 +27,6 @@ gem "warning", "~> 1"
 gem "webmock", ">= 3.10.0"
 gem "rexml", ">= 3.2.7"
 gem "webrick", git: "https://github.com/ruby/webrick.git", ref: "0c600e169bd4ae267cb5eeb6197277c848323bbe"
-gem "yard", "~> 0.9"
 gem "rubocop", "~> 1.50.0", require: false
 gem "rubocop-packaging", "~> 0.5.2", require: false
 gem "rubocop-performance", "~> 1.9", require: false

--- a/gemfiles/ruby_3.4_elasticsearch_8.gemfile.lock
+++ b/gemfiles/ruby_3.4_elasticsearch_8.gemfile.lock
@@ -166,7 +166,6 @@ GEM
       addressable (>= 2.8.0)
       crack (>= 0.3.2)
       hashdiff (>= 0.4.0, < 2.0.0)
-    yard (0.9.36)
 
 PLATFORMS
   aarch64-linux
@@ -208,7 +207,6 @@ DEPENDENCIES
   warning (~> 1)
   webmock (>= 3.10.0)
   webrick!
-  yard (~> 0.9)
 
 BUNDLED WITH
    2.3.26

--- a/gemfiles/ruby_3.4_graphql_1.13.gemfile
+++ b/gemfiles/ruby_3.4_graphql_1.13.gemfile
@@ -27,7 +27,6 @@ gem "warning", "~> 1"
 gem "webmock", ">= 3.10.0"
 gem "rexml", ">= 3.2.7"
 gem "webrick", git: "https://github.com/ruby/webrick.git", ref: "0c600e169bd4ae267cb5eeb6197277c848323bbe"
-gem "yard", "~> 0.9"
 gem "rubocop", "~> 1.50.0", require: false
 gem "rubocop-packaging", "~> 0.5.2", require: false
 gem "rubocop-performance", "~> 1.9", require: false

--- a/gemfiles/ruby_3.4_graphql_1.13.gemfile.lock
+++ b/gemfiles/ruby_3.4_graphql_1.13.gemfile.lock
@@ -292,7 +292,6 @@ GEM
     websocket-driver (0.7.6)
       websocket-extensions (>= 0.1.0)
     websocket-extensions (0.1.5)
-    yard (0.9.36)
     zeitwerk (2.6.16)
 
 PLATFORMS
@@ -339,7 +338,6 @@ DEPENDENCIES
   warning (~> 1)
   webmock (>= 3.10.0)
   webrick!
-  yard (~> 0.9)
 
 BUNDLED WITH
    2.3.26

--- a/gemfiles/ruby_3.4_graphql_2.0.gemfile
+++ b/gemfiles/ruby_3.4_graphql_2.0.gemfile
@@ -27,7 +27,6 @@ gem "warning", "~> 1"
 gem "webmock", ">= 3.10.0"
 gem "rexml", ">= 3.2.7"
 gem "webrick", git: "https://github.com/ruby/webrick.git", ref: "0c600e169bd4ae267cb5eeb6197277c848323bbe"
-gem "yard", "~> 0.9"
 gem "rubocop", "~> 1.50.0", require: false
 gem "rubocop-packaging", "~> 0.5.2", require: false
 gem "rubocop-performance", "~> 1.9", require: false

--- a/gemfiles/ruby_3.4_graphql_2.0.gemfile.lock
+++ b/gemfiles/ruby_3.4_graphql_2.0.gemfile.lock
@@ -292,7 +292,6 @@ GEM
     websocket-driver (0.7.6)
       websocket-extensions (>= 0.1.0)
     websocket-extensions (0.1.5)
-    yard (0.9.36)
     zeitwerk (2.6.16)
 
 PLATFORMS
@@ -339,7 +338,6 @@ DEPENDENCIES
   warning (~> 1)
   webmock (>= 3.10.0)
   webrick!
-  yard (~> 0.9)
 
 BUNDLED WITH
    2.3.26

--- a/gemfiles/ruby_3.4_graphql_2.1.gemfile
+++ b/gemfiles/ruby_3.4_graphql_2.1.gemfile
@@ -27,7 +27,6 @@ gem "warning", "~> 1"
 gem "webmock", ">= 3.10.0"
 gem "rexml", ">= 3.2.7"
 gem "webrick", git: "https://github.com/ruby/webrick.git", ref: "0c600e169bd4ae267cb5eeb6197277c848323bbe"
-gem "yard", "~> 0.9"
 gem "rubocop", "~> 1.50.0", require: false
 gem "rubocop-packaging", "~> 0.5.2", require: false
 gem "rubocop-performance", "~> 1.9", require: false

--- a/gemfiles/ruby_3.4_graphql_2.1.gemfile.lock
+++ b/gemfiles/ruby_3.4_graphql_2.1.gemfile.lock
@@ -292,7 +292,6 @@ GEM
     websocket-driver (0.7.6)
       websocket-extensions (>= 0.1.0)
     websocket-extensions (0.1.5)
-    yard (0.9.36)
     zeitwerk (2.6.16)
 
 PLATFORMS
@@ -339,7 +338,6 @@ DEPENDENCIES
   warning (~> 1)
   webmock (>= 3.10.0)
   webrick!
-  yard (~> 0.9)
 
 BUNDLED WITH
    2.3.26

--- a/gemfiles/ruby_3.4_graphql_2.2.gemfile
+++ b/gemfiles/ruby_3.4_graphql_2.2.gemfile
@@ -27,7 +27,6 @@ gem "warning", "~> 1"
 gem "webmock", ">= 3.10.0"
 gem "rexml", ">= 3.2.7"
 gem "webrick", git: "https://github.com/ruby/webrick.git", ref: "0c600e169bd4ae267cb5eeb6197277c848323bbe"
-gem "yard", "~> 0.9"
 gem "rubocop", "~> 1.50.0", require: false
 gem "rubocop-packaging", "~> 0.5.2", require: false
 gem "rubocop-performance", "~> 1.9", require: false

--- a/gemfiles/ruby_3.4_graphql_2.2.gemfile.lock
+++ b/gemfiles/ruby_3.4_graphql_2.2.gemfile.lock
@@ -292,7 +292,6 @@ GEM
     websocket-driver (0.7.6)
       websocket-extensions (>= 0.1.0)
     websocket-extensions (0.1.5)
-    yard (0.9.36)
     zeitwerk (2.6.16)
 
 PLATFORMS
@@ -339,7 +338,6 @@ DEPENDENCIES
   warning (~> 1)
   webmock (>= 3.10.0)
   webrick!
-  yard (~> 0.9)
 
 BUNDLED WITH
    2.3.26

--- a/gemfiles/ruby_3.4_graphql_2.3.gemfile
+++ b/gemfiles/ruby_3.4_graphql_2.3.gemfile
@@ -27,7 +27,6 @@ gem "warning", "~> 1"
 gem "webmock", ">= 3.10.0"
 gem "rexml", ">= 3.2.7"
 gem "webrick", git: "https://github.com/ruby/webrick.git", ref: "0c600e169bd4ae267cb5eeb6197277c848323bbe"
-gem "yard", "~> 0.9"
 gem "rubocop", "~> 1.50.0", require: false
 gem "rubocop-packaging", "~> 0.5.2", require: false
 gem "rubocop-performance", "~> 1.9", require: false

--- a/gemfiles/ruby_3.4_graphql_2.3.gemfile.lock
+++ b/gemfiles/ruby_3.4_graphql_2.3.gemfile.lock
@@ -292,7 +292,6 @@ GEM
     websocket-driver (0.7.6)
       websocket-extensions (>= 0.1.0)
     websocket-extensions (0.1.5)
-    yard (0.9.36)
     zeitwerk (2.6.16)
 
 PLATFORMS
@@ -339,7 +338,6 @@ DEPENDENCIES
   warning (~> 1)
   webmock (>= 3.10.0)
   webrick!
-  yard (~> 0.9)
 
 BUNDLED WITH
    2.3.26

--- a/gemfiles/ruby_3.4_http.gemfile
+++ b/gemfiles/ruby_3.4_http.gemfile
@@ -27,7 +27,6 @@ gem "warning", "~> 1"
 gem "webmock", ">= 3.10.0"
 gem "rexml", ">= 3.2.7"
 gem "webrick", git: "https://github.com/ruby/webrick.git", ref: "0c600e169bd4ae267cb5eeb6197277c848323bbe"
-gem "yard", "~> 0.9"
 gem "rubocop", "~> 1.50.0", require: false
 gem "rubocop-packaging", "~> 0.5.2", require: false
 gem "rubocop-performance", "~> 1.9", require: false

--- a/gemfiles/ruby_3.4_http.gemfile.lock
+++ b/gemfiles/ruby_3.4_http.gemfile.lock
@@ -190,7 +190,6 @@ GEM
       addressable (>= 2.8.0)
       crack (>= 0.3.2)
       hashdiff (>= 0.4.0, < 2.0.0)
-    yard (0.9.36)
 
 PLATFORMS
   aarch64-linux
@@ -238,7 +237,6 @@ DEPENDENCIES
   warning (~> 1)
   webmock (>= 3.10.0)
   webrick!
-  yard (~> 0.9)
 
 BUNDLED WITH
    2.3.26

--- a/gemfiles/ruby_3.4_opensearch_2.gemfile
+++ b/gemfiles/ruby_3.4_opensearch_2.gemfile
@@ -27,7 +27,6 @@ gem "warning", "~> 1"
 gem "webmock", ">= 3.10.0"
 gem "rexml", ">= 3.2.7"
 gem "webrick", git: "https://github.com/ruby/webrick.git", ref: "0c600e169bd4ae267cb5eeb6197277c848323bbe"
-gem "yard", "~> 0.9"
 gem "rubocop", "~> 1.50.0", require: false
 gem "rubocop-packaging", "~> 0.5.2", require: false
 gem "rubocop-performance", "~> 1.9", require: false

--- a/gemfiles/ruby_3.4_opensearch_2.gemfile.lock
+++ b/gemfiles/ruby_3.4_opensearch_2.gemfile.lock
@@ -166,7 +166,6 @@ GEM
       addressable (>= 2.8.0)
       crack (>= 0.3.2)
       hashdiff (>= 0.4.0, < 2.0.0)
-    yard (0.9.36)
 
 PLATFORMS
   aarch64-linux
@@ -208,7 +207,6 @@ DEPENDENCIES
   warning (~> 1)
   webmock (>= 3.10.0)
   webrick!
-  yard (~> 0.9)
 
 BUNDLED WITH
    2.3.26

--- a/gemfiles/ruby_3.4_opensearch_3.gemfile
+++ b/gemfiles/ruby_3.4_opensearch_3.gemfile
@@ -27,7 +27,6 @@ gem "warning", "~> 1"
 gem "webmock", ">= 3.10.0"
 gem "rexml", ">= 3.2.7"
 gem "webrick", git: "https://github.com/ruby/webrick.git", ref: "0c600e169bd4ae267cb5eeb6197277c848323bbe"
-gem "yard", "~> 0.9"
 gem "rubocop", "~> 1.50.0", require: false
 gem "rubocop-packaging", "~> 0.5.2", require: false
 gem "rubocop-performance", "~> 1.9", require: false

--- a/gemfiles/ruby_3.4_opensearch_3.gemfile.lock
+++ b/gemfiles/ruby_3.4_opensearch_3.gemfile.lock
@@ -161,7 +161,6 @@ GEM
       addressable (>= 2.8.0)
       crack (>= 0.3.2)
       hashdiff (>= 0.4.0, < 2.0.0)
-    yard (0.9.36)
 
 PLATFORMS
   aarch64-linux
@@ -203,7 +202,6 @@ DEPENDENCIES
   warning (~> 1)
   webmock (>= 3.10.0)
   webrick!
-  yard (~> 0.9)
 
 BUNDLED WITH
    2.3.26

--- a/gemfiles/ruby_3.4_opentelemetry.gemfile
+++ b/gemfiles/ruby_3.4_opentelemetry.gemfile
@@ -27,7 +27,6 @@ gem "warning", "~> 1"
 gem "webmock", ">= 3.10.0"
 gem "rexml", ">= 3.2.7"
 gem "webrick", git: "https://github.com/ruby/webrick.git", ref: "0c600e169bd4ae267cb5eeb6197277c848323bbe"
-gem "yard", "~> 0.9"
 gem "rubocop", "~> 1.50.0", require: false
 gem "rubocop-packaging", "~> 0.5.2", require: false
 gem "rubocop-performance", "~> 1.9", require: false

--- a/gemfiles/ruby_3.4_opentelemetry.gemfile.lock
+++ b/gemfiles/ruby_3.4_opentelemetry.gemfile.lock
@@ -162,7 +162,6 @@ GEM
       addressable (>= 2.8.0)
       crack (>= 0.3.2)
       hashdiff (>= 0.4.0, < 2.0.0)
-    yard (0.9.36)
 
 PLATFORMS
   aarch64-linux
@@ -204,7 +203,6 @@ DEPENDENCIES
   warning (~> 1)
   webmock (>= 3.10.0)
   webrick!
-  yard (~> 0.9)
 
 BUNDLED WITH
    2.3.26

--- a/gemfiles/ruby_3.4_rack_2.gemfile
+++ b/gemfiles/ruby_3.4_rack_2.gemfile
@@ -27,7 +27,6 @@ gem "warning", "~> 1"
 gem "webmock", ">= 3.10.0"
 gem "rexml", ">= 3.2.7"
 gem "webrick", git: "https://github.com/ruby/webrick.git", ref: "0c600e169bd4ae267cb5eeb6197277c848323bbe"
-gem "yard", "~> 0.9"
 gem "rubocop", "~> 1.50.0", require: false
 gem "rubocop-packaging", "~> 0.5.2", require: false
 gem "rubocop-performance", "~> 1.9", require: false

--- a/gemfiles/ruby_3.4_rack_2.gemfile.lock
+++ b/gemfiles/ruby_3.4_rack_2.gemfile.lock
@@ -155,7 +155,6 @@ GEM
       addressable (>= 2.8.0)
       crack (>= 0.3.2)
       hashdiff (>= 0.4.0, < 2.0.0)
-    yard (0.9.36)
 
 PLATFORMS
   aarch64-linux
@@ -199,7 +198,6 @@ DEPENDENCIES
   warning (~> 1)
   webmock (>= 3.10.0)
   webrick!
-  yard (~> 0.9)
 
 BUNDLED WITH
    2.3.26

--- a/gemfiles/ruby_3.4_rack_3.gemfile
+++ b/gemfiles/ruby_3.4_rack_3.gemfile
@@ -27,7 +27,6 @@ gem "warning", "~> 1"
 gem "webmock", ">= 3.10.0"
 gem "rexml", ">= 3.2.7"
 gem "webrick", git: "https://github.com/ruby/webrick.git", ref: "0c600e169bd4ae267cb5eeb6197277c848323bbe"
-gem "yard", "~> 0.9"
 gem "rubocop", "~> 1.50.0", require: false
 gem "rubocop-packaging", "~> 0.5.2", require: false
 gem "rubocop-performance", "~> 1.9", require: false

--- a/gemfiles/ruby_3.4_rack_3.gemfile.lock
+++ b/gemfiles/ruby_3.4_rack_3.gemfile.lock
@@ -155,7 +155,6 @@ GEM
       addressable (>= 2.8.0)
       crack (>= 0.3.2)
       hashdiff (>= 0.4.0, < 2.0.0)
-    yard (0.9.36)
 
 PLATFORMS
   aarch64-linux
@@ -199,7 +198,6 @@ DEPENDENCIES
   warning (~> 1)
   webmock (>= 3.10.0)
   webrick!
-  yard (~> 0.9)
 
 BUNDLED WITH
    2.3.26

--- a/gemfiles/ruby_3.4_rails61_mysql2.gemfile
+++ b/gemfiles/ruby_3.4_rails61_mysql2.gemfile
@@ -27,7 +27,6 @@ gem "warning", "~> 1"
 gem "webmock", ">= 3.10.0"
 gem "rexml", ">= 3.2.7"
 gem "webrick", git: "https://github.com/ruby/webrick.git", ref: "0c600e169bd4ae267cb5eeb6197277c848323bbe"
-gem "yard", "~> 0.9"
 gem "rubocop", "~> 1.50.0", require: false
 gem "rubocop-packaging", "~> 0.5.2", require: false
 gem "rubocop-performance", "~> 1.9", require: false

--- a/gemfiles/ruby_3.4_rails61_mysql2.gemfile.lock
+++ b/gemfiles/ruby_3.4_rails61_mysql2.gemfile.lock
@@ -290,7 +290,6 @@ GEM
     websocket-driver (0.7.6)
       websocket-extensions (>= 0.1.0)
     websocket-extensions (0.1.5)
-    yard (0.9.36)
     zeitwerk (2.6.16)
 
 PLATFORMS
@@ -337,7 +336,6 @@ DEPENDENCIES
   warning (~> 1)
   webmock (>= 3.10.0)
   webrick!
-  yard (~> 0.9)
 
 BUNDLED WITH
    2.3.26

--- a/gemfiles/ruby_3.4_rails61_postgres.gemfile
+++ b/gemfiles/ruby_3.4_rails61_postgres.gemfile
@@ -27,7 +27,6 @@ gem "warning", "~> 1"
 gem "webmock", ">= 3.10.0"
 gem "rexml", ">= 3.2.7"
 gem "webrick", git: "https://github.com/ruby/webrick.git", ref: "0c600e169bd4ae267cb5eeb6197277c848323bbe"
-gem "yard", "~> 0.9"
 gem "rubocop", "~> 1.50.0", require: false
 gem "rubocop-packaging", "~> 0.5.2", require: false
 gem "rubocop-performance", "~> 1.9", require: false

--- a/gemfiles/ruby_3.4_rails61_postgres.gemfile.lock
+++ b/gemfiles/ruby_3.4_rails61_postgres.gemfile.lock
@@ -290,7 +290,6 @@ GEM
     websocket-driver (0.7.6)
       websocket-extensions (>= 0.1.0)
     websocket-extensions (0.1.5)
-    yard (0.9.36)
     zeitwerk (2.6.16)
 
 PLATFORMS
@@ -337,7 +336,6 @@ DEPENDENCIES
   warning (~> 1)
   webmock (>= 3.10.0)
   webrick!
-  yard (~> 0.9)
 
 BUNDLED WITH
    2.3.26

--- a/gemfiles/ruby_3.4_rails61_postgres_redis.gemfile
+++ b/gemfiles/ruby_3.4_rails61_postgres_redis.gemfile
@@ -27,7 +27,6 @@ gem "warning", "~> 1"
 gem "webmock", ">= 3.10.0"
 gem "rexml", ">= 3.2.7"
 gem "webrick", git: "https://github.com/ruby/webrick.git", ref: "0c600e169bd4ae267cb5eeb6197277c848323bbe"
-gem "yard", "~> 0.9"
 gem "rubocop", "~> 1.50.0", require: false
 gem "rubocop-packaging", "~> 0.5.2", require: false
 gem "rubocop-performance", "~> 1.9", require: false

--- a/gemfiles/ruby_3.4_rails61_postgres_redis.gemfile.lock
+++ b/gemfiles/ruby_3.4_rails61_postgres_redis.gemfile.lock
@@ -291,7 +291,6 @@ GEM
     websocket-driver (0.7.6)
       websocket-extensions (>= 0.1.0)
     websocket-extensions (0.1.5)
-    yard (0.9.36)
     zeitwerk (2.6.16)
 
 PLATFORMS
@@ -339,7 +338,6 @@ DEPENDENCIES
   warning (~> 1)
   webmock (>= 3.10.0)
   webrick!
-  yard (~> 0.9)
 
 BUNDLED WITH
    2.3.26

--- a/gemfiles/ruby_3.4_rails61_postgres_sidekiq.gemfile
+++ b/gemfiles/ruby_3.4_rails61_postgres_sidekiq.gemfile
@@ -27,7 +27,6 @@ gem "warning", "~> 1"
 gem "webmock", ">= 3.10.0"
 gem "rexml", ">= 3.2.7"
 gem "webrick", git: "https://github.com/ruby/webrick.git", ref: "0c600e169bd4ae267cb5eeb6197277c848323bbe"
-gem "yard", "~> 0.9"
 gem "rubocop", "~> 1.50.0", require: false
 gem "rubocop-packaging", "~> 0.5.2", require: false
 gem "rubocop-performance", "~> 1.9", require: false

--- a/gemfiles/ruby_3.4_rails61_postgres_sidekiq.gemfile.lock
+++ b/gemfiles/ruby_3.4_rails61_postgres_sidekiq.gemfile.lock
@@ -304,7 +304,6 @@ GEM
     websocket-driver (0.7.6)
       websocket-extensions (>= 0.1.0)
     websocket-extensions (0.1.5)
-    yard (0.9.36)
     zeitwerk (2.6.16)
 
 PLATFORMS
@@ -353,7 +352,6 @@ DEPENDENCIES
   warning (~> 1)
   webmock (>= 3.10.0)
   webrick!
-  yard (~> 0.9)
 
 BUNDLED WITH
    2.3.26

--- a/gemfiles/ruby_3.4_rails61_semantic_logger.gemfile
+++ b/gemfiles/ruby_3.4_rails61_semantic_logger.gemfile
@@ -27,7 +27,6 @@ gem "warning", "~> 1"
 gem "webmock", ">= 3.10.0"
 gem "rexml", ">= 3.2.7"
 gem "webrick", git: "https://github.com/ruby/webrick.git", ref: "0c600e169bd4ae267cb5eeb6197277c848323bbe"
-gem "yard", "~> 0.9"
 gem "rubocop", "~> 1.50.0", require: false
 gem "rubocop-packaging", "~> 0.5.2", require: false
 gem "rubocop-performance", "~> 1.9", require: false

--- a/gemfiles/ruby_3.4_rails61_semantic_logger.gemfile.lock
+++ b/gemfiles/ruby_3.4_rails61_semantic_logger.gemfile.lock
@@ -289,7 +289,6 @@ GEM
     websocket-driver (0.7.6)
       websocket-extensions (>= 0.1.0)
     websocket-extensions (0.1.5)
-    yard (0.9.36)
     zeitwerk (2.6.16)
 
 PLATFORMS
@@ -336,7 +335,6 @@ DEPENDENCIES
   warning (~> 1)
   webmock (>= 3.10.0)
   webrick!
-  yard (~> 0.9)
 
 BUNDLED WITH
    2.3.26

--- a/gemfiles/ruby_3.4_rails61_trilogy.gemfile
+++ b/gemfiles/ruby_3.4_rails61_trilogy.gemfile
@@ -27,7 +27,6 @@ gem "warning", "~> 1"
 gem "webmock", ">= 3.10.0"
 gem "rexml", ">= 3.2.7"
 gem "webrick", git: "https://github.com/ruby/webrick.git", ref: "0c600e169bd4ae267cb5eeb6197277c848323bbe"
-gem "yard", "~> 0.9"
 gem "rubocop", "~> 1.50.0", require: false
 gem "rubocop-packaging", "~> 0.5.2", require: false
 gem "rubocop-performance", "~> 1.9", require: false

--- a/gemfiles/ruby_3.4_rails61_trilogy.gemfile.lock
+++ b/gemfiles/ruby_3.4_rails61_trilogy.gemfile.lock
@@ -293,7 +293,6 @@ GEM
     websocket-driver (0.7.6)
       websocket-extensions (>= 0.1.0)
     websocket-extensions (0.1.5)
-    yard (0.9.36)
     zeitwerk (2.6.16)
 
 PLATFORMS
@@ -341,7 +340,6 @@ DEPENDENCIES
   warning (~> 1)
   webmock (>= 3.10.0)
   webrick!
-  yard (~> 0.9)
 
 BUNDLED WITH
    2.3.26

--- a/gemfiles/ruby_3.4_redis_3.gemfile
+++ b/gemfiles/ruby_3.4_redis_3.gemfile
@@ -27,7 +27,6 @@ gem "warning", "~> 1"
 gem "webmock", ">= 3.10.0"
 gem "rexml", ">= 3.2.7"
 gem "webrick", git: "https://github.com/ruby/webrick.git", ref: "0c600e169bd4ae267cb5eeb6197277c848323bbe"
-gem "yard", "~> 0.9"
 gem "rubocop", "~> 1.50.0", require: false
 gem "rubocop-packaging", "~> 0.5.2", require: false
 gem "rubocop-performance", "~> 1.9", require: false

--- a/gemfiles/ruby_3.4_redis_3.gemfile.lock
+++ b/gemfiles/ruby_3.4_redis_3.gemfile.lock
@@ -151,7 +151,6 @@ GEM
       addressable (>= 2.8.0)
       crack (>= 0.3.2)
       hashdiff (>= 0.4.0, < 2.0.0)
-    yard (0.9.36)
 
 PLATFORMS
   aarch64-linux
@@ -193,7 +192,6 @@ DEPENDENCIES
   warning (~> 1)
   webmock (>= 3.10.0)
   webrick!
-  yard (~> 0.9)
 
 BUNDLED WITH
    2.3.26

--- a/gemfiles/ruby_3.4_redis_4.gemfile
+++ b/gemfiles/ruby_3.4_redis_4.gemfile
@@ -27,7 +27,6 @@ gem "warning", "~> 1"
 gem "webmock", ">= 3.10.0"
 gem "rexml", ">= 3.2.7"
 gem "webrick", git: "https://github.com/ruby/webrick.git", ref: "0c600e169bd4ae267cb5eeb6197277c848323bbe"
-gem "yard", "~> 0.9"
 gem "rubocop", "~> 1.50.0", require: false
 gem "rubocop-packaging", "~> 0.5.2", require: false
 gem "rubocop-performance", "~> 1.9", require: false

--- a/gemfiles/ruby_3.4_redis_4.gemfile.lock
+++ b/gemfiles/ruby_3.4_redis_4.gemfile.lock
@@ -151,7 +151,6 @@ GEM
       addressable (>= 2.8.0)
       crack (>= 0.3.2)
       hashdiff (>= 0.4.0, < 2.0.0)
-    yard (0.9.36)
 
 PLATFORMS
   aarch64-linux
@@ -193,7 +192,6 @@ DEPENDENCIES
   warning (~> 1)
   webmock (>= 3.10.0)
   webrick!
-  yard (~> 0.9)
 
 BUNDLED WITH
    2.3.26

--- a/gemfiles/ruby_3.4_redis_5.gemfile
+++ b/gemfiles/ruby_3.4_redis_5.gemfile
@@ -27,7 +27,6 @@ gem "warning", "~> 1"
 gem "webmock", ">= 3.10.0"
 gem "rexml", ">= 3.2.7"
 gem "webrick", git: "https://github.com/ruby/webrick.git", ref: "0c600e169bd4ae267cb5eeb6197277c848323bbe"
-gem "yard", "~> 0.9"
 gem "rubocop", "~> 1.50.0", require: false
 gem "rubocop-packaging", "~> 0.5.2", require: false
 gem "rubocop-performance", "~> 1.9", require: false

--- a/gemfiles/ruby_3.4_redis_5.gemfile.lock
+++ b/gemfiles/ruby_3.4_redis_5.gemfile.lock
@@ -155,7 +155,6 @@ GEM
       addressable (>= 2.8.0)
       crack (>= 0.3.2)
       hashdiff (>= 0.4.0, < 2.0.0)
-    yard (0.9.36)
 
 PLATFORMS
   aarch64-linux
@@ -197,7 +196,6 @@ DEPENDENCIES
   warning (~> 1)
   webmock (>= 3.10.0)
   webrick!
-  yard (~> 0.9)
 
 BUNDLED WITH
    2.3.26

--- a/gemfiles/ruby_3.4_relational_db.gemfile
+++ b/gemfiles/ruby_3.4_relational_db.gemfile
@@ -27,7 +27,6 @@ gem "warning", "~> 1"
 gem "webmock", ">= 3.10.0"
 gem "rexml", ">= 3.2.7"
 gem "webrick", git: "https://github.com/ruby/webrick.git", ref: "0c600e169bd4ae267cb5eeb6197277c848323bbe"
-gem "yard", "~> 0.9"
 gem "rubocop", "~> 1.50.0", require: false
 gem "rubocop-packaging", "~> 0.5.2", require: false
 gem "rubocop-performance", "~> 1.9", require: false

--- a/gemfiles/ruby_3.4_relational_db.gemfile.lock
+++ b/gemfiles/ruby_3.4_relational_db.gemfile.lock
@@ -190,7 +190,6 @@ GEM
       addressable (>= 2.8.0)
       crack (>= 0.3.2)
       hashdiff (>= 0.4.0, < 2.0.0)
-    yard (0.9.36)
 
 PLATFORMS
   aarch64-linux
@@ -240,7 +239,6 @@ DEPENDENCIES
   warning (~> 1)
   webmock (>= 3.10.0)
   webrick!
-  yard (~> 0.9)
 
 BUNDLED WITH
    2.3.26

--- a/gemfiles/ruby_3.4_resque2_redis3.gemfile
+++ b/gemfiles/ruby_3.4_resque2_redis3.gemfile
@@ -27,7 +27,6 @@ gem "warning", "~> 1"
 gem "webmock", ">= 3.10.0"
 gem "rexml", ">= 3.2.7"
 gem "webrick", git: "https://github.com/ruby/webrick.git", ref: "0c600e169bd4ae267cb5eeb6197277c848323bbe"
-gem "yard", "~> 0.9"
 gem "rubocop", "~> 1.50.0", require: false
 gem "rubocop-packaging", "~> 0.5.2", require: false
 gem "rubocop-performance", "~> 1.9", require: false

--- a/gemfiles/ruby_3.4_resque2_redis3.gemfile.lock
+++ b/gemfiles/ruby_3.4_resque2_redis3.gemfile.lock
@@ -177,7 +177,6 @@ GEM
       addressable (>= 2.8.0)
       crack (>= 0.3.2)
       hashdiff (>= 0.4.0, < 2.0.0)
-    yard (0.9.36)
 
 PLATFORMS
   aarch64-linux
@@ -220,7 +219,6 @@ DEPENDENCIES
   warning (~> 1)
   webmock (>= 3.10.0)
   webrick!
-  yard (~> 0.9)
 
 BUNDLED WITH
    2.3.26

--- a/gemfiles/ruby_3.4_resque2_redis4.gemfile
+++ b/gemfiles/ruby_3.4_resque2_redis4.gemfile
@@ -27,7 +27,6 @@ gem "warning", "~> 1"
 gem "webmock", ">= 3.10.0"
 gem "rexml", ">= 3.2.7"
 gem "webrick", git: "https://github.com/ruby/webrick.git", ref: "0c600e169bd4ae267cb5eeb6197277c848323bbe"
-gem "yard", "~> 0.9"
 gem "rubocop", "~> 1.50.0", require: false
 gem "rubocop-packaging", "~> 0.5.2", require: false
 gem "rubocop-performance", "~> 1.9", require: false

--- a/gemfiles/ruby_3.4_resque2_redis4.gemfile.lock
+++ b/gemfiles/ruby_3.4_resque2_redis4.gemfile.lock
@@ -181,7 +181,6 @@ GEM
       addressable (>= 2.8.0)
       crack (>= 0.3.2)
       hashdiff (>= 0.4.0, < 2.0.0)
-    yard (0.9.36)
 
 PLATFORMS
   aarch64-linux
@@ -224,7 +223,6 @@ DEPENDENCIES
   warning (~> 1)
   webmock (>= 3.10.0)
   webrick!
-  yard (~> 0.9)
 
 BUNDLED WITH
    2.3.26

--- a/gemfiles/ruby_3.4_sinatra_2.gemfile
+++ b/gemfiles/ruby_3.4_sinatra_2.gemfile
@@ -27,7 +27,6 @@ gem "warning", "~> 1"
 gem "webmock", ">= 3.10.0"
 gem "rexml", ">= 3.2.7"
 gem "webrick", git: "https://github.com/ruby/webrick.git", ref: "0c600e169bd4ae267cb5eeb6197277c848323bbe"
-gem "yard", "~> 0.9"
 gem "rubocop", "~> 1.50.0", require: false
 gem "rubocop-packaging", "~> 0.5.2", require: false
 gem "rubocop-performance", "~> 1.9", require: false

--- a/gemfiles/ruby_3.4_sinatra_2.gemfile.lock
+++ b/gemfiles/ruby_3.4_sinatra_2.gemfile.lock
@@ -166,7 +166,6 @@ GEM
       addressable (>= 2.8.0)
       crack (>= 0.3.2)
       hashdiff (>= 0.4.0, < 2.0.0)
-    yard (0.9.36)
 
 PLATFORMS
   aarch64-linux
@@ -210,7 +209,6 @@ DEPENDENCIES
   warning (~> 1)
   webmock (>= 3.10.0)
   webrick!
-  yard (~> 0.9)
 
 BUNDLED WITH
    2.3.26

--- a/gemfiles/ruby_3.4_sinatra_3.gemfile
+++ b/gemfiles/ruby_3.4_sinatra_3.gemfile
@@ -27,7 +27,6 @@ gem "warning", "~> 1"
 gem "webmock", ">= 3.10.0"
 gem "rexml", ">= 3.2.7"
 gem "webrick", git: "https://github.com/ruby/webrick.git", ref: "0c600e169bd4ae267cb5eeb6197277c848323bbe"
-gem "yard", "~> 0.9"
 gem "rubocop", "~> 1.50.0", require: false
 gem "rubocop-packaging", "~> 0.5.2", require: false
 gem "rubocop-performance", "~> 1.9", require: false

--- a/gemfiles/ruby_3.4_sinatra_3.gemfile.lock
+++ b/gemfiles/ruby_3.4_sinatra_3.gemfile.lock
@@ -168,7 +168,6 @@ GEM
       addressable (>= 2.8.0)
       crack (>= 0.3.2)
       hashdiff (>= 0.4.0, < 2.0.0)
-    yard (0.9.36)
 
 PLATFORMS
   aarch64-linux
@@ -212,7 +211,6 @@ DEPENDENCIES
   warning (~> 1)
   webmock (>= 3.10.0)
   webrick!
-  yard (~> 0.9)
 
 BUNDLED WITH
    2.3.26

--- a/gemfiles/ruby_3.4_sinatra_4.gemfile
+++ b/gemfiles/ruby_3.4_sinatra_4.gemfile
@@ -27,7 +27,6 @@ gem "warning", "~> 1"
 gem "webmock", ">= 3.10.0"
 gem "rexml", ">= 3.2.7"
 gem "webrick", git: "https://github.com/ruby/webrick.git", ref: "0c600e169bd4ae267cb5eeb6197277c848323bbe"
-gem "yard", "~> 0.9"
 gem "rubocop", "~> 1.50.0", require: false
 gem "rubocop-packaging", "~> 0.5.2", require: false
 gem "rubocop-performance", "~> 1.9", require: false

--- a/gemfiles/ruby_3.4_sinatra_4.gemfile.lock
+++ b/gemfiles/ruby_3.4_sinatra_4.gemfile.lock
@@ -171,7 +171,6 @@ GEM
       addressable (>= 2.8.0)
       crack (>= 0.3.2)
       hashdiff (>= 0.4.0, < 2.0.0)
-    yard (0.9.36)
 
 PLATFORMS
   aarch64-linux
@@ -215,7 +214,6 @@ DEPENDENCIES
   warning (~> 1)
   webmock (>= 3.10.0)
   webrick!
-  yard (~> 0.9)
 
 BUNDLED WITH
    2.3.26

--- a/gemfiles/ruby_3.4_stripe_10.gemfile
+++ b/gemfiles/ruby_3.4_stripe_10.gemfile
@@ -27,7 +27,6 @@ gem "warning", "~> 1"
 gem "webmock", ">= 3.10.0"
 gem "rexml", ">= 3.2.7"
 gem "webrick", git: "https://github.com/ruby/webrick.git", ref: "0c600e169bd4ae267cb5eeb6197277c848323bbe"
-gem "yard", "~> 0.9"
 gem "rubocop", "~> 1.50.0", require: false
 gem "rubocop-packaging", "~> 0.5.2", require: false
 gem "rubocop-performance", "~> 1.9", require: false

--- a/gemfiles/ruby_3.4_stripe_10.gemfile.lock
+++ b/gemfiles/ruby_3.4_stripe_10.gemfile.lock
@@ -151,7 +151,6 @@ GEM
       addressable (>= 2.8.0)
       crack (>= 0.3.2)
       hashdiff (>= 0.4.0, < 2.0.0)
-    yard (0.9.36)
 
 PLATFORMS
   aarch64-linux
@@ -193,7 +192,6 @@ DEPENDENCIES
   warning (~> 1)
   webmock (>= 3.10.0)
   webrick!
-  yard (~> 0.9)
 
 BUNDLED WITH
    2.3.26

--- a/gemfiles/ruby_3.4_stripe_11.gemfile
+++ b/gemfiles/ruby_3.4_stripe_11.gemfile
@@ -27,7 +27,6 @@ gem "warning", "~> 1"
 gem "webmock", ">= 3.10.0"
 gem "rexml", ">= 3.2.7"
 gem "webrick", git: "https://github.com/ruby/webrick.git", ref: "0c600e169bd4ae267cb5eeb6197277c848323bbe"
-gem "yard", "~> 0.9"
 gem "rubocop", "~> 1.50.0", require: false
 gem "rubocop-packaging", "~> 0.5.2", require: false
 gem "rubocop-performance", "~> 1.9", require: false

--- a/gemfiles/ruby_3.4_stripe_11.gemfile.lock
+++ b/gemfiles/ruby_3.4_stripe_11.gemfile.lock
@@ -151,7 +151,6 @@ GEM
       addressable (>= 2.8.0)
       crack (>= 0.3.2)
       hashdiff (>= 0.4.0, < 2.0.0)
-    yard (0.9.36)
 
 PLATFORMS
   aarch64-linux
@@ -193,7 +192,6 @@ DEPENDENCIES
   warning (~> 1)
   webmock (>= 3.10.0)
   webrick!
-  yard (~> 0.9)
 
 BUNDLED WITH
    2.3.26

--- a/gemfiles/ruby_3.4_stripe_12.gemfile
+++ b/gemfiles/ruby_3.4_stripe_12.gemfile
@@ -27,7 +27,6 @@ gem "warning", "~> 1"
 gem "webmock", ">= 3.10.0"
 gem "rexml", ">= 3.2.7"
 gem "webrick", git: "https://github.com/ruby/webrick.git", ref: "0c600e169bd4ae267cb5eeb6197277c848323bbe"
-gem "yard", "~> 0.9"
 gem "rubocop", "~> 1.50.0", require: false
 gem "rubocop-packaging", "~> 0.5.2", require: false
 gem "rubocop-performance", "~> 1.9", require: false

--- a/gemfiles/ruby_3.4_stripe_12.gemfile.lock
+++ b/gemfiles/ruby_3.4_stripe_12.gemfile.lock
@@ -151,7 +151,6 @@ GEM
       addressable (>= 2.8.0)
       crack (>= 0.3.2)
       hashdiff (>= 0.4.0, < 2.0.0)
-    yard (0.9.36)
 
 PLATFORMS
   aarch64-linux
@@ -193,7 +192,6 @@ DEPENDENCIES
   warning (~> 1)
   webmock (>= 3.10.0)
   webrick!
-  yard (~> 0.9)
 
 BUNDLED WITH
    2.3.26

--- a/gemfiles/ruby_3.4_stripe_7.gemfile
+++ b/gemfiles/ruby_3.4_stripe_7.gemfile
@@ -27,7 +27,6 @@ gem "warning", "~> 1"
 gem "webmock", ">= 3.10.0"
 gem "rexml", ">= 3.2.7"
 gem "webrick", git: "https://github.com/ruby/webrick.git", ref: "0c600e169bd4ae267cb5eeb6197277c848323bbe"
-gem "yard", "~> 0.9"
 gem "rubocop", "~> 1.50.0", require: false
 gem "rubocop-packaging", "~> 0.5.2", require: false
 gem "rubocop-performance", "~> 1.9", require: false

--- a/gemfiles/ruby_3.4_stripe_7.gemfile.lock
+++ b/gemfiles/ruby_3.4_stripe_7.gemfile.lock
@@ -151,7 +151,6 @@ GEM
       addressable (>= 2.8.0)
       crack (>= 0.3.2)
       hashdiff (>= 0.4.0, < 2.0.0)
-    yard (0.9.36)
 
 PLATFORMS
   aarch64-linux
@@ -193,7 +192,6 @@ DEPENDENCIES
   warning (~> 1)
   webmock (>= 3.10.0)
   webrick!
-  yard (~> 0.9)
 
 BUNDLED WITH
    2.3.26

--- a/gemfiles/ruby_3.4_stripe_8.gemfile
+++ b/gemfiles/ruby_3.4_stripe_8.gemfile
@@ -27,7 +27,6 @@ gem "warning", "~> 1"
 gem "webmock", ">= 3.10.0"
 gem "rexml", ">= 3.2.7"
 gem "webrick", git: "https://github.com/ruby/webrick.git", ref: "0c600e169bd4ae267cb5eeb6197277c848323bbe"
-gem "yard", "~> 0.9"
 gem "rubocop", "~> 1.50.0", require: false
 gem "rubocop-packaging", "~> 0.5.2", require: false
 gem "rubocop-performance", "~> 1.9", require: false

--- a/gemfiles/ruby_3.4_stripe_8.gemfile.lock
+++ b/gemfiles/ruby_3.4_stripe_8.gemfile.lock
@@ -151,7 +151,6 @@ GEM
       addressable (>= 2.8.0)
       crack (>= 0.3.2)
       hashdiff (>= 0.4.0, < 2.0.0)
-    yard (0.9.36)
 
 PLATFORMS
   aarch64-linux
@@ -193,7 +192,6 @@ DEPENDENCIES
   warning (~> 1)
   webmock (>= 3.10.0)
   webrick!
-  yard (~> 0.9)
 
 BUNDLED WITH
    2.3.26

--- a/gemfiles/ruby_3.4_stripe_9.gemfile
+++ b/gemfiles/ruby_3.4_stripe_9.gemfile
@@ -27,7 +27,6 @@ gem "warning", "~> 1"
 gem "webmock", ">= 3.10.0"
 gem "rexml", ">= 3.2.7"
 gem "webrick", git: "https://github.com/ruby/webrick.git", ref: "0c600e169bd4ae267cb5eeb6197277c848323bbe"
-gem "yard", "~> 0.9"
 gem "rubocop", "~> 1.50.0", require: false
 gem "rubocop-packaging", "~> 0.5.2", require: false
 gem "rubocop-performance", "~> 1.9", require: false

--- a/gemfiles/ruby_3.4_stripe_9.gemfile.lock
+++ b/gemfiles/ruby_3.4_stripe_9.gemfile.lock
@@ -151,7 +151,6 @@ GEM
       addressable (>= 2.8.0)
       crack (>= 0.3.2)
       hashdiff (>= 0.4.0, < 2.0.0)
-    yard (0.9.36)
 
 PLATFORMS
   aarch64-linux
@@ -193,7 +192,6 @@ DEPENDENCIES
   warning (~> 1)
   webmock (>= 3.10.0)
   webrick!
-  yard (~> 0.9)
 
 BUNDLED WITH
    2.3.26

--- a/spec/datadog/release_gem_spec.rb
+++ b/spec/datadog/release_gem_spec.rb
@@ -57,6 +57,7 @@ RSpec.describe 'gem release process' do
             |gemfiles
             |integration
             |tasks
+            |tools
             |yard
             |vendor/rbs
             |suppressions

--- a/tasks/yard.rake
+++ b/tasks/yard.rake
@@ -1,0 +1,18 @@
+
+if Gem.loaded_specs["yard"]
+  require 'yard'
+else
+  warn "'yard' gem not loaded: skipping tasks..." if Rake.verbose == true
+  return
+end
+
+YARD::Rake::YardocTask.new(:docs) do |t|
+  # Options defined in `.yardopts` are read first, then merged with
+  # options defined here.
+  #
+  # It's recommended to define options in `.yardopts` instead of here,
+  # as `.yardopts` can be read by external YARD tools, like the
+  # hot-reload YARD server `yard server --reload`.
+
+  t.options += ['--title', "datadog #{Datadog::VERSION::STRING} documentation"]
+end

--- a/tools/yard.gemfile
+++ b/tools/yard.gemfile
@@ -1,0 +1,7 @@
+source 'https://rubygems.org'
+
+gemspec path: '..'
+
+gem 'rake'
+gem 'yard'
+gem 'redcarpet'


### PR DESCRIPTION
**What does this PR do?**

The PR fixes the Github action for generating yard doc and uploaded to Github Pages.

It was broken due to: https://github.com/DataDog/dd-trace-rb/pull/3710, which I was trying to reduce the size of gemfile by removing `redcarpet`

To address this: I removed `yard` gem entirely from our Gemfile and migrate to a minimized Gemfile (`yard.gemfile`) under `tools` and updated the Github action with this dependency.