### PR TITLE
DEBUG-3175 DI snapshot/rate limit benchmark

### DIFF
--- a/benchmarks/di_snapshot.rb
+++ b/benchmarks/di_snapshot.rb
@@ -39,7 +39,8 @@ require 'datadog'
 require 'webrick'
 
 class DISnapshotBenchmark
-  BASIC_RATE_LIMIT = 5000
+  # If we are validating the benchmark a single operation is sufficient.
+  BASIC_RATE_LIMIT = VALIDATE_BENCHMARK_MODE ? 1 : 5000
   ENRICHED_RATE_LIMIT = 1
 
   def initialize
@@ -60,6 +61,14 @@ class DISnapshotBenchmark
     end
 
     Thread.new do
+      # If there is an actual Datadog agent running locally, the server
+      # used in this benchmark will fail to start.
+      # Using an actual Datadog agent instead of the fake server should not
+      # affect the indication of whether the rate limit is reachable
+      # since the agent shouldn't take longer to process than the fake
+      # web server (and the agent should also run on another core),
+      # however using a real agent would forego reports of the number of
+      # snapshots submitted and their size.
       server.start
     end
 

--- a/benchmarks/di_snapshot.rb
+++ b/benchmarks/di_snapshot.rb
@@ -38,6 +38,7 @@ class DISnapshotBenchmark
       c.remote.enabled = true
       c.dynamic_instrumentation.enabled = true
       c.dynamic_instrumentation.internal.development = true
+      c.dynamic_instrumentation.internal.snapshot_queue_capacity = 10000
     end
 
     Thread.new do

--- a/benchmarks/support/di_snapshot_target.rb
+++ b/benchmarks/support/di_snapshot_target.rb
@@ -2,7 +2,7 @@ class DISnapshotTarget
   def test_method
     # Perform some work to take up time
     SecureRandom.uuid
-    
+
     v1 = Datadog.configuration
     v2 = Datadog.configuration
     v3 = Datadog.configuration

--- a/benchmarks/support/di_snapshot_target.rb
+++ b/benchmarks/support/di_snapshot_target.rb
@@ -1,0 +1,22 @@
+class DISnapshotTarget
+  def test_method
+    # Perform some work to take up time
+    SecureRandom.uuid
+    
+    v1 = Datadog.configuration
+    v2 = Datadog.configuration
+    v3 = Datadog.configuration
+    v4 = Datadog.configuration
+    v5 = Datadog.configuration
+    v6 = Datadog.configuration
+    v7 = Datadog.configuration
+    v8 = Datadog.configuration
+    v9 = Datadog.configuration
+
+    # Currently Ruby DI does not implement capture of local variables
+    # in method probes, or instance variables.
+    # Return a complex object which will be serialized for the
+    # enriched probe.
+    Datadog.configuration # Line 20
+  end
+end

--- a/lib/datadog/di/configuration/settings.rb
+++ b/lib/datadog/di/configuration/settings.rb
@@ -166,7 +166,7 @@ module Datadog
                 # being sent out by the probe notifier worker) and creates a
                 # possibility of dropping payloads if the queue gets too long.
                 option :min_send_interval do |o|
-                  o.type :int
+                  o.type :float
                   o.default 3
                 end
 

--- a/lib/datadog/di/configuration/settings.rb
+++ b/lib/datadog/di/configuration/settings.rb
@@ -170,6 +170,16 @@ module Datadog
                   o.default 3
                 end
 
+                # Number of snapshots that can be stored in the probe
+                # notifier worker queue. Larger capacity runs the risk of
+                # creating snapshots that exceed the agent's request size
+                # limit. Smaller capacity increases the risk of dropping
+                # snapshots.
+                option :snapshot_queue_capacity do |o|
+                  o.type :int
+                  o.default 100
+                end
+
                 # Enable dynamic instrumentation in development environments.
                 # Currently DI does not fully implement support for code
                 # unloading and reloading, and is not supported in

--- a/lib/datadog/di/probe_notifier_worker.rb
+++ b/lib/datadog/di/probe_notifier_worker.rb
@@ -183,8 +183,7 @@ module Datadog
         define_method("add_#{event_type}") do |event|
           @lock.synchronize do
             queue = send("#{event_type}_queue")
-            # TODO determine a suitable limit via testing/benchmarking
-            if queue.length > 10000
+            if queue.length > settings.dynamic_instrumentation.internal.snapshot_queue_capacity
               logger.warn("#{self.class.name}: dropping #{event_type} because queue is full")
             else
               queue << event

--- a/lib/datadog/di/probe_notifier_worker.rb
+++ b/lib/datadog/di/probe_notifier_worker.rb
@@ -184,7 +184,7 @@ module Datadog
           @lock.synchronize do
             queue = send("#{event_type}_queue")
             # TODO determine a suitable limit via testing/benchmarking
-            if queue.length > 100
+            if queue.length > 10000
               logger.warn("#{self.class.name}: dropping #{event_type} because queue is full")
             else
               queue << event

--- a/spec/datadog/di/probe_notifier_worker_spec.rb
+++ b/spec/datadog/di/probe_notifier_worker_spec.rb
@@ -9,6 +9,7 @@ RSpec.describe Datadog::DI::ProbeNotifierWorker do
     allow(settings.dynamic_instrumentation.internal).to receive(:propagate_all_exceptions).and_return(false)
     # Reduce to 1 to have the test run faster
     allow(settings.dynamic_instrumentation.internal).to receive(:min_send_interval).and_return(1)
+    allow(settings.dynamic_instrumentation.internal).to receive(:snapshot_queue_capacity).and_return(10)
   end
 
   let(:transport) do

--- a/spec/datadog/di/validate_benchmarks_spec.rb
+++ b/spec/datadog/di/validate_benchmarks_spec.rb
@@ -20,15 +20,19 @@ RSpec.describe "Dynamic instrumentation benchmarks", :memcheck_valgrind_skip do
       else
         10
       end
-      it("runs without raising errors") do
-        expect_in_fork(timeout_seconds: timeout) { load "./benchmarks/#{benchmark}.rb" }
+      it "runs without raising errors" do
+        expect_in_fork(timeout_seconds: timeout) do
+          load "./benchmarks/#{benchmark}.rb"
+        end
       end
     end
   end
 
   # This test validates that we don't forget to add new benchmarks to benchmarks_to_validate
   it "tests all expected benchmarks in the benchmarks folder" do
-    all_benchmarks = Dir["./benchmarks/di_*"].map { |it| it.gsub("./benchmarks/", "").gsub(".rb", "") }
+    all_benchmarks = Dir["./benchmarks/di_*"].map do |it|
+      it.gsub("./benchmarks/", "").gsub(".rb", "")
+    end
 
     expect(benchmarks_to_validate).to contain_exactly(*all_benchmarks)
   end

--- a/spec/datadog/di/validate_benchmarks_spec.rb
+++ b/spec/datadog/di/validate_benchmarks_spec.rb
@@ -15,7 +15,14 @@ RSpec.describe "Dynamic instrumentation benchmarks", :memcheck_valgrind_skip do
 
   benchmarks_to_validate.each do |benchmark|
     describe benchmark do
-      it("runs without raising errors") { expect_in_fork { load "./benchmarks/#{benchmark}.rb" } }
+      timeout = if benchmark == 'di_snapshot'
+        20
+      else
+        10
+      end
+      it("runs without raising errors") do
+        expect_in_fork(timeout_seconds: timeout) { load "./benchmarks/#{benchmark}.rb" }
+      end
     end
   end
 

--- a/spec/datadog/di/validate_benchmarks_spec.rb
+++ b/spec/datadog/di/validate_benchmarks_spec.rb
@@ -10,7 +10,7 @@ RSpec.describe "Dynamic instrumentation benchmarks", :memcheck_valgrind_skip do
   end
 
   benchmarks_to_validate = [
-    "di_instrument",
+    "di_instrument", "di_snapshot",
   ].freeze
 
   benchmarks_to_validate.each do |benchmark|


### PR DESCRIPTION
<!--
Check out the
https://github.com/DataDog/dd-trace-rb/blob/master/docs/DevelopmentGuide.md
for guidance on how to set up your development environment,
run the test suite, write new integrations, and more.
-->

**What does this PR do?**
<!-- A brief description of the change being made with this pull request. -->
Adds dynamic instrumentation benchmarks verifying that the rate at which probes can capture, serialize and submit snapshots to the agent are below the rate limits.

It also makes the probe notifier worker queue capacity configurable via an internal setting. With default DI settings, DI will permit no more than 30 snapshots/second on average across all probes which is well short of the 5000/second/probe that this benchmark is aiming to achieve. The benchmark raises the limit (and makes flushes more frequent) to demonstrate theoretical performance of DI implementation, however more work is needed to permit higher limits by default - flushing logic must be carefully written to not starve the application of CPU. The default limits are very conservative in this regard.

**Motivation:**
<!-- What inspired you to submit this pull request? -->
We want to ensure that the rate limits we set are achievable, meaning they are not set so high that DI code can starve customer applications of CPU and still not hit rate limits.

**Change log entry**
<!-- If this is a customer-visible change, a brief summary to be placed
into the change log.
If you are not a Datadog employee, you can skip this section
and it will be filled or deleted during PR review. -->
None.

**Additional Notes:**
<!-- Anything else we should know when reviewing? -->
The benchmarks perform as many invocations of target methods as each probe type would permit (5000/second for basic probes, 1/second for enriched probes). A rate of greater than  1 instruction/second in the benchmark means the rate limit was not reached by the test code and thus DI performance is within expectations.

**How to test the change?**
<!--
Describe here how the change can be validated.
You are strongly encouraged to provide automated tests for this PR (unit or integration).
If this change cannot be feasibly tested, please explain why,
unless the change does not modify code (e.g. only modifies docs, comments).
-->
N/A

<!-- Unsure? Have a question? Request a review! -->
