### PR TITLE
DEBUG-2334 run all existing DI tests only on supported configurations

### DIFF
--- a/spec/datadog/di/probe_builder_spec.rb
+++ b/spec/datadog/di/probe_builder_spec.rb
@@ -1,6 +1,9 @@
+require "datadog/di/spec_helper"
 require "datadog/di/probe_builder"
 
 RSpec.describe Datadog::DI::ProbeBuilder do
+  di_test
+
   describe ".build_from_remote_config" do
     let(:probe) do
       described_class.build_from_remote_config(rc_probe_spec)

--- a/spec/datadog/di/probe_spec.rb
+++ b/spec/datadog/di/probe_spec.rb
@@ -1,6 +1,9 @@
+require "datadog/di/spec_helper"
 require "datadog/di/probe"
 
 RSpec.describe Datadog::DI::Probe do
+  di_test
+
   shared_context "method probe" do
     let(:probe) do
       described_class.new(id: "42", type: "foo", type_name: "Foo", method_name: "bar")


### PR DESCRIPTION
Dynamic instrumentation will not work on Ruby 2.5 and JRuby. Some unit tests will pass on those configurations, but there is no reason to run them there because they run on all of the supported configurations already.

<!--
Check out the
https://github.com/DataDog/dd-trace-rb/blob/master/docs/DevelopmentGuide.md
for guidance on how to set up your development environment,
run the test suite, write new integrations, and more.
-->

**What does this PR do?**
Add `di_test` declaration to all existing DI tests that do not have it.
<!-- A brief description of the change being made with this pull request. -->

**Motivation:**
Faster CI runs.
<!-- What inspired you to submit this pull request? -->

**Additional Notes:**
<!-- Anything else we should know when reviewing? -->

**How to test the change?**
<!--
Describe here how the change can be validated.
You are strongly encouraged to provide automated tests for this PR (unit or integration).
If this change cannot be feasibly tested, please explain why,
unless the change does not modify code (e.g. only modifies docs, comments).
-->

Unsure? Have a question? Request a review!
