### PR TITLE
[PROF-9470] Align heap recorder cleanup with GC activity (second try)

### DIFF
--- a/.gitlab/benchmarks.yml
+++ b/.gitlab/benchmarks.yml
@@ -104,6 +104,16 @@ only-profiling-heap:
     DD_PROFILING_EXPERIMENTAL_HEAP_ENABLED: "true"
     ADD_TO_GEMFILE: "gem 'datadog', github: 'datadog/dd-trace-rb', ref: '$CI_COMMIT_SHA'"
 
+only-profiling-heap-clean-after-gc:
+  extends: .benchmarks
+  variables:
+    DD_BENCHMARKS_CONFIGURATION: only-profiling
+    DD_PROFILING_ENABLED: "true"
+    DD_PROFILING_ALLOCATION_ENABLED: "true"
+    DD_PROFILING_EXPERIMENTAL_HEAP_ENABLED: "true"
+    DD_PROFILING_HEAP_CLEAN_AFTER_GC_ENABLED: "true"
+    ADD_TO_GEMFILE: "gem 'datadog', github: 'datadog/dd-trace-rb', ref: '$CI_COMMIT_SHA'"
+
 profiling-and-tracing:
   extends: .benchmarks
   variables:

--- a/.gitlab/benchmarks.yml
+++ b/.gitlab/benchmarks.yml
@@ -95,15 +95,6 @@ only-profiling-alloc:
     DD_PROFILING_ALLOCATION_ENABLED: "true"
     ADD_TO_GEMFILE: "gem 'datadog', github: 'datadog/dd-trace-rb', ref: '$CI_COMMIT_SHA'"
 
-only-profiling-alloc-ddprof:
-  extends: .benchmarks
-  variables:
-    DD_BENCHMARKS_DDPROF: "true"
-    DD_BENCHMARKS_CONFIGURATION: only-profiling
-    DD_PROFILING_ENABLED: "true"
-    DD_PROFILING_ALLOCATION_ENABLED: "true"
-    ADD_TO_GEMFILE: "gem 'datadog', github: 'datadog/dd-trace-rb', ref: '$CI_COMMIT_SHA'"
-
 only-profiling-heap:
   extends: .benchmarks
   variables:

--- a/benchmarks/profiler_gc.rb
+++ b/benchmarks/profiler_gc.rb
@@ -9,14 +9,7 @@ require_relative 'benchmarks_helper'
 
 class ProfilerGcBenchmark
   def create_profiler
-    @recorder = Datadog::Profiling::StackRecorder.new(
-      cpu_time_enabled: true,
-      alloc_samples_enabled: false,
-      heap_samples_enabled: false,
-      heap_size_enabled: false,
-      heap_sample_every: 1,
-      timeline_enabled: true,
-    )
+    @recorder = Datadog::Profiling::StackRecorder.for_testing(timeline_enabled: true)
     @collector = Datadog::Profiling::Collectors::ThreadContext.for_testing(recorder: @recorder, timeline_enabled: true)
 
     # We take a dummy sample so that the context for the main thread is created, as otherwise the GC profiling methods do

--- a/benchmarks/profiler_memory_sample_serialize.rb
+++ b/benchmarks/profiler_memory_sample_serialize.rb
@@ -45,7 +45,7 @@ class ProfilerMemorySampleSerializeBenchmark
     @retain_every = (ENV['RETAIN_EVERY'] || '10').to_i
     @skip_end_gc = ENV['SKIP_END_GC'] == 'true'
     @recorder_factory = proc {
-      Datadog::Profiling::StackRecorder.new(
+      Datadog::Profiling::StackRecorder.for_testing(
         cpu_time_enabled: false,
         alloc_samples_enabled: true,
         heap_samples_enabled: @heap_samples_enabled,

--- a/benchmarks/profiler_sample_gvl.rb
+++ b/benchmarks/profiler_sample_gvl.rb
@@ -31,14 +31,7 @@ class ProfilerSampleGvlBenchmark
   end
 
   def create_profiler
-    @recorder = Datadog::Profiling::StackRecorder.new(
-      cpu_time_enabled: true,
-      alloc_samples_enabled: false,
-      heap_samples_enabled: false,
-      heap_size_enabled: false,
-      heap_sample_every: 1,
-      timeline_enabled: true,
-    )
+    @recorder = Datadog::Profiling::StackRecorder.for_testing(timeline_enabled: true)
     @collector = Datadog::Profiling::Collectors::ThreadContext.for_testing(
       recorder: @recorder,
       waiting_for_gvl_threshold_ns: 0,

--- a/benchmarks/profiler_sample_loop_v2.rb
+++ b/benchmarks/profiler_sample_loop_v2.rb
@@ -13,14 +13,7 @@ class ProfilerSampleLoopBenchmark
   PROFILER_OVERHEAD_STACK_THREAD = Thread.new { sleep }
 
   def create_profiler
-    @recorder = Datadog::Profiling::StackRecorder.new(
-      cpu_time_enabled: true,
-      alloc_samples_enabled: false,
-      heap_samples_enabled: false,
-      heap_size_enabled: false,
-      heap_sample_every: 1,
-      timeline_enabled: false,
-    )
+    @recorder = Datadog::Profiling::StackRecorder.for_testing
     @collector = Datadog::Profiling::Collectors::ThreadContext.for_testing(recorder: @recorder)
   end
 

--- a/benchmarks/profiler_sample_serialize.rb
+++ b/benchmarks/profiler_sample_serialize.rb
@@ -19,14 +19,7 @@ class ProfilerSampleSerializeBenchmark
 
   def create_profiler
     timeline_enabled = ENV['TIMELINE'] == 'true'
-    @recorder = Datadog::Profiling::StackRecorder.new(
-      cpu_time_enabled: true,
-      alloc_samples_enabled: false,
-      heap_samples_enabled: false,
-      heap_size_enabled: false,
-      heap_sample_every: 1,
-      timeline_enabled: timeline_enabled,
-    )
+    @recorder = Datadog::Profiling::StackRecorder.for_testing(timeline_enabled: timeline_enabled)
     @collector = Datadog::Profiling::Collectors::ThreadContext.for_testing(recorder: @recorder, timeline_enabled: timeline_enabled)
   end
 

--- a/ext/datadog_profiling_native_extension/collectors_thread_context.c
+++ b/ext/datadog_profiling_native_extension/collectors_thread_context.c
@@ -815,6 +815,9 @@ VALUE thread_context_collector_sample_after_gc(VALUE self_instance) {
 
   state->stats.gc_samples++;
 
+  // Let recorder do any cleanup/updates it requires after a GC step.
+  recorder_after_gc_step(state->recorder_instance);
+
   // Return a VALUE to make it easier to call this function from Ruby APIs that expect a return value (such as rb_rescue2)
   return Qnil;
 }

--- a/ext/datadog_profiling_native_extension/collectors_thread_context.c
+++ b/ext/datadog_profiling_native_extension/collectors_thread_context.c
@@ -1444,7 +1444,8 @@ void thread_context_collector_sample_allocation(VALUE self_instance, unsigned in
         class_name = ruby_value_type_to_class_name(type);
       }
     } else {
-      // Fallback for objects with no class
+      // Fallback for objects with no class. Objects with no class are a way for the Ruby VM to mark them
+      // as internal objects; see rb_objspace_internal_object_p for details.
       class_name = ruby_value_type_to_class_name(type);
     }
   } else if (type == RUBY_T_IMEMO) {

--- a/ext/datadog_profiling_native_extension/heap_recorder.c
+++ b/ext/datadog_profiling_native_extension/heap_recorder.c
@@ -218,7 +218,7 @@ static int st_object_records_debug(st_data_t key, st_data_t value, st_data_t ext
 static int update_object_record_entry(st_data_t*, st_data_t*, st_data_t, int);
 static void commit_recording(heap_recorder*, heap_record*, recording);
 static VALUE end_heap_allocation_recording(VALUE end_heap_allocation_args);
-static double inline ewma_stat(double previous, double current);
+static inline double ewma_stat(double previous, double current);
 
 // ==========================
 // Heap Recorder External API
@@ -1188,7 +1188,7 @@ st_index_t heap_record_key_hash_st(st_data_t key) {
   }
 }
 
-static double inline ewma_stat(double previous, double current) {
+static inline double ewma_stat(double previous, double current) {
   double alpha = 0.3;
   return (1 - alpha) * previous + alpha * current;
 }

--- a/ext/datadog_profiling_native_extension/heap_recorder.c
+++ b/ext/datadog_profiling_native_extension/heap_recorder.c
@@ -979,12 +979,12 @@ VALUE object_record_inspect(object_record *record) {
     rb_str_catf(inspect, "object=<invalid>");
   } else {
     rb_str_catf(inspect, "value=%p ", (void *) ref);
-    /*VALUE ruby_inspect = ruby_safe_inspect(ref);
+    VALUE ruby_inspect = ruby_safe_inspect(ref);
     if (ruby_inspect != Qnil) {
       rb_str_catf(inspect, "object=%"PRIsVALUE, ruby_inspect);
     } else {
       rb_str_catf(inspect, "object=%s", ruby_value_type_to_string(rb_type(ref)));
-    }*/
+    }
   }
 
   return inspect;

--- a/ext/datadog_profiling_native_extension/heap_recorder.c
+++ b/ext/datadog_profiling_native_extension/heap_recorder.c
@@ -491,6 +491,9 @@ static void heap_recorder_update(heap_recorder *heap_recorder, bool full_update)
   heap_recorder->stats_lifetime.updates_successful++;
 
   // Lifetime stats updating
+  // TODO: Discuss with Alex -- should we separate these out between young objects only and full updates?
+  // Tracking them together in this way seems to be muddying the waters -- young object updates will have more objects
+  // skipped, and different mixes of alive/dead
   heap_recorder->stats_lifetime.ewma_objects_alive = ewma_stat(heap_recorder->stats_lifetime.ewma_objects_alive, heap_recorder->stats_last_update.objects_alive);
   heap_recorder->stats_lifetime.ewma_objects_dead = ewma_stat(heap_recorder->stats_lifetime.ewma_objects_dead, heap_recorder->stats_last_update.objects_dead);
   heap_recorder->stats_lifetime.ewma_objects_skipped = ewma_stat(heap_recorder->stats_lifetime.ewma_objects_skipped, heap_recorder->stats_last_update.objects_skipped);

--- a/ext/datadog_profiling_native_extension/heap_recorder.c
+++ b/ext/datadog_profiling_native_extension/heap_recorder.c
@@ -6,7 +6,6 @@
 #include "collectors_stack.h"
 #include "libdatadog_helpers.h"
 #include "time_helpers.h"
-#include "collectors_gc_profiling_helper.h"
 
 #if (defined(HAVE_WORKING_RB_GC_FORCE_RECYCLE) && ! defined(NO_SEEN_OBJ_ID_FLAG))
   #define CAN_APPLY_GC_FORCE_RECYCLE_BUG_WORKAROUND

--- a/ext/datadog_profiling_native_extension/heap_recorder.c
+++ b/ext/datadog_profiling_native_extension/heap_recorder.c
@@ -463,7 +463,7 @@ void heap_recorder_update(heap_recorder *heap_recorder, bool force_full_update) 
     if (current_gc_gen == heap_recorder->update_gen && (last_update_included_old || !this_update_should_include_old)) {
       // Are we still in the same GC gen as last update? If so, skip updating since things should not have
       // changed significantly since last time (especially if last time already included old objects or
-      // if this update is not going to look at old objects). But skip signalling success/no-op.
+      // if this update is not going to look at old objects).
       // NOTE: This is mostly a performance decision. I suppose some objects may be cleaned up in intermediate
       // GC steps and sizes may change. But because we have to iterate through all our tracked
       // object records to do an update, lets wait until all steps for a particular GC generation

--- a/ext/datadog_profiling_native_extension/heap_recorder.c
+++ b/ext/datadog_profiling_native_extension/heap_recorder.c
@@ -167,8 +167,6 @@ struct heap_recorder {
   bool update_include_old;
   // When did we do the last update of heap recorder?
   long last_update_ns;
-  // Did we see a major GC since then?
-  bool last_update_major_gc_since;
 
   // Data for a heap recording that was started but not yet ended
   recording active_recording;
@@ -451,8 +449,7 @@ void heap_recorder_update(heap_recorder *heap_recorder, bool force_full_update) 
   size_t current_gc_gen = rb_gc_count();
 
   bool last_update_included_old = heap_recorder->update_include_old;
-  bool this_update_should_include_old = heap_recorder->last_update_major_gc_since || force_full_update;
-
+  bool this_update_should_include_old = force_full_update;
   long now_ns = monotonic_wall_time_now_ns(DO_NOT_RAISE_ON_FAILURE);
 
   if (!force_full_update) {
@@ -494,7 +491,6 @@ void heap_recorder_update(heap_recorder *heap_recorder, bool force_full_update) 
 
   st_foreach(heap_recorder->object_records, st_object_record_update, (st_data_t) heap_recorder);
 
-  heap_recorder->last_update_major_gc_since = false;
   heap_recorder->last_update_ns = now_ns;
   heap_recorder->stats_lifetime.updates_successful++;
 

--- a/ext/datadog_profiling_native_extension/heap_recorder.c
+++ b/ext/datadog_profiling_native_extension/heap_recorder.c
@@ -706,7 +706,11 @@ static int st_object_record_update(st_data_t key, st_data_t value, st_data_t ext
 
   #endif
 
-  if (recorder->size_enabled && !record->object_data.is_frozen) {
+  if (
+    recorder->size_enabled &&
+    recorder->update_include_old && // We only update sizes when doing a full update
+    !record->object_data.is_frozen
+  ) {
     // if we were asked to update sizes and this object was not already seen as being frozen,
     // update size again.
     record->object_data.size = ruby_obj_memsize_of(ref);
@@ -729,7 +733,6 @@ static int st_object_records_iterate(DDTRACE_UNUSED st_data_t key, st_data_t val
   iteration_context *context = (iteration_context*) extra;
 
   const heap_recorder *recorder = context->heap_recorder;
-
 
   if (record->object_data.gen_age < ITERATION_MIN_AGE) {
     // Skip objects that should not be included in iteration

--- a/ext/datadog_profiling_native_extension/heap_recorder.c
+++ b/ext/datadog_profiling_native_extension/heap_recorder.c
@@ -5,6 +5,8 @@
 #include <errno.h>
 #include "collectors_stack.h"
 #include "libdatadog_helpers.h"
+#include "time_helpers.h"
+#include "collectors_gc_profiling_helper.h"
 
 #if (defined(HAVE_WORKING_RB_GC_FORCE_RECYCLE) && ! defined(NO_SEEN_OBJ_ID_FLAG))
   #define CAN_APPLY_GC_FORCE_RECYCLE_BUG_WORKAROUND
@@ -20,6 +22,12 @@
 // to align with Ruby's GC definition of what constitutes an old object which are only
 // supposed to be reclaimed in major GCs.
 #define OLD_AGE 3
+// Wait at least 2 seconds before asking heap recorder to explicitly update itself. Heap recorder
+// data will only materialize at profile serialization time but updating often helps keep our
+// heap tracking data small since every GC should get rid of a bunch of temporary objects. The
+// more we clean up before profile flush, the less work we'll have to do all-at-once when preparing
+// to flush heap data and holding the GVL which should hopefully help with reducing latency impact.
+#define MIN_TIME_BETWEEN_HEAP_RECORDER_UPDATES_NS SECONDS_AS_NS(2)
 
 // A compact representation of a stacktrace frame for a heap allocation.
 typedef struct {
@@ -148,14 +156,23 @@ struct heap_recorder {
   // mutation of the data so iteration can occur without acquiring a lock.
   // NOTE: Contrary to object_records, this table has no ownership of its data.
   st_table *object_records_snapshot;
+  // Is there a pending update due to a conflict with an ongoing iteration?
+  // If there is, we'll want to re-issue it after we finish the iteration.
+  bool pending_update;
+  // Was that pending update forced to be a full update?
+  bool pending_update_forced_full;
   // The GC gen/epoch/count in which we are updating (or last updated if not currently updating).
   //
-  // This enables us to calculate the age of iterated objects in the above snapshot by
-  // comparing it against an object's alloc_gen.
+  // This enables us to calculate the age of objects considered in the update by comparing it
+  // against an object's alloc_gen.
   size_t update_gen;
   // Whether the current update (or last update if not currently updating) is including old
   // objects or not.
   bool update_include_old;
+  // When did we do the last update of heap recorder?
+  long last_update_ns;
+  // Did we see a major GC since then?
+  bool last_update_major_gc_since;
 
   // Data for a heap recording that was started but not yet ended
   recording active_recording;
@@ -172,6 +189,17 @@ struct heap_recorder {
     size_t objects_skipped;
     size_t objects_frozen;
   } stats_last_update;
+
+  struct stats_lifetime {
+    unsigned long updates_successful;
+    unsigned long updates_skipped_time;
+    unsigned long updates_skipped_gcgen;
+    unsigned long updates_forced;
+
+    double ewma_objects_alive;
+    double ewma_objects_dead;
+    double ewma_objects_skipped;
+  } stats_lifetime;
 };
 
 struct end_heap_allocation_args {
@@ -190,6 +218,7 @@ static int st_object_records_debug(st_data_t key, st_data_t value, st_data_t ext
 static int update_object_record_entry(st_data_t*, st_data_t*, st_data_t, int);
 static void commit_recording(heap_recorder*, heap_record*, recording);
 static VALUE end_heap_allocation_recording(VALUE end_heap_allocation_args);
+static double inline ewma_stat(double previous, double current);
 
 // ==========================
 // Heap Recorder External API
@@ -287,6 +316,9 @@ void heap_recorder_after_fork(heap_recorder *heap_recorder) {
   if (heap_recorder->object_records_snapshot != NULL) {
     heap_recorder_finish_iteration(heap_recorder);
   }
+
+  // Clear lifetime stats since this is essentially a new heap recorder
+  heap_recorder->stats_lifetime = (struct stats_lifetime) {0};
 }
 
 void start_heap_allocation_recording(heap_recorder *heap_recorder, VALUE new_obj, unsigned int weight, ddog_CharSlice *alloc_class) {
@@ -401,40 +433,63 @@ static VALUE end_heap_allocation_recording(VALUE end_heap_allocation_args) {
   return Qnil;
 }
 
-bool heap_recorder_update(heap_recorder *heap_recorder, bool include_old) {
+void heap_recorder_update(heap_recorder *heap_recorder, bool force_full_update) {
   if (heap_recorder == NULL) {
-    return false;
+    return;
   }
 
   if (heap_recorder->object_records_snapshot != NULL) {
-    // If we're currently iterating, fail the update. Although we iterate on a snapshot of object_records,
-    // these records point to other data that has not been snapshotted for efficiency reasons (e.g. heap_records).
-    // Since there's a chance that updating may invalidate some of that non-snapshotted data, lets refrain from
-    // doing updates during iteration. This also enforces the semantic that iteration will operate as a point-in-time
-    // snapshot.
-    return false;
+    // If we're currently iterating, don't do the update now, we'll do it when we finish the iteration.
+    // Although we iterate on a snapshot of object_records, these records point to other data that has not been
+    // snapshotted for efficiency reasons (e.g. heap_records). Since there's a chance that updating may invalidate
+    // some of that non-snapshotted data, lets refrain from doing updates during iteration. This also enforces the
+    // semantic that iteration will operate as a point-in-time snapshot.
+    heap_recorder->pending_update = true;
+    heap_recorder->pending_update_forced_full = force_full_update;
+    return;
   }
 
   size_t current_gc_gen = rb_gc_count();
 
-  if (current_gc_gen == heap_recorder->update_gen && (heap_recorder->update_include_old || !include_old)) {
-    // Are we still in the same GC gen as last update? If so, skip updating (without signalling failure)
-    // since things should not have changed significantly since last time.
+  bool last_update_included_old = heap_recorder->update_include_old;
+  bool this_update_should_include_old = heap_recorder->last_update_major_gc_since || force_full_update;
+
+  if (current_gc_gen == heap_recorder->update_gen && !force_full_update && (last_update_included_old || !this_update_should_include_old)) {
+    // Are we still in the same GC gen as last update? If so, skip updating since things should not have
+    // changed significantly since last time (especially if last time already included old objects or
+    // if this update is not going to look at old objects). But skip signalling success/no-op.
     // NOTE: This is mostly a performance decision. I suppose some objects may be cleaned up in intermediate
     // GC steps and sizes may change. But because we have to iterate through all our tracked
     // object records to do an update, lets wait until all steps for a particular GC generation
     // have finished to do so. We may revisit this once we have a better liveness checking mechanism.
-    return true;
+    heap_recorder->stats_lifetime.updates_skipped_gcgen++;
+    return;
   }
 
-  heap_recorder->update_gen = current_gc_gen;
-  heap_recorder->update_include_old = include_old;
+  long now_ns = monotonic_wall_time_now_ns(DO_NOT_RAISE_ON_FAILURE);
+
+  if (now_ns > 0 && (now_ns - heap_recorder->last_update_ns) < MIN_TIME_BETWEEN_HEAP_RECORDER_UPDATES_NS && !force_full_update) {
+    // We did an update not too long ago. Lets skip this one with a no-op unless we were forced.
+    heap_recorder->stats_lifetime.updates_skipped_time++;
+    return;
+  }
 
   // Reset last update stats, we'll be building them from scratch during the st_foreach call below
-  heap_recorder->stats_last_update = (struct stats_last_update) {};
+  heap_recorder->stats_last_update = (struct stats_last_update) {0};
+
+  heap_recorder->update_gen = current_gc_gen;
+  heap_recorder->update_include_old = this_update_should_include_old;
 
   st_foreach(heap_recorder->object_records, st_object_record_update, (st_data_t) heap_recorder);
-  return true;
+
+  heap_recorder->last_update_major_gc_since = false;
+  heap_recorder->last_update_ns = now_ns;
+  heap_recorder->stats_lifetime.updates_successful++;
+
+  // Lifetime stats updating
+  heap_recorder->stats_lifetime.ewma_objects_alive = ewma_stat(heap_recorder->stats_lifetime.ewma_objects_alive, heap_recorder->stats_last_update.objects_alive);
+  heap_recorder->stats_lifetime.ewma_objects_dead = ewma_stat(heap_recorder->stats_lifetime.ewma_objects_dead, heap_recorder->stats_last_update.objects_dead);
+  heap_recorder->stats_lifetime.ewma_objects_skipped = ewma_stat(heap_recorder->stats_lifetime.ewma_objects_skipped, heap_recorder->stats_last_update.objects_skipped);
 }
 
 void heap_recorder_prepare_iteration(heap_recorder *heap_recorder) {
@@ -465,6 +520,10 @@ void heap_recorder_finish_iteration(heap_recorder *heap_recorder) {
 
   st_free_table(heap_recorder->object_records_snapshot);
   heap_recorder->object_records_snapshot = NULL;
+
+  if (heap_recorder->pending_update) {
+    heap_recorder_update(heap_recorder, heap_recorder->pending_update_forced_full);
+  }
 }
 
 // Internal data we need while performing iteration over live objects.
@@ -510,6 +569,15 @@ VALUE heap_recorder_state_snapshot(heap_recorder *heap_recorder) {
     ID2SYM(rb_intern("last_update_objects_dead")), /* => */ LONG2NUM(heap_recorder->stats_last_update.objects_dead),
     ID2SYM(rb_intern("last_update_objects_skipped")), /* => */ LONG2NUM(heap_recorder->stats_last_update.objects_skipped),
     ID2SYM(rb_intern("last_update_objects_frozen")), /* => */ LONG2NUM(heap_recorder->stats_last_update.objects_frozen),
+
+    // Lifetime stats
+    ID2SYM(rb_intern("lifetime_updates_successful")), /* => */ LONG2NUM(heap_recorder->stats_lifetime.updates_successful),
+    ID2SYM(rb_intern("lifetime_updates_skipped_gcgen")), /* => */ LONG2NUM(heap_recorder->stats_lifetime.updates_skipped_gcgen),
+    ID2SYM(rb_intern("lifetime_updates_skipped_time")), /* => */ LONG2NUM(heap_recorder->stats_lifetime.updates_skipped_time),
+    ID2SYM(rb_intern("lifetime_updates_forced")), /* => */ LONG2NUM(heap_recorder->stats_lifetime.updates_forced),
+    ID2SYM(rb_intern("lifetime_ewma_objects_alive")), /* => */ DBL2NUM(heap_recorder->stats_lifetime.ewma_objects_alive),
+    ID2SYM(rb_intern("lifetime_ewma_objects_dead")), /* => */ DBL2NUM(heap_recorder->stats_lifetime.ewma_objects_dead),
+    ID2SYM(rb_intern("lifetime_ewma_objects_skipped")), /* => */ DBL2NUM(heap_recorder->stats_lifetime.ewma_objects_skipped),
   };
   VALUE hash = rb_hash_new();
   for (long unsigned int i = 0; i < VALUE_COUNT(arguments); i += 2) rb_hash_aset(hash, arguments[i], arguments[i+1]);
@@ -1118,4 +1186,9 @@ st_index_t heap_record_key_hash_st(st_data_t key) {
   } else {
     return ddog_location_slice_hash(*record_key->location_slice, FNV1_32A_INIT);
   }
+}
+
+static double inline ewma_stat(double previous, double current) {
+  double alpha = 0.3;
+  return (1 - alpha) * previous + alpha * current;
 }

--- a/ext/datadog_profiling_native_extension/heap_recorder.c
+++ b/ext/datadog_profiling_native_extension/heap_recorder.c
@@ -438,7 +438,7 @@ void heap_recorder_update_young_objects(heap_recorder *heap_recorder) {
 
 static void heap_recorder_update(heap_recorder *heap_recorder, bool full_update) {
   if (heap_recorder->updating) {
-    if (full_update) rb_raise(rb_eRuntimeError, "full_update should not be triggered during another update");
+    if (full_update) rb_raise(rb_eRuntimeError, "BUG: full_update should not be triggered during another update");
 
     // If we try to update while another update is still running, short-circuit.
     // NOTE: This runs while holding the GVL. But since updates may be triggered from GC activity, there's still
@@ -457,7 +457,6 @@ static void heap_recorder_update(heap_recorder *heap_recorder, bool full_update)
   }
 
   size_t current_gc_gen = rb_gc_count();
-
   long now_ns = monotonic_wall_time_now_ns(DO_NOT_RAISE_ON_FAILURE);
 
   if (!full_update) {

--- a/ext/datadog_profiling_native_extension/heap_recorder.c
+++ b/ext/datadog_profiling_native_extension/heap_recorder.c
@@ -632,7 +632,7 @@ VALUE heap_recorder_testonly_debug(heap_recorder *heap_recorder) {
   VALUE debug_str = rb_str_new2("object records:\n");
   st_foreach(heap_recorder->object_records, st_object_records_debug, (st_data_t) debug_str);
 
-  rb_str_catf(debug_str, "\nstate snapshot:%"PRIsVALUE"\n", heap_recorder_state_snapshot(heap_recorder));
+  rb_str_catf(debug_str, "state snapshot: %"PRIsVALUE"\n------\n", heap_recorder_state_snapshot(heap_recorder));
 
   return debug_str;
 }
@@ -979,12 +979,12 @@ VALUE object_record_inspect(object_record *record) {
     rb_str_catf(inspect, "object=<invalid>");
   } else {
     rb_str_catf(inspect, "value=%p ", (void *) ref);
-    VALUE ruby_inspect = ruby_safe_inspect(ref);
+    /*VALUE ruby_inspect = ruby_safe_inspect(ref);
     if (ruby_inspect != Qnil) {
       rb_str_catf(inspect, "object=%"PRIsVALUE, ruby_inspect);
     } else {
       rb_str_catf(inspect, "object=%s", ruby_value_type_to_string(rb_type(ref)));
-    }
+    }*/
   }
 
   return inspect;

--- a/ext/datadog_profiling_native_extension/heap_recorder.c
+++ b/ext/datadog_profiling_native_extension/heap_recorder.c
@@ -430,6 +430,10 @@ static VALUE end_heap_allocation_recording(VALUE end_heap_allocation_args) {
   return Qnil;
 }
 
+void heap_recorder_update_young_objects(heap_recorder *heap_recorder) {
+  heap_recorder_update(heap_recorder, false);
+}
+
 void heap_recorder_update(heap_recorder *heap_recorder, bool force_full_update) {
   if (heap_recorder == NULL) {
     return;

--- a/ext/datadog_profiling_native_extension/heap_recorder.c
+++ b/ext/datadog_profiling_native_extension/heap_recorder.c
@@ -614,7 +614,7 @@ void heap_recorder_testonly_assert_hash_matches(ddog_prof_Slice_Location locatio
 
 VALUE heap_recorder_testonly_debug(heap_recorder *heap_recorder) {
   if (heap_recorder == NULL) {
-    return rb_str_new2("NULL heap_recorder");
+    rb_raise(rb_eArgError, "heap_recorder is NULL");
   }
 
   VALUE debug_str = rb_str_new2("object records:\n");
@@ -1204,4 +1204,21 @@ st_index_t heap_record_key_hash_st(st_data_t key) {
 static inline double ewma_stat(double previous, double current) {
   double alpha = 0.3;
   return (1 - alpha) * previous + alpha * current;
+}
+
+VALUE heap_recorder_testonly_is_object_recorded(heap_recorder *heap_recorder, VALUE obj_id) {
+  if (heap_recorder == NULL) {
+    rb_raise(rb_eArgError, "heap_recorder is NULL");
+  }
+
+  // Check if object records contains an object with this object_id
+  return st_is_member(heap_recorder->object_records, FIX2LONG(obj_id)) ? Qtrue : Qfalse;
+}
+
+void heap_recorder_testonly_reset_last_update(heap_recorder *heap_recorder) {
+  if (heap_recorder == NULL) {
+    rb_raise(rb_eArgError, "heap_recorder is NULL");
+  }
+
+  heap_recorder->last_update_ns = 0;
 }

--- a/ext/datadog_profiling_native_extension/heap_recorder.c
+++ b/ext/datadog_profiling_native_extension/heap_recorder.c
@@ -631,6 +631,9 @@ VALUE heap_recorder_testonly_debug(heap_recorder *heap_recorder) {
 
   VALUE debug_str = rb_str_new2("object records:\n");
   st_foreach(heap_recorder->object_records, st_object_records_debug, (st_data_t) debug_str);
+
+  rb_str_catf(debug_str, "\nstate snapshot:%"PRIsVALUE"\n", heap_recorder_state_snapshot(heap_recorder));
+
   return debug_str;
 }
 

--- a/ext/datadog_profiling_native_extension/heap_recorder.h
+++ b/ext/datadog_profiling_native_extension/heap_recorder.h
@@ -118,20 +118,13 @@ void start_heap_allocation_recording(heap_recorder *heap_recorder, VALUE new_obj
 __attribute__((warn_unused_result))
 int end_heap_allocation_recording_with_rb_protect(heap_recorder *heap_recorder, ddog_prof_Slice_Location locations);
 
-// Update the heap recorder, checking young objects. The idea here is to align with GC: most young objects never
+// Update the heap recorder, **checking young objects only**. The idea here is to align with GC: most young objects never
 // survive enough GC generations, and thus periodically running this method reduces memory usage (we get rid of
 // these objects quicker) and hopefully reduces tail latency (because there's less objects at serialization time to check).
 void heap_recorder_update_young_objects(heap_recorder *heap_recorder);
 
-// Update the heap recorder to reflect the latest state of the VM.
-//
-// @param include_old
-//   Whether we should also update old objects in this pass or just new ones (age < 3 GCs).
-// @param force_full_update
-//   Whether we should force a full heap update even if we witnessed no major gcs since last time.
-void heap_recorder_update(heap_recorder *heap_recorder, bool force_full_update);
-
-// Prepare internal structures for efficient iteration.
+// Update the heap recorder to reflect the latest state of the VM and prepare internal structures
+// for efficient iteration.
 //
 // WARN: This must be called strictly before iteration. Failing to do so will result in exceptions.
 void heap_recorder_prepare_iteration(heap_recorder *heap_recorder);

--- a/ext/datadog_profiling_native_extension/heap_recorder.h
+++ b/ext/datadog_profiling_native_extension/heap_recorder.h
@@ -171,3 +171,9 @@ void heap_recorder_testonly_assert_hash_matches(ddog_prof_Slice_Location locatio
 // Returns a Ruby string with a representation of internal data helpful to
 // troubleshoot issues such as unexpected test failures.
 VALUE heap_recorder_testonly_debug(heap_recorder *heap_recorder);
+
+// Check if a given object_id is being tracked or not
+VALUE heap_recorder_testonly_is_object_recorded(heap_recorder *heap_recorder, VALUE obj_id);
+
+// Used to ensure that a GC actually triggers an update of the objects
+void heap_recorder_testonly_reset_last_update(heap_recorder *heap_recorder);

--- a/ext/datadog_profiling_native_extension/heap_recorder.h
+++ b/ext/datadog_profiling_native_extension/heap_recorder.h
@@ -118,6 +118,11 @@ void start_heap_allocation_recording(heap_recorder *heap_recorder, VALUE new_obj
 __attribute__((warn_unused_result))
 int end_heap_allocation_recording_with_rb_protect(heap_recorder *heap_recorder, ddog_prof_Slice_Location locations);
 
+// Update the heap recorder, checking young objects. The idea here is to align with GC: most young objects never
+// survive enough GC generations, and thus periodically running this method reduces memory usage (we get rid of
+// these objects quicker) and hopefully reduces tail latency (because there's less objects at serialization time to check).
+void heap_recorder_update_young_objects(heap_recorder *heap_recorder);
+
 // Update the heap recorder to reflect the latest state of the VM.
 //
 // @param include_old

--- a/ext/datadog_profiling_native_extension/heap_recorder.h
+++ b/ext/datadog_profiling_native_extension/heap_recorder.h
@@ -118,15 +118,14 @@ void start_heap_allocation_recording(heap_recorder *heap_recorder, VALUE new_obj
 __attribute__((warn_unused_result))
 int end_heap_allocation_recording_with_rb_protect(heap_recorder *heap_recorder, ddog_prof_Slice_Location locations);
 
-// Update the heap recorder to reflect the latest state of the VM without preparing internal
-// structures for efficient iteration.
+// Update the heap recorder to reflect the latest state of the VM as it pertains to object liveness.
 //
 // @param include_old
 //   Whether we should also update old objects in this pass or just new ones (age < 3 GCs).
-void heap_recorder_update(heap_recorder *heap_recorder, bool include_old);
+// @return true if update was successful or skipped, false if it failed and should be retried.
+bool heap_recorder_update(heap_recorder *heap_recorder, bool include_old);
 
-// Update the heap recorder to reflect the latest state of the VM and prepare internal structures
-// for efficient iteration.
+// Prepare internal structures for efficient iteration.
 //
 // WARN: This must be called strictly before iteration. Failing to do so will result in exceptions.
 void heap_recorder_prepare_iteration(heap_recorder *heap_recorder);

--- a/ext/datadog_profiling_native_extension/heap_recorder.h
+++ b/ext/datadog_profiling_native_extension/heap_recorder.h
@@ -118,6 +118,13 @@ void start_heap_allocation_recording(heap_recorder *heap_recorder, VALUE new_obj
 __attribute__((warn_unused_result))
 int end_heap_allocation_recording_with_rb_protect(heap_recorder *heap_recorder, ddog_prof_Slice_Location locations);
 
+// Update the heap recorder to reflect the latest state of the VM without preparing internal
+// structures for efficient iteration.
+//
+// @param include_old
+//   Whether we should also update old objects in this pass or just new ones (age < 3 GCs).
+void heap_recorder_update(heap_recorder *heap_recorder, bool include_old);
+
 // Update the heap recorder to reflect the latest state of the VM and prepare internal structures
 // for efficient iteration.
 //

--- a/ext/datadog_profiling_native_extension/heap_recorder.h
+++ b/ext/datadog_profiling_native_extension/heap_recorder.h
@@ -118,12 +118,13 @@ void start_heap_allocation_recording(heap_recorder *heap_recorder, VALUE new_obj
 __attribute__((warn_unused_result))
 int end_heap_allocation_recording_with_rb_protect(heap_recorder *heap_recorder, ddog_prof_Slice_Location locations);
 
-// Update the heap recorder to reflect the latest state of the VM as it pertains to object liveness.
+// Update the heap recorder to reflect the latest state of the VM.
 //
 // @param include_old
 //   Whether we should also update old objects in this pass or just new ones (age < 3 GCs).
-// @return true if update was successful or skipped, false if it failed and should be retried.
-bool heap_recorder_update(heap_recorder *heap_recorder, bool include_old);
+// @param force_full_update
+//   Whether we should force a full heap update even if we witnessed no major gcs since last time.
+void heap_recorder_update(heap_recorder *heap_recorder, bool force_full_update);
 
 // Prepare internal structures for efficient iteration.
 //

--- a/ext/datadog_profiling_native_extension/stack_recorder.c
+++ b/ext/datadog_profiling_native_extension/stack_recorder.c
@@ -8,7 +8,6 @@
 #include "ruby_helpers.h"
 #include "time_helpers.h"
 #include "heap_recorder.h"
-#include "collectors_gc_profiling_helper.h"
 
 // Used to wrap a ddog_prof_Profile in a Ruby object and expose Ruby-level serialization APIs
 // This file implements the native bits of the Datadog::Profiling::StackRecorder class

--- a/ext/datadog_profiling_native_extension/stack_recorder.c
+++ b/ext/datadog_profiling_native_extension/stack_recorder.c
@@ -327,7 +327,7 @@ static VALUE _native_new(VALUE klass) {
   // Note: Any exceptions raised from this note until the TypedData_Wrap_Struct call will lead to the state memory
   // being leaked.
 
-  state->heap_clean_after_gc_enabled = true;
+  state->heap_clean_after_gc_enabled = false;
 
   ddog_prof_Slice_ValueType sample_types = {.ptr = all_value_types, .len = ALL_VALUE_TYPES_COUNT};
 

--- a/ext/datadog_profiling_native_extension/stack_recorder.c
+++ b/ext/datadog_profiling_native_extension/stack_recorder.c
@@ -272,6 +272,7 @@ static VALUE _native_stats(DDTRACE_UNUSED VALUE self, VALUE instance);
 static VALUE build_profile_stats(profile_slot *slot, long serialization_time_ns, long heap_iteration_prep_time_ns, long heap_profile_build_time_ns);
 static VALUE _native_is_object_recorded(DDTRACE_UNUSED VALUE _self, VALUE recorder_instance, VALUE object_id);
 static VALUE _native_heap_recorder_reset_last_update(DDTRACE_UNUSED VALUE _self, VALUE recorder_instance);
+static VALUE _native_recorder_after_gc_step(DDTRACE_UNUSED VALUE _self, VALUE recorder_instance);
 
 void stack_recorder_init(VALUE profiling_module) {
   VALUE stack_recorder_class = rb_define_class_under(profiling_module, "StackRecorder", rb_cObject);
@@ -310,6 +311,7 @@ void stack_recorder_init(VALUE profiling_module) {
       _native_has_seen_id_flag, 1);
   rb_define_singleton_method(testing_module, "_native_is_object_recorded?", _native_is_object_recorded, 2);
   rb_define_singleton_method(testing_module, "_native_heap_recorder_reset_last_update", _native_heap_recorder_reset_last_update, 1);
+  rb_define_singleton_method(testing_module, "_native_recorder_after_gc_step", _native_recorder_after_gc_step, 1);
 
   ok_symbol = ID2SYM(rb_intern_const("ok"));
   error_symbol = ID2SYM(rb_intern_const("error"));
@@ -1083,5 +1085,10 @@ static VALUE _native_heap_recorder_reset_last_update(DDTRACE_UNUSED VALUE _self,
 
   heap_recorder_testonly_reset_last_update(state->heap_recorder);
 
+  return Qtrue;
+}
+
+static VALUE _native_recorder_after_gc_step(DDTRACE_UNUSED VALUE _self, VALUE recorder_instance) {
+  recorder_after_gc_step(recorder_instance);
   return Qtrue;
 }

--- a/ext/datadog_profiling_native_extension/stack_recorder.c
+++ b/ext/datadog_profiling_native_extension/stack_recorder.c
@@ -526,7 +526,6 @@ static VALUE _native_serialize(DDTRACE_UNUSED VALUE _self, VALUE recorder_instan
   long heap_iteration_prep_start_time_ns = monotonic_wall_time_now_ns(DO_NOT_RAISE_ON_FAILURE);
   // Prepare the iteration on heap recorder we'll be doing outside the GVL. The preparation needs to
   // happen while holding on to the GVL.
-  heap_recorder_update(state->heap_recorder, true);
   heap_recorder_prepare_iteration(state->heap_recorder);
   long heap_iteration_prep_time_ns = monotonic_wall_time_now_ns(DO_NOT_RAISE_ON_FAILURE) - heap_iteration_prep_start_time_ns;
 
@@ -975,7 +974,6 @@ static VALUE _native_start_fake_slow_heap_serialization(DDTRACE_UNUSED VALUE _se
   struct stack_recorder_state *state;
   TypedData_Get_Struct(recorder_instance, struct stack_recorder_state, &stack_recorder_typed_data, state);
 
-  heap_recorder_update(state->heap_recorder, true);
   heap_recorder_prepare_iteration(state->heap_recorder);
 
   return Qnil;

--- a/ext/datadog_profiling_native_extension/stack_recorder.c
+++ b/ext/datadog_profiling_native_extension/stack_recorder.c
@@ -277,6 +277,7 @@ static VALUE _native_check_heap_hashes(DDTRACE_UNUSED VALUE _self, VALUE locatio
 static VALUE _native_start_fake_slow_heap_serialization(DDTRACE_UNUSED VALUE _self, VALUE recorder_instance);
 static VALUE _native_end_fake_slow_heap_serialization(DDTRACE_UNUSED VALUE _self, VALUE recorder_instance);
 static VALUE _native_debug_heap_recorder(DDTRACE_UNUSED VALUE _self, VALUE recorder_instance);
+static VALUE _native_force_update_heap_recorder(DDTRACE_UNUSED VALUE _self, VALUE recorder_instance);
 static VALUE _native_gc_force_recycle(DDTRACE_UNUSED VALUE _self, VALUE obj);
 static VALUE _native_has_seen_id_flag(DDTRACE_UNUSED VALUE _self, VALUE obj);
 static VALUE _native_stats(DDTRACE_UNUSED VALUE self, VALUE instance);
@@ -314,6 +315,8 @@ void stack_recorder_init(VALUE profiling_module) {
       _native_end_fake_slow_heap_serialization, 1);
   rb_define_singleton_method(testing_module, "_native_debug_heap_recorder",
       _native_debug_heap_recorder, 1);
+  rb_define_singleton_method(testing_module, "_native_force_update_heap_recorder",
+      _native_force_update_heap_recorder, 1);
   rb_define_singleton_method(testing_module, "_native_gc_force_recycle",
       _native_gc_force_recycle, 1);
   rb_define_singleton_method(testing_module, "_native_has_seen_id_flag",
@@ -1020,6 +1023,17 @@ static VALUE _native_debug_heap_recorder(DDTRACE_UNUSED VALUE _self, VALUE recor
   TypedData_Get_Struct(recorder_instance, struct stack_recorder_state, &stack_recorder_typed_data, state);
 
   return heap_recorder_testonly_debug(state->heap_recorder);
+}
+
+// This method exists only to enable testing Datadog::Profiling::StackRecorder behavior using RSpec.
+// It SHOULD NOT be used for other purposes.
+static VALUE _native_force_update_heap_recorder(DDTRACE_UNUSED VALUE _self, VALUE recorder_instance) {
+  struct stack_recorder_state *state;
+  TypedData_Get_Struct(recorder_instance, struct stack_recorder_state, &stack_recorder_typed_data, state);
+
+  heap_recorder_update(state->heap_recorder, true);
+
+  return Qnil;
 }
 
 #pragma GCC diagnostic push

--- a/ext/datadog_profiling_native_extension/stack_recorder.h
+++ b/ext/datadog_profiling_native_extension/stack_recorder.h
@@ -29,4 +29,3 @@ void record_endpoint(VALUE recorder_instance, uint64_t local_root_span_id, ddog_
 void track_object(VALUE recorder_instance, VALUE new_object, unsigned int sample_weight, ddog_CharSlice *alloc_class);
 void recorder_after_gc_step(VALUE recorder_instance);
 VALUE enforce_recorder_instance(VALUE object);
-

--- a/ext/datadog_profiling_native_extension/stack_recorder.h
+++ b/ext/datadog_profiling_native_extension/stack_recorder.h
@@ -27,4 +27,6 @@ typedef struct sample_labels {
 void record_sample(VALUE recorder_instance, ddog_prof_Slice_Location locations, sample_values values, sample_labels labels);
 void record_endpoint(VALUE recorder_instance, uint64_t local_root_span_id, ddog_CharSlice endpoint);
 void track_object(VALUE recorder_instance, VALUE new_object, unsigned int sample_weight, ddog_CharSlice *alloc_class);
+void recorder_after_gc_step(VALUE recorder_instance);
 VALUE enforce_recorder_instance(VALUE object);
+

--- a/lib/datadog/core/configuration/settings.rb
+++ b/lib/datadog/core/configuration/settings.rb
@@ -514,6 +514,18 @@ module Datadog
                 end
               end
             end
+
+            # Controls if the heap profiler should attempt to clean young objects after GC, rather than just at
+            # serialization time. This lowers memory usage and high percentile latency.
+            #
+            # Only takes effect when used together with `gc_enabled: true` and `experimental_heap_enabled: true`.
+            #
+            # @default false
+            option :heap_clean_after_gc_enabled do |o|
+              o.type :bool
+              o.env 'DD_PROFILING_HEAP_CLEAN_AFTER_GC_ENABLED'
+              o.default false
+            end
           end
 
           # @public_api

--- a/lib/datadog/profiling/component.rb
+++ b/lib/datadog/profiling/component.rb
@@ -53,6 +53,7 @@ module Datadog
           heap_size_enabled: heap_size_profiling_enabled,
           heap_sample_every: heap_sample_every,
           timeline_enabled: timeline_enabled,
+          heap_clean_after_gc_enabled: settings.profiling.advanced.heap_clean_after_gc_enabled,
         )
         thread_context_collector = build_thread_context_collector(settings, recorder, optional_tracer, timeline_enabled)
         worker = Datadog::Profiling::Collectors::CpuAndWallTimeWorker.new(

--- a/lib/datadog/profiling/stack_recorder.rb
+++ b/lib/datadog/profiling/stack_recorder.rb
@@ -9,8 +9,12 @@ module Datadog
     # Methods prefixed with _native_ are implemented in `stack_recorder.c`
     class StackRecorder
       def initialize(
-        cpu_time_enabled:, alloc_samples_enabled:, heap_samples_enabled:, heap_size_enabled:,
-        heap_sample_every:, timeline_enabled:
+        cpu_time_enabled:,
+        alloc_samples_enabled:,
+        heap_samples_enabled:,
+        heap_size_enabled:,
+        heap_sample_every:,
+        timeline_enabled:
       )
         # This mutex works in addition to the fancy C-level mutexes we have in the native side (see the docs there).
         # It prevents multiple Ruby threads calling serialize at the same time -- something like
@@ -21,13 +25,13 @@ module Datadog
         @no_concurrent_synchronize_mutex = Mutex.new
 
         self.class._native_initialize(
-          self,
-          cpu_time_enabled,
-          alloc_samples_enabled,
-          heap_samples_enabled,
-          heap_size_enabled,
-          heap_sample_every,
-          timeline_enabled,
+          self_instance: self,
+          cpu_time_enabled: cpu_time_enabled,
+          alloc_samples_enabled: alloc_samples_enabled,
+          heap_samples_enabled: heap_samples_enabled,
+          heap_size_enabled: heap_size_enabled,
+          heap_sample_every: heap_sample_every,
+          timeline_enabled: timeline_enabled,
         )
       end
 

--- a/lib/datadog/profiling/stack_recorder.rb
+++ b/lib/datadog/profiling/stack_recorder.rb
@@ -14,7 +14,8 @@ module Datadog
         heap_samples_enabled:,
         heap_size_enabled:,
         heap_sample_every:,
-        timeline_enabled:
+        timeline_enabled:,
+        heap_clean_after_gc_enabled:
       )
         # This mutex works in addition to the fancy C-level mutexes we have in the native side (see the docs there).
         # It prevents multiple Ruby threads calling serialize at the same time -- something like
@@ -32,6 +33,7 @@ module Datadog
           heap_size_enabled: heap_size_enabled,
           heap_sample_every: heap_sample_every,
           timeline_enabled: timeline_enabled,
+          heap_clean_after_gc_enabled: heap_clean_after_gc_enabled,
         )
       end
 
@@ -42,6 +44,7 @@ module Datadog
         heap_size_enabled: false,
         heap_sample_every: 1,
         timeline_enabled: false,
+        heap_clean_after_gc_enabled: true,
         **options
       )
         new(
@@ -51,6 +54,7 @@ module Datadog
           heap_size_enabled: heap_size_enabled,
           heap_sample_every: heap_sample_every,
           timeline_enabled: timeline_enabled,
+          heap_clean_after_gc_enabled: heap_clean_after_gc_enabled,
           **options,
         )
       end

--- a/lib/datadog/profiling/stack_recorder.rb
+++ b/lib/datadog/profiling/stack_recorder.rb
@@ -31,6 +31,26 @@ module Datadog
         )
       end
 
+      def self.for_testing(
+        cpu_time_enabled: true,
+        alloc_samples_enabled: false,
+        heap_samples_enabled: false,
+        heap_size_enabled: false,
+        heap_sample_every: 1,
+        timeline_enabled: false,
+        **options
+      )
+        new(
+          cpu_time_enabled: cpu_time_enabled,
+          alloc_samples_enabled: alloc_samples_enabled,
+          heap_samples_enabled: heap_samples_enabled,
+          heap_size_enabled: heap_size_enabled,
+          heap_sample_every: heap_sample_every,
+          timeline_enabled: timeline_enabled,
+          **options,
+        )
+      end
+
       def serialize
         status, result = @no_concurrent_synchronize_mutex.synchronize { self.class._native_serialize(self) }
 

--- a/sig/datadog/profiling/stack_recorder.rbs
+++ b/sig/datadog/profiling/stack_recorder.rbs
@@ -13,13 +13,13 @@ module Datadog
       ) -> void
 
       def self._native_initialize: (
-        Datadog::Profiling::StackRecorder recorder_instance,
-        bool cpu_time_enabled,
-        bool alloc_samples_enabled,
-        bool heap_samples_enabled,
-        bool heap_size_enabled,
-        Integer heap_sample_every,
-        bool timeline_enabled,
+        self_instance: Datadog::Profiling::StackRecorder,
+        cpu_time_enabled: bool,
+        alloc_samples_enabled: bool,
+        heap_samples_enabled: bool,
+        heap_size_enabled: bool,
+        heap_sample_every: Integer,
+        timeline_enabled: bool,
       ) -> true
 
       type serialized_profile_data = [

--- a/sig/datadog/profiling/stack_recorder.rbs
+++ b/sig/datadog/profiling/stack_recorder.rbs
@@ -10,6 +10,7 @@ module Datadog
         heap_size_enabled: bool,
         heap_sample_every: Integer,
         timeline_enabled: bool,
+        heap_clean_after_gc_enabled: bool,
       ) -> void
 
       def self._native_initialize: (
@@ -20,6 +21,7 @@ module Datadog
         heap_size_enabled: bool,
         heap_sample_every: Integer,
         timeline_enabled: bool,
+        heap_clean_after_gc_enabled: bool,
       ) -> true
 
       type serialized_profile_data = [

--- a/spec/datadog/core/configuration/settings_spec.rb
+++ b/spec/datadog/core/configuration/settings_spec.rb
@@ -919,6 +919,41 @@ RSpec.describe Datadog::Core::Configuration::Settings do
         end
       end
 
+      describe '#heap_clean_after_gc_enabled' do
+        subject(:heap_clean_after_gc_enabled) { settings.profiling.advanced.heap_clean_after_gc_enabled }
+
+        context 'when DD_PROFILING_HEAP_CLEAN_AFTER_GC_ENABLED' do
+          around do |example|
+            ClimateControl.modify('DD_PROFILING_HEAP_CLEAN_AFTER_GC_ENABLED' => environment) do
+              example.run
+            end
+          end
+
+          context 'is not defined' do
+            let(:environment) { nil }
+
+            it { is_expected.to be false }
+          end
+
+          [true, false].each do |value|
+            context "is defined as #{value}" do
+              let(:environment) { value.to_s }
+
+              it { is_expected.to be value }
+            end
+          end
+        end
+      end
+
+      describe '#heap_clean_after_gc_enabled=' do
+        it 'updates the #heap_clean_after_gc_enabled setting' do
+          expect { settings.profiling.advanced.heap_clean_after_gc_enabled = true }
+            .to change { settings.profiling.advanced.heap_clean_after_gc_enabled }
+            .from(false)
+            .to(true)
+        end
+      end
+
       describe '#waiting_for_gvl_threshold_ns' do
         subject(:waiting_for_gvl_threshold_ns) { settings.profiling.advanced.waiting_for_gvl_threshold_ns }
 

--- a/spec/datadog/profiling/collectors/cpu_and_wall_time_worker_spec.rb
+++ b/spec/datadog/profiling/collectors/cpu_and_wall_time_worker_spec.rb
@@ -10,7 +10,11 @@ RSpec.describe Datadog::Profiling::Collectors::CpuAndWallTimeWorker do
   let(:allocation_profiling_enabled) { false }
   let(:heap_profiling_enabled) { false }
   let(:recorder) do
-    build_stack_recorder(heap_samples_enabled: heap_profiling_enabled, heap_size_enabled: heap_profiling_enabled)
+    Datadog::Profiling::StackRecorder.for_testing(
+      alloc_samples_enabled: true,
+      heap_samples_enabled: heap_profiling_enabled,
+      heap_size_enabled: heap_profiling_enabled,
+    )
   end
   let(:no_signals_workaround_enabled) { false }
   let(:timeline_enabled) { false }

--- a/spec/datadog/profiling/collectors/cpu_and_wall_time_worker_spec.rb
+++ b/spec/datadog/profiling/collectors/cpu_and_wall_time_worker_spec.rb
@@ -864,7 +864,7 @@ RSpec.describe Datadog::Profiling::Collectors::CpuAndWallTimeWorker do
         # it's very hard to understand what may be happening.
         if example.exception
           puts("Heap recorder debugging info:")
-          puts(described_class::Testing._native_debug_heap_recorder(recorder))
+          puts(Datadog::Profiling::StackRecorder::Testing._native_debug_heap_recorder(recorder))
         end
       end
 

--- a/spec/datadog/profiling/collectors/cpu_and_wall_time_worker_spec.rb
+++ b/spec/datadog/profiling/collectors/cpu_and_wall_time_worker_spec.rb
@@ -884,13 +884,6 @@ RSpec.describe Datadog::Profiling::Collectors::CpuAndWallTimeWorker do
 
         cpu_and_wall_time_worker.stop
 
-        # Heap recorder updates on its own in accordance with GC activity. However, it may also
-        # decide to not necessarily do so after every GC or to rate limit itself over time. For
-        # us to be able to deterministically reason about the test expectations, let's ensure the
-        # heap recorder's state fully reflects everything that happened up until we stopped the
-        # cpu_and_wall_time_worker
-        Datadog::Profiling::StackRecorder::Testing._native_force_update_heap_recorder(recorder)
-
         test_struct_heap_sample = lambda { |sample|
           first_frame = sample.locations.first
           first_frame.lineno == allocation_line &&

--- a/spec/datadog/profiling/collectors/cpu_and_wall_time_worker_spec.rb
+++ b/spec/datadog/profiling/collectors/cpu_and_wall_time_worker_spec.rb
@@ -397,7 +397,7 @@ RSpec.describe Datadog::Profiling::Collectors::CpuAndWallTimeWorker do
         trigger_sample_attempts = stats.fetch(:trigger_sample_attempts)
         signal_handler_enqueued_sample = stats.fetch(:signal_handler_enqueued_sample)
 
-        expect(signal_handler_enqueued_sample.to_f / trigger_sample_attempts).to (be >= 0.6), \
+        expect(signal_handler_enqueued_sample.to_f / trigger_sample_attempts).to (be >= 0.6),
           "Expected at least 60% of signals to be delivered to correct thread (#{stats})"
 
         # Sanity checking
@@ -580,7 +580,7 @@ RSpec.describe Datadog::Profiling::Collectors::CpuAndWallTimeWorker do
         trigger_sample_attempts = stats.fetch(:trigger_sample_attempts)
         simulated_signal_delivery = stats.fetch(:simulated_signal_delivery)
 
-        expect(simulated_signal_delivery.to_f / trigger_sample_attempts).to (be >= 0.8), \
+        expect(simulated_signal_delivery.to_f / trigger_sample_attempts).to (be >= 0.8),
           "Expected at least 80% of signals to be simulated, stats: #{stats}, debug_failures: #{debug_failures}"
 
         # Sanity checking
@@ -611,7 +611,7 @@ RSpec.describe Datadog::Profiling::Collectors::CpuAndWallTimeWorker do
           # To avoid the flakiness, I've added a dummy margin here but... yeah in practice this can happen as many times
           # as we try to sample.
           margin = 1
-          expect(trigger_sample_attempts).to (be >= (sample_count - margin)), \
+          expect(trigger_sample_attempts).to (be >= (sample_count - margin)),
             "sample_count: #{sample_count}, stats: #{stats}, debug_failures: #{debug_failures}"
         end
       end
@@ -857,6 +857,15 @@ RSpec.describe Datadog::Profiling::Collectors::CpuAndWallTimeWorker do
         skip "Heap profiling is only supported on Ruby >= 2.7" if RUBY_VERSION < "2.7"
         allow(Datadog.logger).to receive(:warn)
         expect(Datadog.logger).to receive(:warn).with(/dynamic sampling rate disabled/)
+      end
+
+      after do |example|
+        # This is here to facilitate troubleshooting when this test fails. Otherwise
+        # it's very hard to understand what may be happening.
+        if example.exception
+          puts("Heap recorder debugging info:")
+          puts(described_class::Testing._native_debug_heap_recorder(recorder))
+        end
       end
 
       it "records live heap objects" do

--- a/spec/datadog/profiling/collectors/cpu_and_wall_time_worker_spec.rb
+++ b/spec/datadog/profiling/collectors/cpu_and_wall_time_worker_spec.rb
@@ -886,8 +886,8 @@ RSpec.describe Datadog::Profiling::Collectors::CpuAndWallTimeWorker do
 
         # Heap recorder updates on its own in accordance with GC activity. However, it may also
         # decide to not necessarily do so after every GC or to rate limit itself over time. For
-        # us to be able to deterministically reason about the test expectations, lets ensure
-        # heap recorder state fully reflects everything that happened up until we stopped the
+        # us to be able to deterministically reason about the test expectations, let's ensure the
+        # heap recorder's state fully reflects everything that happened up until we stopped the
         # cpu_and_wall_time_worker
         Datadog::Profiling::StackRecorder::Testing._native_force_update_heap_recorder(recorder)
 

--- a/spec/datadog/profiling/collectors/cpu_and_wall_time_worker_spec.rb
+++ b/spec/datadog/profiling/collectors/cpu_and_wall_time_worker_spec.rb
@@ -884,6 +884,13 @@ RSpec.describe Datadog::Profiling::Collectors::CpuAndWallTimeWorker do
 
         cpu_and_wall_time_worker.stop
 
+        # Heap recorder updates on its own in accordance with GC activity. However, it may also
+        # decide to not necessarily do so after every GC or to rate limit itself over time. For
+        # us to be able to deterministically reason about the test expectations, lets ensure
+        # heap recorder state fully reflects everything that happened up until we stopped the
+        # cpu_and_wall_time_worker
+        Datadog::Profiling::StackRecorder::Testing._native_force_update_heap_recorder(recorder)
+
         test_struct_heap_sample = lambda { |sample|
           first_frame = sample.locations.first
           first_frame.lineno == allocation_line &&

--- a/spec/datadog/profiling/collectors/stack_spec.rb
+++ b/spec/datadog/profiling/collectors/stack_spec.rb
@@ -685,7 +685,7 @@ RSpec.describe Datadog::Profiling::Collectors::Stack do
   context "when trying to sample something which is not a thread" do
     it "raises a TypeError" do
       expect do
-        sample(:not_a_thread, build_stack_recorder, metric_values, labels)
+        sample(:not_a_thread, Datadog::Profiling::StackRecorder.for_testing, metric_values, labels)
       end.to raise_error(TypeError)
     end
   end
@@ -693,7 +693,7 @@ RSpec.describe Datadog::Profiling::Collectors::Stack do
   context "when max_frames is too small" do
     it "raises an ArgumentError" do
       expect do
-        sample(Thread.current, build_stack_recorder, metric_values, labels, max_frames: 4)
+        sample(Thread.current, Datadog::Profiling::StackRecorder.for_testing, metric_values, labels, max_frames: 4)
       end.to raise_error(ArgumentError)
     end
   end
@@ -701,7 +701,7 @@ RSpec.describe Datadog::Profiling::Collectors::Stack do
   context "when max_frames is too large" do
     it "raises an ArgumentError" do
       expect do
-        sample(Thread.current, build_stack_recorder, metric_values, labels, max_frames: 10_001)
+        sample(Thread.current, Datadog::Profiling::StackRecorder.for_testing, metric_values, labels, max_frames: 10_001)
       end.to raise_error(ArgumentError)
     end
   end
@@ -712,7 +712,7 @@ RSpec.describe Datadog::Profiling::Collectors::Stack do
     end
   end
 
-  def sample_and_decode(thread, data = :locations, recorder: build_stack_recorder, **options)
+  def sample_and_decode(thread, data = :locations, recorder: Datadog::Profiling::StackRecorder.for_testing, **options)
     sample(thread, recorder, metric_values, labels, **options)
 
     samples = samples_from_pprof(recorder.serialize!)

--- a/spec/datadog/profiling/collectors/thread_context_spec.rb
+++ b/spec/datadog/profiling/collectors/thread_context_spec.rb
@@ -9,7 +9,9 @@ RSpec.describe Datadog::Profiling::Collectors::ThreadContext do
     expect(Thread.list).to include(Thread.main, t1, t2, t3)
   end
 
-  let(:recorder) { build_stack_recorder(timeline_enabled: timeline_enabled) }
+  let(:recorder) do
+    Datadog::Profiling::StackRecorder.for_testing(alloc_samples_enabled: true, timeline_enabled: timeline_enabled)
+  end
   let(:ready_queue) { Queue.new }
   let(:t1) do
     Thread.new(ready_queue) do |ready_queue|

--- a/spec/datadog/profiling/component_spec.rb
+++ b/spec/datadog/profiling/component_spec.rb
@@ -421,6 +421,28 @@ RSpec.describe Datadog::Profiling::Component do
           end
         end
 
+        context "when heap_clean_after_gc_enabled is enabled" do
+          before { settings.profiling.advanced.heap_clean_after_gc_enabled = true }
+
+          it "sets up the StackRecorder with heap_clean_after_gc_enabled: true" do
+            expect(Datadog::Profiling::StackRecorder)
+              .to receive(:new).with(hash_including(heap_clean_after_gc_enabled: true)).and_call_original
+
+            build_profiler_component
+          end
+        end
+
+        context "when heap_clean_after_gc_enabled is disabled" do
+          before { settings.profiling.advanced.heap_clean_after_gc_enabled = false }
+
+          it "sets up the StackRecorder with heap_clean_after_gc_enabled: false" do
+            expect(Datadog::Profiling::StackRecorder)
+              .to receive(:new).with(hash_including(heap_clean_after_gc_enabled: false)).and_call_original
+
+            build_profiler_component
+          end
+        end
+
         it "sets up the Profiler with the CpuAndWallTimeWorker collector" do
           expect(Datadog::Profiling::Profiler).to receive(:new).with(
             worker: instance_of(Datadog::Profiling::Collectors::CpuAndWallTimeWorker),

--- a/spec/datadog/profiling/spec_helper.rb
+++ b/spec/datadog/profiling/spec_helper.rb
@@ -96,22 +96,6 @@ module ProfileHelpers
     samples_for_thread(samples, thread, expected_size: 1).first
   end
 
-  # We disable heap_sample collection by default in tests since it requires some extra mocking/
-  # setup for it to properly work.
-  def build_stack_recorder(
-    heap_samples_enabled: false, heap_size_enabled: false, heap_sample_every: 1,
-    timeline_enabled: false
-  )
-    Datadog::Profiling::StackRecorder.new(
-      cpu_time_enabled: true,
-      alloc_samples_enabled: true,
-      heap_samples_enabled: heap_samples_enabled,
-      heap_size_enabled: heap_size_enabled,
-      heap_sample_every: heap_sample_every,
-      timeline_enabled: timeline_enabled,
-    )
-  end
-
   def self.maybe_fix_label_range(key, value)
     if [:"local root span id", :"span id"].include?(key) && value < 0
       # pprof labels are defined to be decoded as signed values BUT the backend explicitly interprets these as unsigned


### PR DESCRIPTION
**Change log entry**

Add setting to lower heap profiling memory use/latency by cleaning up young objects after Ruby GC

**What does this PR do?**

This PR adds a new mechanism to lower heap profiling overhead (memory and latency): the ability to clean young objects being tracked by the heap profiler after a Ruby GC cycle runs, rather than waiting for serialization time.

This mechanism is currently off by default and controlled by the setting `c.profiling.advanced.heap_clean_after_gc_enabled` / `DD_PROFILING_HEAP_CLEAN_AFTER_GC_ENABLED`

We plan to run a bit more validation before enabling it by default.

**Motivation:**

By doing these cleanups, we lower memory usage (we don't need to wait until until next serialization to notice an object was already collected), and latency, because there's less work to be done at serialization time.

**Additional Notes:**

This PR started from https://github.com/DataDog/dd-trace-rb/pull/3906; the main change from that earlier PR is that the heap recorder clean after GC behavior has been changed to be a best-effort mechanism (e.g. it's optional and not required for correctness).

**How to test the change?**

This change includes test coverage. I've also added a new benchmarking configuration to evaluate this new setting using our usual harness.