### PR TITLE
Add a force disable of appsec when using Ruby >= 3.3 with old ffi

### DIFF
--- a/lib/datadog/appsec/component.rb
+++ b/lib/datadog/appsec/component.rb
@@ -31,7 +31,8 @@ module Datadog
 
         def incompatible_ffi_version?
           ffi_version = Gem.loaded_specs['ffi'] && Gem.loaded_specs['ffi'].version
-          return false unless RUBY_VERSION >= '3.3.0' && ffi_version < '1.16.0'
+          return false unless Gem::Version.new(RUBY_VERSION) >= Gem::Version.new('3.3') &&
+            ffi_version < Gem::Version.new('1.16.0')
 
           Datadog.logger.warn(
             'AppSec is not supported in Ruby versions above 3.3.0 when using `ffi` versions older than 1.16.0, ' \

--- a/lib/datadog/appsec/component.rb
+++ b/lib/datadog/appsec/component.rb
@@ -31,17 +31,15 @@ module Datadog
 
         def incompatible_ffi_version?
           ffi_version = Gem.loaded_specs['ffi'] && Gem.loaded_specs['ffi'].version
-          if RUBY_VERSION >= '3.3.0' && ffi_version < '1.16.0'
-            Datadog.logger.warn(
-              'AppSec is not supported in Ruby versions above 3.3.0 when using `ffi` versions older than 1.16.0, ' \
-              'and will be forcibly disabled due to a memory leak in `ffi`. ' \
-              'Please upgrade your `ffi` version to 1.16.0 or higher.'
-            )
+          return false unless RUBY_VERSION >= '3.3.0' && ffi_version < '1.16.0'
 
-            true
-          else
-            false
-          end
+          Datadog.logger.warn(
+            'AppSec is not supported in Ruby versions above 3.3.0 when using `ffi` versions older than 1.16.0, ' \
+            'and will be forcibly disabled due to a memory leak in `ffi`. ' \
+            'Please upgrade your `ffi` version to 1.16.0 or higher.'
+          )
+
+          true
         end
 
         def create_processor(settings, telemetry)

--- a/spec/datadog/appsec/component_spec.rb
+++ b/spec/datadog/appsec/component_spec.rb
@@ -19,6 +19,20 @@ RSpec.describe Datadog::AppSec::Component do
         expect(component).to be_a(described_class)
       end
 
+      context 'when using old ffi version with Ruby 3.3.x' do
+        before do
+          stub_const('RUBY_VERSION', '3.3.0')
+          allow(Gem).to receive(:loaded_specs).and_return('ffi' => double(version: Gem::Version.new('1.15.4')))
+        end
+
+        it 'returns a Datadog::AppSec::Component instance with a nil processor' do
+          expect(Datadog.logger).to receive(:warn)
+
+          component = described_class.build_appsec_component(settings, telemetry: telemetry)
+          expect(component).to be_nil
+        end
+      end
+
       context 'when processor is ready' do
         it 'returns a Datadog::AppSec::Component with a processor instance' do
           expect_any_instance_of(Datadog::AppSec::Processor).to receive(:ready?).and_return(true)


### PR DESCRIPTION
Ruby 3.3.0 and above has a memory leak when using `libddwaf-rb` with `ffi` gem older than 1.16.0.

We want to avoid forcing our customers to update `ffi` gem by setting the minimum version in `libddwaf-rb`, since prebuilt `ffi` extension is incompatible with rubygems version supplied with ruby 2.7 and below.

The memory leak happens because `ffi` gem used untyped DATA API prior to this commit (which is part of 1.16.0 release):
https://github.com/ffi/ffi/commit/ca2744aed44da7486b3839b879388af3f6307a88

**Motivation:**
Memory leak that occurs when enabling `appsec` for applications running on ruby 3.3.x and an old version of `ffi` gem locked in Gemfile.lock (older than `1.16.0`).