### PR TITLE
Migrate to Nix Flake

### DIFF
--- a/.github/workflows/nix.yml
+++ b/.github/workflows/nix.yml
@@ -13,16 +13,16 @@ jobs:
         platform:
           - os: darwin
             cpu: x86_64
-            base: macos-12
+            base: macos-13 # always x86_64-darwin
           - os: darwin
             cpu: arm64
-            base: macos-14
+            base: macos-14 # always arm64-darwin
           - os: linux
             cpu: x86_64
-            base: ubuntu-22.04
+            base: ubuntu-24.04 # always x86_64-linux-gnu
           - os: linux
             cpu: aarch64
-            base: arm-4core-linux
+            base: arm-4core-linux # always aarch64-linux-gnu
         nix:
           - 24.05
 

--- a/.github/workflows/nix.yml
+++ b/.github/workflows/nix.yml
@@ -22,7 +22,7 @@ jobs:
             base: ubuntu-24.04 # always x86_64-linux-gnu
           - os: linux
             cpu: aarch64
-            base: arm-4core-linux # always aarch64-linux-gnu
+            base: arm-4core-linux-ubuntu24.04 # always aarch64-linux-gnu
         nix:
           - 24.05
 
@@ -39,6 +39,9 @@ jobs:
       DD_REMOTE_CONFIGURATION_ENABLED: false
 
     steps:
+      - name: Check CPU arch
+        run: |
+          test "$(uname -m)" = "${{ matrix.platform.cpu }}"
       - uses: actions/checkout@v4
       - uses: DeterminateSystems/nix-installer-action@main
       - uses: DeterminateSystems/magic-nix-cache-action@main

--- a/.github/workflows/nix.yml
+++ b/.github/workflows/nix.yml
@@ -45,13 +45,11 @@ jobs:
       - uses: actions/checkout@v4
       - uses: DeterminateSystems/nix-installer-action@main
       - uses: DeterminateSystems/magic-nix-cache-action@main
-      - run: nix-shell --run 'which ruby'
-      - run: nix-shell --run 'ruby --version'
       - name: Print ruby version
         run: |
-          nix-shell --run 'which ruby'
-          nix-shell --run 'ruby --version'
+          nix develop --command which ruby
+          nix develop --command ruby --version
       - name: Bundle install
-        run: nix-shell --run 'bundle install'
+        run: nix develop --command bundle install
       - name: Run spec:main
-        run: nix-shell --run 'bundle exec rake spec:main'
+        run: nix develop --command bundle exec rake spec:main

--- a/.github/workflows/nix.yml
+++ b/.github/workflows/nix.yml
@@ -1,0 +1,54 @@
+name: Test Nix
+
+on:
+  push:
+    branches:
+      - "**"
+
+jobs:
+  test:
+    strategy:
+      fail-fast: false
+      matrix:
+        platform:
+          - os: darwin
+            cpu: x86_64
+            base: macos-12
+          - os: darwin
+            cpu: arm64
+            base: macos-14
+          - os: linux
+            cpu: x86_64
+            base: ubuntu-22.04
+          - os: linux
+            cpu: aarch64
+            base: arm-4core-linux
+        nix:
+          - 24.05
+
+    name: Test Nix (${{ matrix.platform.cpu }}-${{ matrix.platform.os }}, ${{ matrix.nix }})
+    runs-on: ${{ matrix.platform.base }}
+
+    permissions:
+      contents: read
+      id-token: write
+
+    env:
+      SKIP_SIMPLECOV: 1
+      DD_INSTRUMENTATION_TELEMETRY_ENABLED: false
+      DD_REMOTE_CONFIGURATION_ENABLED: false
+
+    steps:
+      - uses: actions/checkout@v4
+      - uses: DeterminateSystems/nix-installer-action@main
+      - uses: DeterminateSystems/magic-nix-cache-action@main
+      - run: nix-shell --run 'which ruby'
+      - run: nix-shell --run 'ruby --version'
+      - name: Print ruby version
+        run: |
+          nix-shell --run 'which ruby'
+          nix-shell --run 'ruby --version'
+      - name: Bundle install
+        run: nix-shell --run 'bundle install'
+      - name: Run spec:main
+        run: nix-shell --run 'bundle exec rake spec:main'

--- a/.gitignore
+++ b/.gitignore
@@ -38,7 +38,8 @@ ext/**/skipped_reason.txt
 # unless supporting rvm < 1.11.0 or doing something fancy, ignore this:
 .rvmrc
 # Ignore local variables
-.envrc
+/.envrc
+/.direnv
 
 # lock files
 Gemfile.lock

--- a/default.nix
+++ b/default.nix
@@ -8,4 +8,4 @@
     }
   )
   { src = ./.; }
-).shellNix
+).defaultNix

--- a/flake.lock
+++ b/flake.lock
@@ -1,0 +1,76 @@
+{
+  "nodes": {
+    "flake-compat": {
+      "locked": {
+        "lastModified": 1696426674,
+        "narHash": "sha256-kvjfFW7WAETZlt09AgDn1MrtKzP7t90Vf7vypd3OL1U=",
+        "rev": "0f9255e01c2351cc7d116c072cb317785dd33b33",
+        "revCount": 57,
+        "type": "tarball",
+        "url": "https://api.flakehub.com/f/pinned/edolstra/flake-compat/1.0.1/018afb31-abd1-7bff-a5e4-cff7e18efb7a/source.tar.gz"
+      },
+      "original": {
+        "type": "tarball",
+        "url": "https://flakehub.com/f/edolstra/flake-compat/1.tar.gz"
+      }
+    },
+    "flake-utils": {
+      "inputs": {
+        "systems": "systems"
+      },
+      "locked": {
+        "lastModified": 1726560853,
+        "narHash": "sha256-X6rJYSESBVr3hBoH0WbKE5KvhPU5bloyZ2L4K60/fPQ=",
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "rev": "c1dfcf08411b08f6b8615f7d8971a2bfa81d5e8a",
+        "type": "github"
+      },
+      "original": {
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "type": "github"
+      }
+    },
+    "nixpkgs": {
+      "locked": {
+        "lastModified": 1729076285,
+        "narHash": "sha256-0pKZR4g2X3YTOcLQexuDrN2vIdFQJ1djqXSBfD0gEgE=",
+        "owner": "nixos",
+        "repo": "nixpkgs",
+        "rev": "2a3b139da1ffe0cdd6ab82583e147a75738ba4f8",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nixos",
+        "ref": "master",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "root": {
+      "inputs": {
+        "flake-compat": "flake-compat",
+        "flake-utils": "flake-utils",
+        "nixpkgs": "nixpkgs"
+      }
+    },
+    "systems": {
+      "locked": {
+        "lastModified": 1681028828,
+        "narHash": "sha256-Vy1rq5AaRuLzOxct8nz4T6wlgyUR7zLU309k9mBC768=",
+        "owner": "nix-systems",
+        "repo": "default",
+        "rev": "da67096a3b9bf56a91d16901293e51ba5b49a27e",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-systems",
+        "repo": "default",
+        "type": "github"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/flake.nix
+++ b/flake.nix
@@ -1,0 +1,57 @@
+{
+  inputs = {
+    nixpkgs.url = "github:nixos/nixpkgs/master";
+
+    # cross-platform convenience
+    flake-utils.url = "github:numtide/flake-utils";
+
+    # backwards compatibility with nix-build and nix-shell
+    flake-compat.url = "https://flakehub.com/f/edolstra/flake-compat/1.tar.gz";
+  };
+
+  outputs = { self, nixpkgs, flake-utils, flake-compat }:
+    # resolve for all platforms in turn
+    flake-utils.lib.eachDefaultSystem (system:
+      let
+        # packages for this system platform
+        pkgs = nixpkgs.legacyPackages.${system};
+
+        # control versions
+        ruby = pkgs.ruby_3_3;
+        llvm = pkgs.llvmPackages_16;
+        gcc = pkgs.gcc13;
+      in {
+        devShell = pkgs.llvm.stdenv.mkDerivation {
+          name = "devshell";
+
+          buildInputs = with pkgs; [
+            ruby
+            libyaml.dev
+
+            # TODO: some gems insist on using `gcc` on Linux, satisfy them for now:
+            # - json
+            # - protobuf
+            # - ruby-prof
+            gcc
+          ];
+
+          shellHook = ''
+            # get major.minor.0 ruby version
+            export RUBY_VERSION="$(ruby -e 'puts RUBY_VERSION.gsub(/\d+$/, "0")')"
+
+            # make gem install work in-project, compatibly with bundler
+            export GEM_HOME="$(pwd)/vendor/bundle/ruby/$RUBY_VERSION"
+
+            # make bundle work in-project
+            export BUNDLE_PATH="$(pwd)/vendor/bundle"
+
+            # enable calling gem scripts without bundle exec
+            export PATH="$GEM_HOME/bin:$PATH"
+
+            # enable implicitly resolving gems to bundled version
+            export RUBYGEMS_GEMDEPS="$(pwd)/Gemfile"
+          '';
+        };
+      }
+    );
+}

--- a/spec/datadog/core/telemetry/logging_spec.rb
+++ b/spec/datadog/core/telemetry/logging_spec.rb
@@ -22,6 +22,10 @@ RSpec.describe Datadog::Core::Telemetry::Logging do
             logs: [{ message: 'RuntimeError', level: 'ERROR',
                      stack_trace: a_string_including('REDACTED') }]
           )
+          expect(event.payload).to include(
+            logs: [{ message: 'RuntimeError', level: 'ERROR',
+                     stack_trace: a_string_including(',/spec/') }]
+          )
         end
 
         begin
@@ -37,6 +41,10 @@ RSpec.describe Datadog::Core::Telemetry::Logging do
             expect(event.payload).to include(
               logs: [{ message: 'RuntimeError:Must not contain PII', level: 'ERROR',
                        stack_trace: a_string_including('REDACTED') }]
+            )
+            expect(event.payload).to include(
+              logs: [{ message: 'RuntimeError:Must not contain PII', level: 'ERROR',
+                       stack_trace: a_string_including(',/spec/') }]
             )
           end
 
@@ -55,6 +63,10 @@ RSpec.describe Datadog::Core::Telemetry::Logging do
           expect(event.payload).to include(
             logs: [{ message: /#<Class:/, level: 'ERROR',
                      stack_trace: a_string_including('REDACTED') }]
+          )
+          expect(event.payload).to include(
+            logs: [{ message: /#<Class:/, level: 'ERROR',
+                     stack_trace: a_string_including(',/spec/') }]
           )
         end
 

--- a/spec/datadog/release_gem_spec.rb
+++ b/spec/datadog/release_gem_spec.rb
@@ -35,6 +35,9 @@ RSpec.describe 'gem release process' do
            |datadog\.gemspec
            |docker-compose\.yml
            |shell\.nix
+           |default\.nix
+           |flake\.nix
+           |flake\.lock
            |static-analysis\.datadog\.yml
            |\.standard\.yml
            |\.standard_todo\.yml


### PR DESCRIPTION
<!--
Check out the
https://github.com/DataDog/dd-trace-rb/blob/master/docs/DevelopmentGuide.md
for guidance on how to set up your development environment,
run the test suite, write new integrations, and more.
-->

**What does this PR do?**
<!-- A brief description of the change being made with this pull request. -->

Migrate from classic Nix to Nix Flake.

**Motivation:**
<!-- What inspired you to submit this pull request? -->

- `flake.lock` is much more potent than simply pinning `pkgs` by commit, like `Gemfile.lock` is for Ruby.
- With evaluation caching, flakes are so much faster.

**Additional Notes:**
<!-- Anything else we should know when reviewing? -->

Backwards compatibility with classic `nix-build` and `nix-shell` is provided via `flake-compat` shims.

**How to test the change?**
<!--
Describe here how the change can be validated.
You are strongly encouraged to provide automated tests for this PR (unit or integration).
If this change cannot be feasibly tested, please explain why,
unless the change does not modify code (e.g. only modifies docs, comments).
-->

- `nix flake show --all-systems`
- `nix develop`
