### PR TITLE
Add missing GraphQL and Hanami tests to CI

### DIFF
--- a/Matrixfile
+++ b/Matrixfile
@@ -283,10 +283,10 @@
     'graphql-2.0'  => '✅ 2.5 / ✅ 2.6 / ✅ 2.7 / ✅ 3.0 / ✅ 3.1 / ✅ 3.2 / ✅ 3.3 / ✅ 3.4 / ✅ jruby',
     'graphql-1.13' => '❌ 2.5 / ✅ 2.6 / ✅ 2.7 / ✅ 3.0 / ✅ 3.1 / ✅ 3.2 / ✅ 3.3 / ✅ 3.4 / ✅ jruby',
   }
-}.flat_map do |tasks, spec_metadata|
-  # Explode arrays of task names into individual tasks
-  # e.g. ['rails', 'railsdisableenv'] => {'...'} becomes [['rails7', '...'], ['railsdisableenv7', '...']]
-  Array(tasks).map { |task| [task, spec_metadata] }
+}.each_with_object({}) do |(tasks, spec_metadata), hash|
+  Array(tasks).each do |task|
+    hash[task] = spec_metadata
+  end
 end.freeze
 # rubocop:enable Layout/HashAlignment
 

--- a/Matrixfile
+++ b/Matrixfile
@@ -79,11 +79,11 @@
   'grape' => {
     'activesupport' => '✅ 2.5 / ✅ 2.6 / ✅ 2.7 / ✅ 3.0 / ✅ 3.1 / ✅ 3.2 / ✅ 3.3 / ✅ 3.4 / ✅ jruby'
   },
-  'graphql' => {
-    'graphql-2.3'  => '❌ 2.5 / ❌ 2.6 / ✅ 2.7 / ✅ 3.0 / ✅ 3.1 / ✅ 3.2 / ✅ 3.3 / ✅ 3.4 / ✅ jruby',
-    'graphql-2.2'  => '❌ 2.5 / ❌ 2.6 / ✅ 2.7 / ✅ 3.0 / ✅ 3.1 / ✅ 3.2 / ✅ 3.3 / ✅ 3.4 / ✅ jruby',
-    'graphql-2.1'  => '❌ 2.5 / ❌ 2.6 / ✅ 2.7 / ✅ 3.0 / ✅ 3.1 / ✅ 3.2 / ✅ 3.3 / ✅ 3.4 / ✅ jruby',
-    'graphql-2.0'  => '✅ 2.5 / ✅ 2.6 / ✅ 2.7 / ✅ 3.0 / ✅ 3.1 / ✅ 3.2 / ✅ 3.3 / ✅ 3.4 / ✅ jruby',
+  ['graphql', 'graphql_unified_trace_patcher', 'graphql_trace_patcher', 'graphql_tracing_patcher'] => {
+    'graphql-2.3' => '❌ 2.5 / ❌ 2.6 / ✅ 2.7 / ✅ 3.0 / ✅ 3.1 / ✅ 3.2 / ✅ 3.3 / ✅ 3.4 / ✅ jruby',
+    'graphql-2.2' => '❌ 2.5 / ❌ 2.6 / ✅ 2.7 / ✅ 3.0 / ✅ 3.1 / ✅ 3.2 / ✅ 3.3 / ✅ 3.4 / ✅ jruby',
+    'graphql-2.1' => '❌ 2.5 / ❌ 2.6 / ✅ 2.7 / ✅ 3.0 / ✅ 3.1 / ✅ 3.2 / ✅ 3.3 / ✅ 3.4 / ✅ jruby',
+    'graphql-2.0' => '✅ 2.5 / ✅ 2.6 / ✅ 2.7 / ✅ 3.0 / ✅ 3.1 / ✅ 3.2 / ✅ 3.3 / ✅ 3.4 / ✅ jruby',
     # Although GraphQL 1.13.x depends on Ruby >= 2.4, but it does not work with Ruby 2.5
     #
     # require 'graphql'
@@ -243,7 +243,7 @@
     'rails6-postgres-redis'  => '✅ 2.5 / ✅ 2.6 / ✅ 2.7 / ❌ 3.0 / ❌ 3.1 / ❌ 3.2 / ❌ 3.3 / ❌ 3.4 / ✅ jruby',
     'rails61-postgres-redis' => '✅ 2.5 / ✅ 2.6 / ✅ 2.7 / ✅ 3.0 / ✅ 3.1 / ✅ 3.2 / ✅ 3.3 / ✅ 3.4 / ✅ jruby'
   },
-  'hanami' => {
+  ['hanami', 'hanami_autoinstrument'] => {
     'hanami-1' => '✅ 2.5 / ✅ 2.6 / ✅ 2.7 / ❌ 3.0 / ❌ 3.1 / ❌ 3.2 / ❌ 3.3 / ❌ 3.4 / ❌ jruby'
   },
   'sinatra' => {
@@ -283,7 +283,11 @@
     'graphql-2.0'  => '✅ 2.5 / ✅ 2.6 / ✅ 2.7 / ✅ 3.0 / ✅ 3.1 / ✅ 3.2 / ✅ 3.3 / ✅ 3.4 / ✅ jruby',
     'graphql-1.13' => '❌ 2.5 / ✅ 2.6 / ✅ 2.7 / ✅ 3.0 / ✅ 3.1 / ✅ 3.2 / ✅ 3.3 / ✅ 3.4 / ✅ jruby',
   }
-}.freeze
+}.flat_map do |tasks, spec_metadata|
+  # Explode arrays of task names into individual tasks
+  # e.g. ['rails', 'railsdisableenv'] => {'...'} becomes [['rails7', '...'], ['railsdisableenv7', '...']]
+  Array(tasks).map { |task| [task, spec_metadata] }
+end.freeze
 # rubocop:enable Layout/HashAlignment
 
 # vim: ft=ruby

--- a/Rakefile
+++ b/Rakefile
@@ -82,6 +82,7 @@ end
 desc 'Run RSpec'
 # rubocop:disable Metrics/BlockLength
 namespace :spec do
+  # REMINDER: If adding a new task here, make sure also add it to the `Matrixfile`
   task all: [:main, :benchmark,
              :graphql, :graphql_unified_trace_patcher, :graphql_trace_patcher, :graphql_tracing_patcher,
              :rails, :railsredis, :railsredis_activesupport, :railsactivejob,
@@ -227,6 +228,7 @@ namespace :spec do
   end
 
   # Datadog Tracing integrations
+  # REMINDER: If adding a new task here, make sure also add it to the `Matrixfile`
   [
     :action_cable,
     :action_mailer,

--- a/docs/DevelopmentGuide.md
+++ b/docs/DevelopmentGuide.md
@@ -53,22 +53,22 @@ All tests should run in CI. When adding new `_spec.rb` files, you may need to ad
  ```ruby
    namespace :spec do
      RSpec::Core::RakeTask.new(:foo) do |t, args|
-       t.pattern = "spec/datadog/tracing/contrib/bar/**/*_spec.rb"
+       t.pattern = "spec/datadog/tracing/contrib/foo/**/*_spec.rb"
        t.rspec_opts = args.to_a.join(' ')
      end
    end
  ```
 
- - Ensure the Rake task is configured to run for the appropriate Ruby runtimes, by introducing it to our test matrix. You should find the task with `bundle exec rake -T test:<foo>`.
+ - Ensure the Rake task is configured to run for the appropriate Ruby runtimes, by adding it to our `Matrixfile`. You should find the task with `bundle exec rake -T test:foo` after adding it.
 
 ```ruby
-  TEST_METADATA = {
+  {
     'foo' => {
       # Without any appraisal group dependencies
       ''    => '✅ 2.1 / ✅ 2.2 / ✅ 2.3 / ✅ 2.4 / ✅ 2.5 / ✅ 2.6 / ✅ 2.7 / ✅ 3.0 / ✅ 3.1 / ✅ 3.2 / ✅ 3.3 / ✅ jruby',
 
-      # or with appraisal group definition `bar`
-      'bar' => '✅ 2.1 / ✅ 2.2 / ✅ 2.3 / ✅ 2.4 / ✅ 2.5 / ✅ 2.6 / ✅ 2.7 / ✅ 3.0 / ✅ 3.1 / ✅ 3.2 / ✅ 3.3 / ✅ jruby'
+      # or with appraisal group definition `foo-on-rails`, that includes additional gems
+      'foo-on-rails' => '✅ 2.1 / ✅ 2.2 / ✅ 2.3 / ✅ 2.4 / ✅ 2.5 / ✅ 2.6 / ✅ 2.7 / ✅ 3.0 / ✅ 3.1 / ✅ 3.2 / ✅ 3.3 / ✅ jruby'
     },
   }
 ```

--- a/spec/datadog/tracing/contrib/graphql/tracing_patcher_spec.rb
+++ b/spec/datadog/tracing/contrib/graphql/tracing_patcher_spec.rb
@@ -35,17 +35,5 @@ RSpec.describe Datadog::Tracing::Contrib::GraphQL::TracingPatcher do
         end
       end
     end
-
-    context 'when given something else' do
-      before { remove_patch!(:graphql) }
-
-      it do
-        expect_any_instance_of(Datadog::Core::Logger).to receive(:warn).with(/Unable to patch/)
-
-        Datadog.configure do |c|
-          c.tracing.instrument :graphql, with_deprecated_tracer: true, schemas: [OpenStruct.new]
-        end
-      end
-    end
   end
 end


### PR DESCRIPTION
This PR adds tests that were added as Rake tasks, but not to the Matrixfile.

It also updates the `docs/DevelopmentGuide.md` to improve a bit on how to add this information when writing new tests.