### PR TITLE
[Debugger] Don't redact env tokens from probe snapshots

### DIFF
--- a/lib/datadog/di/redactor.rb
+++ b/lib/datadog/di/redactor.rb
@@ -119,7 +119,6 @@ module Datadog
         "dburl",
         "encryptionkey",
         "encryptionkeyid",
-        "env",
         "geolocation",
         "gpgkey",
         "ipaddress",


### PR DESCRIPTION
<!--
Check out the
https://github.com/DataDog/dd-trace-rb/blob/master/docs/DevelopmentGuide.md
for guidance on how to set up your development environment,
run the test suite, write new integrations, and more.
-->

**What does this PR do?**

Remove `env` from list of tokens to redact from Dynamic Instrumentation probe snapshots.

Depends on: https://github.com/DataDog/system-tests/pull/3827

**Motivation:**

Feature parity

**Change log entry**
Yes: Dynamic instrumentation: Variables named `env` are no longer redacted
<!-- If this is a customer-visible change, a brief summary to be placed
into the change log.
If you are not a Datadog employee, you can skip this section
and it will be filled or deleted during PR review. -->

**Additional Notes:**
<!-- Anything else we should know when reviewing? -->

**How to test the change?**
<!--
Describe here how the change can be validated.
You are strongly encouraged to provide automated tests for this PR (unit or integration).
If this change cannot be feasibly tested, please explain why,
unless the change does not modify code (e.g. only modifies docs, comments).
-->

<!-- Unsure? Have a question? Request a review! -->
