### PR TITLE
[NO-TICKET] Remove tight version contraint on datadog-ruby_core_source

### DIFF
--- a/datadog.gemspec
+++ b/datadog.gemspec
@@ -61,10 +61,8 @@ Gem::Specification.new do |spec|
   # rubies, see #1739 and #1336 for an extended discussion about this
   spec.add_dependency 'msgpack'
 
-  # Used by the profiler native extension to support Ruby < 2.6 and > 3.2
-  #
-  # We decided to pin it at the latest available version and will manually bump the dependency as needed.
-  spec.add_dependency 'datadog-ruby_core_source', '= 3.3.6'
+  # Used by the profiler native extension to support Ruby 2.5 and > 3.2, see NativeExtensionDesign.md for details
+  spec.add_dependency 'datadog-ruby_core_source', '~> 3.3'
 
   # Used by appsec
   spec.add_dependency 'libddwaf', '~> 1.14.0.0.0'


### PR DESCRIPTION
**What does this PR do?**

This PR removes the tight 1:1 version contraint we have on the `datadog-ruby_core_source` gem, replacing it with allowing any 3.x release.

**Motivation:**

The tight 1:1 constraint was a leftover from when we used `debase-ruby_core_source`. When we introduced it, in #1740, there were some concerns over validating upstream releases before dd-trace-rb adopted them, and we decided to use this approach to allow us to do so.

As we now run our own fork and have full control over releases of the gem, there's no longer any reason to pin to specific versions.

**Change log entry**

(Not needed IMO)

**Additional Notes:**

We've never had to do it so far, but having the looser version constraint means that if, e.g. a new patch version of Ruby 3.3/3.4 comes out that needs updated headers, we can ship an update to `datadog-ruby_core_source` and customers can adopt it without having to re-spin a new version of the `datadog` gem.

**How to test the change?**

If CI passes, we should be good!