### PR TITLE
Remove Ruby version checks from Gemfiles

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -73,8 +73,6 @@ gem 'dogstatsd-ruby', '>= 3.3.0', '!= 5.0.0', '!= 5.0.1', '!= 5.1.0'
 if RUBY_PLATFORM != 'java'
   if RUBY_VERSION >= '2.7.0' # Bundler 1.x fails to find that versions >= 3.8.0 are not compatible because of binary gems
     gem 'google-protobuf', ['~> 3.0', '!= 3.7.0', '!= 3.7.1']
-  elsif RUBY_VERSION >= '2.3.0'
-    gem 'google-protobuf', ['~> 3.0', '!= 3.7.0', '!= 3.7.1', '< 3.19.2']
   else
     gem 'google-protobuf', ['~> 3.0', '!= 3.7.0', '!= 3.7.1', '< 3.8.0']
   end

--- a/Gemfile
+++ b/Gemfile
@@ -74,7 +74,7 @@ if RUBY_PLATFORM != 'java'
   if RUBY_VERSION >= '2.7.0' # Bundler 1.x fails to find that versions >= 3.8.0 are not compatible because of binary gems
     gem 'google-protobuf', ['~> 3.0', '!= 3.7.0', '!= 3.7.1']
   else
-    gem 'google-protobuf', ['~> 3.0', '!= 3.7.0', '!= 3.7.1', '< 3.8.0']
+    gem 'google-protobuf', ['~> 3.0', '!= 3.7.0', '!= 3.7.1', '< 3.19.2']
   end
 end
 

--- a/integration/apps/rack/Gemfile
+++ b/integration/apps/rack/Gemfile
@@ -10,19 +10,11 @@ else
   gem 'passenger'
 end
 gem 'rack'
-gem 'rackup' if RUBY_VERSION >= '2.4'  # The `rackup` is its own gem since Rack 3.0
+gem 'rackup'
 
-if RUBY_VERSION < '2.3'
-  gem 'redis', '< 4.1.1' # 4.1.1 "claims" to support 2.2 but is actually broken
-else
-  # Known compatibility issue: https://github.com/redis/redis-rb/issues/1142
-  gem 'redis', '< 5'
-end
-if RUBY_VERSION < '2.2'
-  gem 'sidekiq', '< 5' # 5.0.3 checks for older Rubies and breaks, but does not declare it on the gemspec :(
-else
-  gem 'sidekiq'
-end
+# Known compatibility issue: https://github.com/redis/redis-rb/issues/1142
+gem 'redis', '< 5'
+gem 'sidekiq'
 gem 'resque'
 gem 'rake'
 
@@ -31,12 +23,11 @@ gem 'dogstatsd-ruby'
 gem 'datadog', *Datadog::DemoEnv.gem_spec('datadog')
 
 # Development
-gem 'pry-byebug' if RUBY_VERSION >= '2.3.0' && RUBY_ENGINE != 'truffleruby' && RUBY_VERSION < '3.2.0'
-gem 'pry-nav' if RUBY_VERSION < '2.3.0'
+gem 'pry-byebug' if RUBY_ENGINE != 'truffleruby' && RUBY_VERSION < '3.2.0'
 # gem 'pry-stack_explorer', platform: :ruby
 # gem 'rbtrace'
 # gem 'ruby-prof'
 
 gem 'rspec'
 gem 'rspec-wait'
-gem 'webrick' if RUBY_VERSION >= '2.3' # Older Rubies can just use the built-in version of webrick
+gem 'webrick'


### PR DESCRIPTION
Remove Ruby 2.3 version checks from Gemfiles as `dd-trace-rb` requires Ruby 2.5+.

- The issue mentioned in the redis gem version restriction has been closed so maybe it's worth looking into it in the future ?
- From what I understand the `Gemfile2-x` `Gemfile3-x` do not need to be updated

EDIT: Need to look into the protobuf failures, maybe missed something
