### PR TITLE
[NO-TICKET] Ignore docs changes in system tests workflow

### DIFF
--- a/.github/workflows/system-tests.yml
+++ b/.github/workflows/system-tests.yml
@@ -4,9 +4,22 @@ on:
   push:
     branches:
       - "**"
+    paths-ignore:
+      - ".circleci/**"
+      - ".gitlab/**"
+      - "appraisal/**"
+      - "benchmarks/**"
+      - "docs/**"
+      - "gemfiles/**"
+      - "integration/**"
+      - "sig/**"
+      - "spec/**"
+      - "suppressions/**"
+      - "tools/**"
+      - "vendor/**"
   workflow_dispatch: {}
   schedule:
-    - cron:  '00 04 * * 2-6'
+    - cron: "00 04 * * 2-6"
 
 env:
   REGISTRY: ghcr.io
@@ -33,7 +46,7 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
         with:
-          repository: 'DataDog/system-tests'
+          repository: "DataDog/system-tests"
           ref: ${{ env.SYSTEM_TESTS_REF }}
           persist-credentials: false
       - name: Login to Docker Hub
@@ -61,21 +74,18 @@ jobs:
         run: |
           echo ${{ secrets.GITHUB_TOKEN }} | docker login ${{ env.REGISTRY }} -u ${{ github.actor }} --password-stdin
       - name: Tag image for CI run
-        run:
-          docker tag ${{ matrix.image.internal }} ${{ env.REPO }}/system-tests/${{ matrix.image.name }}:gha${{ github.run_id }}-g${{ github.sha }}
+        run: docker tag ${{ matrix.image.internal }} ${{ env.REPO }}/system-tests/${{ matrix.image.name }}:gha${{ github.run_id }}-g${{ github.sha }}
       - name: Push image for CI run
         run: |
           docker push ${{ env.REPO }}/system-tests/${{ matrix.image.name }}:gha${{ github.run_id }}-g${{ github.sha }}
       - name: Tag image for commit
-        run:
-          docker tag ${{ matrix.image.internal }} ${{ env.REPO }}/system-tests/${{ matrix.image.name }}:g${{ github.sha }}
+        run: docker tag ${{ matrix.image.internal }} ${{ env.REPO }}/system-tests/${{ matrix.image.name }}:g${{ github.sha }}
       - name: Push image for commit
         run: |
           docker push ${{ env.REPO }}/system-tests/${{ matrix.image.name }}:g${{ github.sha }}
       - name: Tag image for release
         if: ${{ github.ref == 'refs/heads/master' }}
-        run:
-          docker tag ${{ matrix.image.internal }} ${{ env.REPO }}/system-tests/${{ matrix.image.name }}:latest
+        run: docker tag ${{ matrix.image.internal }} ${{ env.REPO }}/system-tests/${{ matrix.image.name }}:latest
       - name: Push image for release
         if: ${{ github.ref == 'refs/heads/master' }}
         run: |
@@ -122,14 +132,14 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
         with:
-          repository: 'DataDog/system-tests'
+          repository: "DataDog/system-tests"
           ref: ${{ env.SYSTEM_TESTS_REF }}
           persist-credentials: false
       - name: Checkout ${{ matrix.library.repository }}
         uses: actions/checkout@v4
         with:
-          repository: '${{ matrix.library.repository }}'
-          path: 'binaries/${{ matrix.library.path }}'
+          repository: "${{ matrix.library.repository }}"
+          path: "binaries/${{ matrix.library.path }}"
           fetch-depth: 2
           persist-credentials: false
       - name: Read forced-tests-list.json file
@@ -168,21 +178,18 @@ jobs:
           echo "cache args: ${cache_from[*]}"
           ./build.sh --library ${{ matrix.library.name }} --weblog-variant ${{ matrix.app }} --images ${{ matrix.image }} --extra-docker-args "${cache_from[*]}"
       - name: Tag image for CI run
-        run:
-          docker tag system_tests/${{ matrix.image }}:latest ${{ env.REPO }}/system-tests/${{ matrix.library.name }}/${{ matrix.image }}-${{ matrix.app }}:gha${{ github.run_id }}-g${{ github.sha }}
+        run: docker tag system_tests/${{ matrix.image }}:latest ${{ env.REPO }}/system-tests/${{ matrix.library.name }}/${{ matrix.image }}-${{ matrix.app }}:gha${{ github.run_id }}-g${{ github.sha }}
       - name: Push image for CI run
         run: |
           docker push ${{ env.REPO }}/system-tests/${{ matrix.library.name }}/${{ matrix.image }}-${{ matrix.app }}:gha${{ github.run_id }}-g${{ github.sha }}
       - name: Tag image for commit
-        run:
-          docker tag system_tests/${{ matrix.image }}:latest ${{ env.REPO }}/system-tests/${{ matrix.library.name }}/${{ matrix.image }}-${{ matrix.app }}:g${{ github.sha }}
+        run: docker tag system_tests/${{ matrix.image }}:latest ${{ env.REPO }}/system-tests/${{ matrix.library.name }}/${{ matrix.image }}-${{ matrix.app }}:g${{ github.sha }}
       - name: Push image for commit
         run: |
           docker push ${{ env.REPO }}/system-tests/${{ matrix.library.name }}/${{ matrix.image }}-${{ matrix.app }}:g${{ github.sha }}
       - name: Tag image for release
         if: ${{ github.ref == 'refs/heads/master' }}
-        run:
-          docker tag system_tests/${{ matrix.image }}:latest ${{ env.REPO }}/system-tests/${{ matrix.library.name }}/${{ matrix.image }}-${{ matrix.app }}:latest
+        run: docker tag system_tests/${{ matrix.image }}:latest ${{ env.REPO }}/system-tests/${{ matrix.library.name }}/${{ matrix.image }}-${{ matrix.app }}:latest
       - name: Push image for release
         if: ${{ github.ref == 'refs/heads/master' }}
         run: |
@@ -306,7 +313,7 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
         with:
-          repository: 'DataDog/system-tests'
+          repository: "DataDog/system-tests"
           ref: ${{ env.SYSTEM_TESTS_REF }}
           persist-credentials: false
       - name: Login to Docker Hub
@@ -390,11 +397,11 @@ jobs:
       - name: Setup python 3.12
         uses: actions/setup-python@v5
         with:
-          python-version: '3.12'
+          python-version: "3.12"
       - name: Checkout
         uses: actions/checkout@v4
         with:
-          repository: 'DataDog/system-tests'
+          repository: "DataDog/system-tests"
           ref: ${{ env.SYSTEM_TESTS_REF }}
           persist-credentials: false
       - name: Retrieve logs
@@ -446,9 +453,9 @@ jobs:
           echo ${{ secrets.GITHUB_TOKEN }} | docker login ${{ env.REGISTRY }} -u ${{ github.actor }} --password-stdin
       - uses: actions/delete-package-versions@v5
         with:
-          package-version-ids: 'gha${{ github.run_id }}-g${{ github.sha }}'
-          package-name: 'system-tests/${{ matrix.image }}'
-          package-type: 'container'
+          package-version-ids: "gha${{ github.run_id }}-g${{ github.sha }}"
+          package-name: "system-tests/${{ matrix.image }}"
+          package-type: "container"
         continue-on-error: true
 
   build-artifacts:
@@ -475,4 +482,4 @@ jobs:
       library: ruby
       binaries_artifact: system_tests_binaries
       _experimental_job_count: 8
-      _experimental_job_matrix: '[1,2,3,4,5,6,7,8]'
+      _experimental_job_matrix: "[1,2,3,4,5,6,7,8]"


### PR DESCRIPTION
**What does this PR do?**

Ignore `docs/**` in system tests workflow.

**Motivation:**

An action item from the last guild meeting, we don't need to run whole test suite for documentation changes. This is exactly [documentation-like changes](https://docs.github.com/en/actions/writing-workflows/workflow-syntax-for-github-actions#example-excluding-paths).

**Change log entry**

No.

**Additional Notes:**

My auto-correction made a few adjustments for consistency, I decide to keep it.

**How to test the change?**

Open PR with documentation changes only, system tests should not be present. Not sure about the required checks, probably we need to configure something there too.
