### PR TITLE
DEBUG-2334 Use :return/:b_return trace points to target 'end' line of methods and blocks with line probes

### DIFF
--- a/lib/datadog/di/instrumenter.rb
+++ b/lib/datadog/di/instrumenter.rb
@@ -223,7 +223,10 @@ module Datadog
         # this optimization just yet and create a trace point for each probe.
 
         types = if iseq
-          # When targeting trace points we can target the 'end' line of a method
+          # When targeting trace points we can target the 'end' line of a method.
+          # However, by adding the :return trace point we lose diagnostics
+          # for lines that contain no executable code (e.g. comments only)
+          # and thus cannot actually be instrumented.
           [:line, :return]
         else
           [:line]

--- a/lib/datadog/di/instrumenter.rb
+++ b/lib/datadog/di/instrumenter.rb
@@ -222,7 +222,13 @@ module Datadog
         # overhead of targeted trace points is minimal, don't worry about
         # this optimization just yet and create a trace point for each probe.
 
-        tp = TracePoint.new(:line) do |tp|
+        types = if iseq
+          # When targeting trace points we can target the 'end' line of a method
+          [:line, :return]
+        else
+          [:line]
+        end
+        tp = TracePoint.new(*types) do |tp|
           begin
             # If trace point is not targeted, we must verify that the invocation
             # is the file & line that we want, because untargeted trace points

--- a/lib/datadog/di/instrumenter.rb
+++ b/lib/datadog/di/instrumenter.rb
@@ -227,7 +227,7 @@ module Datadog
           # However, by adding the :return trace point we lose diagnostics
           # for lines that contain no executable code (e.g. comments only)
           # and thus cannot actually be instrumented.
-          [:line, :return]
+          [:line, :return, :b_return]
         else
           [:line]
         end
@@ -249,7 +249,7 @@ module Datadog
             # TODO test this path
           end
         rescue => exc
-          raise if settings.dynamic_instrumentation.propagate_all_exceptions
+          raise if settings.dynamic_instrumentation.internal.propagate_all_exceptions
           logger.warn("Unhandled exception in line trace point: #{exc.class}: #{exc}")
           telemetry&.report(exc, description: "Unhandled exception in line trace point")
           # TODO test this path

--- a/spec/datadog/di/integration/instrumentation_integration_test_class.rb
+++ b/spec/datadog/di/integration/instrumentation_integration_test_class.rb
@@ -8,5 +8,5 @@ class InstrumentationIntegrationTestClass
     # padding
     # padding
     a * 2 # line 10
-  end
+  end # line 11
 end

--- a/spec/datadog/di/integration/instrumentation_integration_test_class.rb
+++ b/spec/datadog/di/integration/instrumentation_integration_test_class.rb
@@ -9,4 +9,6 @@ class InstrumentationIntegrationTestClass
     # padding
     a * 2 # line 10
   end # line 11
-end
+end # line 12
+
+# Comment - line 14

--- a/spec/datadog/di/integration/instrumentation_integration_test_class.rb
+++ b/spec/datadog/di/integration/instrumentation_integration_test_class.rb
@@ -9,6 +9,14 @@ class InstrumentationIntegrationTestClass
     # padding
     a * 2 # line 10
   end # line 11
-end # line 12
 
-# Comment - line 14
+  def test_method_with_block
+    array = [1]
+    array.each do |value|
+      value_copy = value
+    end # line 17
+  end
+
+end # line 20
+
+# Comment - line 22

--- a/spec/datadog/di/integration/instrumentation_integration_test_class.rb
+++ b/spec/datadog/di/integration/instrumentation_integration_test_class.rb
@@ -17,6 +17,15 @@ class InstrumentationIntegrationTestClass
     end # line 17
   end
 
-end # line 20
+  def test_method_with_conditional
+    if false
+      a = 1
+    else # line 23
+      a = 2
+    end # line 25
+    a
+  end
 
-# Comment - line 22
+end # line 29
+
+# Comment - line 31

--- a/spec/datadog/di/integration/instrumentation_spec.rb
+++ b/spec/datadog/di/integration/instrumentation_spec.rb
@@ -355,10 +355,63 @@ RSpec.describe 'Instrumentation integration' do
           include_examples 'simple log probe'
         end
 
+        context 'target line is the end line of a block' do
+          let(:probe) do
+            Datadog::DI::Probe.new(id: "1234", type: :log,
+              file: 'instrumentation_integration_test_class.rb', line_no: 17,
+              capture_snapshot: false,)
+          end
+
+          it 'invokes probe' do
+            expect(component.transport).to receive(:send_request).at_least(:once)
+            probe_manager.add_probe(probe)
+            component.probe_notifier_worker.flush
+            expect(probe_manager.installed_probes.length).to eq 1
+            expect(component.probe_notifier_worker).to receive(:add_snapshot).once.and_call_original
+            expect(InstrumentationIntegrationTestClass.new.test_method_with_block).to eq([1])
+          end
+
+          describe 'payload' do
+            let(:payload) do
+              probe_manager.add_probe(probe)
+              payload = nil
+              expect(component.probe_notifier_worker).to receive(:add_snapshot) do |payload_|
+                payload = payload_
+              end
+              expect(InstrumentationIntegrationTestClass.new.test_method_with_block).to eq([1])
+              component.probe_notifier_worker.flush
+              expect(payload).to be_a(Hash)
+              payload
+            end
+
+            let(:snapshot) do
+              payload.fetch(:"debugger.snapshot")
+            end
+
+            it 'does not have captures' do
+              expect(component.transport).to receive(:send_request).at_least(:once)
+              expect(snapshot.fetch(:captures)).to be nil
+            end
+
+            let(:stack) do
+              snapshot.fetch(:stack)
+            end
+
+            let(:top_stack_frame) do
+              stack.first
+            end
+
+            it 'has instrumented location as top stack frame' do
+              expect(component.transport).to receive(:send_request).at_least(:once)
+              expect(File.basename(top_stack_frame.fetch(:fileName))).to eq 'instrumentation_integration_test_class.rb'
+            end
+          end
+        end
+
         context 'target line contains a comment (no executable code)' do
           let(:probe) do
             Datadog::DI::Probe.new(id: "1234", type: :log,
-              file: 'instrumentation_integration_test_class.rb', line_no: 14,
+              file: 'instrumentation_integration_test_class.rb', line_no: 22,
               capture_snapshot: false,)
           end
 

--- a/spec/datadog/di/integration/instrumentation_spec.rb
+++ b/spec/datadog/di/integration/instrumentation_spec.rb
@@ -354,6 +354,20 @@ RSpec.describe 'Instrumentation integration' do
 
           include_examples 'simple log probe'
         end
+
+        context 'target line contains a comment (no executable code)' do
+          let(:probe) do
+            Datadog::DI::Probe.new(id: "1234", type: :log,
+              file: 'instrumentation_integration_test_class.rb', line_no: 14,
+              capture_snapshot: false,)
+          end
+
+          # We currently are not told that the line is not executable.
+          it 'installs probe' do
+            expect(probe_manager.add_probe(probe)).to be true
+            expect(probe_manager.installed_probes.length).to eq 1
+          end
+        end
       end
 
       context 'enriched probe' do


### PR DESCRIPTION

**What does this PR do?**
This PR adds `return` and `b_return` trace point types to the `line` trace point, permitting targeting `end` lines of blocks and methods with line probes.<!-- A brief description of the change being made with this pull request. -->

**Motivation:**
Initial DI implementation for Ruby.
<!-- What inspired you to submit this pull request? -->

**Change log entry**
None
<!-- If this is a customer-visible change, a brief summary to be placed
into the change log.
If you are not a Datadog employee, you can skip this section
and it will be filled or deleted during PR review. -->

**Additional Notes:**
The `return` trace point types have the unfortunate side effect of always installing even if the target line has no executable ruby code (e.g. a comment line). This means users will not be getting notified when they try to instrument non-executable code lines. I think it is worthwhile to permit instrumenting `end` lines even if it means no diagnostics when trying to instrument non-instrumentable lines, in other words, it is better to make more use cases work at the expense of worse diagnostics when something that wouldn't work is attempted.
<!-- Anything else we should know when reviewing? -->

**How to test the change?**
Integration tests are included.
<!--
Describe here how the change can be validated.
You are strongly encouraged to provide automated tests for this PR (unit or integration).
If this change cannot be feasibly tested, please explain why,
unless the change does not modify code (e.g. only modifies docs, comments).
-->

<!-- Unsure? Have a question? Request a review! -->
