### PR TITLE
[APPSEC-56456] Add telemetry metrics to rasp calls

### DIFF
--- a/lib/datadog/appsec/context.rb
+++ b/lib/datadog/appsec/context.rb
@@ -46,10 +46,12 @@ module Datadog
         result
       end
 
-      def run_rasp(_type, persistent_data, ephemeral_data, timeout = WAF::LibDDWAF::DDWAF_RUN_TIMEOUT)
+      def run_rasp(type, persistent_data, ephemeral_data, timeout = WAF::LibDDWAF::DDWAF_RUN_TIMEOUT)
         result = @waf_runner.run(persistent_data, ephemeral_data, timeout)
 
+        Metrics::Telemetry.report_rasp(type, result)
         @metrics.record_rasp(result)
+
         result
       end
 

--- a/lib/datadog/appsec/ext.rb
+++ b/lib/datadog/appsec/ext.rb
@@ -3,7 +3,10 @@
 module Datadog
   module AppSec
     module Ext
-      RASP_SQLI = :sql_injection
+      RASP_SQLI = 'sql_injection'
+      RASP_LFI = 'lfi'
+      RASP_SSRF = 'ssrf'
+
       INTERRUPT = :datadog_appsec_interrupt
       CONTEXT_KEY = 'datadog.appsec.context'
       ACTIVE_CONTEXT_KEY = :datadog_appsec_active_context
@@ -11,6 +14,8 @@ module Datadog
       TAG_APPSEC_ENABLED = '_dd.appsec.enabled'
       TAG_APM_ENABLED = '_dd.apm.enabled'
       TAG_DISTRIBUTED_APPSEC_EVENT = '_dd.p.appsec'
+
+      TELEMETRY_METRICS_NAMESPACE = 'appsec'
     end
   end
 end

--- a/lib/datadog/appsec/metrics.rb
+++ b/lib/datadog/appsec/metrics.rb
@@ -10,3 +10,4 @@ end
 
 require_relative 'metrics/collector'
 require_relative 'metrics/exporter'
+require_relative 'metrics/telemetry'

--- a/lib/datadog/appsec/metrics/telemetry.rb
+++ b/lib/datadog/appsec/metrics/telemetry.rb
@@ -1,0 +1,23 @@
+# frozen_string_literal: true
+
+module Datadog
+  module AppSec
+    module Metrics
+      # A class responsible for reporting WAF and RASP telemetry metrics.
+      module Telemetry
+        module_function
+
+        def report_rasp(type, result)
+          return if result.is_a?(SecurityEngine::Result::Error)
+
+          tags = { rule_type: type, waf_version: Datadog::AppSec::WAF::VERSION::BASE_STRING }
+          namespace = Ext::TELEMETRY_METRICS_NAMESPACE
+
+          AppSec.telemetry.inc(namespace, 'rasp.rule.eval', 1, tags: tags)
+          AppSec.telemetry.inc(namespace, 'rasp.rule.match', 1, tags: tags) if result.match?
+          AppSec.telemetry.inc(namespace, 'rasp.timeout', 1, tags: tags) if result.timeout?
+        end
+      end
+    end
+  end
+end

--- a/sig/datadog/appsec/context.rbs
+++ b/sig/datadog/appsec/context.rbs
@@ -33,7 +33,7 @@ module Datadog
 
       def run_waf: (input_data persistent_data, input_data ephemeral_data, ?Integer timeout) -> SecurityEngine::result
 
-      def run_rasp: (::Symbol _type, input_data persistent_data, input_data ephemeral_data, ?Integer timeout) -> SecurityEngine::result
+      def run_rasp: (Ext::rasp_rule_type type, input_data persistent_data, input_data ephemeral_data, ?Integer timeout) -> SecurityEngine::result
 
       def export_metrics: () -> void
 

--- a/sig/datadog/appsec/ext.rbs
+++ b/sig/datadog/appsec/ext.rbs
@@ -1,14 +1,27 @@
 module Datadog
   module AppSec
     module Ext
-      RASP_SQLI: ::Symbol
+      type rasp_rule_type = ::String
+
+      RASP_SQLI: ::String
+
+      RASP_LFI: ::String
+
+      RASP_SSRF: ::String
+
       INTERRUPT: ::Symbol
+
       CONTEXT_KEY: ::String
+
       ACTIVE_CONTEXT_KEY: ::Symbol
 
       TAG_APPSEC_ENABLED: ::String
+
       TAG_APM_ENABLED: ::String
+
       TAG_DISTRIBUTED_APPSEC_EVENT: ::String
+
+      TELEMETRY_METRICS_NAMESPACE: ::String
     end
   end
 end

--- a/sig/datadog/appsec/metrics/telemetry.rbs
+++ b/sig/datadog/appsec/metrics/telemetry.rbs
@@ -1,0 +1,9 @@
+module Datadog
+  module AppSec
+    module Metrics
+      module Telemetry
+        def self?.report_rasp: (Ext::rasp_rule_type type, SecurityEngine::result result) -> void
+      end
+    end
+  end
+end

--- a/spec/datadog/appsec/context_spec.rb
+++ b/spec/datadog/appsec/context_spec.rb
@@ -88,7 +88,7 @@ RSpec.describe Datadog::AppSec::Context do
           'server.request.headers.no_cookies' => { 'user-agent' => 'Nessus SOAP' }
         }
 
-        Array.new(3) { context.run_waf(persistent_data, {}, 10_000) }
+        Array.new(3) { context.run_waf(persistent_data, {}, 1_000_000) }
       end
 
       it 'returns a single match and rest is ok' do
@@ -110,8 +110,8 @@ RSpec.describe Datadog::AppSec::Context do
         }
 
         [
-          context.run_waf(persistent_data_1, {}, 10_000),
-          context.run_waf(persistent_data_2, {}, 10_000),
+          context.run_waf(persistent_data_1, {}, 1_000_000),
+          context.run_waf(persistent_data_2, {}, 1_000_000),
         ]
       end
 
@@ -145,7 +145,7 @@ RSpec.describe Datadog::AppSec::Context do
           .with('appsec', anything, kind_of(Integer), anything)
           .at_least(:once)
 
-        context.run_rasp('sqli', persistent_data, ephemeral_data, 10_000)
+        context.run_rasp('sqli', persistent_data, ephemeral_data, 1_000_000)
       end
     end
 
@@ -172,7 +172,7 @@ RSpec.describe Datadog::AppSec::Context do
       it 'sends telemetry metrics' do
         expect(telemetry).not_to receive(:inc)
 
-        context.run_rasp('sqli', persistent_data, ephemeral_data, 10_000)
+        context.run_rasp('sqli', persistent_data, ephemeral_data, 1_000_000)
       end
     end
   end

--- a/spec/datadog/appsec/context_spec.rb
+++ b/spec/datadog/appsec/context_spec.rb
@@ -126,6 +126,57 @@ RSpec.describe Datadog::AppSec::Context do
     end
   end
 
+  describe '#run_rasp' do
+    context 'when a matching run was made' do
+      before { allow(Datadog::AppSec).to receive(:telemetry).and_return(telemetry) }
+
+      let(:persistent_data) do
+        { 'server.request.query' => { 'q' => "1' OR 1=1;" } }
+      end
+      let(:ephemeral_data) do
+        {
+          'server.db.statement' => "SELECT * FROM users WHERE name = '1' OR 1=1;",
+          'server.db.system' => 'mysql'
+        }
+      end
+
+      it 'sends telemetry metrics' do
+        expect(telemetry).to receive(:inc)
+          .with('appsec', anything, kind_of(Integer), anything)
+          .at_least(:once)
+
+        context.run_rasp('sqli', persistent_data, ephemeral_data, 10_000)
+      end
+    end
+
+    context 'when a run was a failure' do
+      before do
+        allow(Datadog::AppSec).to receive(:telemetry).and_return(telemetry)
+        allow_any_instance_of(Datadog::AppSec::SecurityEngine::Runner).to receive(:run)
+          .and_return(run_result)
+      end
+
+      let(:run_result) do
+        Datadog::AppSec::SecurityEngine::Result::Error.new(duration_ext_ns: 0)
+      end
+      let(:persistent_data) do
+        { 'server.request.query' => { 'q' => "1' OR 1=1;" } }
+      end
+      let(:ephemeral_data) do
+        {
+          'server.db.statement' => "SELECT * FROM users WHERE name = '1' OR 1=1;",
+          'server.db.system' => 'mysql'
+        }
+      end
+
+      it 'sends telemetry metrics' do
+        expect(telemetry).not_to receive(:inc)
+
+        context.run_rasp('sqli', persistent_data, ephemeral_data, 10_000)
+      end
+    end
+  end
+
   describe '#extract_schema' do
     it 'calls the waf runner with specific addresses' do
       expect_any_instance_of(Datadog::AppSec::SecurityEngine::Runner).to receive(:run)

--- a/spec/datadog/appsec/metrics/telemetry_spec.rb
+++ b/spec/datadog/appsec/metrics/telemetry_spec.rb
@@ -1,0 +1,96 @@
+# frozen_string_literal: true
+
+require 'datadog/appsec/spec_helper'
+
+RSpec.describe Datadog::AppSec::Metrics::Telemetry do
+  before do
+    stub_const('Datadog::AppSec::Ext::TELEMETRY_METRICS_NAMESPACE', 'specsec')
+    stub_const('Datadog::AppSec::WAF::VERSION::BASE_STRING', '1.42.99')
+
+    allow(Datadog::AppSec).to receive(:telemetry).and_return(telemetry)
+  end
+
+  let(:telemetry) { instance_double(Datadog::Core::Telemetry::Component) }
+
+  describe '.report_rasp' do
+    context 'when reporting a match run result' do
+      let(:run_result) do
+        Datadog::AppSec::SecurityEngine::Result::Match.new(
+          events: [], actions: {}, derivatives: {}, timeout: false, duration_ns: 0, duration_ext_ns: 0
+        )
+      end
+
+      it 'does not set WAF metrics on the span' do
+        expect(telemetry).to receive(:inc)
+          .with('specsec', 'rasp.rule.eval', 1, tags: { rule_type: 'my-type', waf_version: '1.42.99' })
+        expect(telemetry).to receive(:inc)
+          .with('specsec', 'rasp.rule.match', 1, tags: { rule_type: 'my-type', waf_version: '1.42.99' })
+
+        described_class.report_rasp('my-type', run_result)
+      end
+    end
+
+    context 'when reporting a match run result with timeout' do
+      let(:run_result) do
+        Datadog::AppSec::SecurityEngine::Result::Match.new(
+          events: [], actions: {}, derivatives: {}, timeout: true, duration_ns: 0, duration_ext_ns: 0
+        )
+      end
+
+      it 'does not set WAF metrics on the span' do
+        expect(telemetry).to receive(:inc)
+          .with('specsec', 'rasp.rule.eval', 1, tags: { rule_type: 'my-type', waf_version: '1.42.99' })
+        expect(telemetry).to receive(:inc)
+          .with('specsec', 'rasp.rule.match', 1, tags: { rule_type: 'my-type', waf_version: '1.42.99' })
+        expect(telemetry).to receive(:inc)
+          .with('specsec', 'rasp.timeout', 1, tags: { rule_type: 'my-type', waf_version: '1.42.99' })
+
+        described_class.report_rasp('my-type', run_result)
+      end
+    end
+
+    context 'when reporting a ok run result' do
+      let(:run_result) do
+        Datadog::AppSec::SecurityEngine::Result::Ok.new(
+          events: [], actions: {}, derivatives: {}, timeout: false, duration_ns: 0, duration_ext_ns: 0
+        )
+      end
+
+      it 'does not set WAF metrics on the span' do
+        expect(telemetry).to receive(:inc)
+          .with('specsec', 'rasp.rule.eval', 1, tags: { rule_type: 'my-type', waf_version: '1.42.99' })
+
+        described_class.report_rasp('my-type', run_result)
+      end
+    end
+
+    context 'when reporting a ok run result with timeout' do
+      let(:run_result) do
+        Datadog::AppSec::SecurityEngine::Result::Ok.new(
+          events: [], actions: {}, derivatives: {}, timeout: true, duration_ns: 0, duration_ext_ns: 0
+        )
+      end
+
+      it 'does not set WAF metrics on the span' do
+        expect(telemetry).to receive(:inc)
+          .with('specsec', 'rasp.rule.eval', 1, tags: { rule_type: 'my-type', waf_version: '1.42.99' })
+        expect(telemetry).to receive(:inc)
+          .with('specsec', 'rasp.timeout', 1, tags: { rule_type: 'my-type', waf_version: '1.42.99' })
+
+        described_class.report_rasp('my-type', run_result)
+      end
+    end
+
+    context 'when reporting a error run result' do
+      let(:run_result) do
+        Datadog::AppSec::SecurityEngine::Result::Error.new(duration_ext_ns: 0)
+      end
+
+      it 'does not set WAF metrics on the span' do
+        expect(telemetry).not_to receive(:inc)
+
+        described_class.report_rasp('my-type', run_result)
+      end
+    end
+  end
+end


### PR DESCRIPTION
**What does this PR do?**

Introduce telemetry metrics reporting for rasp calls.

**Motivation:**

We catching up with the rest of the libs.

**Change log entry**

No.

**Additional Notes:**

Here you can see [how it is displayed](https://app.datadoghq.com/metric/explorer?fromUser=true&state=H4sIAAAAAAAAE12R4aqDMAyF3yU_L2XoHDr6KpdRikYXaK23iQMnvvsluu3C_Zccvp6cpCs8MDOlESyci_PFlaUrSjAwZD_dGez3Ch32NJLs0ApCEhAsgDlKx_TUvqw_ig80qGHAXlRcJgWEIjJmQgYDGX9mZDkGZOQpjYyuTzl6-c_-zEel6Oijeqm0aMzOi3ec5tyqHFEyte83C1jwj8HywoLx1E7zaWbM69cG282ADpuDP3xfzZ_1dttum2I8BRLXUcRR76T4R23T2NOwGwSKJGDLwgCnLHqplDvMYKFDbmH30rX6vK-wAotXrmyqpq6uRVNc64sBHLuP1tRlVV30WH1GvruYOt1y8jNjB-ZdWMkzbgZ6CoL5FfAT2D3o6d5fkKZALLD9AhZeSLz3AQAA&start=1737638070864&end=1737638761334&paused=true#N4Ig7glgJg5gpgFxALlAGwIYE8D2BXJVEADxQEYAaELcqyKBAC1pEbghkcLIF8qo4AMwgA7CAgg4RKUAiwAHOChASAtnADOcAE4RNIKtrgBHPJoQaUAbVCCc21XkyXkNkHYdOMy0zqxkQHgBdKl9dfVdQEQx1HzNtfwMQKAwEDAB9DXxtAGMlZBB1BF0cy1D4mgKNPFVkKCgAOlENYpq4ETSJKXSEODQ4IoT0lLSGjHl5LRyG7QwNeRmnOAa4ADcMNGB7GHToZAA2AAYAZn2AFn2eMY10nPwOgAoASkCQkCN5qS10j1VU5TUmh0ejKIBaWH6MhA8g2iF6yigOB2OWcGggOSSaFEcB6CnyYJwWKgmOx6XoTGUInsfzQgX4EHmmCwuMUyixIiUwR4fDB8ixCAAwlJhDAUCInGgeEA)

In addition, I've increased some real WAF calls timeout to reduce flakiness noise. It was misconfigured because it's nanoseconds and not milliseconds 😞 

**How to test the change?**

CI is sufficient.