### PR TITLE
[NO-TICKET] Fix flaky profiler spec by adjusting wait condition

### DIFF
--- a/spec/datadog/profiling/collectors/cpu_and_wall_time_worker_spec.rb
+++ b/spec/datadog/profiling/collectors/cpu_and_wall_time_worker_spec.rb
@@ -1023,7 +1023,7 @@ RSpec.describe Datadog::Profiling::Collectors::CpuAndWallTimeWorker do
 
         all_samples = try_wait_until do
           samples = samples_from_pprof_without_gc_and_overhead(recorder.serialize!)
-          samples if samples.any?
+          samples if samples_for_thread(samples, process_waiter_thread).any?
         end
 
         cpu_and_wall_time_worker.stop


### PR DESCRIPTION
**What does this PR do?**

This PR fixes a profiler flaky spec from
https://app.circleci.com/pipelines/github/DataDog/dd-trace-rb/17279/workflows/bafa8b55-7fee-414f-8875-c7a8ef8b56dd/jobs/615562 :

```
  1) Datadog::Profiling::Collectors::CpuAndWallTimeWorker#start Process::Waiter crash regression tests can sample an instance of Process::Waiter without crashing
     Failure/Error: expect(sample.locations.first.path).to eq "In native code"

     NoMethodError:
       undefined method `locations' for nil
```

The fix in this case is to make sure that we keep running the profiler until we observe a sample for the thread we expect, not just for any thread.

**Motivation:**

We aim to always have zero flaky specs in the profiler.

**Change log entry**

(No entry needed for this one)

**Additional Notes:**

If for some reason we're not able to sample the target thread, the test will still correctly fail (with the `try_wait_until` failing).

Fixes https://github.com/datadog/ruby-guild/issues/182

**How to test the change?**

Validate that CI is still green :)