### PR TITLE
Split single step instrument entry point

### DIFF
--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -38,6 +38,7 @@ Metrics/BlockNesting:
 # AllowedAcronyms: CLI, DSL, ACL, API, ASCII, CPU, CSS, DNS, EOF, GUID, HTML, HTTP, HTTPS, ID, IP, JSON, LHS, QPS, RAM, RHS, RPC, SLA, SMTP, SQL, SSH, TCP, TLS, TTL, UDP, UI, UID, UUID, URI, URL, UTF8, VM, XML, XMPP, XSRF, XSS
 Naming/FileName:
   Exclude:
+    - 'lib/datadog/single_step_instrument.rb'
     - 'lib/datadog/appsec/autoload.rb'
     - 'lib/datadog/opentelemetry/api/trace/span.rb'
     - 'lib/datadog/opentelemetry/sdk/trace/span.rb'

--- a/lib-injection/host_inject.rb
+++ b/lib-injection/host_inject.rb
@@ -197,7 +197,7 @@ else
 
           bundle_add_cmd = "bundle add #{gem} --skip-install --version #{gem_version_mapping[gem]} "
           bundle_add_cmd << ' --verbose ' if ENV['DD_TRACE_DEBUG'] == 'true'
-          bundle_add_cmd << '--require datadog/auto_instrument' if gem == 'datadog'
+          bundle_add_cmd << '--require datadog/single_step_instrument' if gem == 'datadog'
 
           utils.debug "Injection with `#{bundle_add_cmd}`"
 

--- a/lib/datadog/single_step_instrument.rb
+++ b/lib/datadog/single_step_instrument.rb
@@ -8,5 +8,5 @@
 begin
   require_relative 'auto_instrument'
 rescue StandardError, LoadError => e
-  warn "Single step instrumentation failed: #{e.class}, #{e.message}"
+  warn "Single step instrumentation failed: #{e.class}:#{e.message}\n\tSource:\n\t#{Array(e.backtrace).join("\n\t")}"
 end

--- a/lib/datadog/single_step_instrument.rb
+++ b/lib/datadog/single_step_instrument.rb
@@ -1,0 +1,12 @@
+# frozen_string_literal: true
+
+#
+# Entrypoint file for single step instrumentation.
+#
+# This file's path is private. Do not reference this file.
+#
+begin
+  require_relative 'auto_instrument'
+rescue StandardError, LoadError => e
+  warn "Single step instrumentation failed: #{e.class}, #{e.message}"
+end

--- a/spec/datadog/single_step_instrument_spec.rb
+++ b/spec/datadog/single_step_instrument_spec.rb
@@ -1,4 +1,4 @@
-RSpec.describe 'Single step instrument' do
+RSpec.describe 'Single step instrument', skip: !Process.respond_to?(:fork) do
   it do
     expect_in_fork do
       expect_any_instance_of(Object)

--- a/spec/datadog/single_step_instrument_spec.rb
+++ b/spec/datadog/single_step_instrument_spec.rb
@@ -1,0 +1,23 @@
+RSpec.describe 'Single step instrument' do
+  it do
+    expect_in_fork do
+      expect_any_instance_of(Object)
+        .to receive(:require_relative).with('auto_instrument').and_raise(LoadError)
+
+      expect do
+        load 'datadog/single_step_instrument.rb'
+      end.to output(/Single step instrumentation failed/).to_stderr
+    end
+  end
+
+  it do
+    expect_in_fork do
+      expect_any_instance_of(Object)
+        .to receive(:require_relative).with('auto_instrument').and_raise(StandardError)
+
+      expect do
+        load 'datadog/single_step_instrument.rb'
+      end.to output(/Single step instrumentation failed/).to_stderr
+    end
+  end
+end


### PR DESCRIPTION
**What does this PR do?**

For single step instrumentation, use a different entry point that would rescue `LoadError` and not crash the process.