### PR TITLE
Backport: Replace 'debase' with 'datadog'-ruby_core_source gem

### DIFF
--- a/ddtrace.gemspec
+++ b/ddtrace.gemspec
@@ -62,7 +62,7 @@ Gem::Specification.new do |spec|
   # Used by the profiler native extension to support Ruby < 2.6 and > 3.2
   #
   # We decided to pin it at the latest available version and will manually bump the dependency as needed.
-  spec.add_dependency 'debase-ruby_core_source', '= 3.3.1'
+  spec.add_dependency 'datadog-ruby_core_source', '= 3.3.6'
 
   # Used by appsec
   spec.add_dependency 'libddwaf', '~> 1.14.0.0.0'

--- a/ext/datadog_profiling_native_extension/NativeExtensionDesign.md
+++ b/ext/datadog_profiling_native_extension/NativeExtensionDesign.md
@@ -68,7 +68,7 @@ internal types, structures and functions).
 Because these private header files are not included in regular Ruby installations, we have two different workarounds:
 
 1. for Ruby versions 2.6 to 3.2 we make use use the Ruby private MJIT header
-2. for Ruby versions < 2.6 and > 3.2 we make use of the `debase-ruby_core_source` gem
+2. for Ruby versions < 2.6 and > 3.2 we make use of the `datadog-ruby_core_source` gem
 
 Functions which make use of these headers are defined in the <private_vm_api_acccess.c> file.
 
@@ -91,9 +91,9 @@ version. e.g. `rb_mjit_min_header-2.7.4.h`.
 
 This header was removed in Ruby 3.3.
 
-### Approach 2: Using the `debase-ruby_core_source` gem
+### Approach 2: Using the `datadog-ruby_core_source` gem
 
-The [`debase-ruby_core_source`](https://github.com/ruby-debug/debase-ruby_core_source) contains almost no code;
+The [`datadog-ruby_core_source`](https://github.com/ruby-debug/datadog-ruby_core_source) contains almost no code;
 instead, it just contains per-Ruby-version folders with the private VM headers (`.h`) files for that version.
 
 Thus, even though a regular Ruby installation does not include these files, we can access the copy inside this gem.

--- a/ext/datadog_profiling_native_extension/extconf.rb
+++ b/ext/datadog_profiling_native_extension/extconf.rb
@@ -269,16 +269,16 @@ if Datadog::Profiling::NativeExtensionHelpers::CAN_USE_MJIT_HEADER
   create_makefile EXTENSION_NAME
 else
   # The MJIT header was introduced on 2.6 and removed on 3.3; for other Rubies we rely on
-  # the debase-ruby_core_source gem to get access to private VM headers.
+  # the datadog-ruby_core_source gem to get access to private VM headers.
   # This gem ships source code copies of these VM headers for the different Ruby VM versions;
-  # see https://github.com/ruby-debug/debase-ruby_core_source for details
+  # see https://github.com/DataDog/datadog-ruby_core_source for details
 
   create_header
 
-  require 'debase/ruby_core_source'
+  require 'datadog/ruby_core_source'
   dir_config('ruby') # allow user to pass in non-standard core include directory
 
-  Debase::RubyCoreSource
+  Datadog::RubyCoreSource
     .create_makefile_with_core(
       proc do
         headers_available =

--- a/ext/datadog_profiling_native_extension/native_extension_helpers.rb
+++ b/ext/datadog_profiling_native_extension/native_extension_helpers.rb
@@ -12,7 +12,7 @@ module Datadog
       # Can be set to force rubygems to fail gem installation when profiling extension could not be built
       ENV_FAIL_INSTALL_IF_MISSING_EXTENSION = 'DD_PROFILING_FAIL_INSTALL_IF_MISSING_EXTENSION'
 
-      # The MJIT header was introduced on 2.6 and removed on 3.3; for other Rubies we rely on debase-ruby_core_source
+      # The MJIT header was introduced on 2.6 and removed on 3.3; for other Rubies we rely on datadog-ruby_core_source
       CAN_USE_MJIT_HEADER = RUBY_VERSION.start_with?('2.6', '2.7', '3.0.', '3.1.', '3.2.')
 
       LIBDATADOG_VERSION = '~> 7.0.0.1.0'

--- a/ext/datadog_profiling_native_extension/private_vm_api_access.c
+++ b/ext/datadog_profiling_native_extension/private_vm_api_access.c
@@ -13,7 +13,7 @@
   #include RUBY_MJIT_HEADER
 #else
   // The MJIT header was introduced on 2.6 and removed on 3.3; for other Rubies we rely on
-  // the debase-ruby_core_source gem to get access to private VM headers.
+  // the datadog-ruby_core_source gem to get access to private VM headers.
 
   // We can't do anything about warnings in VM headers, so we just use this technique to suppress them.
   // See https://nelkinda.com/blog/suppress-warnings-in-gcc-and-clang/#d11e364 for details.

--- a/lib-injection/host_inject.rb
+++ b/lib-injection/host_inject.rb
@@ -63,7 +63,7 @@ begin
   [
     'msgpack',
     'ffi',
-    'debase-ruby_core_source',
+    'datadog-ruby_core_source',
     'libdatadog',
     'libddwaf',
     'datadog-ci',

--- a/spec/ddtrace/release_gem_spec.rb
+++ b/spec/ddtrace/release_gem_spec.rb
@@ -94,7 +94,7 @@ RSpec.describe 'gem release process' do
           # since it is used to alarm when dependencies  modified.
           'datadog-ci',
           'ddtrace',
-          'debase-ruby_core_source',
+          'datadog-ruby_core_source',
           'ffi',
           'libdatadog',
           'libddwaf',


### PR DESCRIPTION
<!--
Check out the
https://github.com/DataDog/dd-trace-rb/blob/master/docs/DevelopmentGuide.md
for guidance on how to set up your development environment,
run the test suite, write new integrations, and more.
-->

**Change log entry**
Replace the `debase-ruby_core_source` gem with the `datadog-ruby_core_source`.

**What does this PR do?**
This PR updates the library such that it now uses the `datadog-ruby_core_source` Ruby gem.

**Motivation:**
Backport change from #4014 . This update will reduce the size of the gem, as `datadog-ruby_core_source` only includes support for Ruby versions 2.5, 3.3, and 3.4 - [more info here](https://github.com/DataDog/dd-trace-rb/blob/master/ext/datadog_profiling_native_extension/NativeExtensionDesign.md#usage-of-private-vm-headers).

**Additional Notes:**
This PR relates to the larger project of creating the `datadog-ruby_core_source` gem. See [here](https://docs.google.com/document/d/1lbehlvLADt_ztblhlEnnTFKQ8EVxxOWHdgFzTSqD9Qc/edit?tab=t.0#task=YxycgZORWQhz-chI) for more info.

**How to test the change?**
<!--
Describe here how the change can be validated.
You are strongly encouraged to provide automated tests for this PR (unit or integration).
If this change cannot be feasibly tested, please explain why,
unless the change does not modify code (e.g. only modifies docs, comments).
-->

Unsure? Have a question? Request a review!
