### PR TITLE
No requirement for benchmarks

### DIFF
--- a/.gitlab/benchmarks.yml
+++ b/.gitlab/benchmarks.yml
@@ -162,6 +162,7 @@ ddprof-benchmark:
 benchmarks:
   stage: benchmarks
   when: always
+  needs: []
   tags: ["runner:apm-k8s-tweaked-metal"]
   image: $BASE_CI_IMAGE
   interruptible: true


### PR DESCRIPTION
**Motivation:**
Our Gitlab pipeline is basically namespaced with stages.

However, this means the benchmark job requires previous stages to finish and runs last. The job itself took plenty of time (around 20 min) before it could add a PR comment.

However, those stages are not dependent on each other and should run in parallel 

**What does this PR do?**

Make the job without requirement. 

