### PR TITLE
Add Rails 7.2 and Rails 8.0 weblogs to system-tests workflow

### DIFF
--- a/.github/workflows/system-tests.yml
+++ b/.github/workflows/system-tests.yml
@@ -109,6 +109,8 @@ jobs:
           - rails61
           - rails70
           - rails71
+          - rails72
+          - rails80
           - graphql23
     runs-on: ubuntu-latest
     name: Build (${{ matrix.app }})
@@ -210,6 +212,8 @@ jobs:
           - rails61
           - rails70
           - rails71
+          - rails72
+          - rails80
         scenario:
           - DEFAULT
           - APPSEC_DISABLED
@@ -362,6 +366,8 @@ jobs:
           - rails61
           - rails70
           - rails71
+          - rails72
+          - rails80
           - graphql23
     runs-on: ubuntu-latest
     needs:
@@ -415,6 +421,9 @@ jobs:
           - weblog-rails60
           - weblog-rails61
           - weblog-rails70
+          - weblog-rails71
+          - weblog-rails72
+          - weblog-rails80
           - weblog-graphql23
     runs-on: ubuntu-latest
     needs:


### PR DESCRIPTION
<!--
Check out the
https://github.com/DataDog/dd-trace-rb/blob/master/docs/DevelopmentGuide.md
for guidance on how to set up your development environment,
run the test suite, write new integrations, and more.
-->

**What does this PR do?**
This PR adds Rails 7.2 and Rails 8.0 weblogs to system-tests workflow in our CI.

**Motivation:**
Rails 8.0 has been released this week, it is the most used Ruby framework among our clients (and in the Ruby community) so it is important that we support it and see if any of our feature breaks on the newest release of Rails. While doing that, I also saw that we are not running system-tests against Rails 7.2, which still receives frequent updates.

**Change log entry**
None.

**How to test the change?**
You can check the CI, there should be new steps for system-tests on Rails 7.2 and Rails 8.0

<!-- Unsure? Have a question? Request a review! -->
