### PR TITLE
Remove `racc` gem from 3.3 and 3.4 appraisal files

### DIFF
--- a/appraisal/ruby-3.3.rb
+++ b/appraisal/ruby-3.3.rb
@@ -180,8 +180,6 @@ appraise 'contrib-old' do
   gem 'dalli', '< 3.0.0'
   gem 'presto-client', '>= 0.5.14' # Renamed to trino-client in >= 1.0
   gem 'qless', '0.12.0'
-
-  gem 'racc' # Remove this once graphql resolves issue for ruby 3.3 preview. https://github.com/rmosolgo/graphql-ruby/issues/4650
 end
 
 appraise 'core-old' do

--- a/appraisal/ruby-3.4.rb
+++ b/appraisal/ruby-3.4.rb
@@ -191,8 +191,6 @@ appraise 'contrib-old' do
   gem 'dalli', '< 3.0.0'
   gem 'presto-client', '>= 0.5.14' # Renamed to trino-client in >= 1.0
   gem 'qless', '0.12.0'
-
-  gem 'racc' # Remove this once graphql resolves issue for ruby 3.3 preview. https://github.com/rmosolgo/graphql-ruby/issues/4650
 end
 
 appraise 'core-old' do


### PR DESCRIPTION
<!--
Check out the
https://github.com/DataDog/dd-trace-rb/blob/master/docs/DevelopmentGuide.md
for guidance on how to set up your development environment,
run the test suite, write new integrations, and more.
-->

**What does this PR do?**
Remove `racc` gem from 3.3 and 3.4 appraisal files, since https://github.com/rmosolgo/graphql-ruby/issues/4650 is resolved.

**Motivation:**
Update appraisal files.

**Change log entry**
No.

**Additional Notes:**
N/A

**How to test the change?**
Green CI.

<!-- Unsure? Have a question? Request a review! -->
