### PR TITLE
DEBUG-2334 do not try to install pending probes on eval'd code

### DIFF
--- a/lib/datadog/di/code_tracker.rb
+++ b/lib/datadog/di/code_tracker.rb
@@ -78,10 +78,11 @@ module Datadog
               registry_lock.synchronize do
                 registry[path] = tp.instruction_sequence
               end
+
+              # Also, pending line probes should only be installed for
+              # non-eval'd code.
+              DI.current_component&.probe_manager&.install_pending_line_probes(path)
             end
-
-            DI.current_component&.probe_manager&.install_pending_line_probes(path)
-
           # Since this method normally is called from customer applications,
           # rescue any exceptions that might not be handled to not break said
           # customer applications.

--- a/lib/datadog/di/probe.rb
+++ b/lib/datadog/di/probe.rb
@@ -161,6 +161,9 @@ module Datadog
       # If file is not an absolute path, the path matches if the file is its suffix,
       # at a path component boundary.
       def file_matches?(path)
+        if path.nil?
+          raise ArgumentError, "Cannot match against a nil path"
+        end
         unless file
           raise ArgumentError, "Probe does not have a file to match against"
         end

--- a/lib/datadog/di/probe_manager.rb
+++ b/lib/datadog/di/probe_manager.rb
@@ -206,6 +206,9 @@ module Datadog
       # point, which is invoked for each required or loaded file
       # (and also for eval'd code, but those invocations are filtered out).
       def install_pending_line_probes(path)
+        if path.nil?
+          raise ArgumentError, "path must not be nil"
+        end
         @lock.synchronize do
           @pending_probes.values.each do |probe|
             if probe.line?

--- a/lib/datadog/di/utils.rb
+++ b/lib/datadog/di/utils.rb
@@ -12,6 +12,13 @@ module Datadog
       # If suffix is not an absolute path, the path matches if its suffix is
       # the provided suffix, at a path component boundary.
       module_function def path_matches_suffix?(path, suffix)
+        if path.nil?
+          raise ArgumentError, "nil path passed"
+        end
+        if suffix.nil?
+          raise ArgumentError, "nil suffix passed"
+        end
+
         if suffix.start_with?('/')
           path == suffix
         else

--- a/spec/datadog/di/code_tracker_pending_load.rb
+++ b/spec/datadog/di/code_tracker_pending_load.rb
@@ -1,0 +1,1 @@
+# Nothing

--- a/spec/datadog/di/code_tracker_pending_require.rb
+++ b/spec/datadog/di/code_tracker_pending_require.rb
@@ -1,0 +1,1 @@
+# Nothing

--- a/spec/datadog/di/code_tracker_spec.rb
+++ b/spec/datadog/di/code_tracker_spec.rb
@@ -8,6 +8,16 @@ RSpec.describe Datadog::DI::CodeTracker do
     described_class.new
   end
 
+  shared_context 'when code tracker is running' do
+    before do
+      tracker.start
+    end
+
+    after do
+      tracker.stop
+    end
+  end
+
   describe "#start" do
     after do
       tracker.stop
@@ -90,13 +100,7 @@ RSpec.describe Datadog::DI::CodeTracker do
 
   describe "#active?" do
     context "when started" do
-      before do
-        tracker.start
-      end
-
-      after do
-        tracker.stop
-      end
+      include_context 'when code tracker is running'
 
       it "is true" do
         expect(tracker.active?).to be true
@@ -111,6 +115,57 @@ RSpec.describe Datadog::DI::CodeTracker do
 
       it "is false" do
         expect(tracker.active?).to be false
+      end
+    end
+  end
+
+  describe 'line probe installation' do
+    let(:component) do
+      instance_double(Datadog::DI::Component).tap do |component|
+        expect(component).to receive(:probe_manager).and_return(probe_manager)
+      end
+    end
+
+    let(:probe_manager) do
+      instance_double(Datadog::DI::ProbeManager)
+    end
+
+    context 'when started' do
+      include_context 'when code tracker is running'
+
+      context 'when a file is required' do
+        it 'requests to install pending line probes' do
+          expect(Datadog::DI).to receive(:current_component).and_return(component)
+          expect(probe_manager).to receive(:install_pending_line_probes) do |path|
+            # Should be an absolute path
+            expect(path).to start_with('/')
+            expect(File.basename(path)).to eq('code_tracker_pending_require.rb')
+          end
+          require_relative 'code_tracker_pending_require'
+        end
+      end
+
+      context 'when a file is loaded' do
+        it 'requests to install pending line probes' do
+          expect(Datadog::DI).to receive(:current_component).and_return(component)
+          expect(probe_manager).to receive(:install_pending_line_probes) do |path|
+            # Should be an absolute path
+            expect(path).to start_with('/')
+            expect(File.basename(path)).to eq('code_tracker_pending_load.rb')
+          end
+          load File.join(File.dirname(__FILE__), 'code_tracker_pending_load.rb')
+        end
+      end
+
+      context "when Ruby code is eval'd" do
+        it 'requests to install pending line probes' do
+          # Matchers can be lazily loaded, force all code to be loaded here.
+          expect(4).to eq(4)
+
+          expect(Datadog::DI).not_to receive(:current_component)
+          expect(probe_manager).not_to receive(:install_pending_line_probes)
+          expect(eval('2 + 2')).to eq(4) # rubocop:disable Style/EvalWithLocation
+        end
       end
     end
   end

--- a/spec/datadog/di/code_tracker_spec.rb
+++ b/spec/datadog/di/code_tracker_spec.rb
@@ -4,6 +4,10 @@ require "datadog/di/code_tracker"
 RSpec.describe Datadog::DI::CodeTracker do
   di_test
 
+  before(:all) do
+    Datadog::DI.deactivate_tracking!
+  end
+
   let(:tracker) do
     described_class.new
   end

--- a/spec/datadog/di/code_tracker_spec.rb
+++ b/spec/datadog/di/code_tracker_spec.rb
@@ -139,9 +139,6 @@ RSpec.describe Datadog::DI::CodeTracker do
 
       context 'when a file is required' do
         it 'requests to install pending line probes' do
-          # Matchers can be lazily loaded, force all code to be loaded here.
-          expect(4).to eq(4)
-
           expect(Datadog::DI).to receive(:current_component).and_return(component)
           expect(probe_manager).to receive(:install_pending_line_probes) do |path|
             # Should be an absolute path
@@ -154,9 +151,6 @@ RSpec.describe Datadog::DI::CodeTracker do
 
       context 'when a file is loaded' do
         it 'requests to install pending line probes' do
-          # Matchers can be lazily loaded, force all code to be loaded here.
-          expect(4).to eq(4)
-
           expect(Datadog::DI).to receive(:current_component).and_return(component)
           expect(probe_manager).to receive(:install_pending_line_probes) do |path|
             # Should be an absolute path

--- a/spec/datadog/di/code_tracker_spec.rb
+++ b/spec/datadog/di/code_tracker_spec.rb
@@ -135,6 +135,9 @@ RSpec.describe Datadog::DI::CodeTracker do
 
       context 'when a file is required' do
         it 'requests to install pending line probes' do
+          # Matchers can be lazily loaded, force all code to be loaded here.
+          expect(4).to eq(4)
+
           expect(Datadog::DI).to receive(:current_component).and_return(component)
           expect(probe_manager).to receive(:install_pending_line_probes) do |path|
             # Should be an absolute path
@@ -147,6 +150,9 @@ RSpec.describe Datadog::DI::CodeTracker do
 
       context 'when a file is loaded' do
         it 'requests to install pending line probes' do
+          # Matchers can be lazily loaded, force all code to be loaded here.
+          expect(4).to eq(4)
+
           expect(Datadog::DI).to receive(:current_component).and_return(component)
           expect(probe_manager).to receive(:install_pending_line_probes) do |path|
             # Should be an absolute path


### PR DESCRIPTION
<!--
Check out the
https://github.com/DataDog/dd-trace-rb/blob/master/docs/DevelopmentGuide.md
for guidance on how to set up your development environment,
run the test suite, write new integrations, and more.
-->

**What does this PR do?**
Fixes incorrect placement of the call to install pending probes in script_compiled trace point handler. The call should only be made if there is a path corresponding to the code having been compiled (i.e., code was required or loaded but not evaled). Previously the call was outside of the conditional checking if path is present and would be made also for eval'd code, subsequently failing in path suffix matching.
<!-- A brief description of the change being made with this pull request. -->

**Motivation:**
The failure manifested in my local testing with "propagate all exceptions" flag set which I normally have on.
<!-- What inspired you to submit this pull request? -->

**Change log entry**
None
<!-- If this is a customer-visible change, a brief summary to be placed
into the change log.
If you are not a Datadog employee, you can skip this section
and it will be filled or deleted during PR review. -->

**Additional Notes:**
The existing exception boundaries prevent the issue being repaired in this PR from having customer impact - it would only generate noise in the log. The exception boundary at trace point execution means the trace point execution wouldn't do anything, but it *should* do nothing for eval'd code.
<!-- Anything else we should know when reviewing? -->

**How to test the change?**
Unit tests are included
<!--
Describe here how the change can be validated.
You are strongly encouraged to provide automated tests for this PR (unit or integration).
If this change cannot be feasibly tested, please explain why,
unless the change does not modify code (e.g. only modifies docs, comments).
-->

<!-- Unsure? Have a question? Request a review! -->
