### PR TITLE
Bump debase-ruby_core_source dependency to 3.3.5

### DIFF
--- a/datadog.gemspec
+++ b/datadog.gemspec
@@ -64,7 +64,7 @@ Gem::Specification.new do |spec|
   # Used by the profiler native extension to support Ruby < 2.6 and > 3.2
   #
   # We decided to pin it at the latest available version and will manually bump the dependency as needed.
-  spec.add_dependency 'debase-ruby_core_source', '= 3.3.1'
+  spec.add_dependency 'debase-ruby_core_source', '= 3.3.5'
 
   # Used by appsec
   spec.add_dependency 'libddwaf', '~> 1.14.0.0.0'

--- a/gemfiles/jruby_9.2_activesupport.gemfile.lock
+++ b/gemfiles/jruby_9.2_activesupport.gemfile.lock
@@ -12,7 +12,7 @@ PATH
   remote: ..
   specs:
     datadog (2.3.0)
-      debase-ruby_core_source (= 3.3.1)
+      debase-ruby_core_source (= 3.3.5)
       libdatadog (~> 12.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
@@ -62,7 +62,7 @@ GEM
     crack (0.4.5)
       rexml
     crass (1.0.6)
-    debase-ruby_core_source (3.3.1)
+    debase-ruby_core_source (3.3.5)
     diff-lcs (1.5.0)
     digest-crc (0.6.5)
       rake (>= 12.0.0, < 14.0.0)

--- a/gemfiles/jruby_9.2_aws.gemfile.lock
+++ b/gemfiles/jruby_9.2_aws.gemfile.lock
@@ -12,7 +12,7 @@ PATH
   remote: ..
   specs:
     datadog (2.3.0)
-      debase-ruby_core_source (= 3.3.1)
+      debase-ruby_core_source (= 3.3.5)
       libdatadog (~> 12.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
@@ -1454,7 +1454,7 @@ GEM
     concurrent-ruby (1.2.2)
     crack (0.4.5)
       rexml
-    debase-ruby_core_source (3.3.1)
+    debase-ruby_core_source (3.3.5)
     diff-lcs (1.5.0)
     docile (1.4.0)
     dogstatsd-ruby (5.6.0)

--- a/gemfiles/jruby_9.2_contrib.gemfile.lock
+++ b/gemfiles/jruby_9.2_contrib.gemfile.lock
@@ -12,7 +12,7 @@ PATH
   remote: ..
   specs:
     datadog (2.3.0)
-      debase-ruby_core_source (= 3.3.1)
+      debase-ruby_core_source (= 3.3.5)
       libdatadog (~> 12.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
@@ -40,7 +40,7 @@ GEM
     crack (0.4.5)
       rexml
     dalli (3.2.0)
-    debase-ruby_core_source (3.3.1)
+    debase-ruby_core_source (3.3.5)
     diff-lcs (1.5.0)
     docile (1.4.0)
     dogstatsd-ruby (5.6.0)

--- a/gemfiles/jruby_9.2_contrib_old.gemfile.lock
+++ b/gemfiles/jruby_9.2_contrib_old.gemfile.lock
@@ -12,7 +12,7 @@ PATH
   remote: ..
   specs:
     datadog (2.3.0)
-      debase-ruby_core_source (= 3.3.1)
+      debase-ruby_core_source (= 3.3.5)
       libdatadog (~> 12.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
@@ -34,7 +34,7 @@ GEM
     crack (0.4.5)
       rexml
     dalli (2.7.11)
-    debase-ruby_core_source (3.3.1)
+    debase-ruby_core_source (3.3.5)
     diff-lcs (1.5.0)
     docile (1.4.0)
     dogstatsd-ruby (5.5.0)

--- a/gemfiles/jruby_9.2_core_old.gemfile.lock
+++ b/gemfiles/jruby_9.2_core_old.gemfile.lock
@@ -12,7 +12,7 @@ PATH
   remote: ..
   specs:
     datadog (2.3.0)
-      debase-ruby_core_source (= 3.3.1)
+      debase-ruby_core_source (= 3.3.5)
       libdatadog (~> 12.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
@@ -33,7 +33,7 @@ GEM
     concurrent-ruby (1.1.10)
     crack (0.4.5)
       rexml
-    debase-ruby_core_source (3.3.1)
+    debase-ruby_core_source (3.3.5)
     diff-lcs (1.5.0)
     docile (1.4.0)
     dogstatsd-ruby (4.8.3)

--- a/gemfiles/jruby_9.2_elasticsearch_7.gemfile.lock
+++ b/gemfiles/jruby_9.2_elasticsearch_7.gemfile.lock
@@ -12,7 +12,7 @@ PATH
   remote: ..
   specs:
     datadog (2.3.0)
-      debase-ruby_core_source (= 3.3.1)
+      debase-ruby_core_source (= 3.3.5)
       libdatadog (~> 12.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
@@ -34,7 +34,7 @@ GEM
     concurrent-ruby (1.2.2)
     crack (0.4.5)
       rexml
-    debase-ruby_core_source (3.3.1)
+    debase-ruby_core_source (3.3.5)
     diff-lcs (1.5.0)
     docile (1.4.0)
     dogstatsd-ruby (5.6.1)

--- a/gemfiles/jruby_9.2_elasticsearch_8.gemfile.lock
+++ b/gemfiles/jruby_9.2_elasticsearch_8.gemfile.lock
@@ -12,7 +12,7 @@ PATH
   remote: ..
   specs:
     datadog (2.3.0)
-      debase-ruby_core_source (= 3.3.1)
+      debase-ruby_core_source (= 3.3.5)
       libdatadog (~> 12.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
@@ -34,7 +34,7 @@ GEM
     concurrent-ruby (1.2.2)
     crack (0.4.5)
       rexml
-    debase-ruby_core_source (3.3.1)
+    debase-ruby_core_source (3.3.5)
     diff-lcs (1.5.0)
     docile (1.4.0)
     dogstatsd-ruby (5.6.1)

--- a/gemfiles/jruby_9.2_elasticsearch_latest.gemfile.lock
+++ b/gemfiles/jruby_9.2_elasticsearch_latest.gemfile.lock
@@ -12,7 +12,7 @@ PATH
   remote: ..
   specs:
     datadog (2.3.0)
-      debase-ruby_core_source (= 3.3.1)
+      debase-ruby_core_source (= 3.3.5)
       libdatadog (~> 12.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
@@ -36,7 +36,7 @@ GEM
     crack (1.0.0)
       bigdecimal
       rexml
-    debase-ruby_core_source (3.3.1)
+    debase-ruby_core_source (3.3.5)
     diff-lcs (1.5.1)
     docile (1.4.1)
     dogstatsd-ruby (5.6.1)

--- a/gemfiles/jruby_9.2_graphql_2.0.gemfile.lock
+++ b/gemfiles/jruby_9.2_graphql_2.0.gemfile.lock
@@ -12,7 +12,7 @@ PATH
   remote: ..
   specs:
     datadog (2.3.0)
-      debase-ruby_core_source (= 3.3.1)
+      debase-ruby_core_source (= 3.3.5)
       libdatadog (~> 12.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
@@ -96,7 +96,7 @@ GEM
     crack (0.4.5)
       rexml
     crass (1.0.6)
-    debase-ruby_core_source (3.3.1)
+    debase-ruby_core_source (3.3.5)
     diff-lcs (1.5.0)
     digest (3.1.1-java)
     docile (1.4.0)

--- a/gemfiles/jruby_9.2_http.gemfile.lock
+++ b/gemfiles/jruby_9.2_http.gemfile.lock
@@ -12,7 +12,7 @@ PATH
   remote: ..
   specs:
     datadog (2.3.0)
-      debase-ruby_core_source (= 3.3.1)
+      debase-ruby_core_source (= 3.3.5)
       libdatadog (~> 12.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
@@ -33,7 +33,7 @@ GEM
     concurrent-ruby (1.2.2)
     crack (0.4.5)
       rexml
-    debase-ruby_core_source (3.3.1)
+    debase-ruby_core_source (3.3.5)
     diff-lcs (1.5.0)
     docile (1.4.0)
     dogstatsd-ruby (5.6.1)

--- a/gemfiles/jruby_9.2_opensearch_2.gemfile.lock
+++ b/gemfiles/jruby_9.2_opensearch_2.gemfile.lock
@@ -12,7 +12,7 @@ PATH
   remote: ..
   specs:
     datadog (2.3.0)
-      debase-ruby_core_source (= 3.3.1)
+      debase-ruby_core_source (= 3.3.5)
       libdatadog (~> 12.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
@@ -34,7 +34,7 @@ GEM
     concurrent-ruby (1.2.2)
     crack (0.4.5)
       rexml
-    debase-ruby_core_source (3.3.1)
+    debase-ruby_core_source (3.3.5)
     diff-lcs (1.5.0)
     docile (1.4.0)
     dogstatsd-ruby (5.6.1)

--- a/gemfiles/jruby_9.2_opensearch_3.gemfile.lock
+++ b/gemfiles/jruby_9.2_opensearch_3.gemfile.lock
@@ -12,7 +12,7 @@ PATH
   remote: ..
   specs:
     datadog (2.3.0)
-      debase-ruby_core_source (= 3.3.1)
+      debase-ruby_core_source (= 3.3.5)
       libdatadog (~> 12.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
@@ -34,7 +34,7 @@ GEM
     concurrent-ruby (1.2.2)
     crack (0.4.5)
       rexml
-    debase-ruby_core_source (3.3.1)
+    debase-ruby_core_source (3.3.5)
     diff-lcs (1.5.0)
     docile (1.4.0)
     dogstatsd-ruby (5.6.1)

--- a/gemfiles/jruby_9.2_opensearch_latest.gemfile.lock
+++ b/gemfiles/jruby_9.2_opensearch_latest.gemfile.lock
@@ -12,7 +12,7 @@ PATH
   remote: ..
   specs:
     datadog (2.3.0)
-      debase-ruby_core_source (= 3.3.1)
+      debase-ruby_core_source (= 3.3.5)
       libdatadog (~> 12.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
@@ -36,7 +36,7 @@ GEM
     crack (1.0.0)
       bigdecimal
       rexml
-    debase-ruby_core_source (3.3.1)
+    debase-ruby_core_source (3.3.5)
     diff-lcs (1.5.1)
     docile (1.4.1)
     dogstatsd-ruby (5.6.1)

--- a/gemfiles/jruby_9.2_rack_1.gemfile.lock
+++ b/gemfiles/jruby_9.2_rack_1.gemfile.lock
@@ -12,7 +12,7 @@ PATH
   remote: ..
   specs:
     datadog (2.3.0)
-      debase-ruby_core_source (= 3.3.1)
+      debase-ruby_core_source (= 3.3.5)
       libdatadog (~> 12.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
@@ -33,7 +33,7 @@ GEM
     concurrent-ruby (1.2.2)
     crack (0.4.5)
       rexml
-    debase-ruby_core_source (3.3.1)
+    debase-ruby_core_source (3.3.5)
     diff-lcs (1.5.0)
     docile (1.4.0)
     dogstatsd-ruby (5.6.1)

--- a/gemfiles/jruby_9.2_rack_2.gemfile.lock
+++ b/gemfiles/jruby_9.2_rack_2.gemfile.lock
@@ -12,7 +12,7 @@ PATH
   remote: ..
   specs:
     datadog (2.3.0)
-      debase-ruby_core_source (= 3.3.1)
+      debase-ruby_core_source (= 3.3.5)
       libdatadog (~> 12.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
@@ -33,7 +33,7 @@ GEM
     concurrent-ruby (1.2.2)
     crack (0.4.5)
       rexml
-    debase-ruby_core_source (3.3.1)
+    debase-ruby_core_source (3.3.5)
     diff-lcs (1.5.0)
     docile (1.4.0)
     dogstatsd-ruby (5.6.1)

--- a/gemfiles/jruby_9.2_rack_3.gemfile.lock
+++ b/gemfiles/jruby_9.2_rack_3.gemfile.lock
@@ -12,7 +12,7 @@ PATH
   remote: ..
   specs:
     datadog (2.3.0)
-      debase-ruby_core_source (= 3.3.1)
+      debase-ruby_core_source (= 3.3.5)
       libdatadog (~> 12.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
@@ -33,7 +33,7 @@ GEM
     concurrent-ruby (1.2.2)
     crack (0.4.5)
       rexml
-    debase-ruby_core_source (3.3.1)
+    debase-ruby_core_source (3.3.5)
     diff-lcs (1.5.0)
     docile (1.4.0)
     dogstatsd-ruby (5.6.1)

--- a/gemfiles/jruby_9.2_rack_latest.gemfile.lock
+++ b/gemfiles/jruby_9.2_rack_latest.gemfile.lock
@@ -12,7 +12,7 @@ PATH
   remote: ..
   specs:
     datadog (2.3.0)
-      debase-ruby_core_source (= 3.3.1)
+      debase-ruby_core_source (= 3.3.5)
       libdatadog (~> 12.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
@@ -36,7 +36,7 @@ GEM
     crack (1.0.0)
       bigdecimal
       rexml
-    debase-ruby_core_source (3.3.1)
+    debase-ruby_core_source (3.3.5)
     diff-lcs (1.5.1)
     docile (1.4.1)
     dogstatsd-ruby (5.6.2)

--- a/gemfiles/jruby_9.2_rails5_mysql2.gemfile.lock
+++ b/gemfiles/jruby_9.2_rails5_mysql2.gemfile.lock
@@ -12,7 +12,7 @@ PATH
   remote: ..
   specs:
     datadog (2.3.0)
-      debase-ruby_core_source (= 3.3.1)
+      debase-ruby_core_source (= 3.3.5)
       libdatadog (~> 12.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
@@ -82,7 +82,7 @@ GEM
     crack (0.4.5)
       rexml
     crass (1.0.6)
-    debase-ruby_core_source (3.3.1)
+    debase-ruby_core_source (3.3.5)
     diff-lcs (1.5.0)
     docile (1.4.0)
     dogstatsd-ruby (5.5.0)

--- a/gemfiles/jruby_9.2_rails5_postgres.gemfile.lock
+++ b/gemfiles/jruby_9.2_rails5_postgres.gemfile.lock
@@ -12,7 +12,7 @@ PATH
   remote: ..
   specs:
     datadog (2.3.0)
-      debase-ruby_core_source (= 3.3.1)
+      debase-ruby_core_source (= 3.3.5)
       libdatadog (~> 12.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
@@ -82,7 +82,7 @@ GEM
     crack (0.4.5)
       rexml
     crass (1.0.6)
-    debase-ruby_core_source (3.3.1)
+    debase-ruby_core_source (3.3.5)
     diff-lcs (1.5.0)
     digest (3.1.1-java)
     docile (1.4.0)

--- a/gemfiles/jruby_9.2_rails5_postgres_redis.gemfile.lock
+++ b/gemfiles/jruby_9.2_rails5_postgres_redis.gemfile.lock
@@ -12,7 +12,7 @@ PATH
   remote: ..
   specs:
     datadog (2.3.0)
-      debase-ruby_core_source (= 3.3.1)
+      debase-ruby_core_source (= 3.3.5)
       libdatadog (~> 12.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
@@ -83,7 +83,7 @@ GEM
     crack (0.4.5)
       rexml
     crass (1.0.6)
-    debase-ruby_core_source (3.3.1)
+    debase-ruby_core_source (3.3.5)
     diff-lcs (1.5.0)
     digest (3.1.1-java)
     docile (1.4.0)

--- a/gemfiles/jruby_9.2_rails5_postgres_redis_activesupport.gemfile.lock
+++ b/gemfiles/jruby_9.2_rails5_postgres_redis_activesupport.gemfile.lock
@@ -12,7 +12,7 @@ PATH
   remote: ..
   specs:
     datadog (2.3.0)
-      debase-ruby_core_source (= 3.3.1)
+      debase-ruby_core_source (= 3.3.5)
       libdatadog (~> 12.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
@@ -82,7 +82,7 @@ GEM
     crack (0.4.5)
       rexml
     crass (1.0.6)
-    debase-ruby_core_source (3.3.1)
+    debase-ruby_core_source (3.3.5)
     diff-lcs (1.5.0)
     digest (3.1.1-java)
     docile (1.4.0)

--- a/gemfiles/jruby_9.2_rails5_postgres_sidekiq.gemfile.lock
+++ b/gemfiles/jruby_9.2_rails5_postgres_sidekiq.gemfile.lock
@@ -12,7 +12,7 @@ PATH
   remote: ..
   specs:
     datadog (2.3.0)
-      debase-ruby_core_source (= 3.3.1)
+      debase-ruby_core_source (= 3.3.5)
       libdatadog (~> 12.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
@@ -83,7 +83,7 @@ GEM
     crack (0.4.5)
       rexml
     crass (1.0.6)
-    debase-ruby_core_source (3.3.1)
+    debase-ruby_core_source (3.3.5)
     diff-lcs (1.5.0)
     digest (3.1.1-java)
     docile (1.4.0)

--- a/gemfiles/jruby_9.2_rails5_semantic_logger.gemfile.lock
+++ b/gemfiles/jruby_9.2_rails5_semantic_logger.gemfile.lock
@@ -12,7 +12,7 @@ PATH
   remote: ..
   specs:
     datadog (2.3.0)
-      debase-ruby_core_source (= 3.3.1)
+      debase-ruby_core_source (= 3.3.5)
       libdatadog (~> 12.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
@@ -82,7 +82,7 @@ GEM
     crack (0.4.5)
       rexml
     crass (1.0.6)
-    debase-ruby_core_source (3.3.1)
+    debase-ruby_core_source (3.3.5)
     diff-lcs (1.5.0)
     digest (3.1.1-java)
     docile (1.4.0)

--- a/gemfiles/jruby_9.2_rails61_mysql2.gemfile.lock
+++ b/gemfiles/jruby_9.2_rails61_mysql2.gemfile.lock
@@ -12,7 +12,7 @@ PATH
   remote: ..
   specs:
     datadog (2.3.0)
-      debase-ruby_core_source (= 3.3.1)
+      debase-ruby_core_source (= 3.3.5)
       libdatadog (~> 12.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
@@ -99,7 +99,7 @@ GEM
     crack (0.4.5)
       rexml
     crass (1.0.6)
-    debase-ruby_core_source (3.3.1)
+    debase-ruby_core_source (3.3.5)
     diff-lcs (1.5.0)
     docile (1.4.0)
     dogstatsd-ruby (5.5.0)

--- a/gemfiles/jruby_9.2_rails61_postgres.gemfile.lock
+++ b/gemfiles/jruby_9.2_rails61_postgres.gemfile.lock
@@ -12,7 +12,7 @@ PATH
   remote: ..
   specs:
     datadog (2.3.0)
-      debase-ruby_core_source (= 3.3.1)
+      debase-ruby_core_source (= 3.3.5)
       libdatadog (~> 12.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
@@ -99,7 +99,7 @@ GEM
     crack (0.4.5)
       rexml
     crass (1.0.6)
-    debase-ruby_core_source (3.3.1)
+    debase-ruby_core_source (3.3.5)
     diff-lcs (1.5.0)
     digest (3.1.1-java)
     docile (1.4.0)

--- a/gemfiles/jruby_9.2_rails61_postgres_redis.gemfile.lock
+++ b/gemfiles/jruby_9.2_rails61_postgres_redis.gemfile.lock
@@ -12,7 +12,7 @@ PATH
   remote: ..
   specs:
     datadog (2.3.0)
-      debase-ruby_core_source (= 3.3.1)
+      debase-ruby_core_source (= 3.3.5)
       libdatadog (~> 12.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
@@ -100,7 +100,7 @@ GEM
     crack (0.4.5)
       rexml
     crass (1.0.6)
-    debase-ruby_core_source (3.3.1)
+    debase-ruby_core_source (3.3.5)
     diff-lcs (1.5.0)
     digest (3.1.1-java)
     docile (1.4.0)

--- a/gemfiles/jruby_9.2_rails61_postgres_sidekiq.gemfile.lock
+++ b/gemfiles/jruby_9.2_rails61_postgres_sidekiq.gemfile.lock
@@ -12,7 +12,7 @@ PATH
   remote: ..
   specs:
     datadog (2.3.0)
-      debase-ruby_core_source (= 3.3.1)
+      debase-ruby_core_source (= 3.3.5)
       libdatadog (~> 12.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
@@ -100,7 +100,7 @@ GEM
     crack (0.4.5)
       rexml
     crass (1.0.6)
-    debase-ruby_core_source (3.3.1)
+    debase-ruby_core_source (3.3.5)
     diff-lcs (1.5.0)
     digest (3.1.1-java)
     docile (1.4.0)

--- a/gemfiles/jruby_9.2_rails61_semantic_logger.gemfile.lock
+++ b/gemfiles/jruby_9.2_rails61_semantic_logger.gemfile.lock
@@ -12,7 +12,7 @@ PATH
   remote: ..
   specs:
     datadog (2.3.0)
-      debase-ruby_core_source (= 3.3.1)
+      debase-ruby_core_source (= 3.3.5)
       libdatadog (~> 12.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
@@ -99,7 +99,7 @@ GEM
     crack (0.4.5)
       rexml
     crass (1.0.6)
-    debase-ruby_core_source (3.3.1)
+    debase-ruby_core_source (3.3.5)
     diff-lcs (1.5.0)
     digest (3.1.1-java)
     docile (1.4.0)

--- a/gemfiles/jruby_9.2_rails6_mysql2.gemfile.lock
+++ b/gemfiles/jruby_9.2_rails6_mysql2.gemfile.lock
@@ -12,7 +12,7 @@ PATH
   remote: ..
   specs:
     datadog (2.3.0)
-      debase-ruby_core_source (= 3.3.1)
+      debase-ruby_core_source (= 3.3.5)
       libdatadog (~> 12.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
@@ -95,7 +95,7 @@ GEM
     crack (0.4.5)
       rexml
     crass (1.0.6)
-    debase-ruby_core_source (3.3.1)
+    debase-ruby_core_source (3.3.5)
     diff-lcs (1.5.0)
     docile (1.4.0)
     dogstatsd-ruby (5.5.0)

--- a/gemfiles/jruby_9.2_rails6_postgres.gemfile.lock
+++ b/gemfiles/jruby_9.2_rails6_postgres.gemfile.lock
@@ -12,7 +12,7 @@ PATH
   remote: ..
   specs:
     datadog (2.3.0)
-      debase-ruby_core_source (= 3.3.1)
+      debase-ruby_core_source (= 3.3.5)
       libdatadog (~> 12.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
@@ -95,7 +95,7 @@ GEM
     crack (0.4.5)
       rexml
     crass (1.0.6)
-    debase-ruby_core_source (3.3.1)
+    debase-ruby_core_source (3.3.5)
     diff-lcs (1.5.0)
     digest (3.1.1-java)
     docile (1.4.0)

--- a/gemfiles/jruby_9.2_rails6_postgres_redis.gemfile.lock
+++ b/gemfiles/jruby_9.2_rails6_postgres_redis.gemfile.lock
@@ -12,7 +12,7 @@ PATH
   remote: ..
   specs:
     datadog (2.3.0)
-      debase-ruby_core_source (= 3.3.1)
+      debase-ruby_core_source (= 3.3.5)
       libdatadog (~> 12.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
@@ -96,7 +96,7 @@ GEM
     crack (0.4.5)
       rexml
     crass (1.0.6)
-    debase-ruby_core_source (3.3.1)
+    debase-ruby_core_source (3.3.5)
     diff-lcs (1.5.0)
     digest (3.1.1-java)
     docile (1.4.0)

--- a/gemfiles/jruby_9.2_rails6_postgres_redis_activesupport.gemfile.lock
+++ b/gemfiles/jruby_9.2_rails6_postgres_redis_activesupport.gemfile.lock
@@ -12,7 +12,7 @@ PATH
   remote: ..
   specs:
     datadog (2.3.0)
-      debase-ruby_core_source (= 3.3.1)
+      debase-ruby_core_source (= 3.3.5)
       libdatadog (~> 12.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
@@ -95,7 +95,7 @@ GEM
     crack (0.4.5)
       rexml
     crass (1.0.6)
-    debase-ruby_core_source (3.3.1)
+    debase-ruby_core_source (3.3.5)
     diff-lcs (1.5.0)
     digest (3.1.1-java)
     docile (1.4.0)

--- a/gemfiles/jruby_9.2_rails6_postgres_sidekiq.gemfile.lock
+++ b/gemfiles/jruby_9.2_rails6_postgres_sidekiq.gemfile.lock
@@ -12,7 +12,7 @@ PATH
   remote: ..
   specs:
     datadog (2.3.0)
-      debase-ruby_core_source (= 3.3.1)
+      debase-ruby_core_source (= 3.3.5)
       libdatadog (~> 12.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
@@ -96,7 +96,7 @@ GEM
     crack (0.4.5)
       rexml
     crass (1.0.6)
-    debase-ruby_core_source (3.3.1)
+    debase-ruby_core_source (3.3.5)
     diff-lcs (1.5.0)
     digest (3.1.1-java)
     docile (1.4.0)

--- a/gemfiles/jruby_9.2_rails6_semantic_logger.gemfile.lock
+++ b/gemfiles/jruby_9.2_rails6_semantic_logger.gemfile.lock
@@ -12,7 +12,7 @@ PATH
   remote: ..
   specs:
     datadog (2.3.0)
-      debase-ruby_core_source (= 3.3.1)
+      debase-ruby_core_source (= 3.3.5)
       libdatadog (~> 12.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
@@ -95,7 +95,7 @@ GEM
     crack (0.4.5)
       rexml
     crass (1.0.6)
-    debase-ruby_core_source (3.3.1)
+    debase-ruby_core_source (3.3.5)
     diff-lcs (1.5.0)
     digest (3.1.1-java)
     docile (1.4.0)

--- a/gemfiles/jruby_9.2_redis_3.gemfile.lock
+++ b/gemfiles/jruby_9.2_redis_3.gemfile.lock
@@ -12,7 +12,7 @@ PATH
   remote: ..
   specs:
     datadog (2.3.0)
-      debase-ruby_core_source (= 3.3.1)
+      debase-ruby_core_source (= 3.3.5)
       libdatadog (~> 12.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
@@ -33,7 +33,7 @@ GEM
     concurrent-ruby (1.1.10)
     crack (0.4.5)
       rexml
-    debase-ruby_core_source (3.3.1)
+    debase-ruby_core_source (3.3.5)
     diff-lcs (1.5.0)
     docile (1.4.0)
     dogstatsd-ruby (5.5.0)

--- a/gemfiles/jruby_9.2_redis_4.gemfile.lock
+++ b/gemfiles/jruby_9.2_redis_4.gemfile.lock
@@ -12,7 +12,7 @@ PATH
   remote: ..
   specs:
     datadog (2.3.0)
-      debase-ruby_core_source (= 3.3.1)
+      debase-ruby_core_source (= 3.3.5)
       libdatadog (~> 12.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
@@ -33,7 +33,7 @@ GEM
     concurrent-ruby (1.1.10)
     crack (0.4.5)
       rexml
-    debase-ruby_core_source (3.3.1)
+    debase-ruby_core_source (3.3.5)
     diff-lcs (1.5.0)
     docile (1.4.0)
     dogstatsd-ruby (5.5.0)

--- a/gemfiles/jruby_9.2_redis_5.gemfile.lock
+++ b/gemfiles/jruby_9.2_redis_5.gemfile.lock
@@ -12,7 +12,7 @@ PATH
   remote: ..
   specs:
     datadog (2.3.0)
-      debase-ruby_core_source (= 3.3.1)
+      debase-ruby_core_source (= 3.3.5)
       libdatadog (~> 12.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
@@ -34,7 +34,7 @@ GEM
     connection_pool (2.3.0)
     crack (0.4.5)
       rexml
-    debase-ruby_core_source (3.3.1)
+    debase-ruby_core_source (3.3.5)
     diff-lcs (1.5.0)
     docile (1.4.0)
     dogstatsd-ruby (5.5.0)

--- a/gemfiles/jruby_9.2_relational_db.gemfile.lock
+++ b/gemfiles/jruby_9.2_relational_db.gemfile.lock
@@ -12,7 +12,7 @@ PATH
   remote: ..
   specs:
     datadog (2.3.0)
-      debase-ruby_core_source (= 3.3.1)
+      debase-ruby_core_source (= 3.3.5)
       libdatadog (~> 12.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
@@ -57,7 +57,7 @@ GEM
     concurrent-ruby (1.2.2)
     crack (0.4.5)
       rexml
-    debase-ruby_core_source (3.3.1)
+    debase-ruby_core_source (3.3.5)
     delayed_job (4.1.11)
       activesupport (>= 3.0, < 8.0)
     delayed_job_active_record (4.1.7)

--- a/gemfiles/jruby_9.2_resque2_redis3.gemfile.lock
+++ b/gemfiles/jruby_9.2_resque2_redis3.gemfile.lock
@@ -12,7 +12,7 @@ PATH
   remote: ..
   specs:
     datadog (2.3.0)
-      debase-ruby_core_source (= 3.3.1)
+      debase-ruby_core_source (= 3.3.5)
       libdatadog (~> 12.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
@@ -33,7 +33,7 @@ GEM
     concurrent-ruby (1.1.10)
     crack (0.4.5)
       rexml
-    debase-ruby_core_source (3.3.1)
+    debase-ruby_core_source (3.3.5)
     diff-lcs (1.5.0)
     docile (1.4.0)
     dogstatsd-ruby (5.5.0)

--- a/gemfiles/jruby_9.2_resque2_redis4.gemfile.lock
+++ b/gemfiles/jruby_9.2_resque2_redis4.gemfile.lock
@@ -12,7 +12,7 @@ PATH
   remote: ..
   specs:
     datadog (2.3.0)
-      debase-ruby_core_source (= 3.3.1)
+      debase-ruby_core_source (= 3.3.5)
       libdatadog (~> 12.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
@@ -34,7 +34,7 @@ GEM
     connection_pool (2.3.0)
     crack (0.4.5)
       rexml
-    debase-ruby_core_source (3.3.1)
+    debase-ruby_core_source (3.3.5)
     diff-lcs (1.5.0)
     docile (1.4.0)
     dogstatsd-ruby (5.5.0)

--- a/gemfiles/jruby_9.2_sinatra_2.gemfile.lock
+++ b/gemfiles/jruby_9.2_sinatra_2.gemfile.lock
@@ -12,7 +12,7 @@ PATH
   remote: ..
   specs:
     datadog (2.3.0)
-      debase-ruby_core_source (= 3.3.1)
+      debase-ruby_core_source (= 3.3.5)
       libdatadog (~> 12.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
@@ -36,7 +36,7 @@ GEM
     crack (1.0.0)
       bigdecimal
       rexml
-    debase-ruby_core_source (3.3.1)
+    debase-ruby_core_source (3.3.5)
     diff-lcs (1.5.1)
     docile (1.4.0)
     dogstatsd-ruby (5.6.1)

--- a/gemfiles/jruby_9.2_stripe_10.gemfile.lock
+++ b/gemfiles/jruby_9.2_stripe_10.gemfile.lock
@@ -12,7 +12,7 @@ PATH
   remote: ..
   specs:
     datadog (2.3.0)
-      debase-ruby_core_source (= 3.3.1)
+      debase-ruby_core_source (= 3.3.5)
       libdatadog (~> 12.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
@@ -36,7 +36,7 @@ GEM
     crack (1.0.0)
       bigdecimal
       rexml
-    debase-ruby_core_source (3.3.1)
+    debase-ruby_core_source (3.3.5)
     diff-lcs (1.5.1)
     docile (1.4.1)
     dogstatsd-ruby (5.6.1)

--- a/gemfiles/jruby_9.2_stripe_11.gemfile.lock
+++ b/gemfiles/jruby_9.2_stripe_11.gemfile.lock
@@ -12,7 +12,7 @@ PATH
   remote: ..
   specs:
     datadog (2.3.0)
-      debase-ruby_core_source (= 3.3.1)
+      debase-ruby_core_source (= 3.3.5)
       libdatadog (~> 12.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
@@ -36,7 +36,7 @@ GEM
     crack (1.0.0)
       bigdecimal
       rexml
-    debase-ruby_core_source (3.3.1)
+    debase-ruby_core_source (3.3.5)
     diff-lcs (1.5.1)
     docile (1.4.1)
     dogstatsd-ruby (5.6.1)

--- a/gemfiles/jruby_9.2_stripe_12.gemfile.lock
+++ b/gemfiles/jruby_9.2_stripe_12.gemfile.lock
@@ -12,7 +12,7 @@ PATH
   remote: ..
   specs:
     datadog (2.3.0)
-      debase-ruby_core_source (= 3.3.1)
+      debase-ruby_core_source (= 3.3.5)
       libdatadog (~> 12.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
@@ -36,7 +36,7 @@ GEM
     crack (1.0.0)
       bigdecimal
       rexml
-    debase-ruby_core_source (3.3.1)
+    debase-ruby_core_source (3.3.5)
     diff-lcs (1.5.1)
     docile (1.4.1)
     dogstatsd-ruby (5.6.1)

--- a/gemfiles/jruby_9.2_stripe_7.gemfile.lock
+++ b/gemfiles/jruby_9.2_stripe_7.gemfile.lock
@@ -12,7 +12,7 @@ PATH
   remote: ..
   specs:
     datadog (2.3.0)
-      debase-ruby_core_source (= 3.3.1)
+      debase-ruby_core_source (= 3.3.5)
       libdatadog (~> 12.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
@@ -36,7 +36,7 @@ GEM
     crack (1.0.0)
       bigdecimal
       rexml
-    debase-ruby_core_source (3.3.1)
+    debase-ruby_core_source (3.3.5)
     diff-lcs (1.5.1)
     docile (1.4.1)
     dogstatsd-ruby (5.6.1)

--- a/gemfiles/jruby_9.2_stripe_8.gemfile.lock
+++ b/gemfiles/jruby_9.2_stripe_8.gemfile.lock
@@ -12,7 +12,7 @@ PATH
   remote: ..
   specs:
     datadog (2.3.0)
-      debase-ruby_core_source (= 3.3.1)
+      debase-ruby_core_source (= 3.3.5)
       libdatadog (~> 12.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
@@ -36,7 +36,7 @@ GEM
     crack (1.0.0)
       bigdecimal
       rexml
-    debase-ruby_core_source (3.3.1)
+    debase-ruby_core_source (3.3.5)
     diff-lcs (1.5.1)
     docile (1.4.1)
     dogstatsd-ruby (5.6.1)

--- a/gemfiles/jruby_9.2_stripe_9.gemfile.lock
+++ b/gemfiles/jruby_9.2_stripe_9.gemfile.lock
@@ -12,7 +12,7 @@ PATH
   remote: ..
   specs:
     datadog (2.3.0)
-      debase-ruby_core_source (= 3.3.1)
+      debase-ruby_core_source (= 3.3.5)
       libdatadog (~> 12.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
@@ -36,7 +36,7 @@ GEM
     crack (1.0.0)
       bigdecimal
       rexml
-    debase-ruby_core_source (3.3.1)
+    debase-ruby_core_source (3.3.5)
     diff-lcs (1.5.1)
     docile (1.4.1)
     dogstatsd-ruby (5.6.1)

--- a/gemfiles/jruby_9.2_stripe_latest.gemfile.lock
+++ b/gemfiles/jruby_9.2_stripe_latest.gemfile.lock
@@ -12,7 +12,7 @@ PATH
   remote: ..
   specs:
     datadog (2.3.0)
-      debase-ruby_core_source (= 3.3.1)
+      debase-ruby_core_source (= 3.3.5)
       libdatadog (~> 12.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
@@ -36,7 +36,7 @@ GEM
     crack (1.0.0)
       bigdecimal
       rexml
-    debase-ruby_core_source (3.3.1)
+    debase-ruby_core_source (3.3.5)
     diff-lcs (1.5.1)
     docile (1.4.1)
     dogstatsd-ruby (5.6.1)

--- a/gemfiles/jruby_9.2_stripe_min.gemfile.lock
+++ b/gemfiles/jruby_9.2_stripe_min.gemfile.lock
@@ -12,7 +12,7 @@ PATH
   remote: ..
   specs:
     datadog (2.3.0)
-      debase-ruby_core_source (= 3.3.1)
+      debase-ruby_core_source (= 3.3.5)
       libdatadog (~> 12.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
@@ -36,7 +36,7 @@ GEM
     crack (1.0.0)
       bigdecimal
       rexml
-    debase-ruby_core_source (3.3.1)
+    debase-ruby_core_source (3.3.5)
     diff-lcs (1.5.1)
     docile (1.4.1)
     dogstatsd-ruby (5.6.1)

--- a/gemfiles/jruby_9.3_activesupport.gemfile.lock
+++ b/gemfiles/jruby_9.3_activesupport.gemfile.lock
@@ -12,7 +12,7 @@ PATH
   remote: ..
   specs:
     datadog (2.3.0)
-      debase-ruby_core_source (= 3.3.1)
+      debase-ruby_core_source (= 3.3.5)
       libdatadog (~> 12.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
@@ -64,7 +64,7 @@ GEM
     crack (0.4.5)
       rexml
     crass (1.0.6)
-    debase-ruby_core_source (3.3.1)
+    debase-ruby_core_source (3.3.5)
     diff-lcs (1.5.0)
     digest-crc (0.6.5)
       rake (>= 12.0.0, < 14.0.0)

--- a/gemfiles/jruby_9.3_aws.gemfile.lock
+++ b/gemfiles/jruby_9.3_aws.gemfile.lock
@@ -12,7 +12,7 @@ PATH
   remote: ..
   specs:
     datadog (2.3.0)
-      debase-ruby_core_source (= 3.3.1)
+      debase-ruby_core_source (= 3.3.5)
       libdatadog (~> 12.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
@@ -1455,7 +1455,7 @@ GEM
     concurrent-ruby (1.2.2)
     crack (0.4.5)
       rexml
-    debase-ruby_core_source (3.3.1)
+    debase-ruby_core_source (3.3.5)
     diff-lcs (1.5.0)
     docile (1.4.0)
     dogstatsd-ruby (5.6.0)

--- a/gemfiles/jruby_9.3_contrib.gemfile.lock
+++ b/gemfiles/jruby_9.3_contrib.gemfile.lock
@@ -12,7 +12,7 @@ PATH
   remote: ..
   specs:
     datadog (2.3.0)
-      debase-ruby_core_source (= 3.3.1)
+      debase-ruby_core_source (= 3.3.5)
       libdatadog (~> 12.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
@@ -41,7 +41,7 @@ GEM
     crack (0.4.5)
       rexml
     dalli (3.2.3)
-    debase-ruby_core_source (3.3.1)
+    debase-ruby_core_source (3.3.5)
     diff-lcs (1.5.0)
     docile (1.4.0)
     dogstatsd-ruby (5.6.1)

--- a/gemfiles/jruby_9.3_contrib_old.gemfile.lock
+++ b/gemfiles/jruby_9.3_contrib_old.gemfile.lock
@@ -12,7 +12,7 @@ PATH
   remote: ..
   specs:
     datadog (2.3.0)
-      debase-ruby_core_source (= 3.3.1)
+      debase-ruby_core_source (= 3.3.5)
       libdatadog (~> 12.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
@@ -35,7 +35,7 @@ GEM
     crack (0.4.5)
       rexml
     dalli (2.7.11)
-    debase-ruby_core_source (3.3.1)
+    debase-ruby_core_source (3.3.5)
     diff-lcs (1.5.0)
     docile (1.4.0)
     dogstatsd-ruby (5.6.1)

--- a/gemfiles/jruby_9.3_core_old.gemfile.lock
+++ b/gemfiles/jruby_9.3_core_old.gemfile.lock
@@ -12,7 +12,7 @@ PATH
   remote: ..
   specs:
     datadog (2.3.0)
-      debase-ruby_core_source (= 3.3.1)
+      debase-ruby_core_source (= 3.3.5)
       libdatadog (~> 12.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
@@ -34,7 +34,7 @@ GEM
     concurrent-ruby (1.2.2)
     crack (0.4.5)
       rexml
-    debase-ruby_core_source (3.3.1)
+    debase-ruby_core_source (3.3.5)
     diff-lcs (1.5.0)
     docile (1.4.0)
     dogstatsd-ruby (4.8.3)

--- a/gemfiles/jruby_9.3_elasticsearch_7.gemfile.lock
+++ b/gemfiles/jruby_9.3_elasticsearch_7.gemfile.lock
@@ -12,7 +12,7 @@ PATH
   remote: ..
   specs:
     datadog (2.3.0)
-      debase-ruby_core_source (= 3.3.1)
+      debase-ruby_core_source (= 3.3.5)
       libdatadog (~> 12.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
@@ -35,7 +35,7 @@ GEM
     concurrent-ruby (1.2.2)
     crack (0.4.5)
       rexml
-    debase-ruby_core_source (3.3.1)
+    debase-ruby_core_source (3.3.5)
     diff-lcs (1.5.0)
     docile (1.4.0)
     dogstatsd-ruby (5.6.1)

--- a/gemfiles/jruby_9.3_elasticsearch_8.gemfile.lock
+++ b/gemfiles/jruby_9.3_elasticsearch_8.gemfile.lock
@@ -12,7 +12,7 @@ PATH
   remote: ..
   specs:
     datadog (2.3.0)
-      debase-ruby_core_source (= 3.3.1)
+      debase-ruby_core_source (= 3.3.5)
       libdatadog (~> 12.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
@@ -36,7 +36,7 @@ GEM
     concurrent-ruby (1.2.2)
     crack (0.4.5)
       rexml
-    debase-ruby_core_source (3.3.1)
+    debase-ruby_core_source (3.3.5)
     diff-lcs (1.5.0)
     docile (1.4.0)
     dogstatsd-ruby (5.6.1)

--- a/gemfiles/jruby_9.3_elasticsearch_latest.gemfile.lock
+++ b/gemfiles/jruby_9.3_elasticsearch_latest.gemfile.lock
@@ -12,7 +12,7 @@ PATH
   remote: ..
   specs:
     datadog (2.3.0)
-      debase-ruby_core_source (= 3.3.1)
+      debase-ruby_core_source (= 3.3.5)
       libdatadog (~> 12.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
@@ -38,7 +38,7 @@ GEM
     crack (1.0.0)
       bigdecimal
       rexml
-    debase-ruby_core_source (3.3.1)
+    debase-ruby_core_source (3.3.5)
     diff-lcs (1.5.1)
     docile (1.4.1)
     dogstatsd-ruby (5.6.1)

--- a/gemfiles/jruby_9.3_graphql_1.13.gemfile.lock
+++ b/gemfiles/jruby_9.3_graphql_1.13.gemfile.lock
@@ -12,7 +12,7 @@ PATH
   remote: ..
   specs:
     datadog (2.3.0)
-      debase-ruby_core_source (= 3.3.1)
+      debase-ruby_core_source (= 3.3.5)
       libdatadog (~> 12.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
@@ -98,7 +98,7 @@ GEM
       rexml
     crass (1.0.6)
     date (3.3.4-java)
-    debase-ruby_core_source (3.3.1)
+    debase-ruby_core_source (3.3.5)
     diff-lcs (1.5.0)
     docile (1.4.0)
     dogstatsd-ruby (5.6.1)

--- a/gemfiles/jruby_9.3_graphql_2.0.gemfile.lock
+++ b/gemfiles/jruby_9.3_graphql_2.0.gemfile.lock
@@ -12,7 +12,7 @@ PATH
   remote: ..
   specs:
     datadog (2.3.0)
-      debase-ruby_core_source (= 3.3.1)
+      debase-ruby_core_source (= 3.3.5)
       libdatadog (~> 12.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
@@ -98,7 +98,7 @@ GEM
       rexml
     crass (1.0.6)
     date (3.3.4-java)
-    debase-ruby_core_source (3.3.1)
+    debase-ruby_core_source (3.3.5)
     diff-lcs (1.5.0)
     docile (1.4.0)
     dogstatsd-ruby (5.6.1)

--- a/gemfiles/jruby_9.3_http.gemfile.lock
+++ b/gemfiles/jruby_9.3_http.gemfile.lock
@@ -12,7 +12,7 @@ PATH
   remote: ..
   specs:
     datadog (2.3.0)
-      debase-ruby_core_source (= 3.3.1)
+      debase-ruby_core_source (= 3.3.5)
       libdatadog (~> 12.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
@@ -34,7 +34,7 @@ GEM
     concurrent-ruby (1.2.2)
     crack (0.4.5)
       rexml
-    debase-ruby_core_source (3.3.1)
+    debase-ruby_core_source (3.3.5)
     diff-lcs (1.5.0)
     docile (1.4.0)
     dogstatsd-ruby (5.6.1)

--- a/gemfiles/jruby_9.3_opensearch_2.gemfile.lock
+++ b/gemfiles/jruby_9.3_opensearch_2.gemfile.lock
@@ -12,7 +12,7 @@ PATH
   remote: ..
   specs:
     datadog (2.3.0)
-      debase-ruby_core_source (= 3.3.1)
+      debase-ruby_core_source (= 3.3.5)
       libdatadog (~> 12.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
@@ -36,7 +36,7 @@ GEM
     concurrent-ruby (1.2.2)
     crack (0.4.5)
       rexml
-    debase-ruby_core_source (3.3.1)
+    debase-ruby_core_source (3.3.5)
     diff-lcs (1.5.0)
     docile (1.4.0)
     dogstatsd-ruby (5.6.1)

--- a/gemfiles/jruby_9.3_opensearch_3.gemfile.lock
+++ b/gemfiles/jruby_9.3_opensearch_3.gemfile.lock
@@ -12,7 +12,7 @@ PATH
   remote: ..
   specs:
     datadog (2.3.0)
-      debase-ruby_core_source (= 3.3.1)
+      debase-ruby_core_source (= 3.3.5)
       libdatadog (~> 12.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
@@ -36,7 +36,7 @@ GEM
     concurrent-ruby (1.2.2)
     crack (0.4.5)
       rexml
-    debase-ruby_core_source (3.3.1)
+    debase-ruby_core_source (3.3.5)
     diff-lcs (1.5.0)
     docile (1.4.0)
     dogstatsd-ruby (5.6.1)

--- a/gemfiles/jruby_9.3_opensearch_latest.gemfile.lock
+++ b/gemfiles/jruby_9.3_opensearch_latest.gemfile.lock
@@ -12,7 +12,7 @@ PATH
   remote: ..
   specs:
     datadog (2.3.0)
-      debase-ruby_core_source (= 3.3.1)
+      debase-ruby_core_source (= 3.3.5)
       libdatadog (~> 12.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
@@ -38,7 +38,7 @@ GEM
     crack (1.0.0)
       bigdecimal
       rexml
-    debase-ruby_core_source (3.3.1)
+    debase-ruby_core_source (3.3.5)
     diff-lcs (1.5.1)
     docile (1.4.1)
     dogstatsd-ruby (5.6.1)

--- a/gemfiles/jruby_9.3_rack_1.gemfile.lock
+++ b/gemfiles/jruby_9.3_rack_1.gemfile.lock
@@ -12,7 +12,7 @@ PATH
   remote: ..
   specs:
     datadog (2.3.0)
-      debase-ruby_core_source (= 3.3.1)
+      debase-ruby_core_source (= 3.3.5)
       libdatadog (~> 12.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
@@ -34,7 +34,7 @@ GEM
     concurrent-ruby (1.2.2)
     crack (0.4.5)
       rexml
-    debase-ruby_core_source (3.3.1)
+    debase-ruby_core_source (3.3.5)
     diff-lcs (1.5.0)
     docile (1.4.0)
     dogstatsd-ruby (5.6.1)

--- a/gemfiles/jruby_9.3_rack_2.gemfile.lock
+++ b/gemfiles/jruby_9.3_rack_2.gemfile.lock
@@ -12,7 +12,7 @@ PATH
   remote: ..
   specs:
     datadog (2.3.0)
-      debase-ruby_core_source (= 3.3.1)
+      debase-ruby_core_source (= 3.3.5)
       libdatadog (~> 12.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
@@ -34,7 +34,7 @@ GEM
     concurrent-ruby (1.2.2)
     crack (0.4.5)
       rexml
-    debase-ruby_core_source (3.3.1)
+    debase-ruby_core_source (3.3.5)
     diff-lcs (1.5.0)
     docile (1.4.0)
     dogstatsd-ruby (5.6.1)

--- a/gemfiles/jruby_9.3_rack_3.gemfile.lock
+++ b/gemfiles/jruby_9.3_rack_3.gemfile.lock
@@ -12,7 +12,7 @@ PATH
   remote: ..
   specs:
     datadog (2.3.0)
-      debase-ruby_core_source (= 3.3.1)
+      debase-ruby_core_source (= 3.3.5)
       libdatadog (~> 12.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
@@ -34,7 +34,7 @@ GEM
     concurrent-ruby (1.2.2)
     crack (0.4.5)
       rexml
-    debase-ruby_core_source (3.3.1)
+    debase-ruby_core_source (3.3.5)
     diff-lcs (1.5.0)
     docile (1.4.0)
     dogstatsd-ruby (5.6.1)

--- a/gemfiles/jruby_9.3_rack_latest.gemfile.lock
+++ b/gemfiles/jruby_9.3_rack_latest.gemfile.lock
@@ -12,7 +12,7 @@ PATH
   remote: ..
   specs:
     datadog (2.3.0)
-      debase-ruby_core_source (= 3.3.1)
+      debase-ruby_core_source (= 3.3.5)
       libdatadog (~> 12.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
@@ -37,7 +37,7 @@ GEM
     crack (1.0.0)
       bigdecimal
       rexml
-    debase-ruby_core_source (3.3.1)
+    debase-ruby_core_source (3.3.5)
     diff-lcs (1.5.1)
     docile (1.4.1)
     dogstatsd-ruby (5.6.2)

--- a/gemfiles/jruby_9.3_rails5_mysql2.gemfile.lock
+++ b/gemfiles/jruby_9.3_rails5_mysql2.gemfile.lock
@@ -12,7 +12,7 @@ PATH
   remote: ..
   specs:
     datadog (2.3.0)
-      debase-ruby_core_source (= 3.3.1)
+      debase-ruby_core_source (= 3.3.5)
       libdatadog (~> 12.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
@@ -84,7 +84,7 @@ GEM
       rexml
     crass (1.0.6)
     date (3.3.3-java)
-    debase-ruby_core_source (3.3.1)
+    debase-ruby_core_source (3.3.5)
     diff-lcs (1.5.0)
     docile (1.4.0)
     dogstatsd-ruby (5.6.1)

--- a/gemfiles/jruby_9.3_rails5_postgres.gemfile.lock
+++ b/gemfiles/jruby_9.3_rails5_postgres.gemfile.lock
@@ -12,7 +12,7 @@ PATH
   remote: ..
   specs:
     datadog (2.3.0)
-      debase-ruby_core_source (= 3.3.1)
+      debase-ruby_core_source (= 3.3.5)
       libdatadog (~> 12.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
@@ -84,7 +84,7 @@ GEM
       rexml
     crass (1.0.6)
     date (3.3.3-java)
-    debase-ruby_core_source (3.3.1)
+    debase-ruby_core_source (3.3.5)
     diff-lcs (1.5.0)
     docile (1.4.0)
     dogstatsd-ruby (5.6.1)

--- a/gemfiles/jruby_9.3_rails5_postgres_redis.gemfile.lock
+++ b/gemfiles/jruby_9.3_rails5_postgres_redis.gemfile.lock
@@ -12,7 +12,7 @@ PATH
   remote: ..
   specs:
     datadog (2.3.0)
-      debase-ruby_core_source (= 3.3.1)
+      debase-ruby_core_source (= 3.3.5)
       libdatadog (~> 12.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
@@ -84,7 +84,7 @@ GEM
       rexml
     crass (1.0.6)
     date (3.3.3-java)
-    debase-ruby_core_source (3.3.1)
+    debase-ruby_core_source (3.3.5)
     diff-lcs (1.5.0)
     docile (1.4.0)
     dogstatsd-ruby (5.6.1)

--- a/gemfiles/jruby_9.3_rails5_postgres_redis_activesupport.gemfile.lock
+++ b/gemfiles/jruby_9.3_rails5_postgres_redis_activesupport.gemfile.lock
@@ -12,7 +12,7 @@ PATH
   remote: ..
   specs:
     datadog (2.3.0)
-      debase-ruby_core_source (= 3.3.1)
+      debase-ruby_core_source (= 3.3.5)
       libdatadog (~> 12.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
@@ -84,7 +84,7 @@ GEM
       rexml
     crass (1.0.6)
     date (3.3.3-java)
-    debase-ruby_core_source (3.3.1)
+    debase-ruby_core_source (3.3.5)
     diff-lcs (1.5.0)
     docile (1.4.0)
     dogstatsd-ruby (5.6.1)

--- a/gemfiles/jruby_9.3_rails5_postgres_sidekiq.gemfile.lock
+++ b/gemfiles/jruby_9.3_rails5_postgres_sidekiq.gemfile.lock
@@ -12,7 +12,7 @@ PATH
   remote: ..
   specs:
     datadog (2.3.0)
-      debase-ruby_core_source (= 3.3.1)
+      debase-ruby_core_source (= 3.3.5)
       libdatadog (~> 12.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
@@ -85,7 +85,7 @@ GEM
       rexml
     crass (1.0.6)
     date (3.3.3-java)
-    debase-ruby_core_source (3.3.1)
+    debase-ruby_core_source (3.3.5)
     diff-lcs (1.5.0)
     docile (1.4.0)
     dogstatsd-ruby (5.6.1)

--- a/gemfiles/jruby_9.3_rails5_semantic_logger.gemfile.lock
+++ b/gemfiles/jruby_9.3_rails5_semantic_logger.gemfile.lock
@@ -12,7 +12,7 @@ PATH
   remote: ..
   specs:
     datadog (2.3.0)
-      debase-ruby_core_source (= 3.3.1)
+      debase-ruby_core_source (= 3.3.5)
       libdatadog (~> 12.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
@@ -84,7 +84,7 @@ GEM
       rexml
     crass (1.0.6)
     date (3.3.3-java)
-    debase-ruby_core_source (3.3.1)
+    debase-ruby_core_source (3.3.5)
     diff-lcs (1.5.0)
     docile (1.4.0)
     dogstatsd-ruby (5.6.1)

--- a/gemfiles/jruby_9.3_rails61_mysql2.gemfile.lock
+++ b/gemfiles/jruby_9.3_rails61_mysql2.gemfile.lock
@@ -12,7 +12,7 @@ PATH
   remote: ..
   specs:
     datadog (2.3.0)
-      debase-ruby_core_source (= 3.3.1)
+      debase-ruby_core_source (= 3.3.5)
       libdatadog (~> 12.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
@@ -101,7 +101,7 @@ GEM
       rexml
     crass (1.0.6)
     date (3.3.3-java)
-    debase-ruby_core_source (3.3.1)
+    debase-ruby_core_source (3.3.5)
     diff-lcs (1.5.0)
     docile (1.4.0)
     dogstatsd-ruby (5.6.1)

--- a/gemfiles/jruby_9.3_rails61_postgres.gemfile.lock
+++ b/gemfiles/jruby_9.3_rails61_postgres.gemfile.lock
@@ -12,7 +12,7 @@ PATH
   remote: ..
   specs:
     datadog (2.3.0)
-      debase-ruby_core_source (= 3.3.1)
+      debase-ruby_core_source (= 3.3.5)
       libdatadog (~> 12.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
@@ -101,7 +101,7 @@ GEM
       rexml
     crass (1.0.6)
     date (3.3.3-java)
-    debase-ruby_core_source (3.3.1)
+    debase-ruby_core_source (3.3.5)
     diff-lcs (1.5.0)
     docile (1.4.0)
     dogstatsd-ruby (5.6.1)

--- a/gemfiles/jruby_9.3_rails61_postgres_redis.gemfile.lock
+++ b/gemfiles/jruby_9.3_rails61_postgres_redis.gemfile.lock
@@ -12,7 +12,7 @@ PATH
   remote: ..
   specs:
     datadog (2.3.0)
-      debase-ruby_core_source (= 3.3.1)
+      debase-ruby_core_source (= 3.3.5)
       libdatadog (~> 12.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
@@ -101,7 +101,7 @@ GEM
       rexml
     crass (1.0.6)
     date (3.3.3-java)
-    debase-ruby_core_source (3.3.1)
+    debase-ruby_core_source (3.3.5)
     diff-lcs (1.5.0)
     docile (1.4.0)
     dogstatsd-ruby (5.6.1)

--- a/gemfiles/jruby_9.3_rails61_postgres_sidekiq.gemfile.lock
+++ b/gemfiles/jruby_9.3_rails61_postgres_sidekiq.gemfile.lock
@@ -12,7 +12,7 @@ PATH
   remote: ..
   specs:
     datadog (2.3.0)
-      debase-ruby_core_source (= 3.3.1)
+      debase-ruby_core_source (= 3.3.5)
       libdatadog (~> 12.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
@@ -102,7 +102,7 @@ GEM
       rexml
     crass (1.0.6)
     date (3.3.3-java)
-    debase-ruby_core_source (3.3.1)
+    debase-ruby_core_source (3.3.5)
     diff-lcs (1.5.0)
     docile (1.4.0)
     dogstatsd-ruby (5.6.1)

--- a/gemfiles/jruby_9.3_rails61_semantic_logger.gemfile.lock
+++ b/gemfiles/jruby_9.3_rails61_semantic_logger.gemfile.lock
@@ -12,7 +12,7 @@ PATH
   remote: ..
   specs:
     datadog (2.3.0)
-      debase-ruby_core_source (= 3.3.1)
+      debase-ruby_core_source (= 3.3.5)
       libdatadog (~> 12.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
@@ -101,7 +101,7 @@ GEM
       rexml
     crass (1.0.6)
     date (3.3.3-java)
-    debase-ruby_core_source (3.3.1)
+    debase-ruby_core_source (3.3.5)
     diff-lcs (1.5.0)
     docile (1.4.0)
     dogstatsd-ruby (5.6.1)

--- a/gemfiles/jruby_9.3_rails6_mysql2.gemfile.lock
+++ b/gemfiles/jruby_9.3_rails6_mysql2.gemfile.lock
@@ -12,7 +12,7 @@ PATH
   remote: ..
   specs:
     datadog (2.3.0)
-      debase-ruby_core_source (= 3.3.1)
+      debase-ruby_core_source (= 3.3.5)
       libdatadog (~> 12.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
@@ -97,7 +97,7 @@ GEM
       rexml
     crass (1.0.6)
     date (3.3.3-java)
-    debase-ruby_core_source (3.3.1)
+    debase-ruby_core_source (3.3.5)
     diff-lcs (1.5.0)
     docile (1.4.0)
     dogstatsd-ruby (5.6.1)

--- a/gemfiles/jruby_9.3_rails6_postgres.gemfile.lock
+++ b/gemfiles/jruby_9.3_rails6_postgres.gemfile.lock
@@ -12,7 +12,7 @@ PATH
   remote: ..
   specs:
     datadog (2.3.0)
-      debase-ruby_core_source (= 3.3.1)
+      debase-ruby_core_source (= 3.3.5)
       libdatadog (~> 12.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
@@ -97,7 +97,7 @@ GEM
       rexml
     crass (1.0.6)
     date (3.3.3-java)
-    debase-ruby_core_source (3.3.1)
+    debase-ruby_core_source (3.3.5)
     diff-lcs (1.5.0)
     docile (1.4.0)
     dogstatsd-ruby (5.6.1)

--- a/gemfiles/jruby_9.3_rails6_postgres_redis.gemfile.lock
+++ b/gemfiles/jruby_9.3_rails6_postgres_redis.gemfile.lock
@@ -12,7 +12,7 @@ PATH
   remote: ..
   specs:
     datadog (2.3.0)
-      debase-ruby_core_source (= 3.3.1)
+      debase-ruby_core_source (= 3.3.5)
       libdatadog (~> 12.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
@@ -97,7 +97,7 @@ GEM
       rexml
     crass (1.0.6)
     date (3.3.3-java)
-    debase-ruby_core_source (3.3.1)
+    debase-ruby_core_source (3.3.5)
     diff-lcs (1.5.0)
     docile (1.4.0)
     dogstatsd-ruby (5.6.1)

--- a/gemfiles/jruby_9.3_rails6_postgres_redis_activesupport.gemfile.lock
+++ b/gemfiles/jruby_9.3_rails6_postgres_redis_activesupport.gemfile.lock
@@ -12,7 +12,7 @@ PATH
   remote: ..
   specs:
     datadog (2.3.0)
-      debase-ruby_core_source (= 3.3.1)
+      debase-ruby_core_source (= 3.3.5)
       libdatadog (~> 12.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
@@ -97,7 +97,7 @@ GEM
       rexml
     crass (1.0.6)
     date (3.3.3-java)
-    debase-ruby_core_source (3.3.1)
+    debase-ruby_core_source (3.3.5)
     diff-lcs (1.5.0)
     docile (1.4.0)
     dogstatsd-ruby (5.6.1)

--- a/gemfiles/jruby_9.3_rails6_postgres_sidekiq.gemfile.lock
+++ b/gemfiles/jruby_9.3_rails6_postgres_sidekiq.gemfile.lock
@@ -12,7 +12,7 @@ PATH
   remote: ..
   specs:
     datadog (2.3.0)
-      debase-ruby_core_source (= 3.3.1)
+      debase-ruby_core_source (= 3.3.5)
       libdatadog (~> 12.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
@@ -98,7 +98,7 @@ GEM
       rexml
     crass (1.0.6)
     date (3.3.3-java)
-    debase-ruby_core_source (3.3.1)
+    debase-ruby_core_source (3.3.5)
     diff-lcs (1.5.0)
     docile (1.4.0)
     dogstatsd-ruby (5.6.1)

--- a/gemfiles/jruby_9.3_rails6_semantic_logger.gemfile.lock
+++ b/gemfiles/jruby_9.3_rails6_semantic_logger.gemfile.lock
@@ -12,7 +12,7 @@ PATH
   remote: ..
   specs:
     datadog (2.3.0)
-      debase-ruby_core_source (= 3.3.1)
+      debase-ruby_core_source (= 3.3.5)
       libdatadog (~> 12.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
@@ -97,7 +97,7 @@ GEM
       rexml
     crass (1.0.6)
     date (3.3.3-java)
-    debase-ruby_core_source (3.3.1)
+    debase-ruby_core_source (3.3.5)
     diff-lcs (1.5.0)
     docile (1.4.0)
     dogstatsd-ruby (5.6.1)

--- a/gemfiles/jruby_9.3_redis_3.gemfile.lock
+++ b/gemfiles/jruby_9.3_redis_3.gemfile.lock
@@ -12,7 +12,7 @@ PATH
   remote: ..
   specs:
     datadog (2.3.0)
-      debase-ruby_core_source (= 3.3.1)
+      debase-ruby_core_source (= 3.3.5)
       libdatadog (~> 12.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
@@ -34,7 +34,7 @@ GEM
     concurrent-ruby (1.2.2)
     crack (0.4.5)
       rexml
-    debase-ruby_core_source (3.3.1)
+    debase-ruby_core_source (3.3.5)
     diff-lcs (1.5.0)
     docile (1.4.0)
     dogstatsd-ruby (5.6.1)

--- a/gemfiles/jruby_9.3_redis_4.gemfile.lock
+++ b/gemfiles/jruby_9.3_redis_4.gemfile.lock
@@ -12,7 +12,7 @@ PATH
   remote: ..
   specs:
     datadog (2.3.0)
-      debase-ruby_core_source (= 3.3.1)
+      debase-ruby_core_source (= 3.3.5)
       libdatadog (~> 12.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
@@ -34,7 +34,7 @@ GEM
     concurrent-ruby (1.2.2)
     crack (0.4.5)
       rexml
-    debase-ruby_core_source (3.3.1)
+    debase-ruby_core_source (3.3.5)
     diff-lcs (1.5.0)
     docile (1.4.0)
     dogstatsd-ruby (5.6.1)

--- a/gemfiles/jruby_9.3_redis_5.gemfile.lock
+++ b/gemfiles/jruby_9.3_redis_5.gemfile.lock
@@ -12,7 +12,7 @@ PATH
   remote: ..
   specs:
     datadog (2.3.0)
-      debase-ruby_core_source (= 3.3.1)
+      debase-ruby_core_source (= 3.3.5)
       libdatadog (~> 12.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
@@ -35,7 +35,7 @@ GEM
     connection_pool (2.3.0)
     crack (0.4.5)
       rexml
-    debase-ruby_core_source (3.3.1)
+    debase-ruby_core_source (3.3.5)
     diff-lcs (1.5.0)
     docile (1.4.0)
     dogstatsd-ruby (5.6.1)

--- a/gemfiles/jruby_9.3_relational_db.gemfile.lock
+++ b/gemfiles/jruby_9.3_relational_db.gemfile.lock
@@ -12,7 +12,7 @@ PATH
   remote: ..
   specs:
     datadog (2.3.0)
-      debase-ruby_core_source (= 3.3.1)
+      debase-ruby_core_source (= 3.3.5)
       libdatadog (~> 12.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
@@ -54,7 +54,7 @@ GEM
     concurrent-ruby (1.2.2)
     crack (0.4.5)
       rexml
-    debase-ruby_core_source (3.3.1)
+    debase-ruby_core_source (3.3.5)
     delayed_job (4.1.11)
       activesupport (>= 3.0, < 8.0)
     delayed_job_active_record (4.1.7)

--- a/gemfiles/jruby_9.3_resque2_redis3.gemfile.lock
+++ b/gemfiles/jruby_9.3_resque2_redis3.gemfile.lock
@@ -12,7 +12,7 @@ PATH
   remote: ..
   specs:
     datadog (2.3.0)
-      debase-ruby_core_source (= 3.3.1)
+      debase-ruby_core_source (= 3.3.5)
       libdatadog (~> 12.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
@@ -34,7 +34,7 @@ GEM
     concurrent-ruby (1.2.2)
     crack (0.4.5)
       rexml
-    debase-ruby_core_source (3.3.1)
+    debase-ruby_core_source (3.3.5)
     diff-lcs (1.5.0)
     docile (1.4.0)
     dogstatsd-ruby (5.6.1)

--- a/gemfiles/jruby_9.3_resque2_redis4.gemfile.lock
+++ b/gemfiles/jruby_9.3_resque2_redis4.gemfile.lock
@@ -12,7 +12,7 @@ PATH
   remote: ..
   specs:
     datadog (2.3.0)
-      debase-ruby_core_source (= 3.3.1)
+      debase-ruby_core_source (= 3.3.5)
       libdatadog (~> 12.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
@@ -34,7 +34,7 @@ GEM
     concurrent-ruby (1.2.2)
     crack (0.4.5)
       rexml
-    debase-ruby_core_source (3.3.1)
+    debase-ruby_core_source (3.3.5)
     diff-lcs (1.5.0)
     docile (1.4.0)
     dogstatsd-ruby (5.6.1)

--- a/gemfiles/jruby_9.3_sinatra_2.gemfile.lock
+++ b/gemfiles/jruby_9.3_sinatra_2.gemfile.lock
@@ -12,7 +12,7 @@ PATH
   remote: ..
   specs:
     datadog (2.3.0)
-      debase-ruby_core_source (= 3.3.1)
+      debase-ruby_core_source (= 3.3.5)
       libdatadog (~> 12.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
@@ -37,7 +37,7 @@ GEM
     crack (1.0.0)
       bigdecimal
       rexml
-    debase-ruby_core_source (3.3.1)
+    debase-ruby_core_source (3.3.5)
     diff-lcs (1.5.1)
     docile (1.4.0)
     dogstatsd-ruby (5.6.1)

--- a/gemfiles/jruby_9.3_sinatra_3.gemfile.lock
+++ b/gemfiles/jruby_9.3_sinatra_3.gemfile.lock
@@ -12,7 +12,7 @@ PATH
   remote: ..
   specs:
     datadog (2.3.0)
-      debase-ruby_core_source (= 3.3.1)
+      debase-ruby_core_source (= 3.3.5)
       libdatadog (~> 12.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
@@ -38,7 +38,7 @@ GEM
     crack (1.0.0)
       bigdecimal
       rexml
-    debase-ruby_core_source (3.3.1)
+    debase-ruby_core_source (3.3.5)
     diff-lcs (1.5.1)
     docile (1.4.0)
     dogstatsd-ruby (5.6.1)

--- a/gemfiles/jruby_9.3_stripe_10.gemfile.lock
+++ b/gemfiles/jruby_9.3_stripe_10.gemfile.lock
@@ -12,7 +12,7 @@ PATH
   remote: ..
   specs:
     datadog (2.3.0)
-      debase-ruby_core_source (= 3.3.1)
+      debase-ruby_core_source (= 3.3.5)
       libdatadog (~> 12.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
@@ -37,7 +37,7 @@ GEM
     crack (1.0.0)
       bigdecimal
       rexml
-    debase-ruby_core_source (3.3.1)
+    debase-ruby_core_source (3.3.5)
     diff-lcs (1.5.1)
     docile (1.4.1)
     dogstatsd-ruby (5.6.1)

--- a/gemfiles/jruby_9.3_stripe_11.gemfile.lock
+++ b/gemfiles/jruby_9.3_stripe_11.gemfile.lock
@@ -12,7 +12,7 @@ PATH
   remote: ..
   specs:
     datadog (2.3.0)
-      debase-ruby_core_source (= 3.3.1)
+      debase-ruby_core_source (= 3.3.5)
       libdatadog (~> 12.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
@@ -37,7 +37,7 @@ GEM
     crack (1.0.0)
       bigdecimal
       rexml
-    debase-ruby_core_source (3.3.1)
+    debase-ruby_core_source (3.3.5)
     diff-lcs (1.5.1)
     docile (1.4.1)
     dogstatsd-ruby (5.6.1)

--- a/gemfiles/jruby_9.3_stripe_12.gemfile.lock
+++ b/gemfiles/jruby_9.3_stripe_12.gemfile.lock
@@ -12,7 +12,7 @@ PATH
   remote: ..
   specs:
     datadog (2.3.0)
-      debase-ruby_core_source (= 3.3.1)
+      debase-ruby_core_source (= 3.3.5)
       libdatadog (~> 12.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
@@ -37,7 +37,7 @@ GEM
     crack (1.0.0)
       bigdecimal
       rexml
-    debase-ruby_core_source (3.3.1)
+    debase-ruby_core_source (3.3.5)
     diff-lcs (1.5.1)
     docile (1.4.1)
     dogstatsd-ruby (5.6.1)

--- a/gemfiles/jruby_9.3_stripe_7.gemfile.lock
+++ b/gemfiles/jruby_9.3_stripe_7.gemfile.lock
@@ -12,7 +12,7 @@ PATH
   remote: ..
   specs:
     datadog (2.3.0)
-      debase-ruby_core_source (= 3.3.1)
+      debase-ruby_core_source (= 3.3.5)
       libdatadog (~> 12.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
@@ -37,7 +37,7 @@ GEM
     crack (1.0.0)
       bigdecimal
       rexml
-    debase-ruby_core_source (3.3.1)
+    debase-ruby_core_source (3.3.5)
     diff-lcs (1.5.1)
     docile (1.4.1)
     dogstatsd-ruby (5.6.1)

--- a/gemfiles/jruby_9.3_stripe_8.gemfile.lock
+++ b/gemfiles/jruby_9.3_stripe_8.gemfile.lock
@@ -12,7 +12,7 @@ PATH
   remote: ..
   specs:
     datadog (2.3.0)
-      debase-ruby_core_source (= 3.3.1)
+      debase-ruby_core_source (= 3.3.5)
       libdatadog (~> 12.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
@@ -37,7 +37,7 @@ GEM
     crack (1.0.0)
       bigdecimal
       rexml
-    debase-ruby_core_source (3.3.1)
+    debase-ruby_core_source (3.3.5)
     diff-lcs (1.5.1)
     docile (1.4.1)
     dogstatsd-ruby (5.6.1)

--- a/gemfiles/jruby_9.3_stripe_9.gemfile.lock
+++ b/gemfiles/jruby_9.3_stripe_9.gemfile.lock
@@ -12,7 +12,7 @@ PATH
   remote: ..
   specs:
     datadog (2.3.0)
-      debase-ruby_core_source (= 3.3.1)
+      debase-ruby_core_source (= 3.3.5)
       libdatadog (~> 12.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
@@ -37,7 +37,7 @@ GEM
     crack (1.0.0)
       bigdecimal
       rexml
-    debase-ruby_core_source (3.3.1)
+    debase-ruby_core_source (3.3.5)
     diff-lcs (1.5.1)
     docile (1.4.1)
     dogstatsd-ruby (5.6.1)

--- a/gemfiles/jruby_9.3_stripe_latest.gemfile.lock
+++ b/gemfiles/jruby_9.3_stripe_latest.gemfile.lock
@@ -12,7 +12,7 @@ PATH
   remote: ..
   specs:
     datadog (2.3.0)
-      debase-ruby_core_source (= 3.3.1)
+      debase-ruby_core_source (= 3.3.5)
       libdatadog (~> 12.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
@@ -37,7 +37,7 @@ GEM
     crack (1.0.0)
       bigdecimal
       rexml
-    debase-ruby_core_source (3.3.1)
+    debase-ruby_core_source (3.3.5)
     diff-lcs (1.5.1)
     docile (1.4.1)
     dogstatsd-ruby (5.6.1)

--- a/gemfiles/jruby_9.3_stripe_min.gemfile.lock
+++ b/gemfiles/jruby_9.3_stripe_min.gemfile.lock
@@ -12,7 +12,7 @@ PATH
   remote: ..
   specs:
     datadog (2.3.0)
-      debase-ruby_core_source (= 3.3.1)
+      debase-ruby_core_source (= 3.3.5)
       libdatadog (~> 12.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
@@ -37,7 +37,7 @@ GEM
     crack (1.0.0)
       bigdecimal
       rexml
-    debase-ruby_core_source (3.3.1)
+    debase-ruby_core_source (3.3.5)
     diff-lcs (1.5.1)
     docile (1.4.1)
     dogstatsd-ruby (5.6.1)

--- a/gemfiles/jruby_9.4_activesupport.gemfile.lock
+++ b/gemfiles/jruby_9.4_activesupport.gemfile.lock
@@ -12,7 +12,7 @@ PATH
   remote: ..
   specs:
     datadog (2.3.0)
-      debase-ruby_core_source (= 3.3.1)
+      debase-ruby_core_source (= 3.3.5)
       libdatadog (~> 12.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
@@ -63,7 +63,7 @@ GEM
     crack (0.4.5)
       rexml
     crass (1.0.6)
-    debase-ruby_core_source (3.3.1)
+    debase-ruby_core_source (3.3.5)
     diff-lcs (1.5.0)
     digest-crc (0.6.5)
       rake (>= 12.0.0, < 14.0.0)

--- a/gemfiles/jruby_9.4_aws.gemfile.lock
+++ b/gemfiles/jruby_9.4_aws.gemfile.lock
@@ -12,7 +12,7 @@ PATH
   remote: ..
   specs:
     datadog (2.3.0)
-      debase-ruby_core_source (= 3.3.1)
+      debase-ruby_core_source (= 3.3.5)
       libdatadog (~> 12.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
@@ -1455,7 +1455,7 @@ GEM
     concurrent-ruby (1.2.2)
     crack (0.4.5)
       rexml
-    debase-ruby_core_source (3.3.1)
+    debase-ruby_core_source (3.3.5)
     diff-lcs (1.5.0)
     docile (1.4.0)
     dogstatsd-ruby (5.6.0)

--- a/gemfiles/jruby_9.4_contrib.gemfile.lock
+++ b/gemfiles/jruby_9.4_contrib.gemfile.lock
@@ -12,7 +12,7 @@ PATH
   remote: ..
   specs:
     datadog (2.3.0)
-      debase-ruby_core_source (= 3.3.1)
+      debase-ruby_core_source (= 3.3.5)
       libdatadog (~> 12.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
@@ -41,7 +41,7 @@ GEM
     crack (0.4.5)
       rexml
     dalli (3.2.3)
-    debase-ruby_core_source (3.3.1)
+    debase-ruby_core_source (3.3.5)
     diff-lcs (1.5.0)
     docile (1.4.0)
     dogstatsd-ruby (5.5.0)

--- a/gemfiles/jruby_9.4_contrib_old.gemfile.lock
+++ b/gemfiles/jruby_9.4_contrib_old.gemfile.lock
@@ -12,7 +12,7 @@ PATH
   remote: ..
   specs:
     datadog (2.3.0)
-      debase-ruby_core_source (= 3.3.1)
+      debase-ruby_core_source (= 3.3.5)
       libdatadog (~> 12.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
@@ -35,7 +35,7 @@ GEM
     crack (0.4.5)
       rexml
     dalli (2.7.11)
-    debase-ruby_core_source (3.3.1)
+    debase-ruby_core_source (3.3.5)
     diff-lcs (1.5.0)
     docile (1.4.0)
     dogstatsd-ruby (5.5.0)

--- a/gemfiles/jruby_9.4_core_old.gemfile.lock
+++ b/gemfiles/jruby_9.4_core_old.gemfile.lock
@@ -12,7 +12,7 @@ PATH
   remote: ..
   specs:
     datadog (2.3.0)
-      debase-ruby_core_source (= 3.3.1)
+      debase-ruby_core_source (= 3.3.5)
       libdatadog (~> 12.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
@@ -34,7 +34,7 @@ GEM
     concurrent-ruby (1.1.10)
     crack (0.4.5)
       rexml
-    debase-ruby_core_source (3.3.1)
+    debase-ruby_core_source (3.3.5)
     diff-lcs (1.5.0)
     docile (1.4.0)
     dogstatsd-ruby (4.8.3)

--- a/gemfiles/jruby_9.4_elasticsearch_7.gemfile.lock
+++ b/gemfiles/jruby_9.4_elasticsearch_7.gemfile.lock
@@ -12,7 +12,7 @@ PATH
   remote: ..
   specs:
     datadog (2.3.0)
-      debase-ruby_core_source (= 3.3.1)
+      debase-ruby_core_source (= 3.3.5)
       libdatadog (~> 12.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
@@ -35,7 +35,7 @@ GEM
     concurrent-ruby (1.2.2)
     crack (0.4.5)
       rexml
-    debase-ruby_core_source (3.3.1)
+    debase-ruby_core_source (3.3.5)
     diff-lcs (1.5.0)
     docile (1.4.0)
     dogstatsd-ruby (5.6.1)

--- a/gemfiles/jruby_9.4_elasticsearch_8.gemfile.lock
+++ b/gemfiles/jruby_9.4_elasticsearch_8.gemfile.lock
@@ -12,7 +12,7 @@ PATH
   remote: ..
   specs:
     datadog (2.3.0)
-      debase-ruby_core_source (= 3.3.1)
+      debase-ruby_core_source (= 3.3.5)
       libdatadog (~> 12.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
@@ -36,7 +36,7 @@ GEM
     concurrent-ruby (1.2.2)
     crack (0.4.5)
       rexml
-    debase-ruby_core_source (3.3.1)
+    debase-ruby_core_source (3.3.5)
     diff-lcs (1.5.0)
     docile (1.4.0)
     dogstatsd-ruby (5.6.1)

--- a/gemfiles/jruby_9.4_elasticsearch_latest.gemfile.lock
+++ b/gemfiles/jruby_9.4_elasticsearch_latest.gemfile.lock
@@ -12,7 +12,7 @@ PATH
   remote: ..
   specs:
     datadog (2.3.0)
-      debase-ruby_core_source (= 3.3.1)
+      debase-ruby_core_source (= 3.3.5)
       libdatadog (~> 12.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
@@ -37,7 +37,7 @@ GEM
     crack (1.0.0)
       bigdecimal
       rexml
-    debase-ruby_core_source (3.3.1)
+    debase-ruby_core_source (3.3.5)
     diff-lcs (1.5.1)
     docile (1.4.1)
     dogstatsd-ruby (5.6.1)

--- a/gemfiles/jruby_9.4_graphql_1.13.gemfile.lock
+++ b/gemfiles/jruby_9.4_graphql_1.13.gemfile.lock
@@ -12,7 +12,7 @@ PATH
   remote: ..
   specs:
     datadog (2.3.0)
-      debase-ruby_core_source (= 3.3.1)
+      debase-ruby_core_source (= 3.3.5)
       libdatadog (~> 12.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
@@ -98,7 +98,7 @@ GEM
       rexml
     crass (1.0.6)
     date (3.3.4-java)
-    debase-ruby_core_source (3.3.1)
+    debase-ruby_core_source (3.3.5)
     diff-lcs (1.5.0)
     docile (1.4.0)
     dogstatsd-ruby (5.6.1)

--- a/gemfiles/jruby_9.4_graphql_2.0.gemfile.lock
+++ b/gemfiles/jruby_9.4_graphql_2.0.gemfile.lock
@@ -12,7 +12,7 @@ PATH
   remote: ..
   specs:
     datadog (2.3.0)
-      debase-ruby_core_source (= 3.3.1)
+      debase-ruby_core_source (= 3.3.5)
       libdatadog (~> 12.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
@@ -98,7 +98,7 @@ GEM
       rexml
     crass (1.0.6)
     date (3.3.4-java)
-    debase-ruby_core_source (3.3.1)
+    debase-ruby_core_source (3.3.5)
     diff-lcs (1.5.0)
     docile (1.4.0)
     dogstatsd-ruby (5.6.1)

--- a/gemfiles/jruby_9.4_graphql_2.1.gemfile.lock
+++ b/gemfiles/jruby_9.4_graphql_2.1.gemfile.lock
@@ -12,7 +12,7 @@ PATH
   remote: ..
   specs:
     datadog (2.3.0)
-      debase-ruby_core_source (= 3.3.1)
+      debase-ruby_core_source (= 3.3.5)
       libdatadog (~> 12.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
@@ -98,7 +98,7 @@ GEM
       rexml
     crass (1.0.6)
     date (3.3.4-java)
-    debase-ruby_core_source (3.3.1)
+    debase-ruby_core_source (3.3.5)
     diff-lcs (1.5.0)
     docile (1.4.0)
     dogstatsd-ruby (5.6.1)

--- a/gemfiles/jruby_9.4_graphql_2.2.gemfile.lock
+++ b/gemfiles/jruby_9.4_graphql_2.2.gemfile.lock
@@ -12,7 +12,7 @@ PATH
   remote: ..
   specs:
     datadog (2.3.0)
-      debase-ruby_core_source (= 3.3.1)
+      debase-ruby_core_source (= 3.3.5)
       libdatadog (~> 12.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
@@ -98,7 +98,7 @@ GEM
       rexml
     crass (1.0.6)
     date (3.3.4-java)
-    debase-ruby_core_source (3.3.1)
+    debase-ruby_core_source (3.3.5)
     diff-lcs (1.5.0)
     docile (1.4.0)
     dogstatsd-ruby (5.6.1)

--- a/gemfiles/jruby_9.4_graphql_2.3.gemfile.lock
+++ b/gemfiles/jruby_9.4_graphql_2.3.gemfile.lock
@@ -12,7 +12,7 @@ PATH
   remote: ..
   specs:
     datadog (2.3.0)
-      debase-ruby_core_source (= 3.3.1)
+      debase-ruby_core_source (= 3.3.5)
       libdatadog (~> 12.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
@@ -100,7 +100,7 @@ GEM
       rexml
     crass (1.0.6)
     date (3.3.4-java)
-    debase-ruby_core_source (3.3.1)
+    debase-ruby_core_source (3.3.5)
     diff-lcs (1.5.1)
     docile (1.4.0)
     dogstatsd-ruby (5.6.1)

--- a/gemfiles/jruby_9.4_http.gemfile.lock
+++ b/gemfiles/jruby_9.4_http.gemfile.lock
@@ -12,7 +12,7 @@ PATH
   remote: ..
   specs:
     datadog (2.3.0)
-      debase-ruby_core_source (= 3.3.1)
+      debase-ruby_core_source (= 3.3.5)
       libdatadog (~> 12.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
@@ -34,7 +34,7 @@ GEM
     concurrent-ruby (1.2.2)
     crack (0.4.5)
       rexml
-    debase-ruby_core_source (3.3.1)
+    debase-ruby_core_source (3.3.5)
     diff-lcs (1.5.0)
     docile (1.4.0)
     dogstatsd-ruby (5.6.1)

--- a/gemfiles/jruby_9.4_opensearch_2.gemfile.lock
+++ b/gemfiles/jruby_9.4_opensearch_2.gemfile.lock
@@ -12,7 +12,7 @@ PATH
   remote: ..
   specs:
     datadog (2.3.0)
-      debase-ruby_core_source (= 3.3.1)
+      debase-ruby_core_source (= 3.3.5)
       libdatadog (~> 12.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
@@ -36,7 +36,7 @@ GEM
     concurrent-ruby (1.2.2)
     crack (0.4.5)
       rexml
-    debase-ruby_core_source (3.3.1)
+    debase-ruby_core_source (3.3.5)
     diff-lcs (1.5.0)
     docile (1.4.0)
     dogstatsd-ruby (5.6.1)

--- a/gemfiles/jruby_9.4_opensearch_3.gemfile.lock
+++ b/gemfiles/jruby_9.4_opensearch_3.gemfile.lock
@@ -12,7 +12,7 @@ PATH
   remote: ..
   specs:
     datadog (2.3.0)
-      debase-ruby_core_source (= 3.3.1)
+      debase-ruby_core_source (= 3.3.5)
       libdatadog (~> 12.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
@@ -36,7 +36,7 @@ GEM
     concurrent-ruby (1.2.2)
     crack (0.4.5)
       rexml
-    debase-ruby_core_source (3.3.1)
+    debase-ruby_core_source (3.3.5)
     diff-lcs (1.5.0)
     docile (1.4.0)
     dogstatsd-ruby (5.6.1)

--- a/gemfiles/jruby_9.4_opensearch_latest.gemfile.lock
+++ b/gemfiles/jruby_9.4_opensearch_latest.gemfile.lock
@@ -12,7 +12,7 @@ PATH
   remote: ..
   specs:
     datadog (2.3.0)
-      debase-ruby_core_source (= 3.3.1)
+      debase-ruby_core_source (= 3.3.5)
       libdatadog (~> 12.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
@@ -37,7 +37,7 @@ GEM
     crack (1.0.0)
       bigdecimal
       rexml
-    debase-ruby_core_source (3.3.1)
+    debase-ruby_core_source (3.3.5)
     diff-lcs (1.5.1)
     docile (1.4.1)
     dogstatsd-ruby (5.6.1)

--- a/gemfiles/jruby_9.4_rack_1.gemfile.lock
+++ b/gemfiles/jruby_9.4_rack_1.gemfile.lock
@@ -12,7 +12,7 @@ PATH
   remote: ..
   specs:
     datadog (2.3.0)
-      debase-ruby_core_source (= 3.3.1)
+      debase-ruby_core_source (= 3.3.5)
       libdatadog (~> 12.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
@@ -34,7 +34,7 @@ GEM
     concurrent-ruby (1.2.2)
     crack (0.4.5)
       rexml
-    debase-ruby_core_source (3.3.1)
+    debase-ruby_core_source (3.3.5)
     diff-lcs (1.5.0)
     docile (1.4.0)
     dogstatsd-ruby (5.6.1)

--- a/gemfiles/jruby_9.4_rack_2.gemfile.lock
+++ b/gemfiles/jruby_9.4_rack_2.gemfile.lock
@@ -12,7 +12,7 @@ PATH
   remote: ..
   specs:
     datadog (2.3.0)
-      debase-ruby_core_source (= 3.3.1)
+      debase-ruby_core_source (= 3.3.5)
       libdatadog (~> 12.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
@@ -34,7 +34,7 @@ GEM
     concurrent-ruby (1.2.2)
     crack (0.4.5)
       rexml
-    debase-ruby_core_source (3.3.1)
+    debase-ruby_core_source (3.3.5)
     diff-lcs (1.5.0)
     docile (1.4.0)
     dogstatsd-ruby (5.6.1)

--- a/gemfiles/jruby_9.4_rack_3.gemfile.lock
+++ b/gemfiles/jruby_9.4_rack_3.gemfile.lock
@@ -12,7 +12,7 @@ PATH
   remote: ..
   specs:
     datadog (2.3.0)
-      debase-ruby_core_source (= 3.3.1)
+      debase-ruby_core_source (= 3.3.5)
       libdatadog (~> 12.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
@@ -34,7 +34,7 @@ GEM
     concurrent-ruby (1.2.2)
     crack (0.4.5)
       rexml
-    debase-ruby_core_source (3.3.1)
+    debase-ruby_core_source (3.3.5)
     diff-lcs (1.5.0)
     docile (1.4.0)
     dogstatsd-ruby (5.6.1)

--- a/gemfiles/jruby_9.4_rack_latest.gemfile.lock
+++ b/gemfiles/jruby_9.4_rack_latest.gemfile.lock
@@ -12,7 +12,7 @@ PATH
   remote: ..
   specs:
     datadog (2.3.0)
-      debase-ruby_core_source (= 3.3.1)
+      debase-ruby_core_source (= 3.3.5)
       libdatadog (~> 12.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
@@ -37,7 +37,7 @@ GEM
     crack (1.0.0)
       bigdecimal
       rexml
-    debase-ruby_core_source (3.3.1)
+    debase-ruby_core_source (3.3.5)
     diff-lcs (1.5.1)
     docile (1.4.1)
     dogstatsd-ruby (5.6.2)

--- a/gemfiles/jruby_9.4_rails61_mysql2.gemfile.lock
+++ b/gemfiles/jruby_9.4_rails61_mysql2.gemfile.lock
@@ -12,7 +12,7 @@ PATH
   remote: ..
   specs:
     datadog (2.3.0)
-      debase-ruby_core_source (= 3.3.1)
+      debase-ruby_core_source (= 3.3.5)
       libdatadog (~> 12.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
@@ -105,7 +105,7 @@ GEM
       rexml
     crass (1.0.6)
     date (3.3.4-java)
-    debase-ruby_core_source (3.3.1)
+    debase-ruby_core_source (3.3.5)
     diff-lcs (1.5.1)
     docile (1.4.0)
     dogstatsd-ruby (5.6.1)

--- a/gemfiles/jruby_9.4_rails61_postgres.gemfile.lock
+++ b/gemfiles/jruby_9.4_rails61_postgres.gemfile.lock
@@ -12,7 +12,7 @@ PATH
   remote: ..
   specs:
     datadog (2.3.0)
-      debase-ruby_core_source (= 3.3.1)
+      debase-ruby_core_source (= 3.3.5)
       libdatadog (~> 12.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
@@ -101,7 +101,7 @@ GEM
       rexml
     crass (1.0.6)
     date (3.3.3-java)
-    debase-ruby_core_source (3.3.1)
+    debase-ruby_core_source (3.3.5)
     diff-lcs (1.5.0)
     docile (1.4.0)
     dogstatsd-ruby (5.5.0)

--- a/gemfiles/jruby_9.4_rails61_postgres_redis.gemfile.lock
+++ b/gemfiles/jruby_9.4_rails61_postgres_redis.gemfile.lock
@@ -12,7 +12,7 @@ PATH
   remote: ..
   specs:
     datadog (2.3.0)
-      debase-ruby_core_source (= 3.3.1)
+      debase-ruby_core_source (= 3.3.5)
       libdatadog (~> 12.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
@@ -101,7 +101,7 @@ GEM
       rexml
     crass (1.0.6)
     date (3.3.3-java)
-    debase-ruby_core_source (3.3.1)
+    debase-ruby_core_source (3.3.5)
     diff-lcs (1.5.0)
     docile (1.4.0)
     dogstatsd-ruby (5.5.0)

--- a/gemfiles/jruby_9.4_rails61_postgres_sidekiq.gemfile.lock
+++ b/gemfiles/jruby_9.4_rails61_postgres_sidekiq.gemfile.lock
@@ -12,7 +12,7 @@ PATH
   remote: ..
   specs:
     datadog (2.3.0)
-      debase-ruby_core_source (= 3.3.1)
+      debase-ruby_core_source (= 3.3.5)
       libdatadog (~> 12.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
@@ -102,7 +102,7 @@ GEM
       rexml
     crass (1.0.6)
     date (3.3.3-java)
-    debase-ruby_core_source (3.3.1)
+    debase-ruby_core_source (3.3.5)
     diff-lcs (1.5.0)
     docile (1.4.0)
     dogstatsd-ruby (5.5.0)

--- a/gemfiles/jruby_9.4_rails61_semantic_logger.gemfile.lock
+++ b/gemfiles/jruby_9.4_rails61_semantic_logger.gemfile.lock
@@ -12,7 +12,7 @@ PATH
   remote: ..
   specs:
     datadog (2.3.0)
-      debase-ruby_core_source (= 3.3.1)
+      debase-ruby_core_source (= 3.3.5)
       libdatadog (~> 12.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
@@ -101,7 +101,7 @@ GEM
       rexml
     crass (1.0.6)
     date (3.3.3-java)
-    debase-ruby_core_source (3.3.1)
+    debase-ruby_core_source (3.3.5)
     diff-lcs (1.5.0)
     docile (1.4.0)
     dogstatsd-ruby (5.5.0)

--- a/gemfiles/jruby_9.4_redis_3.gemfile.lock
+++ b/gemfiles/jruby_9.4_redis_3.gemfile.lock
@@ -12,7 +12,7 @@ PATH
   remote: ..
   specs:
     datadog (2.3.0)
-      debase-ruby_core_source (= 3.3.1)
+      debase-ruby_core_source (= 3.3.5)
       libdatadog (~> 12.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
@@ -34,7 +34,7 @@ GEM
     concurrent-ruby (1.1.10)
     crack (0.4.5)
       rexml
-    debase-ruby_core_source (3.3.1)
+    debase-ruby_core_source (3.3.5)
     diff-lcs (1.5.0)
     docile (1.4.0)
     dogstatsd-ruby (5.5.0)

--- a/gemfiles/jruby_9.4_redis_4.gemfile.lock
+++ b/gemfiles/jruby_9.4_redis_4.gemfile.lock
@@ -12,7 +12,7 @@ PATH
   remote: ..
   specs:
     datadog (2.3.0)
-      debase-ruby_core_source (= 3.3.1)
+      debase-ruby_core_source (= 3.3.5)
       libdatadog (~> 12.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
@@ -34,7 +34,7 @@ GEM
     concurrent-ruby (1.1.10)
     crack (0.4.5)
       rexml
-    debase-ruby_core_source (3.3.1)
+    debase-ruby_core_source (3.3.5)
     diff-lcs (1.5.0)
     docile (1.4.0)
     dogstatsd-ruby (5.5.0)

--- a/gemfiles/jruby_9.4_redis_5.gemfile.lock
+++ b/gemfiles/jruby_9.4_redis_5.gemfile.lock
@@ -12,7 +12,7 @@ PATH
   remote: ..
   specs:
     datadog (2.3.0)
-      debase-ruby_core_source (= 3.3.1)
+      debase-ruby_core_source (= 3.3.5)
       libdatadog (~> 12.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
@@ -35,7 +35,7 @@ GEM
     connection_pool (2.3.0)
     crack (0.4.5)
       rexml
-    debase-ruby_core_source (3.3.1)
+    debase-ruby_core_source (3.3.5)
     diff-lcs (1.5.0)
     docile (1.4.0)
     dogstatsd-ruby (5.5.0)

--- a/gemfiles/jruby_9.4_relational_db.gemfile.lock
+++ b/gemfiles/jruby_9.4_relational_db.gemfile.lock
@@ -12,7 +12,7 @@ PATH
   remote: ..
   specs:
     datadog (2.3.0)
-      debase-ruby_core_source (= 3.3.1)
+      debase-ruby_core_source (= 3.3.5)
       libdatadog (~> 12.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
@@ -56,7 +56,7 @@ GEM
     crack (1.0.0)
       bigdecimal
       rexml
-    debase-ruby_core_source (3.3.1)
+    debase-ruby_core_source (3.3.5)
     delayed_job (4.1.11)
       activesupport (>= 3.0, < 8.0)
     delayed_job_active_record (4.1.8)

--- a/gemfiles/jruby_9.4_resque2_redis3.gemfile.lock
+++ b/gemfiles/jruby_9.4_resque2_redis3.gemfile.lock
@@ -12,7 +12,7 @@ PATH
   remote: ..
   specs:
     datadog (2.3.0)
-      debase-ruby_core_source (= 3.3.1)
+      debase-ruby_core_source (= 3.3.5)
       libdatadog (~> 12.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
@@ -34,7 +34,7 @@ GEM
     concurrent-ruby (1.1.10)
     crack (0.4.5)
       rexml
-    debase-ruby_core_source (3.3.1)
+    debase-ruby_core_source (3.3.5)
     diff-lcs (1.5.0)
     docile (1.4.0)
     dogstatsd-ruby (5.5.0)

--- a/gemfiles/jruby_9.4_resque2_redis4.gemfile.lock
+++ b/gemfiles/jruby_9.4_resque2_redis4.gemfile.lock
@@ -12,7 +12,7 @@ PATH
   remote: ..
   specs:
     datadog (2.3.0)
-      debase-ruby_core_source (= 3.3.1)
+      debase-ruby_core_source (= 3.3.5)
       libdatadog (~> 12.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
@@ -35,7 +35,7 @@ GEM
     connection_pool (2.3.0)
     crack (0.4.5)
       rexml
-    debase-ruby_core_source (3.3.1)
+    debase-ruby_core_source (3.3.5)
     diff-lcs (1.5.0)
     docile (1.4.0)
     dogstatsd-ruby (5.5.0)

--- a/gemfiles/jruby_9.4_sinatra_2.gemfile.lock
+++ b/gemfiles/jruby_9.4_sinatra_2.gemfile.lock
@@ -12,7 +12,7 @@ PATH
   remote: ..
   specs:
     datadog (2.3.0)
-      debase-ruby_core_source (= 3.3.1)
+      debase-ruby_core_source (= 3.3.5)
       libdatadog (~> 12.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
@@ -37,7 +37,7 @@ GEM
     crack (1.0.0)
       bigdecimal
       rexml
-    debase-ruby_core_source (3.3.1)
+    debase-ruby_core_source (3.3.5)
     diff-lcs (1.5.1)
     docile (1.4.0)
     dogstatsd-ruby (5.6.1)

--- a/gemfiles/jruby_9.4_sinatra_3.gemfile.lock
+++ b/gemfiles/jruby_9.4_sinatra_3.gemfile.lock
@@ -12,7 +12,7 @@ PATH
   remote: ..
   specs:
     datadog (2.3.0)
-      debase-ruby_core_source (= 3.3.1)
+      debase-ruby_core_source (= 3.3.5)
       libdatadog (~> 12.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
@@ -38,7 +38,7 @@ GEM
     crack (1.0.0)
       bigdecimal
       rexml
-    debase-ruby_core_source (3.3.1)
+    debase-ruby_core_source (3.3.5)
     diff-lcs (1.5.1)
     docile (1.4.0)
     dogstatsd-ruby (5.6.1)

--- a/gemfiles/jruby_9.4_sinatra_4.gemfile.lock
+++ b/gemfiles/jruby_9.4_sinatra_4.gemfile.lock
@@ -12,7 +12,7 @@ PATH
   remote: ..
   specs:
     datadog (2.3.0)
-      debase-ruby_core_source (= 3.3.1)
+      debase-ruby_core_source (= 3.3.5)
       libdatadog (~> 12.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
@@ -38,7 +38,7 @@ GEM
     crack (1.0.0)
       bigdecimal
       rexml
-    debase-ruby_core_source (3.3.1)
+    debase-ruby_core_source (3.3.5)
     diff-lcs (1.5.1)
     docile (1.4.0)
     dogstatsd-ruby (5.6.1)

--- a/gemfiles/jruby_9.4_stripe_10.gemfile.lock
+++ b/gemfiles/jruby_9.4_stripe_10.gemfile.lock
@@ -12,7 +12,7 @@ PATH
   remote: ..
   specs:
     datadog (2.3.0)
-      debase-ruby_core_source (= 3.3.1)
+      debase-ruby_core_source (= 3.3.5)
       libdatadog (~> 12.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
@@ -37,7 +37,7 @@ GEM
     crack (1.0.0)
       bigdecimal
       rexml
-    debase-ruby_core_source (3.3.1)
+    debase-ruby_core_source (3.3.5)
     diff-lcs (1.5.1)
     docile (1.4.1)
     dogstatsd-ruby (5.6.1)

--- a/gemfiles/jruby_9.4_stripe_11.gemfile.lock
+++ b/gemfiles/jruby_9.4_stripe_11.gemfile.lock
@@ -12,7 +12,7 @@ PATH
   remote: ..
   specs:
     datadog (2.3.0)
-      debase-ruby_core_source (= 3.3.1)
+      debase-ruby_core_source (= 3.3.5)
       libdatadog (~> 12.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
@@ -37,7 +37,7 @@ GEM
     crack (1.0.0)
       bigdecimal
       rexml
-    debase-ruby_core_source (3.3.1)
+    debase-ruby_core_source (3.3.5)
     diff-lcs (1.5.1)
     docile (1.4.1)
     dogstatsd-ruby (5.6.1)

--- a/gemfiles/jruby_9.4_stripe_12.gemfile.lock
+++ b/gemfiles/jruby_9.4_stripe_12.gemfile.lock
@@ -12,7 +12,7 @@ PATH
   remote: ..
   specs:
     datadog (2.3.0)
-      debase-ruby_core_source (= 3.3.1)
+      debase-ruby_core_source (= 3.3.5)
       libdatadog (~> 12.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
@@ -37,7 +37,7 @@ GEM
     crack (1.0.0)
       bigdecimal
       rexml
-    debase-ruby_core_source (3.3.1)
+    debase-ruby_core_source (3.3.5)
     diff-lcs (1.5.1)
     docile (1.4.1)
     dogstatsd-ruby (5.6.1)

--- a/gemfiles/jruby_9.4_stripe_7.gemfile.lock
+++ b/gemfiles/jruby_9.4_stripe_7.gemfile.lock
@@ -12,7 +12,7 @@ PATH
   remote: ..
   specs:
     datadog (2.3.0)
-      debase-ruby_core_source (= 3.3.1)
+      debase-ruby_core_source (= 3.3.5)
       libdatadog (~> 12.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
@@ -37,7 +37,7 @@ GEM
     crack (1.0.0)
       bigdecimal
       rexml
-    debase-ruby_core_source (3.3.1)
+    debase-ruby_core_source (3.3.5)
     diff-lcs (1.5.1)
     docile (1.4.1)
     dogstatsd-ruby (5.6.1)

--- a/gemfiles/jruby_9.4_stripe_8.gemfile.lock
+++ b/gemfiles/jruby_9.4_stripe_8.gemfile.lock
@@ -12,7 +12,7 @@ PATH
   remote: ..
   specs:
     datadog (2.3.0)
-      debase-ruby_core_source (= 3.3.1)
+      debase-ruby_core_source (= 3.3.5)
       libdatadog (~> 12.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
@@ -37,7 +37,7 @@ GEM
     crack (1.0.0)
       bigdecimal
       rexml
-    debase-ruby_core_source (3.3.1)
+    debase-ruby_core_source (3.3.5)
     diff-lcs (1.5.1)
     docile (1.4.1)
     dogstatsd-ruby (5.6.1)

--- a/gemfiles/jruby_9.4_stripe_9.gemfile.lock
+++ b/gemfiles/jruby_9.4_stripe_9.gemfile.lock
@@ -12,7 +12,7 @@ PATH
   remote: ..
   specs:
     datadog (2.3.0)
-      debase-ruby_core_source (= 3.3.1)
+      debase-ruby_core_source (= 3.3.5)
       libdatadog (~> 12.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
@@ -37,7 +37,7 @@ GEM
     crack (1.0.0)
       bigdecimal
       rexml
-    debase-ruby_core_source (3.3.1)
+    debase-ruby_core_source (3.3.5)
     diff-lcs (1.5.1)
     docile (1.4.1)
     dogstatsd-ruby (5.6.1)

--- a/gemfiles/jruby_9.4_stripe_latest.gemfile.lock
+++ b/gemfiles/jruby_9.4_stripe_latest.gemfile.lock
@@ -12,7 +12,7 @@ PATH
   remote: ..
   specs:
     datadog (2.3.0)
-      debase-ruby_core_source (= 3.3.1)
+      debase-ruby_core_source (= 3.3.5)
       libdatadog (~> 12.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
@@ -37,7 +37,7 @@ GEM
     crack (1.0.0)
       bigdecimal
       rexml
-    debase-ruby_core_source (3.3.1)
+    debase-ruby_core_source (3.3.5)
     diff-lcs (1.5.1)
     docile (1.4.1)
     dogstatsd-ruby (5.6.1)

--- a/gemfiles/jruby_9.4_stripe_min.gemfile.lock
+++ b/gemfiles/jruby_9.4_stripe_min.gemfile.lock
@@ -12,7 +12,7 @@ PATH
   remote: ..
   specs:
     datadog (2.3.0)
-      debase-ruby_core_source (= 3.3.1)
+      debase-ruby_core_source (= 3.3.5)
       libdatadog (~> 12.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
@@ -37,7 +37,7 @@ GEM
     crack (1.0.0)
       bigdecimal
       rexml
-    debase-ruby_core_source (3.3.1)
+    debase-ruby_core_source (3.3.5)
     diff-lcs (1.5.1)
     docile (1.4.1)
     dogstatsd-ruby (5.6.1)

--- a/gemfiles/ruby_2.5_activesupport.gemfile.lock
+++ b/gemfiles/ruby_2.5_activesupport.gemfile.lock
@@ -12,7 +12,7 @@ PATH
   remote: ..
   specs:
     datadog (2.3.0)
-      debase-ruby_core_source (= 3.3.1)
+      debase-ruby_core_source (= 3.3.5)
       libdatadog (~> 12.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
@@ -64,7 +64,7 @@ GEM
     crack (0.4.5)
       rexml
     crass (1.0.6)
-    debase-ruby_core_source (3.3.1)
+    debase-ruby_core_source (3.3.5)
     debug_inspector (1.1.0)
     diff-lcs (1.5.0)
     digest-crc (0.6.5)

--- a/gemfiles/ruby_2.5_aws.gemfile.lock
+++ b/gemfiles/ruby_2.5_aws.gemfile.lock
@@ -12,7 +12,7 @@ PATH
   remote: ..
   specs:
     datadog (2.3.0)
-      debase-ruby_core_source (= 3.3.1)
+      debase-ruby_core_source (= 3.3.5)
       libdatadog (~> 12.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
@@ -1456,7 +1456,7 @@ GEM
     concurrent-ruby (1.2.2)
     crack (0.4.5)
       rexml
-    debase-ruby_core_source (3.3.1)
+    debase-ruby_core_source (3.3.5)
     debug_inspector (1.1.0)
     diff-lcs (1.5.0)
     docile (1.4.0)

--- a/gemfiles/ruby_2.5_contrib.gemfile.lock
+++ b/gemfiles/ruby_2.5_contrib.gemfile.lock
@@ -12,7 +12,7 @@ PATH
   remote: ..
   specs:
     datadog (2.3.0)
-      debase-ruby_core_source (= 3.3.1)
+      debase-ruby_core_source (= 3.3.5)
       libdatadog (~> 12.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
@@ -42,7 +42,7 @@ GEM
     crack (0.4.5)
       rexml
     dalli (3.2.0)
-    debase-ruby_core_source (3.3.1)
+    debase-ruby_core_source (3.3.5)
     debug_inspector (1.1.0)
     diff-lcs (1.5.0)
     docile (1.4.0)

--- a/gemfiles/ruby_2.5_contrib_old.gemfile.lock
+++ b/gemfiles/ruby_2.5_contrib_old.gemfile.lock
@@ -12,7 +12,7 @@ PATH
   remote: ..
   specs:
     datadog (2.3.0)
-      debase-ruby_core_source (= 3.3.1)
+      debase-ruby_core_source (= 3.3.5)
       libdatadog (~> 12.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
@@ -40,7 +40,7 @@ GEM
       rexml
     daemons (1.4.1)
     dalli (2.7.11)
-    debase-ruby_core_source (3.3.1)
+    debase-ruby_core_source (3.3.5)
     debug_inspector (1.1.0)
     diff-lcs (1.5.0)
     docile (1.4.0)

--- a/gemfiles/ruby_2.5_core_old.gemfile.lock
+++ b/gemfiles/ruby_2.5_core_old.gemfile.lock
@@ -12,7 +12,7 @@ PATH
   remote: ..
   specs:
     datadog (2.3.0)
-      debase-ruby_core_source (= 3.3.1)
+      debase-ruby_core_source (= 3.3.5)
       libdatadog (~> 12.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
@@ -35,7 +35,7 @@ GEM
     concurrent-ruby (1.2.2)
     crack (0.4.5)
       rexml
-    debase-ruby_core_source (3.3.1)
+    debase-ruby_core_source (3.3.5)
     debug_inspector (1.1.0)
     diff-lcs (1.5.0)
     docile (1.4.0)

--- a/gemfiles/ruby_2.5_elasticsearch_7.gemfile.lock
+++ b/gemfiles/ruby_2.5_elasticsearch_7.gemfile.lock
@@ -12,7 +12,7 @@ PATH
   remote: ..
   specs:
     datadog (2.3.0)
-      debase-ruby_core_source (= 3.3.1)
+      debase-ruby_core_source (= 3.3.5)
       libdatadog (~> 12.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
@@ -36,7 +36,7 @@ GEM
     concurrent-ruby (1.2.2)
     crack (0.4.5)
       rexml
-    debase-ruby_core_source (3.3.1)
+    debase-ruby_core_source (3.3.5)
     debug_inspector (1.1.0)
     diff-lcs (1.5.0)
     docile (1.4.0)

--- a/gemfiles/ruby_2.5_elasticsearch_8.gemfile.lock
+++ b/gemfiles/ruby_2.5_elasticsearch_8.gemfile.lock
@@ -12,7 +12,7 @@ PATH
   remote: ..
   specs:
     datadog (2.3.0)
-      debase-ruby_core_source (= 3.3.1)
+      debase-ruby_core_source (= 3.3.5)
       libdatadog (~> 12.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
@@ -36,7 +36,7 @@ GEM
     concurrent-ruby (1.2.2)
     crack (0.4.5)
       rexml
-    debase-ruby_core_source (3.3.1)
+    debase-ruby_core_source (3.3.5)
     debug_inspector (1.1.0)
     diff-lcs (1.5.0)
     docile (1.4.0)

--- a/gemfiles/ruby_2.5_elasticsearch_latest.gemfile.lock
+++ b/gemfiles/ruby_2.5_elasticsearch_latest.gemfile.lock
@@ -12,7 +12,7 @@ PATH
   remote: ..
   specs:
     datadog (2.3.0)
-      debase-ruby_core_source (= 3.3.1)
+      debase-ruby_core_source (= 3.3.5)
       libdatadog (~> 12.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
@@ -38,7 +38,7 @@ GEM
     crack (1.0.0)
       bigdecimal
       rexml
-    debase-ruby_core_source (3.3.1)
+    debase-ruby_core_source (3.3.5)
     debug_inspector (1.2.0)
     diff-lcs (1.5.1)
     docile (1.4.1)

--- a/gemfiles/ruby_2.5_graphql_2.0.gemfile.lock
+++ b/gemfiles/ruby_2.5_graphql_2.0.gemfile.lock
@@ -12,7 +12,7 @@ PATH
   remote: ..
   specs:
     datadog (2.3.0)
-      debase-ruby_core_source (= 3.3.1)
+      debase-ruby_core_source (= 3.3.5)
       libdatadog (~> 12.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
@@ -98,7 +98,7 @@ GEM
     crack (0.4.5)
       rexml
     crass (1.0.6)
-    debase-ruby_core_source (3.3.1)
+    debase-ruby_core_source (3.3.5)
     debug_inspector (1.2.0)
     diff-lcs (1.5.0)
     digest (3.1.1)

--- a/gemfiles/ruby_2.5_hanami_1.gemfile.lock
+++ b/gemfiles/ruby_2.5_hanami_1.gemfile.lock
@@ -12,7 +12,7 @@ PATH
   remote: ..
   specs:
     datadog (2.3.0)
-      debase-ruby_core_source (= 3.3.1)
+      debase-ruby_core_source (= 3.3.5)
       libdatadog (~> 12.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
@@ -35,7 +35,7 @@ GEM
     concurrent-ruby (1.2.2)
     crack (0.4.5)
       rexml
-    debase-ruby_core_source (3.3.1)
+    debase-ruby_core_source (3.3.5)
     debug_inspector (1.1.0)
     diff-lcs (1.5.0)
     digest (3.1.1)

--- a/gemfiles/ruby_2.5_http.gemfile.lock
+++ b/gemfiles/ruby_2.5_http.gemfile.lock
@@ -12,7 +12,7 @@ PATH
   remote: ..
   specs:
     datadog (2.3.0)
-      debase-ruby_core_source (= 3.3.1)
+      debase-ruby_core_source (= 3.3.5)
       libdatadog (~> 12.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
@@ -35,7 +35,7 @@ GEM
     concurrent-ruby (1.2.2)
     crack (0.4.5)
       rexml
-    debase-ruby_core_source (3.3.1)
+    debase-ruby_core_source (3.3.5)
     debug_inspector (1.1.0)
     diff-lcs (1.5.0)
     docile (1.4.0)

--- a/gemfiles/ruby_2.5_opensearch_2.gemfile.lock
+++ b/gemfiles/ruby_2.5_opensearch_2.gemfile.lock
@@ -12,7 +12,7 @@ PATH
   remote: ..
   specs:
     datadog (2.3.0)
-      debase-ruby_core_source (= 3.3.1)
+      debase-ruby_core_source (= 3.3.5)
       libdatadog (~> 12.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
@@ -36,7 +36,7 @@ GEM
     concurrent-ruby (1.2.2)
     crack (0.4.5)
       rexml
-    debase-ruby_core_source (3.3.1)
+    debase-ruby_core_source (3.3.5)
     debug_inspector (1.1.0)
     diff-lcs (1.5.0)
     docile (1.4.0)

--- a/gemfiles/ruby_2.5_opensearch_3.gemfile.lock
+++ b/gemfiles/ruby_2.5_opensearch_3.gemfile.lock
@@ -12,7 +12,7 @@ PATH
   remote: ..
   specs:
     datadog (2.3.0)
-      debase-ruby_core_source (= 3.3.1)
+      debase-ruby_core_source (= 3.3.5)
       libdatadog (~> 12.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
@@ -36,7 +36,7 @@ GEM
     concurrent-ruby (1.2.2)
     crack (0.4.5)
       rexml
-    debase-ruby_core_source (3.3.1)
+    debase-ruby_core_source (3.3.5)
     debug_inspector (1.1.0)
     diff-lcs (1.5.0)
     docile (1.4.0)

--- a/gemfiles/ruby_2.5_opensearch_latest.gemfile.lock
+++ b/gemfiles/ruby_2.5_opensearch_latest.gemfile.lock
@@ -12,7 +12,7 @@ PATH
   remote: ..
   specs:
     datadog (2.3.0)
-      debase-ruby_core_source (= 3.3.1)
+      debase-ruby_core_source (= 3.3.5)
       libdatadog (~> 12.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
@@ -38,7 +38,7 @@ GEM
     crack (1.0.0)
       bigdecimal
       rexml
-    debase-ruby_core_source (3.3.1)
+    debase-ruby_core_source (3.3.5)
     debug_inspector (1.2.0)
     diff-lcs (1.5.1)
     docile (1.4.1)

--- a/gemfiles/ruby_2.5_rack_1.gemfile.lock
+++ b/gemfiles/ruby_2.5_rack_1.gemfile.lock
@@ -12,7 +12,7 @@ PATH
   remote: ..
   specs:
     datadog (2.3.0)
-      debase-ruby_core_source (= 3.3.1)
+      debase-ruby_core_source (= 3.3.5)
       libdatadog (~> 12.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
@@ -35,7 +35,7 @@ GEM
     concurrent-ruby (1.2.2)
     crack (0.4.5)
       rexml
-    debase-ruby_core_source (3.3.1)
+    debase-ruby_core_source (3.3.5)
     debug_inspector (1.1.0)
     diff-lcs (1.5.0)
     docile (1.4.0)

--- a/gemfiles/ruby_2.5_rack_2.gemfile.lock
+++ b/gemfiles/ruby_2.5_rack_2.gemfile.lock
@@ -12,7 +12,7 @@ PATH
   remote: ..
   specs:
     datadog (2.3.0)
-      debase-ruby_core_source (= 3.3.1)
+      debase-ruby_core_source (= 3.3.5)
       libdatadog (~> 12.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
@@ -35,7 +35,7 @@ GEM
     concurrent-ruby (1.2.2)
     crack (0.4.5)
       rexml
-    debase-ruby_core_source (3.3.1)
+    debase-ruby_core_source (3.3.5)
     debug_inspector (1.1.0)
     diff-lcs (1.5.0)
     docile (1.4.0)

--- a/gemfiles/ruby_2.5_rack_3.gemfile.lock
+++ b/gemfiles/ruby_2.5_rack_3.gemfile.lock
@@ -12,7 +12,7 @@ PATH
   remote: ..
   specs:
     datadog (2.3.0)
-      debase-ruby_core_source (= 3.3.1)
+      debase-ruby_core_source (= 3.3.5)
       libdatadog (~> 12.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
@@ -35,7 +35,7 @@ GEM
     concurrent-ruby (1.2.2)
     crack (0.4.5)
       rexml
-    debase-ruby_core_source (3.3.1)
+    debase-ruby_core_source (3.3.5)
     debug_inspector (1.1.0)
     diff-lcs (1.5.0)
     docile (1.4.0)

--- a/gemfiles/ruby_2.5_rack_latest.gemfile.lock
+++ b/gemfiles/ruby_2.5_rack_latest.gemfile.lock
@@ -12,7 +12,7 @@ PATH
   remote: ..
   specs:
     datadog (2.3.0)
-      debase-ruby_core_source (= 3.3.1)
+      debase-ruby_core_source (= 3.3.5)
       libdatadog (~> 12.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
@@ -38,7 +38,7 @@ GEM
     crack (1.0.0)
       bigdecimal
       rexml
-    debase-ruby_core_source (3.3.1)
+    debase-ruby_core_source (3.3.5)
     debug_inspector (1.2.0)
     diff-lcs (1.5.1)
     docile (1.4.1)

--- a/gemfiles/ruby_2.5_rails4_mysql2.gemfile.lock
+++ b/gemfiles/ruby_2.5_rails4_mysql2.gemfile.lock
@@ -68,7 +68,7 @@ PATH
   remote: ..
   specs:
     datadog (2.3.0)
-      debase-ruby_core_source (= 3.3.1)
+      debase-ruby_core_source (= 3.3.5)
       libdatadog (~> 12.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
@@ -95,7 +95,7 @@ GEM
     crack (0.4.5)
       rexml
     crass (1.0.6)
-    debase-ruby_core_source (3.3.1)
+    debase-ruby_core_source (3.3.5)
     debug_inspector (1.2.0)
     diff-lcs (1.5.0)
     digest (3.1.1)

--- a/gemfiles/ruby_2.5_rails4_postgres.gemfile.lock
+++ b/gemfiles/ruby_2.5_rails4_postgres.gemfile.lock
@@ -68,7 +68,7 @@ PATH
   remote: ..
   specs:
     datadog (2.3.0)
-      debase-ruby_core_source (= 3.3.1)
+      debase-ruby_core_source (= 3.3.5)
       libdatadog (~> 12.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
@@ -95,7 +95,7 @@ GEM
     crack (0.4.5)
       rexml
     crass (1.0.6)
-    debase-ruby_core_source (3.3.1)
+    debase-ruby_core_source (3.3.5)
     debug_inspector (1.2.0)
     diff-lcs (1.5.0)
     digest (3.1.1)

--- a/gemfiles/ruby_2.5_rails4_postgres_redis.gemfile.lock
+++ b/gemfiles/ruby_2.5_rails4_postgres_redis.gemfile.lock
@@ -68,7 +68,7 @@ PATH
   remote: ..
   specs:
     datadog (2.3.0)
-      debase-ruby_core_source (= 3.3.1)
+      debase-ruby_core_source (= 3.3.5)
       libdatadog (~> 12.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
@@ -95,7 +95,7 @@ GEM
     crack (0.4.5)
       rexml
     crass (1.0.6)
-    debase-ruby_core_source (3.3.1)
+    debase-ruby_core_source (3.3.5)
     debug_inspector (1.2.0)
     diff-lcs (1.5.0)
     digest (3.1.1)

--- a/gemfiles/ruby_2.5_rails4_postgres_sidekiq.gemfile.lock
+++ b/gemfiles/ruby_2.5_rails4_postgres_sidekiq.gemfile.lock
@@ -65,7 +65,7 @@ PATH
   remote: ..
   specs:
     datadog (2.3.0)
-      debase-ruby_core_source (= 3.3.1)
+      debase-ruby_core_source (= 3.3.5)
       libdatadog (~> 12.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
@@ -96,7 +96,7 @@ GEM
     crack (0.4.5)
       rexml
     crass (1.0.6)
-    debase-ruby_core_source (3.3.1)
+    debase-ruby_core_source (3.3.5)
     debug_inspector (1.2.0)
     diff-lcs (1.5.0)
     digest (3.1.1)

--- a/gemfiles/ruby_2.5_rails4_semantic_logger.gemfile.lock
+++ b/gemfiles/ruby_2.5_rails4_semantic_logger.gemfile.lock
@@ -68,7 +68,7 @@ PATH
   remote: ..
   specs:
     datadog (2.3.0)
-      debase-ruby_core_source (= 3.3.1)
+      debase-ruby_core_source (= 3.3.5)
       libdatadog (~> 12.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
@@ -95,7 +95,7 @@ GEM
     crack (0.4.5)
       rexml
     crass (1.0.6)
-    debase-ruby_core_source (3.3.1)
+    debase-ruby_core_source (3.3.5)
     debug_inspector (1.2.0)
     diff-lcs (1.5.0)
     digest (3.1.1)

--- a/gemfiles/ruby_2.5_rails5_mysql2.gemfile.lock
+++ b/gemfiles/ruby_2.5_rails5_mysql2.gemfile.lock
@@ -12,7 +12,7 @@ PATH
   remote: ..
   specs:
     datadog (2.3.0)
-      debase-ruby_core_source (= 3.3.1)
+      debase-ruby_core_source (= 3.3.5)
       libdatadog (~> 12.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
@@ -79,7 +79,7 @@ GEM
     crack (0.4.5)
       rexml
     crass (1.0.6)
-    debase-ruby_core_source (3.3.1)
+    debase-ruby_core_source (3.3.5)
     debug_inspector (1.1.0)
     diff-lcs (1.5.0)
     docile (1.4.0)

--- a/gemfiles/ruby_2.5_rails5_postgres.gemfile.lock
+++ b/gemfiles/ruby_2.5_rails5_postgres.gemfile.lock
@@ -12,7 +12,7 @@ PATH
   remote: ..
   specs:
     datadog (2.3.0)
-      debase-ruby_core_source (= 3.3.1)
+      debase-ruby_core_source (= 3.3.5)
       libdatadog (~> 12.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
@@ -79,7 +79,7 @@ GEM
     crack (0.4.5)
       rexml
     crass (1.0.6)
-    debase-ruby_core_source (3.3.1)
+    debase-ruby_core_source (3.3.5)
     debug_inspector (1.1.0)
     diff-lcs (1.5.0)
     digest (3.1.1)

--- a/gemfiles/ruby_2.5_rails5_postgres_redis.gemfile.lock
+++ b/gemfiles/ruby_2.5_rails5_postgres_redis.gemfile.lock
@@ -12,7 +12,7 @@ PATH
   remote: ..
   specs:
     datadog (2.3.0)
-      debase-ruby_core_source (= 3.3.1)
+      debase-ruby_core_source (= 3.3.5)
       libdatadog (~> 12.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
@@ -80,7 +80,7 @@ GEM
     crack (0.4.5)
       rexml
     crass (1.0.6)
-    debase-ruby_core_source (3.3.1)
+    debase-ruby_core_source (3.3.5)
     debug_inspector (1.1.0)
     diff-lcs (1.5.0)
     digest (3.1.1)

--- a/gemfiles/ruby_2.5_rails5_postgres_redis_activesupport.gemfile.lock
+++ b/gemfiles/ruby_2.5_rails5_postgres_redis_activesupport.gemfile.lock
@@ -12,7 +12,7 @@ PATH
   remote: ..
   specs:
     datadog (2.3.0)
-      debase-ruby_core_source (= 3.3.1)
+      debase-ruby_core_source (= 3.3.5)
       libdatadog (~> 12.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
@@ -79,7 +79,7 @@ GEM
     crack (0.4.5)
       rexml
     crass (1.0.6)
-    debase-ruby_core_source (3.3.1)
+    debase-ruby_core_source (3.3.5)
     debug_inspector (1.1.0)
     diff-lcs (1.5.0)
     digest (3.1.1)

--- a/gemfiles/ruby_2.5_rails5_postgres_sidekiq.gemfile.lock
+++ b/gemfiles/ruby_2.5_rails5_postgres_sidekiq.gemfile.lock
@@ -12,7 +12,7 @@ PATH
   remote: ..
   specs:
     datadog (2.3.0)
-      debase-ruby_core_source (= 3.3.1)
+      debase-ruby_core_source (= 3.3.5)
       libdatadog (~> 12.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
@@ -80,7 +80,7 @@ GEM
     crack (0.4.5)
       rexml
     crass (1.0.6)
-    debase-ruby_core_source (3.3.1)
+    debase-ruby_core_source (3.3.5)
     debug_inspector (1.1.0)
     diff-lcs (1.5.0)
     digest (3.1.1)

--- a/gemfiles/ruby_2.5_rails5_semantic_logger.gemfile.lock
+++ b/gemfiles/ruby_2.5_rails5_semantic_logger.gemfile.lock
@@ -12,7 +12,7 @@ PATH
   remote: ..
   specs:
     datadog (2.3.0)
-      debase-ruby_core_source (= 3.3.1)
+      debase-ruby_core_source (= 3.3.5)
       libdatadog (~> 12.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
@@ -79,7 +79,7 @@ GEM
     crack (0.4.5)
       rexml
     crass (1.0.6)
-    debase-ruby_core_source (3.3.1)
+    debase-ruby_core_source (3.3.5)
     debug_inspector (1.1.0)
     diff-lcs (1.5.0)
     digest (3.1.1)

--- a/gemfiles/ruby_2.5_rails61_mysql2.gemfile.lock
+++ b/gemfiles/ruby_2.5_rails61_mysql2.gemfile.lock
@@ -12,7 +12,7 @@ PATH
   remote: ..
   specs:
     datadog (2.3.0)
-      debase-ruby_core_source (= 3.3.1)
+      debase-ruby_core_source (= 3.3.5)
       libdatadog (~> 12.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
@@ -96,7 +96,7 @@ GEM
     crack (0.4.5)
       rexml
     crass (1.0.6)
-    debase-ruby_core_source (3.3.1)
+    debase-ruby_core_source (3.3.5)
     debug_inspector (1.1.0)
     diff-lcs (1.5.0)
     docile (1.4.0)

--- a/gemfiles/ruby_2.5_rails61_postgres.gemfile.lock
+++ b/gemfiles/ruby_2.5_rails61_postgres.gemfile.lock
@@ -12,7 +12,7 @@ PATH
   remote: ..
   specs:
     datadog (2.3.0)
-      debase-ruby_core_source (= 3.3.1)
+      debase-ruby_core_source (= 3.3.5)
       libdatadog (~> 12.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
@@ -96,7 +96,7 @@ GEM
     crack (0.4.5)
       rexml
     crass (1.0.6)
-    debase-ruby_core_source (3.3.1)
+    debase-ruby_core_source (3.3.5)
     debug_inspector (1.1.0)
     diff-lcs (1.5.0)
     digest (3.1.1)

--- a/gemfiles/ruby_2.5_rails61_postgres_redis.gemfile.lock
+++ b/gemfiles/ruby_2.5_rails61_postgres_redis.gemfile.lock
@@ -12,7 +12,7 @@ PATH
   remote: ..
   specs:
     datadog (2.3.0)
-      debase-ruby_core_source (= 3.3.1)
+      debase-ruby_core_source (= 3.3.5)
       libdatadog (~> 12.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
@@ -97,7 +97,7 @@ GEM
     crack (0.4.5)
       rexml
     crass (1.0.6)
-    debase-ruby_core_source (3.3.1)
+    debase-ruby_core_source (3.3.5)
     debug_inspector (1.1.0)
     diff-lcs (1.5.0)
     digest (3.1.1)

--- a/gemfiles/ruby_2.5_rails61_postgres_sidekiq.gemfile.lock
+++ b/gemfiles/ruby_2.5_rails61_postgres_sidekiq.gemfile.lock
@@ -12,7 +12,7 @@ PATH
   remote: ..
   specs:
     datadog (2.3.0)
-      debase-ruby_core_source (= 3.3.1)
+      debase-ruby_core_source (= 3.3.5)
       libdatadog (~> 12.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
@@ -97,7 +97,7 @@ GEM
     crack (0.4.5)
       rexml
     crass (1.0.6)
-    debase-ruby_core_source (3.3.1)
+    debase-ruby_core_source (3.3.5)
     debug_inspector (1.1.0)
     diff-lcs (1.5.0)
     digest (3.1.1)

--- a/gemfiles/ruby_2.5_rails61_semantic_logger.gemfile.lock
+++ b/gemfiles/ruby_2.5_rails61_semantic_logger.gemfile.lock
@@ -12,7 +12,7 @@ PATH
   remote: ..
   specs:
     datadog (2.3.0)
-      debase-ruby_core_source (= 3.3.1)
+      debase-ruby_core_source (= 3.3.5)
       libdatadog (~> 12.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
@@ -96,7 +96,7 @@ GEM
     crack (0.4.5)
       rexml
     crass (1.0.6)
-    debase-ruby_core_source (3.3.1)
+    debase-ruby_core_source (3.3.5)
     debug_inspector (1.1.0)
     diff-lcs (1.5.0)
     digest (3.1.1)

--- a/gemfiles/ruby_2.5_rails6_mysql2.gemfile.lock
+++ b/gemfiles/ruby_2.5_rails6_mysql2.gemfile.lock
@@ -12,7 +12,7 @@ PATH
   remote: ..
   specs:
     datadog (2.3.0)
-      debase-ruby_core_source (= 3.3.1)
+      debase-ruby_core_source (= 3.3.5)
       libdatadog (~> 12.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
@@ -92,7 +92,7 @@ GEM
     crack (0.4.5)
       rexml
     crass (1.0.6)
-    debase-ruby_core_source (3.3.1)
+    debase-ruby_core_source (3.3.5)
     debug_inspector (1.1.0)
     diff-lcs (1.5.0)
     docile (1.4.0)

--- a/gemfiles/ruby_2.5_rails6_postgres.gemfile.lock
+++ b/gemfiles/ruby_2.5_rails6_postgres.gemfile.lock
@@ -12,7 +12,7 @@ PATH
   remote: ..
   specs:
     datadog (2.3.0)
-      debase-ruby_core_source (= 3.3.1)
+      debase-ruby_core_source (= 3.3.5)
       libdatadog (~> 12.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
@@ -92,7 +92,7 @@ GEM
     crack (0.4.5)
       rexml
     crass (1.0.6)
-    debase-ruby_core_source (3.3.1)
+    debase-ruby_core_source (3.3.5)
     debug_inspector (1.1.0)
     diff-lcs (1.5.0)
     digest (3.1.1)

--- a/gemfiles/ruby_2.5_rails6_postgres_redis.gemfile.lock
+++ b/gemfiles/ruby_2.5_rails6_postgres_redis.gemfile.lock
@@ -12,7 +12,7 @@ PATH
   remote: ..
   specs:
     datadog (2.3.0)
-      debase-ruby_core_source (= 3.3.1)
+      debase-ruby_core_source (= 3.3.5)
       libdatadog (~> 12.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
@@ -93,7 +93,7 @@ GEM
     crack (0.4.5)
       rexml
     crass (1.0.6)
-    debase-ruby_core_source (3.3.1)
+    debase-ruby_core_source (3.3.5)
     debug_inspector (1.1.0)
     diff-lcs (1.5.0)
     digest (3.1.1)

--- a/gemfiles/ruby_2.5_rails6_postgres_redis_activesupport.gemfile.lock
+++ b/gemfiles/ruby_2.5_rails6_postgres_redis_activesupport.gemfile.lock
@@ -12,7 +12,7 @@ PATH
   remote: ..
   specs:
     datadog (2.3.0)
-      debase-ruby_core_source (= 3.3.1)
+      debase-ruby_core_source (= 3.3.5)
       libdatadog (~> 12.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
@@ -92,7 +92,7 @@ GEM
     crack (0.4.5)
       rexml
     crass (1.0.6)
-    debase-ruby_core_source (3.3.1)
+    debase-ruby_core_source (3.3.5)
     debug_inspector (1.1.0)
     diff-lcs (1.5.0)
     digest (3.1.1)

--- a/gemfiles/ruby_2.5_rails6_postgres_sidekiq.gemfile.lock
+++ b/gemfiles/ruby_2.5_rails6_postgres_sidekiq.gemfile.lock
@@ -12,7 +12,7 @@ PATH
   remote: ..
   specs:
     datadog (2.3.0)
-      debase-ruby_core_source (= 3.3.1)
+      debase-ruby_core_source (= 3.3.5)
       libdatadog (~> 12.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
@@ -93,7 +93,7 @@ GEM
     crack (0.4.5)
       rexml
     crass (1.0.6)
-    debase-ruby_core_source (3.3.1)
+    debase-ruby_core_source (3.3.5)
     debug_inspector (1.1.0)
     diff-lcs (1.5.0)
     digest (3.1.1)

--- a/gemfiles/ruby_2.5_rails6_semantic_logger.gemfile.lock
+++ b/gemfiles/ruby_2.5_rails6_semantic_logger.gemfile.lock
@@ -12,7 +12,7 @@ PATH
   remote: ..
   specs:
     datadog (2.3.0)
-      debase-ruby_core_source (= 3.3.1)
+      debase-ruby_core_source (= 3.3.5)
       libdatadog (~> 12.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
@@ -92,7 +92,7 @@ GEM
     crack (0.4.5)
       rexml
     crass (1.0.6)
-    debase-ruby_core_source (3.3.1)
+    debase-ruby_core_source (3.3.5)
     debug_inspector (1.1.0)
     diff-lcs (1.5.0)
     digest (3.1.1)

--- a/gemfiles/ruby_2.5_redis_3.gemfile.lock
+++ b/gemfiles/ruby_2.5_redis_3.gemfile.lock
@@ -12,7 +12,7 @@ PATH
   remote: ..
   specs:
     datadog (2.3.0)
-      debase-ruby_core_source (= 3.3.1)
+      debase-ruby_core_source (= 3.3.5)
       libdatadog (~> 12.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
@@ -35,7 +35,7 @@ GEM
     concurrent-ruby (1.2.2)
     crack (0.4.5)
       rexml
-    debase-ruby_core_source (3.3.1)
+    debase-ruby_core_source (3.3.5)
     debug_inspector (1.1.0)
     diff-lcs (1.5.0)
     docile (1.4.0)

--- a/gemfiles/ruby_2.5_redis_4.gemfile.lock
+++ b/gemfiles/ruby_2.5_redis_4.gemfile.lock
@@ -12,7 +12,7 @@ PATH
   remote: ..
   specs:
     datadog (2.3.0)
-      debase-ruby_core_source (= 3.3.1)
+      debase-ruby_core_source (= 3.3.5)
       libdatadog (~> 12.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
@@ -35,7 +35,7 @@ GEM
     concurrent-ruby (1.2.2)
     crack (0.4.5)
       rexml
-    debase-ruby_core_source (3.3.1)
+    debase-ruby_core_source (3.3.5)
     debug_inspector (1.1.0)
     diff-lcs (1.5.0)
     docile (1.4.0)

--- a/gemfiles/ruby_2.5_redis_5.gemfile.lock
+++ b/gemfiles/ruby_2.5_redis_5.gemfile.lock
@@ -12,7 +12,7 @@ PATH
   remote: ..
   specs:
     datadog (2.3.0)
-      debase-ruby_core_source (= 3.3.1)
+      debase-ruby_core_source (= 3.3.5)
       libdatadog (~> 12.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
@@ -36,7 +36,7 @@ GEM
     connection_pool (2.3.0)
     crack (0.4.5)
       rexml
-    debase-ruby_core_source (3.3.1)
+    debase-ruby_core_source (3.3.5)
     debug_inspector (1.1.0)
     diff-lcs (1.5.0)
     docile (1.4.0)

--- a/gemfiles/ruby_2.5_relational_db.gemfile.lock
+++ b/gemfiles/ruby_2.5_relational_db.gemfile.lock
@@ -12,7 +12,7 @@ PATH
   remote: ..
   specs:
     datadog (2.3.0)
-      debase-ruby_core_source (= 3.3.1)
+      debase-ruby_core_source (= 3.3.5)
       libdatadog (~> 12.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
@@ -48,7 +48,7 @@ GEM
     concurrent-ruby (1.2.2)
     crack (0.4.5)
       rexml
-    debase-ruby_core_source (3.3.1)
+    debase-ruby_core_source (3.3.5)
     debug_inspector (1.1.0)
     delayed_job (4.1.11)
       activesupport (>= 3.0, < 8.0)

--- a/gemfiles/ruby_2.5_resque2_redis3.gemfile.lock
+++ b/gemfiles/ruby_2.5_resque2_redis3.gemfile.lock
@@ -12,7 +12,7 @@ PATH
   remote: ..
   specs:
     datadog (2.3.0)
-      debase-ruby_core_source (= 3.3.1)
+      debase-ruby_core_source (= 3.3.5)
       libdatadog (~> 12.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
@@ -35,7 +35,7 @@ GEM
     concurrent-ruby (1.2.2)
     crack (0.4.5)
       rexml
-    debase-ruby_core_source (3.3.1)
+    debase-ruby_core_source (3.3.5)
     debug_inspector (1.1.0)
     diff-lcs (1.5.0)
     docile (1.4.0)

--- a/gemfiles/ruby_2.5_resque2_redis4.gemfile.lock
+++ b/gemfiles/ruby_2.5_resque2_redis4.gemfile.lock
@@ -12,7 +12,7 @@ PATH
   remote: ..
   specs:
     datadog (2.3.0)
-      debase-ruby_core_source (= 3.3.1)
+      debase-ruby_core_source (= 3.3.5)
       libdatadog (~> 12.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
@@ -36,7 +36,7 @@ GEM
     connection_pool (2.3.0)
     crack (0.4.5)
       rexml
-    debase-ruby_core_source (3.3.1)
+    debase-ruby_core_source (3.3.5)
     debug_inspector (1.1.0)
     diff-lcs (1.5.0)
     docile (1.4.0)

--- a/gemfiles/ruby_2.5_sinatra_2.gemfile.lock
+++ b/gemfiles/ruby_2.5_sinatra_2.gemfile.lock
@@ -12,7 +12,7 @@ PATH
   remote: ..
   specs:
     datadog (2.3.0)
-      debase-ruby_core_source (= 3.3.1)
+      debase-ruby_core_source (= 3.3.5)
       libdatadog (~> 12.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
@@ -38,7 +38,7 @@ GEM
     crack (1.0.0)
       bigdecimal
       rexml
-    debase-ruby_core_source (3.3.1)
+    debase-ruby_core_source (3.3.5)
     debug_inspector (1.2.0)
     diff-lcs (1.5.1)
     docile (1.4.0)

--- a/gemfiles/ruby_2.5_stripe_10.gemfile.lock
+++ b/gemfiles/ruby_2.5_stripe_10.gemfile.lock
@@ -12,7 +12,7 @@ PATH
   remote: ..
   specs:
     datadog (2.3.0)
-      debase-ruby_core_source (= 3.3.1)
+      debase-ruby_core_source (= 3.3.5)
       libdatadog (~> 12.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
@@ -38,7 +38,7 @@ GEM
     crack (1.0.0)
       bigdecimal
       rexml
-    debase-ruby_core_source (3.3.1)
+    debase-ruby_core_source (3.3.5)
     debug_inspector (1.2.0)
     diff-lcs (1.5.1)
     docile (1.4.1)

--- a/gemfiles/ruby_2.5_stripe_11.gemfile.lock
+++ b/gemfiles/ruby_2.5_stripe_11.gemfile.lock
@@ -12,7 +12,7 @@ PATH
   remote: ..
   specs:
     datadog (2.3.0)
-      debase-ruby_core_source (= 3.3.1)
+      debase-ruby_core_source (= 3.3.5)
       libdatadog (~> 12.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
@@ -38,7 +38,7 @@ GEM
     crack (1.0.0)
       bigdecimal
       rexml
-    debase-ruby_core_source (3.3.1)
+    debase-ruby_core_source (3.3.5)
     debug_inspector (1.2.0)
     diff-lcs (1.5.1)
     docile (1.4.1)

--- a/gemfiles/ruby_2.5_stripe_12.gemfile.lock
+++ b/gemfiles/ruby_2.5_stripe_12.gemfile.lock
@@ -12,7 +12,7 @@ PATH
   remote: ..
   specs:
     datadog (2.3.0)
-      debase-ruby_core_source (= 3.3.1)
+      debase-ruby_core_source (= 3.3.5)
       libdatadog (~> 12.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
@@ -38,7 +38,7 @@ GEM
     crack (1.0.0)
       bigdecimal
       rexml
-    debase-ruby_core_source (3.3.1)
+    debase-ruby_core_source (3.3.5)
     debug_inspector (1.2.0)
     diff-lcs (1.5.1)
     docile (1.4.1)

--- a/gemfiles/ruby_2.5_stripe_7.gemfile.lock
+++ b/gemfiles/ruby_2.5_stripe_7.gemfile.lock
@@ -12,7 +12,7 @@ PATH
   remote: ..
   specs:
     datadog (2.3.0)
-      debase-ruby_core_source (= 3.3.1)
+      debase-ruby_core_source (= 3.3.5)
       libdatadog (~> 12.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
@@ -38,7 +38,7 @@ GEM
     crack (1.0.0)
       bigdecimal
       rexml
-    debase-ruby_core_source (3.3.1)
+    debase-ruby_core_source (3.3.5)
     debug_inspector (1.2.0)
     diff-lcs (1.5.1)
     docile (1.4.1)

--- a/gemfiles/ruby_2.5_stripe_8.gemfile.lock
+++ b/gemfiles/ruby_2.5_stripe_8.gemfile.lock
@@ -12,7 +12,7 @@ PATH
   remote: ..
   specs:
     datadog (2.3.0)
-      debase-ruby_core_source (= 3.3.1)
+      debase-ruby_core_source (= 3.3.5)
       libdatadog (~> 12.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
@@ -38,7 +38,7 @@ GEM
     crack (1.0.0)
       bigdecimal
       rexml
-    debase-ruby_core_source (3.3.1)
+    debase-ruby_core_source (3.3.5)
     debug_inspector (1.2.0)
     diff-lcs (1.5.1)
     docile (1.4.1)

--- a/gemfiles/ruby_2.5_stripe_9.gemfile.lock
+++ b/gemfiles/ruby_2.5_stripe_9.gemfile.lock
@@ -12,7 +12,7 @@ PATH
   remote: ..
   specs:
     datadog (2.3.0)
-      debase-ruby_core_source (= 3.3.1)
+      debase-ruby_core_source (= 3.3.5)
       libdatadog (~> 12.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
@@ -38,7 +38,7 @@ GEM
     crack (1.0.0)
       bigdecimal
       rexml
-    debase-ruby_core_source (3.3.1)
+    debase-ruby_core_source (3.3.5)
     debug_inspector (1.2.0)
     diff-lcs (1.5.1)
     docile (1.4.1)

--- a/gemfiles/ruby_2.5_stripe_latest.gemfile.lock
+++ b/gemfiles/ruby_2.5_stripe_latest.gemfile.lock
@@ -12,7 +12,7 @@ PATH
   remote: ..
   specs:
     datadog (2.3.0)
-      debase-ruby_core_source (= 3.3.1)
+      debase-ruby_core_source (= 3.3.5)
       libdatadog (~> 12.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
@@ -38,7 +38,7 @@ GEM
     crack (1.0.0)
       bigdecimal
       rexml
-    debase-ruby_core_source (3.3.1)
+    debase-ruby_core_source (3.3.5)
     debug_inspector (1.2.0)
     diff-lcs (1.5.1)
     docile (1.4.1)

--- a/gemfiles/ruby_2.5_stripe_min.gemfile.lock
+++ b/gemfiles/ruby_2.5_stripe_min.gemfile.lock
@@ -12,7 +12,7 @@ PATH
   remote: ..
   specs:
     datadog (2.3.0)
-      debase-ruby_core_source (= 3.3.1)
+      debase-ruby_core_source (= 3.3.5)
       libdatadog (~> 12.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
@@ -38,7 +38,7 @@ GEM
     crack (1.0.0)
       bigdecimal
       rexml
-    debase-ruby_core_source (3.3.1)
+    debase-ruby_core_source (3.3.5)
     debug_inspector (1.2.0)
     diff-lcs (1.5.1)
     docile (1.4.1)

--- a/gemfiles/ruby_2.6_activesupport.gemfile.lock
+++ b/gemfiles/ruby_2.6_activesupport.gemfile.lock
@@ -12,7 +12,7 @@ PATH
   remote: ..
   specs:
     datadog (2.3.0)
-      debase-ruby_core_source (= 3.3.1)
+      debase-ruby_core_source (= 3.3.5)
       libdatadog (~> 12.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
@@ -67,7 +67,7 @@ GEM
     crack (0.4.5)
       rexml
     crass (1.0.6)
-    debase-ruby_core_source (3.3.1)
+    debase-ruby_core_source (3.3.5)
     debug_inspector (1.1.0)
     diff-lcs (1.5.0)
     digest-crc (0.6.5)

--- a/gemfiles/ruby_2.6_aws.gemfile.lock
+++ b/gemfiles/ruby_2.6_aws.gemfile.lock
@@ -12,7 +12,7 @@ PATH
   remote: ..
   specs:
     datadog (2.3.0)
-      debase-ruby_core_source (= 3.3.1)
+      debase-ruby_core_source (= 3.3.5)
       libdatadog (~> 12.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
@@ -1458,7 +1458,7 @@ GEM
     concurrent-ruby (1.2.2)
     crack (0.4.5)
       rexml
-    debase-ruby_core_source (3.3.1)
+    debase-ruby_core_source (3.3.5)
     debug_inspector (1.1.0)
     diff-lcs (1.5.0)
     docile (1.4.0)

--- a/gemfiles/ruby_2.6_contrib.gemfile.lock
+++ b/gemfiles/ruby_2.6_contrib.gemfile.lock
@@ -12,7 +12,7 @@ PATH
   remote: ..
   specs:
     datadog (2.3.0)
-      debase-ruby_core_source (= 3.3.1)
+      debase-ruby_core_source (= 3.3.5)
       libdatadog (~> 12.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
@@ -44,7 +44,7 @@ GEM
     crack (0.4.5)
       rexml
     dalli (3.2.4)
-    debase-ruby_core_source (3.3.1)
+    debase-ruby_core_source (3.3.5)
     debug_inspector (1.1.0)
     diff-lcs (1.5.0)
     docile (1.4.0)

--- a/gemfiles/ruby_2.6_contrib_old.gemfile.lock
+++ b/gemfiles/ruby_2.6_contrib_old.gemfile.lock
@@ -12,7 +12,7 @@ PATH
   remote: ..
   specs:
     datadog (2.3.0)
-      debase-ruby_core_source (= 3.3.1)
+      debase-ruby_core_source (= 3.3.5)
       libdatadog (~> 12.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
@@ -42,7 +42,7 @@ GEM
       rexml
     daemons (1.4.1)
     dalli (2.7.11)
-    debase-ruby_core_source (3.3.1)
+    debase-ruby_core_source (3.3.5)
     debug_inspector (1.1.0)
     diff-lcs (1.5.0)
     docile (1.4.0)

--- a/gemfiles/ruby_2.6_core_old.gemfile.lock
+++ b/gemfiles/ruby_2.6_core_old.gemfile.lock
@@ -12,7 +12,7 @@ PATH
   remote: ..
   specs:
     datadog (2.3.0)
-      debase-ruby_core_source (= 3.3.1)
+      debase-ruby_core_source (= 3.3.5)
       libdatadog (~> 12.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
@@ -37,7 +37,7 @@ GEM
     concurrent-ruby (1.2.2)
     crack (0.4.5)
       rexml
-    debase-ruby_core_source (3.3.1)
+    debase-ruby_core_source (3.3.5)
     debug_inspector (1.1.0)
     diff-lcs (1.5.0)
     docile (1.4.0)

--- a/gemfiles/ruby_2.6_elasticsearch_7.gemfile.lock
+++ b/gemfiles/ruby_2.6_elasticsearch_7.gemfile.lock
@@ -12,7 +12,7 @@ PATH
   remote: ..
   specs:
     datadog (2.3.0)
-      debase-ruby_core_source (= 3.3.1)
+      debase-ruby_core_source (= 3.3.5)
       libdatadog (~> 12.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
@@ -38,7 +38,7 @@ GEM
     concurrent-ruby (1.2.2)
     crack (0.4.5)
       rexml
-    debase-ruby_core_source (3.3.1)
+    debase-ruby_core_source (3.3.5)
     debug_inspector (1.1.0)
     diff-lcs (1.5.0)
     docile (1.4.0)

--- a/gemfiles/ruby_2.6_elasticsearch_8.gemfile.lock
+++ b/gemfiles/ruby_2.6_elasticsearch_8.gemfile.lock
@@ -12,7 +12,7 @@ PATH
   remote: ..
   specs:
     datadog (2.3.0)
-      debase-ruby_core_source (= 3.3.1)
+      debase-ruby_core_source (= 3.3.5)
       libdatadog (~> 12.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
@@ -39,7 +39,7 @@ GEM
     concurrent-ruby (1.2.2)
     crack (0.4.5)
       rexml
-    debase-ruby_core_source (3.3.1)
+    debase-ruby_core_source (3.3.5)
     debug_inspector (1.1.0)
     diff-lcs (1.5.0)
     docile (1.4.0)

--- a/gemfiles/ruby_2.6_elasticsearch_latest.gemfile.lock
+++ b/gemfiles/ruby_2.6_elasticsearch_latest.gemfile.lock
@@ -12,7 +12,7 @@ PATH
   remote: ..
   specs:
     datadog (2.3.0)
-      debase-ruby_core_source (= 3.3.1)
+      debase-ruby_core_source (= 3.3.5)
       libdatadog (~> 12.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
@@ -41,7 +41,7 @@ GEM
     crack (1.0.0)
       bigdecimal
       rexml
-    debase-ruby_core_source (3.3.1)
+    debase-ruby_core_source (3.3.5)
     debug_inspector (1.2.0)
     diff-lcs (1.5.1)
     docile (1.4.1)

--- a/gemfiles/ruby_2.6_graphql_1.13.gemfile.lock
+++ b/gemfiles/ruby_2.6_graphql_1.13.gemfile.lock
@@ -12,7 +12,7 @@ PATH
   remote: ..
   specs:
     datadog (2.3.0)
-      debase-ruby_core_source (= 3.3.1)
+      debase-ruby_core_source (= 3.3.5)
       libdatadog (~> 12.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
@@ -101,7 +101,7 @@ GEM
       rexml
     crass (1.0.6)
     date (3.3.4)
-    debase-ruby_core_source (3.3.1)
+    debase-ruby_core_source (3.3.5)
     debug_inspector (1.2.0)
     diff-lcs (1.5.0)
     docile (1.4.0)

--- a/gemfiles/ruby_2.6_graphql_2.0.gemfile.lock
+++ b/gemfiles/ruby_2.6_graphql_2.0.gemfile.lock
@@ -12,7 +12,7 @@ PATH
   remote: ..
   specs:
     datadog (2.3.0)
-      debase-ruby_core_source (= 3.3.1)
+      debase-ruby_core_source (= 3.3.5)
       libdatadog (~> 12.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
@@ -101,7 +101,7 @@ GEM
       rexml
     crass (1.0.6)
     date (3.3.4)
-    debase-ruby_core_source (3.3.1)
+    debase-ruby_core_source (3.3.5)
     debug_inspector (1.2.0)
     diff-lcs (1.5.0)
     docile (1.4.0)

--- a/gemfiles/ruby_2.6_hanami_1.gemfile.lock
+++ b/gemfiles/ruby_2.6_hanami_1.gemfile.lock
@@ -12,7 +12,7 @@ PATH
   remote: ..
   specs:
     datadog (2.3.0)
-      debase-ruby_core_source (= 3.3.1)
+      debase-ruby_core_source (= 3.3.5)
       libdatadog (~> 12.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
@@ -38,7 +38,7 @@ GEM
     crack (0.4.5)
       rexml
     date (3.3.3)
-    debase-ruby_core_source (3.3.1)
+    debase-ruby_core_source (3.3.5)
     debug_inspector (1.1.0)
     diff-lcs (1.5.0)
     docile (1.4.0)

--- a/gemfiles/ruby_2.6_http.gemfile.lock
+++ b/gemfiles/ruby_2.6_http.gemfile.lock
@@ -12,7 +12,7 @@ PATH
   remote: ..
   specs:
     datadog (2.3.0)
-      debase-ruby_core_source (= 3.3.1)
+      debase-ruby_core_source (= 3.3.5)
       libdatadog (~> 12.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
@@ -37,7 +37,7 @@ GEM
     concurrent-ruby (1.2.2)
     crack (0.4.5)
       rexml
-    debase-ruby_core_source (3.3.1)
+    debase-ruby_core_source (3.3.5)
     debug_inspector (1.1.0)
     diff-lcs (1.5.0)
     docile (1.4.0)

--- a/gemfiles/ruby_2.6_opensearch_2.gemfile.lock
+++ b/gemfiles/ruby_2.6_opensearch_2.gemfile.lock
@@ -12,7 +12,7 @@ PATH
   remote: ..
   specs:
     datadog (2.3.0)
-      debase-ruby_core_source (= 3.3.1)
+      debase-ruby_core_source (= 3.3.5)
       libdatadog (~> 12.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
@@ -39,7 +39,7 @@ GEM
     concurrent-ruby (1.2.2)
     crack (0.4.5)
       rexml
-    debase-ruby_core_source (3.3.1)
+    debase-ruby_core_source (3.3.5)
     debug_inspector (1.1.0)
     diff-lcs (1.5.0)
     docile (1.4.0)

--- a/gemfiles/ruby_2.6_opensearch_3.gemfile.lock
+++ b/gemfiles/ruby_2.6_opensearch_3.gemfile.lock
@@ -12,7 +12,7 @@ PATH
   remote: ..
   specs:
     datadog (2.3.0)
-      debase-ruby_core_source (= 3.3.1)
+      debase-ruby_core_source (= 3.3.5)
       libdatadog (~> 12.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
@@ -39,7 +39,7 @@ GEM
     concurrent-ruby (1.2.2)
     crack (0.4.5)
       rexml
-    debase-ruby_core_source (3.3.1)
+    debase-ruby_core_source (3.3.5)
     debug_inspector (1.1.0)
     diff-lcs (1.5.0)
     docile (1.4.0)

--- a/gemfiles/ruby_2.6_opensearch_latest.gemfile.lock
+++ b/gemfiles/ruby_2.6_opensearch_latest.gemfile.lock
@@ -12,7 +12,7 @@ PATH
   remote: ..
   specs:
     datadog (2.3.0)
-      debase-ruby_core_source (= 3.3.1)
+      debase-ruby_core_source (= 3.3.5)
       libdatadog (~> 12.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
@@ -41,7 +41,7 @@ GEM
     crack (1.0.0)
       bigdecimal
       rexml
-    debase-ruby_core_source (3.3.1)
+    debase-ruby_core_source (3.3.5)
     debug_inspector (1.2.0)
     diff-lcs (1.5.1)
     docile (1.4.1)

--- a/gemfiles/ruby_2.6_opentelemetry.gemfile.lock
+++ b/gemfiles/ruby_2.6_opentelemetry.gemfile.lock
@@ -12,7 +12,7 @@ PATH
   remote: ..
   specs:
     datadog (2.3.0)
-      debase-ruby_core_source (= 3.3.1)
+      debase-ruby_core_source (= 3.3.5)
       libdatadog (~> 12.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
@@ -37,7 +37,7 @@ GEM
     concurrent-ruby (1.2.2)
     crack (0.4.5)
       rexml
-    debase-ruby_core_source (3.3.1)
+    debase-ruby_core_source (3.3.5)
     debug_inspector (1.1.0)
     diff-lcs (1.5.0)
     docile (1.4.0)

--- a/gemfiles/ruby_2.6_rack_1.gemfile.lock
+++ b/gemfiles/ruby_2.6_rack_1.gemfile.lock
@@ -12,7 +12,7 @@ PATH
   remote: ..
   specs:
     datadog (2.3.0)
-      debase-ruby_core_source (= 3.3.1)
+      debase-ruby_core_source (= 3.3.5)
       libdatadog (~> 12.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
@@ -37,7 +37,7 @@ GEM
     concurrent-ruby (1.2.2)
     crack (0.4.5)
       rexml
-    debase-ruby_core_source (3.3.1)
+    debase-ruby_core_source (3.3.5)
     debug_inspector (1.1.0)
     diff-lcs (1.5.0)
     docile (1.4.0)

--- a/gemfiles/ruby_2.6_rack_2.gemfile.lock
+++ b/gemfiles/ruby_2.6_rack_2.gemfile.lock
@@ -12,7 +12,7 @@ PATH
   remote: ..
   specs:
     datadog (2.3.0)
-      debase-ruby_core_source (= 3.3.1)
+      debase-ruby_core_source (= 3.3.5)
       libdatadog (~> 12.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
@@ -37,7 +37,7 @@ GEM
     concurrent-ruby (1.2.2)
     crack (0.4.5)
       rexml
-    debase-ruby_core_source (3.3.1)
+    debase-ruby_core_source (3.3.5)
     debug_inspector (1.1.0)
     diff-lcs (1.5.0)
     docile (1.4.0)

--- a/gemfiles/ruby_2.6_rack_3.gemfile.lock
+++ b/gemfiles/ruby_2.6_rack_3.gemfile.lock
@@ -12,7 +12,7 @@ PATH
   remote: ..
   specs:
     datadog (2.3.0)
-      debase-ruby_core_source (= 3.3.1)
+      debase-ruby_core_source (= 3.3.5)
       libdatadog (~> 12.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
@@ -37,7 +37,7 @@ GEM
     concurrent-ruby (1.2.2)
     crack (0.4.5)
       rexml
-    debase-ruby_core_source (3.3.1)
+    debase-ruby_core_source (3.3.5)
     debug_inspector (1.1.0)
     diff-lcs (1.5.0)
     docile (1.4.0)

--- a/gemfiles/ruby_2.6_rack_latest.gemfile.lock
+++ b/gemfiles/ruby_2.6_rack_latest.gemfile.lock
@@ -12,7 +12,7 @@ PATH
   remote: ..
   specs:
     datadog (2.3.0)
-      debase-ruby_core_source (= 3.3.1)
+      debase-ruby_core_source (= 3.3.5)
       libdatadog (~> 12.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
@@ -40,7 +40,7 @@ GEM
     crack (1.0.0)
       bigdecimal
       rexml
-    debase-ruby_core_source (3.3.1)
+    debase-ruby_core_source (3.3.5)
     debug_inspector (1.2.0)
     diff-lcs (1.5.1)
     docile (1.4.1)

--- a/gemfiles/ruby_2.6_rails5_mysql2.gemfile.lock
+++ b/gemfiles/ruby_2.6_rails5_mysql2.gemfile.lock
@@ -12,7 +12,7 @@ PATH
   remote: ..
   specs:
     datadog (2.3.0)
-      debase-ruby_core_source (= 3.3.1)
+      debase-ruby_core_source (= 3.3.5)
       libdatadog (~> 12.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
@@ -82,7 +82,7 @@ GEM
       rexml
     crass (1.0.6)
     date (3.3.3)
-    debase-ruby_core_source (3.3.1)
+    debase-ruby_core_source (3.3.5)
     debug_inspector (1.1.0)
     diff-lcs (1.5.0)
     docile (1.4.0)

--- a/gemfiles/ruby_2.6_rails5_postgres.gemfile.lock
+++ b/gemfiles/ruby_2.6_rails5_postgres.gemfile.lock
@@ -12,7 +12,7 @@ PATH
   remote: ..
   specs:
     datadog (2.3.0)
-      debase-ruby_core_source (= 3.3.1)
+      debase-ruby_core_source (= 3.3.5)
       libdatadog (~> 12.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
@@ -82,7 +82,7 @@ GEM
       rexml
     crass (1.0.6)
     date (3.3.3)
-    debase-ruby_core_source (3.3.1)
+    debase-ruby_core_source (3.3.5)
     debug_inspector (1.1.0)
     diff-lcs (1.5.0)
     docile (1.4.0)

--- a/gemfiles/ruby_2.6_rails5_postgres_redis.gemfile.lock
+++ b/gemfiles/ruby_2.6_rails5_postgres_redis.gemfile.lock
@@ -12,7 +12,7 @@ PATH
   remote: ..
   specs:
     datadog (2.3.0)
-      debase-ruby_core_source (= 3.3.1)
+      debase-ruby_core_source (= 3.3.5)
       libdatadog (~> 12.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
@@ -82,7 +82,7 @@ GEM
       rexml
     crass (1.0.6)
     date (3.3.3)
-    debase-ruby_core_source (3.3.1)
+    debase-ruby_core_source (3.3.5)
     debug_inspector (1.1.0)
     diff-lcs (1.5.0)
     docile (1.4.0)

--- a/gemfiles/ruby_2.6_rails5_postgres_redis_activesupport.gemfile.lock
+++ b/gemfiles/ruby_2.6_rails5_postgres_redis_activesupport.gemfile.lock
@@ -12,7 +12,7 @@ PATH
   remote: ..
   specs:
     datadog (2.3.0)
-      debase-ruby_core_source (= 3.3.1)
+      debase-ruby_core_source (= 3.3.5)
       libdatadog (~> 12.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
@@ -82,7 +82,7 @@ GEM
       rexml
     crass (1.0.6)
     date (3.3.3)
-    debase-ruby_core_source (3.3.1)
+    debase-ruby_core_source (3.3.5)
     debug_inspector (1.1.0)
     diff-lcs (1.5.0)
     docile (1.4.0)

--- a/gemfiles/ruby_2.6_rails5_postgres_sidekiq.gemfile.lock
+++ b/gemfiles/ruby_2.6_rails5_postgres_sidekiq.gemfile.lock
@@ -12,7 +12,7 @@ PATH
   remote: ..
   specs:
     datadog (2.3.0)
-      debase-ruby_core_source (= 3.3.1)
+      debase-ruby_core_source (= 3.3.5)
       libdatadog (~> 12.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
@@ -83,7 +83,7 @@ GEM
       rexml
     crass (1.0.6)
     date (3.3.3)
-    debase-ruby_core_source (3.3.1)
+    debase-ruby_core_source (3.3.5)
     debug_inspector (1.1.0)
     diff-lcs (1.5.0)
     docile (1.4.0)

--- a/gemfiles/ruby_2.6_rails5_semantic_logger.gemfile.lock
+++ b/gemfiles/ruby_2.6_rails5_semantic_logger.gemfile.lock
@@ -12,7 +12,7 @@ PATH
   remote: ..
   specs:
     datadog (2.3.0)
-      debase-ruby_core_source (= 3.3.1)
+      debase-ruby_core_source (= 3.3.5)
       libdatadog (~> 12.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
@@ -82,7 +82,7 @@ GEM
       rexml
     crass (1.0.6)
     date (3.3.3)
-    debase-ruby_core_source (3.3.1)
+    debase-ruby_core_source (3.3.5)
     debug_inspector (1.1.0)
     diff-lcs (1.5.0)
     docile (1.4.0)

--- a/gemfiles/ruby_2.6_rails61_mysql2.gemfile.lock
+++ b/gemfiles/ruby_2.6_rails61_mysql2.gemfile.lock
@@ -12,7 +12,7 @@ PATH
   remote: ..
   specs:
     datadog (2.3.0)
-      debase-ruby_core_source (= 3.3.1)
+      debase-ruby_core_source (= 3.3.5)
       libdatadog (~> 12.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
@@ -99,7 +99,7 @@ GEM
       rexml
     crass (1.0.6)
     date (3.3.3)
-    debase-ruby_core_source (3.3.1)
+    debase-ruby_core_source (3.3.5)
     debug_inspector (1.1.0)
     diff-lcs (1.5.0)
     docile (1.4.0)

--- a/gemfiles/ruby_2.6_rails61_postgres.gemfile.lock
+++ b/gemfiles/ruby_2.6_rails61_postgres.gemfile.lock
@@ -12,7 +12,7 @@ PATH
   remote: ..
   specs:
     datadog (2.3.0)
-      debase-ruby_core_source (= 3.3.1)
+      debase-ruby_core_source (= 3.3.5)
       libdatadog (~> 12.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
@@ -99,7 +99,7 @@ GEM
       rexml
     crass (1.0.6)
     date (3.3.3)
-    debase-ruby_core_source (3.3.1)
+    debase-ruby_core_source (3.3.5)
     debug_inspector (1.1.0)
     diff-lcs (1.5.0)
     docile (1.4.0)

--- a/gemfiles/ruby_2.6_rails61_postgres_redis.gemfile.lock
+++ b/gemfiles/ruby_2.6_rails61_postgres_redis.gemfile.lock
@@ -12,7 +12,7 @@ PATH
   remote: ..
   specs:
     datadog (2.3.0)
-      debase-ruby_core_source (= 3.3.1)
+      debase-ruby_core_source (= 3.3.5)
       libdatadog (~> 12.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
@@ -99,7 +99,7 @@ GEM
       rexml
     crass (1.0.6)
     date (3.3.3)
-    debase-ruby_core_source (3.3.1)
+    debase-ruby_core_source (3.3.5)
     debug_inspector (1.1.0)
     diff-lcs (1.5.0)
     docile (1.4.0)

--- a/gemfiles/ruby_2.6_rails61_postgres_sidekiq.gemfile.lock
+++ b/gemfiles/ruby_2.6_rails61_postgres_sidekiq.gemfile.lock
@@ -12,7 +12,7 @@ PATH
   remote: ..
   specs:
     datadog (2.3.0)
-      debase-ruby_core_source (= 3.3.1)
+      debase-ruby_core_source (= 3.3.5)
       libdatadog (~> 12.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
@@ -100,7 +100,7 @@ GEM
       rexml
     crass (1.0.6)
     date (3.3.3)
-    debase-ruby_core_source (3.3.1)
+    debase-ruby_core_source (3.3.5)
     debug_inspector (1.1.0)
     diff-lcs (1.5.0)
     docile (1.4.0)

--- a/gemfiles/ruby_2.6_rails61_semantic_logger.gemfile.lock
+++ b/gemfiles/ruby_2.6_rails61_semantic_logger.gemfile.lock
@@ -12,7 +12,7 @@ PATH
   remote: ..
   specs:
     datadog (2.3.0)
-      debase-ruby_core_source (= 3.3.1)
+      debase-ruby_core_source (= 3.3.5)
       libdatadog (~> 12.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
@@ -99,7 +99,7 @@ GEM
       rexml
     crass (1.0.6)
     date (3.3.3)
-    debase-ruby_core_source (3.3.1)
+    debase-ruby_core_source (3.3.5)
     debug_inspector (1.1.0)
     diff-lcs (1.5.0)
     docile (1.4.0)

--- a/gemfiles/ruby_2.6_rails6_mysql2.gemfile.lock
+++ b/gemfiles/ruby_2.6_rails6_mysql2.gemfile.lock
@@ -12,7 +12,7 @@ PATH
   remote: ..
   specs:
     datadog (2.3.0)
-      debase-ruby_core_source (= 3.3.1)
+      debase-ruby_core_source (= 3.3.5)
       libdatadog (~> 12.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
@@ -95,7 +95,7 @@ GEM
       rexml
     crass (1.0.6)
     date (3.3.3)
-    debase-ruby_core_source (3.3.1)
+    debase-ruby_core_source (3.3.5)
     debug_inspector (1.1.0)
     diff-lcs (1.5.0)
     docile (1.4.0)

--- a/gemfiles/ruby_2.6_rails6_postgres.gemfile.lock
+++ b/gemfiles/ruby_2.6_rails6_postgres.gemfile.lock
@@ -12,7 +12,7 @@ PATH
   remote: ..
   specs:
     datadog (2.3.0)
-      debase-ruby_core_source (= 3.3.1)
+      debase-ruby_core_source (= 3.3.5)
       libdatadog (~> 12.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
@@ -95,7 +95,7 @@ GEM
       rexml
     crass (1.0.6)
     date (3.3.3)
-    debase-ruby_core_source (3.3.1)
+    debase-ruby_core_source (3.3.5)
     debug_inspector (1.1.0)
     diff-lcs (1.5.0)
     docile (1.4.0)

--- a/gemfiles/ruby_2.6_rails6_postgres_redis.gemfile.lock
+++ b/gemfiles/ruby_2.6_rails6_postgres_redis.gemfile.lock
@@ -12,7 +12,7 @@ PATH
   remote: ..
   specs:
     datadog (2.3.0)
-      debase-ruby_core_source (= 3.3.1)
+      debase-ruby_core_source (= 3.3.5)
       libdatadog (~> 12.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
@@ -95,7 +95,7 @@ GEM
       rexml
     crass (1.0.6)
     date (3.3.3)
-    debase-ruby_core_source (3.3.1)
+    debase-ruby_core_source (3.3.5)
     debug_inspector (1.1.0)
     diff-lcs (1.5.0)
     docile (1.4.0)

--- a/gemfiles/ruby_2.6_rails6_postgres_redis_activesupport.gemfile.lock
+++ b/gemfiles/ruby_2.6_rails6_postgres_redis_activesupport.gemfile.lock
@@ -12,7 +12,7 @@ PATH
   remote: ..
   specs:
     datadog (2.3.0)
-      debase-ruby_core_source (= 3.3.1)
+      debase-ruby_core_source (= 3.3.5)
       libdatadog (~> 12.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
@@ -95,7 +95,7 @@ GEM
       rexml
     crass (1.0.6)
     date (3.3.3)
-    debase-ruby_core_source (3.3.1)
+    debase-ruby_core_source (3.3.5)
     debug_inspector (1.1.0)
     diff-lcs (1.5.0)
     docile (1.4.0)

--- a/gemfiles/ruby_2.6_rails6_postgres_sidekiq.gemfile.lock
+++ b/gemfiles/ruby_2.6_rails6_postgres_sidekiq.gemfile.lock
@@ -12,7 +12,7 @@ PATH
   remote: ..
   specs:
     datadog (2.3.0)
-      debase-ruby_core_source (= 3.3.1)
+      debase-ruby_core_source (= 3.3.5)
       libdatadog (~> 12.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
@@ -96,7 +96,7 @@ GEM
       rexml
     crass (1.0.6)
     date (3.3.3)
-    debase-ruby_core_source (3.3.1)
+    debase-ruby_core_source (3.3.5)
     debug_inspector (1.1.0)
     diff-lcs (1.5.0)
     docile (1.4.0)

--- a/gemfiles/ruby_2.6_rails6_semantic_logger.gemfile.lock
+++ b/gemfiles/ruby_2.6_rails6_semantic_logger.gemfile.lock
@@ -12,7 +12,7 @@ PATH
   remote: ..
   specs:
     datadog (2.3.0)
-      debase-ruby_core_source (= 3.3.1)
+      debase-ruby_core_source (= 3.3.5)
       libdatadog (~> 12.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
@@ -95,7 +95,7 @@ GEM
       rexml
     crass (1.0.6)
     date (3.3.3)
-    debase-ruby_core_source (3.3.1)
+    debase-ruby_core_source (3.3.5)
     debug_inspector (1.1.0)
     diff-lcs (1.5.0)
     docile (1.4.0)

--- a/gemfiles/ruby_2.6_redis_3.gemfile.lock
+++ b/gemfiles/ruby_2.6_redis_3.gemfile.lock
@@ -12,7 +12,7 @@ PATH
   remote: ..
   specs:
     datadog (2.3.0)
-      debase-ruby_core_source (= 3.3.1)
+      debase-ruby_core_source (= 3.3.5)
       libdatadog (~> 12.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
@@ -37,7 +37,7 @@ GEM
     concurrent-ruby (1.2.2)
     crack (0.4.5)
       rexml
-    debase-ruby_core_source (3.3.1)
+    debase-ruby_core_source (3.3.5)
     debug_inspector (1.1.0)
     diff-lcs (1.5.0)
     docile (1.4.0)

--- a/gemfiles/ruby_2.6_redis_4.gemfile.lock
+++ b/gemfiles/ruby_2.6_redis_4.gemfile.lock
@@ -12,7 +12,7 @@ PATH
   remote: ..
   specs:
     datadog (2.3.0)
-      debase-ruby_core_source (= 3.3.1)
+      debase-ruby_core_source (= 3.3.5)
       libdatadog (~> 12.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
@@ -37,7 +37,7 @@ GEM
     concurrent-ruby (1.2.2)
     crack (0.4.5)
       rexml
-    debase-ruby_core_source (3.3.1)
+    debase-ruby_core_source (3.3.5)
     debug_inspector (1.1.0)
     diff-lcs (1.5.0)
     docile (1.4.0)

--- a/gemfiles/ruby_2.6_redis_5.gemfile.lock
+++ b/gemfiles/ruby_2.6_redis_5.gemfile.lock
@@ -12,7 +12,7 @@ PATH
   remote: ..
   specs:
     datadog (2.3.0)
-      debase-ruby_core_source (= 3.3.1)
+      debase-ruby_core_source (= 3.3.5)
       libdatadog (~> 12.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
@@ -38,7 +38,7 @@ GEM
     connection_pool (2.3.0)
     crack (0.4.5)
       rexml
-    debase-ruby_core_source (3.3.1)
+    debase-ruby_core_source (3.3.5)
     debug_inspector (1.1.0)
     diff-lcs (1.5.0)
     docile (1.4.0)

--- a/gemfiles/ruby_2.6_relational_db.gemfile.lock
+++ b/gemfiles/ruby_2.6_relational_db.gemfile.lock
@@ -12,7 +12,7 @@ PATH
   remote: ..
   specs:
     datadog (2.3.0)
-      debase-ruby_core_source (= 3.3.1)
+      debase-ruby_core_source (= 3.3.5)
       libdatadog (~> 12.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
@@ -49,7 +49,7 @@ GEM
     concurrent-ruby (1.2.2)
     crack (0.4.5)
       rexml
-    debase-ruby_core_source (3.3.1)
+    debase-ruby_core_source (3.3.5)
     debug_inspector (1.1.0)
     delayed_job (4.1.11)
       activesupport (>= 3.0, < 8.0)

--- a/gemfiles/ruby_2.6_resque2_redis3.gemfile.lock
+++ b/gemfiles/ruby_2.6_resque2_redis3.gemfile.lock
@@ -12,7 +12,7 @@ PATH
   remote: ..
   specs:
     datadog (2.3.0)
-      debase-ruby_core_source (= 3.3.1)
+      debase-ruby_core_source (= 3.3.5)
       libdatadog (~> 12.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
@@ -37,7 +37,7 @@ GEM
     concurrent-ruby (1.2.2)
     crack (0.4.5)
       rexml
-    debase-ruby_core_source (3.3.1)
+    debase-ruby_core_source (3.3.5)
     debug_inspector (1.1.0)
     diff-lcs (1.5.0)
     docile (1.4.0)

--- a/gemfiles/ruby_2.6_resque2_redis4.gemfile.lock
+++ b/gemfiles/ruby_2.6_resque2_redis4.gemfile.lock
@@ -12,7 +12,7 @@ PATH
   remote: ..
   specs:
     datadog (2.3.0)
-      debase-ruby_core_source (= 3.3.1)
+      debase-ruby_core_source (= 3.3.5)
       libdatadog (~> 12.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
@@ -37,7 +37,7 @@ GEM
     concurrent-ruby (1.2.2)
     crack (0.4.5)
       rexml
-    debase-ruby_core_source (3.3.1)
+    debase-ruby_core_source (3.3.5)
     debug_inspector (1.1.0)
     diff-lcs (1.5.0)
     docile (1.4.0)

--- a/gemfiles/ruby_2.6_sinatra_2.gemfile.lock
+++ b/gemfiles/ruby_2.6_sinatra_2.gemfile.lock
@@ -12,7 +12,7 @@ PATH
   remote: ..
   specs:
     datadog (2.3.0)
-      debase-ruby_core_source (= 3.3.1)
+      debase-ruby_core_source (= 3.3.5)
       libdatadog (~> 12.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
@@ -40,7 +40,7 @@ GEM
     crack (1.0.0)
       bigdecimal
       rexml
-    debase-ruby_core_source (3.3.1)
+    debase-ruby_core_source (3.3.5)
     debug_inspector (1.2.0)
     diff-lcs (1.5.1)
     docile (1.4.0)

--- a/gemfiles/ruby_2.6_sinatra_3.gemfile.lock
+++ b/gemfiles/ruby_2.6_sinatra_3.gemfile.lock
@@ -12,7 +12,7 @@ PATH
   remote: ..
   specs:
     datadog (2.3.0)
-      debase-ruby_core_source (= 3.3.1)
+      debase-ruby_core_source (= 3.3.5)
       libdatadog (~> 12.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
@@ -41,7 +41,7 @@ GEM
     crack (1.0.0)
       bigdecimal
       rexml
-    debase-ruby_core_source (3.3.1)
+    debase-ruby_core_source (3.3.5)
     debug_inspector (1.2.0)
     diff-lcs (1.5.1)
     docile (1.4.0)

--- a/gemfiles/ruby_2.6_stripe_10.gemfile.lock
+++ b/gemfiles/ruby_2.6_stripe_10.gemfile.lock
@@ -12,7 +12,7 @@ PATH
   remote: ..
   specs:
     datadog (2.3.0)
-      debase-ruby_core_source (= 3.3.1)
+      debase-ruby_core_source (= 3.3.5)
       libdatadog (~> 12.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
@@ -40,7 +40,7 @@ GEM
     crack (1.0.0)
       bigdecimal
       rexml
-    debase-ruby_core_source (3.3.1)
+    debase-ruby_core_source (3.3.5)
     debug_inspector (1.2.0)
     diff-lcs (1.5.1)
     docile (1.4.1)

--- a/gemfiles/ruby_2.6_stripe_11.gemfile.lock
+++ b/gemfiles/ruby_2.6_stripe_11.gemfile.lock
@@ -12,7 +12,7 @@ PATH
   remote: ..
   specs:
     datadog (2.3.0)
-      debase-ruby_core_source (= 3.3.1)
+      debase-ruby_core_source (= 3.3.5)
       libdatadog (~> 12.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
@@ -40,7 +40,7 @@ GEM
     crack (1.0.0)
       bigdecimal
       rexml
-    debase-ruby_core_source (3.3.1)
+    debase-ruby_core_source (3.3.5)
     debug_inspector (1.2.0)
     diff-lcs (1.5.1)
     docile (1.4.1)

--- a/gemfiles/ruby_2.6_stripe_12.gemfile.lock
+++ b/gemfiles/ruby_2.6_stripe_12.gemfile.lock
@@ -12,7 +12,7 @@ PATH
   remote: ..
   specs:
     datadog (2.3.0)
-      debase-ruby_core_source (= 3.3.1)
+      debase-ruby_core_source (= 3.3.5)
       libdatadog (~> 12.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
@@ -40,7 +40,7 @@ GEM
     crack (1.0.0)
       bigdecimal
       rexml
-    debase-ruby_core_source (3.3.1)
+    debase-ruby_core_source (3.3.5)
     debug_inspector (1.2.0)
     diff-lcs (1.5.1)
     docile (1.4.1)

--- a/gemfiles/ruby_2.6_stripe_7.gemfile.lock
+++ b/gemfiles/ruby_2.6_stripe_7.gemfile.lock
@@ -12,7 +12,7 @@ PATH
   remote: ..
   specs:
     datadog (2.3.0)
-      debase-ruby_core_source (= 3.3.1)
+      debase-ruby_core_source (= 3.3.5)
       libdatadog (~> 12.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
@@ -40,7 +40,7 @@ GEM
     crack (1.0.0)
       bigdecimal
       rexml
-    debase-ruby_core_source (3.3.1)
+    debase-ruby_core_source (3.3.5)
     debug_inspector (1.2.0)
     diff-lcs (1.5.1)
     docile (1.4.1)

--- a/gemfiles/ruby_2.6_stripe_8.gemfile.lock
+++ b/gemfiles/ruby_2.6_stripe_8.gemfile.lock
@@ -12,7 +12,7 @@ PATH
   remote: ..
   specs:
     datadog (2.3.0)
-      debase-ruby_core_source (= 3.3.1)
+      debase-ruby_core_source (= 3.3.5)
       libdatadog (~> 12.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
@@ -40,7 +40,7 @@ GEM
     crack (1.0.0)
       bigdecimal
       rexml
-    debase-ruby_core_source (3.3.1)
+    debase-ruby_core_source (3.3.5)
     debug_inspector (1.2.0)
     diff-lcs (1.5.1)
     docile (1.4.1)

--- a/gemfiles/ruby_2.6_stripe_9.gemfile.lock
+++ b/gemfiles/ruby_2.6_stripe_9.gemfile.lock
@@ -12,7 +12,7 @@ PATH
   remote: ..
   specs:
     datadog (2.3.0)
-      debase-ruby_core_source (= 3.3.1)
+      debase-ruby_core_source (= 3.3.5)
       libdatadog (~> 12.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
@@ -40,7 +40,7 @@ GEM
     crack (1.0.0)
       bigdecimal
       rexml
-    debase-ruby_core_source (3.3.1)
+    debase-ruby_core_source (3.3.5)
     debug_inspector (1.2.0)
     diff-lcs (1.5.1)
     docile (1.4.1)

--- a/gemfiles/ruby_2.6_stripe_latest.gemfile.lock
+++ b/gemfiles/ruby_2.6_stripe_latest.gemfile.lock
@@ -12,7 +12,7 @@ PATH
   remote: ..
   specs:
     datadog (2.3.0)
-      debase-ruby_core_source (= 3.3.1)
+      debase-ruby_core_source (= 3.3.5)
       libdatadog (~> 12.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
@@ -40,7 +40,7 @@ GEM
     crack (1.0.0)
       bigdecimal
       rexml
-    debase-ruby_core_source (3.3.1)
+    debase-ruby_core_source (3.3.5)
     debug_inspector (1.2.0)
     diff-lcs (1.5.1)
     docile (1.4.1)

--- a/gemfiles/ruby_2.6_stripe_min.gemfile.lock
+++ b/gemfiles/ruby_2.6_stripe_min.gemfile.lock
@@ -12,7 +12,7 @@ PATH
   remote: ..
   specs:
     datadog (2.3.0)
-      debase-ruby_core_source (= 3.3.1)
+      debase-ruby_core_source (= 3.3.5)
       libdatadog (~> 12.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
@@ -40,7 +40,7 @@ GEM
     crack (1.0.0)
       bigdecimal
       rexml
-    debase-ruby_core_source (3.3.1)
+    debase-ruby_core_source (3.3.5)
     debug_inspector (1.2.0)
     diff-lcs (1.5.1)
     docile (1.4.1)

--- a/gemfiles/ruby_2.7_activesupport.gemfile.lock
+++ b/gemfiles/ruby_2.7_activesupport.gemfile.lock
@@ -12,7 +12,7 @@ PATH
   remote: ..
   specs:
     datadog (2.3.0)
-      debase-ruby_core_source (= 3.3.1)
+      debase-ruby_core_source (= 3.3.5)
       libdatadog (~> 12.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
@@ -67,7 +67,7 @@ GEM
     crack (0.4.5)
       rexml
     crass (1.0.6)
-    debase-ruby_core_source (3.3.1)
+    debase-ruby_core_source (3.3.5)
     debug_inspector (1.1.0)
     diff-lcs (1.5.0)
     digest-crc (0.6.5)

--- a/gemfiles/ruby_2.7_aws.gemfile.lock
+++ b/gemfiles/ruby_2.7_aws.gemfile.lock
@@ -12,7 +12,7 @@ PATH
   remote: ..
   specs:
     datadog (2.3.0)
-      debase-ruby_core_source (= 3.3.1)
+      debase-ruby_core_source (= 3.3.5)
       libdatadog (~> 12.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
@@ -1458,7 +1458,7 @@ GEM
     concurrent-ruby (1.2.2)
     crack (0.4.5)
       rexml
-    debase-ruby_core_source (3.3.1)
+    debase-ruby_core_source (3.3.5)
     debug_inspector (1.1.0)
     diff-lcs (1.5.0)
     docile (1.4.0)

--- a/gemfiles/ruby_2.7_contrib.gemfile.lock
+++ b/gemfiles/ruby_2.7_contrib.gemfile.lock
@@ -12,7 +12,7 @@ PATH
   remote: ..
   specs:
     datadog (2.3.0)
-      debase-ruby_core_source (= 3.3.1)
+      debase-ruby_core_source (= 3.3.5)
       libdatadog (~> 12.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
@@ -44,7 +44,7 @@ GEM
     crack (0.4.5)
       rexml
     dalli (3.2.4)
-    debase-ruby_core_source (3.3.1)
+    debase-ruby_core_source (3.3.5)
     debug_inspector (1.1.0)
     diff-lcs (1.5.0)
     docile (1.4.0)

--- a/gemfiles/ruby_2.7_contrib_old.gemfile.lock
+++ b/gemfiles/ruby_2.7_contrib_old.gemfile.lock
@@ -12,7 +12,7 @@ PATH
   remote: ..
   specs:
     datadog (2.3.0)
-      debase-ruby_core_source (= 3.3.1)
+      debase-ruby_core_source (= 3.3.5)
       libdatadog (~> 12.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
@@ -42,7 +42,7 @@ GEM
       rexml
     daemons (1.4.1)
     dalli (2.7.11)
-    debase-ruby_core_source (3.3.1)
+    debase-ruby_core_source (3.3.5)
     debug_inspector (1.1.0)
     diff-lcs (1.5.0)
     docile (1.4.0)

--- a/gemfiles/ruby_2.7_core_old.gemfile.lock
+++ b/gemfiles/ruby_2.7_core_old.gemfile.lock
@@ -12,7 +12,7 @@ PATH
   remote: ..
   specs:
     datadog (2.3.0)
-      debase-ruby_core_source (= 3.3.1)
+      debase-ruby_core_source (= 3.3.5)
       libdatadog (~> 12.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
@@ -37,7 +37,7 @@ GEM
     concurrent-ruby (1.2.2)
     crack (0.4.5)
       rexml
-    debase-ruby_core_source (3.3.1)
+    debase-ruby_core_source (3.3.5)
     debug_inspector (1.1.0)
     diff-lcs (1.5.0)
     docile (1.4.0)

--- a/gemfiles/ruby_2.7_elasticsearch_7.gemfile.lock
+++ b/gemfiles/ruby_2.7_elasticsearch_7.gemfile.lock
@@ -12,7 +12,7 @@ PATH
   remote: ..
   specs:
     datadog (2.3.0)
-      debase-ruby_core_source (= 3.3.1)
+      debase-ruby_core_source (= 3.3.5)
       libdatadog (~> 12.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
@@ -38,7 +38,7 @@ GEM
     concurrent-ruby (1.2.2)
     crack (0.4.5)
       rexml
-    debase-ruby_core_source (3.3.1)
+    debase-ruby_core_source (3.3.5)
     debug_inspector (1.1.0)
     diff-lcs (1.5.0)
     docile (1.4.0)

--- a/gemfiles/ruby_2.7_elasticsearch_8.gemfile.lock
+++ b/gemfiles/ruby_2.7_elasticsearch_8.gemfile.lock
@@ -12,7 +12,7 @@ PATH
   remote: ..
   specs:
     datadog (2.3.0)
-      debase-ruby_core_source (= 3.3.1)
+      debase-ruby_core_source (= 3.3.5)
       libdatadog (~> 12.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
@@ -39,7 +39,7 @@ GEM
     concurrent-ruby (1.2.2)
     crack (0.4.5)
       rexml
-    debase-ruby_core_source (3.3.1)
+    debase-ruby_core_source (3.3.5)
     debug_inspector (1.1.0)
     diff-lcs (1.5.0)
     docile (1.4.0)

--- a/gemfiles/ruby_2.7_elasticsearch_latest.gemfile.lock
+++ b/gemfiles/ruby_2.7_elasticsearch_latest.gemfile.lock
@@ -12,7 +12,7 @@ PATH
   remote: ..
   specs:
     datadog (2.3.0)
-      debase-ruby_core_source (= 3.3.1)
+      debase-ruby_core_source (= 3.3.5)
       libdatadog (~> 12.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
@@ -41,7 +41,7 @@ GEM
     crack (1.0.0)
       bigdecimal
       rexml
-    debase-ruby_core_source (3.3.1)
+    debase-ruby_core_source (3.3.5)
     debug_inspector (1.2.0)
     diff-lcs (1.5.1)
     docile (1.4.1)

--- a/gemfiles/ruby_2.7_graphql_1.13.gemfile.lock
+++ b/gemfiles/ruby_2.7_graphql_1.13.gemfile.lock
@@ -12,7 +12,7 @@ PATH
   remote: ..
   specs:
     datadog (2.3.0)
-      debase-ruby_core_source (= 3.3.1)
+      debase-ruby_core_source (= 3.3.5)
       libdatadog (~> 12.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
@@ -101,7 +101,7 @@ GEM
       rexml
     crass (1.0.6)
     date (3.3.4)
-    debase-ruby_core_source (3.3.1)
+    debase-ruby_core_source (3.3.5)
     debug_inspector (1.2.0)
     diff-lcs (1.5.0)
     docile (1.4.0)

--- a/gemfiles/ruby_2.7_graphql_2.0.gemfile.lock
+++ b/gemfiles/ruby_2.7_graphql_2.0.gemfile.lock
@@ -12,7 +12,7 @@ PATH
   remote: ..
   specs:
     datadog (2.3.0)
-      debase-ruby_core_source (= 3.3.1)
+      debase-ruby_core_source (= 3.3.5)
       libdatadog (~> 12.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
@@ -101,7 +101,7 @@ GEM
       rexml
     crass (1.0.6)
     date (3.3.4)
-    debase-ruby_core_source (3.3.1)
+    debase-ruby_core_source (3.3.5)
     debug_inspector (1.2.0)
     diff-lcs (1.5.0)
     docile (1.4.0)

--- a/gemfiles/ruby_2.7_graphql_2.1.gemfile.lock
+++ b/gemfiles/ruby_2.7_graphql_2.1.gemfile.lock
@@ -12,7 +12,7 @@ PATH
   remote: ..
   specs:
     datadog (2.3.0)
-      debase-ruby_core_source (= 3.3.1)
+      debase-ruby_core_source (= 3.3.5)
       libdatadog (~> 12.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
@@ -101,7 +101,7 @@ GEM
       rexml
     crass (1.0.6)
     date (3.3.4)
-    debase-ruby_core_source (3.3.1)
+    debase-ruby_core_source (3.3.5)
     debug_inspector (1.2.0)
     diff-lcs (1.5.0)
     docile (1.4.0)

--- a/gemfiles/ruby_2.7_graphql_2.2.gemfile.lock
+++ b/gemfiles/ruby_2.7_graphql_2.2.gemfile.lock
@@ -12,7 +12,7 @@ PATH
   remote: ..
   specs:
     datadog (2.3.0)
-      debase-ruby_core_source (= 3.3.1)
+      debase-ruby_core_source (= 3.3.5)
       libdatadog (~> 12.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
@@ -101,7 +101,7 @@ GEM
       rexml
     crass (1.0.6)
     date (3.3.4)
-    debase-ruby_core_source (3.3.1)
+    debase-ruby_core_source (3.3.5)
     debug_inspector (1.2.0)
     diff-lcs (1.5.0)
     docile (1.4.0)

--- a/gemfiles/ruby_2.7_graphql_2.3.gemfile.lock
+++ b/gemfiles/ruby_2.7_graphql_2.3.gemfile.lock
@@ -12,7 +12,7 @@ PATH
   remote: ..
   specs:
     datadog (2.3.0)
-      debase-ruby_core_source (= 3.3.1)
+      debase-ruby_core_source (= 3.3.5)
       libdatadog (~> 12.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
@@ -103,7 +103,7 @@ GEM
       rexml
     crass (1.0.6)
     date (3.3.4)
-    debase-ruby_core_source (3.3.1)
+    debase-ruby_core_source (3.3.5)
     debug_inspector (1.2.0)
     diff-lcs (1.5.1)
     docile (1.4.0)

--- a/gemfiles/ruby_2.7_hanami_1.gemfile.lock
+++ b/gemfiles/ruby_2.7_hanami_1.gemfile.lock
@@ -12,7 +12,7 @@ PATH
   remote: ..
   specs:
     datadog (2.3.0)
-      debase-ruby_core_source (= 3.3.1)
+      debase-ruby_core_source (= 3.3.5)
       libdatadog (~> 12.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
@@ -38,7 +38,7 @@ GEM
     crack (0.4.5)
       rexml
     date (3.3.3)
-    debase-ruby_core_source (3.3.1)
+    debase-ruby_core_source (3.3.5)
     debug_inspector (1.1.0)
     diff-lcs (1.5.0)
     docile (1.4.0)

--- a/gemfiles/ruby_2.7_http.gemfile.lock
+++ b/gemfiles/ruby_2.7_http.gemfile.lock
@@ -12,7 +12,7 @@ PATH
   remote: ..
   specs:
     datadog (2.3.0)
-      debase-ruby_core_source (= 3.3.1)
+      debase-ruby_core_source (= 3.3.5)
       libdatadog (~> 12.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
@@ -37,7 +37,7 @@ GEM
     concurrent-ruby (1.2.2)
     crack (0.4.5)
       rexml
-    debase-ruby_core_source (3.3.1)
+    debase-ruby_core_source (3.3.5)
     debug_inspector (1.1.0)
     diff-lcs (1.5.0)
     docile (1.4.0)

--- a/gemfiles/ruby_2.7_opensearch_2.gemfile.lock
+++ b/gemfiles/ruby_2.7_opensearch_2.gemfile.lock
@@ -12,7 +12,7 @@ PATH
   remote: ..
   specs:
     datadog (2.3.0)
-      debase-ruby_core_source (= 3.3.1)
+      debase-ruby_core_source (= 3.3.5)
       libdatadog (~> 12.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
@@ -39,7 +39,7 @@ GEM
     concurrent-ruby (1.2.2)
     crack (0.4.5)
       rexml
-    debase-ruby_core_source (3.3.1)
+    debase-ruby_core_source (3.3.5)
     debug_inspector (1.1.0)
     diff-lcs (1.5.0)
     docile (1.4.0)

--- a/gemfiles/ruby_2.7_opensearch_3.gemfile.lock
+++ b/gemfiles/ruby_2.7_opensearch_3.gemfile.lock
@@ -12,7 +12,7 @@ PATH
   remote: ..
   specs:
     datadog (2.3.0)
-      debase-ruby_core_source (= 3.3.1)
+      debase-ruby_core_source (= 3.3.5)
       libdatadog (~> 12.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
@@ -39,7 +39,7 @@ GEM
     concurrent-ruby (1.2.2)
     crack (0.4.5)
       rexml
-    debase-ruby_core_source (3.3.1)
+    debase-ruby_core_source (3.3.5)
     debug_inspector (1.1.0)
     diff-lcs (1.5.0)
     docile (1.4.0)

--- a/gemfiles/ruby_2.7_opensearch_latest.gemfile.lock
+++ b/gemfiles/ruby_2.7_opensearch_latest.gemfile.lock
@@ -12,7 +12,7 @@ PATH
   remote: ..
   specs:
     datadog (2.3.0)
-      debase-ruby_core_source (= 3.3.1)
+      debase-ruby_core_source (= 3.3.5)
       libdatadog (~> 12.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
@@ -41,7 +41,7 @@ GEM
     crack (1.0.0)
       bigdecimal
       rexml
-    debase-ruby_core_source (3.3.1)
+    debase-ruby_core_source (3.3.5)
     debug_inspector (1.2.0)
     diff-lcs (1.5.1)
     docile (1.4.1)

--- a/gemfiles/ruby_2.7_opentelemetry.gemfile.lock
+++ b/gemfiles/ruby_2.7_opentelemetry.gemfile.lock
@@ -12,7 +12,7 @@ PATH
   remote: ..
   specs:
     datadog (2.3.0)
-      debase-ruby_core_source (= 3.3.1)
+      debase-ruby_core_source (= 3.3.5)
       libdatadog (~> 12.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
@@ -37,7 +37,7 @@ GEM
     concurrent-ruby (1.2.2)
     crack (0.4.5)
       rexml
-    debase-ruby_core_source (3.3.1)
+    debase-ruby_core_source (3.3.5)
     debug_inspector (1.1.0)
     diff-lcs (1.5.0)
     docile (1.4.0)

--- a/gemfiles/ruby_2.7_rack_1.gemfile.lock
+++ b/gemfiles/ruby_2.7_rack_1.gemfile.lock
@@ -12,7 +12,7 @@ PATH
   remote: ..
   specs:
     datadog (2.3.0)
-      debase-ruby_core_source (= 3.3.1)
+      debase-ruby_core_source (= 3.3.5)
       libdatadog (~> 12.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
@@ -37,7 +37,7 @@ GEM
     concurrent-ruby (1.2.2)
     crack (0.4.5)
       rexml
-    debase-ruby_core_source (3.3.1)
+    debase-ruby_core_source (3.3.5)
     debug_inspector (1.1.0)
     diff-lcs (1.5.0)
     docile (1.4.0)

--- a/gemfiles/ruby_2.7_rack_2.gemfile.lock
+++ b/gemfiles/ruby_2.7_rack_2.gemfile.lock
@@ -12,7 +12,7 @@ PATH
   remote: ..
   specs:
     datadog (2.3.0)
-      debase-ruby_core_source (= 3.3.1)
+      debase-ruby_core_source (= 3.3.5)
       libdatadog (~> 12.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
@@ -37,7 +37,7 @@ GEM
     concurrent-ruby (1.2.2)
     crack (0.4.5)
       rexml
-    debase-ruby_core_source (3.3.1)
+    debase-ruby_core_source (3.3.5)
     debug_inspector (1.1.0)
     diff-lcs (1.5.0)
     docile (1.4.0)

--- a/gemfiles/ruby_2.7_rack_3.gemfile.lock
+++ b/gemfiles/ruby_2.7_rack_3.gemfile.lock
@@ -12,7 +12,7 @@ PATH
   remote: ..
   specs:
     datadog (2.3.0)
-      debase-ruby_core_source (= 3.3.1)
+      debase-ruby_core_source (= 3.3.5)
       libdatadog (~> 12.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
@@ -37,7 +37,7 @@ GEM
     concurrent-ruby (1.2.2)
     crack (0.4.5)
       rexml
-    debase-ruby_core_source (3.3.1)
+    debase-ruby_core_source (3.3.5)
     debug_inspector (1.1.0)
     diff-lcs (1.5.0)
     docile (1.4.0)

--- a/gemfiles/ruby_2.7_rack_latest.gemfile.lock
+++ b/gemfiles/ruby_2.7_rack_latest.gemfile.lock
@@ -12,7 +12,7 @@ PATH
   remote: ..
   specs:
     datadog (2.3.0)
-      debase-ruby_core_source (= 3.3.1)
+      debase-ruby_core_source (= 3.3.5)
       libdatadog (~> 12.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
@@ -40,7 +40,7 @@ GEM
     crack (1.0.0)
       bigdecimal
       rexml
-    debase-ruby_core_source (3.3.1)
+    debase-ruby_core_source (3.3.5)
     debug_inspector (1.2.0)
     diff-lcs (1.5.1)
     docile (1.4.1)

--- a/gemfiles/ruby_2.7_rails5_mysql2.gemfile.lock
+++ b/gemfiles/ruby_2.7_rails5_mysql2.gemfile.lock
@@ -12,7 +12,7 @@ PATH
   remote: ..
   specs:
     datadog (2.3.0)
-      debase-ruby_core_source (= 3.3.1)
+      debase-ruby_core_source (= 3.3.5)
       libdatadog (~> 12.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
@@ -82,7 +82,7 @@ GEM
       rexml
     crass (1.0.6)
     date (3.3.3)
-    debase-ruby_core_source (3.3.1)
+    debase-ruby_core_source (3.3.5)
     debug_inspector (1.1.0)
     diff-lcs (1.5.0)
     docile (1.4.0)

--- a/gemfiles/ruby_2.7_rails5_postgres.gemfile.lock
+++ b/gemfiles/ruby_2.7_rails5_postgres.gemfile.lock
@@ -12,7 +12,7 @@ PATH
   remote: ..
   specs:
     datadog (2.3.0)
-      debase-ruby_core_source (= 3.3.1)
+      debase-ruby_core_source (= 3.3.5)
       libdatadog (~> 12.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
@@ -82,7 +82,7 @@ GEM
       rexml
     crass (1.0.6)
     date (3.3.3)
-    debase-ruby_core_source (3.3.1)
+    debase-ruby_core_source (3.3.5)
     debug_inspector (1.1.0)
     diff-lcs (1.5.0)
     docile (1.4.0)

--- a/gemfiles/ruby_2.7_rails5_postgres_redis.gemfile.lock
+++ b/gemfiles/ruby_2.7_rails5_postgres_redis.gemfile.lock
@@ -12,7 +12,7 @@ PATH
   remote: ..
   specs:
     datadog (2.3.0)
-      debase-ruby_core_source (= 3.3.1)
+      debase-ruby_core_source (= 3.3.5)
       libdatadog (~> 12.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
@@ -82,7 +82,7 @@ GEM
       rexml
     crass (1.0.6)
     date (3.3.3)
-    debase-ruby_core_source (3.3.1)
+    debase-ruby_core_source (3.3.5)
     debug_inspector (1.1.0)
     diff-lcs (1.5.0)
     docile (1.4.0)

--- a/gemfiles/ruby_2.7_rails5_postgres_redis_activesupport.gemfile.lock
+++ b/gemfiles/ruby_2.7_rails5_postgres_redis_activesupport.gemfile.lock
@@ -12,7 +12,7 @@ PATH
   remote: ..
   specs:
     datadog (2.3.0)
-      debase-ruby_core_source (= 3.3.1)
+      debase-ruby_core_source (= 3.3.5)
       libdatadog (~> 12.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
@@ -82,7 +82,7 @@ GEM
       rexml
     crass (1.0.6)
     date (3.3.3)
-    debase-ruby_core_source (3.3.1)
+    debase-ruby_core_source (3.3.5)
     debug_inspector (1.1.0)
     diff-lcs (1.5.0)
     docile (1.4.0)

--- a/gemfiles/ruby_2.7_rails5_postgres_sidekiq.gemfile.lock
+++ b/gemfiles/ruby_2.7_rails5_postgres_sidekiq.gemfile.lock
@@ -12,7 +12,7 @@ PATH
   remote: ..
   specs:
     datadog (2.3.0)
-      debase-ruby_core_source (= 3.3.1)
+      debase-ruby_core_source (= 3.3.5)
       libdatadog (~> 12.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
@@ -83,7 +83,7 @@ GEM
       rexml
     crass (1.0.6)
     date (3.3.3)
-    debase-ruby_core_source (3.3.1)
+    debase-ruby_core_source (3.3.5)
     debug_inspector (1.1.0)
     diff-lcs (1.5.0)
     docile (1.4.0)

--- a/gemfiles/ruby_2.7_rails5_semantic_logger.gemfile.lock
+++ b/gemfiles/ruby_2.7_rails5_semantic_logger.gemfile.lock
@@ -12,7 +12,7 @@ PATH
   remote: ..
   specs:
     datadog (2.3.0)
-      debase-ruby_core_source (= 3.3.1)
+      debase-ruby_core_source (= 3.3.5)
       libdatadog (~> 12.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
@@ -82,7 +82,7 @@ GEM
       rexml
     crass (1.0.6)
     date (3.3.3)
-    debase-ruby_core_source (3.3.1)
+    debase-ruby_core_source (3.3.5)
     debug_inspector (1.1.0)
     diff-lcs (1.5.0)
     docile (1.4.0)

--- a/gemfiles/ruby_2.7_rails61_mysql2.gemfile.lock
+++ b/gemfiles/ruby_2.7_rails61_mysql2.gemfile.lock
@@ -12,7 +12,7 @@ PATH
   remote: ..
   specs:
     datadog (2.3.0)
-      debase-ruby_core_source (= 3.3.1)
+      debase-ruby_core_source (= 3.3.5)
       libdatadog (~> 12.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
@@ -99,7 +99,7 @@ GEM
       rexml
     crass (1.0.6)
     date (3.3.3)
-    debase-ruby_core_source (3.3.1)
+    debase-ruby_core_source (3.3.5)
     debug_inspector (1.1.0)
     diff-lcs (1.5.0)
     docile (1.4.0)

--- a/gemfiles/ruby_2.7_rails61_postgres.gemfile.lock
+++ b/gemfiles/ruby_2.7_rails61_postgres.gemfile.lock
@@ -12,7 +12,7 @@ PATH
   remote: ..
   specs:
     datadog (2.3.0)
-      debase-ruby_core_source (= 3.3.1)
+      debase-ruby_core_source (= 3.3.5)
       libdatadog (~> 12.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
@@ -99,7 +99,7 @@ GEM
       rexml
     crass (1.0.6)
     date (3.3.3)
-    debase-ruby_core_source (3.3.1)
+    debase-ruby_core_source (3.3.5)
     debug_inspector (1.1.0)
     diff-lcs (1.5.0)
     docile (1.4.0)

--- a/gemfiles/ruby_2.7_rails61_postgres_redis.gemfile.lock
+++ b/gemfiles/ruby_2.7_rails61_postgres_redis.gemfile.lock
@@ -12,7 +12,7 @@ PATH
   remote: ..
   specs:
     datadog (2.3.0)
-      debase-ruby_core_source (= 3.3.1)
+      debase-ruby_core_source (= 3.3.5)
       libdatadog (~> 12.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
@@ -99,7 +99,7 @@ GEM
       rexml
     crass (1.0.6)
     date (3.3.3)
-    debase-ruby_core_source (3.3.1)
+    debase-ruby_core_source (3.3.5)
     debug_inspector (1.1.0)
     diff-lcs (1.5.0)
     docile (1.4.0)

--- a/gemfiles/ruby_2.7_rails61_postgres_sidekiq.gemfile.lock
+++ b/gemfiles/ruby_2.7_rails61_postgres_sidekiq.gemfile.lock
@@ -12,7 +12,7 @@ PATH
   remote: ..
   specs:
     datadog (2.3.0)
-      debase-ruby_core_source (= 3.3.1)
+      debase-ruby_core_source (= 3.3.5)
       libdatadog (~> 12.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
@@ -100,7 +100,7 @@ GEM
       rexml
     crass (1.0.6)
     date (3.3.3)
-    debase-ruby_core_source (3.3.1)
+    debase-ruby_core_source (3.3.5)
     debug_inspector (1.1.0)
     diff-lcs (1.5.0)
     docile (1.4.0)

--- a/gemfiles/ruby_2.7_rails61_semantic_logger.gemfile.lock
+++ b/gemfiles/ruby_2.7_rails61_semantic_logger.gemfile.lock
@@ -12,7 +12,7 @@ PATH
   remote: ..
   specs:
     datadog (2.3.0)
-      debase-ruby_core_source (= 3.3.1)
+      debase-ruby_core_source (= 3.3.5)
       libdatadog (~> 12.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
@@ -99,7 +99,7 @@ GEM
       rexml
     crass (1.0.6)
     date (3.3.3)
-    debase-ruby_core_source (3.3.1)
+    debase-ruby_core_source (3.3.5)
     debug_inspector (1.1.0)
     diff-lcs (1.5.0)
     docile (1.4.0)

--- a/gemfiles/ruby_2.7_rails6_mysql2.gemfile.lock
+++ b/gemfiles/ruby_2.7_rails6_mysql2.gemfile.lock
@@ -12,7 +12,7 @@ PATH
   remote: ..
   specs:
     datadog (2.3.0)
-      debase-ruby_core_source (= 3.3.1)
+      debase-ruby_core_source (= 3.3.5)
       libdatadog (~> 12.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
@@ -95,7 +95,7 @@ GEM
       rexml
     crass (1.0.6)
     date (3.3.3)
-    debase-ruby_core_source (3.3.1)
+    debase-ruby_core_source (3.3.5)
     debug_inspector (1.1.0)
     diff-lcs (1.5.0)
     docile (1.4.0)

--- a/gemfiles/ruby_2.7_rails6_postgres.gemfile.lock
+++ b/gemfiles/ruby_2.7_rails6_postgres.gemfile.lock
@@ -12,7 +12,7 @@ PATH
   remote: ..
   specs:
     datadog (2.3.0)
-      debase-ruby_core_source (= 3.3.1)
+      debase-ruby_core_source (= 3.3.5)
       libdatadog (~> 12.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
@@ -95,7 +95,7 @@ GEM
       rexml
     crass (1.0.6)
     date (3.3.3)
-    debase-ruby_core_source (3.3.1)
+    debase-ruby_core_source (3.3.5)
     debug_inspector (1.1.0)
     diff-lcs (1.5.0)
     docile (1.4.0)

--- a/gemfiles/ruby_2.7_rails6_postgres_redis.gemfile.lock
+++ b/gemfiles/ruby_2.7_rails6_postgres_redis.gemfile.lock
@@ -12,7 +12,7 @@ PATH
   remote: ..
   specs:
     datadog (2.3.0)
-      debase-ruby_core_source (= 3.3.1)
+      debase-ruby_core_source (= 3.3.5)
       libdatadog (~> 12.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
@@ -95,7 +95,7 @@ GEM
       rexml
     crass (1.0.6)
     date (3.3.3)
-    debase-ruby_core_source (3.3.1)
+    debase-ruby_core_source (3.3.5)
     debug_inspector (1.1.0)
     diff-lcs (1.5.0)
     docile (1.4.0)

--- a/gemfiles/ruby_2.7_rails6_postgres_redis_activesupport.gemfile.lock
+++ b/gemfiles/ruby_2.7_rails6_postgres_redis_activesupport.gemfile.lock
@@ -12,7 +12,7 @@ PATH
   remote: ..
   specs:
     datadog (2.3.0)
-      debase-ruby_core_source (= 3.3.1)
+      debase-ruby_core_source (= 3.3.5)
       libdatadog (~> 12.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
@@ -95,7 +95,7 @@ GEM
       rexml
     crass (1.0.6)
     date (3.3.3)
-    debase-ruby_core_source (3.3.1)
+    debase-ruby_core_source (3.3.5)
     debug_inspector (1.1.0)
     diff-lcs (1.5.0)
     docile (1.4.0)

--- a/gemfiles/ruby_2.7_rails6_postgres_sidekiq.gemfile.lock
+++ b/gemfiles/ruby_2.7_rails6_postgres_sidekiq.gemfile.lock
@@ -12,7 +12,7 @@ PATH
   remote: ..
   specs:
     datadog (2.3.0)
-      debase-ruby_core_source (= 3.3.1)
+      debase-ruby_core_source (= 3.3.5)
       libdatadog (~> 12.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
@@ -96,7 +96,7 @@ GEM
       rexml
     crass (1.0.6)
     date (3.3.3)
-    debase-ruby_core_source (3.3.1)
+    debase-ruby_core_source (3.3.5)
     debug_inspector (1.1.0)
     diff-lcs (1.5.0)
     docile (1.4.0)

--- a/gemfiles/ruby_2.7_rails6_semantic_logger.gemfile.lock
+++ b/gemfiles/ruby_2.7_rails6_semantic_logger.gemfile.lock
@@ -12,7 +12,7 @@ PATH
   remote: ..
   specs:
     datadog (2.3.0)
-      debase-ruby_core_source (= 3.3.1)
+      debase-ruby_core_source (= 3.3.5)
       libdatadog (~> 12.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
@@ -95,7 +95,7 @@ GEM
       rexml
     crass (1.0.6)
     date (3.3.3)
-    debase-ruby_core_source (3.3.1)
+    debase-ruby_core_source (3.3.5)
     debug_inspector (1.1.0)
     diff-lcs (1.5.0)
     docile (1.4.0)

--- a/gemfiles/ruby_2.7_redis_3.gemfile.lock
+++ b/gemfiles/ruby_2.7_redis_3.gemfile.lock
@@ -12,7 +12,7 @@ PATH
   remote: ..
   specs:
     datadog (2.3.0)
-      debase-ruby_core_source (= 3.3.1)
+      debase-ruby_core_source (= 3.3.5)
       libdatadog (~> 12.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
@@ -37,7 +37,7 @@ GEM
     concurrent-ruby (1.2.2)
     crack (0.4.5)
       rexml
-    debase-ruby_core_source (3.3.1)
+    debase-ruby_core_source (3.3.5)
     debug_inspector (1.1.0)
     diff-lcs (1.5.0)
     docile (1.4.0)

--- a/gemfiles/ruby_2.7_redis_4.gemfile.lock
+++ b/gemfiles/ruby_2.7_redis_4.gemfile.lock
@@ -12,7 +12,7 @@ PATH
   remote: ..
   specs:
     datadog (2.3.0)
-      debase-ruby_core_source (= 3.3.1)
+      debase-ruby_core_source (= 3.3.5)
       libdatadog (~> 12.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
@@ -37,7 +37,7 @@ GEM
     concurrent-ruby (1.2.2)
     crack (0.4.5)
       rexml
-    debase-ruby_core_source (3.3.1)
+    debase-ruby_core_source (3.3.5)
     debug_inspector (1.1.0)
     diff-lcs (1.5.0)
     docile (1.4.0)

--- a/gemfiles/ruby_2.7_redis_5.gemfile.lock
+++ b/gemfiles/ruby_2.7_redis_5.gemfile.lock
@@ -12,7 +12,7 @@ PATH
   remote: ..
   specs:
     datadog (2.3.0)
-      debase-ruby_core_source (= 3.3.1)
+      debase-ruby_core_source (= 3.3.5)
       libdatadog (~> 12.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
@@ -38,7 +38,7 @@ GEM
     connection_pool (2.3.0)
     crack (0.4.5)
       rexml
-    debase-ruby_core_source (3.3.1)
+    debase-ruby_core_source (3.3.5)
     debug_inspector (1.1.0)
     diff-lcs (1.5.0)
     docile (1.4.0)

--- a/gemfiles/ruby_2.7_relational_db.gemfile.lock
+++ b/gemfiles/ruby_2.7_relational_db.gemfile.lock
@@ -12,7 +12,7 @@ PATH
   remote: ..
   specs:
     datadog (2.3.0)
-      debase-ruby_core_source (= 3.3.1)
+      debase-ruby_core_source (= 3.3.5)
       libdatadog (~> 12.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
@@ -49,7 +49,7 @@ GEM
     concurrent-ruby (1.2.2)
     crack (0.4.5)
       rexml
-    debase-ruby_core_source (3.3.1)
+    debase-ruby_core_source (3.3.5)
     debug_inspector (1.1.0)
     delayed_job (4.1.11)
       activesupport (>= 3.0, < 8.0)

--- a/gemfiles/ruby_2.7_resque2_redis3.gemfile.lock
+++ b/gemfiles/ruby_2.7_resque2_redis3.gemfile.lock
@@ -12,7 +12,7 @@ PATH
   remote: ..
   specs:
     datadog (2.3.0)
-      debase-ruby_core_source (= 3.3.1)
+      debase-ruby_core_source (= 3.3.5)
       libdatadog (~> 12.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
@@ -37,7 +37,7 @@ GEM
     concurrent-ruby (1.2.2)
     crack (0.4.5)
       rexml
-    debase-ruby_core_source (3.3.1)
+    debase-ruby_core_source (3.3.5)
     debug_inspector (1.1.0)
     diff-lcs (1.5.0)
     docile (1.4.0)

--- a/gemfiles/ruby_2.7_resque2_redis4.gemfile.lock
+++ b/gemfiles/ruby_2.7_resque2_redis4.gemfile.lock
@@ -12,7 +12,7 @@ PATH
   remote: ..
   specs:
     datadog (2.3.0)
-      debase-ruby_core_source (= 3.3.1)
+      debase-ruby_core_source (= 3.3.5)
       libdatadog (~> 12.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
@@ -37,7 +37,7 @@ GEM
     concurrent-ruby (1.2.2)
     crack (0.4.5)
       rexml
-    debase-ruby_core_source (3.3.1)
+    debase-ruby_core_source (3.3.5)
     debug_inspector (1.1.0)
     diff-lcs (1.5.0)
     docile (1.4.0)

--- a/gemfiles/ruby_2.7_sinatra_2.gemfile.lock
+++ b/gemfiles/ruby_2.7_sinatra_2.gemfile.lock
@@ -12,7 +12,7 @@ PATH
   remote: ..
   specs:
     datadog (2.3.0)
-      debase-ruby_core_source (= 3.3.1)
+      debase-ruby_core_source (= 3.3.5)
       libdatadog (~> 12.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
@@ -40,7 +40,7 @@ GEM
     crack (1.0.0)
       bigdecimal
       rexml
-    debase-ruby_core_source (3.3.1)
+    debase-ruby_core_source (3.3.5)
     debug_inspector (1.2.0)
     diff-lcs (1.5.1)
     docile (1.4.0)

--- a/gemfiles/ruby_2.7_sinatra_3.gemfile.lock
+++ b/gemfiles/ruby_2.7_sinatra_3.gemfile.lock
@@ -12,7 +12,7 @@ PATH
   remote: ..
   specs:
     datadog (2.3.0)
-      debase-ruby_core_source (= 3.3.1)
+      debase-ruby_core_source (= 3.3.5)
       libdatadog (~> 12.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
@@ -41,7 +41,7 @@ GEM
     crack (1.0.0)
       bigdecimal
       rexml
-    debase-ruby_core_source (3.3.1)
+    debase-ruby_core_source (3.3.5)
     debug_inspector (1.2.0)
     diff-lcs (1.5.1)
     docile (1.4.0)

--- a/gemfiles/ruby_2.7_stripe_10.gemfile.lock
+++ b/gemfiles/ruby_2.7_stripe_10.gemfile.lock
@@ -12,7 +12,7 @@ PATH
   remote: ..
   specs:
     datadog (2.3.0)
-      debase-ruby_core_source (= 3.3.1)
+      debase-ruby_core_source (= 3.3.5)
       libdatadog (~> 12.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
@@ -40,7 +40,7 @@ GEM
     crack (1.0.0)
       bigdecimal
       rexml
-    debase-ruby_core_source (3.3.1)
+    debase-ruby_core_source (3.3.5)
     debug_inspector (1.2.0)
     diff-lcs (1.5.1)
     docile (1.4.1)

--- a/gemfiles/ruby_2.7_stripe_11.gemfile.lock
+++ b/gemfiles/ruby_2.7_stripe_11.gemfile.lock
@@ -12,7 +12,7 @@ PATH
   remote: ..
   specs:
     datadog (2.3.0)
-      debase-ruby_core_source (= 3.3.1)
+      debase-ruby_core_source (= 3.3.5)
       libdatadog (~> 12.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
@@ -40,7 +40,7 @@ GEM
     crack (1.0.0)
       bigdecimal
       rexml
-    debase-ruby_core_source (3.3.1)
+    debase-ruby_core_source (3.3.5)
     debug_inspector (1.2.0)
     diff-lcs (1.5.1)
     docile (1.4.1)

--- a/gemfiles/ruby_2.7_stripe_12.gemfile.lock
+++ b/gemfiles/ruby_2.7_stripe_12.gemfile.lock
@@ -12,7 +12,7 @@ PATH
   remote: ..
   specs:
     datadog (2.3.0)
-      debase-ruby_core_source (= 3.3.1)
+      debase-ruby_core_source (= 3.3.5)
       libdatadog (~> 12.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
@@ -40,7 +40,7 @@ GEM
     crack (1.0.0)
       bigdecimal
       rexml
-    debase-ruby_core_source (3.3.1)
+    debase-ruby_core_source (3.3.5)
     debug_inspector (1.2.0)
     diff-lcs (1.5.1)
     docile (1.4.1)

--- a/gemfiles/ruby_2.7_stripe_7.gemfile.lock
+++ b/gemfiles/ruby_2.7_stripe_7.gemfile.lock
@@ -12,7 +12,7 @@ PATH
   remote: ..
   specs:
     datadog (2.3.0)
-      debase-ruby_core_source (= 3.3.1)
+      debase-ruby_core_source (= 3.3.5)
       libdatadog (~> 12.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
@@ -40,7 +40,7 @@ GEM
     crack (1.0.0)
       bigdecimal
       rexml
-    debase-ruby_core_source (3.3.1)
+    debase-ruby_core_source (3.3.5)
     debug_inspector (1.2.0)
     diff-lcs (1.5.1)
     docile (1.4.1)

--- a/gemfiles/ruby_2.7_stripe_8.gemfile.lock
+++ b/gemfiles/ruby_2.7_stripe_8.gemfile.lock
@@ -12,7 +12,7 @@ PATH
   remote: ..
   specs:
     datadog (2.3.0)
-      debase-ruby_core_source (= 3.3.1)
+      debase-ruby_core_source (= 3.3.5)
       libdatadog (~> 12.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
@@ -40,7 +40,7 @@ GEM
     crack (1.0.0)
       bigdecimal
       rexml
-    debase-ruby_core_source (3.3.1)
+    debase-ruby_core_source (3.3.5)
     debug_inspector (1.2.0)
     diff-lcs (1.5.1)
     docile (1.4.1)

--- a/gemfiles/ruby_2.7_stripe_9.gemfile.lock
+++ b/gemfiles/ruby_2.7_stripe_9.gemfile.lock
@@ -12,7 +12,7 @@ PATH
   remote: ..
   specs:
     datadog (2.3.0)
-      debase-ruby_core_source (= 3.3.1)
+      debase-ruby_core_source (= 3.3.5)
       libdatadog (~> 12.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
@@ -40,7 +40,7 @@ GEM
     crack (1.0.0)
       bigdecimal
       rexml
-    debase-ruby_core_source (3.3.1)
+    debase-ruby_core_source (3.3.5)
     debug_inspector (1.2.0)
     diff-lcs (1.5.1)
     docile (1.4.1)

--- a/gemfiles/ruby_2.7_stripe_latest.gemfile.lock
+++ b/gemfiles/ruby_2.7_stripe_latest.gemfile.lock
@@ -12,7 +12,7 @@ PATH
   remote: ..
   specs:
     datadog (2.3.0)
-      debase-ruby_core_source (= 3.3.1)
+      debase-ruby_core_source (= 3.3.5)
       libdatadog (~> 12.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
@@ -40,7 +40,7 @@ GEM
     crack (1.0.0)
       bigdecimal
       rexml
-    debase-ruby_core_source (3.3.1)
+    debase-ruby_core_source (3.3.5)
     debug_inspector (1.2.0)
     diff-lcs (1.5.1)
     docile (1.4.1)

--- a/gemfiles/ruby_2.7_stripe_min.gemfile.lock
+++ b/gemfiles/ruby_2.7_stripe_min.gemfile.lock
@@ -12,7 +12,7 @@ PATH
   remote: ..
   specs:
     datadog (2.3.0)
-      debase-ruby_core_source (= 3.3.1)
+      debase-ruby_core_source (= 3.3.5)
       libdatadog (~> 12.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
@@ -40,7 +40,7 @@ GEM
     crack (1.0.0)
       bigdecimal
       rexml
-    debase-ruby_core_source (3.3.1)
+    debase-ruby_core_source (3.3.5)
     debug_inspector (1.2.0)
     diff-lcs (1.5.1)
     docile (1.4.1)

--- a/gemfiles/ruby_3.0_activesupport.gemfile.lock
+++ b/gemfiles/ruby_3.0_activesupport.gemfile.lock
@@ -12,7 +12,7 @@ PATH
   remote: ..
   specs:
     datadog (2.3.0)
-      debase-ruby_core_source (= 3.3.1)
+      debase-ruby_core_source (= 3.3.5)
       libdatadog (~> 12.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
@@ -66,7 +66,7 @@ GEM
     crack (0.4.5)
       rexml
     crass (1.0.6)
-    debase-ruby_core_source (3.3.1)
+    debase-ruby_core_source (3.3.5)
     debug_inspector (1.1.0)
     diff-lcs (1.5.0)
     digest-crc (0.6.5)

--- a/gemfiles/ruby_3.0_aws.gemfile.lock
+++ b/gemfiles/ruby_3.0_aws.gemfile.lock
@@ -12,7 +12,7 @@ PATH
   remote: ..
   specs:
     datadog (2.3.0)
-      debase-ruby_core_source (= 3.3.1)
+      debase-ruby_core_source (= 3.3.5)
       libdatadog (~> 12.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
@@ -1458,7 +1458,7 @@ GEM
     concurrent-ruby (1.2.2)
     crack (0.4.5)
       rexml
-    debase-ruby_core_source (3.3.1)
+    debase-ruby_core_source (3.3.5)
     debug_inspector (1.1.0)
     diff-lcs (1.5.0)
     docile (1.4.0)

--- a/gemfiles/ruby_3.0_contrib.gemfile.lock
+++ b/gemfiles/ruby_3.0_contrib.gemfile.lock
@@ -12,7 +12,7 @@ PATH
   remote: ..
   specs:
     datadog (2.3.0)
-      debase-ruby_core_source (= 3.3.1)
+      debase-ruby_core_source (= 3.3.5)
       libdatadog (~> 12.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
@@ -44,7 +44,7 @@ GEM
     crack (0.4.5)
       rexml
     dalli (3.2.4)
-    debase-ruby_core_source (3.3.1)
+    debase-ruby_core_source (3.3.5)
     debug_inspector (1.1.0)
     diff-lcs (1.5.0)
     docile (1.4.0)

--- a/gemfiles/ruby_3.0_contrib_old.gemfile.lock
+++ b/gemfiles/ruby_3.0_contrib_old.gemfile.lock
@@ -12,7 +12,7 @@ PATH
   remote: ..
   specs:
     datadog (2.3.0)
-      debase-ruby_core_source (= 3.3.1)
+      debase-ruby_core_source (= 3.3.5)
       libdatadog (~> 12.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
@@ -42,7 +42,7 @@ GEM
       rexml
     daemons (1.4.1)
     dalli (2.7.11)
-    debase-ruby_core_source (3.3.1)
+    debase-ruby_core_source (3.3.5)
     debug_inspector (1.1.0)
     diff-lcs (1.5.0)
     docile (1.4.0)

--- a/gemfiles/ruby_3.0_core_old.gemfile.lock
+++ b/gemfiles/ruby_3.0_core_old.gemfile.lock
@@ -12,7 +12,7 @@ PATH
   remote: ..
   specs:
     datadog (2.3.0)
-      debase-ruby_core_source (= 3.3.1)
+      debase-ruby_core_source (= 3.3.5)
       libdatadog (~> 12.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
@@ -37,7 +37,7 @@ GEM
     concurrent-ruby (1.2.2)
     crack (0.4.5)
       rexml
-    debase-ruby_core_source (3.3.1)
+    debase-ruby_core_source (3.3.5)
     debug_inspector (1.1.0)
     diff-lcs (1.5.0)
     docile (1.4.0)

--- a/gemfiles/ruby_3.0_elasticsearch_7.gemfile.lock
+++ b/gemfiles/ruby_3.0_elasticsearch_7.gemfile.lock
@@ -12,7 +12,7 @@ PATH
   remote: ..
   specs:
     datadog (2.3.0)
-      debase-ruby_core_source (= 3.3.1)
+      debase-ruby_core_source (= 3.3.5)
       libdatadog (~> 12.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
@@ -38,7 +38,7 @@ GEM
     concurrent-ruby (1.2.2)
     crack (0.4.5)
       rexml
-    debase-ruby_core_source (3.3.1)
+    debase-ruby_core_source (3.3.5)
     debug_inspector (1.1.0)
     diff-lcs (1.5.0)
     docile (1.4.0)

--- a/gemfiles/ruby_3.0_elasticsearch_8.gemfile.lock
+++ b/gemfiles/ruby_3.0_elasticsearch_8.gemfile.lock
@@ -12,7 +12,7 @@ PATH
   remote: ..
   specs:
     datadog (2.3.0)
-      debase-ruby_core_source (= 3.3.1)
+      debase-ruby_core_source (= 3.3.5)
       libdatadog (~> 12.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
@@ -39,7 +39,7 @@ GEM
     concurrent-ruby (1.2.2)
     crack (0.4.5)
       rexml
-    debase-ruby_core_source (3.3.1)
+    debase-ruby_core_source (3.3.5)
     debug_inspector (1.1.0)
     diff-lcs (1.5.0)
     docile (1.4.0)

--- a/gemfiles/ruby_3.0_elasticsearch_latest.gemfile.lock
+++ b/gemfiles/ruby_3.0_elasticsearch_latest.gemfile.lock
@@ -12,7 +12,7 @@ PATH
   remote: ..
   specs:
     datadog (2.3.0)
-      debase-ruby_core_source (= 3.3.1)
+      debase-ruby_core_source (= 3.3.5)
       libdatadog (~> 12.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
@@ -40,7 +40,7 @@ GEM
     crack (1.0.0)
       bigdecimal
       rexml
-    debase-ruby_core_source (3.3.1)
+    debase-ruby_core_source (3.3.5)
     debug_inspector (1.2.0)
     diff-lcs (1.5.1)
     docile (1.4.1)

--- a/gemfiles/ruby_3.0_graphql_1.13.gemfile.lock
+++ b/gemfiles/ruby_3.0_graphql_1.13.gemfile.lock
@@ -12,7 +12,7 @@ PATH
   remote: ..
   specs:
     datadog (2.3.0)
-      debase-ruby_core_source (= 3.3.1)
+      debase-ruby_core_source (= 3.3.5)
       libdatadog (~> 12.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
@@ -101,7 +101,7 @@ GEM
       rexml
     crass (1.0.6)
     date (3.3.4)
-    debase-ruby_core_source (3.3.1)
+    debase-ruby_core_source (3.3.5)
     debug_inspector (1.2.0)
     diff-lcs (1.5.0)
     docile (1.4.0)

--- a/gemfiles/ruby_3.0_graphql_2.0.gemfile.lock
+++ b/gemfiles/ruby_3.0_graphql_2.0.gemfile.lock
@@ -12,7 +12,7 @@ PATH
   remote: ..
   specs:
     datadog (2.3.0)
-      debase-ruby_core_source (= 3.3.1)
+      debase-ruby_core_source (= 3.3.5)
       libdatadog (~> 12.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
@@ -101,7 +101,7 @@ GEM
       rexml
     crass (1.0.6)
     date (3.3.4)
-    debase-ruby_core_source (3.3.1)
+    debase-ruby_core_source (3.3.5)
     debug_inspector (1.2.0)
     diff-lcs (1.5.0)
     docile (1.4.0)

--- a/gemfiles/ruby_3.0_graphql_2.1.gemfile.lock
+++ b/gemfiles/ruby_3.0_graphql_2.1.gemfile.lock
@@ -12,7 +12,7 @@ PATH
   remote: ..
   specs:
     datadog (2.3.0)
-      debase-ruby_core_source (= 3.3.1)
+      debase-ruby_core_source (= 3.3.5)
       libdatadog (~> 12.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
@@ -101,7 +101,7 @@ GEM
       rexml
     crass (1.0.6)
     date (3.3.4)
-    debase-ruby_core_source (3.3.1)
+    debase-ruby_core_source (3.3.5)
     debug_inspector (1.2.0)
     diff-lcs (1.5.0)
     docile (1.4.0)

--- a/gemfiles/ruby_3.0_graphql_2.2.gemfile.lock
+++ b/gemfiles/ruby_3.0_graphql_2.2.gemfile.lock
@@ -12,7 +12,7 @@ PATH
   remote: ..
   specs:
     datadog (2.3.0)
-      debase-ruby_core_source (= 3.3.1)
+      debase-ruby_core_source (= 3.3.5)
       libdatadog (~> 12.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
@@ -101,7 +101,7 @@ GEM
       rexml
     crass (1.0.6)
     date (3.3.4)
-    debase-ruby_core_source (3.3.1)
+    debase-ruby_core_source (3.3.5)
     debug_inspector (1.2.0)
     diff-lcs (1.5.0)
     docile (1.4.0)

--- a/gemfiles/ruby_3.0_graphql_2.3.gemfile.lock
+++ b/gemfiles/ruby_3.0_graphql_2.3.gemfile.lock
@@ -12,7 +12,7 @@ PATH
   remote: ..
   specs:
     datadog (2.3.0)
-      debase-ruby_core_source (= 3.3.1)
+      debase-ruby_core_source (= 3.3.5)
       libdatadog (~> 12.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
@@ -103,7 +103,7 @@ GEM
       rexml
     crass (1.0.6)
     date (3.3.4)
-    debase-ruby_core_source (3.3.1)
+    debase-ruby_core_source (3.3.5)
     debug_inspector (1.2.0)
     diff-lcs (1.5.1)
     docile (1.4.0)

--- a/gemfiles/ruby_3.0_http.gemfile.lock
+++ b/gemfiles/ruby_3.0_http.gemfile.lock
@@ -12,7 +12,7 @@ PATH
   remote: ..
   specs:
     datadog (2.3.0)
-      debase-ruby_core_source (= 3.3.1)
+      debase-ruby_core_source (= 3.3.5)
       libdatadog (~> 12.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
@@ -37,7 +37,7 @@ GEM
     concurrent-ruby (1.2.2)
     crack (0.4.5)
       rexml
-    debase-ruby_core_source (3.3.1)
+    debase-ruby_core_source (3.3.5)
     debug_inspector (1.1.0)
     diff-lcs (1.5.0)
     docile (1.4.0)

--- a/gemfiles/ruby_3.0_opensearch_2.gemfile.lock
+++ b/gemfiles/ruby_3.0_opensearch_2.gemfile.lock
@@ -12,7 +12,7 @@ PATH
   remote: ..
   specs:
     datadog (2.3.0)
-      debase-ruby_core_source (= 3.3.1)
+      debase-ruby_core_source (= 3.3.5)
       libdatadog (~> 12.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
@@ -39,7 +39,7 @@ GEM
     concurrent-ruby (1.2.2)
     crack (0.4.5)
       rexml
-    debase-ruby_core_source (3.3.1)
+    debase-ruby_core_source (3.3.5)
     debug_inspector (1.1.0)
     diff-lcs (1.5.0)
     docile (1.4.0)

--- a/gemfiles/ruby_3.0_opensearch_3.gemfile.lock
+++ b/gemfiles/ruby_3.0_opensearch_3.gemfile.lock
@@ -12,7 +12,7 @@ PATH
   remote: ..
   specs:
     datadog (2.3.0)
-      debase-ruby_core_source (= 3.3.1)
+      debase-ruby_core_source (= 3.3.5)
       libdatadog (~> 12.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
@@ -39,7 +39,7 @@ GEM
     concurrent-ruby (1.2.2)
     crack (0.4.5)
       rexml
-    debase-ruby_core_source (3.3.1)
+    debase-ruby_core_source (3.3.5)
     debug_inspector (1.1.0)
     diff-lcs (1.5.0)
     docile (1.4.0)

--- a/gemfiles/ruby_3.0_opensearch_latest.gemfile.lock
+++ b/gemfiles/ruby_3.0_opensearch_latest.gemfile.lock
@@ -12,7 +12,7 @@ PATH
   remote: ..
   specs:
     datadog (2.3.0)
-      debase-ruby_core_source (= 3.3.1)
+      debase-ruby_core_source (= 3.3.5)
       libdatadog (~> 12.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
@@ -40,7 +40,7 @@ GEM
     crack (1.0.0)
       bigdecimal
       rexml
-    debase-ruby_core_source (3.3.1)
+    debase-ruby_core_source (3.3.5)
     debug_inspector (1.2.0)
     diff-lcs (1.5.1)
     docile (1.4.1)

--- a/gemfiles/ruby_3.0_opentelemetry.gemfile.lock
+++ b/gemfiles/ruby_3.0_opentelemetry.gemfile.lock
@@ -12,7 +12,7 @@ PATH
   remote: ..
   specs:
     datadog (2.3.0)
-      debase-ruby_core_source (= 3.3.1)
+      debase-ruby_core_source (= 3.3.5)
       libdatadog (~> 12.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
@@ -37,7 +37,7 @@ GEM
     concurrent-ruby (1.2.2)
     crack (0.4.5)
       rexml
-    debase-ruby_core_source (3.3.1)
+    debase-ruby_core_source (3.3.5)
     debug_inspector (1.1.0)
     diff-lcs (1.5.0)
     docile (1.4.0)

--- a/gemfiles/ruby_3.0_rack_1.gemfile.lock
+++ b/gemfiles/ruby_3.0_rack_1.gemfile.lock
@@ -12,7 +12,7 @@ PATH
   remote: ..
   specs:
     datadog (2.3.0)
-      debase-ruby_core_source (= 3.3.1)
+      debase-ruby_core_source (= 3.3.5)
       libdatadog (~> 12.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
@@ -37,7 +37,7 @@ GEM
     concurrent-ruby (1.2.2)
     crack (0.4.5)
       rexml
-    debase-ruby_core_source (3.3.1)
+    debase-ruby_core_source (3.3.5)
     debug_inspector (1.1.0)
     diff-lcs (1.5.0)
     docile (1.4.0)

--- a/gemfiles/ruby_3.0_rack_2.gemfile.lock
+++ b/gemfiles/ruby_3.0_rack_2.gemfile.lock
@@ -12,7 +12,7 @@ PATH
   remote: ..
   specs:
     datadog (2.3.0)
-      debase-ruby_core_source (= 3.3.1)
+      debase-ruby_core_source (= 3.3.5)
       libdatadog (~> 12.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
@@ -37,7 +37,7 @@ GEM
     concurrent-ruby (1.2.2)
     crack (0.4.5)
       rexml
-    debase-ruby_core_source (3.3.1)
+    debase-ruby_core_source (3.3.5)
     debug_inspector (1.1.0)
     diff-lcs (1.5.0)
     docile (1.4.0)

--- a/gemfiles/ruby_3.0_rack_3.gemfile.lock
+++ b/gemfiles/ruby_3.0_rack_3.gemfile.lock
@@ -12,7 +12,7 @@ PATH
   remote: ..
   specs:
     datadog (2.3.0)
-      debase-ruby_core_source (= 3.3.1)
+      debase-ruby_core_source (= 3.3.5)
       libdatadog (~> 12.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
@@ -37,7 +37,7 @@ GEM
     concurrent-ruby (1.2.2)
     crack (0.4.5)
       rexml
-    debase-ruby_core_source (3.3.1)
+    debase-ruby_core_source (3.3.5)
     debug_inspector (1.1.0)
     diff-lcs (1.5.0)
     docile (1.4.0)

--- a/gemfiles/ruby_3.0_rack_latest.gemfile.lock
+++ b/gemfiles/ruby_3.0_rack_latest.gemfile.lock
@@ -12,7 +12,7 @@ PATH
   remote: ..
   specs:
     datadog (2.3.0)
-      debase-ruby_core_source (= 3.3.1)
+      debase-ruby_core_source (= 3.3.5)
       libdatadog (~> 12.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
@@ -40,7 +40,7 @@ GEM
     crack (1.0.0)
       bigdecimal
       rexml
-    debase-ruby_core_source (3.3.1)
+    debase-ruby_core_source (3.3.5)
     debug_inspector (1.2.0)
     diff-lcs (1.5.1)
     docile (1.4.1)

--- a/gemfiles/ruby_3.0_rails61_mysql2.gemfile.lock
+++ b/gemfiles/ruby_3.0_rails61_mysql2.gemfile.lock
@@ -12,7 +12,7 @@ PATH
   remote: ..
   specs:
     datadog (2.3.0)
-      debase-ruby_core_source (= 3.3.1)
+      debase-ruby_core_source (= 3.3.5)
       libdatadog (~> 12.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
@@ -99,7 +99,7 @@ GEM
       rexml
     crass (1.0.6)
     date (3.3.3)
-    debase-ruby_core_source (3.3.1)
+    debase-ruby_core_source (3.3.5)
     debug_inspector (1.1.0)
     diff-lcs (1.5.0)
     docile (1.4.0)

--- a/gemfiles/ruby_3.0_rails61_postgres.gemfile.lock
+++ b/gemfiles/ruby_3.0_rails61_postgres.gemfile.lock
@@ -12,7 +12,7 @@ PATH
   remote: ..
   specs:
     datadog (2.3.0)
-      debase-ruby_core_source (= 3.3.1)
+      debase-ruby_core_source (= 3.3.5)
       libdatadog (~> 12.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
@@ -99,7 +99,7 @@ GEM
       rexml
     crass (1.0.6)
     date (3.3.3)
-    debase-ruby_core_source (3.3.1)
+    debase-ruby_core_source (3.3.5)
     debug_inspector (1.1.0)
     diff-lcs (1.5.0)
     docile (1.4.0)

--- a/gemfiles/ruby_3.0_rails61_postgres_redis.gemfile.lock
+++ b/gemfiles/ruby_3.0_rails61_postgres_redis.gemfile.lock
@@ -12,7 +12,7 @@ PATH
   remote: ..
   specs:
     datadog (2.3.0)
-      debase-ruby_core_source (= 3.3.1)
+      debase-ruby_core_source (= 3.3.5)
       libdatadog (~> 12.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
@@ -99,7 +99,7 @@ GEM
       rexml
     crass (1.0.6)
     date (3.3.3)
-    debase-ruby_core_source (3.3.1)
+    debase-ruby_core_source (3.3.5)
     debug_inspector (1.1.0)
     diff-lcs (1.5.0)
     docile (1.4.0)

--- a/gemfiles/ruby_3.0_rails61_postgres_sidekiq.gemfile.lock
+++ b/gemfiles/ruby_3.0_rails61_postgres_sidekiq.gemfile.lock
@@ -12,7 +12,7 @@ PATH
   remote: ..
   specs:
     datadog (2.3.0)
-      debase-ruby_core_source (= 3.3.1)
+      debase-ruby_core_source (= 3.3.5)
       libdatadog (~> 12.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
@@ -100,7 +100,7 @@ GEM
       rexml
     crass (1.0.6)
     date (3.3.3)
-    debase-ruby_core_source (3.3.1)
+    debase-ruby_core_source (3.3.5)
     debug_inspector (1.1.0)
     diff-lcs (1.5.0)
     docile (1.4.0)

--- a/gemfiles/ruby_3.0_rails61_semantic_logger.gemfile.lock
+++ b/gemfiles/ruby_3.0_rails61_semantic_logger.gemfile.lock
@@ -12,7 +12,7 @@ PATH
   remote: ..
   specs:
     datadog (2.3.0)
-      debase-ruby_core_source (= 3.3.1)
+      debase-ruby_core_source (= 3.3.5)
       libdatadog (~> 12.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
@@ -99,7 +99,7 @@ GEM
       rexml
     crass (1.0.6)
     date (3.3.3)
-    debase-ruby_core_source (3.3.1)
+    debase-ruby_core_source (3.3.5)
     debug_inspector (1.1.0)
     diff-lcs (1.5.0)
     docile (1.4.0)

--- a/gemfiles/ruby_3.0_rails61_trilogy.gemfile.lock
+++ b/gemfiles/ruby_3.0_rails61_trilogy.gemfile.lock
@@ -12,7 +12,7 @@ PATH
   remote: ..
   specs:
     datadog (2.3.0)
-      debase-ruby_core_source (= 3.3.1)
+      debase-ruby_core_source (= 3.3.5)
       libdatadog (~> 12.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
@@ -103,7 +103,7 @@ GEM
       rexml
     crass (1.0.6)
     date (3.3.4)
-    debase-ruby_core_source (3.3.1)
+    debase-ruby_core_source (3.3.5)
     debug_inspector (1.1.0)
     diff-lcs (1.5.0)
     docile (1.4.0)

--- a/gemfiles/ruby_3.0_rails7.gemfile.lock
+++ b/gemfiles/ruby_3.0_rails7.gemfile.lock
@@ -12,7 +12,7 @@ PATH
   remote: ..
   specs:
     datadog (2.3.0)
-      debase-ruby_core_source (= 3.3.1)
+      debase-ruby_core_source (= 3.3.5)
       libdatadog (~> 12.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
@@ -108,7 +108,7 @@ GEM
       rexml
     crass (1.0.6)
     date (3.3.4)
-    debase-ruby_core_source (3.3.1)
+    debase-ruby_core_source (3.3.5)
     debug_inspector (1.2.0)
     diff-lcs (1.5.1)
     docile (1.4.1)

--- a/gemfiles/ruby_3.0_rails71.gemfile.lock
+++ b/gemfiles/ruby_3.0_rails71.gemfile.lock
@@ -12,7 +12,7 @@ PATH
   remote: ..
   specs:
     datadog (2.3.0)
-      debase-ruby_core_source (= 3.3.1)
+      debase-ruby_core_source (= 3.3.5)
       libdatadog (~> 12.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
@@ -119,7 +119,7 @@ GEM
       rexml
     crass (1.0.6)
     date (3.3.4)
-    debase-ruby_core_source (3.3.1)
+    debase-ruby_core_source (3.3.5)
     debug_inspector (1.2.0)
     diff-lcs (1.5.1)
     docile (1.4.1)

--- a/gemfiles/ruby_3.0_redis_3.gemfile.lock
+++ b/gemfiles/ruby_3.0_redis_3.gemfile.lock
@@ -12,7 +12,7 @@ PATH
   remote: ..
   specs:
     datadog (2.3.0)
-      debase-ruby_core_source (= 3.3.1)
+      debase-ruby_core_source (= 3.3.5)
       libdatadog (~> 12.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
@@ -37,7 +37,7 @@ GEM
     concurrent-ruby (1.2.2)
     crack (0.4.5)
       rexml
-    debase-ruby_core_source (3.3.1)
+    debase-ruby_core_source (3.3.5)
     debug_inspector (1.1.0)
     diff-lcs (1.5.0)
     docile (1.4.0)

--- a/gemfiles/ruby_3.0_redis_4.gemfile.lock
+++ b/gemfiles/ruby_3.0_redis_4.gemfile.lock
@@ -12,7 +12,7 @@ PATH
   remote: ..
   specs:
     datadog (2.3.0)
-      debase-ruby_core_source (= 3.3.1)
+      debase-ruby_core_source (= 3.3.5)
       libdatadog (~> 12.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
@@ -37,7 +37,7 @@ GEM
     concurrent-ruby (1.2.2)
     crack (0.4.5)
       rexml
-    debase-ruby_core_source (3.3.1)
+    debase-ruby_core_source (3.3.5)
     debug_inspector (1.1.0)
     diff-lcs (1.5.0)
     docile (1.4.0)

--- a/gemfiles/ruby_3.0_redis_5.gemfile.lock
+++ b/gemfiles/ruby_3.0_redis_5.gemfile.lock
@@ -12,7 +12,7 @@ PATH
   remote: ..
   specs:
     datadog (2.3.0)
-      debase-ruby_core_source (= 3.3.1)
+      debase-ruby_core_source (= 3.3.5)
       libdatadog (~> 12.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
@@ -38,7 +38,7 @@ GEM
     connection_pool (2.3.0)
     crack (0.4.5)
       rexml
-    debase-ruby_core_source (3.3.1)
+    debase-ruby_core_source (3.3.5)
     debug_inspector (1.1.0)
     diff-lcs (1.5.0)
     docile (1.4.0)

--- a/gemfiles/ruby_3.0_relational_db.gemfile.lock
+++ b/gemfiles/ruby_3.0_relational_db.gemfile.lock
@@ -12,7 +12,7 @@ PATH
   remote: ..
   specs:
     datadog (2.3.0)
-      debase-ruby_core_source (= 3.3.1)
+      debase-ruby_core_source (= 3.3.5)
       libdatadog (~> 12.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
@@ -48,7 +48,7 @@ GEM
     concurrent-ruby (1.2.2)
     crack (0.4.5)
       rexml
-    debase-ruby_core_source (3.3.1)
+    debase-ruby_core_source (3.3.5)
     debug_inspector (1.1.0)
     delayed_job (4.1.11)
       activesupport (>= 3.0, < 8.0)

--- a/gemfiles/ruby_3.0_resque2_redis3.gemfile.lock
+++ b/gemfiles/ruby_3.0_resque2_redis3.gemfile.lock
@@ -12,7 +12,7 @@ PATH
   remote: ..
   specs:
     datadog (2.3.0)
-      debase-ruby_core_source (= 3.3.1)
+      debase-ruby_core_source (= 3.3.5)
       libdatadog (~> 12.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
@@ -37,7 +37,7 @@ GEM
     concurrent-ruby (1.2.2)
     crack (0.4.5)
       rexml
-    debase-ruby_core_source (3.3.1)
+    debase-ruby_core_source (3.3.5)
     debug_inspector (1.1.0)
     diff-lcs (1.5.0)
     docile (1.4.0)

--- a/gemfiles/ruby_3.0_resque2_redis4.gemfile.lock
+++ b/gemfiles/ruby_3.0_resque2_redis4.gemfile.lock
@@ -12,7 +12,7 @@ PATH
   remote: ..
   specs:
     datadog (2.3.0)
-      debase-ruby_core_source (= 3.3.1)
+      debase-ruby_core_source (= 3.3.5)
       libdatadog (~> 12.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
@@ -38,7 +38,7 @@ GEM
     connection_pool (2.3.0)
     crack (0.4.5)
       rexml
-    debase-ruby_core_source (3.3.1)
+    debase-ruby_core_source (3.3.5)
     debug_inspector (1.1.0)
     diff-lcs (1.5.0)
     docile (1.4.0)

--- a/gemfiles/ruby_3.0_sinatra_2.gemfile.lock
+++ b/gemfiles/ruby_3.0_sinatra_2.gemfile.lock
@@ -12,7 +12,7 @@ PATH
   remote: ..
   specs:
     datadog (2.3.0)
-      debase-ruby_core_source (= 3.3.1)
+      debase-ruby_core_source (= 3.3.5)
       libdatadog (~> 12.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
@@ -40,7 +40,7 @@ GEM
     crack (1.0.0)
       bigdecimal
       rexml
-    debase-ruby_core_source (3.3.1)
+    debase-ruby_core_source (3.3.5)
     debug_inspector (1.2.0)
     diff-lcs (1.5.1)
     docile (1.4.0)

--- a/gemfiles/ruby_3.0_sinatra_3.gemfile.lock
+++ b/gemfiles/ruby_3.0_sinatra_3.gemfile.lock
@@ -12,7 +12,7 @@ PATH
   remote: ..
   specs:
     datadog (2.3.0)
-      debase-ruby_core_source (= 3.3.1)
+      debase-ruby_core_source (= 3.3.5)
       libdatadog (~> 12.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
@@ -41,7 +41,7 @@ GEM
     crack (1.0.0)
       bigdecimal
       rexml
-    debase-ruby_core_source (3.3.1)
+    debase-ruby_core_source (3.3.5)
     debug_inspector (1.2.0)
     diff-lcs (1.5.1)
     docile (1.4.0)

--- a/gemfiles/ruby_3.0_sinatra_4.gemfile.lock
+++ b/gemfiles/ruby_3.0_sinatra_4.gemfile.lock
@@ -12,7 +12,7 @@ PATH
   remote: ..
   specs:
     datadog (2.3.0)
-      debase-ruby_core_source (= 3.3.1)
+      debase-ruby_core_source (= 3.3.5)
       libdatadog (~> 12.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
@@ -41,7 +41,7 @@ GEM
     crack (1.0.0)
       bigdecimal
       rexml
-    debase-ruby_core_source (3.3.1)
+    debase-ruby_core_source (3.3.5)
     debug_inspector (1.2.0)
     diff-lcs (1.5.1)
     docile (1.4.0)

--- a/gemfiles/ruby_3.0_stripe_10.gemfile.lock
+++ b/gemfiles/ruby_3.0_stripe_10.gemfile.lock
@@ -12,7 +12,7 @@ PATH
   remote: ..
   specs:
     datadog (2.3.0)
-      debase-ruby_core_source (= 3.3.1)
+      debase-ruby_core_source (= 3.3.5)
       libdatadog (~> 12.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
@@ -40,7 +40,7 @@ GEM
     crack (1.0.0)
       bigdecimal
       rexml
-    debase-ruby_core_source (3.3.1)
+    debase-ruby_core_source (3.3.5)
     debug_inspector (1.2.0)
     diff-lcs (1.5.1)
     docile (1.4.1)

--- a/gemfiles/ruby_3.0_stripe_11.gemfile.lock
+++ b/gemfiles/ruby_3.0_stripe_11.gemfile.lock
@@ -12,7 +12,7 @@ PATH
   remote: ..
   specs:
     datadog (2.3.0)
-      debase-ruby_core_source (= 3.3.1)
+      debase-ruby_core_source (= 3.3.5)
       libdatadog (~> 12.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
@@ -40,7 +40,7 @@ GEM
     crack (1.0.0)
       bigdecimal
       rexml
-    debase-ruby_core_source (3.3.1)
+    debase-ruby_core_source (3.3.5)
     debug_inspector (1.2.0)
     diff-lcs (1.5.1)
     docile (1.4.1)

--- a/gemfiles/ruby_3.0_stripe_12.gemfile.lock
+++ b/gemfiles/ruby_3.0_stripe_12.gemfile.lock
@@ -12,7 +12,7 @@ PATH
   remote: ..
   specs:
     datadog (2.3.0)
-      debase-ruby_core_source (= 3.3.1)
+      debase-ruby_core_source (= 3.3.5)
       libdatadog (~> 12.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
@@ -40,7 +40,7 @@ GEM
     crack (1.0.0)
       bigdecimal
       rexml
-    debase-ruby_core_source (3.3.1)
+    debase-ruby_core_source (3.3.5)
     debug_inspector (1.2.0)
     diff-lcs (1.5.1)
     docile (1.4.1)

--- a/gemfiles/ruby_3.0_stripe_7.gemfile.lock
+++ b/gemfiles/ruby_3.0_stripe_7.gemfile.lock
@@ -12,7 +12,7 @@ PATH
   remote: ..
   specs:
     datadog (2.3.0)
-      debase-ruby_core_source (= 3.3.1)
+      debase-ruby_core_source (= 3.3.5)
       libdatadog (~> 12.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
@@ -40,7 +40,7 @@ GEM
     crack (1.0.0)
       bigdecimal
       rexml
-    debase-ruby_core_source (3.3.1)
+    debase-ruby_core_source (3.3.5)
     debug_inspector (1.2.0)
     diff-lcs (1.5.1)
     docile (1.4.1)

--- a/gemfiles/ruby_3.0_stripe_8.gemfile.lock
+++ b/gemfiles/ruby_3.0_stripe_8.gemfile.lock
@@ -12,7 +12,7 @@ PATH
   remote: ..
   specs:
     datadog (2.3.0)
-      debase-ruby_core_source (= 3.3.1)
+      debase-ruby_core_source (= 3.3.5)
       libdatadog (~> 12.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
@@ -40,7 +40,7 @@ GEM
     crack (1.0.0)
       bigdecimal
       rexml
-    debase-ruby_core_source (3.3.1)
+    debase-ruby_core_source (3.3.5)
     debug_inspector (1.2.0)
     diff-lcs (1.5.1)
     docile (1.4.1)

--- a/gemfiles/ruby_3.0_stripe_9.gemfile.lock
+++ b/gemfiles/ruby_3.0_stripe_9.gemfile.lock
@@ -12,7 +12,7 @@ PATH
   remote: ..
   specs:
     datadog (2.3.0)
-      debase-ruby_core_source (= 3.3.1)
+      debase-ruby_core_source (= 3.3.5)
       libdatadog (~> 12.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
@@ -40,7 +40,7 @@ GEM
     crack (1.0.0)
       bigdecimal
       rexml
-    debase-ruby_core_source (3.3.1)
+    debase-ruby_core_source (3.3.5)
     debug_inspector (1.2.0)
     diff-lcs (1.5.1)
     docile (1.4.1)

--- a/gemfiles/ruby_3.0_stripe_latest.gemfile.lock
+++ b/gemfiles/ruby_3.0_stripe_latest.gemfile.lock
@@ -12,7 +12,7 @@ PATH
   remote: ..
   specs:
     datadog (2.3.0)
-      debase-ruby_core_source (= 3.3.1)
+      debase-ruby_core_source (= 3.3.5)
       libdatadog (~> 12.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
@@ -40,7 +40,7 @@ GEM
     crack (1.0.0)
       bigdecimal
       rexml
-    debase-ruby_core_source (3.3.1)
+    debase-ruby_core_source (3.3.5)
     debug_inspector (1.2.0)
     diff-lcs (1.5.1)
     docile (1.4.1)

--- a/gemfiles/ruby_3.0_stripe_min.gemfile.lock
+++ b/gemfiles/ruby_3.0_stripe_min.gemfile.lock
@@ -12,7 +12,7 @@ PATH
   remote: ..
   specs:
     datadog (2.3.0)
-      debase-ruby_core_source (= 3.3.1)
+      debase-ruby_core_source (= 3.3.5)
       libdatadog (~> 12.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
@@ -40,7 +40,7 @@ GEM
     crack (1.0.0)
       bigdecimal
       rexml
-    debase-ruby_core_source (3.3.1)
+    debase-ruby_core_source (3.3.5)
     debug_inspector (1.2.0)
     diff-lcs (1.5.1)
     docile (1.4.1)

--- a/gemfiles/ruby_3.1_activesupport.gemfile.lock
+++ b/gemfiles/ruby_3.1_activesupport.gemfile.lock
@@ -12,7 +12,7 @@ PATH
   remote: ..
   specs:
     datadog (2.3.0)
-      debase-ruby_core_source (= 3.3.1)
+      debase-ruby_core_source (= 3.3.5)
       libdatadog (~> 12.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
@@ -66,7 +66,7 @@ GEM
     crack (0.4.5)
       rexml
     crass (1.0.6)
-    debase-ruby_core_source (3.3.1)
+    debase-ruby_core_source (3.3.5)
     debug_inspector (1.1.0)
     diff-lcs (1.5.0)
     digest-crc (0.6.5)

--- a/gemfiles/ruby_3.1_aws.gemfile.lock
+++ b/gemfiles/ruby_3.1_aws.gemfile.lock
@@ -12,7 +12,7 @@ PATH
   remote: ..
   specs:
     datadog (2.3.0)
-      debase-ruby_core_source (= 3.3.1)
+      debase-ruby_core_source (= 3.3.5)
       libdatadog (~> 12.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
@@ -1458,7 +1458,7 @@ GEM
     concurrent-ruby (1.2.2)
     crack (0.4.5)
       rexml
-    debase-ruby_core_source (3.3.1)
+    debase-ruby_core_source (3.3.5)
     debug_inspector (1.1.0)
     diff-lcs (1.5.0)
     docile (1.4.0)

--- a/gemfiles/ruby_3.1_contrib.gemfile.lock
+++ b/gemfiles/ruby_3.1_contrib.gemfile.lock
@@ -12,7 +12,7 @@ PATH
   remote: ..
   specs:
     datadog (2.3.0)
-      debase-ruby_core_source (= 3.3.1)
+      debase-ruby_core_source (= 3.3.5)
       libdatadog (~> 12.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
@@ -44,7 +44,7 @@ GEM
     crack (0.4.5)
       rexml
     dalli (3.2.4)
-    debase-ruby_core_source (3.3.1)
+    debase-ruby_core_source (3.3.5)
     debug_inspector (1.1.0)
     diff-lcs (1.5.0)
     docile (1.4.0)

--- a/gemfiles/ruby_3.1_contrib_old.gemfile.lock
+++ b/gemfiles/ruby_3.1_contrib_old.gemfile.lock
@@ -12,7 +12,7 @@ PATH
   remote: ..
   specs:
     datadog (2.3.0)
-      debase-ruby_core_source (= 3.3.1)
+      debase-ruby_core_source (= 3.3.5)
       libdatadog (~> 12.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
@@ -42,7 +42,7 @@ GEM
       rexml
     daemons (1.4.1)
     dalli (2.7.11)
-    debase-ruby_core_source (3.3.1)
+    debase-ruby_core_source (3.3.5)
     debug_inspector (1.1.0)
     diff-lcs (1.5.0)
     docile (1.4.0)

--- a/gemfiles/ruby_3.1_core_old.gemfile.lock
+++ b/gemfiles/ruby_3.1_core_old.gemfile.lock
@@ -12,7 +12,7 @@ PATH
   remote: ..
   specs:
     datadog (2.3.0)
-      debase-ruby_core_source (= 3.3.1)
+      debase-ruby_core_source (= 3.3.5)
       libdatadog (~> 12.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
@@ -37,7 +37,7 @@ GEM
     concurrent-ruby (1.2.2)
     crack (0.4.5)
       rexml
-    debase-ruby_core_source (3.3.1)
+    debase-ruby_core_source (3.3.5)
     debug_inspector (1.1.0)
     diff-lcs (1.5.0)
     docile (1.4.0)

--- a/gemfiles/ruby_3.1_elasticsearch_7.gemfile.lock
+++ b/gemfiles/ruby_3.1_elasticsearch_7.gemfile.lock
@@ -12,7 +12,7 @@ PATH
   remote: ..
   specs:
     datadog (2.3.0)
-      debase-ruby_core_source (= 3.3.1)
+      debase-ruby_core_source (= 3.3.5)
       libdatadog (~> 12.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
@@ -38,7 +38,7 @@ GEM
     concurrent-ruby (1.2.2)
     crack (0.4.5)
       rexml
-    debase-ruby_core_source (3.3.1)
+    debase-ruby_core_source (3.3.5)
     debug_inspector (1.1.0)
     diff-lcs (1.5.0)
     docile (1.4.0)

--- a/gemfiles/ruby_3.1_elasticsearch_8.gemfile.lock
+++ b/gemfiles/ruby_3.1_elasticsearch_8.gemfile.lock
@@ -12,7 +12,7 @@ PATH
   remote: ..
   specs:
     datadog (2.3.0)
-      debase-ruby_core_source (= 3.3.1)
+      debase-ruby_core_source (= 3.3.5)
       libdatadog (~> 12.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
@@ -39,7 +39,7 @@ GEM
     concurrent-ruby (1.2.2)
     crack (0.4.5)
       rexml
-    debase-ruby_core_source (3.3.1)
+    debase-ruby_core_source (3.3.5)
     debug_inspector (1.1.0)
     diff-lcs (1.5.0)
     docile (1.4.0)

--- a/gemfiles/ruby_3.1_elasticsearch_latest.gemfile.lock
+++ b/gemfiles/ruby_3.1_elasticsearch_latest.gemfile.lock
@@ -12,7 +12,7 @@ PATH
   remote: ..
   specs:
     datadog (2.3.0)
-      debase-ruby_core_source (= 3.3.1)
+      debase-ruby_core_source (= 3.3.5)
       libdatadog (~> 12.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
@@ -40,7 +40,7 @@ GEM
     crack (1.0.0)
       bigdecimal
       rexml
-    debase-ruby_core_source (3.3.1)
+    debase-ruby_core_source (3.3.5)
     debug_inspector (1.2.0)
     diff-lcs (1.5.1)
     docile (1.4.1)

--- a/gemfiles/ruby_3.1_graphql_1.13.gemfile.lock
+++ b/gemfiles/ruby_3.1_graphql_1.13.gemfile.lock
@@ -12,7 +12,7 @@ PATH
   remote: ..
   specs:
     datadog (2.3.0)
-      debase-ruby_core_source (= 3.3.1)
+      debase-ruby_core_source (= 3.3.5)
       libdatadog (~> 12.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
@@ -101,7 +101,7 @@ GEM
       rexml
     crass (1.0.6)
     date (3.3.4)
-    debase-ruby_core_source (3.3.1)
+    debase-ruby_core_source (3.3.5)
     debug_inspector (1.2.0)
     diff-lcs (1.5.0)
     docile (1.4.0)

--- a/gemfiles/ruby_3.1_graphql_2.0.gemfile.lock
+++ b/gemfiles/ruby_3.1_graphql_2.0.gemfile.lock
@@ -12,7 +12,7 @@ PATH
   remote: ..
   specs:
     datadog (2.3.0)
-      debase-ruby_core_source (= 3.3.1)
+      debase-ruby_core_source (= 3.3.5)
       libdatadog (~> 12.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
@@ -101,7 +101,7 @@ GEM
       rexml
     crass (1.0.6)
     date (3.3.4)
-    debase-ruby_core_source (3.3.1)
+    debase-ruby_core_source (3.3.5)
     debug_inspector (1.2.0)
     diff-lcs (1.5.0)
     docile (1.4.0)

--- a/gemfiles/ruby_3.1_graphql_2.1.gemfile.lock
+++ b/gemfiles/ruby_3.1_graphql_2.1.gemfile.lock
@@ -12,7 +12,7 @@ PATH
   remote: ..
   specs:
     datadog (2.3.0)
-      debase-ruby_core_source (= 3.3.1)
+      debase-ruby_core_source (= 3.3.5)
       libdatadog (~> 12.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
@@ -101,7 +101,7 @@ GEM
       rexml
     crass (1.0.6)
     date (3.3.4)
-    debase-ruby_core_source (3.3.1)
+    debase-ruby_core_source (3.3.5)
     debug_inspector (1.2.0)
     diff-lcs (1.5.0)
     docile (1.4.0)

--- a/gemfiles/ruby_3.1_graphql_2.2.gemfile.lock
+++ b/gemfiles/ruby_3.1_graphql_2.2.gemfile.lock
@@ -12,7 +12,7 @@ PATH
   remote: ..
   specs:
     datadog (2.3.0)
-      debase-ruby_core_source (= 3.3.1)
+      debase-ruby_core_source (= 3.3.5)
       libdatadog (~> 12.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
@@ -101,7 +101,7 @@ GEM
       rexml
     crass (1.0.6)
     date (3.3.4)
-    debase-ruby_core_source (3.3.1)
+    debase-ruby_core_source (3.3.5)
     debug_inspector (1.2.0)
     diff-lcs (1.5.0)
     docile (1.4.0)

--- a/gemfiles/ruby_3.1_graphql_2.3.gemfile.lock
+++ b/gemfiles/ruby_3.1_graphql_2.3.gemfile.lock
@@ -12,7 +12,7 @@ PATH
   remote: ..
   specs:
     datadog (2.3.0)
-      debase-ruby_core_source (= 3.3.1)
+      debase-ruby_core_source (= 3.3.5)
       libdatadog (~> 12.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
@@ -103,7 +103,7 @@ GEM
       rexml
     crass (1.0.6)
     date (3.3.4)
-    debase-ruby_core_source (3.3.1)
+    debase-ruby_core_source (3.3.5)
     debug_inspector (1.2.0)
     diff-lcs (1.5.1)
     docile (1.4.0)

--- a/gemfiles/ruby_3.1_http.gemfile.lock
+++ b/gemfiles/ruby_3.1_http.gemfile.lock
@@ -12,7 +12,7 @@ PATH
   remote: ..
   specs:
     datadog (2.3.0)
-      debase-ruby_core_source (= 3.3.1)
+      debase-ruby_core_source (= 3.3.5)
       libdatadog (~> 12.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
@@ -37,7 +37,7 @@ GEM
     concurrent-ruby (1.2.2)
     crack (0.4.5)
       rexml
-    debase-ruby_core_source (3.3.1)
+    debase-ruby_core_source (3.3.5)
     debug_inspector (1.1.0)
     diff-lcs (1.5.0)
     docile (1.4.0)

--- a/gemfiles/ruby_3.1_opensearch_2.gemfile.lock
+++ b/gemfiles/ruby_3.1_opensearch_2.gemfile.lock
@@ -12,7 +12,7 @@ PATH
   remote: ..
   specs:
     datadog (2.3.0)
-      debase-ruby_core_source (= 3.3.1)
+      debase-ruby_core_source (= 3.3.5)
       libdatadog (~> 12.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
@@ -39,7 +39,7 @@ GEM
     concurrent-ruby (1.2.2)
     crack (0.4.5)
       rexml
-    debase-ruby_core_source (3.3.1)
+    debase-ruby_core_source (3.3.5)
     debug_inspector (1.1.0)
     diff-lcs (1.5.0)
     docile (1.4.0)

--- a/gemfiles/ruby_3.1_opensearch_3.gemfile.lock
+++ b/gemfiles/ruby_3.1_opensearch_3.gemfile.lock
@@ -12,7 +12,7 @@ PATH
   remote: ..
   specs:
     datadog (2.3.0)
-      debase-ruby_core_source (= 3.3.1)
+      debase-ruby_core_source (= 3.3.5)
       libdatadog (~> 12.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
@@ -39,7 +39,7 @@ GEM
     concurrent-ruby (1.2.2)
     crack (0.4.5)
       rexml
-    debase-ruby_core_source (3.3.1)
+    debase-ruby_core_source (3.3.5)
     debug_inspector (1.1.0)
     diff-lcs (1.5.0)
     docile (1.4.0)

--- a/gemfiles/ruby_3.1_opensearch_latest.gemfile.lock
+++ b/gemfiles/ruby_3.1_opensearch_latest.gemfile.lock
@@ -12,7 +12,7 @@ PATH
   remote: ..
   specs:
     datadog (2.3.0)
-      debase-ruby_core_source (= 3.3.1)
+      debase-ruby_core_source (= 3.3.5)
       libdatadog (~> 12.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
@@ -40,7 +40,7 @@ GEM
     crack (1.0.0)
       bigdecimal
       rexml
-    debase-ruby_core_source (3.3.1)
+    debase-ruby_core_source (3.3.5)
     debug_inspector (1.2.0)
     diff-lcs (1.5.1)
     docile (1.4.1)

--- a/gemfiles/ruby_3.1_opentelemetry.gemfile.lock
+++ b/gemfiles/ruby_3.1_opentelemetry.gemfile.lock
@@ -12,7 +12,7 @@ PATH
   remote: ..
   specs:
     datadog (2.3.0)
-      debase-ruby_core_source (= 3.3.1)
+      debase-ruby_core_source (= 3.3.5)
       libdatadog (~> 12.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
@@ -37,7 +37,7 @@ GEM
     concurrent-ruby (1.2.2)
     crack (0.4.5)
       rexml
-    debase-ruby_core_source (3.3.1)
+    debase-ruby_core_source (3.3.5)
     debug_inspector (1.1.0)
     diff-lcs (1.5.0)
     docile (1.4.0)

--- a/gemfiles/ruby_3.1_rack_1.gemfile.lock
+++ b/gemfiles/ruby_3.1_rack_1.gemfile.lock
@@ -12,7 +12,7 @@ PATH
   remote: ..
   specs:
     datadog (2.3.0)
-      debase-ruby_core_source (= 3.3.1)
+      debase-ruby_core_source (= 3.3.5)
       libdatadog (~> 12.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
@@ -37,7 +37,7 @@ GEM
     concurrent-ruby (1.2.2)
     crack (0.4.5)
       rexml
-    debase-ruby_core_source (3.3.1)
+    debase-ruby_core_source (3.3.5)
     debug_inspector (1.1.0)
     diff-lcs (1.5.0)
     docile (1.4.0)

--- a/gemfiles/ruby_3.1_rack_2.gemfile.lock
+++ b/gemfiles/ruby_3.1_rack_2.gemfile.lock
@@ -12,7 +12,7 @@ PATH
   remote: ..
   specs:
     datadog (2.3.0)
-      debase-ruby_core_source (= 3.3.1)
+      debase-ruby_core_source (= 3.3.5)
       libdatadog (~> 12.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
@@ -37,7 +37,7 @@ GEM
     concurrent-ruby (1.2.2)
     crack (0.4.5)
       rexml
-    debase-ruby_core_source (3.3.1)
+    debase-ruby_core_source (3.3.5)
     debug_inspector (1.1.0)
     diff-lcs (1.5.0)
     docile (1.4.0)

--- a/gemfiles/ruby_3.1_rack_3.gemfile.lock
+++ b/gemfiles/ruby_3.1_rack_3.gemfile.lock
@@ -12,7 +12,7 @@ PATH
   remote: ..
   specs:
     datadog (2.3.0)
-      debase-ruby_core_source (= 3.3.1)
+      debase-ruby_core_source (= 3.3.5)
       libdatadog (~> 12.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
@@ -37,7 +37,7 @@ GEM
     concurrent-ruby (1.2.2)
     crack (0.4.5)
       rexml
-    debase-ruby_core_source (3.3.1)
+    debase-ruby_core_source (3.3.5)
     debug_inspector (1.1.0)
     diff-lcs (1.5.0)
     docile (1.4.0)

--- a/gemfiles/ruby_3.1_rack_latest.gemfile.lock
+++ b/gemfiles/ruby_3.1_rack_latest.gemfile.lock
@@ -12,7 +12,7 @@ PATH
   remote: ..
   specs:
     datadog (2.3.0)
-      debase-ruby_core_source (= 3.3.1)
+      debase-ruby_core_source (= 3.3.5)
       libdatadog (~> 12.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
@@ -40,7 +40,7 @@ GEM
     crack (1.0.0)
       bigdecimal
       rexml
-    debase-ruby_core_source (3.3.1)
+    debase-ruby_core_source (3.3.5)
     debug_inspector (1.2.0)
     diff-lcs (1.5.1)
     docile (1.4.1)

--- a/gemfiles/ruby_3.1_rails61_mysql2.gemfile.lock
+++ b/gemfiles/ruby_3.1_rails61_mysql2.gemfile.lock
@@ -12,7 +12,7 @@ PATH
   remote: ..
   specs:
     datadog (2.3.0)
-      debase-ruby_core_source (= 3.3.1)
+      debase-ruby_core_source (= 3.3.5)
       libdatadog (~> 12.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
@@ -99,7 +99,7 @@ GEM
       rexml
     crass (1.0.6)
     date (3.3.3)
-    debase-ruby_core_source (3.3.1)
+    debase-ruby_core_source (3.3.5)
     debug_inspector (1.1.0)
     diff-lcs (1.5.0)
     docile (1.4.0)

--- a/gemfiles/ruby_3.1_rails61_postgres.gemfile.lock
+++ b/gemfiles/ruby_3.1_rails61_postgres.gemfile.lock
@@ -12,7 +12,7 @@ PATH
   remote: ..
   specs:
     datadog (2.3.0)
-      debase-ruby_core_source (= 3.3.1)
+      debase-ruby_core_source (= 3.3.5)
       libdatadog (~> 12.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
@@ -99,7 +99,7 @@ GEM
       rexml
     crass (1.0.6)
     date (3.3.3)
-    debase-ruby_core_source (3.3.1)
+    debase-ruby_core_source (3.3.5)
     debug_inspector (1.1.0)
     diff-lcs (1.5.0)
     docile (1.4.0)

--- a/gemfiles/ruby_3.1_rails61_postgres_redis.gemfile.lock
+++ b/gemfiles/ruby_3.1_rails61_postgres_redis.gemfile.lock
@@ -12,7 +12,7 @@ PATH
   remote: ..
   specs:
     datadog (2.3.0)
-      debase-ruby_core_source (= 3.3.1)
+      debase-ruby_core_source (= 3.3.5)
       libdatadog (~> 12.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
@@ -99,7 +99,7 @@ GEM
       rexml
     crass (1.0.6)
     date (3.3.3)
-    debase-ruby_core_source (3.3.1)
+    debase-ruby_core_source (3.3.5)
     debug_inspector (1.1.0)
     diff-lcs (1.5.0)
     docile (1.4.0)

--- a/gemfiles/ruby_3.1_rails61_postgres_sidekiq.gemfile.lock
+++ b/gemfiles/ruby_3.1_rails61_postgres_sidekiq.gemfile.lock
@@ -12,7 +12,7 @@ PATH
   remote: ..
   specs:
     datadog (2.3.0)
-      debase-ruby_core_source (= 3.3.1)
+      debase-ruby_core_source (= 3.3.5)
       libdatadog (~> 12.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
@@ -100,7 +100,7 @@ GEM
       rexml
     crass (1.0.6)
     date (3.3.3)
-    debase-ruby_core_source (3.3.1)
+    debase-ruby_core_source (3.3.5)
     debug_inspector (1.1.0)
     diff-lcs (1.5.0)
     docile (1.4.0)

--- a/gemfiles/ruby_3.1_rails61_semantic_logger.gemfile.lock
+++ b/gemfiles/ruby_3.1_rails61_semantic_logger.gemfile.lock
@@ -12,7 +12,7 @@ PATH
   remote: ..
   specs:
     datadog (2.3.0)
-      debase-ruby_core_source (= 3.3.1)
+      debase-ruby_core_source (= 3.3.5)
       libdatadog (~> 12.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
@@ -99,7 +99,7 @@ GEM
       rexml
     crass (1.0.6)
     date (3.3.3)
-    debase-ruby_core_source (3.3.1)
+    debase-ruby_core_source (3.3.5)
     debug_inspector (1.1.0)
     diff-lcs (1.5.0)
     docile (1.4.0)

--- a/gemfiles/ruby_3.1_rails61_trilogy.gemfile.lock
+++ b/gemfiles/ruby_3.1_rails61_trilogy.gemfile.lock
@@ -12,7 +12,7 @@ PATH
   remote: ..
   specs:
     datadog (2.3.0)
-      debase-ruby_core_source (= 3.3.1)
+      debase-ruby_core_source (= 3.3.5)
       libdatadog (~> 12.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
@@ -103,7 +103,7 @@ GEM
       rexml
     crass (1.0.6)
     date (3.3.4)
-    debase-ruby_core_source (3.3.1)
+    debase-ruby_core_source (3.3.5)
     debug_inspector (1.1.0)
     diff-lcs (1.5.0)
     docile (1.4.0)

--- a/gemfiles/ruby_3.1_rails7.gemfile.lock
+++ b/gemfiles/ruby_3.1_rails7.gemfile.lock
@@ -12,7 +12,7 @@ PATH
   remote: ..
   specs:
     datadog (2.3.0)
-      debase-ruby_core_source (= 3.3.1)
+      debase-ruby_core_source (= 3.3.5)
       libdatadog (~> 12.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
@@ -108,7 +108,7 @@ GEM
       rexml
     crass (1.0.6)
     date (3.3.4)
-    debase-ruby_core_source (3.3.1)
+    debase-ruby_core_source (3.3.5)
     debug_inspector (1.2.0)
     diff-lcs (1.5.1)
     docile (1.4.1)

--- a/gemfiles/ruby_3.1_rails71.gemfile.lock
+++ b/gemfiles/ruby_3.1_rails71.gemfile.lock
@@ -12,7 +12,7 @@ PATH
   remote: ..
   specs:
     datadog (2.3.0)
-      debase-ruby_core_source (= 3.3.1)
+      debase-ruby_core_source (= 3.3.5)
       libdatadog (~> 12.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
@@ -119,7 +119,7 @@ GEM
       rexml
     crass (1.0.6)
     date (3.3.4)
-    debase-ruby_core_source (3.3.1)
+    debase-ruby_core_source (3.3.5)
     debug_inspector (1.2.0)
     diff-lcs (1.5.1)
     docile (1.4.1)

--- a/gemfiles/ruby_3.1_redis_3.gemfile.lock
+++ b/gemfiles/ruby_3.1_redis_3.gemfile.lock
@@ -12,7 +12,7 @@ PATH
   remote: ..
   specs:
     datadog (2.3.0)
-      debase-ruby_core_source (= 3.3.1)
+      debase-ruby_core_source (= 3.3.5)
       libdatadog (~> 12.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
@@ -37,7 +37,7 @@ GEM
     concurrent-ruby (1.2.2)
     crack (0.4.5)
       rexml
-    debase-ruby_core_source (3.3.1)
+    debase-ruby_core_source (3.3.5)
     debug_inspector (1.1.0)
     diff-lcs (1.5.0)
     docile (1.4.0)

--- a/gemfiles/ruby_3.1_redis_4.gemfile.lock
+++ b/gemfiles/ruby_3.1_redis_4.gemfile.lock
@@ -12,7 +12,7 @@ PATH
   remote: ..
   specs:
     datadog (2.3.0)
-      debase-ruby_core_source (= 3.3.1)
+      debase-ruby_core_source (= 3.3.5)
       libdatadog (~> 12.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
@@ -37,7 +37,7 @@ GEM
     concurrent-ruby (1.2.2)
     crack (0.4.5)
       rexml
-    debase-ruby_core_source (3.3.1)
+    debase-ruby_core_source (3.3.5)
     debug_inspector (1.1.0)
     diff-lcs (1.5.0)
     docile (1.4.0)

--- a/gemfiles/ruby_3.1_redis_5.gemfile.lock
+++ b/gemfiles/ruby_3.1_redis_5.gemfile.lock
@@ -12,7 +12,7 @@ PATH
   remote: ..
   specs:
     datadog (2.3.0)
-      debase-ruby_core_source (= 3.3.1)
+      debase-ruby_core_source (= 3.3.5)
       libdatadog (~> 12.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
@@ -38,7 +38,7 @@ GEM
     connection_pool (2.3.0)
     crack (0.4.5)
       rexml
-    debase-ruby_core_source (3.3.1)
+    debase-ruby_core_source (3.3.5)
     debug_inspector (1.1.0)
     diff-lcs (1.5.0)
     docile (1.4.0)

--- a/gemfiles/ruby_3.1_relational_db.gemfile.lock
+++ b/gemfiles/ruby_3.1_relational_db.gemfile.lock
@@ -12,7 +12,7 @@ PATH
   remote: ..
   specs:
     datadog (2.3.0)
-      debase-ruby_core_source (= 3.3.1)
+      debase-ruby_core_source (= 3.3.5)
       libdatadog (~> 12.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
@@ -48,7 +48,7 @@ GEM
     concurrent-ruby (1.2.2)
     crack (0.4.5)
       rexml
-    debase-ruby_core_source (3.3.1)
+    debase-ruby_core_source (3.3.5)
     debug_inspector (1.1.0)
     delayed_job (4.1.11)
       activesupport (>= 3.0, < 8.0)

--- a/gemfiles/ruby_3.1_resque2_redis3.gemfile.lock
+++ b/gemfiles/ruby_3.1_resque2_redis3.gemfile.lock
@@ -12,7 +12,7 @@ PATH
   remote: ..
   specs:
     datadog (2.3.0)
-      debase-ruby_core_source (= 3.3.1)
+      debase-ruby_core_source (= 3.3.5)
       libdatadog (~> 12.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
@@ -37,7 +37,7 @@ GEM
     concurrent-ruby (1.2.2)
     crack (0.4.5)
       rexml
-    debase-ruby_core_source (3.3.1)
+    debase-ruby_core_source (3.3.5)
     debug_inspector (1.1.0)
     diff-lcs (1.5.0)
     docile (1.4.0)

--- a/gemfiles/ruby_3.1_resque2_redis4.gemfile.lock
+++ b/gemfiles/ruby_3.1_resque2_redis4.gemfile.lock
@@ -12,7 +12,7 @@ PATH
   remote: ..
   specs:
     datadog (2.3.0)
-      debase-ruby_core_source (= 3.3.1)
+      debase-ruby_core_source (= 3.3.5)
       libdatadog (~> 12.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
@@ -38,7 +38,7 @@ GEM
     connection_pool (2.3.0)
     crack (0.4.5)
       rexml
-    debase-ruby_core_source (3.3.1)
+    debase-ruby_core_source (3.3.5)
     debug_inspector (1.1.0)
     diff-lcs (1.5.0)
     docile (1.4.0)

--- a/gemfiles/ruby_3.1_sinatra_2.gemfile.lock
+++ b/gemfiles/ruby_3.1_sinatra_2.gemfile.lock
@@ -12,7 +12,7 @@ PATH
   remote: ..
   specs:
     datadog (2.3.0)
-      debase-ruby_core_source (= 3.3.1)
+      debase-ruby_core_source (= 3.3.5)
       libdatadog (~> 12.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
@@ -40,7 +40,7 @@ GEM
     crack (1.0.0)
       bigdecimal
       rexml
-    debase-ruby_core_source (3.3.1)
+    debase-ruby_core_source (3.3.5)
     debug_inspector (1.2.0)
     diff-lcs (1.5.1)
     docile (1.4.0)

--- a/gemfiles/ruby_3.1_sinatra_3.gemfile.lock
+++ b/gemfiles/ruby_3.1_sinatra_3.gemfile.lock
@@ -12,7 +12,7 @@ PATH
   remote: ..
   specs:
     datadog (2.3.0)
-      debase-ruby_core_source (= 3.3.1)
+      debase-ruby_core_source (= 3.3.5)
       libdatadog (~> 12.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
@@ -41,7 +41,7 @@ GEM
     crack (1.0.0)
       bigdecimal
       rexml
-    debase-ruby_core_source (3.3.1)
+    debase-ruby_core_source (3.3.5)
     debug_inspector (1.2.0)
     diff-lcs (1.5.1)
     docile (1.4.0)

--- a/gemfiles/ruby_3.1_sinatra_4.gemfile.lock
+++ b/gemfiles/ruby_3.1_sinatra_4.gemfile.lock
@@ -12,7 +12,7 @@ PATH
   remote: ..
   specs:
     datadog (2.3.0)
-      debase-ruby_core_source (= 3.3.1)
+      debase-ruby_core_source (= 3.3.5)
       libdatadog (~> 12.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
@@ -41,7 +41,7 @@ GEM
     crack (1.0.0)
       bigdecimal
       rexml
-    debase-ruby_core_source (3.3.1)
+    debase-ruby_core_source (3.3.5)
     debug_inspector (1.2.0)
     diff-lcs (1.5.1)
     docile (1.4.0)

--- a/gemfiles/ruby_3.1_stripe_10.gemfile.lock
+++ b/gemfiles/ruby_3.1_stripe_10.gemfile.lock
@@ -12,7 +12,7 @@ PATH
   remote: ..
   specs:
     datadog (2.3.0)
-      debase-ruby_core_source (= 3.3.1)
+      debase-ruby_core_source (= 3.3.5)
       libdatadog (~> 12.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
@@ -40,7 +40,7 @@ GEM
     crack (1.0.0)
       bigdecimal
       rexml
-    debase-ruby_core_source (3.3.1)
+    debase-ruby_core_source (3.3.5)
     debug_inspector (1.2.0)
     diff-lcs (1.5.1)
     docile (1.4.1)

--- a/gemfiles/ruby_3.1_stripe_11.gemfile.lock
+++ b/gemfiles/ruby_3.1_stripe_11.gemfile.lock
@@ -12,7 +12,7 @@ PATH
   remote: ..
   specs:
     datadog (2.3.0)
-      debase-ruby_core_source (= 3.3.1)
+      debase-ruby_core_source (= 3.3.5)
       libdatadog (~> 12.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
@@ -40,7 +40,7 @@ GEM
     crack (1.0.0)
       bigdecimal
       rexml
-    debase-ruby_core_source (3.3.1)
+    debase-ruby_core_source (3.3.5)
     debug_inspector (1.2.0)
     diff-lcs (1.5.1)
     docile (1.4.1)

--- a/gemfiles/ruby_3.1_stripe_12.gemfile.lock
+++ b/gemfiles/ruby_3.1_stripe_12.gemfile.lock
@@ -12,7 +12,7 @@ PATH
   remote: ..
   specs:
     datadog (2.3.0)
-      debase-ruby_core_source (= 3.3.1)
+      debase-ruby_core_source (= 3.3.5)
       libdatadog (~> 12.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
@@ -40,7 +40,7 @@ GEM
     crack (1.0.0)
       bigdecimal
       rexml
-    debase-ruby_core_source (3.3.1)
+    debase-ruby_core_source (3.3.5)
     debug_inspector (1.2.0)
     diff-lcs (1.5.1)
     docile (1.4.1)

--- a/gemfiles/ruby_3.1_stripe_7.gemfile.lock
+++ b/gemfiles/ruby_3.1_stripe_7.gemfile.lock
@@ -12,7 +12,7 @@ PATH
   remote: ..
   specs:
     datadog (2.3.0)
-      debase-ruby_core_source (= 3.3.1)
+      debase-ruby_core_source (= 3.3.5)
       libdatadog (~> 12.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
@@ -40,7 +40,7 @@ GEM
     crack (1.0.0)
       bigdecimal
       rexml
-    debase-ruby_core_source (3.3.1)
+    debase-ruby_core_source (3.3.5)
     debug_inspector (1.2.0)
     diff-lcs (1.5.1)
     docile (1.4.1)

--- a/gemfiles/ruby_3.1_stripe_8.gemfile.lock
+++ b/gemfiles/ruby_3.1_stripe_8.gemfile.lock
@@ -12,7 +12,7 @@ PATH
   remote: ..
   specs:
     datadog (2.3.0)
-      debase-ruby_core_source (= 3.3.1)
+      debase-ruby_core_source (= 3.3.5)
       libdatadog (~> 12.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
@@ -40,7 +40,7 @@ GEM
     crack (1.0.0)
       bigdecimal
       rexml
-    debase-ruby_core_source (3.3.1)
+    debase-ruby_core_source (3.3.5)
     debug_inspector (1.2.0)
     diff-lcs (1.5.1)
     docile (1.4.1)

--- a/gemfiles/ruby_3.1_stripe_9.gemfile.lock
+++ b/gemfiles/ruby_3.1_stripe_9.gemfile.lock
@@ -12,7 +12,7 @@ PATH
   remote: ..
   specs:
     datadog (2.3.0)
-      debase-ruby_core_source (= 3.3.1)
+      debase-ruby_core_source (= 3.3.5)
       libdatadog (~> 12.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
@@ -40,7 +40,7 @@ GEM
     crack (1.0.0)
       bigdecimal
       rexml
-    debase-ruby_core_source (3.3.1)
+    debase-ruby_core_source (3.3.5)
     debug_inspector (1.2.0)
     diff-lcs (1.5.1)
     docile (1.4.1)

--- a/gemfiles/ruby_3.1_stripe_latest.gemfile.lock
+++ b/gemfiles/ruby_3.1_stripe_latest.gemfile.lock
@@ -12,7 +12,7 @@ PATH
   remote: ..
   specs:
     datadog (2.3.0)
-      debase-ruby_core_source (= 3.3.1)
+      debase-ruby_core_source (= 3.3.5)
       libdatadog (~> 12.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
@@ -40,7 +40,7 @@ GEM
     crack (1.0.0)
       bigdecimal
       rexml
-    debase-ruby_core_source (3.3.1)
+    debase-ruby_core_source (3.3.5)
     debug_inspector (1.2.0)
     diff-lcs (1.5.1)
     docile (1.4.1)

--- a/gemfiles/ruby_3.1_stripe_min.gemfile.lock
+++ b/gemfiles/ruby_3.1_stripe_min.gemfile.lock
@@ -12,7 +12,7 @@ PATH
   remote: ..
   specs:
     datadog (2.3.0)
-      debase-ruby_core_source (= 3.3.1)
+      debase-ruby_core_source (= 3.3.5)
       libdatadog (~> 12.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
@@ -40,7 +40,7 @@ GEM
     crack (1.0.0)
       bigdecimal
       rexml
-    debase-ruby_core_source (3.3.1)
+    debase-ruby_core_source (3.3.5)
     debug_inspector (1.2.0)
     diff-lcs (1.5.1)
     docile (1.4.1)

--- a/gemfiles/ruby_3.2_activesupport.gemfile.lock
+++ b/gemfiles/ruby_3.2_activesupport.gemfile.lock
@@ -12,7 +12,7 @@ PATH
   remote: ..
   specs:
     datadog (2.3.0)
-      debase-ruby_core_source (= 3.3.1)
+      debase-ruby_core_source (= 3.3.5)
       libdatadog (~> 12.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
@@ -65,7 +65,7 @@ GEM
     crack (0.4.5)
       rexml
     crass (1.0.6)
-    debase-ruby_core_source (3.3.1)
+    debase-ruby_core_source (3.3.5)
     debug_inspector (1.1.0)
     diff-lcs (1.5.0)
     digest-crc (0.6.5)

--- a/gemfiles/ruby_3.2_aws.gemfile.lock
+++ b/gemfiles/ruby_3.2_aws.gemfile.lock
@@ -12,7 +12,7 @@ PATH
   remote: ..
   specs:
     datadog (2.3.0)
-      debase-ruby_core_source (= 3.3.1)
+      debase-ruby_core_source (= 3.3.5)
       libdatadog (~> 12.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
@@ -1457,7 +1457,7 @@ GEM
     concurrent-ruby (1.2.2)
     crack (0.4.5)
       rexml
-    debase-ruby_core_source (3.3.1)
+    debase-ruby_core_source (3.3.5)
     debug_inspector (1.1.0)
     diff-lcs (1.5.0)
     docile (1.4.0)

--- a/gemfiles/ruby_3.2_contrib.gemfile.lock
+++ b/gemfiles/ruby_3.2_contrib.gemfile.lock
@@ -12,7 +12,7 @@ PATH
   remote: ..
   specs:
     datadog (2.3.0)
-      debase-ruby_core_source (= 3.3.1)
+      debase-ruby_core_source (= 3.3.5)
       libdatadog (~> 12.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
@@ -43,7 +43,7 @@ GEM
     crack (0.4.5)
       rexml
     dalli (3.2.4)
-    debase-ruby_core_source (3.3.1)
+    debase-ruby_core_source (3.3.5)
     debug_inspector (1.1.0)
     diff-lcs (1.5.0)
     docile (1.4.0)

--- a/gemfiles/ruby_3.2_contrib_old.gemfile.lock
+++ b/gemfiles/ruby_3.2_contrib_old.gemfile.lock
@@ -12,7 +12,7 @@ PATH
   remote: ..
   specs:
     datadog (2.3.0)
-      debase-ruby_core_source (= 3.3.1)
+      debase-ruby_core_source (= 3.3.5)
       libdatadog (~> 12.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
@@ -41,7 +41,7 @@ GEM
       rexml
     daemons (1.4.1)
     dalli (2.7.11)
-    debase-ruby_core_source (3.3.1)
+    debase-ruby_core_source (3.3.5)
     debug_inspector (1.1.0)
     diff-lcs (1.5.0)
     docile (1.4.0)

--- a/gemfiles/ruby_3.2_core_old.gemfile.lock
+++ b/gemfiles/ruby_3.2_core_old.gemfile.lock
@@ -12,7 +12,7 @@ PATH
   remote: ..
   specs:
     datadog (2.3.0)
-      debase-ruby_core_source (= 3.3.1)
+      debase-ruby_core_source (= 3.3.5)
       libdatadog (~> 12.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
@@ -36,7 +36,7 @@ GEM
     concurrent-ruby (1.2.2)
     crack (0.4.5)
       rexml
-    debase-ruby_core_source (3.3.1)
+    debase-ruby_core_source (3.3.5)
     debug_inspector (1.1.0)
     diff-lcs (1.5.0)
     docile (1.4.0)

--- a/gemfiles/ruby_3.2_elasticsearch_7.gemfile.lock
+++ b/gemfiles/ruby_3.2_elasticsearch_7.gemfile.lock
@@ -12,7 +12,7 @@ PATH
   remote: ..
   specs:
     datadog (2.3.0)
-      debase-ruby_core_source (= 3.3.1)
+      debase-ruby_core_source (= 3.3.5)
       libdatadog (~> 12.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
@@ -37,7 +37,7 @@ GEM
     concurrent-ruby (1.2.2)
     crack (0.4.5)
       rexml
-    debase-ruby_core_source (3.3.1)
+    debase-ruby_core_source (3.3.5)
     debug_inspector (1.1.0)
     diff-lcs (1.5.0)
     docile (1.4.0)

--- a/gemfiles/ruby_3.2_elasticsearch_8.gemfile.lock
+++ b/gemfiles/ruby_3.2_elasticsearch_8.gemfile.lock
@@ -12,7 +12,7 @@ PATH
   remote: ..
   specs:
     datadog (2.3.0)
-      debase-ruby_core_source (= 3.3.1)
+      debase-ruby_core_source (= 3.3.5)
       libdatadog (~> 12.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
@@ -38,7 +38,7 @@ GEM
     concurrent-ruby (1.2.2)
     crack (0.4.5)
       rexml
-    debase-ruby_core_source (3.3.1)
+    debase-ruby_core_source (3.3.5)
     debug_inspector (1.1.0)
     diff-lcs (1.5.0)
     docile (1.4.0)

--- a/gemfiles/ruby_3.2_elasticsearch_latest.gemfile.lock
+++ b/gemfiles/ruby_3.2_elasticsearch_latest.gemfile.lock
@@ -12,7 +12,7 @@ PATH
   remote: ..
   specs:
     datadog (2.3.0)
-      debase-ruby_core_source (= 3.3.1)
+      debase-ruby_core_source (= 3.3.5)
       libdatadog (~> 12.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
@@ -39,7 +39,7 @@ GEM
     crack (1.0.0)
       bigdecimal
       rexml
-    debase-ruby_core_source (3.3.1)
+    debase-ruby_core_source (3.3.5)
     debug_inspector (1.2.0)
     diff-lcs (1.5.1)
     docile (1.4.1)

--- a/gemfiles/ruby_3.2_graphql_1.13.gemfile.lock
+++ b/gemfiles/ruby_3.2_graphql_1.13.gemfile.lock
@@ -12,7 +12,7 @@ PATH
   remote: ..
   specs:
     datadog (2.3.0)
-      debase-ruby_core_source (= 3.3.1)
+      debase-ruby_core_source (= 3.3.5)
       libdatadog (~> 12.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
@@ -99,7 +99,7 @@ GEM
       rexml
     crass (1.0.6)
     date (3.3.4)
-    debase-ruby_core_source (3.3.1)
+    debase-ruby_core_source (3.3.5)
     debug_inspector (1.2.0)
     diff-lcs (1.5.0)
     docile (1.4.0)

--- a/gemfiles/ruby_3.2_graphql_2.0.gemfile.lock
+++ b/gemfiles/ruby_3.2_graphql_2.0.gemfile.lock
@@ -12,7 +12,7 @@ PATH
   remote: ..
   specs:
     datadog (2.3.0)
-      debase-ruby_core_source (= 3.3.1)
+      debase-ruby_core_source (= 3.3.5)
       libdatadog (~> 12.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
@@ -99,7 +99,7 @@ GEM
       rexml
     crass (1.0.6)
     date (3.3.4)
-    debase-ruby_core_source (3.3.1)
+    debase-ruby_core_source (3.3.5)
     debug_inspector (1.2.0)
     diff-lcs (1.5.0)
     docile (1.4.0)

--- a/gemfiles/ruby_3.2_graphql_2.1.gemfile.lock
+++ b/gemfiles/ruby_3.2_graphql_2.1.gemfile.lock
@@ -12,7 +12,7 @@ PATH
   remote: ..
   specs:
     datadog (2.3.0)
-      debase-ruby_core_source (= 3.3.1)
+      debase-ruby_core_source (= 3.3.5)
       libdatadog (~> 12.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
@@ -99,7 +99,7 @@ GEM
       rexml
     crass (1.0.6)
     date (3.3.4)
-    debase-ruby_core_source (3.3.1)
+    debase-ruby_core_source (3.3.5)
     debug_inspector (1.2.0)
     diff-lcs (1.5.0)
     docile (1.4.0)

--- a/gemfiles/ruby_3.2_graphql_2.2.gemfile.lock
+++ b/gemfiles/ruby_3.2_graphql_2.2.gemfile.lock
@@ -12,7 +12,7 @@ PATH
   remote: ..
   specs:
     datadog (2.3.0)
-      debase-ruby_core_source (= 3.3.1)
+      debase-ruby_core_source (= 3.3.5)
       libdatadog (~> 12.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
@@ -99,7 +99,7 @@ GEM
       rexml
     crass (1.0.6)
     date (3.3.4)
-    debase-ruby_core_source (3.3.1)
+    debase-ruby_core_source (3.3.5)
     debug_inspector (1.2.0)
     diff-lcs (1.5.0)
     docile (1.4.0)

--- a/gemfiles/ruby_3.2_graphql_2.3.gemfile.lock
+++ b/gemfiles/ruby_3.2_graphql_2.3.gemfile.lock
@@ -12,7 +12,7 @@ PATH
   remote: ..
   specs:
     datadog (2.3.0)
-      debase-ruby_core_source (= 3.3.1)
+      debase-ruby_core_source (= 3.3.5)
       libdatadog (~> 12.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
@@ -102,7 +102,7 @@ GEM
       rexml
     crass (1.0.6)
     date (3.3.4)
-    debase-ruby_core_source (3.3.1)
+    debase-ruby_core_source (3.3.5)
     debug_inspector (1.2.0)
     diff-lcs (1.5.1)
     docile (1.4.0)

--- a/gemfiles/ruby_3.2_http.gemfile.lock
+++ b/gemfiles/ruby_3.2_http.gemfile.lock
@@ -12,7 +12,7 @@ PATH
   remote: ..
   specs:
     datadog (2.3.0)
-      debase-ruby_core_source (= 3.3.1)
+      debase-ruby_core_source (= 3.3.5)
       libdatadog (~> 12.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
@@ -36,7 +36,7 @@ GEM
     concurrent-ruby (1.2.2)
     crack (0.4.5)
       rexml
-    debase-ruby_core_source (3.3.1)
+    debase-ruby_core_source (3.3.5)
     debug_inspector (1.1.0)
     diff-lcs (1.5.0)
     docile (1.4.0)

--- a/gemfiles/ruby_3.2_opensearch_2.gemfile.lock
+++ b/gemfiles/ruby_3.2_opensearch_2.gemfile.lock
@@ -12,7 +12,7 @@ PATH
   remote: ..
   specs:
     datadog (2.3.0)
-      debase-ruby_core_source (= 3.3.1)
+      debase-ruby_core_source (= 3.3.5)
       libdatadog (~> 12.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
@@ -38,7 +38,7 @@ GEM
     concurrent-ruby (1.2.2)
     crack (0.4.5)
       rexml
-    debase-ruby_core_source (3.3.1)
+    debase-ruby_core_source (3.3.5)
     debug_inspector (1.1.0)
     diff-lcs (1.5.0)
     docile (1.4.0)

--- a/gemfiles/ruby_3.2_opensearch_3.gemfile.lock
+++ b/gemfiles/ruby_3.2_opensearch_3.gemfile.lock
@@ -12,7 +12,7 @@ PATH
   remote: ..
   specs:
     datadog (2.3.0)
-      debase-ruby_core_source (= 3.3.1)
+      debase-ruby_core_source (= 3.3.5)
       libdatadog (~> 12.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
@@ -38,7 +38,7 @@ GEM
     concurrent-ruby (1.2.2)
     crack (0.4.5)
       rexml
-    debase-ruby_core_source (3.3.1)
+    debase-ruby_core_source (3.3.5)
     debug_inspector (1.1.0)
     diff-lcs (1.5.0)
     docile (1.4.0)

--- a/gemfiles/ruby_3.2_opensearch_latest.gemfile.lock
+++ b/gemfiles/ruby_3.2_opensearch_latest.gemfile.lock
@@ -12,7 +12,7 @@ PATH
   remote: ..
   specs:
     datadog (2.3.0)
-      debase-ruby_core_source (= 3.3.1)
+      debase-ruby_core_source (= 3.3.5)
       libdatadog (~> 12.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
@@ -39,7 +39,7 @@ GEM
     crack (1.0.0)
       bigdecimal
       rexml
-    debase-ruby_core_source (3.3.1)
+    debase-ruby_core_source (3.3.5)
     debug_inspector (1.2.0)
     diff-lcs (1.5.1)
     docile (1.4.1)

--- a/gemfiles/ruby_3.2_opentelemetry.gemfile.lock
+++ b/gemfiles/ruby_3.2_opentelemetry.gemfile.lock
@@ -12,7 +12,7 @@ PATH
   remote: ..
   specs:
     datadog (2.3.0)
-      debase-ruby_core_source (= 3.3.1)
+      debase-ruby_core_source (= 3.3.5)
       libdatadog (~> 12.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
@@ -36,7 +36,7 @@ GEM
     concurrent-ruby (1.2.2)
     crack (0.4.5)
       rexml
-    debase-ruby_core_source (3.3.1)
+    debase-ruby_core_source (3.3.5)
     debug_inspector (1.1.0)
     diff-lcs (1.5.0)
     docile (1.4.0)

--- a/gemfiles/ruby_3.2_rack_1.gemfile.lock
+++ b/gemfiles/ruby_3.2_rack_1.gemfile.lock
@@ -12,7 +12,7 @@ PATH
   remote: ..
   specs:
     datadog (2.3.0)
-      debase-ruby_core_source (= 3.3.1)
+      debase-ruby_core_source (= 3.3.5)
       libdatadog (~> 12.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
@@ -36,7 +36,7 @@ GEM
     concurrent-ruby (1.2.2)
     crack (0.4.5)
       rexml
-    debase-ruby_core_source (3.3.1)
+    debase-ruby_core_source (3.3.5)
     debug_inspector (1.1.0)
     diff-lcs (1.5.0)
     docile (1.4.0)

--- a/gemfiles/ruby_3.2_rack_2.gemfile.lock
+++ b/gemfiles/ruby_3.2_rack_2.gemfile.lock
@@ -12,7 +12,7 @@ PATH
   remote: ..
   specs:
     datadog (2.3.0)
-      debase-ruby_core_source (= 3.3.1)
+      debase-ruby_core_source (= 3.3.5)
       libdatadog (~> 12.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
@@ -36,7 +36,7 @@ GEM
     concurrent-ruby (1.2.2)
     crack (0.4.5)
       rexml
-    debase-ruby_core_source (3.3.1)
+    debase-ruby_core_source (3.3.5)
     debug_inspector (1.1.0)
     diff-lcs (1.5.0)
     docile (1.4.0)

--- a/gemfiles/ruby_3.2_rack_3.gemfile.lock
+++ b/gemfiles/ruby_3.2_rack_3.gemfile.lock
@@ -12,7 +12,7 @@ PATH
   remote: ..
   specs:
     datadog (2.3.0)
-      debase-ruby_core_source (= 3.3.1)
+      debase-ruby_core_source (= 3.3.5)
       libdatadog (~> 12.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
@@ -36,7 +36,7 @@ GEM
     concurrent-ruby (1.2.2)
     crack (0.4.5)
       rexml
-    debase-ruby_core_source (3.3.1)
+    debase-ruby_core_source (3.3.5)
     debug_inspector (1.1.0)
     diff-lcs (1.5.0)
     docile (1.4.0)

--- a/gemfiles/ruby_3.2_rack_latest.gemfile.lock
+++ b/gemfiles/ruby_3.2_rack_latest.gemfile.lock
@@ -12,7 +12,7 @@ PATH
   remote: ..
   specs:
     datadog (2.3.0)
-      debase-ruby_core_source (= 3.3.1)
+      debase-ruby_core_source (= 3.3.5)
       libdatadog (~> 12.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
@@ -39,7 +39,7 @@ GEM
     crack (1.0.0)
       bigdecimal
       rexml
-    debase-ruby_core_source (3.3.1)
+    debase-ruby_core_source (3.3.5)
     debug_inspector (1.2.0)
     diff-lcs (1.5.1)
     docile (1.4.1)

--- a/gemfiles/ruby_3.2_rails61_mysql2.gemfile.lock
+++ b/gemfiles/ruby_3.2_rails61_mysql2.gemfile.lock
@@ -12,7 +12,7 @@ PATH
   remote: ..
   specs:
     datadog (2.3.0)
-      debase-ruby_core_source (= 3.3.1)
+      debase-ruby_core_source (= 3.3.5)
       libdatadog (~> 12.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
@@ -98,7 +98,7 @@ GEM
       rexml
     crass (1.0.6)
     date (3.3.3)
-    debase-ruby_core_source (3.3.1)
+    debase-ruby_core_source (3.3.5)
     debug_inspector (1.1.0)
     diff-lcs (1.5.0)
     docile (1.4.0)

--- a/gemfiles/ruby_3.2_rails61_postgres.gemfile.lock
+++ b/gemfiles/ruby_3.2_rails61_postgres.gemfile.lock
@@ -12,7 +12,7 @@ PATH
   remote: ..
   specs:
     datadog (2.3.0)
-      debase-ruby_core_source (= 3.3.1)
+      debase-ruby_core_source (= 3.3.5)
       libdatadog (~> 12.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
@@ -98,7 +98,7 @@ GEM
       rexml
     crass (1.0.6)
     date (3.3.3)
-    debase-ruby_core_source (3.3.1)
+    debase-ruby_core_source (3.3.5)
     debug_inspector (1.1.0)
     diff-lcs (1.5.0)
     docile (1.4.0)

--- a/gemfiles/ruby_3.2_rails61_postgres_redis.gemfile.lock
+++ b/gemfiles/ruby_3.2_rails61_postgres_redis.gemfile.lock
@@ -12,7 +12,7 @@ PATH
   remote: ..
   specs:
     datadog (2.3.0)
-      debase-ruby_core_source (= 3.3.1)
+      debase-ruby_core_source (= 3.3.5)
       libdatadog (~> 12.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
@@ -98,7 +98,7 @@ GEM
       rexml
     crass (1.0.6)
     date (3.3.3)
-    debase-ruby_core_source (3.3.1)
+    debase-ruby_core_source (3.3.5)
     debug_inspector (1.1.0)
     diff-lcs (1.5.0)
     docile (1.4.0)

--- a/gemfiles/ruby_3.2_rails61_postgres_sidekiq.gemfile.lock
+++ b/gemfiles/ruby_3.2_rails61_postgres_sidekiq.gemfile.lock
@@ -12,7 +12,7 @@ PATH
   remote: ..
   specs:
     datadog (2.3.0)
-      debase-ruby_core_source (= 3.3.1)
+      debase-ruby_core_source (= 3.3.5)
       libdatadog (~> 12.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
@@ -99,7 +99,7 @@ GEM
       rexml
     crass (1.0.6)
     date (3.3.3)
-    debase-ruby_core_source (3.3.1)
+    debase-ruby_core_source (3.3.5)
     debug_inspector (1.1.0)
     diff-lcs (1.5.0)
     docile (1.4.0)

--- a/gemfiles/ruby_3.2_rails61_semantic_logger.gemfile.lock
+++ b/gemfiles/ruby_3.2_rails61_semantic_logger.gemfile.lock
@@ -12,7 +12,7 @@ PATH
   remote: ..
   specs:
     datadog (2.3.0)
-      debase-ruby_core_source (= 3.3.1)
+      debase-ruby_core_source (= 3.3.5)
       libdatadog (~> 12.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
@@ -98,7 +98,7 @@ GEM
       rexml
     crass (1.0.6)
     date (3.3.3)
-    debase-ruby_core_source (3.3.1)
+    debase-ruby_core_source (3.3.5)
     debug_inspector (1.1.0)
     diff-lcs (1.5.0)
     docile (1.4.0)

--- a/gemfiles/ruby_3.2_rails61_trilogy.gemfile.lock
+++ b/gemfiles/ruby_3.2_rails61_trilogy.gemfile.lock
@@ -12,7 +12,7 @@ PATH
   remote: ..
   specs:
     datadog (2.3.0)
-      debase-ruby_core_source (= 3.3.1)
+      debase-ruby_core_source (= 3.3.5)
       libdatadog (~> 12.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
@@ -102,7 +102,7 @@ GEM
       rexml
     crass (1.0.6)
     date (3.3.4)
-    debase-ruby_core_source (3.3.1)
+    debase-ruby_core_source (3.3.5)
     debug_inspector (1.1.0)
     diff-lcs (1.5.0)
     docile (1.4.0)

--- a/gemfiles/ruby_3.2_rails7.gemfile.lock
+++ b/gemfiles/ruby_3.2_rails7.gemfile.lock
@@ -12,7 +12,7 @@ PATH
   remote: ..
   specs:
     datadog (2.3.0)
-      debase-ruby_core_source (= 3.3.1)
+      debase-ruby_core_source (= 3.3.5)
       libdatadog (~> 12.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
@@ -107,7 +107,7 @@ GEM
       rexml
     crass (1.0.6)
     date (3.3.4)
-    debase-ruby_core_source (3.3.1)
+    debase-ruby_core_source (3.3.5)
     debug_inspector (1.2.0)
     diff-lcs (1.5.1)
     docile (1.4.1)

--- a/gemfiles/ruby_3.2_rails71.gemfile.lock
+++ b/gemfiles/ruby_3.2_rails71.gemfile.lock
@@ -12,7 +12,7 @@ PATH
   remote: ..
   specs:
     datadog (2.3.0)
-      debase-ruby_core_source (= 3.3.1)
+      debase-ruby_core_source (= 3.3.5)
       libdatadog (~> 12.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
@@ -118,7 +118,7 @@ GEM
       rexml
     crass (1.0.6)
     date (3.3.4)
-    debase-ruby_core_source (3.3.1)
+    debase-ruby_core_source (3.3.5)
     debug_inspector (1.2.0)
     diff-lcs (1.5.1)
     docile (1.4.1)

--- a/gemfiles/ruby_3.2_redis_3.gemfile.lock
+++ b/gemfiles/ruby_3.2_redis_3.gemfile.lock
@@ -12,7 +12,7 @@ PATH
   remote: ..
   specs:
     datadog (2.3.0)
-      debase-ruby_core_source (= 3.3.1)
+      debase-ruby_core_source (= 3.3.5)
       libdatadog (~> 12.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
@@ -36,7 +36,7 @@ GEM
     concurrent-ruby (1.2.2)
     crack (0.4.5)
       rexml
-    debase-ruby_core_source (3.3.1)
+    debase-ruby_core_source (3.3.5)
     debug_inspector (1.1.0)
     diff-lcs (1.5.0)
     docile (1.4.0)

--- a/gemfiles/ruby_3.2_redis_4.gemfile.lock
+++ b/gemfiles/ruby_3.2_redis_4.gemfile.lock
@@ -12,7 +12,7 @@ PATH
   remote: ..
   specs:
     datadog (2.3.0)
-      debase-ruby_core_source (= 3.3.1)
+      debase-ruby_core_source (= 3.3.5)
       libdatadog (~> 12.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
@@ -36,7 +36,7 @@ GEM
     concurrent-ruby (1.2.2)
     crack (0.4.5)
       rexml
-    debase-ruby_core_source (3.3.1)
+    debase-ruby_core_source (3.3.5)
     debug_inspector (1.1.0)
     diff-lcs (1.5.0)
     docile (1.4.0)

--- a/gemfiles/ruby_3.2_redis_5.gemfile.lock
+++ b/gemfiles/ruby_3.2_redis_5.gemfile.lock
@@ -12,7 +12,7 @@ PATH
   remote: ..
   specs:
     datadog (2.3.0)
-      debase-ruby_core_source (= 3.3.1)
+      debase-ruby_core_source (= 3.3.5)
       libdatadog (~> 12.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
@@ -37,7 +37,7 @@ GEM
     connection_pool (2.3.0)
     crack (0.4.5)
       rexml
-    debase-ruby_core_source (3.3.1)
+    debase-ruby_core_source (3.3.5)
     debug_inspector (1.1.0)
     diff-lcs (1.5.0)
     docile (1.4.0)

--- a/gemfiles/ruby_3.2_relational_db.gemfile.lock
+++ b/gemfiles/ruby_3.2_relational_db.gemfile.lock
@@ -12,7 +12,7 @@ PATH
   remote: ..
   specs:
     datadog (2.3.0)
-      debase-ruby_core_source (= 3.3.1)
+      debase-ruby_core_source (= 3.3.5)
       libdatadog (~> 12.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
@@ -47,7 +47,7 @@ GEM
     concurrent-ruby (1.2.2)
     crack (0.4.5)
       rexml
-    debase-ruby_core_source (3.3.1)
+    debase-ruby_core_source (3.3.5)
     debug_inspector (1.1.0)
     delayed_job (4.1.11)
       activesupport (>= 3.0, < 8.0)

--- a/gemfiles/ruby_3.2_resque2_redis3.gemfile.lock
+++ b/gemfiles/ruby_3.2_resque2_redis3.gemfile.lock
@@ -12,7 +12,7 @@ PATH
   remote: ..
   specs:
     datadog (2.3.0)
-      debase-ruby_core_source (= 3.3.1)
+      debase-ruby_core_source (= 3.3.5)
       libdatadog (~> 12.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
@@ -36,7 +36,7 @@ GEM
     concurrent-ruby (1.2.2)
     crack (0.4.5)
       rexml
-    debase-ruby_core_source (3.3.1)
+    debase-ruby_core_source (3.3.5)
     debug_inspector (1.1.0)
     diff-lcs (1.5.0)
     docile (1.4.0)

--- a/gemfiles/ruby_3.2_resque2_redis4.gemfile.lock
+++ b/gemfiles/ruby_3.2_resque2_redis4.gemfile.lock
@@ -12,7 +12,7 @@ PATH
   remote: ..
   specs:
     datadog (2.3.0)
-      debase-ruby_core_source (= 3.3.1)
+      debase-ruby_core_source (= 3.3.5)
       libdatadog (~> 12.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
@@ -37,7 +37,7 @@ GEM
     connection_pool (2.3.0)
     crack (0.4.5)
       rexml
-    debase-ruby_core_source (3.3.1)
+    debase-ruby_core_source (3.3.5)
     debug_inspector (1.1.0)
     diff-lcs (1.5.0)
     docile (1.4.0)

--- a/gemfiles/ruby_3.2_sinatra_2.gemfile.lock
+++ b/gemfiles/ruby_3.2_sinatra_2.gemfile.lock
@@ -12,7 +12,7 @@ PATH
   remote: ..
   specs:
     datadog (2.3.0)
-      debase-ruby_core_source (= 3.3.1)
+      debase-ruby_core_source (= 3.3.5)
       libdatadog (~> 12.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
@@ -39,7 +39,7 @@ GEM
     crack (1.0.0)
       bigdecimal
       rexml
-    debase-ruby_core_source (3.3.1)
+    debase-ruby_core_source (3.3.5)
     debug_inspector (1.2.0)
     diff-lcs (1.5.1)
     docile (1.4.0)

--- a/gemfiles/ruby_3.2_sinatra_3.gemfile.lock
+++ b/gemfiles/ruby_3.2_sinatra_3.gemfile.lock
@@ -12,7 +12,7 @@ PATH
   remote: ..
   specs:
     datadog (2.3.0)
-      debase-ruby_core_source (= 3.3.1)
+      debase-ruby_core_source (= 3.3.5)
       libdatadog (~> 12.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
@@ -40,7 +40,7 @@ GEM
     crack (1.0.0)
       bigdecimal
       rexml
-    debase-ruby_core_source (3.3.1)
+    debase-ruby_core_source (3.3.5)
     debug_inspector (1.2.0)
     diff-lcs (1.5.1)
     docile (1.4.0)

--- a/gemfiles/ruby_3.2_sinatra_4.gemfile.lock
+++ b/gemfiles/ruby_3.2_sinatra_4.gemfile.lock
@@ -12,7 +12,7 @@ PATH
   remote: ..
   specs:
     datadog (2.3.0)
-      debase-ruby_core_source (= 3.3.1)
+      debase-ruby_core_source (= 3.3.5)
       libdatadog (~> 12.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
@@ -40,7 +40,7 @@ GEM
     crack (1.0.0)
       bigdecimal
       rexml
-    debase-ruby_core_source (3.3.1)
+    debase-ruby_core_source (3.3.5)
     debug_inspector (1.2.0)
     diff-lcs (1.5.1)
     docile (1.4.0)

--- a/gemfiles/ruby_3.2_stripe_10.gemfile.lock
+++ b/gemfiles/ruby_3.2_stripe_10.gemfile.lock
@@ -12,7 +12,7 @@ PATH
   remote: ..
   specs:
     datadog (2.3.0)
-      debase-ruby_core_source (= 3.3.1)
+      debase-ruby_core_source (= 3.3.5)
       libdatadog (~> 12.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
@@ -39,7 +39,7 @@ GEM
     crack (1.0.0)
       bigdecimal
       rexml
-    debase-ruby_core_source (3.3.1)
+    debase-ruby_core_source (3.3.5)
     debug_inspector (1.2.0)
     diff-lcs (1.5.1)
     docile (1.4.1)

--- a/gemfiles/ruby_3.2_stripe_11.gemfile.lock
+++ b/gemfiles/ruby_3.2_stripe_11.gemfile.lock
@@ -12,7 +12,7 @@ PATH
   remote: ..
   specs:
     datadog (2.3.0)
-      debase-ruby_core_source (= 3.3.1)
+      debase-ruby_core_source (= 3.3.5)
       libdatadog (~> 12.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
@@ -39,7 +39,7 @@ GEM
     crack (1.0.0)
       bigdecimal
       rexml
-    debase-ruby_core_source (3.3.1)
+    debase-ruby_core_source (3.3.5)
     debug_inspector (1.2.0)
     diff-lcs (1.5.1)
     docile (1.4.1)

--- a/gemfiles/ruby_3.2_stripe_12.gemfile.lock
+++ b/gemfiles/ruby_3.2_stripe_12.gemfile.lock
@@ -12,7 +12,7 @@ PATH
   remote: ..
   specs:
     datadog (2.3.0)
-      debase-ruby_core_source (= 3.3.1)
+      debase-ruby_core_source (= 3.3.5)
       libdatadog (~> 12.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
@@ -39,7 +39,7 @@ GEM
     crack (1.0.0)
       bigdecimal
       rexml
-    debase-ruby_core_source (3.3.1)
+    debase-ruby_core_source (3.3.5)
     debug_inspector (1.2.0)
     diff-lcs (1.5.1)
     docile (1.4.1)

--- a/gemfiles/ruby_3.2_stripe_7.gemfile.lock
+++ b/gemfiles/ruby_3.2_stripe_7.gemfile.lock
@@ -12,7 +12,7 @@ PATH
   remote: ..
   specs:
     datadog (2.3.0)
-      debase-ruby_core_source (= 3.3.1)
+      debase-ruby_core_source (= 3.3.5)
       libdatadog (~> 12.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
@@ -39,7 +39,7 @@ GEM
     crack (1.0.0)
       bigdecimal
       rexml
-    debase-ruby_core_source (3.3.1)
+    debase-ruby_core_source (3.3.5)
     debug_inspector (1.2.0)
     diff-lcs (1.5.1)
     docile (1.4.1)

--- a/gemfiles/ruby_3.2_stripe_8.gemfile.lock
+++ b/gemfiles/ruby_3.2_stripe_8.gemfile.lock
@@ -12,7 +12,7 @@ PATH
   remote: ..
   specs:
     datadog (2.3.0)
-      debase-ruby_core_source (= 3.3.1)
+      debase-ruby_core_source (= 3.3.5)
       libdatadog (~> 12.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
@@ -39,7 +39,7 @@ GEM
     crack (1.0.0)
       bigdecimal
       rexml
-    debase-ruby_core_source (3.3.1)
+    debase-ruby_core_source (3.3.5)
     debug_inspector (1.2.0)
     diff-lcs (1.5.1)
     docile (1.4.1)

--- a/gemfiles/ruby_3.2_stripe_9.gemfile.lock
+++ b/gemfiles/ruby_3.2_stripe_9.gemfile.lock
@@ -12,7 +12,7 @@ PATH
   remote: ..
   specs:
     datadog (2.3.0)
-      debase-ruby_core_source (= 3.3.1)
+      debase-ruby_core_source (= 3.3.5)
       libdatadog (~> 12.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
@@ -39,7 +39,7 @@ GEM
     crack (1.0.0)
       bigdecimal
       rexml
-    debase-ruby_core_source (3.3.1)
+    debase-ruby_core_source (3.3.5)
     debug_inspector (1.2.0)
     diff-lcs (1.5.1)
     docile (1.4.1)

--- a/gemfiles/ruby_3.2_stripe_latest.gemfile.lock
+++ b/gemfiles/ruby_3.2_stripe_latest.gemfile.lock
@@ -12,7 +12,7 @@ PATH
   remote: ..
   specs:
     datadog (2.3.0)
-      debase-ruby_core_source (= 3.3.1)
+      debase-ruby_core_source (= 3.3.5)
       libdatadog (~> 12.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
@@ -39,7 +39,7 @@ GEM
     crack (1.0.0)
       bigdecimal
       rexml
-    debase-ruby_core_source (3.3.1)
+    debase-ruby_core_source (3.3.5)
     debug_inspector (1.2.0)
     diff-lcs (1.5.1)
     docile (1.4.1)

--- a/gemfiles/ruby_3.2_stripe_min.gemfile.lock
+++ b/gemfiles/ruby_3.2_stripe_min.gemfile.lock
@@ -12,7 +12,7 @@ PATH
   remote: ..
   specs:
     datadog (2.3.0)
-      debase-ruby_core_source (= 3.3.1)
+      debase-ruby_core_source (= 3.3.5)
       libdatadog (~> 12.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
@@ -39,7 +39,7 @@ GEM
     crack (1.0.0)
       bigdecimal
       rexml
-    debase-ruby_core_source (3.3.1)
+    debase-ruby_core_source (3.3.5)
     debug_inspector (1.2.0)
     diff-lcs (1.5.1)
     docile (1.4.1)

--- a/gemfiles/ruby_3.3_activesupport.gemfile.lock
+++ b/gemfiles/ruby_3.3_activesupport.gemfile.lock
@@ -12,7 +12,7 @@ PATH
   remote: ..
   specs:
     datadog (2.3.0)
-      debase-ruby_core_source (= 3.3.1)
+      debase-ruby_core_source (= 3.3.5)
       libdatadog (~> 12.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
@@ -65,7 +65,7 @@ GEM
     crack (0.4.5)
       rexml
     crass (1.0.6)
-    debase-ruby_core_source (3.3.1)
+    debase-ruby_core_source (3.3.5)
     debug_inspector (1.1.0)
     diff-lcs (1.5.0)
     digest-crc (0.6.5)

--- a/gemfiles/ruby_3.3_aws.gemfile.lock
+++ b/gemfiles/ruby_3.3_aws.gemfile.lock
@@ -12,7 +12,7 @@ PATH
   remote: ..
   specs:
     datadog (2.3.0)
-      debase-ruby_core_source (= 3.3.1)
+      debase-ruby_core_source (= 3.3.5)
       libdatadog (~> 12.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
@@ -1457,7 +1457,7 @@ GEM
     concurrent-ruby (1.2.2)
     crack (0.4.5)
       rexml
-    debase-ruby_core_source (3.3.1)
+    debase-ruby_core_source (3.3.5)
     debug_inspector (1.1.0)
     diff-lcs (1.5.0)
     docile (1.4.0)

--- a/gemfiles/ruby_3.3_contrib.gemfile.lock
+++ b/gemfiles/ruby_3.3_contrib.gemfile.lock
@@ -12,7 +12,7 @@ PATH
   remote: ..
   specs:
     datadog (2.3.0)
-      debase-ruby_core_source (= 3.3.1)
+      debase-ruby_core_source (= 3.3.5)
       libdatadog (~> 12.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
@@ -43,7 +43,7 @@ GEM
     crack (0.4.5)
       rexml
     dalli (3.2.4)
-    debase-ruby_core_source (3.3.1)
+    debase-ruby_core_source (3.3.5)
     debug_inspector (1.1.0)
     diff-lcs (1.5.0)
     docile (1.4.0)

--- a/gemfiles/ruby_3.3_contrib_old.gemfile.lock
+++ b/gemfiles/ruby_3.3_contrib_old.gemfile.lock
@@ -12,7 +12,7 @@ PATH
   remote: ..
   specs:
     datadog (2.3.0)
-      debase-ruby_core_source (= 3.3.1)
+      debase-ruby_core_source (= 3.3.5)
       libdatadog (~> 12.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
@@ -41,7 +41,7 @@ GEM
       rexml
     daemons (1.4.1)
     dalli (2.7.11)
-    debase-ruby_core_source (3.3.1)
+    debase-ruby_core_source (3.3.5)
     debug_inspector (1.1.0)
     diff-lcs (1.5.0)
     docile (1.4.0)

--- a/gemfiles/ruby_3.3_core_old.gemfile.lock
+++ b/gemfiles/ruby_3.3_core_old.gemfile.lock
@@ -12,7 +12,7 @@ PATH
   remote: ..
   specs:
     datadog (2.3.0)
-      debase-ruby_core_source (= 3.3.1)
+      debase-ruby_core_source (= 3.3.5)
       libdatadog (~> 12.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
@@ -36,7 +36,7 @@ GEM
     concurrent-ruby (1.2.2)
     crack (0.4.5)
       rexml
-    debase-ruby_core_source (3.3.1)
+    debase-ruby_core_source (3.3.5)
     debug_inspector (1.1.0)
     diff-lcs (1.5.0)
     docile (1.4.0)

--- a/gemfiles/ruby_3.3_elasticsearch_7.gemfile.lock
+++ b/gemfiles/ruby_3.3_elasticsearch_7.gemfile.lock
@@ -12,7 +12,7 @@ PATH
   remote: ..
   specs:
     datadog (2.3.0)
-      debase-ruby_core_source (= 3.3.1)
+      debase-ruby_core_source (= 3.3.5)
       libdatadog (~> 12.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
@@ -37,7 +37,7 @@ GEM
     concurrent-ruby (1.2.2)
     crack (0.4.5)
       rexml
-    debase-ruby_core_source (3.3.1)
+    debase-ruby_core_source (3.3.5)
     debug_inspector (1.1.0)
     diff-lcs (1.5.0)
     docile (1.4.0)

--- a/gemfiles/ruby_3.3_elasticsearch_8.gemfile.lock
+++ b/gemfiles/ruby_3.3_elasticsearch_8.gemfile.lock
@@ -12,7 +12,7 @@ PATH
   remote: ..
   specs:
     datadog (2.3.0)
-      debase-ruby_core_source (= 3.3.1)
+      debase-ruby_core_source (= 3.3.5)
       libdatadog (~> 12.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
@@ -38,7 +38,7 @@ GEM
     concurrent-ruby (1.2.2)
     crack (0.4.5)
       rexml
-    debase-ruby_core_source (3.3.1)
+    debase-ruby_core_source (3.3.5)
     debug_inspector (1.1.0)
     diff-lcs (1.5.0)
     docile (1.4.0)

--- a/gemfiles/ruby_3.3_elasticsearch_latest.gemfile.lock
+++ b/gemfiles/ruby_3.3_elasticsearch_latest.gemfile.lock
@@ -12,7 +12,7 @@ PATH
   remote: ..
   specs:
     datadog (2.3.0)
-      debase-ruby_core_source (= 3.3.1)
+      debase-ruby_core_source (= 3.3.5)
       libdatadog (~> 12.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
@@ -39,7 +39,7 @@ GEM
     crack (1.0.0)
       bigdecimal
       rexml
-    debase-ruby_core_source (3.3.1)
+    debase-ruby_core_source (3.3.5)
     debug_inspector (1.2.0)
     diff-lcs (1.5.1)
     docile (1.4.1)

--- a/gemfiles/ruby_3.3_graphql_1.13.gemfile.lock
+++ b/gemfiles/ruby_3.3_graphql_1.13.gemfile.lock
@@ -12,7 +12,7 @@ PATH
   remote: ..
   specs:
     datadog (2.3.0)
-      debase-ruby_core_source (= 3.3.1)
+      debase-ruby_core_source (= 3.3.5)
       libdatadog (~> 12.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
@@ -100,7 +100,7 @@ GEM
       rexml
     crass (1.0.6)
     date (3.3.4)
-    debase-ruby_core_source (3.3.1)
+    debase-ruby_core_source (3.3.5)
     debug_inspector (1.2.0)
     diff-lcs (1.5.0)
     docile (1.4.0)

--- a/gemfiles/ruby_3.3_graphql_2.0.gemfile.lock
+++ b/gemfiles/ruby_3.3_graphql_2.0.gemfile.lock
@@ -12,7 +12,7 @@ PATH
   remote: ..
   specs:
     datadog (2.3.0)
-      debase-ruby_core_source (= 3.3.1)
+      debase-ruby_core_source (= 3.3.5)
       libdatadog (~> 12.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
@@ -100,7 +100,7 @@ GEM
       rexml
     crass (1.0.6)
     date (3.3.4)
-    debase-ruby_core_source (3.3.1)
+    debase-ruby_core_source (3.3.5)
     debug_inspector (1.2.0)
     diff-lcs (1.5.0)
     docile (1.4.0)

--- a/gemfiles/ruby_3.3_graphql_2.1.gemfile.lock
+++ b/gemfiles/ruby_3.3_graphql_2.1.gemfile.lock
@@ -12,7 +12,7 @@ PATH
   remote: ..
   specs:
     datadog (2.3.0)
-      debase-ruby_core_source (= 3.3.1)
+      debase-ruby_core_source (= 3.3.5)
       libdatadog (~> 12.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
@@ -100,7 +100,7 @@ GEM
       rexml
     crass (1.0.6)
     date (3.3.4)
-    debase-ruby_core_source (3.3.1)
+    debase-ruby_core_source (3.3.5)
     debug_inspector (1.2.0)
     diff-lcs (1.5.0)
     docile (1.4.0)

--- a/gemfiles/ruby_3.3_graphql_2.2.gemfile.lock
+++ b/gemfiles/ruby_3.3_graphql_2.2.gemfile.lock
@@ -12,7 +12,7 @@ PATH
   remote: ..
   specs:
     datadog (2.3.0)
-      debase-ruby_core_source (= 3.3.1)
+      debase-ruby_core_source (= 3.3.5)
       libdatadog (~> 12.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
@@ -100,7 +100,7 @@ GEM
       rexml
     crass (1.0.6)
     date (3.3.4)
-    debase-ruby_core_source (3.3.1)
+    debase-ruby_core_source (3.3.5)
     debug_inspector (1.2.0)
     diff-lcs (1.5.0)
     docile (1.4.0)

--- a/gemfiles/ruby_3.3_graphql_2.3.gemfile.lock
+++ b/gemfiles/ruby_3.3_graphql_2.3.gemfile.lock
@@ -12,7 +12,7 @@ PATH
   remote: ..
   specs:
     datadog (2.3.0)
-      debase-ruby_core_source (= 3.3.1)
+      debase-ruby_core_source (= 3.3.5)
       libdatadog (~> 12.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
@@ -102,7 +102,7 @@ GEM
       rexml
     crass (1.0.6)
     date (3.3.4)
-    debase-ruby_core_source (3.3.1)
+    debase-ruby_core_source (3.3.5)
     debug_inspector (1.2.0)
     diff-lcs (1.5.1)
     docile (1.4.0)

--- a/gemfiles/ruby_3.3_http.gemfile.lock
+++ b/gemfiles/ruby_3.3_http.gemfile.lock
@@ -12,7 +12,7 @@ PATH
   remote: ..
   specs:
     datadog (2.3.0)
-      debase-ruby_core_source (= 3.3.1)
+      debase-ruby_core_source (= 3.3.5)
       libdatadog (~> 12.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
@@ -36,7 +36,7 @@ GEM
     concurrent-ruby (1.2.2)
     crack (0.4.5)
       rexml
-    debase-ruby_core_source (3.3.1)
+    debase-ruby_core_source (3.3.5)
     debug_inspector (1.1.0)
     diff-lcs (1.5.0)
     docile (1.4.0)

--- a/gemfiles/ruby_3.3_opensearch_2.gemfile.lock
+++ b/gemfiles/ruby_3.3_opensearch_2.gemfile.lock
@@ -12,7 +12,7 @@ PATH
   remote: ..
   specs:
     datadog (2.3.0)
-      debase-ruby_core_source (= 3.3.1)
+      debase-ruby_core_source (= 3.3.5)
       libdatadog (~> 12.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
@@ -38,7 +38,7 @@ GEM
     concurrent-ruby (1.2.2)
     crack (0.4.5)
       rexml
-    debase-ruby_core_source (3.3.1)
+    debase-ruby_core_source (3.3.5)
     debug_inspector (1.1.0)
     diff-lcs (1.5.0)
     docile (1.4.0)

--- a/gemfiles/ruby_3.3_opensearch_3.gemfile.lock
+++ b/gemfiles/ruby_3.3_opensearch_3.gemfile.lock
@@ -12,7 +12,7 @@ PATH
   remote: ..
   specs:
     datadog (2.3.0)
-      debase-ruby_core_source (= 3.3.1)
+      debase-ruby_core_source (= 3.3.5)
       libdatadog (~> 12.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
@@ -38,7 +38,7 @@ GEM
     concurrent-ruby (1.2.2)
     crack (0.4.5)
       rexml
-    debase-ruby_core_source (3.3.1)
+    debase-ruby_core_source (3.3.5)
     debug_inspector (1.1.0)
     diff-lcs (1.5.0)
     docile (1.4.0)

--- a/gemfiles/ruby_3.3_opensearch_latest.gemfile.lock
+++ b/gemfiles/ruby_3.3_opensearch_latest.gemfile.lock
@@ -12,7 +12,7 @@ PATH
   remote: ..
   specs:
     datadog (2.3.0)
-      debase-ruby_core_source (= 3.3.1)
+      debase-ruby_core_source (= 3.3.5)
       libdatadog (~> 12.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
@@ -39,7 +39,7 @@ GEM
     crack (1.0.0)
       bigdecimal
       rexml
-    debase-ruby_core_source (3.3.1)
+    debase-ruby_core_source (3.3.5)
     debug_inspector (1.2.0)
     diff-lcs (1.5.1)
     docile (1.4.1)

--- a/gemfiles/ruby_3.3_opentelemetry.gemfile.lock
+++ b/gemfiles/ruby_3.3_opentelemetry.gemfile.lock
@@ -12,7 +12,7 @@ PATH
   remote: ..
   specs:
     datadog (2.3.0)
-      debase-ruby_core_source (= 3.3.1)
+      debase-ruby_core_source (= 3.3.5)
       libdatadog (~> 12.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
@@ -36,7 +36,7 @@ GEM
     concurrent-ruby (1.2.2)
     crack (0.4.5)
       rexml
-    debase-ruby_core_source (3.3.1)
+    debase-ruby_core_source (3.3.5)
     debug_inspector (1.1.0)
     diff-lcs (1.5.0)
     docile (1.4.0)

--- a/gemfiles/ruby_3.3_rack_2.gemfile.lock
+++ b/gemfiles/ruby_3.3_rack_2.gemfile.lock
@@ -12,7 +12,7 @@ PATH
   remote: ..
   specs:
     datadog (2.3.0)
-      debase-ruby_core_source (= 3.3.1)
+      debase-ruby_core_source (= 3.3.5)
       libdatadog (~> 12.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
@@ -36,7 +36,7 @@ GEM
     concurrent-ruby (1.2.2)
     crack (0.4.5)
       rexml
-    debase-ruby_core_source (3.3.1)
+    debase-ruby_core_source (3.3.5)
     debug_inspector (1.1.0)
     diff-lcs (1.5.0)
     docile (1.4.0)

--- a/gemfiles/ruby_3.3_rack_3.gemfile.lock
+++ b/gemfiles/ruby_3.3_rack_3.gemfile.lock
@@ -12,7 +12,7 @@ PATH
   remote: ..
   specs:
     datadog (2.3.0)
-      debase-ruby_core_source (= 3.3.1)
+      debase-ruby_core_source (= 3.3.5)
       libdatadog (~> 12.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
@@ -36,7 +36,7 @@ GEM
     concurrent-ruby (1.2.2)
     crack (0.4.5)
       rexml
-    debase-ruby_core_source (3.3.1)
+    debase-ruby_core_source (3.3.5)
     debug_inspector (1.1.0)
     diff-lcs (1.5.0)
     docile (1.4.0)

--- a/gemfiles/ruby_3.3_rack_latest.gemfile.lock
+++ b/gemfiles/ruby_3.3_rack_latest.gemfile.lock
@@ -12,7 +12,7 @@ PATH
   remote: ..
   specs:
     datadog (2.3.0)
-      debase-ruby_core_source (= 3.3.1)
+      debase-ruby_core_source (= 3.3.5)
       libdatadog (~> 12.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
@@ -39,7 +39,7 @@ GEM
     crack (1.0.0)
       bigdecimal
       rexml
-    debase-ruby_core_source (3.3.1)
+    debase-ruby_core_source (3.3.5)
     debug_inspector (1.2.0)
     diff-lcs (1.5.1)
     docile (1.4.1)

--- a/gemfiles/ruby_3.3_rails61_mysql2.gemfile.lock
+++ b/gemfiles/ruby_3.3_rails61_mysql2.gemfile.lock
@@ -12,7 +12,7 @@ PATH
   remote: ..
   specs:
     datadog (2.3.0)
-      debase-ruby_core_source (= 3.3.1)
+      debase-ruby_core_source (= 3.3.5)
       libdatadog (~> 12.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
@@ -98,7 +98,7 @@ GEM
       rexml
     crass (1.0.6)
     date (3.3.3)
-    debase-ruby_core_source (3.3.1)
+    debase-ruby_core_source (3.3.5)
     debug_inspector (1.1.0)
     diff-lcs (1.5.0)
     docile (1.4.0)

--- a/gemfiles/ruby_3.3_rails61_postgres.gemfile.lock
+++ b/gemfiles/ruby_3.3_rails61_postgres.gemfile.lock
@@ -12,7 +12,7 @@ PATH
   remote: ..
   specs:
     datadog (2.3.0)
-      debase-ruby_core_source (= 3.3.1)
+      debase-ruby_core_source (= 3.3.5)
       libdatadog (~> 12.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
@@ -98,7 +98,7 @@ GEM
       rexml
     crass (1.0.6)
     date (3.3.3)
-    debase-ruby_core_source (3.3.1)
+    debase-ruby_core_source (3.3.5)
     debug_inspector (1.1.0)
     diff-lcs (1.5.0)
     docile (1.4.0)

--- a/gemfiles/ruby_3.3_rails61_postgres_redis.gemfile.lock
+++ b/gemfiles/ruby_3.3_rails61_postgres_redis.gemfile.lock
@@ -12,7 +12,7 @@ PATH
   remote: ..
   specs:
     datadog (2.3.0)
-      debase-ruby_core_source (= 3.3.1)
+      debase-ruby_core_source (= 3.3.5)
       libdatadog (~> 12.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
@@ -98,7 +98,7 @@ GEM
       rexml
     crass (1.0.6)
     date (3.3.3)
-    debase-ruby_core_source (3.3.1)
+    debase-ruby_core_source (3.3.5)
     debug_inspector (1.1.0)
     diff-lcs (1.5.0)
     docile (1.4.0)

--- a/gemfiles/ruby_3.3_rails61_postgres_sidekiq.gemfile.lock
+++ b/gemfiles/ruby_3.3_rails61_postgres_sidekiq.gemfile.lock
@@ -12,7 +12,7 @@ PATH
   remote: ..
   specs:
     datadog (2.3.0)
-      debase-ruby_core_source (= 3.3.1)
+      debase-ruby_core_source (= 3.3.5)
       libdatadog (~> 12.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
@@ -99,7 +99,7 @@ GEM
       rexml
     crass (1.0.6)
     date (3.3.3)
-    debase-ruby_core_source (3.3.1)
+    debase-ruby_core_source (3.3.5)
     debug_inspector (1.1.0)
     diff-lcs (1.5.0)
     docile (1.4.0)

--- a/gemfiles/ruby_3.3_rails61_semantic_logger.gemfile.lock
+++ b/gemfiles/ruby_3.3_rails61_semantic_logger.gemfile.lock
@@ -12,7 +12,7 @@ PATH
   remote: ..
   specs:
     datadog (2.3.0)
-      debase-ruby_core_source (= 3.3.1)
+      debase-ruby_core_source (= 3.3.5)
       libdatadog (~> 12.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
@@ -98,7 +98,7 @@ GEM
       rexml
     crass (1.0.6)
     date (3.3.3)
-    debase-ruby_core_source (3.3.1)
+    debase-ruby_core_source (3.3.5)
     debug_inspector (1.1.0)
     diff-lcs (1.5.0)
     docile (1.4.0)

--- a/gemfiles/ruby_3.3_rails61_trilogy.gemfile.lock
+++ b/gemfiles/ruby_3.3_rails61_trilogy.gemfile.lock
@@ -12,7 +12,7 @@ PATH
   remote: ..
   specs:
     datadog (2.3.0)
-      debase-ruby_core_source (= 3.3.1)
+      debase-ruby_core_source (= 3.3.5)
       libdatadog (~> 12.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
@@ -102,7 +102,7 @@ GEM
       rexml
     crass (1.0.6)
     date (3.3.4)
-    debase-ruby_core_source (3.3.1)
+    debase-ruby_core_source (3.3.5)
     debug_inspector (1.1.0)
     diff-lcs (1.5.0)
     docile (1.4.0)

--- a/gemfiles/ruby_3.3_rails7.gemfile.lock
+++ b/gemfiles/ruby_3.3_rails7.gemfile.lock
@@ -12,7 +12,7 @@ PATH
   remote: ..
   specs:
     datadog (2.3.0)
-      debase-ruby_core_source (= 3.3.1)
+      debase-ruby_core_source (= 3.3.5)
       libdatadog (~> 12.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
@@ -107,7 +107,7 @@ GEM
       rexml
     crass (1.0.6)
     date (3.3.4)
-    debase-ruby_core_source (3.3.1)
+    debase-ruby_core_source (3.3.5)
     debug_inspector (1.2.0)
     diff-lcs (1.5.1)
     docile (1.4.1)

--- a/gemfiles/ruby_3.3_rails71.gemfile.lock
+++ b/gemfiles/ruby_3.3_rails71.gemfile.lock
@@ -12,7 +12,7 @@ PATH
   remote: ..
   specs:
     datadog (2.3.0)
-      debase-ruby_core_source (= 3.3.1)
+      debase-ruby_core_source (= 3.3.5)
       libdatadog (~> 12.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
@@ -118,7 +118,7 @@ GEM
       rexml
     crass (1.0.6)
     date (3.3.4)
-    debase-ruby_core_source (3.3.1)
+    debase-ruby_core_source (3.3.5)
     debug_inspector (1.2.0)
     diff-lcs (1.5.1)
     docile (1.4.1)

--- a/gemfiles/ruby_3.3_redis_3.gemfile.lock
+++ b/gemfiles/ruby_3.3_redis_3.gemfile.lock
@@ -12,7 +12,7 @@ PATH
   remote: ..
   specs:
     datadog (2.3.0)
-      debase-ruby_core_source (= 3.3.1)
+      debase-ruby_core_source (= 3.3.5)
       libdatadog (~> 12.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
@@ -36,7 +36,7 @@ GEM
     concurrent-ruby (1.2.2)
     crack (0.4.5)
       rexml
-    debase-ruby_core_source (3.3.1)
+    debase-ruby_core_source (3.3.5)
     debug_inspector (1.1.0)
     diff-lcs (1.5.0)
     docile (1.4.0)

--- a/gemfiles/ruby_3.3_redis_4.gemfile.lock
+++ b/gemfiles/ruby_3.3_redis_4.gemfile.lock
@@ -12,7 +12,7 @@ PATH
   remote: ..
   specs:
     datadog (2.3.0)
-      debase-ruby_core_source (= 3.3.1)
+      debase-ruby_core_source (= 3.3.5)
       libdatadog (~> 12.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
@@ -36,7 +36,7 @@ GEM
     concurrent-ruby (1.2.2)
     crack (0.4.5)
       rexml
-    debase-ruby_core_source (3.3.1)
+    debase-ruby_core_source (3.3.5)
     debug_inspector (1.1.0)
     diff-lcs (1.5.0)
     docile (1.4.0)

--- a/gemfiles/ruby_3.3_redis_5.gemfile.lock
+++ b/gemfiles/ruby_3.3_redis_5.gemfile.lock
@@ -12,7 +12,7 @@ PATH
   remote: ..
   specs:
     datadog (2.3.0)
-      debase-ruby_core_source (= 3.3.1)
+      debase-ruby_core_source (= 3.3.5)
       libdatadog (~> 12.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
@@ -37,7 +37,7 @@ GEM
     connection_pool (2.4.0)
     crack (0.4.5)
       rexml
-    debase-ruby_core_source (3.3.1)
+    debase-ruby_core_source (3.3.5)
     debug_inspector (1.1.0)
     diff-lcs (1.5.0)
     docile (1.4.0)

--- a/gemfiles/ruby_3.3_relational_db.gemfile.lock
+++ b/gemfiles/ruby_3.3_relational_db.gemfile.lock
@@ -12,7 +12,7 @@ PATH
   remote: ..
   specs:
     datadog (2.3.0)
-      debase-ruby_core_source (= 3.3.1)
+      debase-ruby_core_source (= 3.3.5)
       libdatadog (~> 12.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
@@ -47,7 +47,7 @@ GEM
     concurrent-ruby (1.2.2)
     crack (0.4.5)
       rexml
-    debase-ruby_core_source (3.3.1)
+    debase-ruby_core_source (3.3.5)
     debug_inspector (1.1.0)
     delayed_job (4.1.11)
       activesupport (>= 3.0, < 8.0)

--- a/gemfiles/ruby_3.3_resque2_redis3.gemfile.lock
+++ b/gemfiles/ruby_3.3_resque2_redis3.gemfile.lock
@@ -12,7 +12,7 @@ PATH
   remote: ..
   specs:
     datadog (2.3.0)
-      debase-ruby_core_source (= 3.3.1)
+      debase-ruby_core_source (= 3.3.5)
       libdatadog (~> 12.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
@@ -36,7 +36,7 @@ GEM
     concurrent-ruby (1.2.2)
     crack (0.4.5)
       rexml
-    debase-ruby_core_source (3.3.1)
+    debase-ruby_core_source (3.3.5)
     debug_inspector (1.1.0)
     diff-lcs (1.5.0)
     docile (1.4.0)

--- a/gemfiles/ruby_3.3_resque2_redis4.gemfile.lock
+++ b/gemfiles/ruby_3.3_resque2_redis4.gemfile.lock
@@ -12,7 +12,7 @@ PATH
   remote: ..
   specs:
     datadog (2.3.0)
-      debase-ruby_core_source (= 3.3.1)
+      debase-ruby_core_source (= 3.3.5)
       libdatadog (~> 12.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
@@ -37,7 +37,7 @@ GEM
     connection_pool (2.4.0)
     crack (0.4.5)
       rexml
-    debase-ruby_core_source (3.3.1)
+    debase-ruby_core_source (3.3.5)
     debug_inspector (1.1.0)
     diff-lcs (1.5.0)
     docile (1.4.0)

--- a/gemfiles/ruby_3.3_sinatra_2.gemfile.lock
+++ b/gemfiles/ruby_3.3_sinatra_2.gemfile.lock
@@ -12,7 +12,7 @@ PATH
   remote: ..
   specs:
     datadog (2.3.0)
-      debase-ruby_core_source (= 3.3.1)
+      debase-ruby_core_source (= 3.3.5)
       libdatadog (~> 12.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
@@ -39,7 +39,7 @@ GEM
     crack (1.0.0)
       bigdecimal
       rexml
-    debase-ruby_core_source (3.3.1)
+    debase-ruby_core_source (3.3.5)
     debug_inspector (1.2.0)
     diff-lcs (1.5.1)
     docile (1.4.0)

--- a/gemfiles/ruby_3.3_sinatra_3.gemfile.lock
+++ b/gemfiles/ruby_3.3_sinatra_3.gemfile.lock
@@ -12,7 +12,7 @@ PATH
   remote: ..
   specs:
     datadog (2.3.0)
-      debase-ruby_core_source (= 3.3.1)
+      debase-ruby_core_source (= 3.3.5)
       libdatadog (~> 12.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
@@ -40,7 +40,7 @@ GEM
     crack (1.0.0)
       bigdecimal
       rexml
-    debase-ruby_core_source (3.3.1)
+    debase-ruby_core_source (3.3.5)
     debug_inspector (1.2.0)
     diff-lcs (1.5.1)
     docile (1.4.0)

--- a/gemfiles/ruby_3.3_sinatra_4.gemfile.lock
+++ b/gemfiles/ruby_3.3_sinatra_4.gemfile.lock
@@ -12,7 +12,7 @@ PATH
   remote: ..
   specs:
     datadog (2.3.0)
-      debase-ruby_core_source (= 3.3.1)
+      debase-ruby_core_source (= 3.3.5)
       libdatadog (~> 12.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
@@ -40,7 +40,7 @@ GEM
     crack (1.0.0)
       bigdecimal
       rexml
-    debase-ruby_core_source (3.3.1)
+    debase-ruby_core_source (3.3.5)
     debug_inspector (1.2.0)
     diff-lcs (1.5.1)
     docile (1.4.0)

--- a/gemfiles/ruby_3.3_stripe_10.gemfile.lock
+++ b/gemfiles/ruby_3.3_stripe_10.gemfile.lock
@@ -12,7 +12,7 @@ PATH
   remote: ..
   specs:
     datadog (2.3.0)
-      debase-ruby_core_source (= 3.3.1)
+      debase-ruby_core_source (= 3.3.5)
       libdatadog (~> 12.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
@@ -39,7 +39,7 @@ GEM
     crack (1.0.0)
       bigdecimal
       rexml
-    debase-ruby_core_source (3.3.1)
+    debase-ruby_core_source (3.3.5)
     debug_inspector (1.2.0)
     diff-lcs (1.5.1)
     docile (1.4.1)

--- a/gemfiles/ruby_3.3_stripe_11.gemfile.lock
+++ b/gemfiles/ruby_3.3_stripe_11.gemfile.lock
@@ -12,7 +12,7 @@ PATH
   remote: ..
   specs:
     datadog (2.3.0)
-      debase-ruby_core_source (= 3.3.1)
+      debase-ruby_core_source (= 3.3.5)
       libdatadog (~> 12.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
@@ -39,7 +39,7 @@ GEM
     crack (1.0.0)
       bigdecimal
       rexml
-    debase-ruby_core_source (3.3.1)
+    debase-ruby_core_source (3.3.5)
     debug_inspector (1.2.0)
     diff-lcs (1.5.1)
     docile (1.4.1)

--- a/gemfiles/ruby_3.3_stripe_12.gemfile.lock
+++ b/gemfiles/ruby_3.3_stripe_12.gemfile.lock
@@ -12,7 +12,7 @@ PATH
   remote: ..
   specs:
     datadog (2.3.0)
-      debase-ruby_core_source (= 3.3.1)
+      debase-ruby_core_source (= 3.3.5)
       libdatadog (~> 12.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
@@ -39,7 +39,7 @@ GEM
     crack (1.0.0)
       bigdecimal
       rexml
-    debase-ruby_core_source (3.3.1)
+    debase-ruby_core_source (3.3.5)
     debug_inspector (1.2.0)
     diff-lcs (1.5.1)
     docile (1.4.1)

--- a/gemfiles/ruby_3.3_stripe_7.gemfile.lock
+++ b/gemfiles/ruby_3.3_stripe_7.gemfile.lock
@@ -12,7 +12,7 @@ PATH
   remote: ..
   specs:
     datadog (2.3.0)
-      debase-ruby_core_source (= 3.3.1)
+      debase-ruby_core_source (= 3.3.5)
       libdatadog (~> 12.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
@@ -39,7 +39,7 @@ GEM
     crack (1.0.0)
       bigdecimal
       rexml
-    debase-ruby_core_source (3.3.1)
+    debase-ruby_core_source (3.3.5)
     debug_inspector (1.2.0)
     diff-lcs (1.5.1)
     docile (1.4.1)

--- a/gemfiles/ruby_3.3_stripe_8.gemfile.lock
+++ b/gemfiles/ruby_3.3_stripe_8.gemfile.lock
@@ -12,7 +12,7 @@ PATH
   remote: ..
   specs:
     datadog (2.3.0)
-      debase-ruby_core_source (= 3.3.1)
+      debase-ruby_core_source (= 3.3.5)
       libdatadog (~> 12.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
@@ -39,7 +39,7 @@ GEM
     crack (1.0.0)
       bigdecimal
       rexml
-    debase-ruby_core_source (3.3.1)
+    debase-ruby_core_source (3.3.5)
     debug_inspector (1.2.0)
     diff-lcs (1.5.1)
     docile (1.4.1)

--- a/gemfiles/ruby_3.3_stripe_9.gemfile.lock
+++ b/gemfiles/ruby_3.3_stripe_9.gemfile.lock
@@ -12,7 +12,7 @@ PATH
   remote: ..
   specs:
     datadog (2.3.0)
-      debase-ruby_core_source (= 3.3.1)
+      debase-ruby_core_source (= 3.3.5)
       libdatadog (~> 12.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
@@ -39,7 +39,7 @@ GEM
     crack (1.0.0)
       bigdecimal
       rexml
-    debase-ruby_core_source (3.3.1)
+    debase-ruby_core_source (3.3.5)
     debug_inspector (1.2.0)
     diff-lcs (1.5.1)
     docile (1.4.1)

--- a/gemfiles/ruby_3.3_stripe_latest.gemfile.lock
+++ b/gemfiles/ruby_3.3_stripe_latest.gemfile.lock
@@ -12,7 +12,7 @@ PATH
   remote: ..
   specs:
     datadog (2.3.0)
-      debase-ruby_core_source (= 3.3.1)
+      debase-ruby_core_source (= 3.3.5)
       libdatadog (~> 12.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
@@ -39,7 +39,7 @@ GEM
     crack (1.0.0)
       bigdecimal
       rexml
-    debase-ruby_core_source (3.3.1)
+    debase-ruby_core_source (3.3.5)
     debug_inspector (1.2.0)
     diff-lcs (1.5.1)
     docile (1.4.1)

--- a/gemfiles/ruby_3.3_stripe_min.gemfile.lock
+++ b/gemfiles/ruby_3.3_stripe_min.gemfile.lock
@@ -12,7 +12,7 @@ PATH
   remote: ..
   specs:
     datadog (2.3.0)
-      debase-ruby_core_source (= 3.3.1)
+      debase-ruby_core_source (= 3.3.5)
       libdatadog (~> 12.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
@@ -39,7 +39,7 @@ GEM
     crack (1.0.0)
       bigdecimal
       rexml
-    debase-ruby_core_source (3.3.1)
+    debase-ruby_core_source (3.3.5)
     debug_inspector (1.2.0)
     diff-lcs (1.5.1)
     docile (1.4.1)

--- a/gemfiles/ruby_3.4_activesupport.gemfile.lock
+++ b/gemfiles/ruby_3.4_activesupport.gemfile.lock
@@ -19,7 +19,7 @@ PATH
   remote: ..
   specs:
     datadog (2.3.0)
-      debase-ruby_core_source (= 3.3.1)
+      debase-ruby_core_source (= 3.3.5)
       libdatadog (~> 12.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
@@ -85,7 +85,7 @@ GEM
       bigdecimal
       rexml
     crass (1.0.6)
-    debase-ruby_core_source (3.3.1)
+    debase-ruby_core_source (3.3.5)
     debug_inspector (1.2.0)
     diff-lcs (1.5.1)
     digest-crc (0.6.5)

--- a/gemfiles/ruby_3.4_aws.gemfile.lock
+++ b/gemfiles/ruby_3.4_aws.gemfile.lock
@@ -19,7 +19,7 @@ PATH
   remote: ..
   specs:
     datadog (2.3.0)
-      debase-ruby_core_source (= 3.3.1)
+      debase-ruby_core_source (= 3.3.5)
       libdatadog (~> 12.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
@@ -1594,7 +1594,7 @@ GEM
     crack (1.0.0)
       bigdecimal
       rexml
-    debase-ruby_core_source (3.3.1)
+    debase-ruby_core_source (3.3.5)
     debug_inspector (1.2.0)
     diff-lcs (1.5.1)
     docile (1.4.0)

--- a/gemfiles/ruby_3.4_contrib.gemfile.lock
+++ b/gemfiles/ruby_3.4_contrib.gemfile.lock
@@ -19,7 +19,7 @@ PATH
   remote: ..
   specs:
     datadog (2.3.0)
-      debase-ruby_core_source (= 3.3.1)
+      debase-ruby_core_source (= 3.3.5)
       libdatadog (~> 12.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
@@ -54,7 +54,7 @@ GEM
       bigdecimal
       rexml
     dalli (3.2.8)
-    debase-ruby_core_source (3.3.1)
+    debase-ruby_core_source (3.3.5)
     debug_inspector (1.2.0)
     diff-lcs (1.5.1)
     docile (1.4.0)

--- a/gemfiles/ruby_3.4_contrib_old.gemfile.lock
+++ b/gemfiles/ruby_3.4_contrib_old.gemfile.lock
@@ -19,7 +19,7 @@ PATH
   remote: ..
   specs:
     datadog (2.3.0)
-      debase-ruby_core_source (= 3.3.1)
+      debase-ruby_core_source (= 3.3.5)
       libdatadog (~> 12.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
@@ -51,7 +51,7 @@ GEM
       rexml
     daemons (1.4.1)
     dalli (2.7.11)
-    debase-ruby_core_source (3.3.1)
+    debase-ruby_core_source (3.3.5)
     debug_inspector (1.2.0)
     diff-lcs (1.5.1)
     docile (1.4.0)

--- a/gemfiles/ruby_3.4_core_old.gemfile.lock
+++ b/gemfiles/ruby_3.4_core_old.gemfile.lock
@@ -19,7 +19,7 @@ PATH
   remote: ..
   specs:
     datadog (2.3.0)
-      debase-ruby_core_source (= 3.3.1)
+      debase-ruby_core_source (= 3.3.5)
       libdatadog (~> 12.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
@@ -46,7 +46,7 @@ GEM
     crack (1.0.0)
       bigdecimal
       rexml
-    debase-ruby_core_source (3.3.1)
+    debase-ruby_core_source (3.3.5)
     debug_inspector (1.2.0)
     diff-lcs (1.5.1)
     docile (1.4.0)

--- a/gemfiles/ruby_3.4_elasticsearch_7.gemfile.lock
+++ b/gemfiles/ruby_3.4_elasticsearch_7.gemfile.lock
@@ -19,7 +19,7 @@ PATH
   remote: ..
   specs:
     datadog (2.3.0)
-      debase-ruby_core_source (= 3.3.1)
+      debase-ruby_core_source (= 3.3.5)
       libdatadog (~> 12.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
@@ -47,7 +47,7 @@ GEM
     crack (1.0.0)
       bigdecimal
       rexml
-    debase-ruby_core_source (3.3.1)
+    debase-ruby_core_source (3.3.5)
     debug_inspector (1.2.0)
     diff-lcs (1.5.1)
     docile (1.4.0)

--- a/gemfiles/ruby_3.4_elasticsearch_8.gemfile.lock
+++ b/gemfiles/ruby_3.4_elasticsearch_8.gemfile.lock
@@ -19,7 +19,7 @@ PATH
   remote: ..
   specs:
     datadog (2.3.0)
-      debase-ruby_core_source (= 3.3.1)
+      debase-ruby_core_source (= 3.3.5)
       libdatadog (~> 12.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
@@ -46,7 +46,7 @@ GEM
     crack (1.0.0)
       bigdecimal
       rexml
-    debase-ruby_core_source (3.3.1)
+    debase-ruby_core_source (3.3.5)
     debug_inspector (1.2.0)
     diff-lcs (1.5.1)
     docile (1.4.0)

--- a/gemfiles/ruby_3.4_elasticsearch_latest.gemfile.lock
+++ b/gemfiles/ruby_3.4_elasticsearch_latest.gemfile.lock
@@ -19,7 +19,7 @@ PATH
   remote: ..
   specs:
     datadog (2.3.0)
-      debase-ruby_core_source (= 3.3.1)
+      debase-ruby_core_source (= 3.3.5)
       libdatadog (~> 12.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
@@ -46,7 +46,7 @@ GEM
     crack (1.0.0)
       bigdecimal
       rexml
-    debase-ruby_core_source (3.3.1)
+    debase-ruby_core_source (3.3.5)
     debug_inspector (1.2.0)
     diff-lcs (1.5.1)
     docile (1.4.1)

--- a/gemfiles/ruby_3.4_graphql_1.13.gemfile.lock
+++ b/gemfiles/ruby_3.4_graphql_1.13.gemfile.lock
@@ -19,7 +19,7 @@ PATH
   remote: ..
   specs:
     datadog (2.3.0)
-      debase-ruby_core_source (= 3.3.1)
+      debase-ruby_core_source (= 3.3.5)
       libdatadog (~> 12.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
@@ -109,7 +109,7 @@ GEM
       rexml
     crass (1.0.6)
     date (3.3.4)
-    debase-ruby_core_source (3.3.1)
+    debase-ruby_core_source (3.3.5)
     debug_inspector (1.2.0)
     diff-lcs (1.5.1)
     docile (1.4.0)

--- a/gemfiles/ruby_3.4_graphql_2.0.gemfile.lock
+++ b/gemfiles/ruby_3.4_graphql_2.0.gemfile.lock
@@ -19,7 +19,7 @@ PATH
   remote: ..
   specs:
     datadog (2.3.0)
-      debase-ruby_core_source (= 3.3.1)
+      debase-ruby_core_source (= 3.3.5)
       libdatadog (~> 12.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
@@ -109,7 +109,7 @@ GEM
       rexml
     crass (1.0.6)
     date (3.3.4)
-    debase-ruby_core_source (3.3.1)
+    debase-ruby_core_source (3.3.5)
     debug_inspector (1.2.0)
     diff-lcs (1.5.1)
     docile (1.4.0)

--- a/gemfiles/ruby_3.4_graphql_2.1.gemfile.lock
+++ b/gemfiles/ruby_3.4_graphql_2.1.gemfile.lock
@@ -19,7 +19,7 @@ PATH
   remote: ..
   specs:
     datadog (2.3.0)
-      debase-ruby_core_source (= 3.3.1)
+      debase-ruby_core_source (= 3.3.5)
       libdatadog (~> 12.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
@@ -109,7 +109,7 @@ GEM
       rexml
     crass (1.0.6)
     date (3.3.4)
-    debase-ruby_core_source (3.3.1)
+    debase-ruby_core_source (3.3.5)
     debug_inspector (1.2.0)
     diff-lcs (1.5.1)
     docile (1.4.0)

--- a/gemfiles/ruby_3.4_graphql_2.2.gemfile.lock
+++ b/gemfiles/ruby_3.4_graphql_2.2.gemfile.lock
@@ -19,7 +19,7 @@ PATH
   remote: ..
   specs:
     datadog (2.3.0)
-      debase-ruby_core_source (= 3.3.1)
+      debase-ruby_core_source (= 3.3.5)
       libdatadog (~> 12.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
@@ -109,7 +109,7 @@ GEM
       rexml
     crass (1.0.6)
     date (3.3.4)
-    debase-ruby_core_source (3.3.1)
+    debase-ruby_core_source (3.3.5)
     debug_inspector (1.2.0)
     diff-lcs (1.5.1)
     docile (1.4.0)

--- a/gemfiles/ruby_3.4_graphql_2.3.gemfile.lock
+++ b/gemfiles/ruby_3.4_graphql_2.3.gemfile.lock
@@ -19,7 +19,7 @@ PATH
   remote: ..
   specs:
     datadog (2.3.0)
-      debase-ruby_core_source (= 3.3.1)
+      debase-ruby_core_source (= 3.3.5)
       libdatadog (~> 12.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
@@ -109,7 +109,7 @@ GEM
       rexml
     crass (1.0.6)
     date (3.3.4)
-    debase-ruby_core_source (3.3.1)
+    debase-ruby_core_source (3.3.5)
     debug_inspector (1.2.0)
     diff-lcs (1.5.1)
     docile (1.4.0)

--- a/gemfiles/ruby_3.4_http.gemfile.lock
+++ b/gemfiles/ruby_3.4_http.gemfile.lock
@@ -19,7 +19,7 @@ PATH
   remote: ..
   specs:
     datadog (2.3.0)
-      debase-ruby_core_source (= 3.3.1)
+      debase-ruby_core_source (= 3.3.5)
       libdatadog (~> 12.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
@@ -47,7 +47,7 @@ GEM
     crack (1.0.0)
       bigdecimal
       rexml
-    debase-ruby_core_source (3.3.1)
+    debase-ruby_core_source (3.3.5)
     debug_inspector (1.2.0)
     diff-lcs (1.5.1)
     docile (1.4.0)

--- a/gemfiles/ruby_3.4_opensearch_2.gemfile.lock
+++ b/gemfiles/ruby_3.4_opensearch_2.gemfile.lock
@@ -19,7 +19,7 @@ PATH
   remote: ..
   specs:
     datadog (2.3.0)
-      debase-ruby_core_source (= 3.3.1)
+      debase-ruby_core_source (= 3.3.5)
       libdatadog (~> 12.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
@@ -46,7 +46,7 @@ GEM
     crack (1.0.0)
       bigdecimal
       rexml
-    debase-ruby_core_source (3.3.1)
+    debase-ruby_core_source (3.3.5)
     debug_inspector (1.2.0)
     diff-lcs (1.5.1)
     docile (1.4.0)

--- a/gemfiles/ruby_3.4_opensearch_3.gemfile.lock
+++ b/gemfiles/ruby_3.4_opensearch_3.gemfile.lock
@@ -19,7 +19,7 @@ PATH
   remote: ..
   specs:
     datadog (2.3.0)
-      debase-ruby_core_source (= 3.3.1)
+      debase-ruby_core_source (= 3.3.5)
       libdatadog (~> 12.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
@@ -46,7 +46,7 @@ GEM
     crack (1.0.0)
       bigdecimal
       rexml
-    debase-ruby_core_source (3.3.1)
+    debase-ruby_core_source (3.3.5)
     debug_inspector (1.2.0)
     diff-lcs (1.5.1)
     docile (1.4.0)

--- a/gemfiles/ruby_3.4_opensearch_latest.gemfile.lock
+++ b/gemfiles/ruby_3.4_opensearch_latest.gemfile.lock
@@ -19,7 +19,7 @@ PATH
   remote: ..
   specs:
     datadog (2.3.0)
-      debase-ruby_core_source (= 3.3.1)
+      debase-ruby_core_source (= 3.3.5)
       libdatadog (~> 12.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
@@ -46,7 +46,7 @@ GEM
     crack (1.0.0)
       bigdecimal
       rexml
-    debase-ruby_core_source (3.3.1)
+    debase-ruby_core_source (3.3.5)
     debug_inspector (1.2.0)
     diff-lcs (1.5.1)
     docile (1.4.1)

--- a/gemfiles/ruby_3.4_opentelemetry.gemfile.lock
+++ b/gemfiles/ruby_3.4_opentelemetry.gemfile.lock
@@ -19,7 +19,7 @@ PATH
   remote: ..
   specs:
     datadog (2.3.0)
-      debase-ruby_core_source (= 3.3.1)
+      debase-ruby_core_source (= 3.3.5)
       libdatadog (~> 12.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
@@ -46,7 +46,7 @@ GEM
     crack (1.0.0)
       bigdecimal
       rexml
-    debase-ruby_core_source (3.3.1)
+    debase-ruby_core_source (3.3.5)
     debug_inspector (1.2.0)
     diff-lcs (1.5.1)
     docile (1.4.0)

--- a/gemfiles/ruby_3.4_rack_2.gemfile.lock
+++ b/gemfiles/ruby_3.4_rack_2.gemfile.lock
@@ -19,7 +19,7 @@ PATH
   remote: ..
   specs:
     datadog (2.3.0)
-      debase-ruby_core_source (= 3.3.1)
+      debase-ruby_core_source (= 3.3.5)
       libdatadog (~> 12.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
@@ -46,7 +46,7 @@ GEM
     crack (1.0.0)
       bigdecimal
       rexml
-    debase-ruby_core_source (3.3.1)
+    debase-ruby_core_source (3.3.5)
     debug_inspector (1.2.0)
     diff-lcs (1.5.1)
     docile (1.4.0)

--- a/gemfiles/ruby_3.4_rack_3.gemfile.lock
+++ b/gemfiles/ruby_3.4_rack_3.gemfile.lock
@@ -19,7 +19,7 @@ PATH
   remote: ..
   specs:
     datadog (2.3.0)
-      debase-ruby_core_source (= 3.3.1)
+      debase-ruby_core_source (= 3.3.5)
       libdatadog (~> 12.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
@@ -46,7 +46,7 @@ GEM
     crack (1.0.0)
       bigdecimal
       rexml
-    debase-ruby_core_source (3.3.1)
+    debase-ruby_core_source (3.3.5)
     debug_inspector (1.2.0)
     diff-lcs (1.5.1)
     docile (1.4.0)

--- a/gemfiles/ruby_3.4_rack_latest.gemfile.lock
+++ b/gemfiles/ruby_3.4_rack_latest.gemfile.lock
@@ -19,7 +19,7 @@ PATH
   remote: ..
   specs:
     datadog (2.3.0)
-      debase-ruby_core_source (= 3.3.1)
+      debase-ruby_core_source (= 3.3.5)
       libdatadog (~> 12.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
@@ -46,7 +46,7 @@ GEM
     crack (1.0.0)
       bigdecimal
       rexml
-    debase-ruby_core_source (3.3.1)
+    debase-ruby_core_source (3.3.5)
     debug_inspector (1.2.0)
     diff-lcs (1.5.1)
     docile (1.4.1)

--- a/gemfiles/ruby_3.4_rails61_mysql2.gemfile.lock
+++ b/gemfiles/ruby_3.4_rails61_mysql2.gemfile.lock
@@ -19,7 +19,7 @@ PATH
   remote: ..
   specs:
     datadog (2.3.0)
-      debase-ruby_core_source (= 3.3.1)
+      debase-ruby_core_source (= 3.3.5)
       libdatadog (~> 12.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
@@ -109,7 +109,7 @@ GEM
       rexml
     crass (1.0.6)
     date (3.3.4)
-    debase-ruby_core_source (3.3.1)
+    debase-ruby_core_source (3.3.5)
     debug_inspector (1.2.0)
     diff-lcs (1.5.1)
     docile (1.4.0)

--- a/gemfiles/ruby_3.4_rails61_postgres.gemfile.lock
+++ b/gemfiles/ruby_3.4_rails61_postgres.gemfile.lock
@@ -19,7 +19,7 @@ PATH
   remote: ..
   specs:
     datadog (2.3.0)
-      debase-ruby_core_source (= 3.3.1)
+      debase-ruby_core_source (= 3.3.5)
       libdatadog (~> 12.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
@@ -109,7 +109,7 @@ GEM
       rexml
     crass (1.0.6)
     date (3.3.4)
-    debase-ruby_core_source (3.3.1)
+    debase-ruby_core_source (3.3.5)
     debug_inspector (1.2.0)
     diff-lcs (1.5.1)
     docile (1.4.0)

--- a/gemfiles/ruby_3.4_rails61_postgres_redis.gemfile.lock
+++ b/gemfiles/ruby_3.4_rails61_postgres_redis.gemfile.lock
@@ -19,7 +19,7 @@ PATH
   remote: ..
   specs:
     datadog (2.3.0)
-      debase-ruby_core_source (= 3.3.1)
+      debase-ruby_core_source (= 3.3.5)
       libdatadog (~> 12.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
@@ -109,7 +109,7 @@ GEM
       rexml
     crass (1.0.6)
     date (3.3.4)
-    debase-ruby_core_source (3.3.1)
+    debase-ruby_core_source (3.3.5)
     debug_inspector (1.2.0)
     diff-lcs (1.5.1)
     docile (1.4.0)

--- a/gemfiles/ruby_3.4_rails61_postgres_sidekiq.gemfile.lock
+++ b/gemfiles/ruby_3.4_rails61_postgres_sidekiq.gemfile.lock
@@ -19,7 +19,7 @@ PATH
   remote: ..
   specs:
     datadog (2.3.0)
-      debase-ruby_core_source (= 3.3.1)
+      debase-ruby_core_source (= 3.3.5)
       libdatadog (~> 12.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
@@ -110,7 +110,7 @@ GEM
       rexml
     crass (1.0.6)
     date (3.3.4)
-    debase-ruby_core_source (3.3.1)
+    debase-ruby_core_source (3.3.5)
     debug_inspector (1.2.0)
     diff-lcs (1.5.1)
     docile (1.4.0)

--- a/gemfiles/ruby_3.4_rails61_semantic_logger.gemfile.lock
+++ b/gemfiles/ruby_3.4_rails61_semantic_logger.gemfile.lock
@@ -19,7 +19,7 @@ PATH
   remote: ..
   specs:
     datadog (2.3.0)
-      debase-ruby_core_source (= 3.3.1)
+      debase-ruby_core_source (= 3.3.5)
       libdatadog (~> 12.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
@@ -109,7 +109,7 @@ GEM
       rexml
     crass (1.0.6)
     date (3.3.4)
-    debase-ruby_core_source (3.3.1)
+    debase-ruby_core_source (3.3.5)
     debug_inspector (1.2.0)
     diff-lcs (1.5.1)
     docile (1.4.0)

--- a/gemfiles/ruby_3.4_rails61_trilogy.gemfile.lock
+++ b/gemfiles/ruby_3.4_rails61_trilogy.gemfile.lock
@@ -19,7 +19,7 @@ PATH
   remote: ..
   specs:
     datadog (2.3.0)
-      debase-ruby_core_source (= 3.3.1)
+      debase-ruby_core_source (= 3.3.5)
       libdatadog (~> 12.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
@@ -112,7 +112,7 @@ GEM
       rexml
     crass (1.0.6)
     date (3.3.4)
-    debase-ruby_core_source (3.3.1)
+    debase-ruby_core_source (3.3.5)
     debug_inspector (1.2.0)
     diff-lcs (1.5.1)
     docile (1.4.0)

--- a/gemfiles/ruby_3.4_rails7.gemfile.lock
+++ b/gemfiles/ruby_3.4_rails7.gemfile.lock
@@ -19,7 +19,7 @@ PATH
   remote: ..
   specs:
     datadog (2.3.0)
-      debase-ruby_core_source (= 3.3.1)
+      debase-ruby_core_source (= 3.3.5)
       libdatadog (~> 12.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
@@ -114,7 +114,7 @@ GEM
       rexml
     crass (1.0.6)
     date (3.3.4)
-    debase-ruby_core_source (3.3.1)
+    debase-ruby_core_source (3.3.5)
     debug_inspector (1.2.0)
     diff-lcs (1.5.1)
     docile (1.4.1)

--- a/gemfiles/ruby_3.4_rails71.gemfile.lock
+++ b/gemfiles/ruby_3.4_rails71.gemfile.lock
@@ -19,7 +19,7 @@ PATH
   remote: ..
   specs:
     datadog (2.3.0)
-      debase-ruby_core_source (= 3.3.1)
+      debase-ruby_core_source (= 3.3.5)
       libdatadog (~> 12.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
@@ -125,7 +125,7 @@ GEM
       rexml
     crass (1.0.6)
     date (3.3.4)
-    debase-ruby_core_source (3.3.1)
+    debase-ruby_core_source (3.3.5)
     debug_inspector (1.2.0)
     diff-lcs (1.5.1)
     docile (1.4.1)

--- a/gemfiles/ruby_3.4_redis_3.gemfile.lock
+++ b/gemfiles/ruby_3.4_redis_3.gemfile.lock
@@ -19,7 +19,7 @@ PATH
   remote: ..
   specs:
     datadog (2.3.0)
-      debase-ruby_core_source (= 3.3.1)
+      debase-ruby_core_source (= 3.3.5)
       libdatadog (~> 12.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
@@ -46,7 +46,7 @@ GEM
     crack (1.0.0)
       bigdecimal
       rexml
-    debase-ruby_core_source (3.3.1)
+    debase-ruby_core_source (3.3.5)
     debug_inspector (1.2.0)
     diff-lcs (1.5.1)
     docile (1.4.0)

--- a/gemfiles/ruby_3.4_redis_4.gemfile.lock
+++ b/gemfiles/ruby_3.4_redis_4.gemfile.lock
@@ -19,7 +19,7 @@ PATH
   remote: ..
   specs:
     datadog (2.3.0)
-      debase-ruby_core_source (= 3.3.1)
+      debase-ruby_core_source (= 3.3.5)
       libdatadog (~> 12.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
@@ -46,7 +46,7 @@ GEM
     crack (1.0.0)
       bigdecimal
       rexml
-    debase-ruby_core_source (3.3.1)
+    debase-ruby_core_source (3.3.5)
     debug_inspector (1.2.0)
     diff-lcs (1.5.1)
     docile (1.4.0)

--- a/gemfiles/ruby_3.4_redis_5.gemfile.lock
+++ b/gemfiles/ruby_3.4_redis_5.gemfile.lock
@@ -19,7 +19,7 @@ PATH
   remote: ..
   specs:
     datadog (2.3.0)
-      debase-ruby_core_source (= 3.3.1)
+      debase-ruby_core_source (= 3.3.5)
       libdatadog (~> 12.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
@@ -47,7 +47,7 @@ GEM
     crack (1.0.0)
       bigdecimal
       rexml
-    debase-ruby_core_source (3.3.1)
+    debase-ruby_core_source (3.3.5)
     debug_inspector (1.2.0)
     diff-lcs (1.5.1)
     docile (1.4.0)

--- a/gemfiles/ruby_3.4_relational_db.gemfile.lock
+++ b/gemfiles/ruby_3.4_relational_db.gemfile.lock
@@ -19,7 +19,7 @@ PATH
   remote: ..
   specs:
     datadog (2.3.0)
-      debase-ruby_core_source (= 3.3.1)
+      debase-ruby_core_source (= 3.3.5)
       libdatadog (~> 12.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
@@ -64,7 +64,7 @@ GEM
     crack (1.0.0)
       bigdecimal
       rexml
-    debase-ruby_core_source (3.3.1)
+    debase-ruby_core_source (3.3.5)
     debug_inspector (1.2.0)
     delayed_job (4.1.11)
       activesupport (>= 3.0, < 8.0)

--- a/gemfiles/ruby_3.4_resque2_redis3.gemfile.lock
+++ b/gemfiles/ruby_3.4_resque2_redis3.gemfile.lock
@@ -19,7 +19,7 @@ PATH
   remote: ..
   specs:
     datadog (2.3.0)
-      debase-ruby_core_source (= 3.3.1)
+      debase-ruby_core_source (= 3.3.5)
       libdatadog (~> 12.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
@@ -47,7 +47,7 @@ GEM
     crack (1.0.0)
       bigdecimal
       rexml
-    debase-ruby_core_source (3.3.1)
+    debase-ruby_core_source (3.3.5)
     debug_inspector (1.2.0)
     diff-lcs (1.5.1)
     docile (1.4.0)

--- a/gemfiles/ruby_3.4_resque2_redis4.gemfile.lock
+++ b/gemfiles/ruby_3.4_resque2_redis4.gemfile.lock
@@ -19,7 +19,7 @@ PATH
   remote: ..
   specs:
     datadog (2.3.0)
-      debase-ruby_core_source (= 3.3.1)
+      debase-ruby_core_source (= 3.3.5)
       libdatadog (~> 12.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
@@ -48,7 +48,7 @@ GEM
     crack (1.0.0)
       bigdecimal
       rexml
-    debase-ruby_core_source (3.3.1)
+    debase-ruby_core_source (3.3.5)
     debug_inspector (1.2.0)
     diff-lcs (1.5.1)
     docile (1.4.0)

--- a/gemfiles/ruby_3.4_sinatra_2.gemfile.lock
+++ b/gemfiles/ruby_3.4_sinatra_2.gemfile.lock
@@ -19,7 +19,7 @@ PATH
   remote: ..
   specs:
     datadog (2.3.0)
-      debase-ruby_core_source (= 3.3.1)
+      debase-ruby_core_source (= 3.3.5)
       libdatadog (~> 12.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
@@ -46,7 +46,7 @@ GEM
     crack (1.0.0)
       bigdecimal
       rexml
-    debase-ruby_core_source (3.3.1)
+    debase-ruby_core_source (3.3.5)
     debug_inspector (1.2.0)
     diff-lcs (1.5.1)
     docile (1.4.0)

--- a/gemfiles/ruby_3.4_sinatra_3.gemfile.lock
+++ b/gemfiles/ruby_3.4_sinatra_3.gemfile.lock
@@ -19,7 +19,7 @@ PATH
   remote: ..
   specs:
     datadog (2.3.0)
-      debase-ruby_core_source (= 3.3.1)
+      debase-ruby_core_source (= 3.3.5)
       libdatadog (~> 12.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
@@ -47,7 +47,7 @@ GEM
     crack (1.0.0)
       bigdecimal
       rexml
-    debase-ruby_core_source (3.3.1)
+    debase-ruby_core_source (3.3.5)
     debug_inspector (1.2.0)
     diff-lcs (1.5.1)
     docile (1.4.0)

--- a/gemfiles/ruby_3.4_sinatra_4.gemfile.lock
+++ b/gemfiles/ruby_3.4_sinatra_4.gemfile.lock
@@ -19,7 +19,7 @@ PATH
   remote: ..
   specs:
     datadog (2.3.0)
-      debase-ruby_core_source (= 3.3.1)
+      debase-ruby_core_source (= 3.3.5)
       libdatadog (~> 12.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
@@ -47,7 +47,7 @@ GEM
     crack (1.0.0)
       bigdecimal
       rexml
-    debase-ruby_core_source (3.3.1)
+    debase-ruby_core_source (3.3.5)
     debug_inspector (1.2.0)
     diff-lcs (1.5.1)
     docile (1.4.0)

--- a/gemfiles/ruby_3.4_stripe_10.gemfile.lock
+++ b/gemfiles/ruby_3.4_stripe_10.gemfile.lock
@@ -19,7 +19,7 @@ PATH
   remote: ..
   specs:
     datadog (2.3.0)
-      debase-ruby_core_source (= 3.3.1)
+      debase-ruby_core_source (= 3.3.5)
       libdatadog (~> 12.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
@@ -46,7 +46,7 @@ GEM
     crack (1.0.0)
       bigdecimal
       rexml
-    debase-ruby_core_source (3.3.1)
+    debase-ruby_core_source (3.3.5)
     debug_inspector (1.2.0)
     diff-lcs (1.5.1)
     docile (1.4.1)

--- a/gemfiles/ruby_3.4_stripe_11.gemfile.lock
+++ b/gemfiles/ruby_3.4_stripe_11.gemfile.lock
@@ -19,7 +19,7 @@ PATH
   remote: ..
   specs:
     datadog (2.3.0)
-      debase-ruby_core_source (= 3.3.1)
+      debase-ruby_core_source (= 3.3.5)
       libdatadog (~> 12.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
@@ -46,7 +46,7 @@ GEM
     crack (1.0.0)
       bigdecimal
       rexml
-    debase-ruby_core_source (3.3.1)
+    debase-ruby_core_source (3.3.5)
     debug_inspector (1.2.0)
     diff-lcs (1.5.1)
     docile (1.4.1)

--- a/gemfiles/ruby_3.4_stripe_12.gemfile.lock
+++ b/gemfiles/ruby_3.4_stripe_12.gemfile.lock
@@ -19,7 +19,7 @@ PATH
   remote: ..
   specs:
     datadog (2.3.0)
-      debase-ruby_core_source (= 3.3.1)
+      debase-ruby_core_source (= 3.3.5)
       libdatadog (~> 12.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
@@ -46,7 +46,7 @@ GEM
     crack (1.0.0)
       bigdecimal
       rexml
-    debase-ruby_core_source (3.3.1)
+    debase-ruby_core_source (3.3.5)
     debug_inspector (1.2.0)
     diff-lcs (1.5.1)
     docile (1.4.1)

--- a/gemfiles/ruby_3.4_stripe_7.gemfile.lock
+++ b/gemfiles/ruby_3.4_stripe_7.gemfile.lock
@@ -19,7 +19,7 @@ PATH
   remote: ..
   specs:
     datadog (2.3.0)
-      debase-ruby_core_source (= 3.3.1)
+      debase-ruby_core_source (= 3.3.5)
       libdatadog (~> 12.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
@@ -46,7 +46,7 @@ GEM
     crack (1.0.0)
       bigdecimal
       rexml
-    debase-ruby_core_source (3.3.1)
+    debase-ruby_core_source (3.3.5)
     debug_inspector (1.2.0)
     diff-lcs (1.5.1)
     docile (1.4.1)

--- a/gemfiles/ruby_3.4_stripe_8.gemfile.lock
+++ b/gemfiles/ruby_3.4_stripe_8.gemfile.lock
@@ -19,7 +19,7 @@ PATH
   remote: ..
   specs:
     datadog (2.3.0)
-      debase-ruby_core_source (= 3.3.1)
+      debase-ruby_core_source (= 3.3.5)
       libdatadog (~> 12.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
@@ -46,7 +46,7 @@ GEM
     crack (1.0.0)
       bigdecimal
       rexml
-    debase-ruby_core_source (3.3.1)
+    debase-ruby_core_source (3.3.5)
     debug_inspector (1.2.0)
     diff-lcs (1.5.1)
     docile (1.4.1)

--- a/gemfiles/ruby_3.4_stripe_9.gemfile.lock
+++ b/gemfiles/ruby_3.4_stripe_9.gemfile.lock
@@ -19,7 +19,7 @@ PATH
   remote: ..
   specs:
     datadog (2.3.0)
-      debase-ruby_core_source (= 3.3.1)
+      debase-ruby_core_source (= 3.3.5)
       libdatadog (~> 12.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
@@ -46,7 +46,7 @@ GEM
     crack (1.0.0)
       bigdecimal
       rexml
-    debase-ruby_core_source (3.3.1)
+    debase-ruby_core_source (3.3.5)
     debug_inspector (1.2.0)
     diff-lcs (1.5.1)
     docile (1.4.1)

--- a/gemfiles/ruby_3.4_stripe_latest.gemfile.lock
+++ b/gemfiles/ruby_3.4_stripe_latest.gemfile.lock
@@ -19,7 +19,7 @@ PATH
   remote: ..
   specs:
     datadog (2.3.0)
-      debase-ruby_core_source (= 3.3.1)
+      debase-ruby_core_source (= 3.3.5)
       libdatadog (~> 12.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
@@ -46,7 +46,7 @@ GEM
     crack (1.0.0)
       bigdecimal
       rexml
-    debase-ruby_core_source (3.3.1)
+    debase-ruby_core_source (3.3.5)
     debug_inspector (1.2.0)
     diff-lcs (1.5.1)
     docile (1.4.1)

--- a/gemfiles/ruby_3.4_stripe_min.gemfile.lock
+++ b/gemfiles/ruby_3.4_stripe_min.gemfile.lock
@@ -19,7 +19,7 @@ PATH
   remote: ..
   specs:
     datadog (2.3.0)
-      debase-ruby_core_source (= 3.3.1)
+      debase-ruby_core_source (= 3.3.5)
       libdatadog (~> 12.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
@@ -46,7 +46,7 @@ GEM
     crack (1.0.0)
       bigdecimal
       rexml
-    debase-ruby_core_source (3.3.1)
+    debase-ruby_core_source (3.3.5)
     debug_inspector (1.2.0)
     diff-lcs (1.5.1)
     docile (1.4.1)


### PR DESCRIPTION
**What does this PR do?**

This PR bumps our dependency on debase-ruby_core_source to version 3.3.5. This version includes the headers for the Ruby 3.3.5 as well as 3.4.0-preview1; up until now we were supporting those Ruby versions using the 3.3.0 headers.

**Motivation:**

Use up-to-date headers for profiling on Ruby 3.3.5 and 3.4.0-preview1.

**Additional Notes:**

I've updated the appraisal gemfiles as well.

**How to test the change?**

Validate that CI is green.