### PR TITLE
fix rack 3/rackup situation on ruby 3.4

### DIFF
--- a/appraisal/ruby-3.4.rb
+++ b/appraisal/ruby-3.4.rb
@@ -125,6 +125,9 @@ appraise 'contrib' do
   gem 'sneakers', '>= 2.12.0'
   gem 'sucker_punch'
   gem 'que', '>= 1.0.0'
+
+  # When Rack 3+ is used, we need rackup.
+  gem 'rackup'
 end
 
 [

--- a/gemfiles/ruby_3.4_contrib.gemfile
+++ b/gemfiles/ruby_3.4_contrib.gemfile
@@ -43,6 +43,7 @@ gem "sidekiq", "~> 7"
 gem "sneakers", ">= 2.12.0"
 gem "sucker_punch"
 gem "que", ">= 1.0.0"
+gem "rackup"
 
 group :check do
   gem "ruby_memcheck", ">= 3"

--- a/gemfiles/ruby_3.4_contrib.gemfile.lock
+++ b/gemfiles/ruby_3.4_contrib.gemfile.lock
@@ -113,6 +113,8 @@ GEM
       rack (>= 3.0.0)
     rack-test (2.1.0)
       rack (>= 1.3)
+    rackup (2.2.0)
+      rack (>= 3)
     rainbow (3.1.1)
     rake (12.3.3)
     rake-compiler (1.2.7)
@@ -247,6 +249,7 @@ DEPENDENCIES
   pry-stack_explorer
   que (>= 1.0.0)
   rack-test
+  rackup
   rake (>= 12.3)
   rake-compiler (~> 1.1, >= 1.1.1)
   resque

--- a/spec/datadog/tracing/contrib/suite/integration_spec.rb
+++ b/spec/datadog/tracing/contrib/suite/integration_spec.rb
@@ -8,7 +8,7 @@ require 'semantic_logger'
 
 require 'rack'
 # `Rack::Handler::WEBrick` was extracted to the `rackup` gem in Rack 3.0
-require 'rackup' if Rack::VERSION[0] >= 3
+require 'rackup' if Gem::Version.new(Rack::RELEASE) >= Gem::Version.new('3')
 require 'webrick'
 
 RSpec.describe 'contrib integration testing', :integration do


### PR DESCRIPTION
<!--
Check out the
https://github.com/DataDog/dd-trace-rb/blob/master/docs/DevelopmentGuide.md
for guidance on how to set up your development environment,
run the test suite, write new integrations, and more.
-->

**What does this PR do?**
<!-- A brief description of the change being made with this pull request. -->
rack 3.1.0 deletes Rack::VERSION constant (in
https://github.com/rack/rack/pull/1966),
causing our tests to fail.

Use Rack::RELEASE instead of Rack::VERSION
to work around the issue

**Motivation:**
<!-- What inspired you to submit this pull request? -->
Repairing CI in #4040 

**Change log entry**
<!-- If this is a customer-visible change, a brief summary to be placed
into the change log.
If you are not a Datadog employee, you can skip this section
and it will be filled or deleted during PR review. -->
None, changes are in test suite only.

**Additional Notes:**
<!-- Anything else we should know when reviewing? -->

**How to test the change?**
<!--
Describe here how the change can be validated.
You are strongly encouraged to provide automated tests for this PR (unit or integration).
If this change cannot be feasibly tested, please explain why,
unless the change does not modify code (e.g. only modifies docs, comments).
-->
I am assuming currently the tests lock rack to pre-3.1.0 therefore there aren't any failures on master, however #4059 exposed this failure when trying to get a new ruby 3.4 configuration going in circleci.
<!-- Unsure? Have a question? Request a review! -->
