### PR TITLE
chore: sample trace before flush unless already sampled

### DIFF
--- a/lib/datadog/tracing/tracer.rb
+++ b/lib/datadog/tracing/tracer.rb
@@ -494,7 +494,11 @@ module Datadog
       def flush_trace(trace_op)
         begin
           trace = @trace_flush.consume!(trace_op)
-          write(trace) if trace && !trace.empty?
+          if trace && !trace.empty?
+            # check if trace is not sampled
+            sample_trace(trace) unless trace.sampled?
+            write(trace)
+          end
         rescue StandardError => e
           FLUSH_TRACE_LOG_ONLY_ONCE.run do
             Datadog.logger.warn { "Failed to flush trace: #{e.class.name} #{e} at #{Array(e.backtrace).first}" }

--- a/lib/datadog/tracing/tracer.rb
+++ b/lib/datadog/tracing/tracer.rb
@@ -496,7 +496,7 @@ module Datadog
           trace = @trace_flush.consume!(trace_op)
           if trace && !trace.empty?
             # check if trace is not sampled
-            sample_trace(trace) unless trace.sampled?
+            sample_trace(trace) unless trace.priority_sampled?
             write(trace)
           end
         rescue StandardError => e


### PR DESCRIPTION
**What does this PR do?**
This PR causes a trace to be sampled during flush with the intent of making sampling lazy. 
**Motivation:**
Lazy sampling allows sampling on tags and resource

**Additional Notes:**
<!-- Anything else we should know when reviewing? -->

**How to test the change?**
<!--
Describe here how the change can be validated.
You are strongly encouraged to provide automated tests for this PR (unit or integration).
If this change cannot be feasibly tested, please explain why,
unless the change does not modify code (e.g. only modifies docs, comments).
-->

Unsure? Have a question? Request a review!
