### PR TITLE
Work around missing logger dependency in Rails 6.1 and 7.0

### DIFF
--- a/integration/apps/rails-five/Gemfile
+++ b/integration/apps/rails-five/Gemfile
@@ -89,3 +89,13 @@ group :test, :development do
 
   gem 'listen'
 end
+
+# concurrent-ruby 1.3.5 removed dependency on logger, see:
+# https://github.com/ruby-concurrency/concurrent-ruby/commit/d7ce956dacd0b772273d39b8ed31a30cff7ecf38
+# Unfortunately this broke Rails because ActiveSupport used Logger
+# before requiring logger.
+# Since the failure happens rather early in rails bootstrapping,
+# patching it is difficult, thus downgrade concurrent-ruby.
+# The issue appears to affect all existing Rails versions:
+# https://github.com/rails/rails/blob/main/activesupport/lib/active_support/logger.rb#L4-L5
+gem 'concurrent-ruby', '1.3.4'

--- a/integration/apps/rails-five/Gemfile
+++ b/integration/apps/rails-five/Gemfile
@@ -89,13 +89,3 @@ group :test, :development do
 
   gem 'listen'
 end
-
-# concurrent-ruby 1.3.5 removed dependency on logger, see:
-# https://github.com/ruby-concurrency/concurrent-ruby/commit/d7ce956dacd0b772273d39b8ed31a30cff7ecf38
-# Unfortunately this broke Rails because ActiveSupport used Logger
-# before requiring logger.
-# Since the failure happens rather early in rails bootstrapping,
-# patching it is difficult, thus downgrade concurrent-ruby.
-# The issue appears to affect all existing Rails versions:
-# https://github.com/rails/rails/blob/main/activesupport/lib/active_support/logger.rb#L4-L5
-gem 'concurrent-ruby', '1.3.4'

--- a/integration/apps/rails-seven/Gemfile
+++ b/integration/apps/rails-seven/Gemfile
@@ -56,7 +56,7 @@ gem 'mutex_m'
 # before requiring logger.
 # Since the failure happens rather early in rails bootstrapping,
 # patching it is difficult, thus downgrade concurrent-ruby.
-# The issue is fixed in 7-1-stable and should be shipped in the release
-# after 7.1.5.1.
+# The issue is fixed in 7-0-stable and should be shipped in the release
+# after 7.0.8.7, at which point the pin of concurrent-ruby should be removed.
 # See https://github.com/rails/rails/issues/54263
 gem 'concurrent-ruby', '1.3.4'

--- a/integration/apps/rails-seven/Gemfile
+++ b/integration/apps/rails-seven/Gemfile
@@ -49,3 +49,13 @@ end
 # Gems no longer included in Ruby 3.4
 gem 'bigdecimal'
 gem 'mutex_m'
+
+# concurrent-ruby 1.3.5 removed dependency on logger, see:
+# https://github.com/ruby-concurrency/concurrent-ruby/commit/d7ce956dacd0b772273d39b8ed31a30cff7ecf38
+# Unfortunately this broke Rails because ActiveSupport used Logger
+# before requiring logger.
+# Since the failure happens rather early in rails bootstrapping,
+# patching it is difficult, thus downgrade concurrent-ruby.
+# The issue appears to affect all existing Rails versions:
+# https://github.com/rails/rails/blob/main/activesupport/lib/active_support/logger.rb#L4-L5
+gem 'concurrent-ruby', '1.3.4'

--- a/integration/apps/rails-seven/Gemfile
+++ b/integration/apps/rails-seven/Gemfile
@@ -56,6 +56,7 @@ gem 'mutex_m'
 # before requiring logger.
 # Since the failure happens rather early in rails bootstrapping,
 # patching it is difficult, thus downgrade concurrent-ruby.
-# The issue appears to affect all existing Rails versions:
-# https://github.com/rails/rails/blob/main/activesupport/lib/active_support/logger.rb#L4-L5
+# The issue is fixed in 7-1-stable and should be shipped in the release
+# after 7.1.5.1.
+# See https://github.com/rails/rails/issues/54263
 gem 'concurrent-ruby', '1.3.4'

--- a/integration/apps/rails-six/Gemfile
+++ b/integration/apps/rails-six/Gemfile
@@ -105,3 +105,12 @@ end
 
 # Gem no longer included in Ruby 3.4
 gem 'mutex_m'
+
+# concurrent-ruby 1.3.5 removed dependency on logger, see:
+# https://github.com/ruby-concurrency/concurrent-ruby/commit/d7ce956dacd0b772273d39b8ed31a30cff7ecf38
+# Unfortunately this broke rails because ActiveSupport used Logger
+# but didn't require logger.
+# Since the failure happens rather early in rails bootstrapping,
+# patching it is difficult, thus downgrade concurrent-ruby for Rails 6.
+# The issue does not occur in Rails 7.
+gem 'concurrent-ruby', '1.3.4'

--- a/integration/apps/rails-six/Gemfile
+++ b/integration/apps/rails-six/Gemfile
@@ -108,9 +108,10 @@ gem 'mutex_m'
 
 # concurrent-ruby 1.3.5 removed dependency on logger, see:
 # https://github.com/ruby-concurrency/concurrent-ruby/commit/d7ce956dacd0b772273d39b8ed31a30cff7ecf38
-# Unfortunately this broke rails because ActiveSupport used Logger
-# but didn't require logger.
+# Unfortunately this broke Rails because ActiveSupport used Logger
+# before requiring logger.
 # Since the failure happens rather early in rails bootstrapping,
-# patching it is difficult, thus downgrade concurrent-ruby for Rails 6.
-# The issue does not occur in Rails 7.
+# patching it is difficult, thus downgrade concurrent-ruby.
+# The issue appears to affect all existing Rails versions:
+# https://github.com/rails/rails/blob/main/activesupport/lib/active_support/logger.rb#L4-L5
 gem 'concurrent-ruby', '1.3.4'

--- a/integration/apps/rails-six/Gemfile
+++ b/integration/apps/rails-six/Gemfile
@@ -112,6 +112,6 @@ gem 'mutex_m'
 # before requiring logger.
 # Since the failure happens rather early in rails bootstrapping,
 # patching it is difficult, thus downgrade concurrent-ruby.
-# The issue appears to affect all existing Rails versions:
-# https://github.com/rails/rails/blob/main/activesupport/lib/active_support/logger.rb#L4-L5
+# The issue affects Rails 6.1 where apparently it will be never fixed
+# (unlike Rails 7.0 which is fixed in https://github.com/rails/rails/issues/54263).
 gem 'concurrent-ruby', '1.3.4'


### PR DESCRIPTION
<!--
Check out the
https://github.com/DataDog/dd-trace-rb/blob/master/docs/DevelopmentGuide.md
for guidance on how to set up your development environment,
run the test suite, write new integrations, and more.
-->

**What does this PR do?**
<!-- A brief description of the change being made with this pull request. -->
Downgrades concurrent-ruby to 1.3.4 to stop rails 6.1 from failing during bootstrap with the following error:

```
app_1                 | Run: bin/rails db:create
app_1                 | Traceback (most recent call last):
app_1                 |         14: from bin/rails:9:in `<main>'
app_1                 |         13: from bin/rails:9:in `require'
app_1                 |         12: from /usr/local/bundle/gems/railties-6.1.7.10/lib/rails/commands.rb:3:in `<top (required)>'
app_1                 |         11: from /usr/local/bundle/gems/railties-6.1.7.10/lib/rails/commands.rb:3:in `require'
app_1                 |         10: from /usr/local/bundle/gems/railties-6.1.7.10/lib/rails/command.rb:3:in `<top (required)>'
app_1                 |          9: from /usr/local/bundle/gems/railties-6.1.7.10/lib/rails/command.rb:3:in `require'
app_1                 |          8: from /usr/local/bundle/gems/activesupport-6.1.7.10/lib/active_support.rb:29:in `<top (required)>'
app_1                 |          7: from /usr/local/bundle/gems/activesupport-6.1.7.10/lib/active_support.rb:29:in `require'
app_1                 |          6: from /usr/local/bundle/gems/activesupport-6.1.7.10/lib/active_support/logger.rb:3:in `<top (required)>'
app_1                 |          5: from /usr/local/bundle/gems/activesupport-6.1.7.10/lib/active_support/logger.rb:3:in `require'
app_1                 |          4: from /usr/local/bundle/gems/activesupport-6.1.7.10/lib/active_support/logger_silence.rb:5:in `<top (required)>'
app_1                 |          3: from /usr/local/bundle/gems/activesupport-6.1.7.10/lib/active_support/logger_silence.rb:5:in `require'
app_1                 |          2: from /usr/local/bundle/gems/activesupport-6.1.7.10/lib/active_support/logger_thread_safe_level.rb:8:in `<top (required)>'
app_1                 |          1: from /usr/local/bundle/gems/activesupport-6.1.7.10/lib/active_support/logger_thread_safe_level.rb:9:in `<module:ActiveSupport>'
app_1                 | /usr/local/bundle/gems/activesupport-6.1.7.10/lib/active_support/logger_thread_safe_level.rb:16:in `<module:LoggerThreadSafeLevel>': uninitialized constant ActiveSupport::LoggerThreadSafeLevel::Logger (NameError)
app_1                 | 
```


**Motivation:**
<!-- What inspired you to submit this pull request? -->
CI is red on master

**Change log entry**
None
<!-- If this is a customer-visible change, a brief summary to be placed
into the change log.
If you are not a Datadog employee, you can skip this section
and it will be filled or deleted during PR review. -->

**Additional Notes:**
<!-- Anything else we should know when reviewing? -->
Commit in concurrent-ruby removing logger dependency: https://github.com/ruby-concurrency/concurrent-ruby/commit/d7ce956dacd0b772273d39b8ed31a30cff7ecf38

Pointer to this being the issue: https://stackoverflow.com/questions/79360526/uninitialized-constant-activesupportloggerthreadsafelevellogger-nameerror

The issue affects Rails 6.1 and 7.0. 7.0 is fixed in https://github.com/rails/rails/issues/54263. I take it 6.1 is not going to be fixed ever. When the next release after 7.0.8.7 comes out we should be able to remove the pin on concurrent-ruby from Rails 7.0 applications.

**How to test the change?**
Existing tests
<!--
Describe here how the change can be validated.
You are strongly encouraged to provide automated tests for this PR (unit or integration).
If this change cannot be feasibly tested, please explain why,
unless the change does not modify code (e.g. only modifies docs, comments).
-->

<!-- Unsure? Have a question? Request a review! -->
