### PR TITLE
DEBUG-2334 duplicate mutable values when serializing for dynamic inst…

### DIFF
--- a/lib/datadog/di/serializer.rb
+++ b/lib/datadog/di/serializer.rb
@@ -103,8 +103,7 @@ module Datadog
           serialized.update(value: value.to_s)
         when String, Symbol
           need_dup = false
-          value = case value
-          when String
+          value = if String === value
             # This is the only place where we duplicate the value, currently.
             # All other values are immutable primitives (e.g. numbers).
             # However, do not duplicate if the string is frozen, or if

--- a/lib/datadog/di/serializer.rb
+++ b/lib/datadog/di/serializer.rb
@@ -26,6 +26,16 @@ module Datadog
     # All serialization methods take the names of the variables being
     # serialized in order to be able to redact values.
     #
+    # The result of serialization should not reference parameter values when
+    # the values are mutable (currently, this only applies to string values).
+    # Serializer will duplicate such mutable values, so that if method
+    # arguments are captured at entry and then modified during method execution,
+    # the serialized values from entry are correctly preserved.
+    # Alternatively, we could pass a parameter to the serialization methods
+    # which would control whether values are duplicated. This may be more
+    # efficient but there would be additional overhead from passing this
+    # parameter all the time and the API would get more complex.
+    #
     # @api private
     class Serializer
       def initialize(settings, redactor)
@@ -92,7 +102,14 @@ module Datadog
         when Integer, Float, TrueClass, FalseClass
           serialized.update(value: value.to_s)
         when String, Symbol
-          value = value.to_s
+          value = case value
+          when String
+            # This is the only place where we duplicate the value, currently.
+            # All other values are immutable primitives (e.g. numbers).
+            value.dup
+          else
+            value.to_s
+          end
           max = settings.dynamic_instrumentation.max_capture_string_length
           if value.length > max
             serialized.update(truncated: true, size: value.length)

--- a/spec/datadog/di/serializer_spec.rb
+++ b/spec/datadog/di/serializer_spec.rb
@@ -359,5 +359,40 @@ RSpec.describe Datadog::DI::Serializer do
         )
       end
     end
+
+    context 'when positional arg is frozen' do
+      let(:frozen_string) { 'hello'.freeze }
+
+      let(:args) do
+        [frozen_string, 'world']
+      end
+
+      let(:kwargs) { {} }
+
+      it 'serializes without duplication' do
+        expect(serialized).to eq(
+          arg1: {type: 'String', value: 'hello'},
+          arg2: {type: 'String', value: 'world'},
+        )
+
+        expect(serialized[:arg1][:value]).to be frozen_string
+      end
+    end
+
+    context 'when keyword arg is frozen' do
+      let(:frozen_string) { 'hello'.freeze }
+
+      let(:args) { [] }
+
+      let(:kwargs) { {foo: frozen_string} }
+
+      it 'serializes without duplication' do
+        expect(serialized).to eq(
+          foo: {type: 'String', value: 'hello'},
+        )
+
+        expect(serialized[:foo][:value]).to be frozen_string
+      end
+    end
   end
 end

--- a/spec/datadog/di/serializer_spec.rb
+++ b/spec/datadog/di/serializer_spec.rb
@@ -320,5 +320,44 @@ RSpec.describe Datadog::DI::Serializer do
         end
       end
     end
+
+    context 'when positional arg is mutated' do
+      let(:args) do
+        ['hello', 'world']
+      end
+
+      let(:kwargs) { {} }
+
+      it 'preserves original value' do
+        serialized
+
+        args.first.gsub!('hello', 'bye')
+
+        expect(serialized).to eq(
+          arg1: {type: 'String', value: 'hello'},
+          arg2: {type: 'String', value: 'world'},
+        )
+      end
+    end
+
+    context 'when keyword arg is mutated' do
+      let(:args) do
+        []
+      end
+
+      let(:kwargs) do
+        {foo: 'bar'}
+      end
+
+      it 'preserves original value' do
+        serialized
+
+        kwargs[:foo].gsub!('bar', 'bye')
+
+        expect(serialized).to eq(
+          foo: {type: 'String', value: 'bar'},
+        )
+      end
+    end
   end
 end


### PR DESCRIPTION
…rumentation


<!--
Check out the
https://github.com/DataDog/dd-trace-rb/blob/master/docs/DevelopmentGuide.md
for guidance on how to set up your development environment,
run the test suite, write new integrations, and more.
-->

**Change log entry**
None needed, DI is not usable by customers yet.
<!-- If this is a customer-visible change, a brief summary to be placed into the change log. -->

**What does this PR do?**
<!-- A brief description of the change being made with this pull request. -->
When serializing parameter values at method entry, the resulting snapshot should not change if the parameter is mutated during method execution. This currently only applies to string values as other values used as serializer output are not mutable.

This PR  duplicates the string values which achieves immutability with no additional API complexity but at the cost of duplicating all strings, even if they are not entry parameters and thus can be stored without duplication.

**Motivation:**
Correct capture of method arguments at method entry.
<!-- What inspired you to submit this pull request? -->

**Additional Notes:**
<!-- Anything else we should know when reviewing? -->

**How to test the change?**
Unit tests at this time.
<!--
Describe here how the change can be validated.
You are strongly encouraged to provide automated tests for this PR (unit or integration).
If this change cannot be feasibly tested, please explain why,
unless the change does not modify code (e.g. only modifies docs, comments).
-->

Unsure? Have a question? Request a review!
