### PR TITLE
[NO-TICKET] Relax profiling CODEOWNERS configuration

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -13,9 +13,9 @@
 /lib/datadog/opentelemetry/ @DataDog/tracing-ruby
 /lib/datadog/opentelemetry.rb @DataDog/tracing-ruby
 /lib-injection/ @DataDog/tracing-ruby
-/lib/datadog/profiling/ @DataDog/profiling-rb
-/lib/datadog/profiling.rb @DataDog/profiling-rb
-/ext/ @DataDog/profiling-rb
+/lib/datadog/profiling/ @DataDog/profiling-rb @DataDog/ruby-guild
+/lib/datadog/profiling.rb @DataDog/profiling-rb @DataDog/ruby-guild
+/ext/ @DataDog/profiling-rb @DataDog/ruby-guild
 
 # RBS signatures
 /sig/datadog/appsec/ @DataDog/asm-ruby
@@ -25,8 +25,8 @@
 /sig/datadog/tracing.rbs @DataDog/tracing-ruby
 /sig/datadog/opentelemetry/ @DataDog/tracing-ruby
 /sig/datadog/opentelemetry.rbs @DataDog/tracing-ruby
-/sig/datadog/profiling/ @DataDog/profiling-rb
-/sig/datadog/profiling.rbs @DataDog/profiling-rb
+/sig/datadog/profiling/ @DataDog/profiling-rb @DataDog/ruby-guild
+/sig/datadog/profiling.rbs @DataDog/profiling-rb @DataDog/ruby-guild
 
 # Specs
 /spec/datadog/appsec/ @DataDog/asm-ruby
@@ -35,5 +35,5 @@
 /spec/datadog/tracing_spec.rb @DataDog/tracing-ruby
 /spec/datadog/opentelemetry/ @DataDog/tracing-ruby
 /spec/datadog/opentelemetry_spec.rb @DataDog/tracing-ruby
-/spec/datadog/profiling/ @DataDog/profiling-rb
-/spec/datadog/profiling_spec.rb @DataDog/profiling-rb
+/spec/datadog/profiling/ @DataDog/profiling-rb @DataDog/ruby-guild
+/spec/datadog/profiling_spec.rb @DataDog/profiling-rb @DataDog/ruby-guild


### PR DESCRIPTION
**What does this PR do?**

This PR relaxes the GitHub `CODEOWNERS` file rules for things related to profiling.

Specifically, it adds `@DataDog/ruby-guild` as a second owner on top of just `@DataDog/profiling-rb`.

**Motivation:**

Now that we've enableed the "Require review from Code Owners" feature on GitHub, since there's not a lot of us working on profiling, it hasn't worked very well.

Specifically, for very small PRs (#4072 is a good example where we slightly tweaked a test to avoid flakiness), it's annoying to have to wait for a very small reviewer pool, when most folks that are on the Ruby guild can help out review such changes.

**Change log entry**

(Not relevant, internal change)

**Additional Notes:**

N/A

**How to test the change?**

Check that future PRs affecting profiling can be merged with a review from anyone on the ruby-guild team.