### PR TITLE
Revert Datadog testagent version from 1.18.0 to 1.12.0

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -107,7 +107,7 @@ test_containers:
     image: memcached:1.5-alpine
   - &memcached_port 11211
   - &container_testagent
-    image: ghcr.io/datadog/dd-apm-test-agent/ddapm-test-agent:v1.18.0
+    image: ghcr.io/datadog/dd-apm-test-agent/ddapm-test-agent:v1.12.0
     name: testagent
     environment:
       - LOG_LEVEL=DEBUG

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -203,7 +203,7 @@ services:
       - ddagent_var_run:/var/run/datadog
 
   testagent:
-    image: ghcr.io/datadog/dd-apm-test-agent/ddapm-test-agent:v1.18.0
+    image: ghcr.io/datadog/dd-apm-test-agent/ddapm-test-agent:v1.12.0
     ports:
         - "127.0.0.1:${DD_TRACE_AGENT_PORT}:9126"
     depends_on:


### PR DESCRIPTION
<!--
Check out the
https://github.com/DataDog/dd-trace-rb/blob/master/docs/DevelopmentGuide.md
for guidance on how to set up your development environment,
run the test suite, write new integrations, and more.
-->

**What does this PR do?**
This PR changes the Datadog testagent version from 1.18.0 back to 1.12.0 in the `docker-compose.yml` and `.circleci/config.yml`.

**Motivation:**
Testagent v1.18.0 causes local tracing parsing errors, such as: `ERROR -- datadog: [datadog] (/app/lib/datadog/tracing/transport/http/client.rb:42:in `rescue in send_request') Internal error during Datadog::Tracing::Transport::HTTP::Client request. Cause: JSON::ParserError unexpected token at '{"rate_by_service": {"service:,e' Location: /usr/local/bundle/gems/json-2.7.5/lib/json/common.rb:220:in `parse'`. No particular functionality of v1.18.0 was needed, and reverting the version to 1.12.0 fixes these errors.

**Change log entry**
No change log entry needed.

**Additional Notes:**
<!-- Anything else we should know when reviewing? -->

**How to test the change?**
To test this change, run `docker compose run --rm -it tracer-<version number> bash -c "rm *lock && bundle install && bundle exec rake spec:main"` locally. All tests should pass, whereas previously, you would see many tracing errors.

<!-- Unsure? Have a question? Request a review! -->
