### PR TITLE
Remove static dependency task for each group

### DIFF
--- a/tasks/dependency.rake
+++ b/tasks/dependency.rake
@@ -3,11 +3,13 @@ require 'open3'
 require_relative 'appraisal_conversion'
 
 namespace :dependency do
-  gemfiles = Dir.glob(AppraisalConversion.gemfile_pattern)
-
   # Replacement for `bundle exec appraisal list`
   desc "List dependencies for #{AppraisalConversion.runtime_identifier}"
-  task :list do
+  task :list do |t, args|
+    pattern = args.extras.any? ? args.extras : AppraisalConversion.gemfile_pattern
+
+    gemfiles = Dir.glob(pattern, base: AppraisalConversion.root_path)
+
     puts "Ahoy! Here is a list of gemfiles you are looking for:\n\n"
 
     puts "========================================\n"
@@ -18,62 +20,37 @@ namespace :dependency do
     puts "`BUNDLE_GEMFILE=#{gemfiles.sample} bundle install`\n\n"
   end
 
-  namespace :lock do
-    gemfiles.each do |gemfile|
-      # desc "Lock dependencies for #{gemfile}"
-      task gemfile do
-        Bundler.with_unbundled_env do
-          command = +'bundle lock'
-          command << ' --add-platform x86_64-linux aarch64-linux' unless RUBY_PLATFORM == 'java'
-          output, = Open3.capture2e({ 'BUNDLE_GEMFILE' => gemfile.to_s }, command)
-
-          puts output
-        end
-      end
-    end
-  end
-
-  # WHY can't we use `multitask` here?
-  #
-  # Running bundler in parallel has various race conditions
-  #
-  # Race condition with the file system, particularly worse with JRuby.
-  # For instance, `Errno::ENOENT: No such file or directory - bundle` is raised with JRuby 9.2
-
-  # Even with CRuby, `simplcov` declaration with `github` in Gemfile causes
-  # race condition for the local gem cache with the following error:
-
-  # ```
-  # [/usr/local/bundle/bundler/gems/simplecov-3bb6b7ee58bf/simplecov.gemspec] isn't a Gem::Specification (NilClass instead).
-  # ```
-
-  # and
-
-  # ```
-  # fatal: Unable to create '/usr/local/bundle/bundler/gems/simplecov-3bb6b7ee58bf/.git/index.lock': File exists.
-  # Another git process seems to be running in this repository, e.g.
-  # an editor opened by 'git commit'. Please make sure all processes
-  # are terminated then try again. If it still fails, a git process
-  # may have crashed in this repository earlier:
-  # remove the file manually to continue.
-  # ```
+  # Replacement for `bundle exec appraisal bundle lock`
   desc "Lock dependencies for #{AppraisalConversion.runtime_identifier}"
-  task :lock => gemfiles.map { |gemfile| "lock:#{gemfile}" }
+  task :lock do |t, args|
+    pattern = args.extras.any? ? args.extras : AppraisalConversion.gemfile_pattern
 
-  namespace :install do
+    gemfiles = Dir.glob(pattern)
+
     gemfiles.each do |gemfile|
-      # desc "Install dependencies for #{gemfile}"
-      task gemfile => "lock:#{gemfile}" do
-        Bundler.with_unbundled_env do
-          output, = Open3.capture2e({ 'BUNDLE_GEMFILE' => gemfile.to_s }, "bundle check || bundle install")
+      Bundler.with_unbundled_env do
+        command = +'bundle lock'
+        command << ' --add-platform x86_64-linux aarch64-linux' unless RUBY_PLATFORM == 'java'
+        output, = Open3.capture2e({ 'BUNDLE_GEMFILE' => gemfile.to_s }, command)
 
-          puts output
-        end
+        puts output
       end
     end
   end
 
   # Replacement for `bundle exec appraisal install`
   desc "Install dependencies for #{AppraisalConversion.runtime_identifier}"
-  task :install => gemfiles.map { |gemfile| "install:#{gemfile}" }
+  task :install => :lock do |t, args|
+    pattern = args.extras.any? ? args.extras : AppraisalConversion.gemfile_pattern
+
+    gemfiles = Dir.glob(pattern)
+
+    gemfiles.each do |gemfile|
+      Bundler.with_unbundled_env do
+        output, = Open3.capture2e({ 'BUNDLE_GEMFILE' => gemfile.to_s }, "bundle check || bundle install")
+
+        puts output
+      end
+    end
+  end
 end

--- a/tasks/dependency.rake
+++ b/tasks/dependency.rake
@@ -2,48 +2,78 @@ require 'open3'
 
 require_relative 'appraisal_conversion'
 
-task :dep => :dependency
-task :dependency => %w[dependency:lock]
 namespace :dependency do
-  # rubocop:disable Style/MultilineBlockChain
-  Dir.glob(AppraisalConversion.gemfile_pattern).each do |gemfile|
-    # desc "Lock the dependencies for #{gemfile}"
-    task gemfile do
-      Bundler.with_unbundled_env do
-        command = +'bundle lock'
-        command << ' --add-platform x86_64-linux aarch64-linux' unless RUBY_PLATFORM == 'java'
-        output, = Open3.capture2e({ 'BUNDLE_GEMFILE' => gemfile.to_s }, command)
+  gemfiles = Dir.glob(AppraisalConversion.gemfile_pattern)
 
-        puts output
+  # Replacement for `bundle exec appraisal list`
+  desc "List dependencies for #{AppraisalConversion.runtime_identifier}"
+  task :list do
+    puts "Ahoy! Here is a list of gemfiles you are looking for:\n\n"
+
+    puts "========================================\n"
+    puts gemfiles
+    puts "========================================\n"
+
+    puts "You can do a bunch of cool stuff by assign it to the BUNDLE_GEMFILE environment variable, like:\n"
+    puts "`BUNDLE_GEMFILE=#{gemfiles.sample} bundle install`\n\n"
+  end
+
+  namespace :lock do
+    gemfiles.each do |gemfile|
+      # desc "Lock dependencies for #{gemfile}"
+      task gemfile do
+        Bundler.with_unbundled_env do
+          command = +'bundle lock'
+          command << ' --add-platform x86_64-linux aarch64-linux' unless RUBY_PLATFORM == 'java'
+          output, = Open3.capture2e({ 'BUNDLE_GEMFILE' => gemfile.to_s }, command)
+
+          puts output
+        end
       end
     end
-  end.tap do |gemfiles|
-    desc "Lock the dependencies for #{AppraisalConversion.runtime_identifier}"
-    # WHY can't we use `multitask :lock => gemfiles` here?
-    #
-    # Running bundler in parallel has various race conditions
-    #
-    # Race condition with the file system, particularly worse with JRuby.
-    # For instance, `Errno::ENOENT: No such file or directory - bundle` is raised with JRuby 9.2
-
-    # Even with CRuby, `simplcov` declaration with `github` in Gemfile causes
-    # race condition for the local gem cache with the following error:
-
-    # ```
-    # [/usr/local/bundle/bundler/gems/simplecov-3bb6b7ee58bf/simplecov.gemspec] isn't a Gem::Specification (NilClass instead).
-    # ```
-
-    # and
-
-    # ```
-    # fatal: Unable to create '/usr/local/bundle/bundler/gems/simplecov-3bb6b7ee58bf/.git/index.lock': File exists.
-    # Another git process seems to be running in this repository, e.g.
-    # an editor opened by 'git commit'. Please make sure all processes
-    # are terminated then try again. If it still fails, a git process
-    # may have crashed in this repository earlier:
-    # remove the file manually to continue.
-    # ```
-    task :lock => gemfiles
   end
-  # rubocop:enable Style/MultilineBlockChain
+
+  # WHY can't we use `multitask` here?
+  #
+  # Running bundler in parallel has various race conditions
+  #
+  # Race condition with the file system, particularly worse with JRuby.
+  # For instance, `Errno::ENOENT: No such file or directory - bundle` is raised with JRuby 9.2
+
+  # Even with CRuby, `simplcov` declaration with `github` in Gemfile causes
+  # race condition for the local gem cache with the following error:
+
+  # ```
+  # [/usr/local/bundle/bundler/gems/simplecov-3bb6b7ee58bf/simplecov.gemspec] isn't a Gem::Specification (NilClass instead).
+  # ```
+
+  # and
+
+  # ```
+  # fatal: Unable to create '/usr/local/bundle/bundler/gems/simplecov-3bb6b7ee58bf/.git/index.lock': File exists.
+  # Another git process seems to be running in this repository, e.g.
+  # an editor opened by 'git commit'. Please make sure all processes
+  # are terminated then try again. If it still fails, a git process
+  # may have crashed in this repository earlier:
+  # remove the file manually to continue.
+  # ```
+  desc "Lock dependencies for #{AppraisalConversion.runtime_identifier}"
+  task :lock => gemfiles.map { |gemfile| "lock:#{gemfile}" }
+
+  namespace :install do
+    gemfiles.each do |gemfile|
+      # desc "Install dependencies for #{gemfile}"
+      task gemfile => "lock:#{gemfile}" do
+        Bundler.with_unbundled_env do
+          output, = Open3.capture2e({ 'BUNDLE_GEMFILE' => gemfile.to_s }, "bundle check || bundle install")
+
+          puts output
+        end
+      end
+    end
+  end
+
+  # Replacement for `bundle exec appraisal install`
+  desc "Install dependencies for #{AppraisalConversion.runtime_identifier}"
+  task :install => gemfiles.map { |gemfile| "install:#{gemfile}" }
 end

--- a/tasks/dependency.rake
+++ b/tasks/dependency.rake
@@ -16,7 +16,7 @@ namespace :dependency do
     puts gemfiles
     puts "========================================\n"
 
-    puts "You can do a bunch of cool stuff by assign it to the BUNDLE_GEMFILE environment variable, like:\n"
+    puts "You can do a bunch of cool stuff by assigning a gemfile path to the BUNDLE_GEMFILE environment variable, like:\n"
     puts "`BUNDLE_GEMFILE=#{gemfiles.sample} bundle install`\n\n"
   end
 


### PR DESCRIPTION
**Motivation:**

Providing dependency task for each group is not ideal, because

- `Dir.glob(AppraisalConversion.gemfile_pattern)` is cached for tasks definition.
- Adding/removing gemfiles makes the cache obsolete. 

**What does this PR do?**

Glob gemfile at runtime instead. 

PS. There will be follow up PR to replace `appraisal` 