### PR TITLE
[PROF-10589] Add more details to flaky profiler spec

### DIFF
--- a/spec/datadog/profiling/collectors/cpu_and_wall_time_worker_spec.rb
+++ b/spec/datadog/profiling/collectors/cpu_and_wall_time_worker_spec.rb
@@ -473,6 +473,7 @@ RSpec.describe Datadog::Profiling::Collectors::CpuAndWallTimeWorker do
             missed_by_profiler_time: missed_by_profiler_time,
             total_time: total_time,
             waiting_for_gvl_time: waiting_for_gvl_time,
+            samples: samples.map { |s| [s.values, s.labels] },
           }
 
           # The background thread should spend almost all of its time waiting to run (since when it gets to run


### PR DESCRIPTION
**What does this PR do?**

I've been hunting down a flaky profiler test that was added as part of the new GVL profiling feature.

Here's how it looks:
https://app.circleci.com/pipelines/github/DataDog/dd-trace-rb/16712/workflows/f2e30fe0-c1e5-4e87-b228-4eec53d41017/jobs/599762

I haven't been able to reproduce the issue locally, so I'm adding more information that will hopefully point the way the next time the spec is flaky again.

**Motivation:**

Hunt down flaky spec.

**Additional Notes:**

Thanks for the patience for the other folks on the team. If I really can't figure this one, I'll disable the spec, but I'm hoping this extra info points the way to solving the issue and keeping the spec (since I do believe this spec offers value -- as it tests the GVL profiling feature end-to-end, profiling a real Ruby thread during the testcase).

**How to test the change?**

This change only shows up once the test fails. So for now a green CI is good, and a red CI with the flaky issue is even better.