### PR TITLE
Adjust OTel Spec for new Ruby 3.4 syntax

### DIFF
--- a/spec/datadog/opentelemetry_spec.rb
+++ b/spec/datadog/opentelemetry_spec.rb
@@ -630,11 +630,11 @@ RSpec.describe Datadog::OpenTelemetry do
             expect(span.events[0].attributes['exception.message']).to eq('Error')
             expect(span.events[0].attributes['exception.type']).to eq('StandardError')
             expect(span.events[0].attributes['exception.stacktrace']).to include(
-              ":in `full_message': Error (StandardError)"
+              "full_message': Error (StandardError)"
             )
             expect(span).to_not have_error
             expect(span).to have_error_message('Error')
-            expect(span).to have_error_stack(include(":in `full_message': Error (StandardError)"))
+            expect(span).to have_error_stack(include("full_message': Error (StandardError)"))
             expect(span).to have_error_type('StandardError')
           end
         end
@@ -649,7 +649,7 @@ RSpec.describe Datadog::OpenTelemetry do
           expect(span.events[0].attributes).to eq({})
           expect(span).to_not have_error
           expect(span).to have_error_message('Error')
-          expect(span).to have_error_stack(include(":in `full_message': Error (StandardError)"))
+          expect(span).to have_error_stack(include("full_message': Error (StandardError)"))
           expect(span).to have_error_type('StandardError')
         end
       end


### PR DESCRIPTION
<!--
Check out the
https://github.com/DataDog/dd-trace-rb/blob/master/docs/DevelopmentGuide.md
for guidance on how to set up your development environment,
run the test suite, write new integrations, and more.
-->

**What does this PR do?**
Removes the beginning ":in `" in three tests.

**Motivation:**
Ruby 3.4 changes ` to ' at the beginning of strings. See [here](https://www.ruby-lang.org/en/news/2024/10/07/ruby-3-4-0-preview2-released/). This PR adjusts our spec to account for this change.

**Change log entry**
No change log needed.

**Additional Notes:**
<!-- Anything else we should know when reviewing? -->

**How to test the change?**
Green CI.

<!-- Unsure? Have a question? Request a review! -->
