### PR TITLE
Clarify change log section instructions for contributors.

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -5,14 +5,17 @@ for guidance on how to set up your development environment,
 run the test suite, write new integrations, and more.
 -->
 
-**Change log entry**
-<!-- If this is a customer-visible change, a brief summary to be placed into the change log. -->
-
 **What does this PR do?**
 <!-- A brief description of the change being made with this pull request. -->
 
 **Motivation:**
 <!-- What inspired you to submit this pull request? -->
+
+**Change log entry**
+<!-- If this is a customer-visible change, a brief summary to be placed
+into the change log.
+If you are not a Datadog employee, you can skip this section
+and it will be filled or deleted during PR review. -->
 
 **Additional Notes:**
 <!-- Anything else we should know when reviewing? -->
@@ -25,4 +28,4 @@ If this change cannot be feasibly tested, please explain why,
 unless the change does not modify code (e.g. only modifies docs, comments).
 -->
 
-Unsure? Have a question? Request a review!
+<!-- Unsure? Have a question? Request a review! -->


### PR DESCRIPTION

**What does this PR do?**
This PR clarifies change log section instructions for contributors.
<!-- A brief description of the change being made with this pull request. -->
Namely, contributors can skip the change log section and it will be filled out during PR review.

Also moved the change log section below explanation of changes which should make the template easier to fill out for contributors, and comment out the review request note since it doesn't need to be part of PR text.

**Motivation:**
Feedback in https://github.com/DataDog/dd-trace-rb/pull/4005
<!-- What inspired you to submit this pull request? -->
