### PR TITLE
Run the cucumber test in unbundled environment

### DIFF
--- a/spec/datadog/core/environment/execution_spec.rb
+++ b/spec/datadog/core/environment/execution_spec.rb
@@ -189,16 +189,18 @@ RSpec.describe Datadog::Core::Environment::Execution do
         it 'returns true' do
           Dir.mktmpdir do |dir|
             Dir.chdir(dir) do
-              FileUtils.mkdir_p('features/support')
+              Bundler.with_unbundled_env do
+                FileUtils.mkdir_p('features/support')
 
-              # Add our script to `env.rb`, which is always run before any feature is executed.
-              File.write('features/support/env.rb', repl_script)
+                # Add our script to `env.rb`, which is always run before any feature is executed.
+                File.write('features/support/env.rb', repl_script)
 
-              _, err, = Bundler.with_unbundled_env do
-                Open3.capture3('ruby', stdin_data: script)
+                _, err, = Bundler.with_unbundled_env do
+                  Open3.capture3('ruby', stdin_data: script)
+                end
+
+                expect(err).to include('ACTUAL:true')
               end
-
-              expect(err).to include('ACTUAL:true')
             end
           end
         end


### PR DESCRIPTION
<!--
Check out the
https://github.com/DataDog/dd-trace-rb/blob/master/docs/DevelopmentGuide.md
for guidance on how to set up your development environment,
run the test suite, write new integrations, and more.
-->

**What does this PR do?**
This PR tries to fix intermittent failures in cucumber `development?` spec by running it in the unbundled environment.
<!-- A brief description of the change being made with this pull request. -->

**Motivation:**
The test is flaky.
<!-- What inspired you to submit this pull request? -->

**Change log entry**
None
<!-- If this is a customer-visible change, a brief summary to be placed
into the change log.
If you are not a Datadog employee, you can skip this section
and it will be filled or deleted during PR review. -->

**Additional Notes:**
I am not sure that this is the correct fix, but when the test is failing, it appears to be loading `psych` from two locations (ruby base runtime and gem path). Since the test does not clear its environment, it might be inheriting some paths from the test suite, but then tries to load bundler and its own set of gems, which is problematic?
<!-- Anything else we should know when reviewing? -->

**How to test the change?**
<!--
Describe here how the change can be validated.
You are strongly encouraged to provide automated tests for this PR (unit or integration).
If this change cannot be feasibly tested, please explain why,
unless the change does not modify code (e.g. only modifies docs, comments).
-->
CI consistently passing

<!-- Unsure? Have a question? Request a review! -->
