### PR TITLE
Clean Ruby 2.x Gemfiles

### DIFF
--- a/gemfiles/ruby_2.5_activesupport.gemfile
+++ b/gemfiles/ruby_2.5_activesupport.gemfile
@@ -6,7 +6,9 @@ gem "benchmark-ips", "~> 2.8"
 gem "benchmark-memory", "< 0.2"
 gem "climate_control", "~> 0.2.0"
 gem "concurrent-ruby"
+gem "dogstatsd-ruby", ">= 3.3.0", "!= 5.0.0", "!= 5.0.1", "!= 5.1.0"
 gem "extlz4", "~> 0.3", ">= 0.3.3"
+gem "google-protobuf", ["~> 3.0", "!= 3.7.0", "!= 3.7.1", "< 3.19.2"]
 gem "json-schema", "< 3"
 gem "memory_profiler", "~> 0.9"
 gem "os", "~> 1.1"
@@ -24,8 +26,6 @@ gem "simplecov", git: "https://github.com/DataDog/simplecov", ref: "3bb6b7ee58bf
 gem "simplecov-cobertura", "~> 2.1.0"
 gem "warning", "~> 1"
 gem "webmock", ">= 3.10.0"
-gem "dogstatsd-ruby", ">= 3.3.0", "!= 5.0.0", "!= 5.0.1", "!= 5.1.0"
-gem "google-protobuf", ["~> 3.0", "!= 3.7.0", "!= 3.7.1", "< 3.19.2"]
 gem "activesupport", "~> 5"
 gem "actionpack"
 gem "actionview"

--- a/gemfiles/ruby_2.5_aws.gemfile
+++ b/gemfiles/ruby_2.5_aws.gemfile
@@ -6,7 +6,9 @@ gem "benchmark-ips", "~> 2.8"
 gem "benchmark-memory", "< 0.2"
 gem "climate_control", "~> 0.2.0"
 gem "concurrent-ruby"
+gem "dogstatsd-ruby", ">= 3.3.0", "!= 5.0.0", "!= 5.0.1", "!= 5.1.0"
 gem "extlz4", "~> 0.3", ">= 0.3.3"
+gem "google-protobuf", ["~> 3.0", "!= 3.7.0", "!= 3.7.1", "< 3.19.2"]
 gem "json-schema", "< 3"
 gem "memory_profiler", "~> 0.9"
 gem "os", "~> 1.1"
@@ -24,8 +26,6 @@ gem "simplecov", git: "https://github.com/DataDog/simplecov", ref: "3bb6b7ee58bf
 gem "simplecov-cobertura", "~> 2.1.0"
 gem "warning", "~> 1"
 gem "webmock", ">= 3.10.0"
-gem "dogstatsd-ruby", ">= 3.3.0", "!= 5.0.0", "!= 5.0.1", "!= 5.1.0"
-gem "google-protobuf", ["~> 3.0", "!= 3.7.0", "!= 3.7.1", "< 3.19.2"]
 gem "aws-sdk"
 gem "shoryuken"
 

--- a/gemfiles/ruby_2.5_contrib.gemfile
+++ b/gemfiles/ruby_2.5_contrib.gemfile
@@ -6,7 +6,9 @@ gem "benchmark-ips", "~> 2.8"
 gem "benchmark-memory", "< 0.2"
 gem "climate_control", "~> 0.2.0"
 gem "concurrent-ruby"
+gem "dogstatsd-ruby", ">= 3.3.0", "!= 5.0.0", "!= 5.0.1", "!= 5.1.0"
 gem "extlz4", "~> 0.3", ">= 0.3.3"
+gem "google-protobuf", ["~> 3.0", "!= 3.7.0", "!= 3.7.1", "< 3.19.2"]
 gem "json-schema", "< 3"
 gem "memory_profiler", "~> 0.9"
 gem "os", "~> 1.1"
@@ -24,8 +26,6 @@ gem "simplecov", git: "https://github.com/DataDog/simplecov", ref: "3bb6b7ee58bf
 gem "simplecov-cobertura", "~> 2.1.0"
 gem "warning", "~> 1"
 gem "webmock", ">= 3.10.0"
-gem "dogstatsd-ruby", ">= 3.3.0", "!= 5.0.0", "!= 5.0.1", "!= 5.1.0"
-gem "google-protobuf", ["~> 3.0", "!= 3.7.0", "!= 3.7.1", "< 3.19.2"]
 gem "dalli", ">= 3.0.0"
 gem "grpc", platform: :ruby
 gem "mongo", ">= 2.8.0", "< 2.15.0"

--- a/gemfiles/ruby_2.5_contrib_old.gemfile
+++ b/gemfiles/ruby_2.5_contrib_old.gemfile
@@ -6,7 +6,9 @@ gem "benchmark-ips", "~> 2.8"
 gem "benchmark-memory", "< 0.2"
 gem "climate_control", "~> 0.2.0"
 gem "concurrent-ruby"
+gem "dogstatsd-ruby", ">= 3.3.0", "!= 5.0.0", "!= 5.0.1", "!= 5.1.0"
 gem "extlz4", "~> 0.3", ">= 0.3.3"
+gem "google-protobuf", ["~> 3.0", "!= 3.7.0", "!= 3.7.1", "< 3.19.2"]
 gem "json-schema", "< 3"
 gem "memory_profiler", "~> 0.9"
 gem "os", "~> 1.1"
@@ -24,8 +26,6 @@ gem "simplecov", git: "https://github.com/DataDog/simplecov", ref: "3bb6b7ee58bf
 gem "simplecov-cobertura", "~> 2.1.0"
 gem "warning", "~> 1"
 gem "webmock", ">= 3.10.0"
-gem "dogstatsd-ruby", ">= 3.3.0", "!= 5.0.0", "!= 5.0.1", "!= 5.1.0"
-gem "google-protobuf", ["~> 3.0", "!= 3.7.0", "!= 3.7.1", "< 3.19.2"]
 gem "dalli", "< 3.0.0"
 gem "faraday", "0.17"
 gem "presto-client", ">= 0.5.14"

--- a/gemfiles/ruby_2.5_core_old.gemfile
+++ b/gemfiles/ruby_2.5_core_old.gemfile
@@ -6,7 +6,9 @@ gem "benchmark-ips", "~> 2.8"
 gem "benchmark-memory", "< 0.2"
 gem "climate_control", "~> 0.2.0"
 gem "concurrent-ruby"
+gem "dogstatsd-ruby", "~> 4"
 gem "extlz4", "~> 0.3", ">= 0.3.3"
+gem "google-protobuf", ["~> 3.0", "!= 3.7.0", "!= 3.7.1", "< 3.19.2"]
 gem "json-schema", "< 3"
 gem "memory_profiler", "~> 0.9"
 gem "os", "~> 1.1"
@@ -24,8 +26,6 @@ gem "simplecov", git: "https://github.com/DataDog/simplecov", ref: "3bb6b7ee58bf
 gem "simplecov-cobertura", "~> 2.1.0"
 gem "warning", "~> 1"
 gem "webmock", ">= 3.10.0"
-gem "dogstatsd-ruby", "~> 4"
-gem "google-protobuf", ["~> 3.0", "!= 3.7.0", "!= 3.7.1", "< 3.19.2"]
 
 group :check do
 

--- a/gemfiles/ruby_2.5_elasticsearch_7.gemfile
+++ b/gemfiles/ruby_2.5_elasticsearch_7.gemfile
@@ -6,7 +6,9 @@ gem "benchmark-ips", "~> 2.8"
 gem "benchmark-memory", "< 0.2"
 gem "climate_control", "~> 0.2.0"
 gem "concurrent-ruby"
+gem "dogstatsd-ruby", ">= 3.3.0", "!= 5.0.0", "!= 5.0.1", "!= 5.1.0"
 gem "extlz4", "~> 0.3", ">= 0.3.3"
+gem "google-protobuf", ["~> 3.0", "!= 3.7.0", "!= 3.7.1", "< 3.19.2"]
 gem "json-schema", "< 3"
 gem "memory_profiler", "~> 0.9"
 gem "os", "~> 1.1"
@@ -24,8 +26,6 @@ gem "simplecov", git: "https://github.com/DataDog/simplecov", ref: "3bb6b7ee58bf
 gem "simplecov-cobertura", "~> 2.1.0"
 gem "warning", "~> 1"
 gem "webmock", ">= 3.10.0"
-gem "dogstatsd-ruby", ">= 3.3.0", "!= 5.0.0", "!= 5.0.1", "!= 5.1.0"
-gem "google-protobuf", ["~> 3.0", "!= 3.7.0", "!= 3.7.1", "< 3.19.2"]
 gem "elasticsearch", "~> 7"
 
 group :check do

--- a/gemfiles/ruby_2.5_elasticsearch_8.gemfile
+++ b/gemfiles/ruby_2.5_elasticsearch_8.gemfile
@@ -6,7 +6,9 @@ gem "benchmark-ips", "~> 2.8"
 gem "benchmark-memory", "< 0.2"
 gem "climate_control", "~> 0.2.0"
 gem "concurrent-ruby"
+gem "dogstatsd-ruby", ">= 3.3.0", "!= 5.0.0", "!= 5.0.1", "!= 5.1.0"
 gem "extlz4", "~> 0.3", ">= 0.3.3"
+gem "google-protobuf", ["~> 3.0", "!= 3.7.0", "!= 3.7.1", "< 3.19.2"]
 gem "json-schema", "< 3"
 gem "memory_profiler", "~> 0.9"
 gem "os", "~> 1.1"
@@ -24,8 +26,6 @@ gem "simplecov", git: "https://github.com/DataDog/simplecov", ref: "3bb6b7ee58bf
 gem "simplecov-cobertura", "~> 2.1.0"
 gem "warning", "~> 1"
 gem "webmock", ">= 3.10.0"
-gem "dogstatsd-ruby", ">= 3.3.0", "!= 5.0.0", "!= 5.0.1", "!= 5.1.0"
-gem "google-protobuf", ["~> 3.0", "!= 3.7.0", "!= 3.7.1", "< 3.19.2"]
 gem "elasticsearch", "~> 8"
 
 group :check do

--- a/gemfiles/ruby_2.5_elasticsearch_latest.gemfile
+++ b/gemfiles/ruby_2.5_elasticsearch_latest.gemfile
@@ -6,7 +6,9 @@ gem "benchmark-ips", "~> 2.8"
 gem "benchmark-memory", "< 0.2"
 gem "climate_control", "~> 0.2.0"
 gem "concurrent-ruby"
+gem "dogstatsd-ruby", ">= 3.3.0", "!= 5.0.0", "!= 5.0.1", "!= 5.1.0"
 gem "extlz4", "~> 0.3", ">= 0.3.3"
+gem "google-protobuf", ["~> 3.0", "!= 3.7.0", "!= 3.7.1", "< 3.19.2"]
 gem "json-schema", "< 3"
 gem "memory_profiler", "~> 0.9"
 gem "os", "~> 1.1"
@@ -24,8 +26,6 @@ gem "simplecov", git: "https://github.com/DataDog/simplecov", ref: "3bb6b7ee58bf
 gem "simplecov-cobertura", "~> 2.1.0"
 gem "warning", "~> 1"
 gem "webmock", ">= 3.10.0"
-gem "dogstatsd-ruby", ">= 3.3.0", "!= 5.0.0", "!= 5.0.1", "!= 5.1.0"
-gem "google-protobuf", ["~> 3.0", "!= 3.7.0", "!= 3.7.1", "< 3.19.2"]
 gem "elasticsearch"
 
 group :check do

--- a/gemfiles/ruby_2.5_graphql_2.0.gemfile
+++ b/gemfiles/ruby_2.5_graphql_2.0.gemfile
@@ -6,7 +6,9 @@ gem "benchmark-ips", "~> 2.8"
 gem "benchmark-memory", "< 0.2"
 gem "climate_control", "~> 0.2.0"
 gem "concurrent-ruby"
+gem "dogstatsd-ruby", ">= 3.3.0", "!= 5.0.0", "!= 5.0.1", "!= 5.1.0"
 gem "extlz4", "~> 0.3", ">= 0.3.3"
+gem "google-protobuf", ["~> 3.0", "!= 3.7.0", "!= 3.7.1", "< 3.19.2"]
 gem "json-schema", "< 3"
 gem "memory_profiler", "~> 0.9"
 gem "os", "~> 1.1"
@@ -24,8 +26,6 @@ gem "simplecov", git: "https://github.com/DataDog/simplecov", ref: "3bb6b7ee58bf
 gem "simplecov-cobertura", "~> 2.1.0"
 gem "warning", "~> 1"
 gem "webmock", ">= 3.10.0"
-gem "dogstatsd-ruby", ">= 3.3.0", "!= 5.0.0", "!= 5.0.1", "!= 5.1.0"
-gem "google-protobuf", ["~> 3.0", "!= 3.7.0", "!= 3.7.1", "< 3.19.2"]
 gem "rails", "~> 6.1.0"
 gem "graphql", "~> 2.0.0"
 gem "sprockets", "< 4"

--- a/gemfiles/ruby_2.5_hanami_1.gemfile
+++ b/gemfiles/ruby_2.5_hanami_1.gemfile
@@ -6,7 +6,9 @@ gem "benchmark-ips", "~> 2.8"
 gem "benchmark-memory", "< 0.2"
 gem "climate_control", "~> 0.2.0"
 gem "concurrent-ruby"
+gem "dogstatsd-ruby", ">= 3.3.0", "!= 5.0.0", "!= 5.0.1", "!= 5.1.0"
 gem "extlz4", "~> 0.3", ">= 0.3.3"
+gem "google-protobuf", ["~> 3.0", "!= 3.7.0", "!= 3.7.1", "< 3.19.2"]
 gem "json-schema", "< 3"
 gem "memory_profiler", "~> 0.9"
 gem "os", "~> 1.1"
@@ -24,8 +26,6 @@ gem "simplecov", git: "https://github.com/DataDog/simplecov", ref: "3bb6b7ee58bf
 gem "simplecov-cobertura", "~> 2.1.0"
 gem "warning", "~> 1"
 gem "webmock", ">= 3.10.0"
-gem "dogstatsd-ruby", ">= 3.3.0", "!= 5.0.0", "!= 5.0.1", "!= 5.1.0"
-gem "google-protobuf", ["~> 3.0", "!= 3.7.0", "!= 3.7.1", "< 3.19.2"]
 gem "rack"
 gem "rack-test"
 gem "hanami", "~> 1"

--- a/gemfiles/ruby_2.5_http.gemfile
+++ b/gemfiles/ruby_2.5_http.gemfile
@@ -6,7 +6,9 @@ gem "benchmark-ips", "~> 2.8"
 gem "benchmark-memory", "< 0.2"
 gem "climate_control", "~> 0.2.0"
 gem "concurrent-ruby"
+gem "dogstatsd-ruby", ">= 3.3.0", "!= 5.0.0", "!= 5.0.1", "!= 5.1.0"
 gem "extlz4", "~> 0.3", ">= 0.3.3"
+gem "google-protobuf", ["~> 3.0", "!= 3.7.0", "!= 3.7.1", "< 3.19.2"]
 gem "json-schema", "< 3"
 gem "memory_profiler", "~> 0.9"
 gem "os", "~> 1.1"
@@ -24,8 +26,6 @@ gem "simplecov", git: "https://github.com/DataDog/simplecov", ref: "3bb6b7ee58bf
 gem "simplecov-cobertura", "~> 2.1.0"
 gem "warning", "~> 1"
 gem "webmock", ">= 3.10.0"
-gem "dogstatsd-ruby", ">= 3.3.0", "!= 5.0.0", "!= 5.0.1", "!= 5.1.0"
-gem "google-protobuf", ["~> 3.0", "!= 3.7.0", "!= 3.7.1", "< 3.19.2"]
 gem "ethon"
 gem "excon"
 gem "faraday"

--- a/gemfiles/ruby_2.5_opensearch_2.gemfile
+++ b/gemfiles/ruby_2.5_opensearch_2.gemfile
@@ -6,7 +6,9 @@ gem "benchmark-ips", "~> 2.8"
 gem "benchmark-memory", "< 0.2"
 gem "climate_control", "~> 0.2.0"
 gem "concurrent-ruby"
+gem "dogstatsd-ruby", ">= 3.3.0", "!= 5.0.0", "!= 5.0.1", "!= 5.1.0"
 gem "extlz4", "~> 0.3", ">= 0.3.3"
+gem "google-protobuf", ["~> 3.0", "!= 3.7.0", "!= 3.7.1", "< 3.19.2"]
 gem "json-schema", "< 3"
 gem "memory_profiler", "~> 0.9"
 gem "os", "~> 1.1"
@@ -24,8 +26,6 @@ gem "simplecov", git: "https://github.com/DataDog/simplecov", ref: "3bb6b7ee58bf
 gem "simplecov-cobertura", "~> 2.1.0"
 gem "warning", "~> 1"
 gem "webmock", ">= 3.10.0"
-gem "dogstatsd-ruby", ">= 3.3.0", "!= 5.0.0", "!= 5.0.1", "!= 5.1.0"
-gem "google-protobuf", ["~> 3.0", "!= 3.7.0", "!= 3.7.1", "< 3.19.2"]
 gem "opensearch-ruby", "~> 2"
 
 group :check do

--- a/gemfiles/ruby_2.5_opensearch_3.gemfile
+++ b/gemfiles/ruby_2.5_opensearch_3.gemfile
@@ -6,7 +6,9 @@ gem "benchmark-ips", "~> 2.8"
 gem "benchmark-memory", "< 0.2"
 gem "climate_control", "~> 0.2.0"
 gem "concurrent-ruby"
+gem "dogstatsd-ruby", ">= 3.3.0", "!= 5.0.0", "!= 5.0.1", "!= 5.1.0"
 gem "extlz4", "~> 0.3", ">= 0.3.3"
+gem "google-protobuf", ["~> 3.0", "!= 3.7.0", "!= 3.7.1", "< 3.19.2"]
 gem "json-schema", "< 3"
 gem "memory_profiler", "~> 0.9"
 gem "os", "~> 1.1"
@@ -24,8 +26,6 @@ gem "simplecov", git: "https://github.com/DataDog/simplecov", ref: "3bb6b7ee58bf
 gem "simplecov-cobertura", "~> 2.1.0"
 gem "warning", "~> 1"
 gem "webmock", ">= 3.10.0"
-gem "dogstatsd-ruby", ">= 3.3.0", "!= 5.0.0", "!= 5.0.1", "!= 5.1.0"
-gem "google-protobuf", ["~> 3.0", "!= 3.7.0", "!= 3.7.1", "< 3.19.2"]
 gem "opensearch-ruby", "~> 3"
 
 group :check do

--- a/gemfiles/ruby_2.5_opensearch_latest.gemfile
+++ b/gemfiles/ruby_2.5_opensearch_latest.gemfile
@@ -6,7 +6,9 @@ gem "benchmark-ips", "~> 2.8"
 gem "benchmark-memory", "< 0.2"
 gem "climate_control", "~> 0.2.0"
 gem "concurrent-ruby"
+gem "dogstatsd-ruby", ">= 3.3.0", "!= 5.0.0", "!= 5.0.1", "!= 5.1.0"
 gem "extlz4", "~> 0.3", ">= 0.3.3"
+gem "google-protobuf", ["~> 3.0", "!= 3.7.0", "!= 3.7.1", "< 3.19.2"]
 gem "json-schema", "< 3"
 gem "memory_profiler", "~> 0.9"
 gem "os", "~> 1.1"
@@ -24,8 +26,6 @@ gem "simplecov", git: "https://github.com/DataDog/simplecov", ref: "3bb6b7ee58bf
 gem "simplecov-cobertura", "~> 2.1.0"
 gem "warning", "~> 1"
 gem "webmock", ">= 3.10.0"
-gem "dogstatsd-ruby", ">= 3.3.0", "!= 5.0.0", "!= 5.0.1", "!= 5.1.0"
-gem "google-protobuf", ["~> 3.0", "!= 3.7.0", "!= 3.7.1", "< 3.19.2"]
 gem "opensearch-ruby"
 
 group :check do

--- a/gemfiles/ruby_2.5_rack_1.gemfile
+++ b/gemfiles/ruby_2.5_rack_1.gemfile
@@ -6,7 +6,9 @@ gem "benchmark-ips", "~> 2.8"
 gem "benchmark-memory", "< 0.2"
 gem "climate_control", "~> 0.2.0"
 gem "concurrent-ruby"
+gem "dogstatsd-ruby", ">= 3.3.0", "!= 5.0.0", "!= 5.0.1", "!= 5.1.0"
 gem "extlz4", "~> 0.3", ">= 0.3.3"
+gem "google-protobuf", ["~> 3.0", "!= 3.7.0", "!= 3.7.1", "< 3.19.2"]
 gem "json-schema", "< 3"
 gem "memory_profiler", "~> 0.9"
 gem "os", "~> 1.1"
@@ -24,8 +26,6 @@ gem "simplecov", git: "https://github.com/DataDog/simplecov", ref: "3bb6b7ee58bf
 gem "simplecov-cobertura", "~> 2.1.0"
 gem "warning", "~> 1"
 gem "webmock", ">= 3.10.0"
-gem "dogstatsd-ruby", ">= 3.3.0", "!= 5.0.0", "!= 5.0.1", "!= 5.1.0"
-gem "google-protobuf", ["~> 3.0", "!= 3.7.0", "!= 3.7.1", "< 3.19.2"]
 gem "rack", "~> 1"
 gem "rack-contrib"
 gem "rack-test"

--- a/gemfiles/ruby_2.5_rack_2.gemfile
+++ b/gemfiles/ruby_2.5_rack_2.gemfile
@@ -6,7 +6,9 @@ gem "benchmark-ips", "~> 2.8"
 gem "benchmark-memory", "< 0.2"
 gem "climate_control", "~> 0.2.0"
 gem "concurrent-ruby"
+gem "dogstatsd-ruby", ">= 3.3.0", "!= 5.0.0", "!= 5.0.1", "!= 5.1.0"
 gem "extlz4", "~> 0.3", ">= 0.3.3"
+gem "google-protobuf", ["~> 3.0", "!= 3.7.0", "!= 3.7.1", "< 3.19.2"]
 gem "json-schema", "< 3"
 gem "memory_profiler", "~> 0.9"
 gem "os", "~> 1.1"
@@ -24,8 +26,6 @@ gem "simplecov", git: "https://github.com/DataDog/simplecov", ref: "3bb6b7ee58bf
 gem "simplecov-cobertura", "~> 2.1.0"
 gem "warning", "~> 1"
 gem "webmock", ">= 3.10.0"
-gem "dogstatsd-ruby", ">= 3.3.0", "!= 5.0.0", "!= 5.0.1", "!= 5.1.0"
-gem "google-protobuf", ["~> 3.0", "!= 3.7.0", "!= 3.7.1", "< 3.19.2"]
 gem "rack", "~> 2"
 gem "rack-contrib"
 gem "rack-test"

--- a/gemfiles/ruby_2.5_rack_3.gemfile
+++ b/gemfiles/ruby_2.5_rack_3.gemfile
@@ -6,7 +6,9 @@ gem "benchmark-ips", "~> 2.8"
 gem "benchmark-memory", "< 0.2"
 gem "climate_control", "~> 0.2.0"
 gem "concurrent-ruby"
+gem "dogstatsd-ruby", ">= 3.3.0", "!= 5.0.0", "!= 5.0.1", "!= 5.1.0"
 gem "extlz4", "~> 0.3", ">= 0.3.3"
+gem "google-protobuf", ["~> 3.0", "!= 3.7.0", "!= 3.7.1", "< 3.19.2"]
 gem "json-schema", "< 3"
 gem "memory_profiler", "~> 0.9"
 gem "os", "~> 1.1"
@@ -24,8 +26,6 @@ gem "simplecov", git: "https://github.com/DataDog/simplecov", ref: "3bb6b7ee58bf
 gem "simplecov-cobertura", "~> 2.1.0"
 gem "warning", "~> 1"
 gem "webmock", ">= 3.10.0"
-gem "dogstatsd-ruby", ">= 3.3.0", "!= 5.0.0", "!= 5.0.1", "!= 5.1.0"
-gem "google-protobuf", ["~> 3.0", "!= 3.7.0", "!= 3.7.1", "< 3.19.2"]
 gem "rack", "~> 3"
 gem "rack-contrib"
 gem "rack-test"

--- a/gemfiles/ruby_2.5_rack_latest.gemfile
+++ b/gemfiles/ruby_2.5_rack_latest.gemfile
@@ -6,7 +6,9 @@ gem "benchmark-ips", "~> 2.8"
 gem "benchmark-memory", "< 0.2"
 gem "climate_control", "~> 0.2.0"
 gem "concurrent-ruby"
+gem "dogstatsd-ruby", ">= 3.3.0", "!= 5.0.0", "!= 5.0.1", "!= 5.1.0"
 gem "extlz4", "~> 0.3", ">= 0.3.3"
+gem "google-protobuf", ["~> 3.0", "!= 3.7.0", "!= 3.7.1", "< 3.19.2"]
 gem "json-schema", "< 3"
 gem "memory_profiler", "~> 0.9"
 gem "os", "~> 1.1"
@@ -24,8 +26,6 @@ gem "simplecov", git: "https://github.com/DataDog/simplecov", ref: "3bb6b7ee58bf
 gem "simplecov-cobertura", "~> 2.1.0"
 gem "warning", "~> 1"
 gem "webmock", ">= 3.10.0"
-gem "dogstatsd-ruby", ">= 3.3.0", "!= 5.0.0", "!= 5.0.1", "!= 5.1.0"
-gem "google-protobuf", ["~> 3.0", "!= 3.7.0", "!= 3.7.1", "< 3.19.2"]
 gem "rack"
 gem "rack-contrib"
 gem "rack-test"

--- a/gemfiles/ruby_2.5_rails4_mysql2.gemfile
+++ b/gemfiles/ruby_2.5_rails4_mysql2.gemfile
@@ -6,7 +6,9 @@ gem "benchmark-ips", "~> 2.8"
 gem "benchmark-memory", "< 0.2"
 gem "climate_control", "~> 0.2.0"
 gem "concurrent-ruby"
+gem "dogstatsd-ruby", ">= 3.3.0", "!= 5.0.0", "!= 5.0.1", "!= 5.1.0"
 gem "extlz4", "~> 0.3", ">= 0.3.3"
+gem "google-protobuf", ["~> 3.0", "!= 3.7.0", "!= 3.7.1", "< 3.19.2"]
 gem "json-schema", "< 3"
 gem "memory_profiler", "~> 0.9"
 gem "os", "~> 1.1"
@@ -24,8 +26,6 @@ gem "simplecov", git: "https://github.com/DataDog/simplecov", ref: "3bb6b7ee58bf
 gem "simplecov-cobertura", "~> 2.1.0"
 gem "warning", "~> 1"
 gem "webmock", ">= 3.10.0"
-gem "dogstatsd-ruby", ">= 3.3.0", "!= 5.0.0", "!= 5.0.1", "!= 5.1.0"
-gem "google-protobuf", ["~> 3.0", "!= 3.7.0", "!= 3.7.1", "< 3.19.2"]
 gem "rails", git: "https://github.com/DataDog/rails", ref: "592dfae8747db3bb28c3292a9730817f0fa76885"
 gem "mysql2", "< 1"
 gem "sprockets", "< 4"

--- a/gemfiles/ruby_2.5_rails4_postgres.gemfile
+++ b/gemfiles/ruby_2.5_rails4_postgres.gemfile
@@ -6,7 +6,9 @@ gem "benchmark-ips", "~> 2.8"
 gem "benchmark-memory", "< 0.2"
 gem "climate_control", "~> 0.2.0"
 gem "concurrent-ruby"
+gem "dogstatsd-ruby", ">= 3.3.0", "!= 5.0.0", "!= 5.0.1", "!= 5.1.0"
 gem "extlz4", "~> 0.3", ">= 0.3.3"
+gem "google-protobuf", ["~> 3.0", "!= 3.7.0", "!= 3.7.1", "< 3.19.2"]
 gem "json-schema", "< 3"
 gem "memory_profiler", "~> 0.9"
 gem "os", "~> 1.1"
@@ -24,8 +26,6 @@ gem "simplecov", git: "https://github.com/DataDog/simplecov", ref: "3bb6b7ee58bf
 gem "simplecov-cobertura", "~> 2.1.0"
 gem "warning", "~> 1"
 gem "webmock", ">= 3.10.0"
-gem "dogstatsd-ruby", ">= 3.3.0", "!= 5.0.0", "!= 5.0.1", "!= 5.1.0"
-gem "google-protobuf", ["~> 3.0", "!= 3.7.0", "!= 3.7.1", "< 3.19.2"]
 gem "rails", git: "https://github.com/DataDog/rails", ref: "592dfae8747db3bb28c3292a9730817f0fa76885"
 gem "pg", "< 1.0"
 gem "sprockets", "< 4"

--- a/gemfiles/ruby_2.5_rails4_postgres_redis.gemfile
+++ b/gemfiles/ruby_2.5_rails4_postgres_redis.gemfile
@@ -6,7 +6,9 @@ gem "benchmark-ips", "~> 2.8"
 gem "benchmark-memory", "< 0.2"
 gem "climate_control", "~> 0.2.0"
 gem "concurrent-ruby"
+gem "dogstatsd-ruby", ">= 3.3.0", "!= 5.0.0", "!= 5.0.1", "!= 5.1.0"
 gem "extlz4", "~> 0.3", ">= 0.3.3"
+gem "google-protobuf", ["~> 3.0", "!= 3.7.0", "!= 3.7.1", "< 3.19.2"]
 gem "json-schema", "< 3"
 gem "memory_profiler", "~> 0.9"
 gem "os", "~> 1.1"
@@ -24,8 +26,6 @@ gem "simplecov", git: "https://github.com/DataDog/simplecov", ref: "3bb6b7ee58bf
 gem "simplecov-cobertura", "~> 2.1.0"
 gem "warning", "~> 1"
 gem "webmock", ">= 3.10.0"
-gem "dogstatsd-ruby", ">= 3.3.0", "!= 5.0.0", "!= 5.0.1", "!= 5.1.0"
-gem "google-protobuf", ["~> 3.0", "!= 3.7.0", "!= 3.7.1", "< 3.19.2"]
 gem "rails", git: "https://github.com/DataDog/rails", ref: "592dfae8747db3bb28c3292a9730817f0fa76885"
 gem "pg", "< 1.0"
 gem "redis-rails"

--- a/gemfiles/ruby_2.5_rails4_postgres_sidekiq.gemfile
+++ b/gemfiles/ruby_2.5_rails4_postgres_sidekiq.gemfile
@@ -6,7 +6,9 @@ gem "benchmark-ips", "~> 2.8"
 gem "benchmark-memory", "< 0.2"
 gem "climate_control", "~> 0.2.0"
 gem "concurrent-ruby"
+gem "dogstatsd-ruby", ">= 3.3.0", "!= 5.0.0", "!= 5.0.1", "!= 5.1.0"
 gem "extlz4", "~> 0.3", ">= 0.3.3"
+gem "google-protobuf", ["~> 3.0", "!= 3.7.0", "!= 3.7.1", "< 3.19.2"]
 gem "json-schema", "< 3"
 gem "memory_profiler", "~> 0.9"
 gem "os", "~> 1.1"
@@ -24,8 +26,6 @@ gem "simplecov", git: "https://github.com/DataDog/simplecov", ref: "3bb6b7ee58bf
 gem "simplecov-cobertura", "~> 2.1.0"
 gem "warning", "~> 1"
 gem "webmock", ">= 3.10.0"
-gem "dogstatsd-ruby", ">= 3.3.0", "!= 5.0.0", "!= 5.0.1", "!= 5.1.0"
-gem "google-protobuf", ["~> 3.0", "!= 3.7.0", "!= 3.7.1", "< 3.19.2"]
 gem "rails", git: "https://github.com/DataDog/rails", ref: "592dfae8747db3bb28c3292a9730817f0fa76885"
 gem "pg", "< 1.0"
 gem "sidekiq"

--- a/gemfiles/ruby_2.5_rails4_semantic_logger.gemfile
+++ b/gemfiles/ruby_2.5_rails4_semantic_logger.gemfile
@@ -6,7 +6,9 @@ gem "benchmark-ips", "~> 2.8"
 gem "benchmark-memory", "< 0.2"
 gem "climate_control", "~> 0.2.0"
 gem "concurrent-ruby"
+gem "dogstatsd-ruby", ">= 3.3.0", "!= 5.0.0", "!= 5.0.1", "!= 5.1.0"
 gem "extlz4", "~> 0.3", ">= 0.3.3"
+gem "google-protobuf", ["~> 3.0", "!= 3.7.0", "!= 3.7.1", "< 3.19.2"]
 gem "json-schema", "< 3"
 gem "memory_profiler", "~> 0.9"
 gem "os", "~> 1.1"
@@ -24,8 +26,6 @@ gem "simplecov", git: "https://github.com/DataDog/simplecov", ref: "3bb6b7ee58bf
 gem "simplecov-cobertura", "~> 2.1.0"
 gem "warning", "~> 1"
 gem "webmock", ">= 3.10.0"
-gem "dogstatsd-ruby", ">= 3.3.0", "!= 5.0.0", "!= 5.0.1", "!= 5.1.0"
-gem "google-protobuf", ["~> 3.0", "!= 3.7.0", "!= 3.7.1", "< 3.19.2"]
 gem "rails", git: "https://github.com/DataDog/rails", ref: "592dfae8747db3bb28c3292a9730817f0fa76885"
 gem "pg", "< 1.0"
 gem "sprockets", "< 4"

--- a/gemfiles/ruby_2.5_rails5_mysql2.gemfile
+++ b/gemfiles/ruby_2.5_rails5_mysql2.gemfile
@@ -6,7 +6,9 @@ gem "benchmark-ips", "~> 2.8"
 gem "benchmark-memory", "< 0.2"
 gem "climate_control", "~> 0.2.0"
 gem "concurrent-ruby"
+gem "dogstatsd-ruby", ">= 3.3.0", "!= 5.0.0", "!= 5.0.1", "!= 5.1.0"
 gem "extlz4", "~> 0.3", ">= 0.3.3"
+gem "google-protobuf", ["~> 3.0", "!= 3.7.0", "!= 3.7.1", "< 3.19.2"]
 gem "json-schema", "< 3"
 gem "memory_profiler", "~> 0.9"
 gem "os", "~> 1.1"
@@ -24,8 +26,6 @@ gem "simplecov", git: "https://github.com/DataDog/simplecov", ref: "3bb6b7ee58bf
 gem "simplecov-cobertura", "~> 2.1.0"
 gem "warning", "~> 1"
 gem "webmock", ">= 3.10.0"
-gem "dogstatsd-ruby", ">= 3.3.0", "!= 5.0.0", "!= 5.0.1", "!= 5.1.0"
-gem "google-protobuf", ["~> 3.0", "!= 3.7.0", "!= 3.7.1", "< 3.19.2"]
 gem "rails", "~> 5.2.1"
 gem "mysql2", "< 1", platform: :ruby
 gem "sprockets", "< 4"

--- a/gemfiles/ruby_2.5_rails5_postgres.gemfile
+++ b/gemfiles/ruby_2.5_rails5_postgres.gemfile
@@ -6,7 +6,9 @@ gem "benchmark-ips", "~> 2.8"
 gem "benchmark-memory", "< 0.2"
 gem "climate_control", "~> 0.2.0"
 gem "concurrent-ruby"
+gem "dogstatsd-ruby", ">= 3.3.0", "!= 5.0.0", "!= 5.0.1", "!= 5.1.0"
 gem "extlz4", "~> 0.3", ">= 0.3.3"
+gem "google-protobuf", ["~> 3.0", "!= 3.7.0", "!= 3.7.1", "< 3.19.2"]
 gem "json-schema", "< 3"
 gem "memory_profiler", "~> 0.9"
 gem "os", "~> 1.1"
@@ -24,8 +26,6 @@ gem "simplecov", git: "https://github.com/DataDog/simplecov", ref: "3bb6b7ee58bf
 gem "simplecov-cobertura", "~> 2.1.0"
 gem "warning", "~> 1"
 gem "webmock", ">= 3.10.0"
-gem "dogstatsd-ruby", ">= 3.3.0", "!= 5.0.0", "!= 5.0.1", "!= 5.1.0"
-gem "google-protobuf", ["~> 3.0", "!= 3.7.0", "!= 3.7.1", "< 3.19.2"]
 gem "rails", "~> 5.2.1"
 gem "pg", "< 1.0", platform: :ruby
 gem "sprockets", "< 4"

--- a/gemfiles/ruby_2.5_rails5_postgres_redis.gemfile
+++ b/gemfiles/ruby_2.5_rails5_postgres_redis.gemfile
@@ -6,7 +6,9 @@ gem "benchmark-ips", "~> 2.8"
 gem "benchmark-memory", "< 0.2"
 gem "climate_control", "~> 0.2.0"
 gem "concurrent-ruby"
+gem "dogstatsd-ruby", ">= 3.3.0", "!= 5.0.0", "!= 5.0.1", "!= 5.1.0"
 gem "extlz4", "~> 0.3", ">= 0.3.3"
+gem "google-protobuf", ["~> 3.0", "!= 3.7.0", "!= 3.7.1", "< 3.19.2"]
 gem "json-schema", "< 3"
 gem "memory_profiler", "~> 0.9"
 gem "os", "~> 1.1"
@@ -24,8 +26,6 @@ gem "simplecov", git: "https://github.com/DataDog/simplecov", ref: "3bb6b7ee58bf
 gem "simplecov-cobertura", "~> 2.1.0"
 gem "warning", "~> 1"
 gem "webmock", ">= 3.10.0"
-gem "dogstatsd-ruby", ">= 3.3.0", "!= 5.0.0", "!= 5.0.1", "!= 5.1.0"
-gem "google-protobuf", ["~> 3.0", "!= 3.7.0", "!= 3.7.1", "< 3.19.2"]
 gem "rails", "~> 5.2.1"
 gem "pg", "< 1.0", platform: :ruby
 gem "redis", ">= 4.0.1"

--- a/gemfiles/ruby_2.5_rails5_postgres_redis_activesupport.gemfile
+++ b/gemfiles/ruby_2.5_rails5_postgres_redis_activesupport.gemfile
@@ -6,7 +6,9 @@ gem "benchmark-ips", "~> 2.8"
 gem "benchmark-memory", "< 0.2"
 gem "climate_control", "~> 0.2.0"
 gem "concurrent-ruby"
+gem "dogstatsd-ruby", ">= 3.3.0", "!= 5.0.0", "!= 5.0.1", "!= 5.1.0"
 gem "extlz4", "~> 0.3", ">= 0.3.3"
+gem "google-protobuf", ["~> 3.0", "!= 3.7.0", "!= 3.7.1", "< 3.19.2"]
 gem "json-schema", "< 3"
 gem "memory_profiler", "~> 0.9"
 gem "os", "~> 1.1"
@@ -24,8 +26,6 @@ gem "simplecov", git: "https://github.com/DataDog/simplecov", ref: "3bb6b7ee58bf
 gem "simplecov-cobertura", "~> 2.1.0"
 gem "warning", "~> 1"
 gem "webmock", ">= 3.10.0"
-gem "dogstatsd-ruby", ">= 3.3.0", "!= 5.0.0", "!= 5.0.1", "!= 5.1.0"
-gem "google-protobuf", ["~> 3.0", "!= 3.7.0", "!= 3.7.1", "< 3.19.2"]
 gem "rails", "~> 5.2.1"
 gem "pg", "< 1.0", platform: :ruby
 gem "redis", "~> 4"

--- a/gemfiles/ruby_2.5_rails5_postgres_sidekiq.gemfile
+++ b/gemfiles/ruby_2.5_rails5_postgres_sidekiq.gemfile
@@ -6,7 +6,9 @@ gem "benchmark-ips", "~> 2.8"
 gem "benchmark-memory", "< 0.2"
 gem "climate_control", "~> 0.2.0"
 gem "concurrent-ruby"
+gem "dogstatsd-ruby", ">= 3.3.0", "!= 5.0.0", "!= 5.0.1", "!= 5.1.0"
 gem "extlz4", "~> 0.3", ">= 0.3.3"
+gem "google-protobuf", ["~> 3.0", "!= 3.7.0", "!= 3.7.1", "< 3.19.2"]
 gem "json-schema", "< 3"
 gem "memory_profiler", "~> 0.9"
 gem "os", "~> 1.1"
@@ -24,8 +26,6 @@ gem "simplecov", git: "https://github.com/DataDog/simplecov", ref: "3bb6b7ee58bf
 gem "simplecov-cobertura", "~> 2.1.0"
 gem "warning", "~> 1"
 gem "webmock", ">= 3.10.0"
-gem "dogstatsd-ruby", ">= 3.3.0", "!= 5.0.0", "!= 5.0.1", "!= 5.1.0"
-gem "google-protobuf", ["~> 3.0", "!= 3.7.0", "!= 3.7.1", "< 3.19.2"]
 gem "rails", "~> 5.2.1"
 gem "pg", "< 1.0", platform: :ruby
 gem "sidekiq"

--- a/gemfiles/ruby_2.5_rails5_semantic_logger.gemfile
+++ b/gemfiles/ruby_2.5_rails5_semantic_logger.gemfile
@@ -6,7 +6,9 @@ gem "benchmark-ips", "~> 2.8"
 gem "benchmark-memory", "< 0.2"
 gem "climate_control", "~> 0.2.0"
 gem "concurrent-ruby"
+gem "dogstatsd-ruby", ">= 3.3.0", "!= 5.0.0", "!= 5.0.1", "!= 5.1.0"
 gem "extlz4", "~> 0.3", ">= 0.3.3"
+gem "google-protobuf", ["~> 3.0", "!= 3.7.0", "!= 3.7.1", "< 3.19.2"]
 gem "json-schema", "< 3"
 gem "memory_profiler", "~> 0.9"
 gem "os", "~> 1.1"
@@ -24,8 +26,6 @@ gem "simplecov", git: "https://github.com/DataDog/simplecov", ref: "3bb6b7ee58bf
 gem "simplecov-cobertura", "~> 2.1.0"
 gem "warning", "~> 1"
 gem "webmock", ">= 3.10.0"
-gem "dogstatsd-ruby", ">= 3.3.0", "!= 5.0.0", "!= 5.0.1", "!= 5.1.0"
-gem "google-protobuf", ["~> 3.0", "!= 3.7.0", "!= 3.7.1", "< 3.19.2"]
 gem "rails", "~> 5.2.1"
 gem "pg", "< 1.0", platform: :ruby
 gem "sprockets", "< 4"

--- a/gemfiles/ruby_2.5_rails61_mysql2.gemfile
+++ b/gemfiles/ruby_2.5_rails61_mysql2.gemfile
@@ -6,7 +6,9 @@ gem "benchmark-ips", "~> 2.8"
 gem "benchmark-memory", "< 0.2"
 gem "climate_control", "~> 0.2.0"
 gem "concurrent-ruby"
+gem "dogstatsd-ruby", ">= 3.3.0", "!= 5.0.0", "!= 5.0.1", "!= 5.1.0"
 gem "extlz4", "~> 0.3", ">= 0.3.3"
+gem "google-protobuf", ["~> 3.0", "!= 3.7.0", "!= 3.7.1", "< 3.19.2"]
 gem "json-schema", "< 3"
 gem "memory_profiler", "~> 0.9"
 gem "os", "~> 1.1"
@@ -24,8 +26,6 @@ gem "simplecov", git: "https://github.com/DataDog/simplecov", ref: "3bb6b7ee58bf
 gem "simplecov-cobertura", "~> 2.1.0"
 gem "warning", "~> 1"
 gem "webmock", ">= 3.10.0"
-gem "dogstatsd-ruby", ">= 3.3.0", "!= 5.0.0", "!= 5.0.1", "!= 5.1.0"
-gem "google-protobuf", ["~> 3.0", "!= 3.7.0", "!= 3.7.1", "< 3.19.2"]
 gem "rails", "~> 6.1.0"
 gem "mysql2", "~> 0.5", platform: :ruby
 gem "sprockets", "< 4"

--- a/gemfiles/ruby_2.5_rails61_postgres.gemfile
+++ b/gemfiles/ruby_2.5_rails61_postgres.gemfile
@@ -6,7 +6,9 @@ gem "benchmark-ips", "~> 2.8"
 gem "benchmark-memory", "< 0.2"
 gem "climate_control", "~> 0.2.0"
 gem "concurrent-ruby"
+gem "dogstatsd-ruby", ">= 3.3.0", "!= 5.0.0", "!= 5.0.1", "!= 5.1.0"
 gem "extlz4", "~> 0.3", ">= 0.3.3"
+gem "google-protobuf", ["~> 3.0", "!= 3.7.0", "!= 3.7.1", "< 3.19.2"]
 gem "json-schema", "< 3"
 gem "memory_profiler", "~> 0.9"
 gem "os", "~> 1.1"
@@ -24,8 +26,6 @@ gem "simplecov", git: "https://github.com/DataDog/simplecov", ref: "3bb6b7ee58bf
 gem "simplecov-cobertura", "~> 2.1.0"
 gem "warning", "~> 1"
 gem "webmock", ">= 3.10.0"
-gem "dogstatsd-ruby", ">= 3.3.0", "!= 5.0.0", "!= 5.0.1", "!= 5.1.0"
-gem "google-protobuf", ["~> 3.0", "!= 3.7.0", "!= 3.7.1", "< 3.19.2"]
 gem "rails", "~> 6.1.0"
 gem "pg", ">= 1.1", platform: :ruby
 gem "sprockets", "< 4"

--- a/gemfiles/ruby_2.5_rails61_postgres_redis.gemfile
+++ b/gemfiles/ruby_2.5_rails61_postgres_redis.gemfile
@@ -6,7 +6,9 @@ gem "benchmark-ips", "~> 2.8"
 gem "benchmark-memory", "< 0.2"
 gem "climate_control", "~> 0.2.0"
 gem "concurrent-ruby"
+gem "dogstatsd-ruby", ">= 3.3.0", "!= 5.0.0", "!= 5.0.1", "!= 5.1.0"
 gem "extlz4", "~> 0.3", ">= 0.3.3"
+gem "google-protobuf", ["~> 3.0", "!= 3.7.0", "!= 3.7.1", "< 3.19.2"]
 gem "json-schema", "< 3"
 gem "memory_profiler", "~> 0.9"
 gem "os", "~> 1.1"
@@ -24,8 +26,6 @@ gem "simplecov", git: "https://github.com/DataDog/simplecov", ref: "3bb6b7ee58bf
 gem "simplecov-cobertura", "~> 2.1.0"
 gem "warning", "~> 1"
 gem "webmock", ">= 3.10.0"
-gem "dogstatsd-ruby", ">= 3.3.0", "!= 5.0.0", "!= 5.0.1", "!= 5.1.0"
-gem "google-protobuf", ["~> 3.0", "!= 3.7.0", "!= 3.7.1", "< 3.19.2"]
 gem "rails", "~> 6.1.0"
 gem "pg", ">= 1.1", platform: :ruby
 gem "redis", ">= 4.2.5"

--- a/gemfiles/ruby_2.5_rails61_postgres_sidekiq.gemfile
+++ b/gemfiles/ruby_2.5_rails61_postgres_sidekiq.gemfile
@@ -6,7 +6,9 @@ gem "benchmark-ips", "~> 2.8"
 gem "benchmark-memory", "< 0.2"
 gem "climate_control", "~> 0.2.0"
 gem "concurrent-ruby"
+gem "dogstatsd-ruby", ">= 3.3.0", "!= 5.0.0", "!= 5.0.1", "!= 5.1.0"
 gem "extlz4", "~> 0.3", ">= 0.3.3"
+gem "google-protobuf", ["~> 3.0", "!= 3.7.0", "!= 3.7.1", "< 3.19.2"]
 gem "json-schema", "< 3"
 gem "memory_profiler", "~> 0.9"
 gem "os", "~> 1.1"
@@ -24,8 +26,6 @@ gem "simplecov", git: "https://github.com/DataDog/simplecov", ref: "3bb6b7ee58bf
 gem "simplecov-cobertura", "~> 2.1.0"
 gem "warning", "~> 1"
 gem "webmock", ">= 3.10.0"
-gem "dogstatsd-ruby", ">= 3.3.0", "!= 5.0.0", "!= 5.0.1", "!= 5.1.0"
-gem "google-protobuf", ["~> 3.0", "!= 3.7.0", "!= 3.7.1", "< 3.19.2"]
 gem "rails", "~> 6.1.0"
 gem "pg", ">= 1.1", platform: :ruby
 gem "sidekiq", ">= 6.1.2"

--- a/gemfiles/ruby_2.5_rails61_semantic_logger.gemfile
+++ b/gemfiles/ruby_2.5_rails61_semantic_logger.gemfile
@@ -6,7 +6,9 @@ gem "benchmark-ips", "~> 2.8"
 gem "benchmark-memory", "< 0.2"
 gem "climate_control", "~> 0.2.0"
 gem "concurrent-ruby"
+gem "dogstatsd-ruby", ">= 3.3.0", "!= 5.0.0", "!= 5.0.1", "!= 5.1.0"
 gem "extlz4", "~> 0.3", ">= 0.3.3"
+gem "google-protobuf", ["~> 3.0", "!= 3.7.0", "!= 3.7.1", "< 3.19.2"]
 gem "json-schema", "< 3"
 gem "memory_profiler", "~> 0.9"
 gem "os", "~> 1.1"
@@ -24,8 +26,6 @@ gem "simplecov", git: "https://github.com/DataDog/simplecov", ref: "3bb6b7ee58bf
 gem "simplecov-cobertura", "~> 2.1.0"
 gem "warning", "~> 1"
 gem "webmock", ">= 3.10.0"
-gem "dogstatsd-ruby", ">= 3.3.0", "!= 5.0.0", "!= 5.0.1", "!= 5.1.0"
-gem "google-protobuf", ["~> 3.0", "!= 3.7.0", "!= 3.7.1", "< 3.19.2"]
 gem "rails", "~> 6.1.0"
 gem "pg", ">= 1.1", platform: :ruby
 gem "sprockets", "< 4"

--- a/gemfiles/ruby_2.5_rails6_mysql2.gemfile
+++ b/gemfiles/ruby_2.5_rails6_mysql2.gemfile
@@ -6,7 +6,9 @@ gem "benchmark-ips", "~> 2.8"
 gem "benchmark-memory", "< 0.2"
 gem "climate_control", "~> 0.2.0"
 gem "concurrent-ruby"
+gem "dogstatsd-ruby", ">= 3.3.0", "!= 5.0.0", "!= 5.0.1", "!= 5.1.0"
 gem "extlz4", "~> 0.3", ">= 0.3.3"
+gem "google-protobuf", ["~> 3.0", "!= 3.7.0", "!= 3.7.1", "< 3.19.2"]
 gem "json-schema", "< 3"
 gem "memory_profiler", "~> 0.9"
 gem "os", "~> 1.1"
@@ -24,8 +26,6 @@ gem "simplecov", git: "https://github.com/DataDog/simplecov", ref: "3bb6b7ee58bf
 gem "simplecov-cobertura", "~> 2.1.0"
 gem "warning", "~> 1"
 gem "webmock", ">= 3.10.0"
-gem "dogstatsd-ruby", ">= 3.3.0", "!= 5.0.0", "!= 5.0.1", "!= 5.1.0"
-gem "google-protobuf", ["~> 3.0", "!= 3.7.0", "!= 3.7.1", "< 3.19.2"]
 gem "rails", "~> 6.0.0"
 gem "mysql2", "< 1", platform: :ruby
 gem "sprockets", "< 4"

--- a/gemfiles/ruby_2.5_rails6_postgres.gemfile
+++ b/gemfiles/ruby_2.5_rails6_postgres.gemfile
@@ -6,7 +6,9 @@ gem "benchmark-ips", "~> 2.8"
 gem "benchmark-memory", "< 0.2"
 gem "climate_control", "~> 0.2.0"
 gem "concurrent-ruby"
+gem "dogstatsd-ruby", ">= 3.3.0", "!= 5.0.0", "!= 5.0.1", "!= 5.1.0"
 gem "extlz4", "~> 0.3", ">= 0.3.3"
+gem "google-protobuf", ["~> 3.0", "!= 3.7.0", "!= 3.7.1", "< 3.19.2"]
 gem "json-schema", "< 3"
 gem "memory_profiler", "~> 0.9"
 gem "os", "~> 1.1"
@@ -24,8 +26,6 @@ gem "simplecov", git: "https://github.com/DataDog/simplecov", ref: "3bb6b7ee58bf
 gem "simplecov-cobertura", "~> 2.1.0"
 gem "warning", "~> 1"
 gem "webmock", ">= 3.10.0"
-gem "dogstatsd-ruby", ">= 3.3.0", "!= 5.0.0", "!= 5.0.1", "!= 5.1.0"
-gem "google-protobuf", ["~> 3.0", "!= 3.7.0", "!= 3.7.1", "< 3.19.2"]
 gem "rails", "~> 6.0.0"
 gem "pg", "< 1.0", platform: :ruby
 gem "sprockets", "< 4"

--- a/gemfiles/ruby_2.5_rails6_postgres_redis.gemfile
+++ b/gemfiles/ruby_2.5_rails6_postgres_redis.gemfile
@@ -6,7 +6,9 @@ gem "benchmark-ips", "~> 2.8"
 gem "benchmark-memory", "< 0.2"
 gem "climate_control", "~> 0.2.0"
 gem "concurrent-ruby"
+gem "dogstatsd-ruby", ">= 3.3.0", "!= 5.0.0", "!= 5.0.1", "!= 5.1.0"
 gem "extlz4", "~> 0.3", ">= 0.3.3"
+gem "google-protobuf", ["~> 3.0", "!= 3.7.0", "!= 3.7.1", "< 3.19.2"]
 gem "json-schema", "< 3"
 gem "memory_profiler", "~> 0.9"
 gem "os", "~> 1.1"
@@ -24,8 +26,6 @@ gem "simplecov", git: "https://github.com/DataDog/simplecov", ref: "3bb6b7ee58bf
 gem "simplecov-cobertura", "~> 2.1.0"
 gem "warning", "~> 1"
 gem "webmock", ">= 3.10.0"
-gem "dogstatsd-ruby", ">= 3.3.0", "!= 5.0.0", "!= 5.0.1", "!= 5.1.0"
-gem "google-protobuf", ["~> 3.0", "!= 3.7.0", "!= 3.7.1", "< 3.19.2"]
 gem "rails", "~> 6.0.0"
 gem "pg", "< 1.0", platform: :ruby
 gem "redis", ">= 4.0.1"

--- a/gemfiles/ruby_2.5_rails6_postgres_redis_activesupport.gemfile
+++ b/gemfiles/ruby_2.5_rails6_postgres_redis_activesupport.gemfile
@@ -6,7 +6,9 @@ gem "benchmark-ips", "~> 2.8"
 gem "benchmark-memory", "< 0.2"
 gem "climate_control", "~> 0.2.0"
 gem "concurrent-ruby"
+gem "dogstatsd-ruby", ">= 3.3.0", "!= 5.0.0", "!= 5.0.1", "!= 5.1.0"
 gem "extlz4", "~> 0.3", ">= 0.3.3"
+gem "google-protobuf", ["~> 3.0", "!= 3.7.0", "!= 3.7.1", "< 3.19.2"]
 gem "json-schema", "< 3"
 gem "memory_profiler", "~> 0.9"
 gem "os", "~> 1.1"
@@ -24,8 +26,6 @@ gem "simplecov", git: "https://github.com/DataDog/simplecov", ref: "3bb6b7ee58bf
 gem "simplecov-cobertura", "~> 2.1.0"
 gem "warning", "~> 1"
 gem "webmock", ">= 3.10.0"
-gem "dogstatsd-ruby", ">= 3.3.0", "!= 5.0.0", "!= 5.0.1", "!= 5.1.0"
-gem "google-protobuf", ["~> 3.0", "!= 3.7.0", "!= 3.7.1", "< 3.19.2"]
 gem "rails", "~> 6.0.0"
 gem "pg", "< 1.0", platform: :ruby
 gem "redis", "~> 4"

--- a/gemfiles/ruby_2.5_rails6_postgres_sidekiq.gemfile
+++ b/gemfiles/ruby_2.5_rails6_postgres_sidekiq.gemfile
@@ -6,7 +6,9 @@ gem "benchmark-ips", "~> 2.8"
 gem "benchmark-memory", "< 0.2"
 gem "climate_control", "~> 0.2.0"
 gem "concurrent-ruby"
+gem "dogstatsd-ruby", ">= 3.3.0", "!= 5.0.0", "!= 5.0.1", "!= 5.1.0"
 gem "extlz4", "~> 0.3", ">= 0.3.3"
+gem "google-protobuf", ["~> 3.0", "!= 3.7.0", "!= 3.7.1", "< 3.19.2"]
 gem "json-schema", "< 3"
 gem "memory_profiler", "~> 0.9"
 gem "os", "~> 1.1"
@@ -24,8 +26,6 @@ gem "simplecov", git: "https://github.com/DataDog/simplecov", ref: "3bb6b7ee58bf
 gem "simplecov-cobertura", "~> 2.1.0"
 gem "warning", "~> 1"
 gem "webmock", ">= 3.10.0"
-gem "dogstatsd-ruby", ">= 3.3.0", "!= 5.0.0", "!= 5.0.1", "!= 5.1.0"
-gem "google-protobuf", ["~> 3.0", "!= 3.7.0", "!= 3.7.1", "< 3.19.2"]
 gem "rails", "~> 6.0.0"
 gem "pg", "< 1.0", platform: :ruby
 gem "sidekiq"

--- a/gemfiles/ruby_2.5_rails6_semantic_logger.gemfile
+++ b/gemfiles/ruby_2.5_rails6_semantic_logger.gemfile
@@ -6,7 +6,9 @@ gem "benchmark-ips", "~> 2.8"
 gem "benchmark-memory", "< 0.2"
 gem "climate_control", "~> 0.2.0"
 gem "concurrent-ruby"
+gem "dogstatsd-ruby", ">= 3.3.0", "!= 5.0.0", "!= 5.0.1", "!= 5.1.0"
 gem "extlz4", "~> 0.3", ">= 0.3.3"
+gem "google-protobuf", ["~> 3.0", "!= 3.7.0", "!= 3.7.1", "< 3.19.2"]
 gem "json-schema", "< 3"
 gem "memory_profiler", "~> 0.9"
 gem "os", "~> 1.1"
@@ -24,8 +26,6 @@ gem "simplecov", git: "https://github.com/DataDog/simplecov", ref: "3bb6b7ee58bf
 gem "simplecov-cobertura", "~> 2.1.0"
 gem "warning", "~> 1"
 gem "webmock", ">= 3.10.0"
-gem "dogstatsd-ruby", ">= 3.3.0", "!= 5.0.0", "!= 5.0.1", "!= 5.1.0"
-gem "google-protobuf", ["~> 3.0", "!= 3.7.0", "!= 3.7.1", "< 3.19.2"]
 gem "rails", "~> 6.0.0"
 gem "pg", "< 1.0", platform: :ruby
 gem "sprockets", "< 4"

--- a/gemfiles/ruby_2.5_rails_old_redis.gemfile
+++ b/gemfiles/ruby_2.5_rails_old_redis.gemfile
@@ -6,7 +6,9 @@ gem "benchmark-ips", "~> 2.8"
 gem "benchmark-memory", "< 0.2"
 gem "climate_control", "~> 0.2.0"
 gem "concurrent-ruby"
+gem "dogstatsd-ruby", ">= 3.3.0", "!= 5.0.0", "!= 5.0.1", "!= 5.1.0"
 gem "extlz4", "~> 0.3", ">= 0.3.3"
+gem "google-protobuf", ["~> 3.0", "!= 3.7.0", "!= 3.7.1", "< 3.19.2"]
 gem "json-schema", "< 3"
 gem "memory_profiler", "~> 0.9"
 gem "os", "~> 1.1"
@@ -24,8 +26,6 @@ gem "simplecov", git: "https://github.com/DataDog/simplecov", ref: "3bb6b7ee58bf
 gem "simplecov-cobertura", "~> 2.1.0"
 gem "warning", "~> 1"
 gem "webmock", ">= 3.10.0"
-gem "dogstatsd-ruby", ">= 3.3.0", "!= 5.0.0", "!= 5.0.1", "!= 5.1.0"
-gem "google-protobuf", ["~> 3.0", "!= 3.7.0", "!= 3.7.1", "< 3.19.2"]
 gem "redis", "< 4"
 gem "rails", "~> 6.1.0"
 gem "pg", ">= 1.1", platform: :ruby

--- a/gemfiles/ruby_2.5_redis_3.gemfile
+++ b/gemfiles/ruby_2.5_redis_3.gemfile
@@ -6,7 +6,9 @@ gem "benchmark-ips", "~> 2.8"
 gem "benchmark-memory", "< 0.2"
 gem "climate_control", "~> 0.2.0"
 gem "concurrent-ruby"
+gem "dogstatsd-ruby", ">= 3.3.0", "!= 5.0.0", "!= 5.0.1", "!= 5.1.0"
 gem "extlz4", "~> 0.3", ">= 0.3.3"
+gem "google-protobuf", ["~> 3.0", "!= 3.7.0", "!= 3.7.1", "< 3.19.2"]
 gem "json-schema", "< 3"
 gem "memory_profiler", "~> 0.9"
 gem "os", "~> 1.1"
@@ -24,8 +26,6 @@ gem "simplecov", git: "https://github.com/DataDog/simplecov", ref: "3bb6b7ee58bf
 gem "simplecov-cobertura", "~> 2.1.0"
 gem "warning", "~> 1"
 gem "webmock", ">= 3.10.0"
-gem "dogstatsd-ruby", ">= 3.3.0", "!= 5.0.0", "!= 5.0.1", "!= 5.1.0"
-gem "google-protobuf", ["~> 3.0", "!= 3.7.0", "!= 3.7.1", "< 3.19.2"]
 gem "redis", "~> 3"
 
 group :check do

--- a/gemfiles/ruby_2.5_redis_4.gemfile
+++ b/gemfiles/ruby_2.5_redis_4.gemfile
@@ -6,7 +6,9 @@ gem "benchmark-ips", "~> 2.8"
 gem "benchmark-memory", "< 0.2"
 gem "climate_control", "~> 0.2.0"
 gem "concurrent-ruby"
+gem "dogstatsd-ruby", ">= 3.3.0", "!= 5.0.0", "!= 5.0.1", "!= 5.1.0"
 gem "extlz4", "~> 0.3", ">= 0.3.3"
+gem "google-protobuf", ["~> 3.0", "!= 3.7.0", "!= 3.7.1", "< 3.19.2"]
 gem "json-schema", "< 3"
 gem "memory_profiler", "~> 0.9"
 gem "os", "~> 1.1"
@@ -24,8 +26,6 @@ gem "simplecov", git: "https://github.com/DataDog/simplecov", ref: "3bb6b7ee58bf
 gem "simplecov-cobertura", "~> 2.1.0"
 gem "warning", "~> 1"
 gem "webmock", ">= 3.10.0"
-gem "dogstatsd-ruby", ">= 3.3.0", "!= 5.0.0", "!= 5.0.1", "!= 5.1.0"
-gem "google-protobuf", ["~> 3.0", "!= 3.7.0", "!= 3.7.1", "< 3.19.2"]
 gem "redis", "~> 4"
 
 group :check do

--- a/gemfiles/ruby_2.5_redis_5.gemfile
+++ b/gemfiles/ruby_2.5_redis_5.gemfile
@@ -6,7 +6,9 @@ gem "benchmark-ips", "~> 2.8"
 gem "benchmark-memory", "< 0.2"
 gem "climate_control", "~> 0.2.0"
 gem "concurrent-ruby"
+gem "dogstatsd-ruby", ">= 3.3.0", "!= 5.0.0", "!= 5.0.1", "!= 5.1.0"
 gem "extlz4", "~> 0.3", ">= 0.3.3"
+gem "google-protobuf", ["~> 3.0", "!= 3.7.0", "!= 3.7.1", "< 3.19.2"]
 gem "json-schema", "< 3"
 gem "memory_profiler", "~> 0.9"
 gem "os", "~> 1.1"
@@ -24,8 +26,6 @@ gem "simplecov", git: "https://github.com/DataDog/simplecov", ref: "3bb6b7ee58bf
 gem "simplecov-cobertura", "~> 2.1.0"
 gem "warning", "~> 1"
 gem "webmock", ">= 3.10.0"
-gem "dogstatsd-ruby", ">= 3.3.0", "!= 5.0.0", "!= 5.0.1", "!= 5.1.0"
-gem "google-protobuf", ["~> 3.0", "!= 3.7.0", "!= 3.7.1", "< 3.19.2"]
 gem "redis", "~> 5"
 
 group :check do

--- a/gemfiles/ruby_2.5_relational_db.gemfile
+++ b/gemfiles/ruby_2.5_relational_db.gemfile
@@ -6,7 +6,9 @@ gem "benchmark-ips", "~> 2.8"
 gem "benchmark-memory", "< 0.2"
 gem "climate_control", "~> 0.2.0"
 gem "concurrent-ruby"
+gem "dogstatsd-ruby", ">= 3.3.0", "!= 5.0.0", "!= 5.0.1", "!= 5.1.0"
 gem "extlz4", "~> 0.3", ">= 0.3.3"
+gem "google-protobuf", ["~> 3.0", "!= 3.7.0", "!= 3.7.1", "< 3.19.2"]
 gem "json-schema", "< 3"
 gem "memory_profiler", "~> 0.9"
 gem "os", "~> 1.1"
@@ -24,8 +26,6 @@ gem "simplecov", git: "https://github.com/DataDog/simplecov", ref: "3bb6b7ee58bf
 gem "simplecov-cobertura", "~> 2.1.0"
 gem "warning", "~> 1"
 gem "webmock", ">= 3.10.0"
-gem "dogstatsd-ruby", ">= 3.3.0", "!= 5.0.0", "!= 5.0.1", "!= 5.1.0"
-gem "google-protobuf", ["~> 3.0", "!= 3.7.0", "!= 3.7.1", "< 3.19.2"]
 gem "activerecord", "~> 5"
 gem "delayed_job"
 gem "delayed_job_active_record"

--- a/gemfiles/ruby_2.5_resque2_redis3.gemfile
+++ b/gemfiles/ruby_2.5_resque2_redis3.gemfile
@@ -6,7 +6,9 @@ gem "benchmark-ips", "~> 2.8"
 gem "benchmark-memory", "< 0.2"
 gem "climate_control", "~> 0.2.0"
 gem "concurrent-ruby"
+gem "dogstatsd-ruby", ">= 3.3.0", "!= 5.0.0", "!= 5.0.1", "!= 5.1.0"
 gem "extlz4", "~> 0.3", ">= 0.3.3"
+gem "google-protobuf", ["~> 3.0", "!= 3.7.0", "!= 3.7.1", "< 3.19.2"]
 gem "json-schema", "< 3"
 gem "memory_profiler", "~> 0.9"
 gem "os", "~> 1.1"
@@ -24,8 +26,6 @@ gem "simplecov", git: "https://github.com/DataDog/simplecov", ref: "3bb6b7ee58bf
 gem "simplecov-cobertura", "~> 2.1.0"
 gem "warning", "~> 1"
 gem "webmock", ">= 3.10.0"
-gem "dogstatsd-ruby", ">= 3.3.0", "!= 5.0.0", "!= 5.0.1", "!= 5.1.0"
-gem "google-protobuf", ["~> 3.0", "!= 3.7.0", "!= 3.7.1", "< 3.19.2"]
 gem "redis", "< 4.0"
 gem "resque", ">= 2.0"
 

--- a/gemfiles/ruby_2.5_resque2_redis4.gemfile
+++ b/gemfiles/ruby_2.5_resque2_redis4.gemfile
@@ -6,7 +6,9 @@ gem "benchmark-ips", "~> 2.8"
 gem "benchmark-memory", "< 0.2"
 gem "climate_control", "~> 0.2.0"
 gem "concurrent-ruby"
+gem "dogstatsd-ruby", ">= 3.3.0", "!= 5.0.0", "!= 5.0.1", "!= 5.1.0"
 gem "extlz4", "~> 0.3", ">= 0.3.3"
+gem "google-protobuf", ["~> 3.0", "!= 3.7.0", "!= 3.7.1", "< 3.19.2"]
 gem "json-schema", "< 3"
 gem "memory_profiler", "~> 0.9"
 gem "os", "~> 1.1"
@@ -24,8 +26,6 @@ gem "simplecov", git: "https://github.com/DataDog/simplecov", ref: "3bb6b7ee58bf
 gem "simplecov-cobertura", "~> 2.1.0"
 gem "warning", "~> 1"
 gem "webmock", ">= 3.10.0"
-gem "dogstatsd-ruby", ">= 3.3.0", "!= 5.0.0", "!= 5.0.1", "!= 5.1.0"
-gem "google-protobuf", ["~> 3.0", "!= 3.7.0", "!= 3.7.1", "< 3.19.2"]
 gem "redis", ">= 4.0"
 gem "resque", ">= 2.0"
 

--- a/gemfiles/ruby_2.5_sinatra_2.gemfile
+++ b/gemfiles/ruby_2.5_sinatra_2.gemfile
@@ -6,7 +6,9 @@ gem "benchmark-ips", "~> 2.8"
 gem "benchmark-memory", "< 0.2"
 gem "climate_control", "~> 0.2.0"
 gem "concurrent-ruby"
+gem "dogstatsd-ruby", ">= 3.3.0", "!= 5.0.0", "!= 5.0.1", "!= 5.1.0"
 gem "extlz4", "~> 0.3", ">= 0.3.3"
+gem "google-protobuf", ["~> 3.0", "!= 3.7.0", "!= 3.7.1", "< 3.19.2"]
 gem "json-schema", "< 3"
 gem "memory_profiler", "~> 0.9"
 gem "os", "~> 1.1"
@@ -24,8 +26,6 @@ gem "simplecov", git: "https://github.com/DataDog/simplecov", ref: "3bb6b7ee58bf
 gem "simplecov-cobertura", "~> 2.1.0"
 gem "warning", "~> 1"
 gem "webmock", ">= 3.10.0"
-gem "dogstatsd-ruby", ">= 3.3.0", "!= 5.0.0", "!= 5.0.1", "!= 5.1.0"
-gem "google-protobuf", ["~> 3.0", "!= 3.7.0", "!= 3.7.1", "< 3.19.2"]
 gem "sinatra", "~> 2"
 gem "rack-contrib"
 gem "rack-test"

--- a/gemfiles/ruby_2.5_stripe_10.gemfile
+++ b/gemfiles/ruby_2.5_stripe_10.gemfile
@@ -6,7 +6,9 @@ gem "benchmark-ips", "~> 2.8"
 gem "benchmark-memory", "< 0.2"
 gem "climate_control", "~> 0.2.0"
 gem "concurrent-ruby"
+gem "dogstatsd-ruby", ">= 3.3.0", "!= 5.0.0", "!= 5.0.1", "!= 5.1.0"
 gem "extlz4", "~> 0.3", ">= 0.3.3"
+gem "google-protobuf", ["~> 3.0", "!= 3.7.0", "!= 3.7.1", "< 3.19.2"]
 gem "json-schema", "< 3"
 gem "memory_profiler", "~> 0.9"
 gem "os", "~> 1.1"
@@ -24,8 +26,6 @@ gem "simplecov", git: "https://github.com/DataDog/simplecov", ref: "3bb6b7ee58bf
 gem "simplecov-cobertura", "~> 2.1.0"
 gem "warning", "~> 1"
 gem "webmock", ">= 3.10.0"
-gem "dogstatsd-ruby", ">= 3.3.0", "!= 5.0.0", "!= 5.0.1", "!= 5.1.0"
-gem "google-protobuf", ["~> 3.0", "!= 3.7.0", "!= 3.7.1", "< 3.19.2"]
 gem "stripe", "~> 10"
 
 group :check do

--- a/gemfiles/ruby_2.5_stripe_11.gemfile
+++ b/gemfiles/ruby_2.5_stripe_11.gemfile
@@ -6,7 +6,9 @@ gem "benchmark-ips", "~> 2.8"
 gem "benchmark-memory", "< 0.2"
 gem "climate_control", "~> 0.2.0"
 gem "concurrent-ruby"
+gem "dogstatsd-ruby", ">= 3.3.0", "!= 5.0.0", "!= 5.0.1", "!= 5.1.0"
 gem "extlz4", "~> 0.3", ">= 0.3.3"
+gem "google-protobuf", ["~> 3.0", "!= 3.7.0", "!= 3.7.1", "< 3.19.2"]
 gem "json-schema", "< 3"
 gem "memory_profiler", "~> 0.9"
 gem "os", "~> 1.1"
@@ -24,8 +26,6 @@ gem "simplecov", git: "https://github.com/DataDog/simplecov", ref: "3bb6b7ee58bf
 gem "simplecov-cobertura", "~> 2.1.0"
 gem "warning", "~> 1"
 gem "webmock", ">= 3.10.0"
-gem "dogstatsd-ruby", ">= 3.3.0", "!= 5.0.0", "!= 5.0.1", "!= 5.1.0"
-gem "google-protobuf", ["~> 3.0", "!= 3.7.0", "!= 3.7.1", "< 3.19.2"]
 gem "stripe", "~> 11"
 
 group :check do

--- a/gemfiles/ruby_2.5_stripe_12.gemfile
+++ b/gemfiles/ruby_2.5_stripe_12.gemfile
@@ -6,7 +6,9 @@ gem "benchmark-ips", "~> 2.8"
 gem "benchmark-memory", "< 0.2"
 gem "climate_control", "~> 0.2.0"
 gem "concurrent-ruby"
+gem "dogstatsd-ruby", ">= 3.3.0", "!= 5.0.0", "!= 5.0.1", "!= 5.1.0"
 gem "extlz4", "~> 0.3", ">= 0.3.3"
+gem "google-protobuf", ["~> 3.0", "!= 3.7.0", "!= 3.7.1", "< 3.19.2"]
 gem "json-schema", "< 3"
 gem "memory_profiler", "~> 0.9"
 gem "os", "~> 1.1"
@@ -24,8 +26,6 @@ gem "simplecov", git: "https://github.com/DataDog/simplecov", ref: "3bb6b7ee58bf
 gem "simplecov-cobertura", "~> 2.1.0"
 gem "warning", "~> 1"
 gem "webmock", ">= 3.10.0"
-gem "dogstatsd-ruby", ">= 3.3.0", "!= 5.0.0", "!= 5.0.1", "!= 5.1.0"
-gem "google-protobuf", ["~> 3.0", "!= 3.7.0", "!= 3.7.1", "< 3.19.2"]
 gem "stripe", "~> 12"
 
 group :check do

--- a/gemfiles/ruby_2.5_stripe_7.gemfile
+++ b/gemfiles/ruby_2.5_stripe_7.gemfile
@@ -6,7 +6,9 @@ gem "benchmark-ips", "~> 2.8"
 gem "benchmark-memory", "< 0.2"
 gem "climate_control", "~> 0.2.0"
 gem "concurrent-ruby"
+gem "dogstatsd-ruby", ">= 3.3.0", "!= 5.0.0", "!= 5.0.1", "!= 5.1.0"
 gem "extlz4", "~> 0.3", ">= 0.3.3"
+gem "google-protobuf", ["~> 3.0", "!= 3.7.0", "!= 3.7.1", "< 3.19.2"]
 gem "json-schema", "< 3"
 gem "memory_profiler", "~> 0.9"
 gem "os", "~> 1.1"
@@ -24,8 +26,6 @@ gem "simplecov", git: "https://github.com/DataDog/simplecov", ref: "3bb6b7ee58bf
 gem "simplecov-cobertura", "~> 2.1.0"
 gem "warning", "~> 1"
 gem "webmock", ">= 3.10.0"
-gem "dogstatsd-ruby", ">= 3.3.0", "!= 5.0.0", "!= 5.0.1", "!= 5.1.0"
-gem "google-protobuf", ["~> 3.0", "!= 3.7.0", "!= 3.7.1", "< 3.19.2"]
 gem "stripe", "~> 7"
 
 group :check do

--- a/gemfiles/ruby_2.5_stripe_8.gemfile
+++ b/gemfiles/ruby_2.5_stripe_8.gemfile
@@ -6,7 +6,9 @@ gem "benchmark-ips", "~> 2.8"
 gem "benchmark-memory", "< 0.2"
 gem "climate_control", "~> 0.2.0"
 gem "concurrent-ruby"
+gem "dogstatsd-ruby", ">= 3.3.0", "!= 5.0.0", "!= 5.0.1", "!= 5.1.0"
 gem "extlz4", "~> 0.3", ">= 0.3.3"
+gem "google-protobuf", ["~> 3.0", "!= 3.7.0", "!= 3.7.1", "< 3.19.2"]
 gem "json-schema", "< 3"
 gem "memory_profiler", "~> 0.9"
 gem "os", "~> 1.1"
@@ -24,8 +26,6 @@ gem "simplecov", git: "https://github.com/DataDog/simplecov", ref: "3bb6b7ee58bf
 gem "simplecov-cobertura", "~> 2.1.0"
 gem "warning", "~> 1"
 gem "webmock", ">= 3.10.0"
-gem "dogstatsd-ruby", ">= 3.3.0", "!= 5.0.0", "!= 5.0.1", "!= 5.1.0"
-gem "google-protobuf", ["~> 3.0", "!= 3.7.0", "!= 3.7.1", "< 3.19.2"]
 gem "stripe", "~> 8"
 
 group :check do

--- a/gemfiles/ruby_2.5_stripe_9.gemfile
+++ b/gemfiles/ruby_2.5_stripe_9.gemfile
@@ -6,7 +6,9 @@ gem "benchmark-ips", "~> 2.8"
 gem "benchmark-memory", "< 0.2"
 gem "climate_control", "~> 0.2.0"
 gem "concurrent-ruby"
+gem "dogstatsd-ruby", ">= 3.3.0", "!= 5.0.0", "!= 5.0.1", "!= 5.1.0"
 gem "extlz4", "~> 0.3", ">= 0.3.3"
+gem "google-protobuf", ["~> 3.0", "!= 3.7.0", "!= 3.7.1", "< 3.19.2"]
 gem "json-schema", "< 3"
 gem "memory_profiler", "~> 0.9"
 gem "os", "~> 1.1"
@@ -24,8 +26,6 @@ gem "simplecov", git: "https://github.com/DataDog/simplecov", ref: "3bb6b7ee58bf
 gem "simplecov-cobertura", "~> 2.1.0"
 gem "warning", "~> 1"
 gem "webmock", ">= 3.10.0"
-gem "dogstatsd-ruby", ">= 3.3.0", "!= 5.0.0", "!= 5.0.1", "!= 5.1.0"
-gem "google-protobuf", ["~> 3.0", "!= 3.7.0", "!= 3.7.1", "< 3.19.2"]
 gem "stripe", "~> 9"
 
 group :check do

--- a/gemfiles/ruby_2.5_stripe_latest.gemfile
+++ b/gemfiles/ruby_2.5_stripe_latest.gemfile
@@ -6,7 +6,9 @@ gem "benchmark-ips", "~> 2.8"
 gem "benchmark-memory", "< 0.2"
 gem "climate_control", "~> 0.2.0"
 gem "concurrent-ruby"
+gem "dogstatsd-ruby", ">= 3.3.0", "!= 5.0.0", "!= 5.0.1", "!= 5.1.0"
 gem "extlz4", "~> 0.3", ">= 0.3.3"
+gem "google-protobuf", ["~> 3.0", "!= 3.7.0", "!= 3.7.1", "< 3.19.2"]
 gem "json-schema", "< 3"
 gem "memory_profiler", "~> 0.9"
 gem "os", "~> 1.1"
@@ -24,8 +26,6 @@ gem "simplecov", git: "https://github.com/DataDog/simplecov", ref: "3bb6b7ee58bf
 gem "simplecov-cobertura", "~> 2.1.0"
 gem "warning", "~> 1"
 gem "webmock", ">= 3.10.0"
-gem "dogstatsd-ruby", ">= 3.3.0", "!= 5.0.0", "!= 5.0.1", "!= 5.1.0"
-gem "google-protobuf", ["~> 3.0", "!= 3.7.0", "!= 3.7.1", "< 3.19.2"]
 gem "stripe"
 
 group :check do

--- a/gemfiles/ruby_2.5_stripe_min.gemfile
+++ b/gemfiles/ruby_2.5_stripe_min.gemfile
@@ -6,7 +6,9 @@ gem "benchmark-ips", "~> 2.8"
 gem "benchmark-memory", "< 0.2"
 gem "climate_control", "~> 0.2.0"
 gem "concurrent-ruby"
+gem "dogstatsd-ruby", ">= 3.3.0", "!= 5.0.0", "!= 5.0.1", "!= 5.1.0"
 gem "extlz4", "~> 0.3", ">= 0.3.3"
+gem "google-protobuf", ["~> 3.0", "!= 3.7.0", "!= 3.7.1", "< 3.19.2"]
 gem "json-schema", "< 3"
 gem "memory_profiler", "~> 0.9"
 gem "os", "~> 1.1"
@@ -24,8 +26,6 @@ gem "simplecov", git: "https://github.com/DataDog/simplecov", ref: "3bb6b7ee58bf
 gem "simplecov-cobertura", "~> 2.1.0"
 gem "warning", "~> 1"
 gem "webmock", ">= 3.10.0"
-gem "dogstatsd-ruby", ">= 3.3.0", "!= 5.0.0", "!= 5.0.1", "!= 5.1.0"
-gem "google-protobuf", ["~> 3.0", "!= 3.7.0", "!= 3.7.1", "< 3.19.2"]
 gem "stripe", "= 5.15.0"
 
 group :check do

--- a/gemfiles/ruby_2.6_activesupport.gemfile
+++ b/gemfiles/ruby_2.6_activesupport.gemfile
@@ -6,7 +6,9 @@ gem "benchmark-ips", "~> 2.8"
 gem "benchmark-memory", "< 0.2"
 gem "climate_control", "~> 0.2.0"
 gem "concurrent-ruby"
+gem "dogstatsd-ruby", ">= 3.3.0", "!= 5.0.0", "!= 5.0.1", "!= 5.1.0"
 gem "extlz4", "~> 0.3", ">= 0.3.3"
+gem "google-protobuf", ["~> 3.0", "!= 3.7.0", "!= 3.7.1", "< 3.19.2"]
 gem "json-schema", "< 3"
 gem "memory_profiler", "~> 0.9"
 gem "os", "~> 1.1"
@@ -20,16 +22,14 @@ gem "rspec", "~> 3.13"
 gem "rspec-collection_matchers", "~> 1.1"
 gem "rspec-wait", "~> 0"
 gem "rspec_junit_formatter", ">= 0.5.1"
-gem "simplecov", git: "https://github.com/DataDog/simplecov", ref: "3bb6b7ee58bf4b1954ca205f50dd44d6f41c57db"
-gem "simplecov-cobertura", "~> 2.1.0"
-gem "warning", "~> 1"
-gem "webmock", ">= 3.10.0"
 gem "rubocop", "~> 1.50.0", require: false
 gem "rubocop-packaging", "~> 0.5.2", require: false
 gem "rubocop-performance", "~> 1.9", require: false
 gem "rubocop-rspec", ["~> 2.20", "< 2.21"], require: false
-gem "dogstatsd-ruby", ">= 3.3.0", "!= 5.0.0", "!= 5.0.1", "!= 5.1.0"
-gem "google-protobuf", ["~> 3.0", "!= 3.7.0", "!= 3.7.1", "< 3.19.2"]
+gem "simplecov", git: "https://github.com/DataDog/simplecov", ref: "3bb6b7ee58bf4b1954ca205f50dd44d6f41c57db"
+gem "simplecov-cobertura", "~> 2.1.0"
+gem "warning", "~> 1"
+gem "webmock", ">= 3.10.0"
 gem "activesupport", "~> 6.0.0"
 gem "actionpack"
 gem "actionview"

--- a/gemfiles/ruby_2.6_aws.gemfile
+++ b/gemfiles/ruby_2.6_aws.gemfile
@@ -6,7 +6,9 @@ gem "benchmark-ips", "~> 2.8"
 gem "benchmark-memory", "< 0.2"
 gem "climate_control", "~> 0.2.0"
 gem "concurrent-ruby"
+gem "dogstatsd-ruby", ">= 3.3.0", "!= 5.0.0", "!= 5.0.1", "!= 5.1.0"
 gem "extlz4", "~> 0.3", ">= 0.3.3"
+gem "google-protobuf", ["~> 3.0", "!= 3.7.0", "!= 3.7.1", "< 3.19.2"]
 gem "json-schema", "< 3"
 gem "memory_profiler", "~> 0.9"
 gem "os", "~> 1.1"
@@ -20,16 +22,14 @@ gem "rspec", "~> 3.13"
 gem "rspec-collection_matchers", "~> 1.1"
 gem "rspec-wait", "~> 0"
 gem "rspec_junit_formatter", ">= 0.5.1"
-gem "simplecov", git: "https://github.com/DataDog/simplecov", ref: "3bb6b7ee58bf4b1954ca205f50dd44d6f41c57db"
-gem "simplecov-cobertura", "~> 2.1.0"
-gem "warning", "~> 1"
-gem "webmock", ">= 3.10.0"
 gem "rubocop", "~> 1.50.0", require: false
 gem "rubocop-packaging", "~> 0.5.2", require: false
 gem "rubocop-performance", "~> 1.9", require: false
 gem "rubocop-rspec", ["~> 2.20", "< 2.21"], require: false
-gem "dogstatsd-ruby", ">= 3.3.0", "!= 5.0.0", "!= 5.0.1", "!= 5.1.0"
-gem "google-protobuf", ["~> 3.0", "!= 3.7.0", "!= 3.7.1", "< 3.19.2"]
+gem "simplecov", git: "https://github.com/DataDog/simplecov", ref: "3bb6b7ee58bf4b1954ca205f50dd44d6f41c57db"
+gem "simplecov-cobertura", "~> 2.1.0"
+gem "warning", "~> 1"
+gem "webmock", ">= 3.10.0"
 gem "aws-sdk"
 gem "shoryuken"
 

--- a/gemfiles/ruby_2.6_contrib.gemfile
+++ b/gemfiles/ruby_2.6_contrib.gemfile
@@ -6,7 +6,9 @@ gem "benchmark-ips", "~> 2.8"
 gem "benchmark-memory", "< 0.2"
 gem "climate_control", "~> 0.2.0"
 gem "concurrent-ruby"
+gem "dogstatsd-ruby", ">= 3.3.0", "!= 5.0.0", "!= 5.0.1", "!= 5.1.0"
 gem "extlz4", "~> 0.3", ">= 0.3.3"
+gem "google-protobuf", ["~> 3.0", "!= 3.7.0", "!= 3.7.1", "< 3.19.2"]
 gem "json-schema", "< 3"
 gem "memory_profiler", "~> 0.9"
 gem "os", "~> 1.1"
@@ -20,16 +22,14 @@ gem "rspec", "~> 3.13"
 gem "rspec-collection_matchers", "~> 1.1"
 gem "rspec-wait", "~> 0"
 gem "rspec_junit_formatter", ">= 0.5.1"
-gem "simplecov", git: "https://github.com/DataDog/simplecov", ref: "3bb6b7ee58bf4b1954ca205f50dd44d6f41c57db"
-gem "simplecov-cobertura", "~> 2.1.0"
-gem "warning", "~> 1"
-gem "webmock", ">= 3.10.0"
 gem "rubocop", "~> 1.50.0", require: false
 gem "rubocop-packaging", "~> 0.5.2", require: false
 gem "rubocop-performance", "~> 1.9", require: false
 gem "rubocop-rspec", ["~> 2.20", "< 2.21"], require: false
-gem "dogstatsd-ruby", ">= 3.3.0", "!= 5.0.0", "!= 5.0.1", "!= 5.1.0"
-gem "google-protobuf", ["~> 3.0", "!= 3.7.0", "!= 3.7.1", "< 3.19.2"]
+gem "simplecov", git: "https://github.com/DataDog/simplecov", ref: "3bb6b7ee58bf4b1954ca205f50dd44d6f41c57db"
+gem "simplecov-cobertura", "~> 2.1.0"
+gem "warning", "~> 1"
+gem "webmock", ">= 3.10.0"
 gem "dalli", ">= 3.0.0"
 gem "grpc", platform: :ruby
 gem "mongo", ">= 2.8.0", "< 2.15.0"

--- a/gemfiles/ruby_2.6_contrib_old.gemfile
+++ b/gemfiles/ruby_2.6_contrib_old.gemfile
@@ -6,7 +6,9 @@ gem "benchmark-ips", "~> 2.8"
 gem "benchmark-memory", "< 0.2"
 gem "climate_control", "~> 0.2.0"
 gem "concurrent-ruby"
+gem "dogstatsd-ruby", ">= 3.3.0", "!= 5.0.0", "!= 5.0.1", "!= 5.1.0"
 gem "extlz4", "~> 0.3", ">= 0.3.3"
+gem "google-protobuf", ["~> 3.0", "!= 3.7.0", "!= 3.7.1", "< 3.19.2"]
 gem "json-schema", "< 3"
 gem "memory_profiler", "~> 0.9"
 gem "os", "~> 1.1"
@@ -20,16 +22,14 @@ gem "rspec", "~> 3.13"
 gem "rspec-collection_matchers", "~> 1.1"
 gem "rspec-wait", "~> 0"
 gem "rspec_junit_formatter", ">= 0.5.1"
-gem "simplecov", git: "https://github.com/DataDog/simplecov", ref: "3bb6b7ee58bf4b1954ca205f50dd44d6f41c57db"
-gem "simplecov-cobertura", "~> 2.1.0"
-gem "warning", "~> 1"
-gem "webmock", ">= 3.10.0"
 gem "rubocop", "~> 1.50.0", require: false
 gem "rubocop-packaging", "~> 0.5.2", require: false
 gem "rubocop-performance", "~> 1.9", require: false
 gem "rubocop-rspec", ["~> 2.20", "< 2.21"], require: false
-gem "dogstatsd-ruby", ">= 3.3.0", "!= 5.0.0", "!= 5.0.1", "!= 5.1.0"
-gem "google-protobuf", ["~> 3.0", "!= 3.7.0", "!= 3.7.1", "< 3.19.2"]
+gem "simplecov", git: "https://github.com/DataDog/simplecov", ref: "3bb6b7ee58bf4b1954ca205f50dd44d6f41c57db"
+gem "simplecov-cobertura", "~> 2.1.0"
+gem "warning", "~> 1"
+gem "webmock", ">= 3.10.0"
 gem "dalli", "< 3.0.0"
 gem "faraday", "0.17"
 gem "presto-client", ">= 0.5.14"

--- a/gemfiles/ruby_2.6_core_old.gemfile
+++ b/gemfiles/ruby_2.6_core_old.gemfile
@@ -6,7 +6,9 @@ gem "benchmark-ips", "~> 2.8"
 gem "benchmark-memory", "< 0.2"
 gem "climate_control", "~> 0.2.0"
 gem "concurrent-ruby"
+gem "dogstatsd-ruby", "~> 4"
 gem "extlz4", "~> 0.3", ">= 0.3.3"
+gem "google-protobuf", ["~> 3.0", "!= 3.7.0", "!= 3.7.1", "< 3.19.2"]
 gem "json-schema", "< 3"
 gem "memory_profiler", "~> 0.9"
 gem "os", "~> 1.1"
@@ -20,16 +22,14 @@ gem "rspec", "~> 3.13"
 gem "rspec-collection_matchers", "~> 1.1"
 gem "rspec-wait", "~> 0"
 gem "rspec_junit_formatter", ">= 0.5.1"
-gem "simplecov", git: "https://github.com/DataDog/simplecov", ref: "3bb6b7ee58bf4b1954ca205f50dd44d6f41c57db"
-gem "simplecov-cobertura", "~> 2.1.0"
-gem "warning", "~> 1"
-gem "webmock", ">= 3.10.0"
 gem "rubocop", "~> 1.50.0", require: false
 gem "rubocop-packaging", "~> 0.5.2", require: false
 gem "rubocop-performance", "~> 1.9", require: false
 gem "rubocop-rspec", ["~> 2.20", "< 2.21"], require: false
-gem "dogstatsd-ruby", "~> 4"
-gem "google-protobuf", ["~> 3.0", "!= 3.7.0", "!= 3.7.1", "< 3.19.2"]
+gem "simplecov", git: "https://github.com/DataDog/simplecov", ref: "3bb6b7ee58bf4b1954ca205f50dd44d6f41c57db"
+gem "simplecov-cobertura", "~> 2.1.0"
+gem "warning", "~> 1"
+gem "webmock", ">= 3.10.0"
 
 group :check do
 

--- a/gemfiles/ruby_2.6_elasticsearch_7.gemfile
+++ b/gemfiles/ruby_2.6_elasticsearch_7.gemfile
@@ -6,7 +6,9 @@ gem "benchmark-ips", "~> 2.8"
 gem "benchmark-memory", "< 0.2"
 gem "climate_control", "~> 0.2.0"
 gem "concurrent-ruby"
+gem "dogstatsd-ruby", ">= 3.3.0", "!= 5.0.0", "!= 5.0.1", "!= 5.1.0"
 gem "extlz4", "~> 0.3", ">= 0.3.3"
+gem "google-protobuf", ["~> 3.0", "!= 3.7.0", "!= 3.7.1", "< 3.19.2"]
 gem "json-schema", "< 3"
 gem "memory_profiler", "~> 0.9"
 gem "os", "~> 1.1"
@@ -20,16 +22,14 @@ gem "rspec", "~> 3.13"
 gem "rspec-collection_matchers", "~> 1.1"
 gem "rspec-wait", "~> 0"
 gem "rspec_junit_formatter", ">= 0.5.1"
-gem "simplecov", git: "https://github.com/DataDog/simplecov", ref: "3bb6b7ee58bf4b1954ca205f50dd44d6f41c57db"
-gem "simplecov-cobertura", "~> 2.1.0"
-gem "warning", "~> 1"
-gem "webmock", ">= 3.10.0"
 gem "rubocop", "~> 1.50.0", require: false
 gem "rubocop-packaging", "~> 0.5.2", require: false
 gem "rubocop-performance", "~> 1.9", require: false
 gem "rubocop-rspec", ["~> 2.20", "< 2.21"], require: false
-gem "dogstatsd-ruby", ">= 3.3.0", "!= 5.0.0", "!= 5.0.1", "!= 5.1.0"
-gem "google-protobuf", ["~> 3.0", "!= 3.7.0", "!= 3.7.1", "< 3.19.2"]
+gem "simplecov", git: "https://github.com/DataDog/simplecov", ref: "3bb6b7ee58bf4b1954ca205f50dd44d6f41c57db"
+gem "simplecov-cobertura", "~> 2.1.0"
+gem "warning", "~> 1"
+gem "webmock", ">= 3.10.0"
 gem "elasticsearch", "~> 7"
 
 group :check do

--- a/gemfiles/ruby_2.6_elasticsearch_8.gemfile
+++ b/gemfiles/ruby_2.6_elasticsearch_8.gemfile
@@ -6,7 +6,9 @@ gem "benchmark-ips", "~> 2.8"
 gem "benchmark-memory", "< 0.2"
 gem "climate_control", "~> 0.2.0"
 gem "concurrent-ruby"
+gem "dogstatsd-ruby", ">= 3.3.0", "!= 5.0.0", "!= 5.0.1", "!= 5.1.0"
 gem "extlz4", "~> 0.3", ">= 0.3.3"
+gem "google-protobuf", ["~> 3.0", "!= 3.7.0", "!= 3.7.1", "< 3.19.2"]
 gem "json-schema", "< 3"
 gem "memory_profiler", "~> 0.9"
 gem "os", "~> 1.1"
@@ -20,16 +22,14 @@ gem "rspec", "~> 3.13"
 gem "rspec-collection_matchers", "~> 1.1"
 gem "rspec-wait", "~> 0"
 gem "rspec_junit_formatter", ">= 0.5.1"
-gem "simplecov", git: "https://github.com/DataDog/simplecov", ref: "3bb6b7ee58bf4b1954ca205f50dd44d6f41c57db"
-gem "simplecov-cobertura", "~> 2.1.0"
-gem "warning", "~> 1"
-gem "webmock", ">= 3.10.0"
 gem "rubocop", "~> 1.50.0", require: false
 gem "rubocop-packaging", "~> 0.5.2", require: false
 gem "rubocop-performance", "~> 1.9", require: false
 gem "rubocop-rspec", ["~> 2.20", "< 2.21"], require: false
-gem "dogstatsd-ruby", ">= 3.3.0", "!= 5.0.0", "!= 5.0.1", "!= 5.1.0"
-gem "google-protobuf", ["~> 3.0", "!= 3.7.0", "!= 3.7.1", "< 3.19.2"]
+gem "simplecov", git: "https://github.com/DataDog/simplecov", ref: "3bb6b7ee58bf4b1954ca205f50dd44d6f41c57db"
+gem "simplecov-cobertura", "~> 2.1.0"
+gem "warning", "~> 1"
+gem "webmock", ">= 3.10.0"
 gem "elasticsearch", "~> 8"
 
 group :check do

--- a/gemfiles/ruby_2.6_elasticsearch_latest.gemfile
+++ b/gemfiles/ruby_2.6_elasticsearch_latest.gemfile
@@ -6,7 +6,9 @@ gem "benchmark-ips", "~> 2.8"
 gem "benchmark-memory", "< 0.2"
 gem "climate_control", "~> 0.2.0"
 gem "concurrent-ruby"
+gem "dogstatsd-ruby", ">= 3.3.0", "!= 5.0.0", "!= 5.0.1", "!= 5.1.0"
 gem "extlz4", "~> 0.3", ">= 0.3.3"
+gem "google-protobuf", ["~> 3.0", "!= 3.7.0", "!= 3.7.1", "< 3.19.2"]
 gem "json-schema", "< 3"
 gem "memory_profiler", "~> 0.9"
 gem "os", "~> 1.1"
@@ -20,16 +22,14 @@ gem "rspec", "~> 3.13"
 gem "rspec-collection_matchers", "~> 1.1"
 gem "rspec-wait", "~> 0"
 gem "rspec_junit_formatter", ">= 0.5.1"
-gem "simplecov", git: "https://github.com/DataDog/simplecov", ref: "3bb6b7ee58bf4b1954ca205f50dd44d6f41c57db"
-gem "simplecov-cobertura", "~> 2.1.0"
-gem "warning", "~> 1"
-gem "webmock", ">= 3.10.0"
 gem "rubocop", "~> 1.50.0", require: false
 gem "rubocop-packaging", "~> 0.5.2", require: false
 gem "rubocop-performance", "~> 1.9", require: false
 gem "rubocop-rspec", ["~> 2.20", "< 2.21"], require: false
-gem "dogstatsd-ruby", ">= 3.3.0", "!= 5.0.0", "!= 5.0.1", "!= 5.1.0"
-gem "google-protobuf", ["~> 3.0", "!= 3.7.0", "!= 3.7.1", "< 3.19.2"]
+gem "simplecov", git: "https://github.com/DataDog/simplecov", ref: "3bb6b7ee58bf4b1954ca205f50dd44d6f41c57db"
+gem "simplecov-cobertura", "~> 2.1.0"
+gem "warning", "~> 1"
+gem "webmock", ">= 3.10.0"
 gem "elasticsearch"
 
 group :check do

--- a/gemfiles/ruby_2.6_graphql_1.13.gemfile
+++ b/gemfiles/ruby_2.6_graphql_1.13.gemfile
@@ -6,7 +6,9 @@ gem "benchmark-ips", "~> 2.8"
 gem "benchmark-memory", "< 0.2"
 gem "climate_control", "~> 0.2.0"
 gem "concurrent-ruby"
+gem "dogstatsd-ruby", ">= 3.3.0", "!= 5.0.0", "!= 5.0.1", "!= 5.1.0"
 gem "extlz4", "~> 0.3", ">= 0.3.3"
+gem "google-protobuf", ["~> 3.0", "!= 3.7.0", "!= 3.7.1", "< 3.19.2"]
 gem "json-schema", "< 3"
 gem "memory_profiler", "~> 0.9"
 gem "os", "~> 1.1"
@@ -20,16 +22,14 @@ gem "rspec", "~> 3.13"
 gem "rspec-collection_matchers", "~> 1.1"
 gem "rspec-wait", "~> 0"
 gem "rspec_junit_formatter", ">= 0.5.1"
-gem "simplecov", git: "https://github.com/DataDog/simplecov", ref: "3bb6b7ee58bf4b1954ca205f50dd44d6f41c57db"
-gem "simplecov-cobertura", "~> 2.1.0"
-gem "warning", "~> 1"
-gem "webmock", ">= 3.10.0"
 gem "rubocop", "~> 1.50.0", require: false
 gem "rubocop-packaging", "~> 0.5.2", require: false
 gem "rubocop-performance", "~> 1.9", require: false
 gem "rubocop-rspec", ["~> 2.20", "< 2.21"], require: false
-gem "dogstatsd-ruby", ">= 3.3.0", "!= 5.0.0", "!= 5.0.1", "!= 5.1.0"
-gem "google-protobuf", ["~> 3.0", "!= 3.7.0", "!= 3.7.1", "< 3.19.2"]
+gem "simplecov", git: "https://github.com/DataDog/simplecov", ref: "3bb6b7ee58bf4b1954ca205f50dd44d6f41c57db"
+gem "simplecov-cobertura", "~> 2.1.0"
+gem "warning", "~> 1"
+gem "webmock", ">= 3.10.0"
 gem "rails", "~> 6.1.0"
 gem "graphql", "~> 1.13.0"
 gem "sprockets", "< 4"

--- a/gemfiles/ruby_2.6_graphql_2.0.gemfile
+++ b/gemfiles/ruby_2.6_graphql_2.0.gemfile
@@ -6,7 +6,9 @@ gem "benchmark-ips", "~> 2.8"
 gem "benchmark-memory", "< 0.2"
 gem "climate_control", "~> 0.2.0"
 gem "concurrent-ruby"
+gem "dogstatsd-ruby", ">= 3.3.0", "!= 5.0.0", "!= 5.0.1", "!= 5.1.0"
 gem "extlz4", "~> 0.3", ">= 0.3.3"
+gem "google-protobuf", ["~> 3.0", "!= 3.7.0", "!= 3.7.1", "< 3.19.2"]
 gem "json-schema", "< 3"
 gem "memory_profiler", "~> 0.9"
 gem "os", "~> 1.1"
@@ -20,16 +22,14 @@ gem "rspec", "~> 3.13"
 gem "rspec-collection_matchers", "~> 1.1"
 gem "rspec-wait", "~> 0"
 gem "rspec_junit_formatter", ">= 0.5.1"
-gem "simplecov", git: "https://github.com/DataDog/simplecov", ref: "3bb6b7ee58bf4b1954ca205f50dd44d6f41c57db"
-gem "simplecov-cobertura", "~> 2.1.0"
-gem "warning", "~> 1"
-gem "webmock", ">= 3.10.0"
 gem "rubocop", "~> 1.50.0", require: false
 gem "rubocop-packaging", "~> 0.5.2", require: false
 gem "rubocop-performance", "~> 1.9", require: false
 gem "rubocop-rspec", ["~> 2.20", "< 2.21"], require: false
-gem "dogstatsd-ruby", ">= 3.3.0", "!= 5.0.0", "!= 5.0.1", "!= 5.1.0"
-gem "google-protobuf", ["~> 3.0", "!= 3.7.0", "!= 3.7.1", "< 3.19.2"]
+gem "simplecov", git: "https://github.com/DataDog/simplecov", ref: "3bb6b7ee58bf4b1954ca205f50dd44d6f41c57db"
+gem "simplecov-cobertura", "~> 2.1.0"
+gem "warning", "~> 1"
+gem "webmock", ">= 3.10.0"
 gem "rails", "~> 6.1.0"
 gem "graphql", "~> 2.0.0"
 gem "sprockets", "< 4"

--- a/gemfiles/ruby_2.6_hanami_1.gemfile
+++ b/gemfiles/ruby_2.6_hanami_1.gemfile
@@ -6,7 +6,9 @@ gem "benchmark-ips", "~> 2.8"
 gem "benchmark-memory", "< 0.2"
 gem "climate_control", "~> 0.2.0"
 gem "concurrent-ruby"
+gem "dogstatsd-ruby", ">= 3.3.0", "!= 5.0.0", "!= 5.0.1", "!= 5.1.0"
 gem "extlz4", "~> 0.3", ">= 0.3.3"
+gem "google-protobuf", ["~> 3.0", "!= 3.7.0", "!= 3.7.1", "< 3.19.2"]
 gem "json-schema", "< 3"
 gem "memory_profiler", "~> 0.9"
 gem "os", "~> 1.1"
@@ -20,16 +22,14 @@ gem "rspec", "~> 3.13"
 gem "rspec-collection_matchers", "~> 1.1"
 gem "rspec-wait", "~> 0"
 gem "rspec_junit_formatter", ">= 0.5.1"
-gem "simplecov", git: "https://github.com/DataDog/simplecov", ref: "3bb6b7ee58bf4b1954ca205f50dd44d6f41c57db"
-gem "simplecov-cobertura", "~> 2.1.0"
-gem "warning", "~> 1"
-gem "webmock", ">= 3.10.0"
 gem "rubocop", "~> 1.50.0", require: false
 gem "rubocop-packaging", "~> 0.5.2", require: false
 gem "rubocop-performance", "~> 1.9", require: false
 gem "rubocop-rspec", ["~> 2.20", "< 2.21"], require: false
-gem "dogstatsd-ruby", ">= 3.3.0", "!= 5.0.0", "!= 5.0.1", "!= 5.1.0"
-gem "google-protobuf", ["~> 3.0", "!= 3.7.0", "!= 3.7.1", "< 3.19.2"]
+gem "simplecov", git: "https://github.com/DataDog/simplecov", ref: "3bb6b7ee58bf4b1954ca205f50dd44d6f41c57db"
+gem "simplecov-cobertura", "~> 2.1.0"
+gem "warning", "~> 1"
+gem "webmock", ">= 3.10.0"
 gem "rack"
 gem "rack-test"
 gem "hanami", "~> 1"

--- a/gemfiles/ruby_2.6_http.gemfile
+++ b/gemfiles/ruby_2.6_http.gemfile
@@ -6,7 +6,9 @@ gem "benchmark-ips", "~> 2.8"
 gem "benchmark-memory", "< 0.2"
 gem "climate_control", "~> 0.2.0"
 gem "concurrent-ruby"
+gem "dogstatsd-ruby", ">= 3.3.0", "!= 5.0.0", "!= 5.0.1", "!= 5.1.0"
 gem "extlz4", "~> 0.3", ">= 0.3.3"
+gem "google-protobuf", ["~> 3.0", "!= 3.7.0", "!= 3.7.1", "< 3.19.2"]
 gem "json-schema", "< 3"
 gem "memory_profiler", "~> 0.9"
 gem "os", "~> 1.1"
@@ -20,16 +22,14 @@ gem "rspec", "~> 3.13"
 gem "rspec-collection_matchers", "~> 1.1"
 gem "rspec-wait", "~> 0"
 gem "rspec_junit_formatter", ">= 0.5.1"
-gem "simplecov", git: "https://github.com/DataDog/simplecov", ref: "3bb6b7ee58bf4b1954ca205f50dd44d6f41c57db"
-gem "simplecov-cobertura", "~> 2.1.0"
-gem "warning", "~> 1"
-gem "webmock", ">= 3.10.0"
 gem "rubocop", "~> 1.50.0", require: false
 gem "rubocop-packaging", "~> 0.5.2", require: false
 gem "rubocop-performance", "~> 1.9", require: false
 gem "rubocop-rspec", ["~> 2.20", "< 2.21"], require: false
-gem "dogstatsd-ruby", ">= 3.3.0", "!= 5.0.0", "!= 5.0.1", "!= 5.1.0"
-gem "google-protobuf", ["~> 3.0", "!= 3.7.0", "!= 3.7.1", "< 3.19.2"]
+gem "simplecov", git: "https://github.com/DataDog/simplecov", ref: "3bb6b7ee58bf4b1954ca205f50dd44d6f41c57db"
+gem "simplecov-cobertura", "~> 2.1.0"
+gem "warning", "~> 1"
+gem "webmock", ">= 3.10.0"
 gem "ethon"
 gem "excon"
 gem "faraday"

--- a/gemfiles/ruby_2.6_opensearch_2.gemfile
+++ b/gemfiles/ruby_2.6_opensearch_2.gemfile
@@ -6,7 +6,9 @@ gem "benchmark-ips", "~> 2.8"
 gem "benchmark-memory", "< 0.2"
 gem "climate_control", "~> 0.2.0"
 gem "concurrent-ruby"
+gem "dogstatsd-ruby", ">= 3.3.0", "!= 5.0.0", "!= 5.0.1", "!= 5.1.0"
 gem "extlz4", "~> 0.3", ">= 0.3.3"
+gem "google-protobuf", ["~> 3.0", "!= 3.7.0", "!= 3.7.1", "< 3.19.2"]
 gem "json-schema", "< 3"
 gem "memory_profiler", "~> 0.9"
 gem "os", "~> 1.1"
@@ -20,16 +22,14 @@ gem "rspec", "~> 3.13"
 gem "rspec-collection_matchers", "~> 1.1"
 gem "rspec-wait", "~> 0"
 gem "rspec_junit_formatter", ">= 0.5.1"
-gem "simplecov", git: "https://github.com/DataDog/simplecov", ref: "3bb6b7ee58bf4b1954ca205f50dd44d6f41c57db"
-gem "simplecov-cobertura", "~> 2.1.0"
-gem "warning", "~> 1"
-gem "webmock", ">= 3.10.0"
 gem "rubocop", "~> 1.50.0", require: false
 gem "rubocop-packaging", "~> 0.5.2", require: false
 gem "rubocop-performance", "~> 1.9", require: false
 gem "rubocop-rspec", ["~> 2.20", "< 2.21"], require: false
-gem "dogstatsd-ruby", ">= 3.3.0", "!= 5.0.0", "!= 5.0.1", "!= 5.1.0"
-gem "google-protobuf", ["~> 3.0", "!= 3.7.0", "!= 3.7.1", "< 3.19.2"]
+gem "simplecov", git: "https://github.com/DataDog/simplecov", ref: "3bb6b7ee58bf4b1954ca205f50dd44d6f41c57db"
+gem "simplecov-cobertura", "~> 2.1.0"
+gem "warning", "~> 1"
+gem "webmock", ">= 3.10.0"
 gem "opensearch-ruby", "~> 2"
 
 group :check do

--- a/gemfiles/ruby_2.6_opensearch_3.gemfile
+++ b/gemfiles/ruby_2.6_opensearch_3.gemfile
@@ -6,7 +6,9 @@ gem "benchmark-ips", "~> 2.8"
 gem "benchmark-memory", "< 0.2"
 gem "climate_control", "~> 0.2.0"
 gem "concurrent-ruby"
+gem "dogstatsd-ruby", ">= 3.3.0", "!= 5.0.0", "!= 5.0.1", "!= 5.1.0"
 gem "extlz4", "~> 0.3", ">= 0.3.3"
+gem "google-protobuf", ["~> 3.0", "!= 3.7.0", "!= 3.7.1", "< 3.19.2"]
 gem "json-schema", "< 3"
 gem "memory_profiler", "~> 0.9"
 gem "os", "~> 1.1"
@@ -20,16 +22,14 @@ gem "rspec", "~> 3.13"
 gem "rspec-collection_matchers", "~> 1.1"
 gem "rspec-wait", "~> 0"
 gem "rspec_junit_formatter", ">= 0.5.1"
-gem "simplecov", git: "https://github.com/DataDog/simplecov", ref: "3bb6b7ee58bf4b1954ca205f50dd44d6f41c57db"
-gem "simplecov-cobertura", "~> 2.1.0"
-gem "warning", "~> 1"
-gem "webmock", ">= 3.10.0"
 gem "rubocop", "~> 1.50.0", require: false
 gem "rubocop-packaging", "~> 0.5.2", require: false
 gem "rubocop-performance", "~> 1.9", require: false
 gem "rubocop-rspec", ["~> 2.20", "< 2.21"], require: false
-gem "dogstatsd-ruby", ">= 3.3.0", "!= 5.0.0", "!= 5.0.1", "!= 5.1.0"
-gem "google-protobuf", ["~> 3.0", "!= 3.7.0", "!= 3.7.1", "< 3.19.2"]
+gem "simplecov", git: "https://github.com/DataDog/simplecov", ref: "3bb6b7ee58bf4b1954ca205f50dd44d6f41c57db"
+gem "simplecov-cobertura", "~> 2.1.0"
+gem "warning", "~> 1"
+gem "webmock", ">= 3.10.0"
 gem "opensearch-ruby", "~> 3"
 
 group :check do

--- a/gemfiles/ruby_2.6_opensearch_latest.gemfile
+++ b/gemfiles/ruby_2.6_opensearch_latest.gemfile
@@ -6,7 +6,9 @@ gem "benchmark-ips", "~> 2.8"
 gem "benchmark-memory", "< 0.2"
 gem "climate_control", "~> 0.2.0"
 gem "concurrent-ruby"
+gem "dogstatsd-ruby", ">= 3.3.0", "!= 5.0.0", "!= 5.0.1", "!= 5.1.0"
 gem "extlz4", "~> 0.3", ">= 0.3.3"
+gem "google-protobuf", ["~> 3.0", "!= 3.7.0", "!= 3.7.1", "< 3.19.2"]
 gem "json-schema", "< 3"
 gem "memory_profiler", "~> 0.9"
 gem "os", "~> 1.1"
@@ -20,16 +22,14 @@ gem "rspec", "~> 3.13"
 gem "rspec-collection_matchers", "~> 1.1"
 gem "rspec-wait", "~> 0"
 gem "rspec_junit_formatter", ">= 0.5.1"
-gem "simplecov", git: "https://github.com/DataDog/simplecov", ref: "3bb6b7ee58bf4b1954ca205f50dd44d6f41c57db"
-gem "simplecov-cobertura", "~> 2.1.0"
-gem "warning", "~> 1"
-gem "webmock", ">= 3.10.0"
 gem "rubocop", "~> 1.50.0", require: false
 gem "rubocop-packaging", "~> 0.5.2", require: false
 gem "rubocop-performance", "~> 1.9", require: false
 gem "rubocop-rspec", ["~> 2.20", "< 2.21"], require: false
-gem "dogstatsd-ruby", ">= 3.3.0", "!= 5.0.0", "!= 5.0.1", "!= 5.1.0"
-gem "google-protobuf", ["~> 3.0", "!= 3.7.0", "!= 3.7.1", "< 3.19.2"]
+gem "simplecov", git: "https://github.com/DataDog/simplecov", ref: "3bb6b7ee58bf4b1954ca205f50dd44d6f41c57db"
+gem "simplecov-cobertura", "~> 2.1.0"
+gem "warning", "~> 1"
+gem "webmock", ">= 3.10.0"
 gem "opensearch-ruby"
 
 group :check do

--- a/gemfiles/ruby_2.6_opentelemetry.gemfile
+++ b/gemfiles/ruby_2.6_opentelemetry.gemfile
@@ -6,7 +6,9 @@ gem "benchmark-ips", "~> 2.8"
 gem "benchmark-memory", "< 0.2"
 gem "climate_control", "~> 0.2.0"
 gem "concurrent-ruby"
+gem "dogstatsd-ruby", ">= 3.3.0", "!= 5.0.0", "!= 5.0.1", "!= 5.1.0"
 gem "extlz4", "~> 0.3", ">= 0.3.3"
+gem "google-protobuf", ["~> 3.0", "!= 3.7.0", "!= 3.7.1", "< 3.19.2"]
 gem "json-schema", "< 3"
 gem "memory_profiler", "~> 0.9"
 gem "os", "~> 1.1"
@@ -20,16 +22,14 @@ gem "rspec", "~> 3.13"
 gem "rspec-collection_matchers", "~> 1.1"
 gem "rspec-wait", "~> 0"
 gem "rspec_junit_formatter", ">= 0.5.1"
-gem "simplecov", git: "https://github.com/DataDog/simplecov", ref: "3bb6b7ee58bf4b1954ca205f50dd44d6f41c57db"
-gem "simplecov-cobertura", "~> 2.1.0"
-gem "warning", "~> 1"
-gem "webmock", ">= 3.10.0"
 gem "rubocop", "~> 1.50.0", require: false
 gem "rubocop-packaging", "~> 0.5.2", require: false
 gem "rubocop-performance", "~> 1.9", require: false
 gem "rubocop-rspec", ["~> 2.20", "< 2.21"], require: false
-gem "dogstatsd-ruby", ">= 3.3.0", "!= 5.0.0", "!= 5.0.1", "!= 5.1.0"
-gem "google-protobuf", ["~> 3.0", "!= 3.7.0", "!= 3.7.1", "< 3.19.2"]
+gem "simplecov", git: "https://github.com/DataDog/simplecov", ref: "3bb6b7ee58bf4b1954ca205f50dd44d6f41c57db"
+gem "simplecov-cobertura", "~> 2.1.0"
+gem "warning", "~> 1"
+gem "webmock", ">= 3.10.0"
 gem "opentelemetry-sdk", "~> 1.1"
 
 group :check do

--- a/gemfiles/ruby_2.6_opentelemetry_otlp.gemfile
+++ b/gemfiles/ruby_2.6_opentelemetry_otlp.gemfile
@@ -6,7 +6,9 @@ gem "benchmark-ips", "~> 2.8"
 gem "benchmark-memory", "< 0.2"
 gem "climate_control", "~> 0.2.0"
 gem "concurrent-ruby"
+gem "dogstatsd-ruby", ">= 3.3.0", "!= 5.0.0", "!= 5.0.1", "!= 5.1.0"
 gem "extlz4", "~> 0.3", ">= 0.3.3"
+gem "google-protobuf", ["~> 3.0", "!= 3.7.0", "!= 3.7.1", "< 3.19.2"]
 gem "json-schema", "< 3"
 gem "memory_profiler", "~> 0.9"
 gem "os", "~> 1.1"
@@ -20,16 +22,14 @@ gem "rspec", "~> 3.13"
 gem "rspec-collection_matchers", "~> 1.1"
 gem "rspec-wait", "~> 0"
 gem "rspec_junit_formatter", ">= 0.5.1"
-gem "simplecov", git: "https://github.com/DataDog/simplecov", ref: "3bb6b7ee58bf4b1954ca205f50dd44d6f41c57db"
-gem "simplecov-cobertura", "~> 2.1.0"
-gem "warning", "~> 1"
-gem "webmock", ">= 3.10.0"
 gem "rubocop", "~> 1.50.0", require: false
 gem "rubocop-packaging", "~> 0.5.2", require: false
 gem "rubocop-performance", "~> 1.9", require: false
 gem "rubocop-rspec", ["~> 2.20", "< 2.21"], require: false
-gem "dogstatsd-ruby", ">= 3.3.0", "!= 5.0.0", "!= 5.0.1", "!= 5.1.0"
-gem "google-protobuf", ["~> 3.0", "!= 3.7.0", "!= 3.7.1", "< 3.19.2"]
+gem "simplecov", git: "https://github.com/DataDog/simplecov", ref: "3bb6b7ee58bf4b1954ca205f50dd44d6f41c57db"
+gem "simplecov-cobertura", "~> 2.1.0"
+gem "warning", "~> 1"
+gem "webmock", ">= 3.10.0"
 gem "opentelemetry-sdk", "~> 1.1"
 gem "opentelemetry-exporter-otlp"
 

--- a/gemfiles/ruby_2.6_rack_1.gemfile
+++ b/gemfiles/ruby_2.6_rack_1.gemfile
@@ -6,7 +6,9 @@ gem "benchmark-ips", "~> 2.8"
 gem "benchmark-memory", "< 0.2"
 gem "climate_control", "~> 0.2.0"
 gem "concurrent-ruby"
+gem "dogstatsd-ruby", ">= 3.3.0", "!= 5.0.0", "!= 5.0.1", "!= 5.1.0"
 gem "extlz4", "~> 0.3", ">= 0.3.3"
+gem "google-protobuf", ["~> 3.0", "!= 3.7.0", "!= 3.7.1", "< 3.19.2"]
 gem "json-schema", "< 3"
 gem "memory_profiler", "~> 0.9"
 gem "os", "~> 1.1"
@@ -20,16 +22,14 @@ gem "rspec", "~> 3.13"
 gem "rspec-collection_matchers", "~> 1.1"
 gem "rspec-wait", "~> 0"
 gem "rspec_junit_formatter", ">= 0.5.1"
-gem "simplecov", git: "https://github.com/DataDog/simplecov", ref: "3bb6b7ee58bf4b1954ca205f50dd44d6f41c57db"
-gem "simplecov-cobertura", "~> 2.1.0"
-gem "warning", "~> 1"
-gem "webmock", ">= 3.10.0"
 gem "rubocop", "~> 1.50.0", require: false
 gem "rubocop-packaging", "~> 0.5.2", require: false
 gem "rubocop-performance", "~> 1.9", require: false
 gem "rubocop-rspec", ["~> 2.20", "< 2.21"], require: false
-gem "dogstatsd-ruby", ">= 3.3.0", "!= 5.0.0", "!= 5.0.1", "!= 5.1.0"
-gem "google-protobuf", ["~> 3.0", "!= 3.7.0", "!= 3.7.1", "< 3.19.2"]
+gem "simplecov", git: "https://github.com/DataDog/simplecov", ref: "3bb6b7ee58bf4b1954ca205f50dd44d6f41c57db"
+gem "simplecov-cobertura", "~> 2.1.0"
+gem "warning", "~> 1"
+gem "webmock", ">= 3.10.0"
 gem "rack", "~> 1"
 gem "rack-contrib"
 gem "rack-test"

--- a/gemfiles/ruby_2.6_rack_2.gemfile
+++ b/gemfiles/ruby_2.6_rack_2.gemfile
@@ -6,7 +6,9 @@ gem "benchmark-ips", "~> 2.8"
 gem "benchmark-memory", "< 0.2"
 gem "climate_control", "~> 0.2.0"
 gem "concurrent-ruby"
+gem "dogstatsd-ruby", ">= 3.3.0", "!= 5.0.0", "!= 5.0.1", "!= 5.1.0"
 gem "extlz4", "~> 0.3", ">= 0.3.3"
+gem "google-protobuf", ["~> 3.0", "!= 3.7.0", "!= 3.7.1", "< 3.19.2"]
 gem "json-schema", "< 3"
 gem "memory_profiler", "~> 0.9"
 gem "os", "~> 1.1"
@@ -20,16 +22,14 @@ gem "rspec", "~> 3.13"
 gem "rspec-collection_matchers", "~> 1.1"
 gem "rspec-wait", "~> 0"
 gem "rspec_junit_formatter", ">= 0.5.1"
-gem "simplecov", git: "https://github.com/DataDog/simplecov", ref: "3bb6b7ee58bf4b1954ca205f50dd44d6f41c57db"
-gem "simplecov-cobertura", "~> 2.1.0"
-gem "warning", "~> 1"
-gem "webmock", ">= 3.10.0"
 gem "rubocop", "~> 1.50.0", require: false
 gem "rubocop-packaging", "~> 0.5.2", require: false
 gem "rubocop-performance", "~> 1.9", require: false
 gem "rubocop-rspec", ["~> 2.20", "< 2.21"], require: false
-gem "dogstatsd-ruby", ">= 3.3.0", "!= 5.0.0", "!= 5.0.1", "!= 5.1.0"
-gem "google-protobuf", ["~> 3.0", "!= 3.7.0", "!= 3.7.1", "< 3.19.2"]
+gem "simplecov", git: "https://github.com/DataDog/simplecov", ref: "3bb6b7ee58bf4b1954ca205f50dd44d6f41c57db"
+gem "simplecov-cobertura", "~> 2.1.0"
+gem "warning", "~> 1"
+gem "webmock", ">= 3.10.0"
 gem "rack", "~> 2"
 gem "rack-contrib"
 gem "rack-test"

--- a/gemfiles/ruby_2.6_rack_3.gemfile
+++ b/gemfiles/ruby_2.6_rack_3.gemfile
@@ -6,7 +6,9 @@ gem "benchmark-ips", "~> 2.8"
 gem "benchmark-memory", "< 0.2"
 gem "climate_control", "~> 0.2.0"
 gem "concurrent-ruby"
+gem "dogstatsd-ruby", ">= 3.3.0", "!= 5.0.0", "!= 5.0.1", "!= 5.1.0"
 gem "extlz4", "~> 0.3", ">= 0.3.3"
+gem "google-protobuf", ["~> 3.0", "!= 3.7.0", "!= 3.7.1", "< 3.19.2"]
 gem "json-schema", "< 3"
 gem "memory_profiler", "~> 0.9"
 gem "os", "~> 1.1"
@@ -20,16 +22,14 @@ gem "rspec", "~> 3.13"
 gem "rspec-collection_matchers", "~> 1.1"
 gem "rspec-wait", "~> 0"
 gem "rspec_junit_formatter", ">= 0.5.1"
-gem "simplecov", git: "https://github.com/DataDog/simplecov", ref: "3bb6b7ee58bf4b1954ca205f50dd44d6f41c57db"
-gem "simplecov-cobertura", "~> 2.1.0"
-gem "warning", "~> 1"
-gem "webmock", ">= 3.10.0"
 gem "rubocop", "~> 1.50.0", require: false
 gem "rubocop-packaging", "~> 0.5.2", require: false
 gem "rubocop-performance", "~> 1.9", require: false
 gem "rubocop-rspec", ["~> 2.20", "< 2.21"], require: false
-gem "dogstatsd-ruby", ">= 3.3.0", "!= 5.0.0", "!= 5.0.1", "!= 5.1.0"
-gem "google-protobuf", ["~> 3.0", "!= 3.7.0", "!= 3.7.1", "< 3.19.2"]
+gem "simplecov", git: "https://github.com/DataDog/simplecov", ref: "3bb6b7ee58bf4b1954ca205f50dd44d6f41c57db"
+gem "simplecov-cobertura", "~> 2.1.0"
+gem "warning", "~> 1"
+gem "webmock", ">= 3.10.0"
 gem "rack", "~> 3"
 gem "rack-contrib"
 gem "rack-test"

--- a/gemfiles/ruby_2.6_rack_latest.gemfile
+++ b/gemfiles/ruby_2.6_rack_latest.gemfile
@@ -6,7 +6,9 @@ gem "benchmark-ips", "~> 2.8"
 gem "benchmark-memory", "< 0.2"
 gem "climate_control", "~> 0.2.0"
 gem "concurrent-ruby"
+gem "dogstatsd-ruby", ">= 3.3.0", "!= 5.0.0", "!= 5.0.1", "!= 5.1.0"
 gem "extlz4", "~> 0.3", ">= 0.3.3"
+gem "google-protobuf", ["~> 3.0", "!= 3.7.0", "!= 3.7.1", "< 3.19.2"]
 gem "json-schema", "< 3"
 gem "memory_profiler", "~> 0.9"
 gem "os", "~> 1.1"
@@ -20,16 +22,14 @@ gem "rspec", "~> 3.13"
 gem "rspec-collection_matchers", "~> 1.1"
 gem "rspec-wait", "~> 0"
 gem "rspec_junit_formatter", ">= 0.5.1"
-gem "simplecov", git: "https://github.com/DataDog/simplecov", ref: "3bb6b7ee58bf4b1954ca205f50dd44d6f41c57db"
-gem "simplecov-cobertura", "~> 2.1.0"
-gem "warning", "~> 1"
-gem "webmock", ">= 3.10.0"
 gem "rubocop", "~> 1.50.0", require: false
 gem "rubocop-packaging", "~> 0.5.2", require: false
 gem "rubocop-performance", "~> 1.9", require: false
 gem "rubocop-rspec", ["~> 2.20", "< 2.21"], require: false
-gem "dogstatsd-ruby", ">= 3.3.0", "!= 5.0.0", "!= 5.0.1", "!= 5.1.0"
-gem "google-protobuf", ["~> 3.0", "!= 3.7.0", "!= 3.7.1", "< 3.19.2"]
+gem "simplecov", git: "https://github.com/DataDog/simplecov", ref: "3bb6b7ee58bf4b1954ca205f50dd44d6f41c57db"
+gem "simplecov-cobertura", "~> 2.1.0"
+gem "warning", "~> 1"
+gem "webmock", ">= 3.10.0"
 gem "rack"
 gem "rack-contrib"
 gem "rack-test"

--- a/gemfiles/ruby_2.6_rails5_mysql2.gemfile
+++ b/gemfiles/ruby_2.6_rails5_mysql2.gemfile
@@ -6,7 +6,9 @@ gem "benchmark-ips", "~> 2.8"
 gem "benchmark-memory", "< 0.2"
 gem "climate_control", "~> 0.2.0"
 gem "concurrent-ruby"
+gem "dogstatsd-ruby", ">= 3.3.0", "!= 5.0.0", "!= 5.0.1", "!= 5.1.0"
 gem "extlz4", "~> 0.3", ">= 0.3.3"
+gem "google-protobuf", ["~> 3.0", "!= 3.7.0", "!= 3.7.1", "< 3.19.2"]
 gem "json-schema", "< 3"
 gem "memory_profiler", "~> 0.9"
 gem "os", "~> 1.1"
@@ -20,16 +22,14 @@ gem "rspec", "~> 3.13"
 gem "rspec-collection_matchers", "~> 1.1"
 gem "rspec-wait", "~> 0"
 gem "rspec_junit_formatter", ">= 0.5.1"
-gem "simplecov", git: "https://github.com/DataDog/simplecov", ref: "3bb6b7ee58bf4b1954ca205f50dd44d6f41c57db"
-gem "simplecov-cobertura", "~> 2.1.0"
-gem "warning", "~> 1"
-gem "webmock", ">= 3.10.0"
 gem "rubocop", "~> 1.50.0", require: false
 gem "rubocop-packaging", "~> 0.5.2", require: false
 gem "rubocop-performance", "~> 1.9", require: false
 gem "rubocop-rspec", ["~> 2.20", "< 2.21"], require: false
-gem "dogstatsd-ruby", ">= 3.3.0", "!= 5.0.0", "!= 5.0.1", "!= 5.1.0"
-gem "google-protobuf", ["~> 3.0", "!= 3.7.0", "!= 3.7.1", "< 3.19.2"]
+gem "simplecov", git: "https://github.com/DataDog/simplecov", ref: "3bb6b7ee58bf4b1954ca205f50dd44d6f41c57db"
+gem "simplecov-cobertura", "~> 2.1.0"
+gem "warning", "~> 1"
+gem "webmock", ">= 3.10.0"
 gem "rails", "~> 5.2.1"
 gem "mysql2", "< 1", platform: :ruby
 gem "sprockets", "< 4"

--- a/gemfiles/ruby_2.6_rails5_postgres.gemfile
+++ b/gemfiles/ruby_2.6_rails5_postgres.gemfile
@@ -6,7 +6,9 @@ gem "benchmark-ips", "~> 2.8"
 gem "benchmark-memory", "< 0.2"
 gem "climate_control", "~> 0.2.0"
 gem "concurrent-ruby"
+gem "dogstatsd-ruby", ">= 3.3.0", "!= 5.0.0", "!= 5.0.1", "!= 5.1.0"
 gem "extlz4", "~> 0.3", ">= 0.3.3"
+gem "google-protobuf", ["~> 3.0", "!= 3.7.0", "!= 3.7.1", "< 3.19.2"]
 gem "json-schema", "< 3"
 gem "memory_profiler", "~> 0.9"
 gem "os", "~> 1.1"
@@ -20,16 +22,14 @@ gem "rspec", "~> 3.13"
 gem "rspec-collection_matchers", "~> 1.1"
 gem "rspec-wait", "~> 0"
 gem "rspec_junit_formatter", ">= 0.5.1"
-gem "simplecov", git: "https://github.com/DataDog/simplecov", ref: "3bb6b7ee58bf4b1954ca205f50dd44d6f41c57db"
-gem "simplecov-cobertura", "~> 2.1.0"
-gem "warning", "~> 1"
-gem "webmock", ">= 3.10.0"
 gem "rubocop", "~> 1.50.0", require: false
 gem "rubocop-packaging", "~> 0.5.2", require: false
 gem "rubocop-performance", "~> 1.9", require: false
 gem "rubocop-rspec", ["~> 2.20", "< 2.21"], require: false
-gem "dogstatsd-ruby", ">= 3.3.0", "!= 5.0.0", "!= 5.0.1", "!= 5.1.0"
-gem "google-protobuf", ["~> 3.0", "!= 3.7.0", "!= 3.7.1", "< 3.19.2"]
+gem "simplecov", git: "https://github.com/DataDog/simplecov", ref: "3bb6b7ee58bf4b1954ca205f50dd44d6f41c57db"
+gem "simplecov-cobertura", "~> 2.1.0"
+gem "warning", "~> 1"
+gem "webmock", ">= 3.10.0"
 gem "rails", "~> 5.2.1"
 gem "pg", "< 1.0", platform: :ruby
 gem "sprockets", "< 4"

--- a/gemfiles/ruby_2.6_rails5_postgres_redis.gemfile
+++ b/gemfiles/ruby_2.6_rails5_postgres_redis.gemfile
@@ -6,7 +6,9 @@ gem "benchmark-ips", "~> 2.8"
 gem "benchmark-memory", "< 0.2"
 gem "climate_control", "~> 0.2.0"
 gem "concurrent-ruby"
+gem "dogstatsd-ruby", ">= 3.3.0", "!= 5.0.0", "!= 5.0.1", "!= 5.1.0"
 gem "extlz4", "~> 0.3", ">= 0.3.3"
+gem "google-protobuf", ["~> 3.0", "!= 3.7.0", "!= 3.7.1", "< 3.19.2"]
 gem "json-schema", "< 3"
 gem "memory_profiler", "~> 0.9"
 gem "os", "~> 1.1"
@@ -20,16 +22,14 @@ gem "rspec", "~> 3.13"
 gem "rspec-collection_matchers", "~> 1.1"
 gem "rspec-wait", "~> 0"
 gem "rspec_junit_formatter", ">= 0.5.1"
-gem "simplecov", git: "https://github.com/DataDog/simplecov", ref: "3bb6b7ee58bf4b1954ca205f50dd44d6f41c57db"
-gem "simplecov-cobertura", "~> 2.1.0"
-gem "warning", "~> 1"
-gem "webmock", ">= 3.10.0"
 gem "rubocop", "~> 1.50.0", require: false
 gem "rubocop-packaging", "~> 0.5.2", require: false
 gem "rubocop-performance", "~> 1.9", require: false
 gem "rubocop-rspec", ["~> 2.20", "< 2.21"], require: false
-gem "dogstatsd-ruby", ">= 3.3.0", "!= 5.0.0", "!= 5.0.1", "!= 5.1.0"
-gem "google-protobuf", ["~> 3.0", "!= 3.7.0", "!= 3.7.1", "< 3.19.2"]
+gem "simplecov", git: "https://github.com/DataDog/simplecov", ref: "3bb6b7ee58bf4b1954ca205f50dd44d6f41c57db"
+gem "simplecov-cobertura", "~> 2.1.0"
+gem "warning", "~> 1"
+gem "webmock", ">= 3.10.0"
 gem "rails", "~> 5.2.1"
 gem "pg", "< 1.0", platform: :ruby
 gem "redis", "~> 4"

--- a/gemfiles/ruby_2.6_rails5_postgres_redis_activesupport.gemfile
+++ b/gemfiles/ruby_2.6_rails5_postgres_redis_activesupport.gemfile
@@ -6,7 +6,9 @@ gem "benchmark-ips", "~> 2.8"
 gem "benchmark-memory", "< 0.2"
 gem "climate_control", "~> 0.2.0"
 gem "concurrent-ruby"
+gem "dogstatsd-ruby", ">= 3.3.0", "!= 5.0.0", "!= 5.0.1", "!= 5.1.0"
 gem "extlz4", "~> 0.3", ">= 0.3.3"
+gem "google-protobuf", ["~> 3.0", "!= 3.7.0", "!= 3.7.1", "< 3.19.2"]
 gem "json-schema", "< 3"
 gem "memory_profiler", "~> 0.9"
 gem "os", "~> 1.1"
@@ -20,16 +22,14 @@ gem "rspec", "~> 3.13"
 gem "rspec-collection_matchers", "~> 1.1"
 gem "rspec-wait", "~> 0"
 gem "rspec_junit_formatter", ">= 0.5.1"
-gem "simplecov", git: "https://github.com/DataDog/simplecov", ref: "3bb6b7ee58bf4b1954ca205f50dd44d6f41c57db"
-gem "simplecov-cobertura", "~> 2.1.0"
-gem "warning", "~> 1"
-gem "webmock", ">= 3.10.0"
 gem "rubocop", "~> 1.50.0", require: false
 gem "rubocop-packaging", "~> 0.5.2", require: false
 gem "rubocop-performance", "~> 1.9", require: false
 gem "rubocop-rspec", ["~> 2.20", "< 2.21"], require: false
-gem "dogstatsd-ruby", ">= 3.3.0", "!= 5.0.0", "!= 5.0.1", "!= 5.1.0"
-gem "google-protobuf", ["~> 3.0", "!= 3.7.0", "!= 3.7.1", "< 3.19.2"]
+gem "simplecov", git: "https://github.com/DataDog/simplecov", ref: "3bb6b7ee58bf4b1954ca205f50dd44d6f41c57db"
+gem "simplecov-cobertura", "~> 2.1.0"
+gem "warning", "~> 1"
+gem "webmock", ">= 3.10.0"
 gem "rails", "~> 5.2.1"
 gem "pg", "< 1.0", platform: :ruby
 gem "redis", "~> 4"

--- a/gemfiles/ruby_2.6_rails5_postgres_sidekiq.gemfile
+++ b/gemfiles/ruby_2.6_rails5_postgres_sidekiq.gemfile
@@ -6,7 +6,9 @@ gem "benchmark-ips", "~> 2.8"
 gem "benchmark-memory", "< 0.2"
 gem "climate_control", "~> 0.2.0"
 gem "concurrent-ruby"
+gem "dogstatsd-ruby", ">= 3.3.0", "!= 5.0.0", "!= 5.0.1", "!= 5.1.0"
 gem "extlz4", "~> 0.3", ">= 0.3.3"
+gem "google-protobuf", ["~> 3.0", "!= 3.7.0", "!= 3.7.1", "< 3.19.2"]
 gem "json-schema", "< 3"
 gem "memory_profiler", "~> 0.9"
 gem "os", "~> 1.1"
@@ -20,16 +22,14 @@ gem "rspec", "~> 3.13"
 gem "rspec-collection_matchers", "~> 1.1"
 gem "rspec-wait", "~> 0"
 gem "rspec_junit_formatter", ">= 0.5.1"
-gem "simplecov", git: "https://github.com/DataDog/simplecov", ref: "3bb6b7ee58bf4b1954ca205f50dd44d6f41c57db"
-gem "simplecov-cobertura", "~> 2.1.0"
-gem "warning", "~> 1"
-gem "webmock", ">= 3.10.0"
 gem "rubocop", "~> 1.50.0", require: false
 gem "rubocop-packaging", "~> 0.5.2", require: false
 gem "rubocop-performance", "~> 1.9", require: false
 gem "rubocop-rspec", ["~> 2.20", "< 2.21"], require: false
-gem "dogstatsd-ruby", ">= 3.3.0", "!= 5.0.0", "!= 5.0.1", "!= 5.1.0"
-gem "google-protobuf", ["~> 3.0", "!= 3.7.0", "!= 3.7.1", "< 3.19.2"]
+gem "simplecov", git: "https://github.com/DataDog/simplecov", ref: "3bb6b7ee58bf4b1954ca205f50dd44d6f41c57db"
+gem "simplecov-cobertura", "~> 2.1.0"
+gem "warning", "~> 1"
+gem "webmock", ">= 3.10.0"
 gem "rails", "~> 5.2.1"
 gem "pg", "< 1.0", platform: :ruby
 gem "sidekiq"

--- a/gemfiles/ruby_2.6_rails5_semantic_logger.gemfile
+++ b/gemfiles/ruby_2.6_rails5_semantic_logger.gemfile
@@ -6,7 +6,9 @@ gem "benchmark-ips", "~> 2.8"
 gem "benchmark-memory", "< 0.2"
 gem "climate_control", "~> 0.2.0"
 gem "concurrent-ruby"
+gem "dogstatsd-ruby", ">= 3.3.0", "!= 5.0.0", "!= 5.0.1", "!= 5.1.0"
 gem "extlz4", "~> 0.3", ">= 0.3.3"
+gem "google-protobuf", ["~> 3.0", "!= 3.7.0", "!= 3.7.1", "< 3.19.2"]
 gem "json-schema", "< 3"
 gem "memory_profiler", "~> 0.9"
 gem "os", "~> 1.1"
@@ -20,16 +22,14 @@ gem "rspec", "~> 3.13"
 gem "rspec-collection_matchers", "~> 1.1"
 gem "rspec-wait", "~> 0"
 gem "rspec_junit_formatter", ">= 0.5.1"
-gem "simplecov", git: "https://github.com/DataDog/simplecov", ref: "3bb6b7ee58bf4b1954ca205f50dd44d6f41c57db"
-gem "simplecov-cobertura", "~> 2.1.0"
-gem "warning", "~> 1"
-gem "webmock", ">= 3.10.0"
 gem "rubocop", "~> 1.50.0", require: false
 gem "rubocop-packaging", "~> 0.5.2", require: false
 gem "rubocop-performance", "~> 1.9", require: false
 gem "rubocop-rspec", ["~> 2.20", "< 2.21"], require: false
-gem "dogstatsd-ruby", ">= 3.3.0", "!= 5.0.0", "!= 5.0.1", "!= 5.1.0"
-gem "google-protobuf", ["~> 3.0", "!= 3.7.0", "!= 3.7.1", "< 3.19.2"]
+gem "simplecov", git: "https://github.com/DataDog/simplecov", ref: "3bb6b7ee58bf4b1954ca205f50dd44d6f41c57db"
+gem "simplecov-cobertura", "~> 2.1.0"
+gem "warning", "~> 1"
+gem "webmock", ">= 3.10.0"
 gem "rails", "~> 5.2.1"
 gem "pg", "< 1.0", platform: :ruby
 gem "sprockets", "< 4"

--- a/gemfiles/ruby_2.6_rails61_mysql2.gemfile
+++ b/gemfiles/ruby_2.6_rails61_mysql2.gemfile
@@ -6,7 +6,9 @@ gem "benchmark-ips", "~> 2.8"
 gem "benchmark-memory", "< 0.2"
 gem "climate_control", "~> 0.2.0"
 gem "concurrent-ruby"
+gem "dogstatsd-ruby", ">= 3.3.0", "!= 5.0.0", "!= 5.0.1", "!= 5.1.0"
 gem "extlz4", "~> 0.3", ">= 0.3.3"
+gem "google-protobuf", ["~> 3.0", "!= 3.7.0", "!= 3.7.1", "< 3.19.2"]
 gem "json-schema", "< 3"
 gem "memory_profiler", "~> 0.9"
 gem "os", "~> 1.1"
@@ -20,16 +22,14 @@ gem "rspec", "~> 3.13"
 gem "rspec-collection_matchers", "~> 1.1"
 gem "rspec-wait", "~> 0"
 gem "rspec_junit_formatter", ">= 0.5.1"
-gem "simplecov", git: "https://github.com/DataDog/simplecov", ref: "3bb6b7ee58bf4b1954ca205f50dd44d6f41c57db"
-gem "simplecov-cobertura", "~> 2.1.0"
-gem "warning", "~> 1"
-gem "webmock", ">= 3.10.0"
 gem "rubocop", "~> 1.50.0", require: false
 gem "rubocop-packaging", "~> 0.5.2", require: false
 gem "rubocop-performance", "~> 1.9", require: false
 gem "rubocop-rspec", ["~> 2.20", "< 2.21"], require: false
-gem "dogstatsd-ruby", ">= 3.3.0", "!= 5.0.0", "!= 5.0.1", "!= 5.1.0"
-gem "google-protobuf", ["~> 3.0", "!= 3.7.0", "!= 3.7.1", "< 3.19.2"]
+gem "simplecov", git: "https://github.com/DataDog/simplecov", ref: "3bb6b7ee58bf4b1954ca205f50dd44d6f41c57db"
+gem "simplecov-cobertura", "~> 2.1.0"
+gem "warning", "~> 1"
+gem "webmock", ">= 3.10.0"
 gem "rails", "~> 6.1.0"
 gem "mysql2", "~> 0.5", platform: :ruby
 gem "sprockets", "< 4"

--- a/gemfiles/ruby_2.6_rails61_postgres.gemfile
+++ b/gemfiles/ruby_2.6_rails61_postgres.gemfile
@@ -6,7 +6,9 @@ gem "benchmark-ips", "~> 2.8"
 gem "benchmark-memory", "< 0.2"
 gem "climate_control", "~> 0.2.0"
 gem "concurrent-ruby"
+gem "dogstatsd-ruby", ">= 3.3.0", "!= 5.0.0", "!= 5.0.1", "!= 5.1.0"
 gem "extlz4", "~> 0.3", ">= 0.3.3"
+gem "google-protobuf", ["~> 3.0", "!= 3.7.0", "!= 3.7.1", "< 3.19.2"]
 gem "json-schema", "< 3"
 gem "memory_profiler", "~> 0.9"
 gem "os", "~> 1.1"
@@ -20,16 +22,14 @@ gem "rspec", "~> 3.13"
 gem "rspec-collection_matchers", "~> 1.1"
 gem "rspec-wait", "~> 0"
 gem "rspec_junit_formatter", ">= 0.5.1"
-gem "simplecov", git: "https://github.com/DataDog/simplecov", ref: "3bb6b7ee58bf4b1954ca205f50dd44d6f41c57db"
-gem "simplecov-cobertura", "~> 2.1.0"
-gem "warning", "~> 1"
-gem "webmock", ">= 3.10.0"
 gem "rubocop", "~> 1.50.0", require: false
 gem "rubocop-packaging", "~> 0.5.2", require: false
 gem "rubocop-performance", "~> 1.9", require: false
 gem "rubocop-rspec", ["~> 2.20", "< 2.21"], require: false
-gem "dogstatsd-ruby", ">= 3.3.0", "!= 5.0.0", "!= 5.0.1", "!= 5.1.0"
-gem "google-protobuf", ["~> 3.0", "!= 3.7.0", "!= 3.7.1", "< 3.19.2"]
+gem "simplecov", git: "https://github.com/DataDog/simplecov", ref: "3bb6b7ee58bf4b1954ca205f50dd44d6f41c57db"
+gem "simplecov-cobertura", "~> 2.1.0"
+gem "warning", "~> 1"
+gem "webmock", ">= 3.10.0"
 gem "rails", "~> 6.1.0"
 gem "pg", ">= 1.1", platform: :ruby
 gem "sprockets", "< 4"

--- a/gemfiles/ruby_2.6_rails61_postgres_redis.gemfile
+++ b/gemfiles/ruby_2.6_rails61_postgres_redis.gemfile
@@ -6,7 +6,9 @@ gem "benchmark-ips", "~> 2.8"
 gem "benchmark-memory", "< 0.2"
 gem "climate_control", "~> 0.2.0"
 gem "concurrent-ruby"
+gem "dogstatsd-ruby", ">= 3.3.0", "!= 5.0.0", "!= 5.0.1", "!= 5.1.0"
 gem "extlz4", "~> 0.3", ">= 0.3.3"
+gem "google-protobuf", ["~> 3.0", "!= 3.7.0", "!= 3.7.1", "< 3.19.2"]
 gem "json-schema", "< 3"
 gem "memory_profiler", "~> 0.9"
 gem "os", "~> 1.1"
@@ -20,16 +22,14 @@ gem "rspec", "~> 3.13"
 gem "rspec-collection_matchers", "~> 1.1"
 gem "rspec-wait", "~> 0"
 gem "rspec_junit_formatter", ">= 0.5.1"
-gem "simplecov", git: "https://github.com/DataDog/simplecov", ref: "3bb6b7ee58bf4b1954ca205f50dd44d6f41c57db"
-gem "simplecov-cobertura", "~> 2.1.0"
-gem "warning", "~> 1"
-gem "webmock", ">= 3.10.0"
 gem "rubocop", "~> 1.50.0", require: false
 gem "rubocop-packaging", "~> 0.5.2", require: false
 gem "rubocop-performance", "~> 1.9", require: false
 gem "rubocop-rspec", ["~> 2.20", "< 2.21"], require: false
-gem "dogstatsd-ruby", ">= 3.3.0", "!= 5.0.0", "!= 5.0.1", "!= 5.1.0"
-gem "google-protobuf", ["~> 3.0", "!= 3.7.0", "!= 3.7.1", "< 3.19.2"]
+gem "simplecov", git: "https://github.com/DataDog/simplecov", ref: "3bb6b7ee58bf4b1954ca205f50dd44d6f41c57db"
+gem "simplecov-cobertura", "~> 2.1.0"
+gem "warning", "~> 1"
+gem "webmock", ">= 3.10.0"
 gem "rails", "~> 6.1.0"
 gem "pg", ">= 1.1", platform: :ruby
 gem "redis", "~> 4"

--- a/gemfiles/ruby_2.6_rails61_postgres_sidekiq.gemfile
+++ b/gemfiles/ruby_2.6_rails61_postgres_sidekiq.gemfile
@@ -6,7 +6,9 @@ gem "benchmark-ips", "~> 2.8"
 gem "benchmark-memory", "< 0.2"
 gem "climate_control", "~> 0.2.0"
 gem "concurrent-ruby"
+gem "dogstatsd-ruby", ">= 3.3.0", "!= 5.0.0", "!= 5.0.1", "!= 5.1.0"
 gem "extlz4", "~> 0.3", ">= 0.3.3"
+gem "google-protobuf", ["~> 3.0", "!= 3.7.0", "!= 3.7.1", "< 3.19.2"]
 gem "json-schema", "< 3"
 gem "memory_profiler", "~> 0.9"
 gem "os", "~> 1.1"
@@ -20,16 +22,14 @@ gem "rspec", "~> 3.13"
 gem "rspec-collection_matchers", "~> 1.1"
 gem "rspec-wait", "~> 0"
 gem "rspec_junit_formatter", ">= 0.5.1"
-gem "simplecov", git: "https://github.com/DataDog/simplecov", ref: "3bb6b7ee58bf4b1954ca205f50dd44d6f41c57db"
-gem "simplecov-cobertura", "~> 2.1.0"
-gem "warning", "~> 1"
-gem "webmock", ">= 3.10.0"
 gem "rubocop", "~> 1.50.0", require: false
 gem "rubocop-packaging", "~> 0.5.2", require: false
 gem "rubocop-performance", "~> 1.9", require: false
 gem "rubocop-rspec", ["~> 2.20", "< 2.21"], require: false
-gem "dogstatsd-ruby", ">= 3.3.0", "!= 5.0.0", "!= 5.0.1", "!= 5.1.0"
-gem "google-protobuf", ["~> 3.0", "!= 3.7.0", "!= 3.7.1", "< 3.19.2"]
+gem "simplecov", git: "https://github.com/DataDog/simplecov", ref: "3bb6b7ee58bf4b1954ca205f50dd44d6f41c57db"
+gem "simplecov-cobertura", "~> 2.1.0"
+gem "warning", "~> 1"
+gem "webmock", ">= 3.10.0"
 gem "rails", "~> 6.1.0"
 gem "pg", ">= 1.1", platform: :ruby
 gem "sidekiq", ">= 6.1.2"

--- a/gemfiles/ruby_2.6_rails61_semantic_logger.gemfile
+++ b/gemfiles/ruby_2.6_rails61_semantic_logger.gemfile
@@ -6,7 +6,9 @@ gem "benchmark-ips", "~> 2.8"
 gem "benchmark-memory", "< 0.2"
 gem "climate_control", "~> 0.2.0"
 gem "concurrent-ruby"
+gem "dogstatsd-ruby", ">= 3.3.0", "!= 5.0.0", "!= 5.0.1", "!= 5.1.0"
 gem "extlz4", "~> 0.3", ">= 0.3.3"
+gem "google-protobuf", ["~> 3.0", "!= 3.7.0", "!= 3.7.1", "< 3.19.2"]
 gem "json-schema", "< 3"
 gem "memory_profiler", "~> 0.9"
 gem "os", "~> 1.1"
@@ -20,16 +22,14 @@ gem "rspec", "~> 3.13"
 gem "rspec-collection_matchers", "~> 1.1"
 gem "rspec-wait", "~> 0"
 gem "rspec_junit_formatter", ">= 0.5.1"
-gem "simplecov", git: "https://github.com/DataDog/simplecov", ref: "3bb6b7ee58bf4b1954ca205f50dd44d6f41c57db"
-gem "simplecov-cobertura", "~> 2.1.0"
-gem "warning", "~> 1"
-gem "webmock", ">= 3.10.0"
 gem "rubocop", "~> 1.50.0", require: false
 gem "rubocop-packaging", "~> 0.5.2", require: false
 gem "rubocop-performance", "~> 1.9", require: false
 gem "rubocop-rspec", ["~> 2.20", "< 2.21"], require: false
-gem "dogstatsd-ruby", ">= 3.3.0", "!= 5.0.0", "!= 5.0.1", "!= 5.1.0"
-gem "google-protobuf", ["~> 3.0", "!= 3.7.0", "!= 3.7.1", "< 3.19.2"]
+gem "simplecov", git: "https://github.com/DataDog/simplecov", ref: "3bb6b7ee58bf4b1954ca205f50dd44d6f41c57db"
+gem "simplecov-cobertura", "~> 2.1.0"
+gem "warning", "~> 1"
+gem "webmock", ">= 3.10.0"
 gem "rails", "~> 6.1.0"
 gem "pg", ">= 1.1", platform: :ruby
 gem "sprockets", "< 4"

--- a/gemfiles/ruby_2.6_rails6_mysql2.gemfile
+++ b/gemfiles/ruby_2.6_rails6_mysql2.gemfile
@@ -6,7 +6,9 @@ gem "benchmark-ips", "~> 2.8"
 gem "benchmark-memory", "< 0.2"
 gem "climate_control", "~> 0.2.0"
 gem "concurrent-ruby"
+gem "dogstatsd-ruby", ">= 3.3.0", "!= 5.0.0", "!= 5.0.1", "!= 5.1.0"
 gem "extlz4", "~> 0.3", ">= 0.3.3"
+gem "google-protobuf", ["~> 3.0", "!= 3.7.0", "!= 3.7.1", "< 3.19.2"]
 gem "json-schema", "< 3"
 gem "memory_profiler", "~> 0.9"
 gem "os", "~> 1.1"
@@ -20,16 +22,14 @@ gem "rspec", "~> 3.13"
 gem "rspec-collection_matchers", "~> 1.1"
 gem "rspec-wait", "~> 0"
 gem "rspec_junit_formatter", ">= 0.5.1"
-gem "simplecov", git: "https://github.com/DataDog/simplecov", ref: "3bb6b7ee58bf4b1954ca205f50dd44d6f41c57db"
-gem "simplecov-cobertura", "~> 2.1.0"
-gem "warning", "~> 1"
-gem "webmock", ">= 3.10.0"
 gem "rubocop", "~> 1.50.0", require: false
 gem "rubocop-packaging", "~> 0.5.2", require: false
 gem "rubocop-performance", "~> 1.9", require: false
 gem "rubocop-rspec", ["~> 2.20", "< 2.21"], require: false
-gem "dogstatsd-ruby", ">= 3.3.0", "!= 5.0.0", "!= 5.0.1", "!= 5.1.0"
-gem "google-protobuf", ["~> 3.0", "!= 3.7.0", "!= 3.7.1", "< 3.19.2"]
+gem "simplecov", git: "https://github.com/DataDog/simplecov", ref: "3bb6b7ee58bf4b1954ca205f50dd44d6f41c57db"
+gem "simplecov-cobertura", "~> 2.1.0"
+gem "warning", "~> 1"
+gem "webmock", ">= 3.10.0"
 gem "rails", "~> 6.0.0"
 gem "mysql2", "< 1", platform: :ruby
 gem "sprockets", "< 4"

--- a/gemfiles/ruby_2.6_rails6_postgres.gemfile
+++ b/gemfiles/ruby_2.6_rails6_postgres.gemfile
@@ -6,7 +6,9 @@ gem "benchmark-ips", "~> 2.8"
 gem "benchmark-memory", "< 0.2"
 gem "climate_control", "~> 0.2.0"
 gem "concurrent-ruby"
+gem "dogstatsd-ruby", ">= 3.3.0", "!= 5.0.0", "!= 5.0.1", "!= 5.1.0"
 gem "extlz4", "~> 0.3", ">= 0.3.3"
+gem "google-protobuf", ["~> 3.0", "!= 3.7.0", "!= 3.7.1", "< 3.19.2"]
 gem "json-schema", "< 3"
 gem "memory_profiler", "~> 0.9"
 gem "os", "~> 1.1"
@@ -20,16 +22,14 @@ gem "rspec", "~> 3.13"
 gem "rspec-collection_matchers", "~> 1.1"
 gem "rspec-wait", "~> 0"
 gem "rspec_junit_formatter", ">= 0.5.1"
-gem "simplecov", git: "https://github.com/DataDog/simplecov", ref: "3bb6b7ee58bf4b1954ca205f50dd44d6f41c57db"
-gem "simplecov-cobertura", "~> 2.1.0"
-gem "warning", "~> 1"
-gem "webmock", ">= 3.10.0"
 gem "rubocop", "~> 1.50.0", require: false
 gem "rubocop-packaging", "~> 0.5.2", require: false
 gem "rubocop-performance", "~> 1.9", require: false
 gem "rubocop-rspec", ["~> 2.20", "< 2.21"], require: false
-gem "dogstatsd-ruby", ">= 3.3.0", "!= 5.0.0", "!= 5.0.1", "!= 5.1.0"
-gem "google-protobuf", ["~> 3.0", "!= 3.7.0", "!= 3.7.1", "< 3.19.2"]
+gem "simplecov", git: "https://github.com/DataDog/simplecov", ref: "3bb6b7ee58bf4b1954ca205f50dd44d6f41c57db"
+gem "simplecov-cobertura", "~> 2.1.0"
+gem "warning", "~> 1"
+gem "webmock", ">= 3.10.0"
 gem "rails", "~> 6.0.0"
 gem "pg", "< 1.0", platform: :ruby
 gem "sprockets", "< 4"

--- a/gemfiles/ruby_2.6_rails6_postgres_redis.gemfile
+++ b/gemfiles/ruby_2.6_rails6_postgres_redis.gemfile
@@ -6,7 +6,9 @@ gem "benchmark-ips", "~> 2.8"
 gem "benchmark-memory", "< 0.2"
 gem "climate_control", "~> 0.2.0"
 gem "concurrent-ruby"
+gem "dogstatsd-ruby", ">= 3.3.0", "!= 5.0.0", "!= 5.0.1", "!= 5.1.0"
 gem "extlz4", "~> 0.3", ">= 0.3.3"
+gem "google-protobuf", ["~> 3.0", "!= 3.7.0", "!= 3.7.1", "< 3.19.2"]
 gem "json-schema", "< 3"
 gem "memory_profiler", "~> 0.9"
 gem "os", "~> 1.1"
@@ -20,16 +22,14 @@ gem "rspec", "~> 3.13"
 gem "rspec-collection_matchers", "~> 1.1"
 gem "rspec-wait", "~> 0"
 gem "rspec_junit_formatter", ">= 0.5.1"
-gem "simplecov", git: "https://github.com/DataDog/simplecov", ref: "3bb6b7ee58bf4b1954ca205f50dd44d6f41c57db"
-gem "simplecov-cobertura", "~> 2.1.0"
-gem "warning", "~> 1"
-gem "webmock", ">= 3.10.0"
 gem "rubocop", "~> 1.50.0", require: false
 gem "rubocop-packaging", "~> 0.5.2", require: false
 gem "rubocop-performance", "~> 1.9", require: false
 gem "rubocop-rspec", ["~> 2.20", "< 2.21"], require: false
-gem "dogstatsd-ruby", ">= 3.3.0", "!= 5.0.0", "!= 5.0.1", "!= 5.1.0"
-gem "google-protobuf", ["~> 3.0", "!= 3.7.0", "!= 3.7.1", "< 3.19.2"]
+gem "simplecov", git: "https://github.com/DataDog/simplecov", ref: "3bb6b7ee58bf4b1954ca205f50dd44d6f41c57db"
+gem "simplecov-cobertura", "~> 2.1.0"
+gem "warning", "~> 1"
+gem "webmock", ">= 3.10.0"
 gem "rails", "~> 6.0.0"
 gem "pg", "< 1.0", platform: :ruby
 gem "redis", "~> 4"

--- a/gemfiles/ruby_2.6_rails6_postgres_redis_activesupport.gemfile
+++ b/gemfiles/ruby_2.6_rails6_postgres_redis_activesupport.gemfile
@@ -6,7 +6,9 @@ gem "benchmark-ips", "~> 2.8"
 gem "benchmark-memory", "< 0.2"
 gem "climate_control", "~> 0.2.0"
 gem "concurrent-ruby"
+gem "dogstatsd-ruby", ">= 3.3.0", "!= 5.0.0", "!= 5.0.1", "!= 5.1.0"
 gem "extlz4", "~> 0.3", ">= 0.3.3"
+gem "google-protobuf", ["~> 3.0", "!= 3.7.0", "!= 3.7.1", "< 3.19.2"]
 gem "json-schema", "< 3"
 gem "memory_profiler", "~> 0.9"
 gem "os", "~> 1.1"
@@ -20,16 +22,14 @@ gem "rspec", "~> 3.13"
 gem "rspec-collection_matchers", "~> 1.1"
 gem "rspec-wait", "~> 0"
 gem "rspec_junit_formatter", ">= 0.5.1"
-gem "simplecov", git: "https://github.com/DataDog/simplecov", ref: "3bb6b7ee58bf4b1954ca205f50dd44d6f41c57db"
-gem "simplecov-cobertura", "~> 2.1.0"
-gem "warning", "~> 1"
-gem "webmock", ">= 3.10.0"
 gem "rubocop", "~> 1.50.0", require: false
 gem "rubocop-packaging", "~> 0.5.2", require: false
 gem "rubocop-performance", "~> 1.9", require: false
 gem "rubocop-rspec", ["~> 2.20", "< 2.21"], require: false
-gem "dogstatsd-ruby", ">= 3.3.0", "!= 5.0.0", "!= 5.0.1", "!= 5.1.0"
-gem "google-protobuf", ["~> 3.0", "!= 3.7.0", "!= 3.7.1", "< 3.19.2"]
+gem "simplecov", git: "https://github.com/DataDog/simplecov", ref: "3bb6b7ee58bf4b1954ca205f50dd44d6f41c57db"
+gem "simplecov-cobertura", "~> 2.1.0"
+gem "warning", "~> 1"
+gem "webmock", ">= 3.10.0"
 gem "rails", "~> 6.0.0"
 gem "pg", "< 1.0", platform: :ruby
 gem "redis", "~> 4"

--- a/gemfiles/ruby_2.6_rails6_postgres_sidekiq.gemfile
+++ b/gemfiles/ruby_2.6_rails6_postgres_sidekiq.gemfile
@@ -6,7 +6,9 @@ gem "benchmark-ips", "~> 2.8"
 gem "benchmark-memory", "< 0.2"
 gem "climate_control", "~> 0.2.0"
 gem "concurrent-ruby"
+gem "dogstatsd-ruby", ">= 3.3.0", "!= 5.0.0", "!= 5.0.1", "!= 5.1.0"
 gem "extlz4", "~> 0.3", ">= 0.3.3"
+gem "google-protobuf", ["~> 3.0", "!= 3.7.0", "!= 3.7.1", "< 3.19.2"]
 gem "json-schema", "< 3"
 gem "memory_profiler", "~> 0.9"
 gem "os", "~> 1.1"
@@ -20,16 +22,14 @@ gem "rspec", "~> 3.13"
 gem "rspec-collection_matchers", "~> 1.1"
 gem "rspec-wait", "~> 0"
 gem "rspec_junit_formatter", ">= 0.5.1"
-gem "simplecov", git: "https://github.com/DataDog/simplecov", ref: "3bb6b7ee58bf4b1954ca205f50dd44d6f41c57db"
-gem "simplecov-cobertura", "~> 2.1.0"
-gem "warning", "~> 1"
-gem "webmock", ">= 3.10.0"
 gem "rubocop", "~> 1.50.0", require: false
 gem "rubocop-packaging", "~> 0.5.2", require: false
 gem "rubocop-performance", "~> 1.9", require: false
 gem "rubocop-rspec", ["~> 2.20", "< 2.21"], require: false
-gem "dogstatsd-ruby", ">= 3.3.0", "!= 5.0.0", "!= 5.0.1", "!= 5.1.0"
-gem "google-protobuf", ["~> 3.0", "!= 3.7.0", "!= 3.7.1", "< 3.19.2"]
+gem "simplecov", git: "https://github.com/DataDog/simplecov", ref: "3bb6b7ee58bf4b1954ca205f50dd44d6f41c57db"
+gem "simplecov-cobertura", "~> 2.1.0"
+gem "warning", "~> 1"
+gem "webmock", ">= 3.10.0"
 gem "rails", "~> 6.0.0"
 gem "pg", "< 1.0", platform: :ruby
 gem "sidekiq"

--- a/gemfiles/ruby_2.6_rails6_semantic_logger.gemfile
+++ b/gemfiles/ruby_2.6_rails6_semantic_logger.gemfile
@@ -6,7 +6,9 @@ gem "benchmark-ips", "~> 2.8"
 gem "benchmark-memory", "< 0.2"
 gem "climate_control", "~> 0.2.0"
 gem "concurrent-ruby"
+gem "dogstatsd-ruby", ">= 3.3.0", "!= 5.0.0", "!= 5.0.1", "!= 5.1.0"
 gem "extlz4", "~> 0.3", ">= 0.3.3"
+gem "google-protobuf", ["~> 3.0", "!= 3.7.0", "!= 3.7.1", "< 3.19.2"]
 gem "json-schema", "< 3"
 gem "memory_profiler", "~> 0.9"
 gem "os", "~> 1.1"
@@ -20,16 +22,14 @@ gem "rspec", "~> 3.13"
 gem "rspec-collection_matchers", "~> 1.1"
 gem "rspec-wait", "~> 0"
 gem "rspec_junit_formatter", ">= 0.5.1"
-gem "simplecov", git: "https://github.com/DataDog/simplecov", ref: "3bb6b7ee58bf4b1954ca205f50dd44d6f41c57db"
-gem "simplecov-cobertura", "~> 2.1.0"
-gem "warning", "~> 1"
-gem "webmock", ">= 3.10.0"
 gem "rubocop", "~> 1.50.0", require: false
 gem "rubocop-packaging", "~> 0.5.2", require: false
 gem "rubocop-performance", "~> 1.9", require: false
 gem "rubocop-rspec", ["~> 2.20", "< 2.21"], require: false
-gem "dogstatsd-ruby", ">= 3.3.0", "!= 5.0.0", "!= 5.0.1", "!= 5.1.0"
-gem "google-protobuf", ["~> 3.0", "!= 3.7.0", "!= 3.7.1", "< 3.19.2"]
+gem "simplecov", git: "https://github.com/DataDog/simplecov", ref: "3bb6b7ee58bf4b1954ca205f50dd44d6f41c57db"
+gem "simplecov-cobertura", "~> 2.1.0"
+gem "warning", "~> 1"
+gem "webmock", ">= 3.10.0"
 gem "rails", "~> 6.0.0"
 gem "pg", "< 1.0", platform: :ruby
 gem "sprockets", "< 4"

--- a/gemfiles/ruby_2.6_rails_old_redis.gemfile
+++ b/gemfiles/ruby_2.6_rails_old_redis.gemfile
@@ -6,7 +6,9 @@ gem "benchmark-ips", "~> 2.8"
 gem "benchmark-memory", "< 0.2"
 gem "climate_control", "~> 0.2.0"
 gem "concurrent-ruby"
+gem "dogstatsd-ruby", ">= 3.3.0", "!= 5.0.0", "!= 5.0.1", "!= 5.1.0"
 gem "extlz4", "~> 0.3", ">= 0.3.3"
+gem "google-protobuf", ["~> 3.0", "!= 3.7.0", "!= 3.7.1", "< 3.19.2"]
 gem "json-schema", "< 3"
 gem "memory_profiler", "~> 0.9"
 gem "os", "~> 1.1"
@@ -20,16 +22,14 @@ gem "rspec", "~> 3.13"
 gem "rspec-collection_matchers", "~> 1.1"
 gem "rspec-wait", "~> 0"
 gem "rspec_junit_formatter", ">= 0.5.1"
-gem "simplecov", git: "https://github.com/DataDog/simplecov", ref: "3bb6b7ee58bf4b1954ca205f50dd44d6f41c57db"
-gem "simplecov-cobertura", "~> 2.1.0"
-gem "warning", "~> 1"
-gem "webmock", ">= 3.10.0"
 gem "rubocop", "~> 1.50.0", require: false
 gem "rubocop-packaging", "~> 0.5.2", require: false
 gem "rubocop-performance", "~> 1.9", require: false
 gem "rubocop-rspec", ["~> 2.20", "< 2.21"], require: false
-gem "dogstatsd-ruby", ">= 3.3.0", "!= 5.0.0", "!= 5.0.1", "!= 5.1.0"
-gem "google-protobuf", ["~> 3.0", "!= 3.7.0", "!= 3.7.1", "< 3.19.2"]
+gem "simplecov", git: "https://github.com/DataDog/simplecov", ref: "3bb6b7ee58bf4b1954ca205f50dd44d6f41c57db"
+gem "simplecov-cobertura", "~> 2.1.0"
+gem "warning", "~> 1"
+gem "webmock", ">= 3.10.0"
 gem "redis", "< 4"
 gem "rails", "~> 6.1.0"
 gem "pg", ">= 1.1", platform: :ruby

--- a/gemfiles/ruby_2.6_redis_3.gemfile
+++ b/gemfiles/ruby_2.6_redis_3.gemfile
@@ -6,7 +6,9 @@ gem "benchmark-ips", "~> 2.8"
 gem "benchmark-memory", "< 0.2"
 gem "climate_control", "~> 0.2.0"
 gem "concurrent-ruby"
+gem "dogstatsd-ruby", ">= 3.3.0", "!= 5.0.0", "!= 5.0.1", "!= 5.1.0"
 gem "extlz4", "~> 0.3", ">= 0.3.3"
+gem "google-protobuf", ["~> 3.0", "!= 3.7.0", "!= 3.7.1", "< 3.19.2"]
 gem "json-schema", "< 3"
 gem "memory_profiler", "~> 0.9"
 gem "os", "~> 1.1"
@@ -20,16 +22,14 @@ gem "rspec", "~> 3.13"
 gem "rspec-collection_matchers", "~> 1.1"
 gem "rspec-wait", "~> 0"
 gem "rspec_junit_formatter", ">= 0.5.1"
-gem "simplecov", git: "https://github.com/DataDog/simplecov", ref: "3bb6b7ee58bf4b1954ca205f50dd44d6f41c57db"
-gem "simplecov-cobertura", "~> 2.1.0"
-gem "warning", "~> 1"
-gem "webmock", ">= 3.10.0"
 gem "rubocop", "~> 1.50.0", require: false
 gem "rubocop-packaging", "~> 0.5.2", require: false
 gem "rubocop-performance", "~> 1.9", require: false
 gem "rubocop-rspec", ["~> 2.20", "< 2.21"], require: false
-gem "dogstatsd-ruby", ">= 3.3.0", "!= 5.0.0", "!= 5.0.1", "!= 5.1.0"
-gem "google-protobuf", ["~> 3.0", "!= 3.7.0", "!= 3.7.1", "< 3.19.2"]
+gem "simplecov", git: "https://github.com/DataDog/simplecov", ref: "3bb6b7ee58bf4b1954ca205f50dd44d6f41c57db"
+gem "simplecov-cobertura", "~> 2.1.0"
+gem "warning", "~> 1"
+gem "webmock", ">= 3.10.0"
 gem "redis", "~> 3"
 
 group :check do

--- a/gemfiles/ruby_2.6_redis_4.gemfile
+++ b/gemfiles/ruby_2.6_redis_4.gemfile
@@ -6,7 +6,9 @@ gem "benchmark-ips", "~> 2.8"
 gem "benchmark-memory", "< 0.2"
 gem "climate_control", "~> 0.2.0"
 gem "concurrent-ruby"
+gem "dogstatsd-ruby", ">= 3.3.0", "!= 5.0.0", "!= 5.0.1", "!= 5.1.0"
 gem "extlz4", "~> 0.3", ">= 0.3.3"
+gem "google-protobuf", ["~> 3.0", "!= 3.7.0", "!= 3.7.1", "< 3.19.2"]
 gem "json-schema", "< 3"
 gem "memory_profiler", "~> 0.9"
 gem "os", "~> 1.1"
@@ -20,16 +22,14 @@ gem "rspec", "~> 3.13"
 gem "rspec-collection_matchers", "~> 1.1"
 gem "rspec-wait", "~> 0"
 gem "rspec_junit_formatter", ">= 0.5.1"
-gem "simplecov", git: "https://github.com/DataDog/simplecov", ref: "3bb6b7ee58bf4b1954ca205f50dd44d6f41c57db"
-gem "simplecov-cobertura", "~> 2.1.0"
-gem "warning", "~> 1"
-gem "webmock", ">= 3.10.0"
 gem "rubocop", "~> 1.50.0", require: false
 gem "rubocop-packaging", "~> 0.5.2", require: false
 gem "rubocop-performance", "~> 1.9", require: false
 gem "rubocop-rspec", ["~> 2.20", "< 2.21"], require: false
-gem "dogstatsd-ruby", ">= 3.3.0", "!= 5.0.0", "!= 5.0.1", "!= 5.1.0"
-gem "google-protobuf", ["~> 3.0", "!= 3.7.0", "!= 3.7.1", "< 3.19.2"]
+gem "simplecov", git: "https://github.com/DataDog/simplecov", ref: "3bb6b7ee58bf4b1954ca205f50dd44d6f41c57db"
+gem "simplecov-cobertura", "~> 2.1.0"
+gem "warning", "~> 1"
+gem "webmock", ">= 3.10.0"
 gem "redis", "~> 4"
 
 group :check do

--- a/gemfiles/ruby_2.6_redis_5.gemfile
+++ b/gemfiles/ruby_2.6_redis_5.gemfile
@@ -6,7 +6,9 @@ gem "benchmark-ips", "~> 2.8"
 gem "benchmark-memory", "< 0.2"
 gem "climate_control", "~> 0.2.0"
 gem "concurrent-ruby"
+gem "dogstatsd-ruby", ">= 3.3.0", "!= 5.0.0", "!= 5.0.1", "!= 5.1.0"
 gem "extlz4", "~> 0.3", ">= 0.3.3"
+gem "google-protobuf", ["~> 3.0", "!= 3.7.0", "!= 3.7.1", "< 3.19.2"]
 gem "json-schema", "< 3"
 gem "memory_profiler", "~> 0.9"
 gem "os", "~> 1.1"
@@ -20,16 +22,14 @@ gem "rspec", "~> 3.13"
 gem "rspec-collection_matchers", "~> 1.1"
 gem "rspec-wait", "~> 0"
 gem "rspec_junit_formatter", ">= 0.5.1"
-gem "simplecov", git: "https://github.com/DataDog/simplecov", ref: "3bb6b7ee58bf4b1954ca205f50dd44d6f41c57db"
-gem "simplecov-cobertura", "~> 2.1.0"
-gem "warning", "~> 1"
-gem "webmock", ">= 3.10.0"
 gem "rubocop", "~> 1.50.0", require: false
 gem "rubocop-packaging", "~> 0.5.2", require: false
 gem "rubocop-performance", "~> 1.9", require: false
 gem "rubocop-rspec", ["~> 2.20", "< 2.21"], require: false
-gem "dogstatsd-ruby", ">= 3.3.0", "!= 5.0.0", "!= 5.0.1", "!= 5.1.0"
-gem "google-protobuf", ["~> 3.0", "!= 3.7.0", "!= 3.7.1", "< 3.19.2"]
+gem "simplecov", git: "https://github.com/DataDog/simplecov", ref: "3bb6b7ee58bf4b1954ca205f50dd44d6f41c57db"
+gem "simplecov-cobertura", "~> 2.1.0"
+gem "warning", "~> 1"
+gem "webmock", ">= 3.10.0"
 gem "redis", "~> 5"
 
 group :check do

--- a/gemfiles/ruby_2.6_relational_db.gemfile
+++ b/gemfiles/ruby_2.6_relational_db.gemfile
@@ -6,7 +6,9 @@ gem "benchmark-ips", "~> 2.8"
 gem "benchmark-memory", "< 0.2"
 gem "climate_control", "~> 0.2.0"
 gem "concurrent-ruby"
+gem "dogstatsd-ruby", ">= 3.3.0", "!= 5.0.0", "!= 5.0.1", "!= 5.1.0"
 gem "extlz4", "~> 0.3", ">= 0.3.3"
+gem "google-protobuf", ["~> 3.0", "!= 3.7.0", "!= 3.7.1", "< 3.19.2"]
 gem "json-schema", "< 3"
 gem "memory_profiler", "~> 0.9"
 gem "os", "~> 1.1"
@@ -20,16 +22,14 @@ gem "rspec", "~> 3.13"
 gem "rspec-collection_matchers", "~> 1.1"
 gem "rspec-wait", "~> 0"
 gem "rspec_junit_formatter", ">= 0.5.1"
-gem "simplecov", git: "https://github.com/DataDog/simplecov", ref: "3bb6b7ee58bf4b1954ca205f50dd44d6f41c57db"
-gem "simplecov-cobertura", "~> 2.1.0"
-gem "warning", "~> 1"
-gem "webmock", ">= 3.10.0"
 gem "rubocop", "~> 1.50.0", require: false
 gem "rubocop-packaging", "~> 0.5.2", require: false
 gem "rubocop-performance", "~> 1.9", require: false
 gem "rubocop-rspec", ["~> 2.20", "< 2.21"], require: false
-gem "dogstatsd-ruby", ">= 3.3.0", "!= 5.0.0", "!= 5.0.1", "!= 5.1.0"
-gem "google-protobuf", ["~> 3.0", "!= 3.7.0", "!= 3.7.1", "< 3.19.2"]
+gem "simplecov", git: "https://github.com/DataDog/simplecov", ref: "3bb6b7ee58bf4b1954ca205f50dd44d6f41c57db"
+gem "simplecov-cobertura", "~> 2.1.0"
+gem "warning", "~> 1"
+gem "webmock", ">= 3.10.0"
 gem "activerecord", "~> 6.0.0"
 gem "delayed_job"
 gem "delayed_job_active_record"

--- a/gemfiles/ruby_2.6_resque2_redis3.gemfile
+++ b/gemfiles/ruby_2.6_resque2_redis3.gemfile
@@ -6,7 +6,9 @@ gem "benchmark-ips", "~> 2.8"
 gem "benchmark-memory", "< 0.2"
 gem "climate_control", "~> 0.2.0"
 gem "concurrent-ruby"
+gem "dogstatsd-ruby", ">= 3.3.0", "!= 5.0.0", "!= 5.0.1", "!= 5.1.0"
 gem "extlz4", "~> 0.3", ">= 0.3.3"
+gem "google-protobuf", ["~> 3.0", "!= 3.7.0", "!= 3.7.1", "< 3.19.2"]
 gem "json-schema", "< 3"
 gem "memory_profiler", "~> 0.9"
 gem "os", "~> 1.1"
@@ -20,16 +22,14 @@ gem "rspec", "~> 3.13"
 gem "rspec-collection_matchers", "~> 1.1"
 gem "rspec-wait", "~> 0"
 gem "rspec_junit_formatter", ">= 0.5.1"
-gem "simplecov", git: "https://github.com/DataDog/simplecov", ref: "3bb6b7ee58bf4b1954ca205f50dd44d6f41c57db"
-gem "simplecov-cobertura", "~> 2.1.0"
-gem "warning", "~> 1"
-gem "webmock", ">= 3.10.0"
 gem "rubocop", "~> 1.50.0", require: false
 gem "rubocop-packaging", "~> 0.5.2", require: false
 gem "rubocop-performance", "~> 1.9", require: false
 gem "rubocop-rspec", ["~> 2.20", "< 2.21"], require: false
-gem "dogstatsd-ruby", ">= 3.3.0", "!= 5.0.0", "!= 5.0.1", "!= 5.1.0"
-gem "google-protobuf", ["~> 3.0", "!= 3.7.0", "!= 3.7.1", "< 3.19.2"]
+gem "simplecov", git: "https://github.com/DataDog/simplecov", ref: "3bb6b7ee58bf4b1954ca205f50dd44d6f41c57db"
+gem "simplecov-cobertura", "~> 2.1.0"
+gem "warning", "~> 1"
+gem "webmock", ">= 3.10.0"
 gem "redis", "~> 3.0"
 gem "resque", ">= 2.0"
 

--- a/gemfiles/ruby_2.6_resque2_redis4.gemfile
+++ b/gemfiles/ruby_2.6_resque2_redis4.gemfile
@@ -6,7 +6,9 @@ gem "benchmark-ips", "~> 2.8"
 gem "benchmark-memory", "< 0.2"
 gem "climate_control", "~> 0.2.0"
 gem "concurrent-ruby"
+gem "dogstatsd-ruby", ">= 3.3.0", "!= 5.0.0", "!= 5.0.1", "!= 5.1.0"
 gem "extlz4", "~> 0.3", ">= 0.3.3"
+gem "google-protobuf", ["~> 3.0", "!= 3.7.0", "!= 3.7.1", "< 3.19.2"]
 gem "json-schema", "< 3"
 gem "memory_profiler", "~> 0.9"
 gem "os", "~> 1.1"
@@ -20,16 +22,14 @@ gem "rspec", "~> 3.13"
 gem "rspec-collection_matchers", "~> 1.1"
 gem "rspec-wait", "~> 0"
 gem "rspec_junit_formatter", ">= 0.5.1"
-gem "simplecov", git: "https://github.com/DataDog/simplecov", ref: "3bb6b7ee58bf4b1954ca205f50dd44d6f41c57db"
-gem "simplecov-cobertura", "~> 2.1.0"
-gem "warning", "~> 1"
-gem "webmock", ">= 3.10.0"
 gem "rubocop", "~> 1.50.0", require: false
 gem "rubocop-packaging", "~> 0.5.2", require: false
 gem "rubocop-performance", "~> 1.9", require: false
 gem "rubocop-rspec", ["~> 2.20", "< 2.21"], require: false
-gem "dogstatsd-ruby", ">= 3.3.0", "!= 5.0.0", "!= 5.0.1", "!= 5.1.0"
-gem "google-protobuf", ["~> 3.0", "!= 3.7.0", "!= 3.7.1", "< 3.19.2"]
+gem "simplecov", git: "https://github.com/DataDog/simplecov", ref: "3bb6b7ee58bf4b1954ca205f50dd44d6f41c57db"
+gem "simplecov-cobertura", "~> 2.1.0"
+gem "warning", "~> 1"
+gem "webmock", ">= 3.10.0"
 gem "redis", "~> 4.0"
 gem "resque", ">= 2.0"
 

--- a/gemfiles/ruby_2.6_sinatra_2.gemfile
+++ b/gemfiles/ruby_2.6_sinatra_2.gemfile
@@ -6,7 +6,9 @@ gem "benchmark-ips", "~> 2.8"
 gem "benchmark-memory", "< 0.2"
 gem "climate_control", "~> 0.2.0"
 gem "concurrent-ruby"
+gem "dogstatsd-ruby", ">= 3.3.0", "!= 5.0.0", "!= 5.0.1", "!= 5.1.0"
 gem "extlz4", "~> 0.3", ">= 0.3.3"
+gem "google-protobuf", ["~> 3.0", "!= 3.7.0", "!= 3.7.1", "< 3.19.2"]
 gem "json-schema", "< 3"
 gem "memory_profiler", "~> 0.9"
 gem "os", "~> 1.1"
@@ -20,16 +22,14 @@ gem "rspec", "~> 3.13"
 gem "rspec-collection_matchers", "~> 1.1"
 gem "rspec-wait", "~> 0"
 gem "rspec_junit_formatter", ">= 0.5.1"
-gem "simplecov", git: "https://github.com/DataDog/simplecov", ref: "3bb6b7ee58bf4b1954ca205f50dd44d6f41c57db"
-gem "simplecov-cobertura", "~> 2.1.0"
-gem "warning", "~> 1"
-gem "webmock", ">= 3.10.0"
 gem "rubocop", "~> 1.50.0", require: false
 gem "rubocop-packaging", "~> 0.5.2", require: false
 gem "rubocop-performance", "~> 1.9", require: false
 gem "rubocop-rspec", ["~> 2.20", "< 2.21"], require: false
-gem "dogstatsd-ruby", ">= 3.3.0", "!= 5.0.0", "!= 5.0.1", "!= 5.1.0"
-gem "google-protobuf", ["~> 3.0", "!= 3.7.0", "!= 3.7.1", "< 3.19.2"]
+gem "simplecov", git: "https://github.com/DataDog/simplecov", ref: "3bb6b7ee58bf4b1954ca205f50dd44d6f41c57db"
+gem "simplecov-cobertura", "~> 2.1.0"
+gem "warning", "~> 1"
+gem "webmock", ">= 3.10.0"
 gem "sinatra", "~> 2"
 gem "rack-contrib"
 gem "rack-test"

--- a/gemfiles/ruby_2.6_sinatra_3.gemfile
+++ b/gemfiles/ruby_2.6_sinatra_3.gemfile
@@ -6,7 +6,9 @@ gem "benchmark-ips", "~> 2.8"
 gem "benchmark-memory", "< 0.2"
 gem "climate_control", "~> 0.2.0"
 gem "concurrent-ruby"
+gem "dogstatsd-ruby", ">= 3.3.0", "!= 5.0.0", "!= 5.0.1", "!= 5.1.0"
 gem "extlz4", "~> 0.3", ">= 0.3.3"
+gem "google-protobuf", ["~> 3.0", "!= 3.7.0", "!= 3.7.1", "< 3.19.2"]
 gem "json-schema", "< 3"
 gem "memory_profiler", "~> 0.9"
 gem "os", "~> 1.1"
@@ -20,16 +22,14 @@ gem "rspec", "~> 3.13"
 gem "rspec-collection_matchers", "~> 1.1"
 gem "rspec-wait", "~> 0"
 gem "rspec_junit_formatter", ">= 0.5.1"
-gem "simplecov", git: "https://github.com/DataDog/simplecov", ref: "3bb6b7ee58bf4b1954ca205f50dd44d6f41c57db"
-gem "simplecov-cobertura", "~> 2.1.0"
-gem "warning", "~> 1"
-gem "webmock", ">= 3.10.0"
 gem "rubocop", "~> 1.50.0", require: false
 gem "rubocop-packaging", "~> 0.5.2", require: false
 gem "rubocop-performance", "~> 1.9", require: false
 gem "rubocop-rspec", ["~> 2.20", "< 2.21"], require: false
-gem "dogstatsd-ruby", ">= 3.3.0", "!= 5.0.0", "!= 5.0.1", "!= 5.1.0"
-gem "google-protobuf", ["~> 3.0", "!= 3.7.0", "!= 3.7.1", "< 3.19.2"]
+gem "simplecov", git: "https://github.com/DataDog/simplecov", ref: "3bb6b7ee58bf4b1954ca205f50dd44d6f41c57db"
+gem "simplecov-cobertura", "~> 2.1.0"
+gem "warning", "~> 1"
+gem "webmock", ">= 3.10.0"
 gem "sinatra", "~> 3"
 gem "rack-contrib"
 gem "rack-test"

--- a/gemfiles/ruby_2.6_stripe_10.gemfile
+++ b/gemfiles/ruby_2.6_stripe_10.gemfile
@@ -6,7 +6,9 @@ gem "benchmark-ips", "~> 2.8"
 gem "benchmark-memory", "< 0.2"
 gem "climate_control", "~> 0.2.0"
 gem "concurrent-ruby"
+gem "dogstatsd-ruby", ">= 3.3.0", "!= 5.0.0", "!= 5.0.1", "!= 5.1.0"
 gem "extlz4", "~> 0.3", ">= 0.3.3"
+gem "google-protobuf", ["~> 3.0", "!= 3.7.0", "!= 3.7.1", "< 3.19.2"]
 gem "json-schema", "< 3"
 gem "memory_profiler", "~> 0.9"
 gem "os", "~> 1.1"
@@ -20,16 +22,14 @@ gem "rspec", "~> 3.13"
 gem "rspec-collection_matchers", "~> 1.1"
 gem "rspec-wait", "~> 0"
 gem "rspec_junit_formatter", ">= 0.5.1"
-gem "simplecov", git: "https://github.com/DataDog/simplecov", ref: "3bb6b7ee58bf4b1954ca205f50dd44d6f41c57db"
-gem "simplecov-cobertura", "~> 2.1.0"
-gem "warning", "~> 1"
-gem "webmock", ">= 3.10.0"
 gem "rubocop", "~> 1.50.0", require: false
 gem "rubocop-packaging", "~> 0.5.2", require: false
 gem "rubocop-performance", "~> 1.9", require: false
 gem "rubocop-rspec", ["~> 2.20", "< 2.21"], require: false
-gem "dogstatsd-ruby", ">= 3.3.0", "!= 5.0.0", "!= 5.0.1", "!= 5.1.0"
-gem "google-protobuf", ["~> 3.0", "!= 3.7.0", "!= 3.7.1", "< 3.19.2"]
+gem "simplecov", git: "https://github.com/DataDog/simplecov", ref: "3bb6b7ee58bf4b1954ca205f50dd44d6f41c57db"
+gem "simplecov-cobertura", "~> 2.1.0"
+gem "warning", "~> 1"
+gem "webmock", ">= 3.10.0"
 gem "stripe", "~> 10"
 
 group :check do

--- a/gemfiles/ruby_2.6_stripe_11.gemfile
+++ b/gemfiles/ruby_2.6_stripe_11.gemfile
@@ -6,7 +6,9 @@ gem "benchmark-ips", "~> 2.8"
 gem "benchmark-memory", "< 0.2"
 gem "climate_control", "~> 0.2.0"
 gem "concurrent-ruby"
+gem "dogstatsd-ruby", ">= 3.3.0", "!= 5.0.0", "!= 5.0.1", "!= 5.1.0"
 gem "extlz4", "~> 0.3", ">= 0.3.3"
+gem "google-protobuf", ["~> 3.0", "!= 3.7.0", "!= 3.7.1", "< 3.19.2"]
 gem "json-schema", "< 3"
 gem "memory_profiler", "~> 0.9"
 gem "os", "~> 1.1"
@@ -20,16 +22,14 @@ gem "rspec", "~> 3.13"
 gem "rspec-collection_matchers", "~> 1.1"
 gem "rspec-wait", "~> 0"
 gem "rspec_junit_formatter", ">= 0.5.1"
-gem "simplecov", git: "https://github.com/DataDog/simplecov", ref: "3bb6b7ee58bf4b1954ca205f50dd44d6f41c57db"
-gem "simplecov-cobertura", "~> 2.1.0"
-gem "warning", "~> 1"
-gem "webmock", ">= 3.10.0"
 gem "rubocop", "~> 1.50.0", require: false
 gem "rubocop-packaging", "~> 0.5.2", require: false
 gem "rubocop-performance", "~> 1.9", require: false
 gem "rubocop-rspec", ["~> 2.20", "< 2.21"], require: false
-gem "dogstatsd-ruby", ">= 3.3.0", "!= 5.0.0", "!= 5.0.1", "!= 5.1.0"
-gem "google-protobuf", ["~> 3.0", "!= 3.7.0", "!= 3.7.1", "< 3.19.2"]
+gem "simplecov", git: "https://github.com/DataDog/simplecov", ref: "3bb6b7ee58bf4b1954ca205f50dd44d6f41c57db"
+gem "simplecov-cobertura", "~> 2.1.0"
+gem "warning", "~> 1"
+gem "webmock", ">= 3.10.0"
 gem "stripe", "~> 11"
 
 group :check do

--- a/gemfiles/ruby_2.6_stripe_12.gemfile
+++ b/gemfiles/ruby_2.6_stripe_12.gemfile
@@ -6,7 +6,9 @@ gem "benchmark-ips", "~> 2.8"
 gem "benchmark-memory", "< 0.2"
 gem "climate_control", "~> 0.2.0"
 gem "concurrent-ruby"
+gem "dogstatsd-ruby", ">= 3.3.0", "!= 5.0.0", "!= 5.0.1", "!= 5.1.0"
 gem "extlz4", "~> 0.3", ">= 0.3.3"
+gem "google-protobuf", ["~> 3.0", "!= 3.7.0", "!= 3.7.1", "< 3.19.2"]
 gem "json-schema", "< 3"
 gem "memory_profiler", "~> 0.9"
 gem "os", "~> 1.1"
@@ -20,16 +22,14 @@ gem "rspec", "~> 3.13"
 gem "rspec-collection_matchers", "~> 1.1"
 gem "rspec-wait", "~> 0"
 gem "rspec_junit_formatter", ">= 0.5.1"
-gem "simplecov", git: "https://github.com/DataDog/simplecov", ref: "3bb6b7ee58bf4b1954ca205f50dd44d6f41c57db"
-gem "simplecov-cobertura", "~> 2.1.0"
-gem "warning", "~> 1"
-gem "webmock", ">= 3.10.0"
 gem "rubocop", "~> 1.50.0", require: false
 gem "rubocop-packaging", "~> 0.5.2", require: false
 gem "rubocop-performance", "~> 1.9", require: false
 gem "rubocop-rspec", ["~> 2.20", "< 2.21"], require: false
-gem "dogstatsd-ruby", ">= 3.3.0", "!= 5.0.0", "!= 5.0.1", "!= 5.1.0"
-gem "google-protobuf", ["~> 3.0", "!= 3.7.0", "!= 3.7.1", "< 3.19.2"]
+gem "simplecov", git: "https://github.com/DataDog/simplecov", ref: "3bb6b7ee58bf4b1954ca205f50dd44d6f41c57db"
+gem "simplecov-cobertura", "~> 2.1.0"
+gem "warning", "~> 1"
+gem "webmock", ">= 3.10.0"
 gem "stripe", "~> 12"
 
 group :check do

--- a/gemfiles/ruby_2.6_stripe_7.gemfile
+++ b/gemfiles/ruby_2.6_stripe_7.gemfile
@@ -6,7 +6,9 @@ gem "benchmark-ips", "~> 2.8"
 gem "benchmark-memory", "< 0.2"
 gem "climate_control", "~> 0.2.0"
 gem "concurrent-ruby"
+gem "dogstatsd-ruby", ">= 3.3.0", "!= 5.0.0", "!= 5.0.1", "!= 5.1.0"
 gem "extlz4", "~> 0.3", ">= 0.3.3"
+gem "google-protobuf", ["~> 3.0", "!= 3.7.0", "!= 3.7.1", "< 3.19.2"]
 gem "json-schema", "< 3"
 gem "memory_profiler", "~> 0.9"
 gem "os", "~> 1.1"
@@ -20,16 +22,14 @@ gem "rspec", "~> 3.13"
 gem "rspec-collection_matchers", "~> 1.1"
 gem "rspec-wait", "~> 0"
 gem "rspec_junit_formatter", ">= 0.5.1"
-gem "simplecov", git: "https://github.com/DataDog/simplecov", ref: "3bb6b7ee58bf4b1954ca205f50dd44d6f41c57db"
-gem "simplecov-cobertura", "~> 2.1.0"
-gem "warning", "~> 1"
-gem "webmock", ">= 3.10.0"
 gem "rubocop", "~> 1.50.0", require: false
 gem "rubocop-packaging", "~> 0.5.2", require: false
 gem "rubocop-performance", "~> 1.9", require: false
 gem "rubocop-rspec", ["~> 2.20", "< 2.21"], require: false
-gem "dogstatsd-ruby", ">= 3.3.0", "!= 5.0.0", "!= 5.0.1", "!= 5.1.0"
-gem "google-protobuf", ["~> 3.0", "!= 3.7.0", "!= 3.7.1", "< 3.19.2"]
+gem "simplecov", git: "https://github.com/DataDog/simplecov", ref: "3bb6b7ee58bf4b1954ca205f50dd44d6f41c57db"
+gem "simplecov-cobertura", "~> 2.1.0"
+gem "warning", "~> 1"
+gem "webmock", ">= 3.10.0"
 gem "stripe", "~> 7"
 
 group :check do

--- a/gemfiles/ruby_2.6_stripe_8.gemfile
+++ b/gemfiles/ruby_2.6_stripe_8.gemfile
@@ -6,7 +6,9 @@ gem "benchmark-ips", "~> 2.8"
 gem "benchmark-memory", "< 0.2"
 gem "climate_control", "~> 0.2.0"
 gem "concurrent-ruby"
+gem "dogstatsd-ruby", ">= 3.3.0", "!= 5.0.0", "!= 5.0.1", "!= 5.1.0"
 gem "extlz4", "~> 0.3", ">= 0.3.3"
+gem "google-protobuf", ["~> 3.0", "!= 3.7.0", "!= 3.7.1", "< 3.19.2"]
 gem "json-schema", "< 3"
 gem "memory_profiler", "~> 0.9"
 gem "os", "~> 1.1"
@@ -20,16 +22,14 @@ gem "rspec", "~> 3.13"
 gem "rspec-collection_matchers", "~> 1.1"
 gem "rspec-wait", "~> 0"
 gem "rspec_junit_formatter", ">= 0.5.1"
-gem "simplecov", git: "https://github.com/DataDog/simplecov", ref: "3bb6b7ee58bf4b1954ca205f50dd44d6f41c57db"
-gem "simplecov-cobertura", "~> 2.1.0"
-gem "warning", "~> 1"
-gem "webmock", ">= 3.10.0"
 gem "rubocop", "~> 1.50.0", require: false
 gem "rubocop-packaging", "~> 0.5.2", require: false
 gem "rubocop-performance", "~> 1.9", require: false
 gem "rubocop-rspec", ["~> 2.20", "< 2.21"], require: false
-gem "dogstatsd-ruby", ">= 3.3.0", "!= 5.0.0", "!= 5.0.1", "!= 5.1.0"
-gem "google-protobuf", ["~> 3.0", "!= 3.7.0", "!= 3.7.1", "< 3.19.2"]
+gem "simplecov", git: "https://github.com/DataDog/simplecov", ref: "3bb6b7ee58bf4b1954ca205f50dd44d6f41c57db"
+gem "simplecov-cobertura", "~> 2.1.0"
+gem "warning", "~> 1"
+gem "webmock", ">= 3.10.0"
 gem "stripe", "~> 8"
 
 group :check do

--- a/gemfiles/ruby_2.6_stripe_9.gemfile
+++ b/gemfiles/ruby_2.6_stripe_9.gemfile
@@ -6,7 +6,9 @@ gem "benchmark-ips", "~> 2.8"
 gem "benchmark-memory", "< 0.2"
 gem "climate_control", "~> 0.2.0"
 gem "concurrent-ruby"
+gem "dogstatsd-ruby", ">= 3.3.0", "!= 5.0.0", "!= 5.0.1", "!= 5.1.0"
 gem "extlz4", "~> 0.3", ">= 0.3.3"
+gem "google-protobuf", ["~> 3.0", "!= 3.7.0", "!= 3.7.1", "< 3.19.2"]
 gem "json-schema", "< 3"
 gem "memory_profiler", "~> 0.9"
 gem "os", "~> 1.1"
@@ -20,16 +22,14 @@ gem "rspec", "~> 3.13"
 gem "rspec-collection_matchers", "~> 1.1"
 gem "rspec-wait", "~> 0"
 gem "rspec_junit_formatter", ">= 0.5.1"
-gem "simplecov", git: "https://github.com/DataDog/simplecov", ref: "3bb6b7ee58bf4b1954ca205f50dd44d6f41c57db"
-gem "simplecov-cobertura", "~> 2.1.0"
-gem "warning", "~> 1"
-gem "webmock", ">= 3.10.0"
 gem "rubocop", "~> 1.50.0", require: false
 gem "rubocop-packaging", "~> 0.5.2", require: false
 gem "rubocop-performance", "~> 1.9", require: false
 gem "rubocop-rspec", ["~> 2.20", "< 2.21"], require: false
-gem "dogstatsd-ruby", ">= 3.3.0", "!= 5.0.0", "!= 5.0.1", "!= 5.1.0"
-gem "google-protobuf", ["~> 3.0", "!= 3.7.0", "!= 3.7.1", "< 3.19.2"]
+gem "simplecov", git: "https://github.com/DataDog/simplecov", ref: "3bb6b7ee58bf4b1954ca205f50dd44d6f41c57db"
+gem "simplecov-cobertura", "~> 2.1.0"
+gem "warning", "~> 1"
+gem "webmock", ">= 3.10.0"
 gem "stripe", "~> 9"
 
 group :check do

--- a/gemfiles/ruby_2.6_stripe_latest.gemfile
+++ b/gemfiles/ruby_2.6_stripe_latest.gemfile
@@ -6,7 +6,9 @@ gem "benchmark-ips", "~> 2.8"
 gem "benchmark-memory", "< 0.2"
 gem "climate_control", "~> 0.2.0"
 gem "concurrent-ruby"
+gem "dogstatsd-ruby", ">= 3.3.0", "!= 5.0.0", "!= 5.0.1", "!= 5.1.0"
 gem "extlz4", "~> 0.3", ">= 0.3.3"
+gem "google-protobuf", ["~> 3.0", "!= 3.7.0", "!= 3.7.1", "< 3.19.2"]
 gem "json-schema", "< 3"
 gem "memory_profiler", "~> 0.9"
 gem "os", "~> 1.1"
@@ -20,16 +22,14 @@ gem "rspec", "~> 3.13"
 gem "rspec-collection_matchers", "~> 1.1"
 gem "rspec-wait", "~> 0"
 gem "rspec_junit_formatter", ">= 0.5.1"
-gem "simplecov", git: "https://github.com/DataDog/simplecov", ref: "3bb6b7ee58bf4b1954ca205f50dd44d6f41c57db"
-gem "simplecov-cobertura", "~> 2.1.0"
-gem "warning", "~> 1"
-gem "webmock", ">= 3.10.0"
 gem "rubocop", "~> 1.50.0", require: false
 gem "rubocop-packaging", "~> 0.5.2", require: false
 gem "rubocop-performance", "~> 1.9", require: false
 gem "rubocop-rspec", ["~> 2.20", "< 2.21"], require: false
-gem "dogstatsd-ruby", ">= 3.3.0", "!= 5.0.0", "!= 5.0.1", "!= 5.1.0"
-gem "google-protobuf", ["~> 3.0", "!= 3.7.0", "!= 3.7.1", "< 3.19.2"]
+gem "simplecov", git: "https://github.com/DataDog/simplecov", ref: "3bb6b7ee58bf4b1954ca205f50dd44d6f41c57db"
+gem "simplecov-cobertura", "~> 2.1.0"
+gem "warning", "~> 1"
+gem "webmock", ">= 3.10.0"
 gem "stripe"
 
 group :check do

--- a/gemfiles/ruby_2.6_stripe_min.gemfile
+++ b/gemfiles/ruby_2.6_stripe_min.gemfile
@@ -6,7 +6,9 @@ gem "benchmark-ips", "~> 2.8"
 gem "benchmark-memory", "< 0.2"
 gem "climate_control", "~> 0.2.0"
 gem "concurrent-ruby"
+gem "dogstatsd-ruby", ">= 3.3.0", "!= 5.0.0", "!= 5.0.1", "!= 5.1.0"
 gem "extlz4", "~> 0.3", ">= 0.3.3"
+gem "google-protobuf", ["~> 3.0", "!= 3.7.0", "!= 3.7.1", "< 3.19.2"]
 gem "json-schema", "< 3"
 gem "memory_profiler", "~> 0.9"
 gem "os", "~> 1.1"
@@ -20,16 +22,14 @@ gem "rspec", "~> 3.13"
 gem "rspec-collection_matchers", "~> 1.1"
 gem "rspec-wait", "~> 0"
 gem "rspec_junit_formatter", ">= 0.5.1"
-gem "simplecov", git: "https://github.com/DataDog/simplecov", ref: "3bb6b7ee58bf4b1954ca205f50dd44d6f41c57db"
-gem "simplecov-cobertura", "~> 2.1.0"
-gem "warning", "~> 1"
-gem "webmock", ">= 3.10.0"
 gem "rubocop", "~> 1.50.0", require: false
 gem "rubocop-packaging", "~> 0.5.2", require: false
 gem "rubocop-performance", "~> 1.9", require: false
 gem "rubocop-rspec", ["~> 2.20", "< 2.21"], require: false
-gem "dogstatsd-ruby", ">= 3.3.0", "!= 5.0.0", "!= 5.0.1", "!= 5.1.0"
-gem "google-protobuf", ["~> 3.0", "!= 3.7.0", "!= 3.7.1", "< 3.19.2"]
+gem "simplecov", git: "https://github.com/DataDog/simplecov", ref: "3bb6b7ee58bf4b1954ca205f50dd44d6f41c57db"
+gem "simplecov-cobertura", "~> 2.1.0"
+gem "warning", "~> 1"
+gem "webmock", ">= 3.10.0"
 gem "stripe", "= 5.15.0"
 
 group :check do

--- a/gemfiles/ruby_2.7_activesupport.gemfile
+++ b/gemfiles/ruby_2.7_activesupport.gemfile
@@ -6,7 +6,9 @@ gem "benchmark-ips", "~> 2.8"
 gem "benchmark-memory", "< 0.2"
 gem "climate_control", "~> 0.2.0"
 gem "concurrent-ruby"
+gem "dogstatsd-ruby", ">= 3.3.0", "!= 5.0.0", "!= 5.0.1", "!= 5.1.0"
 gem "extlz4", "~> 0.3", ">= 0.3.3"
+gem "google-protobuf", ["~> 3.0", "!= 3.7.0", "!= 3.7.1"]
 gem "json-schema", "< 3"
 gem "memory_profiler", "~> 0.9"
 gem "os", "~> 1.1"
@@ -20,16 +22,14 @@ gem "rspec", "~> 3.13"
 gem "rspec-collection_matchers", "~> 1.1"
 gem "rspec-wait", "~> 0"
 gem "rspec_junit_formatter", ">= 0.5.1"
-gem "simplecov", git: "https://github.com/DataDog/simplecov", ref: "3bb6b7ee58bf4b1954ca205f50dd44d6f41c57db"
-gem "simplecov-cobertura", "~> 2.1.0"
-gem "warning", "~> 1"
-gem "webmock", ">= 3.10.0"
 gem "rubocop", "~> 1.50.0", require: false
 gem "rubocop-packaging", "~> 0.5.2", require: false
 gem "rubocop-performance", "~> 1.9", require: false
 gem "rubocop-rspec", ["~> 2.20", "< 2.21"], require: false
-gem "dogstatsd-ruby", ">= 3.3.0", "!= 5.0.0", "!= 5.0.1", "!= 5.1.0"
-gem "google-protobuf", ["~> 3.0", "!= 3.7.0", "!= 3.7.1"]
+gem "simplecov", git: "https://github.com/DataDog/simplecov", ref: "3bb6b7ee58bf4b1954ca205f50dd44d6f41c57db"
+gem "simplecov-cobertura", "~> 2.1.0"
+gem "warning", "~> 1"
+gem "webmock", ">= 3.10.0"
 gem "activesupport", "~> 6.1.0"
 gem "actionpack"
 gem "actionview"

--- a/gemfiles/ruby_2.7_aws.gemfile
+++ b/gemfiles/ruby_2.7_aws.gemfile
@@ -6,7 +6,9 @@ gem "benchmark-ips", "~> 2.8"
 gem "benchmark-memory", "< 0.2"
 gem "climate_control", "~> 0.2.0"
 gem "concurrent-ruby"
+gem "dogstatsd-ruby", ">= 3.3.0", "!= 5.0.0", "!= 5.0.1", "!= 5.1.0"
 gem "extlz4", "~> 0.3", ">= 0.3.3"
+gem "google-protobuf", ["~> 3.0", "!= 3.7.0", "!= 3.7.1"]
 gem "json-schema", "< 3"
 gem "memory_profiler", "~> 0.9"
 gem "os", "~> 1.1"
@@ -20,16 +22,14 @@ gem "rspec", "~> 3.13"
 gem "rspec-collection_matchers", "~> 1.1"
 gem "rspec-wait", "~> 0"
 gem "rspec_junit_formatter", ">= 0.5.1"
-gem "simplecov", git: "https://github.com/DataDog/simplecov", ref: "3bb6b7ee58bf4b1954ca205f50dd44d6f41c57db"
-gem "simplecov-cobertura", "~> 2.1.0"
-gem "warning", "~> 1"
-gem "webmock", ">= 3.10.0"
 gem "rubocop", "~> 1.50.0", require: false
 gem "rubocop-packaging", "~> 0.5.2", require: false
 gem "rubocop-performance", "~> 1.9", require: false
 gem "rubocop-rspec", ["~> 2.20", "< 2.21"], require: false
-gem "dogstatsd-ruby", ">= 3.3.0", "!= 5.0.0", "!= 5.0.1", "!= 5.1.0"
-gem "google-protobuf", ["~> 3.0", "!= 3.7.0", "!= 3.7.1"]
+gem "simplecov", git: "https://github.com/DataDog/simplecov", ref: "3bb6b7ee58bf4b1954ca205f50dd44d6f41c57db"
+gem "simplecov-cobertura", "~> 2.1.0"
+gem "warning", "~> 1"
+gem "webmock", ">= 3.10.0"
 gem "aws-sdk"
 gem "shoryuken"
 

--- a/gemfiles/ruby_2.7_contrib.gemfile
+++ b/gemfiles/ruby_2.7_contrib.gemfile
@@ -6,7 +6,9 @@ gem "benchmark-ips", "~> 2.8"
 gem "benchmark-memory", "< 0.2"
 gem "climate_control", "~> 0.2.0"
 gem "concurrent-ruby"
+gem "dogstatsd-ruby", ">= 3.3.0", "!= 5.0.0", "!= 5.0.1", "!= 5.1.0"
 gem "extlz4", "~> 0.3", ">= 0.3.3"
+gem "google-protobuf", ["~> 3.0", "!= 3.7.0", "!= 3.7.1"]
 gem "json-schema", "< 3"
 gem "memory_profiler", "~> 0.9"
 gem "os", "~> 1.1"
@@ -20,16 +22,14 @@ gem "rspec", "~> 3.13"
 gem "rspec-collection_matchers", "~> 1.1"
 gem "rspec-wait", "~> 0"
 gem "rspec_junit_formatter", ">= 0.5.1"
-gem "simplecov", git: "https://github.com/DataDog/simplecov", ref: "3bb6b7ee58bf4b1954ca205f50dd44d6f41c57db"
-gem "simplecov-cobertura", "~> 2.1.0"
-gem "warning", "~> 1"
-gem "webmock", ">= 3.10.0"
 gem "rubocop", "~> 1.50.0", require: false
 gem "rubocop-packaging", "~> 0.5.2", require: false
 gem "rubocop-performance", "~> 1.9", require: false
 gem "rubocop-rspec", ["~> 2.20", "< 2.21"], require: false
-gem "dogstatsd-ruby", ">= 3.3.0", "!= 5.0.0", "!= 5.0.1", "!= 5.1.0"
-gem "google-protobuf", ["~> 3.0", "!= 3.7.0", "!= 3.7.1"]
+gem "simplecov", git: "https://github.com/DataDog/simplecov", ref: "3bb6b7ee58bf4b1954ca205f50dd44d6f41c57db"
+gem "simplecov-cobertura", "~> 2.1.0"
+gem "warning", "~> 1"
+gem "webmock", ">= 3.10.0"
 gem "dalli", ">= 3.0.0"
 gem "grpc"
 gem "mongo", ">= 2.8.0", "< 2.15.0"

--- a/gemfiles/ruby_2.7_contrib_old.gemfile
+++ b/gemfiles/ruby_2.7_contrib_old.gemfile
@@ -6,7 +6,9 @@ gem "benchmark-ips", "~> 2.8"
 gem "benchmark-memory", "< 0.2"
 gem "climate_control", "~> 0.2.0"
 gem "concurrent-ruby"
+gem "dogstatsd-ruby", ">= 3.3.0", "!= 5.0.0", "!= 5.0.1", "!= 5.1.0"
 gem "extlz4", "~> 0.3", ">= 0.3.3"
+gem "google-protobuf", ["~> 3.0", "!= 3.7.0", "!= 3.7.1"]
 gem "json-schema", "< 3"
 gem "memory_profiler", "~> 0.9"
 gem "os", "~> 1.1"
@@ -20,16 +22,14 @@ gem "rspec", "~> 3.13"
 gem "rspec-collection_matchers", "~> 1.1"
 gem "rspec-wait", "~> 0"
 gem "rspec_junit_formatter", ">= 0.5.1"
-gem "simplecov", git: "https://github.com/DataDog/simplecov", ref: "3bb6b7ee58bf4b1954ca205f50dd44d6f41c57db"
-gem "simplecov-cobertura", "~> 2.1.0"
-gem "warning", "~> 1"
-gem "webmock", ">= 3.10.0"
 gem "rubocop", "~> 1.50.0", require: false
 gem "rubocop-packaging", "~> 0.5.2", require: false
 gem "rubocop-performance", "~> 1.9", require: false
 gem "rubocop-rspec", ["~> 2.20", "< 2.21"], require: false
-gem "dogstatsd-ruby", ">= 3.3.0", "!= 5.0.0", "!= 5.0.1", "!= 5.1.0"
-gem "google-protobuf", ["~> 3.0", "!= 3.7.0", "!= 3.7.1"]
+gem "simplecov", git: "https://github.com/DataDog/simplecov", ref: "3bb6b7ee58bf4b1954ca205f50dd44d6f41c57db"
+gem "simplecov-cobertura", "~> 2.1.0"
+gem "warning", "~> 1"
+gem "webmock", ">= 3.10.0"
 gem "dalli", "< 3.0.0"
 gem "faraday", "0.17"
 gem "presto-client", ">= 0.5.14"

--- a/gemfiles/ruby_2.7_core_old.gemfile
+++ b/gemfiles/ruby_2.7_core_old.gemfile
@@ -6,7 +6,9 @@ gem "benchmark-ips", "~> 2.8"
 gem "benchmark-memory", "< 0.2"
 gem "climate_control", "~> 0.2.0"
 gem "concurrent-ruby"
+gem "dogstatsd-ruby", "~> 4"
 gem "extlz4", "~> 0.3", ">= 0.3.3"
+gem "google-protobuf", ["~> 3.0", "!= 3.7.0", "!= 3.7.1"]
 gem "json-schema", "< 3"
 gem "memory_profiler", "~> 0.9"
 gem "os", "~> 1.1"
@@ -20,16 +22,14 @@ gem "rspec", "~> 3.13"
 gem "rspec-collection_matchers", "~> 1.1"
 gem "rspec-wait", "~> 0"
 gem "rspec_junit_formatter", ">= 0.5.1"
-gem "simplecov", git: "https://github.com/DataDog/simplecov", ref: "3bb6b7ee58bf4b1954ca205f50dd44d6f41c57db"
-gem "simplecov-cobertura", "~> 2.1.0"
-gem "warning", "~> 1"
-gem "webmock", ">= 3.10.0"
 gem "rubocop", "~> 1.50.0", require: false
 gem "rubocop-packaging", "~> 0.5.2", require: false
 gem "rubocop-performance", "~> 1.9", require: false
 gem "rubocop-rspec", ["~> 2.20", "< 2.21"], require: false
-gem "dogstatsd-ruby", "~> 4"
-gem "google-protobuf", ["~> 3.0", "!= 3.7.0", "!= 3.7.1"]
+gem "simplecov", git: "https://github.com/DataDog/simplecov", ref: "3bb6b7ee58bf4b1954ca205f50dd44d6f41c57db"
+gem "simplecov-cobertura", "~> 2.1.0"
+gem "warning", "~> 1"
+gem "webmock", ">= 3.10.0"
 
 group :check do
 

--- a/gemfiles/ruby_2.7_elasticsearch_7.gemfile
+++ b/gemfiles/ruby_2.7_elasticsearch_7.gemfile
@@ -6,7 +6,9 @@ gem "benchmark-ips", "~> 2.8"
 gem "benchmark-memory", "< 0.2"
 gem "climate_control", "~> 0.2.0"
 gem "concurrent-ruby"
+gem "dogstatsd-ruby", ">= 3.3.0", "!= 5.0.0", "!= 5.0.1", "!= 5.1.0"
 gem "extlz4", "~> 0.3", ">= 0.3.3"
+gem "google-protobuf", ["~> 3.0", "!= 3.7.0", "!= 3.7.1"]
 gem "json-schema", "< 3"
 gem "memory_profiler", "~> 0.9"
 gem "os", "~> 1.1"
@@ -20,16 +22,14 @@ gem "rspec", "~> 3.13"
 gem "rspec-collection_matchers", "~> 1.1"
 gem "rspec-wait", "~> 0"
 gem "rspec_junit_formatter", ">= 0.5.1"
-gem "simplecov", git: "https://github.com/DataDog/simplecov", ref: "3bb6b7ee58bf4b1954ca205f50dd44d6f41c57db"
-gem "simplecov-cobertura", "~> 2.1.0"
-gem "warning", "~> 1"
-gem "webmock", ">= 3.10.0"
 gem "rubocop", "~> 1.50.0", require: false
 gem "rubocop-packaging", "~> 0.5.2", require: false
 gem "rubocop-performance", "~> 1.9", require: false
 gem "rubocop-rspec", ["~> 2.20", "< 2.21"], require: false
-gem "dogstatsd-ruby", ">= 3.3.0", "!= 5.0.0", "!= 5.0.1", "!= 5.1.0"
-gem "google-protobuf", ["~> 3.0", "!= 3.7.0", "!= 3.7.1"]
+gem "simplecov", git: "https://github.com/DataDog/simplecov", ref: "3bb6b7ee58bf4b1954ca205f50dd44d6f41c57db"
+gem "simplecov-cobertura", "~> 2.1.0"
+gem "warning", "~> 1"
+gem "webmock", ">= 3.10.0"
 gem "elasticsearch", "~> 7"
 
 group :check do

--- a/gemfiles/ruby_2.7_elasticsearch_8.gemfile
+++ b/gemfiles/ruby_2.7_elasticsearch_8.gemfile
@@ -6,7 +6,9 @@ gem "benchmark-ips", "~> 2.8"
 gem "benchmark-memory", "< 0.2"
 gem "climate_control", "~> 0.2.0"
 gem "concurrent-ruby"
+gem "dogstatsd-ruby", ">= 3.3.0", "!= 5.0.0", "!= 5.0.1", "!= 5.1.0"
 gem "extlz4", "~> 0.3", ">= 0.3.3"
+gem "google-protobuf", ["~> 3.0", "!= 3.7.0", "!= 3.7.1"]
 gem "json-schema", "< 3"
 gem "memory_profiler", "~> 0.9"
 gem "os", "~> 1.1"
@@ -20,16 +22,14 @@ gem "rspec", "~> 3.13"
 gem "rspec-collection_matchers", "~> 1.1"
 gem "rspec-wait", "~> 0"
 gem "rspec_junit_formatter", ">= 0.5.1"
-gem "simplecov", git: "https://github.com/DataDog/simplecov", ref: "3bb6b7ee58bf4b1954ca205f50dd44d6f41c57db"
-gem "simplecov-cobertura", "~> 2.1.0"
-gem "warning", "~> 1"
-gem "webmock", ">= 3.10.0"
 gem "rubocop", "~> 1.50.0", require: false
 gem "rubocop-packaging", "~> 0.5.2", require: false
 gem "rubocop-performance", "~> 1.9", require: false
 gem "rubocop-rspec", ["~> 2.20", "< 2.21"], require: false
-gem "dogstatsd-ruby", ">= 3.3.0", "!= 5.0.0", "!= 5.0.1", "!= 5.1.0"
-gem "google-protobuf", ["~> 3.0", "!= 3.7.0", "!= 3.7.1"]
+gem "simplecov", git: "https://github.com/DataDog/simplecov", ref: "3bb6b7ee58bf4b1954ca205f50dd44d6f41c57db"
+gem "simplecov-cobertura", "~> 2.1.0"
+gem "warning", "~> 1"
+gem "webmock", ">= 3.10.0"
 gem "elasticsearch", "~> 8"
 
 group :check do

--- a/gemfiles/ruby_2.7_elasticsearch_latest.gemfile
+++ b/gemfiles/ruby_2.7_elasticsearch_latest.gemfile
@@ -6,7 +6,9 @@ gem "benchmark-ips", "~> 2.8"
 gem "benchmark-memory", "< 0.2"
 gem "climate_control", "~> 0.2.0"
 gem "concurrent-ruby"
+gem "dogstatsd-ruby", ">= 3.3.0", "!= 5.0.0", "!= 5.0.1", "!= 5.1.0"
 gem "extlz4", "~> 0.3", ">= 0.3.3"
+gem "google-protobuf", ["~> 3.0", "!= 3.7.0", "!= 3.7.1"]
 gem "json-schema", "< 3"
 gem "memory_profiler", "~> 0.9"
 gem "os", "~> 1.1"
@@ -20,16 +22,14 @@ gem "rspec", "~> 3.13"
 gem "rspec-collection_matchers", "~> 1.1"
 gem "rspec-wait", "~> 0"
 gem "rspec_junit_formatter", ">= 0.5.1"
-gem "simplecov", git: "https://github.com/DataDog/simplecov", ref: "3bb6b7ee58bf4b1954ca205f50dd44d6f41c57db"
-gem "simplecov-cobertura", "~> 2.1.0"
-gem "warning", "~> 1"
-gem "webmock", ">= 3.10.0"
 gem "rubocop", "~> 1.50.0", require: false
 gem "rubocop-packaging", "~> 0.5.2", require: false
 gem "rubocop-performance", "~> 1.9", require: false
 gem "rubocop-rspec", ["~> 2.20", "< 2.21"], require: false
-gem "dogstatsd-ruby", ">= 3.3.0", "!= 5.0.0", "!= 5.0.1", "!= 5.1.0"
-gem "google-protobuf", ["~> 3.0", "!= 3.7.0", "!= 3.7.1"]
+gem "simplecov", git: "https://github.com/DataDog/simplecov", ref: "3bb6b7ee58bf4b1954ca205f50dd44d6f41c57db"
+gem "simplecov-cobertura", "~> 2.1.0"
+gem "warning", "~> 1"
+gem "webmock", ">= 3.10.0"
 gem "elasticsearch"
 
 group :check do

--- a/gemfiles/ruby_2.7_graphql_1.13.gemfile
+++ b/gemfiles/ruby_2.7_graphql_1.13.gemfile
@@ -6,7 +6,9 @@ gem "benchmark-ips", "~> 2.8"
 gem "benchmark-memory", "< 0.2"
 gem "climate_control", "~> 0.2.0"
 gem "concurrent-ruby"
+gem "dogstatsd-ruby", ">= 3.3.0", "!= 5.0.0", "!= 5.0.1", "!= 5.1.0"
 gem "extlz4", "~> 0.3", ">= 0.3.3"
+gem "google-protobuf", ["~> 3.0", "!= 3.7.0", "!= 3.7.1"]
 gem "json-schema", "< 3"
 gem "memory_profiler", "~> 0.9"
 gem "os", "~> 1.1"
@@ -20,16 +22,14 @@ gem "rspec", "~> 3.13"
 gem "rspec-collection_matchers", "~> 1.1"
 gem "rspec-wait", "~> 0"
 gem "rspec_junit_formatter", ">= 0.5.1"
-gem "simplecov", git: "https://github.com/DataDog/simplecov", ref: "3bb6b7ee58bf4b1954ca205f50dd44d6f41c57db"
-gem "simplecov-cobertura", "~> 2.1.0"
-gem "warning", "~> 1"
-gem "webmock", ">= 3.10.0"
 gem "rubocop", "~> 1.50.0", require: false
 gem "rubocop-packaging", "~> 0.5.2", require: false
 gem "rubocop-performance", "~> 1.9", require: false
 gem "rubocop-rspec", ["~> 2.20", "< 2.21"], require: false
-gem "dogstatsd-ruby", ">= 3.3.0", "!= 5.0.0", "!= 5.0.1", "!= 5.1.0"
-gem "google-protobuf", ["~> 3.0", "!= 3.7.0", "!= 3.7.1"]
+gem "simplecov", git: "https://github.com/DataDog/simplecov", ref: "3bb6b7ee58bf4b1954ca205f50dd44d6f41c57db"
+gem "simplecov-cobertura", "~> 2.1.0"
+gem "warning", "~> 1"
+gem "webmock", ">= 3.10.0"
 gem "rails", "~> 6.1.0"
 gem "graphql", "~> 1.13.0"
 gem "sprockets", "< 4"

--- a/gemfiles/ruby_2.7_graphql_2.0.gemfile
+++ b/gemfiles/ruby_2.7_graphql_2.0.gemfile
@@ -6,7 +6,9 @@ gem "benchmark-ips", "~> 2.8"
 gem "benchmark-memory", "< 0.2"
 gem "climate_control", "~> 0.2.0"
 gem "concurrent-ruby"
+gem "dogstatsd-ruby", ">= 3.3.0", "!= 5.0.0", "!= 5.0.1", "!= 5.1.0"
 gem "extlz4", "~> 0.3", ">= 0.3.3"
+gem "google-protobuf", ["~> 3.0", "!= 3.7.0", "!= 3.7.1"]
 gem "json-schema", "< 3"
 gem "memory_profiler", "~> 0.9"
 gem "os", "~> 1.1"
@@ -20,16 +22,14 @@ gem "rspec", "~> 3.13"
 gem "rspec-collection_matchers", "~> 1.1"
 gem "rspec-wait", "~> 0"
 gem "rspec_junit_formatter", ">= 0.5.1"
-gem "simplecov", git: "https://github.com/DataDog/simplecov", ref: "3bb6b7ee58bf4b1954ca205f50dd44d6f41c57db"
-gem "simplecov-cobertura", "~> 2.1.0"
-gem "warning", "~> 1"
-gem "webmock", ">= 3.10.0"
 gem "rubocop", "~> 1.50.0", require: false
 gem "rubocop-packaging", "~> 0.5.2", require: false
 gem "rubocop-performance", "~> 1.9", require: false
 gem "rubocop-rspec", ["~> 2.20", "< 2.21"], require: false
-gem "dogstatsd-ruby", ">= 3.3.0", "!= 5.0.0", "!= 5.0.1", "!= 5.1.0"
-gem "google-protobuf", ["~> 3.0", "!= 3.7.0", "!= 3.7.1"]
+gem "simplecov", git: "https://github.com/DataDog/simplecov", ref: "3bb6b7ee58bf4b1954ca205f50dd44d6f41c57db"
+gem "simplecov-cobertura", "~> 2.1.0"
+gem "warning", "~> 1"
+gem "webmock", ">= 3.10.0"
 gem "rails", "~> 6.1.0"
 gem "graphql", "~> 2.0.0"
 gem "sprockets", "< 4"

--- a/gemfiles/ruby_2.7_graphql_2.1.gemfile
+++ b/gemfiles/ruby_2.7_graphql_2.1.gemfile
@@ -6,7 +6,9 @@ gem "benchmark-ips", "~> 2.8"
 gem "benchmark-memory", "< 0.2"
 gem "climate_control", "~> 0.2.0"
 gem "concurrent-ruby"
+gem "dogstatsd-ruby", ">= 3.3.0", "!= 5.0.0", "!= 5.0.1", "!= 5.1.0"
 gem "extlz4", "~> 0.3", ">= 0.3.3"
+gem "google-protobuf", ["~> 3.0", "!= 3.7.0", "!= 3.7.1"]
 gem "json-schema", "< 3"
 gem "memory_profiler", "~> 0.9"
 gem "os", "~> 1.1"
@@ -20,16 +22,14 @@ gem "rspec", "~> 3.13"
 gem "rspec-collection_matchers", "~> 1.1"
 gem "rspec-wait", "~> 0"
 gem "rspec_junit_formatter", ">= 0.5.1"
-gem "simplecov", git: "https://github.com/DataDog/simplecov", ref: "3bb6b7ee58bf4b1954ca205f50dd44d6f41c57db"
-gem "simplecov-cobertura", "~> 2.1.0"
-gem "warning", "~> 1"
-gem "webmock", ">= 3.10.0"
 gem "rubocop", "~> 1.50.0", require: false
 gem "rubocop-packaging", "~> 0.5.2", require: false
 gem "rubocop-performance", "~> 1.9", require: false
 gem "rubocop-rspec", ["~> 2.20", "< 2.21"], require: false
-gem "dogstatsd-ruby", ">= 3.3.0", "!= 5.0.0", "!= 5.0.1", "!= 5.1.0"
-gem "google-protobuf", ["~> 3.0", "!= 3.7.0", "!= 3.7.1"]
+gem "simplecov", git: "https://github.com/DataDog/simplecov", ref: "3bb6b7ee58bf4b1954ca205f50dd44d6f41c57db"
+gem "simplecov-cobertura", "~> 2.1.0"
+gem "warning", "~> 1"
+gem "webmock", ">= 3.10.0"
 gem "rails", "~> 6.1.0"
 gem "graphql", "~> 2.1.0"
 gem "sprockets", "< 4"

--- a/gemfiles/ruby_2.7_graphql_2.2.gemfile
+++ b/gemfiles/ruby_2.7_graphql_2.2.gemfile
@@ -6,7 +6,9 @@ gem "benchmark-ips", "~> 2.8"
 gem "benchmark-memory", "< 0.2"
 gem "climate_control", "~> 0.2.0"
 gem "concurrent-ruby"
+gem "dogstatsd-ruby", ">= 3.3.0", "!= 5.0.0", "!= 5.0.1", "!= 5.1.0"
 gem "extlz4", "~> 0.3", ">= 0.3.3"
+gem "google-protobuf", ["~> 3.0", "!= 3.7.0", "!= 3.7.1"]
 gem "json-schema", "< 3"
 gem "memory_profiler", "~> 0.9"
 gem "os", "~> 1.1"
@@ -20,16 +22,14 @@ gem "rspec", "~> 3.13"
 gem "rspec-collection_matchers", "~> 1.1"
 gem "rspec-wait", "~> 0"
 gem "rspec_junit_formatter", ">= 0.5.1"
-gem "simplecov", git: "https://github.com/DataDog/simplecov", ref: "3bb6b7ee58bf4b1954ca205f50dd44d6f41c57db"
-gem "simplecov-cobertura", "~> 2.1.0"
-gem "warning", "~> 1"
-gem "webmock", ">= 3.10.0"
 gem "rubocop", "~> 1.50.0", require: false
 gem "rubocop-packaging", "~> 0.5.2", require: false
 gem "rubocop-performance", "~> 1.9", require: false
 gem "rubocop-rspec", ["~> 2.20", "< 2.21"], require: false
-gem "dogstatsd-ruby", ">= 3.3.0", "!= 5.0.0", "!= 5.0.1", "!= 5.1.0"
-gem "google-protobuf", ["~> 3.0", "!= 3.7.0", "!= 3.7.1"]
+gem "simplecov", git: "https://github.com/DataDog/simplecov", ref: "3bb6b7ee58bf4b1954ca205f50dd44d6f41c57db"
+gem "simplecov-cobertura", "~> 2.1.0"
+gem "warning", "~> 1"
+gem "webmock", ">= 3.10.0"
 gem "rails", "~> 6.1.0"
 gem "graphql", "~> 2.2.0"
 gem "sprockets", "< 4"

--- a/gemfiles/ruby_2.7_graphql_2.3.gemfile
+++ b/gemfiles/ruby_2.7_graphql_2.3.gemfile
@@ -6,7 +6,9 @@ gem "benchmark-ips", "~> 2.8"
 gem "benchmark-memory", "< 0.2"
 gem "climate_control", "~> 0.2.0"
 gem "concurrent-ruby"
+gem "dogstatsd-ruby", ">= 3.3.0", "!= 5.0.0", "!= 5.0.1", "!= 5.1.0"
 gem "extlz4", "~> 0.3", ">= 0.3.3"
+gem "google-protobuf", ["~> 3.0", "!= 3.7.0", "!= 3.7.1"]
 gem "json-schema", "< 3"
 gem "memory_profiler", "~> 0.9"
 gem "os", "~> 1.1"
@@ -20,16 +22,14 @@ gem "rspec", "~> 3.13"
 gem "rspec-collection_matchers", "~> 1.1"
 gem "rspec-wait", "~> 0"
 gem "rspec_junit_formatter", ">= 0.5.1"
-gem "simplecov", git: "https://github.com/DataDog/simplecov", ref: "3bb6b7ee58bf4b1954ca205f50dd44d6f41c57db"
-gem "simplecov-cobertura", "~> 2.1.0"
-gem "warning", "~> 1"
-gem "webmock", ">= 3.10.0"
 gem "rubocop", "~> 1.50.0", require: false
 gem "rubocop-packaging", "~> 0.5.2", require: false
 gem "rubocop-performance", "~> 1.9", require: false
 gem "rubocop-rspec", ["~> 2.20", "< 2.21"], require: false
-gem "dogstatsd-ruby", ">= 3.3.0", "!= 5.0.0", "!= 5.0.1", "!= 5.1.0"
-gem "google-protobuf", ["~> 3.0", "!= 3.7.0", "!= 3.7.1"]
+gem "simplecov", git: "https://github.com/DataDog/simplecov", ref: "3bb6b7ee58bf4b1954ca205f50dd44d6f41c57db"
+gem "simplecov-cobertura", "~> 2.1.0"
+gem "warning", "~> 1"
+gem "webmock", ">= 3.10.0"
 gem "rails", "~> 6.1.0"
 gem "graphql", "~> 2.3.0"
 gem "sprockets", "< 4"

--- a/gemfiles/ruby_2.7_hanami_1.gemfile
+++ b/gemfiles/ruby_2.7_hanami_1.gemfile
@@ -6,7 +6,9 @@ gem "benchmark-ips", "~> 2.8"
 gem "benchmark-memory", "< 0.2"
 gem "climate_control", "~> 0.2.0"
 gem "concurrent-ruby"
+gem "dogstatsd-ruby", ">= 3.3.0", "!= 5.0.0", "!= 5.0.1", "!= 5.1.0"
 gem "extlz4", "~> 0.3", ">= 0.3.3"
+gem "google-protobuf", ["~> 3.0", "!= 3.7.0", "!= 3.7.1"]
 gem "json-schema", "< 3"
 gem "memory_profiler", "~> 0.9"
 gem "os", "~> 1.1"
@@ -20,16 +22,14 @@ gem "rspec", "~> 3.13"
 gem "rspec-collection_matchers", "~> 1.1"
 gem "rspec-wait", "~> 0"
 gem "rspec_junit_formatter", ">= 0.5.1"
-gem "simplecov", git: "https://github.com/DataDog/simplecov", ref: "3bb6b7ee58bf4b1954ca205f50dd44d6f41c57db"
-gem "simplecov-cobertura", "~> 2.1.0"
-gem "warning", "~> 1"
-gem "webmock", ">= 3.10.0"
 gem "rubocop", "~> 1.50.0", require: false
 gem "rubocop-packaging", "~> 0.5.2", require: false
 gem "rubocop-performance", "~> 1.9", require: false
 gem "rubocop-rspec", ["~> 2.20", "< 2.21"], require: false
-gem "dogstatsd-ruby", ">= 3.3.0", "!= 5.0.0", "!= 5.0.1", "!= 5.1.0"
-gem "google-protobuf", ["~> 3.0", "!= 3.7.0", "!= 3.7.1"]
+gem "simplecov", git: "https://github.com/DataDog/simplecov", ref: "3bb6b7ee58bf4b1954ca205f50dd44d6f41c57db"
+gem "simplecov-cobertura", "~> 2.1.0"
+gem "warning", "~> 1"
+gem "webmock", ">= 3.10.0"
 gem "rack"
 gem "rack-test"
 gem "hanami", "~> 1"

--- a/gemfiles/ruby_2.7_http.gemfile
+++ b/gemfiles/ruby_2.7_http.gemfile
@@ -6,7 +6,9 @@ gem "benchmark-ips", "~> 2.8"
 gem "benchmark-memory", "< 0.2"
 gem "climate_control", "~> 0.2.0"
 gem "concurrent-ruby"
+gem "dogstatsd-ruby", ">= 3.3.0", "!= 5.0.0", "!= 5.0.1", "!= 5.1.0"
 gem "extlz4", "~> 0.3", ">= 0.3.3"
+gem "google-protobuf", ["~> 3.0", "!= 3.7.0", "!= 3.7.1"]
 gem "json-schema", "< 3"
 gem "memory_profiler", "~> 0.9"
 gem "os", "~> 1.1"
@@ -20,16 +22,14 @@ gem "rspec", "~> 3.13"
 gem "rspec-collection_matchers", "~> 1.1"
 gem "rspec-wait", "~> 0"
 gem "rspec_junit_formatter", ">= 0.5.1"
-gem "simplecov", git: "https://github.com/DataDog/simplecov", ref: "3bb6b7ee58bf4b1954ca205f50dd44d6f41c57db"
-gem "simplecov-cobertura", "~> 2.1.0"
-gem "warning", "~> 1"
-gem "webmock", ">= 3.10.0"
 gem "rubocop", "~> 1.50.0", require: false
 gem "rubocop-packaging", "~> 0.5.2", require: false
 gem "rubocop-performance", "~> 1.9", require: false
 gem "rubocop-rspec", ["~> 2.20", "< 2.21"], require: false
-gem "dogstatsd-ruby", ">= 3.3.0", "!= 5.0.0", "!= 5.0.1", "!= 5.1.0"
-gem "google-protobuf", ["~> 3.0", "!= 3.7.0", "!= 3.7.1"]
+gem "simplecov", git: "https://github.com/DataDog/simplecov", ref: "3bb6b7ee58bf4b1954ca205f50dd44d6f41c57db"
+gem "simplecov-cobertura", "~> 2.1.0"
+gem "warning", "~> 1"
+gem "webmock", ">= 3.10.0"
 gem "ethon"
 gem "excon"
 gem "faraday"

--- a/gemfiles/ruby_2.7_opensearch_2.gemfile
+++ b/gemfiles/ruby_2.7_opensearch_2.gemfile
@@ -6,7 +6,9 @@ gem "benchmark-ips", "~> 2.8"
 gem "benchmark-memory", "< 0.2"
 gem "climate_control", "~> 0.2.0"
 gem "concurrent-ruby"
+gem "dogstatsd-ruby", ">= 3.3.0", "!= 5.0.0", "!= 5.0.1", "!= 5.1.0"
 gem "extlz4", "~> 0.3", ">= 0.3.3"
+gem "google-protobuf", ["~> 3.0", "!= 3.7.0", "!= 3.7.1"]
 gem "json-schema", "< 3"
 gem "memory_profiler", "~> 0.9"
 gem "os", "~> 1.1"
@@ -20,16 +22,14 @@ gem "rspec", "~> 3.13"
 gem "rspec-collection_matchers", "~> 1.1"
 gem "rspec-wait", "~> 0"
 gem "rspec_junit_formatter", ">= 0.5.1"
-gem "simplecov", git: "https://github.com/DataDog/simplecov", ref: "3bb6b7ee58bf4b1954ca205f50dd44d6f41c57db"
-gem "simplecov-cobertura", "~> 2.1.0"
-gem "warning", "~> 1"
-gem "webmock", ">= 3.10.0"
 gem "rubocop", "~> 1.50.0", require: false
 gem "rubocop-packaging", "~> 0.5.2", require: false
 gem "rubocop-performance", "~> 1.9", require: false
 gem "rubocop-rspec", ["~> 2.20", "< 2.21"], require: false
-gem "dogstatsd-ruby", ">= 3.3.0", "!= 5.0.0", "!= 5.0.1", "!= 5.1.0"
-gem "google-protobuf", ["~> 3.0", "!= 3.7.0", "!= 3.7.1"]
+gem "simplecov", git: "https://github.com/DataDog/simplecov", ref: "3bb6b7ee58bf4b1954ca205f50dd44d6f41c57db"
+gem "simplecov-cobertura", "~> 2.1.0"
+gem "warning", "~> 1"
+gem "webmock", ">= 3.10.0"
 gem "opensearch-ruby", "~> 2"
 
 group :check do

--- a/gemfiles/ruby_2.7_opensearch_3.gemfile
+++ b/gemfiles/ruby_2.7_opensearch_3.gemfile
@@ -6,7 +6,9 @@ gem "benchmark-ips", "~> 2.8"
 gem "benchmark-memory", "< 0.2"
 gem "climate_control", "~> 0.2.0"
 gem "concurrent-ruby"
+gem "dogstatsd-ruby", ">= 3.3.0", "!= 5.0.0", "!= 5.0.1", "!= 5.1.0"
 gem "extlz4", "~> 0.3", ">= 0.3.3"
+gem "google-protobuf", ["~> 3.0", "!= 3.7.0", "!= 3.7.1"]
 gem "json-schema", "< 3"
 gem "memory_profiler", "~> 0.9"
 gem "os", "~> 1.1"
@@ -20,16 +22,14 @@ gem "rspec", "~> 3.13"
 gem "rspec-collection_matchers", "~> 1.1"
 gem "rspec-wait", "~> 0"
 gem "rspec_junit_formatter", ">= 0.5.1"
-gem "simplecov", git: "https://github.com/DataDog/simplecov", ref: "3bb6b7ee58bf4b1954ca205f50dd44d6f41c57db"
-gem "simplecov-cobertura", "~> 2.1.0"
-gem "warning", "~> 1"
-gem "webmock", ">= 3.10.0"
 gem "rubocop", "~> 1.50.0", require: false
 gem "rubocop-packaging", "~> 0.5.2", require: false
 gem "rubocop-performance", "~> 1.9", require: false
 gem "rubocop-rspec", ["~> 2.20", "< 2.21"], require: false
-gem "dogstatsd-ruby", ">= 3.3.0", "!= 5.0.0", "!= 5.0.1", "!= 5.1.0"
-gem "google-protobuf", ["~> 3.0", "!= 3.7.0", "!= 3.7.1"]
+gem "simplecov", git: "https://github.com/DataDog/simplecov", ref: "3bb6b7ee58bf4b1954ca205f50dd44d6f41c57db"
+gem "simplecov-cobertura", "~> 2.1.0"
+gem "warning", "~> 1"
+gem "webmock", ">= 3.10.0"
 gem "opensearch-ruby", "~> 3"
 
 group :check do

--- a/gemfiles/ruby_2.7_opensearch_latest.gemfile
+++ b/gemfiles/ruby_2.7_opensearch_latest.gemfile
@@ -6,7 +6,9 @@ gem "benchmark-ips", "~> 2.8"
 gem "benchmark-memory", "< 0.2"
 gem "climate_control", "~> 0.2.0"
 gem "concurrent-ruby"
+gem "dogstatsd-ruby", ">= 3.3.0", "!= 5.0.0", "!= 5.0.1", "!= 5.1.0"
 gem "extlz4", "~> 0.3", ">= 0.3.3"
+gem "google-protobuf", ["~> 3.0", "!= 3.7.0", "!= 3.7.1"]
 gem "json-schema", "< 3"
 gem "memory_profiler", "~> 0.9"
 gem "os", "~> 1.1"
@@ -20,16 +22,14 @@ gem "rspec", "~> 3.13"
 gem "rspec-collection_matchers", "~> 1.1"
 gem "rspec-wait", "~> 0"
 gem "rspec_junit_formatter", ">= 0.5.1"
-gem "simplecov", git: "https://github.com/DataDog/simplecov", ref: "3bb6b7ee58bf4b1954ca205f50dd44d6f41c57db"
-gem "simplecov-cobertura", "~> 2.1.0"
-gem "warning", "~> 1"
-gem "webmock", ">= 3.10.0"
 gem "rubocop", "~> 1.50.0", require: false
 gem "rubocop-packaging", "~> 0.5.2", require: false
 gem "rubocop-performance", "~> 1.9", require: false
 gem "rubocop-rspec", ["~> 2.20", "< 2.21"], require: false
-gem "dogstatsd-ruby", ">= 3.3.0", "!= 5.0.0", "!= 5.0.1", "!= 5.1.0"
-gem "google-protobuf", ["~> 3.0", "!= 3.7.0", "!= 3.7.1"]
+gem "simplecov", git: "https://github.com/DataDog/simplecov", ref: "3bb6b7ee58bf4b1954ca205f50dd44d6f41c57db"
+gem "simplecov-cobertura", "~> 2.1.0"
+gem "warning", "~> 1"
+gem "webmock", ">= 3.10.0"
 gem "opensearch-ruby"
 
 group :check do

--- a/gemfiles/ruby_2.7_opentelemetry.gemfile
+++ b/gemfiles/ruby_2.7_opentelemetry.gemfile
@@ -6,7 +6,9 @@ gem "benchmark-ips", "~> 2.8"
 gem "benchmark-memory", "< 0.2"
 gem "climate_control", "~> 0.2.0"
 gem "concurrent-ruby"
+gem "dogstatsd-ruby", ">= 3.3.0", "!= 5.0.0", "!= 5.0.1", "!= 5.1.0"
 gem "extlz4", "~> 0.3", ">= 0.3.3"
+gem "google-protobuf", ["~> 3.0", "!= 3.7.0", "!= 3.7.1"]
 gem "json-schema", "< 3"
 gem "memory_profiler", "~> 0.9"
 gem "os", "~> 1.1"
@@ -20,16 +22,14 @@ gem "rspec", "~> 3.13"
 gem "rspec-collection_matchers", "~> 1.1"
 gem "rspec-wait", "~> 0"
 gem "rspec_junit_formatter", ">= 0.5.1"
-gem "simplecov", git: "https://github.com/DataDog/simplecov", ref: "3bb6b7ee58bf4b1954ca205f50dd44d6f41c57db"
-gem "simplecov-cobertura", "~> 2.1.0"
-gem "warning", "~> 1"
-gem "webmock", ">= 3.10.0"
 gem "rubocop", "~> 1.50.0", require: false
 gem "rubocop-packaging", "~> 0.5.2", require: false
 gem "rubocop-performance", "~> 1.9", require: false
 gem "rubocop-rspec", ["~> 2.20", "< 2.21"], require: false
-gem "dogstatsd-ruby", ">= 3.3.0", "!= 5.0.0", "!= 5.0.1", "!= 5.1.0"
-gem "google-protobuf", ["~> 3.0", "!= 3.7.0", "!= 3.7.1"]
+gem "simplecov", git: "https://github.com/DataDog/simplecov", ref: "3bb6b7ee58bf4b1954ca205f50dd44d6f41c57db"
+gem "simplecov-cobertura", "~> 2.1.0"
+gem "warning", "~> 1"
+gem "webmock", ">= 3.10.0"
 gem "opentelemetry-sdk", "~> 1.1"
 
 group :check do

--- a/gemfiles/ruby_2.7_opentelemetry_otlp.gemfile
+++ b/gemfiles/ruby_2.7_opentelemetry_otlp.gemfile
@@ -6,7 +6,9 @@ gem "benchmark-ips", "~> 2.8"
 gem "benchmark-memory", "< 0.2"
 gem "climate_control", "~> 0.2.0"
 gem "concurrent-ruby"
+gem "dogstatsd-ruby", ">= 3.3.0", "!= 5.0.0", "!= 5.0.1", "!= 5.1.0"
 gem "extlz4", "~> 0.3", ">= 0.3.3"
+gem "google-protobuf", ["~> 3.0", "!= 3.7.0", "!= 3.7.1"]
 gem "json-schema", "< 3"
 gem "memory_profiler", "~> 0.9"
 gem "os", "~> 1.1"
@@ -20,16 +22,14 @@ gem "rspec", "~> 3.13"
 gem "rspec-collection_matchers", "~> 1.1"
 gem "rspec-wait", "~> 0"
 gem "rspec_junit_formatter", ">= 0.5.1"
-gem "simplecov", git: "https://github.com/DataDog/simplecov", ref: "3bb6b7ee58bf4b1954ca205f50dd44d6f41c57db"
-gem "simplecov-cobertura", "~> 2.1.0"
-gem "warning", "~> 1"
-gem "webmock", ">= 3.10.0"
 gem "rubocop", "~> 1.50.0", require: false
 gem "rubocop-packaging", "~> 0.5.2", require: false
 gem "rubocop-performance", "~> 1.9", require: false
 gem "rubocop-rspec", ["~> 2.20", "< 2.21"], require: false
-gem "dogstatsd-ruby", ">= 3.3.0", "!= 5.0.0", "!= 5.0.1", "!= 5.1.0"
-gem "google-protobuf", ["~> 3.0", "!= 3.7.0", "!= 3.7.1"]
+gem "simplecov", git: "https://github.com/DataDog/simplecov", ref: "3bb6b7ee58bf4b1954ca205f50dd44d6f41c57db"
+gem "simplecov-cobertura", "~> 2.1.0"
+gem "warning", "~> 1"
+gem "webmock", ">= 3.10.0"
 gem "opentelemetry-sdk", "~> 1.1"
 gem "opentelemetry-exporter-otlp"
 

--- a/gemfiles/ruby_2.7_rack_1.gemfile
+++ b/gemfiles/ruby_2.7_rack_1.gemfile
@@ -6,7 +6,9 @@ gem "benchmark-ips", "~> 2.8"
 gem "benchmark-memory", "< 0.2"
 gem "climate_control", "~> 0.2.0"
 gem "concurrent-ruby"
+gem "dogstatsd-ruby", ">= 3.3.0", "!= 5.0.0", "!= 5.0.1", "!= 5.1.0"
 gem "extlz4", "~> 0.3", ">= 0.3.3"
+gem "google-protobuf", ["~> 3.0", "!= 3.7.0", "!= 3.7.1"]
 gem "json-schema", "< 3"
 gem "memory_profiler", "~> 0.9"
 gem "os", "~> 1.1"
@@ -20,16 +22,14 @@ gem "rspec", "~> 3.13"
 gem "rspec-collection_matchers", "~> 1.1"
 gem "rspec-wait", "~> 0"
 gem "rspec_junit_formatter", ">= 0.5.1"
-gem "simplecov", git: "https://github.com/DataDog/simplecov", ref: "3bb6b7ee58bf4b1954ca205f50dd44d6f41c57db"
-gem "simplecov-cobertura", "~> 2.1.0"
-gem "warning", "~> 1"
-gem "webmock", ">= 3.10.0"
 gem "rubocop", "~> 1.50.0", require: false
 gem "rubocop-packaging", "~> 0.5.2", require: false
 gem "rubocop-performance", "~> 1.9", require: false
 gem "rubocop-rspec", ["~> 2.20", "< 2.21"], require: false
-gem "dogstatsd-ruby", ">= 3.3.0", "!= 5.0.0", "!= 5.0.1", "!= 5.1.0"
-gem "google-protobuf", ["~> 3.0", "!= 3.7.0", "!= 3.7.1"]
+gem "simplecov", git: "https://github.com/DataDog/simplecov", ref: "3bb6b7ee58bf4b1954ca205f50dd44d6f41c57db"
+gem "simplecov-cobertura", "~> 2.1.0"
+gem "warning", "~> 1"
+gem "webmock", ">= 3.10.0"
 gem "rack", "~> 1"
 gem "rack-contrib"
 gem "rack-test"

--- a/gemfiles/ruby_2.7_rack_2.gemfile
+++ b/gemfiles/ruby_2.7_rack_2.gemfile
@@ -6,7 +6,9 @@ gem "benchmark-ips", "~> 2.8"
 gem "benchmark-memory", "< 0.2"
 gem "climate_control", "~> 0.2.0"
 gem "concurrent-ruby"
+gem "dogstatsd-ruby", ">= 3.3.0", "!= 5.0.0", "!= 5.0.1", "!= 5.1.0"
 gem "extlz4", "~> 0.3", ">= 0.3.3"
+gem "google-protobuf", ["~> 3.0", "!= 3.7.0", "!= 3.7.1"]
 gem "json-schema", "< 3"
 gem "memory_profiler", "~> 0.9"
 gem "os", "~> 1.1"
@@ -20,16 +22,14 @@ gem "rspec", "~> 3.13"
 gem "rspec-collection_matchers", "~> 1.1"
 gem "rspec-wait", "~> 0"
 gem "rspec_junit_formatter", ">= 0.5.1"
-gem "simplecov", git: "https://github.com/DataDog/simplecov", ref: "3bb6b7ee58bf4b1954ca205f50dd44d6f41c57db"
-gem "simplecov-cobertura", "~> 2.1.0"
-gem "warning", "~> 1"
-gem "webmock", ">= 3.10.0"
 gem "rubocop", "~> 1.50.0", require: false
 gem "rubocop-packaging", "~> 0.5.2", require: false
 gem "rubocop-performance", "~> 1.9", require: false
 gem "rubocop-rspec", ["~> 2.20", "< 2.21"], require: false
-gem "dogstatsd-ruby", ">= 3.3.0", "!= 5.0.0", "!= 5.0.1", "!= 5.1.0"
-gem "google-protobuf", ["~> 3.0", "!= 3.7.0", "!= 3.7.1"]
+gem "simplecov", git: "https://github.com/DataDog/simplecov", ref: "3bb6b7ee58bf4b1954ca205f50dd44d6f41c57db"
+gem "simplecov-cobertura", "~> 2.1.0"
+gem "warning", "~> 1"
+gem "webmock", ">= 3.10.0"
 gem "rack", "~> 2"
 gem "rack-contrib"
 gem "rack-test"

--- a/gemfiles/ruby_2.7_rack_3.gemfile
+++ b/gemfiles/ruby_2.7_rack_3.gemfile
@@ -6,7 +6,9 @@ gem "benchmark-ips", "~> 2.8"
 gem "benchmark-memory", "< 0.2"
 gem "climate_control", "~> 0.2.0"
 gem "concurrent-ruby"
+gem "dogstatsd-ruby", ">= 3.3.0", "!= 5.0.0", "!= 5.0.1", "!= 5.1.0"
 gem "extlz4", "~> 0.3", ">= 0.3.3"
+gem "google-protobuf", ["~> 3.0", "!= 3.7.0", "!= 3.7.1"]
 gem "json-schema", "< 3"
 gem "memory_profiler", "~> 0.9"
 gem "os", "~> 1.1"
@@ -20,16 +22,14 @@ gem "rspec", "~> 3.13"
 gem "rspec-collection_matchers", "~> 1.1"
 gem "rspec-wait", "~> 0"
 gem "rspec_junit_formatter", ">= 0.5.1"
-gem "simplecov", git: "https://github.com/DataDog/simplecov", ref: "3bb6b7ee58bf4b1954ca205f50dd44d6f41c57db"
-gem "simplecov-cobertura", "~> 2.1.0"
-gem "warning", "~> 1"
-gem "webmock", ">= 3.10.0"
 gem "rubocop", "~> 1.50.0", require: false
 gem "rubocop-packaging", "~> 0.5.2", require: false
 gem "rubocop-performance", "~> 1.9", require: false
 gem "rubocop-rspec", ["~> 2.20", "< 2.21"], require: false
-gem "dogstatsd-ruby", ">= 3.3.0", "!= 5.0.0", "!= 5.0.1", "!= 5.1.0"
-gem "google-protobuf", ["~> 3.0", "!= 3.7.0", "!= 3.7.1"]
+gem "simplecov", git: "https://github.com/DataDog/simplecov", ref: "3bb6b7ee58bf4b1954ca205f50dd44d6f41c57db"
+gem "simplecov-cobertura", "~> 2.1.0"
+gem "warning", "~> 1"
+gem "webmock", ">= 3.10.0"
 gem "rack", "~> 3"
 gem "rack-contrib"
 gem "rack-test"

--- a/gemfiles/ruby_2.7_rack_latest.gemfile
+++ b/gemfiles/ruby_2.7_rack_latest.gemfile
@@ -6,7 +6,9 @@ gem "benchmark-ips", "~> 2.8"
 gem "benchmark-memory", "< 0.2"
 gem "climate_control", "~> 0.2.0"
 gem "concurrent-ruby"
+gem "dogstatsd-ruby", ">= 3.3.0", "!= 5.0.0", "!= 5.0.1", "!= 5.1.0"
 gem "extlz4", "~> 0.3", ">= 0.3.3"
+gem "google-protobuf", ["~> 3.0", "!= 3.7.0", "!= 3.7.1"]
 gem "json-schema", "< 3"
 gem "memory_profiler", "~> 0.9"
 gem "os", "~> 1.1"
@@ -20,16 +22,14 @@ gem "rspec", "~> 3.13"
 gem "rspec-collection_matchers", "~> 1.1"
 gem "rspec-wait", "~> 0"
 gem "rspec_junit_formatter", ">= 0.5.1"
-gem "simplecov", git: "https://github.com/DataDog/simplecov", ref: "3bb6b7ee58bf4b1954ca205f50dd44d6f41c57db"
-gem "simplecov-cobertura", "~> 2.1.0"
-gem "warning", "~> 1"
-gem "webmock", ">= 3.10.0"
 gem "rubocop", "~> 1.50.0", require: false
 gem "rubocop-packaging", "~> 0.5.2", require: false
 gem "rubocop-performance", "~> 1.9", require: false
 gem "rubocop-rspec", ["~> 2.20", "< 2.21"], require: false
-gem "dogstatsd-ruby", ">= 3.3.0", "!= 5.0.0", "!= 5.0.1", "!= 5.1.0"
-gem "google-protobuf", ["~> 3.0", "!= 3.7.0", "!= 3.7.1"]
+gem "simplecov", git: "https://github.com/DataDog/simplecov", ref: "3bb6b7ee58bf4b1954ca205f50dd44d6f41c57db"
+gem "simplecov-cobertura", "~> 2.1.0"
+gem "warning", "~> 1"
+gem "webmock", ">= 3.10.0"
 gem "rack"
 gem "rack-contrib"
 gem "rack-test"

--- a/gemfiles/ruby_2.7_rails5_mysql2.gemfile
+++ b/gemfiles/ruby_2.7_rails5_mysql2.gemfile
@@ -6,7 +6,9 @@ gem "benchmark-ips", "~> 2.8"
 gem "benchmark-memory", "< 0.2"
 gem "climate_control", "~> 0.2.0"
 gem "concurrent-ruby"
+gem "dogstatsd-ruby", ">= 3.3.0", "!= 5.0.0", "!= 5.0.1", "!= 5.1.0"
 gem "extlz4", "~> 0.3", ">= 0.3.3"
+gem "google-protobuf", ["~> 3.0", "!= 3.7.0", "!= 3.7.1"]
 gem "json-schema", "< 3"
 gem "memory_profiler", "~> 0.9"
 gem "os", "~> 1.1"
@@ -20,16 +22,14 @@ gem "rspec", "~> 3.13"
 gem "rspec-collection_matchers", "~> 1.1"
 gem "rspec-wait", "~> 0"
 gem "rspec_junit_formatter", ">= 0.5.1"
-gem "simplecov", git: "https://github.com/DataDog/simplecov", ref: "3bb6b7ee58bf4b1954ca205f50dd44d6f41c57db"
-gem "simplecov-cobertura", "~> 2.1.0"
-gem "warning", "~> 1"
-gem "webmock", ">= 3.10.0"
 gem "rubocop", "~> 1.50.0", require: false
 gem "rubocop-packaging", "~> 0.5.2", require: false
 gem "rubocop-performance", "~> 1.9", require: false
 gem "rubocop-rspec", ["~> 2.20", "< 2.21"], require: false
-gem "dogstatsd-ruby", ">= 3.3.0", "!= 5.0.0", "!= 5.0.1", "!= 5.1.0"
-gem "google-protobuf", ["~> 3.0", "!= 3.7.0", "!= 3.7.1"]
+gem "simplecov", git: "https://github.com/DataDog/simplecov", ref: "3bb6b7ee58bf4b1954ca205f50dd44d6f41c57db"
+gem "simplecov-cobertura", "~> 2.1.0"
+gem "warning", "~> 1"
+gem "webmock", ">= 3.10.0"
 gem "rails", "~> 5.2.1"
 gem "mysql2", "< 1", platform: :ruby
 gem "sprockets", "< 4"

--- a/gemfiles/ruby_2.7_rails5_postgres.gemfile
+++ b/gemfiles/ruby_2.7_rails5_postgres.gemfile
@@ -6,7 +6,9 @@ gem "benchmark-ips", "~> 2.8"
 gem "benchmark-memory", "< 0.2"
 gem "climate_control", "~> 0.2.0"
 gem "concurrent-ruby"
+gem "dogstatsd-ruby", ">= 3.3.0", "!= 5.0.0", "!= 5.0.1", "!= 5.1.0"
 gem "extlz4", "~> 0.3", ">= 0.3.3"
+gem "google-protobuf", ["~> 3.0", "!= 3.7.0", "!= 3.7.1"]
 gem "json-schema", "< 3"
 gem "memory_profiler", "~> 0.9"
 gem "os", "~> 1.1"
@@ -20,16 +22,14 @@ gem "rspec", "~> 3.13"
 gem "rspec-collection_matchers", "~> 1.1"
 gem "rspec-wait", "~> 0"
 gem "rspec_junit_formatter", ">= 0.5.1"
-gem "simplecov", git: "https://github.com/DataDog/simplecov", ref: "3bb6b7ee58bf4b1954ca205f50dd44d6f41c57db"
-gem "simplecov-cobertura", "~> 2.1.0"
-gem "warning", "~> 1"
-gem "webmock", ">= 3.10.0"
 gem "rubocop", "~> 1.50.0", require: false
 gem "rubocop-packaging", "~> 0.5.2", require: false
 gem "rubocop-performance", "~> 1.9", require: false
 gem "rubocop-rspec", ["~> 2.20", "< 2.21"], require: false
-gem "dogstatsd-ruby", ">= 3.3.0", "!= 5.0.0", "!= 5.0.1", "!= 5.1.0"
-gem "google-protobuf", ["~> 3.0", "!= 3.7.0", "!= 3.7.1"]
+gem "simplecov", git: "https://github.com/DataDog/simplecov", ref: "3bb6b7ee58bf4b1954ca205f50dd44d6f41c57db"
+gem "simplecov-cobertura", "~> 2.1.0"
+gem "warning", "~> 1"
+gem "webmock", ">= 3.10.0"
 gem "rails", "~> 5.2.1"
 gem "pg", "< 1.0", platform: :ruby
 gem "sprockets", "< 4"

--- a/gemfiles/ruby_2.7_rails5_postgres_redis.gemfile
+++ b/gemfiles/ruby_2.7_rails5_postgres_redis.gemfile
@@ -6,7 +6,9 @@ gem "benchmark-ips", "~> 2.8"
 gem "benchmark-memory", "< 0.2"
 gem "climate_control", "~> 0.2.0"
 gem "concurrent-ruby"
+gem "dogstatsd-ruby", ">= 3.3.0", "!= 5.0.0", "!= 5.0.1", "!= 5.1.0"
 gem "extlz4", "~> 0.3", ">= 0.3.3"
+gem "google-protobuf", ["~> 3.0", "!= 3.7.0", "!= 3.7.1"]
 gem "json-schema", "< 3"
 gem "memory_profiler", "~> 0.9"
 gem "os", "~> 1.1"
@@ -20,16 +22,14 @@ gem "rspec", "~> 3.13"
 gem "rspec-collection_matchers", "~> 1.1"
 gem "rspec-wait", "~> 0"
 gem "rspec_junit_formatter", ">= 0.5.1"
-gem "simplecov", git: "https://github.com/DataDog/simplecov", ref: "3bb6b7ee58bf4b1954ca205f50dd44d6f41c57db"
-gem "simplecov-cobertura", "~> 2.1.0"
-gem "warning", "~> 1"
-gem "webmock", ">= 3.10.0"
 gem "rubocop", "~> 1.50.0", require: false
 gem "rubocop-packaging", "~> 0.5.2", require: false
 gem "rubocop-performance", "~> 1.9", require: false
 gem "rubocop-rspec", ["~> 2.20", "< 2.21"], require: false
-gem "dogstatsd-ruby", ">= 3.3.0", "!= 5.0.0", "!= 5.0.1", "!= 5.1.0"
-gem "google-protobuf", ["~> 3.0", "!= 3.7.0", "!= 3.7.1"]
+gem "simplecov", git: "https://github.com/DataDog/simplecov", ref: "3bb6b7ee58bf4b1954ca205f50dd44d6f41c57db"
+gem "simplecov-cobertura", "~> 2.1.0"
+gem "warning", "~> 1"
+gem "webmock", ">= 3.10.0"
 gem "rails", "~> 5.2.1"
 gem "pg", "< 1.0", platform: :ruby
 gem "redis", "~> 4"

--- a/gemfiles/ruby_2.7_rails5_postgres_redis_activesupport.gemfile
+++ b/gemfiles/ruby_2.7_rails5_postgres_redis_activesupport.gemfile
@@ -6,7 +6,9 @@ gem "benchmark-ips", "~> 2.8"
 gem "benchmark-memory", "< 0.2"
 gem "climate_control", "~> 0.2.0"
 gem "concurrent-ruby"
+gem "dogstatsd-ruby", ">= 3.3.0", "!= 5.0.0", "!= 5.0.1", "!= 5.1.0"
 gem "extlz4", "~> 0.3", ">= 0.3.3"
+gem "google-protobuf", ["~> 3.0", "!= 3.7.0", "!= 3.7.1"]
 gem "json-schema", "< 3"
 gem "memory_profiler", "~> 0.9"
 gem "os", "~> 1.1"
@@ -20,16 +22,14 @@ gem "rspec", "~> 3.13"
 gem "rspec-collection_matchers", "~> 1.1"
 gem "rspec-wait", "~> 0"
 gem "rspec_junit_formatter", ">= 0.5.1"
-gem "simplecov", git: "https://github.com/DataDog/simplecov", ref: "3bb6b7ee58bf4b1954ca205f50dd44d6f41c57db"
-gem "simplecov-cobertura", "~> 2.1.0"
-gem "warning", "~> 1"
-gem "webmock", ">= 3.10.0"
 gem "rubocop", "~> 1.50.0", require: false
 gem "rubocop-packaging", "~> 0.5.2", require: false
 gem "rubocop-performance", "~> 1.9", require: false
 gem "rubocop-rspec", ["~> 2.20", "< 2.21"], require: false
-gem "dogstatsd-ruby", ">= 3.3.0", "!= 5.0.0", "!= 5.0.1", "!= 5.1.0"
-gem "google-protobuf", ["~> 3.0", "!= 3.7.0", "!= 3.7.1"]
+gem "simplecov", git: "https://github.com/DataDog/simplecov", ref: "3bb6b7ee58bf4b1954ca205f50dd44d6f41c57db"
+gem "simplecov-cobertura", "~> 2.1.0"
+gem "warning", "~> 1"
+gem "webmock", ">= 3.10.0"
 gem "rails", "~> 5.2.1"
 gem "pg", "< 1.0", platform: :ruby
 gem "redis", "~> 4"

--- a/gemfiles/ruby_2.7_rails5_postgres_sidekiq.gemfile
+++ b/gemfiles/ruby_2.7_rails5_postgres_sidekiq.gemfile
@@ -6,7 +6,9 @@ gem "benchmark-ips", "~> 2.8"
 gem "benchmark-memory", "< 0.2"
 gem "climate_control", "~> 0.2.0"
 gem "concurrent-ruby"
+gem "dogstatsd-ruby", ">= 3.3.0", "!= 5.0.0", "!= 5.0.1", "!= 5.1.0"
 gem "extlz4", "~> 0.3", ">= 0.3.3"
+gem "google-protobuf", ["~> 3.0", "!= 3.7.0", "!= 3.7.1"]
 gem "json-schema", "< 3"
 gem "memory_profiler", "~> 0.9"
 gem "os", "~> 1.1"
@@ -20,16 +22,14 @@ gem "rspec", "~> 3.13"
 gem "rspec-collection_matchers", "~> 1.1"
 gem "rspec-wait", "~> 0"
 gem "rspec_junit_formatter", ">= 0.5.1"
-gem "simplecov", git: "https://github.com/DataDog/simplecov", ref: "3bb6b7ee58bf4b1954ca205f50dd44d6f41c57db"
-gem "simplecov-cobertura", "~> 2.1.0"
-gem "warning", "~> 1"
-gem "webmock", ">= 3.10.0"
 gem "rubocop", "~> 1.50.0", require: false
 gem "rubocop-packaging", "~> 0.5.2", require: false
 gem "rubocop-performance", "~> 1.9", require: false
 gem "rubocop-rspec", ["~> 2.20", "< 2.21"], require: false
-gem "dogstatsd-ruby", ">= 3.3.0", "!= 5.0.0", "!= 5.0.1", "!= 5.1.0"
-gem "google-protobuf", ["~> 3.0", "!= 3.7.0", "!= 3.7.1"]
+gem "simplecov", git: "https://github.com/DataDog/simplecov", ref: "3bb6b7ee58bf4b1954ca205f50dd44d6f41c57db"
+gem "simplecov-cobertura", "~> 2.1.0"
+gem "warning", "~> 1"
+gem "webmock", ">= 3.10.0"
 gem "rails", "~> 5.2.1"
 gem "pg", "< 1.0", platform: :ruby
 gem "sidekiq", "~> 6"

--- a/gemfiles/ruby_2.7_rails5_semantic_logger.gemfile
+++ b/gemfiles/ruby_2.7_rails5_semantic_logger.gemfile
@@ -6,7 +6,9 @@ gem "benchmark-ips", "~> 2.8"
 gem "benchmark-memory", "< 0.2"
 gem "climate_control", "~> 0.2.0"
 gem "concurrent-ruby"
+gem "dogstatsd-ruby", ">= 3.3.0", "!= 5.0.0", "!= 5.0.1", "!= 5.1.0"
 gem "extlz4", "~> 0.3", ">= 0.3.3"
+gem "google-protobuf", ["~> 3.0", "!= 3.7.0", "!= 3.7.1"]
 gem "json-schema", "< 3"
 gem "memory_profiler", "~> 0.9"
 gem "os", "~> 1.1"
@@ -20,16 +22,14 @@ gem "rspec", "~> 3.13"
 gem "rspec-collection_matchers", "~> 1.1"
 gem "rspec-wait", "~> 0"
 gem "rspec_junit_formatter", ">= 0.5.1"
-gem "simplecov", git: "https://github.com/DataDog/simplecov", ref: "3bb6b7ee58bf4b1954ca205f50dd44d6f41c57db"
-gem "simplecov-cobertura", "~> 2.1.0"
-gem "warning", "~> 1"
-gem "webmock", ">= 3.10.0"
 gem "rubocop", "~> 1.50.0", require: false
 gem "rubocop-packaging", "~> 0.5.2", require: false
 gem "rubocop-performance", "~> 1.9", require: false
 gem "rubocop-rspec", ["~> 2.20", "< 2.21"], require: false
-gem "dogstatsd-ruby", ">= 3.3.0", "!= 5.0.0", "!= 5.0.1", "!= 5.1.0"
-gem "google-protobuf", ["~> 3.0", "!= 3.7.0", "!= 3.7.1"]
+gem "simplecov", git: "https://github.com/DataDog/simplecov", ref: "3bb6b7ee58bf4b1954ca205f50dd44d6f41c57db"
+gem "simplecov-cobertura", "~> 2.1.0"
+gem "warning", "~> 1"
+gem "webmock", ">= 3.10.0"
 gem "rails", "~> 5.2.1"
 gem "pg", "< 1.0", platform: :ruby
 gem "sprockets", "< 4"

--- a/gemfiles/ruby_2.7_rails61_mysql2.gemfile
+++ b/gemfiles/ruby_2.7_rails61_mysql2.gemfile
@@ -6,7 +6,9 @@ gem "benchmark-ips", "~> 2.8"
 gem "benchmark-memory", "< 0.2"
 gem "climate_control", "~> 0.2.0"
 gem "concurrent-ruby"
+gem "dogstatsd-ruby", ">= 3.3.0", "!= 5.0.0", "!= 5.0.1", "!= 5.1.0"
 gem "extlz4", "~> 0.3", ">= 0.3.3"
+gem "google-protobuf", ["~> 3.0", "!= 3.7.0", "!= 3.7.1"]
 gem "json-schema", "< 3"
 gem "memory_profiler", "~> 0.9"
 gem "os", "~> 1.1"
@@ -20,16 +22,14 @@ gem "rspec", "~> 3.13"
 gem "rspec-collection_matchers", "~> 1.1"
 gem "rspec-wait", "~> 0"
 gem "rspec_junit_formatter", ">= 0.5.1"
-gem "simplecov", git: "https://github.com/DataDog/simplecov", ref: "3bb6b7ee58bf4b1954ca205f50dd44d6f41c57db"
-gem "simplecov-cobertura", "~> 2.1.0"
-gem "warning", "~> 1"
-gem "webmock", ">= 3.10.0"
 gem "rubocop", "~> 1.50.0", require: false
 gem "rubocop-packaging", "~> 0.5.2", require: false
 gem "rubocop-performance", "~> 1.9", require: false
 gem "rubocop-rspec", ["~> 2.20", "< 2.21"], require: false
-gem "dogstatsd-ruby", ">= 3.3.0", "!= 5.0.0", "!= 5.0.1", "!= 5.1.0"
-gem "google-protobuf", ["~> 3.0", "!= 3.7.0", "!= 3.7.1"]
+gem "simplecov", git: "https://github.com/DataDog/simplecov", ref: "3bb6b7ee58bf4b1954ca205f50dd44d6f41c57db"
+gem "simplecov-cobertura", "~> 2.1.0"
+gem "warning", "~> 1"
+gem "webmock", ">= 3.10.0"
 gem "rails", "~> 6.1.0"
 gem "mysql2", "~> 0.5", platform: :ruby
 gem "sprockets", "< 4"

--- a/gemfiles/ruby_2.7_rails61_postgres.gemfile
+++ b/gemfiles/ruby_2.7_rails61_postgres.gemfile
@@ -6,7 +6,9 @@ gem "benchmark-ips", "~> 2.8"
 gem "benchmark-memory", "< 0.2"
 gem "climate_control", "~> 0.2.0"
 gem "concurrent-ruby"
+gem "dogstatsd-ruby", ">= 3.3.0", "!= 5.0.0", "!= 5.0.1", "!= 5.1.0"
 gem "extlz4", "~> 0.3", ">= 0.3.3"
+gem "google-protobuf", ["~> 3.0", "!= 3.7.0", "!= 3.7.1"]
 gem "json-schema", "< 3"
 gem "memory_profiler", "~> 0.9"
 gem "os", "~> 1.1"
@@ -20,16 +22,14 @@ gem "rspec", "~> 3.13"
 gem "rspec-collection_matchers", "~> 1.1"
 gem "rspec-wait", "~> 0"
 gem "rspec_junit_formatter", ">= 0.5.1"
-gem "simplecov", git: "https://github.com/DataDog/simplecov", ref: "3bb6b7ee58bf4b1954ca205f50dd44d6f41c57db"
-gem "simplecov-cobertura", "~> 2.1.0"
-gem "warning", "~> 1"
-gem "webmock", ">= 3.10.0"
 gem "rubocop", "~> 1.50.0", require: false
 gem "rubocop-packaging", "~> 0.5.2", require: false
 gem "rubocop-performance", "~> 1.9", require: false
 gem "rubocop-rspec", ["~> 2.20", "< 2.21"], require: false
-gem "dogstatsd-ruby", ">= 3.3.0", "!= 5.0.0", "!= 5.0.1", "!= 5.1.0"
-gem "google-protobuf", ["~> 3.0", "!= 3.7.0", "!= 3.7.1"]
+gem "simplecov", git: "https://github.com/DataDog/simplecov", ref: "3bb6b7ee58bf4b1954ca205f50dd44d6f41c57db"
+gem "simplecov-cobertura", "~> 2.1.0"
+gem "warning", "~> 1"
+gem "webmock", ">= 3.10.0"
 gem "rails", "~> 6.1.0"
 gem "pg", ">= 1.1", platform: :ruby
 gem "sprockets", "< 4"

--- a/gemfiles/ruby_2.7_rails61_postgres_redis.gemfile
+++ b/gemfiles/ruby_2.7_rails61_postgres_redis.gemfile
@@ -6,7 +6,9 @@ gem "benchmark-ips", "~> 2.8"
 gem "benchmark-memory", "< 0.2"
 gem "climate_control", "~> 0.2.0"
 gem "concurrent-ruby"
+gem "dogstatsd-ruby", ">= 3.3.0", "!= 5.0.0", "!= 5.0.1", "!= 5.1.0"
 gem "extlz4", "~> 0.3", ">= 0.3.3"
+gem "google-protobuf", ["~> 3.0", "!= 3.7.0", "!= 3.7.1"]
 gem "json-schema", "< 3"
 gem "memory_profiler", "~> 0.9"
 gem "os", "~> 1.1"
@@ -20,16 +22,14 @@ gem "rspec", "~> 3.13"
 gem "rspec-collection_matchers", "~> 1.1"
 gem "rspec-wait", "~> 0"
 gem "rspec_junit_formatter", ">= 0.5.1"
-gem "simplecov", git: "https://github.com/DataDog/simplecov", ref: "3bb6b7ee58bf4b1954ca205f50dd44d6f41c57db"
-gem "simplecov-cobertura", "~> 2.1.0"
-gem "warning", "~> 1"
-gem "webmock", ">= 3.10.0"
 gem "rubocop", "~> 1.50.0", require: false
 gem "rubocop-packaging", "~> 0.5.2", require: false
 gem "rubocop-performance", "~> 1.9", require: false
 gem "rubocop-rspec", ["~> 2.20", "< 2.21"], require: false
-gem "dogstatsd-ruby", ">= 3.3.0", "!= 5.0.0", "!= 5.0.1", "!= 5.1.0"
-gem "google-protobuf", ["~> 3.0", "!= 3.7.0", "!= 3.7.1"]
+gem "simplecov", git: "https://github.com/DataDog/simplecov", ref: "3bb6b7ee58bf4b1954ca205f50dd44d6f41c57db"
+gem "simplecov-cobertura", "~> 2.1.0"
+gem "warning", "~> 1"
+gem "webmock", ">= 3.10.0"
 gem "rails", "~> 6.1.0"
 gem "pg", ">= 1.1", platform: :ruby
 gem "redis", "~> 4"

--- a/gemfiles/ruby_2.7_rails61_postgres_sidekiq.gemfile
+++ b/gemfiles/ruby_2.7_rails61_postgres_sidekiq.gemfile
@@ -6,7 +6,9 @@ gem "benchmark-ips", "~> 2.8"
 gem "benchmark-memory", "< 0.2"
 gem "climate_control", "~> 0.2.0"
 gem "concurrent-ruby"
+gem "dogstatsd-ruby", ">= 3.3.0", "!= 5.0.0", "!= 5.0.1", "!= 5.1.0"
 gem "extlz4", "~> 0.3", ">= 0.3.3"
+gem "google-protobuf", ["~> 3.0", "!= 3.7.0", "!= 3.7.1"]
 gem "json-schema", "< 3"
 gem "memory_profiler", "~> 0.9"
 gem "os", "~> 1.1"
@@ -20,16 +22,14 @@ gem "rspec", "~> 3.13"
 gem "rspec-collection_matchers", "~> 1.1"
 gem "rspec-wait", "~> 0"
 gem "rspec_junit_formatter", ">= 0.5.1"
-gem "simplecov", git: "https://github.com/DataDog/simplecov", ref: "3bb6b7ee58bf4b1954ca205f50dd44d6f41c57db"
-gem "simplecov-cobertura", "~> 2.1.0"
-gem "warning", "~> 1"
-gem "webmock", ">= 3.10.0"
 gem "rubocop", "~> 1.50.0", require: false
 gem "rubocop-packaging", "~> 0.5.2", require: false
 gem "rubocop-performance", "~> 1.9", require: false
 gem "rubocop-rspec", ["~> 2.20", "< 2.21"], require: false
-gem "dogstatsd-ruby", ">= 3.3.0", "!= 5.0.0", "!= 5.0.1", "!= 5.1.0"
-gem "google-protobuf", ["~> 3.0", "!= 3.7.0", "!= 3.7.1"]
+gem "simplecov", git: "https://github.com/DataDog/simplecov", ref: "3bb6b7ee58bf4b1954ca205f50dd44d6f41c57db"
+gem "simplecov-cobertura", "~> 2.1.0"
+gem "warning", "~> 1"
+gem "webmock", ">= 3.10.0"
 gem "rails", "~> 6.1.0"
 gem "pg", ">= 1.1", platform: :ruby
 gem "sidekiq", ">= 6.1.2"

--- a/gemfiles/ruby_2.7_rails61_semantic_logger.gemfile
+++ b/gemfiles/ruby_2.7_rails61_semantic_logger.gemfile
@@ -6,7 +6,9 @@ gem "benchmark-ips", "~> 2.8"
 gem "benchmark-memory", "< 0.2"
 gem "climate_control", "~> 0.2.0"
 gem "concurrent-ruby"
+gem "dogstatsd-ruby", ">= 3.3.0", "!= 5.0.0", "!= 5.0.1", "!= 5.1.0"
 gem "extlz4", "~> 0.3", ">= 0.3.3"
+gem "google-protobuf", ["~> 3.0", "!= 3.7.0", "!= 3.7.1"]
 gem "json-schema", "< 3"
 gem "memory_profiler", "~> 0.9"
 gem "os", "~> 1.1"
@@ -20,16 +22,14 @@ gem "rspec", "~> 3.13"
 gem "rspec-collection_matchers", "~> 1.1"
 gem "rspec-wait", "~> 0"
 gem "rspec_junit_formatter", ">= 0.5.1"
-gem "simplecov", git: "https://github.com/DataDog/simplecov", ref: "3bb6b7ee58bf4b1954ca205f50dd44d6f41c57db"
-gem "simplecov-cobertura", "~> 2.1.0"
-gem "warning", "~> 1"
-gem "webmock", ">= 3.10.0"
 gem "rubocop", "~> 1.50.0", require: false
 gem "rubocop-packaging", "~> 0.5.2", require: false
 gem "rubocop-performance", "~> 1.9", require: false
 gem "rubocop-rspec", ["~> 2.20", "< 2.21"], require: false
-gem "dogstatsd-ruby", ">= 3.3.0", "!= 5.0.0", "!= 5.0.1", "!= 5.1.0"
-gem "google-protobuf", ["~> 3.0", "!= 3.7.0", "!= 3.7.1"]
+gem "simplecov", git: "https://github.com/DataDog/simplecov", ref: "3bb6b7ee58bf4b1954ca205f50dd44d6f41c57db"
+gem "simplecov-cobertura", "~> 2.1.0"
+gem "warning", "~> 1"
+gem "webmock", ">= 3.10.0"
 gem "rails", "~> 6.1.0"
 gem "pg", ">= 1.1", platform: :ruby
 gem "sprockets", "< 4"

--- a/gemfiles/ruby_2.7_rails6_mysql2.gemfile
+++ b/gemfiles/ruby_2.7_rails6_mysql2.gemfile
@@ -6,7 +6,9 @@ gem "benchmark-ips", "~> 2.8"
 gem "benchmark-memory", "< 0.2"
 gem "climate_control", "~> 0.2.0"
 gem "concurrent-ruby"
+gem "dogstatsd-ruby", ">= 3.3.0", "!= 5.0.0", "!= 5.0.1", "!= 5.1.0"
 gem "extlz4", "~> 0.3", ">= 0.3.3"
+gem "google-protobuf", ["~> 3.0", "!= 3.7.0", "!= 3.7.1"]
 gem "json-schema", "< 3"
 gem "memory_profiler", "~> 0.9"
 gem "os", "~> 1.1"
@@ -20,16 +22,14 @@ gem "rspec", "~> 3.13"
 gem "rspec-collection_matchers", "~> 1.1"
 gem "rspec-wait", "~> 0"
 gem "rspec_junit_formatter", ">= 0.5.1"
-gem "simplecov", git: "https://github.com/DataDog/simplecov", ref: "3bb6b7ee58bf4b1954ca205f50dd44d6f41c57db"
-gem "simplecov-cobertura", "~> 2.1.0"
-gem "warning", "~> 1"
-gem "webmock", ">= 3.10.0"
 gem "rubocop", "~> 1.50.0", require: false
 gem "rubocop-packaging", "~> 0.5.2", require: false
 gem "rubocop-performance", "~> 1.9", require: false
 gem "rubocop-rspec", ["~> 2.20", "< 2.21"], require: false
-gem "dogstatsd-ruby", ">= 3.3.0", "!= 5.0.0", "!= 5.0.1", "!= 5.1.0"
-gem "google-protobuf", ["~> 3.0", "!= 3.7.0", "!= 3.7.1"]
+gem "simplecov", git: "https://github.com/DataDog/simplecov", ref: "3bb6b7ee58bf4b1954ca205f50dd44d6f41c57db"
+gem "simplecov-cobertura", "~> 2.1.0"
+gem "warning", "~> 1"
+gem "webmock", ">= 3.10.0"
 gem "rails", "~> 6.0.0"
 gem "mysql2", "< 1", platform: :ruby
 gem "sprockets", "< 4"

--- a/gemfiles/ruby_2.7_rails6_postgres.gemfile
+++ b/gemfiles/ruby_2.7_rails6_postgres.gemfile
@@ -6,7 +6,9 @@ gem "benchmark-ips", "~> 2.8"
 gem "benchmark-memory", "< 0.2"
 gem "climate_control", "~> 0.2.0"
 gem "concurrent-ruby"
+gem "dogstatsd-ruby", ">= 3.3.0", "!= 5.0.0", "!= 5.0.1", "!= 5.1.0"
 gem "extlz4", "~> 0.3", ">= 0.3.3"
+gem "google-protobuf", ["~> 3.0", "!= 3.7.0", "!= 3.7.1"]
 gem "json-schema", "< 3"
 gem "memory_profiler", "~> 0.9"
 gem "os", "~> 1.1"
@@ -20,16 +22,14 @@ gem "rspec", "~> 3.13"
 gem "rspec-collection_matchers", "~> 1.1"
 gem "rspec-wait", "~> 0"
 gem "rspec_junit_formatter", ">= 0.5.1"
-gem "simplecov", git: "https://github.com/DataDog/simplecov", ref: "3bb6b7ee58bf4b1954ca205f50dd44d6f41c57db"
-gem "simplecov-cobertura", "~> 2.1.0"
-gem "warning", "~> 1"
-gem "webmock", ">= 3.10.0"
 gem "rubocop", "~> 1.50.0", require: false
 gem "rubocop-packaging", "~> 0.5.2", require: false
 gem "rubocop-performance", "~> 1.9", require: false
 gem "rubocop-rspec", ["~> 2.20", "< 2.21"], require: false
-gem "dogstatsd-ruby", ">= 3.3.0", "!= 5.0.0", "!= 5.0.1", "!= 5.1.0"
-gem "google-protobuf", ["~> 3.0", "!= 3.7.0", "!= 3.7.1"]
+gem "simplecov", git: "https://github.com/DataDog/simplecov", ref: "3bb6b7ee58bf4b1954ca205f50dd44d6f41c57db"
+gem "simplecov-cobertura", "~> 2.1.0"
+gem "warning", "~> 1"
+gem "webmock", ">= 3.10.0"
 gem "rails", "~> 6.0.0"
 gem "pg", "< 1.0", platform: :ruby
 gem "sprockets", "< 4"

--- a/gemfiles/ruby_2.7_rails6_postgres_redis.gemfile
+++ b/gemfiles/ruby_2.7_rails6_postgres_redis.gemfile
@@ -6,7 +6,9 @@ gem "benchmark-ips", "~> 2.8"
 gem "benchmark-memory", "< 0.2"
 gem "climate_control", "~> 0.2.0"
 gem "concurrent-ruby"
+gem "dogstatsd-ruby", ">= 3.3.0", "!= 5.0.0", "!= 5.0.1", "!= 5.1.0"
 gem "extlz4", "~> 0.3", ">= 0.3.3"
+gem "google-protobuf", ["~> 3.0", "!= 3.7.0", "!= 3.7.1"]
 gem "json-schema", "< 3"
 gem "memory_profiler", "~> 0.9"
 gem "os", "~> 1.1"
@@ -20,16 +22,14 @@ gem "rspec", "~> 3.13"
 gem "rspec-collection_matchers", "~> 1.1"
 gem "rspec-wait", "~> 0"
 gem "rspec_junit_formatter", ">= 0.5.1"
-gem "simplecov", git: "https://github.com/DataDog/simplecov", ref: "3bb6b7ee58bf4b1954ca205f50dd44d6f41c57db"
-gem "simplecov-cobertura", "~> 2.1.0"
-gem "warning", "~> 1"
-gem "webmock", ">= 3.10.0"
 gem "rubocop", "~> 1.50.0", require: false
 gem "rubocop-packaging", "~> 0.5.2", require: false
 gem "rubocop-performance", "~> 1.9", require: false
 gem "rubocop-rspec", ["~> 2.20", "< 2.21"], require: false
-gem "dogstatsd-ruby", ">= 3.3.0", "!= 5.0.0", "!= 5.0.1", "!= 5.1.0"
-gem "google-protobuf", ["~> 3.0", "!= 3.7.0", "!= 3.7.1"]
+gem "simplecov", git: "https://github.com/DataDog/simplecov", ref: "3bb6b7ee58bf4b1954ca205f50dd44d6f41c57db"
+gem "simplecov-cobertura", "~> 2.1.0"
+gem "warning", "~> 1"
+gem "webmock", ">= 3.10.0"
 gem "rails", "~> 6.0.0"
 gem "pg", "< 1.0", platform: :ruby
 gem "redis", "~> 4"

--- a/gemfiles/ruby_2.7_rails6_postgres_redis_activesupport.gemfile
+++ b/gemfiles/ruby_2.7_rails6_postgres_redis_activesupport.gemfile
@@ -6,7 +6,9 @@ gem "benchmark-ips", "~> 2.8"
 gem "benchmark-memory", "< 0.2"
 gem "climate_control", "~> 0.2.0"
 gem "concurrent-ruby"
+gem "dogstatsd-ruby", ">= 3.3.0", "!= 5.0.0", "!= 5.0.1", "!= 5.1.0"
 gem "extlz4", "~> 0.3", ">= 0.3.3"
+gem "google-protobuf", ["~> 3.0", "!= 3.7.0", "!= 3.7.1"]
 gem "json-schema", "< 3"
 gem "memory_profiler", "~> 0.9"
 gem "os", "~> 1.1"
@@ -20,16 +22,14 @@ gem "rspec", "~> 3.13"
 gem "rspec-collection_matchers", "~> 1.1"
 gem "rspec-wait", "~> 0"
 gem "rspec_junit_formatter", ">= 0.5.1"
-gem "simplecov", git: "https://github.com/DataDog/simplecov", ref: "3bb6b7ee58bf4b1954ca205f50dd44d6f41c57db"
-gem "simplecov-cobertura", "~> 2.1.0"
-gem "warning", "~> 1"
-gem "webmock", ">= 3.10.0"
 gem "rubocop", "~> 1.50.0", require: false
 gem "rubocop-packaging", "~> 0.5.2", require: false
 gem "rubocop-performance", "~> 1.9", require: false
 gem "rubocop-rspec", ["~> 2.20", "< 2.21"], require: false
-gem "dogstatsd-ruby", ">= 3.3.0", "!= 5.0.0", "!= 5.0.1", "!= 5.1.0"
-gem "google-protobuf", ["~> 3.0", "!= 3.7.0", "!= 3.7.1"]
+gem "simplecov", git: "https://github.com/DataDog/simplecov", ref: "3bb6b7ee58bf4b1954ca205f50dd44d6f41c57db"
+gem "simplecov-cobertura", "~> 2.1.0"
+gem "warning", "~> 1"
+gem "webmock", ">= 3.10.0"
 gem "rails", "~> 6.0.0"
 gem "pg", "< 1.0", platform: :ruby
 gem "redis", "~> 4"

--- a/gemfiles/ruby_2.7_rails6_postgres_sidekiq.gemfile
+++ b/gemfiles/ruby_2.7_rails6_postgres_sidekiq.gemfile
@@ -6,7 +6,9 @@ gem "benchmark-ips", "~> 2.8"
 gem "benchmark-memory", "< 0.2"
 gem "climate_control", "~> 0.2.0"
 gem "concurrent-ruby"
+gem "dogstatsd-ruby", ">= 3.3.0", "!= 5.0.0", "!= 5.0.1", "!= 5.1.0"
 gem "extlz4", "~> 0.3", ">= 0.3.3"
+gem "google-protobuf", ["~> 3.0", "!= 3.7.0", "!= 3.7.1"]
 gem "json-schema", "< 3"
 gem "memory_profiler", "~> 0.9"
 gem "os", "~> 1.1"
@@ -20,16 +22,14 @@ gem "rspec", "~> 3.13"
 gem "rspec-collection_matchers", "~> 1.1"
 gem "rspec-wait", "~> 0"
 gem "rspec_junit_formatter", ">= 0.5.1"
-gem "simplecov", git: "https://github.com/DataDog/simplecov", ref: "3bb6b7ee58bf4b1954ca205f50dd44d6f41c57db"
-gem "simplecov-cobertura", "~> 2.1.0"
-gem "warning", "~> 1"
-gem "webmock", ">= 3.10.0"
 gem "rubocop", "~> 1.50.0", require: false
 gem "rubocop-packaging", "~> 0.5.2", require: false
 gem "rubocop-performance", "~> 1.9", require: false
 gem "rubocop-rspec", ["~> 2.20", "< 2.21"], require: false
-gem "dogstatsd-ruby", ">= 3.3.0", "!= 5.0.0", "!= 5.0.1", "!= 5.1.0"
-gem "google-protobuf", ["~> 3.0", "!= 3.7.0", "!= 3.7.1"]
+gem "simplecov", git: "https://github.com/DataDog/simplecov", ref: "3bb6b7ee58bf4b1954ca205f50dd44d6f41c57db"
+gem "simplecov-cobertura", "~> 2.1.0"
+gem "warning", "~> 1"
+gem "webmock", ">= 3.10.0"
 gem "rails", "~> 6.0.0"
 gem "pg", "< 1.0", platform: :ruby
 gem "sidekiq", "~> 6"

--- a/gemfiles/ruby_2.7_rails6_semantic_logger.gemfile
+++ b/gemfiles/ruby_2.7_rails6_semantic_logger.gemfile
@@ -6,7 +6,9 @@ gem "benchmark-ips", "~> 2.8"
 gem "benchmark-memory", "< 0.2"
 gem "climate_control", "~> 0.2.0"
 gem "concurrent-ruby"
+gem "dogstatsd-ruby", ">= 3.3.0", "!= 5.0.0", "!= 5.0.1", "!= 5.1.0"
 gem "extlz4", "~> 0.3", ">= 0.3.3"
+gem "google-protobuf", ["~> 3.0", "!= 3.7.0", "!= 3.7.1"]
 gem "json-schema", "< 3"
 gem "memory_profiler", "~> 0.9"
 gem "os", "~> 1.1"
@@ -20,16 +22,14 @@ gem "rspec", "~> 3.13"
 gem "rspec-collection_matchers", "~> 1.1"
 gem "rspec-wait", "~> 0"
 gem "rspec_junit_formatter", ">= 0.5.1"
-gem "simplecov", git: "https://github.com/DataDog/simplecov", ref: "3bb6b7ee58bf4b1954ca205f50dd44d6f41c57db"
-gem "simplecov-cobertura", "~> 2.1.0"
-gem "warning", "~> 1"
-gem "webmock", ">= 3.10.0"
 gem "rubocop", "~> 1.50.0", require: false
 gem "rubocop-packaging", "~> 0.5.2", require: false
 gem "rubocop-performance", "~> 1.9", require: false
 gem "rubocop-rspec", ["~> 2.20", "< 2.21"], require: false
-gem "dogstatsd-ruby", ">= 3.3.0", "!= 5.0.0", "!= 5.0.1", "!= 5.1.0"
-gem "google-protobuf", ["~> 3.0", "!= 3.7.0", "!= 3.7.1"]
+gem "simplecov", git: "https://github.com/DataDog/simplecov", ref: "3bb6b7ee58bf4b1954ca205f50dd44d6f41c57db"
+gem "simplecov-cobertura", "~> 2.1.0"
+gem "warning", "~> 1"
+gem "webmock", ">= 3.10.0"
 gem "rails", "~> 6.0.0"
 gem "pg", "< 1.0", platform: :ruby
 gem "sprockets", "< 4"

--- a/gemfiles/ruby_2.7_rails_old_redis.gemfile
+++ b/gemfiles/ruby_2.7_rails_old_redis.gemfile
@@ -6,7 +6,9 @@ gem "benchmark-ips", "~> 2.8"
 gem "benchmark-memory", "< 0.2"
 gem "climate_control", "~> 0.2.0"
 gem "concurrent-ruby"
+gem "dogstatsd-ruby", ">= 3.3.0", "!= 5.0.0", "!= 5.0.1", "!= 5.1.0"
 gem "extlz4", "~> 0.3", ">= 0.3.3"
+gem "google-protobuf", ["~> 3.0", "!= 3.7.0", "!= 3.7.1"]
 gem "json-schema", "< 3"
 gem "memory_profiler", "~> 0.9"
 gem "os", "~> 1.1"
@@ -20,16 +22,14 @@ gem "rspec", "~> 3.13"
 gem "rspec-collection_matchers", "~> 1.1"
 gem "rspec-wait", "~> 0"
 gem "rspec_junit_formatter", ">= 0.5.1"
-gem "simplecov", git: "https://github.com/DataDog/simplecov", ref: "3bb6b7ee58bf4b1954ca205f50dd44d6f41c57db"
-gem "simplecov-cobertura", "~> 2.1.0"
-gem "warning", "~> 1"
-gem "webmock", ">= 3.10.0"
 gem "rubocop", "~> 1.50.0", require: false
 gem "rubocop-packaging", "~> 0.5.2", require: false
 gem "rubocop-performance", "~> 1.9", require: false
 gem "rubocop-rspec", ["~> 2.20", "< 2.21"], require: false
-gem "dogstatsd-ruby", ">= 3.3.0", "!= 5.0.0", "!= 5.0.1", "!= 5.1.0"
-gem "google-protobuf", ["~> 3.0", "!= 3.7.0", "!= 3.7.1"]
+gem "simplecov", git: "https://github.com/DataDog/simplecov", ref: "3bb6b7ee58bf4b1954ca205f50dd44d6f41c57db"
+gem "simplecov-cobertura", "~> 2.1.0"
+gem "warning", "~> 1"
+gem "webmock", ">= 3.10.0"
 gem "redis", "< 4"
 gem "rails", "~> 6.1.0"
 gem "pg", ">= 1.1", platform: :ruby

--- a/gemfiles/ruby_2.7_redis_3.gemfile
+++ b/gemfiles/ruby_2.7_redis_3.gemfile
@@ -6,7 +6,9 @@ gem "benchmark-ips", "~> 2.8"
 gem "benchmark-memory", "< 0.2"
 gem "climate_control", "~> 0.2.0"
 gem "concurrent-ruby"
+gem "dogstatsd-ruby", ">= 3.3.0", "!= 5.0.0", "!= 5.0.1", "!= 5.1.0"
 gem "extlz4", "~> 0.3", ">= 0.3.3"
+gem "google-protobuf", ["~> 3.0", "!= 3.7.0", "!= 3.7.1"]
 gem "json-schema", "< 3"
 gem "memory_profiler", "~> 0.9"
 gem "os", "~> 1.1"
@@ -20,16 +22,14 @@ gem "rspec", "~> 3.13"
 gem "rspec-collection_matchers", "~> 1.1"
 gem "rspec-wait", "~> 0"
 gem "rspec_junit_formatter", ">= 0.5.1"
-gem "simplecov", git: "https://github.com/DataDog/simplecov", ref: "3bb6b7ee58bf4b1954ca205f50dd44d6f41c57db"
-gem "simplecov-cobertura", "~> 2.1.0"
-gem "warning", "~> 1"
-gem "webmock", ">= 3.10.0"
 gem "rubocop", "~> 1.50.0", require: false
 gem "rubocop-packaging", "~> 0.5.2", require: false
 gem "rubocop-performance", "~> 1.9", require: false
 gem "rubocop-rspec", ["~> 2.20", "< 2.21"], require: false
-gem "dogstatsd-ruby", ">= 3.3.0", "!= 5.0.0", "!= 5.0.1", "!= 5.1.0"
-gem "google-protobuf", ["~> 3.0", "!= 3.7.0", "!= 3.7.1"]
+gem "simplecov", git: "https://github.com/DataDog/simplecov", ref: "3bb6b7ee58bf4b1954ca205f50dd44d6f41c57db"
+gem "simplecov-cobertura", "~> 2.1.0"
+gem "warning", "~> 1"
+gem "webmock", ">= 3.10.0"
 gem "redis", "~> 3"
 
 group :check do

--- a/gemfiles/ruby_2.7_redis_4.gemfile
+++ b/gemfiles/ruby_2.7_redis_4.gemfile
@@ -6,7 +6,9 @@ gem "benchmark-ips", "~> 2.8"
 gem "benchmark-memory", "< 0.2"
 gem "climate_control", "~> 0.2.0"
 gem "concurrent-ruby"
+gem "dogstatsd-ruby", ">= 3.3.0", "!= 5.0.0", "!= 5.0.1", "!= 5.1.0"
 gem "extlz4", "~> 0.3", ">= 0.3.3"
+gem "google-protobuf", ["~> 3.0", "!= 3.7.0", "!= 3.7.1"]
 gem "json-schema", "< 3"
 gem "memory_profiler", "~> 0.9"
 gem "os", "~> 1.1"
@@ -20,16 +22,14 @@ gem "rspec", "~> 3.13"
 gem "rspec-collection_matchers", "~> 1.1"
 gem "rspec-wait", "~> 0"
 gem "rspec_junit_formatter", ">= 0.5.1"
-gem "simplecov", git: "https://github.com/DataDog/simplecov", ref: "3bb6b7ee58bf4b1954ca205f50dd44d6f41c57db"
-gem "simplecov-cobertura", "~> 2.1.0"
-gem "warning", "~> 1"
-gem "webmock", ">= 3.10.0"
 gem "rubocop", "~> 1.50.0", require: false
 gem "rubocop-packaging", "~> 0.5.2", require: false
 gem "rubocop-performance", "~> 1.9", require: false
 gem "rubocop-rspec", ["~> 2.20", "< 2.21"], require: false
-gem "dogstatsd-ruby", ">= 3.3.0", "!= 5.0.0", "!= 5.0.1", "!= 5.1.0"
-gem "google-protobuf", ["~> 3.0", "!= 3.7.0", "!= 3.7.1"]
+gem "simplecov", git: "https://github.com/DataDog/simplecov", ref: "3bb6b7ee58bf4b1954ca205f50dd44d6f41c57db"
+gem "simplecov-cobertura", "~> 2.1.0"
+gem "warning", "~> 1"
+gem "webmock", ">= 3.10.0"
 gem "redis", "~> 4"
 
 group :check do

--- a/gemfiles/ruby_2.7_redis_5.gemfile
+++ b/gemfiles/ruby_2.7_redis_5.gemfile
@@ -6,7 +6,9 @@ gem "benchmark-ips", "~> 2.8"
 gem "benchmark-memory", "< 0.2"
 gem "climate_control", "~> 0.2.0"
 gem "concurrent-ruby"
+gem "dogstatsd-ruby", ">= 3.3.0", "!= 5.0.0", "!= 5.0.1", "!= 5.1.0"
 gem "extlz4", "~> 0.3", ">= 0.3.3"
+gem "google-protobuf", ["~> 3.0", "!= 3.7.0", "!= 3.7.1"]
 gem "json-schema", "< 3"
 gem "memory_profiler", "~> 0.9"
 gem "os", "~> 1.1"
@@ -20,16 +22,14 @@ gem "rspec", "~> 3.13"
 gem "rspec-collection_matchers", "~> 1.1"
 gem "rspec-wait", "~> 0"
 gem "rspec_junit_formatter", ">= 0.5.1"
-gem "simplecov", git: "https://github.com/DataDog/simplecov", ref: "3bb6b7ee58bf4b1954ca205f50dd44d6f41c57db"
-gem "simplecov-cobertura", "~> 2.1.0"
-gem "warning", "~> 1"
-gem "webmock", ">= 3.10.0"
 gem "rubocop", "~> 1.50.0", require: false
 gem "rubocop-packaging", "~> 0.5.2", require: false
 gem "rubocop-performance", "~> 1.9", require: false
 gem "rubocop-rspec", ["~> 2.20", "< 2.21"], require: false
-gem "dogstatsd-ruby", ">= 3.3.0", "!= 5.0.0", "!= 5.0.1", "!= 5.1.0"
-gem "google-protobuf", ["~> 3.0", "!= 3.7.0", "!= 3.7.1"]
+gem "simplecov", git: "https://github.com/DataDog/simplecov", ref: "3bb6b7ee58bf4b1954ca205f50dd44d6f41c57db"
+gem "simplecov-cobertura", "~> 2.1.0"
+gem "warning", "~> 1"
+gem "webmock", ">= 3.10.0"
 gem "redis", "~> 5"
 
 group :check do

--- a/gemfiles/ruby_2.7_relational_db.gemfile
+++ b/gemfiles/ruby_2.7_relational_db.gemfile
@@ -6,7 +6,9 @@ gem "benchmark-ips", "~> 2.8"
 gem "benchmark-memory", "< 0.2"
 gem "climate_control", "~> 0.2.0"
 gem "concurrent-ruby"
+gem "dogstatsd-ruby", ">= 3.3.0", "!= 5.0.0", "!= 5.0.1", "!= 5.1.0"
 gem "extlz4", "~> 0.3", ">= 0.3.3"
+gem "google-protobuf", ["~> 3.0", "!= 3.7.0", "!= 3.7.1"]
 gem "json-schema", "< 3"
 gem "memory_profiler", "~> 0.9"
 gem "os", "~> 1.1"
@@ -20,16 +22,14 @@ gem "rspec", "~> 3.13"
 gem "rspec-collection_matchers", "~> 1.1"
 gem "rspec-wait", "~> 0"
 gem "rspec_junit_formatter", ">= 0.5.1"
-gem "simplecov", git: "https://github.com/DataDog/simplecov", ref: "3bb6b7ee58bf4b1954ca205f50dd44d6f41c57db"
-gem "simplecov-cobertura", "~> 2.1.0"
-gem "warning", "~> 1"
-gem "webmock", ">= 3.10.0"
 gem "rubocop", "~> 1.50.0", require: false
 gem "rubocop-packaging", "~> 0.5.2", require: false
 gem "rubocop-performance", "~> 1.9", require: false
 gem "rubocop-rspec", ["~> 2.20", "< 2.21"], require: false
-gem "dogstatsd-ruby", ">= 3.3.0", "!= 5.0.0", "!= 5.0.1", "!= 5.1.0"
-gem "google-protobuf", ["~> 3.0", "!= 3.7.0", "!= 3.7.1"]
+gem "simplecov", git: "https://github.com/DataDog/simplecov", ref: "3bb6b7ee58bf4b1954ca205f50dd44d6f41c57db"
+gem "simplecov-cobertura", "~> 2.1.0"
+gem "warning", "~> 1"
+gem "webmock", ">= 3.10.0"
 gem "activerecord", "~> 6.1.0"
 gem "delayed_job"
 gem "delayed_job_active_record"

--- a/gemfiles/ruby_2.7_resque2_redis3.gemfile
+++ b/gemfiles/ruby_2.7_resque2_redis3.gemfile
@@ -6,7 +6,9 @@ gem "benchmark-ips", "~> 2.8"
 gem "benchmark-memory", "< 0.2"
 gem "climate_control", "~> 0.2.0"
 gem "concurrent-ruby"
+gem "dogstatsd-ruby", ">= 3.3.0", "!= 5.0.0", "!= 5.0.1", "!= 5.1.0"
 gem "extlz4", "~> 0.3", ">= 0.3.3"
+gem "google-protobuf", ["~> 3.0", "!= 3.7.0", "!= 3.7.1"]
 gem "json-schema", "< 3"
 gem "memory_profiler", "~> 0.9"
 gem "os", "~> 1.1"
@@ -20,16 +22,14 @@ gem "rspec", "~> 3.13"
 gem "rspec-collection_matchers", "~> 1.1"
 gem "rspec-wait", "~> 0"
 gem "rspec_junit_formatter", ">= 0.5.1"
-gem "simplecov", git: "https://github.com/DataDog/simplecov", ref: "3bb6b7ee58bf4b1954ca205f50dd44d6f41c57db"
-gem "simplecov-cobertura", "~> 2.1.0"
-gem "warning", "~> 1"
-gem "webmock", ">= 3.10.0"
 gem "rubocop", "~> 1.50.0", require: false
 gem "rubocop-packaging", "~> 0.5.2", require: false
 gem "rubocop-performance", "~> 1.9", require: false
 gem "rubocop-rspec", ["~> 2.20", "< 2.21"], require: false
-gem "dogstatsd-ruby", ">= 3.3.0", "!= 5.0.0", "!= 5.0.1", "!= 5.1.0"
-gem "google-protobuf", ["~> 3.0", "!= 3.7.0", "!= 3.7.1"]
+gem "simplecov", git: "https://github.com/DataDog/simplecov", ref: "3bb6b7ee58bf4b1954ca205f50dd44d6f41c57db"
+gem "simplecov-cobertura", "~> 2.1.0"
+gem "warning", "~> 1"
+gem "webmock", ">= 3.10.0"
 gem "redis", "< 4.0"
 gem "resque", ">= 2.0"
 

--- a/gemfiles/ruby_2.7_resque2_redis4.gemfile
+++ b/gemfiles/ruby_2.7_resque2_redis4.gemfile
@@ -6,7 +6,9 @@ gem "benchmark-ips", "~> 2.8"
 gem "benchmark-memory", "< 0.2"
 gem "climate_control", "~> 0.2.0"
 gem "concurrent-ruby"
+gem "dogstatsd-ruby", ">= 3.3.0", "!= 5.0.0", "!= 5.0.1", "!= 5.1.0"
 gem "extlz4", "~> 0.3", ">= 0.3.3"
+gem "google-protobuf", ["~> 3.0", "!= 3.7.0", "!= 3.7.1"]
 gem "json-schema", "< 3"
 gem "memory_profiler", "~> 0.9"
 gem "os", "~> 1.1"
@@ -20,16 +22,14 @@ gem "rspec", "~> 3.13"
 gem "rspec-collection_matchers", "~> 1.1"
 gem "rspec-wait", "~> 0"
 gem "rspec_junit_formatter", ">= 0.5.1"
-gem "simplecov", git: "https://github.com/DataDog/simplecov", ref: "3bb6b7ee58bf4b1954ca205f50dd44d6f41c57db"
-gem "simplecov-cobertura", "~> 2.1.0"
-gem "warning", "~> 1"
-gem "webmock", ">= 3.10.0"
 gem "rubocop", "~> 1.50.0", require: false
 gem "rubocop-packaging", "~> 0.5.2", require: false
 gem "rubocop-performance", "~> 1.9", require: false
 gem "rubocop-rspec", ["~> 2.20", "< 2.21"], require: false
-gem "dogstatsd-ruby", ">= 3.3.0", "!= 5.0.0", "!= 5.0.1", "!= 5.1.0"
-gem "google-protobuf", ["~> 3.0", "!= 3.7.0", "!= 3.7.1"]
+gem "simplecov", git: "https://github.com/DataDog/simplecov", ref: "3bb6b7ee58bf4b1954ca205f50dd44d6f41c57db"
+gem "simplecov-cobertura", "~> 2.1.0"
+gem "warning", "~> 1"
+gem "webmock", ">= 3.10.0"
 gem "redis", "~> 4.0"
 gem "resque", ">= 2.0"
 

--- a/gemfiles/ruby_2.7_sinatra_2.gemfile
+++ b/gemfiles/ruby_2.7_sinatra_2.gemfile
@@ -6,7 +6,9 @@ gem "benchmark-ips", "~> 2.8"
 gem "benchmark-memory", "< 0.2"
 gem "climate_control", "~> 0.2.0"
 gem "concurrent-ruby"
+gem "dogstatsd-ruby", ">= 3.3.0", "!= 5.0.0", "!= 5.0.1", "!= 5.1.0"
 gem "extlz4", "~> 0.3", ">= 0.3.3"
+gem "google-protobuf", ["~> 3.0", "!= 3.7.0", "!= 3.7.1"]
 gem "json-schema", "< 3"
 gem "memory_profiler", "~> 0.9"
 gem "os", "~> 1.1"
@@ -20,16 +22,14 @@ gem "rspec", "~> 3.13"
 gem "rspec-collection_matchers", "~> 1.1"
 gem "rspec-wait", "~> 0"
 gem "rspec_junit_formatter", ">= 0.5.1"
-gem "simplecov", git: "https://github.com/DataDog/simplecov", ref: "3bb6b7ee58bf4b1954ca205f50dd44d6f41c57db"
-gem "simplecov-cobertura", "~> 2.1.0"
-gem "warning", "~> 1"
-gem "webmock", ">= 3.10.0"
 gem "rubocop", "~> 1.50.0", require: false
 gem "rubocop-packaging", "~> 0.5.2", require: false
 gem "rubocop-performance", "~> 1.9", require: false
 gem "rubocop-rspec", ["~> 2.20", "< 2.21"], require: false
-gem "dogstatsd-ruby", ">= 3.3.0", "!= 5.0.0", "!= 5.0.1", "!= 5.1.0"
-gem "google-protobuf", ["~> 3.0", "!= 3.7.0", "!= 3.7.1"]
+gem "simplecov", git: "https://github.com/DataDog/simplecov", ref: "3bb6b7ee58bf4b1954ca205f50dd44d6f41c57db"
+gem "simplecov-cobertura", "~> 2.1.0"
+gem "warning", "~> 1"
+gem "webmock", ">= 3.10.0"
 gem "sinatra", "~> 2"
 gem "rack-contrib"
 gem "rack-test"

--- a/gemfiles/ruby_2.7_sinatra_3.gemfile
+++ b/gemfiles/ruby_2.7_sinatra_3.gemfile
@@ -6,7 +6,9 @@ gem "benchmark-ips", "~> 2.8"
 gem "benchmark-memory", "< 0.2"
 gem "climate_control", "~> 0.2.0"
 gem "concurrent-ruby"
+gem "dogstatsd-ruby", ">= 3.3.0", "!= 5.0.0", "!= 5.0.1", "!= 5.1.0"
 gem "extlz4", "~> 0.3", ">= 0.3.3"
+gem "google-protobuf", ["~> 3.0", "!= 3.7.0", "!= 3.7.1"]
 gem "json-schema", "< 3"
 gem "memory_profiler", "~> 0.9"
 gem "os", "~> 1.1"
@@ -20,16 +22,14 @@ gem "rspec", "~> 3.13"
 gem "rspec-collection_matchers", "~> 1.1"
 gem "rspec-wait", "~> 0"
 gem "rspec_junit_formatter", ">= 0.5.1"
-gem "simplecov", git: "https://github.com/DataDog/simplecov", ref: "3bb6b7ee58bf4b1954ca205f50dd44d6f41c57db"
-gem "simplecov-cobertura", "~> 2.1.0"
-gem "warning", "~> 1"
-gem "webmock", ">= 3.10.0"
 gem "rubocop", "~> 1.50.0", require: false
 gem "rubocop-packaging", "~> 0.5.2", require: false
 gem "rubocop-performance", "~> 1.9", require: false
 gem "rubocop-rspec", ["~> 2.20", "< 2.21"], require: false
-gem "dogstatsd-ruby", ">= 3.3.0", "!= 5.0.0", "!= 5.0.1", "!= 5.1.0"
-gem "google-protobuf", ["~> 3.0", "!= 3.7.0", "!= 3.7.1"]
+gem "simplecov", git: "https://github.com/DataDog/simplecov", ref: "3bb6b7ee58bf4b1954ca205f50dd44d6f41c57db"
+gem "simplecov-cobertura", "~> 2.1.0"
+gem "warning", "~> 1"
+gem "webmock", ">= 3.10.0"
 gem "sinatra", "~> 3"
 gem "rack-contrib"
 gem "rack-test"

--- a/gemfiles/ruby_2.7_stripe_10.gemfile
+++ b/gemfiles/ruby_2.7_stripe_10.gemfile
@@ -6,7 +6,9 @@ gem "benchmark-ips", "~> 2.8"
 gem "benchmark-memory", "< 0.2"
 gem "climate_control", "~> 0.2.0"
 gem "concurrent-ruby"
+gem "dogstatsd-ruby", ">= 3.3.0", "!= 5.0.0", "!= 5.0.1", "!= 5.1.0"
 gem "extlz4", "~> 0.3", ">= 0.3.3"
+gem "google-protobuf", ["~> 3.0", "!= 3.7.0", "!= 3.7.1"]
 gem "json-schema", "< 3"
 gem "memory_profiler", "~> 0.9"
 gem "os", "~> 1.1"
@@ -20,16 +22,14 @@ gem "rspec", "~> 3.13"
 gem "rspec-collection_matchers", "~> 1.1"
 gem "rspec-wait", "~> 0"
 gem "rspec_junit_formatter", ">= 0.5.1"
-gem "simplecov", git: "https://github.com/DataDog/simplecov", ref: "3bb6b7ee58bf4b1954ca205f50dd44d6f41c57db"
-gem "simplecov-cobertura", "~> 2.1.0"
-gem "warning", "~> 1"
-gem "webmock", ">= 3.10.0"
 gem "rubocop", "~> 1.50.0", require: false
 gem "rubocop-packaging", "~> 0.5.2", require: false
 gem "rubocop-performance", "~> 1.9", require: false
 gem "rubocop-rspec", ["~> 2.20", "< 2.21"], require: false
-gem "dogstatsd-ruby", ">= 3.3.0", "!= 5.0.0", "!= 5.0.1", "!= 5.1.0"
-gem "google-protobuf", ["~> 3.0", "!= 3.7.0", "!= 3.7.1"]
+gem "simplecov", git: "https://github.com/DataDog/simplecov", ref: "3bb6b7ee58bf4b1954ca205f50dd44d6f41c57db"
+gem "simplecov-cobertura", "~> 2.1.0"
+gem "warning", "~> 1"
+gem "webmock", ">= 3.10.0"
 gem "stripe", "~> 10"
 
 group :check do

--- a/gemfiles/ruby_2.7_stripe_11.gemfile
+++ b/gemfiles/ruby_2.7_stripe_11.gemfile
@@ -6,7 +6,9 @@ gem "benchmark-ips", "~> 2.8"
 gem "benchmark-memory", "< 0.2"
 gem "climate_control", "~> 0.2.0"
 gem "concurrent-ruby"
+gem "dogstatsd-ruby", ">= 3.3.0", "!= 5.0.0", "!= 5.0.1", "!= 5.1.0"
 gem "extlz4", "~> 0.3", ">= 0.3.3"
+gem "google-protobuf", ["~> 3.0", "!= 3.7.0", "!= 3.7.1"]
 gem "json-schema", "< 3"
 gem "memory_profiler", "~> 0.9"
 gem "os", "~> 1.1"
@@ -20,16 +22,14 @@ gem "rspec", "~> 3.13"
 gem "rspec-collection_matchers", "~> 1.1"
 gem "rspec-wait", "~> 0"
 gem "rspec_junit_formatter", ">= 0.5.1"
-gem "simplecov", git: "https://github.com/DataDog/simplecov", ref: "3bb6b7ee58bf4b1954ca205f50dd44d6f41c57db"
-gem "simplecov-cobertura", "~> 2.1.0"
-gem "warning", "~> 1"
-gem "webmock", ">= 3.10.0"
 gem "rubocop", "~> 1.50.0", require: false
 gem "rubocop-packaging", "~> 0.5.2", require: false
 gem "rubocop-performance", "~> 1.9", require: false
 gem "rubocop-rspec", ["~> 2.20", "< 2.21"], require: false
-gem "dogstatsd-ruby", ">= 3.3.0", "!= 5.0.0", "!= 5.0.1", "!= 5.1.0"
-gem "google-protobuf", ["~> 3.0", "!= 3.7.0", "!= 3.7.1"]
+gem "simplecov", git: "https://github.com/DataDog/simplecov", ref: "3bb6b7ee58bf4b1954ca205f50dd44d6f41c57db"
+gem "simplecov-cobertura", "~> 2.1.0"
+gem "warning", "~> 1"
+gem "webmock", ">= 3.10.0"
 gem "stripe", "~> 11"
 
 group :check do

--- a/gemfiles/ruby_2.7_stripe_12.gemfile
+++ b/gemfiles/ruby_2.7_stripe_12.gemfile
@@ -6,7 +6,9 @@ gem "benchmark-ips", "~> 2.8"
 gem "benchmark-memory", "< 0.2"
 gem "climate_control", "~> 0.2.0"
 gem "concurrent-ruby"
+gem "dogstatsd-ruby", ">= 3.3.0", "!= 5.0.0", "!= 5.0.1", "!= 5.1.0"
 gem "extlz4", "~> 0.3", ">= 0.3.3"
+gem "google-protobuf", ["~> 3.0", "!= 3.7.0", "!= 3.7.1"]
 gem "json-schema", "< 3"
 gem "memory_profiler", "~> 0.9"
 gem "os", "~> 1.1"
@@ -20,16 +22,14 @@ gem "rspec", "~> 3.13"
 gem "rspec-collection_matchers", "~> 1.1"
 gem "rspec-wait", "~> 0"
 gem "rspec_junit_formatter", ">= 0.5.1"
-gem "simplecov", git: "https://github.com/DataDog/simplecov", ref: "3bb6b7ee58bf4b1954ca205f50dd44d6f41c57db"
-gem "simplecov-cobertura", "~> 2.1.0"
-gem "warning", "~> 1"
-gem "webmock", ">= 3.10.0"
 gem "rubocop", "~> 1.50.0", require: false
 gem "rubocop-packaging", "~> 0.5.2", require: false
 gem "rubocop-performance", "~> 1.9", require: false
 gem "rubocop-rspec", ["~> 2.20", "< 2.21"], require: false
-gem "dogstatsd-ruby", ">= 3.3.0", "!= 5.0.0", "!= 5.0.1", "!= 5.1.0"
-gem "google-protobuf", ["~> 3.0", "!= 3.7.0", "!= 3.7.1"]
+gem "simplecov", git: "https://github.com/DataDog/simplecov", ref: "3bb6b7ee58bf4b1954ca205f50dd44d6f41c57db"
+gem "simplecov-cobertura", "~> 2.1.0"
+gem "warning", "~> 1"
+gem "webmock", ">= 3.10.0"
 gem "stripe", "~> 12"
 
 group :check do

--- a/gemfiles/ruby_2.7_stripe_7.gemfile
+++ b/gemfiles/ruby_2.7_stripe_7.gemfile
@@ -6,7 +6,9 @@ gem "benchmark-ips", "~> 2.8"
 gem "benchmark-memory", "< 0.2"
 gem "climate_control", "~> 0.2.0"
 gem "concurrent-ruby"
+gem "dogstatsd-ruby", ">= 3.3.0", "!= 5.0.0", "!= 5.0.1", "!= 5.1.0"
 gem "extlz4", "~> 0.3", ">= 0.3.3"
+gem "google-protobuf", ["~> 3.0", "!= 3.7.0", "!= 3.7.1"]
 gem "json-schema", "< 3"
 gem "memory_profiler", "~> 0.9"
 gem "os", "~> 1.1"
@@ -20,16 +22,14 @@ gem "rspec", "~> 3.13"
 gem "rspec-collection_matchers", "~> 1.1"
 gem "rspec-wait", "~> 0"
 gem "rspec_junit_formatter", ">= 0.5.1"
-gem "simplecov", git: "https://github.com/DataDog/simplecov", ref: "3bb6b7ee58bf4b1954ca205f50dd44d6f41c57db"
-gem "simplecov-cobertura", "~> 2.1.0"
-gem "warning", "~> 1"
-gem "webmock", ">= 3.10.0"
 gem "rubocop", "~> 1.50.0", require: false
 gem "rubocop-packaging", "~> 0.5.2", require: false
 gem "rubocop-performance", "~> 1.9", require: false
 gem "rubocop-rspec", ["~> 2.20", "< 2.21"], require: false
-gem "dogstatsd-ruby", ">= 3.3.0", "!= 5.0.0", "!= 5.0.1", "!= 5.1.0"
-gem "google-protobuf", ["~> 3.0", "!= 3.7.0", "!= 3.7.1"]
+gem "simplecov", git: "https://github.com/DataDog/simplecov", ref: "3bb6b7ee58bf4b1954ca205f50dd44d6f41c57db"
+gem "simplecov-cobertura", "~> 2.1.0"
+gem "warning", "~> 1"
+gem "webmock", ">= 3.10.0"
 gem "stripe", "~> 7"
 
 group :check do

--- a/gemfiles/ruby_2.7_stripe_8.gemfile
+++ b/gemfiles/ruby_2.7_stripe_8.gemfile
@@ -6,7 +6,9 @@ gem "benchmark-ips", "~> 2.8"
 gem "benchmark-memory", "< 0.2"
 gem "climate_control", "~> 0.2.0"
 gem "concurrent-ruby"
+gem "dogstatsd-ruby", ">= 3.3.0", "!= 5.0.0", "!= 5.0.1", "!= 5.1.0"
 gem "extlz4", "~> 0.3", ">= 0.3.3"
+gem "google-protobuf", ["~> 3.0", "!= 3.7.0", "!= 3.7.1"]
 gem "json-schema", "< 3"
 gem "memory_profiler", "~> 0.9"
 gem "os", "~> 1.1"
@@ -20,16 +22,14 @@ gem "rspec", "~> 3.13"
 gem "rspec-collection_matchers", "~> 1.1"
 gem "rspec-wait", "~> 0"
 gem "rspec_junit_formatter", ">= 0.5.1"
-gem "simplecov", git: "https://github.com/DataDog/simplecov", ref: "3bb6b7ee58bf4b1954ca205f50dd44d6f41c57db"
-gem "simplecov-cobertura", "~> 2.1.0"
-gem "warning", "~> 1"
-gem "webmock", ">= 3.10.0"
 gem "rubocop", "~> 1.50.0", require: false
 gem "rubocop-packaging", "~> 0.5.2", require: false
 gem "rubocop-performance", "~> 1.9", require: false
 gem "rubocop-rspec", ["~> 2.20", "< 2.21"], require: false
-gem "dogstatsd-ruby", ">= 3.3.0", "!= 5.0.0", "!= 5.0.1", "!= 5.1.0"
-gem "google-protobuf", ["~> 3.0", "!= 3.7.0", "!= 3.7.1"]
+gem "simplecov", git: "https://github.com/DataDog/simplecov", ref: "3bb6b7ee58bf4b1954ca205f50dd44d6f41c57db"
+gem "simplecov-cobertura", "~> 2.1.0"
+gem "warning", "~> 1"
+gem "webmock", ">= 3.10.0"
 gem "stripe", "~> 8"
 
 group :check do

--- a/gemfiles/ruby_2.7_stripe_9.gemfile
+++ b/gemfiles/ruby_2.7_stripe_9.gemfile
@@ -6,7 +6,9 @@ gem "benchmark-ips", "~> 2.8"
 gem "benchmark-memory", "< 0.2"
 gem "climate_control", "~> 0.2.0"
 gem "concurrent-ruby"
+gem "dogstatsd-ruby", ">= 3.3.0", "!= 5.0.0", "!= 5.0.1", "!= 5.1.0"
 gem "extlz4", "~> 0.3", ">= 0.3.3"
+gem "google-protobuf", ["~> 3.0", "!= 3.7.0", "!= 3.7.1"]
 gem "json-schema", "< 3"
 gem "memory_profiler", "~> 0.9"
 gem "os", "~> 1.1"
@@ -20,16 +22,14 @@ gem "rspec", "~> 3.13"
 gem "rspec-collection_matchers", "~> 1.1"
 gem "rspec-wait", "~> 0"
 gem "rspec_junit_formatter", ">= 0.5.1"
-gem "simplecov", git: "https://github.com/DataDog/simplecov", ref: "3bb6b7ee58bf4b1954ca205f50dd44d6f41c57db"
-gem "simplecov-cobertura", "~> 2.1.0"
-gem "warning", "~> 1"
-gem "webmock", ">= 3.10.0"
 gem "rubocop", "~> 1.50.0", require: false
 gem "rubocop-packaging", "~> 0.5.2", require: false
 gem "rubocop-performance", "~> 1.9", require: false
 gem "rubocop-rspec", ["~> 2.20", "< 2.21"], require: false
-gem "dogstatsd-ruby", ">= 3.3.0", "!= 5.0.0", "!= 5.0.1", "!= 5.1.0"
-gem "google-protobuf", ["~> 3.0", "!= 3.7.0", "!= 3.7.1"]
+gem "simplecov", git: "https://github.com/DataDog/simplecov", ref: "3bb6b7ee58bf4b1954ca205f50dd44d6f41c57db"
+gem "simplecov-cobertura", "~> 2.1.0"
+gem "warning", "~> 1"
+gem "webmock", ">= 3.10.0"
 gem "stripe", "~> 9"
 
 group :check do

--- a/gemfiles/ruby_2.7_stripe_latest.gemfile
+++ b/gemfiles/ruby_2.7_stripe_latest.gemfile
@@ -6,7 +6,9 @@ gem "benchmark-ips", "~> 2.8"
 gem "benchmark-memory", "< 0.2"
 gem "climate_control", "~> 0.2.0"
 gem "concurrent-ruby"
+gem "dogstatsd-ruby", ">= 3.3.0", "!= 5.0.0", "!= 5.0.1", "!= 5.1.0"
 gem "extlz4", "~> 0.3", ">= 0.3.3"
+gem "google-protobuf", ["~> 3.0", "!= 3.7.0", "!= 3.7.1"]
 gem "json-schema", "< 3"
 gem "memory_profiler", "~> 0.9"
 gem "os", "~> 1.1"
@@ -20,16 +22,14 @@ gem "rspec", "~> 3.13"
 gem "rspec-collection_matchers", "~> 1.1"
 gem "rspec-wait", "~> 0"
 gem "rspec_junit_formatter", ">= 0.5.1"
-gem "simplecov", git: "https://github.com/DataDog/simplecov", ref: "3bb6b7ee58bf4b1954ca205f50dd44d6f41c57db"
-gem "simplecov-cobertura", "~> 2.1.0"
-gem "warning", "~> 1"
-gem "webmock", ">= 3.10.0"
 gem "rubocop", "~> 1.50.0", require: false
 gem "rubocop-packaging", "~> 0.5.2", require: false
 gem "rubocop-performance", "~> 1.9", require: false
 gem "rubocop-rspec", ["~> 2.20", "< 2.21"], require: false
-gem "dogstatsd-ruby", ">= 3.3.0", "!= 5.0.0", "!= 5.0.1", "!= 5.1.0"
-gem "google-protobuf", ["~> 3.0", "!= 3.7.0", "!= 3.7.1"]
+gem "simplecov", git: "https://github.com/DataDog/simplecov", ref: "3bb6b7ee58bf4b1954ca205f50dd44d6f41c57db"
+gem "simplecov-cobertura", "~> 2.1.0"
+gem "warning", "~> 1"
+gem "webmock", ">= 3.10.0"
 gem "stripe"
 
 group :check do

--- a/gemfiles/ruby_2.7_stripe_min.gemfile
+++ b/gemfiles/ruby_2.7_stripe_min.gemfile
@@ -6,7 +6,9 @@ gem "benchmark-ips", "~> 2.8"
 gem "benchmark-memory", "< 0.2"
 gem "climate_control", "~> 0.2.0"
 gem "concurrent-ruby"
+gem "dogstatsd-ruby", ">= 3.3.0", "!= 5.0.0", "!= 5.0.1", "!= 5.1.0"
 gem "extlz4", "~> 0.3", ">= 0.3.3"
+gem "google-protobuf", ["~> 3.0", "!= 3.7.0", "!= 3.7.1"]
 gem "json-schema", "< 3"
 gem "memory_profiler", "~> 0.9"
 gem "os", "~> 1.1"
@@ -20,16 +22,14 @@ gem "rspec", "~> 3.13"
 gem "rspec-collection_matchers", "~> 1.1"
 gem "rspec-wait", "~> 0"
 gem "rspec_junit_formatter", ">= 0.5.1"
-gem "simplecov", git: "https://github.com/DataDog/simplecov", ref: "3bb6b7ee58bf4b1954ca205f50dd44d6f41c57db"
-gem "simplecov-cobertura", "~> 2.1.0"
-gem "warning", "~> 1"
-gem "webmock", ">= 3.10.0"
 gem "rubocop", "~> 1.50.0", require: false
 gem "rubocop-packaging", "~> 0.5.2", require: false
 gem "rubocop-performance", "~> 1.9", require: false
 gem "rubocop-rspec", ["~> 2.20", "< 2.21"], require: false
-gem "dogstatsd-ruby", ">= 3.3.0", "!= 5.0.0", "!= 5.0.1", "!= 5.1.0"
-gem "google-protobuf", ["~> 3.0", "!= 3.7.0", "!= 3.7.1"]
+gem "simplecov", git: "https://github.com/DataDog/simplecov", ref: "3bb6b7ee58bf4b1954ca205f50dd44d6f41c57db"
+gem "simplecov-cobertura", "~> 2.1.0"
+gem "warning", "~> 1"
+gem "webmock", ">= 3.10.0"
 gem "stripe", "= 5.15.0"
 
 group :check do

--- a/ruby-2.5.gemfile
+++ b/ruby-2.5.gemfile
@@ -8,22 +8,15 @@ gem 'benchmark-memory', '< 0.2' # V0.2 only works with 2.5+
 gem 'climate_control', '~> 0.2.0'
 
 gem 'concurrent-ruby'
-gem 'extlz4', '~> 0.3', '>= 0.3.3' if RUBY_PLATFORM != 'java' # Used to test lz4 compression done by libdatadog
+gem 'extlz4', '~> 0.3', '>= 0.3.3'
 gem 'json-schema', '< 3' # V3 only works with 2.5+
 gem 'memory_profiler', '~> 0.9'
 
 gem 'os', '~> 1.1'
 gem 'pimpmychangelog', '>= 0.1.2'
 gem 'pry'
-if RUBY_PLATFORM != 'java'
-  # There's a few incompatibilities between pry/pry-byebug on older Rubies
-  # There's also a few temproary incompatibilities with newer rubies
-  gem 'pry-byebug' if RUBY_VERSION >= '2.6.0' && RUBY_ENGINE != 'truffleruby' && RUBY_VERSION < '3.2.0'
-  gem 'pry-nav' if RUBY_VERSION < '2.6.0'
-  gem 'pry-stack_explorer'
-else
-  gem 'pry-debugger-jruby'
-end
+gem 'pry-nav'
+gem 'pry-stack_explorer'
 gem 'rake', '>= 10.5'
 gem 'rake-compiler', '~> 1.1', '>= 1.1.1' # To compile native extensions
 gem 'rspec', '~> 3.13'
@@ -41,22 +34,6 @@ gem 'simplecov-cobertura', '~> 2.1.0' # Used by codecov
 gem 'warning', '~> 1' # NOTE: Used in spec_helper.rb
 gem 'webmock', '>= 3.10.0'
 
-if RUBY_VERSION.start_with?('3.4.')
-  # ruby 3.4 breaks stable webrick; we need this fix until a version later than 1.8.1 comes out
-  gem 'webrick', git: 'https://github.com/ruby/webrick.git', ref: '0c600e169bd4ae267cb5eeb6197277c848323bbe'
-elsif RUBY_VERSION >= '3.0.0' # No longer bundled by default since Ruby 3.0
-  gem 'webrick', '>= 1.7.0'
-end
-
-if RUBY_VERSION >= '2.6.0'
-  # 1.50 is the last version to support Ruby 2.6
-  gem 'rubocop', '~> 1.50.0', require: false
-  gem 'rubocop-packaging', '~> 0.5.2', require: false
-  gem 'rubocop-performance', '~> 1.9', require: false
-  # 2.20 is the last version to support Ruby 2.6
-  gem 'rubocop-rspec', ['~> 2.20', '< 2.21'], require: false
-end
-
 # Optional extensions
 # TODO: Move this to Appraisals?
 # dogstatsd v5, but lower than 5.2, has possible memory leak with datadog.
@@ -67,24 +44,12 @@ gem 'dogstatsd-ruby', '>= 3.3.0', '!= 5.0.0', '!= 5.0.1', '!= 5.1.0'
 # NOTE: We're excluding versions 3.7.0 and 3.7.1 for the reasons documented in #1424.
 #       Since most of our customers won't have BUNDLE_FORCE_RUBY_PLATFORM=true, it's not something we want to add
 #       to our CI, so we just shortcut and exclude specific versions that were affecting our CI.
-if RUBY_PLATFORM != 'java'
-  if RUBY_VERSION >= '2.7.0' # Bundler 1.x fails to find that versions >= 3.8.0 are not compatible because of binary gems
-    gem 'google-protobuf', ['~> 3.0', '!= 3.7.0', '!= 3.7.1']
-  else
-    gem 'google-protobuf', ['~> 3.0', '!= 3.7.0', '!= 3.7.1', '< 3.19.2']
-  end
-end
+gem 'google-protobuf', ['~> 3.0', '!= 3.7.0', '!= 3.7.1', '< 3.19.2']
 
 group :check do
-  if RUBY_VERSION >= '3.0.0' && RUBY_PLATFORM != 'java'
-    gem 'rbs', '~> 3.6', require: false
-    gem 'steep', '~> 1.7.0', require: false
-  end
-  gem 'ruby_memcheck', '>= 3' if RUBY_VERSION >= '3.4.0' && RUBY_PLATFORM != 'java'
   gem 'standard', require: false
 end
 
 group :dev do
-  gem 'ruby-lsp', require: false if RUBY_VERSION >= '3.0.0' && RUBY_PLATFORM != 'java'
   gem 'appraisal', '~> 2.4.0', require: false
 end

--- a/ruby-2.5.gemfile
+++ b/ruby-2.5.gemfile
@@ -4,14 +4,25 @@ gemspec
 
 gem 'benchmark-ips', '~> 2.8'
 gem 'benchmark-memory', '< 0.2' # V0.2 only works with 2.5+
-
 gem 'climate_control', '~> 0.2.0'
-
 gem 'concurrent-ruby'
+
+# Optional extensions
+# TODO: Move this to Appraisals?
+# dogstatsd v5, but lower than 5.2, has possible memory leak with datadog.
+# @see https://github.com/DataDog/dogstatsd-ruby/issues/182
+gem 'dogstatsd-ruby', '>= 3.3.0', '!= 5.0.0', '!= 5.0.1', '!= 5.1.0'
+
 gem 'extlz4', '~> 0.3', '>= 0.3.3'
+
+# Profiler testing dependencies
+# NOTE: We're excluding versions 3.7.0 and 3.7.1 for the reasons documented in #1424.
+#       Since most of our customers won't have BUNDLE_FORCE_RUBY_PLATFORM=true, it's not something we want to add
+#       to our CI, so we just shortcut and exclude specific versions that were affecting our CI.
+gem 'google-protobuf', ['~> 3.0', '!= 3.7.0', '!= 3.7.1', '< 3.19.2']
+
 gem 'json-schema', '< 3' # V3 only works with 2.5+
 gem 'memory_profiler', '~> 0.9'
-
 gem 'os', '~> 1.1'
 gem 'pimpmychangelog', '>= 0.1.2'
 gem 'pry'
@@ -22,7 +33,6 @@ gem 'rake-compiler', '~> 1.1', '>= 1.1.1' # To compile native extensions
 gem 'rspec', '~> 3.13'
 gem 'rspec-collection_matchers', '~> 1.1'
 gem 'rspec-wait', '~> 0'
-
 gem 'rspec_junit_formatter', '>= 0.5.1'
 
 # Merging branch coverage results does not work for old, unsupported rubies and JRuby
@@ -33,18 +43,6 @@ gem 'simplecov-cobertura', '~> 2.1.0' # Used by codecov
 
 gem 'warning', '~> 1' # NOTE: Used in spec_helper.rb
 gem 'webmock', '>= 3.10.0'
-
-# Optional extensions
-# TODO: Move this to Appraisals?
-# dogstatsd v5, but lower than 5.2, has possible memory leak with datadog.
-# @see https://github.com/DataDog/dogstatsd-ruby/issues/182
-gem 'dogstatsd-ruby', '>= 3.3.0', '!= 5.0.0', '!= 5.0.1', '!= 5.1.0'
-
-# Profiler testing dependencies
-# NOTE: We're excluding versions 3.7.0 and 3.7.1 for the reasons documented in #1424.
-#       Since most of our customers won't have BUNDLE_FORCE_RUBY_PLATFORM=true, it's not something we want to add
-#       to our CI, so we just shortcut and exclude specific versions that were affecting our CI.
-gem 'google-protobuf', ['~> 3.0', '!= 3.7.0', '!= 3.7.1', '< 3.19.2']
 
 group :check do
   gem 'standard', require: false

--- a/ruby-2.6.gemfile
+++ b/ruby-2.6.gemfile
@@ -8,22 +8,15 @@ gem 'benchmark-memory', '< 0.2' # V0.2 only works with 2.5+
 gem 'climate_control', '~> 0.2.0'
 
 gem 'concurrent-ruby'
-gem 'extlz4', '~> 0.3', '>= 0.3.3' if RUBY_PLATFORM != 'java' # Used to test lz4 compression done by libdatadog
+gem 'extlz4', '~> 0.3', '>= 0.3.3'
 gem 'json-schema', '< 3' # V3 only works with 2.5+
 gem 'memory_profiler', '~> 0.9'
 
 gem 'os', '~> 1.1'
 gem 'pimpmychangelog', '>= 0.1.2'
 gem 'pry'
-if RUBY_PLATFORM != 'java'
-  # There's a few incompatibilities between pry/pry-byebug on older Rubies
-  # There's also a few temproary incompatibilities with newer rubies
-  gem 'pry-byebug' if RUBY_VERSION >= '2.6.0' && RUBY_ENGINE != 'truffleruby' && RUBY_VERSION < '3.2.0'
-  gem 'pry-nav' if RUBY_VERSION < '2.6.0'
-  gem 'pry-stack_explorer'
-else
-  gem 'pry-debugger-jruby'
-end
+gem 'pry-byebug'
+gem 'pry-stack_explorer'
 gem 'rake', '>= 10.5'
 gem 'rake-compiler', '~> 1.1', '>= 1.1.1' # To compile native extensions
 gem 'rspec', '~> 3.13'
@@ -41,21 +34,12 @@ gem 'simplecov-cobertura', '~> 2.1.0' # Used by codecov
 gem 'warning', '~> 1' # NOTE: Used in spec_helper.rb
 gem 'webmock', '>= 3.10.0'
 
-if RUBY_VERSION.start_with?('3.4.')
-  # ruby 3.4 breaks stable webrick; we need this fix until a version later than 1.8.1 comes out
-  gem 'webrick', git: 'https://github.com/ruby/webrick.git', ref: '0c600e169bd4ae267cb5eeb6197277c848323bbe'
-elsif RUBY_VERSION >= '3.0.0' # No longer bundled by default since Ruby 3.0
-  gem 'webrick', '>= 1.7.0'
-end
-
-if RUBY_VERSION >= '2.6.0'
-  # 1.50 is the last version to support Ruby 2.6
-  gem 'rubocop', '~> 1.50.0', require: false
-  gem 'rubocop-packaging', '~> 0.5.2', require: false
-  gem 'rubocop-performance', '~> 1.9', require: false
-  # 2.20 is the last version to support Ruby 2.6
-  gem 'rubocop-rspec', ['~> 2.20', '< 2.21'], require: false
-end
+# 1.50 is the last version to support Ruby 2.6
+gem 'rubocop', '~> 1.50.0', require: false
+gem 'rubocop-packaging', '~> 0.5.2', require: false
+gem 'rubocop-performance', '~> 1.9', require: false
+# 2.20 is the last version to support Ruby 2.6
+gem 'rubocop-rspec', ['~> 2.20', '< 2.21'], require: false
 
 # Optional extensions
 # TODO: Move this to Appraisals?
@@ -67,24 +51,12 @@ gem 'dogstatsd-ruby', '>= 3.3.0', '!= 5.0.0', '!= 5.0.1', '!= 5.1.0'
 # NOTE: We're excluding versions 3.7.0 and 3.7.1 for the reasons documented in #1424.
 #       Since most of our customers won't have BUNDLE_FORCE_RUBY_PLATFORM=true, it's not something we want to add
 #       to our CI, so we just shortcut and exclude specific versions that were affecting our CI.
-if RUBY_PLATFORM != 'java'
-  if RUBY_VERSION >= '2.7.0' # Bundler 1.x fails to find that versions >= 3.8.0 are not compatible because of binary gems
-    gem 'google-protobuf', ['~> 3.0', '!= 3.7.0', '!= 3.7.1']
-  else
-    gem 'google-protobuf', ['~> 3.0', '!= 3.7.0', '!= 3.7.1', '< 3.19.2']
-  end
-end
+gem 'google-protobuf', ['~> 3.0', '!= 3.7.0', '!= 3.7.1', '< 3.19.2']
 
 group :check do
-  if RUBY_VERSION >= '3.0.0' && RUBY_PLATFORM != 'java'
-    gem 'rbs', '~> 3.6', require: false
-    gem 'steep', '~> 1.7.0', require: false
-  end
-  gem 'ruby_memcheck', '>= 3' if RUBY_VERSION >= '3.4.0' && RUBY_PLATFORM != 'java'
   gem 'standard', require: false
 end
 
 group :dev do
-  gem 'ruby-lsp', require: false if RUBY_VERSION >= '3.0.0' && RUBY_PLATFORM != 'java'
   gem 'appraisal', '~> 2.4.0', require: false
 end

--- a/ruby-2.6.gemfile
+++ b/ruby-2.6.gemfile
@@ -4,14 +4,25 @@ gemspec
 
 gem 'benchmark-ips', '~> 2.8'
 gem 'benchmark-memory', '< 0.2' # V0.2 only works with 2.5+
-
 gem 'climate_control', '~> 0.2.0'
-
 gem 'concurrent-ruby'
+
+# Optional extensions
+# TODO: Move this to Appraisals?
+# dogstatsd v5, but lower than 5.2, has possible memory leak with datadog.
+# @see https://github.com/DataDog/dogstatsd-ruby/issues/182
+gem 'dogstatsd-ruby', '>= 3.3.0', '!= 5.0.0', '!= 5.0.1', '!= 5.1.0'
+
 gem 'extlz4', '~> 0.3', '>= 0.3.3'
+
+# Profiler testing dependencies
+# NOTE: We're excluding versions 3.7.0 and 3.7.1 for the reasons documented in #1424.
+#       Since most of our customers won't have BUNDLE_FORCE_RUBY_PLATFORM=true, it's not something we want to add
+#       to our CI, so we just shortcut and exclude specific versions that were affecting our CI.
+gem 'google-protobuf', ['~> 3.0', '!= 3.7.0', '!= 3.7.1', '< 3.19.2']
+
 gem 'json-schema', '< 3' # V3 only works with 2.5+
 gem 'memory_profiler', '~> 0.9'
-
 gem 'os', '~> 1.1'
 gem 'pimpmychangelog', '>= 0.1.2'
 gem 'pry'
@@ -22,8 +33,14 @@ gem 'rake-compiler', '~> 1.1', '>= 1.1.1' # To compile native extensions
 gem 'rspec', '~> 3.13'
 gem 'rspec-collection_matchers', '~> 1.1'
 gem 'rspec-wait', '~> 0'
-
 gem 'rspec_junit_formatter', '>= 0.5.1'
+
+# 1.50 is the last version to support Ruby 2.6
+gem 'rubocop', '~> 1.50.0', require: false
+gem 'rubocop-packaging', '~> 0.5.2', require: false
+gem 'rubocop-performance', '~> 1.9', require: false
+# 2.20 is the last version to support Ruby 2.6
+gem 'rubocop-rspec', ['~> 2.20', '< 2.21'], require: false
 
 # Merging branch coverage results does not work for old, unsupported rubies and JRuby
 # We have a fix up for review, https://github.com/simplecov-ruby/simplecov/pull/972,
@@ -33,25 +50,6 @@ gem 'simplecov-cobertura', '~> 2.1.0' # Used by codecov
 
 gem 'warning', '~> 1' # NOTE: Used in spec_helper.rb
 gem 'webmock', '>= 3.10.0'
-
-# 1.50 is the last version to support Ruby 2.6
-gem 'rubocop', '~> 1.50.0', require: false
-gem 'rubocop-packaging', '~> 0.5.2', require: false
-gem 'rubocop-performance', '~> 1.9', require: false
-# 2.20 is the last version to support Ruby 2.6
-gem 'rubocop-rspec', ['~> 2.20', '< 2.21'], require: false
-
-# Optional extensions
-# TODO: Move this to Appraisals?
-# dogstatsd v5, but lower than 5.2, has possible memory leak with datadog.
-# @see https://github.com/DataDog/dogstatsd-ruby/issues/182
-gem 'dogstatsd-ruby', '>= 3.3.0', '!= 5.0.0', '!= 5.0.1', '!= 5.1.0'
-
-# Profiler testing dependencies
-# NOTE: We're excluding versions 3.7.0 and 3.7.1 for the reasons documented in #1424.
-#       Since most of our customers won't have BUNDLE_FORCE_RUBY_PLATFORM=true, it's not something we want to add
-#       to our CI, so we just shortcut and exclude specific versions that were affecting our CI.
-gem 'google-protobuf', ['~> 3.0', '!= 3.7.0', '!= 3.7.1', '< 3.19.2']
 
 group :check do
   gem 'standard', require: false

--- a/ruby-2.7.gemfile
+++ b/ruby-2.7.gemfile
@@ -4,14 +4,25 @@ gemspec
 
 gem 'benchmark-ips', '~> 2.8'
 gem 'benchmark-memory', '< 0.2' # V0.2 only works with 2.5+
-
 gem 'climate_control', '~> 0.2.0'
-
 gem 'concurrent-ruby'
+
+# Optional extensions
+# TODO: Move this to Appraisals?
+# dogstatsd v5, but lower than 5.2, has possible memory leak with datadog.
+# @see https://github.com/DataDog/dogstatsd-ruby/issues/182
+gem 'dogstatsd-ruby', '>= 3.3.0', '!= 5.0.0', '!= 5.0.1', '!= 5.1.0'
+
 gem 'extlz4', '~> 0.3', '>= 0.3.3'
+
+# Profiler testing dependencies
+# NOTE: We're excluding versions 3.7.0 and 3.7.1 for the reasons documented in #1424.
+#       Since most of our customers won't have BUNDLE_FORCE_RUBY_PLATFORM=true, it's not something we want to add
+#       to our CI, so we just shortcut and exclude specific versions that were affecting our CI.
+gem 'google-protobuf', ['~> 3.0', '!= 3.7.0', '!= 3.7.1']
+
 gem 'json-schema', '< 3' # V3 only works with 2.5+
 gem 'memory_profiler', '~> 0.9'
-
 gem 'os', '~> 1.1'
 gem 'pimpmychangelog', '>= 0.1.2'
 gem 'pry'
@@ -22,8 +33,14 @@ gem 'rake-compiler', '~> 1.1', '>= 1.1.1' # To compile native extensions
 gem 'rspec', '~> 3.13'
 gem 'rspec-collection_matchers', '~> 1.1'
 gem 'rspec-wait', '~> 0'
-
 gem 'rspec_junit_formatter', '>= 0.5.1'
+
+# 1.50 is the last version to support Ruby 2.6
+gem 'rubocop', '~> 1.50.0', require: false
+gem 'rubocop-packaging', '~> 0.5.2', require: false
+gem 'rubocop-performance', '~> 1.9', require: false
+# 2.20 is the last version to support Ruby 2.6
+gem 'rubocop-rspec', ['~> 2.20', '< 2.21'], require: false
 
 # Merging branch coverage results does not work for old, unsupported rubies and JRuby
 # We have a fix up for review, https://github.com/simplecov-ruby/simplecov/pull/972,
@@ -33,25 +50,6 @@ gem 'simplecov-cobertura', '~> 2.1.0' # Used by codecov
 
 gem 'warning', '~> 1' # NOTE: Used in spec_helper.rb
 gem 'webmock', '>= 3.10.0'
-
-# 1.50 is the last version to support Ruby 2.6
-gem 'rubocop', '~> 1.50.0', require: false
-gem 'rubocop-packaging', '~> 0.5.2', require: false
-gem 'rubocop-performance', '~> 1.9', require: false
-# 2.20 is the last version to support Ruby 2.6
-gem 'rubocop-rspec', ['~> 2.20', '< 2.21'], require: false
-
-# Optional extensions
-# TODO: Move this to Appraisals?
-# dogstatsd v5, but lower than 5.2, has possible memory leak with datadog.
-# @see https://github.com/DataDog/dogstatsd-ruby/issues/182
-gem 'dogstatsd-ruby', '>= 3.3.0', '!= 5.0.0', '!= 5.0.1', '!= 5.1.0'
-
-# Profiler testing dependencies
-# NOTE: We're excluding versions 3.7.0 and 3.7.1 for the reasons documented in #1424.
-#       Since most of our customers won't have BUNDLE_FORCE_RUBY_PLATFORM=true, it's not something we want to add
-#       to our CI, so we just shortcut and exclude specific versions that were affecting our CI.
-gem 'google-protobuf', ['~> 3.0', '!= 3.7.0', '!= 3.7.1']
 
 group :check do
   gem 'ruby_memcheck', '>= 3' if RUBY_VERSION >= '3.4.0' && RUBY_PLATFORM != 'java'

--- a/ruby-2.7.gemfile
+++ b/ruby-2.7.gemfile
@@ -8,22 +8,15 @@ gem 'benchmark-memory', '< 0.2' # V0.2 only works with 2.5+
 gem 'climate_control', '~> 0.2.0'
 
 gem 'concurrent-ruby'
-gem 'extlz4', '~> 0.3', '>= 0.3.3' if RUBY_PLATFORM != 'java' # Used to test lz4 compression done by libdatadog
+gem 'extlz4', '~> 0.3', '>= 0.3.3'
 gem 'json-schema', '< 3' # V3 only works with 2.5+
 gem 'memory_profiler', '~> 0.9'
 
 gem 'os', '~> 1.1'
 gem 'pimpmychangelog', '>= 0.1.2'
 gem 'pry'
-if RUBY_PLATFORM != 'java'
-  # There's a few incompatibilities between pry/pry-byebug on older Rubies
-  # There's also a few temproary incompatibilities with newer rubies
-  gem 'pry-byebug' if RUBY_VERSION >= '2.6.0' && RUBY_ENGINE != 'truffleruby' && RUBY_VERSION < '3.2.0'
-  gem 'pry-nav' if RUBY_VERSION < '2.6.0'
-  gem 'pry-stack_explorer'
-else
-  gem 'pry-debugger-jruby'
-end
+gem 'pry-byebug'
+gem 'pry-stack_explorer'
 gem 'rake', '>= 10.5'
 gem 'rake-compiler', '~> 1.1', '>= 1.1.1' # To compile native extensions
 gem 'rspec', '~> 3.13'
@@ -41,21 +34,12 @@ gem 'simplecov-cobertura', '~> 2.1.0' # Used by codecov
 gem 'warning', '~> 1' # NOTE: Used in spec_helper.rb
 gem 'webmock', '>= 3.10.0'
 
-if RUBY_VERSION.start_with?('3.4.')
-  # ruby 3.4 breaks stable webrick; we need this fix until a version later than 1.8.1 comes out
-  gem 'webrick', git: 'https://github.com/ruby/webrick.git', ref: '0c600e169bd4ae267cb5eeb6197277c848323bbe'
-elsif RUBY_VERSION >= '3.0.0' # No longer bundled by default since Ruby 3.0
-  gem 'webrick', '>= 1.7.0'
-end
-
-if RUBY_VERSION >= '2.6.0'
-  # 1.50 is the last version to support Ruby 2.6
-  gem 'rubocop', '~> 1.50.0', require: false
-  gem 'rubocop-packaging', '~> 0.5.2', require: false
-  gem 'rubocop-performance', '~> 1.9', require: false
-  # 2.20 is the last version to support Ruby 2.6
-  gem 'rubocop-rspec', ['~> 2.20', '< 2.21'], require: false
-end
+# 1.50 is the last version to support Ruby 2.6
+gem 'rubocop', '~> 1.50.0', require: false
+gem 'rubocop-packaging', '~> 0.5.2', require: false
+gem 'rubocop-performance', '~> 1.9', require: false
+# 2.20 is the last version to support Ruby 2.6
+gem 'rubocop-rspec', ['~> 2.20', '< 2.21'], require: false
 
 # Optional extensions
 # TODO: Move this to Appraisals?
@@ -67,24 +51,13 @@ gem 'dogstatsd-ruby', '>= 3.3.0', '!= 5.0.0', '!= 5.0.1', '!= 5.1.0'
 # NOTE: We're excluding versions 3.7.0 and 3.7.1 for the reasons documented in #1424.
 #       Since most of our customers won't have BUNDLE_FORCE_RUBY_PLATFORM=true, it's not something we want to add
 #       to our CI, so we just shortcut and exclude specific versions that were affecting our CI.
-if RUBY_PLATFORM != 'java'
-  if RUBY_VERSION >= '2.7.0' # Bundler 1.x fails to find that versions >= 3.8.0 are not compatible because of binary gems
-    gem 'google-protobuf', ['~> 3.0', '!= 3.7.0', '!= 3.7.1']
-  else
-    gem 'google-protobuf', ['~> 3.0', '!= 3.7.0', '!= 3.7.1', '< 3.19.2']
-  end
-end
+gem 'google-protobuf', ['~> 3.0', '!= 3.7.0', '!= 3.7.1']
 
 group :check do
-  if RUBY_VERSION >= '3.0.0' && RUBY_PLATFORM != 'java'
-    gem 'rbs', '~> 3.6', require: false
-    gem 'steep', '~> 1.7.0', require: false
-  end
   gem 'ruby_memcheck', '>= 3' if RUBY_VERSION >= '3.4.0' && RUBY_PLATFORM != 'java'
   gem 'standard', require: false
 end
 
 group :dev do
-  gem 'ruby-lsp', require: false if RUBY_VERSION >= '3.0.0' && RUBY_PLATFORM != 'java'
   gem 'appraisal', '~> 2.4.0', require: false
 end


### PR DESCRIPTION
<!--
Check out the
https://github.com/DataDog/dd-trace-rb/blob/master/docs/DevelopmentGuide.md
for guidance on how to set up your development environment,
run the test suite, write new integrations, and more.
-->

**What does this PR do?**
This PR removes `if` statements and alphabetizes `ruby-2.x.gemfile`s.

**Motivation:**
Since gemfiles are no longer symlinked, we can begin removing `if` statements and generally cleaning each file.

**Change log entry**
None.

**Additional Notes:**
N/A

**How to test the change?**
Green CI.

<!-- Unsure? Have a question? Request a review! -->
