### PR TITLE
[PROF-10422] Fix flaky spec in profiler due to race

### DIFF
--- a/spec/datadog/profiling/collectors/cpu_and_wall_time_worker_spec.rb
+++ b/spec/datadog/profiling/collectors/cpu_and_wall_time_worker_spec.rb
@@ -155,8 +155,11 @@ RSpec.describe Datadog::Profiling::Collectors::CpuAndWallTimeWorker do
 
       it do
         expect(Datadog.logger).to receive(:warn).with(/GVL profiling is not supported/)
+        proc_called = Queue.new
 
-        cpu_and_wall_time_worker.start
+        cpu_and_wall_time_worker.start(on_failure_proc: proc { proc_called << true })
+
+        proc_called.pop
       end
     end
 


### PR DESCRIPTION
**What does this PR do?**

This PR fixes a flaky spec introduced by #3929: a spec to check that an error was raised in a background thread implicitly depended on a race (that the background thread ran before the rspec thread did) and thus started failing when the race was lost.

By actually synchronizing with the background thread using the `on_failure_proc`, we now guarantee that the background thread has the chance to run as expected.

**Motivation:**

Our goal is to always have zero flaky specs in the profiler!

**Additional Notes:**

Fixes https://github.com/DataDog/ruby-guild/issues/179

**How to test the change?**

Validate that CI is still green.