### PR TITLE
Fix crashtracking specs

### DIFF
--- a/ext/libdatadog_api/crashtracker.c
+++ b/ext/libdatadog_api/crashtracker.c
@@ -36,6 +36,8 @@ static VALUE _native_start_or_update_on_fork(int argc, VALUE *argv, DDTRACE_UNUS
   VALUE tags_as_array = rb_hash_fetch(options, ID2SYM(rb_intern("tags_as_array")));
   VALUE action = rb_hash_fetch(options, ID2SYM(rb_intern("action")));
   VALUE upload_timeout_seconds = rb_hash_fetch(options, ID2SYM(rb_intern("upload_timeout_seconds")));
+  VALUE optional_stdout_filename = rb_hash_fetch(options, ID2SYM(rb_intern("optional_stdout_filename")));
+  VALUE optional_stderr_filename = rb_hash_fetch(options, ID2SYM(rb_intern("optional_stderr_filename")));
 
   VALUE start_action = ID2SYM(rb_intern("start"));
   VALUE update_on_fork_action = ID2SYM(rb_intern("update_on_fork"));
@@ -46,6 +48,8 @@ static VALUE _native_start_or_update_on_fork(int argc, VALUE *argv, DDTRACE_UNUS
   ENFORCE_TYPE(ld_library_path, T_STRING);
   ENFORCE_TYPE(action, T_SYMBOL);
   ENFORCE_TYPE(upload_timeout_seconds, T_FIXNUM);
+  ENFORCE_TYPE(optional_stdout_filename, T_STRING);
+  ENFORCE_TYPE(optional_stderr_filename, T_STRING);
 
   if (action != start_action && action != update_on_fork_action) rb_raise(rb_eArgError, "Unexpected action: %+"PRIsVALUE, action);
 
@@ -91,8 +95,8 @@ static VALUE _native_start_or_update_on_fork(int argc, VALUE *argv, DDTRACE_UNUS
     .args = {},
     .env = {.ptr = &ld_library_path_env, .len = 1},
     .path_to_receiver_binary = char_slice_from_ruby_string(path_to_crashtracking_receiver_binary),
-    .optional_stderr_filename = {},
-    .optional_stdout_filename = {},
+    .optional_stderr_filename = char_slice_from_ruby_string(optional_stderr_filename),
+    .optional_stdout_filename = char_slice_from_ruby_string(optional_stdout_filename),
   };
 
   ddog_crasht_Result result =

--- a/lib/datadog/core/configuration/components.rb
+++ b/lib/datadog/core/configuration/components.rb
@@ -59,17 +59,6 @@ module Datadog
           def build_telemetry(settings, agent_settings, logger)
             Telemetry::Component.build(settings, agent_settings, logger)
           end
-
-          def build_crashtracker(settings, agent_settings, logger:)
-            return unless settings.crashtracking.enabled
-
-            if (libdatadog_api_failure = Datadog::Core::Crashtracking::Component::LIBDATADOG_API_FAILURE)
-              logger.debug("Cannot enable crashtracking: #{libdatadog_api_failure}")
-              return
-            end
-
-            Datadog::Core::Crashtracking::Component.build(settings, agent_settings, logger: logger)
-          end
         end
 
         include Datadog::Tracing::Component::InstanceMethods
@@ -98,7 +87,7 @@ module Datadog
 
           @remote = Remote::Component.build(settings, agent_settings, telemetry: telemetry)
           @tracer = self.class.build_tracer(settings, agent_settings, logger: @logger)
-          @crashtracker = self.class.build_crashtracker(settings, agent_settings, logger: @logger)
+          @crashtracker = Datadog::Core::Crashtracking::Component.build(settings, agent_settings, logger: @logger)
 
           @profiler, profiler_logger_extra = Datadog::Profiling::Component.build_profiler_component(
             settings: settings,


### PR DESCRIPTION
<!--
Check out the
https://github.com/DataDog/dd-trace-rb/blob/master/docs/DevelopmentGuide.md
for guidance on how to set up your development environment,
run the test suite, write new integrations, and more.
-->

**What does this PR do?**
<!-- A brief description of the change being made with this pull request. -->

Reinstate crashtracking specs by fixing them. 

**Motivation:**
<!-- What inspired you to submit this pull request? -->

- #3970 identified these specs as being unreliable and/or leaking threads.
- Coverage is both limited and relies on internal behaviours.
- Crashtracking changes to address #3954 will make these same specs fail.

**Additional Notes:**
<!-- Anything else we should know when reviewing? -->

**How to test the change?**
<!--
Describe here how the change can be validated.
You are strongly encouraged to provide automated tests for this PR (unit or integration).
If this change cannot be feasibly tested, please explain why,
unless the change does not modify code (e.g. only modifies docs, comments).
-->

Well, specs!