### PR TITLE
[NO-TICKET] Re-enable ASAN memory leaks testing

### DIFF
--- a/.github/workflows/test-memory-leaks.yaml
+++ b/.github/workflows/test-memory-leaks.yaml
@@ -14,20 +14,10 @@ jobs:
       - run: sudo apt-get update && (sudo apt-get install -y valgrind || sleep 5 && sudo apt-get install -y valgrind) && valgrind --version
       - run: bundle exec rake compile spec:profiling:memcheck
   test-asan:
-    # Temporarily disabled on 2024-09-17 until ruby-asan builds are available again on
-    # https://github.com/ruby/ruby-dev-builder/releases
-    if: false
     runs-on: ubuntu-24.04
     steps:
       - uses: actions/checkout@v4
-      # We're using a fork of ruby/setup-ruby because the "asan" tool is built into the clang compiler toolchain, and
-      # needs Ruby to be built with a special configuration.
-      #
-      # The special configuration is not yet available in the upstream `ruby/setup-ruby` github action, so I needed to
-      # fork it and push a small tweak to make it available.
-      #
-      # (The Ruby builds were added in https://github.com/ruby/ruby-dev-builder/pull/10 ).
-      - uses: datadog/setup-ruby@0c7206d6db81faf999795ceebfac00d164298bd5
+      - uses: ruby/setup-ruby@v1
         with:
           ruby-version: asan
           bundler-cache: true # runs 'bundle install' and caches installed gems automatically


### PR DESCRIPTION
**What does this PR do?**

This PR re-enables the memory leak testing using the asan tool job in CI.

For context, we added this testing in #3864 (more details about what asan is can be found in that PR), but had to disable it in #3915 as the upstream Ruby builds we were using were broken and unavailable for a while.

This has since been fixed upstream, and so let's re-enable this CI job.

In fact, upstream now officially allows these builds to be used, so we no longer even need our fork of `setup-ruby` to enable them.

**Motivation:**

Improve our testing for native memory leaks.

**Change log entry**

(Not relevant, testing-only)

**Additional Notes:**

N/A

**How to test the change?**

Validate that the "test-asan" is now running in CI. Here's a successful run on "test-asan" in CI with this branch: https://github.com/DataDog/dd-trace-rb/actions/runs/11726300446/job/32664597998 .