### PR TITLE
(Draft) [NO-TICKET] Update crashtracker with libdatadog 15 breaking changes

### DIFF
--- a/ext/libdatadog_api/crashtracker.c
+++ b/ext/libdatadog_api/crashtracker.c
@@ -98,7 +98,7 @@ static VALUE _native_start_or_update_on_fork(int argc, VALUE *argv, DDTRACE_UNUS
     .optional_stdout_filename = {},
   };
 
-  ddog_crasht_Result result =
+  ddog_VoidResult result =
     action == start_action ?
       ddog_crasht_init(config, receiver_config, metadata) :
       ddog_crasht_update_on_fork(config, receiver_config, metadata);
@@ -108,7 +108,7 @@ static VALUE _native_start_or_update_on_fork(int argc, VALUE *argv, DDTRACE_UNUS
   ddog_endpoint_drop(endpoint);
   // }} End of exception-free zone to prevent leaks
 
-  if (result.tag == DDOG_CRASHT_RESULT_ERR) {
+  if (result.tag == DDOG_VOID_RESULT_ERR) {
     rb_raise(rb_eRuntimeError, "Failed to start/update the crash tracker: %"PRIsVALUE, get_error_details_and_drop(&result.err));
   }
 
@@ -116,9 +116,9 @@ static VALUE _native_start_or_update_on_fork(int argc, VALUE *argv, DDTRACE_UNUS
 }
 
 static VALUE _native_stop(DDTRACE_UNUSED VALUE _self) {
-  ddog_crasht_Result result = ddog_crasht_shutdown();
+  ddog_VoidResult result = ddog_crasht_shutdown();
 
-  if (result.tag == DDOG_CRASHT_RESULT_ERR) {
+  if (result.tag == DDOG_VOID_RESULT_ERR) {
     rb_raise(rb_eRuntimeError, "Failed to stop the crash tracker: %"PRIsVALUE, get_error_details_and_drop(&result.err));
   }
 


### PR DESCRIPTION
**What does this PR do?**

This PR updates the crasktracker C code to build with the latest libdatadog changes (in main) that will become part of libdatadog 15.

**Motivation:**

I'm working on a libdatadog branch and had to do this to unblock my work, so I decided I'll create a PR with it so nobody needs to repeat this work.

**Change log entry**

No

**Additional Notes:**

I'm opening this PR as draft as we shouldn't merge this until libdatadog 15 is out.

**How to test the change?**

Existing test coverage is enough to validate this.