### PR TITLE
[PROF-10967] Fix missing suppressions after PR 4161 got merged

### DIFF
--- a/.github/workflows/test-memory-leaks.yaml
+++ b/.github/workflows/test-memory-leaks.yaml
@@ -12,6 +12,7 @@ jobs:
           bundler: latest
           cache-version: v1 # bump this to invalidate cache
       - run: sudo apt-get update && (sudo apt-get install -y valgrind || sleep 5 && sudo apt-get install -y valgrind) && valgrind --version
+      - run: gem update --system 3.5.23 # TODO: This is a workaround for a buggy rubygems in 3.4.0-preview2; remove once stable version 3.4 is out
       - run: bundle exec rake compile spec:profiling:memcheck
   test-asan:
     # Temporarily ruby-asan builds changes

--- a/suppressions/ruby-3.4.supp
+++ b/suppressions/ruby-3.4.supp
@@ -45,6 +45,21 @@
   ...
 }
 
+# When a Ruby process forks, it looks like Ruby doesn't clean up the memory of old threads?
+{
+  ruby-native-thread-memory-3
+  Memcheck:Leak
+  fun:calloc
+  fun:calloc1
+  fun:rb_gc_impl_calloc
+  fun:ruby_xcalloc
+  fun:native_thread_alloc
+  fun:native_thread_create_dedicated
+  fun:native_thread_create
+  fun:thread_create_core
+  ...
+}
+
 # We don't care about the pkg-config external tool
 {
   pkg-config-memory


### PR DESCRIPTION
**What does this PR do?**

This PR updates the suppressions file to make the "Test for memory leaks" check pass, after #4161 broke it by upgrading the Ruby version used to run this check.

**Motivation:**

Make sure master is squeaky clean.

**Change log entry**

(Not relevant to customers)

**Additional Notes:**

This was supposed to go together with #4161, but even though the "Test for memory leaks" failed, the auto-merge still merged my PR while I was preparing this extra commit to make it pass CI.

**How to test the change?**

Validate the "Test for memory leaks", CI validation passes again.
