### PR TITLE
DEBUG-2334 duplicate mutable values when serializing for dynamic inst…

### DIFF
--- a/spec/datadog/di/serializer_spec.rb
+++ b/spec/datadog/di/serializer_spec.rb
@@ -320,5 +320,44 @@ RSpec.describe Datadog::DI::Serializer do
         end
       end
     end
+
+    context 'when positional args is mutated' do
+      let(:args) do
+        ['hello', 'world']
+      end
+
+      let(:kwargs) { {} }
+
+      it 'preserves original value' do
+        serialized
+
+        args.first.gsub!('hello', 'bye')
+
+        expect(serialized).to eq(
+          arg1: {type: 'String', value: 'hello'},
+          arg2: {type: 'String', value: 'world'},
+        )
+      end
+    end
+
+    context 'when keyword args is mutated' do
+      let(:args) do
+        []
+      end
+
+      let(:kwargs) do
+        {foo: 'bar'}
+      end
+
+      it 'preserves original value' do
+        serialized
+
+        kwargs[:foo].gsub!('bar', 'bye')
+
+        expect(serialized).to eq(
+          foo: {type: 'String', value: 'bar'},
+        )
+      end
+    end
   end
 end


### PR DESCRIPTION
…rumentation


<!--
Check out the
https://github.com/DataDog/dd-trace-rb/blob/master/docs/DevelopmentGuide.md
for guidance on how to set up your development environment,
run the test suite, write new integrations, and more.
-->

**Change log entry**
None needed, DI is not usable by customers yet.
<!-- If this is a customer-visible change, a brief summary to be placed into the change log. -->

**What does this PR do?**
<!-- A brief description of the change being made with this pull request. -->
When serializing parameter values at method entry, the resulting snapshot should not change if the parameter is mutated during method execution. This currently only applies to string values as other values used as serializer output are not mutable.

This PR  duplicates the string values which achieves immutability with no additional API complexity but at the cost of duplicating all strings, even if they are not entry parameters and thus can be stored without duplication.

**Motivation:**
Correct capture of method arguments at method entry.
<!-- What inspired you to submit this pull request? -->

**Additional Notes:**
<!-- Anything else we should know when reviewing? -->

**How to test the change?**
Unit tests at this time.
<!--
Describe here how the change can be validated.
You are strongly encouraged to provide automated tests for this PR (unit or integration).
If this change cannot be feasibly tested, please explain why,
unless the change does not modify code (e.g. only modifies docs, comments).
-->

Unsure? Have a question? Request a review!
