### PR TITLE
Clean Ruby 3.x Gemfiles

### DIFF
--- a/gemfiles/ruby_3.0_activesupport.gemfile
+++ b/gemfiles/ruby_3.0_activesupport.gemfile
@@ -6,7 +6,9 @@ gem "benchmark-ips", "~> 2.8"
 gem "benchmark-memory", "< 0.2"
 gem "climate_control", "~> 0.2.0"
 gem "concurrent-ruby"
+gem "dogstatsd-ruby", ">= 3.3.0", "!= 5.0.0", "!= 5.0.1", "!= 5.1.0"
 gem "extlz4", "~> 0.3", ">= 0.3.3"
+gem "google-protobuf", ["~> 3.0", "!= 3.7.0", "!= 3.7.1"]
 gem "json-schema", "< 3"
 gem "memory_profiler", "~> 0.9"
 gem "os", "~> 1.1"
@@ -20,17 +22,15 @@ gem "rspec", "~> 3.13"
 gem "rspec-collection_matchers", "~> 1.1"
 gem "rspec-wait", "~> 0"
 gem "rspec_junit_formatter", ">= 0.5.1"
+gem "rubocop", "~> 1.50.0", require: false
+gem "rubocop-packaging", "~> 0.5.2", require: false
+gem "rubocop-performance", "~> 1.9", require: false
+gem "rubocop-rspec", ["~> 2.20", "< 2.21"], require: false
 gem "simplecov", git: "https://github.com/DataDog/simplecov", ref: "3bb6b7ee58bf4b1954ca205f50dd44d6f41c57db"
 gem "simplecov-cobertura", "~> 2.1.0"
 gem "warning", "~> 1"
 gem "webmock", ">= 3.10.0"
 gem "webrick", ">= 1.7.0"
-gem "rubocop", "~> 1.50.0", require: false
-gem "rubocop-packaging", "~> 0.5.2", require: false
-gem "rubocop-performance", "~> 1.9", require: false
-gem "rubocop-rspec", ["~> 2.20", "< 2.21"], require: false
-gem "dogstatsd-ruby", ">= 3.3.0", "!= 5.0.0", "!= 5.0.1", "!= 5.1.0"
-gem "google-protobuf", ["~> 3.0", "!= 3.7.0", "!= 3.7.1"]
 gem "activesupport", "~> 7"
 gem "actionpack"
 gem "actionview"

--- a/gemfiles/ruby_3.0_aws.gemfile
+++ b/gemfiles/ruby_3.0_aws.gemfile
@@ -6,7 +6,9 @@ gem "benchmark-ips", "~> 2.8"
 gem "benchmark-memory", "< 0.2"
 gem "climate_control", "~> 0.2.0"
 gem "concurrent-ruby"
+gem "dogstatsd-ruby", ">= 3.3.0", "!= 5.0.0", "!= 5.0.1", "!= 5.1.0"
 gem "extlz4", "~> 0.3", ">= 0.3.3"
+gem "google-protobuf", ["~> 3.0", "!= 3.7.0", "!= 3.7.1"]
 gem "json-schema", "< 3"
 gem "memory_profiler", "~> 0.9"
 gem "os", "~> 1.1"
@@ -20,17 +22,15 @@ gem "rspec", "~> 3.13"
 gem "rspec-collection_matchers", "~> 1.1"
 gem "rspec-wait", "~> 0"
 gem "rspec_junit_formatter", ">= 0.5.1"
+gem "rubocop", "~> 1.50.0", require: false
+gem "rubocop-packaging", "~> 0.5.2", require: false
+gem "rubocop-performance", "~> 1.9", require: false
+gem "rubocop-rspec", ["~> 2.20", "< 2.21"], require: false
 gem "simplecov", git: "https://github.com/DataDog/simplecov", ref: "3bb6b7ee58bf4b1954ca205f50dd44d6f41c57db"
 gem "simplecov-cobertura", "~> 2.1.0"
 gem "warning", "~> 1"
 gem "webmock", ">= 3.10.0"
 gem "webrick", ">= 1.7.0"
-gem "rubocop", "~> 1.50.0", require: false
-gem "rubocop-packaging", "~> 0.5.2", require: false
-gem "rubocop-performance", "~> 1.9", require: false
-gem "rubocop-rspec", ["~> 2.20", "< 2.21"], require: false
-gem "dogstatsd-ruby", ">= 3.3.0", "!= 5.0.0", "!= 5.0.1", "!= 5.1.0"
-gem "google-protobuf", ["~> 3.0", "!= 3.7.0", "!= 3.7.1"]
 gem "aws-sdk"
 gem "shoryuken"
 

--- a/gemfiles/ruby_3.0_contrib.gemfile
+++ b/gemfiles/ruby_3.0_contrib.gemfile
@@ -6,7 +6,9 @@ gem "benchmark-ips", "~> 2.8"
 gem "benchmark-memory", "< 0.2"
 gem "climate_control", "~> 0.2.0"
 gem "concurrent-ruby"
+gem "dogstatsd-ruby", ">= 3.3.0", "!= 5.0.0", "!= 5.0.1", "!= 5.1.0"
 gem "extlz4", "~> 0.3", ">= 0.3.3"
+gem "google-protobuf", ["~> 3.0", "!= 3.7.0", "!= 3.7.1"]
 gem "json-schema", "< 3"
 gem "memory_profiler", "~> 0.9"
 gem "os", "~> 1.1"
@@ -20,17 +22,15 @@ gem "rspec", "~> 3.13"
 gem "rspec-collection_matchers", "~> 1.1"
 gem "rspec-wait", "~> 0"
 gem "rspec_junit_formatter", ">= 0.5.1"
+gem "rubocop", "~> 1.50.0", require: false
+gem "rubocop-packaging", "~> 0.5.2", require: false
+gem "rubocop-performance", "~> 1.9", require: false
+gem "rubocop-rspec", ["~> 2.20", "< 2.21"], require: false
 gem "simplecov", git: "https://github.com/DataDog/simplecov", ref: "3bb6b7ee58bf4b1954ca205f50dd44d6f41c57db"
 gem "simplecov-cobertura", "~> 2.1.0"
 gem "warning", "~> 1"
 gem "webmock", ">= 3.10.0"
 gem "webrick", ">= 1.7.0"
-gem "rubocop", "~> 1.50.0", require: false
-gem "rubocop-packaging", "~> 0.5.2", require: false
-gem "rubocop-performance", "~> 1.9", require: false
-gem "rubocop-rspec", ["~> 2.20", "< 2.21"], require: false
-gem "dogstatsd-ruby", ">= 3.3.0", "!= 5.0.0", "!= 5.0.1", "!= 5.1.0"
-gem "google-protobuf", ["~> 3.0", "!= 3.7.0", "!= 3.7.1"]
 gem "dalli", ">= 3.0.0"
 gem "grpc", ">= 1.38.0", platform: :ruby
 gem "mongo", ">= 2.8.0", "< 2.15.0"

--- a/gemfiles/ruby_3.0_contrib_old.gemfile
+++ b/gemfiles/ruby_3.0_contrib_old.gemfile
@@ -6,7 +6,9 @@ gem "benchmark-ips", "~> 2.8"
 gem "benchmark-memory", "< 0.2"
 gem "climate_control", "~> 0.2.0"
 gem "concurrent-ruby"
+gem "dogstatsd-ruby", ">= 3.3.0", "!= 5.0.0", "!= 5.0.1", "!= 5.1.0"
 gem "extlz4", "~> 0.3", ">= 0.3.3"
+gem "google-protobuf", ["~> 3.0", "!= 3.7.0", "!= 3.7.1"]
 gem "json-schema", "< 3"
 gem "memory_profiler", "~> 0.9"
 gem "os", "~> 1.1"
@@ -20,17 +22,15 @@ gem "rspec", "~> 3.13"
 gem "rspec-collection_matchers", "~> 1.1"
 gem "rspec-wait", "~> 0"
 gem "rspec_junit_formatter", ">= 0.5.1"
+gem "rubocop", "~> 1.50.0", require: false
+gem "rubocop-packaging", "~> 0.5.2", require: false
+gem "rubocop-performance", "~> 1.9", require: false
+gem "rubocop-rspec", ["~> 2.20", "< 2.21"], require: false
 gem "simplecov", git: "https://github.com/DataDog/simplecov", ref: "3bb6b7ee58bf4b1954ca205f50dd44d6f41c57db"
 gem "simplecov-cobertura", "~> 2.1.0"
 gem "warning", "~> 1"
 gem "webmock", ">= 3.10.0"
 gem "webrick", ">= 1.7.0"
-gem "rubocop", "~> 1.50.0", require: false
-gem "rubocop-packaging", "~> 0.5.2", require: false
-gem "rubocop-performance", "~> 1.9", require: false
-gem "rubocop-rspec", ["~> 2.20", "< 2.21"], require: false
-gem "dogstatsd-ruby", ">= 3.3.0", "!= 5.0.0", "!= 5.0.1", "!= 5.1.0"
-gem "google-protobuf", ["~> 3.0", "!= 3.7.0", "!= 3.7.1"]
 gem "dalli", "< 3.0.0"
 gem "presto-client", ">= 0.5.14"
 gem "qless", "0.12.0"

--- a/gemfiles/ruby_3.0_core_old.gemfile
+++ b/gemfiles/ruby_3.0_core_old.gemfile
@@ -6,7 +6,9 @@ gem "benchmark-ips", "~> 2.8"
 gem "benchmark-memory", "< 0.2"
 gem "climate_control", "~> 0.2.0"
 gem "concurrent-ruby"
+gem "dogstatsd-ruby", "~> 4"
 gem "extlz4", "~> 0.3", ">= 0.3.3"
+gem "google-protobuf", ["~> 3.0", "!= 3.7.0", "!= 3.7.1"]
 gem "json-schema", "< 3"
 gem "memory_profiler", "~> 0.9"
 gem "os", "~> 1.1"
@@ -20,17 +22,15 @@ gem "rspec", "~> 3.13"
 gem "rspec-collection_matchers", "~> 1.1"
 gem "rspec-wait", "~> 0"
 gem "rspec_junit_formatter", ">= 0.5.1"
+gem "rubocop", "~> 1.50.0", require: false
+gem "rubocop-packaging", "~> 0.5.2", require: false
+gem "rubocop-performance", "~> 1.9", require: false
+gem "rubocop-rspec", ["~> 2.20", "< 2.21"], require: false
 gem "simplecov", git: "https://github.com/DataDog/simplecov", ref: "3bb6b7ee58bf4b1954ca205f50dd44d6f41c57db"
 gem "simplecov-cobertura", "~> 2.1.0"
 gem "warning", "~> 1"
 gem "webmock", ">= 3.10.0"
 gem "webrick", ">= 1.7.0"
-gem "rubocop", "~> 1.50.0", require: false
-gem "rubocop-packaging", "~> 0.5.2", require: false
-gem "rubocop-performance", "~> 1.9", require: false
-gem "rubocop-rspec", ["~> 2.20", "< 2.21"], require: false
-gem "dogstatsd-ruby", "~> 4"
-gem "google-protobuf", ["~> 3.0", "!= 3.7.0", "!= 3.7.1"]
 
 group :check do
 

--- a/gemfiles/ruby_3.0_elasticsearch_7.gemfile
+++ b/gemfiles/ruby_3.0_elasticsearch_7.gemfile
@@ -6,7 +6,9 @@ gem "benchmark-ips", "~> 2.8"
 gem "benchmark-memory", "< 0.2"
 gem "climate_control", "~> 0.2.0"
 gem "concurrent-ruby"
+gem "dogstatsd-ruby", ">= 3.3.0", "!= 5.0.0", "!= 5.0.1", "!= 5.1.0"
 gem "extlz4", "~> 0.3", ">= 0.3.3"
+gem "google-protobuf", ["~> 3.0", "!= 3.7.0", "!= 3.7.1"]
 gem "json-schema", "< 3"
 gem "memory_profiler", "~> 0.9"
 gem "os", "~> 1.1"
@@ -20,17 +22,15 @@ gem "rspec", "~> 3.13"
 gem "rspec-collection_matchers", "~> 1.1"
 gem "rspec-wait", "~> 0"
 gem "rspec_junit_formatter", ">= 0.5.1"
+gem "rubocop", "~> 1.50.0", require: false
+gem "rubocop-packaging", "~> 0.5.2", require: false
+gem "rubocop-performance", "~> 1.9", require: false
+gem "rubocop-rspec", ["~> 2.20", "< 2.21"], require: false
 gem "simplecov", git: "https://github.com/DataDog/simplecov", ref: "3bb6b7ee58bf4b1954ca205f50dd44d6f41c57db"
 gem "simplecov-cobertura", "~> 2.1.0"
 gem "warning", "~> 1"
 gem "webmock", ">= 3.10.0"
 gem "webrick", ">= 1.7.0"
-gem "rubocop", "~> 1.50.0", require: false
-gem "rubocop-packaging", "~> 0.5.2", require: false
-gem "rubocop-performance", "~> 1.9", require: false
-gem "rubocop-rspec", ["~> 2.20", "< 2.21"], require: false
-gem "dogstatsd-ruby", ">= 3.3.0", "!= 5.0.0", "!= 5.0.1", "!= 5.1.0"
-gem "google-protobuf", ["~> 3.0", "!= 3.7.0", "!= 3.7.1"]
 gem "elasticsearch", "~> 7"
 
 group :check do

--- a/gemfiles/ruby_3.0_elasticsearch_8.gemfile
+++ b/gemfiles/ruby_3.0_elasticsearch_8.gemfile
@@ -6,7 +6,9 @@ gem "benchmark-ips", "~> 2.8"
 gem "benchmark-memory", "< 0.2"
 gem "climate_control", "~> 0.2.0"
 gem "concurrent-ruby"
+gem "dogstatsd-ruby", ">= 3.3.0", "!= 5.0.0", "!= 5.0.1", "!= 5.1.0"
 gem "extlz4", "~> 0.3", ">= 0.3.3"
+gem "google-protobuf", ["~> 3.0", "!= 3.7.0", "!= 3.7.1"]
 gem "json-schema", "< 3"
 gem "memory_profiler", "~> 0.9"
 gem "os", "~> 1.1"
@@ -20,17 +22,15 @@ gem "rspec", "~> 3.13"
 gem "rspec-collection_matchers", "~> 1.1"
 gem "rspec-wait", "~> 0"
 gem "rspec_junit_formatter", ">= 0.5.1"
+gem "rubocop", "~> 1.50.0", require: false
+gem "rubocop-packaging", "~> 0.5.2", require: false
+gem "rubocop-performance", "~> 1.9", require: false
+gem "rubocop-rspec", ["~> 2.20", "< 2.21"], require: false
 gem "simplecov", git: "https://github.com/DataDog/simplecov", ref: "3bb6b7ee58bf4b1954ca205f50dd44d6f41c57db"
 gem "simplecov-cobertura", "~> 2.1.0"
 gem "warning", "~> 1"
 gem "webmock", ">= 3.10.0"
 gem "webrick", ">= 1.7.0"
-gem "rubocop", "~> 1.50.0", require: false
-gem "rubocop-packaging", "~> 0.5.2", require: false
-gem "rubocop-performance", "~> 1.9", require: false
-gem "rubocop-rspec", ["~> 2.20", "< 2.21"], require: false
-gem "dogstatsd-ruby", ">= 3.3.0", "!= 5.0.0", "!= 5.0.1", "!= 5.1.0"
-gem "google-protobuf", ["~> 3.0", "!= 3.7.0", "!= 3.7.1"]
 gem "elasticsearch", "~> 8"
 
 group :check do

--- a/gemfiles/ruby_3.0_elasticsearch_latest.gemfile
+++ b/gemfiles/ruby_3.0_elasticsearch_latest.gemfile
@@ -6,7 +6,9 @@ gem "benchmark-ips", "~> 2.8"
 gem "benchmark-memory", "< 0.2"
 gem "climate_control", "~> 0.2.0"
 gem "concurrent-ruby"
+gem "dogstatsd-ruby", ">= 3.3.0", "!= 5.0.0", "!= 5.0.1", "!= 5.1.0"
 gem "extlz4", "~> 0.3", ">= 0.3.3"
+gem "google-protobuf", ["~> 3.0", "!= 3.7.0", "!= 3.7.1"]
 gem "json-schema", "< 3"
 gem "memory_profiler", "~> 0.9"
 gem "os", "~> 1.1"
@@ -20,17 +22,15 @@ gem "rspec", "~> 3.13"
 gem "rspec-collection_matchers", "~> 1.1"
 gem "rspec-wait", "~> 0"
 gem "rspec_junit_formatter", ">= 0.5.1"
+gem "rubocop", "~> 1.50.0", require: false
+gem "rubocop-packaging", "~> 0.5.2", require: false
+gem "rubocop-performance", "~> 1.9", require: false
+gem "rubocop-rspec", ["~> 2.20", "< 2.21"], require: false
 gem "simplecov", git: "https://github.com/DataDog/simplecov", ref: "3bb6b7ee58bf4b1954ca205f50dd44d6f41c57db"
 gem "simplecov-cobertura", "~> 2.1.0"
 gem "warning", "~> 1"
 gem "webmock", ">= 3.10.0"
 gem "webrick", ">= 1.7.0"
-gem "rubocop", "~> 1.50.0", require: false
-gem "rubocop-packaging", "~> 0.5.2", require: false
-gem "rubocop-performance", "~> 1.9", require: false
-gem "rubocop-rspec", ["~> 2.20", "< 2.21"], require: false
-gem "dogstatsd-ruby", ">= 3.3.0", "!= 5.0.0", "!= 5.0.1", "!= 5.1.0"
-gem "google-protobuf", ["~> 3.0", "!= 3.7.0", "!= 3.7.1"]
 gem "elasticsearch"
 
 group :check do

--- a/gemfiles/ruby_3.0_graphql_1.13.gemfile
+++ b/gemfiles/ruby_3.0_graphql_1.13.gemfile
@@ -6,7 +6,9 @@ gem "benchmark-ips", "~> 2.8"
 gem "benchmark-memory", "< 0.2"
 gem "climate_control", "~> 0.2.0"
 gem "concurrent-ruby"
+gem "dogstatsd-ruby", ">= 3.3.0", "!= 5.0.0", "!= 5.0.1", "!= 5.1.0"
 gem "extlz4", "~> 0.3", ">= 0.3.3"
+gem "google-protobuf", ["~> 3.0", "!= 3.7.0", "!= 3.7.1"]
 gem "json-schema", "< 3"
 gem "memory_profiler", "~> 0.9"
 gem "os", "~> 1.1"
@@ -20,17 +22,15 @@ gem "rspec", "~> 3.13"
 gem "rspec-collection_matchers", "~> 1.1"
 gem "rspec-wait", "~> 0"
 gem "rspec_junit_formatter", ">= 0.5.1"
+gem "rubocop", "~> 1.50.0", require: false
+gem "rubocop-packaging", "~> 0.5.2", require: false
+gem "rubocop-performance", "~> 1.9", require: false
+gem "rubocop-rspec", ["~> 2.20", "< 2.21"], require: false
 gem "simplecov", git: "https://github.com/DataDog/simplecov", ref: "3bb6b7ee58bf4b1954ca205f50dd44d6f41c57db"
 gem "simplecov-cobertura", "~> 2.1.0"
 gem "warning", "~> 1"
 gem "webmock", ">= 3.10.0"
 gem "webrick", ">= 1.7.0"
-gem "rubocop", "~> 1.50.0", require: false
-gem "rubocop-packaging", "~> 0.5.2", require: false
-gem "rubocop-performance", "~> 1.9", require: false
-gem "rubocop-rspec", ["~> 2.20", "< 2.21"], require: false
-gem "dogstatsd-ruby", ">= 3.3.0", "!= 5.0.0", "!= 5.0.1", "!= 5.1.0"
-gem "google-protobuf", ["~> 3.0", "!= 3.7.0", "!= 3.7.1"]
 gem "rails", "~> 6.1.0"
 gem "graphql", "~> 1.13.0"
 gem "sprockets", "< 4"

--- a/gemfiles/ruby_3.0_graphql_2.0.gemfile
+++ b/gemfiles/ruby_3.0_graphql_2.0.gemfile
@@ -6,7 +6,9 @@ gem "benchmark-ips", "~> 2.8"
 gem "benchmark-memory", "< 0.2"
 gem "climate_control", "~> 0.2.0"
 gem "concurrent-ruby"
+gem "dogstatsd-ruby", ">= 3.3.0", "!= 5.0.0", "!= 5.0.1", "!= 5.1.0"
 gem "extlz4", "~> 0.3", ">= 0.3.3"
+gem "google-protobuf", ["~> 3.0", "!= 3.7.0", "!= 3.7.1"]
 gem "json-schema", "< 3"
 gem "memory_profiler", "~> 0.9"
 gem "os", "~> 1.1"
@@ -20,17 +22,15 @@ gem "rspec", "~> 3.13"
 gem "rspec-collection_matchers", "~> 1.1"
 gem "rspec-wait", "~> 0"
 gem "rspec_junit_formatter", ">= 0.5.1"
+gem "rubocop", "~> 1.50.0", require: false
+gem "rubocop-packaging", "~> 0.5.2", require: false
+gem "rubocop-performance", "~> 1.9", require: false
+gem "rubocop-rspec", ["~> 2.20", "< 2.21"], require: false
 gem "simplecov", git: "https://github.com/DataDog/simplecov", ref: "3bb6b7ee58bf4b1954ca205f50dd44d6f41c57db"
 gem "simplecov-cobertura", "~> 2.1.0"
 gem "warning", "~> 1"
 gem "webmock", ">= 3.10.0"
 gem "webrick", ">= 1.7.0"
-gem "rubocop", "~> 1.50.0", require: false
-gem "rubocop-packaging", "~> 0.5.2", require: false
-gem "rubocop-performance", "~> 1.9", require: false
-gem "rubocop-rspec", ["~> 2.20", "< 2.21"], require: false
-gem "dogstatsd-ruby", ">= 3.3.0", "!= 5.0.0", "!= 5.0.1", "!= 5.1.0"
-gem "google-protobuf", ["~> 3.0", "!= 3.7.0", "!= 3.7.1"]
 gem "rails", "~> 6.1.0"
 gem "graphql", "~> 2.0.0"
 gem "sprockets", "< 4"

--- a/gemfiles/ruby_3.0_graphql_2.1.gemfile
+++ b/gemfiles/ruby_3.0_graphql_2.1.gemfile
@@ -6,7 +6,9 @@ gem "benchmark-ips", "~> 2.8"
 gem "benchmark-memory", "< 0.2"
 gem "climate_control", "~> 0.2.0"
 gem "concurrent-ruby"
+gem "dogstatsd-ruby", ">= 3.3.0", "!= 5.0.0", "!= 5.0.1", "!= 5.1.0"
 gem "extlz4", "~> 0.3", ">= 0.3.3"
+gem "google-protobuf", ["~> 3.0", "!= 3.7.0", "!= 3.7.1"]
 gem "json-schema", "< 3"
 gem "memory_profiler", "~> 0.9"
 gem "os", "~> 1.1"
@@ -20,17 +22,15 @@ gem "rspec", "~> 3.13"
 gem "rspec-collection_matchers", "~> 1.1"
 gem "rspec-wait", "~> 0"
 gem "rspec_junit_formatter", ">= 0.5.1"
+gem "rubocop", "~> 1.50.0", require: false
+gem "rubocop-packaging", "~> 0.5.2", require: false
+gem "rubocop-performance", "~> 1.9", require: false
+gem "rubocop-rspec", ["~> 2.20", "< 2.21"], require: false
 gem "simplecov", git: "https://github.com/DataDog/simplecov", ref: "3bb6b7ee58bf4b1954ca205f50dd44d6f41c57db"
 gem "simplecov-cobertura", "~> 2.1.0"
 gem "warning", "~> 1"
 gem "webmock", ">= 3.10.0"
 gem "webrick", ">= 1.7.0"
-gem "rubocop", "~> 1.50.0", require: false
-gem "rubocop-packaging", "~> 0.5.2", require: false
-gem "rubocop-performance", "~> 1.9", require: false
-gem "rubocop-rspec", ["~> 2.20", "< 2.21"], require: false
-gem "dogstatsd-ruby", ">= 3.3.0", "!= 5.0.0", "!= 5.0.1", "!= 5.1.0"
-gem "google-protobuf", ["~> 3.0", "!= 3.7.0", "!= 3.7.1"]
 gem "rails", "~> 6.1.0"
 gem "graphql", "~> 2.1.0"
 gem "sprockets", "< 4"

--- a/gemfiles/ruby_3.0_graphql_2.2.gemfile
+++ b/gemfiles/ruby_3.0_graphql_2.2.gemfile
@@ -6,7 +6,9 @@ gem "benchmark-ips", "~> 2.8"
 gem "benchmark-memory", "< 0.2"
 gem "climate_control", "~> 0.2.0"
 gem "concurrent-ruby"
+gem "dogstatsd-ruby", ">= 3.3.0", "!= 5.0.0", "!= 5.0.1", "!= 5.1.0"
 gem "extlz4", "~> 0.3", ">= 0.3.3"
+gem "google-protobuf", ["~> 3.0", "!= 3.7.0", "!= 3.7.1"]
 gem "json-schema", "< 3"
 gem "memory_profiler", "~> 0.9"
 gem "os", "~> 1.1"
@@ -20,17 +22,15 @@ gem "rspec", "~> 3.13"
 gem "rspec-collection_matchers", "~> 1.1"
 gem "rspec-wait", "~> 0"
 gem "rspec_junit_formatter", ">= 0.5.1"
+gem "rubocop", "~> 1.50.0", require: false
+gem "rubocop-packaging", "~> 0.5.2", require: false
+gem "rubocop-performance", "~> 1.9", require: false
+gem "rubocop-rspec", ["~> 2.20", "< 2.21"], require: false
 gem "simplecov", git: "https://github.com/DataDog/simplecov", ref: "3bb6b7ee58bf4b1954ca205f50dd44d6f41c57db"
 gem "simplecov-cobertura", "~> 2.1.0"
 gem "warning", "~> 1"
 gem "webmock", ">= 3.10.0"
 gem "webrick", ">= 1.7.0"
-gem "rubocop", "~> 1.50.0", require: false
-gem "rubocop-packaging", "~> 0.5.2", require: false
-gem "rubocop-performance", "~> 1.9", require: false
-gem "rubocop-rspec", ["~> 2.20", "< 2.21"], require: false
-gem "dogstatsd-ruby", ">= 3.3.0", "!= 5.0.0", "!= 5.0.1", "!= 5.1.0"
-gem "google-protobuf", ["~> 3.0", "!= 3.7.0", "!= 3.7.1"]
 gem "rails", "~> 6.1.0"
 gem "graphql", "~> 2.2.0"
 gem "sprockets", "< 4"

--- a/gemfiles/ruby_3.0_graphql_2.3.gemfile
+++ b/gemfiles/ruby_3.0_graphql_2.3.gemfile
@@ -6,7 +6,9 @@ gem "benchmark-ips", "~> 2.8"
 gem "benchmark-memory", "< 0.2"
 gem "climate_control", "~> 0.2.0"
 gem "concurrent-ruby"
+gem "dogstatsd-ruby", ">= 3.3.0", "!= 5.0.0", "!= 5.0.1", "!= 5.1.0"
 gem "extlz4", "~> 0.3", ">= 0.3.3"
+gem "google-protobuf", ["~> 3.0", "!= 3.7.0", "!= 3.7.1"]
 gem "json-schema", "< 3"
 gem "memory_profiler", "~> 0.9"
 gem "os", "~> 1.1"
@@ -20,17 +22,15 @@ gem "rspec", "~> 3.13"
 gem "rspec-collection_matchers", "~> 1.1"
 gem "rspec-wait", "~> 0"
 gem "rspec_junit_formatter", ">= 0.5.1"
+gem "rubocop", "~> 1.50.0", require: false
+gem "rubocop-packaging", "~> 0.5.2", require: false
+gem "rubocop-performance", "~> 1.9", require: false
+gem "rubocop-rspec", ["~> 2.20", "< 2.21"], require: false
 gem "simplecov", git: "https://github.com/DataDog/simplecov", ref: "3bb6b7ee58bf4b1954ca205f50dd44d6f41c57db"
 gem "simplecov-cobertura", "~> 2.1.0"
 gem "warning", "~> 1"
 gem "webmock", ">= 3.10.0"
 gem "webrick", ">= 1.7.0"
-gem "rubocop", "~> 1.50.0", require: false
-gem "rubocop-packaging", "~> 0.5.2", require: false
-gem "rubocop-performance", "~> 1.9", require: false
-gem "rubocop-rspec", ["~> 2.20", "< 2.21"], require: false
-gem "dogstatsd-ruby", ">= 3.3.0", "!= 5.0.0", "!= 5.0.1", "!= 5.1.0"
-gem "google-protobuf", ["~> 3.0", "!= 3.7.0", "!= 3.7.1"]
 gem "rails", "~> 6.1.0"
 gem "graphql", "~> 2.3.0"
 gem "sprockets", "< 4"

--- a/gemfiles/ruby_3.0_http.gemfile
+++ b/gemfiles/ruby_3.0_http.gemfile
@@ -6,7 +6,9 @@ gem "benchmark-ips", "~> 2.8"
 gem "benchmark-memory", "< 0.2"
 gem "climate_control", "~> 0.2.0"
 gem "concurrent-ruby"
+gem "dogstatsd-ruby", ">= 3.3.0", "!= 5.0.0", "!= 5.0.1", "!= 5.1.0"
 gem "extlz4", "~> 0.3", ">= 0.3.3"
+gem "google-protobuf", ["~> 3.0", "!= 3.7.0", "!= 3.7.1"]
 gem "json-schema", "< 3"
 gem "memory_profiler", "~> 0.9"
 gem "os", "~> 1.1"
@@ -20,17 +22,15 @@ gem "rspec", "~> 3.13"
 gem "rspec-collection_matchers", "~> 1.1"
 gem "rspec-wait", "~> 0"
 gem "rspec_junit_formatter", ">= 0.5.1"
+gem "rubocop", "~> 1.50.0", require: false
+gem "rubocop-packaging", "~> 0.5.2", require: false
+gem "rubocop-performance", "~> 1.9", require: false
+gem "rubocop-rspec", ["~> 2.20", "< 2.21"], require: false
 gem "simplecov", git: "https://github.com/DataDog/simplecov", ref: "3bb6b7ee58bf4b1954ca205f50dd44d6f41c57db"
 gem "simplecov-cobertura", "~> 2.1.0"
 gem "warning", "~> 1"
 gem "webmock", ">= 3.10.0"
 gem "webrick", ">= 1.7.0"
-gem "rubocop", "~> 1.50.0", require: false
-gem "rubocop-packaging", "~> 0.5.2", require: false
-gem "rubocop-performance", "~> 1.9", require: false
-gem "rubocop-rspec", ["~> 2.20", "< 2.21"], require: false
-gem "dogstatsd-ruby", ">= 3.3.0", "!= 5.0.0", "!= 5.0.1", "!= 5.1.0"
-gem "google-protobuf", ["~> 3.0", "!= 3.7.0", "!= 3.7.1"]
 gem "ethon"
 gem "excon"
 gem "faraday"

--- a/gemfiles/ruby_3.0_opensearch_2.gemfile
+++ b/gemfiles/ruby_3.0_opensearch_2.gemfile
@@ -6,7 +6,9 @@ gem "benchmark-ips", "~> 2.8"
 gem "benchmark-memory", "< 0.2"
 gem "climate_control", "~> 0.2.0"
 gem "concurrent-ruby"
+gem "dogstatsd-ruby", ">= 3.3.0", "!= 5.0.0", "!= 5.0.1", "!= 5.1.0"
 gem "extlz4", "~> 0.3", ">= 0.3.3"
+gem "google-protobuf", ["~> 3.0", "!= 3.7.0", "!= 3.7.1"]
 gem "json-schema", "< 3"
 gem "memory_profiler", "~> 0.9"
 gem "os", "~> 1.1"
@@ -20,17 +22,15 @@ gem "rspec", "~> 3.13"
 gem "rspec-collection_matchers", "~> 1.1"
 gem "rspec-wait", "~> 0"
 gem "rspec_junit_formatter", ">= 0.5.1"
+gem "rubocop", "~> 1.50.0", require: false
+gem "rubocop-packaging", "~> 0.5.2", require: false
+gem "rubocop-performance", "~> 1.9", require: false
+gem "rubocop-rspec", ["~> 2.20", "< 2.21"], require: false
 gem "simplecov", git: "https://github.com/DataDog/simplecov", ref: "3bb6b7ee58bf4b1954ca205f50dd44d6f41c57db"
 gem "simplecov-cobertura", "~> 2.1.0"
 gem "warning", "~> 1"
 gem "webmock", ">= 3.10.0"
 gem "webrick", ">= 1.7.0"
-gem "rubocop", "~> 1.50.0", require: false
-gem "rubocop-packaging", "~> 0.5.2", require: false
-gem "rubocop-performance", "~> 1.9", require: false
-gem "rubocop-rspec", ["~> 2.20", "< 2.21"], require: false
-gem "dogstatsd-ruby", ">= 3.3.0", "!= 5.0.0", "!= 5.0.1", "!= 5.1.0"
-gem "google-protobuf", ["~> 3.0", "!= 3.7.0", "!= 3.7.1"]
 gem "opensearch-ruby", "~> 2"
 
 group :check do

--- a/gemfiles/ruby_3.0_opensearch_3.gemfile
+++ b/gemfiles/ruby_3.0_opensearch_3.gemfile
@@ -6,7 +6,9 @@ gem "benchmark-ips", "~> 2.8"
 gem "benchmark-memory", "< 0.2"
 gem "climate_control", "~> 0.2.0"
 gem "concurrent-ruby"
+gem "dogstatsd-ruby", ">= 3.3.0", "!= 5.0.0", "!= 5.0.1", "!= 5.1.0"
 gem "extlz4", "~> 0.3", ">= 0.3.3"
+gem "google-protobuf", ["~> 3.0", "!= 3.7.0", "!= 3.7.1"]
 gem "json-schema", "< 3"
 gem "memory_profiler", "~> 0.9"
 gem "os", "~> 1.1"
@@ -20,17 +22,15 @@ gem "rspec", "~> 3.13"
 gem "rspec-collection_matchers", "~> 1.1"
 gem "rspec-wait", "~> 0"
 gem "rspec_junit_formatter", ">= 0.5.1"
+gem "rubocop", "~> 1.50.0", require: false
+gem "rubocop-packaging", "~> 0.5.2", require: false
+gem "rubocop-performance", "~> 1.9", require: false
+gem "rubocop-rspec", ["~> 2.20", "< 2.21"], require: false
 gem "simplecov", git: "https://github.com/DataDog/simplecov", ref: "3bb6b7ee58bf4b1954ca205f50dd44d6f41c57db"
 gem "simplecov-cobertura", "~> 2.1.0"
 gem "warning", "~> 1"
 gem "webmock", ">= 3.10.0"
 gem "webrick", ">= 1.7.0"
-gem "rubocop", "~> 1.50.0", require: false
-gem "rubocop-packaging", "~> 0.5.2", require: false
-gem "rubocop-performance", "~> 1.9", require: false
-gem "rubocop-rspec", ["~> 2.20", "< 2.21"], require: false
-gem "dogstatsd-ruby", ">= 3.3.0", "!= 5.0.0", "!= 5.0.1", "!= 5.1.0"
-gem "google-protobuf", ["~> 3.0", "!= 3.7.0", "!= 3.7.1"]
 gem "opensearch-ruby", "~> 3"
 
 group :check do

--- a/gemfiles/ruby_3.0_opensearch_latest.gemfile
+++ b/gemfiles/ruby_3.0_opensearch_latest.gemfile
@@ -6,7 +6,9 @@ gem "benchmark-ips", "~> 2.8"
 gem "benchmark-memory", "< 0.2"
 gem "climate_control", "~> 0.2.0"
 gem "concurrent-ruby"
+gem "dogstatsd-ruby", ">= 3.3.0", "!= 5.0.0", "!= 5.0.1", "!= 5.1.0"
 gem "extlz4", "~> 0.3", ">= 0.3.3"
+gem "google-protobuf", ["~> 3.0", "!= 3.7.0", "!= 3.7.1"]
 gem "json-schema", "< 3"
 gem "memory_profiler", "~> 0.9"
 gem "os", "~> 1.1"
@@ -20,17 +22,15 @@ gem "rspec", "~> 3.13"
 gem "rspec-collection_matchers", "~> 1.1"
 gem "rspec-wait", "~> 0"
 gem "rspec_junit_formatter", ">= 0.5.1"
+gem "rubocop", "~> 1.50.0", require: false
+gem "rubocop-packaging", "~> 0.5.2", require: false
+gem "rubocop-performance", "~> 1.9", require: false
+gem "rubocop-rspec", ["~> 2.20", "< 2.21"], require: false
 gem "simplecov", git: "https://github.com/DataDog/simplecov", ref: "3bb6b7ee58bf4b1954ca205f50dd44d6f41c57db"
 gem "simplecov-cobertura", "~> 2.1.0"
 gem "warning", "~> 1"
 gem "webmock", ">= 3.10.0"
 gem "webrick", ">= 1.7.0"
-gem "rubocop", "~> 1.50.0", require: false
-gem "rubocop-packaging", "~> 0.5.2", require: false
-gem "rubocop-performance", "~> 1.9", require: false
-gem "rubocop-rspec", ["~> 2.20", "< 2.21"], require: false
-gem "dogstatsd-ruby", ">= 3.3.0", "!= 5.0.0", "!= 5.0.1", "!= 5.1.0"
-gem "google-protobuf", ["~> 3.0", "!= 3.7.0", "!= 3.7.1"]
 gem "opensearch-ruby"
 
 group :check do

--- a/gemfiles/ruby_3.0_opentelemetry.gemfile
+++ b/gemfiles/ruby_3.0_opentelemetry.gemfile
@@ -6,7 +6,9 @@ gem "benchmark-ips", "~> 2.8"
 gem "benchmark-memory", "< 0.2"
 gem "climate_control", "~> 0.2.0"
 gem "concurrent-ruby"
+gem "dogstatsd-ruby", ">= 3.3.0", "!= 5.0.0", "!= 5.0.1", "!= 5.1.0"
 gem "extlz4", "~> 0.3", ">= 0.3.3"
+gem "google-protobuf", ["~> 3.0", "!= 3.7.0", "!= 3.7.1"]
 gem "json-schema", "< 3"
 gem "memory_profiler", "~> 0.9"
 gem "os", "~> 1.1"
@@ -20,17 +22,15 @@ gem "rspec", "~> 3.13"
 gem "rspec-collection_matchers", "~> 1.1"
 gem "rspec-wait", "~> 0"
 gem "rspec_junit_formatter", ">= 0.5.1"
+gem "rubocop", "~> 1.50.0", require: false
+gem "rubocop-packaging", "~> 0.5.2", require: false
+gem "rubocop-performance", "~> 1.9", require: false
+gem "rubocop-rspec", ["~> 2.20", "< 2.21"], require: false
 gem "simplecov", git: "https://github.com/DataDog/simplecov", ref: "3bb6b7ee58bf4b1954ca205f50dd44d6f41c57db"
 gem "simplecov-cobertura", "~> 2.1.0"
 gem "warning", "~> 1"
 gem "webmock", ">= 3.10.0"
 gem "webrick", ">= 1.7.0"
-gem "rubocop", "~> 1.50.0", require: false
-gem "rubocop-packaging", "~> 0.5.2", require: false
-gem "rubocop-performance", "~> 1.9", require: false
-gem "rubocop-rspec", ["~> 2.20", "< 2.21"], require: false
-gem "dogstatsd-ruby", ">= 3.3.0", "!= 5.0.0", "!= 5.0.1", "!= 5.1.0"
-gem "google-protobuf", ["~> 3.0", "!= 3.7.0", "!= 3.7.1"]
 gem "opentelemetry-sdk", "~> 1.1"
 
 group :check do

--- a/gemfiles/ruby_3.0_opentelemetry_otlp.gemfile
+++ b/gemfiles/ruby_3.0_opentelemetry_otlp.gemfile
@@ -6,7 +6,9 @@ gem "benchmark-ips", "~> 2.8"
 gem "benchmark-memory", "< 0.2"
 gem "climate_control", "~> 0.2.0"
 gem "concurrent-ruby"
+gem "dogstatsd-ruby", ">= 3.3.0", "!= 5.0.0", "!= 5.0.1", "!= 5.1.0"
 gem "extlz4", "~> 0.3", ">= 0.3.3"
+gem "google-protobuf", ["~> 3.0", "!= 3.7.0", "!= 3.7.1"]
 gem "json-schema", "< 3"
 gem "memory_profiler", "~> 0.9"
 gem "os", "~> 1.1"
@@ -20,17 +22,15 @@ gem "rspec", "~> 3.13"
 gem "rspec-collection_matchers", "~> 1.1"
 gem "rspec-wait", "~> 0"
 gem "rspec_junit_formatter", ">= 0.5.1"
+gem "rubocop", "~> 1.50.0", require: false
+gem "rubocop-packaging", "~> 0.5.2", require: false
+gem "rubocop-performance", "~> 1.9", require: false
+gem "rubocop-rspec", ["~> 2.20", "< 2.21"], require: false
 gem "simplecov", git: "https://github.com/DataDog/simplecov", ref: "3bb6b7ee58bf4b1954ca205f50dd44d6f41c57db"
 gem "simplecov-cobertura", "~> 2.1.0"
 gem "warning", "~> 1"
 gem "webmock", ">= 3.10.0"
 gem "webrick", ">= 1.7.0"
-gem "rubocop", "~> 1.50.0", require: false
-gem "rubocop-packaging", "~> 0.5.2", require: false
-gem "rubocop-performance", "~> 1.9", require: false
-gem "rubocop-rspec", ["~> 2.20", "< 2.21"], require: false
-gem "dogstatsd-ruby", ">= 3.3.0", "!= 5.0.0", "!= 5.0.1", "!= 5.1.0"
-gem "google-protobuf", ["~> 3.0", "!= 3.7.0", "!= 3.7.1"]
 gem "opentelemetry-sdk", "~> 1.1"
 gem "opentelemetry-exporter-otlp"
 

--- a/gemfiles/ruby_3.0_rack_1.gemfile
+++ b/gemfiles/ruby_3.0_rack_1.gemfile
@@ -6,7 +6,9 @@ gem "benchmark-ips", "~> 2.8"
 gem "benchmark-memory", "< 0.2"
 gem "climate_control", "~> 0.2.0"
 gem "concurrent-ruby"
+gem "dogstatsd-ruby", ">= 3.3.0", "!= 5.0.0", "!= 5.0.1", "!= 5.1.0"
 gem "extlz4", "~> 0.3", ">= 0.3.3"
+gem "google-protobuf", ["~> 3.0", "!= 3.7.0", "!= 3.7.1"]
 gem "json-schema", "< 3"
 gem "memory_profiler", "~> 0.9"
 gem "os", "~> 1.1"
@@ -20,17 +22,15 @@ gem "rspec", "~> 3.13"
 gem "rspec-collection_matchers", "~> 1.1"
 gem "rspec-wait", "~> 0"
 gem "rspec_junit_formatter", ">= 0.5.1"
+gem "rubocop", "~> 1.50.0", require: false
+gem "rubocop-packaging", "~> 0.5.2", require: false
+gem "rubocop-performance", "~> 1.9", require: false
+gem "rubocop-rspec", ["~> 2.20", "< 2.21"], require: false
 gem "simplecov", git: "https://github.com/DataDog/simplecov", ref: "3bb6b7ee58bf4b1954ca205f50dd44d6f41c57db"
 gem "simplecov-cobertura", "~> 2.1.0"
 gem "warning", "~> 1"
 gem "webmock", ">= 3.10.0"
 gem "webrick", ">= 1.7.0"
-gem "rubocop", "~> 1.50.0", require: false
-gem "rubocop-packaging", "~> 0.5.2", require: false
-gem "rubocop-performance", "~> 1.9", require: false
-gem "rubocop-rspec", ["~> 2.20", "< 2.21"], require: false
-gem "dogstatsd-ruby", ">= 3.3.0", "!= 5.0.0", "!= 5.0.1", "!= 5.1.0"
-gem "google-protobuf", ["~> 3.0", "!= 3.7.0", "!= 3.7.1"]
 gem "rack", "~> 1"
 gem "rack-contrib"
 gem "rack-test"

--- a/gemfiles/ruby_3.0_rack_2.gemfile
+++ b/gemfiles/ruby_3.0_rack_2.gemfile
@@ -6,7 +6,9 @@ gem "benchmark-ips", "~> 2.8"
 gem "benchmark-memory", "< 0.2"
 gem "climate_control", "~> 0.2.0"
 gem "concurrent-ruby"
+gem "dogstatsd-ruby", ">= 3.3.0", "!= 5.0.0", "!= 5.0.1", "!= 5.1.0"
 gem "extlz4", "~> 0.3", ">= 0.3.3"
+gem "google-protobuf", ["~> 3.0", "!= 3.7.0", "!= 3.7.1"]
 gem "json-schema", "< 3"
 gem "memory_profiler", "~> 0.9"
 gem "os", "~> 1.1"
@@ -20,17 +22,15 @@ gem "rspec", "~> 3.13"
 gem "rspec-collection_matchers", "~> 1.1"
 gem "rspec-wait", "~> 0"
 gem "rspec_junit_formatter", ">= 0.5.1"
+gem "rubocop", "~> 1.50.0", require: false
+gem "rubocop-packaging", "~> 0.5.2", require: false
+gem "rubocop-performance", "~> 1.9", require: false
+gem "rubocop-rspec", ["~> 2.20", "< 2.21"], require: false
 gem "simplecov", git: "https://github.com/DataDog/simplecov", ref: "3bb6b7ee58bf4b1954ca205f50dd44d6f41c57db"
 gem "simplecov-cobertura", "~> 2.1.0"
 gem "warning", "~> 1"
 gem "webmock", ">= 3.10.0"
 gem "webrick", ">= 1.7.0"
-gem "rubocop", "~> 1.50.0", require: false
-gem "rubocop-packaging", "~> 0.5.2", require: false
-gem "rubocop-performance", "~> 1.9", require: false
-gem "rubocop-rspec", ["~> 2.20", "< 2.21"], require: false
-gem "dogstatsd-ruby", ">= 3.3.0", "!= 5.0.0", "!= 5.0.1", "!= 5.1.0"
-gem "google-protobuf", ["~> 3.0", "!= 3.7.0", "!= 3.7.1"]
 gem "rack", "~> 2"
 gem "rack-contrib"
 gem "rack-test"

--- a/gemfiles/ruby_3.0_rack_3.gemfile
+++ b/gemfiles/ruby_3.0_rack_3.gemfile
@@ -6,7 +6,9 @@ gem "benchmark-ips", "~> 2.8"
 gem "benchmark-memory", "< 0.2"
 gem "climate_control", "~> 0.2.0"
 gem "concurrent-ruby"
+gem "dogstatsd-ruby", ">= 3.3.0", "!= 5.0.0", "!= 5.0.1", "!= 5.1.0"
 gem "extlz4", "~> 0.3", ">= 0.3.3"
+gem "google-protobuf", ["~> 3.0", "!= 3.7.0", "!= 3.7.1"]
 gem "json-schema", "< 3"
 gem "memory_profiler", "~> 0.9"
 gem "os", "~> 1.1"
@@ -20,17 +22,15 @@ gem "rspec", "~> 3.13"
 gem "rspec-collection_matchers", "~> 1.1"
 gem "rspec-wait", "~> 0"
 gem "rspec_junit_formatter", ">= 0.5.1"
+gem "rubocop", "~> 1.50.0", require: false
+gem "rubocop-packaging", "~> 0.5.2", require: false
+gem "rubocop-performance", "~> 1.9", require: false
+gem "rubocop-rspec", ["~> 2.20", "< 2.21"], require: false
 gem "simplecov", git: "https://github.com/DataDog/simplecov", ref: "3bb6b7ee58bf4b1954ca205f50dd44d6f41c57db"
 gem "simplecov-cobertura", "~> 2.1.0"
 gem "warning", "~> 1"
 gem "webmock", ">= 3.10.0"
 gem "webrick", ">= 1.7.0"
-gem "rubocop", "~> 1.50.0", require: false
-gem "rubocop-packaging", "~> 0.5.2", require: false
-gem "rubocop-performance", "~> 1.9", require: false
-gem "rubocop-rspec", ["~> 2.20", "< 2.21"], require: false
-gem "dogstatsd-ruby", ">= 3.3.0", "!= 5.0.0", "!= 5.0.1", "!= 5.1.0"
-gem "google-protobuf", ["~> 3.0", "!= 3.7.0", "!= 3.7.1"]
 gem "rack", "~> 3"
 gem "rack-contrib"
 gem "rack-test"

--- a/gemfiles/ruby_3.0_rack_latest.gemfile
+++ b/gemfiles/ruby_3.0_rack_latest.gemfile
@@ -6,7 +6,9 @@ gem "benchmark-ips", "~> 2.8"
 gem "benchmark-memory", "< 0.2"
 gem "climate_control", "~> 0.2.0"
 gem "concurrent-ruby"
+gem "dogstatsd-ruby", ">= 3.3.0", "!= 5.0.0", "!= 5.0.1", "!= 5.1.0"
 gem "extlz4", "~> 0.3", ">= 0.3.3"
+gem "google-protobuf", ["~> 3.0", "!= 3.7.0", "!= 3.7.1"]
 gem "json-schema", "< 3"
 gem "memory_profiler", "~> 0.9"
 gem "os", "~> 1.1"
@@ -20,17 +22,15 @@ gem "rspec", "~> 3.13"
 gem "rspec-collection_matchers", "~> 1.1"
 gem "rspec-wait", "~> 0"
 gem "rspec_junit_formatter", ">= 0.5.1"
+gem "rubocop", "~> 1.50.0", require: false
+gem "rubocop-packaging", "~> 0.5.2", require: false
+gem "rubocop-performance", "~> 1.9", require: false
+gem "rubocop-rspec", ["~> 2.20", "< 2.21"], require: false
 gem "simplecov", git: "https://github.com/DataDog/simplecov", ref: "3bb6b7ee58bf4b1954ca205f50dd44d6f41c57db"
 gem "simplecov-cobertura", "~> 2.1.0"
 gem "warning", "~> 1"
 gem "webmock", ">= 3.10.0"
 gem "webrick", ">= 1.7.0"
-gem "rubocop", "~> 1.50.0", require: false
-gem "rubocop-packaging", "~> 0.5.2", require: false
-gem "rubocop-performance", "~> 1.9", require: false
-gem "rubocop-rspec", ["~> 2.20", "< 2.21"], require: false
-gem "dogstatsd-ruby", ">= 3.3.0", "!= 5.0.0", "!= 5.0.1", "!= 5.1.0"
-gem "google-protobuf", ["~> 3.0", "!= 3.7.0", "!= 3.7.1"]
 gem "rack"
 gem "rack-contrib"
 gem "rack-test"

--- a/gemfiles/ruby_3.0_rails61_mysql2.gemfile
+++ b/gemfiles/ruby_3.0_rails61_mysql2.gemfile
@@ -6,7 +6,9 @@ gem "benchmark-ips", "~> 2.8"
 gem "benchmark-memory", "< 0.2"
 gem "climate_control", "~> 0.2.0"
 gem "concurrent-ruby"
+gem "dogstatsd-ruby", ">= 3.3.0", "!= 5.0.0", "!= 5.0.1", "!= 5.1.0"
 gem "extlz4", "~> 0.3", ">= 0.3.3"
+gem "google-protobuf", ["~> 3.0", "!= 3.7.0", "!= 3.7.1"]
 gem "json-schema", "< 3"
 gem "memory_profiler", "~> 0.9"
 gem "os", "~> 1.1"
@@ -20,17 +22,15 @@ gem "rspec", "~> 3.13"
 gem "rspec-collection_matchers", "~> 1.1"
 gem "rspec-wait", "~> 0"
 gem "rspec_junit_formatter", ">= 0.5.1"
+gem "rubocop", "~> 1.50.0", require: false
+gem "rubocop-packaging", "~> 0.5.2", require: false
+gem "rubocop-performance", "~> 1.9", require: false
+gem "rubocop-rspec", ["~> 2.20", "< 2.21"], require: false
 gem "simplecov", git: "https://github.com/DataDog/simplecov", ref: "3bb6b7ee58bf4b1954ca205f50dd44d6f41c57db"
 gem "simplecov-cobertura", "~> 2.1.0"
 gem "warning", "~> 1"
 gem "webmock", ">= 3.10.0"
 gem "webrick", ">= 1.7.0"
-gem "rubocop", "~> 1.50.0", require: false
-gem "rubocop-packaging", "~> 0.5.2", require: false
-gem "rubocop-performance", "~> 1.9", require: false
-gem "rubocop-rspec", ["~> 2.20", "< 2.21"], require: false
-gem "dogstatsd-ruby", ">= 3.3.0", "!= 5.0.0", "!= 5.0.1", "!= 5.1.0"
-gem "google-protobuf", ["~> 3.0", "!= 3.7.0", "!= 3.7.1"]
 gem "rails", "~> 6.1.0"
 gem "mysql2", "~> 0.5", platform: :ruby
 gem "sprockets", "< 4"

--- a/gemfiles/ruby_3.0_rails61_postgres.gemfile
+++ b/gemfiles/ruby_3.0_rails61_postgres.gemfile
@@ -6,7 +6,9 @@ gem "benchmark-ips", "~> 2.8"
 gem "benchmark-memory", "< 0.2"
 gem "climate_control", "~> 0.2.0"
 gem "concurrent-ruby"
+gem "dogstatsd-ruby", ">= 3.3.0", "!= 5.0.0", "!= 5.0.1", "!= 5.1.0"
 gem "extlz4", "~> 0.3", ">= 0.3.3"
+gem "google-protobuf", ["~> 3.0", "!= 3.7.0", "!= 3.7.1"]
 gem "json-schema", "< 3"
 gem "memory_profiler", "~> 0.9"
 gem "os", "~> 1.1"
@@ -20,17 +22,15 @@ gem "rspec", "~> 3.13"
 gem "rspec-collection_matchers", "~> 1.1"
 gem "rspec-wait", "~> 0"
 gem "rspec_junit_formatter", ">= 0.5.1"
+gem "rubocop", "~> 1.50.0", require: false
+gem "rubocop-packaging", "~> 0.5.2", require: false
+gem "rubocop-performance", "~> 1.9", require: false
+gem "rubocop-rspec", ["~> 2.20", "< 2.21"], require: false
 gem "simplecov", git: "https://github.com/DataDog/simplecov", ref: "3bb6b7ee58bf4b1954ca205f50dd44d6f41c57db"
 gem "simplecov-cobertura", "~> 2.1.0"
 gem "warning", "~> 1"
 gem "webmock", ">= 3.10.0"
 gem "webrick", ">= 1.7.0"
-gem "rubocop", "~> 1.50.0", require: false
-gem "rubocop-packaging", "~> 0.5.2", require: false
-gem "rubocop-performance", "~> 1.9", require: false
-gem "rubocop-rspec", ["~> 2.20", "< 2.21"], require: false
-gem "dogstatsd-ruby", ">= 3.3.0", "!= 5.0.0", "!= 5.0.1", "!= 5.1.0"
-gem "google-protobuf", ["~> 3.0", "!= 3.7.0", "!= 3.7.1"]
 gem "rails", "~> 6.1.0"
 gem "pg", ">= 1.1", platform: :ruby
 gem "sprockets", "< 4"

--- a/gemfiles/ruby_3.0_rails61_postgres_redis.gemfile
+++ b/gemfiles/ruby_3.0_rails61_postgres_redis.gemfile
@@ -6,7 +6,9 @@ gem "benchmark-ips", "~> 2.8"
 gem "benchmark-memory", "< 0.2"
 gem "climate_control", "~> 0.2.0"
 gem "concurrent-ruby"
+gem "dogstatsd-ruby", ">= 3.3.0", "!= 5.0.0", "!= 5.0.1", "!= 5.1.0"
 gem "extlz4", "~> 0.3", ">= 0.3.3"
+gem "google-protobuf", ["~> 3.0", "!= 3.7.0", "!= 3.7.1"]
 gem "json-schema", "< 3"
 gem "memory_profiler", "~> 0.9"
 gem "os", "~> 1.1"
@@ -20,17 +22,15 @@ gem "rspec", "~> 3.13"
 gem "rspec-collection_matchers", "~> 1.1"
 gem "rspec-wait", "~> 0"
 gem "rspec_junit_formatter", ">= 0.5.1"
+gem "rubocop", "~> 1.50.0", require: false
+gem "rubocop-packaging", "~> 0.5.2", require: false
+gem "rubocop-performance", "~> 1.9", require: false
+gem "rubocop-rspec", ["~> 2.20", "< 2.21"], require: false
 gem "simplecov", git: "https://github.com/DataDog/simplecov", ref: "3bb6b7ee58bf4b1954ca205f50dd44d6f41c57db"
 gem "simplecov-cobertura", "~> 2.1.0"
 gem "warning", "~> 1"
 gem "webmock", ">= 3.10.0"
 gem "webrick", ">= 1.7.0"
-gem "rubocop", "~> 1.50.0", require: false
-gem "rubocop-packaging", "~> 0.5.2", require: false
-gem "rubocop-performance", "~> 1.9", require: false
-gem "rubocop-rspec", ["~> 2.20", "< 2.21"], require: false
-gem "dogstatsd-ruby", ">= 3.3.0", "!= 5.0.0", "!= 5.0.1", "!= 5.1.0"
-gem "google-protobuf", ["~> 3.0", "!= 3.7.0", "!= 3.7.1"]
 gem "rails", "~> 6.1.0"
 gem "pg", ">= 1.1", platform: :ruby
 gem "redis", "~> 4"

--- a/gemfiles/ruby_3.0_rails61_postgres_sidekiq.gemfile
+++ b/gemfiles/ruby_3.0_rails61_postgres_sidekiq.gemfile
@@ -6,7 +6,9 @@ gem "benchmark-ips", "~> 2.8"
 gem "benchmark-memory", "< 0.2"
 gem "climate_control", "~> 0.2.0"
 gem "concurrent-ruby"
+gem "dogstatsd-ruby", ">= 3.3.0", "!= 5.0.0", "!= 5.0.1", "!= 5.1.0"
 gem "extlz4", "~> 0.3", ">= 0.3.3"
+gem "google-protobuf", ["~> 3.0", "!= 3.7.0", "!= 3.7.1"]
 gem "json-schema", "< 3"
 gem "memory_profiler", "~> 0.9"
 gem "os", "~> 1.1"
@@ -20,17 +22,15 @@ gem "rspec", "~> 3.13"
 gem "rspec-collection_matchers", "~> 1.1"
 gem "rspec-wait", "~> 0"
 gem "rspec_junit_formatter", ">= 0.5.1"
+gem "rubocop", "~> 1.50.0", require: false
+gem "rubocop-packaging", "~> 0.5.2", require: false
+gem "rubocop-performance", "~> 1.9", require: false
+gem "rubocop-rspec", ["~> 2.20", "< 2.21"], require: false
 gem "simplecov", git: "https://github.com/DataDog/simplecov", ref: "3bb6b7ee58bf4b1954ca205f50dd44d6f41c57db"
 gem "simplecov-cobertura", "~> 2.1.0"
 gem "warning", "~> 1"
 gem "webmock", ">= 3.10.0"
 gem "webrick", ">= 1.7.0"
-gem "rubocop", "~> 1.50.0", require: false
-gem "rubocop-packaging", "~> 0.5.2", require: false
-gem "rubocop-performance", "~> 1.9", require: false
-gem "rubocop-rspec", ["~> 2.20", "< 2.21"], require: false
-gem "dogstatsd-ruby", ">= 3.3.0", "!= 5.0.0", "!= 5.0.1", "!= 5.1.0"
-gem "google-protobuf", ["~> 3.0", "!= 3.7.0", "!= 3.7.1"]
 gem "rails", "~> 6.1.0"
 gem "pg", ">= 1.1", platform: :ruby
 gem "sidekiq", ">= 6.1.2"

--- a/gemfiles/ruby_3.0_rails61_semantic_logger.gemfile
+++ b/gemfiles/ruby_3.0_rails61_semantic_logger.gemfile
@@ -6,7 +6,9 @@ gem "benchmark-ips", "~> 2.8"
 gem "benchmark-memory", "< 0.2"
 gem "climate_control", "~> 0.2.0"
 gem "concurrent-ruby"
+gem "dogstatsd-ruby", ">= 3.3.0", "!= 5.0.0", "!= 5.0.1", "!= 5.1.0"
 gem "extlz4", "~> 0.3", ">= 0.3.3"
+gem "google-protobuf", ["~> 3.0", "!= 3.7.0", "!= 3.7.1"]
 gem "json-schema", "< 3"
 gem "memory_profiler", "~> 0.9"
 gem "os", "~> 1.1"
@@ -20,17 +22,15 @@ gem "rspec", "~> 3.13"
 gem "rspec-collection_matchers", "~> 1.1"
 gem "rspec-wait", "~> 0"
 gem "rspec_junit_formatter", ">= 0.5.1"
+gem "rubocop", "~> 1.50.0", require: false
+gem "rubocop-packaging", "~> 0.5.2", require: false
+gem "rubocop-performance", "~> 1.9", require: false
+gem "rubocop-rspec", ["~> 2.20", "< 2.21"], require: false
 gem "simplecov", git: "https://github.com/DataDog/simplecov", ref: "3bb6b7ee58bf4b1954ca205f50dd44d6f41c57db"
 gem "simplecov-cobertura", "~> 2.1.0"
 gem "warning", "~> 1"
 gem "webmock", ">= 3.10.0"
 gem "webrick", ">= 1.7.0"
-gem "rubocop", "~> 1.50.0", require: false
-gem "rubocop-packaging", "~> 0.5.2", require: false
-gem "rubocop-performance", "~> 1.9", require: false
-gem "rubocop-rspec", ["~> 2.20", "< 2.21"], require: false
-gem "dogstatsd-ruby", ">= 3.3.0", "!= 5.0.0", "!= 5.0.1", "!= 5.1.0"
-gem "google-protobuf", ["~> 3.0", "!= 3.7.0", "!= 3.7.1"]
 gem "rails", "~> 6.1.0"
 gem "pg", ">= 1.1", platform: :ruby
 gem "sprockets", "< 4"

--- a/gemfiles/ruby_3.0_rails61_trilogy.gemfile
+++ b/gemfiles/ruby_3.0_rails61_trilogy.gemfile
@@ -6,7 +6,9 @@ gem "benchmark-ips", "~> 2.8"
 gem "benchmark-memory", "< 0.2"
 gem "climate_control", "~> 0.2.0"
 gem "concurrent-ruby"
+gem "dogstatsd-ruby", ">= 3.3.0", "!= 5.0.0", "!= 5.0.1", "!= 5.1.0"
 gem "extlz4", "~> 0.3", ">= 0.3.3"
+gem "google-protobuf", ["~> 3.0", "!= 3.7.0", "!= 3.7.1"]
 gem "json-schema", "< 3"
 gem "memory_profiler", "~> 0.9"
 gem "os", "~> 1.1"
@@ -20,17 +22,15 @@ gem "rspec", "~> 3.13"
 gem "rspec-collection_matchers", "~> 1.1"
 gem "rspec-wait", "~> 0"
 gem "rspec_junit_formatter", ">= 0.5.1"
+gem "rubocop", "~> 1.50.0", require: false
+gem "rubocop-packaging", "~> 0.5.2", require: false
+gem "rubocop-performance", "~> 1.9", require: false
+gem "rubocop-rspec", ["~> 2.20", "< 2.21"], require: false
 gem "simplecov", git: "https://github.com/DataDog/simplecov", ref: "3bb6b7ee58bf4b1954ca205f50dd44d6f41c57db"
 gem "simplecov-cobertura", "~> 2.1.0"
 gem "warning", "~> 1"
 gem "webmock", ">= 3.10.0"
 gem "webrick", ">= 1.7.0"
-gem "rubocop", "~> 1.50.0", require: false
-gem "rubocop-packaging", "~> 0.5.2", require: false
-gem "rubocop-performance", "~> 1.9", require: false
-gem "rubocop-rspec", ["~> 2.20", "< 2.21"], require: false
-gem "dogstatsd-ruby", ">= 3.3.0", "!= 5.0.0", "!= 5.0.1", "!= 5.1.0"
-gem "google-protobuf", ["~> 3.0", "!= 3.7.0", "!= 3.7.1"]
 gem "rails", "~> 6.1.0"
 gem "trilogy"
 gem "activerecord-trilogy-adapter"

--- a/gemfiles/ruby_3.0_rails7.gemfile
+++ b/gemfiles/ruby_3.0_rails7.gemfile
@@ -6,7 +6,9 @@ gem "benchmark-ips", "~> 2.8"
 gem "benchmark-memory", "< 0.2"
 gem "climate_control", "~> 0.2.0"
 gem "concurrent-ruby"
+gem "dogstatsd-ruby", ">= 3.3.0", "!= 5.0.0", "!= 5.0.1", "!= 5.1.0"
 gem "extlz4", "~> 0.3", ">= 0.3.3"
+gem "google-protobuf", ["~> 3.0", "!= 3.7.0", "!= 3.7.1"]
 gem "json-schema", "< 3"
 gem "memory_profiler", "~> 0.9"
 gem "os", "~> 1.1"
@@ -20,17 +22,15 @@ gem "rspec", "~> 3.13"
 gem "rspec-collection_matchers", "~> 1.1"
 gem "rspec-wait", "~> 0"
 gem "rspec_junit_formatter", ">= 0.5.1"
+gem "rubocop", "~> 1.50.0", require: false
+gem "rubocop-packaging", "~> 0.5.2", require: false
+gem "rubocop-performance", "~> 1.9", require: false
+gem "rubocop-rspec", ["~> 2.20", "< 2.21"], require: false
 gem "simplecov", git: "https://github.com/DataDog/simplecov", ref: "3bb6b7ee58bf4b1954ca205f50dd44d6f41c57db"
 gem "simplecov-cobertura", "~> 2.1.0"
 gem "warning", "~> 1"
 gem "webmock", ">= 3.10.0"
 gem "webrick", ">= 1.7.0"
-gem "rubocop", "~> 1.50.0", require: false
-gem "rubocop-packaging", "~> 0.5.2", require: false
-gem "rubocop-performance", "~> 1.9", require: false
-gem "rubocop-rspec", ["~> 2.20", "< 2.21"], require: false
-gem "dogstatsd-ruby", ">= 3.3.0", "!= 5.0.0", "!= 5.0.1", "!= 5.1.0"
-gem "google-protobuf", ["~> 3.0", "!= 3.7.0", "!= 3.7.1"]
 gem "rails", "~> 7.0.0"
 
 group :check do

--- a/gemfiles/ruby_3.0_rails71.gemfile
+++ b/gemfiles/ruby_3.0_rails71.gemfile
@@ -6,7 +6,9 @@ gem "benchmark-ips", "~> 2.8"
 gem "benchmark-memory", "< 0.2"
 gem "climate_control", "~> 0.2.0"
 gem "concurrent-ruby"
+gem "dogstatsd-ruby", ">= 3.3.0", "!= 5.0.0", "!= 5.0.1", "!= 5.1.0"
 gem "extlz4", "~> 0.3", ">= 0.3.3"
+gem "google-protobuf", ["~> 3.0", "!= 3.7.0", "!= 3.7.1"]
 gem "json-schema", "< 3"
 gem "memory_profiler", "~> 0.9"
 gem "os", "~> 1.1"
@@ -20,17 +22,15 @@ gem "rspec", "~> 3.13"
 gem "rspec-collection_matchers", "~> 1.1"
 gem "rspec-wait", "~> 0"
 gem "rspec_junit_formatter", ">= 0.5.1"
+gem "rubocop", "~> 1.50.0", require: false
+gem "rubocop-packaging", "~> 0.5.2", require: false
+gem "rubocop-performance", "~> 1.9", require: false
+gem "rubocop-rspec", ["~> 2.20", "< 2.21"], require: false
 gem "simplecov", git: "https://github.com/DataDog/simplecov", ref: "3bb6b7ee58bf4b1954ca205f50dd44d6f41c57db"
 gem "simplecov-cobertura", "~> 2.1.0"
 gem "warning", "~> 1"
 gem "webmock", ">= 3.10.0"
 gem "webrick", ">= 1.7.0"
-gem "rubocop", "~> 1.50.0", require: false
-gem "rubocop-packaging", "~> 0.5.2", require: false
-gem "rubocop-performance", "~> 1.9", require: false
-gem "rubocop-rspec", ["~> 2.20", "< 2.21"], require: false
-gem "dogstatsd-ruby", ">= 3.3.0", "!= 5.0.0", "!= 5.0.1", "!= 5.1.0"
-gem "google-protobuf", ["~> 3.0", "!= 3.7.0", "!= 3.7.1"]
 gem "rails", "~> 7.1.0"
 
 group :check do

--- a/gemfiles/ruby_3.0_rails_old_redis.gemfile
+++ b/gemfiles/ruby_3.0_rails_old_redis.gemfile
@@ -6,7 +6,9 @@ gem "benchmark-ips", "~> 2.8"
 gem "benchmark-memory", "< 0.2"
 gem "climate_control", "~> 0.2.0"
 gem "concurrent-ruby"
+gem "dogstatsd-ruby", ">= 3.3.0", "!= 5.0.0", "!= 5.0.1", "!= 5.1.0"
 gem "extlz4", "~> 0.3", ">= 0.3.3"
+gem "google-protobuf", ["~> 3.0", "!= 3.7.0", "!= 3.7.1"]
 gem "json-schema", "< 3"
 gem "memory_profiler", "~> 0.9"
 gem "os", "~> 1.1"
@@ -20,17 +22,15 @@ gem "rspec", "~> 3.13"
 gem "rspec-collection_matchers", "~> 1.1"
 gem "rspec-wait", "~> 0"
 gem "rspec_junit_formatter", ">= 0.5.1"
+gem "rubocop", "~> 1.50.0", require: false
+gem "rubocop-packaging", "~> 0.5.2", require: false
+gem "rubocop-performance", "~> 1.9", require: false
+gem "rubocop-rspec", ["~> 2.20", "< 2.21"], require: false
 gem "simplecov", git: "https://github.com/DataDog/simplecov", ref: "3bb6b7ee58bf4b1954ca205f50dd44d6f41c57db"
 gem "simplecov-cobertura", "~> 2.1.0"
 gem "warning", "~> 1"
 gem "webmock", ">= 3.10.0"
 gem "webrick", ">= 1.7.0"
-gem "rubocop", "~> 1.50.0", require: false
-gem "rubocop-packaging", "~> 0.5.2", require: false
-gem "rubocop-performance", "~> 1.9", require: false
-gem "rubocop-rspec", ["~> 2.20", "< 2.21"], require: false
-gem "dogstatsd-ruby", ">= 3.3.0", "!= 5.0.0", "!= 5.0.1", "!= 5.1.0"
-gem "google-protobuf", ["~> 3.0", "!= 3.7.0", "!= 3.7.1"]
 gem "redis", "< 4"
 gem "rails", "~> 6.1.0"
 gem "pg", ">= 1.1", platform: :ruby

--- a/gemfiles/ruby_3.0_redis_3.gemfile
+++ b/gemfiles/ruby_3.0_redis_3.gemfile
@@ -6,7 +6,9 @@ gem "benchmark-ips", "~> 2.8"
 gem "benchmark-memory", "< 0.2"
 gem "climate_control", "~> 0.2.0"
 gem "concurrent-ruby"
+gem "dogstatsd-ruby", ">= 3.3.0", "!= 5.0.0", "!= 5.0.1", "!= 5.1.0"
 gem "extlz4", "~> 0.3", ">= 0.3.3"
+gem "google-protobuf", ["~> 3.0", "!= 3.7.0", "!= 3.7.1"]
 gem "json-schema", "< 3"
 gem "memory_profiler", "~> 0.9"
 gem "os", "~> 1.1"
@@ -20,17 +22,15 @@ gem "rspec", "~> 3.13"
 gem "rspec-collection_matchers", "~> 1.1"
 gem "rspec-wait", "~> 0"
 gem "rspec_junit_formatter", ">= 0.5.1"
+gem "rubocop", "~> 1.50.0", require: false
+gem "rubocop-packaging", "~> 0.5.2", require: false
+gem "rubocop-performance", "~> 1.9", require: false
+gem "rubocop-rspec", ["~> 2.20", "< 2.21"], require: false
 gem "simplecov", git: "https://github.com/DataDog/simplecov", ref: "3bb6b7ee58bf4b1954ca205f50dd44d6f41c57db"
 gem "simplecov-cobertura", "~> 2.1.0"
 gem "warning", "~> 1"
 gem "webmock", ">= 3.10.0"
 gem "webrick", ">= 1.7.0"
-gem "rubocop", "~> 1.50.0", require: false
-gem "rubocop-packaging", "~> 0.5.2", require: false
-gem "rubocop-performance", "~> 1.9", require: false
-gem "rubocop-rspec", ["~> 2.20", "< 2.21"], require: false
-gem "dogstatsd-ruby", ">= 3.3.0", "!= 5.0.0", "!= 5.0.1", "!= 5.1.0"
-gem "google-protobuf", ["~> 3.0", "!= 3.7.0", "!= 3.7.1"]
 gem "redis", "~> 3"
 
 group :check do

--- a/gemfiles/ruby_3.0_redis_4.gemfile
+++ b/gemfiles/ruby_3.0_redis_4.gemfile
@@ -6,7 +6,9 @@ gem "benchmark-ips", "~> 2.8"
 gem "benchmark-memory", "< 0.2"
 gem "climate_control", "~> 0.2.0"
 gem "concurrent-ruby"
+gem "dogstatsd-ruby", ">= 3.3.0", "!= 5.0.0", "!= 5.0.1", "!= 5.1.0"
 gem "extlz4", "~> 0.3", ">= 0.3.3"
+gem "google-protobuf", ["~> 3.0", "!= 3.7.0", "!= 3.7.1"]
 gem "json-schema", "< 3"
 gem "memory_profiler", "~> 0.9"
 gem "os", "~> 1.1"
@@ -20,17 +22,15 @@ gem "rspec", "~> 3.13"
 gem "rspec-collection_matchers", "~> 1.1"
 gem "rspec-wait", "~> 0"
 gem "rspec_junit_formatter", ">= 0.5.1"
+gem "rubocop", "~> 1.50.0", require: false
+gem "rubocop-packaging", "~> 0.5.2", require: false
+gem "rubocop-performance", "~> 1.9", require: false
+gem "rubocop-rspec", ["~> 2.20", "< 2.21"], require: false
 gem "simplecov", git: "https://github.com/DataDog/simplecov", ref: "3bb6b7ee58bf4b1954ca205f50dd44d6f41c57db"
 gem "simplecov-cobertura", "~> 2.1.0"
 gem "warning", "~> 1"
 gem "webmock", ">= 3.10.0"
 gem "webrick", ">= 1.7.0"
-gem "rubocop", "~> 1.50.0", require: false
-gem "rubocop-packaging", "~> 0.5.2", require: false
-gem "rubocop-performance", "~> 1.9", require: false
-gem "rubocop-rspec", ["~> 2.20", "< 2.21"], require: false
-gem "dogstatsd-ruby", ">= 3.3.0", "!= 5.0.0", "!= 5.0.1", "!= 5.1.0"
-gem "google-protobuf", ["~> 3.0", "!= 3.7.0", "!= 3.7.1"]
 gem "redis", "~> 4"
 
 group :check do

--- a/gemfiles/ruby_3.0_redis_5.gemfile
+++ b/gemfiles/ruby_3.0_redis_5.gemfile
@@ -6,7 +6,9 @@ gem "benchmark-ips", "~> 2.8"
 gem "benchmark-memory", "< 0.2"
 gem "climate_control", "~> 0.2.0"
 gem "concurrent-ruby"
+gem "dogstatsd-ruby", ">= 3.3.0", "!= 5.0.0", "!= 5.0.1", "!= 5.1.0"
 gem "extlz4", "~> 0.3", ">= 0.3.3"
+gem "google-protobuf", ["~> 3.0", "!= 3.7.0", "!= 3.7.1"]
 gem "json-schema", "< 3"
 gem "memory_profiler", "~> 0.9"
 gem "os", "~> 1.1"
@@ -20,17 +22,15 @@ gem "rspec", "~> 3.13"
 gem "rspec-collection_matchers", "~> 1.1"
 gem "rspec-wait", "~> 0"
 gem "rspec_junit_formatter", ">= 0.5.1"
+gem "rubocop", "~> 1.50.0", require: false
+gem "rubocop-packaging", "~> 0.5.2", require: false
+gem "rubocop-performance", "~> 1.9", require: false
+gem "rubocop-rspec", ["~> 2.20", "< 2.21"], require: false
 gem "simplecov", git: "https://github.com/DataDog/simplecov", ref: "3bb6b7ee58bf4b1954ca205f50dd44d6f41c57db"
 gem "simplecov-cobertura", "~> 2.1.0"
 gem "warning", "~> 1"
 gem "webmock", ">= 3.10.0"
 gem "webrick", ">= 1.7.0"
-gem "rubocop", "~> 1.50.0", require: false
-gem "rubocop-packaging", "~> 0.5.2", require: false
-gem "rubocop-performance", "~> 1.9", require: false
-gem "rubocop-rspec", ["~> 2.20", "< 2.21"], require: false
-gem "dogstatsd-ruby", ">= 3.3.0", "!= 5.0.0", "!= 5.0.1", "!= 5.1.0"
-gem "google-protobuf", ["~> 3.0", "!= 3.7.0", "!= 3.7.1"]
 gem "redis", "~> 5"
 
 group :check do

--- a/gemfiles/ruby_3.0_relational_db.gemfile
+++ b/gemfiles/ruby_3.0_relational_db.gemfile
@@ -6,7 +6,9 @@ gem "benchmark-ips", "~> 2.8"
 gem "benchmark-memory", "< 0.2"
 gem "climate_control", "~> 0.2.0"
 gem "concurrent-ruby"
+gem "dogstatsd-ruby", ">= 3.3.0", "!= 5.0.0", "!= 5.0.1", "!= 5.1.0"
 gem "extlz4", "~> 0.3", ">= 0.3.3"
+gem "google-protobuf", ["~> 3.0", "!= 3.7.0", "!= 3.7.1"]
 gem "json-schema", "< 3"
 gem "memory_profiler", "~> 0.9"
 gem "os", "~> 1.1"
@@ -20,17 +22,15 @@ gem "rspec", "~> 3.13"
 gem "rspec-collection_matchers", "~> 1.1"
 gem "rspec-wait", "~> 0"
 gem "rspec_junit_formatter", ">= 0.5.1"
+gem "rubocop", "~> 1.50.0", require: false
+gem "rubocop-packaging", "~> 0.5.2", require: false
+gem "rubocop-performance", "~> 1.9", require: false
+gem "rubocop-rspec", ["~> 2.20", "< 2.21"], require: false
 gem "simplecov", git: "https://github.com/DataDog/simplecov", ref: "3bb6b7ee58bf4b1954ca205f50dd44d6f41c57db"
 gem "simplecov-cobertura", "~> 2.1.0"
 gem "warning", "~> 1"
 gem "webmock", ">= 3.10.0"
 gem "webrick", ">= 1.7.0"
-gem "rubocop", "~> 1.50.0", require: false
-gem "rubocop-packaging", "~> 0.5.2", require: false
-gem "rubocop-performance", "~> 1.9", require: false
-gem "rubocop-rspec", ["~> 2.20", "< 2.21"], require: false
-gem "dogstatsd-ruby", ">= 3.3.0", "!= 5.0.0", "!= 5.0.1", "!= 5.1.0"
-gem "google-protobuf", ["~> 3.0", "!= 3.7.0", "!= 3.7.1"]
 gem "activerecord", "~> 7"
 gem "delayed_job"
 gem "delayed_job_active_record"

--- a/gemfiles/ruby_3.0_resque2_redis3.gemfile
+++ b/gemfiles/ruby_3.0_resque2_redis3.gemfile
@@ -6,7 +6,9 @@ gem "benchmark-ips", "~> 2.8"
 gem "benchmark-memory", "< 0.2"
 gem "climate_control", "~> 0.2.0"
 gem "concurrent-ruby"
+gem "dogstatsd-ruby", ">= 3.3.0", "!= 5.0.0", "!= 5.0.1", "!= 5.1.0"
 gem "extlz4", "~> 0.3", ">= 0.3.3"
+gem "google-protobuf", ["~> 3.0", "!= 3.7.0", "!= 3.7.1"]
 gem "json-schema", "< 3"
 gem "memory_profiler", "~> 0.9"
 gem "os", "~> 1.1"
@@ -20,17 +22,15 @@ gem "rspec", "~> 3.13"
 gem "rspec-collection_matchers", "~> 1.1"
 gem "rspec-wait", "~> 0"
 gem "rspec_junit_formatter", ">= 0.5.1"
+gem "rubocop", "~> 1.50.0", require: false
+gem "rubocop-packaging", "~> 0.5.2", require: false
+gem "rubocop-performance", "~> 1.9", require: false
+gem "rubocop-rspec", ["~> 2.20", "< 2.21"], require: false
 gem "simplecov", git: "https://github.com/DataDog/simplecov", ref: "3bb6b7ee58bf4b1954ca205f50dd44d6f41c57db"
 gem "simplecov-cobertura", "~> 2.1.0"
 gem "warning", "~> 1"
 gem "webmock", ">= 3.10.0"
 gem "webrick", ">= 1.7.0"
-gem "rubocop", "~> 1.50.0", require: false
-gem "rubocop-packaging", "~> 0.5.2", require: false
-gem "rubocop-performance", "~> 1.9", require: false
-gem "rubocop-rspec", ["~> 2.20", "< 2.21"], require: false
-gem "dogstatsd-ruby", ">= 3.3.0", "!= 5.0.0", "!= 5.0.1", "!= 5.1.0"
-gem "google-protobuf", ["~> 3.0", "!= 3.7.0", "!= 3.7.1"]
 gem "redis", "< 4.0"
 gem "resque", ">= 2.0"
 

--- a/gemfiles/ruby_3.0_resque2_redis4.gemfile
+++ b/gemfiles/ruby_3.0_resque2_redis4.gemfile
@@ -6,7 +6,9 @@ gem "benchmark-ips", "~> 2.8"
 gem "benchmark-memory", "< 0.2"
 gem "climate_control", "~> 0.2.0"
 gem "concurrent-ruby"
+gem "dogstatsd-ruby", ">= 3.3.0", "!= 5.0.0", "!= 5.0.1", "!= 5.1.0"
 gem "extlz4", "~> 0.3", ">= 0.3.3"
+gem "google-protobuf", ["~> 3.0", "!= 3.7.0", "!= 3.7.1"]
 gem "json-schema", "< 3"
 gem "memory_profiler", "~> 0.9"
 gem "os", "~> 1.1"
@@ -20,17 +22,15 @@ gem "rspec", "~> 3.13"
 gem "rspec-collection_matchers", "~> 1.1"
 gem "rspec-wait", "~> 0"
 gem "rspec_junit_formatter", ">= 0.5.1"
+gem "rubocop", "~> 1.50.0", require: false
+gem "rubocop-packaging", "~> 0.5.2", require: false
+gem "rubocop-performance", "~> 1.9", require: false
+gem "rubocop-rspec", ["~> 2.20", "< 2.21"], require: false
 gem "simplecov", git: "https://github.com/DataDog/simplecov", ref: "3bb6b7ee58bf4b1954ca205f50dd44d6f41c57db"
 gem "simplecov-cobertura", "~> 2.1.0"
 gem "warning", "~> 1"
 gem "webmock", ">= 3.10.0"
 gem "webrick", ">= 1.7.0"
-gem "rubocop", "~> 1.50.0", require: false
-gem "rubocop-packaging", "~> 0.5.2", require: false
-gem "rubocop-performance", "~> 1.9", require: false
-gem "rubocop-rspec", ["~> 2.20", "< 2.21"], require: false
-gem "dogstatsd-ruby", ">= 3.3.0", "!= 5.0.0", "!= 5.0.1", "!= 5.1.0"
-gem "google-protobuf", ["~> 3.0", "!= 3.7.0", "!= 3.7.1"]
 gem "redis", ">= 4.0"
 gem "resque", ">= 2.0"
 

--- a/gemfiles/ruby_3.0_sinatra_2.gemfile
+++ b/gemfiles/ruby_3.0_sinatra_2.gemfile
@@ -6,7 +6,9 @@ gem "benchmark-ips", "~> 2.8"
 gem "benchmark-memory", "< 0.2"
 gem "climate_control", "~> 0.2.0"
 gem "concurrent-ruby"
+gem "dogstatsd-ruby", ">= 3.3.0", "!= 5.0.0", "!= 5.0.1", "!= 5.1.0"
 gem "extlz4", "~> 0.3", ">= 0.3.3"
+gem "google-protobuf", ["~> 3.0", "!= 3.7.0", "!= 3.7.1"]
 gem "json-schema", "< 3"
 gem "memory_profiler", "~> 0.9"
 gem "os", "~> 1.1"
@@ -20,17 +22,15 @@ gem "rspec", "~> 3.13"
 gem "rspec-collection_matchers", "~> 1.1"
 gem "rspec-wait", "~> 0"
 gem "rspec_junit_formatter", ">= 0.5.1"
+gem "rubocop", "~> 1.50.0", require: false
+gem "rubocop-packaging", "~> 0.5.2", require: false
+gem "rubocop-performance", "~> 1.9", require: false
+gem "rubocop-rspec", ["~> 2.20", "< 2.21"], require: false
 gem "simplecov", git: "https://github.com/DataDog/simplecov", ref: "3bb6b7ee58bf4b1954ca205f50dd44d6f41c57db"
 gem "simplecov-cobertura", "~> 2.1.0"
 gem "warning", "~> 1"
 gem "webmock", ">= 3.10.0"
 gem "webrick", ">= 1.7.0"
-gem "rubocop", "~> 1.50.0", require: false
-gem "rubocop-packaging", "~> 0.5.2", require: false
-gem "rubocop-performance", "~> 1.9", require: false
-gem "rubocop-rspec", ["~> 2.20", "< 2.21"], require: false
-gem "dogstatsd-ruby", ">= 3.3.0", "!= 5.0.0", "!= 5.0.1", "!= 5.1.0"
-gem "google-protobuf", ["~> 3.0", "!= 3.7.0", "!= 3.7.1"]
 gem "sinatra", "~> 2"
 gem "rack-contrib"
 gem "rack-test"

--- a/gemfiles/ruby_3.0_sinatra_3.gemfile
+++ b/gemfiles/ruby_3.0_sinatra_3.gemfile
@@ -6,7 +6,9 @@ gem "benchmark-ips", "~> 2.8"
 gem "benchmark-memory", "< 0.2"
 gem "climate_control", "~> 0.2.0"
 gem "concurrent-ruby"
+gem "dogstatsd-ruby", ">= 3.3.0", "!= 5.0.0", "!= 5.0.1", "!= 5.1.0"
 gem "extlz4", "~> 0.3", ">= 0.3.3"
+gem "google-protobuf", ["~> 3.0", "!= 3.7.0", "!= 3.7.1"]
 gem "json-schema", "< 3"
 gem "memory_profiler", "~> 0.9"
 gem "os", "~> 1.1"
@@ -20,17 +22,15 @@ gem "rspec", "~> 3.13"
 gem "rspec-collection_matchers", "~> 1.1"
 gem "rspec-wait", "~> 0"
 gem "rspec_junit_formatter", ">= 0.5.1"
+gem "rubocop", "~> 1.50.0", require: false
+gem "rubocop-packaging", "~> 0.5.2", require: false
+gem "rubocop-performance", "~> 1.9", require: false
+gem "rubocop-rspec", ["~> 2.20", "< 2.21"], require: false
 gem "simplecov", git: "https://github.com/DataDog/simplecov", ref: "3bb6b7ee58bf4b1954ca205f50dd44d6f41c57db"
 gem "simplecov-cobertura", "~> 2.1.0"
 gem "warning", "~> 1"
 gem "webmock", ">= 3.10.0"
 gem "webrick", ">= 1.7.0"
-gem "rubocop", "~> 1.50.0", require: false
-gem "rubocop-packaging", "~> 0.5.2", require: false
-gem "rubocop-performance", "~> 1.9", require: false
-gem "rubocop-rspec", ["~> 2.20", "< 2.21"], require: false
-gem "dogstatsd-ruby", ">= 3.3.0", "!= 5.0.0", "!= 5.0.1", "!= 5.1.0"
-gem "google-protobuf", ["~> 3.0", "!= 3.7.0", "!= 3.7.1"]
 gem "sinatra", "~> 3"
 gem "rack-contrib"
 gem "rack-test"

--- a/gemfiles/ruby_3.0_sinatra_4.gemfile
+++ b/gemfiles/ruby_3.0_sinatra_4.gemfile
@@ -6,7 +6,9 @@ gem "benchmark-ips", "~> 2.8"
 gem "benchmark-memory", "< 0.2"
 gem "climate_control", "~> 0.2.0"
 gem "concurrent-ruby"
+gem "dogstatsd-ruby", ">= 3.3.0", "!= 5.0.0", "!= 5.0.1", "!= 5.1.0"
 gem "extlz4", "~> 0.3", ">= 0.3.3"
+gem "google-protobuf", ["~> 3.0", "!= 3.7.0", "!= 3.7.1"]
 gem "json-schema", "< 3"
 gem "memory_profiler", "~> 0.9"
 gem "os", "~> 1.1"
@@ -20,17 +22,15 @@ gem "rspec", "~> 3.13"
 gem "rspec-collection_matchers", "~> 1.1"
 gem "rspec-wait", "~> 0"
 gem "rspec_junit_formatter", ">= 0.5.1"
+gem "rubocop", "~> 1.50.0", require: false
+gem "rubocop-packaging", "~> 0.5.2", require: false
+gem "rubocop-performance", "~> 1.9", require: false
+gem "rubocop-rspec", ["~> 2.20", "< 2.21"], require: false
 gem "simplecov", git: "https://github.com/DataDog/simplecov", ref: "3bb6b7ee58bf4b1954ca205f50dd44d6f41c57db"
 gem "simplecov-cobertura", "~> 2.1.0"
 gem "warning", "~> 1"
 gem "webmock", ">= 3.10.0"
 gem "webrick", ">= 1.7.0"
-gem "rubocop", "~> 1.50.0", require: false
-gem "rubocop-packaging", "~> 0.5.2", require: false
-gem "rubocop-performance", "~> 1.9", require: false
-gem "rubocop-rspec", ["~> 2.20", "< 2.21"], require: false
-gem "dogstatsd-ruby", ">= 3.3.0", "!= 5.0.0", "!= 5.0.1", "!= 5.1.0"
-gem "google-protobuf", ["~> 3.0", "!= 3.7.0", "!= 3.7.1"]
 gem "sinatra", "~> 4"
 gem "rack-contrib"
 gem "rack-test"

--- a/gemfiles/ruby_3.0_stripe_10.gemfile
+++ b/gemfiles/ruby_3.0_stripe_10.gemfile
@@ -6,7 +6,9 @@ gem "benchmark-ips", "~> 2.8"
 gem "benchmark-memory", "< 0.2"
 gem "climate_control", "~> 0.2.0"
 gem "concurrent-ruby"
+gem "dogstatsd-ruby", ">= 3.3.0", "!= 5.0.0", "!= 5.0.1", "!= 5.1.0"
 gem "extlz4", "~> 0.3", ">= 0.3.3"
+gem "google-protobuf", ["~> 3.0", "!= 3.7.0", "!= 3.7.1"]
 gem "json-schema", "< 3"
 gem "memory_profiler", "~> 0.9"
 gem "os", "~> 1.1"
@@ -20,17 +22,15 @@ gem "rspec", "~> 3.13"
 gem "rspec-collection_matchers", "~> 1.1"
 gem "rspec-wait", "~> 0"
 gem "rspec_junit_formatter", ">= 0.5.1"
+gem "rubocop", "~> 1.50.0", require: false
+gem "rubocop-packaging", "~> 0.5.2", require: false
+gem "rubocop-performance", "~> 1.9", require: false
+gem "rubocop-rspec", ["~> 2.20", "< 2.21"], require: false
 gem "simplecov", git: "https://github.com/DataDog/simplecov", ref: "3bb6b7ee58bf4b1954ca205f50dd44d6f41c57db"
 gem "simplecov-cobertura", "~> 2.1.0"
 gem "warning", "~> 1"
 gem "webmock", ">= 3.10.0"
 gem "webrick", ">= 1.7.0"
-gem "rubocop", "~> 1.50.0", require: false
-gem "rubocop-packaging", "~> 0.5.2", require: false
-gem "rubocop-performance", "~> 1.9", require: false
-gem "rubocop-rspec", ["~> 2.20", "< 2.21"], require: false
-gem "dogstatsd-ruby", ">= 3.3.0", "!= 5.0.0", "!= 5.0.1", "!= 5.1.0"
-gem "google-protobuf", ["~> 3.0", "!= 3.7.0", "!= 3.7.1"]
 gem "stripe", "~> 10"
 
 group :check do

--- a/gemfiles/ruby_3.0_stripe_11.gemfile
+++ b/gemfiles/ruby_3.0_stripe_11.gemfile
@@ -6,7 +6,9 @@ gem "benchmark-ips", "~> 2.8"
 gem "benchmark-memory", "< 0.2"
 gem "climate_control", "~> 0.2.0"
 gem "concurrent-ruby"
+gem "dogstatsd-ruby", ">= 3.3.0", "!= 5.0.0", "!= 5.0.1", "!= 5.1.0"
 gem "extlz4", "~> 0.3", ">= 0.3.3"
+gem "google-protobuf", ["~> 3.0", "!= 3.7.0", "!= 3.7.1"]
 gem "json-schema", "< 3"
 gem "memory_profiler", "~> 0.9"
 gem "os", "~> 1.1"
@@ -20,17 +22,15 @@ gem "rspec", "~> 3.13"
 gem "rspec-collection_matchers", "~> 1.1"
 gem "rspec-wait", "~> 0"
 gem "rspec_junit_formatter", ">= 0.5.1"
+gem "rubocop", "~> 1.50.0", require: false
+gem "rubocop-packaging", "~> 0.5.2", require: false
+gem "rubocop-performance", "~> 1.9", require: false
+gem "rubocop-rspec", ["~> 2.20", "< 2.21"], require: false
 gem "simplecov", git: "https://github.com/DataDog/simplecov", ref: "3bb6b7ee58bf4b1954ca205f50dd44d6f41c57db"
 gem "simplecov-cobertura", "~> 2.1.0"
 gem "warning", "~> 1"
 gem "webmock", ">= 3.10.0"
 gem "webrick", ">= 1.7.0"
-gem "rubocop", "~> 1.50.0", require: false
-gem "rubocop-packaging", "~> 0.5.2", require: false
-gem "rubocop-performance", "~> 1.9", require: false
-gem "rubocop-rspec", ["~> 2.20", "< 2.21"], require: false
-gem "dogstatsd-ruby", ">= 3.3.0", "!= 5.0.0", "!= 5.0.1", "!= 5.1.0"
-gem "google-protobuf", ["~> 3.0", "!= 3.7.0", "!= 3.7.1"]
 gem "stripe", "~> 11"
 
 group :check do

--- a/gemfiles/ruby_3.0_stripe_12.gemfile
+++ b/gemfiles/ruby_3.0_stripe_12.gemfile
@@ -6,7 +6,9 @@ gem "benchmark-ips", "~> 2.8"
 gem "benchmark-memory", "< 0.2"
 gem "climate_control", "~> 0.2.0"
 gem "concurrent-ruby"
+gem "dogstatsd-ruby", ">= 3.3.0", "!= 5.0.0", "!= 5.0.1", "!= 5.1.0"
 gem "extlz4", "~> 0.3", ">= 0.3.3"
+gem "google-protobuf", ["~> 3.0", "!= 3.7.0", "!= 3.7.1"]
 gem "json-schema", "< 3"
 gem "memory_profiler", "~> 0.9"
 gem "os", "~> 1.1"
@@ -20,17 +22,15 @@ gem "rspec", "~> 3.13"
 gem "rspec-collection_matchers", "~> 1.1"
 gem "rspec-wait", "~> 0"
 gem "rspec_junit_formatter", ">= 0.5.1"
+gem "rubocop", "~> 1.50.0", require: false
+gem "rubocop-packaging", "~> 0.5.2", require: false
+gem "rubocop-performance", "~> 1.9", require: false
+gem "rubocop-rspec", ["~> 2.20", "< 2.21"], require: false
 gem "simplecov", git: "https://github.com/DataDog/simplecov", ref: "3bb6b7ee58bf4b1954ca205f50dd44d6f41c57db"
 gem "simplecov-cobertura", "~> 2.1.0"
 gem "warning", "~> 1"
 gem "webmock", ">= 3.10.0"
 gem "webrick", ">= 1.7.0"
-gem "rubocop", "~> 1.50.0", require: false
-gem "rubocop-packaging", "~> 0.5.2", require: false
-gem "rubocop-performance", "~> 1.9", require: false
-gem "rubocop-rspec", ["~> 2.20", "< 2.21"], require: false
-gem "dogstatsd-ruby", ">= 3.3.0", "!= 5.0.0", "!= 5.0.1", "!= 5.1.0"
-gem "google-protobuf", ["~> 3.0", "!= 3.7.0", "!= 3.7.1"]
 gem "stripe", "~> 12"
 
 group :check do

--- a/gemfiles/ruby_3.0_stripe_7.gemfile
+++ b/gemfiles/ruby_3.0_stripe_7.gemfile
@@ -6,7 +6,9 @@ gem "benchmark-ips", "~> 2.8"
 gem "benchmark-memory", "< 0.2"
 gem "climate_control", "~> 0.2.0"
 gem "concurrent-ruby"
+gem "dogstatsd-ruby", ">= 3.3.0", "!= 5.0.0", "!= 5.0.1", "!= 5.1.0"
 gem "extlz4", "~> 0.3", ">= 0.3.3"
+gem "google-protobuf", ["~> 3.0", "!= 3.7.0", "!= 3.7.1"]
 gem "json-schema", "< 3"
 gem "memory_profiler", "~> 0.9"
 gem "os", "~> 1.1"
@@ -20,17 +22,15 @@ gem "rspec", "~> 3.13"
 gem "rspec-collection_matchers", "~> 1.1"
 gem "rspec-wait", "~> 0"
 gem "rspec_junit_formatter", ">= 0.5.1"
+gem "rubocop", "~> 1.50.0", require: false
+gem "rubocop-packaging", "~> 0.5.2", require: false
+gem "rubocop-performance", "~> 1.9", require: false
+gem "rubocop-rspec", ["~> 2.20", "< 2.21"], require: false
 gem "simplecov", git: "https://github.com/DataDog/simplecov", ref: "3bb6b7ee58bf4b1954ca205f50dd44d6f41c57db"
 gem "simplecov-cobertura", "~> 2.1.0"
 gem "warning", "~> 1"
 gem "webmock", ">= 3.10.0"
 gem "webrick", ">= 1.7.0"
-gem "rubocop", "~> 1.50.0", require: false
-gem "rubocop-packaging", "~> 0.5.2", require: false
-gem "rubocop-performance", "~> 1.9", require: false
-gem "rubocop-rspec", ["~> 2.20", "< 2.21"], require: false
-gem "dogstatsd-ruby", ">= 3.3.0", "!= 5.0.0", "!= 5.0.1", "!= 5.1.0"
-gem "google-protobuf", ["~> 3.0", "!= 3.7.0", "!= 3.7.1"]
 gem "stripe", "~> 7"
 
 group :check do

--- a/gemfiles/ruby_3.0_stripe_8.gemfile
+++ b/gemfiles/ruby_3.0_stripe_8.gemfile
@@ -6,7 +6,9 @@ gem "benchmark-ips", "~> 2.8"
 gem "benchmark-memory", "< 0.2"
 gem "climate_control", "~> 0.2.0"
 gem "concurrent-ruby"
+gem "dogstatsd-ruby", ">= 3.3.0", "!= 5.0.0", "!= 5.0.1", "!= 5.1.0"
 gem "extlz4", "~> 0.3", ">= 0.3.3"
+gem "google-protobuf", ["~> 3.0", "!= 3.7.0", "!= 3.7.1"]
 gem "json-schema", "< 3"
 gem "memory_profiler", "~> 0.9"
 gem "os", "~> 1.1"
@@ -20,17 +22,15 @@ gem "rspec", "~> 3.13"
 gem "rspec-collection_matchers", "~> 1.1"
 gem "rspec-wait", "~> 0"
 gem "rspec_junit_formatter", ">= 0.5.1"
+gem "rubocop", "~> 1.50.0", require: false
+gem "rubocop-packaging", "~> 0.5.2", require: false
+gem "rubocop-performance", "~> 1.9", require: false
+gem "rubocop-rspec", ["~> 2.20", "< 2.21"], require: false
 gem "simplecov", git: "https://github.com/DataDog/simplecov", ref: "3bb6b7ee58bf4b1954ca205f50dd44d6f41c57db"
 gem "simplecov-cobertura", "~> 2.1.0"
 gem "warning", "~> 1"
 gem "webmock", ">= 3.10.0"
 gem "webrick", ">= 1.7.0"
-gem "rubocop", "~> 1.50.0", require: false
-gem "rubocop-packaging", "~> 0.5.2", require: false
-gem "rubocop-performance", "~> 1.9", require: false
-gem "rubocop-rspec", ["~> 2.20", "< 2.21"], require: false
-gem "dogstatsd-ruby", ">= 3.3.0", "!= 5.0.0", "!= 5.0.1", "!= 5.1.0"
-gem "google-protobuf", ["~> 3.0", "!= 3.7.0", "!= 3.7.1"]
 gem "stripe", "~> 8"
 
 group :check do

--- a/gemfiles/ruby_3.0_stripe_9.gemfile
+++ b/gemfiles/ruby_3.0_stripe_9.gemfile
@@ -6,7 +6,9 @@ gem "benchmark-ips", "~> 2.8"
 gem "benchmark-memory", "< 0.2"
 gem "climate_control", "~> 0.2.0"
 gem "concurrent-ruby"
+gem "dogstatsd-ruby", ">= 3.3.0", "!= 5.0.0", "!= 5.0.1", "!= 5.1.0"
 gem "extlz4", "~> 0.3", ">= 0.3.3"
+gem "google-protobuf", ["~> 3.0", "!= 3.7.0", "!= 3.7.1"]
 gem "json-schema", "< 3"
 gem "memory_profiler", "~> 0.9"
 gem "os", "~> 1.1"
@@ -20,17 +22,15 @@ gem "rspec", "~> 3.13"
 gem "rspec-collection_matchers", "~> 1.1"
 gem "rspec-wait", "~> 0"
 gem "rspec_junit_formatter", ">= 0.5.1"
+gem "rubocop", "~> 1.50.0", require: false
+gem "rubocop-packaging", "~> 0.5.2", require: false
+gem "rubocop-performance", "~> 1.9", require: false
+gem "rubocop-rspec", ["~> 2.20", "< 2.21"], require: false
 gem "simplecov", git: "https://github.com/DataDog/simplecov", ref: "3bb6b7ee58bf4b1954ca205f50dd44d6f41c57db"
 gem "simplecov-cobertura", "~> 2.1.0"
 gem "warning", "~> 1"
 gem "webmock", ">= 3.10.0"
 gem "webrick", ">= 1.7.0"
-gem "rubocop", "~> 1.50.0", require: false
-gem "rubocop-packaging", "~> 0.5.2", require: false
-gem "rubocop-performance", "~> 1.9", require: false
-gem "rubocop-rspec", ["~> 2.20", "< 2.21"], require: false
-gem "dogstatsd-ruby", ">= 3.3.0", "!= 5.0.0", "!= 5.0.1", "!= 5.1.0"
-gem "google-protobuf", ["~> 3.0", "!= 3.7.0", "!= 3.7.1"]
 gem "stripe", "~> 9"
 
 group :check do

--- a/gemfiles/ruby_3.0_stripe_latest.gemfile
+++ b/gemfiles/ruby_3.0_stripe_latest.gemfile
@@ -6,7 +6,9 @@ gem "benchmark-ips", "~> 2.8"
 gem "benchmark-memory", "< 0.2"
 gem "climate_control", "~> 0.2.0"
 gem "concurrent-ruby"
+gem "dogstatsd-ruby", ">= 3.3.0", "!= 5.0.0", "!= 5.0.1", "!= 5.1.0"
 gem "extlz4", "~> 0.3", ">= 0.3.3"
+gem "google-protobuf", ["~> 3.0", "!= 3.7.0", "!= 3.7.1"]
 gem "json-schema", "< 3"
 gem "memory_profiler", "~> 0.9"
 gem "os", "~> 1.1"
@@ -20,17 +22,15 @@ gem "rspec", "~> 3.13"
 gem "rspec-collection_matchers", "~> 1.1"
 gem "rspec-wait", "~> 0"
 gem "rspec_junit_formatter", ">= 0.5.1"
+gem "rubocop", "~> 1.50.0", require: false
+gem "rubocop-packaging", "~> 0.5.2", require: false
+gem "rubocop-performance", "~> 1.9", require: false
+gem "rubocop-rspec", ["~> 2.20", "< 2.21"], require: false
 gem "simplecov", git: "https://github.com/DataDog/simplecov", ref: "3bb6b7ee58bf4b1954ca205f50dd44d6f41c57db"
 gem "simplecov-cobertura", "~> 2.1.0"
 gem "warning", "~> 1"
 gem "webmock", ">= 3.10.0"
 gem "webrick", ">= 1.7.0"
-gem "rubocop", "~> 1.50.0", require: false
-gem "rubocop-packaging", "~> 0.5.2", require: false
-gem "rubocop-performance", "~> 1.9", require: false
-gem "rubocop-rspec", ["~> 2.20", "< 2.21"], require: false
-gem "dogstatsd-ruby", ">= 3.3.0", "!= 5.0.0", "!= 5.0.1", "!= 5.1.0"
-gem "google-protobuf", ["~> 3.0", "!= 3.7.0", "!= 3.7.1"]
 gem "stripe"
 
 group :check do

--- a/gemfiles/ruby_3.0_stripe_min.gemfile
+++ b/gemfiles/ruby_3.0_stripe_min.gemfile
@@ -6,7 +6,9 @@ gem "benchmark-ips", "~> 2.8"
 gem "benchmark-memory", "< 0.2"
 gem "climate_control", "~> 0.2.0"
 gem "concurrent-ruby"
+gem "dogstatsd-ruby", ">= 3.3.0", "!= 5.0.0", "!= 5.0.1", "!= 5.1.0"
 gem "extlz4", "~> 0.3", ">= 0.3.3"
+gem "google-protobuf", ["~> 3.0", "!= 3.7.0", "!= 3.7.1"]
 gem "json-schema", "< 3"
 gem "memory_profiler", "~> 0.9"
 gem "os", "~> 1.1"
@@ -20,17 +22,15 @@ gem "rspec", "~> 3.13"
 gem "rspec-collection_matchers", "~> 1.1"
 gem "rspec-wait", "~> 0"
 gem "rspec_junit_formatter", ">= 0.5.1"
+gem "rubocop", "~> 1.50.0", require: false
+gem "rubocop-packaging", "~> 0.5.2", require: false
+gem "rubocop-performance", "~> 1.9", require: false
+gem "rubocop-rspec", ["~> 2.20", "< 2.21"], require: false
 gem "simplecov", git: "https://github.com/DataDog/simplecov", ref: "3bb6b7ee58bf4b1954ca205f50dd44d6f41c57db"
 gem "simplecov-cobertura", "~> 2.1.0"
 gem "warning", "~> 1"
 gem "webmock", ">= 3.10.0"
 gem "webrick", ">= 1.7.0"
-gem "rubocop", "~> 1.50.0", require: false
-gem "rubocop-packaging", "~> 0.5.2", require: false
-gem "rubocop-performance", "~> 1.9", require: false
-gem "rubocop-rspec", ["~> 2.20", "< 2.21"], require: false
-gem "dogstatsd-ruby", ">= 3.3.0", "!= 5.0.0", "!= 5.0.1", "!= 5.1.0"
-gem "google-protobuf", ["~> 3.0", "!= 3.7.0", "!= 3.7.1"]
 gem "stripe", "= 5.15.0"
 
 group :check do

--- a/gemfiles/ruby_3.1_activesupport.gemfile
+++ b/gemfiles/ruby_3.1_activesupport.gemfile
@@ -6,7 +6,9 @@ gem "benchmark-ips", "~> 2.8"
 gem "benchmark-memory", "< 0.2"
 gem "climate_control", "~> 0.2.0"
 gem "concurrent-ruby"
+gem "dogstatsd-ruby", ">= 3.3.0", "!= 5.0.0", "!= 5.0.1", "!= 5.1.0"
 gem "extlz4", "~> 0.3", ">= 0.3.3"
+gem "google-protobuf", ["~> 3.0", "!= 3.7.0", "!= 3.7.1"]
 gem "json-schema", "< 3"
 gem "memory_profiler", "~> 0.9"
 gem "os", "~> 1.1"
@@ -20,17 +22,15 @@ gem "rspec", "~> 3.13"
 gem "rspec-collection_matchers", "~> 1.1"
 gem "rspec-wait", "~> 0"
 gem "rspec_junit_formatter", ">= 0.5.1"
+gem "rubocop", "~> 1.50.0", require: false
+gem "rubocop-packaging", "~> 0.5.2", require: false
+gem "rubocop-performance", "~> 1.9", require: false
+gem "rubocop-rspec", ["~> 2.20", "< 2.21"], require: false
 gem "simplecov", git: "https://github.com/DataDog/simplecov", ref: "3bb6b7ee58bf4b1954ca205f50dd44d6f41c57db"
 gem "simplecov-cobertura", "~> 2.1.0"
 gem "warning", "~> 1"
 gem "webmock", ">= 3.10.0"
 gem "webrick", ">= 1.7.0"
-gem "rubocop", "~> 1.50.0", require: false
-gem "rubocop-packaging", "~> 0.5.2", require: false
-gem "rubocop-performance", "~> 1.9", require: false
-gem "rubocop-rspec", ["~> 2.20", "< 2.21"], require: false
-gem "dogstatsd-ruby", ">= 3.3.0", "!= 5.0.0", "!= 5.0.1", "!= 5.1.0"
-gem "google-protobuf", ["~> 3.0", "!= 3.7.0", "!= 3.7.1"]
 gem "activesupport", "~> 7"
 gem "actionpack"
 gem "actionview"

--- a/gemfiles/ruby_3.1_aws.gemfile
+++ b/gemfiles/ruby_3.1_aws.gemfile
@@ -6,7 +6,9 @@ gem "benchmark-ips", "~> 2.8"
 gem "benchmark-memory", "< 0.2"
 gem "climate_control", "~> 0.2.0"
 gem "concurrent-ruby"
+gem "dogstatsd-ruby", ">= 3.3.0", "!= 5.0.0", "!= 5.0.1", "!= 5.1.0"
 gem "extlz4", "~> 0.3", ">= 0.3.3"
+gem "google-protobuf", ["~> 3.0", "!= 3.7.0", "!= 3.7.1"]
 gem "json-schema", "< 3"
 gem "memory_profiler", "~> 0.9"
 gem "os", "~> 1.1"
@@ -20,17 +22,15 @@ gem "rspec", "~> 3.13"
 gem "rspec-collection_matchers", "~> 1.1"
 gem "rspec-wait", "~> 0"
 gem "rspec_junit_formatter", ">= 0.5.1"
+gem "rubocop", "~> 1.50.0", require: false
+gem "rubocop-packaging", "~> 0.5.2", require: false
+gem "rubocop-performance", "~> 1.9", require: false
+gem "rubocop-rspec", ["~> 2.20", "< 2.21"], require: false
 gem "simplecov", git: "https://github.com/DataDog/simplecov", ref: "3bb6b7ee58bf4b1954ca205f50dd44d6f41c57db"
 gem "simplecov-cobertura", "~> 2.1.0"
 gem "warning", "~> 1"
 gem "webmock", ">= 3.10.0"
 gem "webrick", ">= 1.7.0"
-gem "rubocop", "~> 1.50.0", require: false
-gem "rubocop-packaging", "~> 0.5.2", require: false
-gem "rubocop-performance", "~> 1.9", require: false
-gem "rubocop-rspec", ["~> 2.20", "< 2.21"], require: false
-gem "dogstatsd-ruby", ">= 3.3.0", "!= 5.0.0", "!= 5.0.1", "!= 5.1.0"
-gem "google-protobuf", ["~> 3.0", "!= 3.7.0", "!= 3.7.1"]
 gem "aws-sdk"
 gem "shoryuken"
 

--- a/gemfiles/ruby_3.1_contrib.gemfile
+++ b/gemfiles/ruby_3.1_contrib.gemfile
@@ -6,7 +6,9 @@ gem "benchmark-ips", "~> 2.8"
 gem "benchmark-memory", "< 0.2"
 gem "climate_control", "~> 0.2.0"
 gem "concurrent-ruby"
+gem "dogstatsd-ruby", ">= 3.3.0", "!= 5.0.0", "!= 5.0.1", "!= 5.1.0"
 gem "extlz4", "~> 0.3", ">= 0.3.3"
+gem "google-protobuf", ["~> 3.0", "!= 3.7.0", "!= 3.7.1"]
 gem "json-schema", "< 3"
 gem "memory_profiler", "~> 0.9"
 gem "os", "~> 1.1"
@@ -20,17 +22,15 @@ gem "rspec", "~> 3.13"
 gem "rspec-collection_matchers", "~> 1.1"
 gem "rspec-wait", "~> 0"
 gem "rspec_junit_formatter", ">= 0.5.1"
+gem "rubocop", "~> 1.50.0", require: false
+gem "rubocop-packaging", "~> 0.5.2", require: false
+gem "rubocop-performance", "~> 1.9", require: false
+gem "rubocop-rspec", ["~> 2.20", "< 2.21"], require: false
 gem "simplecov", git: "https://github.com/DataDog/simplecov", ref: "3bb6b7ee58bf4b1954ca205f50dd44d6f41c57db"
 gem "simplecov-cobertura", "~> 2.1.0"
 gem "warning", "~> 1"
 gem "webmock", ">= 3.10.0"
 gem "webrick", ">= 1.7.0"
-gem "rubocop", "~> 1.50.0", require: false
-gem "rubocop-packaging", "~> 0.5.2", require: false
-gem "rubocop-performance", "~> 1.9", require: false
-gem "rubocop-rspec", ["~> 2.20", "< 2.21"], require: false
-gem "dogstatsd-ruby", ">= 3.3.0", "!= 5.0.0", "!= 5.0.1", "!= 5.1.0"
-gem "google-protobuf", ["~> 3.0", "!= 3.7.0", "!= 3.7.1"]
 gem "dalli", ">= 3.0.0"
 gem "grpc", ">= 1.38.0", platform: :ruby
 gem "mongo", ">= 2.8.0", "< 2.15.0"

--- a/gemfiles/ruby_3.1_contrib_old.gemfile
+++ b/gemfiles/ruby_3.1_contrib_old.gemfile
@@ -6,7 +6,9 @@ gem "benchmark-ips", "~> 2.8"
 gem "benchmark-memory", "< 0.2"
 gem "climate_control", "~> 0.2.0"
 gem "concurrent-ruby"
+gem "dogstatsd-ruby", ">= 3.3.0", "!= 5.0.0", "!= 5.0.1", "!= 5.1.0"
 gem "extlz4", "~> 0.3", ">= 0.3.3"
+gem "google-protobuf", ["~> 3.0", "!= 3.7.0", "!= 3.7.1"]
 gem "json-schema", "< 3"
 gem "memory_profiler", "~> 0.9"
 gem "os", "~> 1.1"
@@ -20,17 +22,15 @@ gem "rspec", "~> 3.13"
 gem "rspec-collection_matchers", "~> 1.1"
 gem "rspec-wait", "~> 0"
 gem "rspec_junit_formatter", ">= 0.5.1"
+gem "rubocop", "~> 1.50.0", require: false
+gem "rubocop-packaging", "~> 0.5.2", require: false
+gem "rubocop-performance", "~> 1.9", require: false
+gem "rubocop-rspec", ["~> 2.20", "< 2.21"], require: false
 gem "simplecov", git: "https://github.com/DataDog/simplecov", ref: "3bb6b7ee58bf4b1954ca205f50dd44d6f41c57db"
 gem "simplecov-cobertura", "~> 2.1.0"
 gem "warning", "~> 1"
 gem "webmock", ">= 3.10.0"
 gem "webrick", ">= 1.7.0"
-gem "rubocop", "~> 1.50.0", require: false
-gem "rubocop-packaging", "~> 0.5.2", require: false
-gem "rubocop-performance", "~> 1.9", require: false
-gem "rubocop-rspec", ["~> 2.20", "< 2.21"], require: false
-gem "dogstatsd-ruby", ">= 3.3.0", "!= 5.0.0", "!= 5.0.1", "!= 5.1.0"
-gem "google-protobuf", ["~> 3.0", "!= 3.7.0", "!= 3.7.1"]
 gem "dalli", "< 3.0.0"
 gem "presto-client", ">= 0.5.14"
 gem "qless", "0.12.0"

--- a/gemfiles/ruby_3.1_core_old.gemfile
+++ b/gemfiles/ruby_3.1_core_old.gemfile
@@ -6,7 +6,9 @@ gem "benchmark-ips", "~> 2.8"
 gem "benchmark-memory", "< 0.2"
 gem "climate_control", "~> 0.2.0"
 gem "concurrent-ruby"
+gem "dogstatsd-ruby", "~> 4"
 gem "extlz4", "~> 0.3", ">= 0.3.3"
+gem "google-protobuf", ["~> 3.0", "!= 3.7.0", "!= 3.7.1"]
 gem "json-schema", "< 3"
 gem "memory_profiler", "~> 0.9"
 gem "os", "~> 1.1"
@@ -20,17 +22,15 @@ gem "rspec", "~> 3.13"
 gem "rspec-collection_matchers", "~> 1.1"
 gem "rspec-wait", "~> 0"
 gem "rspec_junit_formatter", ">= 0.5.1"
+gem "rubocop", "~> 1.50.0", require: false
+gem "rubocop-packaging", "~> 0.5.2", require: false
+gem "rubocop-performance", "~> 1.9", require: false
+gem "rubocop-rspec", ["~> 2.20", "< 2.21"], require: false
 gem "simplecov", git: "https://github.com/DataDog/simplecov", ref: "3bb6b7ee58bf4b1954ca205f50dd44d6f41c57db"
 gem "simplecov-cobertura", "~> 2.1.0"
 gem "warning", "~> 1"
 gem "webmock", ">= 3.10.0"
 gem "webrick", ">= 1.7.0"
-gem "rubocop", "~> 1.50.0", require: false
-gem "rubocop-packaging", "~> 0.5.2", require: false
-gem "rubocop-performance", "~> 1.9", require: false
-gem "rubocop-rspec", ["~> 2.20", "< 2.21"], require: false
-gem "dogstatsd-ruby", "~> 4"
-gem "google-protobuf", ["~> 3.0", "!= 3.7.0", "!= 3.7.1"]
 
 group :check do
 

--- a/gemfiles/ruby_3.1_elasticsearch_7.gemfile
+++ b/gemfiles/ruby_3.1_elasticsearch_7.gemfile
@@ -6,7 +6,9 @@ gem "benchmark-ips", "~> 2.8"
 gem "benchmark-memory", "< 0.2"
 gem "climate_control", "~> 0.2.0"
 gem "concurrent-ruby"
+gem "dogstatsd-ruby", ">= 3.3.0", "!= 5.0.0", "!= 5.0.1", "!= 5.1.0"
 gem "extlz4", "~> 0.3", ">= 0.3.3"
+gem "google-protobuf", ["~> 3.0", "!= 3.7.0", "!= 3.7.1"]
 gem "json-schema", "< 3"
 gem "memory_profiler", "~> 0.9"
 gem "os", "~> 1.1"
@@ -20,17 +22,15 @@ gem "rspec", "~> 3.13"
 gem "rspec-collection_matchers", "~> 1.1"
 gem "rspec-wait", "~> 0"
 gem "rspec_junit_formatter", ">= 0.5.1"
+gem "rubocop", "~> 1.50.0", require: false
+gem "rubocop-packaging", "~> 0.5.2", require: false
+gem "rubocop-performance", "~> 1.9", require: false
+gem "rubocop-rspec", ["~> 2.20", "< 2.21"], require: false
 gem "simplecov", git: "https://github.com/DataDog/simplecov", ref: "3bb6b7ee58bf4b1954ca205f50dd44d6f41c57db"
 gem "simplecov-cobertura", "~> 2.1.0"
 gem "warning", "~> 1"
 gem "webmock", ">= 3.10.0"
 gem "webrick", ">= 1.7.0"
-gem "rubocop", "~> 1.50.0", require: false
-gem "rubocop-packaging", "~> 0.5.2", require: false
-gem "rubocop-performance", "~> 1.9", require: false
-gem "rubocop-rspec", ["~> 2.20", "< 2.21"], require: false
-gem "dogstatsd-ruby", ">= 3.3.0", "!= 5.0.0", "!= 5.0.1", "!= 5.1.0"
-gem "google-protobuf", ["~> 3.0", "!= 3.7.0", "!= 3.7.1"]
 gem "elasticsearch", "~> 7"
 
 group :check do

--- a/gemfiles/ruby_3.1_elasticsearch_8.gemfile
+++ b/gemfiles/ruby_3.1_elasticsearch_8.gemfile
@@ -6,7 +6,9 @@ gem "benchmark-ips", "~> 2.8"
 gem "benchmark-memory", "< 0.2"
 gem "climate_control", "~> 0.2.0"
 gem "concurrent-ruby"
+gem "dogstatsd-ruby", ">= 3.3.0", "!= 5.0.0", "!= 5.0.1", "!= 5.1.0"
 gem "extlz4", "~> 0.3", ">= 0.3.3"
+gem "google-protobuf", ["~> 3.0", "!= 3.7.0", "!= 3.7.1"]
 gem "json-schema", "< 3"
 gem "memory_profiler", "~> 0.9"
 gem "os", "~> 1.1"
@@ -20,17 +22,15 @@ gem "rspec", "~> 3.13"
 gem "rspec-collection_matchers", "~> 1.1"
 gem "rspec-wait", "~> 0"
 gem "rspec_junit_formatter", ">= 0.5.1"
+gem "rubocop", "~> 1.50.0", require: false
+gem "rubocop-packaging", "~> 0.5.2", require: false
+gem "rubocop-performance", "~> 1.9", require: false
+gem "rubocop-rspec", ["~> 2.20", "< 2.21"], require: false
 gem "simplecov", git: "https://github.com/DataDog/simplecov", ref: "3bb6b7ee58bf4b1954ca205f50dd44d6f41c57db"
 gem "simplecov-cobertura", "~> 2.1.0"
 gem "warning", "~> 1"
 gem "webmock", ">= 3.10.0"
 gem "webrick", ">= 1.7.0"
-gem "rubocop", "~> 1.50.0", require: false
-gem "rubocop-packaging", "~> 0.5.2", require: false
-gem "rubocop-performance", "~> 1.9", require: false
-gem "rubocop-rspec", ["~> 2.20", "< 2.21"], require: false
-gem "dogstatsd-ruby", ">= 3.3.0", "!= 5.0.0", "!= 5.0.1", "!= 5.1.0"
-gem "google-protobuf", ["~> 3.0", "!= 3.7.0", "!= 3.7.1"]
 gem "elasticsearch", "~> 8"
 
 group :check do

--- a/gemfiles/ruby_3.1_elasticsearch_latest.gemfile
+++ b/gemfiles/ruby_3.1_elasticsearch_latest.gemfile
@@ -6,7 +6,9 @@ gem "benchmark-ips", "~> 2.8"
 gem "benchmark-memory", "< 0.2"
 gem "climate_control", "~> 0.2.0"
 gem "concurrent-ruby"
+gem "dogstatsd-ruby", ">= 3.3.0", "!= 5.0.0", "!= 5.0.1", "!= 5.1.0"
 gem "extlz4", "~> 0.3", ">= 0.3.3"
+gem "google-protobuf", ["~> 3.0", "!= 3.7.0", "!= 3.7.1"]
 gem "json-schema", "< 3"
 gem "memory_profiler", "~> 0.9"
 gem "os", "~> 1.1"
@@ -20,17 +22,15 @@ gem "rspec", "~> 3.13"
 gem "rspec-collection_matchers", "~> 1.1"
 gem "rspec-wait", "~> 0"
 gem "rspec_junit_formatter", ">= 0.5.1"
+gem "rubocop", "~> 1.50.0", require: false
+gem "rubocop-packaging", "~> 0.5.2", require: false
+gem "rubocop-performance", "~> 1.9", require: false
+gem "rubocop-rspec", ["~> 2.20", "< 2.21"], require: false
 gem "simplecov", git: "https://github.com/DataDog/simplecov", ref: "3bb6b7ee58bf4b1954ca205f50dd44d6f41c57db"
 gem "simplecov-cobertura", "~> 2.1.0"
 gem "warning", "~> 1"
 gem "webmock", ">= 3.10.0"
 gem "webrick", ">= 1.7.0"
-gem "rubocop", "~> 1.50.0", require: false
-gem "rubocop-packaging", "~> 0.5.2", require: false
-gem "rubocop-performance", "~> 1.9", require: false
-gem "rubocop-rspec", ["~> 2.20", "< 2.21"], require: false
-gem "dogstatsd-ruby", ">= 3.3.0", "!= 5.0.0", "!= 5.0.1", "!= 5.1.0"
-gem "google-protobuf", ["~> 3.0", "!= 3.7.0", "!= 3.7.1"]
 gem "elasticsearch"
 
 group :check do

--- a/gemfiles/ruby_3.1_graphql_1.13.gemfile
+++ b/gemfiles/ruby_3.1_graphql_1.13.gemfile
@@ -6,7 +6,9 @@ gem "benchmark-ips", "~> 2.8"
 gem "benchmark-memory", "< 0.2"
 gem "climate_control", "~> 0.2.0"
 gem "concurrent-ruby"
+gem "dogstatsd-ruby", ">= 3.3.0", "!= 5.0.0", "!= 5.0.1", "!= 5.1.0"
 gem "extlz4", "~> 0.3", ">= 0.3.3"
+gem "google-protobuf", ["~> 3.0", "!= 3.7.0", "!= 3.7.1"]
 gem "json-schema", "< 3"
 gem "memory_profiler", "~> 0.9"
 gem "os", "~> 1.1"
@@ -20,17 +22,15 @@ gem "rspec", "~> 3.13"
 gem "rspec-collection_matchers", "~> 1.1"
 gem "rspec-wait", "~> 0"
 gem "rspec_junit_formatter", ">= 0.5.1"
+gem "rubocop", "~> 1.50.0", require: false
+gem "rubocop-packaging", "~> 0.5.2", require: false
+gem "rubocop-performance", "~> 1.9", require: false
+gem "rubocop-rspec", ["~> 2.20", "< 2.21"], require: false
 gem "simplecov", git: "https://github.com/DataDog/simplecov", ref: "3bb6b7ee58bf4b1954ca205f50dd44d6f41c57db"
 gem "simplecov-cobertura", "~> 2.1.0"
 gem "warning", "~> 1"
 gem "webmock", ">= 3.10.0"
 gem "webrick", ">= 1.7.0"
-gem "rubocop", "~> 1.50.0", require: false
-gem "rubocop-packaging", "~> 0.5.2", require: false
-gem "rubocop-performance", "~> 1.9", require: false
-gem "rubocop-rspec", ["~> 2.20", "< 2.21"], require: false
-gem "dogstatsd-ruby", ">= 3.3.0", "!= 5.0.0", "!= 5.0.1", "!= 5.1.0"
-gem "google-protobuf", ["~> 3.0", "!= 3.7.0", "!= 3.7.1"]
 gem "rails", "~> 6.1.0"
 gem "graphql", "~> 1.13.0"
 gem "sprockets", "< 4"

--- a/gemfiles/ruby_3.1_graphql_2.0.gemfile
+++ b/gemfiles/ruby_3.1_graphql_2.0.gemfile
@@ -6,7 +6,9 @@ gem "benchmark-ips", "~> 2.8"
 gem "benchmark-memory", "< 0.2"
 gem "climate_control", "~> 0.2.0"
 gem "concurrent-ruby"
+gem "dogstatsd-ruby", ">= 3.3.0", "!= 5.0.0", "!= 5.0.1", "!= 5.1.0"
 gem "extlz4", "~> 0.3", ">= 0.3.3"
+gem "google-protobuf", ["~> 3.0", "!= 3.7.0", "!= 3.7.1"]
 gem "json-schema", "< 3"
 gem "memory_profiler", "~> 0.9"
 gem "os", "~> 1.1"
@@ -20,17 +22,15 @@ gem "rspec", "~> 3.13"
 gem "rspec-collection_matchers", "~> 1.1"
 gem "rspec-wait", "~> 0"
 gem "rspec_junit_formatter", ">= 0.5.1"
+gem "rubocop", "~> 1.50.0", require: false
+gem "rubocop-packaging", "~> 0.5.2", require: false
+gem "rubocop-performance", "~> 1.9", require: false
+gem "rubocop-rspec", ["~> 2.20", "< 2.21"], require: false
 gem "simplecov", git: "https://github.com/DataDog/simplecov", ref: "3bb6b7ee58bf4b1954ca205f50dd44d6f41c57db"
 gem "simplecov-cobertura", "~> 2.1.0"
 gem "warning", "~> 1"
 gem "webmock", ">= 3.10.0"
 gem "webrick", ">= 1.7.0"
-gem "rubocop", "~> 1.50.0", require: false
-gem "rubocop-packaging", "~> 0.5.2", require: false
-gem "rubocop-performance", "~> 1.9", require: false
-gem "rubocop-rspec", ["~> 2.20", "< 2.21"], require: false
-gem "dogstatsd-ruby", ">= 3.3.0", "!= 5.0.0", "!= 5.0.1", "!= 5.1.0"
-gem "google-protobuf", ["~> 3.0", "!= 3.7.0", "!= 3.7.1"]
 gem "rails", "~> 6.1.0"
 gem "graphql", "~> 2.0.0"
 gem "sprockets", "< 4"

--- a/gemfiles/ruby_3.1_graphql_2.1.gemfile
+++ b/gemfiles/ruby_3.1_graphql_2.1.gemfile
@@ -6,7 +6,9 @@ gem "benchmark-ips", "~> 2.8"
 gem "benchmark-memory", "< 0.2"
 gem "climate_control", "~> 0.2.0"
 gem "concurrent-ruby"
+gem "dogstatsd-ruby", ">= 3.3.0", "!= 5.0.0", "!= 5.0.1", "!= 5.1.0"
 gem "extlz4", "~> 0.3", ">= 0.3.3"
+gem "google-protobuf", ["~> 3.0", "!= 3.7.0", "!= 3.7.1"]
 gem "json-schema", "< 3"
 gem "memory_profiler", "~> 0.9"
 gem "os", "~> 1.1"
@@ -20,17 +22,15 @@ gem "rspec", "~> 3.13"
 gem "rspec-collection_matchers", "~> 1.1"
 gem "rspec-wait", "~> 0"
 gem "rspec_junit_formatter", ">= 0.5.1"
+gem "rubocop", "~> 1.50.0", require: false
+gem "rubocop-packaging", "~> 0.5.2", require: false
+gem "rubocop-performance", "~> 1.9", require: false
+gem "rubocop-rspec", ["~> 2.20", "< 2.21"], require: false
 gem "simplecov", git: "https://github.com/DataDog/simplecov", ref: "3bb6b7ee58bf4b1954ca205f50dd44d6f41c57db"
 gem "simplecov-cobertura", "~> 2.1.0"
 gem "warning", "~> 1"
 gem "webmock", ">= 3.10.0"
 gem "webrick", ">= 1.7.0"
-gem "rubocop", "~> 1.50.0", require: false
-gem "rubocop-packaging", "~> 0.5.2", require: false
-gem "rubocop-performance", "~> 1.9", require: false
-gem "rubocop-rspec", ["~> 2.20", "< 2.21"], require: false
-gem "dogstatsd-ruby", ">= 3.3.0", "!= 5.0.0", "!= 5.0.1", "!= 5.1.0"
-gem "google-protobuf", ["~> 3.0", "!= 3.7.0", "!= 3.7.1"]
 gem "rails", "~> 6.1.0"
 gem "graphql", "~> 2.1.0"
 gem "sprockets", "< 4"

--- a/gemfiles/ruby_3.1_graphql_2.2.gemfile
+++ b/gemfiles/ruby_3.1_graphql_2.2.gemfile
@@ -6,7 +6,9 @@ gem "benchmark-ips", "~> 2.8"
 gem "benchmark-memory", "< 0.2"
 gem "climate_control", "~> 0.2.0"
 gem "concurrent-ruby"
+gem "dogstatsd-ruby", ">= 3.3.0", "!= 5.0.0", "!= 5.0.1", "!= 5.1.0"
 gem "extlz4", "~> 0.3", ">= 0.3.3"
+gem "google-protobuf", ["~> 3.0", "!= 3.7.0", "!= 3.7.1"]
 gem "json-schema", "< 3"
 gem "memory_profiler", "~> 0.9"
 gem "os", "~> 1.1"
@@ -20,17 +22,15 @@ gem "rspec", "~> 3.13"
 gem "rspec-collection_matchers", "~> 1.1"
 gem "rspec-wait", "~> 0"
 gem "rspec_junit_formatter", ">= 0.5.1"
+gem "rubocop", "~> 1.50.0", require: false
+gem "rubocop-packaging", "~> 0.5.2", require: false
+gem "rubocop-performance", "~> 1.9", require: false
+gem "rubocop-rspec", ["~> 2.20", "< 2.21"], require: false
 gem "simplecov", git: "https://github.com/DataDog/simplecov", ref: "3bb6b7ee58bf4b1954ca205f50dd44d6f41c57db"
 gem "simplecov-cobertura", "~> 2.1.0"
 gem "warning", "~> 1"
 gem "webmock", ">= 3.10.0"
 gem "webrick", ">= 1.7.0"
-gem "rubocop", "~> 1.50.0", require: false
-gem "rubocop-packaging", "~> 0.5.2", require: false
-gem "rubocop-performance", "~> 1.9", require: false
-gem "rubocop-rspec", ["~> 2.20", "< 2.21"], require: false
-gem "dogstatsd-ruby", ">= 3.3.0", "!= 5.0.0", "!= 5.0.1", "!= 5.1.0"
-gem "google-protobuf", ["~> 3.0", "!= 3.7.0", "!= 3.7.1"]
 gem "rails", "~> 6.1.0"
 gem "graphql", "~> 2.2.0"
 gem "sprockets", "< 4"

--- a/gemfiles/ruby_3.1_graphql_2.3.gemfile
+++ b/gemfiles/ruby_3.1_graphql_2.3.gemfile
@@ -6,7 +6,9 @@ gem "benchmark-ips", "~> 2.8"
 gem "benchmark-memory", "< 0.2"
 gem "climate_control", "~> 0.2.0"
 gem "concurrent-ruby"
+gem "dogstatsd-ruby", ">= 3.3.0", "!= 5.0.0", "!= 5.0.1", "!= 5.1.0"
 gem "extlz4", "~> 0.3", ">= 0.3.3"
+gem "google-protobuf", ["~> 3.0", "!= 3.7.0", "!= 3.7.1"]
 gem "json-schema", "< 3"
 gem "memory_profiler", "~> 0.9"
 gem "os", "~> 1.1"
@@ -20,17 +22,15 @@ gem "rspec", "~> 3.13"
 gem "rspec-collection_matchers", "~> 1.1"
 gem "rspec-wait", "~> 0"
 gem "rspec_junit_formatter", ">= 0.5.1"
+gem "rubocop", "~> 1.50.0", require: false
+gem "rubocop-packaging", "~> 0.5.2", require: false
+gem "rubocop-performance", "~> 1.9", require: false
+gem "rubocop-rspec", ["~> 2.20", "< 2.21"], require: false
 gem "simplecov", git: "https://github.com/DataDog/simplecov", ref: "3bb6b7ee58bf4b1954ca205f50dd44d6f41c57db"
 gem "simplecov-cobertura", "~> 2.1.0"
 gem "warning", "~> 1"
 gem "webmock", ">= 3.10.0"
 gem "webrick", ">= 1.7.0"
-gem "rubocop", "~> 1.50.0", require: false
-gem "rubocop-packaging", "~> 0.5.2", require: false
-gem "rubocop-performance", "~> 1.9", require: false
-gem "rubocop-rspec", ["~> 2.20", "< 2.21"], require: false
-gem "dogstatsd-ruby", ">= 3.3.0", "!= 5.0.0", "!= 5.0.1", "!= 5.1.0"
-gem "google-protobuf", ["~> 3.0", "!= 3.7.0", "!= 3.7.1"]
 gem "rails", "~> 6.1.0"
 gem "graphql", "~> 2.3.0"
 gem "sprockets", "< 4"

--- a/gemfiles/ruby_3.1_http.gemfile
+++ b/gemfiles/ruby_3.1_http.gemfile
@@ -6,7 +6,9 @@ gem "benchmark-ips", "~> 2.8"
 gem "benchmark-memory", "< 0.2"
 gem "climate_control", "~> 0.2.0"
 gem "concurrent-ruby"
+gem "dogstatsd-ruby", ">= 3.3.0", "!= 5.0.0", "!= 5.0.1", "!= 5.1.0"
 gem "extlz4", "~> 0.3", ">= 0.3.3"
+gem "google-protobuf", ["~> 3.0", "!= 3.7.0", "!= 3.7.1"]
 gem "json-schema", "< 3"
 gem "memory_profiler", "~> 0.9"
 gem "os", "~> 1.1"
@@ -20,17 +22,15 @@ gem "rspec", "~> 3.13"
 gem "rspec-collection_matchers", "~> 1.1"
 gem "rspec-wait", "~> 0"
 gem "rspec_junit_formatter", ">= 0.5.1"
+gem "rubocop", "~> 1.50.0", require: false
+gem "rubocop-packaging", "~> 0.5.2", require: false
+gem "rubocop-performance", "~> 1.9", require: false
+gem "rubocop-rspec", ["~> 2.20", "< 2.21"], require: false
 gem "simplecov", git: "https://github.com/DataDog/simplecov", ref: "3bb6b7ee58bf4b1954ca205f50dd44d6f41c57db"
 gem "simplecov-cobertura", "~> 2.1.0"
 gem "warning", "~> 1"
 gem "webmock", ">= 3.10.0"
 gem "webrick", ">= 1.7.0"
-gem "rubocop", "~> 1.50.0", require: false
-gem "rubocop-packaging", "~> 0.5.2", require: false
-gem "rubocop-performance", "~> 1.9", require: false
-gem "rubocop-rspec", ["~> 2.20", "< 2.21"], require: false
-gem "dogstatsd-ruby", ">= 3.3.0", "!= 5.0.0", "!= 5.0.1", "!= 5.1.0"
-gem "google-protobuf", ["~> 3.0", "!= 3.7.0", "!= 3.7.1"]
 gem "ethon"
 gem "excon"
 gem "faraday"

--- a/gemfiles/ruby_3.1_opensearch_2.gemfile
+++ b/gemfiles/ruby_3.1_opensearch_2.gemfile
@@ -6,7 +6,9 @@ gem "benchmark-ips", "~> 2.8"
 gem "benchmark-memory", "< 0.2"
 gem "climate_control", "~> 0.2.0"
 gem "concurrent-ruby"
+gem "dogstatsd-ruby", ">= 3.3.0", "!= 5.0.0", "!= 5.0.1", "!= 5.1.0"
 gem "extlz4", "~> 0.3", ">= 0.3.3"
+gem "google-protobuf", ["~> 3.0", "!= 3.7.0", "!= 3.7.1"]
 gem "json-schema", "< 3"
 gem "memory_profiler", "~> 0.9"
 gem "os", "~> 1.1"
@@ -20,17 +22,15 @@ gem "rspec", "~> 3.13"
 gem "rspec-collection_matchers", "~> 1.1"
 gem "rspec-wait", "~> 0"
 gem "rspec_junit_formatter", ">= 0.5.1"
+gem "rubocop", "~> 1.50.0", require: false
+gem "rubocop-packaging", "~> 0.5.2", require: false
+gem "rubocop-performance", "~> 1.9", require: false
+gem "rubocop-rspec", ["~> 2.20", "< 2.21"], require: false
 gem "simplecov", git: "https://github.com/DataDog/simplecov", ref: "3bb6b7ee58bf4b1954ca205f50dd44d6f41c57db"
 gem "simplecov-cobertura", "~> 2.1.0"
 gem "warning", "~> 1"
 gem "webmock", ">= 3.10.0"
 gem "webrick", ">= 1.7.0"
-gem "rubocop", "~> 1.50.0", require: false
-gem "rubocop-packaging", "~> 0.5.2", require: false
-gem "rubocop-performance", "~> 1.9", require: false
-gem "rubocop-rspec", ["~> 2.20", "< 2.21"], require: false
-gem "dogstatsd-ruby", ">= 3.3.0", "!= 5.0.0", "!= 5.0.1", "!= 5.1.0"
-gem "google-protobuf", ["~> 3.0", "!= 3.7.0", "!= 3.7.1"]
 gem "opensearch-ruby", "~> 2"
 
 group :check do

--- a/gemfiles/ruby_3.1_opensearch_3.gemfile
+++ b/gemfiles/ruby_3.1_opensearch_3.gemfile
@@ -6,7 +6,9 @@ gem "benchmark-ips", "~> 2.8"
 gem "benchmark-memory", "< 0.2"
 gem "climate_control", "~> 0.2.0"
 gem "concurrent-ruby"
+gem "dogstatsd-ruby", ">= 3.3.0", "!= 5.0.0", "!= 5.0.1", "!= 5.1.0"
 gem "extlz4", "~> 0.3", ">= 0.3.3"
+gem "google-protobuf", ["~> 3.0", "!= 3.7.0", "!= 3.7.1"]
 gem "json-schema", "< 3"
 gem "memory_profiler", "~> 0.9"
 gem "os", "~> 1.1"
@@ -20,17 +22,15 @@ gem "rspec", "~> 3.13"
 gem "rspec-collection_matchers", "~> 1.1"
 gem "rspec-wait", "~> 0"
 gem "rspec_junit_formatter", ">= 0.5.1"
+gem "rubocop", "~> 1.50.0", require: false
+gem "rubocop-packaging", "~> 0.5.2", require: false
+gem "rubocop-performance", "~> 1.9", require: false
+gem "rubocop-rspec", ["~> 2.20", "< 2.21"], require: false
 gem "simplecov", git: "https://github.com/DataDog/simplecov", ref: "3bb6b7ee58bf4b1954ca205f50dd44d6f41c57db"
 gem "simplecov-cobertura", "~> 2.1.0"
 gem "warning", "~> 1"
 gem "webmock", ">= 3.10.0"
 gem "webrick", ">= 1.7.0"
-gem "rubocop", "~> 1.50.0", require: false
-gem "rubocop-packaging", "~> 0.5.2", require: false
-gem "rubocop-performance", "~> 1.9", require: false
-gem "rubocop-rspec", ["~> 2.20", "< 2.21"], require: false
-gem "dogstatsd-ruby", ">= 3.3.0", "!= 5.0.0", "!= 5.0.1", "!= 5.1.0"
-gem "google-protobuf", ["~> 3.0", "!= 3.7.0", "!= 3.7.1"]
 gem "opensearch-ruby", "~> 3"
 
 group :check do

--- a/gemfiles/ruby_3.1_opensearch_latest.gemfile
+++ b/gemfiles/ruby_3.1_opensearch_latest.gemfile
@@ -6,7 +6,9 @@ gem "benchmark-ips", "~> 2.8"
 gem "benchmark-memory", "< 0.2"
 gem "climate_control", "~> 0.2.0"
 gem "concurrent-ruby"
+gem "dogstatsd-ruby", ">= 3.3.0", "!= 5.0.0", "!= 5.0.1", "!= 5.1.0"
 gem "extlz4", "~> 0.3", ">= 0.3.3"
+gem "google-protobuf", ["~> 3.0", "!= 3.7.0", "!= 3.7.1"]
 gem "json-schema", "< 3"
 gem "memory_profiler", "~> 0.9"
 gem "os", "~> 1.1"
@@ -20,17 +22,15 @@ gem "rspec", "~> 3.13"
 gem "rspec-collection_matchers", "~> 1.1"
 gem "rspec-wait", "~> 0"
 gem "rspec_junit_formatter", ">= 0.5.1"
+gem "rubocop", "~> 1.50.0", require: false
+gem "rubocop-packaging", "~> 0.5.2", require: false
+gem "rubocop-performance", "~> 1.9", require: false
+gem "rubocop-rspec", ["~> 2.20", "< 2.21"], require: false
 gem "simplecov", git: "https://github.com/DataDog/simplecov", ref: "3bb6b7ee58bf4b1954ca205f50dd44d6f41c57db"
 gem "simplecov-cobertura", "~> 2.1.0"
 gem "warning", "~> 1"
 gem "webmock", ">= 3.10.0"
 gem "webrick", ">= 1.7.0"
-gem "rubocop", "~> 1.50.0", require: false
-gem "rubocop-packaging", "~> 0.5.2", require: false
-gem "rubocop-performance", "~> 1.9", require: false
-gem "rubocop-rspec", ["~> 2.20", "< 2.21"], require: false
-gem "dogstatsd-ruby", ">= 3.3.0", "!= 5.0.0", "!= 5.0.1", "!= 5.1.0"
-gem "google-protobuf", ["~> 3.0", "!= 3.7.0", "!= 3.7.1"]
 gem "opensearch-ruby"
 
 group :check do

--- a/gemfiles/ruby_3.1_opentelemetry.gemfile
+++ b/gemfiles/ruby_3.1_opentelemetry.gemfile
@@ -6,7 +6,9 @@ gem "benchmark-ips", "~> 2.8"
 gem "benchmark-memory", "< 0.2"
 gem "climate_control", "~> 0.2.0"
 gem "concurrent-ruby"
+gem "dogstatsd-ruby", ">= 3.3.0", "!= 5.0.0", "!= 5.0.1", "!= 5.1.0"
 gem "extlz4", "~> 0.3", ">= 0.3.3"
+gem "google-protobuf", ["~> 3.0", "!= 3.7.0", "!= 3.7.1"]
 gem "json-schema", "< 3"
 gem "memory_profiler", "~> 0.9"
 gem "os", "~> 1.1"
@@ -20,17 +22,15 @@ gem "rspec", "~> 3.13"
 gem "rspec-collection_matchers", "~> 1.1"
 gem "rspec-wait", "~> 0"
 gem "rspec_junit_formatter", ">= 0.5.1"
+gem "rubocop", "~> 1.50.0", require: false
+gem "rubocop-packaging", "~> 0.5.2", require: false
+gem "rubocop-performance", "~> 1.9", require: false
+gem "rubocop-rspec", ["~> 2.20", "< 2.21"], require: false
 gem "simplecov", git: "https://github.com/DataDog/simplecov", ref: "3bb6b7ee58bf4b1954ca205f50dd44d6f41c57db"
 gem "simplecov-cobertura", "~> 2.1.0"
 gem "warning", "~> 1"
 gem "webmock", ">= 3.10.0"
 gem "webrick", ">= 1.7.0"
-gem "rubocop", "~> 1.50.0", require: false
-gem "rubocop-packaging", "~> 0.5.2", require: false
-gem "rubocop-performance", "~> 1.9", require: false
-gem "rubocop-rspec", ["~> 2.20", "< 2.21"], require: false
-gem "dogstatsd-ruby", ">= 3.3.0", "!= 5.0.0", "!= 5.0.1", "!= 5.1.0"
-gem "google-protobuf", ["~> 3.0", "!= 3.7.0", "!= 3.7.1"]
 gem "opentelemetry-sdk", "~> 1.1"
 
 group :check do

--- a/gemfiles/ruby_3.1_opentelemetry_otlp.gemfile
+++ b/gemfiles/ruby_3.1_opentelemetry_otlp.gemfile
@@ -6,7 +6,9 @@ gem "benchmark-ips", "~> 2.8"
 gem "benchmark-memory", "< 0.2"
 gem "climate_control", "~> 0.2.0"
 gem "concurrent-ruby"
+gem "dogstatsd-ruby", ">= 3.3.0", "!= 5.0.0", "!= 5.0.1", "!= 5.1.0"
 gem "extlz4", "~> 0.3", ">= 0.3.3"
+gem "google-protobuf", ["~> 3.0", "!= 3.7.0", "!= 3.7.1"]
 gem "json-schema", "< 3"
 gem "memory_profiler", "~> 0.9"
 gem "os", "~> 1.1"
@@ -20,17 +22,15 @@ gem "rspec", "~> 3.13"
 gem "rspec-collection_matchers", "~> 1.1"
 gem "rspec-wait", "~> 0"
 gem "rspec_junit_formatter", ">= 0.5.1"
+gem "rubocop", "~> 1.50.0", require: false
+gem "rubocop-packaging", "~> 0.5.2", require: false
+gem "rubocop-performance", "~> 1.9", require: false
+gem "rubocop-rspec", ["~> 2.20", "< 2.21"], require: false
 gem "simplecov", git: "https://github.com/DataDog/simplecov", ref: "3bb6b7ee58bf4b1954ca205f50dd44d6f41c57db"
 gem "simplecov-cobertura", "~> 2.1.0"
 gem "warning", "~> 1"
 gem "webmock", ">= 3.10.0"
 gem "webrick", ">= 1.7.0"
-gem "rubocop", "~> 1.50.0", require: false
-gem "rubocop-packaging", "~> 0.5.2", require: false
-gem "rubocop-performance", "~> 1.9", require: false
-gem "rubocop-rspec", ["~> 2.20", "< 2.21"], require: false
-gem "dogstatsd-ruby", ">= 3.3.0", "!= 5.0.0", "!= 5.0.1", "!= 5.1.0"
-gem "google-protobuf", ["~> 3.0", "!= 3.7.0", "!= 3.7.1"]
 gem "opentelemetry-sdk", "~> 1.1"
 gem "opentelemetry-exporter-otlp"
 

--- a/gemfiles/ruby_3.1_rack_1.gemfile
+++ b/gemfiles/ruby_3.1_rack_1.gemfile
@@ -6,7 +6,9 @@ gem "benchmark-ips", "~> 2.8"
 gem "benchmark-memory", "< 0.2"
 gem "climate_control", "~> 0.2.0"
 gem "concurrent-ruby"
+gem "dogstatsd-ruby", ">= 3.3.0", "!= 5.0.0", "!= 5.0.1", "!= 5.1.0"
 gem "extlz4", "~> 0.3", ">= 0.3.3"
+gem "google-protobuf", ["~> 3.0", "!= 3.7.0", "!= 3.7.1"]
 gem "json-schema", "< 3"
 gem "memory_profiler", "~> 0.9"
 gem "os", "~> 1.1"
@@ -20,17 +22,15 @@ gem "rspec", "~> 3.13"
 gem "rspec-collection_matchers", "~> 1.1"
 gem "rspec-wait", "~> 0"
 gem "rspec_junit_formatter", ">= 0.5.1"
+gem "rubocop", "~> 1.50.0", require: false
+gem "rubocop-packaging", "~> 0.5.2", require: false
+gem "rubocop-performance", "~> 1.9", require: false
+gem "rubocop-rspec", ["~> 2.20", "< 2.21"], require: false
 gem "simplecov", git: "https://github.com/DataDog/simplecov", ref: "3bb6b7ee58bf4b1954ca205f50dd44d6f41c57db"
 gem "simplecov-cobertura", "~> 2.1.0"
 gem "warning", "~> 1"
 gem "webmock", ">= 3.10.0"
 gem "webrick", ">= 1.7.0"
-gem "rubocop", "~> 1.50.0", require: false
-gem "rubocop-packaging", "~> 0.5.2", require: false
-gem "rubocop-performance", "~> 1.9", require: false
-gem "rubocop-rspec", ["~> 2.20", "< 2.21"], require: false
-gem "dogstatsd-ruby", ">= 3.3.0", "!= 5.0.0", "!= 5.0.1", "!= 5.1.0"
-gem "google-protobuf", ["~> 3.0", "!= 3.7.0", "!= 3.7.1"]
 gem "rack", "~> 1"
 gem "rack-contrib"
 gem "rack-test"

--- a/gemfiles/ruby_3.1_rack_2.gemfile
+++ b/gemfiles/ruby_3.1_rack_2.gemfile
@@ -6,7 +6,9 @@ gem "benchmark-ips", "~> 2.8"
 gem "benchmark-memory", "< 0.2"
 gem "climate_control", "~> 0.2.0"
 gem "concurrent-ruby"
+gem "dogstatsd-ruby", ">= 3.3.0", "!= 5.0.0", "!= 5.0.1", "!= 5.1.0"
 gem "extlz4", "~> 0.3", ">= 0.3.3"
+gem "google-protobuf", ["~> 3.0", "!= 3.7.0", "!= 3.7.1"]
 gem "json-schema", "< 3"
 gem "memory_profiler", "~> 0.9"
 gem "os", "~> 1.1"
@@ -20,17 +22,15 @@ gem "rspec", "~> 3.13"
 gem "rspec-collection_matchers", "~> 1.1"
 gem "rspec-wait", "~> 0"
 gem "rspec_junit_formatter", ">= 0.5.1"
+gem "rubocop", "~> 1.50.0", require: false
+gem "rubocop-packaging", "~> 0.5.2", require: false
+gem "rubocop-performance", "~> 1.9", require: false
+gem "rubocop-rspec", ["~> 2.20", "< 2.21"], require: false
 gem "simplecov", git: "https://github.com/DataDog/simplecov", ref: "3bb6b7ee58bf4b1954ca205f50dd44d6f41c57db"
 gem "simplecov-cobertura", "~> 2.1.0"
 gem "warning", "~> 1"
 gem "webmock", ">= 3.10.0"
 gem "webrick", ">= 1.7.0"
-gem "rubocop", "~> 1.50.0", require: false
-gem "rubocop-packaging", "~> 0.5.2", require: false
-gem "rubocop-performance", "~> 1.9", require: false
-gem "rubocop-rspec", ["~> 2.20", "< 2.21"], require: false
-gem "dogstatsd-ruby", ">= 3.3.0", "!= 5.0.0", "!= 5.0.1", "!= 5.1.0"
-gem "google-protobuf", ["~> 3.0", "!= 3.7.0", "!= 3.7.1"]
 gem "rack", "~> 2"
 gem "rack-contrib"
 gem "rack-test"

--- a/gemfiles/ruby_3.1_rack_3.gemfile
+++ b/gemfiles/ruby_3.1_rack_3.gemfile
@@ -6,7 +6,9 @@ gem "benchmark-ips", "~> 2.8"
 gem "benchmark-memory", "< 0.2"
 gem "climate_control", "~> 0.2.0"
 gem "concurrent-ruby"
+gem "dogstatsd-ruby", ">= 3.3.0", "!= 5.0.0", "!= 5.0.1", "!= 5.1.0"
 gem "extlz4", "~> 0.3", ">= 0.3.3"
+gem "google-protobuf", ["~> 3.0", "!= 3.7.0", "!= 3.7.1"]
 gem "json-schema", "< 3"
 gem "memory_profiler", "~> 0.9"
 gem "os", "~> 1.1"
@@ -20,17 +22,15 @@ gem "rspec", "~> 3.13"
 gem "rspec-collection_matchers", "~> 1.1"
 gem "rspec-wait", "~> 0"
 gem "rspec_junit_formatter", ">= 0.5.1"
+gem "rubocop", "~> 1.50.0", require: false
+gem "rubocop-packaging", "~> 0.5.2", require: false
+gem "rubocop-performance", "~> 1.9", require: false
+gem "rubocop-rspec", ["~> 2.20", "< 2.21"], require: false
 gem "simplecov", git: "https://github.com/DataDog/simplecov", ref: "3bb6b7ee58bf4b1954ca205f50dd44d6f41c57db"
 gem "simplecov-cobertura", "~> 2.1.0"
 gem "warning", "~> 1"
 gem "webmock", ">= 3.10.0"
 gem "webrick", ">= 1.7.0"
-gem "rubocop", "~> 1.50.0", require: false
-gem "rubocop-packaging", "~> 0.5.2", require: false
-gem "rubocop-performance", "~> 1.9", require: false
-gem "rubocop-rspec", ["~> 2.20", "< 2.21"], require: false
-gem "dogstatsd-ruby", ">= 3.3.0", "!= 5.0.0", "!= 5.0.1", "!= 5.1.0"
-gem "google-protobuf", ["~> 3.0", "!= 3.7.0", "!= 3.7.1"]
 gem "rack", "~> 3"
 gem "rack-contrib"
 gem "rack-test"

--- a/gemfiles/ruby_3.1_rack_latest.gemfile
+++ b/gemfiles/ruby_3.1_rack_latest.gemfile
@@ -6,7 +6,9 @@ gem "benchmark-ips", "~> 2.8"
 gem "benchmark-memory", "< 0.2"
 gem "climate_control", "~> 0.2.0"
 gem "concurrent-ruby"
+gem "dogstatsd-ruby", ">= 3.3.0", "!= 5.0.0", "!= 5.0.1", "!= 5.1.0"
 gem "extlz4", "~> 0.3", ">= 0.3.3"
+gem "google-protobuf", ["~> 3.0", "!= 3.7.0", "!= 3.7.1"]
 gem "json-schema", "< 3"
 gem "memory_profiler", "~> 0.9"
 gem "os", "~> 1.1"
@@ -20,17 +22,15 @@ gem "rspec", "~> 3.13"
 gem "rspec-collection_matchers", "~> 1.1"
 gem "rspec-wait", "~> 0"
 gem "rspec_junit_formatter", ">= 0.5.1"
+gem "rubocop", "~> 1.50.0", require: false
+gem "rubocop-packaging", "~> 0.5.2", require: false
+gem "rubocop-performance", "~> 1.9", require: false
+gem "rubocop-rspec", ["~> 2.20", "< 2.21"], require: false
 gem "simplecov", git: "https://github.com/DataDog/simplecov", ref: "3bb6b7ee58bf4b1954ca205f50dd44d6f41c57db"
 gem "simplecov-cobertura", "~> 2.1.0"
 gem "warning", "~> 1"
 gem "webmock", ">= 3.10.0"
 gem "webrick", ">= 1.7.0"
-gem "rubocop", "~> 1.50.0", require: false
-gem "rubocop-packaging", "~> 0.5.2", require: false
-gem "rubocop-performance", "~> 1.9", require: false
-gem "rubocop-rspec", ["~> 2.20", "< 2.21"], require: false
-gem "dogstatsd-ruby", ">= 3.3.0", "!= 5.0.0", "!= 5.0.1", "!= 5.1.0"
-gem "google-protobuf", ["~> 3.0", "!= 3.7.0", "!= 3.7.1"]
 gem "rack"
 gem "rack-contrib"
 gem "rack-test"

--- a/gemfiles/ruby_3.1_rails61_mysql2.gemfile
+++ b/gemfiles/ruby_3.1_rails61_mysql2.gemfile
@@ -6,7 +6,9 @@ gem "benchmark-ips", "~> 2.8"
 gem "benchmark-memory", "< 0.2"
 gem "climate_control", "~> 0.2.0"
 gem "concurrent-ruby"
+gem "dogstatsd-ruby", ">= 3.3.0", "!= 5.0.0", "!= 5.0.1", "!= 5.1.0"
 gem "extlz4", "~> 0.3", ">= 0.3.3"
+gem "google-protobuf", ["~> 3.0", "!= 3.7.0", "!= 3.7.1"]
 gem "json-schema", "< 3"
 gem "memory_profiler", "~> 0.9"
 gem "os", "~> 1.1"
@@ -20,17 +22,15 @@ gem "rspec", "~> 3.13"
 gem "rspec-collection_matchers", "~> 1.1"
 gem "rspec-wait", "~> 0"
 gem "rspec_junit_formatter", ">= 0.5.1"
+gem "rubocop", "~> 1.50.0", require: false
+gem "rubocop-packaging", "~> 0.5.2", require: false
+gem "rubocop-performance", "~> 1.9", require: false
+gem "rubocop-rspec", ["~> 2.20", "< 2.21"], require: false
 gem "simplecov", git: "https://github.com/DataDog/simplecov", ref: "3bb6b7ee58bf4b1954ca205f50dd44d6f41c57db"
 gem "simplecov-cobertura", "~> 2.1.0"
 gem "warning", "~> 1"
 gem "webmock", ">= 3.10.0"
 gem "webrick", ">= 1.7.0"
-gem "rubocop", "~> 1.50.0", require: false
-gem "rubocop-packaging", "~> 0.5.2", require: false
-gem "rubocop-performance", "~> 1.9", require: false
-gem "rubocop-rspec", ["~> 2.20", "< 2.21"], require: false
-gem "dogstatsd-ruby", ">= 3.3.0", "!= 5.0.0", "!= 5.0.1", "!= 5.1.0"
-gem "google-protobuf", ["~> 3.0", "!= 3.7.0", "!= 3.7.1"]
 gem "rails", "~> 6.1.0"
 gem "mysql2", "~> 0.5", platform: :ruby
 gem "sprockets", "< 4"

--- a/gemfiles/ruby_3.1_rails61_postgres.gemfile
+++ b/gemfiles/ruby_3.1_rails61_postgres.gemfile
@@ -6,7 +6,9 @@ gem "benchmark-ips", "~> 2.8"
 gem "benchmark-memory", "< 0.2"
 gem "climate_control", "~> 0.2.0"
 gem "concurrent-ruby"
+gem "dogstatsd-ruby", ">= 3.3.0", "!= 5.0.0", "!= 5.0.1", "!= 5.1.0"
 gem "extlz4", "~> 0.3", ">= 0.3.3"
+gem "google-protobuf", ["~> 3.0", "!= 3.7.0", "!= 3.7.1"]
 gem "json-schema", "< 3"
 gem "memory_profiler", "~> 0.9"
 gem "os", "~> 1.1"
@@ -20,17 +22,15 @@ gem "rspec", "~> 3.13"
 gem "rspec-collection_matchers", "~> 1.1"
 gem "rspec-wait", "~> 0"
 gem "rspec_junit_formatter", ">= 0.5.1"
+gem "rubocop", "~> 1.50.0", require: false
+gem "rubocop-packaging", "~> 0.5.2", require: false
+gem "rubocop-performance", "~> 1.9", require: false
+gem "rubocop-rspec", ["~> 2.20", "< 2.21"], require: false
 gem "simplecov", git: "https://github.com/DataDog/simplecov", ref: "3bb6b7ee58bf4b1954ca205f50dd44d6f41c57db"
 gem "simplecov-cobertura", "~> 2.1.0"
 gem "warning", "~> 1"
 gem "webmock", ">= 3.10.0"
 gem "webrick", ">= 1.7.0"
-gem "rubocop", "~> 1.50.0", require: false
-gem "rubocop-packaging", "~> 0.5.2", require: false
-gem "rubocop-performance", "~> 1.9", require: false
-gem "rubocop-rspec", ["~> 2.20", "< 2.21"], require: false
-gem "dogstatsd-ruby", ">= 3.3.0", "!= 5.0.0", "!= 5.0.1", "!= 5.1.0"
-gem "google-protobuf", ["~> 3.0", "!= 3.7.0", "!= 3.7.1"]
 gem "rails", "~> 6.1.0"
 gem "pg", ">= 1.1", platform: :ruby
 gem "sprockets", "< 4"

--- a/gemfiles/ruby_3.1_rails61_postgres_redis.gemfile
+++ b/gemfiles/ruby_3.1_rails61_postgres_redis.gemfile
@@ -6,7 +6,9 @@ gem "benchmark-ips", "~> 2.8"
 gem "benchmark-memory", "< 0.2"
 gem "climate_control", "~> 0.2.0"
 gem "concurrent-ruby"
+gem "dogstatsd-ruby", ">= 3.3.0", "!= 5.0.0", "!= 5.0.1", "!= 5.1.0"
 gem "extlz4", "~> 0.3", ">= 0.3.3"
+gem "google-protobuf", ["~> 3.0", "!= 3.7.0", "!= 3.7.1"]
 gem "json-schema", "< 3"
 gem "memory_profiler", "~> 0.9"
 gem "os", "~> 1.1"
@@ -20,17 +22,15 @@ gem "rspec", "~> 3.13"
 gem "rspec-collection_matchers", "~> 1.1"
 gem "rspec-wait", "~> 0"
 gem "rspec_junit_formatter", ">= 0.5.1"
+gem "rubocop", "~> 1.50.0", require: false
+gem "rubocop-packaging", "~> 0.5.2", require: false
+gem "rubocop-performance", "~> 1.9", require: false
+gem "rubocop-rspec", ["~> 2.20", "< 2.21"], require: false
 gem "simplecov", git: "https://github.com/DataDog/simplecov", ref: "3bb6b7ee58bf4b1954ca205f50dd44d6f41c57db"
 gem "simplecov-cobertura", "~> 2.1.0"
 gem "warning", "~> 1"
 gem "webmock", ">= 3.10.0"
 gem "webrick", ">= 1.7.0"
-gem "rubocop", "~> 1.50.0", require: false
-gem "rubocop-packaging", "~> 0.5.2", require: false
-gem "rubocop-performance", "~> 1.9", require: false
-gem "rubocop-rspec", ["~> 2.20", "< 2.21"], require: false
-gem "dogstatsd-ruby", ">= 3.3.0", "!= 5.0.0", "!= 5.0.1", "!= 5.1.0"
-gem "google-protobuf", ["~> 3.0", "!= 3.7.0", "!= 3.7.1"]
 gem "rails", "~> 6.1.0"
 gem "pg", ">= 1.1", platform: :ruby
 gem "redis", "~> 4"

--- a/gemfiles/ruby_3.1_rails61_postgres_sidekiq.gemfile
+++ b/gemfiles/ruby_3.1_rails61_postgres_sidekiq.gemfile
@@ -6,7 +6,9 @@ gem "benchmark-ips", "~> 2.8"
 gem "benchmark-memory", "< 0.2"
 gem "climate_control", "~> 0.2.0"
 gem "concurrent-ruby"
+gem "dogstatsd-ruby", ">= 3.3.0", "!= 5.0.0", "!= 5.0.1", "!= 5.1.0"
 gem "extlz4", "~> 0.3", ">= 0.3.3"
+gem "google-protobuf", ["~> 3.0", "!= 3.7.0", "!= 3.7.1"]
 gem "json-schema", "< 3"
 gem "memory_profiler", "~> 0.9"
 gem "os", "~> 1.1"
@@ -20,17 +22,15 @@ gem "rspec", "~> 3.13"
 gem "rspec-collection_matchers", "~> 1.1"
 gem "rspec-wait", "~> 0"
 gem "rspec_junit_formatter", ">= 0.5.1"
+gem "rubocop", "~> 1.50.0", require: false
+gem "rubocop-packaging", "~> 0.5.2", require: false
+gem "rubocop-performance", "~> 1.9", require: false
+gem "rubocop-rspec", ["~> 2.20", "< 2.21"], require: false
 gem "simplecov", git: "https://github.com/DataDog/simplecov", ref: "3bb6b7ee58bf4b1954ca205f50dd44d6f41c57db"
 gem "simplecov-cobertura", "~> 2.1.0"
 gem "warning", "~> 1"
 gem "webmock", ">= 3.10.0"
 gem "webrick", ">= 1.7.0"
-gem "rubocop", "~> 1.50.0", require: false
-gem "rubocop-packaging", "~> 0.5.2", require: false
-gem "rubocop-performance", "~> 1.9", require: false
-gem "rubocop-rspec", ["~> 2.20", "< 2.21"], require: false
-gem "dogstatsd-ruby", ">= 3.3.0", "!= 5.0.0", "!= 5.0.1", "!= 5.1.0"
-gem "google-protobuf", ["~> 3.0", "!= 3.7.0", "!= 3.7.1"]
 gem "rails", "~> 6.1.0"
 gem "pg", ">= 1.1", platform: :ruby
 gem "sidekiq", ">= 6.1.2"

--- a/gemfiles/ruby_3.1_rails61_semantic_logger.gemfile
+++ b/gemfiles/ruby_3.1_rails61_semantic_logger.gemfile
@@ -6,7 +6,9 @@ gem "benchmark-ips", "~> 2.8"
 gem "benchmark-memory", "< 0.2"
 gem "climate_control", "~> 0.2.0"
 gem "concurrent-ruby"
+gem "dogstatsd-ruby", ">= 3.3.0", "!= 5.0.0", "!= 5.0.1", "!= 5.1.0"
 gem "extlz4", "~> 0.3", ">= 0.3.3"
+gem "google-protobuf", ["~> 3.0", "!= 3.7.0", "!= 3.7.1"]
 gem "json-schema", "< 3"
 gem "memory_profiler", "~> 0.9"
 gem "os", "~> 1.1"
@@ -20,17 +22,15 @@ gem "rspec", "~> 3.13"
 gem "rspec-collection_matchers", "~> 1.1"
 gem "rspec-wait", "~> 0"
 gem "rspec_junit_formatter", ">= 0.5.1"
+gem "rubocop", "~> 1.50.0", require: false
+gem "rubocop-packaging", "~> 0.5.2", require: false
+gem "rubocop-performance", "~> 1.9", require: false
+gem "rubocop-rspec", ["~> 2.20", "< 2.21"], require: false
 gem "simplecov", git: "https://github.com/DataDog/simplecov", ref: "3bb6b7ee58bf4b1954ca205f50dd44d6f41c57db"
 gem "simplecov-cobertura", "~> 2.1.0"
 gem "warning", "~> 1"
 gem "webmock", ">= 3.10.0"
 gem "webrick", ">= 1.7.0"
-gem "rubocop", "~> 1.50.0", require: false
-gem "rubocop-packaging", "~> 0.5.2", require: false
-gem "rubocop-performance", "~> 1.9", require: false
-gem "rubocop-rspec", ["~> 2.20", "< 2.21"], require: false
-gem "dogstatsd-ruby", ">= 3.3.0", "!= 5.0.0", "!= 5.0.1", "!= 5.1.0"
-gem "google-protobuf", ["~> 3.0", "!= 3.7.0", "!= 3.7.1"]
 gem "rails", "~> 6.1.0"
 gem "pg", ">= 1.1", platform: :ruby
 gem "sprockets", "< 4"

--- a/gemfiles/ruby_3.1_rails61_trilogy.gemfile
+++ b/gemfiles/ruby_3.1_rails61_trilogy.gemfile
@@ -6,7 +6,9 @@ gem "benchmark-ips", "~> 2.8"
 gem "benchmark-memory", "< 0.2"
 gem "climate_control", "~> 0.2.0"
 gem "concurrent-ruby"
+gem "dogstatsd-ruby", ">= 3.3.0", "!= 5.0.0", "!= 5.0.1", "!= 5.1.0"
 gem "extlz4", "~> 0.3", ">= 0.3.3"
+gem "google-protobuf", ["~> 3.0", "!= 3.7.0", "!= 3.7.1"]
 gem "json-schema", "< 3"
 gem "memory_profiler", "~> 0.9"
 gem "os", "~> 1.1"
@@ -20,17 +22,15 @@ gem "rspec", "~> 3.13"
 gem "rspec-collection_matchers", "~> 1.1"
 gem "rspec-wait", "~> 0"
 gem "rspec_junit_formatter", ">= 0.5.1"
+gem "rubocop", "~> 1.50.0", require: false
+gem "rubocop-packaging", "~> 0.5.2", require: false
+gem "rubocop-performance", "~> 1.9", require: false
+gem "rubocop-rspec", ["~> 2.20", "< 2.21"], require: false
 gem "simplecov", git: "https://github.com/DataDog/simplecov", ref: "3bb6b7ee58bf4b1954ca205f50dd44d6f41c57db"
 gem "simplecov-cobertura", "~> 2.1.0"
 gem "warning", "~> 1"
 gem "webmock", ">= 3.10.0"
 gem "webrick", ">= 1.7.0"
-gem "rubocop", "~> 1.50.0", require: false
-gem "rubocop-packaging", "~> 0.5.2", require: false
-gem "rubocop-performance", "~> 1.9", require: false
-gem "rubocop-rspec", ["~> 2.20", "< 2.21"], require: false
-gem "dogstatsd-ruby", ">= 3.3.0", "!= 5.0.0", "!= 5.0.1", "!= 5.1.0"
-gem "google-protobuf", ["~> 3.0", "!= 3.7.0", "!= 3.7.1"]
 gem "rails", "~> 6.1.0"
 gem "trilogy"
 gem "activerecord-trilogy-adapter"

--- a/gemfiles/ruby_3.1_rails7.gemfile
+++ b/gemfiles/ruby_3.1_rails7.gemfile
@@ -6,7 +6,9 @@ gem "benchmark-ips", "~> 2.8"
 gem "benchmark-memory", "< 0.2"
 gem "climate_control", "~> 0.2.0"
 gem "concurrent-ruby"
+gem "dogstatsd-ruby", ">= 3.3.0", "!= 5.0.0", "!= 5.0.1", "!= 5.1.0"
 gem "extlz4", "~> 0.3", ">= 0.3.3"
+gem "google-protobuf", ["~> 3.0", "!= 3.7.0", "!= 3.7.1"]
 gem "json-schema", "< 3"
 gem "memory_profiler", "~> 0.9"
 gem "os", "~> 1.1"
@@ -20,17 +22,15 @@ gem "rspec", "~> 3.13"
 gem "rspec-collection_matchers", "~> 1.1"
 gem "rspec-wait", "~> 0"
 gem "rspec_junit_formatter", ">= 0.5.1"
+gem "rubocop", "~> 1.50.0", require: false
+gem "rubocop-packaging", "~> 0.5.2", require: false
+gem "rubocop-performance", "~> 1.9", require: false
+gem "rubocop-rspec", ["~> 2.20", "< 2.21"], require: false
 gem "simplecov", git: "https://github.com/DataDog/simplecov", ref: "3bb6b7ee58bf4b1954ca205f50dd44d6f41c57db"
 gem "simplecov-cobertura", "~> 2.1.0"
 gem "warning", "~> 1"
 gem "webmock", ">= 3.10.0"
 gem "webrick", ">= 1.7.0"
-gem "rubocop", "~> 1.50.0", require: false
-gem "rubocop-packaging", "~> 0.5.2", require: false
-gem "rubocop-performance", "~> 1.9", require: false
-gem "rubocop-rspec", ["~> 2.20", "< 2.21"], require: false
-gem "dogstatsd-ruby", ">= 3.3.0", "!= 5.0.0", "!= 5.0.1", "!= 5.1.0"
-gem "google-protobuf", ["~> 3.0", "!= 3.7.0", "!= 3.7.1"]
 gem "rails", "~> 7.0.0"
 
 group :check do

--- a/gemfiles/ruby_3.1_rails71.gemfile
+++ b/gemfiles/ruby_3.1_rails71.gemfile
@@ -6,7 +6,9 @@ gem "benchmark-ips", "~> 2.8"
 gem "benchmark-memory", "< 0.2"
 gem "climate_control", "~> 0.2.0"
 gem "concurrent-ruby"
+gem "dogstatsd-ruby", ">= 3.3.0", "!= 5.0.0", "!= 5.0.1", "!= 5.1.0"
 gem "extlz4", "~> 0.3", ">= 0.3.3"
+gem "google-protobuf", ["~> 3.0", "!= 3.7.0", "!= 3.7.1"]
 gem "json-schema", "< 3"
 gem "memory_profiler", "~> 0.9"
 gem "os", "~> 1.1"
@@ -20,17 +22,15 @@ gem "rspec", "~> 3.13"
 gem "rspec-collection_matchers", "~> 1.1"
 gem "rspec-wait", "~> 0"
 gem "rspec_junit_formatter", ">= 0.5.1"
+gem "rubocop", "~> 1.50.0", require: false
+gem "rubocop-packaging", "~> 0.5.2", require: false
+gem "rubocop-performance", "~> 1.9", require: false
+gem "rubocop-rspec", ["~> 2.20", "< 2.21"], require: false
 gem "simplecov", git: "https://github.com/DataDog/simplecov", ref: "3bb6b7ee58bf4b1954ca205f50dd44d6f41c57db"
 gem "simplecov-cobertura", "~> 2.1.0"
 gem "warning", "~> 1"
 gem "webmock", ">= 3.10.0"
 gem "webrick", ">= 1.7.0"
-gem "rubocop", "~> 1.50.0", require: false
-gem "rubocop-packaging", "~> 0.5.2", require: false
-gem "rubocop-performance", "~> 1.9", require: false
-gem "rubocop-rspec", ["~> 2.20", "< 2.21"], require: false
-gem "dogstatsd-ruby", ">= 3.3.0", "!= 5.0.0", "!= 5.0.1", "!= 5.1.0"
-gem "google-protobuf", ["~> 3.0", "!= 3.7.0", "!= 3.7.1"]
 gem "rails", "~> 7.1.0"
 
 group :check do

--- a/gemfiles/ruby_3.1_rails_old_redis.gemfile
+++ b/gemfiles/ruby_3.1_rails_old_redis.gemfile
@@ -6,7 +6,9 @@ gem "benchmark-ips", "~> 2.8"
 gem "benchmark-memory", "< 0.2"
 gem "climate_control", "~> 0.2.0"
 gem "concurrent-ruby"
+gem "dogstatsd-ruby", ">= 3.3.0", "!= 5.0.0", "!= 5.0.1", "!= 5.1.0"
 gem "extlz4", "~> 0.3", ">= 0.3.3"
+gem "google-protobuf", ["~> 3.0", "!= 3.7.0", "!= 3.7.1"]
 gem "json-schema", "< 3"
 gem "memory_profiler", "~> 0.9"
 gem "os", "~> 1.1"
@@ -20,17 +22,15 @@ gem "rspec", "~> 3.13"
 gem "rspec-collection_matchers", "~> 1.1"
 gem "rspec-wait", "~> 0"
 gem "rspec_junit_formatter", ">= 0.5.1"
+gem "rubocop", "~> 1.50.0", require: false
+gem "rubocop-packaging", "~> 0.5.2", require: false
+gem "rubocop-performance", "~> 1.9", require: false
+gem "rubocop-rspec", ["~> 2.20", "< 2.21"], require: false
 gem "simplecov", git: "https://github.com/DataDog/simplecov", ref: "3bb6b7ee58bf4b1954ca205f50dd44d6f41c57db"
 gem "simplecov-cobertura", "~> 2.1.0"
 gem "warning", "~> 1"
 gem "webmock", ">= 3.10.0"
 gem "webrick", ">= 1.7.0"
-gem "rubocop", "~> 1.50.0", require: false
-gem "rubocop-packaging", "~> 0.5.2", require: false
-gem "rubocop-performance", "~> 1.9", require: false
-gem "rubocop-rspec", ["~> 2.20", "< 2.21"], require: false
-gem "dogstatsd-ruby", ">= 3.3.0", "!= 5.0.0", "!= 5.0.1", "!= 5.1.0"
-gem "google-protobuf", ["~> 3.0", "!= 3.7.0", "!= 3.7.1"]
 gem "redis", "< 4"
 gem "rails", "~> 6.1.0"
 gem "pg", ">= 1.1", platform: :ruby

--- a/gemfiles/ruby_3.1_redis_3.gemfile
+++ b/gemfiles/ruby_3.1_redis_3.gemfile
@@ -6,7 +6,9 @@ gem "benchmark-ips", "~> 2.8"
 gem "benchmark-memory", "< 0.2"
 gem "climate_control", "~> 0.2.0"
 gem "concurrent-ruby"
+gem "dogstatsd-ruby", ">= 3.3.0", "!= 5.0.0", "!= 5.0.1", "!= 5.1.0"
 gem "extlz4", "~> 0.3", ">= 0.3.3"
+gem "google-protobuf", ["~> 3.0", "!= 3.7.0", "!= 3.7.1"]
 gem "json-schema", "< 3"
 gem "memory_profiler", "~> 0.9"
 gem "os", "~> 1.1"
@@ -20,17 +22,15 @@ gem "rspec", "~> 3.13"
 gem "rspec-collection_matchers", "~> 1.1"
 gem "rspec-wait", "~> 0"
 gem "rspec_junit_formatter", ">= 0.5.1"
+gem "rubocop", "~> 1.50.0", require: false
+gem "rubocop-packaging", "~> 0.5.2", require: false
+gem "rubocop-performance", "~> 1.9", require: false
+gem "rubocop-rspec", ["~> 2.20", "< 2.21"], require: false
 gem "simplecov", git: "https://github.com/DataDog/simplecov", ref: "3bb6b7ee58bf4b1954ca205f50dd44d6f41c57db"
 gem "simplecov-cobertura", "~> 2.1.0"
 gem "warning", "~> 1"
 gem "webmock", ">= 3.10.0"
 gem "webrick", ">= 1.7.0"
-gem "rubocop", "~> 1.50.0", require: false
-gem "rubocop-packaging", "~> 0.5.2", require: false
-gem "rubocop-performance", "~> 1.9", require: false
-gem "rubocop-rspec", ["~> 2.20", "< 2.21"], require: false
-gem "dogstatsd-ruby", ">= 3.3.0", "!= 5.0.0", "!= 5.0.1", "!= 5.1.0"
-gem "google-protobuf", ["~> 3.0", "!= 3.7.0", "!= 3.7.1"]
 gem "redis", "~> 3"
 
 group :check do

--- a/gemfiles/ruby_3.1_redis_4.gemfile
+++ b/gemfiles/ruby_3.1_redis_4.gemfile
@@ -6,7 +6,9 @@ gem "benchmark-ips", "~> 2.8"
 gem "benchmark-memory", "< 0.2"
 gem "climate_control", "~> 0.2.0"
 gem "concurrent-ruby"
+gem "dogstatsd-ruby", ">= 3.3.0", "!= 5.0.0", "!= 5.0.1", "!= 5.1.0"
 gem "extlz4", "~> 0.3", ">= 0.3.3"
+gem "google-protobuf", ["~> 3.0", "!= 3.7.0", "!= 3.7.1"]
 gem "json-schema", "< 3"
 gem "memory_profiler", "~> 0.9"
 gem "os", "~> 1.1"
@@ -20,17 +22,15 @@ gem "rspec", "~> 3.13"
 gem "rspec-collection_matchers", "~> 1.1"
 gem "rspec-wait", "~> 0"
 gem "rspec_junit_formatter", ">= 0.5.1"
+gem "rubocop", "~> 1.50.0", require: false
+gem "rubocop-packaging", "~> 0.5.2", require: false
+gem "rubocop-performance", "~> 1.9", require: false
+gem "rubocop-rspec", ["~> 2.20", "< 2.21"], require: false
 gem "simplecov", git: "https://github.com/DataDog/simplecov", ref: "3bb6b7ee58bf4b1954ca205f50dd44d6f41c57db"
 gem "simplecov-cobertura", "~> 2.1.0"
 gem "warning", "~> 1"
 gem "webmock", ">= 3.10.0"
 gem "webrick", ">= 1.7.0"
-gem "rubocop", "~> 1.50.0", require: false
-gem "rubocop-packaging", "~> 0.5.2", require: false
-gem "rubocop-performance", "~> 1.9", require: false
-gem "rubocop-rspec", ["~> 2.20", "< 2.21"], require: false
-gem "dogstatsd-ruby", ">= 3.3.0", "!= 5.0.0", "!= 5.0.1", "!= 5.1.0"
-gem "google-protobuf", ["~> 3.0", "!= 3.7.0", "!= 3.7.1"]
 gem "redis", "~> 4"
 
 group :check do

--- a/gemfiles/ruby_3.1_redis_5.gemfile
+++ b/gemfiles/ruby_3.1_redis_5.gemfile
@@ -6,7 +6,9 @@ gem "benchmark-ips", "~> 2.8"
 gem "benchmark-memory", "< 0.2"
 gem "climate_control", "~> 0.2.0"
 gem "concurrent-ruby"
+gem "dogstatsd-ruby", ">= 3.3.0", "!= 5.0.0", "!= 5.0.1", "!= 5.1.0"
 gem "extlz4", "~> 0.3", ">= 0.3.3"
+gem "google-protobuf", ["~> 3.0", "!= 3.7.0", "!= 3.7.1"]
 gem "json-schema", "< 3"
 gem "memory_profiler", "~> 0.9"
 gem "os", "~> 1.1"
@@ -20,17 +22,15 @@ gem "rspec", "~> 3.13"
 gem "rspec-collection_matchers", "~> 1.1"
 gem "rspec-wait", "~> 0"
 gem "rspec_junit_formatter", ">= 0.5.1"
+gem "rubocop", "~> 1.50.0", require: false
+gem "rubocop-packaging", "~> 0.5.2", require: false
+gem "rubocop-performance", "~> 1.9", require: false
+gem "rubocop-rspec", ["~> 2.20", "< 2.21"], require: false
 gem "simplecov", git: "https://github.com/DataDog/simplecov", ref: "3bb6b7ee58bf4b1954ca205f50dd44d6f41c57db"
 gem "simplecov-cobertura", "~> 2.1.0"
 gem "warning", "~> 1"
 gem "webmock", ">= 3.10.0"
 gem "webrick", ">= 1.7.0"
-gem "rubocop", "~> 1.50.0", require: false
-gem "rubocop-packaging", "~> 0.5.2", require: false
-gem "rubocop-performance", "~> 1.9", require: false
-gem "rubocop-rspec", ["~> 2.20", "< 2.21"], require: false
-gem "dogstatsd-ruby", ">= 3.3.0", "!= 5.0.0", "!= 5.0.1", "!= 5.1.0"
-gem "google-protobuf", ["~> 3.0", "!= 3.7.0", "!= 3.7.1"]
 gem "redis", "~> 5"
 
 group :check do

--- a/gemfiles/ruby_3.1_relational_db.gemfile
+++ b/gemfiles/ruby_3.1_relational_db.gemfile
@@ -6,7 +6,9 @@ gem "benchmark-ips", "~> 2.8"
 gem "benchmark-memory", "< 0.2"
 gem "climate_control", "~> 0.2.0"
 gem "concurrent-ruby"
+gem "dogstatsd-ruby", ">= 3.3.0", "!= 5.0.0", "!= 5.0.1", "!= 5.1.0"
 gem "extlz4", "~> 0.3", ">= 0.3.3"
+gem "google-protobuf", ["~> 3.0", "!= 3.7.0", "!= 3.7.1"]
 gem "json-schema", "< 3"
 gem "memory_profiler", "~> 0.9"
 gem "os", "~> 1.1"
@@ -20,17 +22,15 @@ gem "rspec", "~> 3.13"
 gem "rspec-collection_matchers", "~> 1.1"
 gem "rspec-wait", "~> 0"
 gem "rspec_junit_formatter", ">= 0.5.1"
+gem "rubocop", "~> 1.50.0", require: false
+gem "rubocop-packaging", "~> 0.5.2", require: false
+gem "rubocop-performance", "~> 1.9", require: false
+gem "rubocop-rspec", ["~> 2.20", "< 2.21"], require: false
 gem "simplecov", git: "https://github.com/DataDog/simplecov", ref: "3bb6b7ee58bf4b1954ca205f50dd44d6f41c57db"
 gem "simplecov-cobertura", "~> 2.1.0"
 gem "warning", "~> 1"
 gem "webmock", ">= 3.10.0"
 gem "webrick", ">= 1.7.0"
-gem "rubocop", "~> 1.50.0", require: false
-gem "rubocop-packaging", "~> 0.5.2", require: false
-gem "rubocop-performance", "~> 1.9", require: false
-gem "rubocop-rspec", ["~> 2.20", "< 2.21"], require: false
-gem "dogstatsd-ruby", ">= 3.3.0", "!= 5.0.0", "!= 5.0.1", "!= 5.1.0"
-gem "google-protobuf", ["~> 3.0", "!= 3.7.0", "!= 3.7.1"]
 gem "activerecord", "~> 7"
 gem "delayed_job"
 gem "delayed_job_active_record"

--- a/gemfiles/ruby_3.1_resque2_redis3.gemfile
+++ b/gemfiles/ruby_3.1_resque2_redis3.gemfile
@@ -6,7 +6,9 @@ gem "benchmark-ips", "~> 2.8"
 gem "benchmark-memory", "< 0.2"
 gem "climate_control", "~> 0.2.0"
 gem "concurrent-ruby"
+gem "dogstatsd-ruby", ">= 3.3.0", "!= 5.0.0", "!= 5.0.1", "!= 5.1.0"
 gem "extlz4", "~> 0.3", ">= 0.3.3"
+gem "google-protobuf", ["~> 3.0", "!= 3.7.0", "!= 3.7.1"]
 gem "json-schema", "< 3"
 gem "memory_profiler", "~> 0.9"
 gem "os", "~> 1.1"
@@ -20,17 +22,15 @@ gem "rspec", "~> 3.13"
 gem "rspec-collection_matchers", "~> 1.1"
 gem "rspec-wait", "~> 0"
 gem "rspec_junit_formatter", ">= 0.5.1"
+gem "rubocop", "~> 1.50.0", require: false
+gem "rubocop-packaging", "~> 0.5.2", require: false
+gem "rubocop-performance", "~> 1.9", require: false
+gem "rubocop-rspec", ["~> 2.20", "< 2.21"], require: false
 gem "simplecov", git: "https://github.com/DataDog/simplecov", ref: "3bb6b7ee58bf4b1954ca205f50dd44d6f41c57db"
 gem "simplecov-cobertura", "~> 2.1.0"
 gem "warning", "~> 1"
 gem "webmock", ">= 3.10.0"
 gem "webrick", ">= 1.7.0"
-gem "rubocop", "~> 1.50.0", require: false
-gem "rubocop-packaging", "~> 0.5.2", require: false
-gem "rubocop-performance", "~> 1.9", require: false
-gem "rubocop-rspec", ["~> 2.20", "< 2.21"], require: false
-gem "dogstatsd-ruby", ">= 3.3.0", "!= 5.0.0", "!= 5.0.1", "!= 5.1.0"
-gem "google-protobuf", ["~> 3.0", "!= 3.7.0", "!= 3.7.1"]
 gem "redis", "< 4.0"
 gem "resque", ">= 2.0"
 

--- a/gemfiles/ruby_3.1_resque2_redis4.gemfile
+++ b/gemfiles/ruby_3.1_resque2_redis4.gemfile
@@ -6,7 +6,9 @@ gem "benchmark-ips", "~> 2.8"
 gem "benchmark-memory", "< 0.2"
 gem "climate_control", "~> 0.2.0"
 gem "concurrent-ruby"
+gem "dogstatsd-ruby", ">= 3.3.0", "!= 5.0.0", "!= 5.0.1", "!= 5.1.0"
 gem "extlz4", "~> 0.3", ">= 0.3.3"
+gem "google-protobuf", ["~> 3.0", "!= 3.7.0", "!= 3.7.1"]
 gem "json-schema", "< 3"
 gem "memory_profiler", "~> 0.9"
 gem "os", "~> 1.1"
@@ -20,17 +22,15 @@ gem "rspec", "~> 3.13"
 gem "rspec-collection_matchers", "~> 1.1"
 gem "rspec-wait", "~> 0"
 gem "rspec_junit_formatter", ">= 0.5.1"
+gem "rubocop", "~> 1.50.0", require: false
+gem "rubocop-packaging", "~> 0.5.2", require: false
+gem "rubocop-performance", "~> 1.9", require: false
+gem "rubocop-rspec", ["~> 2.20", "< 2.21"], require: false
 gem "simplecov", git: "https://github.com/DataDog/simplecov", ref: "3bb6b7ee58bf4b1954ca205f50dd44d6f41c57db"
 gem "simplecov-cobertura", "~> 2.1.0"
 gem "warning", "~> 1"
 gem "webmock", ">= 3.10.0"
 gem "webrick", ">= 1.7.0"
-gem "rubocop", "~> 1.50.0", require: false
-gem "rubocop-packaging", "~> 0.5.2", require: false
-gem "rubocop-performance", "~> 1.9", require: false
-gem "rubocop-rspec", ["~> 2.20", "< 2.21"], require: false
-gem "dogstatsd-ruby", ">= 3.3.0", "!= 5.0.0", "!= 5.0.1", "!= 5.1.0"
-gem "google-protobuf", ["~> 3.0", "!= 3.7.0", "!= 3.7.1"]
 gem "redis", ">= 4.0"
 gem "resque", ">= 2.0"
 

--- a/gemfiles/ruby_3.1_sinatra_2.gemfile
+++ b/gemfiles/ruby_3.1_sinatra_2.gemfile
@@ -6,7 +6,9 @@ gem "benchmark-ips", "~> 2.8"
 gem "benchmark-memory", "< 0.2"
 gem "climate_control", "~> 0.2.0"
 gem "concurrent-ruby"
+gem "dogstatsd-ruby", ">= 3.3.0", "!= 5.0.0", "!= 5.0.1", "!= 5.1.0"
 gem "extlz4", "~> 0.3", ">= 0.3.3"
+gem "google-protobuf", ["~> 3.0", "!= 3.7.0", "!= 3.7.1"]
 gem "json-schema", "< 3"
 gem "memory_profiler", "~> 0.9"
 gem "os", "~> 1.1"
@@ -20,17 +22,15 @@ gem "rspec", "~> 3.13"
 gem "rspec-collection_matchers", "~> 1.1"
 gem "rspec-wait", "~> 0"
 gem "rspec_junit_formatter", ">= 0.5.1"
+gem "rubocop", "~> 1.50.0", require: false
+gem "rubocop-packaging", "~> 0.5.2", require: false
+gem "rubocop-performance", "~> 1.9", require: false
+gem "rubocop-rspec", ["~> 2.20", "< 2.21"], require: false
 gem "simplecov", git: "https://github.com/DataDog/simplecov", ref: "3bb6b7ee58bf4b1954ca205f50dd44d6f41c57db"
 gem "simplecov-cobertura", "~> 2.1.0"
 gem "warning", "~> 1"
 gem "webmock", ">= 3.10.0"
 gem "webrick", ">= 1.7.0"
-gem "rubocop", "~> 1.50.0", require: false
-gem "rubocop-packaging", "~> 0.5.2", require: false
-gem "rubocop-performance", "~> 1.9", require: false
-gem "rubocop-rspec", ["~> 2.20", "< 2.21"], require: false
-gem "dogstatsd-ruby", ">= 3.3.0", "!= 5.0.0", "!= 5.0.1", "!= 5.1.0"
-gem "google-protobuf", ["~> 3.0", "!= 3.7.0", "!= 3.7.1"]
 gem "sinatra", "~> 2"
 gem "rack-contrib"
 gem "rack-test"

--- a/gemfiles/ruby_3.1_sinatra_3.gemfile
+++ b/gemfiles/ruby_3.1_sinatra_3.gemfile
@@ -6,7 +6,9 @@ gem "benchmark-ips", "~> 2.8"
 gem "benchmark-memory", "< 0.2"
 gem "climate_control", "~> 0.2.0"
 gem "concurrent-ruby"
+gem "dogstatsd-ruby", ">= 3.3.0", "!= 5.0.0", "!= 5.0.1", "!= 5.1.0"
 gem "extlz4", "~> 0.3", ">= 0.3.3"
+gem "google-protobuf", ["~> 3.0", "!= 3.7.0", "!= 3.7.1"]
 gem "json-schema", "< 3"
 gem "memory_profiler", "~> 0.9"
 gem "os", "~> 1.1"
@@ -20,17 +22,15 @@ gem "rspec", "~> 3.13"
 gem "rspec-collection_matchers", "~> 1.1"
 gem "rspec-wait", "~> 0"
 gem "rspec_junit_formatter", ">= 0.5.1"
+gem "rubocop", "~> 1.50.0", require: false
+gem "rubocop-packaging", "~> 0.5.2", require: false
+gem "rubocop-performance", "~> 1.9", require: false
+gem "rubocop-rspec", ["~> 2.20", "< 2.21"], require: false
 gem "simplecov", git: "https://github.com/DataDog/simplecov", ref: "3bb6b7ee58bf4b1954ca205f50dd44d6f41c57db"
 gem "simplecov-cobertura", "~> 2.1.0"
 gem "warning", "~> 1"
 gem "webmock", ">= 3.10.0"
 gem "webrick", ">= 1.7.0"
-gem "rubocop", "~> 1.50.0", require: false
-gem "rubocop-packaging", "~> 0.5.2", require: false
-gem "rubocop-performance", "~> 1.9", require: false
-gem "rubocop-rspec", ["~> 2.20", "< 2.21"], require: false
-gem "dogstatsd-ruby", ">= 3.3.0", "!= 5.0.0", "!= 5.0.1", "!= 5.1.0"
-gem "google-protobuf", ["~> 3.0", "!= 3.7.0", "!= 3.7.1"]
 gem "sinatra", "~> 3"
 gem "rack-contrib"
 gem "rack-test"

--- a/gemfiles/ruby_3.1_sinatra_4.gemfile
+++ b/gemfiles/ruby_3.1_sinatra_4.gemfile
@@ -6,7 +6,9 @@ gem "benchmark-ips", "~> 2.8"
 gem "benchmark-memory", "< 0.2"
 gem "climate_control", "~> 0.2.0"
 gem "concurrent-ruby"
+gem "dogstatsd-ruby", ">= 3.3.0", "!= 5.0.0", "!= 5.0.1", "!= 5.1.0"
 gem "extlz4", "~> 0.3", ">= 0.3.3"
+gem "google-protobuf", ["~> 3.0", "!= 3.7.0", "!= 3.7.1"]
 gem "json-schema", "< 3"
 gem "memory_profiler", "~> 0.9"
 gem "os", "~> 1.1"
@@ -20,17 +22,15 @@ gem "rspec", "~> 3.13"
 gem "rspec-collection_matchers", "~> 1.1"
 gem "rspec-wait", "~> 0"
 gem "rspec_junit_formatter", ">= 0.5.1"
+gem "rubocop", "~> 1.50.0", require: false
+gem "rubocop-packaging", "~> 0.5.2", require: false
+gem "rubocop-performance", "~> 1.9", require: false
+gem "rubocop-rspec", ["~> 2.20", "< 2.21"], require: false
 gem "simplecov", git: "https://github.com/DataDog/simplecov", ref: "3bb6b7ee58bf4b1954ca205f50dd44d6f41c57db"
 gem "simplecov-cobertura", "~> 2.1.0"
 gem "warning", "~> 1"
 gem "webmock", ">= 3.10.0"
 gem "webrick", ">= 1.7.0"
-gem "rubocop", "~> 1.50.0", require: false
-gem "rubocop-packaging", "~> 0.5.2", require: false
-gem "rubocop-performance", "~> 1.9", require: false
-gem "rubocop-rspec", ["~> 2.20", "< 2.21"], require: false
-gem "dogstatsd-ruby", ">= 3.3.0", "!= 5.0.0", "!= 5.0.1", "!= 5.1.0"
-gem "google-protobuf", ["~> 3.0", "!= 3.7.0", "!= 3.7.1"]
 gem "sinatra", "~> 4"
 gem "rack-contrib"
 gem "rack-test"

--- a/gemfiles/ruby_3.1_stripe_10.gemfile
+++ b/gemfiles/ruby_3.1_stripe_10.gemfile
@@ -6,7 +6,9 @@ gem "benchmark-ips", "~> 2.8"
 gem "benchmark-memory", "< 0.2"
 gem "climate_control", "~> 0.2.0"
 gem "concurrent-ruby"
+gem "dogstatsd-ruby", ">= 3.3.0", "!= 5.0.0", "!= 5.0.1", "!= 5.1.0"
 gem "extlz4", "~> 0.3", ">= 0.3.3"
+gem "google-protobuf", ["~> 3.0", "!= 3.7.0", "!= 3.7.1"]
 gem "json-schema", "< 3"
 gem "memory_profiler", "~> 0.9"
 gem "os", "~> 1.1"
@@ -20,17 +22,15 @@ gem "rspec", "~> 3.13"
 gem "rspec-collection_matchers", "~> 1.1"
 gem "rspec-wait", "~> 0"
 gem "rspec_junit_formatter", ">= 0.5.1"
+gem "rubocop", "~> 1.50.0", require: false
+gem "rubocop-packaging", "~> 0.5.2", require: false
+gem "rubocop-performance", "~> 1.9", require: false
+gem "rubocop-rspec", ["~> 2.20", "< 2.21"], require: false
 gem "simplecov", git: "https://github.com/DataDog/simplecov", ref: "3bb6b7ee58bf4b1954ca205f50dd44d6f41c57db"
 gem "simplecov-cobertura", "~> 2.1.0"
 gem "warning", "~> 1"
 gem "webmock", ">= 3.10.0"
 gem "webrick", ">= 1.7.0"
-gem "rubocop", "~> 1.50.0", require: false
-gem "rubocop-packaging", "~> 0.5.2", require: false
-gem "rubocop-performance", "~> 1.9", require: false
-gem "rubocop-rspec", ["~> 2.20", "< 2.21"], require: false
-gem "dogstatsd-ruby", ">= 3.3.0", "!= 5.0.0", "!= 5.0.1", "!= 5.1.0"
-gem "google-protobuf", ["~> 3.0", "!= 3.7.0", "!= 3.7.1"]
 gem "stripe", "~> 10"
 
 group :check do

--- a/gemfiles/ruby_3.1_stripe_11.gemfile
+++ b/gemfiles/ruby_3.1_stripe_11.gemfile
@@ -6,7 +6,9 @@ gem "benchmark-ips", "~> 2.8"
 gem "benchmark-memory", "< 0.2"
 gem "climate_control", "~> 0.2.0"
 gem "concurrent-ruby"
+gem "dogstatsd-ruby", ">= 3.3.0", "!= 5.0.0", "!= 5.0.1", "!= 5.1.0"
 gem "extlz4", "~> 0.3", ">= 0.3.3"
+gem "google-protobuf", ["~> 3.0", "!= 3.7.0", "!= 3.7.1"]
 gem "json-schema", "< 3"
 gem "memory_profiler", "~> 0.9"
 gem "os", "~> 1.1"
@@ -20,17 +22,15 @@ gem "rspec", "~> 3.13"
 gem "rspec-collection_matchers", "~> 1.1"
 gem "rspec-wait", "~> 0"
 gem "rspec_junit_formatter", ">= 0.5.1"
+gem "rubocop", "~> 1.50.0", require: false
+gem "rubocop-packaging", "~> 0.5.2", require: false
+gem "rubocop-performance", "~> 1.9", require: false
+gem "rubocop-rspec", ["~> 2.20", "< 2.21"], require: false
 gem "simplecov", git: "https://github.com/DataDog/simplecov", ref: "3bb6b7ee58bf4b1954ca205f50dd44d6f41c57db"
 gem "simplecov-cobertura", "~> 2.1.0"
 gem "warning", "~> 1"
 gem "webmock", ">= 3.10.0"
 gem "webrick", ">= 1.7.0"
-gem "rubocop", "~> 1.50.0", require: false
-gem "rubocop-packaging", "~> 0.5.2", require: false
-gem "rubocop-performance", "~> 1.9", require: false
-gem "rubocop-rspec", ["~> 2.20", "< 2.21"], require: false
-gem "dogstatsd-ruby", ">= 3.3.0", "!= 5.0.0", "!= 5.0.1", "!= 5.1.0"
-gem "google-protobuf", ["~> 3.0", "!= 3.7.0", "!= 3.7.1"]
 gem "stripe", "~> 11"
 
 group :check do

--- a/gemfiles/ruby_3.1_stripe_12.gemfile
+++ b/gemfiles/ruby_3.1_stripe_12.gemfile
@@ -6,7 +6,9 @@ gem "benchmark-ips", "~> 2.8"
 gem "benchmark-memory", "< 0.2"
 gem "climate_control", "~> 0.2.0"
 gem "concurrent-ruby"
+gem "dogstatsd-ruby", ">= 3.3.0", "!= 5.0.0", "!= 5.0.1", "!= 5.1.0"
 gem "extlz4", "~> 0.3", ">= 0.3.3"
+gem "google-protobuf", ["~> 3.0", "!= 3.7.0", "!= 3.7.1"]
 gem "json-schema", "< 3"
 gem "memory_profiler", "~> 0.9"
 gem "os", "~> 1.1"
@@ -20,17 +22,15 @@ gem "rspec", "~> 3.13"
 gem "rspec-collection_matchers", "~> 1.1"
 gem "rspec-wait", "~> 0"
 gem "rspec_junit_formatter", ">= 0.5.1"
+gem "rubocop", "~> 1.50.0", require: false
+gem "rubocop-packaging", "~> 0.5.2", require: false
+gem "rubocop-performance", "~> 1.9", require: false
+gem "rubocop-rspec", ["~> 2.20", "< 2.21"], require: false
 gem "simplecov", git: "https://github.com/DataDog/simplecov", ref: "3bb6b7ee58bf4b1954ca205f50dd44d6f41c57db"
 gem "simplecov-cobertura", "~> 2.1.0"
 gem "warning", "~> 1"
 gem "webmock", ">= 3.10.0"
 gem "webrick", ">= 1.7.0"
-gem "rubocop", "~> 1.50.0", require: false
-gem "rubocop-packaging", "~> 0.5.2", require: false
-gem "rubocop-performance", "~> 1.9", require: false
-gem "rubocop-rspec", ["~> 2.20", "< 2.21"], require: false
-gem "dogstatsd-ruby", ">= 3.3.0", "!= 5.0.0", "!= 5.0.1", "!= 5.1.0"
-gem "google-protobuf", ["~> 3.0", "!= 3.7.0", "!= 3.7.1"]
 gem "stripe", "~> 12"
 
 group :check do

--- a/gemfiles/ruby_3.1_stripe_7.gemfile
+++ b/gemfiles/ruby_3.1_stripe_7.gemfile
@@ -6,7 +6,9 @@ gem "benchmark-ips", "~> 2.8"
 gem "benchmark-memory", "< 0.2"
 gem "climate_control", "~> 0.2.0"
 gem "concurrent-ruby"
+gem "dogstatsd-ruby", ">= 3.3.0", "!= 5.0.0", "!= 5.0.1", "!= 5.1.0"
 gem "extlz4", "~> 0.3", ">= 0.3.3"
+gem "google-protobuf", ["~> 3.0", "!= 3.7.0", "!= 3.7.1"]
 gem "json-schema", "< 3"
 gem "memory_profiler", "~> 0.9"
 gem "os", "~> 1.1"
@@ -20,17 +22,15 @@ gem "rspec", "~> 3.13"
 gem "rspec-collection_matchers", "~> 1.1"
 gem "rspec-wait", "~> 0"
 gem "rspec_junit_formatter", ">= 0.5.1"
+gem "rubocop", "~> 1.50.0", require: false
+gem "rubocop-packaging", "~> 0.5.2", require: false
+gem "rubocop-performance", "~> 1.9", require: false
+gem "rubocop-rspec", ["~> 2.20", "< 2.21"], require: false
 gem "simplecov", git: "https://github.com/DataDog/simplecov", ref: "3bb6b7ee58bf4b1954ca205f50dd44d6f41c57db"
 gem "simplecov-cobertura", "~> 2.1.0"
 gem "warning", "~> 1"
 gem "webmock", ">= 3.10.0"
 gem "webrick", ">= 1.7.0"
-gem "rubocop", "~> 1.50.0", require: false
-gem "rubocop-packaging", "~> 0.5.2", require: false
-gem "rubocop-performance", "~> 1.9", require: false
-gem "rubocop-rspec", ["~> 2.20", "< 2.21"], require: false
-gem "dogstatsd-ruby", ">= 3.3.0", "!= 5.0.0", "!= 5.0.1", "!= 5.1.0"
-gem "google-protobuf", ["~> 3.0", "!= 3.7.0", "!= 3.7.1"]
 gem "stripe", "~> 7"
 
 group :check do

--- a/gemfiles/ruby_3.1_stripe_8.gemfile
+++ b/gemfiles/ruby_3.1_stripe_8.gemfile
@@ -6,7 +6,9 @@ gem "benchmark-ips", "~> 2.8"
 gem "benchmark-memory", "< 0.2"
 gem "climate_control", "~> 0.2.0"
 gem "concurrent-ruby"
+gem "dogstatsd-ruby", ">= 3.3.0", "!= 5.0.0", "!= 5.0.1", "!= 5.1.0"
 gem "extlz4", "~> 0.3", ">= 0.3.3"
+gem "google-protobuf", ["~> 3.0", "!= 3.7.0", "!= 3.7.1"]
 gem "json-schema", "< 3"
 gem "memory_profiler", "~> 0.9"
 gem "os", "~> 1.1"
@@ -20,17 +22,15 @@ gem "rspec", "~> 3.13"
 gem "rspec-collection_matchers", "~> 1.1"
 gem "rspec-wait", "~> 0"
 gem "rspec_junit_formatter", ">= 0.5.1"
+gem "rubocop", "~> 1.50.0", require: false
+gem "rubocop-packaging", "~> 0.5.2", require: false
+gem "rubocop-performance", "~> 1.9", require: false
+gem "rubocop-rspec", ["~> 2.20", "< 2.21"], require: false
 gem "simplecov", git: "https://github.com/DataDog/simplecov", ref: "3bb6b7ee58bf4b1954ca205f50dd44d6f41c57db"
 gem "simplecov-cobertura", "~> 2.1.0"
 gem "warning", "~> 1"
 gem "webmock", ">= 3.10.0"
 gem "webrick", ">= 1.7.0"
-gem "rubocop", "~> 1.50.0", require: false
-gem "rubocop-packaging", "~> 0.5.2", require: false
-gem "rubocop-performance", "~> 1.9", require: false
-gem "rubocop-rspec", ["~> 2.20", "< 2.21"], require: false
-gem "dogstatsd-ruby", ">= 3.3.0", "!= 5.0.0", "!= 5.0.1", "!= 5.1.0"
-gem "google-protobuf", ["~> 3.0", "!= 3.7.0", "!= 3.7.1"]
 gem "stripe", "~> 8"
 
 group :check do

--- a/gemfiles/ruby_3.1_stripe_9.gemfile
+++ b/gemfiles/ruby_3.1_stripe_9.gemfile
@@ -6,7 +6,9 @@ gem "benchmark-ips", "~> 2.8"
 gem "benchmark-memory", "< 0.2"
 gem "climate_control", "~> 0.2.0"
 gem "concurrent-ruby"
+gem "dogstatsd-ruby", ">= 3.3.0", "!= 5.0.0", "!= 5.0.1", "!= 5.1.0"
 gem "extlz4", "~> 0.3", ">= 0.3.3"
+gem "google-protobuf", ["~> 3.0", "!= 3.7.0", "!= 3.7.1"]
 gem "json-schema", "< 3"
 gem "memory_profiler", "~> 0.9"
 gem "os", "~> 1.1"
@@ -20,17 +22,15 @@ gem "rspec", "~> 3.13"
 gem "rspec-collection_matchers", "~> 1.1"
 gem "rspec-wait", "~> 0"
 gem "rspec_junit_formatter", ">= 0.5.1"
+gem "rubocop", "~> 1.50.0", require: false
+gem "rubocop-packaging", "~> 0.5.2", require: false
+gem "rubocop-performance", "~> 1.9", require: false
+gem "rubocop-rspec", ["~> 2.20", "< 2.21"], require: false
 gem "simplecov", git: "https://github.com/DataDog/simplecov", ref: "3bb6b7ee58bf4b1954ca205f50dd44d6f41c57db"
 gem "simplecov-cobertura", "~> 2.1.0"
 gem "warning", "~> 1"
 gem "webmock", ">= 3.10.0"
 gem "webrick", ">= 1.7.0"
-gem "rubocop", "~> 1.50.0", require: false
-gem "rubocop-packaging", "~> 0.5.2", require: false
-gem "rubocop-performance", "~> 1.9", require: false
-gem "rubocop-rspec", ["~> 2.20", "< 2.21"], require: false
-gem "dogstatsd-ruby", ">= 3.3.0", "!= 5.0.0", "!= 5.0.1", "!= 5.1.0"
-gem "google-protobuf", ["~> 3.0", "!= 3.7.0", "!= 3.7.1"]
 gem "stripe", "~> 9"
 
 group :check do

--- a/gemfiles/ruby_3.1_stripe_latest.gemfile
+++ b/gemfiles/ruby_3.1_stripe_latest.gemfile
@@ -6,7 +6,9 @@ gem "benchmark-ips", "~> 2.8"
 gem "benchmark-memory", "< 0.2"
 gem "climate_control", "~> 0.2.0"
 gem "concurrent-ruby"
+gem "dogstatsd-ruby", ">= 3.3.0", "!= 5.0.0", "!= 5.0.1", "!= 5.1.0"
 gem "extlz4", "~> 0.3", ">= 0.3.3"
+gem "google-protobuf", ["~> 3.0", "!= 3.7.0", "!= 3.7.1"]
 gem "json-schema", "< 3"
 gem "memory_profiler", "~> 0.9"
 gem "os", "~> 1.1"
@@ -20,17 +22,15 @@ gem "rspec", "~> 3.13"
 gem "rspec-collection_matchers", "~> 1.1"
 gem "rspec-wait", "~> 0"
 gem "rspec_junit_formatter", ">= 0.5.1"
+gem "rubocop", "~> 1.50.0", require: false
+gem "rubocop-packaging", "~> 0.5.2", require: false
+gem "rubocop-performance", "~> 1.9", require: false
+gem "rubocop-rspec", ["~> 2.20", "< 2.21"], require: false
 gem "simplecov", git: "https://github.com/DataDog/simplecov", ref: "3bb6b7ee58bf4b1954ca205f50dd44d6f41c57db"
 gem "simplecov-cobertura", "~> 2.1.0"
 gem "warning", "~> 1"
 gem "webmock", ">= 3.10.0"
 gem "webrick", ">= 1.7.0"
-gem "rubocop", "~> 1.50.0", require: false
-gem "rubocop-packaging", "~> 0.5.2", require: false
-gem "rubocop-performance", "~> 1.9", require: false
-gem "rubocop-rspec", ["~> 2.20", "< 2.21"], require: false
-gem "dogstatsd-ruby", ">= 3.3.0", "!= 5.0.0", "!= 5.0.1", "!= 5.1.0"
-gem "google-protobuf", ["~> 3.0", "!= 3.7.0", "!= 3.7.1"]
 gem "stripe"
 
 group :check do

--- a/gemfiles/ruby_3.1_stripe_min.gemfile
+++ b/gemfiles/ruby_3.1_stripe_min.gemfile
@@ -6,7 +6,9 @@ gem "benchmark-ips", "~> 2.8"
 gem "benchmark-memory", "< 0.2"
 gem "climate_control", "~> 0.2.0"
 gem "concurrent-ruby"
+gem "dogstatsd-ruby", ">= 3.3.0", "!= 5.0.0", "!= 5.0.1", "!= 5.1.0"
 gem "extlz4", "~> 0.3", ">= 0.3.3"
+gem "google-protobuf", ["~> 3.0", "!= 3.7.0", "!= 3.7.1"]
 gem "json-schema", "< 3"
 gem "memory_profiler", "~> 0.9"
 gem "os", "~> 1.1"
@@ -20,17 +22,15 @@ gem "rspec", "~> 3.13"
 gem "rspec-collection_matchers", "~> 1.1"
 gem "rspec-wait", "~> 0"
 gem "rspec_junit_formatter", ">= 0.5.1"
+gem "rubocop", "~> 1.50.0", require: false
+gem "rubocop-packaging", "~> 0.5.2", require: false
+gem "rubocop-performance", "~> 1.9", require: false
+gem "rubocop-rspec", ["~> 2.20", "< 2.21"], require: false
 gem "simplecov", git: "https://github.com/DataDog/simplecov", ref: "3bb6b7ee58bf4b1954ca205f50dd44d6f41c57db"
 gem "simplecov-cobertura", "~> 2.1.0"
 gem "warning", "~> 1"
 gem "webmock", ">= 3.10.0"
 gem "webrick", ">= 1.7.0"
-gem "rubocop", "~> 1.50.0", require: false
-gem "rubocop-packaging", "~> 0.5.2", require: false
-gem "rubocop-performance", "~> 1.9", require: false
-gem "rubocop-rspec", ["~> 2.20", "< 2.21"], require: false
-gem "dogstatsd-ruby", ">= 3.3.0", "!= 5.0.0", "!= 5.0.1", "!= 5.1.0"
-gem "google-protobuf", ["~> 3.0", "!= 3.7.0", "!= 3.7.1"]
 gem "stripe", "= 5.15.0"
 
 group :check do

--- a/gemfiles/ruby_3.2_activesupport.gemfile
+++ b/gemfiles/ruby_3.2_activesupport.gemfile
@@ -6,7 +6,9 @@ gem "benchmark-ips", "~> 2.8"
 gem "benchmark-memory", "< 0.2"
 gem "climate_control", "~> 0.2.0"
 gem "concurrent-ruby"
+gem "dogstatsd-ruby", ">= 3.3.0", "!= 5.0.0", "!= 5.0.1", "!= 5.1.0"
 gem "extlz4", "~> 0.3", ">= 0.3.3"
+gem "google-protobuf", ["~> 3.0", "!= 3.7.0", "!= 3.7.1"]
 gem "json-schema", "< 3"
 gem "memory_profiler", "~> 0.9"
 gem "os", "~> 1.1"
@@ -19,17 +21,15 @@ gem "rspec", "~> 3.13"
 gem "rspec-collection_matchers", "~> 1.1"
 gem "rspec-wait", "~> 0"
 gem "rspec_junit_formatter", ">= 0.5.1"
+gem "rubocop", "~> 1.50.0", require: false
+gem "rubocop-packaging", "~> 0.5.2", require: false
+gem "rubocop-performance", "~> 1.9", require: false
+gem "rubocop-rspec", ["~> 2.20", "< 2.21"], require: false
 gem "simplecov", git: "https://github.com/DataDog/simplecov", ref: "3bb6b7ee58bf4b1954ca205f50dd44d6f41c57db"
 gem "simplecov-cobertura", "~> 2.1.0"
 gem "warning", "~> 1"
 gem "webmock", ">= 3.10.0"
 gem "webrick", ">= 1.7.0"
-gem "rubocop", "~> 1.50.0", require: false
-gem "rubocop-packaging", "~> 0.5.2", require: false
-gem "rubocop-performance", "~> 1.9", require: false
-gem "rubocop-rspec", ["~> 2.20", "< 2.21"], require: false
-gem "dogstatsd-ruby", ">= 3.3.0", "!= 5.0.0", "!= 5.0.1", "!= 5.1.0"
-gem "google-protobuf", ["~> 3.0", "!= 3.7.0", "!= 3.7.1"]
 gem "activesupport", "~> 7"
 gem "actionpack"
 gem "actionview"

--- a/gemfiles/ruby_3.2_aws.gemfile
+++ b/gemfiles/ruby_3.2_aws.gemfile
@@ -6,7 +6,9 @@ gem "benchmark-ips", "~> 2.8"
 gem "benchmark-memory", "< 0.2"
 gem "climate_control", "~> 0.2.0"
 gem "concurrent-ruby"
+gem "dogstatsd-ruby", ">= 3.3.0", "!= 5.0.0", "!= 5.0.1", "!= 5.1.0"
 gem "extlz4", "~> 0.3", ">= 0.3.3"
+gem "google-protobuf", ["~> 3.0", "!= 3.7.0", "!= 3.7.1"]
 gem "json-schema", "< 3"
 gem "memory_profiler", "~> 0.9"
 gem "os", "~> 1.1"
@@ -19,17 +21,15 @@ gem "rspec", "~> 3.13"
 gem "rspec-collection_matchers", "~> 1.1"
 gem "rspec-wait", "~> 0"
 gem "rspec_junit_formatter", ">= 0.5.1"
+gem "rubocop", "~> 1.50.0", require: false
+gem "rubocop-packaging", "~> 0.5.2", require: false
+gem "rubocop-performance", "~> 1.9", require: false
+gem "rubocop-rspec", ["~> 2.20", "< 2.21"], require: false
 gem "simplecov", git: "https://github.com/DataDog/simplecov", ref: "3bb6b7ee58bf4b1954ca205f50dd44d6f41c57db"
 gem "simplecov-cobertura", "~> 2.1.0"
 gem "warning", "~> 1"
 gem "webmock", ">= 3.10.0"
 gem "webrick", ">= 1.7.0"
-gem "rubocop", "~> 1.50.0", require: false
-gem "rubocop-packaging", "~> 0.5.2", require: false
-gem "rubocop-performance", "~> 1.9", require: false
-gem "rubocop-rspec", ["~> 2.20", "< 2.21"], require: false
-gem "dogstatsd-ruby", ">= 3.3.0", "!= 5.0.0", "!= 5.0.1", "!= 5.1.0"
-gem "google-protobuf", ["~> 3.0", "!= 3.7.0", "!= 3.7.1"]
 gem "aws-sdk"
 gem "shoryuken"
 

--- a/gemfiles/ruby_3.2_contrib.gemfile
+++ b/gemfiles/ruby_3.2_contrib.gemfile
@@ -6,7 +6,9 @@ gem "benchmark-ips", "~> 2.8"
 gem "benchmark-memory", "< 0.2"
 gem "climate_control", "~> 0.2.0"
 gem "concurrent-ruby"
+gem "dogstatsd-ruby", ">= 3.3.0", "!= 5.0.0", "!= 5.0.1", "!= 5.1.0"
 gem "extlz4", "~> 0.3", ">= 0.3.3"
+gem "google-protobuf", ["~> 3.0", "!= 3.7.0", "!= 3.7.1"]
 gem "json-schema", "< 3"
 gem "memory_profiler", "~> 0.9"
 gem "os", "~> 1.1"
@@ -19,17 +21,15 @@ gem "rspec", "~> 3.13"
 gem "rspec-collection_matchers", "~> 1.1"
 gem "rspec-wait", "~> 0"
 gem "rspec_junit_formatter", ">= 0.5.1"
+gem "rubocop", "~> 1.50.0", require: false
+gem "rubocop-packaging", "~> 0.5.2", require: false
+gem "rubocop-performance", "~> 1.9", require: false
+gem "rubocop-rspec", ["~> 2.20", "< 2.21"], require: false
 gem "simplecov", git: "https://github.com/DataDog/simplecov", ref: "3bb6b7ee58bf4b1954ca205f50dd44d6f41c57db"
 gem "simplecov-cobertura", "~> 2.1.0"
 gem "warning", "~> 1"
 gem "webmock", ">= 3.10.0"
 gem "webrick", ">= 1.7.0"
-gem "rubocop", "~> 1.50.0", require: false
-gem "rubocop-packaging", "~> 0.5.2", require: false
-gem "rubocop-performance", "~> 1.9", require: false
-gem "rubocop-rspec", ["~> 2.20", "< 2.21"], require: false
-gem "dogstatsd-ruby", ">= 3.3.0", "!= 5.0.0", "!= 5.0.1", "!= 5.1.0"
-gem "google-protobuf", ["~> 3.0", "!= 3.7.0", "!= 3.7.1"]
 gem "dalli", ">= 3.0.0"
 gem "grpc", ">= 1.38.0", platform: :ruby
 gem "mongo", ">= 2.8.0", "< 2.15.0"

--- a/gemfiles/ruby_3.2_contrib_old.gemfile
+++ b/gemfiles/ruby_3.2_contrib_old.gemfile
@@ -6,7 +6,9 @@ gem "benchmark-ips", "~> 2.8"
 gem "benchmark-memory", "< 0.2"
 gem "climate_control", "~> 0.2.0"
 gem "concurrent-ruby"
+gem "dogstatsd-ruby", ">= 3.3.0", "!= 5.0.0", "!= 5.0.1", "!= 5.1.0"
 gem "extlz4", "~> 0.3", ">= 0.3.3"
+gem "google-protobuf", ["~> 3.0", "!= 3.7.0", "!= 3.7.1"]
 gem "json-schema", "< 3"
 gem "memory_profiler", "~> 0.9"
 gem "os", "~> 1.1"
@@ -19,17 +21,15 @@ gem "rspec", "~> 3.13"
 gem "rspec-collection_matchers", "~> 1.1"
 gem "rspec-wait", "~> 0"
 gem "rspec_junit_formatter", ">= 0.5.1"
+gem "rubocop", "~> 1.50.0", require: false
+gem "rubocop-packaging", "~> 0.5.2", require: false
+gem "rubocop-performance", "~> 1.9", require: false
+gem "rubocop-rspec", ["~> 2.20", "< 2.21"], require: false
 gem "simplecov", git: "https://github.com/DataDog/simplecov", ref: "3bb6b7ee58bf4b1954ca205f50dd44d6f41c57db"
 gem "simplecov-cobertura", "~> 2.1.0"
 gem "warning", "~> 1"
 gem "webmock", ">= 3.10.0"
 gem "webrick", ">= 1.7.0"
-gem "rubocop", "~> 1.50.0", require: false
-gem "rubocop-packaging", "~> 0.5.2", require: false
-gem "rubocop-performance", "~> 1.9", require: false
-gem "rubocop-rspec", ["~> 2.20", "< 2.21"], require: false
-gem "dogstatsd-ruby", ">= 3.3.0", "!= 5.0.0", "!= 5.0.1", "!= 5.1.0"
-gem "google-protobuf", ["~> 3.0", "!= 3.7.0", "!= 3.7.1"]
 gem "dalli", "< 3.0.0"
 gem "presto-client", ">= 0.5.14"
 gem "qless", "0.12.0"

--- a/gemfiles/ruby_3.2_core_old.gemfile
+++ b/gemfiles/ruby_3.2_core_old.gemfile
@@ -6,7 +6,9 @@ gem "benchmark-ips", "~> 2.8"
 gem "benchmark-memory", "< 0.2"
 gem "climate_control", "~> 0.2.0"
 gem "concurrent-ruby"
+gem "dogstatsd-ruby", "~> 4"
 gem "extlz4", "~> 0.3", ">= 0.3.3"
+gem "google-protobuf", ["~> 3.0", "!= 3.7.0", "!= 3.7.1"]
 gem "json-schema", "< 3"
 gem "memory_profiler", "~> 0.9"
 gem "os", "~> 1.1"
@@ -19,17 +21,15 @@ gem "rspec", "~> 3.13"
 gem "rspec-collection_matchers", "~> 1.1"
 gem "rspec-wait", "~> 0"
 gem "rspec_junit_formatter", ">= 0.5.1"
+gem "rubocop", "~> 1.50.0", require: false
+gem "rubocop-packaging", "~> 0.5.2", require: false
+gem "rubocop-performance", "~> 1.9", require: false
+gem "rubocop-rspec", ["~> 2.20", "< 2.21"], require: false
 gem "simplecov", git: "https://github.com/DataDog/simplecov", ref: "3bb6b7ee58bf4b1954ca205f50dd44d6f41c57db"
 gem "simplecov-cobertura", "~> 2.1.0"
 gem "warning", "~> 1"
 gem "webmock", ">= 3.10.0"
 gem "webrick", ">= 1.7.0"
-gem "rubocop", "~> 1.50.0", require: false
-gem "rubocop-packaging", "~> 0.5.2", require: false
-gem "rubocop-performance", "~> 1.9", require: false
-gem "rubocop-rspec", ["~> 2.20", "< 2.21"], require: false
-gem "dogstatsd-ruby", "~> 4"
-gem "google-protobuf", ["~> 3.0", "!= 3.7.0", "!= 3.7.1"]
 
 group :check do
 

--- a/gemfiles/ruby_3.2_elasticsearch_7.gemfile
+++ b/gemfiles/ruby_3.2_elasticsearch_7.gemfile
@@ -6,7 +6,9 @@ gem "benchmark-ips", "~> 2.8"
 gem "benchmark-memory", "< 0.2"
 gem "climate_control", "~> 0.2.0"
 gem "concurrent-ruby"
+gem "dogstatsd-ruby", ">= 3.3.0", "!= 5.0.0", "!= 5.0.1", "!= 5.1.0"
 gem "extlz4", "~> 0.3", ">= 0.3.3"
+gem "google-protobuf", ["~> 3.0", "!= 3.7.0", "!= 3.7.1"]
 gem "json-schema", "< 3"
 gem "memory_profiler", "~> 0.9"
 gem "os", "~> 1.1"
@@ -19,17 +21,15 @@ gem "rspec", "~> 3.13"
 gem "rspec-collection_matchers", "~> 1.1"
 gem "rspec-wait", "~> 0"
 gem "rspec_junit_formatter", ">= 0.5.1"
+gem "rubocop", "~> 1.50.0", require: false
+gem "rubocop-packaging", "~> 0.5.2", require: false
+gem "rubocop-performance", "~> 1.9", require: false
+gem "rubocop-rspec", ["~> 2.20", "< 2.21"], require: false
 gem "simplecov", git: "https://github.com/DataDog/simplecov", ref: "3bb6b7ee58bf4b1954ca205f50dd44d6f41c57db"
 gem "simplecov-cobertura", "~> 2.1.0"
 gem "warning", "~> 1"
 gem "webmock", ">= 3.10.0"
 gem "webrick", ">= 1.7.0"
-gem "rubocop", "~> 1.50.0", require: false
-gem "rubocop-packaging", "~> 0.5.2", require: false
-gem "rubocop-performance", "~> 1.9", require: false
-gem "rubocop-rspec", ["~> 2.20", "< 2.21"], require: false
-gem "dogstatsd-ruby", ">= 3.3.0", "!= 5.0.0", "!= 5.0.1", "!= 5.1.0"
-gem "google-protobuf", ["~> 3.0", "!= 3.7.0", "!= 3.7.1"]
 gem "elasticsearch", "~> 7"
 
 group :check do

--- a/gemfiles/ruby_3.2_elasticsearch_8.gemfile
+++ b/gemfiles/ruby_3.2_elasticsearch_8.gemfile
@@ -6,7 +6,9 @@ gem "benchmark-ips", "~> 2.8"
 gem "benchmark-memory", "< 0.2"
 gem "climate_control", "~> 0.2.0"
 gem "concurrent-ruby"
+gem "dogstatsd-ruby", ">= 3.3.0", "!= 5.0.0", "!= 5.0.1", "!= 5.1.0"
 gem "extlz4", "~> 0.3", ">= 0.3.3"
+gem "google-protobuf", ["~> 3.0", "!= 3.7.0", "!= 3.7.1"]
 gem "json-schema", "< 3"
 gem "memory_profiler", "~> 0.9"
 gem "os", "~> 1.1"
@@ -19,17 +21,15 @@ gem "rspec", "~> 3.13"
 gem "rspec-collection_matchers", "~> 1.1"
 gem "rspec-wait", "~> 0"
 gem "rspec_junit_formatter", ">= 0.5.1"
+gem "rubocop", "~> 1.50.0", require: false
+gem "rubocop-packaging", "~> 0.5.2", require: false
+gem "rubocop-performance", "~> 1.9", require: false
+gem "rubocop-rspec", ["~> 2.20", "< 2.21"], require: false
 gem "simplecov", git: "https://github.com/DataDog/simplecov", ref: "3bb6b7ee58bf4b1954ca205f50dd44d6f41c57db"
 gem "simplecov-cobertura", "~> 2.1.0"
 gem "warning", "~> 1"
 gem "webmock", ">= 3.10.0"
 gem "webrick", ">= 1.7.0"
-gem "rubocop", "~> 1.50.0", require: false
-gem "rubocop-packaging", "~> 0.5.2", require: false
-gem "rubocop-performance", "~> 1.9", require: false
-gem "rubocop-rspec", ["~> 2.20", "< 2.21"], require: false
-gem "dogstatsd-ruby", ">= 3.3.0", "!= 5.0.0", "!= 5.0.1", "!= 5.1.0"
-gem "google-protobuf", ["~> 3.0", "!= 3.7.0", "!= 3.7.1"]
 gem "elasticsearch", "~> 8"
 
 group :check do

--- a/gemfiles/ruby_3.2_elasticsearch_latest.gemfile
+++ b/gemfiles/ruby_3.2_elasticsearch_latest.gemfile
@@ -6,7 +6,9 @@ gem "benchmark-ips", "~> 2.8"
 gem "benchmark-memory", "< 0.2"
 gem "climate_control", "~> 0.2.0"
 gem "concurrent-ruby"
+gem "dogstatsd-ruby", ">= 3.3.0", "!= 5.0.0", "!= 5.0.1", "!= 5.1.0"
 gem "extlz4", "~> 0.3", ">= 0.3.3"
+gem "google-protobuf", ["~> 3.0", "!= 3.7.0", "!= 3.7.1"]
 gem "json-schema", "< 3"
 gem "memory_profiler", "~> 0.9"
 gem "os", "~> 1.1"
@@ -19,17 +21,15 @@ gem "rspec", "~> 3.13"
 gem "rspec-collection_matchers", "~> 1.1"
 gem "rspec-wait", "~> 0"
 gem "rspec_junit_formatter", ">= 0.5.1"
+gem "rubocop", "~> 1.50.0", require: false
+gem "rubocop-packaging", "~> 0.5.2", require: false
+gem "rubocop-performance", "~> 1.9", require: false
+gem "rubocop-rspec", ["~> 2.20", "< 2.21"], require: false
 gem "simplecov", git: "https://github.com/DataDog/simplecov", ref: "3bb6b7ee58bf4b1954ca205f50dd44d6f41c57db"
 gem "simplecov-cobertura", "~> 2.1.0"
 gem "warning", "~> 1"
 gem "webmock", ">= 3.10.0"
 gem "webrick", ">= 1.7.0"
-gem "rubocop", "~> 1.50.0", require: false
-gem "rubocop-packaging", "~> 0.5.2", require: false
-gem "rubocop-performance", "~> 1.9", require: false
-gem "rubocop-rspec", ["~> 2.20", "< 2.21"], require: false
-gem "dogstatsd-ruby", ">= 3.3.0", "!= 5.0.0", "!= 5.0.1", "!= 5.1.0"
-gem "google-protobuf", ["~> 3.0", "!= 3.7.0", "!= 3.7.1"]
 gem "elasticsearch"
 
 group :check do

--- a/gemfiles/ruby_3.2_graphql_1.13.gemfile
+++ b/gemfiles/ruby_3.2_graphql_1.13.gemfile
@@ -6,7 +6,9 @@ gem "benchmark-ips", "~> 2.8"
 gem "benchmark-memory", "< 0.2"
 gem "climate_control", "~> 0.2.0"
 gem "concurrent-ruby"
+gem "dogstatsd-ruby", ">= 3.3.0", "!= 5.0.0", "!= 5.0.1", "!= 5.1.0"
 gem "extlz4", "~> 0.3", ">= 0.3.3"
+gem "google-protobuf", ["~> 3.0", "!= 3.7.0", "!= 3.7.1"]
 gem "json-schema", "< 3"
 gem "memory_profiler", "~> 0.9"
 gem "os", "~> 1.1"
@@ -19,17 +21,15 @@ gem "rspec", "~> 3.13"
 gem "rspec-collection_matchers", "~> 1.1"
 gem "rspec-wait", "~> 0"
 gem "rspec_junit_formatter", ">= 0.5.1"
+gem "rubocop", "~> 1.50.0", require: false
+gem "rubocop-packaging", "~> 0.5.2", require: false
+gem "rubocop-performance", "~> 1.9", require: false
+gem "rubocop-rspec", ["~> 2.20", "< 2.21"], require: false
 gem "simplecov", git: "https://github.com/DataDog/simplecov", ref: "3bb6b7ee58bf4b1954ca205f50dd44d6f41c57db"
 gem "simplecov-cobertura", "~> 2.1.0"
 gem "warning", "~> 1"
 gem "webmock", ">= 3.10.0"
 gem "webrick", ">= 1.7.0"
-gem "rubocop", "~> 1.50.0", require: false
-gem "rubocop-packaging", "~> 0.5.2", require: false
-gem "rubocop-performance", "~> 1.9", require: false
-gem "rubocop-rspec", ["~> 2.20", "< 2.21"], require: false
-gem "dogstatsd-ruby", ">= 3.3.0", "!= 5.0.0", "!= 5.0.1", "!= 5.1.0"
-gem "google-protobuf", ["~> 3.0", "!= 3.7.0", "!= 3.7.1"]
 gem "rails", "~> 6.1.0"
 gem "graphql", "~> 1.13.0"
 gem "sprockets", "< 4"

--- a/gemfiles/ruby_3.2_graphql_2.0.gemfile
+++ b/gemfiles/ruby_3.2_graphql_2.0.gemfile
@@ -6,7 +6,9 @@ gem "benchmark-ips", "~> 2.8"
 gem "benchmark-memory", "< 0.2"
 gem "climate_control", "~> 0.2.0"
 gem "concurrent-ruby"
+gem "dogstatsd-ruby", ">= 3.3.0", "!= 5.0.0", "!= 5.0.1", "!= 5.1.0"
 gem "extlz4", "~> 0.3", ">= 0.3.3"
+gem "google-protobuf", ["~> 3.0", "!= 3.7.0", "!= 3.7.1"]
 gem "json-schema", "< 3"
 gem "memory_profiler", "~> 0.9"
 gem "os", "~> 1.1"
@@ -19,17 +21,15 @@ gem "rspec", "~> 3.13"
 gem "rspec-collection_matchers", "~> 1.1"
 gem "rspec-wait", "~> 0"
 gem "rspec_junit_formatter", ">= 0.5.1"
+gem "rubocop", "~> 1.50.0", require: false
+gem "rubocop-packaging", "~> 0.5.2", require: false
+gem "rubocop-performance", "~> 1.9", require: false
+gem "rubocop-rspec", ["~> 2.20", "< 2.21"], require: false
 gem "simplecov", git: "https://github.com/DataDog/simplecov", ref: "3bb6b7ee58bf4b1954ca205f50dd44d6f41c57db"
 gem "simplecov-cobertura", "~> 2.1.0"
 gem "warning", "~> 1"
 gem "webmock", ">= 3.10.0"
 gem "webrick", ">= 1.7.0"
-gem "rubocop", "~> 1.50.0", require: false
-gem "rubocop-packaging", "~> 0.5.2", require: false
-gem "rubocop-performance", "~> 1.9", require: false
-gem "rubocop-rspec", ["~> 2.20", "< 2.21"], require: false
-gem "dogstatsd-ruby", ">= 3.3.0", "!= 5.0.0", "!= 5.0.1", "!= 5.1.0"
-gem "google-protobuf", ["~> 3.0", "!= 3.7.0", "!= 3.7.1"]
 gem "rails", "~> 6.1.0"
 gem "graphql", "~> 2.0.0"
 gem "sprockets", "< 4"

--- a/gemfiles/ruby_3.2_graphql_2.1.gemfile
+++ b/gemfiles/ruby_3.2_graphql_2.1.gemfile
@@ -6,7 +6,9 @@ gem "benchmark-ips", "~> 2.8"
 gem "benchmark-memory", "< 0.2"
 gem "climate_control", "~> 0.2.0"
 gem "concurrent-ruby"
+gem "dogstatsd-ruby", ">= 3.3.0", "!= 5.0.0", "!= 5.0.1", "!= 5.1.0"
 gem "extlz4", "~> 0.3", ">= 0.3.3"
+gem "google-protobuf", ["~> 3.0", "!= 3.7.0", "!= 3.7.1"]
 gem "json-schema", "< 3"
 gem "memory_profiler", "~> 0.9"
 gem "os", "~> 1.1"
@@ -19,17 +21,15 @@ gem "rspec", "~> 3.13"
 gem "rspec-collection_matchers", "~> 1.1"
 gem "rspec-wait", "~> 0"
 gem "rspec_junit_formatter", ">= 0.5.1"
+gem "rubocop", "~> 1.50.0", require: false
+gem "rubocop-packaging", "~> 0.5.2", require: false
+gem "rubocop-performance", "~> 1.9", require: false
+gem "rubocop-rspec", ["~> 2.20", "< 2.21"], require: false
 gem "simplecov", git: "https://github.com/DataDog/simplecov", ref: "3bb6b7ee58bf4b1954ca205f50dd44d6f41c57db"
 gem "simplecov-cobertura", "~> 2.1.0"
 gem "warning", "~> 1"
 gem "webmock", ">= 3.10.0"
 gem "webrick", ">= 1.7.0"
-gem "rubocop", "~> 1.50.0", require: false
-gem "rubocop-packaging", "~> 0.5.2", require: false
-gem "rubocop-performance", "~> 1.9", require: false
-gem "rubocop-rspec", ["~> 2.20", "< 2.21"], require: false
-gem "dogstatsd-ruby", ">= 3.3.0", "!= 5.0.0", "!= 5.0.1", "!= 5.1.0"
-gem "google-protobuf", ["~> 3.0", "!= 3.7.0", "!= 3.7.1"]
 gem "rails", "~> 6.1.0"
 gem "graphql", "~> 2.1.0"
 gem "sprockets", "< 4"

--- a/gemfiles/ruby_3.2_graphql_2.2.gemfile
+++ b/gemfiles/ruby_3.2_graphql_2.2.gemfile
@@ -6,7 +6,9 @@ gem "benchmark-ips", "~> 2.8"
 gem "benchmark-memory", "< 0.2"
 gem "climate_control", "~> 0.2.0"
 gem "concurrent-ruby"
+gem "dogstatsd-ruby", ">= 3.3.0", "!= 5.0.0", "!= 5.0.1", "!= 5.1.0"
 gem "extlz4", "~> 0.3", ">= 0.3.3"
+gem "google-protobuf", ["~> 3.0", "!= 3.7.0", "!= 3.7.1"]
 gem "json-schema", "< 3"
 gem "memory_profiler", "~> 0.9"
 gem "os", "~> 1.1"
@@ -19,17 +21,15 @@ gem "rspec", "~> 3.13"
 gem "rspec-collection_matchers", "~> 1.1"
 gem "rspec-wait", "~> 0"
 gem "rspec_junit_formatter", ">= 0.5.1"
+gem "rubocop", "~> 1.50.0", require: false
+gem "rubocop-packaging", "~> 0.5.2", require: false
+gem "rubocop-performance", "~> 1.9", require: false
+gem "rubocop-rspec", ["~> 2.20", "< 2.21"], require: false
 gem "simplecov", git: "https://github.com/DataDog/simplecov", ref: "3bb6b7ee58bf4b1954ca205f50dd44d6f41c57db"
 gem "simplecov-cobertura", "~> 2.1.0"
 gem "warning", "~> 1"
 gem "webmock", ">= 3.10.0"
 gem "webrick", ">= 1.7.0"
-gem "rubocop", "~> 1.50.0", require: false
-gem "rubocop-packaging", "~> 0.5.2", require: false
-gem "rubocop-performance", "~> 1.9", require: false
-gem "rubocop-rspec", ["~> 2.20", "< 2.21"], require: false
-gem "dogstatsd-ruby", ">= 3.3.0", "!= 5.0.0", "!= 5.0.1", "!= 5.1.0"
-gem "google-protobuf", ["~> 3.0", "!= 3.7.0", "!= 3.7.1"]
 gem "rails", "~> 6.1.0"
 gem "graphql", "~> 2.2.0"
 gem "sprockets", "< 4"

--- a/gemfiles/ruby_3.2_graphql_2.3.gemfile
+++ b/gemfiles/ruby_3.2_graphql_2.3.gemfile
@@ -6,7 +6,9 @@ gem "benchmark-ips", "~> 2.8"
 gem "benchmark-memory", "< 0.2"
 gem "climate_control", "~> 0.2.0"
 gem "concurrent-ruby"
+gem "dogstatsd-ruby", ">= 3.3.0", "!= 5.0.0", "!= 5.0.1", "!= 5.1.0"
 gem "extlz4", "~> 0.3", ">= 0.3.3"
+gem "google-protobuf", ["~> 3.0", "!= 3.7.0", "!= 3.7.1"]
 gem "json-schema", "< 3"
 gem "memory_profiler", "~> 0.9"
 gem "os", "~> 1.1"
@@ -19,17 +21,15 @@ gem "rspec", "~> 3.13"
 gem "rspec-collection_matchers", "~> 1.1"
 gem "rspec-wait", "~> 0"
 gem "rspec_junit_formatter", ">= 0.5.1"
+gem "rubocop", "~> 1.50.0", require: false
+gem "rubocop-packaging", "~> 0.5.2", require: false
+gem "rubocop-performance", "~> 1.9", require: false
+gem "rubocop-rspec", ["~> 2.20", "< 2.21"], require: false
 gem "simplecov", git: "https://github.com/DataDog/simplecov", ref: "3bb6b7ee58bf4b1954ca205f50dd44d6f41c57db"
 gem "simplecov-cobertura", "~> 2.1.0"
 gem "warning", "~> 1"
 gem "webmock", ">= 3.10.0"
 gem "webrick", ">= 1.7.0"
-gem "rubocop", "~> 1.50.0", require: false
-gem "rubocop-packaging", "~> 0.5.2", require: false
-gem "rubocop-performance", "~> 1.9", require: false
-gem "rubocop-rspec", ["~> 2.20", "< 2.21"], require: false
-gem "dogstatsd-ruby", ">= 3.3.0", "!= 5.0.0", "!= 5.0.1", "!= 5.1.0"
-gem "google-protobuf", ["~> 3.0", "!= 3.7.0", "!= 3.7.1"]
 gem "rails", "~> 6.1.0"
 gem "graphql", "~> 2.3.0"
 gem "sprockets", "< 4"

--- a/gemfiles/ruby_3.2_http.gemfile
+++ b/gemfiles/ruby_3.2_http.gemfile
@@ -6,7 +6,9 @@ gem "benchmark-ips", "~> 2.8"
 gem "benchmark-memory", "< 0.2"
 gem "climate_control", "~> 0.2.0"
 gem "concurrent-ruby"
+gem "dogstatsd-ruby", ">= 3.3.0", "!= 5.0.0", "!= 5.0.1", "!= 5.1.0"
 gem "extlz4", "~> 0.3", ">= 0.3.3"
+gem "google-protobuf", ["~> 3.0", "!= 3.7.0", "!= 3.7.1"]
 gem "json-schema", "< 3"
 gem "memory_profiler", "~> 0.9"
 gem "os", "~> 1.1"
@@ -19,17 +21,15 @@ gem "rspec", "~> 3.13"
 gem "rspec-collection_matchers", "~> 1.1"
 gem "rspec-wait", "~> 0"
 gem "rspec_junit_formatter", ">= 0.5.1"
+gem "rubocop", "~> 1.50.0", require: false
+gem "rubocop-packaging", "~> 0.5.2", require: false
+gem "rubocop-performance", "~> 1.9", require: false
+gem "rubocop-rspec", ["~> 2.20", "< 2.21"], require: false
 gem "simplecov", git: "https://github.com/DataDog/simplecov", ref: "3bb6b7ee58bf4b1954ca205f50dd44d6f41c57db"
 gem "simplecov-cobertura", "~> 2.1.0"
 gem "warning", "~> 1"
 gem "webmock", ">= 3.10.0"
 gem "webrick", ">= 1.7.0"
-gem "rubocop", "~> 1.50.0", require: false
-gem "rubocop-packaging", "~> 0.5.2", require: false
-gem "rubocop-performance", "~> 1.9", require: false
-gem "rubocop-rspec", ["~> 2.20", "< 2.21"], require: false
-gem "dogstatsd-ruby", ">= 3.3.0", "!= 5.0.0", "!= 5.0.1", "!= 5.1.0"
-gem "google-protobuf", ["~> 3.0", "!= 3.7.0", "!= 3.7.1"]
 gem "ethon"
 gem "excon"
 gem "faraday"

--- a/gemfiles/ruby_3.2_opensearch_2.gemfile
+++ b/gemfiles/ruby_3.2_opensearch_2.gemfile
@@ -6,7 +6,9 @@ gem "benchmark-ips", "~> 2.8"
 gem "benchmark-memory", "< 0.2"
 gem "climate_control", "~> 0.2.0"
 gem "concurrent-ruby"
+gem "dogstatsd-ruby", ">= 3.3.0", "!= 5.0.0", "!= 5.0.1", "!= 5.1.0"
 gem "extlz4", "~> 0.3", ">= 0.3.3"
+gem "google-protobuf", ["~> 3.0", "!= 3.7.0", "!= 3.7.1"]
 gem "json-schema", "< 3"
 gem "memory_profiler", "~> 0.9"
 gem "os", "~> 1.1"
@@ -19,17 +21,15 @@ gem "rspec", "~> 3.13"
 gem "rspec-collection_matchers", "~> 1.1"
 gem "rspec-wait", "~> 0"
 gem "rspec_junit_formatter", ">= 0.5.1"
+gem "rubocop", "~> 1.50.0", require: false
+gem "rubocop-packaging", "~> 0.5.2", require: false
+gem "rubocop-performance", "~> 1.9", require: false
+gem "rubocop-rspec", ["~> 2.20", "< 2.21"], require: false
 gem "simplecov", git: "https://github.com/DataDog/simplecov", ref: "3bb6b7ee58bf4b1954ca205f50dd44d6f41c57db"
 gem "simplecov-cobertura", "~> 2.1.0"
 gem "warning", "~> 1"
 gem "webmock", ">= 3.10.0"
 gem "webrick", ">= 1.7.0"
-gem "rubocop", "~> 1.50.0", require: false
-gem "rubocop-packaging", "~> 0.5.2", require: false
-gem "rubocop-performance", "~> 1.9", require: false
-gem "rubocop-rspec", ["~> 2.20", "< 2.21"], require: false
-gem "dogstatsd-ruby", ">= 3.3.0", "!= 5.0.0", "!= 5.0.1", "!= 5.1.0"
-gem "google-protobuf", ["~> 3.0", "!= 3.7.0", "!= 3.7.1"]
 gem "opensearch-ruby", "~> 2"
 
 group :check do

--- a/gemfiles/ruby_3.2_opensearch_3.gemfile
+++ b/gemfiles/ruby_3.2_opensearch_3.gemfile
@@ -6,7 +6,9 @@ gem "benchmark-ips", "~> 2.8"
 gem "benchmark-memory", "< 0.2"
 gem "climate_control", "~> 0.2.0"
 gem "concurrent-ruby"
+gem "dogstatsd-ruby", ">= 3.3.0", "!= 5.0.0", "!= 5.0.1", "!= 5.1.0"
 gem "extlz4", "~> 0.3", ">= 0.3.3"
+gem "google-protobuf", ["~> 3.0", "!= 3.7.0", "!= 3.7.1"]
 gem "json-schema", "< 3"
 gem "memory_profiler", "~> 0.9"
 gem "os", "~> 1.1"
@@ -19,17 +21,15 @@ gem "rspec", "~> 3.13"
 gem "rspec-collection_matchers", "~> 1.1"
 gem "rspec-wait", "~> 0"
 gem "rspec_junit_formatter", ">= 0.5.1"
+gem "rubocop", "~> 1.50.0", require: false
+gem "rubocop-packaging", "~> 0.5.2", require: false
+gem "rubocop-performance", "~> 1.9", require: false
+gem "rubocop-rspec", ["~> 2.20", "< 2.21"], require: false
 gem "simplecov", git: "https://github.com/DataDog/simplecov", ref: "3bb6b7ee58bf4b1954ca205f50dd44d6f41c57db"
 gem "simplecov-cobertura", "~> 2.1.0"
 gem "warning", "~> 1"
 gem "webmock", ">= 3.10.0"
 gem "webrick", ">= 1.7.0"
-gem "rubocop", "~> 1.50.0", require: false
-gem "rubocop-packaging", "~> 0.5.2", require: false
-gem "rubocop-performance", "~> 1.9", require: false
-gem "rubocop-rspec", ["~> 2.20", "< 2.21"], require: false
-gem "dogstatsd-ruby", ">= 3.3.0", "!= 5.0.0", "!= 5.0.1", "!= 5.1.0"
-gem "google-protobuf", ["~> 3.0", "!= 3.7.0", "!= 3.7.1"]
 gem "opensearch-ruby", "~> 3"
 
 group :check do

--- a/gemfiles/ruby_3.2_opensearch_latest.gemfile
+++ b/gemfiles/ruby_3.2_opensearch_latest.gemfile
@@ -6,7 +6,9 @@ gem "benchmark-ips", "~> 2.8"
 gem "benchmark-memory", "< 0.2"
 gem "climate_control", "~> 0.2.0"
 gem "concurrent-ruby"
+gem "dogstatsd-ruby", ">= 3.3.0", "!= 5.0.0", "!= 5.0.1", "!= 5.1.0"
 gem "extlz4", "~> 0.3", ">= 0.3.3"
+gem "google-protobuf", ["~> 3.0", "!= 3.7.0", "!= 3.7.1"]
 gem "json-schema", "< 3"
 gem "memory_profiler", "~> 0.9"
 gem "os", "~> 1.1"
@@ -19,17 +21,15 @@ gem "rspec", "~> 3.13"
 gem "rspec-collection_matchers", "~> 1.1"
 gem "rspec-wait", "~> 0"
 gem "rspec_junit_formatter", ">= 0.5.1"
+gem "rubocop", "~> 1.50.0", require: false
+gem "rubocop-packaging", "~> 0.5.2", require: false
+gem "rubocop-performance", "~> 1.9", require: false
+gem "rubocop-rspec", ["~> 2.20", "< 2.21"], require: false
 gem "simplecov", git: "https://github.com/DataDog/simplecov", ref: "3bb6b7ee58bf4b1954ca205f50dd44d6f41c57db"
 gem "simplecov-cobertura", "~> 2.1.0"
 gem "warning", "~> 1"
 gem "webmock", ">= 3.10.0"
 gem "webrick", ">= 1.7.0"
-gem "rubocop", "~> 1.50.0", require: false
-gem "rubocop-packaging", "~> 0.5.2", require: false
-gem "rubocop-performance", "~> 1.9", require: false
-gem "rubocop-rspec", ["~> 2.20", "< 2.21"], require: false
-gem "dogstatsd-ruby", ">= 3.3.0", "!= 5.0.0", "!= 5.0.1", "!= 5.1.0"
-gem "google-protobuf", ["~> 3.0", "!= 3.7.0", "!= 3.7.1"]
 gem "opensearch-ruby"
 
 group :check do

--- a/gemfiles/ruby_3.2_opentelemetry.gemfile
+++ b/gemfiles/ruby_3.2_opentelemetry.gemfile
@@ -6,7 +6,9 @@ gem "benchmark-ips", "~> 2.8"
 gem "benchmark-memory", "< 0.2"
 gem "climate_control", "~> 0.2.0"
 gem "concurrent-ruby"
+gem "dogstatsd-ruby", ">= 3.3.0", "!= 5.0.0", "!= 5.0.1", "!= 5.1.0"
 gem "extlz4", "~> 0.3", ">= 0.3.3"
+gem "google-protobuf", ["~> 3.0", "!= 3.7.0", "!= 3.7.1"]
 gem "json-schema", "< 3"
 gem "memory_profiler", "~> 0.9"
 gem "os", "~> 1.1"
@@ -19,17 +21,15 @@ gem "rspec", "~> 3.13"
 gem "rspec-collection_matchers", "~> 1.1"
 gem "rspec-wait", "~> 0"
 gem "rspec_junit_formatter", ">= 0.5.1"
+gem "rubocop", "~> 1.50.0", require: false
+gem "rubocop-packaging", "~> 0.5.2", require: false
+gem "rubocop-performance", "~> 1.9", require: false
+gem "rubocop-rspec", ["~> 2.20", "< 2.21"], require: false
 gem "simplecov", git: "https://github.com/DataDog/simplecov", ref: "3bb6b7ee58bf4b1954ca205f50dd44d6f41c57db"
 gem "simplecov-cobertura", "~> 2.1.0"
 gem "warning", "~> 1"
 gem "webmock", ">= 3.10.0"
 gem "webrick", ">= 1.7.0"
-gem "rubocop", "~> 1.50.0", require: false
-gem "rubocop-packaging", "~> 0.5.2", require: false
-gem "rubocop-performance", "~> 1.9", require: false
-gem "rubocop-rspec", ["~> 2.20", "< 2.21"], require: false
-gem "dogstatsd-ruby", ">= 3.3.0", "!= 5.0.0", "!= 5.0.1", "!= 5.1.0"
-gem "google-protobuf", ["~> 3.0", "!= 3.7.0", "!= 3.7.1"]
 gem "opentelemetry-sdk", "~> 1.1"
 
 group :check do

--- a/gemfiles/ruby_3.2_opentelemetry_otlp.gemfile
+++ b/gemfiles/ruby_3.2_opentelemetry_otlp.gemfile
@@ -6,7 +6,9 @@ gem "benchmark-ips", "~> 2.8"
 gem "benchmark-memory", "< 0.2"
 gem "climate_control", "~> 0.2.0"
 gem "concurrent-ruby"
+gem "dogstatsd-ruby", ">= 3.3.0", "!= 5.0.0", "!= 5.0.1", "!= 5.1.0"
 gem "extlz4", "~> 0.3", ">= 0.3.3"
+gem "google-protobuf", ["~> 3.0", "!= 3.7.0", "!= 3.7.1"]
 gem "json-schema", "< 3"
 gem "memory_profiler", "~> 0.9"
 gem "os", "~> 1.1"
@@ -19,17 +21,15 @@ gem "rspec", "~> 3.13"
 gem "rspec-collection_matchers", "~> 1.1"
 gem "rspec-wait", "~> 0"
 gem "rspec_junit_formatter", ">= 0.5.1"
+gem "rubocop", "~> 1.50.0", require: false
+gem "rubocop-packaging", "~> 0.5.2", require: false
+gem "rubocop-performance", "~> 1.9", require: false
+gem "rubocop-rspec", ["~> 2.20", "< 2.21"], require: false
 gem "simplecov", git: "https://github.com/DataDog/simplecov", ref: "3bb6b7ee58bf4b1954ca205f50dd44d6f41c57db"
 gem "simplecov-cobertura", "~> 2.1.0"
 gem "warning", "~> 1"
 gem "webmock", ">= 3.10.0"
 gem "webrick", ">= 1.7.0"
-gem "rubocop", "~> 1.50.0", require: false
-gem "rubocop-packaging", "~> 0.5.2", require: false
-gem "rubocop-performance", "~> 1.9", require: false
-gem "rubocop-rspec", ["~> 2.20", "< 2.21"], require: false
-gem "dogstatsd-ruby", ">= 3.3.0", "!= 5.0.0", "!= 5.0.1", "!= 5.1.0"
-gem "google-protobuf", ["~> 3.0", "!= 3.7.0", "!= 3.7.1"]
 gem "opentelemetry-sdk", "~> 1.1"
 gem "opentelemetry-exporter-otlp"
 

--- a/gemfiles/ruby_3.2_rack_1.gemfile
+++ b/gemfiles/ruby_3.2_rack_1.gemfile
@@ -6,7 +6,9 @@ gem "benchmark-ips", "~> 2.8"
 gem "benchmark-memory", "< 0.2"
 gem "climate_control", "~> 0.2.0"
 gem "concurrent-ruby"
+gem "dogstatsd-ruby", ">= 3.3.0", "!= 5.0.0", "!= 5.0.1", "!= 5.1.0"
 gem "extlz4", "~> 0.3", ">= 0.3.3"
+gem "google-protobuf", ["~> 3.0", "!= 3.7.0", "!= 3.7.1"]
 gem "json-schema", "< 3"
 gem "memory_profiler", "~> 0.9"
 gem "os", "~> 1.1"
@@ -19,17 +21,15 @@ gem "rspec", "~> 3.13"
 gem "rspec-collection_matchers", "~> 1.1"
 gem "rspec-wait", "~> 0"
 gem "rspec_junit_formatter", ">= 0.5.1"
+gem "rubocop", "~> 1.50.0", require: false
+gem "rubocop-packaging", "~> 0.5.2", require: false
+gem "rubocop-performance", "~> 1.9", require: false
+gem "rubocop-rspec", ["~> 2.20", "< 2.21"], require: false
 gem "simplecov", git: "https://github.com/DataDog/simplecov", ref: "3bb6b7ee58bf4b1954ca205f50dd44d6f41c57db"
 gem "simplecov-cobertura", "~> 2.1.0"
 gem "warning", "~> 1"
 gem "webmock", ">= 3.10.0"
 gem "webrick", ">= 1.7.0"
-gem "rubocop", "~> 1.50.0", require: false
-gem "rubocop-packaging", "~> 0.5.2", require: false
-gem "rubocop-performance", "~> 1.9", require: false
-gem "rubocop-rspec", ["~> 2.20", "< 2.21"], require: false
-gem "dogstatsd-ruby", ">= 3.3.0", "!= 5.0.0", "!= 5.0.1", "!= 5.1.0"
-gem "google-protobuf", ["~> 3.0", "!= 3.7.0", "!= 3.7.1"]
 gem "rack", "~> 1"
 gem "rack-contrib"
 gem "rack-test"

--- a/gemfiles/ruby_3.2_rack_2.gemfile
+++ b/gemfiles/ruby_3.2_rack_2.gemfile
@@ -6,7 +6,9 @@ gem "benchmark-ips", "~> 2.8"
 gem "benchmark-memory", "< 0.2"
 gem "climate_control", "~> 0.2.0"
 gem "concurrent-ruby"
+gem "dogstatsd-ruby", ">= 3.3.0", "!= 5.0.0", "!= 5.0.1", "!= 5.1.0"
 gem "extlz4", "~> 0.3", ">= 0.3.3"
+gem "google-protobuf", ["~> 3.0", "!= 3.7.0", "!= 3.7.1"]
 gem "json-schema", "< 3"
 gem "memory_profiler", "~> 0.9"
 gem "os", "~> 1.1"
@@ -19,17 +21,15 @@ gem "rspec", "~> 3.13"
 gem "rspec-collection_matchers", "~> 1.1"
 gem "rspec-wait", "~> 0"
 gem "rspec_junit_formatter", ">= 0.5.1"
+gem "rubocop", "~> 1.50.0", require: false
+gem "rubocop-packaging", "~> 0.5.2", require: false
+gem "rubocop-performance", "~> 1.9", require: false
+gem "rubocop-rspec", ["~> 2.20", "< 2.21"], require: false
 gem "simplecov", git: "https://github.com/DataDog/simplecov", ref: "3bb6b7ee58bf4b1954ca205f50dd44d6f41c57db"
 gem "simplecov-cobertura", "~> 2.1.0"
 gem "warning", "~> 1"
 gem "webmock", ">= 3.10.0"
 gem "webrick", ">= 1.7.0"
-gem "rubocop", "~> 1.50.0", require: false
-gem "rubocop-packaging", "~> 0.5.2", require: false
-gem "rubocop-performance", "~> 1.9", require: false
-gem "rubocop-rspec", ["~> 2.20", "< 2.21"], require: false
-gem "dogstatsd-ruby", ">= 3.3.0", "!= 5.0.0", "!= 5.0.1", "!= 5.1.0"
-gem "google-protobuf", ["~> 3.0", "!= 3.7.0", "!= 3.7.1"]
 gem "rack", "~> 2"
 gem "rack-contrib"
 gem "rack-test"

--- a/gemfiles/ruby_3.2_rack_3.gemfile
+++ b/gemfiles/ruby_3.2_rack_3.gemfile
@@ -6,7 +6,9 @@ gem "benchmark-ips", "~> 2.8"
 gem "benchmark-memory", "< 0.2"
 gem "climate_control", "~> 0.2.0"
 gem "concurrent-ruby"
+gem "dogstatsd-ruby", ">= 3.3.0", "!= 5.0.0", "!= 5.0.1", "!= 5.1.0"
 gem "extlz4", "~> 0.3", ">= 0.3.3"
+gem "google-protobuf", ["~> 3.0", "!= 3.7.0", "!= 3.7.1"]
 gem "json-schema", "< 3"
 gem "memory_profiler", "~> 0.9"
 gem "os", "~> 1.1"
@@ -19,17 +21,15 @@ gem "rspec", "~> 3.13"
 gem "rspec-collection_matchers", "~> 1.1"
 gem "rspec-wait", "~> 0"
 gem "rspec_junit_formatter", ">= 0.5.1"
+gem "rubocop", "~> 1.50.0", require: false
+gem "rubocop-packaging", "~> 0.5.2", require: false
+gem "rubocop-performance", "~> 1.9", require: false
+gem "rubocop-rspec", ["~> 2.20", "< 2.21"], require: false
 gem "simplecov", git: "https://github.com/DataDog/simplecov", ref: "3bb6b7ee58bf4b1954ca205f50dd44d6f41c57db"
 gem "simplecov-cobertura", "~> 2.1.0"
 gem "warning", "~> 1"
 gem "webmock", ">= 3.10.0"
 gem "webrick", ">= 1.7.0"
-gem "rubocop", "~> 1.50.0", require: false
-gem "rubocop-packaging", "~> 0.5.2", require: false
-gem "rubocop-performance", "~> 1.9", require: false
-gem "rubocop-rspec", ["~> 2.20", "< 2.21"], require: false
-gem "dogstatsd-ruby", ">= 3.3.0", "!= 5.0.0", "!= 5.0.1", "!= 5.1.0"
-gem "google-protobuf", ["~> 3.0", "!= 3.7.0", "!= 3.7.1"]
 gem "rack", "~> 3"
 gem "rack-contrib"
 gem "rack-test"

--- a/gemfiles/ruby_3.2_rack_latest.gemfile
+++ b/gemfiles/ruby_3.2_rack_latest.gemfile
@@ -6,7 +6,9 @@ gem "benchmark-ips", "~> 2.8"
 gem "benchmark-memory", "< 0.2"
 gem "climate_control", "~> 0.2.0"
 gem "concurrent-ruby"
+gem "dogstatsd-ruby", ">= 3.3.0", "!= 5.0.0", "!= 5.0.1", "!= 5.1.0"
 gem "extlz4", "~> 0.3", ">= 0.3.3"
+gem "google-protobuf", ["~> 3.0", "!= 3.7.0", "!= 3.7.1"]
 gem "json-schema", "< 3"
 gem "memory_profiler", "~> 0.9"
 gem "os", "~> 1.1"
@@ -19,17 +21,15 @@ gem "rspec", "~> 3.13"
 gem "rspec-collection_matchers", "~> 1.1"
 gem "rspec-wait", "~> 0"
 gem "rspec_junit_formatter", ">= 0.5.1"
+gem "rubocop", "~> 1.50.0", require: false
+gem "rubocop-packaging", "~> 0.5.2", require: false
+gem "rubocop-performance", "~> 1.9", require: false
+gem "rubocop-rspec", ["~> 2.20", "< 2.21"], require: false
 gem "simplecov", git: "https://github.com/DataDog/simplecov", ref: "3bb6b7ee58bf4b1954ca205f50dd44d6f41c57db"
 gem "simplecov-cobertura", "~> 2.1.0"
 gem "warning", "~> 1"
 gem "webmock", ">= 3.10.0"
 gem "webrick", ">= 1.7.0"
-gem "rubocop", "~> 1.50.0", require: false
-gem "rubocop-packaging", "~> 0.5.2", require: false
-gem "rubocop-performance", "~> 1.9", require: false
-gem "rubocop-rspec", ["~> 2.20", "< 2.21"], require: false
-gem "dogstatsd-ruby", ">= 3.3.0", "!= 5.0.0", "!= 5.0.1", "!= 5.1.0"
-gem "google-protobuf", ["~> 3.0", "!= 3.7.0", "!= 3.7.1"]
 gem "rack"
 gem "rack-contrib"
 gem "rack-test"

--- a/gemfiles/ruby_3.2_rails61_mysql2.gemfile
+++ b/gemfiles/ruby_3.2_rails61_mysql2.gemfile
@@ -6,7 +6,9 @@ gem "benchmark-ips", "~> 2.8"
 gem "benchmark-memory", "< 0.2"
 gem "climate_control", "~> 0.2.0"
 gem "concurrent-ruby"
+gem "dogstatsd-ruby", ">= 3.3.0", "!= 5.0.0", "!= 5.0.1", "!= 5.1.0"
 gem "extlz4", "~> 0.3", ">= 0.3.3"
+gem "google-protobuf", ["~> 3.0", "!= 3.7.0", "!= 3.7.1"]
 gem "json-schema", "< 3"
 gem "memory_profiler", "~> 0.9"
 gem "os", "~> 1.1"
@@ -19,17 +21,15 @@ gem "rspec", "~> 3.13"
 gem "rspec-collection_matchers", "~> 1.1"
 gem "rspec-wait", "~> 0"
 gem "rspec_junit_formatter", ">= 0.5.1"
+gem "rubocop", "~> 1.50.0", require: false
+gem "rubocop-packaging", "~> 0.5.2", require: false
+gem "rubocop-performance", "~> 1.9", require: false
+gem "rubocop-rspec", ["~> 2.20", "< 2.21"], require: false
 gem "simplecov", git: "https://github.com/DataDog/simplecov", ref: "3bb6b7ee58bf4b1954ca205f50dd44d6f41c57db"
 gem "simplecov-cobertura", "~> 2.1.0"
 gem "warning", "~> 1"
 gem "webmock", ">= 3.10.0"
 gem "webrick", ">= 1.7.0"
-gem "rubocop", "~> 1.50.0", require: false
-gem "rubocop-packaging", "~> 0.5.2", require: false
-gem "rubocop-performance", "~> 1.9", require: false
-gem "rubocop-rspec", ["~> 2.20", "< 2.21"], require: false
-gem "dogstatsd-ruby", ">= 3.3.0", "!= 5.0.0", "!= 5.0.1", "!= 5.1.0"
-gem "google-protobuf", ["~> 3.0", "!= 3.7.0", "!= 3.7.1"]
 gem "rails", "~> 6.1.0"
 gem "mysql2", "~> 0.5", platform: :ruby
 gem "sprockets", "< 4"

--- a/gemfiles/ruby_3.2_rails61_postgres.gemfile
+++ b/gemfiles/ruby_3.2_rails61_postgres.gemfile
@@ -6,7 +6,9 @@ gem "benchmark-ips", "~> 2.8"
 gem "benchmark-memory", "< 0.2"
 gem "climate_control", "~> 0.2.0"
 gem "concurrent-ruby"
+gem "dogstatsd-ruby", ">= 3.3.0", "!= 5.0.0", "!= 5.0.1", "!= 5.1.0"
 gem "extlz4", "~> 0.3", ">= 0.3.3"
+gem "google-protobuf", ["~> 3.0", "!= 3.7.0", "!= 3.7.1"]
 gem "json-schema", "< 3"
 gem "memory_profiler", "~> 0.9"
 gem "os", "~> 1.1"
@@ -19,17 +21,15 @@ gem "rspec", "~> 3.13"
 gem "rspec-collection_matchers", "~> 1.1"
 gem "rspec-wait", "~> 0"
 gem "rspec_junit_formatter", ">= 0.5.1"
+gem "rubocop", "~> 1.50.0", require: false
+gem "rubocop-packaging", "~> 0.5.2", require: false
+gem "rubocop-performance", "~> 1.9", require: false
+gem "rubocop-rspec", ["~> 2.20", "< 2.21"], require: false
 gem "simplecov", git: "https://github.com/DataDog/simplecov", ref: "3bb6b7ee58bf4b1954ca205f50dd44d6f41c57db"
 gem "simplecov-cobertura", "~> 2.1.0"
 gem "warning", "~> 1"
 gem "webmock", ">= 3.10.0"
 gem "webrick", ">= 1.7.0"
-gem "rubocop", "~> 1.50.0", require: false
-gem "rubocop-packaging", "~> 0.5.2", require: false
-gem "rubocop-performance", "~> 1.9", require: false
-gem "rubocop-rspec", ["~> 2.20", "< 2.21"], require: false
-gem "dogstatsd-ruby", ">= 3.3.0", "!= 5.0.0", "!= 5.0.1", "!= 5.1.0"
-gem "google-protobuf", ["~> 3.0", "!= 3.7.0", "!= 3.7.1"]
 gem "rails", "~> 6.1.0"
 gem "pg", ">= 1.1", platform: :ruby
 gem "sprockets", "< 4"

--- a/gemfiles/ruby_3.2_rails61_postgres_redis.gemfile
+++ b/gemfiles/ruby_3.2_rails61_postgres_redis.gemfile
@@ -6,7 +6,9 @@ gem "benchmark-ips", "~> 2.8"
 gem "benchmark-memory", "< 0.2"
 gem "climate_control", "~> 0.2.0"
 gem "concurrent-ruby"
+gem "dogstatsd-ruby", ">= 3.3.0", "!= 5.0.0", "!= 5.0.1", "!= 5.1.0"
 gem "extlz4", "~> 0.3", ">= 0.3.3"
+gem "google-protobuf", ["~> 3.0", "!= 3.7.0", "!= 3.7.1"]
 gem "json-schema", "< 3"
 gem "memory_profiler", "~> 0.9"
 gem "os", "~> 1.1"
@@ -19,17 +21,15 @@ gem "rspec", "~> 3.13"
 gem "rspec-collection_matchers", "~> 1.1"
 gem "rspec-wait", "~> 0"
 gem "rspec_junit_formatter", ">= 0.5.1"
+gem "rubocop", "~> 1.50.0", require: false
+gem "rubocop-packaging", "~> 0.5.2", require: false
+gem "rubocop-performance", "~> 1.9", require: false
+gem "rubocop-rspec", ["~> 2.20", "< 2.21"], require: false
 gem "simplecov", git: "https://github.com/DataDog/simplecov", ref: "3bb6b7ee58bf4b1954ca205f50dd44d6f41c57db"
 gem "simplecov-cobertura", "~> 2.1.0"
 gem "warning", "~> 1"
 gem "webmock", ">= 3.10.0"
 gem "webrick", ">= 1.7.0"
-gem "rubocop", "~> 1.50.0", require: false
-gem "rubocop-packaging", "~> 0.5.2", require: false
-gem "rubocop-performance", "~> 1.9", require: false
-gem "rubocop-rspec", ["~> 2.20", "< 2.21"], require: false
-gem "dogstatsd-ruby", ">= 3.3.0", "!= 5.0.0", "!= 5.0.1", "!= 5.1.0"
-gem "google-protobuf", ["~> 3.0", "!= 3.7.0", "!= 3.7.1"]
 gem "rails", "~> 6.1.0"
 gem "pg", ">= 1.1", platform: :ruby
 gem "redis", "~> 4"

--- a/gemfiles/ruby_3.2_rails61_postgres_sidekiq.gemfile
+++ b/gemfiles/ruby_3.2_rails61_postgres_sidekiq.gemfile
@@ -6,7 +6,9 @@ gem "benchmark-ips", "~> 2.8"
 gem "benchmark-memory", "< 0.2"
 gem "climate_control", "~> 0.2.0"
 gem "concurrent-ruby"
+gem "dogstatsd-ruby", ">= 3.3.0", "!= 5.0.0", "!= 5.0.1", "!= 5.1.0"
 gem "extlz4", "~> 0.3", ">= 0.3.3"
+gem "google-protobuf", ["~> 3.0", "!= 3.7.0", "!= 3.7.1"]
 gem "json-schema", "< 3"
 gem "memory_profiler", "~> 0.9"
 gem "os", "~> 1.1"
@@ -19,17 +21,15 @@ gem "rspec", "~> 3.13"
 gem "rspec-collection_matchers", "~> 1.1"
 gem "rspec-wait", "~> 0"
 gem "rspec_junit_formatter", ">= 0.5.1"
+gem "rubocop", "~> 1.50.0", require: false
+gem "rubocop-packaging", "~> 0.5.2", require: false
+gem "rubocop-performance", "~> 1.9", require: false
+gem "rubocop-rspec", ["~> 2.20", "< 2.21"], require: false
 gem "simplecov", git: "https://github.com/DataDog/simplecov", ref: "3bb6b7ee58bf4b1954ca205f50dd44d6f41c57db"
 gem "simplecov-cobertura", "~> 2.1.0"
 gem "warning", "~> 1"
 gem "webmock", ">= 3.10.0"
 gem "webrick", ">= 1.7.0"
-gem "rubocop", "~> 1.50.0", require: false
-gem "rubocop-packaging", "~> 0.5.2", require: false
-gem "rubocop-performance", "~> 1.9", require: false
-gem "rubocop-rspec", ["~> 2.20", "< 2.21"], require: false
-gem "dogstatsd-ruby", ">= 3.3.0", "!= 5.0.0", "!= 5.0.1", "!= 5.1.0"
-gem "google-protobuf", ["~> 3.0", "!= 3.7.0", "!= 3.7.1"]
 gem "rails", "~> 6.1.0"
 gem "pg", ">= 1.1", platform: :ruby
 gem "sidekiq", ">= 6.1.2"

--- a/gemfiles/ruby_3.2_rails61_semantic_logger.gemfile
+++ b/gemfiles/ruby_3.2_rails61_semantic_logger.gemfile
@@ -6,7 +6,9 @@ gem "benchmark-ips", "~> 2.8"
 gem "benchmark-memory", "< 0.2"
 gem "climate_control", "~> 0.2.0"
 gem "concurrent-ruby"
+gem "dogstatsd-ruby", ">= 3.3.0", "!= 5.0.0", "!= 5.0.1", "!= 5.1.0"
 gem "extlz4", "~> 0.3", ">= 0.3.3"
+gem "google-protobuf", ["~> 3.0", "!= 3.7.0", "!= 3.7.1"]
 gem "json-schema", "< 3"
 gem "memory_profiler", "~> 0.9"
 gem "os", "~> 1.1"
@@ -19,17 +21,15 @@ gem "rspec", "~> 3.13"
 gem "rspec-collection_matchers", "~> 1.1"
 gem "rspec-wait", "~> 0"
 gem "rspec_junit_formatter", ">= 0.5.1"
+gem "rubocop", "~> 1.50.0", require: false
+gem "rubocop-packaging", "~> 0.5.2", require: false
+gem "rubocop-performance", "~> 1.9", require: false
+gem "rubocop-rspec", ["~> 2.20", "< 2.21"], require: false
 gem "simplecov", git: "https://github.com/DataDog/simplecov", ref: "3bb6b7ee58bf4b1954ca205f50dd44d6f41c57db"
 gem "simplecov-cobertura", "~> 2.1.0"
 gem "warning", "~> 1"
 gem "webmock", ">= 3.10.0"
 gem "webrick", ">= 1.7.0"
-gem "rubocop", "~> 1.50.0", require: false
-gem "rubocop-packaging", "~> 0.5.2", require: false
-gem "rubocop-performance", "~> 1.9", require: false
-gem "rubocop-rspec", ["~> 2.20", "< 2.21"], require: false
-gem "dogstatsd-ruby", ">= 3.3.0", "!= 5.0.0", "!= 5.0.1", "!= 5.1.0"
-gem "google-protobuf", ["~> 3.0", "!= 3.7.0", "!= 3.7.1"]
 gem "rails", "~> 6.1.0"
 gem "pg", ">= 1.1", platform: :ruby
 gem "sprockets", "< 4"

--- a/gemfiles/ruby_3.2_rails61_trilogy.gemfile
+++ b/gemfiles/ruby_3.2_rails61_trilogy.gemfile
@@ -6,7 +6,9 @@ gem "benchmark-ips", "~> 2.8"
 gem "benchmark-memory", "< 0.2"
 gem "climate_control", "~> 0.2.0"
 gem "concurrent-ruby"
+gem "dogstatsd-ruby", ">= 3.3.0", "!= 5.0.0", "!= 5.0.1", "!= 5.1.0"
 gem "extlz4", "~> 0.3", ">= 0.3.3"
+gem "google-protobuf", ["~> 3.0", "!= 3.7.0", "!= 3.7.1"]
 gem "json-schema", "< 3"
 gem "memory_profiler", "~> 0.9"
 gem "os", "~> 1.1"
@@ -19,17 +21,15 @@ gem "rspec", "~> 3.13"
 gem "rspec-collection_matchers", "~> 1.1"
 gem "rspec-wait", "~> 0"
 gem "rspec_junit_formatter", ">= 0.5.1"
+gem "rubocop", "~> 1.50.0", require: false
+gem "rubocop-packaging", "~> 0.5.2", require: false
+gem "rubocop-performance", "~> 1.9", require: false
+gem "rubocop-rspec", ["~> 2.20", "< 2.21"], require: false
 gem "simplecov", git: "https://github.com/DataDog/simplecov", ref: "3bb6b7ee58bf4b1954ca205f50dd44d6f41c57db"
 gem "simplecov-cobertura", "~> 2.1.0"
 gem "warning", "~> 1"
 gem "webmock", ">= 3.10.0"
 gem "webrick", ">= 1.7.0"
-gem "rubocop", "~> 1.50.0", require: false
-gem "rubocop-packaging", "~> 0.5.2", require: false
-gem "rubocop-performance", "~> 1.9", require: false
-gem "rubocop-rspec", ["~> 2.20", "< 2.21"], require: false
-gem "dogstatsd-ruby", ">= 3.3.0", "!= 5.0.0", "!= 5.0.1", "!= 5.1.0"
-gem "google-protobuf", ["~> 3.0", "!= 3.7.0", "!= 3.7.1"]
 gem "rails", "~> 6.1.0"
 gem "trilogy"
 gem "activerecord-trilogy-adapter"

--- a/gemfiles/ruby_3.2_rails7.gemfile
+++ b/gemfiles/ruby_3.2_rails7.gemfile
@@ -6,7 +6,9 @@ gem "benchmark-ips", "~> 2.8"
 gem "benchmark-memory", "< 0.2"
 gem "climate_control", "~> 0.2.0"
 gem "concurrent-ruby"
+gem "dogstatsd-ruby", ">= 3.3.0", "!= 5.0.0", "!= 5.0.1", "!= 5.1.0"
 gem "extlz4", "~> 0.3", ">= 0.3.3"
+gem "google-protobuf", ["~> 3.0", "!= 3.7.0", "!= 3.7.1"]
 gem "json-schema", "< 3"
 gem "memory_profiler", "~> 0.9"
 gem "os", "~> 1.1"
@@ -19,17 +21,15 @@ gem "rspec", "~> 3.13"
 gem "rspec-collection_matchers", "~> 1.1"
 gem "rspec-wait", "~> 0"
 gem "rspec_junit_formatter", ">= 0.5.1"
+gem "rubocop", "~> 1.50.0", require: false
+gem "rubocop-packaging", "~> 0.5.2", require: false
+gem "rubocop-performance", "~> 1.9", require: false
+gem "rubocop-rspec", ["~> 2.20", "< 2.21"], require: false
 gem "simplecov", git: "https://github.com/DataDog/simplecov", ref: "3bb6b7ee58bf4b1954ca205f50dd44d6f41c57db"
 gem "simplecov-cobertura", "~> 2.1.0"
 gem "warning", "~> 1"
 gem "webmock", ">= 3.10.0"
 gem "webrick", ">= 1.7.0"
-gem "rubocop", "~> 1.50.0", require: false
-gem "rubocop-packaging", "~> 0.5.2", require: false
-gem "rubocop-performance", "~> 1.9", require: false
-gem "rubocop-rspec", ["~> 2.20", "< 2.21"], require: false
-gem "dogstatsd-ruby", ">= 3.3.0", "!= 5.0.0", "!= 5.0.1", "!= 5.1.0"
-gem "google-protobuf", ["~> 3.0", "!= 3.7.0", "!= 3.7.1"]
 gem "rails", "~> 7.0.0"
 
 group :check do

--- a/gemfiles/ruby_3.2_rails71.gemfile
+++ b/gemfiles/ruby_3.2_rails71.gemfile
@@ -6,7 +6,9 @@ gem "benchmark-ips", "~> 2.8"
 gem "benchmark-memory", "< 0.2"
 gem "climate_control", "~> 0.2.0"
 gem "concurrent-ruby"
+gem "dogstatsd-ruby", ">= 3.3.0", "!= 5.0.0", "!= 5.0.1", "!= 5.1.0"
 gem "extlz4", "~> 0.3", ">= 0.3.3"
+gem "google-protobuf", ["~> 3.0", "!= 3.7.0", "!= 3.7.1"]
 gem "json-schema", "< 3"
 gem "memory_profiler", "~> 0.9"
 gem "os", "~> 1.1"
@@ -19,17 +21,15 @@ gem "rspec", "~> 3.13"
 gem "rspec-collection_matchers", "~> 1.1"
 gem "rspec-wait", "~> 0"
 gem "rspec_junit_formatter", ">= 0.5.1"
+gem "rubocop", "~> 1.50.0", require: false
+gem "rubocop-packaging", "~> 0.5.2", require: false
+gem "rubocop-performance", "~> 1.9", require: false
+gem "rubocop-rspec", ["~> 2.20", "< 2.21"], require: false
 gem "simplecov", git: "https://github.com/DataDog/simplecov", ref: "3bb6b7ee58bf4b1954ca205f50dd44d6f41c57db"
 gem "simplecov-cobertura", "~> 2.1.0"
 gem "warning", "~> 1"
 gem "webmock", ">= 3.10.0"
 gem "webrick", ">= 1.7.0"
-gem "rubocop", "~> 1.50.0", require: false
-gem "rubocop-packaging", "~> 0.5.2", require: false
-gem "rubocop-performance", "~> 1.9", require: false
-gem "rubocop-rspec", ["~> 2.20", "< 2.21"], require: false
-gem "dogstatsd-ruby", ">= 3.3.0", "!= 5.0.0", "!= 5.0.1", "!= 5.1.0"
-gem "google-protobuf", ["~> 3.0", "!= 3.7.0", "!= 3.7.1"]
 gem "rails", "~> 7.1.0"
 
 group :check do

--- a/gemfiles/ruby_3.2_rails_old_redis.gemfile
+++ b/gemfiles/ruby_3.2_rails_old_redis.gemfile
@@ -6,7 +6,9 @@ gem "benchmark-ips", "~> 2.8"
 gem "benchmark-memory", "< 0.2"
 gem "climate_control", "~> 0.2.0"
 gem "concurrent-ruby"
+gem "dogstatsd-ruby", ">= 3.3.0", "!= 5.0.0", "!= 5.0.1", "!= 5.1.0"
 gem "extlz4", "~> 0.3", ">= 0.3.3"
+gem "google-protobuf", ["~> 3.0", "!= 3.7.0", "!= 3.7.1"]
 gem "json-schema", "< 3"
 gem "memory_profiler", "~> 0.9"
 gem "os", "~> 1.1"
@@ -19,17 +21,15 @@ gem "rspec", "~> 3.13"
 gem "rspec-collection_matchers", "~> 1.1"
 gem "rspec-wait", "~> 0"
 gem "rspec_junit_formatter", ">= 0.5.1"
+gem "rubocop", "~> 1.50.0", require: false
+gem "rubocop-packaging", "~> 0.5.2", require: false
+gem "rubocop-performance", "~> 1.9", require: false
+gem "rubocop-rspec", ["~> 2.20", "< 2.21"], require: false
 gem "simplecov", git: "https://github.com/DataDog/simplecov", ref: "3bb6b7ee58bf4b1954ca205f50dd44d6f41c57db"
 gem "simplecov-cobertura", "~> 2.1.0"
 gem "warning", "~> 1"
 gem "webmock", ">= 3.10.0"
 gem "webrick", ">= 1.7.0"
-gem "rubocop", "~> 1.50.0", require: false
-gem "rubocop-packaging", "~> 0.5.2", require: false
-gem "rubocop-performance", "~> 1.9", require: false
-gem "rubocop-rspec", ["~> 2.20", "< 2.21"], require: false
-gem "dogstatsd-ruby", ">= 3.3.0", "!= 5.0.0", "!= 5.0.1", "!= 5.1.0"
-gem "google-protobuf", ["~> 3.0", "!= 3.7.0", "!= 3.7.1"]
 gem "redis", "< 4"
 gem "rails", "~> 6.1.0"
 gem "pg", ">= 1.1", platform: :ruby

--- a/gemfiles/ruby_3.2_redis_3.gemfile
+++ b/gemfiles/ruby_3.2_redis_3.gemfile
@@ -6,7 +6,9 @@ gem "benchmark-ips", "~> 2.8"
 gem "benchmark-memory", "< 0.2"
 gem "climate_control", "~> 0.2.0"
 gem "concurrent-ruby"
+gem "dogstatsd-ruby", ">= 3.3.0", "!= 5.0.0", "!= 5.0.1", "!= 5.1.0"
 gem "extlz4", "~> 0.3", ">= 0.3.3"
+gem "google-protobuf", ["~> 3.0", "!= 3.7.0", "!= 3.7.1"]
 gem "json-schema", "< 3"
 gem "memory_profiler", "~> 0.9"
 gem "os", "~> 1.1"
@@ -19,17 +21,15 @@ gem "rspec", "~> 3.13"
 gem "rspec-collection_matchers", "~> 1.1"
 gem "rspec-wait", "~> 0"
 gem "rspec_junit_formatter", ">= 0.5.1"
+gem "rubocop", "~> 1.50.0", require: false
+gem "rubocop-packaging", "~> 0.5.2", require: false
+gem "rubocop-performance", "~> 1.9", require: false
+gem "rubocop-rspec", ["~> 2.20", "< 2.21"], require: false
 gem "simplecov", git: "https://github.com/DataDog/simplecov", ref: "3bb6b7ee58bf4b1954ca205f50dd44d6f41c57db"
 gem "simplecov-cobertura", "~> 2.1.0"
 gem "warning", "~> 1"
 gem "webmock", ">= 3.10.0"
 gem "webrick", ">= 1.7.0"
-gem "rubocop", "~> 1.50.0", require: false
-gem "rubocop-packaging", "~> 0.5.2", require: false
-gem "rubocop-performance", "~> 1.9", require: false
-gem "rubocop-rspec", ["~> 2.20", "< 2.21"], require: false
-gem "dogstatsd-ruby", ">= 3.3.0", "!= 5.0.0", "!= 5.0.1", "!= 5.1.0"
-gem "google-protobuf", ["~> 3.0", "!= 3.7.0", "!= 3.7.1"]
 gem "redis", "~> 3"
 
 group :check do

--- a/gemfiles/ruby_3.2_redis_4.gemfile
+++ b/gemfiles/ruby_3.2_redis_4.gemfile
@@ -6,7 +6,9 @@ gem "benchmark-ips", "~> 2.8"
 gem "benchmark-memory", "< 0.2"
 gem "climate_control", "~> 0.2.0"
 gem "concurrent-ruby"
+gem "dogstatsd-ruby", ">= 3.3.0", "!= 5.0.0", "!= 5.0.1", "!= 5.1.0"
 gem "extlz4", "~> 0.3", ">= 0.3.3"
+gem "google-protobuf", ["~> 3.0", "!= 3.7.0", "!= 3.7.1"]
 gem "json-schema", "< 3"
 gem "memory_profiler", "~> 0.9"
 gem "os", "~> 1.1"
@@ -19,17 +21,15 @@ gem "rspec", "~> 3.13"
 gem "rspec-collection_matchers", "~> 1.1"
 gem "rspec-wait", "~> 0"
 gem "rspec_junit_formatter", ">= 0.5.1"
+gem "rubocop", "~> 1.50.0", require: false
+gem "rubocop-packaging", "~> 0.5.2", require: false
+gem "rubocop-performance", "~> 1.9", require: false
+gem "rubocop-rspec", ["~> 2.20", "< 2.21"], require: false
 gem "simplecov", git: "https://github.com/DataDog/simplecov", ref: "3bb6b7ee58bf4b1954ca205f50dd44d6f41c57db"
 gem "simplecov-cobertura", "~> 2.1.0"
 gem "warning", "~> 1"
 gem "webmock", ">= 3.10.0"
 gem "webrick", ">= 1.7.0"
-gem "rubocop", "~> 1.50.0", require: false
-gem "rubocop-packaging", "~> 0.5.2", require: false
-gem "rubocop-performance", "~> 1.9", require: false
-gem "rubocop-rspec", ["~> 2.20", "< 2.21"], require: false
-gem "dogstatsd-ruby", ">= 3.3.0", "!= 5.0.0", "!= 5.0.1", "!= 5.1.0"
-gem "google-protobuf", ["~> 3.0", "!= 3.7.0", "!= 3.7.1"]
 gem "redis", "~> 4"
 
 group :check do

--- a/gemfiles/ruby_3.2_redis_5.gemfile
+++ b/gemfiles/ruby_3.2_redis_5.gemfile
@@ -6,7 +6,9 @@ gem "benchmark-ips", "~> 2.8"
 gem "benchmark-memory", "< 0.2"
 gem "climate_control", "~> 0.2.0"
 gem "concurrent-ruby"
+gem "dogstatsd-ruby", ">= 3.3.0", "!= 5.0.0", "!= 5.0.1", "!= 5.1.0"
 gem "extlz4", "~> 0.3", ">= 0.3.3"
+gem "google-protobuf", ["~> 3.0", "!= 3.7.0", "!= 3.7.1"]
 gem "json-schema", "< 3"
 gem "memory_profiler", "~> 0.9"
 gem "os", "~> 1.1"
@@ -19,17 +21,15 @@ gem "rspec", "~> 3.13"
 gem "rspec-collection_matchers", "~> 1.1"
 gem "rspec-wait", "~> 0"
 gem "rspec_junit_formatter", ">= 0.5.1"
+gem "rubocop", "~> 1.50.0", require: false
+gem "rubocop-packaging", "~> 0.5.2", require: false
+gem "rubocop-performance", "~> 1.9", require: false
+gem "rubocop-rspec", ["~> 2.20", "< 2.21"], require: false
 gem "simplecov", git: "https://github.com/DataDog/simplecov", ref: "3bb6b7ee58bf4b1954ca205f50dd44d6f41c57db"
 gem "simplecov-cobertura", "~> 2.1.0"
 gem "warning", "~> 1"
 gem "webmock", ">= 3.10.0"
 gem "webrick", ">= 1.7.0"
-gem "rubocop", "~> 1.50.0", require: false
-gem "rubocop-packaging", "~> 0.5.2", require: false
-gem "rubocop-performance", "~> 1.9", require: false
-gem "rubocop-rspec", ["~> 2.20", "< 2.21"], require: false
-gem "dogstatsd-ruby", ">= 3.3.0", "!= 5.0.0", "!= 5.0.1", "!= 5.1.0"
-gem "google-protobuf", ["~> 3.0", "!= 3.7.0", "!= 3.7.1"]
 gem "redis", "~> 5"
 
 group :check do

--- a/gemfiles/ruby_3.2_relational_db.gemfile
+++ b/gemfiles/ruby_3.2_relational_db.gemfile
@@ -6,7 +6,9 @@ gem "benchmark-ips", "~> 2.8"
 gem "benchmark-memory", "< 0.2"
 gem "climate_control", "~> 0.2.0"
 gem "concurrent-ruby"
+gem "dogstatsd-ruby", ">= 3.3.0", "!= 5.0.0", "!= 5.0.1", "!= 5.1.0"
 gem "extlz4", "~> 0.3", ">= 0.3.3"
+gem "google-protobuf", ["~> 3.0", "!= 3.7.0", "!= 3.7.1"]
 gem "json-schema", "< 3"
 gem "memory_profiler", "~> 0.9"
 gem "os", "~> 1.1"
@@ -19,17 +21,15 @@ gem "rspec", "~> 3.13"
 gem "rspec-collection_matchers", "~> 1.1"
 gem "rspec-wait", "~> 0"
 gem "rspec_junit_formatter", ">= 0.5.1"
+gem "rubocop", "~> 1.50.0", require: false
+gem "rubocop-packaging", "~> 0.5.2", require: false
+gem "rubocop-performance", "~> 1.9", require: false
+gem "rubocop-rspec", ["~> 2.20", "< 2.21"], require: false
 gem "simplecov", git: "https://github.com/DataDog/simplecov", ref: "3bb6b7ee58bf4b1954ca205f50dd44d6f41c57db"
 gem "simplecov-cobertura", "~> 2.1.0"
 gem "warning", "~> 1"
 gem "webmock", ">= 3.10.0"
 gem "webrick", ">= 1.7.0"
-gem "rubocop", "~> 1.50.0", require: false
-gem "rubocop-packaging", "~> 0.5.2", require: false
-gem "rubocop-performance", "~> 1.9", require: false
-gem "rubocop-rspec", ["~> 2.20", "< 2.21"], require: false
-gem "dogstatsd-ruby", ">= 3.3.0", "!= 5.0.0", "!= 5.0.1", "!= 5.1.0"
-gem "google-protobuf", ["~> 3.0", "!= 3.7.0", "!= 3.7.1"]
 gem "activerecord", "~> 7"
 gem "delayed_job"
 gem "delayed_job_active_record"

--- a/gemfiles/ruby_3.2_resque2_redis3.gemfile
+++ b/gemfiles/ruby_3.2_resque2_redis3.gemfile
@@ -6,7 +6,9 @@ gem "benchmark-ips", "~> 2.8"
 gem "benchmark-memory", "< 0.2"
 gem "climate_control", "~> 0.2.0"
 gem "concurrent-ruby"
+gem "dogstatsd-ruby", ">= 3.3.0", "!= 5.0.0", "!= 5.0.1", "!= 5.1.0"
 gem "extlz4", "~> 0.3", ">= 0.3.3"
+gem "google-protobuf", ["~> 3.0", "!= 3.7.0", "!= 3.7.1"]
 gem "json-schema", "< 3"
 gem "memory_profiler", "~> 0.9"
 gem "os", "~> 1.1"
@@ -19,17 +21,15 @@ gem "rspec", "~> 3.13"
 gem "rspec-collection_matchers", "~> 1.1"
 gem "rspec-wait", "~> 0"
 gem "rspec_junit_formatter", ">= 0.5.1"
+gem "rubocop", "~> 1.50.0", require: false
+gem "rubocop-packaging", "~> 0.5.2", require: false
+gem "rubocop-performance", "~> 1.9", require: false
+gem "rubocop-rspec", ["~> 2.20", "< 2.21"], require: false
 gem "simplecov", git: "https://github.com/DataDog/simplecov", ref: "3bb6b7ee58bf4b1954ca205f50dd44d6f41c57db"
 gem "simplecov-cobertura", "~> 2.1.0"
 gem "warning", "~> 1"
 gem "webmock", ">= 3.10.0"
 gem "webrick", ">= 1.7.0"
-gem "rubocop", "~> 1.50.0", require: false
-gem "rubocop-packaging", "~> 0.5.2", require: false
-gem "rubocop-performance", "~> 1.9", require: false
-gem "rubocop-rspec", ["~> 2.20", "< 2.21"], require: false
-gem "dogstatsd-ruby", ">= 3.3.0", "!= 5.0.0", "!= 5.0.1", "!= 5.1.0"
-gem "google-protobuf", ["~> 3.0", "!= 3.7.0", "!= 3.7.1"]
 gem "redis", "< 4.0"
 gem "resque", ">= 2.0"
 

--- a/gemfiles/ruby_3.2_resque2_redis4.gemfile
+++ b/gemfiles/ruby_3.2_resque2_redis4.gemfile
@@ -6,7 +6,9 @@ gem "benchmark-ips", "~> 2.8"
 gem "benchmark-memory", "< 0.2"
 gem "climate_control", "~> 0.2.0"
 gem "concurrent-ruby"
+gem "dogstatsd-ruby", ">= 3.3.0", "!= 5.0.0", "!= 5.0.1", "!= 5.1.0"
 gem "extlz4", "~> 0.3", ">= 0.3.3"
+gem "google-protobuf", ["~> 3.0", "!= 3.7.0", "!= 3.7.1"]
 gem "json-schema", "< 3"
 gem "memory_profiler", "~> 0.9"
 gem "os", "~> 1.1"
@@ -19,17 +21,15 @@ gem "rspec", "~> 3.13"
 gem "rspec-collection_matchers", "~> 1.1"
 gem "rspec-wait", "~> 0"
 gem "rspec_junit_formatter", ">= 0.5.1"
+gem "rubocop", "~> 1.50.0", require: false
+gem "rubocop-packaging", "~> 0.5.2", require: false
+gem "rubocop-performance", "~> 1.9", require: false
+gem "rubocop-rspec", ["~> 2.20", "< 2.21"], require: false
 gem "simplecov", git: "https://github.com/DataDog/simplecov", ref: "3bb6b7ee58bf4b1954ca205f50dd44d6f41c57db"
 gem "simplecov-cobertura", "~> 2.1.0"
 gem "warning", "~> 1"
 gem "webmock", ">= 3.10.0"
 gem "webrick", ">= 1.7.0"
-gem "rubocop", "~> 1.50.0", require: false
-gem "rubocop-packaging", "~> 0.5.2", require: false
-gem "rubocop-performance", "~> 1.9", require: false
-gem "rubocop-rspec", ["~> 2.20", "< 2.21"], require: false
-gem "dogstatsd-ruby", ">= 3.3.0", "!= 5.0.0", "!= 5.0.1", "!= 5.1.0"
-gem "google-protobuf", ["~> 3.0", "!= 3.7.0", "!= 3.7.1"]
 gem "redis", ">= 4.0"
 gem "resque", ">= 2.0"
 

--- a/gemfiles/ruby_3.2_sinatra_2.gemfile
+++ b/gemfiles/ruby_3.2_sinatra_2.gemfile
@@ -6,7 +6,9 @@ gem "benchmark-ips", "~> 2.8"
 gem "benchmark-memory", "< 0.2"
 gem "climate_control", "~> 0.2.0"
 gem "concurrent-ruby"
+gem "dogstatsd-ruby", ">= 3.3.0", "!= 5.0.0", "!= 5.0.1", "!= 5.1.0"
 gem "extlz4", "~> 0.3", ">= 0.3.3"
+gem "google-protobuf", ["~> 3.0", "!= 3.7.0", "!= 3.7.1"]
 gem "json-schema", "< 3"
 gem "memory_profiler", "~> 0.9"
 gem "os", "~> 1.1"
@@ -19,17 +21,15 @@ gem "rspec", "~> 3.13"
 gem "rspec-collection_matchers", "~> 1.1"
 gem "rspec-wait", "~> 0"
 gem "rspec_junit_formatter", ">= 0.5.1"
+gem "rubocop", "~> 1.50.0", require: false
+gem "rubocop-packaging", "~> 0.5.2", require: false
+gem "rubocop-performance", "~> 1.9", require: false
+gem "rubocop-rspec", ["~> 2.20", "< 2.21"], require: false
 gem "simplecov", git: "https://github.com/DataDog/simplecov", ref: "3bb6b7ee58bf4b1954ca205f50dd44d6f41c57db"
 gem "simplecov-cobertura", "~> 2.1.0"
 gem "warning", "~> 1"
 gem "webmock", ">= 3.10.0"
 gem "webrick", ">= 1.7.0"
-gem "rubocop", "~> 1.50.0", require: false
-gem "rubocop-packaging", "~> 0.5.2", require: false
-gem "rubocop-performance", "~> 1.9", require: false
-gem "rubocop-rspec", ["~> 2.20", "< 2.21"], require: false
-gem "dogstatsd-ruby", ">= 3.3.0", "!= 5.0.0", "!= 5.0.1", "!= 5.1.0"
-gem "google-protobuf", ["~> 3.0", "!= 3.7.0", "!= 3.7.1"]
 gem "sinatra", "~> 2"
 gem "rack-contrib"
 gem "rack-test"

--- a/gemfiles/ruby_3.2_sinatra_3.gemfile
+++ b/gemfiles/ruby_3.2_sinatra_3.gemfile
@@ -6,7 +6,9 @@ gem "benchmark-ips", "~> 2.8"
 gem "benchmark-memory", "< 0.2"
 gem "climate_control", "~> 0.2.0"
 gem "concurrent-ruby"
+gem "dogstatsd-ruby", ">= 3.3.0", "!= 5.0.0", "!= 5.0.1", "!= 5.1.0"
 gem "extlz4", "~> 0.3", ">= 0.3.3"
+gem "google-protobuf", ["~> 3.0", "!= 3.7.0", "!= 3.7.1"]
 gem "json-schema", "< 3"
 gem "memory_profiler", "~> 0.9"
 gem "os", "~> 1.1"
@@ -19,17 +21,15 @@ gem "rspec", "~> 3.13"
 gem "rspec-collection_matchers", "~> 1.1"
 gem "rspec-wait", "~> 0"
 gem "rspec_junit_formatter", ">= 0.5.1"
+gem "rubocop", "~> 1.50.0", require: false
+gem "rubocop-packaging", "~> 0.5.2", require: false
+gem "rubocop-performance", "~> 1.9", require: false
+gem "rubocop-rspec", ["~> 2.20", "< 2.21"], require: false
 gem "simplecov", git: "https://github.com/DataDog/simplecov", ref: "3bb6b7ee58bf4b1954ca205f50dd44d6f41c57db"
 gem "simplecov-cobertura", "~> 2.1.0"
 gem "warning", "~> 1"
 gem "webmock", ">= 3.10.0"
 gem "webrick", ">= 1.7.0"
-gem "rubocop", "~> 1.50.0", require: false
-gem "rubocop-packaging", "~> 0.5.2", require: false
-gem "rubocop-performance", "~> 1.9", require: false
-gem "rubocop-rspec", ["~> 2.20", "< 2.21"], require: false
-gem "dogstatsd-ruby", ">= 3.3.0", "!= 5.0.0", "!= 5.0.1", "!= 5.1.0"
-gem "google-protobuf", ["~> 3.0", "!= 3.7.0", "!= 3.7.1"]
 gem "sinatra", "~> 3"
 gem "rack-contrib"
 gem "rack-test"

--- a/gemfiles/ruby_3.2_sinatra_4.gemfile
+++ b/gemfiles/ruby_3.2_sinatra_4.gemfile
@@ -6,7 +6,9 @@ gem "benchmark-ips", "~> 2.8"
 gem "benchmark-memory", "< 0.2"
 gem "climate_control", "~> 0.2.0"
 gem "concurrent-ruby"
+gem "dogstatsd-ruby", ">= 3.3.0", "!= 5.0.0", "!= 5.0.1", "!= 5.1.0"
 gem "extlz4", "~> 0.3", ">= 0.3.3"
+gem "google-protobuf", ["~> 3.0", "!= 3.7.0", "!= 3.7.1"]
 gem "json-schema", "< 3"
 gem "memory_profiler", "~> 0.9"
 gem "os", "~> 1.1"
@@ -19,17 +21,15 @@ gem "rspec", "~> 3.13"
 gem "rspec-collection_matchers", "~> 1.1"
 gem "rspec-wait", "~> 0"
 gem "rspec_junit_formatter", ">= 0.5.1"
+gem "rubocop", "~> 1.50.0", require: false
+gem "rubocop-packaging", "~> 0.5.2", require: false
+gem "rubocop-performance", "~> 1.9", require: false
+gem "rubocop-rspec", ["~> 2.20", "< 2.21"], require: false
 gem "simplecov", git: "https://github.com/DataDog/simplecov", ref: "3bb6b7ee58bf4b1954ca205f50dd44d6f41c57db"
 gem "simplecov-cobertura", "~> 2.1.0"
 gem "warning", "~> 1"
 gem "webmock", ">= 3.10.0"
 gem "webrick", ">= 1.7.0"
-gem "rubocop", "~> 1.50.0", require: false
-gem "rubocop-packaging", "~> 0.5.2", require: false
-gem "rubocop-performance", "~> 1.9", require: false
-gem "rubocop-rspec", ["~> 2.20", "< 2.21"], require: false
-gem "dogstatsd-ruby", ">= 3.3.0", "!= 5.0.0", "!= 5.0.1", "!= 5.1.0"
-gem "google-protobuf", ["~> 3.0", "!= 3.7.0", "!= 3.7.1"]
 gem "sinatra", "~> 4"
 gem "rack-contrib"
 gem "rack-test"

--- a/gemfiles/ruby_3.2_stripe_10.gemfile
+++ b/gemfiles/ruby_3.2_stripe_10.gemfile
@@ -6,7 +6,9 @@ gem "benchmark-ips", "~> 2.8"
 gem "benchmark-memory", "< 0.2"
 gem "climate_control", "~> 0.2.0"
 gem "concurrent-ruby"
+gem "dogstatsd-ruby", ">= 3.3.0", "!= 5.0.0", "!= 5.0.1", "!= 5.1.0"
 gem "extlz4", "~> 0.3", ">= 0.3.3"
+gem "google-protobuf", ["~> 3.0", "!= 3.7.0", "!= 3.7.1"]
 gem "json-schema", "< 3"
 gem "memory_profiler", "~> 0.9"
 gem "os", "~> 1.1"
@@ -19,17 +21,15 @@ gem "rspec", "~> 3.13"
 gem "rspec-collection_matchers", "~> 1.1"
 gem "rspec-wait", "~> 0"
 gem "rspec_junit_formatter", ">= 0.5.1"
+gem "rubocop", "~> 1.50.0", require: false
+gem "rubocop-packaging", "~> 0.5.2", require: false
+gem "rubocop-performance", "~> 1.9", require: false
+gem "rubocop-rspec", ["~> 2.20", "< 2.21"], require: false
 gem "simplecov", git: "https://github.com/DataDog/simplecov", ref: "3bb6b7ee58bf4b1954ca205f50dd44d6f41c57db"
 gem "simplecov-cobertura", "~> 2.1.0"
 gem "warning", "~> 1"
 gem "webmock", ">= 3.10.0"
 gem "webrick", ">= 1.7.0"
-gem "rubocop", "~> 1.50.0", require: false
-gem "rubocop-packaging", "~> 0.5.2", require: false
-gem "rubocop-performance", "~> 1.9", require: false
-gem "rubocop-rspec", ["~> 2.20", "< 2.21"], require: false
-gem "dogstatsd-ruby", ">= 3.3.0", "!= 5.0.0", "!= 5.0.1", "!= 5.1.0"
-gem "google-protobuf", ["~> 3.0", "!= 3.7.0", "!= 3.7.1"]
 gem "stripe", "~> 10"
 
 group :check do

--- a/gemfiles/ruby_3.2_stripe_11.gemfile
+++ b/gemfiles/ruby_3.2_stripe_11.gemfile
@@ -6,7 +6,9 @@ gem "benchmark-ips", "~> 2.8"
 gem "benchmark-memory", "< 0.2"
 gem "climate_control", "~> 0.2.0"
 gem "concurrent-ruby"
+gem "dogstatsd-ruby", ">= 3.3.0", "!= 5.0.0", "!= 5.0.1", "!= 5.1.0"
 gem "extlz4", "~> 0.3", ">= 0.3.3"
+gem "google-protobuf", ["~> 3.0", "!= 3.7.0", "!= 3.7.1"]
 gem "json-schema", "< 3"
 gem "memory_profiler", "~> 0.9"
 gem "os", "~> 1.1"
@@ -19,17 +21,15 @@ gem "rspec", "~> 3.13"
 gem "rspec-collection_matchers", "~> 1.1"
 gem "rspec-wait", "~> 0"
 gem "rspec_junit_formatter", ">= 0.5.1"
+gem "rubocop", "~> 1.50.0", require: false
+gem "rubocop-packaging", "~> 0.5.2", require: false
+gem "rubocop-performance", "~> 1.9", require: false
+gem "rubocop-rspec", ["~> 2.20", "< 2.21"], require: false
 gem "simplecov", git: "https://github.com/DataDog/simplecov", ref: "3bb6b7ee58bf4b1954ca205f50dd44d6f41c57db"
 gem "simplecov-cobertura", "~> 2.1.0"
 gem "warning", "~> 1"
 gem "webmock", ">= 3.10.0"
 gem "webrick", ">= 1.7.0"
-gem "rubocop", "~> 1.50.0", require: false
-gem "rubocop-packaging", "~> 0.5.2", require: false
-gem "rubocop-performance", "~> 1.9", require: false
-gem "rubocop-rspec", ["~> 2.20", "< 2.21"], require: false
-gem "dogstatsd-ruby", ">= 3.3.0", "!= 5.0.0", "!= 5.0.1", "!= 5.1.0"
-gem "google-protobuf", ["~> 3.0", "!= 3.7.0", "!= 3.7.1"]
 gem "stripe", "~> 11"
 
 group :check do

--- a/gemfiles/ruby_3.2_stripe_12.gemfile
+++ b/gemfiles/ruby_3.2_stripe_12.gemfile
@@ -6,7 +6,9 @@ gem "benchmark-ips", "~> 2.8"
 gem "benchmark-memory", "< 0.2"
 gem "climate_control", "~> 0.2.0"
 gem "concurrent-ruby"
+gem "dogstatsd-ruby", ">= 3.3.0", "!= 5.0.0", "!= 5.0.1", "!= 5.1.0"
 gem "extlz4", "~> 0.3", ">= 0.3.3"
+gem "google-protobuf", ["~> 3.0", "!= 3.7.0", "!= 3.7.1"]
 gem "json-schema", "< 3"
 gem "memory_profiler", "~> 0.9"
 gem "os", "~> 1.1"
@@ -19,17 +21,15 @@ gem "rspec", "~> 3.13"
 gem "rspec-collection_matchers", "~> 1.1"
 gem "rspec-wait", "~> 0"
 gem "rspec_junit_formatter", ">= 0.5.1"
+gem "rubocop", "~> 1.50.0", require: false
+gem "rubocop-packaging", "~> 0.5.2", require: false
+gem "rubocop-performance", "~> 1.9", require: false
+gem "rubocop-rspec", ["~> 2.20", "< 2.21"], require: false
 gem "simplecov", git: "https://github.com/DataDog/simplecov", ref: "3bb6b7ee58bf4b1954ca205f50dd44d6f41c57db"
 gem "simplecov-cobertura", "~> 2.1.0"
 gem "warning", "~> 1"
 gem "webmock", ">= 3.10.0"
 gem "webrick", ">= 1.7.0"
-gem "rubocop", "~> 1.50.0", require: false
-gem "rubocop-packaging", "~> 0.5.2", require: false
-gem "rubocop-performance", "~> 1.9", require: false
-gem "rubocop-rspec", ["~> 2.20", "< 2.21"], require: false
-gem "dogstatsd-ruby", ">= 3.3.0", "!= 5.0.0", "!= 5.0.1", "!= 5.1.0"
-gem "google-protobuf", ["~> 3.0", "!= 3.7.0", "!= 3.7.1"]
 gem "stripe", "~> 12"
 
 group :check do

--- a/gemfiles/ruby_3.2_stripe_7.gemfile
+++ b/gemfiles/ruby_3.2_stripe_7.gemfile
@@ -6,7 +6,9 @@ gem "benchmark-ips", "~> 2.8"
 gem "benchmark-memory", "< 0.2"
 gem "climate_control", "~> 0.2.0"
 gem "concurrent-ruby"
+gem "dogstatsd-ruby", ">= 3.3.0", "!= 5.0.0", "!= 5.0.1", "!= 5.1.0"
 gem "extlz4", "~> 0.3", ">= 0.3.3"
+gem "google-protobuf", ["~> 3.0", "!= 3.7.0", "!= 3.7.1"]
 gem "json-schema", "< 3"
 gem "memory_profiler", "~> 0.9"
 gem "os", "~> 1.1"
@@ -19,17 +21,15 @@ gem "rspec", "~> 3.13"
 gem "rspec-collection_matchers", "~> 1.1"
 gem "rspec-wait", "~> 0"
 gem "rspec_junit_formatter", ">= 0.5.1"
+gem "rubocop", "~> 1.50.0", require: false
+gem "rubocop-packaging", "~> 0.5.2", require: false
+gem "rubocop-performance", "~> 1.9", require: false
+gem "rubocop-rspec", ["~> 2.20", "< 2.21"], require: false
 gem "simplecov", git: "https://github.com/DataDog/simplecov", ref: "3bb6b7ee58bf4b1954ca205f50dd44d6f41c57db"
 gem "simplecov-cobertura", "~> 2.1.0"
 gem "warning", "~> 1"
 gem "webmock", ">= 3.10.0"
 gem "webrick", ">= 1.7.0"
-gem "rubocop", "~> 1.50.0", require: false
-gem "rubocop-packaging", "~> 0.5.2", require: false
-gem "rubocop-performance", "~> 1.9", require: false
-gem "rubocop-rspec", ["~> 2.20", "< 2.21"], require: false
-gem "dogstatsd-ruby", ">= 3.3.0", "!= 5.0.0", "!= 5.0.1", "!= 5.1.0"
-gem "google-protobuf", ["~> 3.0", "!= 3.7.0", "!= 3.7.1"]
 gem "stripe", "~> 7"
 
 group :check do

--- a/gemfiles/ruby_3.2_stripe_8.gemfile
+++ b/gemfiles/ruby_3.2_stripe_8.gemfile
@@ -6,7 +6,9 @@ gem "benchmark-ips", "~> 2.8"
 gem "benchmark-memory", "< 0.2"
 gem "climate_control", "~> 0.2.0"
 gem "concurrent-ruby"
+gem "dogstatsd-ruby", ">= 3.3.0", "!= 5.0.0", "!= 5.0.1", "!= 5.1.0"
 gem "extlz4", "~> 0.3", ">= 0.3.3"
+gem "google-protobuf", ["~> 3.0", "!= 3.7.0", "!= 3.7.1"]
 gem "json-schema", "< 3"
 gem "memory_profiler", "~> 0.9"
 gem "os", "~> 1.1"
@@ -19,17 +21,15 @@ gem "rspec", "~> 3.13"
 gem "rspec-collection_matchers", "~> 1.1"
 gem "rspec-wait", "~> 0"
 gem "rspec_junit_formatter", ">= 0.5.1"
+gem "rubocop", "~> 1.50.0", require: false
+gem "rubocop-packaging", "~> 0.5.2", require: false
+gem "rubocop-performance", "~> 1.9", require: false
+gem "rubocop-rspec", ["~> 2.20", "< 2.21"], require: false
 gem "simplecov", git: "https://github.com/DataDog/simplecov", ref: "3bb6b7ee58bf4b1954ca205f50dd44d6f41c57db"
 gem "simplecov-cobertura", "~> 2.1.0"
 gem "warning", "~> 1"
 gem "webmock", ">= 3.10.0"
 gem "webrick", ">= 1.7.0"
-gem "rubocop", "~> 1.50.0", require: false
-gem "rubocop-packaging", "~> 0.5.2", require: false
-gem "rubocop-performance", "~> 1.9", require: false
-gem "rubocop-rspec", ["~> 2.20", "< 2.21"], require: false
-gem "dogstatsd-ruby", ">= 3.3.0", "!= 5.0.0", "!= 5.0.1", "!= 5.1.0"
-gem "google-protobuf", ["~> 3.0", "!= 3.7.0", "!= 3.7.1"]
 gem "stripe", "~> 8"
 
 group :check do

--- a/gemfiles/ruby_3.2_stripe_9.gemfile
+++ b/gemfiles/ruby_3.2_stripe_9.gemfile
@@ -6,7 +6,9 @@ gem "benchmark-ips", "~> 2.8"
 gem "benchmark-memory", "< 0.2"
 gem "climate_control", "~> 0.2.0"
 gem "concurrent-ruby"
+gem "dogstatsd-ruby", ">= 3.3.0", "!= 5.0.0", "!= 5.0.1", "!= 5.1.0"
 gem "extlz4", "~> 0.3", ">= 0.3.3"
+gem "google-protobuf", ["~> 3.0", "!= 3.7.0", "!= 3.7.1"]
 gem "json-schema", "< 3"
 gem "memory_profiler", "~> 0.9"
 gem "os", "~> 1.1"
@@ -19,17 +21,15 @@ gem "rspec", "~> 3.13"
 gem "rspec-collection_matchers", "~> 1.1"
 gem "rspec-wait", "~> 0"
 gem "rspec_junit_formatter", ">= 0.5.1"
+gem "rubocop", "~> 1.50.0", require: false
+gem "rubocop-packaging", "~> 0.5.2", require: false
+gem "rubocop-performance", "~> 1.9", require: false
+gem "rubocop-rspec", ["~> 2.20", "< 2.21"], require: false
 gem "simplecov", git: "https://github.com/DataDog/simplecov", ref: "3bb6b7ee58bf4b1954ca205f50dd44d6f41c57db"
 gem "simplecov-cobertura", "~> 2.1.0"
 gem "warning", "~> 1"
 gem "webmock", ">= 3.10.0"
 gem "webrick", ">= 1.7.0"
-gem "rubocop", "~> 1.50.0", require: false
-gem "rubocop-packaging", "~> 0.5.2", require: false
-gem "rubocop-performance", "~> 1.9", require: false
-gem "rubocop-rspec", ["~> 2.20", "< 2.21"], require: false
-gem "dogstatsd-ruby", ">= 3.3.0", "!= 5.0.0", "!= 5.0.1", "!= 5.1.0"
-gem "google-protobuf", ["~> 3.0", "!= 3.7.0", "!= 3.7.1"]
 gem "stripe", "~> 9"
 
 group :check do

--- a/gemfiles/ruby_3.2_stripe_latest.gemfile
+++ b/gemfiles/ruby_3.2_stripe_latest.gemfile
@@ -6,7 +6,9 @@ gem "benchmark-ips", "~> 2.8"
 gem "benchmark-memory", "< 0.2"
 gem "climate_control", "~> 0.2.0"
 gem "concurrent-ruby"
+gem "dogstatsd-ruby", ">= 3.3.0", "!= 5.0.0", "!= 5.0.1", "!= 5.1.0"
 gem "extlz4", "~> 0.3", ">= 0.3.3"
+gem "google-protobuf", ["~> 3.0", "!= 3.7.0", "!= 3.7.1"]
 gem "json-schema", "< 3"
 gem "memory_profiler", "~> 0.9"
 gem "os", "~> 1.1"
@@ -19,17 +21,15 @@ gem "rspec", "~> 3.13"
 gem "rspec-collection_matchers", "~> 1.1"
 gem "rspec-wait", "~> 0"
 gem "rspec_junit_formatter", ">= 0.5.1"
+gem "rubocop", "~> 1.50.0", require: false
+gem "rubocop-packaging", "~> 0.5.2", require: false
+gem "rubocop-performance", "~> 1.9", require: false
+gem "rubocop-rspec", ["~> 2.20", "< 2.21"], require: false
 gem "simplecov", git: "https://github.com/DataDog/simplecov", ref: "3bb6b7ee58bf4b1954ca205f50dd44d6f41c57db"
 gem "simplecov-cobertura", "~> 2.1.0"
 gem "warning", "~> 1"
 gem "webmock", ">= 3.10.0"
 gem "webrick", ">= 1.7.0"
-gem "rubocop", "~> 1.50.0", require: false
-gem "rubocop-packaging", "~> 0.5.2", require: false
-gem "rubocop-performance", "~> 1.9", require: false
-gem "rubocop-rspec", ["~> 2.20", "< 2.21"], require: false
-gem "dogstatsd-ruby", ">= 3.3.0", "!= 5.0.0", "!= 5.0.1", "!= 5.1.0"
-gem "google-protobuf", ["~> 3.0", "!= 3.7.0", "!= 3.7.1"]
 gem "stripe"
 
 group :check do

--- a/gemfiles/ruby_3.2_stripe_min.gemfile
+++ b/gemfiles/ruby_3.2_stripe_min.gemfile
@@ -6,7 +6,9 @@ gem "benchmark-ips", "~> 2.8"
 gem "benchmark-memory", "< 0.2"
 gem "climate_control", "~> 0.2.0"
 gem "concurrent-ruby"
+gem "dogstatsd-ruby", ">= 3.3.0", "!= 5.0.0", "!= 5.0.1", "!= 5.1.0"
 gem "extlz4", "~> 0.3", ">= 0.3.3"
+gem "google-protobuf", ["~> 3.0", "!= 3.7.0", "!= 3.7.1"]
 gem "json-schema", "< 3"
 gem "memory_profiler", "~> 0.9"
 gem "os", "~> 1.1"
@@ -19,17 +21,15 @@ gem "rspec", "~> 3.13"
 gem "rspec-collection_matchers", "~> 1.1"
 gem "rspec-wait", "~> 0"
 gem "rspec_junit_formatter", ">= 0.5.1"
+gem "rubocop", "~> 1.50.0", require: false
+gem "rubocop-packaging", "~> 0.5.2", require: false
+gem "rubocop-performance", "~> 1.9", require: false
+gem "rubocop-rspec", ["~> 2.20", "< 2.21"], require: false
 gem "simplecov", git: "https://github.com/DataDog/simplecov", ref: "3bb6b7ee58bf4b1954ca205f50dd44d6f41c57db"
 gem "simplecov-cobertura", "~> 2.1.0"
 gem "warning", "~> 1"
 gem "webmock", ">= 3.10.0"
 gem "webrick", ">= 1.7.0"
-gem "rubocop", "~> 1.50.0", require: false
-gem "rubocop-packaging", "~> 0.5.2", require: false
-gem "rubocop-performance", "~> 1.9", require: false
-gem "rubocop-rspec", ["~> 2.20", "< 2.21"], require: false
-gem "dogstatsd-ruby", ">= 3.3.0", "!= 5.0.0", "!= 5.0.1", "!= 5.1.0"
-gem "google-protobuf", ["~> 3.0", "!= 3.7.0", "!= 3.7.1"]
 gem "stripe", "= 5.15.0"
 
 group :check do

--- a/gemfiles/ruby_3.3_activesupport.gemfile
+++ b/gemfiles/ruby_3.3_activesupport.gemfile
@@ -6,7 +6,9 @@ gem "benchmark-ips", "~> 2.8"
 gem "benchmark-memory", "< 0.2"
 gem "climate_control", "~> 0.2.0"
 gem "concurrent-ruby"
+gem "dogstatsd-ruby", ">= 3.3.0", "!= 5.0.0", "!= 5.0.1", "!= 5.1.0"
 gem "extlz4", "~> 0.3", ">= 0.3.3"
+gem "google-protobuf", ["~> 3.0", "!= 3.7.0", "!= 3.7.1"]
 gem "json-schema", "< 3"
 gem "memory_profiler", "~> 0.9"
 gem "os", "~> 1.1"
@@ -19,17 +21,15 @@ gem "rspec", "~> 3.13"
 gem "rspec-collection_matchers", "~> 1.1"
 gem "rspec-wait", "~> 0"
 gem "rspec_junit_formatter", ">= 0.5.1"
+gem "rubocop", "~> 1.50.0", require: false
+gem "rubocop-packaging", "~> 0.5.2", require: false
+gem "rubocop-performance", "~> 1.9", require: false
+gem "rubocop-rspec", ["~> 2.20", "< 2.21"], require: false
 gem "simplecov", git: "https://github.com/DataDog/simplecov", ref: "3bb6b7ee58bf4b1954ca205f50dd44d6f41c57db"
 gem "simplecov-cobertura", "~> 2.1.0"
 gem "warning", "~> 1"
 gem "webmock", ">= 3.10.0"
 gem "webrick", ">= 1.7.0"
-gem "rubocop", "~> 1.50.0", require: false
-gem "rubocop-packaging", "~> 0.5.2", require: false
-gem "rubocop-performance", "~> 1.9", require: false
-gem "rubocop-rspec", ["~> 2.20", "< 2.21"], require: false
-gem "dogstatsd-ruby", ">= 3.3.0", "!= 5.0.0", "!= 5.0.1", "!= 5.1.0"
-gem "google-protobuf", ["~> 3.0", "!= 3.7.0", "!= 3.7.1"]
 gem "activesupport", "~> 7"
 gem "actionpack"
 gem "actionview"

--- a/gemfiles/ruby_3.3_aws.gemfile
+++ b/gemfiles/ruby_3.3_aws.gemfile
@@ -6,7 +6,9 @@ gem "benchmark-ips", "~> 2.8"
 gem "benchmark-memory", "< 0.2"
 gem "climate_control", "~> 0.2.0"
 gem "concurrent-ruby"
+gem "dogstatsd-ruby", ">= 3.3.0", "!= 5.0.0", "!= 5.0.1", "!= 5.1.0"
 gem "extlz4", "~> 0.3", ">= 0.3.3"
+gem "google-protobuf", ["~> 3.0", "!= 3.7.0", "!= 3.7.1"]
 gem "json-schema", "< 3"
 gem "memory_profiler", "~> 0.9"
 gem "os", "~> 1.1"
@@ -19,17 +21,15 @@ gem "rspec", "~> 3.13"
 gem "rspec-collection_matchers", "~> 1.1"
 gem "rspec-wait", "~> 0"
 gem "rspec_junit_formatter", ">= 0.5.1"
+gem "rubocop", "~> 1.50.0", require: false
+gem "rubocop-packaging", "~> 0.5.2", require: false
+gem "rubocop-performance", "~> 1.9", require: false
+gem "rubocop-rspec", ["~> 2.20", "< 2.21"], require: false
 gem "simplecov", git: "https://github.com/DataDog/simplecov", ref: "3bb6b7ee58bf4b1954ca205f50dd44d6f41c57db"
 gem "simplecov-cobertura", "~> 2.1.0"
 gem "warning", "~> 1"
 gem "webmock", ">= 3.10.0"
 gem "webrick", ">= 1.7.0"
-gem "rubocop", "~> 1.50.0", require: false
-gem "rubocop-packaging", "~> 0.5.2", require: false
-gem "rubocop-performance", "~> 1.9", require: false
-gem "rubocop-rspec", ["~> 2.20", "< 2.21"], require: false
-gem "dogstatsd-ruby", ">= 3.3.0", "!= 5.0.0", "!= 5.0.1", "!= 5.1.0"
-gem "google-protobuf", ["~> 3.0", "!= 3.7.0", "!= 3.7.1"]
 gem "aws-sdk"
 gem "shoryuken"
 

--- a/gemfiles/ruby_3.3_contrib.gemfile
+++ b/gemfiles/ruby_3.3_contrib.gemfile
@@ -6,7 +6,9 @@ gem "benchmark-ips", "~> 2.8"
 gem "benchmark-memory", "< 0.2"
 gem "climate_control", "~> 0.2.0"
 gem "concurrent-ruby"
+gem "dogstatsd-ruby", ">= 3.3.0", "!= 5.0.0", "!= 5.0.1", "!= 5.1.0"
 gem "extlz4", "~> 0.3", ">= 0.3.3"
+gem "google-protobuf", ["~> 3.0", "!= 3.7.0", "!= 3.7.1"]
 gem "json-schema", "< 3"
 gem "memory_profiler", "~> 0.9"
 gem "os", "~> 1.1"
@@ -19,17 +21,15 @@ gem "rspec", "~> 3.13"
 gem "rspec-collection_matchers", "~> 1.1"
 gem "rspec-wait", "~> 0"
 gem "rspec_junit_formatter", ">= 0.5.1"
+gem "rubocop", "~> 1.50.0", require: false
+gem "rubocop-packaging", "~> 0.5.2", require: false
+gem "rubocop-performance", "~> 1.9", require: false
+gem "rubocop-rspec", ["~> 2.20", "< 2.21"], require: false
 gem "simplecov", git: "https://github.com/DataDog/simplecov", ref: "3bb6b7ee58bf4b1954ca205f50dd44d6f41c57db"
 gem "simplecov-cobertura", "~> 2.1.0"
 gem "warning", "~> 1"
 gem "webmock", ">= 3.10.0"
 gem "webrick", ">= 1.7.0"
-gem "rubocop", "~> 1.50.0", require: false
-gem "rubocop-packaging", "~> 0.5.2", require: false
-gem "rubocop-performance", "~> 1.9", require: false
-gem "rubocop-rspec", ["~> 2.20", "< 2.21"], require: false
-gem "dogstatsd-ruby", ">= 3.3.0", "!= 5.0.0", "!= 5.0.1", "!= 5.1.0"
-gem "google-protobuf", ["~> 3.0", "!= 3.7.0", "!= 3.7.1"]
 gem "dalli", ">= 3.0.0"
 gem "grpc", ">= 1.38.0", platform: :ruby
 gem "mongo", ">= 2.8.0", "< 2.15.0"

--- a/gemfiles/ruby_3.3_contrib_old.gemfile
+++ b/gemfiles/ruby_3.3_contrib_old.gemfile
@@ -6,7 +6,9 @@ gem "benchmark-ips", "~> 2.8"
 gem "benchmark-memory", "< 0.2"
 gem "climate_control", "~> 0.2.0"
 gem "concurrent-ruby"
+gem "dogstatsd-ruby", ">= 3.3.0", "!= 5.0.0", "!= 5.0.1", "!= 5.1.0"
 gem "extlz4", "~> 0.3", ">= 0.3.3"
+gem "google-protobuf", ["~> 3.0", "!= 3.7.0", "!= 3.7.1"]
 gem "json-schema", "< 3"
 gem "memory_profiler", "~> 0.9"
 gem "os", "~> 1.1"
@@ -19,17 +21,15 @@ gem "rspec", "~> 3.13"
 gem "rspec-collection_matchers", "~> 1.1"
 gem "rspec-wait", "~> 0"
 gem "rspec_junit_formatter", ">= 0.5.1"
+gem "rubocop", "~> 1.50.0", require: false
+gem "rubocop-packaging", "~> 0.5.2", require: false
+gem "rubocop-performance", "~> 1.9", require: false
+gem "rubocop-rspec", ["~> 2.20", "< 2.21"], require: false
 gem "simplecov", git: "https://github.com/DataDog/simplecov", ref: "3bb6b7ee58bf4b1954ca205f50dd44d6f41c57db"
 gem "simplecov-cobertura", "~> 2.1.0"
 gem "warning", "~> 1"
 gem "webmock", ">= 3.10.0"
 gem "webrick", ">= 1.7.0"
-gem "rubocop", "~> 1.50.0", require: false
-gem "rubocop-packaging", "~> 0.5.2", require: false
-gem "rubocop-performance", "~> 1.9", require: false
-gem "rubocop-rspec", ["~> 2.20", "< 2.21"], require: false
-gem "dogstatsd-ruby", ">= 3.3.0", "!= 5.0.0", "!= 5.0.1", "!= 5.1.0"
-gem "google-protobuf", ["~> 3.0", "!= 3.7.0", "!= 3.7.1"]
 gem "dalli", "< 3.0.0"
 gem "presto-client", ">= 0.5.14"
 gem "qless", "0.12.0"

--- a/gemfiles/ruby_3.3_core_old.gemfile
+++ b/gemfiles/ruby_3.3_core_old.gemfile
@@ -6,7 +6,9 @@ gem "benchmark-ips", "~> 2.8"
 gem "benchmark-memory", "< 0.2"
 gem "climate_control", "~> 0.2.0"
 gem "concurrent-ruby"
+gem "dogstatsd-ruby", "~> 4"
 gem "extlz4", "~> 0.3", ">= 0.3.3"
+gem "google-protobuf", ["~> 3.0", "!= 3.7.0", "!= 3.7.1"]
 gem "json-schema", "< 3"
 gem "memory_profiler", "~> 0.9"
 gem "os", "~> 1.1"
@@ -19,17 +21,15 @@ gem "rspec", "~> 3.13"
 gem "rspec-collection_matchers", "~> 1.1"
 gem "rspec-wait", "~> 0"
 gem "rspec_junit_formatter", ">= 0.5.1"
+gem "rubocop", "~> 1.50.0", require: false
+gem "rubocop-packaging", "~> 0.5.2", require: false
+gem "rubocop-performance", "~> 1.9", require: false
+gem "rubocop-rspec", ["~> 2.20", "< 2.21"], require: false
 gem "simplecov", git: "https://github.com/DataDog/simplecov", ref: "3bb6b7ee58bf4b1954ca205f50dd44d6f41c57db"
 gem "simplecov-cobertura", "~> 2.1.0"
 gem "warning", "~> 1"
 gem "webmock", ">= 3.10.0"
 gem "webrick", ">= 1.7.0"
-gem "rubocop", "~> 1.50.0", require: false
-gem "rubocop-packaging", "~> 0.5.2", require: false
-gem "rubocop-performance", "~> 1.9", require: false
-gem "rubocop-rspec", ["~> 2.20", "< 2.21"], require: false
-gem "dogstatsd-ruby", "~> 4"
-gem "google-protobuf", ["~> 3.0", "!= 3.7.0", "!= 3.7.1"]
 
 group :check do
 

--- a/gemfiles/ruby_3.3_elasticsearch_7.gemfile
+++ b/gemfiles/ruby_3.3_elasticsearch_7.gemfile
@@ -6,7 +6,9 @@ gem "benchmark-ips", "~> 2.8"
 gem "benchmark-memory", "< 0.2"
 gem "climate_control", "~> 0.2.0"
 gem "concurrent-ruby"
+gem "dogstatsd-ruby", ">= 3.3.0", "!= 5.0.0", "!= 5.0.1", "!= 5.1.0"
 gem "extlz4", "~> 0.3", ">= 0.3.3"
+gem "google-protobuf", ["~> 3.0", "!= 3.7.0", "!= 3.7.1"]
 gem "json-schema", "< 3"
 gem "memory_profiler", "~> 0.9"
 gem "os", "~> 1.1"
@@ -19,17 +21,15 @@ gem "rspec", "~> 3.13"
 gem "rspec-collection_matchers", "~> 1.1"
 gem "rspec-wait", "~> 0"
 gem "rspec_junit_formatter", ">= 0.5.1"
+gem "rubocop", "~> 1.50.0", require: false
+gem "rubocop-packaging", "~> 0.5.2", require: false
+gem "rubocop-performance", "~> 1.9", require: false
+gem "rubocop-rspec", ["~> 2.20", "< 2.21"], require: false
 gem "simplecov", git: "https://github.com/DataDog/simplecov", ref: "3bb6b7ee58bf4b1954ca205f50dd44d6f41c57db"
 gem "simplecov-cobertura", "~> 2.1.0"
 gem "warning", "~> 1"
 gem "webmock", ">= 3.10.0"
 gem "webrick", ">= 1.7.0"
-gem "rubocop", "~> 1.50.0", require: false
-gem "rubocop-packaging", "~> 0.5.2", require: false
-gem "rubocop-performance", "~> 1.9", require: false
-gem "rubocop-rspec", ["~> 2.20", "< 2.21"], require: false
-gem "dogstatsd-ruby", ">= 3.3.0", "!= 5.0.0", "!= 5.0.1", "!= 5.1.0"
-gem "google-protobuf", ["~> 3.0", "!= 3.7.0", "!= 3.7.1"]
 gem "elasticsearch", "~> 7"
 
 group :check do

--- a/gemfiles/ruby_3.3_elasticsearch_8.gemfile
+++ b/gemfiles/ruby_3.3_elasticsearch_8.gemfile
@@ -6,7 +6,9 @@ gem "benchmark-ips", "~> 2.8"
 gem "benchmark-memory", "< 0.2"
 gem "climate_control", "~> 0.2.0"
 gem "concurrent-ruby"
+gem "dogstatsd-ruby", ">= 3.3.0", "!= 5.0.0", "!= 5.0.1", "!= 5.1.0"
 gem "extlz4", "~> 0.3", ">= 0.3.3"
+gem "google-protobuf", ["~> 3.0", "!= 3.7.0", "!= 3.7.1"]
 gem "json-schema", "< 3"
 gem "memory_profiler", "~> 0.9"
 gem "os", "~> 1.1"
@@ -19,17 +21,15 @@ gem "rspec", "~> 3.13"
 gem "rspec-collection_matchers", "~> 1.1"
 gem "rspec-wait", "~> 0"
 gem "rspec_junit_formatter", ">= 0.5.1"
+gem "rubocop", "~> 1.50.0", require: false
+gem "rubocop-packaging", "~> 0.5.2", require: false
+gem "rubocop-performance", "~> 1.9", require: false
+gem "rubocop-rspec", ["~> 2.20", "< 2.21"], require: false
 gem "simplecov", git: "https://github.com/DataDog/simplecov", ref: "3bb6b7ee58bf4b1954ca205f50dd44d6f41c57db"
 gem "simplecov-cobertura", "~> 2.1.0"
 gem "warning", "~> 1"
 gem "webmock", ">= 3.10.0"
 gem "webrick", ">= 1.7.0"
-gem "rubocop", "~> 1.50.0", require: false
-gem "rubocop-packaging", "~> 0.5.2", require: false
-gem "rubocop-performance", "~> 1.9", require: false
-gem "rubocop-rspec", ["~> 2.20", "< 2.21"], require: false
-gem "dogstatsd-ruby", ">= 3.3.0", "!= 5.0.0", "!= 5.0.1", "!= 5.1.0"
-gem "google-protobuf", ["~> 3.0", "!= 3.7.0", "!= 3.7.1"]
 gem "elasticsearch", "~> 8"
 
 group :check do

--- a/gemfiles/ruby_3.3_elasticsearch_latest.gemfile
+++ b/gemfiles/ruby_3.3_elasticsearch_latest.gemfile
@@ -6,7 +6,9 @@ gem "benchmark-ips", "~> 2.8"
 gem "benchmark-memory", "< 0.2"
 gem "climate_control", "~> 0.2.0"
 gem "concurrent-ruby"
+gem "dogstatsd-ruby", ">= 3.3.0", "!= 5.0.0", "!= 5.0.1", "!= 5.1.0"
 gem "extlz4", "~> 0.3", ">= 0.3.3"
+gem "google-protobuf", ["~> 3.0", "!= 3.7.0", "!= 3.7.1"]
 gem "json-schema", "< 3"
 gem "memory_profiler", "~> 0.9"
 gem "os", "~> 1.1"
@@ -19,17 +21,15 @@ gem "rspec", "~> 3.13"
 gem "rspec-collection_matchers", "~> 1.1"
 gem "rspec-wait", "~> 0"
 gem "rspec_junit_formatter", ">= 0.5.1"
+gem "rubocop", "~> 1.50.0", require: false
+gem "rubocop-packaging", "~> 0.5.2", require: false
+gem "rubocop-performance", "~> 1.9", require: false
+gem "rubocop-rspec", ["~> 2.20", "< 2.21"], require: false
 gem "simplecov", git: "https://github.com/DataDog/simplecov", ref: "3bb6b7ee58bf4b1954ca205f50dd44d6f41c57db"
 gem "simplecov-cobertura", "~> 2.1.0"
 gem "warning", "~> 1"
 gem "webmock", ">= 3.10.0"
 gem "webrick", ">= 1.7.0"
-gem "rubocop", "~> 1.50.0", require: false
-gem "rubocop-packaging", "~> 0.5.2", require: false
-gem "rubocop-performance", "~> 1.9", require: false
-gem "rubocop-rspec", ["~> 2.20", "< 2.21"], require: false
-gem "dogstatsd-ruby", ">= 3.3.0", "!= 5.0.0", "!= 5.0.1", "!= 5.1.0"
-gem "google-protobuf", ["~> 3.0", "!= 3.7.0", "!= 3.7.1"]
 gem "elasticsearch"
 
 group :check do

--- a/gemfiles/ruby_3.3_graphql_1.13.gemfile
+++ b/gemfiles/ruby_3.3_graphql_1.13.gemfile
@@ -6,7 +6,9 @@ gem "benchmark-ips", "~> 2.8"
 gem "benchmark-memory", "< 0.2"
 gem "climate_control", "~> 0.2.0"
 gem "concurrent-ruby"
+gem "dogstatsd-ruby", ">= 3.3.0", "!= 5.0.0", "!= 5.0.1", "!= 5.1.0"
 gem "extlz4", "~> 0.3", ">= 0.3.3"
+gem "google-protobuf", ["~> 3.0", "!= 3.7.0", "!= 3.7.1"]
 gem "json-schema", "< 3"
 gem "memory_profiler", "~> 0.9"
 gem "os", "~> 1.1"
@@ -19,17 +21,15 @@ gem "rspec", "~> 3.13"
 gem "rspec-collection_matchers", "~> 1.1"
 gem "rspec-wait", "~> 0"
 gem "rspec_junit_formatter", ">= 0.5.1"
+gem "rubocop", "~> 1.50.0", require: false
+gem "rubocop-packaging", "~> 0.5.2", require: false
+gem "rubocop-performance", "~> 1.9", require: false
+gem "rubocop-rspec", ["~> 2.20", "< 2.21"], require: false
 gem "simplecov", git: "https://github.com/DataDog/simplecov", ref: "3bb6b7ee58bf4b1954ca205f50dd44d6f41c57db"
 gem "simplecov-cobertura", "~> 2.1.0"
 gem "warning", "~> 1"
 gem "webmock", ">= 3.10.0"
 gem "webrick", ">= 1.7.0"
-gem "rubocop", "~> 1.50.0", require: false
-gem "rubocop-packaging", "~> 0.5.2", require: false
-gem "rubocop-performance", "~> 1.9", require: false
-gem "rubocop-rspec", ["~> 2.20", "< 2.21"], require: false
-gem "dogstatsd-ruby", ">= 3.3.0", "!= 5.0.0", "!= 5.0.1", "!= 5.1.0"
-gem "google-protobuf", ["~> 3.0", "!= 3.7.0", "!= 3.7.1"]
 gem "rails", "~> 6.1.0"
 gem "graphql", "~> 1.13.0"
 gem "sprockets", "< 4"

--- a/gemfiles/ruby_3.3_graphql_2.0.gemfile
+++ b/gemfiles/ruby_3.3_graphql_2.0.gemfile
@@ -6,7 +6,9 @@ gem "benchmark-ips", "~> 2.8"
 gem "benchmark-memory", "< 0.2"
 gem "climate_control", "~> 0.2.0"
 gem "concurrent-ruby"
+gem "dogstatsd-ruby", ">= 3.3.0", "!= 5.0.0", "!= 5.0.1", "!= 5.1.0"
 gem "extlz4", "~> 0.3", ">= 0.3.3"
+gem "google-protobuf", ["~> 3.0", "!= 3.7.0", "!= 3.7.1"]
 gem "json-schema", "< 3"
 gem "memory_profiler", "~> 0.9"
 gem "os", "~> 1.1"
@@ -19,17 +21,15 @@ gem "rspec", "~> 3.13"
 gem "rspec-collection_matchers", "~> 1.1"
 gem "rspec-wait", "~> 0"
 gem "rspec_junit_formatter", ">= 0.5.1"
+gem "rubocop", "~> 1.50.0", require: false
+gem "rubocop-packaging", "~> 0.5.2", require: false
+gem "rubocop-performance", "~> 1.9", require: false
+gem "rubocop-rspec", ["~> 2.20", "< 2.21"], require: false
 gem "simplecov", git: "https://github.com/DataDog/simplecov", ref: "3bb6b7ee58bf4b1954ca205f50dd44d6f41c57db"
 gem "simplecov-cobertura", "~> 2.1.0"
 gem "warning", "~> 1"
 gem "webmock", ">= 3.10.0"
 gem "webrick", ">= 1.7.0"
-gem "rubocop", "~> 1.50.0", require: false
-gem "rubocop-packaging", "~> 0.5.2", require: false
-gem "rubocop-performance", "~> 1.9", require: false
-gem "rubocop-rspec", ["~> 2.20", "< 2.21"], require: false
-gem "dogstatsd-ruby", ">= 3.3.0", "!= 5.0.0", "!= 5.0.1", "!= 5.1.0"
-gem "google-protobuf", ["~> 3.0", "!= 3.7.0", "!= 3.7.1"]
 gem "rails", "~> 6.1.0"
 gem "graphql", "~> 2.0.0"
 gem "sprockets", "< 4"

--- a/gemfiles/ruby_3.3_graphql_2.1.gemfile
+++ b/gemfiles/ruby_3.3_graphql_2.1.gemfile
@@ -6,7 +6,9 @@ gem "benchmark-ips", "~> 2.8"
 gem "benchmark-memory", "< 0.2"
 gem "climate_control", "~> 0.2.0"
 gem "concurrent-ruby"
+gem "dogstatsd-ruby", ">= 3.3.0", "!= 5.0.0", "!= 5.0.1", "!= 5.1.0"
 gem "extlz4", "~> 0.3", ">= 0.3.3"
+gem "google-protobuf", ["~> 3.0", "!= 3.7.0", "!= 3.7.1"]
 gem "json-schema", "< 3"
 gem "memory_profiler", "~> 0.9"
 gem "os", "~> 1.1"
@@ -19,17 +21,15 @@ gem "rspec", "~> 3.13"
 gem "rspec-collection_matchers", "~> 1.1"
 gem "rspec-wait", "~> 0"
 gem "rspec_junit_formatter", ">= 0.5.1"
+gem "rubocop", "~> 1.50.0", require: false
+gem "rubocop-packaging", "~> 0.5.2", require: false
+gem "rubocop-performance", "~> 1.9", require: false
+gem "rubocop-rspec", ["~> 2.20", "< 2.21"], require: false
 gem "simplecov", git: "https://github.com/DataDog/simplecov", ref: "3bb6b7ee58bf4b1954ca205f50dd44d6f41c57db"
 gem "simplecov-cobertura", "~> 2.1.0"
 gem "warning", "~> 1"
 gem "webmock", ">= 3.10.0"
 gem "webrick", ">= 1.7.0"
-gem "rubocop", "~> 1.50.0", require: false
-gem "rubocop-packaging", "~> 0.5.2", require: false
-gem "rubocop-performance", "~> 1.9", require: false
-gem "rubocop-rspec", ["~> 2.20", "< 2.21"], require: false
-gem "dogstatsd-ruby", ">= 3.3.0", "!= 5.0.0", "!= 5.0.1", "!= 5.1.0"
-gem "google-protobuf", ["~> 3.0", "!= 3.7.0", "!= 3.7.1"]
 gem "rails", "~> 6.1.0"
 gem "graphql", "~> 2.1.0"
 gem "sprockets", "< 4"

--- a/gemfiles/ruby_3.3_graphql_2.2.gemfile
+++ b/gemfiles/ruby_3.3_graphql_2.2.gemfile
@@ -6,7 +6,9 @@ gem "benchmark-ips", "~> 2.8"
 gem "benchmark-memory", "< 0.2"
 gem "climate_control", "~> 0.2.0"
 gem "concurrent-ruby"
+gem "dogstatsd-ruby", ">= 3.3.0", "!= 5.0.0", "!= 5.0.1", "!= 5.1.0"
 gem "extlz4", "~> 0.3", ">= 0.3.3"
+gem "google-protobuf", ["~> 3.0", "!= 3.7.0", "!= 3.7.1"]
 gem "json-schema", "< 3"
 gem "memory_profiler", "~> 0.9"
 gem "os", "~> 1.1"
@@ -19,17 +21,15 @@ gem "rspec", "~> 3.13"
 gem "rspec-collection_matchers", "~> 1.1"
 gem "rspec-wait", "~> 0"
 gem "rspec_junit_formatter", ">= 0.5.1"
+gem "rubocop", "~> 1.50.0", require: false
+gem "rubocop-packaging", "~> 0.5.2", require: false
+gem "rubocop-performance", "~> 1.9", require: false
+gem "rubocop-rspec", ["~> 2.20", "< 2.21"], require: false
 gem "simplecov", git: "https://github.com/DataDog/simplecov", ref: "3bb6b7ee58bf4b1954ca205f50dd44d6f41c57db"
 gem "simplecov-cobertura", "~> 2.1.0"
 gem "warning", "~> 1"
 gem "webmock", ">= 3.10.0"
 gem "webrick", ">= 1.7.0"
-gem "rubocop", "~> 1.50.0", require: false
-gem "rubocop-packaging", "~> 0.5.2", require: false
-gem "rubocop-performance", "~> 1.9", require: false
-gem "rubocop-rspec", ["~> 2.20", "< 2.21"], require: false
-gem "dogstatsd-ruby", ">= 3.3.0", "!= 5.0.0", "!= 5.0.1", "!= 5.1.0"
-gem "google-protobuf", ["~> 3.0", "!= 3.7.0", "!= 3.7.1"]
 gem "rails", "~> 6.1.0"
 gem "graphql", "~> 2.2.0"
 gem "sprockets", "< 4"

--- a/gemfiles/ruby_3.3_graphql_2.3.gemfile
+++ b/gemfiles/ruby_3.3_graphql_2.3.gemfile
@@ -6,7 +6,9 @@ gem "benchmark-ips", "~> 2.8"
 gem "benchmark-memory", "< 0.2"
 gem "climate_control", "~> 0.2.0"
 gem "concurrent-ruby"
+gem "dogstatsd-ruby", ">= 3.3.0", "!= 5.0.0", "!= 5.0.1", "!= 5.1.0"
 gem "extlz4", "~> 0.3", ">= 0.3.3"
+gem "google-protobuf", ["~> 3.0", "!= 3.7.0", "!= 3.7.1"]
 gem "json-schema", "< 3"
 gem "memory_profiler", "~> 0.9"
 gem "os", "~> 1.1"
@@ -19,17 +21,15 @@ gem "rspec", "~> 3.13"
 gem "rspec-collection_matchers", "~> 1.1"
 gem "rspec-wait", "~> 0"
 gem "rspec_junit_formatter", ">= 0.5.1"
+gem "rubocop", "~> 1.50.0", require: false
+gem "rubocop-packaging", "~> 0.5.2", require: false
+gem "rubocop-performance", "~> 1.9", require: false
+gem "rubocop-rspec", ["~> 2.20", "< 2.21"], require: false
 gem "simplecov", git: "https://github.com/DataDog/simplecov", ref: "3bb6b7ee58bf4b1954ca205f50dd44d6f41c57db"
 gem "simplecov-cobertura", "~> 2.1.0"
 gem "warning", "~> 1"
 gem "webmock", ">= 3.10.0"
 gem "webrick", ">= 1.7.0"
-gem "rubocop", "~> 1.50.0", require: false
-gem "rubocop-packaging", "~> 0.5.2", require: false
-gem "rubocop-performance", "~> 1.9", require: false
-gem "rubocop-rspec", ["~> 2.20", "< 2.21"], require: false
-gem "dogstatsd-ruby", ">= 3.3.0", "!= 5.0.0", "!= 5.0.1", "!= 5.1.0"
-gem "google-protobuf", ["~> 3.0", "!= 3.7.0", "!= 3.7.1"]
 gem "rails", "~> 6.1.0"
 gem "graphql", "~> 2.3.0"
 gem "sprockets", "< 4"

--- a/gemfiles/ruby_3.3_http.gemfile
+++ b/gemfiles/ruby_3.3_http.gemfile
@@ -6,7 +6,9 @@ gem "benchmark-ips", "~> 2.8"
 gem "benchmark-memory", "< 0.2"
 gem "climate_control", "~> 0.2.0"
 gem "concurrent-ruby"
+gem "dogstatsd-ruby", ">= 3.3.0", "!= 5.0.0", "!= 5.0.1", "!= 5.1.0"
 gem "extlz4", "~> 0.3", ">= 0.3.3"
+gem "google-protobuf", ["~> 3.0", "!= 3.7.0", "!= 3.7.1"]
 gem "json-schema", "< 3"
 gem "memory_profiler", "~> 0.9"
 gem "os", "~> 1.1"
@@ -19,17 +21,15 @@ gem "rspec", "~> 3.13"
 gem "rspec-collection_matchers", "~> 1.1"
 gem "rspec-wait", "~> 0"
 gem "rspec_junit_formatter", ">= 0.5.1"
+gem "rubocop", "~> 1.50.0", require: false
+gem "rubocop-packaging", "~> 0.5.2", require: false
+gem "rubocop-performance", "~> 1.9", require: false
+gem "rubocop-rspec", ["~> 2.20", "< 2.21"], require: false
 gem "simplecov", git: "https://github.com/DataDog/simplecov", ref: "3bb6b7ee58bf4b1954ca205f50dd44d6f41c57db"
 gem "simplecov-cobertura", "~> 2.1.0"
 gem "warning", "~> 1"
 gem "webmock", ">= 3.10.0"
 gem "webrick", ">= 1.7.0"
-gem "rubocop", "~> 1.50.0", require: false
-gem "rubocop-packaging", "~> 0.5.2", require: false
-gem "rubocop-performance", "~> 1.9", require: false
-gem "rubocop-rspec", ["~> 2.20", "< 2.21"], require: false
-gem "dogstatsd-ruby", ">= 3.3.0", "!= 5.0.0", "!= 5.0.1", "!= 5.1.0"
-gem "google-protobuf", ["~> 3.0", "!= 3.7.0", "!= 3.7.1"]
 gem "ethon"
 gem "excon"
 gem "faraday"

--- a/gemfiles/ruby_3.3_opensearch_2.gemfile
+++ b/gemfiles/ruby_3.3_opensearch_2.gemfile
@@ -6,7 +6,9 @@ gem "benchmark-ips", "~> 2.8"
 gem "benchmark-memory", "< 0.2"
 gem "climate_control", "~> 0.2.0"
 gem "concurrent-ruby"
+gem "dogstatsd-ruby", ">= 3.3.0", "!= 5.0.0", "!= 5.0.1", "!= 5.1.0"
 gem "extlz4", "~> 0.3", ">= 0.3.3"
+gem "google-protobuf", ["~> 3.0", "!= 3.7.0", "!= 3.7.1"]
 gem "json-schema", "< 3"
 gem "memory_profiler", "~> 0.9"
 gem "os", "~> 1.1"
@@ -19,17 +21,15 @@ gem "rspec", "~> 3.13"
 gem "rspec-collection_matchers", "~> 1.1"
 gem "rspec-wait", "~> 0"
 gem "rspec_junit_formatter", ">= 0.5.1"
+gem "rubocop", "~> 1.50.0", require: false
+gem "rubocop-packaging", "~> 0.5.2", require: false
+gem "rubocop-performance", "~> 1.9", require: false
+gem "rubocop-rspec", ["~> 2.20", "< 2.21"], require: false
 gem "simplecov", git: "https://github.com/DataDog/simplecov", ref: "3bb6b7ee58bf4b1954ca205f50dd44d6f41c57db"
 gem "simplecov-cobertura", "~> 2.1.0"
 gem "warning", "~> 1"
 gem "webmock", ">= 3.10.0"
 gem "webrick", ">= 1.7.0"
-gem "rubocop", "~> 1.50.0", require: false
-gem "rubocop-packaging", "~> 0.5.2", require: false
-gem "rubocop-performance", "~> 1.9", require: false
-gem "rubocop-rspec", ["~> 2.20", "< 2.21"], require: false
-gem "dogstatsd-ruby", ">= 3.3.0", "!= 5.0.0", "!= 5.0.1", "!= 5.1.0"
-gem "google-protobuf", ["~> 3.0", "!= 3.7.0", "!= 3.7.1"]
 gem "opensearch-ruby", "~> 2"
 
 group :check do

--- a/gemfiles/ruby_3.3_opensearch_3.gemfile
+++ b/gemfiles/ruby_3.3_opensearch_3.gemfile
@@ -6,7 +6,9 @@ gem "benchmark-ips", "~> 2.8"
 gem "benchmark-memory", "< 0.2"
 gem "climate_control", "~> 0.2.0"
 gem "concurrent-ruby"
+gem "dogstatsd-ruby", ">= 3.3.0", "!= 5.0.0", "!= 5.0.1", "!= 5.1.0"
 gem "extlz4", "~> 0.3", ">= 0.3.3"
+gem "google-protobuf", ["~> 3.0", "!= 3.7.0", "!= 3.7.1"]
 gem "json-schema", "< 3"
 gem "memory_profiler", "~> 0.9"
 gem "os", "~> 1.1"
@@ -19,17 +21,15 @@ gem "rspec", "~> 3.13"
 gem "rspec-collection_matchers", "~> 1.1"
 gem "rspec-wait", "~> 0"
 gem "rspec_junit_formatter", ">= 0.5.1"
+gem "rubocop", "~> 1.50.0", require: false
+gem "rubocop-packaging", "~> 0.5.2", require: false
+gem "rubocop-performance", "~> 1.9", require: false
+gem "rubocop-rspec", ["~> 2.20", "< 2.21"], require: false
 gem "simplecov", git: "https://github.com/DataDog/simplecov", ref: "3bb6b7ee58bf4b1954ca205f50dd44d6f41c57db"
 gem "simplecov-cobertura", "~> 2.1.0"
 gem "warning", "~> 1"
 gem "webmock", ">= 3.10.0"
 gem "webrick", ">= 1.7.0"
-gem "rubocop", "~> 1.50.0", require: false
-gem "rubocop-packaging", "~> 0.5.2", require: false
-gem "rubocop-performance", "~> 1.9", require: false
-gem "rubocop-rspec", ["~> 2.20", "< 2.21"], require: false
-gem "dogstatsd-ruby", ">= 3.3.0", "!= 5.0.0", "!= 5.0.1", "!= 5.1.0"
-gem "google-protobuf", ["~> 3.0", "!= 3.7.0", "!= 3.7.1"]
 gem "opensearch-ruby", "~> 3"
 
 group :check do

--- a/gemfiles/ruby_3.3_opensearch_latest.gemfile
+++ b/gemfiles/ruby_3.3_opensearch_latest.gemfile
@@ -6,7 +6,9 @@ gem "benchmark-ips", "~> 2.8"
 gem "benchmark-memory", "< 0.2"
 gem "climate_control", "~> 0.2.0"
 gem "concurrent-ruby"
+gem "dogstatsd-ruby", ">= 3.3.0", "!= 5.0.0", "!= 5.0.1", "!= 5.1.0"
 gem "extlz4", "~> 0.3", ">= 0.3.3"
+gem "google-protobuf", ["~> 3.0", "!= 3.7.0", "!= 3.7.1"]
 gem "json-schema", "< 3"
 gem "memory_profiler", "~> 0.9"
 gem "os", "~> 1.1"
@@ -19,17 +21,15 @@ gem "rspec", "~> 3.13"
 gem "rspec-collection_matchers", "~> 1.1"
 gem "rspec-wait", "~> 0"
 gem "rspec_junit_formatter", ">= 0.5.1"
+gem "rubocop", "~> 1.50.0", require: false
+gem "rubocop-packaging", "~> 0.5.2", require: false
+gem "rubocop-performance", "~> 1.9", require: false
+gem "rubocop-rspec", ["~> 2.20", "< 2.21"], require: false
 gem "simplecov", git: "https://github.com/DataDog/simplecov", ref: "3bb6b7ee58bf4b1954ca205f50dd44d6f41c57db"
 gem "simplecov-cobertura", "~> 2.1.0"
 gem "warning", "~> 1"
 gem "webmock", ">= 3.10.0"
 gem "webrick", ">= 1.7.0"
-gem "rubocop", "~> 1.50.0", require: false
-gem "rubocop-packaging", "~> 0.5.2", require: false
-gem "rubocop-performance", "~> 1.9", require: false
-gem "rubocop-rspec", ["~> 2.20", "< 2.21"], require: false
-gem "dogstatsd-ruby", ">= 3.3.0", "!= 5.0.0", "!= 5.0.1", "!= 5.1.0"
-gem "google-protobuf", ["~> 3.0", "!= 3.7.0", "!= 3.7.1"]
 gem "opensearch-ruby"
 
 group :check do

--- a/gemfiles/ruby_3.3_opentelemetry.gemfile
+++ b/gemfiles/ruby_3.3_opentelemetry.gemfile
@@ -6,7 +6,9 @@ gem "benchmark-ips", "~> 2.8"
 gem "benchmark-memory", "< 0.2"
 gem "climate_control", "~> 0.2.0"
 gem "concurrent-ruby"
+gem "dogstatsd-ruby", ">= 3.3.0", "!= 5.0.0", "!= 5.0.1", "!= 5.1.0"
 gem "extlz4", "~> 0.3", ">= 0.3.3"
+gem "google-protobuf", ["~> 3.0", "!= 3.7.0", "!= 3.7.1"]
 gem "json-schema", "< 3"
 gem "memory_profiler", "~> 0.9"
 gem "os", "~> 1.1"
@@ -19,17 +21,15 @@ gem "rspec", "~> 3.13"
 gem "rspec-collection_matchers", "~> 1.1"
 gem "rspec-wait", "~> 0"
 gem "rspec_junit_formatter", ">= 0.5.1"
+gem "rubocop", "~> 1.50.0", require: false
+gem "rubocop-packaging", "~> 0.5.2", require: false
+gem "rubocop-performance", "~> 1.9", require: false
+gem "rubocop-rspec", ["~> 2.20", "< 2.21"], require: false
 gem "simplecov", git: "https://github.com/DataDog/simplecov", ref: "3bb6b7ee58bf4b1954ca205f50dd44d6f41c57db"
 gem "simplecov-cobertura", "~> 2.1.0"
 gem "warning", "~> 1"
 gem "webmock", ">= 3.10.0"
 gem "webrick", ">= 1.7.0"
-gem "rubocop", "~> 1.50.0", require: false
-gem "rubocop-packaging", "~> 0.5.2", require: false
-gem "rubocop-performance", "~> 1.9", require: false
-gem "rubocop-rspec", ["~> 2.20", "< 2.21"], require: false
-gem "dogstatsd-ruby", ">= 3.3.0", "!= 5.0.0", "!= 5.0.1", "!= 5.1.0"
-gem "google-protobuf", ["~> 3.0", "!= 3.7.0", "!= 3.7.1"]
 gem "opentelemetry-sdk", "~> 1.1"
 
 group :check do

--- a/gemfiles/ruby_3.3_opentelemetry_otlp.gemfile
+++ b/gemfiles/ruby_3.3_opentelemetry_otlp.gemfile
@@ -6,7 +6,9 @@ gem "benchmark-ips", "~> 2.8"
 gem "benchmark-memory", "< 0.2"
 gem "climate_control", "~> 0.2.0"
 gem "concurrent-ruby"
+gem "dogstatsd-ruby", ">= 3.3.0", "!= 5.0.0", "!= 5.0.1", "!= 5.1.0"
 gem "extlz4", "~> 0.3", ">= 0.3.3"
+gem "google-protobuf", ["~> 3.0", "!= 3.7.0", "!= 3.7.1"]
 gem "json-schema", "< 3"
 gem "memory_profiler", "~> 0.9"
 gem "os", "~> 1.1"
@@ -19,17 +21,15 @@ gem "rspec", "~> 3.13"
 gem "rspec-collection_matchers", "~> 1.1"
 gem "rspec-wait", "~> 0"
 gem "rspec_junit_formatter", ">= 0.5.1"
+gem "rubocop", "~> 1.50.0", require: false
+gem "rubocop-packaging", "~> 0.5.2", require: false
+gem "rubocop-performance", "~> 1.9", require: false
+gem "rubocop-rspec", ["~> 2.20", "< 2.21"], require: false
 gem "simplecov", git: "https://github.com/DataDog/simplecov", ref: "3bb6b7ee58bf4b1954ca205f50dd44d6f41c57db"
 gem "simplecov-cobertura", "~> 2.1.0"
 gem "warning", "~> 1"
 gem "webmock", ">= 3.10.0"
 gem "webrick", ">= 1.7.0"
-gem "rubocop", "~> 1.50.0", require: false
-gem "rubocop-packaging", "~> 0.5.2", require: false
-gem "rubocop-performance", "~> 1.9", require: false
-gem "rubocop-rspec", ["~> 2.20", "< 2.21"], require: false
-gem "dogstatsd-ruby", ">= 3.3.0", "!= 5.0.0", "!= 5.0.1", "!= 5.1.0"
-gem "google-protobuf", ["~> 3.0", "!= 3.7.0", "!= 3.7.1"]
 gem "opentelemetry-sdk", "~> 1.1"
 gem "opentelemetry-exporter-otlp"
 

--- a/gemfiles/ruby_3.3_rack_2.gemfile
+++ b/gemfiles/ruby_3.3_rack_2.gemfile
@@ -6,7 +6,9 @@ gem "benchmark-ips", "~> 2.8"
 gem "benchmark-memory", "< 0.2"
 gem "climate_control", "~> 0.2.0"
 gem "concurrent-ruby"
+gem "dogstatsd-ruby", ">= 3.3.0", "!= 5.0.0", "!= 5.0.1", "!= 5.1.0"
 gem "extlz4", "~> 0.3", ">= 0.3.3"
+gem "google-protobuf", ["~> 3.0", "!= 3.7.0", "!= 3.7.1"]
 gem "json-schema", "< 3"
 gem "memory_profiler", "~> 0.9"
 gem "os", "~> 1.1"
@@ -19,17 +21,15 @@ gem "rspec", "~> 3.13"
 gem "rspec-collection_matchers", "~> 1.1"
 gem "rspec-wait", "~> 0"
 gem "rspec_junit_formatter", ">= 0.5.1"
+gem "rubocop", "~> 1.50.0", require: false
+gem "rubocop-packaging", "~> 0.5.2", require: false
+gem "rubocop-performance", "~> 1.9", require: false
+gem "rubocop-rspec", ["~> 2.20", "< 2.21"], require: false
 gem "simplecov", git: "https://github.com/DataDog/simplecov", ref: "3bb6b7ee58bf4b1954ca205f50dd44d6f41c57db"
 gem "simplecov-cobertura", "~> 2.1.0"
 gem "warning", "~> 1"
 gem "webmock", ">= 3.10.0"
 gem "webrick", ">= 1.7.0"
-gem "rubocop", "~> 1.50.0", require: false
-gem "rubocop-packaging", "~> 0.5.2", require: false
-gem "rubocop-performance", "~> 1.9", require: false
-gem "rubocop-rspec", ["~> 2.20", "< 2.21"], require: false
-gem "dogstatsd-ruby", ">= 3.3.0", "!= 5.0.0", "!= 5.0.1", "!= 5.1.0"
-gem "google-protobuf", ["~> 3.0", "!= 3.7.0", "!= 3.7.1"]
 gem "rack", "~> 2"
 gem "rack-contrib"
 gem "rack-test"

--- a/gemfiles/ruby_3.3_rack_3.gemfile
+++ b/gemfiles/ruby_3.3_rack_3.gemfile
@@ -6,7 +6,9 @@ gem "benchmark-ips", "~> 2.8"
 gem "benchmark-memory", "< 0.2"
 gem "climate_control", "~> 0.2.0"
 gem "concurrent-ruby"
+gem "dogstatsd-ruby", ">= 3.3.0", "!= 5.0.0", "!= 5.0.1", "!= 5.1.0"
 gem "extlz4", "~> 0.3", ">= 0.3.3"
+gem "google-protobuf", ["~> 3.0", "!= 3.7.0", "!= 3.7.1"]
 gem "json-schema", "< 3"
 gem "memory_profiler", "~> 0.9"
 gem "os", "~> 1.1"
@@ -19,17 +21,15 @@ gem "rspec", "~> 3.13"
 gem "rspec-collection_matchers", "~> 1.1"
 gem "rspec-wait", "~> 0"
 gem "rspec_junit_formatter", ">= 0.5.1"
+gem "rubocop", "~> 1.50.0", require: false
+gem "rubocop-packaging", "~> 0.5.2", require: false
+gem "rubocop-performance", "~> 1.9", require: false
+gem "rubocop-rspec", ["~> 2.20", "< 2.21"], require: false
 gem "simplecov", git: "https://github.com/DataDog/simplecov", ref: "3bb6b7ee58bf4b1954ca205f50dd44d6f41c57db"
 gem "simplecov-cobertura", "~> 2.1.0"
 gem "warning", "~> 1"
 gem "webmock", ">= 3.10.0"
 gem "webrick", ">= 1.7.0"
-gem "rubocop", "~> 1.50.0", require: false
-gem "rubocop-packaging", "~> 0.5.2", require: false
-gem "rubocop-performance", "~> 1.9", require: false
-gem "rubocop-rspec", ["~> 2.20", "< 2.21"], require: false
-gem "dogstatsd-ruby", ">= 3.3.0", "!= 5.0.0", "!= 5.0.1", "!= 5.1.0"
-gem "google-protobuf", ["~> 3.0", "!= 3.7.0", "!= 3.7.1"]
 gem "rack", "~> 3"
 gem "rack-contrib"
 gem "rack-test"

--- a/gemfiles/ruby_3.3_rack_latest.gemfile
+++ b/gemfiles/ruby_3.3_rack_latest.gemfile
@@ -6,7 +6,9 @@ gem "benchmark-ips", "~> 2.8"
 gem "benchmark-memory", "< 0.2"
 gem "climate_control", "~> 0.2.0"
 gem "concurrent-ruby"
+gem "dogstatsd-ruby", ">= 3.3.0", "!= 5.0.0", "!= 5.0.1", "!= 5.1.0"
 gem "extlz4", "~> 0.3", ">= 0.3.3"
+gem "google-protobuf", ["~> 3.0", "!= 3.7.0", "!= 3.7.1"]
 gem "json-schema", "< 3"
 gem "memory_profiler", "~> 0.9"
 gem "os", "~> 1.1"
@@ -19,17 +21,15 @@ gem "rspec", "~> 3.13"
 gem "rspec-collection_matchers", "~> 1.1"
 gem "rspec-wait", "~> 0"
 gem "rspec_junit_formatter", ">= 0.5.1"
+gem "rubocop", "~> 1.50.0", require: false
+gem "rubocop-packaging", "~> 0.5.2", require: false
+gem "rubocop-performance", "~> 1.9", require: false
+gem "rubocop-rspec", ["~> 2.20", "< 2.21"], require: false
 gem "simplecov", git: "https://github.com/DataDog/simplecov", ref: "3bb6b7ee58bf4b1954ca205f50dd44d6f41c57db"
 gem "simplecov-cobertura", "~> 2.1.0"
 gem "warning", "~> 1"
 gem "webmock", ">= 3.10.0"
 gem "webrick", ">= 1.7.0"
-gem "rubocop", "~> 1.50.0", require: false
-gem "rubocop-packaging", "~> 0.5.2", require: false
-gem "rubocop-performance", "~> 1.9", require: false
-gem "rubocop-rspec", ["~> 2.20", "< 2.21"], require: false
-gem "dogstatsd-ruby", ">= 3.3.0", "!= 5.0.0", "!= 5.0.1", "!= 5.1.0"
-gem "google-protobuf", ["~> 3.0", "!= 3.7.0", "!= 3.7.1"]
 gem "rack"
 gem "rack-contrib"
 gem "rack-test"

--- a/gemfiles/ruby_3.3_rails61_mysql2.gemfile
+++ b/gemfiles/ruby_3.3_rails61_mysql2.gemfile
@@ -6,7 +6,9 @@ gem "benchmark-ips", "~> 2.8"
 gem "benchmark-memory", "< 0.2"
 gem "climate_control", "~> 0.2.0"
 gem "concurrent-ruby"
+gem "dogstatsd-ruby", ">= 3.3.0", "!= 5.0.0", "!= 5.0.1", "!= 5.1.0"
 gem "extlz4", "~> 0.3", ">= 0.3.3"
+gem "google-protobuf", ["~> 3.0", "!= 3.7.0", "!= 3.7.1"]
 gem "json-schema", "< 3"
 gem "memory_profiler", "~> 0.9"
 gem "os", "~> 1.1"
@@ -19,17 +21,15 @@ gem "rspec", "~> 3.13"
 gem "rspec-collection_matchers", "~> 1.1"
 gem "rspec-wait", "~> 0"
 gem "rspec_junit_formatter", ">= 0.5.1"
+gem "rubocop", "~> 1.50.0", require: false
+gem "rubocop-packaging", "~> 0.5.2", require: false
+gem "rubocop-performance", "~> 1.9", require: false
+gem "rubocop-rspec", ["~> 2.20", "< 2.21"], require: false
 gem "simplecov", git: "https://github.com/DataDog/simplecov", ref: "3bb6b7ee58bf4b1954ca205f50dd44d6f41c57db"
 gem "simplecov-cobertura", "~> 2.1.0"
 gem "warning", "~> 1"
 gem "webmock", ">= 3.10.0"
 gem "webrick", ">= 1.7.0"
-gem "rubocop", "~> 1.50.0", require: false
-gem "rubocop-packaging", "~> 0.5.2", require: false
-gem "rubocop-performance", "~> 1.9", require: false
-gem "rubocop-rspec", ["~> 2.20", "< 2.21"], require: false
-gem "dogstatsd-ruby", ">= 3.3.0", "!= 5.0.0", "!= 5.0.1", "!= 5.1.0"
-gem "google-protobuf", ["~> 3.0", "!= 3.7.0", "!= 3.7.1"]
 gem "rails", "~> 6.1.0"
 gem "mysql2", "~> 0.5", platform: :ruby
 gem "sprockets", "< 4"

--- a/gemfiles/ruby_3.3_rails61_postgres.gemfile
+++ b/gemfiles/ruby_3.3_rails61_postgres.gemfile
@@ -6,7 +6,9 @@ gem "benchmark-ips", "~> 2.8"
 gem "benchmark-memory", "< 0.2"
 gem "climate_control", "~> 0.2.0"
 gem "concurrent-ruby"
+gem "dogstatsd-ruby", ">= 3.3.0", "!= 5.0.0", "!= 5.0.1", "!= 5.1.0"
 gem "extlz4", "~> 0.3", ">= 0.3.3"
+gem "google-protobuf", ["~> 3.0", "!= 3.7.0", "!= 3.7.1"]
 gem "json-schema", "< 3"
 gem "memory_profiler", "~> 0.9"
 gem "os", "~> 1.1"
@@ -19,17 +21,15 @@ gem "rspec", "~> 3.13"
 gem "rspec-collection_matchers", "~> 1.1"
 gem "rspec-wait", "~> 0"
 gem "rspec_junit_formatter", ">= 0.5.1"
+gem "rubocop", "~> 1.50.0", require: false
+gem "rubocop-packaging", "~> 0.5.2", require: false
+gem "rubocop-performance", "~> 1.9", require: false
+gem "rubocop-rspec", ["~> 2.20", "< 2.21"], require: false
 gem "simplecov", git: "https://github.com/DataDog/simplecov", ref: "3bb6b7ee58bf4b1954ca205f50dd44d6f41c57db"
 gem "simplecov-cobertura", "~> 2.1.0"
 gem "warning", "~> 1"
 gem "webmock", ">= 3.10.0"
 gem "webrick", ">= 1.7.0"
-gem "rubocop", "~> 1.50.0", require: false
-gem "rubocop-packaging", "~> 0.5.2", require: false
-gem "rubocop-performance", "~> 1.9", require: false
-gem "rubocop-rspec", ["~> 2.20", "< 2.21"], require: false
-gem "dogstatsd-ruby", ">= 3.3.0", "!= 5.0.0", "!= 5.0.1", "!= 5.1.0"
-gem "google-protobuf", ["~> 3.0", "!= 3.7.0", "!= 3.7.1"]
 gem "rails", "~> 6.1.0"
 gem "pg", ">= 1.1", platform: :ruby
 gem "sprockets", "< 4"

--- a/gemfiles/ruby_3.3_rails61_postgres_redis.gemfile
+++ b/gemfiles/ruby_3.3_rails61_postgres_redis.gemfile
@@ -6,7 +6,9 @@ gem "benchmark-ips", "~> 2.8"
 gem "benchmark-memory", "< 0.2"
 gem "climate_control", "~> 0.2.0"
 gem "concurrent-ruby"
+gem "dogstatsd-ruby", ">= 3.3.0", "!= 5.0.0", "!= 5.0.1", "!= 5.1.0"
 gem "extlz4", "~> 0.3", ">= 0.3.3"
+gem "google-protobuf", ["~> 3.0", "!= 3.7.0", "!= 3.7.1"]
 gem "json-schema", "< 3"
 gem "memory_profiler", "~> 0.9"
 gem "os", "~> 1.1"
@@ -19,17 +21,15 @@ gem "rspec", "~> 3.13"
 gem "rspec-collection_matchers", "~> 1.1"
 gem "rspec-wait", "~> 0"
 gem "rspec_junit_formatter", ">= 0.5.1"
+gem "rubocop", "~> 1.50.0", require: false
+gem "rubocop-packaging", "~> 0.5.2", require: false
+gem "rubocop-performance", "~> 1.9", require: false
+gem "rubocop-rspec", ["~> 2.20", "< 2.21"], require: false
 gem "simplecov", git: "https://github.com/DataDog/simplecov", ref: "3bb6b7ee58bf4b1954ca205f50dd44d6f41c57db"
 gem "simplecov-cobertura", "~> 2.1.0"
 gem "warning", "~> 1"
 gem "webmock", ">= 3.10.0"
 gem "webrick", ">= 1.7.0"
-gem "rubocop", "~> 1.50.0", require: false
-gem "rubocop-packaging", "~> 0.5.2", require: false
-gem "rubocop-performance", "~> 1.9", require: false
-gem "rubocop-rspec", ["~> 2.20", "< 2.21"], require: false
-gem "dogstatsd-ruby", ">= 3.3.0", "!= 5.0.0", "!= 5.0.1", "!= 5.1.0"
-gem "google-protobuf", ["~> 3.0", "!= 3.7.0", "!= 3.7.1"]
 gem "rails", "~> 6.1.0"
 gem "pg", ">= 1.1", platform: :ruby
 gem "redis", "~> 4"

--- a/gemfiles/ruby_3.3_rails61_postgres_sidekiq.gemfile
+++ b/gemfiles/ruby_3.3_rails61_postgres_sidekiq.gemfile
@@ -6,7 +6,9 @@ gem "benchmark-ips", "~> 2.8"
 gem "benchmark-memory", "< 0.2"
 gem "climate_control", "~> 0.2.0"
 gem "concurrent-ruby"
+gem "dogstatsd-ruby", ">= 3.3.0", "!= 5.0.0", "!= 5.0.1", "!= 5.1.0"
 gem "extlz4", "~> 0.3", ">= 0.3.3"
+gem "google-protobuf", ["~> 3.0", "!= 3.7.0", "!= 3.7.1"]
 gem "json-schema", "< 3"
 gem "memory_profiler", "~> 0.9"
 gem "os", "~> 1.1"
@@ -19,17 +21,15 @@ gem "rspec", "~> 3.13"
 gem "rspec-collection_matchers", "~> 1.1"
 gem "rspec-wait", "~> 0"
 gem "rspec_junit_formatter", ">= 0.5.1"
+gem "rubocop", "~> 1.50.0", require: false
+gem "rubocop-packaging", "~> 0.5.2", require: false
+gem "rubocop-performance", "~> 1.9", require: false
+gem "rubocop-rspec", ["~> 2.20", "< 2.21"], require: false
 gem "simplecov", git: "https://github.com/DataDog/simplecov", ref: "3bb6b7ee58bf4b1954ca205f50dd44d6f41c57db"
 gem "simplecov-cobertura", "~> 2.1.0"
 gem "warning", "~> 1"
 gem "webmock", ">= 3.10.0"
 gem "webrick", ">= 1.7.0"
-gem "rubocop", "~> 1.50.0", require: false
-gem "rubocop-packaging", "~> 0.5.2", require: false
-gem "rubocop-performance", "~> 1.9", require: false
-gem "rubocop-rspec", ["~> 2.20", "< 2.21"], require: false
-gem "dogstatsd-ruby", ">= 3.3.0", "!= 5.0.0", "!= 5.0.1", "!= 5.1.0"
-gem "google-protobuf", ["~> 3.0", "!= 3.7.0", "!= 3.7.1"]
 gem "rails", "~> 6.1.0"
 gem "pg", ">= 1.1", platform: :ruby
 gem "sidekiq", ">= 6.1.2"

--- a/gemfiles/ruby_3.3_rails61_semantic_logger.gemfile
+++ b/gemfiles/ruby_3.3_rails61_semantic_logger.gemfile
@@ -6,7 +6,9 @@ gem "benchmark-ips", "~> 2.8"
 gem "benchmark-memory", "< 0.2"
 gem "climate_control", "~> 0.2.0"
 gem "concurrent-ruby"
+gem "dogstatsd-ruby", ">= 3.3.0", "!= 5.0.0", "!= 5.0.1", "!= 5.1.0"
 gem "extlz4", "~> 0.3", ">= 0.3.3"
+gem "google-protobuf", ["~> 3.0", "!= 3.7.0", "!= 3.7.1"]
 gem "json-schema", "< 3"
 gem "memory_profiler", "~> 0.9"
 gem "os", "~> 1.1"
@@ -19,17 +21,15 @@ gem "rspec", "~> 3.13"
 gem "rspec-collection_matchers", "~> 1.1"
 gem "rspec-wait", "~> 0"
 gem "rspec_junit_formatter", ">= 0.5.1"
+gem "rubocop", "~> 1.50.0", require: false
+gem "rubocop-packaging", "~> 0.5.2", require: false
+gem "rubocop-performance", "~> 1.9", require: false
+gem "rubocop-rspec", ["~> 2.20", "< 2.21"], require: false
 gem "simplecov", git: "https://github.com/DataDog/simplecov", ref: "3bb6b7ee58bf4b1954ca205f50dd44d6f41c57db"
 gem "simplecov-cobertura", "~> 2.1.0"
 gem "warning", "~> 1"
 gem "webmock", ">= 3.10.0"
 gem "webrick", ">= 1.7.0"
-gem "rubocop", "~> 1.50.0", require: false
-gem "rubocop-packaging", "~> 0.5.2", require: false
-gem "rubocop-performance", "~> 1.9", require: false
-gem "rubocop-rspec", ["~> 2.20", "< 2.21"], require: false
-gem "dogstatsd-ruby", ">= 3.3.0", "!= 5.0.0", "!= 5.0.1", "!= 5.1.0"
-gem "google-protobuf", ["~> 3.0", "!= 3.7.0", "!= 3.7.1"]
 gem "rails", "~> 6.1.0"
 gem "pg", ">= 1.1", platform: :ruby
 gem "sprockets", "< 4"

--- a/gemfiles/ruby_3.3_rails61_trilogy.gemfile
+++ b/gemfiles/ruby_3.3_rails61_trilogy.gemfile
@@ -6,7 +6,9 @@ gem "benchmark-ips", "~> 2.8"
 gem "benchmark-memory", "< 0.2"
 gem "climate_control", "~> 0.2.0"
 gem "concurrent-ruby"
+gem "dogstatsd-ruby", ">= 3.3.0", "!= 5.0.0", "!= 5.0.1", "!= 5.1.0"
 gem "extlz4", "~> 0.3", ">= 0.3.3"
+gem "google-protobuf", ["~> 3.0", "!= 3.7.0", "!= 3.7.1"]
 gem "json-schema", "< 3"
 gem "memory_profiler", "~> 0.9"
 gem "os", "~> 1.1"
@@ -19,17 +21,15 @@ gem "rspec", "~> 3.13"
 gem "rspec-collection_matchers", "~> 1.1"
 gem "rspec-wait", "~> 0"
 gem "rspec_junit_formatter", ">= 0.5.1"
+gem "rubocop", "~> 1.50.0", require: false
+gem "rubocop-packaging", "~> 0.5.2", require: false
+gem "rubocop-performance", "~> 1.9", require: false
+gem "rubocop-rspec", ["~> 2.20", "< 2.21"], require: false
 gem "simplecov", git: "https://github.com/DataDog/simplecov", ref: "3bb6b7ee58bf4b1954ca205f50dd44d6f41c57db"
 gem "simplecov-cobertura", "~> 2.1.0"
 gem "warning", "~> 1"
 gem "webmock", ">= 3.10.0"
 gem "webrick", ">= 1.7.0"
-gem "rubocop", "~> 1.50.0", require: false
-gem "rubocop-packaging", "~> 0.5.2", require: false
-gem "rubocop-performance", "~> 1.9", require: false
-gem "rubocop-rspec", ["~> 2.20", "< 2.21"], require: false
-gem "dogstatsd-ruby", ">= 3.3.0", "!= 5.0.0", "!= 5.0.1", "!= 5.1.0"
-gem "google-protobuf", ["~> 3.0", "!= 3.7.0", "!= 3.7.1"]
 gem "rails", "~> 6.1.0"
 gem "trilogy"
 gem "activerecord-trilogy-adapter"

--- a/gemfiles/ruby_3.3_rails7.gemfile
+++ b/gemfiles/ruby_3.3_rails7.gemfile
@@ -6,7 +6,9 @@ gem "benchmark-ips", "~> 2.8"
 gem "benchmark-memory", "< 0.2"
 gem "climate_control", "~> 0.2.0"
 gem "concurrent-ruby"
+gem "dogstatsd-ruby", ">= 3.3.0", "!= 5.0.0", "!= 5.0.1", "!= 5.1.0"
 gem "extlz4", "~> 0.3", ">= 0.3.3"
+gem "google-protobuf", ["~> 3.0", "!= 3.7.0", "!= 3.7.1"]
 gem "json-schema", "< 3"
 gem "memory_profiler", "~> 0.9"
 gem "os", "~> 1.1"
@@ -19,17 +21,15 @@ gem "rspec", "~> 3.13"
 gem "rspec-collection_matchers", "~> 1.1"
 gem "rspec-wait", "~> 0"
 gem "rspec_junit_formatter", ">= 0.5.1"
+gem "rubocop", "~> 1.50.0", require: false
+gem "rubocop-packaging", "~> 0.5.2", require: false
+gem "rubocop-performance", "~> 1.9", require: false
+gem "rubocop-rspec", ["~> 2.20", "< 2.21"], require: false
 gem "simplecov", git: "https://github.com/DataDog/simplecov", ref: "3bb6b7ee58bf4b1954ca205f50dd44d6f41c57db"
 gem "simplecov-cobertura", "~> 2.1.0"
 gem "warning", "~> 1"
 gem "webmock", ">= 3.10.0"
 gem "webrick", ">= 1.7.0"
-gem "rubocop", "~> 1.50.0", require: false
-gem "rubocop-packaging", "~> 0.5.2", require: false
-gem "rubocop-performance", "~> 1.9", require: false
-gem "rubocop-rspec", ["~> 2.20", "< 2.21"], require: false
-gem "dogstatsd-ruby", ">= 3.3.0", "!= 5.0.0", "!= 5.0.1", "!= 5.1.0"
-gem "google-protobuf", ["~> 3.0", "!= 3.7.0", "!= 3.7.1"]
 gem "rails", "~> 7.0.0"
 
 group :check do

--- a/gemfiles/ruby_3.3_rails71.gemfile
+++ b/gemfiles/ruby_3.3_rails71.gemfile
@@ -6,7 +6,9 @@ gem "benchmark-ips", "~> 2.8"
 gem "benchmark-memory", "< 0.2"
 gem "climate_control", "~> 0.2.0"
 gem "concurrent-ruby"
+gem "dogstatsd-ruby", ">= 3.3.0", "!= 5.0.0", "!= 5.0.1", "!= 5.1.0"
 gem "extlz4", "~> 0.3", ">= 0.3.3"
+gem "google-protobuf", ["~> 3.0", "!= 3.7.0", "!= 3.7.1"]
 gem "json-schema", "< 3"
 gem "memory_profiler", "~> 0.9"
 gem "os", "~> 1.1"
@@ -19,17 +21,15 @@ gem "rspec", "~> 3.13"
 gem "rspec-collection_matchers", "~> 1.1"
 gem "rspec-wait", "~> 0"
 gem "rspec_junit_formatter", ">= 0.5.1"
+gem "rubocop", "~> 1.50.0", require: false
+gem "rubocop-packaging", "~> 0.5.2", require: false
+gem "rubocop-performance", "~> 1.9", require: false
+gem "rubocop-rspec", ["~> 2.20", "< 2.21"], require: false
 gem "simplecov", git: "https://github.com/DataDog/simplecov", ref: "3bb6b7ee58bf4b1954ca205f50dd44d6f41c57db"
 gem "simplecov-cobertura", "~> 2.1.0"
 gem "warning", "~> 1"
 gem "webmock", ">= 3.10.0"
 gem "webrick", ">= 1.7.0"
-gem "rubocop", "~> 1.50.0", require: false
-gem "rubocop-packaging", "~> 0.5.2", require: false
-gem "rubocop-performance", "~> 1.9", require: false
-gem "rubocop-rspec", ["~> 2.20", "< 2.21"], require: false
-gem "dogstatsd-ruby", ">= 3.3.0", "!= 5.0.0", "!= 5.0.1", "!= 5.1.0"
-gem "google-protobuf", ["~> 3.0", "!= 3.7.0", "!= 3.7.1"]
 gem "rails", "~> 7.1.0"
 
 group :check do

--- a/gemfiles/ruby_3.3_rails_old_redis.gemfile
+++ b/gemfiles/ruby_3.3_rails_old_redis.gemfile
@@ -6,7 +6,9 @@ gem "benchmark-ips", "~> 2.8"
 gem "benchmark-memory", "< 0.2"
 gem "climate_control", "~> 0.2.0"
 gem "concurrent-ruby"
+gem "dogstatsd-ruby", ">= 3.3.0", "!= 5.0.0", "!= 5.0.1", "!= 5.1.0"
 gem "extlz4", "~> 0.3", ">= 0.3.3"
+gem "google-protobuf", ["~> 3.0", "!= 3.7.0", "!= 3.7.1"]
 gem "json-schema", "< 3"
 gem "memory_profiler", "~> 0.9"
 gem "os", "~> 1.1"
@@ -19,17 +21,15 @@ gem "rspec", "~> 3.13"
 gem "rspec-collection_matchers", "~> 1.1"
 gem "rspec-wait", "~> 0"
 gem "rspec_junit_formatter", ">= 0.5.1"
+gem "rubocop", "~> 1.50.0", require: false
+gem "rubocop-packaging", "~> 0.5.2", require: false
+gem "rubocop-performance", "~> 1.9", require: false
+gem "rubocop-rspec", ["~> 2.20", "< 2.21"], require: false
 gem "simplecov", git: "https://github.com/DataDog/simplecov", ref: "3bb6b7ee58bf4b1954ca205f50dd44d6f41c57db"
 gem "simplecov-cobertura", "~> 2.1.0"
 gem "warning", "~> 1"
 gem "webmock", ">= 3.10.0"
 gem "webrick", ">= 1.7.0"
-gem "rubocop", "~> 1.50.0", require: false
-gem "rubocop-packaging", "~> 0.5.2", require: false
-gem "rubocop-performance", "~> 1.9", require: false
-gem "rubocop-rspec", ["~> 2.20", "< 2.21"], require: false
-gem "dogstatsd-ruby", ">= 3.3.0", "!= 5.0.0", "!= 5.0.1", "!= 5.1.0"
-gem "google-protobuf", ["~> 3.0", "!= 3.7.0", "!= 3.7.1"]
 gem "redis", "< 4"
 gem "rails", "~> 6.1.0"
 gem "pg", ">= 1.1", platform: :ruby

--- a/gemfiles/ruby_3.3_redis_3.gemfile
+++ b/gemfiles/ruby_3.3_redis_3.gemfile
@@ -6,7 +6,9 @@ gem "benchmark-ips", "~> 2.8"
 gem "benchmark-memory", "< 0.2"
 gem "climate_control", "~> 0.2.0"
 gem "concurrent-ruby"
+gem "dogstatsd-ruby", ">= 3.3.0", "!= 5.0.0", "!= 5.0.1", "!= 5.1.0"
 gem "extlz4", "~> 0.3", ">= 0.3.3"
+gem "google-protobuf", ["~> 3.0", "!= 3.7.0", "!= 3.7.1"]
 gem "json-schema", "< 3"
 gem "memory_profiler", "~> 0.9"
 gem "os", "~> 1.1"
@@ -19,17 +21,15 @@ gem "rspec", "~> 3.13"
 gem "rspec-collection_matchers", "~> 1.1"
 gem "rspec-wait", "~> 0"
 gem "rspec_junit_formatter", ">= 0.5.1"
+gem "rubocop", "~> 1.50.0", require: false
+gem "rubocop-packaging", "~> 0.5.2", require: false
+gem "rubocop-performance", "~> 1.9", require: false
+gem "rubocop-rspec", ["~> 2.20", "< 2.21"], require: false
 gem "simplecov", git: "https://github.com/DataDog/simplecov", ref: "3bb6b7ee58bf4b1954ca205f50dd44d6f41c57db"
 gem "simplecov-cobertura", "~> 2.1.0"
 gem "warning", "~> 1"
 gem "webmock", ">= 3.10.0"
 gem "webrick", ">= 1.7.0"
-gem "rubocop", "~> 1.50.0", require: false
-gem "rubocop-packaging", "~> 0.5.2", require: false
-gem "rubocop-performance", "~> 1.9", require: false
-gem "rubocop-rspec", ["~> 2.20", "< 2.21"], require: false
-gem "dogstatsd-ruby", ">= 3.3.0", "!= 5.0.0", "!= 5.0.1", "!= 5.1.0"
-gem "google-protobuf", ["~> 3.0", "!= 3.7.0", "!= 3.7.1"]
 gem "redis", "~> 3"
 
 group :check do

--- a/gemfiles/ruby_3.3_redis_4.gemfile
+++ b/gemfiles/ruby_3.3_redis_4.gemfile
@@ -6,7 +6,9 @@ gem "benchmark-ips", "~> 2.8"
 gem "benchmark-memory", "< 0.2"
 gem "climate_control", "~> 0.2.0"
 gem "concurrent-ruby"
+gem "dogstatsd-ruby", ">= 3.3.0", "!= 5.0.0", "!= 5.0.1", "!= 5.1.0"
 gem "extlz4", "~> 0.3", ">= 0.3.3"
+gem "google-protobuf", ["~> 3.0", "!= 3.7.0", "!= 3.7.1"]
 gem "json-schema", "< 3"
 gem "memory_profiler", "~> 0.9"
 gem "os", "~> 1.1"
@@ -19,17 +21,15 @@ gem "rspec", "~> 3.13"
 gem "rspec-collection_matchers", "~> 1.1"
 gem "rspec-wait", "~> 0"
 gem "rspec_junit_formatter", ">= 0.5.1"
+gem "rubocop", "~> 1.50.0", require: false
+gem "rubocop-packaging", "~> 0.5.2", require: false
+gem "rubocop-performance", "~> 1.9", require: false
+gem "rubocop-rspec", ["~> 2.20", "< 2.21"], require: false
 gem "simplecov", git: "https://github.com/DataDog/simplecov", ref: "3bb6b7ee58bf4b1954ca205f50dd44d6f41c57db"
 gem "simplecov-cobertura", "~> 2.1.0"
 gem "warning", "~> 1"
 gem "webmock", ">= 3.10.0"
 gem "webrick", ">= 1.7.0"
-gem "rubocop", "~> 1.50.0", require: false
-gem "rubocop-packaging", "~> 0.5.2", require: false
-gem "rubocop-performance", "~> 1.9", require: false
-gem "rubocop-rspec", ["~> 2.20", "< 2.21"], require: false
-gem "dogstatsd-ruby", ">= 3.3.0", "!= 5.0.0", "!= 5.0.1", "!= 5.1.0"
-gem "google-protobuf", ["~> 3.0", "!= 3.7.0", "!= 3.7.1"]
 gem "redis", "~> 4"
 
 group :check do

--- a/gemfiles/ruby_3.3_redis_5.gemfile
+++ b/gemfiles/ruby_3.3_redis_5.gemfile
@@ -6,7 +6,9 @@ gem "benchmark-ips", "~> 2.8"
 gem "benchmark-memory", "< 0.2"
 gem "climate_control", "~> 0.2.0"
 gem "concurrent-ruby"
+gem "dogstatsd-ruby", ">= 3.3.0", "!= 5.0.0", "!= 5.0.1", "!= 5.1.0"
 gem "extlz4", "~> 0.3", ">= 0.3.3"
+gem "google-protobuf", ["~> 3.0", "!= 3.7.0", "!= 3.7.1"]
 gem "json-schema", "< 3"
 gem "memory_profiler", "~> 0.9"
 gem "os", "~> 1.1"
@@ -19,17 +21,15 @@ gem "rspec", "~> 3.13"
 gem "rspec-collection_matchers", "~> 1.1"
 gem "rspec-wait", "~> 0"
 gem "rspec_junit_formatter", ">= 0.5.1"
+gem "rubocop", "~> 1.50.0", require: false
+gem "rubocop-packaging", "~> 0.5.2", require: false
+gem "rubocop-performance", "~> 1.9", require: false
+gem "rubocop-rspec", ["~> 2.20", "< 2.21"], require: false
 gem "simplecov", git: "https://github.com/DataDog/simplecov", ref: "3bb6b7ee58bf4b1954ca205f50dd44d6f41c57db"
 gem "simplecov-cobertura", "~> 2.1.0"
 gem "warning", "~> 1"
 gem "webmock", ">= 3.10.0"
 gem "webrick", ">= 1.7.0"
-gem "rubocop", "~> 1.50.0", require: false
-gem "rubocop-packaging", "~> 0.5.2", require: false
-gem "rubocop-performance", "~> 1.9", require: false
-gem "rubocop-rspec", ["~> 2.20", "< 2.21"], require: false
-gem "dogstatsd-ruby", ">= 3.3.0", "!= 5.0.0", "!= 5.0.1", "!= 5.1.0"
-gem "google-protobuf", ["~> 3.0", "!= 3.7.0", "!= 3.7.1"]
 gem "redis", "~> 5"
 
 group :check do

--- a/gemfiles/ruby_3.3_relational_db.gemfile
+++ b/gemfiles/ruby_3.3_relational_db.gemfile
@@ -6,7 +6,9 @@ gem "benchmark-ips", "~> 2.8"
 gem "benchmark-memory", "< 0.2"
 gem "climate_control", "~> 0.2.0"
 gem "concurrent-ruby"
+gem "dogstatsd-ruby", ">= 3.3.0", "!= 5.0.0", "!= 5.0.1", "!= 5.1.0"
 gem "extlz4", "~> 0.3", ">= 0.3.3"
+gem "google-protobuf", ["~> 3.0", "!= 3.7.0", "!= 3.7.1"]
 gem "json-schema", "< 3"
 gem "memory_profiler", "~> 0.9"
 gem "os", "~> 1.1"
@@ -19,17 +21,15 @@ gem "rspec", "~> 3.13"
 gem "rspec-collection_matchers", "~> 1.1"
 gem "rspec-wait", "~> 0"
 gem "rspec_junit_formatter", ">= 0.5.1"
+gem "rubocop", "~> 1.50.0", require: false
+gem "rubocop-packaging", "~> 0.5.2", require: false
+gem "rubocop-performance", "~> 1.9", require: false
+gem "rubocop-rspec", ["~> 2.20", "< 2.21"], require: false
 gem "simplecov", git: "https://github.com/DataDog/simplecov", ref: "3bb6b7ee58bf4b1954ca205f50dd44d6f41c57db"
 gem "simplecov-cobertura", "~> 2.1.0"
 gem "warning", "~> 1"
 gem "webmock", ">= 3.10.0"
 gem "webrick", ">= 1.7.0"
-gem "rubocop", "~> 1.50.0", require: false
-gem "rubocop-packaging", "~> 0.5.2", require: false
-gem "rubocop-performance", "~> 1.9", require: false
-gem "rubocop-rspec", ["~> 2.20", "< 2.21"], require: false
-gem "dogstatsd-ruby", ">= 3.3.0", "!= 5.0.0", "!= 5.0.1", "!= 5.1.0"
-gem "google-protobuf", ["~> 3.0", "!= 3.7.0", "!= 3.7.1"]
 gem "activerecord", "~> 7"
 gem "delayed_job"
 gem "delayed_job_active_record"

--- a/gemfiles/ruby_3.3_resque2_redis3.gemfile
+++ b/gemfiles/ruby_3.3_resque2_redis3.gemfile
@@ -6,7 +6,9 @@ gem "benchmark-ips", "~> 2.8"
 gem "benchmark-memory", "< 0.2"
 gem "climate_control", "~> 0.2.0"
 gem "concurrent-ruby"
+gem "dogstatsd-ruby", ">= 3.3.0", "!= 5.0.0", "!= 5.0.1", "!= 5.1.0"
 gem "extlz4", "~> 0.3", ">= 0.3.3"
+gem "google-protobuf", ["~> 3.0", "!= 3.7.0", "!= 3.7.1"]
 gem "json-schema", "< 3"
 gem "memory_profiler", "~> 0.9"
 gem "os", "~> 1.1"
@@ -19,17 +21,15 @@ gem "rspec", "~> 3.13"
 gem "rspec-collection_matchers", "~> 1.1"
 gem "rspec-wait", "~> 0"
 gem "rspec_junit_formatter", ">= 0.5.1"
+gem "rubocop", "~> 1.50.0", require: false
+gem "rubocop-packaging", "~> 0.5.2", require: false
+gem "rubocop-performance", "~> 1.9", require: false
+gem "rubocop-rspec", ["~> 2.20", "< 2.21"], require: false
 gem "simplecov", git: "https://github.com/DataDog/simplecov", ref: "3bb6b7ee58bf4b1954ca205f50dd44d6f41c57db"
 gem "simplecov-cobertura", "~> 2.1.0"
 gem "warning", "~> 1"
 gem "webmock", ">= 3.10.0"
 gem "webrick", ">= 1.7.0"
-gem "rubocop", "~> 1.50.0", require: false
-gem "rubocop-packaging", "~> 0.5.2", require: false
-gem "rubocop-performance", "~> 1.9", require: false
-gem "rubocop-rspec", ["~> 2.20", "< 2.21"], require: false
-gem "dogstatsd-ruby", ">= 3.3.0", "!= 5.0.0", "!= 5.0.1", "!= 5.1.0"
-gem "google-protobuf", ["~> 3.0", "!= 3.7.0", "!= 3.7.1"]
 gem "redis", "< 4.0"
 gem "resque", ">= 2.0"
 

--- a/gemfiles/ruby_3.3_resque2_redis4.gemfile
+++ b/gemfiles/ruby_3.3_resque2_redis4.gemfile
@@ -6,7 +6,9 @@ gem "benchmark-ips", "~> 2.8"
 gem "benchmark-memory", "< 0.2"
 gem "climate_control", "~> 0.2.0"
 gem "concurrent-ruby"
+gem "dogstatsd-ruby", ">= 3.3.0", "!= 5.0.0", "!= 5.0.1", "!= 5.1.0"
 gem "extlz4", "~> 0.3", ">= 0.3.3"
+gem "google-protobuf", ["~> 3.0", "!= 3.7.0", "!= 3.7.1"]
 gem "json-schema", "< 3"
 gem "memory_profiler", "~> 0.9"
 gem "os", "~> 1.1"
@@ -19,17 +21,15 @@ gem "rspec", "~> 3.13"
 gem "rspec-collection_matchers", "~> 1.1"
 gem "rspec-wait", "~> 0"
 gem "rspec_junit_formatter", ">= 0.5.1"
+gem "rubocop", "~> 1.50.0", require: false
+gem "rubocop-packaging", "~> 0.5.2", require: false
+gem "rubocop-performance", "~> 1.9", require: false
+gem "rubocop-rspec", ["~> 2.20", "< 2.21"], require: false
 gem "simplecov", git: "https://github.com/DataDog/simplecov", ref: "3bb6b7ee58bf4b1954ca205f50dd44d6f41c57db"
 gem "simplecov-cobertura", "~> 2.1.0"
 gem "warning", "~> 1"
 gem "webmock", ">= 3.10.0"
 gem "webrick", ">= 1.7.0"
-gem "rubocop", "~> 1.50.0", require: false
-gem "rubocop-packaging", "~> 0.5.2", require: false
-gem "rubocop-performance", "~> 1.9", require: false
-gem "rubocop-rspec", ["~> 2.20", "< 2.21"], require: false
-gem "dogstatsd-ruby", ">= 3.3.0", "!= 5.0.0", "!= 5.0.1", "!= 5.1.0"
-gem "google-protobuf", ["~> 3.0", "!= 3.7.0", "!= 3.7.1"]
 gem "redis", ">= 4.0"
 gem "resque", ">= 2.0"
 

--- a/gemfiles/ruby_3.3_sinatra_2.gemfile
+++ b/gemfiles/ruby_3.3_sinatra_2.gemfile
@@ -6,7 +6,9 @@ gem "benchmark-ips", "~> 2.8"
 gem "benchmark-memory", "< 0.2"
 gem "climate_control", "~> 0.2.0"
 gem "concurrent-ruby"
+gem "dogstatsd-ruby", ">= 3.3.0", "!= 5.0.0", "!= 5.0.1", "!= 5.1.0"
 gem "extlz4", "~> 0.3", ">= 0.3.3"
+gem "google-protobuf", ["~> 3.0", "!= 3.7.0", "!= 3.7.1"]
 gem "json-schema", "< 3"
 gem "memory_profiler", "~> 0.9"
 gem "os", "~> 1.1"
@@ -19,17 +21,15 @@ gem "rspec", "~> 3.13"
 gem "rspec-collection_matchers", "~> 1.1"
 gem "rspec-wait", "~> 0"
 gem "rspec_junit_formatter", ">= 0.5.1"
+gem "rubocop", "~> 1.50.0", require: false
+gem "rubocop-packaging", "~> 0.5.2", require: false
+gem "rubocop-performance", "~> 1.9", require: false
+gem "rubocop-rspec", ["~> 2.20", "< 2.21"], require: false
 gem "simplecov", git: "https://github.com/DataDog/simplecov", ref: "3bb6b7ee58bf4b1954ca205f50dd44d6f41c57db"
 gem "simplecov-cobertura", "~> 2.1.0"
 gem "warning", "~> 1"
 gem "webmock", ">= 3.10.0"
 gem "webrick", ">= 1.7.0"
-gem "rubocop", "~> 1.50.0", require: false
-gem "rubocop-packaging", "~> 0.5.2", require: false
-gem "rubocop-performance", "~> 1.9", require: false
-gem "rubocop-rspec", ["~> 2.20", "< 2.21"], require: false
-gem "dogstatsd-ruby", ">= 3.3.0", "!= 5.0.0", "!= 5.0.1", "!= 5.1.0"
-gem "google-protobuf", ["~> 3.0", "!= 3.7.0", "!= 3.7.1"]
 gem "sinatra", "~> 2"
 gem "rack-contrib"
 gem "rack-test"

--- a/gemfiles/ruby_3.3_sinatra_3.gemfile
+++ b/gemfiles/ruby_3.3_sinatra_3.gemfile
@@ -6,7 +6,9 @@ gem "benchmark-ips", "~> 2.8"
 gem "benchmark-memory", "< 0.2"
 gem "climate_control", "~> 0.2.0"
 gem "concurrent-ruby"
+gem "dogstatsd-ruby", ">= 3.3.0", "!= 5.0.0", "!= 5.0.1", "!= 5.1.0"
 gem "extlz4", "~> 0.3", ">= 0.3.3"
+gem "google-protobuf", ["~> 3.0", "!= 3.7.0", "!= 3.7.1"]
 gem "json-schema", "< 3"
 gem "memory_profiler", "~> 0.9"
 gem "os", "~> 1.1"
@@ -19,17 +21,15 @@ gem "rspec", "~> 3.13"
 gem "rspec-collection_matchers", "~> 1.1"
 gem "rspec-wait", "~> 0"
 gem "rspec_junit_formatter", ">= 0.5.1"
+gem "rubocop", "~> 1.50.0", require: false
+gem "rubocop-packaging", "~> 0.5.2", require: false
+gem "rubocop-performance", "~> 1.9", require: false
+gem "rubocop-rspec", ["~> 2.20", "< 2.21"], require: false
 gem "simplecov", git: "https://github.com/DataDog/simplecov", ref: "3bb6b7ee58bf4b1954ca205f50dd44d6f41c57db"
 gem "simplecov-cobertura", "~> 2.1.0"
 gem "warning", "~> 1"
 gem "webmock", ">= 3.10.0"
 gem "webrick", ">= 1.7.0"
-gem "rubocop", "~> 1.50.0", require: false
-gem "rubocop-packaging", "~> 0.5.2", require: false
-gem "rubocop-performance", "~> 1.9", require: false
-gem "rubocop-rspec", ["~> 2.20", "< 2.21"], require: false
-gem "dogstatsd-ruby", ">= 3.3.0", "!= 5.0.0", "!= 5.0.1", "!= 5.1.0"
-gem "google-protobuf", ["~> 3.0", "!= 3.7.0", "!= 3.7.1"]
 gem "sinatra", "~> 3"
 gem "rack-contrib"
 gem "rack-test"

--- a/gemfiles/ruby_3.3_sinatra_4.gemfile
+++ b/gemfiles/ruby_3.3_sinatra_4.gemfile
@@ -6,7 +6,9 @@ gem "benchmark-ips", "~> 2.8"
 gem "benchmark-memory", "< 0.2"
 gem "climate_control", "~> 0.2.0"
 gem "concurrent-ruby"
+gem "dogstatsd-ruby", ">= 3.3.0", "!= 5.0.0", "!= 5.0.1", "!= 5.1.0"
 gem "extlz4", "~> 0.3", ">= 0.3.3"
+gem "google-protobuf", ["~> 3.0", "!= 3.7.0", "!= 3.7.1"]
 gem "json-schema", "< 3"
 gem "memory_profiler", "~> 0.9"
 gem "os", "~> 1.1"
@@ -19,17 +21,15 @@ gem "rspec", "~> 3.13"
 gem "rspec-collection_matchers", "~> 1.1"
 gem "rspec-wait", "~> 0"
 gem "rspec_junit_formatter", ">= 0.5.1"
+gem "rubocop", "~> 1.50.0", require: false
+gem "rubocop-packaging", "~> 0.5.2", require: false
+gem "rubocop-performance", "~> 1.9", require: false
+gem "rubocop-rspec", ["~> 2.20", "< 2.21"], require: false
 gem "simplecov", git: "https://github.com/DataDog/simplecov", ref: "3bb6b7ee58bf4b1954ca205f50dd44d6f41c57db"
 gem "simplecov-cobertura", "~> 2.1.0"
 gem "warning", "~> 1"
 gem "webmock", ">= 3.10.0"
 gem "webrick", ">= 1.7.0"
-gem "rubocop", "~> 1.50.0", require: false
-gem "rubocop-packaging", "~> 0.5.2", require: false
-gem "rubocop-performance", "~> 1.9", require: false
-gem "rubocop-rspec", ["~> 2.20", "< 2.21"], require: false
-gem "dogstatsd-ruby", ">= 3.3.0", "!= 5.0.0", "!= 5.0.1", "!= 5.1.0"
-gem "google-protobuf", ["~> 3.0", "!= 3.7.0", "!= 3.7.1"]
 gem "sinatra", "~> 4"
 gem "rack-contrib"
 gem "rack-test"

--- a/gemfiles/ruby_3.3_stripe_10.gemfile
+++ b/gemfiles/ruby_3.3_stripe_10.gemfile
@@ -6,7 +6,9 @@ gem "benchmark-ips", "~> 2.8"
 gem "benchmark-memory", "< 0.2"
 gem "climate_control", "~> 0.2.0"
 gem "concurrent-ruby"
+gem "dogstatsd-ruby", ">= 3.3.0", "!= 5.0.0", "!= 5.0.1", "!= 5.1.0"
 gem "extlz4", "~> 0.3", ">= 0.3.3"
+gem "google-protobuf", ["~> 3.0", "!= 3.7.0", "!= 3.7.1"]
 gem "json-schema", "< 3"
 gem "memory_profiler", "~> 0.9"
 gem "os", "~> 1.1"
@@ -19,17 +21,15 @@ gem "rspec", "~> 3.13"
 gem "rspec-collection_matchers", "~> 1.1"
 gem "rspec-wait", "~> 0"
 gem "rspec_junit_formatter", ">= 0.5.1"
+gem "rubocop", "~> 1.50.0", require: false
+gem "rubocop-packaging", "~> 0.5.2", require: false
+gem "rubocop-performance", "~> 1.9", require: false
+gem "rubocop-rspec", ["~> 2.20", "< 2.21"], require: false
 gem "simplecov", git: "https://github.com/DataDog/simplecov", ref: "3bb6b7ee58bf4b1954ca205f50dd44d6f41c57db"
 gem "simplecov-cobertura", "~> 2.1.0"
 gem "warning", "~> 1"
 gem "webmock", ">= 3.10.0"
 gem "webrick", ">= 1.7.0"
-gem "rubocop", "~> 1.50.0", require: false
-gem "rubocop-packaging", "~> 0.5.2", require: false
-gem "rubocop-performance", "~> 1.9", require: false
-gem "rubocop-rspec", ["~> 2.20", "< 2.21"], require: false
-gem "dogstatsd-ruby", ">= 3.3.0", "!= 5.0.0", "!= 5.0.1", "!= 5.1.0"
-gem "google-protobuf", ["~> 3.0", "!= 3.7.0", "!= 3.7.1"]
 gem "stripe", "~> 10"
 
 group :check do

--- a/gemfiles/ruby_3.3_stripe_11.gemfile
+++ b/gemfiles/ruby_3.3_stripe_11.gemfile
@@ -6,7 +6,9 @@ gem "benchmark-ips", "~> 2.8"
 gem "benchmark-memory", "< 0.2"
 gem "climate_control", "~> 0.2.0"
 gem "concurrent-ruby"
+gem "dogstatsd-ruby", ">= 3.3.0", "!= 5.0.0", "!= 5.0.1", "!= 5.1.0"
 gem "extlz4", "~> 0.3", ">= 0.3.3"
+gem "google-protobuf", ["~> 3.0", "!= 3.7.0", "!= 3.7.1"]
 gem "json-schema", "< 3"
 gem "memory_profiler", "~> 0.9"
 gem "os", "~> 1.1"
@@ -19,17 +21,15 @@ gem "rspec", "~> 3.13"
 gem "rspec-collection_matchers", "~> 1.1"
 gem "rspec-wait", "~> 0"
 gem "rspec_junit_formatter", ">= 0.5.1"
+gem "rubocop", "~> 1.50.0", require: false
+gem "rubocop-packaging", "~> 0.5.2", require: false
+gem "rubocop-performance", "~> 1.9", require: false
+gem "rubocop-rspec", ["~> 2.20", "< 2.21"], require: false
 gem "simplecov", git: "https://github.com/DataDog/simplecov", ref: "3bb6b7ee58bf4b1954ca205f50dd44d6f41c57db"
 gem "simplecov-cobertura", "~> 2.1.0"
 gem "warning", "~> 1"
 gem "webmock", ">= 3.10.0"
 gem "webrick", ">= 1.7.0"
-gem "rubocop", "~> 1.50.0", require: false
-gem "rubocop-packaging", "~> 0.5.2", require: false
-gem "rubocop-performance", "~> 1.9", require: false
-gem "rubocop-rspec", ["~> 2.20", "< 2.21"], require: false
-gem "dogstatsd-ruby", ">= 3.3.0", "!= 5.0.0", "!= 5.0.1", "!= 5.1.0"
-gem "google-protobuf", ["~> 3.0", "!= 3.7.0", "!= 3.7.1"]
 gem "stripe", "~> 11"
 
 group :check do

--- a/gemfiles/ruby_3.3_stripe_12.gemfile
+++ b/gemfiles/ruby_3.3_stripe_12.gemfile
@@ -6,7 +6,9 @@ gem "benchmark-ips", "~> 2.8"
 gem "benchmark-memory", "< 0.2"
 gem "climate_control", "~> 0.2.0"
 gem "concurrent-ruby"
+gem "dogstatsd-ruby", ">= 3.3.0", "!= 5.0.0", "!= 5.0.1", "!= 5.1.0"
 gem "extlz4", "~> 0.3", ">= 0.3.3"
+gem "google-protobuf", ["~> 3.0", "!= 3.7.0", "!= 3.7.1"]
 gem "json-schema", "< 3"
 gem "memory_profiler", "~> 0.9"
 gem "os", "~> 1.1"
@@ -19,17 +21,15 @@ gem "rspec", "~> 3.13"
 gem "rspec-collection_matchers", "~> 1.1"
 gem "rspec-wait", "~> 0"
 gem "rspec_junit_formatter", ">= 0.5.1"
+gem "rubocop", "~> 1.50.0", require: false
+gem "rubocop-packaging", "~> 0.5.2", require: false
+gem "rubocop-performance", "~> 1.9", require: false
+gem "rubocop-rspec", ["~> 2.20", "< 2.21"], require: false
 gem "simplecov", git: "https://github.com/DataDog/simplecov", ref: "3bb6b7ee58bf4b1954ca205f50dd44d6f41c57db"
 gem "simplecov-cobertura", "~> 2.1.0"
 gem "warning", "~> 1"
 gem "webmock", ">= 3.10.0"
 gem "webrick", ">= 1.7.0"
-gem "rubocop", "~> 1.50.0", require: false
-gem "rubocop-packaging", "~> 0.5.2", require: false
-gem "rubocop-performance", "~> 1.9", require: false
-gem "rubocop-rspec", ["~> 2.20", "< 2.21"], require: false
-gem "dogstatsd-ruby", ">= 3.3.0", "!= 5.0.0", "!= 5.0.1", "!= 5.1.0"
-gem "google-protobuf", ["~> 3.0", "!= 3.7.0", "!= 3.7.1"]
 gem "stripe", "~> 12"
 
 group :check do

--- a/gemfiles/ruby_3.3_stripe_7.gemfile
+++ b/gemfiles/ruby_3.3_stripe_7.gemfile
@@ -6,7 +6,9 @@ gem "benchmark-ips", "~> 2.8"
 gem "benchmark-memory", "< 0.2"
 gem "climate_control", "~> 0.2.0"
 gem "concurrent-ruby"
+gem "dogstatsd-ruby", ">= 3.3.0", "!= 5.0.0", "!= 5.0.1", "!= 5.1.0"
 gem "extlz4", "~> 0.3", ">= 0.3.3"
+gem "google-protobuf", ["~> 3.0", "!= 3.7.0", "!= 3.7.1"]
 gem "json-schema", "< 3"
 gem "memory_profiler", "~> 0.9"
 gem "os", "~> 1.1"
@@ -19,17 +21,15 @@ gem "rspec", "~> 3.13"
 gem "rspec-collection_matchers", "~> 1.1"
 gem "rspec-wait", "~> 0"
 gem "rspec_junit_formatter", ">= 0.5.1"
+gem "rubocop", "~> 1.50.0", require: false
+gem "rubocop-packaging", "~> 0.5.2", require: false
+gem "rubocop-performance", "~> 1.9", require: false
+gem "rubocop-rspec", ["~> 2.20", "< 2.21"], require: false
 gem "simplecov", git: "https://github.com/DataDog/simplecov", ref: "3bb6b7ee58bf4b1954ca205f50dd44d6f41c57db"
 gem "simplecov-cobertura", "~> 2.1.0"
 gem "warning", "~> 1"
 gem "webmock", ">= 3.10.0"
 gem "webrick", ">= 1.7.0"
-gem "rubocop", "~> 1.50.0", require: false
-gem "rubocop-packaging", "~> 0.5.2", require: false
-gem "rubocop-performance", "~> 1.9", require: false
-gem "rubocop-rspec", ["~> 2.20", "< 2.21"], require: false
-gem "dogstatsd-ruby", ">= 3.3.0", "!= 5.0.0", "!= 5.0.1", "!= 5.1.0"
-gem "google-protobuf", ["~> 3.0", "!= 3.7.0", "!= 3.7.1"]
 gem "stripe", "~> 7"
 
 group :check do

--- a/gemfiles/ruby_3.3_stripe_8.gemfile
+++ b/gemfiles/ruby_3.3_stripe_8.gemfile
@@ -6,7 +6,9 @@ gem "benchmark-ips", "~> 2.8"
 gem "benchmark-memory", "< 0.2"
 gem "climate_control", "~> 0.2.0"
 gem "concurrent-ruby"
+gem "dogstatsd-ruby", ">= 3.3.0", "!= 5.0.0", "!= 5.0.1", "!= 5.1.0"
 gem "extlz4", "~> 0.3", ">= 0.3.3"
+gem "google-protobuf", ["~> 3.0", "!= 3.7.0", "!= 3.7.1"]
 gem "json-schema", "< 3"
 gem "memory_profiler", "~> 0.9"
 gem "os", "~> 1.1"
@@ -19,17 +21,15 @@ gem "rspec", "~> 3.13"
 gem "rspec-collection_matchers", "~> 1.1"
 gem "rspec-wait", "~> 0"
 gem "rspec_junit_formatter", ">= 0.5.1"
+gem "rubocop", "~> 1.50.0", require: false
+gem "rubocop-packaging", "~> 0.5.2", require: false
+gem "rubocop-performance", "~> 1.9", require: false
+gem "rubocop-rspec", ["~> 2.20", "< 2.21"], require: false
 gem "simplecov", git: "https://github.com/DataDog/simplecov", ref: "3bb6b7ee58bf4b1954ca205f50dd44d6f41c57db"
 gem "simplecov-cobertura", "~> 2.1.0"
 gem "warning", "~> 1"
 gem "webmock", ">= 3.10.0"
 gem "webrick", ">= 1.7.0"
-gem "rubocop", "~> 1.50.0", require: false
-gem "rubocop-packaging", "~> 0.5.2", require: false
-gem "rubocop-performance", "~> 1.9", require: false
-gem "rubocop-rspec", ["~> 2.20", "< 2.21"], require: false
-gem "dogstatsd-ruby", ">= 3.3.0", "!= 5.0.0", "!= 5.0.1", "!= 5.1.0"
-gem "google-protobuf", ["~> 3.0", "!= 3.7.0", "!= 3.7.1"]
 gem "stripe", "~> 8"
 
 group :check do

--- a/gemfiles/ruby_3.3_stripe_9.gemfile
+++ b/gemfiles/ruby_3.3_stripe_9.gemfile
@@ -6,7 +6,9 @@ gem "benchmark-ips", "~> 2.8"
 gem "benchmark-memory", "< 0.2"
 gem "climate_control", "~> 0.2.0"
 gem "concurrent-ruby"
+gem "dogstatsd-ruby", ">= 3.3.0", "!= 5.0.0", "!= 5.0.1", "!= 5.1.0"
 gem "extlz4", "~> 0.3", ">= 0.3.3"
+gem "google-protobuf", ["~> 3.0", "!= 3.7.0", "!= 3.7.1"]
 gem "json-schema", "< 3"
 gem "memory_profiler", "~> 0.9"
 gem "os", "~> 1.1"
@@ -19,17 +21,15 @@ gem "rspec", "~> 3.13"
 gem "rspec-collection_matchers", "~> 1.1"
 gem "rspec-wait", "~> 0"
 gem "rspec_junit_formatter", ">= 0.5.1"
+gem "rubocop", "~> 1.50.0", require: false
+gem "rubocop-packaging", "~> 0.5.2", require: false
+gem "rubocop-performance", "~> 1.9", require: false
+gem "rubocop-rspec", ["~> 2.20", "< 2.21"], require: false
 gem "simplecov", git: "https://github.com/DataDog/simplecov", ref: "3bb6b7ee58bf4b1954ca205f50dd44d6f41c57db"
 gem "simplecov-cobertura", "~> 2.1.0"
 gem "warning", "~> 1"
 gem "webmock", ">= 3.10.0"
 gem "webrick", ">= 1.7.0"
-gem "rubocop", "~> 1.50.0", require: false
-gem "rubocop-packaging", "~> 0.5.2", require: false
-gem "rubocop-performance", "~> 1.9", require: false
-gem "rubocop-rspec", ["~> 2.20", "< 2.21"], require: false
-gem "dogstatsd-ruby", ">= 3.3.0", "!= 5.0.0", "!= 5.0.1", "!= 5.1.0"
-gem "google-protobuf", ["~> 3.0", "!= 3.7.0", "!= 3.7.1"]
 gem "stripe", "~> 9"
 
 group :check do

--- a/gemfiles/ruby_3.3_stripe_latest.gemfile
+++ b/gemfiles/ruby_3.3_stripe_latest.gemfile
@@ -6,7 +6,9 @@ gem "benchmark-ips", "~> 2.8"
 gem "benchmark-memory", "< 0.2"
 gem "climate_control", "~> 0.2.0"
 gem "concurrent-ruby"
+gem "dogstatsd-ruby", ">= 3.3.0", "!= 5.0.0", "!= 5.0.1", "!= 5.1.0"
 gem "extlz4", "~> 0.3", ">= 0.3.3"
+gem "google-protobuf", ["~> 3.0", "!= 3.7.0", "!= 3.7.1"]
 gem "json-schema", "< 3"
 gem "memory_profiler", "~> 0.9"
 gem "os", "~> 1.1"
@@ -19,17 +21,15 @@ gem "rspec", "~> 3.13"
 gem "rspec-collection_matchers", "~> 1.1"
 gem "rspec-wait", "~> 0"
 gem "rspec_junit_formatter", ">= 0.5.1"
+gem "rubocop", "~> 1.50.0", require: false
+gem "rubocop-packaging", "~> 0.5.2", require: false
+gem "rubocop-performance", "~> 1.9", require: false
+gem "rubocop-rspec", ["~> 2.20", "< 2.21"], require: false
 gem "simplecov", git: "https://github.com/DataDog/simplecov", ref: "3bb6b7ee58bf4b1954ca205f50dd44d6f41c57db"
 gem "simplecov-cobertura", "~> 2.1.0"
 gem "warning", "~> 1"
 gem "webmock", ">= 3.10.0"
 gem "webrick", ">= 1.7.0"
-gem "rubocop", "~> 1.50.0", require: false
-gem "rubocop-packaging", "~> 0.5.2", require: false
-gem "rubocop-performance", "~> 1.9", require: false
-gem "rubocop-rspec", ["~> 2.20", "< 2.21"], require: false
-gem "dogstatsd-ruby", ">= 3.3.0", "!= 5.0.0", "!= 5.0.1", "!= 5.1.0"
-gem "google-protobuf", ["~> 3.0", "!= 3.7.0", "!= 3.7.1"]
 gem "stripe"
 
 group :check do

--- a/gemfiles/ruby_3.3_stripe_min.gemfile
+++ b/gemfiles/ruby_3.3_stripe_min.gemfile
@@ -6,7 +6,9 @@ gem "benchmark-ips", "~> 2.8"
 gem "benchmark-memory", "< 0.2"
 gem "climate_control", "~> 0.2.0"
 gem "concurrent-ruby"
+gem "dogstatsd-ruby", ">= 3.3.0", "!= 5.0.0", "!= 5.0.1", "!= 5.1.0"
 gem "extlz4", "~> 0.3", ">= 0.3.3"
+gem "google-protobuf", ["~> 3.0", "!= 3.7.0", "!= 3.7.1"]
 gem "json-schema", "< 3"
 gem "memory_profiler", "~> 0.9"
 gem "os", "~> 1.1"
@@ -19,17 +21,15 @@ gem "rspec", "~> 3.13"
 gem "rspec-collection_matchers", "~> 1.1"
 gem "rspec-wait", "~> 0"
 gem "rspec_junit_formatter", ">= 0.5.1"
+gem "rubocop", "~> 1.50.0", require: false
+gem "rubocop-packaging", "~> 0.5.2", require: false
+gem "rubocop-performance", "~> 1.9", require: false
+gem "rubocop-rspec", ["~> 2.20", "< 2.21"], require: false
 gem "simplecov", git: "https://github.com/DataDog/simplecov", ref: "3bb6b7ee58bf4b1954ca205f50dd44d6f41c57db"
 gem "simplecov-cobertura", "~> 2.1.0"
 gem "warning", "~> 1"
 gem "webmock", ">= 3.10.0"
 gem "webrick", ">= 1.7.0"
-gem "rubocop", "~> 1.50.0", require: false
-gem "rubocop-packaging", "~> 0.5.2", require: false
-gem "rubocop-performance", "~> 1.9", require: false
-gem "rubocop-rspec", ["~> 2.20", "< 2.21"], require: false
-gem "dogstatsd-ruby", ">= 3.3.0", "!= 5.0.0", "!= 5.0.1", "!= 5.1.0"
-gem "google-protobuf", ["~> 3.0", "!= 3.7.0", "!= 3.7.1"]
 gem "stripe", "= 5.15.0"
 
 group :check do

--- a/ruby-3.0.gemfile
+++ b/ruby-3.0.gemfile
@@ -8,22 +8,15 @@ gem 'benchmark-memory', '< 0.2' # V0.2 only works with 2.5+
 gem 'climate_control', '~> 0.2.0'
 
 gem 'concurrent-ruby'
-gem 'extlz4', '~> 0.3', '>= 0.3.3' if RUBY_PLATFORM != 'java' # Used to test lz4 compression done by libdatadog
+gem 'extlz4', '~> 0.3', '>= 0.3.3'
 gem 'json-schema', '< 3' # V3 only works with 2.5+
 gem 'memory_profiler', '~> 0.9'
 
 gem 'os', '~> 1.1'
 gem 'pimpmychangelog', '>= 0.1.2'
 gem 'pry'
-if RUBY_PLATFORM != 'java'
-  # There's a few incompatibilities between pry/pry-byebug on older Rubies
-  # There's also a few temproary incompatibilities with newer rubies
-  gem 'pry-byebug' if RUBY_VERSION >= '2.6.0' && RUBY_ENGINE != 'truffleruby' && RUBY_VERSION < '3.2.0'
-  gem 'pry-nav' if RUBY_VERSION < '2.6.0'
-  gem 'pry-stack_explorer'
-else
-  gem 'pry-debugger-jruby'
-end
+gem 'pry-byebug'
+gem 'pry-stack_explorer'
 gem 'rake', '>= 10.5'
 gem 'rake-compiler', '~> 1.1', '>= 1.1.1' # To compile native extensions
 gem 'rspec', '~> 3.13'
@@ -41,21 +34,14 @@ gem 'simplecov-cobertura', '~> 2.1.0' # Used by codecov
 gem 'warning', '~> 1' # NOTE: Used in spec_helper.rb
 gem 'webmock', '>= 3.10.0'
 
-if RUBY_VERSION.start_with?('3.4.')
-  # ruby 3.4 breaks stable webrick; we need this fix until a version later than 1.8.1 comes out
-  gem 'webrick', git: 'https://github.com/ruby/webrick.git', ref: '0c600e169bd4ae267cb5eeb6197277c848323bbe'
-elsif RUBY_VERSION >= '3.0.0' # No longer bundled by default since Ruby 3.0
-  gem 'webrick', '>= 1.7.0'
-end
+gem 'webrick', '>= 1.7.0'
 
-if RUBY_VERSION >= '2.6.0'
-  # 1.50 is the last version to support Ruby 2.6
-  gem 'rubocop', '~> 1.50.0', require: false
-  gem 'rubocop-packaging', '~> 0.5.2', require: false
-  gem 'rubocop-performance', '~> 1.9', require: false
-  # 2.20 is the last version to support Ruby 2.6
-  gem 'rubocop-rspec', ['~> 2.20', '< 2.21'], require: false
-end
+# 1.50 is the last version to support Ruby 2.6
+gem 'rubocop', '~> 1.50.0', require: false
+gem 'rubocop-packaging', '~> 0.5.2', require: false
+gem 'rubocop-performance', '~> 1.9', require: false
+# 2.20 is the last version to support Ruby 2.6
+gem 'rubocop-rspec', ['~> 2.20', '< 2.21'], require: false
 
 # Optional extensions
 # TODO: Move this to Appraisals?
@@ -67,24 +53,15 @@ gem 'dogstatsd-ruby', '>= 3.3.0', '!= 5.0.0', '!= 5.0.1', '!= 5.1.0'
 # NOTE: We're excluding versions 3.7.0 and 3.7.1 for the reasons documented in #1424.
 #       Since most of our customers won't have BUNDLE_FORCE_RUBY_PLATFORM=true, it's not something we want to add
 #       to our CI, so we just shortcut and exclude specific versions that were affecting our CI.
-if RUBY_PLATFORM != 'java'
-  if RUBY_VERSION >= '2.7.0' # Bundler 1.x fails to find that versions >= 3.8.0 are not compatible because of binary gems
-    gem 'google-protobuf', ['~> 3.0', '!= 3.7.0', '!= 3.7.1']
-  else
-    gem 'google-protobuf', ['~> 3.0', '!= 3.7.0', '!= 3.7.1', '< 3.19.2']
-  end
-end
+gem 'google-protobuf', ['~> 3.0', '!= 3.7.0', '!= 3.7.1']
 
 group :check do
-  if RUBY_VERSION >= '3.0.0' && RUBY_PLATFORM != 'java'
-    gem 'rbs', '~> 3.6', require: false
-    gem 'steep', '~> 1.7.0', require: false
-  end
-  gem 'ruby_memcheck', '>= 3' if RUBY_VERSION >= '3.4.0' && RUBY_PLATFORM != 'java'
+  gem 'rbs', '~> 3.6', require: false
+  gem 'steep', '~> 1.7.0', require: false
   gem 'standard', require: false
 end
 
 group :dev do
-  gem 'ruby-lsp', require: false if RUBY_VERSION >= '3.0.0' && RUBY_PLATFORM != 'java'
+  gem 'ruby-lsp', require: false
   gem 'appraisal', '~> 2.4.0', require: false
 end

--- a/ruby-3.0.gemfile
+++ b/ruby-3.0.gemfile
@@ -4,14 +4,25 @@ gemspec
 
 gem 'benchmark-ips', '~> 2.8'
 gem 'benchmark-memory', '< 0.2' # V0.2 only works with 2.5+
-
 gem 'climate_control', '~> 0.2.0'
-
 gem 'concurrent-ruby'
+
+# Optional extensions
+# TODO: Move this to Appraisals?
+# dogstatsd v5, but lower than 5.2, has possible memory leak with datadog.
+# @see https://github.com/DataDog/dogstatsd-ruby/issues/182
+gem 'dogstatsd-ruby', '>= 3.3.0', '!= 5.0.0', '!= 5.0.1', '!= 5.1.0'
+
 gem 'extlz4', '~> 0.3', '>= 0.3.3'
+
+# Profiler testing dependencies
+# NOTE: We're excluding versions 3.7.0 and 3.7.1 for the reasons documented in #1424.
+#       Since most of our customers won't have BUNDLE_FORCE_RUBY_PLATFORM=true, it's not something we want to add
+#       to our CI, so we just shortcut and exclude specific versions that were affecting our CI.
+gem 'google-protobuf', ['~> 3.0', '!= 3.7.0', '!= 3.7.1']
+
 gem 'json-schema', '< 3' # V3 only works with 2.5+
 gem 'memory_profiler', '~> 0.9'
-
 gem 'os', '~> 1.1'
 gem 'pimpmychangelog', '>= 0.1.2'
 gem 'pry'
@@ -22,8 +33,14 @@ gem 'rake-compiler', '~> 1.1', '>= 1.1.1' # To compile native extensions
 gem 'rspec', '~> 3.13'
 gem 'rspec-collection_matchers', '~> 1.1'
 gem 'rspec-wait', '~> 0'
-
 gem 'rspec_junit_formatter', '>= 0.5.1'
+
+# 1.50 is the last version to support Ruby 2.6
+gem 'rubocop', '~> 1.50.0', require: false
+gem 'rubocop-packaging', '~> 0.5.2', require: false
+gem 'rubocop-performance', '~> 1.9', require: false
+# 2.20 is the last version to support Ruby 2.6
+gem 'rubocop-rspec', ['~> 2.20', '< 2.21'], require: false
 
 # Merging branch coverage results does not work for old, unsupported rubies and JRuby
 # We have a fix up for review, https://github.com/simplecov-ruby/simplecov/pull/972,
@@ -33,27 +50,7 @@ gem 'simplecov-cobertura', '~> 2.1.0' # Used by codecov
 
 gem 'warning', '~> 1' # NOTE: Used in spec_helper.rb
 gem 'webmock', '>= 3.10.0'
-
 gem 'webrick', '>= 1.7.0'
-
-# 1.50 is the last version to support Ruby 2.6
-gem 'rubocop', '~> 1.50.0', require: false
-gem 'rubocop-packaging', '~> 0.5.2', require: false
-gem 'rubocop-performance', '~> 1.9', require: false
-# 2.20 is the last version to support Ruby 2.6
-gem 'rubocop-rspec', ['~> 2.20', '< 2.21'], require: false
-
-# Optional extensions
-# TODO: Move this to Appraisals?
-# dogstatsd v5, but lower than 5.2, has possible memory leak with datadog.
-# @see https://github.com/DataDog/dogstatsd-ruby/issues/182
-gem 'dogstatsd-ruby', '>= 3.3.0', '!= 5.0.0', '!= 5.0.1', '!= 5.1.0'
-
-# Profiler testing dependencies
-# NOTE: We're excluding versions 3.7.0 and 3.7.1 for the reasons documented in #1424.
-#       Since most of our customers won't have BUNDLE_FORCE_RUBY_PLATFORM=true, it's not something we want to add
-#       to our CI, so we just shortcut and exclude specific versions that were affecting our CI.
-gem 'google-protobuf', ['~> 3.0', '!= 3.7.0', '!= 3.7.1']
 
 group :check do
   gem 'rbs', '~> 3.6', require: false

--- a/ruby-3.1.gemfile
+++ b/ruby-3.1.gemfile
@@ -8,22 +8,15 @@ gem 'benchmark-memory', '< 0.2' # V0.2 only works with 2.5+
 gem 'climate_control', '~> 0.2.0'
 
 gem 'concurrent-ruby'
-gem 'extlz4', '~> 0.3', '>= 0.3.3' if RUBY_PLATFORM != 'java' # Used to test lz4 compression done by libdatadog
+gem 'extlz4', '~> 0.3', '>= 0.3.3'
 gem 'json-schema', '< 3' # V3 only works with 2.5+
 gem 'memory_profiler', '~> 0.9'
 
 gem 'os', '~> 1.1'
 gem 'pimpmychangelog', '>= 0.1.2'
 gem 'pry'
-if RUBY_PLATFORM != 'java'
-  # There's a few incompatibilities between pry/pry-byebug on older Rubies
-  # There's also a few temproary incompatibilities with newer rubies
-  gem 'pry-byebug' if RUBY_VERSION >= '2.6.0' && RUBY_ENGINE != 'truffleruby' && RUBY_VERSION < '3.2.0'
-  gem 'pry-nav' if RUBY_VERSION < '2.6.0'
-  gem 'pry-stack_explorer'
-else
-  gem 'pry-debugger-jruby'
-end
+gem 'pry-byebug'
+gem 'pry-stack_explorer'
 gem 'rake', '>= 10.5'
 gem 'rake-compiler', '~> 1.1', '>= 1.1.1' # To compile native extensions
 gem 'rspec', '~> 3.13'
@@ -41,21 +34,14 @@ gem 'simplecov-cobertura', '~> 2.1.0' # Used by codecov
 gem 'warning', '~> 1' # NOTE: Used in spec_helper.rb
 gem 'webmock', '>= 3.10.0'
 
-if RUBY_VERSION.start_with?('3.4.')
-  # ruby 3.4 breaks stable webrick; we need this fix until a version later than 1.8.1 comes out
-  gem 'webrick', git: 'https://github.com/ruby/webrick.git', ref: '0c600e169bd4ae267cb5eeb6197277c848323bbe'
-elsif RUBY_VERSION >= '3.0.0' # No longer bundled by default since Ruby 3.0
-  gem 'webrick', '>= 1.7.0'
-end
+gem 'webrick', '>= 1.7.0'
 
-if RUBY_VERSION >= '2.6.0'
-  # 1.50 is the last version to support Ruby 2.6
-  gem 'rubocop', '~> 1.50.0', require: false
-  gem 'rubocop-packaging', '~> 0.5.2', require: false
-  gem 'rubocop-performance', '~> 1.9', require: false
-  # 2.20 is the last version to support Ruby 2.6
-  gem 'rubocop-rspec', ['~> 2.20', '< 2.21'], require: false
-end
+# 1.50 is the last version to support Ruby 2.6
+gem 'rubocop', '~> 1.50.0', require: false
+gem 'rubocop-packaging', '~> 0.5.2', require: false
+gem 'rubocop-performance', '~> 1.9', require: false
+# 2.20 is the last version to support Ruby 2.6
+gem 'rubocop-rspec', ['~> 2.20', '< 2.21'], require: false
 
 # Optional extensions
 # TODO: Move this to Appraisals?
@@ -67,24 +53,15 @@ gem 'dogstatsd-ruby', '>= 3.3.0', '!= 5.0.0', '!= 5.0.1', '!= 5.1.0'
 # NOTE: We're excluding versions 3.7.0 and 3.7.1 for the reasons documented in #1424.
 #       Since most of our customers won't have BUNDLE_FORCE_RUBY_PLATFORM=true, it's not something we want to add
 #       to our CI, so we just shortcut and exclude specific versions that were affecting our CI.
-if RUBY_PLATFORM != 'java'
-  if RUBY_VERSION >= '2.7.0' # Bundler 1.x fails to find that versions >= 3.8.0 are not compatible because of binary gems
-    gem 'google-protobuf', ['~> 3.0', '!= 3.7.0', '!= 3.7.1']
-  else
-    gem 'google-protobuf', ['~> 3.0', '!= 3.7.0', '!= 3.7.1', '< 3.19.2']
-  end
-end
+gem 'google-protobuf', ['~> 3.0', '!= 3.7.0', '!= 3.7.1']
 
 group :check do
-  if RUBY_VERSION >= '3.0.0' && RUBY_PLATFORM != 'java'
-    gem 'rbs', '~> 3.6', require: false
-    gem 'steep', '~> 1.7.0', require: false
-  end
-  gem 'ruby_memcheck', '>= 3' if RUBY_VERSION >= '3.4.0' && RUBY_PLATFORM != 'java'
+  gem 'rbs', '~> 3.6', require: false
+  gem 'steep', '~> 1.7.0', require: false
   gem 'standard', require: false
 end
 
 group :dev do
-  gem 'ruby-lsp', require: false if RUBY_VERSION >= '3.0.0' && RUBY_PLATFORM != 'java'
+  gem 'ruby-lsp', require: false
   gem 'appraisal', '~> 2.4.0', require: false
 end

--- a/ruby-3.1.gemfile
+++ b/ruby-3.1.gemfile
@@ -4,14 +4,25 @@ gemspec
 
 gem 'benchmark-ips', '~> 2.8'
 gem 'benchmark-memory', '< 0.2' # V0.2 only works with 2.5+
-
 gem 'climate_control', '~> 0.2.0'
-
 gem 'concurrent-ruby'
+
+# Optional extensions
+# TODO: Move this to Appraisals?
+# dogstatsd v5, but lower than 5.2, has possible memory leak with datadog.
+# @see https://github.com/DataDog/dogstatsd-ruby/issues/182
+gem 'dogstatsd-ruby', '>= 3.3.0', '!= 5.0.0', '!= 5.0.1', '!= 5.1.0'
+
 gem 'extlz4', '~> 0.3', '>= 0.3.3'
+
+# Profiler testing dependencies
+# NOTE: We're excluding versions 3.7.0 and 3.7.1 for the reasons documented in #1424.
+#       Since most of our customers won't have BUNDLE_FORCE_RUBY_PLATFORM=true, it's not something we want to add
+#       to our CI, so we just shortcut and exclude specific versions that were affecting our CI.
+gem 'google-protobuf', ['~> 3.0', '!= 3.7.0', '!= 3.7.1']
+
 gem 'json-schema', '< 3' # V3 only works with 2.5+
 gem 'memory_profiler', '~> 0.9'
-
 gem 'os', '~> 1.1'
 gem 'pimpmychangelog', '>= 0.1.2'
 gem 'pry'
@@ -22,8 +33,14 @@ gem 'rake-compiler', '~> 1.1', '>= 1.1.1' # To compile native extensions
 gem 'rspec', '~> 3.13'
 gem 'rspec-collection_matchers', '~> 1.1'
 gem 'rspec-wait', '~> 0'
-
 gem 'rspec_junit_formatter', '>= 0.5.1'
+
+# 1.50 is the last version to support Ruby 2.6
+gem 'rubocop', '~> 1.50.0', require: false
+gem 'rubocop-packaging', '~> 0.5.2', require: false
+gem 'rubocop-performance', '~> 1.9', require: false
+# 2.20 is the last version to support Ruby 2.6
+gem 'rubocop-rspec', ['~> 2.20', '< 2.21'], require: false
 
 # Merging branch coverage results does not work for old, unsupported rubies and JRuby
 # We have a fix up for review, https://github.com/simplecov-ruby/simplecov/pull/972,
@@ -33,27 +50,7 @@ gem 'simplecov-cobertura', '~> 2.1.0' # Used by codecov
 
 gem 'warning', '~> 1' # NOTE: Used in spec_helper.rb
 gem 'webmock', '>= 3.10.0'
-
 gem 'webrick', '>= 1.7.0'
-
-# 1.50 is the last version to support Ruby 2.6
-gem 'rubocop', '~> 1.50.0', require: false
-gem 'rubocop-packaging', '~> 0.5.2', require: false
-gem 'rubocop-performance', '~> 1.9', require: false
-# 2.20 is the last version to support Ruby 2.6
-gem 'rubocop-rspec', ['~> 2.20', '< 2.21'], require: false
-
-# Optional extensions
-# TODO: Move this to Appraisals?
-# dogstatsd v5, but lower than 5.2, has possible memory leak with datadog.
-# @see https://github.com/DataDog/dogstatsd-ruby/issues/182
-gem 'dogstatsd-ruby', '>= 3.3.0', '!= 5.0.0', '!= 5.0.1', '!= 5.1.0'
-
-# Profiler testing dependencies
-# NOTE: We're excluding versions 3.7.0 and 3.7.1 for the reasons documented in #1424.
-#       Since most of our customers won't have BUNDLE_FORCE_RUBY_PLATFORM=true, it's not something we want to add
-#       to our CI, so we just shortcut and exclude specific versions that were affecting our CI.
-gem 'google-protobuf', ['~> 3.0', '!= 3.7.0', '!= 3.7.1']
 
 group :check do
   gem 'rbs', '~> 3.6', require: false

--- a/ruby-3.2.gemfile
+++ b/ruby-3.2.gemfile
@@ -8,22 +8,14 @@ gem 'benchmark-memory', '< 0.2' # V0.2 only works with 2.5+
 gem 'climate_control', '~> 0.2.0'
 
 gem 'concurrent-ruby'
-gem 'extlz4', '~> 0.3', '>= 0.3.3' if RUBY_PLATFORM != 'java' # Used to test lz4 compression done by libdatadog
+gem 'extlz4', '~> 0.3', '>= 0.3.3'
 gem 'json-schema', '< 3' # V3 only works with 2.5+
 gem 'memory_profiler', '~> 0.9'
 
 gem 'os', '~> 1.1'
 gem 'pimpmychangelog', '>= 0.1.2'
 gem 'pry'
-if RUBY_PLATFORM != 'java'
-  # There's a few incompatibilities between pry/pry-byebug on older Rubies
-  # There's also a few temproary incompatibilities with newer rubies
-  gem 'pry-byebug' if RUBY_VERSION >= '2.6.0' && RUBY_ENGINE != 'truffleruby' && RUBY_VERSION < '3.2.0'
-  gem 'pry-nav' if RUBY_VERSION < '2.6.0'
-  gem 'pry-stack_explorer'
-else
-  gem 'pry-debugger-jruby'
-end
+gem 'pry-stack_explorer'
 gem 'rake', '>= 10.5'
 gem 'rake-compiler', '~> 1.1', '>= 1.1.1' # To compile native extensions
 gem 'rspec', '~> 3.13'
@@ -41,21 +33,14 @@ gem 'simplecov-cobertura', '~> 2.1.0' # Used by codecov
 gem 'warning', '~> 1' # NOTE: Used in spec_helper.rb
 gem 'webmock', '>= 3.10.0'
 
-if RUBY_VERSION.start_with?('3.4.')
-  # ruby 3.4 breaks stable webrick; we need this fix until a version later than 1.8.1 comes out
-  gem 'webrick', git: 'https://github.com/ruby/webrick.git', ref: '0c600e169bd4ae267cb5eeb6197277c848323bbe'
-elsif RUBY_VERSION >= '3.0.0' # No longer bundled by default since Ruby 3.0
-  gem 'webrick', '>= 1.7.0'
-end
+gem 'webrick', '>= 1.7.0'
 
-if RUBY_VERSION >= '2.6.0'
-  # 1.50 is the last version to support Ruby 2.6
-  gem 'rubocop', '~> 1.50.0', require: false
-  gem 'rubocop-packaging', '~> 0.5.2', require: false
-  gem 'rubocop-performance', '~> 1.9', require: false
-  # 2.20 is the last version to support Ruby 2.6
-  gem 'rubocop-rspec', ['~> 2.20', '< 2.21'], require: false
-end
+# 1.50 is the last version to support Ruby 2.6
+gem 'rubocop', '~> 1.50.0', require: false
+gem 'rubocop-packaging', '~> 0.5.2', require: false
+gem 'rubocop-performance', '~> 1.9', require: false
+# 2.20 is the last version to support Ruby 2.6
+gem 'rubocop-rspec', ['~> 2.20', '< 2.21'], require: false
 
 # Optional extensions
 # TODO: Move this to Appraisals?
@@ -67,24 +52,15 @@ gem 'dogstatsd-ruby', '>= 3.3.0', '!= 5.0.0', '!= 5.0.1', '!= 5.1.0'
 # NOTE: We're excluding versions 3.7.0 and 3.7.1 for the reasons documented in #1424.
 #       Since most of our customers won't have BUNDLE_FORCE_RUBY_PLATFORM=true, it's not something we want to add
 #       to our CI, so we just shortcut and exclude specific versions that were affecting our CI.
-if RUBY_PLATFORM != 'java'
-  if RUBY_VERSION >= '2.7.0' # Bundler 1.x fails to find that versions >= 3.8.0 are not compatible because of binary gems
-    gem 'google-protobuf', ['~> 3.0', '!= 3.7.0', '!= 3.7.1']
-  else
-    gem 'google-protobuf', ['~> 3.0', '!= 3.7.0', '!= 3.7.1', '< 3.19.2']
-  end
-end
+gem 'google-protobuf', ['~> 3.0', '!= 3.7.0', '!= 3.7.1']
 
 group :check do
-  if RUBY_VERSION >= '3.0.0' && RUBY_PLATFORM != 'java'
-    gem 'rbs', '~> 3.6', require: false
-    gem 'steep', '~> 1.7.0', require: false
-  end
-  gem 'ruby_memcheck', '>= 3' if RUBY_VERSION >= '3.4.0' && RUBY_PLATFORM != 'java'
+  gem 'rbs', '~> 3.6', require: false
+  gem 'steep', '~> 1.7.0', require: false
   gem 'standard', require: false
 end
 
 group :dev do
-  gem 'ruby-lsp', require: false if RUBY_VERSION >= '3.0.0' && RUBY_PLATFORM != 'java'
+  gem 'ruby-lsp', require: false
   gem 'appraisal', '~> 2.4.0', require: false
 end

--- a/ruby-3.2.gemfile
+++ b/ruby-3.2.gemfile
@@ -4,14 +4,25 @@ gemspec
 
 gem 'benchmark-ips', '~> 2.8'
 gem 'benchmark-memory', '< 0.2' # V0.2 only works with 2.5+
-
 gem 'climate_control', '~> 0.2.0'
-
 gem 'concurrent-ruby'
+
+# Optional extensions
+# TODO: Move this to Appraisals?
+# dogstatsd v5, but lower than 5.2, has possible memory leak with datadog.
+# @see https://github.com/DataDog/dogstatsd-ruby/issues/182
+gem 'dogstatsd-ruby', '>= 3.3.0', '!= 5.0.0', '!= 5.0.1', '!= 5.1.0'
+
 gem 'extlz4', '~> 0.3', '>= 0.3.3'
+
+# Profiler testing dependencies
+# NOTE: We're excluding versions 3.7.0 and 3.7.1 for the reasons documented in #1424.
+#       Since most of our customers won't have BUNDLE_FORCE_RUBY_PLATFORM=true, it's not something we want to add
+#       to our CI, so we just shortcut and exclude specific versions that were affecting our CI.
+gem 'google-protobuf', ['~> 3.0', '!= 3.7.0', '!= 3.7.1']
+
 gem 'json-schema', '< 3' # V3 only works with 2.5+
 gem 'memory_profiler', '~> 0.9'
-
 gem 'os', '~> 1.1'
 gem 'pimpmychangelog', '>= 0.1.2'
 gem 'pry'
@@ -21,8 +32,14 @@ gem 'rake-compiler', '~> 1.1', '>= 1.1.1' # To compile native extensions
 gem 'rspec', '~> 3.13'
 gem 'rspec-collection_matchers', '~> 1.1'
 gem 'rspec-wait', '~> 0'
-
 gem 'rspec_junit_formatter', '>= 0.5.1'
+
+# 1.50 is the last version to support Ruby 2.6
+gem 'rubocop', '~> 1.50.0', require: false
+gem 'rubocop-packaging', '~> 0.5.2', require: false
+gem 'rubocop-performance', '~> 1.9', require: false
+# 2.20 is the last version to support Ruby 2.6
+gem 'rubocop-rspec', ['~> 2.20', '< 2.21'], require: false
 
 # Merging branch coverage results does not work for old, unsupported rubies and JRuby
 # We have a fix up for review, https://github.com/simplecov-ruby/simplecov/pull/972,
@@ -32,27 +49,7 @@ gem 'simplecov-cobertura', '~> 2.1.0' # Used by codecov
 
 gem 'warning', '~> 1' # NOTE: Used in spec_helper.rb
 gem 'webmock', '>= 3.10.0'
-
 gem 'webrick', '>= 1.7.0'
-
-# 1.50 is the last version to support Ruby 2.6
-gem 'rubocop', '~> 1.50.0', require: false
-gem 'rubocop-packaging', '~> 0.5.2', require: false
-gem 'rubocop-performance', '~> 1.9', require: false
-# 2.20 is the last version to support Ruby 2.6
-gem 'rubocop-rspec', ['~> 2.20', '< 2.21'], require: false
-
-# Optional extensions
-# TODO: Move this to Appraisals?
-# dogstatsd v5, but lower than 5.2, has possible memory leak with datadog.
-# @see https://github.com/DataDog/dogstatsd-ruby/issues/182
-gem 'dogstatsd-ruby', '>= 3.3.0', '!= 5.0.0', '!= 5.0.1', '!= 5.1.0'
-
-# Profiler testing dependencies
-# NOTE: We're excluding versions 3.7.0 and 3.7.1 for the reasons documented in #1424.
-#       Since most of our customers won't have BUNDLE_FORCE_RUBY_PLATFORM=true, it's not something we want to add
-#       to our CI, so we just shortcut and exclude specific versions that were affecting our CI.
-gem 'google-protobuf', ['~> 3.0', '!= 3.7.0', '!= 3.7.1']
 
 group :check do
   gem 'rbs', '~> 3.6', require: false

--- a/ruby-3.3.gemfile
+++ b/ruby-3.3.gemfile
@@ -8,22 +8,14 @@ gem 'benchmark-memory', '< 0.2' # V0.2 only works with 2.5+
 gem 'climate_control', '~> 0.2.0'
 
 gem 'concurrent-ruby'
-gem 'extlz4', '~> 0.3', '>= 0.3.3' if RUBY_PLATFORM != 'java' # Used to test lz4 compression done by libdatadog
+gem 'extlz4', '~> 0.3', '>= 0.3.3'
 gem 'json-schema', '< 3' # V3 only works with 2.5+
 gem 'memory_profiler', '~> 0.9'
 
 gem 'os', '~> 1.1'
 gem 'pimpmychangelog', '>= 0.1.2'
 gem 'pry'
-if RUBY_PLATFORM != 'java'
-  # There's a few incompatibilities between pry/pry-byebug on older Rubies
-  # There's also a few temproary incompatibilities with newer rubies
-  gem 'pry-byebug' if RUBY_VERSION >= '2.6.0' && RUBY_ENGINE != 'truffleruby' && RUBY_VERSION < '3.2.0'
-  gem 'pry-nav' if RUBY_VERSION < '2.6.0'
-  gem 'pry-stack_explorer'
-else
-  gem 'pry-debugger-jruby'
-end
+gem 'pry-stack_explorer'
 gem 'rake', '>= 10.5'
 gem 'rake-compiler', '~> 1.1', '>= 1.1.1' # To compile native extensions
 gem 'rspec', '~> 3.13'
@@ -41,21 +33,14 @@ gem 'simplecov-cobertura', '~> 2.1.0' # Used by codecov
 gem 'warning', '~> 1' # NOTE: Used in spec_helper.rb
 gem 'webmock', '>= 3.10.0'
 
-if RUBY_VERSION.start_with?('3.4.')
-  # ruby 3.4 breaks stable webrick; we need this fix until a version later than 1.8.1 comes out
-  gem 'webrick', git: 'https://github.com/ruby/webrick.git', ref: '0c600e169bd4ae267cb5eeb6197277c848323bbe'
-elsif RUBY_VERSION >= '3.0.0' # No longer bundled by default since Ruby 3.0
-  gem 'webrick', '>= 1.7.0'
-end
+gem 'webrick', '>= 1.7.0'
 
-if RUBY_VERSION >= '2.6.0'
-  # 1.50 is the last version to support Ruby 2.6
-  gem 'rubocop', '~> 1.50.0', require: false
-  gem 'rubocop-packaging', '~> 0.5.2', require: false
-  gem 'rubocop-performance', '~> 1.9', require: false
-  # 2.20 is the last version to support Ruby 2.6
-  gem 'rubocop-rspec', ['~> 2.20', '< 2.21'], require: false
-end
+# 1.50 is the last version to support Ruby 2.6
+gem 'rubocop', '~> 1.50.0', require: false
+gem 'rubocop-packaging', '~> 0.5.2', require: false
+gem 'rubocop-performance', '~> 1.9', require: false
+# 2.20 is the last version to support Ruby 2.6
+gem 'rubocop-rspec', ['~> 2.20', '< 2.21'], require: false
 
 # Optional extensions
 # TODO: Move this to Appraisals?
@@ -67,24 +52,15 @@ gem 'dogstatsd-ruby', '>= 3.3.0', '!= 5.0.0', '!= 5.0.1', '!= 5.1.0'
 # NOTE: We're excluding versions 3.7.0 and 3.7.1 for the reasons documented in #1424.
 #       Since most of our customers won't have BUNDLE_FORCE_RUBY_PLATFORM=true, it's not something we want to add
 #       to our CI, so we just shortcut and exclude specific versions that were affecting our CI.
-if RUBY_PLATFORM != 'java'
-  if RUBY_VERSION >= '2.7.0' # Bundler 1.x fails to find that versions >= 3.8.0 are not compatible because of binary gems
-    gem 'google-protobuf', ['~> 3.0', '!= 3.7.0', '!= 3.7.1']
-  else
-    gem 'google-protobuf', ['~> 3.0', '!= 3.7.0', '!= 3.7.1', '< 3.19.2']
-  end
-end
+gem 'google-protobuf', ['~> 3.0', '!= 3.7.0', '!= 3.7.1']
 
 group :check do
-  if RUBY_VERSION >= '3.0.0' && RUBY_PLATFORM != 'java'
-    gem 'rbs', '~> 3.6', require: false
-    gem 'steep', '~> 1.7.0', require: false
-  end
-  gem 'ruby_memcheck', '>= 3' if RUBY_VERSION >= '3.4.0' && RUBY_PLATFORM != 'java'
+  gem 'rbs', '~> 3.6', require: false
+  gem 'steep', '~> 1.7.0', require: false
   gem 'standard', require: false
 end
 
 group :dev do
-  gem 'ruby-lsp', require: false if RUBY_VERSION >= '3.0.0' && RUBY_PLATFORM != 'java'
+  gem 'ruby-lsp', require: false
   gem 'appraisal', '~> 2.4.0', require: false
 end

--- a/ruby-3.3.gemfile
+++ b/ruby-3.3.gemfile
@@ -4,14 +4,25 @@ gemspec
 
 gem 'benchmark-ips', '~> 2.8'
 gem 'benchmark-memory', '< 0.2' # V0.2 only works with 2.5+
-
 gem 'climate_control', '~> 0.2.0'
-
 gem 'concurrent-ruby'
+
+# Optional extensions
+# TODO: Move this to Appraisals?
+# dogstatsd v5, but lower than 5.2, has possible memory leak with datadog.
+# @see https://github.com/DataDog/dogstatsd-ruby/issues/182
+gem 'dogstatsd-ruby', '>= 3.3.0', '!= 5.0.0', '!= 5.0.1', '!= 5.1.0'
+
 gem 'extlz4', '~> 0.3', '>= 0.3.3'
+
+# Profiler testing dependencies
+# NOTE: We're excluding versions 3.7.0 and 3.7.1 for the reasons documented in #1424.
+#       Since most of our customers won't have BUNDLE_FORCE_RUBY_PLATFORM=true, it's not something we want to add
+#       to our CI, so we just shortcut and exclude specific versions that were affecting our CI.
+gem 'google-protobuf', ['~> 3.0', '!= 3.7.0', '!= 3.7.1']
+
 gem 'json-schema', '< 3' # V3 only works with 2.5+
 gem 'memory_profiler', '~> 0.9'
-
 gem 'os', '~> 1.1'
 gem 'pimpmychangelog', '>= 0.1.2'
 gem 'pry'
@@ -21,8 +32,14 @@ gem 'rake-compiler', '~> 1.1', '>= 1.1.1' # To compile native extensions
 gem 'rspec', '~> 3.13'
 gem 'rspec-collection_matchers', '~> 1.1'
 gem 'rspec-wait', '~> 0'
-
 gem 'rspec_junit_formatter', '>= 0.5.1'
+
+# 1.50 is the last version to support Ruby 2.6
+gem 'rubocop', '~> 1.50.0', require: false
+gem 'rubocop-packaging', '~> 0.5.2', require: false
+gem 'rubocop-performance', '~> 1.9', require: false
+# 2.20 is the last version to support Ruby 2.6
+gem 'rubocop-rspec', ['~> 2.20', '< 2.21'], require: false
 
 # Merging branch coverage results does not work for old, unsupported rubies and JRuby
 # We have a fix up for review, https://github.com/simplecov-ruby/simplecov/pull/972,
@@ -32,27 +49,7 @@ gem 'simplecov-cobertura', '~> 2.1.0' # Used by codecov
 
 gem 'warning', '~> 1' # NOTE: Used in spec_helper.rb
 gem 'webmock', '>= 3.10.0'
-
 gem 'webrick', '>= 1.7.0'
-
-# 1.50 is the last version to support Ruby 2.6
-gem 'rubocop', '~> 1.50.0', require: false
-gem 'rubocop-packaging', '~> 0.5.2', require: false
-gem 'rubocop-performance', '~> 1.9', require: false
-# 2.20 is the last version to support Ruby 2.6
-gem 'rubocop-rspec', ['~> 2.20', '< 2.21'], require: false
-
-# Optional extensions
-# TODO: Move this to Appraisals?
-# dogstatsd v5, but lower than 5.2, has possible memory leak with datadog.
-# @see https://github.com/DataDog/dogstatsd-ruby/issues/182
-gem 'dogstatsd-ruby', '>= 3.3.0', '!= 5.0.0', '!= 5.0.1', '!= 5.1.0'
-
-# Profiler testing dependencies
-# NOTE: We're excluding versions 3.7.0 and 3.7.1 for the reasons documented in #1424.
-#       Since most of our customers won't have BUNDLE_FORCE_RUBY_PLATFORM=true, it's not something we want to add
-#       to our CI, so we just shortcut and exclude specific versions that were affecting our CI.
-gem 'google-protobuf', ['~> 3.0', '!= 3.7.0', '!= 3.7.1']
 
 group :check do
   gem 'rbs', '~> 3.6', require: false


### PR DESCRIPTION
<!--
Check out the
https://github.com/DataDog/dd-trace-rb/blob/master/docs/DevelopmentGuide.md
for guidance on how to set up your development environment,
run the test suite, write new integrations, and more.
-->

**What does this PR do?**
This PR removes `if` statements and alphabetizes `ruby-3.x.gemfile`s.

**Motivation:**
Since gemfiles are no longer symlinked, we can begin removing `if` statements and generally cleaning each file.

**Change log entry**
None.

**Additional Notes:**
N/A

**How to test the change?**
Green CI.

<!-- Unsure? Have a question? Request a review! -->
