### PR TITLE
Fix handling of non integer response status code in AppSec

### DIFF
--- a/.github/workflows/system-tests.yml
+++ b/.github/workflows/system-tests.yml
@@ -11,7 +11,7 @@ on:
 env:
   REGISTRY: ghcr.io
   REPO: ghcr.io/datadog/dd-trace-rb
-  SYSTEM_TESTS_REF: unskip-waf-blocking-tests-for-ruby # This must always be set to `main` on dd-trace-rb's master branch
+  SYSTEM_TESTS_REF: main # This must always be set to `main` on dd-trace-rb's master branch
 
 jobs:
   build-harness:

--- a/.github/workflows/system-tests.yml
+++ b/.github/workflows/system-tests.yml
@@ -11,7 +11,7 @@ on:
 env:
   REGISTRY: ghcr.io
   REPO: ghcr.io/datadog/dd-trace-rb
-  SYSTEM_TESTS_REF: main # This must always be set to `main` on dd-trace-rb's master branch
+  SYSTEM_TESTS_REF: unskip-waf-blocking-tests-for-ruby # This must always be set to `main` on dd-trace-rb's master branch
 
 jobs:
   build-harness:

--- a/lib/datadog/appsec/response.rb
+++ b/lib/datadog/appsec/response.rb
@@ -87,7 +87,7 @@ module Datadog
           body << content(content_type)
 
           Response.new(
-            status: options.fetch('status_code', 403).to_i,
+            status: options['status_code']&.to_i || 403,
             headers: { 'Content-Type' => content_type },
             body: body,
           )

--- a/lib/datadog/appsec/response.rb
+++ b/lib/datadog/appsec/response.rb
@@ -87,7 +87,7 @@ module Datadog
           body << content(content_type)
 
           Response.new(
-            status: options['status_code'] || 403,
+            status: (options['status_code'] ? options['status_code'].to_i : 403),
             headers: { 'Content-Type' => content_type },
             body: body,
           )
@@ -96,8 +96,9 @@ module Datadog
         def redirect_response(env, options)
           if options['location'] && !options['location'].empty?
             content_type = content_type(env)
+            status_code = options['status_code'].to_i
 
-            status = options['status_code'] >= 300 && options['status_code'] < 400 ? options['status_code'] : 303
+            status = status_code >= 300 && status_code < 400 ? status_code : 303
 
             headers = {
               'Content-Type' => content_type,

--- a/lib/datadog/appsec/response.rb
+++ b/lib/datadog/appsec/response.rb
@@ -98,7 +98,7 @@ module Datadog
             content_type = content_type(env)
             status_code = options['status_code'].to_i
 
-            status = status_code >= 300 && status_code < 400 ? status_code : 303
+            status = (300...400).cover?(status_code) ? status_code : 303
 
             headers = {
               'Content-Type' => content_type,

--- a/lib/datadog/appsec/response.rb
+++ b/lib/datadog/appsec/response.rb
@@ -87,7 +87,7 @@ module Datadog
           body << content(content_type)
 
           Response.new(
-            status: options['status_code']&.to_i || 403,
+            status: options.fetch('status_code', 403).to_i,
             headers: { 'Content-Type' => content_type },
             body: body,
           )
@@ -96,17 +96,15 @@ module Datadog
         def redirect_response(env, options)
           if options['location'] && !options['location'].empty?
             content_type = content_type(env)
-            status_code = options['status_code'].to_i
-
-            status = (300...400).cover?(status_code) ? status_code : 303
 
             headers = {
               'Content-Type' => content_type,
               'Location' => options['location']
             }
 
+            status_code = options['status_code'].to_i
             Response.new(
-              status: status,
+              status: (status_code >= 300 && status_code < 400 ? status_code : 303),
               headers: headers,
               body: [],
             )

--- a/lib/datadog/appsec/response.rb
+++ b/lib/datadog/appsec/response.rb
@@ -87,7 +87,7 @@ module Datadog
           body << content(content_type)
 
           Response.new(
-            status: (options['status_code'] ? options['status_code'].to_i : 403),
+            status: options['status_code']&.to_i || 403,
             headers: { 'Content-Type' => content_type },
             body: body,
           )

--- a/spec/datadog/appsec/response_spec.rb
+++ b/spec/datadog/appsec/response_spec.rb
@@ -21,7 +21,7 @@ RSpec.describe Datadog::AppSec::Response do
         end
 
         let(:type) { 'html' }
-        let(:status_code) { 100 }
+        let(:status_code) { '100' }
 
         context 'status_code' do
           subject(:status) { described_class.negotiate(env, actions).status }
@@ -92,7 +92,7 @@ RSpec.describe Datadog::AppSec::Response do
         end
 
         let(:location) { 'foo' }
-        let(:status_code) { 303 }
+        let(:status_code) { '303' }
 
         context 'status_code' do
           subject(:status) { described_class.negotiate(env, actions).status }
@@ -100,7 +100,7 @@ RSpec.describe Datadog::AppSec::Response do
           it { is_expected.to eq 303 }
 
           context 'when status code do not starts with 3' do
-            let(:status_code) { 202 }
+            let(:status_code) { '202' }
 
             it { is_expected.to eq 303 }
           end


### PR DESCRIPTION
Custom actions for AppSec can have status codes that are strings and not integers. We need to handle them properly.

**What does this PR do?**
This PR adds conversion of response status code for AppSec actions.

**Motivation:**
Failing system tests:
https://github.com/DataDog/system-tests/pull/3586

**Change log entry**
None

**Additional Notes:**
None

**How to test the change?**
CI is enough