### PR TITLE
[NOTICKET-1] use Ruby 3.4.1 for test-memcheck GHA + other fixes to bring master CI to green with 3.4

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -65,7 +65,7 @@ save_bundle_checksum: &save_bundle_checksum
     command: |
       if [ "$CI_BUNDLE_CACHE_HIT" != 1 ]; then
         # Recompute gemfiles/*.lock checksum, as those files might have changed
-        cat Gemfile Gemfile.lock Appraisals gemfiles/*.gemfile gemfiles/*.gemfile.lock | md5sum > .circleci/bundle_checksum
+        cat Gemfile Gemfile.lock ruby-*.gemfile gemfiles/*.gemfile gemfiles/*.gemfile.lock | md5sum > .circleci/bundle_checksum
       fi
       cp .circleci/bundle_checksum /usr/local/bundle/bundle_checksum
 step_bundle_install: &step_bundle_install
@@ -96,7 +96,7 @@ step_compute_bundle_checksum: &step_compute_bundle_checksum
     # updating the gemset lock files produces extremely large commits.
     command: |
       bundle lock # Create Gemfile.lock
-      cat Gemfile Gemfile.lock Appraisals gemfiles/*.gemfile gemfiles/*.gemfile.lock | md5sum > .circleci/bundle_checksum
+      cat Gemfile Gemfile.lock ruby-*.gemfile gemfiles/*.gemfile gemfiles/*.gemfile.lock | md5sum > .circleci/bundle_checksum
 step_get_test_agent_trace_check_results: &step_get_test_agent_trace_check_results
   run:
     name: Get APM Test Agent Trace Check Results

--- a/.github/workflows/test-memory-leaks.yaml
+++ b/.github/workflows/test-memory-leaks.yaml
@@ -7,10 +7,10 @@ jobs:
       - uses: actions/checkout@v4
       - uses: ruby/setup-ruby@v1
         with:
-          ruby-version: 3.4.0-preview2 # TODO: Use stable version once 3.4 is out
+          ruby-version: 3.4.1
           bundler-cache: true # runs 'bundle install' and caches installed gems automatically
           bundler: latest
-          cache-version: v1 # bump this to invalidate cache
+          cache-version: v2 # bump this to invalidate cache
       - run: sudo apt-get update && (sudo apt-get install -y valgrind || sleep 5 && sudo apt-get install -y valgrind) && valgrind --version
       - run: gem update --system 3.5.23 # TODO: This is a workaround for a buggy rubygems in 3.4.0-preview2; remove once stable version 3.4 is out
       - run: bundle exec rake compile spec:profiling:memcheck

--- a/integration/images/ruby/3.4/Dockerfile
+++ b/integration/images/ruby/3.4/Dockerfile
@@ -1,4 +1,4 @@
-FROM ruby:3.4.0-preview2
+FROM ruby:3.4
 
 ENV DEBIAN_FRONTEND=noninteractive
 

--- a/ruby-3.5.gemfile
+++ b/ruby-3.5.gemfile
@@ -1,0 +1,75 @@
+source 'https://rubygems.org'
+
+gemspec
+
+gem 'base64'
+gem 'benchmark-ips', '~> 2.8'
+gem 'benchmark-memory', '< 0.2' # V0.2 only works with 2.5+
+gem 'bigdecimal'
+gem 'climate_control', '~> 0.2.0'
+gem 'concurrent-ruby'
+
+# Optional extensions
+# TODO: Move this to Appraisals?
+# dogstatsd v5, but lower than 5.2, has possible memory leak with datadog.
+# @see https://github.com/DataDog/dogstatsd-ruby/issues/182
+gem 'dogstatsd-ruby', '>= 3.3.0', '!= 5.0.0', '!= 5.0.1', '!= 5.1.0'
+
+gem 'extlz4', '~> 0.3', '>= 0.3.3'
+
+# Profiler testing dependencies
+# NOTE: We're excluding versions 3.7.0 and 3.7.1 for the reasons documented in #1424.
+#       Since most of our customers won't have BUNDLE_FORCE_RUBY_PLATFORM=true, it's not something we want to add
+#       to our CI, so we just shortcut and exclude specific versions that were affecting our CI.
+gem 'google-protobuf', ['~> 3.0', '!= 3.7.0', '!= 3.7.1']
+
+gem 'json-schema', '< 3' # V3 only works with 2.5+
+gem 'memory_profiler', '~> 0.9'
+gem 'mutex_m'
+gem 'os', '~> 1.1'
+gem 'pimpmychangelog', '>= 0.1.2'
+gem 'pry'
+gem 'pry-stack_explorer'
+gem 'rake', '>= 10.5'
+gem 'rake-compiler', '~> 1.1', '>= 1.1.1' # To compile native extensions
+gem 'rspec', '~> 3.13'
+gem 'rspec-collection_matchers', '~> 1.1'
+gem 'rspec-wait', '~> 0'
+gem 'rspec_junit_formatter', '>= 0.5.1'
+
+# 1.50 is the last version to support Ruby 2.6
+gem 'rubocop', '~> 1.50.0', require: false
+gem 'rubocop-packaging', '~> 0.5.2', require: false
+gem 'rubocop-performance', '~> 1.9', require: false
+# 2.20 is the last version to support Ruby 2.6
+gem 'rubocop-rspec', ['~> 2.20', '< 2.21'], require: false
+
+# Merging branch coverage results does not work for old, unsupported rubies and JRuby
+# We have a fix up for review, https://github.com/simplecov-ruby/simplecov/pull/972,
+# but given it only affects unsupported version of Ruby, it might not get merged.
+gem 'simplecov', git: 'https://github.com/DataDog/simplecov', ref: '3bb6b7ee58bf4b1954ca205f50dd44d6f41c57db'
+gem 'simplecov-cobertura', '~> 2.1.0' # Used by codecov
+
+# Ruby 3.4 should be supported by strscan v3.1.1. However, the latest release of strscan is v3.1.0.
+# Pin strscan to the latest commit sha.
+#
+# TODO: Remove once v3.1.1 is released.
+gem 'strscan',
+  git: 'https://github.com/ruby/strscan',
+  ref: '041b15df4ccc067deabd85fd489b2c15961d0e2f'
+
+gem 'warning', '~> 1' # NOTE: Used in spec_helper.rb
+gem 'webmock', '>= 3.10.0'
+gem 'webrick', '>= 1.8.2'
+
+group :check do
+  gem 'rbs', '~> 3.7', require: false
+  gem 'steep', '~> 1', '>= 1.9.1', require: false
+  gem 'ruby_memcheck', '>= 3'
+  gem 'standard', require: false
+end
+
+group :dev do
+  gem 'ruby-lsp', require: false
+  gem 'appraisal', '~> 2.4.0', require: false
+end

--- a/ruby-3.5.gemfile
+++ b/ruby-3.5.gemfile
@@ -50,14 +50,6 @@ gem 'rubocop-rspec', ['~> 2.20', '< 2.21'], require: false
 gem 'simplecov', git: 'https://github.com/DataDog/simplecov', ref: '3bb6b7ee58bf4b1954ca205f50dd44d6f41c57db'
 gem 'simplecov-cobertura', '~> 2.1.0' # Used by codecov
 
-# Ruby 3.4 should be supported by strscan v3.1.1. However, the latest release of strscan is v3.1.0.
-# Pin strscan to the latest commit sha.
-#
-# TODO: Remove once v3.1.1 is released.
-gem 'strscan',
-  git: 'https://github.com/ruby/strscan',
-  ref: '041b15df4ccc067deabd85fd489b2c15961d0e2f'
-
 gem 'warning', '~> 1' # NOTE: Used in spec_helper.rb
 gem 'webmock', '>= 3.10.0'
 gem 'webrick', '>= 1.8.2'

--- a/suppressions/ruby-3.4.supp
+++ b/suppressions/ruby-3.4.supp
@@ -77,3 +77,19 @@
   obj:/usr/bin/tr
   ...
 }
+
+# When a Ruby process forks, it looks like Ruby doesn't clean up the memory of old threads?
+{
+  ruby-native-thread-memory-4
+  Memcheck:Leak
+  fun:calloc
+  fun:calloc1
+  fun:rb_gc_impl_calloc
+  fun:ruby_xcalloc_body
+  fun:ruby_xcalloc
+  fun:native_thread_alloc
+  fun:native_thread_create_dedicated
+  fun:native_thread_create
+  fun:thread_create_core
+  ...
+}


### PR DESCRIPTION
**What does this PR do?**
Fixes previously failing test-memcheck job by using released Ruby version 3.4.1 instead of Ruby 3.4.0-preview

**Motivation:**
CI started to fail

**Change log entry**
none

**How to test the change?**
CI is green