### PR TITLE
Fix Core::Telemetry stacktrace and error logging

### DIFF
--- a/lib/datadog/core/telemetry/logging.rb
+++ b/lib/datadog/core/telemetry/logging.rb
@@ -41,7 +41,7 @@ module Datadog
               else
                 'REDACTED'
               end
-            end.join(',')
+            end.join("\n")
           end
         end
 
@@ -49,7 +49,7 @@ module Datadog
           # Annoymous exceptions to be logged as <Class:0x00007f8b1c0b3b40>
           message = +''
           message << (exception.class.name || exception.class.inspect)
-          message << ':' << description if description
+          message << ': ' << description if description
 
           event = Event::Log.new(
             message: message,

--- a/spec/datadog/core/telemetry/logging_spec.rb
+++ b/spec/datadog/core/telemetry/logging_spec.rb
@@ -24,7 +24,7 @@ RSpec.describe Datadog::Core::Telemetry::Logging do
           )
           expect(event.payload).to include(
             logs: [{ message: 'RuntimeError', level: 'ERROR',
-                     stack_trace: a_string_including(',/spec/') }]
+                     stack_trace: a_string_including("\n/spec/") }]
           )
         end
 
@@ -39,12 +39,12 @@ RSpec.describe Datadog::Core::Telemetry::Logging do
         it 'sends a log event to via telemetry' do
           expect(component).to receive(:log!).with(instance_of(Datadog::Core::Telemetry::Event::Log)) do |event|
             expect(event.payload).to include(
-              logs: [{ message: 'RuntimeError:Must not contain PII', level: 'ERROR',
+              logs: [{ message: 'RuntimeError: Must not contain PII', level: 'ERROR',
                        stack_trace: a_string_including('REDACTED') }]
             )
             expect(event.payload).to include(
-              logs: [{ message: 'RuntimeError:Must not contain PII', level: 'ERROR',
-                       stack_trace: a_string_including(',/spec/') }]
+              logs: [{ message: 'RuntimeError: Must not contain PII', level: 'ERROR',
+                       stack_trace: a_string_including("\n/spec/") }]
             )
           end
 
@@ -66,7 +66,7 @@ RSpec.describe Datadog::Core::Telemetry::Logging do
           )
           expect(event.payload).to include(
             logs: [{ message: /#<Class:/, level: 'ERROR',
-                     stack_trace: a_string_including(',/spec/') }]
+                     stack_trace: a_string_including("\n/spec/") }]
           )
         end
 


### PR DESCRIPTION
<!--
Check out the
https://github.com/DataDog/dd-trace-rb/blob/master/docs/DevelopmentGuide.md
for guidance on how to set up your development environment,
run the test suite, write new integrations, and more.
-->

**What does this PR do?**

Correct internal Telemetry logging stacktrace and error name reporting.

**Motivation:**

Without that change stacktrace doesn't show up correctly which also leads to ErrorTracking being impossible. In addition an extra space added between Error name and description.

**Change log entry**

No.

**Additional Notes:**

<img width="1452" alt="Screenshot 2024-12-11 at 16 00 56" src="https://github.com/user-attachments/assets/be1ff555-7d36-4d26-87a4-7f6496890aeb" />

**How to test the change?**

CI and [ErrorTracking example](https://app.datadoghq.com/error-tracking?query=%40lib_language%3Aruby&et-viz=sample&fromUser=true&issueId=5c4d2828-b7cb-11ef-ab88-da7ad0900002&refresh_mode=sliding&source=backend&from_ts=1733926089112&to_ts=1733926989112&live=true)