### PR TITLE
Update `uri` for all dependencies

### DIFF
--- a/gemfiles/jruby_9.4_elasticsearch_7.gemfile.lock
+++ b/gemfiles/jruby_9.4_elasticsearch_7.gemfile.lock
@@ -145,7 +145,7 @@ GEM
     strscan (3.1.0-java)
     thor (1.2.2)
     unicode-display_width (2.5.0)
-    uri (0.13.1)
+    uri (1.0.1)
     warning (1.3.0)
     webmock (3.19.1)
       addressable (>= 2.8.0)

--- a/gemfiles/jruby_9.4_elasticsearch_8.gemfile.lock
+++ b/gemfiles/jruby_9.4_elasticsearch_8.gemfile.lock
@@ -143,7 +143,7 @@ GEM
     strscan (3.1.0-java)
     thor (1.2.2)
     unicode-display_width (2.5.0)
-    uri (0.13.1)
+    uri (1.0.1)
     warning (1.3.0)
     webmock (3.19.1)
       addressable (>= 2.8.0)

--- a/gemfiles/jruby_9.4_elasticsearch_latest.gemfile.lock
+++ b/gemfiles/jruby_9.4_elasticsearch_latest.gemfile.lock
@@ -143,7 +143,7 @@ GEM
       ffi
     thor (1.3.2)
     unicode-display_width (2.6.0)
-    uri (0.13.1)
+    uri (1.0.1)
     warning (1.4.0)
     webmock (3.23.1)
       addressable (>= 2.8.0)

--- a/gemfiles/jruby_9.4_opensearch_2.gemfile.lock
+++ b/gemfiles/jruby_9.4_opensearch_2.gemfile.lock
@@ -143,7 +143,7 @@ GEM
     strscan (3.1.0-java)
     thor (1.2.2)
     unicode-display_width (2.5.0)
-    uri (0.13.1)
+    uri (1.0.1)
     warning (1.3.0)
     webmock (3.19.1)
       addressable (>= 2.8.0)

--- a/gemfiles/jruby_9.4_opensearch_3.gemfile.lock
+++ b/gemfiles/jruby_9.4_opensearch_3.gemfile.lock
@@ -138,7 +138,7 @@ GEM
     strscan (3.1.0-java)
     thor (1.2.2)
     unicode-display_width (2.5.0)
-    uri (0.13.1)
+    uri (1.0.1)
     warning (1.3.0)
     webmock (3.19.1)
       addressable (>= 2.8.0)

--- a/gemfiles/jruby_9.4_opensearch_latest.gemfile.lock
+++ b/gemfiles/jruby_9.4_opensearch_latest.gemfile.lock
@@ -138,7 +138,7 @@ GEM
       ffi
     thor (1.3.2)
     unicode-display_width (2.6.0)
-    uri (0.13.1)
+    uri (1.0.1)
     warning (1.4.0)
     webmock (3.23.1)
       addressable (>= 2.8.0)

--- a/gemfiles/ruby_3.0_elasticsearch_7.gemfile.lock
+++ b/gemfiles/ruby_3.0_elasticsearch_7.gemfile.lock
@@ -155,7 +155,7 @@ GEM
     strscan (3.1.0)
     thor (1.2.2)
     unicode-display_width (2.5.0)
-    uri (0.13.1)
+    uri (1.0.1)
     warning (1.3.0)
     webmock (3.19.1)
       addressable (>= 2.8.0)

--- a/gemfiles/ruby_3.0_elasticsearch_8.gemfile.lock
+++ b/gemfiles/ruby_3.0_elasticsearch_8.gemfile.lock
@@ -153,7 +153,7 @@ GEM
     strscan (3.1.0)
     thor (1.2.2)
     unicode-display_width (2.5.0)
-    uri (0.13.1)
+    uri (1.0.1)
     warning (1.3.0)
     webmock (3.19.1)
       addressable (>= 2.8.0)

--- a/gemfiles/ruby_3.0_elasticsearch_latest.gemfile.lock
+++ b/gemfiles/ruby_3.0_elasticsearch_latest.gemfile.lock
@@ -153,7 +153,7 @@ GEM
     simplecov_json_formatter (0.1.4)
     thor (1.3.2)
     unicode-display_width (2.6.0)
-    uri (0.13.1)
+    uri (1.0.1)
     warning (1.4.0)
     webmock (3.23.1)
       addressable (>= 2.8.0)

--- a/gemfiles/ruby_3.0_opensearch_2.gemfile.lock
+++ b/gemfiles/ruby_3.0_opensearch_2.gemfile.lock
@@ -153,7 +153,7 @@ GEM
     strscan (3.1.0)
     thor (1.2.2)
     unicode-display_width (2.5.0)
-    uri (0.13.1)
+    uri (1.0.1)
     warning (1.3.0)
     webmock (3.19.1)
       addressable (>= 2.8.0)

--- a/gemfiles/ruby_3.0_opensearch_3.gemfile.lock
+++ b/gemfiles/ruby_3.0_opensearch_3.gemfile.lock
@@ -148,7 +148,7 @@ GEM
     strscan (3.1.0)
     thor (1.2.2)
     unicode-display_width (2.5.0)
-    uri (0.13.1)
+    uri (1.0.1)
     warning (1.3.0)
     webmock (3.19.1)
       addressable (>= 2.8.0)

--- a/gemfiles/ruby_3.0_opensearch_latest.gemfile.lock
+++ b/gemfiles/ruby_3.0_opensearch_latest.gemfile.lock
@@ -148,7 +148,7 @@ GEM
     simplecov_json_formatter (0.1.4)
     thor (1.3.2)
     unicode-display_width (2.6.0)
-    uri (0.13.1)
+    uri (1.0.1)
     warning (1.4.0)
     webmock (3.23.1)
       addressable (>= 2.8.0)

--- a/gemfiles/ruby_3.1_elasticsearch_7.gemfile.lock
+++ b/gemfiles/ruby_3.1_elasticsearch_7.gemfile.lock
@@ -155,7 +155,7 @@ GEM
     strscan (3.1.0)
     thor (1.2.2)
     unicode-display_width (2.5.0)
-    uri (0.13.1)
+    uri (1.0.1)
     warning (1.3.0)
     webmock (3.19.1)
       addressable (>= 2.8.0)

--- a/gemfiles/ruby_3.1_elasticsearch_8.gemfile.lock
+++ b/gemfiles/ruby_3.1_elasticsearch_8.gemfile.lock
@@ -153,7 +153,7 @@ GEM
     strscan (3.1.0)
     thor (1.2.2)
     unicode-display_width (2.5.0)
-    uri (0.13.1)
+    uri (1.0.1)
     warning (1.3.0)
     webmock (3.19.1)
       addressable (>= 2.8.0)

--- a/gemfiles/ruby_3.1_elasticsearch_latest.gemfile.lock
+++ b/gemfiles/ruby_3.1_elasticsearch_latest.gemfile.lock
@@ -153,7 +153,7 @@ GEM
     simplecov_json_formatter (0.1.4)
     thor (1.3.2)
     unicode-display_width (2.6.0)
-    uri (0.13.1)
+    uri (1.0.1)
     warning (1.4.0)
     webmock (3.23.1)
       addressable (>= 2.8.0)

--- a/gemfiles/ruby_3.1_opensearch_2.gemfile.lock
+++ b/gemfiles/ruby_3.1_opensearch_2.gemfile.lock
@@ -153,7 +153,7 @@ GEM
     strscan (3.1.0)
     thor (1.2.2)
     unicode-display_width (2.5.0)
-    uri (0.13.1)
+    uri (1.0.1)
     warning (1.3.0)
     webmock (3.19.1)
       addressable (>= 2.8.0)

--- a/gemfiles/ruby_3.1_opensearch_3.gemfile.lock
+++ b/gemfiles/ruby_3.1_opensearch_3.gemfile.lock
@@ -148,7 +148,7 @@ GEM
     strscan (3.1.0)
     thor (1.2.2)
     unicode-display_width (2.5.0)
-    uri (0.13.1)
+    uri (1.0.1)
     warning (1.3.0)
     webmock (3.19.1)
       addressable (>= 2.8.0)

--- a/gemfiles/ruby_3.1_opensearch_latest.gemfile.lock
+++ b/gemfiles/ruby_3.1_opensearch_latest.gemfile.lock
@@ -148,7 +148,7 @@ GEM
     simplecov_json_formatter (0.1.4)
     thor (1.3.2)
     unicode-display_width (2.6.0)
-    uri (0.13.1)
+    uri (1.0.1)
     warning (1.4.0)
     webmock (3.23.1)
       addressable (>= 2.8.0)

--- a/gemfiles/ruby_3.2_elasticsearch_7.gemfile.lock
+++ b/gemfiles/ruby_3.2_elasticsearch_7.gemfile.lock
@@ -151,7 +151,7 @@ GEM
     strscan (3.1.0)
     thor (1.2.2)
     unicode-display_width (2.5.0)
-    uri (0.13.1)
+    uri (1.0.1)
     warning (1.3.0)
     webmock (3.19.1)
       addressable (>= 2.8.0)

--- a/gemfiles/ruby_3.2_elasticsearch_8.gemfile.lock
+++ b/gemfiles/ruby_3.2_elasticsearch_8.gemfile.lock
@@ -149,7 +149,7 @@ GEM
     strscan (3.1.0)
     thor (1.2.2)
     unicode-display_width (2.5.0)
-    uri (0.13.1)
+    uri (1.0.1)
     warning (1.3.0)
     webmock (3.19.1)
       addressable (>= 2.8.0)

--- a/gemfiles/ruby_3.2_elasticsearch_latest.gemfile.lock
+++ b/gemfiles/ruby_3.2_elasticsearch_latest.gemfile.lock
@@ -149,7 +149,7 @@ GEM
     simplecov_json_formatter (0.1.4)
     thor (1.3.2)
     unicode-display_width (2.6.0)
-    uri (0.13.1)
+    uri (1.0.1)
     warning (1.4.0)
     webmock (3.23.1)
       addressable (>= 2.8.0)

--- a/gemfiles/ruby_3.2_opensearch_2.gemfile.lock
+++ b/gemfiles/ruby_3.2_opensearch_2.gemfile.lock
@@ -149,7 +149,7 @@ GEM
     strscan (3.1.0)
     thor (1.2.2)
     unicode-display_width (2.5.0)
-    uri (0.13.1)
+    uri (1.0.1)
     warning (1.3.0)
     webmock (3.19.1)
       addressable (>= 2.8.0)

--- a/gemfiles/ruby_3.2_opensearch_3.gemfile.lock
+++ b/gemfiles/ruby_3.2_opensearch_3.gemfile.lock
@@ -144,7 +144,7 @@ GEM
     strscan (3.1.0)
     thor (1.2.2)
     unicode-display_width (2.5.0)
-    uri (0.13.1)
+    uri (1.0.1)
     warning (1.3.0)
     webmock (3.19.1)
       addressable (>= 2.8.0)

--- a/gemfiles/ruby_3.2_opensearch_latest.gemfile.lock
+++ b/gemfiles/ruby_3.2_opensearch_latest.gemfile.lock
@@ -144,7 +144,7 @@ GEM
     simplecov_json_formatter (0.1.4)
     thor (1.3.2)
     unicode-display_width (2.6.0)
-    uri (0.13.1)
+    uri (1.0.1)
     warning (1.4.0)
     webmock (3.23.1)
       addressable (>= 2.8.0)

--- a/gemfiles/ruby_3.3_elasticsearch_7.gemfile.lock
+++ b/gemfiles/ruby_3.3_elasticsearch_7.gemfile.lock
@@ -150,7 +150,7 @@ GEM
     strscan (3.1.0)
     thor (1.2.2)
     unicode-display_width (2.5.0)
-    uri (0.13.1)
+    uri (1.0.1)
     warning (1.3.0)
     webmock (3.19.1)
       addressable (>= 2.8.0)

--- a/gemfiles/ruby_3.3_elasticsearch_8.gemfile.lock
+++ b/gemfiles/ruby_3.3_elasticsearch_8.gemfile.lock
@@ -148,7 +148,7 @@ GEM
     strscan (3.1.0)
     thor (1.2.2)
     unicode-display_width (2.5.0)
-    uri (0.13.1)
+    uri (1.0.1)
     warning (1.3.0)
     webmock (3.19.1)
       addressable (>= 2.8.0)

--- a/gemfiles/ruby_3.3_elasticsearch_latest.gemfile.lock
+++ b/gemfiles/ruby_3.3_elasticsearch_latest.gemfile.lock
@@ -149,7 +149,7 @@ GEM
     simplecov_json_formatter (0.1.4)
     thor (1.3.2)
     unicode-display_width (2.6.0)
-    uri (0.13.1)
+    uri (1.0.1)
     warning (1.4.0)
     webmock (3.23.1)
       addressable (>= 2.8.0)

--- a/gemfiles/ruby_3.3_opensearch_2.gemfile.lock
+++ b/gemfiles/ruby_3.3_opensearch_2.gemfile.lock
@@ -148,7 +148,7 @@ GEM
     strscan (3.1.0)
     thor (1.2.2)
     unicode-display_width (2.5.0)
-    uri (0.13.1)
+    uri (1.0.1)
     warning (1.3.0)
     webmock (3.19.1)
       addressable (>= 2.8.0)

--- a/gemfiles/ruby_3.3_opensearch_3.gemfile.lock
+++ b/gemfiles/ruby_3.3_opensearch_3.gemfile.lock
@@ -143,7 +143,7 @@ GEM
     strscan (3.1.0)
     thor (1.2.2)
     unicode-display_width (2.5.0)
-    uri (0.13.1)
+    uri (1.0.1)
     warning (1.3.0)
     webmock (3.19.1)
       addressable (>= 2.8.0)

--- a/gemfiles/ruby_3.3_opensearch_latest.gemfile.lock
+++ b/gemfiles/ruby_3.3_opensearch_latest.gemfile.lock
@@ -144,7 +144,7 @@ GEM
     simplecov_json_formatter (0.1.4)
     thor (1.3.2)
     unicode-display_width (2.6.0)
-    uri (0.13.1)
+    uri (1.0.1)
     warning (1.4.0)
     webmock (3.23.1)
       addressable (>= 2.8.0)

--- a/gemfiles/ruby_3.4_elasticsearch_7.gemfile.lock
+++ b/gemfiles/ruby_3.4_elasticsearch_7.gemfile.lock
@@ -164,7 +164,7 @@ GEM
     strscan (3.1.1)
     thor (1.3.1)
     unicode-display_width (2.5.0)
-    uri (0.13.1)
+    uri (1.0.1)
     warning (1.4.0)
     webmock (3.23.1)
       addressable (>= 2.8.0)

--- a/gemfiles/ruby_3.4_elasticsearch_8.gemfile.lock
+++ b/gemfiles/ruby_3.4_elasticsearch_8.gemfile.lock
@@ -162,7 +162,7 @@ GEM
     strscan (3.1.1)
     thor (1.3.1)
     unicode-display_width (2.5.0)
-    uri (0.13.1)
+    uri (1.0.1)
     warning (1.4.0)
     webmock (3.23.1)
       addressable (>= 2.8.0)

--- a/gemfiles/ruby_3.4_elasticsearch_latest.gemfile.lock
+++ b/gemfiles/ruby_3.4_elasticsearch_latest.gemfile.lock
@@ -160,7 +160,7 @@ GEM
     simplecov_json_formatter (0.1.4)
     thor (1.3.2)
     unicode-display_width (2.6.0)
-    uri (0.13.1)
+    uri (1.0.1)
     warning (1.4.0)
     webmock (3.23.1)
       addressable (>= 2.8.0)

--- a/gemfiles/ruby_3.4_http.gemfile.lock
+++ b/gemfiles/ruby_3.4_http.gemfile.lock
@@ -183,7 +183,7 @@ GEM
     typhoeus (1.4.1)
       ethon (>= 0.9.0)
     unicode-display_width (2.5.0)
-    uri (0.13.0)
+    uri (1.0.1)
     warning (1.4.0)
     webmock (3.23.1)
       addressable (>= 2.8.0)

--- a/gemfiles/ruby_3.4_opensearch_2.gemfile.lock
+++ b/gemfiles/ruby_3.4_opensearch_2.gemfile.lock
@@ -162,7 +162,7 @@ GEM
     strscan (3.1.1)
     thor (1.3.1)
     unicode-display_width (2.5.0)
-    uri (0.13.1)
+    uri (1.0.1)
     warning (1.4.0)
     webmock (3.23.1)
       addressable (>= 2.8.0)

--- a/gemfiles/ruby_3.4_opensearch_3.gemfile.lock
+++ b/gemfiles/ruby_3.4_opensearch_3.gemfile.lock
@@ -157,7 +157,7 @@ GEM
     strscan (3.1.1)
     thor (1.3.1)
     unicode-display_width (2.5.0)
-    uri (0.13.1)
+    uri (1.0.1)
     warning (1.4.0)
     webmock (3.23.1)
       addressable (>= 2.8.0)

--- a/gemfiles/ruby_3.4_opensearch_latest.gemfile.lock
+++ b/gemfiles/ruby_3.4_opensearch_latest.gemfile.lock
@@ -155,7 +155,7 @@ GEM
     simplecov_json_formatter (0.1.4)
     thor (1.3.2)
     unicode-display_width (2.6.0)
-    uri (0.13.1)
+    uri (1.0.1)
     warning (1.4.0)
     webmock (3.23.1)
       addressable (>= 2.8.0)


### PR DESCRIPTION
**Motivation:**

`uri` (one of the default ruby gems) upgraded, and our lockfiles are stale, failing CI
https://app.circleci.com/pipelines/github/DataDog/dd-trace-rb/17411/workflows/f191263c-fc1c-4b65-a5d8-be6ba1549181/jobs/619211

**What does this PR do?**

Bump `uri` to the latest version