### PR TITLE
[PROF-10987] Add Ruby GC guard to heap profiler as a preventative measure

### DIFF
--- a/ext/datadog_profiling_native_extension/heap_recorder.c
+++ b/ext/datadog_profiling_native_extension/heap_recorder.c
@@ -656,6 +656,10 @@ static int st_object_record_update(st_data_t key, st_data_t value, st_data_t ext
     record->object_data.is_frozen = RB_OBJ_FROZEN(ref);
   }
 
+  // Ensure that ref is kept on the stack so the Ruby garbage collector does not try to clean up the object before this
+  // point.
+  RB_GC_GUARD(ref);
+
   recorder->stats_last_update.objects_alive++;
   if (record->object_data.is_frozen) {
     recorder->stats_last_update.objects_frozen++;


### PR DESCRIPTION
**What does this PR do?**

This PR adds a `RUBY_GC_GUARD` call to the Ruby heap profiler, making sure that the object being pointed by the `ref` local variable does not get garbage collected too early.

**Motivation:**

This is a speculative fix:
We've seen a crash coming from calls to `ruby_obj_memsize_of` (line 654). Adding this `RUBY_GC_GUARD` is a very-low-cost "just in case" until we can fully get to the bottom of this crash, and even if it wasn't needed, it's very harmless to have.

**Change log entry**

(Internal change, not relevant for changelog)

**Additional Notes:**

N/A

**How to test the change?**

This is part of the challenge -- it's extremely hard to test this change, as in many compilers it may even turn out to be a no-op.

We'll need to wait for more info on the crash to go further than this change.
