### PR TITLE
Update injection guard for Ruby 3.3

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -92,7 +92,8 @@ install-dependencies:
   tags: [ "arch:$ARCH" ]
   parallel:
     matrix:
-      - RUBY_VERSION: ["3.4", "3.3", "3.2", "3.1", "3.0", "2.7"]
+      # Promote again when adding 3.4 support
+      - RUBY_VERSION: ["3.3", "3.2", "3.1", "3.0", "2.7"]
         ARCH: [ "amd64", "arm64" ]
   stage: package
   needs:

--- a/lib-injection/README.md
+++ b/lib-injection/README.md
@@ -41,9 +41,9 @@ Currently, we support
 
 | Environment| version |
 |---|---|
-| Ruby  | `2.7`, `3.0`, `3.1`, `3.2`|
+| Ruby  | `2.7`, `3.0`, `3.1`, `3.2`, `3.3`|
 | Arch  | `amd64`, `arm64` |
-| glibc |  2.28+ |
+| glibc |  2.17+ |
 
 In order to ship `datadog` and its dependencies as a pre-install package, we need a few tweaks in our build pipeline.
 

--- a/lib-injection/host_inject.rb
+++ b/lib-injection/host_inject.rb
@@ -87,7 +87,7 @@ else
           major, minor, = RUBY_VERSION.split('.')
           ruby_api_version = "#{major}.#{minor}.0"
 
-          supported_ruby_api_versions = ['2.7.0', '3.0.0', '3.1.0', '3.2.0'].freeze
+          supported_ruby_api_versions = ['2.7.0', '3.0.0', '3.1.0', '3.2.0', '3.3.0'].freeze
 
           RUBY_ENGINE == 'ruby' && supported_ruby_api_versions.any? { |v| ruby_api_version == v }
         end


### PR DESCRIPTION
**What does this PR do?**

Followup with https://github.com/DataDog/dd-trace-rb/pull/4137

1. Update Injection guard to allow Ruby 3.3 runtime
2. Exclude Ruby 3.4 installation
3. Update documentation with runtime and glibc support