### PR TITLE
[NO-TICKET] Minor: Clean up output of profiler rspec execution

### DIFF
--- a/spec/datadog/profiling/component_spec.rb
+++ b/spec/datadog/profiling/component_spec.rb
@@ -649,6 +649,8 @@ RSpec.describe Datadog::Profiling::Component do
           before { skip "Behavior does not apply to current Ruby version" if RUBY_VERSION >= "3.2." }
 
           it "does not enable GVL profiling" do
+            allow(Datadog.logger).to receive(:warn)
+
             expect(Datadog::Profiling::Collectors::CpuAndWallTimeWorker)
               .to receive(:new).with(hash_including(gvl_profiling_enabled: false))
 

--- a/spec/datadog/profiling/http_transport_spec.rb
+++ b/spec/datadog/profiling/http_transport_spec.rb
@@ -222,6 +222,7 @@ RSpec.describe Datadog::Profiling::HttpTransport do
         before do
           expect(described_class).to receive(:_native_do_export).and_return([:ok, 500])
           allow(Datadog.logger).to receive(:error)
+          allow(Datadog::Core::Telemetry::Logger).to receive(:error)
         end
 
         it "logs an error message" do
@@ -248,6 +249,7 @@ RSpec.describe Datadog::Profiling::HttpTransport do
         before do
           expect(described_class).to receive(:_native_do_export).and_return([:error, "Some error message"])
           allow(Datadog.logger).to receive(:error)
+          allow(Datadog::Core::Telemetry::Logger).to receive(:error)
         end
 
         it "logs an error message" do
@@ -440,6 +442,7 @@ RSpec.describe Datadog::Profiling::HttpTransport do
 
       it "logs an error" do
         expect(Datadog.logger).to receive(:error).with(/error trying to connect/)
+        expect(Datadog::Core::Telemetry::Logger).to receive(:error).with("Failed to report profiling data")
 
         http_transport.export(flush)
       end
@@ -451,6 +454,7 @@ RSpec.describe Datadog::Profiling::HttpTransport do
 
       it "logs an error" do
         expect(Datadog.logger).to receive(:error).with(/timed out/)
+        expect(Datadog::Core::Telemetry::Logger).to receive(:error).with("Failed to report profiling data")
 
         http_transport.export(flush)
       end
@@ -461,6 +465,8 @@ RSpec.describe Datadog::Profiling::HttpTransport do
 
       it "logs an error" do
         expect(Datadog.logger).to receive(:error).with(/unexpected HTTP 418/)
+        expect(Datadog::Core::Telemetry::Logger)
+          .to receive(:error).with("Failed to report profiling data: unexpected HTTP 418 status code")
 
         http_transport.export(flush)
       end
@@ -471,6 +477,8 @@ RSpec.describe Datadog::Profiling::HttpTransport do
 
       it "logs an error" do
         expect(Datadog.logger).to receive(:error).with(/unexpected HTTP 503/)
+        expect(Datadog::Core::Telemetry::Logger)
+          .to receive(:error).with("Failed to report profiling data: unexpected HTTP 503 status code")
 
         http_transport.export(flush)
       end

--- a/spec/datadog/profiling/stack_recorder_spec.rb
+++ b/spec/datadog/profiling/stack_recorder_spec.rb
@@ -929,6 +929,7 @@ RSpec.describe Datadog::Profiling::StackRecorder do
     context "when there is a failure during serialization" do
       before do
         allow(Datadog.logger).to receive(:error)
+        allow(Datadog::Core::Telemetry::Logger).to receive(:error)
 
         # Real failures in serialization are hard to trigger, so we're using a mock failure instead
         expect(described_class).to receive(:_native_serialize).and_return([:error, "test error message"])

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -108,7 +108,6 @@ RSpec.configure do |config|
     end
   end
 
-
   # Check for leaky test resources.
   #
   # Execute this after the test has finished

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -89,11 +89,17 @@ RSpec.configure do |config|
   config.wait_timeout = 5 # default timeout for `wait_for(...)`, in seconds
   config.wait_delay = 0.01 # default retry delay for `wait_for(...)`, in seconds
 
+  # This hides the list of skipped/pending specs by default
+  config.pending_failure_output = :skip
+
   if config.files_to_run.one?
     # Use the documentation formatter for detailed output,
     # unless a formatter has already been configured
     # (e.g. via a command-line flag).
     config.default_formatter = 'doc'
+
+    # List skipped/pending specs
+    config.pending_failure_output = :full
   end
 
   config.before(:example, ractors: true) do
@@ -101,6 +107,7 @@ RSpec.configure do |config|
       skip 'Skipping ractor tests. Use rake spec:profiling:ractors or pass -t ractors to rspec to run.'
     end
   end
+
 
   # Check for leaky test resources.
   #


### PR DESCRIPTION
**What does this PR do?**

This PR tweaks rspec and some of the profiler tests so that running `bundle exec rspec spec/datadog/profiling` gets a clean output:

```
Run options: include {:focus=>true}

All examples were filtered out; ignoring {:focus=>true}

Randomized with seed 34395
..........................................******..............................................................................*.*..................................................................**............**......*........*.....................*..............***.....*....*********.................******.............*..***********................*........................*.....**....*.....*.......................................................................................................................................................................*....**...*............................*..............................*..................................................................................................0.29.2
...


Finished in 14.4 seconds (files took 0.46237 seconds to load)
734 examples, 0 failures, 58 pending

Randomized with seed 34395
```

**Motivation:**

Make it easier to focus on failing specs, rather than on spec output noise.

**Change log entry**

(Does not impact customers)

**Additional Notes:**

N/A

**How to test the change?**

Validate that CI is still green + run the profiler test suite for yourself to see how the output is not noisy anymore!