### PR TITLE
Clean Ruby 3.4 Gemfile

### DIFF
--- a/gemfiles/ruby_3.4_activesupport.gemfile
+++ b/gemfiles/ruby_3.4_activesupport.gemfile
@@ -2,13 +2,18 @@
 
 source "https://rubygems.org"
 
+gem "base64"
 gem "benchmark-ips", "~> 2.8"
 gem "benchmark-memory", "< 0.2"
+gem "bigdecimal"
 gem "climate_control", "~> 0.2.0"
 gem "concurrent-ruby"
+gem "dogstatsd-ruby", ">= 3.3.0", "!= 5.0.0", "!= 5.0.1", "!= 5.1.0"
 gem "extlz4", "~> 0.3", ">= 0.3.3"
+gem "google-protobuf", ["~> 3.0", "!= 3.7.0", "!= 3.7.1"]
 gem "json-schema", "< 3"
 gem "memory_profiler", "~> 0.9"
+gem "mutex_m"
 gem "os", "~> 1.1"
 gem "pimpmychangelog", ">= 0.1.2"
 gem "pry"
@@ -19,21 +24,16 @@ gem "rspec", "~> 3.13"
 gem "rspec-collection_matchers", "~> 1.1"
 gem "rspec-wait", "~> 0"
 gem "rspec_junit_formatter", ">= 0.5.1"
-gem "simplecov", git: "https://github.com/DataDog/simplecov", ref: "3bb6b7ee58bf4b1954ca205f50dd44d6f41c57db"
-gem "simplecov-cobertura", "~> 2.1.0"
-gem "warning", "~> 1"
-gem "webmock", ">= 3.10.0"
-gem "webrick", ">= 1.8.2"
 gem "rubocop", "~> 1.50.0", require: false
 gem "rubocop-packaging", "~> 0.5.2", require: false
 gem "rubocop-performance", "~> 1.9", require: false
 gem "rubocop-rspec", ["~> 2.20", "< 2.21"], require: false
-gem "dogstatsd-ruby", ">= 3.3.0", "!= 5.0.0", "!= 5.0.1", "!= 5.1.0"
-gem "google-protobuf", ["~> 3.0", "!= 3.7.0", "!= 3.7.1"]
+gem "simplecov", git: "https://github.com/DataDog/simplecov", ref: "3bb6b7ee58bf4b1954ca205f50dd44d6f41c57db"
+gem "simplecov-cobertura", "~> 2.1.0"
 gem "strscan", git: "https://github.com/ruby/strscan", ref: "041b15df4ccc067deabd85fd489b2c15961d0e2f"
-gem "base64"
-gem "bigdecimal"
-gem "mutex_m"
+gem "warning", "~> 1"
+gem "webmock", ">= 3.10.0"
+gem "webrick", ">= 1.8.2"
 gem "activesupport", "~> 7"
 gem "actionpack"
 gem "actionview"

--- a/gemfiles/ruby_3.4_aws.gemfile
+++ b/gemfiles/ruby_3.4_aws.gemfile
@@ -2,13 +2,18 @@
 
 source "https://rubygems.org"
 
+gem "base64"
 gem "benchmark-ips", "~> 2.8"
 gem "benchmark-memory", "< 0.2"
+gem "bigdecimal"
 gem "climate_control", "~> 0.2.0"
 gem "concurrent-ruby"
+gem "dogstatsd-ruby", ">= 3.3.0", "!= 5.0.0", "!= 5.0.1", "!= 5.1.0"
 gem "extlz4", "~> 0.3", ">= 0.3.3"
+gem "google-protobuf", ["~> 3.0", "!= 3.7.0", "!= 3.7.1"]
 gem "json-schema", "< 3"
 gem "memory_profiler", "~> 0.9"
+gem "mutex_m"
 gem "os", "~> 1.1"
 gem "pimpmychangelog", ">= 0.1.2"
 gem "pry"
@@ -19,21 +24,16 @@ gem "rspec", "~> 3.13"
 gem "rspec-collection_matchers", "~> 1.1"
 gem "rspec-wait", "~> 0"
 gem "rspec_junit_formatter", ">= 0.5.1"
-gem "simplecov", git: "https://github.com/DataDog/simplecov", ref: "3bb6b7ee58bf4b1954ca205f50dd44d6f41c57db"
-gem "simplecov-cobertura", "~> 2.1.0"
-gem "warning", "~> 1"
-gem "webmock", ">= 3.10.0"
-gem "webrick", ">= 1.8.2"
 gem "rubocop", "~> 1.50.0", require: false
 gem "rubocop-packaging", "~> 0.5.2", require: false
 gem "rubocop-performance", "~> 1.9", require: false
 gem "rubocop-rspec", ["~> 2.20", "< 2.21"], require: false
-gem "dogstatsd-ruby", ">= 3.3.0", "!= 5.0.0", "!= 5.0.1", "!= 5.1.0"
-gem "google-protobuf", ["~> 3.0", "!= 3.7.0", "!= 3.7.1"]
+gem "simplecov", git: "https://github.com/DataDog/simplecov", ref: "3bb6b7ee58bf4b1954ca205f50dd44d6f41c57db"
+gem "simplecov-cobertura", "~> 2.1.0"
 gem "strscan", git: "https://github.com/ruby/strscan", ref: "041b15df4ccc067deabd85fd489b2c15961d0e2f"
-gem "base64"
-gem "bigdecimal"
-gem "mutex_m"
+gem "warning", "~> 1"
+gem "webmock", ">= 3.10.0"
+gem "webrick", ">= 1.8.2"
 gem "aws-sdk"
 gem "shoryuken"
 

--- a/gemfiles/ruby_3.4_contrib.gemfile
+++ b/gemfiles/ruby_3.4_contrib.gemfile
@@ -2,13 +2,18 @@
 
 source "https://rubygems.org"
 
+gem "base64"
 gem "benchmark-ips", "~> 2.8"
 gem "benchmark-memory", "< 0.2"
+gem "bigdecimal"
 gem "climate_control", "~> 0.2.0"
 gem "concurrent-ruby"
+gem "dogstatsd-ruby", ">= 3.3.0", "!= 5.0.0", "!= 5.0.1", "!= 5.1.0"
 gem "extlz4", "~> 0.3", ">= 0.3.3"
+gem "google-protobuf", ["~> 3.0", "!= 3.7.0", "!= 3.7.1"]
 gem "json-schema", "< 3"
 gem "memory_profiler", "~> 0.9"
+gem "mutex_m"
 gem "os", "~> 1.1"
 gem "pimpmychangelog", ">= 0.1.2"
 gem "pry"
@@ -19,21 +24,16 @@ gem "rspec", "~> 3.13"
 gem "rspec-collection_matchers", "~> 1.1"
 gem "rspec-wait", "~> 0"
 gem "rspec_junit_formatter", ">= 0.5.1"
-gem "simplecov", git: "https://github.com/DataDog/simplecov", ref: "3bb6b7ee58bf4b1954ca205f50dd44d6f41c57db"
-gem "simplecov-cobertura", "~> 2.1.0"
-gem "warning", "~> 1"
-gem "webmock", ">= 3.10.0"
-gem "webrick", ">= 1.8.2"
 gem "rubocop", "~> 1.50.0", require: false
 gem "rubocop-packaging", "~> 0.5.2", require: false
 gem "rubocop-performance", "~> 1.9", require: false
 gem "rubocop-rspec", ["~> 2.20", "< 2.21"], require: false
-gem "dogstatsd-ruby", ">= 3.3.0", "!= 5.0.0", "!= 5.0.1", "!= 5.1.0"
-gem "google-protobuf", ["~> 3.0", "!= 3.7.0", "!= 3.7.1"]
+gem "simplecov", git: "https://github.com/DataDog/simplecov", ref: "3bb6b7ee58bf4b1954ca205f50dd44d6f41c57db"
+gem "simplecov-cobertura", "~> 2.1.0"
 gem "strscan", git: "https://github.com/ruby/strscan", ref: "041b15df4ccc067deabd85fd489b2c15961d0e2f"
-gem "base64"
-gem "bigdecimal"
-gem "mutex_m"
+gem "warning", "~> 1"
+gem "webmock", ">= 3.10.0"
+gem "webrick", ">= 1.8.2"
 gem "dalli", ">= 3.0.0"
 gem "grpc", ">= 1.38.0", platform: :ruby
 gem "mongo", ">= 2.8.0", "< 2.15.0"

--- a/gemfiles/ruby_3.4_contrib_old.gemfile
+++ b/gemfiles/ruby_3.4_contrib_old.gemfile
@@ -2,13 +2,18 @@
 
 source "https://rubygems.org"
 
+gem "base64"
 gem "benchmark-ips", "~> 2.8"
 gem "benchmark-memory", "< 0.2"
+gem "bigdecimal"
 gem "climate_control", "~> 0.2.0"
 gem "concurrent-ruby"
+gem "dogstatsd-ruby", ">= 3.3.0", "!= 5.0.0", "!= 5.0.1", "!= 5.1.0"
 gem "extlz4", "~> 0.3", ">= 0.3.3"
+gem "google-protobuf", ["~> 3.0", "!= 3.7.0", "!= 3.7.1"]
 gem "json-schema", "< 3"
 gem "memory_profiler", "~> 0.9"
+gem "mutex_m"
 gem "os", "~> 1.1"
 gem "pimpmychangelog", ">= 0.1.2"
 gem "pry"
@@ -19,21 +24,16 @@ gem "rspec", "~> 3.13"
 gem "rspec-collection_matchers", "~> 1.1"
 gem "rspec-wait", "~> 0"
 gem "rspec_junit_formatter", ">= 0.5.1"
-gem "simplecov", git: "https://github.com/DataDog/simplecov", ref: "3bb6b7ee58bf4b1954ca205f50dd44d6f41c57db"
-gem "simplecov-cobertura", "~> 2.1.0"
-gem "warning", "~> 1"
-gem "webmock", ">= 3.10.0"
-gem "webrick", ">= 1.8.2"
 gem "rubocop", "~> 1.50.0", require: false
 gem "rubocop-packaging", "~> 0.5.2", require: false
 gem "rubocop-performance", "~> 1.9", require: false
 gem "rubocop-rspec", ["~> 2.20", "< 2.21"], require: false
-gem "dogstatsd-ruby", ">= 3.3.0", "!= 5.0.0", "!= 5.0.1", "!= 5.1.0"
-gem "google-protobuf", ["~> 3.0", "!= 3.7.0", "!= 3.7.1"]
+gem "simplecov", git: "https://github.com/DataDog/simplecov", ref: "3bb6b7ee58bf4b1954ca205f50dd44d6f41c57db"
+gem "simplecov-cobertura", "~> 2.1.0"
 gem "strscan", git: "https://github.com/ruby/strscan", ref: "041b15df4ccc067deabd85fd489b2c15961d0e2f"
-gem "base64"
-gem "bigdecimal"
-gem "mutex_m"
+gem "warning", "~> 1"
+gem "webmock", ">= 3.10.0"
+gem "webrick", ">= 1.8.2"
 gem "dalli", "< 3.0.0"
 gem "presto-client", ">= 0.5.14"
 gem "qless", "0.12.0"

--- a/gemfiles/ruby_3.4_core_old.gemfile
+++ b/gemfiles/ruby_3.4_core_old.gemfile
@@ -2,13 +2,18 @@
 
 source "https://rubygems.org"
 
+gem "base64"
 gem "benchmark-ips", "~> 2.8"
 gem "benchmark-memory", "< 0.2"
+gem "bigdecimal"
 gem "climate_control", "~> 0.2.0"
 gem "concurrent-ruby"
+gem "dogstatsd-ruby", "~> 4"
 gem "extlz4", "~> 0.3", ">= 0.3.3"
+gem "google-protobuf", ["~> 3.0", "!= 3.7.0", "!= 3.7.1"]
 gem "json-schema", "< 3"
 gem "memory_profiler", "~> 0.9"
+gem "mutex_m"
 gem "os", "~> 1.1"
 gem "pimpmychangelog", ">= 0.1.2"
 gem "pry"
@@ -19,21 +24,16 @@ gem "rspec", "~> 3.13"
 gem "rspec-collection_matchers", "~> 1.1"
 gem "rspec-wait", "~> 0"
 gem "rspec_junit_formatter", ">= 0.5.1"
-gem "simplecov", git: "https://github.com/DataDog/simplecov", ref: "3bb6b7ee58bf4b1954ca205f50dd44d6f41c57db"
-gem "simplecov-cobertura", "~> 2.1.0"
-gem "warning", "~> 1"
-gem "webmock", ">= 3.10.0"
-gem "webrick", ">= 1.8.2"
 gem "rubocop", "~> 1.50.0", require: false
 gem "rubocop-packaging", "~> 0.5.2", require: false
 gem "rubocop-performance", "~> 1.9", require: false
 gem "rubocop-rspec", ["~> 2.20", "< 2.21"], require: false
-gem "dogstatsd-ruby", "~> 4"
-gem "google-protobuf", ["~> 3.0", "!= 3.7.0", "!= 3.7.1"]
+gem "simplecov", git: "https://github.com/DataDog/simplecov", ref: "3bb6b7ee58bf4b1954ca205f50dd44d6f41c57db"
+gem "simplecov-cobertura", "~> 2.1.0"
 gem "strscan", git: "https://github.com/ruby/strscan", ref: "041b15df4ccc067deabd85fd489b2c15961d0e2f"
-gem "base64"
-gem "bigdecimal"
-gem "mutex_m"
+gem "warning", "~> 1"
+gem "webmock", ">= 3.10.0"
+gem "webrick", ">= 1.8.2"
 
 group :check do
 

--- a/gemfiles/ruby_3.4_elasticsearch_7.gemfile
+++ b/gemfiles/ruby_3.4_elasticsearch_7.gemfile
@@ -2,13 +2,18 @@
 
 source "https://rubygems.org"
 
+gem "base64"
 gem "benchmark-ips", "~> 2.8"
 gem "benchmark-memory", "< 0.2"
+gem "bigdecimal"
 gem "climate_control", "~> 0.2.0"
 gem "concurrent-ruby"
+gem "dogstatsd-ruby", ">= 3.3.0", "!= 5.0.0", "!= 5.0.1", "!= 5.1.0"
 gem "extlz4", "~> 0.3", ">= 0.3.3"
+gem "google-protobuf", ["~> 3.0", "!= 3.7.0", "!= 3.7.1"]
 gem "json-schema", "< 3"
 gem "memory_profiler", "~> 0.9"
+gem "mutex_m"
 gem "os", "~> 1.1"
 gem "pimpmychangelog", ">= 0.1.2"
 gem "pry"
@@ -19,21 +24,16 @@ gem "rspec", "~> 3.13"
 gem "rspec-collection_matchers", "~> 1.1"
 gem "rspec-wait", "~> 0"
 gem "rspec_junit_formatter", ">= 0.5.1"
-gem "simplecov", git: "https://github.com/DataDog/simplecov", ref: "3bb6b7ee58bf4b1954ca205f50dd44d6f41c57db"
-gem "simplecov-cobertura", "~> 2.1.0"
-gem "warning", "~> 1"
-gem "webmock", ">= 3.10.0"
-gem "webrick", ">= 1.8.2"
 gem "rubocop", "~> 1.50.0", require: false
 gem "rubocop-packaging", "~> 0.5.2", require: false
 gem "rubocop-performance", "~> 1.9", require: false
 gem "rubocop-rspec", ["~> 2.20", "< 2.21"], require: false
-gem "dogstatsd-ruby", ">= 3.3.0", "!= 5.0.0", "!= 5.0.1", "!= 5.1.0"
-gem "google-protobuf", ["~> 3.0", "!= 3.7.0", "!= 3.7.1"]
+gem "simplecov", git: "https://github.com/DataDog/simplecov", ref: "3bb6b7ee58bf4b1954ca205f50dd44d6f41c57db"
+gem "simplecov-cobertura", "~> 2.1.0"
 gem "strscan", git: "https://github.com/ruby/strscan", ref: "041b15df4ccc067deabd85fd489b2c15961d0e2f"
-gem "base64"
-gem "bigdecimal"
-gem "mutex_m"
+gem "warning", "~> 1"
+gem "webmock", ">= 3.10.0"
+gem "webrick", ">= 1.8.2"
 gem "elasticsearch", "~> 7"
 
 group :check do

--- a/gemfiles/ruby_3.4_elasticsearch_8.gemfile
+++ b/gemfiles/ruby_3.4_elasticsearch_8.gemfile
@@ -2,13 +2,18 @@
 
 source "https://rubygems.org"
 
+gem "base64"
 gem "benchmark-ips", "~> 2.8"
 gem "benchmark-memory", "< 0.2"
+gem "bigdecimal"
 gem "climate_control", "~> 0.2.0"
 gem "concurrent-ruby"
+gem "dogstatsd-ruby", ">= 3.3.0", "!= 5.0.0", "!= 5.0.1", "!= 5.1.0"
 gem "extlz4", "~> 0.3", ">= 0.3.3"
+gem "google-protobuf", ["~> 3.0", "!= 3.7.0", "!= 3.7.1"]
 gem "json-schema", "< 3"
 gem "memory_profiler", "~> 0.9"
+gem "mutex_m"
 gem "os", "~> 1.1"
 gem "pimpmychangelog", ">= 0.1.2"
 gem "pry"
@@ -19,21 +24,16 @@ gem "rspec", "~> 3.13"
 gem "rspec-collection_matchers", "~> 1.1"
 gem "rspec-wait", "~> 0"
 gem "rspec_junit_formatter", ">= 0.5.1"
-gem "simplecov", git: "https://github.com/DataDog/simplecov", ref: "3bb6b7ee58bf4b1954ca205f50dd44d6f41c57db"
-gem "simplecov-cobertura", "~> 2.1.0"
-gem "warning", "~> 1"
-gem "webmock", ">= 3.10.0"
-gem "webrick", ">= 1.8.2"
 gem "rubocop", "~> 1.50.0", require: false
 gem "rubocop-packaging", "~> 0.5.2", require: false
 gem "rubocop-performance", "~> 1.9", require: false
 gem "rubocop-rspec", ["~> 2.20", "< 2.21"], require: false
-gem "dogstatsd-ruby", ">= 3.3.0", "!= 5.0.0", "!= 5.0.1", "!= 5.1.0"
-gem "google-protobuf", ["~> 3.0", "!= 3.7.0", "!= 3.7.1"]
+gem "simplecov", git: "https://github.com/DataDog/simplecov", ref: "3bb6b7ee58bf4b1954ca205f50dd44d6f41c57db"
+gem "simplecov-cobertura", "~> 2.1.0"
 gem "strscan", git: "https://github.com/ruby/strscan", ref: "041b15df4ccc067deabd85fd489b2c15961d0e2f"
-gem "base64"
-gem "bigdecimal"
-gem "mutex_m"
+gem "warning", "~> 1"
+gem "webmock", ">= 3.10.0"
+gem "webrick", ">= 1.8.2"
 gem "elasticsearch", "~> 8"
 
 group :check do

--- a/gemfiles/ruby_3.4_elasticsearch_latest.gemfile
+++ b/gemfiles/ruby_3.4_elasticsearch_latest.gemfile
@@ -2,13 +2,18 @@
 
 source "https://rubygems.org"
 
+gem "base64"
 gem "benchmark-ips", "~> 2.8"
 gem "benchmark-memory", "< 0.2"
+gem "bigdecimal"
 gem "climate_control", "~> 0.2.0"
 gem "concurrent-ruby"
+gem "dogstatsd-ruby", ">= 3.3.0", "!= 5.0.0", "!= 5.0.1", "!= 5.1.0"
 gem "extlz4", "~> 0.3", ">= 0.3.3"
+gem "google-protobuf", ["~> 3.0", "!= 3.7.0", "!= 3.7.1"]
 gem "json-schema", "< 3"
 gem "memory_profiler", "~> 0.9"
+gem "mutex_m"
 gem "os", "~> 1.1"
 gem "pimpmychangelog", ">= 0.1.2"
 gem "pry"
@@ -19,21 +24,16 @@ gem "rspec", "~> 3.13"
 gem "rspec-collection_matchers", "~> 1.1"
 gem "rspec-wait", "~> 0"
 gem "rspec_junit_formatter", ">= 0.5.1"
-gem "simplecov", git: "https://github.com/DataDog/simplecov", ref: "3bb6b7ee58bf4b1954ca205f50dd44d6f41c57db"
-gem "simplecov-cobertura", "~> 2.1.0"
-gem "warning", "~> 1"
-gem "webmock", ">= 3.10.0"
-gem "webrick", ">= 1.8.2"
 gem "rubocop", "~> 1.50.0", require: false
 gem "rubocop-packaging", "~> 0.5.2", require: false
 gem "rubocop-performance", "~> 1.9", require: false
 gem "rubocop-rspec", ["~> 2.20", "< 2.21"], require: false
-gem "dogstatsd-ruby", ">= 3.3.0", "!= 5.0.0", "!= 5.0.1", "!= 5.1.0"
-gem "google-protobuf", ["~> 3.0", "!= 3.7.0", "!= 3.7.1"]
+gem "simplecov", git: "https://github.com/DataDog/simplecov", ref: "3bb6b7ee58bf4b1954ca205f50dd44d6f41c57db"
+gem "simplecov-cobertura", "~> 2.1.0"
 gem "strscan", git: "https://github.com/ruby/strscan", ref: "041b15df4ccc067deabd85fd489b2c15961d0e2f"
-gem "base64"
-gem "bigdecimal"
-gem "mutex_m"
+gem "warning", "~> 1"
+gem "webmock", ">= 3.10.0"
+gem "webrick", ">= 1.8.2"
 gem "elasticsearch"
 
 group :check do

--- a/gemfiles/ruby_3.4_graphql_1.13.gemfile
+++ b/gemfiles/ruby_3.4_graphql_1.13.gemfile
@@ -2,13 +2,18 @@
 
 source "https://rubygems.org"
 
+gem "base64"
 gem "benchmark-ips", "~> 2.8"
 gem "benchmark-memory", "< 0.2"
+gem "bigdecimal"
 gem "climate_control", "~> 0.2.0"
 gem "concurrent-ruby"
+gem "dogstatsd-ruby", ">= 3.3.0", "!= 5.0.0", "!= 5.0.1", "!= 5.1.0"
 gem "extlz4", "~> 0.3", ">= 0.3.3"
+gem "google-protobuf", ["~> 3.0", "!= 3.7.0", "!= 3.7.1"]
 gem "json-schema", "< 3"
 gem "memory_profiler", "~> 0.9"
+gem "mutex_m", ">= 0.1.0"
 gem "os", "~> 1.1"
 gem "pimpmychangelog", ">= 0.1.2"
 gem "pry"
@@ -19,21 +24,16 @@ gem "rspec", "~> 3.13"
 gem "rspec-collection_matchers", "~> 1.1"
 gem "rspec-wait", "~> 0"
 gem "rspec_junit_formatter", ">= 0.5.1"
-gem "simplecov", git: "https://github.com/DataDog/simplecov", ref: "3bb6b7ee58bf4b1954ca205f50dd44d6f41c57db"
-gem "simplecov-cobertura", "~> 2.1.0"
-gem "warning", "~> 1"
-gem "webmock", ">= 3.10.0"
-gem "webrick", ">= 1.8.2"
 gem "rubocop", "~> 1.50.0", require: false
 gem "rubocop-packaging", "~> 0.5.2", require: false
 gem "rubocop-performance", "~> 1.9", require: false
 gem "rubocop-rspec", ["~> 2.20", "< 2.21"], require: false
-gem "dogstatsd-ruby", ">= 3.3.0", "!= 5.0.0", "!= 5.0.1", "!= 5.1.0"
-gem "google-protobuf", ["~> 3.0", "!= 3.7.0", "!= 3.7.1"]
+gem "simplecov", git: "https://github.com/DataDog/simplecov", ref: "3bb6b7ee58bf4b1954ca205f50dd44d6f41c57db"
+gem "simplecov-cobertura", "~> 2.1.0"
 gem "strscan", git: "https://github.com/ruby/strscan", ref: "041b15df4ccc067deabd85fd489b2c15961d0e2f"
-gem "base64"
-gem "bigdecimal"
-gem "mutex_m", ">= 0.1.0"
+gem "warning", "~> 1"
+gem "webmock", ">= 3.10.0"
+gem "webrick", ">= 1.8.2"
 gem "rails", "~> 6.1.0"
 gem "graphql", "~> 1.13.0"
 gem "sprockets", "< 4"

--- a/gemfiles/ruby_3.4_graphql_2.0.gemfile
+++ b/gemfiles/ruby_3.4_graphql_2.0.gemfile
@@ -2,13 +2,18 @@
 
 source "https://rubygems.org"
 
+gem "base64"
 gem "benchmark-ips", "~> 2.8"
 gem "benchmark-memory", "< 0.2"
+gem "bigdecimal"
 gem "climate_control", "~> 0.2.0"
 gem "concurrent-ruby"
+gem "dogstatsd-ruby", ">= 3.3.0", "!= 5.0.0", "!= 5.0.1", "!= 5.1.0"
 gem "extlz4", "~> 0.3", ">= 0.3.3"
+gem "google-protobuf", ["~> 3.0", "!= 3.7.0", "!= 3.7.1"]
 gem "json-schema", "< 3"
 gem "memory_profiler", "~> 0.9"
+gem "mutex_m", ">= 0.1.0"
 gem "os", "~> 1.1"
 gem "pimpmychangelog", ">= 0.1.2"
 gem "pry"
@@ -19,21 +24,16 @@ gem "rspec", "~> 3.13"
 gem "rspec-collection_matchers", "~> 1.1"
 gem "rspec-wait", "~> 0"
 gem "rspec_junit_formatter", ">= 0.5.1"
-gem "simplecov", git: "https://github.com/DataDog/simplecov", ref: "3bb6b7ee58bf4b1954ca205f50dd44d6f41c57db"
-gem "simplecov-cobertura", "~> 2.1.0"
-gem "warning", "~> 1"
-gem "webmock", ">= 3.10.0"
-gem "webrick", ">= 1.8.2"
 gem "rubocop", "~> 1.50.0", require: false
 gem "rubocop-packaging", "~> 0.5.2", require: false
 gem "rubocop-performance", "~> 1.9", require: false
 gem "rubocop-rspec", ["~> 2.20", "< 2.21"], require: false
-gem "dogstatsd-ruby", ">= 3.3.0", "!= 5.0.0", "!= 5.0.1", "!= 5.1.0"
-gem "google-protobuf", ["~> 3.0", "!= 3.7.0", "!= 3.7.1"]
+gem "simplecov", git: "https://github.com/DataDog/simplecov", ref: "3bb6b7ee58bf4b1954ca205f50dd44d6f41c57db"
+gem "simplecov-cobertura", "~> 2.1.0"
 gem "strscan", git: "https://github.com/ruby/strscan", ref: "041b15df4ccc067deabd85fd489b2c15961d0e2f"
-gem "base64"
-gem "bigdecimal"
-gem "mutex_m", ">= 0.1.0"
+gem "warning", "~> 1"
+gem "webmock", ">= 3.10.0"
+gem "webrick", ">= 1.8.2"
 gem "rails", "~> 6.1.0"
 gem "graphql", "~> 2.0.0"
 gem "sprockets", "< 4"

--- a/gemfiles/ruby_3.4_graphql_2.1.gemfile
+++ b/gemfiles/ruby_3.4_graphql_2.1.gemfile
@@ -2,13 +2,18 @@
 
 source "https://rubygems.org"
 
+gem "base64"
 gem "benchmark-ips", "~> 2.8"
 gem "benchmark-memory", "< 0.2"
+gem "bigdecimal"
 gem "climate_control", "~> 0.2.0"
 gem "concurrent-ruby"
+gem "dogstatsd-ruby", ">= 3.3.0", "!= 5.0.0", "!= 5.0.1", "!= 5.1.0"
 gem "extlz4", "~> 0.3", ">= 0.3.3"
+gem "google-protobuf", ["~> 3.0", "!= 3.7.0", "!= 3.7.1"]
 gem "json-schema", "< 3"
 gem "memory_profiler", "~> 0.9"
+gem "mutex_m", ">= 0.1.0"
 gem "os", "~> 1.1"
 gem "pimpmychangelog", ">= 0.1.2"
 gem "pry"
@@ -19,21 +24,16 @@ gem "rspec", "~> 3.13"
 gem "rspec-collection_matchers", "~> 1.1"
 gem "rspec-wait", "~> 0"
 gem "rspec_junit_formatter", ">= 0.5.1"
-gem "simplecov", git: "https://github.com/DataDog/simplecov", ref: "3bb6b7ee58bf4b1954ca205f50dd44d6f41c57db"
-gem "simplecov-cobertura", "~> 2.1.0"
-gem "warning", "~> 1"
-gem "webmock", ">= 3.10.0"
-gem "webrick", ">= 1.8.2"
 gem "rubocop", "~> 1.50.0", require: false
 gem "rubocop-packaging", "~> 0.5.2", require: false
 gem "rubocop-performance", "~> 1.9", require: false
 gem "rubocop-rspec", ["~> 2.20", "< 2.21"], require: false
-gem "dogstatsd-ruby", ">= 3.3.0", "!= 5.0.0", "!= 5.0.1", "!= 5.1.0"
-gem "google-protobuf", ["~> 3.0", "!= 3.7.0", "!= 3.7.1"]
+gem "simplecov", git: "https://github.com/DataDog/simplecov", ref: "3bb6b7ee58bf4b1954ca205f50dd44d6f41c57db"
+gem "simplecov-cobertura", "~> 2.1.0"
 gem "strscan", git: "https://github.com/ruby/strscan", ref: "041b15df4ccc067deabd85fd489b2c15961d0e2f"
-gem "base64"
-gem "bigdecimal"
-gem "mutex_m", ">= 0.1.0"
+gem "warning", "~> 1"
+gem "webmock", ">= 3.10.0"
+gem "webrick", ">= 1.8.2"
 gem "rails", "~> 6.1.0"
 gem "graphql", "~> 2.1.0"
 gem "sprockets", "< 4"

--- a/gemfiles/ruby_3.4_graphql_2.2.gemfile
+++ b/gemfiles/ruby_3.4_graphql_2.2.gemfile
@@ -2,13 +2,18 @@
 
 source "https://rubygems.org"
 
+gem "base64"
 gem "benchmark-ips", "~> 2.8"
 gem "benchmark-memory", "< 0.2"
+gem "bigdecimal"
 gem "climate_control", "~> 0.2.0"
 gem "concurrent-ruby"
+gem "dogstatsd-ruby", ">= 3.3.0", "!= 5.0.0", "!= 5.0.1", "!= 5.1.0"
 gem "extlz4", "~> 0.3", ">= 0.3.3"
+gem "google-protobuf", ["~> 3.0", "!= 3.7.0", "!= 3.7.1"]
 gem "json-schema", "< 3"
 gem "memory_profiler", "~> 0.9"
+gem "mutex_m", ">= 0.1.0"
 gem "os", "~> 1.1"
 gem "pimpmychangelog", ">= 0.1.2"
 gem "pry"
@@ -19,21 +24,16 @@ gem "rspec", "~> 3.13"
 gem "rspec-collection_matchers", "~> 1.1"
 gem "rspec-wait", "~> 0"
 gem "rspec_junit_formatter", ">= 0.5.1"
-gem "simplecov", git: "https://github.com/DataDog/simplecov", ref: "3bb6b7ee58bf4b1954ca205f50dd44d6f41c57db"
-gem "simplecov-cobertura", "~> 2.1.0"
-gem "warning", "~> 1"
-gem "webmock", ">= 3.10.0"
-gem "webrick", ">= 1.8.2"
 gem "rubocop", "~> 1.50.0", require: false
 gem "rubocop-packaging", "~> 0.5.2", require: false
 gem "rubocop-performance", "~> 1.9", require: false
 gem "rubocop-rspec", ["~> 2.20", "< 2.21"], require: false
-gem "dogstatsd-ruby", ">= 3.3.0", "!= 5.0.0", "!= 5.0.1", "!= 5.1.0"
-gem "google-protobuf", ["~> 3.0", "!= 3.7.0", "!= 3.7.1"]
+gem "simplecov", git: "https://github.com/DataDog/simplecov", ref: "3bb6b7ee58bf4b1954ca205f50dd44d6f41c57db"
+gem "simplecov-cobertura", "~> 2.1.0"
 gem "strscan", git: "https://github.com/ruby/strscan", ref: "041b15df4ccc067deabd85fd489b2c15961d0e2f"
-gem "base64"
-gem "bigdecimal"
-gem "mutex_m", ">= 0.1.0"
+gem "warning", "~> 1"
+gem "webmock", ">= 3.10.0"
+gem "webrick", ">= 1.8.2"
 gem "rails", "~> 6.1.0"
 gem "graphql", "~> 2.2.0"
 gem "sprockets", "< 4"

--- a/gemfiles/ruby_3.4_graphql_2.3.gemfile
+++ b/gemfiles/ruby_3.4_graphql_2.3.gemfile
@@ -2,13 +2,18 @@
 
 source "https://rubygems.org"
 
+gem "base64"
 gem "benchmark-ips", "~> 2.8"
 gem "benchmark-memory", "< 0.2"
+gem "bigdecimal"
 gem "climate_control", "~> 0.2.0"
 gem "concurrent-ruby"
+gem "dogstatsd-ruby", ">= 3.3.0", "!= 5.0.0", "!= 5.0.1", "!= 5.1.0"
 gem "extlz4", "~> 0.3", ">= 0.3.3"
+gem "google-protobuf", ["~> 3.0", "!= 3.7.0", "!= 3.7.1"]
 gem "json-schema", "< 3"
 gem "memory_profiler", "~> 0.9"
+gem "mutex_m", ">= 0.1.0"
 gem "os", "~> 1.1"
 gem "pimpmychangelog", ">= 0.1.2"
 gem "pry"
@@ -19,21 +24,16 @@ gem "rspec", "~> 3.13"
 gem "rspec-collection_matchers", "~> 1.1"
 gem "rspec-wait", "~> 0"
 gem "rspec_junit_formatter", ">= 0.5.1"
-gem "simplecov", git: "https://github.com/DataDog/simplecov", ref: "3bb6b7ee58bf4b1954ca205f50dd44d6f41c57db"
-gem "simplecov-cobertura", "~> 2.1.0"
-gem "warning", "~> 1"
-gem "webmock", ">= 3.10.0"
-gem "webrick", ">= 1.8.2"
 gem "rubocop", "~> 1.50.0", require: false
 gem "rubocop-packaging", "~> 0.5.2", require: false
 gem "rubocop-performance", "~> 1.9", require: false
 gem "rubocop-rspec", ["~> 2.20", "< 2.21"], require: false
-gem "dogstatsd-ruby", ">= 3.3.0", "!= 5.0.0", "!= 5.0.1", "!= 5.1.0"
-gem "google-protobuf", ["~> 3.0", "!= 3.7.0", "!= 3.7.1"]
+gem "simplecov", git: "https://github.com/DataDog/simplecov", ref: "3bb6b7ee58bf4b1954ca205f50dd44d6f41c57db"
+gem "simplecov-cobertura", "~> 2.1.0"
 gem "strscan", git: "https://github.com/ruby/strscan", ref: "041b15df4ccc067deabd85fd489b2c15961d0e2f"
-gem "base64"
-gem "bigdecimal"
-gem "mutex_m", ">= 0.1.0"
+gem "warning", "~> 1"
+gem "webmock", ">= 3.10.0"
+gem "webrick", ">= 1.8.2"
 gem "rails", "~> 6.1.0"
 gem "graphql", "~> 2.3.0"
 gem "sprockets", "< 4"

--- a/gemfiles/ruby_3.4_http.gemfile
+++ b/gemfiles/ruby_3.4_http.gemfile
@@ -2,13 +2,18 @@
 
 source "https://rubygems.org"
 
+gem "base64"
 gem "benchmark-ips", "~> 2.8"
 gem "benchmark-memory", "< 0.2"
+gem "bigdecimal"
 gem "climate_control", "~> 0.2.0"
 gem "concurrent-ruby"
+gem "dogstatsd-ruby", ">= 3.3.0", "!= 5.0.0", "!= 5.0.1", "!= 5.1.0"
 gem "extlz4", "~> 0.3", ">= 0.3.3"
+gem "google-protobuf", ["~> 3.0", "!= 3.7.0", "!= 3.7.1"]
 gem "json-schema", "< 3"
 gem "memory_profiler", "~> 0.9"
+gem "mutex_m"
 gem "os", "~> 1.1"
 gem "pimpmychangelog", ">= 0.1.2"
 gem "pry"
@@ -19,21 +24,16 @@ gem "rspec", "~> 3.13"
 gem "rspec-collection_matchers", "~> 1.1"
 gem "rspec-wait", "~> 0"
 gem "rspec_junit_formatter", ">= 0.5.1"
-gem "simplecov", git: "https://github.com/DataDog/simplecov", ref: "3bb6b7ee58bf4b1954ca205f50dd44d6f41c57db"
-gem "simplecov-cobertura", "~> 2.1.0"
-gem "warning", "~> 1"
-gem "webmock", ">= 3.10.0"
-gem "webrick", ">= 1.8.2"
 gem "rubocop", "~> 1.50.0", require: false
 gem "rubocop-packaging", "~> 0.5.2", require: false
 gem "rubocop-performance", "~> 1.9", require: false
 gem "rubocop-rspec", ["~> 2.20", "< 2.21"], require: false
-gem "dogstatsd-ruby", ">= 3.3.0", "!= 5.0.0", "!= 5.0.1", "!= 5.1.0"
-gem "google-protobuf", ["~> 3.0", "!= 3.7.0", "!= 3.7.1"]
+gem "simplecov", git: "https://github.com/DataDog/simplecov", ref: "3bb6b7ee58bf4b1954ca205f50dd44d6f41c57db"
+gem "simplecov-cobertura", "~> 2.1.0"
 gem "strscan", git: "https://github.com/ruby/strscan", ref: "041b15df4ccc067deabd85fd489b2c15961d0e2f"
-gem "base64"
-gem "bigdecimal"
-gem "mutex_m"
+gem "warning", "~> 1"
+gem "webmock", ">= 3.10.0"
+gem "webrick", ">= 1.8.2"
 gem "ethon"
 gem "excon"
 gem "faraday"

--- a/gemfiles/ruby_3.4_opensearch_2.gemfile
+++ b/gemfiles/ruby_3.4_opensearch_2.gemfile
@@ -2,13 +2,18 @@
 
 source "https://rubygems.org"
 
+gem "base64"
 gem "benchmark-ips", "~> 2.8"
 gem "benchmark-memory", "< 0.2"
+gem "bigdecimal"
 gem "climate_control", "~> 0.2.0"
 gem "concurrent-ruby"
+gem "dogstatsd-ruby", ">= 3.3.0", "!= 5.0.0", "!= 5.0.1", "!= 5.1.0"
 gem "extlz4", "~> 0.3", ">= 0.3.3"
+gem "google-protobuf", ["~> 3.0", "!= 3.7.0", "!= 3.7.1"]
 gem "json-schema", "< 3"
 gem "memory_profiler", "~> 0.9"
+gem "mutex_m"
 gem "os", "~> 1.1"
 gem "pimpmychangelog", ">= 0.1.2"
 gem "pry"
@@ -19,21 +24,16 @@ gem "rspec", "~> 3.13"
 gem "rspec-collection_matchers", "~> 1.1"
 gem "rspec-wait", "~> 0"
 gem "rspec_junit_formatter", ">= 0.5.1"
-gem "simplecov", git: "https://github.com/DataDog/simplecov", ref: "3bb6b7ee58bf4b1954ca205f50dd44d6f41c57db"
-gem "simplecov-cobertura", "~> 2.1.0"
-gem "warning", "~> 1"
-gem "webmock", ">= 3.10.0"
-gem "webrick", ">= 1.8.2"
 gem "rubocop", "~> 1.50.0", require: false
 gem "rubocop-packaging", "~> 0.5.2", require: false
 gem "rubocop-performance", "~> 1.9", require: false
 gem "rubocop-rspec", ["~> 2.20", "< 2.21"], require: false
-gem "dogstatsd-ruby", ">= 3.3.0", "!= 5.0.0", "!= 5.0.1", "!= 5.1.0"
-gem "google-protobuf", ["~> 3.0", "!= 3.7.0", "!= 3.7.1"]
+gem "simplecov", git: "https://github.com/DataDog/simplecov", ref: "3bb6b7ee58bf4b1954ca205f50dd44d6f41c57db"
+gem "simplecov-cobertura", "~> 2.1.0"
 gem "strscan", git: "https://github.com/ruby/strscan", ref: "041b15df4ccc067deabd85fd489b2c15961d0e2f"
-gem "base64"
-gem "bigdecimal"
-gem "mutex_m"
+gem "warning", "~> 1"
+gem "webmock", ">= 3.10.0"
+gem "webrick", ">= 1.8.2"
 gem "opensearch-ruby", "~> 2"
 
 group :check do

--- a/gemfiles/ruby_3.4_opensearch_3.gemfile
+++ b/gemfiles/ruby_3.4_opensearch_3.gemfile
@@ -2,13 +2,18 @@
 
 source "https://rubygems.org"
 
+gem "base64"
 gem "benchmark-ips", "~> 2.8"
 gem "benchmark-memory", "< 0.2"
+gem "bigdecimal"
 gem "climate_control", "~> 0.2.0"
 gem "concurrent-ruby"
+gem "dogstatsd-ruby", ">= 3.3.0", "!= 5.0.0", "!= 5.0.1", "!= 5.1.0"
 gem "extlz4", "~> 0.3", ">= 0.3.3"
+gem "google-protobuf", ["~> 3.0", "!= 3.7.0", "!= 3.7.1"]
 gem "json-schema", "< 3"
 gem "memory_profiler", "~> 0.9"
+gem "mutex_m"
 gem "os", "~> 1.1"
 gem "pimpmychangelog", ">= 0.1.2"
 gem "pry"
@@ -19,21 +24,16 @@ gem "rspec", "~> 3.13"
 gem "rspec-collection_matchers", "~> 1.1"
 gem "rspec-wait", "~> 0"
 gem "rspec_junit_formatter", ">= 0.5.1"
-gem "simplecov", git: "https://github.com/DataDog/simplecov", ref: "3bb6b7ee58bf4b1954ca205f50dd44d6f41c57db"
-gem "simplecov-cobertura", "~> 2.1.0"
-gem "warning", "~> 1"
-gem "webmock", ">= 3.10.0"
-gem "webrick", ">= 1.8.2"
 gem "rubocop", "~> 1.50.0", require: false
 gem "rubocop-packaging", "~> 0.5.2", require: false
 gem "rubocop-performance", "~> 1.9", require: false
 gem "rubocop-rspec", ["~> 2.20", "< 2.21"], require: false
-gem "dogstatsd-ruby", ">= 3.3.0", "!= 5.0.0", "!= 5.0.1", "!= 5.1.0"
-gem "google-protobuf", ["~> 3.0", "!= 3.7.0", "!= 3.7.1"]
+gem "simplecov", git: "https://github.com/DataDog/simplecov", ref: "3bb6b7ee58bf4b1954ca205f50dd44d6f41c57db"
+gem "simplecov-cobertura", "~> 2.1.0"
 gem "strscan", git: "https://github.com/ruby/strscan", ref: "041b15df4ccc067deabd85fd489b2c15961d0e2f"
-gem "base64"
-gem "bigdecimal"
-gem "mutex_m"
+gem "warning", "~> 1"
+gem "webmock", ">= 3.10.0"
+gem "webrick", ">= 1.8.2"
 gem "opensearch-ruby", "~> 3"
 
 group :check do

--- a/gemfiles/ruby_3.4_opensearch_latest.gemfile
+++ b/gemfiles/ruby_3.4_opensearch_latest.gemfile
@@ -2,13 +2,18 @@
 
 source "https://rubygems.org"
 
+gem "base64"
 gem "benchmark-ips", "~> 2.8"
 gem "benchmark-memory", "< 0.2"
+gem "bigdecimal"
 gem "climate_control", "~> 0.2.0"
 gem "concurrent-ruby"
+gem "dogstatsd-ruby", ">= 3.3.0", "!= 5.0.0", "!= 5.0.1", "!= 5.1.0"
 gem "extlz4", "~> 0.3", ">= 0.3.3"
+gem "google-protobuf", ["~> 3.0", "!= 3.7.0", "!= 3.7.1"]
 gem "json-schema", "< 3"
 gem "memory_profiler", "~> 0.9"
+gem "mutex_m"
 gem "os", "~> 1.1"
 gem "pimpmychangelog", ">= 0.1.2"
 gem "pry"
@@ -19,21 +24,16 @@ gem "rspec", "~> 3.13"
 gem "rspec-collection_matchers", "~> 1.1"
 gem "rspec-wait", "~> 0"
 gem "rspec_junit_formatter", ">= 0.5.1"
-gem "simplecov", git: "https://github.com/DataDog/simplecov", ref: "3bb6b7ee58bf4b1954ca205f50dd44d6f41c57db"
-gem "simplecov-cobertura", "~> 2.1.0"
-gem "warning", "~> 1"
-gem "webmock", ">= 3.10.0"
-gem "webrick", ">= 1.8.2"
 gem "rubocop", "~> 1.50.0", require: false
 gem "rubocop-packaging", "~> 0.5.2", require: false
 gem "rubocop-performance", "~> 1.9", require: false
 gem "rubocop-rspec", ["~> 2.20", "< 2.21"], require: false
-gem "dogstatsd-ruby", ">= 3.3.0", "!= 5.0.0", "!= 5.0.1", "!= 5.1.0"
-gem "google-protobuf", ["~> 3.0", "!= 3.7.0", "!= 3.7.1"]
+gem "simplecov", git: "https://github.com/DataDog/simplecov", ref: "3bb6b7ee58bf4b1954ca205f50dd44d6f41c57db"
+gem "simplecov-cobertura", "~> 2.1.0"
 gem "strscan", git: "https://github.com/ruby/strscan", ref: "041b15df4ccc067deabd85fd489b2c15961d0e2f"
-gem "base64"
-gem "bigdecimal"
-gem "mutex_m"
+gem "warning", "~> 1"
+gem "webmock", ">= 3.10.0"
+gem "webrick", ">= 1.8.2"
 gem "opensearch-ruby"
 
 group :check do

--- a/gemfiles/ruby_3.4_opentelemetry.gemfile
+++ b/gemfiles/ruby_3.4_opentelemetry.gemfile
@@ -2,13 +2,18 @@
 
 source "https://rubygems.org"
 
+gem "base64"
 gem "benchmark-ips", "~> 2.8"
 gem "benchmark-memory", "< 0.2"
+gem "bigdecimal"
 gem "climate_control", "~> 0.2.0"
 gem "concurrent-ruby"
+gem "dogstatsd-ruby", ">= 3.3.0", "!= 5.0.0", "!= 5.0.1", "!= 5.1.0"
 gem "extlz4", "~> 0.3", ">= 0.3.3"
+gem "google-protobuf", ["~> 3.0", "!= 3.7.0", "!= 3.7.1"]
 gem "json-schema", "< 3"
 gem "memory_profiler", "~> 0.9"
+gem "mutex_m"
 gem "os", "~> 1.1"
 gem "pimpmychangelog", ">= 0.1.2"
 gem "pry"
@@ -19,21 +24,16 @@ gem "rspec", "~> 3.13"
 gem "rspec-collection_matchers", "~> 1.1"
 gem "rspec-wait", "~> 0"
 gem "rspec_junit_formatter", ">= 0.5.1"
-gem "simplecov", git: "https://github.com/DataDog/simplecov", ref: "3bb6b7ee58bf4b1954ca205f50dd44d6f41c57db"
-gem "simplecov-cobertura", "~> 2.1.0"
-gem "warning", "~> 1"
-gem "webmock", ">= 3.10.0"
-gem "webrick", ">= 1.8.2"
 gem "rubocop", "~> 1.50.0", require: false
 gem "rubocop-packaging", "~> 0.5.2", require: false
 gem "rubocop-performance", "~> 1.9", require: false
 gem "rubocop-rspec", ["~> 2.20", "< 2.21"], require: false
-gem "dogstatsd-ruby", ">= 3.3.0", "!= 5.0.0", "!= 5.0.1", "!= 5.1.0"
-gem "google-protobuf", ["~> 3.0", "!= 3.7.0", "!= 3.7.1"]
+gem "simplecov", git: "https://github.com/DataDog/simplecov", ref: "3bb6b7ee58bf4b1954ca205f50dd44d6f41c57db"
+gem "simplecov-cobertura", "~> 2.1.0"
 gem "strscan", git: "https://github.com/ruby/strscan", ref: "041b15df4ccc067deabd85fd489b2c15961d0e2f"
-gem "base64"
-gem "bigdecimal"
-gem "mutex_m"
+gem "warning", "~> 1"
+gem "webmock", ">= 3.10.0"
+gem "webrick", ">= 1.8.2"
 gem "opentelemetry-sdk", "~> 1.1"
 
 group :check do

--- a/gemfiles/ruby_3.4_opentelemetry_otlp.gemfile
+++ b/gemfiles/ruby_3.4_opentelemetry_otlp.gemfile
@@ -2,13 +2,18 @@
 
 source "https://rubygems.org"
 
+gem "base64"
 gem "benchmark-ips", "~> 2.8"
 gem "benchmark-memory", "< 0.2"
+gem "bigdecimal"
 gem "climate_control", "~> 0.2.0"
 gem "concurrent-ruby"
+gem "dogstatsd-ruby", ">= 3.3.0", "!= 5.0.0", "!= 5.0.1", "!= 5.1.0"
 gem "extlz4", "~> 0.3", ">= 0.3.3"
+gem "google-protobuf", ["~> 3.0", "!= 3.7.0", "!= 3.7.1"]
 gem "json-schema", "< 3"
 gem "memory_profiler", "~> 0.9"
+gem "mutex_m"
 gem "os", "~> 1.1"
 gem "pimpmychangelog", ">= 0.1.2"
 gem "pry"
@@ -19,21 +24,16 @@ gem "rspec", "~> 3.13"
 gem "rspec-collection_matchers", "~> 1.1"
 gem "rspec-wait", "~> 0"
 gem "rspec_junit_formatter", ">= 0.5.1"
-gem "simplecov", git: "https://github.com/DataDog/simplecov", ref: "3bb6b7ee58bf4b1954ca205f50dd44d6f41c57db"
-gem "simplecov-cobertura", "~> 2.1.0"
-gem "warning", "~> 1"
-gem "webmock", ">= 3.10.0"
-gem "webrick", ">= 1.8.2"
 gem "rubocop", "~> 1.50.0", require: false
 gem "rubocop-packaging", "~> 0.5.2", require: false
 gem "rubocop-performance", "~> 1.9", require: false
 gem "rubocop-rspec", ["~> 2.20", "< 2.21"], require: false
-gem "dogstatsd-ruby", ">= 3.3.0", "!= 5.0.0", "!= 5.0.1", "!= 5.1.0"
-gem "google-protobuf", ["~> 3.0", "!= 3.7.0", "!= 3.7.1"]
+gem "simplecov", git: "https://github.com/DataDog/simplecov", ref: "3bb6b7ee58bf4b1954ca205f50dd44d6f41c57db"
+gem "simplecov-cobertura", "~> 2.1.0"
 gem "strscan", git: "https://github.com/ruby/strscan", ref: "041b15df4ccc067deabd85fd489b2c15961d0e2f"
-gem "base64"
-gem "bigdecimal"
-gem "mutex_m"
+gem "warning", "~> 1"
+gem "webmock", ">= 3.10.0"
+gem "webrick", ">= 1.8.2"
 gem "opentelemetry-sdk", "~> 1.1"
 gem "opentelemetry-exporter-otlp"
 

--- a/gemfiles/ruby_3.4_rack_2.gemfile
+++ b/gemfiles/ruby_3.4_rack_2.gemfile
@@ -2,13 +2,18 @@
 
 source "https://rubygems.org"
 
+gem "base64"
 gem "benchmark-ips", "~> 2.8"
 gem "benchmark-memory", "< 0.2"
+gem "bigdecimal"
 gem "climate_control", "~> 0.2.0"
 gem "concurrent-ruby"
+gem "dogstatsd-ruby", ">= 3.3.0", "!= 5.0.0", "!= 5.0.1", "!= 5.1.0"
 gem "extlz4", "~> 0.3", ">= 0.3.3"
+gem "google-protobuf", ["~> 3.0", "!= 3.7.0", "!= 3.7.1"]
 gem "json-schema", "< 3"
 gem "memory_profiler", "~> 0.9"
+gem "mutex_m"
 gem "os", "~> 1.1"
 gem "pimpmychangelog", ">= 0.1.2"
 gem "pry"
@@ -19,21 +24,16 @@ gem "rspec", "~> 3.13"
 gem "rspec-collection_matchers", "~> 1.1"
 gem "rspec-wait", "~> 0"
 gem "rspec_junit_formatter", ">= 0.5.1"
-gem "simplecov", git: "https://github.com/DataDog/simplecov", ref: "3bb6b7ee58bf4b1954ca205f50dd44d6f41c57db"
-gem "simplecov-cobertura", "~> 2.1.0"
-gem "warning", "~> 1"
-gem "webmock", ">= 3.10.0"
-gem "webrick", ">= 1.8.2"
 gem "rubocop", "~> 1.50.0", require: false
 gem "rubocop-packaging", "~> 0.5.2", require: false
 gem "rubocop-performance", "~> 1.9", require: false
 gem "rubocop-rspec", ["~> 2.20", "< 2.21"], require: false
-gem "dogstatsd-ruby", ">= 3.3.0", "!= 5.0.0", "!= 5.0.1", "!= 5.1.0"
-gem "google-protobuf", ["~> 3.0", "!= 3.7.0", "!= 3.7.1"]
+gem "simplecov", git: "https://github.com/DataDog/simplecov", ref: "3bb6b7ee58bf4b1954ca205f50dd44d6f41c57db"
+gem "simplecov-cobertura", "~> 2.1.0"
 gem "strscan", git: "https://github.com/ruby/strscan", ref: "041b15df4ccc067deabd85fd489b2c15961d0e2f"
-gem "base64"
-gem "bigdecimal"
-gem "mutex_m"
+gem "warning", "~> 1"
+gem "webmock", ">= 3.10.0"
+gem "webrick", ">= 1.8.2"
 gem "rack", "~> 2"
 gem "rack-contrib"
 gem "rack-test"

--- a/gemfiles/ruby_3.4_rack_3.gemfile
+++ b/gemfiles/ruby_3.4_rack_3.gemfile
@@ -2,13 +2,18 @@
 
 source "https://rubygems.org"
 
+gem "base64"
 gem "benchmark-ips", "~> 2.8"
 gem "benchmark-memory", "< 0.2"
+gem "bigdecimal"
 gem "climate_control", "~> 0.2.0"
 gem "concurrent-ruby"
+gem "dogstatsd-ruby", ">= 3.3.0", "!= 5.0.0", "!= 5.0.1", "!= 5.1.0"
 gem "extlz4", "~> 0.3", ">= 0.3.3"
+gem "google-protobuf", ["~> 3.0", "!= 3.7.0", "!= 3.7.1"]
 gem "json-schema", "< 3"
 gem "memory_profiler", "~> 0.9"
+gem "mutex_m"
 gem "os", "~> 1.1"
 gem "pimpmychangelog", ">= 0.1.2"
 gem "pry"
@@ -19,21 +24,16 @@ gem "rspec", "~> 3.13"
 gem "rspec-collection_matchers", "~> 1.1"
 gem "rspec-wait", "~> 0"
 gem "rspec_junit_formatter", ">= 0.5.1"
-gem "simplecov", git: "https://github.com/DataDog/simplecov", ref: "3bb6b7ee58bf4b1954ca205f50dd44d6f41c57db"
-gem "simplecov-cobertura", "~> 2.1.0"
-gem "warning", "~> 1"
-gem "webmock", ">= 3.10.0"
-gem "webrick", ">= 1.8.2"
 gem "rubocop", "~> 1.50.0", require: false
 gem "rubocop-packaging", "~> 0.5.2", require: false
 gem "rubocop-performance", "~> 1.9", require: false
 gem "rubocop-rspec", ["~> 2.20", "< 2.21"], require: false
-gem "dogstatsd-ruby", ">= 3.3.0", "!= 5.0.0", "!= 5.0.1", "!= 5.1.0"
-gem "google-protobuf", ["~> 3.0", "!= 3.7.0", "!= 3.7.1"]
+gem "simplecov", git: "https://github.com/DataDog/simplecov", ref: "3bb6b7ee58bf4b1954ca205f50dd44d6f41c57db"
+gem "simplecov-cobertura", "~> 2.1.0"
 gem "strscan", git: "https://github.com/ruby/strscan", ref: "041b15df4ccc067deabd85fd489b2c15961d0e2f"
-gem "base64"
-gem "bigdecimal"
-gem "mutex_m"
+gem "warning", "~> 1"
+gem "webmock", ">= 3.10.0"
+gem "webrick", ">= 1.8.2"
 gem "rack", "~> 3"
 gem "rack-contrib"
 gem "rack-test"

--- a/gemfiles/ruby_3.4_rack_latest.gemfile
+++ b/gemfiles/ruby_3.4_rack_latest.gemfile
@@ -2,13 +2,18 @@
 
 source "https://rubygems.org"
 
+gem "base64"
 gem "benchmark-ips", "~> 2.8"
 gem "benchmark-memory", "< 0.2"
+gem "bigdecimal"
 gem "climate_control", "~> 0.2.0"
 gem "concurrent-ruby"
+gem "dogstatsd-ruby", ">= 3.3.0", "!= 5.0.0", "!= 5.0.1", "!= 5.1.0"
 gem "extlz4", "~> 0.3", ">= 0.3.3"
+gem "google-protobuf", ["~> 3.0", "!= 3.7.0", "!= 3.7.1"]
 gem "json-schema", "< 3"
 gem "memory_profiler", "~> 0.9"
+gem "mutex_m"
 gem "os", "~> 1.1"
 gem "pimpmychangelog", ">= 0.1.2"
 gem "pry"
@@ -19,21 +24,16 @@ gem "rspec", "~> 3.13"
 gem "rspec-collection_matchers", "~> 1.1"
 gem "rspec-wait", "~> 0"
 gem "rspec_junit_formatter", ">= 0.5.1"
-gem "simplecov", git: "https://github.com/DataDog/simplecov", ref: "3bb6b7ee58bf4b1954ca205f50dd44d6f41c57db"
-gem "simplecov-cobertura", "~> 2.1.0"
-gem "warning", "~> 1"
-gem "webmock", ">= 3.10.0"
-gem "webrick", ">= 1.8.2"
 gem "rubocop", "~> 1.50.0", require: false
 gem "rubocop-packaging", "~> 0.5.2", require: false
 gem "rubocop-performance", "~> 1.9", require: false
 gem "rubocop-rspec", ["~> 2.20", "< 2.21"], require: false
-gem "dogstatsd-ruby", ">= 3.3.0", "!= 5.0.0", "!= 5.0.1", "!= 5.1.0"
-gem "google-protobuf", ["~> 3.0", "!= 3.7.0", "!= 3.7.1"]
+gem "simplecov", git: "https://github.com/DataDog/simplecov", ref: "3bb6b7ee58bf4b1954ca205f50dd44d6f41c57db"
+gem "simplecov-cobertura", "~> 2.1.0"
 gem "strscan", git: "https://github.com/ruby/strscan", ref: "041b15df4ccc067deabd85fd489b2c15961d0e2f"
-gem "base64"
-gem "bigdecimal"
-gem "mutex_m"
+gem "warning", "~> 1"
+gem "webmock", ">= 3.10.0"
+gem "webrick", ">= 1.8.2"
 gem "rack"
 gem "rack-contrib"
 gem "rack-test"

--- a/gemfiles/ruby_3.4_rails61_mysql2.gemfile
+++ b/gemfiles/ruby_3.4_rails61_mysql2.gemfile
@@ -2,13 +2,18 @@
 
 source "https://rubygems.org"
 
+gem "base64"
 gem "benchmark-ips", "~> 2.8"
 gem "benchmark-memory", "< 0.2"
+gem "bigdecimal"
 gem "climate_control", "~> 0.2.0"
 gem "concurrent-ruby"
+gem "dogstatsd-ruby", ">= 3.3.0", "!= 5.0.0", "!= 5.0.1", "!= 5.1.0"
 gem "extlz4", "~> 0.3", ">= 0.3.3"
+gem "google-protobuf", ["~> 3.0", "!= 3.7.0", "!= 3.7.1"]
 gem "json-schema", "< 3"
 gem "memory_profiler", "~> 0.9"
+gem "mutex_m"
 gem "os", "~> 1.1"
 gem "pimpmychangelog", ">= 0.1.2"
 gem "pry"
@@ -19,21 +24,16 @@ gem "rspec", "~> 3.13"
 gem "rspec-collection_matchers", "~> 1.1"
 gem "rspec-wait", "~> 0"
 gem "rspec_junit_formatter", ">= 0.5.1"
-gem "simplecov", git: "https://github.com/DataDog/simplecov", ref: "3bb6b7ee58bf4b1954ca205f50dd44d6f41c57db"
-gem "simplecov-cobertura", "~> 2.1.0"
-gem "warning", "~> 1"
-gem "webmock", ">= 3.10.0"
-gem "webrick", ">= 1.8.2"
 gem "rubocop", "~> 1.50.0", require: false
 gem "rubocop-packaging", "~> 0.5.2", require: false
 gem "rubocop-performance", "~> 1.9", require: false
 gem "rubocop-rspec", ["~> 2.20", "< 2.21"], require: false
-gem "dogstatsd-ruby", ">= 3.3.0", "!= 5.0.0", "!= 5.0.1", "!= 5.1.0"
-gem "google-protobuf", ["~> 3.0", "!= 3.7.0", "!= 3.7.1"]
+gem "simplecov", git: "https://github.com/DataDog/simplecov", ref: "3bb6b7ee58bf4b1954ca205f50dd44d6f41c57db"
+gem "simplecov-cobertura", "~> 2.1.0"
 gem "strscan", git: "https://github.com/ruby/strscan", ref: "041b15df4ccc067deabd85fd489b2c15961d0e2f"
-gem "base64"
-gem "bigdecimal"
-gem "mutex_m"
+gem "warning", "~> 1"
+gem "webmock", ">= 3.10.0"
+gem "webrick", ">= 1.8.2"
 gem "rails", "~> 6.1.0"
 gem "mysql2", "~> 0.5", platform: :ruby
 gem "sprockets", "< 4"

--- a/gemfiles/ruby_3.4_rails61_postgres.gemfile
+++ b/gemfiles/ruby_3.4_rails61_postgres.gemfile
@@ -2,13 +2,18 @@
 
 source "https://rubygems.org"
 
+gem "base64"
 gem "benchmark-ips", "~> 2.8"
 gem "benchmark-memory", "< 0.2"
+gem "bigdecimal"
 gem "climate_control", "~> 0.2.0"
 gem "concurrent-ruby"
+gem "dogstatsd-ruby", ">= 3.3.0", "!= 5.0.0", "!= 5.0.1", "!= 5.1.0"
 gem "extlz4", "~> 0.3", ">= 0.3.3"
+gem "google-protobuf", ["~> 3.0", "!= 3.7.0", "!= 3.7.1"]
 gem "json-schema", "< 3"
 gem "memory_profiler", "~> 0.9"
+gem "mutex_m"
 gem "os", "~> 1.1"
 gem "pimpmychangelog", ">= 0.1.2"
 gem "pry"
@@ -19,21 +24,16 @@ gem "rspec", "~> 3.13"
 gem "rspec-collection_matchers", "~> 1.1"
 gem "rspec-wait", "~> 0"
 gem "rspec_junit_formatter", ">= 0.5.1"
-gem "simplecov", git: "https://github.com/DataDog/simplecov", ref: "3bb6b7ee58bf4b1954ca205f50dd44d6f41c57db"
-gem "simplecov-cobertura", "~> 2.1.0"
-gem "warning", "~> 1"
-gem "webmock", ">= 3.10.0"
-gem "webrick", ">= 1.8.2"
 gem "rubocop", "~> 1.50.0", require: false
 gem "rubocop-packaging", "~> 0.5.2", require: false
 gem "rubocop-performance", "~> 1.9", require: false
 gem "rubocop-rspec", ["~> 2.20", "< 2.21"], require: false
-gem "dogstatsd-ruby", ">= 3.3.0", "!= 5.0.0", "!= 5.0.1", "!= 5.1.0"
-gem "google-protobuf", ["~> 3.0", "!= 3.7.0", "!= 3.7.1"]
+gem "simplecov", git: "https://github.com/DataDog/simplecov", ref: "3bb6b7ee58bf4b1954ca205f50dd44d6f41c57db"
+gem "simplecov-cobertura", "~> 2.1.0"
 gem "strscan", git: "https://github.com/ruby/strscan", ref: "041b15df4ccc067deabd85fd489b2c15961d0e2f"
-gem "base64"
-gem "bigdecimal"
-gem "mutex_m"
+gem "warning", "~> 1"
+gem "webmock", ">= 3.10.0"
+gem "webrick", ">= 1.8.2"
 gem "rails", "~> 6.1.0"
 gem "pg", ">= 1.1", platform: :ruby
 gem "sprockets", "< 4"

--- a/gemfiles/ruby_3.4_rails61_postgres_redis.gemfile
+++ b/gemfiles/ruby_3.4_rails61_postgres_redis.gemfile
@@ -2,13 +2,18 @@
 
 source "https://rubygems.org"
 
+gem "base64"
 gem "benchmark-ips", "~> 2.8"
 gem "benchmark-memory", "< 0.2"
+gem "bigdecimal"
 gem "climate_control", "~> 0.2.0"
 gem "concurrent-ruby"
+gem "dogstatsd-ruby", ">= 3.3.0", "!= 5.0.0", "!= 5.0.1", "!= 5.1.0"
 gem "extlz4", "~> 0.3", ">= 0.3.3"
+gem "google-protobuf", ["~> 3.0", "!= 3.7.0", "!= 3.7.1"]
 gem "json-schema", "< 3"
 gem "memory_profiler", "~> 0.9"
+gem "mutex_m"
 gem "os", "~> 1.1"
 gem "pimpmychangelog", ">= 0.1.2"
 gem "pry"
@@ -19,21 +24,16 @@ gem "rspec", "~> 3.13"
 gem "rspec-collection_matchers", "~> 1.1"
 gem "rspec-wait", "~> 0"
 gem "rspec_junit_formatter", ">= 0.5.1"
-gem "simplecov", git: "https://github.com/DataDog/simplecov", ref: "3bb6b7ee58bf4b1954ca205f50dd44d6f41c57db"
-gem "simplecov-cobertura", "~> 2.1.0"
-gem "warning", "~> 1"
-gem "webmock", ">= 3.10.0"
-gem "webrick", ">= 1.8.2"
 gem "rubocop", "~> 1.50.0", require: false
 gem "rubocop-packaging", "~> 0.5.2", require: false
 gem "rubocop-performance", "~> 1.9", require: false
 gem "rubocop-rspec", ["~> 2.20", "< 2.21"], require: false
-gem "dogstatsd-ruby", ">= 3.3.0", "!= 5.0.0", "!= 5.0.1", "!= 5.1.0"
-gem "google-protobuf", ["~> 3.0", "!= 3.7.0", "!= 3.7.1"]
+gem "simplecov", git: "https://github.com/DataDog/simplecov", ref: "3bb6b7ee58bf4b1954ca205f50dd44d6f41c57db"
+gem "simplecov-cobertura", "~> 2.1.0"
 gem "strscan", git: "https://github.com/ruby/strscan", ref: "041b15df4ccc067deabd85fd489b2c15961d0e2f"
-gem "base64"
-gem "bigdecimal"
-gem "mutex_m"
+gem "warning", "~> 1"
+gem "webmock", ">= 3.10.0"
+gem "webrick", ">= 1.8.2"
 gem "rails", "~> 6.1.0"
 gem "pg", ">= 1.1", platform: :ruby
 gem "redis", "~> 4"

--- a/gemfiles/ruby_3.4_rails61_postgres_sidekiq.gemfile
+++ b/gemfiles/ruby_3.4_rails61_postgres_sidekiq.gemfile
@@ -2,13 +2,18 @@
 
 source "https://rubygems.org"
 
+gem "base64"
 gem "benchmark-ips", "~> 2.8"
 gem "benchmark-memory", "< 0.2"
+gem "bigdecimal"
 gem "climate_control", "~> 0.2.0"
 gem "concurrent-ruby"
+gem "dogstatsd-ruby", ">= 3.3.0", "!= 5.0.0", "!= 5.0.1", "!= 5.1.0"
 gem "extlz4", "~> 0.3", ">= 0.3.3"
+gem "google-protobuf", ["~> 3.0", "!= 3.7.0", "!= 3.7.1"]
 gem "json-schema", "< 3"
 gem "memory_profiler", "~> 0.9"
+gem "mutex_m"
 gem "os", "~> 1.1"
 gem "pimpmychangelog", ">= 0.1.2"
 gem "pry"
@@ -19,21 +24,16 @@ gem "rspec", "~> 3.13"
 gem "rspec-collection_matchers", "~> 1.1"
 gem "rspec-wait", "~> 0"
 gem "rspec_junit_formatter", ">= 0.5.1"
-gem "simplecov", git: "https://github.com/DataDog/simplecov", ref: "3bb6b7ee58bf4b1954ca205f50dd44d6f41c57db"
-gem "simplecov-cobertura", "~> 2.1.0"
-gem "warning", "~> 1"
-gem "webmock", ">= 3.10.0"
-gem "webrick", ">= 1.8.2"
 gem "rubocop", "~> 1.50.0", require: false
 gem "rubocop-packaging", "~> 0.5.2", require: false
 gem "rubocop-performance", "~> 1.9", require: false
 gem "rubocop-rspec", ["~> 2.20", "< 2.21"], require: false
-gem "dogstatsd-ruby", ">= 3.3.0", "!= 5.0.0", "!= 5.0.1", "!= 5.1.0"
-gem "google-protobuf", ["~> 3.0", "!= 3.7.0", "!= 3.7.1"]
+gem "simplecov", git: "https://github.com/DataDog/simplecov", ref: "3bb6b7ee58bf4b1954ca205f50dd44d6f41c57db"
+gem "simplecov-cobertura", "~> 2.1.0"
 gem "strscan", git: "https://github.com/ruby/strscan", ref: "041b15df4ccc067deabd85fd489b2c15961d0e2f"
-gem "base64"
-gem "bigdecimal"
-gem "mutex_m"
+gem "warning", "~> 1"
+gem "webmock", ">= 3.10.0"
+gem "webrick", ">= 1.8.2"
 gem "rails", "~> 6.1.0"
 gem "pg", ">= 1.1", platform: :ruby
 gem "sidekiq", ">= 6.1.2"

--- a/gemfiles/ruby_3.4_rails61_semantic_logger.gemfile
+++ b/gemfiles/ruby_3.4_rails61_semantic_logger.gemfile
@@ -2,13 +2,18 @@
 
 source "https://rubygems.org"
 
+gem "base64"
 gem "benchmark-ips", "~> 2.8"
 gem "benchmark-memory", "< 0.2"
+gem "bigdecimal"
 gem "climate_control", "~> 0.2.0"
 gem "concurrent-ruby"
+gem "dogstatsd-ruby", ">= 3.3.0", "!= 5.0.0", "!= 5.0.1", "!= 5.1.0"
 gem "extlz4", "~> 0.3", ">= 0.3.3"
+gem "google-protobuf", ["~> 3.0", "!= 3.7.0", "!= 3.7.1"]
 gem "json-schema", "< 3"
 gem "memory_profiler", "~> 0.9"
+gem "mutex_m"
 gem "os", "~> 1.1"
 gem "pimpmychangelog", ">= 0.1.2"
 gem "pry"
@@ -19,21 +24,16 @@ gem "rspec", "~> 3.13"
 gem "rspec-collection_matchers", "~> 1.1"
 gem "rspec-wait", "~> 0"
 gem "rspec_junit_formatter", ">= 0.5.1"
-gem "simplecov", git: "https://github.com/DataDog/simplecov", ref: "3bb6b7ee58bf4b1954ca205f50dd44d6f41c57db"
-gem "simplecov-cobertura", "~> 2.1.0"
-gem "warning", "~> 1"
-gem "webmock", ">= 3.10.0"
-gem "webrick", ">= 1.8.2"
 gem "rubocop", "~> 1.50.0", require: false
 gem "rubocop-packaging", "~> 0.5.2", require: false
 gem "rubocop-performance", "~> 1.9", require: false
 gem "rubocop-rspec", ["~> 2.20", "< 2.21"], require: false
-gem "dogstatsd-ruby", ">= 3.3.0", "!= 5.0.0", "!= 5.0.1", "!= 5.1.0"
-gem "google-protobuf", ["~> 3.0", "!= 3.7.0", "!= 3.7.1"]
+gem "simplecov", git: "https://github.com/DataDog/simplecov", ref: "3bb6b7ee58bf4b1954ca205f50dd44d6f41c57db"
+gem "simplecov-cobertura", "~> 2.1.0"
 gem "strscan", git: "https://github.com/ruby/strscan", ref: "041b15df4ccc067deabd85fd489b2c15961d0e2f"
-gem "base64"
-gem "bigdecimal"
-gem "mutex_m"
+gem "warning", "~> 1"
+gem "webmock", ">= 3.10.0"
+gem "webrick", ">= 1.8.2"
 gem "rails", "~> 6.1.0"
 gem "pg", ">= 1.1", platform: :ruby
 gem "sprockets", "< 4"

--- a/gemfiles/ruby_3.4_rails61_trilogy.gemfile
+++ b/gemfiles/ruby_3.4_rails61_trilogy.gemfile
@@ -2,13 +2,18 @@
 
 source "https://rubygems.org"
 
+gem "base64"
 gem "benchmark-ips", "~> 2.8"
 gem "benchmark-memory", "< 0.2"
+gem "bigdecimal"
 gem "climate_control", "~> 0.2.0"
 gem "concurrent-ruby"
+gem "dogstatsd-ruby", ">= 3.3.0", "!= 5.0.0", "!= 5.0.1", "!= 5.1.0"
 gem "extlz4", "~> 0.3", ">= 0.3.3"
+gem "google-protobuf", ["~> 3.0", "!= 3.7.0", "!= 3.7.1"]
 gem "json-schema", "< 3"
 gem "memory_profiler", "~> 0.9"
+gem "mutex_m"
 gem "os", "~> 1.1"
 gem "pimpmychangelog", ">= 0.1.2"
 gem "pry"
@@ -19,21 +24,16 @@ gem "rspec", "~> 3.13"
 gem "rspec-collection_matchers", "~> 1.1"
 gem "rspec-wait", "~> 0"
 gem "rspec_junit_formatter", ">= 0.5.1"
-gem "simplecov", git: "https://github.com/DataDog/simplecov", ref: "3bb6b7ee58bf4b1954ca205f50dd44d6f41c57db"
-gem "simplecov-cobertura", "~> 2.1.0"
-gem "warning", "~> 1"
-gem "webmock", ">= 3.10.0"
-gem "webrick", ">= 1.8.2"
 gem "rubocop", "~> 1.50.0", require: false
 gem "rubocop-packaging", "~> 0.5.2", require: false
 gem "rubocop-performance", "~> 1.9", require: false
 gem "rubocop-rspec", ["~> 2.20", "< 2.21"], require: false
-gem "dogstatsd-ruby", ">= 3.3.0", "!= 5.0.0", "!= 5.0.1", "!= 5.1.0"
-gem "google-protobuf", ["~> 3.0", "!= 3.7.0", "!= 3.7.1"]
+gem "simplecov", git: "https://github.com/DataDog/simplecov", ref: "3bb6b7ee58bf4b1954ca205f50dd44d6f41c57db"
+gem "simplecov-cobertura", "~> 2.1.0"
 gem "strscan", git: "https://github.com/ruby/strscan", ref: "041b15df4ccc067deabd85fd489b2c15961d0e2f"
-gem "base64"
-gem "bigdecimal"
-gem "mutex_m"
+gem "warning", "~> 1"
+gem "webmock", ">= 3.10.0"
+gem "webrick", ">= 1.8.2"
 gem "rails", "~> 6.1.0"
 gem "trilogy"
 gem "activerecord-trilogy-adapter"

--- a/gemfiles/ruby_3.4_rails7.gemfile
+++ b/gemfiles/ruby_3.4_rails7.gemfile
@@ -2,13 +2,18 @@
 
 source "https://rubygems.org"
 
+gem "base64"
 gem "benchmark-ips", "~> 2.8"
 gem "benchmark-memory", "< 0.2"
+gem "bigdecimal"
 gem "climate_control", "~> 0.2.0"
 gem "concurrent-ruby"
+gem "dogstatsd-ruby", ">= 3.3.0", "!= 5.0.0", "!= 5.0.1", "!= 5.1.0"
 gem "extlz4", "~> 0.3", ">= 0.3.3"
+gem "google-protobuf", ["~> 3.0", "!= 3.7.0", "!= 3.7.1"]
 gem "json-schema", "< 3"
 gem "memory_profiler", "~> 0.9"
+gem "mutex_m"
 gem "os", "~> 1.1"
 gem "pimpmychangelog", ">= 0.1.2"
 gem "pry"
@@ -19,21 +24,16 @@ gem "rspec", "~> 3.13"
 gem "rspec-collection_matchers", "~> 1.1"
 gem "rspec-wait", "~> 0"
 gem "rspec_junit_formatter", ">= 0.5.1"
-gem "simplecov", git: "https://github.com/DataDog/simplecov", ref: "3bb6b7ee58bf4b1954ca205f50dd44d6f41c57db"
-gem "simplecov-cobertura", "~> 2.1.0"
-gem "warning", "~> 1"
-gem "webmock", ">= 3.10.0"
-gem "webrick", ">= 1.8.2"
 gem "rubocop", "~> 1.50.0", require: false
 gem "rubocop-packaging", "~> 0.5.2", require: false
 gem "rubocop-performance", "~> 1.9", require: false
 gem "rubocop-rspec", ["~> 2.20", "< 2.21"], require: false
-gem "dogstatsd-ruby", ">= 3.3.0", "!= 5.0.0", "!= 5.0.1", "!= 5.1.0"
-gem "google-protobuf", ["~> 3.0", "!= 3.7.0", "!= 3.7.1"]
+gem "simplecov", git: "https://github.com/DataDog/simplecov", ref: "3bb6b7ee58bf4b1954ca205f50dd44d6f41c57db"
+gem "simplecov-cobertura", "~> 2.1.0"
 gem "strscan", git: "https://github.com/ruby/strscan", ref: "041b15df4ccc067deabd85fd489b2c15961d0e2f"
-gem "base64"
-gem "bigdecimal"
-gem "mutex_m"
+gem "warning", "~> 1"
+gem "webmock", ">= 3.10.0"
+gem "webrick", ">= 1.8.2"
 gem "rails", "~> 7.0.0"
 
 group :check do

--- a/gemfiles/ruby_3.4_rails71.gemfile
+++ b/gemfiles/ruby_3.4_rails71.gemfile
@@ -2,13 +2,18 @@
 
 source "https://rubygems.org"
 
+gem "base64"
 gem "benchmark-ips", "~> 2.8"
 gem "benchmark-memory", "< 0.2"
+gem "bigdecimal"
 gem "climate_control", "~> 0.2.0"
 gem "concurrent-ruby"
+gem "dogstatsd-ruby", ">= 3.3.0", "!= 5.0.0", "!= 5.0.1", "!= 5.1.0"
 gem "extlz4", "~> 0.3", ">= 0.3.3"
+gem "google-protobuf", ["~> 3.0", "!= 3.7.0", "!= 3.7.1"]
 gem "json-schema", "< 3"
 gem "memory_profiler", "~> 0.9"
+gem "mutex_m"
 gem "os", "~> 1.1"
 gem "pimpmychangelog", ">= 0.1.2"
 gem "pry"
@@ -19,21 +24,16 @@ gem "rspec", "~> 3.13"
 gem "rspec-collection_matchers", "~> 1.1"
 gem "rspec-wait", "~> 0"
 gem "rspec_junit_formatter", ">= 0.5.1"
-gem "simplecov", git: "https://github.com/DataDog/simplecov", ref: "3bb6b7ee58bf4b1954ca205f50dd44d6f41c57db"
-gem "simplecov-cobertura", "~> 2.1.0"
-gem "warning", "~> 1"
-gem "webmock", ">= 3.10.0"
-gem "webrick", ">= 1.8.2"
 gem "rubocop", "~> 1.50.0", require: false
 gem "rubocop-packaging", "~> 0.5.2", require: false
 gem "rubocop-performance", "~> 1.9", require: false
 gem "rubocop-rspec", ["~> 2.20", "< 2.21"], require: false
-gem "dogstatsd-ruby", ">= 3.3.0", "!= 5.0.0", "!= 5.0.1", "!= 5.1.0"
-gem "google-protobuf", ["~> 3.0", "!= 3.7.0", "!= 3.7.1"]
+gem "simplecov", git: "https://github.com/DataDog/simplecov", ref: "3bb6b7ee58bf4b1954ca205f50dd44d6f41c57db"
+gem "simplecov-cobertura", "~> 2.1.0"
 gem "strscan", git: "https://github.com/ruby/strscan", ref: "041b15df4ccc067deabd85fd489b2c15961d0e2f"
-gem "base64"
-gem "bigdecimal"
-gem "mutex_m"
+gem "warning", "~> 1"
+gem "webmock", ">= 3.10.0"
+gem "webrick", ">= 1.8.2"
 gem "rails", "~> 7.1.0"
 
 group :check do

--- a/gemfiles/ruby_3.4_rails_old_redis.gemfile
+++ b/gemfiles/ruby_3.4_rails_old_redis.gemfile
@@ -2,13 +2,18 @@
 
 source "https://rubygems.org"
 
+gem "base64"
 gem "benchmark-ips", "~> 2.8"
 gem "benchmark-memory", "< 0.2"
+gem "bigdecimal"
 gem "climate_control", "~> 0.2.0"
 gem "concurrent-ruby"
+gem "dogstatsd-ruby", ">= 3.3.0", "!= 5.0.0", "!= 5.0.1", "!= 5.1.0"
 gem "extlz4", "~> 0.3", ">= 0.3.3"
+gem "google-protobuf", ["~> 3.0", "!= 3.7.0", "!= 3.7.1"]
 gem "json-schema", "< 3"
 gem "memory_profiler", "~> 0.9"
+gem "mutex_m"
 gem "os", "~> 1.1"
 gem "pimpmychangelog", ">= 0.1.2"
 gem "pry"
@@ -19,21 +24,16 @@ gem "rspec", "~> 3.13"
 gem "rspec-collection_matchers", "~> 1.1"
 gem "rspec-wait", "~> 0"
 gem "rspec_junit_formatter", ">= 0.5.1"
-gem "simplecov", git: "https://github.com/DataDog/simplecov", ref: "3bb6b7ee58bf4b1954ca205f50dd44d6f41c57db"
-gem "simplecov-cobertura", "~> 2.1.0"
-gem "warning", "~> 1"
-gem "webmock", ">= 3.10.0"
-gem "webrick", ">= 1.8.2"
 gem "rubocop", "~> 1.50.0", require: false
 gem "rubocop-packaging", "~> 0.5.2", require: false
 gem "rubocop-performance", "~> 1.9", require: false
 gem "rubocop-rspec", ["~> 2.20", "< 2.21"], require: false
-gem "dogstatsd-ruby", ">= 3.3.0", "!= 5.0.0", "!= 5.0.1", "!= 5.1.0"
-gem "google-protobuf", ["~> 3.0", "!= 3.7.0", "!= 3.7.1"]
+gem "simplecov", git: "https://github.com/DataDog/simplecov", ref: "3bb6b7ee58bf4b1954ca205f50dd44d6f41c57db"
+gem "simplecov-cobertura", "~> 2.1.0"
 gem "strscan", git: "https://github.com/ruby/strscan", ref: "041b15df4ccc067deabd85fd489b2c15961d0e2f"
-gem "base64"
-gem "bigdecimal"
-gem "mutex_m"
+gem "warning", "~> 1"
+gem "webmock", ">= 3.10.0"
+gem "webrick", ">= 1.8.2"
 gem "redis", "< 4"
 gem "rails", "~> 6.1.0"
 gem "pg", ">= 1.1", platform: :ruby

--- a/gemfiles/ruby_3.4_redis_3.gemfile
+++ b/gemfiles/ruby_3.4_redis_3.gemfile
@@ -2,13 +2,18 @@
 
 source "https://rubygems.org"
 
+gem "base64"
 gem "benchmark-ips", "~> 2.8"
 gem "benchmark-memory", "< 0.2"
+gem "bigdecimal"
 gem "climate_control", "~> 0.2.0"
 gem "concurrent-ruby"
+gem "dogstatsd-ruby", ">= 3.3.0", "!= 5.0.0", "!= 5.0.1", "!= 5.1.0"
 gem "extlz4", "~> 0.3", ">= 0.3.3"
+gem "google-protobuf", ["~> 3.0", "!= 3.7.0", "!= 3.7.1"]
 gem "json-schema", "< 3"
 gem "memory_profiler", "~> 0.9"
+gem "mutex_m"
 gem "os", "~> 1.1"
 gem "pimpmychangelog", ">= 0.1.2"
 gem "pry"
@@ -19,21 +24,16 @@ gem "rspec", "~> 3.13"
 gem "rspec-collection_matchers", "~> 1.1"
 gem "rspec-wait", "~> 0"
 gem "rspec_junit_formatter", ">= 0.5.1"
-gem "simplecov", git: "https://github.com/DataDog/simplecov", ref: "3bb6b7ee58bf4b1954ca205f50dd44d6f41c57db"
-gem "simplecov-cobertura", "~> 2.1.0"
-gem "warning", "~> 1"
-gem "webmock", ">= 3.10.0"
-gem "webrick", ">= 1.8.2"
 gem "rubocop", "~> 1.50.0", require: false
 gem "rubocop-packaging", "~> 0.5.2", require: false
 gem "rubocop-performance", "~> 1.9", require: false
 gem "rubocop-rspec", ["~> 2.20", "< 2.21"], require: false
-gem "dogstatsd-ruby", ">= 3.3.0", "!= 5.0.0", "!= 5.0.1", "!= 5.1.0"
-gem "google-protobuf", ["~> 3.0", "!= 3.7.0", "!= 3.7.1"]
+gem "simplecov", git: "https://github.com/DataDog/simplecov", ref: "3bb6b7ee58bf4b1954ca205f50dd44d6f41c57db"
+gem "simplecov-cobertura", "~> 2.1.0"
 gem "strscan", git: "https://github.com/ruby/strscan", ref: "041b15df4ccc067deabd85fd489b2c15961d0e2f"
-gem "base64"
-gem "bigdecimal"
-gem "mutex_m"
+gem "warning", "~> 1"
+gem "webmock", ">= 3.10.0"
+gem "webrick", ">= 1.8.2"
 gem "redis", "~> 3"
 
 group :check do

--- a/gemfiles/ruby_3.4_redis_4.gemfile
+++ b/gemfiles/ruby_3.4_redis_4.gemfile
@@ -2,13 +2,18 @@
 
 source "https://rubygems.org"
 
+gem "base64"
 gem "benchmark-ips", "~> 2.8"
 gem "benchmark-memory", "< 0.2"
+gem "bigdecimal"
 gem "climate_control", "~> 0.2.0"
 gem "concurrent-ruby"
+gem "dogstatsd-ruby", ">= 3.3.0", "!= 5.0.0", "!= 5.0.1", "!= 5.1.0"
 gem "extlz4", "~> 0.3", ">= 0.3.3"
+gem "google-protobuf", ["~> 3.0", "!= 3.7.0", "!= 3.7.1"]
 gem "json-schema", "< 3"
 gem "memory_profiler", "~> 0.9"
+gem "mutex_m"
 gem "os", "~> 1.1"
 gem "pimpmychangelog", ">= 0.1.2"
 gem "pry"
@@ -19,21 +24,16 @@ gem "rspec", "~> 3.13"
 gem "rspec-collection_matchers", "~> 1.1"
 gem "rspec-wait", "~> 0"
 gem "rspec_junit_formatter", ">= 0.5.1"
-gem "simplecov", git: "https://github.com/DataDog/simplecov", ref: "3bb6b7ee58bf4b1954ca205f50dd44d6f41c57db"
-gem "simplecov-cobertura", "~> 2.1.0"
-gem "warning", "~> 1"
-gem "webmock", ">= 3.10.0"
-gem "webrick", ">= 1.8.2"
 gem "rubocop", "~> 1.50.0", require: false
 gem "rubocop-packaging", "~> 0.5.2", require: false
 gem "rubocop-performance", "~> 1.9", require: false
 gem "rubocop-rspec", ["~> 2.20", "< 2.21"], require: false
-gem "dogstatsd-ruby", ">= 3.3.0", "!= 5.0.0", "!= 5.0.1", "!= 5.1.0"
-gem "google-protobuf", ["~> 3.0", "!= 3.7.0", "!= 3.7.1"]
+gem "simplecov", git: "https://github.com/DataDog/simplecov", ref: "3bb6b7ee58bf4b1954ca205f50dd44d6f41c57db"
+gem "simplecov-cobertura", "~> 2.1.0"
 gem "strscan", git: "https://github.com/ruby/strscan", ref: "041b15df4ccc067deabd85fd489b2c15961d0e2f"
-gem "base64"
-gem "bigdecimal"
-gem "mutex_m"
+gem "warning", "~> 1"
+gem "webmock", ">= 3.10.0"
+gem "webrick", ">= 1.8.2"
 gem "redis", "~> 4"
 
 group :check do

--- a/gemfiles/ruby_3.4_redis_5.gemfile
+++ b/gemfiles/ruby_3.4_redis_5.gemfile
@@ -2,13 +2,18 @@
 
 source "https://rubygems.org"
 
+gem "base64"
 gem "benchmark-ips", "~> 2.8"
 gem "benchmark-memory", "< 0.2"
+gem "bigdecimal"
 gem "climate_control", "~> 0.2.0"
 gem "concurrent-ruby"
+gem "dogstatsd-ruby", ">= 3.3.0", "!= 5.0.0", "!= 5.0.1", "!= 5.1.0"
 gem "extlz4", "~> 0.3", ">= 0.3.3"
+gem "google-protobuf", ["~> 3.0", "!= 3.7.0", "!= 3.7.1"]
 gem "json-schema", "< 3"
 gem "memory_profiler", "~> 0.9"
+gem "mutex_m"
 gem "os", "~> 1.1"
 gem "pimpmychangelog", ">= 0.1.2"
 gem "pry"
@@ -19,21 +24,16 @@ gem "rspec", "~> 3.13"
 gem "rspec-collection_matchers", "~> 1.1"
 gem "rspec-wait", "~> 0"
 gem "rspec_junit_formatter", ">= 0.5.1"
-gem "simplecov", git: "https://github.com/DataDog/simplecov", ref: "3bb6b7ee58bf4b1954ca205f50dd44d6f41c57db"
-gem "simplecov-cobertura", "~> 2.1.0"
-gem "warning", "~> 1"
-gem "webmock", ">= 3.10.0"
-gem "webrick", ">= 1.8.2"
 gem "rubocop", "~> 1.50.0", require: false
 gem "rubocop-packaging", "~> 0.5.2", require: false
 gem "rubocop-performance", "~> 1.9", require: false
 gem "rubocop-rspec", ["~> 2.20", "< 2.21"], require: false
-gem "dogstatsd-ruby", ">= 3.3.0", "!= 5.0.0", "!= 5.0.1", "!= 5.1.0"
-gem "google-protobuf", ["~> 3.0", "!= 3.7.0", "!= 3.7.1"]
+gem "simplecov", git: "https://github.com/DataDog/simplecov", ref: "3bb6b7ee58bf4b1954ca205f50dd44d6f41c57db"
+gem "simplecov-cobertura", "~> 2.1.0"
 gem "strscan", git: "https://github.com/ruby/strscan", ref: "041b15df4ccc067deabd85fd489b2c15961d0e2f"
-gem "base64"
-gem "bigdecimal"
-gem "mutex_m"
+gem "warning", "~> 1"
+gem "webmock", ">= 3.10.0"
+gem "webrick", ">= 1.8.2"
 gem "redis", "~> 5"
 
 group :check do

--- a/gemfiles/ruby_3.4_relational_db.gemfile
+++ b/gemfiles/ruby_3.4_relational_db.gemfile
@@ -2,13 +2,18 @@
 
 source "https://rubygems.org"
 
+gem "base64"
 gem "benchmark-ips", "~> 2.8"
 gem "benchmark-memory", "< 0.2"
+gem "bigdecimal"
 gem "climate_control", "~> 0.2.0"
 gem "concurrent-ruby"
+gem "dogstatsd-ruby", ">= 3.3.0", "!= 5.0.0", "!= 5.0.1", "!= 5.1.0"
 gem "extlz4", "~> 0.3", ">= 0.3.3"
+gem "google-protobuf", ["~> 3.0", "!= 3.7.0", "!= 3.7.1"]
 gem "json-schema", "< 3"
 gem "memory_profiler", "~> 0.9"
+gem "mutex_m"
 gem "os", "~> 1.1"
 gem "pimpmychangelog", ">= 0.1.2"
 gem "pry"
@@ -19,21 +24,16 @@ gem "rspec", "~> 3.13"
 gem "rspec-collection_matchers", "~> 1.1"
 gem "rspec-wait", "~> 0"
 gem "rspec_junit_formatter", ">= 0.5.1"
-gem "simplecov", git: "https://github.com/DataDog/simplecov", ref: "3bb6b7ee58bf4b1954ca205f50dd44d6f41c57db"
-gem "simplecov-cobertura", "~> 2.1.0"
-gem "warning", "~> 1"
-gem "webmock", ">= 3.10.0"
-gem "webrick", ">= 1.8.2"
 gem "rubocop", "~> 1.50.0", require: false
 gem "rubocop-packaging", "~> 0.5.2", require: false
 gem "rubocop-performance", "~> 1.9", require: false
 gem "rubocop-rspec", ["~> 2.20", "< 2.21"], require: false
-gem "dogstatsd-ruby", ">= 3.3.0", "!= 5.0.0", "!= 5.0.1", "!= 5.1.0"
-gem "google-protobuf", ["~> 3.0", "!= 3.7.0", "!= 3.7.1"]
+gem "simplecov", git: "https://github.com/DataDog/simplecov", ref: "3bb6b7ee58bf4b1954ca205f50dd44d6f41c57db"
+gem "simplecov-cobertura", "~> 2.1.0"
 gem "strscan", git: "https://github.com/ruby/strscan", ref: "041b15df4ccc067deabd85fd489b2c15961d0e2f"
-gem "base64"
-gem "bigdecimal"
-gem "mutex_m"
+gem "warning", "~> 1"
+gem "webmock", ">= 3.10.0"
+gem "webrick", ">= 1.8.2"
 gem "activerecord", "~> 7.0.0"
 gem "delayed_job"
 gem "delayed_job_active_record"

--- a/gemfiles/ruby_3.4_resque2_redis3.gemfile
+++ b/gemfiles/ruby_3.4_resque2_redis3.gemfile
@@ -2,13 +2,18 @@
 
 source "https://rubygems.org"
 
+gem "base64"
 gem "benchmark-ips", "~> 2.8"
 gem "benchmark-memory", "< 0.2"
+gem "bigdecimal"
 gem "climate_control", "~> 0.2.0"
 gem "concurrent-ruby"
+gem "dogstatsd-ruby", ">= 3.3.0", "!= 5.0.0", "!= 5.0.1", "!= 5.1.0"
 gem "extlz4", "~> 0.3", ">= 0.3.3"
+gem "google-protobuf", ["~> 3.0", "!= 3.7.0", "!= 3.7.1"]
 gem "json-schema", "< 3"
 gem "memory_profiler", "~> 0.9"
+gem "mutex_m"
 gem "os", "~> 1.1"
 gem "pimpmychangelog", ">= 0.1.2"
 gem "pry"
@@ -19,21 +24,16 @@ gem "rspec", "~> 3.13"
 gem "rspec-collection_matchers", "~> 1.1"
 gem "rspec-wait", "~> 0"
 gem "rspec_junit_formatter", ">= 0.5.1"
-gem "simplecov", git: "https://github.com/DataDog/simplecov", ref: "3bb6b7ee58bf4b1954ca205f50dd44d6f41c57db"
-gem "simplecov-cobertura", "~> 2.1.0"
-gem "warning", "~> 1"
-gem "webmock", ">= 3.10.0"
-gem "webrick", ">= 1.8.2"
 gem "rubocop", "~> 1.50.0", require: false
 gem "rubocop-packaging", "~> 0.5.2", require: false
 gem "rubocop-performance", "~> 1.9", require: false
 gem "rubocop-rspec", ["~> 2.20", "< 2.21"], require: false
-gem "dogstatsd-ruby", ">= 3.3.0", "!= 5.0.0", "!= 5.0.1", "!= 5.1.0"
-gem "google-protobuf", ["~> 3.0", "!= 3.7.0", "!= 3.7.1"]
+gem "simplecov", git: "https://github.com/DataDog/simplecov", ref: "3bb6b7ee58bf4b1954ca205f50dd44d6f41c57db"
+gem "simplecov-cobertura", "~> 2.1.0"
 gem "strscan", git: "https://github.com/ruby/strscan", ref: "041b15df4ccc067deabd85fd489b2c15961d0e2f"
-gem "base64"
-gem "bigdecimal"
-gem "mutex_m"
+gem "warning", "~> 1"
+gem "webmock", ">= 3.10.0"
+gem "webrick", ">= 1.8.2"
 gem "redis", "< 4.0"
 gem "resque", ">= 2.0"
 

--- a/gemfiles/ruby_3.4_resque2_redis4.gemfile
+++ b/gemfiles/ruby_3.4_resque2_redis4.gemfile
@@ -2,13 +2,18 @@
 
 source "https://rubygems.org"
 
+gem "base64"
 gem "benchmark-ips", "~> 2.8"
 gem "benchmark-memory", "< 0.2"
+gem "bigdecimal"
 gem "climate_control", "~> 0.2.0"
 gem "concurrent-ruby"
+gem "dogstatsd-ruby", ">= 3.3.0", "!= 5.0.0", "!= 5.0.1", "!= 5.1.0"
 gem "extlz4", "~> 0.3", ">= 0.3.3"
+gem "google-protobuf", ["~> 3.0", "!= 3.7.0", "!= 3.7.1"]
 gem "json-schema", "< 3"
 gem "memory_profiler", "~> 0.9"
+gem "mutex_m"
 gem "os", "~> 1.1"
 gem "pimpmychangelog", ">= 0.1.2"
 gem "pry"
@@ -19,21 +24,16 @@ gem "rspec", "~> 3.13"
 gem "rspec-collection_matchers", "~> 1.1"
 gem "rspec-wait", "~> 0"
 gem "rspec_junit_formatter", ">= 0.5.1"
-gem "simplecov", git: "https://github.com/DataDog/simplecov", ref: "3bb6b7ee58bf4b1954ca205f50dd44d6f41c57db"
-gem "simplecov-cobertura", "~> 2.1.0"
-gem "warning", "~> 1"
-gem "webmock", ">= 3.10.0"
-gem "webrick", ">= 1.8.2"
 gem "rubocop", "~> 1.50.0", require: false
 gem "rubocop-packaging", "~> 0.5.2", require: false
 gem "rubocop-performance", "~> 1.9", require: false
 gem "rubocop-rspec", ["~> 2.20", "< 2.21"], require: false
-gem "dogstatsd-ruby", ">= 3.3.0", "!= 5.0.0", "!= 5.0.1", "!= 5.1.0"
-gem "google-protobuf", ["~> 3.0", "!= 3.7.0", "!= 3.7.1"]
+gem "simplecov", git: "https://github.com/DataDog/simplecov", ref: "3bb6b7ee58bf4b1954ca205f50dd44d6f41c57db"
+gem "simplecov-cobertura", "~> 2.1.0"
 gem "strscan", git: "https://github.com/ruby/strscan", ref: "041b15df4ccc067deabd85fd489b2c15961d0e2f"
-gem "base64"
-gem "bigdecimal"
-gem "mutex_m"
+gem "warning", "~> 1"
+gem "webmock", ">= 3.10.0"
+gem "webrick", ">= 1.8.2"
 gem "redis", ">= 4.0"
 gem "resque", ">= 2.0"
 

--- a/gemfiles/ruby_3.4_sinatra_2.gemfile
+++ b/gemfiles/ruby_3.4_sinatra_2.gemfile
@@ -2,13 +2,18 @@
 
 source "https://rubygems.org"
 
+gem "base64"
 gem "benchmark-ips", "~> 2.8"
 gem "benchmark-memory", "< 0.2"
+gem "bigdecimal"
 gem "climate_control", "~> 0.2.0"
 gem "concurrent-ruby"
+gem "dogstatsd-ruby", ">= 3.3.0", "!= 5.0.0", "!= 5.0.1", "!= 5.1.0"
 gem "extlz4", "~> 0.3", ">= 0.3.3"
+gem "google-protobuf", ["~> 3.0", "!= 3.7.0", "!= 3.7.1"]
 gem "json-schema", "< 3"
 gem "memory_profiler", "~> 0.9"
+gem "mutex_m"
 gem "os", "~> 1.1"
 gem "pimpmychangelog", ">= 0.1.2"
 gem "pry"
@@ -19,21 +24,16 @@ gem "rspec", "~> 3.13"
 gem "rspec-collection_matchers", "~> 1.1"
 gem "rspec-wait", "~> 0"
 gem "rspec_junit_formatter", ">= 0.5.1"
-gem "simplecov", git: "https://github.com/DataDog/simplecov", ref: "3bb6b7ee58bf4b1954ca205f50dd44d6f41c57db"
-gem "simplecov-cobertura", "~> 2.1.0"
-gem "warning", "~> 1"
-gem "webmock", ">= 3.10.0"
-gem "webrick", ">= 1.8.2"
 gem "rubocop", "~> 1.50.0", require: false
 gem "rubocop-packaging", "~> 0.5.2", require: false
 gem "rubocop-performance", "~> 1.9", require: false
 gem "rubocop-rspec", ["~> 2.20", "< 2.21"], require: false
-gem "dogstatsd-ruby", ">= 3.3.0", "!= 5.0.0", "!= 5.0.1", "!= 5.1.0"
-gem "google-protobuf", ["~> 3.0", "!= 3.7.0", "!= 3.7.1"]
+gem "simplecov", git: "https://github.com/DataDog/simplecov", ref: "3bb6b7ee58bf4b1954ca205f50dd44d6f41c57db"
+gem "simplecov-cobertura", "~> 2.1.0"
 gem "strscan", git: "https://github.com/ruby/strscan", ref: "041b15df4ccc067deabd85fd489b2c15961d0e2f"
-gem "base64"
-gem "bigdecimal"
-gem "mutex_m"
+gem "warning", "~> 1"
+gem "webmock", ">= 3.10.0"
+gem "webrick", ">= 1.8.2"
 gem "sinatra", "~> 2"
 gem "rack-contrib"
 gem "rack-test"

--- a/gemfiles/ruby_3.4_sinatra_3.gemfile
+++ b/gemfiles/ruby_3.4_sinatra_3.gemfile
@@ -2,13 +2,18 @@
 
 source "https://rubygems.org"
 
+gem "base64"
 gem "benchmark-ips", "~> 2.8"
 gem "benchmark-memory", "< 0.2"
+gem "bigdecimal"
 gem "climate_control", "~> 0.2.0"
 gem "concurrent-ruby"
+gem "dogstatsd-ruby", ">= 3.3.0", "!= 5.0.0", "!= 5.0.1", "!= 5.1.0"
 gem "extlz4", "~> 0.3", ">= 0.3.3"
+gem "google-protobuf", ["~> 3.0", "!= 3.7.0", "!= 3.7.1"]
 gem "json-schema", "< 3"
 gem "memory_profiler", "~> 0.9"
+gem "mutex_m"
 gem "os", "~> 1.1"
 gem "pimpmychangelog", ">= 0.1.2"
 gem "pry"
@@ -19,21 +24,16 @@ gem "rspec", "~> 3.13"
 gem "rspec-collection_matchers", "~> 1.1"
 gem "rspec-wait", "~> 0"
 gem "rspec_junit_formatter", ">= 0.5.1"
-gem "simplecov", git: "https://github.com/DataDog/simplecov", ref: "3bb6b7ee58bf4b1954ca205f50dd44d6f41c57db"
-gem "simplecov-cobertura", "~> 2.1.0"
-gem "warning", "~> 1"
-gem "webmock", ">= 3.10.0"
-gem "webrick", ">= 1.8.2"
 gem "rubocop", "~> 1.50.0", require: false
 gem "rubocop-packaging", "~> 0.5.2", require: false
 gem "rubocop-performance", "~> 1.9", require: false
 gem "rubocop-rspec", ["~> 2.20", "< 2.21"], require: false
-gem "dogstatsd-ruby", ">= 3.3.0", "!= 5.0.0", "!= 5.0.1", "!= 5.1.0"
-gem "google-protobuf", ["~> 3.0", "!= 3.7.0", "!= 3.7.1"]
+gem "simplecov", git: "https://github.com/DataDog/simplecov", ref: "3bb6b7ee58bf4b1954ca205f50dd44d6f41c57db"
+gem "simplecov-cobertura", "~> 2.1.0"
 gem "strscan", git: "https://github.com/ruby/strscan", ref: "041b15df4ccc067deabd85fd489b2c15961d0e2f"
-gem "base64"
-gem "bigdecimal"
-gem "mutex_m"
+gem "warning", "~> 1"
+gem "webmock", ">= 3.10.0"
+gem "webrick", ">= 1.8.2"
 gem "sinatra", "~> 3"
 gem "rack-contrib"
 gem "rack-test"

--- a/gemfiles/ruby_3.4_sinatra_4.gemfile
+++ b/gemfiles/ruby_3.4_sinatra_4.gemfile
@@ -2,13 +2,18 @@
 
 source "https://rubygems.org"
 
+gem "base64"
 gem "benchmark-ips", "~> 2.8"
 gem "benchmark-memory", "< 0.2"
+gem "bigdecimal"
 gem "climate_control", "~> 0.2.0"
 gem "concurrent-ruby"
+gem "dogstatsd-ruby", ">= 3.3.0", "!= 5.0.0", "!= 5.0.1", "!= 5.1.0"
 gem "extlz4", "~> 0.3", ">= 0.3.3"
+gem "google-protobuf", ["~> 3.0", "!= 3.7.0", "!= 3.7.1"]
 gem "json-schema", "< 3"
 gem "memory_profiler", "~> 0.9"
+gem "mutex_m"
 gem "os", "~> 1.1"
 gem "pimpmychangelog", ">= 0.1.2"
 gem "pry"
@@ -19,21 +24,16 @@ gem "rspec", "~> 3.13"
 gem "rspec-collection_matchers", "~> 1.1"
 gem "rspec-wait", "~> 0"
 gem "rspec_junit_formatter", ">= 0.5.1"
-gem "simplecov", git: "https://github.com/DataDog/simplecov", ref: "3bb6b7ee58bf4b1954ca205f50dd44d6f41c57db"
-gem "simplecov-cobertura", "~> 2.1.0"
-gem "warning", "~> 1"
-gem "webmock", ">= 3.10.0"
-gem "webrick", ">= 1.8.2"
 gem "rubocop", "~> 1.50.0", require: false
 gem "rubocop-packaging", "~> 0.5.2", require: false
 gem "rubocop-performance", "~> 1.9", require: false
 gem "rubocop-rspec", ["~> 2.20", "< 2.21"], require: false
-gem "dogstatsd-ruby", ">= 3.3.0", "!= 5.0.0", "!= 5.0.1", "!= 5.1.0"
-gem "google-protobuf", ["~> 3.0", "!= 3.7.0", "!= 3.7.1"]
+gem "simplecov", git: "https://github.com/DataDog/simplecov", ref: "3bb6b7ee58bf4b1954ca205f50dd44d6f41c57db"
+gem "simplecov-cobertura", "~> 2.1.0"
 gem "strscan", git: "https://github.com/ruby/strscan", ref: "041b15df4ccc067deabd85fd489b2c15961d0e2f"
-gem "base64"
-gem "bigdecimal"
-gem "mutex_m"
+gem "warning", "~> 1"
+gem "webmock", ">= 3.10.0"
+gem "webrick", ">= 1.8.2"
 gem "sinatra", "~> 4"
 gem "rack-contrib"
 gem "rack-test"

--- a/gemfiles/ruby_3.4_stripe_10.gemfile
+++ b/gemfiles/ruby_3.4_stripe_10.gemfile
@@ -2,13 +2,18 @@
 
 source "https://rubygems.org"
 
+gem "base64"
 gem "benchmark-ips", "~> 2.8"
 gem "benchmark-memory", "< 0.2"
+gem "bigdecimal"
 gem "climate_control", "~> 0.2.0"
 gem "concurrent-ruby"
+gem "dogstatsd-ruby", ">= 3.3.0", "!= 5.0.0", "!= 5.0.1", "!= 5.1.0"
 gem "extlz4", "~> 0.3", ">= 0.3.3"
+gem "google-protobuf", ["~> 3.0", "!= 3.7.0", "!= 3.7.1"]
 gem "json-schema", "< 3"
 gem "memory_profiler", "~> 0.9"
+gem "mutex_m"
 gem "os", "~> 1.1"
 gem "pimpmychangelog", ">= 0.1.2"
 gem "pry"
@@ -19,21 +24,16 @@ gem "rspec", "~> 3.13"
 gem "rspec-collection_matchers", "~> 1.1"
 gem "rspec-wait", "~> 0"
 gem "rspec_junit_formatter", ">= 0.5.1"
-gem "simplecov", git: "https://github.com/DataDog/simplecov", ref: "3bb6b7ee58bf4b1954ca205f50dd44d6f41c57db"
-gem "simplecov-cobertura", "~> 2.1.0"
-gem "warning", "~> 1"
-gem "webmock", ">= 3.10.0"
-gem "webrick", ">= 1.8.2"
 gem "rubocop", "~> 1.50.0", require: false
 gem "rubocop-packaging", "~> 0.5.2", require: false
 gem "rubocop-performance", "~> 1.9", require: false
 gem "rubocop-rspec", ["~> 2.20", "< 2.21"], require: false
-gem "dogstatsd-ruby", ">= 3.3.0", "!= 5.0.0", "!= 5.0.1", "!= 5.1.0"
-gem "google-protobuf", ["~> 3.0", "!= 3.7.0", "!= 3.7.1"]
+gem "simplecov", git: "https://github.com/DataDog/simplecov", ref: "3bb6b7ee58bf4b1954ca205f50dd44d6f41c57db"
+gem "simplecov-cobertura", "~> 2.1.0"
 gem "strscan", git: "https://github.com/ruby/strscan", ref: "041b15df4ccc067deabd85fd489b2c15961d0e2f"
-gem "base64"
-gem "bigdecimal"
-gem "mutex_m"
+gem "warning", "~> 1"
+gem "webmock", ">= 3.10.0"
+gem "webrick", ">= 1.8.2"
 gem "stripe", "~> 10"
 
 group :check do

--- a/gemfiles/ruby_3.4_stripe_11.gemfile
+++ b/gemfiles/ruby_3.4_stripe_11.gemfile
@@ -2,13 +2,18 @@
 
 source "https://rubygems.org"
 
+gem "base64"
 gem "benchmark-ips", "~> 2.8"
 gem "benchmark-memory", "< 0.2"
+gem "bigdecimal"
 gem "climate_control", "~> 0.2.0"
 gem "concurrent-ruby"
+gem "dogstatsd-ruby", ">= 3.3.0", "!= 5.0.0", "!= 5.0.1", "!= 5.1.0"
 gem "extlz4", "~> 0.3", ">= 0.3.3"
+gem "google-protobuf", ["~> 3.0", "!= 3.7.0", "!= 3.7.1"]
 gem "json-schema", "< 3"
 gem "memory_profiler", "~> 0.9"
+gem "mutex_m"
 gem "os", "~> 1.1"
 gem "pimpmychangelog", ">= 0.1.2"
 gem "pry"
@@ -19,21 +24,16 @@ gem "rspec", "~> 3.13"
 gem "rspec-collection_matchers", "~> 1.1"
 gem "rspec-wait", "~> 0"
 gem "rspec_junit_formatter", ">= 0.5.1"
-gem "simplecov", git: "https://github.com/DataDog/simplecov", ref: "3bb6b7ee58bf4b1954ca205f50dd44d6f41c57db"
-gem "simplecov-cobertura", "~> 2.1.0"
-gem "warning", "~> 1"
-gem "webmock", ">= 3.10.0"
-gem "webrick", ">= 1.8.2"
 gem "rubocop", "~> 1.50.0", require: false
 gem "rubocop-packaging", "~> 0.5.2", require: false
 gem "rubocop-performance", "~> 1.9", require: false
 gem "rubocop-rspec", ["~> 2.20", "< 2.21"], require: false
-gem "dogstatsd-ruby", ">= 3.3.0", "!= 5.0.0", "!= 5.0.1", "!= 5.1.0"
-gem "google-protobuf", ["~> 3.0", "!= 3.7.0", "!= 3.7.1"]
+gem "simplecov", git: "https://github.com/DataDog/simplecov", ref: "3bb6b7ee58bf4b1954ca205f50dd44d6f41c57db"
+gem "simplecov-cobertura", "~> 2.1.0"
 gem "strscan", git: "https://github.com/ruby/strscan", ref: "041b15df4ccc067deabd85fd489b2c15961d0e2f"
-gem "base64"
-gem "bigdecimal"
-gem "mutex_m"
+gem "warning", "~> 1"
+gem "webmock", ">= 3.10.0"
+gem "webrick", ">= 1.8.2"
 gem "stripe", "~> 11"
 
 group :check do

--- a/gemfiles/ruby_3.4_stripe_12.gemfile
+++ b/gemfiles/ruby_3.4_stripe_12.gemfile
@@ -2,13 +2,18 @@
 
 source "https://rubygems.org"
 
+gem "base64"
 gem "benchmark-ips", "~> 2.8"
 gem "benchmark-memory", "< 0.2"
+gem "bigdecimal"
 gem "climate_control", "~> 0.2.0"
 gem "concurrent-ruby"
+gem "dogstatsd-ruby", ">= 3.3.0", "!= 5.0.0", "!= 5.0.1", "!= 5.1.0"
 gem "extlz4", "~> 0.3", ">= 0.3.3"
+gem "google-protobuf", ["~> 3.0", "!= 3.7.0", "!= 3.7.1"]
 gem "json-schema", "< 3"
 gem "memory_profiler", "~> 0.9"
+gem "mutex_m"
 gem "os", "~> 1.1"
 gem "pimpmychangelog", ">= 0.1.2"
 gem "pry"
@@ -19,21 +24,16 @@ gem "rspec", "~> 3.13"
 gem "rspec-collection_matchers", "~> 1.1"
 gem "rspec-wait", "~> 0"
 gem "rspec_junit_formatter", ">= 0.5.1"
-gem "simplecov", git: "https://github.com/DataDog/simplecov", ref: "3bb6b7ee58bf4b1954ca205f50dd44d6f41c57db"
-gem "simplecov-cobertura", "~> 2.1.0"
-gem "warning", "~> 1"
-gem "webmock", ">= 3.10.0"
-gem "webrick", ">= 1.8.2"
 gem "rubocop", "~> 1.50.0", require: false
 gem "rubocop-packaging", "~> 0.5.2", require: false
 gem "rubocop-performance", "~> 1.9", require: false
 gem "rubocop-rspec", ["~> 2.20", "< 2.21"], require: false
-gem "dogstatsd-ruby", ">= 3.3.0", "!= 5.0.0", "!= 5.0.1", "!= 5.1.0"
-gem "google-protobuf", ["~> 3.0", "!= 3.7.0", "!= 3.7.1"]
+gem "simplecov", git: "https://github.com/DataDog/simplecov", ref: "3bb6b7ee58bf4b1954ca205f50dd44d6f41c57db"
+gem "simplecov-cobertura", "~> 2.1.0"
 gem "strscan", git: "https://github.com/ruby/strscan", ref: "041b15df4ccc067deabd85fd489b2c15961d0e2f"
-gem "base64"
-gem "bigdecimal"
-gem "mutex_m"
+gem "warning", "~> 1"
+gem "webmock", ">= 3.10.0"
+gem "webrick", ">= 1.8.2"
 gem "stripe", "~> 12"
 
 group :check do

--- a/gemfiles/ruby_3.4_stripe_7.gemfile
+++ b/gemfiles/ruby_3.4_stripe_7.gemfile
@@ -2,13 +2,18 @@
 
 source "https://rubygems.org"
 
+gem "base64"
 gem "benchmark-ips", "~> 2.8"
 gem "benchmark-memory", "< 0.2"
+gem "bigdecimal"
 gem "climate_control", "~> 0.2.0"
 gem "concurrent-ruby"
+gem "dogstatsd-ruby", ">= 3.3.0", "!= 5.0.0", "!= 5.0.1", "!= 5.1.0"
 gem "extlz4", "~> 0.3", ">= 0.3.3"
+gem "google-protobuf", ["~> 3.0", "!= 3.7.0", "!= 3.7.1"]
 gem "json-schema", "< 3"
 gem "memory_profiler", "~> 0.9"
+gem "mutex_m"
 gem "os", "~> 1.1"
 gem "pimpmychangelog", ">= 0.1.2"
 gem "pry"
@@ -19,21 +24,16 @@ gem "rspec", "~> 3.13"
 gem "rspec-collection_matchers", "~> 1.1"
 gem "rspec-wait", "~> 0"
 gem "rspec_junit_formatter", ">= 0.5.1"
-gem "simplecov", git: "https://github.com/DataDog/simplecov", ref: "3bb6b7ee58bf4b1954ca205f50dd44d6f41c57db"
-gem "simplecov-cobertura", "~> 2.1.0"
-gem "warning", "~> 1"
-gem "webmock", ">= 3.10.0"
-gem "webrick", ">= 1.8.2"
 gem "rubocop", "~> 1.50.0", require: false
 gem "rubocop-packaging", "~> 0.5.2", require: false
 gem "rubocop-performance", "~> 1.9", require: false
 gem "rubocop-rspec", ["~> 2.20", "< 2.21"], require: false
-gem "dogstatsd-ruby", ">= 3.3.0", "!= 5.0.0", "!= 5.0.1", "!= 5.1.0"
-gem "google-protobuf", ["~> 3.0", "!= 3.7.0", "!= 3.7.1"]
+gem "simplecov", git: "https://github.com/DataDog/simplecov", ref: "3bb6b7ee58bf4b1954ca205f50dd44d6f41c57db"
+gem "simplecov-cobertura", "~> 2.1.0"
 gem "strscan", git: "https://github.com/ruby/strscan", ref: "041b15df4ccc067deabd85fd489b2c15961d0e2f"
-gem "base64"
-gem "bigdecimal"
-gem "mutex_m"
+gem "warning", "~> 1"
+gem "webmock", ">= 3.10.0"
+gem "webrick", ">= 1.8.2"
 gem "stripe", "~> 7"
 
 group :check do

--- a/gemfiles/ruby_3.4_stripe_8.gemfile
+++ b/gemfiles/ruby_3.4_stripe_8.gemfile
@@ -2,13 +2,18 @@
 
 source "https://rubygems.org"
 
+gem "base64"
 gem "benchmark-ips", "~> 2.8"
 gem "benchmark-memory", "< 0.2"
+gem "bigdecimal"
 gem "climate_control", "~> 0.2.0"
 gem "concurrent-ruby"
+gem "dogstatsd-ruby", ">= 3.3.0", "!= 5.0.0", "!= 5.0.1", "!= 5.1.0"
 gem "extlz4", "~> 0.3", ">= 0.3.3"
+gem "google-protobuf", ["~> 3.0", "!= 3.7.0", "!= 3.7.1"]
 gem "json-schema", "< 3"
 gem "memory_profiler", "~> 0.9"
+gem "mutex_m"
 gem "os", "~> 1.1"
 gem "pimpmychangelog", ">= 0.1.2"
 gem "pry"
@@ -19,21 +24,16 @@ gem "rspec", "~> 3.13"
 gem "rspec-collection_matchers", "~> 1.1"
 gem "rspec-wait", "~> 0"
 gem "rspec_junit_formatter", ">= 0.5.1"
-gem "simplecov", git: "https://github.com/DataDog/simplecov", ref: "3bb6b7ee58bf4b1954ca205f50dd44d6f41c57db"
-gem "simplecov-cobertura", "~> 2.1.0"
-gem "warning", "~> 1"
-gem "webmock", ">= 3.10.0"
-gem "webrick", ">= 1.8.2"
 gem "rubocop", "~> 1.50.0", require: false
 gem "rubocop-packaging", "~> 0.5.2", require: false
 gem "rubocop-performance", "~> 1.9", require: false
 gem "rubocop-rspec", ["~> 2.20", "< 2.21"], require: false
-gem "dogstatsd-ruby", ">= 3.3.0", "!= 5.0.0", "!= 5.0.1", "!= 5.1.0"
-gem "google-protobuf", ["~> 3.0", "!= 3.7.0", "!= 3.7.1"]
+gem "simplecov", git: "https://github.com/DataDog/simplecov", ref: "3bb6b7ee58bf4b1954ca205f50dd44d6f41c57db"
+gem "simplecov-cobertura", "~> 2.1.0"
 gem "strscan", git: "https://github.com/ruby/strscan", ref: "041b15df4ccc067deabd85fd489b2c15961d0e2f"
-gem "base64"
-gem "bigdecimal"
-gem "mutex_m"
+gem "warning", "~> 1"
+gem "webmock", ">= 3.10.0"
+gem "webrick", ">= 1.8.2"
 gem "stripe", "~> 8"
 
 group :check do

--- a/gemfiles/ruby_3.4_stripe_9.gemfile
+++ b/gemfiles/ruby_3.4_stripe_9.gemfile
@@ -2,13 +2,18 @@
 
 source "https://rubygems.org"
 
+gem "base64"
 gem "benchmark-ips", "~> 2.8"
 gem "benchmark-memory", "< 0.2"
+gem "bigdecimal"
 gem "climate_control", "~> 0.2.0"
 gem "concurrent-ruby"
+gem "dogstatsd-ruby", ">= 3.3.0", "!= 5.0.0", "!= 5.0.1", "!= 5.1.0"
 gem "extlz4", "~> 0.3", ">= 0.3.3"
+gem "google-protobuf", ["~> 3.0", "!= 3.7.0", "!= 3.7.1"]
 gem "json-schema", "< 3"
 gem "memory_profiler", "~> 0.9"
+gem "mutex_m"
 gem "os", "~> 1.1"
 gem "pimpmychangelog", ">= 0.1.2"
 gem "pry"
@@ -19,21 +24,16 @@ gem "rspec", "~> 3.13"
 gem "rspec-collection_matchers", "~> 1.1"
 gem "rspec-wait", "~> 0"
 gem "rspec_junit_formatter", ">= 0.5.1"
-gem "simplecov", git: "https://github.com/DataDog/simplecov", ref: "3bb6b7ee58bf4b1954ca205f50dd44d6f41c57db"
-gem "simplecov-cobertura", "~> 2.1.0"
-gem "warning", "~> 1"
-gem "webmock", ">= 3.10.0"
-gem "webrick", ">= 1.8.2"
 gem "rubocop", "~> 1.50.0", require: false
 gem "rubocop-packaging", "~> 0.5.2", require: false
 gem "rubocop-performance", "~> 1.9", require: false
 gem "rubocop-rspec", ["~> 2.20", "< 2.21"], require: false
-gem "dogstatsd-ruby", ">= 3.3.0", "!= 5.0.0", "!= 5.0.1", "!= 5.1.0"
-gem "google-protobuf", ["~> 3.0", "!= 3.7.0", "!= 3.7.1"]
+gem "simplecov", git: "https://github.com/DataDog/simplecov", ref: "3bb6b7ee58bf4b1954ca205f50dd44d6f41c57db"
+gem "simplecov-cobertura", "~> 2.1.0"
 gem "strscan", git: "https://github.com/ruby/strscan", ref: "041b15df4ccc067deabd85fd489b2c15961d0e2f"
-gem "base64"
-gem "bigdecimal"
-gem "mutex_m"
+gem "warning", "~> 1"
+gem "webmock", ">= 3.10.0"
+gem "webrick", ">= 1.8.2"
 gem "stripe", "~> 9"
 
 group :check do

--- a/gemfiles/ruby_3.4_stripe_latest.gemfile
+++ b/gemfiles/ruby_3.4_stripe_latest.gemfile
@@ -2,13 +2,18 @@
 
 source "https://rubygems.org"
 
+gem "base64"
 gem "benchmark-ips", "~> 2.8"
 gem "benchmark-memory", "< 0.2"
+gem "bigdecimal"
 gem "climate_control", "~> 0.2.0"
 gem "concurrent-ruby"
+gem "dogstatsd-ruby", ">= 3.3.0", "!= 5.0.0", "!= 5.0.1", "!= 5.1.0"
 gem "extlz4", "~> 0.3", ">= 0.3.3"
+gem "google-protobuf", ["~> 3.0", "!= 3.7.0", "!= 3.7.1"]
 gem "json-schema", "< 3"
 gem "memory_profiler", "~> 0.9"
+gem "mutex_m"
 gem "os", "~> 1.1"
 gem "pimpmychangelog", ">= 0.1.2"
 gem "pry"
@@ -19,21 +24,16 @@ gem "rspec", "~> 3.13"
 gem "rspec-collection_matchers", "~> 1.1"
 gem "rspec-wait", "~> 0"
 gem "rspec_junit_formatter", ">= 0.5.1"
-gem "simplecov", git: "https://github.com/DataDog/simplecov", ref: "3bb6b7ee58bf4b1954ca205f50dd44d6f41c57db"
-gem "simplecov-cobertura", "~> 2.1.0"
-gem "warning", "~> 1"
-gem "webmock", ">= 3.10.0"
-gem "webrick", ">= 1.8.2"
 gem "rubocop", "~> 1.50.0", require: false
 gem "rubocop-packaging", "~> 0.5.2", require: false
 gem "rubocop-performance", "~> 1.9", require: false
 gem "rubocop-rspec", ["~> 2.20", "< 2.21"], require: false
-gem "dogstatsd-ruby", ">= 3.3.0", "!= 5.0.0", "!= 5.0.1", "!= 5.1.0"
-gem "google-protobuf", ["~> 3.0", "!= 3.7.0", "!= 3.7.1"]
+gem "simplecov", git: "https://github.com/DataDog/simplecov", ref: "3bb6b7ee58bf4b1954ca205f50dd44d6f41c57db"
+gem "simplecov-cobertura", "~> 2.1.0"
 gem "strscan", git: "https://github.com/ruby/strscan", ref: "041b15df4ccc067deabd85fd489b2c15961d0e2f"
-gem "base64"
-gem "bigdecimal"
-gem "mutex_m"
+gem "warning", "~> 1"
+gem "webmock", ">= 3.10.0"
+gem "webrick", ">= 1.8.2"
 gem "stripe"
 
 group :check do

--- a/gemfiles/ruby_3.4_stripe_min.gemfile
+++ b/gemfiles/ruby_3.4_stripe_min.gemfile
@@ -2,13 +2,18 @@
 
 source "https://rubygems.org"
 
+gem "base64"
 gem "benchmark-ips", "~> 2.8"
 gem "benchmark-memory", "< 0.2"
+gem "bigdecimal"
 gem "climate_control", "~> 0.2.0"
 gem "concurrent-ruby"
+gem "dogstatsd-ruby", ">= 3.3.0", "!= 5.0.0", "!= 5.0.1", "!= 5.1.0"
 gem "extlz4", "~> 0.3", ">= 0.3.3"
+gem "google-protobuf", ["~> 3.0", "!= 3.7.0", "!= 3.7.1"]
 gem "json-schema", "< 3"
 gem "memory_profiler", "~> 0.9"
+gem "mutex_m"
 gem "os", "~> 1.1"
 gem "pimpmychangelog", ">= 0.1.2"
 gem "pry"
@@ -19,21 +24,16 @@ gem "rspec", "~> 3.13"
 gem "rspec-collection_matchers", "~> 1.1"
 gem "rspec-wait", "~> 0"
 gem "rspec_junit_formatter", ">= 0.5.1"
-gem "simplecov", git: "https://github.com/DataDog/simplecov", ref: "3bb6b7ee58bf4b1954ca205f50dd44d6f41c57db"
-gem "simplecov-cobertura", "~> 2.1.0"
-gem "warning", "~> 1"
-gem "webmock", ">= 3.10.0"
-gem "webrick", ">= 1.8.2"
 gem "rubocop", "~> 1.50.0", require: false
 gem "rubocop-packaging", "~> 0.5.2", require: false
 gem "rubocop-performance", "~> 1.9", require: false
 gem "rubocop-rspec", ["~> 2.20", "< 2.21"], require: false
-gem "dogstatsd-ruby", ">= 3.3.0", "!= 5.0.0", "!= 5.0.1", "!= 5.1.0"
-gem "google-protobuf", ["~> 3.0", "!= 3.7.0", "!= 3.7.1"]
+gem "simplecov", git: "https://github.com/DataDog/simplecov", ref: "3bb6b7ee58bf4b1954ca205f50dd44d6f41c57db"
+gem "simplecov-cobertura", "~> 2.1.0"
 gem "strscan", git: "https://github.com/ruby/strscan", ref: "041b15df4ccc067deabd85fd489b2c15961d0e2f"
-gem "base64"
-gem "bigdecimal"
-gem "mutex_m"
+gem "warning", "~> 1"
+gem "webmock", ">= 3.10.0"
+gem "webrick", ">= 1.8.2"
 gem "stripe", "= 5.15.0"
 
 group :check do

--- a/ruby-3.4.gemfile
+++ b/ruby-3.4.gemfile
@@ -8,22 +8,14 @@ gem 'benchmark-memory', '< 0.2' # V0.2 only works with 2.5+
 gem 'climate_control', '~> 0.2.0'
 
 gem 'concurrent-ruby'
-gem 'extlz4', '~> 0.3', '>= 0.3.3' if RUBY_PLATFORM != 'java' # Used to test lz4 compression done by libdatadog
+gem 'extlz4', '~> 0.3', '>= 0.3.3'
 gem 'json-schema', '< 3' # V3 only works with 2.5+
 gem 'memory_profiler', '~> 0.9'
 
 gem 'os', '~> 1.1'
 gem 'pimpmychangelog', '>= 0.1.2'
 gem 'pry'
-if RUBY_PLATFORM != 'java'
-  # There's a few incompatibilities between pry/pry-byebug on older Rubies
-  # There's also a few temproary incompatibilities with newer rubies
-  gem 'pry-byebug' if RUBY_VERSION >= '2.6.0' && RUBY_ENGINE != 'truffleruby' && RUBY_VERSION < '3.2.0'
-  gem 'pry-nav' if RUBY_VERSION < '2.6.0'
-  gem 'pry-stack_explorer'
-else
-  gem 'pry-debugger-jruby'
-end
+gem 'pry-stack_explorer'
 gem 'rake', '>= 10.5'
 gem 'rake-compiler', '~> 1.1', '>= 1.1.1' # To compile native extensions
 gem 'rspec', '~> 3.13'
@@ -42,16 +34,14 @@ gem 'warning', '~> 1' # NOTE: Used in spec_helper.rb
 gem 'webmock', '>= 3.10.0'
 
 # No longer bundled by default since Ruby 3.0
-gem 'webrick', '>= 1.8.2' if RUBY_VERSION >= '3.0.0'
+gem 'webrick', '>= 1.8.2'
 
-if RUBY_VERSION >= '2.6.0'
-  # 1.50 is the last version to support Ruby 2.6
-  gem 'rubocop', '~> 1.50.0', require: false
-  gem 'rubocop-packaging', '~> 0.5.2', require: false
-  gem 'rubocop-performance', '~> 1.9', require: false
-  # 2.20 is the last version to support Ruby 2.6
-  gem 'rubocop-rspec', ['~> 2.20', '< 2.21'], require: false
-end
+# 1.50 is the last version to support Ruby 2.6
+gem 'rubocop', '~> 1.50.0', require: false
+gem 'rubocop-packaging', '~> 0.5.2', require: false
+gem 'rubocop-performance', '~> 1.9', require: false
+# 2.20 is the last version to support Ruby 2.6
+gem 'rubocop-rspec', ['~> 2.20', '< 2.21'], require: false
 
 # Optional extensions
 # TODO: Move this to Appraisals?
@@ -63,25 +53,17 @@ gem 'dogstatsd-ruby', '>= 3.3.0', '!= 5.0.0', '!= 5.0.1', '!= 5.1.0'
 # NOTE: We're excluding versions 3.7.0 and 3.7.1 for the reasons documented in #1424.
 #       Since most of our customers won't have BUNDLE_FORCE_RUBY_PLATFORM=true, it's not something we want to add
 #       to our CI, so we just shortcut and exclude specific versions that were affecting our CI.
-if RUBY_PLATFORM != 'java'
-  if RUBY_VERSION >= '2.7.0' # Bundler 1.x fails to find that versions >= 3.8.0 are not compatible because of binary gems
-    gem 'google-protobuf', ['~> 3.0', '!= 3.7.0', '!= 3.7.1']
-  else
-    gem 'google-protobuf', ['~> 3.0', '!= 3.7.0', '!= 3.7.1', '< 3.19.2']
-  end
-end
+gem 'google-protobuf', ['~> 3.0', '!= 3.7.0', '!= 3.7.1']
 
 group :check do
-  if RUBY_VERSION >= '3.0.0' && RUBY_PLATFORM != 'java'
-    gem 'rbs', '~> 3.6', require: false
-    gem 'steep', '~> 1.7.0', require: false
-  end
-  gem 'ruby_memcheck', '>= 3' if RUBY_VERSION >= '3.4.0' && RUBY_PLATFORM != 'java'
+  gem 'rbs', '~> 3.6', require: false
+  gem 'steep', '~> 1.7.0', require: false
+  gem 'ruby_memcheck', '>= 3'
   gem 'standard', require: false
 end
 
 group :dev do
-  gem 'ruby-lsp', require: false if RUBY_VERSION >= '3.0.0' && RUBY_PLATFORM != 'java'
+  gem 'ruby-lsp', require: false
   gem 'appraisal', '~> 2.4.0', require: false
 end
 

--- a/ruby-3.4.gemfile
+++ b/ruby-3.4.gemfile
@@ -2,16 +2,30 @@ source 'https://rubygems.org'
 
 gemspec
 
+gem 'base64'
 gem 'benchmark-ips', '~> 2.8'
 gem 'benchmark-memory', '< 0.2' # V0.2 only works with 2.5+
-
+gem 'bigdecimal'
 gem 'climate_control', '~> 0.2.0'
-
 gem 'concurrent-ruby'
+
+# Optional extensions
+# TODO: Move this to Appraisals?
+# dogstatsd v5, but lower than 5.2, has possible memory leak with datadog.
+# @see https://github.com/DataDog/dogstatsd-ruby/issues/182
+gem 'dogstatsd-ruby', '>= 3.3.0', '!= 5.0.0', '!= 5.0.1', '!= 5.1.0'
+
 gem 'extlz4', '~> 0.3', '>= 0.3.3'
+
+# Profiler testing dependencies
+# NOTE: We're excluding versions 3.7.0 and 3.7.1 for the reasons documented in #1424.
+#       Since most of our customers won't have BUNDLE_FORCE_RUBY_PLATFORM=true, it's not something we want to add
+#       to our CI, so we just shortcut and exclude specific versions that were affecting our CI.
+gem 'google-protobuf', ['~> 3.0', '!= 3.7.0', '!= 3.7.1']
+
 gem 'json-schema', '< 3' # V3 only works with 2.5+
 gem 'memory_profiler', '~> 0.9'
-
+gem 'mutex_m'
 gem 'os', '~> 1.1'
 gem 'pimpmychangelog', '>= 0.1.2'
 gem 'pry'
@@ -21,20 +35,7 @@ gem 'rake-compiler', '~> 1.1', '>= 1.1.1' # To compile native extensions
 gem 'rspec', '~> 3.13'
 gem 'rspec-collection_matchers', '~> 1.1'
 gem 'rspec-wait', '~> 0'
-
 gem 'rspec_junit_formatter', '>= 0.5.1'
-
-# Merging branch coverage results does not work for old, unsupported rubies and JRuby
-# We have a fix up for review, https://github.com/simplecov-ruby/simplecov/pull/972,
-# but given it only affects unsupported version of Ruby, it might not get merged.
-gem 'simplecov', git: 'https://github.com/DataDog/simplecov', ref: '3bb6b7ee58bf4b1954ca205f50dd44d6f41c57db'
-gem 'simplecov-cobertura', '~> 2.1.0' # Used by codecov
-
-gem 'warning', '~> 1' # NOTE: Used in spec_helper.rb
-gem 'webmock', '>= 3.10.0'
-
-# No longer bundled by default since Ruby 3.0
-gem 'webrick', '>= 1.8.2'
 
 # 1.50 is the last version to support Ruby 2.6
 gem 'rubocop', '~> 1.50.0', require: false
@@ -43,17 +44,23 @@ gem 'rubocop-performance', '~> 1.9', require: false
 # 2.20 is the last version to support Ruby 2.6
 gem 'rubocop-rspec', ['~> 2.20', '< 2.21'], require: false
 
-# Optional extensions
-# TODO: Move this to Appraisals?
-# dogstatsd v5, but lower than 5.2, has possible memory leak with datadog.
-# @see https://github.com/DataDog/dogstatsd-ruby/issues/182
-gem 'dogstatsd-ruby', '>= 3.3.0', '!= 5.0.0', '!= 5.0.1', '!= 5.1.0'
+# Merging branch coverage results does not work for old, unsupported rubies and JRuby
+# We have a fix up for review, https://github.com/simplecov-ruby/simplecov/pull/972,
+# but given it only affects unsupported version of Ruby, it might not get merged.
+gem 'simplecov', git: 'https://github.com/DataDog/simplecov', ref: '3bb6b7ee58bf4b1954ca205f50dd44d6f41c57db'
+gem 'simplecov-cobertura', '~> 2.1.0' # Used by codecov
 
-# Profiler testing dependencies
-# NOTE: We're excluding versions 3.7.0 and 3.7.1 for the reasons documented in #1424.
-#       Since most of our customers won't have BUNDLE_FORCE_RUBY_PLATFORM=true, it's not something we want to add
-#       to our CI, so we just shortcut and exclude specific versions that were affecting our CI.
-gem 'google-protobuf', ['~> 3.0', '!= 3.7.0', '!= 3.7.1']
+# Ruby 3.4 should be supported by strscan v3.1.1. However, the latest release of strscan is v3.1.0.
+# Pin strscan to the latest commit sha.
+#
+# TODO: Remove once v3.1.1 is released.
+gem 'strscan',
+  git: 'https://github.com/ruby/strscan',
+  ref: '041b15df4ccc067deabd85fd489b2c15961d0e2f'
+
+gem 'warning', '~> 1' # NOTE: Used in spec_helper.rb
+gem 'webmock', '>= 3.10.0'
+gem 'webrick', '>= 1.8.2'
 
 group :check do
   gem 'rbs', '~> 3.6', require: false
@@ -66,16 +73,3 @@ group :dev do
   gem 'ruby-lsp', require: false
   gem 'appraisal', '~> 2.4.0', require: false
 end
-
-# Ruby 3.4 should be supported by strscan v3.1.1. However, the latest release of strscan is v3.1.0.
-# Pin strscan to the latest commit sha.
-#
-# TODO: Remove once v3.1.1 is released.
-gem 'strscan',
-  git: 'https://github.com/ruby/strscan',
-  ref: '041b15df4ccc067deabd85fd489b2c15961d0e2f'
-
-# No longer bundled by default since Ruby 3.4
-gem 'base64'
-gem 'bigdecimal'
-gem 'mutex_m'


### PR DESCRIPTION
<!--
Check out the
https://github.com/DataDog/dd-trace-rb/blob/master/docs/DevelopmentGuide.md
for guidance on how to set up your development environment,
run the test suite, write new integrations, and more.
-->

**What does this PR do?**
This PR removes `if` statements and alphabetizes `ruby-3.4.gemfile`.

**Motivation:**
Since the gemfiles are no longer symlinked, we can begin removing `if` statements and generally cleaning each file.

**Change log entry**
None.

**Additional Notes:**
N/A

**How to test the change?**
Green CI.

<!-- Unsure? Have a question? Request a review! -->
