### PR TITLE
DEBUG-2334 add new_record flag to ActiveRecord model custom serializer

### DIFF
--- a/lib/datadog/di/contrib/active_record.rb
+++ b/lib/datadog/di/contrib/active_record.rb
@@ -5,6 +5,7 @@ Datadog::DI::Serializer.register(condition: lambda { |value| ActiveRecord::Base 
   # steep:ignore:start
   value_to_serialize = {
     attributes: value.attributes,
+    new_record: value.new_record?,
   }
   serializer.serialize_value(value_to_serialize, depth: depth ? depth - 1 : nil, type: value.class)
   # steep:ignore:end

--- a/spec/datadog/di/contrib/active_record/serializer_active_record_spec.rb
+++ b/spec/datadog/di/contrib/active_record/serializer_active_record_spec.rb
@@ -78,6 +78,9 @@ RSpec.describe Datadog::DI::Serializer do
        expected: {type: "SerializerRailsSpecTestEmptyModel", entries: [[
          {type: 'Symbol', value: 'attributes'},
          {type: 'Hash', entries: [[{type: 'String', value: 'id'}, {type: 'NilClass', isNull: true}]]},
+       ], [
+        {type: 'Symbol', value: 'new_record'},
+        {type: 'TrueClass', value: 'true'},
        ]]}},
       {name: "AR model with empty attributes",
        input: -> { SerializerRailsSpecTestBasicModel.new },
@@ -89,6 +92,9 @@ RSpec.describe Datadog::DI::Serializer do
            [{type: 'String', value: 'created_at'}, {type: 'NilClass', isNull: true}],
            [{type: 'String', value: 'updated_at'}, {type: 'NilClass', isNull: true}],
          ]},
+       ], [
+        {type: 'Symbol', value: 'new_record'},
+        {type: 'TrueClass', value: 'true'},
        ]]}},
       {name: "AR model with filled out attributes",
        input: -> {
@@ -105,6 +111,28 @@ RSpec.describe Datadog::DI::Serializer do
            [{type: 'String', value: 'created_at'}, {type: 'Time', value: '2020-01-02T00:00:00Z'}],
            [{type: 'String', value: 'updated_at'}, {type: 'Time', value: '2020-01-03T00:00:00Z'}],
          ]},
+       ], [
+        {type: 'Symbol', value: 'new_record'},
+        {type: 'TrueClass', value: 'true'},
+       ]]}},
+      {name: "AR model with filled out attributes and persisted",
+       input: -> {
+                SerializerRailsSpecTestBasicModel.create!(
+                  title: 'Hello, world!', created_at: Time.utc(2020, 1, 2), updated_at: Time.utc(2020, 1, 3)
+                )
+              },
+       expected: {type: "SerializerRailsSpecTestBasicModel", entries: [[
+         {type: 'Symbol', value: 'attributes'},
+         {type: 'Hash', entries: [
+           [{type: 'String', value: 'id'}, {type: 'Integer', value: '1'}],
+           [{type: 'String', value: 'title'}, {type: 'String', value: 'Hello, world!'}],
+           # TODO serialize Time, Date, DateTime types
+           [{type: 'String', value: 'created_at'}, {type: 'Time', value: '2020-01-02T00:00:00Z'}],
+           [{type: 'String', value: 'updated_at'}, {type: 'Time', value: '2020-01-03T00:00:00Z'}],
+         ]},
+       ], [
+        {type: 'Symbol', value: 'new_record'},
+        {type: 'FalseClass', value: 'false'},
        ]]}},
     ]
 

--- a/spec/datadog/di/contrib/active_record/serializer_active_record_spec.rb
+++ b/spec/datadog/di/contrib/active_record/serializer_active_record_spec.rb
@@ -107,7 +107,6 @@ RSpec.describe Datadog::DI::Serializer do
          {type: 'Hash', entries: [
            [{type: 'String', value: 'id'}, {type: 'NilClass', isNull: true}],
            [{type: 'String', value: 'title'}, {type: 'String', value: 'Hello, world!'}],
-           # TODO serialize Time, Date, DateTime types
            [{type: 'String', value: 'created_at'}, {type: 'Time', value: '2020-01-02T00:00:00Z'}],
            [{type: 'String', value: 'updated_at'}, {type: 'Time', value: '2020-01-03T00:00:00Z'}],
          ]},
@@ -126,7 +125,6 @@ RSpec.describe Datadog::DI::Serializer do
          {type: 'Hash', entries: [
            [{type: 'String', value: 'id'}, {type: 'Integer', value: '1'}],
            [{type: 'String', value: 'title'}, {type: 'String', value: 'Hello, world!'}],
-           # TODO serialize Time, Date, DateTime types
            [{type: 'String', value: 'created_at'}, {type: 'Time', value: '2020-01-02T00:00:00Z'}],
            [{type: 'String', value: 'updated_at'}, {type: 'Time', value: '2020-01-03T00:00:00Z'}],
          ]},

--- a/spec/datadog/di/contrib/active_record/serializer_active_record_spec.rb
+++ b/spec/datadog/di/contrib/active_record/serializer_active_record_spec.rb
@@ -79,8 +79,8 @@ RSpec.describe Datadog::DI::Serializer do
          {type: 'Symbol', value: 'attributes'},
          {type: 'Hash', entries: [[{type: 'String', value: 'id'}, {type: 'NilClass', isNull: true}]]},
        ], [
-        {type: 'Symbol', value: 'new_record'},
-        {type: 'TrueClass', value: 'true'},
+         {type: 'Symbol', value: 'new_record'},
+         {type: 'TrueClass', value: 'true'},
        ]]}},
       {name: "AR model with empty attributes",
        input: -> { SerializerRailsSpecTestBasicModel.new },
@@ -93,8 +93,8 @@ RSpec.describe Datadog::DI::Serializer do
            [{type: 'String', value: 'updated_at'}, {type: 'NilClass', isNull: true}],
          ]},
        ], [
-        {type: 'Symbol', value: 'new_record'},
-        {type: 'TrueClass', value: 'true'},
+         {type: 'Symbol', value: 'new_record'},
+         {type: 'TrueClass', value: 'true'},
        ]]}},
       {name: "AR model with filled out attributes",
        input: -> {
@@ -112,8 +112,8 @@ RSpec.describe Datadog::DI::Serializer do
            [{type: 'String', value: 'updated_at'}, {type: 'Time', value: '2020-01-03T00:00:00Z'}],
          ]},
        ], [
-        {type: 'Symbol', value: 'new_record'},
-        {type: 'TrueClass', value: 'true'},
+         {type: 'Symbol', value: 'new_record'},
+         {type: 'TrueClass', value: 'true'},
        ]]}},
       {name: "AR model with filled out attributes and persisted",
        input: -> {
@@ -131,8 +131,8 @@ RSpec.describe Datadog::DI::Serializer do
            [{type: 'String', value: 'updated_at'}, {type: 'Time', value: '2020-01-03T00:00:00Z'}],
          ]},
        ], [
-        {type: 'Symbol', value: 'new_record'},
-        {type: 'FalseClass', value: 'false'},
+         {type: 'Symbol', value: 'new_record'},
+         {type: 'FalseClass', value: 'false'},
        ]]}},
     ]
 


### PR DESCRIPTION
<!--
Check out the
https://github.com/DataDog/dd-trace-rb/blob/master/docs/DevelopmentGuide.md
for guidance on how to set up your development environment,
run the test suite, write new integrations, and more.
-->

**What does this PR do?**
Dynamic Instrumentation ships with a custom serializer for ActiveRecord models which lifts the interesting fields (i.e. attributes) to the top level of the serialized object.

This PR adds the new_record? flag to the serialized object.
<!-- A brief description of the change being made with this pull request. -->

**Motivation:**
The current rendering of AR models in dynamic instrumentation UI is somewhat "weird" because the attributes are nested under the "attributes" field, but there are no other fields. It's confusing why the attributes aren't just rendered on the top level.

Adding the new_record flag, in my opinion, improves the UI to where it looks more polished and doesn't look like something is wrong with it.
<!-- What inspired you to submit this pull request? -->

**Change log entry**
None (part of initial DI release)
<!-- If this is a customer-visible change, a brief summary to be placed
into the change log.
If you are not a Datadog employee, you can skip this section
and it will be filled or deleted during PR review. -->

**Additional Notes:**
<!-- Anything else we should know when reviewing? -->

**How to test the change?**
<!--
Describe here how the change can be validated.
You are strongly encouraged to provide automated tests for this PR (unit or integration).
If this change cannot be feasibly tested, please explain why,
unless the change does not modify code (e.g. only modifies docs, comments).
-->
Unit tests are included

<!-- Unsure? Have a question? Request a review! -->
