### PR TITLE
Fix execution spec with cucumber on ruby 3.4

### DIFF
--- a/spec/datadog/core/environment/execution_spec.rb
+++ b/spec/datadog/core/environment/execution_spec.rb
@@ -173,7 +173,13 @@ RSpec.describe Datadog::Core::Environment::Execution do
 
             gemfile(true) do
               source 'https://rubygems.org'
-              gem 'cucumber', '>= 3'
+              if RUBY_VERSION >= '3.4'
+                # Cucumber is broken on Ruby 3.4, requires the fix in
+                # https://github.com/cucumber/cucumber-ruby/pull/1757
+                gem 'cucumber', '>= 3', git: 'https://github.com/cucumber/cucumber-ruby'
+              else
+                gem 'cucumber', '>= 3'
+              end
             end
 
             load Gem.bin_path('cucumber', 'cucumber')
@@ -192,8 +198,6 @@ RSpec.describe Datadog::Core::Environment::Execution do
                 Open3.capture3('ruby', stdin_data: script)
               end
 
-              # Ruby 3.4 outputs an exception instead of the information to be asserted because of the forked process.
-              pending('Pending for Ruby 3.4.') if RUBY_VERSION.start_with?('3.4.')
               expect(err).to include('ACTUAL:true')
             end
           end


### PR DESCRIPTION
<!--
Check out the
https://github.com/DataDog/dd-trace-rb/blob/master/docs/DevelopmentGuide.md
for guidance on how to set up your development environment,
run the test suite, write new integrations, and more.
-->

**What does this PR do?**
Cucumber is broken on ruby 3.4 currently, requires the fix in https://github.com/cucumber/cucumber-ruby/pull/1757 (not released yet).

Use their master from git on ruby 3.4 and unpend the test.
<!-- A brief description of the change being made with this pull request. -->

**Motivation:**
Investigating intermittent failure in that test on the other Ruby versions.
<!-- What inspired you to submit this pull request? -->

**Change log entry**
None
<!-- If this is a customer-visible change, a brief summary to be placed
into the change log.
If you are not a Datadog employee, you can skip this section
and it will be filled or deleted during PR review. -->

**Additional Notes:**
<!-- Anything else we should know when reviewing? -->

**How to test the change?**
<!--
Describe here how the change can be validated.
You are strongly encouraged to provide automated tests for this PR (unit or integration).
If this change cannot be feasibly tested, please explain why,
unless the change does not modify code (e.g. only modifies docs, comments).
-->
Existing test is unpended.

<!-- Unsure? Have a question? Request a review! -->
