### PR TITLE
DEBUG-2334 require file presence for line probe

### DIFF
--- a/lib/datadog/di/probe.rb
+++ b/lib/datadog/di/probe.rb
@@ -47,6 +47,10 @@ module Datadog
           raise ArgumentError, "Probe contains both line number and method name: #{id}"
         end
 
+        if line_no && !file
+          raise ArgumentError, "Probe contains line number but not file: #{id}"
+        end
+
         if type_name && !method_name || method_name && !type_name
           raise ArgumentError, "Partial method probe definition: #{id}"
         end
@@ -103,7 +107,10 @@ module Datadog
       # method or for stack traversal purposes?), therefore we do not check
       # for file name/path presence here and just consider the line number.
       def line?
-        !line_no.nil?
+        # Constructor checks that file is given if line number is given,
+        # but for safety, check again here since we somehow got a probe with
+        # a line number but no file in the wild.
+        !!(file && line_no)
       end
 
       # Returns whether the probe is a method probe.

--- a/spec/datadog/di/probe_spec.rb
+++ b/spec/datadog/di/probe_spec.rb
@@ -45,6 +45,18 @@ RSpec.describe Datadog::DI::Probe do
       end
     end
 
+    context 'line number given but file is not' do
+      let(:probe) do
+        described_class.new(id: "42", type: :log, line_no: 5)
+      end
+
+      it "raises ArgumentError" do
+        expect do
+          probe
+        end.to raise_error(ArgumentError, /Probe contains line number but not file/)
+      end
+    end
+
     context 'unsupported type' do
       let(:probe) do
         # LOG_PROBE is a valid type in RC probe specification but not
@@ -151,7 +163,7 @@ RSpec.describe Datadog::DI::Probe do
 
   describe "#line_no" do
     context "one line number" do
-      let(:probe) { described_class.new(id: "x", type: :log, line_no: 5) }
+      let(:probe) { described_class.new(id: "x", type: :log, file: 'x', line_no: 5) }
 
       it "returns the line number" do
         expect(probe.line_no).to eq 5
@@ -169,7 +181,7 @@ RSpec.describe Datadog::DI::Probe do
 
   describe "#line_no!" do
     context "one line number" do
-      let(:probe) { described_class.new(id: "x", type: :log, line_no: 5) }
+      let(:probe) { described_class.new(id: "x", type: :log, file: 'x', line_no: 5) }
 
       it "returns the line number" do
         expect(probe.line_no!).to eq 5


### PR DESCRIPTION

<!--
Check out the
https://github.com/DataDog/dd-trace-rb/blob/master/docs/DevelopmentGuide.md
for guidance on how to set up your development environment,
run the test suite, write new integrations, and more.
-->

**What does this PR do?**
<!-- A brief description of the change being made with this pull request. -->
Adds checks that a line probe contains a file, which is required to instrument such a probe.

**Motivation:**
While testing manually I encountered an exception due to a line probe missing the file. This should not happen and such a configuration is not usable since we don't know which file to instrument. Add extra guards and a unit test to handle this case.
<!-- What inspired you to submit this pull request? -->

**Change log entry**
None
<!-- If this is a customer-visible change, a brief summary to be placed
into the change log.
If you are not a Datadog employee, you can skip this section
and it will be filled or deleted during PR review. -->

**Additional Notes:**
<!-- Anything else we should know when reviewing? -->

**How to test the change?**
Unit tests
<!--
Describe here how the change can be validated.
You are strongly encouraged to provide automated tests for this PR (unit or integration).
If this change cannot be feasibly tested, please explain why,
unless the change does not modify code (e.g. only modifies docs, comments).
-->

<!-- Unsure? Have a question? Request a review! -->
