### PR TITLE
DEBUG-3182 DI railtie

### DIFF
--- a/Steepfile
+++ b/Steepfile
@@ -91,6 +91,7 @@ target :datadog do
   ignore 'lib/datadog/core/workers/queue.rb'
   ignore 'lib/datadog/core/workers/runtime_metrics.rb'
   ignore 'lib/datadog/di/configuration/settings.rb'
+  ignore 'lib/datadog/di/contrib/railtie.rb'
   ignore 'lib/datadog/kit/appsec/events.rb' # disabled because of https://github.com/soutaro/steep/issues/701
   ignore 'lib/datadog/kit/identity.rb'      # disabled because of https://github.com/soutaro/steep/issues/701
   ignore 'lib/datadog/opentelemetry.rb'

--- a/integration/apps/hanami/Gemfile
+++ b/integration/apps/hanami/Gemfile
@@ -15,15 +15,7 @@ gem 'unicorn'
 gem 'webrick'
 gem 'pry-byebug'
 
-gem_spec = Datadog::DemoEnv.gem_spec('datadog')
-req = {require: 'datadog/auto_instrument'}
-opts = if gem_spec.last.is_a?(Hash)
-  gem_spec.pop.merge(req)
-else
-  req
-end
-gem_spec << opts
-gem 'datadog', *gem_spec
+gem *Datadog::DemoEnv.gem_datadog_auto_instrument
 gem 'google-protobuf', '~> 3.0'
 
 group :development do

--- a/integration/apps/rails-five/Gemfile
+++ b/integration/apps/rails-five/Gemfile
@@ -25,7 +25,7 @@ gem 'unicorn'
 gem 'loofah', '2.19.1'
 
 # Choose correct specs for 'datadog' demo environment
-gem 'datadog', *Datadog::DemoEnv.gem_spec('datadog')
+gem *Datadog::DemoEnv.gem_datadog_auto_instrument
 
 gem 'dogstatsd-ruby'
 gem 'ffi'

--- a/integration/apps/rails-five/app/controllers/di_controller.rb
+++ b/integration/apps/rails-five/app/controllers/di_controller.rb
@@ -1,0 +1,6 @@
+class DiController < ApplicationController
+  def ar_serializer
+    test = Test.create!
+    render json: Datadog::DI.component.serializer.serialize_value(test)
+  end
+end

--- a/integration/apps/rails-five/bin/run
+++ b/integration/apps/rails-five/bin/run
@@ -8,13 +8,13 @@ puts "\n== Starting application process =="
 process = (ARGV[0] || Datadog::DemoEnv.process)
 command = case process
           when 'puma'
-            "bundle exec ddprofrb exec puma -C /app/config/puma.rb"
+            "bundle exec puma -C /app/config/puma.rb"
           when 'unicorn'
-            "bundle exec ddprofrb exec unicorn -c /app/config/unicorn.rb"
+            "bundle exec unicorn -c /app/config/unicorn.rb"
           when 'console'
-            "bundle exec ddprofrb exec rails c"
+            "bundle exec rails c"
           when 'irb'
-            "bundle exec ddprofrb exec irb"
+            "bundle exec irb"
           when nil, ''
             abort("\n== ERROR: Must specify a application process! ==")
           else

--- a/integration/apps/rails-five/config/initializers/datadog.rb
+++ b/integration/apps/rails-five/config/initializers/datadog.rb
@@ -28,4 +28,8 @@ Datadog.configure do |c|
       c.profiling.exporter.transport = Datadog::DemoEnv.profiler_file_transport
     end
   end
+
+  c.remote.enabled = true
+  c.dynamic_instrumentation.enabled = true
+  c.dynamic_instrumentation.internal.development = true
 end

--- a/integration/apps/rails-five/config/initializers/datadog.rb
+++ b/integration/apps/rails-five/config/initializers/datadog.rb
@@ -29,7 +29,9 @@ Datadog.configure do |c|
     end
   end
 
-  c.remote.enabled = true
-  c.dynamic_instrumentation.enabled = true
-  c.dynamic_instrumentation.internal.development = true
+  if c.respond_to?(:dynamic_instrumentation)
+    c.remote.enabled = true
+    c.dynamic_instrumentation.enabled = true
+    c.dynamic_instrumentation.internal.development = true
+  end
 end

--- a/integration/apps/rails-five/config/routes.rb
+++ b/integration/apps/rails-five/config/routes.rb
@@ -7,6 +7,8 @@ Rails.application.routes.draw do
   get 'basic/default', to: 'basic#default'
   get 'basic/fibonacci', to: 'basic#fibonacci'
 
+  get 'di/ar_serializer', to: 'di#ar_serializer'
+
   # Job test scenarios
   post 'jobs', to: 'jobs#create'
 end

--- a/integration/apps/rails-five/spec/integration/di_spec.rb
+++ b/integration/apps/rails-five/spec/integration/di_spec.rb
@@ -23,9 +23,9 @@ RSpec.describe 'Dynamic Instrumentation' do
                [{"type"=>"String", "value"=>"version"}, {"type"=>"NilClass", "isNull"=>true}],
                [{"type"=>"String", "value"=>"data"}, {"type"=>"NilClass", "isNull"=>true}],
                [{"type"=>"String", "value"=>"created_at"},
-                {"type"=>"ActiveSupport::TimeWithZone", "value"=>String}],
+                {"type"=>"Time", "value"=>String}],
                [{"type"=>"String", "value"=>"updated_at"},
-                {"type"=>"ActiveSupport::TimeWithZone", "value"=>String}]]}],
+                {"type"=>"Time", "value"=>String}]]}],
            [{"type"=>"Symbol", "value"=>"new_record"}, {"type"=>"FalseClass", "value"=>"false"}]]}
       )
     end

--- a/integration/apps/rails-five/spec/integration/di_spec.rb
+++ b/integration/apps/rails-five/spec/integration/di_spec.rb
@@ -6,9 +6,12 @@ RSpec.describe 'Dynamic Instrumentation' do
   di_test
 
   describe 'ActiveRecord integration' do
-    subject { JSON.parse(get('di/ar_serializer').body) }
+    let(:response) { get('di/ar_serializer') }
+    subject { JSON.parse(response.body) }
 
     it 'is loaded' do
+      expect(response.code).to eq '200'
+
       # If AR integration is loaded, this output will be the result of
       # the custom serializer.
       # If AR integration is not loaded, the output here will have a bunch of

--- a/integration/apps/rails-five/spec/integration/di_spec.rb
+++ b/integration/apps/rails-five/spec/integration/di_spec.rb
@@ -3,6 +3,7 @@ require 'json'
 
 RSpec.describe 'Dynamic Instrumentation' do
   include_context 'integration test'
+  di_test
 
   describe 'ActiveRecord integration' do
     subject { JSON.parse(get('di/ar_serializer').body) }

--- a/integration/apps/rails-five/spec/integration/di_spec.rb
+++ b/integration/apps/rails-five/spec/integration/di_spec.rb
@@ -1,0 +1,32 @@
+require 'spec_helper'
+require 'json'
+
+RSpec.describe 'Dynamic Instrumentation' do
+  include_context 'integration test'
+
+  describe 'ActiveRecord integration' do
+    subject { JSON.parse(get('di/ar_serializer').body) }
+
+    it 'is loaded' do
+      # If AR integration is loaded, this output will be the result of
+      # the custom serializer.
+      # If AR integration is not loaded, the output here will have a bunch of
+      # internal AR fields but not the attributes themselves.
+      expect(subject).to match(
+        {"type"=>"Test",
+         "entries"=>
+          [[{"type"=>"Symbol", "value"=>"attributes"},
+            {"type"=>"Hash",
+             "entries"=>
+              [[{"type"=>"String", "value"=>"id"}, {"type"=>"Integer", "value"=>String}],
+               [{"type"=>"String", "value"=>"version"}, {"type"=>"NilClass", "isNull"=>true}],
+               [{"type"=>"String", "value"=>"data"}, {"type"=>"NilClass", "isNull"=>true}],
+               [{"type"=>"String", "value"=>"created_at"},
+                {"type"=>"ActiveSupport::TimeWithZone", "value"=>String}],
+               [{"type"=>"String", "value"=>"updated_at"},
+                {"type"=>"ActiveSupport::TimeWithZone", "value"=>String}]]}],
+           [{"type"=>"Symbol", "value"=>"new_record"}, {"type"=>"FalseClass", "value"=>"false"}]]}
+      )
+    end
+  end
+end

--- a/integration/apps/rails-five/spec/support/integration_helper.rb
+++ b/integration/apps/rails-five/spec/support/integration_helper.rb
@@ -19,4 +19,23 @@ module IntegrationHelper
       Net::HTTP.get_response(uri)
     end
   end
+
+  module ClassMethods
+    def di_test
+      if RUBY_ENGINE == 'jruby'
+        before(:all) do
+          skip "Dynamic instrumentation is not supported on JRuby"
+        end
+      end
+      if RUBY_VERSION < "2.6"
+        before(:all) do
+          skip "Dynamic instrumentation requires Ruby 2.6 or higher"
+        end
+      end
+    end
+  end
+
+  def self.included(base)
+    base.extend(ClassMethods)
+  end
 end

--- a/integration/apps/rails-seven/Gemfile
+++ b/integration/apps/rails-seven/Gemfile
@@ -7,7 +7,7 @@ git_source(:github) { |repo| "https://github.com/#{repo}.git" }
 gem "rails", "~> 7.0.5"
 
 # Choose correct specs for 'datadog' demo environment
-gem 'datadog', *Datadog::DemoEnv.gem_spec('datadog')
+gem *Datadog::DemoEnv.gem_datadog_auto_instrument
 
 gem 'dogstatsd-ruby'
 

--- a/integration/apps/rails-seven/app/controllers/di_controller.rb
+++ b/integration/apps/rails-seven/app/controllers/di_controller.rb
@@ -1,0 +1,6 @@
+class DiController < ApplicationController
+  def ar_serializer
+    test = Test.create!
+    render json: Datadog::DI.component.serializer.serialize_value(test)
+  end
+end

--- a/integration/apps/rails-seven/bin/run
+++ b/integration/apps/rails-seven/bin/run
@@ -8,13 +8,13 @@ puts "\n== Starting application process =="
 process = (ARGV[0] || Datadog::DemoEnv.process)
 command = case process
           when 'puma'
-            "bundle exec ddprofrb exec puma -C /app/config/puma.rb"
+            "bundle exec puma -C /app/config/puma.rb"
           when 'unicorn'
-            "bundle exec ddprofrb exec unicorn -c /app/config/unicorn.rb"
+            "bundle exec unicorn -c /app/config/unicorn.rb"
           when 'console'
-            "bundle exec ddprofrb exec rails c"
+            "bundle exec rails c"
           when 'irb'
-            "bundle exec ddprofrb exec irb"
+            "bundle exec irb"
           when nil, ''
             abort("\n== ERROR: Must specify a application process! ==")
           else

--- a/integration/apps/rails-seven/config/initializers/datadog.rb
+++ b/integration/apps/rails-seven/config/initializers/datadog.rb
@@ -1,6 +1,5 @@
 require 'datadog/statsd'
 require 'datadog'
-require 'datadog/appsec'
 
 Datadog.configure do |c|
   c.env = 'integration'
@@ -26,4 +25,8 @@ Datadog.configure do |c|
     # Reconfigure transport to write pprof to file
     c.profiling.exporter.transport = Datadog::DemoEnv.profiler_file_transport
   end
+
+  c.remote.enabled = true
+  c.dynamic_instrumentation.enabled = true
+  c.dynamic_instrumentation.internal.development = true
 end

--- a/integration/apps/rails-seven/config/initializers/datadog.rb
+++ b/integration/apps/rails-seven/config/initializers/datadog.rb
@@ -26,7 +26,9 @@ Datadog.configure do |c|
     c.profiling.exporter.transport = Datadog::DemoEnv.profiler_file_transport
   end
 
-  c.remote.enabled = true
-  c.dynamic_instrumentation.enabled = true
-  c.dynamic_instrumentation.internal.development = true
+  if c.respond_to?(:dynamic_instrumentation)
+    c.remote.enabled = true
+    c.dynamic_instrumentation.enabled = true
+    c.dynamic_instrumentation.internal.development = true
+  end
 end

--- a/integration/apps/rails-seven/config/routes.rb
+++ b/integration/apps/rails-seven/config/routes.rb
@@ -10,6 +10,8 @@ Rails.application.routes.draw do
   get 'basic/fibonacci', to: 'basic#fibonacci'
   get 'basic/boom', to: 'basic#boom'
 
+  get 'di/ar_serializer', to: 'di#ar_serializer'
+
   # Job test scenarios
   post 'jobs', to: 'jobs#create'
 end

--- a/integration/apps/rails-seven/spec/integration/di_spec.rb
+++ b/integration/apps/rails-seven/spec/integration/di_spec.rb
@@ -6,9 +6,12 @@ RSpec.describe 'Dynamic Instrumentation' do
   di_test
 
   describe 'ActiveRecord integration' do
-    subject { JSON.parse(get('di/ar_serializer').body) }
+    let(:response) { get('di/ar_serializer') }
+    subject { JSON.parse(response.body) }
 
     it 'is loaded' do
+      expect(response.code).to eq '200'
+
       # If AR integration is loaded, this output will be the result of
       # the custom serializer.
       # If AR integration is not loaded, the output here will have a bunch of

--- a/integration/apps/rails-seven/spec/integration/di_spec.rb
+++ b/integration/apps/rails-seven/spec/integration/di_spec.rb
@@ -3,6 +3,7 @@ require 'json'
 
 RSpec.describe 'Dynamic Instrumentation' do
   include_context 'integration test'
+  di_test
 
   describe 'ActiveRecord integration' do
     subject { JSON.parse(get('di/ar_serializer').body) }

--- a/integration/apps/rails-seven/spec/integration/di_spec.rb
+++ b/integration/apps/rails-seven/spec/integration/di_spec.rb
@@ -1,0 +1,32 @@
+require 'spec_helper'
+require 'json'
+
+RSpec.describe 'Dynamic Instrumentation' do
+  include_context 'integration test'
+
+  describe 'ActiveRecord integration' do
+    subject { JSON.parse(get('di/ar_serializer').body) }
+
+    it 'is loaded' do
+      # If AR integration is loaded, this output will be the result of
+      # the custom serializer.
+      # If AR integration is not loaded, the output here will have a bunch of
+      # internal AR fields but not the attributes themselves.
+      expect(subject).to match(
+        {"type"=>"Test",
+         "entries"=>
+          [[{"type"=>"Symbol", "value"=>"attributes"},
+            {"type"=>"Hash",
+             "entries"=>
+              [[{"type"=>"String", "value"=>"id"}, {"type"=>"Integer", "value"=>String}],
+               [{"type"=>"String", "value"=>"version"}, {"type"=>"NilClass", "isNull"=>true}],
+               [{"type"=>"String", "value"=>"data"}, {"type"=>"NilClass", "isNull"=>true}],
+               [{"type"=>"String", "value"=>"created_at"},
+                {"type"=>"ActiveSupport::TimeWithZone", "value"=>String}],
+               [{"type"=>"String", "value"=>"updated_at"},
+                {"type"=>"ActiveSupport::TimeWithZone", "value"=>String}]]}],
+           [{"type"=>"Symbol", "value"=>"new_record"}, {"type"=>"FalseClass", "value"=>"false"}]]}
+      )
+    end
+  end
+end

--- a/integration/apps/rails-seven/spec/support/integration_helper.rb
+++ b/integration/apps/rails-seven/spec/support/integration_helper.rb
@@ -19,4 +19,23 @@ module IntegrationHelper
       Net::HTTP.get_response(uri)
     end
   end
+
+  module ClassMethods
+    def di_test
+      if RUBY_ENGINE == 'jruby'
+        before(:all) do
+          skip "Dynamic instrumentation is not supported on JRuby"
+        end
+      end
+      if RUBY_VERSION < "2.6"
+        before(:all) do
+          skip "Dynamic instrumentation requires Ruby 2.6 or higher"
+        end
+      end
+    end
+  end
+
+  def self.included(base)
+    base.extend(ClassMethods)
+  end
 end

--- a/integration/apps/rails-six/Gemfile
+++ b/integration/apps/rails-six/Gemfile
@@ -18,7 +18,7 @@ gem 'puma'
 gem 'unicorn'
 
 # Choose correct specs for 'datadog' demo environment
-gem 'datadog', *Datadog::DemoEnv.gem_spec('datadog')
+gem *Datadog::DemoEnv.gem_datadog_auto_instrument
 
 gem 'dogstatsd-ruby'
 gem 'ffi'

--- a/integration/apps/rails-six/Gemfile
+++ b/integration/apps/rails-six/Gemfile
@@ -90,7 +90,8 @@ end
 
 group :test, :development do
   gem 'byebug', platform: :ruby
-  gem 'mock_redis'
+  # mock_redis 0.47.0+ requires redis 5 or higher
+  gem 'mock_redis', '~> 0.46.0'
   gem 'parallel_tests'
 
   gem 'listen'

--- a/integration/apps/rails-six/Gemfile
+++ b/integration/apps/rails-six/Gemfile
@@ -91,7 +91,9 @@ end
 group :test, :development do
   gem 'byebug', platform: :ruby
   # mock_redis 0.47.0+ requires redis 5 or higher
-  gem 'mock_redis', '~> 0.46.0'
+  # mock_redis 0.42.0+ requires Ruby 3.0 or higher
+  # mock_redis 0.37.0+ requires Ruby 2.7 or higher
+  gem 'mock_redis', '~> 0.41.0'
   gem 'parallel_tests'
 
   gem 'listen'

--- a/integration/apps/rails-six/Gemfile
+++ b/integration/apps/rails-six/Gemfile
@@ -93,7 +93,11 @@ group :test, :development do
   # mock_redis 0.47.0+ requires redis 5 or higher
   # mock_redis 0.42.0+ requires Ruby 3.0 or higher
   # mock_redis 0.37.0+ requires Ruby 2.7 or higher
-  gem 'mock_redis', '~> 0.41.0'
+  if RUBY_VERSION >= '2.7'
+    gem 'mock_redis', '~> 0.37.0'
+  else
+    gem 'mock_redis', '< 0.37.0'
+  end
   gem 'parallel_tests'
 
   gem 'listen'

--- a/integration/apps/rails-six/app/controllers/di_controller.rb
+++ b/integration/apps/rails-six/app/controllers/di_controller.rb
@@ -1,0 +1,6 @@
+class DiController < ApplicationController
+  def ar_serializer
+    test = Test.create!
+    render json: Datadog::DI.component.serializer.serialize_value(test)
+  end
+end

--- a/integration/apps/rails-six/bin/run
+++ b/integration/apps/rails-six/bin/run
@@ -8,13 +8,13 @@ puts "\n== Starting application process =="
 process = (ARGV[0] || Datadog::DemoEnv.process)
 command = case process
           when 'puma'
-            "bundle exec ddprofrb exec puma -C /app/config/puma.rb"
+            "bundle exec puma -C /app/config/puma.rb"
           when 'unicorn'
-            "bundle exec ddprofrb exec unicorn -c /app/config/unicorn.rb"
+            "bundle exec unicorn -c /app/config/unicorn.rb"
           when 'console'
-            "bundle exec ddprofrb exec rails c"
+            "bundle exec rails c"
           when 'irb'
-            "bundle exec ddprofrb exec irb"
+            "bundle exec irb"
           when nil, ''
             abort("\n== ERROR: Must specify a application process! ==")
           else

--- a/integration/apps/rails-six/config/initializers/datadog.rb
+++ b/integration/apps/rails-six/config/initializers/datadog.rb
@@ -28,4 +28,8 @@ Datadog.configure do |c|
       c.profiling.exporter.transport = Datadog::DemoEnv.profiler_file_transport
     end
   end
+
+  c.remote.enabled = true
+  c.dynamic_instrumentation.enabled = true
+  c.dynamic_instrumentation.internal.development = true
 end

--- a/integration/apps/rails-six/config/initializers/datadog.rb
+++ b/integration/apps/rails-six/config/initializers/datadog.rb
@@ -29,7 +29,9 @@ Datadog.configure do |c|
     end
   end
 
-  c.remote.enabled = true
-  c.dynamic_instrumentation.enabled = true
-  c.dynamic_instrumentation.internal.development = true
+  if c.respond_to?(:dynamic_instrumentation)
+    c.remote.enabled = true
+    c.dynamic_instrumentation.enabled = true
+    c.dynamic_instrumentation.internal.development = true
+  end
 end

--- a/integration/apps/rails-six/config/routes.rb
+++ b/integration/apps/rails-six/config/routes.rb
@@ -10,6 +10,8 @@ Rails.application.routes.draw do
   get 'basic/fibonacci', to: 'basic#fibonacci'
   get 'basic/boom', to: 'basic#boom'
 
+  get 'di/ar_serializer', to: 'di#ar_serializer'
+
   # Job test scenarios
   post 'jobs', to: 'jobs#create'
 end

--- a/integration/apps/rails-six/spec/integration/di_spec.rb
+++ b/integration/apps/rails-six/spec/integration/di_spec.rb
@@ -23,9 +23,9 @@ RSpec.describe 'Dynamic Instrumentation' do
                [{"type"=>"String", "value"=>"version"}, {"type"=>"NilClass", "isNull"=>true}],
                [{"type"=>"String", "value"=>"data"}, {"type"=>"NilClass", "isNull"=>true}],
                [{"type"=>"String", "value"=>"created_at"},
-                {"type"=>"ActiveSupport::TimeWithZone", "value"=>String}],
+                {"type"=>"Time", "value"=>String}],
                [{"type"=>"String", "value"=>"updated_at"},
-                {"type"=>"ActiveSupport::TimeWithZone", "value"=>String}]]}],
+                {"type"=>"Time", "value"=>String}]]}],
            [{"type"=>"Symbol", "value"=>"new_record"}, {"type"=>"FalseClass", "value"=>"false"}]]}
       )
     end

--- a/integration/apps/rails-six/spec/integration/di_spec.rb
+++ b/integration/apps/rails-six/spec/integration/di_spec.rb
@@ -6,9 +6,12 @@ RSpec.describe 'Dynamic Instrumentation' do
   di_test
 
   describe 'ActiveRecord integration' do
-    subject { JSON.parse(get('di/ar_serializer').body) }
+    let(:response) { get('di/ar_serializer') }
+    subject { JSON.parse(response.body) }
 
     it 'is loaded' do
+      expect(response.code).to eq '200'
+
       # If AR integration is loaded, this output will be the result of
       # the custom serializer.
       # If AR integration is not loaded, the output here will have a bunch of

--- a/integration/apps/rails-six/spec/integration/di_spec.rb
+++ b/integration/apps/rails-six/spec/integration/di_spec.rb
@@ -3,6 +3,7 @@ require 'json'
 
 RSpec.describe 'Dynamic Instrumentation' do
   include_context 'integration test'
+  di_test
 
   describe 'ActiveRecord integration' do
     subject { JSON.parse(get('di/ar_serializer').body) }

--- a/integration/apps/rails-six/spec/integration/di_spec.rb
+++ b/integration/apps/rails-six/spec/integration/di_spec.rb
@@ -1,0 +1,32 @@
+require 'spec_helper'
+require 'json'
+
+RSpec.describe 'Dynamic Instrumentation' do
+  include_context 'integration test'
+
+  describe 'ActiveRecord integration' do
+    subject { JSON.parse(get('di/ar_serializer').body) }
+
+    it 'is loaded' do
+      # If AR integration is loaded, this output will be the result of
+      # the custom serializer.
+      # If AR integration is not loaded, the output here will have a bunch of
+      # internal AR fields but not the attributes themselves.
+      expect(subject).to match(
+        {"type"=>"Test",
+         "entries"=>
+          [[{"type"=>"Symbol", "value"=>"attributes"},
+            {"type"=>"Hash",
+             "entries"=>
+              [[{"type"=>"String", "value"=>"id"}, {"type"=>"Integer", "value"=>String}],
+               [{"type"=>"String", "value"=>"version"}, {"type"=>"NilClass", "isNull"=>true}],
+               [{"type"=>"String", "value"=>"data"}, {"type"=>"NilClass", "isNull"=>true}],
+               [{"type"=>"String", "value"=>"created_at"},
+                {"type"=>"ActiveSupport::TimeWithZone", "value"=>String}],
+               [{"type"=>"String", "value"=>"updated_at"},
+                {"type"=>"ActiveSupport::TimeWithZone", "value"=>String}]]}],
+           [{"type"=>"Symbol", "value"=>"new_record"}, {"type"=>"FalseClass", "value"=>"false"}]]}
+      )
+    end
+  end
+end

--- a/integration/apps/rails-six/spec/support/integration_helper.rb
+++ b/integration/apps/rails-six/spec/support/integration_helper.rb
@@ -19,4 +19,23 @@ module IntegrationHelper
       Net::HTTP.get_response(uri)
     end
   end
+
+  module ClassMethods
+    def di_test
+      if RUBY_ENGINE == 'jruby'
+        before(:all) do
+          skip "Dynamic instrumentation is not supported on JRuby"
+        end
+      end
+      if RUBY_VERSION < "2.6"
+        before(:all) do
+          skip "Dynamic instrumentation requires Ruby 2.6 or higher"
+        end
+      end
+    end
+  end
+
+  def self.included(base)
+    base.extend(ClassMethods)
+  end
 end

--- a/integration/images/include/datadog/demo_env.rb
+++ b/integration/images/include/datadog/demo_env.rb
@@ -3,7 +3,7 @@ module Datadog
   module DemoEnv
     module_function
 
-    def gem_spec(gem_name, defaults = {})
+    def gem_spec(gem_name)
       args = if local_gem(gem_name)
                [local_gem(gem_name)]
              elsif git_gem(gem_name)
@@ -15,6 +15,18 @@ module Datadog
       yield(args) if block_given?
 
       args
+    end
+
+    def gem_datadog_auto_instrument
+      gem_spec = gem_spec('datadog')
+      req = {require: 'datadog/auto_instrument'}
+      opts = if gem_spec.last.is_a?(Hash)
+        gem_spec.pop.merge(req)
+      else
+        req
+      end
+      gem_spec << opts
+      ['datadog', *gem_spec]
     end
 
     def gem_env_name(gem_name)

--- a/lib/datadog/auto_instrument.rb
+++ b/lib/datadog/auto_instrument.rb
@@ -6,6 +6,11 @@
 require_relative '../datadog'
 require_relative 'tracing/contrib/auto_instrument'
 
+# DI is not loaded on Ruby 2.5 and JRuby
+if defined?(Datadog::DI::Contrib)
+  Datadog::DI::Contrib.load_now_or_later
+end
+
 Datadog::Profiling.start_if_enabled
 
 module Datadog

--- a/lib/datadog/auto_instrument.rb
+++ b/lib/datadog/auto_instrument.rb
@@ -7,9 +7,7 @@ require_relative '../datadog'
 require_relative 'tracing/contrib/auto_instrument'
 
 # DI is not loaded on Ruby 2.5 and JRuby
-if defined?(Datadog::DI::Contrib)
-  Datadog::DI::Contrib.load_now_or_later
-end
+Datadog::DI::Contrib.load_now_or_later if defined?(Datadog::DI::Contrib)
 
 Datadog::Profiling.start_if_enabled
 

--- a/lib/datadog/di.rb
+++ b/lib/datadog/di.rb
@@ -18,21 +18,6 @@ require_relative 'di/serializer'
 require_relative 'di/transport'
 require_relative 'di/utils'
 
-if defined?(ActiveRecord::Base)
-  # The third-party library integrations need to be loaded after the
-  # third-party libraries are loaded. Tracing and appsec use Railtie
-  # to delay integrations until all of the application's dependencies
-  # are loaded, when running under Rails. We should do the same here in
-  # principle, however DI currently only has an ActiveRecord integration
-  # and AR should be loaded before any application code is loaded, being
-  # part of Rails, therefore for now we should be OK to just require the
-  # AR integration from here.
-  #
-  # TODO this require might need to be delayed via Rails post-initialization
-  # logic?
-  require_relative 'di/contrib/active_record'
-end
-
 module Datadog
   # Namespace for Datadog dynamic instrumentation.
   #
@@ -75,3 +60,7 @@ if %w(1 true).include?(ENV['DD_DYNAMIC_INSTRUMENTATION_ENABLED']) # steep:ignore
   # for line probes to work) activate tracking in an initializer.
   Datadog::DI.activate_tracking
 end
+
+require_relative 'di/contrib'
+
+Datadog::DI::Contrib.load_now_or_later

--- a/lib/datadog/di/contrib.rb
+++ b/lib/datadog/di/contrib.rb
@@ -13,6 +13,9 @@ module Datadog
         end
       end
 
+      # This method can be called more than once, to attempt to load
+      # DI components that depend on third-party libraries after additional
+      # dependencies are loaded (or potentially loaded).
       module_function def load_now
         if defined?(ActiveRecord::Base)
           require_relative 'contrib/active_record'

--- a/lib/datadog/di/contrib.rb
+++ b/lib/datadog/di/contrib.rb
@@ -1,0 +1,23 @@
+# frozen_string_literal: true
+
+require_relative '../core/contrib/rails/utils'
+
+module Datadog
+  module DI
+    module Contrib
+      module_function def load_now_or_later
+        if Datadog::Core::Contrib::Rails::Utils.railtie_supported?
+          require_relative 'contrib/railtie'
+        else
+          load_now
+        end
+      end
+
+      module_function def load_now
+        if defined?(ActiveRecord::Base)
+          require_relative 'contrib/active_record'
+        end
+      end
+    end
+  end
+end

--- a/lib/datadog/di/contrib/railtie.rb
+++ b/lib/datadog/di/contrib/railtie.rb
@@ -1,0 +1,15 @@
+# frozen_string_literal: true
+
+module Datadog
+  module DI
+    module Contrib
+      # Railtie class initializes dynamic instrumentation contrib code
+      # in Rails environments.
+      class Railtie < Rails::Railtie
+        initializer 'datadog.dynamic_instrumentation.initialize' do |app|
+          Contrib.load_now
+        end
+      end
+    end
+  end
+end

--- a/sig/datadog/di/contrib.rbs
+++ b/sig/datadog/di/contrib.rbs
@@ -1,0 +1,9 @@
+module Datadog
+  module DI
+    module Contrib
+      def self?.load_now_or_later: () -> void
+
+      def self?.load_now: () -> void
+    end
+  end
+end

--- a/sig/datadog/di/contrib/railtie.rbs
+++ b/sig/datadog/di/contrib/railtie.rbs
@@ -1,0 +1,8 @@
+module Datadog
+  module DI
+    module Contrib
+      class Railtie < Rails::Railtie
+      end
+    end
+  end
+end


### PR DESCRIPTION
<!--
Check out the
https://github.com/DataDog/dd-trace-rb/blob/master/docs/DevelopmentGuide.md
for guidance on how to set up your development environment,
run the test suite, write new integrations, and more.
-->

**What does this PR do?**
<!-- A brief description of the change being made with this pull request. -->
Adds a Railtie for dynamic instrumentation. The railtie delays loading of DI contrib code (currently, ActiveRecord serializer) until Rails components have been loaded.

Also adds an integration test verifying AR serialization works correctly.

**Motivation:**
<!-- What inspired you to submit this pull request? -->
Improving DI reliability 

**Change log entry**
<!-- If this is a customer-visible change, a brief summary to be placed
into the change log.
If you are not a Datadog employee, you can skip this section
and it will be filled or deleted during PR review. -->
Yes: improve loading of dynamic instrumentation components

**Additional Notes:**
<!-- Anything else we should know when reviewing? -->

**How to test the change?**
<!--
Describe here how the change can be validated.
You are strongly encouraged to provide automated tests for this PR (unit or integration).
If this change cannot be feasibly tested, please explain why,
unless the change does not modify code (e.g. only modifies docs, comments).
-->
An integration test is added in this PR

<!-- Unsure? Have a question? Request a review! -->
