### PR TITLE
Internal: Add span events native serialization

### DIFF
--- a/lib/datadog/tracing/span_event.rb
+++ b/lib/datadog/tracing/span_event.rb
@@ -19,22 +19,134 @@ module Datadog
       #   @return [Integer]
       attr_reader :time_unix_nano
 
+      # TODO: Accept {Time} as the time_unix_nano parameter, possibly in addition to the current nano integer.
       def initialize(
         name,
         attributes: nil,
         time_unix_nano: nil
       )
         @name = name
-        @attributes = attributes || {}
+
+        @attributes = attributes.dup || {}
+        validate_attributes!(@attributes)
+        @attributes.transform_keys!(&:to_s)
+
         # OpenTelemetry SDK stores span event timestamps in nanoseconds (not seconds).
         # We will do the same here to avoid unnecessary conversions and inconsistencies.
         @time_unix_nano = time_unix_nano || (Time.now.to_r * 1_000_000_000).to_i
       end
 
       def to_hash
-        h = { name: @name, time_unix_nano: @time_unix_nano }
-        h[:attributes] = attributes unless @attributes.empty?
+        h = { 'name' => @name, 'time_unix_nano' => @time_unix_nano }
+        h['attributes'] = @attributes unless @attributes.empty?
         h
+      end
+
+      def to_native_format
+        h = { 'name' => @name, 'time_unix_nano' => @time_unix_nano }
+
+        attr = {}
+        @attributes.each do |key, value|
+          attr[key] = if value.is_a?(Array)
+                        { type: ARRAY_TYPE, array_value: value.map { |v| serialize_native_attribute(v) } }
+                      else
+                        serialize_native_attribute(value)
+                      end
+        end
+
+        h['attributes'] = attr unless @attributes.empty?
+
+        h
+      end
+
+      private
+
+      MIN_INT64_SIGNED = -2**63
+      MAX_INT64_SIGNED = 2 << 63 - 1
+
+      # Checks the attributes hash to ensure it only contains serializable values.
+      # Invalid values are removed from the hash.
+      def validate_attributes!(attributes)
+        attributes.select! do |key, value|
+          case value
+          when Array
+            next true if value.empty?
+
+            first = value.first
+            case first
+            when String, Integer, Float
+              first_type = first.class
+              if value.all? { |v| v.is_a?(first_type) }
+                value.all? { |v| validate_scalar_attribute!(key, v) }
+              else
+                Datadog.logger.warn("Attribute #{key} array must be homogenous: #{value}.")
+                false
+              end
+            when TrueClass, FalseClass
+              if value.all? { |v| v.is_a?(TrueClass) || v.is_a?(FalseClass) }
+                value.all? { |v| validate_scalar_attribute!(key, v) }
+              else
+                Datadog.logger.warn("Attribute #{key} array must be homogenous: #{value}.")
+                false
+              end
+            else
+              Datadog.logger.warn("Attribute #{key} must be a string, number, or boolean: #{value}.")
+              false
+            end
+          when String, Numeric, TrueClass, FalseClass
+            validate_scalar_attribute!(key, value)
+          else
+            Datadog.logger.warn("Attribute #{key} must be a string, number, boolean, or array: #{value}.")
+            false
+          end
+        end
+      end
+
+      def validate_scalar_attribute!(key, value)
+        case value
+        when String, TrueClass, FalseClass
+          true
+        when Integer
+          # Cannot be larger than signed 64-bit integer
+          if value < MIN_INT64_SIGNED || value > MAX_INT64_SIGNED
+            Datadog.logger.warn("Attribute #{key} must be within the range of a signed 64-bit integer: #{value}.")
+            false
+          else
+            true
+          end
+        when Float
+          # Has to be finite
+          return true if value.finite?
+
+          Datadog.logger.warn("Attribute #{key} must be a finite number: #{value}.")
+          false
+        else
+          Datadog.logger.warn("Attribute #{key} must be a string, number, or boolean: #{value}.")
+          false
+        end
+      end
+
+      STRING_TYPE = 0
+      BOOLEAN_TYPE = 1
+      INTEGER_TYPE = 2
+      DOUBLE_TYPE = 3
+      ARRAY_TYPE = 4
+
+      # Serializes individual scalar attributes into the native format.
+      def serialize_native_attribute(value)
+        case value
+        when String
+          { type: STRING_TYPE, string_value: value }
+        when TrueClass, FalseClass
+          { type: BOOLEAN_TYPE, bool_value: value }
+        when Integer
+          { type: INTEGER_TYPE, int_value: value }
+        when Float
+          { type: DOUBLE_TYPE, double_value: value }
+        else
+          # This is technically unreachable due to the validation in #initialize.
+          raise ArgumentError, "Attribute must be a string, number, or boolean: #{value}."
+        end
       end
     end
   end

--- a/lib/datadog/tracing/span_event.rb
+++ b/lib/datadog/tracing/span_event.rb
@@ -36,12 +36,20 @@ module Datadog
         @time_unix_nano = time_unix_nano || (Time.now.to_r * 1_000_000_000).to_i
       end
 
+      # Converts the span event into a hash to be used by with the span tag serialization
+      # (`span.set_tag('events) = [event.to_hash]`). This serialization format has the drawback
+      # of being limiting span events to the size limit of a span tag.
+      # All Datadog agents support this format.
       def to_hash
         h = { 'name' => @name, 'time_unix_nano' => @time_unix_nano }
         h['attributes'] = @attributes unless @attributes.empty?
         h
       end
 
+      # Converts the span event into a hash to be used by the MessagePack serialization as a
+      # top-level span field (span.span_events = [event.to_native_format]).
+      # This serialization format removes the serialization limitations of the `span.set_tag('events)` approach,
+      # but is only supported by newer version of the Datadog agent.
       def to_native_format
         h = { 'name' => @name, 'time_unix_nano' => @time_unix_nano }
 

--- a/lib/datadog/tracing/span_operation.rb
+++ b/lib/datadog/tracing/span_operation.rb
@@ -11,6 +11,8 @@ require_relative 'event'
 require_relative 'metadata'
 require_relative 'metadata/ext'
 require_relative 'span'
+require_relative 'span_event'
+require_relative 'span_link'
 require_relative 'utils'
 
 module Datadog

--- a/lib/datadog/tracing/transport/serializable_trace.rb
+++ b/lib/datadog/tracing/transport/serializable_trace.rb
@@ -12,6 +12,8 @@ module Datadog
         attr_reader \
           :trace
 
+        # @param trace [Datadog::Trace] the trace to serialize
+        # @param native_events_supported [Boolean] whether the agent supports span events as a top-level field
         def initialize(trace, native_events_supported = false)
           @trace = trace
           @native_events_supported = native_events_supported
@@ -42,6 +44,8 @@ module Datadog
         attr_reader \
           :span
 
+        # @param span [Datadog::Span] the span to serialize
+        # @param native_events_supported [Boolean] whether the agent supports span events as a top-level field
         def initialize(span, native_events_supported)
           @span = span
           @trace_id = Tracing::Utils::TraceId.to_low_order(span.trace_id)

--- a/sig/datadog/tracing/span_event.rbs
+++ b/sig/datadog/tracing/span_event.rbs
@@ -1,27 +1,47 @@
 module Datadog
   module Tracing
-    # SpanEvent represents an annotation on a span.
-    # @public_api
     class SpanEvent
-      @name: untyped
+      type attributes = Hash[String,attributeValue]
+      type attributeValue = String | Integer | Float | bool | Array[String] | Array[Integer] | Array[Float] | Array[bool]
 
-      @attributes: untyped
+      MIN_INT64_SIGNED: Integer
+      MAX_INT64_SIGNED: Integer
+      STRING_TYPE: Integer
+      BOOLEAN_TYPE: Integer
+      INTEGER_TYPE: Integer
+      DOUBLE_TYPE: Integer
+      ARRAY_TYPE: Integer
 
-      @time_unix_nano: untyped
+      attr_reader name: untyped # TODO: Typing this makes to_hash internal typecheck fail
+      attr_reader attributes: attributes
+      attr_reader time_unix_nano: untyped # TODO: Typing this also makes to_hash internal typecheck fail
 
-      # @!attribute [r] name
-      #   @return [String]
-      attr_reader name: untyped
+      def initialize: (String name, ?attributes: attributes, ?time_unix_nano: Integer) -> void
 
-      # @!attribute [r] attributes
-      #   @return [Hash<String,String>]
-      attr_reader attributes: untyped
+      def to_hash: -> Hash[String, untyped]
+      # TODO: Steep does not track Hash keys when they are added with `hash[:key] = val`.
+      #   {
+      #   name: String,
+      #   time_unix_nano: Integer,
+      #   ?attributes: attributes,
+      # }
 
-      # @!attribute [r] time_unix_nano
-      #   @return [Integer]
-      attr_reader time_unix_nano: untyped
+      def to_native_format: -> Hash[String, untyped]
+      # TODO: Steep does not track Hash keys when they are added with `hash[:key] = val`.
+      # {
+      #   name: String,
+      #   time_unix_nano: Integer,
+      #   ?attributes: Hash[String, nativeAttributeValue],
+      # }
+      # type nativeAttributeValue = { type: Integer, string_value: String } | { type: Integer, int_value: Integer } | { type: Integer, double_value: Float } | { type: Integer, bool_value: bool } | { type: Integer, string_array_value: Array[String] } | { type: Integer, int_array_value: Array[Integer] } | { type: Integer, double_array_value: Array[Float] } | { type: Integer, bool_array_value: Array[bool] }
 
-      def initialize: (untyped name, ?attributes: untyped?, ?time_unix_nano: untyped?) -> void
+      private
+
+      def serialize_native_attribute: (attributeValue value)-> ({ type: Integer, string_value: String } | { type: Integer, int_value: Integer } | { type: Integer, double_value: Float } | { type: Integer, bool_value: bool })
+
+      def validate_attributes!: (attributes attributes)-> void
+
+      def validate_scalar_attribute!: (String key, attributeValue value)-> bool
     end
   end
 end

--- a/sig/datadog/tracing/transport/serializable_trace.rbs
+++ b/sig/datadog/tracing/transport/serializable_trace.rbs
@@ -2,9 +2,11 @@ module Datadog
   module Tracing
     module Transport
       class SerializableTrace
-        attr_reader trace: untyped
+        @native_events_supported: bool
 
-        def initialize: (untyped trace) -> void
+        attr_reader trace: Span
+
+        def initialize: (untyped trace, bool native_events_supported) -> void
 
         def to_msgpack: (?untyped? packer) -> untyped
 
@@ -12,9 +14,12 @@ module Datadog
       end
 
       class SerializableSpan
-        attr_reader span: untyped
+        @native_events_supported: bool
+        @trace_id: Integer
 
-        def initialize: (untyped span) -> void
+        attr_reader span: Span
+
+        def initialize: (untyped span, bool native_events_supported) -> void
 
         def to_msgpack: (?untyped? packer) -> untyped
 

--- a/spec/datadog/tracing/span_event_spec.rb
+++ b/spec/datadog/tracing/span_event_spec.rb
@@ -19,11 +19,40 @@ RSpec.describe Datadog::Tracing::SpanEvent do
         expect(span_event.attributes).to eq({})
         expect(span_event.time_unix_nano / 1e9).to be_within(1).of(Time.now.to_f)
       end
+
+      context 'with invalid attributes' do
+        let(:attributes) do
+          {
+            'int' => 1,
+            'invalid_arr1' => [1, 'a'],
+            'invalid_arr2' => [[1]],
+            'invalid_int1' => 2 << 65,
+            'invalid_int2' => -2 << 65,
+            'invalid_float1' => Float::NAN,
+            'invalid_float2' => Float::INFINITY,
+            'string' => 'bar',
+          }
+        end
+
+        it 'skips invalid values' do
+          expect(Datadog.logger).to receive(:warn).with(/Attribute invalid_.*/).exactly(6).times
+
+          expect(span_event.attributes).to eq('int' => 1, 'string' => 'bar',)
+        end
+      end
+
+      context 'with attributes with non-string keys' do
+        let(:attributes) { { 1 => 'val1', sym: 'val2' } }
+
+        it 'converts keys to strings' do
+          expect(span_event.attributes).to eq('1' => 'val1', 'sym' => 'val2')
+        end
+      end
     end
 
     context 'given' do
       context ':attributes' do
-        let(:attributes) { { tag: 'value' } }
+        let(:attributes) { { 'tag' => 'value' } }
         it { is_expected.to have_attributes(attributes: attributes) }
       end
 
@@ -39,21 +68,62 @@ RSpec.describe Datadog::Tracing::SpanEvent do
     let(:name) { 'Another Event!' }
 
     context 'with required fields' do
-      it { is_expected.to eq({ name: name, time_unix_nano: span_event.time_unix_nano }) }
+      it { is_expected.to eq({ 'name' => name, 'time_unix_nano' => span_event.time_unix_nano }) }
     end
 
     context 'with timestamp' do
       let(:time_unix_nano) { 25 }
-      it { is_expected.to include(time_unix_nano: 25) }
+      it { is_expected.to include('time_unix_nano' => 25) }
     end
 
     context 'when attributes is set' do
-      let(:attributes) { { 'event.name' => 'test_event', 'event.id' => 1, 'nested' => [true, [2, 3], 'val'] } }
-      it {
-        is_expected.to include(
-          attributes: attributes
+      let(:attributes) { { 'event.name' => 'test_event', 'event.id' => 1, 'nested' => [2, 3] } }
+      it { is_expected.to include('attributes' => attributes) }
+    end
+  end
+
+  describe '#to_native_format' do
+    subject(:to_native_format) { span_event.to_native_format }
+    let(:name) { 'Another Event!' }
+
+    context 'with required fields' do
+      it { is_expected.to eq({ 'name' => name, 'time_unix_nano' => span_event.time_unix_nano }) }
+    end
+
+    context 'with timestamp' do
+      let(:time_unix_nano) { 25 }
+      it { is_expected.to include('time_unix_nano' => 25) }
+    end
+
+    context 'when attributes is set' do
+      let(:attributes) do
+        {
+          'string' => 'value',
+          'bool' => true,
+          'int' => 1,
+          'float' => 1.0,
+          'string_arr' => %w[ab cd],
+          'bool_arr' => [true, false],
+          'int_arr' => [1, 2],
+          'float_arr' => [1.0, 2.0]
+        }
+      end
+
+      it do
+        expect(to_native_format['attributes']).to eq(
+          'string' => { type: 0, string_value: 'value' },
+          'bool' => { type: 1, bool_value: true },
+          'int' => { type: 2, int_value: 1 },
+          'float' => { type: 3, double_value: 1.0 },
+          'string_arr' => { type: 4,
+                            array_value: [{ type: 0, string_value: 'ab' }, { type: 0, string_value: 'cd' }] },
+          'bool_arr' => { type: 4,
+                          array_value: [{ type: 1, bool_value: true }, { type: 1, bool_value: false }] },
+          'int_arr' => { type: 4, array_value: [{ type: 2, int_value: 1 }, { type: 2, int_value: 2 }] },
+          'float_arr' => { type: 4,
+                           array_value: [{ type: 3, double_value: 1.0 }, { type: 3, double_value: 2.0 }] }
         )
-      }
+      end
     end
   end
 end

--- a/spec/datadog/tracing/transport/serializable_trace_spec.rb
+++ b/spec/datadog/tracing/transport/serializable_trace_spec.rb
@@ -8,9 +8,10 @@ require 'datadog/tracing/trace_segment'
 require 'datadog/tracing/transport/serializable_trace'
 
 RSpec.describe Datadog::Tracing::Transport::SerializableTrace do
-  subject(:serializable_trace) { described_class.new(trace) }
+  subject(:serializable_trace) { described_class.new(trace, native_events_supported) }
 
   let(:trace) { Datadog::Tracing::TraceSegment.new(spans) }
+  let(:native_events_supported) { false }
   let(:spans) do
     Array.new(3) do |i|
       span = Datadog::Tracing::Span.new(
@@ -26,12 +27,38 @@ RSpec.describe Datadog::Tracing::Transport::SerializableTrace do
     end
   end
 
+  shared_examples 'serialize all fields' do |include_duration: false, include_native_events: false|
+    it 'contains all fields' do
+      unpacked_trace.each do |span|
+        expected = [
+          'span_id',
+          'parent_id',
+          'trace_id',
+          'name',
+          'service',
+          'resource',
+          'type',
+          'meta',
+          'metrics',
+          'span_links',
+          'error',
+        ]
+        if include_duration
+          expected << 'start'
+          expected << 'duration'
+        end
+        expected << 'span_events' if include_native_events
+
+        expect(span.keys).to match_array(expected)
+      end
+    end
+  end
+
   describe '#to_msgpack' do
-    subject(:to_msgpack) { serializable_trace.to_msgpack }
+    subject(:unpacked_trace) { MessagePack.unpack(to_msgpack) }
+    let(:to_msgpack) { serializable_trace.to_msgpack }
 
-    context 'when packed then upacked' do
-      subject(:unpacked_trace) { MessagePack.unpack(to_msgpack) }
-
+    context 'when packed then unpacked' do
       let(:original_spans) do
         spans.map do |span|
           Hash[span.to_hash.map { |k, v| [k.to_s, v] }]
@@ -44,8 +71,6 @@ RSpec.describe Datadog::Tracing::Transport::SerializableTrace do
     end
 
     context 'when given trace_id' do
-      subject(:unpacked_trace) { MessagePack.unpack(to_msgpack) }
-
       let(:spans) do
         Array.new(3) do |_i|
           Datadog::Tracing::Span.new(
@@ -73,8 +98,6 @@ RSpec.describe Datadog::Tracing::Transport::SerializableTrace do
     end
 
     context 'when given span links' do
-      subject(:unpacked_trace) { MessagePack.unpack(to_msgpack) }
-
       let(:spans) do
         Array.new(3) do |_i|
           Datadog::Tracing::Span.new(
@@ -131,8 +154,6 @@ RSpec.describe Datadog::Tracing::Transport::SerializableTrace do
     end
 
     context 'when given span events' do
-      subject(:unpacked_trace) { MessagePack.unpack(to_msgpack) }
-
       let(:spans) do
         Array.new(2) do |i|
           Datadog::Tracing::Span.new(
@@ -140,11 +161,11 @@ RSpec.describe Datadog::Tracing::Transport::SerializableTrace do
             events: [
               Datadog::Tracing::SpanEvent.new(
                 'First Event',
-                time_unix_nano: 1_000_000_000
+                time_unix_nano: 123
               ),
               Datadog::Tracing::SpanEvent.new(
                 "Another Event #{i}!",
-                time_unix_nano: 2_000_000_000,
+                time_unix_nano: 456,
                 attributes: { id: i, required: (i == 1) },
               ),
             ],
@@ -159,14 +180,47 @@ RSpec.describe Datadog::Tracing::Transport::SerializableTrace do
           end
         ).to eq(
           [
-            '[{"name":"First Event","time_unix_nano":1000000000},{"name":"Another Event 0!","time_unix_nano":2000000000,' \
+            '[{"name":"First Event","time_unix_nano":123},{"name":"Another Event 0!","time_unix_nano":456,' \
             '"attributes":{"id":0,"required":false}}]',
-            '[{"name":"First Event","time_unix_nano":1000000000},{"name":"Another Event 1!","time_unix_nano":2000000000,' \
+            '[{"name":"First Event","time_unix_nano":123},{"name":"Another Event 1!","time_unix_nano":456,' \
             '"attributes":{"id":1,"required":true}}]',
           ]
         )
       end
+
+      it_behaves_like 'serialize all fields'
+
+      context 'when native events are supported' do
+        let(:native_events_supported) { true }
+
+        it 'serializes span events as top-level field' do
+          expect(
+            unpacked_trace.map do |s|
+              s['span_events']
+            end
+          ).to eq(
+            [
+              [
+                { 'name' => 'First Event', 'time_unix_nano' => 123 },
+                { 'name' => 'Another Event 0!', 'time_unix_nano' => 456, 'attributes' => {
+                  'id' => { 'int_value' => 0, 'type' => 2 }, 'required' => { 'bool_value' => false, 'type' => 1 }
+                } }
+              ],
+              [
+                { 'name' => 'First Event', 'time_unix_nano' => 123 },
+                { 'name' => 'Another Event 1!', 'time_unix_nano' => 456, 'attributes' => {
+                  'id' => { 'int_value' => 1, 'type' => 2 }, 'required' => { 'bool_value' => true, 'type' => 1 }
+                } }
+              ],
+            ]
+          )
+        end
+
+        it_behaves_like 'serialize all fields', include_native_events: true
+      end
     end
+
+    it_behaves_like 'serialize all fields'
   end
 
   describe '#to_json' do


### PR DESCRIPTION
Add native serialization for the `Datadog::Tracing::SpanEvent` object, when serialized as MessagePack.

This code disabled today, through the `native_events_supported` variable, so this PR is just adding the serialization code that will be activated in a future PR.

**Change log entry**
None

**Additional Notes:**

I've also changed the returned keys from `to_hash` to have String keys, instead of Symbols from before, because both the MessagePack and JSON serialization will convert all this Symbols to Strings immediately. Making this change avoids an unnecessary Symbol -> String conversion. 

**How to test the change?**
All changes are tested, as well as some improved testing for existing Span Events methods.
