### PR TITLE
[NO-TICKET] Upgrade to libdatadog 14.0

### DIFF
--- a/datadog.gemspec
+++ b/datadog.gemspec
@@ -69,7 +69,7 @@ Gem::Specification.new do |spec|
 
   # When updating the version here, please also update the version in `libdatadog_extconf_helpers.rb`
   # (and yes we have a test for it)
-  spec.add_dependency 'libdatadog', '~> 13.1.0.1.0'
+  spec.add_dependency 'libdatadog', '~> 14.0.0.1.0'
 
   spec.extensions = [
     'ext/datadog_profiling_native_extension/extconf.rb',

--- a/ext/libdatadog_api/crashtracker.c
+++ b/ext/libdatadog_api/crashtracker.c
@@ -67,7 +67,7 @@ static VALUE _native_start_or_update_on_fork(int argc, VALUE *argv, DDTRACE_UNUS
     // The Ruby crash handler also seems to get confused when this option is enabled and
     // "Process.kill('SEGV', Process.pid)" gets run.
     .create_alt_stack = false,
-    .use_alt_stack = false,
+    .use_alt_stack = true, // NOTE: This is a no-op in libdatadog 14.0; should be fixed in a future version
     .endpoint = endpoint,
     .resolve_frames = DDOG_CRASHT_STACKTRACE_COLLECTION_ENABLED_WITH_SYMBOLS_IN_RECEIVER,
     .timeout_ms = FIX2INT(upload_timeout_seconds) * 1000,

--- a/ext/libdatadog_api/crashtracker.c
+++ b/ext/libdatadog_api/crashtracker.c
@@ -67,12 +67,10 @@ static VALUE _native_start_or_update_on_fork(int argc, VALUE *argv, DDTRACE_UNUS
     // The Ruby crash handler also seems to get confused when this option is enabled and
     // "Process.kill('SEGV', Process.pid)" gets run.
     .create_alt_stack = false,
+    .use_alt_stack = false,
     .endpoint = endpoint,
     .resolve_frames = DDOG_CRASHT_STACKTRACE_COLLECTION_ENABLED_WITH_SYMBOLS_IN_RECEIVER,
-    .timeout_secs = FIX2INT(upload_timeout_seconds),
-    // Waits for crash tracker to finish reporting the issue before letting the Ruby process die; see
-    // https://github.com/DataDog/libdatadog/pull/477 for details
-    .wait_for_receiver = true,
+    .timeout_ms = FIX2INT(upload_timeout_seconds) * 1000,
   };
 
   ddog_crasht_Metadata metadata = {
@@ -97,7 +95,7 @@ static VALUE _native_start_or_update_on_fork(int argc, VALUE *argv, DDTRACE_UNUS
 
   ddog_crasht_Result result =
     action == start_action ?
-      ddog_crasht_init_with_receiver(config, receiver_config, metadata) :
+      ddog_crasht_init(config, receiver_config, metadata) :
       ddog_crasht_update_on_fork(config, receiver_config, metadata);
 
   // Clean up before potentially raising any exceptions

--- a/ext/libdatadog_extconf_helpers.rb
+++ b/ext/libdatadog_extconf_helpers.rb
@@ -8,7 +8,7 @@ module Datadog
   module LibdatadogExtconfHelpers
     # Used to make sure the correct gem version gets loaded, as extconf.rb does not get run with "bundle exec" and thus
     # may see multiple libdatadog versions. See https://github.com/DataDog/dd-trace-rb/pull/2531 for the horror story.
-    LIBDATADOG_VERSION = '~> 13.1.0.1.0'
+    LIBDATADOG_VERSION = '~> 14.0.0.1.0'
 
     # Used as an workaround for a limitation with how dynamic linking works in environments where the datadog gem and
     # libdatadog are moved after the extension gets compiled.

--- a/gemfiles/jruby_9.2_activesupport.gemfile.lock
+++ b/gemfiles/jruby_9.2_activesupport.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     datadog (2.4.0)
       datadog-ruby_core_source (~> 3.3)
-      libdatadog (~> 13.1.0.1.0)
+      libdatadog (~> 14.0.0.1.0)
       libddwaf (~> 1.15.0.0.0)
       msgpack
 
@@ -102,7 +102,7 @@ GEM
       addressable (>= 2.4)
     jsonapi-renderer (0.2.2)
     king_konf (1.0.1)
-    libdatadog (13.1.0.1.0)
+    libdatadog (14.0.0.1.0)
     libddwaf (1.15.0.0.0-java)
       ffi (~> 1.0)
     lograge (0.13.0)

--- a/gemfiles/jruby_9.2_aws.gemfile.lock
+++ b/gemfiles/jruby_9.2_aws.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     datadog (2.4.0)
       datadog-ruby_core_source (~> 3.3)
-      libdatadog (~> 13.1.0.1.0)
+      libdatadog (~> 14.0.0.1.0)
       libddwaf (~> 1.15.0.0.0)
       msgpack
 
@@ -1463,7 +1463,7 @@ GEM
     jmespath (1.6.2)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (13.1.0.1.0)
+    libdatadog (14.0.0.1.0)
     libddwaf (1.15.0.0.0-java)
       ffi (~> 1.0)
     memory_profiler (0.9.14)

--- a/gemfiles/jruby_9.2_contrib.gemfile.lock
+++ b/gemfiles/jruby_9.2_contrib.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     datadog (2.4.0)
       datadog-ruby_core_source (~> 3.3)
-      libdatadog (~> 13.1.0.1.0)
+      libdatadog (~> 14.0.0.1.0)
       libddwaf (~> 1.15.0.0.0)
       msgpack
 
@@ -50,7 +50,7 @@ GEM
       concurrent-ruby (~> 1.0)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (13.1.0.1.0)
+    libdatadog (14.0.0.1.0)
     libddwaf (1.15.0.0.0-java)
       ffi (~> 1.0)
     memory_profiler (0.9.14)

--- a/gemfiles/jruby_9.2_contrib_old.gemfile.lock
+++ b/gemfiles/jruby_9.2_contrib_old.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     datadog (2.4.0)
       datadog-ruby_core_source (~> 3.3)
-      libdatadog (~> 13.1.0.1.0)
+      libdatadog (~> 14.0.0.1.0)
       libddwaf (~> 1.15.0.0.0)
       msgpack
 
@@ -46,7 +46,7 @@ GEM
     hashdiff (1.0.1)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (13.1.0.1.0)
+    libdatadog (14.0.0.1.0)
     libddwaf (1.15.0.0.0-java)
       ffi (~> 1.0)
     memory_profiler (0.9.14)

--- a/gemfiles/jruby_9.2_core_old.gemfile.lock
+++ b/gemfiles/jruby_9.2_core_old.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     datadog (2.4.0)
       datadog-ruby_core_source (~> 3.3)
-      libdatadog (~> 13.1.0.1.0)
+      libdatadog (~> 14.0.0.1.0)
       libddwaf (~> 1.15.0.0.0)
       msgpack
 
@@ -41,7 +41,7 @@ GEM
     hashdiff (1.0.1)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (13.1.0.1.0)
+    libdatadog (14.0.0.1.0)
     libddwaf (1.15.0.0.0-java)
       ffi (~> 1.0)
     memory_profiler (0.9.14)

--- a/gemfiles/jruby_9.2_elasticsearch_7.gemfile.lock
+++ b/gemfiles/jruby_9.2_elasticsearch_7.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     datadog (2.4.0)
       datadog-ruby_core_source (~> 3.3)
-      libdatadog (~> 13.1.0.1.0)
+      libdatadog (~> 14.0.0.1.0)
       libddwaf (~> 1.15.0.0.0)
       msgpack
 
@@ -75,7 +75,7 @@ GEM
     hashdiff (1.0.1)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (13.1.0.1.0)
+    libdatadog (14.0.0.1.0)
     libddwaf (1.15.0.0.0-java)
       ffi (~> 1.0)
     memory_profiler (0.9.14)

--- a/gemfiles/jruby_9.2_elasticsearch_8.gemfile.lock
+++ b/gemfiles/jruby_9.2_elasticsearch_8.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     datadog (2.4.0)
       datadog-ruby_core_source (~> 3.3)
-      libdatadog (~> 13.1.0.1.0)
+      libdatadog (~> 14.0.0.1.0)
       libddwaf (~> 1.15.0.0.0)
       msgpack
 
@@ -73,7 +73,7 @@ GEM
     hashdiff (1.0.1)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (13.1.0.1.0)
+    libdatadog (14.0.0.1.0)
     libddwaf (1.15.0.0.0-java)
       ffi (~> 1.0)
     memory_profiler (0.9.14)

--- a/gemfiles/jruby_9.2_elasticsearch_latest.gemfile.lock
+++ b/gemfiles/jruby_9.2_elasticsearch_latest.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     datadog (2.4.0)
       datadog-ruby_core_source (~> 3.3)
-      libdatadog (~> 13.1.0.1.0)
+      libdatadog (~> 14.0.0.1.0)
       libddwaf (~> 1.15.0.0.0)
       msgpack
 
@@ -75,7 +75,7 @@ GEM
     hashdiff (1.1.1)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (13.1.0.1.0)
+    libdatadog (14.0.0.1.0)
     libddwaf (1.15.0.0.0-java)
       ffi (~> 1.0)
     memory_profiler (0.9.14)

--- a/gemfiles/jruby_9.2_graphql_2.0.gemfile.lock
+++ b/gemfiles/jruby_9.2_graphql_2.0.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     datadog (2.4.0)
       datadog-ruby_core_source (~> 3.3)
-      libdatadog (~> 13.1.0.1.0)
+      libdatadog (~> 14.0.0.1.0)
       libddwaf (~> 1.15.0.0.0)
       msgpack
 
@@ -112,7 +112,7 @@ GEM
     io-wait (0.3.1-java)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (13.1.0.1.0)
+    libdatadog (14.0.0.1.0)
     libddwaf (1.15.0.0.0-java)
       ffi (~> 1.0)
     lograge (0.14.0)

--- a/gemfiles/jruby_9.2_http.gemfile.lock
+++ b/gemfiles/jruby_9.2_http.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     datadog (2.4.0)
       datadog-ruby_core_source (~> 3.3)
-      libdatadog (~> 13.1.0.1.0)
+      libdatadog (~> 14.0.0.1.0)
       libddwaf (~> 1.15.0.0.0)
       msgpack
 
@@ -84,7 +84,7 @@ GEM
     httpclient (2.8.3)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (13.1.0.1.0)
+    libdatadog (14.0.0.1.0)
     libddwaf (1.15.0.0.0-java)
       ffi (~> 1.0)
     memory_profiler (0.9.14)

--- a/gemfiles/jruby_9.2_opensearch_2.gemfile.lock
+++ b/gemfiles/jruby_9.2_opensearch_2.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     datadog (2.4.0)
       datadog-ruby_core_source (~> 3.3)
-      libdatadog (~> 13.1.0.1.0)
+      libdatadog (~> 14.0.0.1.0)
       libddwaf (~> 1.15.0.0.0)
       msgpack
 
@@ -65,7 +65,7 @@ GEM
     hashdiff (1.0.1)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (13.1.0.1.0)
+    libdatadog (14.0.0.1.0)
     libddwaf (1.15.0.0.0-java)
       ffi (~> 1.0)
     memory_profiler (0.9.14)

--- a/gemfiles/jruby_9.2_opensearch_3.gemfile.lock
+++ b/gemfiles/jruby_9.2_opensearch_3.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     datadog (2.4.0)
       datadog-ruby_core_source (~> 3.3)
-      libdatadog (~> 13.1.0.1.0)
+      libdatadog (~> 14.0.0.1.0)
       libddwaf (~> 1.15.0.0.0)
       msgpack
 
@@ -65,7 +65,7 @@ GEM
     hashdiff (1.0.1)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (13.1.0.1.0)
+    libdatadog (14.0.0.1.0)
     libddwaf (1.15.0.0.0-java)
       ffi (~> 1.0)
     memory_profiler (0.9.14)

--- a/gemfiles/jruby_9.2_opensearch_latest.gemfile.lock
+++ b/gemfiles/jruby_9.2_opensearch_latest.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     datadog (2.4.0)
       datadog-ruby_core_source (~> 3.3)
-      libdatadog (~> 13.1.0.1.0)
+      libdatadog (~> 14.0.0.1.0)
       libddwaf (~> 1.15.0.0.0)
       msgpack
 
@@ -67,7 +67,7 @@ GEM
     hashdiff (1.1.1)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (13.1.0.1.0)
+    libdatadog (14.0.0.1.0)
     libddwaf (1.15.0.0.0-java)
       ffi (~> 1.0)
     memory_profiler (0.9.14)

--- a/gemfiles/jruby_9.2_rack_1.gemfile.lock
+++ b/gemfiles/jruby_9.2_rack_1.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     datadog (2.4.0)
       datadog-ruby_core_source (~> 3.3)
-      libdatadog (~> 13.1.0.1.0)
+      libdatadog (~> 14.0.0.1.0)
       libddwaf (~> 1.15.0.0.0)
       msgpack
 
@@ -41,7 +41,7 @@ GEM
     hashdiff (1.0.1)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (13.1.0.1.0)
+    libdatadog (14.0.0.1.0)
     libddwaf (1.15.0.0.0-java)
       ffi (~> 1.0)
     memory_profiler (0.9.14)

--- a/gemfiles/jruby_9.2_rack_2.gemfile.lock
+++ b/gemfiles/jruby_9.2_rack_2.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     datadog (2.4.0)
       datadog-ruby_core_source (~> 3.3)
-      libdatadog (~> 13.1.0.1.0)
+      libdatadog (~> 14.0.0.1.0)
       libddwaf (~> 1.15.0.0.0)
       msgpack
 
@@ -41,7 +41,7 @@ GEM
     hashdiff (1.0.1)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (13.1.0.1.0)
+    libdatadog (14.0.0.1.0)
     libddwaf (1.15.0.0.0-java)
       ffi (~> 1.0)
     memory_profiler (0.9.14)

--- a/gemfiles/jruby_9.2_rack_3.gemfile.lock
+++ b/gemfiles/jruby_9.2_rack_3.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     datadog (2.4.0)
       datadog-ruby_core_source (~> 3.3)
-      libdatadog (~> 13.1.0.1.0)
+      libdatadog (~> 14.0.0.1.0)
       libddwaf (~> 1.15.0.0.0)
       msgpack
 
@@ -41,7 +41,7 @@ GEM
     hashdiff (1.0.1)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (13.1.0.1.0)
+    libdatadog (14.0.0.1.0)
     libddwaf (1.15.0.0.0-java)
       ffi (~> 1.0)
     memory_profiler (0.9.14)

--- a/gemfiles/jruby_9.2_rack_latest.gemfile.lock
+++ b/gemfiles/jruby_9.2_rack_latest.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     datadog (2.4.0)
       datadog-ruby_core_source (~> 3.3)
-      libdatadog (~> 13.1.0.1.0)
+      libdatadog (~> 14.0.0.1.0)
       libddwaf (~> 1.15.0.0.0)
       msgpack
 
@@ -44,7 +44,7 @@ GEM
     hashdiff (1.1.1)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (13.1.0.1.0)
+    libdatadog (14.0.0.1.0)
     libddwaf (1.15.0.0.0-java)
       ffi (~> 1.0)
     memory_profiler (0.9.14)

--- a/gemfiles/jruby_9.2_rails5_mysql2.gemfile.lock
+++ b/gemfiles/jruby_9.2_rails5_mysql2.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     datadog (2.4.0)
       datadog-ruby_core_source (~> 3.3)
-      libdatadog (~> 13.1.0.1.0)
+      libdatadog (~> 14.0.0.1.0)
       libddwaf (~> 1.15.0.0.0)
       msgpack
 
@@ -96,7 +96,7 @@ GEM
     jdbc-mysql (8.0.27)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (13.1.0.1.0)
+    libdatadog (14.0.0.1.0)
     libddwaf (1.15.0.0.0-java)
       ffi (~> 1.0)
     lograge (0.12.0)

--- a/gemfiles/jruby_9.2_rails5_postgres.gemfile.lock
+++ b/gemfiles/jruby_9.2_rails5_postgres.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     datadog (2.4.0)
       datadog-ruby_core_source (~> 3.3)
-      libdatadog (~> 13.1.0.1.0)
+      libdatadog (~> 14.0.0.1.0)
       libddwaf (~> 1.15.0.0.0)
       msgpack
 
@@ -98,7 +98,7 @@ GEM
     jdbc-postgres (42.2.25)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (13.1.0.1.0)
+    libdatadog (14.0.0.1.0)
     libddwaf (1.15.0.0.0-java)
       ffi (~> 1.0)
     lograge (0.12.0)

--- a/gemfiles/jruby_9.2_rails5_postgres_redis.gemfile.lock
+++ b/gemfiles/jruby_9.2_rails5_postgres_redis.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     datadog (2.4.0)
       datadog-ruby_core_source (~> 3.3)
-      libdatadog (~> 13.1.0.1.0)
+      libdatadog (~> 14.0.0.1.0)
       libddwaf (~> 1.15.0.0.0)
       msgpack
 
@@ -99,7 +99,7 @@ GEM
     jdbc-postgres (42.2.25)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (13.1.0.1.0)
+    libdatadog (14.0.0.1.0)
     libddwaf (1.15.0.0.0-java)
       ffi (~> 1.0)
     lograge (0.12.0)

--- a/gemfiles/jruby_9.2_rails5_postgres_redis_activesupport.gemfile.lock
+++ b/gemfiles/jruby_9.2_rails5_postgres_redis_activesupport.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     datadog (2.4.0)
       datadog-ruby_core_source (~> 3.3)
-      libdatadog (~> 13.1.0.1.0)
+      libdatadog (~> 14.0.0.1.0)
       libddwaf (~> 1.15.0.0.0)
       msgpack
 
@@ -98,7 +98,7 @@ GEM
     jdbc-postgres (42.2.25)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (13.1.0.1.0)
+    libdatadog (14.0.0.1.0)
     libddwaf (1.15.0.0.0-java)
       ffi (~> 1.0)
     lograge (0.12.0)

--- a/gemfiles/jruby_9.2_rails5_postgres_sidekiq.gemfile.lock
+++ b/gemfiles/jruby_9.2_rails5_postgres_sidekiq.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     datadog (2.4.0)
       datadog-ruby_core_source (~> 3.3)
-      libdatadog (~> 13.1.0.1.0)
+      libdatadog (~> 14.0.0.1.0)
       libddwaf (~> 1.15.0.0.0)
       msgpack
 
@@ -99,7 +99,7 @@ GEM
     jdbc-postgres (42.2.25)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (13.1.0.1.0)
+    libdatadog (14.0.0.1.0)
     libddwaf (1.15.0.0.0-java)
       ffi (~> 1.0)
     lograge (0.12.0)

--- a/gemfiles/jruby_9.2_rails5_semantic_logger.gemfile.lock
+++ b/gemfiles/jruby_9.2_rails5_semantic_logger.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     datadog (2.4.0)
       datadog-ruby_core_source (~> 3.3)
-      libdatadog (~> 13.1.0.1.0)
+      libdatadog (~> 14.0.0.1.0)
       libddwaf (~> 1.15.0.0.0)
       msgpack
 
@@ -98,7 +98,7 @@ GEM
     jdbc-postgres (42.2.25)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (13.1.0.1.0)
+    libdatadog (14.0.0.1.0)
     libddwaf (1.15.0.0.0-java)
       ffi (~> 1.0)
     loofah (2.19.1)

--- a/gemfiles/jruby_9.2_rails61_mysql2.gemfile.lock
+++ b/gemfiles/jruby_9.2_rails61_mysql2.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     datadog (2.4.0)
       datadog-ruby_core_source (~> 3.3)
-      libdatadog (~> 13.1.0.1.0)
+      libdatadog (~> 14.0.0.1.0)
       libddwaf (~> 1.15.0.0.0)
       msgpack
 
@@ -113,7 +113,7 @@ GEM
     jdbc-mysql (8.0.27)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (13.1.0.1.0)
+    libdatadog (14.0.0.1.0)
     libddwaf (1.15.0.0.0-java)
       ffi (~> 1.0)
     lograge (0.12.0)

--- a/gemfiles/jruby_9.2_rails61_postgres.gemfile.lock
+++ b/gemfiles/jruby_9.2_rails61_postgres.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     datadog (2.4.0)
       datadog-ruby_core_source (~> 3.3)
-      libdatadog (~> 13.1.0.1.0)
+      libdatadog (~> 14.0.0.1.0)
       libddwaf (~> 1.15.0.0.0)
       msgpack
 
@@ -115,7 +115,7 @@ GEM
     jdbc-postgres (42.2.25)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (13.1.0.1.0)
+    libdatadog (14.0.0.1.0)
     libddwaf (1.15.0.0.0-java)
       ffi (~> 1.0)
     lograge (0.12.0)

--- a/gemfiles/jruby_9.2_rails61_postgres_redis.gemfile.lock
+++ b/gemfiles/jruby_9.2_rails61_postgres_redis.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     datadog (2.4.0)
       datadog-ruby_core_source (~> 3.3)
-      libdatadog (~> 13.1.0.1.0)
+      libdatadog (~> 14.0.0.1.0)
       libddwaf (~> 1.15.0.0.0)
       msgpack
 
@@ -116,7 +116,7 @@ GEM
     jdbc-postgres (42.2.25)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (13.1.0.1.0)
+    libdatadog (14.0.0.1.0)
     libddwaf (1.15.0.0.0-java)
       ffi (~> 1.0)
     lograge (0.12.0)

--- a/gemfiles/jruby_9.2_rails61_postgres_sidekiq.gemfile.lock
+++ b/gemfiles/jruby_9.2_rails61_postgres_sidekiq.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     datadog (2.4.0)
       datadog-ruby_core_source (~> 3.3)
-      libdatadog (~> 13.1.0.1.0)
+      libdatadog (~> 14.0.0.1.0)
       libddwaf (~> 1.15.0.0.0)
       msgpack
 
@@ -116,7 +116,7 @@ GEM
     jdbc-postgres (42.2.25)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (13.1.0.1.0)
+    libdatadog (14.0.0.1.0)
     libddwaf (1.15.0.0.0-java)
       ffi (~> 1.0)
     lograge (0.12.0)

--- a/gemfiles/jruby_9.2_rails61_semantic_logger.gemfile.lock
+++ b/gemfiles/jruby_9.2_rails61_semantic_logger.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     datadog (2.4.0)
       datadog-ruby_core_source (~> 3.3)
-      libdatadog (~> 13.1.0.1.0)
+      libdatadog (~> 14.0.0.1.0)
       libddwaf (~> 1.15.0.0.0)
       msgpack
 
@@ -115,7 +115,7 @@ GEM
     jdbc-postgres (42.2.25)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (13.1.0.1.0)
+    libdatadog (14.0.0.1.0)
     libddwaf (1.15.0.0.0-java)
       ffi (~> 1.0)
     loofah (2.19.1)

--- a/gemfiles/jruby_9.2_rails6_mysql2.gemfile.lock
+++ b/gemfiles/jruby_9.2_rails6_mysql2.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     datadog (2.4.0)
       datadog-ruby_core_source (~> 3.3)
-      libdatadog (~> 13.1.0.1.0)
+      libdatadog (~> 14.0.0.1.0)
       libddwaf (~> 1.15.0.0.0)
       msgpack
 
@@ -109,7 +109,7 @@ GEM
     jdbc-mysql (8.0.27)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (13.1.0.1.0)
+    libdatadog (14.0.0.1.0)
     libddwaf (1.15.0.0.0-java)
       ffi (~> 1.0)
     lograge (0.12.0)

--- a/gemfiles/jruby_9.2_rails6_postgres.gemfile.lock
+++ b/gemfiles/jruby_9.2_rails6_postgres.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     datadog (2.4.0)
       datadog-ruby_core_source (~> 3.3)
-      libdatadog (~> 13.1.0.1.0)
+      libdatadog (~> 14.0.0.1.0)
       libddwaf (~> 1.15.0.0.0)
       msgpack
 
@@ -111,7 +111,7 @@ GEM
     jdbc-postgres (42.2.25)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (13.1.0.1.0)
+    libdatadog (14.0.0.1.0)
     libddwaf (1.15.0.0.0-java)
       ffi (~> 1.0)
     lograge (0.12.0)

--- a/gemfiles/jruby_9.2_rails6_postgres_redis.gemfile.lock
+++ b/gemfiles/jruby_9.2_rails6_postgres_redis.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     datadog (2.4.0)
       datadog-ruby_core_source (~> 3.3)
-      libdatadog (~> 13.1.0.1.0)
+      libdatadog (~> 14.0.0.1.0)
       libddwaf (~> 1.15.0.0.0)
       msgpack
 
@@ -112,7 +112,7 @@ GEM
     jdbc-postgres (42.2.25)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (13.1.0.1.0)
+    libdatadog (14.0.0.1.0)
     libddwaf (1.15.0.0.0-java)
       ffi (~> 1.0)
     lograge (0.12.0)

--- a/gemfiles/jruby_9.2_rails6_postgres_redis_activesupport.gemfile.lock
+++ b/gemfiles/jruby_9.2_rails6_postgres_redis_activesupport.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     datadog (2.4.0)
       datadog-ruby_core_source (~> 3.3)
-      libdatadog (~> 13.1.0.1.0)
+      libdatadog (~> 14.0.0.1.0)
       libddwaf (~> 1.15.0.0.0)
       msgpack
 
@@ -111,7 +111,7 @@ GEM
     jdbc-postgres (42.2.25)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (13.1.0.1.0)
+    libdatadog (14.0.0.1.0)
     libddwaf (1.15.0.0.0-java)
       ffi (~> 1.0)
     lograge (0.12.0)

--- a/gemfiles/jruby_9.2_rails6_postgres_sidekiq.gemfile.lock
+++ b/gemfiles/jruby_9.2_rails6_postgres_sidekiq.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     datadog (2.4.0)
       datadog-ruby_core_source (~> 3.3)
-      libdatadog (~> 13.1.0.1.0)
+      libdatadog (~> 14.0.0.1.0)
       libddwaf (~> 1.15.0.0.0)
       msgpack
 
@@ -112,7 +112,7 @@ GEM
     jdbc-postgres (42.2.25)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (13.1.0.1.0)
+    libdatadog (14.0.0.1.0)
     libddwaf (1.15.0.0.0-java)
       ffi (~> 1.0)
     lograge (0.12.0)

--- a/gemfiles/jruby_9.2_rails6_semantic_logger.gemfile.lock
+++ b/gemfiles/jruby_9.2_rails6_semantic_logger.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     datadog (2.4.0)
       datadog-ruby_core_source (~> 3.3)
-      libdatadog (~> 13.1.0.1.0)
+      libdatadog (~> 14.0.0.1.0)
       libddwaf (~> 1.15.0.0.0)
       msgpack
 
@@ -111,7 +111,7 @@ GEM
     jdbc-postgres (42.2.25)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (13.1.0.1.0)
+    libdatadog (14.0.0.1.0)
     libddwaf (1.15.0.0.0-java)
       ffi (~> 1.0)
     loofah (2.19.1)

--- a/gemfiles/jruby_9.2_redis_3.gemfile.lock
+++ b/gemfiles/jruby_9.2_redis_3.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     datadog (2.4.0)
       datadog-ruby_core_source (~> 3.3)
-      libdatadog (~> 13.1.0.1.0)
+      libdatadog (~> 14.0.0.1.0)
       libddwaf (~> 1.15.0.0.0)
       msgpack
 
@@ -41,7 +41,7 @@ GEM
     hashdiff (1.0.1)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (13.1.0.1.0)
+    libdatadog (14.0.0.1.0)
     libddwaf (1.15.0.0.0-java)
       ffi (~> 1.0)
     memory_profiler (0.9.14)

--- a/gemfiles/jruby_9.2_redis_4.gemfile.lock
+++ b/gemfiles/jruby_9.2_redis_4.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     datadog (2.4.0)
       datadog-ruby_core_source (~> 3.3)
-      libdatadog (~> 13.1.0.1.0)
+      libdatadog (~> 14.0.0.1.0)
       libddwaf (~> 1.15.0.0.0)
       msgpack
 
@@ -41,7 +41,7 @@ GEM
     hashdiff (1.0.1)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (13.1.0.1.0)
+    libdatadog (14.0.0.1.0)
     libddwaf (1.15.0.0.0-java)
       ffi (~> 1.0)
     memory_profiler (0.9.14)

--- a/gemfiles/jruby_9.2_redis_5.gemfile.lock
+++ b/gemfiles/jruby_9.2_redis_5.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     datadog (2.4.0)
       datadog-ruby_core_source (~> 3.3)
-      libdatadog (~> 13.1.0.1.0)
+      libdatadog (~> 14.0.0.1.0)
       libddwaf (~> 1.15.0.0.0)
       msgpack
 
@@ -42,7 +42,7 @@ GEM
     hashdiff (1.0.1)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (13.1.0.1.0)
+    libdatadog (14.0.0.1.0)
     libddwaf (1.15.0.0.0-java)
       ffi (~> 1.0)
     memory_profiler (0.9.14)

--- a/gemfiles/jruby_9.2_relational_db.gemfile.lock
+++ b/gemfiles/jruby_9.2_relational_db.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     datadog (2.4.0)
       datadog-ruby_core_source (~> 3.3)
-      libdatadog (~> 13.1.0.1.0)
+      libdatadog (~> 14.0.0.1.0)
       libddwaf (~> 1.15.0.0.0)
       msgpack
 
@@ -75,7 +75,7 @@ GEM
     jdbc-sqlite3 (3.28.0)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (13.1.0.1.0)
+    libdatadog (14.0.0.1.0)
     libddwaf (1.15.0.0.0-java)
       ffi (~> 1.0)
     makara (0.5.1)

--- a/gemfiles/jruby_9.2_resque2_redis3.gemfile.lock
+++ b/gemfiles/jruby_9.2_resque2_redis3.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     datadog (2.4.0)
       datadog-ruby_core_source (~> 3.3)
-      libdatadog (~> 13.1.0.1.0)
+      libdatadog (~> 14.0.0.1.0)
       libddwaf (~> 1.15.0.0.0)
       msgpack
 
@@ -41,7 +41,7 @@ GEM
     hashdiff (1.0.1)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (13.1.0.1.0)
+    libdatadog (14.0.0.1.0)
     libddwaf (1.15.0.0.0-java)
       ffi (~> 1.0)
     memory_profiler (0.9.14)

--- a/gemfiles/jruby_9.2_resque2_redis4.gemfile.lock
+++ b/gemfiles/jruby_9.2_resque2_redis4.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     datadog (2.4.0)
       datadog-ruby_core_source (~> 3.3)
-      libdatadog (~> 13.1.0.1.0)
+      libdatadog (~> 14.0.0.1.0)
       libddwaf (~> 1.15.0.0.0)
       msgpack
 
@@ -42,7 +42,7 @@ GEM
     hashdiff (1.0.1)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (13.1.0.1.0)
+    libdatadog (14.0.0.1.0)
     libddwaf (1.15.0.0.0-java)
       ffi (~> 1.0)
     memory_profiler (0.9.14)

--- a/gemfiles/jruby_9.2_sinatra_2.gemfile.lock
+++ b/gemfiles/jruby_9.2_sinatra_2.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     datadog (2.4.0)
       datadog-ruby_core_source (~> 3.3)
-      libdatadog (~> 13.1.0.1.0)
+      libdatadog (~> 14.0.0.1.0)
       libddwaf (~> 1.15.0.0.0)
       msgpack
 
@@ -44,7 +44,7 @@ GEM
     hashdiff (1.1.0)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (13.1.0.1.0)
+    libdatadog (14.0.0.1.0)
     libddwaf (1.15.0.0.0-java)
       ffi (~> 1.0)
     memory_profiler (0.9.14)

--- a/gemfiles/jruby_9.2_stripe_10.gemfile.lock
+++ b/gemfiles/jruby_9.2_stripe_10.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     datadog (2.4.0)
       datadog-ruby_core_source (~> 3.3)
-      libdatadog (~> 13.1.0.1.0)
+      libdatadog (~> 14.0.0.1.0)
       libddwaf (~> 1.15.0.0.0)
       msgpack
 
@@ -44,7 +44,7 @@ GEM
     hashdiff (1.1.1)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (13.1.0.1.0)
+    libdatadog (14.0.0.1.0)
     libddwaf (1.15.0.0.0-java)
       ffi (~> 1.0)
     memory_profiler (0.9.14)

--- a/gemfiles/jruby_9.2_stripe_11.gemfile.lock
+++ b/gemfiles/jruby_9.2_stripe_11.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     datadog (2.4.0)
       datadog-ruby_core_source (~> 3.3)
-      libdatadog (~> 13.1.0.1.0)
+      libdatadog (~> 14.0.0.1.0)
       libddwaf (~> 1.15.0.0.0)
       msgpack
 
@@ -44,7 +44,7 @@ GEM
     hashdiff (1.1.1)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (13.1.0.1.0)
+    libdatadog (14.0.0.1.0)
     libddwaf (1.15.0.0.0-java)
       ffi (~> 1.0)
     memory_profiler (0.9.14)

--- a/gemfiles/jruby_9.2_stripe_12.gemfile.lock
+++ b/gemfiles/jruby_9.2_stripe_12.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     datadog (2.4.0)
       datadog-ruby_core_source (~> 3.3)
-      libdatadog (~> 13.1.0.1.0)
+      libdatadog (~> 14.0.0.1.0)
       libddwaf (~> 1.15.0.0.0)
       msgpack
 
@@ -44,7 +44,7 @@ GEM
     hashdiff (1.1.1)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (13.1.0.1.0)
+    libdatadog (14.0.0.1.0)
     libddwaf (1.15.0.0.0-java)
       ffi (~> 1.0)
     memory_profiler (0.9.14)

--- a/gemfiles/jruby_9.2_stripe_7.gemfile.lock
+++ b/gemfiles/jruby_9.2_stripe_7.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     datadog (2.4.0)
       datadog-ruby_core_source (~> 3.3)
-      libdatadog (~> 13.1.0.1.0)
+      libdatadog (~> 14.0.0.1.0)
       libddwaf (~> 1.15.0.0.0)
       msgpack
 
@@ -44,7 +44,7 @@ GEM
     hashdiff (1.1.1)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (13.1.0.1.0)
+    libdatadog (14.0.0.1.0)
     libddwaf (1.15.0.0.0-java)
       ffi (~> 1.0)
     memory_profiler (0.9.14)

--- a/gemfiles/jruby_9.2_stripe_8.gemfile.lock
+++ b/gemfiles/jruby_9.2_stripe_8.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     datadog (2.4.0)
       datadog-ruby_core_source (~> 3.3)
-      libdatadog (~> 13.1.0.1.0)
+      libdatadog (~> 14.0.0.1.0)
       libddwaf (~> 1.15.0.0.0)
       msgpack
 
@@ -44,7 +44,7 @@ GEM
     hashdiff (1.1.1)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (13.1.0.1.0)
+    libdatadog (14.0.0.1.0)
     libddwaf (1.15.0.0.0-java)
       ffi (~> 1.0)
     memory_profiler (0.9.14)

--- a/gemfiles/jruby_9.2_stripe_9.gemfile.lock
+++ b/gemfiles/jruby_9.2_stripe_9.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     datadog (2.4.0)
       datadog-ruby_core_source (~> 3.3)
-      libdatadog (~> 13.1.0.1.0)
+      libdatadog (~> 14.0.0.1.0)
       libddwaf (~> 1.15.0.0.0)
       msgpack
 
@@ -44,7 +44,7 @@ GEM
     hashdiff (1.1.1)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (13.1.0.1.0)
+    libdatadog (14.0.0.1.0)
     libddwaf (1.15.0.0.0-java)
       ffi (~> 1.0)
     memory_profiler (0.9.14)

--- a/gemfiles/jruby_9.2_stripe_latest.gemfile.lock
+++ b/gemfiles/jruby_9.2_stripe_latest.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     datadog (2.4.0)
       datadog-ruby_core_source (~> 3.3)
-      libdatadog (~> 13.1.0.1.0)
+      libdatadog (~> 14.0.0.1.0)
       libddwaf (~> 1.15.0.0.0)
       msgpack
 
@@ -44,7 +44,7 @@ GEM
     hashdiff (1.1.1)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (13.1.0.1.0)
+    libdatadog (14.0.0.1.0)
     libddwaf (1.15.0.0.0-java)
       ffi (~> 1.0)
     memory_profiler (0.9.14)

--- a/gemfiles/jruby_9.2_stripe_min.gemfile.lock
+++ b/gemfiles/jruby_9.2_stripe_min.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     datadog (2.4.0)
       datadog-ruby_core_source (~> 3.3)
-      libdatadog (~> 13.1.0.1.0)
+      libdatadog (~> 14.0.0.1.0)
       libddwaf (~> 1.15.0.0.0)
       msgpack
 
@@ -44,7 +44,7 @@ GEM
     hashdiff (1.1.1)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (13.1.0.1.0)
+    libdatadog (14.0.0.1.0)
     libddwaf (1.15.0.0.0-java)
       ffi (~> 1.0)
     memory_profiler (0.9.14)

--- a/gemfiles/jruby_9.3_activesupport.gemfile.lock
+++ b/gemfiles/jruby_9.3_activesupport.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     datadog (2.4.0)
       datadog-ruby_core_source (~> 3.3)
-      libdatadog (~> 13.1.0.1.0)
+      libdatadog (~> 14.0.0.1.0)
       libddwaf (~> 1.15.0.0.0)
       msgpack
 
@@ -105,7 +105,7 @@ GEM
       addressable (>= 2.4)
     jsonapi-renderer (0.2.2)
     king_konf (1.0.1)
-    libdatadog (13.1.0.1.0)
+    libdatadog (14.0.0.1.0)
     libddwaf (1.15.0.0.0-java)
       ffi (~> 1.0)
     lograge (0.13.0)

--- a/gemfiles/jruby_9.3_aws.gemfile.lock
+++ b/gemfiles/jruby_9.3_aws.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     datadog (2.4.0)
       datadog-ruby_core_source (~> 3.3)
-      libdatadog (~> 13.1.0.1.0)
+      libdatadog (~> 14.0.0.1.0)
       libddwaf (~> 1.15.0.0.0)
       msgpack
 
@@ -1465,7 +1465,7 @@ GEM
     json (2.6.3-java)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (13.1.0.1.0)
+    libdatadog (14.0.0.1.0)
     libddwaf (1.15.0.0.0-java)
       ffi (~> 1.0)
     memory_profiler (0.9.14)

--- a/gemfiles/jruby_9.3_contrib.gemfile.lock
+++ b/gemfiles/jruby_9.3_contrib.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     datadog (2.4.0)
       datadog-ruby_core_source (~> 3.3)
-      libdatadog (~> 13.1.0.1.0)
+      libdatadog (~> 14.0.0.1.0)
       libddwaf (~> 1.15.0.0.0)
       msgpack
 
@@ -50,7 +50,7 @@ GEM
     json (2.6.3-java)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (13.1.0.1.0)
+    libdatadog (14.0.0.1.0)
     libddwaf (1.15.0.0.0-java)
       ffi (~> 1.0)
     memory_profiler (0.9.14)

--- a/gemfiles/jruby_9.3_contrib_old.gemfile.lock
+++ b/gemfiles/jruby_9.3_contrib_old.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     datadog (2.4.0)
       datadog-ruby_core_source (~> 3.3)
-      libdatadog (~> 13.1.0.1.0)
+      libdatadog (~> 14.0.0.1.0)
       libddwaf (~> 1.15.0.0.0)
       msgpack
 
@@ -48,7 +48,7 @@ GEM
     json (2.6.3-java)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (13.1.0.1.0)
+    libdatadog (14.0.0.1.0)
     libddwaf (1.15.0.0.0-java)
       ffi (~> 1.0)
     memory_profiler (0.9.14)

--- a/gemfiles/jruby_9.3_core_old.gemfile.lock
+++ b/gemfiles/jruby_9.3_core_old.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     datadog (2.4.0)
       datadog-ruby_core_source (~> 3.3)
-      libdatadog (~> 13.1.0.1.0)
+      libdatadog (~> 14.0.0.1.0)
       libddwaf (~> 1.15.0.0.0)
       msgpack
 
@@ -43,7 +43,7 @@ GEM
     json (2.6.3-java)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (13.1.0.1.0)
+    libdatadog (14.0.0.1.0)
     libddwaf (1.15.0.0.0-java)
       ffi (~> 1.0)
     memory_profiler (0.9.14)

--- a/gemfiles/jruby_9.3_elasticsearch_7.gemfile.lock
+++ b/gemfiles/jruby_9.3_elasticsearch_7.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     datadog (2.4.0)
       datadog-ruby_core_source (~> 3.3)
-      libdatadog (~> 13.1.0.1.0)
+      libdatadog (~> 14.0.0.1.0)
       libddwaf (~> 1.15.0.0.0)
       msgpack
 
@@ -59,7 +59,7 @@ GEM
     json (2.6.3-java)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (13.1.0.1.0)
+    libdatadog (14.0.0.1.0)
     libddwaf (1.15.0.0.0-java)
       ffi (~> 1.0)
     memory_profiler (0.9.14)

--- a/gemfiles/jruby_9.3_elasticsearch_8.gemfile.lock
+++ b/gemfiles/jruby_9.3_elasticsearch_8.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     datadog (2.4.0)
       datadog-ruby_core_source (~> 3.3)
-      libdatadog (~> 13.1.0.1.0)
+      libdatadog (~> 14.0.0.1.0)
       libddwaf (~> 1.15.0.0.0)
       msgpack
 
@@ -58,7 +58,7 @@ GEM
     json (2.6.3-java)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (13.1.0.1.0)
+    libdatadog (14.0.0.1.0)
     libddwaf (1.15.0.0.0-java)
       ffi (~> 1.0)
     memory_profiler (0.9.14)

--- a/gemfiles/jruby_9.3_elasticsearch_latest.gemfile.lock
+++ b/gemfiles/jruby_9.3_elasticsearch_latest.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     datadog (2.4.0)
       datadog-ruby_core_source (~> 3.3)
-      libdatadog (~> 13.1.0.1.0)
+      libdatadog (~> 14.0.0.1.0)
       libddwaf (~> 1.15.0.0.0)
       msgpack
 
@@ -60,7 +60,7 @@ GEM
     json (2.7.2-java)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (13.1.0.1.0)
+    libdatadog (14.0.0.1.0)
     libddwaf (1.15.0.0.0-java)
       ffi (~> 1.0)
     memory_profiler (0.9.14)

--- a/gemfiles/jruby_9.3_graphql_1.13.gemfile.lock
+++ b/gemfiles/jruby_9.3_graphql_1.13.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     datadog (2.4.0)
       datadog-ruby_core_source (~> 3.3)
-      libdatadog (~> 13.1.0.1.0)
+      libdatadog (~> 14.0.0.1.0)
       libddwaf (~> 1.15.0.0.0)
       msgpack
 
@@ -113,7 +113,7 @@ GEM
     json (2.7.1-java)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (13.1.0.1.0)
+    libdatadog (14.0.0.1.0)
     libddwaf (1.15.0.0.0-java)
       ffi (~> 1.0)
     lograge (0.14.0)

--- a/gemfiles/jruby_9.3_graphql_2.0.gemfile.lock
+++ b/gemfiles/jruby_9.3_graphql_2.0.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     datadog (2.4.0)
       datadog-ruby_core_source (~> 3.3)
-      libdatadog (~> 13.1.0.1.0)
+      libdatadog (~> 14.0.0.1.0)
       libddwaf (~> 1.15.0.0.0)
       msgpack
 
@@ -113,7 +113,7 @@ GEM
     json (2.7.1-java)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (13.1.0.1.0)
+    libdatadog (14.0.0.1.0)
     libddwaf (1.15.0.0.0-java)
       ffi (~> 1.0)
     lograge (0.14.0)

--- a/gemfiles/jruby_9.3_http.gemfile.lock
+++ b/gemfiles/jruby_9.3_http.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     datadog (2.4.0)
       datadog-ruby_core_source (~> 3.3)
-      libdatadog (~> 13.1.0.1.0)
+      libdatadog (~> 14.0.0.1.0)
       libddwaf (~> 1.15.0.0.0)
       msgpack
 
@@ -67,7 +67,7 @@ GEM
     json (2.6.3-java)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (13.1.0.1.0)
+    libdatadog (14.0.0.1.0)
     libddwaf (1.15.0.0.0-java)
       ffi (~> 1.0)
     memory_profiler (0.9.14)

--- a/gemfiles/jruby_9.3_opensearch_2.gemfile.lock
+++ b/gemfiles/jruby_9.3_opensearch_2.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     datadog (2.4.0)
       datadog-ruby_core_source (~> 3.3)
-      libdatadog (~> 13.1.0.1.0)
+      libdatadog (~> 14.0.0.1.0)
       libddwaf (~> 1.15.0.0.0)
       msgpack
 
@@ -50,7 +50,7 @@ GEM
     json (2.6.3-java)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (13.1.0.1.0)
+    libdatadog (14.0.0.1.0)
     libddwaf (1.15.0.0.0-java)
       ffi (~> 1.0)
     memory_profiler (0.9.14)

--- a/gemfiles/jruby_9.3_opensearch_3.gemfile.lock
+++ b/gemfiles/jruby_9.3_opensearch_3.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     datadog (2.4.0)
       datadog-ruby_core_source (~> 3.3)
-      libdatadog (~> 13.1.0.1.0)
+      libdatadog (~> 14.0.0.1.0)
       libddwaf (~> 1.15.0.0.0)
       msgpack
 
@@ -50,7 +50,7 @@ GEM
     json (2.6.3-java)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (13.1.0.1.0)
+    libdatadog (14.0.0.1.0)
     libddwaf (1.15.0.0.0-java)
       ffi (~> 1.0)
     memory_profiler (0.9.14)

--- a/gemfiles/jruby_9.3_opensearch_latest.gemfile.lock
+++ b/gemfiles/jruby_9.3_opensearch_latest.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     datadog (2.4.0)
       datadog-ruby_core_source (~> 3.3)
-      libdatadog (~> 13.1.0.1.0)
+      libdatadog (~> 14.0.0.1.0)
       libddwaf (~> 1.15.0.0.0)
       msgpack
 
@@ -52,7 +52,7 @@ GEM
     json (2.7.2-java)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (13.1.0.1.0)
+    libdatadog (14.0.0.1.0)
     libddwaf (1.15.0.0.0-java)
       ffi (~> 1.0)
     memory_profiler (0.9.14)

--- a/gemfiles/jruby_9.3_rack_1.gemfile.lock
+++ b/gemfiles/jruby_9.3_rack_1.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     datadog (2.4.0)
       datadog-ruby_core_source (~> 3.3)
-      libdatadog (~> 13.1.0.1.0)
+      libdatadog (~> 14.0.0.1.0)
       libddwaf (~> 1.15.0.0.0)
       msgpack
 
@@ -43,7 +43,7 @@ GEM
     json (2.6.3-java)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (13.1.0.1.0)
+    libdatadog (14.0.0.1.0)
     libddwaf (1.15.0.0.0-java)
       ffi (~> 1.0)
     memory_profiler (0.9.14)

--- a/gemfiles/jruby_9.3_rack_2.gemfile.lock
+++ b/gemfiles/jruby_9.3_rack_2.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     datadog (2.4.0)
       datadog-ruby_core_source (~> 3.3)
-      libdatadog (~> 13.1.0.1.0)
+      libdatadog (~> 14.0.0.1.0)
       libddwaf (~> 1.15.0.0.0)
       msgpack
 
@@ -43,7 +43,7 @@ GEM
     json (2.6.3-java)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (13.1.0.1.0)
+    libdatadog (14.0.0.1.0)
     libddwaf (1.15.0.0.0-java)
       ffi (~> 1.0)
     memory_profiler (0.9.14)

--- a/gemfiles/jruby_9.3_rack_3.gemfile.lock
+++ b/gemfiles/jruby_9.3_rack_3.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     datadog (2.4.0)
       datadog-ruby_core_source (~> 3.3)
-      libdatadog (~> 13.1.0.1.0)
+      libdatadog (~> 14.0.0.1.0)
       libddwaf (~> 1.15.0.0.0)
       msgpack
 
@@ -43,7 +43,7 @@ GEM
     json (2.6.3-java)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (13.1.0.1.0)
+    libdatadog (14.0.0.1.0)
     libddwaf (1.15.0.0.0-java)
       ffi (~> 1.0)
     memory_profiler (0.9.14)

--- a/gemfiles/jruby_9.3_rack_latest.gemfile.lock
+++ b/gemfiles/jruby_9.3_rack_latest.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     datadog (2.4.0)
       datadog-ruby_core_source (~> 3.3)
-      libdatadog (~> 13.1.0.1.0)
+      libdatadog (~> 14.0.0.1.0)
       libddwaf (~> 1.15.0.0.0)
       msgpack
 
@@ -46,7 +46,7 @@ GEM
     json (2.7.2-java)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (13.1.0.1.0)
+    libdatadog (14.0.0.1.0)
     libddwaf (1.15.0.0.0-java)
       ffi (~> 1.0)
     memory_profiler (0.9.14)

--- a/gemfiles/jruby_9.3_rails5_mysql2.gemfile.lock
+++ b/gemfiles/jruby_9.3_rails5_mysql2.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     datadog (2.4.0)
       datadog-ruby_core_source (~> 3.3)
-      libdatadog (~> 13.1.0.1.0)
+      libdatadog (~> 14.0.0.1.0)
       libddwaf (~> 1.15.0.0.0)
       msgpack
 
@@ -99,7 +99,7 @@ GEM
     json (2.6.3-java)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (13.1.0.1.0)
+    libdatadog (14.0.0.1.0)
     libddwaf (1.15.0.0.0-java)
       ffi (~> 1.0)
     lograge (0.12.0)

--- a/gemfiles/jruby_9.3_rails5_postgres.gemfile.lock
+++ b/gemfiles/jruby_9.3_rails5_postgres.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     datadog (2.4.0)
       datadog-ruby_core_source (~> 3.3)
-      libdatadog (~> 13.1.0.1.0)
+      libdatadog (~> 14.0.0.1.0)
       libddwaf (~> 1.15.0.0.0)
       msgpack
 
@@ -99,7 +99,7 @@ GEM
     json (2.6.3-java)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (13.1.0.1.0)
+    libdatadog (14.0.0.1.0)
     libddwaf (1.15.0.0.0-java)
       ffi (~> 1.0)
     lograge (0.12.0)

--- a/gemfiles/jruby_9.3_rails5_postgres_redis.gemfile.lock
+++ b/gemfiles/jruby_9.3_rails5_postgres_redis.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     datadog (2.4.0)
       datadog-ruby_core_source (~> 3.3)
-      libdatadog (~> 13.1.0.1.0)
+      libdatadog (~> 14.0.0.1.0)
       libddwaf (~> 1.15.0.0.0)
       msgpack
 
@@ -99,7 +99,7 @@ GEM
     json (2.6.3-java)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (13.1.0.1.0)
+    libdatadog (14.0.0.1.0)
     libddwaf (1.15.0.0.0-java)
       ffi (~> 1.0)
     lograge (0.12.0)

--- a/gemfiles/jruby_9.3_rails5_postgres_redis_activesupport.gemfile.lock
+++ b/gemfiles/jruby_9.3_rails5_postgres_redis_activesupport.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     datadog (2.4.0)
       datadog-ruby_core_source (~> 3.3)
-      libdatadog (~> 13.1.0.1.0)
+      libdatadog (~> 14.0.0.1.0)
       libddwaf (~> 1.15.0.0.0)
       msgpack
 
@@ -99,7 +99,7 @@ GEM
     json (2.6.3-java)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (13.1.0.1.0)
+    libdatadog (14.0.0.1.0)
     libddwaf (1.15.0.0.0-java)
       ffi (~> 1.0)
     lograge (0.12.0)

--- a/gemfiles/jruby_9.3_rails5_postgres_sidekiq.gemfile.lock
+++ b/gemfiles/jruby_9.3_rails5_postgres_sidekiq.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     datadog (2.4.0)
       datadog-ruby_core_source (~> 3.3)
-      libdatadog (~> 13.1.0.1.0)
+      libdatadog (~> 14.0.0.1.0)
       libddwaf (~> 1.15.0.0.0)
       msgpack
 
@@ -100,7 +100,7 @@ GEM
     json (2.6.3-java)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (13.1.0.1.0)
+    libdatadog (14.0.0.1.0)
     libddwaf (1.15.0.0.0-java)
       ffi (~> 1.0)
     lograge (0.12.0)

--- a/gemfiles/jruby_9.3_rails5_semantic_logger.gemfile.lock
+++ b/gemfiles/jruby_9.3_rails5_semantic_logger.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     datadog (2.4.0)
       datadog-ruby_core_source (~> 3.3)
-      libdatadog (~> 13.1.0.1.0)
+      libdatadog (~> 14.0.0.1.0)
       libddwaf (~> 1.15.0.0.0)
       msgpack
 
@@ -99,7 +99,7 @@ GEM
     json (2.6.3-java)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (13.1.0.1.0)
+    libdatadog (14.0.0.1.0)
     libddwaf (1.15.0.0.0-java)
       ffi (~> 1.0)
     loofah (2.21.3)

--- a/gemfiles/jruby_9.3_rails61_mysql2.gemfile.lock
+++ b/gemfiles/jruby_9.3_rails61_mysql2.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     datadog (2.4.0)
       datadog-ruby_core_source (~> 3.3)
-      libdatadog (~> 13.1.0.1.0)
+      libdatadog (~> 14.0.0.1.0)
       libddwaf (~> 1.15.0.0.0)
       msgpack
 
@@ -116,7 +116,7 @@ GEM
     json (2.6.3-java)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (13.1.0.1.0)
+    libdatadog (14.0.0.1.0)
     libddwaf (1.15.0.0.0-java)
       ffi (~> 1.0)
     lograge (0.12.0)

--- a/gemfiles/jruby_9.3_rails61_postgres.gemfile.lock
+++ b/gemfiles/jruby_9.3_rails61_postgres.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     datadog (2.4.0)
       datadog-ruby_core_source (~> 3.3)
-      libdatadog (~> 13.1.0.1.0)
+      libdatadog (~> 14.0.0.1.0)
       libddwaf (~> 1.15.0.0.0)
       msgpack
 
@@ -116,7 +116,7 @@ GEM
     json (2.6.3-java)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (13.1.0.1.0)
+    libdatadog (14.0.0.1.0)
     libddwaf (1.15.0.0.0-java)
       ffi (~> 1.0)
     lograge (0.12.0)

--- a/gemfiles/jruby_9.3_rails61_postgres_redis.gemfile.lock
+++ b/gemfiles/jruby_9.3_rails61_postgres_redis.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     datadog (2.4.0)
       datadog-ruby_core_source (~> 3.3)
-      libdatadog (~> 13.1.0.1.0)
+      libdatadog (~> 14.0.0.1.0)
       libddwaf (~> 1.15.0.0.0)
       msgpack
 
@@ -116,7 +116,7 @@ GEM
     json (2.6.3-java)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (13.1.0.1.0)
+    libdatadog (14.0.0.1.0)
     libddwaf (1.15.0.0.0-java)
       ffi (~> 1.0)
     lograge (0.12.0)

--- a/gemfiles/jruby_9.3_rails61_postgres_sidekiq.gemfile.lock
+++ b/gemfiles/jruby_9.3_rails61_postgres_sidekiq.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     datadog (2.4.0)
       datadog-ruby_core_source (~> 3.3)
-      libdatadog (~> 13.1.0.1.0)
+      libdatadog (~> 14.0.0.1.0)
       libddwaf (~> 1.15.0.0.0)
       msgpack
 
@@ -117,7 +117,7 @@ GEM
     json (2.6.3-java)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (13.1.0.1.0)
+    libdatadog (14.0.0.1.0)
     libddwaf (1.15.0.0.0-java)
       ffi (~> 1.0)
     lograge (0.12.0)

--- a/gemfiles/jruby_9.3_rails61_semantic_logger.gemfile.lock
+++ b/gemfiles/jruby_9.3_rails61_semantic_logger.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     datadog (2.4.0)
       datadog-ruby_core_source (~> 3.3)
-      libdatadog (~> 13.1.0.1.0)
+      libdatadog (~> 14.0.0.1.0)
       libddwaf (~> 1.15.0.0.0)
       msgpack
 
@@ -116,7 +116,7 @@ GEM
     json (2.6.3-java)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (13.1.0.1.0)
+    libdatadog (14.0.0.1.0)
     libddwaf (1.15.0.0.0-java)
       ffi (~> 1.0)
     loofah (2.21.3)

--- a/gemfiles/jruby_9.3_rails6_mysql2.gemfile.lock
+++ b/gemfiles/jruby_9.3_rails6_mysql2.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     datadog (2.4.0)
       datadog-ruby_core_source (~> 3.3)
-      libdatadog (~> 13.1.0.1.0)
+      libdatadog (~> 14.0.0.1.0)
       libddwaf (~> 1.15.0.0.0)
       msgpack
 
@@ -112,7 +112,7 @@ GEM
     json (2.6.3-java)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (13.1.0.1.0)
+    libdatadog (14.0.0.1.0)
     libddwaf (1.15.0.0.0-java)
       ffi (~> 1.0)
     lograge (0.12.0)

--- a/gemfiles/jruby_9.3_rails6_postgres.gemfile.lock
+++ b/gemfiles/jruby_9.3_rails6_postgres.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     datadog (2.4.0)
       datadog-ruby_core_source (~> 3.3)
-      libdatadog (~> 13.1.0.1.0)
+      libdatadog (~> 14.0.0.1.0)
       libddwaf (~> 1.15.0.0.0)
       msgpack
 
@@ -112,7 +112,7 @@ GEM
     json (2.6.3-java)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (13.1.0.1.0)
+    libdatadog (14.0.0.1.0)
     libddwaf (1.15.0.0.0-java)
       ffi (~> 1.0)
     lograge (0.12.0)

--- a/gemfiles/jruby_9.3_rails6_postgres_redis.gemfile.lock
+++ b/gemfiles/jruby_9.3_rails6_postgres_redis.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     datadog (2.4.0)
       datadog-ruby_core_source (~> 3.3)
-      libdatadog (~> 13.1.0.1.0)
+      libdatadog (~> 14.0.0.1.0)
       libddwaf (~> 1.15.0.0.0)
       msgpack
 
@@ -112,7 +112,7 @@ GEM
     json (2.6.3-java)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (13.1.0.1.0)
+    libdatadog (14.0.0.1.0)
     libddwaf (1.15.0.0.0-java)
       ffi (~> 1.0)
     lograge (0.12.0)

--- a/gemfiles/jruby_9.3_rails6_postgres_redis_activesupport.gemfile.lock
+++ b/gemfiles/jruby_9.3_rails6_postgres_redis_activesupport.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     datadog (2.4.0)
       datadog-ruby_core_source (~> 3.3)
-      libdatadog (~> 13.1.0.1.0)
+      libdatadog (~> 14.0.0.1.0)
       libddwaf (~> 1.15.0.0.0)
       msgpack
 
@@ -112,7 +112,7 @@ GEM
     json (2.6.3-java)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (13.1.0.1.0)
+    libdatadog (14.0.0.1.0)
     libddwaf (1.15.0.0.0-java)
       ffi (~> 1.0)
     lograge (0.12.0)

--- a/gemfiles/jruby_9.3_rails6_postgres_sidekiq.gemfile.lock
+++ b/gemfiles/jruby_9.3_rails6_postgres_sidekiq.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     datadog (2.4.0)
       datadog-ruby_core_source (~> 3.3)
-      libdatadog (~> 13.1.0.1.0)
+      libdatadog (~> 14.0.0.1.0)
       libddwaf (~> 1.15.0.0.0)
       msgpack
 
@@ -113,7 +113,7 @@ GEM
     json (2.6.3-java)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (13.1.0.1.0)
+    libdatadog (14.0.0.1.0)
     libddwaf (1.15.0.0.0-java)
       ffi (~> 1.0)
     lograge (0.12.0)

--- a/gemfiles/jruby_9.3_rails6_semantic_logger.gemfile.lock
+++ b/gemfiles/jruby_9.3_rails6_semantic_logger.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     datadog (2.4.0)
       datadog-ruby_core_source (~> 3.3)
-      libdatadog (~> 13.1.0.1.0)
+      libdatadog (~> 14.0.0.1.0)
       libddwaf (~> 1.15.0.0.0)
       msgpack
 
@@ -112,7 +112,7 @@ GEM
     json (2.6.3-java)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (13.1.0.1.0)
+    libdatadog (14.0.0.1.0)
     libddwaf (1.15.0.0.0-java)
       ffi (~> 1.0)
     loofah (2.21.3)

--- a/gemfiles/jruby_9.3_redis_3.gemfile.lock
+++ b/gemfiles/jruby_9.3_redis_3.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     datadog (2.4.0)
       datadog-ruby_core_source (~> 3.3)
-      libdatadog (~> 13.1.0.1.0)
+      libdatadog (~> 14.0.0.1.0)
       libddwaf (~> 1.15.0.0.0)
       msgpack
 
@@ -43,7 +43,7 @@ GEM
     json (2.6.3-java)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (13.1.0.1.0)
+    libdatadog (14.0.0.1.0)
     libddwaf (1.15.0.0.0-java)
       ffi (~> 1.0)
     memory_profiler (0.9.14)

--- a/gemfiles/jruby_9.3_redis_4.gemfile.lock
+++ b/gemfiles/jruby_9.3_redis_4.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     datadog (2.4.0)
       datadog-ruby_core_source (~> 3.3)
-      libdatadog (~> 13.1.0.1.0)
+      libdatadog (~> 14.0.0.1.0)
       libddwaf (~> 1.15.0.0.0)
       msgpack
 
@@ -43,7 +43,7 @@ GEM
     json (2.6.3-java)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (13.1.0.1.0)
+    libdatadog (14.0.0.1.0)
     libddwaf (1.15.0.0.0-java)
       ffi (~> 1.0)
     memory_profiler (0.9.14)

--- a/gemfiles/jruby_9.3_redis_5.gemfile.lock
+++ b/gemfiles/jruby_9.3_redis_5.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     datadog (2.4.0)
       datadog-ruby_core_source (~> 3.3)
-      libdatadog (~> 13.1.0.1.0)
+      libdatadog (~> 14.0.0.1.0)
       libddwaf (~> 1.15.0.0.0)
       msgpack
 
@@ -44,7 +44,7 @@ GEM
     json (2.6.3-java)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (13.1.0.1.0)
+    libdatadog (14.0.0.1.0)
     libddwaf (1.15.0.0.0-java)
       ffi (~> 1.0)
     memory_profiler (0.9.14)

--- a/gemfiles/jruby_9.3_relational_db.gemfile.lock
+++ b/gemfiles/jruby_9.3_relational_db.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     datadog (2.4.0)
       datadog-ruby_core_source (~> 3.3)
-      libdatadog (~> 13.1.0.1.0)
+      libdatadog (~> 14.0.0.1.0)
       libddwaf (~> 1.15.0.0.0)
       msgpack
 
@@ -73,7 +73,7 @@ GEM
     json (2.6.3-java)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (13.1.0.1.0)
+    libdatadog (14.0.0.1.0)
     libddwaf (1.15.0.0.0-java)
       ffi (~> 1.0)
     makara (0.5.1)

--- a/gemfiles/jruby_9.3_resque2_redis3.gemfile.lock
+++ b/gemfiles/jruby_9.3_resque2_redis3.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     datadog (2.4.0)
       datadog-ruby_core_source (~> 3.3)
-      libdatadog (~> 13.1.0.1.0)
+      libdatadog (~> 14.0.0.1.0)
       libddwaf (~> 1.15.0.0.0)
       msgpack
 
@@ -43,7 +43,7 @@ GEM
     json (2.6.3-java)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (13.1.0.1.0)
+    libdatadog (14.0.0.1.0)
     libddwaf (1.15.0.0.0-java)
       ffi (~> 1.0)
     memory_profiler (0.9.14)

--- a/gemfiles/jruby_9.3_resque2_redis4.gemfile.lock
+++ b/gemfiles/jruby_9.3_resque2_redis4.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     datadog (2.4.0)
       datadog-ruby_core_source (~> 3.3)
-      libdatadog (~> 13.1.0.1.0)
+      libdatadog (~> 14.0.0.1.0)
       libddwaf (~> 1.15.0.0.0)
       msgpack
 
@@ -43,7 +43,7 @@ GEM
     json (2.6.3-java)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (13.1.0.1.0)
+    libdatadog (14.0.0.1.0)
     libddwaf (1.15.0.0.0-java)
       ffi (~> 1.0)
     memory_profiler (0.9.14)

--- a/gemfiles/jruby_9.3_sinatra_2.gemfile.lock
+++ b/gemfiles/jruby_9.3_sinatra_2.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     datadog (2.4.0)
       datadog-ruby_core_source (~> 3.3)
-      libdatadog (~> 13.1.0.1.0)
+      libdatadog (~> 14.0.0.1.0)
       libddwaf (~> 1.15.0.0.0)
       msgpack
 
@@ -46,7 +46,7 @@ GEM
     json (2.7.2-java)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (13.1.0.1.0)
+    libdatadog (14.0.0.1.0)
     libddwaf (1.15.0.0.0-java)
       ffi (~> 1.0)
     memory_profiler (0.9.14)

--- a/gemfiles/jruby_9.3_sinatra_3.gemfile.lock
+++ b/gemfiles/jruby_9.3_sinatra_3.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     datadog (2.4.0)
       datadog-ruby_core_source (~> 3.3)
-      libdatadog (~> 13.1.0.1.0)
+      libdatadog (~> 14.0.0.1.0)
       libddwaf (~> 1.15.0.0.0)
       msgpack
 
@@ -47,7 +47,7 @@ GEM
     json (2.7.2-java)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (13.1.0.1.0)
+    libdatadog (14.0.0.1.0)
     libddwaf (1.15.0.0.0-java)
       ffi (~> 1.0)
     memory_profiler (0.9.14)

--- a/gemfiles/jruby_9.3_stripe_10.gemfile.lock
+++ b/gemfiles/jruby_9.3_stripe_10.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     datadog (2.4.0)
       datadog-ruby_core_source (~> 3.3)
-      libdatadog (~> 13.1.0.1.0)
+      libdatadog (~> 14.0.0.1.0)
       libddwaf (~> 1.15.0.0.0)
       msgpack
 
@@ -46,7 +46,7 @@ GEM
     json (2.7.2-java)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (13.1.0.1.0)
+    libdatadog (14.0.0.1.0)
     libddwaf (1.15.0.0.0-java)
       ffi (~> 1.0)
     memory_profiler (0.9.14)

--- a/gemfiles/jruby_9.3_stripe_11.gemfile.lock
+++ b/gemfiles/jruby_9.3_stripe_11.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     datadog (2.4.0)
       datadog-ruby_core_source (~> 3.3)
-      libdatadog (~> 13.1.0.1.0)
+      libdatadog (~> 14.0.0.1.0)
       libddwaf (~> 1.15.0.0.0)
       msgpack
 
@@ -46,7 +46,7 @@ GEM
     json (2.7.2-java)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (13.1.0.1.0)
+    libdatadog (14.0.0.1.0)
     libddwaf (1.15.0.0.0-java)
       ffi (~> 1.0)
     memory_profiler (0.9.14)

--- a/gemfiles/jruby_9.3_stripe_12.gemfile.lock
+++ b/gemfiles/jruby_9.3_stripe_12.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     datadog (2.4.0)
       datadog-ruby_core_source (~> 3.3)
-      libdatadog (~> 13.1.0.1.0)
+      libdatadog (~> 14.0.0.1.0)
       libddwaf (~> 1.15.0.0.0)
       msgpack
 
@@ -46,7 +46,7 @@ GEM
     json (2.7.2-java)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (13.1.0.1.0)
+    libdatadog (14.0.0.1.0)
     libddwaf (1.15.0.0.0-java)
       ffi (~> 1.0)
     memory_profiler (0.9.14)

--- a/gemfiles/jruby_9.3_stripe_7.gemfile.lock
+++ b/gemfiles/jruby_9.3_stripe_7.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     datadog (2.4.0)
       datadog-ruby_core_source (~> 3.3)
-      libdatadog (~> 13.1.0.1.0)
+      libdatadog (~> 14.0.0.1.0)
       libddwaf (~> 1.15.0.0.0)
       msgpack
 
@@ -46,7 +46,7 @@ GEM
     json (2.7.2-java)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (13.1.0.1.0)
+    libdatadog (14.0.0.1.0)
     libddwaf (1.15.0.0.0-java)
       ffi (~> 1.0)
     memory_profiler (0.9.14)

--- a/gemfiles/jruby_9.3_stripe_8.gemfile.lock
+++ b/gemfiles/jruby_9.3_stripe_8.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     datadog (2.4.0)
       datadog-ruby_core_source (~> 3.3)
-      libdatadog (~> 13.1.0.1.0)
+      libdatadog (~> 14.0.0.1.0)
       libddwaf (~> 1.15.0.0.0)
       msgpack
 
@@ -46,7 +46,7 @@ GEM
     json (2.7.2-java)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (13.1.0.1.0)
+    libdatadog (14.0.0.1.0)
     libddwaf (1.15.0.0.0-java)
       ffi (~> 1.0)
     memory_profiler (0.9.14)

--- a/gemfiles/jruby_9.3_stripe_9.gemfile.lock
+++ b/gemfiles/jruby_9.3_stripe_9.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     datadog (2.4.0)
       datadog-ruby_core_source (~> 3.3)
-      libdatadog (~> 13.1.0.1.0)
+      libdatadog (~> 14.0.0.1.0)
       libddwaf (~> 1.15.0.0.0)
       msgpack
 
@@ -46,7 +46,7 @@ GEM
     json (2.7.2-java)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (13.1.0.1.0)
+    libdatadog (14.0.0.1.0)
     libddwaf (1.15.0.0.0-java)
       ffi (~> 1.0)
     memory_profiler (0.9.14)

--- a/gemfiles/jruby_9.3_stripe_latest.gemfile.lock
+++ b/gemfiles/jruby_9.3_stripe_latest.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     datadog (2.4.0)
       datadog-ruby_core_source (~> 3.3)
-      libdatadog (~> 13.1.0.1.0)
+      libdatadog (~> 14.0.0.1.0)
       libddwaf (~> 1.15.0.0.0)
       msgpack
 
@@ -46,7 +46,7 @@ GEM
     json (2.7.2-java)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (13.1.0.1.0)
+    libdatadog (14.0.0.1.0)
     libddwaf (1.15.0.0.0-java)
       ffi (~> 1.0)
     memory_profiler (0.9.14)

--- a/gemfiles/jruby_9.3_stripe_min.gemfile.lock
+++ b/gemfiles/jruby_9.3_stripe_min.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     datadog (2.4.0)
       datadog-ruby_core_source (~> 3.3)
-      libdatadog (~> 13.1.0.1.0)
+      libdatadog (~> 14.0.0.1.0)
       libddwaf (~> 1.15.0.0.0)
       msgpack
 
@@ -46,7 +46,7 @@ GEM
     json (2.7.2-java)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (13.1.0.1.0)
+    libdatadog (14.0.0.1.0)
     libddwaf (1.15.0.0.0-java)
       ffi (~> 1.0)
     memory_profiler (0.9.14)

--- a/gemfiles/jruby_9.4_activesupport.gemfile.lock
+++ b/gemfiles/jruby_9.4_activesupport.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     datadog (2.4.0)
       datadog-ruby_core_source (~> 3.3)
-      libdatadog (~> 13.1.0.1.0)
+      libdatadog (~> 14.0.0.1.0)
       libddwaf (~> 1.15.0.0.0)
       msgpack
 
@@ -100,7 +100,7 @@ GEM
       addressable (>= 2.4)
     jsonapi-renderer (0.2.2)
     king_konf (1.0.1)
-    libdatadog (13.1.0.1.0)
+    libdatadog (14.0.0.1.0)
     libddwaf (1.15.0.0.0-java)
       ffi (~> 1.0)
     lograge (0.13.0)

--- a/gemfiles/jruby_9.4_aws.gemfile.lock
+++ b/gemfiles/jruby_9.4_aws.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     datadog (2.4.0)
       datadog-ruby_core_source (~> 3.3)
-      libdatadog (~> 13.1.0.1.0)
+      libdatadog (~> 14.0.0.1.0)
       libddwaf (~> 1.15.0.0.0)
       msgpack
 
@@ -1465,7 +1465,7 @@ GEM
     json (2.6.3-java)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (13.1.0.1.0)
+    libdatadog (14.0.0.1.0)
     libddwaf (1.15.0.0.0-java)
       ffi (~> 1.0)
     memory_profiler (0.9.14)

--- a/gemfiles/jruby_9.4_contrib.gemfile.lock
+++ b/gemfiles/jruby_9.4_contrib.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     datadog (2.4.0)
       datadog-ruby_core_source (~> 3.3)
-      libdatadog (~> 13.1.0.1.0)
+      libdatadog (~> 14.0.0.1.0)
       libddwaf (~> 1.15.0.0.0)
       msgpack
 
@@ -50,7 +50,7 @@ GEM
     json (2.6.3-java)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (13.1.0.1.0)
+    libdatadog (14.0.0.1.0)
     libddwaf (1.15.0.0.0-java)
       ffi (~> 1.0)
     memory_profiler (0.9.14)

--- a/gemfiles/jruby_9.4_contrib_old.gemfile.lock
+++ b/gemfiles/jruby_9.4_contrib_old.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     datadog (2.4.0)
       datadog-ruby_core_source (~> 3.3)
-      libdatadog (~> 13.1.0.1.0)
+      libdatadog (~> 14.0.0.1.0)
       libddwaf (~> 1.15.0.0.0)
       msgpack
 
@@ -48,7 +48,7 @@ GEM
     json (2.6.3-java)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (13.1.0.1.0)
+    libdatadog (14.0.0.1.0)
     libddwaf (1.15.0.0.0-java)
       ffi (~> 1.0)
     memory_profiler (0.9.14)

--- a/gemfiles/jruby_9.4_core_old.gemfile.lock
+++ b/gemfiles/jruby_9.4_core_old.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     datadog (2.4.0)
       datadog-ruby_core_source (~> 3.3)
-      libdatadog (~> 13.1.0.1.0)
+      libdatadog (~> 14.0.0.1.0)
       libddwaf (~> 1.15.0.0.0)
       msgpack
 
@@ -43,7 +43,7 @@ GEM
     json (2.6.3-java)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (13.1.0.1.0)
+    libdatadog (14.0.0.1.0)
     libddwaf (1.15.0.0.0-java)
       ffi (~> 1.0)
     memory_profiler (0.9.14)

--- a/gemfiles/jruby_9.4_elasticsearch_7.gemfile.lock
+++ b/gemfiles/jruby_9.4_elasticsearch_7.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     datadog (2.4.0)
       datadog-ruby_core_source (~> 3.3)
-      libdatadog (~> 13.1.0.1.0)
+      libdatadog (~> 14.0.0.1.0)
       libddwaf (~> 1.15.0.0.0)
       msgpack
 
@@ -60,7 +60,7 @@ GEM
     json (2.7.5-java)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (13.1.0.1.0)
+    libdatadog (14.0.0.1.0)
     libddwaf (1.15.0.0.0-java)
       ffi (~> 1.0)
     logger (1.6.1)

--- a/gemfiles/jruby_9.4_elasticsearch_8.gemfile.lock
+++ b/gemfiles/jruby_9.4_elasticsearch_8.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     datadog (2.4.0)
       datadog-ruby_core_source (~> 3.3)
-      libdatadog (~> 13.1.0.1.0)
+      libdatadog (~> 14.0.0.1.0)
       libddwaf (~> 1.15.0.0.0)
       msgpack
 
@@ -58,7 +58,7 @@ GEM
     json (2.7.5-java)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (13.1.0.1.0)
+    libdatadog (14.0.0.1.0)
     libddwaf (1.15.0.0.0-java)
       ffi (~> 1.0)
     logger (1.6.1)

--- a/gemfiles/jruby_9.4_elasticsearch_latest.gemfile.lock
+++ b/gemfiles/jruby_9.4_elasticsearch_latest.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     datadog (2.4.0)
       datadog-ruby_core_source (~> 3.3)
-      libdatadog (~> 13.1.0.1.0)
+      libdatadog (~> 14.0.0.1.0)
       libddwaf (~> 1.15.0.0.0)
       msgpack
 
@@ -60,7 +60,7 @@ GEM
     json (2.7.5-java)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (13.1.0.1.0)
+    libdatadog (14.0.0.1.0)
     libddwaf (1.15.0.0.0-java)
       ffi (~> 1.0)
     logger (1.6.1)

--- a/gemfiles/jruby_9.4_graphql_1.13.gemfile.lock
+++ b/gemfiles/jruby_9.4_graphql_1.13.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     datadog (2.4.0)
       datadog-ruby_core_source (~> 3.3)
-      libdatadog (~> 13.1.0.1.0)
+      libdatadog (~> 14.0.0.1.0)
       libddwaf (~> 1.15.0.0.0)
       msgpack
 
@@ -113,7 +113,7 @@ GEM
     json (2.7.1-java)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (13.1.0.1.0)
+    libdatadog (14.0.0.1.0)
     libddwaf (1.15.0.0.0-java)
       ffi (~> 1.0)
     lograge (0.14.0)

--- a/gemfiles/jruby_9.4_graphql_2.0.gemfile.lock
+++ b/gemfiles/jruby_9.4_graphql_2.0.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     datadog (2.4.0)
       datadog-ruby_core_source (~> 3.3)
-      libdatadog (~> 13.1.0.1.0)
+      libdatadog (~> 14.0.0.1.0)
       libddwaf (~> 1.15.0.0.0)
       msgpack
 
@@ -113,7 +113,7 @@ GEM
     json (2.7.1-java)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (13.1.0.1.0)
+    libdatadog (14.0.0.1.0)
     libddwaf (1.15.0.0.0-java)
       ffi (~> 1.0)
     lograge (0.14.0)

--- a/gemfiles/jruby_9.4_graphql_2.1.gemfile.lock
+++ b/gemfiles/jruby_9.4_graphql_2.1.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     datadog (2.4.0)
       datadog-ruby_core_source (~> 3.3)
-      libdatadog (~> 13.1.0.1.0)
+      libdatadog (~> 14.0.0.1.0)
       libddwaf (~> 1.15.0.0.0)
       msgpack
 
@@ -114,7 +114,7 @@ GEM
     json (2.7.1-java)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (13.1.0.1.0)
+    libdatadog (14.0.0.1.0)
     libddwaf (1.15.0.0.0-java)
       ffi (~> 1.0)
     lograge (0.14.0)

--- a/gemfiles/jruby_9.4_graphql_2.2.gemfile.lock
+++ b/gemfiles/jruby_9.4_graphql_2.2.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     datadog (2.4.0)
       datadog-ruby_core_source (~> 3.3)
-      libdatadog (~> 13.1.0.1.0)
+      libdatadog (~> 14.0.0.1.0)
       libddwaf (~> 1.15.0.0.0)
       msgpack
 
@@ -114,7 +114,7 @@ GEM
     json (2.7.1-java)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (13.1.0.1.0)
+    libdatadog (14.0.0.1.0)
     libddwaf (1.15.0.0.0-java)
       ffi (~> 1.0)
     lograge (0.14.0)

--- a/gemfiles/jruby_9.4_graphql_2.3.gemfile.lock
+++ b/gemfiles/jruby_9.4_graphql_2.3.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     datadog (2.4.0)
       datadog-ruby_core_source (~> 3.3)
-      libdatadog (~> 13.1.0.1.0)
+      libdatadog (~> 14.0.0.1.0)
       libddwaf (~> 1.15.0.0.0)
       msgpack
 
@@ -116,7 +116,7 @@ GEM
     json (2.7.2-java)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (13.1.0.1.0)
+    libdatadog (14.0.0.1.0)
     libddwaf (1.15.0.0.0-java)
       ffi (~> 1.0)
     lograge (0.14.0)

--- a/gemfiles/jruby_9.4_http.gemfile.lock
+++ b/gemfiles/jruby_9.4_http.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     datadog (2.4.0)
       datadog-ruby_core_source (~> 3.3)
-      libdatadog (~> 13.1.0.1.0)
+      libdatadog (~> 14.0.0.1.0)
       libddwaf (~> 1.15.0.0.0)
       msgpack
 
@@ -67,7 +67,7 @@ GEM
     json (2.6.3-java)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (13.1.0.1.0)
+    libdatadog (14.0.0.1.0)
     libddwaf (1.15.0.0.0-java)
       ffi (~> 1.0)
     memory_profiler (0.9.14)

--- a/gemfiles/jruby_9.4_opensearch_2.gemfile.lock
+++ b/gemfiles/jruby_9.4_opensearch_2.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     datadog (2.4.0)
       datadog-ruby_core_source (~> 3.3)
-      libdatadog (~> 13.1.0.1.0)
+      libdatadog (~> 14.0.0.1.0)
       libddwaf (~> 1.15.0.0.0)
       msgpack
 
@@ -50,7 +50,7 @@ GEM
     json (2.7.5-java)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (13.1.0.1.0)
+    libdatadog (14.0.0.1.0)
     libddwaf (1.15.0.0.0-java)
       ffi (~> 1.0)
     logger (1.6.1)

--- a/gemfiles/jruby_9.4_opensearch_3.gemfile.lock
+++ b/gemfiles/jruby_9.4_opensearch_3.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     datadog (2.4.0)
       datadog-ruby_core_source (~> 3.3)
-      libdatadog (~> 13.1.0.1.0)
+      libdatadog (~> 14.0.0.1.0)
       libddwaf (~> 1.15.0.0.0)
       msgpack
 
@@ -50,7 +50,7 @@ GEM
     json (2.7.5-java)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (13.1.0.1.0)
+    libdatadog (14.0.0.1.0)
     libddwaf (1.15.0.0.0-java)
       ffi (~> 1.0)
     logger (1.6.1)

--- a/gemfiles/jruby_9.4_opensearch_latest.gemfile.lock
+++ b/gemfiles/jruby_9.4_opensearch_latest.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     datadog (2.4.0)
       datadog-ruby_core_source (~> 3.3)
-      libdatadog (~> 13.1.0.1.0)
+      libdatadog (~> 14.0.0.1.0)
       libddwaf (~> 1.15.0.0.0)
       msgpack
 
@@ -52,7 +52,7 @@ GEM
     json (2.7.5-java)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (13.1.0.1.0)
+    libdatadog (14.0.0.1.0)
     libddwaf (1.15.0.0.0-java)
       ffi (~> 1.0)
     logger (1.6.1)

--- a/gemfiles/jruby_9.4_rack_1.gemfile.lock
+++ b/gemfiles/jruby_9.4_rack_1.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     datadog (2.4.0)
       datadog-ruby_core_source (~> 3.3)
-      libdatadog (~> 13.1.0.1.0)
+      libdatadog (~> 14.0.0.1.0)
       libddwaf (~> 1.15.0.0.0)
       msgpack
 
@@ -43,7 +43,7 @@ GEM
     json (2.6.3-java)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (13.1.0.1.0)
+    libdatadog (14.0.0.1.0)
     libddwaf (1.15.0.0.0-java)
       ffi (~> 1.0)
     memory_profiler (0.9.14)

--- a/gemfiles/jruby_9.4_rack_2.gemfile.lock
+++ b/gemfiles/jruby_9.4_rack_2.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     datadog (2.4.0)
       datadog-ruby_core_source (~> 3.3)
-      libdatadog (~> 13.1.0.1.0)
+      libdatadog (~> 14.0.0.1.0)
       libddwaf (~> 1.15.0.0.0)
       msgpack
 
@@ -43,7 +43,7 @@ GEM
     json (2.6.3-java)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (13.1.0.1.0)
+    libdatadog (14.0.0.1.0)
     libddwaf (1.15.0.0.0-java)
       ffi (~> 1.0)
     memory_profiler (0.9.14)

--- a/gemfiles/jruby_9.4_rack_3.gemfile.lock
+++ b/gemfiles/jruby_9.4_rack_3.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     datadog (2.4.0)
       datadog-ruby_core_source (~> 3.3)
-      libdatadog (~> 13.1.0.1.0)
+      libdatadog (~> 14.0.0.1.0)
       libddwaf (~> 1.15.0.0.0)
       msgpack
 
@@ -43,7 +43,7 @@ GEM
     json (2.6.3-java)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (13.1.0.1.0)
+    libdatadog (14.0.0.1.0)
     libddwaf (1.15.0.0.0-java)
       ffi (~> 1.0)
     memory_profiler (0.9.14)

--- a/gemfiles/jruby_9.4_rack_latest.gemfile.lock
+++ b/gemfiles/jruby_9.4_rack_latest.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     datadog (2.4.0)
       datadog-ruby_core_source (~> 3.3)
-      libdatadog (~> 13.1.0.1.0)
+      libdatadog (~> 14.0.0.1.0)
       libddwaf (~> 1.15.0.0.0)
       msgpack
 
@@ -46,7 +46,7 @@ GEM
     json (2.7.2-java)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (13.1.0.1.0)
+    libdatadog (14.0.0.1.0)
     libddwaf (1.15.0.0.0-java)
       ffi (~> 1.0)
     memory_profiler (0.9.14)

--- a/gemfiles/jruby_9.4_rails61_mysql2.gemfile.lock
+++ b/gemfiles/jruby_9.4_rails61_mysql2.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     datadog (2.4.0)
       datadog-ruby_core_source (~> 3.3)
-      libdatadog (~> 13.1.0.1.0)
+      libdatadog (~> 14.0.0.1.0)
       libddwaf (~> 1.15.0.0.0)
       msgpack
 
@@ -120,7 +120,7 @@ GEM
     json (2.7.2-java)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (13.1.0.1.0)
+    libdatadog (14.0.0.1.0)
     libddwaf (1.15.0.0.0-java)
       ffi (~> 1.0)
     lograge (0.14.0)

--- a/gemfiles/jruby_9.4_rails61_postgres.gemfile.lock
+++ b/gemfiles/jruby_9.4_rails61_postgres.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     datadog (2.4.0)
       datadog-ruby_core_source (~> 3.3)
-      libdatadog (~> 13.1.0.1.0)
+      libdatadog (~> 14.0.0.1.0)
       libddwaf (~> 1.15.0.0.0)
       msgpack
 
@@ -116,7 +116,7 @@ GEM
     json (2.6.3-java)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (13.1.0.1.0)
+    libdatadog (14.0.0.1.0)
     libddwaf (1.15.0.0.0-java)
       ffi (~> 1.0)
     lograge (0.12.0)

--- a/gemfiles/jruby_9.4_rails61_postgres_redis.gemfile.lock
+++ b/gemfiles/jruby_9.4_rails61_postgres_redis.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     datadog (2.4.0)
       datadog-ruby_core_source (~> 3.3)
-      libdatadog (~> 13.1.0.1.0)
+      libdatadog (~> 14.0.0.1.0)
       libddwaf (~> 1.15.0.0.0)
       msgpack
 
@@ -116,7 +116,7 @@ GEM
     json (2.6.3-java)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (13.1.0.1.0)
+    libdatadog (14.0.0.1.0)
     libddwaf (1.15.0.0.0-java)
       ffi (~> 1.0)
     lograge (0.12.0)

--- a/gemfiles/jruby_9.4_rails61_postgres_sidekiq.gemfile.lock
+++ b/gemfiles/jruby_9.4_rails61_postgres_sidekiq.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     datadog (2.4.0)
       datadog-ruby_core_source (~> 3.3)
-      libdatadog (~> 13.1.0.1.0)
+      libdatadog (~> 14.0.0.1.0)
       libddwaf (~> 1.15.0.0.0)
       msgpack
 
@@ -117,7 +117,7 @@ GEM
     json (2.6.3-java)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (13.1.0.1.0)
+    libdatadog (14.0.0.1.0)
     libddwaf (1.15.0.0.0-java)
       ffi (~> 1.0)
     lograge (0.12.0)

--- a/gemfiles/jruby_9.4_rails61_semantic_logger.gemfile.lock
+++ b/gemfiles/jruby_9.4_rails61_semantic_logger.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     datadog (2.4.0)
       datadog-ruby_core_source (~> 3.3)
-      libdatadog (~> 13.1.0.1.0)
+      libdatadog (~> 14.0.0.1.0)
       libddwaf (~> 1.15.0.0.0)
       msgpack
 
@@ -116,7 +116,7 @@ GEM
     json (2.6.3-java)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (13.1.0.1.0)
+    libdatadog (14.0.0.1.0)
     libddwaf (1.15.0.0.0-java)
       ffi (~> 1.0)
     loofah (2.19.1)

--- a/gemfiles/jruby_9.4_redis_3.gemfile.lock
+++ b/gemfiles/jruby_9.4_redis_3.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     datadog (2.4.0)
       datadog-ruby_core_source (~> 3.3)
-      libdatadog (~> 13.1.0.1.0)
+      libdatadog (~> 14.0.0.1.0)
       libddwaf (~> 1.15.0.0.0)
       msgpack
 
@@ -43,7 +43,7 @@ GEM
     json (2.6.3-java)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (13.1.0.1.0)
+    libdatadog (14.0.0.1.0)
     libddwaf (1.15.0.0.0-java)
       ffi (~> 1.0)
     memory_profiler (0.9.14)

--- a/gemfiles/jruby_9.4_redis_4.gemfile.lock
+++ b/gemfiles/jruby_9.4_redis_4.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     datadog (2.4.0)
       datadog-ruby_core_source (~> 3.3)
-      libdatadog (~> 13.1.0.1.0)
+      libdatadog (~> 14.0.0.1.0)
       libddwaf (~> 1.15.0.0.0)
       msgpack
 
@@ -43,7 +43,7 @@ GEM
     json (2.6.3-java)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (13.1.0.1.0)
+    libdatadog (14.0.0.1.0)
     libddwaf (1.15.0.0.0-java)
       ffi (~> 1.0)
     memory_profiler (0.9.14)

--- a/gemfiles/jruby_9.4_redis_5.gemfile.lock
+++ b/gemfiles/jruby_9.4_redis_5.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     datadog (2.4.0)
       datadog-ruby_core_source (~> 3.3)
-      libdatadog (~> 13.1.0.1.0)
+      libdatadog (~> 14.0.0.1.0)
       libddwaf (~> 1.15.0.0.0)
       msgpack
 
@@ -44,7 +44,7 @@ GEM
     json (2.6.3-java)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (13.1.0.1.0)
+    libdatadog (14.0.0.1.0)
     libddwaf (1.15.0.0.0-java)
       ffi (~> 1.0)
     memory_profiler (0.9.14)

--- a/gemfiles/jruby_9.4_relational_db.gemfile.lock
+++ b/gemfiles/jruby_9.4_relational_db.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     datadog (2.4.0)
       datadog-ruby_core_source (~> 3.3)
-      libdatadog (~> 13.1.0.1.0)
+      libdatadog (~> 14.0.0.1.0)
       libddwaf (~> 1.15.0.0.0)
       msgpack
 
@@ -75,7 +75,7 @@ GEM
     json (2.7.2-java)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (13.1.0.1.0)
+    libdatadog (14.0.0.1.0)
     libddwaf (1.15.0.0.0-java)
       ffi (~> 1.0)
     makara (0.6.0.pre)

--- a/gemfiles/jruby_9.4_resque2_redis3.gemfile.lock
+++ b/gemfiles/jruby_9.4_resque2_redis3.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     datadog (2.4.0)
       datadog-ruby_core_source (~> 3.3)
-      libdatadog (~> 13.1.0.1.0)
+      libdatadog (~> 14.0.0.1.0)
       libddwaf (~> 1.15.0.0.0)
       msgpack
 
@@ -43,7 +43,7 @@ GEM
     json (2.6.3-java)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (13.1.0.1.0)
+    libdatadog (14.0.0.1.0)
     libddwaf (1.15.0.0.0-java)
       ffi (~> 1.0)
     memory_profiler (0.9.14)

--- a/gemfiles/jruby_9.4_resque2_redis4.gemfile.lock
+++ b/gemfiles/jruby_9.4_resque2_redis4.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     datadog (2.4.0)
       datadog-ruby_core_source (~> 3.3)
-      libdatadog (~> 13.1.0.1.0)
+      libdatadog (~> 14.0.0.1.0)
       libddwaf (~> 1.15.0.0.0)
       msgpack
 
@@ -44,7 +44,7 @@ GEM
     json (2.6.3-java)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (13.1.0.1.0)
+    libdatadog (14.0.0.1.0)
     libddwaf (1.15.0.0.0-java)
       ffi (~> 1.0)
     memory_profiler (0.9.14)

--- a/gemfiles/jruby_9.4_sinatra_2.gemfile.lock
+++ b/gemfiles/jruby_9.4_sinatra_2.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     datadog (2.4.0)
       datadog-ruby_core_source (~> 3.3)
-      libdatadog (~> 13.1.0.1.0)
+      libdatadog (~> 14.0.0.1.0)
       libddwaf (~> 1.15.0.0.0)
       msgpack
 
@@ -46,7 +46,7 @@ GEM
     json (2.7.2-java)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (13.1.0.1.0)
+    libdatadog (14.0.0.1.0)
     libddwaf (1.15.0.0.0-java)
       ffi (~> 1.0)
     memory_profiler (0.9.14)

--- a/gemfiles/jruby_9.4_sinatra_3.gemfile.lock
+++ b/gemfiles/jruby_9.4_sinatra_3.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     datadog (2.4.0)
       datadog-ruby_core_source (~> 3.3)
-      libdatadog (~> 13.1.0.1.0)
+      libdatadog (~> 14.0.0.1.0)
       libddwaf (~> 1.15.0.0.0)
       msgpack
 
@@ -47,7 +47,7 @@ GEM
     json (2.7.2-java)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (13.1.0.1.0)
+    libdatadog (14.0.0.1.0)
     libddwaf (1.15.0.0.0-java)
       ffi (~> 1.0)
     memory_profiler (0.9.14)

--- a/gemfiles/jruby_9.4_sinatra_4.gemfile.lock
+++ b/gemfiles/jruby_9.4_sinatra_4.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     datadog (2.4.0)
       datadog-ruby_core_source (~> 3.3)
-      libdatadog (~> 13.1.0.1.0)
+      libdatadog (~> 14.0.0.1.0)
       libddwaf (~> 1.15.0.0.0)
       msgpack
 
@@ -47,7 +47,7 @@ GEM
     json (2.7.2-java)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (13.1.0.1.0)
+    libdatadog (14.0.0.1.0)
     libddwaf (1.15.0.0.0-java)
       ffi (~> 1.0)
     memory_profiler (0.9.14)

--- a/gemfiles/jruby_9.4_stripe_10.gemfile.lock
+++ b/gemfiles/jruby_9.4_stripe_10.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     datadog (2.4.0)
       datadog-ruby_core_source (~> 3.3)
-      libdatadog (~> 13.1.0.1.0)
+      libdatadog (~> 14.0.0.1.0)
       libddwaf (~> 1.15.0.0.0)
       msgpack
 
@@ -46,7 +46,7 @@ GEM
     json (2.7.2-java)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (13.1.0.1.0)
+    libdatadog (14.0.0.1.0)
     libddwaf (1.15.0.0.0-java)
       ffi (~> 1.0)
     memory_profiler (0.9.14)

--- a/gemfiles/jruby_9.4_stripe_11.gemfile.lock
+++ b/gemfiles/jruby_9.4_stripe_11.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     datadog (2.4.0)
       datadog-ruby_core_source (~> 3.3)
-      libdatadog (~> 13.1.0.1.0)
+      libdatadog (~> 14.0.0.1.0)
       libddwaf (~> 1.15.0.0.0)
       msgpack
 
@@ -46,7 +46,7 @@ GEM
     json (2.7.2-java)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (13.1.0.1.0)
+    libdatadog (14.0.0.1.0)
     libddwaf (1.15.0.0.0-java)
       ffi (~> 1.0)
     memory_profiler (0.9.14)

--- a/gemfiles/jruby_9.4_stripe_12.gemfile.lock
+++ b/gemfiles/jruby_9.4_stripe_12.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     datadog (2.4.0)
       datadog-ruby_core_source (~> 3.3)
-      libdatadog (~> 13.1.0.1.0)
+      libdatadog (~> 14.0.0.1.0)
       libddwaf (~> 1.15.0.0.0)
       msgpack
 
@@ -46,7 +46,7 @@ GEM
     json (2.7.2-java)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (13.1.0.1.0)
+    libdatadog (14.0.0.1.0)
     libddwaf (1.15.0.0.0-java)
       ffi (~> 1.0)
     memory_profiler (0.9.14)

--- a/gemfiles/jruby_9.4_stripe_7.gemfile.lock
+++ b/gemfiles/jruby_9.4_stripe_7.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     datadog (2.4.0)
       datadog-ruby_core_source (~> 3.3)
-      libdatadog (~> 13.1.0.1.0)
+      libdatadog (~> 14.0.0.1.0)
       libddwaf (~> 1.15.0.0.0)
       msgpack
 
@@ -46,7 +46,7 @@ GEM
     json (2.7.2-java)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (13.1.0.1.0)
+    libdatadog (14.0.0.1.0)
     libddwaf (1.15.0.0.0-java)
       ffi (~> 1.0)
     memory_profiler (0.9.14)

--- a/gemfiles/jruby_9.4_stripe_8.gemfile.lock
+++ b/gemfiles/jruby_9.4_stripe_8.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     datadog (2.4.0)
       datadog-ruby_core_source (~> 3.3)
-      libdatadog (~> 13.1.0.1.0)
+      libdatadog (~> 14.0.0.1.0)
       libddwaf (~> 1.15.0.0.0)
       msgpack
 
@@ -46,7 +46,7 @@ GEM
     json (2.7.2-java)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (13.1.0.1.0)
+    libdatadog (14.0.0.1.0)
     libddwaf (1.15.0.0.0-java)
       ffi (~> 1.0)
     memory_profiler (0.9.14)

--- a/gemfiles/jruby_9.4_stripe_9.gemfile.lock
+++ b/gemfiles/jruby_9.4_stripe_9.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     datadog (2.4.0)
       datadog-ruby_core_source (~> 3.3)
-      libdatadog (~> 13.1.0.1.0)
+      libdatadog (~> 14.0.0.1.0)
       libddwaf (~> 1.15.0.0.0)
       msgpack
 
@@ -46,7 +46,7 @@ GEM
     json (2.7.2-java)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (13.1.0.1.0)
+    libdatadog (14.0.0.1.0)
     libddwaf (1.15.0.0.0-java)
       ffi (~> 1.0)
     memory_profiler (0.9.14)

--- a/gemfiles/jruby_9.4_stripe_latest.gemfile.lock
+++ b/gemfiles/jruby_9.4_stripe_latest.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     datadog (2.4.0)
       datadog-ruby_core_source (~> 3.3)
-      libdatadog (~> 13.1.0.1.0)
+      libdatadog (~> 14.0.0.1.0)
       libddwaf (~> 1.15.0.0.0)
       msgpack
 
@@ -46,7 +46,7 @@ GEM
     json (2.7.2-java)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (13.1.0.1.0)
+    libdatadog (14.0.0.1.0)
     libddwaf (1.15.0.0.0-java)
       ffi (~> 1.0)
     memory_profiler (0.9.14)

--- a/gemfiles/jruby_9.4_stripe_min.gemfile.lock
+++ b/gemfiles/jruby_9.4_stripe_min.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     datadog (2.4.0)
       datadog-ruby_core_source (~> 3.3)
-      libdatadog (~> 13.1.0.1.0)
+      libdatadog (~> 14.0.0.1.0)
       libddwaf (~> 1.15.0.0.0)
       msgpack
 
@@ -46,7 +46,7 @@ GEM
     json (2.7.2-java)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (13.1.0.1.0)
+    libdatadog (14.0.0.1.0)
     libddwaf (1.15.0.0.0-java)
       ffi (~> 1.0)
     memory_profiler (0.9.14)

--- a/gemfiles/ruby_2.5_activesupport.gemfile.lock
+++ b/gemfiles/ruby_2.5_activesupport.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     datadog (2.4.0)
       datadog-ruby_core_source (~> 3.3)
-      libdatadog (~> 13.1.0.1.0)
+      libdatadog (~> 14.0.0.1.0)
       libddwaf (~> 1.15.0.0.0)
       msgpack
 
@@ -109,8 +109,8 @@ GEM
       addressable (>= 2.4)
     jsonapi-renderer (0.2.2)
     king_konf (1.0.1)
-    libdatadog (13.1.0.1.0-aarch64-linux)
-    libdatadog (13.1.0.1.0-x86_64-linux)
+    libdatadog (14.0.0.1.0-aarch64-linux)
+    libdatadog (14.0.0.1.0-x86_64-linux)
     libddwaf (1.15.0.0.0-aarch64-linux)
       ffi (~> 1.0)
     libddwaf (1.15.0.0.0-x86_64-linux)

--- a/gemfiles/ruby_2.5_aws.gemfile.lock
+++ b/gemfiles/ruby_2.5_aws.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     datadog (2.4.0)
       datadog-ruby_core_source (~> 3.3)
-      libdatadog (~> 13.1.0.1.0)
+      libdatadog (~> 14.0.0.1.0)
       libddwaf (~> 1.15.0.0.0)
       msgpack
 
@@ -1470,8 +1470,8 @@ GEM
     jmespath (1.6.2)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (13.1.0.1.0-aarch64-linux)
-    libdatadog (13.1.0.1.0-x86_64-linux)
+    libdatadog (14.0.0.1.0-aarch64-linux)
+    libdatadog (14.0.0.1.0-x86_64-linux)
     libddwaf (1.15.0.0.0-aarch64-linux)
       ffi (~> 1.0)
     libddwaf (1.15.0.0.0-x86_64-linux)

--- a/gemfiles/ruby_2.5_contrib.gemfile.lock
+++ b/gemfiles/ruby_2.5_contrib.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     datadog (2.4.0)
       datadog-ruby_core_source (~> 3.3)
-      libdatadog (~> 13.1.0.1.0)
+      libdatadog (~> 14.0.0.1.0)
       libddwaf (~> 1.15.0.0.0)
       msgpack
 
@@ -63,8 +63,8 @@ GEM
     hashdiff (1.0.1)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (13.1.0.1.0-aarch64-linux)
-    libdatadog (13.1.0.1.0-x86_64-linux)
+    libdatadog (14.0.0.1.0-aarch64-linux)
+    libdatadog (14.0.0.1.0-x86_64-linux)
     libddwaf (1.15.0.0.0-aarch64-linux)
       ffi (~> 1.0)
     libddwaf (1.15.0.0.0-x86_64-linux)

--- a/gemfiles/ruby_2.5_contrib_old.gemfile.lock
+++ b/gemfiles/ruby_2.5_contrib_old.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     datadog (2.4.0)
       datadog-ruby_core_source (~> 3.3)
-      libdatadog (~> 13.1.0.1.0)
+      libdatadog (~> 14.0.0.1.0)
       libddwaf (~> 1.15.0.0.0)
       msgpack
 
@@ -59,8 +59,8 @@ GEM
     hitimes (1.3.1)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (13.1.0.1.0-aarch64-linux)
-    libdatadog (13.1.0.1.0-x86_64-linux)
+    libdatadog (14.0.0.1.0-aarch64-linux)
+    libdatadog (14.0.0.1.0-x86_64-linux)
     libddwaf (1.15.0.0.0-aarch64-linux)
       ffi (~> 1.0)
     libddwaf (1.15.0.0.0-x86_64-linux)

--- a/gemfiles/ruby_2.5_core_old.gemfile.lock
+++ b/gemfiles/ruby_2.5_core_old.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     datadog (2.4.0)
       datadog-ruby_core_source (~> 3.3)
-      libdatadog (~> 13.1.0.1.0)
+      libdatadog (~> 14.0.0.1.0)
       libddwaf (~> 1.15.0.0.0)
       msgpack
 
@@ -48,8 +48,8 @@ GEM
     hashdiff (1.0.1)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (13.1.0.1.0-aarch64-linux)
-    libdatadog (13.1.0.1.0-x86_64-linux)
+    libdatadog (14.0.0.1.0-aarch64-linux)
+    libdatadog (14.0.0.1.0-x86_64-linux)
     libddwaf (1.15.0.0.0-aarch64-linux)
       ffi (~> 1.0)
     libddwaf (1.15.0.0.0-x86_64-linux)

--- a/gemfiles/ruby_2.5_elasticsearch_7.gemfile.lock
+++ b/gemfiles/ruby_2.5_elasticsearch_7.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     datadog (2.4.0)
       datadog-ruby_core_source (~> 3.3)
-      libdatadog (~> 13.1.0.1.0)
+      libdatadog (~> 14.0.0.1.0)
       libddwaf (~> 1.15.0.0.0)
       msgpack
 
@@ -82,8 +82,8 @@ GEM
     hashdiff (1.0.1)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (13.1.0.1.0-aarch64-linux)
-    libdatadog (13.1.0.1.0-x86_64-linux)
+    libdatadog (14.0.0.1.0-aarch64-linux)
+    libdatadog (14.0.0.1.0-x86_64-linux)
     libddwaf (1.15.0.0.0-aarch64-linux)
       ffi (~> 1.0)
     libddwaf (1.15.0.0.0-x86_64-linux)

--- a/gemfiles/ruby_2.5_elasticsearch_8.gemfile.lock
+++ b/gemfiles/ruby_2.5_elasticsearch_8.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     datadog (2.4.0)
       datadog-ruby_core_source (~> 3.3)
-      libdatadog (~> 13.1.0.1.0)
+      libdatadog (~> 14.0.0.1.0)
       libddwaf (~> 1.15.0.0.0)
       msgpack
 
@@ -80,8 +80,8 @@ GEM
     hashdiff (1.0.1)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (13.1.0.1.0-aarch64-linux)
-    libdatadog (13.1.0.1.0-x86_64-linux)
+    libdatadog (14.0.0.1.0-aarch64-linux)
+    libdatadog (14.0.0.1.0-x86_64-linux)
     libddwaf (1.15.0.0.0-aarch64-linux)
       ffi (~> 1.0)
     libddwaf (1.15.0.0.0-x86_64-linux)

--- a/gemfiles/ruby_2.5_elasticsearch_latest.gemfile.lock
+++ b/gemfiles/ruby_2.5_elasticsearch_latest.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     datadog (2.4.0)
       datadog-ruby_core_source (~> 3.3)
-      libdatadog (~> 13.1.0.1.0)
+      libdatadog (~> 14.0.0.1.0)
       libddwaf (~> 1.15.0.0.0)
       msgpack
 
@@ -82,8 +82,8 @@ GEM
     hashdiff (1.1.1)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (13.1.0.1.0-aarch64-linux)
-    libdatadog (13.1.0.1.0-x86_64-linux)
+    libdatadog (14.0.0.1.0-aarch64-linux)
+    libdatadog (14.0.0.1.0-x86_64-linux)
     libddwaf (1.15.0.0.0-aarch64-linux)
       ffi (~> 1.0)
     libddwaf (1.15.0.0.0-x86_64-linux)

--- a/gemfiles/ruby_2.5_graphql_2.0.gemfile.lock
+++ b/gemfiles/ruby_2.5_graphql_2.0.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     datadog (2.4.0)
       datadog-ruby_core_source (~> 3.3)
-      libdatadog (~> 13.1.0.1.0)
+      libdatadog (~> 14.0.0.1.0)
       libddwaf (~> 1.15.0.0.0)
       msgpack
 
@@ -119,8 +119,8 @@ GEM
     io-wait (0.3.1)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (13.1.0.1.0-aarch64-linux)
-    libdatadog (13.1.0.1.0-x86_64-linux)
+    libdatadog (14.0.0.1.0-aarch64-linux)
+    libdatadog (14.0.0.1.0-x86_64-linux)
     libddwaf (1.15.0.0.0-aarch64-linux)
       ffi (~> 1.0)
     libddwaf (1.15.0.0.0-x86_64-linux)

--- a/gemfiles/ruby_2.5_hanami_1.gemfile.lock
+++ b/gemfiles/ruby_2.5_hanami_1.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     datadog (2.4.0)
       datadog-ruby_core_source (~> 3.3)
-      libdatadog (~> 13.1.0.1.0)
+      libdatadog (~> 14.0.0.1.0)
       libddwaf (~> 1.15.0.0.0)
       msgpack
 
@@ -124,8 +124,8 @@ GEM
     io-wait (0.3.0)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (13.1.0.1.0-aarch64-linux)
-    libdatadog (13.1.0.1.0-x86_64-linux)
+    libdatadog (14.0.0.1.0-aarch64-linux)
+    libdatadog (14.0.0.1.0-x86_64-linux)
     libddwaf (1.15.0.0.0-aarch64-linux)
       ffi (~> 1.0)
     libddwaf (1.15.0.0.0-x86_64-linux)

--- a/gemfiles/ruby_2.5_http.gemfile.lock
+++ b/gemfiles/ruby_2.5_http.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     datadog (2.4.0)
       datadog-ruby_core_source (~> 3.3)
-      libdatadog (~> 13.1.0.1.0)
+      libdatadog (~> 14.0.0.1.0)
       libddwaf (~> 1.15.0.0.0)
       msgpack
 
@@ -89,8 +89,8 @@ GEM
     httpclient (2.8.3)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (13.1.0.1.0-aarch64-linux)
-    libdatadog (13.1.0.1.0-x86_64-linux)
+    libdatadog (14.0.0.1.0-aarch64-linux)
+    libdatadog (14.0.0.1.0-x86_64-linux)
     libddwaf (1.15.0.0.0-aarch64-linux)
       ffi (~> 1.0)
     libddwaf (1.15.0.0.0-x86_64-linux)

--- a/gemfiles/ruby_2.5_opensearch_2.gemfile.lock
+++ b/gemfiles/ruby_2.5_opensearch_2.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     datadog (2.4.0)
       datadog-ruby_core_source (~> 3.3)
-      libdatadog (~> 13.1.0.1.0)
+      libdatadog (~> 14.0.0.1.0)
       libddwaf (~> 1.15.0.0.0)
       msgpack
 
@@ -72,8 +72,8 @@ GEM
     hashdiff (1.0.1)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (13.1.0.1.0-aarch64-linux)
-    libdatadog (13.1.0.1.0-x86_64-linux)
+    libdatadog (14.0.0.1.0-aarch64-linux)
+    libdatadog (14.0.0.1.0-x86_64-linux)
     libddwaf (1.15.0.0.0-aarch64-linux)
       ffi (~> 1.0)
     libddwaf (1.15.0.0.0-x86_64-linux)

--- a/gemfiles/ruby_2.5_opensearch_3.gemfile.lock
+++ b/gemfiles/ruby_2.5_opensearch_3.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     datadog (2.4.0)
       datadog-ruby_core_source (~> 3.3)
-      libdatadog (~> 13.1.0.1.0)
+      libdatadog (~> 14.0.0.1.0)
       libddwaf (~> 1.15.0.0.0)
       msgpack
 
@@ -72,8 +72,8 @@ GEM
     hashdiff (1.0.1)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (13.1.0.1.0-aarch64-linux)
-    libdatadog (13.1.0.1.0-x86_64-linux)
+    libdatadog (14.0.0.1.0-aarch64-linux)
+    libdatadog (14.0.0.1.0-x86_64-linux)
     libddwaf (1.15.0.0.0-aarch64-linux)
       ffi (~> 1.0)
     libddwaf (1.15.0.0.0-x86_64-linux)

--- a/gemfiles/ruby_2.5_opensearch_latest.gemfile.lock
+++ b/gemfiles/ruby_2.5_opensearch_latest.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     datadog (2.4.0)
       datadog-ruby_core_source (~> 3.3)
-      libdatadog (~> 13.1.0.1.0)
+      libdatadog (~> 14.0.0.1.0)
       libddwaf (~> 1.15.0.0.0)
       msgpack
 
@@ -74,8 +74,8 @@ GEM
     hashdiff (1.1.1)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (13.1.0.1.0-aarch64-linux)
-    libdatadog (13.1.0.1.0-x86_64-linux)
+    libdatadog (14.0.0.1.0-aarch64-linux)
+    libdatadog (14.0.0.1.0-x86_64-linux)
     libddwaf (1.15.0.0.0-aarch64-linux)
       ffi (~> 1.0)
     libddwaf (1.15.0.0.0-x86_64-linux)

--- a/gemfiles/ruby_2.5_rack_1.gemfile.lock
+++ b/gemfiles/ruby_2.5_rack_1.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     datadog (2.4.0)
       datadog-ruby_core_source (~> 3.3)
-      libdatadog (~> 13.1.0.1.0)
+      libdatadog (~> 14.0.0.1.0)
       libddwaf (~> 1.15.0.0.0)
       msgpack
 
@@ -48,8 +48,8 @@ GEM
     hashdiff (1.0.1)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (13.1.0.1.0-aarch64-linux)
-    libdatadog (13.1.0.1.0-x86_64-linux)
+    libdatadog (14.0.0.1.0-aarch64-linux)
+    libdatadog (14.0.0.1.0-x86_64-linux)
     libddwaf (1.15.0.0.0-aarch64-linux)
       ffi (~> 1.0)
     libddwaf (1.15.0.0.0-x86_64-linux)

--- a/gemfiles/ruby_2.5_rack_2.gemfile.lock
+++ b/gemfiles/ruby_2.5_rack_2.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     datadog (2.4.0)
       datadog-ruby_core_source (~> 3.3)
-      libdatadog (~> 13.1.0.1.0)
+      libdatadog (~> 14.0.0.1.0)
       libddwaf (~> 1.15.0.0.0)
       msgpack
 
@@ -48,8 +48,8 @@ GEM
     hashdiff (1.0.1)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (13.1.0.1.0-aarch64-linux)
-    libdatadog (13.1.0.1.0-x86_64-linux)
+    libdatadog (14.0.0.1.0-aarch64-linux)
+    libdatadog (14.0.0.1.0-x86_64-linux)
     libddwaf (1.15.0.0.0-aarch64-linux)
       ffi (~> 1.0)
     libddwaf (1.15.0.0.0-x86_64-linux)

--- a/gemfiles/ruby_2.5_rack_3.gemfile.lock
+++ b/gemfiles/ruby_2.5_rack_3.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     datadog (2.4.0)
       datadog-ruby_core_source (~> 3.3)
-      libdatadog (~> 13.1.0.1.0)
+      libdatadog (~> 14.0.0.1.0)
       libddwaf (~> 1.15.0.0.0)
       msgpack
 
@@ -48,8 +48,8 @@ GEM
     hashdiff (1.0.1)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (13.1.0.1.0-aarch64-linux)
-    libdatadog (13.1.0.1.0-x86_64-linux)
+    libdatadog (14.0.0.1.0-aarch64-linux)
+    libdatadog (14.0.0.1.0-x86_64-linux)
     libddwaf (1.15.0.0.0-aarch64-linux)
       ffi (~> 1.0)
     libddwaf (1.15.0.0.0-x86_64-linux)

--- a/gemfiles/ruby_2.5_rack_latest.gemfile.lock
+++ b/gemfiles/ruby_2.5_rack_latest.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     datadog (2.4.0)
       datadog-ruby_core_source (~> 3.3)
-      libdatadog (~> 13.1.0.1.0)
+      libdatadog (~> 14.0.0.1.0)
       libddwaf (~> 1.15.0.0.0)
       msgpack
 
@@ -51,8 +51,8 @@ GEM
     hashdiff (1.1.1)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (13.1.0.1.0-aarch64-linux)
-    libdatadog (13.1.0.1.0-x86_64-linux)
+    libdatadog (14.0.0.1.0-aarch64-linux)
+    libdatadog (14.0.0.1.0-x86_64-linux)
     libddwaf (1.15.0.0.0-aarch64-linux)
       ffi (~> 1.0)
     libddwaf (1.15.0.0.0-x86_64-linux)

--- a/gemfiles/ruby_2.5_rails4_mysql2.gemfile.lock
+++ b/gemfiles/ruby_2.5_rails4_mysql2.gemfile.lock
@@ -69,7 +69,7 @@ PATH
   specs:
     datadog (2.4.0)
       datadog-ruby_core_source (~> 3.3)
-      libdatadog (~> 13.1.0.1.0)
+      libdatadog (~> 14.0.0.1.0)
       libddwaf (~> 1.15.0.0.0)
       msgpack
 
@@ -115,8 +115,8 @@ GEM
     io-wait (0.3.1)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (13.1.0.1.0-aarch64-linux)
-    libdatadog (13.1.0.1.0-x86_64-linux)
+    libdatadog (14.0.0.1.0-aarch64-linux)
+    libdatadog (14.0.0.1.0-x86_64-linux)
     libddwaf (1.15.0.0.0-aarch64-linux)
       ffi (~> 1.0)
     libddwaf (1.15.0.0.0-x86_64-linux)

--- a/gemfiles/ruby_2.5_rails4_postgres.gemfile.lock
+++ b/gemfiles/ruby_2.5_rails4_postgres.gemfile.lock
@@ -69,7 +69,7 @@ PATH
   specs:
     datadog (2.4.0)
       datadog-ruby_core_source (~> 3.3)
-      libdatadog (~> 13.1.0.1.0)
+      libdatadog (~> 14.0.0.1.0)
       libddwaf (~> 1.15.0.0.0)
       msgpack
 
@@ -115,8 +115,8 @@ GEM
     io-wait (0.3.1)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (13.1.0.1.0-aarch64-linux)
-    libdatadog (13.1.0.1.0-x86_64-linux)
+    libdatadog (14.0.0.1.0-aarch64-linux)
+    libdatadog (14.0.0.1.0-x86_64-linux)
     libddwaf (1.15.0.0.0-aarch64-linux)
       ffi (~> 1.0)
     libddwaf (1.15.0.0.0-x86_64-linux)

--- a/gemfiles/ruby_2.5_rails4_postgres_redis.gemfile.lock
+++ b/gemfiles/ruby_2.5_rails4_postgres_redis.gemfile.lock
@@ -69,7 +69,7 @@ PATH
   specs:
     datadog (2.4.0)
       datadog-ruby_core_source (~> 3.3)
-      libdatadog (~> 13.1.0.1.0)
+      libdatadog (~> 14.0.0.1.0)
       libddwaf (~> 1.15.0.0.0)
       msgpack
 
@@ -115,8 +115,8 @@ GEM
     io-wait (0.3.1)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (13.1.0.1.0-aarch64-linux)
-    libdatadog (13.1.0.1.0-x86_64-linux)
+    libdatadog (14.0.0.1.0-aarch64-linux)
+    libdatadog (14.0.0.1.0-x86_64-linux)
     libddwaf (1.15.0.0.0-aarch64-linux)
       ffi (~> 1.0)
     libddwaf (1.15.0.0.0-x86_64-linux)

--- a/gemfiles/ruby_2.5_rails4_postgres_sidekiq.gemfile.lock
+++ b/gemfiles/ruby_2.5_rails4_postgres_sidekiq.gemfile.lock
@@ -66,7 +66,7 @@ PATH
   specs:
     datadog (2.4.0)
       datadog-ruby_core_source (~> 3.3)
-      libdatadog (~> 13.1.0.1.0)
+      libdatadog (~> 14.0.0.1.0)
       libddwaf (~> 1.15.0.0.0)
       msgpack
 
@@ -116,8 +116,8 @@ GEM
     io-wait (0.3.1)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (13.1.0.1.0-aarch64-linux)
-    libdatadog (13.1.0.1.0-x86_64-linux)
+    libdatadog (14.0.0.1.0-aarch64-linux)
+    libdatadog (14.0.0.1.0-x86_64-linux)
     libddwaf (1.15.0.0.0-aarch64-linux)
       ffi (~> 1.0)
     libddwaf (1.15.0.0.0-x86_64-linux)

--- a/gemfiles/ruby_2.5_rails4_semantic_logger.gemfile.lock
+++ b/gemfiles/ruby_2.5_rails4_semantic_logger.gemfile.lock
@@ -69,7 +69,7 @@ PATH
   specs:
     datadog (2.4.0)
       datadog-ruby_core_source (~> 3.3)
-      libdatadog (~> 13.1.0.1.0)
+      libdatadog (~> 14.0.0.1.0)
       libddwaf (~> 1.15.0.0.0)
       msgpack
 
@@ -115,8 +115,8 @@ GEM
     io-wait (0.3.1)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (13.1.0.1.0-aarch64-linux)
-    libdatadog (13.1.0.1.0-x86_64-linux)
+    libdatadog (14.0.0.1.0-aarch64-linux)
+    libdatadog (14.0.0.1.0-x86_64-linux)
     libddwaf (1.15.0.0.0-aarch64-linux)
       ffi (~> 1.0)
     libddwaf (1.15.0.0.0-x86_64-linux)

--- a/gemfiles/ruby_2.5_rails5_mysql2.gemfile.lock
+++ b/gemfiles/ruby_2.5_rails5_mysql2.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     datadog (2.4.0)
       datadog-ruby_core_source (~> 3.3)
-      libdatadog (~> 13.1.0.1.0)
+      libdatadog (~> 14.0.0.1.0)
       libddwaf (~> 1.15.0.0.0)
       msgpack
 
@@ -97,8 +97,8 @@ GEM
       concurrent-ruby (~> 1.0)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (13.1.0.1.0-aarch64-linux)
-    libdatadog (13.1.0.1.0-x86_64-linux)
+    libdatadog (14.0.0.1.0-aarch64-linux)
+    libdatadog (14.0.0.1.0-x86_64-linux)
     libddwaf (1.15.0.0.0-aarch64-linux)
       ffi (~> 1.0)
     libddwaf (1.15.0.0.0-x86_64-linux)

--- a/gemfiles/ruby_2.5_rails5_postgres.gemfile.lock
+++ b/gemfiles/ruby_2.5_rails5_postgres.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     datadog (2.4.0)
       datadog-ruby_core_source (~> 3.3)
-      libdatadog (~> 13.1.0.1.0)
+      libdatadog (~> 14.0.0.1.0)
       libddwaf (~> 1.15.0.0.0)
       msgpack
 
@@ -99,8 +99,8 @@ GEM
     io-wait (0.3.0)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (13.1.0.1.0-aarch64-linux)
-    libdatadog (13.1.0.1.0-x86_64-linux)
+    libdatadog (14.0.0.1.0-aarch64-linux)
+    libdatadog (14.0.0.1.0-x86_64-linux)
     libddwaf (1.15.0.0.0-aarch64-linux)
       ffi (~> 1.0)
     libddwaf (1.15.0.0.0-x86_64-linux)

--- a/gemfiles/ruby_2.5_rails5_postgres_redis.gemfile.lock
+++ b/gemfiles/ruby_2.5_rails5_postgres_redis.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     datadog (2.4.0)
       datadog-ruby_core_source (~> 3.3)
-      libdatadog (~> 13.1.0.1.0)
+      libdatadog (~> 14.0.0.1.0)
       libddwaf (~> 1.15.0.0.0)
       msgpack
 
@@ -100,8 +100,8 @@ GEM
     io-wait (0.3.0)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (13.1.0.1.0-aarch64-linux)
-    libdatadog (13.1.0.1.0-x86_64-linux)
+    libdatadog (14.0.0.1.0-aarch64-linux)
+    libdatadog (14.0.0.1.0-x86_64-linux)
     libddwaf (1.15.0.0.0-aarch64-linux)
       ffi (~> 1.0)
     libddwaf (1.15.0.0.0-x86_64-linux)

--- a/gemfiles/ruby_2.5_rails5_postgres_redis_activesupport.gemfile.lock
+++ b/gemfiles/ruby_2.5_rails5_postgres_redis_activesupport.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     datadog (2.4.0)
       datadog-ruby_core_source (~> 3.3)
-      libdatadog (~> 13.1.0.1.0)
+      libdatadog (~> 14.0.0.1.0)
       libddwaf (~> 1.15.0.0.0)
       msgpack
 
@@ -99,8 +99,8 @@ GEM
     io-wait (0.3.0)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (13.1.0.1.0-aarch64-linux)
-    libdatadog (13.1.0.1.0-x86_64-linux)
+    libdatadog (14.0.0.1.0-aarch64-linux)
+    libdatadog (14.0.0.1.0-x86_64-linux)
     libddwaf (1.15.0.0.0-aarch64-linux)
       ffi (~> 1.0)
     libddwaf (1.15.0.0.0-x86_64-linux)

--- a/gemfiles/ruby_2.5_rails5_postgres_sidekiq.gemfile.lock
+++ b/gemfiles/ruby_2.5_rails5_postgres_sidekiq.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     datadog (2.4.0)
       datadog-ruby_core_source (~> 3.3)
-      libdatadog (~> 13.1.0.1.0)
+      libdatadog (~> 14.0.0.1.0)
       libddwaf (~> 1.15.0.0.0)
       msgpack
 
@@ -100,8 +100,8 @@ GEM
     io-wait (0.3.0)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (13.1.0.1.0-aarch64-linux)
-    libdatadog (13.1.0.1.0-x86_64-linux)
+    libdatadog (14.0.0.1.0-aarch64-linux)
+    libdatadog (14.0.0.1.0-x86_64-linux)
     libddwaf (1.15.0.0.0-aarch64-linux)
       ffi (~> 1.0)
     libddwaf (1.15.0.0.0-x86_64-linux)

--- a/gemfiles/ruby_2.5_rails5_semantic_logger.gemfile.lock
+++ b/gemfiles/ruby_2.5_rails5_semantic_logger.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     datadog (2.4.0)
       datadog-ruby_core_source (~> 3.3)
-      libdatadog (~> 13.1.0.1.0)
+      libdatadog (~> 14.0.0.1.0)
       libddwaf (~> 1.15.0.0.0)
       msgpack
 
@@ -99,8 +99,8 @@ GEM
     io-wait (0.3.0)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (13.1.0.1.0-aarch64-linux)
-    libdatadog (13.1.0.1.0-x86_64-linux)
+    libdatadog (14.0.0.1.0-aarch64-linux)
+    libdatadog (14.0.0.1.0-x86_64-linux)
     libddwaf (1.15.0.0.0-aarch64-linux)
       ffi (~> 1.0)
     libddwaf (1.15.0.0.0-x86_64-linux)

--- a/gemfiles/ruby_2.5_rails61_mysql2.gemfile.lock
+++ b/gemfiles/ruby_2.5_rails61_mysql2.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     datadog (2.4.0)
       datadog-ruby_core_source (~> 3.3)
-      libdatadog (~> 13.1.0.1.0)
+      libdatadog (~> 14.0.0.1.0)
       libddwaf (~> 1.15.0.0.0)
       msgpack
 
@@ -114,8 +114,8 @@ GEM
       concurrent-ruby (~> 1.0)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (13.1.0.1.0-aarch64-linux)
-    libdatadog (13.1.0.1.0-x86_64-linux)
+    libdatadog (14.0.0.1.0-aarch64-linux)
+    libdatadog (14.0.0.1.0-x86_64-linux)
     libddwaf (1.15.0.0.0-aarch64-linux)
       ffi (~> 1.0)
     libddwaf (1.15.0.0.0-x86_64-linux)

--- a/gemfiles/ruby_2.5_rails61_postgres.gemfile.lock
+++ b/gemfiles/ruby_2.5_rails61_postgres.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     datadog (2.4.0)
       datadog-ruby_core_source (~> 3.3)
-      libdatadog (~> 13.1.0.1.0)
+      libdatadog (~> 14.0.0.1.0)
       libddwaf (~> 1.15.0.0.0)
       msgpack
 
@@ -116,8 +116,8 @@ GEM
     io-wait (0.3.0)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (13.1.0.1.0-aarch64-linux)
-    libdatadog (13.1.0.1.0-x86_64-linux)
+    libdatadog (14.0.0.1.0-aarch64-linux)
+    libdatadog (14.0.0.1.0-x86_64-linux)
     libddwaf (1.15.0.0.0-aarch64-linux)
       ffi (~> 1.0)
     libddwaf (1.15.0.0.0-x86_64-linux)

--- a/gemfiles/ruby_2.5_rails61_postgres_redis.gemfile.lock
+++ b/gemfiles/ruby_2.5_rails61_postgres_redis.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     datadog (2.4.0)
       datadog-ruby_core_source (~> 3.3)
-      libdatadog (~> 13.1.0.1.0)
+      libdatadog (~> 14.0.0.1.0)
       libddwaf (~> 1.15.0.0.0)
       msgpack
 
@@ -117,8 +117,8 @@ GEM
     io-wait (0.3.0)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (13.1.0.1.0-aarch64-linux)
-    libdatadog (13.1.0.1.0-x86_64-linux)
+    libdatadog (14.0.0.1.0-aarch64-linux)
+    libdatadog (14.0.0.1.0-x86_64-linux)
     libddwaf (1.15.0.0.0-aarch64-linux)
       ffi (~> 1.0)
     libddwaf (1.15.0.0.0-x86_64-linux)

--- a/gemfiles/ruby_2.5_rails61_postgres_sidekiq.gemfile.lock
+++ b/gemfiles/ruby_2.5_rails61_postgres_sidekiq.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     datadog (2.4.0)
       datadog-ruby_core_source (~> 3.3)
-      libdatadog (~> 13.1.0.1.0)
+      libdatadog (~> 14.0.0.1.0)
       libddwaf (~> 1.15.0.0.0)
       msgpack
 
@@ -117,8 +117,8 @@ GEM
     io-wait (0.3.0)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (13.1.0.1.0-aarch64-linux)
-    libdatadog (13.1.0.1.0-x86_64-linux)
+    libdatadog (14.0.0.1.0-aarch64-linux)
+    libdatadog (14.0.0.1.0-x86_64-linux)
     libddwaf (1.15.0.0.0-aarch64-linux)
       ffi (~> 1.0)
     libddwaf (1.15.0.0.0-x86_64-linux)

--- a/gemfiles/ruby_2.5_rails61_semantic_logger.gemfile.lock
+++ b/gemfiles/ruby_2.5_rails61_semantic_logger.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     datadog (2.4.0)
       datadog-ruby_core_source (~> 3.3)
-      libdatadog (~> 13.1.0.1.0)
+      libdatadog (~> 14.0.0.1.0)
       libddwaf (~> 1.15.0.0.0)
       msgpack
 
@@ -116,8 +116,8 @@ GEM
     io-wait (0.3.0)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (13.1.0.1.0-aarch64-linux)
-    libdatadog (13.1.0.1.0-x86_64-linux)
+    libdatadog (14.0.0.1.0-aarch64-linux)
+    libdatadog (14.0.0.1.0-x86_64-linux)
     libddwaf (1.15.0.0.0-aarch64-linux)
       ffi (~> 1.0)
     libddwaf (1.15.0.0.0-x86_64-linux)

--- a/gemfiles/ruby_2.5_rails6_mysql2.gemfile.lock
+++ b/gemfiles/ruby_2.5_rails6_mysql2.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     datadog (2.4.0)
       datadog-ruby_core_source (~> 3.3)
-      libdatadog (~> 13.1.0.1.0)
+      libdatadog (~> 14.0.0.1.0)
       libddwaf (~> 1.15.0.0.0)
       msgpack
 
@@ -110,8 +110,8 @@ GEM
       concurrent-ruby (~> 1.0)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (13.1.0.1.0-aarch64-linux)
-    libdatadog (13.1.0.1.0-x86_64-linux)
+    libdatadog (14.0.0.1.0-aarch64-linux)
+    libdatadog (14.0.0.1.0-x86_64-linux)
     libddwaf (1.15.0.0.0-aarch64-linux)
       ffi (~> 1.0)
     libddwaf (1.15.0.0.0-x86_64-linux)

--- a/gemfiles/ruby_2.5_rails6_postgres.gemfile.lock
+++ b/gemfiles/ruby_2.5_rails6_postgres.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     datadog (2.4.0)
       datadog-ruby_core_source (~> 3.3)
-      libdatadog (~> 13.1.0.1.0)
+      libdatadog (~> 14.0.0.1.0)
       libddwaf (~> 1.15.0.0.0)
       msgpack
 
@@ -112,8 +112,8 @@ GEM
     io-wait (0.3.0)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (13.1.0.1.0-aarch64-linux)
-    libdatadog (13.1.0.1.0-x86_64-linux)
+    libdatadog (14.0.0.1.0-aarch64-linux)
+    libdatadog (14.0.0.1.0-x86_64-linux)
     libddwaf (1.15.0.0.0-aarch64-linux)
       ffi (~> 1.0)
     libddwaf (1.15.0.0.0-x86_64-linux)

--- a/gemfiles/ruby_2.5_rails6_postgres_redis.gemfile.lock
+++ b/gemfiles/ruby_2.5_rails6_postgres_redis.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     datadog (2.4.0)
       datadog-ruby_core_source (~> 3.3)
-      libdatadog (~> 13.1.0.1.0)
+      libdatadog (~> 14.0.0.1.0)
       libddwaf (~> 1.15.0.0.0)
       msgpack
 
@@ -113,8 +113,8 @@ GEM
     io-wait (0.3.0)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (13.1.0.1.0-aarch64-linux)
-    libdatadog (13.1.0.1.0-x86_64-linux)
+    libdatadog (14.0.0.1.0-aarch64-linux)
+    libdatadog (14.0.0.1.0-x86_64-linux)
     libddwaf (1.15.0.0.0-aarch64-linux)
       ffi (~> 1.0)
     libddwaf (1.15.0.0.0-x86_64-linux)

--- a/gemfiles/ruby_2.5_rails6_postgres_redis_activesupport.gemfile.lock
+++ b/gemfiles/ruby_2.5_rails6_postgres_redis_activesupport.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     datadog (2.4.0)
       datadog-ruby_core_source (~> 3.3)
-      libdatadog (~> 13.1.0.1.0)
+      libdatadog (~> 14.0.0.1.0)
       libddwaf (~> 1.15.0.0.0)
       msgpack
 
@@ -112,8 +112,8 @@ GEM
     io-wait (0.3.0)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (13.1.0.1.0-aarch64-linux)
-    libdatadog (13.1.0.1.0-x86_64-linux)
+    libdatadog (14.0.0.1.0-aarch64-linux)
+    libdatadog (14.0.0.1.0-x86_64-linux)
     libddwaf (1.15.0.0.0-aarch64-linux)
       ffi (~> 1.0)
     libddwaf (1.15.0.0.0-x86_64-linux)

--- a/gemfiles/ruby_2.5_rails6_postgres_sidekiq.gemfile.lock
+++ b/gemfiles/ruby_2.5_rails6_postgres_sidekiq.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     datadog (2.4.0)
       datadog-ruby_core_source (~> 3.3)
-      libdatadog (~> 13.1.0.1.0)
+      libdatadog (~> 14.0.0.1.0)
       libddwaf (~> 1.15.0.0.0)
       msgpack
 
@@ -113,8 +113,8 @@ GEM
     io-wait (0.3.0)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (13.1.0.1.0-aarch64-linux)
-    libdatadog (13.1.0.1.0-x86_64-linux)
+    libdatadog (14.0.0.1.0-aarch64-linux)
+    libdatadog (14.0.0.1.0-x86_64-linux)
     libddwaf (1.15.0.0.0-aarch64-linux)
       ffi (~> 1.0)
     libddwaf (1.15.0.0.0-x86_64-linux)

--- a/gemfiles/ruby_2.5_rails6_semantic_logger.gemfile.lock
+++ b/gemfiles/ruby_2.5_rails6_semantic_logger.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     datadog (2.4.0)
       datadog-ruby_core_source (~> 3.3)
-      libdatadog (~> 13.1.0.1.0)
+      libdatadog (~> 14.0.0.1.0)
       libddwaf (~> 1.15.0.0.0)
       msgpack
 
@@ -112,8 +112,8 @@ GEM
     io-wait (0.3.0)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (13.1.0.1.0-aarch64-linux)
-    libdatadog (13.1.0.1.0-x86_64-linux)
+    libdatadog (14.0.0.1.0-aarch64-linux)
+    libdatadog (14.0.0.1.0-x86_64-linux)
     libddwaf (1.15.0.0.0-aarch64-linux)
       ffi (~> 1.0)
     libddwaf (1.15.0.0.0-x86_64-linux)

--- a/gemfiles/ruby_2.5_redis_3.gemfile.lock
+++ b/gemfiles/ruby_2.5_redis_3.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     datadog (2.4.0)
       datadog-ruby_core_source (~> 3.3)
-      libdatadog (~> 13.1.0.1.0)
+      libdatadog (~> 14.0.0.1.0)
       libddwaf (~> 1.15.0.0.0)
       msgpack
 
@@ -48,8 +48,8 @@ GEM
     hashdiff (1.0.1)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (13.1.0.1.0-aarch64-linux)
-    libdatadog (13.1.0.1.0-x86_64-linux)
+    libdatadog (14.0.0.1.0-aarch64-linux)
+    libdatadog (14.0.0.1.0-x86_64-linux)
     libddwaf (1.15.0.0.0-aarch64-linux)
       ffi (~> 1.0)
     libddwaf (1.15.0.0.0-x86_64-linux)

--- a/gemfiles/ruby_2.5_redis_4.gemfile.lock
+++ b/gemfiles/ruby_2.5_redis_4.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     datadog (2.4.0)
       datadog-ruby_core_source (~> 3.3)
-      libdatadog (~> 13.1.0.1.0)
+      libdatadog (~> 14.0.0.1.0)
       libddwaf (~> 1.15.0.0.0)
       msgpack
 
@@ -48,8 +48,8 @@ GEM
     hashdiff (1.0.1)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (13.1.0.1.0-aarch64-linux)
-    libdatadog (13.1.0.1.0-x86_64-linux)
+    libdatadog (14.0.0.1.0-aarch64-linux)
+    libdatadog (14.0.0.1.0-x86_64-linux)
     libddwaf (1.15.0.0.0-aarch64-linux)
       ffi (~> 1.0)
     libddwaf (1.15.0.0.0-x86_64-linux)

--- a/gemfiles/ruby_2.5_redis_5.gemfile.lock
+++ b/gemfiles/ruby_2.5_redis_5.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     datadog (2.4.0)
       datadog-ruby_core_source (~> 3.3)
-      libdatadog (~> 13.1.0.1.0)
+      libdatadog (~> 14.0.0.1.0)
       libddwaf (~> 1.15.0.0.0)
       msgpack
 
@@ -49,8 +49,8 @@ GEM
     hashdiff (1.0.1)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (13.1.0.1.0-aarch64-linux)
-    libdatadog (13.1.0.1.0-x86_64-linux)
+    libdatadog (14.0.0.1.0-aarch64-linux)
+    libdatadog (14.0.0.1.0-x86_64-linux)
     libddwaf (1.15.0.0.0-aarch64-linux)
       ffi (~> 1.0)
     libddwaf (1.15.0.0.0-x86_64-linux)

--- a/gemfiles/ruby_2.5_relational_db.gemfile.lock
+++ b/gemfiles/ruby_2.5_relational_db.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     datadog (2.4.0)
       datadog-ruby_core_source (~> 3.3)
-      libdatadog (~> 13.1.0.1.0)
+      libdatadog (~> 14.0.0.1.0)
       libddwaf (~> 1.15.0.0.0)
       msgpack
 
@@ -68,8 +68,8 @@ GEM
       concurrent-ruby (~> 1.0)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (13.1.0.1.0-aarch64-linux)
-    libdatadog (13.1.0.1.0-x86_64-linux)
+    libdatadog (14.0.0.1.0-aarch64-linux)
+    libdatadog (14.0.0.1.0-x86_64-linux)
     libddwaf (1.15.0.0.0-aarch64-linux)
       ffi (~> 1.0)
     libddwaf (1.15.0.0.0-x86_64-linux)

--- a/gemfiles/ruby_2.5_resque2_redis3.gemfile.lock
+++ b/gemfiles/ruby_2.5_resque2_redis3.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     datadog (2.4.0)
       datadog-ruby_core_source (~> 3.3)
-      libdatadog (~> 13.1.0.1.0)
+      libdatadog (~> 14.0.0.1.0)
       libddwaf (~> 1.15.0.0.0)
       msgpack
 
@@ -48,8 +48,8 @@ GEM
     hashdiff (1.0.1)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (13.1.0.1.0-aarch64-linux)
-    libdatadog (13.1.0.1.0-x86_64-linux)
+    libdatadog (14.0.0.1.0-aarch64-linux)
+    libdatadog (14.0.0.1.0-x86_64-linux)
     libddwaf (1.15.0.0.0-aarch64-linux)
       ffi (~> 1.0)
     libddwaf (1.15.0.0.0-x86_64-linux)

--- a/gemfiles/ruby_2.5_resque2_redis4.gemfile.lock
+++ b/gemfiles/ruby_2.5_resque2_redis4.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     datadog (2.4.0)
       datadog-ruby_core_source (~> 3.3)
-      libdatadog (~> 13.1.0.1.0)
+      libdatadog (~> 14.0.0.1.0)
       libddwaf (~> 1.15.0.0.0)
       msgpack
 
@@ -49,8 +49,8 @@ GEM
     hashdiff (1.0.1)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (13.1.0.1.0-aarch64-linux)
-    libdatadog (13.1.0.1.0-x86_64-linux)
+    libdatadog (14.0.0.1.0-aarch64-linux)
+    libdatadog (14.0.0.1.0-x86_64-linux)
     libddwaf (1.15.0.0.0-aarch64-linux)
       ffi (~> 1.0)
     libddwaf (1.15.0.0.0-x86_64-linux)

--- a/gemfiles/ruby_2.5_sinatra_2.gemfile.lock
+++ b/gemfiles/ruby_2.5_sinatra_2.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     datadog (2.4.0)
       datadog-ruby_core_source (~> 3.3)
-      libdatadog (~> 13.1.0.1.0)
+      libdatadog (~> 14.0.0.1.0)
       libddwaf (~> 1.15.0.0.0)
       msgpack
 
@@ -51,8 +51,8 @@ GEM
     hashdiff (1.1.0)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (13.1.0.1.0-aarch64-linux)
-    libdatadog (13.1.0.1.0-x86_64-linux)
+    libdatadog (14.0.0.1.0-aarch64-linux)
+    libdatadog (14.0.0.1.0-x86_64-linux)
     libddwaf (1.15.0.0.0-aarch64-linux)
       ffi (~> 1.0)
     libddwaf (1.15.0.0.0-x86_64-linux)

--- a/gemfiles/ruby_2.5_stripe_10.gemfile.lock
+++ b/gemfiles/ruby_2.5_stripe_10.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     datadog (2.4.0)
       datadog-ruby_core_source (~> 3.3)
-      libdatadog (~> 13.1.0.1.0)
+      libdatadog (~> 14.0.0.1.0)
       libddwaf (~> 1.15.0.0.0)
       msgpack
 
@@ -51,8 +51,8 @@ GEM
     hashdiff (1.1.1)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (13.1.0.1.0-aarch64-linux)
-    libdatadog (13.1.0.1.0-x86_64-linux)
+    libdatadog (14.0.0.1.0-aarch64-linux)
+    libdatadog (14.0.0.1.0-x86_64-linux)
     libddwaf (1.15.0.0.0-aarch64-linux)
       ffi (~> 1.0)
     libddwaf (1.15.0.0.0-x86_64-linux)

--- a/gemfiles/ruby_2.5_stripe_11.gemfile.lock
+++ b/gemfiles/ruby_2.5_stripe_11.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     datadog (2.4.0)
       datadog-ruby_core_source (~> 3.3)
-      libdatadog (~> 13.1.0.1.0)
+      libdatadog (~> 14.0.0.1.0)
       libddwaf (~> 1.15.0.0.0)
       msgpack
 
@@ -51,8 +51,8 @@ GEM
     hashdiff (1.1.1)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (13.1.0.1.0-aarch64-linux)
-    libdatadog (13.1.0.1.0-x86_64-linux)
+    libdatadog (14.0.0.1.0-aarch64-linux)
+    libdatadog (14.0.0.1.0-x86_64-linux)
     libddwaf (1.15.0.0.0-aarch64-linux)
       ffi (~> 1.0)
     libddwaf (1.15.0.0.0-x86_64-linux)

--- a/gemfiles/ruby_2.5_stripe_12.gemfile.lock
+++ b/gemfiles/ruby_2.5_stripe_12.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     datadog (2.4.0)
       datadog-ruby_core_source (~> 3.3)
-      libdatadog (~> 13.1.0.1.0)
+      libdatadog (~> 14.0.0.1.0)
       libddwaf (~> 1.15.0.0.0)
       msgpack
 
@@ -51,8 +51,8 @@ GEM
     hashdiff (1.1.1)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (13.1.0.1.0-aarch64-linux)
-    libdatadog (13.1.0.1.0-x86_64-linux)
+    libdatadog (14.0.0.1.0-aarch64-linux)
+    libdatadog (14.0.0.1.0-x86_64-linux)
     libddwaf (1.15.0.0.0-aarch64-linux)
       ffi (~> 1.0)
     libddwaf (1.15.0.0.0-x86_64-linux)

--- a/gemfiles/ruby_2.5_stripe_7.gemfile.lock
+++ b/gemfiles/ruby_2.5_stripe_7.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     datadog (2.4.0)
       datadog-ruby_core_source (~> 3.3)
-      libdatadog (~> 13.1.0.1.0)
+      libdatadog (~> 14.0.0.1.0)
       libddwaf (~> 1.15.0.0.0)
       msgpack
 
@@ -51,8 +51,8 @@ GEM
     hashdiff (1.1.1)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (13.1.0.1.0-aarch64-linux)
-    libdatadog (13.1.0.1.0-x86_64-linux)
+    libdatadog (14.0.0.1.0-aarch64-linux)
+    libdatadog (14.0.0.1.0-x86_64-linux)
     libddwaf (1.15.0.0.0-aarch64-linux)
       ffi (~> 1.0)
     libddwaf (1.15.0.0.0-x86_64-linux)

--- a/gemfiles/ruby_2.5_stripe_8.gemfile.lock
+++ b/gemfiles/ruby_2.5_stripe_8.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     datadog (2.4.0)
       datadog-ruby_core_source (~> 3.3)
-      libdatadog (~> 13.1.0.1.0)
+      libdatadog (~> 14.0.0.1.0)
       libddwaf (~> 1.15.0.0.0)
       msgpack
 
@@ -51,8 +51,8 @@ GEM
     hashdiff (1.1.1)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (13.1.0.1.0-aarch64-linux)
-    libdatadog (13.1.0.1.0-x86_64-linux)
+    libdatadog (14.0.0.1.0-aarch64-linux)
+    libdatadog (14.0.0.1.0-x86_64-linux)
     libddwaf (1.15.0.0.0-aarch64-linux)
       ffi (~> 1.0)
     libddwaf (1.15.0.0.0-x86_64-linux)

--- a/gemfiles/ruby_2.5_stripe_9.gemfile.lock
+++ b/gemfiles/ruby_2.5_stripe_9.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     datadog (2.4.0)
       datadog-ruby_core_source (~> 3.3)
-      libdatadog (~> 13.1.0.1.0)
+      libdatadog (~> 14.0.0.1.0)
       libddwaf (~> 1.15.0.0.0)
       msgpack
 
@@ -51,8 +51,8 @@ GEM
     hashdiff (1.1.1)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (13.1.0.1.0-aarch64-linux)
-    libdatadog (13.1.0.1.0-x86_64-linux)
+    libdatadog (14.0.0.1.0-aarch64-linux)
+    libdatadog (14.0.0.1.0-x86_64-linux)
     libddwaf (1.15.0.0.0-aarch64-linux)
       ffi (~> 1.0)
     libddwaf (1.15.0.0.0-x86_64-linux)

--- a/gemfiles/ruby_2.5_stripe_latest.gemfile.lock
+++ b/gemfiles/ruby_2.5_stripe_latest.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     datadog (2.4.0)
       datadog-ruby_core_source (~> 3.3)
-      libdatadog (~> 13.1.0.1.0)
+      libdatadog (~> 14.0.0.1.0)
       libddwaf (~> 1.15.0.0.0)
       msgpack
 
@@ -51,8 +51,8 @@ GEM
     hashdiff (1.1.1)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (13.1.0.1.0-aarch64-linux)
-    libdatadog (13.1.0.1.0-x86_64-linux)
+    libdatadog (14.0.0.1.0-aarch64-linux)
+    libdatadog (14.0.0.1.0-x86_64-linux)
     libddwaf (1.15.0.0.0-aarch64-linux)
       ffi (~> 1.0)
     libddwaf (1.15.0.0.0-x86_64-linux)

--- a/gemfiles/ruby_2.5_stripe_min.gemfile.lock
+++ b/gemfiles/ruby_2.5_stripe_min.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     datadog (2.4.0)
       datadog-ruby_core_source (~> 3.3)
-      libdatadog (~> 13.1.0.1.0)
+      libdatadog (~> 14.0.0.1.0)
       libddwaf (~> 1.15.0.0.0)
       msgpack
 
@@ -51,8 +51,8 @@ GEM
     hashdiff (1.1.1)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (13.1.0.1.0-aarch64-linux)
-    libdatadog (13.1.0.1.0-x86_64-linux)
+    libdatadog (14.0.0.1.0-aarch64-linux)
+    libdatadog (14.0.0.1.0-x86_64-linux)
     libddwaf (1.15.0.0.0-aarch64-linux)
       ffi (~> 1.0)
     libddwaf (1.15.0.0.0-x86_64-linux)

--- a/gemfiles/ruby_2.6_activesupport.gemfile.lock
+++ b/gemfiles/ruby_2.6_activesupport.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     datadog (2.4.0)
       datadog-ruby_core_source (~> 3.3)
-      libdatadog (~> 13.1.0.1.0)
+      libdatadog (~> 14.0.0.1.0)
       libddwaf (~> 1.15.0.0.0)
       msgpack
 
@@ -113,8 +113,8 @@ GEM
       addressable (>= 2.4)
     jsonapi-renderer (0.2.2)
     king_konf (1.0.1)
-    libdatadog (13.1.0.1.0-aarch64-linux)
-    libdatadog (13.1.0.1.0-x86_64-linux)
+    libdatadog (14.0.0.1.0-aarch64-linux)
+    libdatadog (14.0.0.1.0-x86_64-linux)
     libddwaf (1.15.0.0.0-aarch64-linux)
       ffi (~> 1.0)
     libddwaf (1.15.0.0.0-x86_64-linux)

--- a/gemfiles/ruby_2.6_aws.gemfile.lock
+++ b/gemfiles/ruby_2.6_aws.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     datadog (2.4.0)
       datadog-ruby_core_source (~> 3.3)
-      libdatadog (~> 13.1.0.1.0)
+      libdatadog (~> 14.0.0.1.0)
       libddwaf (~> 1.15.0.0.0)
       msgpack
 
@@ -1473,8 +1473,8 @@ GEM
     json (2.6.3)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (13.1.0.1.0-aarch64-linux)
-    libdatadog (13.1.0.1.0-x86_64-linux)
+    libdatadog (14.0.0.1.0-aarch64-linux)
+    libdatadog (14.0.0.1.0-x86_64-linux)
     libddwaf (1.15.0.0.0-aarch64-linux)
       ffi (~> 1.0)
     libddwaf (1.15.0.0.0-x86_64-linux)

--- a/gemfiles/ruby_2.6_contrib.gemfile.lock
+++ b/gemfiles/ruby_2.6_contrib.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     datadog (2.4.0)
       datadog-ruby_core_source (~> 3.3)
-      libdatadog (~> 13.1.0.1.0)
+      libdatadog (~> 14.0.0.1.0)
       libddwaf (~> 1.15.0.0.0)
       msgpack
 
@@ -66,8 +66,8 @@ GEM
     json (2.6.3)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (13.1.0.1.0-aarch64-linux)
-    libdatadog (13.1.0.1.0-x86_64-linux)
+    libdatadog (14.0.0.1.0-aarch64-linux)
+    libdatadog (14.0.0.1.0-x86_64-linux)
     libddwaf (1.15.0.0.0-aarch64-linux)
       ffi (~> 1.0)
     libddwaf (1.15.0.0.0-x86_64-linux)

--- a/gemfiles/ruby_2.6_contrib_old.gemfile.lock
+++ b/gemfiles/ruby_2.6_contrib_old.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     datadog (2.4.0)
       datadog-ruby_core_source (~> 3.3)
-      libdatadog (~> 13.1.0.1.0)
+      libdatadog (~> 14.0.0.1.0)
       libddwaf (~> 1.15.0.0.0)
       msgpack
 
@@ -62,8 +62,8 @@ GEM
     json (2.6.3)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (13.1.0.1.0-aarch64-linux)
-    libdatadog (13.1.0.1.0-x86_64-linux)
+    libdatadog (14.0.0.1.0-aarch64-linux)
+    libdatadog (14.0.0.1.0-x86_64-linux)
     libddwaf (1.15.0.0.0-aarch64-linux)
       ffi (~> 1.0)
     libddwaf (1.15.0.0.0-x86_64-linux)

--- a/gemfiles/ruby_2.6_core_old.gemfile.lock
+++ b/gemfiles/ruby_2.6_core_old.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     datadog (2.4.0)
       datadog-ruby_core_source (~> 3.3)
-      libdatadog (~> 13.1.0.1.0)
+      libdatadog (~> 14.0.0.1.0)
       libddwaf (~> 1.15.0.0.0)
       msgpack
 
@@ -51,8 +51,8 @@ GEM
     json (2.6.3)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (13.1.0.1.0-aarch64-linux)
-    libdatadog (13.1.0.1.0-x86_64-linux)
+    libdatadog (14.0.0.1.0-aarch64-linux)
+    libdatadog (14.0.0.1.0-x86_64-linux)
     libddwaf (1.15.0.0.0-aarch64-linux)
       ffi (~> 1.0)
     libddwaf (1.15.0.0.0-x86_64-linux)

--- a/gemfiles/ruby_2.6_elasticsearch_7.gemfile.lock
+++ b/gemfiles/ruby_2.6_elasticsearch_7.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     datadog (2.4.0)
       datadog-ruby_core_source (~> 3.3)
-      libdatadog (~> 13.1.0.1.0)
+      libdatadog (~> 14.0.0.1.0)
       libddwaf (~> 1.15.0.0.0)
       msgpack
 
@@ -67,8 +67,8 @@ GEM
     json (2.6.3)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (13.1.0.1.0-aarch64-linux)
-    libdatadog (13.1.0.1.0-x86_64-linux)
+    libdatadog (14.0.0.1.0-aarch64-linux)
+    libdatadog (14.0.0.1.0-x86_64-linux)
     libddwaf (1.15.0.0.0-aarch64-linux)
       ffi (~> 1.0)
     libddwaf (1.15.0.0.0-x86_64-linux)

--- a/gemfiles/ruby_2.6_elasticsearch_8.gemfile.lock
+++ b/gemfiles/ruby_2.6_elasticsearch_8.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     datadog (2.4.0)
       datadog-ruby_core_source (~> 3.3)
-      libdatadog (~> 13.1.0.1.0)
+      libdatadog (~> 14.0.0.1.0)
       libddwaf (~> 1.15.0.0.0)
       msgpack
 
@@ -66,8 +66,8 @@ GEM
     json (2.6.3)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (13.1.0.1.0-aarch64-linux)
-    libdatadog (13.1.0.1.0-x86_64-linux)
+    libdatadog (14.0.0.1.0-aarch64-linux)
+    libdatadog (14.0.0.1.0-x86_64-linux)
     libddwaf (1.15.0.0.0-aarch64-linux)
       ffi (~> 1.0)
     libddwaf (1.15.0.0.0-x86_64-linux)

--- a/gemfiles/ruby_2.6_elasticsearch_latest.gemfile.lock
+++ b/gemfiles/ruby_2.6_elasticsearch_latest.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     datadog (2.4.0)
       datadog-ruby_core_source (~> 3.3)
-      libdatadog (~> 13.1.0.1.0)
+      libdatadog (~> 14.0.0.1.0)
       libddwaf (~> 1.15.0.0.0)
       msgpack
 
@@ -68,8 +68,8 @@ GEM
     json (2.7.2)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (13.1.0.1.0-aarch64-linux)
-    libdatadog (13.1.0.1.0-x86_64-linux)
+    libdatadog (14.0.0.1.0-aarch64-linux)
+    libdatadog (14.0.0.1.0-x86_64-linux)
     libddwaf (1.15.0.0.0-aarch64-linux)
       ffi (~> 1.0)
     libddwaf (1.15.0.0.0-x86_64-linux)

--- a/gemfiles/ruby_2.6_graphql_1.13.gemfile.lock
+++ b/gemfiles/ruby_2.6_graphql_1.13.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     datadog (2.4.0)
       datadog-ruby_core_source (~> 3.3)
-      libdatadog (~> 13.1.0.1.0)
+      libdatadog (~> 14.0.0.1.0)
       libddwaf (~> 1.15.0.0.0)
       msgpack
 
@@ -121,8 +121,8 @@ GEM
     json (2.7.1)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (13.1.0.1.0-aarch64-linux)
-    libdatadog (13.1.0.1.0-x86_64-linux)
+    libdatadog (14.0.0.1.0-aarch64-linux)
+    libdatadog (14.0.0.1.0-x86_64-linux)
     libddwaf (1.15.0.0.0-aarch64-linux)
       ffi (~> 1.0)
     libddwaf (1.15.0.0.0-x86_64-linux)

--- a/gemfiles/ruby_2.6_graphql_2.0.gemfile.lock
+++ b/gemfiles/ruby_2.6_graphql_2.0.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     datadog (2.4.0)
       datadog-ruby_core_source (~> 3.3)
-      libdatadog (~> 13.1.0.1.0)
+      libdatadog (~> 14.0.0.1.0)
       libddwaf (~> 1.15.0.0.0)
       msgpack
 
@@ -121,8 +121,8 @@ GEM
     json (2.7.1)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (13.1.0.1.0-aarch64-linux)
-    libdatadog (13.1.0.1.0-x86_64-linux)
+    libdatadog (14.0.0.1.0-aarch64-linux)
+    libdatadog (14.0.0.1.0-x86_64-linux)
     libddwaf (1.15.0.0.0-aarch64-linux)
       ffi (~> 1.0)
     libddwaf (1.15.0.0.0-x86_64-linux)

--- a/gemfiles/ruby_2.6_hanami_1.gemfile.lock
+++ b/gemfiles/ruby_2.6_hanami_1.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     datadog (2.4.0)
       datadog-ruby_core_source (~> 3.3)
-      libdatadog (~> 13.1.0.1.0)
+      libdatadog (~> 14.0.0.1.0)
       libddwaf (~> 1.15.0.0.0)
       msgpack
 
@@ -126,8 +126,8 @@ GEM
     json (2.6.3)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (13.1.0.1.0-aarch64-linux)
-    libdatadog (13.1.0.1.0-x86_64-linux)
+    libdatadog (14.0.0.1.0-aarch64-linux)
+    libdatadog (14.0.0.1.0-x86_64-linux)
     libddwaf (1.15.0.0.0-aarch64-linux)
       ffi (~> 1.0)
     libddwaf (1.15.0.0.0-x86_64-linux)

--- a/gemfiles/ruby_2.6_http.gemfile.lock
+++ b/gemfiles/ruby_2.6_http.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     datadog (2.4.0)
       datadog-ruby_core_source (~> 3.3)
-      libdatadog (~> 13.1.0.1.0)
+      libdatadog (~> 14.0.0.1.0)
       libddwaf (~> 1.15.0.0.0)
       msgpack
 
@@ -73,8 +73,8 @@ GEM
     json (2.6.3)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (13.1.0.1.0-aarch64-linux)
-    libdatadog (13.1.0.1.0-x86_64-linux)
+    libdatadog (14.0.0.1.0-aarch64-linux)
+    libdatadog (14.0.0.1.0-x86_64-linux)
     libddwaf (1.15.0.0.0-aarch64-linux)
       ffi (~> 1.0)
     libddwaf (1.15.0.0.0-x86_64-linux)

--- a/gemfiles/ruby_2.6_opensearch_2.gemfile.lock
+++ b/gemfiles/ruby_2.6_opensearch_2.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     datadog (2.4.0)
       datadog-ruby_core_source (~> 3.3)
-      libdatadog (~> 13.1.0.1.0)
+      libdatadog (~> 14.0.0.1.0)
       libddwaf (~> 1.15.0.0.0)
       msgpack
 
@@ -58,8 +58,8 @@ GEM
     json (2.6.3)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (13.1.0.1.0-aarch64-linux)
-    libdatadog (13.1.0.1.0-x86_64-linux)
+    libdatadog (14.0.0.1.0-aarch64-linux)
+    libdatadog (14.0.0.1.0-x86_64-linux)
     libddwaf (1.15.0.0.0-aarch64-linux)
       ffi (~> 1.0)
     libddwaf (1.15.0.0.0-x86_64-linux)

--- a/gemfiles/ruby_2.6_opensearch_3.gemfile.lock
+++ b/gemfiles/ruby_2.6_opensearch_3.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     datadog (2.4.0)
       datadog-ruby_core_source (~> 3.3)
-      libdatadog (~> 13.1.0.1.0)
+      libdatadog (~> 14.0.0.1.0)
       libddwaf (~> 1.15.0.0.0)
       msgpack
 
@@ -58,8 +58,8 @@ GEM
     json (2.6.3)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (13.1.0.1.0-aarch64-linux)
-    libdatadog (13.1.0.1.0-x86_64-linux)
+    libdatadog (14.0.0.1.0-aarch64-linux)
+    libdatadog (14.0.0.1.0-x86_64-linux)
     libddwaf (1.15.0.0.0-aarch64-linux)
       ffi (~> 1.0)
     libddwaf (1.15.0.0.0-x86_64-linux)

--- a/gemfiles/ruby_2.6_opensearch_latest.gemfile.lock
+++ b/gemfiles/ruby_2.6_opensearch_latest.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     datadog (2.4.0)
       datadog-ruby_core_source (~> 3.3)
-      libdatadog (~> 13.1.0.1.0)
+      libdatadog (~> 14.0.0.1.0)
       libddwaf (~> 1.15.0.0.0)
       msgpack
 
@@ -60,8 +60,8 @@ GEM
     json (2.7.2)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (13.1.0.1.0-aarch64-linux)
-    libdatadog (13.1.0.1.0-x86_64-linux)
+    libdatadog (14.0.0.1.0-aarch64-linux)
+    libdatadog (14.0.0.1.0-x86_64-linux)
     libddwaf (1.15.0.0.0-aarch64-linux)
       ffi (~> 1.0)
     libddwaf (1.15.0.0.0-x86_64-linux)

--- a/gemfiles/ruby_2.6_opentelemetry.gemfile.lock
+++ b/gemfiles/ruby_2.6_opentelemetry.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     datadog (2.4.0)
       datadog-ruby_core_source (~> 3.3)
-      libdatadog (~> 13.1.0.1.0)
+      libdatadog (~> 14.0.0.1.0)
       libddwaf (~> 1.15.0.0.0)
       msgpack
 
@@ -51,8 +51,8 @@ GEM
     json (2.6.3)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (13.1.0.1.0-aarch64-linux)
-    libdatadog (13.1.0.1.0-x86_64-linux)
+    libdatadog (14.0.0.1.0-aarch64-linux)
+    libdatadog (14.0.0.1.0-x86_64-linux)
     libddwaf (1.15.0.0.0-aarch64-linux)
       ffi (~> 1.0)
     libddwaf (1.15.0.0.0-x86_64-linux)

--- a/gemfiles/ruby_2.6_opentelemetry_otlp.gemfile.lock
+++ b/gemfiles/ruby_2.6_opentelemetry_otlp.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     datadog (2.4.0)
       datadog-ruby_core_source (~> 3.3)
-      libdatadog (~> 13.1.0.1.0)
+      libdatadog (~> 14.0.0.1.0)
       libddwaf (~> 1.15.0.0.0)
       msgpack
 
@@ -56,8 +56,8 @@ GEM
     json (2.7.1)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (13.1.0.1.0-aarch64-linux)
-    libdatadog (13.1.0.1.0-x86_64-linux)
+    libdatadog (14.0.0.1.0-aarch64-linux)
+    libdatadog (14.0.0.1.0-x86_64-linux)
     libddwaf (1.15.0.0.0-aarch64-linux)
       ffi (~> 1.0)
     libddwaf (1.15.0.0.0-x86_64-linux)

--- a/gemfiles/ruby_2.6_rack_1.gemfile.lock
+++ b/gemfiles/ruby_2.6_rack_1.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     datadog (2.4.0)
       datadog-ruby_core_source (~> 3.3)
-      libdatadog (~> 13.1.0.1.0)
+      libdatadog (~> 14.0.0.1.0)
       libddwaf (~> 1.15.0.0.0)
       msgpack
 
@@ -51,8 +51,8 @@ GEM
     json (2.6.3)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (13.1.0.1.0-aarch64-linux)
-    libdatadog (13.1.0.1.0-x86_64-linux)
+    libdatadog (14.0.0.1.0-aarch64-linux)
+    libdatadog (14.0.0.1.0-x86_64-linux)
     libddwaf (1.15.0.0.0-aarch64-linux)
       ffi (~> 1.0)
     libddwaf (1.15.0.0.0-x86_64-linux)

--- a/gemfiles/ruby_2.6_rack_2.gemfile.lock
+++ b/gemfiles/ruby_2.6_rack_2.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     datadog (2.4.0)
       datadog-ruby_core_source (~> 3.3)
-      libdatadog (~> 13.1.0.1.0)
+      libdatadog (~> 14.0.0.1.0)
       libddwaf (~> 1.15.0.0.0)
       msgpack
 
@@ -51,8 +51,8 @@ GEM
     json (2.6.3)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (13.1.0.1.0-aarch64-linux)
-    libdatadog (13.1.0.1.0-x86_64-linux)
+    libdatadog (14.0.0.1.0-aarch64-linux)
+    libdatadog (14.0.0.1.0-x86_64-linux)
     libddwaf (1.15.0.0.0-aarch64-linux)
       ffi (~> 1.0)
     libddwaf (1.15.0.0.0-x86_64-linux)

--- a/gemfiles/ruby_2.6_rack_3.gemfile.lock
+++ b/gemfiles/ruby_2.6_rack_3.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     datadog (2.4.0)
       datadog-ruby_core_source (~> 3.3)
-      libdatadog (~> 13.1.0.1.0)
+      libdatadog (~> 14.0.0.1.0)
       libddwaf (~> 1.15.0.0.0)
       msgpack
 
@@ -51,8 +51,8 @@ GEM
     json (2.6.3)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (13.1.0.1.0-aarch64-linux)
-    libdatadog (13.1.0.1.0-x86_64-linux)
+    libdatadog (14.0.0.1.0-aarch64-linux)
+    libdatadog (14.0.0.1.0-x86_64-linux)
     libddwaf (1.15.0.0.0-aarch64-linux)
       ffi (~> 1.0)
     libddwaf (1.15.0.0.0-x86_64-linux)

--- a/gemfiles/ruby_2.6_rack_latest.gemfile.lock
+++ b/gemfiles/ruby_2.6_rack_latest.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     datadog (2.4.0)
       datadog-ruby_core_source (~> 3.3)
-      libdatadog (~> 13.1.0.1.0)
+      libdatadog (~> 14.0.0.1.0)
       libddwaf (~> 1.15.0.0.0)
       msgpack
 
@@ -54,8 +54,8 @@ GEM
     json (2.7.2)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (13.1.0.1.0-aarch64-linux)
-    libdatadog (13.1.0.1.0-x86_64-linux)
+    libdatadog (14.0.0.1.0-aarch64-linux)
+    libdatadog (14.0.0.1.0-x86_64-linux)
     libddwaf (1.15.0.0.0-aarch64-linux)
       ffi (~> 1.0)
     libddwaf (1.15.0.0.0-x86_64-linux)

--- a/gemfiles/ruby_2.6_rails5_mysql2.gemfile.lock
+++ b/gemfiles/ruby_2.6_rails5_mysql2.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     datadog (2.4.0)
       datadog-ruby_core_source (~> 3.3)
-      libdatadog (~> 13.1.0.1.0)
+      libdatadog (~> 14.0.0.1.0)
       libddwaf (~> 1.15.0.0.0)
       msgpack
 
@@ -101,8 +101,8 @@ GEM
     json (2.6.3)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (13.1.0.1.0-aarch64-linux)
-    libdatadog (13.1.0.1.0-x86_64-linux)
+    libdatadog (14.0.0.1.0-aarch64-linux)
+    libdatadog (14.0.0.1.0-x86_64-linux)
     libddwaf (1.15.0.0.0-aarch64-linux)
       ffi (~> 1.0)
     libddwaf (1.15.0.0.0-x86_64-linux)

--- a/gemfiles/ruby_2.6_rails5_postgres.gemfile.lock
+++ b/gemfiles/ruby_2.6_rails5_postgres.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     datadog (2.4.0)
       datadog-ruby_core_source (~> 3.3)
-      libdatadog (~> 13.1.0.1.0)
+      libdatadog (~> 14.0.0.1.0)
       libddwaf (~> 1.15.0.0.0)
       msgpack
 
@@ -101,8 +101,8 @@ GEM
     json (2.6.3)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (13.1.0.1.0-aarch64-linux)
-    libdatadog (13.1.0.1.0-x86_64-linux)
+    libdatadog (14.0.0.1.0-aarch64-linux)
+    libdatadog (14.0.0.1.0-x86_64-linux)
     libddwaf (1.15.0.0.0-aarch64-linux)
       ffi (~> 1.0)
     libddwaf (1.15.0.0.0-x86_64-linux)

--- a/gemfiles/ruby_2.6_rails5_postgres_redis.gemfile.lock
+++ b/gemfiles/ruby_2.6_rails5_postgres_redis.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     datadog (2.4.0)
       datadog-ruby_core_source (~> 3.3)
-      libdatadog (~> 13.1.0.1.0)
+      libdatadog (~> 14.0.0.1.0)
       libddwaf (~> 1.15.0.0.0)
       msgpack
 
@@ -101,8 +101,8 @@ GEM
     json (2.6.3)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (13.1.0.1.0-aarch64-linux)
-    libdatadog (13.1.0.1.0-x86_64-linux)
+    libdatadog (14.0.0.1.0-aarch64-linux)
+    libdatadog (14.0.0.1.0-x86_64-linux)
     libddwaf (1.15.0.0.0-aarch64-linux)
       ffi (~> 1.0)
     libddwaf (1.15.0.0.0-x86_64-linux)

--- a/gemfiles/ruby_2.6_rails5_postgres_redis_activesupport.gemfile.lock
+++ b/gemfiles/ruby_2.6_rails5_postgres_redis_activesupport.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     datadog (2.4.0)
       datadog-ruby_core_source (~> 3.3)
-      libdatadog (~> 13.1.0.1.0)
+      libdatadog (~> 14.0.0.1.0)
       libddwaf (~> 1.15.0.0.0)
       msgpack
 
@@ -101,8 +101,8 @@ GEM
     json (2.6.3)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (13.1.0.1.0-aarch64-linux)
-    libdatadog (13.1.0.1.0-x86_64-linux)
+    libdatadog (14.0.0.1.0-aarch64-linux)
+    libdatadog (14.0.0.1.0-x86_64-linux)
     libddwaf (1.15.0.0.0-aarch64-linux)
       ffi (~> 1.0)
     libddwaf (1.15.0.0.0-x86_64-linux)

--- a/gemfiles/ruby_2.6_rails5_postgres_sidekiq.gemfile.lock
+++ b/gemfiles/ruby_2.6_rails5_postgres_sidekiq.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     datadog (2.4.0)
       datadog-ruby_core_source (~> 3.3)
-      libdatadog (~> 13.1.0.1.0)
+      libdatadog (~> 14.0.0.1.0)
       libddwaf (~> 1.15.0.0.0)
       msgpack
 
@@ -102,8 +102,8 @@ GEM
     json (2.6.3)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (13.1.0.1.0-aarch64-linux)
-    libdatadog (13.1.0.1.0-x86_64-linux)
+    libdatadog (14.0.0.1.0-aarch64-linux)
+    libdatadog (14.0.0.1.0-x86_64-linux)
     libddwaf (1.15.0.0.0-aarch64-linux)
       ffi (~> 1.0)
     libddwaf (1.15.0.0.0-x86_64-linux)

--- a/gemfiles/ruby_2.6_rails5_semantic_logger.gemfile.lock
+++ b/gemfiles/ruby_2.6_rails5_semantic_logger.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     datadog (2.4.0)
       datadog-ruby_core_source (~> 3.3)
-      libdatadog (~> 13.1.0.1.0)
+      libdatadog (~> 14.0.0.1.0)
       libddwaf (~> 1.15.0.0.0)
       msgpack
 
@@ -101,8 +101,8 @@ GEM
     json (2.6.3)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (13.1.0.1.0-aarch64-linux)
-    libdatadog (13.1.0.1.0-x86_64-linux)
+    libdatadog (14.0.0.1.0-aarch64-linux)
+    libdatadog (14.0.0.1.0-x86_64-linux)
     libddwaf (1.15.0.0.0-aarch64-linux)
       ffi (~> 1.0)
     libddwaf (1.15.0.0.0-x86_64-linux)

--- a/gemfiles/ruby_2.6_rails61_mysql2.gemfile.lock
+++ b/gemfiles/ruby_2.6_rails61_mysql2.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     datadog (2.4.0)
       datadog-ruby_core_source (~> 3.3)
-      libdatadog (~> 13.1.0.1.0)
+      libdatadog (~> 14.0.0.1.0)
       libddwaf (~> 1.15.0.0.0)
       msgpack
 
@@ -118,8 +118,8 @@ GEM
     json (2.6.3)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (13.1.0.1.0-aarch64-linux)
-    libdatadog (13.1.0.1.0-x86_64-linux)
+    libdatadog (14.0.0.1.0-aarch64-linux)
+    libdatadog (14.0.0.1.0-x86_64-linux)
     libddwaf (1.15.0.0.0-aarch64-linux)
       ffi (~> 1.0)
     libddwaf (1.15.0.0.0-x86_64-linux)

--- a/gemfiles/ruby_2.6_rails61_postgres.gemfile.lock
+++ b/gemfiles/ruby_2.6_rails61_postgres.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     datadog (2.4.0)
       datadog-ruby_core_source (~> 3.3)
-      libdatadog (~> 13.1.0.1.0)
+      libdatadog (~> 14.0.0.1.0)
       libddwaf (~> 1.15.0.0.0)
       msgpack
 
@@ -118,8 +118,8 @@ GEM
     json (2.6.3)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (13.1.0.1.0-aarch64-linux)
-    libdatadog (13.1.0.1.0-x86_64-linux)
+    libdatadog (14.0.0.1.0-aarch64-linux)
+    libdatadog (14.0.0.1.0-x86_64-linux)
     libddwaf (1.15.0.0.0-aarch64-linux)
       ffi (~> 1.0)
     libddwaf (1.15.0.0.0-x86_64-linux)

--- a/gemfiles/ruby_2.6_rails61_postgres_redis.gemfile.lock
+++ b/gemfiles/ruby_2.6_rails61_postgres_redis.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     datadog (2.4.0)
       datadog-ruby_core_source (~> 3.3)
-      libdatadog (~> 13.1.0.1.0)
+      libdatadog (~> 14.0.0.1.0)
       libddwaf (~> 1.15.0.0.0)
       msgpack
 
@@ -118,8 +118,8 @@ GEM
     json (2.6.3)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (13.1.0.1.0-aarch64-linux)
-    libdatadog (13.1.0.1.0-x86_64-linux)
+    libdatadog (14.0.0.1.0-aarch64-linux)
+    libdatadog (14.0.0.1.0-x86_64-linux)
     libddwaf (1.15.0.0.0-aarch64-linux)
       ffi (~> 1.0)
     libddwaf (1.15.0.0.0-x86_64-linux)

--- a/gemfiles/ruby_2.6_rails61_postgres_sidekiq.gemfile.lock
+++ b/gemfiles/ruby_2.6_rails61_postgres_sidekiq.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     datadog (2.4.0)
       datadog-ruby_core_source (~> 3.3)
-      libdatadog (~> 13.1.0.1.0)
+      libdatadog (~> 14.0.0.1.0)
       libddwaf (~> 1.15.0.0.0)
       msgpack
 
@@ -119,8 +119,8 @@ GEM
     json (2.6.3)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (13.1.0.1.0-aarch64-linux)
-    libdatadog (13.1.0.1.0-x86_64-linux)
+    libdatadog (14.0.0.1.0-aarch64-linux)
+    libdatadog (14.0.0.1.0-x86_64-linux)
     libddwaf (1.15.0.0.0-aarch64-linux)
       ffi (~> 1.0)
     libddwaf (1.15.0.0.0-x86_64-linux)

--- a/gemfiles/ruby_2.6_rails61_semantic_logger.gemfile.lock
+++ b/gemfiles/ruby_2.6_rails61_semantic_logger.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     datadog (2.4.0)
       datadog-ruby_core_source (~> 3.3)
-      libdatadog (~> 13.1.0.1.0)
+      libdatadog (~> 14.0.0.1.0)
       libddwaf (~> 1.15.0.0.0)
       msgpack
 
@@ -118,8 +118,8 @@ GEM
     json (2.6.3)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (13.1.0.1.0-aarch64-linux)
-    libdatadog (13.1.0.1.0-x86_64-linux)
+    libdatadog (14.0.0.1.0-aarch64-linux)
+    libdatadog (14.0.0.1.0-x86_64-linux)
     libddwaf (1.15.0.0.0-aarch64-linux)
       ffi (~> 1.0)
     libddwaf (1.15.0.0.0-x86_64-linux)

--- a/gemfiles/ruby_2.6_rails6_mysql2.gemfile.lock
+++ b/gemfiles/ruby_2.6_rails6_mysql2.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     datadog (2.4.0)
       datadog-ruby_core_source (~> 3.3)
-      libdatadog (~> 13.1.0.1.0)
+      libdatadog (~> 14.0.0.1.0)
       libddwaf (~> 1.15.0.0.0)
       msgpack
 
@@ -114,8 +114,8 @@ GEM
     json (2.6.3)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (13.1.0.1.0-aarch64-linux)
-    libdatadog (13.1.0.1.0-x86_64-linux)
+    libdatadog (14.0.0.1.0-aarch64-linux)
+    libdatadog (14.0.0.1.0-x86_64-linux)
     libddwaf (1.15.0.0.0-aarch64-linux)
       ffi (~> 1.0)
     libddwaf (1.15.0.0.0-x86_64-linux)

--- a/gemfiles/ruby_2.6_rails6_postgres.gemfile.lock
+++ b/gemfiles/ruby_2.6_rails6_postgres.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     datadog (2.4.0)
       datadog-ruby_core_source (~> 3.3)
-      libdatadog (~> 13.1.0.1.0)
+      libdatadog (~> 14.0.0.1.0)
       libddwaf (~> 1.15.0.0.0)
       msgpack
 
@@ -114,8 +114,8 @@ GEM
     json (2.6.3)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (13.1.0.1.0-aarch64-linux)
-    libdatadog (13.1.0.1.0-x86_64-linux)
+    libdatadog (14.0.0.1.0-aarch64-linux)
+    libdatadog (14.0.0.1.0-x86_64-linux)
     libddwaf (1.15.0.0.0-aarch64-linux)
       ffi (~> 1.0)
     libddwaf (1.15.0.0.0-x86_64-linux)

--- a/gemfiles/ruby_2.6_rails6_postgres_redis.gemfile.lock
+++ b/gemfiles/ruby_2.6_rails6_postgres_redis.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     datadog (2.4.0)
       datadog-ruby_core_source (~> 3.3)
-      libdatadog (~> 13.1.0.1.0)
+      libdatadog (~> 14.0.0.1.0)
       libddwaf (~> 1.15.0.0.0)
       msgpack
 
@@ -114,8 +114,8 @@ GEM
     json (2.6.3)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (13.1.0.1.0-aarch64-linux)
-    libdatadog (13.1.0.1.0-x86_64-linux)
+    libdatadog (14.0.0.1.0-aarch64-linux)
+    libdatadog (14.0.0.1.0-x86_64-linux)
     libddwaf (1.15.0.0.0-aarch64-linux)
       ffi (~> 1.0)
     libddwaf (1.15.0.0.0-x86_64-linux)

--- a/gemfiles/ruby_2.6_rails6_postgres_redis_activesupport.gemfile.lock
+++ b/gemfiles/ruby_2.6_rails6_postgres_redis_activesupport.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     datadog (2.4.0)
       datadog-ruby_core_source (~> 3.3)
-      libdatadog (~> 13.1.0.1.0)
+      libdatadog (~> 14.0.0.1.0)
       libddwaf (~> 1.15.0.0.0)
       msgpack
 
@@ -114,8 +114,8 @@ GEM
     json (2.6.3)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (13.1.0.1.0-aarch64-linux)
-    libdatadog (13.1.0.1.0-x86_64-linux)
+    libdatadog (14.0.0.1.0-aarch64-linux)
+    libdatadog (14.0.0.1.0-x86_64-linux)
     libddwaf (1.15.0.0.0-aarch64-linux)
       ffi (~> 1.0)
     libddwaf (1.15.0.0.0-x86_64-linux)

--- a/gemfiles/ruby_2.6_rails6_postgres_sidekiq.gemfile.lock
+++ b/gemfiles/ruby_2.6_rails6_postgres_sidekiq.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     datadog (2.4.0)
       datadog-ruby_core_source (~> 3.3)
-      libdatadog (~> 13.1.0.1.0)
+      libdatadog (~> 14.0.0.1.0)
       libddwaf (~> 1.15.0.0.0)
       msgpack
 
@@ -115,8 +115,8 @@ GEM
     json (2.6.3)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (13.1.0.1.0-aarch64-linux)
-    libdatadog (13.1.0.1.0-x86_64-linux)
+    libdatadog (14.0.0.1.0-aarch64-linux)
+    libdatadog (14.0.0.1.0-x86_64-linux)
     libddwaf (1.15.0.0.0-aarch64-linux)
       ffi (~> 1.0)
     libddwaf (1.15.0.0.0-x86_64-linux)

--- a/gemfiles/ruby_2.6_rails6_semantic_logger.gemfile.lock
+++ b/gemfiles/ruby_2.6_rails6_semantic_logger.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     datadog (2.4.0)
       datadog-ruby_core_source (~> 3.3)
-      libdatadog (~> 13.1.0.1.0)
+      libdatadog (~> 14.0.0.1.0)
       libddwaf (~> 1.15.0.0.0)
       msgpack
 
@@ -114,8 +114,8 @@ GEM
     json (2.6.3)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (13.1.0.1.0-aarch64-linux)
-    libdatadog (13.1.0.1.0-x86_64-linux)
+    libdatadog (14.0.0.1.0-aarch64-linux)
+    libdatadog (14.0.0.1.0-x86_64-linux)
     libddwaf (1.15.0.0.0-aarch64-linux)
       ffi (~> 1.0)
     libddwaf (1.15.0.0.0-x86_64-linux)

--- a/gemfiles/ruby_2.6_redis_3.gemfile.lock
+++ b/gemfiles/ruby_2.6_redis_3.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     datadog (2.4.0)
       datadog-ruby_core_source (~> 3.3)
-      libdatadog (~> 13.1.0.1.0)
+      libdatadog (~> 14.0.0.1.0)
       libddwaf (~> 1.15.0.0.0)
       msgpack
 
@@ -51,8 +51,8 @@ GEM
     json (2.6.3)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (13.1.0.1.0-aarch64-linux)
-    libdatadog (13.1.0.1.0-x86_64-linux)
+    libdatadog (14.0.0.1.0-aarch64-linux)
+    libdatadog (14.0.0.1.0-x86_64-linux)
     libddwaf (1.15.0.0.0-aarch64-linux)
       ffi (~> 1.0)
     libddwaf (1.15.0.0.0-x86_64-linux)

--- a/gemfiles/ruby_2.6_redis_4.gemfile.lock
+++ b/gemfiles/ruby_2.6_redis_4.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     datadog (2.4.0)
       datadog-ruby_core_source (~> 3.3)
-      libdatadog (~> 13.1.0.1.0)
+      libdatadog (~> 14.0.0.1.0)
       libddwaf (~> 1.15.0.0.0)
       msgpack
 
@@ -51,8 +51,8 @@ GEM
     json (2.6.3)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (13.1.0.1.0-aarch64-linux)
-    libdatadog (13.1.0.1.0-x86_64-linux)
+    libdatadog (14.0.0.1.0-aarch64-linux)
+    libdatadog (14.0.0.1.0-x86_64-linux)
     libddwaf (1.15.0.0.0-aarch64-linux)
       ffi (~> 1.0)
     libddwaf (1.15.0.0.0-x86_64-linux)

--- a/gemfiles/ruby_2.6_redis_5.gemfile.lock
+++ b/gemfiles/ruby_2.6_redis_5.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     datadog (2.4.0)
       datadog-ruby_core_source (~> 3.3)
-      libdatadog (~> 13.1.0.1.0)
+      libdatadog (~> 14.0.0.1.0)
       libddwaf (~> 1.15.0.0.0)
       msgpack
 
@@ -52,8 +52,8 @@ GEM
     json (2.6.3)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (13.1.0.1.0-aarch64-linux)
-    libdatadog (13.1.0.1.0-x86_64-linux)
+    libdatadog (14.0.0.1.0-aarch64-linux)
+    libdatadog (14.0.0.1.0-x86_64-linux)
     libddwaf (1.15.0.0.0-aarch64-linux)
       ffi (~> 1.0)
     libddwaf (1.15.0.0.0-x86_64-linux)

--- a/gemfiles/ruby_2.6_relational_db.gemfile.lock
+++ b/gemfiles/ruby_2.6_relational_db.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     datadog (2.4.0)
       datadog-ruby_core_source (~> 3.3)
-      libdatadog (~> 13.1.0.1.0)
+      libdatadog (~> 14.0.0.1.0)
       libddwaf (~> 1.15.0.0.0)
       msgpack
 
@@ -70,8 +70,8 @@ GEM
     json (2.6.3)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (13.1.0.1.0-aarch64-linux)
-    libdatadog (13.1.0.1.0-x86_64-linux)
+    libdatadog (14.0.0.1.0-aarch64-linux)
+    libdatadog (14.0.0.1.0-x86_64-linux)
     libddwaf (1.15.0.0.0-aarch64-linux)
       ffi (~> 1.0)
     libddwaf (1.15.0.0.0-x86_64-linux)

--- a/gemfiles/ruby_2.6_resque2_redis3.gemfile.lock
+++ b/gemfiles/ruby_2.6_resque2_redis3.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     datadog (2.4.0)
       datadog-ruby_core_source (~> 3.3)
-      libdatadog (~> 13.1.0.1.0)
+      libdatadog (~> 14.0.0.1.0)
       libddwaf (~> 1.15.0.0.0)
       msgpack
 
@@ -51,8 +51,8 @@ GEM
     json (2.6.3)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (13.1.0.1.0-aarch64-linux)
-    libdatadog (13.1.0.1.0-x86_64-linux)
+    libdatadog (14.0.0.1.0-aarch64-linux)
+    libdatadog (14.0.0.1.0-x86_64-linux)
     libddwaf (1.15.0.0.0-aarch64-linux)
       ffi (~> 1.0)
     libddwaf (1.15.0.0.0-x86_64-linux)

--- a/gemfiles/ruby_2.6_resque2_redis4.gemfile.lock
+++ b/gemfiles/ruby_2.6_resque2_redis4.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     datadog (2.4.0)
       datadog-ruby_core_source (~> 3.3)
-      libdatadog (~> 13.1.0.1.0)
+      libdatadog (~> 14.0.0.1.0)
       libddwaf (~> 1.15.0.0.0)
       msgpack
 
@@ -51,8 +51,8 @@ GEM
     json (2.6.3)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (13.1.0.1.0-aarch64-linux)
-    libdatadog (13.1.0.1.0-x86_64-linux)
+    libdatadog (14.0.0.1.0-aarch64-linux)
+    libdatadog (14.0.0.1.0-x86_64-linux)
     libddwaf (1.15.0.0.0-aarch64-linux)
       ffi (~> 1.0)
     libddwaf (1.15.0.0.0-x86_64-linux)

--- a/gemfiles/ruby_2.6_sinatra_2.gemfile.lock
+++ b/gemfiles/ruby_2.6_sinatra_2.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     datadog (2.4.0)
       datadog-ruby_core_source (~> 3.3)
-      libdatadog (~> 13.1.0.1.0)
+      libdatadog (~> 14.0.0.1.0)
       libddwaf (~> 1.15.0.0.0)
       msgpack
 
@@ -54,8 +54,8 @@ GEM
     json (2.7.2)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (13.1.0.1.0-aarch64-linux)
-    libdatadog (13.1.0.1.0-x86_64-linux)
+    libdatadog (14.0.0.1.0-aarch64-linux)
+    libdatadog (14.0.0.1.0-x86_64-linux)
     libddwaf (1.15.0.0.0-aarch64-linux)
       ffi (~> 1.0)
     libddwaf (1.15.0.0.0-x86_64-linux)

--- a/gemfiles/ruby_2.6_sinatra_3.gemfile.lock
+++ b/gemfiles/ruby_2.6_sinatra_3.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     datadog (2.4.0)
       datadog-ruby_core_source (~> 3.3)
-      libdatadog (~> 13.1.0.1.0)
+      libdatadog (~> 14.0.0.1.0)
       libddwaf (~> 1.15.0.0.0)
       msgpack
 
@@ -55,8 +55,8 @@ GEM
     json (2.7.2)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (13.1.0.1.0-aarch64-linux)
-    libdatadog (13.1.0.1.0-x86_64-linux)
+    libdatadog (14.0.0.1.0-aarch64-linux)
+    libdatadog (14.0.0.1.0-x86_64-linux)
     libddwaf (1.15.0.0.0-aarch64-linux)
       ffi (~> 1.0)
     libddwaf (1.15.0.0.0-x86_64-linux)

--- a/gemfiles/ruby_2.6_stripe_10.gemfile.lock
+++ b/gemfiles/ruby_2.6_stripe_10.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     datadog (2.4.0)
       datadog-ruby_core_source (~> 3.3)
-      libdatadog (~> 13.1.0.1.0)
+      libdatadog (~> 14.0.0.1.0)
       libddwaf (~> 1.15.0.0.0)
       msgpack
 
@@ -54,8 +54,8 @@ GEM
     json (2.7.2)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (13.1.0.1.0-aarch64-linux)
-    libdatadog (13.1.0.1.0-x86_64-linux)
+    libdatadog (14.0.0.1.0-aarch64-linux)
+    libdatadog (14.0.0.1.0-x86_64-linux)
     libddwaf (1.15.0.0.0-aarch64-linux)
       ffi (~> 1.0)
     libddwaf (1.15.0.0.0-x86_64-linux)

--- a/gemfiles/ruby_2.6_stripe_11.gemfile.lock
+++ b/gemfiles/ruby_2.6_stripe_11.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     datadog (2.4.0)
       datadog-ruby_core_source (~> 3.3)
-      libdatadog (~> 13.1.0.1.0)
+      libdatadog (~> 14.0.0.1.0)
       libddwaf (~> 1.15.0.0.0)
       msgpack
 
@@ -54,8 +54,8 @@ GEM
     json (2.7.2)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (13.1.0.1.0-aarch64-linux)
-    libdatadog (13.1.0.1.0-x86_64-linux)
+    libdatadog (14.0.0.1.0-aarch64-linux)
+    libdatadog (14.0.0.1.0-x86_64-linux)
     libddwaf (1.15.0.0.0-aarch64-linux)
       ffi (~> 1.0)
     libddwaf (1.15.0.0.0-x86_64-linux)

--- a/gemfiles/ruby_2.6_stripe_12.gemfile.lock
+++ b/gemfiles/ruby_2.6_stripe_12.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     datadog (2.4.0)
       datadog-ruby_core_source (~> 3.3)
-      libdatadog (~> 13.1.0.1.0)
+      libdatadog (~> 14.0.0.1.0)
       libddwaf (~> 1.15.0.0.0)
       msgpack
 
@@ -54,8 +54,8 @@ GEM
     json (2.7.2)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (13.1.0.1.0-aarch64-linux)
-    libdatadog (13.1.0.1.0-x86_64-linux)
+    libdatadog (14.0.0.1.0-aarch64-linux)
+    libdatadog (14.0.0.1.0-x86_64-linux)
     libddwaf (1.15.0.0.0-aarch64-linux)
       ffi (~> 1.0)
     libddwaf (1.15.0.0.0-x86_64-linux)

--- a/gemfiles/ruby_2.6_stripe_7.gemfile.lock
+++ b/gemfiles/ruby_2.6_stripe_7.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     datadog (2.4.0)
       datadog-ruby_core_source (~> 3.3)
-      libdatadog (~> 13.1.0.1.0)
+      libdatadog (~> 14.0.0.1.0)
       libddwaf (~> 1.15.0.0.0)
       msgpack
 
@@ -54,8 +54,8 @@ GEM
     json (2.7.2)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (13.1.0.1.0-aarch64-linux)
-    libdatadog (13.1.0.1.0-x86_64-linux)
+    libdatadog (14.0.0.1.0-aarch64-linux)
+    libdatadog (14.0.0.1.0-x86_64-linux)
     libddwaf (1.15.0.0.0-aarch64-linux)
       ffi (~> 1.0)
     libddwaf (1.15.0.0.0-x86_64-linux)

--- a/gemfiles/ruby_2.6_stripe_8.gemfile.lock
+++ b/gemfiles/ruby_2.6_stripe_8.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     datadog (2.4.0)
       datadog-ruby_core_source (~> 3.3)
-      libdatadog (~> 13.1.0.1.0)
+      libdatadog (~> 14.0.0.1.0)
       libddwaf (~> 1.15.0.0.0)
       msgpack
 
@@ -54,8 +54,8 @@ GEM
     json (2.7.2)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (13.1.0.1.0-aarch64-linux)
-    libdatadog (13.1.0.1.0-x86_64-linux)
+    libdatadog (14.0.0.1.0-aarch64-linux)
+    libdatadog (14.0.0.1.0-x86_64-linux)
     libddwaf (1.15.0.0.0-aarch64-linux)
       ffi (~> 1.0)
     libddwaf (1.15.0.0.0-x86_64-linux)

--- a/gemfiles/ruby_2.6_stripe_9.gemfile.lock
+++ b/gemfiles/ruby_2.6_stripe_9.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     datadog (2.4.0)
       datadog-ruby_core_source (~> 3.3)
-      libdatadog (~> 13.1.0.1.0)
+      libdatadog (~> 14.0.0.1.0)
       libddwaf (~> 1.15.0.0.0)
       msgpack
 
@@ -54,8 +54,8 @@ GEM
     json (2.7.2)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (13.1.0.1.0-aarch64-linux)
-    libdatadog (13.1.0.1.0-x86_64-linux)
+    libdatadog (14.0.0.1.0-aarch64-linux)
+    libdatadog (14.0.0.1.0-x86_64-linux)
     libddwaf (1.15.0.0.0-aarch64-linux)
       ffi (~> 1.0)
     libddwaf (1.15.0.0.0-x86_64-linux)

--- a/gemfiles/ruby_2.6_stripe_latest.gemfile.lock
+++ b/gemfiles/ruby_2.6_stripe_latest.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     datadog (2.4.0)
       datadog-ruby_core_source (~> 3.3)
-      libdatadog (~> 13.1.0.1.0)
+      libdatadog (~> 14.0.0.1.0)
       libddwaf (~> 1.15.0.0.0)
       msgpack
 
@@ -54,8 +54,8 @@ GEM
     json (2.7.2)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (13.1.0.1.0-aarch64-linux)
-    libdatadog (13.1.0.1.0-x86_64-linux)
+    libdatadog (14.0.0.1.0-aarch64-linux)
+    libdatadog (14.0.0.1.0-x86_64-linux)
     libddwaf (1.15.0.0.0-aarch64-linux)
       ffi (~> 1.0)
     libddwaf (1.15.0.0.0-x86_64-linux)

--- a/gemfiles/ruby_2.6_stripe_min.gemfile.lock
+++ b/gemfiles/ruby_2.6_stripe_min.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     datadog (2.4.0)
       datadog-ruby_core_source (~> 3.3)
-      libdatadog (~> 13.1.0.1.0)
+      libdatadog (~> 14.0.0.1.0)
       libddwaf (~> 1.15.0.0.0)
       msgpack
 
@@ -54,8 +54,8 @@ GEM
     json (2.7.2)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (13.1.0.1.0-aarch64-linux)
-    libdatadog (13.1.0.1.0-x86_64-linux)
+    libdatadog (14.0.0.1.0-aarch64-linux)
+    libdatadog (14.0.0.1.0-x86_64-linux)
     libddwaf (1.15.0.0.0-aarch64-linux)
       ffi (~> 1.0)
     libddwaf (1.15.0.0.0-x86_64-linux)

--- a/gemfiles/ruby_2.7_activesupport.gemfile.lock
+++ b/gemfiles/ruby_2.7_activesupport.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     datadog (2.4.0)
       datadog-ruby_core_source (~> 3.3)
-      libdatadog (~> 13.1.0.1.0)
+      libdatadog (~> 14.0.0.1.0)
       libddwaf (~> 1.15.0.0.0)
       msgpack
 
@@ -109,8 +109,8 @@ GEM
       addressable (>= 2.4)
     jsonapi-renderer (0.2.2)
     king_konf (1.0.1)
-    libdatadog (13.1.0.1.0-aarch64-linux)
-    libdatadog (13.1.0.1.0-x86_64-linux)
+    libdatadog (14.0.0.1.0-aarch64-linux)
+    libdatadog (14.0.0.1.0-x86_64-linux)
     libddwaf (1.15.0.0.0-aarch64-linux)
       ffi (~> 1.0)
     libddwaf (1.15.0.0.0-x86_64-linux)

--- a/gemfiles/ruby_2.7_aws.gemfile.lock
+++ b/gemfiles/ruby_2.7_aws.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     datadog (2.4.0)
       datadog-ruby_core_source (~> 3.3)
-      libdatadog (~> 13.1.0.1.0)
+      libdatadog (~> 14.0.0.1.0)
       libddwaf (~> 1.15.0.0.0)
       msgpack
 
@@ -1473,8 +1473,8 @@ GEM
     json (2.6.3)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (13.1.0.1.0-aarch64-linux)
-    libdatadog (13.1.0.1.0-x86_64-linux)
+    libdatadog (14.0.0.1.0-aarch64-linux)
+    libdatadog (14.0.0.1.0-x86_64-linux)
     libddwaf (1.15.0.0.0-aarch64-linux)
       ffi (~> 1.0)
     libddwaf (1.15.0.0.0-x86_64-linux)

--- a/gemfiles/ruby_2.7_contrib.gemfile.lock
+++ b/gemfiles/ruby_2.7_contrib.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     datadog (2.4.0)
       datadog-ruby_core_source (~> 3.3)
-      libdatadog (~> 13.1.0.1.0)
+      libdatadog (~> 14.0.0.1.0)
       libddwaf (~> 1.15.0.0.0)
       msgpack
 
@@ -66,8 +66,8 @@ GEM
     json (2.6.3)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (13.1.0.1.0-aarch64-linux)
-    libdatadog (13.1.0.1.0-x86_64-linux)
+    libdatadog (14.0.0.1.0-aarch64-linux)
+    libdatadog (14.0.0.1.0-x86_64-linux)
     libddwaf (1.15.0.0.0-aarch64-linux)
       ffi (~> 1.0)
     libddwaf (1.15.0.0.0-x86_64-linux)

--- a/gemfiles/ruby_2.7_contrib_old.gemfile.lock
+++ b/gemfiles/ruby_2.7_contrib_old.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     datadog (2.4.0)
       datadog-ruby_core_source (~> 3.3)
-      libdatadog (~> 13.1.0.1.0)
+      libdatadog (~> 14.0.0.1.0)
       libddwaf (~> 1.15.0.0.0)
       msgpack
 
@@ -62,8 +62,8 @@ GEM
     json (2.6.3)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (13.1.0.1.0-aarch64-linux)
-    libdatadog (13.1.0.1.0-x86_64-linux)
+    libdatadog (14.0.0.1.0-aarch64-linux)
+    libdatadog (14.0.0.1.0-x86_64-linux)
     libddwaf (1.15.0.0.0-aarch64-linux)
       ffi (~> 1.0)
     libddwaf (1.15.0.0.0-x86_64-linux)

--- a/gemfiles/ruby_2.7_core_old.gemfile.lock
+++ b/gemfiles/ruby_2.7_core_old.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     datadog (2.4.0)
       datadog-ruby_core_source (~> 3.3)
-      libdatadog (~> 13.1.0.1.0)
+      libdatadog (~> 14.0.0.1.0)
       libddwaf (~> 1.15.0.0.0)
       msgpack
 
@@ -51,8 +51,8 @@ GEM
     json (2.6.3)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (13.1.0.1.0-aarch64-linux)
-    libdatadog (13.1.0.1.0-x86_64-linux)
+    libdatadog (14.0.0.1.0-aarch64-linux)
+    libdatadog (14.0.0.1.0-x86_64-linux)
     libddwaf (1.15.0.0.0-aarch64-linux)
       ffi (~> 1.0)
     libddwaf (1.15.0.0.0-x86_64-linux)

--- a/gemfiles/ruby_2.7_elasticsearch_7.gemfile.lock
+++ b/gemfiles/ruby_2.7_elasticsearch_7.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     datadog (2.4.0)
       datadog-ruby_core_source (~> 3.3)
-      libdatadog (~> 13.1.0.1.0)
+      libdatadog (~> 14.0.0.1.0)
       libddwaf (~> 1.15.0.0.0)
       msgpack
 
@@ -67,8 +67,8 @@ GEM
     json (2.6.3)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (13.1.0.1.0-aarch64-linux)
-    libdatadog (13.1.0.1.0-x86_64-linux)
+    libdatadog (14.0.0.1.0-aarch64-linux)
+    libdatadog (14.0.0.1.0-x86_64-linux)
     libddwaf (1.15.0.0.0-aarch64-linux)
       ffi (~> 1.0)
     libddwaf (1.15.0.0.0-x86_64-linux)

--- a/gemfiles/ruby_2.7_elasticsearch_8.gemfile.lock
+++ b/gemfiles/ruby_2.7_elasticsearch_8.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     datadog (2.4.0)
       datadog-ruby_core_source (~> 3.3)
-      libdatadog (~> 13.1.0.1.0)
+      libdatadog (~> 14.0.0.1.0)
       libddwaf (~> 1.15.0.0.0)
       msgpack
 
@@ -66,8 +66,8 @@ GEM
     json (2.6.3)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (13.1.0.1.0-aarch64-linux)
-    libdatadog (13.1.0.1.0-x86_64-linux)
+    libdatadog (14.0.0.1.0-aarch64-linux)
+    libdatadog (14.0.0.1.0-x86_64-linux)
     libddwaf (1.15.0.0.0-aarch64-linux)
       ffi (~> 1.0)
     libddwaf (1.15.0.0.0-x86_64-linux)

--- a/gemfiles/ruby_2.7_elasticsearch_latest.gemfile.lock
+++ b/gemfiles/ruby_2.7_elasticsearch_latest.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     datadog (2.4.0)
       datadog-ruby_core_source (~> 3.3)
-      libdatadog (~> 13.1.0.1.0)
+      libdatadog (~> 14.0.0.1.0)
       libddwaf (~> 1.15.0.0.0)
       msgpack
 
@@ -67,8 +67,8 @@ GEM
     json (2.7.2)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (13.1.0.1.0-aarch64-linux)
-    libdatadog (13.1.0.1.0-x86_64-linux)
+    libdatadog (14.0.0.1.0-aarch64-linux)
+    libdatadog (14.0.0.1.0-x86_64-linux)
     libddwaf (1.15.0.0.0-aarch64-linux)
       ffi (~> 1.0)
     libddwaf (1.15.0.0.0-x86_64-linux)

--- a/gemfiles/ruby_2.7_graphql_1.13.gemfile.lock
+++ b/gemfiles/ruby_2.7_graphql_1.13.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     datadog (2.4.0)
       datadog-ruby_core_source (~> 3.3)
-      libdatadog (~> 13.1.0.1.0)
+      libdatadog (~> 14.0.0.1.0)
       libddwaf (~> 1.15.0.0.0)
       msgpack
 
@@ -121,8 +121,8 @@ GEM
     json (2.7.1)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (13.1.0.1.0-aarch64-linux)
-    libdatadog (13.1.0.1.0-x86_64-linux)
+    libdatadog (14.0.0.1.0-aarch64-linux)
+    libdatadog (14.0.0.1.0-x86_64-linux)
     libddwaf (1.15.0.0.0-aarch64-linux)
       ffi (~> 1.0)
     libddwaf (1.15.0.0.0-x86_64-linux)

--- a/gemfiles/ruby_2.7_graphql_2.0.gemfile.lock
+++ b/gemfiles/ruby_2.7_graphql_2.0.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     datadog (2.4.0)
       datadog-ruby_core_source (~> 3.3)
-      libdatadog (~> 13.1.0.1.0)
+      libdatadog (~> 14.0.0.1.0)
       libddwaf (~> 1.15.0.0.0)
       msgpack
 
@@ -121,8 +121,8 @@ GEM
     json (2.7.1)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (13.1.0.1.0-aarch64-linux)
-    libdatadog (13.1.0.1.0-x86_64-linux)
+    libdatadog (14.0.0.1.0-aarch64-linux)
+    libdatadog (14.0.0.1.0-x86_64-linux)
     libddwaf (1.15.0.0.0-aarch64-linux)
       ffi (~> 1.0)
     libddwaf (1.15.0.0.0-x86_64-linux)

--- a/gemfiles/ruby_2.7_graphql_2.1.gemfile.lock
+++ b/gemfiles/ruby_2.7_graphql_2.1.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     datadog (2.4.0)
       datadog-ruby_core_source (~> 3.3)
-      libdatadog (~> 13.1.0.1.0)
+      libdatadog (~> 14.0.0.1.0)
       libddwaf (~> 1.15.0.0.0)
       msgpack
 
@@ -122,8 +122,8 @@ GEM
     json (2.7.1)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (13.1.0.1.0-aarch64-linux)
-    libdatadog (13.1.0.1.0-x86_64-linux)
+    libdatadog (14.0.0.1.0-aarch64-linux)
+    libdatadog (14.0.0.1.0-x86_64-linux)
     libddwaf (1.15.0.0.0-aarch64-linux)
       ffi (~> 1.0)
     libddwaf (1.15.0.0.0-x86_64-linux)

--- a/gemfiles/ruby_2.7_graphql_2.2.gemfile.lock
+++ b/gemfiles/ruby_2.7_graphql_2.2.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     datadog (2.4.0)
       datadog-ruby_core_source (~> 3.3)
-      libdatadog (~> 13.1.0.1.0)
+      libdatadog (~> 14.0.0.1.0)
       libddwaf (~> 1.15.0.0.0)
       msgpack
 
@@ -122,8 +122,8 @@ GEM
     json (2.7.1)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (13.1.0.1.0-aarch64-linux)
-    libdatadog (13.1.0.1.0-x86_64-linux)
+    libdatadog (14.0.0.1.0-aarch64-linux)
+    libdatadog (14.0.0.1.0-x86_64-linux)
     libddwaf (1.15.0.0.0-aarch64-linux)
       ffi (~> 1.0)
     libddwaf (1.15.0.0.0-x86_64-linux)

--- a/gemfiles/ruby_2.7_graphql_2.3.gemfile.lock
+++ b/gemfiles/ruby_2.7_graphql_2.3.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     datadog (2.4.0)
       datadog-ruby_core_source (~> 3.3)
-      libdatadog (~> 13.1.0.1.0)
+      libdatadog (~> 14.0.0.1.0)
       libddwaf (~> 1.15.0.0.0)
       msgpack
 
@@ -123,8 +123,8 @@ GEM
     json (2.7.2)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (13.1.0.1.0-aarch64-linux)
-    libdatadog (13.1.0.1.0-x86_64-linux)
+    libdatadog (14.0.0.1.0-aarch64-linux)
+    libdatadog (14.0.0.1.0-x86_64-linux)
     libddwaf (1.15.0.0.0-aarch64-linux)
       ffi (~> 1.0)
     libddwaf (1.15.0.0.0-x86_64-linux)

--- a/gemfiles/ruby_2.7_hanami_1.gemfile.lock
+++ b/gemfiles/ruby_2.7_hanami_1.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     datadog (2.4.0)
       datadog-ruby_core_source (~> 3.3)
-      libdatadog (~> 13.1.0.1.0)
+      libdatadog (~> 14.0.0.1.0)
       libddwaf (~> 1.15.0.0.0)
       msgpack
 
@@ -127,8 +127,8 @@ GEM
     json (2.6.3)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (13.1.0.1.0-aarch64-linux)
-    libdatadog (13.1.0.1.0-x86_64-linux)
+    libdatadog (14.0.0.1.0-aarch64-linux)
+    libdatadog (14.0.0.1.0-x86_64-linux)
     libddwaf (1.15.0.0.0-aarch64-linux)
       ffi (~> 1.0)
     libddwaf (1.15.0.0.0-x86_64-linux)

--- a/gemfiles/ruby_2.7_http.gemfile.lock
+++ b/gemfiles/ruby_2.7_http.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     datadog (2.4.0)
       datadog-ruby_core_source (~> 3.3)
-      libdatadog (~> 13.1.0.1.0)
+      libdatadog (~> 14.0.0.1.0)
       libddwaf (~> 1.15.0.0.0)
       msgpack
 
@@ -73,8 +73,8 @@ GEM
     json (2.6.3)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (13.1.0.1.0-aarch64-linux)
-    libdatadog (13.1.0.1.0-x86_64-linux)
+    libdatadog (14.0.0.1.0-aarch64-linux)
+    libdatadog (14.0.0.1.0-x86_64-linux)
     libddwaf (1.15.0.0.0-aarch64-linux)
       ffi (~> 1.0)
     libddwaf (1.15.0.0.0-x86_64-linux)

--- a/gemfiles/ruby_2.7_opensearch_2.gemfile.lock
+++ b/gemfiles/ruby_2.7_opensearch_2.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     datadog (2.4.0)
       datadog-ruby_core_source (~> 3.3)
-      libdatadog (~> 13.1.0.1.0)
+      libdatadog (~> 14.0.0.1.0)
       libddwaf (~> 1.15.0.0.0)
       msgpack
 
@@ -58,8 +58,8 @@ GEM
     json (2.6.3)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (13.1.0.1.0-aarch64-linux)
-    libdatadog (13.1.0.1.0-x86_64-linux)
+    libdatadog (14.0.0.1.0-aarch64-linux)
+    libdatadog (14.0.0.1.0-x86_64-linux)
     libddwaf (1.15.0.0.0-aarch64-linux)
       ffi (~> 1.0)
     libddwaf (1.15.0.0.0-x86_64-linux)

--- a/gemfiles/ruby_2.7_opensearch_3.gemfile.lock
+++ b/gemfiles/ruby_2.7_opensearch_3.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     datadog (2.4.0)
       datadog-ruby_core_source (~> 3.3)
-      libdatadog (~> 13.1.0.1.0)
+      libdatadog (~> 14.0.0.1.0)
       libddwaf (~> 1.15.0.0.0)
       msgpack
 
@@ -58,8 +58,8 @@ GEM
     json (2.6.3)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (13.1.0.1.0-aarch64-linux)
-    libdatadog (13.1.0.1.0-x86_64-linux)
+    libdatadog (14.0.0.1.0-aarch64-linux)
+    libdatadog (14.0.0.1.0-x86_64-linux)
     libddwaf (1.15.0.0.0-aarch64-linux)
       ffi (~> 1.0)
     libddwaf (1.15.0.0.0-x86_64-linux)

--- a/gemfiles/ruby_2.7_opensearch_latest.gemfile.lock
+++ b/gemfiles/ruby_2.7_opensearch_latest.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     datadog (2.4.0)
       datadog-ruby_core_source (~> 3.3)
-      libdatadog (~> 13.1.0.1.0)
+      libdatadog (~> 14.0.0.1.0)
       libddwaf (~> 1.15.0.0.0)
       msgpack
 
@@ -59,8 +59,8 @@ GEM
     json (2.7.2)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (13.1.0.1.0-aarch64-linux)
-    libdatadog (13.1.0.1.0-x86_64-linux)
+    libdatadog (14.0.0.1.0-aarch64-linux)
+    libdatadog (14.0.0.1.0-x86_64-linux)
     libddwaf (1.15.0.0.0-aarch64-linux)
       ffi (~> 1.0)
     libddwaf (1.15.0.0.0-x86_64-linux)

--- a/gemfiles/ruby_2.7_opentelemetry.gemfile.lock
+++ b/gemfiles/ruby_2.7_opentelemetry.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     datadog (2.4.0)
       datadog-ruby_core_source (~> 3.3)
-      libdatadog (~> 13.1.0.1.0)
+      libdatadog (~> 14.0.0.1.0)
       libddwaf (~> 1.15.0.0.0)
       msgpack
 
@@ -51,8 +51,8 @@ GEM
     json (2.6.3)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (13.1.0.1.0-aarch64-linux)
-    libdatadog (13.1.0.1.0-x86_64-linux)
+    libdatadog (14.0.0.1.0-aarch64-linux)
+    libdatadog (14.0.0.1.0-x86_64-linux)
     libddwaf (1.15.0.0.0-aarch64-linux)
       ffi (~> 1.0)
     libddwaf (1.15.0.0.0-x86_64-linux)

--- a/gemfiles/ruby_2.7_opentelemetry_otlp.gemfile.lock
+++ b/gemfiles/ruby_2.7_opentelemetry_otlp.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     datadog (2.4.0)
       datadog-ruby_core_source (~> 3.3)
-      libdatadog (~> 13.1.0.1.0)
+      libdatadog (~> 14.0.0.1.0)
       libddwaf (~> 1.15.0.0.0)
       msgpack
 
@@ -56,8 +56,8 @@ GEM
     json (2.7.1)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (13.1.0.1.0-aarch64-linux)
-    libdatadog (13.1.0.1.0-x86_64-linux)
+    libdatadog (14.0.0.1.0-aarch64-linux)
+    libdatadog (14.0.0.1.0-x86_64-linux)
     libddwaf (1.15.0.0.0-aarch64-linux)
       ffi (~> 1.0)
     libddwaf (1.15.0.0.0-x86_64-linux)

--- a/gemfiles/ruby_2.7_rack_1.gemfile.lock
+++ b/gemfiles/ruby_2.7_rack_1.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     datadog (2.4.0)
       datadog-ruby_core_source (~> 3.3)
-      libdatadog (~> 13.1.0.1.0)
+      libdatadog (~> 14.0.0.1.0)
       libddwaf (~> 1.15.0.0.0)
       msgpack
 
@@ -51,8 +51,8 @@ GEM
     json (2.6.3)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (13.1.0.1.0-aarch64-linux)
-    libdatadog (13.1.0.1.0-x86_64-linux)
+    libdatadog (14.0.0.1.0-aarch64-linux)
+    libdatadog (14.0.0.1.0-x86_64-linux)
     libddwaf (1.15.0.0.0-aarch64-linux)
       ffi (~> 1.0)
     libddwaf (1.15.0.0.0-x86_64-linux)

--- a/gemfiles/ruby_2.7_rack_2.gemfile.lock
+++ b/gemfiles/ruby_2.7_rack_2.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     datadog (2.4.0)
       datadog-ruby_core_source (~> 3.3)
-      libdatadog (~> 13.1.0.1.0)
+      libdatadog (~> 14.0.0.1.0)
       libddwaf (~> 1.15.0.0.0)
       msgpack
 
@@ -51,8 +51,8 @@ GEM
     json (2.6.3)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (13.1.0.1.0-aarch64-linux)
-    libdatadog (13.1.0.1.0-x86_64-linux)
+    libdatadog (14.0.0.1.0-aarch64-linux)
+    libdatadog (14.0.0.1.0-x86_64-linux)
     libddwaf (1.15.0.0.0-aarch64-linux)
       ffi (~> 1.0)
     libddwaf (1.15.0.0.0-x86_64-linux)

--- a/gemfiles/ruby_2.7_rack_3.gemfile.lock
+++ b/gemfiles/ruby_2.7_rack_3.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     datadog (2.4.0)
       datadog-ruby_core_source (~> 3.3)
-      libdatadog (~> 13.1.0.1.0)
+      libdatadog (~> 14.0.0.1.0)
       libddwaf (~> 1.15.0.0.0)
       msgpack
 
@@ -51,8 +51,8 @@ GEM
     json (2.6.3)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (13.1.0.1.0-aarch64-linux)
-    libdatadog (13.1.0.1.0-x86_64-linux)
+    libdatadog (14.0.0.1.0-aarch64-linux)
+    libdatadog (14.0.0.1.0-x86_64-linux)
     libddwaf (1.15.0.0.0-aarch64-linux)
       ffi (~> 1.0)
     libddwaf (1.15.0.0.0-x86_64-linux)

--- a/gemfiles/ruby_2.7_rack_latest.gemfile.lock
+++ b/gemfiles/ruby_2.7_rack_latest.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     datadog (2.4.0)
       datadog-ruby_core_source (~> 3.3)
-      libdatadog (~> 13.1.0.1.0)
+      libdatadog (~> 14.0.0.1.0)
       libddwaf (~> 1.15.0.0.0)
       msgpack
 
@@ -54,8 +54,8 @@ GEM
     json (2.7.2)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (13.1.0.1.0-aarch64-linux)
-    libdatadog (13.1.0.1.0-x86_64-linux)
+    libdatadog (14.0.0.1.0-aarch64-linux)
+    libdatadog (14.0.0.1.0-x86_64-linux)
     libddwaf (1.15.0.0.0-aarch64-linux)
       ffi (~> 1.0)
     libddwaf (1.15.0.0.0-x86_64-linux)

--- a/gemfiles/ruby_2.7_rails5_mysql2.gemfile.lock
+++ b/gemfiles/ruby_2.7_rails5_mysql2.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     datadog (2.4.0)
       datadog-ruby_core_source (~> 3.3)
-      libdatadog (~> 13.1.0.1.0)
+      libdatadog (~> 14.0.0.1.0)
       libddwaf (~> 1.15.0.0.0)
       msgpack
 
@@ -101,8 +101,8 @@ GEM
     json (2.6.3)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (13.1.0.1.0-aarch64-linux)
-    libdatadog (13.1.0.1.0-x86_64-linux)
+    libdatadog (14.0.0.1.0-aarch64-linux)
+    libdatadog (14.0.0.1.0-x86_64-linux)
     libddwaf (1.15.0.0.0-aarch64-linux)
       ffi (~> 1.0)
     libddwaf (1.15.0.0.0-x86_64-linux)

--- a/gemfiles/ruby_2.7_rails5_postgres.gemfile.lock
+++ b/gemfiles/ruby_2.7_rails5_postgres.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     datadog (2.4.0)
       datadog-ruby_core_source (~> 3.3)
-      libdatadog (~> 13.1.0.1.0)
+      libdatadog (~> 14.0.0.1.0)
       libddwaf (~> 1.15.0.0.0)
       msgpack
 
@@ -101,8 +101,8 @@ GEM
     json (2.6.3)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (13.1.0.1.0-aarch64-linux)
-    libdatadog (13.1.0.1.0-x86_64-linux)
+    libdatadog (14.0.0.1.0-aarch64-linux)
+    libdatadog (14.0.0.1.0-x86_64-linux)
     libddwaf (1.15.0.0.0-aarch64-linux)
       ffi (~> 1.0)
     libddwaf (1.15.0.0.0-x86_64-linux)

--- a/gemfiles/ruby_2.7_rails5_postgres_redis.gemfile.lock
+++ b/gemfiles/ruby_2.7_rails5_postgres_redis.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     datadog (2.4.0)
       datadog-ruby_core_source (~> 3.3)
-      libdatadog (~> 13.1.0.1.0)
+      libdatadog (~> 14.0.0.1.0)
       libddwaf (~> 1.15.0.0.0)
       msgpack
 
@@ -101,8 +101,8 @@ GEM
     json (2.6.3)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (13.1.0.1.0-aarch64-linux)
-    libdatadog (13.1.0.1.0-x86_64-linux)
+    libdatadog (14.0.0.1.0-aarch64-linux)
+    libdatadog (14.0.0.1.0-x86_64-linux)
     libddwaf (1.15.0.0.0-aarch64-linux)
       ffi (~> 1.0)
     libddwaf (1.15.0.0.0-x86_64-linux)

--- a/gemfiles/ruby_2.7_rails5_postgres_redis_activesupport.gemfile.lock
+++ b/gemfiles/ruby_2.7_rails5_postgres_redis_activesupport.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     datadog (2.4.0)
       datadog-ruby_core_source (~> 3.3)
-      libdatadog (~> 13.1.0.1.0)
+      libdatadog (~> 14.0.0.1.0)
       libddwaf (~> 1.15.0.0.0)
       msgpack
 
@@ -101,8 +101,8 @@ GEM
     json (2.6.3)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (13.1.0.1.0-aarch64-linux)
-    libdatadog (13.1.0.1.0-x86_64-linux)
+    libdatadog (14.0.0.1.0-aarch64-linux)
+    libdatadog (14.0.0.1.0-x86_64-linux)
     libddwaf (1.15.0.0.0-aarch64-linux)
       ffi (~> 1.0)
     libddwaf (1.15.0.0.0-x86_64-linux)

--- a/gemfiles/ruby_2.7_rails5_postgres_sidekiq.gemfile.lock
+++ b/gemfiles/ruby_2.7_rails5_postgres_sidekiq.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     datadog (2.4.0)
       datadog-ruby_core_source (~> 3.3)
-      libdatadog (~> 13.1.0.1.0)
+      libdatadog (~> 14.0.0.1.0)
       libddwaf (~> 1.15.0.0.0)
       msgpack
 
@@ -102,8 +102,8 @@ GEM
     json (2.6.3)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (13.1.0.1.0-aarch64-linux)
-    libdatadog (13.1.0.1.0-x86_64-linux)
+    libdatadog (14.0.0.1.0-aarch64-linux)
+    libdatadog (14.0.0.1.0-x86_64-linux)
     libddwaf (1.15.0.0.0-aarch64-linux)
       ffi (~> 1.0)
     libddwaf (1.15.0.0.0-x86_64-linux)

--- a/gemfiles/ruby_2.7_rails5_semantic_logger.gemfile.lock
+++ b/gemfiles/ruby_2.7_rails5_semantic_logger.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     datadog (2.4.0)
       datadog-ruby_core_source (~> 3.3)
-      libdatadog (~> 13.1.0.1.0)
+      libdatadog (~> 14.0.0.1.0)
       libddwaf (~> 1.15.0.0.0)
       msgpack
 
@@ -101,8 +101,8 @@ GEM
     json (2.6.3)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (13.1.0.1.0-aarch64-linux)
-    libdatadog (13.1.0.1.0-x86_64-linux)
+    libdatadog (14.0.0.1.0-aarch64-linux)
+    libdatadog (14.0.0.1.0-x86_64-linux)
     libddwaf (1.15.0.0.0-aarch64-linux)
       ffi (~> 1.0)
     libddwaf (1.15.0.0.0-x86_64-linux)

--- a/gemfiles/ruby_2.7_rails61_mysql2.gemfile.lock
+++ b/gemfiles/ruby_2.7_rails61_mysql2.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     datadog (2.4.0)
       datadog-ruby_core_source (~> 3.3)
-      libdatadog (~> 13.1.0.1.0)
+      libdatadog (~> 14.0.0.1.0)
       libddwaf (~> 1.15.0.0.0)
       msgpack
 
@@ -118,8 +118,8 @@ GEM
     json (2.6.3)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (13.1.0.1.0-aarch64-linux)
-    libdatadog (13.1.0.1.0-x86_64-linux)
+    libdatadog (14.0.0.1.0-aarch64-linux)
+    libdatadog (14.0.0.1.0-x86_64-linux)
     libddwaf (1.15.0.0.0-aarch64-linux)
       ffi (~> 1.0)
     libddwaf (1.15.0.0.0-x86_64-linux)

--- a/gemfiles/ruby_2.7_rails61_postgres.gemfile.lock
+++ b/gemfiles/ruby_2.7_rails61_postgres.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     datadog (2.4.0)
       datadog-ruby_core_source (~> 3.3)
-      libdatadog (~> 13.1.0.1.0)
+      libdatadog (~> 14.0.0.1.0)
       libddwaf (~> 1.15.0.0.0)
       msgpack
 
@@ -118,8 +118,8 @@ GEM
     json (2.6.3)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (13.1.0.1.0-aarch64-linux)
-    libdatadog (13.1.0.1.0-x86_64-linux)
+    libdatadog (14.0.0.1.0-aarch64-linux)
+    libdatadog (14.0.0.1.0-x86_64-linux)
     libddwaf (1.15.0.0.0-aarch64-linux)
       ffi (~> 1.0)
     libddwaf (1.15.0.0.0-x86_64-linux)

--- a/gemfiles/ruby_2.7_rails61_postgres_redis.gemfile.lock
+++ b/gemfiles/ruby_2.7_rails61_postgres_redis.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     datadog (2.4.0)
       datadog-ruby_core_source (~> 3.3)
-      libdatadog (~> 13.1.0.1.0)
+      libdatadog (~> 14.0.0.1.0)
       libddwaf (~> 1.15.0.0.0)
       msgpack
 
@@ -118,8 +118,8 @@ GEM
     json (2.6.3)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (13.1.0.1.0-aarch64-linux)
-    libdatadog (13.1.0.1.0-x86_64-linux)
+    libdatadog (14.0.0.1.0-aarch64-linux)
+    libdatadog (14.0.0.1.0-x86_64-linux)
     libddwaf (1.15.0.0.0-aarch64-linux)
       ffi (~> 1.0)
     libddwaf (1.15.0.0.0-x86_64-linux)

--- a/gemfiles/ruby_2.7_rails61_postgres_sidekiq.gemfile.lock
+++ b/gemfiles/ruby_2.7_rails61_postgres_sidekiq.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     datadog (2.4.0)
       datadog-ruby_core_source (~> 3.3)
-      libdatadog (~> 13.1.0.1.0)
+      libdatadog (~> 14.0.0.1.0)
       libddwaf (~> 1.15.0.0.0)
       msgpack
 
@@ -119,8 +119,8 @@ GEM
     json (2.6.3)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (13.1.0.1.0-aarch64-linux)
-    libdatadog (13.1.0.1.0-x86_64-linux)
+    libdatadog (14.0.0.1.0-aarch64-linux)
+    libdatadog (14.0.0.1.0-x86_64-linux)
     libddwaf (1.15.0.0.0-aarch64-linux)
       ffi (~> 1.0)
     libddwaf (1.15.0.0.0-x86_64-linux)

--- a/gemfiles/ruby_2.7_rails61_semantic_logger.gemfile.lock
+++ b/gemfiles/ruby_2.7_rails61_semantic_logger.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     datadog (2.4.0)
       datadog-ruby_core_source (~> 3.3)
-      libdatadog (~> 13.1.0.1.0)
+      libdatadog (~> 14.0.0.1.0)
       libddwaf (~> 1.15.0.0.0)
       msgpack
 
@@ -118,8 +118,8 @@ GEM
     json (2.6.3)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (13.1.0.1.0-aarch64-linux)
-    libdatadog (13.1.0.1.0-x86_64-linux)
+    libdatadog (14.0.0.1.0-aarch64-linux)
+    libdatadog (14.0.0.1.0-x86_64-linux)
     libddwaf (1.15.0.0.0-aarch64-linux)
       ffi (~> 1.0)
     libddwaf (1.15.0.0.0-x86_64-linux)

--- a/gemfiles/ruby_2.7_rails6_mysql2.gemfile.lock
+++ b/gemfiles/ruby_2.7_rails6_mysql2.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     datadog (2.4.0)
       datadog-ruby_core_source (~> 3.3)
-      libdatadog (~> 13.1.0.1.0)
+      libdatadog (~> 14.0.0.1.0)
       libddwaf (~> 1.15.0.0.0)
       msgpack
 
@@ -114,8 +114,8 @@ GEM
     json (2.6.3)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (13.1.0.1.0-aarch64-linux)
-    libdatadog (13.1.0.1.0-x86_64-linux)
+    libdatadog (14.0.0.1.0-aarch64-linux)
+    libdatadog (14.0.0.1.0-x86_64-linux)
     libddwaf (1.15.0.0.0-aarch64-linux)
       ffi (~> 1.0)
     libddwaf (1.15.0.0.0-x86_64-linux)

--- a/gemfiles/ruby_2.7_rails6_postgres.gemfile.lock
+++ b/gemfiles/ruby_2.7_rails6_postgres.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     datadog (2.4.0)
       datadog-ruby_core_source (~> 3.3)
-      libdatadog (~> 13.1.0.1.0)
+      libdatadog (~> 14.0.0.1.0)
       libddwaf (~> 1.15.0.0.0)
       msgpack
 
@@ -114,8 +114,8 @@ GEM
     json (2.6.3)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (13.1.0.1.0-aarch64-linux)
-    libdatadog (13.1.0.1.0-x86_64-linux)
+    libdatadog (14.0.0.1.0-aarch64-linux)
+    libdatadog (14.0.0.1.0-x86_64-linux)
     libddwaf (1.15.0.0.0-aarch64-linux)
       ffi (~> 1.0)
     libddwaf (1.15.0.0.0-x86_64-linux)

--- a/gemfiles/ruby_2.7_rails6_postgres_redis.gemfile.lock
+++ b/gemfiles/ruby_2.7_rails6_postgres_redis.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     datadog (2.4.0)
       datadog-ruby_core_source (~> 3.3)
-      libdatadog (~> 13.1.0.1.0)
+      libdatadog (~> 14.0.0.1.0)
       libddwaf (~> 1.15.0.0.0)
       msgpack
 
@@ -114,8 +114,8 @@ GEM
     json (2.6.3)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (13.1.0.1.0-aarch64-linux)
-    libdatadog (13.1.0.1.0-x86_64-linux)
+    libdatadog (14.0.0.1.0-aarch64-linux)
+    libdatadog (14.0.0.1.0-x86_64-linux)
     libddwaf (1.15.0.0.0-aarch64-linux)
       ffi (~> 1.0)
     libddwaf (1.15.0.0.0-x86_64-linux)

--- a/gemfiles/ruby_2.7_rails6_postgres_redis_activesupport.gemfile.lock
+++ b/gemfiles/ruby_2.7_rails6_postgres_redis_activesupport.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     datadog (2.4.0)
       datadog-ruby_core_source (~> 3.3)
-      libdatadog (~> 13.1.0.1.0)
+      libdatadog (~> 14.0.0.1.0)
       libddwaf (~> 1.15.0.0.0)
       msgpack
 
@@ -114,8 +114,8 @@ GEM
     json (2.6.3)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (13.1.0.1.0-aarch64-linux)
-    libdatadog (13.1.0.1.0-x86_64-linux)
+    libdatadog (14.0.0.1.0-aarch64-linux)
+    libdatadog (14.0.0.1.0-x86_64-linux)
     libddwaf (1.15.0.0.0-aarch64-linux)
       ffi (~> 1.0)
     libddwaf (1.15.0.0.0-x86_64-linux)

--- a/gemfiles/ruby_2.7_rails6_postgres_sidekiq.gemfile.lock
+++ b/gemfiles/ruby_2.7_rails6_postgres_sidekiq.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     datadog (2.4.0)
       datadog-ruby_core_source (~> 3.3)
-      libdatadog (~> 13.1.0.1.0)
+      libdatadog (~> 14.0.0.1.0)
       libddwaf (~> 1.15.0.0.0)
       msgpack
 
@@ -115,8 +115,8 @@ GEM
     json (2.6.3)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (13.1.0.1.0-aarch64-linux)
-    libdatadog (13.1.0.1.0-x86_64-linux)
+    libdatadog (14.0.0.1.0-aarch64-linux)
+    libdatadog (14.0.0.1.0-x86_64-linux)
     libddwaf (1.15.0.0.0-aarch64-linux)
       ffi (~> 1.0)
     libddwaf (1.15.0.0.0-x86_64-linux)

--- a/gemfiles/ruby_2.7_rails6_semantic_logger.gemfile.lock
+++ b/gemfiles/ruby_2.7_rails6_semantic_logger.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     datadog (2.4.0)
       datadog-ruby_core_source (~> 3.3)
-      libdatadog (~> 13.1.0.1.0)
+      libdatadog (~> 14.0.0.1.0)
       libddwaf (~> 1.15.0.0.0)
       msgpack
 
@@ -114,8 +114,8 @@ GEM
     json (2.6.3)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (13.1.0.1.0-aarch64-linux)
-    libdatadog (13.1.0.1.0-x86_64-linux)
+    libdatadog (14.0.0.1.0-aarch64-linux)
+    libdatadog (14.0.0.1.0-x86_64-linux)
     libddwaf (1.15.0.0.0-aarch64-linux)
       ffi (~> 1.0)
     libddwaf (1.15.0.0.0-x86_64-linux)

--- a/gemfiles/ruby_2.7_redis_3.gemfile.lock
+++ b/gemfiles/ruby_2.7_redis_3.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     datadog (2.4.0)
       datadog-ruby_core_source (~> 3.3)
-      libdatadog (~> 13.1.0.1.0)
+      libdatadog (~> 14.0.0.1.0)
       libddwaf (~> 1.15.0.0.0)
       msgpack
 
@@ -51,8 +51,8 @@ GEM
     json (2.6.3)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (13.1.0.1.0-aarch64-linux)
-    libdatadog (13.1.0.1.0-x86_64-linux)
+    libdatadog (14.0.0.1.0-aarch64-linux)
+    libdatadog (14.0.0.1.0-x86_64-linux)
     libddwaf (1.15.0.0.0-aarch64-linux)
       ffi (~> 1.0)
     libddwaf (1.15.0.0.0-x86_64-linux)

--- a/gemfiles/ruby_2.7_redis_4.gemfile.lock
+++ b/gemfiles/ruby_2.7_redis_4.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     datadog (2.4.0)
       datadog-ruby_core_source (~> 3.3)
-      libdatadog (~> 13.1.0.1.0)
+      libdatadog (~> 14.0.0.1.0)
       libddwaf (~> 1.15.0.0.0)
       msgpack
 
@@ -51,8 +51,8 @@ GEM
     json (2.6.3)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (13.1.0.1.0-aarch64-linux)
-    libdatadog (13.1.0.1.0-x86_64-linux)
+    libdatadog (14.0.0.1.0-aarch64-linux)
+    libdatadog (14.0.0.1.0-x86_64-linux)
     libddwaf (1.15.0.0.0-aarch64-linux)
       ffi (~> 1.0)
     libddwaf (1.15.0.0.0-x86_64-linux)

--- a/gemfiles/ruby_2.7_redis_5.gemfile.lock
+++ b/gemfiles/ruby_2.7_redis_5.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     datadog (2.4.0)
       datadog-ruby_core_source (~> 3.3)
-      libdatadog (~> 13.1.0.1.0)
+      libdatadog (~> 14.0.0.1.0)
       libddwaf (~> 1.15.0.0.0)
       msgpack
 
@@ -52,8 +52,8 @@ GEM
     json (2.6.3)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (13.1.0.1.0-aarch64-linux)
-    libdatadog (13.1.0.1.0-x86_64-linux)
+    libdatadog (14.0.0.1.0-aarch64-linux)
+    libdatadog (14.0.0.1.0-x86_64-linux)
     libddwaf (1.15.0.0.0-aarch64-linux)
       ffi (~> 1.0)
     libddwaf (1.15.0.0.0-x86_64-linux)

--- a/gemfiles/ruby_2.7_relational_db.gemfile.lock
+++ b/gemfiles/ruby_2.7_relational_db.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     datadog (2.4.0)
       datadog-ruby_core_source (~> 3.3)
-      libdatadog (~> 13.1.0.1.0)
+      libdatadog (~> 14.0.0.1.0)
       libddwaf (~> 1.15.0.0.0)
       msgpack
 
@@ -70,8 +70,8 @@ GEM
     json (2.6.3)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (13.1.0.1.0-aarch64-linux)
-    libdatadog (13.1.0.1.0-x86_64-linux)
+    libdatadog (14.0.0.1.0-aarch64-linux)
+    libdatadog (14.0.0.1.0-x86_64-linux)
     libddwaf (1.15.0.0.0-aarch64-linux)
       ffi (~> 1.0)
     libddwaf (1.15.0.0.0-x86_64-linux)

--- a/gemfiles/ruby_2.7_resque2_redis3.gemfile.lock
+++ b/gemfiles/ruby_2.7_resque2_redis3.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     datadog (2.4.0)
       datadog-ruby_core_source (~> 3.3)
-      libdatadog (~> 13.1.0.1.0)
+      libdatadog (~> 14.0.0.1.0)
       libddwaf (~> 1.15.0.0.0)
       msgpack
 
@@ -51,8 +51,8 @@ GEM
     json (2.6.3)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (13.1.0.1.0-aarch64-linux)
-    libdatadog (13.1.0.1.0-x86_64-linux)
+    libdatadog (14.0.0.1.0-aarch64-linux)
+    libdatadog (14.0.0.1.0-x86_64-linux)
     libddwaf (1.15.0.0.0-aarch64-linux)
       ffi (~> 1.0)
     libddwaf (1.15.0.0.0-x86_64-linux)

--- a/gemfiles/ruby_2.7_resque2_redis4.gemfile.lock
+++ b/gemfiles/ruby_2.7_resque2_redis4.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     datadog (2.4.0)
       datadog-ruby_core_source (~> 3.3)
-      libdatadog (~> 13.1.0.1.0)
+      libdatadog (~> 14.0.0.1.0)
       libddwaf (~> 1.15.0.0.0)
       msgpack
 
@@ -51,8 +51,8 @@ GEM
     json (2.6.3)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (13.1.0.1.0-aarch64-linux)
-    libdatadog (13.1.0.1.0-x86_64-linux)
+    libdatadog (14.0.0.1.0-aarch64-linux)
+    libdatadog (14.0.0.1.0-x86_64-linux)
     libddwaf (1.15.0.0.0-aarch64-linux)
       ffi (~> 1.0)
     libddwaf (1.15.0.0.0-x86_64-linux)

--- a/gemfiles/ruby_2.7_sinatra_2.gemfile.lock
+++ b/gemfiles/ruby_2.7_sinatra_2.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     datadog (2.4.0)
       datadog-ruby_core_source (~> 3.3)
-      libdatadog (~> 13.1.0.1.0)
+      libdatadog (~> 14.0.0.1.0)
       libddwaf (~> 1.15.0.0.0)
       msgpack
 
@@ -54,8 +54,8 @@ GEM
     json (2.7.2)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (13.1.0.1.0-aarch64-linux)
-    libdatadog (13.1.0.1.0-x86_64-linux)
+    libdatadog (14.0.0.1.0-aarch64-linux)
+    libdatadog (14.0.0.1.0-x86_64-linux)
     libddwaf (1.15.0.0.0-aarch64-linux)
       ffi (~> 1.0)
     libddwaf (1.15.0.0.0-x86_64-linux)

--- a/gemfiles/ruby_2.7_sinatra_3.gemfile.lock
+++ b/gemfiles/ruby_2.7_sinatra_3.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     datadog (2.4.0)
       datadog-ruby_core_source (~> 3.3)
-      libdatadog (~> 13.1.0.1.0)
+      libdatadog (~> 14.0.0.1.0)
       libddwaf (~> 1.15.0.0.0)
       msgpack
 
@@ -55,8 +55,8 @@ GEM
     json (2.7.2)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (13.1.0.1.0-aarch64-linux)
-    libdatadog (13.1.0.1.0-x86_64-linux)
+    libdatadog (14.0.0.1.0-aarch64-linux)
+    libdatadog (14.0.0.1.0-x86_64-linux)
     libddwaf (1.15.0.0.0-aarch64-linux)
       ffi (~> 1.0)
     libddwaf (1.15.0.0.0-x86_64-linux)

--- a/gemfiles/ruby_2.7_stripe_10.gemfile.lock
+++ b/gemfiles/ruby_2.7_stripe_10.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     datadog (2.4.0)
       datadog-ruby_core_source (~> 3.3)
-      libdatadog (~> 13.1.0.1.0)
+      libdatadog (~> 14.0.0.1.0)
       libddwaf (~> 1.15.0.0.0)
       msgpack
 
@@ -53,8 +53,8 @@ GEM
     json (2.7.2)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (13.1.0.1.0-aarch64-linux)
-    libdatadog (13.1.0.1.0-x86_64-linux)
+    libdatadog (14.0.0.1.0-aarch64-linux)
+    libdatadog (14.0.0.1.0-x86_64-linux)
     libddwaf (1.15.0.0.0-aarch64-linux)
       ffi (~> 1.0)
     libddwaf (1.15.0.0.0-x86_64-linux)

--- a/gemfiles/ruby_2.7_stripe_11.gemfile.lock
+++ b/gemfiles/ruby_2.7_stripe_11.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     datadog (2.4.0)
       datadog-ruby_core_source (~> 3.3)
-      libdatadog (~> 13.1.0.1.0)
+      libdatadog (~> 14.0.0.1.0)
       libddwaf (~> 1.15.0.0.0)
       msgpack
 
@@ -53,8 +53,8 @@ GEM
     json (2.7.2)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (13.1.0.1.0-aarch64-linux)
-    libdatadog (13.1.0.1.0-x86_64-linux)
+    libdatadog (14.0.0.1.0-aarch64-linux)
+    libdatadog (14.0.0.1.0-x86_64-linux)
     libddwaf (1.15.0.0.0-aarch64-linux)
       ffi (~> 1.0)
     libddwaf (1.15.0.0.0-x86_64-linux)

--- a/gemfiles/ruby_2.7_stripe_12.gemfile.lock
+++ b/gemfiles/ruby_2.7_stripe_12.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     datadog (2.4.0)
       datadog-ruby_core_source (~> 3.3)
-      libdatadog (~> 13.1.0.1.0)
+      libdatadog (~> 14.0.0.1.0)
       libddwaf (~> 1.15.0.0.0)
       msgpack
 
@@ -53,8 +53,8 @@ GEM
     json (2.7.2)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (13.1.0.1.0-aarch64-linux)
-    libdatadog (13.1.0.1.0-x86_64-linux)
+    libdatadog (14.0.0.1.0-aarch64-linux)
+    libdatadog (14.0.0.1.0-x86_64-linux)
     libddwaf (1.15.0.0.0-aarch64-linux)
       ffi (~> 1.0)
     libddwaf (1.15.0.0.0-x86_64-linux)

--- a/gemfiles/ruby_2.7_stripe_7.gemfile.lock
+++ b/gemfiles/ruby_2.7_stripe_7.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     datadog (2.4.0)
       datadog-ruby_core_source (~> 3.3)
-      libdatadog (~> 13.1.0.1.0)
+      libdatadog (~> 14.0.0.1.0)
       libddwaf (~> 1.15.0.0.0)
       msgpack
 
@@ -53,8 +53,8 @@ GEM
     json (2.7.2)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (13.1.0.1.0-aarch64-linux)
-    libdatadog (13.1.0.1.0-x86_64-linux)
+    libdatadog (14.0.0.1.0-aarch64-linux)
+    libdatadog (14.0.0.1.0-x86_64-linux)
     libddwaf (1.15.0.0.0-aarch64-linux)
       ffi (~> 1.0)
     libddwaf (1.15.0.0.0-x86_64-linux)

--- a/gemfiles/ruby_2.7_stripe_8.gemfile.lock
+++ b/gemfiles/ruby_2.7_stripe_8.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     datadog (2.4.0)
       datadog-ruby_core_source (~> 3.3)
-      libdatadog (~> 13.1.0.1.0)
+      libdatadog (~> 14.0.0.1.0)
       libddwaf (~> 1.15.0.0.0)
       msgpack
 
@@ -53,8 +53,8 @@ GEM
     json (2.7.2)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (13.1.0.1.0-aarch64-linux)
-    libdatadog (13.1.0.1.0-x86_64-linux)
+    libdatadog (14.0.0.1.0-aarch64-linux)
+    libdatadog (14.0.0.1.0-x86_64-linux)
     libddwaf (1.15.0.0.0-aarch64-linux)
       ffi (~> 1.0)
     libddwaf (1.15.0.0.0-x86_64-linux)

--- a/gemfiles/ruby_2.7_stripe_9.gemfile.lock
+++ b/gemfiles/ruby_2.7_stripe_9.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     datadog (2.4.0)
       datadog-ruby_core_source (~> 3.3)
-      libdatadog (~> 13.1.0.1.0)
+      libdatadog (~> 14.0.0.1.0)
       libddwaf (~> 1.15.0.0.0)
       msgpack
 
@@ -53,8 +53,8 @@ GEM
     json (2.7.2)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (13.1.0.1.0-aarch64-linux)
-    libdatadog (13.1.0.1.0-x86_64-linux)
+    libdatadog (14.0.0.1.0-aarch64-linux)
+    libdatadog (14.0.0.1.0-x86_64-linux)
     libddwaf (1.15.0.0.0-aarch64-linux)
       ffi (~> 1.0)
     libddwaf (1.15.0.0.0-x86_64-linux)

--- a/gemfiles/ruby_2.7_stripe_latest.gemfile.lock
+++ b/gemfiles/ruby_2.7_stripe_latest.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     datadog (2.4.0)
       datadog-ruby_core_source (~> 3.3)
-      libdatadog (~> 13.1.0.1.0)
+      libdatadog (~> 14.0.0.1.0)
       libddwaf (~> 1.15.0.0.0)
       msgpack
 
@@ -53,8 +53,8 @@ GEM
     json (2.7.2)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (13.1.0.1.0-aarch64-linux)
-    libdatadog (13.1.0.1.0-x86_64-linux)
+    libdatadog (14.0.0.1.0-aarch64-linux)
+    libdatadog (14.0.0.1.0-x86_64-linux)
     libddwaf (1.15.0.0.0-aarch64-linux)
       ffi (~> 1.0)
     libddwaf (1.15.0.0.0-x86_64-linux)

--- a/gemfiles/ruby_2.7_stripe_min.gemfile.lock
+++ b/gemfiles/ruby_2.7_stripe_min.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     datadog (2.4.0)
       datadog-ruby_core_source (~> 3.3)
-      libdatadog (~> 13.1.0.1.0)
+      libdatadog (~> 14.0.0.1.0)
       libddwaf (~> 1.15.0.0.0)
       msgpack
 
@@ -54,8 +54,8 @@ GEM
     json (2.7.2)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (13.1.0.1.0-aarch64-linux)
-    libdatadog (13.1.0.1.0-x86_64-linux)
+    libdatadog (14.0.0.1.0-aarch64-linux)
+    libdatadog (14.0.0.1.0-x86_64-linux)
     libddwaf (1.15.0.0.0-aarch64-linux)
       ffi (~> 1.0)
     libddwaf (1.15.0.0.0-x86_64-linux)

--- a/gemfiles/ruby_3.0_activesupport.gemfile.lock
+++ b/gemfiles/ruby_3.0_activesupport.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     datadog (2.4.0)
       datadog-ruby_core_source (~> 3.3)
-      libdatadog (~> 13.1.0.1.0)
+      libdatadog (~> 14.0.0.1.0)
       libddwaf (~> 1.15.0.0.0)
       msgpack
 
@@ -108,8 +108,8 @@ GEM
       addressable (>= 2.4)
     jsonapi-renderer (0.2.2)
     king_konf (1.0.1)
-    libdatadog (13.1.0.1.0-aarch64-linux)
-    libdatadog (13.1.0.1.0-x86_64-linux)
+    libdatadog (14.0.0.1.0-aarch64-linux)
+    libdatadog (14.0.0.1.0-x86_64-linux)
     libddwaf (1.15.0.0.0-aarch64-linux)
       ffi (~> 1.0)
     libddwaf (1.15.0.0.0-x86_64-linux)

--- a/gemfiles/ruby_3.0_aws.gemfile.lock
+++ b/gemfiles/ruby_3.0_aws.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     datadog (2.4.0)
       datadog-ruby_core_source (~> 3.3)
-      libdatadog (~> 13.1.0.1.0)
+      libdatadog (~> 14.0.0.1.0)
       libddwaf (~> 1.15.0.0.0)
       msgpack
 
@@ -1473,8 +1473,8 @@ GEM
     json (2.6.3)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (13.1.0.1.0-aarch64-linux)
-    libdatadog (13.1.0.1.0-x86_64-linux)
+    libdatadog (14.0.0.1.0-aarch64-linux)
+    libdatadog (14.0.0.1.0-x86_64-linux)
     libddwaf (1.15.0.0.0-aarch64-linux)
       ffi (~> 1.0)
     libddwaf (1.15.0.0.0-x86_64-linux)

--- a/gemfiles/ruby_3.0_contrib.gemfile.lock
+++ b/gemfiles/ruby_3.0_contrib.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     datadog (2.4.0)
       datadog-ruby_core_source (~> 3.3)
-      libdatadog (~> 13.1.0.1.0)
+      libdatadog (~> 14.0.0.1.0)
       libddwaf (~> 1.15.0.0.0)
       msgpack
 
@@ -66,8 +66,8 @@ GEM
     json (2.6.3)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (13.1.0.1.0-aarch64-linux)
-    libdatadog (13.1.0.1.0-x86_64-linux)
+    libdatadog (14.0.0.1.0-aarch64-linux)
+    libdatadog (14.0.0.1.0-x86_64-linux)
     libddwaf (1.15.0.0.0-aarch64-linux)
       ffi (~> 1.0)
     libddwaf (1.15.0.0.0-x86_64-linux)

--- a/gemfiles/ruby_3.0_contrib_old.gemfile.lock
+++ b/gemfiles/ruby_3.0_contrib_old.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     datadog (2.4.0)
       datadog-ruby_core_source (~> 3.3)
-      libdatadog (~> 13.1.0.1.0)
+      libdatadog (~> 14.0.0.1.0)
       libddwaf (~> 1.15.0.0.0)
       msgpack
 
@@ -62,8 +62,8 @@ GEM
     json (2.6.3)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (13.1.0.1.0-aarch64-linux)
-    libdatadog (13.1.0.1.0-x86_64-linux)
+    libdatadog (14.0.0.1.0-aarch64-linux)
+    libdatadog (14.0.0.1.0-x86_64-linux)
     libddwaf (1.15.0.0.0-aarch64-linux)
       ffi (~> 1.0)
     libddwaf (1.15.0.0.0-x86_64-linux)

--- a/gemfiles/ruby_3.0_core_old.gemfile.lock
+++ b/gemfiles/ruby_3.0_core_old.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     datadog (2.4.0)
       datadog-ruby_core_source (~> 3.3)
-      libdatadog (~> 13.1.0.1.0)
+      libdatadog (~> 14.0.0.1.0)
       libddwaf (~> 1.15.0.0.0)
       msgpack
 
@@ -51,8 +51,8 @@ GEM
     json (2.6.3)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (13.1.0.1.0-aarch64-linux)
-    libdatadog (13.1.0.1.0-x86_64-linux)
+    libdatadog (14.0.0.1.0-aarch64-linux)
+    libdatadog (14.0.0.1.0-x86_64-linux)
     libddwaf (1.15.0.0.0-aarch64-linux)
       ffi (~> 1.0)
     libddwaf (1.15.0.0.0-x86_64-linux)

--- a/gemfiles/ruby_3.0_elasticsearch_7.gemfile.lock
+++ b/gemfiles/ruby_3.0_elasticsearch_7.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     datadog (2.4.0)
       datadog-ruby_core_source (~> 3.3)
-      libdatadog (~> 13.1.0.1.0)
+      libdatadog (~> 14.0.0.1.0)
       libddwaf (~> 1.15.0.0.0)
       msgpack
 
@@ -68,8 +68,8 @@ GEM
     json (2.7.5)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (13.1.0.1.0-aarch64-linux)
-    libdatadog (13.1.0.1.0-x86_64-linux)
+    libdatadog (14.0.0.1.0-aarch64-linux)
+    libdatadog (14.0.0.1.0-x86_64-linux)
     libddwaf (1.15.0.0.0-aarch64-linux)
       ffi (~> 1.0)
     libddwaf (1.15.0.0.0-x86_64-linux)

--- a/gemfiles/ruby_3.0_elasticsearch_8.gemfile.lock
+++ b/gemfiles/ruby_3.0_elasticsearch_8.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     datadog (2.4.0)
       datadog-ruby_core_source (~> 3.3)
-      libdatadog (~> 13.1.0.1.0)
+      libdatadog (~> 14.0.0.1.0)
       libddwaf (~> 1.15.0.0.0)
       msgpack
 
@@ -66,8 +66,8 @@ GEM
     json (2.7.5)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (13.1.0.1.0-aarch64-linux)
-    libdatadog (13.1.0.1.0-x86_64-linux)
+    libdatadog (14.0.0.1.0-aarch64-linux)
+    libdatadog (14.0.0.1.0-x86_64-linux)
     libddwaf (1.15.0.0.0-aarch64-linux)
       ffi (~> 1.0)
     libddwaf (1.15.0.0.0-x86_64-linux)

--- a/gemfiles/ruby_3.0_elasticsearch_latest.gemfile.lock
+++ b/gemfiles/ruby_3.0_elasticsearch_latest.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     datadog (2.4.0)
       datadog-ruby_core_source (~> 3.3)
-      libdatadog (~> 13.1.0.1.0)
+      libdatadog (~> 14.0.0.1.0)
       libddwaf (~> 1.15.0.0.0)
       msgpack
 
@@ -68,8 +68,8 @@ GEM
     json (2.7.5)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (13.1.0.1.0-aarch64-linux)
-    libdatadog (13.1.0.1.0-x86_64-linux)
+    libdatadog (14.0.0.1.0-aarch64-linux)
+    libdatadog (14.0.0.1.0-x86_64-linux)
     libddwaf (1.15.0.0.0-aarch64-linux)
       ffi (~> 1.0)
     libddwaf (1.15.0.0.0-x86_64-linux)

--- a/gemfiles/ruby_3.0_graphql_1.13.gemfile.lock
+++ b/gemfiles/ruby_3.0_graphql_1.13.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     datadog (2.4.0)
       datadog-ruby_core_source (~> 3.3)
-      libdatadog (~> 13.1.0.1.0)
+      libdatadog (~> 14.0.0.1.0)
       libddwaf (~> 1.15.0.0.0)
       msgpack
 
@@ -121,8 +121,8 @@ GEM
     json (2.7.1)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (13.1.0.1.0-aarch64-linux)
-    libdatadog (13.1.0.1.0-x86_64-linux)
+    libdatadog (14.0.0.1.0-aarch64-linux)
+    libdatadog (14.0.0.1.0-x86_64-linux)
     libddwaf (1.15.0.0.0-aarch64-linux)
       ffi (~> 1.0)
     libddwaf (1.15.0.0.0-x86_64-linux)

--- a/gemfiles/ruby_3.0_graphql_2.0.gemfile.lock
+++ b/gemfiles/ruby_3.0_graphql_2.0.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     datadog (2.4.0)
       datadog-ruby_core_source (~> 3.3)
-      libdatadog (~> 13.1.0.1.0)
+      libdatadog (~> 14.0.0.1.0)
       libddwaf (~> 1.15.0.0.0)
       msgpack
 
@@ -121,8 +121,8 @@ GEM
     json (2.7.1)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (13.1.0.1.0-aarch64-linux)
-    libdatadog (13.1.0.1.0-x86_64-linux)
+    libdatadog (14.0.0.1.0-aarch64-linux)
+    libdatadog (14.0.0.1.0-x86_64-linux)
     libddwaf (1.15.0.0.0-aarch64-linux)
       ffi (~> 1.0)
     libddwaf (1.15.0.0.0-x86_64-linux)

--- a/gemfiles/ruby_3.0_graphql_2.1.gemfile.lock
+++ b/gemfiles/ruby_3.0_graphql_2.1.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     datadog (2.4.0)
       datadog-ruby_core_source (~> 3.3)
-      libdatadog (~> 13.1.0.1.0)
+      libdatadog (~> 14.0.0.1.0)
       libddwaf (~> 1.15.0.0.0)
       msgpack
 
@@ -122,8 +122,8 @@ GEM
     json (2.7.1)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (13.1.0.1.0-aarch64-linux)
-    libdatadog (13.1.0.1.0-x86_64-linux)
+    libdatadog (14.0.0.1.0-aarch64-linux)
+    libdatadog (14.0.0.1.0-x86_64-linux)
     libddwaf (1.15.0.0.0-aarch64-linux)
       ffi (~> 1.0)
     libddwaf (1.15.0.0.0-x86_64-linux)

--- a/gemfiles/ruby_3.0_graphql_2.2.gemfile.lock
+++ b/gemfiles/ruby_3.0_graphql_2.2.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     datadog (2.4.0)
       datadog-ruby_core_source (~> 3.3)
-      libdatadog (~> 13.1.0.1.0)
+      libdatadog (~> 14.0.0.1.0)
       libddwaf (~> 1.15.0.0.0)
       msgpack
 
@@ -122,8 +122,8 @@ GEM
     json (2.7.1)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (13.1.0.1.0-aarch64-linux)
-    libdatadog (13.1.0.1.0-x86_64-linux)
+    libdatadog (14.0.0.1.0-aarch64-linux)
+    libdatadog (14.0.0.1.0-x86_64-linux)
     libddwaf (1.15.0.0.0-aarch64-linux)
       ffi (~> 1.0)
     libddwaf (1.15.0.0.0-x86_64-linux)

--- a/gemfiles/ruby_3.0_graphql_2.3.gemfile.lock
+++ b/gemfiles/ruby_3.0_graphql_2.3.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     datadog (2.4.0)
       datadog-ruby_core_source (~> 3.3)
-      libdatadog (~> 13.1.0.1.0)
+      libdatadog (~> 14.0.0.1.0)
       libddwaf (~> 1.15.0.0.0)
       msgpack
 
@@ -124,8 +124,8 @@ GEM
     json (2.7.2)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (13.1.0.1.0-aarch64-linux)
-    libdatadog (13.1.0.1.0-x86_64-linux)
+    libdatadog (14.0.0.1.0-aarch64-linux)
+    libdatadog (14.0.0.1.0-x86_64-linux)
     libddwaf (1.15.0.0.0-aarch64-linux)
       ffi (~> 1.0)
     libddwaf (1.15.0.0.0-x86_64-linux)

--- a/gemfiles/ruby_3.0_http.gemfile.lock
+++ b/gemfiles/ruby_3.0_http.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     datadog (2.4.0)
       datadog-ruby_core_source (~> 3.3)
-      libdatadog (~> 13.1.0.1.0)
+      libdatadog (~> 14.0.0.1.0)
       libddwaf (~> 1.15.0.0.0)
       msgpack
 
@@ -73,8 +73,8 @@ GEM
     json (2.6.3)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (13.1.0.1.0-aarch64-linux)
-    libdatadog (13.1.0.1.0-x86_64-linux)
+    libdatadog (14.0.0.1.0-aarch64-linux)
+    libdatadog (14.0.0.1.0-x86_64-linux)
     libddwaf (1.15.0.0.0-aarch64-linux)
       ffi (~> 1.0)
     libddwaf (1.15.0.0.0-x86_64-linux)

--- a/gemfiles/ruby_3.0_opensearch_2.gemfile.lock
+++ b/gemfiles/ruby_3.0_opensearch_2.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     datadog (2.4.0)
       datadog-ruby_core_source (~> 3.3)
-      libdatadog (~> 13.1.0.1.0)
+      libdatadog (~> 14.0.0.1.0)
       libddwaf (~> 1.15.0.0.0)
       msgpack
 
@@ -58,8 +58,8 @@ GEM
     json (2.7.5)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (13.1.0.1.0-aarch64-linux)
-    libdatadog (13.1.0.1.0-x86_64-linux)
+    libdatadog (14.0.0.1.0-aarch64-linux)
+    libdatadog (14.0.0.1.0-x86_64-linux)
     libddwaf (1.15.0.0.0-aarch64-linux)
       ffi (~> 1.0)
     libddwaf (1.15.0.0.0-x86_64-linux)

--- a/gemfiles/ruby_3.0_opensearch_3.gemfile.lock
+++ b/gemfiles/ruby_3.0_opensearch_3.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     datadog (2.4.0)
       datadog-ruby_core_source (~> 3.3)
-      libdatadog (~> 13.1.0.1.0)
+      libdatadog (~> 14.0.0.1.0)
       libddwaf (~> 1.15.0.0.0)
       msgpack
 
@@ -58,8 +58,8 @@ GEM
     json (2.7.5)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (13.1.0.1.0-aarch64-linux)
-    libdatadog (13.1.0.1.0-x86_64-linux)
+    libdatadog (14.0.0.1.0-aarch64-linux)
+    libdatadog (14.0.0.1.0-x86_64-linux)
     libddwaf (1.15.0.0.0-aarch64-linux)
       ffi (~> 1.0)
     libddwaf (1.15.0.0.0-x86_64-linux)

--- a/gemfiles/ruby_3.0_opensearch_latest.gemfile.lock
+++ b/gemfiles/ruby_3.0_opensearch_latest.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     datadog (2.4.0)
       datadog-ruby_core_source (~> 3.3)
-      libdatadog (~> 13.1.0.1.0)
+      libdatadog (~> 14.0.0.1.0)
       libddwaf (~> 1.15.0.0.0)
       msgpack
 
@@ -60,8 +60,8 @@ GEM
     json (2.7.5)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (13.1.0.1.0-aarch64-linux)
-    libdatadog (13.1.0.1.0-x86_64-linux)
+    libdatadog (14.0.0.1.0-aarch64-linux)
+    libdatadog (14.0.0.1.0-x86_64-linux)
     libddwaf (1.15.0.0.0-aarch64-linux)
       ffi (~> 1.0)
     libddwaf (1.15.0.0.0-x86_64-linux)

--- a/gemfiles/ruby_3.0_opentelemetry.gemfile.lock
+++ b/gemfiles/ruby_3.0_opentelemetry.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     datadog (2.4.0)
       datadog-ruby_core_source (~> 3.3)
-      libdatadog (~> 13.1.0.1.0)
+      libdatadog (~> 14.0.0.1.0)
       libddwaf (~> 1.15.0.0.0)
       msgpack
 
@@ -51,8 +51,8 @@ GEM
     json (2.6.3)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (13.1.0.1.0-aarch64-linux)
-    libdatadog (13.1.0.1.0-x86_64-linux)
+    libdatadog (14.0.0.1.0-aarch64-linux)
+    libdatadog (14.0.0.1.0-x86_64-linux)
     libddwaf (1.15.0.0.0-aarch64-linux)
       ffi (~> 1.0)
     libddwaf (1.15.0.0.0-x86_64-linux)

--- a/gemfiles/ruby_3.0_opentelemetry_otlp.gemfile.lock
+++ b/gemfiles/ruby_3.0_opentelemetry_otlp.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     datadog (2.4.0)
       datadog-ruby_core_source (~> 3.3)
-      libdatadog (~> 13.1.0.1.0)
+      libdatadog (~> 14.0.0.1.0)
       libddwaf (~> 1.15.0.0.0)
       msgpack
 
@@ -56,8 +56,8 @@ GEM
     json (2.7.1)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (13.1.0.1.0-aarch64-linux)
-    libdatadog (13.1.0.1.0-x86_64-linux)
+    libdatadog (14.0.0.1.0-aarch64-linux)
+    libdatadog (14.0.0.1.0-x86_64-linux)
     libddwaf (1.15.0.0.0-aarch64-linux)
       ffi (~> 1.0)
     libddwaf (1.15.0.0.0-x86_64-linux)

--- a/gemfiles/ruby_3.0_rack_1.gemfile.lock
+++ b/gemfiles/ruby_3.0_rack_1.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     datadog (2.4.0)
       datadog-ruby_core_source (~> 3.3)
-      libdatadog (~> 13.1.0.1.0)
+      libdatadog (~> 14.0.0.1.0)
       libddwaf (~> 1.15.0.0.0)
       msgpack
 
@@ -51,8 +51,8 @@ GEM
     json (2.6.3)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (13.1.0.1.0-aarch64-linux)
-    libdatadog (13.1.0.1.0-x86_64-linux)
+    libdatadog (14.0.0.1.0-aarch64-linux)
+    libdatadog (14.0.0.1.0-x86_64-linux)
     libddwaf (1.15.0.0.0-aarch64-linux)
       ffi (~> 1.0)
     libddwaf (1.15.0.0.0-x86_64-linux)

--- a/gemfiles/ruby_3.0_rack_2.gemfile.lock
+++ b/gemfiles/ruby_3.0_rack_2.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     datadog (2.4.0)
       datadog-ruby_core_source (~> 3.3)
-      libdatadog (~> 13.1.0.1.0)
+      libdatadog (~> 14.0.0.1.0)
       libddwaf (~> 1.15.0.0.0)
       msgpack
 
@@ -51,8 +51,8 @@ GEM
     json (2.6.3)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (13.1.0.1.0-aarch64-linux)
-    libdatadog (13.1.0.1.0-x86_64-linux)
+    libdatadog (14.0.0.1.0-aarch64-linux)
+    libdatadog (14.0.0.1.0-x86_64-linux)
     libddwaf (1.15.0.0.0-aarch64-linux)
       ffi (~> 1.0)
     libddwaf (1.15.0.0.0-x86_64-linux)

--- a/gemfiles/ruby_3.0_rack_3.gemfile.lock
+++ b/gemfiles/ruby_3.0_rack_3.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     datadog (2.4.0)
       datadog-ruby_core_source (~> 3.3)
-      libdatadog (~> 13.1.0.1.0)
+      libdatadog (~> 14.0.0.1.0)
       libddwaf (~> 1.15.0.0.0)
       msgpack
 
@@ -51,8 +51,8 @@ GEM
     json (2.6.3)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (13.1.0.1.0-aarch64-linux)
-    libdatadog (13.1.0.1.0-x86_64-linux)
+    libdatadog (14.0.0.1.0-aarch64-linux)
+    libdatadog (14.0.0.1.0-x86_64-linux)
     libddwaf (1.15.0.0.0-aarch64-linux)
       ffi (~> 1.0)
     libddwaf (1.15.0.0.0-x86_64-linux)

--- a/gemfiles/ruby_3.0_rack_latest.gemfile.lock
+++ b/gemfiles/ruby_3.0_rack_latest.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     datadog (2.4.0)
       datadog-ruby_core_source (~> 3.3)
-      libdatadog (~> 13.1.0.1.0)
+      libdatadog (~> 14.0.0.1.0)
       libddwaf (~> 1.15.0.0.0)
       msgpack
 
@@ -54,8 +54,8 @@ GEM
     json (2.7.2)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (13.1.0.1.0-aarch64-linux)
-    libdatadog (13.1.0.1.0-x86_64-linux)
+    libdatadog (14.0.0.1.0-aarch64-linux)
+    libdatadog (14.0.0.1.0-x86_64-linux)
     libddwaf (1.15.0.0.0-aarch64-linux)
       ffi (~> 1.0)
     libddwaf (1.15.0.0.0-x86_64-linux)

--- a/gemfiles/ruby_3.0_rails61_mysql2.gemfile.lock
+++ b/gemfiles/ruby_3.0_rails61_mysql2.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     datadog (2.4.0)
       datadog-ruby_core_source (~> 3.3)
-      libdatadog (~> 13.1.0.1.0)
+      libdatadog (~> 14.0.0.1.0)
       libddwaf (~> 1.15.0.0.0)
       msgpack
 
@@ -118,8 +118,8 @@ GEM
     json (2.6.3)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (13.1.0.1.0-aarch64-linux)
-    libdatadog (13.1.0.1.0-x86_64-linux)
+    libdatadog (14.0.0.1.0-aarch64-linux)
+    libdatadog (14.0.0.1.0-x86_64-linux)
     libddwaf (1.15.0.0.0-aarch64-linux)
       ffi (~> 1.0)
     libddwaf (1.15.0.0.0-x86_64-linux)

--- a/gemfiles/ruby_3.0_rails61_postgres.gemfile.lock
+++ b/gemfiles/ruby_3.0_rails61_postgres.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     datadog (2.4.0)
       datadog-ruby_core_source (~> 3.3)
-      libdatadog (~> 13.1.0.1.0)
+      libdatadog (~> 14.0.0.1.0)
       libddwaf (~> 1.15.0.0.0)
       msgpack
 
@@ -118,8 +118,8 @@ GEM
     json (2.6.3)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (13.1.0.1.0-aarch64-linux)
-    libdatadog (13.1.0.1.0-x86_64-linux)
+    libdatadog (14.0.0.1.0-aarch64-linux)
+    libdatadog (14.0.0.1.0-x86_64-linux)
     libddwaf (1.15.0.0.0-aarch64-linux)
       ffi (~> 1.0)
     libddwaf (1.15.0.0.0-x86_64-linux)

--- a/gemfiles/ruby_3.0_rails61_postgres_redis.gemfile.lock
+++ b/gemfiles/ruby_3.0_rails61_postgres_redis.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     datadog (2.4.0)
       datadog-ruby_core_source (~> 3.3)
-      libdatadog (~> 13.1.0.1.0)
+      libdatadog (~> 14.0.0.1.0)
       libddwaf (~> 1.15.0.0.0)
       msgpack
 
@@ -118,8 +118,8 @@ GEM
     json (2.6.3)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (13.1.0.1.0-aarch64-linux)
-    libdatadog (13.1.0.1.0-x86_64-linux)
+    libdatadog (14.0.0.1.0-aarch64-linux)
+    libdatadog (14.0.0.1.0-x86_64-linux)
     libddwaf (1.15.0.0.0-aarch64-linux)
       ffi (~> 1.0)
     libddwaf (1.15.0.0.0-x86_64-linux)

--- a/gemfiles/ruby_3.0_rails61_postgres_sidekiq.gemfile.lock
+++ b/gemfiles/ruby_3.0_rails61_postgres_sidekiq.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     datadog (2.4.0)
       datadog-ruby_core_source (~> 3.3)
-      libdatadog (~> 13.1.0.1.0)
+      libdatadog (~> 14.0.0.1.0)
       libddwaf (~> 1.15.0.0.0)
       msgpack
 
@@ -119,8 +119,8 @@ GEM
     json (2.6.3)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (13.1.0.1.0-aarch64-linux)
-    libdatadog (13.1.0.1.0-x86_64-linux)
+    libdatadog (14.0.0.1.0-aarch64-linux)
+    libdatadog (14.0.0.1.0-x86_64-linux)
     libddwaf (1.15.0.0.0-aarch64-linux)
       ffi (~> 1.0)
     libddwaf (1.15.0.0.0-x86_64-linux)

--- a/gemfiles/ruby_3.0_rails61_semantic_logger.gemfile.lock
+++ b/gemfiles/ruby_3.0_rails61_semantic_logger.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     datadog (2.4.0)
       datadog-ruby_core_source (~> 3.3)
-      libdatadog (~> 13.1.0.1.0)
+      libdatadog (~> 14.0.0.1.0)
       libddwaf (~> 1.15.0.0.0)
       msgpack
 
@@ -118,8 +118,8 @@ GEM
     json (2.6.3)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (13.1.0.1.0-aarch64-linux)
-    libdatadog (13.1.0.1.0-x86_64-linux)
+    libdatadog (14.0.0.1.0-aarch64-linux)
+    libdatadog (14.0.0.1.0-x86_64-linux)
     libddwaf (1.15.0.0.0-aarch64-linux)
       ffi (~> 1.0)
     libddwaf (1.15.0.0.0-x86_64-linux)

--- a/gemfiles/ruby_3.0_rails61_trilogy.gemfile.lock
+++ b/gemfiles/ruby_3.0_rails61_trilogy.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     datadog (2.4.0)
       datadog-ruby_core_source (~> 3.3)
-      libdatadog (~> 13.1.0.1.0)
+      libdatadog (~> 14.0.0.1.0)
       libddwaf (~> 1.15.0.0.0)
       msgpack
 
@@ -122,8 +122,8 @@ GEM
     json (2.6.3)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (13.1.0.1.0-aarch64-linux)
-    libdatadog (13.1.0.1.0-x86_64-linux)
+    libdatadog (14.0.0.1.0-aarch64-linux)
+    libdatadog (14.0.0.1.0-x86_64-linux)
     libddwaf (1.15.0.0.0-aarch64-linux)
       ffi (~> 1.0)
     libddwaf (1.15.0.0.0-x86_64-linux)

--- a/gemfiles/ruby_3.0_rails7.gemfile.lock
+++ b/gemfiles/ruby_3.0_rails7.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     datadog (2.4.0)
       datadog-ruby_core_source (~> 3.3)
-      libdatadog (~> 13.1.0.1.0)
+      libdatadog (~> 14.0.0.1.0)
       libddwaf (~> 1.15.0.0.0)
       msgpack
 
@@ -127,8 +127,8 @@ GEM
     json (2.7.2)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (13.1.0.1.0-aarch64-linux)
-    libdatadog (13.1.0.1.0-x86_64-linux)
+    libdatadog (14.0.0.1.0-aarch64-linux)
+    libdatadog (14.0.0.1.0-x86_64-linux)
     libddwaf (1.15.0.0.0-aarch64-linux)
       ffi (~> 1.0)
     libddwaf (1.15.0.0.0-x86_64-linux)

--- a/gemfiles/ruby_3.0_rails71.gemfile.lock
+++ b/gemfiles/ruby_3.0_rails71.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     datadog (2.4.0)
       datadog-ruby_core_source (~> 3.3)
-      libdatadog (~> 13.1.0.1.0)
+      libdatadog (~> 14.0.0.1.0)
       libddwaf (~> 1.15.0.0.0)
       msgpack
 
@@ -143,8 +143,8 @@ GEM
     json (2.7.2)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (13.1.0.1.0-aarch64-linux)
-    libdatadog (13.1.0.1.0-x86_64-linux)
+    libdatadog (14.0.0.1.0-aarch64-linux)
+    libdatadog (14.0.0.1.0-x86_64-linux)
     libddwaf (1.15.0.0.0-aarch64-linux)
       ffi (~> 1.0)
     libddwaf (1.15.0.0.0-x86_64-linux)

--- a/gemfiles/ruby_3.0_redis_3.gemfile.lock
+++ b/gemfiles/ruby_3.0_redis_3.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     datadog (2.4.0)
       datadog-ruby_core_source (~> 3.3)
-      libdatadog (~> 13.1.0.1.0)
+      libdatadog (~> 14.0.0.1.0)
       libddwaf (~> 1.15.0.0.0)
       msgpack
 
@@ -51,8 +51,8 @@ GEM
     json (2.6.3)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (13.1.0.1.0-aarch64-linux)
-    libdatadog (13.1.0.1.0-x86_64-linux)
+    libdatadog (14.0.0.1.0-aarch64-linux)
+    libdatadog (14.0.0.1.0-x86_64-linux)
     libddwaf (1.15.0.0.0-aarch64-linux)
       ffi (~> 1.0)
     libddwaf (1.15.0.0.0-x86_64-linux)

--- a/gemfiles/ruby_3.0_redis_4.gemfile.lock
+++ b/gemfiles/ruby_3.0_redis_4.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     datadog (2.4.0)
       datadog-ruby_core_source (~> 3.3)
-      libdatadog (~> 13.1.0.1.0)
+      libdatadog (~> 14.0.0.1.0)
       libddwaf (~> 1.15.0.0.0)
       msgpack
 
@@ -51,8 +51,8 @@ GEM
     json (2.6.3)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (13.1.0.1.0-aarch64-linux)
-    libdatadog (13.1.0.1.0-x86_64-linux)
+    libdatadog (14.0.0.1.0-aarch64-linux)
+    libdatadog (14.0.0.1.0-x86_64-linux)
     libddwaf (1.15.0.0.0-aarch64-linux)
       ffi (~> 1.0)
     libddwaf (1.15.0.0.0-x86_64-linux)

--- a/gemfiles/ruby_3.0_redis_5.gemfile.lock
+++ b/gemfiles/ruby_3.0_redis_5.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     datadog (2.4.0)
       datadog-ruby_core_source (~> 3.3)
-      libdatadog (~> 13.1.0.1.0)
+      libdatadog (~> 14.0.0.1.0)
       libddwaf (~> 1.15.0.0.0)
       msgpack
 
@@ -52,8 +52,8 @@ GEM
     json (2.6.3)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (13.1.0.1.0-aarch64-linux)
-    libdatadog (13.1.0.1.0-x86_64-linux)
+    libdatadog (14.0.0.1.0-aarch64-linux)
+    libdatadog (14.0.0.1.0-x86_64-linux)
     libddwaf (1.15.0.0.0-aarch64-linux)
       ffi (~> 1.0)
     libddwaf (1.15.0.0.0-x86_64-linux)

--- a/gemfiles/ruby_3.0_relational_db.gemfile.lock
+++ b/gemfiles/ruby_3.0_relational_db.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     datadog (2.4.0)
       datadog-ruby_core_source (~> 3.3)
-      libdatadog (~> 13.1.0.1.0)
+      libdatadog (~> 14.0.0.1.0)
       libddwaf (~> 1.15.0.0.0)
       msgpack
 
@@ -69,8 +69,8 @@ GEM
     json (2.6.3)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (13.1.0.1.0-aarch64-linux)
-    libdatadog (13.1.0.1.0-x86_64-linux)
+    libdatadog (14.0.0.1.0-aarch64-linux)
+    libdatadog (14.0.0.1.0-x86_64-linux)
     libddwaf (1.15.0.0.0-aarch64-linux)
       ffi (~> 1.0)
     libddwaf (1.15.0.0.0-x86_64-linux)

--- a/gemfiles/ruby_3.0_resque2_redis3.gemfile.lock
+++ b/gemfiles/ruby_3.0_resque2_redis3.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     datadog (2.4.0)
       datadog-ruby_core_source (~> 3.3)
-      libdatadog (~> 13.1.0.1.0)
+      libdatadog (~> 14.0.0.1.0)
       libddwaf (~> 1.15.0.0.0)
       msgpack
 
@@ -51,8 +51,8 @@ GEM
     json (2.6.3)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (13.1.0.1.0-aarch64-linux)
-    libdatadog (13.1.0.1.0-x86_64-linux)
+    libdatadog (14.0.0.1.0-aarch64-linux)
+    libdatadog (14.0.0.1.0-x86_64-linux)
     libddwaf (1.15.0.0.0-aarch64-linux)
       ffi (~> 1.0)
     libddwaf (1.15.0.0.0-x86_64-linux)

--- a/gemfiles/ruby_3.0_resque2_redis4.gemfile.lock
+++ b/gemfiles/ruby_3.0_resque2_redis4.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     datadog (2.4.0)
       datadog-ruby_core_source (~> 3.3)
-      libdatadog (~> 13.1.0.1.0)
+      libdatadog (~> 14.0.0.1.0)
       libddwaf (~> 1.15.0.0.0)
       msgpack
 
@@ -52,8 +52,8 @@ GEM
     json (2.6.3)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (13.1.0.1.0-aarch64-linux)
-    libdatadog (13.1.0.1.0-x86_64-linux)
+    libdatadog (14.0.0.1.0-aarch64-linux)
+    libdatadog (14.0.0.1.0-x86_64-linux)
     libddwaf (1.15.0.0.0-aarch64-linux)
       ffi (~> 1.0)
     libddwaf (1.15.0.0.0-x86_64-linux)

--- a/gemfiles/ruby_3.0_sinatra_2.gemfile.lock
+++ b/gemfiles/ruby_3.0_sinatra_2.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     datadog (2.4.0)
       datadog-ruby_core_source (~> 3.3)
-      libdatadog (~> 13.1.0.1.0)
+      libdatadog (~> 14.0.0.1.0)
       libddwaf (~> 1.15.0.0.0)
       msgpack
 
@@ -54,8 +54,8 @@ GEM
     json (2.7.2)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (13.1.0.1.0-aarch64-linux)
-    libdatadog (13.1.0.1.0-x86_64-linux)
+    libdatadog (14.0.0.1.0-aarch64-linux)
+    libdatadog (14.0.0.1.0-x86_64-linux)
     libddwaf (1.15.0.0.0-aarch64-linux)
       ffi (~> 1.0)
     libddwaf (1.15.0.0.0-x86_64-linux)

--- a/gemfiles/ruby_3.0_sinatra_3.gemfile.lock
+++ b/gemfiles/ruby_3.0_sinatra_3.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     datadog (2.4.0)
       datadog-ruby_core_source (~> 3.3)
-      libdatadog (~> 13.1.0.1.0)
+      libdatadog (~> 14.0.0.1.0)
       libddwaf (~> 1.15.0.0.0)
       msgpack
 
@@ -55,8 +55,8 @@ GEM
     json (2.7.2)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (13.1.0.1.0-aarch64-linux)
-    libdatadog (13.1.0.1.0-x86_64-linux)
+    libdatadog (14.0.0.1.0-aarch64-linux)
+    libdatadog (14.0.0.1.0-x86_64-linux)
     libddwaf (1.15.0.0.0-aarch64-linux)
       ffi (~> 1.0)
     libddwaf (1.15.0.0.0-x86_64-linux)

--- a/gemfiles/ruby_3.0_sinatra_4.gemfile.lock
+++ b/gemfiles/ruby_3.0_sinatra_4.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     datadog (2.4.0)
       datadog-ruby_core_source (~> 3.3)
-      libdatadog (~> 13.1.0.1.0)
+      libdatadog (~> 14.0.0.1.0)
       libddwaf (~> 1.15.0.0.0)
       msgpack
 
@@ -55,8 +55,8 @@ GEM
     json (2.7.2)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (13.1.0.1.0-aarch64-linux)
-    libdatadog (13.1.0.1.0-x86_64-linux)
+    libdatadog (14.0.0.1.0-aarch64-linux)
+    libdatadog (14.0.0.1.0-x86_64-linux)
     libddwaf (1.15.0.0.0-aarch64-linux)
       ffi (~> 1.0)
     libddwaf (1.15.0.0.0-x86_64-linux)

--- a/gemfiles/ruby_3.0_stripe_10.gemfile.lock
+++ b/gemfiles/ruby_3.0_stripe_10.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     datadog (2.4.0)
       datadog-ruby_core_source (~> 3.3)
-      libdatadog (~> 13.1.0.1.0)
+      libdatadog (~> 14.0.0.1.0)
       libddwaf (~> 1.15.0.0.0)
       msgpack
 
@@ -54,8 +54,8 @@ GEM
     json (2.7.2)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (13.1.0.1.0-aarch64-linux)
-    libdatadog (13.1.0.1.0-x86_64-linux)
+    libdatadog (14.0.0.1.0-aarch64-linux)
+    libdatadog (14.0.0.1.0-x86_64-linux)
     libddwaf (1.15.0.0.0-aarch64-linux)
       ffi (~> 1.0)
     libddwaf (1.15.0.0.0-x86_64-linux)

--- a/gemfiles/ruby_3.0_stripe_11.gemfile.lock
+++ b/gemfiles/ruby_3.0_stripe_11.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     datadog (2.4.0)
       datadog-ruby_core_source (~> 3.3)
-      libdatadog (~> 13.1.0.1.0)
+      libdatadog (~> 14.0.0.1.0)
       libddwaf (~> 1.15.0.0.0)
       msgpack
 
@@ -54,8 +54,8 @@ GEM
     json (2.7.2)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (13.1.0.1.0-aarch64-linux)
-    libdatadog (13.1.0.1.0-x86_64-linux)
+    libdatadog (14.0.0.1.0-aarch64-linux)
+    libdatadog (14.0.0.1.0-x86_64-linux)
     libddwaf (1.15.0.0.0-aarch64-linux)
       ffi (~> 1.0)
     libddwaf (1.15.0.0.0-x86_64-linux)

--- a/gemfiles/ruby_3.0_stripe_12.gemfile.lock
+++ b/gemfiles/ruby_3.0_stripe_12.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     datadog (2.4.0)
       datadog-ruby_core_source (~> 3.3)
-      libdatadog (~> 13.1.0.1.0)
+      libdatadog (~> 14.0.0.1.0)
       libddwaf (~> 1.15.0.0.0)
       msgpack
 
@@ -54,8 +54,8 @@ GEM
     json (2.7.2)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (13.1.0.1.0-aarch64-linux)
-    libdatadog (13.1.0.1.0-x86_64-linux)
+    libdatadog (14.0.0.1.0-aarch64-linux)
+    libdatadog (14.0.0.1.0-x86_64-linux)
     libddwaf (1.15.0.0.0-aarch64-linux)
       ffi (~> 1.0)
     libddwaf (1.15.0.0.0-x86_64-linux)

--- a/gemfiles/ruby_3.0_stripe_7.gemfile.lock
+++ b/gemfiles/ruby_3.0_stripe_7.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     datadog (2.4.0)
       datadog-ruby_core_source (~> 3.3)
-      libdatadog (~> 13.1.0.1.0)
+      libdatadog (~> 14.0.0.1.0)
       libddwaf (~> 1.15.0.0.0)
       msgpack
 
@@ -54,8 +54,8 @@ GEM
     json (2.7.2)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (13.1.0.1.0-aarch64-linux)
-    libdatadog (13.1.0.1.0-x86_64-linux)
+    libdatadog (14.0.0.1.0-aarch64-linux)
+    libdatadog (14.0.0.1.0-x86_64-linux)
     libddwaf (1.15.0.0.0-aarch64-linux)
       ffi (~> 1.0)
     libddwaf (1.15.0.0.0-x86_64-linux)

--- a/gemfiles/ruby_3.0_stripe_8.gemfile.lock
+++ b/gemfiles/ruby_3.0_stripe_8.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     datadog (2.4.0)
       datadog-ruby_core_source (~> 3.3)
-      libdatadog (~> 13.1.0.1.0)
+      libdatadog (~> 14.0.0.1.0)
       libddwaf (~> 1.15.0.0.0)
       msgpack
 
@@ -54,8 +54,8 @@ GEM
     json (2.7.2)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (13.1.0.1.0-aarch64-linux)
-    libdatadog (13.1.0.1.0-x86_64-linux)
+    libdatadog (14.0.0.1.0-aarch64-linux)
+    libdatadog (14.0.0.1.0-x86_64-linux)
     libddwaf (1.15.0.0.0-aarch64-linux)
       ffi (~> 1.0)
     libddwaf (1.15.0.0.0-x86_64-linux)

--- a/gemfiles/ruby_3.0_stripe_9.gemfile.lock
+++ b/gemfiles/ruby_3.0_stripe_9.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     datadog (2.4.0)
       datadog-ruby_core_source (~> 3.3)
-      libdatadog (~> 13.1.0.1.0)
+      libdatadog (~> 14.0.0.1.0)
       libddwaf (~> 1.15.0.0.0)
       msgpack
 
@@ -54,8 +54,8 @@ GEM
     json (2.7.2)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (13.1.0.1.0-aarch64-linux)
-    libdatadog (13.1.0.1.0-x86_64-linux)
+    libdatadog (14.0.0.1.0-aarch64-linux)
+    libdatadog (14.0.0.1.0-x86_64-linux)
     libddwaf (1.15.0.0.0-aarch64-linux)
       ffi (~> 1.0)
     libddwaf (1.15.0.0.0-x86_64-linux)

--- a/gemfiles/ruby_3.0_stripe_latest.gemfile.lock
+++ b/gemfiles/ruby_3.0_stripe_latest.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     datadog (2.4.0)
       datadog-ruby_core_source (~> 3.3)
-      libdatadog (~> 13.1.0.1.0)
+      libdatadog (~> 14.0.0.1.0)
       libddwaf (~> 1.15.0.0.0)
       msgpack
 
@@ -54,8 +54,8 @@ GEM
     json (2.7.2)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (13.1.0.1.0-aarch64-linux)
-    libdatadog (13.1.0.1.0-x86_64-linux)
+    libdatadog (14.0.0.1.0-aarch64-linux)
+    libdatadog (14.0.0.1.0-x86_64-linux)
     libddwaf (1.15.0.0.0-aarch64-linux)
       ffi (~> 1.0)
     libddwaf (1.15.0.0.0-x86_64-linux)

--- a/gemfiles/ruby_3.0_stripe_min.gemfile.lock
+++ b/gemfiles/ruby_3.0_stripe_min.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     datadog (2.4.0)
       datadog-ruby_core_source (~> 3.3)
-      libdatadog (~> 13.1.0.1.0)
+      libdatadog (~> 14.0.0.1.0)
       libddwaf (~> 1.15.0.0.0)
       msgpack
 
@@ -54,8 +54,8 @@ GEM
     json (2.7.2)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (13.1.0.1.0-aarch64-linux)
-    libdatadog (13.1.0.1.0-x86_64-linux)
+    libdatadog (14.0.0.1.0-aarch64-linux)
+    libdatadog (14.0.0.1.0-x86_64-linux)
     libddwaf (1.15.0.0.0-aarch64-linux)
       ffi (~> 1.0)
     libddwaf (1.15.0.0.0-x86_64-linux)

--- a/gemfiles/ruby_3.1_activesupport.gemfile.lock
+++ b/gemfiles/ruby_3.1_activesupport.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     datadog (2.4.0)
       datadog-ruby_core_source (~> 3.3)
-      libdatadog (~> 13.1.0.1.0)
+      libdatadog (~> 14.0.0.1.0)
       libddwaf (~> 1.15.0.0.0)
       msgpack
 
@@ -108,8 +108,8 @@ GEM
       addressable (>= 2.4)
     jsonapi-renderer (0.2.2)
     king_konf (1.0.1)
-    libdatadog (13.1.0.1.0-aarch64-linux)
-    libdatadog (13.1.0.1.0-x86_64-linux)
+    libdatadog (14.0.0.1.0-aarch64-linux)
+    libdatadog (14.0.0.1.0-x86_64-linux)
     libddwaf (1.15.0.0.0-aarch64-linux)
       ffi (~> 1.0)
     libddwaf (1.15.0.0.0-x86_64-linux)

--- a/gemfiles/ruby_3.1_aws.gemfile.lock
+++ b/gemfiles/ruby_3.1_aws.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     datadog (2.4.0)
       datadog-ruby_core_source (~> 3.3)
-      libdatadog (~> 13.1.0.1.0)
+      libdatadog (~> 14.0.0.1.0)
       libddwaf (~> 1.15.0.0.0)
       msgpack
 
@@ -1473,8 +1473,8 @@ GEM
     json (2.6.3)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (13.1.0.1.0-aarch64-linux)
-    libdatadog (13.1.0.1.0-x86_64-linux)
+    libdatadog (14.0.0.1.0-aarch64-linux)
+    libdatadog (14.0.0.1.0-x86_64-linux)
     libddwaf (1.15.0.0.0-aarch64-linux)
       ffi (~> 1.0)
     libddwaf (1.15.0.0.0-x86_64-linux)

--- a/gemfiles/ruby_3.1_contrib.gemfile.lock
+++ b/gemfiles/ruby_3.1_contrib.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     datadog (2.4.0)
       datadog-ruby_core_source (~> 3.3)
-      libdatadog (~> 13.1.0.1.0)
+      libdatadog (~> 14.0.0.1.0)
       libddwaf (~> 1.15.0.0.0)
       msgpack
 
@@ -66,8 +66,8 @@ GEM
     json (2.6.3)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (13.1.0.1.0-aarch64-linux)
-    libdatadog (13.1.0.1.0-x86_64-linux)
+    libdatadog (14.0.0.1.0-aarch64-linux)
+    libdatadog (14.0.0.1.0-x86_64-linux)
     libddwaf (1.15.0.0.0-aarch64-linux)
       ffi (~> 1.0)
     libddwaf (1.15.0.0.0-x86_64-linux)

--- a/gemfiles/ruby_3.1_contrib_old.gemfile.lock
+++ b/gemfiles/ruby_3.1_contrib_old.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     datadog (2.4.0)
       datadog-ruby_core_source (~> 3.3)
-      libdatadog (~> 13.1.0.1.0)
+      libdatadog (~> 14.0.0.1.0)
       libddwaf (~> 1.15.0.0.0)
       msgpack
 
@@ -62,8 +62,8 @@ GEM
     json (2.6.3)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (13.1.0.1.0-aarch64-linux)
-    libdatadog (13.1.0.1.0-x86_64-linux)
+    libdatadog (14.0.0.1.0-aarch64-linux)
+    libdatadog (14.0.0.1.0-x86_64-linux)
     libddwaf (1.15.0.0.0-aarch64-linux)
       ffi (~> 1.0)
     libddwaf (1.15.0.0.0-x86_64-linux)

--- a/gemfiles/ruby_3.1_core_old.gemfile.lock
+++ b/gemfiles/ruby_3.1_core_old.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     datadog (2.4.0)
       datadog-ruby_core_source (~> 3.3)
-      libdatadog (~> 13.1.0.1.0)
+      libdatadog (~> 14.0.0.1.0)
       libddwaf (~> 1.15.0.0.0)
       msgpack
 
@@ -51,8 +51,8 @@ GEM
     json (2.6.3)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (13.1.0.1.0-aarch64-linux)
-    libdatadog (13.1.0.1.0-x86_64-linux)
+    libdatadog (14.0.0.1.0-aarch64-linux)
+    libdatadog (14.0.0.1.0-x86_64-linux)
     libddwaf (1.15.0.0.0-aarch64-linux)
       ffi (~> 1.0)
     libddwaf (1.15.0.0.0-x86_64-linux)

--- a/gemfiles/ruby_3.1_elasticsearch_7.gemfile.lock
+++ b/gemfiles/ruby_3.1_elasticsearch_7.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     datadog (2.4.0)
       datadog-ruby_core_source (~> 3.3)
-      libdatadog (~> 13.1.0.1.0)
+      libdatadog (~> 14.0.0.1.0)
       libddwaf (~> 1.15.0.0.0)
       msgpack
 
@@ -68,8 +68,8 @@ GEM
     json (2.7.5)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (13.1.0.1.0-aarch64-linux)
-    libdatadog (13.1.0.1.0-x86_64-linux)
+    libdatadog (14.0.0.1.0-aarch64-linux)
+    libdatadog (14.0.0.1.0-x86_64-linux)
     libddwaf (1.15.0.0.0-aarch64-linux)
       ffi (~> 1.0)
     libddwaf (1.15.0.0.0-x86_64-linux)

--- a/gemfiles/ruby_3.1_elasticsearch_8.gemfile.lock
+++ b/gemfiles/ruby_3.1_elasticsearch_8.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     datadog (2.4.0)
       datadog-ruby_core_source (~> 3.3)
-      libdatadog (~> 13.1.0.1.0)
+      libdatadog (~> 14.0.0.1.0)
       libddwaf (~> 1.15.0.0.0)
       msgpack
 
@@ -66,8 +66,8 @@ GEM
     json (2.7.5)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (13.1.0.1.0-aarch64-linux)
-    libdatadog (13.1.0.1.0-x86_64-linux)
+    libdatadog (14.0.0.1.0-aarch64-linux)
+    libdatadog (14.0.0.1.0-x86_64-linux)
     libddwaf (1.15.0.0.0-aarch64-linux)
       ffi (~> 1.0)
     libddwaf (1.15.0.0.0-x86_64-linux)

--- a/gemfiles/ruby_3.1_elasticsearch_latest.gemfile.lock
+++ b/gemfiles/ruby_3.1_elasticsearch_latest.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     datadog (2.4.0)
       datadog-ruby_core_source (~> 3.3)
-      libdatadog (~> 13.1.0.1.0)
+      libdatadog (~> 14.0.0.1.0)
       libddwaf (~> 1.15.0.0.0)
       msgpack
 
@@ -68,8 +68,8 @@ GEM
     json (2.7.5)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (13.1.0.1.0-aarch64-linux)
-    libdatadog (13.1.0.1.0-x86_64-linux)
+    libdatadog (14.0.0.1.0-aarch64-linux)
+    libdatadog (14.0.0.1.0-x86_64-linux)
     libddwaf (1.15.0.0.0-aarch64-linux)
       ffi (~> 1.0)
     libddwaf (1.15.0.0.0-x86_64-linux)

--- a/gemfiles/ruby_3.1_graphql_1.13.gemfile.lock
+++ b/gemfiles/ruby_3.1_graphql_1.13.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     datadog (2.4.0)
       datadog-ruby_core_source (~> 3.3)
-      libdatadog (~> 13.1.0.1.0)
+      libdatadog (~> 14.0.0.1.0)
       libddwaf (~> 1.15.0.0.0)
       msgpack
 
@@ -121,8 +121,8 @@ GEM
     json (2.7.1)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (13.1.0.1.0-aarch64-linux)
-    libdatadog (13.1.0.1.0-x86_64-linux)
+    libdatadog (14.0.0.1.0-aarch64-linux)
+    libdatadog (14.0.0.1.0-x86_64-linux)
     libddwaf (1.15.0.0.0-aarch64-linux)
       ffi (~> 1.0)
     libddwaf (1.15.0.0.0-x86_64-linux)

--- a/gemfiles/ruby_3.1_graphql_2.0.gemfile.lock
+++ b/gemfiles/ruby_3.1_graphql_2.0.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     datadog (2.4.0)
       datadog-ruby_core_source (~> 3.3)
-      libdatadog (~> 13.1.0.1.0)
+      libdatadog (~> 14.0.0.1.0)
       libddwaf (~> 1.15.0.0.0)
       msgpack
 
@@ -121,8 +121,8 @@ GEM
     json (2.7.1)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (13.1.0.1.0-aarch64-linux)
-    libdatadog (13.1.0.1.0-x86_64-linux)
+    libdatadog (14.0.0.1.0-aarch64-linux)
+    libdatadog (14.0.0.1.0-x86_64-linux)
     libddwaf (1.15.0.0.0-aarch64-linux)
       ffi (~> 1.0)
     libddwaf (1.15.0.0.0-x86_64-linux)

--- a/gemfiles/ruby_3.1_graphql_2.1.gemfile.lock
+++ b/gemfiles/ruby_3.1_graphql_2.1.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     datadog (2.4.0)
       datadog-ruby_core_source (~> 3.3)
-      libdatadog (~> 13.1.0.1.0)
+      libdatadog (~> 14.0.0.1.0)
       libddwaf (~> 1.15.0.0.0)
       msgpack
 
@@ -122,8 +122,8 @@ GEM
     json (2.7.1)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (13.1.0.1.0-aarch64-linux)
-    libdatadog (13.1.0.1.0-x86_64-linux)
+    libdatadog (14.0.0.1.0-aarch64-linux)
+    libdatadog (14.0.0.1.0-x86_64-linux)
     libddwaf (1.15.0.0.0-aarch64-linux)
       ffi (~> 1.0)
     libddwaf (1.15.0.0.0-x86_64-linux)

--- a/gemfiles/ruby_3.1_graphql_2.2.gemfile.lock
+++ b/gemfiles/ruby_3.1_graphql_2.2.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     datadog (2.4.0)
       datadog-ruby_core_source (~> 3.3)
-      libdatadog (~> 13.1.0.1.0)
+      libdatadog (~> 14.0.0.1.0)
       libddwaf (~> 1.15.0.0.0)
       msgpack
 
@@ -122,8 +122,8 @@ GEM
     json (2.7.1)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (13.1.0.1.0-aarch64-linux)
-    libdatadog (13.1.0.1.0-x86_64-linux)
+    libdatadog (14.0.0.1.0-aarch64-linux)
+    libdatadog (14.0.0.1.0-x86_64-linux)
     libddwaf (1.15.0.0.0-aarch64-linux)
       ffi (~> 1.0)
     libddwaf (1.15.0.0.0-x86_64-linux)

--- a/gemfiles/ruby_3.1_graphql_2.3.gemfile.lock
+++ b/gemfiles/ruby_3.1_graphql_2.3.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     datadog (2.4.0)
       datadog-ruby_core_source (~> 3.3)
-      libdatadog (~> 13.1.0.1.0)
+      libdatadog (~> 14.0.0.1.0)
       libddwaf (~> 1.15.0.0.0)
       msgpack
 
@@ -124,8 +124,8 @@ GEM
     json (2.7.2)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (13.1.0.1.0-aarch64-linux)
-    libdatadog (13.1.0.1.0-x86_64-linux)
+    libdatadog (14.0.0.1.0-aarch64-linux)
+    libdatadog (14.0.0.1.0-x86_64-linux)
     libddwaf (1.15.0.0.0-aarch64-linux)
       ffi (~> 1.0)
     libddwaf (1.15.0.0.0-x86_64-linux)

--- a/gemfiles/ruby_3.1_http.gemfile.lock
+++ b/gemfiles/ruby_3.1_http.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     datadog (2.4.0)
       datadog-ruby_core_source (~> 3.3)
-      libdatadog (~> 13.1.0.1.0)
+      libdatadog (~> 14.0.0.1.0)
       libddwaf (~> 1.15.0.0.0)
       msgpack
 
@@ -73,8 +73,8 @@ GEM
     json (2.6.3)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (13.1.0.1.0-aarch64-linux)
-    libdatadog (13.1.0.1.0-x86_64-linux)
+    libdatadog (14.0.0.1.0-aarch64-linux)
+    libdatadog (14.0.0.1.0-x86_64-linux)
     libddwaf (1.15.0.0.0-aarch64-linux)
       ffi (~> 1.0)
     libddwaf (1.15.0.0.0-x86_64-linux)

--- a/gemfiles/ruby_3.1_opensearch_2.gemfile.lock
+++ b/gemfiles/ruby_3.1_opensearch_2.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     datadog (2.4.0)
       datadog-ruby_core_source (~> 3.3)
-      libdatadog (~> 13.1.0.1.0)
+      libdatadog (~> 14.0.0.1.0)
       libddwaf (~> 1.15.0.0.0)
       msgpack
 
@@ -58,8 +58,8 @@ GEM
     json (2.7.5)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (13.1.0.1.0-aarch64-linux)
-    libdatadog (13.1.0.1.0-x86_64-linux)
+    libdatadog (14.0.0.1.0-aarch64-linux)
+    libdatadog (14.0.0.1.0-x86_64-linux)
     libddwaf (1.15.0.0.0-aarch64-linux)
       ffi (~> 1.0)
     libddwaf (1.15.0.0.0-x86_64-linux)

--- a/gemfiles/ruby_3.1_opensearch_3.gemfile.lock
+++ b/gemfiles/ruby_3.1_opensearch_3.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     datadog (2.4.0)
       datadog-ruby_core_source (~> 3.3)
-      libdatadog (~> 13.1.0.1.0)
+      libdatadog (~> 14.0.0.1.0)
       libddwaf (~> 1.15.0.0.0)
       msgpack
 
@@ -58,8 +58,8 @@ GEM
     json (2.7.5)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (13.1.0.1.0-aarch64-linux)
-    libdatadog (13.1.0.1.0-x86_64-linux)
+    libdatadog (14.0.0.1.0-aarch64-linux)
+    libdatadog (14.0.0.1.0-x86_64-linux)
     libddwaf (1.15.0.0.0-aarch64-linux)
       ffi (~> 1.0)
     libddwaf (1.15.0.0.0-x86_64-linux)

--- a/gemfiles/ruby_3.1_opensearch_latest.gemfile.lock
+++ b/gemfiles/ruby_3.1_opensearch_latest.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     datadog (2.4.0)
       datadog-ruby_core_source (~> 3.3)
-      libdatadog (~> 13.1.0.1.0)
+      libdatadog (~> 14.0.0.1.0)
       libddwaf (~> 1.15.0.0.0)
       msgpack
 
@@ -60,8 +60,8 @@ GEM
     json (2.7.5)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (13.1.0.1.0-aarch64-linux)
-    libdatadog (13.1.0.1.0-x86_64-linux)
+    libdatadog (14.0.0.1.0-aarch64-linux)
+    libdatadog (14.0.0.1.0-x86_64-linux)
     libddwaf (1.15.0.0.0-aarch64-linux)
       ffi (~> 1.0)
     libddwaf (1.15.0.0.0-x86_64-linux)

--- a/gemfiles/ruby_3.1_opentelemetry.gemfile.lock
+++ b/gemfiles/ruby_3.1_opentelemetry.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     datadog (2.4.0)
       datadog-ruby_core_source (~> 3.3)
-      libdatadog (~> 13.1.0.1.0)
+      libdatadog (~> 14.0.0.1.0)
       libddwaf (~> 1.15.0.0.0)
       msgpack
 
@@ -53,9 +53,9 @@ GEM
     json (2.6.3)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (13.1.0.1.0)
-    libdatadog (13.1.0.1.0-aarch64-linux)
-    libdatadog (13.1.0.1.0-x86_64-linux)
+    libdatadog (14.0.0.1.0)
+    libdatadog (14.0.0.1.0-aarch64-linux)
+    libdatadog (14.0.0.1.0-x86_64-linux)
     libddwaf (1.15.0.0.0-aarch64-linux)
       ffi (~> 1.0)
     libddwaf (1.15.0.0.0-x86_64-darwin)

--- a/gemfiles/ruby_3.1_opentelemetry_otlp.gemfile.lock
+++ b/gemfiles/ruby_3.1_opentelemetry_otlp.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     datadog (2.4.0)
       datadog-ruby_core_source (~> 3.3)
-      libdatadog (~> 13.1.0.1.0)
+      libdatadog (~> 14.0.0.1.0)
       libddwaf (~> 1.15.0.0.0)
       msgpack
 
@@ -56,8 +56,8 @@ GEM
     json (2.7.1)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (13.1.0.1.0-aarch64-linux)
-    libdatadog (13.1.0.1.0-x86_64-linux)
+    libdatadog (14.0.0.1.0-aarch64-linux)
+    libdatadog (14.0.0.1.0-x86_64-linux)
     libddwaf (1.15.0.0.0-aarch64-linux)
       ffi (~> 1.0)
     libddwaf (1.15.0.0.0-x86_64-linux)

--- a/gemfiles/ruby_3.1_rack_1.gemfile.lock
+++ b/gemfiles/ruby_3.1_rack_1.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     datadog (2.4.0)
       datadog-ruby_core_source (~> 3.3)
-      libdatadog (~> 13.1.0.1.0)
+      libdatadog (~> 14.0.0.1.0)
       libddwaf (~> 1.15.0.0.0)
       msgpack
 
@@ -51,8 +51,8 @@ GEM
     json (2.6.3)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (13.1.0.1.0-aarch64-linux)
-    libdatadog (13.1.0.1.0-x86_64-linux)
+    libdatadog (14.0.0.1.0-aarch64-linux)
+    libdatadog (14.0.0.1.0-x86_64-linux)
     libddwaf (1.15.0.0.0-aarch64-linux)
       ffi (~> 1.0)
     libddwaf (1.15.0.0.0-x86_64-linux)

--- a/gemfiles/ruby_3.1_rack_2.gemfile.lock
+++ b/gemfiles/ruby_3.1_rack_2.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     datadog (2.4.0)
       datadog-ruby_core_source (~> 3.3)
-      libdatadog (~> 13.1.0.1.0)
+      libdatadog (~> 14.0.0.1.0)
       libddwaf (~> 1.15.0.0.0)
       msgpack
 
@@ -51,8 +51,8 @@ GEM
     json (2.6.3)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (13.1.0.1.0-aarch64-linux)
-    libdatadog (13.1.0.1.0-x86_64-linux)
+    libdatadog (14.0.0.1.0-aarch64-linux)
+    libdatadog (14.0.0.1.0-x86_64-linux)
     libddwaf (1.15.0.0.0-aarch64-linux)
       ffi (~> 1.0)
     libddwaf (1.15.0.0.0-x86_64-linux)

--- a/gemfiles/ruby_3.1_rack_3.gemfile.lock
+++ b/gemfiles/ruby_3.1_rack_3.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     datadog (2.4.0)
       datadog-ruby_core_source (~> 3.3)
-      libdatadog (~> 13.1.0.1.0)
+      libdatadog (~> 14.0.0.1.0)
       libddwaf (~> 1.15.0.0.0)
       msgpack
 
@@ -51,8 +51,8 @@ GEM
     json (2.6.3)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (13.1.0.1.0-aarch64-linux)
-    libdatadog (13.1.0.1.0-x86_64-linux)
+    libdatadog (14.0.0.1.0-aarch64-linux)
+    libdatadog (14.0.0.1.0-x86_64-linux)
     libddwaf (1.15.0.0.0-aarch64-linux)
       ffi (~> 1.0)
     libddwaf (1.15.0.0.0-x86_64-linux)

--- a/gemfiles/ruby_3.1_rack_latest.gemfile.lock
+++ b/gemfiles/ruby_3.1_rack_latest.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     datadog (2.4.0)
       datadog-ruby_core_source (~> 3.3)
-      libdatadog (~> 13.1.0.1.0)
+      libdatadog (~> 14.0.0.1.0)
       libddwaf (~> 1.15.0.0.0)
       msgpack
 
@@ -54,8 +54,8 @@ GEM
     json (2.7.2)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (13.1.0.1.0-aarch64-linux)
-    libdatadog (13.1.0.1.0-x86_64-linux)
+    libdatadog (14.0.0.1.0-aarch64-linux)
+    libdatadog (14.0.0.1.0-x86_64-linux)
     libddwaf (1.15.0.0.0-aarch64-linux)
       ffi (~> 1.0)
     libddwaf (1.15.0.0.0-x86_64-linux)

--- a/gemfiles/ruby_3.1_rails61_mysql2.gemfile.lock
+++ b/gemfiles/ruby_3.1_rails61_mysql2.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     datadog (2.4.0)
       datadog-ruby_core_source (~> 3.3)
-      libdatadog (~> 13.1.0.1.0)
+      libdatadog (~> 14.0.0.1.0)
       libddwaf (~> 1.15.0.0.0)
       msgpack
 
@@ -118,8 +118,8 @@ GEM
     json (2.6.3)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (13.1.0.1.0-aarch64-linux)
-    libdatadog (13.1.0.1.0-x86_64-linux)
+    libdatadog (14.0.0.1.0-aarch64-linux)
+    libdatadog (14.0.0.1.0-x86_64-linux)
     libddwaf (1.15.0.0.0-aarch64-linux)
       ffi (~> 1.0)
     libddwaf (1.15.0.0.0-x86_64-linux)

--- a/gemfiles/ruby_3.1_rails61_postgres.gemfile.lock
+++ b/gemfiles/ruby_3.1_rails61_postgres.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     datadog (2.4.0)
       datadog-ruby_core_source (~> 3.3)
-      libdatadog (~> 13.1.0.1.0)
+      libdatadog (~> 14.0.0.1.0)
       libddwaf (~> 1.15.0.0.0)
       msgpack
 
@@ -118,8 +118,8 @@ GEM
     json (2.6.3)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (13.1.0.1.0-aarch64-linux)
-    libdatadog (13.1.0.1.0-x86_64-linux)
+    libdatadog (14.0.0.1.0-aarch64-linux)
+    libdatadog (14.0.0.1.0-x86_64-linux)
     libddwaf (1.15.0.0.0-aarch64-linux)
       ffi (~> 1.0)
     libddwaf (1.15.0.0.0-x86_64-linux)

--- a/gemfiles/ruby_3.1_rails61_postgres_redis.gemfile.lock
+++ b/gemfiles/ruby_3.1_rails61_postgres_redis.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     datadog (2.4.0)
       datadog-ruby_core_source (~> 3.3)
-      libdatadog (~> 13.1.0.1.0)
+      libdatadog (~> 14.0.0.1.0)
       libddwaf (~> 1.15.0.0.0)
       msgpack
 
@@ -118,8 +118,8 @@ GEM
     json (2.6.3)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (13.1.0.1.0-aarch64-linux)
-    libdatadog (13.1.0.1.0-x86_64-linux)
+    libdatadog (14.0.0.1.0-aarch64-linux)
+    libdatadog (14.0.0.1.0-x86_64-linux)
     libddwaf (1.15.0.0.0-aarch64-linux)
       ffi (~> 1.0)
     libddwaf (1.15.0.0.0-x86_64-linux)

--- a/gemfiles/ruby_3.1_rails61_postgres_sidekiq.gemfile.lock
+++ b/gemfiles/ruby_3.1_rails61_postgres_sidekiq.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     datadog (2.4.0)
       datadog-ruby_core_source (~> 3.3)
-      libdatadog (~> 13.1.0.1.0)
+      libdatadog (~> 14.0.0.1.0)
       libddwaf (~> 1.15.0.0.0)
       msgpack
 
@@ -119,8 +119,8 @@ GEM
     json (2.6.3)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (13.1.0.1.0-aarch64-linux)
-    libdatadog (13.1.0.1.0-x86_64-linux)
+    libdatadog (14.0.0.1.0-aarch64-linux)
+    libdatadog (14.0.0.1.0-x86_64-linux)
     libddwaf (1.15.0.0.0-aarch64-linux)
       ffi (~> 1.0)
     libddwaf (1.15.0.0.0-x86_64-linux)

--- a/gemfiles/ruby_3.1_rails61_semantic_logger.gemfile.lock
+++ b/gemfiles/ruby_3.1_rails61_semantic_logger.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     datadog (2.4.0)
       datadog-ruby_core_source (~> 3.3)
-      libdatadog (~> 13.1.0.1.0)
+      libdatadog (~> 14.0.0.1.0)
       libddwaf (~> 1.15.0.0.0)
       msgpack
 
@@ -118,8 +118,8 @@ GEM
     json (2.6.3)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (13.1.0.1.0-aarch64-linux)
-    libdatadog (13.1.0.1.0-x86_64-linux)
+    libdatadog (14.0.0.1.0-aarch64-linux)
+    libdatadog (14.0.0.1.0-x86_64-linux)
     libddwaf (1.15.0.0.0-aarch64-linux)
       ffi (~> 1.0)
     libddwaf (1.15.0.0.0-x86_64-linux)

--- a/gemfiles/ruby_3.1_rails61_trilogy.gemfile.lock
+++ b/gemfiles/ruby_3.1_rails61_trilogy.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     datadog (2.4.0)
       datadog-ruby_core_source (~> 3.3)
-      libdatadog (~> 13.1.0.1.0)
+      libdatadog (~> 14.0.0.1.0)
       libddwaf (~> 1.15.0.0.0)
       msgpack
 
@@ -122,8 +122,8 @@ GEM
     json (2.6.3)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (13.1.0.1.0-aarch64-linux)
-    libdatadog (13.1.0.1.0-x86_64-linux)
+    libdatadog (14.0.0.1.0-aarch64-linux)
+    libdatadog (14.0.0.1.0-x86_64-linux)
     libddwaf (1.15.0.0.0-aarch64-linux)
       ffi (~> 1.0)
     libddwaf (1.15.0.0.0-x86_64-linux)

--- a/gemfiles/ruby_3.1_rails7.gemfile.lock
+++ b/gemfiles/ruby_3.1_rails7.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     datadog (2.4.0)
       datadog-ruby_core_source (~> 3.3)
-      libdatadog (~> 13.1.0.1.0)
+      libdatadog (~> 14.0.0.1.0)
       libddwaf (~> 1.15.0.0.0)
       msgpack
 
@@ -127,8 +127,8 @@ GEM
     json (2.7.2)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (13.1.0.1.0-aarch64-linux)
-    libdatadog (13.1.0.1.0-x86_64-linux)
+    libdatadog (14.0.0.1.0-aarch64-linux)
+    libdatadog (14.0.0.1.0-x86_64-linux)
     libddwaf (1.15.0.0.0-aarch64-linux)
       ffi (~> 1.0)
     libddwaf (1.15.0.0.0-x86_64-linux)

--- a/gemfiles/ruby_3.1_rails71.gemfile.lock
+++ b/gemfiles/ruby_3.1_rails71.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     datadog (2.4.0)
       datadog-ruby_core_source (~> 3.3)
-      libdatadog (~> 13.1.0.1.0)
+      libdatadog (~> 14.0.0.1.0)
       libddwaf (~> 1.15.0.0.0)
       msgpack
 
@@ -143,8 +143,8 @@ GEM
     json (2.7.2)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (13.1.0.1.0-aarch64-linux)
-    libdatadog (13.1.0.1.0-x86_64-linux)
+    libdatadog (14.0.0.1.0-aarch64-linux)
+    libdatadog (14.0.0.1.0-x86_64-linux)
     libddwaf (1.15.0.0.0-aarch64-linux)
       ffi (~> 1.0)
     libddwaf (1.15.0.0.0-x86_64-linux)

--- a/gemfiles/ruby_3.1_redis_3.gemfile.lock
+++ b/gemfiles/ruby_3.1_redis_3.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     datadog (2.4.0)
       datadog-ruby_core_source (~> 3.3)
-      libdatadog (~> 13.1.0.1.0)
+      libdatadog (~> 14.0.0.1.0)
       libddwaf (~> 1.15.0.0.0)
       msgpack
 
@@ -51,8 +51,8 @@ GEM
     json (2.6.3)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (13.1.0.1.0-aarch64-linux)
-    libdatadog (13.1.0.1.0-x86_64-linux)
+    libdatadog (14.0.0.1.0-aarch64-linux)
+    libdatadog (14.0.0.1.0-x86_64-linux)
     libddwaf (1.15.0.0.0-aarch64-linux)
       ffi (~> 1.0)
     libddwaf (1.15.0.0.0-x86_64-linux)

--- a/gemfiles/ruby_3.1_redis_4.gemfile.lock
+++ b/gemfiles/ruby_3.1_redis_4.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     datadog (2.4.0)
       datadog-ruby_core_source (~> 3.3)
-      libdatadog (~> 13.1.0.1.0)
+      libdatadog (~> 14.0.0.1.0)
       libddwaf (~> 1.15.0.0.0)
       msgpack
 
@@ -51,8 +51,8 @@ GEM
     json (2.6.3)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (13.1.0.1.0-aarch64-linux)
-    libdatadog (13.1.0.1.0-x86_64-linux)
+    libdatadog (14.0.0.1.0-aarch64-linux)
+    libdatadog (14.0.0.1.0-x86_64-linux)
     libddwaf (1.15.0.0.0-aarch64-linux)
       ffi (~> 1.0)
     libddwaf (1.15.0.0.0-x86_64-linux)

--- a/gemfiles/ruby_3.1_redis_5.gemfile.lock
+++ b/gemfiles/ruby_3.1_redis_5.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     datadog (2.4.0)
       datadog-ruby_core_source (~> 3.3)
-      libdatadog (~> 13.1.0.1.0)
+      libdatadog (~> 14.0.0.1.0)
       libddwaf (~> 1.15.0.0.0)
       msgpack
 
@@ -52,8 +52,8 @@ GEM
     json (2.6.3)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (13.1.0.1.0-aarch64-linux)
-    libdatadog (13.1.0.1.0-x86_64-linux)
+    libdatadog (14.0.0.1.0-aarch64-linux)
+    libdatadog (14.0.0.1.0-x86_64-linux)
     libddwaf (1.15.0.0.0-aarch64-linux)
       ffi (~> 1.0)
     libddwaf (1.15.0.0.0-x86_64-linux)

--- a/gemfiles/ruby_3.1_relational_db.gemfile.lock
+++ b/gemfiles/ruby_3.1_relational_db.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     datadog (2.4.0)
       datadog-ruby_core_source (~> 3.3)
-      libdatadog (~> 13.1.0.1.0)
+      libdatadog (~> 14.0.0.1.0)
       libddwaf (~> 1.15.0.0.0)
       msgpack
 
@@ -69,8 +69,8 @@ GEM
     json (2.6.3)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (13.1.0.1.0-aarch64-linux)
-    libdatadog (13.1.0.1.0-x86_64-linux)
+    libdatadog (14.0.0.1.0-aarch64-linux)
+    libdatadog (14.0.0.1.0-x86_64-linux)
     libddwaf (1.15.0.0.0-aarch64-linux)
       ffi (~> 1.0)
     libddwaf (1.15.0.0.0-x86_64-linux)

--- a/gemfiles/ruby_3.1_resque2_redis3.gemfile.lock
+++ b/gemfiles/ruby_3.1_resque2_redis3.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     datadog (2.4.0)
       datadog-ruby_core_source (~> 3.3)
-      libdatadog (~> 13.1.0.1.0)
+      libdatadog (~> 14.0.0.1.0)
       libddwaf (~> 1.15.0.0.0)
       msgpack
 
@@ -51,8 +51,8 @@ GEM
     json (2.6.3)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (13.1.0.1.0-aarch64-linux)
-    libdatadog (13.1.0.1.0-x86_64-linux)
+    libdatadog (14.0.0.1.0-aarch64-linux)
+    libdatadog (14.0.0.1.0-x86_64-linux)
     libddwaf (1.15.0.0.0-aarch64-linux)
       ffi (~> 1.0)
     libddwaf (1.15.0.0.0-x86_64-linux)

--- a/gemfiles/ruby_3.1_resque2_redis4.gemfile.lock
+++ b/gemfiles/ruby_3.1_resque2_redis4.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     datadog (2.4.0)
       datadog-ruby_core_source (~> 3.3)
-      libdatadog (~> 13.1.0.1.0)
+      libdatadog (~> 14.0.0.1.0)
       libddwaf (~> 1.15.0.0.0)
       msgpack
 
@@ -52,8 +52,8 @@ GEM
     json (2.6.3)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (13.1.0.1.0-aarch64-linux)
-    libdatadog (13.1.0.1.0-x86_64-linux)
+    libdatadog (14.0.0.1.0-aarch64-linux)
+    libdatadog (14.0.0.1.0-x86_64-linux)
     libddwaf (1.15.0.0.0-aarch64-linux)
       ffi (~> 1.0)
     libddwaf (1.15.0.0.0-x86_64-linux)

--- a/gemfiles/ruby_3.1_sinatra_2.gemfile.lock
+++ b/gemfiles/ruby_3.1_sinatra_2.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     datadog (2.4.0)
       datadog-ruby_core_source (~> 3.3)
-      libdatadog (~> 13.1.0.1.0)
+      libdatadog (~> 14.0.0.1.0)
       libddwaf (~> 1.15.0.0.0)
       msgpack
 
@@ -54,8 +54,8 @@ GEM
     json (2.7.2)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (13.1.0.1.0-aarch64-linux)
-    libdatadog (13.1.0.1.0-x86_64-linux)
+    libdatadog (14.0.0.1.0-aarch64-linux)
+    libdatadog (14.0.0.1.0-x86_64-linux)
     libddwaf (1.15.0.0.0-aarch64-linux)
       ffi (~> 1.0)
     libddwaf (1.15.0.0.0-x86_64-linux)

--- a/gemfiles/ruby_3.1_sinatra_3.gemfile.lock
+++ b/gemfiles/ruby_3.1_sinatra_3.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     datadog (2.4.0)
       datadog-ruby_core_source (~> 3.3)
-      libdatadog (~> 13.1.0.1.0)
+      libdatadog (~> 14.0.0.1.0)
       libddwaf (~> 1.15.0.0.0)
       msgpack
 
@@ -55,8 +55,8 @@ GEM
     json (2.7.2)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (13.1.0.1.0-aarch64-linux)
-    libdatadog (13.1.0.1.0-x86_64-linux)
+    libdatadog (14.0.0.1.0-aarch64-linux)
+    libdatadog (14.0.0.1.0-x86_64-linux)
     libddwaf (1.15.0.0.0-aarch64-linux)
       ffi (~> 1.0)
     libddwaf (1.15.0.0.0-x86_64-linux)

--- a/gemfiles/ruby_3.1_sinatra_4.gemfile.lock
+++ b/gemfiles/ruby_3.1_sinatra_4.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     datadog (2.4.0)
       datadog-ruby_core_source (~> 3.3)
-      libdatadog (~> 13.1.0.1.0)
+      libdatadog (~> 14.0.0.1.0)
       libddwaf (~> 1.15.0.0.0)
       msgpack
 
@@ -55,8 +55,8 @@ GEM
     json (2.7.2)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (13.1.0.1.0-aarch64-linux)
-    libdatadog (13.1.0.1.0-x86_64-linux)
+    libdatadog (14.0.0.1.0-aarch64-linux)
+    libdatadog (14.0.0.1.0-x86_64-linux)
     libddwaf (1.15.0.0.0-aarch64-linux)
       ffi (~> 1.0)
     libddwaf (1.15.0.0.0-x86_64-linux)

--- a/gemfiles/ruby_3.1_stripe_10.gemfile.lock
+++ b/gemfiles/ruby_3.1_stripe_10.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     datadog (2.4.0)
       datadog-ruby_core_source (~> 3.3)
-      libdatadog (~> 13.1.0.1.0)
+      libdatadog (~> 14.0.0.1.0)
       libddwaf (~> 1.15.0.0.0)
       msgpack
 
@@ -54,8 +54,8 @@ GEM
     json (2.7.2)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (13.1.0.1.0-aarch64-linux)
-    libdatadog (13.1.0.1.0-x86_64-linux)
+    libdatadog (14.0.0.1.0-aarch64-linux)
+    libdatadog (14.0.0.1.0-x86_64-linux)
     libddwaf (1.15.0.0.0-aarch64-linux)
       ffi (~> 1.0)
     libddwaf (1.15.0.0.0-x86_64-linux)

--- a/gemfiles/ruby_3.1_stripe_11.gemfile.lock
+++ b/gemfiles/ruby_3.1_stripe_11.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     datadog (2.4.0)
       datadog-ruby_core_source (~> 3.3)
-      libdatadog (~> 13.1.0.1.0)
+      libdatadog (~> 14.0.0.1.0)
       libddwaf (~> 1.15.0.0.0)
       msgpack
 
@@ -54,8 +54,8 @@ GEM
     json (2.7.2)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (13.1.0.1.0-aarch64-linux)
-    libdatadog (13.1.0.1.0-x86_64-linux)
+    libdatadog (14.0.0.1.0-aarch64-linux)
+    libdatadog (14.0.0.1.0-x86_64-linux)
     libddwaf (1.15.0.0.0-aarch64-linux)
       ffi (~> 1.0)
     libddwaf (1.15.0.0.0-x86_64-linux)

--- a/gemfiles/ruby_3.1_stripe_12.gemfile.lock
+++ b/gemfiles/ruby_3.1_stripe_12.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     datadog (2.4.0)
       datadog-ruby_core_source (~> 3.3)
-      libdatadog (~> 13.1.0.1.0)
+      libdatadog (~> 14.0.0.1.0)
       libddwaf (~> 1.15.0.0.0)
       msgpack
 
@@ -54,8 +54,8 @@ GEM
     json (2.7.2)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (13.1.0.1.0-aarch64-linux)
-    libdatadog (13.1.0.1.0-x86_64-linux)
+    libdatadog (14.0.0.1.0-aarch64-linux)
+    libdatadog (14.0.0.1.0-x86_64-linux)
     libddwaf (1.15.0.0.0-aarch64-linux)
       ffi (~> 1.0)
     libddwaf (1.15.0.0.0-x86_64-linux)

--- a/gemfiles/ruby_3.1_stripe_7.gemfile.lock
+++ b/gemfiles/ruby_3.1_stripe_7.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     datadog (2.4.0)
       datadog-ruby_core_source (~> 3.3)
-      libdatadog (~> 13.1.0.1.0)
+      libdatadog (~> 14.0.0.1.0)
       libddwaf (~> 1.15.0.0.0)
       msgpack
 
@@ -54,8 +54,8 @@ GEM
     json (2.7.2)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (13.1.0.1.0-aarch64-linux)
-    libdatadog (13.1.0.1.0-x86_64-linux)
+    libdatadog (14.0.0.1.0-aarch64-linux)
+    libdatadog (14.0.0.1.0-x86_64-linux)
     libddwaf (1.15.0.0.0-aarch64-linux)
       ffi (~> 1.0)
     libddwaf (1.15.0.0.0-x86_64-linux)

--- a/gemfiles/ruby_3.1_stripe_8.gemfile.lock
+++ b/gemfiles/ruby_3.1_stripe_8.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     datadog (2.4.0)
       datadog-ruby_core_source (~> 3.3)
-      libdatadog (~> 13.1.0.1.0)
+      libdatadog (~> 14.0.0.1.0)
       libddwaf (~> 1.15.0.0.0)
       msgpack
 
@@ -54,8 +54,8 @@ GEM
     json (2.7.2)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (13.1.0.1.0-aarch64-linux)
-    libdatadog (13.1.0.1.0-x86_64-linux)
+    libdatadog (14.0.0.1.0-aarch64-linux)
+    libdatadog (14.0.0.1.0-x86_64-linux)
     libddwaf (1.15.0.0.0-aarch64-linux)
       ffi (~> 1.0)
     libddwaf (1.15.0.0.0-x86_64-linux)

--- a/gemfiles/ruby_3.1_stripe_9.gemfile.lock
+++ b/gemfiles/ruby_3.1_stripe_9.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     datadog (2.4.0)
       datadog-ruby_core_source (~> 3.3)
-      libdatadog (~> 13.1.0.1.0)
+      libdatadog (~> 14.0.0.1.0)
       libddwaf (~> 1.15.0.0.0)
       msgpack
 
@@ -54,8 +54,8 @@ GEM
     json (2.7.2)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (13.1.0.1.0-aarch64-linux)
-    libdatadog (13.1.0.1.0-x86_64-linux)
+    libdatadog (14.0.0.1.0-aarch64-linux)
+    libdatadog (14.0.0.1.0-x86_64-linux)
     libddwaf (1.15.0.0.0-aarch64-linux)
       ffi (~> 1.0)
     libddwaf (1.15.0.0.0-x86_64-linux)

--- a/gemfiles/ruby_3.1_stripe_latest.gemfile.lock
+++ b/gemfiles/ruby_3.1_stripe_latest.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     datadog (2.4.0)
       datadog-ruby_core_source (~> 3.3)
-      libdatadog (~> 13.1.0.1.0)
+      libdatadog (~> 14.0.0.1.0)
       libddwaf (~> 1.15.0.0.0)
       msgpack
 
@@ -54,8 +54,8 @@ GEM
     json (2.7.2)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (13.1.0.1.0-aarch64-linux)
-    libdatadog (13.1.0.1.0-x86_64-linux)
+    libdatadog (14.0.0.1.0-aarch64-linux)
+    libdatadog (14.0.0.1.0-x86_64-linux)
     libddwaf (1.15.0.0.0-aarch64-linux)
       ffi (~> 1.0)
     libddwaf (1.15.0.0.0-x86_64-linux)

--- a/gemfiles/ruby_3.1_stripe_min.gemfile.lock
+++ b/gemfiles/ruby_3.1_stripe_min.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     datadog (2.4.0)
       datadog-ruby_core_source (~> 3.3)
-      libdatadog (~> 13.1.0.1.0)
+      libdatadog (~> 14.0.0.1.0)
       libddwaf (~> 1.15.0.0.0)
       msgpack
 
@@ -54,8 +54,8 @@ GEM
     json (2.7.2)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (13.1.0.1.0-aarch64-linux)
-    libdatadog (13.1.0.1.0-x86_64-linux)
+    libdatadog (14.0.0.1.0-aarch64-linux)
+    libdatadog (14.0.0.1.0-x86_64-linux)
     libddwaf (1.15.0.0.0-aarch64-linux)
       ffi (~> 1.0)
     libddwaf (1.15.0.0.0-x86_64-linux)

--- a/gemfiles/ruby_3.2_activesupport.gemfile.lock
+++ b/gemfiles/ruby_3.2_activesupport.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     datadog (2.4.0)
       datadog-ruby_core_source (~> 3.3)
-      libdatadog (~> 13.1.0.1.0)
+      libdatadog (~> 14.0.0.1.0)
       libddwaf (~> 1.15.0.0.0)
       msgpack
 
@@ -107,8 +107,8 @@ GEM
       addressable (>= 2.4)
     jsonapi-renderer (0.2.2)
     king_konf (1.0.1)
-    libdatadog (13.1.0.1.0-aarch64-linux)
-    libdatadog (13.1.0.1.0-x86_64-linux)
+    libdatadog (14.0.0.1.0-aarch64-linux)
+    libdatadog (14.0.0.1.0-x86_64-linux)
     libddwaf (1.15.0.0.0-aarch64-linux)
       ffi (~> 1.0)
     libddwaf (1.15.0.0.0-x86_64-linux)

--- a/gemfiles/ruby_3.2_aws.gemfile.lock
+++ b/gemfiles/ruby_3.2_aws.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     datadog (2.4.0)
       datadog-ruby_core_source (~> 3.3)
-      libdatadog (~> 13.1.0.1.0)
+      libdatadog (~> 14.0.0.1.0)
       libddwaf (~> 1.15.0.0.0)
       msgpack
 
@@ -1472,8 +1472,8 @@ GEM
     json (2.6.3)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (13.1.0.1.0-aarch64-linux)
-    libdatadog (13.1.0.1.0-x86_64-linux)
+    libdatadog (14.0.0.1.0-aarch64-linux)
+    libdatadog (14.0.0.1.0-x86_64-linux)
     libddwaf (1.15.0.0.0-aarch64-linux)
       ffi (~> 1.0)
     libddwaf (1.15.0.0.0-x86_64-linux)

--- a/gemfiles/ruby_3.2_contrib.gemfile.lock
+++ b/gemfiles/ruby_3.2_contrib.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     datadog (2.4.0)
       datadog-ruby_core_source (~> 3.3)
-      libdatadog (~> 13.1.0.1.0)
+      libdatadog (~> 14.0.0.1.0)
       libddwaf (~> 1.15.0.0.0)
       msgpack
 
@@ -65,8 +65,8 @@ GEM
     json (2.6.3)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (13.1.0.1.0-aarch64-linux)
-    libdatadog (13.1.0.1.0-x86_64-linux)
+    libdatadog (14.0.0.1.0-aarch64-linux)
+    libdatadog (14.0.0.1.0-x86_64-linux)
     libddwaf (1.15.0.0.0-aarch64-linux)
       ffi (~> 1.0)
     libddwaf (1.15.0.0.0-x86_64-linux)

--- a/gemfiles/ruby_3.2_contrib_old.gemfile.lock
+++ b/gemfiles/ruby_3.2_contrib_old.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     datadog (2.4.0)
       datadog-ruby_core_source (~> 3.3)
-      libdatadog (~> 13.1.0.1.0)
+      libdatadog (~> 14.0.0.1.0)
       libddwaf (~> 1.15.0.0.0)
       msgpack
 
@@ -61,8 +61,8 @@ GEM
     json (2.6.3)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (13.1.0.1.0-aarch64-linux)
-    libdatadog (13.1.0.1.0-x86_64-linux)
+    libdatadog (14.0.0.1.0-aarch64-linux)
+    libdatadog (14.0.0.1.0-x86_64-linux)
     libddwaf (1.15.0.0.0-aarch64-linux)
       ffi (~> 1.0)
     libddwaf (1.15.0.0.0-x86_64-linux)

--- a/gemfiles/ruby_3.2_core_old.gemfile.lock
+++ b/gemfiles/ruby_3.2_core_old.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     datadog (2.4.0)
       datadog-ruby_core_source (~> 3.3)
-      libdatadog (~> 13.1.0.1.0)
+      libdatadog (~> 14.0.0.1.0)
       libddwaf (~> 1.15.0.0.0)
       msgpack
 
@@ -50,8 +50,8 @@ GEM
     json (2.6.3)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (13.1.0.1.0-aarch64-linux)
-    libdatadog (13.1.0.1.0-x86_64-linux)
+    libdatadog (14.0.0.1.0-aarch64-linux)
+    libdatadog (14.0.0.1.0-x86_64-linux)
     libddwaf (1.15.0.0.0-aarch64-linux)
       ffi (~> 1.0)
     libddwaf (1.15.0.0.0-x86_64-linux)

--- a/gemfiles/ruby_3.2_elasticsearch_7.gemfile.lock
+++ b/gemfiles/ruby_3.2_elasticsearch_7.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     datadog (2.4.0)
       datadog-ruby_core_source (~> 3.3)
-      libdatadog (~> 13.1.0.1.0)
+      libdatadog (~> 14.0.0.1.0)
       libddwaf (~> 1.15.0.0.0)
       msgpack
 
@@ -67,8 +67,8 @@ GEM
     json (2.7.5)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (13.1.0.1.0-aarch64-linux)
-    libdatadog (13.1.0.1.0-x86_64-linux)
+    libdatadog (14.0.0.1.0-aarch64-linux)
+    libdatadog (14.0.0.1.0-x86_64-linux)
     libddwaf (1.15.0.0.0-aarch64-linux)
       ffi (~> 1.0)
     libddwaf (1.15.0.0.0-x86_64-linux)

--- a/gemfiles/ruby_3.2_elasticsearch_8.gemfile.lock
+++ b/gemfiles/ruby_3.2_elasticsearch_8.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     datadog (2.4.0)
       datadog-ruby_core_source (~> 3.3)
-      libdatadog (~> 13.1.0.1.0)
+      libdatadog (~> 14.0.0.1.0)
       libddwaf (~> 1.15.0.0.0)
       msgpack
 
@@ -65,8 +65,8 @@ GEM
     json (2.7.5)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (13.1.0.1.0-aarch64-linux)
-    libdatadog (13.1.0.1.0-x86_64-linux)
+    libdatadog (14.0.0.1.0-aarch64-linux)
+    libdatadog (14.0.0.1.0-x86_64-linux)
     libddwaf (1.15.0.0.0-aarch64-linux)
       ffi (~> 1.0)
     libddwaf (1.15.0.0.0-x86_64-linux)

--- a/gemfiles/ruby_3.2_elasticsearch_latest.gemfile.lock
+++ b/gemfiles/ruby_3.2_elasticsearch_latest.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     datadog (2.4.0)
       datadog-ruby_core_source (~> 3.3)
-      libdatadog (~> 13.1.0.1.0)
+      libdatadog (~> 14.0.0.1.0)
       libddwaf (~> 1.15.0.0.0)
       msgpack
 
@@ -67,8 +67,8 @@ GEM
     json (2.7.5)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (13.1.0.1.0-aarch64-linux)
-    libdatadog (13.1.0.1.0-x86_64-linux)
+    libdatadog (14.0.0.1.0-aarch64-linux)
+    libdatadog (14.0.0.1.0-x86_64-linux)
     libddwaf (1.15.0.0.0-aarch64-linux)
       ffi (~> 1.0)
     libddwaf (1.15.0.0.0-x86_64-linux)

--- a/gemfiles/ruby_3.2_graphql_1.13.gemfile.lock
+++ b/gemfiles/ruby_3.2_graphql_1.13.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     datadog (2.4.0)
       datadog-ruby_core_source (~> 3.3)
-      libdatadog (~> 13.1.0.1.0)
+      libdatadog (~> 14.0.0.1.0)
       libddwaf (~> 1.15.0.0.0)
       msgpack
 
@@ -119,8 +119,8 @@ GEM
     json (2.7.1)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (13.1.0.1.0-aarch64-linux)
-    libdatadog (13.1.0.1.0-x86_64-linux)
+    libdatadog (14.0.0.1.0-aarch64-linux)
+    libdatadog (14.0.0.1.0-x86_64-linux)
     libddwaf (1.15.0.0.0-aarch64-linux)
       ffi (~> 1.0)
     libddwaf (1.15.0.0.0-x86_64-linux)

--- a/gemfiles/ruby_3.2_graphql_2.0.gemfile.lock
+++ b/gemfiles/ruby_3.2_graphql_2.0.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     datadog (2.4.0)
       datadog-ruby_core_source (~> 3.3)
-      libdatadog (~> 13.1.0.1.0)
+      libdatadog (~> 14.0.0.1.0)
       libddwaf (~> 1.15.0.0.0)
       msgpack
 
@@ -119,8 +119,8 @@ GEM
     json (2.7.1)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (13.1.0.1.0-aarch64-linux)
-    libdatadog (13.1.0.1.0-x86_64-linux)
+    libdatadog (14.0.0.1.0-aarch64-linux)
+    libdatadog (14.0.0.1.0-x86_64-linux)
     libddwaf (1.15.0.0.0-aarch64-linux)
       ffi (~> 1.0)
     libddwaf (1.15.0.0.0-x86_64-linux)

--- a/gemfiles/ruby_3.2_graphql_2.1.gemfile.lock
+++ b/gemfiles/ruby_3.2_graphql_2.1.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     datadog (2.4.0)
       datadog-ruby_core_source (~> 3.3)
-      libdatadog (~> 13.1.0.1.0)
+      libdatadog (~> 14.0.0.1.0)
       libddwaf (~> 1.15.0.0.0)
       msgpack
 
@@ -120,8 +120,8 @@ GEM
     json (2.7.1)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (13.1.0.1.0-aarch64-linux)
-    libdatadog (13.1.0.1.0-x86_64-linux)
+    libdatadog (14.0.0.1.0-aarch64-linux)
+    libdatadog (14.0.0.1.0-x86_64-linux)
     libddwaf (1.15.0.0.0-aarch64-linux)
       ffi (~> 1.0)
     libddwaf (1.15.0.0.0-x86_64-linux)

--- a/gemfiles/ruby_3.2_graphql_2.2.gemfile.lock
+++ b/gemfiles/ruby_3.2_graphql_2.2.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     datadog (2.4.0)
       datadog-ruby_core_source (~> 3.3)
-      libdatadog (~> 13.1.0.1.0)
+      libdatadog (~> 14.0.0.1.0)
       libddwaf (~> 1.15.0.0.0)
       msgpack
 
@@ -120,8 +120,8 @@ GEM
     json (2.7.1)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (13.1.0.1.0-aarch64-linux)
-    libdatadog (13.1.0.1.0-x86_64-linux)
+    libdatadog (14.0.0.1.0-aarch64-linux)
+    libdatadog (14.0.0.1.0-x86_64-linux)
     libddwaf (1.15.0.0.0-aarch64-linux)
       ffi (~> 1.0)
     libddwaf (1.15.0.0.0-x86_64-linux)

--- a/gemfiles/ruby_3.2_graphql_2.3.gemfile.lock
+++ b/gemfiles/ruby_3.2_graphql_2.3.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     datadog (2.4.0)
       datadog-ruby_core_source (~> 3.3)
-      libdatadog (~> 13.1.0.1.0)
+      libdatadog (~> 14.0.0.1.0)
       libddwaf (~> 1.15.0.0.0)
       msgpack
 
@@ -123,8 +123,8 @@ GEM
     json (2.7.2)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (13.1.0.1.0-aarch64-linux)
-    libdatadog (13.1.0.1.0-x86_64-linux)
+    libdatadog (14.0.0.1.0-aarch64-linux)
+    libdatadog (14.0.0.1.0-x86_64-linux)
     libddwaf (1.15.0.0.0-aarch64-linux)
       ffi (~> 1.0)
     libddwaf (1.15.0.0.0-x86_64-linux)

--- a/gemfiles/ruby_3.2_http.gemfile.lock
+++ b/gemfiles/ruby_3.2_http.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     datadog (2.4.0)
       datadog-ruby_core_source (~> 3.3)
-      libdatadog (~> 13.1.0.1.0)
+      libdatadog (~> 14.0.0.1.0)
       libddwaf (~> 1.15.0.0.0)
       msgpack
 
@@ -72,8 +72,8 @@ GEM
     json (2.6.3)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (13.1.0.1.0-aarch64-linux)
-    libdatadog (13.1.0.1.0-x86_64-linux)
+    libdatadog (14.0.0.1.0-aarch64-linux)
+    libdatadog (14.0.0.1.0-x86_64-linux)
     libddwaf (1.15.0.0.0-aarch64-linux)
       ffi (~> 1.0)
     libddwaf (1.15.0.0.0-x86_64-linux)

--- a/gemfiles/ruby_3.2_opensearch_2.gemfile.lock
+++ b/gemfiles/ruby_3.2_opensearch_2.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     datadog (2.4.0)
       datadog-ruby_core_source (~> 3.3)
-      libdatadog (~> 13.1.0.1.0)
+      libdatadog (~> 14.0.0.1.0)
       libddwaf (~> 1.15.0.0.0)
       msgpack
 
@@ -57,8 +57,8 @@ GEM
     json (2.7.5)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (13.1.0.1.0-aarch64-linux)
-    libdatadog (13.1.0.1.0-x86_64-linux)
+    libdatadog (14.0.0.1.0-aarch64-linux)
+    libdatadog (14.0.0.1.0-x86_64-linux)
     libddwaf (1.15.0.0.0-aarch64-linux)
       ffi (~> 1.0)
     libddwaf (1.15.0.0.0-x86_64-linux)

--- a/gemfiles/ruby_3.2_opensearch_3.gemfile.lock
+++ b/gemfiles/ruby_3.2_opensearch_3.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     datadog (2.4.0)
       datadog-ruby_core_source (~> 3.3)
-      libdatadog (~> 13.1.0.1.0)
+      libdatadog (~> 14.0.0.1.0)
       libddwaf (~> 1.15.0.0.0)
       msgpack
 
@@ -57,8 +57,8 @@ GEM
     json (2.7.5)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (13.1.0.1.0-aarch64-linux)
-    libdatadog (13.1.0.1.0-x86_64-linux)
+    libdatadog (14.0.0.1.0-aarch64-linux)
+    libdatadog (14.0.0.1.0-x86_64-linux)
     libddwaf (1.15.0.0.0-aarch64-linux)
       ffi (~> 1.0)
     libddwaf (1.15.0.0.0-x86_64-linux)

--- a/gemfiles/ruby_3.2_opensearch_latest.gemfile.lock
+++ b/gemfiles/ruby_3.2_opensearch_latest.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     datadog (2.4.0)
       datadog-ruby_core_source (~> 3.3)
-      libdatadog (~> 13.1.0.1.0)
+      libdatadog (~> 14.0.0.1.0)
       libddwaf (~> 1.15.0.0.0)
       msgpack
 
@@ -59,8 +59,8 @@ GEM
     json (2.7.5)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (13.1.0.1.0-aarch64-linux)
-    libdatadog (13.1.0.1.0-x86_64-linux)
+    libdatadog (14.0.0.1.0-aarch64-linux)
+    libdatadog (14.0.0.1.0-x86_64-linux)
     libddwaf (1.15.0.0.0-aarch64-linux)
       ffi (~> 1.0)
     libddwaf (1.15.0.0.0-x86_64-linux)

--- a/gemfiles/ruby_3.2_opentelemetry.gemfile.lock
+++ b/gemfiles/ruby_3.2_opentelemetry.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     datadog (2.4.0)
       datadog-ruby_core_source (~> 3.3)
-      libdatadog (~> 13.1.0.1.0)
+      libdatadog (~> 14.0.0.1.0)
       libddwaf (~> 1.15.0.0.0)
       msgpack
 
@@ -50,8 +50,8 @@ GEM
     json (2.6.3)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (13.1.0.1.0-aarch64-linux)
-    libdatadog (13.1.0.1.0-x86_64-linux)
+    libdatadog (14.0.0.1.0-aarch64-linux)
+    libdatadog (14.0.0.1.0-x86_64-linux)
     libddwaf (1.15.0.0.0-aarch64-linux)
       ffi (~> 1.0)
     libddwaf (1.15.0.0.0-x86_64-linux)

--- a/gemfiles/ruby_3.2_opentelemetry_otlp.gemfile.lock
+++ b/gemfiles/ruby_3.2_opentelemetry_otlp.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     datadog (2.4.0)
       datadog-ruby_core_source (~> 3.3)
-      libdatadog (~> 13.1.0.1.0)
+      libdatadog (~> 14.0.0.1.0)
       libddwaf (~> 1.15.0.0.0)
       msgpack
 
@@ -55,8 +55,8 @@ GEM
     json (2.7.1)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (13.1.0.1.0-aarch64-linux)
-    libdatadog (13.1.0.1.0-x86_64-linux)
+    libdatadog (14.0.0.1.0-aarch64-linux)
+    libdatadog (14.0.0.1.0-x86_64-linux)
     libddwaf (1.15.0.0.0-aarch64-linux)
       ffi (~> 1.0)
     libddwaf (1.15.0.0.0-x86_64-linux)

--- a/gemfiles/ruby_3.2_rack_1.gemfile.lock
+++ b/gemfiles/ruby_3.2_rack_1.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     datadog (2.4.0)
       datadog-ruby_core_source (~> 3.3)
-      libdatadog (~> 13.1.0.1.0)
+      libdatadog (~> 14.0.0.1.0)
       libddwaf (~> 1.15.0.0.0)
       msgpack
 
@@ -50,8 +50,8 @@ GEM
     json (2.6.3)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (13.1.0.1.0-aarch64-linux)
-    libdatadog (13.1.0.1.0-x86_64-linux)
+    libdatadog (14.0.0.1.0-aarch64-linux)
+    libdatadog (14.0.0.1.0-x86_64-linux)
     libddwaf (1.15.0.0.0-aarch64-linux)
       ffi (~> 1.0)
     libddwaf (1.15.0.0.0-x86_64-linux)

--- a/gemfiles/ruby_3.2_rack_2.gemfile.lock
+++ b/gemfiles/ruby_3.2_rack_2.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     datadog (2.4.0)
       datadog-ruby_core_source (~> 3.3)
-      libdatadog (~> 13.1.0.1.0)
+      libdatadog (~> 14.0.0.1.0)
       libddwaf (~> 1.15.0.0.0)
       msgpack
 
@@ -50,8 +50,8 @@ GEM
     json (2.6.3)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (13.1.0.1.0-aarch64-linux)
-    libdatadog (13.1.0.1.0-x86_64-linux)
+    libdatadog (14.0.0.1.0-aarch64-linux)
+    libdatadog (14.0.0.1.0-x86_64-linux)
     libddwaf (1.15.0.0.0-aarch64-linux)
       ffi (~> 1.0)
     libddwaf (1.15.0.0.0-x86_64-linux)

--- a/gemfiles/ruby_3.2_rack_3.gemfile.lock
+++ b/gemfiles/ruby_3.2_rack_3.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     datadog (2.4.0)
       datadog-ruby_core_source (~> 3.3)
-      libdatadog (~> 13.1.0.1.0)
+      libdatadog (~> 14.0.0.1.0)
       libddwaf (~> 1.15.0.0.0)
       msgpack
 
@@ -50,8 +50,8 @@ GEM
     json (2.6.3)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (13.1.0.1.0-aarch64-linux)
-    libdatadog (13.1.0.1.0-x86_64-linux)
+    libdatadog (14.0.0.1.0-aarch64-linux)
+    libdatadog (14.0.0.1.0-x86_64-linux)
     libddwaf (1.15.0.0.0-aarch64-linux)
       ffi (~> 1.0)
     libddwaf (1.15.0.0.0-x86_64-linux)

--- a/gemfiles/ruby_3.2_rack_latest.gemfile.lock
+++ b/gemfiles/ruby_3.2_rack_latest.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     datadog (2.4.0)
       datadog-ruby_core_source (~> 3.3)
-      libdatadog (~> 13.1.0.1.0)
+      libdatadog (~> 14.0.0.1.0)
       libddwaf (~> 1.15.0.0.0)
       msgpack
 
@@ -53,8 +53,8 @@ GEM
     json (2.7.2)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (13.1.0.1.0-aarch64-linux)
-    libdatadog (13.1.0.1.0-x86_64-linux)
+    libdatadog (14.0.0.1.0-aarch64-linux)
+    libdatadog (14.0.0.1.0-x86_64-linux)
     libddwaf (1.15.0.0.0-aarch64-linux)
       ffi (~> 1.0)
     libddwaf (1.15.0.0.0-x86_64-linux)

--- a/gemfiles/ruby_3.2_rails61_mysql2.gemfile.lock
+++ b/gemfiles/ruby_3.2_rails61_mysql2.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     datadog (2.4.0)
       datadog-ruby_core_source (~> 3.3)
-      libdatadog (~> 13.1.0.1.0)
+      libdatadog (~> 14.0.0.1.0)
       libddwaf (~> 1.15.0.0.0)
       msgpack
 
@@ -117,8 +117,8 @@ GEM
     json (2.6.3)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (13.1.0.1.0-aarch64-linux)
-    libdatadog (13.1.0.1.0-x86_64-linux)
+    libdatadog (14.0.0.1.0-aarch64-linux)
+    libdatadog (14.0.0.1.0-x86_64-linux)
     libddwaf (1.15.0.0.0-aarch64-linux)
       ffi (~> 1.0)
     libddwaf (1.15.0.0.0-x86_64-linux)

--- a/gemfiles/ruby_3.2_rails61_postgres.gemfile.lock
+++ b/gemfiles/ruby_3.2_rails61_postgres.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     datadog (2.4.0)
       datadog-ruby_core_source (~> 3.3)
-      libdatadog (~> 13.1.0.1.0)
+      libdatadog (~> 14.0.0.1.0)
       libddwaf (~> 1.15.0.0.0)
       msgpack
 
@@ -117,8 +117,8 @@ GEM
     json (2.6.3)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (13.1.0.1.0-aarch64-linux)
-    libdatadog (13.1.0.1.0-x86_64-linux)
+    libdatadog (14.0.0.1.0-aarch64-linux)
+    libdatadog (14.0.0.1.0-x86_64-linux)
     libddwaf (1.15.0.0.0-aarch64-linux)
       ffi (~> 1.0)
     libddwaf (1.15.0.0.0-x86_64-linux)

--- a/gemfiles/ruby_3.2_rails61_postgres_redis.gemfile.lock
+++ b/gemfiles/ruby_3.2_rails61_postgres_redis.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     datadog (2.4.0)
       datadog-ruby_core_source (~> 3.3)
-      libdatadog (~> 13.1.0.1.0)
+      libdatadog (~> 14.0.0.1.0)
       libddwaf (~> 1.15.0.0.0)
       msgpack
 
@@ -117,8 +117,8 @@ GEM
     json (2.6.3)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (13.1.0.1.0-aarch64-linux)
-    libdatadog (13.1.0.1.0-x86_64-linux)
+    libdatadog (14.0.0.1.0-aarch64-linux)
+    libdatadog (14.0.0.1.0-x86_64-linux)
     libddwaf (1.15.0.0.0-aarch64-linux)
       ffi (~> 1.0)
     libddwaf (1.15.0.0.0-x86_64-linux)

--- a/gemfiles/ruby_3.2_rails61_postgres_sidekiq.gemfile.lock
+++ b/gemfiles/ruby_3.2_rails61_postgres_sidekiq.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     datadog (2.4.0)
       datadog-ruby_core_source (~> 3.3)
-      libdatadog (~> 13.1.0.1.0)
+      libdatadog (~> 14.0.0.1.0)
       libddwaf (~> 1.15.0.0.0)
       msgpack
 
@@ -118,8 +118,8 @@ GEM
     json (2.6.3)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (13.1.0.1.0-aarch64-linux)
-    libdatadog (13.1.0.1.0-x86_64-linux)
+    libdatadog (14.0.0.1.0-aarch64-linux)
+    libdatadog (14.0.0.1.0-x86_64-linux)
     libddwaf (1.15.0.0.0-aarch64-linux)
       ffi (~> 1.0)
     libddwaf (1.15.0.0.0-x86_64-linux)

--- a/gemfiles/ruby_3.2_rails61_semantic_logger.gemfile.lock
+++ b/gemfiles/ruby_3.2_rails61_semantic_logger.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     datadog (2.4.0)
       datadog-ruby_core_source (~> 3.3)
-      libdatadog (~> 13.1.0.1.0)
+      libdatadog (~> 14.0.0.1.0)
       libddwaf (~> 1.15.0.0.0)
       msgpack
 
@@ -117,8 +117,8 @@ GEM
     json (2.6.3)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (13.1.0.1.0-aarch64-linux)
-    libdatadog (13.1.0.1.0-x86_64-linux)
+    libdatadog (14.0.0.1.0-aarch64-linux)
+    libdatadog (14.0.0.1.0-x86_64-linux)
     libddwaf (1.15.0.0.0-aarch64-linux)
       ffi (~> 1.0)
     libddwaf (1.15.0.0.0-x86_64-linux)

--- a/gemfiles/ruby_3.2_rails61_trilogy.gemfile.lock
+++ b/gemfiles/ruby_3.2_rails61_trilogy.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     datadog (2.4.0)
       datadog-ruby_core_source (~> 3.3)
-      libdatadog (~> 13.1.0.1.0)
+      libdatadog (~> 14.0.0.1.0)
       libddwaf (~> 1.15.0.0.0)
       msgpack
 
@@ -121,8 +121,8 @@ GEM
     json (2.6.3)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (13.1.0.1.0-aarch64-linux)
-    libdatadog (13.1.0.1.0-x86_64-linux)
+    libdatadog (14.0.0.1.0-aarch64-linux)
+    libdatadog (14.0.0.1.0-x86_64-linux)
     libddwaf (1.15.0.0.0-aarch64-linux)
       ffi (~> 1.0)
     libddwaf (1.15.0.0.0-x86_64-linux)

--- a/gemfiles/ruby_3.2_rails7.gemfile.lock
+++ b/gemfiles/ruby_3.2_rails7.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     datadog (2.4.0)
       datadog-ruby_core_source (~> 3.3)
-      libdatadog (~> 13.1.0.1.0)
+      libdatadog (~> 14.0.0.1.0)
       libddwaf (~> 1.15.0.0.0)
       msgpack
 
@@ -126,8 +126,8 @@ GEM
     json (2.7.2)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (13.1.0.1.0-aarch64-linux)
-    libdatadog (13.1.0.1.0-x86_64-linux)
+    libdatadog (14.0.0.1.0-aarch64-linux)
+    libdatadog (14.0.0.1.0-x86_64-linux)
     libddwaf (1.15.0.0.0-aarch64-linux)
       ffi (~> 1.0)
     libddwaf (1.15.0.0.0-x86_64-linux)

--- a/gemfiles/ruby_3.2_rails71.gemfile.lock
+++ b/gemfiles/ruby_3.2_rails71.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     datadog (2.4.0)
       datadog-ruby_core_source (~> 3.3)
-      libdatadog (~> 13.1.0.1.0)
+      libdatadog (~> 14.0.0.1.0)
       libddwaf (~> 1.15.0.0.0)
       msgpack
 
@@ -142,8 +142,8 @@ GEM
     json (2.7.2)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (13.1.0.1.0-aarch64-linux)
-    libdatadog (13.1.0.1.0-x86_64-linux)
+    libdatadog (14.0.0.1.0-aarch64-linux)
+    libdatadog (14.0.0.1.0-x86_64-linux)
     libddwaf (1.15.0.0.0-aarch64-linux)
       ffi (~> 1.0)
     libddwaf (1.15.0.0.0-x86_64-linux)

--- a/gemfiles/ruby_3.2_redis_3.gemfile.lock
+++ b/gemfiles/ruby_3.2_redis_3.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     datadog (2.4.0)
       datadog-ruby_core_source (~> 3.3)
-      libdatadog (~> 13.1.0.1.0)
+      libdatadog (~> 14.0.0.1.0)
       libddwaf (~> 1.15.0.0.0)
       msgpack
 
@@ -50,8 +50,8 @@ GEM
     json (2.6.3)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (13.1.0.1.0-aarch64-linux)
-    libdatadog (13.1.0.1.0-x86_64-linux)
+    libdatadog (14.0.0.1.0-aarch64-linux)
+    libdatadog (14.0.0.1.0-x86_64-linux)
     libddwaf (1.15.0.0.0-aarch64-linux)
       ffi (~> 1.0)
     libddwaf (1.15.0.0.0-x86_64-linux)

--- a/gemfiles/ruby_3.2_redis_4.gemfile.lock
+++ b/gemfiles/ruby_3.2_redis_4.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     datadog (2.4.0)
       datadog-ruby_core_source (~> 3.3)
-      libdatadog (~> 13.1.0.1.0)
+      libdatadog (~> 14.0.0.1.0)
       libddwaf (~> 1.15.0.0.0)
       msgpack
 
@@ -50,8 +50,8 @@ GEM
     json (2.6.3)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (13.1.0.1.0-aarch64-linux)
-    libdatadog (13.1.0.1.0-x86_64-linux)
+    libdatadog (14.0.0.1.0-aarch64-linux)
+    libdatadog (14.0.0.1.0-x86_64-linux)
     libddwaf (1.15.0.0.0-aarch64-linux)
       ffi (~> 1.0)
     libddwaf (1.15.0.0.0-x86_64-linux)

--- a/gemfiles/ruby_3.2_redis_5.gemfile.lock
+++ b/gemfiles/ruby_3.2_redis_5.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     datadog (2.4.0)
       datadog-ruby_core_source (~> 3.3)
-      libdatadog (~> 13.1.0.1.0)
+      libdatadog (~> 14.0.0.1.0)
       libddwaf (~> 1.15.0.0.0)
       msgpack
 
@@ -51,8 +51,8 @@ GEM
     json (2.6.3)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (13.1.0.1.0-aarch64-linux)
-    libdatadog (13.1.0.1.0-x86_64-linux)
+    libdatadog (14.0.0.1.0-aarch64-linux)
+    libdatadog (14.0.0.1.0-x86_64-linux)
     libddwaf (1.15.0.0.0-aarch64-linux)
       ffi (~> 1.0)
     libddwaf (1.15.0.0.0-x86_64-linux)

--- a/gemfiles/ruby_3.2_relational_db.gemfile.lock
+++ b/gemfiles/ruby_3.2_relational_db.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     datadog (2.4.0)
       datadog-ruby_core_source (~> 3.3)
-      libdatadog (~> 13.1.0.1.0)
+      libdatadog (~> 14.0.0.1.0)
       libddwaf (~> 1.15.0.0.0)
       msgpack
 
@@ -68,8 +68,8 @@ GEM
     json (2.6.3)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (13.1.0.1.0-aarch64-linux)
-    libdatadog (13.1.0.1.0-x86_64-linux)
+    libdatadog (14.0.0.1.0-aarch64-linux)
+    libdatadog (14.0.0.1.0-x86_64-linux)
     libddwaf (1.15.0.0.0-aarch64-linux)
       ffi (~> 1.0)
     libddwaf (1.15.0.0.0-x86_64-linux)

--- a/gemfiles/ruby_3.2_resque2_redis3.gemfile.lock
+++ b/gemfiles/ruby_3.2_resque2_redis3.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     datadog (2.4.0)
       datadog-ruby_core_source (~> 3.3)
-      libdatadog (~> 13.1.0.1.0)
+      libdatadog (~> 14.0.0.1.0)
       libddwaf (~> 1.15.0.0.0)
       msgpack
 
@@ -50,8 +50,8 @@ GEM
     json (2.6.3)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (13.1.0.1.0-aarch64-linux)
-    libdatadog (13.1.0.1.0-x86_64-linux)
+    libdatadog (14.0.0.1.0-aarch64-linux)
+    libdatadog (14.0.0.1.0-x86_64-linux)
     libddwaf (1.15.0.0.0-aarch64-linux)
       ffi (~> 1.0)
     libddwaf (1.15.0.0.0-x86_64-linux)

--- a/gemfiles/ruby_3.2_resque2_redis4.gemfile.lock
+++ b/gemfiles/ruby_3.2_resque2_redis4.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     datadog (2.4.0)
       datadog-ruby_core_source (~> 3.3)
-      libdatadog (~> 13.1.0.1.0)
+      libdatadog (~> 14.0.0.1.0)
       libddwaf (~> 1.15.0.0.0)
       msgpack
 
@@ -51,8 +51,8 @@ GEM
     json (2.6.3)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (13.1.0.1.0-aarch64-linux)
-    libdatadog (13.1.0.1.0-x86_64-linux)
+    libdatadog (14.0.0.1.0-aarch64-linux)
+    libdatadog (14.0.0.1.0-x86_64-linux)
     libddwaf (1.15.0.0.0-aarch64-linux)
       ffi (~> 1.0)
     libddwaf (1.15.0.0.0-x86_64-linux)

--- a/gemfiles/ruby_3.2_sinatra_2.gemfile.lock
+++ b/gemfiles/ruby_3.2_sinatra_2.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     datadog (2.4.0)
       datadog-ruby_core_source (~> 3.3)
-      libdatadog (~> 13.1.0.1.0)
+      libdatadog (~> 14.0.0.1.0)
       libddwaf (~> 1.15.0.0.0)
       msgpack
 
@@ -53,8 +53,8 @@ GEM
     json (2.7.2)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (13.1.0.1.0-aarch64-linux)
-    libdatadog (13.1.0.1.0-x86_64-linux)
+    libdatadog (14.0.0.1.0-aarch64-linux)
+    libdatadog (14.0.0.1.0-x86_64-linux)
     libddwaf (1.15.0.0.0-aarch64-linux)
       ffi (~> 1.0)
     libddwaf (1.15.0.0.0-x86_64-linux)

--- a/gemfiles/ruby_3.2_sinatra_3.gemfile.lock
+++ b/gemfiles/ruby_3.2_sinatra_3.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     datadog (2.4.0)
       datadog-ruby_core_source (~> 3.3)
-      libdatadog (~> 13.1.0.1.0)
+      libdatadog (~> 14.0.0.1.0)
       libddwaf (~> 1.15.0.0.0)
       msgpack
 
@@ -54,8 +54,8 @@ GEM
     json (2.7.2)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (13.1.0.1.0-aarch64-linux)
-    libdatadog (13.1.0.1.0-x86_64-linux)
+    libdatadog (14.0.0.1.0-aarch64-linux)
+    libdatadog (14.0.0.1.0-x86_64-linux)
     libddwaf (1.15.0.0.0-aarch64-linux)
       ffi (~> 1.0)
     libddwaf (1.15.0.0.0-x86_64-linux)

--- a/gemfiles/ruby_3.2_sinatra_4.gemfile.lock
+++ b/gemfiles/ruby_3.2_sinatra_4.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     datadog (2.4.0)
       datadog-ruby_core_source (~> 3.3)
-      libdatadog (~> 13.1.0.1.0)
+      libdatadog (~> 14.0.0.1.0)
       libddwaf (~> 1.15.0.0.0)
       msgpack
 
@@ -54,8 +54,8 @@ GEM
     json (2.7.2)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (13.1.0.1.0-aarch64-linux)
-    libdatadog (13.1.0.1.0-x86_64-linux)
+    libdatadog (14.0.0.1.0-aarch64-linux)
+    libdatadog (14.0.0.1.0-x86_64-linux)
     libddwaf (1.15.0.0.0-aarch64-linux)
       ffi (~> 1.0)
     libddwaf (1.15.0.0.0-x86_64-linux)

--- a/gemfiles/ruby_3.2_stripe_10.gemfile.lock
+++ b/gemfiles/ruby_3.2_stripe_10.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     datadog (2.4.0)
       datadog-ruby_core_source (~> 3.3)
-      libdatadog (~> 13.1.0.1.0)
+      libdatadog (~> 14.0.0.1.0)
       libddwaf (~> 1.15.0.0.0)
       msgpack
 
@@ -53,8 +53,8 @@ GEM
     json (2.7.2)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (13.1.0.1.0-aarch64-linux)
-    libdatadog (13.1.0.1.0-x86_64-linux)
+    libdatadog (14.0.0.1.0-aarch64-linux)
+    libdatadog (14.0.0.1.0-x86_64-linux)
     libddwaf (1.15.0.0.0-aarch64-linux)
       ffi (~> 1.0)
     libddwaf (1.15.0.0.0-x86_64-linux)

--- a/gemfiles/ruby_3.2_stripe_11.gemfile.lock
+++ b/gemfiles/ruby_3.2_stripe_11.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     datadog (2.4.0)
       datadog-ruby_core_source (~> 3.3)
-      libdatadog (~> 13.1.0.1.0)
+      libdatadog (~> 14.0.0.1.0)
       libddwaf (~> 1.15.0.0.0)
       msgpack
 
@@ -53,8 +53,8 @@ GEM
     json (2.7.2)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (13.1.0.1.0-aarch64-linux)
-    libdatadog (13.1.0.1.0-x86_64-linux)
+    libdatadog (14.0.0.1.0-aarch64-linux)
+    libdatadog (14.0.0.1.0-x86_64-linux)
     libddwaf (1.15.0.0.0-aarch64-linux)
       ffi (~> 1.0)
     libddwaf (1.15.0.0.0-x86_64-linux)

--- a/gemfiles/ruby_3.2_stripe_12.gemfile.lock
+++ b/gemfiles/ruby_3.2_stripe_12.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     datadog (2.4.0)
       datadog-ruby_core_source (~> 3.3)
-      libdatadog (~> 13.1.0.1.0)
+      libdatadog (~> 14.0.0.1.0)
       libddwaf (~> 1.15.0.0.0)
       msgpack
 
@@ -53,8 +53,8 @@ GEM
     json (2.7.2)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (13.1.0.1.0-aarch64-linux)
-    libdatadog (13.1.0.1.0-x86_64-linux)
+    libdatadog (14.0.0.1.0-aarch64-linux)
+    libdatadog (14.0.0.1.0-x86_64-linux)
     libddwaf (1.15.0.0.0-aarch64-linux)
       ffi (~> 1.0)
     libddwaf (1.15.0.0.0-x86_64-linux)

--- a/gemfiles/ruby_3.2_stripe_7.gemfile.lock
+++ b/gemfiles/ruby_3.2_stripe_7.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     datadog (2.4.0)
       datadog-ruby_core_source (~> 3.3)
-      libdatadog (~> 13.1.0.1.0)
+      libdatadog (~> 14.0.0.1.0)
       libddwaf (~> 1.15.0.0.0)
       msgpack
 
@@ -53,8 +53,8 @@ GEM
     json (2.7.2)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (13.1.0.1.0-aarch64-linux)
-    libdatadog (13.1.0.1.0-x86_64-linux)
+    libdatadog (14.0.0.1.0-aarch64-linux)
+    libdatadog (14.0.0.1.0-x86_64-linux)
     libddwaf (1.15.0.0.0-aarch64-linux)
       ffi (~> 1.0)
     libddwaf (1.15.0.0.0-x86_64-linux)

--- a/gemfiles/ruby_3.2_stripe_8.gemfile.lock
+++ b/gemfiles/ruby_3.2_stripe_8.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     datadog (2.4.0)
       datadog-ruby_core_source (~> 3.3)
-      libdatadog (~> 13.1.0.1.0)
+      libdatadog (~> 14.0.0.1.0)
       libddwaf (~> 1.15.0.0.0)
       msgpack
 
@@ -53,8 +53,8 @@ GEM
     json (2.7.2)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (13.1.0.1.0-aarch64-linux)
-    libdatadog (13.1.0.1.0-x86_64-linux)
+    libdatadog (14.0.0.1.0-aarch64-linux)
+    libdatadog (14.0.0.1.0-x86_64-linux)
     libddwaf (1.15.0.0.0-aarch64-linux)
       ffi (~> 1.0)
     libddwaf (1.15.0.0.0-x86_64-linux)

--- a/gemfiles/ruby_3.2_stripe_9.gemfile.lock
+++ b/gemfiles/ruby_3.2_stripe_9.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     datadog (2.4.0)
       datadog-ruby_core_source (~> 3.3)
-      libdatadog (~> 13.1.0.1.0)
+      libdatadog (~> 14.0.0.1.0)
       libddwaf (~> 1.15.0.0.0)
       msgpack
 
@@ -53,8 +53,8 @@ GEM
     json (2.7.2)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (13.1.0.1.0-aarch64-linux)
-    libdatadog (13.1.0.1.0-x86_64-linux)
+    libdatadog (14.0.0.1.0-aarch64-linux)
+    libdatadog (14.0.0.1.0-x86_64-linux)
     libddwaf (1.15.0.0.0-aarch64-linux)
       ffi (~> 1.0)
     libddwaf (1.15.0.0.0-x86_64-linux)

--- a/gemfiles/ruby_3.2_stripe_latest.gemfile.lock
+++ b/gemfiles/ruby_3.2_stripe_latest.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     datadog (2.4.0)
       datadog-ruby_core_source (~> 3.3)
-      libdatadog (~> 13.1.0.1.0)
+      libdatadog (~> 14.0.0.1.0)
       libddwaf (~> 1.15.0.0.0)
       msgpack
 
@@ -53,8 +53,8 @@ GEM
     json (2.7.2)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (13.1.0.1.0-aarch64-linux)
-    libdatadog (13.1.0.1.0-x86_64-linux)
+    libdatadog (14.0.0.1.0-aarch64-linux)
+    libdatadog (14.0.0.1.0-x86_64-linux)
     libddwaf (1.15.0.0.0-aarch64-linux)
       ffi (~> 1.0)
     libddwaf (1.15.0.0.0-x86_64-linux)

--- a/gemfiles/ruby_3.2_stripe_min.gemfile.lock
+++ b/gemfiles/ruby_3.2_stripe_min.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     datadog (2.4.0)
       datadog-ruby_core_source (~> 3.3)
-      libdatadog (~> 13.1.0.1.0)
+      libdatadog (~> 14.0.0.1.0)
       libddwaf (~> 1.15.0.0.0)
       msgpack
 
@@ -53,8 +53,8 @@ GEM
     json (2.7.2)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (13.1.0.1.0-aarch64-linux)
-    libdatadog (13.1.0.1.0-x86_64-linux)
+    libdatadog (14.0.0.1.0-aarch64-linux)
+    libdatadog (14.0.0.1.0-x86_64-linux)
     libddwaf (1.15.0.0.0-aarch64-linux)
       ffi (~> 1.0)
     libddwaf (1.15.0.0.0-x86_64-linux)

--- a/gemfiles/ruby_3.3_activesupport.gemfile.lock
+++ b/gemfiles/ruby_3.3_activesupport.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     datadog (2.4.0)
       datadog-ruby_core_source (~> 3.3)
-      libdatadog (~> 13.1.0.1.0)
+      libdatadog (~> 14.0.0.1.0)
       libddwaf (~> 1.15.0.0.0)
       msgpack
 
@@ -106,8 +106,8 @@ GEM
       addressable (>= 2.4)
     jsonapi-renderer (0.2.2)
     king_konf (1.0.1)
-    libdatadog (13.1.0.1.0-aarch64-linux)
-    libdatadog (13.1.0.1.0-x86_64-linux)
+    libdatadog (14.0.0.1.0-aarch64-linux)
+    libdatadog (14.0.0.1.0-x86_64-linux)
     libddwaf (1.15.0.0.0-aarch64-linux)
       ffi (~> 1.0)
     libddwaf (1.15.0.0.0-x86_64-linux)

--- a/gemfiles/ruby_3.3_aws.gemfile.lock
+++ b/gemfiles/ruby_3.3_aws.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     datadog (2.4.0)
       datadog-ruby_core_source (~> 3.3)
-      libdatadog (~> 13.1.0.1.0)
+      libdatadog (~> 14.0.0.1.0)
       libddwaf (~> 1.15.0.0.0)
       msgpack
 
@@ -1471,8 +1471,8 @@ GEM
     json (2.6.3)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (13.1.0.1.0-aarch64-linux)
-    libdatadog (13.1.0.1.0-x86_64-linux)
+    libdatadog (14.0.0.1.0-aarch64-linux)
+    libdatadog (14.0.0.1.0-x86_64-linux)
     libddwaf (1.15.0.0.0-aarch64-linux)
       ffi (~> 1.0)
     libddwaf (1.15.0.0.0-x86_64-linux)

--- a/gemfiles/ruby_3.3_contrib.gemfile.lock
+++ b/gemfiles/ruby_3.3_contrib.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     datadog (2.4.0)
       datadog-ruby_core_source (~> 3.3)
-      libdatadog (~> 13.1.0.1.0)
+      libdatadog (~> 14.0.0.1.0)
       libddwaf (~> 1.15.0.0.0)
       msgpack
 
@@ -61,8 +61,8 @@ GEM
     json (2.6.3)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (13.1.0.1.0-aarch64-linux)
-    libdatadog (13.1.0.1.0-x86_64-linux)
+    libdatadog (14.0.0.1.0-aarch64-linux)
+    libdatadog (14.0.0.1.0-x86_64-linux)
     libddwaf (1.15.0.0.0-aarch64-linux)
       ffi (~> 1.0)
     libddwaf (1.15.0.0.0-x86_64-linux)

--- a/gemfiles/ruby_3.3_contrib_old.gemfile.lock
+++ b/gemfiles/ruby_3.3_contrib_old.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     datadog (2.4.0)
       datadog-ruby_core_source (~> 3.3)
-      libdatadog (~> 13.1.0.1.0)
+      libdatadog (~> 14.0.0.1.0)
       libddwaf (~> 1.15.0.0.0)
       msgpack
 
@@ -60,8 +60,8 @@ GEM
     json (2.6.3)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (13.1.0.1.0-aarch64-linux)
-    libdatadog (13.1.0.1.0-x86_64-linux)
+    libdatadog (14.0.0.1.0-aarch64-linux)
+    libdatadog (14.0.0.1.0-x86_64-linux)
     libddwaf (1.15.0.0.0-aarch64-linux)
       ffi (~> 1.0)
     libddwaf (1.15.0.0.0-x86_64-linux)

--- a/gemfiles/ruby_3.3_core_old.gemfile.lock
+++ b/gemfiles/ruby_3.3_core_old.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     datadog (2.4.0)
       datadog-ruby_core_source (~> 3.3)
-      libdatadog (~> 13.1.0.1.0)
+      libdatadog (~> 14.0.0.1.0)
       libddwaf (~> 1.15.0.0.0)
       msgpack
 
@@ -49,8 +49,8 @@ GEM
     json (2.6.3)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (13.1.0.1.0-aarch64-linux)
-    libdatadog (13.1.0.1.0-x86_64-linux)
+    libdatadog (14.0.0.1.0-aarch64-linux)
+    libdatadog (14.0.0.1.0-x86_64-linux)
     libddwaf (1.15.0.0.0-aarch64-linux)
       ffi (~> 1.0)
     libddwaf (1.15.0.0.0-x86_64-linux)

--- a/gemfiles/ruby_3.3_elasticsearch_7.gemfile.lock
+++ b/gemfiles/ruby_3.3_elasticsearch_7.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     datadog (2.4.0)
       datadog-ruby_core_source (~> 3.3)
-      libdatadog (~> 13.1.0.1.0)
+      libdatadog (~> 14.0.0.1.0)
       libddwaf (~> 1.15.0.0.0)
       msgpack
 
@@ -66,8 +66,8 @@ GEM
     json (2.7.5)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (13.1.0.1.0-aarch64-linux)
-    libdatadog (13.1.0.1.0-x86_64-linux)
+    libdatadog (14.0.0.1.0-aarch64-linux)
+    libdatadog (14.0.0.1.0-x86_64-linux)
     libddwaf (1.15.0.0.0-aarch64-linux)
       ffi (~> 1.0)
     libddwaf (1.15.0.0.0-x86_64-linux)

--- a/gemfiles/ruby_3.3_elasticsearch_8.gemfile.lock
+++ b/gemfiles/ruby_3.3_elasticsearch_8.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     datadog (2.4.0)
       datadog-ruby_core_source (~> 3.3)
-      libdatadog (~> 13.1.0.1.0)
+      libdatadog (~> 14.0.0.1.0)
       libddwaf (~> 1.15.0.0.0)
       msgpack
 
@@ -64,8 +64,8 @@ GEM
     json (2.7.5)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (13.1.0.1.0-aarch64-linux)
-    libdatadog (13.1.0.1.0-x86_64-linux)
+    libdatadog (14.0.0.1.0-aarch64-linux)
+    libdatadog (14.0.0.1.0-x86_64-linux)
     libddwaf (1.15.0.0.0-aarch64-linux)
       ffi (~> 1.0)
     libddwaf (1.15.0.0.0-x86_64-linux)

--- a/gemfiles/ruby_3.3_elasticsearch_latest.gemfile.lock
+++ b/gemfiles/ruby_3.3_elasticsearch_latest.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     datadog (2.4.0)
       datadog-ruby_core_source (~> 3.3)
-      libdatadog (~> 13.1.0.1.0)
+      libdatadog (~> 14.0.0.1.0)
       libddwaf (~> 1.15.0.0.0)
       msgpack
 
@@ -67,8 +67,8 @@ GEM
     json (2.7.5)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (13.1.0.1.0-aarch64-linux)
-    libdatadog (13.1.0.1.0-x86_64-linux)
+    libdatadog (14.0.0.1.0-aarch64-linux)
+    libdatadog (14.0.0.1.0-x86_64-linux)
     libddwaf (1.15.0.0.0-aarch64-linux)
       ffi (~> 1.0)
     libddwaf (1.15.0.0.0-x86_64-linux)

--- a/gemfiles/ruby_3.3_graphql_1.13.gemfile.lock
+++ b/gemfiles/ruby_3.3_graphql_1.13.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     datadog (2.4.0)
       datadog-ruby_core_source (~> 3.3)
-      libdatadog (~> 13.1.0.1.0)
+      libdatadog (~> 14.0.0.1.0)
       libddwaf (~> 1.15.0.0.0)
       msgpack
 
@@ -119,8 +119,8 @@ GEM
     json (2.7.1)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (13.1.0.1.0-aarch64-linux)
-    libdatadog (13.1.0.1.0-x86_64-linux)
+    libdatadog (14.0.0.1.0-aarch64-linux)
+    libdatadog (14.0.0.1.0-x86_64-linux)
     libddwaf (1.15.0.0.0-aarch64-linux)
       ffi (~> 1.0)
     libddwaf (1.15.0.0.0-x86_64-linux)

--- a/gemfiles/ruby_3.3_graphql_2.0.gemfile.lock
+++ b/gemfiles/ruby_3.3_graphql_2.0.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     datadog (2.4.0)
       datadog-ruby_core_source (~> 3.3)
-      libdatadog (~> 13.1.0.1.0)
+      libdatadog (~> 14.0.0.1.0)
       libddwaf (~> 1.15.0.0.0)
       msgpack
 
@@ -119,8 +119,8 @@ GEM
     json (2.7.1)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (13.1.0.1.0-aarch64-linux)
-    libdatadog (13.1.0.1.0-x86_64-linux)
+    libdatadog (14.0.0.1.0-aarch64-linux)
+    libdatadog (14.0.0.1.0-x86_64-linux)
     libddwaf (1.15.0.0.0-aarch64-linux)
       ffi (~> 1.0)
     libddwaf (1.15.0.0.0-x86_64-linux)

--- a/gemfiles/ruby_3.3_graphql_2.1.gemfile.lock
+++ b/gemfiles/ruby_3.3_graphql_2.1.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     datadog (2.4.0)
       datadog-ruby_core_source (~> 3.3)
-      libdatadog (~> 13.1.0.1.0)
+      libdatadog (~> 14.0.0.1.0)
       libddwaf (~> 1.15.0.0.0)
       msgpack
 
@@ -120,8 +120,8 @@ GEM
     json (2.7.1)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (13.1.0.1.0-aarch64-linux)
-    libdatadog (13.1.0.1.0-x86_64-linux)
+    libdatadog (14.0.0.1.0-aarch64-linux)
+    libdatadog (14.0.0.1.0-x86_64-linux)
     libddwaf (1.15.0.0.0-aarch64-linux)
       ffi (~> 1.0)
     libddwaf (1.15.0.0.0-x86_64-linux)

--- a/gemfiles/ruby_3.3_graphql_2.2.gemfile.lock
+++ b/gemfiles/ruby_3.3_graphql_2.2.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     datadog (2.4.0)
       datadog-ruby_core_source (~> 3.3)
-      libdatadog (~> 13.1.0.1.0)
+      libdatadog (~> 14.0.0.1.0)
       libddwaf (~> 1.15.0.0.0)
       msgpack
 
@@ -120,8 +120,8 @@ GEM
     json (2.7.1)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (13.1.0.1.0-aarch64-linux)
-    libdatadog (13.1.0.1.0-x86_64-linux)
+    libdatadog (14.0.0.1.0-aarch64-linux)
+    libdatadog (14.0.0.1.0-x86_64-linux)
     libddwaf (1.15.0.0.0-aarch64-linux)
       ffi (~> 1.0)
     libddwaf (1.15.0.0.0-x86_64-linux)

--- a/gemfiles/ruby_3.3_graphql_2.3.gemfile.lock
+++ b/gemfiles/ruby_3.3_graphql_2.3.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     datadog (2.4.0)
       datadog-ruby_core_source (~> 3.3)
-      libdatadog (~> 13.1.0.1.0)
+      libdatadog (~> 14.0.0.1.0)
       libddwaf (~> 1.15.0.0.0)
       msgpack
 
@@ -123,8 +123,8 @@ GEM
     json (2.7.2)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (13.1.0.1.0-aarch64-linux)
-    libdatadog (13.1.0.1.0-x86_64-linux)
+    libdatadog (14.0.0.1.0-aarch64-linux)
+    libdatadog (14.0.0.1.0-x86_64-linux)
     libddwaf (1.15.0.0.0-aarch64-linux)
       ffi (~> 1.0)
     libddwaf (1.15.0.0.0-x86_64-linux)

--- a/gemfiles/ruby_3.3_http.gemfile.lock
+++ b/gemfiles/ruby_3.3_http.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     datadog (2.4.0)
       datadog-ruby_core_source (~> 3.3)
-      libdatadog (~> 13.1.0.1.0)
+      libdatadog (~> 14.0.0.1.0)
       libddwaf (~> 1.15.0.0.0)
       msgpack
 
@@ -71,8 +71,8 @@ GEM
     json (2.6.3)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (13.1.0.1.0-aarch64-linux)
-    libdatadog (13.1.0.1.0-x86_64-linux)
+    libdatadog (14.0.0.1.0-aarch64-linux)
+    libdatadog (14.0.0.1.0-x86_64-linux)
     libddwaf (1.15.0.0.0-aarch64-linux)
       ffi (~> 1.0)
     libddwaf (1.15.0.0.0-x86_64-linux)

--- a/gemfiles/ruby_3.3_opensearch_2.gemfile.lock
+++ b/gemfiles/ruby_3.3_opensearch_2.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     datadog (2.4.0)
       datadog-ruby_core_source (~> 3.3)
-      libdatadog (~> 13.1.0.1.0)
+      libdatadog (~> 14.0.0.1.0)
       libddwaf (~> 1.15.0.0.0)
       msgpack
 
@@ -56,8 +56,8 @@ GEM
     json (2.7.5)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (13.1.0.1.0-aarch64-linux)
-    libdatadog (13.1.0.1.0-x86_64-linux)
+    libdatadog (14.0.0.1.0-aarch64-linux)
+    libdatadog (14.0.0.1.0-x86_64-linux)
     libddwaf (1.15.0.0.0-aarch64-linux)
       ffi (~> 1.0)
     libddwaf (1.15.0.0.0-x86_64-linux)

--- a/gemfiles/ruby_3.3_opensearch_3.gemfile.lock
+++ b/gemfiles/ruby_3.3_opensearch_3.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     datadog (2.4.0)
       datadog-ruby_core_source (~> 3.3)
-      libdatadog (~> 13.1.0.1.0)
+      libdatadog (~> 14.0.0.1.0)
       libddwaf (~> 1.15.0.0.0)
       msgpack
 
@@ -56,8 +56,8 @@ GEM
     json (2.7.5)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (13.1.0.1.0-aarch64-linux)
-    libdatadog (13.1.0.1.0-x86_64-linux)
+    libdatadog (14.0.0.1.0-aarch64-linux)
+    libdatadog (14.0.0.1.0-x86_64-linux)
     libddwaf (1.15.0.0.0-aarch64-linux)
       ffi (~> 1.0)
     libddwaf (1.15.0.0.0-x86_64-linux)

--- a/gemfiles/ruby_3.3_opensearch_latest.gemfile.lock
+++ b/gemfiles/ruby_3.3_opensearch_latest.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     datadog (2.4.0)
       datadog-ruby_core_source (~> 3.3)
-      libdatadog (~> 13.1.0.1.0)
+      libdatadog (~> 14.0.0.1.0)
       libddwaf (~> 1.15.0.0.0)
       msgpack
 
@@ -59,8 +59,8 @@ GEM
     json (2.7.5)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (13.1.0.1.0-aarch64-linux)
-    libdatadog (13.1.0.1.0-x86_64-linux)
+    libdatadog (14.0.0.1.0-aarch64-linux)
+    libdatadog (14.0.0.1.0-x86_64-linux)
     libddwaf (1.15.0.0.0-aarch64-linux)
       ffi (~> 1.0)
     libddwaf (1.15.0.0.0-x86_64-linux)

--- a/gemfiles/ruby_3.3_opentelemetry.gemfile.lock
+++ b/gemfiles/ruby_3.3_opentelemetry.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     datadog (2.4.0)
       datadog-ruby_core_source (~> 3.3)
-      libdatadog (~> 13.1.0.1.0)
+      libdatadog (~> 14.0.0.1.0)
       libddwaf (~> 1.15.0.0.0)
       msgpack
 
@@ -49,8 +49,8 @@ GEM
     json (2.6.3)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (13.1.0.1.0-aarch64-linux)
-    libdatadog (13.1.0.1.0-x86_64-linux)
+    libdatadog (14.0.0.1.0-aarch64-linux)
+    libdatadog (14.0.0.1.0-x86_64-linux)
     libddwaf (1.15.0.0.0-aarch64-linux)
       ffi (~> 1.0)
     libddwaf (1.15.0.0.0-x86_64-linux)

--- a/gemfiles/ruby_3.3_opentelemetry_otlp.gemfile.lock
+++ b/gemfiles/ruby_3.3_opentelemetry_otlp.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     datadog (2.4.0)
       datadog-ruby_core_source (~> 3.3)
-      libdatadog (~> 13.1.0.1.0)
+      libdatadog (~> 14.0.0.1.0)
       libddwaf (~> 1.15.0.0.0)
       msgpack
 
@@ -55,8 +55,8 @@ GEM
     json (2.7.1)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (13.1.0.1.0-aarch64-linux)
-    libdatadog (13.1.0.1.0-x86_64-linux)
+    libdatadog (14.0.0.1.0-aarch64-linux)
+    libdatadog (14.0.0.1.0-x86_64-linux)
     libddwaf (1.15.0.0.0-aarch64-linux)
       ffi (~> 1.0)
     libddwaf (1.15.0.0.0-x86_64-linux)

--- a/gemfiles/ruby_3.3_rack_2.gemfile.lock
+++ b/gemfiles/ruby_3.3_rack_2.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     datadog (2.4.0)
       datadog-ruby_core_source (~> 3.3)
-      libdatadog (~> 13.1.0.1.0)
+      libdatadog (~> 14.0.0.1.0)
       libddwaf (~> 1.15.0.0.0)
       msgpack
 
@@ -49,8 +49,8 @@ GEM
     json (2.6.3)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (13.1.0.1.0-aarch64-linux)
-    libdatadog (13.1.0.1.0-x86_64-linux)
+    libdatadog (14.0.0.1.0-aarch64-linux)
+    libdatadog (14.0.0.1.0-x86_64-linux)
     libddwaf (1.15.0.0.0-aarch64-linux)
       ffi (~> 1.0)
     libddwaf (1.15.0.0.0-x86_64-linux)

--- a/gemfiles/ruby_3.3_rack_3.gemfile.lock
+++ b/gemfiles/ruby_3.3_rack_3.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     datadog (2.4.0)
       datadog-ruby_core_source (~> 3.3)
-      libdatadog (~> 13.1.0.1.0)
+      libdatadog (~> 14.0.0.1.0)
       libddwaf (~> 1.15.0.0.0)
       msgpack
 
@@ -49,8 +49,8 @@ GEM
     json (2.6.3)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (13.1.0.1.0-aarch64-linux)
-    libdatadog (13.1.0.1.0-x86_64-linux)
+    libdatadog (14.0.0.1.0-aarch64-linux)
+    libdatadog (14.0.0.1.0-x86_64-linux)
     libddwaf (1.15.0.0.0-aarch64-linux)
       ffi (~> 1.0)
     libddwaf (1.15.0.0.0-x86_64-linux)

--- a/gemfiles/ruby_3.3_rack_latest.gemfile.lock
+++ b/gemfiles/ruby_3.3_rack_latest.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     datadog (2.4.0)
       datadog-ruby_core_source (~> 3.3)
-      libdatadog (~> 13.1.0.1.0)
+      libdatadog (~> 14.0.0.1.0)
       libddwaf (~> 1.15.0.0.0)
       msgpack
 
@@ -53,8 +53,8 @@ GEM
     json (2.7.2)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (13.1.0.1.0-aarch64-linux)
-    libdatadog (13.1.0.1.0-x86_64-linux)
+    libdatadog (14.0.0.1.0-aarch64-linux)
+    libdatadog (14.0.0.1.0-x86_64-linux)
     libddwaf (1.15.0.0.0-aarch64-linux)
       ffi (~> 1.0)
     libddwaf (1.15.0.0.0-x86_64-linux)

--- a/gemfiles/ruby_3.3_rails61_mysql2.gemfile.lock
+++ b/gemfiles/ruby_3.3_rails61_mysql2.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     datadog (2.4.0)
       datadog-ruby_core_source (~> 3.3)
-      libdatadog (~> 13.1.0.1.0)
+      libdatadog (~> 14.0.0.1.0)
       libddwaf (~> 1.15.0.0.0)
       msgpack
 
@@ -116,8 +116,8 @@ GEM
     json (2.6.3)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (13.1.0.1.0-aarch64-linux)
-    libdatadog (13.1.0.1.0-x86_64-linux)
+    libdatadog (14.0.0.1.0-aarch64-linux)
+    libdatadog (14.0.0.1.0-x86_64-linux)
     libddwaf (1.15.0.0.0-aarch64-linux)
       ffi (~> 1.0)
     libddwaf (1.15.0.0.0-x86_64-linux)

--- a/gemfiles/ruby_3.3_rails61_postgres.gemfile.lock
+++ b/gemfiles/ruby_3.3_rails61_postgres.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     datadog (2.4.0)
       datadog-ruby_core_source (~> 3.3)
-      libdatadog (~> 13.1.0.1.0)
+      libdatadog (~> 14.0.0.1.0)
       libddwaf (~> 1.15.0.0.0)
       msgpack
 
@@ -116,8 +116,8 @@ GEM
     json (2.6.3)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (13.1.0.1.0-aarch64-linux)
-    libdatadog (13.1.0.1.0-x86_64-linux)
+    libdatadog (14.0.0.1.0-aarch64-linux)
+    libdatadog (14.0.0.1.0-x86_64-linux)
     libddwaf (1.15.0.0.0-aarch64-linux)
       ffi (~> 1.0)
     libddwaf (1.15.0.0.0-x86_64-linux)

--- a/gemfiles/ruby_3.3_rails61_postgres_redis.gemfile.lock
+++ b/gemfiles/ruby_3.3_rails61_postgres_redis.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     datadog (2.4.0)
       datadog-ruby_core_source (~> 3.3)
-      libdatadog (~> 13.1.0.1.0)
+      libdatadog (~> 14.0.0.1.0)
       libddwaf (~> 1.15.0.0.0)
       msgpack
 
@@ -116,8 +116,8 @@ GEM
     json (2.6.3)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (13.1.0.1.0-aarch64-linux)
-    libdatadog (13.1.0.1.0-x86_64-linux)
+    libdatadog (14.0.0.1.0-aarch64-linux)
+    libdatadog (14.0.0.1.0-x86_64-linux)
     libddwaf (1.15.0.0.0-aarch64-linux)
       ffi (~> 1.0)
     libddwaf (1.15.0.0.0-x86_64-linux)

--- a/gemfiles/ruby_3.3_rails61_postgres_sidekiq.gemfile.lock
+++ b/gemfiles/ruby_3.3_rails61_postgres_sidekiq.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     datadog (2.4.0)
       datadog-ruby_core_source (~> 3.3)
-      libdatadog (~> 13.1.0.1.0)
+      libdatadog (~> 14.0.0.1.0)
       libddwaf (~> 1.15.0.0.0)
       msgpack
 
@@ -117,8 +117,8 @@ GEM
     json (2.6.3)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (13.1.0.1.0-aarch64-linux)
-    libdatadog (13.1.0.1.0-x86_64-linux)
+    libdatadog (14.0.0.1.0-aarch64-linux)
+    libdatadog (14.0.0.1.0-x86_64-linux)
     libddwaf (1.15.0.0.0-aarch64-linux)
       ffi (~> 1.0)
     libddwaf (1.15.0.0.0-x86_64-linux)

--- a/gemfiles/ruby_3.3_rails61_semantic_logger.gemfile.lock
+++ b/gemfiles/ruby_3.3_rails61_semantic_logger.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     datadog (2.4.0)
       datadog-ruby_core_source (~> 3.3)
-      libdatadog (~> 13.1.0.1.0)
+      libdatadog (~> 14.0.0.1.0)
       libddwaf (~> 1.15.0.0.0)
       msgpack
 
@@ -116,8 +116,8 @@ GEM
     json (2.6.3)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (13.1.0.1.0-aarch64-linux)
-    libdatadog (13.1.0.1.0-x86_64-linux)
+    libdatadog (14.0.0.1.0-aarch64-linux)
+    libdatadog (14.0.0.1.0-x86_64-linux)
     libddwaf (1.15.0.0.0-aarch64-linux)
       ffi (~> 1.0)
     libddwaf (1.15.0.0.0-x86_64-linux)

--- a/gemfiles/ruby_3.3_rails61_trilogy.gemfile.lock
+++ b/gemfiles/ruby_3.3_rails61_trilogy.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     datadog (2.4.0)
       datadog-ruby_core_source (~> 3.3)
-      libdatadog (~> 13.1.0.1.0)
+      libdatadog (~> 14.0.0.1.0)
       libddwaf (~> 1.15.0.0.0)
       msgpack
 
@@ -120,8 +120,8 @@ GEM
     json (2.6.3)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (13.1.0.1.0-aarch64-linux)
-    libdatadog (13.1.0.1.0-x86_64-linux)
+    libdatadog (14.0.0.1.0-aarch64-linux)
+    libdatadog (14.0.0.1.0-x86_64-linux)
     libddwaf (1.15.0.0.0-aarch64-linux)
       ffi (~> 1.0)
     libddwaf (1.15.0.0.0-x86_64-linux)

--- a/gemfiles/ruby_3.3_rails7.gemfile.lock
+++ b/gemfiles/ruby_3.3_rails7.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     datadog (2.4.0)
       datadog-ruby_core_source (~> 3.3)
-      libdatadog (~> 13.1.0.1.0)
+      libdatadog (~> 14.0.0.1.0)
       libddwaf (~> 1.15.0.0.0)
       msgpack
 
@@ -126,8 +126,8 @@ GEM
     json (2.7.2)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (13.1.0.1.0-aarch64-linux)
-    libdatadog (13.1.0.1.0-x86_64-linux)
+    libdatadog (14.0.0.1.0-aarch64-linux)
+    libdatadog (14.0.0.1.0-x86_64-linux)
     libddwaf (1.15.0.0.0-aarch64-linux)
       ffi (~> 1.0)
     libddwaf (1.15.0.0.0-x86_64-linux)

--- a/gemfiles/ruby_3.3_rails71.gemfile.lock
+++ b/gemfiles/ruby_3.3_rails71.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     datadog (2.4.0)
       datadog-ruby_core_source (~> 3.3)
-      libdatadog (~> 13.1.0.1.0)
+      libdatadog (~> 14.0.0.1.0)
       libddwaf (~> 1.15.0.0.0)
       msgpack
 
@@ -142,8 +142,8 @@ GEM
     json (2.7.2)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (13.1.0.1.0-aarch64-linux)
-    libdatadog (13.1.0.1.0-x86_64-linux)
+    libdatadog (14.0.0.1.0-aarch64-linux)
+    libdatadog (14.0.0.1.0-x86_64-linux)
     libddwaf (1.15.0.0.0-aarch64-linux)
       ffi (~> 1.0)
     libddwaf (1.15.0.0.0-x86_64-linux)

--- a/gemfiles/ruby_3.3_redis_3.gemfile.lock
+++ b/gemfiles/ruby_3.3_redis_3.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     datadog (2.4.0)
       datadog-ruby_core_source (~> 3.3)
-      libdatadog (~> 13.1.0.1.0)
+      libdatadog (~> 14.0.0.1.0)
       libddwaf (~> 1.15.0.0.0)
       msgpack
 
@@ -49,8 +49,8 @@ GEM
     json (2.6.3)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (13.1.0.1.0-aarch64-linux)
-    libdatadog (13.1.0.1.0-x86_64-linux)
+    libdatadog (14.0.0.1.0-aarch64-linux)
+    libdatadog (14.0.0.1.0-x86_64-linux)
     libddwaf (1.15.0.0.0-aarch64-linux)
       ffi (~> 1.0)
     libddwaf (1.15.0.0.0-x86_64-linux)

--- a/gemfiles/ruby_3.3_redis_4.gemfile.lock
+++ b/gemfiles/ruby_3.3_redis_4.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     datadog (2.4.0)
       datadog-ruby_core_source (~> 3.3)
-      libdatadog (~> 13.1.0.1.0)
+      libdatadog (~> 14.0.0.1.0)
       libddwaf (~> 1.15.0.0.0)
       msgpack
 
@@ -49,8 +49,8 @@ GEM
     json (2.6.3)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (13.1.0.1.0-aarch64-linux)
-    libdatadog (13.1.0.1.0-x86_64-linux)
+    libdatadog (14.0.0.1.0-aarch64-linux)
+    libdatadog (14.0.0.1.0-x86_64-linux)
     libddwaf (1.15.0.0.0-aarch64-linux)
       ffi (~> 1.0)
     libddwaf (1.15.0.0.0-x86_64-linux)

--- a/gemfiles/ruby_3.3_redis_5.gemfile.lock
+++ b/gemfiles/ruby_3.3_redis_5.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     datadog (2.4.0)
       datadog-ruby_core_source (~> 3.3)
-      libdatadog (~> 13.1.0.1.0)
+      libdatadog (~> 14.0.0.1.0)
       libddwaf (~> 1.15.0.0.0)
       msgpack
 
@@ -50,8 +50,8 @@ GEM
     json (2.6.3)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (13.1.0.1.0-aarch64-linux)
-    libdatadog (13.1.0.1.0-x86_64-linux)
+    libdatadog (14.0.0.1.0-aarch64-linux)
+    libdatadog (14.0.0.1.0-x86_64-linux)
     libddwaf (1.15.0.0.0-aarch64-linux)
       ffi (~> 1.0)
     libddwaf (1.15.0.0.0-x86_64-linux)

--- a/gemfiles/ruby_3.3_relational_db.gemfile.lock
+++ b/gemfiles/ruby_3.3_relational_db.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     datadog (2.4.0)
       datadog-ruby_core_source (~> 3.3)
-      libdatadog (~> 13.1.0.1.0)
+      libdatadog (~> 14.0.0.1.0)
       libddwaf (~> 1.15.0.0.0)
       msgpack
 
@@ -67,8 +67,8 @@ GEM
     json (2.6.3)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (13.1.0.1.0-aarch64-linux)
-    libdatadog (13.1.0.1.0-x86_64-linux)
+    libdatadog (14.0.0.1.0-aarch64-linux)
+    libdatadog (14.0.0.1.0-x86_64-linux)
     libddwaf (1.15.0.0.0-aarch64-linux)
       ffi (~> 1.0)
     libddwaf (1.15.0.0.0-x86_64-linux)

--- a/gemfiles/ruby_3.3_resque2_redis3.gemfile.lock
+++ b/gemfiles/ruby_3.3_resque2_redis3.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     datadog (2.4.0)
       datadog-ruby_core_source (~> 3.3)
-      libdatadog (~> 13.1.0.1.0)
+      libdatadog (~> 14.0.0.1.0)
       libddwaf (~> 1.15.0.0.0)
       msgpack
 
@@ -49,8 +49,8 @@ GEM
     json (2.6.3)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (13.1.0.1.0-aarch64-linux)
-    libdatadog (13.1.0.1.0-x86_64-linux)
+    libdatadog (14.0.0.1.0-aarch64-linux)
+    libdatadog (14.0.0.1.0-x86_64-linux)
     libddwaf (1.15.0.0.0-aarch64-linux)
       ffi (~> 1.0)
     libddwaf (1.15.0.0.0-x86_64-linux)

--- a/gemfiles/ruby_3.3_resque2_redis4.gemfile.lock
+++ b/gemfiles/ruby_3.3_resque2_redis4.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     datadog (2.4.0)
       datadog-ruby_core_source (~> 3.3)
-      libdatadog (~> 13.1.0.1.0)
+      libdatadog (~> 14.0.0.1.0)
       libddwaf (~> 1.15.0.0.0)
       msgpack
 
@@ -50,8 +50,8 @@ GEM
     json (2.6.3)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (13.1.0.1.0-aarch64-linux)
-    libdatadog (13.1.0.1.0-x86_64-linux)
+    libdatadog (14.0.0.1.0-aarch64-linux)
+    libdatadog (14.0.0.1.0-x86_64-linux)
     libddwaf (1.15.0.0.0-aarch64-linux)
       ffi (~> 1.0)
     libddwaf (1.15.0.0.0-x86_64-linux)

--- a/gemfiles/ruby_3.3_sinatra_2.gemfile.lock
+++ b/gemfiles/ruby_3.3_sinatra_2.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     datadog (2.4.0)
       datadog-ruby_core_source (~> 3.3)
-      libdatadog (~> 13.1.0.1.0)
+      libdatadog (~> 14.0.0.1.0)
       libddwaf (~> 1.15.0.0.0)
       msgpack
 
@@ -53,8 +53,8 @@ GEM
     json (2.7.2)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (13.1.0.1.0-aarch64-linux)
-    libdatadog (13.1.0.1.0-x86_64-linux)
+    libdatadog (14.0.0.1.0-aarch64-linux)
+    libdatadog (14.0.0.1.0-x86_64-linux)
     libddwaf (1.15.0.0.0-aarch64-linux)
       ffi (~> 1.0)
     libddwaf (1.15.0.0.0-x86_64-linux)

--- a/gemfiles/ruby_3.3_sinatra_3.gemfile.lock
+++ b/gemfiles/ruby_3.3_sinatra_3.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     datadog (2.4.0)
       datadog-ruby_core_source (~> 3.3)
-      libdatadog (~> 13.1.0.1.0)
+      libdatadog (~> 14.0.0.1.0)
       libddwaf (~> 1.15.0.0.0)
       msgpack
 
@@ -54,8 +54,8 @@ GEM
     json (2.7.2)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (13.1.0.1.0-aarch64-linux)
-    libdatadog (13.1.0.1.0-x86_64-linux)
+    libdatadog (14.0.0.1.0-aarch64-linux)
+    libdatadog (14.0.0.1.0-x86_64-linux)
     libddwaf (1.15.0.0.0-aarch64-linux)
       ffi (~> 1.0)
     libddwaf (1.15.0.0.0-x86_64-linux)

--- a/gemfiles/ruby_3.3_sinatra_4.gemfile.lock
+++ b/gemfiles/ruby_3.3_sinatra_4.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     datadog (2.4.0)
       datadog-ruby_core_source (~> 3.3)
-      libdatadog (~> 13.1.0.1.0)
+      libdatadog (~> 14.0.0.1.0)
       libddwaf (~> 1.15.0.0.0)
       msgpack
 
@@ -54,8 +54,8 @@ GEM
     json (2.7.2)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (13.1.0.1.0-aarch64-linux)
-    libdatadog (13.1.0.1.0-x86_64-linux)
+    libdatadog (14.0.0.1.0-aarch64-linux)
+    libdatadog (14.0.0.1.0-x86_64-linux)
     libddwaf (1.15.0.0.0-aarch64-linux)
       ffi (~> 1.0)
     libddwaf (1.15.0.0.0-x86_64-linux)

--- a/gemfiles/ruby_3.3_stripe_10.gemfile.lock
+++ b/gemfiles/ruby_3.3_stripe_10.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     datadog (2.4.0)
       datadog-ruby_core_source (~> 3.3)
-      libdatadog (~> 13.1.0.1.0)
+      libdatadog (~> 14.0.0.1.0)
       libddwaf (~> 1.15.0.0.0)
       msgpack
 
@@ -53,8 +53,8 @@ GEM
     json (2.7.2)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (13.1.0.1.0-aarch64-linux)
-    libdatadog (13.1.0.1.0-x86_64-linux)
+    libdatadog (14.0.0.1.0-aarch64-linux)
+    libdatadog (14.0.0.1.0-x86_64-linux)
     libddwaf (1.15.0.0.0-aarch64-linux)
       ffi (~> 1.0)
     libddwaf (1.15.0.0.0-x86_64-linux)

--- a/gemfiles/ruby_3.3_stripe_11.gemfile.lock
+++ b/gemfiles/ruby_3.3_stripe_11.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     datadog (2.4.0)
       datadog-ruby_core_source (~> 3.3)
-      libdatadog (~> 13.1.0.1.0)
+      libdatadog (~> 14.0.0.1.0)
       libddwaf (~> 1.15.0.0.0)
       msgpack
 
@@ -53,8 +53,8 @@ GEM
     json (2.7.2)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (13.1.0.1.0-aarch64-linux)
-    libdatadog (13.1.0.1.0-x86_64-linux)
+    libdatadog (14.0.0.1.0-aarch64-linux)
+    libdatadog (14.0.0.1.0-x86_64-linux)
     libddwaf (1.15.0.0.0-aarch64-linux)
       ffi (~> 1.0)
     libddwaf (1.15.0.0.0-x86_64-linux)

--- a/gemfiles/ruby_3.3_stripe_12.gemfile.lock
+++ b/gemfiles/ruby_3.3_stripe_12.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     datadog (2.4.0)
       datadog-ruby_core_source (~> 3.3)
-      libdatadog (~> 13.1.0.1.0)
+      libdatadog (~> 14.0.0.1.0)
       libddwaf (~> 1.15.0.0.0)
       msgpack
 
@@ -53,8 +53,8 @@ GEM
     json (2.7.2)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (13.1.0.1.0-aarch64-linux)
-    libdatadog (13.1.0.1.0-x86_64-linux)
+    libdatadog (14.0.0.1.0-aarch64-linux)
+    libdatadog (14.0.0.1.0-x86_64-linux)
     libddwaf (1.15.0.0.0-aarch64-linux)
       ffi (~> 1.0)
     libddwaf (1.15.0.0.0-x86_64-linux)

--- a/gemfiles/ruby_3.3_stripe_7.gemfile.lock
+++ b/gemfiles/ruby_3.3_stripe_7.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     datadog (2.4.0)
       datadog-ruby_core_source (~> 3.3)
-      libdatadog (~> 13.1.0.1.0)
+      libdatadog (~> 14.0.0.1.0)
       libddwaf (~> 1.15.0.0.0)
       msgpack
 
@@ -53,8 +53,8 @@ GEM
     json (2.7.2)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (13.1.0.1.0-aarch64-linux)
-    libdatadog (13.1.0.1.0-x86_64-linux)
+    libdatadog (14.0.0.1.0-aarch64-linux)
+    libdatadog (14.0.0.1.0-x86_64-linux)
     libddwaf (1.15.0.0.0-aarch64-linux)
       ffi (~> 1.0)
     libddwaf (1.15.0.0.0-x86_64-linux)

--- a/gemfiles/ruby_3.3_stripe_8.gemfile.lock
+++ b/gemfiles/ruby_3.3_stripe_8.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     datadog (2.4.0)
       datadog-ruby_core_source (~> 3.3)
-      libdatadog (~> 13.1.0.1.0)
+      libdatadog (~> 14.0.0.1.0)
       libddwaf (~> 1.15.0.0.0)
       msgpack
 
@@ -53,8 +53,8 @@ GEM
     json (2.7.2)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (13.1.0.1.0-aarch64-linux)
-    libdatadog (13.1.0.1.0-x86_64-linux)
+    libdatadog (14.0.0.1.0-aarch64-linux)
+    libdatadog (14.0.0.1.0-x86_64-linux)
     libddwaf (1.15.0.0.0-aarch64-linux)
       ffi (~> 1.0)
     libddwaf (1.15.0.0.0-x86_64-linux)

--- a/gemfiles/ruby_3.3_stripe_9.gemfile.lock
+++ b/gemfiles/ruby_3.3_stripe_9.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     datadog (2.4.0)
       datadog-ruby_core_source (~> 3.3)
-      libdatadog (~> 13.1.0.1.0)
+      libdatadog (~> 14.0.0.1.0)
       libddwaf (~> 1.15.0.0.0)
       msgpack
 
@@ -53,8 +53,8 @@ GEM
     json (2.7.2)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (13.1.0.1.0-aarch64-linux)
-    libdatadog (13.1.0.1.0-x86_64-linux)
+    libdatadog (14.0.0.1.0-aarch64-linux)
+    libdatadog (14.0.0.1.0-x86_64-linux)
     libddwaf (1.15.0.0.0-aarch64-linux)
       ffi (~> 1.0)
     libddwaf (1.15.0.0.0-x86_64-linux)

--- a/gemfiles/ruby_3.3_stripe_latest.gemfile.lock
+++ b/gemfiles/ruby_3.3_stripe_latest.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     datadog (2.4.0)
       datadog-ruby_core_source (~> 3.3)
-      libdatadog (~> 13.1.0.1.0)
+      libdatadog (~> 14.0.0.1.0)
       libddwaf (~> 1.15.0.0.0)
       msgpack
 
@@ -53,8 +53,8 @@ GEM
     json (2.7.2)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (13.1.0.1.0-aarch64-linux)
-    libdatadog (13.1.0.1.0-x86_64-linux)
+    libdatadog (14.0.0.1.0-aarch64-linux)
+    libdatadog (14.0.0.1.0-x86_64-linux)
     libddwaf (1.15.0.0.0-aarch64-linux)
       ffi (~> 1.0)
     libddwaf (1.15.0.0.0-x86_64-linux)

--- a/gemfiles/ruby_3.3_stripe_min.gemfile.lock
+++ b/gemfiles/ruby_3.3_stripe_min.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     datadog (2.4.0)
       datadog-ruby_core_source (~> 3.3)
-      libdatadog (~> 13.1.0.1.0)
+      libdatadog (~> 14.0.0.1.0)
       libddwaf (~> 1.15.0.0.0)
       msgpack
 
@@ -53,8 +53,8 @@ GEM
     json (2.7.2)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (13.1.0.1.0-aarch64-linux)
-    libdatadog (13.1.0.1.0-x86_64-linux)
+    libdatadog (14.0.0.1.0-aarch64-linux)
+    libdatadog (14.0.0.1.0-x86_64-linux)
     libddwaf (1.15.0.0.0-aarch64-linux)
       ffi (~> 1.0)
     libddwaf (1.15.0.0.0-x86_64-linux)

--- a/gemfiles/ruby_3.4_activesupport.gemfile.lock
+++ b/gemfiles/ruby_3.4_activesupport.gemfile.lock
@@ -20,7 +20,7 @@ PATH
   specs:
     datadog (2.4.0)
       datadog-ruby_core_source (~> 3.3)
-      libdatadog (~> 13.1.0.1.0)
+      libdatadog (~> 14.0.0.1.0)
       libddwaf (~> 1.15.0.0.0)
       msgpack
 
@@ -130,8 +130,8 @@ GEM
       addressable (>= 2.4)
     jsonapi-renderer (0.2.2)
     king_konf (1.0.1)
-    libdatadog (13.1.0.1.0-aarch64-linux)
-    libdatadog (13.1.0.1.0-x86_64-linux)
+    libdatadog (14.0.0.1.0-aarch64-linux)
+    libdatadog (14.0.0.1.0-x86_64-linux)
     libddwaf (1.15.0.0.0-aarch64-linux)
       ffi (~> 1.0)
     libddwaf (1.15.0.0.0-x86_64-linux)

--- a/gemfiles/ruby_3.4_aws.gemfile.lock
+++ b/gemfiles/ruby_3.4_aws.gemfile.lock
@@ -20,7 +20,7 @@ PATH
   specs:
     datadog (2.4.0)
       datadog-ruby_core_source (~> 3.3)
-      libdatadog (~> 13.1.0.1.0)
+      libdatadog (~> 14.0.0.1.0)
       libddwaf (~> 1.15.0.0.0)
       msgpack
 
@@ -1607,8 +1607,8 @@ GEM
     json (2.7.2)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (13.1.0.1.0-aarch64-linux)
-    libdatadog (13.1.0.1.0-x86_64-linux)
+    libdatadog (14.0.0.1.0-aarch64-linux)
+    libdatadog (14.0.0.1.0-x86_64-linux)
     libddwaf (1.15.0.0.0-aarch64-linux)
       ffi (~> 1.0)
     libddwaf (1.15.0.0.0-x86_64-linux)

--- a/gemfiles/ruby_3.4_contrib.gemfile.lock
+++ b/gemfiles/ruby_3.4_contrib.gemfile.lock
@@ -20,7 +20,7 @@ PATH
   specs:
     datadog (2.4.0)
       datadog-ruby_core_source (~> 3.3)
-      libdatadog (~> 13.1.0.1.0)
+      libdatadog (~> 14.0.0.1.0)
       libddwaf (~> 1.15.0.0.0)
       msgpack
 
@@ -71,8 +71,8 @@ GEM
     json (2.7.2)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (13.1.0.1.0-aarch64-linux)
-    libdatadog (13.1.0.1.0-x86_64-linux)
+    libdatadog (14.0.0.1.0-aarch64-linux)
+    libdatadog (14.0.0.1.0-x86_64-linux)
     libddwaf (1.15.0.0.0-aarch64-linux)
       ffi (~> 1.0)
     libddwaf (1.15.0.0.0-x86_64-linux)

--- a/gemfiles/ruby_3.4_contrib_old.gemfile.lock
+++ b/gemfiles/ruby_3.4_contrib_old.gemfile.lock
@@ -20,7 +20,7 @@ PATH
   specs:
     datadog (2.4.0)
       datadog-ruby_core_source (~> 3.3)
-      libdatadog (~> 13.1.0.1.0)
+      libdatadog (~> 14.0.0.1.0)
       libddwaf (~> 1.15.0.0.0)
       msgpack
 
@@ -69,8 +69,8 @@ GEM
     json (2.7.2)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (13.1.0.1.0-aarch64-linux)
-    libdatadog (13.1.0.1.0-x86_64-linux)
+    libdatadog (14.0.0.1.0-aarch64-linux)
+    libdatadog (14.0.0.1.0-x86_64-linux)
     libddwaf (1.15.0.0.0-aarch64-linux)
       ffi (~> 1.0)
     libddwaf (1.15.0.0.0-x86_64-linux)

--- a/gemfiles/ruby_3.4_core_old.gemfile.lock
+++ b/gemfiles/ruby_3.4_core_old.gemfile.lock
@@ -20,7 +20,7 @@ PATH
   specs:
     datadog (2.4.0)
       datadog-ruby_core_source (~> 3.3)
-      libdatadog (~> 13.1.0.1.0)
+      libdatadog (~> 14.0.0.1.0)
       libddwaf (~> 1.15.0.0.0)
       msgpack
 
@@ -58,8 +58,8 @@ GEM
     json (2.7.2)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (13.1.0.1.0-aarch64-linux)
-    libdatadog (13.1.0.1.0-x86_64-linux)
+    libdatadog (14.0.0.1.0-aarch64-linux)
+    libdatadog (14.0.0.1.0-x86_64-linux)
     libddwaf (1.15.0.0.0-aarch64-linux)
       ffi (~> 1.0)
     libddwaf (1.15.0.0.0-x86_64-linux)

--- a/gemfiles/ruby_3.4_elasticsearch_7.gemfile.lock
+++ b/gemfiles/ruby_3.4_elasticsearch_7.gemfile.lock
@@ -20,7 +20,7 @@ PATH
   specs:
     datadog (2.4.0)
       datadog-ruby_core_source (~> 3.3)
-      libdatadog (~> 13.1.0.1.0)
+      libdatadog (~> 14.0.0.1.0)
       libddwaf (~> 1.15.0.0.0)
       msgpack
 
@@ -74,8 +74,8 @@ GEM
     json (2.7.5)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (13.1.0.1.0-aarch64-linux)
-    libdatadog (13.1.0.1.0-x86_64-linux)
+    libdatadog (14.0.0.1.0-aarch64-linux)
+    libdatadog (14.0.0.1.0-x86_64-linux)
     libddwaf (1.15.0.0.0-aarch64-linux)
       ffi (~> 1.0)
     libddwaf (1.15.0.0.0-x86_64-linux)

--- a/gemfiles/ruby_3.4_elasticsearch_8.gemfile.lock
+++ b/gemfiles/ruby_3.4_elasticsearch_8.gemfile.lock
@@ -20,7 +20,7 @@ PATH
   specs:
     datadog (2.4.0)
       datadog-ruby_core_source (~> 3.3)
-      libdatadog (~> 13.1.0.1.0)
+      libdatadog (~> 14.0.0.1.0)
       libddwaf (~> 1.15.0.0.0)
       msgpack
 
@@ -72,8 +72,8 @@ GEM
     json (2.7.5)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (13.1.0.1.0-aarch64-linux)
-    libdatadog (13.1.0.1.0-x86_64-linux)
+    libdatadog (14.0.0.1.0-aarch64-linux)
+    libdatadog (14.0.0.1.0-x86_64-linux)
     libddwaf (1.15.0.0.0-aarch64-linux)
       ffi (~> 1.0)
     libddwaf (1.15.0.0.0-x86_64-linux)

--- a/gemfiles/ruby_3.4_elasticsearch_latest.gemfile.lock
+++ b/gemfiles/ruby_3.4_elasticsearch_latest.gemfile.lock
@@ -20,7 +20,7 @@ PATH
   specs:
     datadog (2.4.0)
       datadog-ruby_core_source (~> 3.3)
-      libdatadog (~> 13.1.0.1.0)
+      libdatadog (~> 14.0.0.1.0)
       libddwaf (~> 1.15.0.0.0)
       msgpack
 
@@ -72,8 +72,8 @@ GEM
     json (2.7.5)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (13.1.0.1.0-aarch64-linux)
-    libdatadog (13.1.0.1.0-x86_64-linux)
+    libdatadog (14.0.0.1.0-aarch64-linux)
+    libdatadog (14.0.0.1.0-x86_64-linux)
     libddwaf (1.15.0.0.0-aarch64-linux)
       ffi (~> 1.0)
     libddwaf (1.15.0.0.0-x86_64-linux)

--- a/gemfiles/ruby_3.4_graphql_1.13.gemfile.lock
+++ b/gemfiles/ruby_3.4_graphql_1.13.gemfile.lock
@@ -20,7 +20,7 @@ PATH
   specs:
     datadog (2.4.0)
       datadog-ruby_core_source (~> 3.3)
-      libdatadog (~> 13.1.0.1.0)
+      libdatadog (~> 14.0.0.1.0)
       libddwaf (~> 1.15.0.0.0)
       msgpack
 
@@ -128,8 +128,8 @@ GEM
     json (2.7.2)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (13.1.0.1.0-aarch64-linux)
-    libdatadog (13.1.0.1.0-x86_64-linux)
+    libdatadog (14.0.0.1.0-aarch64-linux)
+    libdatadog (14.0.0.1.0-x86_64-linux)
     libddwaf (1.15.0.0.0-aarch64-linux)
       ffi (~> 1.0)
     libddwaf (1.15.0.0.0-x86_64-linux)

--- a/gemfiles/ruby_3.4_graphql_2.0.gemfile.lock
+++ b/gemfiles/ruby_3.4_graphql_2.0.gemfile.lock
@@ -20,7 +20,7 @@ PATH
   specs:
     datadog (2.4.0)
       datadog-ruby_core_source (~> 3.3)
-      libdatadog (~> 13.1.0.1.0)
+      libdatadog (~> 14.0.0.1.0)
       libddwaf (~> 1.15.0.0.0)
       msgpack
 
@@ -128,8 +128,8 @@ GEM
     json (2.7.2)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (13.1.0.1.0-aarch64-linux)
-    libdatadog (13.1.0.1.0-x86_64-linux)
+    libdatadog (14.0.0.1.0-aarch64-linux)
+    libdatadog (14.0.0.1.0-x86_64-linux)
     libddwaf (1.15.0.0.0-aarch64-linux)
       ffi (~> 1.0)
     libddwaf (1.15.0.0.0-x86_64-linux)

--- a/gemfiles/ruby_3.4_graphql_2.1.gemfile.lock
+++ b/gemfiles/ruby_3.4_graphql_2.1.gemfile.lock
@@ -20,7 +20,7 @@ PATH
   specs:
     datadog (2.4.0)
       datadog-ruby_core_source (~> 3.3)
-      libdatadog (~> 13.1.0.1.0)
+      libdatadog (~> 14.0.0.1.0)
       libddwaf (~> 1.15.0.0.0)
       msgpack
 
@@ -128,8 +128,8 @@ GEM
     json (2.7.2)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (13.1.0.1.0-aarch64-linux)
-    libdatadog (13.1.0.1.0-x86_64-linux)
+    libdatadog (14.0.0.1.0-aarch64-linux)
+    libdatadog (14.0.0.1.0-x86_64-linux)
     libddwaf (1.15.0.0.0-aarch64-linux)
       ffi (~> 1.0)
     libddwaf (1.15.0.0.0-x86_64-linux)

--- a/gemfiles/ruby_3.4_graphql_2.2.gemfile.lock
+++ b/gemfiles/ruby_3.4_graphql_2.2.gemfile.lock
@@ -20,7 +20,7 @@ PATH
   specs:
     datadog (2.4.0)
       datadog-ruby_core_source (~> 3.3)
-      libdatadog (~> 13.1.0.1.0)
+      libdatadog (~> 14.0.0.1.0)
       libddwaf (~> 1.15.0.0.0)
       msgpack
 
@@ -128,8 +128,8 @@ GEM
     json (2.7.2)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (13.1.0.1.0-aarch64-linux)
-    libdatadog (13.1.0.1.0-x86_64-linux)
+    libdatadog (14.0.0.1.0-aarch64-linux)
+    libdatadog (14.0.0.1.0-x86_64-linux)
     libddwaf (1.15.0.0.0-aarch64-linux)
       ffi (~> 1.0)
     libddwaf (1.15.0.0.0-x86_64-linux)

--- a/gemfiles/ruby_3.4_graphql_2.3.gemfile.lock
+++ b/gemfiles/ruby_3.4_graphql_2.3.gemfile.lock
@@ -20,7 +20,7 @@ PATH
   specs:
     datadog (2.4.0)
       datadog-ruby_core_source (~> 3.3)
-      libdatadog (~> 13.1.0.1.0)
+      libdatadog (~> 14.0.0.1.0)
       libddwaf (~> 1.15.0.0.0)
       msgpack
 
@@ -128,8 +128,8 @@ GEM
     json (2.7.2)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (13.1.0.1.0-aarch64-linux)
-    libdatadog (13.1.0.1.0-x86_64-linux)
+    libdatadog (14.0.0.1.0-aarch64-linux)
+    libdatadog (14.0.0.1.0-x86_64-linux)
     libddwaf (1.15.0.0.0-aarch64-linux)
       ffi (~> 1.0)
     libddwaf (1.15.0.0.0-x86_64-linux)

--- a/gemfiles/ruby_3.4_http.gemfile.lock
+++ b/gemfiles/ruby_3.4_http.gemfile.lock
@@ -20,7 +20,7 @@ PATH
   specs:
     datadog (2.4.0)
       datadog-ruby_core_source (~> 3.3)
-      libdatadog (~> 13.1.0.1.0)
+      libdatadog (~> 14.0.0.1.0)
       libddwaf (~> 1.15.0.0.0)
       msgpack
 
@@ -81,8 +81,8 @@ GEM
     json (2.7.2)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (13.1.0.1.0-aarch64-linux)
-    libdatadog (13.1.0.1.0-x86_64-linux)
+    libdatadog (14.0.0.1.0-aarch64-linux)
+    libdatadog (14.0.0.1.0-x86_64-linux)
     libddwaf (1.15.0.0.0-aarch64-linux)
       ffi (~> 1.0)
     libddwaf (1.15.0.0.0-x86_64-linux)

--- a/gemfiles/ruby_3.4_opensearch_2.gemfile.lock
+++ b/gemfiles/ruby_3.4_opensearch_2.gemfile.lock
@@ -20,7 +20,7 @@ PATH
   specs:
     datadog (2.4.0)
       datadog-ruby_core_source (~> 3.3)
-      libdatadog (~> 13.1.0.1.0)
+      libdatadog (~> 14.0.0.1.0)
       libddwaf (~> 1.15.0.0.0)
       msgpack
 
@@ -64,8 +64,8 @@ GEM
     json (2.7.5)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (13.1.0.1.0-aarch64-linux)
-    libdatadog (13.1.0.1.0-x86_64-linux)
+    libdatadog (14.0.0.1.0-aarch64-linux)
+    libdatadog (14.0.0.1.0-x86_64-linux)
     libddwaf (1.15.0.0.0-aarch64-linux)
       ffi (~> 1.0)
     libddwaf (1.15.0.0.0-x86_64-linux)

--- a/gemfiles/ruby_3.4_opensearch_3.gemfile.lock
+++ b/gemfiles/ruby_3.4_opensearch_3.gemfile.lock
@@ -20,7 +20,7 @@ PATH
   specs:
     datadog (2.4.0)
       datadog-ruby_core_source (~> 3.3)
-      libdatadog (~> 13.1.0.1.0)
+      libdatadog (~> 14.0.0.1.0)
       libddwaf (~> 1.15.0.0.0)
       msgpack
 
@@ -64,8 +64,8 @@ GEM
     json (2.7.5)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (13.1.0.1.0-aarch64-linux)
-    libdatadog (13.1.0.1.0-x86_64-linux)
+    libdatadog (14.0.0.1.0-aarch64-linux)
+    libdatadog (14.0.0.1.0-x86_64-linux)
     libddwaf (1.15.0.0.0-aarch64-linux)
       ffi (~> 1.0)
     libddwaf (1.15.0.0.0-x86_64-linux)

--- a/gemfiles/ruby_3.4_opensearch_latest.gemfile.lock
+++ b/gemfiles/ruby_3.4_opensearch_latest.gemfile.lock
@@ -20,7 +20,7 @@ PATH
   specs:
     datadog (2.4.0)
       datadog-ruby_core_source (~> 3.3)
-      libdatadog (~> 13.1.0.1.0)
+      libdatadog (~> 14.0.0.1.0)
       libddwaf (~> 1.15.0.0.0)
       msgpack
 
@@ -64,8 +64,8 @@ GEM
     json (2.7.5)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (13.1.0.1.0-aarch64-linux)
-    libdatadog (13.1.0.1.0-x86_64-linux)
+    libdatadog (14.0.0.1.0-aarch64-linux)
+    libdatadog (14.0.0.1.0-x86_64-linux)
     libddwaf (1.15.0.0.0-aarch64-linux)
       ffi (~> 1.0)
     libddwaf (1.15.0.0.0-x86_64-linux)

--- a/gemfiles/ruby_3.4_opentelemetry.gemfile.lock
+++ b/gemfiles/ruby_3.4_opentelemetry.gemfile.lock
@@ -20,7 +20,7 @@ PATH
   specs:
     datadog (2.4.0)
       datadog-ruby_core_source (~> 3.3)
-      libdatadog (~> 13.1.0.1.0)
+      libdatadog (~> 14.0.0.1.0)
       libddwaf (~> 1.15.0.0.0)
       msgpack
 
@@ -58,8 +58,8 @@ GEM
     json (2.7.2)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (13.1.0.1.0-aarch64-linux)
-    libdatadog (13.1.0.1.0-x86_64-linux)
+    libdatadog (14.0.0.1.0-aarch64-linux)
+    libdatadog (14.0.0.1.0-x86_64-linux)
     libddwaf (1.15.0.0.0-aarch64-linux)
       ffi (~> 1.0)
     libddwaf (1.15.0.0.0-x86_64-linux)

--- a/gemfiles/ruby_3.4_opentelemetry_otlp.gemfile.lock
+++ b/gemfiles/ruby_3.4_opentelemetry_otlp.gemfile.lock
@@ -20,7 +20,7 @@ PATH
   specs:
     datadog (2.4.0)
       datadog-ruby_core_source (~> 3.3)
-      libdatadog (~> 13.1.0.1.0)
+      libdatadog (~> 14.0.0.1.0)
       libddwaf (~> 1.15.0.0.0)
       msgpack
 
@@ -60,8 +60,8 @@ GEM
     json (2.7.2)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (13.1.0.1.0-aarch64-linux)
-    libdatadog (13.1.0.1.0-x86_64-linux)
+    libdatadog (14.0.0.1.0-aarch64-linux)
+    libdatadog (14.0.0.1.0-x86_64-linux)
     libddwaf (1.15.0.0.0-aarch64-linux)
       ffi (~> 1.0)
     libddwaf (1.15.0.0.0-x86_64-linux)

--- a/gemfiles/ruby_3.4_rack_2.gemfile.lock
+++ b/gemfiles/ruby_3.4_rack_2.gemfile.lock
@@ -20,7 +20,7 @@ PATH
   specs:
     datadog (2.4.0)
       datadog-ruby_core_source (~> 3.3)
-      libdatadog (~> 13.1.0.1.0)
+      libdatadog (~> 14.0.0.1.0)
       libddwaf (~> 1.15.0.0.0)
       msgpack
 
@@ -58,8 +58,8 @@ GEM
     json (2.7.2)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (13.1.0.1.0-aarch64-linux)
-    libdatadog (13.1.0.1.0-x86_64-linux)
+    libdatadog (14.0.0.1.0-aarch64-linux)
+    libdatadog (14.0.0.1.0-x86_64-linux)
     libddwaf (1.15.0.0.0-aarch64-linux)
       ffi (~> 1.0)
     libddwaf (1.15.0.0.0-x86_64-linux)

--- a/gemfiles/ruby_3.4_rack_3.gemfile.lock
+++ b/gemfiles/ruby_3.4_rack_3.gemfile.lock
@@ -20,7 +20,7 @@ PATH
   specs:
     datadog (2.4.0)
       datadog-ruby_core_source (~> 3.3)
-      libdatadog (~> 13.1.0.1.0)
+      libdatadog (~> 14.0.0.1.0)
       libddwaf (~> 1.15.0.0.0)
       msgpack
 
@@ -58,8 +58,8 @@ GEM
     json (2.7.2)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (13.1.0.1.0-aarch64-linux)
-    libdatadog (13.1.0.1.0-x86_64-linux)
+    libdatadog (14.0.0.1.0-aarch64-linux)
+    libdatadog (14.0.0.1.0-x86_64-linux)
     libddwaf (1.15.0.0.0-aarch64-linux)
       ffi (~> 1.0)
     libddwaf (1.15.0.0.0-x86_64-linux)

--- a/gemfiles/ruby_3.4_rack_latest.gemfile.lock
+++ b/gemfiles/ruby_3.4_rack_latest.gemfile.lock
@@ -20,7 +20,7 @@ PATH
   specs:
     datadog (2.4.0)
       datadog-ruby_core_source (~> 3.3)
-      libdatadog (~> 13.1.0.1.0)
+      libdatadog (~> 14.0.0.1.0)
       libddwaf (~> 1.15.0.0.0)
       msgpack
 
@@ -58,8 +58,8 @@ GEM
     json (2.7.2)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (13.1.0.1.0-aarch64-linux)
-    libdatadog (13.1.0.1.0-x86_64-linux)
+    libdatadog (14.0.0.1.0-aarch64-linux)
+    libdatadog (14.0.0.1.0-x86_64-linux)
     libddwaf (1.15.0.0.0-aarch64-linux)
       ffi (~> 1.0)
     libddwaf (1.15.0.0.0-x86_64-linux)

--- a/gemfiles/ruby_3.4_rails61_mysql2.gemfile.lock
+++ b/gemfiles/ruby_3.4_rails61_mysql2.gemfile.lock
@@ -20,7 +20,7 @@ PATH
   specs:
     datadog (2.4.0)
       datadog-ruby_core_source (~> 3.3)
-      libdatadog (~> 13.1.0.1.0)
+      libdatadog (~> 14.0.0.1.0)
       libddwaf (~> 1.15.0.0.0)
       msgpack
 
@@ -126,8 +126,8 @@ GEM
     json (2.7.2)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (13.1.0.1.0-aarch64-linux)
-    libdatadog (13.1.0.1.0-x86_64-linux)
+    libdatadog (14.0.0.1.0-aarch64-linux)
+    libdatadog (14.0.0.1.0-x86_64-linux)
     libddwaf (1.15.0.0.0-aarch64-linux)
       ffi (~> 1.0)
     libddwaf (1.15.0.0.0-x86_64-linux)

--- a/gemfiles/ruby_3.4_rails61_postgres.gemfile.lock
+++ b/gemfiles/ruby_3.4_rails61_postgres.gemfile.lock
@@ -20,7 +20,7 @@ PATH
   specs:
     datadog (2.4.0)
       datadog-ruby_core_source (~> 3.3)
-      libdatadog (~> 13.1.0.1.0)
+      libdatadog (~> 14.0.0.1.0)
       libddwaf (~> 1.15.0.0.0)
       msgpack
 
@@ -126,8 +126,8 @@ GEM
     json (2.7.2)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (13.1.0.1.0-aarch64-linux)
-    libdatadog (13.1.0.1.0-x86_64-linux)
+    libdatadog (14.0.0.1.0-aarch64-linux)
+    libdatadog (14.0.0.1.0-x86_64-linux)
     libddwaf (1.15.0.0.0-aarch64-linux)
       ffi (~> 1.0)
     libddwaf (1.15.0.0.0-x86_64-linux)

--- a/gemfiles/ruby_3.4_rails61_postgres_redis.gemfile.lock
+++ b/gemfiles/ruby_3.4_rails61_postgres_redis.gemfile.lock
@@ -20,7 +20,7 @@ PATH
   specs:
     datadog (2.4.0)
       datadog-ruby_core_source (~> 3.3)
-      libdatadog (~> 13.1.0.1.0)
+      libdatadog (~> 14.0.0.1.0)
       libddwaf (~> 1.15.0.0.0)
       msgpack
 
@@ -126,8 +126,8 @@ GEM
     json (2.7.2)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (13.1.0.1.0-aarch64-linux)
-    libdatadog (13.1.0.1.0-x86_64-linux)
+    libdatadog (14.0.0.1.0-aarch64-linux)
+    libdatadog (14.0.0.1.0-x86_64-linux)
     libddwaf (1.15.0.0.0-aarch64-linux)
       ffi (~> 1.0)
     libddwaf (1.15.0.0.0-x86_64-linux)

--- a/gemfiles/ruby_3.4_rails61_postgres_sidekiq.gemfile.lock
+++ b/gemfiles/ruby_3.4_rails61_postgres_sidekiq.gemfile.lock
@@ -20,7 +20,7 @@ PATH
   specs:
     datadog (2.4.0)
       datadog-ruby_core_source (~> 3.3)
-      libdatadog (~> 13.1.0.1.0)
+      libdatadog (~> 14.0.0.1.0)
       libddwaf (~> 1.15.0.0.0)
       msgpack
 
@@ -127,8 +127,8 @@ GEM
     json (2.7.2)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (13.1.0.1.0-aarch64-linux)
-    libdatadog (13.1.0.1.0-x86_64-linux)
+    libdatadog (14.0.0.1.0-aarch64-linux)
+    libdatadog (14.0.0.1.0-x86_64-linux)
     libddwaf (1.15.0.0.0-aarch64-linux)
       ffi (~> 1.0)
     libddwaf (1.15.0.0.0-x86_64-linux)

--- a/gemfiles/ruby_3.4_rails61_semantic_logger.gemfile.lock
+++ b/gemfiles/ruby_3.4_rails61_semantic_logger.gemfile.lock
@@ -20,7 +20,7 @@ PATH
   specs:
     datadog (2.4.0)
       datadog-ruby_core_source (~> 3.3)
-      libdatadog (~> 13.1.0.1.0)
+      libdatadog (~> 14.0.0.1.0)
       libddwaf (~> 1.15.0.0.0)
       msgpack
 
@@ -126,8 +126,8 @@ GEM
     json (2.7.2)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (13.1.0.1.0-aarch64-linux)
-    libdatadog (13.1.0.1.0-x86_64-linux)
+    libdatadog (14.0.0.1.0-aarch64-linux)
+    libdatadog (14.0.0.1.0-x86_64-linux)
     libddwaf (1.15.0.0.0-aarch64-linux)
       ffi (~> 1.0)
     libddwaf (1.15.0.0.0-x86_64-linux)

--- a/gemfiles/ruby_3.4_rails61_trilogy.gemfile.lock
+++ b/gemfiles/ruby_3.4_rails61_trilogy.gemfile.lock
@@ -20,7 +20,7 @@ PATH
   specs:
     datadog (2.4.0)
       datadog-ruby_core_source (~> 3.3)
-      libdatadog (~> 13.1.0.1.0)
+      libdatadog (~> 14.0.0.1.0)
       libddwaf (~> 1.15.0.0.0)
       msgpack
 
@@ -129,8 +129,8 @@ GEM
     json (2.7.2)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (13.1.0.1.0-aarch64-linux)
-    libdatadog (13.1.0.1.0-x86_64-linux)
+    libdatadog (14.0.0.1.0-aarch64-linux)
+    libdatadog (14.0.0.1.0-x86_64-linux)
     libddwaf (1.15.0.0.0-aarch64-linux)
       ffi (~> 1.0)
     libddwaf (1.15.0.0.0-x86_64-linux)

--- a/gemfiles/ruby_3.4_rails7.gemfile.lock
+++ b/gemfiles/ruby_3.4_rails7.gemfile.lock
@@ -20,7 +20,7 @@ PATH
   specs:
     datadog (2.4.0)
       datadog-ruby_core_source (~> 3.3)
-      libdatadog (~> 13.1.0.1.0)
+      libdatadog (~> 14.0.0.1.0)
       libddwaf (~> 1.15.0.0.0)
       msgpack
 
@@ -131,9 +131,9 @@ GEM
     json (2.7.2)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (13.1.0.1.0)
-    libdatadog (13.1.0.1.0-aarch64-linux)
-    libdatadog (13.1.0.1.0-x86_64-linux)
+    libdatadog (14.0.0.1.0)
+    libdatadog (14.0.0.1.0-aarch64-linux)
+    libdatadog (14.0.0.1.0-x86_64-linux)
     libddwaf (1.15.0.0.0)
       ffi (~> 1.0)
     libddwaf (1.15.0.0.0-aarch64-linux)

--- a/gemfiles/ruby_3.4_rails71.gemfile.lock
+++ b/gemfiles/ruby_3.4_rails71.gemfile.lock
@@ -20,7 +20,7 @@ PATH
   specs:
     datadog (2.4.0)
       datadog-ruby_core_source (~> 3.3)
-      libdatadog (~> 13.1.0.1.0)
+      libdatadog (~> 14.0.0.1.0)
       libddwaf (~> 1.15.0.0.0)
       msgpack
 
@@ -147,9 +147,9 @@ GEM
     json (2.7.2)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (13.1.0.1.0)
-    libdatadog (13.1.0.1.0-aarch64-linux)
-    libdatadog (13.1.0.1.0-x86_64-linux)
+    libdatadog (14.0.0.1.0)
+    libdatadog (14.0.0.1.0-aarch64-linux)
+    libdatadog (14.0.0.1.0-x86_64-linux)
     libddwaf (1.15.0.0.0)
       ffi (~> 1.0)
     libddwaf (1.15.0.0.0-aarch64-linux)

--- a/gemfiles/ruby_3.4_redis_3.gemfile.lock
+++ b/gemfiles/ruby_3.4_redis_3.gemfile.lock
@@ -20,7 +20,7 @@ PATH
   specs:
     datadog (2.4.0)
       datadog-ruby_core_source (~> 3.3)
-      libdatadog (~> 13.1.0.1.0)
+      libdatadog (~> 14.0.0.1.0)
       libddwaf (~> 1.15.0.0.0)
       msgpack
 
@@ -58,8 +58,8 @@ GEM
     json (2.7.2)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (13.1.0.1.0-aarch64-linux)
-    libdatadog (13.1.0.1.0-x86_64-linux)
+    libdatadog (14.0.0.1.0-aarch64-linux)
+    libdatadog (14.0.0.1.0-x86_64-linux)
     libddwaf (1.15.0.0.0-aarch64-linux)
       ffi (~> 1.0)
     libddwaf (1.15.0.0.0-x86_64-linux)

--- a/gemfiles/ruby_3.4_redis_4.gemfile.lock
+++ b/gemfiles/ruby_3.4_redis_4.gemfile.lock
@@ -20,7 +20,7 @@ PATH
   specs:
     datadog (2.4.0)
       datadog-ruby_core_source (~> 3.3)
-      libdatadog (~> 13.1.0.1.0)
+      libdatadog (~> 14.0.0.1.0)
       libddwaf (~> 1.15.0.0.0)
       msgpack
 
@@ -58,8 +58,8 @@ GEM
     json (2.7.2)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (13.1.0.1.0-aarch64-linux)
-    libdatadog (13.1.0.1.0-x86_64-linux)
+    libdatadog (14.0.0.1.0-aarch64-linux)
+    libdatadog (14.0.0.1.0-x86_64-linux)
     libddwaf (1.15.0.0.0-aarch64-linux)
       ffi (~> 1.0)
     libddwaf (1.15.0.0.0-x86_64-linux)

--- a/gemfiles/ruby_3.4_redis_5.gemfile.lock
+++ b/gemfiles/ruby_3.4_redis_5.gemfile.lock
@@ -20,7 +20,7 @@ PATH
   specs:
     datadog (2.4.0)
       datadog-ruby_core_source (~> 3.3)
-      libdatadog (~> 13.1.0.1.0)
+      libdatadog (~> 14.0.0.1.0)
       libddwaf (~> 1.15.0.0.0)
       msgpack
 
@@ -59,8 +59,8 @@ GEM
     json (2.7.2)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (13.1.0.1.0-aarch64-linux)
-    libdatadog (13.1.0.1.0-x86_64-linux)
+    libdatadog (14.0.0.1.0-aarch64-linux)
+    libdatadog (14.0.0.1.0-x86_64-linux)
     libddwaf (1.15.0.0.0-aarch64-linux)
       ffi (~> 1.0)
     libddwaf (1.15.0.0.0-x86_64-linux)

--- a/gemfiles/ruby_3.4_relational_db.gemfile.lock
+++ b/gemfiles/ruby_3.4_relational_db.gemfile.lock
@@ -20,7 +20,7 @@ PATH
   specs:
     datadog (2.4.0)
       datadog-ruby_core_source (~> 3.3)
-      libdatadog (~> 13.1.0.1.0)
+      libdatadog (~> 14.0.0.1.0)
       libddwaf (~> 1.15.0.0.0)
       msgpack
 
@@ -84,8 +84,8 @@ GEM
     json (2.7.2)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (13.1.0.1.0-aarch64-linux)
-    libdatadog (13.1.0.1.0-x86_64-linux)
+    libdatadog (14.0.0.1.0-aarch64-linux)
+    libdatadog (14.0.0.1.0-x86_64-linux)
     libddwaf (1.15.0.0.0-aarch64-linux)
       ffi (~> 1.0)
     libddwaf (1.15.0.0.0-x86_64-linux)

--- a/gemfiles/ruby_3.4_resque2_redis3.gemfile.lock
+++ b/gemfiles/ruby_3.4_resque2_redis3.gemfile.lock
@@ -20,7 +20,7 @@ PATH
   specs:
     datadog (2.4.0)
       datadog-ruby_core_source (~> 3.3)
-      libdatadog (~> 13.1.0.1.0)
+      libdatadog (~> 14.0.0.1.0)
       libddwaf (~> 1.15.0.0.0)
       msgpack
 
@@ -59,8 +59,8 @@ GEM
     json (2.7.2)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (13.1.0.1.0-aarch64-linux)
-    libdatadog (13.1.0.1.0-x86_64-linux)
+    libdatadog (14.0.0.1.0-aarch64-linux)
+    libdatadog (14.0.0.1.0-x86_64-linux)
     libddwaf (1.15.0.0.0-aarch64-linux)
       ffi (~> 1.0)
     libddwaf (1.15.0.0.0-x86_64-linux)

--- a/gemfiles/ruby_3.4_resque2_redis4.gemfile.lock
+++ b/gemfiles/ruby_3.4_resque2_redis4.gemfile.lock
@@ -20,7 +20,7 @@ PATH
   specs:
     datadog (2.4.0)
       datadog-ruby_core_source (~> 3.3)
-      libdatadog (~> 13.1.0.1.0)
+      libdatadog (~> 14.0.0.1.0)
       libddwaf (~> 1.15.0.0.0)
       msgpack
 
@@ -60,8 +60,8 @@ GEM
     json (2.7.2)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (13.1.0.1.0-aarch64-linux)
-    libdatadog (13.1.0.1.0-x86_64-linux)
+    libdatadog (14.0.0.1.0-aarch64-linux)
+    libdatadog (14.0.0.1.0-x86_64-linux)
     libddwaf (1.15.0.0.0-aarch64-linux)
       ffi (~> 1.0)
     libddwaf (1.15.0.0.0-x86_64-linux)

--- a/gemfiles/ruby_3.4_sinatra_2.gemfile.lock
+++ b/gemfiles/ruby_3.4_sinatra_2.gemfile.lock
@@ -20,7 +20,7 @@ PATH
   specs:
     datadog (2.4.0)
       datadog-ruby_core_source (~> 3.3)
-      libdatadog (~> 13.1.0.1.0)
+      libdatadog (~> 14.0.0.1.0)
       libddwaf (~> 1.15.0.0.0)
       msgpack
 
@@ -58,8 +58,8 @@ GEM
     json (2.7.2)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (13.1.0.1.0-aarch64-linux)
-    libdatadog (13.1.0.1.0-x86_64-linux)
+    libdatadog (14.0.0.1.0-aarch64-linux)
+    libdatadog (14.0.0.1.0-x86_64-linux)
     libddwaf (1.15.0.0.0-aarch64-linux)
       ffi (~> 1.0)
     libddwaf (1.15.0.0.0-x86_64-linux)

--- a/gemfiles/ruby_3.4_sinatra_3.gemfile.lock
+++ b/gemfiles/ruby_3.4_sinatra_3.gemfile.lock
@@ -20,7 +20,7 @@ PATH
   specs:
     datadog (2.4.0)
       datadog-ruby_core_source (~> 3.3)
-      libdatadog (~> 13.1.0.1.0)
+      libdatadog (~> 14.0.0.1.0)
       libddwaf (~> 1.15.0.0.0)
       msgpack
 
@@ -59,8 +59,8 @@ GEM
     json (2.7.2)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (13.1.0.1.0-aarch64-linux)
-    libdatadog (13.1.0.1.0-x86_64-linux)
+    libdatadog (14.0.0.1.0-aarch64-linux)
+    libdatadog (14.0.0.1.0-x86_64-linux)
     libddwaf (1.15.0.0.0-aarch64-linux)
       ffi (~> 1.0)
     libddwaf (1.15.0.0.0-x86_64-linux)

--- a/gemfiles/ruby_3.4_sinatra_4.gemfile.lock
+++ b/gemfiles/ruby_3.4_sinatra_4.gemfile.lock
@@ -20,7 +20,7 @@ PATH
   specs:
     datadog (2.4.0)
       datadog-ruby_core_source (~> 3.3)
-      libdatadog (~> 13.1.0.1.0)
+      libdatadog (~> 14.0.0.1.0)
       libddwaf (~> 1.15.0.0.0)
       msgpack
 
@@ -59,8 +59,8 @@ GEM
     json (2.7.2)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (13.1.0.1.0-aarch64-linux)
-    libdatadog (13.1.0.1.0-x86_64-linux)
+    libdatadog (14.0.0.1.0-aarch64-linux)
+    libdatadog (14.0.0.1.0-x86_64-linux)
     libddwaf (1.15.0.0.0-aarch64-linux)
       ffi (~> 1.0)
     libddwaf (1.15.0.0.0-x86_64-linux)

--- a/gemfiles/ruby_3.4_stripe_10.gemfile.lock
+++ b/gemfiles/ruby_3.4_stripe_10.gemfile.lock
@@ -20,7 +20,7 @@ PATH
   specs:
     datadog (2.4.0)
       datadog-ruby_core_source (~> 3.3)
-      libdatadog (~> 13.1.0.1.0)
+      libdatadog (~> 14.0.0.1.0)
       libddwaf (~> 1.15.0.0.0)
       msgpack
 
@@ -58,8 +58,8 @@ GEM
     json (2.7.2)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (13.1.0.1.0-aarch64-linux)
-    libdatadog (13.1.0.1.0-x86_64-linux)
+    libdatadog (14.0.0.1.0-aarch64-linux)
+    libdatadog (14.0.0.1.0-x86_64-linux)
     libddwaf (1.15.0.0.0-aarch64-linux)
       ffi (~> 1.0)
     libddwaf (1.15.0.0.0-x86_64-linux)

--- a/gemfiles/ruby_3.4_stripe_11.gemfile.lock
+++ b/gemfiles/ruby_3.4_stripe_11.gemfile.lock
@@ -20,7 +20,7 @@ PATH
   specs:
     datadog (2.4.0)
       datadog-ruby_core_source (~> 3.3)
-      libdatadog (~> 13.1.0.1.0)
+      libdatadog (~> 14.0.0.1.0)
       libddwaf (~> 1.15.0.0.0)
       msgpack
 
@@ -58,8 +58,8 @@ GEM
     json (2.7.2)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (13.1.0.1.0-aarch64-linux)
-    libdatadog (13.1.0.1.0-x86_64-linux)
+    libdatadog (14.0.0.1.0-aarch64-linux)
+    libdatadog (14.0.0.1.0-x86_64-linux)
     libddwaf (1.15.0.0.0-aarch64-linux)
       ffi (~> 1.0)
     libddwaf (1.15.0.0.0-x86_64-linux)

--- a/gemfiles/ruby_3.4_stripe_12.gemfile.lock
+++ b/gemfiles/ruby_3.4_stripe_12.gemfile.lock
@@ -20,7 +20,7 @@ PATH
   specs:
     datadog (2.4.0)
       datadog-ruby_core_source (~> 3.3)
-      libdatadog (~> 13.1.0.1.0)
+      libdatadog (~> 14.0.0.1.0)
       libddwaf (~> 1.15.0.0.0)
       msgpack
 
@@ -58,8 +58,8 @@ GEM
     json (2.7.2)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (13.1.0.1.0-aarch64-linux)
-    libdatadog (13.1.0.1.0-x86_64-linux)
+    libdatadog (14.0.0.1.0-aarch64-linux)
+    libdatadog (14.0.0.1.0-x86_64-linux)
     libddwaf (1.15.0.0.0-aarch64-linux)
       ffi (~> 1.0)
     libddwaf (1.15.0.0.0-x86_64-linux)

--- a/gemfiles/ruby_3.4_stripe_7.gemfile.lock
+++ b/gemfiles/ruby_3.4_stripe_7.gemfile.lock
@@ -20,7 +20,7 @@ PATH
   specs:
     datadog (2.4.0)
       datadog-ruby_core_source (~> 3.3)
-      libdatadog (~> 13.1.0.1.0)
+      libdatadog (~> 14.0.0.1.0)
       libddwaf (~> 1.15.0.0.0)
       msgpack
 
@@ -58,8 +58,8 @@ GEM
     json (2.7.2)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (13.1.0.1.0-aarch64-linux)
-    libdatadog (13.1.0.1.0-x86_64-linux)
+    libdatadog (14.0.0.1.0-aarch64-linux)
+    libdatadog (14.0.0.1.0-x86_64-linux)
     libddwaf (1.15.0.0.0-aarch64-linux)
       ffi (~> 1.0)
     libddwaf (1.15.0.0.0-x86_64-linux)

--- a/gemfiles/ruby_3.4_stripe_8.gemfile.lock
+++ b/gemfiles/ruby_3.4_stripe_8.gemfile.lock
@@ -20,7 +20,7 @@ PATH
   specs:
     datadog (2.4.0)
       datadog-ruby_core_source (~> 3.3)
-      libdatadog (~> 13.1.0.1.0)
+      libdatadog (~> 14.0.0.1.0)
       libddwaf (~> 1.15.0.0.0)
       msgpack
 
@@ -58,8 +58,8 @@ GEM
     json (2.7.2)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (13.1.0.1.0-aarch64-linux)
-    libdatadog (13.1.0.1.0-x86_64-linux)
+    libdatadog (14.0.0.1.0-aarch64-linux)
+    libdatadog (14.0.0.1.0-x86_64-linux)
     libddwaf (1.15.0.0.0-aarch64-linux)
       ffi (~> 1.0)
     libddwaf (1.15.0.0.0-x86_64-linux)

--- a/gemfiles/ruby_3.4_stripe_9.gemfile.lock
+++ b/gemfiles/ruby_3.4_stripe_9.gemfile.lock
@@ -20,7 +20,7 @@ PATH
   specs:
     datadog (2.4.0)
       datadog-ruby_core_source (~> 3.3)
-      libdatadog (~> 13.1.0.1.0)
+      libdatadog (~> 14.0.0.1.0)
       libddwaf (~> 1.15.0.0.0)
       msgpack
 
@@ -58,8 +58,8 @@ GEM
     json (2.7.2)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (13.1.0.1.0-aarch64-linux)
-    libdatadog (13.1.0.1.0-x86_64-linux)
+    libdatadog (14.0.0.1.0-aarch64-linux)
+    libdatadog (14.0.0.1.0-x86_64-linux)
     libddwaf (1.15.0.0.0-aarch64-linux)
       ffi (~> 1.0)
     libddwaf (1.15.0.0.0-x86_64-linux)

--- a/gemfiles/ruby_3.4_stripe_latest.gemfile.lock
+++ b/gemfiles/ruby_3.4_stripe_latest.gemfile.lock
@@ -20,7 +20,7 @@ PATH
   specs:
     datadog (2.4.0)
       datadog-ruby_core_source (~> 3.3)
-      libdatadog (~> 13.1.0.1.0)
+      libdatadog (~> 14.0.0.1.0)
       libddwaf (~> 1.15.0.0.0)
       msgpack
 
@@ -58,8 +58,8 @@ GEM
     json (2.7.2)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (13.1.0.1.0-aarch64-linux)
-    libdatadog (13.1.0.1.0-x86_64-linux)
+    libdatadog (14.0.0.1.0-aarch64-linux)
+    libdatadog (14.0.0.1.0-x86_64-linux)
     libddwaf (1.15.0.0.0-aarch64-linux)
       ffi (~> 1.0)
     libddwaf (1.15.0.0.0-x86_64-linux)

--- a/gemfiles/ruby_3.4_stripe_min.gemfile.lock
+++ b/gemfiles/ruby_3.4_stripe_min.gemfile.lock
@@ -20,7 +20,7 @@ PATH
   specs:
     datadog (2.4.0)
       datadog-ruby_core_source (~> 3.3)
-      libdatadog (~> 13.1.0.1.0)
+      libdatadog (~> 14.0.0.1.0)
       libddwaf (~> 1.15.0.0.0)
       msgpack
 
@@ -58,8 +58,8 @@ GEM
     json (2.7.2)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (13.1.0.1.0-aarch64-linux)
-    libdatadog (13.1.0.1.0-x86_64-linux)
+    libdatadog (14.0.0.1.0-aarch64-linux)
+    libdatadog (14.0.0.1.0-x86_64-linux)
     libddwaf (1.15.0.0.0-aarch64-linux)
       ffi (~> 1.0)
     libddwaf (1.15.0.0.0-x86_64-linux)


### PR DESCRIPTION
**What does this PR do?**

This PR upgrades the libdatadog dependency to the latest 14.0 release.

It also updates our API usage to match some 13.1 -> 14.0 changes.

**Motivation:**

The libdatadog 14.0 release includes a number of improvements to the crashtracking implementation, and we want to pick them up.

**Change log entry**
Upgraded libdatadog dependency to version 14.0

**Additional Notes:**

As a first pass, I've disabled the creation and use of the alt stack, to match our existing setup.

I did not yet experiment with `use_alt_stack = true`.

**How to test the change?**

Existing test coverage should be enough to cover our libdatadog API usage.