### PR TITLE
Fix `spec:appsec:rack` for Rack 3.1 (latest)

### DIFF
--- a/Matrixfile
+++ b/Matrixfile
@@ -258,7 +258,7 @@
     'redis-5' => '✅ 2.5 / ✅ 2.6 / ✅ 2.7 / ✅ 3.0 / ✅ 3.1 / ✅ 3.2 / ✅ 3.3 / ✅ 3.4 / ✅ jruby'
   },
   'appsec:rack' => {
-    # 'rack-latest' => '✅ 2.5 / ✅ 2.6 / ✅ 2.7 / ✅ 3.0 / ✅ 3.1 / ✅ 3.2 / ✅ 3.3 / ✅ 3.4 / ✅ jruby',
+    'rack-latest' => '✅ 2.5 / ✅ 2.6 / ✅ 2.7 / ✅ 3.0 / ✅ 3.1 / ✅ 3.2 / ✅ 3.3 / ✅ 3.4 / ✅ jruby',
     'rack-3'      => '✅ 2.5 / ✅ 2.6 / ✅ 2.7 / ✅ 3.0 / ✅ 3.1 / ✅ 3.2 / ✅ 3.3 / ✅ 3.4 / ✅ jruby',
     'rack-2'      => '✅ 2.5 / ✅ 2.6 / ✅ 2.7 / ✅ 3.0 / ✅ 3.1 / ✅ 3.2 / ✅ 3.3 / ✅ 3.4 / ✅ jruby',
     # Non-deprecated form of Regexp.new does not backport to Rack 1.x, see: https://github.com/rack/rack/pull/1998

--- a/lib/datadog/appsec/contrib/rack/gateway/request.rb
+++ b/lib/datadog/appsec/contrib/rack/gateway/request.rb
@@ -45,12 +45,9 @@ module Datadog
               end
 
               result['content-type'] = request.content_type if request.content_type
-              result['content-length'] = request.content_length if request.content_length
+              # Since Rack 3.1, content-length is nil if the body is empty, but we still want to send it to the WAF.
+              result['content-length'] = request.content_length || '0'
               result
-            end
-
-            def body
-              request.body.read.tap { request.body.rewind }
             end
 
             def url

--- a/spec/datadog/appsec/contrib/rack/gateway/request_spec.rb
+++ b/spec/datadog/appsec/contrib/rack/gateway/request_spec.rb
@@ -65,12 +65,6 @@ RSpec.describe Datadog::AppSec::Contrib::Rack::Gateway::Request do
     end
   end
 
-  describe '#body' do
-    it 'returns the body' do
-      expect(request.body).to eq('')
-    end
-  end
-
   describe '#url' do
     it 'returns the url' do
       expect(request.url).to eq('http://example.com:8080/?a=foo&a=bar&b=baz')


### PR DESCRIPTION
<!--
Check out the
https://github.com/DataDog/dd-trace-rb/blob/master/docs/DevelopmentGuide.md
for guidance on how to set up your development environment,
run the test suite, write new integrations, and more.
-->

**What does this PR do?**
<!-- A brief description of the change being made with this pull request. -->
This PR fix `spec:appsec:rack` by deleting the `#body` method from the Rack request gateway (as this method is not used anywhere in our code, and the reactive engine uses `#form_hash` to send the body to the WAF) and sets a default value of `'0'` to `headers['content-length']`

**Motivation:**
<!-- What inspired you to submit this pull request? -->
`spec:appsec:rack` was failing for Rack 3.1+. Rack is used by most, if not all of our clients, we must be sure to support the latest version (hopefully these failing tests were not critical)

Unsure? Have a question? Request a review!
