### PR TITLE
DEBUG-2334 test argument squashing into hashes on ruby 2

### DIFF
--- a/spec/datadog/di/hook_method.rb
+++ b/spec/datadog/di/hook_method.rb
@@ -26,4 +26,12 @@ class HookTestClass
   def infinitely_recursive(depth = 0)
     infinitely_recursive(depth + 1)
   end
+
+  def squashed(options)
+    options
+  end
+
+  def positional_and_squashed(arg, options)
+    [arg, options]
+  end
 end

--- a/spec/datadog/di/instrumenter_spec.rb
+++ b/spec/datadog/di/instrumenter_spec.rb
@@ -271,7 +271,6 @@ RSpec.describe Datadog::DI::Instrumenter do
       end
 
       context 'when there is also a positional argument' do
-
         shared_examples 'invokes callback and captures parameters' do
           it 'invokes callback and captures parameters' do
             instrumenter.hook_method(probe) do |payload|

--- a/spec/datadog/di/instrumenter_spec.rb
+++ b/spec/datadog/di/instrumenter_spec.rb
@@ -13,6 +13,7 @@ RSpec.describe Datadog::DI::Instrumenter do
     allow(settings.dynamic_instrumentation.internal).to receive(:untargeted_trace_points).and_return(false)
     allow(settings.dynamic_instrumentation).to receive(:max_capture_depth).and_return(2)
     allow(settings.dynamic_instrumentation).to receive(:max_capture_attribute_count).and_return(2)
+    allow(settings.dynamic_instrumentation).to receive(:max_capture_string_length).and_return(100)
     allow(settings.dynamic_instrumentation).to receive(:redacted_type_names).and_return([])
     allow(settings.dynamic_instrumentation).to receive(:redacted_identifiers).and_return([])
   end
@@ -218,6 +219,96 @@ RSpec.describe Datadog::DI::Instrumenter do
             args = [41]
             kwargs = {kwarg: 42}
             expect(HookTestClass.new.hook_test_method_with_pos_and_kwarg(*args, **kwargs)).to eq [41, 42]
+          end
+
+          include_examples 'invokes callback and captures parameters'
+        end
+      end
+    end
+
+    context 'keyword arguments squashed into a hash' do
+      ruby_2_only
+
+      shared_examples 'invokes callback and captures parameters' do
+        it 'invokes callback and captures parameters' do
+          instrumenter.hook_method(probe) do |payload|
+            observed_calls << payload
+          end
+
+          target_call
+
+          expect(observed_calls.length).to eq 1
+          expect(observed_calls.first.keys.sort).to eq call_keys
+          expect(observed_calls.first[:rv]).to eq(kwarg: 42)
+          expect(observed_calls.first[:duration]).to be_a(Float)
+
+          expect(observed_calls.first[:serialized_entry_args]).to eq(
+            kwarg: {type: 'Integer', value: '42'}
+          )
+        end
+      end
+
+      let(:probe_args) do
+        {type_name: 'HookTestClass', method_name: 'squashed',
+         capture_snapshot: true}
+      end
+
+      context 'call with keyword arguments' do
+        let(:target_call) do
+          expect(HookTestClass.new.squashed(kwarg: 42)).to eq(kwarg: 42)
+        end
+
+        include_examples 'invokes callback and captures parameters'
+      end
+
+      context 'call with positional argument' do
+        let(:target_call) do
+          arg = {kwarg: 42}
+          expect(HookTestClass.new.squashed(arg)).to eq(kwarg: 42)
+        end
+
+        include_examples 'invokes callback and captures parameters'
+      end
+
+      context 'when there is also a positional argument' do
+
+        shared_examples 'invokes callback and captures parameters' do
+          it 'invokes callback and captures parameters' do
+            instrumenter.hook_method(probe) do |payload|
+              observed_calls << payload
+            end
+
+            target_call
+
+            expect(observed_calls.length).to eq 1
+            expect(observed_calls.first.keys.sort).to eq call_keys
+            expect(observed_calls.first[:rv]).to eq(['hello', {kwarg: 42}])
+            expect(observed_calls.first[:duration]).to be_a(Float)
+
+            expect(observed_calls.first[:serialized_entry_args]).to eq(
+              arg1: {type: 'String', value: 'hello'},
+              kwarg: {type: 'Integer', value: '42'},
+            )
+          end
+        end
+
+        let(:probe_args) do
+          {type_name: 'HookTestClass', method_name: 'positional_and_squashed',
+           capture_snapshot: true}
+        end
+
+        context 'call with positional and keyword arguments' do
+          let(:target_call) do
+            expect(HookTestClass.new.positional_and_squashed('hello', kwarg: 42)).to eq(['hello', {kwarg: 42}])
+          end
+
+          include_examples 'invokes callback and captures parameters'
+        end
+
+        context 'call with a splat' do
+          let(:target_call) do
+            args = ['hello', {kwarg: 42}]
+            expect(HookTestClass.new.positional_and_squashed(*args)).to eq(['hello', {kwarg: 42}])
           end
 
           include_examples 'invokes callback and captures parameters'

--- a/spec/datadog/di/spec_helper.rb
+++ b/spec/datadog/di/spec_helper.rb
@@ -1,5 +1,13 @@
 module DIHelpers
   module ClassMethods
+    def ruby_2_only
+      if RUBY_VERSION >= '3'
+        before(:all) do
+          skip "Test is only for Ruby 2"
+        end
+      end
+    end
+
     def di_test
       if PlatformHelpers.jruby?
         before(:all) do


### PR DESCRIPTION
<!--
Check out the
https://github.com/DataDog/dd-trace-rb/blob/master/docs/DevelopmentGuide.md
for guidance on how to set up your development environment,
run the test suite, write new integrations, and more.
-->

**What does this PR do?**
Adds test coverage for Ruby 2 pattern of defining a method with an "options" last argument that keyword arguments are squashed into.
<!-- A brief description of the change being made with this pull request. -->

**Motivation:**
Additional test coverage for DI.
<!-- What inspired you to submit this pull request? -->

**Change log entry**
None
<!-- If this is a customer-visible change, a brief summary to be placed
into the change log.
If you are not a Datadog employee, you can skip this section
and it will be filled or deleted during PR review. -->

**Additional Notes:**
<!-- Anything else we should know when reviewing? -->

**How to test the change?**
Unit tests are included.
<!--
Describe here how the change can be validated.
You are strongly encouraged to provide automated tests for this PR (unit or integration).
If this change cannot be feasibly tested, please explain why,
unless the change does not modify code (e.g. only modifies docs, comments).
-->

<!-- Unsure? Have a question? Request a review! -->
