### PR TITLE
[NO-TICKET] Add "How does Datadog help you?" to feature request template

### DIFF
--- a/.github/ISSUE_TEMPLATE/feature_request.yaml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yaml
@@ -48,3 +48,10 @@ body:
       description: Add any other context or screenshots about the feature request here
     validations:
       required: false
+
+  - type: textarea
+    attributes:
+      label: How does Datadog help you?
+      description: "Optionally, tell us why and how you're using datadog, and what your overall experience with it is!"
+    validations:
+      required: false


### PR DESCRIPTION
**What does this PR do?**

This PR adds a "How does Datadog help you?" question to the feature request template.

**Motivation:**

We've had it in the past, but it got removed as part of some cleanups in #4235, but we'd like to keep it for the reasons discussed in https://github.com/datadog/dd-trace-rb/pull/4235/files#r1891447495 .

**Change log entry**

None

**Additional Notes:**

N/A

**How to test the change?**

I'm not actually sure if there's any way to preview this before it's merged. But, you can check that

1. It's copy-pasted from https://github.com/DataDog/dd-trace-rb/blob/e3ea38f741bf936fda5b9e41c1271c38e6c61e8a/.github/ISSUE_TEMPLATE/bug_report.yaml
2. How that one looks in https://github.com/DataDog/dd-trace-rb/issues/new?template=bug_report.yaml