### PR TITLE
psych fix attempt #3

### DIFF
--- a/spec/datadog/core/environment/execution_spec.rb
+++ b/spec/datadog/core/environment/execution_spec.rb
@@ -112,15 +112,6 @@ RSpec.describe Datadog::Core::Environment::Execution do
 
         let(:script) do
           <<-RUBY
-            # Under Ruby 3.0 through 3.2 there is a weird error that occurs
-            # in CI where two copies of psych get loaded in the same process,
-            # and even more strangely the first version is a newer one from
-            # gem and the second one is the older one from Ruby standard
-            # library. Try to work around this situation by forcing psych
-            # to be loaded from (some) gem.
-            # We still don't know exactly what is causing the original issue.
-            gem 'psych'
-
             require 'bundler/inline'
 
             gemfile(true) do
@@ -178,6 +169,15 @@ RSpec.describe Datadog::Core::Environment::Execution do
 
         let(:script) do
           <<-'RUBY'
+            # Under Ruby 3.0 through 3.2 there is a weird error that occurs
+            # in CI where two copies of psych get loaded in the same process,
+            # and even more strangely the first version is a newer one from
+            # gem and the second one is the older one from Ruby standard
+            # library. Try to work around this situation by forcing psych
+            # to be loaded from (some) gem.
+            # We still don't know exactly what is causing the original issue.
+            gem 'psych'
+
             require 'bundler/inline'
 
             gemfile(true) do


### PR DESCRIPTION
<!--
Check out the
https://github.com/DataDog/dd-trace-rb/blob/master/docs/DevelopmentGuide.md
for guidance on how to set up your development environment,
run the test suite, write new integrations, and more.
-->

**What does this PR do?**
Attempts to fix the flaky environment execution spec.

In the previous PR (#4145) I mistakenly placed the 'gem' instruction into a spring test. It was intended to be in the cucumber test.
<!-- A brief description of the change being made with this pull request. -->

**Motivation:**
Noticed this while reading the diff in https://github.com/DataDog/dd-trace-rb/pull/4150.
<!-- What inspired you to submit this pull request? -->

**Change log entry**
None
<!-- If this is a customer-visible change, a brief summary to be placed
into the change log.
If you are not a Datadog employee, you can skip this section
and it will be filled or deleted during PR review. -->

**Additional Notes:**
<!-- Anything else we should know when reviewing? -->

**How to test the change?**
<!--
Describe here how the change can be validated.
You are strongly encouraged to provide automated tests for this PR (unit or integration).
If this change cannot be feasibly tested, please explain why,
unless the change does not modify code (e.g. only modifies docs, comments).
-->

<!-- Unsure? Have a question? Request a review! -->
