### PR TITLE
DEBUG-2334 remove unused method stubs from DI test suite

### DIFF
--- a/spec/datadog/di/probe_notification_builder_spec.rb
+++ b/spec/datadog/di/probe_notification_builder_spec.rb
@@ -23,7 +23,6 @@ RSpec.describe Datadog::DI::ProbeNotificationBuilder do
   let(:di_settings) do
     double("di settings").tap do |settings|
       allow(settings).to receive(:enabled).and_return(true)
-      allow(settings).to receive(:propagate_all_exceptions).and_return(false)
       allow(settings).to receive(:redacted_identifiers).and_return([])
       allow(settings).to receive(:redacted_type_names).and_return(%w[])
       allow(settings).to receive(:max_capture_collection_size).and_return(10)

--- a/spec/datadog/di/redactor_spec.rb
+++ b/spec/datadog/di/redactor_spec.rb
@@ -39,7 +39,6 @@ RSpec.describe Datadog::DI::Redactor do
   let(:di_settings) do
     double("di settings").tap do |settings|
       allow(settings).to receive(:enabled).and_return(true)
-      allow(settings).to receive(:propagate_all_exceptions).and_return(false)
       allow(settings).to receive(:redacted_identifiers).and_return([])
     end
   end

--- a/spec/datadog/di/serializer_helper.rb
+++ b/spec/datadog/di/serializer_helper.rb
@@ -43,7 +43,6 @@ module SerializerHelper
     let(:di_settings) do
       double("di settings").tap do |settings|
         allow(settings).to receive(:enabled).and_return(true)
-        allow(settings).to receive(:propagate_all_exceptions).and_return(false)
         allow(settings).to receive(:redacted_identifiers).and_return([])
         allow(settings).to receive(:redacted_type_names).and_return(%w[
           DISerializerSpecSensitiveType DISerializerSpecWildCard*


### PR DESCRIPTION
<!--
Check out the
https://github.com/DataDog/dd-trace-rb/blob/master/docs/DevelopmentGuide.md
for guidance on how to set up your development environment,
run the test suite, write new integrations, and more.
-->

**What does this PR do?**
Removes `allow` calls from test suite for the relocated `propagate_all_exceptions` setting. 
<!-- A brief description of the change being made with this pull request. -->

**Motivation:**
Test suite cleanup.
<!-- What inspired you to submit this pull request? -->

**Change log entry**
None
<!-- If this is a customer-visible change, a brief summary to be placed
into the change log.
If you are not a Datadog employee, you can skip this section
and it will be filled or deleted during PR review. -->

**Additional Notes:**
<!-- Anything else we should know when reviewing? -->

**How to test the change?**
<!--
Describe here how the change can be validated.
You are strongly encouraged to provide automated tests for this PR (unit or integration).
If this change cannot be feasibly tested, please explain why,
unless the change does not modify code (e.g. only modifies docs, comments).
-->

<!-- Unsure? Have a question? Request a review! -->
