### PR TITLE
Revert "Disable crashtracking by default"

### DIFF
--- a/lib/datadog/core/configuration/settings.rb
+++ b/lib/datadog/core/configuration/settings.rb
@@ -927,7 +927,7 @@ module Datadog
           # Enables reporting of information when Ruby VM crashes.
           option :enabled do |o|
             o.type :bool
-            o.default false
+            o.default true
             o.env 'DD_CRASHTRACKING_ENABLED'
           end
         end

--- a/spec/datadog/core/configuration/settings_spec.rb
+++ b/spec/datadog/core/configuration/settings_spec.rb
@@ -2075,7 +2075,7 @@ RSpec.describe Datadog::Core::Configuration::Settings do
         context 'is not defined' do
           let(:environment) { nil }
 
-          it { is_expected.to be false }
+          it { is_expected.to be true }
         end
 
         [true, false].each do |value|
@@ -2090,9 +2090,9 @@ RSpec.describe Datadog::Core::Configuration::Settings do
 
     describe '#enabled=' do
       it 'updates the #enabled setting' do
-        expect { settings.crashtracking.enabled = true }
+        expect { settings.crashtracking.enabled = false }
           .to change { settings.crashtracking.enabled }
-          .from(false).to(true)
+          .from(true).to(false)
       end
     end
   end


### PR DESCRIPTION
<!--
Check out the
https://github.com/DataDog/dd-trace-rb/blob/master/docs/DevelopmentGuide.md
for guidance on how to set up your development environment,
run the test suite, write new integrations, and more.
-->

**What does this PR do?**
<!-- A brief description of the change being made with this pull request. -->

This reverts commit c8a2165607cba186b3a3b23742448dc94e53f224 from https://github.com/DataDog/dd-trace-rb/pull/3970

**Motivation:**
<!-- What inspired you to submit this pull request? -->

https://github.com/DataDog/dd-trace-rb/pull/4082 fixed the root cause.

**Change log entry**
<!-- If this is a customer-visible change, a brief summary to be placed
into the change log.
If you are not a Datadog employee, you can skip this section
and it will be filled or deleted during PR review. -->

Default crashtracking to enabled.

**Additional Notes:**
<!-- Anything else we should know when reviewing? -->

**How to test the change?**
<!--
Describe here how the change can be validated.
You are strongly encouraged to provide automated tests for this PR (unit or integration).
If this change cannot be feasibly tested, please explain why,
unless the change does not modify code (e.g. only modifies docs, comments).
-->

CI

<!-- Unsure? Have a question? Request a review! -->
