### PR TITLE
Disable crashtracking by default

### DIFF
--- a/lib/datadog/core/configuration/settings.rb
+++ b/lib/datadog/core/configuration/settings.rb
@@ -886,7 +886,7 @@ module Datadog
           # Enables reporting of information when Ruby VM crashes.
           option :enabled do |o|
             o.type :bool
-            o.default true
+            o.default false
             o.env 'DD_CRASHTRACKING_ENABLED'
           end
         end

--- a/spec/datadog/core/configuration/settings_spec.rb
+++ b/spec/datadog/core/configuration/settings_spec.rb
@@ -1967,7 +1967,7 @@ RSpec.describe Datadog::Core::Configuration::Settings do
         context 'is not defined' do
           let(:environment) { nil }
 
-          it { is_expected.to be true }
+          it { is_expected.to be false }
         end
 
         [true, false].each do |value|
@@ -1982,9 +1982,9 @@ RSpec.describe Datadog::Core::Configuration::Settings do
 
     describe '#enabled=' do
       it 'updates the #enabled setting' do
-        expect { settings.crashtracking.enabled = false }
+        expect { settings.crashtracking.enabled = true }
           .to change { settings.crashtracking.enabled }
-          .from(true).to(false)
+          .from(false).to(true)
       end
     end
   end

--- a/spec/datadog/core/crashtracking/component_spec.rb
+++ b/spec/datadog/core/crashtracking/component_spec.rb
@@ -97,13 +97,6 @@ RSpec.describe Datadog::Core::Crashtracking::Component, skip: !CrashtrackingHelp
   end
 
   context 'instance methods' do
-    # No crash tracker process should still be running at the start of each testcase
-    around do |example|
-      wait_for { `pgrep -f libdatadog-crashtracking-receiver` }.to be_empty
-      example.run
-      wait_for { `pgrep -f libdatadog-crashtracking-receiver` }.to be_empty
-    end
-
     describe '#start' do
       context 'when _native_start_or_update_on_fork raises an exception' do
         it 'logs the exception' do
@@ -114,56 +107,6 @@ RSpec.describe Datadog::Core::Crashtracking::Component, skip: !CrashtrackingHelp
           expect(logger).to receive(:error).with(/Failed to start crash tracking: Test failure/)
 
           crashtracker.start
-        end
-      end
-
-      it 'starts the crash tracker' do
-        crashtracker = build_crashtracker
-
-        crashtracker.start
-
-        wait_for { `pgrep -f libdatadog-crashtracking-receiver` }.to_not be_empty
-
-        tear_down!
-      end
-
-      context 'when calling start multiple times in a row' do
-        it 'only starts the crash tracker once' do
-          crashtracker = build_crashtracker
-
-          3.times { crashtracker.start }
-
-          wait_for { `pgrep -f libdatadog-crashtracking-receiver`.lines.size }.to be 1
-
-          tear_down!
-        end
-      end
-
-      context 'when multiple instances' do
-        it 'only starts the crash tracker once' do
-          crashtracker = build_crashtracker
-          crashtracker.start
-
-          another_crashtracker = build_crashtracker
-          another_crashtracker.start
-
-          wait_for { `pgrep -f libdatadog-crashtracking-receiver`.lines.size }.to be 1
-
-          tear_down!
-        end
-      end
-
-      context 'when forked' do
-        it 'starts a second crash tracker for the fork' do
-          crashtracker = build_crashtracker
-
-          crashtracker.start
-
-          expect_in_fork do
-            wait_for { `pgrep -f libdatadog-crashtracking-receiver`.lines.size }.to be 2
-          end
-
-          tear_down!
         end
       end
     end
@@ -179,18 +122,6 @@ RSpec.describe Datadog::Core::Crashtracking::Component, skip: !CrashtrackingHelp
 
           crashtracker.stop
         end
-      end
-
-      it 'stops the crash tracker' do
-        crashtracker = build_crashtracker
-
-        crashtracker.start
-
-        wait_for { `pgrep -f libdatadog-crashtracking-receiver`.lines.size }.to eq 1
-
-        crashtracker.stop
-
-        wait_for { `pgrep -f libdatadog-crashtracking-receiver` }.to be_empty
       end
     end
 
@@ -215,17 +146,6 @@ RSpec.describe Datadog::Core::Crashtracking::Component, skip: !CrashtrackingHelp
         crashtracker = build_crashtracker
 
         crashtracker.update_on_fork
-      end
-
-      it 'updates existing crash tracking process after started' do
-        crashtracker = build_crashtracker
-
-        crashtracker.start
-        crashtracker.update_on_fork
-
-        wait_for { `pgrep -f libdatadog-crashtracking-receiver`.lines.size }.to be 1
-
-        tear_down!
       end
     end
 
@@ -358,36 +278,6 @@ RSpec.describe Datadog::Core::Crashtracking::Component, skip: !CrashtrackingHelp
           expect(crash_report_message[:metadata]).to_not be_empty
           expect(crash_report_message[:files][:'/proc/self/maps']).to_not be_empty
           expect(crash_report_message[:os_info]).to_not be_empty
-        end
-      end
-
-      context 'when forked' do
-        # This integration test coverages the case that
-        # the callback registered with `Utils::AtForkMonkeyPatch.at_fork`
-        # does not contain a stale instance of the crashtracker component.
-        it 'ensures the latest configuration applied' do
-          allow(described_class).to receive(:_native_start_or_update_on_fork)
-
-          # `Datadog.configure` to trigger crashtracking component reinstantiation,
-          #  a callback is first registered with `Utils::AtForkMonkeyPatch.at_fork`,
-          #  but not with the second `Datadog.configure` invokation.
-          Datadog.configure do |c|
-            c.agent.host = 'example.com'
-          end
-
-          Datadog.configure do |c|
-            c.agent.host = 'google.com'
-            c.agent.port = 12345
-          end
-
-          expect_in_fork do
-            expect(described_class).to have_received(:_native_start_or_update_on_fork).with(
-              hash_including(
-                action: :update_on_fork,
-                agent_base_url: 'http://google.com:12345/',
-              )
-            )
-          end
         end
       end
     end


### PR DESCRIPTION
<!--
Check out the
https://github.com/DataDog/dd-trace-rb/blob/master/docs/DevelopmentGuide.md
for guidance on how to set up your development environment,
run the test suite, write new integrations, and more.
-->

**What does this PR do?**

Disable by default as a cautionary measure.

**Motivation:**

Crashtracking has been identified as causing issues with `ECHILD` and `waitpid`, and possibly anything involving `SIGCHLD` with obscure failure modes of hard to anticipate consequences.

**Additional Notes:**

- Mitigates #3954.
- Attempted fix for `Process.wait(pid)` at #3959, but the problem is more intricate.
- Deeper fix `libdatadog` pending.

**How to test the change?**

<!--
Describe here how the change can be validated.
You are strongly encouraged to provide automated tests for this PR (unit or integration).
If this change cannot be feasibly tested, please explain why,
unless the change does not modify code (e.g. only modifies docs, comments).
-->

CI
