### PR TITLE
Fix change log action condition to write warning

### DIFF
--- a/.github/workflows/ensure-changelog-entry.yml
+++ b/.github/workflows/ensure-changelog-entry.yml
@@ -57,13 +57,11 @@ jobs:
         with:
           github-token: ${{secrets.GITHUB_TOKEN}}
           script: |
-            const isMember = ${{steps.membership.outputs.result}}
             const regex = /\*\*Change log entry\*\*\s+(?:(?<answer_yes>yes|yep|yeah)(?:\.\s*(?<yes_message>[^\r\n<!-]+))?|(?<answer_no>no|nope|none)\.?)\s*/mi
             const entry = context.payload.pull_request.body.match(regex)
 
             const isWriteComment =
-              !isMember
-                || null === entry
+              null === entry
                 || (undefined === entry.groups.answer_yes && undefined === entry.groups.answer_no)
                 || (undefined !== entry.groups.answer_yes && undefined === entry.groups.yes_message)
                 || (undefined !== entry.groups.answer_yes && "" === entry.groups.yes_message.trim())


### PR DESCRIPTION
**What does this PR do?**

Fix condition (leftover after small refactoring) on when to write "Thank you" message on correct "Change log entry"

**Motivation:**

I've noticed that in this PR https://github.com/DataDog/dd-trace-rb/pull/4193 after a failed membership check action wasn't writing "Thank you" message when should. It turn out I have some leftovers in condition when to write a warning message.

**Change log entry**

No.

**Additional Notes:**

Good news - it works, bad news - it's impolite 🥸 

**How to test the change?**

Make your profile private, open PR with no "Change log entry", correct it and don't receive any "Thank you"