### PR TITLE
Switch AppSec rack blocking to throw

### DIFF
--- a/lib/datadog/appsec/contrib/rack/gateway/watcher.rb
+++ b/lib/datadog/appsec/contrib/rack/gateway/watcher.rb
@@ -48,7 +48,7 @@ module Datadog
                   end
 
                   block = Rack::Reactive::Request.publish(engine, gateway_request)
-                  next [nil, [[:block, event]]] if block
+                  throw(Datadog::AppSec::Ext::INTERRUPT, event[:actions]) if block
 
                   stack.call(gateway_request.request)
                 end
@@ -79,7 +79,7 @@ module Datadog
                   end
 
                   block = Rack::Reactive::Response.publish(engine, gateway_response)
-                  next [nil, [[:block, event]]] if block
+                  throw(Datadog::AppSec::Ext::INTERRUPT, event[:actions]) if block
 
                   stack.call(gateway_response.response)
                 end
@@ -110,7 +110,7 @@ module Datadog
                   end
 
                   block = Rack::Reactive::RequestBody.publish(engine, gateway_request)
-                  next [nil, [[:block, event]]] if block
+                  throw(Datadog::AppSec::Ext::INTERRUPT, event[:actions]) if block
 
                   stack.call(gateway_request.request)
                 end

--- a/lib/datadog/appsec/contrib/rack/request_body_middleware.rb
+++ b/lib/datadog/appsec/contrib/rack/request_body_middleware.rb
@@ -23,9 +23,9 @@ module Datadog
 
             # TODO: handle exceptions, except for @app.call
 
-            request_return = nil
+            http_response = nil
             block_actions = catch(::Datadog::AppSec::Ext::INTERRUPT) do
-              request_return, _request_response = Instrumentation.gateway.push(
+              http_response, = Instrumentation.gateway.push(
                 'rack.request.body', Gateway::Request.new(env)
               ) do
                 @app.call(env)
@@ -33,9 +33,9 @@ module Datadog
 
               nil
             end
-            request_return = AppSec::Response.negotiate(env, block_actions).to_rack if block_actions
+            http_response = AppSec::Response.negotiate(env, block_actions).to_rack if block_actions
 
-            request_return
+            http_response
           end
         end
       end

--- a/lib/datadog/appsec/contrib/rack/request_body_middleware.rb
+++ b/lib/datadog/appsec/contrib/rack/request_body_middleware.rb
@@ -25,15 +25,14 @@ module Datadog
 
             http_response = nil
             block_actions = catch(::Datadog::AppSec::Ext::INTERRUPT) do
-              http_response, = Instrumentation.gateway.push(
-                'rack.request.body', Gateway::Request.new(env)
-              ) do
+              http_response, = Instrumentation.gateway.push('rack.request.body', Gateway::Request.new(env)) do
                 @app.call(env)
               end
 
               nil
             end
-            http_response = AppSec::Response.negotiate(env, block_actions).to_rack if block_actions
+
+            return AppSec::Response.negotiate(env, block_actions).to_rack if block_actions
 
             http_response
           end

--- a/lib/datadog/appsec/contrib/rack/request_body_middleware.rb
+++ b/lib/datadog/appsec/contrib/rack/request_body_middleware.rb
@@ -23,17 +23,17 @@ module Datadog
 
             # TODO: handle exceptions, except for @app.call
 
-            request_return, request_response = Instrumentation.gateway.push(
-              'rack.request.body',
-              Gateway::Request.new(env)
-            ) do
-              @app.call(env)
-            end
+            request_return = nil
+            block_actions = catch(::Datadog::AppSec::Ext::INTERRUPT) do
+              request_return, _request_response = Instrumentation.gateway.push(
+                'rack.request.body', Gateway::Request.new(env)
+              ) do
+                @app.call(env)
+              end
 
-            if request_response
-              blocked_event = request_response.find { |action, _event| action == :block }
-              request_return = AppSec::Response.negotiate(env, blocked_event.last[:actions]).to_rack if blocked_event
+              nil
             end
+            request_return = AppSec::Response.negotiate(env, block_actions).to_rack if block_actions
 
             request_return
           end

--- a/lib/datadog/appsec/contrib/rack/request_middleware.rb
+++ b/lib/datadog/appsec/contrib/rack/request_middleware.rb
@@ -72,8 +72,8 @@ module Datadog
             add_appsec_tags(processor, ctx)
             add_request_tags(ctx, env)
 
-            gateway_request = Gateway::Request.new(env)
             http_response = nil
+            gateway_request = Gateway::Request.new(env)
             gateway_response = nil
 
             block_actions = catch(::Datadog::AppSec::Ext::INTERRUPT) do

--- a/lib/datadog/appsec/contrib/rack/request_middleware.rb
+++ b/lib/datadog/appsec/contrib/rack/request_middleware.rb
@@ -92,12 +92,10 @@ module Datadog
 
             http_response = AppSec::Response.negotiate(env, block_actions).to_rack if block_actions
 
-            result = ctx.waf_runner.extract_schema
-
-            if (result = ctx.processor_context.extract_schema)
-              scope.processor_context.events << {
+            if (result = ctx.waf_runner.extract_schema)
+              ctx.waf_runner.events << {
                 trace: ctx.trace,
-                span: ctx.service_entry_span,
+                span: ctx.span,
                 waf_result: result,
               }
             end

--- a/lib/datadog/appsec/monitor/gateway/watcher.rb
+++ b/lib/datadog/appsec/monitor/gateway/watcher.rb
@@ -42,7 +42,7 @@ module Datadog
                 end
 
                 block = Monitor::Reactive::SetUser.publish(engine, user)
-                throw(Datadog::AppSec::Ext::INTERRUPT, [nil, [[:block, event]]]) if block
+                throw(Datadog::AppSec::Ext::INTERRUPT, event[:actions]) if block
 
                 stack.call(user)
               end


### PR DESCRIPTION
**What does this PR do?**
We want to have a unified way of blocking in AppSec and separate `catch` return arguments from `Gateway#watch` return arguments.

**Motivation:**
Reducing code complexity.

**Change log entry**
None.

**Additional Notes:**
None.

**How to test the change?**
CI and manual testing with app generator.
