### PR TITLE
[APPSEC-56128] Replace telemetry error with report

### DIFF
--- a/spec/datadog/appsec/processor/context_spec.rb
+++ b/spec/datadog/appsec/processor/context_spec.rb
@@ -259,7 +259,9 @@ RSpec.describe Datadog::AppSec::Processor::Context do
       end
 
       it 'sends telemetry error' do
-        expect(telemetry).to receive(:error).with(/libddwaf:[\d.]+ method:ddwaf_run execution error: :err_invalid_object/)
+        expect(telemetry).to receive(:report)
+          .with(kind_of(Datadog::AppSec::WAF::LibDDWAF::Error),
+            description: /libddwaf:[\d.]+ method:ddwaf_run execution error: :err_invalid_object/)
 
         context.run(input, {}, timeout)
       end
@@ -274,9 +276,13 @@ RSpec.describe Datadog::AppSec::Processor::Context do
       let(:result) { context.run(input, {}, timeout) }
 
       it 'sends telemetry report' do
-        expect(telemetry).to receive(:error).with(/libddwaf:[\d.]+ method:ddwaf_run execution error: :err_internal/)
         expect(telemetry).to receive(:report)
-          .with(kind_of(Datadog::AppSec::WAF::LibDDWAF::Error), description: 'libddwaf-rb internal low-level error')
+          .with(kind_of(Datadog::AppSec::WAF::LibDDWAF::Error),
+            description: /libddwaf:[\d.]+ method:ddwaf_run execution error: :err_internal/)
+
+        expect(telemetry).to receive(:report)
+          .with(kind_of(Datadog::AppSec::WAF::LibDDWAF::Error),
+            description: /libddwaf:[\d.]+ method:ddwaf_run internal low-level error/)
 
         expect(result.status).to eq(:err_internal)
       end


### PR DESCRIPTION
<!--
Check out the
https://github.com/DataDog/dd-trace-rb/blob/master/docs/DevelopmentGuide.md
for guidance on how to set up your development environment,
run the test suite, write new integrations, and more.
-->

**What does this PR do?**

Replace AppSec telemetry error with report upon receiving internal "implicit" error of `libddwaf`.

**Motivation:**

This change is a part-done set of changes in order to have a single monitor to control issues with `libddwaf` calls.

With this change we will be able to see errors both "implicit" and explicit in the same place to build a Monitor around them.

<img width="2112" alt="Screenshot 2024-12-12 at 12 58 35" src="https://github.com/user-attachments/assets/571c23cd-34e2-4726-93fd-8715bbb87d71" />
<sup>(example picture for reference - <a href="https://app.datadoghq.com/error-tracking?query=%40lib_language%3Aruby%20%22AppSec%3A%3AWAF%3A%3ALibDDWAF%22&et-viz=sample&fromUser=false&refresh_mode=sliding&source=backend&from_ts=1733912983976&to_ts=1733999383976&live=true">live log</a>)</sup>

We have a task to replace exceptions in `libddwaf-rb` with return status Result (implicit error) which means two things:

1. a single place to record the error - in report execution method
2. a better `Result` object from `libddwaf-rb` (decouple from its origin interface)

**Change log entry**

No.

**Additional Notes:**

In order to deliver log which will appear in ErrorTracking I need a backtrace and a faster backtrace collection appears only in [Ruby 3.4.0](https://github.com/ruby/ruby/pull/10017).

Telemetry to ErrorTracking is not in the perfect state, which means errors will have a generic name instead of a name of exception. But I've added this request to the APM Language team.

**How to test the change?**

CI is enough