### PR TITLE
[PROF-11305] Enable memory leak testing with ASAN, try 3

### DIFF
--- a/.github/workflows/test-memory-leaks.yaml
+++ b/.github/workflows/test-memory-leaks.yaml
@@ -15,10 +15,6 @@ jobs:
       - run: gem update --system 3.5.23 # TODO: This is a workaround for a buggy rubygems in 3.4.0-preview2; remove once stable version 3.4 is out
       - run: bundle exec rake compile spec:profiling:memcheck
   test-asan:
-    # Temporarily ruby-asan builds changes
-    # from: `ruby 3.4.0dev (2024-11-07T14:35:19Z :detached: fca07d73e3) +PRISM [x86_64-linux]`
-    # To:   `ruby 3.4.0dev (2024-11-11T18:38:40Z :detached: 8672e88cd2) +PRISM [x86_64-linux]`
-    if: false
     runs-on: ubuntu-24.04
     steps:
       - uses: actions/checkout@v4
@@ -27,5 +23,5 @@ jobs:
           ruby-version: asan
           bundler-cache: true # runs 'bundle install' and caches installed gems automatically
           bundler: latest
-          cache-version: v1 # bump this to invalidate cache
+          cache-version: v2 # bump this to invalidate cache
       - run: env RUBY_FREE_AT_EXIT=1 LSAN_OPTIONS=verbosity=0:log_threads=1:suppressions=`pwd`/suppressions/lsan.supp ASAN_OPTIONS=detect_leaks=1 bundle exec rake spec:profiling:main


### PR DESCRIPTION
**What does this PR do?**

This PR tries again to re-enable the memory leak testing with AddressSanitizer ("ASAN").

We previously had disabled it since it was failing due to an unrelated issue (specifically, the asan builds are based on Ruby master, and Ruby master was slightly incompatible with the profiler until the `datadog-ruby_core_source` 3.3.7 brought a newer set of headers).

**Motivation:**

The ASAN tool is quite powerful at detecting memory issues and other problems in native extensions, so if we can keep it running it can help flag issues before they make it to our customers.

**Change log entry**

None.

**Additional Notes:**

We can always disable again later if needed.

Hopefully once Ruby 3.4 stable is out, we can see if it's possible to have a "stable ASAN" build that's not based off of ruby master, and thus is a bit more predictable.

**How to test the change?**

Validate the "Test for memory leaks > test asan" CI step is running and passing.