### PR TITLE
[NO-TICKET] Update documentation to clarify what test mode does

### DIFF
--- a/docs/GettingStarted.md
+++ b/docs/GettingStarted.md
@@ -108,7 +108,7 @@ OR
 
 #### Other Ruby applications
 
-If your application does not use the supported gems (Rails or Hanami) above, you can set it up as follows:
+If your application does not use the above mentioned gems (Rails or Hanami), you can set it up as follows:
 
 1. Add the `datadog` gem to your Gemfile:
 
@@ -2021,7 +2021,6 @@ To change the default behavior of `datadog`, you can use, in order of priority, 
      c.env = ENV['RACK_ENV']
 
      c.tracing.report_hostname = true
-     c.tracing.test_mode.enabled = (ENV['RACK_ENV'] == 'test')
    end
    ```
 
@@ -2067,7 +2066,7 @@ For example, if `tracing.sampling.default_rate` is configured by [Remote Configu
 | `tracing.sampling.span_rules`                          | `DD_SPAN_SAMPLING_RULES`,`ENV_SPAN_SAMPLING_RULES_FILE` | `String`                              | `nil`                        | Sets [Single Span Sampling](#single-span-sampling) rules. These rules allow you to keep spans even when their respective traces are dropped.                                                                                                                                                                                                                                                                                                                                                                                                                                                                                           |
 | `tracing.trace_id_128_bit_generation_enabled`          | `DD_TRACE_128_BIT_TRACEID_GENERATION_ENABLED`           | `Bool`                                | `true`                       | `true` to generate 128 bits trace ID and `false` to generate 64 bits trace ID                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                          |
 | `tracing.report_hostname`                              | `DD_TRACE_REPORT_HOSTNAME`                              | `Bool`                                | `false`                      | Adds hostname tag to traces.                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                           |
-| `tracing.test_mode.enabled`                            | `DD_TRACE_TEST_MODE_ENABLED`                            | `Bool`                                | `false`                      | Enables or disables test mode, for use of tracing in test suites.                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                      |
+| `tracing.test_mode.enabled`                            | `DD_TRACE_TEST_MODE_ENABLED`                            | `Bool`                                | `false`                      | Enables or disables "test mode", used for testing distributed tracing behavior. Note that traces will still be sent; consider using `tracing.enabled` instead to disable sending of traces entirely. |
 | `tracing.test_mode.trace_flush`                        |                                                         | `Datadog::Tracing::TraceFlush`        | `nil`                        | Object that determines trace flushing behavior.                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                        |
 
 #### Custom logging
@@ -2637,15 +2636,12 @@ or `c.agent.port`.
 
 #### Transporting in Test Mode
 
-When test mode is enabled, the tracer uses a `Test` adapter for no-op transport that can optionally buffer requests in
-test suites or other non-production environments. It is configured by setting `c.tracing.test_mode.enabled` to true.
-This mode only works for tracing.
+The test mode can be used for testing distributed tracing behavior. Enabling this setting will mean every
+span will be sent (no sampling is applied) and the transport will send data synchronously.
+It is configured by setting `c.tracing.test_mode.enabled` to true.
 
-```ruby
-Datadog.configure do |c|
-  c.tracing.test_mode.enabled = true
-end
-```
+If you're looking to disable tracing while your test suite is running, consider using the `tracing.enabled` setting
+to disable sending of traces.
 
 ### Setting the time provider
 

--- a/docs/GettingStarted.md
+++ b/docs/GettingStarted.md
@@ -2066,8 +2066,6 @@ For example, if `tracing.sampling.default_rate` is configured by [Remote Configu
 | `tracing.sampling.span_rules`                          | `DD_SPAN_SAMPLING_RULES`,`ENV_SPAN_SAMPLING_RULES_FILE` | `String`                              | `nil`                        | Sets [Single Span Sampling](#single-span-sampling) rules. These rules allow you to keep spans even when their respective traces are dropped.                                                                                                                                                                                                                                                                                                                                                                                                                                                                                           |
 | `tracing.trace_id_128_bit_generation_enabled`          | `DD_TRACE_128_BIT_TRACEID_GENERATION_ENABLED`           | `Bool`                                | `true`                       | `true` to generate 128 bits trace ID and `false` to generate 64 bits trace ID                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                          |
 | `tracing.report_hostname`                              | `DD_TRACE_REPORT_HOSTNAME`                              | `Bool`                                | `false`                      | Adds hostname tag to traces.                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                           |
-| `tracing.test_mode.enabled`                            | `DD_TRACE_TEST_MODE_ENABLED`                            | `Bool`                                | `false`                      | Enables or disables "test mode", used for testing distributed tracing behavior. Note that traces will still be sent; consider using `tracing.enabled` instead to disable sending of traces entirely. |
-| `tracing.test_mode.trace_flush`                        |                                                         | `Datadog::Tracing::TraceFlush`        | `nil`                        | Object that determines trace flushing behavior.                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                        |
 
 #### Custom logging
 
@@ -2633,15 +2631,6 @@ DD_TRACE_AGENT_URL=unix:///tmp/ddagent/trace.sock
 
 Note: You cannot mix UDS and TCP configurations. If you set `c.agent.uds_path`, you must not set `c.agent.host`
 or `c.agent.port`.
-
-#### Transporting in Test Mode
-
-Use the test mode for testing distributed tracing behavior. Enabling this setting causes every
-span to be sent (no sampling is applied) and causes the transport to send data synchronously.
-To configure test mode, set `c.tracing.test_mode.enabled` to `true`.
-
-If you're looking to disable tracing while your test suite is running, consider using the `tracing.enabled` setting
-to disable sending of traces.
 
 ### Setting the time provider
 

--- a/docs/GettingStarted.md
+++ b/docs/GettingStarted.md
@@ -167,6 +167,24 @@ If your Agent runs on a different host or container than your application, or yo
 
 After setting up, your services will appear on the [APM services page](https://app.datadoghq.com/apm/services) within a few minutes. Learn more about [using the APM UI][visualization docs].
 
+### Disabling during testing/specs and test optimization for Ruby
+
+Tracing is enabled by default; this includes:
+
+* When loading using `datadog/auto_instrument`
+* When activating integrations using `tracing.instrument` in the `Datadog.configure` block
+* When calling the `Datadog::Tracing.trace` method
+
+If you'd like to disable tracing when running your tests/specs, you can set the `DD_TRACE_ENABLED` environment variable to `false` or via code:
+
+```ruby
+Datadog.configure do |c|
+  c.tracing.enabled = false
+end
+```
+
+Furthermore, if you're trying to get more visibility into your tests or you're struggling with slow or flaky test suites, consider looking at Datadog's [Test optimization](https://docs.datadoghq.com/tests/) via the [`datadog-ci`](https://github.com/DataDog/datadog-ci-rb?tab=readme-ov-file#datadog-test-optimization-for-ruby) gem.
+
 ## Manual Instrumentation
 
 If you aren't using a supported framework instrumentation, you may want to manually instrument your code.
@@ -294,10 +312,6 @@ end
 For a list of available integrations and their supported versions, see [Ruby Integration Compatibility][2].
 
 For a list of configuration options for the available integrations, refer to the following:
-
-#### CI Visibility
-
-Checkout [Datadog's Ruby Library for instrumenting your test and continuous integration pipeline](https://github.com/DataDog/datadog-ci-rb)
 
 ### Action Cable
 

--- a/docs/GettingStarted.md
+++ b/docs/GettingStarted.md
@@ -2636,9 +2636,9 @@ or `c.agent.port`.
 
 #### Transporting in Test Mode
 
-The test mode can be used for testing distributed tracing behavior. Enabling this setting will mean every
-span will be sent (no sampling is applied) and the transport will send data synchronously.
-It is configured by setting `c.tracing.test_mode.enabled` to true.
+Use the test mode for testing distributed tracing behavior. Enabling this setting causes every
+span to be sent (no sampling is applied) and causes the transport to send data synchronously.
+To configure test mode, set `c.tracing.test_mode.enabled` to `true`.
 
 If you're looking to disable tracing while your test suite is running, consider using the `tracing.enabled` setting
 to disable sending of traces.

--- a/lib/datadog/tracing/configuration/settings.rb
+++ b/lib/datadog/tracing/configuration/settings.rb
@@ -368,22 +368,18 @@ module Datadog
                 end
               end
 
-              # [Continuous Integration Visibility](https://docs.datadoghq.com/continuous_integration/) configuration.
+              # This is only for internal Datadog use via https://github.com/DataDog/datadog-ci-rb . It should not be
+              # used directly.
+              #
+              # DEV-3.0: Make this a non-public API in the next release.
               # @public_api
               settings :test_mode do
-                # Enable test mode. This allows the tracer to collect spans from test runs.
-                #
-                # It also prevents the tracer from collecting spans in a production environment. Only use in a test environment.
-                #
-                # @default `DD_TRACE_TEST_MODE_ENABLED` environment variable, otherwise `false`
-                # @return [Boolean]
                 option :enabled do |o|
                   o.type :bool
                   o.default false
                   o.env Tracing::Configuration::Ext::Test::ENV_MODE_ENABLED
                 end
 
-                # Use async writer in test mode
                 option :async do |o|
                   o.type :bool
                   o.default false


### PR DESCRIPTION
**What does this PR do?**

This PR updates our documentation to clarify what test mode does:

1. I've tweaked the wording to make it clear that this feature is used for testing distributed tracing behavior

2. I've explicitly mentioned that traces will still be sent; the previous version of the docs erroneously claimed a no-op transport would be applied, which is not true

3. I've left hints for folks that search for "test" while trying to disable dd-trace-rb in their test suites, that they should look at `tracing.enabled` instead

4. I've removed the bigger code examples for this feature, as it's a very niche thing that almost nobody will want to use, and having the code examples invites copy-paste of something that is probably not what the customer wants

**Motivation:**

The fact this doc is confusing came up in #4149 so it seemed relevant to fix our docs to avoid more confusion in the future.

**Change log entry**

(Not relevant to changelog)

**Additional Notes:**

N/A

**How to test the change?**

Docs-only change :)
