### PR TITLE
Reduce test flakiness for telemetry request spec

### DIFF
--- a/spec/datadog/core/telemetry/request_spec.rb
+++ b/spec/datadog/core/telemetry/request_spec.rb
@@ -3,6 +3,14 @@ require 'spec_helper'
 require 'datadog/core/telemetry/request'
 
 RSpec.describe Datadog::Core::Telemetry::Request do
+  before do
+    # The tests here assert on time equality after rounding to a second;
+    # these assertions will fail if the code executes just before
+    # a second boundary and the assertions run just after the second boundary.
+    # Align the runs closer to the beginning of a second to reduce flakiness.
+    sleep 0 until Time.now.usec < 750000
+  end
+
   describe '.build_payload' do
     subject { described_class.build_payload(event, seq_id) }
     let(:event) { double('event', payload: payload, type: request_type) }


### PR DESCRIPTION
<!--
Check out the
https://github.com/DataDog/dd-trace-rb/blob/master/docs/DevelopmentGuide.md
for guidance on how to set up your development environment,
run the test suite, write new integrations, and more.
-->

**What does this PR do?**
<!-- A brief description of the change being made with this pull request. -->
This PR inserts a brief wait (up to 0.25 seconds) for telemetry request spec to avoid the code under test and the test code happening in different whole seconds, which would then fail a test assertion.

**Motivation:**
<!-- What inspired you to submit this pull request? -->
Repair the following observed CI failure:
```

  1) Datadog::Core::Telemetry::Request.build_payload is expected to eq {:api_version=>"v2", :application=>{:env=>"env", :language_name=>"ruby", :language_version=>"2.5.9", ...e_id=>"40935bf2-7e96-4797-af75-b687b45ad719", :seq_id=>#<Double "seq_id">, :tracer_time=>1727716350}
     Failure/Error:
       is_expected.to eq(
         api_version: api_version,
         application: application,
         debug: debug,
         host: host,
         payload: payload,
         request_type: request_type,
         runtime_id: runtime_id,
         seq_id: seq_id,
         tracer_time: tracer_time,

       expected: {:api_version=>"v2", :application=>{:env=>"env", :language_name=>"ruby", :language_version=>"2.5.9", ...e_id=>"40935bf2-7e96-4797-af75-b687b45ad719", :seq_id=>#<Double "seq_id">, :tracer_time=>1727716350}
            got: {:api_version=>"v2", :application=>{:env=>"env", :language_name=>"ruby", :language_version=>"2.5.9", ...e_id=>"40935bf2-7e96-4797-af75-b687b45ad719", :seq_id=>#<Double "seq_id">, :tracer_time=>1727716349}

       (compared using ==)

       Diff:
       @@ -6,5 +6,5 @@
        :request_type => #<Double "request_type">,
        :runtime_id => "40935bf2-7e96-4797-af75-b687b45ad719",
        :seq_id => #<Double "seq_id">,
       -:tracer_time => 1727716350,
       +:tracer_time => 1727716349,
     # ./spec/datadog/core/telemetry/request_spec.rb:65:in `block (3 levels) in <top (required)>'
     # ./spec/spec_helper.rb:231:in `block (2 levels) in <top (required)>'
     # ./spec/spec_helper.rb:116:in `block (2 levels) in <top (required)>'
```


**Additional Notes:**
<!-- Anything else we should know when reviewing? -->

**How to test the change?**
<!--
Describe here how the change can be validated.
You are strongly encouraged to provide automated tests for this PR (unit or integration).
If this change cannot be feasibly tested, please explain why,
unless the change does not modify code (e.g. only modifies docs, comments).
-->

On my machine the failure can be reliably reproduced by changing the sleep into
```
    sleep 0 until Time.now.usec > 995700
```

The required time is the approximate time of the second test's execution subtracted from 1,000,000.

Unsure? Have a question? Request a review!
