### PR TITLE
Add lib injection support for Ruby 3.3

### DIFF
--- a/lib-injection/README.md
+++ b/lib-injection/README.md
@@ -41,7 +41,7 @@ Currently, we support
 
 | Environment| version |
 |---|---|
-| Ruby  | `2.7`, `3.0`, `3.1`, `3.2`|
+| Ruby  | `2.7`, `3.0`, `3.1`, `3.2`, `3.3`|
 | Arch  | `amd64`, `arm64` |
 | glibc |  2.28+ |
 

--- a/lib-injection/host_inject.rb
+++ b/lib-injection/host_inject.rb
@@ -83,11 +83,14 @@ else
           Bundler::SharedHelpers.in_bundle?
         end
 
+        # CRuby does *not* break API or ABI compatibility in TEENY version bumps.
+        # The ABI always sets the TEENY version to zero to reflect that: {MAJOR}.{MINOR}.0.
+        # https://www.ruby-lang.org/en/news/2013/12/21/ruby-version-policy-changes-with-2-1-0/
         def runtime_supported?
-          major, minor, = RUBY_VERSION.split('.')
+          major, minor, = RUBY_VERSION.split('.') # {MAJOR}_{MINOR}_{TEENY}
           ruby_api_version = "#{major}.#{minor}.0"
 
-          supported_ruby_api_versions = ['2.7.0', '3.0.0', '3.1.0', '3.2.0'].freeze
+          supported_ruby_api_versions = ['2.7.0', '3.0.0', '3.1.0', '3.2.0', '3.3.0'].freeze
 
           RUBY_ENGINE == 'ruby' && supported_ruby_api_versions.any? { |v| ruby_api_version == v }
         end


### PR DESCRIPTION
Support for Ruby 3.3 is present in the gem, the only thing needed for injection is to change the installation script to allow it to run with that version of Ruby.

Because the Ruby API does not change in incompatible ways in between patch versions, we declare our compatibility with the API version "3.3.0", thus supporting all 3.3.x versions.

**How to test the change?**
<!--
Describe here how the change can be validated.
You are strongly encouraged to provide automated tests for this PR (unit or integration).
If this change cannot be feasibly tested, please explain why,
unless the change does not modify code (e.g. only modifies docs, comments).
-->

Unsure? Have a question? Request a review!
