### PR TITLE
[NO-TICKET] Revert "Merge pull request #4306 from DataDog/ivoanjo/cache-system-tests-images"

### DIFF
--- a/.github/workflows/system-tests.yml
+++ b/.github/workflows/system-tests.yml
@@ -330,13 +330,6 @@ jobs:
         run: |
           docker pull ${{ env.REPO }}/system-tests/${{ matrix.library }}/weblog-${{ matrix.app }}:gha${{ github.run_id }}-g${{ github.sha }}
           docker tag ${{ env.REPO }}/system-tests/${{ matrix.library }}/weblog-${{ matrix.app }}:gha${{ github.run_id }}-g${{ github.sha }} system_tests/weblog:latest
-      - name: Build local runner
-        uses: ./.github/actions/install_runner
-      - name: Pull images
-        uses: ./.github/actions/pull_images
-        with:
-          scenarios: ${{ matrix.scenario }}
-          cleanup: false
       - name: List images
         run: |
           docker image list


### PR DESCRIPTION
**What does this PR do?**

This reverts commit 94f3d65421f3433a6227f2b839962bb249ba3b37, thus undoing the work in https://github.com/DataDog/dd-trace-rb/pull/4306 .

**Motivation:**

We're seeing the reverse of the attempted effect in #4306: more images are now failing to pull and hitting rate limits. [Example of issue](https://github.com/DataDog/dd-trace-rb/actions/runs/12911000274/job/36002386092?pr=4299).

Let's revert this to avoid impacting master while we figure out the next steps.

**Change log entry**

No.

**Additional Notes:**

N/A

**How to test the change?**

We should stop hitting rate limits again, or at least not as often.