### PR TITLE
Add Datadog.configuration.appsec.rasp_enabled

### DIFF
--- a/lib/datadog/appsec.rb
+++ b/lib/datadog/appsec.rb
@@ -14,6 +14,10 @@ module Datadog
         Datadog.configuration.appsec.enabled
       end
 
+      def rasp_enabled?
+        Datadog.configuration.appsec.rasp_enabled
+      end
+
       def active_context
         Datadog::AppSec::Context.active
       end

--- a/lib/datadog/appsec/configuration/settings.rb
+++ b/lib/datadog/appsec/configuration/settings.rb
@@ -49,6 +49,12 @@ module Datadog
                 end
               end
 
+              option :rasp_enabled do |o|
+                o.type :bool, nilable: true
+                o.env 'DD_APPSEC_RASP_ENABLED'
+                o.default true
+              end
+
               option :ruleset do |o|
                 o.env 'DD_APPSEC_RULES'
                 o.default :recommended

--- a/lib/datadog/appsec/configuration/settings.rb
+++ b/lib/datadog/appsec/configuration/settings.rb
@@ -49,6 +49,9 @@ module Datadog
                 end
               end
 
+              # RASP or Runtime Application Self-Protection
+              # is a collection of techniques and heuristics aimed at detecting malicious inputs and preventing
+              # any potential side-effects on the application resulting from the use of said malicious inputs.
               option :rasp_enabled do |o|
                 o.type :bool, nilable: true
                 o.env 'DD_APPSEC_RASP_ENABLED'

--- a/lib/datadog/appsec/contrib/active_record/instrumentation.rb
+++ b/lib/datadog/appsec/contrib/active_record/instrumentation.rb
@@ -9,6 +9,8 @@ module Datadog
           module_function
 
           def detect_sql_injection(sql, adapter_name)
+            return unless AppSec.rasp_enabled?
+
             context = AppSec.active_context
             return unless context
 

--- a/spec/datadog/appsec/configuration/settings_spec.rb
+++ b/spec/datadog/appsec/configuration/settings_spec.rb
@@ -77,6 +77,30 @@ RSpec.describe Datadog::AppSec::Configuration::Settings do
       end
     end
 
+    describe '#rasp_enabled' do
+      subject(:rasp_enabled) { settings.appsec.rasp_enabled }
+
+      context 'when DD_APPSEC_RASP_ENABLED' do
+        around do |example|
+          ClimateControl.modify('DD_APPSEC_RASP_ENABLED' => rasp_enabled_env_var) do
+            example.run
+          end
+        end
+
+        context 'is not defined' do
+          let(:rasp_enabled_env_var) { nil }
+
+          it { is_expected.to eq true }
+        end
+
+        context 'is defined' do
+          let(:rasp_enabled_env_var) { 'false' }
+
+          it { is_expected.to eq(false) }
+        end
+      end
+    end
+
     describe '#instrument' do
       let(:registry) { {} }
       let(:integration_name) { :fake }

--- a/spec/datadog/appsec/configuration/settings_spec.rb
+++ b/spec/datadog/appsec/configuration/settings_spec.rb
@@ -90,13 +90,13 @@ RSpec.describe Datadog::AppSec::Configuration::Settings do
         context 'is not defined' do
           let(:rasp_enabled_env_var) { nil }
 
-          it { is_expected.to eq true }
+          it { expect(settings.appsec.rasp_enabled).to eq(true) }
         end
 
         context 'is defined' do
           let(:rasp_enabled_env_var) { 'false' }
 
-          it { is_expected.to eq(false) }
+          it { expect(settings.appsec.rasp_enabled).to eq(false) }
         end
       end
     end

--- a/spec/datadog/appsec/configuration/settings_spec.rb
+++ b/spec/datadog/appsec/configuration/settings_spec.rb
@@ -78,8 +78,6 @@ RSpec.describe Datadog::AppSec::Configuration::Settings do
     end
 
     describe '#rasp_enabled' do
-      subject(:rasp_enabled) { settings.appsec.rasp_enabled }
-
       context 'when DD_APPSEC_RASP_ENABLED' do
         around do |example|
           ClimateControl.modify('DD_APPSEC_RASP_ENABLED' => rasp_enabled_env_var) do

--- a/spec/datadog/appsec/contrib/active_record/mysql2_adapter_spec.rb
+++ b/spec/datadog/appsec/contrib/active_record/mysql2_adapter_spec.rb
@@ -16,7 +16,6 @@ RSpec.describe 'AppSec ActiveRecord integration for Mysql2 adapter' do
   let(:ruleset) { Datadog::AppSec::Processor::RuleLoader.load_rules(ruleset: :recommended, telemetry: telemetry) }
   let(:processor) { Datadog::AppSec::Processor.new(ruleset: ruleset, telemetry: telemetry) }
   let(:context) { Datadog::AppSec::Context.new(trace, span, processor) }
-  let(:rasp_enabled) { true }
 
   let(:span) { Datadog::Tracing::SpanOperation.new('root') }
   let(:trace) { Datadog::Tracing::TraceOperation.new }
@@ -55,8 +54,6 @@ RSpec.describe 'AppSec ActiveRecord integration for Mysql2 adapter' do
 
     Datadog::AppSec::Context.activate(context)
 
-    allow(Datadog::AppSec).to receive(:rasp_enabled?).and_return(rasp_enabled)
-
     raise_on_rails_deprecation!
   end
 
@@ -68,7 +65,9 @@ RSpec.describe 'AppSec ActiveRecord integration for Mysql2 adapter' do
   end
 
   context 'when RASP is disabled' do
-    let(:rasp_enabled) { false }
+    before do
+      allow(Datadog::AppSec).to receive(:rasp_enabled?).and_return(false)
+    end
 
     it 'does not call waf when querying using .where' do
       expect(Datadog::AppSec.active_context).not_to receive(:run_rasp)
@@ -83,46 +82,52 @@ RSpec.describe 'AppSec ActiveRecord integration for Mysql2 adapter' do
     end
   end
 
-  it 'calls waf with correct arguments when querying using .where' do
-    expect(Datadog::AppSec.active_context).to(
-      receive(:run_rasp).with(
-        Datadog::AppSec::Ext::RASP_SQLI,
-        {},
-        {
-          'server.db.statement' => "SELECT `users`.* FROM `users` WHERE `users`.`name` = 'Bob'",
-          'server.db.system' => 'mysql2'
-        },
-        Datadog.configuration.appsec.waf_timeout
-      ).and_call_original
-    )
+  context 'when RASP is enabled' do
+    before do
+      allow(Datadog::AppSec).to receive(:rasp_enabled?).and_return(true)
+    end
 
-    User.where(name: 'Bob').to_a
-  end
+    it 'calls waf with correct arguments when querying using .where' do
+      expect(Datadog::AppSec.active_context).to(
+        receive(:run_rasp).with(
+          Datadog::AppSec::Ext::RASP_SQLI,
+          {},
+          {
+            'server.db.statement' => "SELECT `users`.* FROM `users` WHERE `users`.`name` = 'Bob'",
+            'server.db.system' => 'mysql2'
+          },
+          Datadog.configuration.appsec.waf_timeout
+        ).and_call_original
+      )
 
-  it 'calls waf with correct arguments when querying using .find_by_sql' do
-    expect(Datadog::AppSec.active_context).to(
-      receive(:run_rasp).with(
-        Datadog::AppSec::Ext::RASP_SQLI,
-        {},
-        {
-          'server.db.statement' => "SELECT * FROM users WHERE name = 'Bob'",
-          'server.db.system' => 'mysql2'
-        },
-        Datadog.configuration.appsec.waf_timeout
-      ).and_call_original
-    )
+      User.where(name: 'Bob').to_a
+    end
 
-    User.find_by_sql("SELECT * FROM users WHERE name = 'Bob'").to_a
-  end
+    it 'calls waf with correct arguments when querying using .find_by_sql' do
+      expect(Datadog::AppSec.active_context).to(
+        receive(:run_rasp).with(
+          Datadog::AppSec::Ext::RASP_SQLI,
+          {},
+          {
+            'server.db.statement' => "SELECT * FROM users WHERE name = 'Bob'",
+            'server.db.system' => 'mysql2'
+          },
+          Datadog.configuration.appsec.waf_timeout
+        ).and_call_original
+      )
 
-  it 'adds an event to processor context if waf result is a match' do
-    result = Datadog::AppSec::SecurityEngine::Result::Match.new(
-      events: [], actions: {}, derivatives: {}, timeout: false, duration_ns: 0, duration_ext_ns: 0
-    )
+      User.find_by_sql("SELECT * FROM users WHERE name = 'Bob'").to_a
+    end
 
-    expect(Datadog::AppSec.active_context).to receive(:run_rasp).and_return(result)
-    expect(Datadog::AppSec.active_context.events).to receive(:<<).and_call_original
+    it 'adds an event to processor context if waf result is a match' do
+      result = Datadog::AppSec::SecurityEngine::Result::Match.new(
+        events: [], actions: {}, derivatives: {}, timeout: false, duration_ns: 0, duration_ext_ns: 0
+      )
 
-    User.where(name: 'Bob').to_a
+      expect(Datadog::AppSec.active_context).to receive(:run_rasp).and_return(result)
+      expect(Datadog::AppSec.active_context.events).to receive(:<<).and_call_original
+
+      User.where(name: 'Bob').to_a
+    end
   end
 end

--- a/spec/datadog/appsec/contrib/active_record/mysql2_adapter_spec.rb
+++ b/spec/datadog/appsec/contrib/active_record/mysql2_adapter_spec.rb
@@ -16,6 +16,7 @@ RSpec.describe 'AppSec ActiveRecord integration for Mysql2 adapter' do
   let(:ruleset) { Datadog::AppSec::Processor::RuleLoader.load_rules(ruleset: :recommended, telemetry: telemetry) }
   let(:processor) { Datadog::AppSec::Processor.new(ruleset: ruleset, telemetry: telemetry) }
   let(:context) { Datadog::AppSec::Context.new(trace, span, processor) }
+  let(:rasp_enabled) { true }
 
   let(:span) { Datadog::Tracing::SpanOperation.new('root') }
   let(:trace) { Datadog::Tracing::TraceOperation.new }
@@ -54,6 +55,8 @@ RSpec.describe 'AppSec ActiveRecord integration for Mysql2 adapter' do
 
     Datadog::AppSec::Context.activate(context)
 
+    allow(Datadog::AppSec).to receive(:rasp_enabled?).and_return(rasp_enabled)
+
     raise_on_rails_deprecation!
   end
 
@@ -62,6 +65,22 @@ RSpec.describe 'AppSec ActiveRecord integration for Mysql2 adapter' do
 
     Datadog::AppSec::Context.deactivate
     processor.finalize
+  end
+
+  context 'when RASP is disabled' do
+    let(:rasp_enabled) { false }
+
+    it 'does not call waf when querying using .where' do
+      expect(Datadog::AppSec.active_context).not_to receive(:run_rasp)
+
+      User.where(name: 'Bob').to_a
+    end
+
+    it 'does not call waf when querying using .find_by_sql' do
+      expect(Datadog::AppSec.active_context).not_to receive(:run_rasp)
+
+      User.find_by_sql("SELECT * FROM users WHERE name = 'Bob'").to_a
+    end
   end
 
   it 'calls waf with correct arguments when querying using .where' do

--- a/spec/datadog/appsec/contrib/active_record/postgresql_adapter_spec.rb
+++ b/spec/datadog/appsec/contrib/active_record/postgresql_adapter_spec.rb
@@ -16,7 +16,6 @@ RSpec.describe 'AppSec ActiveRecord integration for Postgresql adapter' do
   let(:ruleset) { Datadog::AppSec::Processor::RuleLoader.load_rules(ruleset: :recommended, telemetry: telemetry) }
   let(:processor) { Datadog::AppSec::Processor.new(ruleset: ruleset, telemetry: telemetry) }
   let(:context) { Datadog::AppSec::Context.new(trace, span, processor) }
-  let(:rasp_enabled) { true }
 
   let(:span) { Datadog::Tracing::SpanOperation.new('root') }
   let(:trace) { Datadog::Tracing::TraceOperation.new }
@@ -56,8 +55,6 @@ RSpec.describe 'AppSec ActiveRecord integration for Postgresql adapter' do
 
     Datadog::AppSec::Context.activate(context)
 
-    allow(Datadog::AppSec).to receive(:rasp_enabled?).and_return(rasp_enabled)
-
     raise_on_rails_deprecation!
   end
 
@@ -69,7 +66,9 @@ RSpec.describe 'AppSec ActiveRecord integration for Postgresql adapter' do
   end
 
   context 'when RASP is disabled' do
-    let(:rasp_enabled) { false }
+    before do
+      allow(Datadog::AppSec).to receive(:rasp_enabled?).and_return(false)
+    end
 
     it 'does not call waf when querying using .where' do
       expect(Datadog::AppSec.active_context).not_to receive(:run_rasp)
@@ -84,52 +83,58 @@ RSpec.describe 'AppSec ActiveRecord integration for Postgresql adapter' do
     end
   end
 
-  it 'calls waf with correct arguments when querying using .where' do
-    expected_db_statement = if PlatformHelpers.jruby?
-                              'SELECT "users".* FROM "users" WHERE "users"."name" = ?'
-                            else
-                              'SELECT "users".* FROM "users" WHERE "users"."name" = $1'
-                            end
+  context 'when RASP is enabled' do
+    before do
+      allow(Datadog::AppSec).to receive(:rasp_enabled?).and_return(true)
+    end
 
-    expect(Datadog::AppSec.active_context).to(
-      receive(:run_rasp).with(
-        Datadog::AppSec::Ext::RASP_SQLI,
-        {},
-        {
-          'server.db.statement' => expected_db_statement,
-          'server.db.system' => 'postgresql'
-        },
-        Datadog.configuration.appsec.waf_timeout
-      ).and_call_original
-    )
+    it 'calls waf with correct arguments when querying using .where' do
+      expected_db_statement = if PlatformHelpers.jruby?
+                                'SELECT "users".* FROM "users" WHERE "users"."name" = ?'
+                              else
+                                'SELECT "users".* FROM "users" WHERE "users"."name" = $1'
+                              end
 
-    User.where(name: 'Bob').to_a
-  end
+      expect(Datadog::AppSec.active_context).to(
+        receive(:run_rasp).with(
+          Datadog::AppSec::Ext::RASP_SQLI,
+          {},
+          {
+            'server.db.statement' => expected_db_statement,
+            'server.db.system' => 'postgresql'
+          },
+          Datadog.configuration.appsec.waf_timeout
+        ).and_call_original
+      )
 
-  it 'calls waf with correct arguments when querying using .find_by_sql' do
-    expect(Datadog::AppSec.active_context).to(
-      receive(:run_rasp).with(
-        Datadog::AppSec::Ext::RASP_SQLI,
-        {},
-        {
-          'server.db.statement' => "SELECT * FROM users WHERE name = 'Bob'",
-          'server.db.system' => 'postgresql'
-        },
-        Datadog.configuration.appsec.waf_timeout
-      ).and_call_original
-    )
+      User.where(name: 'Bob').to_a
+    end
 
-    User.find_by_sql("SELECT * FROM users WHERE name = 'Bob'").to_a
-  end
+    it 'calls waf with correct arguments when querying using .find_by_sql' do
+      expect(Datadog::AppSec.active_context).to(
+        receive(:run_rasp).with(
+          Datadog::AppSec::Ext::RASP_SQLI,
+          {},
+          {
+            'server.db.statement' => "SELECT * FROM users WHERE name = 'Bob'",
+            'server.db.system' => 'postgresql'
+          },
+          Datadog.configuration.appsec.waf_timeout
+        ).and_call_original
+      )
 
-  it 'adds an event to processor context if waf result is a match' do
-    result = Datadog::AppSec::SecurityEngine::Result::Match.new(
-      events: [], actions: {}, derivatives: {}, timeout: false, duration_ns: 0, duration_ext_ns: 0
-    )
+      User.find_by_sql("SELECT * FROM users WHERE name = 'Bob'").to_a
+    end
 
-    expect(Datadog::AppSec.active_context).to receive(:run_rasp).and_return(result)
-    expect(Datadog::AppSec.active_context.events).to receive(:<<).and_call_original
+    it 'adds an event to processor context if waf result is a match' do
+      result = Datadog::AppSec::SecurityEngine::Result::Match.new(
+        events: [], actions: {}, derivatives: {}, timeout: false, duration_ns: 0, duration_ext_ns: 0
+      )
 
-    User.where(name: 'Bob').to_a
+      expect(Datadog::AppSec.active_context).to receive(:run_rasp).and_return(result)
+      expect(Datadog::AppSec.active_context.events).to receive(:<<).and_call_original
+
+      User.where(name: 'Bob').to_a
+    end
   end
 end

--- a/spec/datadog/appsec/contrib/active_record/postgresql_adapter_spec.rb
+++ b/spec/datadog/appsec/contrib/active_record/postgresql_adapter_spec.rb
@@ -16,6 +16,7 @@ RSpec.describe 'AppSec ActiveRecord integration for Postgresql adapter' do
   let(:ruleset) { Datadog::AppSec::Processor::RuleLoader.load_rules(ruleset: :recommended, telemetry: telemetry) }
   let(:processor) { Datadog::AppSec::Processor.new(ruleset: ruleset, telemetry: telemetry) }
   let(:context) { Datadog::AppSec::Context.new(trace, span, processor) }
+  let(:rasp_enabled) { true }
 
   let(:span) { Datadog::Tracing::SpanOperation.new('root') }
   let(:trace) { Datadog::Tracing::TraceOperation.new }
@@ -55,6 +56,8 @@ RSpec.describe 'AppSec ActiveRecord integration for Postgresql adapter' do
 
     Datadog::AppSec::Context.activate(context)
 
+    allow(Datadog::AppSec).to receive(:rasp_enabled?).and_return(rasp_enabled)
+
     raise_on_rails_deprecation!
   end
 
@@ -63,6 +66,22 @@ RSpec.describe 'AppSec ActiveRecord integration for Postgresql adapter' do
 
     Datadog::AppSec::Context.deactivate
     processor.finalize
+  end
+
+  context 'when RASP is disabled' do
+    let(:rasp_enabled) { false }
+
+    it 'does not call waf when querying using .where' do
+      expect(Datadog::AppSec.active_context).not_to receive(:run_rasp)
+
+      User.where(name: 'Bob').to_a
+    end
+
+    it 'does not call waf when querying using .find_by_sql' do
+      expect(Datadog::AppSec.active_context).not_to receive(:run_rasp)
+
+      User.find_by_sql("SELECT * FROM users WHERE name = 'Bob'").to_a
+    end
   end
 
   it 'calls waf with correct arguments when querying using .where' do


### PR DESCRIPTION
**What does this PR do?**
It adds `DD_APPSEC_RASP_ENABLED` setting to AppSec for disabling RASP.

**Motivation:**
This [RFC](https://datadoghq.atlassian.net/wiki/spaces/SAAL/embed/4385407620)

**Change log entry**
Yes. AppSec: Add setting to disable RASP checks

**Additional Notes:**
None.

**How to test the change?**
CI is enough