### PR TITLE
Edit CODEOWNERS and JUnit XML file paths to match

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -275,6 +275,8 @@ orbs:
               name: Upload JUnit reports to Datadog
               when: always
               command: |
+                sed -i 's/file="\.\//file="/g' tmp/rspec/*.xml
+                
                 ls -l tmp/rspec/*.xml
 
                 curl -L --fail --retry 3 "https://github.com/DataDog/datadog-ci/releases/latest/download/datadog-ci_linux-x64" --output "/usr/local/bin/datadog-ci" && chmod +x /usr/local/bin/datadog-ci

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,39 +1,39 @@
 * @DataDog/ruby-guild
 
 # Public Documentation
-./docs/Compatibility.md @DataDog/documentation
-./docs/GettingStarted.md @DataDog/documentation
+docs/Compatibility.md @DataDog/documentation
+docs/GettingStarted.md @DataDog/documentation
 
 # Library
-./lib/datadog/appsec/ @DataDog/asm-ruby
-./lib/datadog/appsec.rb @DataDog/asm-ruby
-./lib/datadog/tracing/ @DataDog/tracing-ruby
-./lib/datadog/tracing/contrib/ @DataDog/apm-idm-ruby
-./lib/datadog/tracing.rb @DataDog/tracing-ruby
-./lib/datadog/opentelemetry/ @DataDog/tracing-ruby
-./lib/datadog/opentelemetry.rb @DataDog/tracing-ruby
-./lib-injection/ @DataDog/tracing-ruby
-./lib/datadog/profiling/ @DataDog/profiling-rb @DataDog/ruby-guild
-./lib/datadog/profiling.rb @DataDog/profiling-rb @DataDog/ruby-guild
-./ext/ @DataDog/profiling-rb @DataDog/ruby-guild
+lib/datadog/appsec/ @DataDog/asm-ruby
+lib/datadog/appsec.rb @DataDog/asm-ruby
+lib/datadog/tracing/ @DataDog/tracing-ruby
+lib/datadog/tracing/contrib/ @DataDog/apm-idm-ruby
+lib/datadog/tracing.rb @DataDog/tracing-ruby
+lib/datadog/opentelemetry/ @DataDog/tracing-ruby
+lib/datadog/opentelemetry.rb @DataDog/tracing-ruby
+lib-injection/ @DataDog/tracing-ruby
+lib/datadog/profiling/ @DataDog/profiling-rb @DataDog/ruby-guild
+lib/datadog/profiling.rb @DataDog/profiling-rb @DataDog/ruby-guild
+ext/ @DataDog/profiling-rb @DataDog/ruby-guild
 
 # RBS signatures
-./sig/datadog/appsec/ @DataDog/asm-ruby
-./sig/datadog/appsec.rbs @DataDog/asm-ruby
-./sig/datadog/tracing/ @DataDog/tracing-ruby
-./sig/datadog/tracing/contrib/ @DataDog/apm-idm-ruby
-./sig/datadog/tracing.rbs @DataDog/tracing-ruby
-./sig/datadog/opentelemetry/ @DataDog/tracing-ruby
-./sig/datadog/opentelemetry.rbs @DataDog/tracing-ruby
-./sig/datadog/profiling/ @DataDog/profiling-rb @DataDog/ruby-guild
-./sig/datadog/profiling.rbs @DataDog/profiling-rb @DataDog/ruby-guild
+sig/datadog/appsec/ @DataDog/asm-ruby
+sig/datadog/appsec.rbs @DataDog/asm-ruby
+sig/datadog/tracing/ @DataDog/tracing-ruby
+sig/datadog/tracing/contrib/ @DataDog/apm-idm-ruby
+sig/datadog/tracing.rbs @DataDog/tracing-ruby
+sig/datadog/opentelemetry/ @DataDog/tracing-ruby
+sig/datadog/opentelemetry.rbs @DataDog/tracing-ruby
+sig/datadog/profiling/ @DataDog/profiling-rb @DataDog/ruby-guild
+sig/datadog/profiling.rbs @DataDog/profiling-rb @DataDog/ruby-guild
 
 # Specs
-./spec/datadog/appsec/ @DataDog/asm-ruby
-./spec/datadog/tracing/ @DataDog/tracing-ruby
-./spec/datadog/tracing/contrib/ @DataDog/apm-idm-ruby
-./spec/datadog/tracing_spec.rb @DataDog/tracing-ruby
-./spec/datadog/opentelemetry/ @DataDog/tracing-ruby
-./spec/datadog/opentelemetry_spec.rb @DataDog/tracing-ruby
-./spec/datadog/profiling/ @DataDog/profiling-rb @DataDog/ruby-guild
-./spec/datadog/profiling_spec.rb @DataDog/profiling-rb @DataDog/ruby-guild
+spec/datadog/appsec/ @DataDog/asm-ruby
+spec/datadog/tracing/ @DataDog/tracing-ruby
+spec/datadog/tracing/contrib/ @DataDog/apm-idm-ruby
+spec/datadog/tracing_spec.rb @DataDog/tracing-ruby
+spec/datadog/opentelemetry/ @DataDog/tracing-ruby
+spec/datadog/opentelemetry_spec.rb @DataDog/tracing-ruby
+spec/datadog/profiling/ @DataDog/profiling-rb @DataDog/ruby-guild
+spec/datadog/profiling_spec.rb @DataDog/profiling-rb @DataDog/ruby-guild

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,39 +1,39 @@
 * @DataDog/ruby-guild
 
 # Public Documentation
-/docs/Compatibility.md @DataDog/documentation
-/docs/GettingStarted.md @DataDog/documentation
+./docs/Compatibility.md @DataDog/documentation
+./docs/GettingStarted.md @DataDog/documentation
 
 # Library
-/lib/datadog/appsec/ @DataDog/asm-ruby
-/lib/datadog/appsec.rb @DataDog/asm-ruby
-/lib/datadog/tracing/ @DataDog/tracing-ruby
-/lib/datadog/tracing/contrib/ @DataDog/apm-idm-ruby
-/lib/datadog/tracing.rb @DataDog/tracing-ruby
-/lib/datadog/opentelemetry/ @DataDog/tracing-ruby
-/lib/datadog/opentelemetry.rb @DataDog/tracing-ruby
-/lib-injection/ @DataDog/tracing-ruby
-/lib/datadog/profiling/ @DataDog/profiling-rb @DataDog/ruby-guild
-/lib/datadog/profiling.rb @DataDog/profiling-rb @DataDog/ruby-guild
-/ext/ @DataDog/profiling-rb @DataDog/ruby-guild
+./lib/datadog/appsec/ @DataDog/asm-ruby
+./lib/datadog/appsec.rb @DataDog/asm-ruby
+./lib/datadog/tracing/ @DataDog/tracing-ruby
+./lib/datadog/tracing/contrib/ @DataDog/apm-idm-ruby
+./lib/datadog/tracing.rb @DataDog/tracing-ruby
+./lib/datadog/opentelemetry/ @DataDog/tracing-ruby
+./lib/datadog/opentelemetry.rb @DataDog/tracing-ruby
+./lib-injection/ @DataDog/tracing-ruby
+./lib/datadog/profiling/ @DataDog/profiling-rb @DataDog/ruby-guild
+./lib/datadog/profiling.rb @DataDog/profiling-rb @DataDog/ruby-guild
+./ext/ @DataDog/profiling-rb @DataDog/ruby-guild
 
 # RBS signatures
-/sig/datadog/appsec/ @DataDog/asm-ruby
-/sig/datadog/appsec.rbs @DataDog/asm-ruby
-/sig/datadog/tracing/ @DataDog/tracing-ruby
-/sig/datadog/tracing/contrib/ @DataDog/apm-idm-ruby
-/sig/datadog/tracing.rbs @DataDog/tracing-ruby
-/sig/datadog/opentelemetry/ @DataDog/tracing-ruby
-/sig/datadog/opentelemetry.rbs @DataDog/tracing-ruby
-/sig/datadog/profiling/ @DataDog/profiling-rb @DataDog/ruby-guild
-/sig/datadog/profiling.rbs @DataDog/profiling-rb @DataDog/ruby-guild
+./sig/datadog/appsec/ @DataDog/asm-ruby
+./sig/datadog/appsec.rbs @DataDog/asm-ruby
+./sig/datadog/tracing/ @DataDog/tracing-ruby
+./sig/datadog/tracing/contrib/ @DataDog/apm-idm-ruby
+./sig/datadog/tracing.rbs @DataDog/tracing-ruby
+./sig/datadog/opentelemetry/ @DataDog/tracing-ruby
+./sig/datadog/opentelemetry.rbs @DataDog/tracing-ruby
+./sig/datadog/profiling/ @DataDog/profiling-rb @DataDog/ruby-guild
+./sig/datadog/profiling.rbs @DataDog/profiling-rb @DataDog/ruby-guild
 
 # Specs
-/spec/datadog/appsec/ @DataDog/asm-ruby
-/spec/datadog/tracing/ @DataDog/tracing-ruby
-/spec/datadog/tracing/contrib/ @DataDog/apm-idm-ruby
-/spec/datadog/tracing_spec.rb @DataDog/tracing-ruby
-/spec/datadog/opentelemetry/ @DataDog/tracing-ruby
-/spec/datadog/opentelemetry_spec.rb @DataDog/tracing-ruby
-/spec/datadog/profiling/ @DataDog/profiling-rb @DataDog/ruby-guild
-/spec/datadog/profiling_spec.rb @DataDog/profiling-rb @DataDog/ruby-guild
+./spec/datadog/appsec/ @DataDog/asm-ruby
+./spec/datadog/tracing/ @DataDog/tracing-ruby
+./spec/datadog/tracing/contrib/ @DataDog/apm-idm-ruby
+./spec/datadog/tracing_spec.rb @DataDog/tracing-ruby
+./spec/datadog/opentelemetry/ @DataDog/tracing-ruby
+./spec/datadog/opentelemetry_spec.rb @DataDog/tracing-ruby
+./spec/datadog/profiling/ @DataDog/profiling-rb @DataDog/ruby-guild
+./spec/datadog/profiling_spec.rb @DataDog/profiling-rb @DataDog/ruby-guild


### PR DESCRIPTION
<!--
Check out the
https://github.com/DataDog/dd-trace-rb/blob/master/docs/DevelopmentGuide.md
for guidance on how to set up your development environment,
run the test suite, write new integrations, and more.
-->

**What does this PR do?**
This PR removes the `/` prefix from the `CODEOWNERS` paths and the `./` prefix from the JUnit XML testcase source file paths.

**Motivation:**
Currently, all of our testcase codeowner tags in CI are incorrectly marked as the default @DataDog/ruby-guild. This is because the JUnit XML testcase source file paths do not match the `CODEOWNERS` paths. By removing the prefixes above, the paths will match and testcase codeowner tags will be properly set. See [this reference](https://docs.datadoghq.com/tests/setup/junit_xml/?tab=linux#adding-code-owners) for how testcase codeowner tag assignments work.

With proper codeowners assigned, we can better see the distribution and ownership of tests. This especially will help with identifying flaky test ownership.

**Change log entry**
No.

**Additional Notes:**
N/A

**How to test the change?**
1. [CircleCI build-and-test workflow](https://app.circleci.com/pipelines/github/DataDog/dd-trace-rb/18765/workflows/8af081a7-b9f8-4fa5-a48e-3202f10850a2) 
2. any test, any run (e.g. [test-3.4, run 0](https://app.circleci.com/pipelines/github/DataDog/dd-trace-rb/18765/workflows/8af081a7-b9f8-4fa5-a48e-3202f10850a2/jobs/658488)) 
3. "Upload JUnit reports to Datadog" (e.g. [for test-3.4, run 0](https://app.circleci.com/pipelines/github/DataDog/dd-trace-rb/18765/workflows/8af081a7-b9f8-4fa5-a48e-3202f10850a2/jobs/658488/parallel-runs/0/steps/0-116))
4. Link under "Test runs report:" (e.g. [for test-3.4, run 0](https://app.datadoghq.com/ci/test-runs?query=%20%40ci.job.url%3A%22https%3A%2F%2Fcircleci.com%2Fgh%2FDataDog%2Fdd-trace-rb%2F658488%22))
5. "Test name" corresponds to the "Test code owners" (e.g. @DataDog/asm-ruby instead of @DataDog/ruby-guild)

This change should also show up in dashboards that filter on test codeowner tags (e.g. this dashboard under the "Test failure by codeowner" widget).

<!-- Unsure? Have a question? Request a review! -->
