### PR TITLE
DEBUG-2334 Set duration to 0 for DI line probes

### DIFF
--- a/lib/datadog/di/probe_notification_builder.rb
+++ b/lib/datadog/di/probe_notification_builder.rb
@@ -121,7 +121,7 @@ module Datadog
           },
           # In python tracer duration is under debugger.snapshot,
           # but UI appears to expect it here at top level.
-          duration: duration ? (duration * 10**9).to_i : nil,
+          duration: duration ? (duration * 10**9).to_i : 0,
           host: nil,
           logger: {
             name: probe.file,
@@ -139,7 +139,7 @@ module Datadog
           "dd.span_id": Datadog::Tracing.active_span&.id&.to_s,
           ddsource: 'dd_debugger',
           message: probe.template && evaluate_template(probe.template,
-            duration: duration ? duration * 1000 : nil),
+            duration: duration ? duration * 1000 : 0),
           timestamp: timestamp,
         }
       end

--- a/spec/datadog/di/probe_notification_builder_spec.rb
+++ b/spec/datadog/di/probe_notification_builder_spec.rb
@@ -42,7 +42,6 @@ RSpec.describe Datadog::DI::ProbeNotificationBuilder do
   end
 
   describe '#build_received' do
-
     let(:payload) do
       builder.build_received(probe)
     end
@@ -72,7 +71,6 @@ RSpec.describe Datadog::DI::ProbeNotificationBuilder do
   end
 
   describe '#build_installed' do
-
     let(:payload) do
       builder.build_installed(probe)
     end
@@ -102,7 +100,6 @@ RSpec.describe Datadog::DI::ProbeNotificationBuilder do
   end
 
   describe '#build_emitting' do
-
     let(:payload) do
       builder.build_emitting(probe)
     end
@@ -132,7 +129,6 @@ RSpec.describe Datadog::DI::ProbeNotificationBuilder do
   end
 
   describe '#build_executed' do
-
     let(:payload) { builder.build_executed(probe) }
 
     context 'with template' do
@@ -144,9 +140,9 @@ RSpec.describe Datadog::DI::ProbeNotificationBuilder do
       let(:expected) do
         {
           ddsource: 'dd_debugger',
-          'dd.span_id': nil,
-          'dd.trace_id': nil,
-          'debugger.snapshot': {
+          "dd.span_id": nil,
+          "dd.trace_id": nil,
+          "debugger.snapshot": {
             captures: nil,
             evaluationErrors: [],
             id: String,
@@ -192,9 +188,9 @@ RSpec.describe Datadog::DI::ProbeNotificationBuilder do
       let(:expected) do
         {
           ddsource: 'dd_debugger',
-          'dd.span_id': nil,
-          'dd.trace_id': nil,
-          'debugger.snapshot': {
+          "dd.span_id": nil,
+          "dd.trace_id": nil,
+          "debugger.snapshot": {
             captures: nil,
             evaluationErrors: [],
             id: String,
@@ -257,9 +253,9 @@ RSpec.describe Datadog::DI::ProbeNotificationBuilder do
       let(:expected) do
         {
           ddsource: 'dd_debugger',
-          'dd.span_id': nil,
-          'dd.trace_id': nil,
-          'debugger.snapshot': {
+          "dd.span_id": nil,
+          "dd.trace_id": nil,
+          "debugger.snapshot": {
             captures: {
               lines: {
                 1 => {


### PR DESCRIPTION
<!--
Check out the
https://github.com/DataDog/dd-trace-rb/blob/master/docs/DevelopmentGuide.md
for guidance on how to set up your development environment,
run the test suite, write new integrations, and more.
-->

**What does this PR do?**
This PR  changes the probe notification builder to set duration to 0 in the generated payload if it was not supplied by the caller.
<!-- A brief description of the change being made with this pull request. -->

**Motivation:**
Line probes do not have a meaningful duration, however schema validation in system tests demands a numeric value.

Follow the behavior of other tracers and send 0 instead of nil in this case.
<!-- What inspired you to submit this pull request? -->

**Change log entry**
None
<!-- If this is a customer-visible change, a brief summary to be placed
into the change log.
If you are not a Datadog employee, you can skip this section
and it will be filled or deleted during PR review. -->

**Additional Notes:**
<!-- Anything else we should know when reviewing? -->
This PR also includes additional assertions in the unit test for probe notification builder to make that test in general way more useful. Some of these assertions already exist in integration tests but here they are closer to the code.

**How to test the change?**
Tested by system tests (to be committed in a later PR) and by the unit tests in this PR.
<!--
Describe here how the change can be validated.
You are strongly encouraged to provide automated tests for this PR (unit or integration).
If this change cannot be feasibly tested, please explain why,
unless the change does not modify code (e.g. only modifies docs, comments).
-->

<!-- Unsure? Have a question? Request a review! -->
