### PR TITLE
Replace `ubuntu-latest` with pinned version

### DIFF
--- a/.github/workflows/add-milestone-to-pull-requests.yml
+++ b/.github/workflows/add-milestone-to-pull-requests.yml
@@ -9,7 +9,7 @@ jobs:
       contents: read
       issues: write
       pull-requests: write
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     if: github.event.pull_request.merged == true && github.event.pull_request.milestone == null
     steps:
       - name: Checkout code

--- a/.github/workflows/build-gem.yml
+++ b/.github/workflows/build-gem.yml
@@ -23,7 +23,7 @@ jobs:
         type:
           - final
           - dev
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     name: Build gem (${{ matrix.type }})
     steps:
       - name: Checkout
@@ -71,7 +71,7 @@ jobs:
         type:
           - final
           - dev
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     name: Test gem
     needs:
       - build
@@ -96,7 +96,7 @@ jobs:
       matrix:
         type:
           - dev
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     name: Push gem
     needs:
       - test

--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -4,7 +4,7 @@ on:
 
 jobs:
   lint:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     container:
       image: ghcr.io/datadog/images-rb/engines/ruby:3.2
     steps:
@@ -15,7 +15,7 @@ jobs:
 
   check:
     name: Check types
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     container:
       image: ghcr.io/datadog/images-rb/engines/ruby:3.2
     steps:

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -10,7 +10,7 @@ on:
 jobs:
   analyze:
     name: Analyze
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     permissions:
       actions: read
       contents: read

--- a/.github/workflows/datadog-sca.yml
+++ b/.github/workflows/datadog-sca.yml
@@ -4,7 +4,7 @@ name: Datadog Software Composition Analysis
 
 jobs:
   software-composition-analysis:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     name: Datadog SBOM Generation and Upload
     steps:
       - name: Checkout

--- a/.github/workflows/datadog-static-analysis.yml
+++ b/.github/workflows/datadog-static-analysis.yml
@@ -4,7 +4,7 @@ name: Datadog Static Analysis
 
 jobs:
   static-analysis:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     name: Datadog Static Analyzer
     steps:
       - name: Checkout

--- a/.github/workflows/lock-dependency.yml
+++ b/.github/workflows/lock-dependency.yml
@@ -25,7 +25,7 @@ concurrency:
 jobs:
   pr:
     name: Pull Request attached
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     outputs:
       pr_found: ${{ steps.pr.outputs.pr_found }}
       pr_base_ref: ${{ steps.pr.outputs.pr.base.ref }}
@@ -40,7 +40,7 @@ jobs:
     name: Depenedency changes
     needs: pr
     if: ${{ needs.pr.outputs.pr_found == 'true' }}
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     outputs:
       changes: ${{ steps.changes.outputs.dependencies }}
     steps:
@@ -57,7 +57,7 @@ jobs:
           filters: .github/dependency_filters.yml
 
   lock:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     needs: dependency
     if: ${{ needs.dependency.outputs.changes == 'true' }}
     strategy:
@@ -111,7 +111,7 @@ jobs:
   commit:
     name: Commit changes
     needs: lock
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     steps:
       - uses: actions/checkout@v4
         with:

--- a/.github/workflows/pull-request-labeler.yml
+++ b/.github/workflows/pull-request-labeler.yml
@@ -7,7 +7,7 @@ jobs:
     permissions:
       contents: read
       pull-requests: write
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     steps:
       - uses: actions/labeler@v5
         with:

--- a/.github/workflows/semgrep.yml
+++ b/.github/workflows/semgrep.yml
@@ -12,7 +12,7 @@ on:
 jobs:
   semgrep:
     name: semgrep/ci
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
 
     container:
       image: returntocorp/semgrep

--- a/.github/workflows/system-tests.yml
+++ b/.github/workflows/system-tests.yml
@@ -25,7 +25,7 @@ jobs:
             internal: system_tests/agent:latest
           - name: proxy
             internal: datadog/system-tests:proxy-v1
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     permissions:
       packages: write
     name: Build (${{ matrix.image.name }})
@@ -112,7 +112,7 @@ jobs:
           - rails72
           - rails80
           - graphql23
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     name: Build (${{ matrix.app }})
     permissions:
       packages: write
@@ -303,7 +303,7 @@ jobs:
           - library: ruby
             app: graphql23
             scenario: GRAPHQL_APPSEC
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     needs:
       - build-harness
       - build-apps
@@ -385,7 +385,7 @@ jobs:
           - rails72
           - rails80
           - graphql23
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     needs:
       - build-harness
       - build-apps
@@ -441,7 +441,7 @@ jobs:
           - weblog-rails72
           - weblog-rails80
           - weblog-graphql23
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     needs:
       - test
     if: ${{ always() }}
@@ -458,7 +458,7 @@ jobs:
         continue-on-error: true
 
   build-artifacts:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     permissions:
       packages: write
     steps:

--- a/.github/workflows/test-yjit.yaml
+++ b/.github/workflows/test-yjit.yaml
@@ -6,7 +6,7 @@ jobs:
       fail-fast: false
       matrix:
         os:
-          - ubuntu-latest
+          - ubuntu-22.04
         ruby:
           - '3.2'
           - '3.3'

--- a/.github/workflows/update-latest-dependency.yml
+++ b/.github/workflows/update-latest-dependency.yml
@@ -65,7 +65,7 @@ jobs:
 
   aggregate:
     needs: build
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     steps:
       - name: Checkout code
         uses: actions/checkout@v4

--- a/.github/workflows/yard.yml
+++ b/.github/workflows/yard.yml
@@ -24,7 +24,7 @@ jobs:
     environment:
       name: github-pages
       url: ${{ steps.deployment.outputs.page_url }}
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     container:
       image: ghcr.io/datadog/images-rb/engines/ruby:3.2
       env:


### PR DESCRIPTION
**Motivation:**

https://github.blog/changelog/2024-11-05-notice-of-breaking-changes-for-github-actions/#ubuntu-latest-upcoming-breaking-changes

>We will migrate the ubuntu-latest label to ubuntu 24 starting on December 5, 2024 and ending on January 17, 2025. The ubuntu 24 image has a different set of tools and packages than ubuntu 22. We have made cuts to the list of packages so that we can maintain our SLA for free disk space. This may break your workflows if you depend on certain packages that have been removed. Please review this [list](https://github.com/actions/runner-images/issues/10636) to see if you are using any affected packages.

**What does this PR do?**

Pin to ubuntu 22 instead of `latest`