### PR TITLE
[PROF-11035] Require datadog-ruby_core_source >= 3.3.7 to ensure Ruby 3.4 support

### DIFF
--- a/datadog.gemspec
+++ b/datadog.gemspec
@@ -62,7 +62,7 @@ Gem::Specification.new do |spec|
   spec.add_dependency 'msgpack'
 
   # Used by the profiler native extension to support Ruby 2.5 and > 3.2, see NativeExtensionDesign.md for details
-  spec.add_dependency 'datadog-ruby_core_source', '~> 3.3'
+  spec.add_dependency 'datadog-ruby_core_source', '~> 3.3', '>= 3.3.7'
 
   # Used by appsec
   spec.add_dependency 'libddwaf', '~> 1.18.0.0.0'


### PR DESCRIPTION
**What does this PR do?**

This PR adds an extra version restriction to our `datadog-ruby_core_source` dependency to ensure that version 3.3.7 or newer gets used.

**Motivation:**

Version 3.3.7 ships support for Ruby 3.4 (using 3.4.0-rc1 headers) and has a nice on-disk footprint reduction so we want to make sure that it gets used, instead of an older version.

**Change log entry**

Yes. Require datadog-ruby_core_source >= 3.3.7 to ensure Ruby 3.4 support

**Additional Notes:**

N/A

**How to test the change?**

If CI is still green, we're almost good. The final part is testing this with 3.4.0-rc1 -- which we don't yet have in CI.

For now I did that locally and got a green build; once we pick up 3.4.0-rc1 (or 3.4.0 stable) in CI, we'll be able to validate this part in CI as well.
