### PR TITLE
Use BUNDLE_GEMFILE directly instead of appraisal binary

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -59,7 +59,7 @@ namespace :test do
         command = if appraisal_group.empty?
                     "bundle exec rake #{spec_task}"
                   else
-                    gemfile = File.join(File.dirname(__FILE__), "gemfiles", "#{ruby_runtime}-#{appraisal_group}.gemfile".tr('-', '_'))
+                    gemfile = File.join(File.dirname(__FILE__), 'gemfiles', "#{ruby_runtime}-#{appraisal_group}.gemfile".tr('-', '_'))
                     "env BUNDLE_GEMFILE=#{gemfile} bundle exec rake #{spec_task}"
                   end
 

--- a/Rakefile
+++ b/Rakefile
@@ -59,7 +59,8 @@ namespace :test do
         command = if appraisal_group.empty?
                     "bundle exec rake #{spec_task}"
                   else
-                    "bundle exec appraisal #{ruby_runtime}-#{appraisal_group} rake #{spec_task}"
+                    gemfile = File.join(File.dirname(__FILE__), "gemfiles", "#{ruby_runtime}-#{appraisal_group}.gemfile".tr('-', '_'))
+                    "env BUNDLE_GEMFILE=#{gemfile} bundle exec rake #{spec_task}"
                   end
 
         command += "'[#{spec_arguments}]'" if spec_arguments

--- a/docs/DevelopmentGuide.md
+++ b/docs/DevelopmentGuide.md
@@ -105,6 +105,24 @@ TEST_METADATA = {
 }
 ```
 
+**Using appraisal**
+
+`appraisal` command should only be used to update gemfiles in `gemfiles/`
+and install dependencies. It should not be used to run tests, since it does not
+work in all configurations. To run the tests, use:
+
+```sh
+env BUNDLE_GEMFILE=gemfiles/#{ruby_runtime}_#{appraisal_group}.gemfile rake #{spec_task}
+```
+
+Note that the file names use underscores while appraisal group and
+configuration definitions use dashes. The conversion could be performed as
+follows:
+
+```sh
+env BUNDLE_GEMFILE=gemfiles/#{ruby_runtime.tr('-', '_')}_#{appraisal_group.tr('-', '_')}.gemfile rake #{spec_task}
+```
+
 **Working with appraisal groups**
 
 Checkout [Apppraisal](https://github.com/thoughtbot/appraisal) to learn the basics.


### PR DESCRIPTION

**What does this PR do?**
appraisal binary appears to be incompatible with bundler 2.4+ that set BUNDLER_SETUP environment variable.
In some cases developers are already using BUNDLE_GEMFILE manually to invoke appraisal configurations, probably those using ruby 3.3 and newer.

This PR changes the rakefile to always use BUNDLE_GEMFILE approach, making it work for all Ruby versions, and adds documentation stating that appraisal binary does not work and to use the BUNDLE_GEMFILE manual approach.

<!-- A brief description of the change being made with this pull request. -->

**Motivation:**
<!-- What inspired you to submit this pull request? -->
Fixing CI in #4040

**Change log entry**
<!-- If this is a customer-visible change, a brief summary to be placed
into the change log.
If you are not a Datadog employee, you can skip this section
and it will be filled or deleted during PR review. -->
None

**Additional Notes:**
<!-- Anything else we should know when reviewing? -->

**How to test the change?**
Tested in #4059
<!--
Describe here how the change can be validated.
You are strongly encouraged to provide automated tests for this PR (unit or integration).
If this change cannot be feasibly tested, please explain why,
unless the change does not modify code (e.g. only modifies docs, comments).
-->

<!-- Unsure? Have a question? Request a review! -->
