### PR TITLE
DEBUG-2334 Add integration_test helper

### DIFF
--- a/spec/datadog/core/remote/transport/integration_spec.rb
+++ b/spec/datadog/core/remote/transport/integration_spec.rb
@@ -8,7 +8,7 @@ require 'datadog/core/remote/transport/http/negotiation'
 require 'datadog/core/remote/transport/negotiation'
 
 RSpec.describe Datadog::Core::Remote::Transport::HTTP do
-  before { skip unless ENV['TEST_DATADOG_INTEGRATION'] }
+  integration_test
 
   describe '.root' do
     subject(:transport) { described_class.root(&client_options) }

--- a/spec/datadog/core/remote/transport/integration_spec.rb
+++ b/spec/datadog/core/remote/transport/integration_spec.rb
@@ -8,7 +8,7 @@ require 'datadog/core/remote/transport/http/negotiation'
 require 'datadog/core/remote/transport/negotiation'
 
 RSpec.describe Datadog::Core::Remote::Transport::HTTP do
-  integration_test
+  skip_unless_integration_testing_enabled
 
   describe '.root' do
     subject(:transport) { described_class.root(&client_options) }

--- a/spec/datadog/tracing/contrib/ethon/integration_test_spec.rb
+++ b/spec/datadog/tracing/contrib/ethon/integration_test_spec.rb
@@ -13,7 +13,7 @@ require 'datadog/tracing/contrib/support/http'
 require 'spec/datadog/tracing/contrib/ethon/support/thread_helpers'
 
 RSpec.describe 'Ethon integration tests' do
-  integration_test
+  skip_unless_integration_testing_enabled
 
   context 'with Easy HTTP request' do
     subject(:request) do

--- a/spec/datadog/tracing/contrib/ethon/integration_test_spec.rb
+++ b/spec/datadog/tracing/contrib/ethon/integration_test_spec.rb
@@ -13,7 +13,7 @@ require 'datadog/tracing/contrib/support/http'
 require 'spec/datadog/tracing/contrib/ethon/support/thread_helpers'
 
 RSpec.describe 'Ethon integration tests' do
-  before { skip unless ENV['TEST_DATADOG_INTEGRATION'] }
+  integration_test
 
   context 'with Easy HTTP request' do
     subject(:request) do

--- a/spec/datadog/tracing/contrib/ethon/typhoeus_integration_spec.rb
+++ b/spec/datadog/tracing/contrib/ethon/typhoeus_integration_spec.rb
@@ -5,7 +5,7 @@ require 'datadog/tracing/contrib/ethon/integration_context'
 require 'spec/datadog/tracing/contrib/ethon/support/thread_helpers'
 
 RSpec.describe Datadog::Tracing::Contrib::Ethon do
-  integration_test
+  skip_unless_integration_testing_enabled
 
   before(:context) do
     # Ethon will lazily initialize LibCurl,

--- a/spec/datadog/tracing/contrib/ethon/typhoeus_integration_spec.rb
+++ b/spec/datadog/tracing/contrib/ethon/typhoeus_integration_spec.rb
@@ -5,7 +5,7 @@ require 'datadog/tracing/contrib/ethon/integration_context'
 require 'spec/datadog/tracing/contrib/ethon/support/thread_helpers'
 
 RSpec.describe Datadog::Tracing::Contrib::Ethon do
-  before { skip unless ENV['TEST_DATADOG_INTEGRATION'] }
+  integration_test
 
   before(:context) do
     # Ethon will lazily initialize LibCurl,

--- a/spec/datadog/tracing/contrib/redis/instrumentation_spec.rb
+++ b/spec/datadog/tracing/contrib/redis/instrumentation_spec.rb
@@ -4,7 +4,7 @@ require 'redis'
 require 'datadog'
 
 RSpec.describe 'Redis instrumentation test' do
-  integration_test
+  skip_unless_integration_testing_enabled
 
   let(:test_host) { ENV.fetch('TEST_REDIS_HOST', '127.0.0.1') }
   let(:test_port) { ENV.fetch('TEST_REDIS_PORT', 6379).to_i }

--- a/spec/datadog/tracing/contrib/redis/instrumentation_spec.rb
+++ b/spec/datadog/tracing/contrib/redis/instrumentation_spec.rb
@@ -4,6 +4,8 @@ require 'redis'
 require 'datadog'
 
 RSpec.describe 'Redis instrumentation test' do
+  integration_test
+
   let(:test_host) { ENV.fetch('TEST_REDIS_HOST', '127.0.0.1') }
   let(:test_port) { ENV.fetch('TEST_REDIS_PORT', 6379).to_i }
 
@@ -18,10 +20,6 @@ RSpec.describe 'Redis instrumentation test' do
     Datadog.registry[:redis].reset_configuration!
     example.run
     Datadog.registry[:redis].reset_configuration!
-  end
-
-  before do
-    skip unless ENV['TEST_DATADOG_INTEGRATION']
   end
 
   RSpec::Matchers.define :be_a_redis_span do

--- a/spec/datadog/tracing/contrib/redis/integration_test_spec.rb
+++ b/spec/datadog/tracing/contrib/redis/integration_test_spec.rb
@@ -5,9 +5,9 @@ require 'redis'
 require 'datadog'
 
 RSpec.describe 'Redis integration test' do
-  before do
-    skip unless ENV['TEST_DATADOG_INTEGRATION']
+  integration_test
 
+  before do
     use_real_tracer!
 
     Datadog.configure do |c|

--- a/spec/datadog/tracing/contrib/redis/integration_test_spec.rb
+++ b/spec/datadog/tracing/contrib/redis/integration_test_spec.rb
@@ -5,7 +5,7 @@ require 'redis'
 require 'datadog'
 
 RSpec.describe 'Redis integration test' do
-  integration_test
+  skip_unless_integration_testing_enabled
 
   before do
     use_real_tracer!

--- a/spec/datadog/tracing/contrib/redis/miniapp_spec.rb
+++ b/spec/datadog/tracing/contrib/redis/miniapp_spec.rb
@@ -6,7 +6,7 @@ require 'redis'
 require 'datadog'
 
 RSpec.describe 'Redis mini app test' do
-  before { skip unless ENV['TEST_DATADOG_INTEGRATION'] }
+  integration_test
 
   before do
     Datadog.configure { |c| c.tracing.instrument :redis }

--- a/spec/datadog/tracing/contrib/redis/miniapp_spec.rb
+++ b/spec/datadog/tracing/contrib/redis/miniapp_spec.rb
@@ -6,7 +6,7 @@ require 'redis'
 require 'datadog'
 
 RSpec.describe 'Redis mini app test' do
-  integration_test
+  skip_unless_integration_testing_enabled
 
   before do
     Datadog.configure { |c| c.tracing.instrument :redis }

--- a/spec/datadog/tracing/integration_spec.rb
+++ b/spec/datadog/tracing/integration_spec.rb
@@ -20,7 +20,7 @@ require 'datadog/tracing/transport/traces'
 
 RSpec.describe 'Tracer integration tests' do
   shared_context 'agent-based test' do
-    integration_test
+    skip_unless_integration_testing_enabled
 
     before do
       # Ensure background Writer worker doesn't wait, making tests faster.

--- a/spec/datadog/tracing/integration_spec.rb
+++ b/spec/datadog/tracing/integration_spec.rb
@@ -20,9 +20,9 @@ require 'datadog/tracing/transport/traces'
 
 RSpec.describe 'Tracer integration tests' do
   shared_context 'agent-based test' do
-    before do
-      skip unless ENV['TEST_DATADOG_INTEGRATION']
+    integration_test
 
+    before do
       # Ensure background Writer worker doesn't wait, making tests faster.
       stub_const('Datadog::Tracing::Workers::AsyncTransport::DEFAULT_FLUSH_INTERVAL', 0)
 

--- a/spec/datadog/tracing/transport/http/adapters/net_integration_spec.rb
+++ b/spec/datadog/tracing/transport/http/adapters/net_integration_spec.rb
@@ -7,7 +7,7 @@ require 'datadog/tracing/transport/http'
 require 'datadog/core/transport/http/adapters/net'
 
 RSpec.describe 'Adapters::Net tracing integration tests' do
-  before { skip('Skipping test as ENV["TEST_DATADOG_INTEGRATION"] is not set') unless ENV['TEST_DATADOG_INTEGRATION'] }
+  integration_test
 
   subject(:adapter) { Datadog::Core::Transport::HTTP::Adapters::Net.new(agent_settings) }
 

--- a/spec/datadog/tracing/transport/http/adapters/net_integration_spec.rb
+++ b/spec/datadog/tracing/transport/http/adapters/net_integration_spec.rb
@@ -7,7 +7,7 @@ require 'datadog/tracing/transport/http'
 require 'datadog/core/transport/http/adapters/net'
 
 RSpec.describe 'Adapters::Net tracing integration tests' do
-  integration_test
+  skip_unless_integration_testing_enabled
 
   subject(:adapter) { Datadog::Core::Transport::HTTP::Adapters::Net.new(agent_settings) }
 

--- a/spec/datadog/tracing/transport/http/adapters/unix_socket_integration_spec.rb
+++ b/spec/datadog/tracing/transport/http/adapters/unix_socket_integration_spec.rb
@@ -7,7 +7,7 @@ require 'datadog/tracing/transport/http'
 require 'datadog/core/transport/http/adapters/unix_socket'
 
 RSpec.describe 'Adapters::UnixSocket integration tests' do
-  before { skip unless ENV['TEST_DATADOG_INTEGRATION'] }
+  integration_test
 
   subject(:adapter) { Datadog::Core::Transport::HTTP::Adapters::UnixSocket.new(**options) }
 

--- a/spec/datadog/tracing/transport/http/adapters/unix_socket_integration_spec.rb
+++ b/spec/datadog/tracing/transport/http/adapters/unix_socket_integration_spec.rb
@@ -7,7 +7,7 @@ require 'datadog/tracing/transport/http'
 require 'datadog/core/transport/http/adapters/unix_socket'
 
 RSpec.describe 'Adapters::UnixSocket integration tests' do
-  integration_test
+  skip_unless_integration_testing_enabled
 
   subject(:adapter) { Datadog::Core::Transport::HTTP::Adapters::UnixSocket.new(**options) }
 

--- a/spec/datadog/tracing/transport/http/integration_spec.rb
+++ b/spec/datadog/tracing/transport/http/integration_spec.rb
@@ -6,7 +6,7 @@ require 'datadog/tracing/transport/http/traces'
 require 'datadog/tracing/transport/traces'
 
 RSpec.describe 'Datadog::Tracing::Transport::HTTP integration tests' do
-  integration_test
+  skip_unless_integration_testing_enabled
 
   describe 'HTTP#default' do
     subject(:transport) { Datadog::Tracing::Transport::HTTP.default(&client_options) }

--- a/spec/datadog/tracing/transport/http/integration_spec.rb
+++ b/spec/datadog/tracing/transport/http/integration_spec.rb
@@ -6,7 +6,7 @@ require 'datadog/tracing/transport/http/traces'
 require 'datadog/tracing/transport/traces'
 
 RSpec.describe 'Datadog::Tracing::Transport::HTTP integration tests' do
-  before { skip unless ENV['TEST_DATADOG_INTEGRATION'] }
+  integration_test
 
   describe 'HTTP#default' do
     subject(:transport) { Datadog::Tracing::Transport::HTTP.default(&client_options) }

--- a/spec/support/core_helpers.rb
+++ b/spec/support/core_helpers.rb
@@ -49,7 +49,7 @@ module CoreHelpers
     def integration_test
       unless ENV['TEST_DATADOG_INTEGRATION']
         before(:all) do
-          skip "Set TEST_DATADOG_INTEGRATION=1 in environment to run this test"
+          skip 'Set TEST_DATADOG_INTEGRATION=1 in environment to run this test'
         end
       end
     end

--- a/spec/support/core_helpers.rb
+++ b/spec/support/core_helpers.rb
@@ -44,4 +44,18 @@ module CoreHelpers
       false
     end
   end
+
+  module ClassMethods
+    def integration_test
+      unless ENV['TEST_DATADOG_INTEGRATION']
+        before(:all) do
+          skip "Set TEST_DATADOG_INTEGRATION=1 in environment to run this test"
+        end
+      end
+    end
+  end
+
+  def self.included(base)
+    base.extend ClassMethods
+  end
 end

--- a/spec/support/core_helpers.rb
+++ b/spec/support/core_helpers.rb
@@ -46,7 +46,7 @@ module CoreHelpers
   end
 
   module ClassMethods
-    def integration_test
+    def skip_unless_integration_testing_enabled
       unless ENV['TEST_DATADOG_INTEGRATION']
         before(:all) do
           skip 'Set TEST_DATADOG_INTEGRATION=1 in environment to run this test'

--- a/spec/support/test_helpers.rb
+++ b/spec/support/test_helpers.rb
@@ -11,7 +11,7 @@ module TestHelpers
     module Integration
       def self.included(base)
         base.class_exec do
-          integration_test
+          skip_unless_integration_testing_enabled
 
           include_context 'non-development execution environment'
         end

--- a/spec/support/test_helpers.rb
+++ b/spec/support/test_helpers.rb
@@ -11,11 +11,7 @@ module TestHelpers
     module Integration
       def self.included(base)
         base.class_exec do
-          before do
-            unless ENV['TEST_DATADOG_INTEGRATION']
-              skip('Integration tests can be enabled by setting the environment variable `TEST_DATADOG_INTEGRATION=1`')
-            end
-          end
+          integration_test
 
           include_context 'non-development execution environment'
         end


### PR DESCRIPTION
DRY the logic to skip integration tests into a class-level helper

<!--
Check out the
https://github.com/DataDog/dd-trace-rb/blob/master/docs/DevelopmentGuide.md
for guidance on how to set up your development environment,
run the test suite, write new integrations, and more.
-->

**What does this PR do?**
<!-- A brief description of the change being made with this pull request. -->
Adds `integration_test` helper method to mark test cases that require a running agent.

**Motivation:**
<!-- What inspired you to submit this pull request? -->
Testing of DI network clients.

**Additional Notes:**
<!-- Anything else we should know when reviewing? -->

**How to test the change?**
No code changes in this PR.
<!--
Describe here how the change can be validated.
You are strongly encouraged to provide automated tests for this PR (unit or integration).
If this change cannot be feasibly tested, please explain why,
unless the change does not modify code (e.g. only modifies docs, comments).
-->

Unsure? Have a question? Request a review!
