### PR TITLE
Fix AppSec::Component building when ffi gem is not loaded

### DIFF
--- a/lib/datadog/appsec/component.rb
+++ b/lib/datadog/appsec/component.rb
@@ -31,6 +31,8 @@ module Datadog
 
         def incompatible_ffi_version?
           ffi_version = Gem.loaded_specs['ffi'] && Gem.loaded_specs['ffi'].version
+          return true unless ffi_version
+
           return false unless Gem::Version.new(RUBY_VERSION) >= Gem::Version.new('3.3') &&
             ffi_version < Gem::Version.new('1.16.0')
 

--- a/spec/datadog/appsec/component_spec.rb
+++ b/spec/datadog/appsec/component_spec.rb
@@ -33,6 +33,19 @@ RSpec.describe Datadog::AppSec::Component do
         end
       end
 
+      context 'when ffi is not loaded' do
+        before do
+          allow(Gem).to receive(:loaded_specs).and_return({})
+        end
+
+        it 'returns a Datadog::AppSec::Component instance with a nil processor and does not warn' do
+          expect(Datadog.logger).not_to receive(:warn)
+
+          component = described_class.build_appsec_component(settings, telemetry: telemetry)
+          expect(component).to be_nil
+        end
+      end
+
       context 'when processor is ready' do
         it 'returns a Datadog::AppSec::Component with a processor instance' do
           expect_any_instance_of(Datadog::AppSec::Processor).to receive(:ready?).and_return(true)


### PR DESCRIPTION
Follow-up for #3969 

**What does this PR do?**
It fixes `Appsec::Component` building in case when `ffi` gem was not loaded.

**Motivation:**
It was mentioned during review of #3969 that `ffi` gem might not be loaded, and in this case `ffi_version` would be `nil`:
https://github.com/DataDog/dd-trace-rb/pull/3969#discussion_r1789852584

**Additional Notes:**


**How to test the change?**


Unsure? Have a question? Request a review!
