### PR TITLE
DEBUG-2334 correctly instrument methods that yield

### DIFF
--- a/lib/datadog/di/instrumenter.rb
+++ b/lib/datadog/di/instrumenter.rb
@@ -106,7 +106,7 @@ module Datadog
         settings = self.settings
 
         mod = Module.new do
-          define_method(method_name) do |*args, **kwargs| # steep:ignore
+          define_method(method_name) do |*args, **kwargs, &target_block| # steep:ignore
             if rate_limiter.nil? || rate_limiter.allow?
               # Arguments may be mutated by the method, therefore
               # they need to be serialized prior to method invocation.
@@ -120,14 +120,14 @@ module Datadog
               duration = Benchmark.realtime do # steep:ignore
                 rv = if args.any?
                   if kwargs.any?
-                    super(*args, **kwargs)
+                    super(*args, **kwargs, &target_block)
                   else
-                    super(*args)
+                    super(*args, &target_block)
                   end
                 elsif kwargs.any?
-                  super(**kwargs)
+                  super(**kwargs, &target_block)
                 else
-                  super()
+                  super(&target_block)
                 end
               end
               # The method itself is not part of the stack trace because

--- a/spec/datadog/di/hook_method.rb
+++ b/spec/datadog/di/hook_method.rb
@@ -15,6 +15,10 @@ class HookTestClass
     [arg, kwarg]
   end
 
+  def yielding(arg)
+    yield arg
+  end
+
   def recursive(depth)
     if depth > 0
       recursive(depth - 1) + '-'

--- a/spec/datadog/di/instrumenter_spec.rb
+++ b/spec/datadog/di/instrumenter_spec.rb
@@ -76,6 +76,31 @@ RSpec.describe Datadog::DI::Instrumenter do
       end
     end
 
+    context 'when target method yields to a block' do
+      let(:probe_args) do
+        {type_name: 'HookTestClass', method_name: 'yielding'}
+      end
+
+      it 'invokes callback' do
+        instrumenter.hook_method(probe) do |payload|
+          observed_calls << payload
+        end
+
+        yielded_value = nil
+        expect(HookTestClass.new.yielding('hello') do |value|
+          yielded_value = value
+          [value]
+        end).to eq ['hello']
+
+        expect(yielded_value).to eq('hello')
+
+        expect(observed_calls.length).to eq 1
+        expect(observed_calls.first.keys.sort).to eq call_keys
+        expect(observed_calls.first[:rv]).to eq ['hello']
+        expect(observed_calls.first[:duration]).to be_a(Float)
+      end
+    end
+
     context 'positional args' do
       context 'without snapshot capture' do
         let(:probe_args) do


### PR DESCRIPTION
<!--
Check out the
https://github.com/DataDog/dd-trace-rb/blob/master/docs/DevelopmentGuide.md
for guidance on how to set up your development environment,
run the test suite, write new integrations, and more.
-->

**What does this PR do?**
Implements/repairs instrumentation of methods that yield. Previously attempting to call such a method after instrumenting it would produce infinite recursion.
<!-- A brief description of the change being made with this pull request. -->

**Motivation:**
Initial Ruby DI implementation.
<!-- What inspired you to submit this pull request? -->

**Change log entry**
None
<!-- If this is a customer-visible change, a brief summary to be placed
into the change log.
If you are not a Datadog employee, you can skip this section
and it will be filled or deleted during PR review. -->

**Additional Notes:**
<!-- Anything else we should know when reviewing? -->

**How to test the change?**
<!--
Describe here how the change can be validated.
You are strongly encouraged to provide automated tests for this PR (unit or integration).
If this change cannot be feasibly tested, please explain why,
unless the change does not modify code (e.g. only modifies docs, comments).
-->
Unit tests are included.

<!-- Unsure? Have a question? Request a review! -->
