### PR TITLE
Skip non-linux OCI package creation

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -8,7 +8,7 @@ stages:
   - benchmarks
 
 include:
-  - remote: https://gitlab-templates.ddbuild.io/libdatadog/include/one-pipeline.yml
+  - remote: https://gitlab-templates.ddbuild.io/libdatadog/include-wip/landerson/windows-layer/one-pipeline.yml
   - local: ".gitlab/benchmarks.yml"
 
 variables:

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -8,7 +8,7 @@ stages:
   - benchmarks
 
 include:
-  - remote: https://gitlab-templates.ddbuild.io/libdatadog/include-wip/landerson/windows-layer/one-pipeline.yml
+  - remote: https://gitlab-templates.ddbuild.io/libdatadog/include/one-pipeline.yml
   - local: ".gitlab/benchmarks.yml"
 
 variables:

--- a/.gitlab/prepare-oci-package.sh
+++ b/.gitlab/prepare-oci-package.sh
@@ -2,6 +2,11 @@
 
 set -e
 
+if [ "$OS" != "linux" ]; then
+  echo "Only linux packages are supported. Exiting"
+  exit 0
+fi
+
 mkdir sources
 
 cp ../lib-injection/host_inject.rb sources


### PR DESCRIPTION
<!--
Check out the
https://github.com/DataDog/dd-trace-rb/blob/master/docs/DevelopmentGuide.md
for guidance on how to set up your development environment,
run the test suite, write new integrations, and more.
-->

**What does this PR do?**
Skips package creation for non-linux packages

**Motivation:**
The shared pipeline is introducing support for windows OCI packages. This PR ensure dd-trace-rb doesn't generate nonsensical packages. Windows support can be added later

**How to test the change?**
<!--
Describe here how the change can be validated.
You are strongly encouraged to provide automated tests for this PR (unit or integration).
If this change cannot be feasibly tested, please explain why,
unless the change does not modify code (e.g. only modifies docs, comments).
-->
The change is tested against the WIP one-pipeline branch

<!-- Unsure? Have a question? Request a review! -->
