### PR TITLE
DEBUG-2334 require ostruct for OpenStruct dependency

### DIFF
--- a/lib/datadog/di/transport.rb
+++ b/lib/datadog/di/transport.rb
@@ -1,5 +1,6 @@
 # frozen_string_literal: true
 
+require 'ostruct'
 require_relative 'error'
 
 module Datadog


### PR DESCRIPTION
<!--
Check out the
https://github.com/DataDog/dd-trace-rb/blob/master/docs/DevelopmentGuide.md
for guidance on how to set up your development environment,
run the test suite, write new integrations, and more.
-->

**What does this PR do?**
This PR adds a require for ostruct to the file which uses OpenStruct.
<!-- A brief description of the change being made with this pull request. -->

**Motivation:**
When testing locally, the corresponding unit test fails without the require.
<!-- What inspired you to submit this pull request? -->

**Change log entry**
None
<!-- If this is a customer-visible change, a brief summary to be placed
into the change log.
If you are not a Datadog employee, you can skip this section
and it will be filled or deleted during PR review. -->

**Additional Notes:**
Same situation as https://github.com/DataDog/dd-trace-rb/pull/4126
<!-- Anything else we should know when reviewing? -->

**How to test the change?**
<!--
Describe here how the change can be validated.
You are strongly encouraged to provide automated tests for this PR (unit or integration).
If this change cannot be feasibly tested, please explain why,
unless the change does not modify code (e.g. only modifies docs, comments).
-->

<!-- Unsure? Have a question? Request a review! -->
