### PR TITLE
DEBUG-2334 DI: use fixed description for telemetry report when probe fail…

### DIFF
--- a/lib/datadog/di/probe_manager.rb
+++ b/lib/datadog/di/probe_manager.rb
@@ -161,7 +161,7 @@ module Datadog
                 # Silence all exceptions?
                 # TODO should we propagate here and rescue upstream?
                 logger.warn("Error removing probe #{probe.id}: #{exc.class}: #{exc}")
-                telemetry&.report(exc, description: "Error removing probe #{probe.id}")
+                telemetry&.report(exc, description: "Error removing probe")
               end
             end
           end


### PR DESCRIPTION
…s to be removed

<!--
Check out the
https://github.com/DataDog/dd-trace-rb/blob/master/docs/DevelopmentGuide.md
for guidance on how to set up your development environment,
run the test suite, write new integrations, and more.
-->

**What does this PR do?**
<!-- A brief description of the change being made with this pull request. -->
Changes the one location in DI where the description being sent to telemetry contained variable interpolated input (probe id) to not contain the variable input.

**Motivation:**
Consistency check of dynamic instrumentation implementation.
<!-- What inspired you to submit this pull request? -->

**Change log entry**
None
<!-- If this is a customer-visible change, a brief summary to be placed
into the change log.
If you are not a Datadog employee, you can skip this section
and it will be filled or deleted during PR review. -->

**Additional Notes:**
<!-- Anything else we should know when reviewing? -->

**How to test the change?**
<!--
Describe here how the change can be validated.
You are strongly encouraged to provide automated tests for this PR (unit or integration).
If this change cannot be feasibly tested, please explain why,
unless the change does not modify code (e.g. only modifies docs, comments).
-->
I will be manually reviewing telemetry submissions by DI.

<!-- Unsure? Have a question? Request a review! -->
