### PR TITLE
Permit single-quoted strings in standard.rb

### DIFF
--- a/.standard_todo.yml
+++ b/.standard_todo.yml
@@ -9,6 +9,7 @@ ignore:
   - Style/TrailingCommaInArguments
   - Style/TrailingCommaInArrayLiteral
   - Style/TrailingCommaInHashLiteral
+  - Style/StringLiterals
 
 # This disables standardrb for the rest of dd-trace-rb (other than profiling)
 - .pryrc


### PR DESCRIPTION
<!--
Check out the
https://github.com/DataDog/dd-trace-rb/blob/master/docs/DevelopmentGuide.md
for guidance on how to set up your development environment,
run the test suite, write new integrations, and more.
-->

**What does this PR do?**
<!-- A brief description of the change being made with this pull request. -->
This PR changes standard.rb rules to not enforce particular string quoting style.

**Motivation:**
<!-- What inspired you to submit this pull request? -->
I usually use single-quoted strings because they are easier to type (one use of pinky per quote instead of two). standard.rb is currently used by profiler and dynamic instrumentation and @ivoanjo is OK with string quote style being left alone.

**Additional Notes:**
<!-- Anything else we should know when reviewing? -->
None

**How to test the change?**
Not applicable
<!--
Describe here how the change can be validated.
You are strongly encouraged to provide automated tests for this PR (unit or integration).
If this change cannot be feasibly tested, please explain why,
unless the change does not modify code (e.g. only modifies docs, comments).
-->

Unsure? Have a question? Request a review!
