### PR TITLE
Gracefully handle Rails runner patching whenever spans aren't instrumented

### DIFF
--- a/lib/datadog/tracing/contrib/rails/runner.rb
+++ b/lib/datadog/tracing/contrib/rails/runner.rb
@@ -58,7 +58,7 @@ module Datadog
           # Capture the executed source code when provided from STDIN.
           def eval(*args)
             span = Datadog::Tracing.active_span
-            if span.name == Ext::SPAN_RUNNER_STDIN
+            if span&.name == Ext::SPAN_RUNNER_STDIN
               source = args[0]
               span.set_tag(
                 Ext::TAG_RUNNER_SOURCE,

--- a/spec/datadog/tracing/contrib/rails/runner_spec.rb
+++ b/spec/datadog/tracing/contrib/rails/runner_spec.rb
@@ -136,6 +136,14 @@ RSpec.describe Datadog::Tracing::Contrib::Rails::Runner do
       expect(span.get_tag('operation')).to eq('runner.inline')
     end
 
+    context "when a current span isn't detected" do
+      it "doesn't error when a span can't be identified to set the source tag on" do
+        allow(Datadog::Tracing).to receive(:active_span).and_return(nil)
+
+        expect { run }.to output('OK').to_stdout
+      end
+    end
+
     include_context 'with a custom service name'
     include_context 'with source code too long'
 


### PR DESCRIPTION
<!--
Check out the
https://github.com/DataDog/dd-trace-rb/blob/master/docs/DevelopmentGuide.md
for guidance on how to set up your development environment,
run the test suite, write new integrations, and more.
-->

**What does this PR do?**
<!-- A brief description of the change being made with this pull request. -->

- Resolves #3995 

**Motivation:**
<!-- What inspired you to submit this pull request? -->

This avoids an `undefined method` error on `nilClass` whenever when attempting `span.name=`. The spec correctly captures the scenario we're seeing during deploys in our Rails app.

**Additional Notes:**
<!-- Anything else we should know when reviewing? -->

**How to test the change?**
<!--
Describe here how the change can be validated.
You are strongly encouraged to provide automated tests for this PR (unit or integration).
If this change cannot be feasibly tested, please explain why,
unless the change does not modify code (e.g. only modifies docs, comments).
-->

Unsure? Have a question? Request a review!
