### PR TITLE
[PROF-11045] Fix profiling warnings being really hard to silence

### DIFF
--- a/lib/datadog/core/configuration/components.rb
+++ b/lib/datadog/core/configuration/components.rb
@@ -105,7 +105,8 @@ module Datadog
           @profiler, profiler_logger_extra = Datadog::Profiling::Component.build_profiler_component(
             settings: settings,
             agent_settings: agent_settings,
-            optional_tracer: @tracer
+            optional_tracer: @tracer,
+            logger: @logger,
           )
           @environment_logger_extra.merge!(profiler_logger_extra) if profiler_logger_extra
 

--- a/lib/datadog/profiling/component.rb
+++ b/lib/datadog/profiling/component.rb
@@ -5,7 +5,7 @@ module Datadog
     # Responsible for wiring up the Profiler for execution
     module Component
       # Passing in a `nil` tracer is supported and will disable the following profiling features:
-      # * Code Hotspots panel in the trace viewer, as well as scoping a profile down to a span
+      # * Profiling in the trace viewer, as well as scoping a profile down to a span
       # * Endpoint aggregation in the profiler UX, including normalization (resource per endpoint call)
       def self.build_profiler_component(settings:, agent_settings:, optional_tracer:) # rubocop:disable Metrics/MethodLength
         return [nil, {profiling_enabled: false}] unless settings.profiling.enabled

--- a/lib/datadog/profiling/component.rb
+++ b/lib/datadog/profiling/component.rb
@@ -246,7 +246,6 @@ module Datadog
 
       private_class_method def self.no_signals_workaround_enabled?(settings, logger) # rubocop:disable Metrics/MethodLength
         setting_value = settings.profiling.advanced.no_signals_workaround_enabled
-        legacy_ruby_that_should_use_workaround = RUBY_VERSION.start_with?("2.5.")
 
         unless [true, false, :auto].include?(setting_value)
           logger.warn(
@@ -284,7 +283,7 @@ module Datadog
         # Setting is in auto mode. Let's probe to see if we should enable it:
 
         # We don't warn users in this situation because "upgrade your Ruby" is not a great warning
-        return true if legacy_ruby_that_should_use_workaround
+        return true if RUBY_VERSION.start_with?("2.5.")
 
         if Gem.loaded_specs["mysql2"] && incompatible_libmysqlclient_version?(settings, logger)
           logger.warn(

--- a/lib/datadog/profiling/component.rb
+++ b/lib/datadog/profiling/component.rb
@@ -244,8 +244,7 @@ module Datadog
         legacy_ruby_that_should_use_workaround = RUBY_VERSION.start_with?("2.5.")
 
         unless [true, false, :auto].include?(setting_value)
-          # TODO: Replace with a warning instead.
-          logger.error(
+          logger.warn(
             "Ignoring invalid value for profiling no_signals_workaround_enabled setting: #{setting_value.inspect}. " \
             "Valid options are `true`, `false` or (default) `:auto`."
           )
@@ -387,8 +386,7 @@ module Datadog
         if overhead_target_percentage > 0 && overhead_target_percentage <= 20
           overhead_target_percentage
         else
-          # TODO: Replace with a warning instead.
-          logger.error(
+          logger.warn(
             "Ignoring invalid value for profiling overhead_target_percentage setting: " \
             "#{overhead_target_percentage.inspect}. Falling back to default value."
           )

--- a/lib/datadog/profiling/component.rb
+++ b/lib/datadog/profiling/component.rb
@@ -138,7 +138,7 @@ module Datadog
           return false
         elsif RUBY_VERSION.start_with?("3.")
           Datadog.logger.debug(
-            "In all known versions of Ruby 3.x, using Ractors may result in GC profiling unexpectedly " \
+            "Using Ractors may result in GC profiling unexpectedly " \
             "stopping (https://bugs.ruby-lang.org/issues/19112). Note that this stop has no impact in your " \
             "application stability or performance. This does not happen if Ractors are not used."
           )
@@ -254,12 +254,12 @@ module Datadog
         end
 
         if setting_value == false
-          if legacy_ruby_that_should_use_workaround
+          if RUBY_VERSION.start_with?("2.5.")
             Datadog.logger.warn(
-              'The profiling "no signals" workaround has been disabled via configuration on a legacy Ruby version ' \
-              "(< 2.6). This is not recommended " \
-              "in production environments, as due to limitations in Ruby APIs, we suspect it may lead to crashes " \
-              "in very rare situations. Please report any issues you run into to Datadog support or " \
+              'The profiling "no signals" workaround has been disabled via configuration on Ruby 2.5. ' \
+              "This is not recommended " \
+              "in production environments, as due to limitations in Ruby APIs, we suspect it may lead to rare crashes " \
+              "Please report any issues you run into to Datadog support or " \
               "via <https://github.com/datadog/dd-trace-rb/issues/new>!"
             )
           else

--- a/lib/datadog/profiling/component.rb
+++ b/lib/datadog/profiling/component.rb
@@ -190,8 +190,8 @@ module Datadog
         # On all known versions of Ruby 3.x, due to https://bugs.ruby-lang.org/issues/19112, when a ractor gets
         # garbage collected, Ruby will disable all active tracepoints, which this feature internally relies on.
         elsif RUBY_VERSION.start_with?("3.")
-          Datadog.logger.warn(
-            "In all known versions of Ruby 3.x, using Ractors may result in allocation profiling unexpectedly " \
+          Datadog.logger.info(
+            "Using Ractors may result in allocation profiling " \
             "stopping (https://bugs.ruby-lang.org/issues/19112). Note that this stop has no impact in your " \
             "application stability or performance. This does not happen if Ractors are not used."
           )

--- a/sig/datadog/profiling/component.rbs
+++ b/sig/datadog/profiling/component.rbs
@@ -5,6 +5,7 @@ module Datadog
         settings: untyped,
         agent_settings: Datadog::Core::Configuration::AgentSettingsResolver::AgentSettings,
         optional_tracer: Datadog::Tracing::Tracer?,
+        logger: Datadog::Core::Logger,
       ) -> [Datadog::Profiling::Profiler?, {profiling_enabled: bool}]
 
       def self.build_thread_context_collector: (
@@ -26,20 +27,25 @@ module Datadog
         Datadog::Core::Configuration::AgentSettingsResolver::AgentSettings agent_settings
       ) -> untyped
 
-      def self.enable_gc_profiling?: (untyped settings) -> bool
-      def self.enable_allocation_profiling?: (untyped settings) -> bool
+      def self.enable_gc_profiling?: (untyped settings, Datadog::Core::Logger logger) -> bool
+      def self.enable_allocation_profiling?: (untyped settings, Datadog::Core::Logger logger) -> bool
       def self.get_heap_sample_every: (untyped settings) -> ::Integer
-      def self.enable_heap_profiling?: (untyped settings, bool allocation_profiling_enabled, ::Integer heap_sample_every) -> bool
-      def self.enable_heap_size_profiling?: (untyped settings, bool heap_profiling_enabled) -> bool
+      def self.enable_heap_profiling?: (
+        untyped settings,
+        bool allocation_profiling_enabled,
+        ::Integer heap_sample_every,
+        Datadog::Core::Logger logger,
+      ) -> bool
+      def self.enable_heap_size_profiling?: (untyped settings, bool heap_profiling_enabled, Datadog::Core::Logger logger) -> bool
 
-      def self.no_signals_workaround_enabled?: (untyped settings) -> bool
-      def self.incompatible_libmysqlclient_version?: (untyped settings) -> bool
+      def self.no_signals_workaround_enabled?: (untyped settings, Datadog::Core::Logger logger) -> bool
+      def self.incompatible_libmysqlclient_version?: (untyped settings, Datadog::Core::Logger logger) -> bool
       def self.incompatible_passenger_version?: () -> bool
       def self.flush_interval: (untyped settings) -> ::Numeric
-      def self.valid_overhead_target: (::Float overhead_target_percentage) -> ::Float
+      def self.valid_overhead_target: (::Float overhead_target_percentage, Datadog::Core::Logger logger) -> ::Float
       def self.looks_like_mariadb?: ({ header_version: ::String? }, ::Gem::Version) -> bool
       def self.dir_interruption_workaround_enabled?: (untyped settings, bool no_signals_workaround_enabled) -> bool
-      def self.enable_gvl_profiling?: (untyped settings) -> bool
+      def self.enable_gvl_profiling?: (untyped settings, Datadog::Core::Logger logger) -> bool
     end
   end
 end

--- a/sig/datadog/profiling/component.rbs
+++ b/sig/datadog/profiling/component.rbs
@@ -1,6 +1,8 @@
 module Datadog
   module Profiling
     module Component
+      ALLOCATION_WITH_RACTORS_ONLY_ONCE: Datadog::Core::Utils::OnlyOnce
+
       def self.build_profiler_component: (
         settings: untyped,
         agent_settings: Datadog::Core::Configuration::AgentSettingsResolver::AgentSettings,

--- a/spec/datadog/core/configuration/components_spec.rb
+++ b/spec/datadog/core/configuration/components_spec.rb
@@ -75,7 +75,8 @@ RSpec.describe Datadog::Core::Configuration::Components do
       expect(Datadog::Profiling::Component).to receive(:build_profiler_component).with(
         settings: settings,
         agent_settings: agent_settings,
-        optional_tracer: tracer
+        optional_tracer: tracer,
+        logger: logger,
       ).and_return([profiler, environment_logger_extra])
 
       expect(described_class).to receive(:build_runtime_metrics_worker)
@@ -1091,7 +1092,8 @@ RSpec.describe Datadog::Core::Configuration::Components do
           expect(Datadog::Profiling::Component).to receive(:build_profiler_component).with(
             settings: settings,
             agent_settings: agent_settings,
-            optional_tracer: anything
+            optional_tracer: anything,
+            logger: anything, # Tested above in "new"
           ).and_return([profiler, environment_logger_extra])
         end
 

--- a/spec/datadog/profiling/component_spec.rb
+++ b/spec/datadog/profiling/component_spec.rb
@@ -360,6 +360,7 @@ RSpec.describe Datadog::Profiling::Component do
                   .with(hash_including(heap_samples_enabled: true, heap_size_enabled: false))
                   .and_call_original
 
+                expect(Datadog.logger).to receive(:info).with(/Ractors.+stopping/)
                 expect(Datadog.logger).to receive(:debug).with(/Enabled allocation profiling/)
                 expect(Datadog.logger).to receive(:warn).with(/experimental heap profiling/)
                 expect(Datadog.logger).not_to receive(:warn).with(/experimental heap size profiling/)

--- a/spec/datadog/profiling/component_spec.rb
+++ b/spec/datadog/profiling/component_spec.rb
@@ -203,6 +203,8 @@ RSpec.describe Datadog::Profiling::Component do
             settings.profiling.allocation_enabled = true
             settings.profiling.advanced.gc_enabled = false # Disable this to avoid any additional warnings coming from it
             stub_const("RUBY_VERSION", testing_version)
+
+            described_class.const_get(:ALLOCATION_WITH_RACTORS_ONLY_ONCE).send(:reset_ran_once_state_for_tests)
           end
 
           context "on Ruby 2.x" do
@@ -337,6 +339,8 @@ RSpec.describe Datadog::Profiling::Component do
           context "and allocation profiling enabled and supported" do
             before do
               settings.profiling.allocation_enabled = true
+
+              described_class.const_get(:ALLOCATION_WITH_RACTORS_ONLY_ONCE).send(:reset_ran_once_state_for_tests)
             end
 
             it "initializes StackRecorder with heap sampling support and warns" do

--- a/spec/datadog/profiling/component_spec.rb
+++ b/spec/datadog/profiling/component_spec.rb
@@ -272,7 +272,7 @@ RSpec.describe Datadog::Profiling::Component do
                   .with(hash_including(alloc_samples_enabled: true))
                   .and_call_original
 
-                expect(Datadog.logger).to receive(:warn).with(/Ractors.+stopping/)
+                expect(Datadog.logger).to receive(:info).with(/Ractors.+stopping/)
                 expect(Datadog.logger).to receive(:debug).with(/Enabled allocation profiling/)
 
                 build_profiler_component
@@ -342,7 +342,7 @@ RSpec.describe Datadog::Profiling::Component do
                 .with(hash_including(heap_samples_enabled: true, heap_size_enabled: true))
                 .and_call_original
 
-              expect(Datadog.logger).to receive(:warn).with(/Ractors.+stopping/)
+              expect(Datadog.logger).to receive(:info).with(/Ractors.+stopping/)
               expect(Datadog.logger).to receive(:debug).with(/Enabled allocation profiling/)
               expect(Datadog.logger).to receive(:warn).with(/experimental heap profiling/)
               expect(Datadog.logger).to receive(:warn).with(/experimental heap size profiling/)

--- a/spec/datadog/profiling/component_spec.rb
+++ b/spec/datadog/profiling/component_spec.rb
@@ -689,7 +689,7 @@ RSpec.describe Datadog::Profiling::Component do
 
       context "when overhead_target_percentage is invalid value (#{invalid_value})" do
         it "logs an error" do
-          expect(logger).to receive(:error).with(
+          expect(logger).to receive(:warn).with(
             /Ignoring invalid value for profiling overhead_target_percentage/
           )
 
@@ -697,7 +697,7 @@ RSpec.describe Datadog::Profiling::Component do
         end
 
         it "falls back to the default value" do
-          allow(logger).to receive(:error)
+          allow(logger).to receive(:warn)
 
           expect(valid_overhead_target).to eq 2.0
         end
@@ -1009,13 +1009,8 @@ RSpec.describe Datadog::Profiling::Component do
     context "when no_signals_workaround_enabled is an invalid value" do
       before do
         settings.profiling.advanced.no_signals_workaround_enabled = "invalid value"
-        allow(logger).to receive(:error)
-      end
 
-      it "logs an error message mentioning that the invalid value will be ignored" do
-        expect(logger).to receive(:error).with(/Ignoring invalid value/)
-
-        no_signals_workaround_enabled?
+        expect(logger).to receive(:warn).with(/Ignoring invalid value/)
       end
 
       include_examples "no_signals_workaround_enabled :auto behavior"

--- a/spec/datadog/profiling/component_spec.rb
+++ b/spec/datadog/profiling/component_spec.rb
@@ -177,7 +177,7 @@ RSpec.describe Datadog::Profiling::Component do
 
             it "emits a debug log about Ractors interfering with GC profiling" do
               expect(Datadog.logger)
-                .to receive(:debug).with(/using Ractors may result in GC profiling unexpectedly stopping/)
+                .to receive(:debug).with(/Ractors may result in GC profiling unexpectedly stopping/)
 
               build_profiler_component
             end


### PR DESCRIPTION
**What does this PR do?**

This PR fixes the report we had in #4231 that the profiling initialization warnings were hard to silence.

In particular, due to the way the profiling component was accessing the dd-trace-rb logger, any configuration changes to change the log level were actually not visible to the profiling component. This issue is now fixed, and enabling profiling + changing the log level in the same `Datadog.configure` block will be respected.

I also included a few more improvements:
* Wrapped the message from #4231 in an `OnlyOnce` so even when it does get logged, it will only get logged at most once
* Lowered the log level of some of our log messages
* Simplified/cleaned up a few of the messages

**Motivation:**

Fixes #4231

**Change log entry**

Yes. Fix profiling warnings being really hard to silence

**Additional Notes:**

There's still one case where it's not possible to avoid the warning: when starting profiling via an environment variable (e.g. `DD_PROFILING_ENABLED=true bundle exec ddprofrb ruby <somescript>`).

This is a result of there not being a way to set the log level of dd-trace-rb via an environment variable. I decided to not tackle this one for now; hopefully the fixes above are enough of an improvement to the status quo ;)

**How to test the change?**

Here's two sample test cases:

1. `DD_PROFILING_ENABLED=true DD_PROFILING_ALLOCATION_ENABLED=true bundle exec ddprofrb exec ruby -e "Datadog.configure { |c| c.logger.level = Logger::ERROR; c.profiling.enabled = true };"`

With this PR prints the "using Ractors may result in allocation profiling stopping" only once, whereas in master it prints it multiple times

2. `DD_PROFILING_ALLOCATION_ENABLED=true bundle exec ruby -e "require 'datadog/auto_instrument'; Datadog.configure { |c| c.logger.level = Logger::ERROR; c.profiling.enabled = true }"`

With this PR does not print the message; whereas in master it prints it once.