### PR TITLE
Update appsec WAF rules to version 1.13.3

### DIFF
--- a/lib/datadog/appsec/assets/waf_rules/recommended.json
+++ b/lib/datadog/appsec/assets/waf_rules/recommended.json
@@ -1,7 +1,7 @@
 {
   "version": "2.2",
   "metadata": {
-    "rules_version": "1.13.1"
+    "rules_version": "1.13.3"
   },
   "rules": [
     {
@@ -9,7 +9,8 @@
       "name": "Block IP Addresses",
       "tags": {
         "type": "block_ip",
-        "category": "security_response"
+        "category": "security_response",
+        "module": "network-acl"
       },
       "conditions": [
         {
@@ -34,7 +35,8 @@
       "name": "Block User Addresses",
       "tags": {
         "type": "block_user",
-        "category": "security_response"
+        "category": "security_response",
+        "module": "authentication-acl"
       },
       "conditions": [
         {
@@ -64,7 +66,8 @@
         "tool_name": "Acunetix",
         "cwe": "200",
         "capec": "1000/118/169",
-        "confidence": "0"
+        "confidence": "0",
+        "module": "waf"
       },
       "conditions": [
         {
@@ -98,7 +101,8 @@
         "category": "attack_attempt",
         "cwe": "200",
         "capec": "1000/118/169",
-        "confidence": "1"
+        "confidence": "1",
+        "module": "waf"
       },
       "conditions": [
         {
@@ -162,7 +166,8 @@
         "category": "attack_attempt",
         "cwe": "176",
         "capec": "1000/255/153/267/71",
-        "confidence": "0"
+        "confidence": "0",
+        "module": "waf"
       },
       "conditions": [
         {
@@ -191,7 +196,8 @@
         "crs_id": "921110",
         "category": "attack_attempt",
         "cwe": "444",
-        "capec": "1000/210/272/220/33"
+        "capec": "1000/210/272/220/33",
+        "module": "waf"
       },
       "conditions": [
         {
@@ -228,7 +234,8 @@
         "crs_id": "921160",
         "category": "attack_attempt",
         "cwe": "113",
-        "capec": "1000/210/272/220/105"
+        "capec": "1000/210/272/220/105",
+        "module": "waf"
       },
       "conditions": [
         {
@@ -263,7 +270,8 @@
         "category": "attack_attempt",
         "cwe": "22",
         "capec": "1000/255/153/126",
-        "confidence": "1"
+        "confidence": "1",
+        "module": "waf"
       },
       "conditions": [
         {
@@ -297,7 +305,8 @@
         "category": "attack_attempt",
         "cwe": "22",
         "capec": "1000/255/153/126",
-        "confidence": "1"
+        "confidence": "1",
+        "module": "waf"
       },
       "conditions": [
         {
@@ -1803,7 +1812,8 @@
         "category": "attack_attempt",
         "cwe": "98",
         "capec": "1000/152/175/253/193",
-        "confidence": "1"
+        "confidence": "1",
+        "module": "waf"
       },
       "conditions": [
         {
@@ -1831,7 +1841,8 @@
         "crs_id": "931120",
         "category": "attack_attempt",
         "cwe": "98",
-        "capec": "1000/152/175/253/193"
+        "capec": "1000/152/175/253/193",
+        "module": "waf"
       },
       "conditions": [
         {
@@ -1876,7 +1887,8 @@
         "category": "attack_attempt",
         "cwe": "77",
         "capec": "1000/152/248/88",
-        "confidence": "1"
+        "confidence": "1",
+        "module": "waf"
       },
       "conditions": [
         {
@@ -2388,7 +2400,8 @@
         "category": "attack_attempt",
         "cwe": "77",
         "capec": "1000/152/248/88",
-        "confidence": "1"
+        "confidence": "1",
+        "module": "waf"
       },
       "conditions": [
         {
@@ -2436,7 +2449,8 @@
         "category": "attack_attempt",
         "cwe": "706",
         "capec": "1000/225/122/17/177",
-        "confidence": "1"
+        "confidence": "1",
+        "module": "waf"
       },
       "conditions": [
         {
@@ -2500,7 +2514,8 @@
         "category": "attack_attempt",
         "cwe": "434",
         "capec": "1000/225/122/17/650",
-        "confidence": "1"
+        "confidence": "1",
+        "module": "waf"
       },
       "conditions": [
         {
@@ -2553,7 +2568,8 @@
         "category": "attack_attempt",
         "cwe": "94",
         "capec": "1000/225/122/17/650",
-        "confidence": "1"
+        "confidence": "1",
+        "module": "waf"
       },
       "conditions": [
         {
@@ -2620,7 +2636,8 @@
         "crs_id": "933131",
         "category": "attack_attempt",
         "cwe": "94",
-        "capec": "1000/225/122/17/650"
+        "capec": "1000/225/122/17/650",
+        "module": "waf"
       },
       "conditions": [
         {
@@ -2665,7 +2682,8 @@
         "category": "attack_attempt",
         "cwe": "94",
         "capec": "1000/225/122/17/650",
-        "confidence": "1"
+        "confidence": "1",
+        "module": "waf"
       },
       "conditions": [
         {
@@ -2709,7 +2727,8 @@
         "category": "attack_attempt",
         "cwe": "94",
         "capec": "1000/225/122/17/650",
-        "confidence": "1"
+        "confidence": "1",
+        "module": "waf"
       },
       "conditions": [
         {
@@ -2799,7 +2818,8 @@
         "crs_id": "933160",
         "category": "attack_attempt",
         "cwe": "94",
-        "capec": "1000/225/122/17/650"
+        "capec": "1000/225/122/17/650",
+        "module": "waf"
       },
       "conditions": [
         {
@@ -2824,7 +2844,7 @@
                 "address": "graphql.server.resolver"
               }
             ],
-            "regex": "\\b(?:s(?:e(?:t(?:_(?:e(?:xception|rror)_handler|magic_quotes_runtime|include_path)|defaultstub)|ssion_s(?:et_save_handler|tart))|qlite_(?:(?:(?:unbuffered|single|array)_)?query|create_(?:aggregate|function)|p?open|exec)|tr(?:eam_(?:context_create|socket_client)|ipc?slashes|rev)|implexml_load_(?:string|file)|ocket_c(?:onnect|reate)|h(?:ow_sourc|a1_fil)e|pl_autoload_register|ystem)|p(?:r(?:eg_(?:replace(?:_callback(?:_array)?)?|match(?:_all)?|split)|oc_(?:(?:terminat|clos|nic)e|get_status|open)|int_r)|o(?:six_(?:get(?:(?:e[gu]|g)id|login|pwnam)|mk(?:fifo|nod)|ttyname|kill)|pen)|hp(?:_(?:strip_whitespac|unam)e|version|info)|g_(?:(?:execut|prepar)e|connect|query)|a(?:rse_(?:ini_file|str)|ssthru)|utenv)|r(?:unkit_(?:function_(?:re(?:defin|nam)e|copy|add)|method_(?:re(?:defin|nam)e|copy|add)|constant_(?:redefine|add))|e(?:(?:gister_(?:shutdown|tick)|name)_function|ad(?:(?:gz)?file|_exif_data|dir))|awurl(?:de|en)code)|i(?:mage(?:createfrom(?:(?:jpe|pn)g|x[bp]m|wbmp|gif)|(?:jpe|pn)g|g(?:d2?|if)|2?wbmp|xbm)|s_(?:(?:(?:execut|write?|read)ab|fi)le|dir)|ni_(?:get(?:_all)?|set)|terator_apply|ptcembed)|g(?:et(?:_(?:c(?:urrent_use|fg_va)r|meta_tags)|my(?:[gpu]id|inode)|(?:lastmo|cw)d|imagesize|env)|z(?:(?:(?:defla|wri)t|encod|fil)e|compress|open|read)|lob)|a(?:rray_(?:u(?:intersect(?:_u?assoc)?|diff(?:_u?assoc)?)|intersect_u(?:assoc|key)|diff_u(?:assoc|key)|filter|reduce|map)|ssert(?:_options)?|tob)|h(?:tml(?:specialchars(?:_decode)?|_entity_decode|entities)|(?:ash(?:_(?:update|hmac))?|ighlight)_file|e(?:ader_register_callback|x2bin))|f(?:i(?:le(?:(?:[acm]tim|inod)e|(?:_exist|perm)s|group)?|nfo_open)|tp_(?:nb_(?:ge|pu)|connec|ge|pu)t|(?:unction_exis|pu)ts|write|open)|o(?:b_(?:get_(?:c(?:ontents|lean)|flush)|end_(?:clean|flush)|clean|flush|start)|dbc_(?:result(?:_all)?|exec(?:ute)?|connect)|pendir)|m(?:b_(?:ereg(?:_(?:replace(?:_callback)?|match)|i(?:_replace)?)?|parse_str)|(?:ove_uploaded|d5)_file|ethod_exists|ysql_query|kdir)|e(?:x(?:if_(?:t(?:humbnail|agname)|imagetype|read_data)|ec)|scapeshell(?:arg|cmd)|rror_reporting|val)|c(?:url_(?:file_create|exec|init)|onvert_uuencode|reate_function|hr)|u(?:n(?:serialize|pack)|rl(?:de|en)code|[ak]?sort)|b(?:(?:son_(?:de|en)|ase64_en)code|zopen|toa)|(?:json_(?:de|en)cod|debug_backtrac|tmpfil)e|var_dump)(?:\\s|/\\*.*\\*/|//.*|#.*|\\\"|')*\\((?:(?:\\s|/\\*.*\\*/|//.*|#.*)*(?:\\$\\w+|[A-Z\\d]\\w*|\\w+\\(.*\\)|\\\\?\"(?:[^\"]|\\\\\"|\"\"|\"\\+\")*\\\\?\"|\\\\?'(?:[^']|''|'\\+')*\\\\?')(?:\\s|/\\*.*\\*/|//.*|#.*)*(?:(?:::|\\.|->)(?:\\s|/\\*.*\\*/|//.*|#.*)*\\w+(?:\\(.*\\))?)?,)*(?:(?:\\s|/\\*.*\\*/|//.*|#.*)*(?:\\$\\w+|[A-Z\\d]\\w*|\\w+\\(.*\\)|\\\\?\"(?:[^\"]|\\\\\"|\"\"|\"\\+\")*\\\\?\"|\\\\?'(?:[^']|''|'\\+')*\\\\?')(?:\\s|/\\*.*\\*/|//.*|#.*)*(?:(?:::|\\.|->)(?:\\s|/\\*.*\\*/|//.*|#.*)*\\w+(?:\\(.*\\))?)?)?\\)",
+            "regex": "\\b(?:s(?:e(?:t(?:_(?:e(?:xception|rror)_handler|magic_quotes_runtime|include_path)|defaultstub)|ssion_s(?:et_save_handler|tart))|qlite_(?:(?:(?:unbuffered|single|array)_)?query|create_(?:aggregate|function)|p?open|exec)|tr(?:eam_(?:context_create|socket_client)|ipc?slashes|rev)|implexml_load_(?:string|file)|ocket_c(?:onnect|reate)|h(?:ow_sourc|a1_fil)e|pl_autoload_register|ystem)|p(?:r(?:eg_(?:replace(?:_callback(?:_array)?)?|match(?:_all)?|split)|oc_(?:(?:terminat|clos|nic)e|get_status|open)|int_r)|o(?:six_(?:get(?:(?:e[gu]|g)id|login|pwnam)|mk(?:fifo|nod)|ttyname|kill)|pen)|hp(?:_(?:strip_whitespac|unam)e|version|info)|g_(?:(?:execut|prepar)e|connect|query)|a(?:rse_(?:ini_file|str)|ssthru)|utenv)|r(?:unkit_(?:function_(?:re(?:defin|nam)e|copy|add)|method_(?:re(?:defin|nam)e|copy|add)|constant_(?:redefine|add))|e(?:(?:gister_(?:shutdown|tick)|name)_function|ad(?:(?:gz)?file|_exif_data|dir))|awurl(?:de|en)code)|i(?:mage(?:createfrom(?:(?:jpe|pn)g|x[bp]m|wbmp|gif)|(?:jpe|pn)g|g(?:d2?|if)|2?wbmp|xbm)|s_(?:(?:(?:execut|write?|read)ab|fi)le|dir)|ni_(?:get(?:_all)?|set)|terator_apply|ptcembed)|g(?:et(?:_(?:c(?:urrent_use|fg_va)r|meta_tags)|my(?:[gpu]id|inode)|(?:lastmo|cw)d|imagesize|env)|z(?:(?:(?:defla|wri)t|encod|fil)e|compress|open|read)|lob)|a(?:rray_(?:u(?:intersect(?:_u?assoc)?|diff(?:_u?assoc)?)|intersect_u(?:assoc|key)|diff_u(?:assoc|key)|filter|reduce|map)|ssert(?:_options)?|tob)|h(?:tml(?:specialchars(?:_decode)?|_entity_decode|entities)|(?:ash(?:_(?:update|hmac))?|ighlight)_file|e(?:ader_register_callback|x2bin))|f(?:i(?:le(?:(?:[acm]tim|inod)e|(?:_exist|perm)s|group)?|nfo_open)|tp_(?:nb_(?:ge|pu)|connec|ge|pu)t|(?:unction_exis|pu)ts|write|open)|o(?:b_(?:get_(?:c(?:ontents|lean)|flush)|end_(?:clean|flush)|clean|flush|start)|dbc_(?:result(?:_all)?|exec(?:ute)?|connect)|pendir)|m(?:b_(?:ereg(?:_(?:replace(?:_callback)?|match)|i(?:_replace)?)?|parse_str)|(?:ove_uploaded|d5)_file|ethod_exists|ysql_query|kdir)|e(?:x(?:if_(?:t(?:humbnail|agname)|imagetype|read_data)|ec)|scapeshell(?:arg|cmd)|rror_reporting|val)|c(?:url_(?:file_create|exec|init)|onvert_uuencode|reate_function|hr)|u(?:n(?:serialize|pack)|rl(?:de|en)code|[ak]?sort)|b(?:(?:son_(?:de|en)|ase64_en)code|zopen|toa)|(?:json_(?:de|en)cod|debug_backtrac|tmpfil)e|var_dump)(?:\\s|/\\*.*\\*/|//.*|#.*|\\\"|')*\\((?:(?:\\s|/\\*.*\\*/|//.*|#.*)*(?:\\$\\w+|[A-Z\\d]\\w*|\\w+\\(.*\\)|\\\\?\"(?:[^\"]|\\\\\"|\"\"|\"\\+\")*\\\\?\"|\\\\?'(?:[^']|''|'\\+')*\\\\?')(?:\\s|/\\*.*\\*/|//.*|#.*)*(?:(?:::|\\.|->)(?:\\s|/\\*.*\\*/|//.*|#.*)*\\w+(?:\\(.*\\))?)?,)*(?:(?:\\s|/\\*.*\\*/|//.*|#.*)*(?:\\$\\w+|[A-Z\\d]\\w*|\\w+\\(.*\\)|\\\\?\"(?:[^\"]|\\\\\"|\"\"|\"\\+\")*\\\\?\"|\\\\?'(?:[^']|''|'\\+')*\\\\?')(?:\\s|/\\*.*\\*/|//.*|#.*)*(?:(?:::|\\.|->)(?:\\s|/\\*.*\\*/|//.*|#.*)*\\w+(?:\\(.*\\))?)?)?\\)\\s*(?:[;\\.)}\\]|\\\\]|\\?>|%>|$)",
             "options": {
               "case_sensitive": true,
               "min_length": 5
@@ -2844,7 +2864,8 @@
         "category": "attack_attempt",
         "cwe": "502",
         "capec": "1000/152/586",
-        "confidence": "1"
+        "confidence": "1",
+        "module": "waf"
       },
       "conditions": [
         {
@@ -2891,7 +2912,8 @@
         "crs_id": "933200",
         "category": "attack_attempt",
         "cwe": "502",
-        "capec": "1000/152/586"
+        "capec": "1000/152/586",
+        "module": "waf"
       },
       "conditions": [
         {
@@ -2937,7 +2959,8 @@
         "crs_id": "934100",
         "category": "attack_attempt",
         "cwe": "94",
-        "capec": "1000/152/242"
+        "capec": "1000/152/242",
+        "module": "waf"
       },
       "conditions": [
         {
@@ -2982,7 +3005,8 @@
         "category": "attack_attempt",
         "confidence": "1",
         "cwe": "94",
-        "capec": "1000/152/242"
+        "capec": "1000/152/242",
+        "module": "waf"
       },
       "conditions": [
         {
@@ -3024,7 +3048,8 @@
         "category": "attack_attempt",
         "cwe": "80",
         "capec": "1000/152/242/63/591",
-        "confidence": "1"
+        "confidence": "1",
+        "module": "waf"
       },
       "conditions": [
         {
@@ -3081,7 +3106,8 @@
         "category": "attack_attempt",
         "cwe": "83",
         "capec": "1000/152/242/63/591/243",
-        "confidence": "1"
+        "confidence": "1",
+        "module": "waf"
       },
       "conditions": [
         {
@@ -3140,7 +3166,8 @@
         "category": "attack_attempt",
         "cwe": "84",
         "capec": "1000/152/242/63/591/244",
-        "confidence": "1"
+        "confidence": "1",
+        "module": "waf"
       },
       "conditions": [
         {
@@ -3199,7 +3226,8 @@
         "category": "attack_attempt",
         "cwe": "83",
         "capec": "1000/152/242/63/591/243",
-        "confidence": "1"
+        "confidence": "1",
+        "module": "waf"
       },
       "conditions": [
         {
@@ -3257,7 +3285,8 @@
         "crs_id": "941180",
         "category": "attack_attempt",
         "cwe": "79",
-        "capec": "1000/152/242/63/591"
+        "capec": "1000/152/242/63/591",
+        "module": "waf"
       },
       "conditions": [
         {
@@ -3311,7 +3340,8 @@
         "category": "attack_attempt",
         "cwe": "80",
         "capec": "1000/152/242/63/591",
-        "confidence": "1"
+        "confidence": "1",
+        "module": "waf"
       },
       "conditions": [
         {
@@ -3358,7 +3388,8 @@
         "category": "attack_attempt",
         "cwe": "80",
         "capec": "1000/152/242/63/591",
-        "confidence": "1"
+        "confidence": "1",
+        "module": "waf"
       },
       "conditions": [
         {
@@ -3405,7 +3436,8 @@
         "category": "attack_attempt",
         "cwe": "80",
         "capec": "1000/152/242/63/591",
-        "confidence": "1"
+        "confidence": "1",
+        "module": "waf"
       },
       "conditions": [
         {
@@ -3452,7 +3484,8 @@
         "category": "attack_attempt",
         "cwe": "83",
         "capec": "1000/152/242/63/591/243",
-        "confidence": "1"
+        "confidence": "1",
+        "module": "waf"
       },
       "conditions": [
         {
@@ -3498,7 +3531,8 @@
         "category": "attack_attempt",
         "cwe": "83",
         "capec": "1000/152/242/63/591/243",
-        "confidence": "1"
+        "confidence": "1",
+        "module": "waf"
       },
       "conditions": [
         {
@@ -3545,7 +3579,8 @@
         "crs_id": "941270",
         "category": "attack_attempt",
         "cwe": "83",
-        "capec": "1000/152/242/63/591/243"
+        "capec": "1000/152/242/63/591/243",
+        "module": "waf"
       },
       "conditions": [
         {
@@ -3588,7 +3623,8 @@
         "category": "attack_attempt",
         "cwe": "83",
         "capec": "1000/152/242/63/591/243",
-        "confidence": "1"
+        "confidence": "1",
+        "module": "waf"
       },
       "conditions": [
         {
@@ -3634,7 +3670,8 @@
         "category": "attack_attempt",
         "cwe": "83",
         "capec": "1000/152/242/63/591/243",
-        "confidence": "1"
+        "confidence": "1",
+        "module": "waf"
       },
       "conditions": [
         {
@@ -3680,7 +3717,8 @@
         "category": "attack_attempt",
         "cwe": "83",
         "capec": "1000/152/242/63/591/243",
-        "confidence": "1"
+        "confidence": "1",
+        "module": "waf"
       },
       "conditions": [
         {
@@ -3726,7 +3764,8 @@
         "category": "attack_attempt",
         "cwe": "87",
         "capec": "1000/152/242/63/591/199",
-        "confidence": "1"
+        "confidence": "1",
+        "module": "waf"
       },
       "conditions": [
         {
@@ -3770,7 +3809,8 @@
         "crs_id": "941360",
         "category": "attack_attempt",
         "cwe": "87",
-        "capec": "1000/152/242/63/591/199"
+        "capec": "1000/152/242/63/591/199",
+        "module": "waf"
       },
       "conditions": [
         {
@@ -3815,7 +3855,8 @@
         "category": "attack_attempt",
         "confidence": "1",
         "cwe": "79",
-        "capec": "1000/152/242/63/591"
+        "capec": "1000/152/242/63/591",
+        "module": "waf"
       },
       "conditions": [
         {
@@ -3859,7 +3900,8 @@
         "crs_id": "942100",
         "category": "attack_attempt",
         "cwe": "89",
-        "capec": "1000/152/248/66"
+        "capec": "1000/152/248/66",
+        "module": "waf"
       },
       "conditions": [
         {
@@ -3898,7 +3940,8 @@
         "category": "attack_attempt",
         "cwe": "89",
         "capec": "1000/152/248/66/7",
-        "confidence": "1"
+        "confidence": "1",
+        "module": "waf"
       },
       "conditions": [
         {
@@ -3943,7 +3986,8 @@
         "category": "attack_attempt",
         "cwe": "89",
         "capec": "1000/152/248/66/7",
-        "confidence": "1"
+        "confidence": "1",
+        "module": "waf"
       },
       "conditions": [
         {
@@ -3986,7 +4030,8 @@
         "crs_id": "942250",
         "category": "attack_attempt",
         "cwe": "89",
-        "capec": "1000/152/248/66"
+        "capec": "1000/152/248/66",
+        "module": "waf"
       },
       "conditions": [
         {
@@ -4030,7 +4075,8 @@
         "crs_id": "942270",
         "category": "attack_attempt",
         "cwe": "89",
-        "capec": "1000/152/248/66"
+        "capec": "1000/152/248/66",
+        "module": "waf"
       },
       "conditions": [
         {
@@ -4074,7 +4120,8 @@
         "category": "attack_attempt",
         "cwe": "89",
         "capec": "1000/152/248/66/7",
-        "confidence": "1"
+        "confidence": "1",
+        "module": "waf"
       },
       "conditions": [
         {
@@ -4117,7 +4164,8 @@
         "crs_id": "942290",
         "category": "attack_attempt",
         "cwe": "943",
-        "capec": "1000/152/248/676"
+        "capec": "1000/152/248/676",
+        "module": "waf"
       },
       "conditions": [
         {
@@ -4163,7 +4211,8 @@
         "crs_id": "942360",
         "category": "attack_attempt",
         "cwe": "89",
-        "capec": "1000/152/248/66/470"
+        "capec": "1000/152/248/66/470",
+        "module": "waf"
       },
       "conditions": [
         {
@@ -4206,7 +4255,8 @@
         "crs_id": "942500",
         "category": "attack_attempt",
         "cwe": "89",
-        "capec": "1000/152/248/66"
+        "capec": "1000/152/248/66",
+        "module": "waf"
       },
       "conditions": [
         {
@@ -4251,7 +4301,8 @@
         "category": "attack_attempt",
         "cwe": "384",
         "capec": "1000/225/21/593/61",
-        "confidence": "1"
+        "confidence": "1",
+        "module": "waf"
       },
       "conditions": [
         {
@@ -4296,7 +4347,8 @@
         "category": "attack_attempt",
         "cwe": "94",
         "capec": "1000/152/242",
-        "confidence": "1"
+        "confidence": "1",
+        "module": "waf"
       },
       "conditions": [
         {
@@ -4344,7 +4396,8 @@
         "type": "java_code_injection",
         "category": "attack_attempt",
         "cwe": "94",
-        "capec": "1000/152/242"
+        "capec": "1000/152/242",
+        "module": "waf"
       },
       "conditions": [
         {
@@ -4391,7 +4444,8 @@
         "crs_id": "944130",
         "category": "attack_attempt",
         "cwe": "94",
-        "capec": "1000/152/242"
+        "capec": "1000/152/242",
+        "module": "waf"
       },
       "conditions": [
         {
@@ -4529,7 +4583,8 @@
         "type": "nosql_injection",
         "category": "attack_attempt",
         "cwe": "943",
-        "capec": "1000/152/248/676"
+        "capec": "1000/152/248/676",
+        "module": "waf"
       },
       "conditions": [
         {
@@ -4573,7 +4628,8 @@
         "type": "java_code_injection",
         "category": "attack_attempt",
         "cwe": "94",
-        "capec": "1000/152/242"
+        "capec": "1000/152/242",
+        "module": "waf"
       },
       "conditions": [
         {
@@ -4619,7 +4675,8 @@
         "category": "attack_attempt",
         "cwe": "94",
         "capec": "1000/152/242",
-        "confidence": "1"
+        "confidence": "1",
+        "module": "waf"
       },
       "conditions": [
         {
@@ -4695,7 +4752,8 @@
         "category": "attack_attempt",
         "cwe": "1321",
         "capec": "1000/152/242",
-        "confidence": "1"
+        "confidence": "1",
+        "module": "waf"
       },
       "conditions": [
         {
@@ -4725,7 +4783,8 @@
         "category": "attack_attempt",
         "cwe": "1321",
         "capec": "1000/152/242",
-        "confidence": "1"
+        "confidence": "1",
+        "module": "waf"
       },
       "conditions": [
         {
@@ -4769,7 +4828,8 @@
         "category": "attack_attempt",
         "cwe": "1336",
         "capec": "1000/152/242/19",
-        "confidence": "1"
+        "confidence": "1",
+        "module": "waf"
       },
       "conditions": [
         {
@@ -4813,7 +4873,8 @@
         "tool_name": "BurpCollaborator",
         "cwe": "200",
         "capec": "1000/118/169",
-        "confidence": "1"
+        "confidence": "1",
+        "module": "waf"
       },
       "conditions": [
         {
@@ -4857,7 +4918,8 @@
         "tool_name": "Qualys",
         "cwe": "200",
         "capec": "1000/118/169",
-        "confidence": "0"
+        "confidence": "0",
+        "module": "waf"
       },
       "conditions": [
         {
@@ -4901,7 +4963,8 @@
         "tool_name": "Probely",
         "cwe": "200",
         "capec": "1000/118/169",
-        "confidence": "0"
+        "confidence": "0",
+        "module": "waf"
       },
       "conditions": [
         {
@@ -4944,7 +5007,8 @@
         "category": "attack_attempt",
         "cwe": "200",
         "capec": "1000/118/169",
-        "confidence": "1"
+        "confidence": "1",
+        "module": "waf"
       },
       "conditions": [
         {
@@ -4987,7 +5051,8 @@
         "category": "attack_attempt",
         "cwe": "200",
         "capec": "1000/118/169",
-        "confidence": "0"
+        "confidence": "0",
+        "module": "waf"
       },
       "conditions": [
         {
@@ -5031,7 +5096,8 @@
         "tool_name": "Rapid7",
         "cwe": "200",
         "capec": "1000/118/169",
-        "confidence": "0"
+        "confidence": "0",
+        "module": "waf"
       },
       "conditions": [
         {
@@ -5075,7 +5141,8 @@
         "tool_name": "interact.sh",
         "cwe": "200",
         "capec": "1000/118/169",
-        "confidence": "1"
+        "confidence": "1",
+        "module": "waf"
       },
       "conditions": [
         {
@@ -5119,7 +5186,8 @@
         "tool_name": "Netsparker",
         "cwe": "200",
         "capec": "1000/118/169",
-        "confidence": "0"
+        "confidence": "0",
+        "module": "waf"
       },
       "conditions": [
         {
@@ -5167,7 +5235,8 @@
         "tool_name": "WhiteHatSecurity",
         "cwe": "200",
         "capec": "1000/118/169",
-        "confidence": "0"
+        "confidence": "0",
+        "module": "waf"
       },
       "conditions": [
         {
@@ -5215,7 +5284,8 @@
         "tool_name": "Nessus",
         "cwe": "200",
         "capec": "1000/118/169",
-        "confidence": "0"
+        "confidence": "0",
+        "module": "waf"
       },
       "conditions": [
         {
@@ -5263,7 +5333,8 @@
         "tool_name": "Watchtowr",
         "cwe": "200",
         "capec": "1000/118/169",
-        "confidence": "0"
+        "confidence": "0",
+        "module": "waf"
       },
       "conditions": [
         {
@@ -5311,7 +5382,8 @@
         "tool_name": "AppCheckNG",
         "cwe": "200",
         "capec": "1000/118/169",
-        "confidence": "0"
+        "confidence": "0",
+        "module": "waf"
       },
       "conditions": [
         {
@@ -5358,7 +5430,8 @@
         "category": "attack_attempt",
         "cwe": "287",
         "capec": "1000/225/115",
-        "confidence": "0"
+        "confidence": "0",
+        "module": "waf"
       },
       "conditions": [
         {
@@ -5392,7 +5465,8 @@
         "category": "attack_attempt",
         "cwe": "98",
         "capec": "1000/152/175/253/193",
-        "confidence": "1"
+        "confidence": "1",
+        "module": "waf"
       },
       "conditions": [
         {
@@ -5436,7 +5510,8 @@
         "category": "attack_attempt",
         "cwe": "77",
         "capec": "1000/152/248/88",
-        "confidence": "0"
+        "confidence": "0",
+        "module": "waf"
       },
       "conditions": [
         {
@@ -5483,7 +5558,8 @@
         "category": "attack_attempt",
         "cwe": "91",
         "capec": "1000/152/248/250",
-        "confidence": "1"
+        "confidence": "1",
+        "module": "waf"
       },
       "conditions": [
         {
@@ -5521,7 +5597,8 @@
         "category": "attack_attempt",
         "cwe": "83",
         "capec": "1000/152/242/63/591/243",
-        "confidence": "1"
+        "confidence": "1",
+        "module": "waf"
       },
       "conditions": [
         {
@@ -5579,7 +5656,8 @@
         "category": "attack_attempt",
         "cwe": "83",
         "capec": "1000/152/242/63/591/243",
-        "confidence": "1"
+        "confidence": "1",
+        "module": "waf"
       },
       "conditions": [
         {
@@ -5866,7 +5944,8 @@
         "category": "attack_attempt",
         "cwe": "200",
         "capec": "1000/118/169",
-        "confidence": "1"
+        "confidence": "1",
+        "module": "waf"
       },
       "conditions": [
         {
@@ -5908,7 +5987,8 @@
         "category": "attack_attempt",
         "cwe": "200",
         "capec": "1000/118/169",
-        "confidence": "1"
+        "confidence": "1",
+        "module": "waf"
       },
       "conditions": [
         {
@@ -5950,7 +6030,8 @@
         "category": "attack_attempt",
         "cwe": "200",
         "capec": "1000/118/169",
-        "confidence": "1"
+        "confidence": "1",
+        "module": "waf"
       },
       "conditions": [
         {
@@ -5992,7 +6073,8 @@
         "category": "attack_attempt",
         "cwe": "200",
         "capec": "1000/118/169",
-        "confidence": "1"
+        "confidence": "1",
+        "module": "waf"
       },
       "conditions": [
         {
@@ -6034,7 +6116,8 @@
         "category": "attack_attempt",
         "cwe": "200",
         "capec": "1000/118/169",
-        "confidence": "1"
+        "confidence": "1",
+        "module": "waf"
       },
       "conditions": [
         {
@@ -6059,7 +6142,7 @@
                 "address": "server.request.uri.raw"
               }
             ],
-            "regex": "\\.(cgi|bat|dll|exe|key|cert|crt|pem|der|pkcs|pkcs|pkcs[0-9]*|nsf|jsa|war|java|class|vb|vba|so|git|svn|hg|cvs)([^a-zA-Z0-9_]|$)",
+            "regex": "\\.(cgi|bat|dll|exe|key|cert|crt|pem|der|pkcs|pkcs|pkcs[0-9]*|nsf|jsa|war|java|class|vb|vba|so|git|svn|hg|cvs)([?#&/]|$)",
             "options": {
               "case_sensitive": false
             }
@@ -6076,7 +6159,8 @@
         "category": "attack_attempt",
         "cwe": "200",
         "capec": "1000/118/169",
-        "confidence": "1"
+        "confidence": "1",
+        "module": "waf"
       },
       "conditions": [
         {
@@ -6118,7 +6202,8 @@
         "category": "attack_attempt",
         "cwe": "200",
         "capec": "1000/118/169",
-        "confidence": "1"
+        "confidence": "1",
+        "module": "waf"
       },
       "conditions": [
         {
@@ -6160,7 +6245,8 @@
         "category": "attack_attempt",
         "cwe": "200",
         "capec": "1000/118/169",
-        "confidence": "1"
+        "confidence": "1",
+        "module": "waf"
       },
       "conditions": [
         {
@@ -6202,7 +6288,8 @@
         "category": "attack_attempt",
         "cwe": "200",
         "capec": "1000/118/169",
-        "confidence": "0"
+        "confidence": "0",
+        "module": "waf"
       },
       "conditions": [
         {
@@ -6276,7 +6363,7 @@
               }
             ]
           },
-          "operator": "lfi_detector"
+          "operator": "lfi_detector@v2"
         }
       ],
       "transformers": [],
@@ -6286,7 +6373,7 @@
     },
     {
       "id": "rasp-932-100",
-      "name": "Shell injection exploit",
+      "name": "Shell command injection exploit",
       "tags": {
         "type": "command_injection",
         "category": "vulnerability_trigger",
@@ -6325,6 +6412,54 @@
             ]
           },
           "operator": "shi_detector"
+        }
+      ],
+      "transformers": [],
+      "on_match": [
+        "stack_trace"
+      ]
+    },
+    {
+      "id": "rasp-932-110",
+      "name": "OS command injection exploit",
+      "tags": {
+        "type": "command_injection",
+        "category": "vulnerability_trigger",
+        "cwe": "77",
+        "capec": "1000/152/248/88",
+        "confidence": "0",
+        "module": "rasp"
+      },
+      "conditions": [
+        {
+          "parameters": {
+            "resource": [
+              {
+                "address": "server.sys.exec.cmd"
+              }
+            ],
+            "params": [
+              {
+                "address": "server.request.query"
+              },
+              {
+                "address": "server.request.body"
+              },
+              {
+                "address": "server.request.path_params"
+              },
+              {
+                "address": "grpc.server.request.message"
+              },
+              {
+                "address": "graphql.server.all_resolvers"
+              },
+              {
+                "address": "graphql.server.resolver"
+              }
+            ]
+          },
+          "operator": "cmdi_detector"
         }
       ],
       "transformers": [],
@@ -6422,7 +6557,7 @@
               }
             ]
           },
-          "operator": "sqli_detector"
+          "operator": "sqli_detector@v2"
         }
       ],
       "transformers": [],
@@ -6438,7 +6573,8 @@
         "category": "attack_attempt",
         "cwe": "918",
         "capec": "1000/225/115/664",
-        "confidence": "1"
+        "confidence": "1",
+        "module": "waf"
       },
       "conditions": [
         {
@@ -6482,7 +6618,8 @@
         "type": "js_code_injection",
         "category": "attack_attempt",
         "cwe": "94",
-        "capec": "1000/152/242"
+        "capec": "1000/152/242",
+        "module": "waf"
       },
       "conditions": [
         {
@@ -6527,7 +6664,8 @@
         "category": "attack_attempt",
         "cwe": "78",
         "capec": "1000/152/248/88",
-        "confidence": "1"
+        "confidence": "1",
+        "module": "waf"
       },
       "conditions": [
         {
@@ -6570,7 +6708,8 @@
         "category": "attack_attempt",
         "cwe": "78",
         "capec": "1000/152/248/88",
-        "confidence": "1"
+        "confidence": "1",
+        "module": "waf"
       },
       "conditions": [
         {
@@ -6615,7 +6754,8 @@
         "category": "attack_attempt",
         "cwe": "78",
         "capec": "1000/152/248/88",
-        "confidence": "1"
+        "confidence": "1",
+        "module": "waf"
       },
       "conditions": [
         {
@@ -6658,7 +6798,8 @@
         "category": "attack_attempt",
         "cwe": "918",
         "capec": "1000/225/115/664",
-        "confidence": "1"
+        "confidence": "1",
+        "module": "waf"
       },
       "conditions": [
         {
@@ -6701,7 +6842,8 @@
         "category": "attack_attempt",
         "cwe": "918",
         "capec": "1000/225/115/664",
-        "confidence": "0"
+        "confidence": "0",
+        "module": "waf"
       },
       "conditions": [
         {
@@ -6743,7 +6885,8 @@
         "category": "attack_attempt",
         "cwe": "918",
         "capec": "1000/225/115/664",
-        "confidence": "0"
+        "confidence": "0",
+        "module": "waf"
       },
       "conditions": [
         {
@@ -6785,7 +6928,8 @@
         "category": "attack_attempt",
         "cwe": "918",
         "capec": "1000/225/115/664",
-        "confidence": "1"
+        "confidence": "1",
+        "module": "waf"
       },
       "conditions": [
         {
@@ -6828,7 +6972,8 @@
         "category": "attack_attempt",
         "cwe": "918",
         "capec": "1000/225/115/664",
-        "confidence": "0"
+        "confidence": "0",
+        "module": "waf"
       },
       "conditions": [
         {
@@ -6870,7 +7015,8 @@
         "category": "attack_attempt",
         "cwe": "94",
         "capec": "1000/152/242",
-        "confidence": "1"
+        "confidence": "1",
+        "module": "waf"
       },
       "conditions": [
         {
@@ -6916,7 +7062,8 @@
         "cwe": "200",
         "capec": "1000/118/169",
         "tool_name": "Joomla exploitation tool",
-        "confidence": "1"
+        "confidence": "1",
+        "module": "waf"
       },
       "conditions": [
         {
@@ -6945,7 +7092,8 @@
         "cwe": "200",
         "capec": "1000/118/169",
         "tool_name": "Nessus",
-        "confidence": "1"
+        "confidence": "1",
+        "module": "waf"
       },
       "conditions": [
         {
@@ -6974,7 +7122,8 @@
         "cwe": "200",
         "capec": "1000/118/169",
         "tool_name": "Arachni",
-        "confidence": "1"
+        "confidence": "1",
+        "module": "waf"
       },
       "conditions": [
         {
@@ -7003,7 +7152,8 @@
         "cwe": "200",
         "capec": "1000/118/169",
         "tool_name": "Jorgee",
-        "confidence": "1"
+        "confidence": "1",
+        "module": "waf"
       },
       "conditions": [
         {
@@ -7032,7 +7182,8 @@
         "cwe": "200",
         "capec": "1000/118/169",
         "tool_name": "Probely",
-        "confidence": "0"
+        "confidence": "0",
+        "module": "waf"
       },
       "conditions": [
         {
@@ -7061,7 +7212,8 @@
         "cwe": "200",
         "capec": "1000/118/169",
         "tool_name": "Metis",
-        "confidence": "1"
+        "confidence": "1",
+        "module": "waf"
       },
       "conditions": [
         {
@@ -7090,7 +7242,8 @@
         "cwe": "200",
         "capec": "1000/118/169",
         "tool_name": "SQLPowerInjector",
-        "confidence": "1"
+        "confidence": "1",
+        "module": "waf"
       },
       "conditions": [
         {
@@ -7119,7 +7272,8 @@
         "cwe": "200",
         "capec": "1000/118/169",
         "tool_name": "N-Stealth",
-        "confidence": "1"
+        "confidence": "1",
+        "module": "waf"
       },
       "conditions": [
         {
@@ -7148,7 +7302,8 @@
         "cwe": "200",
         "capec": "1000/118/169",
         "tool_name": "Brutus",
-        "confidence": "1"
+        "confidence": "1",
+        "module": "waf"
       },
       "conditions": [
         {
@@ -7176,7 +7331,8 @@
         "category": "attack_attempt",
         "cwe": "200",
         "capec": "1000/118/169",
-        "confidence": "1"
+        "confidence": "1",
+        "module": "waf"
       },
       "conditions": [
         {
@@ -7205,7 +7361,8 @@
         "cwe": "200",
         "capec": "1000/118/169",
         "tool_name": "Netsparker",
-        "confidence": "0"
+        "confidence": "0",
+        "module": "waf"
       },
       "conditions": [
         {
@@ -7234,7 +7391,8 @@
         "cwe": "200",
         "capec": "1000/118/169",
         "tool_name": "JAASCois",
-        "confidence": "1"
+        "confidence": "1",
+        "module": "waf"
       },
       "conditions": [
         {
@@ -7263,7 +7421,8 @@
         "cwe": "200",
         "capec": "1000/118/169",
         "tool_name": "Nsauditor",
-        "confidence": "1"
+        "confidence": "1",
+        "module": "waf"
       },
       "conditions": [
         {
@@ -7292,7 +7451,8 @@
         "cwe": "200",
         "capec": "1000/118/169",
         "tool_name": "Paros",
-        "confidence": "1"
+        "confidence": "1",
+        "module": "waf"
       },
       "conditions": [
         {
@@ -7321,7 +7481,8 @@
         "cwe": "200",
         "capec": "1000/118/169",
         "tool_name": "DirBuster",
-        "confidence": "1"
+        "confidence": "1",
+        "module": "waf"
       },
       "conditions": [
         {
@@ -7350,7 +7511,8 @@
         "cwe": "200",
         "capec": "1000/118/169",
         "tool_name": "Pangolin",
-        "confidence": "1"
+        "confidence": "1",
+        "module": "waf"
       },
       "conditions": [
         {
@@ -7379,7 +7541,8 @@
         "cwe": "200",
         "capec": "1000/118/169",
         "tool_name": "Qualys",
-        "confidence": "0"
+        "confidence": "0",
+        "module": "waf"
       },
       "conditions": [
         {
@@ -7408,7 +7571,8 @@
         "cwe": "200",
         "capec": "1000/118/169",
         "tool_name": "SQLNinja",
-        "confidence": "1"
+        "confidence": "1",
+        "module": "waf"
       },
       "conditions": [
         {
@@ -7437,7 +7601,8 @@
         "cwe": "200",
         "capec": "1000/118/169",
         "tool_name": "Nikto",
-        "confidence": "1"
+        "confidence": "1",
+        "module": "waf"
       },
       "conditions": [
         {
@@ -7466,7 +7631,8 @@
         "cwe": "200",
         "capec": "1000/118/169",
         "tool_name": "BlackWidow",
-        "confidence": "1"
+        "confidence": "1",
+        "module": "waf"
       },
       "conditions": [
         {
@@ -7495,7 +7661,8 @@
         "cwe": "200",
         "capec": "1000/118/169",
         "tool_name": "Grendel-Scan",
-        "confidence": "1"
+        "confidence": "1",
+        "module": "waf"
       },
       "conditions": [
         {
@@ -7524,7 +7691,8 @@
         "cwe": "200",
         "capec": "1000/118/169",
         "tool_name": "Havij",
-        "confidence": "1"
+        "confidence": "1",
+        "module": "waf"
       },
       "conditions": [
         {
@@ -7553,7 +7721,8 @@
         "cwe": "200",
         "capec": "1000/118/169",
         "tool_name": "w3af",
-        "confidence": "1"
+        "confidence": "1",
+        "module": "waf"
       },
       "conditions": [
         {
@@ -7582,7 +7751,8 @@
         "cwe": "200",
         "capec": "1000/118/169",
         "tool_name": "Nmap",
-        "confidence": "1"
+        "confidence": "1",
+        "module": "waf"
       },
       "conditions": [
         {
@@ -7611,7 +7781,8 @@
         "cwe": "200",
         "capec": "1000/118/169",
         "tool_name": "Nessus",
-        "confidence": "1"
+        "confidence": "1",
+        "module": "waf"
       },
       "conditions": [
         {
@@ -7640,7 +7811,8 @@
         "cwe": "200",
         "capec": "1000/118/169",
         "tool_name": "EvilScanner",
-        "confidence": "1"
+        "confidence": "1",
+        "module": "waf"
       },
       "conditions": [
         {
@@ -7669,7 +7841,8 @@
         "cwe": "200",
         "capec": "1000/118/169",
         "tool_name": "WebFuck",
-        "confidence": "1"
+        "confidence": "1",
+        "module": "waf"
       },
       "conditions": [
         {
@@ -7698,7 +7871,8 @@
         "cwe": "200",
         "capec": "1000/118/169",
         "tool_name": "OpenVAS",
-        "confidence": "1"
+        "confidence": "1",
+        "module": "waf"
       },
       "conditions": [
         {
@@ -7727,7 +7901,8 @@
         "cwe": "200",
         "capec": "1000/118/169",
         "tool_name": "Spider-Pig",
-        "confidence": "1"
+        "confidence": "1",
+        "module": "waf"
       },
       "conditions": [
         {
@@ -7756,7 +7931,8 @@
         "cwe": "200",
         "capec": "1000/118/169",
         "tool_name": "Zgrab",
-        "confidence": "1"
+        "confidence": "1",
+        "module": "waf"
       },
       "conditions": [
         {
@@ -7785,7 +7961,8 @@
         "cwe": "200",
         "capec": "1000/118/169",
         "tool_name": "Zmeu",
-        "confidence": "1"
+        "confidence": "1",
+        "module": "waf"
       },
       "conditions": [
         {
@@ -7814,7 +7991,8 @@
         "cwe": "200",
         "capec": "1000/118/169",
         "tool_name": "GoogleSecurityScanner",
-        "confidence": "0"
+        "confidence": "0",
+        "module": "waf"
       },
       "conditions": [
         {
@@ -7843,7 +8021,8 @@
         "cwe": "200",
         "capec": "1000/118/169",
         "tool_name": "Commix",
-        "confidence": "1"
+        "confidence": "1",
+        "module": "waf"
       },
       "conditions": [
         {
@@ -7872,7 +8051,8 @@
         "cwe": "200",
         "capec": "1000/118/169",
         "tool_name": "Gobuster",
-        "confidence": "1"
+        "confidence": "1",
+        "module": "waf"
       },
       "conditions": [
         {
@@ -7901,7 +8081,8 @@
         "cwe": "200",
         "capec": "1000/118/169",
         "tool_name": "CGIchk",
-        "confidence": "1"
+        "confidence": "1",
+        "module": "waf"
       },
       "conditions": [
         {
@@ -7930,7 +8111,8 @@
         "cwe": "200",
         "capec": "1000/118/169",
         "tool_name": "FFUF",
-        "confidence": "1"
+        "confidence": "1",
+        "module": "waf"
       },
       "conditions": [
         {
@@ -7959,7 +8141,8 @@
         "cwe": "200",
         "capec": "1000/118/169",
         "tool_name": "Nuclei",
-        "confidence": "1"
+        "confidence": "1",
+        "module": "waf"
       },
       "conditions": [
         {
@@ -7988,7 +8171,8 @@
         "cwe": "200",
         "capec": "1000/118/169",
         "tool_name": "Tsunami",
-        "confidence": "1"
+        "confidence": "1",
+        "module": "waf"
       },
       "conditions": [
         {
@@ -8017,7 +8201,8 @@
         "cwe": "200",
         "capec": "1000/118/169",
         "tool_name": "Nimbostratus",
-        "confidence": "1"
+        "confidence": "1",
+        "module": "waf"
       },
       "conditions": [
         {
@@ -8046,7 +8231,8 @@
         "cwe": "200",
         "capec": "1000/118/169",
         "tool_name": "Datadog Canary Test",
-        "confidence": "1"
+        "confidence": "1",
+        "module": "waf"
       },
       "conditions": [
         {
@@ -8081,7 +8267,8 @@
         "cwe": "200",
         "capec": "1000/118/169",
         "tool_name": "Datadog Canary Test",
-        "confidence": "1"
+        "confidence": "1",
+        "module": "waf"
       },
       "conditions": [
         {
@@ -8119,7 +8306,8 @@
         "cwe": "200",
         "capec": "1000/118/169",
         "tool_name": "AlertLogic",
-        "confidence": "0"
+        "confidence": "0",
+        "module": "waf"
       },
       "conditions": [
         {
@@ -8148,7 +8336,8 @@
         "cwe": "200",
         "capec": "1000/118/169",
         "tool_name": "wfuzz",
-        "confidence": "1"
+        "confidence": "1",
+        "module": "waf"
       },
       "conditions": [
         {
@@ -8177,7 +8366,8 @@
         "cwe": "200",
         "capec": "1000/118/169",
         "tool_name": "Detectify",
-        "confidence": "0"
+        "confidence": "0",
+        "module": "waf"
       },
       "conditions": [
         {
@@ -8206,7 +8396,8 @@
         "cwe": "200",
         "capec": "1000/118/169",
         "tool_name": "BSQLBF",
-        "confidence": "1"
+        "confidence": "1",
+        "module": "waf"
       },
       "conditions": [
         {
@@ -8235,7 +8426,8 @@
         "cwe": "200",
         "capec": "1000/118/169",
         "tool_name": "masscan",
-        "confidence": "1"
+        "confidence": "1",
+        "module": "waf"
       },
       "conditions": [
         {
@@ -8264,7 +8456,8 @@
         "cwe": "200",
         "capec": "1000/118/169",
         "tool_name": "WPScan",
-        "confidence": "1"
+        "confidence": "1",
+        "module": "waf"
       },
       "conditions": [
         {
@@ -8293,7 +8486,8 @@
         "cwe": "200",
         "capec": "1000/118/169",
         "tool_name": "Aon",
-        "confidence": "0"
+        "confidence": "0",
+        "module": "waf"
       },
       "conditions": [
         {
@@ -8322,7 +8516,8 @@
         "cwe": "200",
         "capec": "1000/118/169",
         "tool_name": "feroxbuster",
-        "confidence": "1"
+        "confidence": "1",
+        "module": "waf"
       },
       "conditions": [
         {
@@ -8350,7 +8545,8 @@
         "category": "attack_attempt",
         "cwe": "200",
         "capec": "1000/118/169",
-        "confidence": "1"
+        "confidence": "1",
+        "module": "waf"
       },
       "conditions": [
         {
@@ -8382,7 +8578,8 @@
         "cwe": "200",
         "capec": "1000/118/169",
         "tool_name": "SQLmap",
-        "confidence": "1"
+        "confidence": "1",
+        "module": "waf"
       },
       "conditions": [
         {
@@ -8411,7 +8608,8 @@
         "cwe": "200",
         "capec": "1000/118/169",
         "tool_name": "Skipfish",
-        "confidence": "1"
+        "confidence": "1",
+        "module": "waf"
       },
       "conditions": [
         {

--- a/lib/datadog/appsec/assets/waf_rules/strict.json
+++ b/lib/datadog/appsec/assets/waf_rules/strict.json
@@ -1,7 +1,7 @@
 {
   "version": "2.2",
   "metadata": {
-    "rules_version": "1.13.1"
+    "rules_version": "1.13.3"
   },
   "rules": [
     {
@@ -10,7 +10,8 @@
       "tags": {
         "type": "security_scanner",
         "crs_id": "913100",
-        "category": "attack_attempt"
+        "category": "attack_attempt",
+        "module": "waf"
       },
       "conditions": [
         {
@@ -84,7 +85,8 @@
       "tags": {
         "type": "http_protocol_violation",
         "crs_id": "921120",
-        "category": "attack_attempt"
+        "category": "attack_attempt",
+        "module": "waf"
       },
       "conditions": [
         {
@@ -127,7 +129,8 @@
         "crs_id": "921140",
         "category": "attack_attempt",
         "capec": "1000/210/272/220/273",
-        "cwe": "113"
+        "cwe": "113",
+        "module": "waf"
       },
       "conditions": [
         {
@@ -154,7 +157,8 @@
       "tags": {
         "type": "command_injection",
         "crs_id": "932100",
-        "category": "attack_attempt"
+        "category": "attack_attempt",
+        "module": "waf"
       },
       "conditions": [
         {
@@ -193,7 +197,8 @@
       "tags": {
         "type": "command_injection",
         "crs_id": "932115",
-        "category": "attack_attempt"
+        "category": "attack_attempt",
+        "module": "waf"
       },
       "conditions": [
         {
@@ -690,7 +695,8 @@
       "tags": {
         "type": "command_injection",
         "crs_id": "932130",
-        "category": "attack_attempt"
+        "category": "attack_attempt",
+        "module": "waf"
       },
       "conditions": [
         {
@@ -729,7 +735,8 @@
       "tags": {
         "type": "command_injection",
         "crs_id": "932150",
-        "category": "attack_attempt"
+        "category": "attack_attempt",
+        "module": "waf"
       },
       "conditions": [
         {
@@ -768,7 +775,8 @@
       "tags": {
         "type": "php_code_injection",
         "crs_id": "933110",
-        "category": "attack_attempt"
+        "category": "attack_attempt",
+        "module": "waf"
       },
       "conditions": [
         {
@@ -818,7 +826,8 @@
       "tags": {
         "type": "php_code_injection",
         "crs_id": "933180",
-        "category": "attack_attempt"
+        "category": "attack_attempt",
+        "module": "waf"
       },
       "conditions": [
         {
@@ -857,7 +866,8 @@
       "tags": {
         "type": "php_code_injection",
         "crs_id": "933210",
-        "category": "attack_attempt"
+        "category": "attack_attempt",
+        "module": "waf"
       },
       "conditions": [
         {
@@ -897,7 +907,8 @@
         "type": "xss",
         "crs_id": "941100",
         "category": "attack_attempt",
-        "cwe": "79"
+        "cwe": "79",
+        "module": "waf"
       },
       "conditions": [
         {
@@ -948,7 +959,8 @@
       "tags": {
         "type": "xss",
         "crs_id": "941130",
-        "category": "attack_attempt"
+        "category": "attack_attempt",
+        "module": "waf"
       },
       "conditions": [
         {
@@ -994,7 +1006,8 @@
       "tags": {
         "type": "xss",
         "crs_id": "941150",
-        "category": "attack_attempt"
+        "category": "attack_attempt",
+        "module": "waf"
       },
       "conditions": [
         {
@@ -1041,7 +1054,8 @@
       "tags": {
         "type": "xss",
         "crs_id": "941160",
-        "category": "attack_attempt"
+        "category": "attack_attempt",
+        "module": "waf"
       },
       "conditions": [
         {
@@ -1093,7 +1107,8 @@
       "tags": {
         "type": "xss",
         "crs_id": "941190",
-        "category": "attack_attempt"
+        "category": "attack_attempt",
+        "module": "waf"
       },
       "conditions": [
         {
@@ -1134,7 +1149,8 @@
       "tags": {
         "type": "xss",
         "crs_id": "941250",
-        "category": "attack_attempt"
+        "category": "attack_attempt",
+        "module": "waf"
       },
       "conditions": [
         {
@@ -1175,7 +1191,8 @@
       "tags": {
         "type": "xss",
         "crs_id": "941260",
-        "category": "attack_attempt"
+        "category": "attack_attempt",
+        "module": "waf"
       },
       "conditions": [
         {
@@ -1216,7 +1233,8 @@
       "tags": {
         "type": "xss",
         "crs_id": "941370",
-        "category": "attack_attempt"
+        "category": "attack_attempt",
+        "module": "waf"
       },
       "conditions": [
         {
@@ -1255,7 +1273,8 @@
       "tags": {
         "type": "js_code_injection",
         "crs_id": "941380",
-        "category": "attack_attempt"
+        "category": "attack_attempt",
+        "module": "waf"
       },
       "conditions": [
         {
@@ -1294,7 +1313,8 @@
       "tags": {
         "type": "sql_injection",
         "crs_id": "942151",
-        "category": "attack_attempt"
+        "category": "attack_attempt",
+        "module": "waf"
       },
       "conditions": [
         {
@@ -1333,7 +1353,8 @@
       "tags": {
         "type": "sql_injection",
         "crs_id": "942170",
-        "category": "attack_attempt"
+        "category": "attack_attempt",
+        "module": "waf"
       },
       "conditions": [
         {
@@ -1372,7 +1393,8 @@
         "type": "sql_injection",
         "crs_id": "942190",
         "category": "attack_attempt",
-        "cwe": "89"
+        "cwe": "89",
+        "module": "waf"
       },
       "conditions": [
         {
@@ -1413,7 +1435,8 @@
       "tags": {
         "type": "sql_injection",
         "crs_id": "942230",
-        "category": "attack_attempt"
+        "category": "attack_attempt",
+        "module": "waf"
       },
       "conditions": [
         {
@@ -1452,7 +1475,8 @@
       "tags": {
         "type": "sql_injection",
         "crs_id": "942320",
-        "category": "attack_attempt"
+        "category": "attack_attempt",
+        "module": "waf"
       },
       "conditions": [
         {
@@ -1490,7 +1514,8 @@
       "tags": {
         "type": "sql_injection",
         "crs_id": "942350",
-        "category": "attack_attempt"
+        "category": "attack_attempt",
+        "module": "waf"
       },
       "conditions": [
         {
@@ -1528,7 +1553,8 @@
       "tags": {
         "type": "java_code_injection",
         "crs_id": "944240",
-        "category": "attack_attempt"
+        "category": "attack_attempt",
+        "module": "waf"
       },
       "conditions": [
         {
@@ -1573,7 +1599,8 @@
         "type": "lfi",
         "category": "attack_attempt",
         "cwe": "22",
-        "capec": "1000/255/153/126"
+        "capec": "1000/255/153/126",
+        "module": "waf"
       },
       "conditions": [
         {
@@ -1612,7 +1639,8 @@
         "type": "lfi",
         "category": "attack_attempt",
         "cwe": "22",
-        "capec": "1000/255/153/126"
+        "capec": "1000/255/153/126",
+        "module": "waf"
       },
       "conditions": [
         {
@@ -1653,7 +1681,8 @@
       "tags": {
         "type": "nosql_injection",
         "category": "attack_attempt",
-        "cwe": "943"
+        "cwe": "943",
+        "module": "waf"
       },
       "conditions": [
         {
@@ -1689,7 +1718,8 @@
       "name": "Node.js: Prototype pollution",
       "tags": {
         "type": "js_code_injection",
-        "category": "attack_attempt"
+        "category": "attack_attempt",
+        "module": "waf"
       },
       "conditions": [
         {


### PR DESCRIPTION
**What does this PR do?**
This PR updates AppSec WAF rules to version 1.13.3.

**Motivation:**
New version of rules is released.

**Change log entry**
None.

**Additional Notes:**
This ruleset is already being pushed via remote config, so it's safe to update.

**How to test the change?**
CI is enough.
