### PR TITLE
Fix system-tests CI flakiness by adding Dockerhub login

### DIFF
--- a/.github/workflows/system-tests.yml
+++ b/.github/workflows/system-tests.yml
@@ -36,6 +36,11 @@ jobs:
           repository: 'DataDog/system-tests'
           ref: ${{ env.SYSTEM_TESTS_REF }}
           persist-credentials: false
+      - name: Login to Docker Hub
+        uses: docker/login-action@v3
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
       - name: Pull released image
         run: |
           if docker pull ${{ env.REPO }}/system-tests/${{ matrix.image.name }}:latest; then
@@ -131,6 +136,11 @@ jobs:
           echo "FORCED_TESTS_LIST<<EOF" >> $GITHUB_OUTPUT
           echo "$(cat binaries/dd-trace-rb/.github/forced-tests-list.json)" >> $GITHUB_OUTPUT
           echo "EOF" >> $GITHUB_OUTPUT
+      - name: Login to Docker Hub
+        uses: docker/login-action@v3
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
       - name: Pull released image
         run: |
           if docker pull ${{ env.REPO }}/system-tests/${{ matrix.library.name }}/${{ matrix.image }}-${{ matrix.app }}:latest; then
@@ -285,6 +295,11 @@ jobs:
           repository: 'DataDog/system-tests'
           ref: ${{ env.SYSTEM_TESTS_REF }}
           persist-credentials: false
+      - name: Login to Docker Hub
+        uses: docker/login-action@v3
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
       - name: Pull runner image
         run: |
           docker pull ${{ env.REPO }}/system-tests/runner:gha${{ github.run_id }}-g${{ github.sha }}


### PR DESCRIPTION
<!--
Check out the
https://github.com/DataDog/dd-trace-rb/blob/master/docs/DevelopmentGuide.md
for guidance on how to set up your development environment,
run the test suite, write new integrations, and more.
-->

**What does this PR do?**
Fix system-tests CI flakiness by adding Dockerhub login

**Motivation:**
> Docker has a rate limit based on your IP when you docker pull without being logged. This limit is pretty low. If you make the same command, but being authenticated before, the rate limit docker applies is way higher.

**Change log entry**
None.

**Additional Notes:**
Variables added as repository secrets.

**How to test the change?**
I suppose that you could launch system-tests GH workflow a lot of time and see that it does not fail because of dockerhub rate limit
