### PR TITLE
Move `ostruct` gem out from test group for Ruby 3.5

### DIFF
--- a/ruby-3.5.gemfile
+++ b/ruby-3.5.gemfile
@@ -27,6 +27,7 @@ gem 'json-schema', '< 3' # V3 only works with 2.5+
 gem 'memory_profiler', '~> 0.9'
 gem 'mutex_m'
 gem 'os', '~> 1.1'
+gem 'ostruct'
 gem 'pimpmychangelog', '>= 0.1.2'
 gem 'pry'
 gem 'pry-stack_explorer'
@@ -61,8 +62,4 @@ end
 group :dev do
   gem 'ruby-lsp', require: false
   gem 'appraisal', '~> 2.4.0', require: false
-end
-
-group :test do
-  gem 'ostruct'
 end


### PR DESCRIPTION
Apparently `ostruct` gem is removed by `bundle clean` before the memory leak check.

**What does this PR do?**
This PR moves `ostruct` gem out from the test group.

**Motivation:**
CI failing:
https://github.com/DataDog/dd-trace-rb/actions/runs/12713392872/job/35441183658?pr=4236

**Change log entry**
None.

**Additional Notes:**
None.

**How to test the change?**
CI is enough
