### PR TITLE
ci: adds APPSEC_BLOCKING scenario in CI

### DIFF
--- a/.github/workflows/system-tests.yml
+++ b/.github/workflows/system-tests.yml
@@ -220,6 +220,7 @@ jobs:
           - APPSEC_BLOCKING_FULL_DENYLIST
           - APPSEC_REQUEST_BLOCKING
           - APPSEC_STANDALONE
+          - APPSEC_BLOCKING
         include:
           - library: ruby
             app: rack


### PR DESCRIPTION
<!--
Check out the
https://github.com/DataDog/dd-trace-rb/blob/master/docs/DevelopmentGuide.md
for guidance on how to set up your development environment,
run the test suite, write new integrations, and more.
-->

**What does this PR do?**
Adds system-tests scenario APPSEC_BLOCKING in the CI

**Motivation:**
A change (probably #4163) broke blocking feature. this scenario will prevent any future bug

**Change log entry**
<!-- If this is a customer-visible change, a brief summary to be placed
into the change log.
If you are not a Datadog employee, you can skip this section
and it will be filled or deleted during PR review. -->

**Additional Notes:**
This PR can't be merged before the feature is fixed, or the test adapted

**How to test the change?**
CI is green.

<!-- Unsure? Have a question? Request a review! -->
