### PR TITLE
Add permissions for publishing Ruby image

### DIFF
--- a/.github/workflows/build-ruby.yml
+++ b/.github/workflows/build-ruby.yml
@@ -57,6 +57,9 @@ jobs:
             dockerfile: Dockerfile-jruby-9.4.7.0
     runs-on: ubuntu-latest
     name: Build (${{ matrix.engine }} ${{ matrix.version }})
+    permissions:
+      contents: read
+      packages: write
     steps:
       - name: Checkout
         uses: actions/checkout@v4


### PR DESCRIPTION
<!--
Check out the
https://github.com/DataDog/dd-trace-rb/blob/master/docs/DevelopmentGuide.md
for guidance on how to set up your development environment,
run the test suite, write new integrations, and more.
-->

**What does this PR do?**
Adds permissions to `read contents` and `write packages`.

**Motivation:**
Given tightened restrictions from the Datadog security team on public repositories, we can no longer push images to `ghcr.io`. The change in this PR should address this issue by giving explicit permission to read contents and write packages.

**Change log entry**
N/A

**Additional Notes:**
N/A

**How to test the change?**
All CI tests should pass, and we should be able to push images to `ghcr.io` after this change.

<!-- Unsure? Have a question? Request a review! -->
