### PR TITLE
Remove Ruby 2.3 version checks in Configuration and workers

### DIFF
--- a/lib/datadog/core/configuration.rb
+++ b/lib/datadog/core/configuration.rb
@@ -278,9 +278,7 @@ module Datadog
       def handle_interrupt_shutdown!
         logger = Datadog.logger
         shutdown_thread = Thread.new { shutdown! }
-        unless Gem::Version.new(RUBY_VERSION) < Gem::Version.new('2.3')
-          shutdown_thread.name = Datadog::Core::Configuration.name
-        end
+        shutdown_thread.name = Datadog::Core::Configuration.name
 
         print_message_treshold_seconds = 0.2
 

--- a/lib/datadog/core/remote/worker.rb
+++ b/lib/datadog/core/remote/worker.rb
@@ -34,7 +34,7 @@ module Datadog
           @starting = true
 
           thread = Thread.new { poll(@interval) }
-          thread.name = self.class.name unless Gem::Version.new(RUBY_VERSION) < Gem::Version.new('2.3')
+          thread.name = self.class.name
           thread.thread_variable_set(:fork_safe, true)
           @thr = thread
 

--- a/lib/datadog/tracing/workers.rb
+++ b/lib/datadog/tracing/workers.rb
@@ -70,7 +70,7 @@ module Datadog
             @run = true
             Datadog.logger.debug { "Starting thread for: #{self}" }
             @worker = Thread.new { perform }
-            @worker.name = self.class.name unless Gem::Version.new(RUBY_VERSION) < Gem::Version.new('2.3')
+            @worker.name = self.class.name
             @worker.thread_variable_set(:fork_safe, true)
 
             nil

--- a/spec/datadog/core/configuration_spec.rb
+++ b/spec/datadog/core/configuration_spec.rb
@@ -575,9 +575,7 @@ RSpec.describe Datadog::Core::Configuration do
 
       let(:fake_thread) do
         instance_double(Thread, 'fake thread').tap do |it|
-          if Gem::Version.new(RUBY_VERSION) >= Gem::Version.new('2.3')
-            expect(it).to(receive(:name=).with('Datadog::Core::Configuration'))
-          end
+          expect(it).to(receive(:name=).with('Datadog::Core::Configuration'))
         end
       end
 

--- a/spec/datadog/core/remote/worker_spec.rb
+++ b/spec/datadog/core/remote/worker_spec.rb
@@ -49,16 +49,10 @@ RSpec.describe Datadog::Core::Remote::Worker do
       end
     end
 
-    context 'on Ruby >= 2.3' do
-      before do
-        skip 'Not supported on old Rubies' if Gem::Version.new(RUBY_VERSION) < Gem::Version.new('2.3')
-      end
+    it 'names the worker thread' do
+      worker.start
 
-      it 'names the worker thread' do
-        worker.start
-
-        expect(Thread.list.map(&:name)).to include(described_class.to_s)
-      end
+      expect(Thread.list.map(&:name)).to include(described_class.to_s)
     end
 
     # See https://github.com/puma/puma/blob/32e011ab9e029c757823efb068358ed255fb7ef4/lib/puma/cluster.rb#L353-L359

--- a/spec/datadog/tracing/workers_spec.rb
+++ b/spec/datadog/tracing/workers_spec.rb
@@ -40,30 +40,10 @@ RSpec.describe Datadog::Tracing::Workers::AsyncTransport do
   end
 
   describe 'thread naming and fork-safety marker' do
-    context 'on Ruby < 2.3' do
-      before do
-        skip 'Only applies to old Rubies' if Gem::Version.new(RUBY_VERSION) >= Gem::Version.new('2.3')
-      end
+    it do
+      worker.start
 
-      it 'does not try to set a thread name' do
-        without_partial_double_verification do
-          expect_any_instance_of(Thread).not_to receive(:name=)
-        end
-
-        worker.start
-      end
-    end
-
-    context 'on Ruby >= 2.3' do
-      before do
-        skip 'Not supported on old Rubies' if Gem::Version.new(RUBY_VERSION) < Gem::Version.new('2.3')
-      end
-
-      it do
-        worker.start
-
-        expect(worker.instance_variable_get(:@worker).name).to eq described_class.name
-      end
+      expect(worker.instance_variable_get(:@worker).name).to eq described_class.name
     end
 
     # See https://github.com/puma/puma/blob/32e011ab9e029c757823efb068358ed255fb7ef4/lib/puma/cluster.rb#L353-L359


### PR DESCRIPTION
Similar to https://github.com/DataDog/dd-trace-rb/pull/3998
Removing a couple more mentions to Ruby 2.3 now that the gem requires 2.5+
  - lib/datadog/core/configuration.rb
  - lib/datadog/tracing/workers.rb
  - lib/datadog/core/remote/worker.rb


**How to test the change?**
I've updated the corresponding specs to also remove the version check as the test matrix is also not running ruby 2.3 anymore

There are still a couple more places that I'd like to cleanup, but I'm keeping the PRs short 🤞 
