### PR TITLE
[APPSEC-55194] Handle low-level libddwaf exceptions

### DIFF
--- a/sig/datadog/appsec/processor/context.rbs
+++ b/sig/datadog/appsec/processor/context.rbs
@@ -16,7 +16,7 @@ module Datadog
 
         @run_mutex: ::Thread::Mutex
 
-        @libddwaf_tag: ::String
+        @libddwaf_debug_tag: ::String
 
         LIBDDWAF_SUCCESSFUL_EXECUTION_CODES: ::Array[::Symbol]
 
@@ -37,6 +37,8 @@ module Datadog
         def finalize: () -> void
 
         private
+
+        def try_run: (Hash[untyped, untyped] input, ::Integer timeout) -> [::Symbol, WAF::Result]
 
         def report_execution: (WAF::Result result) -> void
 


### PR DESCRIPTION
**What does this PR do?**

Wrap `Processor::Context#run` with an error handling and telemetry reporting.

**Motivation:**

Is some specific situations, our `libddwaf-rb` is going to throw an exception when it fails to convert C-object into Ruby-object and some other low-level occasions.

**Change log entry**

Not needed.

**Additional Notes:**

Likely we would change the interface of libddwaf-rb soon™️, but in foreseen future we need to be able to land on feet when something wrong happen with our FFI binding.

**How to test the change?**

CI is enough.