### PR TITLE
DEBUG-3176 DI: report an error when instrumenting a loaded file that is not in registry

### DIFF
--- a/lib/datadog/di/error.rb
+++ b/lib/datadog/di/error.rb
@@ -27,6 +27,11 @@ module Datadog
       class DITargetNotDefined < Error
       end
 
+      # Attempting to instrument a line and the file containing the line
+      # was loaded prior to code tracking being enabled.
+      class DITargetNotInRegistry < Error
+      end
+
       # Raised when trying to install a probe whose installation failed
       # earlier in the same process. This exception should contain the
       # original exception report from initial installation attempt.

--- a/lib/datadog/di/instrumenter.rb
+++ b/lib/datadog/di/instrumenter.rb
@@ -224,11 +224,12 @@ module Datadog
               #
               # If the requested file is not in code tracker's registry,
               # or the code tracker does not exist at all,
-              # do not attempt to instrumnet now.
+              # do not attempt to instrument now.
               # The caller should add the line to the list of pending lines
               # to instrument and install the hook when the file in
               # question is loaded (and hopefully, by then code tracking
               # is active, otherwise the line will never be instrumented.)
+              raise_if_probe_in_loaded_features(probe)
               raise Error::DITargetNotDefined, "File not in code tracker registry: #{probe.file}"
             end
           end
@@ -236,6 +237,7 @@ module Datadog
           # Same as previous comment, if untargeted trace points are not
           # explicitly defined, and we do not have code tracking, do not
           # instrument the method.
+          raise_if_probe_in_loaded_features(probe)
           raise Error::DITargetNotDefined, "File not in code tracker registry: #{probe.file}"
         end
 
@@ -351,6 +353,26 @@ module Datadog
       private
 
       attr_reader :lock
+
+      def raise_if_probe_in_loaded_features(probe)
+        return unless probe.file
+
+        # If the probe file is in the list of loaded files
+        # (as per $LOADED_FEATURES, using either exact or suffix match),
+        # raise an error indicating that
+        # code tracker is missing the loaded file because the file
+        # won't be loaded again (DI only works in production environments
+        # that do not normally reload code).
+        if $LOADED_FEATURES.include?(probe.file)
+          raise Error::DITargetNotInRegistry, "File loaded but is not in code tracker registry: #{probe.file}"
+        end
+        # Ths is an expensive check
+        $LOADED_FEATURES.each do |path|
+          if Utils.path_matches_suffix?(path, probe.file)
+            raise Error::DITargetNotInRegistry, "File matching probe path (#{probe.file}) was loaded and is not in code tracker registry: #{path}"
+          end
+        end
+      end
 
       # TODO test that this resolves qualified names e.g. A::B
       def symbolize_class_name(cls_name)

--- a/sig/datadog/di/error.rbs
+++ b/sig/datadog/di/error.rbs
@@ -7,6 +7,8 @@ module Datadog
       end
       class DITargetNotDefined < Error
       end
+      class DITargetNotInRegistry < Error
+      end
       class ProbePreviouslyFailed < Error
       end
       class MultiplePathsMatch < Error

--- a/sig/datadog/di/instrumenter.rbs
+++ b/sig/datadog/di/instrumenter.rbs
@@ -48,6 +48,7 @@ module Datadog
 
       attr_reader lock: untyped
       def symbolize_class_name: (untyped cls_name) -> untyped
+      def raise_if_probe_in_loaded_features: (Probe probe) -> void
     end
   end
 end

--- a/spec/datadog/di/instrumenter_spec.rb
+++ b/spec/datadog/di/instrumenter_spec.rb
@@ -742,6 +742,20 @@ RSpec.describe Datadog::DI::Instrumenter do
         expect(observed_calls.length).to eq 1
         expect(observed_calls.first).to be_a(Hash)
       end
+
+      context 'when instrumenting a line in loaded but not tracked file' do
+        let(:probe) do
+          Datadog::DI::Probe.new(file: 'hook_line.rb', line_no: 3,
+            id: 1, type: :log)
+        end
+
+        it 'raises DITargetNotInRegistry' do
+          expect do
+            instrumenter.hook_line(probe) do |payload|
+            end
+          end.to raise_error(Datadog::DI::Error::DITargetNotInRegistry, /File matching probe path.*was loaded and is not in code tracker registry/)
+        end
+      end
     end
 
     context 'when method is recursive' do


### PR DESCRIPTION
<!--
Check out the
https://github.com/DataDog/dd-trace-rb/blob/master/docs/DevelopmentGuide.md
for guidance on how to set up your development environment,
run the test suite, write new integrations, and more.
-->

**What does this PR do?**
<!-- A brief description of the change being made with this pull request. -->
Ruby stores the list of loaded files in $LOADED_FEATURES. Use this list to detect line probes that attempt to instrument files that have been loaded prior to code tracking being active, and report error to the user when instrumenting those files (since they won’t ever be instrumented in production).

**Motivation:**
<!-- What inspired you to submit this pull request? -->
Better diagnostics for DI.

**Change log entry**
<!-- If this is a customer-visible change, a brief summary to be placed
into the change log.
If you are not a Datadog employee, you can skip this section
and it will be filled or deleted during PR review. -->
Report instrumentation error in dynamic instrumentation when attempting to instrument line probes and the target file is loaded but not in code tracker registry.

**Additional Notes:**
<!-- Anything else we should know when reviewing? -->
The check can be expensive because it performs path suffix matching for potentially thousands of file paths corresponding to the loaded files.

**How to test the change?**
<!--
Describe here how the change can be validated.
You are strongly encouraged to provide automated tests for this PR (unit or integration).
If this change cannot be feasibly tested, please explain why,
unless the change does not modify code (e.g. only modifies docs, comments).
-->
Unit tests are included

<!-- Unsure? Have a question? Request a review! -->
