### PR TITLE
DEBUG-2334 make serialize_value of Serializer public and add test cov…

### DIFF
--- a/sig/datadog/di/serializer.rbs
+++ b/sig/datadog/di/serializer.rbs
@@ -9,12 +9,13 @@ module Datadog
 
       attr_reader settings: untyped
 
-      attr_reader redactor: untyped
+      attr_reader redactor: Datadog::DI::Redactor
+      
       def serialize_args: (untyped args, untyped kwargs) -> untyped
       def serialize_vars: (untyped vars) -> untyped
 
       private
-      def serialize_value: (untyped name, untyped value, ?depth: untyped) -> ({ type: untyped, notCapturedReason: "redactedType" } | { type: untyped, notCapturedReason: "redactedIdent" } | untyped)
+      def serialize_value: (untyped value, ?name: String, ?depth: untyped) -> ({ type: untyped, notCapturedReason: "redactedType" } | { type: untyped, notCapturedReason: "redactedIdent" } | untyped)
       def class_name: (untyped cls) -> untyped
     end
   end


### PR DESCRIPTION
…erage


**What does this PR do?**
Make serialize_value public and add some tests for it (simple cases that were under serialize_vars previously + explicit redaction cases).

<!--
Check out the
https://github.com/DataDog/dd-trace-rb/blob/master/docs/DevelopmentGuide.md
for guidance on how to set up your development environment,
run the test suite, write new integrations, and more.
-->

<!-- A brief description of the change being made with this pull request. -->

**Motivation:**
For serializing method return values, we will need to call serialize_value from outside of Serializer and this call will not have a name provided.
<!-- What inspired you to submit this pull request? -->

**Additional Notes:**
<!-- Anything else we should know when reviewing? -->

**How to test the change?**
Unit tests.
<!--
Describe here how the change can be validated.
You are strongly encouraged to provide automated tests for this PR (unit or integration).
If this change cannot be feasibly tested, please explain why,
unless the change does not modify code (e.g. only modifies docs, comments).
-->

Unsure? Have a question? Request a review!
