### PR TITLE
Update libddwaf to 1.18.0.0.0

### DIFF
--- a/datadog.gemspec
+++ b/datadog.gemspec
@@ -65,7 +65,7 @@ Gem::Specification.new do |spec|
   spec.add_dependency 'datadog-ruby_core_source', '~> 3.3'
 
   # Used by appsec
-  spec.add_dependency 'libddwaf', '~> 1.15.0.0.0'
+  spec.add_dependency 'libddwaf', '~> 1.18.0.0.0'
 
   # When updating the version here, please also update the version in `libdatadog_extconf_helpers.rb`
   # (and yes we have a test for it)

--- a/gemfiles/jruby_9.2_activesupport.gemfile.lock
+++ b/gemfiles/jruby_9.2_activesupport.gemfile.lock
@@ -14,7 +14,7 @@ PATH
     datadog (2.7.0)
       datadog-ruby_core_source (~> 3.3)
       libdatadog (~> 14.1.0.1.0)
-      libddwaf (~> 1.15.0.0.0)
+      libddwaf (~> 1.18.0.0.0)
       msgpack
 
 GEM
@@ -103,7 +103,7 @@ GEM
     jsonapi-renderer (0.2.2)
     king_konf (1.0.1)
     libdatadog (14.1.0.1.0)
-    libddwaf (1.15.0.0.0-java)
+    libddwaf (1.18.0.0.0-java)
       ffi (~> 1.0)
     lograge (0.13.0)
       actionpack (>= 4)

--- a/gemfiles/jruby_9.2_aws.gemfile.lock
+++ b/gemfiles/jruby_9.2_aws.gemfile.lock
@@ -14,7 +14,7 @@ PATH
     datadog (2.7.0)
       datadog-ruby_core_source (~> 3.3)
       libdatadog (~> 14.1.0.1.0)
-      libddwaf (~> 1.15.0.0.0)
+      libddwaf (~> 1.18.0.0.0)
       msgpack
 
 GEM
@@ -1464,7 +1464,7 @@ GEM
     json-schema (2.8.1)
       addressable (>= 2.4)
     libdatadog (14.1.0.1.0)
-    libddwaf (1.15.0.0.0-java)
+    libddwaf (1.18.0.0.0-java)
       ffi (~> 1.0)
     memory_profiler (0.9.14)
     method_source (1.0.0)

--- a/gemfiles/jruby_9.2_contrib.gemfile.lock
+++ b/gemfiles/jruby_9.2_contrib.gemfile.lock
@@ -14,7 +14,7 @@ PATH
     datadog (2.7.0)
       datadog-ruby_core_source (~> 3.3)
       libdatadog (~> 14.1.0.1.0)
-      libddwaf (~> 1.15.0.0.0)
+      libddwaf (~> 1.18.0.0.0)
       msgpack
 
 GEM
@@ -51,7 +51,7 @@ GEM
     json-schema (2.8.1)
       addressable (>= 2.4)
     libdatadog (14.1.0.1.0)
-    libddwaf (1.15.0.0.0-java)
+    libddwaf (1.18.0.0.0-java)
       ffi (~> 1.0)
     memory_profiler (0.9.14)
     method_source (1.0.0)

--- a/gemfiles/jruby_9.2_contrib_old.gemfile.lock
+++ b/gemfiles/jruby_9.2_contrib_old.gemfile.lock
@@ -14,7 +14,7 @@ PATH
     datadog (2.7.0)
       datadog-ruby_core_source (~> 3.3)
       libdatadog (~> 14.1.0.1.0)
-      libddwaf (~> 1.15.0.0.0)
+      libddwaf (~> 1.18.0.0.0)
       msgpack
 
 GEM
@@ -47,7 +47,7 @@ GEM
     json-schema (2.8.1)
       addressable (>= 2.4)
     libdatadog (14.1.0.1.0)
-    libddwaf (1.15.0.0.0-java)
+    libddwaf (1.18.0.0.0-java)
       ffi (~> 1.0)
     memory_profiler (0.9.14)
     method_source (1.0.0)

--- a/gemfiles/jruby_9.2_core_old.gemfile.lock
+++ b/gemfiles/jruby_9.2_core_old.gemfile.lock
@@ -14,7 +14,7 @@ PATH
     datadog (2.7.0)
       datadog-ruby_core_source (~> 3.3)
       libdatadog (~> 14.1.0.1.0)
-      libddwaf (~> 1.15.0.0.0)
+      libddwaf (~> 1.18.0.0.0)
       msgpack
 
 GEM
@@ -42,7 +42,7 @@ GEM
     json-schema (2.8.1)
       addressable (>= 2.4)
     libdatadog (14.1.0.1.0)
-    libddwaf (1.15.0.0.0-java)
+    libddwaf (1.18.0.0.0-java)
       ffi (~> 1.0)
     memory_profiler (0.9.14)
     method_source (1.0.0)

--- a/gemfiles/jruby_9.2_elasticsearch_7.gemfile.lock
+++ b/gemfiles/jruby_9.2_elasticsearch_7.gemfile.lock
@@ -14,7 +14,7 @@ PATH
     datadog (2.7.0)
       datadog-ruby_core_source (~> 3.3)
       libdatadog (~> 14.1.0.1.0)
-      libddwaf (~> 1.15.0.0.0)
+      libddwaf (~> 1.18.0.0.0)
       msgpack
 
 GEM
@@ -76,7 +76,7 @@ GEM
     json-schema (2.8.1)
       addressable (>= 2.4)
     libdatadog (14.1.0.1.0)
-    libddwaf (1.15.0.0.0-java)
+    libddwaf (1.18.0.0.0-java)
       ffi (~> 1.0)
     memory_profiler (0.9.14)
     method_source (1.0.0)

--- a/gemfiles/jruby_9.2_elasticsearch_8.gemfile.lock
+++ b/gemfiles/jruby_9.2_elasticsearch_8.gemfile.lock
@@ -14,7 +14,7 @@ PATH
     datadog (2.7.0)
       datadog-ruby_core_source (~> 3.3)
       libdatadog (~> 14.1.0.1.0)
-      libddwaf (~> 1.15.0.0.0)
+      libddwaf (~> 1.18.0.0.0)
       msgpack
 
 GEM
@@ -74,7 +74,7 @@ GEM
     json-schema (2.8.1)
       addressable (>= 2.4)
     libdatadog (14.1.0.1.0)
-    libddwaf (1.15.0.0.0-java)
+    libddwaf (1.18.0.0.0-java)
       ffi (~> 1.0)
     memory_profiler (0.9.14)
     method_source (1.0.0)

--- a/gemfiles/jruby_9.2_elasticsearch_latest.gemfile.lock
+++ b/gemfiles/jruby_9.2_elasticsearch_latest.gemfile.lock
@@ -14,7 +14,7 @@ PATH
     datadog (2.7.0)
       datadog-ruby_core_source (~> 3.3)
       libdatadog (~> 14.1.0.1.0)
-      libddwaf (~> 1.15.0.0.0)
+      libddwaf (~> 1.18.0.0.0)
       msgpack
 
 GEM
@@ -76,7 +76,7 @@ GEM
     json-schema (2.8.1)
       addressable (>= 2.4)
     libdatadog (14.1.0.1.0)
-    libddwaf (1.15.0.0.0-java)
+    libddwaf (1.18.0.0.0-java)
       ffi (~> 1.0)
     memory_profiler (0.9.14)
     method_source (1.1.0)

--- a/gemfiles/jruby_9.2_graphql_2.0.gemfile.lock
+++ b/gemfiles/jruby_9.2_graphql_2.0.gemfile.lock
@@ -14,7 +14,7 @@ PATH
     datadog (2.7.0)
       datadog-ruby_core_source (~> 3.3)
       libdatadog (~> 14.1.0.1.0)
-      libddwaf (~> 1.15.0.0.0)
+      libddwaf (~> 1.18.0.0.0)
       msgpack
 
 GEM
@@ -113,7 +113,7 @@ GEM
     json-schema (2.8.1)
       addressable (>= 2.4)
     libdatadog (14.1.0.1.0)
-    libddwaf (1.15.0.0.0-java)
+    libddwaf (1.18.0.0.0-java)
       ffi (~> 1.0)
     lograge (0.14.0)
       actionpack (>= 4)

--- a/gemfiles/jruby_9.2_http.gemfile.lock
+++ b/gemfiles/jruby_9.2_http.gemfile.lock
@@ -14,7 +14,7 @@ PATH
     datadog (2.7.0)
       datadog-ruby_core_source (~> 3.3)
       libdatadog (~> 14.1.0.1.0)
-      libddwaf (~> 1.15.0.0.0)
+      libddwaf (~> 1.18.0.0.0)
       msgpack
 
 GEM
@@ -85,7 +85,7 @@ GEM
     json-schema (2.8.1)
       addressable (>= 2.4)
     libdatadog (14.1.0.1.0)
-    libddwaf (1.15.0.0.0-java)
+    libddwaf (1.18.0.0.0-java)
       ffi (~> 1.0)
     memory_profiler (0.9.14)
     method_source (1.0.0)

--- a/gemfiles/jruby_9.2_opensearch_2.gemfile.lock
+++ b/gemfiles/jruby_9.2_opensearch_2.gemfile.lock
@@ -14,7 +14,7 @@ PATH
     datadog (2.7.0)
       datadog-ruby_core_source (~> 3.3)
       libdatadog (~> 14.1.0.1.0)
-      libddwaf (~> 1.15.0.0.0)
+      libddwaf (~> 1.18.0.0.0)
       msgpack
 
 GEM
@@ -66,7 +66,7 @@ GEM
     json-schema (2.8.1)
       addressable (>= 2.4)
     libdatadog (14.1.0.1.0)
-    libddwaf (1.15.0.0.0-java)
+    libddwaf (1.18.0.0.0-java)
       ffi (~> 1.0)
     memory_profiler (0.9.14)
     method_source (1.0.0)

--- a/gemfiles/jruby_9.2_opensearch_3.gemfile.lock
+++ b/gemfiles/jruby_9.2_opensearch_3.gemfile.lock
@@ -14,7 +14,7 @@ PATH
     datadog (2.7.0)
       datadog-ruby_core_source (~> 3.3)
       libdatadog (~> 14.1.0.1.0)
-      libddwaf (~> 1.15.0.0.0)
+      libddwaf (~> 1.18.0.0.0)
       msgpack
 
 GEM
@@ -66,7 +66,7 @@ GEM
     json-schema (2.8.1)
       addressable (>= 2.4)
     libdatadog (14.1.0.1.0)
-    libddwaf (1.15.0.0.0-java)
+    libddwaf (1.18.0.0.0-java)
       ffi (~> 1.0)
     memory_profiler (0.9.14)
     method_source (1.0.0)

--- a/gemfiles/jruby_9.2_opensearch_latest.gemfile.lock
+++ b/gemfiles/jruby_9.2_opensearch_latest.gemfile.lock
@@ -14,7 +14,7 @@ PATH
     datadog (2.7.0)
       datadog-ruby_core_source (~> 3.3)
       libdatadog (~> 14.1.0.1.0)
-      libddwaf (~> 1.15.0.0.0)
+      libddwaf (~> 1.18.0.0.0)
       msgpack
 
 GEM
@@ -68,7 +68,7 @@ GEM
     json-schema (2.8.1)
       addressable (>= 2.4)
     libdatadog (14.1.0.1.0)
-    libddwaf (1.15.0.0.0-java)
+    libddwaf (1.18.0.0.0-java)
       ffi (~> 1.0)
     memory_profiler (0.9.14)
     method_source (1.1.0)

--- a/gemfiles/jruby_9.2_rack_1.gemfile.lock
+++ b/gemfiles/jruby_9.2_rack_1.gemfile.lock
@@ -14,7 +14,7 @@ PATH
     datadog (2.7.0)
       datadog-ruby_core_source (~> 3.3)
       libdatadog (~> 14.1.0.1.0)
-      libddwaf (~> 1.15.0.0.0)
+      libddwaf (~> 1.18.0.0.0)
       msgpack
 
 GEM
@@ -42,7 +42,7 @@ GEM
     json-schema (2.8.1)
       addressable (>= 2.4)
     libdatadog (14.1.0.1.0)
-    libddwaf (1.15.0.0.0-java)
+    libddwaf (1.18.0.0.0-java)
       ffi (~> 1.0)
     memory_profiler (0.9.14)
     method_source (1.0.0)

--- a/gemfiles/jruby_9.2_rack_2.gemfile.lock
+++ b/gemfiles/jruby_9.2_rack_2.gemfile.lock
@@ -14,7 +14,7 @@ PATH
     datadog (2.7.0)
       datadog-ruby_core_source (~> 3.3)
       libdatadog (~> 14.1.0.1.0)
-      libddwaf (~> 1.15.0.0.0)
+      libddwaf (~> 1.18.0.0.0)
       msgpack
 
 GEM
@@ -42,7 +42,7 @@ GEM
     json-schema (2.8.1)
       addressable (>= 2.4)
     libdatadog (14.1.0.1.0)
-    libddwaf (1.15.0.0.0-java)
+    libddwaf (1.18.0.0.0-java)
       ffi (~> 1.0)
     memory_profiler (0.9.14)
     method_source (1.0.0)

--- a/gemfiles/jruby_9.2_rack_3.gemfile.lock
+++ b/gemfiles/jruby_9.2_rack_3.gemfile.lock
@@ -14,7 +14,7 @@ PATH
     datadog (2.7.0)
       datadog-ruby_core_source (~> 3.3)
       libdatadog (~> 14.1.0.1.0)
-      libddwaf (~> 1.15.0.0.0)
+      libddwaf (~> 1.18.0.0.0)
       msgpack
 
 GEM
@@ -42,7 +42,7 @@ GEM
     json-schema (2.8.1)
       addressable (>= 2.4)
     libdatadog (14.1.0.1.0)
-    libddwaf (1.15.0.0.0-java)
+    libddwaf (1.18.0.0.0-java)
       ffi (~> 1.0)
     memory_profiler (0.9.14)
     method_source (1.0.0)

--- a/gemfiles/jruby_9.2_rack_latest.gemfile.lock
+++ b/gemfiles/jruby_9.2_rack_latest.gemfile.lock
@@ -14,7 +14,7 @@ PATH
     datadog (2.7.0)
       datadog-ruby_core_source (~> 3.3)
       libdatadog (~> 14.1.0.1.0)
-      libddwaf (~> 1.15.0.0.0)
+      libddwaf (~> 1.18.0.0.0)
       msgpack
 
 GEM
@@ -45,7 +45,7 @@ GEM
     json-schema (2.8.1)
       addressable (>= 2.4)
     libdatadog (14.1.0.1.0)
-    libddwaf (1.15.0.0.0-java)
+    libddwaf (1.18.0.0.0-java)
       ffi (~> 1.0)
     memory_profiler (0.9.14)
     method_source (1.1.0)

--- a/gemfiles/jruby_9.2_rails5_mysql2.gemfile.lock
+++ b/gemfiles/jruby_9.2_rails5_mysql2.gemfile.lock
@@ -14,7 +14,7 @@ PATH
     datadog (2.7.0)
       datadog-ruby_core_source (~> 3.3)
       libdatadog (~> 14.1.0.1.0)
-      libddwaf (~> 1.15.0.0.0)
+      libddwaf (~> 1.18.0.0.0)
       msgpack
 
 GEM
@@ -97,7 +97,7 @@ GEM
     json-schema (2.8.1)
       addressable (>= 2.4)
     libdatadog (14.1.0.1.0)
-    libddwaf (1.15.0.0.0-java)
+    libddwaf (1.18.0.0.0-java)
       ffi (~> 1.0)
     lograge (0.12.0)
       actionpack (>= 4)

--- a/gemfiles/jruby_9.2_rails5_postgres.gemfile.lock
+++ b/gemfiles/jruby_9.2_rails5_postgres.gemfile.lock
@@ -14,7 +14,7 @@ PATH
     datadog (2.7.0)
       datadog-ruby_core_source (~> 3.3)
       libdatadog (~> 14.1.0.1.0)
-      libddwaf (~> 1.15.0.0.0)
+      libddwaf (~> 1.18.0.0.0)
       msgpack
 
 GEM
@@ -99,7 +99,7 @@ GEM
     json-schema (2.8.1)
       addressable (>= 2.4)
     libdatadog (14.1.0.1.0)
-    libddwaf (1.15.0.0.0-java)
+    libddwaf (1.18.0.0.0-java)
       ffi (~> 1.0)
     lograge (0.12.0)
       actionpack (>= 4)

--- a/gemfiles/jruby_9.2_rails5_postgres_redis.gemfile.lock
+++ b/gemfiles/jruby_9.2_rails5_postgres_redis.gemfile.lock
@@ -14,7 +14,7 @@ PATH
     datadog (2.7.0)
       datadog-ruby_core_source (~> 3.3)
       libdatadog (~> 14.1.0.1.0)
-      libddwaf (~> 1.15.0.0.0)
+      libddwaf (~> 1.18.0.0.0)
       msgpack
 
 GEM
@@ -100,7 +100,7 @@ GEM
     json-schema (2.8.1)
       addressable (>= 2.4)
     libdatadog (14.1.0.1.0)
-    libddwaf (1.15.0.0.0-java)
+    libddwaf (1.18.0.0.0-java)
       ffi (~> 1.0)
     lograge (0.12.0)
       actionpack (>= 4)

--- a/gemfiles/jruby_9.2_rails5_postgres_redis_activesupport.gemfile.lock
+++ b/gemfiles/jruby_9.2_rails5_postgres_redis_activesupport.gemfile.lock
@@ -14,7 +14,7 @@ PATH
     datadog (2.7.0)
       datadog-ruby_core_source (~> 3.3)
       libdatadog (~> 14.1.0.1.0)
-      libddwaf (~> 1.15.0.0.0)
+      libddwaf (~> 1.18.0.0.0)
       msgpack
 
 GEM
@@ -99,7 +99,7 @@ GEM
     json-schema (2.8.1)
       addressable (>= 2.4)
     libdatadog (14.1.0.1.0)
-    libddwaf (1.15.0.0.0-java)
+    libddwaf (1.18.0.0.0-java)
       ffi (~> 1.0)
     lograge (0.12.0)
       actionpack (>= 4)

--- a/gemfiles/jruby_9.2_rails5_postgres_sidekiq.gemfile.lock
+++ b/gemfiles/jruby_9.2_rails5_postgres_sidekiq.gemfile.lock
@@ -14,7 +14,7 @@ PATH
     datadog (2.7.0)
       datadog-ruby_core_source (~> 3.3)
       libdatadog (~> 14.1.0.1.0)
-      libddwaf (~> 1.15.0.0.0)
+      libddwaf (~> 1.18.0.0.0)
       msgpack
 
 GEM
@@ -100,7 +100,7 @@ GEM
     json-schema (2.8.1)
       addressable (>= 2.4)
     libdatadog (14.1.0.1.0)
-    libddwaf (1.15.0.0.0-java)
+    libddwaf (1.18.0.0.0-java)
       ffi (~> 1.0)
     lograge (0.12.0)
       actionpack (>= 4)

--- a/gemfiles/jruby_9.2_rails5_semantic_logger.gemfile.lock
+++ b/gemfiles/jruby_9.2_rails5_semantic_logger.gemfile.lock
@@ -14,7 +14,7 @@ PATH
     datadog (2.7.0)
       datadog-ruby_core_source (~> 3.3)
       libdatadog (~> 14.1.0.1.0)
-      libddwaf (~> 1.15.0.0.0)
+      libddwaf (~> 1.18.0.0.0)
       msgpack
 
 GEM
@@ -99,7 +99,7 @@ GEM
     json-schema (2.8.1)
       addressable (>= 2.4)
     libdatadog (14.1.0.1.0)
-    libddwaf (1.15.0.0.0-java)
+    libddwaf (1.18.0.0.0-java)
       ffi (~> 1.0)
     loofah (2.19.1)
       crass (~> 1.0.2)

--- a/gemfiles/jruby_9.2_rails61_mysql2.gemfile.lock
+++ b/gemfiles/jruby_9.2_rails61_mysql2.gemfile.lock
@@ -14,7 +14,7 @@ PATH
     datadog (2.7.0)
       datadog-ruby_core_source (~> 3.3)
       libdatadog (~> 14.1.0.1.0)
-      libddwaf (~> 1.15.0.0.0)
+      libddwaf (~> 1.18.0.0.0)
       msgpack
 
 GEM
@@ -114,7 +114,7 @@ GEM
     json-schema (2.8.1)
       addressable (>= 2.4)
     libdatadog (14.1.0.1.0)
-    libddwaf (1.15.0.0.0-java)
+    libddwaf (1.18.0.0.0-java)
       ffi (~> 1.0)
     lograge (0.12.0)
       actionpack (>= 4)

--- a/gemfiles/jruby_9.2_rails61_postgres.gemfile.lock
+++ b/gemfiles/jruby_9.2_rails61_postgres.gemfile.lock
@@ -14,7 +14,7 @@ PATH
     datadog (2.7.0)
       datadog-ruby_core_source (~> 3.3)
       libdatadog (~> 14.1.0.1.0)
-      libddwaf (~> 1.15.0.0.0)
+      libddwaf (~> 1.18.0.0.0)
       msgpack
 
 GEM
@@ -116,7 +116,7 @@ GEM
     json-schema (2.8.1)
       addressable (>= 2.4)
     libdatadog (14.1.0.1.0)
-    libddwaf (1.15.0.0.0-java)
+    libddwaf (1.18.0.0.0-java)
       ffi (~> 1.0)
     lograge (0.12.0)
       actionpack (>= 4)

--- a/gemfiles/jruby_9.2_rails61_postgres_redis.gemfile.lock
+++ b/gemfiles/jruby_9.2_rails61_postgres_redis.gemfile.lock
@@ -14,7 +14,7 @@ PATH
     datadog (2.7.0)
       datadog-ruby_core_source (~> 3.3)
       libdatadog (~> 14.1.0.1.0)
-      libddwaf (~> 1.15.0.0.0)
+      libddwaf (~> 1.18.0.0.0)
       msgpack
 
 GEM
@@ -117,7 +117,7 @@ GEM
     json-schema (2.8.1)
       addressable (>= 2.4)
     libdatadog (14.1.0.1.0)
-    libddwaf (1.15.0.0.0-java)
+    libddwaf (1.18.0.0.0-java)
       ffi (~> 1.0)
     lograge (0.12.0)
       actionpack (>= 4)

--- a/gemfiles/jruby_9.2_rails61_postgres_sidekiq.gemfile.lock
+++ b/gemfiles/jruby_9.2_rails61_postgres_sidekiq.gemfile.lock
@@ -14,7 +14,7 @@ PATH
     datadog (2.7.0)
       datadog-ruby_core_source (~> 3.3)
       libdatadog (~> 14.1.0.1.0)
-      libddwaf (~> 1.15.0.0.0)
+      libddwaf (~> 1.18.0.0.0)
       msgpack
 
 GEM
@@ -117,7 +117,7 @@ GEM
     json-schema (2.8.1)
       addressable (>= 2.4)
     libdatadog (14.1.0.1.0)
-    libddwaf (1.15.0.0.0-java)
+    libddwaf (1.18.0.0.0-java)
       ffi (~> 1.0)
     lograge (0.12.0)
       actionpack (>= 4)

--- a/gemfiles/jruby_9.2_rails61_semantic_logger.gemfile.lock
+++ b/gemfiles/jruby_9.2_rails61_semantic_logger.gemfile.lock
@@ -14,7 +14,7 @@ PATH
     datadog (2.7.0)
       datadog-ruby_core_source (~> 3.3)
       libdatadog (~> 14.1.0.1.0)
-      libddwaf (~> 1.15.0.0.0)
+      libddwaf (~> 1.18.0.0.0)
       msgpack
 
 GEM
@@ -116,7 +116,7 @@ GEM
     json-schema (2.8.1)
       addressable (>= 2.4)
     libdatadog (14.1.0.1.0)
-    libddwaf (1.15.0.0.0-java)
+    libddwaf (1.18.0.0.0-java)
       ffi (~> 1.0)
     loofah (2.19.1)
       crass (~> 1.0.2)

--- a/gemfiles/jruby_9.2_rails6_mysql2.gemfile.lock
+++ b/gemfiles/jruby_9.2_rails6_mysql2.gemfile.lock
@@ -14,7 +14,7 @@ PATH
     datadog (2.7.0)
       datadog-ruby_core_source (~> 3.3)
       libdatadog (~> 14.1.0.1.0)
-      libddwaf (~> 1.15.0.0.0)
+      libddwaf (~> 1.18.0.0.0)
       msgpack
 
 GEM
@@ -110,7 +110,7 @@ GEM
     json-schema (2.8.1)
       addressable (>= 2.4)
     libdatadog (14.1.0.1.0)
-    libddwaf (1.15.0.0.0-java)
+    libddwaf (1.18.0.0.0-java)
       ffi (~> 1.0)
     lograge (0.12.0)
       actionpack (>= 4)

--- a/gemfiles/jruby_9.2_rails6_postgres.gemfile.lock
+++ b/gemfiles/jruby_9.2_rails6_postgres.gemfile.lock
@@ -14,7 +14,7 @@ PATH
     datadog (2.7.0)
       datadog-ruby_core_source (~> 3.3)
       libdatadog (~> 14.1.0.1.0)
-      libddwaf (~> 1.15.0.0.0)
+      libddwaf (~> 1.18.0.0.0)
       msgpack
 
 GEM
@@ -112,7 +112,7 @@ GEM
     json-schema (2.8.1)
       addressable (>= 2.4)
     libdatadog (14.1.0.1.0)
-    libddwaf (1.15.0.0.0-java)
+    libddwaf (1.18.0.0.0-java)
       ffi (~> 1.0)
     lograge (0.12.0)
       actionpack (>= 4)

--- a/gemfiles/jruby_9.2_rails6_postgres_redis.gemfile.lock
+++ b/gemfiles/jruby_9.2_rails6_postgres_redis.gemfile.lock
@@ -14,7 +14,7 @@ PATH
     datadog (2.7.0)
       datadog-ruby_core_source (~> 3.3)
       libdatadog (~> 14.1.0.1.0)
-      libddwaf (~> 1.15.0.0.0)
+      libddwaf (~> 1.18.0.0.0)
       msgpack
 
 GEM
@@ -113,7 +113,7 @@ GEM
     json-schema (2.8.1)
       addressable (>= 2.4)
     libdatadog (14.1.0.1.0)
-    libddwaf (1.15.0.0.0-java)
+    libddwaf (1.18.0.0.0-java)
       ffi (~> 1.0)
     lograge (0.12.0)
       actionpack (>= 4)

--- a/gemfiles/jruby_9.2_rails6_postgres_redis_activesupport.gemfile.lock
+++ b/gemfiles/jruby_9.2_rails6_postgres_redis_activesupport.gemfile.lock
@@ -14,7 +14,7 @@ PATH
     datadog (2.7.0)
       datadog-ruby_core_source (~> 3.3)
       libdatadog (~> 14.1.0.1.0)
-      libddwaf (~> 1.15.0.0.0)
+      libddwaf (~> 1.18.0.0.0)
       msgpack
 
 GEM
@@ -112,7 +112,7 @@ GEM
     json-schema (2.8.1)
       addressable (>= 2.4)
     libdatadog (14.1.0.1.0)
-    libddwaf (1.15.0.0.0-java)
+    libddwaf (1.18.0.0.0-java)
       ffi (~> 1.0)
     lograge (0.12.0)
       actionpack (>= 4)

--- a/gemfiles/jruby_9.2_rails6_postgres_sidekiq.gemfile.lock
+++ b/gemfiles/jruby_9.2_rails6_postgres_sidekiq.gemfile.lock
@@ -14,7 +14,7 @@ PATH
     datadog (2.7.0)
       datadog-ruby_core_source (~> 3.3)
       libdatadog (~> 14.1.0.1.0)
-      libddwaf (~> 1.15.0.0.0)
+      libddwaf (~> 1.18.0.0.0)
       msgpack
 
 GEM
@@ -113,7 +113,7 @@ GEM
     json-schema (2.8.1)
       addressable (>= 2.4)
     libdatadog (14.1.0.1.0)
-    libddwaf (1.15.0.0.0-java)
+    libddwaf (1.18.0.0.0-java)
       ffi (~> 1.0)
     lograge (0.12.0)
       actionpack (>= 4)

--- a/gemfiles/jruby_9.2_rails6_semantic_logger.gemfile.lock
+++ b/gemfiles/jruby_9.2_rails6_semantic_logger.gemfile.lock
@@ -14,7 +14,7 @@ PATH
     datadog (2.7.0)
       datadog-ruby_core_source (~> 3.3)
       libdatadog (~> 14.1.0.1.0)
-      libddwaf (~> 1.15.0.0.0)
+      libddwaf (~> 1.18.0.0.0)
       msgpack
 
 GEM
@@ -112,7 +112,7 @@ GEM
     json-schema (2.8.1)
       addressable (>= 2.4)
     libdatadog (14.1.0.1.0)
-    libddwaf (1.15.0.0.0-java)
+    libddwaf (1.18.0.0.0-java)
       ffi (~> 1.0)
     loofah (2.19.1)
       crass (~> 1.0.2)

--- a/gemfiles/jruby_9.2_redis_3.gemfile.lock
+++ b/gemfiles/jruby_9.2_redis_3.gemfile.lock
@@ -14,7 +14,7 @@ PATH
     datadog (2.7.0)
       datadog-ruby_core_source (~> 3.3)
       libdatadog (~> 14.1.0.1.0)
-      libddwaf (~> 1.15.0.0.0)
+      libddwaf (~> 1.18.0.0.0)
       msgpack
 
 GEM
@@ -42,7 +42,7 @@ GEM
     json-schema (2.8.1)
       addressable (>= 2.4)
     libdatadog (14.1.0.1.0)
-    libddwaf (1.15.0.0.0-java)
+    libddwaf (1.18.0.0.0-java)
       ffi (~> 1.0)
     memory_profiler (0.9.14)
     method_source (1.0.0)

--- a/gemfiles/jruby_9.2_redis_4.gemfile.lock
+++ b/gemfiles/jruby_9.2_redis_4.gemfile.lock
@@ -14,7 +14,7 @@ PATH
     datadog (2.7.0)
       datadog-ruby_core_source (~> 3.3)
       libdatadog (~> 14.1.0.1.0)
-      libddwaf (~> 1.15.0.0.0)
+      libddwaf (~> 1.18.0.0.0)
       msgpack
 
 GEM
@@ -42,7 +42,7 @@ GEM
     json-schema (2.8.1)
       addressable (>= 2.4)
     libdatadog (14.1.0.1.0)
-    libddwaf (1.15.0.0.0-java)
+    libddwaf (1.18.0.0.0-java)
       ffi (~> 1.0)
     memory_profiler (0.9.14)
     method_source (1.0.0)

--- a/gemfiles/jruby_9.2_redis_5.gemfile.lock
+++ b/gemfiles/jruby_9.2_redis_5.gemfile.lock
@@ -14,7 +14,7 @@ PATH
     datadog (2.7.0)
       datadog-ruby_core_source (~> 3.3)
       libdatadog (~> 14.1.0.1.0)
-      libddwaf (~> 1.15.0.0.0)
+      libddwaf (~> 1.18.0.0.0)
       msgpack
 
 GEM
@@ -43,7 +43,7 @@ GEM
     json-schema (2.8.1)
       addressable (>= 2.4)
     libdatadog (14.1.0.1.0)
-    libddwaf (1.15.0.0.0-java)
+    libddwaf (1.18.0.0.0-java)
       ffi (~> 1.0)
     memory_profiler (0.9.14)
     method_source (1.0.0)

--- a/gemfiles/jruby_9.2_relational_db.gemfile.lock
+++ b/gemfiles/jruby_9.2_relational_db.gemfile.lock
@@ -14,7 +14,7 @@ PATH
     datadog (2.7.0)
       datadog-ruby_core_source (~> 3.3)
       libdatadog (~> 14.1.0.1.0)
-      libddwaf (~> 1.15.0.0.0)
+      libddwaf (~> 1.18.0.0.0)
       msgpack
 
 GEM
@@ -76,7 +76,7 @@ GEM
     json-schema (2.8.1)
       addressable (>= 2.4)
     libdatadog (14.1.0.1.0)
-    libddwaf (1.15.0.0.0-java)
+    libddwaf (1.18.0.0.0-java)
       ffi (~> 1.0)
     makara (0.5.1)
       activerecord (>= 5.2.0)

--- a/gemfiles/jruby_9.2_resque2_redis3.gemfile.lock
+++ b/gemfiles/jruby_9.2_resque2_redis3.gemfile.lock
@@ -14,7 +14,7 @@ PATH
     datadog (2.7.0)
       datadog-ruby_core_source (~> 3.3)
       libdatadog (~> 14.1.0.1.0)
-      libddwaf (~> 1.15.0.0.0)
+      libddwaf (~> 1.18.0.0.0)
       msgpack
 
 GEM
@@ -42,7 +42,7 @@ GEM
     json-schema (2.8.1)
       addressable (>= 2.4)
     libdatadog (14.1.0.1.0)
-    libddwaf (1.15.0.0.0-java)
+    libddwaf (1.18.0.0.0-java)
       ffi (~> 1.0)
     memory_profiler (0.9.14)
     method_source (1.0.0)

--- a/gemfiles/jruby_9.2_resque2_redis4.gemfile.lock
+++ b/gemfiles/jruby_9.2_resque2_redis4.gemfile.lock
@@ -14,7 +14,7 @@ PATH
     datadog (2.7.0)
       datadog-ruby_core_source (~> 3.3)
       libdatadog (~> 14.1.0.1.0)
-      libddwaf (~> 1.15.0.0.0)
+      libddwaf (~> 1.18.0.0.0)
       msgpack
 
 GEM
@@ -43,7 +43,7 @@ GEM
     json-schema (2.8.1)
       addressable (>= 2.4)
     libdatadog (14.1.0.1.0)
-    libddwaf (1.15.0.0.0-java)
+    libddwaf (1.18.0.0.0-java)
       ffi (~> 1.0)
     memory_profiler (0.9.14)
     method_source (1.0.0)

--- a/gemfiles/jruby_9.2_sinatra_2.gemfile.lock
+++ b/gemfiles/jruby_9.2_sinatra_2.gemfile.lock
@@ -14,7 +14,7 @@ PATH
     datadog (2.7.0)
       datadog-ruby_core_source (~> 3.3)
       libdatadog (~> 14.1.0.1.0)
-      libddwaf (~> 1.15.0.0.0)
+      libddwaf (~> 1.18.0.0.0)
       msgpack
 
 GEM
@@ -45,7 +45,7 @@ GEM
     json-schema (2.8.1)
       addressable (>= 2.4)
     libdatadog (14.1.0.1.0)
-    libddwaf (1.15.0.0.0-java)
+    libddwaf (1.18.0.0.0-java)
       ffi (~> 1.0)
     memory_profiler (0.9.14)
     method_source (1.1.0)

--- a/gemfiles/jruby_9.2_stripe_10.gemfile.lock
+++ b/gemfiles/jruby_9.2_stripe_10.gemfile.lock
@@ -14,7 +14,7 @@ PATH
     datadog (2.7.0)
       datadog-ruby_core_source (~> 3.3)
       libdatadog (~> 14.1.0.1.0)
-      libddwaf (~> 1.15.0.0.0)
+      libddwaf (~> 1.18.0.0.0)
       msgpack
 
 GEM
@@ -45,7 +45,7 @@ GEM
     json-schema (2.8.1)
       addressable (>= 2.4)
     libdatadog (14.1.0.1.0)
-    libddwaf (1.15.0.0.0-java)
+    libddwaf (1.18.0.0.0-java)
       ffi (~> 1.0)
     memory_profiler (0.9.14)
     method_source (1.1.0)

--- a/gemfiles/jruby_9.2_stripe_11.gemfile.lock
+++ b/gemfiles/jruby_9.2_stripe_11.gemfile.lock
@@ -14,7 +14,7 @@ PATH
     datadog (2.7.0)
       datadog-ruby_core_source (~> 3.3)
       libdatadog (~> 14.1.0.1.0)
-      libddwaf (~> 1.15.0.0.0)
+      libddwaf (~> 1.18.0.0.0)
       msgpack
 
 GEM
@@ -45,7 +45,7 @@ GEM
     json-schema (2.8.1)
       addressable (>= 2.4)
     libdatadog (14.1.0.1.0)
-    libddwaf (1.15.0.0.0-java)
+    libddwaf (1.18.0.0.0-java)
       ffi (~> 1.0)
     memory_profiler (0.9.14)
     method_source (1.1.0)

--- a/gemfiles/jruby_9.2_stripe_12.gemfile.lock
+++ b/gemfiles/jruby_9.2_stripe_12.gemfile.lock
@@ -14,7 +14,7 @@ PATH
     datadog (2.7.0)
       datadog-ruby_core_source (~> 3.3)
       libdatadog (~> 14.1.0.1.0)
-      libddwaf (~> 1.15.0.0.0)
+      libddwaf (~> 1.18.0.0.0)
       msgpack
 
 GEM
@@ -45,7 +45,7 @@ GEM
     json-schema (2.8.1)
       addressable (>= 2.4)
     libdatadog (14.1.0.1.0)
-    libddwaf (1.15.0.0.0-java)
+    libddwaf (1.18.0.0.0-java)
       ffi (~> 1.0)
     memory_profiler (0.9.14)
     method_source (1.1.0)

--- a/gemfiles/jruby_9.2_stripe_7.gemfile.lock
+++ b/gemfiles/jruby_9.2_stripe_7.gemfile.lock
@@ -14,7 +14,7 @@ PATH
     datadog (2.7.0)
       datadog-ruby_core_source (~> 3.3)
       libdatadog (~> 14.1.0.1.0)
-      libddwaf (~> 1.15.0.0.0)
+      libddwaf (~> 1.18.0.0.0)
       msgpack
 
 GEM
@@ -45,7 +45,7 @@ GEM
     json-schema (2.8.1)
       addressable (>= 2.4)
     libdatadog (14.1.0.1.0)
-    libddwaf (1.15.0.0.0-java)
+    libddwaf (1.18.0.0.0-java)
       ffi (~> 1.0)
     memory_profiler (0.9.14)
     method_source (1.1.0)

--- a/gemfiles/jruby_9.2_stripe_8.gemfile.lock
+++ b/gemfiles/jruby_9.2_stripe_8.gemfile.lock
@@ -14,7 +14,7 @@ PATH
     datadog (2.7.0)
       datadog-ruby_core_source (~> 3.3)
       libdatadog (~> 14.1.0.1.0)
-      libddwaf (~> 1.15.0.0.0)
+      libddwaf (~> 1.18.0.0.0)
       msgpack
 
 GEM
@@ -45,7 +45,7 @@ GEM
     json-schema (2.8.1)
       addressable (>= 2.4)
     libdatadog (14.1.0.1.0)
-    libddwaf (1.15.0.0.0-java)
+    libddwaf (1.18.0.0.0-java)
       ffi (~> 1.0)
     memory_profiler (0.9.14)
     method_source (1.1.0)

--- a/gemfiles/jruby_9.2_stripe_9.gemfile.lock
+++ b/gemfiles/jruby_9.2_stripe_9.gemfile.lock
@@ -14,7 +14,7 @@ PATH
     datadog (2.7.0)
       datadog-ruby_core_source (~> 3.3)
       libdatadog (~> 14.1.0.1.0)
-      libddwaf (~> 1.15.0.0.0)
+      libddwaf (~> 1.18.0.0.0)
       msgpack
 
 GEM
@@ -45,7 +45,7 @@ GEM
     json-schema (2.8.1)
       addressable (>= 2.4)
     libdatadog (14.1.0.1.0)
-    libddwaf (1.15.0.0.0-java)
+    libddwaf (1.18.0.0.0-java)
       ffi (~> 1.0)
     memory_profiler (0.9.14)
     method_source (1.1.0)

--- a/gemfiles/jruby_9.2_stripe_latest.gemfile.lock
+++ b/gemfiles/jruby_9.2_stripe_latest.gemfile.lock
@@ -14,7 +14,7 @@ PATH
     datadog (2.7.0)
       datadog-ruby_core_source (~> 3.3)
       libdatadog (~> 14.1.0.1.0)
-      libddwaf (~> 1.15.0.0.0)
+      libddwaf (~> 1.18.0.0.0)
       msgpack
 
 GEM
@@ -45,7 +45,7 @@ GEM
     json-schema (2.8.1)
       addressable (>= 2.4)
     libdatadog (14.1.0.1.0)
-    libddwaf (1.15.0.0.0-java)
+    libddwaf (1.18.0.0.0-java)
       ffi (~> 1.0)
     memory_profiler (0.9.14)
     method_source (1.1.0)

--- a/gemfiles/jruby_9.2_stripe_min.gemfile.lock
+++ b/gemfiles/jruby_9.2_stripe_min.gemfile.lock
@@ -14,7 +14,7 @@ PATH
     datadog (2.7.0)
       datadog-ruby_core_source (~> 3.3)
       libdatadog (~> 14.1.0.1.0)
-      libddwaf (~> 1.15.0.0.0)
+      libddwaf (~> 1.18.0.0.0)
       msgpack
 
 GEM
@@ -45,7 +45,7 @@ GEM
     json-schema (2.8.1)
       addressable (>= 2.4)
     libdatadog (14.1.0.1.0)
-    libddwaf (1.15.0.0.0-java)
+    libddwaf (1.18.0.0.0-java)
       ffi (~> 1.0)
     memory_profiler (0.9.14)
     method_source (1.1.0)

--- a/gemfiles/jruby_9.3_activesupport.gemfile.lock
+++ b/gemfiles/jruby_9.3_activesupport.gemfile.lock
@@ -14,7 +14,7 @@ PATH
     datadog (2.7.0)
       datadog-ruby_core_source (~> 3.3)
       libdatadog (~> 14.1.0.1.0)
-      libddwaf (~> 1.15.0.0.0)
+      libddwaf (~> 1.18.0.0.0)
       msgpack
 
 GEM
@@ -106,7 +106,7 @@ GEM
     jsonapi-renderer (0.2.2)
     king_konf (1.0.1)
     libdatadog (14.1.0.1.0)
-    libddwaf (1.15.0.0.0-java)
+    libddwaf (1.18.0.0.0-java)
       ffi (~> 1.0)
     lograge (0.13.0)
       actionpack (>= 4)

--- a/gemfiles/jruby_9.3_aws.gemfile.lock
+++ b/gemfiles/jruby_9.3_aws.gemfile.lock
@@ -14,7 +14,7 @@ PATH
     datadog (2.7.0)
       datadog-ruby_core_source (~> 3.3)
       libdatadog (~> 14.1.0.1.0)
-      libddwaf (~> 1.15.0.0.0)
+      libddwaf (~> 1.18.0.0.0)
       msgpack
 
 GEM
@@ -1466,7 +1466,7 @@ GEM
     json-schema (2.8.1)
       addressable (>= 2.4)
     libdatadog (14.1.0.1.0)
-    libddwaf (1.15.0.0.0-java)
+    libddwaf (1.18.0.0.0-java)
       ffi (~> 1.0)
     memory_profiler (0.9.14)
     method_source (1.0.0)

--- a/gemfiles/jruby_9.3_contrib.gemfile.lock
+++ b/gemfiles/jruby_9.3_contrib.gemfile.lock
@@ -14,7 +14,7 @@ PATH
     datadog (2.7.0)
       datadog-ruby_core_source (~> 3.3)
       libdatadog (~> 14.1.0.1.0)
-      libddwaf (~> 1.15.0.0.0)
+      libddwaf (~> 1.18.0.0.0)
       msgpack
 
 GEM
@@ -51,7 +51,7 @@ GEM
     json-schema (2.8.1)
       addressable (>= 2.4)
     libdatadog (14.1.0.1.0)
-    libddwaf (1.15.0.0.0-java)
+    libddwaf (1.18.0.0.0-java)
       ffi (~> 1.0)
     memory_profiler (0.9.14)
     method_source (1.0.0)

--- a/gemfiles/jruby_9.3_contrib_old.gemfile.lock
+++ b/gemfiles/jruby_9.3_contrib_old.gemfile.lock
@@ -14,7 +14,7 @@ PATH
     datadog (2.7.0)
       datadog-ruby_core_source (~> 3.3)
       libdatadog (~> 14.1.0.1.0)
-      libddwaf (~> 1.15.0.0.0)
+      libddwaf (~> 1.18.0.0.0)
       msgpack
 
 GEM
@@ -49,7 +49,7 @@ GEM
     json-schema (2.8.1)
       addressable (>= 2.4)
     libdatadog (14.1.0.1.0)
-    libddwaf (1.15.0.0.0-java)
+    libddwaf (1.18.0.0.0-java)
       ffi (~> 1.0)
     memory_profiler (0.9.14)
     method_source (1.0.0)

--- a/gemfiles/jruby_9.3_core_old.gemfile.lock
+++ b/gemfiles/jruby_9.3_core_old.gemfile.lock
@@ -14,7 +14,7 @@ PATH
     datadog (2.7.0)
       datadog-ruby_core_source (~> 3.3)
       libdatadog (~> 14.1.0.1.0)
-      libddwaf (~> 1.15.0.0.0)
+      libddwaf (~> 1.18.0.0.0)
       msgpack
 
 GEM
@@ -44,7 +44,7 @@ GEM
     json-schema (2.8.1)
       addressable (>= 2.4)
     libdatadog (14.1.0.1.0)
-    libddwaf (1.15.0.0.0-java)
+    libddwaf (1.18.0.0.0-java)
       ffi (~> 1.0)
     memory_profiler (0.9.14)
     method_source (1.0.0)

--- a/gemfiles/jruby_9.3_elasticsearch_7.gemfile.lock
+++ b/gemfiles/jruby_9.3_elasticsearch_7.gemfile.lock
@@ -14,7 +14,7 @@ PATH
     datadog (2.7.0)
       datadog-ruby_core_source (~> 3.3)
       libdatadog (~> 14.1.0.1.0)
-      libddwaf (~> 1.15.0.0.0)
+      libddwaf (~> 1.18.0.0.0)
       msgpack
 
 GEM
@@ -60,7 +60,7 @@ GEM
     json-schema (2.8.1)
       addressable (>= 2.4)
     libdatadog (14.1.0.1.0)
-    libddwaf (1.15.0.0.0-java)
+    libddwaf (1.18.0.0.0-java)
       ffi (~> 1.0)
     memory_profiler (0.9.14)
     method_source (1.0.0)

--- a/gemfiles/jruby_9.3_elasticsearch_8.gemfile.lock
+++ b/gemfiles/jruby_9.3_elasticsearch_8.gemfile.lock
@@ -14,7 +14,7 @@ PATH
     datadog (2.7.0)
       datadog-ruby_core_source (~> 3.3)
       libdatadog (~> 14.1.0.1.0)
-      libddwaf (~> 1.15.0.0.0)
+      libddwaf (~> 1.18.0.0.0)
       msgpack
 
 GEM
@@ -59,7 +59,7 @@ GEM
     json-schema (2.8.1)
       addressable (>= 2.4)
     libdatadog (14.1.0.1.0)
-    libddwaf (1.15.0.0.0-java)
+    libddwaf (1.18.0.0.0-java)
       ffi (~> 1.0)
     memory_profiler (0.9.14)
     method_source (1.0.0)

--- a/gemfiles/jruby_9.3_elasticsearch_latest.gemfile.lock
+++ b/gemfiles/jruby_9.3_elasticsearch_latest.gemfile.lock
@@ -14,7 +14,7 @@ PATH
     datadog (2.7.0)
       datadog-ruby_core_source (~> 3.3)
       libdatadog (~> 14.1.0.1.0)
-      libddwaf (~> 1.15.0.0.0)
+      libddwaf (~> 1.18.0.0.0)
       msgpack
 
 GEM
@@ -61,7 +61,7 @@ GEM
     json-schema (2.8.1)
       addressable (>= 2.4)
     libdatadog (14.1.0.1.0)
-    libddwaf (1.15.0.0.0-java)
+    libddwaf (1.18.0.0.0-java)
       ffi (~> 1.0)
     memory_profiler (0.9.14)
     method_source (1.1.0)

--- a/gemfiles/jruby_9.3_graphql_1.13.gemfile.lock
+++ b/gemfiles/jruby_9.3_graphql_1.13.gemfile.lock
@@ -14,7 +14,7 @@ PATH
     datadog (2.7.0)
       datadog-ruby_core_source (~> 3.3)
       libdatadog (~> 14.1.0.1.0)
-      libddwaf (~> 1.15.0.0.0)
+      libddwaf (~> 1.18.0.0.0)
       msgpack
 
 GEM
@@ -114,7 +114,7 @@ GEM
     json-schema (2.8.1)
       addressable (>= 2.4)
     libdatadog (14.1.0.1.0)
-    libddwaf (1.15.0.0.0-java)
+    libddwaf (1.18.0.0.0-java)
       ffi (~> 1.0)
     lograge (0.14.0)
       actionpack (>= 4)

--- a/gemfiles/jruby_9.3_graphql_2.0.gemfile.lock
+++ b/gemfiles/jruby_9.3_graphql_2.0.gemfile.lock
@@ -14,7 +14,7 @@ PATH
     datadog (2.7.0)
       datadog-ruby_core_source (~> 3.3)
       libdatadog (~> 14.1.0.1.0)
-      libddwaf (~> 1.15.0.0.0)
+      libddwaf (~> 1.18.0.0.0)
       msgpack
 
 GEM
@@ -114,7 +114,7 @@ GEM
     json-schema (2.8.1)
       addressable (>= 2.4)
     libdatadog (14.1.0.1.0)
-    libddwaf (1.15.0.0.0-java)
+    libddwaf (1.18.0.0.0-java)
       ffi (~> 1.0)
     lograge (0.14.0)
       actionpack (>= 4)

--- a/gemfiles/jruby_9.3_http.gemfile.lock
+++ b/gemfiles/jruby_9.3_http.gemfile.lock
@@ -14,7 +14,7 @@ PATH
     datadog (2.7.0)
       datadog-ruby_core_source (~> 3.3)
       libdatadog (~> 14.1.0.1.0)
-      libddwaf (~> 1.15.0.0.0)
+      libddwaf (~> 1.18.0.0.0)
       msgpack
 
 GEM
@@ -68,7 +68,7 @@ GEM
     json-schema (2.8.1)
       addressable (>= 2.4)
     libdatadog (14.1.0.1.0)
-    libddwaf (1.15.0.0.0-java)
+    libddwaf (1.18.0.0.0-java)
       ffi (~> 1.0)
     memory_profiler (0.9.14)
     method_source (1.0.0)

--- a/gemfiles/jruby_9.3_opensearch_2.gemfile.lock
+++ b/gemfiles/jruby_9.3_opensearch_2.gemfile.lock
@@ -14,7 +14,7 @@ PATH
     datadog (2.7.0)
       datadog-ruby_core_source (~> 3.3)
       libdatadog (~> 14.1.0.1.0)
-      libddwaf (~> 1.15.0.0.0)
+      libddwaf (~> 1.18.0.0.0)
       msgpack
 
 GEM
@@ -51,7 +51,7 @@ GEM
     json-schema (2.8.1)
       addressable (>= 2.4)
     libdatadog (14.1.0.1.0)
-    libddwaf (1.15.0.0.0-java)
+    libddwaf (1.18.0.0.0-java)
       ffi (~> 1.0)
     memory_profiler (0.9.14)
     method_source (1.0.0)

--- a/gemfiles/jruby_9.3_opensearch_3.gemfile.lock
+++ b/gemfiles/jruby_9.3_opensearch_3.gemfile.lock
@@ -14,7 +14,7 @@ PATH
     datadog (2.7.0)
       datadog-ruby_core_source (~> 3.3)
       libdatadog (~> 14.1.0.1.0)
-      libddwaf (~> 1.15.0.0.0)
+      libddwaf (~> 1.18.0.0.0)
       msgpack
 
 GEM
@@ -51,7 +51,7 @@ GEM
     json-schema (2.8.1)
       addressable (>= 2.4)
     libdatadog (14.1.0.1.0)
-    libddwaf (1.15.0.0.0-java)
+    libddwaf (1.18.0.0.0-java)
       ffi (~> 1.0)
     memory_profiler (0.9.14)
     method_source (1.0.0)

--- a/gemfiles/jruby_9.3_opensearch_latest.gemfile.lock
+++ b/gemfiles/jruby_9.3_opensearch_latest.gemfile.lock
@@ -14,7 +14,7 @@ PATH
     datadog (2.7.0)
       datadog-ruby_core_source (~> 3.3)
       libdatadog (~> 14.1.0.1.0)
-      libddwaf (~> 1.15.0.0.0)
+      libddwaf (~> 1.18.0.0.0)
       msgpack
 
 GEM
@@ -53,7 +53,7 @@ GEM
     json-schema (2.8.1)
       addressable (>= 2.4)
     libdatadog (14.1.0.1.0)
-    libddwaf (1.15.0.0.0-java)
+    libddwaf (1.18.0.0.0-java)
       ffi (~> 1.0)
     memory_profiler (0.9.14)
     method_source (1.1.0)

--- a/gemfiles/jruby_9.3_rack_1.gemfile.lock
+++ b/gemfiles/jruby_9.3_rack_1.gemfile.lock
@@ -14,7 +14,7 @@ PATH
     datadog (2.7.0)
       datadog-ruby_core_source (~> 3.3)
       libdatadog (~> 14.1.0.1.0)
-      libddwaf (~> 1.15.0.0.0)
+      libddwaf (~> 1.18.0.0.0)
       msgpack
 
 GEM
@@ -44,7 +44,7 @@ GEM
     json-schema (2.8.1)
       addressable (>= 2.4)
     libdatadog (14.1.0.1.0)
-    libddwaf (1.15.0.0.0-java)
+    libddwaf (1.18.0.0.0-java)
       ffi (~> 1.0)
     memory_profiler (0.9.14)
     method_source (1.0.0)

--- a/gemfiles/jruby_9.3_rack_2.gemfile.lock
+++ b/gemfiles/jruby_9.3_rack_2.gemfile.lock
@@ -14,7 +14,7 @@ PATH
     datadog (2.7.0)
       datadog-ruby_core_source (~> 3.3)
       libdatadog (~> 14.1.0.1.0)
-      libddwaf (~> 1.15.0.0.0)
+      libddwaf (~> 1.18.0.0.0)
       msgpack
 
 GEM
@@ -44,7 +44,7 @@ GEM
     json-schema (2.8.1)
       addressable (>= 2.4)
     libdatadog (14.1.0.1.0)
-    libddwaf (1.15.0.0.0-java)
+    libddwaf (1.18.0.0.0-java)
       ffi (~> 1.0)
     memory_profiler (0.9.14)
     method_source (1.0.0)

--- a/gemfiles/jruby_9.3_rack_3.gemfile.lock
+++ b/gemfiles/jruby_9.3_rack_3.gemfile.lock
@@ -14,7 +14,7 @@ PATH
     datadog (2.7.0)
       datadog-ruby_core_source (~> 3.3)
       libdatadog (~> 14.1.0.1.0)
-      libddwaf (~> 1.15.0.0.0)
+      libddwaf (~> 1.18.0.0.0)
       msgpack
 
 GEM
@@ -44,7 +44,7 @@ GEM
     json-schema (2.8.1)
       addressable (>= 2.4)
     libdatadog (14.1.0.1.0)
-    libddwaf (1.15.0.0.0-java)
+    libddwaf (1.18.0.0.0-java)
       ffi (~> 1.0)
     memory_profiler (0.9.14)
     method_source (1.0.0)

--- a/gemfiles/jruby_9.3_rack_latest.gemfile.lock
+++ b/gemfiles/jruby_9.3_rack_latest.gemfile.lock
@@ -14,7 +14,7 @@ PATH
     datadog (2.7.0)
       datadog-ruby_core_source (~> 3.3)
       libdatadog (~> 14.1.0.1.0)
-      libddwaf (~> 1.15.0.0.0)
+      libddwaf (~> 1.18.0.0.0)
       msgpack
 
 GEM
@@ -47,7 +47,7 @@ GEM
     json-schema (2.8.1)
       addressable (>= 2.4)
     libdatadog (14.1.0.1.0)
-    libddwaf (1.15.0.0.0-java)
+    libddwaf (1.18.0.0.0-java)
       ffi (~> 1.0)
     memory_profiler (0.9.14)
     method_source (1.1.0)

--- a/gemfiles/jruby_9.3_rails5_mysql2.gemfile.lock
+++ b/gemfiles/jruby_9.3_rails5_mysql2.gemfile.lock
@@ -14,7 +14,7 @@ PATH
     datadog (2.7.0)
       datadog-ruby_core_source (~> 3.3)
       libdatadog (~> 14.1.0.1.0)
-      libddwaf (~> 1.15.0.0.0)
+      libddwaf (~> 1.18.0.0.0)
       msgpack
 
 GEM
@@ -100,7 +100,7 @@ GEM
     json-schema (2.8.1)
       addressable (>= 2.4)
     libdatadog (14.1.0.1.0)
-    libddwaf (1.15.0.0.0-java)
+    libddwaf (1.18.0.0.0-java)
       ffi (~> 1.0)
     lograge (0.12.0)
       actionpack (>= 4)

--- a/gemfiles/jruby_9.3_rails5_postgres.gemfile.lock
+++ b/gemfiles/jruby_9.3_rails5_postgres.gemfile.lock
@@ -14,7 +14,7 @@ PATH
     datadog (2.7.0)
       datadog-ruby_core_source (~> 3.3)
       libdatadog (~> 14.1.0.1.0)
-      libddwaf (~> 1.15.0.0.0)
+      libddwaf (~> 1.18.0.0.0)
       msgpack
 
 GEM
@@ -100,7 +100,7 @@ GEM
     json-schema (2.8.1)
       addressable (>= 2.4)
     libdatadog (14.1.0.1.0)
-    libddwaf (1.15.0.0.0-java)
+    libddwaf (1.18.0.0.0-java)
       ffi (~> 1.0)
     lograge (0.12.0)
       actionpack (>= 4)

--- a/gemfiles/jruby_9.3_rails5_postgres_redis.gemfile.lock
+++ b/gemfiles/jruby_9.3_rails5_postgres_redis.gemfile.lock
@@ -14,7 +14,7 @@ PATH
     datadog (2.7.0)
       datadog-ruby_core_source (~> 3.3)
       libdatadog (~> 14.1.0.1.0)
-      libddwaf (~> 1.15.0.0.0)
+      libddwaf (~> 1.18.0.0.0)
       msgpack
 
 GEM
@@ -100,7 +100,7 @@ GEM
     json-schema (2.8.1)
       addressable (>= 2.4)
     libdatadog (14.1.0.1.0)
-    libddwaf (1.15.0.0.0-java)
+    libddwaf (1.18.0.0.0-java)
       ffi (~> 1.0)
     lograge (0.12.0)
       actionpack (>= 4)

--- a/gemfiles/jruby_9.3_rails5_postgres_redis_activesupport.gemfile.lock
+++ b/gemfiles/jruby_9.3_rails5_postgres_redis_activesupport.gemfile.lock
@@ -14,7 +14,7 @@ PATH
     datadog (2.7.0)
       datadog-ruby_core_source (~> 3.3)
       libdatadog (~> 14.1.0.1.0)
-      libddwaf (~> 1.15.0.0.0)
+      libddwaf (~> 1.18.0.0.0)
       msgpack
 
 GEM
@@ -100,7 +100,7 @@ GEM
     json-schema (2.8.1)
       addressable (>= 2.4)
     libdatadog (14.1.0.1.0)
-    libddwaf (1.15.0.0.0-java)
+    libddwaf (1.18.0.0.0-java)
       ffi (~> 1.0)
     lograge (0.12.0)
       actionpack (>= 4)

--- a/gemfiles/jruby_9.3_rails5_postgres_sidekiq.gemfile.lock
+++ b/gemfiles/jruby_9.3_rails5_postgres_sidekiq.gemfile.lock
@@ -14,7 +14,7 @@ PATH
     datadog (2.7.0)
       datadog-ruby_core_source (~> 3.3)
       libdatadog (~> 14.1.0.1.0)
-      libddwaf (~> 1.15.0.0.0)
+      libddwaf (~> 1.18.0.0.0)
       msgpack
 
 GEM
@@ -101,7 +101,7 @@ GEM
     json-schema (2.8.1)
       addressable (>= 2.4)
     libdatadog (14.1.0.1.0)
-    libddwaf (1.15.0.0.0-java)
+    libddwaf (1.18.0.0.0-java)
       ffi (~> 1.0)
     lograge (0.12.0)
       actionpack (>= 4)

--- a/gemfiles/jruby_9.3_rails5_semantic_logger.gemfile.lock
+++ b/gemfiles/jruby_9.3_rails5_semantic_logger.gemfile.lock
@@ -14,7 +14,7 @@ PATH
     datadog (2.7.0)
       datadog-ruby_core_source (~> 3.3)
       libdatadog (~> 14.1.0.1.0)
-      libddwaf (~> 1.15.0.0.0)
+      libddwaf (~> 1.18.0.0.0)
       msgpack
 
 GEM
@@ -100,7 +100,7 @@ GEM
     json-schema (2.8.1)
       addressable (>= 2.4)
     libdatadog (14.1.0.1.0)
-    libddwaf (1.15.0.0.0-java)
+    libddwaf (1.18.0.0.0-java)
       ffi (~> 1.0)
     loofah (2.21.3)
       crass (~> 1.0.2)

--- a/gemfiles/jruby_9.3_rails61_mysql2.gemfile.lock
+++ b/gemfiles/jruby_9.3_rails61_mysql2.gemfile.lock
@@ -14,7 +14,7 @@ PATH
     datadog (2.7.0)
       datadog-ruby_core_source (~> 3.3)
       libdatadog (~> 14.1.0.1.0)
-      libddwaf (~> 1.15.0.0.0)
+      libddwaf (~> 1.18.0.0.0)
       msgpack
 
 GEM
@@ -117,7 +117,7 @@ GEM
     json-schema (2.8.1)
       addressable (>= 2.4)
     libdatadog (14.1.0.1.0)
-    libddwaf (1.15.0.0.0-java)
+    libddwaf (1.18.0.0.0-java)
       ffi (~> 1.0)
     lograge (0.12.0)
       actionpack (>= 4)

--- a/gemfiles/jruby_9.3_rails61_postgres.gemfile.lock
+++ b/gemfiles/jruby_9.3_rails61_postgres.gemfile.lock
@@ -14,7 +14,7 @@ PATH
     datadog (2.7.0)
       datadog-ruby_core_source (~> 3.3)
       libdatadog (~> 14.1.0.1.0)
-      libddwaf (~> 1.15.0.0.0)
+      libddwaf (~> 1.18.0.0.0)
       msgpack
 
 GEM
@@ -117,7 +117,7 @@ GEM
     json-schema (2.8.1)
       addressable (>= 2.4)
     libdatadog (14.1.0.1.0)
-    libddwaf (1.15.0.0.0-java)
+    libddwaf (1.18.0.0.0-java)
       ffi (~> 1.0)
     lograge (0.12.0)
       actionpack (>= 4)

--- a/gemfiles/jruby_9.3_rails61_postgres_redis.gemfile.lock
+++ b/gemfiles/jruby_9.3_rails61_postgres_redis.gemfile.lock
@@ -14,7 +14,7 @@ PATH
     datadog (2.7.0)
       datadog-ruby_core_source (~> 3.3)
       libdatadog (~> 14.1.0.1.0)
-      libddwaf (~> 1.15.0.0.0)
+      libddwaf (~> 1.18.0.0.0)
       msgpack
 
 GEM
@@ -117,7 +117,7 @@ GEM
     json-schema (2.8.1)
       addressable (>= 2.4)
     libdatadog (14.1.0.1.0)
-    libddwaf (1.15.0.0.0-java)
+    libddwaf (1.18.0.0.0-java)
       ffi (~> 1.0)
     lograge (0.12.0)
       actionpack (>= 4)

--- a/gemfiles/jruby_9.3_rails61_postgres_sidekiq.gemfile.lock
+++ b/gemfiles/jruby_9.3_rails61_postgres_sidekiq.gemfile.lock
@@ -14,7 +14,7 @@ PATH
     datadog (2.7.0)
       datadog-ruby_core_source (~> 3.3)
       libdatadog (~> 14.1.0.1.0)
-      libddwaf (~> 1.15.0.0.0)
+      libddwaf (~> 1.18.0.0.0)
       msgpack
 
 GEM
@@ -118,7 +118,7 @@ GEM
     json-schema (2.8.1)
       addressable (>= 2.4)
     libdatadog (14.1.0.1.0)
-    libddwaf (1.15.0.0.0-java)
+    libddwaf (1.18.0.0.0-java)
       ffi (~> 1.0)
     lograge (0.12.0)
       actionpack (>= 4)

--- a/gemfiles/jruby_9.3_rails61_semantic_logger.gemfile.lock
+++ b/gemfiles/jruby_9.3_rails61_semantic_logger.gemfile.lock
@@ -14,7 +14,7 @@ PATH
     datadog (2.7.0)
       datadog-ruby_core_source (~> 3.3)
       libdatadog (~> 14.1.0.1.0)
-      libddwaf (~> 1.15.0.0.0)
+      libddwaf (~> 1.18.0.0.0)
       msgpack
 
 GEM
@@ -117,7 +117,7 @@ GEM
     json-schema (2.8.1)
       addressable (>= 2.4)
     libdatadog (14.1.0.1.0)
-    libddwaf (1.15.0.0.0-java)
+    libddwaf (1.18.0.0.0-java)
       ffi (~> 1.0)
     loofah (2.21.3)
       crass (~> 1.0.2)

--- a/gemfiles/jruby_9.3_rails6_mysql2.gemfile.lock
+++ b/gemfiles/jruby_9.3_rails6_mysql2.gemfile.lock
@@ -14,7 +14,7 @@ PATH
     datadog (2.7.0)
       datadog-ruby_core_source (~> 3.3)
       libdatadog (~> 14.1.0.1.0)
-      libddwaf (~> 1.15.0.0.0)
+      libddwaf (~> 1.18.0.0.0)
       msgpack
 
 GEM
@@ -113,7 +113,7 @@ GEM
     json-schema (2.8.1)
       addressable (>= 2.4)
     libdatadog (14.1.0.1.0)
-    libddwaf (1.15.0.0.0-java)
+    libddwaf (1.18.0.0.0-java)
       ffi (~> 1.0)
     lograge (0.12.0)
       actionpack (>= 4)

--- a/gemfiles/jruby_9.3_rails6_postgres.gemfile.lock
+++ b/gemfiles/jruby_9.3_rails6_postgres.gemfile.lock
@@ -14,7 +14,7 @@ PATH
     datadog (2.7.0)
       datadog-ruby_core_source (~> 3.3)
       libdatadog (~> 14.1.0.1.0)
-      libddwaf (~> 1.15.0.0.0)
+      libddwaf (~> 1.18.0.0.0)
       msgpack
 
 GEM
@@ -113,7 +113,7 @@ GEM
     json-schema (2.8.1)
       addressable (>= 2.4)
     libdatadog (14.1.0.1.0)
-    libddwaf (1.15.0.0.0-java)
+    libddwaf (1.18.0.0.0-java)
       ffi (~> 1.0)
     lograge (0.12.0)
       actionpack (>= 4)

--- a/gemfiles/jruby_9.3_rails6_postgres_redis.gemfile.lock
+++ b/gemfiles/jruby_9.3_rails6_postgres_redis.gemfile.lock
@@ -14,7 +14,7 @@ PATH
     datadog (2.7.0)
       datadog-ruby_core_source (~> 3.3)
       libdatadog (~> 14.1.0.1.0)
-      libddwaf (~> 1.15.0.0.0)
+      libddwaf (~> 1.18.0.0.0)
       msgpack
 
 GEM
@@ -113,7 +113,7 @@ GEM
     json-schema (2.8.1)
       addressable (>= 2.4)
     libdatadog (14.1.0.1.0)
-    libddwaf (1.15.0.0.0-java)
+    libddwaf (1.18.0.0.0-java)
       ffi (~> 1.0)
     lograge (0.12.0)
       actionpack (>= 4)

--- a/gemfiles/jruby_9.3_rails6_postgres_redis_activesupport.gemfile.lock
+++ b/gemfiles/jruby_9.3_rails6_postgres_redis_activesupport.gemfile.lock
@@ -14,7 +14,7 @@ PATH
     datadog (2.7.0)
       datadog-ruby_core_source (~> 3.3)
       libdatadog (~> 14.1.0.1.0)
-      libddwaf (~> 1.15.0.0.0)
+      libddwaf (~> 1.18.0.0.0)
       msgpack
 
 GEM
@@ -113,7 +113,7 @@ GEM
     json-schema (2.8.1)
       addressable (>= 2.4)
     libdatadog (14.1.0.1.0)
-    libddwaf (1.15.0.0.0-java)
+    libddwaf (1.18.0.0.0-java)
       ffi (~> 1.0)
     lograge (0.12.0)
       actionpack (>= 4)

--- a/gemfiles/jruby_9.3_rails6_postgres_sidekiq.gemfile.lock
+++ b/gemfiles/jruby_9.3_rails6_postgres_sidekiq.gemfile.lock
@@ -14,7 +14,7 @@ PATH
     datadog (2.7.0)
       datadog-ruby_core_source (~> 3.3)
       libdatadog (~> 14.1.0.1.0)
-      libddwaf (~> 1.15.0.0.0)
+      libddwaf (~> 1.18.0.0.0)
       msgpack
 
 GEM
@@ -114,7 +114,7 @@ GEM
     json-schema (2.8.1)
       addressable (>= 2.4)
     libdatadog (14.1.0.1.0)
-    libddwaf (1.15.0.0.0-java)
+    libddwaf (1.18.0.0.0-java)
       ffi (~> 1.0)
     lograge (0.12.0)
       actionpack (>= 4)

--- a/gemfiles/jruby_9.3_rails6_semantic_logger.gemfile.lock
+++ b/gemfiles/jruby_9.3_rails6_semantic_logger.gemfile.lock
@@ -14,7 +14,7 @@ PATH
     datadog (2.7.0)
       datadog-ruby_core_source (~> 3.3)
       libdatadog (~> 14.1.0.1.0)
-      libddwaf (~> 1.15.0.0.0)
+      libddwaf (~> 1.18.0.0.0)
       msgpack
 
 GEM
@@ -113,7 +113,7 @@ GEM
     json-schema (2.8.1)
       addressable (>= 2.4)
     libdatadog (14.1.0.1.0)
-    libddwaf (1.15.0.0.0-java)
+    libddwaf (1.18.0.0.0-java)
       ffi (~> 1.0)
     loofah (2.21.3)
       crass (~> 1.0.2)

--- a/gemfiles/jruby_9.3_redis_3.gemfile.lock
+++ b/gemfiles/jruby_9.3_redis_3.gemfile.lock
@@ -14,7 +14,7 @@ PATH
     datadog (2.7.0)
       datadog-ruby_core_source (~> 3.3)
       libdatadog (~> 14.1.0.1.0)
-      libddwaf (~> 1.15.0.0.0)
+      libddwaf (~> 1.18.0.0.0)
       msgpack
 
 GEM
@@ -44,7 +44,7 @@ GEM
     json-schema (2.8.1)
       addressable (>= 2.4)
     libdatadog (14.1.0.1.0)
-    libddwaf (1.15.0.0.0-java)
+    libddwaf (1.18.0.0.0-java)
       ffi (~> 1.0)
     memory_profiler (0.9.14)
     method_source (1.0.0)

--- a/gemfiles/jruby_9.3_redis_4.gemfile.lock
+++ b/gemfiles/jruby_9.3_redis_4.gemfile.lock
@@ -14,7 +14,7 @@ PATH
     datadog (2.7.0)
       datadog-ruby_core_source (~> 3.3)
       libdatadog (~> 14.1.0.1.0)
-      libddwaf (~> 1.15.0.0.0)
+      libddwaf (~> 1.18.0.0.0)
       msgpack
 
 GEM
@@ -44,7 +44,7 @@ GEM
     json-schema (2.8.1)
       addressable (>= 2.4)
     libdatadog (14.1.0.1.0)
-    libddwaf (1.15.0.0.0-java)
+    libddwaf (1.18.0.0.0-java)
       ffi (~> 1.0)
     memory_profiler (0.9.14)
     method_source (1.0.0)

--- a/gemfiles/jruby_9.3_redis_5.gemfile.lock
+++ b/gemfiles/jruby_9.3_redis_5.gemfile.lock
@@ -14,7 +14,7 @@ PATH
     datadog (2.7.0)
       datadog-ruby_core_source (~> 3.3)
       libdatadog (~> 14.1.0.1.0)
-      libddwaf (~> 1.15.0.0.0)
+      libddwaf (~> 1.18.0.0.0)
       msgpack
 
 GEM
@@ -45,7 +45,7 @@ GEM
     json-schema (2.8.1)
       addressable (>= 2.4)
     libdatadog (14.1.0.1.0)
-    libddwaf (1.15.0.0.0-java)
+    libddwaf (1.18.0.0.0-java)
       ffi (~> 1.0)
     memory_profiler (0.9.14)
     method_source (1.0.0)

--- a/gemfiles/jruby_9.3_relational_db.gemfile.lock
+++ b/gemfiles/jruby_9.3_relational_db.gemfile.lock
@@ -14,7 +14,7 @@ PATH
     datadog (2.7.0)
       datadog-ruby_core_source (~> 3.3)
       libdatadog (~> 14.1.0.1.0)
-      libddwaf (~> 1.15.0.0.0)
+      libddwaf (~> 1.18.0.0.0)
       msgpack
 
 GEM
@@ -74,7 +74,7 @@ GEM
     json-schema (2.8.1)
       addressable (>= 2.4)
     libdatadog (14.1.0.1.0)
-    libddwaf (1.15.0.0.0-java)
+    libddwaf (1.18.0.0.0-java)
       ffi (~> 1.0)
     makara (0.5.1)
       activerecord (>= 5.2.0)

--- a/gemfiles/jruby_9.3_resque2_redis3.gemfile.lock
+++ b/gemfiles/jruby_9.3_resque2_redis3.gemfile.lock
@@ -14,7 +14,7 @@ PATH
     datadog (2.7.0)
       datadog-ruby_core_source (~> 3.3)
       libdatadog (~> 14.1.0.1.0)
-      libddwaf (~> 1.15.0.0.0)
+      libddwaf (~> 1.18.0.0.0)
       msgpack
 
 GEM
@@ -44,7 +44,7 @@ GEM
     json-schema (2.8.1)
       addressable (>= 2.4)
     libdatadog (14.1.0.1.0)
-    libddwaf (1.15.0.0.0-java)
+    libddwaf (1.18.0.0.0-java)
       ffi (~> 1.0)
     memory_profiler (0.9.14)
     method_source (1.0.0)

--- a/gemfiles/jruby_9.3_resque2_redis4.gemfile.lock
+++ b/gemfiles/jruby_9.3_resque2_redis4.gemfile.lock
@@ -14,7 +14,7 @@ PATH
     datadog (2.7.0)
       datadog-ruby_core_source (~> 3.3)
       libdatadog (~> 14.1.0.1.0)
-      libddwaf (~> 1.15.0.0.0)
+      libddwaf (~> 1.18.0.0.0)
       msgpack
 
 GEM
@@ -44,7 +44,7 @@ GEM
     json-schema (2.8.1)
       addressable (>= 2.4)
     libdatadog (14.1.0.1.0)
-    libddwaf (1.15.0.0.0-java)
+    libddwaf (1.18.0.0.0-java)
       ffi (~> 1.0)
     memory_profiler (0.9.14)
     method_source (1.0.0)

--- a/gemfiles/jruby_9.3_sinatra_2.gemfile.lock
+++ b/gemfiles/jruby_9.3_sinatra_2.gemfile.lock
@@ -14,7 +14,7 @@ PATH
     datadog (2.7.0)
       datadog-ruby_core_source (~> 3.3)
       libdatadog (~> 14.1.0.1.0)
-      libddwaf (~> 1.15.0.0.0)
+      libddwaf (~> 1.18.0.0.0)
       msgpack
 
 GEM
@@ -47,7 +47,7 @@ GEM
     json-schema (2.8.1)
       addressable (>= 2.4)
     libdatadog (14.1.0.1.0)
-    libddwaf (1.15.0.0.0-java)
+    libddwaf (1.18.0.0.0-java)
       ffi (~> 1.0)
     memory_profiler (0.9.14)
     method_source (1.1.0)

--- a/gemfiles/jruby_9.3_sinatra_3.gemfile.lock
+++ b/gemfiles/jruby_9.3_sinatra_3.gemfile.lock
@@ -14,7 +14,7 @@ PATH
     datadog (2.7.0)
       datadog-ruby_core_source (~> 3.3)
       libdatadog (~> 14.1.0.1.0)
-      libddwaf (~> 1.15.0.0.0)
+      libddwaf (~> 1.18.0.0.0)
       msgpack
 
 GEM
@@ -48,7 +48,7 @@ GEM
     json-schema (2.8.1)
       addressable (>= 2.4)
     libdatadog (14.1.0.1.0)
-    libddwaf (1.15.0.0.0-java)
+    libddwaf (1.18.0.0.0-java)
       ffi (~> 1.0)
     memory_profiler (0.9.14)
     method_source (1.1.0)

--- a/gemfiles/jruby_9.3_stripe_10.gemfile.lock
+++ b/gemfiles/jruby_9.3_stripe_10.gemfile.lock
@@ -14,7 +14,7 @@ PATH
     datadog (2.7.0)
       datadog-ruby_core_source (~> 3.3)
       libdatadog (~> 14.1.0.1.0)
-      libddwaf (~> 1.15.0.0.0)
+      libddwaf (~> 1.18.0.0.0)
       msgpack
 
 GEM
@@ -47,7 +47,7 @@ GEM
     json-schema (2.8.1)
       addressable (>= 2.4)
     libdatadog (14.1.0.1.0)
-    libddwaf (1.15.0.0.0-java)
+    libddwaf (1.18.0.0.0-java)
       ffi (~> 1.0)
     memory_profiler (0.9.14)
     method_source (1.1.0)

--- a/gemfiles/jruby_9.3_stripe_11.gemfile.lock
+++ b/gemfiles/jruby_9.3_stripe_11.gemfile.lock
@@ -14,7 +14,7 @@ PATH
     datadog (2.7.0)
       datadog-ruby_core_source (~> 3.3)
       libdatadog (~> 14.1.0.1.0)
-      libddwaf (~> 1.15.0.0.0)
+      libddwaf (~> 1.18.0.0.0)
       msgpack
 
 GEM
@@ -47,7 +47,7 @@ GEM
     json-schema (2.8.1)
       addressable (>= 2.4)
     libdatadog (14.1.0.1.0)
-    libddwaf (1.15.0.0.0-java)
+    libddwaf (1.18.0.0.0-java)
       ffi (~> 1.0)
     memory_profiler (0.9.14)
     method_source (1.1.0)

--- a/gemfiles/jruby_9.3_stripe_12.gemfile.lock
+++ b/gemfiles/jruby_9.3_stripe_12.gemfile.lock
@@ -14,7 +14,7 @@ PATH
     datadog (2.7.0)
       datadog-ruby_core_source (~> 3.3)
       libdatadog (~> 14.1.0.1.0)
-      libddwaf (~> 1.15.0.0.0)
+      libddwaf (~> 1.18.0.0.0)
       msgpack
 
 GEM
@@ -47,7 +47,7 @@ GEM
     json-schema (2.8.1)
       addressable (>= 2.4)
     libdatadog (14.1.0.1.0)
-    libddwaf (1.15.0.0.0-java)
+    libddwaf (1.18.0.0.0-java)
       ffi (~> 1.0)
     memory_profiler (0.9.14)
     method_source (1.1.0)

--- a/gemfiles/jruby_9.3_stripe_7.gemfile.lock
+++ b/gemfiles/jruby_9.3_stripe_7.gemfile.lock
@@ -14,7 +14,7 @@ PATH
     datadog (2.7.0)
       datadog-ruby_core_source (~> 3.3)
       libdatadog (~> 14.1.0.1.0)
-      libddwaf (~> 1.15.0.0.0)
+      libddwaf (~> 1.18.0.0.0)
       msgpack
 
 GEM
@@ -47,7 +47,7 @@ GEM
     json-schema (2.8.1)
       addressable (>= 2.4)
     libdatadog (14.1.0.1.0)
-    libddwaf (1.15.0.0.0-java)
+    libddwaf (1.18.0.0.0-java)
       ffi (~> 1.0)
     memory_profiler (0.9.14)
     method_source (1.1.0)

--- a/gemfiles/jruby_9.3_stripe_8.gemfile.lock
+++ b/gemfiles/jruby_9.3_stripe_8.gemfile.lock
@@ -14,7 +14,7 @@ PATH
     datadog (2.7.0)
       datadog-ruby_core_source (~> 3.3)
       libdatadog (~> 14.1.0.1.0)
-      libddwaf (~> 1.15.0.0.0)
+      libddwaf (~> 1.18.0.0.0)
       msgpack
 
 GEM
@@ -47,7 +47,7 @@ GEM
     json-schema (2.8.1)
       addressable (>= 2.4)
     libdatadog (14.1.0.1.0)
-    libddwaf (1.15.0.0.0-java)
+    libddwaf (1.18.0.0.0-java)
       ffi (~> 1.0)
     memory_profiler (0.9.14)
     method_source (1.1.0)

--- a/gemfiles/jruby_9.3_stripe_9.gemfile.lock
+++ b/gemfiles/jruby_9.3_stripe_9.gemfile.lock
@@ -14,7 +14,7 @@ PATH
     datadog (2.7.0)
       datadog-ruby_core_source (~> 3.3)
       libdatadog (~> 14.1.0.1.0)
-      libddwaf (~> 1.15.0.0.0)
+      libddwaf (~> 1.18.0.0.0)
       msgpack
 
 GEM
@@ -47,7 +47,7 @@ GEM
     json-schema (2.8.1)
       addressable (>= 2.4)
     libdatadog (14.1.0.1.0)
-    libddwaf (1.15.0.0.0-java)
+    libddwaf (1.18.0.0.0-java)
       ffi (~> 1.0)
     memory_profiler (0.9.14)
     method_source (1.1.0)

--- a/gemfiles/jruby_9.3_stripe_latest.gemfile.lock
+++ b/gemfiles/jruby_9.3_stripe_latest.gemfile.lock
@@ -14,7 +14,7 @@ PATH
     datadog (2.7.0)
       datadog-ruby_core_source (~> 3.3)
       libdatadog (~> 14.1.0.1.0)
-      libddwaf (~> 1.15.0.0.0)
+      libddwaf (~> 1.18.0.0.0)
       msgpack
 
 GEM
@@ -47,7 +47,7 @@ GEM
     json-schema (2.8.1)
       addressable (>= 2.4)
     libdatadog (14.1.0.1.0)
-    libddwaf (1.15.0.0.0-java)
+    libddwaf (1.18.0.0.0-java)
       ffi (~> 1.0)
     memory_profiler (0.9.14)
     method_source (1.1.0)

--- a/gemfiles/jruby_9.3_stripe_min.gemfile.lock
+++ b/gemfiles/jruby_9.3_stripe_min.gemfile.lock
@@ -14,7 +14,7 @@ PATH
     datadog (2.7.0)
       datadog-ruby_core_source (~> 3.3)
       libdatadog (~> 14.1.0.1.0)
-      libddwaf (~> 1.15.0.0.0)
+      libddwaf (~> 1.18.0.0.0)
       msgpack
 
 GEM
@@ -47,7 +47,7 @@ GEM
     json-schema (2.8.1)
       addressable (>= 2.4)
     libdatadog (14.1.0.1.0)
-    libddwaf (1.15.0.0.0-java)
+    libddwaf (1.18.0.0.0-java)
       ffi (~> 1.0)
     memory_profiler (0.9.14)
     method_source (1.1.0)

--- a/gemfiles/jruby_9.4_activesupport.gemfile.lock
+++ b/gemfiles/jruby_9.4_activesupport.gemfile.lock
@@ -14,7 +14,7 @@ PATH
     datadog (2.7.0)
       datadog-ruby_core_source (~> 3.3)
       libdatadog (~> 14.1.0.1.0)
-      libddwaf (~> 1.15.0.0.0)
+      libddwaf (~> 1.18.0.0.0)
       msgpack
 
 GEM
@@ -101,7 +101,7 @@ GEM
     jsonapi-renderer (0.2.2)
     king_konf (1.0.1)
     libdatadog (14.1.0.1.0)
-    libddwaf (1.15.0.0.0-java)
+    libddwaf (1.18.0.0.0-java)
       ffi (~> 1.0)
     lograge (0.13.0)
       actionpack (>= 4)

--- a/gemfiles/jruby_9.4_aws.gemfile.lock
+++ b/gemfiles/jruby_9.4_aws.gemfile.lock
@@ -14,7 +14,7 @@ PATH
     datadog (2.7.0)
       datadog-ruby_core_source (~> 3.3)
       libdatadog (~> 14.1.0.1.0)
-      libddwaf (~> 1.15.0.0.0)
+      libddwaf (~> 1.18.0.0.0)
       msgpack
 
 GEM
@@ -1466,7 +1466,7 @@ GEM
     json-schema (2.8.1)
       addressable (>= 2.4)
     libdatadog (14.1.0.1.0)
-    libddwaf (1.15.0.0.0-java)
+    libddwaf (1.18.0.0.0-java)
       ffi (~> 1.0)
     memory_profiler (0.9.14)
     method_source (1.0.0)

--- a/gemfiles/jruby_9.4_contrib.gemfile.lock
+++ b/gemfiles/jruby_9.4_contrib.gemfile.lock
@@ -14,7 +14,7 @@ PATH
     datadog (2.7.0)
       datadog-ruby_core_source (~> 3.3)
       libdatadog (~> 14.1.0.1.0)
-      libddwaf (~> 1.15.0.0.0)
+      libddwaf (~> 1.18.0.0.0)
       msgpack
 
 GEM
@@ -51,7 +51,7 @@ GEM
     json-schema (2.8.1)
       addressable (>= 2.4)
     libdatadog (14.1.0.1.0)
-    libddwaf (1.15.0.0.0-java)
+    libddwaf (1.18.0.0.0-java)
       ffi (~> 1.0)
     memory_profiler (0.9.14)
     method_source (1.0.0)

--- a/gemfiles/jruby_9.4_contrib_old.gemfile.lock
+++ b/gemfiles/jruby_9.4_contrib_old.gemfile.lock
@@ -14,7 +14,7 @@ PATH
     datadog (2.7.0)
       datadog-ruby_core_source (~> 3.3)
       libdatadog (~> 14.1.0.1.0)
-      libddwaf (~> 1.15.0.0.0)
+      libddwaf (~> 1.18.0.0.0)
       msgpack
 
 GEM
@@ -49,7 +49,7 @@ GEM
     json-schema (2.8.1)
       addressable (>= 2.4)
     libdatadog (14.1.0.1.0)
-    libddwaf (1.15.0.0.0-java)
+    libddwaf (1.18.0.0.0-java)
       ffi (~> 1.0)
     memory_profiler (0.9.14)
     method_source (1.0.0)

--- a/gemfiles/jruby_9.4_core_old.gemfile.lock
+++ b/gemfiles/jruby_9.4_core_old.gemfile.lock
@@ -14,7 +14,7 @@ PATH
     datadog (2.7.0)
       datadog-ruby_core_source (~> 3.3)
       libdatadog (~> 14.1.0.1.0)
-      libddwaf (~> 1.15.0.0.0)
+      libddwaf (~> 1.18.0.0.0)
       msgpack
 
 GEM
@@ -44,7 +44,7 @@ GEM
     json-schema (2.8.1)
       addressable (>= 2.4)
     libdatadog (14.1.0.1.0)
-    libddwaf (1.15.0.0.0-java)
+    libddwaf (1.18.0.0.0-java)
       ffi (~> 1.0)
     memory_profiler (0.9.14)
     method_source (1.0.0)

--- a/gemfiles/jruby_9.4_elasticsearch_7.gemfile.lock
+++ b/gemfiles/jruby_9.4_elasticsearch_7.gemfile.lock
@@ -14,7 +14,7 @@ PATH
     datadog (2.7.0)
       datadog-ruby_core_source (~> 3.3)
       libdatadog (~> 14.1.0.1.0)
-      libddwaf (~> 1.15.0.0.0)
+      libddwaf (~> 1.18.0.0.0)
       msgpack
 
 GEM
@@ -61,7 +61,7 @@ GEM
     json-schema (2.8.1)
       addressable (>= 2.4)
     libdatadog (14.1.0.1.0)
-    libddwaf (1.15.0.0.0-java)
+    libddwaf (1.18.0.0.0-java)
       ffi (~> 1.0)
     logger (1.6.1)
     memory_profiler (0.9.14)

--- a/gemfiles/jruby_9.4_elasticsearch_8.gemfile.lock
+++ b/gemfiles/jruby_9.4_elasticsearch_8.gemfile.lock
@@ -14,7 +14,7 @@ PATH
     datadog (2.7.0)
       datadog-ruby_core_source (~> 3.3)
       libdatadog (~> 14.1.0.1.0)
-      libddwaf (~> 1.15.0.0.0)
+      libddwaf (~> 1.18.0.0.0)
       msgpack
 
 GEM
@@ -59,7 +59,7 @@ GEM
     json-schema (2.8.1)
       addressable (>= 2.4)
     libdatadog (14.1.0.1.0)
-    libddwaf (1.15.0.0.0-java)
+    libddwaf (1.18.0.0.0-java)
       ffi (~> 1.0)
     logger (1.6.1)
     memory_profiler (0.9.14)

--- a/gemfiles/jruby_9.4_elasticsearch_latest.gemfile.lock
+++ b/gemfiles/jruby_9.4_elasticsearch_latest.gemfile.lock
@@ -14,7 +14,7 @@ PATH
     datadog (2.7.0)
       datadog-ruby_core_source (~> 3.3)
       libdatadog (~> 14.1.0.1.0)
-      libddwaf (~> 1.15.0.0.0)
+      libddwaf (~> 1.18.0.0.0)
       msgpack
 
 GEM
@@ -61,7 +61,7 @@ GEM
     json-schema (2.8.1)
       addressable (>= 2.4)
     libdatadog (14.1.0.1.0)
-    libddwaf (1.15.0.0.0-java)
+    libddwaf (1.18.0.0.0-java)
       ffi (~> 1.0)
     logger (1.6.1)
     memory_profiler (0.9.14)

--- a/gemfiles/jruby_9.4_graphql_1.13.gemfile.lock
+++ b/gemfiles/jruby_9.4_graphql_1.13.gemfile.lock
@@ -14,7 +14,7 @@ PATH
     datadog (2.7.0)
       datadog-ruby_core_source (~> 3.3)
       libdatadog (~> 14.1.0.1.0)
-      libddwaf (~> 1.15.0.0.0)
+      libddwaf (~> 1.18.0.0.0)
       msgpack
 
 GEM
@@ -114,7 +114,7 @@ GEM
     json-schema (2.8.1)
       addressable (>= 2.4)
     libdatadog (14.1.0.1.0)
-    libddwaf (1.15.0.0.0-java)
+    libddwaf (1.18.0.0.0-java)
       ffi (~> 1.0)
     lograge (0.14.0)
       actionpack (>= 4)

--- a/gemfiles/jruby_9.4_graphql_2.0.gemfile.lock
+++ b/gemfiles/jruby_9.4_graphql_2.0.gemfile.lock
@@ -14,7 +14,7 @@ PATH
     datadog (2.7.0)
       datadog-ruby_core_source (~> 3.3)
       libdatadog (~> 14.1.0.1.0)
-      libddwaf (~> 1.15.0.0.0)
+      libddwaf (~> 1.18.0.0.0)
       msgpack
 
 GEM
@@ -114,7 +114,7 @@ GEM
     json-schema (2.8.1)
       addressable (>= 2.4)
     libdatadog (14.1.0.1.0)
-    libddwaf (1.15.0.0.0-java)
+    libddwaf (1.18.0.0.0-java)
       ffi (~> 1.0)
     lograge (0.14.0)
       actionpack (>= 4)

--- a/gemfiles/jruby_9.4_graphql_2.1.gemfile.lock
+++ b/gemfiles/jruby_9.4_graphql_2.1.gemfile.lock
@@ -14,7 +14,7 @@ PATH
     datadog (2.7.0)
       datadog-ruby_core_source (~> 3.3)
       libdatadog (~> 14.1.0.1.0)
-      libddwaf (~> 1.15.0.0.0)
+      libddwaf (~> 1.18.0.0.0)
       msgpack
 
 GEM
@@ -115,7 +115,7 @@ GEM
     json-schema (2.8.1)
       addressable (>= 2.4)
     libdatadog (14.1.0.1.0)
-    libddwaf (1.15.0.0.0-java)
+    libddwaf (1.18.0.0.0-java)
       ffi (~> 1.0)
     lograge (0.14.0)
       actionpack (>= 4)

--- a/gemfiles/jruby_9.4_graphql_2.2.gemfile.lock
+++ b/gemfiles/jruby_9.4_graphql_2.2.gemfile.lock
@@ -14,7 +14,7 @@ PATH
     datadog (2.7.0)
       datadog-ruby_core_source (~> 3.3)
       libdatadog (~> 14.1.0.1.0)
-      libddwaf (~> 1.15.0.0.0)
+      libddwaf (~> 1.18.0.0.0)
       msgpack
 
 GEM
@@ -115,7 +115,7 @@ GEM
     json-schema (2.8.1)
       addressable (>= 2.4)
     libdatadog (14.1.0.1.0)
-    libddwaf (1.15.0.0.0-java)
+    libddwaf (1.18.0.0.0-java)
       ffi (~> 1.0)
     lograge (0.14.0)
       actionpack (>= 4)

--- a/gemfiles/jruby_9.4_graphql_2.3.gemfile.lock
+++ b/gemfiles/jruby_9.4_graphql_2.3.gemfile.lock
@@ -14,7 +14,7 @@ PATH
     datadog (2.7.0)
       datadog-ruby_core_source (~> 3.3)
       libdatadog (~> 14.1.0.1.0)
-      libddwaf (~> 1.15.0.0.0)
+      libddwaf (~> 1.18.0.0.0)
       msgpack
 
 GEM
@@ -117,7 +117,7 @@ GEM
     json-schema (2.8.1)
       addressable (>= 2.4)
     libdatadog (14.1.0.1.0)
-    libddwaf (1.15.0.0.0-java)
+    libddwaf (1.18.0.0.0-java)
       ffi (~> 1.0)
     lograge (0.14.0)
       actionpack (>= 4)

--- a/gemfiles/jruby_9.4_http.gemfile.lock
+++ b/gemfiles/jruby_9.4_http.gemfile.lock
@@ -14,7 +14,7 @@ PATH
     datadog (2.7.0)
       datadog-ruby_core_source (~> 3.3)
       libdatadog (~> 14.1.0.1.0)
-      libddwaf (~> 1.15.0.0.0)
+      libddwaf (~> 1.18.0.0.0)
       msgpack
 
 GEM
@@ -68,7 +68,7 @@ GEM
     json-schema (2.8.1)
       addressable (>= 2.4)
     libdatadog (14.1.0.1.0)
-    libddwaf (1.15.0.0.0-java)
+    libddwaf (1.18.0.0.0-java)
       ffi (~> 1.0)
     memory_profiler (0.9.14)
     method_source (1.0.0)

--- a/gemfiles/jruby_9.4_opensearch_2.gemfile.lock
+++ b/gemfiles/jruby_9.4_opensearch_2.gemfile.lock
@@ -14,7 +14,7 @@ PATH
     datadog (2.7.0)
       datadog-ruby_core_source (~> 3.3)
       libdatadog (~> 14.1.0.1.0)
-      libddwaf (~> 1.15.0.0.0)
+      libddwaf (~> 1.18.0.0.0)
       msgpack
 
 GEM
@@ -51,7 +51,7 @@ GEM
     json-schema (2.8.1)
       addressable (>= 2.4)
     libdatadog (14.1.0.1.0)
-    libddwaf (1.15.0.0.0-java)
+    libddwaf (1.18.0.0.0-java)
       ffi (~> 1.0)
     logger (1.6.1)
     memory_profiler (0.9.14)

--- a/gemfiles/jruby_9.4_opensearch_3.gemfile.lock
+++ b/gemfiles/jruby_9.4_opensearch_3.gemfile.lock
@@ -14,7 +14,7 @@ PATH
     datadog (2.7.0)
       datadog-ruby_core_source (~> 3.3)
       libdatadog (~> 14.1.0.1.0)
-      libddwaf (~> 1.15.0.0.0)
+      libddwaf (~> 1.18.0.0.0)
       msgpack
 
 GEM
@@ -51,7 +51,7 @@ GEM
     json-schema (2.8.1)
       addressable (>= 2.4)
     libdatadog (14.1.0.1.0)
-    libddwaf (1.15.0.0.0-java)
+    libddwaf (1.18.0.0.0-java)
       ffi (~> 1.0)
     logger (1.6.1)
     memory_profiler (0.9.14)

--- a/gemfiles/jruby_9.4_opensearch_latest.gemfile.lock
+++ b/gemfiles/jruby_9.4_opensearch_latest.gemfile.lock
@@ -14,7 +14,7 @@ PATH
     datadog (2.7.0)
       datadog-ruby_core_source (~> 3.3)
       libdatadog (~> 14.1.0.1.0)
-      libddwaf (~> 1.15.0.0.0)
+      libddwaf (~> 1.18.0.0.0)
       msgpack
 
 GEM
@@ -53,7 +53,7 @@ GEM
     json-schema (2.8.1)
       addressable (>= 2.4)
     libdatadog (14.1.0.1.0)
-    libddwaf (1.15.0.0.0-java)
+    libddwaf (1.18.0.0.0-java)
       ffi (~> 1.0)
     logger (1.6.1)
     memory_profiler (0.9.14)

--- a/gemfiles/jruby_9.4_rack_1.gemfile.lock
+++ b/gemfiles/jruby_9.4_rack_1.gemfile.lock
@@ -14,7 +14,7 @@ PATH
     datadog (2.7.0)
       datadog-ruby_core_source (~> 3.3)
       libdatadog (~> 14.1.0.1.0)
-      libddwaf (~> 1.15.0.0.0)
+      libddwaf (~> 1.18.0.0.0)
       msgpack
 
 GEM
@@ -44,7 +44,7 @@ GEM
     json-schema (2.8.1)
       addressable (>= 2.4)
     libdatadog (14.1.0.1.0)
-    libddwaf (1.15.0.0.0-java)
+    libddwaf (1.18.0.0.0-java)
       ffi (~> 1.0)
     memory_profiler (0.9.14)
     method_source (1.0.0)

--- a/gemfiles/jruby_9.4_rack_2.gemfile.lock
+++ b/gemfiles/jruby_9.4_rack_2.gemfile.lock
@@ -14,7 +14,7 @@ PATH
     datadog (2.7.0)
       datadog-ruby_core_source (~> 3.3)
       libdatadog (~> 14.1.0.1.0)
-      libddwaf (~> 1.15.0.0.0)
+      libddwaf (~> 1.18.0.0.0)
       msgpack
 
 GEM
@@ -44,7 +44,7 @@ GEM
     json-schema (2.8.1)
       addressable (>= 2.4)
     libdatadog (14.1.0.1.0)
-    libddwaf (1.15.0.0.0-java)
+    libddwaf (1.18.0.0.0-java)
       ffi (~> 1.0)
     memory_profiler (0.9.14)
     method_source (1.0.0)

--- a/gemfiles/jruby_9.4_rack_3.gemfile.lock
+++ b/gemfiles/jruby_9.4_rack_3.gemfile.lock
@@ -14,7 +14,7 @@ PATH
     datadog (2.7.0)
       datadog-ruby_core_source (~> 3.3)
       libdatadog (~> 14.1.0.1.0)
-      libddwaf (~> 1.15.0.0.0)
+      libddwaf (~> 1.18.0.0.0)
       msgpack
 
 GEM
@@ -44,7 +44,7 @@ GEM
     json-schema (2.8.1)
       addressable (>= 2.4)
     libdatadog (14.1.0.1.0)
-    libddwaf (1.15.0.0.0-java)
+    libddwaf (1.18.0.0.0-java)
       ffi (~> 1.0)
     memory_profiler (0.9.14)
     method_source (1.0.0)

--- a/gemfiles/jruby_9.4_rack_latest.gemfile.lock
+++ b/gemfiles/jruby_9.4_rack_latest.gemfile.lock
@@ -14,7 +14,7 @@ PATH
     datadog (2.7.0)
       datadog-ruby_core_source (~> 3.3)
       libdatadog (~> 14.1.0.1.0)
-      libddwaf (~> 1.15.0.0.0)
+      libddwaf (~> 1.18.0.0.0)
       msgpack
 
 GEM
@@ -47,7 +47,7 @@ GEM
     json-schema (2.8.1)
       addressable (>= 2.4)
     libdatadog (14.1.0.1.0)
-    libddwaf (1.15.0.0.0-java)
+    libddwaf (1.18.0.0.0-java)
       ffi (~> 1.0)
     memory_profiler (0.9.14)
     method_source (1.1.0)

--- a/gemfiles/jruby_9.4_rails61_mysql2.gemfile.lock
+++ b/gemfiles/jruby_9.4_rails61_mysql2.gemfile.lock
@@ -14,7 +14,7 @@ PATH
     datadog (2.7.0)
       datadog-ruby_core_source (~> 3.3)
       libdatadog (~> 14.1.0.1.0)
-      libddwaf (~> 1.15.0.0.0)
+      libddwaf (~> 1.18.0.0.0)
       msgpack
 
 GEM
@@ -121,7 +121,7 @@ GEM
     json-schema (2.8.1)
       addressable (>= 2.4)
     libdatadog (14.1.0.1.0)
-    libddwaf (1.15.0.0.0-java)
+    libddwaf (1.18.0.0.0-java)
       ffi (~> 1.0)
     lograge (0.14.0)
       actionpack (>= 4)

--- a/gemfiles/jruby_9.4_rails61_postgres.gemfile.lock
+++ b/gemfiles/jruby_9.4_rails61_postgres.gemfile.lock
@@ -14,7 +14,7 @@ PATH
     datadog (2.7.0)
       datadog-ruby_core_source (~> 3.3)
       libdatadog (~> 14.1.0.1.0)
-      libddwaf (~> 1.15.0.0.0)
+      libddwaf (~> 1.18.0.0.0)
       msgpack
 
 GEM
@@ -117,7 +117,7 @@ GEM
     json-schema (2.8.1)
       addressable (>= 2.4)
     libdatadog (14.1.0.1.0)
-    libddwaf (1.15.0.0.0-java)
+    libddwaf (1.18.0.0.0-java)
       ffi (~> 1.0)
     lograge (0.12.0)
       actionpack (>= 4)

--- a/gemfiles/jruby_9.4_rails61_postgres_redis.gemfile.lock
+++ b/gemfiles/jruby_9.4_rails61_postgres_redis.gemfile.lock
@@ -14,7 +14,7 @@ PATH
     datadog (2.7.0)
       datadog-ruby_core_source (~> 3.3)
       libdatadog (~> 14.1.0.1.0)
-      libddwaf (~> 1.15.0.0.0)
+      libddwaf (~> 1.18.0.0.0)
       msgpack
 
 GEM
@@ -117,7 +117,7 @@ GEM
     json-schema (2.8.1)
       addressable (>= 2.4)
     libdatadog (14.1.0.1.0)
-    libddwaf (1.15.0.0.0-java)
+    libddwaf (1.18.0.0.0-java)
       ffi (~> 1.0)
     lograge (0.12.0)
       actionpack (>= 4)

--- a/gemfiles/jruby_9.4_rails61_postgres_sidekiq.gemfile.lock
+++ b/gemfiles/jruby_9.4_rails61_postgres_sidekiq.gemfile.lock
@@ -14,7 +14,7 @@ PATH
     datadog (2.7.0)
       datadog-ruby_core_source (~> 3.3)
       libdatadog (~> 14.1.0.1.0)
-      libddwaf (~> 1.15.0.0.0)
+      libddwaf (~> 1.18.0.0.0)
       msgpack
 
 GEM
@@ -118,7 +118,7 @@ GEM
     json-schema (2.8.1)
       addressable (>= 2.4)
     libdatadog (14.1.0.1.0)
-    libddwaf (1.15.0.0.0-java)
+    libddwaf (1.18.0.0.0-java)
       ffi (~> 1.0)
     lograge (0.12.0)
       actionpack (>= 4)

--- a/gemfiles/jruby_9.4_rails61_semantic_logger.gemfile.lock
+++ b/gemfiles/jruby_9.4_rails61_semantic_logger.gemfile.lock
@@ -14,7 +14,7 @@ PATH
     datadog (2.7.0)
       datadog-ruby_core_source (~> 3.3)
       libdatadog (~> 14.1.0.1.0)
-      libddwaf (~> 1.15.0.0.0)
+      libddwaf (~> 1.18.0.0.0)
       msgpack
 
 GEM
@@ -117,7 +117,7 @@ GEM
     json-schema (2.8.1)
       addressable (>= 2.4)
     libdatadog (14.1.0.1.0)
-    libddwaf (1.15.0.0.0-java)
+    libddwaf (1.18.0.0.0-java)
       ffi (~> 1.0)
     loofah (2.19.1)
       crass (~> 1.0.2)

--- a/gemfiles/jruby_9.4_redis_3.gemfile.lock
+++ b/gemfiles/jruby_9.4_redis_3.gemfile.lock
@@ -14,7 +14,7 @@ PATH
     datadog (2.7.0)
       datadog-ruby_core_source (~> 3.3)
       libdatadog (~> 14.1.0.1.0)
-      libddwaf (~> 1.15.0.0.0)
+      libddwaf (~> 1.18.0.0.0)
       msgpack
 
 GEM
@@ -44,7 +44,7 @@ GEM
     json-schema (2.8.1)
       addressable (>= 2.4)
     libdatadog (14.1.0.1.0)
-    libddwaf (1.15.0.0.0-java)
+    libddwaf (1.18.0.0.0-java)
       ffi (~> 1.0)
     memory_profiler (0.9.14)
     method_source (1.0.0)

--- a/gemfiles/jruby_9.4_redis_4.gemfile.lock
+++ b/gemfiles/jruby_9.4_redis_4.gemfile.lock
@@ -14,7 +14,7 @@ PATH
     datadog (2.7.0)
       datadog-ruby_core_source (~> 3.3)
       libdatadog (~> 14.1.0.1.0)
-      libddwaf (~> 1.15.0.0.0)
+      libddwaf (~> 1.18.0.0.0)
       msgpack
 
 GEM
@@ -44,7 +44,7 @@ GEM
     json-schema (2.8.1)
       addressable (>= 2.4)
     libdatadog (14.1.0.1.0)
-    libddwaf (1.15.0.0.0-java)
+    libddwaf (1.18.0.0.0-java)
       ffi (~> 1.0)
     memory_profiler (0.9.14)
     method_source (1.0.0)

--- a/gemfiles/jruby_9.4_redis_5.gemfile.lock
+++ b/gemfiles/jruby_9.4_redis_5.gemfile.lock
@@ -14,7 +14,7 @@ PATH
     datadog (2.7.0)
       datadog-ruby_core_source (~> 3.3)
       libdatadog (~> 14.1.0.1.0)
-      libddwaf (~> 1.15.0.0.0)
+      libddwaf (~> 1.18.0.0.0)
       msgpack
 
 GEM
@@ -45,7 +45,7 @@ GEM
     json-schema (2.8.1)
       addressable (>= 2.4)
     libdatadog (14.1.0.1.0)
-    libddwaf (1.15.0.0.0-java)
+    libddwaf (1.18.0.0.0-java)
       ffi (~> 1.0)
     memory_profiler (0.9.14)
     method_source (1.0.0)

--- a/gemfiles/jruby_9.4_relational_db.gemfile.lock
+++ b/gemfiles/jruby_9.4_relational_db.gemfile.lock
@@ -14,7 +14,7 @@ PATH
     datadog (2.7.0)
       datadog-ruby_core_source (~> 3.3)
       libdatadog (~> 14.1.0.1.0)
-      libddwaf (~> 1.15.0.0.0)
+      libddwaf (~> 1.18.0.0.0)
       msgpack
 
 GEM
@@ -76,7 +76,7 @@ GEM
     json-schema (2.8.1)
       addressable (>= 2.4)
     libdatadog (14.1.0.1.0)
-    libddwaf (1.15.0.0.0-java)
+    libddwaf (1.18.0.0.0-java)
       ffi (~> 1.0)
     makara (0.6.0.pre)
       activerecord (>= 5.2.0)

--- a/gemfiles/jruby_9.4_resque2_redis3.gemfile.lock
+++ b/gemfiles/jruby_9.4_resque2_redis3.gemfile.lock
@@ -14,7 +14,7 @@ PATH
     datadog (2.7.0)
       datadog-ruby_core_source (~> 3.3)
       libdatadog (~> 14.1.0.1.0)
-      libddwaf (~> 1.15.0.0.0)
+      libddwaf (~> 1.18.0.0.0)
       msgpack
 
 GEM
@@ -44,7 +44,7 @@ GEM
     json-schema (2.8.1)
       addressable (>= 2.4)
     libdatadog (14.1.0.1.0)
-    libddwaf (1.15.0.0.0-java)
+    libddwaf (1.18.0.0.0-java)
       ffi (~> 1.0)
     memory_profiler (0.9.14)
     method_source (1.0.0)

--- a/gemfiles/jruby_9.4_resque2_redis4.gemfile.lock
+++ b/gemfiles/jruby_9.4_resque2_redis4.gemfile.lock
@@ -14,7 +14,7 @@ PATH
     datadog (2.7.0)
       datadog-ruby_core_source (~> 3.3)
       libdatadog (~> 14.1.0.1.0)
-      libddwaf (~> 1.15.0.0.0)
+      libddwaf (~> 1.18.0.0.0)
       msgpack
 
 GEM
@@ -45,7 +45,7 @@ GEM
     json-schema (2.8.1)
       addressable (>= 2.4)
     libdatadog (14.1.0.1.0)
-    libddwaf (1.15.0.0.0-java)
+    libddwaf (1.18.0.0.0-java)
       ffi (~> 1.0)
     memory_profiler (0.9.14)
     method_source (1.0.0)

--- a/gemfiles/jruby_9.4_sinatra_2.gemfile.lock
+++ b/gemfiles/jruby_9.4_sinatra_2.gemfile.lock
@@ -14,7 +14,7 @@ PATH
     datadog (2.7.0)
       datadog-ruby_core_source (~> 3.3)
       libdatadog (~> 14.1.0.1.0)
-      libddwaf (~> 1.15.0.0.0)
+      libddwaf (~> 1.18.0.0.0)
       msgpack
 
 GEM
@@ -47,7 +47,7 @@ GEM
     json-schema (2.8.1)
       addressable (>= 2.4)
     libdatadog (14.1.0.1.0)
-    libddwaf (1.15.0.0.0-java)
+    libddwaf (1.18.0.0.0-java)
       ffi (~> 1.0)
     memory_profiler (0.9.14)
     method_source (1.1.0)

--- a/gemfiles/jruby_9.4_sinatra_3.gemfile.lock
+++ b/gemfiles/jruby_9.4_sinatra_3.gemfile.lock
@@ -14,7 +14,7 @@ PATH
     datadog (2.7.0)
       datadog-ruby_core_source (~> 3.3)
       libdatadog (~> 14.1.0.1.0)
-      libddwaf (~> 1.15.0.0.0)
+      libddwaf (~> 1.18.0.0.0)
       msgpack
 
 GEM
@@ -48,7 +48,7 @@ GEM
     json-schema (2.8.1)
       addressable (>= 2.4)
     libdatadog (14.1.0.1.0)
-    libddwaf (1.15.0.0.0-java)
+    libddwaf (1.18.0.0.0-java)
       ffi (~> 1.0)
     memory_profiler (0.9.14)
     method_source (1.1.0)

--- a/gemfiles/jruby_9.4_sinatra_4.gemfile.lock
+++ b/gemfiles/jruby_9.4_sinatra_4.gemfile.lock
@@ -14,7 +14,7 @@ PATH
     datadog (2.7.0)
       datadog-ruby_core_source (~> 3.3)
       libdatadog (~> 14.1.0.1.0)
-      libddwaf (~> 1.15.0.0.0)
+      libddwaf (~> 1.18.0.0.0)
       msgpack
 
 GEM
@@ -48,7 +48,7 @@ GEM
     json-schema (2.8.1)
       addressable (>= 2.4)
     libdatadog (14.1.0.1.0)
-    libddwaf (1.15.0.0.0-java)
+    libddwaf (1.18.0.0.0-java)
       ffi (~> 1.0)
     memory_profiler (0.9.14)
     method_source (1.1.0)

--- a/gemfiles/jruby_9.4_stripe_10.gemfile.lock
+++ b/gemfiles/jruby_9.4_stripe_10.gemfile.lock
@@ -14,7 +14,7 @@ PATH
     datadog (2.7.0)
       datadog-ruby_core_source (~> 3.3)
       libdatadog (~> 14.1.0.1.0)
-      libddwaf (~> 1.15.0.0.0)
+      libddwaf (~> 1.18.0.0.0)
       msgpack
 
 GEM
@@ -47,7 +47,7 @@ GEM
     json-schema (2.8.1)
       addressable (>= 2.4)
     libdatadog (14.1.0.1.0)
-    libddwaf (1.15.0.0.0-java)
+    libddwaf (1.18.0.0.0-java)
       ffi (~> 1.0)
     memory_profiler (0.9.14)
     method_source (1.1.0)

--- a/gemfiles/jruby_9.4_stripe_11.gemfile.lock
+++ b/gemfiles/jruby_9.4_stripe_11.gemfile.lock
@@ -14,7 +14,7 @@ PATH
     datadog (2.7.0)
       datadog-ruby_core_source (~> 3.3)
       libdatadog (~> 14.1.0.1.0)
-      libddwaf (~> 1.15.0.0.0)
+      libddwaf (~> 1.18.0.0.0)
       msgpack
 
 GEM
@@ -47,7 +47,7 @@ GEM
     json-schema (2.8.1)
       addressable (>= 2.4)
     libdatadog (14.1.0.1.0)
-    libddwaf (1.15.0.0.0-java)
+    libddwaf (1.18.0.0.0-java)
       ffi (~> 1.0)
     memory_profiler (0.9.14)
     method_source (1.1.0)

--- a/gemfiles/jruby_9.4_stripe_12.gemfile.lock
+++ b/gemfiles/jruby_9.4_stripe_12.gemfile.lock
@@ -14,7 +14,7 @@ PATH
     datadog (2.7.0)
       datadog-ruby_core_source (~> 3.3)
       libdatadog (~> 14.1.0.1.0)
-      libddwaf (~> 1.15.0.0.0)
+      libddwaf (~> 1.18.0.0.0)
       msgpack
 
 GEM
@@ -47,7 +47,7 @@ GEM
     json-schema (2.8.1)
       addressable (>= 2.4)
     libdatadog (14.1.0.1.0)
-    libddwaf (1.15.0.0.0-java)
+    libddwaf (1.18.0.0.0-java)
       ffi (~> 1.0)
     memory_profiler (0.9.14)
     method_source (1.1.0)

--- a/gemfiles/jruby_9.4_stripe_7.gemfile.lock
+++ b/gemfiles/jruby_9.4_stripe_7.gemfile.lock
@@ -14,7 +14,7 @@ PATH
     datadog (2.7.0)
       datadog-ruby_core_source (~> 3.3)
       libdatadog (~> 14.1.0.1.0)
-      libddwaf (~> 1.15.0.0.0)
+      libddwaf (~> 1.18.0.0.0)
       msgpack
 
 GEM
@@ -47,7 +47,7 @@ GEM
     json-schema (2.8.1)
       addressable (>= 2.4)
     libdatadog (14.1.0.1.0)
-    libddwaf (1.15.0.0.0-java)
+    libddwaf (1.18.0.0.0-java)
       ffi (~> 1.0)
     memory_profiler (0.9.14)
     method_source (1.1.0)

--- a/gemfiles/jruby_9.4_stripe_8.gemfile.lock
+++ b/gemfiles/jruby_9.4_stripe_8.gemfile.lock
@@ -14,7 +14,7 @@ PATH
     datadog (2.7.0)
       datadog-ruby_core_source (~> 3.3)
       libdatadog (~> 14.1.0.1.0)
-      libddwaf (~> 1.15.0.0.0)
+      libddwaf (~> 1.18.0.0.0)
       msgpack
 
 GEM
@@ -47,7 +47,7 @@ GEM
     json-schema (2.8.1)
       addressable (>= 2.4)
     libdatadog (14.1.0.1.0)
-    libddwaf (1.15.0.0.0-java)
+    libddwaf (1.18.0.0.0-java)
       ffi (~> 1.0)
     memory_profiler (0.9.14)
     method_source (1.1.0)

--- a/gemfiles/jruby_9.4_stripe_9.gemfile.lock
+++ b/gemfiles/jruby_9.4_stripe_9.gemfile.lock
@@ -14,7 +14,7 @@ PATH
     datadog (2.7.0)
       datadog-ruby_core_source (~> 3.3)
       libdatadog (~> 14.1.0.1.0)
-      libddwaf (~> 1.15.0.0.0)
+      libddwaf (~> 1.18.0.0.0)
       msgpack
 
 GEM
@@ -47,7 +47,7 @@ GEM
     json-schema (2.8.1)
       addressable (>= 2.4)
     libdatadog (14.1.0.1.0)
-    libddwaf (1.15.0.0.0-java)
+    libddwaf (1.18.0.0.0-java)
       ffi (~> 1.0)
     memory_profiler (0.9.14)
     method_source (1.1.0)

--- a/gemfiles/jruby_9.4_stripe_latest.gemfile.lock
+++ b/gemfiles/jruby_9.4_stripe_latest.gemfile.lock
@@ -14,7 +14,7 @@ PATH
     datadog (2.7.0)
       datadog-ruby_core_source (~> 3.3)
       libdatadog (~> 14.1.0.1.0)
-      libddwaf (~> 1.15.0.0.0)
+      libddwaf (~> 1.18.0.0.0)
       msgpack
 
 GEM
@@ -47,7 +47,7 @@ GEM
     json-schema (2.8.1)
       addressable (>= 2.4)
     libdatadog (14.1.0.1.0)
-    libddwaf (1.15.0.0.0-java)
+    libddwaf (1.18.0.0.0-java)
       ffi (~> 1.0)
     memory_profiler (0.9.14)
     method_source (1.1.0)

--- a/gemfiles/jruby_9.4_stripe_min.gemfile.lock
+++ b/gemfiles/jruby_9.4_stripe_min.gemfile.lock
@@ -14,7 +14,7 @@ PATH
     datadog (2.7.0)
       datadog-ruby_core_source (~> 3.3)
       libdatadog (~> 14.1.0.1.0)
-      libddwaf (~> 1.15.0.0.0)
+      libddwaf (~> 1.18.0.0.0)
       msgpack
 
 GEM
@@ -47,7 +47,7 @@ GEM
     json-schema (2.8.1)
       addressable (>= 2.4)
     libdatadog (14.1.0.1.0)
-    libddwaf (1.15.0.0.0-java)
+    libddwaf (1.18.0.0.0-java)
       ffi (~> 1.0)
     memory_profiler (0.9.14)
     method_source (1.1.0)

--- a/gemfiles/ruby_2.5_activesupport.gemfile.lock
+++ b/gemfiles/ruby_2.5_activesupport.gemfile.lock
@@ -14,7 +14,7 @@ PATH
     datadog (2.7.0)
       datadog-ruby_core_source (~> 3.3)
       libdatadog (~> 14.1.0.1.0)
-      libddwaf (~> 1.15.0.0.0)
+      libddwaf (~> 1.18.0.0.0)
       msgpack
 
 GEM
@@ -111,9 +111,9 @@ GEM
     king_konf (1.0.1)
     libdatadog (14.1.0.1.0-aarch64-linux)
     libdatadog (14.1.0.1.0-x86_64-linux)
-    libddwaf (1.15.0.0.0-aarch64-linux)
+    libddwaf (1.18.0.0.0-aarch64-linux)
       ffi (~> 1.0)
-    libddwaf (1.15.0.0.0-x86_64-linux)
+    libddwaf (1.18.0.0.0-x86_64-linux)
       ffi (~> 1.0)
     lograge (0.13.0)
       actionpack (>= 4)

--- a/gemfiles/ruby_2.5_aws.gemfile.lock
+++ b/gemfiles/ruby_2.5_aws.gemfile.lock
@@ -14,7 +14,7 @@ PATH
     datadog (2.7.0)
       datadog-ruby_core_source (~> 3.3)
       libdatadog (~> 14.1.0.1.0)
-      libddwaf (~> 1.15.0.0.0)
+      libddwaf (~> 1.18.0.0.0)
       msgpack
 
 GEM
@@ -1472,9 +1472,9 @@ GEM
       addressable (>= 2.4)
     libdatadog (14.1.0.1.0-aarch64-linux)
     libdatadog (14.1.0.1.0-x86_64-linux)
-    libddwaf (1.15.0.0.0-aarch64-linux)
+    libddwaf (1.18.0.0.0-aarch64-linux)
       ffi (~> 1.0)
-    libddwaf (1.15.0.0.0-x86_64-linux)
+    libddwaf (1.18.0.0.0-x86_64-linux)
       ffi (~> 1.0)
     memory_profiler (0.9.14)
     method_source (1.0.0)

--- a/gemfiles/ruby_2.5_contrib.gemfile.lock
+++ b/gemfiles/ruby_2.5_contrib.gemfile.lock
@@ -14,7 +14,7 @@ PATH
     datadog (2.7.0)
       datadog-ruby_core_source (~> 3.3)
       libdatadog (~> 14.1.0.1.0)
-      libddwaf (~> 1.15.0.0.0)
+      libddwaf (~> 1.18.0.0.0)
       msgpack
 
 GEM
@@ -65,9 +65,9 @@ GEM
       addressable (>= 2.4)
     libdatadog (14.1.0.1.0-aarch64-linux)
     libdatadog (14.1.0.1.0-x86_64-linux)
-    libddwaf (1.15.0.0.0-aarch64-linux)
+    libddwaf (1.18.0.0.0-aarch64-linux)
       ffi (~> 1.0)
-    libddwaf (1.15.0.0.0-x86_64-linux)
+    libddwaf (1.18.0.0.0-x86_64-linux)
       ffi (~> 1.0)
     memory_profiler (0.9.14)
     method_source (1.0.0)

--- a/gemfiles/ruby_2.5_contrib_old.gemfile.lock
+++ b/gemfiles/ruby_2.5_contrib_old.gemfile.lock
@@ -14,7 +14,7 @@ PATH
     datadog (2.7.0)
       datadog-ruby_core_source (~> 3.3)
       libdatadog (~> 14.1.0.1.0)
-      libddwaf (~> 1.15.0.0.0)
+      libddwaf (~> 1.18.0.0.0)
       msgpack
 
 GEM
@@ -61,9 +61,9 @@ GEM
       addressable (>= 2.4)
     libdatadog (14.1.0.1.0-aarch64-linux)
     libdatadog (14.1.0.1.0-x86_64-linux)
-    libddwaf (1.15.0.0.0-aarch64-linux)
+    libddwaf (1.18.0.0.0-aarch64-linux)
       ffi (~> 1.0)
-    libddwaf (1.15.0.0.0-x86_64-linux)
+    libddwaf (1.18.0.0.0-x86_64-linux)
       ffi (~> 1.0)
     memory_profiler (0.9.14)
     method_source (1.0.0)

--- a/gemfiles/ruby_2.5_core_old.gemfile.lock
+++ b/gemfiles/ruby_2.5_core_old.gemfile.lock
@@ -14,7 +14,7 @@ PATH
     datadog (2.7.0)
       datadog-ruby_core_source (~> 3.3)
       libdatadog (~> 14.1.0.1.0)
-      libddwaf (~> 1.15.0.0.0)
+      libddwaf (~> 1.18.0.0.0)
       msgpack
 
 GEM
@@ -50,9 +50,9 @@ GEM
       addressable (>= 2.4)
     libdatadog (14.1.0.1.0-aarch64-linux)
     libdatadog (14.1.0.1.0-x86_64-linux)
-    libddwaf (1.15.0.0.0-aarch64-linux)
+    libddwaf (1.18.0.0.0-aarch64-linux)
       ffi (~> 1.0)
-    libddwaf (1.15.0.0.0-x86_64-linux)
+    libddwaf (1.18.0.0.0-x86_64-linux)
       ffi (~> 1.0)
     memory_profiler (0.9.14)
     method_source (1.0.0)

--- a/gemfiles/ruby_2.5_elasticsearch_7.gemfile.lock
+++ b/gemfiles/ruby_2.5_elasticsearch_7.gemfile.lock
@@ -14,7 +14,7 @@ PATH
     datadog (2.7.0)
       datadog-ruby_core_source (~> 3.3)
       libdatadog (~> 14.1.0.1.0)
-      libddwaf (~> 1.15.0.0.0)
+      libddwaf (~> 1.18.0.0.0)
       msgpack
 
 GEM
@@ -84,9 +84,9 @@ GEM
       addressable (>= 2.4)
     libdatadog (14.1.0.1.0-aarch64-linux)
     libdatadog (14.1.0.1.0-x86_64-linux)
-    libddwaf (1.15.0.0.0-aarch64-linux)
+    libddwaf (1.18.0.0.0-aarch64-linux)
       ffi (~> 1.0)
-    libddwaf (1.15.0.0.0-x86_64-linux)
+    libddwaf (1.18.0.0.0-x86_64-linux)
       ffi (~> 1.0)
     memory_profiler (0.9.14)
     method_source (1.0.0)

--- a/gemfiles/ruby_2.5_elasticsearch_8.gemfile.lock
+++ b/gemfiles/ruby_2.5_elasticsearch_8.gemfile.lock
@@ -14,7 +14,7 @@ PATH
     datadog (2.7.0)
       datadog-ruby_core_source (~> 3.3)
       libdatadog (~> 14.1.0.1.0)
-      libddwaf (~> 1.15.0.0.0)
+      libddwaf (~> 1.18.0.0.0)
       msgpack
 
 GEM
@@ -82,9 +82,9 @@ GEM
       addressable (>= 2.4)
     libdatadog (14.1.0.1.0-aarch64-linux)
     libdatadog (14.1.0.1.0-x86_64-linux)
-    libddwaf (1.15.0.0.0-aarch64-linux)
+    libddwaf (1.18.0.0.0-aarch64-linux)
       ffi (~> 1.0)
-    libddwaf (1.15.0.0.0-x86_64-linux)
+    libddwaf (1.18.0.0.0-x86_64-linux)
       ffi (~> 1.0)
     memory_profiler (0.9.14)
     method_source (1.0.0)

--- a/gemfiles/ruby_2.5_elasticsearch_latest.gemfile.lock
+++ b/gemfiles/ruby_2.5_elasticsearch_latest.gemfile.lock
@@ -14,7 +14,7 @@ PATH
     datadog (2.7.0)
       datadog-ruby_core_source (~> 3.3)
       libdatadog (~> 14.1.0.1.0)
-      libddwaf (~> 1.15.0.0.0)
+      libddwaf (~> 1.18.0.0.0)
       msgpack
 
 GEM
@@ -84,9 +84,9 @@ GEM
       addressable (>= 2.4)
     libdatadog (14.1.0.1.0-aarch64-linux)
     libdatadog (14.1.0.1.0-x86_64-linux)
-    libddwaf (1.15.0.0.0-aarch64-linux)
+    libddwaf (1.18.0.0.0-aarch64-linux)
       ffi (~> 1.0)
-    libddwaf (1.15.0.0.0-x86_64-linux)
+    libddwaf (1.18.0.0.0-x86_64-linux)
       ffi (~> 1.0)
     memory_profiler (0.9.14)
     method_source (1.1.0)

--- a/gemfiles/ruby_2.5_graphql_2.0.gemfile.lock
+++ b/gemfiles/ruby_2.5_graphql_2.0.gemfile.lock
@@ -14,7 +14,7 @@ PATH
     datadog (2.7.0)
       datadog-ruby_core_source (~> 3.3)
       libdatadog (~> 14.1.0.1.0)
-      libddwaf (~> 1.15.0.0.0)
+      libddwaf (~> 1.18.0.0.0)
       msgpack
 
 GEM
@@ -121,9 +121,9 @@ GEM
       addressable (>= 2.4)
     libdatadog (14.1.0.1.0-aarch64-linux)
     libdatadog (14.1.0.1.0-x86_64-linux)
-    libddwaf (1.15.0.0.0-aarch64-linux)
+    libddwaf (1.18.0.0.0-aarch64-linux)
       ffi (~> 1.0)
-    libddwaf (1.15.0.0.0-x86_64-linux)
+    libddwaf (1.18.0.0.0-x86_64-linux)
       ffi (~> 1.0)
     lograge (0.14.0)
       actionpack (>= 4)

--- a/gemfiles/ruby_2.5_hanami_1.gemfile.lock
+++ b/gemfiles/ruby_2.5_hanami_1.gemfile.lock
@@ -14,7 +14,7 @@ PATH
     datadog (2.7.0)
       datadog-ruby_core_source (~> 3.3)
       libdatadog (~> 14.1.0.1.0)
-      libddwaf (~> 1.15.0.0.0)
+      libddwaf (~> 1.18.0.0.0)
       msgpack
 
 GEM
@@ -126,9 +126,9 @@ GEM
       addressable (>= 2.4)
     libdatadog (14.1.0.1.0-aarch64-linux)
     libdatadog (14.1.0.1.0-x86_64-linux)
-    libddwaf (1.15.0.0.0-aarch64-linux)
+    libddwaf (1.18.0.0.0-aarch64-linux)
       ffi (~> 1.0)
-    libddwaf (1.15.0.0.0-x86_64-linux)
+    libddwaf (1.18.0.0.0-x86_64-linux)
       ffi (~> 1.0)
     mail (2.8.1)
       mini_mime (>= 0.1.1)

--- a/gemfiles/ruby_2.5_http.gemfile.lock
+++ b/gemfiles/ruby_2.5_http.gemfile.lock
@@ -14,7 +14,7 @@ PATH
     datadog (2.7.0)
       datadog-ruby_core_source (~> 3.3)
       libdatadog (~> 14.1.0.1.0)
-      libddwaf (~> 1.15.0.0.0)
+      libddwaf (~> 1.18.0.0.0)
       msgpack
 
 GEM
@@ -91,9 +91,9 @@ GEM
       addressable (>= 2.4)
     libdatadog (14.1.0.1.0-aarch64-linux)
     libdatadog (14.1.0.1.0-x86_64-linux)
-    libddwaf (1.15.0.0.0-aarch64-linux)
+    libddwaf (1.18.0.0.0-aarch64-linux)
       ffi (~> 1.0)
-    libddwaf (1.15.0.0.0-x86_64-linux)
+    libddwaf (1.18.0.0.0-x86_64-linux)
       ffi (~> 1.0)
     llhttp-ffi (0.3.1)
       ffi-compiler (~> 1.0)

--- a/gemfiles/ruby_2.5_opensearch_2.gemfile.lock
+++ b/gemfiles/ruby_2.5_opensearch_2.gemfile.lock
@@ -14,7 +14,7 @@ PATH
     datadog (2.7.0)
       datadog-ruby_core_source (~> 3.3)
       libdatadog (~> 14.1.0.1.0)
-      libddwaf (~> 1.15.0.0.0)
+      libddwaf (~> 1.18.0.0.0)
       msgpack
 
 GEM
@@ -74,9 +74,9 @@ GEM
       addressable (>= 2.4)
     libdatadog (14.1.0.1.0-aarch64-linux)
     libdatadog (14.1.0.1.0-x86_64-linux)
-    libddwaf (1.15.0.0.0-aarch64-linux)
+    libddwaf (1.18.0.0.0-aarch64-linux)
       ffi (~> 1.0)
-    libddwaf (1.15.0.0.0-x86_64-linux)
+    libddwaf (1.18.0.0.0-x86_64-linux)
       ffi (~> 1.0)
     memory_profiler (0.9.14)
     method_source (1.0.0)

--- a/gemfiles/ruby_2.5_opensearch_3.gemfile.lock
+++ b/gemfiles/ruby_2.5_opensearch_3.gemfile.lock
@@ -14,7 +14,7 @@ PATH
     datadog (2.7.0)
       datadog-ruby_core_source (~> 3.3)
       libdatadog (~> 14.1.0.1.0)
-      libddwaf (~> 1.15.0.0.0)
+      libddwaf (~> 1.18.0.0.0)
       msgpack
 
 GEM
@@ -74,9 +74,9 @@ GEM
       addressable (>= 2.4)
     libdatadog (14.1.0.1.0-aarch64-linux)
     libdatadog (14.1.0.1.0-x86_64-linux)
-    libddwaf (1.15.0.0.0-aarch64-linux)
+    libddwaf (1.18.0.0.0-aarch64-linux)
       ffi (~> 1.0)
-    libddwaf (1.15.0.0.0-x86_64-linux)
+    libddwaf (1.18.0.0.0-x86_64-linux)
       ffi (~> 1.0)
     memory_profiler (0.9.14)
     method_source (1.0.0)

--- a/gemfiles/ruby_2.5_opensearch_latest.gemfile.lock
+++ b/gemfiles/ruby_2.5_opensearch_latest.gemfile.lock
@@ -14,7 +14,7 @@ PATH
     datadog (2.7.0)
       datadog-ruby_core_source (~> 3.3)
       libdatadog (~> 14.1.0.1.0)
-      libddwaf (~> 1.15.0.0.0)
+      libddwaf (~> 1.18.0.0.0)
       msgpack
 
 GEM
@@ -76,9 +76,9 @@ GEM
       addressable (>= 2.4)
     libdatadog (14.1.0.1.0-aarch64-linux)
     libdatadog (14.1.0.1.0-x86_64-linux)
-    libddwaf (1.15.0.0.0-aarch64-linux)
+    libddwaf (1.18.0.0.0-aarch64-linux)
       ffi (~> 1.0)
-    libddwaf (1.15.0.0.0-x86_64-linux)
+    libddwaf (1.18.0.0.0-x86_64-linux)
       ffi (~> 1.0)
     memory_profiler (0.9.14)
     method_source (1.1.0)

--- a/gemfiles/ruby_2.5_rack_1.gemfile.lock
+++ b/gemfiles/ruby_2.5_rack_1.gemfile.lock
@@ -14,7 +14,7 @@ PATH
     datadog (2.7.0)
       datadog-ruby_core_source (~> 3.3)
       libdatadog (~> 14.1.0.1.0)
-      libddwaf (~> 1.15.0.0.0)
+      libddwaf (~> 1.18.0.0.0)
       msgpack
 
 GEM
@@ -50,9 +50,9 @@ GEM
       addressable (>= 2.4)
     libdatadog (14.1.0.1.0-aarch64-linux)
     libdatadog (14.1.0.1.0-x86_64-linux)
-    libddwaf (1.15.0.0.0-aarch64-linux)
+    libddwaf (1.18.0.0.0-aarch64-linux)
       ffi (~> 1.0)
-    libddwaf (1.15.0.0.0-x86_64-linux)
+    libddwaf (1.18.0.0.0-x86_64-linux)
       ffi (~> 1.0)
     memory_profiler (0.9.14)
     method_source (1.0.0)

--- a/gemfiles/ruby_2.5_rack_2.gemfile.lock
+++ b/gemfiles/ruby_2.5_rack_2.gemfile.lock
@@ -14,7 +14,7 @@ PATH
     datadog (2.7.0)
       datadog-ruby_core_source (~> 3.3)
       libdatadog (~> 14.1.0.1.0)
-      libddwaf (~> 1.15.0.0.0)
+      libddwaf (~> 1.18.0.0.0)
       msgpack
 
 GEM
@@ -50,9 +50,9 @@ GEM
       addressable (>= 2.4)
     libdatadog (14.1.0.1.0-aarch64-linux)
     libdatadog (14.1.0.1.0-x86_64-linux)
-    libddwaf (1.15.0.0.0-aarch64-linux)
+    libddwaf (1.18.0.0.0-aarch64-linux)
       ffi (~> 1.0)
-    libddwaf (1.15.0.0.0-x86_64-linux)
+    libddwaf (1.18.0.0.0-x86_64-linux)
       ffi (~> 1.0)
     memory_profiler (0.9.14)
     method_source (1.0.0)

--- a/gemfiles/ruby_2.5_rack_3.gemfile.lock
+++ b/gemfiles/ruby_2.5_rack_3.gemfile.lock
@@ -14,7 +14,7 @@ PATH
     datadog (2.7.0)
       datadog-ruby_core_source (~> 3.3)
       libdatadog (~> 14.1.0.1.0)
-      libddwaf (~> 1.15.0.0.0)
+      libddwaf (~> 1.18.0.0.0)
       msgpack
 
 GEM
@@ -50,9 +50,9 @@ GEM
       addressable (>= 2.4)
     libdatadog (14.1.0.1.0-aarch64-linux)
     libdatadog (14.1.0.1.0-x86_64-linux)
-    libddwaf (1.15.0.0.0-aarch64-linux)
+    libddwaf (1.18.0.0.0-aarch64-linux)
       ffi (~> 1.0)
-    libddwaf (1.15.0.0.0-x86_64-linux)
+    libddwaf (1.18.0.0.0-x86_64-linux)
       ffi (~> 1.0)
     memory_profiler (0.9.14)
     method_source (1.0.0)

--- a/gemfiles/ruby_2.5_rack_latest.gemfile.lock
+++ b/gemfiles/ruby_2.5_rack_latest.gemfile.lock
@@ -14,7 +14,7 @@ PATH
     datadog (2.7.0)
       datadog-ruby_core_source (~> 3.3)
       libdatadog (~> 14.1.0.1.0)
-      libddwaf (~> 1.15.0.0.0)
+      libddwaf (~> 1.18.0.0.0)
       msgpack
 
 GEM
@@ -53,9 +53,9 @@ GEM
       addressable (>= 2.4)
     libdatadog (14.1.0.1.0-aarch64-linux)
     libdatadog (14.1.0.1.0-x86_64-linux)
-    libddwaf (1.15.0.0.0-aarch64-linux)
+    libddwaf (1.18.0.0.0-aarch64-linux)
       ffi (~> 1.0)
-    libddwaf (1.15.0.0.0-x86_64-linux)
+    libddwaf (1.18.0.0.0-x86_64-linux)
       ffi (~> 1.0)
     memory_profiler (0.9.14)
     method_source (1.1.0)

--- a/gemfiles/ruby_2.5_rails4_mysql2.gemfile.lock
+++ b/gemfiles/ruby_2.5_rails4_mysql2.gemfile.lock
@@ -70,7 +70,7 @@ PATH
     datadog (2.7.0)
       datadog-ruby_core_source (~> 3.3)
       libdatadog (~> 14.1.0.1.0)
-      libddwaf (~> 1.15.0.0.0)
+      libddwaf (~> 1.18.0.0.0)
       msgpack
 
 GEM
@@ -117,9 +117,9 @@ GEM
       addressable (>= 2.4)
     libdatadog (14.1.0.1.0-aarch64-linux)
     libdatadog (14.1.0.1.0-x86_64-linux)
-    libddwaf (1.15.0.0.0-aarch64-linux)
+    libddwaf (1.18.0.0.0-aarch64-linux)
       ffi (~> 1.0)
-    libddwaf (1.15.0.0.0-x86_64-linux)
+    libddwaf (1.18.0.0.0-x86_64-linux)
       ffi (~> 1.0)
     lograge (0.14.0)
       actionpack (>= 4)

--- a/gemfiles/ruby_2.5_rails4_postgres.gemfile.lock
+++ b/gemfiles/ruby_2.5_rails4_postgres.gemfile.lock
@@ -70,7 +70,7 @@ PATH
     datadog (2.7.0)
       datadog-ruby_core_source (~> 3.3)
       libdatadog (~> 14.1.0.1.0)
-      libddwaf (~> 1.15.0.0.0)
+      libddwaf (~> 1.18.0.0.0)
       msgpack
 
 GEM
@@ -117,9 +117,9 @@ GEM
       addressable (>= 2.4)
     libdatadog (14.1.0.1.0-aarch64-linux)
     libdatadog (14.1.0.1.0-x86_64-linux)
-    libddwaf (1.15.0.0.0-aarch64-linux)
+    libddwaf (1.18.0.0.0-aarch64-linux)
       ffi (~> 1.0)
-    libddwaf (1.15.0.0.0-x86_64-linux)
+    libddwaf (1.18.0.0.0-x86_64-linux)
       ffi (~> 1.0)
     lograge (0.14.0)
       actionpack (>= 4)

--- a/gemfiles/ruby_2.5_rails4_postgres_redis.gemfile.lock
+++ b/gemfiles/ruby_2.5_rails4_postgres_redis.gemfile.lock
@@ -70,7 +70,7 @@ PATH
     datadog (2.7.0)
       datadog-ruby_core_source (~> 3.3)
       libdatadog (~> 14.1.0.1.0)
-      libddwaf (~> 1.15.0.0.0)
+      libddwaf (~> 1.18.0.0.0)
       msgpack
 
 GEM
@@ -117,9 +117,9 @@ GEM
       addressable (>= 2.4)
     libdatadog (14.1.0.1.0-aarch64-linux)
     libdatadog (14.1.0.1.0-x86_64-linux)
-    libddwaf (1.15.0.0.0-aarch64-linux)
+    libddwaf (1.18.0.0.0-aarch64-linux)
       ffi (~> 1.0)
-    libddwaf (1.15.0.0.0-x86_64-linux)
+    libddwaf (1.18.0.0.0-x86_64-linux)
       ffi (~> 1.0)
     lograge (0.14.0)
       actionpack (>= 4)

--- a/gemfiles/ruby_2.5_rails4_postgres_sidekiq.gemfile.lock
+++ b/gemfiles/ruby_2.5_rails4_postgres_sidekiq.gemfile.lock
@@ -67,7 +67,7 @@ PATH
     datadog (2.7.0)
       datadog-ruby_core_source (~> 3.3)
       libdatadog (~> 14.1.0.1.0)
-      libddwaf (~> 1.15.0.0.0)
+      libddwaf (~> 1.18.0.0.0)
       msgpack
 
 GEM
@@ -118,9 +118,9 @@ GEM
       addressable (>= 2.4)
     libdatadog (14.1.0.1.0-aarch64-linux)
     libdatadog (14.1.0.1.0-x86_64-linux)
-    libddwaf (1.15.0.0.0-aarch64-linux)
+    libddwaf (1.18.0.0.0-aarch64-linux)
       ffi (~> 1.0)
-    libddwaf (1.15.0.0.0-x86_64-linux)
+    libddwaf (1.18.0.0.0-x86_64-linux)
       ffi (~> 1.0)
     lograge (0.14.0)
       actionpack (>= 4)

--- a/gemfiles/ruby_2.5_rails4_semantic_logger.gemfile.lock
+++ b/gemfiles/ruby_2.5_rails4_semantic_logger.gemfile.lock
@@ -70,7 +70,7 @@ PATH
     datadog (2.7.0)
       datadog-ruby_core_source (~> 3.3)
       libdatadog (~> 14.1.0.1.0)
-      libddwaf (~> 1.15.0.0.0)
+      libddwaf (~> 1.18.0.0.0)
       msgpack
 
 GEM
@@ -117,9 +117,9 @@ GEM
       addressable (>= 2.4)
     libdatadog (14.1.0.1.0-aarch64-linux)
     libdatadog (14.1.0.1.0-x86_64-linux)
-    libddwaf (1.15.0.0.0-aarch64-linux)
+    libddwaf (1.18.0.0.0-aarch64-linux)
       ffi (~> 1.0)
-    libddwaf (1.15.0.0.0-x86_64-linux)
+    libddwaf (1.18.0.0.0-x86_64-linux)
       ffi (~> 1.0)
     loofah (2.22.0)
       crass (~> 1.0.2)

--- a/gemfiles/ruby_2.5_rails5_mysql2.gemfile.lock
+++ b/gemfiles/ruby_2.5_rails5_mysql2.gemfile.lock
@@ -14,7 +14,7 @@ PATH
     datadog (2.7.0)
       datadog-ruby_core_source (~> 3.3)
       libdatadog (~> 14.1.0.1.0)
-      libddwaf (~> 1.15.0.0.0)
+      libddwaf (~> 1.18.0.0.0)
       msgpack
 
 GEM
@@ -99,9 +99,9 @@ GEM
       addressable (>= 2.4)
     libdatadog (14.1.0.1.0-aarch64-linux)
     libdatadog (14.1.0.1.0-x86_64-linux)
-    libddwaf (1.15.0.0.0-aarch64-linux)
+    libddwaf (1.18.0.0.0-aarch64-linux)
       ffi (~> 1.0)
-    libddwaf (1.15.0.0.0-x86_64-linux)
+    libddwaf (1.18.0.0.0-x86_64-linux)
       ffi (~> 1.0)
     lograge (0.12.0)
       actionpack (>= 4)

--- a/gemfiles/ruby_2.5_rails5_postgres.gemfile.lock
+++ b/gemfiles/ruby_2.5_rails5_postgres.gemfile.lock
@@ -14,7 +14,7 @@ PATH
     datadog (2.7.0)
       datadog-ruby_core_source (~> 3.3)
       libdatadog (~> 14.1.0.1.0)
-      libddwaf (~> 1.15.0.0.0)
+      libddwaf (~> 1.18.0.0.0)
       msgpack
 
 GEM
@@ -101,9 +101,9 @@ GEM
       addressable (>= 2.4)
     libdatadog (14.1.0.1.0-aarch64-linux)
     libdatadog (14.1.0.1.0-x86_64-linux)
-    libddwaf (1.15.0.0.0-aarch64-linux)
+    libddwaf (1.18.0.0.0-aarch64-linux)
       ffi (~> 1.0)
-    libddwaf (1.15.0.0.0-x86_64-linux)
+    libddwaf (1.18.0.0.0-x86_64-linux)
       ffi (~> 1.0)
     lograge (0.12.0)
       actionpack (>= 4)

--- a/gemfiles/ruby_2.5_rails5_postgres_redis.gemfile.lock
+++ b/gemfiles/ruby_2.5_rails5_postgres_redis.gemfile.lock
@@ -14,7 +14,7 @@ PATH
     datadog (2.7.0)
       datadog-ruby_core_source (~> 3.3)
       libdatadog (~> 14.1.0.1.0)
-      libddwaf (~> 1.15.0.0.0)
+      libddwaf (~> 1.18.0.0.0)
       msgpack
 
 GEM
@@ -102,9 +102,9 @@ GEM
       addressable (>= 2.4)
     libdatadog (14.1.0.1.0-aarch64-linux)
     libdatadog (14.1.0.1.0-x86_64-linux)
-    libddwaf (1.15.0.0.0-aarch64-linux)
+    libddwaf (1.18.0.0.0-aarch64-linux)
       ffi (~> 1.0)
-    libddwaf (1.15.0.0.0-x86_64-linux)
+    libddwaf (1.18.0.0.0-x86_64-linux)
       ffi (~> 1.0)
     lograge (0.12.0)
       actionpack (>= 4)

--- a/gemfiles/ruby_2.5_rails5_postgres_redis_activesupport.gemfile.lock
+++ b/gemfiles/ruby_2.5_rails5_postgres_redis_activesupport.gemfile.lock
@@ -14,7 +14,7 @@ PATH
     datadog (2.7.0)
       datadog-ruby_core_source (~> 3.3)
       libdatadog (~> 14.1.0.1.0)
-      libddwaf (~> 1.15.0.0.0)
+      libddwaf (~> 1.18.0.0.0)
       msgpack
 
 GEM
@@ -101,9 +101,9 @@ GEM
       addressable (>= 2.4)
     libdatadog (14.1.0.1.0-aarch64-linux)
     libdatadog (14.1.0.1.0-x86_64-linux)
-    libddwaf (1.15.0.0.0-aarch64-linux)
+    libddwaf (1.18.0.0.0-aarch64-linux)
       ffi (~> 1.0)
-    libddwaf (1.15.0.0.0-x86_64-linux)
+    libddwaf (1.18.0.0.0-x86_64-linux)
       ffi (~> 1.0)
     lograge (0.12.0)
       actionpack (>= 4)

--- a/gemfiles/ruby_2.5_rails5_postgres_sidekiq.gemfile.lock
+++ b/gemfiles/ruby_2.5_rails5_postgres_sidekiq.gemfile.lock
@@ -14,7 +14,7 @@ PATH
     datadog (2.7.0)
       datadog-ruby_core_source (~> 3.3)
       libdatadog (~> 14.1.0.1.0)
-      libddwaf (~> 1.15.0.0.0)
+      libddwaf (~> 1.18.0.0.0)
       msgpack
 
 GEM
@@ -102,9 +102,9 @@ GEM
       addressable (>= 2.4)
     libdatadog (14.1.0.1.0-aarch64-linux)
     libdatadog (14.1.0.1.0-x86_64-linux)
-    libddwaf (1.15.0.0.0-aarch64-linux)
+    libddwaf (1.18.0.0.0-aarch64-linux)
       ffi (~> 1.0)
-    libddwaf (1.15.0.0.0-x86_64-linux)
+    libddwaf (1.18.0.0.0-x86_64-linux)
       ffi (~> 1.0)
     lograge (0.12.0)
       actionpack (>= 4)

--- a/gemfiles/ruby_2.5_rails5_semantic_logger.gemfile.lock
+++ b/gemfiles/ruby_2.5_rails5_semantic_logger.gemfile.lock
@@ -14,7 +14,7 @@ PATH
     datadog (2.7.0)
       datadog-ruby_core_source (~> 3.3)
       libdatadog (~> 14.1.0.1.0)
-      libddwaf (~> 1.15.0.0.0)
+      libddwaf (~> 1.18.0.0.0)
       msgpack
 
 GEM
@@ -101,9 +101,9 @@ GEM
       addressable (>= 2.4)
     libdatadog (14.1.0.1.0-aarch64-linux)
     libdatadog (14.1.0.1.0-x86_64-linux)
-    libddwaf (1.15.0.0.0-aarch64-linux)
+    libddwaf (1.18.0.0.0-aarch64-linux)
       ffi (~> 1.0)
-    libddwaf (1.15.0.0.0-x86_64-linux)
+    libddwaf (1.18.0.0.0-x86_64-linux)
       ffi (~> 1.0)
     loofah (2.19.1)
       crass (~> 1.0.2)

--- a/gemfiles/ruby_2.5_rails61_mysql2.gemfile.lock
+++ b/gemfiles/ruby_2.5_rails61_mysql2.gemfile.lock
@@ -14,7 +14,7 @@ PATH
     datadog (2.7.0)
       datadog-ruby_core_source (~> 3.3)
       libdatadog (~> 14.1.0.1.0)
-      libddwaf (~> 1.15.0.0.0)
+      libddwaf (~> 1.18.0.0.0)
       msgpack
 
 GEM
@@ -116,9 +116,9 @@ GEM
       addressable (>= 2.4)
     libdatadog (14.1.0.1.0-aarch64-linux)
     libdatadog (14.1.0.1.0-x86_64-linux)
-    libddwaf (1.15.0.0.0-aarch64-linux)
+    libddwaf (1.18.0.0.0-aarch64-linux)
       ffi (~> 1.0)
-    libddwaf (1.15.0.0.0-x86_64-linux)
+    libddwaf (1.18.0.0.0-x86_64-linux)
       ffi (~> 1.0)
     lograge (0.12.0)
       actionpack (>= 4)

--- a/gemfiles/ruby_2.5_rails61_postgres.gemfile.lock
+++ b/gemfiles/ruby_2.5_rails61_postgres.gemfile.lock
@@ -14,7 +14,7 @@ PATH
     datadog (2.7.0)
       datadog-ruby_core_source (~> 3.3)
       libdatadog (~> 14.1.0.1.0)
-      libddwaf (~> 1.15.0.0.0)
+      libddwaf (~> 1.18.0.0.0)
       msgpack
 
 GEM
@@ -118,9 +118,9 @@ GEM
       addressable (>= 2.4)
     libdatadog (14.1.0.1.0-aarch64-linux)
     libdatadog (14.1.0.1.0-x86_64-linux)
-    libddwaf (1.15.0.0.0-aarch64-linux)
+    libddwaf (1.18.0.0.0-aarch64-linux)
       ffi (~> 1.0)
-    libddwaf (1.15.0.0.0-x86_64-linux)
+    libddwaf (1.18.0.0.0-x86_64-linux)
       ffi (~> 1.0)
     lograge (0.12.0)
       actionpack (>= 4)

--- a/gemfiles/ruby_2.5_rails61_postgres_redis.gemfile.lock
+++ b/gemfiles/ruby_2.5_rails61_postgres_redis.gemfile.lock
@@ -14,7 +14,7 @@ PATH
     datadog (2.7.0)
       datadog-ruby_core_source (~> 3.3)
       libdatadog (~> 14.1.0.1.0)
-      libddwaf (~> 1.15.0.0.0)
+      libddwaf (~> 1.18.0.0.0)
       msgpack
 
 GEM
@@ -119,9 +119,9 @@ GEM
       addressable (>= 2.4)
     libdatadog (14.1.0.1.0-aarch64-linux)
     libdatadog (14.1.0.1.0-x86_64-linux)
-    libddwaf (1.15.0.0.0-aarch64-linux)
+    libddwaf (1.18.0.0.0-aarch64-linux)
       ffi (~> 1.0)
-    libddwaf (1.15.0.0.0-x86_64-linux)
+    libddwaf (1.18.0.0.0-x86_64-linux)
       ffi (~> 1.0)
     lograge (0.12.0)
       actionpack (>= 4)

--- a/gemfiles/ruby_2.5_rails61_postgres_sidekiq.gemfile.lock
+++ b/gemfiles/ruby_2.5_rails61_postgres_sidekiq.gemfile.lock
@@ -14,7 +14,7 @@ PATH
     datadog (2.7.0)
       datadog-ruby_core_source (~> 3.3)
       libdatadog (~> 14.1.0.1.0)
-      libddwaf (~> 1.15.0.0.0)
+      libddwaf (~> 1.18.0.0.0)
       msgpack
 
 GEM
@@ -119,9 +119,9 @@ GEM
       addressable (>= 2.4)
     libdatadog (14.1.0.1.0-aarch64-linux)
     libdatadog (14.1.0.1.0-x86_64-linux)
-    libddwaf (1.15.0.0.0-aarch64-linux)
+    libddwaf (1.18.0.0.0-aarch64-linux)
       ffi (~> 1.0)
-    libddwaf (1.15.0.0.0-x86_64-linux)
+    libddwaf (1.18.0.0.0-x86_64-linux)
       ffi (~> 1.0)
     lograge (0.12.0)
       actionpack (>= 4)

--- a/gemfiles/ruby_2.5_rails61_semantic_logger.gemfile.lock
+++ b/gemfiles/ruby_2.5_rails61_semantic_logger.gemfile.lock
@@ -14,7 +14,7 @@ PATH
     datadog (2.7.0)
       datadog-ruby_core_source (~> 3.3)
       libdatadog (~> 14.1.0.1.0)
-      libddwaf (~> 1.15.0.0.0)
+      libddwaf (~> 1.18.0.0.0)
       msgpack
 
 GEM
@@ -118,9 +118,9 @@ GEM
       addressable (>= 2.4)
     libdatadog (14.1.0.1.0-aarch64-linux)
     libdatadog (14.1.0.1.0-x86_64-linux)
-    libddwaf (1.15.0.0.0-aarch64-linux)
+    libddwaf (1.18.0.0.0-aarch64-linux)
       ffi (~> 1.0)
-    libddwaf (1.15.0.0.0-x86_64-linux)
+    libddwaf (1.18.0.0.0-x86_64-linux)
       ffi (~> 1.0)
     loofah (2.19.1)
       crass (~> 1.0.2)

--- a/gemfiles/ruby_2.5_rails6_mysql2.gemfile.lock
+++ b/gemfiles/ruby_2.5_rails6_mysql2.gemfile.lock
@@ -14,7 +14,7 @@ PATH
     datadog (2.7.0)
       datadog-ruby_core_source (~> 3.3)
       libdatadog (~> 14.1.0.1.0)
-      libddwaf (~> 1.15.0.0.0)
+      libddwaf (~> 1.18.0.0.0)
       msgpack
 
 GEM
@@ -112,9 +112,9 @@ GEM
       addressable (>= 2.4)
     libdatadog (14.1.0.1.0-aarch64-linux)
     libdatadog (14.1.0.1.0-x86_64-linux)
-    libddwaf (1.15.0.0.0-aarch64-linux)
+    libddwaf (1.18.0.0.0-aarch64-linux)
       ffi (~> 1.0)
-    libddwaf (1.15.0.0.0-x86_64-linux)
+    libddwaf (1.18.0.0.0-x86_64-linux)
       ffi (~> 1.0)
     lograge (0.12.0)
       actionpack (>= 4)

--- a/gemfiles/ruby_2.5_rails6_postgres.gemfile.lock
+++ b/gemfiles/ruby_2.5_rails6_postgres.gemfile.lock
@@ -14,7 +14,7 @@ PATH
     datadog (2.7.0)
       datadog-ruby_core_source (~> 3.3)
       libdatadog (~> 14.1.0.1.0)
-      libddwaf (~> 1.15.0.0.0)
+      libddwaf (~> 1.18.0.0.0)
       msgpack
 
 GEM
@@ -114,9 +114,9 @@ GEM
       addressable (>= 2.4)
     libdatadog (14.1.0.1.0-aarch64-linux)
     libdatadog (14.1.0.1.0-x86_64-linux)
-    libddwaf (1.15.0.0.0-aarch64-linux)
+    libddwaf (1.18.0.0.0-aarch64-linux)
       ffi (~> 1.0)
-    libddwaf (1.15.0.0.0-x86_64-linux)
+    libddwaf (1.18.0.0.0-x86_64-linux)
       ffi (~> 1.0)
     lograge (0.12.0)
       actionpack (>= 4)

--- a/gemfiles/ruby_2.5_rails6_postgres_redis.gemfile.lock
+++ b/gemfiles/ruby_2.5_rails6_postgres_redis.gemfile.lock
@@ -14,7 +14,7 @@ PATH
     datadog (2.7.0)
       datadog-ruby_core_source (~> 3.3)
       libdatadog (~> 14.1.0.1.0)
-      libddwaf (~> 1.15.0.0.0)
+      libddwaf (~> 1.18.0.0.0)
       msgpack
 
 GEM
@@ -115,9 +115,9 @@ GEM
       addressable (>= 2.4)
     libdatadog (14.1.0.1.0-aarch64-linux)
     libdatadog (14.1.0.1.0-x86_64-linux)
-    libddwaf (1.15.0.0.0-aarch64-linux)
+    libddwaf (1.18.0.0.0-aarch64-linux)
       ffi (~> 1.0)
-    libddwaf (1.15.0.0.0-x86_64-linux)
+    libddwaf (1.18.0.0.0-x86_64-linux)
       ffi (~> 1.0)
     lograge (0.12.0)
       actionpack (>= 4)

--- a/gemfiles/ruby_2.5_rails6_postgres_redis_activesupport.gemfile.lock
+++ b/gemfiles/ruby_2.5_rails6_postgres_redis_activesupport.gemfile.lock
@@ -14,7 +14,7 @@ PATH
     datadog (2.7.0)
       datadog-ruby_core_source (~> 3.3)
       libdatadog (~> 14.1.0.1.0)
-      libddwaf (~> 1.15.0.0.0)
+      libddwaf (~> 1.18.0.0.0)
       msgpack
 
 GEM
@@ -114,9 +114,9 @@ GEM
       addressable (>= 2.4)
     libdatadog (14.1.0.1.0-aarch64-linux)
     libdatadog (14.1.0.1.0-x86_64-linux)
-    libddwaf (1.15.0.0.0-aarch64-linux)
+    libddwaf (1.18.0.0.0-aarch64-linux)
       ffi (~> 1.0)
-    libddwaf (1.15.0.0.0-x86_64-linux)
+    libddwaf (1.18.0.0.0-x86_64-linux)
       ffi (~> 1.0)
     lograge (0.12.0)
       actionpack (>= 4)

--- a/gemfiles/ruby_2.5_rails6_postgres_sidekiq.gemfile.lock
+++ b/gemfiles/ruby_2.5_rails6_postgres_sidekiq.gemfile.lock
@@ -14,7 +14,7 @@ PATH
     datadog (2.7.0)
       datadog-ruby_core_source (~> 3.3)
       libdatadog (~> 14.1.0.1.0)
-      libddwaf (~> 1.15.0.0.0)
+      libddwaf (~> 1.18.0.0.0)
       msgpack
 
 GEM
@@ -115,9 +115,9 @@ GEM
       addressable (>= 2.4)
     libdatadog (14.1.0.1.0-aarch64-linux)
     libdatadog (14.1.0.1.0-x86_64-linux)
-    libddwaf (1.15.0.0.0-aarch64-linux)
+    libddwaf (1.18.0.0.0-aarch64-linux)
       ffi (~> 1.0)
-    libddwaf (1.15.0.0.0-x86_64-linux)
+    libddwaf (1.18.0.0.0-x86_64-linux)
       ffi (~> 1.0)
     lograge (0.12.0)
       actionpack (>= 4)

--- a/gemfiles/ruby_2.5_rails6_semantic_logger.gemfile.lock
+++ b/gemfiles/ruby_2.5_rails6_semantic_logger.gemfile.lock
@@ -14,7 +14,7 @@ PATH
     datadog (2.7.0)
       datadog-ruby_core_source (~> 3.3)
       libdatadog (~> 14.1.0.1.0)
-      libddwaf (~> 1.15.0.0.0)
+      libddwaf (~> 1.18.0.0.0)
       msgpack
 
 GEM
@@ -114,9 +114,9 @@ GEM
       addressable (>= 2.4)
     libdatadog (14.1.0.1.0-aarch64-linux)
     libdatadog (14.1.0.1.0-x86_64-linux)
-    libddwaf (1.15.0.0.0-aarch64-linux)
+    libddwaf (1.18.0.0.0-aarch64-linux)
       ffi (~> 1.0)
-    libddwaf (1.15.0.0.0-x86_64-linux)
+    libddwaf (1.18.0.0.0-x86_64-linux)
       ffi (~> 1.0)
     loofah (2.19.1)
       crass (~> 1.0.2)

--- a/gemfiles/ruby_2.5_redis_3.gemfile.lock
+++ b/gemfiles/ruby_2.5_redis_3.gemfile.lock
@@ -14,7 +14,7 @@ PATH
     datadog (2.7.0)
       datadog-ruby_core_source (~> 3.3)
       libdatadog (~> 14.1.0.1.0)
-      libddwaf (~> 1.15.0.0.0)
+      libddwaf (~> 1.18.0.0.0)
       msgpack
 
 GEM
@@ -50,9 +50,9 @@ GEM
       addressable (>= 2.4)
     libdatadog (14.1.0.1.0-aarch64-linux)
     libdatadog (14.1.0.1.0-x86_64-linux)
-    libddwaf (1.15.0.0.0-aarch64-linux)
+    libddwaf (1.18.0.0.0-aarch64-linux)
       ffi (~> 1.0)
-    libddwaf (1.15.0.0.0-x86_64-linux)
+    libddwaf (1.18.0.0.0-x86_64-linux)
       ffi (~> 1.0)
     memory_profiler (0.9.14)
     method_source (1.0.0)

--- a/gemfiles/ruby_2.5_redis_4.gemfile.lock
+++ b/gemfiles/ruby_2.5_redis_4.gemfile.lock
@@ -14,7 +14,7 @@ PATH
     datadog (2.7.0)
       datadog-ruby_core_source (~> 3.3)
       libdatadog (~> 14.1.0.1.0)
-      libddwaf (~> 1.15.0.0.0)
+      libddwaf (~> 1.18.0.0.0)
       msgpack
 
 GEM
@@ -50,9 +50,9 @@ GEM
       addressable (>= 2.4)
     libdatadog (14.1.0.1.0-aarch64-linux)
     libdatadog (14.1.0.1.0-x86_64-linux)
-    libddwaf (1.15.0.0.0-aarch64-linux)
+    libddwaf (1.18.0.0.0-aarch64-linux)
       ffi (~> 1.0)
-    libddwaf (1.15.0.0.0-x86_64-linux)
+    libddwaf (1.18.0.0.0-x86_64-linux)
       ffi (~> 1.0)
     memory_profiler (0.9.14)
     method_source (1.0.0)

--- a/gemfiles/ruby_2.5_redis_5.gemfile.lock
+++ b/gemfiles/ruby_2.5_redis_5.gemfile.lock
@@ -14,7 +14,7 @@ PATH
     datadog (2.7.0)
       datadog-ruby_core_source (~> 3.3)
       libdatadog (~> 14.1.0.1.0)
-      libddwaf (~> 1.15.0.0.0)
+      libddwaf (~> 1.18.0.0.0)
       msgpack
 
 GEM
@@ -51,9 +51,9 @@ GEM
       addressable (>= 2.4)
     libdatadog (14.1.0.1.0-aarch64-linux)
     libdatadog (14.1.0.1.0-x86_64-linux)
-    libddwaf (1.15.0.0.0-aarch64-linux)
+    libddwaf (1.18.0.0.0-aarch64-linux)
       ffi (~> 1.0)
-    libddwaf (1.15.0.0.0-x86_64-linux)
+    libddwaf (1.18.0.0.0-x86_64-linux)
       ffi (~> 1.0)
     memory_profiler (0.9.14)
     method_source (1.0.0)

--- a/gemfiles/ruby_2.5_relational_db.gemfile.lock
+++ b/gemfiles/ruby_2.5_relational_db.gemfile.lock
@@ -14,7 +14,7 @@ PATH
     datadog (2.7.0)
       datadog-ruby_core_source (~> 3.3)
       libdatadog (~> 14.1.0.1.0)
-      libddwaf (~> 1.15.0.0.0)
+      libddwaf (~> 1.18.0.0.0)
       msgpack
 
 GEM
@@ -70,9 +70,9 @@ GEM
       addressable (>= 2.4)
     libdatadog (14.1.0.1.0-aarch64-linux)
     libdatadog (14.1.0.1.0-x86_64-linux)
-    libddwaf (1.15.0.0.0-aarch64-linux)
+    libddwaf (1.18.0.0.0-aarch64-linux)
       ffi (~> 1.0)
-    libddwaf (1.15.0.0.0-x86_64-linux)
+    libddwaf (1.18.0.0.0-x86_64-linux)
       ffi (~> 1.0)
     makara (0.5.1)
       activerecord (>= 5.2.0)

--- a/gemfiles/ruby_2.5_resque2_redis3.gemfile.lock
+++ b/gemfiles/ruby_2.5_resque2_redis3.gemfile.lock
@@ -14,7 +14,7 @@ PATH
     datadog (2.7.0)
       datadog-ruby_core_source (~> 3.3)
       libdatadog (~> 14.1.0.1.0)
-      libddwaf (~> 1.15.0.0.0)
+      libddwaf (~> 1.18.0.0.0)
       msgpack
 
 GEM
@@ -50,9 +50,9 @@ GEM
       addressable (>= 2.4)
     libdatadog (14.1.0.1.0-aarch64-linux)
     libdatadog (14.1.0.1.0-x86_64-linux)
-    libddwaf (1.15.0.0.0-aarch64-linux)
+    libddwaf (1.18.0.0.0-aarch64-linux)
       ffi (~> 1.0)
-    libddwaf (1.15.0.0.0-x86_64-linux)
+    libddwaf (1.18.0.0.0-x86_64-linux)
       ffi (~> 1.0)
     memory_profiler (0.9.14)
     method_source (1.0.0)

--- a/gemfiles/ruby_2.5_resque2_redis4.gemfile.lock
+++ b/gemfiles/ruby_2.5_resque2_redis4.gemfile.lock
@@ -14,7 +14,7 @@ PATH
     datadog (2.7.0)
       datadog-ruby_core_source (~> 3.3)
       libdatadog (~> 14.1.0.1.0)
-      libddwaf (~> 1.15.0.0.0)
+      libddwaf (~> 1.18.0.0.0)
       msgpack
 
 GEM
@@ -51,9 +51,9 @@ GEM
       addressable (>= 2.4)
     libdatadog (14.1.0.1.0-aarch64-linux)
     libdatadog (14.1.0.1.0-x86_64-linux)
-    libddwaf (1.15.0.0.0-aarch64-linux)
+    libddwaf (1.18.0.0.0-aarch64-linux)
       ffi (~> 1.0)
-    libddwaf (1.15.0.0.0-x86_64-linux)
+    libddwaf (1.18.0.0.0-x86_64-linux)
       ffi (~> 1.0)
     memory_profiler (0.9.14)
     method_source (1.0.0)

--- a/gemfiles/ruby_2.5_sinatra_2.gemfile.lock
+++ b/gemfiles/ruby_2.5_sinatra_2.gemfile.lock
@@ -14,7 +14,7 @@ PATH
     datadog (2.7.0)
       datadog-ruby_core_source (~> 3.3)
       libdatadog (~> 14.1.0.1.0)
-      libddwaf (~> 1.15.0.0.0)
+      libddwaf (~> 1.18.0.0.0)
       msgpack
 
 GEM
@@ -53,9 +53,9 @@ GEM
       addressable (>= 2.4)
     libdatadog (14.1.0.1.0-aarch64-linux)
     libdatadog (14.1.0.1.0-x86_64-linux)
-    libddwaf (1.15.0.0.0-aarch64-linux)
+    libddwaf (1.18.0.0.0-aarch64-linux)
       ffi (~> 1.0)
-    libddwaf (1.15.0.0.0-x86_64-linux)
+    libddwaf (1.18.0.0.0-x86_64-linux)
       ffi (~> 1.0)
     memory_profiler (0.9.14)
     method_source (1.1.0)

--- a/gemfiles/ruby_2.5_stripe_10.gemfile.lock
+++ b/gemfiles/ruby_2.5_stripe_10.gemfile.lock
@@ -14,7 +14,7 @@ PATH
     datadog (2.7.0)
       datadog-ruby_core_source (~> 3.3)
       libdatadog (~> 14.1.0.1.0)
-      libddwaf (~> 1.15.0.0.0)
+      libddwaf (~> 1.18.0.0.0)
       msgpack
 
 GEM
@@ -53,9 +53,9 @@ GEM
       addressable (>= 2.4)
     libdatadog (14.1.0.1.0-aarch64-linux)
     libdatadog (14.1.0.1.0-x86_64-linux)
-    libddwaf (1.15.0.0.0-aarch64-linux)
+    libddwaf (1.18.0.0.0-aarch64-linux)
       ffi (~> 1.0)
-    libddwaf (1.15.0.0.0-x86_64-linux)
+    libddwaf (1.18.0.0.0-x86_64-linux)
       ffi (~> 1.0)
     memory_profiler (0.9.14)
     method_source (1.1.0)

--- a/gemfiles/ruby_2.5_stripe_11.gemfile.lock
+++ b/gemfiles/ruby_2.5_stripe_11.gemfile.lock
@@ -14,7 +14,7 @@ PATH
     datadog (2.7.0)
       datadog-ruby_core_source (~> 3.3)
       libdatadog (~> 14.1.0.1.0)
-      libddwaf (~> 1.15.0.0.0)
+      libddwaf (~> 1.18.0.0.0)
       msgpack
 
 GEM
@@ -53,9 +53,9 @@ GEM
       addressable (>= 2.4)
     libdatadog (14.1.0.1.0-aarch64-linux)
     libdatadog (14.1.0.1.0-x86_64-linux)
-    libddwaf (1.15.0.0.0-aarch64-linux)
+    libddwaf (1.18.0.0.0-aarch64-linux)
       ffi (~> 1.0)
-    libddwaf (1.15.0.0.0-x86_64-linux)
+    libddwaf (1.18.0.0.0-x86_64-linux)
       ffi (~> 1.0)
     memory_profiler (0.9.14)
     method_source (1.1.0)

--- a/gemfiles/ruby_2.5_stripe_12.gemfile.lock
+++ b/gemfiles/ruby_2.5_stripe_12.gemfile.lock
@@ -14,7 +14,7 @@ PATH
     datadog (2.7.0)
       datadog-ruby_core_source (~> 3.3)
       libdatadog (~> 14.1.0.1.0)
-      libddwaf (~> 1.15.0.0.0)
+      libddwaf (~> 1.18.0.0.0)
       msgpack
 
 GEM
@@ -53,9 +53,9 @@ GEM
       addressable (>= 2.4)
     libdatadog (14.1.0.1.0-aarch64-linux)
     libdatadog (14.1.0.1.0-x86_64-linux)
-    libddwaf (1.15.0.0.0-aarch64-linux)
+    libddwaf (1.18.0.0.0-aarch64-linux)
       ffi (~> 1.0)
-    libddwaf (1.15.0.0.0-x86_64-linux)
+    libddwaf (1.18.0.0.0-x86_64-linux)
       ffi (~> 1.0)
     memory_profiler (0.9.14)
     method_source (1.1.0)

--- a/gemfiles/ruby_2.5_stripe_7.gemfile.lock
+++ b/gemfiles/ruby_2.5_stripe_7.gemfile.lock
@@ -14,7 +14,7 @@ PATH
     datadog (2.7.0)
       datadog-ruby_core_source (~> 3.3)
       libdatadog (~> 14.1.0.1.0)
-      libddwaf (~> 1.15.0.0.0)
+      libddwaf (~> 1.18.0.0.0)
       msgpack
 
 GEM
@@ -53,9 +53,9 @@ GEM
       addressable (>= 2.4)
     libdatadog (14.1.0.1.0-aarch64-linux)
     libdatadog (14.1.0.1.0-x86_64-linux)
-    libddwaf (1.15.0.0.0-aarch64-linux)
+    libddwaf (1.18.0.0.0-aarch64-linux)
       ffi (~> 1.0)
-    libddwaf (1.15.0.0.0-x86_64-linux)
+    libddwaf (1.18.0.0.0-x86_64-linux)
       ffi (~> 1.0)
     memory_profiler (0.9.14)
     method_source (1.1.0)

--- a/gemfiles/ruby_2.5_stripe_8.gemfile.lock
+++ b/gemfiles/ruby_2.5_stripe_8.gemfile.lock
@@ -14,7 +14,7 @@ PATH
     datadog (2.7.0)
       datadog-ruby_core_source (~> 3.3)
       libdatadog (~> 14.1.0.1.0)
-      libddwaf (~> 1.15.0.0.0)
+      libddwaf (~> 1.18.0.0.0)
       msgpack
 
 GEM
@@ -53,9 +53,9 @@ GEM
       addressable (>= 2.4)
     libdatadog (14.1.0.1.0-aarch64-linux)
     libdatadog (14.1.0.1.0-x86_64-linux)
-    libddwaf (1.15.0.0.0-aarch64-linux)
+    libddwaf (1.18.0.0.0-aarch64-linux)
       ffi (~> 1.0)
-    libddwaf (1.15.0.0.0-x86_64-linux)
+    libddwaf (1.18.0.0.0-x86_64-linux)
       ffi (~> 1.0)
     memory_profiler (0.9.14)
     method_source (1.1.0)

--- a/gemfiles/ruby_2.5_stripe_9.gemfile.lock
+++ b/gemfiles/ruby_2.5_stripe_9.gemfile.lock
@@ -14,7 +14,7 @@ PATH
     datadog (2.7.0)
       datadog-ruby_core_source (~> 3.3)
       libdatadog (~> 14.1.0.1.0)
-      libddwaf (~> 1.15.0.0.0)
+      libddwaf (~> 1.18.0.0.0)
       msgpack
 
 GEM
@@ -53,9 +53,9 @@ GEM
       addressable (>= 2.4)
     libdatadog (14.1.0.1.0-aarch64-linux)
     libdatadog (14.1.0.1.0-x86_64-linux)
-    libddwaf (1.15.0.0.0-aarch64-linux)
+    libddwaf (1.18.0.0.0-aarch64-linux)
       ffi (~> 1.0)
-    libddwaf (1.15.0.0.0-x86_64-linux)
+    libddwaf (1.18.0.0.0-x86_64-linux)
       ffi (~> 1.0)
     memory_profiler (0.9.14)
     method_source (1.1.0)

--- a/gemfiles/ruby_2.5_stripe_latest.gemfile.lock
+++ b/gemfiles/ruby_2.5_stripe_latest.gemfile.lock
@@ -14,7 +14,7 @@ PATH
     datadog (2.7.0)
       datadog-ruby_core_source (~> 3.3)
       libdatadog (~> 14.1.0.1.0)
-      libddwaf (~> 1.15.0.0.0)
+      libddwaf (~> 1.18.0.0.0)
       msgpack
 
 GEM
@@ -53,9 +53,9 @@ GEM
       addressable (>= 2.4)
     libdatadog (14.1.0.1.0-aarch64-linux)
     libdatadog (14.1.0.1.0-x86_64-linux)
-    libddwaf (1.15.0.0.0-aarch64-linux)
+    libddwaf (1.18.0.0.0-aarch64-linux)
       ffi (~> 1.0)
-    libddwaf (1.15.0.0.0-x86_64-linux)
+    libddwaf (1.18.0.0.0-x86_64-linux)
       ffi (~> 1.0)
     memory_profiler (0.9.14)
     method_source (1.1.0)

--- a/gemfiles/ruby_2.5_stripe_min.gemfile.lock
+++ b/gemfiles/ruby_2.5_stripe_min.gemfile.lock
@@ -14,7 +14,7 @@ PATH
     datadog (2.7.0)
       datadog-ruby_core_source (~> 3.3)
       libdatadog (~> 14.1.0.1.0)
-      libddwaf (~> 1.15.0.0.0)
+      libddwaf (~> 1.18.0.0.0)
       msgpack
 
 GEM
@@ -53,9 +53,9 @@ GEM
       addressable (>= 2.4)
     libdatadog (14.1.0.1.0-aarch64-linux)
     libdatadog (14.1.0.1.0-x86_64-linux)
-    libddwaf (1.15.0.0.0-aarch64-linux)
+    libddwaf (1.18.0.0.0-aarch64-linux)
       ffi (~> 1.0)
-    libddwaf (1.15.0.0.0-x86_64-linux)
+    libddwaf (1.18.0.0.0-x86_64-linux)
       ffi (~> 1.0)
     memory_profiler (0.9.14)
     method_source (1.1.0)

--- a/gemfiles/ruby_2.6_activesupport.gemfile.lock
+++ b/gemfiles/ruby_2.6_activesupport.gemfile.lock
@@ -14,7 +14,7 @@ PATH
     datadog (2.7.0)
       datadog-ruby_core_source (~> 3.3)
       libdatadog (~> 14.1.0.1.0)
-      libddwaf (~> 1.15.0.0.0)
+      libddwaf (~> 1.18.0.0.0)
       msgpack
 
 GEM
@@ -115,9 +115,9 @@ GEM
     king_konf (1.0.1)
     libdatadog (14.1.0.1.0-aarch64-linux)
     libdatadog (14.1.0.1.0-x86_64-linux)
-    libddwaf (1.15.0.0.0-aarch64-linux)
+    libddwaf (1.18.0.0.0-aarch64-linux)
       ffi (~> 1.0)
-    libddwaf (1.15.0.0.0-x86_64-linux)
+    libddwaf (1.18.0.0.0-x86_64-linux)
       ffi (~> 1.0)
     lograge (0.13.0)
       actionpack (>= 4)

--- a/gemfiles/ruby_2.6_aws.gemfile.lock
+++ b/gemfiles/ruby_2.6_aws.gemfile.lock
@@ -14,7 +14,7 @@ PATH
     datadog (2.7.0)
       datadog-ruby_core_source (~> 3.3)
       libdatadog (~> 14.1.0.1.0)
-      libddwaf (~> 1.15.0.0.0)
+      libddwaf (~> 1.18.0.0.0)
       msgpack
 
 GEM
@@ -1475,9 +1475,9 @@ GEM
       addressable (>= 2.4)
     libdatadog (14.1.0.1.0-aarch64-linux)
     libdatadog (14.1.0.1.0-x86_64-linux)
-    libddwaf (1.15.0.0.0-aarch64-linux)
+    libddwaf (1.18.0.0.0-aarch64-linux)
       ffi (~> 1.0)
-    libddwaf (1.15.0.0.0-x86_64-linux)
+    libddwaf (1.18.0.0.0-x86_64-linux)
       ffi (~> 1.0)
     memory_profiler (0.9.14)
     method_source (1.0.0)

--- a/gemfiles/ruby_2.6_contrib.gemfile.lock
+++ b/gemfiles/ruby_2.6_contrib.gemfile.lock
@@ -14,7 +14,7 @@ PATH
     datadog (2.7.0)
       datadog-ruby_core_source (~> 3.3)
       libdatadog (~> 14.1.0.1.0)
-      libddwaf (~> 1.15.0.0.0)
+      libddwaf (~> 1.18.0.0.0)
       msgpack
 
 GEM
@@ -68,9 +68,9 @@ GEM
       addressable (>= 2.4)
     libdatadog (14.1.0.1.0-aarch64-linux)
     libdatadog (14.1.0.1.0-x86_64-linux)
-    libddwaf (1.15.0.0.0-aarch64-linux)
+    libddwaf (1.18.0.0.0-aarch64-linux)
       ffi (~> 1.0)
-    libddwaf (1.15.0.0.0-x86_64-linux)
+    libddwaf (1.18.0.0.0-x86_64-linux)
       ffi (~> 1.0)
     memory_profiler (0.9.14)
     method_source (1.0.0)

--- a/gemfiles/ruby_2.6_contrib_old.gemfile.lock
+++ b/gemfiles/ruby_2.6_contrib_old.gemfile.lock
@@ -14,7 +14,7 @@ PATH
     datadog (2.7.0)
       datadog-ruby_core_source (~> 3.3)
       libdatadog (~> 14.1.0.1.0)
-      libddwaf (~> 1.15.0.0.0)
+      libddwaf (~> 1.18.0.0.0)
       msgpack
 
 GEM
@@ -64,9 +64,9 @@ GEM
       addressable (>= 2.4)
     libdatadog (14.1.0.1.0-aarch64-linux)
     libdatadog (14.1.0.1.0-x86_64-linux)
-    libddwaf (1.15.0.0.0-aarch64-linux)
+    libddwaf (1.18.0.0.0-aarch64-linux)
       ffi (~> 1.0)
-    libddwaf (1.15.0.0.0-x86_64-linux)
+    libddwaf (1.18.0.0.0-x86_64-linux)
       ffi (~> 1.0)
     memory_profiler (0.9.14)
     method_source (1.0.0)

--- a/gemfiles/ruby_2.6_core_old.gemfile.lock
+++ b/gemfiles/ruby_2.6_core_old.gemfile.lock
@@ -14,7 +14,7 @@ PATH
     datadog (2.7.0)
       datadog-ruby_core_source (~> 3.3)
       libdatadog (~> 14.1.0.1.0)
-      libddwaf (~> 1.15.0.0.0)
+      libddwaf (~> 1.18.0.0.0)
       msgpack
 
 GEM
@@ -53,9 +53,9 @@ GEM
       addressable (>= 2.4)
     libdatadog (14.1.0.1.0-aarch64-linux)
     libdatadog (14.1.0.1.0-x86_64-linux)
-    libddwaf (1.15.0.0.0-aarch64-linux)
+    libddwaf (1.18.0.0.0-aarch64-linux)
       ffi (~> 1.0)
-    libddwaf (1.15.0.0.0-x86_64-linux)
+    libddwaf (1.18.0.0.0-x86_64-linux)
       ffi (~> 1.0)
     memory_profiler (0.9.14)
     method_source (1.0.0)

--- a/gemfiles/ruby_2.6_elasticsearch_7.gemfile.lock
+++ b/gemfiles/ruby_2.6_elasticsearch_7.gemfile.lock
@@ -14,7 +14,7 @@ PATH
     datadog (2.7.0)
       datadog-ruby_core_source (~> 3.3)
       libdatadog (~> 14.1.0.1.0)
-      libddwaf (~> 1.15.0.0.0)
+      libddwaf (~> 1.18.0.0.0)
       msgpack
 
 GEM
@@ -69,9 +69,9 @@ GEM
       addressable (>= 2.4)
     libdatadog (14.1.0.1.0-aarch64-linux)
     libdatadog (14.1.0.1.0-x86_64-linux)
-    libddwaf (1.15.0.0.0-aarch64-linux)
+    libddwaf (1.18.0.0.0-aarch64-linux)
       ffi (~> 1.0)
-    libddwaf (1.15.0.0.0-x86_64-linux)
+    libddwaf (1.18.0.0.0-x86_64-linux)
       ffi (~> 1.0)
     memory_profiler (0.9.14)
     method_source (1.0.0)

--- a/gemfiles/ruby_2.6_elasticsearch_8.gemfile.lock
+++ b/gemfiles/ruby_2.6_elasticsearch_8.gemfile.lock
@@ -14,7 +14,7 @@ PATH
     datadog (2.7.0)
       datadog-ruby_core_source (~> 3.3)
       libdatadog (~> 14.1.0.1.0)
-      libddwaf (~> 1.15.0.0.0)
+      libddwaf (~> 1.18.0.0.0)
       msgpack
 
 GEM
@@ -68,9 +68,9 @@ GEM
       addressable (>= 2.4)
     libdatadog (14.1.0.1.0-aarch64-linux)
     libdatadog (14.1.0.1.0-x86_64-linux)
-    libddwaf (1.15.0.0.0-aarch64-linux)
+    libddwaf (1.18.0.0.0-aarch64-linux)
       ffi (~> 1.0)
-    libddwaf (1.15.0.0.0-x86_64-linux)
+    libddwaf (1.18.0.0.0-x86_64-linux)
       ffi (~> 1.0)
     memory_profiler (0.9.14)
     method_source (1.0.0)

--- a/gemfiles/ruby_2.6_elasticsearch_latest.gemfile.lock
+++ b/gemfiles/ruby_2.6_elasticsearch_latest.gemfile.lock
@@ -14,7 +14,7 @@ PATH
     datadog (2.7.0)
       datadog-ruby_core_source (~> 3.3)
       libdatadog (~> 14.1.0.1.0)
-      libddwaf (~> 1.15.0.0.0)
+      libddwaf (~> 1.18.0.0.0)
       msgpack
 
 GEM
@@ -70,9 +70,9 @@ GEM
       addressable (>= 2.4)
     libdatadog (14.1.0.1.0-aarch64-linux)
     libdatadog (14.1.0.1.0-x86_64-linux)
-    libddwaf (1.15.0.0.0-aarch64-linux)
+    libddwaf (1.18.0.0.0-aarch64-linux)
       ffi (~> 1.0)
-    libddwaf (1.15.0.0.0-x86_64-linux)
+    libddwaf (1.18.0.0.0-x86_64-linux)
       ffi (~> 1.0)
     memory_profiler (0.9.14)
     method_source (1.1.0)

--- a/gemfiles/ruby_2.6_graphql_1.13.gemfile.lock
+++ b/gemfiles/ruby_2.6_graphql_1.13.gemfile.lock
@@ -14,7 +14,7 @@ PATH
     datadog (2.7.0)
       datadog-ruby_core_source (~> 3.3)
       libdatadog (~> 14.1.0.1.0)
-      libddwaf (~> 1.15.0.0.0)
+      libddwaf (~> 1.18.0.0.0)
       msgpack
 
 GEM
@@ -123,9 +123,9 @@ GEM
       addressable (>= 2.4)
     libdatadog (14.1.0.1.0-aarch64-linux)
     libdatadog (14.1.0.1.0-x86_64-linux)
-    libddwaf (1.15.0.0.0-aarch64-linux)
+    libddwaf (1.18.0.0.0-aarch64-linux)
       ffi (~> 1.0)
-    libddwaf (1.15.0.0.0-x86_64-linux)
+    libddwaf (1.18.0.0.0-x86_64-linux)
       ffi (~> 1.0)
     lograge (0.14.0)
       actionpack (>= 4)

--- a/gemfiles/ruby_2.6_graphql_2.0.gemfile.lock
+++ b/gemfiles/ruby_2.6_graphql_2.0.gemfile.lock
@@ -14,7 +14,7 @@ PATH
     datadog (2.7.0)
       datadog-ruby_core_source (~> 3.3)
       libdatadog (~> 14.1.0.1.0)
-      libddwaf (~> 1.15.0.0.0)
+      libddwaf (~> 1.18.0.0.0)
       msgpack
 
 GEM
@@ -123,9 +123,9 @@ GEM
       addressable (>= 2.4)
     libdatadog (14.1.0.1.0-aarch64-linux)
     libdatadog (14.1.0.1.0-x86_64-linux)
-    libddwaf (1.15.0.0.0-aarch64-linux)
+    libddwaf (1.18.0.0.0-aarch64-linux)
       ffi (~> 1.0)
-    libddwaf (1.15.0.0.0-x86_64-linux)
+    libddwaf (1.18.0.0.0-x86_64-linux)
       ffi (~> 1.0)
     lograge (0.14.0)
       actionpack (>= 4)

--- a/gemfiles/ruby_2.6_hanami_1.gemfile.lock
+++ b/gemfiles/ruby_2.6_hanami_1.gemfile.lock
@@ -14,7 +14,7 @@ PATH
     datadog (2.7.0)
       datadog-ruby_core_source (~> 3.3)
       libdatadog (~> 14.1.0.1.0)
-      libddwaf (~> 1.15.0.0.0)
+      libddwaf (~> 1.18.0.0.0)
       msgpack
 
 GEM
@@ -128,9 +128,9 @@ GEM
       addressable (>= 2.4)
     libdatadog (14.1.0.1.0-aarch64-linux)
     libdatadog (14.1.0.1.0-x86_64-linux)
-    libddwaf (1.15.0.0.0-aarch64-linux)
+    libddwaf (1.18.0.0.0-aarch64-linux)
       ffi (~> 1.0)
-    libddwaf (1.15.0.0.0-x86_64-linux)
+    libddwaf (1.18.0.0.0-x86_64-linux)
       ffi (~> 1.0)
     mail (2.8.1)
       mini_mime (>= 0.1.1)

--- a/gemfiles/ruby_2.6_http.gemfile.lock
+++ b/gemfiles/ruby_2.6_http.gemfile.lock
@@ -14,7 +14,7 @@ PATH
     datadog (2.7.0)
       datadog-ruby_core_source (~> 3.3)
       libdatadog (~> 14.1.0.1.0)
-      libddwaf (~> 1.15.0.0.0)
+      libddwaf (~> 1.18.0.0.0)
       msgpack
 
 GEM
@@ -75,9 +75,9 @@ GEM
       addressable (>= 2.4)
     libdatadog (14.1.0.1.0-aarch64-linux)
     libdatadog (14.1.0.1.0-x86_64-linux)
-    libddwaf (1.15.0.0.0-aarch64-linux)
+    libddwaf (1.18.0.0.0-aarch64-linux)
       ffi (~> 1.0)
-    libddwaf (1.15.0.0.0-x86_64-linux)
+    libddwaf (1.18.0.0.0-x86_64-linux)
       ffi (~> 1.0)
     llhttp-ffi (0.3.1)
       ffi-compiler (~> 1.0)

--- a/gemfiles/ruby_2.6_opensearch_2.gemfile.lock
+++ b/gemfiles/ruby_2.6_opensearch_2.gemfile.lock
@@ -14,7 +14,7 @@ PATH
     datadog (2.7.0)
       datadog-ruby_core_source (~> 3.3)
       libdatadog (~> 14.1.0.1.0)
-      libddwaf (~> 1.15.0.0.0)
+      libddwaf (~> 1.18.0.0.0)
       msgpack
 
 GEM
@@ -60,9 +60,9 @@ GEM
       addressable (>= 2.4)
     libdatadog (14.1.0.1.0-aarch64-linux)
     libdatadog (14.1.0.1.0-x86_64-linux)
-    libddwaf (1.15.0.0.0-aarch64-linux)
+    libddwaf (1.18.0.0.0-aarch64-linux)
       ffi (~> 1.0)
-    libddwaf (1.15.0.0.0-x86_64-linux)
+    libddwaf (1.18.0.0.0-x86_64-linux)
       ffi (~> 1.0)
     memory_profiler (0.9.14)
     method_source (1.0.0)

--- a/gemfiles/ruby_2.6_opensearch_3.gemfile.lock
+++ b/gemfiles/ruby_2.6_opensearch_3.gemfile.lock
@@ -14,7 +14,7 @@ PATH
     datadog (2.7.0)
       datadog-ruby_core_source (~> 3.3)
       libdatadog (~> 14.1.0.1.0)
-      libddwaf (~> 1.15.0.0.0)
+      libddwaf (~> 1.18.0.0.0)
       msgpack
 
 GEM
@@ -60,9 +60,9 @@ GEM
       addressable (>= 2.4)
     libdatadog (14.1.0.1.0-aarch64-linux)
     libdatadog (14.1.0.1.0-x86_64-linux)
-    libddwaf (1.15.0.0.0-aarch64-linux)
+    libddwaf (1.18.0.0.0-aarch64-linux)
       ffi (~> 1.0)
-    libddwaf (1.15.0.0.0-x86_64-linux)
+    libddwaf (1.18.0.0.0-x86_64-linux)
       ffi (~> 1.0)
     memory_profiler (0.9.14)
     method_source (1.0.0)

--- a/gemfiles/ruby_2.6_opensearch_latest.gemfile.lock
+++ b/gemfiles/ruby_2.6_opensearch_latest.gemfile.lock
@@ -14,7 +14,7 @@ PATH
     datadog (2.7.0)
       datadog-ruby_core_source (~> 3.3)
       libdatadog (~> 14.1.0.1.0)
-      libddwaf (~> 1.15.0.0.0)
+      libddwaf (~> 1.18.0.0.0)
       msgpack
 
 GEM
@@ -62,9 +62,9 @@ GEM
       addressable (>= 2.4)
     libdatadog (14.1.0.1.0-aarch64-linux)
     libdatadog (14.1.0.1.0-x86_64-linux)
-    libddwaf (1.15.0.0.0-aarch64-linux)
+    libddwaf (1.18.0.0.0-aarch64-linux)
       ffi (~> 1.0)
-    libddwaf (1.15.0.0.0-x86_64-linux)
+    libddwaf (1.18.0.0.0-x86_64-linux)
       ffi (~> 1.0)
     memory_profiler (0.9.14)
     method_source (1.1.0)

--- a/gemfiles/ruby_2.6_opentelemetry.gemfile.lock
+++ b/gemfiles/ruby_2.6_opentelemetry.gemfile.lock
@@ -14,7 +14,7 @@ PATH
     datadog (2.7.0)
       datadog-ruby_core_source (~> 3.3)
       libdatadog (~> 14.1.0.1.0)
-      libddwaf (~> 1.15.0.0.0)
+      libddwaf (~> 1.18.0.0.0)
       msgpack
 
 GEM
@@ -53,9 +53,9 @@ GEM
       addressable (>= 2.4)
     libdatadog (14.1.0.1.0-aarch64-linux)
     libdatadog (14.1.0.1.0-x86_64-linux)
-    libddwaf (1.15.0.0.0-aarch64-linux)
+    libddwaf (1.18.0.0.0-aarch64-linux)
       ffi (~> 1.0)
-    libddwaf (1.15.0.0.0-x86_64-linux)
+    libddwaf (1.18.0.0.0-x86_64-linux)
       ffi (~> 1.0)
     memory_profiler (0.9.14)
     method_source (1.0.0)

--- a/gemfiles/ruby_2.6_opentelemetry_otlp.gemfile.lock
+++ b/gemfiles/ruby_2.6_opentelemetry_otlp.gemfile.lock
@@ -14,7 +14,7 @@ PATH
     datadog (2.7.0)
       datadog-ruby_core_source (~> 3.3)
       libdatadog (~> 14.1.0.1.0)
-      libddwaf (~> 1.15.0.0.0)
+      libddwaf (~> 1.18.0.0.0)
       msgpack
 
 GEM
@@ -58,9 +58,9 @@ GEM
       addressable (>= 2.4)
     libdatadog (14.1.0.1.0-aarch64-linux)
     libdatadog (14.1.0.1.0-x86_64-linux)
-    libddwaf (1.15.0.0.0-aarch64-linux)
+    libddwaf (1.18.0.0.0-aarch64-linux)
       ffi (~> 1.0)
-    libddwaf (1.15.0.0.0-x86_64-linux)
+    libddwaf (1.18.0.0.0-x86_64-linux)
       ffi (~> 1.0)
     memory_profiler (0.9.14)
     method_source (1.0.0)

--- a/gemfiles/ruby_2.6_rack_1.gemfile.lock
+++ b/gemfiles/ruby_2.6_rack_1.gemfile.lock
@@ -14,7 +14,7 @@ PATH
     datadog (2.7.0)
       datadog-ruby_core_source (~> 3.3)
       libdatadog (~> 14.1.0.1.0)
-      libddwaf (~> 1.15.0.0.0)
+      libddwaf (~> 1.18.0.0.0)
       msgpack
 
 GEM
@@ -53,9 +53,9 @@ GEM
       addressable (>= 2.4)
     libdatadog (14.1.0.1.0-aarch64-linux)
     libdatadog (14.1.0.1.0-x86_64-linux)
-    libddwaf (1.15.0.0.0-aarch64-linux)
+    libddwaf (1.18.0.0.0-aarch64-linux)
       ffi (~> 1.0)
-    libddwaf (1.15.0.0.0-x86_64-linux)
+    libddwaf (1.18.0.0.0-x86_64-linux)
       ffi (~> 1.0)
     memory_profiler (0.9.14)
     method_source (1.0.0)

--- a/gemfiles/ruby_2.6_rack_2.gemfile.lock
+++ b/gemfiles/ruby_2.6_rack_2.gemfile.lock
@@ -14,7 +14,7 @@ PATH
     datadog (2.7.0)
       datadog-ruby_core_source (~> 3.3)
       libdatadog (~> 14.1.0.1.0)
-      libddwaf (~> 1.15.0.0.0)
+      libddwaf (~> 1.18.0.0.0)
       msgpack
 
 GEM
@@ -53,9 +53,9 @@ GEM
       addressable (>= 2.4)
     libdatadog (14.1.0.1.0-aarch64-linux)
     libdatadog (14.1.0.1.0-x86_64-linux)
-    libddwaf (1.15.0.0.0-aarch64-linux)
+    libddwaf (1.18.0.0.0-aarch64-linux)
       ffi (~> 1.0)
-    libddwaf (1.15.0.0.0-x86_64-linux)
+    libddwaf (1.18.0.0.0-x86_64-linux)
       ffi (~> 1.0)
     memory_profiler (0.9.14)
     method_source (1.0.0)

--- a/gemfiles/ruby_2.6_rack_3.gemfile.lock
+++ b/gemfiles/ruby_2.6_rack_3.gemfile.lock
@@ -14,7 +14,7 @@ PATH
     datadog (2.7.0)
       datadog-ruby_core_source (~> 3.3)
       libdatadog (~> 14.1.0.1.0)
-      libddwaf (~> 1.15.0.0.0)
+      libddwaf (~> 1.18.0.0.0)
       msgpack
 
 GEM
@@ -53,9 +53,9 @@ GEM
       addressable (>= 2.4)
     libdatadog (14.1.0.1.0-aarch64-linux)
     libdatadog (14.1.0.1.0-x86_64-linux)
-    libddwaf (1.15.0.0.0-aarch64-linux)
+    libddwaf (1.18.0.0.0-aarch64-linux)
       ffi (~> 1.0)
-    libddwaf (1.15.0.0.0-x86_64-linux)
+    libddwaf (1.18.0.0.0-x86_64-linux)
       ffi (~> 1.0)
     memory_profiler (0.9.14)
     method_source (1.0.0)

--- a/gemfiles/ruby_2.6_rack_latest.gemfile.lock
+++ b/gemfiles/ruby_2.6_rack_latest.gemfile.lock
@@ -14,7 +14,7 @@ PATH
     datadog (2.7.0)
       datadog-ruby_core_source (~> 3.3)
       libdatadog (~> 14.1.0.1.0)
-      libddwaf (~> 1.15.0.0.0)
+      libddwaf (~> 1.18.0.0.0)
       msgpack
 
 GEM
@@ -56,9 +56,9 @@ GEM
       addressable (>= 2.4)
     libdatadog (14.1.0.1.0-aarch64-linux)
     libdatadog (14.1.0.1.0-x86_64-linux)
-    libddwaf (1.15.0.0.0-aarch64-linux)
+    libddwaf (1.18.0.0.0-aarch64-linux)
       ffi (~> 1.0)
-    libddwaf (1.15.0.0.0-x86_64-linux)
+    libddwaf (1.18.0.0.0-x86_64-linux)
       ffi (~> 1.0)
     memory_profiler (0.9.14)
     method_source (1.1.0)

--- a/gemfiles/ruby_2.6_rails5_mysql2.gemfile.lock
+++ b/gemfiles/ruby_2.6_rails5_mysql2.gemfile.lock
@@ -14,7 +14,7 @@ PATH
     datadog (2.7.0)
       datadog-ruby_core_source (~> 3.3)
       libdatadog (~> 14.1.0.1.0)
-      libddwaf (~> 1.15.0.0.0)
+      libddwaf (~> 1.18.0.0.0)
       msgpack
 
 GEM
@@ -103,9 +103,9 @@ GEM
       addressable (>= 2.4)
     libdatadog (14.1.0.1.0-aarch64-linux)
     libdatadog (14.1.0.1.0-x86_64-linux)
-    libddwaf (1.15.0.0.0-aarch64-linux)
+    libddwaf (1.18.0.0.0-aarch64-linux)
       ffi (~> 1.0)
-    libddwaf (1.15.0.0.0-x86_64-linux)
+    libddwaf (1.18.0.0.0-x86_64-linux)
       ffi (~> 1.0)
     lograge (0.12.0)
       actionpack (>= 4)

--- a/gemfiles/ruby_2.6_rails5_postgres.gemfile.lock
+++ b/gemfiles/ruby_2.6_rails5_postgres.gemfile.lock
@@ -14,7 +14,7 @@ PATH
     datadog (2.7.0)
       datadog-ruby_core_source (~> 3.3)
       libdatadog (~> 14.1.0.1.0)
-      libddwaf (~> 1.15.0.0.0)
+      libddwaf (~> 1.18.0.0.0)
       msgpack
 
 GEM
@@ -103,9 +103,9 @@ GEM
       addressable (>= 2.4)
     libdatadog (14.1.0.1.0-aarch64-linux)
     libdatadog (14.1.0.1.0-x86_64-linux)
-    libddwaf (1.15.0.0.0-aarch64-linux)
+    libddwaf (1.18.0.0.0-aarch64-linux)
       ffi (~> 1.0)
-    libddwaf (1.15.0.0.0-x86_64-linux)
+    libddwaf (1.18.0.0.0-x86_64-linux)
       ffi (~> 1.0)
     lograge (0.12.0)
       actionpack (>= 4)

--- a/gemfiles/ruby_2.6_rails5_postgres_redis.gemfile.lock
+++ b/gemfiles/ruby_2.6_rails5_postgres_redis.gemfile.lock
@@ -14,7 +14,7 @@ PATH
     datadog (2.7.0)
       datadog-ruby_core_source (~> 3.3)
       libdatadog (~> 14.1.0.1.0)
-      libddwaf (~> 1.15.0.0.0)
+      libddwaf (~> 1.18.0.0.0)
       msgpack
 
 GEM
@@ -103,9 +103,9 @@ GEM
       addressable (>= 2.4)
     libdatadog (14.1.0.1.0-aarch64-linux)
     libdatadog (14.1.0.1.0-x86_64-linux)
-    libddwaf (1.15.0.0.0-aarch64-linux)
+    libddwaf (1.18.0.0.0-aarch64-linux)
       ffi (~> 1.0)
-    libddwaf (1.15.0.0.0-x86_64-linux)
+    libddwaf (1.18.0.0.0-x86_64-linux)
       ffi (~> 1.0)
     lograge (0.12.0)
       actionpack (>= 4)

--- a/gemfiles/ruby_2.6_rails5_postgres_redis_activesupport.gemfile.lock
+++ b/gemfiles/ruby_2.6_rails5_postgres_redis_activesupport.gemfile.lock
@@ -14,7 +14,7 @@ PATH
     datadog (2.7.0)
       datadog-ruby_core_source (~> 3.3)
       libdatadog (~> 14.1.0.1.0)
-      libddwaf (~> 1.15.0.0.0)
+      libddwaf (~> 1.18.0.0.0)
       msgpack
 
 GEM
@@ -103,9 +103,9 @@ GEM
       addressable (>= 2.4)
     libdatadog (14.1.0.1.0-aarch64-linux)
     libdatadog (14.1.0.1.0-x86_64-linux)
-    libddwaf (1.15.0.0.0-aarch64-linux)
+    libddwaf (1.18.0.0.0-aarch64-linux)
       ffi (~> 1.0)
-    libddwaf (1.15.0.0.0-x86_64-linux)
+    libddwaf (1.18.0.0.0-x86_64-linux)
       ffi (~> 1.0)
     lograge (0.12.0)
       actionpack (>= 4)

--- a/gemfiles/ruby_2.6_rails5_postgres_sidekiq.gemfile.lock
+++ b/gemfiles/ruby_2.6_rails5_postgres_sidekiq.gemfile.lock
@@ -14,7 +14,7 @@ PATH
     datadog (2.7.0)
       datadog-ruby_core_source (~> 3.3)
       libdatadog (~> 14.1.0.1.0)
-      libddwaf (~> 1.15.0.0.0)
+      libddwaf (~> 1.18.0.0.0)
       msgpack
 
 GEM
@@ -104,9 +104,9 @@ GEM
       addressable (>= 2.4)
     libdatadog (14.1.0.1.0-aarch64-linux)
     libdatadog (14.1.0.1.0-x86_64-linux)
-    libddwaf (1.15.0.0.0-aarch64-linux)
+    libddwaf (1.18.0.0.0-aarch64-linux)
       ffi (~> 1.0)
-    libddwaf (1.15.0.0.0-x86_64-linux)
+    libddwaf (1.18.0.0.0-x86_64-linux)
       ffi (~> 1.0)
     lograge (0.12.0)
       actionpack (>= 4)

--- a/gemfiles/ruby_2.6_rails5_semantic_logger.gemfile.lock
+++ b/gemfiles/ruby_2.6_rails5_semantic_logger.gemfile.lock
@@ -14,7 +14,7 @@ PATH
     datadog (2.7.0)
       datadog-ruby_core_source (~> 3.3)
       libdatadog (~> 14.1.0.1.0)
-      libddwaf (~> 1.15.0.0.0)
+      libddwaf (~> 1.18.0.0.0)
       msgpack
 
 GEM
@@ -103,9 +103,9 @@ GEM
       addressable (>= 2.4)
     libdatadog (14.1.0.1.0-aarch64-linux)
     libdatadog (14.1.0.1.0-x86_64-linux)
-    libddwaf (1.15.0.0.0-aarch64-linux)
+    libddwaf (1.18.0.0.0-aarch64-linux)
       ffi (~> 1.0)
-    libddwaf (1.15.0.0.0-x86_64-linux)
+    libddwaf (1.18.0.0.0-x86_64-linux)
       ffi (~> 1.0)
     loofah (2.19.1)
       crass (~> 1.0.2)

--- a/gemfiles/ruby_2.6_rails61_mysql2.gemfile.lock
+++ b/gemfiles/ruby_2.6_rails61_mysql2.gemfile.lock
@@ -14,7 +14,7 @@ PATH
     datadog (2.7.0)
       datadog-ruby_core_source (~> 3.3)
       libdatadog (~> 14.1.0.1.0)
-      libddwaf (~> 1.15.0.0.0)
+      libddwaf (~> 1.18.0.0.0)
       msgpack
 
 GEM
@@ -120,9 +120,9 @@ GEM
       addressable (>= 2.4)
     libdatadog (14.1.0.1.0-aarch64-linux)
     libdatadog (14.1.0.1.0-x86_64-linux)
-    libddwaf (1.15.0.0.0-aarch64-linux)
+    libddwaf (1.18.0.0.0-aarch64-linux)
       ffi (~> 1.0)
-    libddwaf (1.15.0.0.0-x86_64-linux)
+    libddwaf (1.18.0.0.0-x86_64-linux)
       ffi (~> 1.0)
     lograge (0.12.0)
       actionpack (>= 4)

--- a/gemfiles/ruby_2.6_rails61_postgres.gemfile.lock
+++ b/gemfiles/ruby_2.6_rails61_postgres.gemfile.lock
@@ -14,7 +14,7 @@ PATH
     datadog (2.7.0)
       datadog-ruby_core_source (~> 3.3)
       libdatadog (~> 14.1.0.1.0)
-      libddwaf (~> 1.15.0.0.0)
+      libddwaf (~> 1.18.0.0.0)
       msgpack
 
 GEM
@@ -120,9 +120,9 @@ GEM
       addressable (>= 2.4)
     libdatadog (14.1.0.1.0-aarch64-linux)
     libdatadog (14.1.0.1.0-x86_64-linux)
-    libddwaf (1.15.0.0.0-aarch64-linux)
+    libddwaf (1.18.0.0.0-aarch64-linux)
       ffi (~> 1.0)
-    libddwaf (1.15.0.0.0-x86_64-linux)
+    libddwaf (1.18.0.0.0-x86_64-linux)
       ffi (~> 1.0)
     lograge (0.12.0)
       actionpack (>= 4)

--- a/gemfiles/ruby_2.6_rails61_postgres_redis.gemfile.lock
+++ b/gemfiles/ruby_2.6_rails61_postgres_redis.gemfile.lock
@@ -14,7 +14,7 @@ PATH
     datadog (2.7.0)
       datadog-ruby_core_source (~> 3.3)
       libdatadog (~> 14.1.0.1.0)
-      libddwaf (~> 1.15.0.0.0)
+      libddwaf (~> 1.18.0.0.0)
       msgpack
 
 GEM
@@ -120,9 +120,9 @@ GEM
       addressable (>= 2.4)
     libdatadog (14.1.0.1.0-aarch64-linux)
     libdatadog (14.1.0.1.0-x86_64-linux)
-    libddwaf (1.15.0.0.0-aarch64-linux)
+    libddwaf (1.18.0.0.0-aarch64-linux)
       ffi (~> 1.0)
-    libddwaf (1.15.0.0.0-x86_64-linux)
+    libddwaf (1.18.0.0.0-x86_64-linux)
       ffi (~> 1.0)
     lograge (0.12.0)
       actionpack (>= 4)

--- a/gemfiles/ruby_2.6_rails61_postgres_sidekiq.gemfile.lock
+++ b/gemfiles/ruby_2.6_rails61_postgres_sidekiq.gemfile.lock
@@ -14,7 +14,7 @@ PATH
     datadog (2.7.0)
       datadog-ruby_core_source (~> 3.3)
       libdatadog (~> 14.1.0.1.0)
-      libddwaf (~> 1.15.0.0.0)
+      libddwaf (~> 1.18.0.0.0)
       msgpack
 
 GEM
@@ -121,9 +121,9 @@ GEM
       addressable (>= 2.4)
     libdatadog (14.1.0.1.0-aarch64-linux)
     libdatadog (14.1.0.1.0-x86_64-linux)
-    libddwaf (1.15.0.0.0-aarch64-linux)
+    libddwaf (1.18.0.0.0-aarch64-linux)
       ffi (~> 1.0)
-    libddwaf (1.15.0.0.0-x86_64-linux)
+    libddwaf (1.18.0.0.0-x86_64-linux)
       ffi (~> 1.0)
     lograge (0.12.0)
       actionpack (>= 4)

--- a/gemfiles/ruby_2.6_rails61_semantic_logger.gemfile.lock
+++ b/gemfiles/ruby_2.6_rails61_semantic_logger.gemfile.lock
@@ -14,7 +14,7 @@ PATH
     datadog (2.7.0)
       datadog-ruby_core_source (~> 3.3)
       libdatadog (~> 14.1.0.1.0)
-      libddwaf (~> 1.15.0.0.0)
+      libddwaf (~> 1.18.0.0.0)
       msgpack
 
 GEM
@@ -120,9 +120,9 @@ GEM
       addressable (>= 2.4)
     libdatadog (14.1.0.1.0-aarch64-linux)
     libdatadog (14.1.0.1.0-x86_64-linux)
-    libddwaf (1.15.0.0.0-aarch64-linux)
+    libddwaf (1.18.0.0.0-aarch64-linux)
       ffi (~> 1.0)
-    libddwaf (1.15.0.0.0-x86_64-linux)
+    libddwaf (1.18.0.0.0-x86_64-linux)
       ffi (~> 1.0)
     loofah (2.19.1)
       crass (~> 1.0.2)

--- a/gemfiles/ruby_2.6_rails6_mysql2.gemfile.lock
+++ b/gemfiles/ruby_2.6_rails6_mysql2.gemfile.lock
@@ -14,7 +14,7 @@ PATH
     datadog (2.7.0)
       datadog-ruby_core_source (~> 3.3)
       libdatadog (~> 14.1.0.1.0)
-      libddwaf (~> 1.15.0.0.0)
+      libddwaf (~> 1.18.0.0.0)
       msgpack
 
 GEM
@@ -116,9 +116,9 @@ GEM
       addressable (>= 2.4)
     libdatadog (14.1.0.1.0-aarch64-linux)
     libdatadog (14.1.0.1.0-x86_64-linux)
-    libddwaf (1.15.0.0.0-aarch64-linux)
+    libddwaf (1.18.0.0.0-aarch64-linux)
       ffi (~> 1.0)
-    libddwaf (1.15.0.0.0-x86_64-linux)
+    libddwaf (1.18.0.0.0-x86_64-linux)
       ffi (~> 1.0)
     lograge (0.12.0)
       actionpack (>= 4)

--- a/gemfiles/ruby_2.6_rails6_postgres.gemfile.lock
+++ b/gemfiles/ruby_2.6_rails6_postgres.gemfile.lock
@@ -14,7 +14,7 @@ PATH
     datadog (2.7.0)
       datadog-ruby_core_source (~> 3.3)
       libdatadog (~> 14.1.0.1.0)
-      libddwaf (~> 1.15.0.0.0)
+      libddwaf (~> 1.18.0.0.0)
       msgpack
 
 GEM
@@ -116,9 +116,9 @@ GEM
       addressable (>= 2.4)
     libdatadog (14.1.0.1.0-aarch64-linux)
     libdatadog (14.1.0.1.0-x86_64-linux)
-    libddwaf (1.15.0.0.0-aarch64-linux)
+    libddwaf (1.18.0.0.0-aarch64-linux)
       ffi (~> 1.0)
-    libddwaf (1.15.0.0.0-x86_64-linux)
+    libddwaf (1.18.0.0.0-x86_64-linux)
       ffi (~> 1.0)
     lograge (0.12.0)
       actionpack (>= 4)

--- a/gemfiles/ruby_2.6_rails6_postgres_redis.gemfile.lock
+++ b/gemfiles/ruby_2.6_rails6_postgres_redis.gemfile.lock
@@ -14,7 +14,7 @@ PATH
     datadog (2.7.0)
       datadog-ruby_core_source (~> 3.3)
       libdatadog (~> 14.1.0.1.0)
-      libddwaf (~> 1.15.0.0.0)
+      libddwaf (~> 1.18.0.0.0)
       msgpack
 
 GEM
@@ -116,9 +116,9 @@ GEM
       addressable (>= 2.4)
     libdatadog (14.1.0.1.0-aarch64-linux)
     libdatadog (14.1.0.1.0-x86_64-linux)
-    libddwaf (1.15.0.0.0-aarch64-linux)
+    libddwaf (1.18.0.0.0-aarch64-linux)
       ffi (~> 1.0)
-    libddwaf (1.15.0.0.0-x86_64-linux)
+    libddwaf (1.18.0.0.0-x86_64-linux)
       ffi (~> 1.0)
     lograge (0.12.0)
       actionpack (>= 4)

--- a/gemfiles/ruby_2.6_rails6_postgres_redis_activesupport.gemfile.lock
+++ b/gemfiles/ruby_2.6_rails6_postgres_redis_activesupport.gemfile.lock
@@ -14,7 +14,7 @@ PATH
     datadog (2.7.0)
       datadog-ruby_core_source (~> 3.3)
       libdatadog (~> 14.1.0.1.0)
-      libddwaf (~> 1.15.0.0.0)
+      libddwaf (~> 1.18.0.0.0)
       msgpack
 
 GEM
@@ -116,9 +116,9 @@ GEM
       addressable (>= 2.4)
     libdatadog (14.1.0.1.0-aarch64-linux)
     libdatadog (14.1.0.1.0-x86_64-linux)
-    libddwaf (1.15.0.0.0-aarch64-linux)
+    libddwaf (1.18.0.0.0-aarch64-linux)
       ffi (~> 1.0)
-    libddwaf (1.15.0.0.0-x86_64-linux)
+    libddwaf (1.18.0.0.0-x86_64-linux)
       ffi (~> 1.0)
     lograge (0.12.0)
       actionpack (>= 4)

--- a/gemfiles/ruby_2.6_rails6_postgres_sidekiq.gemfile.lock
+++ b/gemfiles/ruby_2.6_rails6_postgres_sidekiq.gemfile.lock
@@ -14,7 +14,7 @@ PATH
     datadog (2.7.0)
       datadog-ruby_core_source (~> 3.3)
       libdatadog (~> 14.1.0.1.0)
-      libddwaf (~> 1.15.0.0.0)
+      libddwaf (~> 1.18.0.0.0)
       msgpack
 
 GEM
@@ -117,9 +117,9 @@ GEM
       addressable (>= 2.4)
     libdatadog (14.1.0.1.0-aarch64-linux)
     libdatadog (14.1.0.1.0-x86_64-linux)
-    libddwaf (1.15.0.0.0-aarch64-linux)
+    libddwaf (1.18.0.0.0-aarch64-linux)
       ffi (~> 1.0)
-    libddwaf (1.15.0.0.0-x86_64-linux)
+    libddwaf (1.18.0.0.0-x86_64-linux)
       ffi (~> 1.0)
     lograge (0.12.0)
       actionpack (>= 4)

--- a/gemfiles/ruby_2.6_rails6_semantic_logger.gemfile.lock
+++ b/gemfiles/ruby_2.6_rails6_semantic_logger.gemfile.lock
@@ -14,7 +14,7 @@ PATH
     datadog (2.7.0)
       datadog-ruby_core_source (~> 3.3)
       libdatadog (~> 14.1.0.1.0)
-      libddwaf (~> 1.15.0.0.0)
+      libddwaf (~> 1.18.0.0.0)
       msgpack
 
 GEM
@@ -116,9 +116,9 @@ GEM
       addressable (>= 2.4)
     libdatadog (14.1.0.1.0-aarch64-linux)
     libdatadog (14.1.0.1.0-x86_64-linux)
-    libddwaf (1.15.0.0.0-aarch64-linux)
+    libddwaf (1.18.0.0.0-aarch64-linux)
       ffi (~> 1.0)
-    libddwaf (1.15.0.0.0-x86_64-linux)
+    libddwaf (1.18.0.0.0-x86_64-linux)
       ffi (~> 1.0)
     loofah (2.19.1)
       crass (~> 1.0.2)

--- a/gemfiles/ruby_2.6_redis_3.gemfile.lock
+++ b/gemfiles/ruby_2.6_redis_3.gemfile.lock
@@ -14,7 +14,7 @@ PATH
     datadog (2.7.0)
       datadog-ruby_core_source (~> 3.3)
       libdatadog (~> 14.1.0.1.0)
-      libddwaf (~> 1.15.0.0.0)
+      libddwaf (~> 1.18.0.0.0)
       msgpack
 
 GEM
@@ -53,9 +53,9 @@ GEM
       addressable (>= 2.4)
     libdatadog (14.1.0.1.0-aarch64-linux)
     libdatadog (14.1.0.1.0-x86_64-linux)
-    libddwaf (1.15.0.0.0-aarch64-linux)
+    libddwaf (1.18.0.0.0-aarch64-linux)
       ffi (~> 1.0)
-    libddwaf (1.15.0.0.0-x86_64-linux)
+    libddwaf (1.18.0.0.0-x86_64-linux)
       ffi (~> 1.0)
     memory_profiler (0.9.14)
     method_source (1.0.0)

--- a/gemfiles/ruby_2.6_redis_4.gemfile.lock
+++ b/gemfiles/ruby_2.6_redis_4.gemfile.lock
@@ -14,7 +14,7 @@ PATH
     datadog (2.7.0)
       datadog-ruby_core_source (~> 3.3)
       libdatadog (~> 14.1.0.1.0)
-      libddwaf (~> 1.15.0.0.0)
+      libddwaf (~> 1.18.0.0.0)
       msgpack
 
 GEM
@@ -53,9 +53,9 @@ GEM
       addressable (>= 2.4)
     libdatadog (14.1.0.1.0-aarch64-linux)
     libdatadog (14.1.0.1.0-x86_64-linux)
-    libddwaf (1.15.0.0.0-aarch64-linux)
+    libddwaf (1.18.0.0.0-aarch64-linux)
       ffi (~> 1.0)
-    libddwaf (1.15.0.0.0-x86_64-linux)
+    libddwaf (1.18.0.0.0-x86_64-linux)
       ffi (~> 1.0)
     memory_profiler (0.9.14)
     method_source (1.0.0)

--- a/gemfiles/ruby_2.6_redis_5.gemfile.lock
+++ b/gemfiles/ruby_2.6_redis_5.gemfile.lock
@@ -14,7 +14,7 @@ PATH
     datadog (2.7.0)
       datadog-ruby_core_source (~> 3.3)
       libdatadog (~> 14.1.0.1.0)
-      libddwaf (~> 1.15.0.0.0)
+      libddwaf (~> 1.18.0.0.0)
       msgpack
 
 GEM
@@ -54,9 +54,9 @@ GEM
       addressable (>= 2.4)
     libdatadog (14.1.0.1.0-aarch64-linux)
     libdatadog (14.1.0.1.0-x86_64-linux)
-    libddwaf (1.15.0.0.0-aarch64-linux)
+    libddwaf (1.18.0.0.0-aarch64-linux)
       ffi (~> 1.0)
-    libddwaf (1.15.0.0.0-x86_64-linux)
+    libddwaf (1.18.0.0.0-x86_64-linux)
       ffi (~> 1.0)
     memory_profiler (0.9.14)
     method_source (1.0.0)

--- a/gemfiles/ruby_2.6_relational_db.gemfile.lock
+++ b/gemfiles/ruby_2.6_relational_db.gemfile.lock
@@ -14,7 +14,7 @@ PATH
     datadog (2.7.0)
       datadog-ruby_core_source (~> 3.3)
       libdatadog (~> 14.1.0.1.0)
-      libddwaf (~> 1.15.0.0.0)
+      libddwaf (~> 1.18.0.0.0)
       msgpack
 
 GEM
@@ -72,9 +72,9 @@ GEM
       addressable (>= 2.4)
     libdatadog (14.1.0.1.0-aarch64-linux)
     libdatadog (14.1.0.1.0-x86_64-linux)
-    libddwaf (1.15.0.0.0-aarch64-linux)
+    libddwaf (1.18.0.0.0-aarch64-linux)
       ffi (~> 1.0)
-    libddwaf (1.15.0.0.0-x86_64-linux)
+    libddwaf (1.18.0.0.0-x86_64-linux)
       ffi (~> 1.0)
     makara (0.5.1)
       activerecord (>= 5.2.0)

--- a/gemfiles/ruby_2.6_resque2_redis3.gemfile.lock
+++ b/gemfiles/ruby_2.6_resque2_redis3.gemfile.lock
@@ -14,7 +14,7 @@ PATH
     datadog (2.7.0)
       datadog-ruby_core_source (~> 3.3)
       libdatadog (~> 14.1.0.1.0)
-      libddwaf (~> 1.15.0.0.0)
+      libddwaf (~> 1.18.0.0.0)
       msgpack
 
 GEM
@@ -53,9 +53,9 @@ GEM
       addressable (>= 2.4)
     libdatadog (14.1.0.1.0-aarch64-linux)
     libdatadog (14.1.0.1.0-x86_64-linux)
-    libddwaf (1.15.0.0.0-aarch64-linux)
+    libddwaf (1.18.0.0.0-aarch64-linux)
       ffi (~> 1.0)
-    libddwaf (1.15.0.0.0-x86_64-linux)
+    libddwaf (1.18.0.0.0-x86_64-linux)
       ffi (~> 1.0)
     memory_profiler (0.9.14)
     method_source (1.0.0)

--- a/gemfiles/ruby_2.6_resque2_redis4.gemfile.lock
+++ b/gemfiles/ruby_2.6_resque2_redis4.gemfile.lock
@@ -14,7 +14,7 @@ PATH
     datadog (2.7.0)
       datadog-ruby_core_source (~> 3.3)
       libdatadog (~> 14.1.0.1.0)
-      libddwaf (~> 1.15.0.0.0)
+      libddwaf (~> 1.18.0.0.0)
       msgpack
 
 GEM
@@ -53,9 +53,9 @@ GEM
       addressable (>= 2.4)
     libdatadog (14.1.0.1.0-aarch64-linux)
     libdatadog (14.1.0.1.0-x86_64-linux)
-    libddwaf (1.15.0.0.0-aarch64-linux)
+    libddwaf (1.18.0.0.0-aarch64-linux)
       ffi (~> 1.0)
-    libddwaf (1.15.0.0.0-x86_64-linux)
+    libddwaf (1.18.0.0.0-x86_64-linux)
       ffi (~> 1.0)
     memory_profiler (0.9.14)
     method_source (1.0.0)

--- a/gemfiles/ruby_2.6_sinatra_2.gemfile.lock
+++ b/gemfiles/ruby_2.6_sinatra_2.gemfile.lock
@@ -14,7 +14,7 @@ PATH
     datadog (2.7.0)
       datadog-ruby_core_source (~> 3.3)
       libdatadog (~> 14.1.0.1.0)
-      libddwaf (~> 1.15.0.0.0)
+      libddwaf (~> 1.18.0.0.0)
       msgpack
 
 GEM
@@ -56,9 +56,9 @@ GEM
       addressable (>= 2.4)
     libdatadog (14.1.0.1.0-aarch64-linux)
     libdatadog (14.1.0.1.0-x86_64-linux)
-    libddwaf (1.15.0.0.0-aarch64-linux)
+    libddwaf (1.18.0.0.0-aarch64-linux)
       ffi (~> 1.0)
-    libddwaf (1.15.0.0.0-x86_64-linux)
+    libddwaf (1.18.0.0.0-x86_64-linux)
       ffi (~> 1.0)
     memory_profiler (0.9.14)
     method_source (1.1.0)

--- a/gemfiles/ruby_2.6_sinatra_3.gemfile.lock
+++ b/gemfiles/ruby_2.6_sinatra_3.gemfile.lock
@@ -14,7 +14,7 @@ PATH
     datadog (2.7.0)
       datadog-ruby_core_source (~> 3.3)
       libdatadog (~> 14.1.0.1.0)
-      libddwaf (~> 1.15.0.0.0)
+      libddwaf (~> 1.18.0.0.0)
       msgpack
 
 GEM
@@ -57,9 +57,9 @@ GEM
       addressable (>= 2.4)
     libdatadog (14.1.0.1.0-aarch64-linux)
     libdatadog (14.1.0.1.0-x86_64-linux)
-    libddwaf (1.15.0.0.0-aarch64-linux)
+    libddwaf (1.18.0.0.0-aarch64-linux)
       ffi (~> 1.0)
-    libddwaf (1.15.0.0.0-x86_64-linux)
+    libddwaf (1.18.0.0.0-x86_64-linux)
       ffi (~> 1.0)
     memory_profiler (0.9.14)
     method_source (1.1.0)

--- a/gemfiles/ruby_2.6_stripe_10.gemfile.lock
+++ b/gemfiles/ruby_2.6_stripe_10.gemfile.lock
@@ -14,7 +14,7 @@ PATH
     datadog (2.7.0)
       datadog-ruby_core_source (~> 3.3)
       libdatadog (~> 14.1.0.1.0)
-      libddwaf (~> 1.15.0.0.0)
+      libddwaf (~> 1.18.0.0.0)
       msgpack
 
 GEM
@@ -56,9 +56,9 @@ GEM
       addressable (>= 2.4)
     libdatadog (14.1.0.1.0-aarch64-linux)
     libdatadog (14.1.0.1.0-x86_64-linux)
-    libddwaf (1.15.0.0.0-aarch64-linux)
+    libddwaf (1.18.0.0.0-aarch64-linux)
       ffi (~> 1.0)
-    libddwaf (1.15.0.0.0-x86_64-linux)
+    libddwaf (1.18.0.0.0-x86_64-linux)
       ffi (~> 1.0)
     memory_profiler (0.9.14)
     method_source (1.1.0)

--- a/gemfiles/ruby_2.6_stripe_11.gemfile.lock
+++ b/gemfiles/ruby_2.6_stripe_11.gemfile.lock
@@ -14,7 +14,7 @@ PATH
     datadog (2.7.0)
       datadog-ruby_core_source (~> 3.3)
       libdatadog (~> 14.1.0.1.0)
-      libddwaf (~> 1.15.0.0.0)
+      libddwaf (~> 1.18.0.0.0)
       msgpack
 
 GEM
@@ -56,9 +56,9 @@ GEM
       addressable (>= 2.4)
     libdatadog (14.1.0.1.0-aarch64-linux)
     libdatadog (14.1.0.1.0-x86_64-linux)
-    libddwaf (1.15.0.0.0-aarch64-linux)
+    libddwaf (1.18.0.0.0-aarch64-linux)
       ffi (~> 1.0)
-    libddwaf (1.15.0.0.0-x86_64-linux)
+    libddwaf (1.18.0.0.0-x86_64-linux)
       ffi (~> 1.0)
     memory_profiler (0.9.14)
     method_source (1.1.0)

--- a/gemfiles/ruby_2.6_stripe_12.gemfile.lock
+++ b/gemfiles/ruby_2.6_stripe_12.gemfile.lock
@@ -14,7 +14,7 @@ PATH
     datadog (2.7.0)
       datadog-ruby_core_source (~> 3.3)
       libdatadog (~> 14.1.0.1.0)
-      libddwaf (~> 1.15.0.0.0)
+      libddwaf (~> 1.18.0.0.0)
       msgpack
 
 GEM
@@ -56,9 +56,9 @@ GEM
       addressable (>= 2.4)
     libdatadog (14.1.0.1.0-aarch64-linux)
     libdatadog (14.1.0.1.0-x86_64-linux)
-    libddwaf (1.15.0.0.0-aarch64-linux)
+    libddwaf (1.18.0.0.0-aarch64-linux)
       ffi (~> 1.0)
-    libddwaf (1.15.0.0.0-x86_64-linux)
+    libddwaf (1.18.0.0.0-x86_64-linux)
       ffi (~> 1.0)
     memory_profiler (0.9.14)
     method_source (1.1.0)

--- a/gemfiles/ruby_2.6_stripe_7.gemfile.lock
+++ b/gemfiles/ruby_2.6_stripe_7.gemfile.lock
@@ -14,7 +14,7 @@ PATH
     datadog (2.7.0)
       datadog-ruby_core_source (~> 3.3)
       libdatadog (~> 14.1.0.1.0)
-      libddwaf (~> 1.15.0.0.0)
+      libddwaf (~> 1.18.0.0.0)
       msgpack
 
 GEM
@@ -56,9 +56,9 @@ GEM
       addressable (>= 2.4)
     libdatadog (14.1.0.1.0-aarch64-linux)
     libdatadog (14.1.0.1.0-x86_64-linux)
-    libddwaf (1.15.0.0.0-aarch64-linux)
+    libddwaf (1.18.0.0.0-aarch64-linux)
       ffi (~> 1.0)
-    libddwaf (1.15.0.0.0-x86_64-linux)
+    libddwaf (1.18.0.0.0-x86_64-linux)
       ffi (~> 1.0)
     memory_profiler (0.9.14)
     method_source (1.1.0)

--- a/gemfiles/ruby_2.6_stripe_8.gemfile.lock
+++ b/gemfiles/ruby_2.6_stripe_8.gemfile.lock
@@ -14,7 +14,7 @@ PATH
     datadog (2.7.0)
       datadog-ruby_core_source (~> 3.3)
       libdatadog (~> 14.1.0.1.0)
-      libddwaf (~> 1.15.0.0.0)
+      libddwaf (~> 1.18.0.0.0)
       msgpack
 
 GEM
@@ -56,9 +56,9 @@ GEM
       addressable (>= 2.4)
     libdatadog (14.1.0.1.0-aarch64-linux)
     libdatadog (14.1.0.1.0-x86_64-linux)
-    libddwaf (1.15.0.0.0-aarch64-linux)
+    libddwaf (1.18.0.0.0-aarch64-linux)
       ffi (~> 1.0)
-    libddwaf (1.15.0.0.0-x86_64-linux)
+    libddwaf (1.18.0.0.0-x86_64-linux)
       ffi (~> 1.0)
     memory_profiler (0.9.14)
     method_source (1.1.0)

--- a/gemfiles/ruby_2.6_stripe_9.gemfile.lock
+++ b/gemfiles/ruby_2.6_stripe_9.gemfile.lock
@@ -14,7 +14,7 @@ PATH
     datadog (2.7.0)
       datadog-ruby_core_source (~> 3.3)
       libdatadog (~> 14.1.0.1.0)
-      libddwaf (~> 1.15.0.0.0)
+      libddwaf (~> 1.18.0.0.0)
       msgpack
 
 GEM
@@ -56,9 +56,9 @@ GEM
       addressable (>= 2.4)
     libdatadog (14.1.0.1.0-aarch64-linux)
     libdatadog (14.1.0.1.0-x86_64-linux)
-    libddwaf (1.15.0.0.0-aarch64-linux)
+    libddwaf (1.18.0.0.0-aarch64-linux)
       ffi (~> 1.0)
-    libddwaf (1.15.0.0.0-x86_64-linux)
+    libddwaf (1.18.0.0.0-x86_64-linux)
       ffi (~> 1.0)
     memory_profiler (0.9.14)
     method_source (1.1.0)

--- a/gemfiles/ruby_2.6_stripe_latest.gemfile.lock
+++ b/gemfiles/ruby_2.6_stripe_latest.gemfile.lock
@@ -14,7 +14,7 @@ PATH
     datadog (2.7.0)
       datadog-ruby_core_source (~> 3.3)
       libdatadog (~> 14.1.0.1.0)
-      libddwaf (~> 1.15.0.0.0)
+      libddwaf (~> 1.18.0.0.0)
       msgpack
 
 GEM
@@ -56,9 +56,9 @@ GEM
       addressable (>= 2.4)
     libdatadog (14.1.0.1.0-aarch64-linux)
     libdatadog (14.1.0.1.0-x86_64-linux)
-    libddwaf (1.15.0.0.0-aarch64-linux)
+    libddwaf (1.18.0.0.0-aarch64-linux)
       ffi (~> 1.0)
-    libddwaf (1.15.0.0.0-x86_64-linux)
+    libddwaf (1.18.0.0.0-x86_64-linux)
       ffi (~> 1.0)
     memory_profiler (0.9.14)
     method_source (1.1.0)

--- a/gemfiles/ruby_2.6_stripe_min.gemfile.lock
+++ b/gemfiles/ruby_2.6_stripe_min.gemfile.lock
@@ -14,7 +14,7 @@ PATH
     datadog (2.7.0)
       datadog-ruby_core_source (~> 3.3)
       libdatadog (~> 14.1.0.1.0)
-      libddwaf (~> 1.15.0.0.0)
+      libddwaf (~> 1.18.0.0.0)
       msgpack
 
 GEM
@@ -56,9 +56,9 @@ GEM
       addressable (>= 2.4)
     libdatadog (14.1.0.1.0-aarch64-linux)
     libdatadog (14.1.0.1.0-x86_64-linux)
-    libddwaf (1.15.0.0.0-aarch64-linux)
+    libddwaf (1.18.0.0.0-aarch64-linux)
       ffi (~> 1.0)
-    libddwaf (1.15.0.0.0-x86_64-linux)
+    libddwaf (1.18.0.0.0-x86_64-linux)
       ffi (~> 1.0)
     memory_profiler (0.9.14)
     method_source (1.1.0)

--- a/gemfiles/ruby_2.7_activesupport.gemfile.lock
+++ b/gemfiles/ruby_2.7_activesupport.gemfile.lock
@@ -14,7 +14,7 @@ PATH
     datadog (2.7.0)
       datadog-ruby_core_source (~> 3.3)
       libdatadog (~> 14.1.0.1.0)
-      libddwaf (~> 1.15.0.0.0)
+      libddwaf (~> 1.18.0.0.0)
       msgpack
 
 GEM
@@ -111,9 +111,9 @@ GEM
     king_konf (1.0.1)
     libdatadog (14.1.0.1.0-aarch64-linux)
     libdatadog (14.1.0.1.0-x86_64-linux)
-    libddwaf (1.15.0.0.0-aarch64-linux)
+    libddwaf (1.18.0.0.0-aarch64-linux)
       ffi (~> 1.0)
-    libddwaf (1.15.0.0.0-x86_64-linux)
+    libddwaf (1.18.0.0.0-x86_64-linux)
       ffi (~> 1.0)
     lograge (0.13.0)
       actionpack (>= 4)

--- a/gemfiles/ruby_2.7_aws.gemfile.lock
+++ b/gemfiles/ruby_2.7_aws.gemfile.lock
@@ -14,7 +14,7 @@ PATH
     datadog (2.7.0)
       datadog-ruby_core_source (~> 3.3)
       libdatadog (~> 14.1.0.1.0)
-      libddwaf (~> 1.15.0.0.0)
+      libddwaf (~> 1.18.0.0.0)
       msgpack
 
 GEM
@@ -1475,9 +1475,9 @@ GEM
       addressable (>= 2.4)
     libdatadog (14.1.0.1.0-aarch64-linux)
     libdatadog (14.1.0.1.0-x86_64-linux)
-    libddwaf (1.15.0.0.0-aarch64-linux)
+    libddwaf (1.18.0.0.0-aarch64-linux)
       ffi (~> 1.0)
-    libddwaf (1.15.0.0.0-x86_64-linux)
+    libddwaf (1.18.0.0.0-x86_64-linux)
       ffi (~> 1.0)
     memory_profiler (0.9.14)
     method_source (1.0.0)

--- a/gemfiles/ruby_2.7_contrib.gemfile.lock
+++ b/gemfiles/ruby_2.7_contrib.gemfile.lock
@@ -14,7 +14,7 @@ PATH
     datadog (2.7.0)
       datadog-ruby_core_source (~> 3.3)
       libdatadog (~> 14.1.0.1.0)
-      libddwaf (~> 1.15.0.0.0)
+      libddwaf (~> 1.18.0.0.0)
       msgpack
 
 GEM
@@ -68,9 +68,9 @@ GEM
       addressable (>= 2.4)
     libdatadog (14.1.0.1.0-aarch64-linux)
     libdatadog (14.1.0.1.0-x86_64-linux)
-    libddwaf (1.15.0.0.0-aarch64-linux)
+    libddwaf (1.18.0.0.0-aarch64-linux)
       ffi (~> 1.0)
-    libddwaf (1.15.0.0.0-x86_64-linux)
+    libddwaf (1.18.0.0.0-x86_64-linux)
       ffi (~> 1.0)
     memory_profiler (0.9.14)
     method_source (1.0.0)

--- a/gemfiles/ruby_2.7_contrib_old.gemfile.lock
+++ b/gemfiles/ruby_2.7_contrib_old.gemfile.lock
@@ -14,7 +14,7 @@ PATH
     datadog (2.7.0)
       datadog-ruby_core_source (~> 3.3)
       libdatadog (~> 14.1.0.1.0)
-      libddwaf (~> 1.15.0.0.0)
+      libddwaf (~> 1.18.0.0.0)
       msgpack
 
 GEM
@@ -64,9 +64,9 @@ GEM
       addressable (>= 2.4)
     libdatadog (14.1.0.1.0-aarch64-linux)
     libdatadog (14.1.0.1.0-x86_64-linux)
-    libddwaf (1.15.0.0.0-aarch64-linux)
+    libddwaf (1.18.0.0.0-aarch64-linux)
       ffi (~> 1.0)
-    libddwaf (1.15.0.0.0-x86_64-linux)
+    libddwaf (1.18.0.0.0-x86_64-linux)
       ffi (~> 1.0)
     memory_profiler (0.9.14)
     method_source (1.0.0)

--- a/gemfiles/ruby_2.7_core_old.gemfile.lock
+++ b/gemfiles/ruby_2.7_core_old.gemfile.lock
@@ -14,7 +14,7 @@ PATH
     datadog (2.7.0)
       datadog-ruby_core_source (~> 3.3)
       libdatadog (~> 14.1.0.1.0)
-      libddwaf (~> 1.15.0.0.0)
+      libddwaf (~> 1.18.0.0.0)
       msgpack
 
 GEM
@@ -53,9 +53,9 @@ GEM
       addressable (>= 2.4)
     libdatadog (14.1.0.1.0-aarch64-linux)
     libdatadog (14.1.0.1.0-x86_64-linux)
-    libddwaf (1.15.0.0.0-aarch64-linux)
+    libddwaf (1.18.0.0.0-aarch64-linux)
       ffi (~> 1.0)
-    libddwaf (1.15.0.0.0-x86_64-linux)
+    libddwaf (1.18.0.0.0-x86_64-linux)
       ffi (~> 1.0)
     memory_profiler (0.9.14)
     method_source (1.0.0)

--- a/gemfiles/ruby_2.7_elasticsearch_7.gemfile.lock
+++ b/gemfiles/ruby_2.7_elasticsearch_7.gemfile.lock
@@ -14,7 +14,7 @@ PATH
     datadog (2.7.0)
       datadog-ruby_core_source (~> 3.3)
       libdatadog (~> 14.1.0.1.0)
-      libddwaf (~> 1.15.0.0.0)
+      libddwaf (~> 1.18.0.0.0)
       msgpack
 
 GEM
@@ -69,9 +69,9 @@ GEM
       addressable (>= 2.4)
     libdatadog (14.1.0.1.0-aarch64-linux)
     libdatadog (14.1.0.1.0-x86_64-linux)
-    libddwaf (1.15.0.0.0-aarch64-linux)
+    libddwaf (1.18.0.0.0-aarch64-linux)
       ffi (~> 1.0)
-    libddwaf (1.15.0.0.0-x86_64-linux)
+    libddwaf (1.18.0.0.0-x86_64-linux)
       ffi (~> 1.0)
     memory_profiler (0.9.14)
     method_source (1.0.0)

--- a/gemfiles/ruby_2.7_elasticsearch_8.gemfile.lock
+++ b/gemfiles/ruby_2.7_elasticsearch_8.gemfile.lock
@@ -14,7 +14,7 @@ PATH
     datadog (2.7.0)
       datadog-ruby_core_source (~> 3.3)
       libdatadog (~> 14.1.0.1.0)
-      libddwaf (~> 1.15.0.0.0)
+      libddwaf (~> 1.18.0.0.0)
       msgpack
 
 GEM
@@ -68,9 +68,9 @@ GEM
       addressable (>= 2.4)
     libdatadog (14.1.0.1.0-aarch64-linux)
     libdatadog (14.1.0.1.0-x86_64-linux)
-    libddwaf (1.15.0.0.0-aarch64-linux)
+    libddwaf (1.18.0.0.0-aarch64-linux)
       ffi (~> 1.0)
-    libddwaf (1.15.0.0.0-x86_64-linux)
+    libddwaf (1.18.0.0.0-x86_64-linux)
       ffi (~> 1.0)
     memory_profiler (0.9.14)
     method_source (1.0.0)

--- a/gemfiles/ruby_2.7_elasticsearch_latest.gemfile.lock
+++ b/gemfiles/ruby_2.7_elasticsearch_latest.gemfile.lock
@@ -14,7 +14,7 @@ PATH
     datadog (2.7.0)
       datadog-ruby_core_source (~> 3.3)
       libdatadog (~> 14.1.0.1.0)
-      libddwaf (~> 1.15.0.0.0)
+      libddwaf (~> 1.18.0.0.0)
       msgpack
 
 GEM
@@ -69,9 +69,9 @@ GEM
       addressable (>= 2.4)
     libdatadog (14.1.0.1.0-aarch64-linux)
     libdatadog (14.1.0.1.0-x86_64-linux)
-    libddwaf (1.15.0.0.0-aarch64-linux)
+    libddwaf (1.18.0.0.0-aarch64-linux)
       ffi (~> 1.0)
-    libddwaf (1.15.0.0.0-x86_64-linux)
+    libddwaf (1.18.0.0.0-x86_64-linux)
       ffi (~> 1.0)
     memory_profiler (0.9.14)
     method_source (1.1.0)

--- a/gemfiles/ruby_2.7_graphql_1.13.gemfile.lock
+++ b/gemfiles/ruby_2.7_graphql_1.13.gemfile.lock
@@ -14,7 +14,7 @@ PATH
     datadog (2.7.0)
       datadog-ruby_core_source (~> 3.3)
       libdatadog (~> 14.1.0.1.0)
-      libddwaf (~> 1.15.0.0.0)
+      libddwaf (~> 1.18.0.0.0)
       msgpack
 
 GEM
@@ -123,9 +123,9 @@ GEM
       addressable (>= 2.4)
     libdatadog (14.1.0.1.0-aarch64-linux)
     libdatadog (14.1.0.1.0-x86_64-linux)
-    libddwaf (1.15.0.0.0-aarch64-linux)
+    libddwaf (1.18.0.0.0-aarch64-linux)
       ffi (~> 1.0)
-    libddwaf (1.15.0.0.0-x86_64-linux)
+    libddwaf (1.18.0.0.0-x86_64-linux)
       ffi (~> 1.0)
     lograge (0.14.0)
       actionpack (>= 4)

--- a/gemfiles/ruby_2.7_graphql_2.0.gemfile.lock
+++ b/gemfiles/ruby_2.7_graphql_2.0.gemfile.lock
@@ -14,7 +14,7 @@ PATH
     datadog (2.7.0)
       datadog-ruby_core_source (~> 3.3)
       libdatadog (~> 14.1.0.1.0)
-      libddwaf (~> 1.15.0.0.0)
+      libddwaf (~> 1.18.0.0.0)
       msgpack
 
 GEM
@@ -123,9 +123,9 @@ GEM
       addressable (>= 2.4)
     libdatadog (14.1.0.1.0-aarch64-linux)
     libdatadog (14.1.0.1.0-x86_64-linux)
-    libddwaf (1.15.0.0.0-aarch64-linux)
+    libddwaf (1.18.0.0.0-aarch64-linux)
       ffi (~> 1.0)
-    libddwaf (1.15.0.0.0-x86_64-linux)
+    libddwaf (1.18.0.0.0-x86_64-linux)
       ffi (~> 1.0)
     lograge (0.14.0)
       actionpack (>= 4)

--- a/gemfiles/ruby_2.7_graphql_2.1.gemfile.lock
+++ b/gemfiles/ruby_2.7_graphql_2.1.gemfile.lock
@@ -14,7 +14,7 @@ PATH
     datadog (2.7.0)
       datadog-ruby_core_source (~> 3.3)
       libdatadog (~> 14.1.0.1.0)
-      libddwaf (~> 1.15.0.0.0)
+      libddwaf (~> 1.18.0.0.0)
       msgpack
 
 GEM
@@ -124,9 +124,9 @@ GEM
       addressable (>= 2.4)
     libdatadog (14.1.0.1.0-aarch64-linux)
     libdatadog (14.1.0.1.0-x86_64-linux)
-    libddwaf (1.15.0.0.0-aarch64-linux)
+    libddwaf (1.18.0.0.0-aarch64-linux)
       ffi (~> 1.0)
-    libddwaf (1.15.0.0.0-x86_64-linux)
+    libddwaf (1.18.0.0.0-x86_64-linux)
       ffi (~> 1.0)
     lograge (0.14.0)
       actionpack (>= 4)

--- a/gemfiles/ruby_2.7_graphql_2.2.gemfile.lock
+++ b/gemfiles/ruby_2.7_graphql_2.2.gemfile.lock
@@ -14,7 +14,7 @@ PATH
     datadog (2.7.0)
       datadog-ruby_core_source (~> 3.3)
       libdatadog (~> 14.1.0.1.0)
-      libddwaf (~> 1.15.0.0.0)
+      libddwaf (~> 1.18.0.0.0)
       msgpack
 
 GEM
@@ -124,9 +124,9 @@ GEM
       addressable (>= 2.4)
     libdatadog (14.1.0.1.0-aarch64-linux)
     libdatadog (14.1.0.1.0-x86_64-linux)
-    libddwaf (1.15.0.0.0-aarch64-linux)
+    libddwaf (1.18.0.0.0-aarch64-linux)
       ffi (~> 1.0)
-    libddwaf (1.15.0.0.0-x86_64-linux)
+    libddwaf (1.18.0.0.0-x86_64-linux)
       ffi (~> 1.0)
     lograge (0.14.0)
       actionpack (>= 4)

--- a/gemfiles/ruby_2.7_graphql_2.3.gemfile.lock
+++ b/gemfiles/ruby_2.7_graphql_2.3.gemfile.lock
@@ -14,7 +14,7 @@ PATH
     datadog (2.7.0)
       datadog-ruby_core_source (~> 3.3)
       libdatadog (~> 14.1.0.1.0)
-      libddwaf (~> 1.15.0.0.0)
+      libddwaf (~> 1.18.0.0.0)
       msgpack
 
 GEM
@@ -125,9 +125,9 @@ GEM
       addressable (>= 2.4)
     libdatadog (14.1.0.1.0-aarch64-linux)
     libdatadog (14.1.0.1.0-x86_64-linux)
-    libddwaf (1.15.0.0.0-aarch64-linux)
+    libddwaf (1.18.0.0.0-aarch64-linux)
       ffi (~> 1.0)
-    libddwaf (1.15.0.0.0-x86_64-linux)
+    libddwaf (1.18.0.0.0-x86_64-linux)
       ffi (~> 1.0)
     lograge (0.14.0)
       actionpack (>= 4)

--- a/gemfiles/ruby_2.7_hanami_1.gemfile.lock
+++ b/gemfiles/ruby_2.7_hanami_1.gemfile.lock
@@ -14,7 +14,7 @@ PATH
     datadog (2.7.0)
       datadog-ruby_core_source (~> 3.3)
       libdatadog (~> 14.1.0.1.0)
-      libddwaf (~> 1.15.0.0.0)
+      libddwaf (~> 1.18.0.0.0)
       msgpack
 
 GEM
@@ -129,9 +129,9 @@ GEM
       addressable (>= 2.4)
     libdatadog (14.1.0.1.0-aarch64-linux)
     libdatadog (14.1.0.1.0-x86_64-linux)
-    libddwaf (1.15.0.0.0-aarch64-linux)
+    libddwaf (1.18.0.0.0-aarch64-linux)
       ffi (~> 1.0)
-    libddwaf (1.15.0.0.0-x86_64-linux)
+    libddwaf (1.18.0.0.0-x86_64-linux)
       ffi (~> 1.0)
     mail (2.8.1)
       mini_mime (>= 0.1.1)

--- a/gemfiles/ruby_2.7_http.gemfile.lock
+++ b/gemfiles/ruby_2.7_http.gemfile.lock
@@ -14,7 +14,7 @@ PATH
     datadog (2.7.0)
       datadog-ruby_core_source (~> 3.3)
       libdatadog (~> 14.1.0.1.0)
-      libddwaf (~> 1.15.0.0.0)
+      libddwaf (~> 1.18.0.0.0)
       msgpack
 
 GEM
@@ -75,9 +75,9 @@ GEM
       addressable (>= 2.4)
     libdatadog (14.1.0.1.0-aarch64-linux)
     libdatadog (14.1.0.1.0-x86_64-linux)
-    libddwaf (1.15.0.0.0-aarch64-linux)
+    libddwaf (1.18.0.0.0-aarch64-linux)
       ffi (~> 1.0)
-    libddwaf (1.15.0.0.0-x86_64-linux)
+    libddwaf (1.18.0.0.0-x86_64-linux)
       ffi (~> 1.0)
     llhttp-ffi (0.3.1)
       ffi-compiler (~> 1.0)

--- a/gemfiles/ruby_2.7_opensearch_2.gemfile.lock
+++ b/gemfiles/ruby_2.7_opensearch_2.gemfile.lock
@@ -14,7 +14,7 @@ PATH
     datadog (2.7.0)
       datadog-ruby_core_source (~> 3.3)
       libdatadog (~> 14.1.0.1.0)
-      libddwaf (~> 1.15.0.0.0)
+      libddwaf (~> 1.18.0.0.0)
       msgpack
 
 GEM
@@ -60,9 +60,9 @@ GEM
       addressable (>= 2.4)
     libdatadog (14.1.0.1.0-aarch64-linux)
     libdatadog (14.1.0.1.0-x86_64-linux)
-    libddwaf (1.15.0.0.0-aarch64-linux)
+    libddwaf (1.18.0.0.0-aarch64-linux)
       ffi (~> 1.0)
-    libddwaf (1.15.0.0.0-x86_64-linux)
+    libddwaf (1.18.0.0.0-x86_64-linux)
       ffi (~> 1.0)
     memory_profiler (0.9.14)
     method_source (1.0.0)

--- a/gemfiles/ruby_2.7_opensearch_3.gemfile.lock
+++ b/gemfiles/ruby_2.7_opensearch_3.gemfile.lock
@@ -14,7 +14,7 @@ PATH
     datadog (2.7.0)
       datadog-ruby_core_source (~> 3.3)
       libdatadog (~> 14.1.0.1.0)
-      libddwaf (~> 1.15.0.0.0)
+      libddwaf (~> 1.18.0.0.0)
       msgpack
 
 GEM
@@ -60,9 +60,9 @@ GEM
       addressable (>= 2.4)
     libdatadog (14.1.0.1.0-aarch64-linux)
     libdatadog (14.1.0.1.0-x86_64-linux)
-    libddwaf (1.15.0.0.0-aarch64-linux)
+    libddwaf (1.18.0.0.0-aarch64-linux)
       ffi (~> 1.0)
-    libddwaf (1.15.0.0.0-x86_64-linux)
+    libddwaf (1.18.0.0.0-x86_64-linux)
       ffi (~> 1.0)
     memory_profiler (0.9.14)
     method_source (1.0.0)

--- a/gemfiles/ruby_2.7_opensearch_latest.gemfile.lock
+++ b/gemfiles/ruby_2.7_opensearch_latest.gemfile.lock
@@ -14,7 +14,7 @@ PATH
     datadog (2.7.0)
       datadog-ruby_core_source (~> 3.3)
       libdatadog (~> 14.1.0.1.0)
-      libddwaf (~> 1.15.0.0.0)
+      libddwaf (~> 1.18.0.0.0)
       msgpack
 
 GEM
@@ -61,9 +61,9 @@ GEM
       addressable (>= 2.4)
     libdatadog (14.1.0.1.0-aarch64-linux)
     libdatadog (14.1.0.1.0-x86_64-linux)
-    libddwaf (1.15.0.0.0-aarch64-linux)
+    libddwaf (1.18.0.0.0-aarch64-linux)
       ffi (~> 1.0)
-    libddwaf (1.15.0.0.0-x86_64-linux)
+    libddwaf (1.18.0.0.0-x86_64-linux)
       ffi (~> 1.0)
     memory_profiler (0.9.14)
     method_source (1.1.0)

--- a/gemfiles/ruby_2.7_opentelemetry.gemfile.lock
+++ b/gemfiles/ruby_2.7_opentelemetry.gemfile.lock
@@ -14,7 +14,7 @@ PATH
     datadog (2.7.0)
       datadog-ruby_core_source (~> 3.3)
       libdatadog (~> 14.1.0.1.0)
-      libddwaf (~> 1.15.0.0.0)
+      libddwaf (~> 1.18.0.0.0)
       msgpack
 
 GEM
@@ -53,9 +53,9 @@ GEM
       addressable (>= 2.4)
     libdatadog (14.1.0.1.0-aarch64-linux)
     libdatadog (14.1.0.1.0-x86_64-linux)
-    libddwaf (1.15.0.0.0-aarch64-linux)
+    libddwaf (1.18.0.0.0-aarch64-linux)
       ffi (~> 1.0)
-    libddwaf (1.15.0.0.0-x86_64-linux)
+    libddwaf (1.18.0.0.0-x86_64-linux)
       ffi (~> 1.0)
     memory_profiler (0.9.14)
     method_source (1.0.0)

--- a/gemfiles/ruby_2.7_opentelemetry_otlp.gemfile.lock
+++ b/gemfiles/ruby_2.7_opentelemetry_otlp.gemfile.lock
@@ -14,7 +14,7 @@ PATH
     datadog (2.7.0)
       datadog-ruby_core_source (~> 3.3)
       libdatadog (~> 14.1.0.1.0)
-      libddwaf (~> 1.15.0.0.0)
+      libddwaf (~> 1.18.0.0.0)
       msgpack
 
 GEM
@@ -58,9 +58,9 @@ GEM
       addressable (>= 2.4)
     libdatadog (14.1.0.1.0-aarch64-linux)
     libdatadog (14.1.0.1.0-x86_64-linux)
-    libddwaf (1.15.0.0.0-aarch64-linux)
+    libddwaf (1.18.0.0.0-aarch64-linux)
       ffi (~> 1.0)
-    libddwaf (1.15.0.0.0-x86_64-linux)
+    libddwaf (1.18.0.0.0-x86_64-linux)
       ffi (~> 1.0)
     memory_profiler (0.9.14)
     method_source (1.0.0)

--- a/gemfiles/ruby_2.7_rack_1.gemfile.lock
+++ b/gemfiles/ruby_2.7_rack_1.gemfile.lock
@@ -14,7 +14,7 @@ PATH
     datadog (2.7.0)
       datadog-ruby_core_source (~> 3.3)
       libdatadog (~> 14.1.0.1.0)
-      libddwaf (~> 1.15.0.0.0)
+      libddwaf (~> 1.18.0.0.0)
       msgpack
 
 GEM
@@ -53,9 +53,9 @@ GEM
       addressable (>= 2.4)
     libdatadog (14.1.0.1.0-aarch64-linux)
     libdatadog (14.1.0.1.0-x86_64-linux)
-    libddwaf (1.15.0.0.0-aarch64-linux)
+    libddwaf (1.18.0.0.0-aarch64-linux)
       ffi (~> 1.0)
-    libddwaf (1.15.0.0.0-x86_64-linux)
+    libddwaf (1.18.0.0.0-x86_64-linux)
       ffi (~> 1.0)
     memory_profiler (0.9.14)
     method_source (1.0.0)

--- a/gemfiles/ruby_2.7_rack_2.gemfile.lock
+++ b/gemfiles/ruby_2.7_rack_2.gemfile.lock
@@ -14,7 +14,7 @@ PATH
     datadog (2.7.0)
       datadog-ruby_core_source (~> 3.3)
       libdatadog (~> 14.1.0.1.0)
-      libddwaf (~> 1.15.0.0.0)
+      libddwaf (~> 1.18.0.0.0)
       msgpack
 
 GEM
@@ -53,9 +53,9 @@ GEM
       addressable (>= 2.4)
     libdatadog (14.1.0.1.0-aarch64-linux)
     libdatadog (14.1.0.1.0-x86_64-linux)
-    libddwaf (1.15.0.0.0-aarch64-linux)
+    libddwaf (1.18.0.0.0-aarch64-linux)
       ffi (~> 1.0)
-    libddwaf (1.15.0.0.0-x86_64-linux)
+    libddwaf (1.18.0.0.0-x86_64-linux)
       ffi (~> 1.0)
     memory_profiler (0.9.14)
     method_source (1.0.0)

--- a/gemfiles/ruby_2.7_rack_3.gemfile.lock
+++ b/gemfiles/ruby_2.7_rack_3.gemfile.lock
@@ -14,7 +14,7 @@ PATH
     datadog (2.7.0)
       datadog-ruby_core_source (~> 3.3)
       libdatadog (~> 14.1.0.1.0)
-      libddwaf (~> 1.15.0.0.0)
+      libddwaf (~> 1.18.0.0.0)
       msgpack
 
 GEM
@@ -53,9 +53,9 @@ GEM
       addressable (>= 2.4)
     libdatadog (14.1.0.1.0-aarch64-linux)
     libdatadog (14.1.0.1.0-x86_64-linux)
-    libddwaf (1.15.0.0.0-aarch64-linux)
+    libddwaf (1.18.0.0.0-aarch64-linux)
       ffi (~> 1.0)
-    libddwaf (1.15.0.0.0-x86_64-linux)
+    libddwaf (1.18.0.0.0-x86_64-linux)
       ffi (~> 1.0)
     memory_profiler (0.9.14)
     method_source (1.0.0)

--- a/gemfiles/ruby_2.7_rack_latest.gemfile.lock
+++ b/gemfiles/ruby_2.7_rack_latest.gemfile.lock
@@ -14,7 +14,7 @@ PATH
     datadog (2.7.0)
       datadog-ruby_core_source (~> 3.3)
       libdatadog (~> 14.1.0.1.0)
-      libddwaf (~> 1.15.0.0.0)
+      libddwaf (~> 1.18.0.0.0)
       msgpack
 
 GEM
@@ -56,9 +56,9 @@ GEM
       addressable (>= 2.4)
     libdatadog (14.1.0.1.0-aarch64-linux)
     libdatadog (14.1.0.1.0-x86_64-linux)
-    libddwaf (1.15.0.0.0-aarch64-linux)
+    libddwaf (1.18.0.0.0-aarch64-linux)
       ffi (~> 1.0)
-    libddwaf (1.15.0.0.0-x86_64-linux)
+    libddwaf (1.18.0.0.0-x86_64-linux)
       ffi (~> 1.0)
     memory_profiler (0.9.14)
     method_source (1.1.0)

--- a/gemfiles/ruby_2.7_rails5_mysql2.gemfile.lock
+++ b/gemfiles/ruby_2.7_rails5_mysql2.gemfile.lock
@@ -14,7 +14,7 @@ PATH
     datadog (2.7.0)
       datadog-ruby_core_source (~> 3.3)
       libdatadog (~> 14.1.0.1.0)
-      libddwaf (~> 1.15.0.0.0)
+      libddwaf (~> 1.18.0.0.0)
       msgpack
 
 GEM
@@ -103,9 +103,9 @@ GEM
       addressable (>= 2.4)
     libdatadog (14.1.0.1.0-aarch64-linux)
     libdatadog (14.1.0.1.0-x86_64-linux)
-    libddwaf (1.15.0.0.0-aarch64-linux)
+    libddwaf (1.18.0.0.0-aarch64-linux)
       ffi (~> 1.0)
-    libddwaf (1.15.0.0.0-x86_64-linux)
+    libddwaf (1.18.0.0.0-x86_64-linux)
       ffi (~> 1.0)
     lograge (0.12.0)
       actionpack (>= 4)

--- a/gemfiles/ruby_2.7_rails5_postgres.gemfile.lock
+++ b/gemfiles/ruby_2.7_rails5_postgres.gemfile.lock
@@ -14,7 +14,7 @@ PATH
     datadog (2.7.0)
       datadog-ruby_core_source (~> 3.3)
       libdatadog (~> 14.1.0.1.0)
-      libddwaf (~> 1.15.0.0.0)
+      libddwaf (~> 1.18.0.0.0)
       msgpack
 
 GEM
@@ -103,9 +103,9 @@ GEM
       addressable (>= 2.4)
     libdatadog (14.1.0.1.0-aarch64-linux)
     libdatadog (14.1.0.1.0-x86_64-linux)
-    libddwaf (1.15.0.0.0-aarch64-linux)
+    libddwaf (1.18.0.0.0-aarch64-linux)
       ffi (~> 1.0)
-    libddwaf (1.15.0.0.0-x86_64-linux)
+    libddwaf (1.18.0.0.0-x86_64-linux)
       ffi (~> 1.0)
     lograge (0.12.0)
       actionpack (>= 4)

--- a/gemfiles/ruby_2.7_rails5_postgres_redis.gemfile.lock
+++ b/gemfiles/ruby_2.7_rails5_postgres_redis.gemfile.lock
@@ -14,7 +14,7 @@ PATH
     datadog (2.7.0)
       datadog-ruby_core_source (~> 3.3)
       libdatadog (~> 14.1.0.1.0)
-      libddwaf (~> 1.15.0.0.0)
+      libddwaf (~> 1.18.0.0.0)
       msgpack
 
 GEM
@@ -103,9 +103,9 @@ GEM
       addressable (>= 2.4)
     libdatadog (14.1.0.1.0-aarch64-linux)
     libdatadog (14.1.0.1.0-x86_64-linux)
-    libddwaf (1.15.0.0.0-aarch64-linux)
+    libddwaf (1.18.0.0.0-aarch64-linux)
       ffi (~> 1.0)
-    libddwaf (1.15.0.0.0-x86_64-linux)
+    libddwaf (1.18.0.0.0-x86_64-linux)
       ffi (~> 1.0)
     lograge (0.12.0)
       actionpack (>= 4)

--- a/gemfiles/ruby_2.7_rails5_postgres_redis_activesupport.gemfile.lock
+++ b/gemfiles/ruby_2.7_rails5_postgres_redis_activesupport.gemfile.lock
@@ -14,7 +14,7 @@ PATH
     datadog (2.7.0)
       datadog-ruby_core_source (~> 3.3)
       libdatadog (~> 14.1.0.1.0)
-      libddwaf (~> 1.15.0.0.0)
+      libddwaf (~> 1.18.0.0.0)
       msgpack
 
 GEM
@@ -103,9 +103,9 @@ GEM
       addressable (>= 2.4)
     libdatadog (14.1.0.1.0-aarch64-linux)
     libdatadog (14.1.0.1.0-x86_64-linux)
-    libddwaf (1.15.0.0.0-aarch64-linux)
+    libddwaf (1.18.0.0.0-aarch64-linux)
       ffi (~> 1.0)
-    libddwaf (1.15.0.0.0-x86_64-linux)
+    libddwaf (1.18.0.0.0-x86_64-linux)
       ffi (~> 1.0)
     lograge (0.12.0)
       actionpack (>= 4)

--- a/gemfiles/ruby_2.7_rails5_postgres_sidekiq.gemfile.lock
+++ b/gemfiles/ruby_2.7_rails5_postgres_sidekiq.gemfile.lock
@@ -14,7 +14,7 @@ PATH
     datadog (2.7.0)
       datadog-ruby_core_source (~> 3.3)
       libdatadog (~> 14.1.0.1.0)
-      libddwaf (~> 1.15.0.0.0)
+      libddwaf (~> 1.18.0.0.0)
       msgpack
 
 GEM
@@ -104,9 +104,9 @@ GEM
       addressable (>= 2.4)
     libdatadog (14.1.0.1.0-aarch64-linux)
     libdatadog (14.1.0.1.0-x86_64-linux)
-    libddwaf (1.15.0.0.0-aarch64-linux)
+    libddwaf (1.18.0.0.0-aarch64-linux)
       ffi (~> 1.0)
-    libddwaf (1.15.0.0.0-x86_64-linux)
+    libddwaf (1.18.0.0.0-x86_64-linux)
       ffi (~> 1.0)
     lograge (0.12.0)
       actionpack (>= 4)

--- a/gemfiles/ruby_2.7_rails5_semantic_logger.gemfile.lock
+++ b/gemfiles/ruby_2.7_rails5_semantic_logger.gemfile.lock
@@ -14,7 +14,7 @@ PATH
     datadog (2.7.0)
       datadog-ruby_core_source (~> 3.3)
       libdatadog (~> 14.1.0.1.0)
-      libddwaf (~> 1.15.0.0.0)
+      libddwaf (~> 1.18.0.0.0)
       msgpack
 
 GEM
@@ -103,9 +103,9 @@ GEM
       addressable (>= 2.4)
     libdatadog (14.1.0.1.0-aarch64-linux)
     libdatadog (14.1.0.1.0-x86_64-linux)
-    libddwaf (1.15.0.0.0-aarch64-linux)
+    libddwaf (1.18.0.0.0-aarch64-linux)
       ffi (~> 1.0)
-    libddwaf (1.15.0.0.0-x86_64-linux)
+    libddwaf (1.18.0.0.0-x86_64-linux)
       ffi (~> 1.0)
     loofah (2.19.1)
       crass (~> 1.0.2)

--- a/gemfiles/ruby_2.7_rails61_mysql2.gemfile.lock
+++ b/gemfiles/ruby_2.7_rails61_mysql2.gemfile.lock
@@ -14,7 +14,7 @@ PATH
     datadog (2.7.0)
       datadog-ruby_core_source (~> 3.3)
       libdatadog (~> 14.1.0.1.0)
-      libddwaf (~> 1.15.0.0.0)
+      libddwaf (~> 1.18.0.0.0)
       msgpack
 
 GEM
@@ -120,9 +120,9 @@ GEM
       addressable (>= 2.4)
     libdatadog (14.1.0.1.0-aarch64-linux)
     libdatadog (14.1.0.1.0-x86_64-linux)
-    libddwaf (1.15.0.0.0-aarch64-linux)
+    libddwaf (1.18.0.0.0-aarch64-linux)
       ffi (~> 1.0)
-    libddwaf (1.15.0.0.0-x86_64-linux)
+    libddwaf (1.18.0.0.0-x86_64-linux)
       ffi (~> 1.0)
     lograge (0.12.0)
       actionpack (>= 4)

--- a/gemfiles/ruby_2.7_rails61_postgres.gemfile.lock
+++ b/gemfiles/ruby_2.7_rails61_postgres.gemfile.lock
@@ -14,7 +14,7 @@ PATH
     datadog (2.7.0)
       datadog-ruby_core_source (~> 3.3)
       libdatadog (~> 14.1.0.1.0)
-      libddwaf (~> 1.15.0.0.0)
+      libddwaf (~> 1.18.0.0.0)
       msgpack
 
 GEM
@@ -120,9 +120,9 @@ GEM
       addressable (>= 2.4)
     libdatadog (14.1.0.1.0-aarch64-linux)
     libdatadog (14.1.0.1.0-x86_64-linux)
-    libddwaf (1.15.0.0.0-aarch64-linux)
+    libddwaf (1.18.0.0.0-aarch64-linux)
       ffi (~> 1.0)
-    libddwaf (1.15.0.0.0-x86_64-linux)
+    libddwaf (1.18.0.0.0-x86_64-linux)
       ffi (~> 1.0)
     lograge (0.12.0)
       actionpack (>= 4)

--- a/gemfiles/ruby_2.7_rails61_postgres_redis.gemfile.lock
+++ b/gemfiles/ruby_2.7_rails61_postgres_redis.gemfile.lock
@@ -14,7 +14,7 @@ PATH
     datadog (2.7.0)
       datadog-ruby_core_source (~> 3.3)
       libdatadog (~> 14.1.0.1.0)
-      libddwaf (~> 1.15.0.0.0)
+      libddwaf (~> 1.18.0.0.0)
       msgpack
 
 GEM
@@ -120,9 +120,9 @@ GEM
       addressable (>= 2.4)
     libdatadog (14.1.0.1.0-aarch64-linux)
     libdatadog (14.1.0.1.0-x86_64-linux)
-    libddwaf (1.15.0.0.0-aarch64-linux)
+    libddwaf (1.18.0.0.0-aarch64-linux)
       ffi (~> 1.0)
-    libddwaf (1.15.0.0.0-x86_64-linux)
+    libddwaf (1.18.0.0.0-x86_64-linux)
       ffi (~> 1.0)
     lograge (0.12.0)
       actionpack (>= 4)

--- a/gemfiles/ruby_2.7_rails61_postgres_sidekiq.gemfile.lock
+++ b/gemfiles/ruby_2.7_rails61_postgres_sidekiq.gemfile.lock
@@ -14,7 +14,7 @@ PATH
     datadog (2.7.0)
       datadog-ruby_core_source (~> 3.3)
       libdatadog (~> 14.1.0.1.0)
-      libddwaf (~> 1.15.0.0.0)
+      libddwaf (~> 1.18.0.0.0)
       msgpack
 
 GEM
@@ -121,9 +121,9 @@ GEM
       addressable (>= 2.4)
     libdatadog (14.1.0.1.0-aarch64-linux)
     libdatadog (14.1.0.1.0-x86_64-linux)
-    libddwaf (1.15.0.0.0-aarch64-linux)
+    libddwaf (1.18.0.0.0-aarch64-linux)
       ffi (~> 1.0)
-    libddwaf (1.15.0.0.0-x86_64-linux)
+    libddwaf (1.18.0.0.0-x86_64-linux)
       ffi (~> 1.0)
     lograge (0.12.0)
       actionpack (>= 4)

--- a/gemfiles/ruby_2.7_rails61_semantic_logger.gemfile.lock
+++ b/gemfiles/ruby_2.7_rails61_semantic_logger.gemfile.lock
@@ -14,7 +14,7 @@ PATH
     datadog (2.7.0)
       datadog-ruby_core_source (~> 3.3)
       libdatadog (~> 14.1.0.1.0)
-      libddwaf (~> 1.15.0.0.0)
+      libddwaf (~> 1.18.0.0.0)
       msgpack
 
 GEM
@@ -120,9 +120,9 @@ GEM
       addressable (>= 2.4)
     libdatadog (14.1.0.1.0-aarch64-linux)
     libdatadog (14.1.0.1.0-x86_64-linux)
-    libddwaf (1.15.0.0.0-aarch64-linux)
+    libddwaf (1.18.0.0.0-aarch64-linux)
       ffi (~> 1.0)
-    libddwaf (1.15.0.0.0-x86_64-linux)
+    libddwaf (1.18.0.0.0-x86_64-linux)
       ffi (~> 1.0)
     loofah (2.19.1)
       crass (~> 1.0.2)

--- a/gemfiles/ruby_2.7_rails6_mysql2.gemfile.lock
+++ b/gemfiles/ruby_2.7_rails6_mysql2.gemfile.lock
@@ -14,7 +14,7 @@ PATH
     datadog (2.7.0)
       datadog-ruby_core_source (~> 3.3)
       libdatadog (~> 14.1.0.1.0)
-      libddwaf (~> 1.15.0.0.0)
+      libddwaf (~> 1.18.0.0.0)
       msgpack
 
 GEM
@@ -116,9 +116,9 @@ GEM
       addressable (>= 2.4)
     libdatadog (14.1.0.1.0-aarch64-linux)
     libdatadog (14.1.0.1.0-x86_64-linux)
-    libddwaf (1.15.0.0.0-aarch64-linux)
+    libddwaf (1.18.0.0.0-aarch64-linux)
       ffi (~> 1.0)
-    libddwaf (1.15.0.0.0-x86_64-linux)
+    libddwaf (1.18.0.0.0-x86_64-linux)
       ffi (~> 1.0)
     lograge (0.12.0)
       actionpack (>= 4)

--- a/gemfiles/ruby_2.7_rails6_postgres.gemfile.lock
+++ b/gemfiles/ruby_2.7_rails6_postgres.gemfile.lock
@@ -14,7 +14,7 @@ PATH
     datadog (2.7.0)
       datadog-ruby_core_source (~> 3.3)
       libdatadog (~> 14.1.0.1.0)
-      libddwaf (~> 1.15.0.0.0)
+      libddwaf (~> 1.18.0.0.0)
       msgpack
 
 GEM
@@ -116,9 +116,9 @@ GEM
       addressable (>= 2.4)
     libdatadog (14.1.0.1.0-aarch64-linux)
     libdatadog (14.1.0.1.0-x86_64-linux)
-    libddwaf (1.15.0.0.0-aarch64-linux)
+    libddwaf (1.18.0.0.0-aarch64-linux)
       ffi (~> 1.0)
-    libddwaf (1.15.0.0.0-x86_64-linux)
+    libddwaf (1.18.0.0.0-x86_64-linux)
       ffi (~> 1.0)
     lograge (0.12.0)
       actionpack (>= 4)

--- a/gemfiles/ruby_2.7_rails6_postgres_redis.gemfile.lock
+++ b/gemfiles/ruby_2.7_rails6_postgres_redis.gemfile.lock
@@ -14,7 +14,7 @@ PATH
     datadog (2.7.0)
       datadog-ruby_core_source (~> 3.3)
       libdatadog (~> 14.1.0.1.0)
-      libddwaf (~> 1.15.0.0.0)
+      libddwaf (~> 1.18.0.0.0)
       msgpack
 
 GEM
@@ -116,9 +116,9 @@ GEM
       addressable (>= 2.4)
     libdatadog (14.1.0.1.0-aarch64-linux)
     libdatadog (14.1.0.1.0-x86_64-linux)
-    libddwaf (1.15.0.0.0-aarch64-linux)
+    libddwaf (1.18.0.0.0-aarch64-linux)
       ffi (~> 1.0)
-    libddwaf (1.15.0.0.0-x86_64-linux)
+    libddwaf (1.18.0.0.0-x86_64-linux)
       ffi (~> 1.0)
     lograge (0.12.0)
       actionpack (>= 4)

--- a/gemfiles/ruby_2.7_rails6_postgres_redis_activesupport.gemfile.lock
+++ b/gemfiles/ruby_2.7_rails6_postgres_redis_activesupport.gemfile.lock
@@ -14,7 +14,7 @@ PATH
     datadog (2.7.0)
       datadog-ruby_core_source (~> 3.3)
       libdatadog (~> 14.1.0.1.0)
-      libddwaf (~> 1.15.0.0.0)
+      libddwaf (~> 1.18.0.0.0)
       msgpack
 
 GEM
@@ -116,9 +116,9 @@ GEM
       addressable (>= 2.4)
     libdatadog (14.1.0.1.0-aarch64-linux)
     libdatadog (14.1.0.1.0-x86_64-linux)
-    libddwaf (1.15.0.0.0-aarch64-linux)
+    libddwaf (1.18.0.0.0-aarch64-linux)
       ffi (~> 1.0)
-    libddwaf (1.15.0.0.0-x86_64-linux)
+    libddwaf (1.18.0.0.0-x86_64-linux)
       ffi (~> 1.0)
     lograge (0.12.0)
       actionpack (>= 4)

--- a/gemfiles/ruby_2.7_rails6_postgres_sidekiq.gemfile.lock
+++ b/gemfiles/ruby_2.7_rails6_postgres_sidekiq.gemfile.lock
@@ -14,7 +14,7 @@ PATH
     datadog (2.7.0)
       datadog-ruby_core_source (~> 3.3)
       libdatadog (~> 14.1.0.1.0)
-      libddwaf (~> 1.15.0.0.0)
+      libddwaf (~> 1.18.0.0.0)
       msgpack
 
 GEM
@@ -117,9 +117,9 @@ GEM
       addressable (>= 2.4)
     libdatadog (14.1.0.1.0-aarch64-linux)
     libdatadog (14.1.0.1.0-x86_64-linux)
-    libddwaf (1.15.0.0.0-aarch64-linux)
+    libddwaf (1.18.0.0.0-aarch64-linux)
       ffi (~> 1.0)
-    libddwaf (1.15.0.0.0-x86_64-linux)
+    libddwaf (1.18.0.0.0-x86_64-linux)
       ffi (~> 1.0)
     lograge (0.12.0)
       actionpack (>= 4)

--- a/gemfiles/ruby_2.7_rails6_semantic_logger.gemfile.lock
+++ b/gemfiles/ruby_2.7_rails6_semantic_logger.gemfile.lock
@@ -14,7 +14,7 @@ PATH
     datadog (2.7.0)
       datadog-ruby_core_source (~> 3.3)
       libdatadog (~> 14.1.0.1.0)
-      libddwaf (~> 1.15.0.0.0)
+      libddwaf (~> 1.18.0.0.0)
       msgpack
 
 GEM
@@ -116,9 +116,9 @@ GEM
       addressable (>= 2.4)
     libdatadog (14.1.0.1.0-aarch64-linux)
     libdatadog (14.1.0.1.0-x86_64-linux)
-    libddwaf (1.15.0.0.0-aarch64-linux)
+    libddwaf (1.18.0.0.0-aarch64-linux)
       ffi (~> 1.0)
-    libddwaf (1.15.0.0.0-x86_64-linux)
+    libddwaf (1.18.0.0.0-x86_64-linux)
       ffi (~> 1.0)
     loofah (2.19.1)
       crass (~> 1.0.2)

--- a/gemfiles/ruby_2.7_redis_3.gemfile.lock
+++ b/gemfiles/ruby_2.7_redis_3.gemfile.lock
@@ -14,7 +14,7 @@ PATH
     datadog (2.7.0)
       datadog-ruby_core_source (~> 3.3)
       libdatadog (~> 14.1.0.1.0)
-      libddwaf (~> 1.15.0.0.0)
+      libddwaf (~> 1.18.0.0.0)
       msgpack
 
 GEM
@@ -53,9 +53,9 @@ GEM
       addressable (>= 2.4)
     libdatadog (14.1.0.1.0-aarch64-linux)
     libdatadog (14.1.0.1.0-x86_64-linux)
-    libddwaf (1.15.0.0.0-aarch64-linux)
+    libddwaf (1.18.0.0.0-aarch64-linux)
       ffi (~> 1.0)
-    libddwaf (1.15.0.0.0-x86_64-linux)
+    libddwaf (1.18.0.0.0-x86_64-linux)
       ffi (~> 1.0)
     memory_profiler (0.9.14)
     method_source (1.0.0)

--- a/gemfiles/ruby_2.7_redis_4.gemfile.lock
+++ b/gemfiles/ruby_2.7_redis_4.gemfile.lock
@@ -14,7 +14,7 @@ PATH
     datadog (2.7.0)
       datadog-ruby_core_source (~> 3.3)
       libdatadog (~> 14.1.0.1.0)
-      libddwaf (~> 1.15.0.0.0)
+      libddwaf (~> 1.18.0.0.0)
       msgpack
 
 GEM
@@ -53,9 +53,9 @@ GEM
       addressable (>= 2.4)
     libdatadog (14.1.0.1.0-aarch64-linux)
     libdatadog (14.1.0.1.0-x86_64-linux)
-    libddwaf (1.15.0.0.0-aarch64-linux)
+    libddwaf (1.18.0.0.0-aarch64-linux)
       ffi (~> 1.0)
-    libddwaf (1.15.0.0.0-x86_64-linux)
+    libddwaf (1.18.0.0.0-x86_64-linux)
       ffi (~> 1.0)
     memory_profiler (0.9.14)
     method_source (1.0.0)

--- a/gemfiles/ruby_2.7_redis_5.gemfile.lock
+++ b/gemfiles/ruby_2.7_redis_5.gemfile.lock
@@ -14,7 +14,7 @@ PATH
     datadog (2.7.0)
       datadog-ruby_core_source (~> 3.3)
       libdatadog (~> 14.1.0.1.0)
-      libddwaf (~> 1.15.0.0.0)
+      libddwaf (~> 1.18.0.0.0)
       msgpack
 
 GEM
@@ -54,9 +54,9 @@ GEM
       addressable (>= 2.4)
     libdatadog (14.1.0.1.0-aarch64-linux)
     libdatadog (14.1.0.1.0-x86_64-linux)
-    libddwaf (1.15.0.0.0-aarch64-linux)
+    libddwaf (1.18.0.0.0-aarch64-linux)
       ffi (~> 1.0)
-    libddwaf (1.15.0.0.0-x86_64-linux)
+    libddwaf (1.18.0.0.0-x86_64-linux)
       ffi (~> 1.0)
     memory_profiler (0.9.14)
     method_source (1.0.0)

--- a/gemfiles/ruby_2.7_relational_db.gemfile.lock
+++ b/gemfiles/ruby_2.7_relational_db.gemfile.lock
@@ -14,7 +14,7 @@ PATH
     datadog (2.7.0)
       datadog-ruby_core_source (~> 3.3)
       libdatadog (~> 14.1.0.1.0)
-      libddwaf (~> 1.15.0.0.0)
+      libddwaf (~> 1.18.0.0.0)
       msgpack
 
 GEM
@@ -72,9 +72,9 @@ GEM
       addressable (>= 2.4)
     libdatadog (14.1.0.1.0-aarch64-linux)
     libdatadog (14.1.0.1.0-x86_64-linux)
-    libddwaf (1.15.0.0.0-aarch64-linux)
+    libddwaf (1.18.0.0.0-aarch64-linux)
       ffi (~> 1.0)
-    libddwaf (1.15.0.0.0-x86_64-linux)
+    libddwaf (1.18.0.0.0-x86_64-linux)
       ffi (~> 1.0)
     makara (0.5.1)
       activerecord (>= 5.2.0)

--- a/gemfiles/ruby_2.7_resque2_redis3.gemfile.lock
+++ b/gemfiles/ruby_2.7_resque2_redis3.gemfile.lock
@@ -14,7 +14,7 @@ PATH
     datadog (2.7.0)
       datadog-ruby_core_source (~> 3.3)
       libdatadog (~> 14.1.0.1.0)
-      libddwaf (~> 1.15.0.0.0)
+      libddwaf (~> 1.18.0.0.0)
       msgpack
 
 GEM
@@ -53,9 +53,9 @@ GEM
       addressable (>= 2.4)
     libdatadog (14.1.0.1.0-aarch64-linux)
     libdatadog (14.1.0.1.0-x86_64-linux)
-    libddwaf (1.15.0.0.0-aarch64-linux)
+    libddwaf (1.18.0.0.0-aarch64-linux)
       ffi (~> 1.0)
-    libddwaf (1.15.0.0.0-x86_64-linux)
+    libddwaf (1.18.0.0.0-x86_64-linux)
       ffi (~> 1.0)
     memory_profiler (0.9.14)
     method_source (1.0.0)

--- a/gemfiles/ruby_2.7_resque2_redis4.gemfile.lock
+++ b/gemfiles/ruby_2.7_resque2_redis4.gemfile.lock
@@ -14,7 +14,7 @@ PATH
     datadog (2.7.0)
       datadog-ruby_core_source (~> 3.3)
       libdatadog (~> 14.1.0.1.0)
-      libddwaf (~> 1.15.0.0.0)
+      libddwaf (~> 1.18.0.0.0)
       msgpack
 
 GEM
@@ -53,9 +53,9 @@ GEM
       addressable (>= 2.4)
     libdatadog (14.1.0.1.0-aarch64-linux)
     libdatadog (14.1.0.1.0-x86_64-linux)
-    libddwaf (1.15.0.0.0-aarch64-linux)
+    libddwaf (1.18.0.0.0-aarch64-linux)
       ffi (~> 1.0)
-    libddwaf (1.15.0.0.0-x86_64-linux)
+    libddwaf (1.18.0.0.0-x86_64-linux)
       ffi (~> 1.0)
     memory_profiler (0.9.14)
     method_source (1.0.0)

--- a/gemfiles/ruby_2.7_sinatra_2.gemfile.lock
+++ b/gemfiles/ruby_2.7_sinatra_2.gemfile.lock
@@ -14,7 +14,7 @@ PATH
     datadog (2.7.0)
       datadog-ruby_core_source (~> 3.3)
       libdatadog (~> 14.1.0.1.0)
-      libddwaf (~> 1.15.0.0.0)
+      libddwaf (~> 1.18.0.0.0)
       msgpack
 
 GEM
@@ -56,9 +56,9 @@ GEM
       addressable (>= 2.4)
     libdatadog (14.1.0.1.0-aarch64-linux)
     libdatadog (14.1.0.1.0-x86_64-linux)
-    libddwaf (1.15.0.0.0-aarch64-linux)
+    libddwaf (1.18.0.0.0-aarch64-linux)
       ffi (~> 1.0)
-    libddwaf (1.15.0.0.0-x86_64-linux)
+    libddwaf (1.18.0.0.0-x86_64-linux)
       ffi (~> 1.0)
     memory_profiler (0.9.14)
     method_source (1.1.0)

--- a/gemfiles/ruby_2.7_sinatra_3.gemfile.lock
+++ b/gemfiles/ruby_2.7_sinatra_3.gemfile.lock
@@ -14,7 +14,7 @@ PATH
     datadog (2.7.0)
       datadog-ruby_core_source (~> 3.3)
       libdatadog (~> 14.1.0.1.0)
-      libddwaf (~> 1.15.0.0.0)
+      libddwaf (~> 1.18.0.0.0)
       msgpack
 
 GEM
@@ -57,9 +57,9 @@ GEM
       addressable (>= 2.4)
     libdatadog (14.1.0.1.0-aarch64-linux)
     libdatadog (14.1.0.1.0-x86_64-linux)
-    libddwaf (1.15.0.0.0-aarch64-linux)
+    libddwaf (1.18.0.0.0-aarch64-linux)
       ffi (~> 1.0)
-    libddwaf (1.15.0.0.0-x86_64-linux)
+    libddwaf (1.18.0.0.0-x86_64-linux)
       ffi (~> 1.0)
     memory_profiler (0.9.14)
     method_source (1.1.0)

--- a/gemfiles/ruby_2.7_stripe_10.gemfile.lock
+++ b/gemfiles/ruby_2.7_stripe_10.gemfile.lock
@@ -14,7 +14,7 @@ PATH
     datadog (2.7.0)
       datadog-ruby_core_source (~> 3.3)
       libdatadog (~> 14.1.0.1.0)
-      libddwaf (~> 1.15.0.0.0)
+      libddwaf (~> 1.18.0.0.0)
       msgpack
 
 GEM
@@ -55,9 +55,9 @@ GEM
       addressable (>= 2.4)
     libdatadog (14.1.0.1.0-aarch64-linux)
     libdatadog (14.1.0.1.0-x86_64-linux)
-    libddwaf (1.15.0.0.0-aarch64-linux)
+    libddwaf (1.18.0.0.0-aarch64-linux)
       ffi (~> 1.0)
-    libddwaf (1.15.0.0.0-x86_64-linux)
+    libddwaf (1.18.0.0.0-x86_64-linux)
       ffi (~> 1.0)
     memory_profiler (0.9.14)
     method_source (1.1.0)

--- a/gemfiles/ruby_2.7_stripe_11.gemfile.lock
+++ b/gemfiles/ruby_2.7_stripe_11.gemfile.lock
@@ -14,7 +14,7 @@ PATH
     datadog (2.7.0)
       datadog-ruby_core_source (~> 3.3)
       libdatadog (~> 14.1.0.1.0)
-      libddwaf (~> 1.15.0.0.0)
+      libddwaf (~> 1.18.0.0.0)
       msgpack
 
 GEM
@@ -55,9 +55,9 @@ GEM
       addressable (>= 2.4)
     libdatadog (14.1.0.1.0-aarch64-linux)
     libdatadog (14.1.0.1.0-x86_64-linux)
-    libddwaf (1.15.0.0.0-aarch64-linux)
+    libddwaf (1.18.0.0.0-aarch64-linux)
       ffi (~> 1.0)
-    libddwaf (1.15.0.0.0-x86_64-linux)
+    libddwaf (1.18.0.0.0-x86_64-linux)
       ffi (~> 1.0)
     memory_profiler (0.9.14)
     method_source (1.1.0)

--- a/gemfiles/ruby_2.7_stripe_12.gemfile.lock
+++ b/gemfiles/ruby_2.7_stripe_12.gemfile.lock
@@ -14,7 +14,7 @@ PATH
     datadog (2.7.0)
       datadog-ruby_core_source (~> 3.3)
       libdatadog (~> 14.1.0.1.0)
-      libddwaf (~> 1.15.0.0.0)
+      libddwaf (~> 1.18.0.0.0)
       msgpack
 
 GEM
@@ -55,9 +55,9 @@ GEM
       addressable (>= 2.4)
     libdatadog (14.1.0.1.0-aarch64-linux)
     libdatadog (14.1.0.1.0-x86_64-linux)
-    libddwaf (1.15.0.0.0-aarch64-linux)
+    libddwaf (1.18.0.0.0-aarch64-linux)
       ffi (~> 1.0)
-    libddwaf (1.15.0.0.0-x86_64-linux)
+    libddwaf (1.18.0.0.0-x86_64-linux)
       ffi (~> 1.0)
     memory_profiler (0.9.14)
     method_source (1.1.0)

--- a/gemfiles/ruby_2.7_stripe_7.gemfile.lock
+++ b/gemfiles/ruby_2.7_stripe_7.gemfile.lock
@@ -14,7 +14,7 @@ PATH
     datadog (2.7.0)
       datadog-ruby_core_source (~> 3.3)
       libdatadog (~> 14.1.0.1.0)
-      libddwaf (~> 1.15.0.0.0)
+      libddwaf (~> 1.18.0.0.0)
       msgpack
 
 GEM
@@ -55,9 +55,9 @@ GEM
       addressable (>= 2.4)
     libdatadog (14.1.0.1.0-aarch64-linux)
     libdatadog (14.1.0.1.0-x86_64-linux)
-    libddwaf (1.15.0.0.0-aarch64-linux)
+    libddwaf (1.18.0.0.0-aarch64-linux)
       ffi (~> 1.0)
-    libddwaf (1.15.0.0.0-x86_64-linux)
+    libddwaf (1.18.0.0.0-x86_64-linux)
       ffi (~> 1.0)
     memory_profiler (0.9.14)
     method_source (1.1.0)

--- a/gemfiles/ruby_2.7_stripe_8.gemfile.lock
+++ b/gemfiles/ruby_2.7_stripe_8.gemfile.lock
@@ -14,7 +14,7 @@ PATH
     datadog (2.7.0)
       datadog-ruby_core_source (~> 3.3)
       libdatadog (~> 14.1.0.1.0)
-      libddwaf (~> 1.15.0.0.0)
+      libddwaf (~> 1.18.0.0.0)
       msgpack
 
 GEM
@@ -55,9 +55,9 @@ GEM
       addressable (>= 2.4)
     libdatadog (14.1.0.1.0-aarch64-linux)
     libdatadog (14.1.0.1.0-x86_64-linux)
-    libddwaf (1.15.0.0.0-aarch64-linux)
+    libddwaf (1.18.0.0.0-aarch64-linux)
       ffi (~> 1.0)
-    libddwaf (1.15.0.0.0-x86_64-linux)
+    libddwaf (1.18.0.0.0-x86_64-linux)
       ffi (~> 1.0)
     memory_profiler (0.9.14)
     method_source (1.1.0)

--- a/gemfiles/ruby_2.7_stripe_9.gemfile.lock
+++ b/gemfiles/ruby_2.7_stripe_9.gemfile.lock
@@ -14,7 +14,7 @@ PATH
     datadog (2.7.0)
       datadog-ruby_core_source (~> 3.3)
       libdatadog (~> 14.1.0.1.0)
-      libddwaf (~> 1.15.0.0.0)
+      libddwaf (~> 1.18.0.0.0)
       msgpack
 
 GEM
@@ -55,9 +55,9 @@ GEM
       addressable (>= 2.4)
     libdatadog (14.1.0.1.0-aarch64-linux)
     libdatadog (14.1.0.1.0-x86_64-linux)
-    libddwaf (1.15.0.0.0-aarch64-linux)
+    libddwaf (1.18.0.0.0-aarch64-linux)
       ffi (~> 1.0)
-    libddwaf (1.15.0.0.0-x86_64-linux)
+    libddwaf (1.18.0.0.0-x86_64-linux)
       ffi (~> 1.0)
     memory_profiler (0.9.14)
     method_source (1.1.0)

--- a/gemfiles/ruby_2.7_stripe_latest.gemfile.lock
+++ b/gemfiles/ruby_2.7_stripe_latest.gemfile.lock
@@ -14,7 +14,7 @@ PATH
     datadog (2.7.0)
       datadog-ruby_core_source (~> 3.3)
       libdatadog (~> 14.1.0.1.0)
-      libddwaf (~> 1.15.0.0.0)
+      libddwaf (~> 1.18.0.0.0)
       msgpack
 
 GEM
@@ -55,9 +55,9 @@ GEM
       addressable (>= 2.4)
     libdatadog (14.1.0.1.0-aarch64-linux)
     libdatadog (14.1.0.1.0-x86_64-linux)
-    libddwaf (1.15.0.0.0-aarch64-linux)
+    libddwaf (1.18.0.0.0-aarch64-linux)
       ffi (~> 1.0)
-    libddwaf (1.15.0.0.0-x86_64-linux)
+    libddwaf (1.18.0.0.0-x86_64-linux)
       ffi (~> 1.0)
     memory_profiler (0.9.14)
     method_source (1.1.0)

--- a/gemfiles/ruby_2.7_stripe_min.gemfile.lock
+++ b/gemfiles/ruby_2.7_stripe_min.gemfile.lock
@@ -14,7 +14,7 @@ PATH
     datadog (2.7.0)
       datadog-ruby_core_source (~> 3.3)
       libdatadog (~> 14.1.0.1.0)
-      libddwaf (~> 1.15.0.0.0)
+      libddwaf (~> 1.18.0.0.0)
       msgpack
 
 GEM
@@ -56,9 +56,9 @@ GEM
       addressable (>= 2.4)
     libdatadog (14.1.0.1.0-aarch64-linux)
     libdatadog (14.1.0.1.0-x86_64-linux)
-    libddwaf (1.15.0.0.0-aarch64-linux)
+    libddwaf (1.18.0.0.0-aarch64-linux)
       ffi (~> 1.0)
-    libddwaf (1.15.0.0.0-x86_64-linux)
+    libddwaf (1.18.0.0.0-x86_64-linux)
       ffi (~> 1.0)
     memory_profiler (0.9.14)
     method_source (1.1.0)

--- a/gemfiles/ruby_3.0_activesupport.gemfile.lock
+++ b/gemfiles/ruby_3.0_activesupport.gemfile.lock
@@ -14,7 +14,7 @@ PATH
     datadog (2.7.0)
       datadog-ruby_core_source (~> 3.3)
       libdatadog (~> 14.1.0.1.0)
-      libddwaf (~> 1.15.0.0.0)
+      libddwaf (~> 1.18.0.0.0)
       msgpack
 
 GEM
@@ -110,9 +110,9 @@ GEM
     king_konf (1.0.1)
     libdatadog (14.1.0.1.0-aarch64-linux)
     libdatadog (14.1.0.1.0-x86_64-linux)
-    libddwaf (1.15.0.0.0-aarch64-linux)
+    libddwaf (1.18.0.0.0-aarch64-linux)
       ffi (~> 1.0)
-    libddwaf (1.15.0.0.0-x86_64-linux)
+    libddwaf (1.18.0.0.0-x86_64-linux)
       ffi (~> 1.0)
     lograge (0.13.0)
       actionpack (>= 4)

--- a/gemfiles/ruby_3.0_aws.gemfile.lock
+++ b/gemfiles/ruby_3.0_aws.gemfile.lock
@@ -14,7 +14,7 @@ PATH
     datadog (2.7.0)
       datadog-ruby_core_source (~> 3.3)
       libdatadog (~> 14.1.0.1.0)
-      libddwaf (~> 1.15.0.0.0)
+      libddwaf (~> 1.18.0.0.0)
       msgpack
 
 GEM
@@ -1475,9 +1475,9 @@ GEM
       addressable (>= 2.4)
     libdatadog (14.1.0.1.0-aarch64-linux)
     libdatadog (14.1.0.1.0-x86_64-linux)
-    libddwaf (1.15.0.0.0-aarch64-linux)
+    libddwaf (1.18.0.0.0-aarch64-linux)
       ffi (~> 1.0)
-    libddwaf (1.15.0.0.0-x86_64-linux)
+    libddwaf (1.18.0.0.0-x86_64-linux)
       ffi (~> 1.0)
     memory_profiler (0.9.14)
     method_source (1.0.0)

--- a/gemfiles/ruby_3.0_contrib.gemfile.lock
+++ b/gemfiles/ruby_3.0_contrib.gemfile.lock
@@ -14,7 +14,7 @@ PATH
     datadog (2.7.0)
       datadog-ruby_core_source (~> 3.3)
       libdatadog (~> 14.1.0.1.0)
-      libddwaf (~> 1.15.0.0.0)
+      libddwaf (~> 1.18.0.0.0)
       msgpack
 
 GEM
@@ -68,9 +68,9 @@ GEM
       addressable (>= 2.4)
     libdatadog (14.1.0.1.0-aarch64-linux)
     libdatadog (14.1.0.1.0-x86_64-linux)
-    libddwaf (1.15.0.0.0-aarch64-linux)
+    libddwaf (1.18.0.0.0-aarch64-linux)
       ffi (~> 1.0)
-    libddwaf (1.15.0.0.0-x86_64-linux)
+    libddwaf (1.18.0.0.0-x86_64-linux)
       ffi (~> 1.0)
     memory_profiler (0.9.14)
     method_source (1.0.0)

--- a/gemfiles/ruby_3.0_contrib_old.gemfile.lock
+++ b/gemfiles/ruby_3.0_contrib_old.gemfile.lock
@@ -14,7 +14,7 @@ PATH
     datadog (2.7.0)
       datadog-ruby_core_source (~> 3.3)
       libdatadog (~> 14.1.0.1.0)
-      libddwaf (~> 1.15.0.0.0)
+      libddwaf (~> 1.18.0.0.0)
       msgpack
 
 GEM
@@ -64,9 +64,9 @@ GEM
       addressable (>= 2.4)
     libdatadog (14.1.0.1.0-aarch64-linux)
     libdatadog (14.1.0.1.0-x86_64-linux)
-    libddwaf (1.15.0.0.0-aarch64-linux)
+    libddwaf (1.18.0.0.0-aarch64-linux)
       ffi (~> 1.0)
-    libddwaf (1.15.0.0.0-x86_64-linux)
+    libddwaf (1.18.0.0.0-x86_64-linux)
       ffi (~> 1.0)
     memory_profiler (0.9.14)
     method_source (1.0.0)

--- a/gemfiles/ruby_3.0_core_old.gemfile.lock
+++ b/gemfiles/ruby_3.0_core_old.gemfile.lock
@@ -14,7 +14,7 @@ PATH
     datadog (2.7.0)
       datadog-ruby_core_source (~> 3.3)
       libdatadog (~> 14.1.0.1.0)
-      libddwaf (~> 1.15.0.0.0)
+      libddwaf (~> 1.18.0.0.0)
       msgpack
 
 GEM
@@ -53,9 +53,9 @@ GEM
       addressable (>= 2.4)
     libdatadog (14.1.0.1.0-aarch64-linux)
     libdatadog (14.1.0.1.0-x86_64-linux)
-    libddwaf (1.15.0.0.0-aarch64-linux)
+    libddwaf (1.18.0.0.0-aarch64-linux)
       ffi (~> 1.0)
-    libddwaf (1.15.0.0.0-x86_64-linux)
+    libddwaf (1.18.0.0.0-x86_64-linux)
       ffi (~> 1.0)
     memory_profiler (0.9.14)
     method_source (1.0.0)

--- a/gemfiles/ruby_3.0_elasticsearch_7.gemfile.lock
+++ b/gemfiles/ruby_3.0_elasticsearch_7.gemfile.lock
@@ -14,7 +14,7 @@ PATH
     datadog (2.7.0)
       datadog-ruby_core_source (~> 3.3)
       libdatadog (~> 14.1.0.1.0)
-      libddwaf (~> 1.15.0.0.0)
+      libddwaf (~> 1.18.0.0.0)
       msgpack
 
 GEM
@@ -70,9 +70,9 @@ GEM
       addressable (>= 2.4)
     libdatadog (14.1.0.1.0-aarch64-linux)
     libdatadog (14.1.0.1.0-x86_64-linux)
-    libddwaf (1.15.0.0.0-aarch64-linux)
+    libddwaf (1.18.0.0.0-aarch64-linux)
       ffi (~> 1.0)
-    libddwaf (1.15.0.0.0-x86_64-linux)
+    libddwaf (1.18.0.0.0-x86_64-linux)
       ffi (~> 1.0)
     logger (1.6.1)
     memory_profiler (0.9.14)

--- a/gemfiles/ruby_3.0_elasticsearch_8.gemfile.lock
+++ b/gemfiles/ruby_3.0_elasticsearch_8.gemfile.lock
@@ -14,7 +14,7 @@ PATH
     datadog (2.7.0)
       datadog-ruby_core_source (~> 3.3)
       libdatadog (~> 14.1.0.1.0)
-      libddwaf (~> 1.15.0.0.0)
+      libddwaf (~> 1.18.0.0.0)
       msgpack
 
 GEM
@@ -68,9 +68,9 @@ GEM
       addressable (>= 2.4)
     libdatadog (14.1.0.1.0-aarch64-linux)
     libdatadog (14.1.0.1.0-x86_64-linux)
-    libddwaf (1.15.0.0.0-aarch64-linux)
+    libddwaf (1.18.0.0.0-aarch64-linux)
       ffi (~> 1.0)
-    libddwaf (1.15.0.0.0-x86_64-linux)
+    libddwaf (1.18.0.0.0-x86_64-linux)
       ffi (~> 1.0)
     logger (1.6.1)
     memory_profiler (0.9.14)

--- a/gemfiles/ruby_3.0_elasticsearch_latest.gemfile.lock
+++ b/gemfiles/ruby_3.0_elasticsearch_latest.gemfile.lock
@@ -14,7 +14,7 @@ PATH
     datadog (2.7.0)
       datadog-ruby_core_source (~> 3.3)
       libdatadog (~> 14.1.0.1.0)
-      libddwaf (~> 1.15.0.0.0)
+      libddwaf (~> 1.18.0.0.0)
       msgpack
 
 GEM
@@ -70,9 +70,9 @@ GEM
       addressable (>= 2.4)
     libdatadog (14.1.0.1.0-aarch64-linux)
     libdatadog (14.1.0.1.0-x86_64-linux)
-    libddwaf (1.15.0.0.0-aarch64-linux)
+    libddwaf (1.18.0.0.0-aarch64-linux)
       ffi (~> 1.0)
-    libddwaf (1.15.0.0.0-x86_64-linux)
+    libddwaf (1.18.0.0.0-x86_64-linux)
       ffi (~> 1.0)
     logger (1.6.1)
     memory_profiler (0.9.14)

--- a/gemfiles/ruby_3.0_graphql_1.13.gemfile.lock
+++ b/gemfiles/ruby_3.0_graphql_1.13.gemfile.lock
@@ -14,7 +14,7 @@ PATH
     datadog (2.7.0)
       datadog-ruby_core_source (~> 3.3)
       libdatadog (~> 14.1.0.1.0)
-      libddwaf (~> 1.15.0.0.0)
+      libddwaf (~> 1.18.0.0.0)
       msgpack
 
 GEM
@@ -123,9 +123,9 @@ GEM
       addressable (>= 2.4)
     libdatadog (14.1.0.1.0-aarch64-linux)
     libdatadog (14.1.0.1.0-x86_64-linux)
-    libddwaf (1.15.0.0.0-aarch64-linux)
+    libddwaf (1.18.0.0.0-aarch64-linux)
       ffi (~> 1.0)
-    libddwaf (1.15.0.0.0-x86_64-linux)
+    libddwaf (1.18.0.0.0-x86_64-linux)
       ffi (~> 1.0)
     lograge (0.14.0)
       actionpack (>= 4)

--- a/gemfiles/ruby_3.0_graphql_2.0.gemfile.lock
+++ b/gemfiles/ruby_3.0_graphql_2.0.gemfile.lock
@@ -14,7 +14,7 @@ PATH
     datadog (2.7.0)
       datadog-ruby_core_source (~> 3.3)
       libdatadog (~> 14.1.0.1.0)
-      libddwaf (~> 1.15.0.0.0)
+      libddwaf (~> 1.18.0.0.0)
       msgpack
 
 GEM
@@ -123,9 +123,9 @@ GEM
       addressable (>= 2.4)
     libdatadog (14.1.0.1.0-aarch64-linux)
     libdatadog (14.1.0.1.0-x86_64-linux)
-    libddwaf (1.15.0.0.0-aarch64-linux)
+    libddwaf (1.18.0.0.0-aarch64-linux)
       ffi (~> 1.0)
-    libddwaf (1.15.0.0.0-x86_64-linux)
+    libddwaf (1.18.0.0.0-x86_64-linux)
       ffi (~> 1.0)
     lograge (0.14.0)
       actionpack (>= 4)

--- a/gemfiles/ruby_3.0_graphql_2.1.gemfile.lock
+++ b/gemfiles/ruby_3.0_graphql_2.1.gemfile.lock
@@ -14,7 +14,7 @@ PATH
     datadog (2.7.0)
       datadog-ruby_core_source (~> 3.3)
       libdatadog (~> 14.1.0.1.0)
-      libddwaf (~> 1.15.0.0.0)
+      libddwaf (~> 1.18.0.0.0)
       msgpack
 
 GEM
@@ -124,9 +124,9 @@ GEM
       addressable (>= 2.4)
     libdatadog (14.1.0.1.0-aarch64-linux)
     libdatadog (14.1.0.1.0-x86_64-linux)
-    libddwaf (1.15.0.0.0-aarch64-linux)
+    libddwaf (1.18.0.0.0-aarch64-linux)
       ffi (~> 1.0)
-    libddwaf (1.15.0.0.0-x86_64-linux)
+    libddwaf (1.18.0.0.0-x86_64-linux)
       ffi (~> 1.0)
     lograge (0.14.0)
       actionpack (>= 4)

--- a/gemfiles/ruby_3.0_graphql_2.2.gemfile.lock
+++ b/gemfiles/ruby_3.0_graphql_2.2.gemfile.lock
@@ -14,7 +14,7 @@ PATH
     datadog (2.7.0)
       datadog-ruby_core_source (~> 3.3)
       libdatadog (~> 14.1.0.1.0)
-      libddwaf (~> 1.15.0.0.0)
+      libddwaf (~> 1.18.0.0.0)
       msgpack
 
 GEM
@@ -124,9 +124,9 @@ GEM
       addressable (>= 2.4)
     libdatadog (14.1.0.1.0-aarch64-linux)
     libdatadog (14.1.0.1.0-x86_64-linux)
-    libddwaf (1.15.0.0.0-aarch64-linux)
+    libddwaf (1.18.0.0.0-aarch64-linux)
       ffi (~> 1.0)
-    libddwaf (1.15.0.0.0-x86_64-linux)
+    libddwaf (1.18.0.0.0-x86_64-linux)
       ffi (~> 1.0)
     lograge (0.14.0)
       actionpack (>= 4)

--- a/gemfiles/ruby_3.0_graphql_2.3.gemfile.lock
+++ b/gemfiles/ruby_3.0_graphql_2.3.gemfile.lock
@@ -14,7 +14,7 @@ PATH
     datadog (2.7.0)
       datadog-ruby_core_source (~> 3.3)
       libdatadog (~> 14.1.0.1.0)
-      libddwaf (~> 1.15.0.0.0)
+      libddwaf (~> 1.18.0.0.0)
       msgpack
 
 GEM
@@ -126,9 +126,9 @@ GEM
       addressable (>= 2.4)
     libdatadog (14.1.0.1.0-aarch64-linux)
     libdatadog (14.1.0.1.0-x86_64-linux)
-    libddwaf (1.15.0.0.0-aarch64-linux)
+    libddwaf (1.18.0.0.0-aarch64-linux)
       ffi (~> 1.0)
-    libddwaf (1.15.0.0.0-x86_64-linux)
+    libddwaf (1.18.0.0.0-x86_64-linux)
       ffi (~> 1.0)
     lograge (0.14.0)
       actionpack (>= 4)

--- a/gemfiles/ruby_3.0_http.gemfile.lock
+++ b/gemfiles/ruby_3.0_http.gemfile.lock
@@ -14,7 +14,7 @@ PATH
     datadog (2.7.0)
       datadog-ruby_core_source (~> 3.3)
       libdatadog (~> 14.1.0.1.0)
-      libddwaf (~> 1.15.0.0.0)
+      libddwaf (~> 1.18.0.0.0)
       msgpack
 
 GEM
@@ -75,9 +75,9 @@ GEM
       addressable (>= 2.4)
     libdatadog (14.1.0.1.0-aarch64-linux)
     libdatadog (14.1.0.1.0-x86_64-linux)
-    libddwaf (1.15.0.0.0-aarch64-linux)
+    libddwaf (1.18.0.0.0-aarch64-linux)
       ffi (~> 1.0)
-    libddwaf (1.15.0.0.0-x86_64-linux)
+    libddwaf (1.18.0.0.0-x86_64-linux)
       ffi (~> 1.0)
     llhttp-ffi (0.3.1)
       ffi-compiler (~> 1.0)

--- a/gemfiles/ruby_3.0_opensearch_2.gemfile.lock
+++ b/gemfiles/ruby_3.0_opensearch_2.gemfile.lock
@@ -14,7 +14,7 @@ PATH
     datadog (2.7.0)
       datadog-ruby_core_source (~> 3.3)
       libdatadog (~> 14.1.0.1.0)
-      libddwaf (~> 1.15.0.0.0)
+      libddwaf (~> 1.18.0.0.0)
       msgpack
 
 GEM
@@ -60,9 +60,9 @@ GEM
       addressable (>= 2.4)
     libdatadog (14.1.0.1.0-aarch64-linux)
     libdatadog (14.1.0.1.0-x86_64-linux)
-    libddwaf (1.15.0.0.0-aarch64-linux)
+    libddwaf (1.18.0.0.0-aarch64-linux)
       ffi (~> 1.0)
-    libddwaf (1.15.0.0.0-x86_64-linux)
+    libddwaf (1.18.0.0.0-x86_64-linux)
       ffi (~> 1.0)
     logger (1.6.1)
     memory_profiler (0.9.14)

--- a/gemfiles/ruby_3.0_opensearch_3.gemfile.lock
+++ b/gemfiles/ruby_3.0_opensearch_3.gemfile.lock
@@ -14,7 +14,7 @@ PATH
     datadog (2.7.0)
       datadog-ruby_core_source (~> 3.3)
       libdatadog (~> 14.1.0.1.0)
-      libddwaf (~> 1.15.0.0.0)
+      libddwaf (~> 1.18.0.0.0)
       msgpack
 
 GEM
@@ -60,9 +60,9 @@ GEM
       addressable (>= 2.4)
     libdatadog (14.1.0.1.0-aarch64-linux)
     libdatadog (14.1.0.1.0-x86_64-linux)
-    libddwaf (1.15.0.0.0-aarch64-linux)
+    libddwaf (1.18.0.0.0-aarch64-linux)
       ffi (~> 1.0)
-    libddwaf (1.15.0.0.0-x86_64-linux)
+    libddwaf (1.18.0.0.0-x86_64-linux)
       ffi (~> 1.0)
     logger (1.6.1)
     memory_profiler (0.9.14)

--- a/gemfiles/ruby_3.0_opensearch_latest.gemfile.lock
+++ b/gemfiles/ruby_3.0_opensearch_latest.gemfile.lock
@@ -14,7 +14,7 @@ PATH
     datadog (2.7.0)
       datadog-ruby_core_source (~> 3.3)
       libdatadog (~> 14.1.0.1.0)
-      libddwaf (~> 1.15.0.0.0)
+      libddwaf (~> 1.18.0.0.0)
       msgpack
 
 GEM
@@ -62,9 +62,9 @@ GEM
       addressable (>= 2.4)
     libdatadog (14.1.0.1.0-aarch64-linux)
     libdatadog (14.1.0.1.0-x86_64-linux)
-    libddwaf (1.15.0.0.0-aarch64-linux)
+    libddwaf (1.18.0.0.0-aarch64-linux)
       ffi (~> 1.0)
-    libddwaf (1.15.0.0.0-x86_64-linux)
+    libddwaf (1.18.0.0.0-x86_64-linux)
       ffi (~> 1.0)
     logger (1.6.1)
     memory_profiler (0.9.14)

--- a/gemfiles/ruby_3.0_opentelemetry.gemfile.lock
+++ b/gemfiles/ruby_3.0_opentelemetry.gemfile.lock
@@ -14,7 +14,7 @@ PATH
     datadog (2.7.0)
       datadog-ruby_core_source (~> 3.3)
       libdatadog (~> 14.1.0.1.0)
-      libddwaf (~> 1.15.0.0.0)
+      libddwaf (~> 1.18.0.0.0)
       msgpack
 
 GEM
@@ -53,9 +53,9 @@ GEM
       addressable (>= 2.4)
     libdatadog (14.1.0.1.0-aarch64-linux)
     libdatadog (14.1.0.1.0-x86_64-linux)
-    libddwaf (1.15.0.0.0-aarch64-linux)
+    libddwaf (1.18.0.0.0-aarch64-linux)
       ffi (~> 1.0)
-    libddwaf (1.15.0.0.0-x86_64-linux)
+    libddwaf (1.18.0.0.0-x86_64-linux)
       ffi (~> 1.0)
     memory_profiler (0.9.14)
     method_source (1.0.0)

--- a/gemfiles/ruby_3.0_opentelemetry_otlp.gemfile.lock
+++ b/gemfiles/ruby_3.0_opentelemetry_otlp.gemfile.lock
@@ -14,7 +14,7 @@ PATH
     datadog (2.7.0)
       datadog-ruby_core_source (~> 3.3)
       libdatadog (~> 14.1.0.1.0)
-      libddwaf (~> 1.15.0.0.0)
+      libddwaf (~> 1.18.0.0.0)
       msgpack
 
 GEM
@@ -58,9 +58,9 @@ GEM
       addressable (>= 2.4)
     libdatadog (14.1.0.1.0-aarch64-linux)
     libdatadog (14.1.0.1.0-x86_64-linux)
-    libddwaf (1.15.0.0.0-aarch64-linux)
+    libddwaf (1.18.0.0.0-aarch64-linux)
       ffi (~> 1.0)
-    libddwaf (1.15.0.0.0-x86_64-linux)
+    libddwaf (1.18.0.0.0-x86_64-linux)
       ffi (~> 1.0)
     memory_profiler (0.9.14)
     method_source (1.0.0)

--- a/gemfiles/ruby_3.0_rack_1.gemfile.lock
+++ b/gemfiles/ruby_3.0_rack_1.gemfile.lock
@@ -14,7 +14,7 @@ PATH
     datadog (2.7.0)
       datadog-ruby_core_source (~> 3.3)
       libdatadog (~> 14.1.0.1.0)
-      libddwaf (~> 1.15.0.0.0)
+      libddwaf (~> 1.18.0.0.0)
       msgpack
 
 GEM
@@ -53,9 +53,9 @@ GEM
       addressable (>= 2.4)
     libdatadog (14.1.0.1.0-aarch64-linux)
     libdatadog (14.1.0.1.0-x86_64-linux)
-    libddwaf (1.15.0.0.0-aarch64-linux)
+    libddwaf (1.18.0.0.0-aarch64-linux)
       ffi (~> 1.0)
-    libddwaf (1.15.0.0.0-x86_64-linux)
+    libddwaf (1.18.0.0.0-x86_64-linux)
       ffi (~> 1.0)
     memory_profiler (0.9.14)
     method_source (1.0.0)

--- a/gemfiles/ruby_3.0_rack_2.gemfile.lock
+++ b/gemfiles/ruby_3.0_rack_2.gemfile.lock
@@ -14,7 +14,7 @@ PATH
     datadog (2.7.0)
       datadog-ruby_core_source (~> 3.3)
       libdatadog (~> 14.1.0.1.0)
-      libddwaf (~> 1.15.0.0.0)
+      libddwaf (~> 1.18.0.0.0)
       msgpack
 
 GEM
@@ -53,9 +53,9 @@ GEM
       addressable (>= 2.4)
     libdatadog (14.1.0.1.0-aarch64-linux)
     libdatadog (14.1.0.1.0-x86_64-linux)
-    libddwaf (1.15.0.0.0-aarch64-linux)
+    libddwaf (1.18.0.0.0-aarch64-linux)
       ffi (~> 1.0)
-    libddwaf (1.15.0.0.0-x86_64-linux)
+    libddwaf (1.18.0.0.0-x86_64-linux)
       ffi (~> 1.0)
     memory_profiler (0.9.14)
     method_source (1.0.0)

--- a/gemfiles/ruby_3.0_rack_3.gemfile.lock
+++ b/gemfiles/ruby_3.0_rack_3.gemfile.lock
@@ -14,7 +14,7 @@ PATH
     datadog (2.7.0)
       datadog-ruby_core_source (~> 3.3)
       libdatadog (~> 14.1.0.1.0)
-      libddwaf (~> 1.15.0.0.0)
+      libddwaf (~> 1.18.0.0.0)
       msgpack
 
 GEM
@@ -53,9 +53,9 @@ GEM
       addressable (>= 2.4)
     libdatadog (14.1.0.1.0-aarch64-linux)
     libdatadog (14.1.0.1.0-x86_64-linux)
-    libddwaf (1.15.0.0.0-aarch64-linux)
+    libddwaf (1.18.0.0.0-aarch64-linux)
       ffi (~> 1.0)
-    libddwaf (1.15.0.0.0-x86_64-linux)
+    libddwaf (1.18.0.0.0-x86_64-linux)
       ffi (~> 1.0)
     memory_profiler (0.9.14)
     method_source (1.0.0)

--- a/gemfiles/ruby_3.0_rack_latest.gemfile.lock
+++ b/gemfiles/ruby_3.0_rack_latest.gemfile.lock
@@ -14,7 +14,7 @@ PATH
     datadog (2.7.0)
       datadog-ruby_core_source (~> 3.3)
       libdatadog (~> 14.1.0.1.0)
-      libddwaf (~> 1.15.0.0.0)
+      libddwaf (~> 1.18.0.0.0)
       msgpack
 
 GEM
@@ -56,9 +56,9 @@ GEM
       addressable (>= 2.4)
     libdatadog (14.1.0.1.0-aarch64-linux)
     libdatadog (14.1.0.1.0-x86_64-linux)
-    libddwaf (1.15.0.0.0-aarch64-linux)
+    libddwaf (1.18.0.0.0-aarch64-linux)
       ffi (~> 1.0)
-    libddwaf (1.15.0.0.0-x86_64-linux)
+    libddwaf (1.18.0.0.0-x86_64-linux)
       ffi (~> 1.0)
     memory_profiler (0.9.14)
     method_source (1.1.0)

--- a/gemfiles/ruby_3.0_rails61_mysql2.gemfile.lock
+++ b/gemfiles/ruby_3.0_rails61_mysql2.gemfile.lock
@@ -14,7 +14,7 @@ PATH
     datadog (2.7.0)
       datadog-ruby_core_source (~> 3.3)
       libdatadog (~> 14.1.0.1.0)
-      libddwaf (~> 1.15.0.0.0)
+      libddwaf (~> 1.18.0.0.0)
       msgpack
 
 GEM
@@ -120,9 +120,9 @@ GEM
       addressable (>= 2.4)
     libdatadog (14.1.0.1.0-aarch64-linux)
     libdatadog (14.1.0.1.0-x86_64-linux)
-    libddwaf (1.15.0.0.0-aarch64-linux)
+    libddwaf (1.18.0.0.0-aarch64-linux)
       ffi (~> 1.0)
-    libddwaf (1.15.0.0.0-x86_64-linux)
+    libddwaf (1.18.0.0.0-x86_64-linux)
       ffi (~> 1.0)
     lograge (0.12.0)
       actionpack (>= 4)

--- a/gemfiles/ruby_3.0_rails61_postgres.gemfile.lock
+++ b/gemfiles/ruby_3.0_rails61_postgres.gemfile.lock
@@ -14,7 +14,7 @@ PATH
     datadog (2.7.0)
       datadog-ruby_core_source (~> 3.3)
       libdatadog (~> 14.1.0.1.0)
-      libddwaf (~> 1.15.0.0.0)
+      libddwaf (~> 1.18.0.0.0)
       msgpack
 
 GEM
@@ -120,9 +120,9 @@ GEM
       addressable (>= 2.4)
     libdatadog (14.1.0.1.0-aarch64-linux)
     libdatadog (14.1.0.1.0-x86_64-linux)
-    libddwaf (1.15.0.0.0-aarch64-linux)
+    libddwaf (1.18.0.0.0-aarch64-linux)
       ffi (~> 1.0)
-    libddwaf (1.15.0.0.0-x86_64-linux)
+    libddwaf (1.18.0.0.0-x86_64-linux)
       ffi (~> 1.0)
     lograge (0.12.0)
       actionpack (>= 4)

--- a/gemfiles/ruby_3.0_rails61_postgres_redis.gemfile.lock
+++ b/gemfiles/ruby_3.0_rails61_postgres_redis.gemfile.lock
@@ -14,7 +14,7 @@ PATH
     datadog (2.7.0)
       datadog-ruby_core_source (~> 3.3)
       libdatadog (~> 14.1.0.1.0)
-      libddwaf (~> 1.15.0.0.0)
+      libddwaf (~> 1.18.0.0.0)
       msgpack
 
 GEM
@@ -120,9 +120,9 @@ GEM
       addressable (>= 2.4)
     libdatadog (14.1.0.1.0-aarch64-linux)
     libdatadog (14.1.0.1.0-x86_64-linux)
-    libddwaf (1.15.0.0.0-aarch64-linux)
+    libddwaf (1.18.0.0.0-aarch64-linux)
       ffi (~> 1.0)
-    libddwaf (1.15.0.0.0-x86_64-linux)
+    libddwaf (1.18.0.0.0-x86_64-linux)
       ffi (~> 1.0)
     lograge (0.12.0)
       actionpack (>= 4)

--- a/gemfiles/ruby_3.0_rails61_postgres_sidekiq.gemfile.lock
+++ b/gemfiles/ruby_3.0_rails61_postgres_sidekiq.gemfile.lock
@@ -14,7 +14,7 @@ PATH
     datadog (2.7.0)
       datadog-ruby_core_source (~> 3.3)
       libdatadog (~> 14.1.0.1.0)
-      libddwaf (~> 1.15.0.0.0)
+      libddwaf (~> 1.18.0.0.0)
       msgpack
 
 GEM
@@ -121,9 +121,9 @@ GEM
       addressable (>= 2.4)
     libdatadog (14.1.0.1.0-aarch64-linux)
     libdatadog (14.1.0.1.0-x86_64-linux)
-    libddwaf (1.15.0.0.0-aarch64-linux)
+    libddwaf (1.18.0.0.0-aarch64-linux)
       ffi (~> 1.0)
-    libddwaf (1.15.0.0.0-x86_64-linux)
+    libddwaf (1.18.0.0.0-x86_64-linux)
       ffi (~> 1.0)
     lograge (0.12.0)
       actionpack (>= 4)

--- a/gemfiles/ruby_3.0_rails61_semantic_logger.gemfile.lock
+++ b/gemfiles/ruby_3.0_rails61_semantic_logger.gemfile.lock
@@ -14,7 +14,7 @@ PATH
     datadog (2.7.0)
       datadog-ruby_core_source (~> 3.3)
       libdatadog (~> 14.1.0.1.0)
-      libddwaf (~> 1.15.0.0.0)
+      libddwaf (~> 1.18.0.0.0)
       msgpack
 
 GEM
@@ -120,9 +120,9 @@ GEM
       addressable (>= 2.4)
     libdatadog (14.1.0.1.0-aarch64-linux)
     libdatadog (14.1.0.1.0-x86_64-linux)
-    libddwaf (1.15.0.0.0-aarch64-linux)
+    libddwaf (1.18.0.0.0-aarch64-linux)
       ffi (~> 1.0)
-    libddwaf (1.15.0.0.0-x86_64-linux)
+    libddwaf (1.18.0.0.0-x86_64-linux)
       ffi (~> 1.0)
     loofah (2.19.1)
       crass (~> 1.0.2)

--- a/gemfiles/ruby_3.0_rails61_trilogy.gemfile.lock
+++ b/gemfiles/ruby_3.0_rails61_trilogy.gemfile.lock
@@ -14,7 +14,7 @@ PATH
     datadog (2.7.0)
       datadog-ruby_core_source (~> 3.3)
       libdatadog (~> 14.1.0.1.0)
-      libddwaf (~> 1.15.0.0.0)
+      libddwaf (~> 1.18.0.0.0)
       msgpack
 
 GEM
@@ -124,9 +124,9 @@ GEM
       addressable (>= 2.4)
     libdatadog (14.1.0.1.0-aarch64-linux)
     libdatadog (14.1.0.1.0-x86_64-linux)
-    libddwaf (1.15.0.0.0-aarch64-linux)
+    libddwaf (1.18.0.0.0-aarch64-linux)
       ffi (~> 1.0)
-    libddwaf (1.15.0.0.0-x86_64-linux)
+    libddwaf (1.18.0.0.0-x86_64-linux)
       ffi (~> 1.0)
     lograge (0.14.0)
       actionpack (>= 4)

--- a/gemfiles/ruby_3.0_rails7.gemfile.lock
+++ b/gemfiles/ruby_3.0_rails7.gemfile.lock
@@ -14,7 +14,7 @@ PATH
     datadog (2.7.0)
       datadog-ruby_core_source (~> 3.3)
       libdatadog (~> 14.1.0.1.0)
-      libddwaf (~> 1.15.0.0.0)
+      libddwaf (~> 1.18.0.0.0)
       msgpack
 
 GEM
@@ -129,9 +129,9 @@ GEM
       addressable (>= 2.4)
     libdatadog (14.1.0.1.0-aarch64-linux)
     libdatadog (14.1.0.1.0-x86_64-linux)
-    libddwaf (1.15.0.0.0-aarch64-linux)
+    libddwaf (1.18.0.0.0-aarch64-linux)
       ffi (~> 1.0)
-    libddwaf (1.15.0.0.0-x86_64-linux)
+    libddwaf (1.18.0.0.0-x86_64-linux)
       ffi (~> 1.0)
     loofah (2.22.0)
       crass (~> 1.0.2)

--- a/gemfiles/ruby_3.0_rails71.gemfile.lock
+++ b/gemfiles/ruby_3.0_rails71.gemfile.lock
@@ -14,7 +14,7 @@ PATH
     datadog (2.7.0)
       datadog-ruby_core_source (~> 3.3)
       libdatadog (~> 14.1.0.1.0)
-      libddwaf (~> 1.15.0.0.0)
+      libddwaf (~> 1.18.0.0.0)
       msgpack
 
 GEM
@@ -145,9 +145,9 @@ GEM
       addressable (>= 2.4)
     libdatadog (14.1.0.1.0-aarch64-linux)
     libdatadog (14.1.0.1.0-x86_64-linux)
-    libddwaf (1.15.0.0.0-aarch64-linux)
+    libddwaf (1.18.0.0.0-aarch64-linux)
       ffi (~> 1.0)
-    libddwaf (1.15.0.0.0-x86_64-linux)
+    libddwaf (1.18.0.0.0-x86_64-linux)
       ffi (~> 1.0)
     loofah (2.22.0)
       crass (~> 1.0.2)

--- a/gemfiles/ruby_3.0_redis_3.gemfile.lock
+++ b/gemfiles/ruby_3.0_redis_3.gemfile.lock
@@ -14,7 +14,7 @@ PATH
     datadog (2.7.0)
       datadog-ruby_core_source (~> 3.3)
       libdatadog (~> 14.1.0.1.0)
-      libddwaf (~> 1.15.0.0.0)
+      libddwaf (~> 1.18.0.0.0)
       msgpack
 
 GEM
@@ -53,9 +53,9 @@ GEM
       addressable (>= 2.4)
     libdatadog (14.1.0.1.0-aarch64-linux)
     libdatadog (14.1.0.1.0-x86_64-linux)
-    libddwaf (1.15.0.0.0-aarch64-linux)
+    libddwaf (1.18.0.0.0-aarch64-linux)
       ffi (~> 1.0)
-    libddwaf (1.15.0.0.0-x86_64-linux)
+    libddwaf (1.18.0.0.0-x86_64-linux)
       ffi (~> 1.0)
     memory_profiler (0.9.14)
     method_source (1.0.0)

--- a/gemfiles/ruby_3.0_redis_4.gemfile.lock
+++ b/gemfiles/ruby_3.0_redis_4.gemfile.lock
@@ -14,7 +14,7 @@ PATH
     datadog (2.7.0)
       datadog-ruby_core_source (~> 3.3)
       libdatadog (~> 14.1.0.1.0)
-      libddwaf (~> 1.15.0.0.0)
+      libddwaf (~> 1.18.0.0.0)
       msgpack
 
 GEM
@@ -53,9 +53,9 @@ GEM
       addressable (>= 2.4)
     libdatadog (14.1.0.1.0-aarch64-linux)
     libdatadog (14.1.0.1.0-x86_64-linux)
-    libddwaf (1.15.0.0.0-aarch64-linux)
+    libddwaf (1.18.0.0.0-aarch64-linux)
       ffi (~> 1.0)
-    libddwaf (1.15.0.0.0-x86_64-linux)
+    libddwaf (1.18.0.0.0-x86_64-linux)
       ffi (~> 1.0)
     memory_profiler (0.9.14)
     method_source (1.0.0)

--- a/gemfiles/ruby_3.0_redis_5.gemfile.lock
+++ b/gemfiles/ruby_3.0_redis_5.gemfile.lock
@@ -14,7 +14,7 @@ PATH
     datadog (2.7.0)
       datadog-ruby_core_source (~> 3.3)
       libdatadog (~> 14.1.0.1.0)
-      libddwaf (~> 1.15.0.0.0)
+      libddwaf (~> 1.18.0.0.0)
       msgpack
 
 GEM
@@ -54,9 +54,9 @@ GEM
       addressable (>= 2.4)
     libdatadog (14.1.0.1.0-aarch64-linux)
     libdatadog (14.1.0.1.0-x86_64-linux)
-    libddwaf (1.15.0.0.0-aarch64-linux)
+    libddwaf (1.18.0.0.0-aarch64-linux)
       ffi (~> 1.0)
-    libddwaf (1.15.0.0.0-x86_64-linux)
+    libddwaf (1.18.0.0.0-x86_64-linux)
       ffi (~> 1.0)
     memory_profiler (0.9.14)
     method_source (1.0.0)

--- a/gemfiles/ruby_3.0_relational_db.gemfile.lock
+++ b/gemfiles/ruby_3.0_relational_db.gemfile.lock
@@ -14,7 +14,7 @@ PATH
     datadog (2.7.0)
       datadog-ruby_core_source (~> 3.3)
       libdatadog (~> 14.1.0.1.0)
-      libddwaf (~> 1.15.0.0.0)
+      libddwaf (~> 1.18.0.0.0)
       msgpack
 
 GEM
@@ -71,9 +71,9 @@ GEM
       addressable (>= 2.4)
     libdatadog (14.1.0.1.0-aarch64-linux)
     libdatadog (14.1.0.1.0-x86_64-linux)
-    libddwaf (1.15.0.0.0-aarch64-linux)
+    libddwaf (1.18.0.0.0-aarch64-linux)
       ffi (~> 1.0)
-    libddwaf (1.15.0.0.0-x86_64-linux)
+    libddwaf (1.18.0.0.0-x86_64-linux)
       ffi (~> 1.0)
     makara (0.6.0.pre)
       activerecord (>= 5.2.0)

--- a/gemfiles/ruby_3.0_resque2_redis3.gemfile.lock
+++ b/gemfiles/ruby_3.0_resque2_redis3.gemfile.lock
@@ -14,7 +14,7 @@ PATH
     datadog (2.7.0)
       datadog-ruby_core_source (~> 3.3)
       libdatadog (~> 14.1.0.1.0)
-      libddwaf (~> 1.15.0.0.0)
+      libddwaf (~> 1.18.0.0.0)
       msgpack
 
 GEM
@@ -53,9 +53,9 @@ GEM
       addressable (>= 2.4)
     libdatadog (14.1.0.1.0-aarch64-linux)
     libdatadog (14.1.0.1.0-x86_64-linux)
-    libddwaf (1.15.0.0.0-aarch64-linux)
+    libddwaf (1.18.0.0.0-aarch64-linux)
       ffi (~> 1.0)
-    libddwaf (1.15.0.0.0-x86_64-linux)
+    libddwaf (1.18.0.0.0-x86_64-linux)
       ffi (~> 1.0)
     memory_profiler (0.9.14)
     method_source (1.0.0)

--- a/gemfiles/ruby_3.0_resque2_redis4.gemfile.lock
+++ b/gemfiles/ruby_3.0_resque2_redis4.gemfile.lock
@@ -14,7 +14,7 @@ PATH
     datadog (2.7.0)
       datadog-ruby_core_source (~> 3.3)
       libdatadog (~> 14.1.0.1.0)
-      libddwaf (~> 1.15.0.0.0)
+      libddwaf (~> 1.18.0.0.0)
       msgpack
 
 GEM
@@ -54,9 +54,9 @@ GEM
       addressable (>= 2.4)
     libdatadog (14.1.0.1.0-aarch64-linux)
     libdatadog (14.1.0.1.0-x86_64-linux)
-    libddwaf (1.15.0.0.0-aarch64-linux)
+    libddwaf (1.18.0.0.0-aarch64-linux)
       ffi (~> 1.0)
-    libddwaf (1.15.0.0.0-x86_64-linux)
+    libddwaf (1.18.0.0.0-x86_64-linux)
       ffi (~> 1.0)
     memory_profiler (0.9.14)
     method_source (1.0.0)

--- a/gemfiles/ruby_3.0_sinatra_2.gemfile.lock
+++ b/gemfiles/ruby_3.0_sinatra_2.gemfile.lock
@@ -14,7 +14,7 @@ PATH
     datadog (2.7.0)
       datadog-ruby_core_source (~> 3.3)
       libdatadog (~> 14.1.0.1.0)
-      libddwaf (~> 1.15.0.0.0)
+      libddwaf (~> 1.18.0.0.0)
       msgpack
 
 GEM
@@ -56,9 +56,9 @@ GEM
       addressable (>= 2.4)
     libdatadog (14.1.0.1.0-aarch64-linux)
     libdatadog (14.1.0.1.0-x86_64-linux)
-    libddwaf (1.15.0.0.0-aarch64-linux)
+    libddwaf (1.18.0.0.0-aarch64-linux)
       ffi (~> 1.0)
-    libddwaf (1.15.0.0.0-x86_64-linux)
+    libddwaf (1.18.0.0.0-x86_64-linux)
       ffi (~> 1.0)
     memory_profiler (0.9.14)
     method_source (1.1.0)

--- a/gemfiles/ruby_3.0_sinatra_3.gemfile.lock
+++ b/gemfiles/ruby_3.0_sinatra_3.gemfile.lock
@@ -14,7 +14,7 @@ PATH
     datadog (2.7.0)
       datadog-ruby_core_source (~> 3.3)
       libdatadog (~> 14.1.0.1.0)
-      libddwaf (~> 1.15.0.0.0)
+      libddwaf (~> 1.18.0.0.0)
       msgpack
 
 GEM
@@ -57,9 +57,9 @@ GEM
       addressable (>= 2.4)
     libdatadog (14.1.0.1.0-aarch64-linux)
     libdatadog (14.1.0.1.0-x86_64-linux)
-    libddwaf (1.15.0.0.0-aarch64-linux)
+    libddwaf (1.18.0.0.0-aarch64-linux)
       ffi (~> 1.0)
-    libddwaf (1.15.0.0.0-x86_64-linux)
+    libddwaf (1.18.0.0.0-x86_64-linux)
       ffi (~> 1.0)
     memory_profiler (0.9.14)
     method_source (1.1.0)

--- a/gemfiles/ruby_3.0_sinatra_4.gemfile.lock
+++ b/gemfiles/ruby_3.0_sinatra_4.gemfile.lock
@@ -14,7 +14,7 @@ PATH
     datadog (2.7.0)
       datadog-ruby_core_source (~> 3.3)
       libdatadog (~> 14.1.0.1.0)
-      libddwaf (~> 1.15.0.0.0)
+      libddwaf (~> 1.18.0.0.0)
       msgpack
 
 GEM
@@ -57,9 +57,9 @@ GEM
       addressable (>= 2.4)
     libdatadog (14.1.0.1.0-aarch64-linux)
     libdatadog (14.1.0.1.0-x86_64-linux)
-    libddwaf (1.15.0.0.0-aarch64-linux)
+    libddwaf (1.18.0.0.0-aarch64-linux)
       ffi (~> 1.0)
-    libddwaf (1.15.0.0.0-x86_64-linux)
+    libddwaf (1.18.0.0.0-x86_64-linux)
       ffi (~> 1.0)
     memory_profiler (0.9.14)
     method_source (1.1.0)

--- a/gemfiles/ruby_3.0_stripe_10.gemfile.lock
+++ b/gemfiles/ruby_3.0_stripe_10.gemfile.lock
@@ -14,7 +14,7 @@ PATH
     datadog (2.7.0)
       datadog-ruby_core_source (~> 3.3)
       libdatadog (~> 14.1.0.1.0)
-      libddwaf (~> 1.15.0.0.0)
+      libddwaf (~> 1.18.0.0.0)
       msgpack
 
 GEM
@@ -56,9 +56,9 @@ GEM
       addressable (>= 2.4)
     libdatadog (14.1.0.1.0-aarch64-linux)
     libdatadog (14.1.0.1.0-x86_64-linux)
-    libddwaf (1.15.0.0.0-aarch64-linux)
+    libddwaf (1.18.0.0.0-aarch64-linux)
       ffi (~> 1.0)
-    libddwaf (1.15.0.0.0-x86_64-linux)
+    libddwaf (1.18.0.0.0-x86_64-linux)
       ffi (~> 1.0)
     memory_profiler (0.9.14)
     method_source (1.1.0)

--- a/gemfiles/ruby_3.0_stripe_11.gemfile.lock
+++ b/gemfiles/ruby_3.0_stripe_11.gemfile.lock
@@ -14,7 +14,7 @@ PATH
     datadog (2.7.0)
       datadog-ruby_core_source (~> 3.3)
       libdatadog (~> 14.1.0.1.0)
-      libddwaf (~> 1.15.0.0.0)
+      libddwaf (~> 1.18.0.0.0)
       msgpack
 
 GEM
@@ -56,9 +56,9 @@ GEM
       addressable (>= 2.4)
     libdatadog (14.1.0.1.0-aarch64-linux)
     libdatadog (14.1.0.1.0-x86_64-linux)
-    libddwaf (1.15.0.0.0-aarch64-linux)
+    libddwaf (1.18.0.0.0-aarch64-linux)
       ffi (~> 1.0)
-    libddwaf (1.15.0.0.0-x86_64-linux)
+    libddwaf (1.18.0.0.0-x86_64-linux)
       ffi (~> 1.0)
     memory_profiler (0.9.14)
     method_source (1.1.0)

--- a/gemfiles/ruby_3.0_stripe_12.gemfile.lock
+++ b/gemfiles/ruby_3.0_stripe_12.gemfile.lock
@@ -14,7 +14,7 @@ PATH
     datadog (2.7.0)
       datadog-ruby_core_source (~> 3.3)
       libdatadog (~> 14.1.0.1.0)
-      libddwaf (~> 1.15.0.0.0)
+      libddwaf (~> 1.18.0.0.0)
       msgpack
 
 GEM
@@ -56,9 +56,9 @@ GEM
       addressable (>= 2.4)
     libdatadog (14.1.0.1.0-aarch64-linux)
     libdatadog (14.1.0.1.0-x86_64-linux)
-    libddwaf (1.15.0.0.0-aarch64-linux)
+    libddwaf (1.18.0.0.0-aarch64-linux)
       ffi (~> 1.0)
-    libddwaf (1.15.0.0.0-x86_64-linux)
+    libddwaf (1.18.0.0.0-x86_64-linux)
       ffi (~> 1.0)
     memory_profiler (0.9.14)
     method_source (1.1.0)

--- a/gemfiles/ruby_3.0_stripe_7.gemfile.lock
+++ b/gemfiles/ruby_3.0_stripe_7.gemfile.lock
@@ -14,7 +14,7 @@ PATH
     datadog (2.7.0)
       datadog-ruby_core_source (~> 3.3)
       libdatadog (~> 14.1.0.1.0)
-      libddwaf (~> 1.15.0.0.0)
+      libddwaf (~> 1.18.0.0.0)
       msgpack
 
 GEM
@@ -56,9 +56,9 @@ GEM
       addressable (>= 2.4)
     libdatadog (14.1.0.1.0-aarch64-linux)
     libdatadog (14.1.0.1.0-x86_64-linux)
-    libddwaf (1.15.0.0.0-aarch64-linux)
+    libddwaf (1.18.0.0.0-aarch64-linux)
       ffi (~> 1.0)
-    libddwaf (1.15.0.0.0-x86_64-linux)
+    libddwaf (1.18.0.0.0-x86_64-linux)
       ffi (~> 1.0)
     memory_profiler (0.9.14)
     method_source (1.1.0)

--- a/gemfiles/ruby_3.0_stripe_8.gemfile.lock
+++ b/gemfiles/ruby_3.0_stripe_8.gemfile.lock
@@ -14,7 +14,7 @@ PATH
     datadog (2.7.0)
       datadog-ruby_core_source (~> 3.3)
       libdatadog (~> 14.1.0.1.0)
-      libddwaf (~> 1.15.0.0.0)
+      libddwaf (~> 1.18.0.0.0)
       msgpack
 
 GEM
@@ -56,9 +56,9 @@ GEM
       addressable (>= 2.4)
     libdatadog (14.1.0.1.0-aarch64-linux)
     libdatadog (14.1.0.1.0-x86_64-linux)
-    libddwaf (1.15.0.0.0-aarch64-linux)
+    libddwaf (1.18.0.0.0-aarch64-linux)
       ffi (~> 1.0)
-    libddwaf (1.15.0.0.0-x86_64-linux)
+    libddwaf (1.18.0.0.0-x86_64-linux)
       ffi (~> 1.0)
     memory_profiler (0.9.14)
     method_source (1.1.0)

--- a/gemfiles/ruby_3.0_stripe_9.gemfile.lock
+++ b/gemfiles/ruby_3.0_stripe_9.gemfile.lock
@@ -14,7 +14,7 @@ PATH
     datadog (2.7.0)
       datadog-ruby_core_source (~> 3.3)
       libdatadog (~> 14.1.0.1.0)
-      libddwaf (~> 1.15.0.0.0)
+      libddwaf (~> 1.18.0.0.0)
       msgpack
 
 GEM
@@ -56,9 +56,9 @@ GEM
       addressable (>= 2.4)
     libdatadog (14.1.0.1.0-aarch64-linux)
     libdatadog (14.1.0.1.0-x86_64-linux)
-    libddwaf (1.15.0.0.0-aarch64-linux)
+    libddwaf (1.18.0.0.0-aarch64-linux)
       ffi (~> 1.0)
-    libddwaf (1.15.0.0.0-x86_64-linux)
+    libddwaf (1.18.0.0.0-x86_64-linux)
       ffi (~> 1.0)
     memory_profiler (0.9.14)
     method_source (1.1.0)

--- a/gemfiles/ruby_3.0_stripe_latest.gemfile.lock
+++ b/gemfiles/ruby_3.0_stripe_latest.gemfile.lock
@@ -14,7 +14,7 @@ PATH
     datadog (2.7.0)
       datadog-ruby_core_source (~> 3.3)
       libdatadog (~> 14.1.0.1.0)
-      libddwaf (~> 1.15.0.0.0)
+      libddwaf (~> 1.18.0.0.0)
       msgpack
 
 GEM
@@ -56,9 +56,9 @@ GEM
       addressable (>= 2.4)
     libdatadog (14.1.0.1.0-aarch64-linux)
     libdatadog (14.1.0.1.0-x86_64-linux)
-    libddwaf (1.15.0.0.0-aarch64-linux)
+    libddwaf (1.18.0.0.0-aarch64-linux)
       ffi (~> 1.0)
-    libddwaf (1.15.0.0.0-x86_64-linux)
+    libddwaf (1.18.0.0.0-x86_64-linux)
       ffi (~> 1.0)
     memory_profiler (0.9.14)
     method_source (1.1.0)

--- a/gemfiles/ruby_3.0_stripe_min.gemfile.lock
+++ b/gemfiles/ruby_3.0_stripe_min.gemfile.lock
@@ -14,7 +14,7 @@ PATH
     datadog (2.7.0)
       datadog-ruby_core_source (~> 3.3)
       libdatadog (~> 14.1.0.1.0)
-      libddwaf (~> 1.15.0.0.0)
+      libddwaf (~> 1.18.0.0.0)
       msgpack
 
 GEM
@@ -56,9 +56,9 @@ GEM
       addressable (>= 2.4)
     libdatadog (14.1.0.1.0-aarch64-linux)
     libdatadog (14.1.0.1.0-x86_64-linux)
-    libddwaf (1.15.0.0.0-aarch64-linux)
+    libddwaf (1.18.0.0.0-aarch64-linux)
       ffi (~> 1.0)
-    libddwaf (1.15.0.0.0-x86_64-linux)
+    libddwaf (1.18.0.0.0-x86_64-linux)
       ffi (~> 1.0)
     memory_profiler (0.9.14)
     method_source (1.1.0)

--- a/gemfiles/ruby_3.1_activesupport.gemfile.lock
+++ b/gemfiles/ruby_3.1_activesupport.gemfile.lock
@@ -14,7 +14,7 @@ PATH
     datadog (2.7.0)
       datadog-ruby_core_source (~> 3.3)
       libdatadog (~> 14.1.0.1.0)
-      libddwaf (~> 1.15.0.0.0)
+      libddwaf (~> 1.18.0.0.0)
       msgpack
 
 GEM
@@ -110,9 +110,9 @@ GEM
     king_konf (1.0.1)
     libdatadog (14.1.0.1.0-aarch64-linux)
     libdatadog (14.1.0.1.0-x86_64-linux)
-    libddwaf (1.15.0.0.0-aarch64-linux)
+    libddwaf (1.18.0.0.0-aarch64-linux)
       ffi (~> 1.0)
-    libddwaf (1.15.0.0.0-x86_64-linux)
+    libddwaf (1.18.0.0.0-x86_64-linux)
       ffi (~> 1.0)
     lograge (0.13.0)
       actionpack (>= 4)

--- a/gemfiles/ruby_3.1_aws.gemfile.lock
+++ b/gemfiles/ruby_3.1_aws.gemfile.lock
@@ -14,7 +14,7 @@ PATH
     datadog (2.7.0)
       datadog-ruby_core_source (~> 3.3)
       libdatadog (~> 14.1.0.1.0)
-      libddwaf (~> 1.15.0.0.0)
+      libddwaf (~> 1.18.0.0.0)
       msgpack
 
 GEM
@@ -1475,9 +1475,9 @@ GEM
       addressable (>= 2.4)
     libdatadog (14.1.0.1.0-aarch64-linux)
     libdatadog (14.1.0.1.0-x86_64-linux)
-    libddwaf (1.15.0.0.0-aarch64-linux)
+    libddwaf (1.18.0.0.0-aarch64-linux)
       ffi (~> 1.0)
-    libddwaf (1.15.0.0.0-x86_64-linux)
+    libddwaf (1.18.0.0.0-x86_64-linux)
       ffi (~> 1.0)
     memory_profiler (0.9.14)
     method_source (1.0.0)

--- a/gemfiles/ruby_3.1_contrib.gemfile.lock
+++ b/gemfiles/ruby_3.1_contrib.gemfile.lock
@@ -14,7 +14,7 @@ PATH
     datadog (2.7.0)
       datadog-ruby_core_source (~> 3.3)
       libdatadog (~> 14.1.0.1.0)
-      libddwaf (~> 1.15.0.0.0)
+      libddwaf (~> 1.18.0.0.0)
       msgpack
 
 GEM
@@ -68,9 +68,9 @@ GEM
       addressable (>= 2.4)
     libdatadog (14.1.0.1.0-aarch64-linux)
     libdatadog (14.1.0.1.0-x86_64-linux)
-    libddwaf (1.15.0.0.0-aarch64-linux)
+    libddwaf (1.18.0.0.0-aarch64-linux)
       ffi (~> 1.0)
-    libddwaf (1.15.0.0.0-x86_64-linux)
+    libddwaf (1.18.0.0.0-x86_64-linux)
       ffi (~> 1.0)
     memory_profiler (0.9.14)
     method_source (1.0.0)

--- a/gemfiles/ruby_3.1_contrib_old.gemfile.lock
+++ b/gemfiles/ruby_3.1_contrib_old.gemfile.lock
@@ -14,7 +14,7 @@ PATH
     datadog (2.7.0)
       datadog-ruby_core_source (~> 3.3)
       libdatadog (~> 14.1.0.1.0)
-      libddwaf (~> 1.15.0.0.0)
+      libddwaf (~> 1.18.0.0.0)
       msgpack
 
 GEM
@@ -64,9 +64,9 @@ GEM
       addressable (>= 2.4)
     libdatadog (14.1.0.1.0-aarch64-linux)
     libdatadog (14.1.0.1.0-x86_64-linux)
-    libddwaf (1.15.0.0.0-aarch64-linux)
+    libddwaf (1.18.0.0.0-aarch64-linux)
       ffi (~> 1.0)
-    libddwaf (1.15.0.0.0-x86_64-linux)
+    libddwaf (1.18.0.0.0-x86_64-linux)
       ffi (~> 1.0)
     memory_profiler (0.9.14)
     method_source (1.0.0)

--- a/gemfiles/ruby_3.1_core_old.gemfile.lock
+++ b/gemfiles/ruby_3.1_core_old.gemfile.lock
@@ -14,7 +14,7 @@ PATH
     datadog (2.7.0)
       datadog-ruby_core_source (~> 3.3)
       libdatadog (~> 14.1.0.1.0)
-      libddwaf (~> 1.15.0.0.0)
+      libddwaf (~> 1.18.0.0.0)
       msgpack
 
 GEM
@@ -53,9 +53,9 @@ GEM
       addressable (>= 2.4)
     libdatadog (14.1.0.1.0-aarch64-linux)
     libdatadog (14.1.0.1.0-x86_64-linux)
-    libddwaf (1.15.0.0.0-aarch64-linux)
+    libddwaf (1.18.0.0.0-aarch64-linux)
       ffi (~> 1.0)
-    libddwaf (1.15.0.0.0-x86_64-linux)
+    libddwaf (1.18.0.0.0-x86_64-linux)
       ffi (~> 1.0)
     memory_profiler (0.9.14)
     method_source (1.0.0)

--- a/gemfiles/ruby_3.1_elasticsearch_7.gemfile.lock
+++ b/gemfiles/ruby_3.1_elasticsearch_7.gemfile.lock
@@ -14,7 +14,7 @@ PATH
     datadog (2.7.0)
       datadog-ruby_core_source (~> 3.3)
       libdatadog (~> 14.1.0.1.0)
-      libddwaf (~> 1.15.0.0.0)
+      libddwaf (~> 1.18.0.0.0)
       msgpack
 
 GEM
@@ -70,9 +70,9 @@ GEM
       addressable (>= 2.4)
     libdatadog (14.1.0.1.0-aarch64-linux)
     libdatadog (14.1.0.1.0-x86_64-linux)
-    libddwaf (1.15.0.0.0-aarch64-linux)
+    libddwaf (1.18.0.0.0-aarch64-linux)
       ffi (~> 1.0)
-    libddwaf (1.15.0.0.0-x86_64-linux)
+    libddwaf (1.18.0.0.0-x86_64-linux)
       ffi (~> 1.0)
     logger (1.6.1)
     memory_profiler (0.9.14)

--- a/gemfiles/ruby_3.1_elasticsearch_8.gemfile.lock
+++ b/gemfiles/ruby_3.1_elasticsearch_8.gemfile.lock
@@ -14,7 +14,7 @@ PATH
     datadog (2.7.0)
       datadog-ruby_core_source (~> 3.3)
       libdatadog (~> 14.1.0.1.0)
-      libddwaf (~> 1.15.0.0.0)
+      libddwaf (~> 1.18.0.0.0)
       msgpack
 
 GEM
@@ -68,9 +68,9 @@ GEM
       addressable (>= 2.4)
     libdatadog (14.1.0.1.0-aarch64-linux)
     libdatadog (14.1.0.1.0-x86_64-linux)
-    libddwaf (1.15.0.0.0-aarch64-linux)
+    libddwaf (1.18.0.0.0-aarch64-linux)
       ffi (~> 1.0)
-    libddwaf (1.15.0.0.0-x86_64-linux)
+    libddwaf (1.18.0.0.0-x86_64-linux)
       ffi (~> 1.0)
     logger (1.6.1)
     memory_profiler (0.9.14)

--- a/gemfiles/ruby_3.1_elasticsearch_latest.gemfile.lock
+++ b/gemfiles/ruby_3.1_elasticsearch_latest.gemfile.lock
@@ -14,7 +14,7 @@ PATH
     datadog (2.7.0)
       datadog-ruby_core_source (~> 3.3)
       libdatadog (~> 14.1.0.1.0)
-      libddwaf (~> 1.15.0.0.0)
+      libddwaf (~> 1.18.0.0.0)
       msgpack
 
 GEM
@@ -70,9 +70,9 @@ GEM
       addressable (>= 2.4)
     libdatadog (14.1.0.1.0-aarch64-linux)
     libdatadog (14.1.0.1.0-x86_64-linux)
-    libddwaf (1.15.0.0.0-aarch64-linux)
+    libddwaf (1.18.0.0.0-aarch64-linux)
       ffi (~> 1.0)
-    libddwaf (1.15.0.0.0-x86_64-linux)
+    libddwaf (1.18.0.0.0-x86_64-linux)
       ffi (~> 1.0)
     logger (1.6.1)
     memory_profiler (0.9.14)

--- a/gemfiles/ruby_3.1_graphql_1.13.gemfile.lock
+++ b/gemfiles/ruby_3.1_graphql_1.13.gemfile.lock
@@ -14,7 +14,7 @@ PATH
     datadog (2.7.0)
       datadog-ruby_core_source (~> 3.3)
       libdatadog (~> 14.1.0.1.0)
-      libddwaf (~> 1.15.0.0.0)
+      libddwaf (~> 1.18.0.0.0)
       msgpack
 
 GEM
@@ -123,9 +123,9 @@ GEM
       addressable (>= 2.4)
     libdatadog (14.1.0.1.0-aarch64-linux)
     libdatadog (14.1.0.1.0-x86_64-linux)
-    libddwaf (1.15.0.0.0-aarch64-linux)
+    libddwaf (1.18.0.0.0-aarch64-linux)
       ffi (~> 1.0)
-    libddwaf (1.15.0.0.0-x86_64-linux)
+    libddwaf (1.18.0.0.0-x86_64-linux)
       ffi (~> 1.0)
     lograge (0.14.0)
       actionpack (>= 4)

--- a/gemfiles/ruby_3.1_graphql_2.0.gemfile.lock
+++ b/gemfiles/ruby_3.1_graphql_2.0.gemfile.lock
@@ -14,7 +14,7 @@ PATH
     datadog (2.7.0)
       datadog-ruby_core_source (~> 3.3)
       libdatadog (~> 14.1.0.1.0)
-      libddwaf (~> 1.15.0.0.0)
+      libddwaf (~> 1.18.0.0.0)
       msgpack
 
 GEM
@@ -123,9 +123,9 @@ GEM
       addressable (>= 2.4)
     libdatadog (14.1.0.1.0-aarch64-linux)
     libdatadog (14.1.0.1.0-x86_64-linux)
-    libddwaf (1.15.0.0.0-aarch64-linux)
+    libddwaf (1.18.0.0.0-aarch64-linux)
       ffi (~> 1.0)
-    libddwaf (1.15.0.0.0-x86_64-linux)
+    libddwaf (1.18.0.0.0-x86_64-linux)
       ffi (~> 1.0)
     lograge (0.14.0)
       actionpack (>= 4)

--- a/gemfiles/ruby_3.1_graphql_2.1.gemfile.lock
+++ b/gemfiles/ruby_3.1_graphql_2.1.gemfile.lock
@@ -14,7 +14,7 @@ PATH
     datadog (2.7.0)
       datadog-ruby_core_source (~> 3.3)
       libdatadog (~> 14.1.0.1.0)
-      libddwaf (~> 1.15.0.0.0)
+      libddwaf (~> 1.18.0.0.0)
       msgpack
 
 GEM
@@ -124,9 +124,9 @@ GEM
       addressable (>= 2.4)
     libdatadog (14.1.0.1.0-aarch64-linux)
     libdatadog (14.1.0.1.0-x86_64-linux)
-    libddwaf (1.15.0.0.0-aarch64-linux)
+    libddwaf (1.18.0.0.0-aarch64-linux)
       ffi (~> 1.0)
-    libddwaf (1.15.0.0.0-x86_64-linux)
+    libddwaf (1.18.0.0.0-x86_64-linux)
       ffi (~> 1.0)
     lograge (0.14.0)
       actionpack (>= 4)

--- a/gemfiles/ruby_3.1_graphql_2.2.gemfile.lock
+++ b/gemfiles/ruby_3.1_graphql_2.2.gemfile.lock
@@ -14,7 +14,7 @@ PATH
     datadog (2.7.0)
       datadog-ruby_core_source (~> 3.3)
       libdatadog (~> 14.1.0.1.0)
-      libddwaf (~> 1.15.0.0.0)
+      libddwaf (~> 1.18.0.0.0)
       msgpack
 
 GEM
@@ -124,9 +124,9 @@ GEM
       addressable (>= 2.4)
     libdatadog (14.1.0.1.0-aarch64-linux)
     libdatadog (14.1.0.1.0-x86_64-linux)
-    libddwaf (1.15.0.0.0-aarch64-linux)
+    libddwaf (1.18.0.0.0-aarch64-linux)
       ffi (~> 1.0)
-    libddwaf (1.15.0.0.0-x86_64-linux)
+    libddwaf (1.18.0.0.0-x86_64-linux)
       ffi (~> 1.0)
     lograge (0.14.0)
       actionpack (>= 4)

--- a/gemfiles/ruby_3.1_graphql_2.3.gemfile.lock
+++ b/gemfiles/ruby_3.1_graphql_2.3.gemfile.lock
@@ -14,7 +14,7 @@ PATH
     datadog (2.7.0)
       datadog-ruby_core_source (~> 3.3)
       libdatadog (~> 14.1.0.1.0)
-      libddwaf (~> 1.15.0.0.0)
+      libddwaf (~> 1.18.0.0.0)
       msgpack
 
 GEM
@@ -126,9 +126,9 @@ GEM
       addressable (>= 2.4)
     libdatadog (14.1.0.1.0-aarch64-linux)
     libdatadog (14.1.0.1.0-x86_64-linux)
-    libddwaf (1.15.0.0.0-aarch64-linux)
+    libddwaf (1.18.0.0.0-aarch64-linux)
       ffi (~> 1.0)
-    libddwaf (1.15.0.0.0-x86_64-linux)
+    libddwaf (1.18.0.0.0-x86_64-linux)
       ffi (~> 1.0)
     lograge (0.14.0)
       actionpack (>= 4)

--- a/gemfiles/ruby_3.1_http.gemfile.lock
+++ b/gemfiles/ruby_3.1_http.gemfile.lock
@@ -14,7 +14,7 @@ PATH
     datadog (2.7.0)
       datadog-ruby_core_source (~> 3.3)
       libdatadog (~> 14.1.0.1.0)
-      libddwaf (~> 1.15.0.0.0)
+      libddwaf (~> 1.18.0.0.0)
       msgpack
 
 GEM
@@ -75,9 +75,9 @@ GEM
       addressable (>= 2.4)
     libdatadog (14.1.0.1.0-aarch64-linux)
     libdatadog (14.1.0.1.0-x86_64-linux)
-    libddwaf (1.15.0.0.0-aarch64-linux)
+    libddwaf (1.18.0.0.0-aarch64-linux)
       ffi (~> 1.0)
-    libddwaf (1.15.0.0.0-x86_64-linux)
+    libddwaf (1.18.0.0.0-x86_64-linux)
       ffi (~> 1.0)
     llhttp-ffi (0.3.1)
       ffi-compiler (~> 1.0)

--- a/gemfiles/ruby_3.1_opensearch_2.gemfile.lock
+++ b/gemfiles/ruby_3.1_opensearch_2.gemfile.lock
@@ -14,7 +14,7 @@ PATH
     datadog (2.7.0)
       datadog-ruby_core_source (~> 3.3)
       libdatadog (~> 14.1.0.1.0)
-      libddwaf (~> 1.15.0.0.0)
+      libddwaf (~> 1.18.0.0.0)
       msgpack
 
 GEM
@@ -60,9 +60,9 @@ GEM
       addressable (>= 2.4)
     libdatadog (14.1.0.1.0-aarch64-linux)
     libdatadog (14.1.0.1.0-x86_64-linux)
-    libddwaf (1.15.0.0.0-aarch64-linux)
+    libddwaf (1.18.0.0.0-aarch64-linux)
       ffi (~> 1.0)
-    libddwaf (1.15.0.0.0-x86_64-linux)
+    libddwaf (1.18.0.0.0-x86_64-linux)
       ffi (~> 1.0)
     logger (1.6.1)
     memory_profiler (0.9.14)

--- a/gemfiles/ruby_3.1_opensearch_3.gemfile.lock
+++ b/gemfiles/ruby_3.1_opensearch_3.gemfile.lock
@@ -14,7 +14,7 @@ PATH
     datadog (2.7.0)
       datadog-ruby_core_source (~> 3.3)
       libdatadog (~> 14.1.0.1.0)
-      libddwaf (~> 1.15.0.0.0)
+      libddwaf (~> 1.18.0.0.0)
       msgpack
 
 GEM
@@ -60,9 +60,9 @@ GEM
       addressable (>= 2.4)
     libdatadog (14.1.0.1.0-aarch64-linux)
     libdatadog (14.1.0.1.0-x86_64-linux)
-    libddwaf (1.15.0.0.0-aarch64-linux)
+    libddwaf (1.18.0.0.0-aarch64-linux)
       ffi (~> 1.0)
-    libddwaf (1.15.0.0.0-x86_64-linux)
+    libddwaf (1.18.0.0.0-x86_64-linux)
       ffi (~> 1.0)
     logger (1.6.1)
     memory_profiler (0.9.14)

--- a/gemfiles/ruby_3.1_opensearch_latest.gemfile.lock
+++ b/gemfiles/ruby_3.1_opensearch_latest.gemfile.lock
@@ -14,7 +14,7 @@ PATH
     datadog (2.7.0)
       datadog-ruby_core_source (~> 3.3)
       libdatadog (~> 14.1.0.1.0)
-      libddwaf (~> 1.15.0.0.0)
+      libddwaf (~> 1.18.0.0.0)
       msgpack
 
 GEM
@@ -62,9 +62,9 @@ GEM
       addressable (>= 2.4)
     libdatadog (14.1.0.1.0-aarch64-linux)
     libdatadog (14.1.0.1.0-x86_64-linux)
-    libddwaf (1.15.0.0.0-aarch64-linux)
+    libddwaf (1.18.0.0.0-aarch64-linux)
       ffi (~> 1.0)
-    libddwaf (1.15.0.0.0-x86_64-linux)
+    libddwaf (1.18.0.0.0-x86_64-linux)
       ffi (~> 1.0)
     logger (1.6.1)
     memory_profiler (0.9.14)

--- a/gemfiles/ruby_3.1_opentelemetry.gemfile.lock
+++ b/gemfiles/ruby_3.1_opentelemetry.gemfile.lock
@@ -14,7 +14,7 @@ PATH
     datadog (2.7.0)
       datadog-ruby_core_source (~> 3.3)
       libdatadog (~> 14.1.0.1.0)
-      libddwaf (~> 1.15.0.0.0)
+      libddwaf (~> 1.18.0.0.0)
       msgpack
 
 GEM
@@ -56,11 +56,11 @@ GEM
     libdatadog (14.1.0.1.0)
     libdatadog (14.1.0.1.0-aarch64-linux)
     libdatadog (14.1.0.1.0-x86_64-linux)
-    libddwaf (1.15.0.0.0-aarch64-linux)
+    libddwaf (1.18.0.0.0-aarch64-linux)
       ffi (~> 1.0)
-    libddwaf (1.15.0.0.0-x86_64-darwin)
+    libddwaf (1.18.0.0.0-x86_64-darwin)
       ffi (~> 1.0)
-    libddwaf (1.15.0.0.0-x86_64-linux)
+    libddwaf (1.18.0.0.0-x86_64-linux)
       ffi (~> 1.0)
     memory_profiler (0.9.14)
     method_source (1.0.0)

--- a/gemfiles/ruby_3.1_opentelemetry_otlp.gemfile.lock
+++ b/gemfiles/ruby_3.1_opentelemetry_otlp.gemfile.lock
@@ -14,7 +14,7 @@ PATH
     datadog (2.7.0)
       datadog-ruby_core_source (~> 3.3)
       libdatadog (~> 14.1.0.1.0)
-      libddwaf (~> 1.15.0.0.0)
+      libddwaf (~> 1.18.0.0.0)
       msgpack
 
 GEM
@@ -58,9 +58,9 @@ GEM
       addressable (>= 2.4)
     libdatadog (14.1.0.1.0-aarch64-linux)
     libdatadog (14.1.0.1.0-x86_64-linux)
-    libddwaf (1.15.0.0.0-aarch64-linux)
+    libddwaf (1.18.0.0.0-aarch64-linux)
       ffi (~> 1.0)
-    libddwaf (1.15.0.0.0-x86_64-linux)
+    libddwaf (1.18.0.0.0-x86_64-linux)
       ffi (~> 1.0)
     memory_profiler (0.9.14)
     method_source (1.0.0)

--- a/gemfiles/ruby_3.1_rack_1.gemfile.lock
+++ b/gemfiles/ruby_3.1_rack_1.gemfile.lock
@@ -14,7 +14,7 @@ PATH
     datadog (2.7.0)
       datadog-ruby_core_source (~> 3.3)
       libdatadog (~> 14.1.0.1.0)
-      libddwaf (~> 1.15.0.0.0)
+      libddwaf (~> 1.18.0.0.0)
       msgpack
 
 GEM
@@ -53,9 +53,9 @@ GEM
       addressable (>= 2.4)
     libdatadog (14.1.0.1.0-aarch64-linux)
     libdatadog (14.1.0.1.0-x86_64-linux)
-    libddwaf (1.15.0.0.0-aarch64-linux)
+    libddwaf (1.18.0.0.0-aarch64-linux)
       ffi (~> 1.0)
-    libddwaf (1.15.0.0.0-x86_64-linux)
+    libddwaf (1.18.0.0.0-x86_64-linux)
       ffi (~> 1.0)
     memory_profiler (0.9.14)
     method_source (1.0.0)

--- a/gemfiles/ruby_3.1_rack_2.gemfile.lock
+++ b/gemfiles/ruby_3.1_rack_2.gemfile.lock
@@ -14,7 +14,7 @@ PATH
     datadog (2.7.0)
       datadog-ruby_core_source (~> 3.3)
       libdatadog (~> 14.1.0.1.0)
-      libddwaf (~> 1.15.0.0.0)
+      libddwaf (~> 1.18.0.0.0)
       msgpack
 
 GEM
@@ -53,9 +53,9 @@ GEM
       addressable (>= 2.4)
     libdatadog (14.1.0.1.0-aarch64-linux)
     libdatadog (14.1.0.1.0-x86_64-linux)
-    libddwaf (1.15.0.0.0-aarch64-linux)
+    libddwaf (1.18.0.0.0-aarch64-linux)
       ffi (~> 1.0)
-    libddwaf (1.15.0.0.0-x86_64-linux)
+    libddwaf (1.18.0.0.0-x86_64-linux)
       ffi (~> 1.0)
     memory_profiler (0.9.14)
     method_source (1.0.0)

--- a/gemfiles/ruby_3.1_rack_3.gemfile.lock
+++ b/gemfiles/ruby_3.1_rack_3.gemfile.lock
@@ -14,7 +14,7 @@ PATH
     datadog (2.7.0)
       datadog-ruby_core_source (~> 3.3)
       libdatadog (~> 14.1.0.1.0)
-      libddwaf (~> 1.15.0.0.0)
+      libddwaf (~> 1.18.0.0.0)
       msgpack
 
 GEM
@@ -53,9 +53,9 @@ GEM
       addressable (>= 2.4)
     libdatadog (14.1.0.1.0-aarch64-linux)
     libdatadog (14.1.0.1.0-x86_64-linux)
-    libddwaf (1.15.0.0.0-aarch64-linux)
+    libddwaf (1.18.0.0.0-aarch64-linux)
       ffi (~> 1.0)
-    libddwaf (1.15.0.0.0-x86_64-linux)
+    libddwaf (1.18.0.0.0-x86_64-linux)
       ffi (~> 1.0)
     memory_profiler (0.9.14)
     method_source (1.0.0)

--- a/gemfiles/ruby_3.1_rack_latest.gemfile.lock
+++ b/gemfiles/ruby_3.1_rack_latest.gemfile.lock
@@ -14,7 +14,7 @@ PATH
     datadog (2.7.0)
       datadog-ruby_core_source (~> 3.3)
       libdatadog (~> 14.1.0.1.0)
-      libddwaf (~> 1.15.0.0.0)
+      libddwaf (~> 1.18.0.0.0)
       msgpack
 
 GEM
@@ -56,9 +56,9 @@ GEM
       addressable (>= 2.4)
     libdatadog (14.1.0.1.0-aarch64-linux)
     libdatadog (14.1.0.1.0-x86_64-linux)
-    libddwaf (1.15.0.0.0-aarch64-linux)
+    libddwaf (1.18.0.0.0-aarch64-linux)
       ffi (~> 1.0)
-    libddwaf (1.15.0.0.0-x86_64-linux)
+    libddwaf (1.18.0.0.0-x86_64-linux)
       ffi (~> 1.0)
     memory_profiler (0.9.14)
     method_source (1.1.0)

--- a/gemfiles/ruby_3.1_rails61_mysql2.gemfile.lock
+++ b/gemfiles/ruby_3.1_rails61_mysql2.gemfile.lock
@@ -14,7 +14,7 @@ PATH
     datadog (2.7.0)
       datadog-ruby_core_source (~> 3.3)
       libdatadog (~> 14.1.0.1.0)
-      libddwaf (~> 1.15.0.0.0)
+      libddwaf (~> 1.18.0.0.0)
       msgpack
 
 GEM
@@ -120,9 +120,9 @@ GEM
       addressable (>= 2.4)
     libdatadog (14.1.0.1.0-aarch64-linux)
     libdatadog (14.1.0.1.0-x86_64-linux)
-    libddwaf (1.15.0.0.0-aarch64-linux)
+    libddwaf (1.18.0.0.0-aarch64-linux)
       ffi (~> 1.0)
-    libddwaf (1.15.0.0.0-x86_64-linux)
+    libddwaf (1.18.0.0.0-x86_64-linux)
       ffi (~> 1.0)
     lograge (0.12.0)
       actionpack (>= 4)

--- a/gemfiles/ruby_3.1_rails61_postgres.gemfile.lock
+++ b/gemfiles/ruby_3.1_rails61_postgres.gemfile.lock
@@ -14,7 +14,7 @@ PATH
     datadog (2.7.0)
       datadog-ruby_core_source (~> 3.3)
       libdatadog (~> 14.1.0.1.0)
-      libddwaf (~> 1.15.0.0.0)
+      libddwaf (~> 1.18.0.0.0)
       msgpack
 
 GEM
@@ -120,9 +120,9 @@ GEM
       addressable (>= 2.4)
     libdatadog (14.1.0.1.0-aarch64-linux)
     libdatadog (14.1.0.1.0-x86_64-linux)
-    libddwaf (1.15.0.0.0-aarch64-linux)
+    libddwaf (1.18.0.0.0-aarch64-linux)
       ffi (~> 1.0)
-    libddwaf (1.15.0.0.0-x86_64-linux)
+    libddwaf (1.18.0.0.0-x86_64-linux)
       ffi (~> 1.0)
     lograge (0.12.0)
       actionpack (>= 4)

--- a/gemfiles/ruby_3.1_rails61_postgres_redis.gemfile.lock
+++ b/gemfiles/ruby_3.1_rails61_postgres_redis.gemfile.lock
@@ -14,7 +14,7 @@ PATH
     datadog (2.7.0)
       datadog-ruby_core_source (~> 3.3)
       libdatadog (~> 14.1.0.1.0)
-      libddwaf (~> 1.15.0.0.0)
+      libddwaf (~> 1.18.0.0.0)
       msgpack
 
 GEM
@@ -120,9 +120,9 @@ GEM
       addressable (>= 2.4)
     libdatadog (14.1.0.1.0-aarch64-linux)
     libdatadog (14.1.0.1.0-x86_64-linux)
-    libddwaf (1.15.0.0.0-aarch64-linux)
+    libddwaf (1.18.0.0.0-aarch64-linux)
       ffi (~> 1.0)
-    libddwaf (1.15.0.0.0-x86_64-linux)
+    libddwaf (1.18.0.0.0-x86_64-linux)
       ffi (~> 1.0)
     lograge (0.12.0)
       actionpack (>= 4)

--- a/gemfiles/ruby_3.1_rails61_postgres_sidekiq.gemfile.lock
+++ b/gemfiles/ruby_3.1_rails61_postgres_sidekiq.gemfile.lock
@@ -14,7 +14,7 @@ PATH
     datadog (2.7.0)
       datadog-ruby_core_source (~> 3.3)
       libdatadog (~> 14.1.0.1.0)
-      libddwaf (~> 1.15.0.0.0)
+      libddwaf (~> 1.18.0.0.0)
       msgpack
 
 GEM
@@ -121,9 +121,9 @@ GEM
       addressable (>= 2.4)
     libdatadog (14.1.0.1.0-aarch64-linux)
     libdatadog (14.1.0.1.0-x86_64-linux)
-    libddwaf (1.15.0.0.0-aarch64-linux)
+    libddwaf (1.18.0.0.0-aarch64-linux)
       ffi (~> 1.0)
-    libddwaf (1.15.0.0.0-x86_64-linux)
+    libddwaf (1.18.0.0.0-x86_64-linux)
       ffi (~> 1.0)
     lograge (0.12.0)
       actionpack (>= 4)

--- a/gemfiles/ruby_3.1_rails61_semantic_logger.gemfile.lock
+++ b/gemfiles/ruby_3.1_rails61_semantic_logger.gemfile.lock
@@ -14,7 +14,7 @@ PATH
     datadog (2.7.0)
       datadog-ruby_core_source (~> 3.3)
       libdatadog (~> 14.1.0.1.0)
-      libddwaf (~> 1.15.0.0.0)
+      libddwaf (~> 1.18.0.0.0)
       msgpack
 
 GEM
@@ -120,9 +120,9 @@ GEM
       addressable (>= 2.4)
     libdatadog (14.1.0.1.0-aarch64-linux)
     libdatadog (14.1.0.1.0-x86_64-linux)
-    libddwaf (1.15.0.0.0-aarch64-linux)
+    libddwaf (1.18.0.0.0-aarch64-linux)
       ffi (~> 1.0)
-    libddwaf (1.15.0.0.0-x86_64-linux)
+    libddwaf (1.18.0.0.0-x86_64-linux)
       ffi (~> 1.0)
     loofah (2.19.1)
       crass (~> 1.0.2)

--- a/gemfiles/ruby_3.1_rails61_trilogy.gemfile.lock
+++ b/gemfiles/ruby_3.1_rails61_trilogy.gemfile.lock
@@ -14,7 +14,7 @@ PATH
     datadog (2.7.0)
       datadog-ruby_core_source (~> 3.3)
       libdatadog (~> 14.1.0.1.0)
-      libddwaf (~> 1.15.0.0.0)
+      libddwaf (~> 1.18.0.0.0)
       msgpack
 
 GEM
@@ -124,9 +124,9 @@ GEM
       addressable (>= 2.4)
     libdatadog (14.1.0.1.0-aarch64-linux)
     libdatadog (14.1.0.1.0-x86_64-linux)
-    libddwaf (1.15.0.0.0-aarch64-linux)
+    libddwaf (1.18.0.0.0-aarch64-linux)
       ffi (~> 1.0)
-    libddwaf (1.15.0.0.0-x86_64-linux)
+    libddwaf (1.18.0.0.0-x86_64-linux)
       ffi (~> 1.0)
     lograge (0.14.0)
       actionpack (>= 4)

--- a/gemfiles/ruby_3.1_rails7.gemfile.lock
+++ b/gemfiles/ruby_3.1_rails7.gemfile.lock
@@ -14,7 +14,7 @@ PATH
     datadog (2.7.0)
       datadog-ruby_core_source (~> 3.3)
       libdatadog (~> 14.1.0.1.0)
-      libddwaf (~> 1.15.0.0.0)
+      libddwaf (~> 1.18.0.0.0)
       msgpack
 
 GEM
@@ -129,9 +129,9 @@ GEM
       addressable (>= 2.4)
     libdatadog (14.1.0.1.0-aarch64-linux)
     libdatadog (14.1.0.1.0-x86_64-linux)
-    libddwaf (1.15.0.0.0-aarch64-linux)
+    libddwaf (1.18.0.0.0-aarch64-linux)
       ffi (~> 1.0)
-    libddwaf (1.15.0.0.0-x86_64-linux)
+    libddwaf (1.18.0.0.0-x86_64-linux)
       ffi (~> 1.0)
     loofah (2.22.0)
       crass (~> 1.0.2)

--- a/gemfiles/ruby_3.1_rails71.gemfile.lock
+++ b/gemfiles/ruby_3.1_rails71.gemfile.lock
@@ -14,7 +14,7 @@ PATH
     datadog (2.7.0)
       datadog-ruby_core_source (~> 3.3)
       libdatadog (~> 14.1.0.1.0)
-      libddwaf (~> 1.15.0.0.0)
+      libddwaf (~> 1.18.0.0.0)
       msgpack
 
 GEM
@@ -145,9 +145,9 @@ GEM
       addressable (>= 2.4)
     libdatadog (14.1.0.1.0-aarch64-linux)
     libdatadog (14.1.0.1.0-x86_64-linux)
-    libddwaf (1.15.0.0.0-aarch64-linux)
+    libddwaf (1.18.0.0.0-aarch64-linux)
       ffi (~> 1.0)
-    libddwaf (1.15.0.0.0-x86_64-linux)
+    libddwaf (1.18.0.0.0-x86_64-linux)
       ffi (~> 1.0)
     loofah (2.22.0)
       crass (~> 1.0.2)

--- a/gemfiles/ruby_3.1_redis_3.gemfile.lock
+++ b/gemfiles/ruby_3.1_redis_3.gemfile.lock
@@ -14,7 +14,7 @@ PATH
     datadog (2.7.0)
       datadog-ruby_core_source (~> 3.3)
       libdatadog (~> 14.1.0.1.0)
-      libddwaf (~> 1.15.0.0.0)
+      libddwaf (~> 1.18.0.0.0)
       msgpack
 
 GEM
@@ -53,9 +53,9 @@ GEM
       addressable (>= 2.4)
     libdatadog (14.1.0.1.0-aarch64-linux)
     libdatadog (14.1.0.1.0-x86_64-linux)
-    libddwaf (1.15.0.0.0-aarch64-linux)
+    libddwaf (1.18.0.0.0-aarch64-linux)
       ffi (~> 1.0)
-    libddwaf (1.15.0.0.0-x86_64-linux)
+    libddwaf (1.18.0.0.0-x86_64-linux)
       ffi (~> 1.0)
     memory_profiler (0.9.14)
     method_source (1.0.0)

--- a/gemfiles/ruby_3.1_redis_4.gemfile.lock
+++ b/gemfiles/ruby_3.1_redis_4.gemfile.lock
@@ -14,7 +14,7 @@ PATH
     datadog (2.7.0)
       datadog-ruby_core_source (~> 3.3)
       libdatadog (~> 14.1.0.1.0)
-      libddwaf (~> 1.15.0.0.0)
+      libddwaf (~> 1.18.0.0.0)
       msgpack
 
 GEM
@@ -53,9 +53,9 @@ GEM
       addressable (>= 2.4)
     libdatadog (14.1.0.1.0-aarch64-linux)
     libdatadog (14.1.0.1.0-x86_64-linux)
-    libddwaf (1.15.0.0.0-aarch64-linux)
+    libddwaf (1.18.0.0.0-aarch64-linux)
       ffi (~> 1.0)
-    libddwaf (1.15.0.0.0-x86_64-linux)
+    libddwaf (1.18.0.0.0-x86_64-linux)
       ffi (~> 1.0)
     memory_profiler (0.9.14)
     method_source (1.0.0)

--- a/gemfiles/ruby_3.1_redis_5.gemfile.lock
+++ b/gemfiles/ruby_3.1_redis_5.gemfile.lock
@@ -14,7 +14,7 @@ PATH
     datadog (2.7.0)
       datadog-ruby_core_source (~> 3.3)
       libdatadog (~> 14.1.0.1.0)
-      libddwaf (~> 1.15.0.0.0)
+      libddwaf (~> 1.18.0.0.0)
       msgpack
 
 GEM
@@ -54,9 +54,9 @@ GEM
       addressable (>= 2.4)
     libdatadog (14.1.0.1.0-aarch64-linux)
     libdatadog (14.1.0.1.0-x86_64-linux)
-    libddwaf (1.15.0.0.0-aarch64-linux)
+    libddwaf (1.18.0.0.0-aarch64-linux)
       ffi (~> 1.0)
-    libddwaf (1.15.0.0.0-x86_64-linux)
+    libddwaf (1.18.0.0.0-x86_64-linux)
       ffi (~> 1.0)
     memory_profiler (0.9.14)
     method_source (1.0.0)

--- a/gemfiles/ruby_3.1_relational_db.gemfile.lock
+++ b/gemfiles/ruby_3.1_relational_db.gemfile.lock
@@ -14,7 +14,7 @@ PATH
     datadog (2.7.0)
       datadog-ruby_core_source (~> 3.3)
       libdatadog (~> 14.1.0.1.0)
-      libddwaf (~> 1.15.0.0.0)
+      libddwaf (~> 1.18.0.0.0)
       msgpack
 
 GEM
@@ -71,9 +71,9 @@ GEM
       addressable (>= 2.4)
     libdatadog (14.1.0.1.0-aarch64-linux)
     libdatadog (14.1.0.1.0-x86_64-linux)
-    libddwaf (1.15.0.0.0-aarch64-linux)
+    libddwaf (1.18.0.0.0-aarch64-linux)
       ffi (~> 1.0)
-    libddwaf (1.15.0.0.0-x86_64-linux)
+    libddwaf (1.18.0.0.0-x86_64-linux)
       ffi (~> 1.0)
     makara (0.6.0.pre)
       activerecord (>= 5.2.0)

--- a/gemfiles/ruby_3.1_resque2_redis3.gemfile.lock
+++ b/gemfiles/ruby_3.1_resque2_redis3.gemfile.lock
@@ -14,7 +14,7 @@ PATH
     datadog (2.7.0)
       datadog-ruby_core_source (~> 3.3)
       libdatadog (~> 14.1.0.1.0)
-      libddwaf (~> 1.15.0.0.0)
+      libddwaf (~> 1.18.0.0.0)
       msgpack
 
 GEM
@@ -53,9 +53,9 @@ GEM
       addressable (>= 2.4)
     libdatadog (14.1.0.1.0-aarch64-linux)
     libdatadog (14.1.0.1.0-x86_64-linux)
-    libddwaf (1.15.0.0.0-aarch64-linux)
+    libddwaf (1.18.0.0.0-aarch64-linux)
       ffi (~> 1.0)
-    libddwaf (1.15.0.0.0-x86_64-linux)
+    libddwaf (1.18.0.0.0-x86_64-linux)
       ffi (~> 1.0)
     memory_profiler (0.9.14)
     method_source (1.0.0)

--- a/gemfiles/ruby_3.1_resque2_redis4.gemfile.lock
+++ b/gemfiles/ruby_3.1_resque2_redis4.gemfile.lock
@@ -14,7 +14,7 @@ PATH
     datadog (2.7.0)
       datadog-ruby_core_source (~> 3.3)
       libdatadog (~> 14.1.0.1.0)
-      libddwaf (~> 1.15.0.0.0)
+      libddwaf (~> 1.18.0.0.0)
       msgpack
 
 GEM
@@ -54,9 +54,9 @@ GEM
       addressable (>= 2.4)
     libdatadog (14.1.0.1.0-aarch64-linux)
     libdatadog (14.1.0.1.0-x86_64-linux)
-    libddwaf (1.15.0.0.0-aarch64-linux)
+    libddwaf (1.18.0.0.0-aarch64-linux)
       ffi (~> 1.0)
-    libddwaf (1.15.0.0.0-x86_64-linux)
+    libddwaf (1.18.0.0.0-x86_64-linux)
       ffi (~> 1.0)
     memory_profiler (0.9.14)
     method_source (1.0.0)

--- a/gemfiles/ruby_3.1_sinatra_2.gemfile.lock
+++ b/gemfiles/ruby_3.1_sinatra_2.gemfile.lock
@@ -14,7 +14,7 @@ PATH
     datadog (2.7.0)
       datadog-ruby_core_source (~> 3.3)
       libdatadog (~> 14.1.0.1.0)
-      libddwaf (~> 1.15.0.0.0)
+      libddwaf (~> 1.18.0.0.0)
       msgpack
 
 GEM
@@ -56,9 +56,9 @@ GEM
       addressable (>= 2.4)
     libdatadog (14.1.0.1.0-aarch64-linux)
     libdatadog (14.1.0.1.0-x86_64-linux)
-    libddwaf (1.15.0.0.0-aarch64-linux)
+    libddwaf (1.18.0.0.0-aarch64-linux)
       ffi (~> 1.0)
-    libddwaf (1.15.0.0.0-x86_64-linux)
+    libddwaf (1.18.0.0.0-x86_64-linux)
       ffi (~> 1.0)
     memory_profiler (0.9.14)
     method_source (1.1.0)

--- a/gemfiles/ruby_3.1_sinatra_3.gemfile.lock
+++ b/gemfiles/ruby_3.1_sinatra_3.gemfile.lock
@@ -14,7 +14,7 @@ PATH
     datadog (2.7.0)
       datadog-ruby_core_source (~> 3.3)
       libdatadog (~> 14.1.0.1.0)
-      libddwaf (~> 1.15.0.0.0)
+      libddwaf (~> 1.18.0.0.0)
       msgpack
 
 GEM
@@ -57,9 +57,9 @@ GEM
       addressable (>= 2.4)
     libdatadog (14.1.0.1.0-aarch64-linux)
     libdatadog (14.1.0.1.0-x86_64-linux)
-    libddwaf (1.15.0.0.0-aarch64-linux)
+    libddwaf (1.18.0.0.0-aarch64-linux)
       ffi (~> 1.0)
-    libddwaf (1.15.0.0.0-x86_64-linux)
+    libddwaf (1.18.0.0.0-x86_64-linux)
       ffi (~> 1.0)
     memory_profiler (0.9.14)
     method_source (1.1.0)

--- a/gemfiles/ruby_3.1_sinatra_4.gemfile.lock
+++ b/gemfiles/ruby_3.1_sinatra_4.gemfile.lock
@@ -14,7 +14,7 @@ PATH
     datadog (2.7.0)
       datadog-ruby_core_source (~> 3.3)
       libdatadog (~> 14.1.0.1.0)
-      libddwaf (~> 1.15.0.0.0)
+      libddwaf (~> 1.18.0.0.0)
       msgpack
 
 GEM
@@ -57,9 +57,9 @@ GEM
       addressable (>= 2.4)
     libdatadog (14.1.0.1.0-aarch64-linux)
     libdatadog (14.1.0.1.0-x86_64-linux)
-    libddwaf (1.15.0.0.0-aarch64-linux)
+    libddwaf (1.18.0.0.0-aarch64-linux)
       ffi (~> 1.0)
-    libddwaf (1.15.0.0.0-x86_64-linux)
+    libddwaf (1.18.0.0.0-x86_64-linux)
       ffi (~> 1.0)
     memory_profiler (0.9.14)
     method_source (1.1.0)

--- a/gemfiles/ruby_3.1_stripe_10.gemfile.lock
+++ b/gemfiles/ruby_3.1_stripe_10.gemfile.lock
@@ -14,7 +14,7 @@ PATH
     datadog (2.7.0)
       datadog-ruby_core_source (~> 3.3)
       libdatadog (~> 14.1.0.1.0)
-      libddwaf (~> 1.15.0.0.0)
+      libddwaf (~> 1.18.0.0.0)
       msgpack
 
 GEM
@@ -56,9 +56,9 @@ GEM
       addressable (>= 2.4)
     libdatadog (14.1.0.1.0-aarch64-linux)
     libdatadog (14.1.0.1.0-x86_64-linux)
-    libddwaf (1.15.0.0.0-aarch64-linux)
+    libddwaf (1.18.0.0.0-aarch64-linux)
       ffi (~> 1.0)
-    libddwaf (1.15.0.0.0-x86_64-linux)
+    libddwaf (1.18.0.0.0-x86_64-linux)
       ffi (~> 1.0)
     memory_profiler (0.9.14)
     method_source (1.1.0)

--- a/gemfiles/ruby_3.1_stripe_11.gemfile.lock
+++ b/gemfiles/ruby_3.1_stripe_11.gemfile.lock
@@ -14,7 +14,7 @@ PATH
     datadog (2.7.0)
       datadog-ruby_core_source (~> 3.3)
       libdatadog (~> 14.1.0.1.0)
-      libddwaf (~> 1.15.0.0.0)
+      libddwaf (~> 1.18.0.0.0)
       msgpack
 
 GEM
@@ -56,9 +56,9 @@ GEM
       addressable (>= 2.4)
     libdatadog (14.1.0.1.0-aarch64-linux)
     libdatadog (14.1.0.1.0-x86_64-linux)
-    libddwaf (1.15.0.0.0-aarch64-linux)
+    libddwaf (1.18.0.0.0-aarch64-linux)
       ffi (~> 1.0)
-    libddwaf (1.15.0.0.0-x86_64-linux)
+    libddwaf (1.18.0.0.0-x86_64-linux)
       ffi (~> 1.0)
     memory_profiler (0.9.14)
     method_source (1.1.0)

--- a/gemfiles/ruby_3.1_stripe_12.gemfile.lock
+++ b/gemfiles/ruby_3.1_stripe_12.gemfile.lock
@@ -14,7 +14,7 @@ PATH
     datadog (2.7.0)
       datadog-ruby_core_source (~> 3.3)
       libdatadog (~> 14.1.0.1.0)
-      libddwaf (~> 1.15.0.0.0)
+      libddwaf (~> 1.18.0.0.0)
       msgpack
 
 GEM
@@ -56,9 +56,9 @@ GEM
       addressable (>= 2.4)
     libdatadog (14.1.0.1.0-aarch64-linux)
     libdatadog (14.1.0.1.0-x86_64-linux)
-    libddwaf (1.15.0.0.0-aarch64-linux)
+    libddwaf (1.18.0.0.0-aarch64-linux)
       ffi (~> 1.0)
-    libddwaf (1.15.0.0.0-x86_64-linux)
+    libddwaf (1.18.0.0.0-x86_64-linux)
       ffi (~> 1.0)
     memory_profiler (0.9.14)
     method_source (1.1.0)

--- a/gemfiles/ruby_3.1_stripe_7.gemfile.lock
+++ b/gemfiles/ruby_3.1_stripe_7.gemfile.lock
@@ -14,7 +14,7 @@ PATH
     datadog (2.7.0)
       datadog-ruby_core_source (~> 3.3)
       libdatadog (~> 14.1.0.1.0)
-      libddwaf (~> 1.15.0.0.0)
+      libddwaf (~> 1.18.0.0.0)
       msgpack
 
 GEM
@@ -56,9 +56,9 @@ GEM
       addressable (>= 2.4)
     libdatadog (14.1.0.1.0-aarch64-linux)
     libdatadog (14.1.0.1.0-x86_64-linux)
-    libddwaf (1.15.0.0.0-aarch64-linux)
+    libddwaf (1.18.0.0.0-aarch64-linux)
       ffi (~> 1.0)
-    libddwaf (1.15.0.0.0-x86_64-linux)
+    libddwaf (1.18.0.0.0-x86_64-linux)
       ffi (~> 1.0)
     memory_profiler (0.9.14)
     method_source (1.1.0)

--- a/gemfiles/ruby_3.1_stripe_8.gemfile.lock
+++ b/gemfiles/ruby_3.1_stripe_8.gemfile.lock
@@ -14,7 +14,7 @@ PATH
     datadog (2.7.0)
       datadog-ruby_core_source (~> 3.3)
       libdatadog (~> 14.1.0.1.0)
-      libddwaf (~> 1.15.0.0.0)
+      libddwaf (~> 1.18.0.0.0)
       msgpack
 
 GEM
@@ -56,9 +56,9 @@ GEM
       addressable (>= 2.4)
     libdatadog (14.1.0.1.0-aarch64-linux)
     libdatadog (14.1.0.1.0-x86_64-linux)
-    libddwaf (1.15.0.0.0-aarch64-linux)
+    libddwaf (1.18.0.0.0-aarch64-linux)
       ffi (~> 1.0)
-    libddwaf (1.15.0.0.0-x86_64-linux)
+    libddwaf (1.18.0.0.0-x86_64-linux)
       ffi (~> 1.0)
     memory_profiler (0.9.14)
     method_source (1.1.0)

--- a/gemfiles/ruby_3.1_stripe_9.gemfile.lock
+++ b/gemfiles/ruby_3.1_stripe_9.gemfile.lock
@@ -14,7 +14,7 @@ PATH
     datadog (2.7.0)
       datadog-ruby_core_source (~> 3.3)
       libdatadog (~> 14.1.0.1.0)
-      libddwaf (~> 1.15.0.0.0)
+      libddwaf (~> 1.18.0.0.0)
       msgpack
 
 GEM
@@ -56,9 +56,9 @@ GEM
       addressable (>= 2.4)
     libdatadog (14.1.0.1.0-aarch64-linux)
     libdatadog (14.1.0.1.0-x86_64-linux)
-    libddwaf (1.15.0.0.0-aarch64-linux)
+    libddwaf (1.18.0.0.0-aarch64-linux)
       ffi (~> 1.0)
-    libddwaf (1.15.0.0.0-x86_64-linux)
+    libddwaf (1.18.0.0.0-x86_64-linux)
       ffi (~> 1.0)
     memory_profiler (0.9.14)
     method_source (1.1.0)

--- a/gemfiles/ruby_3.1_stripe_latest.gemfile.lock
+++ b/gemfiles/ruby_3.1_stripe_latest.gemfile.lock
@@ -14,7 +14,7 @@ PATH
     datadog (2.7.0)
       datadog-ruby_core_source (~> 3.3)
       libdatadog (~> 14.1.0.1.0)
-      libddwaf (~> 1.15.0.0.0)
+      libddwaf (~> 1.18.0.0.0)
       msgpack
 
 GEM
@@ -56,9 +56,9 @@ GEM
       addressable (>= 2.4)
     libdatadog (14.1.0.1.0-aarch64-linux)
     libdatadog (14.1.0.1.0-x86_64-linux)
-    libddwaf (1.15.0.0.0-aarch64-linux)
+    libddwaf (1.18.0.0.0-aarch64-linux)
       ffi (~> 1.0)
-    libddwaf (1.15.0.0.0-x86_64-linux)
+    libddwaf (1.18.0.0.0-x86_64-linux)
       ffi (~> 1.0)
     memory_profiler (0.9.14)
     method_source (1.1.0)

--- a/gemfiles/ruby_3.1_stripe_min.gemfile.lock
+++ b/gemfiles/ruby_3.1_stripe_min.gemfile.lock
@@ -14,7 +14,7 @@ PATH
     datadog (2.7.0)
       datadog-ruby_core_source (~> 3.3)
       libdatadog (~> 14.1.0.1.0)
-      libddwaf (~> 1.15.0.0.0)
+      libddwaf (~> 1.18.0.0.0)
       msgpack
 
 GEM
@@ -56,9 +56,9 @@ GEM
       addressable (>= 2.4)
     libdatadog (14.1.0.1.0-aarch64-linux)
     libdatadog (14.1.0.1.0-x86_64-linux)
-    libddwaf (1.15.0.0.0-aarch64-linux)
+    libddwaf (1.18.0.0.0-aarch64-linux)
       ffi (~> 1.0)
-    libddwaf (1.15.0.0.0-x86_64-linux)
+    libddwaf (1.18.0.0.0-x86_64-linux)
       ffi (~> 1.0)
     memory_profiler (0.9.14)
     method_source (1.1.0)

--- a/gemfiles/ruby_3.2_activesupport.gemfile.lock
+++ b/gemfiles/ruby_3.2_activesupport.gemfile.lock
@@ -14,7 +14,7 @@ PATH
     datadog (2.7.0)
       datadog-ruby_core_source (~> 3.3)
       libdatadog (~> 14.1.0.1.0)
-      libddwaf (~> 1.15.0.0.0)
+      libddwaf (~> 1.18.0.0.0)
       msgpack
 
 GEM
@@ -109,9 +109,9 @@ GEM
     king_konf (1.0.1)
     libdatadog (14.1.0.1.0-aarch64-linux)
     libdatadog (14.1.0.1.0-x86_64-linux)
-    libddwaf (1.15.0.0.0-aarch64-linux)
+    libddwaf (1.18.0.0.0-aarch64-linux)
       ffi (~> 1.0)
-    libddwaf (1.15.0.0.0-x86_64-linux)
+    libddwaf (1.18.0.0.0-x86_64-linux)
       ffi (~> 1.0)
     lograge (0.13.0)
       actionpack (>= 4)

--- a/gemfiles/ruby_3.2_aws.gemfile.lock
+++ b/gemfiles/ruby_3.2_aws.gemfile.lock
@@ -14,7 +14,7 @@ PATH
     datadog (2.7.0)
       datadog-ruby_core_source (~> 3.3)
       libdatadog (~> 14.1.0.1.0)
-      libddwaf (~> 1.15.0.0.0)
+      libddwaf (~> 1.18.0.0.0)
       msgpack
 
 GEM
@@ -1474,9 +1474,9 @@ GEM
       addressable (>= 2.4)
     libdatadog (14.1.0.1.0-aarch64-linux)
     libdatadog (14.1.0.1.0-x86_64-linux)
-    libddwaf (1.15.0.0.0-aarch64-linux)
+    libddwaf (1.18.0.0.0-aarch64-linux)
       ffi (~> 1.0)
-    libddwaf (1.15.0.0.0-x86_64-linux)
+    libddwaf (1.18.0.0.0-x86_64-linux)
       ffi (~> 1.0)
     memory_profiler (0.9.14)
     method_source (1.0.0)

--- a/gemfiles/ruby_3.2_contrib.gemfile.lock
+++ b/gemfiles/ruby_3.2_contrib.gemfile.lock
@@ -14,7 +14,7 @@ PATH
     datadog (2.7.0)
       datadog-ruby_core_source (~> 3.3)
       libdatadog (~> 14.1.0.1.0)
-      libddwaf (~> 1.15.0.0.0)
+      libddwaf (~> 1.18.0.0.0)
       msgpack
 
 GEM
@@ -67,9 +67,9 @@ GEM
       addressable (>= 2.4)
     libdatadog (14.1.0.1.0-aarch64-linux)
     libdatadog (14.1.0.1.0-x86_64-linux)
-    libddwaf (1.15.0.0.0-aarch64-linux)
+    libddwaf (1.18.0.0.0-aarch64-linux)
       ffi (~> 1.0)
-    libddwaf (1.15.0.0.0-x86_64-linux)
+    libddwaf (1.18.0.0.0-x86_64-linux)
       ffi (~> 1.0)
     memory_profiler (0.9.14)
     method_source (1.0.0)

--- a/gemfiles/ruby_3.2_contrib_old.gemfile.lock
+++ b/gemfiles/ruby_3.2_contrib_old.gemfile.lock
@@ -14,7 +14,7 @@ PATH
     datadog (2.7.0)
       datadog-ruby_core_source (~> 3.3)
       libdatadog (~> 14.1.0.1.0)
-      libddwaf (~> 1.15.0.0.0)
+      libddwaf (~> 1.18.0.0.0)
       msgpack
 
 GEM
@@ -63,9 +63,9 @@ GEM
       addressable (>= 2.4)
     libdatadog (14.1.0.1.0-aarch64-linux)
     libdatadog (14.1.0.1.0-x86_64-linux)
-    libddwaf (1.15.0.0.0-aarch64-linux)
+    libddwaf (1.18.0.0.0-aarch64-linux)
       ffi (~> 1.0)
-    libddwaf (1.15.0.0.0-x86_64-linux)
+    libddwaf (1.18.0.0.0-x86_64-linux)
       ffi (~> 1.0)
     memory_profiler (0.9.14)
     method_source (1.0.0)

--- a/gemfiles/ruby_3.2_core_old.gemfile.lock
+++ b/gemfiles/ruby_3.2_core_old.gemfile.lock
@@ -14,7 +14,7 @@ PATH
     datadog (2.7.0)
       datadog-ruby_core_source (~> 3.3)
       libdatadog (~> 14.1.0.1.0)
-      libddwaf (~> 1.15.0.0.0)
+      libddwaf (~> 1.18.0.0.0)
       msgpack
 
 GEM
@@ -52,9 +52,9 @@ GEM
       addressable (>= 2.4)
     libdatadog (14.1.0.1.0-aarch64-linux)
     libdatadog (14.1.0.1.0-x86_64-linux)
-    libddwaf (1.15.0.0.0-aarch64-linux)
+    libddwaf (1.18.0.0.0-aarch64-linux)
       ffi (~> 1.0)
-    libddwaf (1.15.0.0.0-x86_64-linux)
+    libddwaf (1.18.0.0.0-x86_64-linux)
       ffi (~> 1.0)
     memory_profiler (0.9.14)
     method_source (1.0.0)

--- a/gemfiles/ruby_3.2_elasticsearch_7.gemfile.lock
+++ b/gemfiles/ruby_3.2_elasticsearch_7.gemfile.lock
@@ -14,7 +14,7 @@ PATH
     datadog (2.7.0)
       datadog-ruby_core_source (~> 3.3)
       libdatadog (~> 14.1.0.1.0)
-      libddwaf (~> 1.15.0.0.0)
+      libddwaf (~> 1.18.0.0.0)
       msgpack
 
 GEM
@@ -69,9 +69,9 @@ GEM
       addressable (>= 2.4)
     libdatadog (14.1.0.1.0-aarch64-linux)
     libdatadog (14.1.0.1.0-x86_64-linux)
-    libddwaf (1.15.0.0.0-aarch64-linux)
+    libddwaf (1.18.0.0.0-aarch64-linux)
       ffi (~> 1.0)
-    libddwaf (1.15.0.0.0-x86_64-linux)
+    libddwaf (1.18.0.0.0-x86_64-linux)
       ffi (~> 1.0)
     logger (1.6.1)
     memory_profiler (0.9.14)

--- a/gemfiles/ruby_3.2_elasticsearch_8.gemfile.lock
+++ b/gemfiles/ruby_3.2_elasticsearch_8.gemfile.lock
@@ -14,7 +14,7 @@ PATH
     datadog (2.7.0)
       datadog-ruby_core_source (~> 3.3)
       libdatadog (~> 14.1.0.1.0)
-      libddwaf (~> 1.15.0.0.0)
+      libddwaf (~> 1.18.0.0.0)
       msgpack
 
 GEM
@@ -67,9 +67,9 @@ GEM
       addressable (>= 2.4)
     libdatadog (14.1.0.1.0-aarch64-linux)
     libdatadog (14.1.0.1.0-x86_64-linux)
-    libddwaf (1.15.0.0.0-aarch64-linux)
+    libddwaf (1.18.0.0.0-aarch64-linux)
       ffi (~> 1.0)
-    libddwaf (1.15.0.0.0-x86_64-linux)
+    libddwaf (1.18.0.0.0-x86_64-linux)
       ffi (~> 1.0)
     logger (1.6.1)
     memory_profiler (0.9.14)

--- a/gemfiles/ruby_3.2_elasticsearch_latest.gemfile.lock
+++ b/gemfiles/ruby_3.2_elasticsearch_latest.gemfile.lock
@@ -14,7 +14,7 @@ PATH
     datadog (2.7.0)
       datadog-ruby_core_source (~> 3.3)
       libdatadog (~> 14.1.0.1.0)
-      libddwaf (~> 1.15.0.0.0)
+      libddwaf (~> 1.18.0.0.0)
       msgpack
 
 GEM
@@ -69,9 +69,9 @@ GEM
       addressable (>= 2.4)
     libdatadog (14.1.0.1.0-aarch64-linux)
     libdatadog (14.1.0.1.0-x86_64-linux)
-    libddwaf (1.15.0.0.0-aarch64-linux)
+    libddwaf (1.18.0.0.0-aarch64-linux)
       ffi (~> 1.0)
-    libddwaf (1.15.0.0.0-x86_64-linux)
+    libddwaf (1.18.0.0.0-x86_64-linux)
       ffi (~> 1.0)
     logger (1.6.1)
     memory_profiler (0.9.14)

--- a/gemfiles/ruby_3.2_graphql_1.13.gemfile.lock
+++ b/gemfiles/ruby_3.2_graphql_1.13.gemfile.lock
@@ -14,7 +14,7 @@ PATH
     datadog (2.7.0)
       datadog-ruby_core_source (~> 3.3)
       libdatadog (~> 14.1.0.1.0)
-      libddwaf (~> 1.15.0.0.0)
+      libddwaf (~> 1.18.0.0.0)
       msgpack
 
 GEM
@@ -121,9 +121,9 @@ GEM
       addressable (>= 2.4)
     libdatadog (14.1.0.1.0-aarch64-linux)
     libdatadog (14.1.0.1.0-x86_64-linux)
-    libddwaf (1.15.0.0.0-aarch64-linux)
+    libddwaf (1.18.0.0.0-aarch64-linux)
       ffi (~> 1.0)
-    libddwaf (1.15.0.0.0-x86_64-linux)
+    libddwaf (1.18.0.0.0-x86_64-linux)
       ffi (~> 1.0)
     lograge (0.14.0)
       actionpack (>= 4)

--- a/gemfiles/ruby_3.2_graphql_2.0.gemfile.lock
+++ b/gemfiles/ruby_3.2_graphql_2.0.gemfile.lock
@@ -14,7 +14,7 @@ PATH
     datadog (2.7.0)
       datadog-ruby_core_source (~> 3.3)
       libdatadog (~> 14.1.0.1.0)
-      libddwaf (~> 1.15.0.0.0)
+      libddwaf (~> 1.18.0.0.0)
       msgpack
 
 GEM
@@ -121,9 +121,9 @@ GEM
       addressable (>= 2.4)
     libdatadog (14.1.0.1.0-aarch64-linux)
     libdatadog (14.1.0.1.0-x86_64-linux)
-    libddwaf (1.15.0.0.0-aarch64-linux)
+    libddwaf (1.18.0.0.0-aarch64-linux)
       ffi (~> 1.0)
-    libddwaf (1.15.0.0.0-x86_64-linux)
+    libddwaf (1.18.0.0.0-x86_64-linux)
       ffi (~> 1.0)
     lograge (0.14.0)
       actionpack (>= 4)

--- a/gemfiles/ruby_3.2_graphql_2.1.gemfile.lock
+++ b/gemfiles/ruby_3.2_graphql_2.1.gemfile.lock
@@ -14,7 +14,7 @@ PATH
     datadog (2.7.0)
       datadog-ruby_core_source (~> 3.3)
       libdatadog (~> 14.1.0.1.0)
-      libddwaf (~> 1.15.0.0.0)
+      libddwaf (~> 1.18.0.0.0)
       msgpack
 
 GEM
@@ -122,9 +122,9 @@ GEM
       addressable (>= 2.4)
     libdatadog (14.1.0.1.0-aarch64-linux)
     libdatadog (14.1.0.1.0-x86_64-linux)
-    libddwaf (1.15.0.0.0-aarch64-linux)
+    libddwaf (1.18.0.0.0-aarch64-linux)
       ffi (~> 1.0)
-    libddwaf (1.15.0.0.0-x86_64-linux)
+    libddwaf (1.18.0.0.0-x86_64-linux)
       ffi (~> 1.0)
     lograge (0.14.0)
       actionpack (>= 4)

--- a/gemfiles/ruby_3.2_graphql_2.2.gemfile.lock
+++ b/gemfiles/ruby_3.2_graphql_2.2.gemfile.lock
@@ -14,7 +14,7 @@ PATH
     datadog (2.7.0)
       datadog-ruby_core_source (~> 3.3)
       libdatadog (~> 14.1.0.1.0)
-      libddwaf (~> 1.15.0.0.0)
+      libddwaf (~> 1.18.0.0.0)
       msgpack
 
 GEM
@@ -122,9 +122,9 @@ GEM
       addressable (>= 2.4)
     libdatadog (14.1.0.1.0-aarch64-linux)
     libdatadog (14.1.0.1.0-x86_64-linux)
-    libddwaf (1.15.0.0.0-aarch64-linux)
+    libddwaf (1.18.0.0.0-aarch64-linux)
       ffi (~> 1.0)
-    libddwaf (1.15.0.0.0-x86_64-linux)
+    libddwaf (1.18.0.0.0-x86_64-linux)
       ffi (~> 1.0)
     lograge (0.14.0)
       actionpack (>= 4)

--- a/gemfiles/ruby_3.2_graphql_2.3.gemfile.lock
+++ b/gemfiles/ruby_3.2_graphql_2.3.gemfile.lock
@@ -14,7 +14,7 @@ PATH
     datadog (2.7.0)
       datadog-ruby_core_source (~> 3.3)
       libdatadog (~> 14.1.0.1.0)
-      libddwaf (~> 1.15.0.0.0)
+      libddwaf (~> 1.18.0.0.0)
       msgpack
 
 GEM
@@ -125,9 +125,9 @@ GEM
       addressable (>= 2.4)
     libdatadog (14.1.0.1.0-aarch64-linux)
     libdatadog (14.1.0.1.0-x86_64-linux)
-    libddwaf (1.15.0.0.0-aarch64-linux)
+    libddwaf (1.18.0.0.0-aarch64-linux)
       ffi (~> 1.0)
-    libddwaf (1.15.0.0.0-x86_64-linux)
+    libddwaf (1.18.0.0.0-x86_64-linux)
       ffi (~> 1.0)
     lograge (0.14.0)
       actionpack (>= 4)

--- a/gemfiles/ruby_3.2_http.gemfile.lock
+++ b/gemfiles/ruby_3.2_http.gemfile.lock
@@ -14,7 +14,7 @@ PATH
     datadog (2.7.0)
       datadog-ruby_core_source (~> 3.3)
       libdatadog (~> 14.1.0.1.0)
-      libddwaf (~> 1.15.0.0.0)
+      libddwaf (~> 1.18.0.0.0)
       msgpack
 
 GEM
@@ -74,9 +74,9 @@ GEM
       addressable (>= 2.4)
     libdatadog (14.1.0.1.0-aarch64-linux)
     libdatadog (14.1.0.1.0-x86_64-linux)
-    libddwaf (1.15.0.0.0-aarch64-linux)
+    libddwaf (1.18.0.0.0-aarch64-linux)
       ffi (~> 1.0)
-    libddwaf (1.15.0.0.0-x86_64-linux)
+    libddwaf (1.18.0.0.0-x86_64-linux)
       ffi (~> 1.0)
     llhttp-ffi (0.3.1)
       ffi-compiler (~> 1.0)

--- a/gemfiles/ruby_3.2_opensearch_2.gemfile.lock
+++ b/gemfiles/ruby_3.2_opensearch_2.gemfile.lock
@@ -14,7 +14,7 @@ PATH
     datadog (2.7.0)
       datadog-ruby_core_source (~> 3.3)
       libdatadog (~> 14.1.0.1.0)
-      libddwaf (~> 1.15.0.0.0)
+      libddwaf (~> 1.18.0.0.0)
       msgpack
 
 GEM
@@ -59,9 +59,9 @@ GEM
       addressable (>= 2.4)
     libdatadog (14.1.0.1.0-aarch64-linux)
     libdatadog (14.1.0.1.0-x86_64-linux)
-    libddwaf (1.15.0.0.0-aarch64-linux)
+    libddwaf (1.18.0.0.0-aarch64-linux)
       ffi (~> 1.0)
-    libddwaf (1.15.0.0.0-x86_64-linux)
+    libddwaf (1.18.0.0.0-x86_64-linux)
       ffi (~> 1.0)
     logger (1.6.1)
     memory_profiler (0.9.14)

--- a/gemfiles/ruby_3.2_opensearch_3.gemfile.lock
+++ b/gemfiles/ruby_3.2_opensearch_3.gemfile.lock
@@ -14,7 +14,7 @@ PATH
     datadog (2.7.0)
       datadog-ruby_core_source (~> 3.3)
       libdatadog (~> 14.1.0.1.0)
-      libddwaf (~> 1.15.0.0.0)
+      libddwaf (~> 1.18.0.0.0)
       msgpack
 
 GEM
@@ -59,9 +59,9 @@ GEM
       addressable (>= 2.4)
     libdatadog (14.1.0.1.0-aarch64-linux)
     libdatadog (14.1.0.1.0-x86_64-linux)
-    libddwaf (1.15.0.0.0-aarch64-linux)
+    libddwaf (1.18.0.0.0-aarch64-linux)
       ffi (~> 1.0)
-    libddwaf (1.15.0.0.0-x86_64-linux)
+    libddwaf (1.18.0.0.0-x86_64-linux)
       ffi (~> 1.0)
     logger (1.6.1)
     memory_profiler (0.9.14)

--- a/gemfiles/ruby_3.2_opensearch_latest.gemfile.lock
+++ b/gemfiles/ruby_3.2_opensearch_latest.gemfile.lock
@@ -14,7 +14,7 @@ PATH
     datadog (2.7.0)
       datadog-ruby_core_source (~> 3.3)
       libdatadog (~> 14.1.0.1.0)
-      libddwaf (~> 1.15.0.0.0)
+      libddwaf (~> 1.18.0.0.0)
       msgpack
 
 GEM
@@ -61,9 +61,9 @@ GEM
       addressable (>= 2.4)
     libdatadog (14.1.0.1.0-aarch64-linux)
     libdatadog (14.1.0.1.0-x86_64-linux)
-    libddwaf (1.15.0.0.0-aarch64-linux)
+    libddwaf (1.18.0.0.0-aarch64-linux)
       ffi (~> 1.0)
-    libddwaf (1.15.0.0.0-x86_64-linux)
+    libddwaf (1.18.0.0.0-x86_64-linux)
       ffi (~> 1.0)
     logger (1.6.1)
     memory_profiler (0.9.14)

--- a/gemfiles/ruby_3.2_opentelemetry.gemfile.lock
+++ b/gemfiles/ruby_3.2_opentelemetry.gemfile.lock
@@ -14,7 +14,7 @@ PATH
     datadog (2.7.0)
       datadog-ruby_core_source (~> 3.3)
       libdatadog (~> 14.1.0.1.0)
-      libddwaf (~> 1.15.0.0.0)
+      libddwaf (~> 1.18.0.0.0)
       msgpack
 
 GEM
@@ -52,9 +52,9 @@ GEM
       addressable (>= 2.4)
     libdatadog (14.1.0.1.0-aarch64-linux)
     libdatadog (14.1.0.1.0-x86_64-linux)
-    libddwaf (1.15.0.0.0-aarch64-linux)
+    libddwaf (1.18.0.0.0-aarch64-linux)
       ffi (~> 1.0)
-    libddwaf (1.15.0.0.0-x86_64-linux)
+    libddwaf (1.18.0.0.0-x86_64-linux)
       ffi (~> 1.0)
     memory_profiler (0.9.14)
     method_source (1.0.0)

--- a/gemfiles/ruby_3.2_opentelemetry_otlp.gemfile.lock
+++ b/gemfiles/ruby_3.2_opentelemetry_otlp.gemfile.lock
@@ -14,7 +14,7 @@ PATH
     datadog (2.7.0)
       datadog-ruby_core_source (~> 3.3)
       libdatadog (~> 14.1.0.1.0)
-      libddwaf (~> 1.15.0.0.0)
+      libddwaf (~> 1.18.0.0.0)
       msgpack
 
 GEM
@@ -57,9 +57,9 @@ GEM
       addressable (>= 2.4)
     libdatadog (14.1.0.1.0-aarch64-linux)
     libdatadog (14.1.0.1.0-x86_64-linux)
-    libddwaf (1.15.0.0.0-aarch64-linux)
+    libddwaf (1.18.0.0.0-aarch64-linux)
       ffi (~> 1.0)
-    libddwaf (1.15.0.0.0-x86_64-linux)
+    libddwaf (1.18.0.0.0-x86_64-linux)
       ffi (~> 1.0)
     memory_profiler (0.9.14)
     method_source (1.0.0)

--- a/gemfiles/ruby_3.2_rack_1.gemfile.lock
+++ b/gemfiles/ruby_3.2_rack_1.gemfile.lock
@@ -14,7 +14,7 @@ PATH
     datadog (2.7.0)
       datadog-ruby_core_source (~> 3.3)
       libdatadog (~> 14.1.0.1.0)
-      libddwaf (~> 1.15.0.0.0)
+      libddwaf (~> 1.18.0.0.0)
       msgpack
 
 GEM
@@ -52,9 +52,9 @@ GEM
       addressable (>= 2.4)
     libdatadog (14.1.0.1.0-aarch64-linux)
     libdatadog (14.1.0.1.0-x86_64-linux)
-    libddwaf (1.15.0.0.0-aarch64-linux)
+    libddwaf (1.18.0.0.0-aarch64-linux)
       ffi (~> 1.0)
-    libddwaf (1.15.0.0.0-x86_64-linux)
+    libddwaf (1.18.0.0.0-x86_64-linux)
       ffi (~> 1.0)
     memory_profiler (0.9.14)
     method_source (1.0.0)

--- a/gemfiles/ruby_3.2_rack_2.gemfile.lock
+++ b/gemfiles/ruby_3.2_rack_2.gemfile.lock
@@ -14,7 +14,7 @@ PATH
     datadog (2.7.0)
       datadog-ruby_core_source (~> 3.3)
       libdatadog (~> 14.1.0.1.0)
-      libddwaf (~> 1.15.0.0.0)
+      libddwaf (~> 1.18.0.0.0)
       msgpack
 
 GEM
@@ -52,9 +52,9 @@ GEM
       addressable (>= 2.4)
     libdatadog (14.1.0.1.0-aarch64-linux)
     libdatadog (14.1.0.1.0-x86_64-linux)
-    libddwaf (1.15.0.0.0-aarch64-linux)
+    libddwaf (1.18.0.0.0-aarch64-linux)
       ffi (~> 1.0)
-    libddwaf (1.15.0.0.0-x86_64-linux)
+    libddwaf (1.18.0.0.0-x86_64-linux)
       ffi (~> 1.0)
     memory_profiler (0.9.14)
     method_source (1.0.0)

--- a/gemfiles/ruby_3.2_rack_3.gemfile.lock
+++ b/gemfiles/ruby_3.2_rack_3.gemfile.lock
@@ -14,7 +14,7 @@ PATH
     datadog (2.7.0)
       datadog-ruby_core_source (~> 3.3)
       libdatadog (~> 14.1.0.1.0)
-      libddwaf (~> 1.15.0.0.0)
+      libddwaf (~> 1.18.0.0.0)
       msgpack
 
 GEM
@@ -52,9 +52,9 @@ GEM
       addressable (>= 2.4)
     libdatadog (14.1.0.1.0-aarch64-linux)
     libdatadog (14.1.0.1.0-x86_64-linux)
-    libddwaf (1.15.0.0.0-aarch64-linux)
+    libddwaf (1.18.0.0.0-aarch64-linux)
       ffi (~> 1.0)
-    libddwaf (1.15.0.0.0-x86_64-linux)
+    libddwaf (1.18.0.0.0-x86_64-linux)
       ffi (~> 1.0)
     memory_profiler (0.9.14)
     method_source (1.0.0)

--- a/gemfiles/ruby_3.2_rack_latest.gemfile.lock
+++ b/gemfiles/ruby_3.2_rack_latest.gemfile.lock
@@ -14,7 +14,7 @@ PATH
     datadog (2.7.0)
       datadog-ruby_core_source (~> 3.3)
       libdatadog (~> 14.1.0.1.0)
-      libddwaf (~> 1.15.0.0.0)
+      libddwaf (~> 1.18.0.0.0)
       msgpack
 
 GEM
@@ -55,9 +55,9 @@ GEM
       addressable (>= 2.4)
     libdatadog (14.1.0.1.0-aarch64-linux)
     libdatadog (14.1.0.1.0-x86_64-linux)
-    libddwaf (1.15.0.0.0-aarch64-linux)
+    libddwaf (1.18.0.0.0-aarch64-linux)
       ffi (~> 1.0)
-    libddwaf (1.15.0.0.0-x86_64-linux)
+    libddwaf (1.18.0.0.0-x86_64-linux)
       ffi (~> 1.0)
     memory_profiler (0.9.14)
     method_source (1.1.0)

--- a/gemfiles/ruby_3.2_rails61_mysql2.gemfile.lock
+++ b/gemfiles/ruby_3.2_rails61_mysql2.gemfile.lock
@@ -14,7 +14,7 @@ PATH
     datadog (2.7.0)
       datadog-ruby_core_source (~> 3.3)
       libdatadog (~> 14.1.0.1.0)
-      libddwaf (~> 1.15.0.0.0)
+      libddwaf (~> 1.18.0.0.0)
       msgpack
 
 GEM
@@ -119,9 +119,9 @@ GEM
       addressable (>= 2.4)
     libdatadog (14.1.0.1.0-aarch64-linux)
     libdatadog (14.1.0.1.0-x86_64-linux)
-    libddwaf (1.15.0.0.0-aarch64-linux)
+    libddwaf (1.18.0.0.0-aarch64-linux)
       ffi (~> 1.0)
-    libddwaf (1.15.0.0.0-x86_64-linux)
+    libddwaf (1.18.0.0.0-x86_64-linux)
       ffi (~> 1.0)
     lograge (0.12.0)
       actionpack (>= 4)

--- a/gemfiles/ruby_3.2_rails61_postgres.gemfile.lock
+++ b/gemfiles/ruby_3.2_rails61_postgres.gemfile.lock
@@ -14,7 +14,7 @@ PATH
     datadog (2.7.0)
       datadog-ruby_core_source (~> 3.3)
       libdatadog (~> 14.1.0.1.0)
-      libddwaf (~> 1.15.0.0.0)
+      libddwaf (~> 1.18.0.0.0)
       msgpack
 
 GEM
@@ -119,9 +119,9 @@ GEM
       addressable (>= 2.4)
     libdatadog (14.1.0.1.0-aarch64-linux)
     libdatadog (14.1.0.1.0-x86_64-linux)
-    libddwaf (1.15.0.0.0-aarch64-linux)
+    libddwaf (1.18.0.0.0-aarch64-linux)
       ffi (~> 1.0)
-    libddwaf (1.15.0.0.0-x86_64-linux)
+    libddwaf (1.18.0.0.0-x86_64-linux)
       ffi (~> 1.0)
     lograge (0.12.0)
       actionpack (>= 4)

--- a/gemfiles/ruby_3.2_rails61_postgres_redis.gemfile.lock
+++ b/gemfiles/ruby_3.2_rails61_postgres_redis.gemfile.lock
@@ -14,7 +14,7 @@ PATH
     datadog (2.7.0)
       datadog-ruby_core_source (~> 3.3)
       libdatadog (~> 14.1.0.1.0)
-      libddwaf (~> 1.15.0.0.0)
+      libddwaf (~> 1.18.0.0.0)
       msgpack
 
 GEM
@@ -119,9 +119,9 @@ GEM
       addressable (>= 2.4)
     libdatadog (14.1.0.1.0-aarch64-linux)
     libdatadog (14.1.0.1.0-x86_64-linux)
-    libddwaf (1.15.0.0.0-aarch64-linux)
+    libddwaf (1.18.0.0.0-aarch64-linux)
       ffi (~> 1.0)
-    libddwaf (1.15.0.0.0-x86_64-linux)
+    libddwaf (1.18.0.0.0-x86_64-linux)
       ffi (~> 1.0)
     lograge (0.12.0)
       actionpack (>= 4)

--- a/gemfiles/ruby_3.2_rails61_postgres_sidekiq.gemfile.lock
+++ b/gemfiles/ruby_3.2_rails61_postgres_sidekiq.gemfile.lock
@@ -14,7 +14,7 @@ PATH
     datadog (2.7.0)
       datadog-ruby_core_source (~> 3.3)
       libdatadog (~> 14.1.0.1.0)
-      libddwaf (~> 1.15.0.0.0)
+      libddwaf (~> 1.18.0.0.0)
       msgpack
 
 GEM
@@ -120,9 +120,9 @@ GEM
       addressable (>= 2.4)
     libdatadog (14.1.0.1.0-aarch64-linux)
     libdatadog (14.1.0.1.0-x86_64-linux)
-    libddwaf (1.15.0.0.0-aarch64-linux)
+    libddwaf (1.18.0.0.0-aarch64-linux)
       ffi (~> 1.0)
-    libddwaf (1.15.0.0.0-x86_64-linux)
+    libddwaf (1.18.0.0.0-x86_64-linux)
       ffi (~> 1.0)
     lograge (0.12.0)
       actionpack (>= 4)

--- a/gemfiles/ruby_3.2_rails61_semantic_logger.gemfile.lock
+++ b/gemfiles/ruby_3.2_rails61_semantic_logger.gemfile.lock
@@ -14,7 +14,7 @@ PATH
     datadog (2.7.0)
       datadog-ruby_core_source (~> 3.3)
       libdatadog (~> 14.1.0.1.0)
-      libddwaf (~> 1.15.0.0.0)
+      libddwaf (~> 1.18.0.0.0)
       msgpack
 
 GEM
@@ -119,9 +119,9 @@ GEM
       addressable (>= 2.4)
     libdatadog (14.1.0.1.0-aarch64-linux)
     libdatadog (14.1.0.1.0-x86_64-linux)
-    libddwaf (1.15.0.0.0-aarch64-linux)
+    libddwaf (1.18.0.0.0-aarch64-linux)
       ffi (~> 1.0)
-    libddwaf (1.15.0.0.0-x86_64-linux)
+    libddwaf (1.18.0.0.0-x86_64-linux)
       ffi (~> 1.0)
     loofah (2.19.1)
       crass (~> 1.0.2)

--- a/gemfiles/ruby_3.2_rails61_trilogy.gemfile.lock
+++ b/gemfiles/ruby_3.2_rails61_trilogy.gemfile.lock
@@ -14,7 +14,7 @@ PATH
     datadog (2.7.0)
       datadog-ruby_core_source (~> 3.3)
       libdatadog (~> 14.1.0.1.0)
-      libddwaf (~> 1.15.0.0.0)
+      libddwaf (~> 1.18.0.0.0)
       msgpack
 
 GEM
@@ -123,9 +123,9 @@ GEM
       addressable (>= 2.4)
     libdatadog (14.1.0.1.0-aarch64-linux)
     libdatadog (14.1.0.1.0-x86_64-linux)
-    libddwaf (1.15.0.0.0-aarch64-linux)
+    libddwaf (1.18.0.0.0-aarch64-linux)
       ffi (~> 1.0)
-    libddwaf (1.15.0.0.0-x86_64-linux)
+    libddwaf (1.18.0.0.0-x86_64-linux)
       ffi (~> 1.0)
     lograge (0.14.0)
       actionpack (>= 4)

--- a/gemfiles/ruby_3.2_rails7.gemfile.lock
+++ b/gemfiles/ruby_3.2_rails7.gemfile.lock
@@ -14,7 +14,7 @@ PATH
     datadog (2.7.0)
       datadog-ruby_core_source (~> 3.3)
       libdatadog (~> 14.1.0.1.0)
-      libddwaf (~> 1.15.0.0.0)
+      libddwaf (~> 1.18.0.0.0)
       msgpack
 
 GEM
@@ -128,9 +128,9 @@ GEM
       addressable (>= 2.4)
     libdatadog (14.1.0.1.0-aarch64-linux)
     libdatadog (14.1.0.1.0-x86_64-linux)
-    libddwaf (1.15.0.0.0-aarch64-linux)
+    libddwaf (1.18.0.0.0-aarch64-linux)
       ffi (~> 1.0)
-    libddwaf (1.15.0.0.0-x86_64-linux)
+    libddwaf (1.18.0.0.0-x86_64-linux)
       ffi (~> 1.0)
     loofah (2.22.0)
       crass (~> 1.0.2)

--- a/gemfiles/ruby_3.2_rails71.gemfile.lock
+++ b/gemfiles/ruby_3.2_rails71.gemfile.lock
@@ -14,7 +14,7 @@ PATH
     datadog (2.7.0)
       datadog-ruby_core_source (~> 3.3)
       libdatadog (~> 14.1.0.1.0)
-      libddwaf (~> 1.15.0.0.0)
+      libddwaf (~> 1.18.0.0.0)
       msgpack
 
 GEM
@@ -144,9 +144,9 @@ GEM
       addressable (>= 2.4)
     libdatadog (14.1.0.1.0-aarch64-linux)
     libdatadog (14.1.0.1.0-x86_64-linux)
-    libddwaf (1.15.0.0.0-aarch64-linux)
+    libddwaf (1.18.0.0.0-aarch64-linux)
       ffi (~> 1.0)
-    libddwaf (1.15.0.0.0-x86_64-linux)
+    libddwaf (1.18.0.0.0-x86_64-linux)
       ffi (~> 1.0)
     loofah (2.22.0)
       crass (~> 1.0.2)

--- a/gemfiles/ruby_3.2_redis_3.gemfile.lock
+++ b/gemfiles/ruby_3.2_redis_3.gemfile.lock
@@ -14,7 +14,7 @@ PATH
     datadog (2.7.0)
       datadog-ruby_core_source (~> 3.3)
       libdatadog (~> 14.1.0.1.0)
-      libddwaf (~> 1.15.0.0.0)
+      libddwaf (~> 1.18.0.0.0)
       msgpack
 
 GEM
@@ -52,9 +52,9 @@ GEM
       addressable (>= 2.4)
     libdatadog (14.1.0.1.0-aarch64-linux)
     libdatadog (14.1.0.1.0-x86_64-linux)
-    libddwaf (1.15.0.0.0-aarch64-linux)
+    libddwaf (1.18.0.0.0-aarch64-linux)
       ffi (~> 1.0)
-    libddwaf (1.15.0.0.0-x86_64-linux)
+    libddwaf (1.18.0.0.0-x86_64-linux)
       ffi (~> 1.0)
     memory_profiler (0.9.14)
     method_source (1.0.0)

--- a/gemfiles/ruby_3.2_redis_4.gemfile.lock
+++ b/gemfiles/ruby_3.2_redis_4.gemfile.lock
@@ -14,7 +14,7 @@ PATH
     datadog (2.7.0)
       datadog-ruby_core_source (~> 3.3)
       libdatadog (~> 14.1.0.1.0)
-      libddwaf (~> 1.15.0.0.0)
+      libddwaf (~> 1.18.0.0.0)
       msgpack
 
 GEM
@@ -52,9 +52,9 @@ GEM
       addressable (>= 2.4)
     libdatadog (14.1.0.1.0-aarch64-linux)
     libdatadog (14.1.0.1.0-x86_64-linux)
-    libddwaf (1.15.0.0.0-aarch64-linux)
+    libddwaf (1.18.0.0.0-aarch64-linux)
       ffi (~> 1.0)
-    libddwaf (1.15.0.0.0-x86_64-linux)
+    libddwaf (1.18.0.0.0-x86_64-linux)
       ffi (~> 1.0)
     memory_profiler (0.9.14)
     method_source (1.0.0)

--- a/gemfiles/ruby_3.2_redis_5.gemfile.lock
+++ b/gemfiles/ruby_3.2_redis_5.gemfile.lock
@@ -14,7 +14,7 @@ PATH
     datadog (2.7.0)
       datadog-ruby_core_source (~> 3.3)
       libdatadog (~> 14.1.0.1.0)
-      libddwaf (~> 1.15.0.0.0)
+      libddwaf (~> 1.18.0.0.0)
       msgpack
 
 GEM
@@ -53,9 +53,9 @@ GEM
       addressable (>= 2.4)
     libdatadog (14.1.0.1.0-aarch64-linux)
     libdatadog (14.1.0.1.0-x86_64-linux)
-    libddwaf (1.15.0.0.0-aarch64-linux)
+    libddwaf (1.18.0.0.0-aarch64-linux)
       ffi (~> 1.0)
-    libddwaf (1.15.0.0.0-x86_64-linux)
+    libddwaf (1.18.0.0.0-x86_64-linux)
       ffi (~> 1.0)
     memory_profiler (0.9.14)
     method_source (1.0.0)

--- a/gemfiles/ruby_3.2_relational_db.gemfile.lock
+++ b/gemfiles/ruby_3.2_relational_db.gemfile.lock
@@ -14,7 +14,7 @@ PATH
     datadog (2.7.0)
       datadog-ruby_core_source (~> 3.3)
       libdatadog (~> 14.1.0.1.0)
-      libddwaf (~> 1.15.0.0.0)
+      libddwaf (~> 1.18.0.0.0)
       msgpack
 
 GEM
@@ -70,9 +70,9 @@ GEM
       addressable (>= 2.4)
     libdatadog (14.1.0.1.0-aarch64-linux)
     libdatadog (14.1.0.1.0-x86_64-linux)
-    libddwaf (1.15.0.0.0-aarch64-linux)
+    libddwaf (1.18.0.0.0-aarch64-linux)
       ffi (~> 1.0)
-    libddwaf (1.15.0.0.0-x86_64-linux)
+    libddwaf (1.18.0.0.0-x86_64-linux)
       ffi (~> 1.0)
     makara (0.6.0.pre)
       activerecord (>= 5.2.0)

--- a/gemfiles/ruby_3.2_resque2_redis3.gemfile.lock
+++ b/gemfiles/ruby_3.2_resque2_redis3.gemfile.lock
@@ -14,7 +14,7 @@ PATH
     datadog (2.7.0)
       datadog-ruby_core_source (~> 3.3)
       libdatadog (~> 14.1.0.1.0)
-      libddwaf (~> 1.15.0.0.0)
+      libddwaf (~> 1.18.0.0.0)
       msgpack
 
 GEM
@@ -52,9 +52,9 @@ GEM
       addressable (>= 2.4)
     libdatadog (14.1.0.1.0-aarch64-linux)
     libdatadog (14.1.0.1.0-x86_64-linux)
-    libddwaf (1.15.0.0.0-aarch64-linux)
+    libddwaf (1.18.0.0.0-aarch64-linux)
       ffi (~> 1.0)
-    libddwaf (1.15.0.0.0-x86_64-linux)
+    libddwaf (1.18.0.0.0-x86_64-linux)
       ffi (~> 1.0)
     memory_profiler (0.9.14)
     method_source (1.0.0)

--- a/gemfiles/ruby_3.2_resque2_redis4.gemfile.lock
+++ b/gemfiles/ruby_3.2_resque2_redis4.gemfile.lock
@@ -14,7 +14,7 @@ PATH
     datadog (2.7.0)
       datadog-ruby_core_source (~> 3.3)
       libdatadog (~> 14.1.0.1.0)
-      libddwaf (~> 1.15.0.0.0)
+      libddwaf (~> 1.18.0.0.0)
       msgpack
 
 GEM
@@ -53,9 +53,9 @@ GEM
       addressable (>= 2.4)
     libdatadog (14.1.0.1.0-aarch64-linux)
     libdatadog (14.1.0.1.0-x86_64-linux)
-    libddwaf (1.15.0.0.0-aarch64-linux)
+    libddwaf (1.18.0.0.0-aarch64-linux)
       ffi (~> 1.0)
-    libddwaf (1.15.0.0.0-x86_64-linux)
+    libddwaf (1.18.0.0.0-x86_64-linux)
       ffi (~> 1.0)
     memory_profiler (0.9.14)
     method_source (1.0.0)

--- a/gemfiles/ruby_3.2_sinatra_2.gemfile.lock
+++ b/gemfiles/ruby_3.2_sinatra_2.gemfile.lock
@@ -14,7 +14,7 @@ PATH
     datadog (2.7.0)
       datadog-ruby_core_source (~> 3.3)
       libdatadog (~> 14.1.0.1.0)
-      libddwaf (~> 1.15.0.0.0)
+      libddwaf (~> 1.18.0.0.0)
       msgpack
 
 GEM
@@ -55,9 +55,9 @@ GEM
       addressable (>= 2.4)
     libdatadog (14.1.0.1.0-aarch64-linux)
     libdatadog (14.1.0.1.0-x86_64-linux)
-    libddwaf (1.15.0.0.0-aarch64-linux)
+    libddwaf (1.18.0.0.0-aarch64-linux)
       ffi (~> 1.0)
-    libddwaf (1.15.0.0.0-x86_64-linux)
+    libddwaf (1.18.0.0.0-x86_64-linux)
       ffi (~> 1.0)
     memory_profiler (0.9.14)
     method_source (1.1.0)

--- a/gemfiles/ruby_3.2_sinatra_3.gemfile.lock
+++ b/gemfiles/ruby_3.2_sinatra_3.gemfile.lock
@@ -14,7 +14,7 @@ PATH
     datadog (2.7.0)
       datadog-ruby_core_source (~> 3.3)
       libdatadog (~> 14.1.0.1.0)
-      libddwaf (~> 1.15.0.0.0)
+      libddwaf (~> 1.18.0.0.0)
       msgpack
 
 GEM
@@ -56,9 +56,9 @@ GEM
       addressable (>= 2.4)
     libdatadog (14.1.0.1.0-aarch64-linux)
     libdatadog (14.1.0.1.0-x86_64-linux)
-    libddwaf (1.15.0.0.0-aarch64-linux)
+    libddwaf (1.18.0.0.0-aarch64-linux)
       ffi (~> 1.0)
-    libddwaf (1.15.0.0.0-x86_64-linux)
+    libddwaf (1.18.0.0.0-x86_64-linux)
       ffi (~> 1.0)
     memory_profiler (0.9.14)
     method_source (1.1.0)

--- a/gemfiles/ruby_3.2_sinatra_4.gemfile.lock
+++ b/gemfiles/ruby_3.2_sinatra_4.gemfile.lock
@@ -14,7 +14,7 @@ PATH
     datadog (2.7.0)
       datadog-ruby_core_source (~> 3.3)
       libdatadog (~> 14.1.0.1.0)
-      libddwaf (~> 1.15.0.0.0)
+      libddwaf (~> 1.18.0.0.0)
       msgpack
 
 GEM
@@ -56,9 +56,9 @@ GEM
       addressable (>= 2.4)
     libdatadog (14.1.0.1.0-aarch64-linux)
     libdatadog (14.1.0.1.0-x86_64-linux)
-    libddwaf (1.15.0.0.0-aarch64-linux)
+    libddwaf (1.18.0.0.0-aarch64-linux)
       ffi (~> 1.0)
-    libddwaf (1.15.0.0.0-x86_64-linux)
+    libddwaf (1.18.0.0.0-x86_64-linux)
       ffi (~> 1.0)
     memory_profiler (0.9.14)
     method_source (1.1.0)

--- a/gemfiles/ruby_3.2_stripe_10.gemfile.lock
+++ b/gemfiles/ruby_3.2_stripe_10.gemfile.lock
@@ -14,7 +14,7 @@ PATH
     datadog (2.7.0)
       datadog-ruby_core_source (~> 3.3)
       libdatadog (~> 14.1.0.1.0)
-      libddwaf (~> 1.15.0.0.0)
+      libddwaf (~> 1.18.0.0.0)
       msgpack
 
 GEM
@@ -55,9 +55,9 @@ GEM
       addressable (>= 2.4)
     libdatadog (14.1.0.1.0-aarch64-linux)
     libdatadog (14.1.0.1.0-x86_64-linux)
-    libddwaf (1.15.0.0.0-aarch64-linux)
+    libddwaf (1.18.0.0.0-aarch64-linux)
       ffi (~> 1.0)
-    libddwaf (1.15.0.0.0-x86_64-linux)
+    libddwaf (1.18.0.0.0-x86_64-linux)
       ffi (~> 1.0)
     memory_profiler (0.9.14)
     method_source (1.1.0)

--- a/gemfiles/ruby_3.2_stripe_11.gemfile.lock
+++ b/gemfiles/ruby_3.2_stripe_11.gemfile.lock
@@ -14,7 +14,7 @@ PATH
     datadog (2.7.0)
       datadog-ruby_core_source (~> 3.3)
       libdatadog (~> 14.1.0.1.0)
-      libddwaf (~> 1.15.0.0.0)
+      libddwaf (~> 1.18.0.0.0)
       msgpack
 
 GEM
@@ -55,9 +55,9 @@ GEM
       addressable (>= 2.4)
     libdatadog (14.1.0.1.0-aarch64-linux)
     libdatadog (14.1.0.1.0-x86_64-linux)
-    libddwaf (1.15.0.0.0-aarch64-linux)
+    libddwaf (1.18.0.0.0-aarch64-linux)
       ffi (~> 1.0)
-    libddwaf (1.15.0.0.0-x86_64-linux)
+    libddwaf (1.18.0.0.0-x86_64-linux)
       ffi (~> 1.0)
     memory_profiler (0.9.14)
     method_source (1.1.0)

--- a/gemfiles/ruby_3.2_stripe_12.gemfile.lock
+++ b/gemfiles/ruby_3.2_stripe_12.gemfile.lock
@@ -14,7 +14,7 @@ PATH
     datadog (2.7.0)
       datadog-ruby_core_source (~> 3.3)
       libdatadog (~> 14.1.0.1.0)
-      libddwaf (~> 1.15.0.0.0)
+      libddwaf (~> 1.18.0.0.0)
       msgpack
 
 GEM
@@ -55,9 +55,9 @@ GEM
       addressable (>= 2.4)
     libdatadog (14.1.0.1.0-aarch64-linux)
     libdatadog (14.1.0.1.0-x86_64-linux)
-    libddwaf (1.15.0.0.0-aarch64-linux)
+    libddwaf (1.18.0.0.0-aarch64-linux)
       ffi (~> 1.0)
-    libddwaf (1.15.0.0.0-x86_64-linux)
+    libddwaf (1.18.0.0.0-x86_64-linux)
       ffi (~> 1.0)
     memory_profiler (0.9.14)
     method_source (1.1.0)

--- a/gemfiles/ruby_3.2_stripe_7.gemfile.lock
+++ b/gemfiles/ruby_3.2_stripe_7.gemfile.lock
@@ -14,7 +14,7 @@ PATH
     datadog (2.7.0)
       datadog-ruby_core_source (~> 3.3)
       libdatadog (~> 14.1.0.1.0)
-      libddwaf (~> 1.15.0.0.0)
+      libddwaf (~> 1.18.0.0.0)
       msgpack
 
 GEM
@@ -55,9 +55,9 @@ GEM
       addressable (>= 2.4)
     libdatadog (14.1.0.1.0-aarch64-linux)
     libdatadog (14.1.0.1.0-x86_64-linux)
-    libddwaf (1.15.0.0.0-aarch64-linux)
+    libddwaf (1.18.0.0.0-aarch64-linux)
       ffi (~> 1.0)
-    libddwaf (1.15.0.0.0-x86_64-linux)
+    libddwaf (1.18.0.0.0-x86_64-linux)
       ffi (~> 1.0)
     memory_profiler (0.9.14)
     method_source (1.1.0)

--- a/gemfiles/ruby_3.2_stripe_8.gemfile.lock
+++ b/gemfiles/ruby_3.2_stripe_8.gemfile.lock
@@ -14,7 +14,7 @@ PATH
     datadog (2.7.0)
       datadog-ruby_core_source (~> 3.3)
       libdatadog (~> 14.1.0.1.0)
-      libddwaf (~> 1.15.0.0.0)
+      libddwaf (~> 1.18.0.0.0)
       msgpack
 
 GEM
@@ -55,9 +55,9 @@ GEM
       addressable (>= 2.4)
     libdatadog (14.1.0.1.0-aarch64-linux)
     libdatadog (14.1.0.1.0-x86_64-linux)
-    libddwaf (1.15.0.0.0-aarch64-linux)
+    libddwaf (1.18.0.0.0-aarch64-linux)
       ffi (~> 1.0)
-    libddwaf (1.15.0.0.0-x86_64-linux)
+    libddwaf (1.18.0.0.0-x86_64-linux)
       ffi (~> 1.0)
     memory_profiler (0.9.14)
     method_source (1.1.0)

--- a/gemfiles/ruby_3.2_stripe_9.gemfile.lock
+++ b/gemfiles/ruby_3.2_stripe_9.gemfile.lock
@@ -14,7 +14,7 @@ PATH
     datadog (2.7.0)
       datadog-ruby_core_source (~> 3.3)
       libdatadog (~> 14.1.0.1.0)
-      libddwaf (~> 1.15.0.0.0)
+      libddwaf (~> 1.18.0.0.0)
       msgpack
 
 GEM
@@ -55,9 +55,9 @@ GEM
       addressable (>= 2.4)
     libdatadog (14.1.0.1.0-aarch64-linux)
     libdatadog (14.1.0.1.0-x86_64-linux)
-    libddwaf (1.15.0.0.0-aarch64-linux)
+    libddwaf (1.18.0.0.0-aarch64-linux)
       ffi (~> 1.0)
-    libddwaf (1.15.0.0.0-x86_64-linux)
+    libddwaf (1.18.0.0.0-x86_64-linux)
       ffi (~> 1.0)
     memory_profiler (0.9.14)
     method_source (1.1.0)

--- a/gemfiles/ruby_3.2_stripe_latest.gemfile.lock
+++ b/gemfiles/ruby_3.2_stripe_latest.gemfile.lock
@@ -14,7 +14,7 @@ PATH
     datadog (2.7.0)
       datadog-ruby_core_source (~> 3.3)
       libdatadog (~> 14.1.0.1.0)
-      libddwaf (~> 1.15.0.0.0)
+      libddwaf (~> 1.18.0.0.0)
       msgpack
 
 GEM
@@ -55,9 +55,9 @@ GEM
       addressable (>= 2.4)
     libdatadog (14.1.0.1.0-aarch64-linux)
     libdatadog (14.1.0.1.0-x86_64-linux)
-    libddwaf (1.15.0.0.0-aarch64-linux)
+    libddwaf (1.18.0.0.0-aarch64-linux)
       ffi (~> 1.0)
-    libddwaf (1.15.0.0.0-x86_64-linux)
+    libddwaf (1.18.0.0.0-x86_64-linux)
       ffi (~> 1.0)
     memory_profiler (0.9.14)
     method_source (1.1.0)

--- a/gemfiles/ruby_3.2_stripe_min.gemfile.lock
+++ b/gemfiles/ruby_3.2_stripe_min.gemfile.lock
@@ -14,7 +14,7 @@ PATH
     datadog (2.7.0)
       datadog-ruby_core_source (~> 3.3)
       libdatadog (~> 14.1.0.1.0)
-      libddwaf (~> 1.15.0.0.0)
+      libddwaf (~> 1.18.0.0.0)
       msgpack
 
 GEM
@@ -55,9 +55,9 @@ GEM
       addressable (>= 2.4)
     libdatadog (14.1.0.1.0-aarch64-linux)
     libdatadog (14.1.0.1.0-x86_64-linux)
-    libddwaf (1.15.0.0.0-aarch64-linux)
+    libddwaf (1.18.0.0.0-aarch64-linux)
       ffi (~> 1.0)
-    libddwaf (1.15.0.0.0-x86_64-linux)
+    libddwaf (1.18.0.0.0-x86_64-linux)
       ffi (~> 1.0)
     memory_profiler (0.9.14)
     method_source (1.1.0)

--- a/gemfiles/ruby_3.3_activesupport.gemfile.lock
+++ b/gemfiles/ruby_3.3_activesupport.gemfile.lock
@@ -14,7 +14,7 @@ PATH
     datadog (2.7.0)
       datadog-ruby_core_source (~> 3.3)
       libdatadog (~> 14.1.0.1.0)
-      libddwaf (~> 1.15.0.0.0)
+      libddwaf (~> 1.18.0.0.0)
       msgpack
 
 GEM
@@ -108,9 +108,9 @@ GEM
     king_konf (1.0.1)
     libdatadog (14.1.0.1.0-aarch64-linux)
     libdatadog (14.1.0.1.0-x86_64-linux)
-    libddwaf (1.15.0.0.0-aarch64-linux)
+    libddwaf (1.18.0.0.0-aarch64-linux)
       ffi (~> 1.0)
-    libddwaf (1.15.0.0.0-x86_64-linux)
+    libddwaf (1.18.0.0.0-x86_64-linux)
       ffi (~> 1.0)
     lograge (0.14.0)
       actionpack (>= 4)

--- a/gemfiles/ruby_3.3_aws.gemfile.lock
+++ b/gemfiles/ruby_3.3_aws.gemfile.lock
@@ -14,7 +14,7 @@ PATH
     datadog (2.7.0)
       datadog-ruby_core_source (~> 3.3)
       libdatadog (~> 14.1.0.1.0)
-      libddwaf (~> 1.15.0.0.0)
+      libddwaf (~> 1.18.0.0.0)
       msgpack
 
 GEM
@@ -1473,9 +1473,9 @@ GEM
       addressable (>= 2.4)
     libdatadog (14.1.0.1.0-aarch64-linux)
     libdatadog (14.1.0.1.0-x86_64-linux)
-    libddwaf (1.15.0.0.0-aarch64-linux)
+    libddwaf (1.18.0.0.0-aarch64-linux)
       ffi (~> 1.0)
-    libddwaf (1.15.0.0.0-x86_64-linux)
+    libddwaf (1.18.0.0.0-x86_64-linux)
       ffi (~> 1.0)
     memory_profiler (0.9.14)
     method_source (1.0.0)

--- a/gemfiles/ruby_3.3_contrib.gemfile.lock
+++ b/gemfiles/ruby_3.3_contrib.gemfile.lock
@@ -14,7 +14,7 @@ PATH
     datadog (2.7.0)
       datadog-ruby_core_source (~> 3.3)
       libdatadog (~> 14.1.0.1.0)
-      libddwaf (~> 1.15.0.0.0)
+      libddwaf (~> 1.18.0.0.0)
       msgpack
 
 GEM
@@ -67,9 +67,9 @@ GEM
       addressable (>= 2.4)
     libdatadog (14.1.0.1.0-aarch64-linux)
     libdatadog (14.1.0.1.0-x86_64-linux)
-    libddwaf (1.15.0.0.0-aarch64-linux)
+    libddwaf (1.18.0.0.0-aarch64-linux)
       ffi (~> 1.0)
-    libddwaf (1.15.0.0.0-x86_64-linux)
+    libddwaf (1.18.0.0.0-x86_64-linux)
       ffi (~> 1.0)
     memory_profiler (0.9.14)
     method_source (1.0.0)

--- a/gemfiles/ruby_3.3_contrib_old.gemfile.lock
+++ b/gemfiles/ruby_3.3_contrib_old.gemfile.lock
@@ -14,7 +14,7 @@ PATH
     datadog (2.7.0)
       datadog-ruby_core_source (~> 3.3)
       libdatadog (~> 14.1.0.1.0)
-      libddwaf (~> 1.15.0.0.0)
+      libddwaf (~> 1.18.0.0.0)
       msgpack
 
 GEM
@@ -62,9 +62,9 @@ GEM
       addressable (>= 2.4)
     libdatadog (14.1.0.1.0-aarch64-linux)
     libdatadog (14.1.0.1.0-x86_64-linux)
-    libddwaf (1.15.0.0.0-aarch64-linux)
+    libddwaf (1.18.0.0.0-aarch64-linux)
       ffi (~> 1.0)
-    libddwaf (1.15.0.0.0-x86_64-linux)
+    libddwaf (1.18.0.0.0-x86_64-linux)
       ffi (~> 1.0)
     memory_profiler (0.9.14)
     method_source (1.0.0)

--- a/gemfiles/ruby_3.3_core_old.gemfile.lock
+++ b/gemfiles/ruby_3.3_core_old.gemfile.lock
@@ -14,7 +14,7 @@ PATH
     datadog (2.7.0)
       datadog-ruby_core_source (~> 3.3)
       libdatadog (~> 14.1.0.1.0)
-      libddwaf (~> 1.15.0.0.0)
+      libddwaf (~> 1.18.0.0.0)
       msgpack
 
 GEM
@@ -51,9 +51,9 @@ GEM
       addressable (>= 2.4)
     libdatadog (14.1.0.1.0-aarch64-linux)
     libdatadog (14.1.0.1.0-x86_64-linux)
-    libddwaf (1.15.0.0.0-aarch64-linux)
+    libddwaf (1.18.0.0.0-aarch64-linux)
       ffi (~> 1.0)
-    libddwaf (1.15.0.0.0-x86_64-linux)
+    libddwaf (1.18.0.0.0-x86_64-linux)
       ffi (~> 1.0)
     memory_profiler (0.9.14)
     method_source (1.0.0)

--- a/gemfiles/ruby_3.3_elasticsearch_7.gemfile.lock
+++ b/gemfiles/ruby_3.3_elasticsearch_7.gemfile.lock
@@ -14,7 +14,7 @@ PATH
     datadog (2.7.0)
       datadog-ruby_core_source (~> 3.3)
       libdatadog (~> 14.1.0.1.0)
-      libddwaf (~> 1.15.0.0.0)
+      libddwaf (~> 1.18.0.0.0)
       msgpack
 
 GEM
@@ -68,9 +68,9 @@ GEM
       addressable (>= 2.4)
     libdatadog (14.1.0.1.0-aarch64-linux)
     libdatadog (14.1.0.1.0-x86_64-linux)
-    libddwaf (1.15.0.0.0-aarch64-linux)
+    libddwaf (1.18.0.0.0-aarch64-linux)
       ffi (~> 1.0)
-    libddwaf (1.15.0.0.0-x86_64-linux)
+    libddwaf (1.18.0.0.0-x86_64-linux)
       ffi (~> 1.0)
     logger (1.6.1)
     memory_profiler (0.9.14)

--- a/gemfiles/ruby_3.3_elasticsearch_8.gemfile.lock
+++ b/gemfiles/ruby_3.3_elasticsearch_8.gemfile.lock
@@ -14,7 +14,7 @@ PATH
     datadog (2.7.0)
       datadog-ruby_core_source (~> 3.3)
       libdatadog (~> 14.1.0.1.0)
-      libddwaf (~> 1.15.0.0.0)
+      libddwaf (~> 1.18.0.0.0)
       msgpack
 
 GEM
@@ -66,9 +66,9 @@ GEM
       addressable (>= 2.4)
     libdatadog (14.1.0.1.0-aarch64-linux)
     libdatadog (14.1.0.1.0-x86_64-linux)
-    libddwaf (1.15.0.0.0-aarch64-linux)
+    libddwaf (1.18.0.0.0-aarch64-linux)
       ffi (~> 1.0)
-    libddwaf (1.15.0.0.0-x86_64-linux)
+    libddwaf (1.18.0.0.0-x86_64-linux)
       ffi (~> 1.0)
     logger (1.6.1)
     memory_profiler (0.9.14)

--- a/gemfiles/ruby_3.3_elasticsearch_latest.gemfile.lock
+++ b/gemfiles/ruby_3.3_elasticsearch_latest.gemfile.lock
@@ -14,7 +14,7 @@ PATH
     datadog (2.7.0)
       datadog-ruby_core_source (~> 3.3)
       libdatadog (~> 14.1.0.1.0)
-      libddwaf (~> 1.15.0.0.0)
+      libddwaf (~> 1.18.0.0.0)
       msgpack
 
 GEM
@@ -69,9 +69,9 @@ GEM
       addressable (>= 2.4)
     libdatadog (14.1.0.1.0-aarch64-linux)
     libdatadog (14.1.0.1.0-x86_64-linux)
-    libddwaf (1.15.0.0.0-aarch64-linux)
+    libddwaf (1.18.0.0.0-aarch64-linux)
       ffi (~> 1.0)
-    libddwaf (1.15.0.0.0-x86_64-linux)
+    libddwaf (1.18.0.0.0-x86_64-linux)
       ffi (~> 1.0)
     logger (1.6.1)
     memory_profiler (0.9.14)

--- a/gemfiles/ruby_3.3_graphql_1.13.gemfile.lock
+++ b/gemfiles/ruby_3.3_graphql_1.13.gemfile.lock
@@ -14,7 +14,7 @@ PATH
     datadog (2.7.0)
       datadog-ruby_core_source (~> 3.3)
       libdatadog (~> 14.1.0.1.0)
-      libddwaf (~> 1.15.0.0.0)
+      libddwaf (~> 1.18.0.0.0)
       msgpack
 
 GEM
@@ -121,9 +121,9 @@ GEM
       addressable (>= 2.4)
     libdatadog (14.1.0.1.0-aarch64-linux)
     libdatadog (14.1.0.1.0-x86_64-linux)
-    libddwaf (1.15.0.0.0-aarch64-linux)
+    libddwaf (1.18.0.0.0-aarch64-linux)
       ffi (~> 1.0)
-    libddwaf (1.15.0.0.0-x86_64-linux)
+    libddwaf (1.18.0.0.0-x86_64-linux)
       ffi (~> 1.0)
     lograge (0.14.0)
       actionpack (>= 4)

--- a/gemfiles/ruby_3.3_graphql_2.0.gemfile.lock
+++ b/gemfiles/ruby_3.3_graphql_2.0.gemfile.lock
@@ -14,7 +14,7 @@ PATH
     datadog (2.7.0)
       datadog-ruby_core_source (~> 3.3)
       libdatadog (~> 14.1.0.1.0)
-      libddwaf (~> 1.15.0.0.0)
+      libddwaf (~> 1.18.0.0.0)
       msgpack
 
 GEM
@@ -121,9 +121,9 @@ GEM
       addressable (>= 2.4)
     libdatadog (14.1.0.1.0-aarch64-linux)
     libdatadog (14.1.0.1.0-x86_64-linux)
-    libddwaf (1.15.0.0.0-aarch64-linux)
+    libddwaf (1.18.0.0.0-aarch64-linux)
       ffi (~> 1.0)
-    libddwaf (1.15.0.0.0-x86_64-linux)
+    libddwaf (1.18.0.0.0-x86_64-linux)
       ffi (~> 1.0)
     lograge (0.14.0)
       actionpack (>= 4)

--- a/gemfiles/ruby_3.3_graphql_2.1.gemfile.lock
+++ b/gemfiles/ruby_3.3_graphql_2.1.gemfile.lock
@@ -14,7 +14,7 @@ PATH
     datadog (2.7.0)
       datadog-ruby_core_source (~> 3.3)
       libdatadog (~> 14.1.0.1.0)
-      libddwaf (~> 1.15.0.0.0)
+      libddwaf (~> 1.18.0.0.0)
       msgpack
 
 GEM
@@ -122,9 +122,9 @@ GEM
       addressable (>= 2.4)
     libdatadog (14.1.0.1.0-aarch64-linux)
     libdatadog (14.1.0.1.0-x86_64-linux)
-    libddwaf (1.15.0.0.0-aarch64-linux)
+    libddwaf (1.18.0.0.0-aarch64-linux)
       ffi (~> 1.0)
-    libddwaf (1.15.0.0.0-x86_64-linux)
+    libddwaf (1.18.0.0.0-x86_64-linux)
       ffi (~> 1.0)
     lograge (0.14.0)
       actionpack (>= 4)

--- a/gemfiles/ruby_3.3_graphql_2.2.gemfile.lock
+++ b/gemfiles/ruby_3.3_graphql_2.2.gemfile.lock
@@ -14,7 +14,7 @@ PATH
     datadog (2.7.0)
       datadog-ruby_core_source (~> 3.3)
       libdatadog (~> 14.1.0.1.0)
-      libddwaf (~> 1.15.0.0.0)
+      libddwaf (~> 1.18.0.0.0)
       msgpack
 
 GEM
@@ -122,9 +122,9 @@ GEM
       addressable (>= 2.4)
     libdatadog (14.1.0.1.0-aarch64-linux)
     libdatadog (14.1.0.1.0-x86_64-linux)
-    libddwaf (1.15.0.0.0-aarch64-linux)
+    libddwaf (1.18.0.0.0-aarch64-linux)
       ffi (~> 1.0)
-    libddwaf (1.15.0.0.0-x86_64-linux)
+    libddwaf (1.18.0.0.0-x86_64-linux)
       ffi (~> 1.0)
     lograge (0.14.0)
       actionpack (>= 4)

--- a/gemfiles/ruby_3.3_graphql_2.3.gemfile.lock
+++ b/gemfiles/ruby_3.3_graphql_2.3.gemfile.lock
@@ -14,7 +14,7 @@ PATH
     datadog (2.7.0)
       datadog-ruby_core_source (~> 3.3)
       libdatadog (~> 14.1.0.1.0)
-      libddwaf (~> 1.15.0.0.0)
+      libddwaf (~> 1.18.0.0.0)
       msgpack
 
 GEM
@@ -125,9 +125,9 @@ GEM
       addressable (>= 2.4)
     libdatadog (14.1.0.1.0-aarch64-linux)
     libdatadog (14.1.0.1.0-x86_64-linux)
-    libddwaf (1.15.0.0.0-aarch64-linux)
+    libddwaf (1.18.0.0.0-aarch64-linux)
       ffi (~> 1.0)
-    libddwaf (1.15.0.0.0-x86_64-linux)
+    libddwaf (1.18.0.0.0-x86_64-linux)
       ffi (~> 1.0)
     lograge (0.14.0)
       actionpack (>= 4)

--- a/gemfiles/ruby_3.3_http.gemfile.lock
+++ b/gemfiles/ruby_3.3_http.gemfile.lock
@@ -14,7 +14,7 @@ PATH
     datadog (2.7.0)
       datadog-ruby_core_source (~> 3.3)
       libdatadog (~> 14.1.0.1.0)
-      libddwaf (~> 1.15.0.0.0)
+      libddwaf (~> 1.18.0.0.0)
       msgpack
 
 GEM
@@ -73,9 +73,9 @@ GEM
       addressable (>= 2.4)
     libdatadog (14.1.0.1.0-aarch64-linux)
     libdatadog (14.1.0.1.0-x86_64-linux)
-    libddwaf (1.15.0.0.0-aarch64-linux)
+    libddwaf (1.18.0.0.0-aarch64-linux)
       ffi (~> 1.0)
-    libddwaf (1.15.0.0.0-x86_64-linux)
+    libddwaf (1.18.0.0.0-x86_64-linux)
       ffi (~> 1.0)
     llhttp-ffi (0.3.1)
       ffi-compiler (~> 1.0)

--- a/gemfiles/ruby_3.3_opensearch_2.gemfile.lock
+++ b/gemfiles/ruby_3.3_opensearch_2.gemfile.lock
@@ -14,7 +14,7 @@ PATH
     datadog (2.7.0)
       datadog-ruby_core_source (~> 3.3)
       libdatadog (~> 14.1.0.1.0)
-      libddwaf (~> 1.15.0.0.0)
+      libddwaf (~> 1.18.0.0.0)
       msgpack
 
 GEM
@@ -58,9 +58,9 @@ GEM
       addressable (>= 2.4)
     libdatadog (14.1.0.1.0-aarch64-linux)
     libdatadog (14.1.0.1.0-x86_64-linux)
-    libddwaf (1.15.0.0.0-aarch64-linux)
+    libddwaf (1.18.0.0.0-aarch64-linux)
       ffi (~> 1.0)
-    libddwaf (1.15.0.0.0-x86_64-linux)
+    libddwaf (1.18.0.0.0-x86_64-linux)
       ffi (~> 1.0)
     logger (1.6.1)
     memory_profiler (0.9.14)

--- a/gemfiles/ruby_3.3_opensearch_3.gemfile.lock
+++ b/gemfiles/ruby_3.3_opensearch_3.gemfile.lock
@@ -14,7 +14,7 @@ PATH
     datadog (2.7.0)
       datadog-ruby_core_source (~> 3.3)
       libdatadog (~> 14.1.0.1.0)
-      libddwaf (~> 1.15.0.0.0)
+      libddwaf (~> 1.18.0.0.0)
       msgpack
 
 GEM
@@ -58,9 +58,9 @@ GEM
       addressable (>= 2.4)
     libdatadog (14.1.0.1.0-aarch64-linux)
     libdatadog (14.1.0.1.0-x86_64-linux)
-    libddwaf (1.15.0.0.0-aarch64-linux)
+    libddwaf (1.18.0.0.0-aarch64-linux)
       ffi (~> 1.0)
-    libddwaf (1.15.0.0.0-x86_64-linux)
+    libddwaf (1.18.0.0.0-x86_64-linux)
       ffi (~> 1.0)
     logger (1.6.1)
     memory_profiler (0.9.14)

--- a/gemfiles/ruby_3.3_opensearch_latest.gemfile.lock
+++ b/gemfiles/ruby_3.3_opensearch_latest.gemfile.lock
@@ -14,7 +14,7 @@ PATH
     datadog (2.7.0)
       datadog-ruby_core_source (~> 3.3)
       libdatadog (~> 14.1.0.1.0)
-      libddwaf (~> 1.15.0.0.0)
+      libddwaf (~> 1.18.0.0.0)
       msgpack
 
 GEM
@@ -61,9 +61,9 @@ GEM
       addressable (>= 2.4)
     libdatadog (14.1.0.1.0-aarch64-linux)
     libdatadog (14.1.0.1.0-x86_64-linux)
-    libddwaf (1.15.0.0.0-aarch64-linux)
+    libddwaf (1.18.0.0.0-aarch64-linux)
       ffi (~> 1.0)
-    libddwaf (1.15.0.0.0-x86_64-linux)
+    libddwaf (1.18.0.0.0-x86_64-linux)
       ffi (~> 1.0)
     logger (1.6.1)
     memory_profiler (0.9.14)

--- a/gemfiles/ruby_3.3_opentelemetry.gemfile.lock
+++ b/gemfiles/ruby_3.3_opentelemetry.gemfile.lock
@@ -14,7 +14,7 @@ PATH
     datadog (2.7.0)
       datadog-ruby_core_source (~> 3.3)
       libdatadog (~> 14.1.0.1.0)
-      libddwaf (~> 1.15.0.0.0)
+      libddwaf (~> 1.18.0.0.0)
       msgpack
 
 GEM
@@ -51,9 +51,9 @@ GEM
       addressable (>= 2.4)
     libdatadog (14.1.0.1.0-aarch64-linux)
     libdatadog (14.1.0.1.0-x86_64-linux)
-    libddwaf (1.15.0.0.0-aarch64-linux)
+    libddwaf (1.18.0.0.0-aarch64-linux)
       ffi (~> 1.0)
-    libddwaf (1.15.0.0.0-x86_64-linux)
+    libddwaf (1.18.0.0.0-x86_64-linux)
       ffi (~> 1.0)
     memory_profiler (0.9.14)
     method_source (1.0.0)

--- a/gemfiles/ruby_3.3_opentelemetry_otlp.gemfile.lock
+++ b/gemfiles/ruby_3.3_opentelemetry_otlp.gemfile.lock
@@ -14,7 +14,7 @@ PATH
     datadog (2.7.0)
       datadog-ruby_core_source (~> 3.3)
       libdatadog (~> 14.1.0.1.0)
-      libddwaf (~> 1.15.0.0.0)
+      libddwaf (~> 1.18.0.0.0)
       msgpack
 
 GEM
@@ -57,9 +57,9 @@ GEM
       addressable (>= 2.4)
     libdatadog (14.1.0.1.0-aarch64-linux)
     libdatadog (14.1.0.1.0-x86_64-linux)
-    libddwaf (1.15.0.0.0-aarch64-linux)
+    libddwaf (1.18.0.0.0-aarch64-linux)
       ffi (~> 1.0)
-    libddwaf (1.15.0.0.0-x86_64-linux)
+    libddwaf (1.18.0.0.0-x86_64-linux)
       ffi (~> 1.0)
     memory_profiler (0.9.14)
     method_source (1.0.0)

--- a/gemfiles/ruby_3.3_rack_2.gemfile.lock
+++ b/gemfiles/ruby_3.3_rack_2.gemfile.lock
@@ -14,7 +14,7 @@ PATH
     datadog (2.7.0)
       datadog-ruby_core_source (~> 3.3)
       libdatadog (~> 14.1.0.1.0)
-      libddwaf (~> 1.15.0.0.0)
+      libddwaf (~> 1.18.0.0.0)
       msgpack
 
 GEM
@@ -51,9 +51,9 @@ GEM
       addressable (>= 2.4)
     libdatadog (14.1.0.1.0-aarch64-linux)
     libdatadog (14.1.0.1.0-x86_64-linux)
-    libddwaf (1.15.0.0.0-aarch64-linux)
+    libddwaf (1.18.0.0.0-aarch64-linux)
       ffi (~> 1.0)
-    libddwaf (1.15.0.0.0-x86_64-linux)
+    libddwaf (1.18.0.0.0-x86_64-linux)
       ffi (~> 1.0)
     memory_profiler (0.9.14)
     method_source (1.0.0)

--- a/gemfiles/ruby_3.3_rack_3.gemfile.lock
+++ b/gemfiles/ruby_3.3_rack_3.gemfile.lock
@@ -14,7 +14,7 @@ PATH
     datadog (2.7.0)
       datadog-ruby_core_source (~> 3.3)
       libdatadog (~> 14.1.0.1.0)
-      libddwaf (~> 1.15.0.0.0)
+      libddwaf (~> 1.18.0.0.0)
       msgpack
 
 GEM
@@ -51,9 +51,9 @@ GEM
       addressable (>= 2.4)
     libdatadog (14.1.0.1.0-aarch64-linux)
     libdatadog (14.1.0.1.0-x86_64-linux)
-    libddwaf (1.15.0.0.0-aarch64-linux)
+    libddwaf (1.18.0.0.0-aarch64-linux)
       ffi (~> 1.0)
-    libddwaf (1.15.0.0.0-x86_64-linux)
+    libddwaf (1.18.0.0.0-x86_64-linux)
       ffi (~> 1.0)
     memory_profiler (0.9.14)
     method_source (1.0.0)

--- a/gemfiles/ruby_3.3_rack_latest.gemfile.lock
+++ b/gemfiles/ruby_3.3_rack_latest.gemfile.lock
@@ -14,7 +14,7 @@ PATH
     datadog (2.7.0)
       datadog-ruby_core_source (~> 3.3)
       libdatadog (~> 14.1.0.1.0)
-      libddwaf (~> 1.15.0.0.0)
+      libddwaf (~> 1.18.0.0.0)
       msgpack
 
 GEM
@@ -55,9 +55,9 @@ GEM
       addressable (>= 2.4)
     libdatadog (14.1.0.1.0-aarch64-linux)
     libdatadog (14.1.0.1.0-x86_64-linux)
-    libddwaf (1.15.0.0.0-aarch64-linux)
+    libddwaf (1.18.0.0.0-aarch64-linux)
       ffi (~> 1.0)
-    libddwaf (1.15.0.0.0-x86_64-linux)
+    libddwaf (1.18.0.0.0-x86_64-linux)
       ffi (~> 1.0)
     memory_profiler (0.9.14)
     method_source (1.1.0)

--- a/gemfiles/ruby_3.3_rails61_mysql2.gemfile.lock
+++ b/gemfiles/ruby_3.3_rails61_mysql2.gemfile.lock
@@ -14,7 +14,7 @@ PATH
     datadog (2.7.0)
       datadog-ruby_core_source (~> 3.3)
       libdatadog (~> 14.1.0.1.0)
-      libddwaf (~> 1.15.0.0.0)
+      libddwaf (~> 1.18.0.0.0)
       msgpack
 
 GEM
@@ -118,9 +118,9 @@ GEM
       addressable (>= 2.4)
     libdatadog (14.1.0.1.0-aarch64-linux)
     libdatadog (14.1.0.1.0-x86_64-linux)
-    libddwaf (1.15.0.0.0-aarch64-linux)
+    libddwaf (1.18.0.0.0-aarch64-linux)
       ffi (~> 1.0)
-    libddwaf (1.15.0.0.0-x86_64-linux)
+    libddwaf (1.18.0.0.0-x86_64-linux)
       ffi (~> 1.0)
     lograge (0.14.0)
       actionpack (>= 4)

--- a/gemfiles/ruby_3.3_rails61_postgres.gemfile.lock
+++ b/gemfiles/ruby_3.3_rails61_postgres.gemfile.lock
@@ -14,7 +14,7 @@ PATH
     datadog (2.7.0)
       datadog-ruby_core_source (~> 3.3)
       libdatadog (~> 14.1.0.1.0)
-      libddwaf (~> 1.15.0.0.0)
+      libddwaf (~> 1.18.0.0.0)
       msgpack
 
 GEM
@@ -118,9 +118,9 @@ GEM
       addressable (>= 2.4)
     libdatadog (14.1.0.1.0-aarch64-linux)
     libdatadog (14.1.0.1.0-x86_64-linux)
-    libddwaf (1.15.0.0.0-aarch64-linux)
+    libddwaf (1.18.0.0.0-aarch64-linux)
       ffi (~> 1.0)
-    libddwaf (1.15.0.0.0-x86_64-linux)
+    libddwaf (1.18.0.0.0-x86_64-linux)
       ffi (~> 1.0)
     lograge (0.14.0)
       actionpack (>= 4)

--- a/gemfiles/ruby_3.3_rails61_postgres_redis.gemfile.lock
+++ b/gemfiles/ruby_3.3_rails61_postgres_redis.gemfile.lock
@@ -14,7 +14,7 @@ PATH
     datadog (2.7.0)
       datadog-ruby_core_source (~> 3.3)
       libdatadog (~> 14.1.0.1.0)
-      libddwaf (~> 1.15.0.0.0)
+      libddwaf (~> 1.18.0.0.0)
       msgpack
 
 GEM
@@ -118,9 +118,9 @@ GEM
       addressable (>= 2.4)
     libdatadog (14.1.0.1.0-aarch64-linux)
     libdatadog (14.1.0.1.0-x86_64-linux)
-    libddwaf (1.15.0.0.0-aarch64-linux)
+    libddwaf (1.18.0.0.0-aarch64-linux)
       ffi (~> 1.0)
-    libddwaf (1.15.0.0.0-x86_64-linux)
+    libddwaf (1.18.0.0.0-x86_64-linux)
       ffi (~> 1.0)
     lograge (0.14.0)
       actionpack (>= 4)

--- a/gemfiles/ruby_3.3_rails61_postgres_sidekiq.gemfile.lock
+++ b/gemfiles/ruby_3.3_rails61_postgres_sidekiq.gemfile.lock
@@ -14,7 +14,7 @@ PATH
     datadog (2.7.0)
       datadog-ruby_core_source (~> 3.3)
       libdatadog (~> 14.1.0.1.0)
-      libddwaf (~> 1.15.0.0.0)
+      libddwaf (~> 1.18.0.0.0)
       msgpack
 
 GEM
@@ -119,9 +119,9 @@ GEM
       addressable (>= 2.4)
     libdatadog (14.1.0.1.0-aarch64-linux)
     libdatadog (14.1.0.1.0-x86_64-linux)
-    libddwaf (1.15.0.0.0-aarch64-linux)
+    libddwaf (1.18.0.0.0-aarch64-linux)
       ffi (~> 1.0)
-    libddwaf (1.15.0.0.0-x86_64-linux)
+    libddwaf (1.18.0.0.0-x86_64-linux)
       ffi (~> 1.0)
     lograge (0.14.0)
       actionpack (>= 4)

--- a/gemfiles/ruby_3.3_rails61_semantic_logger.gemfile.lock
+++ b/gemfiles/ruby_3.3_rails61_semantic_logger.gemfile.lock
@@ -14,7 +14,7 @@ PATH
     datadog (2.7.0)
       datadog-ruby_core_source (~> 3.3)
       libdatadog (~> 14.1.0.1.0)
-      libddwaf (~> 1.15.0.0.0)
+      libddwaf (~> 1.18.0.0.0)
       msgpack
 
 GEM
@@ -118,9 +118,9 @@ GEM
       addressable (>= 2.4)
     libdatadog (14.1.0.1.0-aarch64-linux)
     libdatadog (14.1.0.1.0-x86_64-linux)
-    libddwaf (1.15.0.0.0-aarch64-linux)
+    libddwaf (1.18.0.0.0-aarch64-linux)
       ffi (~> 1.0)
-    libddwaf (1.15.0.0.0-x86_64-linux)
+    libddwaf (1.18.0.0.0-x86_64-linux)
       ffi (~> 1.0)
     loofah (2.23.1)
       crass (~> 1.0.2)

--- a/gemfiles/ruby_3.3_rails61_trilogy.gemfile.lock
+++ b/gemfiles/ruby_3.3_rails61_trilogy.gemfile.lock
@@ -14,7 +14,7 @@ PATH
     datadog (2.7.0)
       datadog-ruby_core_source (~> 3.3)
       libdatadog (~> 14.1.0.1.0)
-      libddwaf (~> 1.15.0.0.0)
+      libddwaf (~> 1.18.0.0.0)
       msgpack
 
 GEM
@@ -122,9 +122,9 @@ GEM
       addressable (>= 2.4)
     libdatadog (14.1.0.1.0-aarch64-linux)
     libdatadog (14.1.0.1.0-x86_64-linux)
-    libddwaf (1.15.0.0.0-aarch64-linux)
+    libddwaf (1.18.0.0.0-aarch64-linux)
       ffi (~> 1.0)
-    libddwaf (1.15.0.0.0-x86_64-linux)
+    libddwaf (1.18.0.0.0-x86_64-linux)
       ffi (~> 1.0)
     lograge (0.14.0)
       actionpack (>= 4)

--- a/gemfiles/ruby_3.3_rails7.gemfile.lock
+++ b/gemfiles/ruby_3.3_rails7.gemfile.lock
@@ -14,7 +14,7 @@ PATH
     datadog (2.7.0)
       datadog-ruby_core_source (~> 3.3)
       libdatadog (~> 14.1.0.1.0)
-      libddwaf (~> 1.15.0.0.0)
+      libddwaf (~> 1.18.0.0.0)
       msgpack
 
 GEM
@@ -128,9 +128,9 @@ GEM
       addressable (>= 2.4)
     libdatadog (14.1.0.1.0-aarch64-linux)
     libdatadog (14.1.0.1.0-x86_64-linux)
-    libddwaf (1.15.0.0.0-aarch64-linux)
+    libddwaf (1.18.0.0.0-aarch64-linux)
       ffi (~> 1.0)
-    libddwaf (1.15.0.0.0-x86_64-linux)
+    libddwaf (1.18.0.0.0-x86_64-linux)
       ffi (~> 1.0)
     loofah (2.22.0)
       crass (~> 1.0.2)

--- a/gemfiles/ruby_3.3_rails71.gemfile.lock
+++ b/gemfiles/ruby_3.3_rails71.gemfile.lock
@@ -14,7 +14,7 @@ PATH
     datadog (2.7.0)
       datadog-ruby_core_source (~> 3.3)
       libdatadog (~> 14.1.0.1.0)
-      libddwaf (~> 1.15.0.0.0)
+      libddwaf (~> 1.18.0.0.0)
       msgpack
 
 GEM
@@ -144,9 +144,9 @@ GEM
       addressable (>= 2.4)
     libdatadog (14.1.0.1.0-aarch64-linux)
     libdatadog (14.1.0.1.0-x86_64-linux)
-    libddwaf (1.15.0.0.0-aarch64-linux)
+    libddwaf (1.18.0.0.0-aarch64-linux)
       ffi (~> 1.0)
-    libddwaf (1.15.0.0.0-x86_64-linux)
+    libddwaf (1.18.0.0.0-x86_64-linux)
       ffi (~> 1.0)
     loofah (2.22.0)
       crass (~> 1.0.2)

--- a/gemfiles/ruby_3.3_redis_3.gemfile.lock
+++ b/gemfiles/ruby_3.3_redis_3.gemfile.lock
@@ -14,7 +14,7 @@ PATH
     datadog (2.7.0)
       datadog-ruby_core_source (~> 3.3)
       libdatadog (~> 14.1.0.1.0)
-      libddwaf (~> 1.15.0.0.0)
+      libddwaf (~> 1.18.0.0.0)
       msgpack
 
 GEM
@@ -51,9 +51,9 @@ GEM
       addressable (>= 2.4)
     libdatadog (14.1.0.1.0-aarch64-linux)
     libdatadog (14.1.0.1.0-x86_64-linux)
-    libddwaf (1.15.0.0.0-aarch64-linux)
+    libddwaf (1.18.0.0.0-aarch64-linux)
       ffi (~> 1.0)
-    libddwaf (1.15.0.0.0-x86_64-linux)
+    libddwaf (1.18.0.0.0-x86_64-linux)
       ffi (~> 1.0)
     memory_profiler (0.9.14)
     method_source (1.0.0)

--- a/gemfiles/ruby_3.3_redis_4.gemfile.lock
+++ b/gemfiles/ruby_3.3_redis_4.gemfile.lock
@@ -14,7 +14,7 @@ PATH
     datadog (2.7.0)
       datadog-ruby_core_source (~> 3.3)
       libdatadog (~> 14.1.0.1.0)
-      libddwaf (~> 1.15.0.0.0)
+      libddwaf (~> 1.18.0.0.0)
       msgpack
 
 GEM
@@ -51,9 +51,9 @@ GEM
       addressable (>= 2.4)
     libdatadog (14.1.0.1.0-aarch64-linux)
     libdatadog (14.1.0.1.0-x86_64-linux)
-    libddwaf (1.15.0.0.0-aarch64-linux)
+    libddwaf (1.18.0.0.0-aarch64-linux)
       ffi (~> 1.0)
-    libddwaf (1.15.0.0.0-x86_64-linux)
+    libddwaf (1.18.0.0.0-x86_64-linux)
       ffi (~> 1.0)
     memory_profiler (0.9.14)
     method_source (1.0.0)

--- a/gemfiles/ruby_3.3_redis_5.gemfile.lock
+++ b/gemfiles/ruby_3.3_redis_5.gemfile.lock
@@ -14,7 +14,7 @@ PATH
     datadog (2.7.0)
       datadog-ruby_core_source (~> 3.3)
       libdatadog (~> 14.1.0.1.0)
-      libddwaf (~> 1.15.0.0.0)
+      libddwaf (~> 1.18.0.0.0)
       msgpack
 
 GEM
@@ -52,9 +52,9 @@ GEM
       addressable (>= 2.4)
     libdatadog (14.1.0.1.0-aarch64-linux)
     libdatadog (14.1.0.1.0-x86_64-linux)
-    libddwaf (1.15.0.0.0-aarch64-linux)
+    libddwaf (1.18.0.0.0-aarch64-linux)
       ffi (~> 1.0)
-    libddwaf (1.15.0.0.0-x86_64-linux)
+    libddwaf (1.18.0.0.0-x86_64-linux)
       ffi (~> 1.0)
     memory_profiler (0.9.14)
     method_source (1.0.0)

--- a/gemfiles/ruby_3.3_relational_db.gemfile.lock
+++ b/gemfiles/ruby_3.3_relational_db.gemfile.lock
@@ -14,7 +14,7 @@ PATH
     datadog (2.7.0)
       datadog-ruby_core_source (~> 3.3)
       libdatadog (~> 14.1.0.1.0)
-      libddwaf (~> 1.15.0.0.0)
+      libddwaf (~> 1.18.0.0.0)
       msgpack
 
 GEM
@@ -69,9 +69,9 @@ GEM
       addressable (>= 2.4)
     libdatadog (14.1.0.1.0-aarch64-linux)
     libdatadog (14.1.0.1.0-x86_64-linux)
-    libddwaf (1.15.0.0.0-aarch64-linux)
+    libddwaf (1.18.0.0.0-aarch64-linux)
       ffi (~> 1.0)
-    libddwaf (1.15.0.0.0-x86_64-linux)
+    libddwaf (1.18.0.0.0-x86_64-linux)
       ffi (~> 1.0)
     makara (0.6.0.pre)
       activerecord (>= 5.2.0)

--- a/gemfiles/ruby_3.3_resque2_redis3.gemfile.lock
+++ b/gemfiles/ruby_3.3_resque2_redis3.gemfile.lock
@@ -14,7 +14,7 @@ PATH
     datadog (2.7.0)
       datadog-ruby_core_source (~> 3.3)
       libdatadog (~> 14.1.0.1.0)
-      libddwaf (~> 1.15.0.0.0)
+      libddwaf (~> 1.18.0.0.0)
       msgpack
 
 GEM
@@ -51,9 +51,9 @@ GEM
       addressable (>= 2.4)
     libdatadog (14.1.0.1.0-aarch64-linux)
     libdatadog (14.1.0.1.0-x86_64-linux)
-    libddwaf (1.15.0.0.0-aarch64-linux)
+    libddwaf (1.18.0.0.0-aarch64-linux)
       ffi (~> 1.0)
-    libddwaf (1.15.0.0.0-x86_64-linux)
+    libddwaf (1.18.0.0.0-x86_64-linux)
       ffi (~> 1.0)
     memory_profiler (0.9.14)
     method_source (1.0.0)

--- a/gemfiles/ruby_3.3_resque2_redis4.gemfile.lock
+++ b/gemfiles/ruby_3.3_resque2_redis4.gemfile.lock
@@ -14,7 +14,7 @@ PATH
     datadog (2.7.0)
       datadog-ruby_core_source (~> 3.3)
       libdatadog (~> 14.1.0.1.0)
-      libddwaf (~> 1.15.0.0.0)
+      libddwaf (~> 1.18.0.0.0)
       msgpack
 
 GEM
@@ -52,9 +52,9 @@ GEM
       addressable (>= 2.4)
     libdatadog (14.1.0.1.0-aarch64-linux)
     libdatadog (14.1.0.1.0-x86_64-linux)
-    libddwaf (1.15.0.0.0-aarch64-linux)
+    libddwaf (1.18.0.0.0-aarch64-linux)
       ffi (~> 1.0)
-    libddwaf (1.15.0.0.0-x86_64-linux)
+    libddwaf (1.18.0.0.0-x86_64-linux)
       ffi (~> 1.0)
     memory_profiler (0.9.14)
     method_source (1.0.0)

--- a/gemfiles/ruby_3.3_sinatra_2.gemfile.lock
+++ b/gemfiles/ruby_3.3_sinatra_2.gemfile.lock
@@ -14,7 +14,7 @@ PATH
     datadog (2.7.0)
       datadog-ruby_core_source (~> 3.3)
       libdatadog (~> 14.1.0.1.0)
-      libddwaf (~> 1.15.0.0.0)
+      libddwaf (~> 1.18.0.0.0)
       msgpack
 
 GEM
@@ -55,9 +55,9 @@ GEM
       addressable (>= 2.4)
     libdatadog (14.1.0.1.0-aarch64-linux)
     libdatadog (14.1.0.1.0-x86_64-linux)
-    libddwaf (1.15.0.0.0-aarch64-linux)
+    libddwaf (1.18.0.0.0-aarch64-linux)
       ffi (~> 1.0)
-    libddwaf (1.15.0.0.0-x86_64-linux)
+    libddwaf (1.18.0.0.0-x86_64-linux)
       ffi (~> 1.0)
     memory_profiler (0.9.14)
     method_source (1.1.0)

--- a/gemfiles/ruby_3.3_sinatra_3.gemfile.lock
+++ b/gemfiles/ruby_3.3_sinatra_3.gemfile.lock
@@ -14,7 +14,7 @@ PATH
     datadog (2.7.0)
       datadog-ruby_core_source (~> 3.3)
       libdatadog (~> 14.1.0.1.0)
-      libddwaf (~> 1.15.0.0.0)
+      libddwaf (~> 1.18.0.0.0)
       msgpack
 
 GEM
@@ -56,9 +56,9 @@ GEM
       addressable (>= 2.4)
     libdatadog (14.1.0.1.0-aarch64-linux)
     libdatadog (14.1.0.1.0-x86_64-linux)
-    libddwaf (1.15.0.0.0-aarch64-linux)
+    libddwaf (1.18.0.0.0-aarch64-linux)
       ffi (~> 1.0)
-    libddwaf (1.15.0.0.0-x86_64-linux)
+    libddwaf (1.18.0.0.0-x86_64-linux)
       ffi (~> 1.0)
     memory_profiler (0.9.14)
     method_source (1.1.0)

--- a/gemfiles/ruby_3.3_sinatra_4.gemfile.lock
+++ b/gemfiles/ruby_3.3_sinatra_4.gemfile.lock
@@ -14,7 +14,7 @@ PATH
     datadog (2.7.0)
       datadog-ruby_core_source (~> 3.3)
       libdatadog (~> 14.1.0.1.0)
-      libddwaf (~> 1.15.0.0.0)
+      libddwaf (~> 1.18.0.0.0)
       msgpack
 
 GEM
@@ -56,9 +56,9 @@ GEM
       addressable (>= 2.4)
     libdatadog (14.1.0.1.0-aarch64-linux)
     libdatadog (14.1.0.1.0-x86_64-linux)
-    libddwaf (1.15.0.0.0-aarch64-linux)
+    libddwaf (1.18.0.0.0-aarch64-linux)
       ffi (~> 1.0)
-    libddwaf (1.15.0.0.0-x86_64-linux)
+    libddwaf (1.18.0.0.0-x86_64-linux)
       ffi (~> 1.0)
     memory_profiler (0.9.14)
     method_source (1.1.0)

--- a/gemfiles/ruby_3.3_stripe_10.gemfile.lock
+++ b/gemfiles/ruby_3.3_stripe_10.gemfile.lock
@@ -14,7 +14,7 @@ PATH
     datadog (2.7.0)
       datadog-ruby_core_source (~> 3.3)
       libdatadog (~> 14.1.0.1.0)
-      libddwaf (~> 1.15.0.0.0)
+      libddwaf (~> 1.18.0.0.0)
       msgpack
 
 GEM
@@ -55,9 +55,9 @@ GEM
       addressable (>= 2.4)
     libdatadog (14.1.0.1.0-aarch64-linux)
     libdatadog (14.1.0.1.0-x86_64-linux)
-    libddwaf (1.15.0.0.0-aarch64-linux)
+    libddwaf (1.18.0.0.0-aarch64-linux)
       ffi (~> 1.0)
-    libddwaf (1.15.0.0.0-x86_64-linux)
+    libddwaf (1.18.0.0.0-x86_64-linux)
       ffi (~> 1.0)
     memory_profiler (0.9.14)
     method_source (1.1.0)

--- a/gemfiles/ruby_3.3_stripe_11.gemfile.lock
+++ b/gemfiles/ruby_3.3_stripe_11.gemfile.lock
@@ -14,7 +14,7 @@ PATH
     datadog (2.7.0)
       datadog-ruby_core_source (~> 3.3)
       libdatadog (~> 14.1.0.1.0)
-      libddwaf (~> 1.15.0.0.0)
+      libddwaf (~> 1.18.0.0.0)
       msgpack
 
 GEM
@@ -55,9 +55,9 @@ GEM
       addressable (>= 2.4)
     libdatadog (14.1.0.1.0-aarch64-linux)
     libdatadog (14.1.0.1.0-x86_64-linux)
-    libddwaf (1.15.0.0.0-aarch64-linux)
+    libddwaf (1.18.0.0.0-aarch64-linux)
       ffi (~> 1.0)
-    libddwaf (1.15.0.0.0-x86_64-linux)
+    libddwaf (1.18.0.0.0-x86_64-linux)
       ffi (~> 1.0)
     memory_profiler (0.9.14)
     method_source (1.1.0)

--- a/gemfiles/ruby_3.3_stripe_12.gemfile.lock
+++ b/gemfiles/ruby_3.3_stripe_12.gemfile.lock
@@ -14,7 +14,7 @@ PATH
     datadog (2.7.0)
       datadog-ruby_core_source (~> 3.3)
       libdatadog (~> 14.1.0.1.0)
-      libddwaf (~> 1.15.0.0.0)
+      libddwaf (~> 1.18.0.0.0)
       msgpack
 
 GEM
@@ -55,9 +55,9 @@ GEM
       addressable (>= 2.4)
     libdatadog (14.1.0.1.0-aarch64-linux)
     libdatadog (14.1.0.1.0-x86_64-linux)
-    libddwaf (1.15.0.0.0-aarch64-linux)
+    libddwaf (1.18.0.0.0-aarch64-linux)
       ffi (~> 1.0)
-    libddwaf (1.15.0.0.0-x86_64-linux)
+    libddwaf (1.18.0.0.0-x86_64-linux)
       ffi (~> 1.0)
     memory_profiler (0.9.14)
     method_source (1.1.0)

--- a/gemfiles/ruby_3.3_stripe_7.gemfile.lock
+++ b/gemfiles/ruby_3.3_stripe_7.gemfile.lock
@@ -14,7 +14,7 @@ PATH
     datadog (2.7.0)
       datadog-ruby_core_source (~> 3.3)
       libdatadog (~> 14.1.0.1.0)
-      libddwaf (~> 1.15.0.0.0)
+      libddwaf (~> 1.18.0.0.0)
       msgpack
 
 GEM
@@ -55,9 +55,9 @@ GEM
       addressable (>= 2.4)
     libdatadog (14.1.0.1.0-aarch64-linux)
     libdatadog (14.1.0.1.0-x86_64-linux)
-    libddwaf (1.15.0.0.0-aarch64-linux)
+    libddwaf (1.18.0.0.0-aarch64-linux)
       ffi (~> 1.0)
-    libddwaf (1.15.0.0.0-x86_64-linux)
+    libddwaf (1.18.0.0.0-x86_64-linux)
       ffi (~> 1.0)
     memory_profiler (0.9.14)
     method_source (1.1.0)

--- a/gemfiles/ruby_3.3_stripe_8.gemfile.lock
+++ b/gemfiles/ruby_3.3_stripe_8.gemfile.lock
@@ -14,7 +14,7 @@ PATH
     datadog (2.7.0)
       datadog-ruby_core_source (~> 3.3)
       libdatadog (~> 14.1.0.1.0)
-      libddwaf (~> 1.15.0.0.0)
+      libddwaf (~> 1.18.0.0.0)
       msgpack
 
 GEM
@@ -55,9 +55,9 @@ GEM
       addressable (>= 2.4)
     libdatadog (14.1.0.1.0-aarch64-linux)
     libdatadog (14.1.0.1.0-x86_64-linux)
-    libddwaf (1.15.0.0.0-aarch64-linux)
+    libddwaf (1.18.0.0.0-aarch64-linux)
       ffi (~> 1.0)
-    libddwaf (1.15.0.0.0-x86_64-linux)
+    libddwaf (1.18.0.0.0-x86_64-linux)
       ffi (~> 1.0)
     memory_profiler (0.9.14)
     method_source (1.1.0)

--- a/gemfiles/ruby_3.3_stripe_9.gemfile.lock
+++ b/gemfiles/ruby_3.3_stripe_9.gemfile.lock
@@ -14,7 +14,7 @@ PATH
     datadog (2.7.0)
       datadog-ruby_core_source (~> 3.3)
       libdatadog (~> 14.1.0.1.0)
-      libddwaf (~> 1.15.0.0.0)
+      libddwaf (~> 1.18.0.0.0)
       msgpack
 
 GEM
@@ -55,9 +55,9 @@ GEM
       addressable (>= 2.4)
     libdatadog (14.1.0.1.0-aarch64-linux)
     libdatadog (14.1.0.1.0-x86_64-linux)
-    libddwaf (1.15.0.0.0-aarch64-linux)
+    libddwaf (1.18.0.0.0-aarch64-linux)
       ffi (~> 1.0)
-    libddwaf (1.15.0.0.0-x86_64-linux)
+    libddwaf (1.18.0.0.0-x86_64-linux)
       ffi (~> 1.0)
     memory_profiler (0.9.14)
     method_source (1.1.0)

--- a/gemfiles/ruby_3.3_stripe_latest.gemfile.lock
+++ b/gemfiles/ruby_3.3_stripe_latest.gemfile.lock
@@ -14,7 +14,7 @@ PATH
     datadog (2.7.0)
       datadog-ruby_core_source (~> 3.3)
       libdatadog (~> 14.1.0.1.0)
-      libddwaf (~> 1.15.0.0.0)
+      libddwaf (~> 1.18.0.0.0)
       msgpack
 
 GEM
@@ -55,9 +55,9 @@ GEM
       addressable (>= 2.4)
     libdatadog (14.1.0.1.0-aarch64-linux)
     libdatadog (14.1.0.1.0-x86_64-linux)
-    libddwaf (1.15.0.0.0-aarch64-linux)
+    libddwaf (1.18.0.0.0-aarch64-linux)
       ffi (~> 1.0)
-    libddwaf (1.15.0.0.0-x86_64-linux)
+    libddwaf (1.18.0.0.0-x86_64-linux)
       ffi (~> 1.0)
     memory_profiler (0.9.14)
     method_source (1.1.0)

--- a/gemfiles/ruby_3.3_stripe_min.gemfile.lock
+++ b/gemfiles/ruby_3.3_stripe_min.gemfile.lock
@@ -14,7 +14,7 @@ PATH
     datadog (2.7.0)
       datadog-ruby_core_source (~> 3.3)
       libdatadog (~> 14.1.0.1.0)
-      libddwaf (~> 1.15.0.0.0)
+      libddwaf (~> 1.18.0.0.0)
       msgpack
 
 GEM
@@ -55,9 +55,9 @@ GEM
       addressable (>= 2.4)
     libdatadog (14.1.0.1.0-aarch64-linux)
     libdatadog (14.1.0.1.0-x86_64-linux)
-    libddwaf (1.15.0.0.0-aarch64-linux)
+    libddwaf (1.18.0.0.0-aarch64-linux)
       ffi (~> 1.0)
-    libddwaf (1.15.0.0.0-x86_64-linux)
+    libddwaf (1.18.0.0.0-x86_64-linux)
       ffi (~> 1.0)
     memory_profiler (0.9.14)
     method_source (1.1.0)

--- a/gemfiles/ruby_3.4_activesupport.gemfile.lock
+++ b/gemfiles/ruby_3.4_activesupport.gemfile.lock
@@ -21,7 +21,7 @@ PATH
     datadog (2.7.0)
       datadog-ruby_core_source (~> 3.3)
       libdatadog (~> 14.1.0.1.0)
-      libddwaf (~> 1.15.0.0.0)
+      libddwaf (~> 1.18.0.0.0)
       msgpack
 
 GEM
@@ -132,9 +132,9 @@ GEM
     king_konf (1.0.1)
     libdatadog (14.1.0.1.0-aarch64-linux)
     libdatadog (14.1.0.1.0-x86_64-linux)
-    libddwaf (1.15.0.0.0-aarch64-linux)
+    libddwaf (1.18.0.0.0-aarch64-linux)
       ffi (~> 1.0)
-    libddwaf (1.15.0.0.0-x86_64-linux)
+    libddwaf (1.18.0.0.0-x86_64-linux)
       ffi (~> 1.0)
     lograge (0.14.0)
       actionpack (>= 4)

--- a/gemfiles/ruby_3.4_aws.gemfile.lock
+++ b/gemfiles/ruby_3.4_aws.gemfile.lock
@@ -21,7 +21,7 @@ PATH
     datadog (2.7.0)
       datadog-ruby_core_source (~> 3.3)
       libdatadog (~> 14.1.0.1.0)
-      libddwaf (~> 1.15.0.0.0)
+      libddwaf (~> 1.18.0.0.0)
       msgpack
 
 GEM
@@ -1610,9 +1610,9 @@ GEM
       addressable (>= 2.4)
     libdatadog (14.1.0.1.0-aarch64-linux)
     libdatadog (14.1.0.1.0-x86_64-linux)
-    libddwaf (1.15.0.0.0-aarch64-linux)
+    libddwaf (1.18.0.0.0-aarch64-linux)
       ffi (~> 1.0)
-    libddwaf (1.15.0.0.0-x86_64-linux)
+    libddwaf (1.18.0.0.0-x86_64-linux)
       ffi (~> 1.0)
     memory_profiler (0.9.14)
     method_source (1.1.0)

--- a/gemfiles/ruby_3.4_contrib.gemfile.lock
+++ b/gemfiles/ruby_3.4_contrib.gemfile.lock
@@ -21,7 +21,7 @@ PATH
     datadog (2.7.0)
       datadog-ruby_core_source (~> 3.3)
       libdatadog (~> 14.1.0.1.0)
-      libddwaf (~> 1.15.0.0.0)
+      libddwaf (~> 1.18.0.0.0)
       msgpack
 
 GEM
@@ -73,9 +73,9 @@ GEM
       addressable (>= 2.4)
     libdatadog (14.1.0.1.0-aarch64-linux)
     libdatadog (14.1.0.1.0-x86_64-linux)
-    libddwaf (1.15.0.0.0-aarch64-linux)
+    libddwaf (1.18.0.0.0-aarch64-linux)
       ffi (~> 1.0)
-    libddwaf (1.15.0.0.0-x86_64-linux)
+    libddwaf (1.18.0.0.0-x86_64-linux)
       ffi (~> 1.0)
     memory_profiler (0.9.14)
     method_source (1.1.0)

--- a/gemfiles/ruby_3.4_contrib_old.gemfile.lock
+++ b/gemfiles/ruby_3.4_contrib_old.gemfile.lock
@@ -21,7 +21,7 @@ PATH
     datadog (2.7.0)
       datadog-ruby_core_source (~> 3.3)
       libdatadog (~> 14.1.0.1.0)
-      libddwaf (~> 1.15.0.0.0)
+      libddwaf (~> 1.18.0.0.0)
       msgpack
 
 GEM
@@ -72,9 +72,9 @@ GEM
       addressable (>= 2.4)
     libdatadog (14.1.0.1.0-aarch64-linux)
     libdatadog (14.1.0.1.0-x86_64-linux)
-    libddwaf (1.15.0.0.0-aarch64-linux)
+    libddwaf (1.18.0.0.0-aarch64-linux)
       ffi (~> 1.0)
-    libddwaf (1.15.0.0.0-x86_64-linux)
+    libddwaf (1.18.0.0.0-x86_64-linux)
       ffi (~> 1.0)
     memory_profiler (0.9.14)
     method_source (1.1.0)

--- a/gemfiles/ruby_3.4_core_old.gemfile.lock
+++ b/gemfiles/ruby_3.4_core_old.gemfile.lock
@@ -21,7 +21,7 @@ PATH
     datadog (2.7.0)
       datadog-ruby_core_source (~> 3.3)
       libdatadog (~> 14.1.0.1.0)
-      libddwaf (~> 1.15.0.0.0)
+      libddwaf (~> 1.18.0.0.0)
       msgpack
 
 GEM
@@ -61,9 +61,9 @@ GEM
       addressable (>= 2.4)
     libdatadog (14.1.0.1.0-aarch64-linux)
     libdatadog (14.1.0.1.0-x86_64-linux)
-    libddwaf (1.15.0.0.0-aarch64-linux)
+    libddwaf (1.18.0.0.0-aarch64-linux)
       ffi (~> 1.0)
-    libddwaf (1.15.0.0.0-x86_64-linux)
+    libddwaf (1.18.0.0.0-x86_64-linux)
       ffi (~> 1.0)
     memory_profiler (0.9.14)
     method_source (1.1.0)

--- a/gemfiles/ruby_3.4_elasticsearch_7.gemfile.lock
+++ b/gemfiles/ruby_3.4_elasticsearch_7.gemfile.lock
@@ -21,7 +21,7 @@ PATH
     datadog (2.7.0)
       datadog-ruby_core_source (~> 3.3)
       libdatadog (~> 14.1.0.1.0)
-      libddwaf (~> 1.15.0.0.0)
+      libddwaf (~> 1.18.0.0.0)
       msgpack
 
 GEM
@@ -76,9 +76,9 @@ GEM
       addressable (>= 2.4)
     libdatadog (14.1.0.1.0-aarch64-linux)
     libdatadog (14.1.0.1.0-x86_64-linux)
-    libddwaf (1.15.0.0.0-aarch64-linux)
+    libddwaf (1.18.0.0.0-aarch64-linux)
       ffi (~> 1.0)
-    libddwaf (1.15.0.0.0-x86_64-linux)
+    libddwaf (1.18.0.0.0-x86_64-linux)
       ffi (~> 1.0)
     logger (1.6.1)
     memory_profiler (0.9.14)

--- a/gemfiles/ruby_3.4_elasticsearch_8.gemfile.lock
+++ b/gemfiles/ruby_3.4_elasticsearch_8.gemfile.lock
@@ -21,7 +21,7 @@ PATH
     datadog (2.7.0)
       datadog-ruby_core_source (~> 3.3)
       libdatadog (~> 14.1.0.1.0)
-      libddwaf (~> 1.15.0.0.0)
+      libddwaf (~> 1.18.0.0.0)
       msgpack
 
 GEM
@@ -75,9 +75,9 @@ GEM
       addressable (>= 2.4)
     libdatadog (14.1.0.1.0-aarch64-linux)
     libdatadog (14.1.0.1.0-x86_64-linux)
-    libddwaf (1.15.0.0.0-aarch64-linux)
+    libddwaf (1.18.0.0.0-aarch64-linux)
       ffi (~> 1.0)
-    libddwaf (1.15.0.0.0-x86_64-linux)
+    libddwaf (1.18.0.0.0-x86_64-linux)
       ffi (~> 1.0)
     logger (1.6.1)
     memory_profiler (0.9.14)

--- a/gemfiles/ruby_3.4_elasticsearch_latest.gemfile.lock
+++ b/gemfiles/ruby_3.4_elasticsearch_latest.gemfile.lock
@@ -21,7 +21,7 @@ PATH
     datadog (2.7.0)
       datadog-ruby_core_source (~> 3.3)
       libdatadog (~> 14.1.0.1.0)
-      libddwaf (~> 1.15.0.0.0)
+      libddwaf (~> 1.18.0.0.0)
       msgpack
 
 GEM
@@ -75,9 +75,9 @@ GEM
       addressable (>= 2.4)
     libdatadog (14.1.0.1.0-aarch64-linux)
     libdatadog (14.1.0.1.0-x86_64-linux)
-    libddwaf (1.15.0.0.0-aarch64-linux)
+    libddwaf (1.18.0.0.0-aarch64-linux)
       ffi (~> 1.0)
-    libddwaf (1.15.0.0.0-x86_64-linux)
+    libddwaf (1.18.0.0.0-x86_64-linux)
       ffi (~> 1.0)
     logger (1.6.1)
     memory_profiler (0.9.14)

--- a/gemfiles/ruby_3.4_graphql_1.13.gemfile.lock
+++ b/gemfiles/ruby_3.4_graphql_1.13.gemfile.lock
@@ -21,7 +21,7 @@ PATH
     datadog (2.7.0)
       datadog-ruby_core_source (~> 3.3)
       libdatadog (~> 14.1.0.1.0)
-      libddwaf (~> 1.15.0.0.0)
+      libddwaf (~> 1.18.0.0.0)
       msgpack
 
 GEM
@@ -130,9 +130,9 @@ GEM
       addressable (>= 2.4)
     libdatadog (14.1.0.1.0-aarch64-linux)
     libdatadog (14.1.0.1.0-x86_64-linux)
-    libddwaf (1.15.0.0.0-aarch64-linux)
+    libddwaf (1.18.0.0.0-aarch64-linux)
       ffi (~> 1.0)
-    libddwaf (1.15.0.0.0-x86_64-linux)
+    libddwaf (1.18.0.0.0-x86_64-linux)
       ffi (~> 1.0)
     lograge (0.14.0)
       actionpack (>= 4)

--- a/gemfiles/ruby_3.4_graphql_2.0.gemfile.lock
+++ b/gemfiles/ruby_3.4_graphql_2.0.gemfile.lock
@@ -21,7 +21,7 @@ PATH
     datadog (2.7.0)
       datadog-ruby_core_source (~> 3.3)
       libdatadog (~> 14.1.0.1.0)
-      libddwaf (~> 1.15.0.0.0)
+      libddwaf (~> 1.18.0.0.0)
       msgpack
 
 GEM
@@ -130,9 +130,9 @@ GEM
       addressable (>= 2.4)
     libdatadog (14.1.0.1.0-aarch64-linux)
     libdatadog (14.1.0.1.0-x86_64-linux)
-    libddwaf (1.15.0.0.0-aarch64-linux)
+    libddwaf (1.18.0.0.0-aarch64-linux)
       ffi (~> 1.0)
-    libddwaf (1.15.0.0.0-x86_64-linux)
+    libddwaf (1.18.0.0.0-x86_64-linux)
       ffi (~> 1.0)
     lograge (0.14.0)
       actionpack (>= 4)

--- a/gemfiles/ruby_3.4_graphql_2.1.gemfile.lock
+++ b/gemfiles/ruby_3.4_graphql_2.1.gemfile.lock
@@ -21,7 +21,7 @@ PATH
     datadog (2.7.0)
       datadog-ruby_core_source (~> 3.3)
       libdatadog (~> 14.1.0.1.0)
-      libddwaf (~> 1.15.0.0.0)
+      libddwaf (~> 1.18.0.0.0)
       msgpack
 
 GEM
@@ -130,9 +130,9 @@ GEM
       addressable (>= 2.4)
     libdatadog (14.1.0.1.0-aarch64-linux)
     libdatadog (14.1.0.1.0-x86_64-linux)
-    libddwaf (1.15.0.0.0-aarch64-linux)
+    libddwaf (1.18.0.0.0-aarch64-linux)
       ffi (~> 1.0)
-    libddwaf (1.15.0.0.0-x86_64-linux)
+    libddwaf (1.18.0.0.0-x86_64-linux)
       ffi (~> 1.0)
     lograge (0.14.0)
       actionpack (>= 4)

--- a/gemfiles/ruby_3.4_graphql_2.2.gemfile.lock
+++ b/gemfiles/ruby_3.4_graphql_2.2.gemfile.lock
@@ -21,7 +21,7 @@ PATH
     datadog (2.7.0)
       datadog-ruby_core_source (~> 3.3)
       libdatadog (~> 14.1.0.1.0)
-      libddwaf (~> 1.15.0.0.0)
+      libddwaf (~> 1.18.0.0.0)
       msgpack
 
 GEM
@@ -130,9 +130,9 @@ GEM
       addressable (>= 2.4)
     libdatadog (14.1.0.1.0-aarch64-linux)
     libdatadog (14.1.0.1.0-x86_64-linux)
-    libddwaf (1.15.0.0.0-aarch64-linux)
+    libddwaf (1.18.0.0.0-aarch64-linux)
       ffi (~> 1.0)
-    libddwaf (1.15.0.0.0-x86_64-linux)
+    libddwaf (1.18.0.0.0-x86_64-linux)
       ffi (~> 1.0)
     lograge (0.14.0)
       actionpack (>= 4)

--- a/gemfiles/ruby_3.4_graphql_2.3.gemfile.lock
+++ b/gemfiles/ruby_3.4_graphql_2.3.gemfile.lock
@@ -21,7 +21,7 @@ PATH
     datadog (2.7.0)
       datadog-ruby_core_source (~> 3.3)
       libdatadog (~> 14.1.0.1.0)
-      libddwaf (~> 1.15.0.0.0)
+      libddwaf (~> 1.18.0.0.0)
       msgpack
 
 GEM
@@ -130,9 +130,9 @@ GEM
       addressable (>= 2.4)
     libdatadog (14.1.0.1.0-aarch64-linux)
     libdatadog (14.1.0.1.0-x86_64-linux)
-    libddwaf (1.15.0.0.0-aarch64-linux)
+    libddwaf (1.18.0.0.0-aarch64-linux)
       ffi (~> 1.0)
-    libddwaf (1.15.0.0.0-x86_64-linux)
+    libddwaf (1.18.0.0.0-x86_64-linux)
       ffi (~> 1.0)
     lograge (0.14.0)
       actionpack (>= 4)

--- a/gemfiles/ruby_3.4_http.gemfile.lock
+++ b/gemfiles/ruby_3.4_http.gemfile.lock
@@ -21,7 +21,7 @@ PATH
     datadog (2.7.0)
       datadog-ruby_core_source (~> 3.3)
       libdatadog (~> 14.1.0.1.0)
-      libddwaf (~> 1.15.0.0.0)
+      libddwaf (~> 1.18.0.0.0)
       msgpack
 
 GEM
@@ -83,9 +83,9 @@ GEM
       addressable (>= 2.4)
     libdatadog (14.1.0.1.0-aarch64-linux)
     libdatadog (14.1.0.1.0-x86_64-linux)
-    libddwaf (1.15.0.0.0-aarch64-linux)
+    libddwaf (1.18.0.0.0-aarch64-linux)
       ffi (~> 1.0)
-    libddwaf (1.15.0.0.0-x86_64-linux)
+    libddwaf (1.18.0.0.0-x86_64-linux)
       ffi (~> 1.0)
     llhttp-ffi (0.5.0)
       ffi-compiler (~> 1.0)

--- a/gemfiles/ruby_3.4_opensearch_2.gemfile.lock
+++ b/gemfiles/ruby_3.4_opensearch_2.gemfile.lock
@@ -21,7 +21,7 @@ PATH
     datadog (2.7.0)
       datadog-ruby_core_source (~> 3.3)
       libdatadog (~> 14.1.0.1.0)
-      libddwaf (~> 1.15.0.0.0)
+      libddwaf (~> 1.18.0.0.0)
       msgpack
 
 GEM
@@ -67,9 +67,9 @@ GEM
       addressable (>= 2.4)
     libdatadog (14.1.0.1.0-aarch64-linux)
     libdatadog (14.1.0.1.0-x86_64-linux)
-    libddwaf (1.15.0.0.0-aarch64-linux)
+    libddwaf (1.18.0.0.0-aarch64-linux)
       ffi (~> 1.0)
-    libddwaf (1.15.0.0.0-x86_64-linux)
+    libddwaf (1.18.0.0.0-x86_64-linux)
       ffi (~> 1.0)
     logger (1.6.1)
     memory_profiler (0.9.14)

--- a/gemfiles/ruby_3.4_opensearch_3.gemfile.lock
+++ b/gemfiles/ruby_3.4_opensearch_3.gemfile.lock
@@ -21,7 +21,7 @@ PATH
     datadog (2.7.0)
       datadog-ruby_core_source (~> 3.3)
       libdatadog (~> 14.1.0.1.0)
-      libddwaf (~> 1.15.0.0.0)
+      libddwaf (~> 1.18.0.0.0)
       msgpack
 
 GEM
@@ -67,9 +67,9 @@ GEM
       addressable (>= 2.4)
     libdatadog (14.1.0.1.0-aarch64-linux)
     libdatadog (14.1.0.1.0-x86_64-linux)
-    libddwaf (1.15.0.0.0-aarch64-linux)
+    libddwaf (1.18.0.0.0-aarch64-linux)
       ffi (~> 1.0)
-    libddwaf (1.15.0.0.0-x86_64-linux)
+    libddwaf (1.18.0.0.0-x86_64-linux)
       ffi (~> 1.0)
     logger (1.6.1)
     memory_profiler (0.9.14)

--- a/gemfiles/ruby_3.4_opensearch_latest.gemfile.lock
+++ b/gemfiles/ruby_3.4_opensearch_latest.gemfile.lock
@@ -21,7 +21,7 @@ PATH
     datadog (2.7.0)
       datadog-ruby_core_source (~> 3.3)
       libdatadog (~> 14.1.0.1.0)
-      libddwaf (~> 1.15.0.0.0)
+      libddwaf (~> 1.18.0.0.0)
       msgpack
 
 GEM
@@ -67,9 +67,9 @@ GEM
       addressable (>= 2.4)
     libdatadog (14.1.0.1.0-aarch64-linux)
     libdatadog (14.1.0.1.0-x86_64-linux)
-    libddwaf (1.15.0.0.0-aarch64-linux)
+    libddwaf (1.18.0.0.0-aarch64-linux)
       ffi (~> 1.0)
-    libddwaf (1.15.0.0.0-x86_64-linux)
+    libddwaf (1.18.0.0.0-x86_64-linux)
       ffi (~> 1.0)
     logger (1.6.1)
     memory_profiler (0.9.14)

--- a/gemfiles/ruby_3.4_opentelemetry.gemfile.lock
+++ b/gemfiles/ruby_3.4_opentelemetry.gemfile.lock
@@ -21,7 +21,7 @@ PATH
     datadog (2.7.0)
       datadog-ruby_core_source (~> 3.3)
       libdatadog (~> 14.1.0.1.0)
-      libddwaf (~> 1.15.0.0.0)
+      libddwaf (~> 1.18.0.0.0)
       msgpack
 
 GEM
@@ -61,9 +61,9 @@ GEM
       addressable (>= 2.4)
     libdatadog (14.1.0.1.0-aarch64-linux)
     libdatadog (14.1.0.1.0-x86_64-linux)
-    libddwaf (1.15.0.0.0-aarch64-linux)
+    libddwaf (1.18.0.0.0-aarch64-linux)
       ffi (~> 1.0)
-    libddwaf (1.15.0.0.0-x86_64-linux)
+    libddwaf (1.18.0.0.0-x86_64-linux)
       ffi (~> 1.0)
     memory_profiler (0.9.14)
     method_source (1.1.0)

--- a/gemfiles/ruby_3.4_opentelemetry_otlp.gemfile.lock
+++ b/gemfiles/ruby_3.4_opentelemetry_otlp.gemfile.lock
@@ -21,7 +21,7 @@ PATH
     datadog (2.7.0)
       datadog-ruby_core_source (~> 3.3)
       libdatadog (~> 14.1.0.1.0)
-      libddwaf (~> 1.15.0.0.0)
+      libddwaf (~> 1.18.0.0.0)
       msgpack
 
 GEM
@@ -63,9 +63,9 @@ GEM
       addressable (>= 2.4)
     libdatadog (14.1.0.1.0-aarch64-linux)
     libdatadog (14.1.0.1.0-x86_64-linux)
-    libddwaf (1.15.0.0.0-aarch64-linux)
+    libddwaf (1.18.0.0.0-aarch64-linux)
       ffi (~> 1.0)
-    libddwaf (1.15.0.0.0-x86_64-linux)
+    libddwaf (1.18.0.0.0-x86_64-linux)
       ffi (~> 1.0)
     memory_profiler (0.9.14)
     method_source (1.1.0)

--- a/gemfiles/ruby_3.4_rack_2.gemfile.lock
+++ b/gemfiles/ruby_3.4_rack_2.gemfile.lock
@@ -21,7 +21,7 @@ PATH
     datadog (2.7.0)
       datadog-ruby_core_source (~> 3.3)
       libdatadog (~> 14.1.0.1.0)
-      libddwaf (~> 1.15.0.0.0)
+      libddwaf (~> 1.18.0.0.0)
       msgpack
 
 GEM
@@ -61,9 +61,9 @@ GEM
       addressable (>= 2.4)
     libdatadog (14.1.0.1.0-aarch64-linux)
     libdatadog (14.1.0.1.0-x86_64-linux)
-    libddwaf (1.15.0.0.0-aarch64-linux)
+    libddwaf (1.18.0.0.0-aarch64-linux)
       ffi (~> 1.0)
-    libddwaf (1.15.0.0.0-x86_64-linux)
+    libddwaf (1.18.0.0.0-x86_64-linux)
       ffi (~> 1.0)
     memory_profiler (0.9.14)
     method_source (1.1.0)

--- a/gemfiles/ruby_3.4_rack_3.gemfile.lock
+++ b/gemfiles/ruby_3.4_rack_3.gemfile.lock
@@ -21,7 +21,7 @@ PATH
     datadog (2.7.0)
       datadog-ruby_core_source (~> 3.3)
       libdatadog (~> 14.1.0.1.0)
-      libddwaf (~> 1.15.0.0.0)
+      libddwaf (~> 1.18.0.0.0)
       msgpack
 
 GEM
@@ -61,9 +61,9 @@ GEM
       addressable (>= 2.4)
     libdatadog (14.1.0.1.0-aarch64-linux)
     libdatadog (14.1.0.1.0-x86_64-linux)
-    libddwaf (1.15.0.0.0-aarch64-linux)
+    libddwaf (1.18.0.0.0-aarch64-linux)
       ffi (~> 1.0)
-    libddwaf (1.15.0.0.0-x86_64-linux)
+    libddwaf (1.18.0.0.0-x86_64-linux)
       ffi (~> 1.0)
     memory_profiler (0.9.14)
     method_source (1.1.0)

--- a/gemfiles/ruby_3.4_rack_latest.gemfile.lock
+++ b/gemfiles/ruby_3.4_rack_latest.gemfile.lock
@@ -21,7 +21,7 @@ PATH
     datadog (2.7.0)
       datadog-ruby_core_source (~> 3.3)
       libdatadog (~> 14.1.0.1.0)
-      libddwaf (~> 1.15.0.0.0)
+      libddwaf (~> 1.18.0.0.0)
       msgpack
 
 GEM
@@ -61,9 +61,9 @@ GEM
       addressable (>= 2.4)
     libdatadog (14.1.0.1.0-aarch64-linux)
     libdatadog (14.1.0.1.0-x86_64-linux)
-    libddwaf (1.15.0.0.0-aarch64-linux)
+    libddwaf (1.18.0.0.0-aarch64-linux)
       ffi (~> 1.0)
-    libddwaf (1.15.0.0.0-x86_64-linux)
+    libddwaf (1.18.0.0.0-x86_64-linux)
       ffi (~> 1.0)
     memory_profiler (0.9.14)
     method_source (1.1.0)

--- a/gemfiles/ruby_3.4_rails61_mysql2.gemfile.lock
+++ b/gemfiles/ruby_3.4_rails61_mysql2.gemfile.lock
@@ -21,7 +21,7 @@ PATH
     datadog (2.7.0)
       datadog-ruby_core_source (~> 3.3)
       libdatadog (~> 14.1.0.1.0)
-      libddwaf (~> 1.15.0.0.0)
+      libddwaf (~> 1.18.0.0.0)
       msgpack
 
 GEM
@@ -128,9 +128,9 @@ GEM
       addressable (>= 2.4)
     libdatadog (14.1.0.1.0-aarch64-linux)
     libdatadog (14.1.0.1.0-x86_64-linux)
-    libddwaf (1.15.0.0.0-aarch64-linux)
+    libddwaf (1.18.0.0.0-aarch64-linux)
       ffi (~> 1.0)
-    libddwaf (1.15.0.0.0-x86_64-linux)
+    libddwaf (1.18.0.0.0-x86_64-linux)
       ffi (~> 1.0)
     lograge (0.14.0)
       actionpack (>= 4)

--- a/gemfiles/ruby_3.4_rails61_postgres.gemfile.lock
+++ b/gemfiles/ruby_3.4_rails61_postgres.gemfile.lock
@@ -21,7 +21,7 @@ PATH
     datadog (2.7.0)
       datadog-ruby_core_source (~> 3.3)
       libdatadog (~> 14.1.0.1.0)
-      libddwaf (~> 1.15.0.0.0)
+      libddwaf (~> 1.18.0.0.0)
       msgpack
 
 GEM
@@ -128,9 +128,9 @@ GEM
       addressable (>= 2.4)
     libdatadog (14.1.0.1.0-aarch64-linux)
     libdatadog (14.1.0.1.0-x86_64-linux)
-    libddwaf (1.15.0.0.0-aarch64-linux)
+    libddwaf (1.18.0.0.0-aarch64-linux)
       ffi (~> 1.0)
-    libddwaf (1.15.0.0.0-x86_64-linux)
+    libddwaf (1.18.0.0.0-x86_64-linux)
       ffi (~> 1.0)
     lograge (0.14.0)
       actionpack (>= 4)

--- a/gemfiles/ruby_3.4_rails61_postgres_redis.gemfile.lock
+++ b/gemfiles/ruby_3.4_rails61_postgres_redis.gemfile.lock
@@ -21,7 +21,7 @@ PATH
     datadog (2.7.0)
       datadog-ruby_core_source (~> 3.3)
       libdatadog (~> 14.1.0.1.0)
-      libddwaf (~> 1.15.0.0.0)
+      libddwaf (~> 1.18.0.0.0)
       msgpack
 
 GEM
@@ -128,9 +128,9 @@ GEM
       addressable (>= 2.4)
     libdatadog (14.1.0.1.0-aarch64-linux)
     libdatadog (14.1.0.1.0-x86_64-linux)
-    libddwaf (1.15.0.0.0-aarch64-linux)
+    libddwaf (1.18.0.0.0-aarch64-linux)
       ffi (~> 1.0)
-    libddwaf (1.15.0.0.0-x86_64-linux)
+    libddwaf (1.18.0.0.0-x86_64-linux)
       ffi (~> 1.0)
     lograge (0.14.0)
       actionpack (>= 4)

--- a/gemfiles/ruby_3.4_rails61_postgres_sidekiq.gemfile.lock
+++ b/gemfiles/ruby_3.4_rails61_postgres_sidekiq.gemfile.lock
@@ -21,7 +21,7 @@ PATH
     datadog (2.7.0)
       datadog-ruby_core_source (~> 3.3)
       libdatadog (~> 14.1.0.1.0)
-      libddwaf (~> 1.15.0.0.0)
+      libddwaf (~> 1.18.0.0.0)
       msgpack
 
 GEM
@@ -129,9 +129,9 @@ GEM
       addressable (>= 2.4)
     libdatadog (14.1.0.1.0-aarch64-linux)
     libdatadog (14.1.0.1.0-x86_64-linux)
-    libddwaf (1.15.0.0.0-aarch64-linux)
+    libddwaf (1.18.0.0.0-aarch64-linux)
       ffi (~> 1.0)
-    libddwaf (1.15.0.0.0-x86_64-linux)
+    libddwaf (1.18.0.0.0-x86_64-linux)
       ffi (~> 1.0)
     lograge (0.14.0)
       actionpack (>= 4)

--- a/gemfiles/ruby_3.4_rails61_semantic_logger.gemfile.lock
+++ b/gemfiles/ruby_3.4_rails61_semantic_logger.gemfile.lock
@@ -21,7 +21,7 @@ PATH
     datadog (2.7.0)
       datadog-ruby_core_source (~> 3.3)
       libdatadog (~> 14.1.0.1.0)
-      libddwaf (~> 1.15.0.0.0)
+      libddwaf (~> 1.18.0.0.0)
       msgpack
 
 GEM
@@ -128,9 +128,9 @@ GEM
       addressable (>= 2.4)
     libdatadog (14.1.0.1.0-aarch64-linux)
     libdatadog (14.1.0.1.0-x86_64-linux)
-    libddwaf (1.15.0.0.0-aarch64-linux)
+    libddwaf (1.18.0.0.0-aarch64-linux)
       ffi (~> 1.0)
-    libddwaf (1.15.0.0.0-x86_64-linux)
+    libddwaf (1.18.0.0.0-x86_64-linux)
       ffi (~> 1.0)
     loofah (2.22.0)
       crass (~> 1.0.2)

--- a/gemfiles/ruby_3.4_rails61_trilogy.gemfile.lock
+++ b/gemfiles/ruby_3.4_rails61_trilogy.gemfile.lock
@@ -21,7 +21,7 @@ PATH
     datadog (2.7.0)
       datadog-ruby_core_source (~> 3.3)
       libdatadog (~> 14.1.0.1.0)
-      libddwaf (~> 1.15.0.0.0)
+      libddwaf (~> 1.18.0.0.0)
       msgpack
 
 GEM
@@ -131,9 +131,9 @@ GEM
       addressable (>= 2.4)
     libdatadog (14.1.0.1.0-aarch64-linux)
     libdatadog (14.1.0.1.0-x86_64-linux)
-    libddwaf (1.15.0.0.0-aarch64-linux)
+    libddwaf (1.18.0.0.0-aarch64-linux)
       ffi (~> 1.0)
-    libddwaf (1.15.0.0.0-x86_64-linux)
+    libddwaf (1.18.0.0.0-x86_64-linux)
       ffi (~> 1.0)
     lograge (0.14.0)
       actionpack (>= 4)

--- a/gemfiles/ruby_3.4_rails7.gemfile.lock
+++ b/gemfiles/ruby_3.4_rails7.gemfile.lock
@@ -21,7 +21,7 @@ PATH
     datadog (2.7.0)
       datadog-ruby_core_source (~> 3.3)
       libdatadog (~> 14.1.0.1.0)
-      libddwaf (~> 1.15.0.0.0)
+      libddwaf (~> 1.18.0.0.0)
       msgpack
 
 GEM
@@ -135,11 +135,11 @@ GEM
     libdatadog (14.1.0.1.0)
     libdatadog (14.1.0.1.0-aarch64-linux)
     libdatadog (14.1.0.1.0-x86_64-linux)
-    libddwaf (1.15.0.0.0)
+    libddwaf (1.18.0.0.0)
       ffi (~> 1.0)
-    libddwaf (1.15.0.0.0-aarch64-linux)
+    libddwaf (1.18.0.0.0-aarch64-linux)
       ffi (~> 1.0)
-    libddwaf (1.15.0.0.0-x86_64-linux)
+    libddwaf (1.18.0.0.0-x86_64-linux)
       ffi (~> 1.0)
     loofah (2.22.0)
       crass (~> 1.0.2)

--- a/gemfiles/ruby_3.4_rails71.gemfile.lock
+++ b/gemfiles/ruby_3.4_rails71.gemfile.lock
@@ -21,7 +21,7 @@ PATH
     datadog (2.7.0)
       datadog-ruby_core_source (~> 3.3)
       libdatadog (~> 14.1.0.1.0)
-      libddwaf (~> 1.15.0.0.0)
+      libddwaf (~> 1.18.0.0.0)
       msgpack
 
 GEM
@@ -150,11 +150,11 @@ GEM
     libdatadog (14.1.0.1.0)
     libdatadog (14.1.0.1.0-aarch64-linux)
     libdatadog (14.1.0.1.0-x86_64-linux)
-    libddwaf (1.15.0.0.0)
+    libddwaf (1.18.0.0.0)
       ffi (~> 1.0)
-    libddwaf (1.15.0.0.0-aarch64-linux)
+    libddwaf (1.18.0.0.0-aarch64-linux)
       ffi (~> 1.0)
-    libddwaf (1.15.0.0.0-x86_64-linux)
+    libddwaf (1.18.0.0.0-x86_64-linux)
       ffi (~> 1.0)
     loofah (2.22.0)
       crass (~> 1.0.2)

--- a/gemfiles/ruby_3.4_redis_3.gemfile.lock
+++ b/gemfiles/ruby_3.4_redis_3.gemfile.lock
@@ -21,7 +21,7 @@ PATH
     datadog (2.7.0)
       datadog-ruby_core_source (~> 3.3)
       libdatadog (~> 14.1.0.1.0)
-      libddwaf (~> 1.15.0.0.0)
+      libddwaf (~> 1.18.0.0.0)
       msgpack
 
 GEM
@@ -61,9 +61,9 @@ GEM
       addressable (>= 2.4)
     libdatadog (14.1.0.1.0-aarch64-linux)
     libdatadog (14.1.0.1.0-x86_64-linux)
-    libddwaf (1.15.0.0.0-aarch64-linux)
+    libddwaf (1.18.0.0.0-aarch64-linux)
       ffi (~> 1.0)
-    libddwaf (1.15.0.0.0-x86_64-linux)
+    libddwaf (1.18.0.0.0-x86_64-linux)
       ffi (~> 1.0)
     memory_profiler (0.9.14)
     method_source (1.1.0)

--- a/gemfiles/ruby_3.4_redis_4.gemfile.lock
+++ b/gemfiles/ruby_3.4_redis_4.gemfile.lock
@@ -21,7 +21,7 @@ PATH
     datadog (2.7.0)
       datadog-ruby_core_source (~> 3.3)
       libdatadog (~> 14.1.0.1.0)
-      libddwaf (~> 1.15.0.0.0)
+      libddwaf (~> 1.18.0.0.0)
       msgpack
 
 GEM
@@ -61,9 +61,9 @@ GEM
       addressable (>= 2.4)
     libdatadog (14.1.0.1.0-aarch64-linux)
     libdatadog (14.1.0.1.0-x86_64-linux)
-    libddwaf (1.15.0.0.0-aarch64-linux)
+    libddwaf (1.18.0.0.0-aarch64-linux)
       ffi (~> 1.0)
-    libddwaf (1.15.0.0.0-x86_64-linux)
+    libddwaf (1.18.0.0.0-x86_64-linux)
       ffi (~> 1.0)
     memory_profiler (0.9.14)
     method_source (1.1.0)

--- a/gemfiles/ruby_3.4_redis_5.gemfile.lock
+++ b/gemfiles/ruby_3.4_redis_5.gemfile.lock
@@ -21,7 +21,7 @@ PATH
     datadog (2.7.0)
       datadog-ruby_core_source (~> 3.3)
       libdatadog (~> 14.1.0.1.0)
-      libddwaf (~> 1.15.0.0.0)
+      libddwaf (~> 1.18.0.0.0)
       msgpack
 
 GEM
@@ -62,9 +62,9 @@ GEM
       addressable (>= 2.4)
     libdatadog (14.1.0.1.0-aarch64-linux)
     libdatadog (14.1.0.1.0-x86_64-linux)
-    libddwaf (1.15.0.0.0-aarch64-linux)
+    libddwaf (1.18.0.0.0-aarch64-linux)
       ffi (~> 1.0)
-    libddwaf (1.15.0.0.0-x86_64-linux)
+    libddwaf (1.18.0.0.0-x86_64-linux)
       ffi (~> 1.0)
     memory_profiler (0.9.14)
     method_source (1.1.0)

--- a/gemfiles/ruby_3.4_relational_db.gemfile.lock
+++ b/gemfiles/ruby_3.4_relational_db.gemfile.lock
@@ -21,7 +21,7 @@ PATH
     datadog (2.7.0)
       datadog-ruby_core_source (~> 3.3)
       libdatadog (~> 14.1.0.1.0)
-      libddwaf (~> 1.15.0.0.0)
+      libddwaf (~> 1.18.0.0.0)
       msgpack
 
 GEM
@@ -78,9 +78,9 @@ GEM
       addressable (>= 2.4)
     libdatadog (14.1.0.1.0-aarch64-linux)
     libdatadog (14.1.0.1.0-x86_64-linux)
-    libddwaf (1.15.0.0.0-aarch64-linux)
+    libddwaf (1.18.0.0.0-aarch64-linux)
       ffi (~> 1.0)
-    libddwaf (1.15.0.0.0-x86_64-linux)
+    libddwaf (1.18.0.0.0-x86_64-linux)
       ffi (~> 1.0)
     makara (0.6.0.pre)
       activerecord (>= 5.2.0)

--- a/gemfiles/ruby_3.4_resque2_redis3.gemfile.lock
+++ b/gemfiles/ruby_3.4_resque2_redis3.gemfile.lock
@@ -21,7 +21,7 @@ PATH
     datadog (2.7.0)
       datadog-ruby_core_source (~> 3.3)
       libdatadog (~> 14.1.0.1.0)
-      libddwaf (~> 1.15.0.0.0)
+      libddwaf (~> 1.18.0.0.0)
       msgpack
 
 GEM
@@ -61,9 +61,9 @@ GEM
       addressable (>= 2.4)
     libdatadog (14.1.0.1.0-aarch64-linux)
     libdatadog (14.1.0.1.0-x86_64-linux)
-    libddwaf (1.15.0.0.0-aarch64-linux)
+    libddwaf (1.18.0.0.0-aarch64-linux)
       ffi (~> 1.0)
-    libddwaf (1.15.0.0.0-x86_64-linux)
+    libddwaf (1.18.0.0.0-x86_64-linux)
       ffi (~> 1.0)
     memory_profiler (0.9.14)
     method_source (1.1.0)

--- a/gemfiles/ruby_3.4_resque2_redis4.gemfile.lock
+++ b/gemfiles/ruby_3.4_resque2_redis4.gemfile.lock
@@ -21,7 +21,7 @@ PATH
     datadog (2.7.0)
       datadog-ruby_core_source (~> 3.3)
       libdatadog (~> 14.1.0.1.0)
-      libddwaf (~> 1.15.0.0.0)
+      libddwaf (~> 1.18.0.0.0)
       msgpack
 
 GEM
@@ -62,9 +62,9 @@ GEM
       addressable (>= 2.4)
     libdatadog (14.1.0.1.0-aarch64-linux)
     libdatadog (14.1.0.1.0-x86_64-linux)
-    libddwaf (1.15.0.0.0-aarch64-linux)
+    libddwaf (1.18.0.0.0-aarch64-linux)
       ffi (~> 1.0)
-    libddwaf (1.15.0.0.0-x86_64-linux)
+    libddwaf (1.18.0.0.0-x86_64-linux)
       ffi (~> 1.0)
     memory_profiler (0.9.14)
     method_source (1.1.0)

--- a/gemfiles/ruby_3.4_sinatra_2.gemfile.lock
+++ b/gemfiles/ruby_3.4_sinatra_2.gemfile.lock
@@ -21,7 +21,7 @@ PATH
     datadog (2.7.0)
       datadog-ruby_core_source (~> 3.3)
       libdatadog (~> 14.1.0.1.0)
-      libddwaf (~> 1.15.0.0.0)
+      libddwaf (~> 1.18.0.0.0)
       msgpack
 
 GEM
@@ -61,9 +61,9 @@ GEM
       addressable (>= 2.4)
     libdatadog (14.1.0.1.0-aarch64-linux)
     libdatadog (14.1.0.1.0-x86_64-linux)
-    libddwaf (1.15.0.0.0-aarch64-linux)
+    libddwaf (1.18.0.0.0-aarch64-linux)
       ffi (~> 1.0)
-    libddwaf (1.15.0.0.0-x86_64-linux)
+    libddwaf (1.18.0.0.0-x86_64-linux)
       ffi (~> 1.0)
     memory_profiler (0.9.14)
     method_source (1.1.0)

--- a/gemfiles/ruby_3.4_sinatra_3.gemfile.lock
+++ b/gemfiles/ruby_3.4_sinatra_3.gemfile.lock
@@ -21,7 +21,7 @@ PATH
     datadog (2.7.0)
       datadog-ruby_core_source (~> 3.3)
       libdatadog (~> 14.1.0.1.0)
-      libddwaf (~> 1.15.0.0.0)
+      libddwaf (~> 1.18.0.0.0)
       msgpack
 
 GEM
@@ -61,9 +61,9 @@ GEM
       addressable (>= 2.4)
     libdatadog (14.1.0.1.0-aarch64-linux)
     libdatadog (14.1.0.1.0-x86_64-linux)
-    libddwaf (1.15.0.0.0-aarch64-linux)
+    libddwaf (1.18.0.0.0-aarch64-linux)
       ffi (~> 1.0)
-    libddwaf (1.15.0.0.0-x86_64-linux)
+    libddwaf (1.18.0.0.0-x86_64-linux)
       ffi (~> 1.0)
     memory_profiler (0.9.14)
     method_source (1.1.0)

--- a/gemfiles/ruby_3.4_sinatra_4.gemfile.lock
+++ b/gemfiles/ruby_3.4_sinatra_4.gemfile.lock
@@ -21,7 +21,7 @@ PATH
     datadog (2.7.0)
       datadog-ruby_core_source (~> 3.3)
       libdatadog (~> 14.1.0.1.0)
-      libddwaf (~> 1.15.0.0.0)
+      libddwaf (~> 1.18.0.0.0)
       msgpack
 
 GEM
@@ -61,9 +61,9 @@ GEM
       addressable (>= 2.4)
     libdatadog (14.1.0.1.0-aarch64-linux)
     libdatadog (14.1.0.1.0-x86_64-linux)
-    libddwaf (1.15.0.0.0-aarch64-linux)
+    libddwaf (1.18.0.0.0-aarch64-linux)
       ffi (~> 1.0)
-    libddwaf (1.15.0.0.0-x86_64-linux)
+    libddwaf (1.18.0.0.0-x86_64-linux)
       ffi (~> 1.0)
     memory_profiler (0.9.14)
     method_source (1.1.0)

--- a/gemfiles/ruby_3.4_stripe_10.gemfile.lock
+++ b/gemfiles/ruby_3.4_stripe_10.gemfile.lock
@@ -21,7 +21,7 @@ PATH
     datadog (2.7.0)
       datadog-ruby_core_source (~> 3.3)
       libdatadog (~> 14.1.0.1.0)
-      libddwaf (~> 1.15.0.0.0)
+      libddwaf (~> 1.18.0.0.0)
       msgpack
 
 GEM
@@ -61,9 +61,9 @@ GEM
       addressable (>= 2.4)
     libdatadog (14.1.0.1.0-aarch64-linux)
     libdatadog (14.1.0.1.0-x86_64-linux)
-    libddwaf (1.15.0.0.0-aarch64-linux)
+    libddwaf (1.18.0.0.0-aarch64-linux)
       ffi (~> 1.0)
-    libddwaf (1.15.0.0.0-x86_64-linux)
+    libddwaf (1.18.0.0.0-x86_64-linux)
       ffi (~> 1.0)
     memory_profiler (0.9.14)
     method_source (1.1.0)

--- a/gemfiles/ruby_3.4_stripe_11.gemfile.lock
+++ b/gemfiles/ruby_3.4_stripe_11.gemfile.lock
@@ -21,7 +21,7 @@ PATH
     datadog (2.7.0)
       datadog-ruby_core_source (~> 3.3)
       libdatadog (~> 14.1.0.1.0)
-      libddwaf (~> 1.15.0.0.0)
+      libddwaf (~> 1.18.0.0.0)
       msgpack
 
 GEM
@@ -61,9 +61,9 @@ GEM
       addressable (>= 2.4)
     libdatadog (14.1.0.1.0-aarch64-linux)
     libdatadog (14.1.0.1.0-x86_64-linux)
-    libddwaf (1.15.0.0.0-aarch64-linux)
+    libddwaf (1.18.0.0.0-aarch64-linux)
       ffi (~> 1.0)
-    libddwaf (1.15.0.0.0-x86_64-linux)
+    libddwaf (1.18.0.0.0-x86_64-linux)
       ffi (~> 1.0)
     memory_profiler (0.9.14)
     method_source (1.1.0)

--- a/gemfiles/ruby_3.4_stripe_12.gemfile.lock
+++ b/gemfiles/ruby_3.4_stripe_12.gemfile.lock
@@ -21,7 +21,7 @@ PATH
     datadog (2.7.0)
       datadog-ruby_core_source (~> 3.3)
       libdatadog (~> 14.1.0.1.0)
-      libddwaf (~> 1.15.0.0.0)
+      libddwaf (~> 1.18.0.0.0)
       msgpack
 
 GEM
@@ -61,9 +61,9 @@ GEM
       addressable (>= 2.4)
     libdatadog (14.1.0.1.0-aarch64-linux)
     libdatadog (14.1.0.1.0-x86_64-linux)
-    libddwaf (1.15.0.0.0-aarch64-linux)
+    libddwaf (1.18.0.0.0-aarch64-linux)
       ffi (~> 1.0)
-    libddwaf (1.15.0.0.0-x86_64-linux)
+    libddwaf (1.18.0.0.0-x86_64-linux)
       ffi (~> 1.0)
     memory_profiler (0.9.14)
     method_source (1.1.0)

--- a/gemfiles/ruby_3.4_stripe_7.gemfile.lock
+++ b/gemfiles/ruby_3.4_stripe_7.gemfile.lock
@@ -21,7 +21,7 @@ PATH
     datadog (2.7.0)
       datadog-ruby_core_source (~> 3.3)
       libdatadog (~> 14.1.0.1.0)
-      libddwaf (~> 1.15.0.0.0)
+      libddwaf (~> 1.18.0.0.0)
       msgpack
 
 GEM
@@ -61,9 +61,9 @@ GEM
       addressable (>= 2.4)
     libdatadog (14.1.0.1.0-aarch64-linux)
     libdatadog (14.1.0.1.0-x86_64-linux)
-    libddwaf (1.15.0.0.0-aarch64-linux)
+    libddwaf (1.18.0.0.0-aarch64-linux)
       ffi (~> 1.0)
-    libddwaf (1.15.0.0.0-x86_64-linux)
+    libddwaf (1.18.0.0.0-x86_64-linux)
       ffi (~> 1.0)
     memory_profiler (0.9.14)
     method_source (1.1.0)

--- a/gemfiles/ruby_3.4_stripe_8.gemfile.lock
+++ b/gemfiles/ruby_3.4_stripe_8.gemfile.lock
@@ -21,7 +21,7 @@ PATH
     datadog (2.7.0)
       datadog-ruby_core_source (~> 3.3)
       libdatadog (~> 14.1.0.1.0)
-      libddwaf (~> 1.15.0.0.0)
+      libddwaf (~> 1.18.0.0.0)
       msgpack
 
 GEM
@@ -61,9 +61,9 @@ GEM
       addressable (>= 2.4)
     libdatadog (14.1.0.1.0-aarch64-linux)
     libdatadog (14.1.0.1.0-x86_64-linux)
-    libddwaf (1.15.0.0.0-aarch64-linux)
+    libddwaf (1.18.0.0.0-aarch64-linux)
       ffi (~> 1.0)
-    libddwaf (1.15.0.0.0-x86_64-linux)
+    libddwaf (1.18.0.0.0-x86_64-linux)
       ffi (~> 1.0)
     memory_profiler (0.9.14)
     method_source (1.1.0)

--- a/gemfiles/ruby_3.4_stripe_9.gemfile.lock
+++ b/gemfiles/ruby_3.4_stripe_9.gemfile.lock
@@ -21,7 +21,7 @@ PATH
     datadog (2.7.0)
       datadog-ruby_core_source (~> 3.3)
       libdatadog (~> 14.1.0.1.0)
-      libddwaf (~> 1.15.0.0.0)
+      libddwaf (~> 1.18.0.0.0)
       msgpack
 
 GEM
@@ -61,9 +61,9 @@ GEM
       addressable (>= 2.4)
     libdatadog (14.1.0.1.0-aarch64-linux)
     libdatadog (14.1.0.1.0-x86_64-linux)
-    libddwaf (1.15.0.0.0-aarch64-linux)
+    libddwaf (1.18.0.0.0-aarch64-linux)
       ffi (~> 1.0)
-    libddwaf (1.15.0.0.0-x86_64-linux)
+    libddwaf (1.18.0.0.0-x86_64-linux)
       ffi (~> 1.0)
     memory_profiler (0.9.14)
     method_source (1.1.0)

--- a/gemfiles/ruby_3.4_stripe_latest.gemfile.lock
+++ b/gemfiles/ruby_3.4_stripe_latest.gemfile.lock
@@ -21,7 +21,7 @@ PATH
     datadog (2.7.0)
       datadog-ruby_core_source (~> 3.3)
       libdatadog (~> 14.1.0.1.0)
-      libddwaf (~> 1.15.0.0.0)
+      libddwaf (~> 1.18.0.0.0)
       msgpack
 
 GEM
@@ -61,9 +61,9 @@ GEM
       addressable (>= 2.4)
     libdatadog (14.1.0.1.0-aarch64-linux)
     libdatadog (14.1.0.1.0-x86_64-linux)
-    libddwaf (1.15.0.0.0-aarch64-linux)
+    libddwaf (1.18.0.0.0-aarch64-linux)
       ffi (~> 1.0)
-    libddwaf (1.15.0.0.0-x86_64-linux)
+    libddwaf (1.18.0.0.0-x86_64-linux)
       ffi (~> 1.0)
     memory_profiler (0.9.14)
     method_source (1.1.0)

--- a/gemfiles/ruby_3.4_stripe_min.gemfile.lock
+++ b/gemfiles/ruby_3.4_stripe_min.gemfile.lock
@@ -21,7 +21,7 @@ PATH
     datadog (2.7.0)
       datadog-ruby_core_source (~> 3.3)
       libdatadog (~> 14.1.0.1.0)
-      libddwaf (~> 1.15.0.0.0)
+      libddwaf (~> 1.18.0.0.0)
       msgpack
 
 GEM
@@ -61,9 +61,9 @@ GEM
       addressable (>= 2.4)
     libdatadog (14.1.0.1.0-aarch64-linux)
     libdatadog (14.1.0.1.0-x86_64-linux)
-    libddwaf (1.15.0.0.0-aarch64-linux)
+    libddwaf (1.18.0.0.0-aarch64-linux)
       ffi (~> 1.0)
-    libddwaf (1.15.0.0.0-x86_64-linux)
+    libddwaf (1.18.0.0.0-x86_64-linux)
       ffi (~> 1.0)
     memory_profiler (0.9.14)
     method_source (1.1.0)

--- a/lib/datadog/appsec/event.rb
+++ b/lib/datadog/appsec/event.rb
@@ -142,7 +142,7 @@ module Datadog
           scope.trace.keep! if scope.trace
 
           if scope.service_entry_span
-            scope.service_entry_span.set_tag('appsec.blocked', 'true') if waf_result.actions.include?('block')
+            scope.service_entry_span.set_tag('appsec.blocked', 'true') if waf_result.actions.include?('block_request')
             scope.service_entry_span.set_tag('appsec.event', 'true')
           end
 

--- a/lib/datadog/appsec/event.rb
+++ b/lib/datadog/appsec/event.rb
@@ -142,7 +142,7 @@ module Datadog
           scope.trace.keep! if scope.trace
 
           if scope.service_entry_span
-            scope.service_entry_span.set_tag('appsec.blocked', 'true') if waf_result.actions.include?('block_request')
+            scope.service_entry_span.set_tag('appsec.blocked', 'true') if waf_result.actions.key?('block_request')
             scope.service_entry_span.set_tag('appsec.event', 'true')
           end
 

--- a/spec/datadog/appsec/event_spec.rb
+++ b/spec/datadog/appsec/event_spec.rb
@@ -366,7 +366,7 @@ RSpec.describe Datadog::AppSec::Event do
     let(:with_trace) { true }
     let(:with_span) { true }
 
-    let(:waf_actions) { [] }
+    let(:waf_actions) { {} }
     let(:waf_result) do
       dbl = double
 
@@ -410,7 +410,9 @@ RSpec.describe Datadog::AppSec::Event do
     end
 
     context 'with block action' do
-      let(:waf_actions) { ['block'] }
+      let(:waf_actions) do
+        { 'block_request' => { 'grpc_status_code' => '10', 'status_core' => '403', 'type' => 'auto' } }
+      end
 
       it 'adds appsec.blocked tag to span' do
         expect(scope.service_entry_span.send(:meta)['appsec.blocked']).to eq('true')
@@ -442,7 +444,9 @@ RSpec.describe Datadog::AppSec::Event do
       end
 
       context 'with block action' do
-        let(:waf_actions) { ['block'] }
+        let(:waf_actions) do
+          { 'block_request' => { 'grpc_status_code' => '10', 'status_core' => '403', 'type' => 'auto' } }
+        end
 
         it 'does not add distributed tags but still add appsec span tags' do
           expect(scope.trace).to be nil

--- a/spec/datadog/appsec/processor/context_spec.rb
+++ b/spec/datadog/appsec/processor/context_spec.rb
@@ -173,7 +173,7 @@ RSpec.describe Datadog::AppSec::Processor::Context do
       it { expect(telemetry).not_to receive(:error) }
       it { expect(matches).to have_attributes(count: 1) }
       it { expect(events).to have_attributes(count: 1) }
-      it { expect(actions).to eq [[]] }
+      it { expect(actions).to eq [{}] }
     end
 
     context 'multiple attacks per run' do
@@ -181,7 +181,7 @@ RSpec.describe Datadog::AppSec::Processor::Context do
 
       it { expect(matches).to have_attributes(count: 1) }
       it { expect(events).to have_attributes(count: 2) }
-      it { expect(actions).to eq [[]] }
+      it { expect(actions).to eq [{}] }
     end
 
     context 'multiple runs' do
@@ -199,7 +199,7 @@ RSpec.describe Datadog::AppSec::Processor::Context do
 
         it { expect(matches).to have_attributes(count: 1) }
         it { expect(events).to have_attributes(count: 1) }
-        it { expect(actions).to eq [[]] }
+        it { expect(actions).to eq [{}] }
       end
 
       context 'different attacks' do
@@ -215,7 +215,7 @@ RSpec.describe Datadog::AppSec::Processor::Context do
 
         it { expect(matches).to have_attributes(count: 2) }
         it { expect(events).to have_attributes(count: 2) }
-        it { expect(actions).to eq [[], []] }
+        it { expect(actions).to eq [{}, {}] }
       end
     end
 
@@ -235,7 +235,12 @@ RSpec.describe Datadog::AppSec::Processor::Context do
 
       it { expect(matches).to have_attributes(count: 1) }
       it { expect(events).to have_attributes(count: 1) }
-      it { expect(actions).to eq [['block']] }
+
+      it do
+        expect(actions).to(
+          eq([{ 'block_request' => { 'grpc_status_code' => '10', 'status_code' => '403', 'type' => 'auto' } }])
+        )
+      end
     end
 
     context 'run failed with libddwaf error result' do


### PR DESCRIPTION
Libddwaf 1.18.0.0.0 had some breaking changes - `actions` in the result is now an array of objects, instead of an array of strings.

**Please don't merge until 2.8.0 is released**

**What does this PR do?**
This PR updates `libddwaf` dependency to 1.18.0.0.0 and fixes specs that were broken with this update.

**Motivation:**
This version of `libddwaf` is required for detecting SQL injections.

**Change log entry**
None

**Additional Notes:**
None

**How to test the change?**
CI is enough
