### PR TITLE
APMLP-350 fix crash in crashtracker when agent url is an ipv6 address

### DIFF
--- a/ext/libdatadog_api/crashtracker.c
+++ b/ext/libdatadog_api/crashtracker.c
@@ -54,6 +54,9 @@ static VALUE _native_start_or_update_on_fork(int argc, VALUE *argv, DDTRACE_UNUS
   // Tags and endpoint are heap-allocated, so after here we can't raise exceptions otherwise we'll leak this memory
   // Start of exception-free zone to prevent leaks {{
   ddog_Endpoint *endpoint = ddog_endpoint_from_url(char_slice_from_ruby_string(agent_base_url));
+  if (endpoint == NULL) {
+    rb_raise(rb_eRuntimeError, "Failed to create endpoint from agent_base_url: %"PRIsVALUE, agent_base_url);
+  }
   ddog_Vec_Tag tags = convert_tags(tags_as_array);
 
   ddog_crasht_Config config = {

--- a/lib/datadog/core/crashtracking/agent_base_url.rb
+++ b/lib/datadog/core/crashtracking/agent_base_url.rb
@@ -10,15 +10,13 @@ module Datadog
         # IPv6 regular expression from
         # https://stackoverflow.com/questions/53497/regular-expression-that-matches-valid-ipv6-addresses
         # Does not match IPv4 addresses.
-        IPV6_REGEXP = /\A(([0-9a-fA-F]{1,4}:){7,7}[0-9a-fA-F]{1,4}|([0-9a-fA-F]{1,4}:){1,7}:|([0-9a-fA-F]{1,4}:){1,6}:[0-9a-fA-F]{1,4}|([0-9a-fA-F]{1,4}:){1,5}(:[0-9a-fA-F]{1,4}){1,2}|([0-9a-fA-F]{1,4}:){1,4}(:[0-9a-fA-F]{1,4}){1,3}|([0-9a-fA-F]{1,4}:){1,3}(:[0-9a-fA-F]{1,4}){1,4}|([0-9a-fA-F]{1,4}:){1,2}(:[0-9a-fA-F]{1,4}){1,5}|[0-9a-fA-F]{1,4}:((:[0-9a-fA-F]{1,4}){1,6})|:((:[0-9a-fA-F]{1,4}){1,7}|:)|fe80:(:[0-9a-fA-F]{0,4}){0,4}%[0-9a-zA-Z]{1,}|::(ffff(:0{1,4}){0,1}:){0,1}((25[0-5]|(2[0-4]|1{0,1}[0-9]){0,1}[0-9])\.){3,3}(25[0-5]|(2[0-4]|1{0,1}[0-9]){0,1}[0-9])|([0-9a-fA-F]{1,4}:){1,4}:((25[0-5]|(2[0-4]|1{0,1}[0-9]){0,1}[0-9])\.){3,3}(25[0-5]|(2[0-4]|1{0,1}[0-9]){0,1}[0-9])\z)/
+        IPV6_REGEXP = /\A(([0-9a-fA-F]{1,4}:){7,7}[0-9a-fA-F]{1,4}|([0-9a-fA-F]{1,4}:){1,7}:|([0-9a-fA-F]{1,4}:){1,6}:[0-9a-fA-F]{1,4}|([0-9a-fA-F]{1,4}:){1,5}(:[0-9a-fA-F]{1,4}){1,2}|([0-9a-fA-F]{1,4}:){1,4}(:[0-9a-fA-F]{1,4}){1,3}|([0-9a-fA-F]{1,4}:){1,3}(:[0-9a-fA-F]{1,4}){1,4}|([0-9a-fA-F]{1,4}:){1,2}(:[0-9a-fA-F]{1,4}){1,5}|[0-9a-fA-F]{1,4}:((:[0-9a-fA-F]{1,4}){1,6})|:((:[0-9a-fA-F]{1,4}){1,7}|:)|fe80:(:[0-9a-fA-F]{0,4}){0,4}%[0-9a-zA-Z]{1,}|::(ffff(:0{1,4}){0,1}:){0,1}((25[0-5]|(2[0-4]|1{0,1}[0-9]){0,1}[0-9])\.){3,3}(25[0-5]|(2[0-4]|1{0,1}[0-9]){0,1}[0-9])|([0-9a-fA-F]{1,4}:){1,4}:((25[0-5]|(2[0-4]|1{0,1}[0-9]){0,1}[0-9])\.){3,3}(25[0-5]|(2[0-4]|1{0,1}[0-9]){0,1}[0-9])\z)/.freeze
 
         def self.resolve(agent_settings)
           case agent_settings.adapter
           when Datadog::Core::Configuration::Ext::Agent::HTTP::ADAPTER
             hostname = agent_settings.hostname
-            if hostname =~ IPV6_REGEXP
-              hostname = "[#{hostname}]"
-            end
+            hostname = "[#{hostname}]" if hostname =~ IPV6_REGEXP
             "#{agent_settings.ssl ? 'https' : 'http'}://#{hostname}:#{agent_settings.port}/"
           when Datadog::Core::Configuration::Ext::Agent::UnixSocket::ADAPTER
             "unix://#{agent_settings.uds_path}"

--- a/lib/datadog/core/crashtracking/agent_base_url.rb
+++ b/lib/datadog/core/crashtracking/agent_base_url.rb
@@ -7,10 +7,19 @@ module Datadog
     module Crashtracking
       # This module provides a method to resolve the base URL of the agent
       module AgentBaseUrl
+        # IPv6 regular expression from
+        # https://stackoverflow.com/questions/53497/regular-expression-that-matches-valid-ipv6-addresses
+        # Does not match IPv4 addresses.
+        IPV6_REGEXP = /\A(([0-9a-fA-F]{1,4}:){7,7}[0-9a-fA-F]{1,4}|([0-9a-fA-F]{1,4}:){1,7}:|([0-9a-fA-F]{1,4}:){1,6}:[0-9a-fA-F]{1,4}|([0-9a-fA-F]{1,4}:){1,5}(:[0-9a-fA-F]{1,4}){1,2}|([0-9a-fA-F]{1,4}:){1,4}(:[0-9a-fA-F]{1,4}){1,3}|([0-9a-fA-F]{1,4}:){1,3}(:[0-9a-fA-F]{1,4}){1,4}|([0-9a-fA-F]{1,4}:){1,2}(:[0-9a-fA-F]{1,4}){1,5}|[0-9a-fA-F]{1,4}:((:[0-9a-fA-F]{1,4}){1,6})|:((:[0-9a-fA-F]{1,4}){1,7}|:)|fe80:(:[0-9a-fA-F]{0,4}){0,4}%[0-9a-zA-Z]{1,}|::(ffff(:0{1,4}){0,1}:){0,1}((25[0-5]|(2[0-4]|1{0,1}[0-9]){0,1}[0-9])\.){3,3}(25[0-5]|(2[0-4]|1{0,1}[0-9]){0,1}[0-9])|([0-9a-fA-F]{1,4}:){1,4}:((25[0-5]|(2[0-4]|1{0,1}[0-9]){0,1}[0-9])\.){3,3}(25[0-5]|(2[0-4]|1{0,1}[0-9]){0,1}[0-9])\z)/
+
         def self.resolve(agent_settings)
           case agent_settings.adapter
           when Datadog::Core::Configuration::Ext::Agent::HTTP::ADAPTER
-            "#{agent_settings.ssl ? 'https' : 'http'}://#{agent_settings.hostname}:#{agent_settings.port}/"
+            hostname = agent_settings.hostname
+            if hostname =~ IPV6_REGEXP
+              hostname = "[#{hostname}]"
+            end
+            "#{agent_settings.ssl ? 'https' : 'http'}://#{hostname}:#{agent_settings.port}/"
           when Datadog::Core::Configuration::Ext::Agent::UnixSocket::ADAPTER
             "unix://#{agent_settings.uds_path}"
           end

--- a/lib/datadog/core/crashtracking/agent_base_url.rb
+++ b/lib/datadog/core/crashtracking/agent_base_url.rb
@@ -10,15 +10,13 @@ module Datadog
         # IPv6 regular expression from
         # https://stackoverflow.com/questions/53497/regular-expression-that-matches-valid-ipv6-addresses
         # Does not match IPv4 addresses.
-        IPV6_REGEXP = /\A(([0-9a-fA-F]{1,4}:){7,7}[0-9a-fA-F]{1,4}|([0-9a-fA-F]{1,4}:){1,7}:|([0-9a-fA-F]{1,4}:){1,6}:[0-9a-fA-F]{1,4}|([0-9a-fA-F]{1,4}:){1,5}(:[0-9a-fA-F]{1,4}){1,2}|([0-9a-fA-F]{1,4}:){1,4}(:[0-9a-fA-F]{1,4}){1,3}|([0-9a-fA-F]{1,4}:){1,3}(:[0-9a-fA-F]{1,4}){1,4}|([0-9a-fA-F]{1,4}:){1,2}(:[0-9a-fA-F]{1,4}){1,5}|[0-9a-fA-F]{1,4}:((:[0-9a-fA-F]{1,4}){1,6})|:((:[0-9a-fA-F]{1,4}){1,7}|:)|fe80:(:[0-9a-fA-F]{0,4}){0,4}%[0-9a-zA-Z]{1,}|::(ffff(:0{1,4}){0,1}:){0,1}((25[0-5]|(2[0-4]|1{0,1}[0-9]){0,1}[0-9])\.){3,3}(25[0-5]|(2[0-4]|1{0,1}[0-9]){0,1}[0-9])|([0-9a-fA-F]{1,4}:){1,4}:((25[0-5]|(2[0-4]|1{0,1}[0-9]){0,1}[0-9])\.){3,3}(25[0-5]|(2[0-4]|1{0,1}[0-9]){0,1}[0-9])\z)/ # rubocop:disable Layout/LineLength
+        IPV6_REGEXP = /\A(([0-9a-fA-F]{1,4}:){7,7}[0-9a-fA-F]{1,4}|([0-9a-fA-F]{1,4}:){1,7}:|([0-9a-fA-F]{1,4}:){1,6}:[0-9a-fA-F]{1,4}|([0-9a-fA-F]{1,4}:){1,5}(:[0-9a-fA-F]{1,4}){1,2}|([0-9a-fA-F]{1,4}:){1,4}(:[0-9a-fA-F]{1,4}){1,3}|([0-9a-fA-F]{1,4}:){1,3}(:[0-9a-fA-F]{1,4}){1,4}|([0-9a-fA-F]{1,4}:){1,2}(:[0-9a-fA-F]{1,4}){1,5}|[0-9a-fA-F]{1,4}:((:[0-9a-fA-F]{1,4}){1,6})|:((:[0-9a-fA-F]{1,4}){1,7}|:)|fe80:(:[0-9a-fA-F]{0,4}){0,4}%[0-9a-zA-Z]{1,}|::(ffff(:0{1,4}){0,1}:){0,1}((25[0-5]|(2[0-4]|1{0,1}[0-9]){0,1}[0-9])\.){3,3}(25[0-5]|(2[0-4]|1{0,1}[0-9]){0,1}[0-9])|([0-9a-fA-F]{1,4}:){1,4}:((25[0-5]|(2[0-4]|1{0,1}[0-9]){0,1}[0-9])\.){3,3}(25[0-5]|(2[0-4]|1{0,1}[0-9]){0,1}[0-9])\z)/.freeze # rubocop:disable Layout/LineLength
 
         def self.resolve(agent_settings)
           case agent_settings.adapter
           when Datadog::Core::Configuration::Ext::Agent::HTTP::ADAPTER
             hostname = agent_settings.hostname
-            if hostname =~ IPV6_REGEXP
-              hostname = "[#{hostname}]"
-            end
+            hostname = "[#{hostname}]" if hostname =~ IPV6_REGEXP
             "#{agent_settings.ssl ? 'https' : 'http'}://#{hostname}:#{agent_settings.port}/"
           when Datadog::Core::Configuration::Ext::Agent::UnixSocket::ADAPTER
             "unix://#{agent_settings.uds_path}"

--- a/lib/datadog/core/crashtracking/agent_base_url.rb
+++ b/lib/datadog/core/crashtracking/agent_base_url.rb
@@ -10,13 +10,15 @@ module Datadog
         # IPv6 regular expression from
         # https://stackoverflow.com/questions/53497/regular-expression-that-matches-valid-ipv6-addresses
         # Does not match IPv4 addresses.
-        IPV6_REGEXP = /\A(([0-9a-fA-F]{1,4}:){7,7}[0-9a-fA-F]{1,4}|([0-9a-fA-F]{1,4}:){1,7}:|([0-9a-fA-F]{1,4}:){1,6}:[0-9a-fA-F]{1,4}|([0-9a-fA-F]{1,4}:){1,5}(:[0-9a-fA-F]{1,4}){1,2}|([0-9a-fA-F]{1,4}:){1,4}(:[0-9a-fA-F]{1,4}){1,3}|([0-9a-fA-F]{1,4}:){1,3}(:[0-9a-fA-F]{1,4}){1,4}|([0-9a-fA-F]{1,4}:){1,2}(:[0-9a-fA-F]{1,4}){1,5}|[0-9a-fA-F]{1,4}:((:[0-9a-fA-F]{1,4}){1,6})|:((:[0-9a-fA-F]{1,4}){1,7}|:)|fe80:(:[0-9a-fA-F]{0,4}){0,4}%[0-9a-zA-Z]{1,}|::(ffff(:0{1,4}){0,1}:){0,1}((25[0-5]|(2[0-4]|1{0,1}[0-9]){0,1}[0-9])\.){3,3}(25[0-5]|(2[0-4]|1{0,1}[0-9]){0,1}[0-9])|([0-9a-fA-F]{1,4}:){1,4}:((25[0-5]|(2[0-4]|1{0,1}[0-9]){0,1}[0-9])\.){3,3}(25[0-5]|(2[0-4]|1{0,1}[0-9]){0,1}[0-9])\z)/.freeze
+        IPV6_REGEXP = /\A(([0-9a-fA-F]{1,4}:){7,7}[0-9a-fA-F]{1,4}|([0-9a-fA-F]{1,4}:){1,7}:|([0-9a-fA-F]{1,4}:){1,6}:[0-9a-fA-F]{1,4}|([0-9a-fA-F]{1,4}:){1,5}(:[0-9a-fA-F]{1,4}){1,2}|([0-9a-fA-F]{1,4}:){1,4}(:[0-9a-fA-F]{1,4}){1,3}|([0-9a-fA-F]{1,4}:){1,3}(:[0-9a-fA-F]{1,4}){1,4}|([0-9a-fA-F]{1,4}:){1,2}(:[0-9a-fA-F]{1,4}){1,5}|[0-9a-fA-F]{1,4}:((:[0-9a-fA-F]{1,4}){1,6})|:((:[0-9a-fA-F]{1,4}){1,7}|:)|fe80:(:[0-9a-fA-F]{0,4}){0,4}%[0-9a-zA-Z]{1,}|::(ffff(:0{1,4}){0,1}:){0,1}((25[0-5]|(2[0-4]|1{0,1}[0-9]){0,1}[0-9])\.){3,3}(25[0-5]|(2[0-4]|1{0,1}[0-9]){0,1}[0-9])|([0-9a-fA-F]{1,4}:){1,4}:((25[0-5]|(2[0-4]|1{0,1}[0-9]){0,1}[0-9])\.){3,3}(25[0-5]|(2[0-4]|1{0,1}[0-9]){0,1}[0-9])\z)/ # rubocop:disable Layout/LineLength
 
         def self.resolve(agent_settings)
           case agent_settings.adapter
           when Datadog::Core::Configuration::Ext::Agent::HTTP::ADAPTER
             hostname = agent_settings.hostname
-            hostname = "[#{hostname}]" if hostname =~ IPV6_REGEXP
+            if hostname =~ IPV6_REGEXP
+              hostname = "[#{hostname}]"
+            end
             "#{agent_settings.ssl ? 'https' : 'http'}://#{hostname}:#{agent_settings.port}/"
           when Datadog::Core::Configuration::Ext::Agent::UnixSocket::ADAPTER
             "unix://#{agent_settings.uds_path}"

--- a/sig/datadog/core/crashtracking/agent_base_url.rbs
+++ b/sig/datadog/core/crashtracking/agent_base_url.rbs
@@ -2,6 +2,7 @@ module Datadog
   module Core
     module Crashtracking
       module AgentBaseUrl
+        IPV6_REGEXP: Regexp
         def self.resolve: (Datadog::Core::Configuration::AgentSettingsResolver::AgentSettings) -> ::String?
       end
     end

--- a/spec/datadog/core/crashtracking/agent_base_url_spec.rb
+++ b/spec/datadog/core/crashtracking/agent_base_url_spec.rb
@@ -37,6 +37,38 @@ RSpec.describe Datadog::Core::Crashtracking::AgentBaseUrl do
           expect(described_class.resolve(agent_settings)).to eq('http://example.com:8080/')
         end
       end
+
+      context 'when hostname is an IPv4 address' do
+        let(:agent_settings) do
+          instance_double(
+            Datadog::Core::Configuration::AgentSettingsResolver::AgentSettings,
+            adapter: Datadog::Core::Configuration::Ext::Agent::HTTP::ADAPTER,
+            ssl: false,
+            hostname: '1.2.3.4',
+            port: 8080
+          )
+        end
+
+        it 'returns the correct base URL' do
+          expect(described_class.resolve(agent_settings)).to eq('http://1.2.3.4:8080/')
+        end
+      end
+
+      context 'when hostname is an IPv6 address' do
+        let(:agent_settings) do
+          instance_double(
+            Datadog::Core::Configuration::AgentSettingsResolver::AgentSettings,
+            adapter: Datadog::Core::Configuration::Ext::Agent::HTTP::ADAPTER,
+            ssl: false,
+            hostname: '1234:1234::1',
+            port: 8080
+          )
+        end
+
+        it 'returns the correct base URL' do
+          expect(described_class.resolve(agent_settings)).to eq('http://[1234:1234::1]:8080/')
+        end
+      end
     end
 
     context 'when using UnixSocket adapter' do


### PR DESCRIPTION
<!--
Check out the
https://github.com/DataDog/dd-trace-rb/blob/master/docs/DevelopmentGuide.md
for guidance on how to set up your development environment,
run the test suite, write new integrations, and more.
-->

**What does this PR do?**
<!-- A brief description of the change being made with this pull request. -->
- Repairs the crash in crashtracker due to insufficient error handling - adds a check for the endpoint construction failing (returning NULL) and raises an exception in this case
- Repairs incorrect agent URL construction from IPv6 addresses - the IPv6 addresses must be bracketed when put into the hostname of a URL

**Motivation:**
<!-- What inspired you to submit this pull request? -->
Crash reported by system tests

**Change log entry**
<!-- If this is a customer-visible change, a brief summary to be placed
into the change log.
If you are not a Datadog employee, you can skip this section
and it will be filled or deleted during PR review. -->
Yes: fix a crash in crashtracker when agent hostname is an IPv6 address

**Additional Notes:**
<!-- Anything else we should know when reviewing? -->
The code that this PR touches may have more missing error handling (of other situations), I didn't check it exhaustively.

**How to test the change?**
<!--
Describe here how the change can be validated.
You are strongly encouraged to provide automated tests for this PR (unit or integration).
If this change cannot be feasibly tested, please explain why,
unless the change does not modify code (e.g. only modifies docs, comments).
-->
Unit tests are added. 
I also wrote https://github.com/DataDog/libdatadog/pull/809 for libdatadog to verify it works OK with our provided input (which it does).

<!-- Unsure? Have a question? Request a review! -->
