### PR TITLE
DEBUG-3182 DI: remove hard dependency on tracing

### DIFF
--- a/lib/datadog/di/component.rb
+++ b/lib/datadog/di/component.rb
@@ -1,5 +1,7 @@
 # frozen_string_literal: true
 
+require_relative '../core'
+
 module Datadog
   module DI
     # Component for dynamic instrumentation.

--- a/lib/datadog/di/init.rb
+++ b/lib/datadog/di/init.rb
@@ -4,8 +4,6 @@
 # enable dynamic instrumentation for third-party libraries used by the
 # application.
 
-require_relative '../tracing'
-require_relative '../tracing/contrib'
 require_relative '../di'
 
 # Code tracking is required for line probes to work; see the comments

--- a/lib/datadog/di/probe_notification_builder.rb
+++ b/lib/datadog/di/probe_notification_builder.rb
@@ -141,14 +141,16 @@ module Datadog
             version: 2,
           },
           # TODO add tests that the trace/span id is correctly propagated
-          "dd.trace_id": Datadog::Tracing.active_trace&.id&.to_s,
-          "dd.span_id": Datadog::Tracing.active_span&.id&.to_s,
+          "dd.trace_id": active_trace&.id&.to_s,
+          "dd.span_id": active_span&.id&.to_s,
           ddsource: 'dd_debugger',
           message: probe.template && evaluate_template(probe.template,
             duration: duration ? duration * 1000 : 0),
           timestamp: timestamp,
         }
       end
+
+      private
 
       def build_status(probe, message:, status:)
         {
@@ -198,6 +200,18 @@ module Datadog
         binding.local_variables.each_with_object({}) do |name, map|
           value = binding.local_variable_get(name)
           map[name] = value
+        end
+      end
+
+      def active_trace
+        if defined?(Datadog::Tracing)
+          Datadog::Tracing.active_trace
+        end
+      end
+
+      def active_span
+        if defined?(Datadog::Tracing)
+          Datadog::Tracing.active_span
         end
       end
     end

--- a/lib/datadog/di/transport.rb
+++ b/lib/datadog/di/transport.rb
@@ -2,6 +2,7 @@
 
 require 'ostruct'
 require_relative 'error'
+require_relative '../core/transport/http/adapters/net'
 
 module Datadog
   module DI

--- a/sig/datadog/di/probe_notification_builder.rbs
+++ b/sig/datadog/di/probe_notification_builder.rbs
@@ -27,6 +27,9 @@ module Datadog
       def timestamp_now: () -> Integer
 
       def get_local_variables: (TracePoint trace_point) -> Hash[Symbol,untyped]
+      
+      def active_trace: () -> Datadog::Tracing::TraceSegment?
+      def active_span: () -> Datadog::Tracing::SpanOperation?
     end
   end
 end

--- a/spec/datadog/di/code_tracker_spec.rb
+++ b/spec/datadog/di/code_tracker_spec.rb
@@ -1,12 +1,9 @@
+require 'datadog/di'
 require "datadog/di/spec_helper"
-require "datadog/di/code_tracker"
 
 RSpec.describe Datadog::DI::CodeTracker do
   di_test
-
-  before(:all) do
-    Datadog::DI.deactivate_tracking!
-  end
+  deactivate_code_tracking
 
   let(:tracker) do
     described_class.new

--- a/spec/datadog/di/probe_manager_spec.rb
+++ b/spec/datadog/di/probe_manager_spec.rb
@@ -1,5 +1,7 @@
 require "datadog/di/spec_helper"
 require 'datadog/di/probe_manager'
+require 'datadog/di/instrumenter'
+require 'logger'
 
 class ProbeManagerSpecTestClass; end
 

--- a/spec/datadog/di/probe_notifier_worker_spec.rb
+++ b/spec/datadog/di/probe_notifier_worker_spec.rb
@@ -1,5 +1,6 @@
 require "datadog/di/spec_helper"
 require "datadog/di/probe_notifier_worker"
+require 'logger'
 
 RSpec.describe Datadog::DI::ProbeNotifierWorker do
   di_test

--- a/spec/datadog/di/remote_spec.rb
+++ b/spec/datadog/di/remote_spec.rb
@@ -1,5 +1,7 @@
 require "datadog/di/spec_helper"
+require 'datadog/di'
 require 'spec_helper'
+require 'logger'
 
 RSpec.describe Datadog::DI::Remote do
   di_test

--- a/spec/datadog/di/spec_helper.rb
+++ b/spec/datadog/di/spec_helper.rb
@@ -1,5 +1,13 @@
 module DIHelpers
   module ClassMethods
+    def deactivate_code_tracking
+      before(:all) do
+        if Datadog::DI.respond_to?(:deactivate_tracking!)
+          Datadog::DI.deactivate_tracking!
+        end
+      end
+    end
+
     def ruby_2_only
       if RUBY_VERSION >= '3'
         before(:all) do

--- a/spec/datadog/di/transport_spec.rb
+++ b/spec/datadog/di/transport_spec.rb
@@ -1,5 +1,6 @@
 require "datadog/di/spec_helper"
 require "datadog/di/transport"
+require 'datadog/core/configuration/agent_settings_resolver'
 
 RSpec.describe Datadog::DI::Transport do
   di_test

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -306,4 +306,4 @@ Timeout.ensure_timeout_thread_created if Timeout.respond_to?(:ensure_timeout_thr
 # Code tracking calls out to the current DI component, which may reference
 # mock objects in the test suite. Disable it and tests that need code tracking
 # will enable it back for themselves.
-Datadog::DI.deactivate_tracking! if Datadog::DI.respond_to?(:deactivate_tracking!)
+Datadog::DI.deactivate_tracking! if defined?(Datadog::DI) && Datadog::DI.respond_to?(:deactivate_tracking!)


### PR DESCRIPTION
<!--
Check out the
https://github.com/DataDog/dd-trace-rb/blob/master/docs/DevelopmentGuide.md
for guidance on how to set up your development environment,
run the test suite, write new integrations, and more.
-->

**What does this PR do?**
<!-- A brief description of the change being made with this pull request. -->
Removes hard dependency of DI on Tracing.

- Existing requires of tracing components from DI removed
- DI will check if Datadog::Tracing exists before referencing current_span & current_trace
- Unit tests adjusted to require their dependencies explicitly and to use local CodeTracker instances rather than the global one

**Motivation:**
<!-- What inspired you to submit this pull request? -->
DI code tracker must be loaded early in application boot process. Tracing must be loaded late to instrument third-party libraries. Currently, DI requires some tracing components which may result in tracing not loading correctly.

**Change log entry**
<!-- If this is a customer-visible change, a brief summary to be placed
into the change log.
If you are not a Datadog employee, you can skip this section
and it will be filled or deleted during PR review. -->
None - I am currently not aware of specific issues with DI or tracing loading.

**Additional Notes:**
<!-- Anything else we should know when reviewing? -->
I intend to add a test in a separate PR that loads DI code tracking in a forked process, verifies that the code tracking works correctly, and asserts that none of the other components (most importantly tracing but we could check others too) have been loaded.

**How to test the change?**
<!--
Describe here how the change can be validated.
You are strongly encouraged to provide automated tests for this PR (unit or integration).
If this change cannot be feasibly tested, please explain why,
unless the change does not modify code (e.g. only modifies docs, comments).
-->
I tested the encapsulation manually by removing a bunch of requires pertaining to tracing from spec_helper.rb and other helpers. The main test of the DI code tracker both working correctly and not loading tracing will be in a later PR.

<!-- Unsure? Have a question? Request a review! -->
