### PR TITLE
Remove cached gems from artifacts

### DIFF
--- a/.gitlab/install_datadog_deps.rb
+++ b/.gitlab/install_datadog_deps.rb
@@ -114,6 +114,15 @@ unless File.exist?("#{datadog_gem_path}/lib/#{libdatadog_so_file}")
   raise "Missing #{libdatadog_so_file} in #{datadog_gem_path}."
 end
 
+cached_gems = Dir.glob(versioned_path.join("cache/*.gem"))
+
+FileUtils.rm_r(
+  [
+    *cached_gems,
+  ],
+  verbose: true
+)
+
 FileUtils.cd(versioned_path.join("extensions/#{Gem::Platform.local}"), verbose: true) do
   # Symlink those directories to be utilized by Ruby compiled with shared libraries
   FileUtils.ln_sf Gem.extension_api_version, ruby_api_version


### PR DESCRIPTION
**What does this PR do?**

This PR reduces the artifacts size by removing the cached gems. 


| base (`7f64645565f4967fa1a6b6c047665b04acbc1384`) | branch (`fe76de905f07c8a5e9322cca4563e7a45aa742d6`)| 
|---|---|
| 240 mb |  203.3 mb |