### PR TITLE
Remove strscan specification in 3.4 gemfile

### DIFF
--- a/ruby-3.4.gemfile
+++ b/ruby-3.4.gemfile
@@ -49,15 +49,6 @@ gem 'rubocop-rspec', ['~> 2.20', '< 2.21'], require: false
 # but given it only affects unsupported version of Ruby, it might not get merged.
 gem 'simplecov', git: 'https://github.com/DataDog/simplecov', ref: '3bb6b7ee58bf4b1954ca205f50dd44d6f41c57db'
 gem 'simplecov-cobertura', '~> 2.1.0' # Used by codecov
-
-# Ruby 3.4 should be supported by strscan v3.1.1. However, the latest release of strscan is v3.1.0.
-# Pin strscan to the latest commit sha.
-#
-# TODO: Remove once v3.1.1 is released.
-gem 'strscan',
-  git: 'https://github.com/ruby/strscan',
-  ref: '041b15df4ccc067deabd85fd489b2c15961d0e2f'
-
 gem 'warning', '~> 1' # NOTE: Used in spec_helper.rb
 gem 'webmock', '>= 3.10.0'
 gem 'webrick', '>= 1.8.2'


### PR DESCRIPTION
<!--
Check out the
https://github.com/DataDog/dd-trace-rb/blob/master/docs/DevelopmentGuide.md
for guidance on how to set up your development environment,
run the test suite, write new integrations, and more.
-->

**What does this PR do?**
Remove pinned `strscan` version now that the gem has been updated to 3.1.2.

**Motivation:**
Keep our gemfiles updated.

**Change log entry**
No.

**Additional Notes:**
N/A

**How to test the change?**
Green CI.

<!-- Unsure? Have a question? Request a review! -->
