### PR TITLE
test ignore

### DIFF
--- a/spec/datadog/core/environment/execution_spec.rb
+++ b/spec/datadog/core/environment/execution_spec.rb
@@ -201,6 +201,7 @@ RSpec.describe Datadog::Core::Environment::Execution do
                 end
 
                 expect(err).to include('ACTUAL:true')
+                puts err
                 fail 'check logs for load path'
               end
             end

--- a/spec/datadog/core/environment/execution_spec.rb
+++ b/spec/datadog/core/environment/execution_spec.rb
@@ -201,6 +201,9 @@ RSpec.describe Datadog::Core::Environment::Execution do
                 end
 
                 expect(err).to include('ACTUAL:true')
+                puts "OUTPUT::"
+                puts _
+                puts "ERROR::"
                 puts err
                 fail 'check logs for load path'
               end

--- a/spec/datadog/core/environment/execution_spec.rb
+++ b/spec/datadog/core/environment/execution_spec.rb
@@ -48,6 +48,7 @@ RSpec.describe Datadog::Core::Environment::Execution do
           require 'datadog/core/environment/execution'
 
           # Print actual value to STDERR, as STDOUT tends to have more noise in REPL sessions.
+          pp $LOAD_PATH
           STDERR.print "ACTUAL:\#{Datadog::Core::Environment::Execution.development?}"
         RUBY
       end
@@ -200,6 +201,7 @@ RSpec.describe Datadog::Core::Environment::Execution do
                 end
 
                 expect(err).to include('ACTUAL:true')
+                fail 'check logs for load path'
               end
             end
           end

--- a/spec/datadog/core/environment/execution_spec.rb
+++ b/spec/datadog/core/environment/execution_spec.rb
@@ -189,18 +189,18 @@ RSpec.describe Datadog::Core::Environment::Execution do
         it 'returns true' do
           Dir.mktmpdir do |dir|
             Dir.chdir(dir) do
-              FileUtils.mkdir_p('features/support')
+              Bundler.with_unbundled_env do
+                FileUtils.mkdir_p('features/support')
 
-              # Add our script to `env.rb`, which is always run before any feature is executed.
-              File.write('features/support/env.rb', repl_script)
+                # Add our script to `env.rb`, which is always run before any feature is executed.
+                File.write('features/support/env.rb', repl_script)
 
-              _, err, = Bundler.with_unbundled_env do
-                Open3.capture3('ruby', stdin_data: script)
+                _, err, = Bundler.with_unbundled_env do
+                  Open3.capture3('ruby', stdin_data: script)
+                end
+
+                expect(err).to include('ACTUAL:true')
               end
-
-              # Ruby 3.4 outputs an exception instead of the information to be asserted because of the forked process.
-              pending('Pending for Ruby 3.4.') if RUBY_VERSION.start_with?('3.4.')
-              expect(err).to include('ACTUAL:true')
             end
           end
         end

--- a/spec/datadog/core/environment/execution_spec.rb
+++ b/spec/datadog/core/environment/execution_spec.rb
@@ -173,7 +173,13 @@ RSpec.describe Datadog::Core::Environment::Execution do
 
             gemfile(true) do
               source 'https://rubygems.org'
-              gem 'cucumber', '>= 3'
+              if RUBY_VERSION >= '3.4'
+                # Cucumber is broken on Ruby 3.4, requires the fix in
+                # https://github.com/cucumber/cucumber-ruby/pull/1757
+                gem 'cucumber', '>= 3', git: 'https://github.com/cucumber/cucumber-ruby'
+              else
+                gem 'cucumber', '>= 3'
+              end
             end
 
             load Gem.bin_path('cucumber', 'cucumber')
@@ -192,8 +198,6 @@ RSpec.describe Datadog::Core::Environment::Execution do
                 Open3.capture3('ruby', stdin_data: script)
               end
 
-              # Ruby 3.4 outputs an exception instead of the information to be asserted because of the forked process.
-              pending('Pending for Ruby 3.4.') if RUBY_VERSION.start_with?('3.4.')
               expect(err).to include('ACTUAL:true')
             end
           end

--- a/spec/datadog/core/environment/execution_spec.rb
+++ b/spec/datadog/core/environment/execution_spec.rb
@@ -198,6 +198,8 @@ RSpec.describe Datadog::Core::Environment::Execution do
                 Open3.capture3('ruby', stdin_data: script)
               end
 
+              # Ruby 3.4 outputs an exception instead of the information to be asserted because of the forked process.
+              pending('Pending for Ruby 3.4.') if RUBY_VERSION.start_with?('3.4.')
               expect(err).to include('ACTUAL:true')
             end
           end


### PR DESCRIPTION
Cucumber is broken on ruby 3.4 currently, requires the fix in
cucumber/cucumber-ruby#1757
(not released yet).

Use their master from git on ruby 3.4 and unpend the test.<!--
Check out the
https://github.com/DataDog/dd-trace-rb/blob/master/docs/DevelopmentGuide.md
for guidance on how to set up your development environment,
run the test suite, write new integrations, and more.
-->

**What does this PR do?**
<!-- A brief description of the change being made with this pull request. -->

**Motivation:**
<!-- What inspired you to submit this pull request? -->

**Change log entry**
<!-- If this is a customer-visible change, a brief summary to be placed
into the change log.
If you are not a Datadog employee, you can skip this section
and it will be filled or deleted during PR review. -->

**Additional Notes:**
<!-- Anything else we should know when reviewing? -->

**How to test the change?**
<!--
Describe here how the change can be validated.
You are strongly encouraged to provide automated tests for this PR (unit or integration).
If this change cannot be feasibly tested, please explain why,
unless the change does not modify code (e.g. only modifies docs, comments).
-->

<!-- Unsure? Have a question? Request a review! -->
