### PR TITLE
Attempt to fix psych test flakiness

### DIFF
--- a/spec/datadog/core/environment/execution_spec.rb
+++ b/spec/datadog/core/environment/execution_spec.rb
@@ -112,6 +112,15 @@ RSpec.describe Datadog::Core::Environment::Execution do
 
         let(:script) do
           <<-RUBY
+            # Under Ruby 3.0 through 3.2 there is a weird error that occurs
+            # in CI where two copies of psych get loaded in the same process,
+            # and even more strangely the first version is a newer one from
+            # gem and the second one is the older one from Ruby standard
+            # library. Try to work around this situation by forcing psych
+            # to be loaded from (some) gem.
+            # We still don't know exactly what is causing the original issue.
+            gem 'psych'
+
             require 'bundler/inline'
 
             gemfile(true) do


### PR DESCRIPTION
<!--
Check out the
https://github.com/DataDog/dd-trace-rb/blob/master/docs/DevelopmentGuide.md
for guidance on how to set up your development environment,
run the test suite, write new integrations, and more.
-->

**What does this PR do?**
This PR tries to fix intermittent failures in cucumber development? spec by explicitly loading *some* `psych` gem in the cucumber launcher.


<!-- A brief description of the change being made with this pull request. -->

**Motivation:**
The cucumber test is intermittently failing on Ruby 3.0 through 3.2. When it fails, there are two copies of psych being loaded, and the second copy fails during loading (psych can't overwrite itself).

We haven't figured out what is triggering the second load, but it seems to happen during package installation (i.e., cucumber-*) which requires YAML to parse gem metadata.

https://github.com/DataDog/dd-trace-rb/pull/4130 has additional investigation.

This PR offers a workaround for the issue by always configuring psych to be loaded from (some) gem, thus avoiding the error case where it's loaded from a gem and then is attempted to be loaded from standard library.
<!-- What inspired you to submit this pull request? -->

**Change log entry**
None
<!-- If this is a customer-visible change, a brief summary to be placed
into the change log.
If you are not a Datadog employee, you can skip this section
and it will be filled or deleted during PR review. -->

**Additional Notes:**
<!-- Anything else we should know when reviewing? -->

**How to test the change?**
<!--
Describe here how the change can be validated.
You are strongly encouraged to provide automated tests for this PR (unit or integration).
If this change cannot be feasibly tested, please explain why,
unless the change does not modify code (e.g. only modifies docs, comments).
-->
This PR passed full CI runs 3 times.

<!-- Unsure? Have a question? Request a review! -->
