### PR TITLE
feat: enable lazy sampling

### DIFF
--- a/lib/datadog/tracing/tracer.rb
+++ b/lib/datadog/tracing/tracer.rb
@@ -347,7 +347,6 @@ module Datadog
         events.span_before_start.subscribe do |event_span_op, event_trace_op|
           event_trace_op.service ||= @default_service
           event_span_op.service ||= @default_service
-          sample_trace(event_trace_op) if event_span_op && event_span_op.parent_id == 0
         end
 
         events.span_finished.subscribe do |event_span, event_trace_op|


### PR DESCRIPTION
**What does this PR do?**
By not sampling at span start we are essentially enabling lazy sampling once the groundwork has been merged:
https://github.com/DataDog/dd-trace-rb/pull/3945
https://github.com/DataDog/dd-trace-rb/pull/3946

**Motivation:**
By enabling lazy sampling we can sample on tags and resource

**Additional Notes:**
<!-- Anything else we should know when reviewing? -->

**How to test the change?**
<!--
Describe here how the change can be validated.
You are strongly encouraged to provide automated tests for this PR (unit or integration).
If this change cannot be feasibly tested, please explain why,
unless the change does not modify code (e.g. only modifies docs, comments).
-->

Unsure? Have a question? Request a review!
