### PR TITLE
fix: Apply DD_VERSION on all spans that use the default or global service name

### DIFF
--- a/lib/datadog/tracing/tracer.rb
+++ b/lib/datadog/tracing/tracer.rb
@@ -442,7 +442,7 @@ module Datadog
                         tags || @tags.dup
                       end
         # Remove version tag if service is not the default service
-        if merged_tags.key?(Core::Environment::Ext::TAG_VERSION) && service != @default_service
+        if merged_tags.key?(Core::Environment::Ext::TAG_VERSION) && service && service != @default_service
           merged_tags.delete(Core::Environment::Ext::TAG_VERSION)
         end
         merged_tags

--- a/spec/datadog/tracing/tracer_spec.rb
+++ b/spec/datadog/tracing/tracer_spec.rb
@@ -126,15 +126,45 @@ RSpec.describe Datadog::Tracing::Tracer do
             expect(span.get_tag('my')).to eq('tag')
           end
 
-          context 'contains version and span.service is not equal to the default tracer service' do
-            let(:tracer_options) { { default_service: 'global-service', tags: { version: '1.1.0' } } }
-            let(:service) { 'my-service' }
-            it 'does not set version on the span' do
-              expect(tracer.default_service).to eq('global-service')
-              expect(span.service).not_to eq('my-service')
+          context 'contains version and the span service name' do
+            let(:tracer_options) do
+              { default_service: 'global-service', tags: { Datadog::Core::Environment::Ext::TAG_VERSION => '1.1.0' } }
+            end
+            let(:options) { { service: service } }
 
-              expect(tracer.tags).to include(version: '1.1.0')
-              expect(span.tags).not_to include(:version)
+            context 'is nil' do
+              let(:service) { nil }
+
+              it 'sets version' do
+                expect(tracer.default_service).to eq('global-service')
+                expect(span.service).to eq('global-service')
+
+                expect(tracer.tags).to include('version' => '1.1.0')
+                expect(span.tags).to include('version' => '1.1.0')
+              end
+            end
+
+            context 'is equal to the default tracer service' do
+              let(:service) { 'global-service' }
+
+              it 'sets version' do
+                expect(tracer.default_service).to eq('global-service')
+                expect(span.service).to eq('global-service')
+
+                expect(tracer.tags).to include('version' => '1.1.0')
+                expect(span.tags).to include('version' => '1.1.0')
+              end
+            end
+
+            context 'is not equal to the default tracer service' do
+              let(:service) { 'local-service' }
+              it 'does not set version' do
+                expect(tracer.default_service).to eq('global-service')
+                expect(span.service).to eq('local-service')
+
+                expect(tracer.tags).to include('version' => '1.1.0')
+                expect(span.tags).not_to include('version' => '1.1.0')
+              end
             end
           end
 


### PR DESCRIPTION
**What does this PR do?**

Addresses a broken edge case introduced by: https://github.com/DataDog/dd-trace-rb/pull/4027. 

Edge Case: When a global service name and a global version are set (for example via DD_SERVICE and DD_VERSION) and a span is initialized without a service name, the global version MUST be set on the span. As of v2.5.0 this is no longer the case.

**Motivation:**

This bug was detected when v2.5.0 was released and the following system failed: [Test_Config_UnifiedServiceTagging::test_specific_version](https://github.com/DataDog/system-tests/actions/runs/11689546728/job/32553275066). 

**Change log entry**

Fix
- Tracing: Ensure the global version tag is set on spans that have the global service name.

**Additional Notes:**
<!-- Anything else we should know when reviewing? -->

**How to test the change?**
<!--
Describe here how the change can be validated.
You are strongly encouraged to provide automated tests for this PR (unit or integration).
If this change cannot be feasibly tested, please explain why,
unless the change does not modify code (e.g. only modifies docs, comments).
-->

<!-- Unsure? Have a question? Request a review! -->
