### PR TITLE
Update Ruby 3.4 image to preview2

### DIFF
--- a/.circleci/images/primary/Dockerfile-3.4.0
+++ b/.circleci/images/primary/Dockerfile-3.4.0
@@ -1,6 +1,6 @@
 # Note: See the "Publishing updates to images" note in ./README.md for how to publish new builds of this container image
 
-FROM ruby:3.4.0-preview1-bookworm
+FROM ruby:3.4.0-preview2
 
 # Make apt non-interactive
 RUN echo 'APT::Get::Assume-Yes "true";' > /etc/apt/apt.conf.d/90circleci \


### PR DESCRIPTION
<!--
Check out the
https://github.com/DataDog/dd-trace-rb/blob/master/docs/DevelopmentGuide.md
for guidance on how to set up your development environment,
run the test suite, write new integrations, and more.
-->

**What does this PR do?**
This PR updates the Ruby 3.4 image for CI from `preview1-bookworm` to `preview2`.

**Motivation:**
I am progressively adding Ruby 3.4.0-preview2 support to our library. This PR will help push the new image to our ghcr.io.

**Change log entry**
No change log entry for now. Thinking to have a "Ruby 3.4.0-preview2 support added" update after it is fully supported.

**Additional Notes:**
<!-- Anything else we should know when reviewing? -->

**How to test the change?**
The "Build Ruby" CI step passes for the PR.

<!-- Unsure? Have a question? Request a review! -->
