### PR TITLE
Switch system-tests back to main branch

### DIFF
--- a/.github/workflows/system-tests.yml
+++ b/.github/workflows/system-tests.yml
@@ -11,7 +11,7 @@ on:
 env:
   REGISTRY: ghcr.io
   REPO: ghcr.io/datadog/dd-trace-rb
-  SYSTEM_TESTS_REF: appsec-remove-graphql-status-code-exception-for-ruby # This must always be set to `main` on dd-trace-rb's master branch
+  SYSTEM_TESTS_REF: main # This must always be set to `main` on dd-trace-rb's master branch
 
 jobs:
   build-harness:


### PR DESCRIPTION
**What does this PR do?**
It switches system-tests ref back to `main`

**Motivation:**
I forgot to change the ref in this [PR](https://github.com/DataDog/dd-trace-rb/pull/4300) before merging

**Change log entry**
None.

**Additional Notes:**
This PR has to be merged first:
https://github.com/DataDog/system-tests/pull/3843

**How to test the change?**
CI should be green.