### PR TITLE
Remove unintentional libddwaf require

### DIFF
--- a/lib/datadog/appsec/processor/context.rb
+++ b/lib/datadog/appsec/processor/context.rb
@@ -1,7 +1,5 @@
 # frozen_string_literal: true
 
-require 'libddwaf'
-
 module Datadog
   module AppSec
     class Processor


### PR DESCRIPTION
**What does this PR do?**

Remove unintentional require libddwaf library from the Context class.

**Motivation:**

This was a mistake which slipped through the review and coding.
Related: https://github.com/DataDog/dd-trace-rb/issues/4077

**Change log entry**

Yes.
Fix: Remove unnecessary require of libddwaf library which may cause crashing.

**Additional Notes:**

Probably this should be released as 2.5.1 patch release

**How to test the change?**

Ideally just CI.