### PR TITLE
DEBUG-2334 Ruby 2 compatibility for dynamic instrumentation

### DIFF
--- a/lib/datadog/di/instrumenter.rb
+++ b/lib/datadog/di/instrumenter.rb
@@ -105,7 +105,7 @@ module Datadog
                 serializer.serialize_args(args, kwargs)
               end
               rv = nil
-              # Under Ruby 2.x we cannot just call super(*args, **kwargs)
+              # Under Ruby 2.6 we cannot just call super(*args, **kwargs)
               duration = Benchmark.realtime do # steep:ignore
                 rv = if args.any?
                   if kwargs.any?

--- a/lib/datadog/di/instrumenter.rb
+++ b/lib/datadog/di/instrumenter.rb
@@ -105,8 +105,19 @@ module Datadog
                 serializer.serialize_args(args, kwargs)
               end
               rv = nil
+              # Under Ruby 2.x we cannot just call super(*args, **kwargs)
               duration = Benchmark.realtime do # steep:ignore
-                rv = super(*args, **kwargs)
+                rv = if args.any?
+                  if kwargs.any?
+                    super(*args, **kwargs)
+                  else
+                    super(*args)
+                  end
+                elsif kwargs.any?
+                  super(**kwargs)
+                else
+                  super()
+                end
               end
               # The method itself is not part of the stack trace because
               # we are getting the stack trace from outside of the method.

--- a/spec/datadog/di/hook_method.rb
+++ b/spec/datadog/di/hook_method.rb
@@ -11,6 +11,10 @@ class HookTestClass
     kwarg
   end
 
+  def hook_test_method_with_pos_and_kwarg(arg, kwarg:)
+    [arg, kwarg]
+  end
+
   def recursive(depth)
     if depth > 0
       recursive(depth - 1) + '-'

--- a/spec/datadog/di/instrumenter_spec.rb
+++ b/spec/datadog/di/instrumenter_spec.rb
@@ -187,6 +187,61 @@ RSpec.describe Datadog::DI::Instrumenter do
       end
     end
 
+    context 'positional and keyword args' do
+      context 'with snapshot capture' do
+        let(:probe_args) do
+          {type_name: 'HookTestClass', method_name: 'hook_test_method_with_pos_and_kwarg',
+           capture_snapshot: true}
+        end
+
+        let(:target_call) do
+          expect(HookTestClass.new.hook_test_method_with_pos_and_kwarg(41, kwarg: 42)).to eq [41, 42]
+        end
+
+        shared_examples 'invokes callback and captures parameters' do
+          it 'invokes callback and captures parameters' do
+            instrumenter.hook_method(probe) do |payload|
+              observed_calls << payload
+            end
+
+            target_call
+
+            expect(observed_calls.length).to eq 1
+            expect(observed_calls.first.keys.sort).to eq call_keys
+            expect(observed_calls.first[:rv]).to eq [41, 42]
+            expect(observed_calls.first[:duration]).to be_a(Float)
+
+            expect(observed_calls.first[:serialized_entry_args]).to eq(
+              # TODO actual argument name not captured yet,
+              # requires method call trace point.
+              arg1: {type: 'Integer', value: '41'},
+              kwarg: {type: 'Integer', value: '42'})
+          end
+        end
+
+        include_examples 'invokes callback and captures parameters'
+
+        context 'when passed via a splat' do
+
+          let(:target_call) do
+            expect(HookTestClass.new.hook_test_method_with_pos_and_kwarg(*[41], **{kwarg: 42})).to eq [41, 42]
+          end
+
+          include_examples 'invokes callback and captures parameters'
+        end
+
+        context 'when passed via a splat with string keys' do
+
+          let(:target_call) do
+            pending '2.x only?'
+            expect(HookTestClass.new.hook_test_method_with_kwarg(**{'kwarg' => 42})).to eq 42
+          end
+
+          include_examples 'invokes callback and captures parameters'
+        end
+      end
+    end
+
     context 'when hooking two identical but different probes' do
       let(:probe) do
         Datadog::DI::Probe.new(**base_probe_args.merge(

--- a/spec/datadog/di/instrumenter_spec.rb
+++ b/spec/datadog/di/instrumenter_spec.rb
@@ -174,16 +174,6 @@ RSpec.describe Datadog::DI::Instrumenter do
 
           include_examples 'invokes callback and captures parameters'
         end
-
-        context 'when passed via a splat with string keys' do
-
-          let(:target_call) do
-            pending '2.x only?'
-            expect(HookTestClass.new.hook_test_method_with_kwarg(**{'kwarg' => 42})).to eq 42
-          end
-
-          include_examples 'invokes callback and captures parameters'
-        end
       end
     end
 
@@ -225,16 +215,6 @@ RSpec.describe Datadog::DI::Instrumenter do
 
           let(:target_call) do
             expect(HookTestClass.new.hook_test_method_with_pos_and_kwarg(*[41], **{kwarg: 42})).to eq [41, 42]
-          end
-
-          include_examples 'invokes callback and captures parameters'
-        end
-
-        context 'when passed via a splat with string keys' do
-
-          let(:target_call) do
-            pending '2.x only?'
-            expect(HookTestClass.new.hook_test_method_with_kwarg(**{'kwarg' => 42})).to eq 42
           end
 
           include_examples 'invokes callback and captures parameters'


### PR DESCRIPTION
<!--
Check out the
https://github.com/DataDog/dd-trace-rb/blob/master/docs/DevelopmentGuide.md
for guidance on how to set up your development environment,
run the test suite, write new integrations, and more.
-->

**What does this PR do?**
Adds special handling for Ruby 2 to dynamic instrumentation. Specifically,  Ruby 2.6 is not able to execute `super(*args, **kwargs)` when the target method has no arguments.
<!-- A brief description of the change being made with this pull request. -->

**Motivation:**
Ruby 2 support was on the roadmap for DI, however the lack of support was exposed by tests added in https://github.com/DataDog/dd-trace-rb/pull/4106.
<!-- What inspired you to submit this pull request? -->

**Change log entry**
None
<!-- If this is a customer-visible change, a brief summary to be placed
into the change log.
If you are not a Datadog employee, you can skip this section
and it will be filled or deleted during PR review. -->

**Additional Notes:**
More tests need to be added for Ruby 2  - the folding of keyword arguments into positional `options` argument at the end of a method.
<!-- Anything else we should know when reviewing? -->

**How to test the change?**
Unit tests are included.
<!--
Describe here how the change can be validated.
You are strongly encouraged to provide automated tests for this PR (unit or integration).
If this change cannot be feasibly tested, please explain why,
unless the change does not modify code (e.g. only modifies docs, comments).
-->

<!-- Unsure? Have a question? Request a review! -->
