### PR TITLE
Address psych flaky test

### DIFF
--- a/spec/datadog/core/environment/execution_spec.rb
+++ b/spec/datadog/core/environment/execution_spec.rb
@@ -162,7 +162,9 @@ RSpec.describe Datadog::Core::Environment::Execution do
 
       context 'for Cucumber' do
         before do
-          unless PlatformHelpers.ci? || Gem.loaded_specs['cucumber']
+          if PlatformHelpers.ci? && Gem.loaded_specs['cucumber']
+            system('gem uninstall psych')
+          else
             skip('cucumber gem not present. In CI, this test is never skipped.')
           end
         end

--- a/spec/datadog/core/environment/execution_spec.rb
+++ b/spec/datadog/core/environment/execution_spec.rb
@@ -173,6 +173,7 @@ RSpec.describe Datadog::Core::Environment::Execution do
 
             gemfile(true) do
               source 'https://rubygems.org'
+              gem 'psych'
               if RUBY_VERSION >= '3.4'
                 # Cucumber is broken on Ruby 3.4, requires the fix in
                 # https://github.com/cucumber/cucumber-ruby/pull/1757
@@ -182,6 +183,7 @@ RSpec.describe Datadog::Core::Environment::Execution do
               end
             end
 
+            load Gem.bin_path('psych', 'psych')
             load Gem.bin_path('cucumber', 'cucumber')
           RUBY
         end


### PR DESCRIPTION
<!--
Check out the
https://github.com/DataDog/dd-trace-rb/blob/master/docs/DevelopmentGuide.md
for guidance on how to set up your development environment,
run the test suite, write new integrations, and more.
-->

**What does this PR do?**
This PR adds the `psych` gem to the cucumber loading script and uninstalls `psych` before the script runs.

**Motivation:**
The goal of this PR is to address a flaky test caused by the `psych` gem double loading. @p-datadog includes details in #4130. Per Oleg's findings, the built-in `psych` gem attempts to override the local/bundle gem. The error is caused when `lib/psych/class_loader.rb` is loaded for the second time. This solution first uninstalls `psych` before reinstalling it in the cucumber loading script in order to avoid the double-load error; however, it does not address the original gem load.

**Change log entry**
No change log entry.

**Additional Notes:**
This PR addresses the @DataDog/ruby-guild issue [here](https://github.com/DataDog/ruby-guild/issues/185).

**How to test the change?**
Given the nature of flakiness, I am testing the change through a Green CI and following up to confirm that no more flaky tests related to the `psych` gem double-loading occur throughout the repo.

<!-- Unsure? Have a question? Request a review! -->
