### PR TITLE
[PROF-10422] Add GVL profiling as a preview feature

### DIFF
--- a/benchmarks/profiler_gc.rb
+++ b/benchmarks/profiler_gc.rb
@@ -17,9 +17,7 @@ class ProfilerGcBenchmark
       heap_sample_every: 1,
       timeline_enabled: true,
     )
-    @collector = Datadog::Profiling::Collectors::ThreadContext.new(
-      recorder: @recorder, max_frames: 400, tracer: nil, endpoint_collection_enabled: false, timeline_enabled: true
-    )
+    @collector = Datadog::Profiling::Collectors::ThreadContext.for_testing(recorder: @recorder, timeline_enabled: true)
 
     # We take a dummy sample so that the context for the main thread is created, as otherwise the GC profiling methods do
     # not create it (because we don't want to do memory allocations in the middle of GC)

--- a/benchmarks/profiler_memory_sample_serialize.rb
+++ b/benchmarks/profiler_memory_sample_serialize.rb
@@ -30,8 +30,6 @@ def sample_object(recorder, depth = 0)
       METRIC_VALUES,
       [],
       [],
-      400,
-      false
     )
     obj
   else

--- a/benchmarks/profiler_sample_loop_v2.rb
+++ b/benchmarks/profiler_sample_loop_v2.rb
@@ -21,9 +21,7 @@ class ProfilerSampleLoopBenchmark
       heap_sample_every: 1,
       timeline_enabled: false,
     )
-    @collector = Datadog::Profiling::Collectors::ThreadContext.new(
-      recorder: @recorder, max_frames: 400, tracer: nil, endpoint_collection_enabled: false, timeline_enabled: false
-    )
+    @collector = Datadog::Profiling::Collectors::ThreadContext.for_testing(recorder: @recorder)
   end
 
   def thread_with_very_deep_stack(depth: 500)

--- a/benchmarks/profiler_sample_serialize.rb
+++ b/benchmarks/profiler_sample_serialize.rb
@@ -27,9 +27,7 @@ class ProfilerSampleSerializeBenchmark
       heap_sample_every: 1,
       timeline_enabled: timeline_enabled,
     )
-    @collector = Datadog::Profiling::Collectors::ThreadContext.new(
-      recorder: @recorder, max_frames: 400, tracer: nil, endpoint_collection_enabled: false, timeline_enabled: timeline_enabled
-    )
+    @collector = Datadog::Profiling::Collectors::ThreadContext.for_testing(recorder: @recorder, timeline_enabled: timeline_enabled)
   end
 
   def run_benchmark

--- a/docs/ProfilingDevelopment.md
+++ b/docs/ProfilingDevelopment.md
@@ -4,6 +4,8 @@ This file contains development notes specific to the continuous profiler.
 
 For a more practical view of getting started with development of `datadog`, see <DevelopmentGuide.md>.
 
+There's also a `NativeExtentionDesign.md` file in the `ext/datadog_profiling_native_extension` that contains further profiler implementation design notes.
+
 ## Profiling components high-level view
 
 Some of the profiling components referenced below are implemented using C code. As much as possible, that C code is still
@@ -140,3 +142,153 @@ available, from the tracer.
 Note that if a given trace executes too fast, it's possible that the profiler will not contain any samples for that
 specific trace. Nevertheless, the linking still works and is useful, as it allows users to explore what was going on their
 profile at that time, even if they can't filter down to the specific request.
+
+## Tracking of cpu-time and wall-time spent during garbage collection
+
+See comments at the top of `collectors_thread_context.c` for an explanation on how that feature is implemented.
+
+## How GVL profiling works
+
+Profiling the Ruby Global VM Lock (GVL) works by using the [GVL instrumentation API](https://github.com/ruby/ruby/pull/5500).
+
+This API currently only works on Ruby 3.2+, although there were a few changes and refinements on Ruby 3.3+ and as of this writing
+(September 2024) we _only_ support Ruby 3.3+.
+
+These blog posts are good starting points to understand this API:
+
+* https://ivoanjo.me/blog/2022/07/17/tracing-ruby-global-vm-lock/
+* https://ivoanjo.me/blog/2023/02/11/ruby-unexpected-io-vs-cpu-unfairness/
+* https://ivoanjo.me/blog/2023/07/23/understanding-the-ruby-global-vm-lock-by-observing-it/
+
+Below follow some notes on how it works. Note that it's possible we'll forget to update this documentation as the code
+changes, so take the below info as a starting point to understanding how the feature is integrated, rather than an exact spec.
+
+### Getting VM callbacks in `CpuAndWallTimeWorker`
+
+From our side, the magic starts in the `CpuAndWallTimeWorker` class. When GVL profiling is enabled, we ask the VM to tell
+us about two kinds of thread events:
+
+```c
+    if (state->gvl_profiling_enabled) {
+      state->gvl_profiling_hook = rb_internal_thread_add_event_hook(
+        on_gvl_event,
+        (
+          // For now we're only asking for these events, even though there's more
+          // (e.g. check docs or gvl-tracing gem)
+          RUBY_INTERNAL_THREAD_EVENT_READY /* waiting for gvl */ |
+          RUBY_INTERNAL_THREAD_EVENT_RESUMED /* running/runnable */
+        ),
+        NULL
+      );
+    }
+```
+
+As the comments hint at:
+* `RUBY_INTERNAL_THREAD_EVENT_READY` is emitted by the VM when a thread is ready to start running again. E.g. it's now
+waiting for its turn to acquire the GVL. We call this thread "Waiting for GVL" in the profiler code, as well as in the Datadog UX
+* `RUBY_INTERNAL_THREAD_EVENT_RESUMED` is emitted by the VM immediately after a thread has acquired the GVL. It's so
+immediately after that (looking at the VM code) it may not even have done all the cleanup needed after acquisition for the
+thread to start running.
+
+Once one of those events happen, Ruby will tell us by calling our `on_gvl_event` function
+(still in the `CpuAndWallTimeWorker`).
+
+Both events above are (as far as I know) emitted by the thread they are representing. But, we need to be very careful
+about running code in `on_gvl_event` to handle these events:
+
+* `RUBY_INTERNAL_THREAD_EVENT_READY` is emitted while the thread is not holding the GVL, and thus it can be in parallel with
+other things
+* All events are emitted _for all Ractors_, and each Ractor has their own GVL (yes yes, naming, see
+[the talk linked into](https://ivoanjo.me/blog/2023/07/23/understanding-the-ruby-global-vm-lock-by-observing-it/) for a discussion on this)
+* With the Ruby M:N threading, a native thread may play host to multiple Ruby threads so let's not assume too much
+
+All of the above taken together mean that we need to be very careful with what state we mutate or access from `on_gvl_event`, as they
+can be concurrent with other operations in the profiler (including sampling).
+
+(The current implementation is similar to GC profiling, which shares similar constraints and limitations in not being able to sample
+from the VM callbacks and also messing with cpu/wall-time accounting for threads that are GCing.)
+
+The `ThreadContext` collector exposes three APIs for GVL profiling:
+
+* `void thread_context_collector_on_gvl_waiting(VALUE thread)`
+* `bool thread_context_collector_on_gvl_running(VALUE thread)`
+* `VALUE thread_context_collector_sample_after_gvl_running(VALUE self_instance)`
+
+The intuition here is that:
+
+* `on_gvl_waiting` tracks when a thread began Waiting for GVL. It should be called when a thread
+reports `RUBY_INTERNAL_THREAD_EVENT_READY`
+* `on_gvl_running` tracks when a thread acquired the GVL. It should be called when a thread reports
+`RUBY_INTERNAL_THREAD_EVENT_RESUMED`
+* `sample_after_gvl_running` is the one that actually triggers the creation of a sample to represent
+the waiting period. It should be called via the VM postponed job API when `on_gvl_running` returns `true`; e.g. when the
+`ThreadContext` collector reports a sample should be taken.
+
+As far as the `CpuAndWallTimeWorker` cares, the above is all it needs to call in response to VM events. You'll notice
+that `on_gvl_waiting` and `on_gvl_running` don't need or use any of the `CpuAndWallTimeWorker` or `ThreadContext`
+instance state.
+
+The `sample_after_gvl_running` actually does, and that's why it's supposed to be used from a postponed job, which
+ensures there's no concurrency (in our setup it only gets called with the GVL + on the main ractor) and thus we're safe to
+access and mutate state inside it.
+
+### Tracking thread state and sampling in `ThreadContext`
+
+The weirdest piece of this puzzle is done in the `ThreadContext` collector. Because, as mentioned above,
+`on_gvl_waiting` and `on_gvl_running` can get called outside the GVL/in other Ractors, we avoid touching the current
+`ThreadContext` instance state in these methods.
+
+Instead, we ask Ruby to hold the data we need for us using the `rb_internal_thread_specific` API. This API provides
+an extremely low-level and limited thread-local storage mechanism, but one that's thread-safe and thus a good match
+for our needs. (This API is only available on Ruby 3.3+; to support Ruby 3.2 we'll need to figure out an alternative.)
+
+So, here's how this works: the first time the `ThreadContext` collector sees a thread (e.g. when it creates a context
+for it), it uses this API to tag this thread as a thread we want to know about:
+
+```c
+rb_internal_thread_specific_set(thread, per_thread_gvl_waiting_timestamp_key, (void *) GVL_WAITING_ENABLED_EMPTY);
+```
+
+From here on out, `on_gvl_waiting` and `on_gvl_running` know that if a thread has the `per_thread_gvl_waiting_timestamp`
+variable set (to any other value than the default of `NULL`/0), it means this thread is known by the `ThreadContext`
+collector and thus we should record data about it.
+(And threads not in the main Ractor don't get this marker so this is one way we filter them out.)
+
+Could we have stored a pointer to the thread context directly on the thread? Potentially, yes, but we'd need to be
+extremely careful when accessing thread contexts and when cleaning them up. (Maybe we'll evolve in this direction in
+the future?)
+
+With the storage problem solved, here's what happens: the first part is that `on_gvl_waiting` records a timestamp for
+when waiting started in the thread in `per_thread_gvl_waiting_timestamp`.
+
+Then, `on_gvl_running` checks the duration of the waiting (e.g. time between waiting started and current time). This
+is a mechanism for reducing overhead: we'll produce at least two samples for every "Waiting for GVL" event that
+we choose to sample, so we need to be careful not to allow situations with a lot of threads waiting for very brief
+periods to induce too much overhead on the application.
+
+If we decide to sample (duration >= some minimal threshold duration for sampling), we can't sample yet!
+As documented above, `on_gvl_running` is called in response to VM `RUBY_INTERNAL_THREAD_EVENT_RESUMED` events that
+happen right after the thread acquired the GVL but there's still some book-keeping to do. Thus, we don't sample
+from this method, but use the `bool` return to signal the caller when a sample should be taken.
+
+Then, a sample is taken once the caller (`CpuAndWallTimeWorker`) calls into `sample_after_gvl_running`.
+This design is similar to GC profiling, where we also can't sample during GC, and thus we trigger a sample to happen immediately after.
+
+### Representing the Waiting for GVL in `ThreadContext`
+
+As far as sampling goes, we represent a Waiting for GVL as a thread state, similar to other thread states we emit.
+This state is special, as it "overrides" other states, e.g. if a thread was sleeping, but wants to wake up, even
+though the thread is still inside `sleep`, it will have the "Waiting for GVL" state.
+
+Waiting for GVL does not affect the regular flamegraph, only the timeline visualization, as it's a thread state, and
+currently we do not represent thread states in any way on the regular flamegraph.
+
+The timestamp of the beginning of waiting for GVL gets used to create a sample that represents the "Waiting for GVL"
+period. Because there's some unaccounted for cpu and wall-time between the previous sample and the start of a waiting
+period, we also create a sample to account for this.
+
+There's some (lovely?) ASCII art in `handle_gvl_waiting` to explain how we create these two samples.
+
+Once a thread is in the "Waiting for GVL" state, then all regular cpu/wall-time samples triggered by the `CpuAndWallTimeWorker`
+will continue to mark the thread as being in this state, until `on_gvl_running` + `sample_after_gvl_running` happen and
+clear the `per_thread_gvl_waiting_timestamp`, which will make samples revert back to the regular behavior.

--- a/ext/datadog_profiling_native_extension/collectors_cpu_and_wall_time_worker.c
+++ b/ext/datadog_profiling_native_extension/collectors_cpu_and_wall_time_worker.c
@@ -802,8 +802,8 @@ static VALUE release_gvl_and_run_sampling_trigger_loop(VALUE instance) {
     ;
   }
 
-  #ifndef NO_GVL_INSTRUMENTATION
-    if (state->gvl_profiling_enabled) {
+  if (state->gvl_profiling_enabled) {
+    #ifndef NO_GVL_INSTRUMENTATION
       state->gvl_profiling_hook = rb_internal_thread_add_event_hook(
         on_gvl_event,
         (
@@ -814,8 +814,10 @@ static VALUE release_gvl_and_run_sampling_trigger_loop(VALUE instance) {
         ),
         NULL
       );
-    }
-  #endif
+    #else
+      rb_raise(rb_eArgError, "GVL profiling is not supported in this Ruby version");
+    #endif
+  }
 
   // Flag the profiler as running before we release the GVL, in case anyone's waiting to know about it
   rb_funcall(instance, rb_intern("signal_running"), 0);

--- a/ext/datadog_profiling_native_extension/collectors_cpu_and_wall_time_worker.c
+++ b/ext/datadog_profiling_native_extension/collectors_cpu_and_wall_time_worker.c
@@ -228,8 +228,8 @@ static VALUE _native_hold_signals(DDTRACE_UNUSED VALUE self);
 static VALUE _native_resume_signals(DDTRACE_UNUSED VALUE self);
 #ifndef NO_GVL_INSTRUMENTATION
 static void on_gvl_event(rb_event_flag_t event_id, const rb_internal_thread_event_data_t *event_data, DDTRACE_UNUSED void *_unused);
-#endif
 static void after_gvl_running_from_postponed_job(DDTRACE_UNUSED void *_unused);
+#endif
 static VALUE _native_gvl_profiling_hook_active(DDTRACE_UNUSED VALUE self, VALUE instance);
 
 // We're using `on_newobj_event` function with `rb_add_event_hook2`, which requires in its public signature a function
@@ -1298,7 +1298,7 @@ static VALUE _native_resume_signals(DDTRACE_UNUSED VALUE self) {
 #ifndef NO_GVL_INSTRUMENTATION
   static void on_gvl_event(rb_event_flag_t event_id, const rb_internal_thread_event_data_t *event_data, DDTRACE_UNUSED void *_unused) {
     // Be very careful about touching the `state` here or doing anything at all:
-    // This function gets called even without the GVL, and even from background Ractors!
+    // This function gets called without the GVL, and potentially from background Ractors!
     //
     // In fact, the `target_thread` that this event is about may not even be the current thread. (So be careful with thread locals that
     // are not directly tied to the `target_thread` object and the like)

--- a/ext/datadog_profiling_native_extension/collectors_cpu_and_wall_time_worker.c
+++ b/ext/datadog_profiling_native_extension/collectors_cpu_and_wall_time_worker.c
@@ -1339,15 +1339,15 @@ static VALUE _native_resume_signals(DDTRACE_UNUSED VALUE self) {
 
     state->during_sample = false;
   }
-#endif
 
-static VALUE _native_gvl_profiling_hook_active(DDTRACE_UNUSED VALUE self, VALUE instance) {
-  #ifndef NO_GVL_INSTRUMENTATION
+  static VALUE _native_gvl_profiling_hook_active(DDTRACE_UNUSED VALUE self, VALUE instance) {
     struct cpu_and_wall_time_worker_state *state;
     TypedData_Get_Struct(instance, struct cpu_and_wall_time_worker_state, &cpu_and_wall_time_worker_typed_data, state);
 
     return state->gvl_profiling_hook != NULL ? Qtrue : Qfalse;
-  #else
+  }
+#else
+  static VALUE _native_gvl_profiling_hook_active(DDTRACE_UNUSED VALUE self, DDTRACE_UNUSED VALUE instance) {
     return Qfalse;
-  #endif
-}
+  }
+#endif

--- a/ext/datadog_profiling_native_extension/collectors_cpu_and_wall_time_worker.c
+++ b/ext/datadog_profiling_native_extension/collectors_cpu_and_wall_time_worker.c
@@ -1278,6 +1278,24 @@ static VALUE _native_resume_signals(DDTRACE_UNUSED VALUE self) {
 }
 
 static void on_gvl_event(rb_event_flag_t event_id, const rb_internal_thread_event_data_t *event_data, DDTRACE_UNUSED void *_unused) {
-  // TODO
-  fprintf(stderr, "on_gvl_event %d\n", event_id);
+  struct cpu_and_wall_time_worker_state *state = active_sampler_instance_state; // Read from global variable, see "sampler global state safety" note above
+
+  if (state == NULL) {
+    // This should not be possible; the state is only cleared AFTER we stop any active event hooks,
+    // and there's a lock inside the VM that prevents concurrent in clearing and executing hooks
+    // (so there can't be a hook that started executing while another thread was stopping and cleaning up)
+    fprintf(stderr, "[ddtrace] Unexpected missing state in on_gvl_event (%d)\n", event_id);
+    return;
+  }
+
+  VALUE current_thread = event_data->thread;
+
+  if (event_id == RUBY_INTERNAL_THREAD_EVENT_READY) { /* waiting for gvl */
+    thread_context_collector_on_gvl_waiting(current_thread);
+  } else if (event_id == RUBY_INTERNAL_THREAD_EVENT_RESUMED) { /* running/runnable */
+    thread_context_collector_on_gvl_running(state->thread_context_collector_instance, current_thread);
+  } else {
+    // This is a very delicate time and it's hard for us to raise an exception so let's at least complain to stderr
+    fprintf(stderr, "[ddtrace] Unexpected value in on_gvl_event (%d)\n", event_id);
+  }
 }

--- a/ext/datadog_profiling_native_extension/collectors_thread_context.c
+++ b/ext/datadog_profiling_native_extension/collectors_thread_context.c
@@ -1724,11 +1724,15 @@ static VALUE _native_sample_skipped_allocation_samples(DDTRACE_UNUSED VALUE self
   }
 
   static VALUE _native_on_gvl_waiting(DDTRACE_UNUSED VALUE self, VALUE thread) {
+    ENFORCE_THREAD(thread);
+
     thread_context_collector_on_gvl_waiting(thread);
     return Qnil;
   }
 
   static VALUE _native_gvl_waiting_at_for(DDTRACE_UNUSED VALUE self, VALUE thread) {
+    ENFORCE_THREAD(thread);
+
     intptr_t gvl_waiting_at = (intptr_t) rb_internal_thread_specific_get(thread, per_thread_gvl_waiting_timestamp_key);
     return INT2NUM(gvl_waiting_at);
   }

--- a/ext/datadog_profiling_native_extension/collectors_thread_context.c
+++ b/ext/datadog_profiling_native_extension/collectors_thread_context.c
@@ -1056,6 +1056,10 @@ static int per_thread_context_as_ruby_hash(st_data_t key_thread, st_data_t value
 
     ID2SYM(rb_intern("gc_tracking.cpu_time_at_start_ns")),   /* => */ LONG2NUM(thread_context->gc_tracking.cpu_time_at_start_ns),
     ID2SYM(rb_intern("gc_tracking.wall_time_at_start_ns")),  /* => */ LONG2NUM(thread_context->gc_tracking.wall_time_at_start_ns),
+
+    #ifndef NO_GVL_INSTRUMENTATION
+      ID2SYM(rb_intern("gvl_waiting_at")), /* => */ LONG2NUM((intptr_t) rb_internal_thread_specific_get(thread, per_thread_gvl_waiting_timestamp_key)),
+    #endif
   };
   for (long unsigned int i = 0; i < VALUE_COUNT(arguments); i += 2) rb_hash_aset(context_as_hash, arguments[i], arguments[i+1]);
 

--- a/ext/datadog_profiling_native_extension/collectors_thread_context.c
+++ b/ext/datadog_profiling_native_extension/collectors_thread_context.c
@@ -443,7 +443,7 @@ static VALUE _native_on_gc_start(DDTRACE_UNUSED VALUE self, VALUE collector_inst
 // This method exists only to enable testing Datadog::Profiling::Collectors::ThreadContext behavior using RSpec.
 // It SHOULD NOT be used for other purposes.
 static VALUE _native_on_gc_finish(DDTRACE_UNUSED VALUE self, VALUE collector_instance) {
-  (void) thread_context_collector_on_gc_finish(collector_instance);
+  (void) !thread_context_collector_on_gc_finish(collector_instance);
   return Qtrue;
 }
 
@@ -1526,7 +1526,7 @@ bool thread_context_collector_on_gvl_running(VALUE thread) {
   // Thread was not being profiled / not waiting on gvl
   if (gvl_waiting_at == 0 || gvl_waiting_at == GVL_WAITING_ENABLED_EMPTY) return false;
 
-  long waiting_for_gvl_duration_ns = monotonic_wall_time_now_ns(DO_NOT_RAISE_ON_FAILURE) - wall_time_at_start_ns;
+  long waiting_for_gvl_duration_ns = monotonic_wall_time_now_ns(DO_NOT_RAISE_ON_FAILURE) - gvl_waiting_at;
 
   return waiting_for_gvl_duration_ns >= WAITING_FOR_GVL_THRESHOLD_NS;
 }

--- a/ext/datadog_profiling_native_extension/collectors_thread_context.c
+++ b/ext/datadog_profiling_native_extension/collectors_thread_context.c
@@ -1810,6 +1810,6 @@ static VALUE _native_sample_skipped_allocation_samples(DDTRACE_UNUSED VALUE self
     DDTRACE_UNUSED VALUE stack_from_thread,
     DDTRACE_UNUSED struct per_thread_context *thread_context,
     DDTRACE_UNUSED sampling_buffer* sampling_buffer,
-    DDTRACE_UNUSED long current_cpu_time_ns,
+    DDTRACE_UNUSED long current_cpu_time_ns
   ) { return false; }
 #endif // NO_GVL_INSTRUMENTATION

--- a/ext/datadog_profiling_native_extension/collectors_thread_context.h
+++ b/ext/datadog_profiling_native_extension/collectors_thread_context.h
@@ -14,3 +14,5 @@ VALUE thread_context_collector_sample_after_gc(VALUE self_instance);
 void thread_context_collector_on_gc_start(VALUE self_instance);
 bool thread_context_collector_on_gc_finish(VALUE self_instance);
 VALUE enforce_thread_context_collector_instance(VALUE object);
+void thread_context_collector_on_gvl_waiting(VALUE thread);
+void thread_context_collector_on_gvl_running(VALUE self_instance, VALUE thread);

--- a/ext/datadog_profiling_native_extension/collectors_thread_context.h
+++ b/ext/datadog_profiling_native_extension/collectors_thread_context.h
@@ -16,3 +16,4 @@ __attribute__((warn_unused_result)) bool thread_context_collector_on_gc_finish(V
 VALUE enforce_thread_context_collector_instance(VALUE object);
 void thread_context_collector_on_gvl_waiting(VALUE thread);
 __attribute__((warn_unused_result)) bool thread_context_collector_on_gvl_running(VALUE thread);
+VALUE thread_context_collector_sample_after_gvl_running(VALUE self_instance);

--- a/ext/datadog_profiling_native_extension/collectors_thread_context.h
+++ b/ext/datadog_profiling_native_extension/collectors_thread_context.h
@@ -12,7 +12,7 @@ void thread_context_collector_sample_allocation(VALUE self_instance, unsigned in
 void thread_context_collector_sample_skipped_allocation_samples(VALUE self_instance, unsigned int skipped_samples);
 VALUE thread_context_collector_sample_after_gc(VALUE self_instance);
 void thread_context_collector_on_gc_start(VALUE self_instance);
-bool thread_context_collector_on_gc_finish(VALUE self_instance);
+__attribute__((warn_unused_result)) bool thread_context_collector_on_gc_finish(VALUE self_instance);
 VALUE enforce_thread_context_collector_instance(VALUE object);
 void thread_context_collector_on_gvl_waiting(VALUE thread);
-void thread_context_collector_on_gvl_running(VALUE self_instance, VALUE thread);
+__attribute__((warn_unused_result)) bool thread_context_collector_on_gvl_running(VALUE thread);

--- a/ext/datadog_profiling_native_extension/datadog_ruby_common.h
+++ b/ext/datadog_profiling_native_extension/datadog_ruby_common.h
@@ -27,7 +27,6 @@
 #define ENFORCE_BOOLEAN(value) \
   { if (RB_UNLIKELY(value != Qtrue && value != Qfalse)) raise_unexpected_type(value, ADD_QUOTES(value), "true or false", __FILE__, __LINE__, __func__); }
 
-// Called by ENFORCE_TYPE; should not be used directly
 NORETURN(void raise_unexpected_type(VALUE value, const char *value_name, const char *type_name, const char *file, int line, const char* function_name));
 
 // Helper to retrieve Datadog::VERSION::STRING

--- a/ext/datadog_profiling_native_extension/extconf.rb
+++ b/ext/datadog_profiling_native_extension/extconf.rb
@@ -132,7 +132,7 @@ end
 have_func "malloc_stats"
 
 # On older Rubies, there was no GVL instrumentation API and APIs created to support it
-# TODO: We can probably support Ruby 3.2 as well here, but not for the first version
+# TODO: We can probably support Ruby 3.2 as well here, but we haven't done that work yet
 $defs << "-DNO_GVL_INSTRUMENTATION" if RUBY_VERSION < "3.3"
 
 # On older Rubies, rb_postponed_job_preregister/rb_postponed_job_trigger did not exist

--- a/ext/datadog_profiling_native_extension/extconf.rb
+++ b/ext/datadog_profiling_native_extension/extconf.rb
@@ -131,6 +131,10 @@ end
 
 have_func "malloc_stats"
 
+# On older Rubies, there was no GVL instrumentation API and APIs created to support it
+# TODO: We can probably support Ruby 3.2 as well here, but not for the first version
+$defs << "-DNO_GVL_INSTRUMENTATION" if RUBY_VERSION < "3.3"
+
 # On older Rubies, rb_postponed_job_preregister/rb_postponed_job_trigger did not exist
 $defs << "-DNO_POSTPONED_TRIGGER" if RUBY_VERSION < "3.3"
 

--- a/ext/datadog_profiling_native_extension/private_vm_api_access.h
+++ b/ext/datadog_profiling_native_extension/private_vm_api_access.h
@@ -65,3 +65,6 @@ const char *imemo_kind(VALUE imemo);
 #ifdef NO_POSTPONED_TRIGGER
   void *objspace_ptr_for_gc_finalize_deferred_workaround(void);
 #endif
+
+#define ENFORCE_THREAD(value) \
+  { if (RB_UNLIKELY(!rb_typeddata_is_kind_of(value, RTYPEDDATA_TYPE(rb_thread_current())))) raise_unexpected_type(value, ADD_QUOTES(value), "Thread", __FILE__, __LINE__, __func__); }

--- a/ext/datadog_profiling_native_extension/stack_recorder.h
+++ b/ext/datadog_profiling_native_extension/stack_recorder.h
@@ -21,6 +21,8 @@ typedef struct sample_labels {
   ddog_prof_Label *state_label;
 
   int64_t end_timestamp_ns;
+
+  bool is_gvl_waiting_state;
 } sample_labels;
 
 void record_sample(VALUE recorder_instance, ddog_prof_Slice_Location locations, sample_values values, sample_labels labels);

--- a/ext/datadog_profiling_native_extension/stack_recorder.h
+++ b/ext/datadog_profiling_native_extension/stack_recorder.h
@@ -19,10 +19,9 @@ typedef struct sample_labels {
   // This is used to allow the `Collectors::Stack` to modify the existing label, if any. This MUST be NULL or point
   // somewhere inside the labels slice above.
   ddog_prof_Label *state_label;
+  bool is_gvl_waiting_state;
 
   int64_t end_timestamp_ns;
-
-  bool is_gvl_waiting_state;
 } sample_labels;
 
 void record_sample(VALUE recorder_instance, ddog_prof_Slice_Location locations, sample_values values, sample_labels labels);

--- a/ext/libdatadog_api/crashtracker.c
+++ b/ext/libdatadog_api/crashtracker.c
@@ -28,6 +28,7 @@ void crashtracker_init(VALUE crashtracking_module) {
 static VALUE _native_start_or_update_on_fork(int argc, VALUE *argv, DDTRACE_UNUSED VALUE _self) {
   VALUE options;
   rb_scan_args(argc, argv, "0:", &options);
+  if (options == Qnil) options = rb_hash_new();
 
   VALUE agent_base_url = rb_hash_fetch(options, ID2SYM(rb_intern("agent_base_url")));
   VALUE path_to_crashtracking_receiver_binary = rb_hash_fetch(options, ID2SYM(rb_intern("path_to_crashtracking_receiver_binary")));

--- a/ext/libdatadog_api/datadog_ruby_common.h
+++ b/ext/libdatadog_api/datadog_ruby_common.h
@@ -27,7 +27,6 @@
 #define ENFORCE_BOOLEAN(value) \
   { if (RB_UNLIKELY(value != Qtrue && value != Qfalse)) raise_unexpected_type(value, ADD_QUOTES(value), "true or false", __FILE__, __LINE__, __func__); }
 
-// Called by ENFORCE_TYPE; should not be used directly
 NORETURN(void raise_unexpected_type(VALUE value, const char *value_name, const char *type_name, const char *file, int line, const char* function_name));
 
 // Helper to retrieve Datadog::VERSION::STRING

--- a/lib/datadog/core/configuration/settings.rb
+++ b/lib/datadog/core/configuration/settings.rb
@@ -460,6 +460,32 @@ module Datadog
                 end
               end
             end
+
+            # Enables GVL profiling. This will show when threads are waiting for GVL in the timeline view.
+            #
+            # This is a preview feature and disabled by default. It requires Ruby 3.3+ although in the future we may
+            # be able to support Ruby 3.2 as well.
+            #
+            # @default `DD_PROFILING_PREVIEW_GVL_ENABLED` environment variable as a boolean, otherwise `false`
+            option :preview_gvl_enabled do |o|
+              o.type :bool
+              o.env 'DD_PROFILING_PREVIEW_GVL_ENABLED'
+              o.default false
+            end
+
+            # Controls the smallest time period the profiler will report a thread waiting for the GVL.
+            #
+            # The default value was set to minimize overhead. Periods smaller than the set value will not be reported (e.g.
+            # the thread will be reported as whatever it was doing before it waited for the GVL).
+            #
+            # We do not recommend setting this to less than 1ms. Tweaking this value can increase application latency and
+            # memory use.
+            #
+            # @default 10_000_000 (10ms)
+            option :waiting_for_gvl_threshold_ns do |o|
+              o.type :int
+              o.default 10_000_000
+            end
           end
 
           # @public_api

--- a/lib/datadog/core/telemetry/logger.rb
+++ b/lib/datadog/core/telemetry/logger.rb
@@ -39,7 +39,7 @@ module Datadog
               components.telemetry
             else
               Datadog.logger.warn(
-                'Fail to send telemetry log before components initialization or within components lifecycle'
+                'Failed to send telemetry before components initialization or within components lifecycle'
               )
               nil
             end

--- a/lib/datadog/profiling/collectors/cpu_and_wall_time_worker.rb
+++ b/lib/datadog/profiling/collectors/cpu_and_wall_time_worker.rb
@@ -37,17 +37,17 @@ module Datadog
           gvl_profiling_enabled = ENV["TESTING_GVL_PROFILING"] == "true"
 
           self.class._native_initialize(
-            self,
-            thread_context_collector,
-            gc_profiling_enabled,
-            idle_sampling_helper,
-            no_signals_workaround_enabled,
-            dynamic_sampling_rate_enabled,
-            dynamic_sampling_rate_overhead_target_percentage,
-            allocation_profiling_enabled,
-            allocation_counting_enabled,
-            gvl_profiling_enabled,
-            skip_idle_samples_for_testing,
+            self_instance: self,
+            thread_context_collector: thread_context_collector,
+            gc_profiling_enabled: gc_profiling_enabled,
+            idle_sampling_helper: idle_sampling_helper,
+            no_signals_workaround_enabled: no_signals_workaround_enabled,
+            dynamic_sampling_rate_enabled: dynamic_sampling_rate_enabled,
+            dynamic_sampling_rate_overhead_target_percentage: dynamic_sampling_rate_overhead_target_percentage,
+            allocation_profiling_enabled: allocation_profiling_enabled,
+            allocation_counting_enabled: allocation_counting_enabled,
+            gvl_profiling_enabled: gvl_profiling_enabled,
+            skip_idle_samples_for_testing: skip_idle_samples_for_testing,
           )
           @worker_thread = nil
           @failure_exception = nil

--- a/lib/datadog/profiling/collectors/cpu_and_wall_time_worker.rb
+++ b/lib/datadog/profiling/collectors/cpu_and_wall_time_worker.rb
@@ -34,6 +34,8 @@ module Datadog
             )
           end
 
+          gvl_profiling_enabled = true # TODO
+
           self.class._native_initialize(
             self,
             thread_context_collector,
@@ -44,6 +46,7 @@ module Datadog
             dynamic_sampling_rate_overhead_target_percentage,
             allocation_profiling_enabled,
             allocation_counting_enabled,
+            gvl_profiling_enabled,
             skip_idle_samples_for_testing,
           )
           @worker_thread = nil

--- a/lib/datadog/profiling/collectors/cpu_and_wall_time_worker.rb
+++ b/lib/datadog/profiling/collectors/cpu_and_wall_time_worker.rb
@@ -34,7 +34,7 @@ module Datadog
             )
           end
 
-          gvl_profiling_enabled = true # TODO
+          gvl_profiling_enabled = ENV['TESTING_GVL_PROFILING'] == 'true'
 
           self.class._native_initialize(
             self,

--- a/lib/datadog/profiling/collectors/cpu_and_wall_time_worker.rb
+++ b/lib/datadog/profiling/collectors/cpu_and_wall_time_worker.rb
@@ -34,7 +34,7 @@ module Datadog
             )
           end
 
-          gvl_profiling_enabled = ENV['TESTING_GVL_PROFILING'] == 'true'
+          gvl_profiling_enabled = ENV["TESTING_GVL_PROFILING"] == "true"
 
           self.class._native_initialize(
             self,

--- a/lib/datadog/profiling/collectors/cpu_and_wall_time_worker.rb
+++ b/lib/datadog/profiling/collectors/cpu_and_wall_time_worker.rb
@@ -22,6 +22,7 @@ module Datadog
           dynamic_sampling_rate_overhead_target_percentage:,
           allocation_profiling_enabled:,
           allocation_counting_enabled:,
+          gvl_profiling_enabled:,
           # **NOTE**: This should only be used for testing; disabling the dynamic sampling rate will increase the
           # profiler overhead!
           dynamic_sampling_rate_enabled: true,
@@ -33,8 +34,6 @@ module Datadog
               "Profiling dynamic sampling rate disabled. This should only be used for testing, and will increase overhead!"
             )
           end
-
-          gvl_profiling_enabled = ENV["TESTING_GVL_PROFILING"] == "true"
 
           self.class._native_initialize(
             self_instance: self,

--- a/lib/datadog/profiling/collectors/thread_context.rb
+++ b/lib/datadog/profiling/collectors/thread_context.rb
@@ -20,6 +20,7 @@ module Datadog
           tracer:,
           endpoint_collection_enabled:,
           timeline_enabled:,
+          waiting_for_gvl_threshold_ns:,
           allocation_type_enabled: true
         )
           tracer_context_key = safely_extract_context_key_from(tracer)
@@ -30,6 +31,7 @@ module Datadog
             tracer_context_key,
             endpoint_collection_enabled,
             timeline_enabled,
+            waiting_for_gvl_threshold_ns,
             allocation_type_enabled,
           )
         end
@@ -40,6 +42,7 @@ module Datadog
           tracer: nil,
           endpoint_collection_enabled: false,
           timeline_enabled: false,
+          waiting_for_gvl_threshold_ns: 10_000_000,
           **options
         )
           new(
@@ -48,6 +51,7 @@ module Datadog
             tracer: tracer,
             endpoint_collection_enabled: endpoint_collection_enabled,
             timeline_enabled: timeline_enabled,
+            waiting_for_gvl_threshold_ns: waiting_for_gvl_threshold_ns,
             **options,
           )
         end

--- a/lib/datadog/profiling/collectors/thread_context.rb
+++ b/lib/datadog/profiling/collectors/thread_context.rb
@@ -34,6 +34,24 @@ module Datadog
           )
         end
 
+        def self.for_testing(
+          recorder:,
+          max_frames: 400,
+          tracer: nil,
+          endpoint_collection_enabled: false,
+          timeline_enabled: false,
+          **options
+        )
+          new(
+            recorder: recorder,
+            max_frames: max_frames,
+            tracer: tracer,
+            endpoint_collection_enabled: endpoint_collection_enabled,
+            timeline_enabled: timeline_enabled,
+            **options,
+          )
+        end
+
         def inspect
           # Compose Ruby's default inspect with our custom inspect for the native parts
           result = super()

--- a/lib/datadog/profiling/component.rb
+++ b/lib/datadog/profiling/component.rb
@@ -89,6 +89,7 @@ module Datadog
           tracer: optional_tracer,
           endpoint_collection_enabled: settings.profiling.advanced.endpoint.collection.enabled,
           timeline_enabled: timeline_enabled,
+          waiting_for_gvl_threshold_ns: 10_000_000, # TODO: Make this configurable, from the settings
         )
       end
 

--- a/lib/datadog/profiling/component.rb
+++ b/lib/datadog/profiling/component.rb
@@ -62,6 +62,7 @@ module Datadog
           dynamic_sampling_rate_overhead_target_percentage: overhead_target_percentage,
           allocation_profiling_enabled: allocation_profiling_enabled,
           allocation_counting_enabled: settings.profiling.advanced.allocation_counting_enabled,
+          gvl_profiling_enabled: false, # TODO: Make this configurable, from the settings
         )
 
         internal_metadata = {

--- a/sig/datadog/profiling/collectors/cpu_and_wall_time_worker.rbs
+++ b/sig/datadog/profiling/collectors/cpu_and_wall_time_worker.rbs
@@ -29,6 +29,7 @@ module Datadog
           Float dynamic_sampling_rate_overhead_target_percentage,
           bool allocation_profiling_enabled,
           bool allocation_counting_enabled,
+          bool gvl_profiling_enabled,
           bool skip_idle_samples_for_testing,
         ) -> true
 

--- a/sig/datadog/profiling/collectors/cpu_and_wall_time_worker.rbs
+++ b/sig/datadog/profiling/collectors/cpu_and_wall_time_worker.rbs
@@ -20,17 +20,17 @@ module Datadog
         ) -> void
 
         def self._native_initialize: (
-          CpuAndWallTimeWorker self_instance,
-          ThreadContext thread_context_collector,
-          bool gc_profiling_enabled,
-          IdleSamplingHelper idle_sampling_helper,
-          bool no_signals_workaround_enabled,
-          bool dynamic_sampling_rate_enabled,
-          Float dynamic_sampling_rate_overhead_target_percentage,
-          bool allocation_profiling_enabled,
-          bool allocation_counting_enabled,
-          bool gvl_profiling_enabled,
-          bool skip_idle_samples_for_testing,
+          self_instance: CpuAndWallTimeWorker,
+          thread_context_collector: ThreadContext,
+          gc_profiling_enabled: bool,
+          idle_sampling_helper: IdleSamplingHelper,
+          no_signals_workaround_enabled: bool,
+          dynamic_sampling_rate_enabled: bool,
+          dynamic_sampling_rate_overhead_target_percentage: Float,
+          allocation_profiling_enabled: bool,
+          allocation_counting_enabled: bool,
+          gvl_profiling_enabled: bool,
+          skip_idle_samples_for_testing: bool,
         ) -> true
 
         def start: (?on_failure_proc: ::Proc?) -> bool?

--- a/sig/datadog/profiling/collectors/cpu_and_wall_time_worker.rbs
+++ b/sig/datadog/profiling/collectors/cpu_and_wall_time_worker.rbs
@@ -16,6 +16,7 @@ module Datadog
           ?dynamic_sampling_rate_enabled: bool,
           allocation_profiling_enabled: bool,
           allocation_counting_enabled: bool,
+          gvl_profiling_enabled: bool,
           ?skip_idle_samples_for_testing: false,
         ) -> void
 

--- a/sig/datadog/profiling/collectors/thread_context.rbs
+++ b/sig/datadog/profiling/collectors/thread_context.rbs
@@ -8,6 +8,7 @@ module Datadog
           tracer: Datadog::Tracing::Tracer?,
           endpoint_collection_enabled: bool,
           timeline_enabled: bool,
+          waiting_for_gvl_threshold_ns: ::Integer,
           ?allocation_type_enabled: bool,
         ) -> void
 
@@ -18,6 +19,7 @@ module Datadog
           ::Symbol? tracer_context_key,
           bool endpoint_collection_enabled,
           bool timeline_enabled,
+          ::Integer waiting_for_gvl_threshold_ns,
           bool allocation_type_enabled,
         ) -> void
 

--- a/sig/datadog/profiling/component.rbs
+++ b/sig/datadog/profiling/component.rbs
@@ -39,6 +39,7 @@ module Datadog
       def self.valid_overhead_target: (::Float overhead_target_percentage) -> ::Float
       def self.looks_like_mariadb?: ({ header_version: ::String? }, ::Gem::Version) -> bool
       def self.dir_interruption_workaround_enabled?: (untyped settings, bool no_signals_workaround_enabled) -> bool
+      def self.enable_gvl_profiling?: (untyped settings) -> bool
     end
   end
 end

--- a/spec/datadog/core/configuration/settings_spec.rb
+++ b/spec/datadog/core/configuration/settings_spec.rb
@@ -883,6 +883,56 @@ RSpec.describe Datadog::Core::Configuration::Settings do
             .to(false)
         end
       end
+
+      describe '#preview_gvl_enabled' do
+        subject(:preview_gvl_enabled) { settings.profiling.advanced.preview_gvl_enabled }
+
+        context 'when DD_PROFILING_PREVIEW_GVL_ENABLED' do
+          around do |example|
+            ClimateControl.modify('DD_PROFILING_PREVIEW_GVL_ENABLED' => environment) do
+              example.run
+            end
+          end
+
+          context 'is not defined' do
+            let(:environment) { nil }
+
+            it { is_expected.to be false }
+          end
+
+          [true, false].each do |value|
+            context "is defined as #{value}" do
+              let(:environment) { value.to_s }
+
+              it { is_expected.to be value }
+            end
+          end
+        end
+      end
+
+      describe '#preview_gvl_enabled=' do
+        it 'updates the #preview_gvl_enabled setting' do
+          expect { settings.profiling.advanced.preview_gvl_enabled = true }
+            .to change { settings.profiling.advanced.preview_gvl_enabled }
+            .from(false)
+            .to(true)
+        end
+      end
+
+      describe '#waiting_for_gvl_threshold_ns' do
+        subject(:waiting_for_gvl_threshold_ns) { settings.profiling.advanced.waiting_for_gvl_threshold_ns }
+
+        it { is_expected.to be 10_000_000 }
+      end
+
+      describe '#waiting_for_gvl_threshold_ns=' do
+        it 'updates the #waiting_for_gvl_threshold_ns setting' do
+          expect { settings.profiling.advanced.waiting_for_gvl_threshold_ns = 123_000_000 }
+            .to change { settings.profiling.advanced.waiting_for_gvl_threshold_ns }
+            .from(10_000_000)
+            .to(123_000_000)
+        end
+      end
     end
 
     describe '#upload' do

--- a/spec/datadog/core/telemetry/logger_spec.rb
+++ b/spec/datadog/core/telemetry/logger_spec.rb
@@ -36,7 +36,7 @@ RSpec.describe Datadog::Core::Telemetry::Logger do
       it do
         exception = StandardError.new
         allow(Datadog.send(:components)).to receive(:telemetry).and_return(nil)
-        expect(Datadog.logger).to receive(:warn).with(/Fail to send telemetry log/)
+        expect(Datadog.logger).to receive(:warn).with(/Failed to send telemetry/)
 
         expect do
           described_class.report(exception, level: :error, description: 'Oops...')
@@ -60,7 +60,7 @@ RSpec.describe Datadog::Core::Telemetry::Logger do
     context 'when there is no telemetry component configured' do
       it do
         allow(Datadog.send(:components)).to receive(:telemetry).and_return(nil)
-        expect(Datadog.logger).to receive(:warn).with(/Fail to send telemetry log/)
+        expect(Datadog.logger).to receive(:warn).with(/Failed to send telemetry/)
 
         expect { described_class.error('description') }.not_to raise_error
       end

--- a/spec/datadog/profiling/collectors/cpu_and_wall_time_worker_spec.rb
+++ b/spec/datadog/profiling/collectors/cpu_and_wall_time_worker_spec.rb
@@ -909,15 +909,7 @@ RSpec.describe Datadog::Profiling::Collectors::CpuAndWallTimeWorker do
   describe "#reset_after_fork" do
     subject(:reset_after_fork) { cpu_and_wall_time_worker.reset_after_fork }
 
-    let(:thread_context_collector) do
-      Datadog::Profiling::Collectors::ThreadContext.new(
-        recorder: recorder,
-        max_frames: 400,
-        tracer: nil,
-        endpoint_collection_enabled: endpoint_collection_enabled,
-        timeline_enabled: timeline_enabled,
-      )
-    end
+    let(:thread_context_collector) { build_thread_context_collector(recorder) }
     let(:options) { {thread_context_collector: thread_context_collector} }
 
     before do
@@ -1261,10 +1253,8 @@ RSpec.describe Datadog::Profiling::Collectors::CpuAndWallTimeWorker do
   end
 
   def build_thread_context_collector(recorder)
-    Datadog::Profiling::Collectors::ThreadContext.new(
+    Datadog::Profiling::Collectors::ThreadContext.for_testing(
       recorder: recorder,
-      max_frames: 400,
-      tracer: nil,
       endpoint_collection_enabled: endpoint_collection_enabled,
       timeline_enabled: timeline_enabled,
     )

--- a/spec/datadog/profiling/collectors/cpu_and_wall_time_worker_spec.rb
+++ b/spec/datadog/profiling/collectors/cpu_and_wall_time_worker_spec.rb
@@ -967,7 +967,7 @@ RSpec.describe Datadog::Profiling::Collectors::CpuAndWallTimeWorker do
       end
 
       context "when GVL profiling is enabled" do
-        before { skip_if_gvl_profiling_not_supported(self) }
+        before { skip_if_gvl_profiling_not_supported(self) { stop } }
 
         let(:gvl_profiling_enabled) { true }
 

--- a/spec/datadog/profiling/collectors/cpu_and_wall_time_worker_spec.rb
+++ b/spec/datadog/profiling/collectors/cpu_and_wall_time_worker_spec.rb
@@ -16,6 +16,7 @@ RSpec.describe Datadog::Profiling::Collectors::CpuAndWallTimeWorker do
   let(:timeline_enabled) { false }
   let(:options) { {} }
   let(:allocation_counting_enabled) { false }
+  let(:gvl_profiling_enabled) { false }
   let(:worker_settings) do
     {
       gc_profiling_enabled: gc_profiling_enabled,
@@ -24,6 +25,7 @@ RSpec.describe Datadog::Profiling::Collectors::CpuAndWallTimeWorker do
       dynamic_sampling_rate_overhead_target_percentage: 2.0,
       allocation_profiling_enabled: allocation_profiling_enabled,
       allocation_counting_enabled: allocation_counting_enabled,
+      gvl_profiling_enabled: gvl_profiling_enabled,
       **options
     }
   end

--- a/spec/datadog/profiling/collectors/stack_spec.rb
+++ b/spec/datadog/profiling/collectors/stack_spec.rb
@@ -17,9 +17,9 @@ RSpec.describe Datadog::Profiling::Collectors::Stack do
   let(:reference_stack) { convert_reference_stack(raw_reference_stack) }
   let(:gathered_stack) { stacks.fetch(:gathered) }
 
-  def sample(thread, recorder_instance, metric_values_hash, labels_array, max_frames: 400, in_gc: false)
+  def sample(thread, recorder_instance, metric_values_hash, labels_array, **options)
     numeric_labels_array = []
-    described_class::Testing._native_sample(thread, recorder_instance, metric_values_hash, labels_array, numeric_labels_array, max_frames, in_gc)
+    described_class::Testing._native_sample(thread, recorder_instance, metric_values_hash, labels_array, numeric_labels_array, **options)
   end
 
   # This spec explicitly tests the main thread because an unpatched rb_profile_frames returns one more frame in the

--- a/spec/datadog/profiling/collectors/thread_context_spec.rb
+++ b/spec/datadog/profiling/collectors/thread_context_spec.rb
@@ -772,6 +772,8 @@ RSpec.describe Datadog::Profiling::Collectors::ThreadContext do
 
         context "when thread starts Waiting for GVL" do
           before do
+            skip "Behavior does not apply to current Ruby version" if min_ruby_for_gvl_profiling > RUBY_VERSION
+
             sample # trigger context creation
             samples_from_pprof(recorder.serialize!) # flush sample
 
@@ -833,6 +835,8 @@ RSpec.describe Datadog::Profiling::Collectors::ThreadContext do
 
         context "when thread is Waiting for GVL" do
           before do
+            skip "Behavior does not apply to current Ruby version" if min_ruby_for_gvl_profiling > RUBY_VERSION
+
             sample # trigger context creation
             on_gvl_waiting(t1)
             sample # trigger creation of sample representing the period before Waiting for GVL
@@ -1561,6 +1565,8 @@ RSpec.describe Datadog::Profiling::Collectors::ThreadContext do
   end
 
   describe "#sample_after_gvl_running" do
+    before { skip "Behavior does not apply to current Ruby version" if min_ruby_for_gvl_profiling > RUBY_VERSION }
+
     let(:timeline_enabled) { true }
 
     context "when thread does not have the end of Waiting for GVL to be recorded" do

--- a/spec/datadog/profiling/collectors/thread_context_spec.rb
+++ b/spec/datadog/profiling/collectors/thread_context_spec.rb
@@ -780,7 +780,7 @@ RSpec.describe Datadog::Profiling::Collectors::ThreadContext do
 
         context "when thread starts Waiting for GVL" do
           before do
-            skip "Behavior does not apply to current Ruby version" if min_ruby_for_gvl_profiling > RUBY_VERSION
+            skip_if_gvl_profiling_not_supported(self)
 
             sample # trigger context creation
             samples_from_pprof(recorder.serialize!) # flush sample
@@ -843,7 +843,7 @@ RSpec.describe Datadog::Profiling::Collectors::ThreadContext do
 
         context "when thread is Waiting for GVL" do
           before do
-            skip "Behavior does not apply to current Ruby version" if min_ruby_for_gvl_profiling > RUBY_VERSION
+            skip_if_gvl_profiling_not_supported(self)
 
             sample # trigger context creation
             on_gvl_waiting(t1)
@@ -1465,7 +1465,7 @@ RSpec.describe Datadog::Profiling::Collectors::ThreadContext do
   end
 
   describe "#on_gvl_waiting" do
-    before { skip "Behavior does not apply to current Ruby version" if min_ruby_for_gvl_profiling > RUBY_VERSION }
+    before { skip_if_gvl_profiling_not_supported(self) }
 
     context "if thread has not been sampled before" do
       it "does not record anything in the internal_thread_specific value" do
@@ -1491,7 +1491,7 @@ RSpec.describe Datadog::Profiling::Collectors::ThreadContext do
   end
 
   describe "#on_gvl_running" do
-    before { skip "Behavior does not apply to current Ruby version" if min_ruby_for_gvl_profiling > RUBY_VERSION }
+    before { skip_if_gvl_profiling_not_supported(self) }
 
     context "if thread has not been sampled before" do
       it "does not record anything in the internal_thread_specific value" do
@@ -1571,7 +1571,7 @@ RSpec.describe Datadog::Profiling::Collectors::ThreadContext do
   end
 
   describe "#sample_after_gvl_running" do
-    before { skip "Behavior does not apply to current Ruby version" if min_ruby_for_gvl_profiling > RUBY_VERSION }
+    before { skip_if_gvl_profiling_not_supported(self) }
 
     let(:timeline_enabled) { true }
 
@@ -1823,7 +1823,7 @@ RSpec.describe Datadog::Profiling::Collectors::ThreadContext do
 
       describe ":gvl_waiting_at" do
         context "on supported Rubies" do
-          before { skip "Behavior does not apply to current Ruby version" if min_ruby_for_gvl_profiling > RUBY_VERSION }
+          before { skip_if_gvl_profiling_not_supported(self) }
 
           it "is initialized to GVL_WAITING_ENABLED_EMPTY (INTPTR_MAX)" do
             expect(per_thread_context.values).to all(
@@ -1833,7 +1833,7 @@ RSpec.describe Datadog::Profiling::Collectors::ThreadContext do
         end
 
         context "on legacy Rubies" do
-          before { skip "Behavior does not apply to current Ruby version" if min_ruby_for_gvl_profiling <= RUBY_VERSION }
+          before { skip "Behavior does not apply to current Ruby version" if RUBY_VERSION >= "3.3." }
 
           it "is not set" do
             per_thread_context.each do |_thread, context|

--- a/spec/datadog/profiling/collectors/thread_context_spec.rb
+++ b/spec/datadog/profiling/collectors/thread_context_spec.rb
@@ -1569,7 +1569,7 @@ RSpec.describe Datadog::Profiling::Collectors::ThreadContext do
 
     let(:timeline_enabled) { true }
 
-    context "when thread does not have the end of Waiting for GVL to be recorded" do
+    context "when thread is not at the end of a Waiting for GVL period" do
       before do
         expect(gvl_waiting_at_for(t1)).to be 0
       end
@@ -1592,7 +1592,7 @@ RSpec.describe Datadog::Profiling::Collectors::ThreadContext do
     # for why we need a separate `sample_after_gvl_running`.
     #
     # Thus, I chose to not repeat the extensive Waiting for GVL asserts we already have in #sample, and do a smaller pass.
-    context "when thread has the end of Waiting for GVL to be recorded (and a start was not yet recorded)" do
+    context "when thread is at the end of a Waiting for GVL period" do
       before do
         sample # trigger context creation
         on_gvl_waiting(t1)

--- a/spec/datadog/profiling/collectors/thread_context_spec.rb
+++ b/spec/datadog/profiling/collectors/thread_context_spec.rb
@@ -40,6 +40,7 @@ RSpec.describe Datadog::Profiling::Collectors::ThreadContext do
   let(:endpoint_collection_enabled) { true }
   let(:timeline_enabled) { false }
   let(:allocation_type_enabled) { true }
+  let(:minimum_ruby_for_gvl_profiling) { "3.3." }
   # This mirrors the use of INTPTR_MAX for GVL_WAITING_ENABLED_EMPTY in the native code; it may need adjusting if we ever
   # want to support more platforms
   let(:gvl_waiting_enabled_empty_magic_value) { 2**63 - 1 }
@@ -1258,7 +1259,7 @@ RSpec.describe Datadog::Profiling::Collectors::ThreadContext do
   end
 
   describe "#on_gvl_waiting" do
-    before { skip "Behavior does not apply to current Ruby version" if RUBY_VERSION < "3.3." }
+    before { skip "Behavior does not apply to current Ruby version" if minimum_ruby_for_gvl_profiling > RUBY_VERSION }
 
     context "if thread has not been sampled before" do
       it "does not record anything in the internal_thread_specific value" do
@@ -1284,7 +1285,7 @@ RSpec.describe Datadog::Profiling::Collectors::ThreadContext do
   end
 
   describe "#on_gvl_running" do
-    before { skip "Behavior does not apply to current Ruby version" if RUBY_VERSION < "3.3." }
+    before { skip "Behavior does not apply to current Ruby version" if minimum_ruby_for_gvl_profiling > RUBY_VERSION }
 
     context "if thread has not been sampled before" do
       it "does not record anything in the internal_thread_specific value" do
@@ -1538,7 +1539,7 @@ RSpec.describe Datadog::Profiling::Collectors::ThreadContext do
 
       describe ":gvl_waiting_at" do
         context "on Ruby >= 3.3" do
-          before { skip "Behavior does not apply to current Ruby version" if RUBY_VERSION < "3.3." }
+          before { skip "Behavior does not apply to current Ruby version" if minimum_ruby_for_gvl_profiling > RUBY_VERSION }
 
           it "is initialized to GVL_WAITING_ENABLED_EMPTY (INTPTR_MAX)" do
             expect(per_thread_context.values).to all(
@@ -1548,7 +1549,7 @@ RSpec.describe Datadog::Profiling::Collectors::ThreadContext do
         end
 
         context "on Ruby < 3.3" do
-          before { skip "Behavior does not apply to current Ruby version" if RUBY_VERSION >= "3.3." }
+          before { skip "Behavior does not apply to current Ruby version" if minimum_ruby_for_gvl_profiling <= RUBY_VERSION }
 
           it "is not set" do
             per_thread_context.each do |_thread, context|

--- a/spec/datadog/profiling/collectors/thread_context_spec.rb
+++ b/spec/datadog/profiling/collectors/thread_context_spec.rb
@@ -848,7 +848,7 @@ RSpec.describe Datadog::Profiling::Collectors::ThreadContext do
             sample # trigger context creation
             on_gvl_waiting(t1)
             sample # trigger creation of sample representing the period before Waiting for GVL
-            samples_from_pprof(recorder.serialize!) # flush previous samples
+            recorder.serialize! # flush previous samples
           end
 
           def sample_and_check(expected_state:)
@@ -924,7 +924,7 @@ RSpec.describe Datadog::Profiling::Collectors::ThreadContext do
 
               it "does not record a new Waiting for GVL sample afterwards" do
                 sample # last Waiting for GVL sample
-                samples_from_pprof(recorder.serialize!) # flush previous samples
+                recorder.serialize! # flush previous samples
 
                 3.times { sample_and_check(expected_state: "sleeping") }
               end
@@ -1597,7 +1597,7 @@ RSpec.describe Datadog::Profiling::Collectors::ThreadContext do
     # See the big comment next to the definition of `thread_context_collector_sample_after_gvl_running_with_thread`
     # for why we need a separate `sample_after_gvl_running`.
     #
-    # Thus, I chose to not repeat the extensive Waiting for GVL asserts we already have in #sample, and do a smaller pass.
+    # Thus, I chose to not repeat the extensive Waiting for GVL specs we already have in #sample, and do a smaller pass.
     context "when thread is at the end of a Waiting for GVL period" do
       let(:waiting_for_gvl_threshold_ns) { 0 }
 
@@ -1608,7 +1608,7 @@ RSpec.describe Datadog::Profiling::Collectors::ThreadContext do
         sample if record_start
 
         on_gvl_running(t1)
-        samples_from_pprof(recorder.serialize!) # flush samples
+        recorder.serialize! # flush samples
 
         expect(gvl_waiting_at_for(t1)).to be < 0
       end

--- a/spec/datadog/profiling/collectors/thread_context_spec.rb
+++ b/spec/datadog/profiling/collectors/thread_context_spec.rb
@@ -1414,6 +1414,28 @@ RSpec.describe Datadog::Profiling::Collectors::ThreadContext do
           # rubocop:enable Style/GlobalVars
         end
       end
+
+      describe ":gvl_waiting_at" do
+        context "on Ruby >= 3.3" do
+          before { skip "Behavior does not apply to current Ruby version" if RUBY_VERSION < "3.3." }
+
+          it "is initialized to GVL_WAITING_ENABLED_EMPTY (INTPTR_MAX)" do
+            expect(per_thread_context.values).to all(
+              include(gvl_waiting_at: 2**63 - 1) # This may need adjusting if we ever support more platforms
+            )
+          end
+        end
+
+        context "on Ruby < 3.3" do
+          before { skip "Behavior does not apply to current Ruby version" if RUBY_VERSION >= "3.3." }
+
+          it "is not set" do
+            per_thread_context.each do |_thread, context|
+              expect(context.key?(:gvl_waiting_at)).to be false
+            end
+          end
+        end
+      end
     end
 
     context "after sampling multiple times" do

--- a/spec/datadog/profiling/collectors/thread_context_spec.rb
+++ b/spec/datadog/profiling/collectors/thread_context_spec.rb
@@ -40,7 +40,6 @@ RSpec.describe Datadog::Profiling::Collectors::ThreadContext do
   let(:endpoint_collection_enabled) { true }
   let(:timeline_enabled) { false }
   let(:allocation_type_enabled) { true }
-  let(:min_ruby_for_gvl_profiling) { "3.3." }
   # This mirrors the use of INTPTR_MAX for GVL_WAITING_ENABLED_EMPTY in the native code; it may need adjusting if we ever
   # want to support more platforms
   let(:gvl_waiting_enabled_empty_magic_value) { 2**63 - 1 }

--- a/spec/datadog/profiling/component_spec.rb
+++ b/spec/datadog/profiling/component_spec.rb
@@ -592,7 +592,11 @@ RSpec.describe Datadog::Profiling::Component do
       end
 
       context "when GVL profiling is requested" do
-        before { settings.profiling.advanced.preview_gvl_enabled = true }
+        before do
+          settings.profiling.advanced.preview_gvl_enabled = true
+          # This triggers a warning in some Rubies so it's easier for testing to disable it
+          settings.profiling.advanced.gc_enabled = false
+        end
 
         context "on Ruby < 3.3" do
           before { skip "Behavior does not apply to current Ruby version" if RUBY_VERSION >= "3.3." }

--- a/spec/datadog/profiling/component_spec.rb
+++ b/spec/datadog/profiling/component_spec.rb
@@ -628,7 +628,7 @@ RSpec.describe Datadog::Profiling::Component do
           context "when timeline is disabled" do
             before { settings.profiling.advanced.timeline_enabled = false }
 
-          it "does not enable GVL profiling" do
+            it "does not enable GVL profiling" do
               expect(Datadog::Profiling::Collectors::CpuAndWallTimeWorker)
                 .to receive(:new).with(hash_including(gvl_profiling_enabled: false))
 

--- a/spec/datadog/profiling/component_spec.rb
+++ b/spec/datadog/profiling/component_spec.rb
@@ -77,6 +77,7 @@ RSpec.describe Datadog::Profiling::Component do
             tracer: tracer,
             endpoint_collection_enabled: :endpoint_collection_enabled_config,
             timeline_enabled: :timeline_enabled_config,
+            waiting_for_gvl_threshold_ns: 10_000_000, # TODO: Make this configurable, from the settings
           )
 
           build_profiler_component

--- a/spec/datadog/profiling/component_spec.rb
+++ b/spec/datadog/profiling/component_spec.rb
@@ -99,6 +99,7 @@ RSpec.describe Datadog::Profiling::Component do
             dynamic_sampling_rate_overhead_target_percentage: :overhead_target_percentage_config,
             allocation_profiling_enabled: false,
             allocation_counting_enabled: :allocation_counting_enabled_config,
+            gvl_profiling_enabled: false, # TODO: Make this configurable, from the settings
           )
 
           build_profiler_component

--- a/spec/datadog/profiling/spec_helper.rb
+++ b/spec/datadog/profiling/spec_helper.rb
@@ -79,11 +79,21 @@ module ProfileHelpers
     end
   end
 
-  def samples_for_thread(samples, thread)
-    samples.select do |sample|
+  def samples_for_thread(samples, thread, expected_size: nil)
+    result = samples.select do |sample|
       thread_id = sample.labels[:"thread id"]
       thread_id && object_id_from(thread_id) == thread.object_id
     end
+
+    if expected_size
+      expect(result.size).to(be(expected_size), "Found unexpected sample count in result: #{result}")
+    end
+
+    result
+  end
+
+  def sample_for_thread(samples, thread)
+    samples_for_thread(samples, thread, expected_size: 1).first
   end
 
   # We disable heap_sample collection by default in tests since it requires some extra mocking/

--- a/spec/datadog/profiling/spec_helper.rb
+++ b/spec/datadog/profiling/spec_helper.rb
@@ -122,8 +122,11 @@ module ProfileHelpers
     end
   end
 
-  def skip_if_gvl_profiling_not_supported(testcase)
-    testcase.skip "GVL profiling is only supported on Ruby >= 3.3" if RUBY_VERSION < "3.3."
+  def skip_if_gvl_profiling_not_supported(testcase, &skip_steps)
+    if RUBY_VERSION < "3.3."
+      yield if skip_steps
+      testcase.skip "GVL profiling is only supported on Ruby >= 3.3"
+    end
   end
 end
 

--- a/spec/datadog/profiling/spec_helper.rb
+++ b/spec/datadog/profiling/spec_helper.rb
@@ -122,8 +122,8 @@ module ProfileHelpers
     end
   end
 
-  def min_ruby_for_gvl_profiling
-    "3.3."
+  def skip_if_gvl_profiling_not_supported(testcase)
+    testcase.skip "GVL profiling is only supported on Ruby >= 3.3" if RUBY_VERSION < "3.3."
   end
 end
 

--- a/spec/datadog/profiling/spec_helper.rb
+++ b/spec/datadog/profiling/spec_helper.rb
@@ -55,7 +55,7 @@ module ProfileHelpers
         sample.label.map do |it|
           key = string_table[it.key].to_sym
           [key, ((it.num == 0) ? string_table[it.str] : ProfileHelpers.maybe_fix_label_range(key, it.num))]
-        end.to_h,
+        end.sort.to_h,
       ).freeze
     end
   end
@@ -120,6 +120,10 @@ module ProfileHelpers
     else
       value
     end
+  end
+
+  def min_ruby_for_gvl_profiling
+    "3.3."
   end
 end
 

--- a/spec/datadog/profiling/spec_helper.rb
+++ b/spec/datadog/profiling/spec_helper.rb
@@ -122,9 +122,8 @@ module ProfileHelpers
     end
   end
 
-  def skip_if_gvl_profiling_not_supported(testcase, &skip_steps)
+  def skip_if_gvl_profiling_not_supported(testcase)
     if RUBY_VERSION < "3.3."
-      yield if skip_steps
       testcase.skip "GVL profiling is only supported on Ruby >= 3.3"
     end
   end

--- a/spec/datadog/profiling/stack_recorder_spec.rb
+++ b/spec/datadog/profiling/stack_recorder_spec.rb
@@ -262,7 +262,7 @@ RSpec.describe Datadog::Profiling::StackRecorder do
 
       before do
         Datadog::Profiling::Collectors::Stack::Testing
-          ._native_sample(Thread.current, stack_recorder, metric_values, labels, numeric_labels, 400, false)
+          ._native_sample(Thread.current, stack_recorder, metric_values, labels, numeric_labels)
         expect(samples.size).to be 1
       end
 
@@ -337,8 +337,6 @@ RSpec.describe Datadog::Profiling::StackRecorder do
               metric_values,
               {"local root span id" => "incorrect", "state" => "unknown"}.to_a,
               [],
-              400,
-              false,
             )
           end.to raise_error(ArgumentError)
         end
@@ -355,7 +353,7 @@ RSpec.describe Datadog::Profiling::StackRecorder do
 
         sample = proc do |numeric_labels = {}|
           Datadog::Profiling::Collectors::Stack::Testing._native_sample(
-            Thread.current, stack_recorder, metric_values, {"state" => "unknown"}.to_a, numeric_labels.to_a, 400, false
+            Thread.current, stack_recorder, metric_values, {"state" => "unknown"}.to_a, numeric_labels.to_a
           )
         end
 
@@ -415,7 +413,7 @@ RSpec.describe Datadog::Profiling::StackRecorder do
         # Heap sampling currently requires this 2-step process to first pass data about the allocated object...
         described_class::Testing._native_track_object(stack_recorder, obj, sample_rate, obj.class.name)
         Datadog::Profiling::Collectors::Stack::Testing
-          ._native_sample(Thread.current, stack_recorder, metric_values, labels, numeric_labels, 400, false)
+          ._native_sample(Thread.current, stack_recorder, metric_values, labels, numeric_labels)
       end
 
       before do
@@ -794,7 +792,7 @@ RSpec.describe Datadog::Profiling::StackRecorder do
           it "propagates the exception" do
             expect do
               Datadog::Profiling::Collectors::Stack::Testing
-                ._native_sample(Thread.current, stack_recorder, metric_values, labels, numeric_labels, 400, false)
+                ._native_sample(Thread.current, stack_recorder, metric_values, labels, numeric_labels)
             end.to raise_error(RuntimeError, /Ended a heap recording/)
           end
 
@@ -805,7 +803,7 @@ RSpec.describe Datadog::Profiling::StackRecorder do
 
             begin
               Datadog::Profiling::Collectors::Stack::Testing
-                ._native_sample(Thread.current, stack_recorder, metric_values, labels, numeric_labels, 400, false)
+                ._native_sample(Thread.current, stack_recorder, metric_values, labels, numeric_labels)
             rescue # rubocop:disable Lint/SuppressedException
             end
 
@@ -925,7 +923,7 @@ RSpec.describe Datadog::Profiling::StackRecorder do
       it "makes the next calls to serialize return no data" do
         # Add some data
         Datadog::Profiling::Collectors::Stack::Testing
-          ._native_sample(Thread.current, stack_recorder, metric_values, labels, numeric_labels, 400, false)
+          ._native_sample(Thread.current, stack_recorder, metric_values, labels, numeric_labels)
 
         # Sanity check: validate that data is there, to avoid the test passing because of other issues
         sanity_check_samples = samples_from_pprof(stack_recorder.serialize[2])
@@ -933,7 +931,7 @@ RSpec.describe Datadog::Profiling::StackRecorder do
 
         # Add some data, again
         Datadog::Profiling::Collectors::Stack::Testing
-          ._native_sample(Thread.current, stack_recorder, metric_values, labels, numeric_labels, 400, false)
+          ._native_sample(Thread.current, stack_recorder, metric_values, labels, numeric_labels)
 
         reset_after_fork
 
@@ -1011,7 +1009,7 @@ RSpec.describe Datadog::Profiling::StackRecorder do
         # Heap sampling currently requires this 2-step process to first pass data about the allocated object...
         described_class::Testing._native_track_object(stack_recorder, obj, 1, obj.class.name)
         Datadog::Profiling::Collectors::Stack::Testing._native_sample(
-          Thread.current, stack_recorder, {"alloc-samples" => 1, "heap_sample" => true}, [], [], 400, false
+          Thread.current, stack_recorder, {"alloc-samples" => 1, "heap_sample" => true}, [], [],
         )
       end
 

--- a/spec/datadog/profiling/stack_recorder_spec.rb
+++ b/spec/datadog/profiling/stack_recorder_spec.rb
@@ -1026,7 +1026,7 @@ RSpec.describe Datadog::Profiling::StackRecorder do
         # See also the discussion on commit 2fc03d5ae5860d4e9a75ce3825fba95ed288a1 for an earlier attempt at fixing this.
         dead_heap_samples = 10
         dead_heap_samples.times do |_i|
-          obj = {}
+          obj = []
           sample_allocation(obj)
         end
 


### PR DESCRIPTION
**What does this PR do?**

This PR introduces a new feature for the Continuous Profiler: GVL profiling.

Specifically, when enabled, GVL profiling means the profiler gathers information from threads waiting to acquire the Ruby "Global VM Lock" (GVL).

This is important because this can be a big a source of latency for Ruby applications: a thread "Waiting on the GVL" is a thread that's ready to make progress, as soon as Ruby allows it to run again.

For instance, consider this example where four threads are fighting to execute [(source)](https://github.com/ivoanjo/gvl-tracing/blob/master/examples/example1.rb):

```ruby
def fib(n)
  return n if n <= 1
  fib(n - 1) + fib(n - 2)
end

Thread.new { sleep(0.05) while true }

3.times.map { Thread.new { fib(37) } }.map(&:join)
```

And here's how they are shown in profiler timeline view:

> ![image](https://github.com/user-attachments/assets/df392577-f766-44a6-8925-9634c8ac704f)

This new feature is off by default and requires Ruby 3.3+. This PR introduces a new environment variable (`DD_PROFILING_PREVIEW_GVL_ENABLED`) and setting `c.settings.profiler.advanced.preview_gvl_enabled` to enable the feature.

For more details on why GVL profiling is relevant, check out [Understanding the Ruby Global VM Lock (GVL) by observing it](https://ivoanjo.me/blog/2023/07/23/understanding-the-ruby-global-vm-lock-by-observing-it/).

**Motivation:**

The latency impact of GVL contention has thus far not been observable in most profilers, including ours. You'd see that a thread wasn't running for some time period (let's say 200ms), but it may not be clear that out of those 200ms, maybe the database answered back in 100ms, but then the other 100ms were GVL contention.

This feature (built atop the GVL instrumentation API) finally exposes this information.

**Additional Notes:**

I've written an intro to how this feature is implemented in `docs/ProfilingDevelopment.md`. I suggest starting there to review the PR.

Ruby 3.2 provides some, but not all of the new APIs needed to support this functionality. We should be able to support Ruby 3.2 in the future, but I opted to skip it for this first version as making it work for Ruby 3.3+ was already quite complex.

This PRs includes a few refactoring cleanups to make it easier to introduce the functionality. I opted not to extract them into separate PRs, but I'm open to doing so if it looks this PR is too complex for a good review.

**How to test the change?**

This feature includes test coverage. Additionally, I tried it with a number of examples from the https://github.com/ivoanjo/gvl-tracing gem, which you can see below.

I still plan to do more validation with our usual integration testing apps, but I'm opening this PR already as I think that this feature can be merged as-is while we do more validation. Its blast radius is expected to be extremely small (off by default, only for Ruby 3.3+) and thus we can have it live in master during this extra validation.

https://github.com/ivoanjo/gvl-tracing/blob/master/examples/example4.rb:

> ![image](https://github.com/user-attachments/assets/7de7c8c8-2a96-4188-b3cb-f5b21557ce1a)

https://github.com/ivoanjo/gvl-tracing/blob/master/examples/rubykaigi2023/rk-example2.rb:

> ![image](https://github.com/user-attachments/assets/4031106d-11a2-4d82-878e-6a49360d3251)

https://github.com/ivoanjo/gvl-tracing/blob/master/examples/rubykaigi2023/rk-example4.rb:

> ![image](https://github.com/user-attachments/assets/468eb57d-a299-4d41-a21e-c826cdcadcc7)

https://github.com/ivoanjo/gvl-tracing/blob/master/examples/rubykaigi2023/rk-example6.rb:

![image](https://github.com/user-attachments/assets/57365ffe-1d02-42bd-aaba-0bb39ec64eb1)