### PR TITLE
Remove Rails version check from active_record/app.rb

### DIFF
--- a/spec/datadog/tracing/contrib/active_record/app.rb
+++ b/spec/datadog/tracing/contrib/active_record/app.rb
@@ -4,20 +4,6 @@ if PlatformHelpers.jruby?
   require 'activerecord-jdbc-adapter'
 else
   require 'mysql2'
-
-  # Fix for https://github.com/brianmario/mysql2/issues/784#issuecomment-414878642
-  # for Rails 3.2.
-  if ActiveRecord::VERSION::MAJOR < 4
-    require 'active_record/connection_adapters/mysql2_adapter'
-
-    module ActiveRecord
-      module ConnectionAdapters
-        class Mysql2Adapter
-          NATIVE_DATABASE_TYPES[:primary_key] = 'int(11) auto_increment PRIMARY KEY'
-        end
-      end
-    end
-  end
 end
 
 logger = Logger.new($stdout)

--- a/spec/datadog/tracing/contrib/active_record/instantiation_spec.rb
+++ b/spec/datadog/tracing/contrib/active_record/instantiation_spec.rb
@@ -12,9 +12,6 @@ RSpec.describe 'ActiveRecord instantiation instrumentation' do
   let(:article) { Article.first }
 
   before do
-    if Gem::Version.new(ActiveRecord::VERSION::STRING) < Gem::Version.new('4.2')
-      skip 'ActiveRecord instantiation events were added in Rails 4.2'
-    end
     Article.create!(title: 'test')
 
     # Reset options (that might linger from other tests)


### PR DESCRIPTION
**What does this PR do?**
Remove a Rails gem version check in `spec/datadog/tracing/contrib/active_record/app.rb`

**Motivation:**
Since dd-trace-rb v2.0+ requires Rails 4+ then this check can be removed. I'm not sure if there's any additional cleanup that can be performed here (or even some gem cleanup?)

**How to test the change?**
Didn't see any tests covering this feature but since the test matrix does not install Rails below 4.2 then I would assume all tests pass. Also removed a `skip` condition that does not make sense anymore given test matrix is Rails 4.2+