### PR TITLE
[NO-TICKET] Fix crashtracking sending parent pid/runtime-id when child crashes

### DIFF
--- a/lib/datadog/core/crashtracking/component.rb
+++ b/lib/datadog/core/crashtracking/component.rb
@@ -101,7 +101,7 @@ module Datadog
             tags_as_array: tags.to_a,
             upload_timeout_seconds: 1
           )
-          logger.debug("Crash tracking #{action} successfully")
+          logger.debug("Crash tracking action: #{action} successful")
         rescue => e
           logger.error("Failed to #{action} crash tracking: #{e.message}")
         end

--- a/lib/datadog/core/crashtracking/component.rb
+++ b/lib/datadog/core/crashtracking/component.rb
@@ -66,7 +66,8 @@ module Datadog
         def start
           Utils::AtForkMonkeyPatch.apply!
 
-          start_or_update_on_fork(action: :start)
+          start_or_update_on_fork(action: :start, tags: tags)
+
           ONLY_ONCE.run do
             Utils::AtForkMonkeyPatch.at_fork(:child) do
               # Must NOT reference `self` here, as only the first instance will
@@ -77,8 +78,10 @@ module Datadog
           end
         end
 
-        def update_on_fork
-          start_or_update_on_fork(action: :update_on_fork)
+        def update_on_fork(settings: Datadog.configuration)
+          # Here we pick up the latest settings, so that we pick up any tags that change after forking
+          # such as the pid or runtime-id
+          start_or_update_on_fork(action: :update_on_fork, tags: TagBuilder.call(settings))
         end
 
         def stop
@@ -92,7 +95,7 @@ module Datadog
 
         attr_reader :tags, :agent_base_url, :ld_library_path, :path_to_crashtracking_receiver_binary, :logger
 
-        def start_or_update_on_fork(action:)
+        def start_or_update_on_fork(action:, tags:)
           self.class._native_start_or_update_on_fork(
             action: action,
             agent_base_url: agent_base_url,

--- a/sig/datadog/core/crashtracking/component.rbs
+++ b/sig/datadog/core/crashtracking/component.rbs
@@ -21,7 +21,7 @@ module Datadog
 
         def start: -> void
 
-        def update_on_fork: -> void
+        def update_on_fork: (settings: Datadog::Core::Configuration::Settings) -> void
 
         def stop: -> void
 
@@ -33,7 +33,7 @@ module Datadog
         attr_reader path_to_crashtracking_receiver_binary: ::String
         attr_reader logger: untyped
 
-        def start_or_update_on_fork: (action: :start | :update_on_fork) -> void
+        def start_or_update_on_fork: (action: :start | :update_on_fork, tags: ::Hash[::String, ::String]) -> void
 
         def self._native_start_or_update_on_fork: (
           action: :start | :update_on_fork,

--- a/spec/datadog/core/crashtracking/component_spec.rb
+++ b/spec/datadog/core/crashtracking/component_spec.rb
@@ -149,8 +149,9 @@ RSpec.describe Datadog::Core::Crashtracking::Component, skip: !CrashtrackingHelp
       end
 
       it 'refreshes the latest settings' do
-        expect(Datadog).to receive(:configuration).and_return(:latest_settings)
-        expect(Datadog::Core::Crashtracking::TagBuilder).to receive(:call).with(:latest_settings).and_return([:latest_tags])
+        allow(Datadog).to receive(:configuration).and_return(:latest_settings)
+        allow(Datadog::Core::Crashtracking::TagBuilder).to receive(:call).with(:latest_settings).and_return([:latest_tags])
+
         expect(described_class).to receive(:_native_start_or_update_on_fork).with(
           hash_including(tags_as_array: [:latest_tags])
         )

--- a/spec/datadog/core/crashtracking/component_spec.rb
+++ b/spec/datadog/core/crashtracking/component_spec.rb
@@ -5,10 +5,11 @@ require 'webrick'
 require 'fiddle'
 
 RSpec.describe Datadog::Core::Crashtracking::Component, skip: !CrashtrackingHelpers.supported? do
+  let(:logger) { Logger.new($stdout) }
+
   describe '.build' do
     let(:settings) { Datadog::Core::Configuration::Settings.new }
     let(:agent_settings) { double('agent_settings') }
-    let(:logger) { Logger.new($stdout) }
     let(:tags) { { 'tag1' => 'value1' } }
     let(:agent_base_url) { 'agent_base_url' }
     let(:ld_library_path) { 'ld_library_path' }
@@ -100,7 +101,6 @@ RSpec.describe Datadog::Core::Crashtracking::Component, skip: !CrashtrackingHelp
     describe '#start' do
       context 'when _native_start_or_update_on_fork raises an exception' do
         it 'logs the exception' do
-          logger = Logger.new($stdout)
           crashtracker = build_crashtracker(logger: logger)
 
           expect(described_class).to receive(:_native_start_or_update_on_fork) { raise 'Test failure' }
@@ -114,7 +114,6 @@ RSpec.describe Datadog::Core::Crashtracking::Component, skip: !CrashtrackingHelp
     describe '#stop' do
       context 'when _native_stop_crashtracker raises an exception' do
         it 'logs the exception' do
-          logger = Logger.new($stdout)
           crashtracker = build_crashtracker(logger: logger)
 
           expect(described_class).to receive(:_native_stop) { raise 'Test failure' }
@@ -128,7 +127,6 @@ RSpec.describe Datadog::Core::Crashtracking::Component, skip: !CrashtrackingHelp
     describe '#update_on_fork' do
       context 'when _native_stop_crashtracker raises an exception' do
         it 'logs the exception' do
-          logger = Logger.new($stdout)
           crashtracker = build_crashtracker(logger: logger)
 
           expect(described_class).to receive(:_native_start_or_update_on_fork) { raise 'Test failure' }
@@ -138,12 +136,14 @@ RSpec.describe Datadog::Core::Crashtracking::Component, skip: !CrashtrackingHelp
         end
       end
 
-      it 'update_on_fork the crash tracker' do
+      it 'updates the crash tracker' do
+        allow(logger).to receive(:debug)
+
         expect(described_class).to receive(:_native_start_or_update_on_fork).with(
           hash_including(action: :update_on_fork)
         )
 
-        crashtracker = build_crashtracker
+        crashtracker = build_crashtracker(logger: logger)
 
         crashtracker.update_on_fork
       end


### PR DESCRIPTION
**What does this PR do?**

This PR fixes a bug in the crashtracking component: because it cached all of the tags from creation, if a process forked, it would use the tags from the parent, which included a (now-incorrect) pid and runtime-id.

**Motivation:**

This makes sure we have accurate metadata in crashtracking reports.

**Change log entry**

(Internal change, not relevant for changelog)

**Additional Notes:**

N/A

**How to test the change?**

I've added test coverage for this change. It can also be observed by using

> `$ DD_CRASHTRACKING_ENABLED=true bundle exec ruby -e 'require "datadog/auto_instrument"; puts "Parent: #{Process.pid} #{Datadog::Core::Environment::Identity.id}"; fork { puts "Child: #{Process.pid} #{Datadog::Core::Environment::Identity.id}"; Process.kill("SEGV", Process.pid) }'`

and validating that the correct pid/runtime-id from the child is sent in the metadata.