### PR TITLE
DEBUG-2334 DI: method probes: pass block to target method when rate limited

### DIFF
--- a/lib/datadog/di/instrumenter.rb
+++ b/lib/datadog/di/instrumenter.rb
@@ -153,7 +153,25 @@ module Datadog
                 serialized_entry_args: entry_args)
               rv
             else
-              super(*args, **kwargs, &target_block)
+              # The necessity to invoke super in each of these specific
+              # ways is very difficult to test.
+              # Existing tests, even though I wrote many, still don't
+              # cause a failure if I replace all of the below with a
+              # simple super(*args, **kwargs, &target_block).
+              # But, let's be safe and go through the motions in case
+              # there is actually a legitimate need for the breakdown.
+              # TODO figure out how to test this properly.
+              if args.any?
+                if kwargs.any?
+                  super(*args, **kwargs, &target_block)
+                else
+                  super(*args, &target_block)
+                end
+              elsif kwargs.any?
+                super(**kwargs, &target_block)
+              else
+                super(&target_block)
+              end
             end
           end
         end

--- a/lib/datadog/di/instrumenter.rb
+++ b/lib/datadog/di/instrumenter.rb
@@ -117,6 +117,7 @@ module Datadog
               end
               rv = nil
               # Under Ruby 2.6 we cannot just call super(*args, **kwargs)
+              # for methods defined via method_missing.
               duration = Benchmark.realtime do # steep:ignore
                 rv = if args.any?
                   if kwargs.any?
@@ -152,7 +153,7 @@ module Datadog
                 serialized_entry_args: entry_args)
               rv
             else
-              super(*args, **kwargs)
+              super(*args, **kwargs, &target_block)
             end
           end
         end

--- a/lib/datadog/di/instrumenter.rb
+++ b/lib/datadog/di/instrumenter.rb
@@ -153,6 +153,9 @@ module Datadog
                 serialized_entry_args: entry_args)
               rv
             else
+              # stop standard from trying to mess up my code
+              _ = 42
+
               # The necessity to invoke super in each of these specific
               # ways is very difficult to test.
               # Existing tests, even though I wrote many, still don't

--- a/spec/datadog/di/hook_method.rb
+++ b/spec/datadog/di/hook_method.rb
@@ -27,6 +27,10 @@ class HookTestClass
     yield [[pos], kw: kw]
   end
 
+  def yielding_squashed(pos, options)
+    yield [[pos], options]
+  end
+
   def recursive(depth)
     if depth > 0
       recursive(depth - 1) + '-'

--- a/spec/datadog/di/hook_method.rb
+++ b/spec/datadog/di/hook_method.rb
@@ -53,6 +53,11 @@ class HookTestClass
 end
 
 class YieldingMethodMissingHookTestClass
+  # only here to stop standard complaints
+  def respond_to_missing?(name)
+    true
+  end
+
   def method_missing(name, *args, **kwargs)
     yield [args, kwargs]
     [args, kwargs]

--- a/spec/datadog/di/hook_method.rb
+++ b/spec/datadog/di/hook_method.rb
@@ -16,7 +16,15 @@ class HookTestClass
   end
 
   def yielding(arg)
-    yield arg
+    yield [[arg], {}]
+  end
+
+  def yielding_kw(arg:)
+    yield [[], arg: arg]
+  end
+
+  def yielding_both(pos, kw:)
+    yield [[pos], kw: kw]
   end
 
   def recursive(depth)
@@ -42,6 +50,7 @@ end
 
 class YieldingMethodMissingHookTestClass
   def method_missing(name, *args, **kwargs)
-    yield args.first
+    yield [args, kwargs]
+    [args, kwargs]
   end
 end

--- a/spec/datadog/di/hook_method.rb
+++ b/spec/datadog/di/hook_method.rb
@@ -39,3 +39,9 @@ class HookTestClass
     [arg, options]
   end
 end
+
+class YieldingMethodMissingHookTestClass
+  def method_missing(name, *args, **kwargs)
+    yield args.first
+  end
+end

--- a/spec/datadog/di/instrumenter_spec.rb
+++ b/spec/datadog/di/instrumenter_spec.rb
@@ -42,8 +42,10 @@ RSpec.describe Datadog::DI::Instrumenter do
   end
 
   let(:base_probe_args) do
-    {id: '1234', type: :log}
+    {id: '1234', type: :log, rate_limit: rate_limit}
   end
+
+  let(:rate_limit) { nil }
 
   let(:probe) do
     Datadog::DI::Probe.new(**base_probe_args.merge(probe_args))
@@ -100,6 +102,38 @@ RSpec.describe Datadog::DI::Instrumenter do
         expect(observed_calls.first[:rv]).to eq ['hello']
         expect(observed_calls.first[:duration]).to be_a(Float)
       end
+
+      context 'when rate limited' do
+        let(:rate_limit) { 0 }
+
+        it 'does not invoke callback but invokes target method with block' do
+          instrumenter.hook_method(probe) do |payload|
+            observed_calls << payload
+          end
+
+          yielded_value = nil
+          expect(HookTestClass.new.yielding('hello') do |value|
+            yielded_value = value
+            [value]
+          end).to eq ['hello']
+
+          expect(yielded_value).to eq('hello')
+
+          expect(observed_calls.length).to eq 0
+        end
+      end
+    end
+
+    shared_examples 'does not invoke callback but invokes target method' do
+      it 'does not invoke callback but invokes target method' do
+        instrumenter.hook_method(probe) do |payload|
+          observed_calls << payload
+        end
+
+        target_call
+
+        expect(observed_calls.length).to eq 0
+      end
     end
 
     context 'positional args' do
@@ -152,6 +186,12 @@ RSpec.describe Datadog::DI::Instrumenter do
 
         include_examples 'invokes callback and captures parameters'
 
+        context 'when rate limited' do
+          let(:rate_limit) { 0 }
+
+          include_examples 'does not invoke callback but invokes target method'
+        end
+
         context 'when passed via a splat' do
           let(:target_call) do
             args = [2]
@@ -159,6 +199,12 @@ RSpec.describe Datadog::DI::Instrumenter do
           end
 
           include_examples 'invokes callback and captures parameters'
+
+          context 'when rate limited' do
+            let(:rate_limit) { 0 }
+
+            include_examples 'does not invoke callback but invokes target method'
+          end
         end
       end
     end
@@ -193,6 +239,12 @@ RSpec.describe Datadog::DI::Instrumenter do
 
         include_examples 'invokes callback and captures parameters'
 
+        context 'when rate limited' do
+          let(:rate_limit) { 0 }
+
+          include_examples 'does not invoke callback but invokes target method'
+        end
+
         context 'when passed via a splat' do
           let(:target_call) do
             kwargs = {kwarg: 42}
@@ -200,6 +252,12 @@ RSpec.describe Datadog::DI::Instrumenter do
           end
 
           include_examples 'invokes callback and captures parameters'
+
+          context 'when rate limited' do
+            let(:rate_limit) { 0 }
+
+            include_examples 'does not invoke callback but invokes target method'
+          end
         end
       end
     end
@@ -239,6 +297,12 @@ RSpec.describe Datadog::DI::Instrumenter do
 
         include_examples 'invokes callback and captures parameters'
 
+        context 'when rate limited' do
+          let(:rate_limit) { 0 }
+
+          include_examples 'does not invoke callback but invokes target method'
+        end
+
         context 'when passed via a splat' do
           let(:target_call) do
             args = [41]
@@ -247,6 +311,12 @@ RSpec.describe Datadog::DI::Instrumenter do
           end
 
           include_examples 'invokes callback and captures parameters'
+
+          context 'when rate limited' do
+            let(:rate_limit) { 0 }
+
+            include_examples 'does not invoke callback but invokes target method'
+          end
         end
       end
     end
@@ -284,6 +354,12 @@ RSpec.describe Datadog::DI::Instrumenter do
         end
 
         include_examples 'invokes callback and captures parameters'
+
+        context 'when rate limited' do
+          let(:rate_limit) { 0 }
+
+          include_examples 'does not invoke callback but invokes target method'
+        end
       end
 
       context 'call with positional argument' do
@@ -293,6 +369,12 @@ RSpec.describe Datadog::DI::Instrumenter do
         end
 
         include_examples 'invokes callback and captures parameters'
+
+        context 'when rate limited' do
+          let(:rate_limit) { 0 }
+
+          include_examples 'does not invoke callback but invokes target method'
+        end
       end
 
       context 'when there is also a positional argument' do
@@ -327,6 +409,12 @@ RSpec.describe Datadog::DI::Instrumenter do
           end
 
           include_examples 'invokes callback and captures parameters'
+
+          context 'when rate limited' do
+            let(:rate_limit) { 0 }
+
+            include_examples 'does not invoke callback but invokes target method'
+          end
         end
 
         context 'call with a splat' do
@@ -336,6 +424,12 @@ RSpec.describe Datadog::DI::Instrumenter do
           end
 
           include_examples 'invokes callback and captures parameters'
+
+          context 'when rate limited' do
+            let(:rate_limit) { 0 }
+
+            include_examples 'does not invoke callback but invokes target method'
+          end
         end
       end
     end

--- a/spec/datadog/di/instrumenter_spec.rb
+++ b/spec/datadog/di/instrumenter_spec.rb
@@ -80,7 +80,6 @@ RSpec.describe Datadog::DI::Instrumenter do
     end
 
     context 'when target method yields to a block' do
-
       shared_examples 'yields to the block' do
         context 'when method takes a positional argument' do
           let(:probe_args) do


### PR DESCRIPTION
<!--
Check out the
https://github.com/DataDog/dd-trace-rb/blob/master/docs/DevelopmentGuide.md
for guidance on how to set up your development environment,
run the test suite, write new integrations, and more.
-->

**What does this PR do?**
<!-- A brief description of the change being made with this pull request. -->
Fixes a bug in dynamic instrumentation where once a method was instrumented with a method probe and the rate limit for the probe was reached, the block would not be passed to target method from DI.

**Motivation:**
<!-- What inspired you to submit this pull request? -->
Code inspection when implementing snapshot benchmarks (https://github.com/DataDog/dd-trace-rb/pull/4207).

**Change log entry**
<!-- If this is a customer-visible change, a brief summary to be placed
into the change log.
If you are not a Datadog employee, you can skip this section
and it will be filled or deleted during PR review. -->

No.

**Additional Notes:**
<!-- Anything else we should know when reviewing? -->
*Reason: while this issue would have affected customer applications, DI has not yet been shipped.*

I added many tests but could not yet reproduce the scenario where the separated calls to `super` were necessary as they are in the non-rate limited path. I added the separated calls in case they are indeed required.

**How to test the change?**
<!--
Describe here how the change can be validated.
You are strongly encouraged to provide automated tests for this PR (unit or integration).
If this change cannot be feasibly tested, please explain why,
unless the change does not modify code (e.g. only modifies docs, comments).
-->
Unit tests are included.
<!-- Unsure? Have a question? Request a review! -->
