### PR TITLE
Update Compatibility.md for 3.4

### DIFF
--- a/docs/Compatibility.md
+++ b/docs/Compatibility.md
@@ -9,7 +9,8 @@ The Ruby Datadog Trace library is open source. See the [dd-trace-rb][1] GitHub r
 
 | Type  | Documentation              | Version   | Support type              | Gem version support |
 |-------|----------------------------|-----------|---------------------------|---------------------|
-| MRI   | https://www.ruby-lang.org/ | 3.3       | [latest](#support-latest) | Latest              |
+| MRI   | https://www.ruby-lang.org/ | 3.4       | [latest](#support-latest) | Latest              |
+|       |                            | 3.3       | [latest](#support-latest) | Latest              |
 |       |                            | 3.2       | [latest](#support-latest) | Latest              |
 |       |                            | 3.1       | [latest](#support-latest) | Latest              |
 |       |                            | 3.0       | [latest](#support-latest) | Latest              |


### PR DESCRIPTION
<!--
Check out the
https://github.com/DataDog/dd-trace-rb/blob/master/docs/DevelopmentGuide.md
for guidance on how to set up your development environment,
run the test suite, write new integrations, and more.
-->

**What does this PR do?**
Add Ruby 3.4 to the list of compatibilities.

**Motivation:**
Keep our public Compatibility.md doc updated to reflect new support.

**Change log entry**
Support for Ruby 3.4 is added.

**Additional Notes:**
N/A

**How to test the change?**
N/A

<!-- Unsure? Have a question? Request a review! -->
