### PR TITLE
CircleCI cache fix

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -65,7 +65,7 @@ save_bundle_checksum: &save_bundle_checksum
     command: |
       if [ "$CI_BUNDLE_CACHE_HIT" != 1 ]; then
         # Recompute gemfiles/*.lock checksum, as those files might have changed
-        cat Gemfile Gemfile.lock Appraisals gemfiles/*.gemfile.lock | md5sum > .circleci/bundle_checksum
+        cat Gemfile Gemfile.lock Appraisals gemfiles/*.gemfile gemfiles/*.gemfile.lock | md5sum > .circleci/bundle_checksum
       fi
       cp .circleci/bundle_checksum /usr/local/bundle/bundle_checksum
 step_bundle_install: &step_bundle_install
@@ -96,7 +96,7 @@ step_compute_bundle_checksum: &step_compute_bundle_checksum
     # updating the gemset lock files produces extremely large commits.
     command: |
       bundle lock # Create Gemfile.lock
-      cat Gemfile Gemfile.lock Appraisals gemfiles/*.gemfile.lock | md5sum > .circleci/bundle_checksum
+      cat Gemfile Gemfile.lock Appraisals gemfiles/*.gemfile gemfiles/*.gemfile.lock | md5sum > .circleci/bundle_checksum
 step_run_all_tests: &step_run_all_tests
   run:
     name: Run tests

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -87,11 +87,6 @@ step_appraisal_install: &step_appraisal_install
         bundle exec appraisal generate # Generate the appraisal files to match the lockfiles in the tree
         echo "All required gems were found in cache."
       fi
-step_appraisal_update: &step_appraisal_update
-  run:
-    name: Update Appraisal gems
-    command: | # Remove all generated gemfiles and lockfiles, resolve, and install dependencies again
-      bundle exec appraisal update
 step_compute_bundle_checksum: &step_compute_bundle_checksum
   run:
     name: Compute bundle checksum
@@ -181,17 +176,7 @@ orbs:
                 - bundle-{{ .Environment.CIRCLE_CACHE_VERSION }}-{{ checksum ".circleci/images/primary/binary_version" }}-<<parameters.ruby_version>>-{{ checksum "lib/datadog/version.rb" }}
           - *check_exact_bundle_cache_hit
           - *step_bundle_install
-          - when:
-              condition:
-                equal: [ << parameters.edge >>, true ]
-              steps:
-                - *step_appraisal_update # Run on latest version of all gems we integrate with
-          - when:
-              condition:
-                not:
-                  equal: [ << parameters.edge >>, true ]
-              steps:
-                - *step_appraisal_install # Run on a stable set of gems we integrate with
+          - *step_appraisal_install # Run on a stable set of gems we integrate with
           - *save_bundle_checksum
           - save_cache:
               key: '{{ .Environment.CIRCLE_CACHE_VERSION }}-bundled-repo-<<parameters.ruby_version>>-{{ .Environment.CIRCLE_SHA1 }}'

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -81,12 +81,8 @@ step_appraisal_install: &step_appraisal_install
   run:
     name: Install Appraisal gems
     command: |
-      if [ "$CI_BUNDLE_CACHE_HIT" != 1 ]; then
-        bundle exec appraisal install
-      else
-        bundle exec appraisal generate # Generate the appraisal files to match the lockfiles in the tree
-        echo "All required gems were found in cache."
-      fi
+      bundle exec appraisal generate
+      bundle exec rake dependency:install
 step_compute_bundle_checksum: &step_compute_bundle_checksum
   run:
     name: Compute bundle checksum

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -285,6 +285,10 @@ orbs:
                 curl --silent --show-error --location --fail --retry 3 --output /usr/local/bin/dockerize $DOCKERIZE_URL
                 chmod +x /usr/local/bin/dockerize
                 dockerize --version
+          # Test agent uses `jq` to check results
+          - run:
+              name: Install jq
+              command: apt update && apt install jq -y
           # Wait for containers to start
           - docker-wait:
               port: 5432
@@ -307,10 +311,6 @@ orbs:
               host: "testagent"
               port: 9126
           - *step_run_all_tests
-          - run:
-              # Test agent uses `jq` to check results
-              name: Install jq
-              command: apt update && apt install jq -y
           - *step_get_test_agent_trace_check_results
           - store_test_results:
               path: /tmp/rspec

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -81,8 +81,13 @@ step_appraisal_install: &step_appraisal_install
   run:
     name: Install Appraisal gems
     command: |
-      bundle exec appraisal generate
-      bundle exec rake dependency:install
+      if [ "$CI_BUNDLE_CACHE_HIT" != 1 ]; then
+        bundle exec appraisal generate
+        bundle exec rake dependency:install
+      else
+        bundle exec appraisal generate
+        echo "All required gems were found in cache."
+      fi
 step_compute_bundle_checksum: &step_compute_bundle_checksum
   run:
     name: Compute bundle checksum

--- a/tasks/dependency.rake
+++ b/tasks/dependency.rake
@@ -1,5 +1,3 @@
-require 'open3'
-
 require_relative 'appraisal_conversion'
 
 namespace :dependency do
@@ -31,9 +29,7 @@ namespace :dependency do
       Bundler.with_unbundled_env do
         command = +'bundle lock'
         command << ' --add-platform x86_64-linux aarch64-linux' unless RUBY_PLATFORM == 'java'
-        output, = Open3.capture2e({ 'BUNDLE_GEMFILE' => gemfile.to_s }, command)
-
-        puts output
+        sh({ 'BUNDLE_GEMFILE' => gemfile.to_s }, command)
       end
     end
   end
@@ -47,9 +43,7 @@ namespace :dependency do
 
     gemfiles.each do |gemfile|
       Bundler.with_unbundled_env do
-        output, = Open3.capture2e({ 'BUNDLE_GEMFILE' => gemfile.to_s }, "bundle check || bundle install")
-
-        puts output
+        sh({ 'BUNDLE_GEMFILE' => gemfile.to_s }, 'bundle check || bundle install')
       end
     end
   end


### PR DESCRIPTION
**Motivation:**

CircleCI cache is corrupted. Running `bundle exec appraisal install` would return a false negative result that dependencies are still missing. 

For example: https://app.circleci.com/pipelines/github/DataDog/dd-trace-rb/17478/workflows/d773b359-cf13-4438-821d-150202473ba3

The bundle cache is around 50 mb and the missing dependencies are install with a fallback when running in the task.

**What does this PR do?**

1. Replace the broken `bundle exec appraisal install` with `bundle exec rake dependency:install` 
2. Adding `gemfiles/*.gemfile` into bundle checksum 
3. Other minor improvements