### PR TITLE
fix: sample on TraceOperation and root span metrics and tags

### DIFF
--- a/lib/datadog/tracing/trace_operation.rb
+++ b/lib/datadog/tracing/trace_operation.rb
@@ -166,7 +166,6 @@ module Datadog
         super || (root_span && root_span.get_tag(key))
       end
 
-
       def get_metric(key)
         @metric[key?] || (root_span && root_span.get_metric(key))
       end
@@ -177,11 +176,6 @@ module Datadog
         all_tags.merge(@tags)
         all_tags.merge(@metrics)
         all_tags
-      end
-
-
-
-        @resource || (root_span && root_span.resource)
       end
 
       # Returns true if the resource has been explicitly set

--- a/lib/datadog/tracing/trace_operation.rb
+++ b/lib/datadog/tracing/trace_operation.rb
@@ -161,6 +161,29 @@ module Datadog
         @resource || (root_span && root_span.resource)
       end
 
+      # When retrieving tags or metrics we need to include root span tags for sampling purposes
+      def get_tag(key)
+        super || (root_span && root_span.get_tag(key))
+      end
+
+
+      def get_metric(key)
+        @metric[key?] || (root_span && root_span.get_metric(key))
+      end
+
+      def tags
+        all_tags = {}
+        all_tags.merge(root_span.tags) if root_span
+        all_tags.merge(@tags)
+        all_tags.merge(@metrics)
+        all_tags
+      end
+
+
+
+        @resource || (root_span && root_span.resource)
+      end
+
       # Returns true if the resource has been explicitly set
       #
       # @return [Boolean]

--- a/lib/datadog/tracing/trace_operation.rb
+++ b/lib/datadog/tracing/trace_operation.rb
@@ -167,7 +167,7 @@ module Datadog
       end
 
       def get_metric(key)
-        @metric[key?] || (root_span && root_span.get_metric(key))
+        super || (root_span && root_span.get_metric(key))
       end
 
       def tags


### PR DESCRIPTION
**What does this PR do?**
By changing what the trace operation returns for its metadata by checking the root span as well for it, we can easily sample on all values both in the trace operation (which will be added to the root span before flush) and the root span. 

**Motivation:**
Previously Ruby was not up to spec because only metadata attached to the trace operation was able to be sampled on. This meant that users could possibly see tag or metric values on the root span in the UI but not be able actually sample on them.

**Additional Notes:**
<!-- Anything else we should know when reviewing? -->

**How to test the change?**
<!--
Describe here how the change can be validated.
You are strongly encouraged to provide automated tests for this PR (unit or integration).
If this change cannot be feasibly tested, please explain why,
unless the change does not modify code (e.g. only modifies docs, comments).
-->

Unsure? Have a question? Request a review!
