### PR TITLE
[APPSEC-55378] Move AppSec context creation into processor

### DIFF
--- a/lib/datadog/appsec/processor.rb
+++ b/lib/datadog/appsec/processor.rb
@@ -1,5 +1,7 @@
 # frozen_string_literal: true
 
+require_relative 'processor/context'
+
 module Datadog
   module AppSec
     # Processor integrates libddwaf into datadog/appsec
@@ -7,10 +9,11 @@ module Datadog
       attr_reader :diagnostics, :addresses
 
       def initialize(ruleset:, telemetry:)
+        @telemetry = telemetry
         @diagnostics = nil
         @addresses = []
+
         settings = Datadog.configuration.appsec
-        @telemetry = telemetry
 
         # TODO: Refactor to make it easier to test
         unless require_libddwaf && libddwaf_provides_waf? && create_waf_handle(settings, ruleset)
@@ -26,9 +29,9 @@ module Datadog
         @handle.finalize
       end
 
-      protected
-
-      attr_reader :handle
+      def new_context
+        Context.new(@handle, telemetry: @telemetry)
+      end
 
       private
 

--- a/lib/datadog/appsec/processor/context.rb
+++ b/lib/datadog/appsec/processor/context.rb
@@ -7,8 +7,10 @@ module Datadog
       class Context
         attr_reader :time_ns, :time_ext_ns, :timeouts, :events
 
-        def initialize(processor)
-          @context = Datadog::AppSec::WAF::Context.new(processor.send(:handle))
+        def initialize(handle, telemetry:)
+          @context = Datadog::AppSec::WAF::Context.new(handle)
+          @telemetry = telemetry
+
           @time_ns = 0.0
           @time_ext_ns = 0.0
           @timeouts = 0
@@ -39,6 +41,7 @@ module Datadog
           @time_ext_ns += (stop_ns - start_ns)
           @timeouts += 1 if res.timeout
 
+          # TODO: handle the response
           res
         ensure
           @run_mutex.unlock

--- a/lib/datadog/appsec/processor/context.rb
+++ b/lib/datadog/appsec/processor/context.rb
@@ -41,7 +41,6 @@ module Datadog
           @time_ext_ns += (stop_ns - start_ns)
           @timeouts += 1 if res.timeout
 
-          # TODO: handle the response
           res
         ensure
           @run_mutex.unlock

--- a/lib/datadog/appsec/scope.rb
+++ b/lib/datadog/appsec/scope.rb
@@ -1,7 +1,5 @@
 # frozen_string_literal: true
 
-require_relative 'processor/context'
-
 module Datadog
   module AppSec
     # Capture context essential to consistently call processor and report via traces
@@ -22,8 +20,7 @@ module Datadog
         def activate_scope(trace, service_entry_span, processor)
           raise ActiveScopeError, 'another scope is active, nested scopes are not supported' if active_scope
 
-          context = Datadog::AppSec::Processor::Context.new(processor)
-
+          context = processor.new_context
           self.active_scope = new(trace, service_entry_span, context)
         end
 

--- a/sig/datadog/appsec/processor.rbs
+++ b/sig/datadog/appsec/processor.rbs
@@ -1,29 +1,39 @@
 module Datadog
   module AppSec
     class Processor
-      def self.active_context: () -> Context
+      type rule = bool | ::Integer | ::String | ::Hash[::String, rule] | ::Array[rule]
+      type ruleset = ::Hash[::String, rule]
 
-      private
+      @telemetry: Core::Telemetry::Component
 
-      attr_reader diagnostics: WAF::LibDDWAF::Object?
-      attr_reader addresses: ::Array[::String]
+      @diagnostics: WAF::LibDDWAF::Object?
 
-      @handle: WAF::Handle
-      @ruleset: ::Hash[::String, untyped]
       @addresses: ::Array[::String]
 
-      def initialize: (ruleset: ::Hash[untyped, untyped], telemetry: Core::Telemetry::Component) -> void
+      @handle: WAF::Handle
+
+      attr_reader diagnostics: WAF::LibDDWAF::Object?
+
+      attr_reader addresses: ::Array[::String]
+
+      def initialize: (ruleset: ruleset, telemetry: Core::Telemetry::Component) -> void
+
       def ready?: () -> bool
+
       def finalize: () -> void
 
-      attr_reader handle: untyped
+      def new_context: () -> Context
 
       private
 
       def require_libddwaf: () -> bool
+
       def libddwaf_provides_waf?: () -> bool
-      def create_waf_handle: (Core::Configuration::Settings::_AppSec settings, ::Hash[String, untyped] ruleset) -> bool
+
+      def create_waf_handle: (Core::Configuration::Settings::_AppSec settings, ruleset ruleset) -> bool
+
       def libddwaf_platform: () -> ::String
+
       def ruby_platforms: () -> ::Array[::String]
     end
   end

--- a/sig/datadog/appsec/processor/context.rbs
+++ b/sig/datadog/appsec/processor/context.rbs
@@ -2,24 +2,38 @@ module Datadog
   module AppSec
     class Processor
       class Context
-        type event = untyped
-        type data = WAF::data
-
-        attr_reader time_ns: ::Float
-        attr_reader time_ext_ns: ::Float
-        attr_reader timeouts: ::Integer
-        attr_reader events: ::Array[event]
-
         @context: WAF::Context
+
+        @telemetry: Core::Telemetry::Component
+
+        @time_ns: ::Float
+
+        @time_ext_ns: ::Float
+
+        @timeouts: ::Integer
+
+        @events: ::Array[untyped]
 
         @run_mutex: ::Thread::Mutex
 
-        def initialize: (Processor processor) -> void
+        attr_reader time_ns: ::Float
+
+        attr_reader time_ext_ns: ::Float
+
+        attr_reader timeouts: ::Integer
+
+        attr_reader events: ::Array[untyped]
+
+        def initialize: (WAF::Handle handle, telemetry: Core::Telemetry::Component) -> void
+
         def run: (Hash[untyped, untyped] input, ?::Integer timeout) -> WAF::Result
+
         def extract_schema: () -> WAF::Result?
+
         def finalize: () -> void
 
         private
+
         def extract_schema?: () -> bool
       end
     end

--- a/spec/datadog/appsec/processor/context_spec.rb
+++ b/spec/datadog/appsec/processor/context_spec.rb
@@ -18,9 +18,7 @@ RSpec.describe Datadog::AppSec::Processor::Context do
   let(:input_client_ip) { { 'http.client_ip' => '1.2.3.4' } }
 
   let(:client_ip) { '1.2.3.4' }
-
   let(:input) { input_scanner }
-
   let(:processor) { Datadog::AppSec::Processor.new(ruleset: ruleset, telemetry: telemetry) }
 
   let(:run_count) { 1 }
@@ -36,12 +34,9 @@ RSpec.describe Datadog::AppSec::Processor::Context do
     results.first
   end
 
-  subject(:context) { described_class.new(processor) }
+  subject(:context) { processor.new_context }
 
-  before do
-    runs
-  end
-
+  before { runs }
   after do
     context.finalize
     processor.finalize

--- a/spec/datadog/appsec/processor_spec.rb
+++ b/spec/datadog/appsec/processor_spec.rb
@@ -283,4 +283,10 @@ RSpec.describe Datadog::AppSec::Processor do
       end
     end
   end
+
+  describe '#new_context' do
+    let(:processor) { described_class.new(ruleset: ruleset, telemetry: telemetry) }
+
+    it { expect(processor.new_context).to be_instance_of(described_class::Context) }
+  end
 end


### PR DESCRIPTION
**What does this PR do?**

This PR will move `Processor::Context` creation inside the `Processor` to avoid leaking knowledge into the caller and fix dependency direction between `Processor`-`Context`.

A new argument will appear on the `Context` - telemetry. Later we will shift responsibilities of how we handle unsuccessful responses of the C-ext WAF and remove spread of the common logic from other classes.

**Motivation:**

Since `Context` is a part of the `Processor` it can't call handle on the injected dependency (also handle is a hidden API). Instead, `Processor` is going to create a fully operational `Context` and provide all requirements to it.

**Change log entry**

Not needed.

**How to test the change?**

Just CI.