### PR TITLE
Improve reliability by removing `jq` installation from CircleCI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -115,35 +115,7 @@ step_get_test_agent_trace_check_results: &step_get_test_agent_trace_check_result
   run:
     name: Get APM Test Agent Trace Check Results
     command: |
-      set +e  # Disable exiting from testagent response failure
-      SUMMARY_RESPONSE=$(curl -s -w "\n%{http_code}" -o summary_response.txt http://testagent:9126/test/trace_check/summary)
-      set -e
-      SUMMARY_RESPONSE_CODE=$(echo "$SUMMARY_RESPONSE" | awk 'END {print $NF}')
-
-      if [[ SUMMARY_RESPONSE_CODE -eq 200 ]]; then
-        echo "APM Test Agent is running. (HTTP 200)"
-      else
-        echo "APM Test Agent is not running and was not used for testing. No checks failed."
-        exit 0
-      fi
-
-      RESPONSE=$(curl -s -w "\n%{http_code}" -o response.txt http://testagent:9126/test/trace_check/failures)
-      RESPONSE_CODE=$(echo "$RESPONSE" | awk 'END {print $NF}')
-
-      if [[ $RESPONSE_CODE -eq 200 ]]; then
-        echo "All APM Test Agent Check Traces returned successful! (HTTP 200)"
-        echo "APM Test Agent Check Traces Summary Results:"
-        cat summary_response.txt | jq '.'
-      elif [[ $RESPONSE_CODE -eq 404 ]]; then
-        echo "Real APM Agent running in place of TestAgent, no checks to validate!"
-      else
-        echo "APM Test Agent Check Traces failed with response code: $RESPONSE_CODE"
-        echo "Failures:"
-        cat response.txt
-        echo "APM Test Agent Check Traces Summary Results:"
-        cat summary_response.txt | jq '.'
-        exit 1
-      fi
+      ruby .circleci/test_agent_check.rb
     when: always
 
 filters_all_branches_and_tags: &filters_all_branches_and_tags
@@ -285,10 +257,6 @@ orbs:
                 curl --silent --show-error --location --fail --retry 3 --output /usr/local/bin/dockerize $DOCKERIZE_URL
                 chmod +x /usr/local/bin/dockerize
                 dockerize --version
-          # Test agent uses `jq` to check results
-          - run:
-              name: Install jq
-              command: apt update && apt install jq -y
           # Wait for containers to start
           - docker-wait:
               port: 5432

--- a/.circleci/test_agent_check.rb
+++ b/.circleci/test_agent_check.rb
@@ -1,0 +1,42 @@
+#!/usr/bin/env ruby
+
+require 'net/http'
+require 'uri'
+require 'json'
+
+# Disable exiting on command failure
+begin
+  # Check if test agent is running
+  summary_uri = URI.parse('http://testagent:9126/test/trace_check/summary')
+  summary_response = Net::HTTP.get_response(summary_uri)
+
+  if summary_response.code == '200'
+    puts 'APM Test Agent is running. (HTTP 200)'
+  else
+    puts 'APM Test Agent is not running and was not used for testing. No checks failed.'
+    exit 0
+  end
+
+  # Check for test failures
+  failures_uri = URI.parse('http://testagent:9126/test/trace_check/failures')
+  failures_response = Net::HTTP.get_response(failures_uri)
+
+  case failures_response.code
+  when '200'
+    puts 'All APM Test Agent Check Traces returned successful! (HTTP 200)'
+    puts 'APM Test Agent Check Traces Summary Results:'
+    puts JSON.pretty_generate(JSON.parse(summary_response.body))
+  when '404'
+    puts 'Real APM Agent running in place of TestAgent, no checks to validate!'
+  else
+    puts "APM Test Agent Check Traces failed with response code: #{failures_response.code}"
+    puts 'Failures:'
+    puts failures_response.body
+    puts 'APM Test Agent Check Traces Summary Results:'
+    puts JSON.pretty_generate(JSON.parse(summary_response.body))
+    exit 1
+  end
+rescue => e
+  puts "An error occurred: #{e.message}"
+  exit 1
+end


### PR DESCRIPTION
**What does this PR do?**

I asked my friend Claude to write me a ruby script to replace `jq` installation.