### PR TITLE
Support stats "ratio_in_yjit"

### DIFF
--- a/.github/workflows/test-yjit.yaml
+++ b/.github/workflows/test-yjit.yaml
@@ -11,10 +11,40 @@ jobs:
           - '3.2'
           - '3.3'
           # ADD NEW RUBIES HERE
-    name: Test (${{ matrix.os }}, ${{ matrix.ruby }})
+    name: Test YJIT (${{ matrix.os }}, ${{ matrix.ruby }})
     runs-on: ${{ matrix.os }}
     env:
       RUBYOPT: "--yjit"
+      SKIP_SIMPLECOV: 1
+      DD_INSTRUMENTATION_TELEMETRY_ENABLED: false
+      DD_REMOTE_CONFIGURATION_ENABLED: false
+    steps:
+      - uses: actions/checkout@v4
+      # bundler appears to match both prerelease and release rubies when we
+      # want the former only. relax the constraint to allow any version for
+      # head rubies
+      - if: ${{ matrix.ruby == 'head' }}
+        run: sed -i~ -e '/spec\.required_ruby_version/d' datadog.gemspec
+      - uses: ruby/setup-ruby@v1
+        with:
+          ruby-version: ${{ matrix.ruby }}
+          bundler-cache: true # runs 'bundle install' and caches installed gems automatically
+          bundler: latest # needed to fix issue with steep on Ruby 3.0/3.1
+          cache-version: v2 # bump this to invalidate cache
+      - run: bundle exec rake spec:yjit
+  test-yjit-stats:
+    strategy:
+      fail-fast: false
+      matrix:
+        os:
+          - ubuntu-latest
+        ruby:
+          - '3.3'
+          # ADD NEW RUBIES HERE
+    name: Test YJIT Stats (${{ matrix.os }}, ${{ matrix.ruby }})
+    runs-on: ${{ matrix.os }}
+    env:
+      RUBYOPT: "--yjit --yjit-stats=quiet"
       SKIP_SIMPLECOV: 1
       DD_INSTRUMENTATION_TELEMETRY_ENABLED: false
       DD_REMOTE_CONFIGURATION_ENABLED: false

--- a/.github/workflows/test-yjit.yaml
+++ b/.github/workflows/test-yjit.yaml
@@ -10,41 +10,14 @@ jobs:
         ruby:
           - '3.2'
           - '3.3'
+        rubyopt:
+          - '--yjit'
+          - '--yjit --yjit-stats=quiet'
           # ADD NEW RUBIES HERE
-    name: Test YJIT (${{ matrix.os }}, ${{ matrix.ruby }})
+    name: Test YJIT (${{ matrix.os }}, ${{ matrix.ruby }} ${{ matrix.rubyopt }})
     runs-on: ${{ matrix.os }}
     env:
-      RUBYOPT: "--yjit"
-      SKIP_SIMPLECOV: 1
-      DD_INSTRUMENTATION_TELEMETRY_ENABLED: false
-      DD_REMOTE_CONFIGURATION_ENABLED: false
-    steps:
-      - uses: actions/checkout@v4
-      # bundler appears to match both prerelease and release rubies when we
-      # want the former only. relax the constraint to allow any version for
-      # head rubies
-      - if: ${{ matrix.ruby == 'head' }}
-        run: sed -i~ -e '/spec\.required_ruby_version/d' datadog.gemspec
-      - uses: ruby/setup-ruby@v1
-        with:
-          ruby-version: ${{ matrix.ruby }}
-          bundler-cache: true # runs 'bundle install' and caches installed gems automatically
-          bundler: latest # needed to fix issue with steep on Ruby 3.0/3.1
-          cache-version: v2 # bump this to invalidate cache
-      - run: bundle exec rake spec:yjit
-  test-yjit-stats:
-    strategy:
-      fail-fast: false
-      matrix:
-        os:
-          - ubuntu-latest
-        ruby:
-          - '3.3'
-          # ADD NEW RUBIES HERE
-    name: Test YJIT Stats (${{ matrix.os }}, ${{ matrix.ruby }})
-    runs-on: ${{ matrix.os }}
-    env:
-      RUBYOPT: "--yjit --yjit-stats=quiet"
+      RUBYOPT: ${{ matrix.rubyopt }}
       SKIP_SIMPLECOV: 1
       DD_INSTRUMENTATION_TELEMETRY_ENABLED: false
       DD_REMOTE_CONFIGURATION_ENABLED: false

--- a/.github/workflows/test-yjit.yaml
+++ b/.github/workflows/test-yjit.yaml
@@ -10,10 +10,10 @@ jobs:
         ruby:
           - '3.2'
           - '3.3'
+          # ADD NEW RUBIES HERE
         rubyopt:
           - '--yjit'
           - '--yjit --yjit-stats=quiet'
-          # ADD NEW RUBIES HERE
     name: Test YJIT (${{ matrix.os }}, ${{ matrix.ruby }} ${{ matrix.rubyopt }})
     runs-on: ${{ matrix.os }}
     env:

--- a/.github/workflows/test-yjit.yaml
+++ b/.github/workflows/test-yjit.yaml
@@ -14,6 +14,9 @@ jobs:
         rubyopt:
           - '--yjit'
           - '--yjit --yjit-stats=quiet'
+        exclude:
+          - ruby: '3.2'
+            rubyopt: '--yjit --yjit-stats=quiet'
     name: Test YJIT (${{ matrix.os }}, ${{ matrix.ruby }} ${{ matrix.rubyopt }})
     runs-on: ${{ matrix.os }}
     env:

--- a/lib/datadog/core/environment/yjit.rb
+++ b/lib/datadog/core/environment/yjit.rb
@@ -62,10 +62,6 @@ module Datadog
             && ::RubyVM::YJIT.enabled? \
             && ::RubyVM::YJIT.respond_to?(:runtime_stats)
         end
-
-        def stats_available?
-          available? && ::RubyVM::YJIT.respond_to?(:stats_enabled?)
-        end
       end
     end
   end

--- a/lib/datadog/core/environment/yjit.rb
+++ b/lib/datadog/core/environment/yjit.rb
@@ -52,10 +52,19 @@ module Datadog
           ::RubyVM::YJIT.runtime_stats[:yjit_alloc_size]
         end
 
+        # Ratio of YJIT-executed instructions
+        def ratio_in_yjit
+          ::RubyVM::YJIT.runtime_stats[:ratio_in_yjit]
+        end
+
         def available?
           defined?(::RubyVM::YJIT) \
             && ::RubyVM::YJIT.enabled? \
             && ::RubyVM::YJIT.respond_to?(:runtime_stats)
+        end
+
+        def stats_available?
+          available? && ::RubyVM::YJIT.respond_to?(:stats_enabled?)
         end
       end
     end

--- a/lib/datadog/core/runtime/ext.rb
+++ b/lib/datadog/core/runtime/ext.rb
@@ -31,7 +31,7 @@ module Datadog
           METRIC_YJIT_OBJECT_SHAPE_COUNT = 'runtime.ruby.yjit.object_shape_count'
           METRIC_YJIT_OUTLINED_CODE_SIZE = 'runtime.ruby.yjit.outlined_code_size'
           METRIC_YJIT_YJIT_ALLOC_SIZE = 'runtime.ruby.yjit.yjit_alloc_size'
-          METRIC_YJIT_RATIO_IN_YJIT= 'runtime.ruby.yjit.ratio_in_yjit'
+          METRIC_YJIT_RATIO_IN_YJIT = 'runtime.ruby.yjit.ratio_in_yjit'
 
           TAG_SERVICE = 'service'
         end

--- a/lib/datadog/core/runtime/ext.rb
+++ b/lib/datadog/core/runtime/ext.rb
@@ -31,6 +31,7 @@ module Datadog
           METRIC_YJIT_OBJECT_SHAPE_COUNT = 'runtime.ruby.yjit.object_shape_count'
           METRIC_YJIT_OUTLINED_CODE_SIZE = 'runtime.ruby.yjit.outlined_code_size'
           METRIC_YJIT_YJIT_ALLOC_SIZE = 'runtime.ruby.yjit.yjit_alloc_size'
+          METRIC_YJIT_RATIO_IN_YJIT= 'runtime.ruby.yjit.ratio_in_yjit'
 
           TAG_SERVICE = 'service'
         end

--- a/lib/datadog/core/runtime/metrics.rb
+++ b/lib/datadog/core/runtime/metrics.rb
@@ -181,6 +181,10 @@ module Datadog
                 Core::Runtime::Ext::Metrics::METRIC_YJIT_YJIT_ALLOC_SIZE,
                 Core::Environment::YJIT.yjit_alloc_size
               )
+              gauge_if_not_nil(
+                Core::Runtime::Ext::Metrics::METRIC_YJIT_RATIO_IN_YJIT,
+                Core::Environment::YJIT.ratio_in_yjit
+              )
             end
           end
         end

--- a/sig/datadog/core/environment/yjit.rbs
+++ b/sig/datadog/core/environment/yjit.rbs
@@ -11,6 +11,7 @@ module Datadog
         def self?.code_region_size: () -> untyped
         def self?.object_shape_count: () -> untyped
         def self?.yjit_alloc_size: () -> untyped
+        def self?.ratio_in_yjit: () -> untyped
 
         def self?.available?: () -> untyped
       end

--- a/spec/datadog/core/runtime/metrics_spec.rb
+++ b/spec/datadog/core/runtime/metrics_spec.rb
@@ -251,10 +251,10 @@ RSpec.describe Datadog::Core::Runtime::Metrics do
 
         context 'with YJIT enabled and RubyVM::YJIT.stats_enabled? true' do
           before do
-            unless Datadog::Core::Environment::YJIT.stats_available?
+            skip('Test only runs on Ruby >= 3.3') if RUBY_VERSION < '3.3.'
+            unless Datadog::Core::Environment::YJIT.available? && ::RubyVM::YJIT.stats_enabled?
               skip('Test only runs with YJIT enabled and RubyVM::YJIT.stats_enabled? true')
             end
-            skip('Test only runs on Ruby >= 3.3') if RUBY_VERSION < '3.3.'
             allow(runtime_metrics).to receive(:gauge)
           end
 

--- a/spec/datadog/core/runtime/metrics_spec.rb
+++ b/spec/datadog/core/runtime/metrics_spec.rb
@@ -198,10 +198,10 @@ RSpec.describe Datadog::Core::Runtime::Metrics do
           skip('Test only runs on Ruby >= 3.2') if RUBY_VERSION < '3.2.'
         end
 
-        context 'with YJIT enabled and RubyVM::YJIT.stats_enabled? false' do
+        context 'with YJIT enabled' do
           before do
             unless Datadog::Core::Environment::YJIT.available?
-              skip('Test only runs with YJIT enabled and RubyVM::YJIT.stats_enabled? false')
+              skip('Test only runs with YJIT enabled')
             end
             allow(runtime_metrics).to receive(:gauge)
           end

--- a/spec/datadog/core/runtime/metrics_spec.rb
+++ b/spec/datadog/core/runtime/metrics_spec.rb
@@ -200,9 +200,7 @@ RSpec.describe Datadog::Core::Runtime::Metrics do
 
         context 'with YJIT enabled' do
           before do
-            unless Datadog::Core::Environment::YJIT.available?
-              skip('Test only runs with YJIT enabled')
-            end
+            skip('Test only runs with YJIT enabled') unless Datadog::Core::Environment::YJIT.available?
             allow(runtime_metrics).to receive(:gauge)
           end
 

--- a/spec/datadog/core/runtime/metrics_spec.rb
+++ b/spec/datadog/core/runtime/metrics_spec.rb
@@ -248,6 +248,24 @@ RSpec.describe Datadog::Core::Runtime::Metrics do
             end
           end
         end
+
+        context 'with YJIT enabled and RubyVM::YJIT.stats_enabled? true' do
+          before do
+            unless Datadog::Core::Environment::YJIT.stats_available?
+              skip('Test only runs with YJIT enabled and RubyVM::YJIT.stats_enabled? true')
+            end
+            skip('Test only runs on Ruby >= 3.3') if RUBY_VERSION < '3.3.'
+            allow(runtime_metrics).to receive(:gauge)
+          end
+
+          it do
+            flush
+
+            expect(runtime_metrics).to have_received(:gauge)
+              .with(Datadog::Core::Runtime::Ext::Metrics::METRIC_YJIT_RATIO_IN_YJIT, kind_of(Numeric))
+              .once
+          end
+        end
       end
     end
 


### PR DESCRIPTION
<!--
Check out the
https://github.com/DataDog/dd-trace-rb/blob/master/docs/DevelopmentGuide.md
for guidance on how to set up your development environment,
run the test suite, write new integrations, and more.
-->

**What does this PR do?**
<!-- A brief description of the change being made with this pull request. -->

When ruby's extended YJIT stats are available (`--yjit-stat`), then we have access to numerous additional stats.

This adds `:ratio_in_yjit`, which is only present when additional stats are enabled.

Example:

```shell
RUBYOPT='--yjit --yjit-stats=quiet' ruby -e '
  def foo = "a" * 10
  300.times{foo}
  puts "ratio_in_yjit: #{::RubyVM::YJIT.runtime_stats[:ratio_in_yjit]}"
'
ratio_in_yjit: 0.9550806290358625
```

**Motivation:**
<!-- What inspired you to submit this pull request? -->

This should allow for a better understanding of how to tune `--yjit-exec-mem-size`.

From https://github.com/ruby/ruby/blob/ef084cc8f4958c1b6e4ead99136631bef6d8ddba/doc/yjit/yjit.md?plain=1#L213-L223:

> If you start Ruby with `--yjit-stats`, e.g. using an environment variable `RUBYOPT=--yjit-stats`,
> `RubyVM::YJIT.runtime_stats[:ratio_in_yjit]` shows the ratio of YJIT-executed instructions in %.
> Ideally, `ratio_in_yjit` should be as large as 99%, and increasing `--yjit-exec-mem-size` often
> helps improving `ratio_in_yjit`.


**Additional Notes:**
<!-- Anything else we should know when reviewing? -->

Fwiw, I directly based this on the previous YJIT PRs, which were very helpful here:
- https://github.com/DataDog/dd-trace-rb/pull/2711
- https://github.com/DataDog/dd-trace-rb/pull/3661

`ratio_in_yjit` has been available sine 3.3.0: https://github.com/ruby/ruby/blob/caf0d2058aa223515897401ff94e11e1c0671ce0/doc/NEWS/NEWS-3.3.0.md?plain=1#L436

**How to test the change?**
<!--
Describe here how the change can be validated.
You are strongly encouraged to provide automated tests for this PR (unit or integration).
If this change cannot be feasibly tested, please explain why,
unless the change does not modify code (e.g. only modifies docs, comments).
-->

```
RUBYOPT="--yjit --yjit-stats=quiet" bundle exec rake spec:yjit

bundle exec rake spec:yjit # skipped
```
