### PR TITLE
[PROF-10589] Temporarily disable flaky spec for GVL profiling

### DIFF
--- a/spec/datadog/profiling/collectors/cpu_and_wall_time_worker_spec.rb
+++ b/spec/datadog/profiling/collectors/cpu_and_wall_time_worker_spec.rb
@@ -430,6 +430,8 @@ RSpec.describe Datadog::Profiling::Collectors::CpuAndWallTimeWorker do
         end
 
         it "records Waiting for GVL samples" do
+          skip "Temporarily skipped until we can fix flakiness"
+
           background_thread_affected_by_gvl_contention
           ready_queue_2.pop
 


### PR DESCRIPTION
**What does this PR do?**

This PR temporarily disables a spec in the profiler that has proven to be flaky.

I've been trying to hunt it down, and finally got a lot of relevant info in https://app.circleci.com/pipelines/github/DataDog/dd-trace-rb/16739/workflows/fe009eb1-d942-4432-bc39-713fa9a3b751/jobs/600523

I think I have enough info to analyze the issue, but since this week there's a profiling team meetup let's disable the spec until I have a bit more time to actually sit down and fix it.

**Motivation:**

Avoid annoying folks with flaky specs.

**Additional Notes:**

N/A

**How to test the change?**

Validate that CI is green!