### PR TITLE
[NO-TICKET] Tweak duration of profiler_sample_serialize benchmark

### DIFF
--- a/benchmarks/profiler_sample_serialize.rb
+++ b/benchmarks/profiler_sample_serialize.rb
@@ -34,7 +34,7 @@ class ProfilerSampleSerializeBenchmark
 
   def run_benchmark
     Benchmark.ips do |x|
-      benchmark_time = VALIDATE_BENCHMARK_MODE ? { time: 0.01, warmup: 0 } : { time: 10, warmup: 2 }
+      benchmark_time = VALIDATE_BENCHMARK_MODE ? { time: 0.01, warmup: 0 } : { time: 60, warmup: 2 }
       x.config(
         **benchmark_time,
       )


### PR DESCRIPTION
**What does this PR do?**

This PR tweaks the default duration of the
`benchmarks/profiler_sample_serialize.rb` benchmark. This duration gets used when we run benchmarks on every PR.

**Motivation:**

We've been seeing quite a bit of variance in the benchmarks from run-to-run which makes it seem like there are regressions/improvements even when nothing of consequence is touched (e.g. PR that changes docs even).

This got better when we adjusted the thresholds used by the benchmarking platform, but I'm still seeing this benchmark in particular show up quite often in a "flaky" way.

I suspect this behavior may be because each step on this benchmark can take ~takes~ more than one second (since it simulates 60 seconds of profiling data) and thus the low number of iterations creates more noise.

I'm hoping that by raising the duration of this benchmark to 1 minute we'll see the run-to-run variation go down.

**Additional Notes:**

N/A

**How to test the change?**

Validate benchmark is running for 1 minute in CI.