### PR TITLE
Revert "Run the cucumber test in unbundled environment"

### DIFF
--- a/spec/datadog/core/environment/execution_spec.rb
+++ b/spec/datadog/core/environment/execution_spec.rb
@@ -189,18 +189,16 @@ RSpec.describe Datadog::Core::Environment::Execution do
         it 'returns true' do
           Dir.mktmpdir do |dir|
             Dir.chdir(dir) do
-              Bundler.with_unbundled_env do
-                FileUtils.mkdir_p('features/support')
+              FileUtils.mkdir_p('features/support')
 
-                # Add our script to `env.rb`, which is always run before any feature is executed.
-                File.write('features/support/env.rb', repl_script)
+              # Add our script to `env.rb`, which is always run before any feature is executed.
+              File.write('features/support/env.rb', repl_script)
 
-                _, err, = Bundler.with_unbundled_env do
-                  Open3.capture3('ruby', stdin_data: script)
-                end
-
-                expect(err).to include('ACTUAL:true')
+              _, err, = Bundler.with_unbundled_env do
+                Open3.capture3('ruby', stdin_data: script)
               end
+
+              expect(err).to include('ACTUAL:true')
             end
           end
         end


### PR DESCRIPTION
Reverts DataDog/dd-trace-rb#4130

I missed that there was already a request to run the command in unbundled environment two lines below, thus the original PR did not add any value.