### PR TITLE
DEBUG-2334 replace double() with instance_double() in DI test suite

### DIFF
--- a/spec/datadog/di/component_spec.rb
+++ b/spec/datadog/di/component_spec.rb
@@ -13,7 +13,7 @@ RSpec.describe Datadog::DI::Component do
     end
 
     let(:agent_settings) do
-      double('agent settings')
+      instance_double_agent_settings
     end
 
     context 'when dynamic instrumentation is enabled' do

--- a/spec/datadog/di/integration/everything_from_remote_config_spec.rb
+++ b/spec/datadog/di/integration/everything_from_remote_config_spec.rb
@@ -90,7 +90,7 @@ RSpec.describe 'DI integration from remote config' do
   end
 
   let(:agent_settings) do
-    double('agent settings').tap do |agent_settings|
+    instance_double_agent_settings.tap do |agent_settings|
       allow(agent_settings).to receive(:hostname)
       allow(agent_settings).to receive(:port)
       allow(agent_settings).to receive(:timeout_seconds).and_return(1)

--- a/spec/datadog/di/integration/instrumentation_spec.rb
+++ b/spec/datadog/di/integration/instrumentation_spec.rb
@@ -43,7 +43,7 @@ RSpec.describe 'Instrumentation integration' do
   end
 
   let(:agent_settings) do
-    double('agent settings')
+    instance_double_agent_settings
   end
 
   let(:component) do

--- a/spec/datadog/di/probe_notifier_worker_spec.rb
+++ b/spec/datadog/di/probe_notifier_worker_spec.rb
@@ -12,7 +12,7 @@ RSpec.describe Datadog::DI::ProbeNotifierWorker do
   end
 
   let(:transport) do
-    double('transport')
+    instance_double(Datadog::DI::Transport)
   end
 
   let(:logger) do

--- a/spec/datadog/di/remote_spec.rb
+++ b/spec/datadog/di/remote_spec.rb
@@ -115,11 +115,11 @@ RSpec.describe Datadog::DI::Remote do
       end
 
       let(:agent_settings) do
-        double('agent settings')
+        instance_double_agent_settings
       end
 
       let(:transport) do
-        double('transport')
+        instance_double(Datadog::DI::Transport)
       end
 
       let(:notifier_worker) do

--- a/spec/datadog/di/spec_helper.rb
+++ b/spec/datadog/di/spec_helper.rb
@@ -73,6 +73,10 @@ module DIHelpers
         hash
       end
     end
+
+    def instance_double_agent_settings
+      instance_double(Datadog::Core::Configuration::AgentSettingsResolver::AgentSettings)
+    end
   end
 end
 


### PR DESCRIPTION
<!--
Check out the
https://github.com/DataDog/dd-trace-rb/blob/master/docs/DevelopmentGuide.md
for guidance on how to set up your development environment,
run the test suite, write new integrations, and more.
-->

**What does this PR do?**
<!-- A brief description of the change being made with this pull request. -->
Replaces double(...) with instance_double(...) usage in DI test suite, except for (non-agent) settings which I don't think can be mocked this way since they use anonymous classes?

**Motivation:**
<!-- What inspired you to submit this pull request? -->
Feedback on earlier PRs

**Change log entry**
None
<!-- If this is a customer-visible change, a brief summary to be placed
into the change log.
If you are not a Datadog employee, you can skip this section
and it will be filled or deleted during PR review. -->

**Additional Notes:**
<!-- Anything else we should know when reviewing? -->

**How to test the change?**
Existing unit tests
<!--
Describe here how the change can be validated.
You are strongly encouraged to provide automated tests for this PR (unit or integration).
If this change cannot be feasibly tested, please explain why,
unless the change does not modify code (e.g. only modifies docs, comments).
-->

<!-- Unsure? Have a question? Request a review! -->
