### PR TITLE
Remove ffi ext directory from artifacts

### DIFF
--- a/.gitlab/install_datadog_deps.rb
+++ b/.gitlab/install_datadog_deps.rb
@@ -63,6 +63,10 @@ end
 
 puts gem_version_mapping
 
+ffi_version = gem_version_mapping.fetch('ffi')
+puts "=== ffi version ==="
+puts ffi_version
+
 env = {
   'GEM_HOME' => versioned_path.to_s,
   # Install `datadog` gem locally without its profiling native extension
@@ -119,6 +123,7 @@ cached_gems = Dir.glob(versioned_path.join("cache/*.gem"))
 FileUtils.rm_r(
   [
     *cached_gems,
+    versioned_path.join("gems/ffi-#{ffi_version}/ext"),
   ],
   verbose: true
 )


### PR DESCRIPTION
**What does this PR do?**

This PR reduces the artifacts size by removing `ext` directories for `ffi` gems

Comparing to the previous PR: https://github.com/DataDog/dd-trace-rb/pull/4042

| base (`fe76de905f07c8a5e9322cca4563e7a45aa742d6`)|  branch(`c803ac20fe15014e56585e7d0119e9a07535f8bf`) | 
|---|---|
|203.3 mb | 173.7 mb |