### PR TITLE
DEBUG-2334 correctly serialize debugger input payloads

### DIFF
--- a/lib/datadog/di/probe_notification_builder.rb
+++ b/lib/datadog/di/probe_notification_builder.rb
@@ -135,8 +135,8 @@ module Datadog
             version: 2,
           },
           # TODO add tests that the trace/span id is correctly propagated
-          "dd.trace_id": Datadog::Tracing.active_trace&.id,
-          "dd.span_id": Datadog::Tracing.active_span&.id,
+          "dd.trace_id": Datadog::Tracing.active_trace&.id&.to_s,
+          "dd.span_id": Datadog::Tracing.active_span&.id&.to_s,
           ddsource: 'dd_debugger',
           message: probe.template && evaluate_template(probe.template,
             duration: duration ? duration * 1000 : nil),

--- a/lib/datadog/di/transport.rb
+++ b/lib/datadog/di/transport.rb
@@ -44,7 +44,7 @@ module Datadog
 
       def send_input(payload)
         send_request('Probe snapshot submission',
-          path: INPUT_PATH, body: payload.to_s,
+          path: INPUT_PATH, body: payload.to_json,
           headers: {'content-type' => 'application/json'},)
       end
 


### PR DESCRIPTION
<!--
Check out the
https://github.com/DataDog/dd-trace-rb/blob/master/docs/DevelopmentGuide.md
for guidance on how to set up your development environment,
run the test suite, write new integrations, and more.
-->

**What does this PR do?**
<!-- A brief description of the change being made with this pull request. -->
This PR fixes serialization of debugger "input" endpoint payloads. The serialization must be to JSON, previously simple stringification was used which is not JSON.

**Motivation:**
System tests (under development) revealed the issue.

The incorrect behavior also renders DI inoperable in demos.
<!-- What inspired you to submit this pull request? -->

**Change log entry**
None
<!-- If this is a customer-visible change, a brief summary to be placed
into the change log.
If you are not a Datadog employee, you can skip this section
and it will be filled or deleted during PR review. -->

**Additional Notes:**
<!-- Anything else we should know when reviewing? -->

**How to test the change?**
There is no test coverage in the library for this change, however it is covered by system tests that I am currently working on.
<!--
Describe here how the change can be validated.
You are strongly encouraged to provide automated tests for this PR (unit or integration).
If this change cannot be feasibly tested, please explain why,
unless the change does not modify code (e.g. only modifies docs, comments).
-->

<!-- Unsure? Have a question? Request a review! -->
