### PR TITLE
[PROF-10589] Fix GVL profiling bug that was causing test flakiness

### DIFF
--- a/ext/datadog_profiling_native_extension/collectors_stack.c
+++ b/ext/datadog_profiling_native_extension/collectors_stack.c
@@ -217,7 +217,10 @@ void sample_thread(
   ddog_prof_Label *state_label = labels.state_label;
   bool cpu_or_wall_sample = values.cpu_or_wall_samples > 0;
   bool has_cpu_time = cpu_or_wall_sample && values.cpu_time_ns > 0;
-  bool only_wall_time = cpu_or_wall_sample && values.cpu_time_ns == 0 && values.wall_time_ns > 0;
+  // Note: In theory, a cpu_or_wall_sample should always have some wall-time. In practice, the first sample for a thread
+  // will be zero, as well as if the system clock does something weird. Thus, at some point we had values.wall_time_ns > 0
+  // here, but >= 0 makes this easier to understand/debug.
+  bool only_wall_time = cpu_or_wall_sample && values.cpu_time_ns == 0 && values.wall_time_ns >= 0;
 
   if (cpu_or_wall_sample && state_label == NULL) rb_raise(rb_eRuntimeError, "BUG: Unexpected missing state_label");
 

--- a/spec/datadog/profiling/collectors/cpu_and_wall_time_worker_spec.rb
+++ b/spec/datadog/profiling/collectors/cpu_and_wall_time_worker_spec.rb
@@ -430,8 +430,6 @@ RSpec.describe Datadog::Profiling::Collectors::CpuAndWallTimeWorker do
         end
 
         it "records Waiting for GVL samples" do
-          skip "Temporarily skipped until we can fix flakiness"
-
           background_thread_affected_by_gvl_contention
           ready_queue_2.pop
 

--- a/spec/datadog/profiling/collectors/stack_spec.rb
+++ b/spec/datadog/profiling/collectors/stack_spec.rb
@@ -305,6 +305,15 @@ RSpec.describe Datadog::Profiling::Collectors::Stack do
         it do
           expect(sample_and_decode(background_thread, :labels)).to include(state: "sleeping")
         end
+
+        # See comment on sample_thread in collectors_stack.c for details of why we do this
+        context 'when wall_time is zero' do
+          let(:metric_values) { {"cpu-time" => 0, "cpu-samples" => 1, "wall-time" => 0} }
+
+          it do
+            expect(sample_and_decode(background_thread, :labels)).to include(state: "sleeping")
+          end
+        end
       end
 
       context "when sampling a thread waiting on a select" do


### PR DESCRIPTION
**What does this PR do?**

This PR fixes a small bug in GVL profiling that was causing test flakiness such as
https://app.circleci.com/pipelines/github/DataDog/dd-trace-rb/16739/workflows/fe009eb1-d942-4432-bc39-713fa9a3b751/jobs/600523

The TL;DR is that it's possible for the "Waiting for GVL" state to be entered in parallel with a sample. This means that the wall-time timestamp used by the profiler trying to take a sample is actually < the wall-time timestamp where the "Waiting for GVL" started.

This was causing the profiler to generate samples with wall-time of zero, which means:
1. Samples that are not useful are created
2. These samples, which were "Waiting for GVL" samples, were not showing up as such because the stack collector did not apply states to samples with wall-time of zero.

These two things together were confusing our
"Datadog::Profiling::Collectors::CpuAndWallTimeWorker#start when main thread is sleeping but a background thread is working when GVL profiling is enabled records Waiting for GVL samples"
spec, because that spec assumed that all samples for the `background_thread_affected_by_gvl_contention` were either "Waiting for GVL" or "on cpu", but we were getting a bunch of "unknown" state samples.

**Motivation:**

This avoids producing samples which are not useful and also gets rid of a source of flakiness for a test.

**Additional Notes:**

It's a bit hard to test some of this behavior using unit tests, so I'm relying on the integration-style checks to catch it.

**How to test the change?**

The main test for this behavior is the spec being re-activated.