### PR TITLE
DEBUG-2334 upgrade steep & rbs

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -82,8 +82,8 @@ end
 
 group :check do
   if RUBY_VERSION >= '3.0.0' && RUBY_PLATFORM != 'java'
-    gem 'rbs', '~> 3.2.0', require: false
-    gem 'steep', '~> 1.6.0', require: false
+    gem 'rbs', '~> 3.5.0', require: false
+    gem 'steep', '~> 1.7.0', require: false
   end
   gem 'ruby_memcheck', '>= 3' if RUBY_VERSION >= '3.4.0' && RUBY_PLATFORM != 'java'
   gem 'standard', require: false

--- a/Steepfile
+++ b/Steepfile
@@ -5,6 +5,8 @@ target :datadog do
 
   ignore 'lib/datadog/appsec.rb'
   ignore 'lib/datadog/appsec/component.rb'
+  # Excluded due to https://github.com/soutaro/steep/issues/1232
+  ignore 'lib/datadog/appsec/configuration/settings.rb'
   ignore 'lib/datadog/appsec/contrib/'
   ignore 'lib/datadog/appsec/contrib/auto_instrument.rb'
   ignore 'lib/datadog/appsec/contrib/integration.rb'

--- a/Steepfile
+++ b/Steepfile
@@ -69,6 +69,8 @@ target :datadog do
   ignore 'lib/datadog/core/metrics/options.rb'
   ignore 'lib/datadog/core/pin.rb'
   ignore 'lib/datadog/core/rate_limiter.rb'
+  # steep fails in this file due to https://github.com/soutaro/steep/issues/1231
+  ignore 'lib/datadog/core/remote/tie.rb'
   ignore 'lib/datadog/core/runtime/ext.rb'
   ignore 'lib/datadog/core/runtime/metrics.rb'
   ignore 'lib/datadog/core/transport/ext.rb'

--- a/lib/datadog/core/environment/execution.rb
+++ b/lib/datadog/core/environment/execution.rb
@@ -25,9 +25,9 @@ module Datadog
           #   2. Checking if `Net::HTTP` is referring to the original one
           #   => ::Net::HTTP.equal?(::WebMock::HttpLibAdapters::NetHttpAdapter::OriginalNetHTTP)
           def webmock_enabled?
-            defined?(::WebMock::HttpLibAdapters::NetHttpAdapter) &&
+            !!(defined?(::WebMock::HttpLibAdapters::NetHttpAdapter) &&
               defined?(::Net::HTTP) &&
-              ::Net::HTTP.equal?(::WebMock::HttpLibAdapters::NetHttpAdapter.instance_variable_get(:@webMockNetHTTP))
+              ::Net::HTTP.equal?(::WebMock::HttpLibAdapters::NetHttpAdapter.instance_variable_get(:@webMockNetHTTP)))
           end
 
           private
@@ -68,7 +68,7 @@ module Datadog
 
           # Check if we are running from `bin/cucumber` or `cucumber/rake/task`.
           def cucumber?
-            defined?(::Cucumber::Cli)
+            !!defined?(::Cucumber::Cli)
           end
 
           # If this is a Rails application, use different heuristics to detect
@@ -80,7 +80,7 @@ module Datadog
             # detecting its presence is enough to deduct if this is a development environment.
             #
             # @see https://github.com/rails/spring/blob/48b299348ace2188444489a0c216a6f3e9687281/README.md?plain=1#L204-L207
-            defined?(::Spring) || rails_env_development?
+            !!defined?(::Spring) || rails_env_development?
           end
 
           RAILS_ENV_DEVELOPMENT = Set['development', 'test'].freeze
@@ -94,7 +94,7 @@ module Datadog
           # it's common to have a custom "staging" environment, and such environment normally want to run as close
           # to production as possible.
           def rails_env_development?
-            defined?(::Rails.env) && RAILS_ENV_DEVELOPMENT.include?(::Rails.env)
+            !!defined?(::Rails.env) && RAILS_ENV_DEVELOPMENT.include?(::Rails.env)
           end
         end
       end

--- a/lib/datadog/core/remote/tie.rb
+++ b/lib/datadog/core/remote/tie.rb
@@ -19,6 +19,8 @@ module Datadog
             barrier = Datadog::Core::Remote.active_remote.barrier(:once)
           end
 
+          # steep does not permit the next line due to
+          # https://github.com/soutaro/steep/issues/1231
           Boot.new(barrier, t)
         end
       end

--- a/sig/datadog/appsec/configuration/settings.rbs
+++ b/sig/datadog/appsec/configuration/settings.rbs
@@ -17,7 +17,7 @@ module Datadog
 
         def self.add_settings!: (untyped base) -> untyped
 
-        def self.enabled:  -> bool
+        def enabled:  -> bool
       end
     end
   end

--- a/sig/datadog/appsec/configuration/settings.rbs
+++ b/sig/datadog/appsec/configuration/settings.rbs
@@ -17,7 +17,7 @@ module Datadog
 
         def self.add_settings!: (untyped base) -> untyped
 
-        def enabled:  -> bool
+        def self.enabled:  -> bool
       end
     end
   end

--- a/sig/datadog/core/remote/tie.rbs
+++ b/sig/datadog/core/remote/tie.rbs
@@ -2,14 +2,14 @@ module Datadog
   module Core
     module Remote
       module Tie
-        class Boot < ::Struct[untyped]
+        class Boot < ::Struct[[Component::Barrier, Numeric]]
           def initialize: (Component::Barrier? barrier, Numeric? time) -> void
 
           attr_reader barrier: Component::Barrier
           attr_reader time: Numeric
         end
 
-        def self.boot: () -> (nil | Boot)
+        def self.boot: () -> Boot?
       end
     end
   end

--- a/sig/datadog/core/telemetry/event.rbs
+++ b/sig/datadog/core/telemetry/event.rbs
@@ -24,7 +24,7 @@ module Datadog
 
           def agent_transport: (untyped config) -> String
 
-          def conf_value: (String name, Object value, Integer seq_id, ?String origin) -> Hash[Symbol, untyped]
+          def conf_value: (String name, untyped value, Integer seq_id, ?String origin) -> Hash[Symbol, untyped]
 
           def to_value: (Object value) -> Object
 


### PR DESCRIPTION
<!--
Check out the
https://github.com/DataDog/dd-trace-rb/blob/master/docs/DevelopmentGuide.md
for guidance on how to set up your development environment,
run the test suite, write new integrations, and more.
-->

**What does this PR do?**
<!-- A brief description of the change being made with this pull request. -->
This PR upgrades steep and rbs to current versions.

For rbs, current version is somehow a 3.6 preview - I constrained it to a 3.5 release instead of using the preview. Can upgrade to the preview if this is more desirable.

**Motivation:**
<!-- What inspired you to submit this pull request? -->
To type check the code tracking component (https://github.com/DataDog/dd-trace-rb/pull/3942) I need type definitions for RubyVM::InstructionSequence which I added in https://github.com/ruby/rbs/pull/2027 to upstream. When I tried to use master of rbs in dd-trace-rb I received several type check errors. This PR repairs the errors to permit usage of current steep & rbs.

**Additional Notes:**
<!-- Anything else we should know when reviewing? -->
- `defined?` returns nil or a string, not a bool. `!!` was added in several places to cast the return value to a boolean.
- "anything" in Ruby is apparently not an Object (I guess there is BasicObject as well?). event.rbs was changed from Object to untyped for "any value", I think "untyped" means anything but correct me if this is not the right type to use.
- The code in tie.rb runs into https://github.com/soutaro/steep/issues/1231 where steep does not assign correct type to a variable when its value is overwritten from an inner scope. I don't know how to fix this error on our side (hoping to receive some guidance in the upstream issue) and in the mean time I added tie.rb to excluded files. I checked steep 1.6 that is currently being used in master and in my testing it seems to have the same behavior/issue, thus I don't know why we currently aren't receiving this error in master. My theory is the file somehow isn't actually checked (maybe surrounding types aren't resolved as well as with steep 1.7 and as a result steep doesn't attempt to do anything on the Boot return).
- The change from `self.enabled` to `enabled` in appsec fixes the test suite but I don't know why it was `self.enabled` before.

**How to test the change?**
<!--
Describe here how the change can be validated.
You are strongly encouraged to provide automated tests for this PR (unit or integration).
If this change cannot be feasibly tested, please explain why,
unless the change does not modify code (e.g. only modifies docs, comments).
-->

Unsure? Have a question? Request a review!
