### PR TITLE
DEBUG-3210 DI: change logging to be appropriate for customer inspection

### DIFF
--- a/lib/datadog/di/code_tracker.rb
+++ b/lib/datadog/di/code_tracker.rb
@@ -91,7 +91,7 @@ module Datadog
             # before release.
             if component = DI.current_component # steep:ignore
               raise if component.settings.dynamic_instrumentation.internal.propagate_all_exceptions
-              component.logger.warn("Unhandled exception in script_compiled trace point: #{exc.class}: #{exc}")
+              component.log_warn_internal("Unhandled exception in script_compiled trace point: #{exc.class}: #{exc}")
               component.telemetry&.report(exc, description: "Unhandled exception in script_compiled trace point")
               # TODO test this path
             else

--- a/lib/datadog/di/component.rb
+++ b/lib/datadog/di/component.rb
@@ -1,5 +1,7 @@
 # frozen_string_literal: true
 
+require_relative 'logging'
+
 module Datadog
   module DI
     # Component for dynamic instrumentation.
@@ -13,12 +15,14 @@ module Datadog
     # intalled tracepoints and so on. Component will clean up all
     # resources and installed tracepoints upon shutdown.
     class Component
+      include Logging
+
       class << self
         def build(settings, agent_settings, telemetry: nil)
           return unless settings.respond_to?(:dynamic_instrumentation) && settings.dynamic_instrumentation.enabled
 
           unless settings.respond_to?(:remote) && settings.remote.enabled
-            Datadog.logger.debug("Dynamic Instrumentation could not be enabled because Remote Configuration Management is not available. To enable Remote Configuration, see https://docs.datadoghq.com/agent/remote_config")
+            Datadog.logger.warn("Dynamic Instrumentation could not be enabled because Remote Configuration Management is not available. To enable Remote Configuration, see https://docs.datadoghq.com/agent/remote_config")
             return
           end
 
@@ -53,12 +57,12 @@ module Datadog
           # TODO add tests?
           unless settings.dynamic_instrumentation.internal.development
             if Datadog::Core::Environment::Execution.development?
-              Datadog.logger.debug("Not enabling dynamic instrumentation because we are in development environment")
+              Datadog.logger.warn("Not enabling dynamic instrumentation because we are in development environment")
               return false
             end
           end
           if RUBY_ENGINE != 'ruby' || RUBY_VERSION < '2.6'
-            Datadog.logger.debug("Not enabling dynamic instrumentation because of unsupported Ruby version")
+            Datadog.logger.warn("Not enabling dynamic instrumentation because of unsupported Ruby version")
             return false
           end
           true

--- a/lib/datadog/di/configuration/settings.rb
+++ b/lib/datadog/di/configuration/settings.rb
@@ -157,6 +157,15 @@ module Datadog
                   o.default false
                 end
 
+                # Increases logging verbosity level from 'debug' to 'warn'
+                # for internal DI diagnostics, i.e. log messages that
+                # should not be written to customers' logs in production but
+                # that are useful when developing DI.
+                option :verbose_logging do |o|
+                  o.type :bool
+                  o.default false
+                end
+
                 # Minimum interval, in seconds, between probe status and
                 # snapshot submissions to the agent. Probe notifier worker will
                 # batch together payloads submitted during each interval.

--- a/lib/datadog/di/instrumenter.rb
+++ b/lib/datadog/di/instrumenter.rb
@@ -3,6 +3,7 @@
 # rubocop:disable Lint/AssignmentInCondition
 
 require 'benchmark'
+require_relative 'logging'
 
 module Datadog
   module DI
@@ -54,6 +55,8 @@ module Datadog
     #
     # @api private
     class Instrumenter
+      include Logging
+
       def initialize(settings, serializer, logger, code_tracker: nil, telemetry: nil)
         @settings = settings
         @serializer = serializer
@@ -305,13 +308,13 @@ module Datadog
             end
           rescue => exc
             raise if settings.dynamic_instrumentation.internal.propagate_all_exceptions
-            logger.warn("Unhandled exception in line trace point: #{exc.class}: #{exc}")
+            log_warn_internal("Unhandled exception in line trace point: #{exc.class}: #{exc}")
             telemetry&.report(exc, description: "Unhandled exception in line trace point")
             # TODO test this path
           end
         rescue => exc
           raise if settings.dynamic_instrumentation.internal.propagate_all_exceptions
-          logger.warn("Unhandled exception in line trace point: #{exc.class}: #{exc}")
+          log_warn_internal("Unhandled exception in line trace point: #{exc.class}: #{exc}")
           telemetry&.report(exc, description: "Unhandled exception in line trace point")
           # TODO test this path
         end
@@ -357,7 +360,7 @@ module Datadog
           hook_line(probe, &block)
         else
           # TODO add test coverage for this path
-          logger.warn("Unknown probe type to hook: #{probe}")
+          log_warn_internal("Unknown probe type to hook: #{probe}")
         end
       end
 
@@ -368,7 +371,7 @@ module Datadog
           unhook_line(probe)
         else
           # TODO add test coverage for this path
-          logger.warn("Unknown probe type to unhook: #{probe}")
+          log_warn_internal("Unknown probe type to unhook: #{probe}")
         end
       end
 

--- a/lib/datadog/di/logging.rb
+++ b/lib/datadog/di/logging.rb
@@ -1,0 +1,30 @@
+# frozen_string_literal: true
+
+module Datadog
+  module DI
+    # Logging for DI
+    module Logging
+      # Logs an internal warning message.
+      # When verbose logging is enabled, the logging happens at warn level.
+      # When verbose logging is disabled, the logging happens at debug level
+      # (which is how the rest of the library is reporting its internal
+      # warnings/errors).
+      def log_warn_internal(msg)
+        if settings.dynamic_instrumentation.internal.verbose_logging
+          logger.warn(msg)
+        else
+          logger.debug(msg)
+        end
+      end
+      
+      # Logs an internal informational message.
+      # When verbose logging is enabled, the logging happens at info level.
+      # When verbose logging is disabled, nothing is logged.
+      def log_info_internal(msg)
+        if settings.dynamic_instrumentation.internal.verbose_logging
+          logger.info(msg)
+        end
+      end
+    end
+  end
+end

--- a/lib/datadog/di/probe_manager.rb
+++ b/lib/datadog/di/probe_manager.rb
@@ -3,6 +3,7 @@
 # rubocop:disable Lint/AssignmentInCondition
 
 require 'monitor'
+require_relative 'logging'
 
 module Datadog
   module DI
@@ -15,6 +16,8 @@ module Datadog
     #
     # @api private
     class ProbeManager
+      include Logging
+
       def initialize(settings, instrumenter, probe_notification_builder,
         probe_notifier_worker, logger, telemetry: nil)
         @settings = settings
@@ -32,7 +35,7 @@ module Datadog
           install_pending_method_probes(tp.self)
         rescue => exc
           raise if settings.dynamic_instrumentation.internal.propagate_all_exceptions
-          logger.warn("Unhandled exception in definition trace point: #{exc.class}: #{exc}")
+          log_warn_internal("Unhandled exception in definition trace point: #{exc.class}: #{exc}")
           telemetry&.report(exc, description: "Unhandled exception in definition trace point")
           # TODO test this path
         end
@@ -120,7 +123,7 @@ module Datadog
           # In "propagate all exceptions" mode we will try to instrument again.
           raise if settings.dynamic_instrumentation.internal.propagate_all_exceptions
 
-          logger.warn("Error processing probe configuration: #{exc.class}: #{exc}")
+          log_warn_internal("Error processing probe configuration: #{exc.class}: #{exc}")
           telemetry&.report(exc, description: "Error processing probe configuration")
           # TODO report probe as failed to agent since we won't attempt to
           # install it again.
@@ -160,7 +163,7 @@ module Datadog
                 raise if settings.dynamic_instrumentation.internal.propagate_all_exceptions
                 # Silence all exceptions?
                 # TODO should we propagate here and rescue upstream?
-                logger.warn("Error removing probe #{probe.id}: #{exc.class}: #{exc}")
+                log_warn_internal("Error removing probe #{probe.id}: #{exc.class}: #{exc}")
                 telemetry&.report(exc, description: "Error removing probe")
               end
             end
@@ -190,7 +193,7 @@ module Datadog
                 rescue => exc
                   raise if settings.dynamic_instrumentation.internal.propagate_all_exceptions
 
-                  logger.warn("Error installing probe after class is defined: #{exc.class}: #{exc}")
+                  log_warn_internal("Error installing probe after class is defined: #{exc.class}: #{exc}")
                   telemetry&.report(exc, description: "Error installing probe after class is defined")
                 end
               end

--- a/lib/datadog/di/remote.rb
+++ b/lib/datadog/di/remote.rb
@@ -51,7 +51,7 @@ module Datadog
                     probe = ProbeBuilder.build_from_remote_config(probe_spec)
                     payload = component.probe_notification_builder.build_received(probe)
                     component.probe_notifier_worker.add_status(payload)
-                    component.logger.info("Received probe from RC: #{probe.type} #{probe.location}")
+                    component.log_info_internal("Received probe from RC: #{probe.type} #{probe.location}")
 
                     begin
                       # TODO test exception capture
@@ -60,7 +60,7 @@ module Datadog
                     rescue => exc
                       raise if component.settings.dynamic_instrumentation.internal.propagate_all_exceptions
 
-                      component.logger.warn("Unhandled exception adding probe in DI remote receiver: #{exc.class}: #{exc}")
+                      component.log_warn_internal("Unhandled exception adding probe in DI remote receiver: #{exc.class}: #{exc}")
                       component.telemetry&.report(exc, description: "Unhandled exception adding probe in DI remote receiver")
 
                       # If a probe fails to install, we will mark the content
@@ -81,7 +81,7 @@ module Datadog
                   rescue => exc
                     raise if component.settings.dynamic_instrumentation.internal.propagate_all_exceptions
 
-                    component.logger.warn("Unhandled exception handling probe in DI remote receiver: #{exc.class}: #{exc}")
+                    component.log_warn_internal("Unhandled exception handling probe in DI remote receiver: #{exc.class}: #{exc}")
                     component.telemetry&.report(exc, description: "Unhandled exception handling probe in DI remote receiver")
 
                     content.errored("Error applying dynamic instrumentation configuration: #{exc.class.name} #{exc.message}: #{Array(exc.backtrace).join("\n")}")
@@ -95,7 +95,7 @@ module Datadog
               rescue => exc
                 raise if component.settings.dynamic_instrumentation.internal.propagate_all_exceptions
 
-                component.logger.warn("Unhandled exception removing probes in DI remote receiver: #{exc.class}: #{exc}")
+                component.log_warn_internal("Unhandled exception removing probes in DI remote receiver: #{exc.class}: #{exc}")
                 component.telemetry&.report(exc, description: "Unhandled exception removing probes in DI remote receiver")
               end
             end

--- a/spec/datadog/di/instrumenter_spec.rb
+++ b/spec/datadog/di/instrumenter_spec.rb
@@ -11,6 +11,7 @@ RSpec.describe Datadog::DI::Instrumenter do
   mock_settings_for_di do |settings|
     allow(settings.dynamic_instrumentation).to receive(:enabled).and_return(true)
     allow(settings.dynamic_instrumentation.internal).to receive(:untargeted_trace_points).and_return(false)
+    allow(settings.dynamic_instrumentation.internal).to receive(:verbose_logging).and_return(true)
     allow(settings.dynamic_instrumentation).to receive(:max_capture_depth).and_return(2)
     allow(settings.dynamic_instrumentation).to receive(:max_capture_attribute_count).and_return(2)
     allow(settings.dynamic_instrumentation).to receive(:max_capture_string_length).and_return(100)

--- a/spec/datadog/di/probe_manager_spec.rb
+++ b/spec/datadog/di/probe_manager_spec.rb
@@ -9,6 +9,7 @@ RSpec.describe Datadog::DI::ProbeManager do
   mock_settings_for_di do |settings|
     allow(settings.dynamic_instrumentation).to receive(:enabled).and_return(true)
     allow(settings.dynamic_instrumentation.internal).to receive(:propagate_all_exceptions).and_return(false)
+    allow(settings.dynamic_instrumentation.internal).to receive(:verbose_logging).and_return(true)
   end
 
   let(:instrumenter) do


### PR DESCRIPTION

<!--
Check out the
https://github.com/DataDog/dd-trace-rb/blob/master/docs/DevelopmentGuide.md
for guidance on how to set up your development environment,
run the test suite, write new integrations, and more.
-->

**What does this PR do?**
<!-- A brief description of the change being made with this pull request. -->
Failure to enable DI is now a warning (since enabling it must have been requested by the customer).

Remaining logging calls are now emitted at debug level by default, making those entries not visible in customer logs.

An internal DI setting is added to reinstate logging of internal issues at warn level, for developing/debugging DI.

**Motivation:**
<!-- What inspired you to submit this pull request? -->
DI currently uses the logger for reporting its internal issues. However, the logger normally logs to customer logs, and as such the default logging should be customer-centric, meaning log entries should only be created for matters that the customers understand and can fix.

**Change log entry**
<!-- If this is a customer-visible change, a brief summary to be placed
into the change log.
If you are not a Datadog employee, you can skip this section
and it will be filled or deleted during PR review. -->
Dynamic instrumentation: logging of internal conditions is now done on debug level, and these log entries will not be visible by default in customer applications.

**Additional Notes:**
<!-- Anything else we should know when reviewing? -->

**How to test the change?**
<!--
Describe here how the change can be validated.
You are strongly encouraged to provide automated tests for this PR (unit or integration).
If this change cannot be feasibly tested, please explain why,
unless the change does not modify code (e.g. only modifies docs, comments).
-->
Due to the introduction of an additional layer of abstraction for DI logging, end-to-end tests will need to have additional assertions added for log entries being visible (or not). This will be done as part of DEBUG-3210 but is not part of this PR.

<!-- Unsure? Have a question? Request a review! -->
