### PR TITLE
Update codeql scan

### DIFF
--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -29,7 +29,7 @@ jobs:
 
     # Initializes the CodeQL tools for scanning.
     - name: Initialize CodeQL
-      uses: github/codeql-action/init@v2
+      uses: github/codeql-action/init@v3
       with:
         languages: ${{ matrix.language }}
         # If you wish to specify custom queries, you can do so here or in a config file.
@@ -40,7 +40,7 @@ jobs:
     # Autobuild attempts to build any compiled languages  (C/C++, C#, or Java).
     # If this step fails, then you should remove it and run the build manually
     - name: Autobuild
-      uses: github/codeql-action/autobuild@v2
+      uses: github/codeql-action/autobuild@v3
 
     - name: Perform CodeQL Analysis
-      uses: github/codeql-action/analyze@v2
+      uses: github/codeql-action/analyze@v3


### PR DESCRIPTION
**What does this PR do?**

Update

**Motivation:**

https://github.blog/changelog/2024-01-12-code-scanning-deprecation-of-codeql-action-v2/

>On December 13, 2023, we released CodeQL Action v3, which runs on the Node.js 20 runtime. CodeQL Action v2 will be deprecated at the same time as GHES 3.11, which is currently scheduled for December 2024.

**Change log entry**
None.