### PR TITLE
Remove Ruby 2.3 version check on async.rb

### DIFF
--- a/lib/datadog/core/workers/async.rb
+++ b/lib/datadog/core/workers/async.rb
@@ -148,7 +148,7 @@ module Datadog
               end
               # rubocop:enable Lint/RescueException
             end
-            @worker.name = self.class.name unless Gem::Version.new(RUBY_VERSION) < Gem::Version.new('2.3')
+            @worker.name = self.class.name
             @worker.thread_variable_set(:fork_safe, true)
 
             nil


### PR DESCRIPTION
**What does this PR do?**
I'm proposing to remove a Ruby version check on the `async.rb` file.

**Motivation:**
Since dd-trace-rb v2.0+ requires Ruby 2.5+ there are a couple of places where those checks can be removed.

**How to test the change?**
I've updated the corresponding specs to also remove the version check as the test matrix is also not running ruby 2.3 anymore

Unsure? Have a question? Request a review!
 - Let me know if this is ok, or if you are still releasing new versions under 1.x.x. If all is fine I would like to help with the cleanup of these checks in the future.