### PR TITLE
Increase benchmark validation timeout

### DIFF
--- a/spec/datadog/tracing/validate_benchmarks_spec.rb
+++ b/spec/datadog/tracing/validate_benchmarks_spec.rb
@@ -16,7 +16,7 @@ RSpec.describe 'Tracing benchmarks' do
   benchmarks_to_validate.each do |benchmark|
     describe benchmark do
       it 'runs without raising errors' do
-        expect_in_fork(timeout_seconds: 30) do
+        expect_in_fork(timeout_seconds: 20) do
           load "./benchmarks/#{benchmark}.rb"
         end
       end

--- a/spec/datadog/tracing/validate_benchmarks_spec.rb
+++ b/spec/datadog/tracing/validate_benchmarks_spec.rb
@@ -16,7 +16,7 @@ RSpec.describe 'Tracing benchmarks' do
   benchmarks_to_validate.each do |benchmark|
     describe benchmark do
       it 'runs without raising errors' do
-        expect_in_fork do
+        expect_in_fork(timeout_seconds: 30) do
           load "./benchmarks/#{benchmark}.rb"
         end
       end


### PR DESCRIPTION
I got this [flaky test recently](https://github.com/DataDog/dd-trace-rb/actions/runs/12323376519/job/34398857257?pr=4154):
```
  1) Tracing benchmarks tracing_trace runs without raising errors
     Failure/Error: raise('Wait time exhausted!')

     RuntimeError:
       Wait time exhausted!
     # ./spec/support/synchronization_helpers.rb:97:in `try_wait_until'
     # ./spec/support/synchronization_helpers.rb:26:in `expect_in_fork'
     # ./spec/datadog/tracing/validate_benchmarks_spec.rb:19:in `block (4 levels) in <top (required)>'
     # ./spec/datadog/tracing/validate_benchmarks_spec.rb:8:in `block (3 levels) in <top (required)>'
     # ./spec/datadog/tracing/validate_benchmarks_spec.rb:7:in `block (2 levels) in <top (required)>'
     # ./spec/spec_helper.rb:237:in `block (2 levels) in <top (required)>'
     # ./spec/spec_helper.rb:122:in `block (2 levels) in <top (required)>'
```

It looks like this benchmark validation test has a timeout of 10 seconds that was _just_ exceeded in the MacOS CI.

This PR increases it to 30 seconds.

**Change log entry**
None.