### PR TITLE
Update integration test READMEs

### DIFF
--- a/integration/README.md
+++ b/integration/README.md
@@ -10,19 +10,19 @@ Integration tests for `datadog` that use a variety of real applications.
     ./script/build-images
     ```
 
-You can specify which ruby version to build using the `-v` option.
+You can specify which ruby version to build using the `-v` option. If you are running on ARM architecture (e.g. mac), include `DOCKER_DEFAULT_PLATFORM=linux/arm64` as a prefix to the script.
 
-2. Choose an application and follow instructions (in corresponding `README.md`.)
+2. Choose an application, and follow the instructions in the corresponding `README.md`.
 
 ## Demo applications
 
-Ruby demo applications are configured with Datadog APM, which can be used to generate sample traces/profiles. These are used to drive tests in the integration suite.
+Ruby demo applications are configured with Datadog APM, which can be used to generate sample traces and profiles. These are used to drive tests in the integration suite.
 
 ### Applications
 
 See `README.md` in each directory for more information:
 
-- `apps/opentelemetry`: Generates OpenTelemetry traces
+- `apps/opentelemetry`: OpenTelemetry traces
 - `apps/rack`: Rack application
 - `apps/rails-five`: Rails 5 application
 - `apps/rails-six`: Rails 6 application

--- a/integration/apps/hanami/README.md
+++ b/integration/apps/hanami/README.md
@@ -136,11 +136,11 @@ You can also define your own custom scenario by creating a LUA file, mounting it
 
 ### Running integration tests
 
-You can run integration tests using the following and substituting for the Ruby major and minor version (e.g. `2.7`)
+You can run integration tests using the following and substituting for the Ruby major and minor version (e.g. `2.7`). If you are running on ARM architecture (e.g. mac), include `DOCKER_DEFAULT_PLATFORM=linux/arm64` as a prefix for the build script and `DOCKER_BUILDKIT=0` as a prefix for the ci script.
 
 ```sh
-./bin/build-images -v <RUBY_VERSION>
-./bin/ci -v <RUBY_VERSION>
+./script/build-images -v <RUBY_VERSION>
+./script/ci -v <RUBY_VERSION>
 ```
 
 Or inside a running container:

--- a/integration/apps/opentelemetry/README.md
+++ b/integration/apps/opentelemetry/README.md
@@ -56,7 +56,7 @@ e.g. `DD_DEMO_ENV_FEATURES=tracing,profiling`
 
 ### Running integration tests
 
-You can run integration tests using the following and substituting for the Ruby major and minor version (e.g. `2.7`)
+You can run integration tests using the following and substituting for the Ruby major and minor version (e.g. `2.7`). If you are running on ARM architecture (e.g. mac), include `DOCKER_DEFAULT_PLATFORM=linux/arm64` as a prefix for the build script and `DOCKER_BUILDKIT=0` as a prefix for the ci script.
 
 ```sh
 ./script/build-images -v <RUBY_VERSION>

--- a/integration/apps/rack/README.md
+++ b/integration/apps/rack/README.md
@@ -10,7 +10,7 @@ Install [direnv](https://github.com/direnv/direnv) for applying local settings.
 
 1. `cp .envrc.sample .envrc` and add your Datadog API key.
 2. `direnv allow` to load the env var.
-4. `docker-compose run --rm app bin/setup`
+3. `docker-compose run --rm app bin/setup`
 
 ## Running the application
 
@@ -103,7 +103,7 @@ You can also define your own custom scenario by creating a LUA file, mounting it
 
 ### Running integration tests
 
-You can run integration tests using the following and substituting for the Ruby major and minor version (e.g. `2.7`)
+You can run integration tests using the following and substituting for the Ruby major and minor version (e.g. `2.7`). If you are running on ARM architecture (e.g. mac), include `DOCKER_DEFAULT_PLATFORM=linux/arm64` as a prefix for the build script and `DOCKER_BUILDKIT=0` as a prefix for the ci script.
 
 ```sh
 ./script/build-images -v <RUBY_VERSION>

--- a/integration/apps/rails-five/README.md
+++ b/integration/apps/rails-five/README.md
@@ -140,11 +140,11 @@ You can also define your own custom scenario by creating a LUA file, mounting it
 
 ### Running integration tests
 
-You can run integration tests using the following and substituting for the Ruby major and minor version (e.g. `2.7`)
+You can run integration tests using the following and substituting for the Ruby major and minor version (e.g. `2.7`). If you are running on ARM architecture (e.g. mac), include `DOCKER_DEFAULT_PLATFORM=linux/arm64` as a prefix for the build script and `DOCKER_BUILDKIT=0` as a prefix for the ci script.
 
 ```sh
-./bin/build-images -v <RUBY_VERSION>
-./bin/ci -v <RUBY_VERSION>
+./script/build-images -v <RUBY_VERSION>
+./script/ci -v <RUBY_VERSION>
 ```
 
 Or inside a running container:

--- a/integration/apps/rails-seven/README.md
+++ b/integration/apps/rails-seven/README.md
@@ -140,11 +140,11 @@ You can also define your own custom scenario by creating a LUA file, mounting it
 
 ### Running integration tests
 
-You can run integration tests using the following and substituting for the Ruby major and minor version (e.g. `2.7`)
+You can run integration tests using the following and substituting for the Ruby major and minor version (e.g. `2.7`). If you are running on ARM architecture (e.g. mac), include `DOCKER_DEFAULT_PLATFORM=linux/arm64` as a prefix for the build script and `DOCKER_BUILDKIT=0` as a prefix for the ci script.
 
 ```sh
-./bin/build-images -v <RUBY_VERSION>
-./bin/ci -v <RUBY_VERSION>
+./script/build-images -v <RUBY_VERSION>
+./script/ci -v <RUBY_VERSION>
 ```
 
 Or inside a running container:

--- a/integration/apps/rails-six/README.md
+++ b/integration/apps/rails-six/README.md
@@ -140,11 +140,11 @@ You can also define your own custom scenario by creating a LUA file, mounting it
 
 ### Running integration tests
 
-You can run integration tests using the following and substituting for the Ruby major and minor version (e.g. `2.7`)
+You can run integration tests using the following and substituting for the Ruby major and minor version (e.g. `2.7`). If you are running on ARM architecture (e.g. mac), include `DOCKER_DEFAULT_PLATFORM=linux/arm64` as a prefix for the build script and `DOCKER_BUILDKIT=0` as a prefix for the ci script.
 
 ```sh
-./bin/build-images -v <RUBY_VERSION>
-./bin/ci -v <RUBY_VERSION>
+./script/build-images -v <RUBY_VERSION>
+./script/ci -v <RUBY_VERSION>
 ```
 
 Or inside a running container:

--- a/integration/apps/rspec/README.md
+++ b/integration/apps/rspec/README.md
@@ -10,7 +10,7 @@ Install [direnv](https://github.com/direnv/direnv) for applying local settings.
 
 1. `cp .envrc.sample .envrc` and add your Datadog API key.
 2. `direnv allow` to load the env var.
-4. `docker-compose run --rm app bin/setup`
+3. `docker-compose run --rm app bin/setup`
 
 ## Running the application
 
@@ -78,7 +78,7 @@ e.g. `DD_DEMO_ENV_FEATURES=tracing,profiling`
 
 ### Running integration tests
 
-You can run integration tests using the following and substituting for the Ruby major and minor version (e.g. `2.7`)
+You can run integration tests using the following and substituting for the Ruby major and minor version (e.g. `2.7`). Currently, this integration test has nothing to do in CI, and there are no RSpec tests in `/bin/test`.
 
 ```sh
 ./script/build-images -v <RUBY_VERSION>

--- a/integration/apps/ruby/README.md
+++ b/integration/apps/ruby/README.md
@@ -10,7 +10,7 @@ Install [direnv](https://github.com/direnv/direnv) for applying local settings.
 
 1. `cp .envrc.sample .envrc` and add your Datadog API key.
 2. `direnv allow` to load the env var.
-4. `docker-compose run --rm app bin/setup`
+3. `docker-compose run --rm app bin/setup`
 
 ## Running the application
 
@@ -78,7 +78,7 @@ e.g. `DD_DEMO_ENV_FEATURES=tracing,profiling`
 
 ### Running integration tests
 
-You can run integration tests using the following and substituting for the Ruby major and minor version (e.g. `2.7`)
+You can run integration tests using the following and substituting for the Ruby major and minor version (e.g. `2.7`). Currently, this integration test has nothing to do in CI, and there are no Ruby tests in `/bin/test`.
 
 ```sh
 ./script/build-images -v <RUBY_VERSION>

--- a/integration/apps/sinatra2-classic/README.md
+++ b/integration/apps/sinatra2-classic/README.md
@@ -99,7 +99,7 @@ You can also define your own custom scenario by creating a LUA file, mounting it
 
 ### Running integration tests
 
-You can run integration tests using the following and substituting for the Ruby major and minor version (e.g. `2.7`)
+You can run integration tests using the following and substituting for the Ruby major and minor version (e.g. `2.7`). If you are running on ARM architecture (e.g. mac), include `DOCKER_DEFAULT_PLATFORM=linux/arm64` as a prefix for the build script and `DOCKER_BUILDKIT=0` as a prefix for the ci script.
 
 ```sh
 ./script/build-images -v <RUBY_VERSION>

--- a/integration/apps/sinatra2-modular/README.md
+++ b/integration/apps/sinatra2-modular/README.md
@@ -99,7 +99,7 @@ You can also define your own custom scenario by creating a LUA file, mounting it
 
 ### Running integration tests
 
-You can run integration tests using the following and substituting for the Ruby major and minor version (e.g. `2.7`)
+You can run integration tests using the following and substituting for the Ruby major and minor version (e.g. `2.7`). If you are running on ARM architecture (e.g. mac), include `DOCKER_DEFAULT_PLATFORM=linux/arm64` as a prefix for the build script and `DOCKER_BUILDKIT=0` as a prefix for the ci script.
 
 ```sh
 ./script/build-images -v <RUBY_VERSION>


### PR DESCRIPTION
<!--
Check out the
https://github.com/DataDog/dd-trace-rb/blob/master/docs/DevelopmentGuide.md
for guidance on how to set up your development environment,
run the test suite, write new integrations, and more.
-->

**What does this PR do?**
This PR updates the integration test READMEs to address issues when running the tests on aarch64 / arm64 architecture machines (e.g. mac). 

The images by default build on x86_64 / amd64 architecture, so those not running a compatible machine need to specify the aarch64 / arm64 platform when building the image. When running the test scripts, macOS users may also need to disable the automatic use of the buildx docker command, so a fix for this is noted in the updated READMEs as well.

**Motivation:**
I was trying to run integration tests on my local mac, and I encountered issues with image architecture build incompatibilities. Notably, I found that with my macOS (aarch64 / arm64 architecture), even though I had a local image with the same name, the scripts were unable to "find" that image locally because it was built on an incompatible architecture. I was able to run the tests by specifying the platform when building the images (i.e. prefix with `DOCKER_DEFAULT_PLATFORM=linux/arm64`) and disabling the automatic use of the buildx docker command on macOS (i.e. prefix with `DOCKER_BUILDKIT=0`). Since macOS and generally aarch64 / arm64 architecture is widely used, I thought that notes for this fix could be helpful to add to our READMEs.

**Additional Notes:**
<!-- Anything else we should know when reviewing? -->

**How to test the change?**
This change only modifies README documents; however, you can test the newly added advice locally on a mac. Running the original README commands (e.g. `./script/build-images`) produces an error along the lines of `InvalidBaseImagePlatform: Base image datadog/dd-apm-demo:ruby-2.7 was pulled with platform "linux/amd64", expected "linux/arm64" for current build`. After adding the `DOCKER_DEFAULT_PLATFORM=linux/arm64` prefix, the image should successfully build.

Unsure? Have a question? Request a review!
