### PR TITLE
DEBUG-2334 enforce probe type validity

### DIFF
--- a/lib/datadog/di/probe.rb
+++ b/lib/datadog/di/probe.rb
@@ -31,11 +31,17 @@ module Datadog
     #
     # @api private
     class Probe
+      KNOWN_TYPES = %i[log].freeze
+
       def initialize(id:, type:,
         file: nil, line_no: nil, type_name: nil, method_name: nil,
         template: nil, capture_snapshot: false, max_capture_depth: nil, rate_limit: nil)
         # Perform some sanity checks here to detect unexpected attribute
         # combinations, in order to not do them in subsequent code.
+        unless KNOWN_TYPES.include?(type)
+          raise ArgumentError, "Unknown probe type: #{type}"
+        end
+
         if line_no && method_name
           raise ArgumentError, "Probe contains both line number and method name: #{id}"
         end

--- a/lib/datadog/di/probe_builder.rb
+++ b/lib/datadog/di/probe_builder.rb
@@ -17,11 +17,17 @@ module Datadog
     #
     # @api private
     module ProbeBuilder
+      PROBE_TYPES = {
+        'LOG_PROBE' => :log,
+      }.freeze
+
       module_function def build_from_remote_config(config)
         # The validations here are not yet comprehensive.
+        type = config.fetch('type')
+        type_symbol = PROBE_TYPES[type] or raise ArgumentError, "Unrecognized probe type: #{type}"
         Probe.new(
           id: config.fetch("id"),
-          type: config.fetch("type"),
+          type: type_symbol,
           file: config["where"]&.[]("sourceFile"),
           # Sometimes lines are sometimes received as an array of nil
           # for some reason.

--- a/sig/datadog/di/probe.rbs
+++ b/sig/datadog/di/probe.rbs
@@ -1,9 +1,11 @@
 module Datadog
   module DI
     class Probe
+      KNOWN_TYPES: Array[Symbol]
+      
       @id: String
 
-      @type: String
+      @type: Symbol
 
       @file: String?
 
@@ -19,12 +21,12 @@ module Datadog
 
       @rate_limiter: Datadog::Core::RateLimiter
 
-      def initialize: (id: String, type: String, ?file: String?, ?line_no: Integer?, ?type_name: String?, ?method_name: String?, ?template: String?, ?capture_snapshot: bool,
+      def initialize: (id: String, type: Symbol, ?file: String?, ?line_no: Integer?, ?type_name: String?, ?method_name: String?, ?template: String?, ?capture_snapshot: bool,
 	?max_capture_depth: Integer, ?rate_limit: Integer) -> void
 
       attr_reader id: String
 
-      attr_reader type: String
+      attr_reader type: Symbol
 
       attr_reader file: String?
 

--- a/sig/datadog/di/probe_builder.rbs
+++ b/sig/datadog/di/probe_builder.rbs
@@ -1,6 +1,8 @@
 module Datadog
   module DI
     module ProbeBuilder
+      PROBE_TYPES: { "LOG_PROBE" => :log }
+      
       def self?.build_from_remote_config: (Hash[untyped,untyped] config) -> Probe
     end
   end

--- a/spec/datadog/di/probe_builder_spec.rb
+++ b/spec/datadog/di/probe_builder_spec.rb
@@ -31,7 +31,7 @@ RSpec.describe Datadog::DI::ProbeBuilder do
 
       it "creates line probe with corresponding values" do
         expect(probe.id).to eq "3ecfd456-2d7c-4359-a51f-d4cc44141ffe"
-        expect(probe.type).to eq "LOG_PROBE"
+        expect(probe.type).to eq :log
         expect(probe.file).to eq "aaa.rb"
         expect(probe.line_no).to eq 4321
         expect(probe.type_name).to be nil


### PR DESCRIPTION

<!--
Check out the
https://github.com/DataDog/dd-trace-rb/blob/master/docs/DevelopmentGuide.md
for guidance on how to set up your development environment,
run the test suite, write new integrations, and more.
-->

**Change log entry**
<!-- If this is a customer-visible change, a brief summary to be placed into the change log. -->
None, DI is not yet shipped to customers.

**What does this PR do?**
<!-- A brief description of the change being made with this pull request. -->
Dynamic instrumentation currently supports 4 probe types (log, metric, span and span decoration). Initial implementation of Ruby DI will only support log probes.
To avoid installing the other probe types, potentially with incorrect results, add a validation of probe type and require that the probe is of the supported type
(currently, just the log probe).

**Motivation:**
<!-- What inspired you to submit this pull request? -->

**Additional Notes:**
<!-- Anything else we should know when reviewing? -->

**How to test the change?**
<!--
Describe here how the change can be validated.
You are strongly encouraged to provide automated tests for this PR (unit or integration).
If this change cannot be feasibly tested, please explain why,
unless the change does not modify code (e.g. only modifies docs, comments).
-->

Unsure? Have a question? Request a review!
