### PR TITLE
DEBUG-3328 report DI status in environment logger summary

### DIFF
--- a/lib/datadog/core/configuration/components.rb
+++ b/lib/datadog/core/configuration/components.rb
@@ -114,9 +114,7 @@ module Datadog
           @health_metrics = self.class.build_health_metrics(settings)
           @appsec = Datadog::AppSec::Component.build_appsec_component(settings, telemetry: telemetry)
           @dynamic_instrumentation = Datadog::DI::Component.build(settings, agent_settings, @logger, telemetry: telemetry)
-          @environment_logger_extra.merge!(
-            dynamic_instrumentation_enabled: !!@dynamic_instrumentation,
-          )
+          @environment_logger_extra[:dynamic_instrumentation_enabled] = !!@dynamic_instrumentation
 
           self.class.configure_tracing(settings)
         end

--- a/lib/datadog/core/configuration/components.rb
+++ b/lib/datadog/core/configuration/components.rb
@@ -114,6 +114,9 @@ module Datadog
           @health_metrics = self.class.build_health_metrics(settings)
           @appsec = Datadog::AppSec::Component.build_appsec_component(settings, telemetry: telemetry)
           @dynamic_instrumentation = Datadog::DI::Component.build(settings, agent_settings, @logger, telemetry: telemetry)
+          @environment_logger_extra.merge!(
+            dynamic_instrumentation_enabled: !!@dynamic_instrumentation,
+          )
 
           self.class.configure_tracing(settings)
         end

--- a/spec/datadog/core/configuration/components_spec.rb
+++ b/spec/datadog/core/configuration/components_spec.rb
@@ -99,20 +99,22 @@ RSpec.describe Datadog::Core::Configuration::Components do
     describe '@environment_logger_extra' do
       let(:environment_logger_extra) { {} }
 
-      subject do
+      let(:extra) do
         components.instance_variable_get('@environment_logger_extra')
       end
 
       context 'DI is not enabled' do
         it 'reports DI as disabled' do
           expect(components.dynamic_instrumentation).to be nil
-          expect(subject).to eq(dynamic_instrumentation_enabled: false)
+          expect(extra).to eq(dynamic_instrumentation_enabled: false)
         end
       end
 
       context 'DI is enabled' do
         before(:all) do
-          skip 'DI is disabled due to Ruby version < 2.5' if RUBY_VERSION < '2.6'
+          if RUBY_VERSION < '2.6'
+            skip "DI is disabled due to Ruby version < 2.5"
+          end
         end
 
         before do
@@ -121,7 +123,7 @@ RSpec.describe Datadog::Core::Configuration::Components do
 
         it 'reports DI as enabled' do
           expect(components.dynamic_instrumentation).to be_a(Datadog::DI::Component)
-          expect(subject).to eq(dynamic_instrumentation_enabled: true)
+          expect(extra).to eq(dynamic_instrumentation_enabled: true)
         end
       end
     end
@@ -1164,8 +1166,7 @@ RSpec.describe Datadog::Core::Configuration::Components do
 
       expect(Datadog::Core::Diagnostics::EnvironmentLogger).to \
         receive(:collect_and_log!).with(
-          environment_logger_extra.merge(dynamic_instrumentation_enabled: false)
-        )
+          environment_logger_extra.merge(dynamic_instrumentation_enabled: false))
 
       startup!
     end

--- a/spec/datadog/core/configuration/components_spec.rb
+++ b/spec/datadog/core/configuration/components_spec.rb
@@ -122,9 +122,7 @@ RSpec.describe Datadog::Core::Configuration::Components do
 
         context 'MRI' do
           before(:all) do
-            if PlatformHelpers.jruby?
-              skip "Test requires MRI"
-            end
+            skip 'Test requires MRI' if PlatformHelpers.jruby?
           end
 
           it 'reports DI as enabled' do
@@ -135,9 +133,7 @@ RSpec.describe Datadog::Core::Configuration::Components do
 
         context 'JRuby' do
           before(:all) do
-            unless PlatformHelpers.jruby?
-              skip "Test requires JRuby"
-            end
+            skip 'Test requires JRuby' unless PlatformHelpers.jruby?
           end
 
           it 'reports DI as disabled' do

--- a/spec/datadog/core/configuration/components_spec.rb
+++ b/spec/datadog/core/configuration/components_spec.rb
@@ -112,9 +112,7 @@ RSpec.describe Datadog::Core::Configuration::Components do
 
       context 'DI is enabled' do
         before(:all) do
-          if RUBY_VERSION < '2.6'
-            skip "DI is disabled due to Ruby version < 2.5"
-          end
+          skip 'DI is disabled due to Ruby version < 2.5' if RUBY_VERSION < '2.6'
         end
 
         before do
@@ -1166,7 +1164,8 @@ RSpec.describe Datadog::Core::Configuration::Components do
 
       expect(Datadog::Core::Diagnostics::EnvironmentLogger).to \
         receive(:collect_and_log!).with(
-          environment_logger_extra.merge(dynamic_instrumentation_enabled: false))
+          environment_logger_extra.merge(dynamic_instrumentation_enabled: false)
+        )
 
       startup!
     end


### PR DESCRIPTION
<!--
Check out the
https://github.com/DataDog/dd-trace-rb/blob/master/docs/DevelopmentGuide.md
for guidance on how to set up your development environment,
run the test suite, write new integrations, and more.
-->

**What does this PR do?**
<!-- A brief description of the change being made with this pull request. -->
Adds the state of dynamic instrumentation to environment logger summary reporting.

**Motivation:**
<!-- What inspired you to submit this pull request? -->
For troubleshooting it would be helpful to see whether DI is effectively turned on (i.e. it's requested to be on programmatically or via an environment variable, and environmental conditions are appropriate (environment, Ruby version, etc.))

**Change log entry**
<!-- If this is a customer-visible change, a brief summary to be placed
into the change log.
If you are not a Datadog employee, you can skip this section
and it will be filled or deleted during PR review. -->
Yes: library will report whether dynamic instrumentation is enabled in startup summary report

**Additional Notes:**
<!-- Anything else we should know when reviewing? -->

**How to test the change?**
<!--
Describe here how the change can be validated.
You are strongly encouraged to provide automated tests for this PR (unit or integration).
If this change cannot be feasibly tested, please explain why,
unless the change does not modify code (e.g. only modifies docs, comments).
-->
Unit tests are included

<!-- Unsure? Have a question? Request a review! -->
