### PR TITLE
[PROF-10589] Add benchmarking configuration for gvl profiling

### DIFF
--- a/.gitlab/benchmarks.yml
+++ b/.gitlab/benchmarks.yml
@@ -114,6 +114,14 @@ only-profiling-heap-clean-after-gc:
     DD_PROFILING_HEAP_CLEAN_AFTER_GC_ENABLED: "true"
     ADD_TO_GEMFILE: "gem 'datadog', github: 'datadog/dd-trace-rb', ref: '$CI_COMMIT_SHA'"
 
+only-profiling-gvl:
+  extends: .benchmarks
+  variables:
+    DD_BENCHMARKS_CONFIGURATION: only-profiling
+    DD_PROFILING_ENABLED: "true"
+    DD_PROFILING_PREVIEW_GVL_ENABLED: "true"
+    ADD_TO_GEMFILE: "gem 'datadog', github: 'datadog/dd-trace-rb', ref: '$CI_COMMIT_SHA'"
+
 profiling-and-tracing:
   extends: .benchmarks
   variables:


### PR DESCRIPTION
**What does this PR do?**

This PR tweaks our nightly benchmark runs configuration to add a new configuration that enables GVL profiling.

**Motivation:**

This will allow us to have better coverage for testing this feature.

**Change log entry**

(Not relevant for this PR)

**Additional Notes:**

This was previously blocked on upgrading the gitlab image that we run in the benchmarking platform, which I finally took care of in https://github.com/DataDog/benchmarking-platform/pull/108 .

**How to test the change?**

I'll trigger a manual run to validate it's running fine and report back ;)

