### PR TITLE
Add Ruby 3.4.0-preview2 support for integration apps

### DIFF
--- a/integration/apps/opentelemetry/script/build-images
+++ b/integration/apps/opentelemetry/script/build-images
@@ -36,6 +36,7 @@ else
   docker build --build-arg BASE_IMAGE=datadog/dd-apm-demo:rb-3.1 -t datadog/dd-apm-demo:rb-3.1-opentelemetry .
   docker build --build-arg BASE_IMAGE=datadog/dd-apm-demo:rb-3.2 -t datadog/dd-apm-demo:rb-3.2-opentelemetry .
   docker build --build-arg BASE_IMAGE=datadog/dd-apm-demo:rb-3.3 -t datadog/dd-apm-demo:rb-3.3-opentelemetry .
+  docker build --build-arg BASE_IMAGE=datadog/dd-apm-demo:rb-3.4 -t datadog/dd-apm-demo:rb-3.4-opentelemetry .
   # ADD NEW RUBIES HERE
 fi
 echo "== Done building Ruby app images. =="

--- a/integration/apps/rack/script/build-images
+++ b/integration/apps/rack/script/build-images
@@ -36,6 +36,7 @@ else
   docker build --build-arg BASE_IMAGE=datadog/dd-apm-demo:rb-3.1 -t datadog/dd-apm-demo:rb-3.1-rack .
   docker build --build-arg BASE_IMAGE=datadog/dd-apm-demo:rb-3.2 -t datadog/dd-apm-demo:rb-3.2-rack .
   docker build --build-arg BASE_IMAGE=datadog/dd-apm-demo:rb-3.3 -t datadog/dd-apm-demo:rb-3.3-rack .
+  docker build --build-arg BASE_IMAGE=datadog/dd-apm-demo:rb-3.4 -t datadog/dd-apm-demo:rb-3.4-rack .
   # ADD NEW RUBIES HERE
 fi
 echo "== Done building Rack images. =="

--- a/integration/apps/rails-five/script/ci
+++ b/integration/apps/rails-five/script/ci
@@ -48,6 +48,11 @@ if [[ "$APP_RUBY_VERSION" == "3.3" ]]; then
   exit 1
 fi
 
+if [[ "$APP_RUBY_VERSION" == "3.4" ]]; then
+  echo "Ruby 3.4 is not supported by Rails 5"
+  exit 1
+fi
+
 # ADD NEW RUBIES HERE
 
 # Set configuration

--- a/integration/apps/rails-seven/Gemfile
+++ b/integration/apps/rails-seven/Gemfile
@@ -45,3 +45,7 @@ group :development do
   # Speed up commands on slow machines / big apps [https://github.com/rails/spring]
   # gem "spring"
 end
+
+# Gems no longer included in Ruby 3.4
+gem 'bigdecimal'
+gem 'mutex_m'

--- a/integration/apps/rails-seven/script/build-images
+++ b/integration/apps/rails-seven/script/build-images
@@ -30,6 +30,7 @@ else
   docker build --build-arg BASE_IMAGE=datadog/dd-apm-demo:rb-3.1 -t datadog/dd-apm-demo:rb-3.1-rails-seven .
   docker build --build-arg BASE_IMAGE=datadog/dd-apm-demo:rb-3.2 -t datadog/dd-apm-demo:rb-3.2-rails-seven .
   docker build --build-arg BASE_IMAGE=datadog/dd-apm-demo:rb-3.3 -t datadog/dd-apm-demo:rb-3.3-rails-seven .
+  docker build --build-arg BASE_IMAGE=datadog/dd-apm-demo:rb-3.4 -t datadog/dd-apm-demo:rb-3.4-rails-seven .
   # ADD NEW RUBIES HERE
 fi
 echo "== Done building Rails 7 images. =="

--- a/integration/apps/rails-six/Gemfile
+++ b/integration/apps/rails-six/Gemfile
@@ -96,3 +96,6 @@ group :test, :development do
 
   gem 'listen'
 end
+
+# Gem no longer included in Ruby 3.4
+gem 'mutex_m'

--- a/integration/apps/rails-six/script/build-images
+++ b/integration/apps/rails-six/script/build-images
@@ -32,6 +32,7 @@ else
   docker build --build-arg BASE_IMAGE=datadog/dd-apm-demo:rb-3.1 -t datadog/dd-apm-demo:rb-3.1-rails-six .
   docker build --build-arg BASE_IMAGE=datadog/dd-apm-demo:rb-3.2 -t datadog/dd-apm-demo:rb-3.2-rails-six .
   docker build --build-arg BASE_IMAGE=datadog/dd-apm-demo:rb-3.3 -t datadog/dd-apm-demo:rb-3.3-rails-six .
+  docker build --build-arg BASE_IMAGE=datadog/dd-apm-demo:rb-3.4 -t datadog/dd-apm-demo:rb-3.4-rails-six .
   # ADD NEW RUBIES HERE
 fi
 echo "== Done building Rails 6 images. =="

--- a/integration/apps/rspec/script/build-images
+++ b/integration/apps/rspec/script/build-images
@@ -36,6 +36,7 @@ else
   docker build --build-arg BASE_IMAGE=datadog/dd-apm-demo:rb-3.1 -t datadog/dd-apm-demo:rb-3.1-rspec .
   docker build --build-arg BASE_IMAGE=datadog/dd-apm-demo:rb-3.2 -t datadog/dd-apm-demo:rb-3.2-rspec .
   docker build --build-arg BASE_IMAGE=datadog/dd-apm-demo:rb-3.3 -t datadog/dd-apm-demo:rb-3.3-rspec .
+  docker build --build-arg BASE_IMAGE=datadog/dd-apm-demo:rb-3.4 -t datadog/dd-apm-demo:rb-3.4-rspec .
   # ADD NEW RUBIES HERE
 fi
 echo "== Done building Ruby app images. =="

--- a/integration/apps/ruby/script/build-images
+++ b/integration/apps/ruby/script/build-images
@@ -36,6 +36,7 @@ else
   docker build --build-arg BASE_IMAGE=datadog/dd-apm-demo:rb-3.1 -t datadog/dd-apm-demo:rb-3.1-ruby .
   docker build --build-arg BASE_IMAGE=datadog/dd-apm-demo:rb-3.2 -t datadog/dd-apm-demo:rb-3.2-ruby .
   docker build --build-arg BASE_IMAGE=datadog/dd-apm-demo:rb-3.3 -t datadog/dd-apm-demo:rb-3.3-ruby .
+  docker build --build-arg BASE_IMAGE=datadog/dd-apm-demo:rb-3.4 -t datadog/dd-apm-demo:rb-3.4-ruby .
   # ADD NEW RUBIES HERE
 fi
 echo "== Done building Ruby app images. =="

--- a/integration/apps/sinatra2-classic/script/build-images
+++ b/integration/apps/sinatra2-classic/script/build-images
@@ -31,6 +31,7 @@ else
   docker build --build-arg BASE_IMAGE=datadog/dd-apm-demo:rb-3.1 -t datadog/dd-apm-demo:rb-3.1-sinatra2-classic .
   docker build --build-arg BASE_IMAGE=datadog/dd-apm-demo:rb-3.2 -t datadog/dd-apm-demo:rb-3.2-sinatra2-classic .
   docker build --build-arg BASE_IMAGE=datadog/dd-apm-demo:rb-3.3 -t datadog/dd-apm-demo:rb-3.3-sinatra2-classic .
+  docker build --build-arg BASE_IMAGE=datadog/dd-apm-demo:rb-3.4 -t datadog/dd-apm-demo:rb-3.4-sinatra2-classic .
   # ADD NEW RUBIES HERE
 fi
 echo "== Done building Sinatra images. =="

--- a/integration/apps/sinatra2-modular/script/build-images
+++ b/integration/apps/sinatra2-modular/script/build-images
@@ -31,6 +31,7 @@ else
   docker build --build-arg BASE_IMAGE=datadog/dd-apm-demo:rb-3.1 -t datadog/dd-apm-demo:rb-3.1-sinatra2-modular .
   docker build --build-arg BASE_IMAGE=datadog/dd-apm-demo:rb-3.2 -t datadog/dd-apm-demo:rb-3.2-sinatra2-modular .
   docker build --build-arg BASE_IMAGE=datadog/dd-apm-demo:rb-3.3 -t datadog/dd-apm-demo:rb-3.3-sinatra2-modular .
+  docker build --build-arg BASE_IMAGE=datadog/dd-apm-demo:rb-3.4 -t datadog/dd-apm-demo:rb-3.4-sinatra2-modular .
   # ADD NEW RUBIES HERE
 fi
 echo "== Done building Sinatra images. =="

--- a/integration/images/ruby/3.4/Dockerfile
+++ b/integration/images/ruby/3.4/Dockerfile
@@ -1,0 +1,54 @@
+FROM ruby:3.4.0-preview2
+
+ENV DEBIAN_FRONTEND=noninteractive
+
+# Install prerequisites
+RUN set -ex && \
+        echo "===> Installing dependencies" && \
+        apt-get -y update && \
+        apt-get install -y --force-yes --no-install-recommends \
+            curl wget tar gzip gnupg apt-transport-https ca-certificates tzdata locales && \
+        \
+        echo "===> Installing NodeJS" && \
+        apt-get install -y --force-yes --no-install-recommends nodejs && \
+        \
+        echo "===> Installing Yarn" && \
+        curl -sS https://dl.yarnpkg.com/debian/pubkey.gpg | apt-key add - && \
+        echo "deb https://dl.yarnpkg.com/debian/ stable main" | tee /etc/apt/sources.list.d/yarn.list && \
+        apt-get update && \
+        apt-get install -y --force-yes --no-install-recommends yarn && \
+        \
+        echo "===> Installing database libraries" && \
+        apt-get install -y --force-yes --no-install-recommends \
+            postgresql-client sqlite3 && \
+        \
+        echo "===> Installing dev tools" && \
+        mkdir -p /usr/share/man/man1 && \
+        apt-get install -y --force-yes --no-install-recommends \
+            sudo git openssh-client rsync vim \
+            net-tools netcat-openbsd parallel unzip zip bzip2 && \
+        \
+        echo "===> Cleaning up" && \
+        rm -rf /var/lib/apt/lists/*;
+
+# Set timezone to UTC by default
+RUN ln -sf /usr/share/zoneinfo/Etc/UTC /etc/localtime
+
+# Set language
+RUN locale-gen en_US.UTF-8
+ENV LANG en_US.UTF-8
+ENV LANGUAGE en_US:en
+
+# Install RubyGems
+RUN gem update --system 3.4.1
+RUN mkdir -p "$GEM_HOME" && chmod -R 777 "$GEM_HOME"
+
+# Upgrade RubyGems and Bundler
+RUN gem update --system 3.4.1
+RUN gem install bundler
+ENV BUNDLE_SILENCE_ROOT_WARNING 1
+
+# Setup demo environment includes
+COPY ./include /vendor/dd-demo
+ENV RUBYLIB /vendor/dd-demo
+ENV RUBYOPT -rdatadog/demo_env

--- a/integration/script/build-images
+++ b/integration/script/build-images
@@ -50,6 +50,7 @@ else
   docker build -t datadog/dd-apm-demo:rb-3.1 -f $INTEGRATION_DIR/images/ruby/3.1/Dockerfile $INTEGRATION_DIR/images
   docker build -t datadog/dd-apm-demo:rb-3.2 -f $INTEGRATION_DIR/images/ruby/3.2/Dockerfile $INTEGRATION_DIR/images
   docker build -t datadog/dd-apm-demo:rb-3.3 -f $INTEGRATION_DIR/images/ruby/3.3/Dockerfile $INTEGRATION_DIR/images
+  docker build -t datadog/dd-apm-demo:rb-3.4 -f $INTEGRATION_DIR/images/ruby/3.4/Dockerfile $INTEGRATION_DIR/images
   # ADD NEW RUBIES HERE
 fi
 echo "== Done building base images. =="


### PR DESCRIPTION
<!--
Check out the
https://github.com/DataDog/dd-trace-rb/blob/master/docs/DevelopmentGuide.md
for guidance on how to set up your development environment,
run the test suite, write new integrations, and more.
-->

**What does this PR do?**
This PR adds Ruby 3.4.0-preview2 support for integration apps. The PR adds a "3.4" version to every file under `integration` that needs to be modified to provide support (indicated with "ADD NEW RUBIES HERE").

**Motivation:**
Though the official Ruby 3.4 is not yet released, we can temporarily add Ruby 3.4.0-preview2. This allows us to start testing with Ruby 3.4 in our CI and spot -> address issues early. After Ruby 3.4 is officially released post-Dec 25, 2024, we can replace the preview with it.

**Change log entry**
No change log entry for now. Thinking to have a "Ruby 3.4.0-preview2 support added" update after it is fully supported.

**Additional Notes:**
More Ruby 3.4.0-preview2 support is needed. This PR is one step toward full support and only addresses integration apps.

**How to test the change?**
This change can be tested in CI.

<!-- Unsure? Have a question? Request a review! -->
