### PR TITLE
Add all supported weblogs to system-tests GH Workflow file

### DIFF
--- a/.github/workflows/system-tests.yml
+++ b/.github/workflows/system-tests.yml
@@ -98,7 +98,7 @@ jobs:
           - sinatra31
           - sinatra32
           - sinatra40
-#          - rails42 # DEV: Uncomment after https://github.com/DataDog/system-tests/pull/3142 is merged
+          - rails42
           - rails50
           - rails51
           - rails52
@@ -186,7 +186,7 @@ jobs:
           - sinatra31
           - sinatra32
           - sinatra40
-#          - rails42 # DEV: Uncomment after https://github.com/DataDog/system-tests/pull/3142 is merged
+          - rails42
           - rails50
           - rails51
           - rails52
@@ -329,7 +329,7 @@ jobs:
           - sinatra31
           - sinatra32
           - sinatra40
-#          - rails42 # DEV: Uncomment after https://github.com/DataDog/system-tests/pull/3142 is merged
+          - rails42
           - rails50
           - rails51
           - rails52
@@ -383,7 +383,7 @@ jobs:
           - weblog-sinatra32
           - weblog-sinatra32
           - weblog-sinatra40
-#          - weblog-rails42 # DEV: Uncomment after https://github.com/DataDog/system-tests/pull/3142 is merged
+          - weblog-rails42
           - weblog-rails50
           - weblog-rails51
           - weblog-rails52

--- a/.github/workflows/system-tests.yml
+++ b/.github/workflows/system-tests.yml
@@ -90,9 +90,15 @@ jobs:
             path: dd-trace-rb
         app:
           - rack
-#           - sinatra14 # DEV-2.0: Uncomment after https://github.com/DataDog/system-tests/pull/1882 is merged
+          - sinatra14
           - sinatra20
           - sinatra21
+          - sinatra22
+          - sinatra30
+          - sinatra31
+          - sinatra32
+          - sinatra40
+#          - rails42 # DEV: Uncomment after https://github.com/DataDog/system-tests/pull/3142 is merged
           - rails50
           - rails51
           - rails52
@@ -172,9 +178,15 @@ jobs:
           - ruby
         app:
           - rack
-#           - sinatra14 # DEV-2.0: Uncomment after https://github.com/DataDog/system-tests/pull/1882 is merged
+          - sinatra14
           - sinatra20
           - sinatra21
+          - sinatra22
+          - sinatra30
+          - sinatra31
+          - sinatra32
+          - sinatra40
+#          - rails42 # DEV: Uncomment after https://github.com/DataDog/system-tests/pull/3142 is merged
           - rails50
           - rails51
           - rails52
@@ -309,9 +321,15 @@ jobs:
           - ruby
         app:
           - rack
-#           - sinatra14 # DEV-2.0: Uncomment after https://github.com/DataDog/system-tests/pull/1882 is merged
+          - sinatra14
           - sinatra20
           - sinatra21
+          - sinatra22
+          - sinatra30
+          - sinatra31
+          - sinatra32
+          - sinatra40
+#          - rails42 # DEV: Uncomment after https://github.com/DataDog/system-tests/pull/3142 is merged
           - rails50
           - rails51
           - rails52
@@ -357,9 +375,15 @@ jobs:
           - runner
           - agent
           - weblog-rack
-#           - weblog-sinatra14 # DEV-2.0: Uncomment after https://github.com/DataDog/system-tests/pull/1882 is merged
+          - weblog-sinatra14
           - weblog-sinatra20
           - weblog-sinatra21
+          - weblog-sinatra22
+          - weblog-sinatra30
+          - weblog-sinatra32
+          - weblog-sinatra32
+          - weblog-sinatra40
+#          - weblog-rails42 # DEV: Uncomment after https://github.com/DataDog/system-tests/pull/3142 is merged
           - weblog-rails50
           - weblog-rails51
           - weblog-rails52

--- a/.github/workflows/system-tests.yml
+++ b/.github/workflows/system-tests.yml
@@ -380,7 +380,7 @@ jobs:
           - weblog-sinatra21
           - weblog-sinatra22
           - weblog-sinatra30
-          - weblog-sinatra32
+          - weblog-sinatra31
           - weblog-sinatra32
           - weblog-sinatra40
           - weblog-rails42


### PR DESCRIPTION
<!--
Check out the
https://github.com/DataDog/dd-trace-rb/blob/master/docs/DevelopmentGuide.md
for guidance on how to set up your development environment,
run the test suite, write new integrations, and more.
-->

**What does this PR do?**
<!-- A brief description of the change being made with this pull request. -->

This PR adds all system-tests available weblogs to system-tests GH workflow file.

**Additional Notes:**
<!-- Anything else we should know when reviewing? -->

Rails 4.2 weblog should be uncommented before merging this PR, when [this system-tests PR](https://github.com/DataDog/system-tests/pull/3142) will be merged

**How to test the change?**
<!--
Describe here how the change can be validated.
You are strongly encouraged to provide automated tests for this PR (unit or integration).
If this change cannot be feasibly tested, please explain why,
unless the change does not modify code (e.g. only modifies docs, comments).
-->

GH Actions should test it automatically
