### PR TITLE
fix: ensure uds always takes precedence over http if both configurations are defined

### DIFF
--- a/lib/datadog/core/configuration/agent_settings_resolver.rb
+++ b/lib/datadog/core/configuration/agent_settings_resolver.rb
@@ -234,6 +234,11 @@ module Datadog
         def should_use_uds?
           # When we have mixed settings for http/https and uds, we print a warning
           # and use the uds settings.
+          mixed_http_and_uds
+          can_use_uds?
+        end
+
+        def mixed_http_and_uds
           unless defined?(@mixed_http_and_uds)
             @mixed_http_and_uds = (configured_hostname || configured_port) && can_use_uds?
             if @mixed_http_and_uds
@@ -251,7 +256,6 @@ module Datadog
               )
             end
           end
-          can_use_uds?
         end
 
         def can_use_uds?

--- a/lib/datadog/core/configuration/agent_settings_resolver.rb
+++ b/lib/datadog/core/configuration/agent_settings_resolver.rb
@@ -240,7 +240,7 @@ module Datadog
 
         def mixed_http_and_uds
           return @mixed_http_and_uds if defined?(@mixed_http_and_uds)
-          
+
           @mixed_http_and_uds = (configured_hostname || configured_port) && can_use_uds?
           if @mixed_http_and_uds
             warn_if_configuration_mismatch(
@@ -256,7 +256,7 @@ module Datadog
               ]
             )
           end
-          
+
           @mixed_http_and_uds
         end
 

--- a/lib/datadog/core/configuration/agent_settings_resolver.rb
+++ b/lib/datadog/core/configuration/agent_settings_resolver.rb
@@ -232,7 +232,26 @@ module Datadog
         end
 
         def should_use_uds?
-          can_use_uds? && !mixed_http_and_uds?
+          # When we have mixed settings for http/https and uds, we print a warning
+          # and use the uds settings.
+          unless defined?(@mixed_http_and_uds)
+            @mixed_http_and_uds = (configured_hostname || configured_port) && can_use_uds?
+            if @mixed_http_and_uds
+              warn_if_configuration_mismatch(
+                [
+                  DetectedConfiguration.new(
+                    friendly_name: 'configuration of hostname/port for http/https use',
+                    value: "hostname: '#{hostname}', port: '#{port}'",
+                  ),
+                  DetectedConfiguration.new(
+                    friendly_name: 'configuration for unix domain socket',
+                    value: parsed_url.to_s,
+                  ),
+                ]
+              )
+            end
+          end
+          can_use_uds?
         end
 
         def can_use_uds?
@@ -305,30 +324,6 @@ module Datadog
 
         def unix_scheme?(uri)
           uri.scheme == 'unix'
-        end
-
-        # When we have mixed settings for http/https and uds, we print a warning and ignore the uds settings
-        def mixed_http_and_uds?
-          return @mixed_http_and_uds if defined?(@mixed_http_and_uds)
-
-          @mixed_http_and_uds = (configured_hostname || configured_port) && can_use_uds?
-
-          if @mixed_http_and_uds
-            warn_if_configuration_mismatch(
-              [
-                DetectedConfiguration.new(
-                  friendly_name: 'configuration of hostname/port for http/https use',
-                  value: "hostname: '#{hostname}', port: '#{port}'",
-                ),
-                DetectedConfiguration.new(
-                  friendly_name: 'configuration for unix domain socket',
-                  value: parsed_url.to_s,
-                ),
-              ]
-            )
-          end
-
-          @mixed_http_and_uds
         end
 
         # Represents a given configuration value and where we got it from

--- a/lib/datadog/core/configuration/agent_settings_resolver.rb
+++ b/lib/datadog/core/configuration/agent_settings_resolver.rb
@@ -239,23 +239,25 @@ module Datadog
         end
 
         def mixed_http_and_uds
-          unless defined?(@mixed_http_and_uds)
-            @mixed_http_and_uds = (configured_hostname || configured_port) && can_use_uds?
-            if @mixed_http_and_uds
-              warn_if_configuration_mismatch(
-                [
-                  DetectedConfiguration.new(
-                    friendly_name: 'configuration for unix domain socket',
-                    value: parsed_url.to_s,
-                  ),
-                  DetectedConfiguration.new(
-                    friendly_name: 'configuration of hostname/port for http/https use',
-                    value: "hostname: '#{hostname}', port: '#{port}'",
-                  ),
-                ]
-              )
-            end
+          return @mixed_http_and_uds if defined?(@mixed_http_and_uds)
+          
+          @mixed_http_and_uds = (configured_hostname || configured_port) && can_use_uds?
+          if @mixed_http_and_uds
+            warn_if_configuration_mismatch(
+              [
+                DetectedConfiguration.new(
+                  friendly_name: 'configuration for unix domain socket',
+                  value: parsed_url.to_s,
+                ),
+                DetectedConfiguration.new(
+                  friendly_name: 'configuration of hostname/port for http/https use',
+                  value: "hostname: '#{hostname}', port: '#{port}'",
+                ),
+              ]
+            )
           end
+          
+          @mixed_http_and_uds
         end
 
         def can_use_uds?

--- a/lib/datadog/core/configuration/agent_settings_resolver.rb
+++ b/lib/datadog/core/configuration/agent_settings_resolver.rb
@@ -240,12 +240,12 @@ module Datadog
               warn_if_configuration_mismatch(
                 [
                   DetectedConfiguration.new(
-                    friendly_name: 'configuration of hostname/port for http/https use',
-                    value: "hostname: '#{hostname}', port: '#{port}'",
-                  ),
-                  DetectedConfiguration.new(
                     friendly_name: 'configuration for unix domain socket',
                     value: parsed_url.to_s,
+                  ),
+                  DetectedConfiguration.new(
+                    friendly_name: 'configuration of hostname/port for http/https use',
+                    value: "hostname: '#{hostname}', port: '#{port}'",
                   ),
                 ]
               )

--- a/spec/datadog/core/configuration/agent_settings_resolver_spec.rb
+++ b/spec/datadog/core/configuration/agent_settings_resolver_spec.rb
@@ -192,7 +192,7 @@ RSpec.describe Datadog::Core::Configuration::AgentSettingsResolver do
 
             it 'logs a warning including the uds path' do
               expect(logger).to receive(:warn)
-                .with(%r{Configuration mismatch.*Using "unix:[/|]some/path"})
+                .with(%r{Configuration mismatch.*Using "unix:[\/]{1,3}some/path"})
 
               resolver
             end
@@ -207,7 +207,7 @@ RSpec.describe Datadog::Core::Configuration::AgentSettingsResolver do
 
             it 'logs a warning including the uds configuration' do
               expect(logger).to receive(:warn)
-                .with(%r{Configuration mismatch.*Using "unix:[/|]some/path"})
+                .with(%r{Configuration mismatch.*Using "unix:[\/]{1,3}some/path"})
 
               resolver
             end
@@ -239,7 +239,7 @@ RSpec.describe Datadog::Core::Configuration::AgentSettingsResolver do
 
             it 'logs a warning including the uds configuration' do
               expect(logger).to receive(:warn)
-                .with(%r{Configuration mismatch.*Using "unix:[/|]some/path"})
+                .with(%r{Configuration mismatch.*Using "unix:[\/]{1,3}some/path"})
 
               resolver
             end
@@ -254,7 +254,7 @@ RSpec.describe Datadog::Core::Configuration::AgentSettingsResolver do
 
             it 'logs a warning including the uds configuration' do
               expect(logger).to receive(:warn)
-                .with(%r{Configuration mismatch.*Using "unix:[/|]some/path"})
+                .with(%r{Configuration mismatch.*Using "unix:[\/]{1,3}some/path"})
 
               resolver
             end

--- a/spec/datadog/core/configuration/agent_settings_resolver_spec.rb
+++ b/spec/datadog/core/configuration/agent_settings_resolver_spec.rb
@@ -192,7 +192,7 @@ RSpec.describe Datadog::Core::Configuration::AgentSettingsResolver do
 
             it 'logs a warning including the uds path' do
               expect(logger).to receive(:warn)
-                .with(%r{Configuration mismatch.*Using "unix:[\/]{1,3}some/path"})
+                .with(%r{Configuration mismatch.*Using "unix:[\/]{1,3}some/path"}) # rubocop:disable Style/edundantRegexpCharacterClass
 
               resolver
             end
@@ -207,7 +207,7 @@ RSpec.describe Datadog::Core::Configuration::AgentSettingsResolver do
 
             it 'logs a warning including the uds configuration' do
               expect(logger).to receive(:warn)
-                .with(%r{Configuration mismatch.*Using "unix:[\/]{1,3}some/path"})
+                .with(%r{Configuration mismatch.*Using "unix:[\/]{1,3}some/path"}) # rubocop:disable Style/edundantRegexpCharacterClass
 
               resolver
             end
@@ -239,7 +239,7 @@ RSpec.describe Datadog::Core::Configuration::AgentSettingsResolver do
 
             it 'logs a warning including the uds configuration' do
               expect(logger).to receive(:warn)
-                .with(%r{Configuration mismatch.*Using "unix:[\/]{1,3}some/path"})
+                .with(%r{Configuration mismatch.*Using "unix:[\/]{1,3}some/path"}) # rubocop:disable Style/edundantRegexpCharacterClass
 
               resolver
             end
@@ -254,7 +254,7 @@ RSpec.describe Datadog::Core::Configuration::AgentSettingsResolver do
 
             it 'logs a warning including the uds configuration' do
               expect(logger).to receive(:warn)
-                .with(%r{Configuration mismatch.*Using "unix:[\/]{1,3}some/path"})
+                .with(%r{Configuration mismatch.*Using "unix:[\/]{1,3}some/path"}) # rubocop:disable Style/edundantRegexpCharacterClass
 
               resolver
             end

--- a/spec/datadog/core/configuration/agent_settings_resolver_spec.rb
+++ b/spec/datadog/core/configuration/agent_settings_resolver_spec.rb
@@ -170,32 +170,29 @@ RSpec.describe Datadog::Core::Configuration::AgentSettingsResolver do
         context 'when there is a hostname specified along with uds configuration' do
           let(:with_agent_host) { 'custom-hostname' }
 
-          it 'prioritizes the http configuration' do
-            expect(resolver).to have_attributes(hostname: 'custom-hostname', adapter: :net_http)
+          it 'prioritizes the uds configuration' do
+            expect(resolver).to have_attributes(adapter: :unix)
           end
 
-          it 'logs a warning including the uds path' do
+          it 'logs a warning including the mismatching hostname' do
             expect(logger).to receive(:warn)
-              .with(%r{Configuration mismatch.*configuration for unix domain socket \("unix:.*/some/path"\)})
+              .with(/Configuration mismatch:.*hostname: 'custom-hostname'.*/)
 
             resolver
           end
 
-          it 'does not include a uds_path in the configuration' do
-            expect(resolver).to have_attributes(uds_path: nil)
+          it 'includes a uds_path in the configuration' do
+            expect(resolver).to have_attributes(uds_path: '/some/path')
           end
 
           context 'when there is no port specified' do
-            it 'prioritizes the http configuration and uses the default port' do
-              expect(resolver).to have_attributes(port: 8126, hostname: 'custom-hostname', adapter: :net_http)
+            it 'prioritizes the uds configuration and ignores the default port' do
+              expect(resolver).to have_attributes(adapter: :unix)
             end
 
-            it 'logs a warning including the hostname and default port' do
+            it 'logs a warning including the uds path' do
               expect(logger).to receive(:warn)
-                .with(/
-                  Configuration\ mismatch:\ values\ differ\ between\ configuration.*
-                  Using\ "hostname:\ 'custom-hostname',\ port:\ '8126'".*
-                /x)
+              .with(/Configuration mismatch.*Using "unix:\/some\/path"/)
 
               resolver
             end
@@ -204,51 +201,45 @@ RSpec.describe Datadog::Core::Configuration::AgentSettingsResolver do
           context 'when there is a port specified' do
             let(:with_agent_port) { 1234 }
 
-            it 'prioritizes the http configuration and uses the specified port' do
-              expect(resolver).to have_attributes(port: 1234, hostname: 'custom-hostname', adapter: :net_http)
+            it 'prioritizes the uds path' do
+              expect(resolver).to have_attributes(adapter: :unix)
             end
 
-            it 'logs a warning including the hostname and port' do
+            it 'logs a warning including the uds configuration' do
               expect(logger).to receive(:warn)
-                .with(/
-                  Configuration\ mismatch:\ values\ differ\ between\ configuration.*
-                  Using\ "hostname:\ 'custom-hostname',\ port:\ '1234'".*
-                /x)
+              .with(/Configuration mismatch.*Using "unix:\/some\/path"/)
 
               resolver
             end
           end
         end
 
-        context 'when there is a port specified along with uds configuration' do
+        context 'when there is a port specified along with a uds configuration' do
           let(:with_agent_port) { 5678 }
 
-          it 'prioritizes the http configuration' do
-            expect(resolver).to have_attributes(port: 5678, adapter: :net_http)
+          it 'prioritizes the uds configuration' do
+            expect(resolver).to have_attributes(port: 5678, adapter: :unix)
           end
 
-          it 'logs a warning including the uds path' do
+          it 'logs a warning including the mismatching port' do
             expect(logger).to receive(:warn)
-              .with(%r{Configuration mismatch.*configuration for unix domain socket \("unix:.*/some/path"\)})
+            .with(/Configuration mismatch:.*port: '5678'.*/)
 
             resolver
           end
 
-          it 'does not include a uds_path in the configuration' do
-            expect(resolver).to have_attributes(uds_path: nil)
+          it 'includes the uds path in the configuration' do
+            expect(resolver).to have_attributes(uds_path: '/some/path')
           end
 
           context 'when there is no hostname specified' do
-            it 'prioritizes the http configuration and uses the default hostname' do
-              expect(resolver).to have_attributes(port: 5678, hostname: '127.0.0.1', adapter: :net_http)
+            it 'prioritizes the uds configuration' do
+              expect(resolver).to have_attributes(port: 5678, hostname: nil, adapter: :unix)
             end
 
-            it 'logs a warning including the default hostname and port' do
+            it 'logs a warning including the uds configuration' do
               expect(logger).to receive(:warn)
-                .with(/
-                  Configuration\ mismatch:\ values\ differ\ between\ configuration.*
-                  Using\ "hostname:\ '127.0.0.1',\ port:\ '5678'".*
-                /x)
+                .with(/Configuration mismatch.*Using "unix:\/some\/path"/)
 
               resolver
             end
@@ -257,16 +248,13 @@ RSpec.describe Datadog::Core::Configuration::AgentSettingsResolver do
           context 'when there is a hostname specified' do
             let(:with_agent_host) { 'custom-hostname' }
 
-            it 'prioritizes the http configuration and uses the specified hostname' do
-              expect(resolver).to have_attributes(port: 5678, hostname: 'custom-hostname', adapter: :net_http)
+            it 'prioritizes the uds configuration' do
+              expect(resolver).to have_attributes(adapter: :unix)
             end
 
-            it 'logs a warning including the hostname and port' do
+            it 'logs a warning including the uds configuration' do
               expect(logger).to receive(:warn)
-                .with(/
-                  Configuration\ mismatch:\ values\ differ\ between\ configuration.*
-                  Using\ "hostname:\ 'custom-hostname',\ port:\ '5678'".*
-                /x)
+              .with(/Configuration mismatch.*Using "unix:\/some\/path"/)
 
               resolver
             end

--- a/spec/datadog/core/configuration/agent_settings_resolver_spec.rb
+++ b/spec/datadog/core/configuration/agent_settings_resolver_spec.rb
@@ -192,7 +192,7 @@ RSpec.describe Datadog::Core::Configuration::AgentSettingsResolver do
 
             it 'logs a warning including the uds path' do
               expect(logger).to receive(:warn)
-              .with(/Configuration mismatch.*Using "unix:\/some\/path"/)
+                .with(%r{Configuration mismatch.*Using "unix:[/|]some/path"})
 
               resolver
             end
@@ -207,7 +207,7 @@ RSpec.describe Datadog::Core::Configuration::AgentSettingsResolver do
 
             it 'logs a warning including the uds configuration' do
               expect(logger).to receive(:warn)
-              .with(/Configuration mismatch.*Using "unix:\/some\/path"/)
+                .with(%r{Configuration mismatch.*Using "unix:[/|]some/path"})
 
               resolver
             end
@@ -223,7 +223,7 @@ RSpec.describe Datadog::Core::Configuration::AgentSettingsResolver do
 
           it 'logs a warning including the mismatching port' do
             expect(logger).to receive(:warn)
-            .with(/Configuration mismatch:.*port: '5678'.*/)
+              .with(/Configuration mismatch:.*port: '5678'.*/)
 
             resolver
           end
@@ -239,7 +239,7 @@ RSpec.describe Datadog::Core::Configuration::AgentSettingsResolver do
 
             it 'logs a warning including the uds configuration' do
               expect(logger).to receive(:warn)
-                .with(/Configuration mismatch.*Using "unix:\/some\/path"/)
+                .with(%r{Configuration mismatch.*Using "unix:[/|]some/path"})
 
               resolver
             end
@@ -254,7 +254,7 @@ RSpec.describe Datadog::Core::Configuration::AgentSettingsResolver do
 
             it 'logs a warning including the uds configuration' do
               expect(logger).to receive(:warn)
-              .with(/Configuration mismatch.*Using "unix:\/some\/path"/)
+                .with(%r{Configuration mismatch.*Using "unix:[/|]some/path"})
 
               resolver
             end


### PR DESCRIPTION
**What does this PR do?**

Ensures uds configurations are parsed in a manner that is consistent with other libraries. 

**Motivation:**

- Ensures `DD_TRACE_AGENT_URL` is applied in a consistent manner.

**Change log entry**
<!-- If this is a customer-visible change, a brief summary to be placed
into the change log.
If you are not a Datadog employee, you can skip this section
and it will be filled or deleted during PR review. -->

**Additional Notes:**
<!-- Anything else we should know when reviewing? -->

**How to test the change?**
<!--
Describe here how the change can be validated.
You are strongly encouraged to provide automated tests for this PR (unit or integration).
If this change cannot be feasibly tested, please explain why,
unless the change does not modify code (e.g. only modifies docs, comments).
-->

<!-- Unsure? Have a question? Request a review! -->
