### PR TITLE
[WIP] Fix `Process.waitall` hanging when crashtracking enabled

### DIFF
--- a/lib/datadog/core/configuration/components.rb
+++ b/lib/datadog/core/configuration/components.rb
@@ -65,6 +65,7 @@ module Datadog
 
             if (libdatadog_api_failure = Datadog::Core::Crashtracking::Component::LIBDATADOG_API_FAILURE)
               logger.debug("Cannot enable crashtracking: #{libdatadog_api_failure}")
+              # Consider return OpenStruct.new as null object to avoid nil checks
               return
             end
 
@@ -133,6 +134,7 @@ module Datadog
         # If it has another instance to compare to, it will compare
         # and avoid tearing down parts still in use.
         def shutdown!(replacement = nil)
+          crashtracker.stop if crashtracker
           # Shutdown remote configuration
           remote.shutdown! if remote
 

--- a/spec/datadog/core/configuration/components_spec.rb
+++ b/spec/datadog/core/configuration/components_spec.rb
@@ -56,6 +56,7 @@ RSpec.describe Datadog::Core::Configuration::Components do
   describe '::new' do
     let(:tracer) { instance_double(Datadog::Tracing::Tracer) }
     let(:profiler) { Datadog::Profiling.supported? ? instance_double(Datadog::Profiling::Profiler) : nil }
+    let(:crashtracker) { CrashtrackingHelpers.supported? ? instance_double(Datadog::Core::Crashtracking::Component) : nil }
     let(:runtime_metrics) { instance_double(Datadog::Core::Workers::RuntimeMetrics) }
     let(:health_metrics) { instance_double(Datadog::Core::Diagnostics::Health::Metrics) }
 
@@ -67,7 +68,6 @@ RSpec.describe Datadog::Core::Configuration::Components do
       expect(described_class).to receive(:build_tracer)
         .with(settings, agent_settings, logger: logger)
         .and_return(tracer)
-      crashtracker = double('crashtracker')
       expect(described_class).to receive(:build_crashtracker)
         .with(settings, agent_settings, logger: logger)
         .and_return(crashtracker)
@@ -1148,6 +1148,7 @@ RSpec.describe Datadog::Core::Configuration::Components do
         expect(components.health_metrics.statsd).to receive(:close)
         expect(components.telemetry).to receive(:emit_closing!)
         expect(components.telemetry).to receive(:stop!)
+        expect(components.crashtracker).to receive(:stop) unless components.crashtracker.nil?
 
         shutdown!
       end
@@ -1165,6 +1166,7 @@ RSpec.describe Datadog::Core::Configuration::Components do
         let(:health_metrics) { instance_double(Datadog::Core::Diagnostics::Health::Metrics, statsd: statsd) }
         let(:statsd) { instance_double(::Datadog::Statsd) }
         let(:telemetry) { instance_double(Datadog::Core::Telemetry::Component) }
+        let(:crashtracker) { CrashtrackingHelpers.supported? ? instance_double(Datadog::Core::Crashtracking::Component) : nil }
 
         before do
           allow(replacement).to receive(:tracer).and_return(tracer)
@@ -1174,6 +1176,7 @@ RSpec.describe Datadog::Core::Configuration::Components do
           allow(replacement).to receive(:runtime_metrics).and_return(runtime_metrics_worker)
           allow(replacement).to receive(:health_metrics).and_return(health_metrics)
           allow(replacement).to receive(:telemetry).and_return(telemetry)
+          allow(replacement).to receive(:crashtracker).and_return(crashtracker)
         end
       end
 
@@ -1190,6 +1193,7 @@ RSpec.describe Datadog::Core::Configuration::Components do
           expect(components.health_metrics.statsd).to receive(:close)
           expect(components.remote).to receive(:shutdown!)
           expect(components.telemetry).to receive(:stop!)
+          expect(components.crashtracker).to receive(:stop) unless components.crashtracker.nil?
 
           shutdown!
         end
@@ -1209,6 +1213,7 @@ RSpec.describe Datadog::Core::Configuration::Components do
             expect(components.health_metrics.statsd).to receive(:close)
             expect(components.remote).to receive(:shutdown!)
             expect(components.telemetry).to receive(:stop!)
+            expect(components.crashtracker).to receive(:stop) unless components.crashtracker.nil?
 
             shutdown!
           end
@@ -1229,6 +1234,7 @@ RSpec.describe Datadog::Core::Configuration::Components do
           expect(components.health_metrics.statsd).to receive(:close)
           expect(components.remote).to receive(:shutdown!)
           expect(components.telemetry).to receive(:stop!)
+          expect(components.crashtracker).to receive(:stop) unless components.crashtracker.nil?
 
           shutdown!
         end
@@ -1248,6 +1254,7 @@ RSpec.describe Datadog::Core::Configuration::Components do
           expect(components.health_metrics.statsd).to receive(:close)
           expect(components.remote).to receive(:shutdown!)
           expect(components.telemetry).to receive(:stop!)
+          expect(components.crashtracker).to receive(:stop) unless components.crashtracker.nil?
 
           shutdown!
         end
@@ -1268,6 +1275,7 @@ RSpec.describe Datadog::Core::Configuration::Components do
           expect(components.health_metrics.statsd).to_not receive(:close)
           expect(components.remote).to receive(:shutdown!)
           expect(components.telemetry).to receive(:stop!)
+          expect(components.crashtracker).to receive(:stop) unless components.crashtracker.nil?
 
           shutdown!
         end


### PR DESCRIPTION
<!--
Check out the
https://github.com/DataDog/dd-trace-rb/blob/master/docs/DevelopmentGuide.md
for guidance on how to set up your development environment,
run the test suite, write new integrations, and more.
-->

**What does this PR do?**
<!-- A brief description of the change being made with this pull request. -->

**Motivation:**
<!-- What inspired you to submit this pull request? -->

**Additional Notes:**
<!-- Anything else we should know when reviewing? -->

**How to test the change?**
<!--
Describe here how the change can be validated.
You are strongly encouraged to provide automated tests for this PR (unit or integration).
If this change cannot be feasibly tested, please explain why,
unless the change does not modify code (e.g. only modifies docs, comments).
-->

Unsure? Have a question? Request a review!
