### PR TITLE
Remove obsolete code from gateway watchers

### DIFF
--- a/lib/datadog/appsec/contrib/graphql/gateway/watcher.rb
+++ b/lib/datadog/appsec/contrib/graphql/gateway/watcher.rb
@@ -46,14 +46,7 @@ module Datadog
 
                   next [nil, [[:block, event]]] if block
 
-                  ret, res = stack.call(gateway_multiplex.arguments)
-
-                  if event
-                    res ||= []
-                    res << [:monitor, event]
-                  end
-
-                  [ret, res]
+                  stack.call(gateway_multiplex.arguments)
                 end
               end
             end

--- a/lib/datadog/appsec/contrib/rack/gateway/watcher.rb
+++ b/lib/datadog/appsec/contrib/rack/gateway/watcher.rb
@@ -50,14 +50,7 @@ module Datadog
                   block = Rack::Reactive::Request.publish(engine, gateway_request)
                   next [nil, [[:block, event]]] if block
 
-                  ret, res = stack.call(gateway_request.request)
-
-                  if event
-                    res ||= []
-                    res << [:monitor, event]
-                  end
-
-                  [ret, res]
+                  stack.call(gateway_request.request)
                 end
               end
 
@@ -88,14 +81,7 @@ module Datadog
                   block = Rack::Reactive::Response.publish(engine, gateway_response)
                   next [nil, [[:block, event]]] if block
 
-                  ret, res = stack.call(gateway_response.response)
-
-                  if event
-                    res ||= []
-                    res << [:monitor, event]
-                  end
-
-                  [ret, res]
+                  stack.call(gateway_response.response)
                 end
               end
 
@@ -126,14 +112,7 @@ module Datadog
                   block = Rack::Reactive::RequestBody.publish(engine, gateway_request)
                   next [nil, [[:block, event]]] if block
 
-                  ret, res = stack.call(gateway_request.request)
-
-                  if event
-                    res ||= []
-                    res << [:monitor, event]
-                  end
-
-                  [ret, res]
+                  stack.call(gateway_request.request)
                 end
               end
             end

--- a/lib/datadog/appsec/contrib/rails/gateway/watcher.rb
+++ b/lib/datadog/appsec/contrib/rails/gateway/watcher.rb
@@ -46,14 +46,7 @@ module Datadog
                   block = Rails::Reactive::Action.publish(engine, gateway_request)
                   next [nil, [[:block, event]]] if block
 
-                  ret, res = stack.call(gateway_request.request)
-
-                  if event
-                    res ||= []
-                    res << [:monitor, event]
-                  end
-
-                  [ret, res]
+                  stack.call(gateway_request.request)
                 end
               end
             end

--- a/lib/datadog/appsec/contrib/sinatra/gateway/watcher.rb
+++ b/lib/datadog/appsec/contrib/sinatra/gateway/watcher.rb
@@ -48,14 +48,7 @@ module Datadog
                   block = Rack::Reactive::RequestBody.publish(engine, gateway_request)
                   next [nil, [[:block, event]]] if block
 
-                  ret, res = stack.call(gateway_request.request)
-
-                  if event
-                    res ||= []
-                    res << [:monitor, event]
-                  end
-
-                  [ret, res]
+                  stack.call(gateway_request.request)
                 end
               end
 
@@ -86,14 +79,7 @@ module Datadog
                   block = Sinatra::Reactive::Routed.publish(engine, [gateway_request, gateway_route_params])
                   next [nil, [[:block, event]]] if block
 
-                  ret, res = stack.call(gateway_request.request)
-
-                  if event
-                    res ||= []
-                    res << [:monitor, event]
-                  end
-
-                  [ret, res]
+                  stack.call(gateway_request.request)
                 end
               end
             end

--- a/lib/datadog/appsec/monitor/gateway/watcher.rb
+++ b/lib/datadog/appsec/monitor/gateway/watcher.rb
@@ -44,14 +44,7 @@ module Datadog
                 block = Monitor::Reactive::SetUser.publish(engine, user)
                 throw(Datadog::AppSec::Ext::INTERRUPT, [nil, [[:block, event]]]) if block
 
-                ret, res = stack.call(user)
-
-                if event
-                  res ||= []
-                  res << [:monitor, event]
-                end
-
-                [ret, res]
+                stack.call(user)
               end
             end
           end


### PR DESCRIPTION
This `:monitor` event that we are adding to the response in every gateway watcher is not used anywhere. We are only looking for `:block` events in the method callers and ignoring the rest.

**What does this PR do?**
Removes dead code in gateway watchers for different integrations.

**Motivation:**
Simplifying AppSec code.

**Change log entry**
None.

**Additional Notes:**
Here you can check how the response from `Gateway#watch` is being used:
https://github.com/DataDog/dd-trace-rb/blob/master/lib/datadog/appsec/contrib/rack/request_middleware.rb#L80-L81
https://github.com/DataDog/dd-trace-rb/blob/master/lib/datadog/appsec/contrib/rack/request_middleware.rb#L111-L112
https://github.com/DataDog/dd-trace-rb/blob/master/lib/datadog/appsec/contrib/rails/patcher.rb#L87-L88
https://github.com/DataDog/dd-trace-rb/blob/master/lib/datadog/appsec/contrib/rack/request_body_middleware.rb#L33-L34
https://github.com/DataDog/dd-trace-rb/blob/master/lib/datadog/appsec/contrib/sinatra/patcher.rb#L70-L71
https://github.com/DataDog/dd-trace-rb/blob/master/lib/datadog/appsec/contrib/sinatra/patcher.rb#L111-L112
https://github.com/DataDog/dd-trace-rb/blob/master/lib/datadog/appsec/contrib/graphql/appsec_trace.rb#L24-L25

**How to test the change?**
CI should be green, and manual testing in app-generator.
