### PR TITLE
[NO-TICKET] Profiling: Minor cleanup to error messages

### DIFF
--- a/lib/datadog/profiling/http_transport.rb
+++ b/lib/datadog/profiling/http_transport.rb
@@ -139,7 +139,7 @@ module Datadog
       end
 
       def config_without_api_key
-        [exporter_configuration[0..1]].to_h
+        "#{exporter_configuration[0]}: #{exporter_configuration[1]}"
       end
     end
   end

--- a/sig/datadog/profiling/http_transport.rbs
+++ b/sig/datadog/profiling/http_transport.rbs
@@ -61,7 +61,7 @@ module Datadog
         ::String info_json,
       ) -> [:ok | :error, ::Integer | ::String]
 
-      def config_without_api_key: () -> ::Hash[:agent | :agentless, ::String]
+      def config_without_api_key: () -> ::String
     end
   end
 end

--- a/spec/datadog/profiling/http_transport_spec.rb
+++ b/spec/datadog/profiling/http_transport_spec.rb
@@ -226,7 +226,7 @@ RSpec.describe Datadog::Profiling::HttpTransport do
 
         it "logs an error message" do
           expect(Datadog.logger).to receive(:error).with(
-            'Failed to report profiling data ({:agent=>"http://192.168.0.1:12345/"}): ' \
+            "Failed to report profiling data (agent: http://192.168.0.1:12345/): " \
             "server returned unexpected HTTP 500 status code"
           )
 
@@ -252,7 +252,7 @@ RSpec.describe Datadog::Profiling::HttpTransport do
 
         it "logs an error message" do
           expect(Datadog.logger).to receive(:error)
-            .with('Failed to report profiling data ({:agent=>"http://192.168.0.1:12345/"}): Some error message')
+            .with("Failed to report profiling data (agent: http://192.168.0.1:12345/): Some error message")
 
           export
         end
@@ -266,31 +266,6 @@ RSpec.describe Datadog::Profiling::HttpTransport do
         end
 
         it { is_expected.to be false }
-      end
-    end
-  end
-
-  describe "#config_without_api_key" do
-    subject(:config_without_api_key) { http_transport.send(:config_without_api_key) }
-
-    context "when using agentless mode" do
-      let(:site) { "test.datadoghq.com" }
-      let(:api_key) { SecureRandom.uuid }
-
-      around do |example|
-        ClimateControl.modify("DD_PROFILING_AGENTLESS" => "true") do
-          example.run
-        end
-      end
-
-      it "returns the mode and site, but not the api key" do
-        is_expected.to eq(agentless: "test.datadoghq.com")
-      end
-    end
-
-    context "when using agent mode" do
-      it "returns the mode the agent url" do
-        is_expected.to eq(agent: "http://192.168.0.1:12345/")
       end
     end
   end


### PR DESCRIPTION
**What does this PR do?**

This PR does a very small refactoring to the tests and code in the profiler to print errors when talking to the backend.

**Motivation:**

In Ruby 3.4, the printing of arrays is being slightly tweaked, and so our tests started failing.

Regardless of that change sticking or being reverted (it does seem like it could cause a bit of annoyance across the ecosystem), I've decided to simplify a bit our code to provide our own printing rather than rely on the Ruby defaults, and thus work everywhere.

Also I decided to remove the specs for
`HttpTransport#config_without_api_key` since it's only used internally for error printing (which did not use to be the case!).

**Additional Notes:**

There's a few more things not working on Ruby head due to changes in rubygems/bundler, but I'll handle those separately.

**How to test the change?**

This change includes test coverage.
