### PR TITLE
Bump to version 2.4.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,29 @@
 
 ## [Unreleased]
 
+## [2.4.0] - 2024-10-11
+
+### Added
+
+* Core: Allow changing sampling rate for customer defined tags and resources ([#3956][])
+* Profiling: Add GVL profiling for Ruby 3.2+ as a preview feature ([#3929][])
+* Profiling: Otel: Add preview support for correlating profiling with otel ruby gem ([#3984][])
+* Tracing: AppSec: Add http.route tag to Rails, Grape, and Sinatra integrations ([#3849][])
+* Tracing: Add capabilities to remote config: tracing sample rate, tracing logs injection, tracing http header tags ([#3888][])
+* AppSec: Add a force disable of AppSec feature when using Ruby >= 3.3 with old FFI gem version ([#3969][])
+
+### Changed
+
+* AppSec: Improve PII compliance ([#3857][])
+* AppSec: Integrations: Improve accuracy of login tracking for Devise ([#3867][])
+* Crashtracking feature is now disabled by default ([#3970][])
+
+### Fixed
+
+* AppSec: Integrations: Fix GraphQL instrumentation for query fragments ([#3887][])
+* Bug: Profiling: Fix (small) memory leak in profiler when forking ([#3852][])
+* Tracing: Integrations: Fix GraphQL integration reconfiguration ([#3859][])
+
 ## [2.3.0] - 2024-08-22
 
 ### Added
@@ -2962,7 +2985,8 @@ Release notes: https://github.com/DataDog/dd-trace-rb/releases/tag/v0.3.1
 Git diff: https://github.com/DataDog/dd-trace-rb/compare/v0.3.0...v0.3.1
 
 
-[Unreleased]: https://github.com/DataDog/dd-trace-rb/compare/v2.3.0...master
+[Unreleased]: https://github.com/DataDog/dd-trace-rb/compare/v2.4.0...master
+[2.4.0]: https://github.com/DataDog/dd-trace-rb/compare/v2.3.0...v2.4.0
 [2.3.0]: https://github.com/DataDog/dd-trace-rb/compare/v2.2.0...v2.3.0
 [2.2.0]: https://github.com/DataDog/dd-trace-rb/compare/v2.1.0...v2.2.0
 [2.1.0]: https://github.com/DataDog/dd-trace-rb/compare/v2.0.0...v2.1.0
@@ -4383,6 +4407,18 @@ Git diff: https://github.com/DataDog/dd-trace-rb/compare/v0.3.0...v0.3.1
 [#3837]: https://github.com/DataDog/dd-trace-rb/issues/3837
 [#3839]: https://github.com/DataDog/dd-trace-rb/issues/3839
 [#3841]: https://github.com/DataDog/dd-trace-rb/issues/3841
+[#3849]: https://github.com/DataDog/dd-trace-rb/issues/3849
+[#3852]: https://github.com/DataDog/dd-trace-rb/issues/3852
+[#3857]: https://github.com/DataDog/dd-trace-rb/issues/3857
+[#3859]: https://github.com/DataDog/dd-trace-rb/issues/3859
+[#3867]: https://github.com/DataDog/dd-trace-rb/issues/3867
+[#3887]: https://github.com/DataDog/dd-trace-rb/issues/3887
+[#3888]: https://github.com/DataDog/dd-trace-rb/issues/3888
+[#3929]: https://github.com/DataDog/dd-trace-rb/issues/3929
+[#3956]: https://github.com/DataDog/dd-trace-rb/issues/3956
+[#3969]: https://github.com/DataDog/dd-trace-rb/issues/3969
+[#3970]: https://github.com/DataDog/dd-trace-rb/issues/3970
+[#3984]: https://github.com/DataDog/dd-trace-rb/issues/3984
 [@AdrianLC]: https://github.com/AdrianLC
 [@Azure7111]: https://github.com/Azure7111
 [@BabyGroot]: https://github.com/BabyGroot

--- a/gemfiles/jruby_9.2_activesupport.gemfile.lock
+++ b/gemfiles/jruby_9.2_activesupport.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    datadog (2.3.0)
+    datadog (2.4.0)
       debase-ruby_core_source (= 3.3.1)
       libdatadog (~> 12.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)

--- a/gemfiles/jruby_9.2_aws.gemfile.lock
+++ b/gemfiles/jruby_9.2_aws.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    datadog (2.3.0)
+    datadog (2.4.0)
       debase-ruby_core_source (= 3.3.1)
       libdatadog (~> 12.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)

--- a/gemfiles/jruby_9.2_contrib.gemfile.lock
+++ b/gemfiles/jruby_9.2_contrib.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    datadog (2.3.0)
+    datadog (2.4.0)
       debase-ruby_core_source (= 3.3.1)
       libdatadog (~> 12.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)

--- a/gemfiles/jruby_9.2_contrib_old.gemfile.lock
+++ b/gemfiles/jruby_9.2_contrib_old.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    datadog (2.3.0)
+    datadog (2.4.0)
       debase-ruby_core_source (= 3.3.1)
       libdatadog (~> 12.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)

--- a/gemfiles/jruby_9.2_core_old.gemfile.lock
+++ b/gemfiles/jruby_9.2_core_old.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    datadog (2.3.0)
+    datadog (2.4.0)
       debase-ruby_core_source (= 3.3.1)
       libdatadog (~> 12.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)

--- a/gemfiles/jruby_9.2_elasticsearch_7.gemfile.lock
+++ b/gemfiles/jruby_9.2_elasticsearch_7.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    datadog (2.3.0)
+    datadog (2.4.0)
       debase-ruby_core_source (= 3.3.1)
       libdatadog (~> 12.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)

--- a/gemfiles/jruby_9.2_elasticsearch_8.gemfile.lock
+++ b/gemfiles/jruby_9.2_elasticsearch_8.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    datadog (2.3.0)
+    datadog (2.4.0)
       debase-ruby_core_source (= 3.3.1)
       libdatadog (~> 12.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)

--- a/gemfiles/jruby_9.2_elasticsearch_latest.gemfile.lock
+++ b/gemfiles/jruby_9.2_elasticsearch_latest.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    datadog (2.3.0)
+    datadog (2.4.0)
       debase-ruby_core_source (= 3.3.1)
       libdatadog (~> 12.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)

--- a/gemfiles/jruby_9.2_graphql_2.0.gemfile.lock
+++ b/gemfiles/jruby_9.2_graphql_2.0.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    datadog (2.3.0)
+    datadog (2.4.0)
       debase-ruby_core_source (= 3.3.1)
       libdatadog (~> 12.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)

--- a/gemfiles/jruby_9.2_http.gemfile.lock
+++ b/gemfiles/jruby_9.2_http.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    datadog (2.3.0)
+    datadog (2.4.0)
       debase-ruby_core_source (= 3.3.1)
       libdatadog (~> 12.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)

--- a/gemfiles/jruby_9.2_opensearch_2.gemfile.lock
+++ b/gemfiles/jruby_9.2_opensearch_2.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    datadog (2.3.0)
+    datadog (2.4.0)
       debase-ruby_core_source (= 3.3.1)
       libdatadog (~> 12.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)

--- a/gemfiles/jruby_9.2_opensearch_3.gemfile.lock
+++ b/gemfiles/jruby_9.2_opensearch_3.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    datadog (2.3.0)
+    datadog (2.4.0)
       debase-ruby_core_source (= 3.3.1)
       libdatadog (~> 12.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)

--- a/gemfiles/jruby_9.2_opensearch_latest.gemfile.lock
+++ b/gemfiles/jruby_9.2_opensearch_latest.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    datadog (2.3.0)
+    datadog (2.4.0)
       debase-ruby_core_source (= 3.3.1)
       libdatadog (~> 12.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)

--- a/gemfiles/jruby_9.2_rack_1.gemfile.lock
+++ b/gemfiles/jruby_9.2_rack_1.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    datadog (2.3.0)
+    datadog (2.4.0)
       debase-ruby_core_source (= 3.3.1)
       libdatadog (~> 12.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)

--- a/gemfiles/jruby_9.2_rack_2.gemfile.lock
+++ b/gemfiles/jruby_9.2_rack_2.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    datadog (2.3.0)
+    datadog (2.4.0)
       debase-ruby_core_source (= 3.3.1)
       libdatadog (~> 12.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)

--- a/gemfiles/jruby_9.2_rack_3.gemfile.lock
+++ b/gemfiles/jruby_9.2_rack_3.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    datadog (2.3.0)
+    datadog (2.4.0)
       debase-ruby_core_source (= 3.3.1)
       libdatadog (~> 12.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)

--- a/gemfiles/jruby_9.2_rack_latest.gemfile.lock
+++ b/gemfiles/jruby_9.2_rack_latest.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    datadog (2.3.0)
+    datadog (2.4.0)
       debase-ruby_core_source (= 3.3.1)
       libdatadog (~> 12.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)

--- a/gemfiles/jruby_9.2_rails5_mysql2.gemfile.lock
+++ b/gemfiles/jruby_9.2_rails5_mysql2.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    datadog (2.3.0)
+    datadog (2.4.0)
       debase-ruby_core_source (= 3.3.1)
       libdatadog (~> 12.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)

--- a/gemfiles/jruby_9.2_rails5_postgres.gemfile.lock
+++ b/gemfiles/jruby_9.2_rails5_postgres.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    datadog (2.3.0)
+    datadog (2.4.0)
       debase-ruby_core_source (= 3.3.1)
       libdatadog (~> 12.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)

--- a/gemfiles/jruby_9.2_rails5_postgres_redis.gemfile.lock
+++ b/gemfiles/jruby_9.2_rails5_postgres_redis.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    datadog (2.3.0)
+    datadog (2.4.0)
       debase-ruby_core_source (= 3.3.1)
       libdatadog (~> 12.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)

--- a/gemfiles/jruby_9.2_rails5_postgres_redis_activesupport.gemfile.lock
+++ b/gemfiles/jruby_9.2_rails5_postgres_redis_activesupport.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    datadog (2.3.0)
+    datadog (2.4.0)
       debase-ruby_core_source (= 3.3.1)
       libdatadog (~> 12.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)

--- a/gemfiles/jruby_9.2_rails5_postgres_sidekiq.gemfile.lock
+++ b/gemfiles/jruby_9.2_rails5_postgres_sidekiq.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    datadog (2.3.0)
+    datadog (2.4.0)
       debase-ruby_core_source (= 3.3.1)
       libdatadog (~> 12.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)

--- a/gemfiles/jruby_9.2_rails5_semantic_logger.gemfile.lock
+++ b/gemfiles/jruby_9.2_rails5_semantic_logger.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    datadog (2.3.0)
+    datadog (2.4.0)
       debase-ruby_core_source (= 3.3.1)
       libdatadog (~> 12.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)

--- a/gemfiles/jruby_9.2_rails61_mysql2.gemfile.lock
+++ b/gemfiles/jruby_9.2_rails61_mysql2.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    datadog (2.3.0)
+    datadog (2.4.0)
       debase-ruby_core_source (= 3.3.1)
       libdatadog (~> 12.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)

--- a/gemfiles/jruby_9.2_rails61_postgres.gemfile.lock
+++ b/gemfiles/jruby_9.2_rails61_postgres.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    datadog (2.3.0)
+    datadog (2.4.0)
       debase-ruby_core_source (= 3.3.1)
       libdatadog (~> 12.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)

--- a/gemfiles/jruby_9.2_rails61_postgres_redis.gemfile.lock
+++ b/gemfiles/jruby_9.2_rails61_postgres_redis.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    datadog (2.3.0)
+    datadog (2.4.0)
       debase-ruby_core_source (= 3.3.1)
       libdatadog (~> 12.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)

--- a/gemfiles/jruby_9.2_rails61_postgres_sidekiq.gemfile.lock
+++ b/gemfiles/jruby_9.2_rails61_postgres_sidekiq.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    datadog (2.3.0)
+    datadog (2.4.0)
       debase-ruby_core_source (= 3.3.1)
       libdatadog (~> 12.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)

--- a/gemfiles/jruby_9.2_rails61_semantic_logger.gemfile.lock
+++ b/gemfiles/jruby_9.2_rails61_semantic_logger.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    datadog (2.3.0)
+    datadog (2.4.0)
       debase-ruby_core_source (= 3.3.1)
       libdatadog (~> 12.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)

--- a/gemfiles/jruby_9.2_rails6_mysql2.gemfile.lock
+++ b/gemfiles/jruby_9.2_rails6_mysql2.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    datadog (2.3.0)
+    datadog (2.4.0)
       debase-ruby_core_source (= 3.3.1)
       libdatadog (~> 12.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)

--- a/gemfiles/jruby_9.2_rails6_postgres.gemfile.lock
+++ b/gemfiles/jruby_9.2_rails6_postgres.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    datadog (2.3.0)
+    datadog (2.4.0)
       debase-ruby_core_source (= 3.3.1)
       libdatadog (~> 12.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)

--- a/gemfiles/jruby_9.2_rails6_postgres_redis.gemfile.lock
+++ b/gemfiles/jruby_9.2_rails6_postgres_redis.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    datadog (2.3.0)
+    datadog (2.4.0)
       debase-ruby_core_source (= 3.3.1)
       libdatadog (~> 12.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)

--- a/gemfiles/jruby_9.2_rails6_postgres_redis_activesupport.gemfile.lock
+++ b/gemfiles/jruby_9.2_rails6_postgres_redis_activesupport.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    datadog (2.3.0)
+    datadog (2.4.0)
       debase-ruby_core_source (= 3.3.1)
       libdatadog (~> 12.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)

--- a/gemfiles/jruby_9.2_rails6_postgres_sidekiq.gemfile.lock
+++ b/gemfiles/jruby_9.2_rails6_postgres_sidekiq.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    datadog (2.3.0)
+    datadog (2.4.0)
       debase-ruby_core_source (= 3.3.1)
       libdatadog (~> 12.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)

--- a/gemfiles/jruby_9.2_rails6_semantic_logger.gemfile.lock
+++ b/gemfiles/jruby_9.2_rails6_semantic_logger.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    datadog (2.3.0)
+    datadog (2.4.0)
       debase-ruby_core_source (= 3.3.1)
       libdatadog (~> 12.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)

--- a/gemfiles/jruby_9.2_redis_3.gemfile.lock
+++ b/gemfiles/jruby_9.2_redis_3.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    datadog (2.3.0)
+    datadog (2.4.0)
       debase-ruby_core_source (= 3.3.1)
       libdatadog (~> 12.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)

--- a/gemfiles/jruby_9.2_redis_4.gemfile.lock
+++ b/gemfiles/jruby_9.2_redis_4.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    datadog (2.3.0)
+    datadog (2.4.0)
       debase-ruby_core_source (= 3.3.1)
       libdatadog (~> 12.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)

--- a/gemfiles/jruby_9.2_redis_5.gemfile.lock
+++ b/gemfiles/jruby_9.2_redis_5.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    datadog (2.3.0)
+    datadog (2.4.0)
       debase-ruby_core_source (= 3.3.1)
       libdatadog (~> 12.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)

--- a/gemfiles/jruby_9.2_relational_db.gemfile.lock
+++ b/gemfiles/jruby_9.2_relational_db.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    datadog (2.3.0)
+    datadog (2.4.0)
       debase-ruby_core_source (= 3.3.1)
       libdatadog (~> 12.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)

--- a/gemfiles/jruby_9.2_resque2_redis3.gemfile.lock
+++ b/gemfiles/jruby_9.2_resque2_redis3.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    datadog (2.3.0)
+    datadog (2.4.0)
       debase-ruby_core_source (= 3.3.1)
       libdatadog (~> 12.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)

--- a/gemfiles/jruby_9.2_resque2_redis4.gemfile.lock
+++ b/gemfiles/jruby_9.2_resque2_redis4.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    datadog (2.3.0)
+    datadog (2.4.0)
       debase-ruby_core_source (= 3.3.1)
       libdatadog (~> 12.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)

--- a/gemfiles/jruby_9.2_sinatra_2.gemfile.lock
+++ b/gemfiles/jruby_9.2_sinatra_2.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    datadog (2.3.0)
+    datadog (2.4.0)
       debase-ruby_core_source (= 3.3.1)
       libdatadog (~> 12.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)

--- a/gemfiles/jruby_9.2_stripe_10.gemfile.lock
+++ b/gemfiles/jruby_9.2_stripe_10.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    datadog (2.3.0)
+    datadog (2.4.0)
       debase-ruby_core_source (= 3.3.1)
       libdatadog (~> 12.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)

--- a/gemfiles/jruby_9.2_stripe_11.gemfile.lock
+++ b/gemfiles/jruby_9.2_stripe_11.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    datadog (2.3.0)
+    datadog (2.4.0)
       debase-ruby_core_source (= 3.3.1)
       libdatadog (~> 12.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)

--- a/gemfiles/jruby_9.2_stripe_12.gemfile.lock
+++ b/gemfiles/jruby_9.2_stripe_12.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    datadog (2.3.0)
+    datadog (2.4.0)
       debase-ruby_core_source (= 3.3.1)
       libdatadog (~> 12.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)

--- a/gemfiles/jruby_9.2_stripe_7.gemfile.lock
+++ b/gemfiles/jruby_9.2_stripe_7.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    datadog (2.3.0)
+    datadog (2.4.0)
       debase-ruby_core_source (= 3.3.1)
       libdatadog (~> 12.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)

--- a/gemfiles/jruby_9.2_stripe_8.gemfile.lock
+++ b/gemfiles/jruby_9.2_stripe_8.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    datadog (2.3.0)
+    datadog (2.4.0)
       debase-ruby_core_source (= 3.3.1)
       libdatadog (~> 12.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)

--- a/gemfiles/jruby_9.2_stripe_9.gemfile.lock
+++ b/gemfiles/jruby_9.2_stripe_9.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    datadog (2.3.0)
+    datadog (2.4.0)
       debase-ruby_core_source (= 3.3.1)
       libdatadog (~> 12.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)

--- a/gemfiles/jruby_9.2_stripe_latest.gemfile.lock
+++ b/gemfiles/jruby_9.2_stripe_latest.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    datadog (2.3.0)
+    datadog (2.4.0)
       debase-ruby_core_source (= 3.3.1)
       libdatadog (~> 12.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)

--- a/gemfiles/jruby_9.2_stripe_min.gemfile.lock
+++ b/gemfiles/jruby_9.2_stripe_min.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    datadog (2.3.0)
+    datadog (2.4.0)
       debase-ruby_core_source (= 3.3.1)
       libdatadog (~> 12.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)

--- a/gemfiles/jruby_9.3_activesupport.gemfile.lock
+++ b/gemfiles/jruby_9.3_activesupport.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    datadog (2.3.0)
+    datadog (2.4.0)
       debase-ruby_core_source (= 3.3.1)
       libdatadog (~> 12.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)

--- a/gemfiles/jruby_9.3_aws.gemfile.lock
+++ b/gemfiles/jruby_9.3_aws.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    datadog (2.3.0)
+    datadog (2.4.0)
       debase-ruby_core_source (= 3.3.1)
       libdatadog (~> 12.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)

--- a/gemfiles/jruby_9.3_contrib.gemfile.lock
+++ b/gemfiles/jruby_9.3_contrib.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    datadog (2.3.0)
+    datadog (2.4.0)
       debase-ruby_core_source (= 3.3.1)
       libdatadog (~> 12.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)

--- a/gemfiles/jruby_9.3_contrib_old.gemfile.lock
+++ b/gemfiles/jruby_9.3_contrib_old.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    datadog (2.3.0)
+    datadog (2.4.0)
       debase-ruby_core_source (= 3.3.1)
       libdatadog (~> 12.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)

--- a/gemfiles/jruby_9.3_core_old.gemfile.lock
+++ b/gemfiles/jruby_9.3_core_old.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    datadog (2.3.0)
+    datadog (2.4.0)
       debase-ruby_core_source (= 3.3.1)
       libdatadog (~> 12.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)

--- a/gemfiles/jruby_9.3_elasticsearch_7.gemfile.lock
+++ b/gemfiles/jruby_9.3_elasticsearch_7.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    datadog (2.3.0)
+    datadog (2.4.0)
       debase-ruby_core_source (= 3.3.1)
       libdatadog (~> 12.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)

--- a/gemfiles/jruby_9.3_elasticsearch_8.gemfile.lock
+++ b/gemfiles/jruby_9.3_elasticsearch_8.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    datadog (2.3.0)
+    datadog (2.4.0)
       debase-ruby_core_source (= 3.3.1)
       libdatadog (~> 12.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)

--- a/gemfiles/jruby_9.3_elasticsearch_latest.gemfile.lock
+++ b/gemfiles/jruby_9.3_elasticsearch_latest.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    datadog (2.3.0)
+    datadog (2.4.0)
       debase-ruby_core_source (= 3.3.1)
       libdatadog (~> 12.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)

--- a/gemfiles/jruby_9.3_graphql_1.13.gemfile.lock
+++ b/gemfiles/jruby_9.3_graphql_1.13.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    datadog (2.3.0)
+    datadog (2.4.0)
       debase-ruby_core_source (= 3.3.1)
       libdatadog (~> 12.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)

--- a/gemfiles/jruby_9.3_graphql_2.0.gemfile.lock
+++ b/gemfiles/jruby_9.3_graphql_2.0.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    datadog (2.3.0)
+    datadog (2.4.0)
       debase-ruby_core_source (= 3.3.1)
       libdatadog (~> 12.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)

--- a/gemfiles/jruby_9.3_http.gemfile.lock
+++ b/gemfiles/jruby_9.3_http.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    datadog (2.3.0)
+    datadog (2.4.0)
       debase-ruby_core_source (= 3.3.1)
       libdatadog (~> 12.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)

--- a/gemfiles/jruby_9.3_opensearch_2.gemfile.lock
+++ b/gemfiles/jruby_9.3_opensearch_2.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    datadog (2.3.0)
+    datadog (2.4.0)
       debase-ruby_core_source (= 3.3.1)
       libdatadog (~> 12.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)

--- a/gemfiles/jruby_9.3_opensearch_3.gemfile.lock
+++ b/gemfiles/jruby_9.3_opensearch_3.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    datadog (2.3.0)
+    datadog (2.4.0)
       debase-ruby_core_source (= 3.3.1)
       libdatadog (~> 12.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)

--- a/gemfiles/jruby_9.3_opensearch_latest.gemfile.lock
+++ b/gemfiles/jruby_9.3_opensearch_latest.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    datadog (2.3.0)
+    datadog (2.4.0)
       debase-ruby_core_source (= 3.3.1)
       libdatadog (~> 12.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)

--- a/gemfiles/jruby_9.3_rack_1.gemfile.lock
+++ b/gemfiles/jruby_9.3_rack_1.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    datadog (2.3.0)
+    datadog (2.4.0)
       debase-ruby_core_source (= 3.3.1)
       libdatadog (~> 12.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)

--- a/gemfiles/jruby_9.3_rack_2.gemfile.lock
+++ b/gemfiles/jruby_9.3_rack_2.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    datadog (2.3.0)
+    datadog (2.4.0)
       debase-ruby_core_source (= 3.3.1)
       libdatadog (~> 12.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)

--- a/gemfiles/jruby_9.3_rack_3.gemfile.lock
+++ b/gemfiles/jruby_9.3_rack_3.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    datadog (2.3.0)
+    datadog (2.4.0)
       debase-ruby_core_source (= 3.3.1)
       libdatadog (~> 12.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)

--- a/gemfiles/jruby_9.3_rack_latest.gemfile.lock
+++ b/gemfiles/jruby_9.3_rack_latest.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    datadog (2.3.0)
+    datadog (2.4.0)
       debase-ruby_core_source (= 3.3.1)
       libdatadog (~> 12.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)

--- a/gemfiles/jruby_9.3_rails5_mysql2.gemfile.lock
+++ b/gemfiles/jruby_9.3_rails5_mysql2.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    datadog (2.3.0)
+    datadog (2.4.0)
       debase-ruby_core_source (= 3.3.1)
       libdatadog (~> 12.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)

--- a/gemfiles/jruby_9.3_rails5_postgres.gemfile.lock
+++ b/gemfiles/jruby_9.3_rails5_postgres.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    datadog (2.3.0)
+    datadog (2.4.0)
       debase-ruby_core_source (= 3.3.1)
       libdatadog (~> 12.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)

--- a/gemfiles/jruby_9.3_rails5_postgres_redis.gemfile.lock
+++ b/gemfiles/jruby_9.3_rails5_postgres_redis.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    datadog (2.3.0)
+    datadog (2.4.0)
       debase-ruby_core_source (= 3.3.1)
       libdatadog (~> 12.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)

--- a/gemfiles/jruby_9.3_rails5_postgres_redis_activesupport.gemfile.lock
+++ b/gemfiles/jruby_9.3_rails5_postgres_redis_activesupport.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    datadog (2.3.0)
+    datadog (2.4.0)
       debase-ruby_core_source (= 3.3.1)
       libdatadog (~> 12.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)

--- a/gemfiles/jruby_9.3_rails5_postgres_sidekiq.gemfile.lock
+++ b/gemfiles/jruby_9.3_rails5_postgres_sidekiq.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    datadog (2.3.0)
+    datadog (2.4.0)
       debase-ruby_core_source (= 3.3.1)
       libdatadog (~> 12.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)

--- a/gemfiles/jruby_9.3_rails5_semantic_logger.gemfile.lock
+++ b/gemfiles/jruby_9.3_rails5_semantic_logger.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    datadog (2.3.0)
+    datadog (2.4.0)
       debase-ruby_core_source (= 3.3.1)
       libdatadog (~> 12.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)

--- a/gemfiles/jruby_9.3_rails61_mysql2.gemfile.lock
+++ b/gemfiles/jruby_9.3_rails61_mysql2.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    datadog (2.3.0)
+    datadog (2.4.0)
       debase-ruby_core_source (= 3.3.1)
       libdatadog (~> 12.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)

--- a/gemfiles/jruby_9.3_rails61_postgres.gemfile.lock
+++ b/gemfiles/jruby_9.3_rails61_postgres.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    datadog (2.3.0)
+    datadog (2.4.0)
       debase-ruby_core_source (= 3.3.1)
       libdatadog (~> 12.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)

--- a/gemfiles/jruby_9.3_rails61_postgres_redis.gemfile.lock
+++ b/gemfiles/jruby_9.3_rails61_postgres_redis.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    datadog (2.3.0)
+    datadog (2.4.0)
       debase-ruby_core_source (= 3.3.1)
       libdatadog (~> 12.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)

--- a/gemfiles/jruby_9.3_rails61_postgres_sidekiq.gemfile.lock
+++ b/gemfiles/jruby_9.3_rails61_postgres_sidekiq.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    datadog (2.3.0)
+    datadog (2.4.0)
       debase-ruby_core_source (= 3.3.1)
       libdatadog (~> 12.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)

--- a/gemfiles/jruby_9.3_rails61_semantic_logger.gemfile.lock
+++ b/gemfiles/jruby_9.3_rails61_semantic_logger.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    datadog (2.3.0)
+    datadog (2.4.0)
       debase-ruby_core_source (= 3.3.1)
       libdatadog (~> 12.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)

--- a/gemfiles/jruby_9.3_rails6_mysql2.gemfile.lock
+++ b/gemfiles/jruby_9.3_rails6_mysql2.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    datadog (2.3.0)
+    datadog (2.4.0)
       debase-ruby_core_source (= 3.3.1)
       libdatadog (~> 12.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)

--- a/gemfiles/jruby_9.3_rails6_postgres.gemfile.lock
+++ b/gemfiles/jruby_9.3_rails6_postgres.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    datadog (2.3.0)
+    datadog (2.4.0)
       debase-ruby_core_source (= 3.3.1)
       libdatadog (~> 12.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)

--- a/gemfiles/jruby_9.3_rails6_postgres_redis.gemfile.lock
+++ b/gemfiles/jruby_9.3_rails6_postgres_redis.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    datadog (2.3.0)
+    datadog (2.4.0)
       debase-ruby_core_source (= 3.3.1)
       libdatadog (~> 12.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)

--- a/gemfiles/jruby_9.3_rails6_postgres_redis_activesupport.gemfile.lock
+++ b/gemfiles/jruby_9.3_rails6_postgres_redis_activesupport.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    datadog (2.3.0)
+    datadog (2.4.0)
       debase-ruby_core_source (= 3.3.1)
       libdatadog (~> 12.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)

--- a/gemfiles/jruby_9.3_rails6_postgres_sidekiq.gemfile.lock
+++ b/gemfiles/jruby_9.3_rails6_postgres_sidekiq.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    datadog (2.3.0)
+    datadog (2.4.0)
       debase-ruby_core_source (= 3.3.1)
       libdatadog (~> 12.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)

--- a/gemfiles/jruby_9.3_rails6_semantic_logger.gemfile.lock
+++ b/gemfiles/jruby_9.3_rails6_semantic_logger.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    datadog (2.3.0)
+    datadog (2.4.0)
       debase-ruby_core_source (= 3.3.1)
       libdatadog (~> 12.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)

--- a/gemfiles/jruby_9.3_redis_3.gemfile.lock
+++ b/gemfiles/jruby_9.3_redis_3.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    datadog (2.3.0)
+    datadog (2.4.0)
       debase-ruby_core_source (= 3.3.1)
       libdatadog (~> 12.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)

--- a/gemfiles/jruby_9.3_redis_4.gemfile.lock
+++ b/gemfiles/jruby_9.3_redis_4.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    datadog (2.3.0)
+    datadog (2.4.0)
       debase-ruby_core_source (= 3.3.1)
       libdatadog (~> 12.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)

--- a/gemfiles/jruby_9.3_redis_5.gemfile.lock
+++ b/gemfiles/jruby_9.3_redis_5.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    datadog (2.3.0)
+    datadog (2.4.0)
       debase-ruby_core_source (= 3.3.1)
       libdatadog (~> 12.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)

--- a/gemfiles/jruby_9.3_relational_db.gemfile.lock
+++ b/gemfiles/jruby_9.3_relational_db.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    datadog (2.3.0)
+    datadog (2.4.0)
       debase-ruby_core_source (= 3.3.1)
       libdatadog (~> 12.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)

--- a/gemfiles/jruby_9.3_resque2_redis3.gemfile.lock
+++ b/gemfiles/jruby_9.3_resque2_redis3.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    datadog (2.3.0)
+    datadog (2.4.0)
       debase-ruby_core_source (= 3.3.1)
       libdatadog (~> 12.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)

--- a/gemfiles/jruby_9.3_resque2_redis4.gemfile.lock
+++ b/gemfiles/jruby_9.3_resque2_redis4.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    datadog (2.3.0)
+    datadog (2.4.0)
       debase-ruby_core_source (= 3.3.1)
       libdatadog (~> 12.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)

--- a/gemfiles/jruby_9.3_sinatra_2.gemfile.lock
+++ b/gemfiles/jruby_9.3_sinatra_2.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    datadog (2.3.0)
+    datadog (2.4.0)
       debase-ruby_core_source (= 3.3.1)
       libdatadog (~> 12.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)

--- a/gemfiles/jruby_9.3_sinatra_3.gemfile.lock
+++ b/gemfiles/jruby_9.3_sinatra_3.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    datadog (2.3.0)
+    datadog (2.4.0)
       debase-ruby_core_source (= 3.3.1)
       libdatadog (~> 12.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)

--- a/gemfiles/jruby_9.3_stripe_10.gemfile.lock
+++ b/gemfiles/jruby_9.3_stripe_10.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    datadog (2.3.0)
+    datadog (2.4.0)
       debase-ruby_core_source (= 3.3.1)
       libdatadog (~> 12.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)

--- a/gemfiles/jruby_9.3_stripe_11.gemfile.lock
+++ b/gemfiles/jruby_9.3_stripe_11.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    datadog (2.3.0)
+    datadog (2.4.0)
       debase-ruby_core_source (= 3.3.1)
       libdatadog (~> 12.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)

--- a/gemfiles/jruby_9.3_stripe_12.gemfile.lock
+++ b/gemfiles/jruby_9.3_stripe_12.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    datadog (2.3.0)
+    datadog (2.4.0)
       debase-ruby_core_source (= 3.3.1)
       libdatadog (~> 12.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)

--- a/gemfiles/jruby_9.3_stripe_7.gemfile.lock
+++ b/gemfiles/jruby_9.3_stripe_7.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    datadog (2.3.0)
+    datadog (2.4.0)
       debase-ruby_core_source (= 3.3.1)
       libdatadog (~> 12.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)

--- a/gemfiles/jruby_9.3_stripe_8.gemfile.lock
+++ b/gemfiles/jruby_9.3_stripe_8.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    datadog (2.3.0)
+    datadog (2.4.0)
       debase-ruby_core_source (= 3.3.1)
       libdatadog (~> 12.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)

--- a/gemfiles/jruby_9.3_stripe_9.gemfile.lock
+++ b/gemfiles/jruby_9.3_stripe_9.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    datadog (2.3.0)
+    datadog (2.4.0)
       debase-ruby_core_source (= 3.3.1)
       libdatadog (~> 12.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)

--- a/gemfiles/jruby_9.3_stripe_latest.gemfile.lock
+++ b/gemfiles/jruby_9.3_stripe_latest.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    datadog (2.3.0)
+    datadog (2.4.0)
       debase-ruby_core_source (= 3.3.1)
       libdatadog (~> 12.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)

--- a/gemfiles/jruby_9.3_stripe_min.gemfile.lock
+++ b/gemfiles/jruby_9.3_stripe_min.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    datadog (2.3.0)
+    datadog (2.4.0)
       debase-ruby_core_source (= 3.3.1)
       libdatadog (~> 12.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)

--- a/gemfiles/jruby_9.4_activesupport.gemfile.lock
+++ b/gemfiles/jruby_9.4_activesupport.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    datadog (2.3.0)
+    datadog (2.4.0)
       debase-ruby_core_source (= 3.3.1)
       libdatadog (~> 12.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)

--- a/gemfiles/jruby_9.4_aws.gemfile.lock
+++ b/gemfiles/jruby_9.4_aws.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    datadog (2.3.0)
+    datadog (2.4.0)
       debase-ruby_core_source (= 3.3.1)
       libdatadog (~> 12.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)

--- a/gemfiles/jruby_9.4_contrib.gemfile.lock
+++ b/gemfiles/jruby_9.4_contrib.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    datadog (2.3.0)
+    datadog (2.4.0)
       debase-ruby_core_source (= 3.3.1)
       libdatadog (~> 12.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)

--- a/gemfiles/jruby_9.4_contrib_old.gemfile.lock
+++ b/gemfiles/jruby_9.4_contrib_old.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    datadog (2.3.0)
+    datadog (2.4.0)
       debase-ruby_core_source (= 3.3.1)
       libdatadog (~> 12.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)

--- a/gemfiles/jruby_9.4_core_old.gemfile.lock
+++ b/gemfiles/jruby_9.4_core_old.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    datadog (2.3.0)
+    datadog (2.4.0)
       debase-ruby_core_source (= 3.3.1)
       libdatadog (~> 12.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)

--- a/gemfiles/jruby_9.4_elasticsearch_7.gemfile.lock
+++ b/gemfiles/jruby_9.4_elasticsearch_7.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    datadog (2.3.0)
+    datadog (2.4.0)
       debase-ruby_core_source (= 3.3.1)
       libdatadog (~> 12.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)

--- a/gemfiles/jruby_9.4_elasticsearch_8.gemfile.lock
+++ b/gemfiles/jruby_9.4_elasticsearch_8.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    datadog (2.3.0)
+    datadog (2.4.0)
       debase-ruby_core_source (= 3.3.1)
       libdatadog (~> 12.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)

--- a/gemfiles/jruby_9.4_elasticsearch_latest.gemfile.lock
+++ b/gemfiles/jruby_9.4_elasticsearch_latest.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    datadog (2.3.0)
+    datadog (2.4.0)
       debase-ruby_core_source (= 3.3.1)
       libdatadog (~> 12.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)

--- a/gemfiles/jruby_9.4_graphql_1.13.gemfile.lock
+++ b/gemfiles/jruby_9.4_graphql_1.13.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    datadog (2.3.0)
+    datadog (2.4.0)
       debase-ruby_core_source (= 3.3.1)
       libdatadog (~> 12.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)

--- a/gemfiles/jruby_9.4_graphql_2.0.gemfile.lock
+++ b/gemfiles/jruby_9.4_graphql_2.0.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    datadog (2.3.0)
+    datadog (2.4.0)
       debase-ruby_core_source (= 3.3.1)
       libdatadog (~> 12.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)

--- a/gemfiles/jruby_9.4_graphql_2.1.gemfile.lock
+++ b/gemfiles/jruby_9.4_graphql_2.1.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    datadog (2.3.0)
+    datadog (2.4.0)
       debase-ruby_core_source (= 3.3.1)
       libdatadog (~> 12.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)

--- a/gemfiles/jruby_9.4_graphql_2.2.gemfile.lock
+++ b/gemfiles/jruby_9.4_graphql_2.2.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    datadog (2.3.0)
+    datadog (2.4.0)
       debase-ruby_core_source (= 3.3.1)
       libdatadog (~> 12.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)

--- a/gemfiles/jruby_9.4_graphql_2.3.gemfile.lock
+++ b/gemfiles/jruby_9.4_graphql_2.3.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    datadog (2.3.0)
+    datadog (2.4.0)
       debase-ruby_core_source (= 3.3.1)
       libdatadog (~> 12.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)

--- a/gemfiles/jruby_9.4_http.gemfile.lock
+++ b/gemfiles/jruby_9.4_http.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    datadog (2.3.0)
+    datadog (2.4.0)
       debase-ruby_core_source (= 3.3.1)
       libdatadog (~> 12.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)

--- a/gemfiles/jruby_9.4_opensearch_2.gemfile.lock
+++ b/gemfiles/jruby_9.4_opensearch_2.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    datadog (2.3.0)
+    datadog (2.4.0)
       debase-ruby_core_source (= 3.3.1)
       libdatadog (~> 12.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)

--- a/gemfiles/jruby_9.4_opensearch_3.gemfile.lock
+++ b/gemfiles/jruby_9.4_opensearch_3.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    datadog (2.3.0)
+    datadog (2.4.0)
       debase-ruby_core_source (= 3.3.1)
       libdatadog (~> 12.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)

--- a/gemfiles/jruby_9.4_opensearch_latest.gemfile.lock
+++ b/gemfiles/jruby_9.4_opensearch_latest.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    datadog (2.3.0)
+    datadog (2.4.0)
       debase-ruby_core_source (= 3.3.1)
       libdatadog (~> 12.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)

--- a/gemfiles/jruby_9.4_rack_1.gemfile.lock
+++ b/gemfiles/jruby_9.4_rack_1.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    datadog (2.3.0)
+    datadog (2.4.0)
       debase-ruby_core_source (= 3.3.1)
       libdatadog (~> 12.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)

--- a/gemfiles/jruby_9.4_rack_2.gemfile.lock
+++ b/gemfiles/jruby_9.4_rack_2.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    datadog (2.3.0)
+    datadog (2.4.0)
       debase-ruby_core_source (= 3.3.1)
       libdatadog (~> 12.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)

--- a/gemfiles/jruby_9.4_rack_3.gemfile.lock
+++ b/gemfiles/jruby_9.4_rack_3.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    datadog (2.3.0)
+    datadog (2.4.0)
       debase-ruby_core_source (= 3.3.1)
       libdatadog (~> 12.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)

--- a/gemfiles/jruby_9.4_rack_latest.gemfile.lock
+++ b/gemfiles/jruby_9.4_rack_latest.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    datadog (2.3.0)
+    datadog (2.4.0)
       debase-ruby_core_source (= 3.3.1)
       libdatadog (~> 12.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)

--- a/gemfiles/jruby_9.4_rails61_mysql2.gemfile.lock
+++ b/gemfiles/jruby_9.4_rails61_mysql2.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    datadog (2.3.0)
+    datadog (2.4.0)
       debase-ruby_core_source (= 3.3.1)
       libdatadog (~> 12.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)

--- a/gemfiles/jruby_9.4_rails61_postgres.gemfile.lock
+++ b/gemfiles/jruby_9.4_rails61_postgres.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    datadog (2.3.0)
+    datadog (2.4.0)
       debase-ruby_core_source (= 3.3.1)
       libdatadog (~> 12.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)

--- a/gemfiles/jruby_9.4_rails61_postgres_redis.gemfile.lock
+++ b/gemfiles/jruby_9.4_rails61_postgres_redis.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    datadog (2.3.0)
+    datadog (2.4.0)
       debase-ruby_core_source (= 3.3.1)
       libdatadog (~> 12.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)

--- a/gemfiles/jruby_9.4_rails61_postgres_sidekiq.gemfile.lock
+++ b/gemfiles/jruby_9.4_rails61_postgres_sidekiq.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    datadog (2.3.0)
+    datadog (2.4.0)
       debase-ruby_core_source (= 3.3.1)
       libdatadog (~> 12.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)

--- a/gemfiles/jruby_9.4_rails61_semantic_logger.gemfile.lock
+++ b/gemfiles/jruby_9.4_rails61_semantic_logger.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    datadog (2.3.0)
+    datadog (2.4.0)
       debase-ruby_core_source (= 3.3.1)
       libdatadog (~> 12.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)

--- a/gemfiles/jruby_9.4_redis_3.gemfile.lock
+++ b/gemfiles/jruby_9.4_redis_3.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    datadog (2.3.0)
+    datadog (2.4.0)
       debase-ruby_core_source (= 3.3.1)
       libdatadog (~> 12.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)

--- a/gemfiles/jruby_9.4_redis_4.gemfile.lock
+++ b/gemfiles/jruby_9.4_redis_4.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    datadog (2.3.0)
+    datadog (2.4.0)
       debase-ruby_core_source (= 3.3.1)
       libdatadog (~> 12.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)

--- a/gemfiles/jruby_9.4_redis_5.gemfile.lock
+++ b/gemfiles/jruby_9.4_redis_5.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    datadog (2.3.0)
+    datadog (2.4.0)
       debase-ruby_core_source (= 3.3.1)
       libdatadog (~> 12.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)

--- a/gemfiles/jruby_9.4_relational_db.gemfile.lock
+++ b/gemfiles/jruby_9.4_relational_db.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    datadog (2.3.0)
+    datadog (2.4.0)
       debase-ruby_core_source (= 3.3.1)
       libdatadog (~> 12.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)

--- a/gemfiles/jruby_9.4_resque2_redis3.gemfile.lock
+++ b/gemfiles/jruby_9.4_resque2_redis3.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    datadog (2.3.0)
+    datadog (2.4.0)
       debase-ruby_core_source (= 3.3.1)
       libdatadog (~> 12.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)

--- a/gemfiles/jruby_9.4_resque2_redis4.gemfile.lock
+++ b/gemfiles/jruby_9.4_resque2_redis4.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    datadog (2.3.0)
+    datadog (2.4.0)
       debase-ruby_core_source (= 3.3.1)
       libdatadog (~> 12.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)

--- a/gemfiles/jruby_9.4_sinatra_2.gemfile.lock
+++ b/gemfiles/jruby_9.4_sinatra_2.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    datadog (2.3.0)
+    datadog (2.4.0)
       debase-ruby_core_source (= 3.3.1)
       libdatadog (~> 12.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)

--- a/gemfiles/jruby_9.4_sinatra_3.gemfile.lock
+++ b/gemfiles/jruby_9.4_sinatra_3.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    datadog (2.3.0)
+    datadog (2.4.0)
       debase-ruby_core_source (= 3.3.1)
       libdatadog (~> 12.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)

--- a/gemfiles/jruby_9.4_sinatra_4.gemfile.lock
+++ b/gemfiles/jruby_9.4_sinatra_4.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    datadog (2.3.0)
+    datadog (2.4.0)
       debase-ruby_core_source (= 3.3.1)
       libdatadog (~> 12.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)

--- a/gemfiles/jruby_9.4_stripe_10.gemfile.lock
+++ b/gemfiles/jruby_9.4_stripe_10.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    datadog (2.3.0)
+    datadog (2.4.0)
       debase-ruby_core_source (= 3.3.1)
       libdatadog (~> 12.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)

--- a/gemfiles/jruby_9.4_stripe_11.gemfile.lock
+++ b/gemfiles/jruby_9.4_stripe_11.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    datadog (2.3.0)
+    datadog (2.4.0)
       debase-ruby_core_source (= 3.3.1)
       libdatadog (~> 12.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)

--- a/gemfiles/jruby_9.4_stripe_12.gemfile.lock
+++ b/gemfiles/jruby_9.4_stripe_12.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    datadog (2.3.0)
+    datadog (2.4.0)
       debase-ruby_core_source (= 3.3.1)
       libdatadog (~> 12.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)

--- a/gemfiles/jruby_9.4_stripe_7.gemfile.lock
+++ b/gemfiles/jruby_9.4_stripe_7.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    datadog (2.3.0)
+    datadog (2.4.0)
       debase-ruby_core_source (= 3.3.1)
       libdatadog (~> 12.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)

--- a/gemfiles/jruby_9.4_stripe_8.gemfile.lock
+++ b/gemfiles/jruby_9.4_stripe_8.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    datadog (2.3.0)
+    datadog (2.4.0)
       debase-ruby_core_source (= 3.3.1)
       libdatadog (~> 12.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)

--- a/gemfiles/jruby_9.4_stripe_9.gemfile.lock
+++ b/gemfiles/jruby_9.4_stripe_9.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    datadog (2.3.0)
+    datadog (2.4.0)
       debase-ruby_core_source (= 3.3.1)
       libdatadog (~> 12.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)

--- a/gemfiles/jruby_9.4_stripe_latest.gemfile.lock
+++ b/gemfiles/jruby_9.4_stripe_latest.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    datadog (2.3.0)
+    datadog (2.4.0)
       debase-ruby_core_source (= 3.3.1)
       libdatadog (~> 12.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)

--- a/gemfiles/jruby_9.4_stripe_min.gemfile.lock
+++ b/gemfiles/jruby_9.4_stripe_min.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    datadog (2.3.0)
+    datadog (2.4.0)
       debase-ruby_core_source (= 3.3.1)
       libdatadog (~> 12.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)

--- a/gemfiles/ruby_2.5_activesupport.gemfile.lock
+++ b/gemfiles/ruby_2.5_activesupport.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    datadog (2.3.0)
+    datadog (2.4.0)
       debase-ruby_core_source (= 3.3.1)
       libdatadog (~> 12.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)

--- a/gemfiles/ruby_2.5_aws.gemfile.lock
+++ b/gemfiles/ruby_2.5_aws.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    datadog (2.3.0)
+    datadog (2.4.0)
       debase-ruby_core_source (= 3.3.1)
       libdatadog (~> 12.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)

--- a/gemfiles/ruby_2.5_contrib.gemfile.lock
+++ b/gemfiles/ruby_2.5_contrib.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    datadog (2.3.0)
+    datadog (2.4.0)
       debase-ruby_core_source (= 3.3.1)
       libdatadog (~> 12.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)

--- a/gemfiles/ruby_2.5_contrib_old.gemfile.lock
+++ b/gemfiles/ruby_2.5_contrib_old.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    datadog (2.3.0)
+    datadog (2.4.0)
       debase-ruby_core_source (= 3.3.1)
       libdatadog (~> 12.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)

--- a/gemfiles/ruby_2.5_core_old.gemfile.lock
+++ b/gemfiles/ruby_2.5_core_old.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    datadog (2.3.0)
+    datadog (2.4.0)
       debase-ruby_core_source (= 3.3.1)
       libdatadog (~> 12.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)

--- a/gemfiles/ruby_2.5_elasticsearch_7.gemfile.lock
+++ b/gemfiles/ruby_2.5_elasticsearch_7.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    datadog (2.3.0)
+    datadog (2.4.0)
       debase-ruby_core_source (= 3.3.1)
       libdatadog (~> 12.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)

--- a/gemfiles/ruby_2.5_elasticsearch_8.gemfile.lock
+++ b/gemfiles/ruby_2.5_elasticsearch_8.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    datadog (2.3.0)
+    datadog (2.4.0)
       debase-ruby_core_source (= 3.3.1)
       libdatadog (~> 12.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)

--- a/gemfiles/ruby_2.5_elasticsearch_latest.gemfile.lock
+++ b/gemfiles/ruby_2.5_elasticsearch_latest.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    datadog (2.3.0)
+    datadog (2.4.0)
       debase-ruby_core_source (= 3.3.1)
       libdatadog (~> 12.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)

--- a/gemfiles/ruby_2.5_graphql_2.0.gemfile.lock
+++ b/gemfiles/ruby_2.5_graphql_2.0.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    datadog (2.3.0)
+    datadog (2.4.0)
       debase-ruby_core_source (= 3.3.1)
       libdatadog (~> 12.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)

--- a/gemfiles/ruby_2.5_hanami_1.gemfile.lock
+++ b/gemfiles/ruby_2.5_hanami_1.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    datadog (2.3.0)
+    datadog (2.4.0)
       debase-ruby_core_source (= 3.3.1)
       libdatadog (~> 12.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)

--- a/gemfiles/ruby_2.5_http.gemfile.lock
+++ b/gemfiles/ruby_2.5_http.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    datadog (2.3.0)
+    datadog (2.4.0)
       debase-ruby_core_source (= 3.3.1)
       libdatadog (~> 12.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)

--- a/gemfiles/ruby_2.5_opensearch_2.gemfile.lock
+++ b/gemfiles/ruby_2.5_opensearch_2.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    datadog (2.3.0)
+    datadog (2.4.0)
       debase-ruby_core_source (= 3.3.1)
       libdatadog (~> 12.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)

--- a/gemfiles/ruby_2.5_opensearch_3.gemfile.lock
+++ b/gemfiles/ruby_2.5_opensearch_3.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    datadog (2.3.0)
+    datadog (2.4.0)
       debase-ruby_core_source (= 3.3.1)
       libdatadog (~> 12.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)

--- a/gemfiles/ruby_2.5_opensearch_latest.gemfile.lock
+++ b/gemfiles/ruby_2.5_opensearch_latest.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    datadog (2.3.0)
+    datadog (2.4.0)
       debase-ruby_core_source (= 3.3.1)
       libdatadog (~> 12.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)

--- a/gemfiles/ruby_2.5_rack_1.gemfile.lock
+++ b/gemfiles/ruby_2.5_rack_1.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    datadog (2.3.0)
+    datadog (2.4.0)
       debase-ruby_core_source (= 3.3.1)
       libdatadog (~> 12.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)

--- a/gemfiles/ruby_2.5_rack_2.gemfile.lock
+++ b/gemfiles/ruby_2.5_rack_2.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    datadog (2.3.0)
+    datadog (2.4.0)
       debase-ruby_core_source (= 3.3.1)
       libdatadog (~> 12.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)

--- a/gemfiles/ruby_2.5_rack_3.gemfile.lock
+++ b/gemfiles/ruby_2.5_rack_3.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    datadog (2.3.0)
+    datadog (2.4.0)
       debase-ruby_core_source (= 3.3.1)
       libdatadog (~> 12.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)

--- a/gemfiles/ruby_2.5_rack_latest.gemfile.lock
+++ b/gemfiles/ruby_2.5_rack_latest.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    datadog (2.3.0)
+    datadog (2.4.0)
       debase-ruby_core_source (= 3.3.1)
       libdatadog (~> 12.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)

--- a/gemfiles/ruby_2.5_rails4_mysql2.gemfile.lock
+++ b/gemfiles/ruby_2.5_rails4_mysql2.gemfile.lock
@@ -67,7 +67,7 @@ GIT
 PATH
   remote: ..
   specs:
-    datadog (2.3.0)
+    datadog (2.4.0)
       debase-ruby_core_source (= 3.3.1)
       libdatadog (~> 12.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)

--- a/gemfiles/ruby_2.5_rails4_postgres.gemfile.lock
+++ b/gemfiles/ruby_2.5_rails4_postgres.gemfile.lock
@@ -67,7 +67,7 @@ GIT
 PATH
   remote: ..
   specs:
-    datadog (2.3.0)
+    datadog (2.4.0)
       debase-ruby_core_source (= 3.3.1)
       libdatadog (~> 12.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)

--- a/gemfiles/ruby_2.5_rails4_postgres_redis.gemfile.lock
+++ b/gemfiles/ruby_2.5_rails4_postgres_redis.gemfile.lock
@@ -67,7 +67,7 @@ GIT
 PATH
   remote: ..
   specs:
-    datadog (2.3.0)
+    datadog (2.4.0)
       debase-ruby_core_source (= 3.3.1)
       libdatadog (~> 12.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)

--- a/gemfiles/ruby_2.5_rails4_postgres_sidekiq.gemfile.lock
+++ b/gemfiles/ruby_2.5_rails4_postgres_sidekiq.gemfile.lock
@@ -64,7 +64,7 @@ GIT
 PATH
   remote: ..
   specs:
-    datadog (2.3.0)
+    datadog (2.4.0)
       debase-ruby_core_source (= 3.3.1)
       libdatadog (~> 12.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)

--- a/gemfiles/ruby_2.5_rails4_semantic_logger.gemfile.lock
+++ b/gemfiles/ruby_2.5_rails4_semantic_logger.gemfile.lock
@@ -67,7 +67,7 @@ GIT
 PATH
   remote: ..
   specs:
-    datadog (2.3.0)
+    datadog (2.4.0)
       debase-ruby_core_source (= 3.3.1)
       libdatadog (~> 12.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)

--- a/gemfiles/ruby_2.5_rails5_mysql2.gemfile.lock
+++ b/gemfiles/ruby_2.5_rails5_mysql2.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    datadog (2.3.0)
+    datadog (2.4.0)
       debase-ruby_core_source (= 3.3.1)
       libdatadog (~> 12.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)

--- a/gemfiles/ruby_2.5_rails5_postgres.gemfile.lock
+++ b/gemfiles/ruby_2.5_rails5_postgres.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    datadog (2.3.0)
+    datadog (2.4.0)
       debase-ruby_core_source (= 3.3.1)
       libdatadog (~> 12.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)

--- a/gemfiles/ruby_2.5_rails5_postgres_redis.gemfile.lock
+++ b/gemfiles/ruby_2.5_rails5_postgres_redis.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    datadog (2.3.0)
+    datadog (2.4.0)
       debase-ruby_core_source (= 3.3.1)
       libdatadog (~> 12.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)

--- a/gemfiles/ruby_2.5_rails5_postgres_redis_activesupport.gemfile.lock
+++ b/gemfiles/ruby_2.5_rails5_postgres_redis_activesupport.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    datadog (2.3.0)
+    datadog (2.4.0)
       debase-ruby_core_source (= 3.3.1)
       libdatadog (~> 12.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)

--- a/gemfiles/ruby_2.5_rails5_postgres_sidekiq.gemfile.lock
+++ b/gemfiles/ruby_2.5_rails5_postgres_sidekiq.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    datadog (2.3.0)
+    datadog (2.4.0)
       debase-ruby_core_source (= 3.3.1)
       libdatadog (~> 12.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)

--- a/gemfiles/ruby_2.5_rails5_semantic_logger.gemfile.lock
+++ b/gemfiles/ruby_2.5_rails5_semantic_logger.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    datadog (2.3.0)
+    datadog (2.4.0)
       debase-ruby_core_source (= 3.3.1)
       libdatadog (~> 12.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)

--- a/gemfiles/ruby_2.5_rails61_mysql2.gemfile.lock
+++ b/gemfiles/ruby_2.5_rails61_mysql2.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    datadog (2.3.0)
+    datadog (2.4.0)
       debase-ruby_core_source (= 3.3.1)
       libdatadog (~> 12.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)

--- a/gemfiles/ruby_2.5_rails61_postgres.gemfile.lock
+++ b/gemfiles/ruby_2.5_rails61_postgres.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    datadog (2.3.0)
+    datadog (2.4.0)
       debase-ruby_core_source (= 3.3.1)
       libdatadog (~> 12.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)

--- a/gemfiles/ruby_2.5_rails61_postgres_redis.gemfile.lock
+++ b/gemfiles/ruby_2.5_rails61_postgres_redis.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    datadog (2.3.0)
+    datadog (2.4.0)
       debase-ruby_core_source (= 3.3.1)
       libdatadog (~> 12.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)

--- a/gemfiles/ruby_2.5_rails61_postgres_sidekiq.gemfile.lock
+++ b/gemfiles/ruby_2.5_rails61_postgres_sidekiq.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    datadog (2.3.0)
+    datadog (2.4.0)
       debase-ruby_core_source (= 3.3.1)
       libdatadog (~> 12.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)

--- a/gemfiles/ruby_2.5_rails61_semantic_logger.gemfile.lock
+++ b/gemfiles/ruby_2.5_rails61_semantic_logger.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    datadog (2.3.0)
+    datadog (2.4.0)
       debase-ruby_core_source (= 3.3.1)
       libdatadog (~> 12.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)

--- a/gemfiles/ruby_2.5_rails6_mysql2.gemfile.lock
+++ b/gemfiles/ruby_2.5_rails6_mysql2.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    datadog (2.3.0)
+    datadog (2.4.0)
       debase-ruby_core_source (= 3.3.1)
       libdatadog (~> 12.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)

--- a/gemfiles/ruby_2.5_rails6_postgres.gemfile.lock
+++ b/gemfiles/ruby_2.5_rails6_postgres.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    datadog (2.3.0)
+    datadog (2.4.0)
       debase-ruby_core_source (= 3.3.1)
       libdatadog (~> 12.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)

--- a/gemfiles/ruby_2.5_rails6_postgres_redis.gemfile.lock
+++ b/gemfiles/ruby_2.5_rails6_postgres_redis.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    datadog (2.3.0)
+    datadog (2.4.0)
       debase-ruby_core_source (= 3.3.1)
       libdatadog (~> 12.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)

--- a/gemfiles/ruby_2.5_rails6_postgres_redis_activesupport.gemfile.lock
+++ b/gemfiles/ruby_2.5_rails6_postgres_redis_activesupport.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    datadog (2.3.0)
+    datadog (2.4.0)
       debase-ruby_core_source (= 3.3.1)
       libdatadog (~> 12.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)

--- a/gemfiles/ruby_2.5_rails6_postgres_sidekiq.gemfile.lock
+++ b/gemfiles/ruby_2.5_rails6_postgres_sidekiq.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    datadog (2.3.0)
+    datadog (2.4.0)
       debase-ruby_core_source (= 3.3.1)
       libdatadog (~> 12.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)

--- a/gemfiles/ruby_2.5_rails6_semantic_logger.gemfile.lock
+++ b/gemfiles/ruby_2.5_rails6_semantic_logger.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    datadog (2.3.0)
+    datadog (2.4.0)
       debase-ruby_core_source (= 3.3.1)
       libdatadog (~> 12.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)

--- a/gemfiles/ruby_2.5_redis_3.gemfile.lock
+++ b/gemfiles/ruby_2.5_redis_3.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    datadog (2.3.0)
+    datadog (2.4.0)
       debase-ruby_core_source (= 3.3.1)
       libdatadog (~> 12.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)

--- a/gemfiles/ruby_2.5_redis_4.gemfile.lock
+++ b/gemfiles/ruby_2.5_redis_4.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    datadog (2.3.0)
+    datadog (2.4.0)
       debase-ruby_core_source (= 3.3.1)
       libdatadog (~> 12.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)

--- a/gemfiles/ruby_2.5_redis_5.gemfile.lock
+++ b/gemfiles/ruby_2.5_redis_5.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    datadog (2.3.0)
+    datadog (2.4.0)
       debase-ruby_core_source (= 3.3.1)
       libdatadog (~> 12.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)

--- a/gemfiles/ruby_2.5_relational_db.gemfile.lock
+++ b/gemfiles/ruby_2.5_relational_db.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    datadog (2.3.0)
+    datadog (2.4.0)
       debase-ruby_core_source (= 3.3.1)
       libdatadog (~> 12.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)

--- a/gemfiles/ruby_2.5_resque2_redis3.gemfile.lock
+++ b/gemfiles/ruby_2.5_resque2_redis3.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    datadog (2.3.0)
+    datadog (2.4.0)
       debase-ruby_core_source (= 3.3.1)
       libdatadog (~> 12.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)

--- a/gemfiles/ruby_2.5_resque2_redis4.gemfile.lock
+++ b/gemfiles/ruby_2.5_resque2_redis4.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    datadog (2.3.0)
+    datadog (2.4.0)
       debase-ruby_core_source (= 3.3.1)
       libdatadog (~> 12.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)

--- a/gemfiles/ruby_2.5_sinatra_2.gemfile.lock
+++ b/gemfiles/ruby_2.5_sinatra_2.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    datadog (2.3.0)
+    datadog (2.4.0)
       debase-ruby_core_source (= 3.3.1)
       libdatadog (~> 12.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)

--- a/gemfiles/ruby_2.5_stripe_10.gemfile.lock
+++ b/gemfiles/ruby_2.5_stripe_10.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    datadog (2.3.0)
+    datadog (2.4.0)
       debase-ruby_core_source (= 3.3.1)
       libdatadog (~> 12.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)

--- a/gemfiles/ruby_2.5_stripe_11.gemfile.lock
+++ b/gemfiles/ruby_2.5_stripe_11.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    datadog (2.3.0)
+    datadog (2.4.0)
       debase-ruby_core_source (= 3.3.1)
       libdatadog (~> 12.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)

--- a/gemfiles/ruby_2.5_stripe_12.gemfile.lock
+++ b/gemfiles/ruby_2.5_stripe_12.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    datadog (2.3.0)
+    datadog (2.4.0)
       debase-ruby_core_source (= 3.3.1)
       libdatadog (~> 12.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)

--- a/gemfiles/ruby_2.5_stripe_7.gemfile.lock
+++ b/gemfiles/ruby_2.5_stripe_7.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    datadog (2.3.0)
+    datadog (2.4.0)
       debase-ruby_core_source (= 3.3.1)
       libdatadog (~> 12.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)

--- a/gemfiles/ruby_2.5_stripe_8.gemfile.lock
+++ b/gemfiles/ruby_2.5_stripe_8.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    datadog (2.3.0)
+    datadog (2.4.0)
       debase-ruby_core_source (= 3.3.1)
       libdatadog (~> 12.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)

--- a/gemfiles/ruby_2.5_stripe_9.gemfile.lock
+++ b/gemfiles/ruby_2.5_stripe_9.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    datadog (2.3.0)
+    datadog (2.4.0)
       debase-ruby_core_source (= 3.3.1)
       libdatadog (~> 12.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)

--- a/gemfiles/ruby_2.5_stripe_latest.gemfile.lock
+++ b/gemfiles/ruby_2.5_stripe_latest.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    datadog (2.3.0)
+    datadog (2.4.0)
       debase-ruby_core_source (= 3.3.1)
       libdatadog (~> 12.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)

--- a/gemfiles/ruby_2.5_stripe_min.gemfile.lock
+++ b/gemfiles/ruby_2.5_stripe_min.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    datadog (2.3.0)
+    datadog (2.4.0)
       debase-ruby_core_source (= 3.3.1)
       libdatadog (~> 12.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)

--- a/gemfiles/ruby_2.6_activesupport.gemfile.lock
+++ b/gemfiles/ruby_2.6_activesupport.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    datadog (2.3.0)
+    datadog (2.4.0)
       debase-ruby_core_source (= 3.3.1)
       libdatadog (~> 12.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)

--- a/gemfiles/ruby_2.6_aws.gemfile.lock
+++ b/gemfiles/ruby_2.6_aws.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    datadog (2.3.0)
+    datadog (2.4.0)
       debase-ruby_core_source (= 3.3.1)
       libdatadog (~> 12.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)

--- a/gemfiles/ruby_2.6_contrib.gemfile.lock
+++ b/gemfiles/ruby_2.6_contrib.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    datadog (2.3.0)
+    datadog (2.4.0)
       debase-ruby_core_source (= 3.3.1)
       libdatadog (~> 12.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)

--- a/gemfiles/ruby_2.6_contrib_old.gemfile.lock
+++ b/gemfiles/ruby_2.6_contrib_old.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    datadog (2.3.0)
+    datadog (2.4.0)
       debase-ruby_core_source (= 3.3.1)
       libdatadog (~> 12.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)

--- a/gemfiles/ruby_2.6_core_old.gemfile.lock
+++ b/gemfiles/ruby_2.6_core_old.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    datadog (2.3.0)
+    datadog (2.4.0)
       debase-ruby_core_source (= 3.3.1)
       libdatadog (~> 12.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)

--- a/gemfiles/ruby_2.6_elasticsearch_7.gemfile.lock
+++ b/gemfiles/ruby_2.6_elasticsearch_7.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    datadog (2.3.0)
+    datadog (2.4.0)
       debase-ruby_core_source (= 3.3.1)
       libdatadog (~> 12.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)

--- a/gemfiles/ruby_2.6_elasticsearch_8.gemfile.lock
+++ b/gemfiles/ruby_2.6_elasticsearch_8.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    datadog (2.3.0)
+    datadog (2.4.0)
       debase-ruby_core_source (= 3.3.1)
       libdatadog (~> 12.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)

--- a/gemfiles/ruby_2.6_elasticsearch_latest.gemfile.lock
+++ b/gemfiles/ruby_2.6_elasticsearch_latest.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    datadog (2.3.0)
+    datadog (2.4.0)
       debase-ruby_core_source (= 3.3.1)
       libdatadog (~> 12.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)

--- a/gemfiles/ruby_2.6_graphql_1.13.gemfile.lock
+++ b/gemfiles/ruby_2.6_graphql_1.13.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    datadog (2.3.0)
+    datadog (2.4.0)
       debase-ruby_core_source (= 3.3.1)
       libdatadog (~> 12.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)

--- a/gemfiles/ruby_2.6_graphql_2.0.gemfile.lock
+++ b/gemfiles/ruby_2.6_graphql_2.0.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    datadog (2.3.0)
+    datadog (2.4.0)
       debase-ruby_core_source (= 3.3.1)
       libdatadog (~> 12.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)

--- a/gemfiles/ruby_2.6_hanami_1.gemfile.lock
+++ b/gemfiles/ruby_2.6_hanami_1.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    datadog (2.3.0)
+    datadog (2.4.0)
       debase-ruby_core_source (= 3.3.1)
       libdatadog (~> 12.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)

--- a/gemfiles/ruby_2.6_http.gemfile.lock
+++ b/gemfiles/ruby_2.6_http.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    datadog (2.3.0)
+    datadog (2.4.0)
       debase-ruby_core_source (= 3.3.1)
       libdatadog (~> 12.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)

--- a/gemfiles/ruby_2.6_opensearch_2.gemfile.lock
+++ b/gemfiles/ruby_2.6_opensearch_2.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    datadog (2.3.0)
+    datadog (2.4.0)
       debase-ruby_core_source (= 3.3.1)
       libdatadog (~> 12.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)

--- a/gemfiles/ruby_2.6_opensearch_3.gemfile.lock
+++ b/gemfiles/ruby_2.6_opensearch_3.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    datadog (2.3.0)
+    datadog (2.4.0)
       debase-ruby_core_source (= 3.3.1)
       libdatadog (~> 12.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)

--- a/gemfiles/ruby_2.6_opensearch_latest.gemfile.lock
+++ b/gemfiles/ruby_2.6_opensearch_latest.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    datadog (2.3.0)
+    datadog (2.4.0)
       debase-ruby_core_source (= 3.3.1)
       libdatadog (~> 12.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)

--- a/gemfiles/ruby_2.6_opentelemetry.gemfile.lock
+++ b/gemfiles/ruby_2.6_opentelemetry.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    datadog (2.3.0)
+    datadog (2.4.0)
       debase-ruby_core_source (= 3.3.1)
       libdatadog (~> 12.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)

--- a/gemfiles/ruby_2.6_rack_1.gemfile.lock
+++ b/gemfiles/ruby_2.6_rack_1.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    datadog (2.3.0)
+    datadog (2.4.0)
       debase-ruby_core_source (= 3.3.1)
       libdatadog (~> 12.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)

--- a/gemfiles/ruby_2.6_rack_2.gemfile.lock
+++ b/gemfiles/ruby_2.6_rack_2.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    datadog (2.3.0)
+    datadog (2.4.0)
       debase-ruby_core_source (= 3.3.1)
       libdatadog (~> 12.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)

--- a/gemfiles/ruby_2.6_rack_3.gemfile.lock
+++ b/gemfiles/ruby_2.6_rack_3.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    datadog (2.3.0)
+    datadog (2.4.0)
       debase-ruby_core_source (= 3.3.1)
       libdatadog (~> 12.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)

--- a/gemfiles/ruby_2.6_rack_latest.gemfile.lock
+++ b/gemfiles/ruby_2.6_rack_latest.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    datadog (2.3.0)
+    datadog (2.4.0)
       debase-ruby_core_source (= 3.3.1)
       libdatadog (~> 12.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)

--- a/gemfiles/ruby_2.6_rails5_mysql2.gemfile.lock
+++ b/gemfiles/ruby_2.6_rails5_mysql2.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    datadog (2.3.0)
+    datadog (2.4.0)
       debase-ruby_core_source (= 3.3.1)
       libdatadog (~> 12.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)

--- a/gemfiles/ruby_2.6_rails5_postgres.gemfile.lock
+++ b/gemfiles/ruby_2.6_rails5_postgres.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    datadog (2.3.0)
+    datadog (2.4.0)
       debase-ruby_core_source (= 3.3.1)
       libdatadog (~> 12.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)

--- a/gemfiles/ruby_2.6_rails5_postgres_redis.gemfile.lock
+++ b/gemfiles/ruby_2.6_rails5_postgres_redis.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    datadog (2.3.0)
+    datadog (2.4.0)
       debase-ruby_core_source (= 3.3.1)
       libdatadog (~> 12.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)

--- a/gemfiles/ruby_2.6_rails5_postgres_redis_activesupport.gemfile.lock
+++ b/gemfiles/ruby_2.6_rails5_postgres_redis_activesupport.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    datadog (2.3.0)
+    datadog (2.4.0)
       debase-ruby_core_source (= 3.3.1)
       libdatadog (~> 12.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)

--- a/gemfiles/ruby_2.6_rails5_postgres_sidekiq.gemfile.lock
+++ b/gemfiles/ruby_2.6_rails5_postgres_sidekiq.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    datadog (2.3.0)
+    datadog (2.4.0)
       debase-ruby_core_source (= 3.3.1)
       libdatadog (~> 12.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)

--- a/gemfiles/ruby_2.6_rails5_semantic_logger.gemfile.lock
+++ b/gemfiles/ruby_2.6_rails5_semantic_logger.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    datadog (2.3.0)
+    datadog (2.4.0)
       debase-ruby_core_source (= 3.3.1)
       libdatadog (~> 12.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)

--- a/gemfiles/ruby_2.6_rails61_mysql2.gemfile.lock
+++ b/gemfiles/ruby_2.6_rails61_mysql2.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    datadog (2.3.0)
+    datadog (2.4.0)
       debase-ruby_core_source (= 3.3.1)
       libdatadog (~> 12.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)

--- a/gemfiles/ruby_2.6_rails61_postgres.gemfile.lock
+++ b/gemfiles/ruby_2.6_rails61_postgres.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    datadog (2.3.0)
+    datadog (2.4.0)
       debase-ruby_core_source (= 3.3.1)
       libdatadog (~> 12.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)

--- a/gemfiles/ruby_2.6_rails61_postgres_redis.gemfile.lock
+++ b/gemfiles/ruby_2.6_rails61_postgres_redis.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    datadog (2.3.0)
+    datadog (2.4.0)
       debase-ruby_core_source (= 3.3.1)
       libdatadog (~> 12.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)

--- a/gemfiles/ruby_2.6_rails61_postgres_sidekiq.gemfile.lock
+++ b/gemfiles/ruby_2.6_rails61_postgres_sidekiq.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    datadog (2.3.0)
+    datadog (2.4.0)
       debase-ruby_core_source (= 3.3.1)
       libdatadog (~> 12.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)

--- a/gemfiles/ruby_2.6_rails61_semantic_logger.gemfile.lock
+++ b/gemfiles/ruby_2.6_rails61_semantic_logger.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    datadog (2.3.0)
+    datadog (2.4.0)
       debase-ruby_core_source (= 3.3.1)
       libdatadog (~> 12.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)

--- a/gemfiles/ruby_2.6_rails6_mysql2.gemfile.lock
+++ b/gemfiles/ruby_2.6_rails6_mysql2.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    datadog (2.3.0)
+    datadog (2.4.0)
       debase-ruby_core_source (= 3.3.1)
       libdatadog (~> 12.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)

--- a/gemfiles/ruby_2.6_rails6_postgres.gemfile.lock
+++ b/gemfiles/ruby_2.6_rails6_postgres.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    datadog (2.3.0)
+    datadog (2.4.0)
       debase-ruby_core_source (= 3.3.1)
       libdatadog (~> 12.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)

--- a/gemfiles/ruby_2.6_rails6_postgres_redis.gemfile.lock
+++ b/gemfiles/ruby_2.6_rails6_postgres_redis.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    datadog (2.3.0)
+    datadog (2.4.0)
       debase-ruby_core_source (= 3.3.1)
       libdatadog (~> 12.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)

--- a/gemfiles/ruby_2.6_rails6_postgres_redis_activesupport.gemfile.lock
+++ b/gemfiles/ruby_2.6_rails6_postgres_redis_activesupport.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    datadog (2.3.0)
+    datadog (2.4.0)
       debase-ruby_core_source (= 3.3.1)
       libdatadog (~> 12.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)

--- a/gemfiles/ruby_2.6_rails6_postgres_sidekiq.gemfile.lock
+++ b/gemfiles/ruby_2.6_rails6_postgres_sidekiq.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    datadog (2.3.0)
+    datadog (2.4.0)
       debase-ruby_core_source (= 3.3.1)
       libdatadog (~> 12.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)

--- a/gemfiles/ruby_2.6_rails6_semantic_logger.gemfile.lock
+++ b/gemfiles/ruby_2.6_rails6_semantic_logger.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    datadog (2.3.0)
+    datadog (2.4.0)
       debase-ruby_core_source (= 3.3.1)
       libdatadog (~> 12.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)

--- a/gemfiles/ruby_2.6_redis_3.gemfile.lock
+++ b/gemfiles/ruby_2.6_redis_3.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    datadog (2.3.0)
+    datadog (2.4.0)
       debase-ruby_core_source (= 3.3.1)
       libdatadog (~> 12.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)

--- a/gemfiles/ruby_2.6_redis_4.gemfile.lock
+++ b/gemfiles/ruby_2.6_redis_4.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    datadog (2.3.0)
+    datadog (2.4.0)
       debase-ruby_core_source (= 3.3.1)
       libdatadog (~> 12.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)

--- a/gemfiles/ruby_2.6_redis_5.gemfile.lock
+++ b/gemfiles/ruby_2.6_redis_5.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    datadog (2.3.0)
+    datadog (2.4.0)
       debase-ruby_core_source (= 3.3.1)
       libdatadog (~> 12.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)

--- a/gemfiles/ruby_2.6_relational_db.gemfile.lock
+++ b/gemfiles/ruby_2.6_relational_db.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    datadog (2.3.0)
+    datadog (2.4.0)
       debase-ruby_core_source (= 3.3.1)
       libdatadog (~> 12.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)

--- a/gemfiles/ruby_2.6_resque2_redis3.gemfile.lock
+++ b/gemfiles/ruby_2.6_resque2_redis3.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    datadog (2.3.0)
+    datadog (2.4.0)
       debase-ruby_core_source (= 3.3.1)
       libdatadog (~> 12.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)

--- a/gemfiles/ruby_2.6_resque2_redis4.gemfile.lock
+++ b/gemfiles/ruby_2.6_resque2_redis4.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    datadog (2.3.0)
+    datadog (2.4.0)
       debase-ruby_core_source (= 3.3.1)
       libdatadog (~> 12.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)

--- a/gemfiles/ruby_2.6_sinatra_2.gemfile.lock
+++ b/gemfiles/ruby_2.6_sinatra_2.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    datadog (2.3.0)
+    datadog (2.4.0)
       debase-ruby_core_source (= 3.3.1)
       libdatadog (~> 12.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)

--- a/gemfiles/ruby_2.6_sinatra_3.gemfile.lock
+++ b/gemfiles/ruby_2.6_sinatra_3.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    datadog (2.3.0)
+    datadog (2.4.0)
       debase-ruby_core_source (= 3.3.1)
       libdatadog (~> 12.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)

--- a/gemfiles/ruby_2.6_stripe_10.gemfile.lock
+++ b/gemfiles/ruby_2.6_stripe_10.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    datadog (2.3.0)
+    datadog (2.4.0)
       debase-ruby_core_source (= 3.3.1)
       libdatadog (~> 12.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)

--- a/gemfiles/ruby_2.6_stripe_11.gemfile.lock
+++ b/gemfiles/ruby_2.6_stripe_11.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    datadog (2.3.0)
+    datadog (2.4.0)
       debase-ruby_core_source (= 3.3.1)
       libdatadog (~> 12.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)

--- a/gemfiles/ruby_2.6_stripe_12.gemfile.lock
+++ b/gemfiles/ruby_2.6_stripe_12.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    datadog (2.3.0)
+    datadog (2.4.0)
       debase-ruby_core_source (= 3.3.1)
       libdatadog (~> 12.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)

--- a/gemfiles/ruby_2.6_stripe_7.gemfile.lock
+++ b/gemfiles/ruby_2.6_stripe_7.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    datadog (2.3.0)
+    datadog (2.4.0)
       debase-ruby_core_source (= 3.3.1)
       libdatadog (~> 12.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)

--- a/gemfiles/ruby_2.6_stripe_8.gemfile.lock
+++ b/gemfiles/ruby_2.6_stripe_8.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    datadog (2.3.0)
+    datadog (2.4.0)
       debase-ruby_core_source (= 3.3.1)
       libdatadog (~> 12.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)

--- a/gemfiles/ruby_2.6_stripe_9.gemfile.lock
+++ b/gemfiles/ruby_2.6_stripe_9.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    datadog (2.3.0)
+    datadog (2.4.0)
       debase-ruby_core_source (= 3.3.1)
       libdatadog (~> 12.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)

--- a/gemfiles/ruby_2.6_stripe_latest.gemfile.lock
+++ b/gemfiles/ruby_2.6_stripe_latest.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    datadog (2.3.0)
+    datadog (2.4.0)
       debase-ruby_core_source (= 3.3.1)
       libdatadog (~> 12.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)

--- a/gemfiles/ruby_2.6_stripe_min.gemfile.lock
+++ b/gemfiles/ruby_2.6_stripe_min.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    datadog (2.3.0)
+    datadog (2.4.0)
       debase-ruby_core_source (= 3.3.1)
       libdatadog (~> 12.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)

--- a/gemfiles/ruby_2.7_activesupport.gemfile.lock
+++ b/gemfiles/ruby_2.7_activesupport.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    datadog (2.3.0)
+    datadog (2.4.0)
       debase-ruby_core_source (= 3.3.1)
       libdatadog (~> 12.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)

--- a/gemfiles/ruby_2.7_aws.gemfile.lock
+++ b/gemfiles/ruby_2.7_aws.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    datadog (2.3.0)
+    datadog (2.4.0)
       debase-ruby_core_source (= 3.3.1)
       libdatadog (~> 12.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)

--- a/gemfiles/ruby_2.7_contrib.gemfile.lock
+++ b/gemfiles/ruby_2.7_contrib.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    datadog (2.3.0)
+    datadog (2.4.0)
       debase-ruby_core_source (= 3.3.1)
       libdatadog (~> 12.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)

--- a/gemfiles/ruby_2.7_contrib_old.gemfile.lock
+++ b/gemfiles/ruby_2.7_contrib_old.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    datadog (2.3.0)
+    datadog (2.4.0)
       debase-ruby_core_source (= 3.3.1)
       libdatadog (~> 12.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)

--- a/gemfiles/ruby_2.7_core_old.gemfile.lock
+++ b/gemfiles/ruby_2.7_core_old.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    datadog (2.3.0)
+    datadog (2.4.0)
       debase-ruby_core_source (= 3.3.1)
       libdatadog (~> 12.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)

--- a/gemfiles/ruby_2.7_elasticsearch_7.gemfile.lock
+++ b/gemfiles/ruby_2.7_elasticsearch_7.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    datadog (2.3.0)
+    datadog (2.4.0)
       debase-ruby_core_source (= 3.3.1)
       libdatadog (~> 12.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)

--- a/gemfiles/ruby_2.7_elasticsearch_8.gemfile.lock
+++ b/gemfiles/ruby_2.7_elasticsearch_8.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    datadog (2.3.0)
+    datadog (2.4.0)
       debase-ruby_core_source (= 3.3.1)
       libdatadog (~> 12.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)

--- a/gemfiles/ruby_2.7_elasticsearch_latest.gemfile.lock
+++ b/gemfiles/ruby_2.7_elasticsearch_latest.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    datadog (2.3.0)
+    datadog (2.4.0)
       debase-ruby_core_source (= 3.3.1)
       libdatadog (~> 12.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)

--- a/gemfiles/ruby_2.7_graphql_1.13.gemfile.lock
+++ b/gemfiles/ruby_2.7_graphql_1.13.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    datadog (2.3.0)
+    datadog (2.4.0)
       debase-ruby_core_source (= 3.3.1)
       libdatadog (~> 12.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)

--- a/gemfiles/ruby_2.7_graphql_2.0.gemfile.lock
+++ b/gemfiles/ruby_2.7_graphql_2.0.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    datadog (2.3.0)
+    datadog (2.4.0)
       debase-ruby_core_source (= 3.3.1)
       libdatadog (~> 12.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)

--- a/gemfiles/ruby_2.7_graphql_2.1.gemfile.lock
+++ b/gemfiles/ruby_2.7_graphql_2.1.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    datadog (2.3.0)
+    datadog (2.4.0)
       debase-ruby_core_source (= 3.3.1)
       libdatadog (~> 12.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)

--- a/gemfiles/ruby_2.7_graphql_2.2.gemfile.lock
+++ b/gemfiles/ruby_2.7_graphql_2.2.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    datadog (2.3.0)
+    datadog (2.4.0)
       debase-ruby_core_source (= 3.3.1)
       libdatadog (~> 12.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)

--- a/gemfiles/ruby_2.7_graphql_2.3.gemfile.lock
+++ b/gemfiles/ruby_2.7_graphql_2.3.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    datadog (2.3.0)
+    datadog (2.4.0)
       debase-ruby_core_source (= 3.3.1)
       libdatadog (~> 12.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)

--- a/gemfiles/ruby_2.7_hanami_1.gemfile.lock
+++ b/gemfiles/ruby_2.7_hanami_1.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    datadog (2.3.0)
+    datadog (2.4.0)
       debase-ruby_core_source (= 3.3.1)
       libdatadog (~> 12.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)

--- a/gemfiles/ruby_2.7_http.gemfile.lock
+++ b/gemfiles/ruby_2.7_http.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    datadog (2.3.0)
+    datadog (2.4.0)
       debase-ruby_core_source (= 3.3.1)
       libdatadog (~> 12.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)

--- a/gemfiles/ruby_2.7_opensearch_2.gemfile.lock
+++ b/gemfiles/ruby_2.7_opensearch_2.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    datadog (2.3.0)
+    datadog (2.4.0)
       debase-ruby_core_source (= 3.3.1)
       libdatadog (~> 12.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)

--- a/gemfiles/ruby_2.7_opensearch_3.gemfile.lock
+++ b/gemfiles/ruby_2.7_opensearch_3.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    datadog (2.3.0)
+    datadog (2.4.0)
       debase-ruby_core_source (= 3.3.1)
       libdatadog (~> 12.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)

--- a/gemfiles/ruby_2.7_opensearch_latest.gemfile.lock
+++ b/gemfiles/ruby_2.7_opensearch_latest.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    datadog (2.3.0)
+    datadog (2.4.0)
       debase-ruby_core_source (= 3.3.1)
       libdatadog (~> 12.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)

--- a/gemfiles/ruby_2.7_opentelemetry.gemfile.lock
+++ b/gemfiles/ruby_2.7_opentelemetry.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    datadog (2.3.0)
+    datadog (2.4.0)
       debase-ruby_core_source (= 3.3.1)
       libdatadog (~> 12.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)

--- a/gemfiles/ruby_2.7_rack_1.gemfile.lock
+++ b/gemfiles/ruby_2.7_rack_1.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    datadog (2.3.0)
+    datadog (2.4.0)
       debase-ruby_core_source (= 3.3.1)
       libdatadog (~> 12.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)

--- a/gemfiles/ruby_2.7_rack_2.gemfile.lock
+++ b/gemfiles/ruby_2.7_rack_2.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    datadog (2.3.0)
+    datadog (2.4.0)
       debase-ruby_core_source (= 3.3.1)
       libdatadog (~> 12.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)

--- a/gemfiles/ruby_2.7_rack_3.gemfile.lock
+++ b/gemfiles/ruby_2.7_rack_3.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    datadog (2.3.0)
+    datadog (2.4.0)
       debase-ruby_core_source (= 3.3.1)
       libdatadog (~> 12.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)

--- a/gemfiles/ruby_2.7_rack_latest.gemfile.lock
+++ b/gemfiles/ruby_2.7_rack_latest.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    datadog (2.3.0)
+    datadog (2.4.0)
       debase-ruby_core_source (= 3.3.1)
       libdatadog (~> 12.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)

--- a/gemfiles/ruby_2.7_rails5_mysql2.gemfile.lock
+++ b/gemfiles/ruby_2.7_rails5_mysql2.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    datadog (2.3.0)
+    datadog (2.4.0)
       debase-ruby_core_source (= 3.3.1)
       libdatadog (~> 12.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)

--- a/gemfiles/ruby_2.7_rails5_postgres.gemfile.lock
+++ b/gemfiles/ruby_2.7_rails5_postgres.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    datadog (2.3.0)
+    datadog (2.4.0)
       debase-ruby_core_source (= 3.3.1)
       libdatadog (~> 12.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)

--- a/gemfiles/ruby_2.7_rails5_postgres_redis.gemfile.lock
+++ b/gemfiles/ruby_2.7_rails5_postgres_redis.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    datadog (2.3.0)
+    datadog (2.4.0)
       debase-ruby_core_source (= 3.3.1)
       libdatadog (~> 12.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)

--- a/gemfiles/ruby_2.7_rails5_postgres_redis_activesupport.gemfile.lock
+++ b/gemfiles/ruby_2.7_rails5_postgres_redis_activesupport.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    datadog (2.3.0)
+    datadog (2.4.0)
       debase-ruby_core_source (= 3.3.1)
       libdatadog (~> 12.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)

--- a/gemfiles/ruby_2.7_rails5_postgres_sidekiq.gemfile.lock
+++ b/gemfiles/ruby_2.7_rails5_postgres_sidekiq.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    datadog (2.3.0)
+    datadog (2.4.0)
       debase-ruby_core_source (= 3.3.1)
       libdatadog (~> 12.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)

--- a/gemfiles/ruby_2.7_rails5_semantic_logger.gemfile.lock
+++ b/gemfiles/ruby_2.7_rails5_semantic_logger.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    datadog (2.3.0)
+    datadog (2.4.0)
       debase-ruby_core_source (= 3.3.1)
       libdatadog (~> 12.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)

--- a/gemfiles/ruby_2.7_rails61_mysql2.gemfile.lock
+++ b/gemfiles/ruby_2.7_rails61_mysql2.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    datadog (2.3.0)
+    datadog (2.4.0)
       debase-ruby_core_source (= 3.3.1)
       libdatadog (~> 12.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)

--- a/gemfiles/ruby_2.7_rails61_postgres.gemfile.lock
+++ b/gemfiles/ruby_2.7_rails61_postgres.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    datadog (2.3.0)
+    datadog (2.4.0)
       debase-ruby_core_source (= 3.3.1)
       libdatadog (~> 12.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)

--- a/gemfiles/ruby_2.7_rails61_postgres_redis.gemfile.lock
+++ b/gemfiles/ruby_2.7_rails61_postgres_redis.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    datadog (2.3.0)
+    datadog (2.4.0)
       debase-ruby_core_source (= 3.3.1)
       libdatadog (~> 12.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)

--- a/gemfiles/ruby_2.7_rails61_postgres_sidekiq.gemfile.lock
+++ b/gemfiles/ruby_2.7_rails61_postgres_sidekiq.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    datadog (2.3.0)
+    datadog (2.4.0)
       debase-ruby_core_source (= 3.3.1)
       libdatadog (~> 12.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)

--- a/gemfiles/ruby_2.7_rails61_semantic_logger.gemfile.lock
+++ b/gemfiles/ruby_2.7_rails61_semantic_logger.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    datadog (2.3.0)
+    datadog (2.4.0)
       debase-ruby_core_source (= 3.3.1)
       libdatadog (~> 12.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)

--- a/gemfiles/ruby_2.7_rails6_mysql2.gemfile.lock
+++ b/gemfiles/ruby_2.7_rails6_mysql2.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    datadog (2.3.0)
+    datadog (2.4.0)
       debase-ruby_core_source (= 3.3.1)
       libdatadog (~> 12.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)

--- a/gemfiles/ruby_2.7_rails6_postgres.gemfile.lock
+++ b/gemfiles/ruby_2.7_rails6_postgres.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    datadog (2.3.0)
+    datadog (2.4.0)
       debase-ruby_core_source (= 3.3.1)
       libdatadog (~> 12.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)

--- a/gemfiles/ruby_2.7_rails6_postgres_redis.gemfile.lock
+++ b/gemfiles/ruby_2.7_rails6_postgres_redis.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    datadog (2.3.0)
+    datadog (2.4.0)
       debase-ruby_core_source (= 3.3.1)
       libdatadog (~> 12.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)

--- a/gemfiles/ruby_2.7_rails6_postgres_redis_activesupport.gemfile.lock
+++ b/gemfiles/ruby_2.7_rails6_postgres_redis_activesupport.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    datadog (2.3.0)
+    datadog (2.4.0)
       debase-ruby_core_source (= 3.3.1)
       libdatadog (~> 12.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)

--- a/gemfiles/ruby_2.7_rails6_postgres_sidekiq.gemfile.lock
+++ b/gemfiles/ruby_2.7_rails6_postgres_sidekiq.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    datadog (2.3.0)
+    datadog (2.4.0)
       debase-ruby_core_source (= 3.3.1)
       libdatadog (~> 12.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)

--- a/gemfiles/ruby_2.7_rails6_semantic_logger.gemfile.lock
+++ b/gemfiles/ruby_2.7_rails6_semantic_logger.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    datadog (2.3.0)
+    datadog (2.4.0)
       debase-ruby_core_source (= 3.3.1)
       libdatadog (~> 12.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)

--- a/gemfiles/ruby_2.7_redis_3.gemfile.lock
+++ b/gemfiles/ruby_2.7_redis_3.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    datadog (2.3.0)
+    datadog (2.4.0)
       debase-ruby_core_source (= 3.3.1)
       libdatadog (~> 12.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)

--- a/gemfiles/ruby_2.7_redis_4.gemfile.lock
+++ b/gemfiles/ruby_2.7_redis_4.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    datadog (2.3.0)
+    datadog (2.4.0)
       debase-ruby_core_source (= 3.3.1)
       libdatadog (~> 12.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)

--- a/gemfiles/ruby_2.7_redis_5.gemfile.lock
+++ b/gemfiles/ruby_2.7_redis_5.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    datadog (2.3.0)
+    datadog (2.4.0)
       debase-ruby_core_source (= 3.3.1)
       libdatadog (~> 12.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)

--- a/gemfiles/ruby_2.7_relational_db.gemfile.lock
+++ b/gemfiles/ruby_2.7_relational_db.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    datadog (2.3.0)
+    datadog (2.4.0)
       debase-ruby_core_source (= 3.3.1)
       libdatadog (~> 12.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)

--- a/gemfiles/ruby_2.7_resque2_redis3.gemfile.lock
+++ b/gemfiles/ruby_2.7_resque2_redis3.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    datadog (2.3.0)
+    datadog (2.4.0)
       debase-ruby_core_source (= 3.3.1)
       libdatadog (~> 12.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)

--- a/gemfiles/ruby_2.7_resque2_redis4.gemfile.lock
+++ b/gemfiles/ruby_2.7_resque2_redis4.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    datadog (2.3.0)
+    datadog (2.4.0)
       debase-ruby_core_source (= 3.3.1)
       libdatadog (~> 12.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)

--- a/gemfiles/ruby_2.7_sinatra_2.gemfile.lock
+++ b/gemfiles/ruby_2.7_sinatra_2.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    datadog (2.3.0)
+    datadog (2.4.0)
       debase-ruby_core_source (= 3.3.1)
       libdatadog (~> 12.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)

--- a/gemfiles/ruby_2.7_sinatra_3.gemfile.lock
+++ b/gemfiles/ruby_2.7_sinatra_3.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    datadog (2.3.0)
+    datadog (2.4.0)
       debase-ruby_core_source (= 3.3.1)
       libdatadog (~> 12.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)

--- a/gemfiles/ruby_2.7_stripe_10.gemfile.lock
+++ b/gemfiles/ruby_2.7_stripe_10.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    datadog (2.3.0)
+    datadog (2.4.0)
       debase-ruby_core_source (= 3.3.1)
       libdatadog (~> 12.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)

--- a/gemfiles/ruby_2.7_stripe_11.gemfile.lock
+++ b/gemfiles/ruby_2.7_stripe_11.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    datadog (2.3.0)
+    datadog (2.4.0)
       debase-ruby_core_source (= 3.3.1)
       libdatadog (~> 12.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)

--- a/gemfiles/ruby_2.7_stripe_12.gemfile.lock
+++ b/gemfiles/ruby_2.7_stripe_12.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    datadog (2.3.0)
+    datadog (2.4.0)
       debase-ruby_core_source (= 3.3.1)
       libdatadog (~> 12.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)

--- a/gemfiles/ruby_2.7_stripe_7.gemfile.lock
+++ b/gemfiles/ruby_2.7_stripe_7.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    datadog (2.3.0)
+    datadog (2.4.0)
       debase-ruby_core_source (= 3.3.1)
       libdatadog (~> 12.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)

--- a/gemfiles/ruby_2.7_stripe_8.gemfile.lock
+++ b/gemfiles/ruby_2.7_stripe_8.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    datadog (2.3.0)
+    datadog (2.4.0)
       debase-ruby_core_source (= 3.3.1)
       libdatadog (~> 12.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)

--- a/gemfiles/ruby_2.7_stripe_9.gemfile.lock
+++ b/gemfiles/ruby_2.7_stripe_9.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    datadog (2.3.0)
+    datadog (2.4.0)
       debase-ruby_core_source (= 3.3.1)
       libdatadog (~> 12.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)

--- a/gemfiles/ruby_2.7_stripe_latest.gemfile.lock
+++ b/gemfiles/ruby_2.7_stripe_latest.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    datadog (2.3.0)
+    datadog (2.4.0)
       debase-ruby_core_source (= 3.3.1)
       libdatadog (~> 12.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)

--- a/gemfiles/ruby_2.7_stripe_min.gemfile.lock
+++ b/gemfiles/ruby_2.7_stripe_min.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    datadog (2.3.0)
+    datadog (2.4.0)
       debase-ruby_core_source (= 3.3.1)
       libdatadog (~> 12.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)

--- a/gemfiles/ruby_3.0_activesupport.gemfile.lock
+++ b/gemfiles/ruby_3.0_activesupport.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    datadog (2.3.0)
+    datadog (2.4.0)
       debase-ruby_core_source (= 3.3.1)
       libdatadog (~> 12.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)

--- a/gemfiles/ruby_3.0_aws.gemfile.lock
+++ b/gemfiles/ruby_3.0_aws.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    datadog (2.3.0)
+    datadog (2.4.0)
       debase-ruby_core_source (= 3.3.1)
       libdatadog (~> 12.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)

--- a/gemfiles/ruby_3.0_contrib.gemfile.lock
+++ b/gemfiles/ruby_3.0_contrib.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    datadog (2.3.0)
+    datadog (2.4.0)
       debase-ruby_core_source (= 3.3.1)
       libdatadog (~> 12.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)

--- a/gemfiles/ruby_3.0_contrib_old.gemfile.lock
+++ b/gemfiles/ruby_3.0_contrib_old.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    datadog (2.3.0)
+    datadog (2.4.0)
       debase-ruby_core_source (= 3.3.1)
       libdatadog (~> 12.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)

--- a/gemfiles/ruby_3.0_core_old.gemfile.lock
+++ b/gemfiles/ruby_3.0_core_old.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    datadog (2.3.0)
+    datadog (2.4.0)
       debase-ruby_core_source (= 3.3.1)
       libdatadog (~> 12.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)

--- a/gemfiles/ruby_3.0_elasticsearch_7.gemfile.lock
+++ b/gemfiles/ruby_3.0_elasticsearch_7.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    datadog (2.3.0)
+    datadog (2.4.0)
       debase-ruby_core_source (= 3.3.1)
       libdatadog (~> 12.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)

--- a/gemfiles/ruby_3.0_elasticsearch_8.gemfile.lock
+++ b/gemfiles/ruby_3.0_elasticsearch_8.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    datadog (2.3.0)
+    datadog (2.4.0)
       debase-ruby_core_source (= 3.3.1)
       libdatadog (~> 12.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)

--- a/gemfiles/ruby_3.0_elasticsearch_latest.gemfile.lock
+++ b/gemfiles/ruby_3.0_elasticsearch_latest.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    datadog (2.3.0)
+    datadog (2.4.0)
       debase-ruby_core_source (= 3.3.1)
       libdatadog (~> 12.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)

--- a/gemfiles/ruby_3.0_graphql_1.13.gemfile.lock
+++ b/gemfiles/ruby_3.0_graphql_1.13.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    datadog (2.3.0)
+    datadog (2.4.0)
       debase-ruby_core_source (= 3.3.1)
       libdatadog (~> 12.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)

--- a/gemfiles/ruby_3.0_graphql_2.0.gemfile.lock
+++ b/gemfiles/ruby_3.0_graphql_2.0.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    datadog (2.3.0)
+    datadog (2.4.0)
       debase-ruby_core_source (= 3.3.1)
       libdatadog (~> 12.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)

--- a/gemfiles/ruby_3.0_graphql_2.1.gemfile.lock
+++ b/gemfiles/ruby_3.0_graphql_2.1.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    datadog (2.3.0)
+    datadog (2.4.0)
       debase-ruby_core_source (= 3.3.1)
       libdatadog (~> 12.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)

--- a/gemfiles/ruby_3.0_graphql_2.2.gemfile.lock
+++ b/gemfiles/ruby_3.0_graphql_2.2.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    datadog (2.3.0)
+    datadog (2.4.0)
       debase-ruby_core_source (= 3.3.1)
       libdatadog (~> 12.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)

--- a/gemfiles/ruby_3.0_graphql_2.3.gemfile.lock
+++ b/gemfiles/ruby_3.0_graphql_2.3.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    datadog (2.3.0)
+    datadog (2.4.0)
       debase-ruby_core_source (= 3.3.1)
       libdatadog (~> 12.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)

--- a/gemfiles/ruby_3.0_http.gemfile.lock
+++ b/gemfiles/ruby_3.0_http.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    datadog (2.3.0)
+    datadog (2.4.0)
       debase-ruby_core_source (= 3.3.1)
       libdatadog (~> 12.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)

--- a/gemfiles/ruby_3.0_opensearch_2.gemfile.lock
+++ b/gemfiles/ruby_3.0_opensearch_2.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    datadog (2.3.0)
+    datadog (2.4.0)
       debase-ruby_core_source (= 3.3.1)
       libdatadog (~> 12.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)

--- a/gemfiles/ruby_3.0_opensearch_3.gemfile.lock
+++ b/gemfiles/ruby_3.0_opensearch_3.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    datadog (2.3.0)
+    datadog (2.4.0)
       debase-ruby_core_source (= 3.3.1)
       libdatadog (~> 12.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)

--- a/gemfiles/ruby_3.0_opensearch_latest.gemfile.lock
+++ b/gemfiles/ruby_3.0_opensearch_latest.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    datadog (2.3.0)
+    datadog (2.4.0)
       debase-ruby_core_source (= 3.3.1)
       libdatadog (~> 12.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)

--- a/gemfiles/ruby_3.0_opentelemetry.gemfile.lock
+++ b/gemfiles/ruby_3.0_opentelemetry.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    datadog (2.3.0)
+    datadog (2.4.0)
       debase-ruby_core_source (= 3.3.1)
       libdatadog (~> 12.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)

--- a/gemfiles/ruby_3.0_rack_1.gemfile.lock
+++ b/gemfiles/ruby_3.0_rack_1.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    datadog (2.3.0)
+    datadog (2.4.0)
       debase-ruby_core_source (= 3.3.1)
       libdatadog (~> 12.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)

--- a/gemfiles/ruby_3.0_rack_2.gemfile.lock
+++ b/gemfiles/ruby_3.0_rack_2.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    datadog (2.3.0)
+    datadog (2.4.0)
       debase-ruby_core_source (= 3.3.1)
       libdatadog (~> 12.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)

--- a/gemfiles/ruby_3.0_rack_3.gemfile.lock
+++ b/gemfiles/ruby_3.0_rack_3.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    datadog (2.3.0)
+    datadog (2.4.0)
       debase-ruby_core_source (= 3.3.1)
       libdatadog (~> 12.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)

--- a/gemfiles/ruby_3.0_rack_latest.gemfile.lock
+++ b/gemfiles/ruby_3.0_rack_latest.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    datadog (2.3.0)
+    datadog (2.4.0)
       debase-ruby_core_source (= 3.3.1)
       libdatadog (~> 12.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)

--- a/gemfiles/ruby_3.0_rails61_mysql2.gemfile.lock
+++ b/gemfiles/ruby_3.0_rails61_mysql2.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    datadog (2.3.0)
+    datadog (2.4.0)
       debase-ruby_core_source (= 3.3.1)
       libdatadog (~> 12.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)

--- a/gemfiles/ruby_3.0_rails61_postgres.gemfile.lock
+++ b/gemfiles/ruby_3.0_rails61_postgres.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    datadog (2.3.0)
+    datadog (2.4.0)
       debase-ruby_core_source (= 3.3.1)
       libdatadog (~> 12.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)

--- a/gemfiles/ruby_3.0_rails61_postgres_redis.gemfile.lock
+++ b/gemfiles/ruby_3.0_rails61_postgres_redis.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    datadog (2.3.0)
+    datadog (2.4.0)
       debase-ruby_core_source (= 3.3.1)
       libdatadog (~> 12.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)

--- a/gemfiles/ruby_3.0_rails61_postgres_sidekiq.gemfile.lock
+++ b/gemfiles/ruby_3.0_rails61_postgres_sidekiq.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    datadog (2.3.0)
+    datadog (2.4.0)
       debase-ruby_core_source (= 3.3.1)
       libdatadog (~> 12.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)

--- a/gemfiles/ruby_3.0_rails61_semantic_logger.gemfile.lock
+++ b/gemfiles/ruby_3.0_rails61_semantic_logger.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    datadog (2.3.0)
+    datadog (2.4.0)
       debase-ruby_core_source (= 3.3.1)
       libdatadog (~> 12.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)

--- a/gemfiles/ruby_3.0_rails61_trilogy.gemfile.lock
+++ b/gemfiles/ruby_3.0_rails61_trilogy.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    datadog (2.3.0)
+    datadog (2.4.0)
       debase-ruby_core_source (= 3.3.1)
       libdatadog (~> 12.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)

--- a/gemfiles/ruby_3.0_rails7.gemfile.lock
+++ b/gemfiles/ruby_3.0_rails7.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    datadog (2.3.0)
+    datadog (2.4.0)
       debase-ruby_core_source (= 3.3.1)
       libdatadog (~> 12.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)

--- a/gemfiles/ruby_3.0_rails71.gemfile.lock
+++ b/gemfiles/ruby_3.0_rails71.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    datadog (2.3.0)
+    datadog (2.4.0)
       debase-ruby_core_source (= 3.3.1)
       libdatadog (~> 12.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)

--- a/gemfiles/ruby_3.0_redis_3.gemfile.lock
+++ b/gemfiles/ruby_3.0_redis_3.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    datadog (2.3.0)
+    datadog (2.4.0)
       debase-ruby_core_source (= 3.3.1)
       libdatadog (~> 12.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)

--- a/gemfiles/ruby_3.0_redis_4.gemfile.lock
+++ b/gemfiles/ruby_3.0_redis_4.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    datadog (2.3.0)
+    datadog (2.4.0)
       debase-ruby_core_source (= 3.3.1)
       libdatadog (~> 12.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)

--- a/gemfiles/ruby_3.0_redis_5.gemfile.lock
+++ b/gemfiles/ruby_3.0_redis_5.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    datadog (2.3.0)
+    datadog (2.4.0)
       debase-ruby_core_source (= 3.3.1)
       libdatadog (~> 12.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)

--- a/gemfiles/ruby_3.0_relational_db.gemfile.lock
+++ b/gemfiles/ruby_3.0_relational_db.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    datadog (2.3.0)
+    datadog (2.4.0)
       debase-ruby_core_source (= 3.3.1)
       libdatadog (~> 12.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)

--- a/gemfiles/ruby_3.0_resque2_redis3.gemfile.lock
+++ b/gemfiles/ruby_3.0_resque2_redis3.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    datadog (2.3.0)
+    datadog (2.4.0)
       debase-ruby_core_source (= 3.3.1)
       libdatadog (~> 12.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)

--- a/gemfiles/ruby_3.0_resque2_redis4.gemfile.lock
+++ b/gemfiles/ruby_3.0_resque2_redis4.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    datadog (2.3.0)
+    datadog (2.4.0)
       debase-ruby_core_source (= 3.3.1)
       libdatadog (~> 12.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)

--- a/gemfiles/ruby_3.0_sinatra_2.gemfile.lock
+++ b/gemfiles/ruby_3.0_sinatra_2.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    datadog (2.3.0)
+    datadog (2.4.0)
       debase-ruby_core_source (= 3.3.1)
       libdatadog (~> 12.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)

--- a/gemfiles/ruby_3.0_sinatra_3.gemfile.lock
+++ b/gemfiles/ruby_3.0_sinatra_3.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    datadog (2.3.0)
+    datadog (2.4.0)
       debase-ruby_core_source (= 3.3.1)
       libdatadog (~> 12.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)

--- a/gemfiles/ruby_3.0_sinatra_4.gemfile.lock
+++ b/gemfiles/ruby_3.0_sinatra_4.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    datadog (2.3.0)
+    datadog (2.4.0)
       debase-ruby_core_source (= 3.3.1)
       libdatadog (~> 12.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)

--- a/gemfiles/ruby_3.0_stripe_10.gemfile.lock
+++ b/gemfiles/ruby_3.0_stripe_10.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    datadog (2.3.0)
+    datadog (2.4.0)
       debase-ruby_core_source (= 3.3.1)
       libdatadog (~> 12.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)

--- a/gemfiles/ruby_3.0_stripe_11.gemfile.lock
+++ b/gemfiles/ruby_3.0_stripe_11.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    datadog (2.3.0)
+    datadog (2.4.0)
       debase-ruby_core_source (= 3.3.1)
       libdatadog (~> 12.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)

--- a/gemfiles/ruby_3.0_stripe_12.gemfile.lock
+++ b/gemfiles/ruby_3.0_stripe_12.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    datadog (2.3.0)
+    datadog (2.4.0)
       debase-ruby_core_source (= 3.3.1)
       libdatadog (~> 12.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)

--- a/gemfiles/ruby_3.0_stripe_7.gemfile.lock
+++ b/gemfiles/ruby_3.0_stripe_7.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    datadog (2.3.0)
+    datadog (2.4.0)
       debase-ruby_core_source (= 3.3.1)
       libdatadog (~> 12.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)

--- a/gemfiles/ruby_3.0_stripe_8.gemfile.lock
+++ b/gemfiles/ruby_3.0_stripe_8.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    datadog (2.3.0)
+    datadog (2.4.0)
       debase-ruby_core_source (= 3.3.1)
       libdatadog (~> 12.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)

--- a/gemfiles/ruby_3.0_stripe_9.gemfile.lock
+++ b/gemfiles/ruby_3.0_stripe_9.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    datadog (2.3.0)
+    datadog (2.4.0)
       debase-ruby_core_source (= 3.3.1)
       libdatadog (~> 12.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)

--- a/gemfiles/ruby_3.0_stripe_latest.gemfile.lock
+++ b/gemfiles/ruby_3.0_stripe_latest.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    datadog (2.3.0)
+    datadog (2.4.0)
       debase-ruby_core_source (= 3.3.1)
       libdatadog (~> 12.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)

--- a/gemfiles/ruby_3.0_stripe_min.gemfile.lock
+++ b/gemfiles/ruby_3.0_stripe_min.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    datadog (2.3.0)
+    datadog (2.4.0)
       debase-ruby_core_source (= 3.3.1)
       libdatadog (~> 12.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)

--- a/gemfiles/ruby_3.1_activesupport.gemfile.lock
+++ b/gemfiles/ruby_3.1_activesupport.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    datadog (2.3.0)
+    datadog (2.4.0)
       debase-ruby_core_source (= 3.3.1)
       libdatadog (~> 12.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)

--- a/gemfiles/ruby_3.1_aws.gemfile.lock
+++ b/gemfiles/ruby_3.1_aws.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    datadog (2.3.0)
+    datadog (2.4.0)
       debase-ruby_core_source (= 3.3.1)
       libdatadog (~> 12.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)

--- a/gemfiles/ruby_3.1_contrib.gemfile.lock
+++ b/gemfiles/ruby_3.1_contrib.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    datadog (2.3.0)
+    datadog (2.4.0)
       debase-ruby_core_source (= 3.3.1)
       libdatadog (~> 12.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)

--- a/gemfiles/ruby_3.1_contrib_old.gemfile.lock
+++ b/gemfiles/ruby_3.1_contrib_old.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    datadog (2.3.0)
+    datadog (2.4.0)
       debase-ruby_core_source (= 3.3.1)
       libdatadog (~> 12.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)

--- a/gemfiles/ruby_3.1_core_old.gemfile.lock
+++ b/gemfiles/ruby_3.1_core_old.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    datadog (2.3.0)
+    datadog (2.4.0)
       debase-ruby_core_source (= 3.3.1)
       libdatadog (~> 12.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)

--- a/gemfiles/ruby_3.1_elasticsearch_7.gemfile.lock
+++ b/gemfiles/ruby_3.1_elasticsearch_7.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    datadog (2.3.0)
+    datadog (2.4.0)
       debase-ruby_core_source (= 3.3.1)
       libdatadog (~> 12.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)

--- a/gemfiles/ruby_3.1_elasticsearch_8.gemfile.lock
+++ b/gemfiles/ruby_3.1_elasticsearch_8.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    datadog (2.3.0)
+    datadog (2.4.0)
       debase-ruby_core_source (= 3.3.1)
       libdatadog (~> 12.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)

--- a/gemfiles/ruby_3.1_elasticsearch_latest.gemfile.lock
+++ b/gemfiles/ruby_3.1_elasticsearch_latest.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    datadog (2.3.0)
+    datadog (2.4.0)
       debase-ruby_core_source (= 3.3.1)
       libdatadog (~> 12.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)

--- a/gemfiles/ruby_3.1_graphql_1.13.gemfile.lock
+++ b/gemfiles/ruby_3.1_graphql_1.13.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    datadog (2.3.0)
+    datadog (2.4.0)
       debase-ruby_core_source (= 3.3.1)
       libdatadog (~> 12.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)

--- a/gemfiles/ruby_3.1_graphql_2.0.gemfile.lock
+++ b/gemfiles/ruby_3.1_graphql_2.0.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    datadog (2.3.0)
+    datadog (2.4.0)
       debase-ruby_core_source (= 3.3.1)
       libdatadog (~> 12.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)

--- a/gemfiles/ruby_3.1_graphql_2.1.gemfile.lock
+++ b/gemfiles/ruby_3.1_graphql_2.1.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    datadog (2.3.0)
+    datadog (2.4.0)
       debase-ruby_core_source (= 3.3.1)
       libdatadog (~> 12.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)

--- a/gemfiles/ruby_3.1_graphql_2.2.gemfile.lock
+++ b/gemfiles/ruby_3.1_graphql_2.2.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    datadog (2.3.0)
+    datadog (2.4.0)
       debase-ruby_core_source (= 3.3.1)
       libdatadog (~> 12.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)

--- a/gemfiles/ruby_3.1_graphql_2.3.gemfile.lock
+++ b/gemfiles/ruby_3.1_graphql_2.3.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    datadog (2.3.0)
+    datadog (2.4.0)
       debase-ruby_core_source (= 3.3.1)
       libdatadog (~> 12.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)

--- a/gemfiles/ruby_3.1_http.gemfile.lock
+++ b/gemfiles/ruby_3.1_http.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    datadog (2.3.0)
+    datadog (2.4.0)
       debase-ruby_core_source (= 3.3.1)
       libdatadog (~> 12.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)

--- a/gemfiles/ruby_3.1_opensearch_2.gemfile.lock
+++ b/gemfiles/ruby_3.1_opensearch_2.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    datadog (2.3.0)
+    datadog (2.4.0)
       debase-ruby_core_source (= 3.3.1)
       libdatadog (~> 12.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)

--- a/gemfiles/ruby_3.1_opensearch_3.gemfile.lock
+++ b/gemfiles/ruby_3.1_opensearch_3.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    datadog (2.3.0)
+    datadog (2.4.0)
       debase-ruby_core_source (= 3.3.1)
       libdatadog (~> 12.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)

--- a/gemfiles/ruby_3.1_opensearch_latest.gemfile.lock
+++ b/gemfiles/ruby_3.1_opensearch_latest.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    datadog (2.3.0)
+    datadog (2.4.0)
       debase-ruby_core_source (= 3.3.1)
       libdatadog (~> 12.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)

--- a/gemfiles/ruby_3.1_opentelemetry.gemfile.lock
+++ b/gemfiles/ruby_3.1_opentelemetry.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    datadog (2.3.0)
+    datadog (2.4.0)
       debase-ruby_core_source (= 3.3.1)
       libdatadog (~> 12.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)

--- a/gemfiles/ruby_3.1_rack_1.gemfile.lock
+++ b/gemfiles/ruby_3.1_rack_1.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    datadog (2.3.0)
+    datadog (2.4.0)
       debase-ruby_core_source (= 3.3.1)
       libdatadog (~> 12.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)

--- a/gemfiles/ruby_3.1_rack_2.gemfile.lock
+++ b/gemfiles/ruby_3.1_rack_2.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    datadog (2.3.0)
+    datadog (2.4.0)
       debase-ruby_core_source (= 3.3.1)
       libdatadog (~> 12.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)

--- a/gemfiles/ruby_3.1_rack_3.gemfile.lock
+++ b/gemfiles/ruby_3.1_rack_3.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    datadog (2.3.0)
+    datadog (2.4.0)
       debase-ruby_core_source (= 3.3.1)
       libdatadog (~> 12.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)

--- a/gemfiles/ruby_3.1_rack_latest.gemfile.lock
+++ b/gemfiles/ruby_3.1_rack_latest.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    datadog (2.3.0)
+    datadog (2.4.0)
       debase-ruby_core_source (= 3.3.1)
       libdatadog (~> 12.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)

--- a/gemfiles/ruby_3.1_rails61_mysql2.gemfile.lock
+++ b/gemfiles/ruby_3.1_rails61_mysql2.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    datadog (2.3.0)
+    datadog (2.4.0)
       debase-ruby_core_source (= 3.3.1)
       libdatadog (~> 12.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)

--- a/gemfiles/ruby_3.1_rails61_postgres.gemfile.lock
+++ b/gemfiles/ruby_3.1_rails61_postgres.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    datadog (2.3.0)
+    datadog (2.4.0)
       debase-ruby_core_source (= 3.3.1)
       libdatadog (~> 12.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)

--- a/gemfiles/ruby_3.1_rails61_postgres_redis.gemfile.lock
+++ b/gemfiles/ruby_3.1_rails61_postgres_redis.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    datadog (2.3.0)
+    datadog (2.4.0)
       debase-ruby_core_source (= 3.3.1)
       libdatadog (~> 12.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)

--- a/gemfiles/ruby_3.1_rails61_postgres_sidekiq.gemfile.lock
+++ b/gemfiles/ruby_3.1_rails61_postgres_sidekiq.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    datadog (2.3.0)
+    datadog (2.4.0)
       debase-ruby_core_source (= 3.3.1)
       libdatadog (~> 12.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)

--- a/gemfiles/ruby_3.1_rails61_semantic_logger.gemfile.lock
+++ b/gemfiles/ruby_3.1_rails61_semantic_logger.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    datadog (2.3.0)
+    datadog (2.4.0)
       debase-ruby_core_source (= 3.3.1)
       libdatadog (~> 12.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)

--- a/gemfiles/ruby_3.1_rails61_trilogy.gemfile.lock
+++ b/gemfiles/ruby_3.1_rails61_trilogy.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    datadog (2.3.0)
+    datadog (2.4.0)
       debase-ruby_core_source (= 3.3.1)
       libdatadog (~> 12.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)

--- a/gemfiles/ruby_3.1_rails7.gemfile.lock
+++ b/gemfiles/ruby_3.1_rails7.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    datadog (2.3.0)
+    datadog (2.4.0)
       debase-ruby_core_source (= 3.3.1)
       libdatadog (~> 12.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)

--- a/gemfiles/ruby_3.1_rails71.gemfile.lock
+++ b/gemfiles/ruby_3.1_rails71.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    datadog (2.3.0)
+    datadog (2.4.0)
       debase-ruby_core_source (= 3.3.1)
       libdatadog (~> 12.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)

--- a/gemfiles/ruby_3.1_redis_3.gemfile.lock
+++ b/gemfiles/ruby_3.1_redis_3.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    datadog (2.3.0)
+    datadog (2.4.0)
       debase-ruby_core_source (= 3.3.1)
       libdatadog (~> 12.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)

--- a/gemfiles/ruby_3.1_redis_4.gemfile.lock
+++ b/gemfiles/ruby_3.1_redis_4.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    datadog (2.3.0)
+    datadog (2.4.0)
       debase-ruby_core_source (= 3.3.1)
       libdatadog (~> 12.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)

--- a/gemfiles/ruby_3.1_redis_5.gemfile.lock
+++ b/gemfiles/ruby_3.1_redis_5.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    datadog (2.3.0)
+    datadog (2.4.0)
       debase-ruby_core_source (= 3.3.1)
       libdatadog (~> 12.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)

--- a/gemfiles/ruby_3.1_relational_db.gemfile.lock
+++ b/gemfiles/ruby_3.1_relational_db.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    datadog (2.3.0)
+    datadog (2.4.0)
       debase-ruby_core_source (= 3.3.1)
       libdatadog (~> 12.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)

--- a/gemfiles/ruby_3.1_resque2_redis3.gemfile.lock
+++ b/gemfiles/ruby_3.1_resque2_redis3.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    datadog (2.3.0)
+    datadog (2.4.0)
       debase-ruby_core_source (= 3.3.1)
       libdatadog (~> 12.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)

--- a/gemfiles/ruby_3.1_resque2_redis4.gemfile.lock
+++ b/gemfiles/ruby_3.1_resque2_redis4.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    datadog (2.3.0)
+    datadog (2.4.0)
       debase-ruby_core_source (= 3.3.1)
       libdatadog (~> 12.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)

--- a/gemfiles/ruby_3.1_sinatra_2.gemfile.lock
+++ b/gemfiles/ruby_3.1_sinatra_2.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    datadog (2.3.0)
+    datadog (2.4.0)
       debase-ruby_core_source (= 3.3.1)
       libdatadog (~> 12.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)

--- a/gemfiles/ruby_3.1_sinatra_3.gemfile.lock
+++ b/gemfiles/ruby_3.1_sinatra_3.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    datadog (2.3.0)
+    datadog (2.4.0)
       debase-ruby_core_source (= 3.3.1)
       libdatadog (~> 12.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)

--- a/gemfiles/ruby_3.1_sinatra_4.gemfile.lock
+++ b/gemfiles/ruby_3.1_sinatra_4.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    datadog (2.3.0)
+    datadog (2.4.0)
       debase-ruby_core_source (= 3.3.1)
       libdatadog (~> 12.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)

--- a/gemfiles/ruby_3.1_stripe_10.gemfile.lock
+++ b/gemfiles/ruby_3.1_stripe_10.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    datadog (2.3.0)
+    datadog (2.4.0)
       debase-ruby_core_source (= 3.3.1)
       libdatadog (~> 12.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)

--- a/gemfiles/ruby_3.1_stripe_11.gemfile.lock
+++ b/gemfiles/ruby_3.1_stripe_11.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    datadog (2.3.0)
+    datadog (2.4.0)
       debase-ruby_core_source (= 3.3.1)
       libdatadog (~> 12.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)

--- a/gemfiles/ruby_3.1_stripe_12.gemfile.lock
+++ b/gemfiles/ruby_3.1_stripe_12.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    datadog (2.3.0)
+    datadog (2.4.0)
       debase-ruby_core_source (= 3.3.1)
       libdatadog (~> 12.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)

--- a/gemfiles/ruby_3.1_stripe_7.gemfile.lock
+++ b/gemfiles/ruby_3.1_stripe_7.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    datadog (2.3.0)
+    datadog (2.4.0)
       debase-ruby_core_source (= 3.3.1)
       libdatadog (~> 12.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)

--- a/gemfiles/ruby_3.1_stripe_8.gemfile.lock
+++ b/gemfiles/ruby_3.1_stripe_8.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    datadog (2.3.0)
+    datadog (2.4.0)
       debase-ruby_core_source (= 3.3.1)
       libdatadog (~> 12.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)

--- a/gemfiles/ruby_3.1_stripe_9.gemfile.lock
+++ b/gemfiles/ruby_3.1_stripe_9.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    datadog (2.3.0)
+    datadog (2.4.0)
       debase-ruby_core_source (= 3.3.1)
       libdatadog (~> 12.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)

--- a/gemfiles/ruby_3.1_stripe_latest.gemfile.lock
+++ b/gemfiles/ruby_3.1_stripe_latest.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    datadog (2.3.0)
+    datadog (2.4.0)
       debase-ruby_core_source (= 3.3.1)
       libdatadog (~> 12.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)

--- a/gemfiles/ruby_3.1_stripe_min.gemfile.lock
+++ b/gemfiles/ruby_3.1_stripe_min.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    datadog (2.3.0)
+    datadog (2.4.0)
       debase-ruby_core_source (= 3.3.1)
       libdatadog (~> 12.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)

--- a/gemfiles/ruby_3.2_activesupport.gemfile.lock
+++ b/gemfiles/ruby_3.2_activesupport.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    datadog (2.3.0)
+    datadog (2.4.0)
       debase-ruby_core_source (= 3.3.1)
       libdatadog (~> 12.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)

--- a/gemfiles/ruby_3.2_aws.gemfile.lock
+++ b/gemfiles/ruby_3.2_aws.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    datadog (2.3.0)
+    datadog (2.4.0)
       debase-ruby_core_source (= 3.3.1)
       libdatadog (~> 12.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)

--- a/gemfiles/ruby_3.2_contrib.gemfile.lock
+++ b/gemfiles/ruby_3.2_contrib.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    datadog (2.3.0)
+    datadog (2.4.0)
       debase-ruby_core_source (= 3.3.1)
       libdatadog (~> 12.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)

--- a/gemfiles/ruby_3.2_contrib_old.gemfile.lock
+++ b/gemfiles/ruby_3.2_contrib_old.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    datadog (2.3.0)
+    datadog (2.4.0)
       debase-ruby_core_source (= 3.3.1)
       libdatadog (~> 12.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)

--- a/gemfiles/ruby_3.2_core_old.gemfile.lock
+++ b/gemfiles/ruby_3.2_core_old.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    datadog (2.3.0)
+    datadog (2.4.0)
       debase-ruby_core_source (= 3.3.1)
       libdatadog (~> 12.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)

--- a/gemfiles/ruby_3.2_elasticsearch_7.gemfile.lock
+++ b/gemfiles/ruby_3.2_elasticsearch_7.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    datadog (2.3.0)
+    datadog (2.4.0)
       debase-ruby_core_source (= 3.3.1)
       libdatadog (~> 12.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)

--- a/gemfiles/ruby_3.2_elasticsearch_8.gemfile.lock
+++ b/gemfiles/ruby_3.2_elasticsearch_8.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    datadog (2.3.0)
+    datadog (2.4.0)
       debase-ruby_core_source (= 3.3.1)
       libdatadog (~> 12.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)

--- a/gemfiles/ruby_3.2_elasticsearch_latest.gemfile.lock
+++ b/gemfiles/ruby_3.2_elasticsearch_latest.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    datadog (2.3.0)
+    datadog (2.4.0)
       debase-ruby_core_source (= 3.3.1)
       libdatadog (~> 12.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)

--- a/gemfiles/ruby_3.2_graphql_1.13.gemfile.lock
+++ b/gemfiles/ruby_3.2_graphql_1.13.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    datadog (2.3.0)
+    datadog (2.4.0)
       debase-ruby_core_source (= 3.3.1)
       libdatadog (~> 12.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)

--- a/gemfiles/ruby_3.2_graphql_2.0.gemfile.lock
+++ b/gemfiles/ruby_3.2_graphql_2.0.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    datadog (2.3.0)
+    datadog (2.4.0)
       debase-ruby_core_source (= 3.3.1)
       libdatadog (~> 12.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)

--- a/gemfiles/ruby_3.2_graphql_2.1.gemfile.lock
+++ b/gemfiles/ruby_3.2_graphql_2.1.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    datadog (2.3.0)
+    datadog (2.4.0)
       debase-ruby_core_source (= 3.3.1)
       libdatadog (~> 12.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)

--- a/gemfiles/ruby_3.2_graphql_2.2.gemfile.lock
+++ b/gemfiles/ruby_3.2_graphql_2.2.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    datadog (2.3.0)
+    datadog (2.4.0)
       debase-ruby_core_source (= 3.3.1)
       libdatadog (~> 12.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)

--- a/gemfiles/ruby_3.2_graphql_2.3.gemfile.lock
+++ b/gemfiles/ruby_3.2_graphql_2.3.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    datadog (2.3.0)
+    datadog (2.4.0)
       debase-ruby_core_source (= 3.3.1)
       libdatadog (~> 12.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)

--- a/gemfiles/ruby_3.2_http.gemfile.lock
+++ b/gemfiles/ruby_3.2_http.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    datadog (2.3.0)
+    datadog (2.4.0)
       debase-ruby_core_source (= 3.3.1)
       libdatadog (~> 12.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)

--- a/gemfiles/ruby_3.2_opensearch_2.gemfile.lock
+++ b/gemfiles/ruby_3.2_opensearch_2.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    datadog (2.3.0)
+    datadog (2.4.0)
       debase-ruby_core_source (= 3.3.1)
       libdatadog (~> 12.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)

--- a/gemfiles/ruby_3.2_opensearch_3.gemfile.lock
+++ b/gemfiles/ruby_3.2_opensearch_3.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    datadog (2.3.0)
+    datadog (2.4.0)
       debase-ruby_core_source (= 3.3.1)
       libdatadog (~> 12.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)

--- a/gemfiles/ruby_3.2_opensearch_latest.gemfile.lock
+++ b/gemfiles/ruby_3.2_opensearch_latest.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    datadog (2.3.0)
+    datadog (2.4.0)
       debase-ruby_core_source (= 3.3.1)
       libdatadog (~> 12.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)

--- a/gemfiles/ruby_3.2_opentelemetry.gemfile.lock
+++ b/gemfiles/ruby_3.2_opentelemetry.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    datadog (2.3.0)
+    datadog (2.4.0)
       debase-ruby_core_source (= 3.3.1)
       libdatadog (~> 12.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)

--- a/gemfiles/ruby_3.2_rack_1.gemfile.lock
+++ b/gemfiles/ruby_3.2_rack_1.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    datadog (2.3.0)
+    datadog (2.4.0)
       debase-ruby_core_source (= 3.3.1)
       libdatadog (~> 12.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)

--- a/gemfiles/ruby_3.2_rack_2.gemfile.lock
+++ b/gemfiles/ruby_3.2_rack_2.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    datadog (2.3.0)
+    datadog (2.4.0)
       debase-ruby_core_source (= 3.3.1)
       libdatadog (~> 12.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)

--- a/gemfiles/ruby_3.2_rack_3.gemfile.lock
+++ b/gemfiles/ruby_3.2_rack_3.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    datadog (2.3.0)
+    datadog (2.4.0)
       debase-ruby_core_source (= 3.3.1)
       libdatadog (~> 12.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)

--- a/gemfiles/ruby_3.2_rack_latest.gemfile.lock
+++ b/gemfiles/ruby_3.2_rack_latest.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    datadog (2.3.0)
+    datadog (2.4.0)
       debase-ruby_core_source (= 3.3.1)
       libdatadog (~> 12.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)

--- a/gemfiles/ruby_3.2_rails61_mysql2.gemfile.lock
+++ b/gemfiles/ruby_3.2_rails61_mysql2.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    datadog (2.3.0)
+    datadog (2.4.0)
       debase-ruby_core_source (= 3.3.1)
       libdatadog (~> 12.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)

--- a/gemfiles/ruby_3.2_rails61_postgres.gemfile.lock
+++ b/gemfiles/ruby_3.2_rails61_postgres.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    datadog (2.3.0)
+    datadog (2.4.0)
       debase-ruby_core_source (= 3.3.1)
       libdatadog (~> 12.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)

--- a/gemfiles/ruby_3.2_rails61_postgres_redis.gemfile.lock
+++ b/gemfiles/ruby_3.2_rails61_postgres_redis.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    datadog (2.3.0)
+    datadog (2.4.0)
       debase-ruby_core_source (= 3.3.1)
       libdatadog (~> 12.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)

--- a/gemfiles/ruby_3.2_rails61_postgres_sidekiq.gemfile.lock
+++ b/gemfiles/ruby_3.2_rails61_postgres_sidekiq.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    datadog (2.3.0)
+    datadog (2.4.0)
       debase-ruby_core_source (= 3.3.1)
       libdatadog (~> 12.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)

--- a/gemfiles/ruby_3.2_rails61_semantic_logger.gemfile.lock
+++ b/gemfiles/ruby_3.2_rails61_semantic_logger.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    datadog (2.3.0)
+    datadog (2.4.0)
       debase-ruby_core_source (= 3.3.1)
       libdatadog (~> 12.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)

--- a/gemfiles/ruby_3.2_rails61_trilogy.gemfile.lock
+++ b/gemfiles/ruby_3.2_rails61_trilogy.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    datadog (2.3.0)
+    datadog (2.4.0)
       debase-ruby_core_source (= 3.3.1)
       libdatadog (~> 12.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)

--- a/gemfiles/ruby_3.2_rails7.gemfile.lock
+++ b/gemfiles/ruby_3.2_rails7.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    datadog (2.3.0)
+    datadog (2.4.0)
       debase-ruby_core_source (= 3.3.1)
       libdatadog (~> 12.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)

--- a/gemfiles/ruby_3.2_rails71.gemfile.lock
+++ b/gemfiles/ruby_3.2_rails71.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    datadog (2.3.0)
+    datadog (2.4.0)
       debase-ruby_core_source (= 3.3.1)
       libdatadog (~> 12.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)

--- a/gemfiles/ruby_3.2_redis_3.gemfile.lock
+++ b/gemfiles/ruby_3.2_redis_3.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    datadog (2.3.0)
+    datadog (2.4.0)
       debase-ruby_core_source (= 3.3.1)
       libdatadog (~> 12.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)

--- a/gemfiles/ruby_3.2_redis_4.gemfile.lock
+++ b/gemfiles/ruby_3.2_redis_4.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    datadog (2.3.0)
+    datadog (2.4.0)
       debase-ruby_core_source (= 3.3.1)
       libdatadog (~> 12.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)

--- a/gemfiles/ruby_3.2_redis_5.gemfile.lock
+++ b/gemfiles/ruby_3.2_redis_5.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    datadog (2.3.0)
+    datadog (2.4.0)
       debase-ruby_core_source (= 3.3.1)
       libdatadog (~> 12.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)

--- a/gemfiles/ruby_3.2_relational_db.gemfile.lock
+++ b/gemfiles/ruby_3.2_relational_db.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    datadog (2.3.0)
+    datadog (2.4.0)
       debase-ruby_core_source (= 3.3.1)
       libdatadog (~> 12.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)

--- a/gemfiles/ruby_3.2_resque2_redis3.gemfile.lock
+++ b/gemfiles/ruby_3.2_resque2_redis3.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    datadog (2.3.0)
+    datadog (2.4.0)
       debase-ruby_core_source (= 3.3.1)
       libdatadog (~> 12.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)

--- a/gemfiles/ruby_3.2_resque2_redis4.gemfile.lock
+++ b/gemfiles/ruby_3.2_resque2_redis4.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    datadog (2.3.0)
+    datadog (2.4.0)
       debase-ruby_core_source (= 3.3.1)
       libdatadog (~> 12.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)

--- a/gemfiles/ruby_3.2_sinatra_2.gemfile.lock
+++ b/gemfiles/ruby_3.2_sinatra_2.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    datadog (2.3.0)
+    datadog (2.4.0)
       debase-ruby_core_source (= 3.3.1)
       libdatadog (~> 12.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)

--- a/gemfiles/ruby_3.2_sinatra_3.gemfile.lock
+++ b/gemfiles/ruby_3.2_sinatra_3.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    datadog (2.3.0)
+    datadog (2.4.0)
       debase-ruby_core_source (= 3.3.1)
       libdatadog (~> 12.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)

--- a/gemfiles/ruby_3.2_sinatra_4.gemfile.lock
+++ b/gemfiles/ruby_3.2_sinatra_4.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    datadog (2.3.0)
+    datadog (2.4.0)
       debase-ruby_core_source (= 3.3.1)
       libdatadog (~> 12.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)

--- a/gemfiles/ruby_3.2_stripe_10.gemfile.lock
+++ b/gemfiles/ruby_3.2_stripe_10.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    datadog (2.3.0)
+    datadog (2.4.0)
       debase-ruby_core_source (= 3.3.1)
       libdatadog (~> 12.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)

--- a/gemfiles/ruby_3.2_stripe_11.gemfile.lock
+++ b/gemfiles/ruby_3.2_stripe_11.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    datadog (2.3.0)
+    datadog (2.4.0)
       debase-ruby_core_source (= 3.3.1)
       libdatadog (~> 12.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)

--- a/gemfiles/ruby_3.2_stripe_12.gemfile.lock
+++ b/gemfiles/ruby_3.2_stripe_12.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    datadog (2.3.0)
+    datadog (2.4.0)
       debase-ruby_core_source (= 3.3.1)
       libdatadog (~> 12.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)

--- a/gemfiles/ruby_3.2_stripe_7.gemfile.lock
+++ b/gemfiles/ruby_3.2_stripe_7.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    datadog (2.3.0)
+    datadog (2.4.0)
       debase-ruby_core_source (= 3.3.1)
       libdatadog (~> 12.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)

--- a/gemfiles/ruby_3.2_stripe_8.gemfile.lock
+++ b/gemfiles/ruby_3.2_stripe_8.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    datadog (2.3.0)
+    datadog (2.4.0)
       debase-ruby_core_source (= 3.3.1)
       libdatadog (~> 12.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)

--- a/gemfiles/ruby_3.2_stripe_9.gemfile.lock
+++ b/gemfiles/ruby_3.2_stripe_9.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    datadog (2.3.0)
+    datadog (2.4.0)
       debase-ruby_core_source (= 3.3.1)
       libdatadog (~> 12.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)

--- a/gemfiles/ruby_3.2_stripe_latest.gemfile.lock
+++ b/gemfiles/ruby_3.2_stripe_latest.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    datadog (2.3.0)
+    datadog (2.4.0)
       debase-ruby_core_source (= 3.3.1)
       libdatadog (~> 12.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)

--- a/gemfiles/ruby_3.2_stripe_min.gemfile.lock
+++ b/gemfiles/ruby_3.2_stripe_min.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    datadog (2.3.0)
+    datadog (2.4.0)
       debase-ruby_core_source (= 3.3.1)
       libdatadog (~> 12.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)

--- a/gemfiles/ruby_3.3_activesupport.gemfile.lock
+++ b/gemfiles/ruby_3.3_activesupport.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    datadog (2.3.0)
+    datadog (2.4.0)
       debase-ruby_core_source (= 3.3.1)
       libdatadog (~> 12.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)

--- a/gemfiles/ruby_3.3_aws.gemfile.lock
+++ b/gemfiles/ruby_3.3_aws.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    datadog (2.3.0)
+    datadog (2.4.0)
       debase-ruby_core_source (= 3.3.1)
       libdatadog (~> 12.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)

--- a/gemfiles/ruby_3.3_contrib.gemfile.lock
+++ b/gemfiles/ruby_3.3_contrib.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    datadog (2.3.0)
+    datadog (2.4.0)
       debase-ruby_core_source (= 3.3.1)
       libdatadog (~> 12.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)

--- a/gemfiles/ruby_3.3_contrib_old.gemfile.lock
+++ b/gemfiles/ruby_3.3_contrib_old.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    datadog (2.3.0)
+    datadog (2.4.0)
       debase-ruby_core_source (= 3.3.1)
       libdatadog (~> 12.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)

--- a/gemfiles/ruby_3.3_core_old.gemfile.lock
+++ b/gemfiles/ruby_3.3_core_old.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    datadog (2.3.0)
+    datadog (2.4.0)
       debase-ruby_core_source (= 3.3.1)
       libdatadog (~> 12.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)

--- a/gemfiles/ruby_3.3_elasticsearch_7.gemfile.lock
+++ b/gemfiles/ruby_3.3_elasticsearch_7.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    datadog (2.3.0)
+    datadog (2.4.0)
       debase-ruby_core_source (= 3.3.1)
       libdatadog (~> 12.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)

--- a/gemfiles/ruby_3.3_elasticsearch_8.gemfile.lock
+++ b/gemfiles/ruby_3.3_elasticsearch_8.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    datadog (2.3.0)
+    datadog (2.4.0)
       debase-ruby_core_source (= 3.3.1)
       libdatadog (~> 12.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)

--- a/gemfiles/ruby_3.3_elasticsearch_latest.gemfile.lock
+++ b/gemfiles/ruby_3.3_elasticsearch_latest.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    datadog (2.3.0)
+    datadog (2.4.0)
       debase-ruby_core_source (= 3.3.1)
       libdatadog (~> 12.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)

--- a/gemfiles/ruby_3.3_graphql_1.13.gemfile.lock
+++ b/gemfiles/ruby_3.3_graphql_1.13.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    datadog (2.3.0)
+    datadog (2.4.0)
       debase-ruby_core_source (= 3.3.1)
       libdatadog (~> 12.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)

--- a/gemfiles/ruby_3.3_graphql_2.0.gemfile.lock
+++ b/gemfiles/ruby_3.3_graphql_2.0.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    datadog (2.3.0)
+    datadog (2.4.0)
       debase-ruby_core_source (= 3.3.1)
       libdatadog (~> 12.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)

--- a/gemfiles/ruby_3.3_graphql_2.1.gemfile.lock
+++ b/gemfiles/ruby_3.3_graphql_2.1.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    datadog (2.3.0)
+    datadog (2.4.0)
       debase-ruby_core_source (= 3.3.1)
       libdatadog (~> 12.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)

--- a/gemfiles/ruby_3.3_graphql_2.2.gemfile.lock
+++ b/gemfiles/ruby_3.3_graphql_2.2.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    datadog (2.3.0)
+    datadog (2.4.0)
       debase-ruby_core_source (= 3.3.1)
       libdatadog (~> 12.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)

--- a/gemfiles/ruby_3.3_graphql_2.3.gemfile.lock
+++ b/gemfiles/ruby_3.3_graphql_2.3.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    datadog (2.3.0)
+    datadog (2.4.0)
       debase-ruby_core_source (= 3.3.1)
       libdatadog (~> 12.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)

--- a/gemfiles/ruby_3.3_http.gemfile.lock
+++ b/gemfiles/ruby_3.3_http.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    datadog (2.3.0)
+    datadog (2.4.0)
       debase-ruby_core_source (= 3.3.1)
       libdatadog (~> 12.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)

--- a/gemfiles/ruby_3.3_opensearch_2.gemfile.lock
+++ b/gemfiles/ruby_3.3_opensearch_2.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    datadog (2.3.0)
+    datadog (2.4.0)
       debase-ruby_core_source (= 3.3.1)
       libdatadog (~> 12.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)

--- a/gemfiles/ruby_3.3_opensearch_3.gemfile.lock
+++ b/gemfiles/ruby_3.3_opensearch_3.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    datadog (2.3.0)
+    datadog (2.4.0)
       debase-ruby_core_source (= 3.3.1)
       libdatadog (~> 12.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)

--- a/gemfiles/ruby_3.3_opensearch_latest.gemfile.lock
+++ b/gemfiles/ruby_3.3_opensearch_latest.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    datadog (2.3.0)
+    datadog (2.4.0)
       debase-ruby_core_source (= 3.3.1)
       libdatadog (~> 12.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)

--- a/gemfiles/ruby_3.3_opentelemetry.gemfile.lock
+++ b/gemfiles/ruby_3.3_opentelemetry.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    datadog (2.3.0)
+    datadog (2.4.0)
       debase-ruby_core_source (= 3.3.1)
       libdatadog (~> 12.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)

--- a/gemfiles/ruby_3.3_rack_2.gemfile.lock
+++ b/gemfiles/ruby_3.3_rack_2.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    datadog (2.3.0)
+    datadog (2.4.0)
       debase-ruby_core_source (= 3.3.1)
       libdatadog (~> 12.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)

--- a/gemfiles/ruby_3.3_rack_3.gemfile.lock
+++ b/gemfiles/ruby_3.3_rack_3.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    datadog (2.3.0)
+    datadog (2.4.0)
       debase-ruby_core_source (= 3.3.1)
       libdatadog (~> 12.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)

--- a/gemfiles/ruby_3.3_rack_latest.gemfile.lock
+++ b/gemfiles/ruby_3.3_rack_latest.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    datadog (2.3.0)
+    datadog (2.4.0)
       debase-ruby_core_source (= 3.3.1)
       libdatadog (~> 12.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)

--- a/gemfiles/ruby_3.3_rails61_mysql2.gemfile.lock
+++ b/gemfiles/ruby_3.3_rails61_mysql2.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    datadog (2.3.0)
+    datadog (2.4.0)
       debase-ruby_core_source (= 3.3.1)
       libdatadog (~> 12.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)

--- a/gemfiles/ruby_3.3_rails61_postgres.gemfile.lock
+++ b/gemfiles/ruby_3.3_rails61_postgres.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    datadog (2.3.0)
+    datadog (2.4.0)
       debase-ruby_core_source (= 3.3.1)
       libdatadog (~> 12.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)

--- a/gemfiles/ruby_3.3_rails61_postgres_redis.gemfile.lock
+++ b/gemfiles/ruby_3.3_rails61_postgres_redis.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    datadog (2.3.0)
+    datadog (2.4.0)
       debase-ruby_core_source (= 3.3.1)
       libdatadog (~> 12.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)

--- a/gemfiles/ruby_3.3_rails61_postgres_sidekiq.gemfile.lock
+++ b/gemfiles/ruby_3.3_rails61_postgres_sidekiq.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    datadog (2.3.0)
+    datadog (2.4.0)
       debase-ruby_core_source (= 3.3.1)
       libdatadog (~> 12.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)

--- a/gemfiles/ruby_3.3_rails61_semantic_logger.gemfile.lock
+++ b/gemfiles/ruby_3.3_rails61_semantic_logger.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    datadog (2.3.0)
+    datadog (2.4.0)
       debase-ruby_core_source (= 3.3.1)
       libdatadog (~> 12.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)

--- a/gemfiles/ruby_3.3_rails61_trilogy.gemfile.lock
+++ b/gemfiles/ruby_3.3_rails61_trilogy.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    datadog (2.3.0)
+    datadog (2.4.0)
       debase-ruby_core_source (= 3.3.1)
       libdatadog (~> 12.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)

--- a/gemfiles/ruby_3.3_rails7.gemfile.lock
+++ b/gemfiles/ruby_3.3_rails7.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    datadog (2.3.0)
+    datadog (2.4.0)
       debase-ruby_core_source (= 3.3.1)
       libdatadog (~> 12.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)

--- a/gemfiles/ruby_3.3_rails71.gemfile.lock
+++ b/gemfiles/ruby_3.3_rails71.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    datadog (2.3.0)
+    datadog (2.4.0)
       debase-ruby_core_source (= 3.3.1)
       libdatadog (~> 12.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)

--- a/gemfiles/ruby_3.3_redis_3.gemfile.lock
+++ b/gemfiles/ruby_3.3_redis_3.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    datadog (2.3.0)
+    datadog (2.4.0)
       debase-ruby_core_source (= 3.3.1)
       libdatadog (~> 12.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)

--- a/gemfiles/ruby_3.3_redis_4.gemfile.lock
+++ b/gemfiles/ruby_3.3_redis_4.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    datadog (2.3.0)
+    datadog (2.4.0)
       debase-ruby_core_source (= 3.3.1)
       libdatadog (~> 12.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)

--- a/gemfiles/ruby_3.3_redis_5.gemfile.lock
+++ b/gemfiles/ruby_3.3_redis_5.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    datadog (2.3.0)
+    datadog (2.4.0)
       debase-ruby_core_source (= 3.3.1)
       libdatadog (~> 12.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)

--- a/gemfiles/ruby_3.3_relational_db.gemfile.lock
+++ b/gemfiles/ruby_3.3_relational_db.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    datadog (2.3.0)
+    datadog (2.4.0)
       debase-ruby_core_source (= 3.3.1)
       libdatadog (~> 12.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)

--- a/gemfiles/ruby_3.3_resque2_redis3.gemfile.lock
+++ b/gemfiles/ruby_3.3_resque2_redis3.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    datadog (2.3.0)
+    datadog (2.4.0)
       debase-ruby_core_source (= 3.3.1)
       libdatadog (~> 12.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)

--- a/gemfiles/ruby_3.3_resque2_redis4.gemfile.lock
+++ b/gemfiles/ruby_3.3_resque2_redis4.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    datadog (2.3.0)
+    datadog (2.4.0)
       debase-ruby_core_source (= 3.3.1)
       libdatadog (~> 12.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)

--- a/gemfiles/ruby_3.3_sinatra_2.gemfile.lock
+++ b/gemfiles/ruby_3.3_sinatra_2.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    datadog (2.3.0)
+    datadog (2.4.0)
       debase-ruby_core_source (= 3.3.1)
       libdatadog (~> 12.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)

--- a/gemfiles/ruby_3.3_sinatra_3.gemfile.lock
+++ b/gemfiles/ruby_3.3_sinatra_3.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    datadog (2.3.0)
+    datadog (2.4.0)
       debase-ruby_core_source (= 3.3.1)
       libdatadog (~> 12.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)

--- a/gemfiles/ruby_3.3_sinatra_4.gemfile.lock
+++ b/gemfiles/ruby_3.3_sinatra_4.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    datadog (2.3.0)
+    datadog (2.4.0)
       debase-ruby_core_source (= 3.3.1)
       libdatadog (~> 12.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)

--- a/gemfiles/ruby_3.3_stripe_10.gemfile.lock
+++ b/gemfiles/ruby_3.3_stripe_10.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    datadog (2.3.0)
+    datadog (2.4.0)
       debase-ruby_core_source (= 3.3.1)
       libdatadog (~> 12.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)

--- a/gemfiles/ruby_3.3_stripe_11.gemfile.lock
+++ b/gemfiles/ruby_3.3_stripe_11.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    datadog (2.3.0)
+    datadog (2.4.0)
       debase-ruby_core_source (= 3.3.1)
       libdatadog (~> 12.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)

--- a/gemfiles/ruby_3.3_stripe_12.gemfile.lock
+++ b/gemfiles/ruby_3.3_stripe_12.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    datadog (2.3.0)
+    datadog (2.4.0)
       debase-ruby_core_source (= 3.3.1)
       libdatadog (~> 12.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)

--- a/gemfiles/ruby_3.3_stripe_7.gemfile.lock
+++ b/gemfiles/ruby_3.3_stripe_7.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    datadog (2.3.0)
+    datadog (2.4.0)
       debase-ruby_core_source (= 3.3.1)
       libdatadog (~> 12.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)

--- a/gemfiles/ruby_3.3_stripe_8.gemfile.lock
+++ b/gemfiles/ruby_3.3_stripe_8.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    datadog (2.3.0)
+    datadog (2.4.0)
       debase-ruby_core_source (= 3.3.1)
       libdatadog (~> 12.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)

--- a/gemfiles/ruby_3.3_stripe_9.gemfile.lock
+++ b/gemfiles/ruby_3.3_stripe_9.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    datadog (2.3.0)
+    datadog (2.4.0)
       debase-ruby_core_source (= 3.3.1)
       libdatadog (~> 12.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)

--- a/gemfiles/ruby_3.3_stripe_latest.gemfile.lock
+++ b/gemfiles/ruby_3.3_stripe_latest.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    datadog (2.3.0)
+    datadog (2.4.0)
       debase-ruby_core_source (= 3.3.1)
       libdatadog (~> 12.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)

--- a/gemfiles/ruby_3.3_stripe_min.gemfile.lock
+++ b/gemfiles/ruby_3.3_stripe_min.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    datadog (2.3.0)
+    datadog (2.4.0)
       debase-ruby_core_source (= 3.3.1)
       libdatadog (~> 12.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)

--- a/gemfiles/ruby_3.4_activesupport.gemfile.lock
+++ b/gemfiles/ruby_3.4_activesupport.gemfile.lock
@@ -18,7 +18,7 @@ GIT
 PATH
   remote: ..
   specs:
-    datadog (2.3.0)
+    datadog (2.4.0)
       debase-ruby_core_source (= 3.3.1)
       libdatadog (~> 12.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)

--- a/gemfiles/ruby_3.4_aws.gemfile.lock
+++ b/gemfiles/ruby_3.4_aws.gemfile.lock
@@ -18,7 +18,7 @@ GIT
 PATH
   remote: ..
   specs:
-    datadog (2.3.0)
+    datadog (2.4.0)
       debase-ruby_core_source (= 3.3.1)
       libdatadog (~> 12.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)

--- a/gemfiles/ruby_3.4_contrib.gemfile.lock
+++ b/gemfiles/ruby_3.4_contrib.gemfile.lock
@@ -18,7 +18,7 @@ GIT
 PATH
   remote: ..
   specs:
-    datadog (2.3.0)
+    datadog (2.4.0)
       debase-ruby_core_source (= 3.3.1)
       libdatadog (~> 12.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)

--- a/gemfiles/ruby_3.4_contrib_old.gemfile.lock
+++ b/gemfiles/ruby_3.4_contrib_old.gemfile.lock
@@ -18,7 +18,7 @@ GIT
 PATH
   remote: ..
   specs:
-    datadog (2.3.0)
+    datadog (2.4.0)
       debase-ruby_core_source (= 3.3.1)
       libdatadog (~> 12.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)

--- a/gemfiles/ruby_3.4_core_old.gemfile.lock
+++ b/gemfiles/ruby_3.4_core_old.gemfile.lock
@@ -18,7 +18,7 @@ GIT
 PATH
   remote: ..
   specs:
-    datadog (2.3.0)
+    datadog (2.4.0)
       debase-ruby_core_source (= 3.3.1)
       libdatadog (~> 12.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)

--- a/gemfiles/ruby_3.4_elasticsearch_7.gemfile.lock
+++ b/gemfiles/ruby_3.4_elasticsearch_7.gemfile.lock
@@ -18,7 +18,7 @@ GIT
 PATH
   remote: ..
   specs:
-    datadog (2.3.0)
+    datadog (2.4.0)
       debase-ruby_core_source (= 3.3.1)
       libdatadog (~> 12.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)

--- a/gemfiles/ruby_3.4_elasticsearch_8.gemfile.lock
+++ b/gemfiles/ruby_3.4_elasticsearch_8.gemfile.lock
@@ -18,7 +18,7 @@ GIT
 PATH
   remote: ..
   specs:
-    datadog (2.3.0)
+    datadog (2.4.0)
       debase-ruby_core_source (= 3.3.1)
       libdatadog (~> 12.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)

--- a/gemfiles/ruby_3.4_elasticsearch_latest.gemfile.lock
+++ b/gemfiles/ruby_3.4_elasticsearch_latest.gemfile.lock
@@ -18,7 +18,7 @@ GIT
 PATH
   remote: ..
   specs:
-    datadog (2.3.0)
+    datadog (2.4.0)
       debase-ruby_core_source (= 3.3.1)
       libdatadog (~> 12.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)

--- a/gemfiles/ruby_3.4_graphql_1.13.gemfile.lock
+++ b/gemfiles/ruby_3.4_graphql_1.13.gemfile.lock
@@ -18,7 +18,7 @@ GIT
 PATH
   remote: ..
   specs:
-    datadog (2.3.0)
+    datadog (2.4.0)
       debase-ruby_core_source (= 3.3.1)
       libdatadog (~> 12.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)

--- a/gemfiles/ruby_3.4_graphql_2.0.gemfile.lock
+++ b/gemfiles/ruby_3.4_graphql_2.0.gemfile.lock
@@ -18,7 +18,7 @@ GIT
 PATH
   remote: ..
   specs:
-    datadog (2.3.0)
+    datadog (2.4.0)
       debase-ruby_core_source (= 3.3.1)
       libdatadog (~> 12.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)

--- a/gemfiles/ruby_3.4_graphql_2.1.gemfile.lock
+++ b/gemfiles/ruby_3.4_graphql_2.1.gemfile.lock
@@ -18,7 +18,7 @@ GIT
 PATH
   remote: ..
   specs:
-    datadog (2.3.0)
+    datadog (2.4.0)
       debase-ruby_core_source (= 3.3.1)
       libdatadog (~> 12.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)

--- a/gemfiles/ruby_3.4_graphql_2.2.gemfile.lock
+++ b/gemfiles/ruby_3.4_graphql_2.2.gemfile.lock
@@ -18,7 +18,7 @@ GIT
 PATH
   remote: ..
   specs:
-    datadog (2.3.0)
+    datadog (2.4.0)
       debase-ruby_core_source (= 3.3.1)
       libdatadog (~> 12.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)

--- a/gemfiles/ruby_3.4_graphql_2.3.gemfile.lock
+++ b/gemfiles/ruby_3.4_graphql_2.3.gemfile.lock
@@ -18,7 +18,7 @@ GIT
 PATH
   remote: ..
   specs:
-    datadog (2.3.0)
+    datadog (2.4.0)
       debase-ruby_core_source (= 3.3.1)
       libdatadog (~> 12.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)

--- a/gemfiles/ruby_3.4_http.gemfile.lock
+++ b/gemfiles/ruby_3.4_http.gemfile.lock
@@ -18,7 +18,7 @@ GIT
 PATH
   remote: ..
   specs:
-    datadog (2.3.0)
+    datadog (2.4.0)
       debase-ruby_core_source (= 3.3.1)
       libdatadog (~> 12.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)

--- a/gemfiles/ruby_3.4_opensearch_2.gemfile.lock
+++ b/gemfiles/ruby_3.4_opensearch_2.gemfile.lock
@@ -18,7 +18,7 @@ GIT
 PATH
   remote: ..
   specs:
-    datadog (2.3.0)
+    datadog (2.4.0)
       debase-ruby_core_source (= 3.3.1)
       libdatadog (~> 12.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)

--- a/gemfiles/ruby_3.4_opensearch_3.gemfile.lock
+++ b/gemfiles/ruby_3.4_opensearch_3.gemfile.lock
@@ -18,7 +18,7 @@ GIT
 PATH
   remote: ..
   specs:
-    datadog (2.3.0)
+    datadog (2.4.0)
       debase-ruby_core_source (= 3.3.1)
       libdatadog (~> 12.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)

--- a/gemfiles/ruby_3.4_opensearch_latest.gemfile.lock
+++ b/gemfiles/ruby_3.4_opensearch_latest.gemfile.lock
@@ -18,7 +18,7 @@ GIT
 PATH
   remote: ..
   specs:
-    datadog (2.3.0)
+    datadog (2.4.0)
       debase-ruby_core_source (= 3.3.1)
       libdatadog (~> 12.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)

--- a/gemfiles/ruby_3.4_opentelemetry.gemfile.lock
+++ b/gemfiles/ruby_3.4_opentelemetry.gemfile.lock
@@ -18,7 +18,7 @@ GIT
 PATH
   remote: ..
   specs:
-    datadog (2.3.0)
+    datadog (2.4.0)
       debase-ruby_core_source (= 3.3.1)
       libdatadog (~> 12.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)

--- a/gemfiles/ruby_3.4_rack_2.gemfile.lock
+++ b/gemfiles/ruby_3.4_rack_2.gemfile.lock
@@ -18,7 +18,7 @@ GIT
 PATH
   remote: ..
   specs:
-    datadog (2.3.0)
+    datadog (2.4.0)
       debase-ruby_core_source (= 3.3.1)
       libdatadog (~> 12.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)

--- a/gemfiles/ruby_3.4_rack_3.gemfile.lock
+++ b/gemfiles/ruby_3.4_rack_3.gemfile.lock
@@ -18,7 +18,7 @@ GIT
 PATH
   remote: ..
   specs:
-    datadog (2.3.0)
+    datadog (2.4.0)
       debase-ruby_core_source (= 3.3.1)
       libdatadog (~> 12.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)

--- a/gemfiles/ruby_3.4_rack_latest.gemfile.lock
+++ b/gemfiles/ruby_3.4_rack_latest.gemfile.lock
@@ -18,7 +18,7 @@ GIT
 PATH
   remote: ..
   specs:
-    datadog (2.3.0)
+    datadog (2.4.0)
       debase-ruby_core_source (= 3.3.1)
       libdatadog (~> 12.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)

--- a/gemfiles/ruby_3.4_rails61_mysql2.gemfile.lock
+++ b/gemfiles/ruby_3.4_rails61_mysql2.gemfile.lock
@@ -18,7 +18,7 @@ GIT
 PATH
   remote: ..
   specs:
-    datadog (2.3.0)
+    datadog (2.4.0)
       debase-ruby_core_source (= 3.3.1)
       libdatadog (~> 12.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)

--- a/gemfiles/ruby_3.4_rails61_postgres.gemfile.lock
+++ b/gemfiles/ruby_3.4_rails61_postgres.gemfile.lock
@@ -18,7 +18,7 @@ GIT
 PATH
   remote: ..
   specs:
-    datadog (2.3.0)
+    datadog (2.4.0)
       debase-ruby_core_source (= 3.3.1)
       libdatadog (~> 12.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)

--- a/gemfiles/ruby_3.4_rails61_postgres_redis.gemfile.lock
+++ b/gemfiles/ruby_3.4_rails61_postgres_redis.gemfile.lock
@@ -18,7 +18,7 @@ GIT
 PATH
   remote: ..
   specs:
-    datadog (2.3.0)
+    datadog (2.4.0)
       debase-ruby_core_source (= 3.3.1)
       libdatadog (~> 12.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)

--- a/gemfiles/ruby_3.4_rails61_postgres_sidekiq.gemfile.lock
+++ b/gemfiles/ruby_3.4_rails61_postgres_sidekiq.gemfile.lock
@@ -18,7 +18,7 @@ GIT
 PATH
   remote: ..
   specs:
-    datadog (2.3.0)
+    datadog (2.4.0)
       debase-ruby_core_source (= 3.3.1)
       libdatadog (~> 12.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)

--- a/gemfiles/ruby_3.4_rails61_semantic_logger.gemfile.lock
+++ b/gemfiles/ruby_3.4_rails61_semantic_logger.gemfile.lock
@@ -18,7 +18,7 @@ GIT
 PATH
   remote: ..
   specs:
-    datadog (2.3.0)
+    datadog (2.4.0)
       debase-ruby_core_source (= 3.3.1)
       libdatadog (~> 12.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)

--- a/gemfiles/ruby_3.4_rails61_trilogy.gemfile.lock
+++ b/gemfiles/ruby_3.4_rails61_trilogy.gemfile.lock
@@ -18,7 +18,7 @@ GIT
 PATH
   remote: ..
   specs:
-    datadog (2.3.0)
+    datadog (2.4.0)
       debase-ruby_core_source (= 3.3.1)
       libdatadog (~> 12.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)

--- a/gemfiles/ruby_3.4_rails7.gemfile.lock
+++ b/gemfiles/ruby_3.4_rails7.gemfile.lock
@@ -18,7 +18,7 @@ GIT
 PATH
   remote: ..
   specs:
-    datadog (2.3.0)
+    datadog (2.4.0)
       debase-ruby_core_source (= 3.3.1)
       libdatadog (~> 12.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)

--- a/gemfiles/ruby_3.4_rails71.gemfile.lock
+++ b/gemfiles/ruby_3.4_rails71.gemfile.lock
@@ -18,7 +18,7 @@ GIT
 PATH
   remote: ..
   specs:
-    datadog (2.3.0)
+    datadog (2.4.0)
       debase-ruby_core_source (= 3.3.1)
       libdatadog (~> 12.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)

--- a/gemfiles/ruby_3.4_redis_3.gemfile.lock
+++ b/gemfiles/ruby_3.4_redis_3.gemfile.lock
@@ -18,7 +18,7 @@ GIT
 PATH
   remote: ..
   specs:
-    datadog (2.3.0)
+    datadog (2.4.0)
       debase-ruby_core_source (= 3.3.1)
       libdatadog (~> 12.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)

--- a/gemfiles/ruby_3.4_redis_4.gemfile.lock
+++ b/gemfiles/ruby_3.4_redis_4.gemfile.lock
@@ -18,7 +18,7 @@ GIT
 PATH
   remote: ..
   specs:
-    datadog (2.3.0)
+    datadog (2.4.0)
       debase-ruby_core_source (= 3.3.1)
       libdatadog (~> 12.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)

--- a/gemfiles/ruby_3.4_redis_5.gemfile.lock
+++ b/gemfiles/ruby_3.4_redis_5.gemfile.lock
@@ -18,7 +18,7 @@ GIT
 PATH
   remote: ..
   specs:
-    datadog (2.3.0)
+    datadog (2.4.0)
       debase-ruby_core_source (= 3.3.1)
       libdatadog (~> 12.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)

--- a/gemfiles/ruby_3.4_relational_db.gemfile.lock
+++ b/gemfiles/ruby_3.4_relational_db.gemfile.lock
@@ -18,7 +18,7 @@ GIT
 PATH
   remote: ..
   specs:
-    datadog (2.3.0)
+    datadog (2.4.0)
       debase-ruby_core_source (= 3.3.1)
       libdatadog (~> 12.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)

--- a/gemfiles/ruby_3.4_resque2_redis3.gemfile.lock
+++ b/gemfiles/ruby_3.4_resque2_redis3.gemfile.lock
@@ -18,7 +18,7 @@ GIT
 PATH
   remote: ..
   specs:
-    datadog (2.3.0)
+    datadog (2.4.0)
       debase-ruby_core_source (= 3.3.1)
       libdatadog (~> 12.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)

--- a/gemfiles/ruby_3.4_resque2_redis4.gemfile.lock
+++ b/gemfiles/ruby_3.4_resque2_redis4.gemfile.lock
@@ -18,7 +18,7 @@ GIT
 PATH
   remote: ..
   specs:
-    datadog (2.3.0)
+    datadog (2.4.0)
       debase-ruby_core_source (= 3.3.1)
       libdatadog (~> 12.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)

--- a/gemfiles/ruby_3.4_sinatra_2.gemfile.lock
+++ b/gemfiles/ruby_3.4_sinatra_2.gemfile.lock
@@ -18,7 +18,7 @@ GIT
 PATH
   remote: ..
   specs:
-    datadog (2.3.0)
+    datadog (2.4.0)
       debase-ruby_core_source (= 3.3.1)
       libdatadog (~> 12.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)

--- a/gemfiles/ruby_3.4_sinatra_3.gemfile.lock
+++ b/gemfiles/ruby_3.4_sinatra_3.gemfile.lock
@@ -18,7 +18,7 @@ GIT
 PATH
   remote: ..
   specs:
-    datadog (2.3.0)
+    datadog (2.4.0)
       debase-ruby_core_source (= 3.3.1)
       libdatadog (~> 12.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)

--- a/gemfiles/ruby_3.4_sinatra_4.gemfile.lock
+++ b/gemfiles/ruby_3.4_sinatra_4.gemfile.lock
@@ -18,7 +18,7 @@ GIT
 PATH
   remote: ..
   specs:
-    datadog (2.3.0)
+    datadog (2.4.0)
       debase-ruby_core_source (= 3.3.1)
       libdatadog (~> 12.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)

--- a/gemfiles/ruby_3.4_stripe_10.gemfile.lock
+++ b/gemfiles/ruby_3.4_stripe_10.gemfile.lock
@@ -18,7 +18,7 @@ GIT
 PATH
   remote: ..
   specs:
-    datadog (2.3.0)
+    datadog (2.4.0)
       debase-ruby_core_source (= 3.3.1)
       libdatadog (~> 12.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)

--- a/gemfiles/ruby_3.4_stripe_11.gemfile.lock
+++ b/gemfiles/ruby_3.4_stripe_11.gemfile.lock
@@ -18,7 +18,7 @@ GIT
 PATH
   remote: ..
   specs:
-    datadog (2.3.0)
+    datadog (2.4.0)
       debase-ruby_core_source (= 3.3.1)
       libdatadog (~> 12.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)

--- a/gemfiles/ruby_3.4_stripe_12.gemfile.lock
+++ b/gemfiles/ruby_3.4_stripe_12.gemfile.lock
@@ -18,7 +18,7 @@ GIT
 PATH
   remote: ..
   specs:
-    datadog (2.3.0)
+    datadog (2.4.0)
       debase-ruby_core_source (= 3.3.1)
       libdatadog (~> 12.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)

--- a/gemfiles/ruby_3.4_stripe_7.gemfile.lock
+++ b/gemfiles/ruby_3.4_stripe_7.gemfile.lock
@@ -18,7 +18,7 @@ GIT
 PATH
   remote: ..
   specs:
-    datadog (2.3.0)
+    datadog (2.4.0)
       debase-ruby_core_source (= 3.3.1)
       libdatadog (~> 12.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)

--- a/gemfiles/ruby_3.4_stripe_8.gemfile.lock
+++ b/gemfiles/ruby_3.4_stripe_8.gemfile.lock
@@ -18,7 +18,7 @@ GIT
 PATH
   remote: ..
   specs:
-    datadog (2.3.0)
+    datadog (2.4.0)
       debase-ruby_core_source (= 3.3.1)
       libdatadog (~> 12.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)

--- a/gemfiles/ruby_3.4_stripe_9.gemfile.lock
+++ b/gemfiles/ruby_3.4_stripe_9.gemfile.lock
@@ -18,7 +18,7 @@ GIT
 PATH
   remote: ..
   specs:
-    datadog (2.3.0)
+    datadog (2.4.0)
       debase-ruby_core_source (= 3.3.1)
       libdatadog (~> 12.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)

--- a/gemfiles/ruby_3.4_stripe_latest.gemfile.lock
+++ b/gemfiles/ruby_3.4_stripe_latest.gemfile.lock
@@ -18,7 +18,7 @@ GIT
 PATH
   remote: ..
   specs:
-    datadog (2.3.0)
+    datadog (2.4.0)
       debase-ruby_core_source (= 3.3.1)
       libdatadog (~> 12.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)

--- a/gemfiles/ruby_3.4_stripe_min.gemfile.lock
+++ b/gemfiles/ruby_3.4_stripe_min.gemfile.lock
@@ -18,7 +18,7 @@ GIT
 PATH
   remote: ..
   specs:
-    datadog (2.3.0)
+    datadog (2.4.0)
       debase-ruby_core_source (= 3.3.1)
       libdatadog (~> 12.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)

--- a/lib/datadog/version.rb
+++ b/lib/datadog/version.rb
@@ -3,7 +3,7 @@
 module Datadog
   module VERSION
     MAJOR = 2
-    MINOR = 3
+    MINOR = 4
     PATCH = 0
     PRE = nil
     BUILD = nil


### PR DESCRIPTION
### Added

* Core: Allow changing sampling rate for customer defined tags and resources (#3956)
* Profiling: Add GVL profiling for Ruby 3.2+ as a preview feature (#3929)
* Profiling: Otel: Add preview support for correlating profiling with otel ruby gem (#3984)
* Tracing: AppSec: Add http.route tag to Rails, Grape, and Sinatra integrations (#3849)
* Tracing: Add capabilities to remote config: tracing sample rate, tracing logs injection, tracing http header tags (#3888)
* AppSec: Add a force disable of AppSec feature when using Ruby >= 3.3 with old FFI gem version (#3969)

### Changed

* AppSec: Improve PII compliance (#3857)
* AppSec: Integrations: Improve accuracy of login tracking for Devise (#3867)
* Crashtracking feature is now disabled by default (#3970)

### Fixed

* AppSec: Integrations: Fix GraphQL instrumentation for query fragments (#3887)
* Bug: Profiling: Fix (small) memory leak in profiler when forking (#3852)
* Tracing: Integrations: Fix GraphQL integration reconfiguration (#3859)
