### PR TITLE
Update use of rack vs rackup

### DIFF
--- a/spec/datadog/tracing/contrib/suite/integration_spec.rb
+++ b/spec/datadog/tracing/contrib/suite/integration_spec.rb
@@ -8,7 +8,7 @@ require 'semantic_logger'
 
 require 'rack'
 # `Rack::Handler::WEBrick` was extracted to the `rackup` gem in Rack 3.0
-require 'rackup' if Gem::Version.new(Rack::RELEASE) >= Gem::Version.new('3')
+require 'rackup/handler/webrick' if Gem::Version.new(Rack::RELEASE) >= Gem::Version.new('3')
 require 'webrick'
 
 RSpec.describe 'contrib integration testing', :integration do
@@ -164,7 +164,11 @@ RSpec.describe 'contrib integration testing', :integration do
             end
           end.to_app
 
-          server.mount '/', Rack::Handler::WEBrick, app
+          if Gem::Version.new(Rack::RELEASE) >= Gem::Version.new('3')
+            server.mount '/', Rackup::Handler::WEBrick, app
+          else
+            server.mount '/', Rack::Handler::WEBrick, app
+          end
 
           @thread = Thread.new { server.start }
           try_wait_until { started }


### PR DESCRIPTION
<!--
Check out the
https://github.com/DataDog/dd-trace-rb/blob/master/docs/DevelopmentGuide.md
for guidance on how to set up your development environment,
run the test suite, write new integrations, and more.
-->

**What does this PR do?**
This PR specifies `Rackup::Handler::WEBrick` for versions of Rack >= 3.

**Motivation:**
`Rack::Handler::WEBrick` was extracted to the `rackup` gem in Rack 3.0. We were already requiring `rackup` for relevant Rack versions, so this propagates that change in the code below.

**Change log entry**
No change log needed.

**Additional Notes:**
<!-- Anything else we should know when reviewing? -->

**How to test the change?**
CI

<!-- Unsure? Have a question? Request a review! -->
