### PR TITLE
Update filter with splitted  gemfile and task

### DIFF
--- a/.github/dependency_filters.yml
+++ b/.github/dependency_filters.yml
@@ -1,8 +1,10 @@
 dependencies:
   - Gemfile
+  - '*.gemfile'
   - Appraisals
   - datadog.gemspec
   - tasks/appraisal.rake
+  - tasks/dependency.rake
   - .github/workflows/lock-dependency.yml
   - lib/datadog/version.rb
   - appraisal/**


### PR DESCRIPTION
**What does this PR do?**

We've update our flow for dependency management in https://github.com/DataDog/dd-trace-rb/pull/4112, we should update the dependency filter to better allow our [automated detection](https://github.com/DataDog/dd-trace-rb/actions/workflows/lock-dependency.yml) for updating lock files.