### PR TITLE
DEBUG-2334 enable dynamic instrumentation line probe benchmarks

### DIFF
--- a/benchmarks/di_instrument.rb
+++ b/benchmarks/di_instrument.rb
@@ -131,7 +131,6 @@ class DIInstrumentBenchmark
 
     instrumenter.unhook(probe)
 
-=begin Line probes require more of DI code to be merged
     calls = 0
     probe = Datadog::DI::Probe.new(id: 1, type: :log,
       file: file, line_no: line + 1)
@@ -207,7 +206,6 @@ class DIInstrumentBenchmark
     # target code is approximately what it was prior to hook installation.
 
     instrumenter.unhook(probe)
-=end
 
     calls = 0
 

--- a/benchmarks/di_instrument.rb
+++ b/benchmarks/di_instrument.rb
@@ -69,19 +69,24 @@ class DIInstrumentBenchmark
     end
   end
 
-  def run_benchmark
+  attr_reader :instrumenter
+
+  def logger
+    @logger ||= Logger.new(STDERR)
+  end
+
+  def configure
     settings = Datadog.configuration
-    # We benchmark untargeted and targeted trace points; untargeted ones
-    # are prohibited by default, permit them.
-    begin
-      settings.dynamic_instrumentation.internal.untargeted_trace_points = true
-    rescue NoMethodError
-      settings.dynamic_instrumentation.untargeted_trace_points = true
-    end
+    yield settings if block_given?
+
     redactor = Datadog::DI::Redactor.new(settings)
     serializer = Datadog::DI::Serializer.new(settings, redactor)
-    logger = Logger.new(STDERR)
-    instrumenter = Datadog::DI::Instrumenter.new(settings, serializer, logger)
+    @instrumenter = Datadog::DI::Instrumenter.new(settings, serializer, logger,
+      code_tracker: Datadog::DI.code_tracker)
+  end
+
+  def run_benchmark
+    configure
 
     m = Target.instance_method(:test_method_for_line_probe)
     file, line = m.source_location
@@ -103,8 +108,11 @@ class DIInstrumentBenchmark
     calls = 0
     probe = Datadog::DI::Probe.new(id: 1, type: :log,
       type_name: 'DIInstrumentBenchmark::Target', method_name: 'test_method')
-    instrumenter.hook_method(probe) do
+    rv = instrumenter.hook_method(probe) do
       calls += 1
+    end
+    unless rv
+      raise "Method probe was not successfully installed"
     end
 
     Benchmark.ips do |x|
@@ -131,11 +139,23 @@ class DIInstrumentBenchmark
 
     instrumenter.unhook(probe)
 
+    # We benchmark untargeted and targeted trace points; untargeted ones
+    # are prohibited by default, permit them.
+    # In order to install untargeted trace point, we currently need to
+    # disable code tracking.
+    Datadog::DI.deactivate_tracking!
+    configure do |c|
+      c.dynamic_instrumentation.internal.untargeted_trace_points = true
+    end
+
     calls = 0
     probe = Datadog::DI::Probe.new(id: 1, type: :log,
       file: file, line_no: line + 1)
-    instrumenter.hook_line(probe) do
+    rv = instrumenter.hook_line(probe) do
       calls += 1
+    end
+    unless rv
+      raise "Line probe (in method) was not successfully installed"
     end
 
     Benchmark.ips do |x|
@@ -143,8 +163,7 @@ class DIInstrumentBenchmark
       x.config(
         **benchmark_time,
       )
-
-      x.report('line instrumentation') do
+      x.report('line instrumentation - untargeted') do
         Target.new.test_method_for_line_probe
       end
 
@@ -160,7 +179,13 @@ class DIInstrumentBenchmark
       raise "Expected at least 1000 calls to the method, got #{calls}"
     end
 
+    instrumenter.unhook(probe)
+
     Datadog::DI.activate_tracking!
+    configure do |c|
+      c.dynamic_instrumentation.internal.untargeted_trace_points = false
+    end
+
     if defined?(DITarget)
       raise "DITarget is already defined, this should not happen"
     end
@@ -172,12 +197,14 @@ class DIInstrumentBenchmark
     m = DITarget.instance_method(:test_method_for_line_probe)
     targeted_file, targeted_line = m.source_location
 
-    instrumenter.unhook(probe)
     calls = 0
     probe = Datadog::DI::Probe.new(id: 1, type: :log,
       file: targeted_file, line_no: targeted_line + 1)
-    instrumenter.hook_line(probe) do
+    rv = instrumenter.hook_line(probe) do
       calls += 1
+    end
+    unless rv
+      raise "Line probe (targeted) was not successfully installed"
     end
 
     Benchmark.ips do |x|

--- a/lib/datadog/di/instrumenter.rb
+++ b/lib/datadog/di/instrumenter.rb
@@ -305,7 +305,9 @@ module Datadog
           else
             tp.enable
           end
+          # TracePoint#enable returns false when it succeeds.
         end
+        true
       end
 
       def unhook_line(probe)

--- a/lib/datadog/di/instrumenter.rb
+++ b/lib/datadog/di/instrumenter.rb
@@ -266,7 +266,11 @@ module Datadog
             # If trace point is not targeted, we must verify that the invocation
             # is the file & line that we want, because untargeted trace points
             # are invoked for *each* line of Ruby executed.
-            if iseq || tp.lineno == probe.line_no && probe.file_matches?(tp.path)
+            # TODO find out exactly when the path in trace point is relative.
+            # Looks like this is the case when line trace point is not targeted?
+            if iseq || tp.lineno == probe.line_no && (
+              probe.file == tp.path || probe.file_matches?(tp.path)
+            )
               if rate_limiter.nil? || rate_limiter.allow?
                 # & is to stop steep complaints, block is always present here.
                 block&.call(probe: probe, trace_point: tp, caller_locations: caller_locations)

--- a/spec/datadog/di/validate_benchmarks_spec.rb
+++ b/spec/datadog/di/validate_benchmarks_spec.rb
@@ -1,8 +1,5 @@
 require "datadog/di/spec_helper"
 
-# rubocop:disable Style/BlockComments
-
-=begin benchmarks require DI code to be merged
 RSpec.describe "Dynamic instrumentation benchmarks", :memcheck_valgrind_skip do
   di_test
 
@@ -29,6 +26,3 @@ RSpec.describe "Dynamic instrumentation benchmarks", :memcheck_valgrind_skip do
     expect(benchmarks_to_validate).to contain_exactly(*all_benchmarks)
   end
 end
-=end
-
-# rubocop:enable Style/BlockComments


### PR DESCRIPTION
<!--
Check out the
https://github.com/DataDog/dd-trace-rb/blob/master/docs/DevelopmentGuide.md
for guidance on how to set up your development environment,
run the test suite, write new integrations, and more.
-->

**What does this PR do?**
<!-- A brief description of the change being made with this pull request. -->
Enables line probe benchmarks for dynamic instrumentation.

**Motivation:**
Initial DI implementation in Ruby.
<!-- What inspired you to submit this pull request? -->

**Change log entry**
None
<!-- If this is a customer-visible change, a brief summary to be placed
into the change log.
If you are not a Datadog employee, you can skip this section
and it will be filled or deleted during PR review. -->

**Additional Notes:**
The code being benchmarked must be in master for the benchmarks to work, which is why the benchmarks were committed but turned off.
<!-- Anything else we should know when reviewing? -->

**How to test the change?**
<!--
Describe here how the change can be validated.
You are strongly encouraged to provide automated tests for this PR (unit or integration).
If this change cannot be feasibly tested, please explain why,
unless the change does not modify code (e.g. only modifies docs, comments).
-->

<!-- Unsure? Have a question? Request a review! -->
